### PR TITLE
Capitalize app name to Orca for desktop installs

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,5 +1,5 @@
 appId: com.stablyai.orca
-productName: orca
+productName: Orca
 directories:
   buildResources: build
 files:
@@ -12,7 +12,7 @@ files:
 asarUnpack:
   - resources/**
 win:
-  executableName: orca
+  executableName: Orca
 nsis:
   artifactName: ${name}-${version}-setup.${ext}
   shortcutName: ${productName}


### PR DESCRIPTION
## Summary
- Changes `productName` and `executableName` in electron-builder.yml from `orca` to `Orca`
- Ensures the app displays as "Orca" when installed on desktop (dock, taskbar, start menu, etc.)

## Test plan
- [ ] Build the app and verify it shows as "Orca" in macOS dock/Finder
- [ ] Verify Windows executable and shortcut names show "Orca"

🤖 Generated with [Claude Code](https://claude.com/claude-code)