### PR TITLE
Improve terminal font rendering, per-pane zoom, and UI zoom

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -53,6 +53,23 @@ function createWindow(): BrowserWindow {
     return { action: 'deny' }
   })
 
+  // Handle zoom shortcuts reliably via before-input-event
+  mainWindow.webContents.on('before-input-event', (_event, input) => {
+    if (input.type !== 'keyDown') return
+    const mod = process.platform === 'darwin' ? input.meta : input.control
+    if (!mod || input.alt) return
+    if (input.key === '=' || input.key === '+') {
+      _event.preventDefault()
+      mainWindow.webContents.send('terminal:zoom', 'in')
+    } else if (input.key === '-') {
+      _event.preventDefault()
+      mainWindow.webContents.send('terminal:zoom', 'out')
+    } else if (input.key === '0' && !input.shift) {
+      _event.preventDefault()
+      mainWindow.webContents.send('terminal:zoom', 'reset')
+    }
+  })
+
   // HMR for renderer base on electron-vite cli.
   // Load the remote URL for development or the local html file for production.
   if (is.dev && process.env['ELECTRON_RENDERER_URL']) {
@@ -123,9 +140,21 @@ app.whenReady().then(() => {
         { role: 'forceReload' },
         { role: 'toggleDevTools' },
         { type: 'separator' },
-        { role: 'resetZoom' },
-        { role: 'zoomIn' },
-        { role: 'zoomOut' },
+        {
+          label: 'Actual Size',
+          accelerator: 'CmdOrCtrl+0',
+          registerAccelerator: false
+        },
+        {
+          label: 'Zoom In',
+          accelerator: 'CmdOrCtrl+=',
+          registerAccelerator: false
+        },
+        {
+          label: 'Zoom Out',
+          accelerator: 'CmdOrCtrl+-',
+          registerAccelerator: false
+        },
         { type: 'separator' },
         { role: 'togglefullscreen' }
       ]

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -87,6 +87,9 @@ interface UIApi {
   get: () => Promise<PersistedUIState>
   set: (args: Partial<PersistedUIState>) => Promise<void>
   onOpenSettings: (callback: () => void) => () => void
+  onTerminalZoom: (callback: (direction: 'in' | 'out' | 'reset') => void) => () => void
+  getZoomLevel: () => number
+  setZoomLevel: (level: number) => void
 }
 
 interface Api {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,4 +1,4 @@
-import { contextBridge, ipcRenderer } from 'electron'
+import { contextBridge, ipcRenderer, webFrame } from 'electron'
 import { electronAPI } from '@electron-toolkit/preload'
 
 // Custom APIs for renderer
@@ -133,7 +133,15 @@ const api = {
       const listener = (_event: Electron.IpcRendererEvent) => callback()
       ipcRenderer.on('ui:openSettings', listener)
       return () => ipcRenderer.removeListener('ui:openSettings', listener)
-    }
+    },
+    onTerminalZoom: (callback: (direction: 'in' | 'out' | 'reset') => void): (() => void) => {
+      const listener = (_event: Electron.IpcRendererEvent, direction: 'in' | 'out' | 'reset') =>
+        callback(direction)
+      ipcRenderer.on('terminal:zoom', listener)
+      return () => ipcRenderer.removeListener('terminal:zoom', listener)
+    },
+    getZoomLevel: (): number => webFrame.getZoomLevel(),
+    setZoomLevel: (level: number): void => webFrame.setZoomLevel(level)
   }
 }
 

--- a/src/renderer/src/components/Settings.tsx
+++ b/src/renderer/src/components/Settings.tsx
@@ -26,6 +26,7 @@ import {
   Minus,
   Plus,
   SlidersHorizontal,
+  RotateCcw,
   SquareTerminal,
   Trash2
 } from 'lucide-react'
@@ -35,6 +36,65 @@ const DEFAULT_REPO_HOOK_SETTINGS = getDefaultRepoHookSettings()
 const MAX_THEME_RESULTS = 80
 const MAX_FONT_RESULTS = 12
 const SCROLLBACK_PRESETS_MB = [10, 25, 50, 100, 250] as const
