### PR TITLE
Linux support

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "typecheck:web": "tsc --noEmit -p tsconfig.web.json --composite false",
     "typecheck": "npm run typecheck:node && npm run typecheck:web",
     "start": "electron-vite preview",
-    "dev": "electron-vite dev",
+    "dev": "electron-vite dev -- --no-sandbox",
     "build": "npm run typecheck && electron-vite build",
     "postinstall": "electron-builder install-app-deps",
     "build:unpack": "npm run build && electron-builder --dir",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "typecheck:web": "tsc --noEmit -p tsconfig.web.json --composite false",
     "typecheck": "npm run typecheck:node && npm run typecheck:web",
     "start": "electron-vite preview",
-    "dev": "electron-vite dev -- --no-sandbox",
+    "dev": "electron-vite dev",
     "build": "npm run typecheck && electron-vite build",
     "postinstall": "electron-builder install-app-deps",
     "build:unpack": "npm run build && electron-builder --dir",

--- a/src/renderer/src/components/TerminalPane.tsx
+++ b/src/renderer/src/components/TerminalPane.tsx
@@ -245,6 +245,11 @@ function buildTerminalFontSources(fontFamily: string) {
       type: 'local' as const,
       label: 'Menlo',
       matchers: ['menlo', 'menlo regular']
+    },
+    {
+      type: 'local' as const,
+      label: 'Monospace fallback',
+      matchers: ['dejavu sans mono', 'liberation mono', 'ubuntu mono', 'monospace']
     }
   ]
 }
@@ -615,7 +620,7 @@ export default function TerminalPane({
           restty.closePane(id)
         }
         return {
-          renderer: 'webgpu',
+          renderer: 'auto',
           fontSize: currentSettings?.terminalFontSize ?? 14,
           fontSizeMode: 'em',
           alphaBlending: 'native',

--- a/src/renderer/src/lib/terminal-theme.ts
+++ b/src/renderer/src/lib/terminal-theme.ts
@@ -70,7 +70,21 @@ export function buildTerminalFontMatchers(fontFamily: string): string[] {
   const trimmed = fontFamily.trim()
   const normalized = trimmed.toLowerCase()
   const matchers = trimmed ? [trimmed, normalized] : []
-  return Array.from(new Set([...matchers, 'sf mono', 'sfmono-regular', 'menlo', 'menlo regular']))
+  return Array.from(
+    new Set([
+      ...matchers,
+      // macOS
+      'sf mono',
+      'sfmono-regular',
+      'menlo',
+      'menlo regular',
+      // Linux
+      'dejavu sans mono',
+      'liberation mono',
+      'ubuntu mono',
+      'monospace'
+    ])
+  )
 }
 
 export function clampNumber(value: number, min: number, max: number): number {


### PR DESCRIPTION
## Summary
- Switch restty terminal renderer from hardcoded `webgpu` to `auto` so it falls back to WebGL2 when WebGPU/Vulkan is unavailable
- Add Linux monospace font fallbacks (DejaVu Sans Mono, Liberation Mono, Ubuntu Mono, generic monospace) so the terminal can render on systems without macOS fonts

## Test plan
- [ ] Verify clicking a worktree renders the terminal in the right panel on Linux
- [ ] Verify terminal still works on macOS (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)