### PR TITLE
Add repo-added notifications

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,8 +1,8 @@
 import { useEffect } from 'react'
-import { Toaster } from 'sonner'
 import { Minimize2, PanelLeft, PanelRight } from 'lucide-react'
 import { TOGGLE_TERMINAL_PANE_EXPAND_EVENT } from '@/constants/terminal'
 import { syncZoomCSSVar } from '@/lib/ui-zoom'
+import { Toaster } from '@/components/ui/sonner'
 import { useAppStore } from './store'
 import { useIpcEvents } from './hooks/useIpcEvents'
 import Sidebar from './components/Sidebar'
@@ -275,12 +275,7 @@ function App(): React.JSX.Element {
         </div>
         {showSidebar && rightSidebarOpen ? <RightSidebar /> : null}
       </div>
-      <Toaster
-        theme="system"
-        position="bottom-right"
-        closeButton
-        toastOptions={{ className: 'font-sans text-sm' }}
-      />
+      <Toaster closeButton toastOptions={{ className: 'font-sans text-sm' }} />
     </div>
   )
 }

--- a/src/renderer/src/components/ui/sonner.tsx
+++ b/src/renderer/src/components/ui/sonner.tsx
@@ -1,0 +1,39 @@
+import {
+  CircleCheckIcon,
+  InfoIcon,
+  Loader2Icon,
+  OctagonXIcon,
+  TriangleAlertIcon
+} from 'lucide-react'
+import { Toaster as Sonner, type ToasterProps } from 'sonner'
+import { useAppStore } from '@/store'
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  const theme = useAppStore((s) => s.settings?.theme) || 'system'
+
+  return (
+    <Sonner
+      theme={theme as ToasterProps['theme']}
+      position="bottom-right"
+      className="toaster group"
+      icons={{
+        success: <CircleCheckIcon className="size-4" />,
+        info: <InfoIcon className="size-4" />,
+        warning: <TriangleAlertIcon className="size-4" />,
+        error: <OctagonXIcon className="size-4" />,
+        loading: <Loader2Icon className="size-4 animate-spin" />
+      }}
+      style={
+        {
+          '--normal-bg': 'var(--popover)',
+          '--normal-text': 'var(--popover-foreground)',
+          '--normal-border': 'var(--border)',
+          '--border-radius': 'var(--radius)'
+        } as React.CSSProperties
+      }
+      {...props}
+    />
+  )
+}
+
+export { Toaster }

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -1,4 +1,5 @@
 import type { StateCreator } from 'zustand'
+import { toast } from 'sonner'
 import type { AppState } from '../types'
 import type { Repo } from '../../../../shared/types'
 
@@ -33,7 +34,16 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
       const path = await window.api.repos.pickFolder()
       if (!path) return null
       const repo = await window.api.repos.add({ path })
-      set((s) => ({ repos: [...s.repos, repo] }))
+      const alreadyAdded = get().repos.some((r) => r.id === repo.id)
+      set((s) => {
+        if (s.repos.some((r) => r.id === repo.id)) return s
+        return { repos: [...s.repos, repo] }
+      })
+      if (alreadyAdded) {
+        toast.info('Repo already added', { description: repo.displayName })
+      } else {
+        toast.success('Repo added', { description: repo.displayName })
+      }
       return repo
     } catch (err) {
       console.error('Failed to add repo:', err)

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -3,7 +3,7 @@ import { toast } from 'sonner'
 import type { AppState } from '../types'
 import type { Repo } from '../../../../shared/types'
 
-export interface RepoSlice {
+export type RepoSlice = {
   repos: Repo[]
   activeRepoId: string | null
   fetchRepos: () => Promise<void>
@@ -32,11 +32,15 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
   addRepo: async () => {
     try {
       const path = await window.api.repos.pickFolder()
-      if (!path) return null
+      if (!path) {
+        return null
+      }
       const repo = await window.api.repos.add({ path })
       const alreadyAdded = get().repos.some((r) => r.id === repo.id)
       set((s) => {
-        if (s.repos.some((r) => r.id === repo.id)) return s
+        if (s.repos.some((r) => r.id === repo.id)) {
+          return s
+        }
         return { repos: [...s.repos, repo] }
       })
       if (alreadyAdded) {


### PR DESCRIPTION
## Problem
Adding a repository gave little feedback and could report success even when the selected repo had already been added. The app also used the default Sonner toaster instead of the app theme and icon styling.

## Solution
Add a shared renderer toaster wrapper that matches Orca's theme tokens and icons, mount it in the app shell, and emit repo add notifications from the repo slice. When the selected path already exists, show an informational toast instead of duplicating repo state or claiming a fresh add succeeded.