+const ZOOM_STEP = 0.5
+const ZOOM_MIN = -3
+const ZOOM_MAX = 5
+
+function zoomLevelToPercent(level: number): number {
+  return Math.round(100 * Math.pow(1.2, level))
+}
+
+function UIZoomControl(): React.JSX.Element {
+  const [zoomLevel, setZoomLevel] = useState(() => window.api.ui.getZoomLevel())
+
+  useEffect(() => {
+    return window.api.ui.onTerminalZoom((direction) => {
+      setZoomLevel(window.api.ui.getZoomLevel())
+      // Small delay to read after the level is actually applied
+      setTimeout(() => setZoomLevel(window.api.ui.getZoomLevel()), 50)
+    })
+  }, [])
+
+  const applyZoom = useCallback((level: number) => {
+    const clamped = Math.max(ZOOM_MIN, Math.min(ZOOM_MAX, level))
+    window.api.ui.setZoomLevel(clamped)
+    setZoomLevel(clamped)
+  }, [])
+
+  const percent = zoomLevelToPercent(zoomLevel)
+
+  return (
+    <div className="flex items-center gap-2">
+      <Button
+        variant="outline"
+        size="icon-sm"
+        onClick={() => applyZoom(zoomLevel - ZOOM_STEP)}
+        disabled={zoomLevel <= ZOOM_MIN}
+      >
+        <Minus className="size-3" />
+      </Button>
+      <span className="w-14 text-center text-sm tabular-nums text-foreground">{percent}%</span>
+      <Button
+        variant="outline"
+        size="icon-sm"
+        onClick={() => applyZoom(zoomLevel + ZOOM_STEP)}
+        disabled={zoomLevel >= ZOOM_MAX}
+      >
+        <Plus className="size-3" />
+      </Button>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() => applyZoom(0)}
+        disabled={zoomLevel === 0}
+        className="ml-1 gap-1.5"
+      >
+        <RotateCcw className="size-3" />
+        Reset
+      </Button>
+    </div>
+  )
+}
 
 function getFallbackTerminalFonts(): string[] {
   const nav =
@@ -889,6 +949,22 @@ function Settings(): React.JSX.Element {
                       </button>
                     ))}
                   </div>
+                </section>
+
+                <Separator />
+
+                <section className="space-y-4">
+                  <div className="space-y-1">
+                    <h2 className="text-sm font-semibold">UI Zoom</h2>
+                    <p className="text-xs text-muted-foreground">
+                      Scale the entire application interface. Use{' '}
+                      <kbd className="rounded border px-1 py-0.5 text-[10px]">⌘+</kbd> /{' '}
+                      <kbd className="rounded border px-1 py-0.5 text-[10px]">⌘-</kbd> when not in a
+                      terminal pane.
+                    </p>
+                  </div>
+
+                  <UIZoomControl />
                 </section>
               </div>
             ) : showTerminalPane ? (

--- a/src/renderer/src/components/TerminalPane.tsx
+++ b/src/renderer/src/components/TerminalPane.tsx
@@ -158,14 +158,14 @@ function createIpcPtyTransport(
           }
         })
 
