### PR TITLE
Fix first worktree card top border cutoff

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -357,7 +357,7 @@ const WorktreeList = React.memo(function WorktreeList() {
   }
 
   return (
-    <div ref={scrollRef} className="flex-1 overflow-auto px-1 scrollbar-sleek scroll-smooth">
+    <div ref={scrollRef} className="flex-1 overflow-auto px-1 pt-px scrollbar-sleek scroll-smooth">
       <div className="relative w-full" style={{ height: `${virtualizer.getTotalSize()}px` }}>
         {virtualizer.getVirtualItems().map((vItem) => {
           const row = rows[vItem.index]


### PR DESCRIPTION
## Summary
- Add `pt-px` (1px top padding) to the worktree list scroll container to prevent `overflow-auto` from clipping the top border/ring of the first card

## Test plan
- [ ] Verify the first card in the worktree list no longer has its top border clipped
- [ ] Verify scrolling behavior is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)