-        ptyExitHandlers.set(result.id, (code) => {
+        const spawnedId = result.id
+        ptyExitHandlers.set(spawnedId, (code) => {
           connected = false
-          const exitedPtyId = ptyId!
           ptyId = null
-          unregisterPtyHandlers(exitedPtyId)
+          unregisterPtyHandlers(spawnedId)
           storedCallbacks.onExit?.(code)
           storedCallbacks.onDisconnect?.()
-          onPtyExit?.(exitedPtyId)
+          onPtyExit?.(spawnedId)
         })
 
         storedCallbacks.onConnect?.()
@@ -391,6 +391,7 @@ export default function TerminalPane({
   const resttyRef = useRef<Restty | null>(null)
   const contextPaneIdRef = useRef<number | null>(null)
   const wasActiveRef = useRef(false)
+  const paneFontSizesRef = useRef<Map<number, number>>(new Map())
   const expandedPaneIdRef = useRef<number | null>(null)
   const expandedStyleSnapshotRef = useRef<Map<HTMLElement, { display: string; flex: string }>>(
     new Map()
@@ -581,7 +582,8 @@ export default function TerminalPane({
       if (theme) {
         pane.app.applyTheme(theme, appearance.themeName)
       }
-      pane.app.setFontSize(currentSettings.terminalFontSize)
+      const paneSize = paneFontSizesRef.current.get(pane.id)
+      pane.app.setFontSize(paneSize ?? currentSettings.terminalFontSize)
       pane.app.sendInput(cursorSequence, 'pty')
     }
 
@@ -650,7 +652,8 @@ export default function TerminalPane({
           fontSize: currentSettings?.terminalFontSize ?? 14,
           fontSizeMode: 'em',
           fontHinting: true,
-          fontHintTarget: 'light',
+          fontHintTarget: 'normal',
+          fontThicken: true,
           alphaBlending: 'linear-corrected',
           maxScrollbackBytes: currentSettings?.terminalScrollbackBytes ?? 10_000_000,
           ptyTransport: createIpcPtyTransport(
@@ -733,6 +736,38 @@ export default function TerminalPane({
         )
     )
   }, [settings, systemPrefersDark])
+
+  // Per-pane font zoom via Cmd+Plus/Minus/0
+  useEffect(() => {
+    if (!isActive) return
+    const MIN_FONT_SIZE = 8
+    const MAX_FONT_SIZE = 32
+    const FONT_SIZE_STEP = 1
+
+    return window.api.ui.onTerminalZoom((direction) => {
+      const restty = resttyRef.current
+      if (!restty) return
+      const pane = restty.getActivePane()
+      if (!pane) return
+
+      const globalSize = settingsRef.current?.terminalFontSize ?? 14
+      const currentSize = paneFontSizesRef.current.get(pane.id) ?? globalSize
+
+      let nextSize: number
+      if (direction === 'reset') {
+        nextSize = globalSize
+        paneFontSizesRef.current.delete(pane.id)
+      } else if (direction === 'in') {
+        nextSize = Math.min(MAX_FONT_SIZE, currentSize + FONT_SIZE_STEP)
+        paneFontSizesRef.current.set(pane.id, nextSize)
+      } else {
+        nextSize = Math.max(MIN_FONT_SIZE, currentSize - FONT_SIZE_STEP)
+        paneFontSizesRef.current.set(pane.id, nextSize)
+      }
+
+      pane.app.setFontSize(nextSize)
+    })
+  }, [isActive])
 
   // Handle focus and resize when tab becomes active
   useEffect(() => {

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -1,6 +1,8 @@
 import { useEffect } from 'react'
 import { useAppStore } from '../store'
 
+const ZOOM_STEP = 0.5
+
 export function useIpcEvents(): void {
   useEffect(() => {
     const unsubs: (() => void)[] = []
@@ -20,6 +22,18 @@ export function useIpcEvents(): void {
     unsubs.push(
       window.api.ui.onOpenSettings(() => {
         useAppStore.getState().setActiveView('settings')
+      })
+    )
+
+    // Browser zoom fallback when no terminal is active
+    unsubs.push(
+      window.api.ui.onTerminalZoom((direction) => {
+        const { activeView } = useAppStore.getState()
+        if (activeView === 'terminal') return
+        const current = window.api.ui.getZoomLevel()
+        if (direction === 'in') window.api.ui.setZoomLevel(current + ZOOM_STEP)
+        else if (direction === 'out') window.api.ui.setZoomLevel(current - ZOOM_STEP)
+        else window.api.ui.setZoomLevel(0)
       })
     )
 


### PR DESCRIPTION
## Summary
- **Font rendering**: Switch to `fontHintTarget: 'normal'` (full grid-fitting) and enable `fontThicken` in restty for crisper, bolder terminal text matching native terminals like Ghostty
- **Per-pane font zoom**: Cmd+/- now adjusts only the focused terminal pane's font size (8-32px range), Cmd+0 resets to global setting
- **UI zoom fallback**: When not on a terminal (settings/landing page), Cmd+/- zooms the entire application UI like standard Chromium behavior
- **UI Zoom control**: Added to General settings with +/- buttons, percentage display, and reset button
- **Bug fix**: Race condition in PTY exit handler — used captured spawn ID instead of mutable `ptyId` ref to prevent handler misrouting

## Test plan
- [ ] Verify terminal text appears crisper/bolder compared to previous rendering
- [ ] Open split panes, Cmd+= on one pane — only that pane's font should grow
- [ ] Cmd+0 resets the pane back to the global font size setting
- [ ] Navigate to Settings, Cmd+/- should zoom the entire UI
- [ ] Check UI Zoom control in General settings: +/- buttons, reset, percentage display
- [ ] Cmd+- works reliably on settings page (was broken with menu accelerators)
- [ ] Changing global font size in settings preserves per-pane zoom overrides

🤖 Generated with [Claude Code](https://claude.com/claude-code)