### PR TITLE
Add dismiss button to update notifications

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -278,6 +278,7 @@ function App(): React.JSX.Element {
       <Toaster
         theme="system"
         position="bottom-right"
+        closeButton
         toastOptions={{ className: 'font-sans text-sm' }}
       />
     </div>

--- a/src/renderer/src/components/sidebar/SidebarToolbar.tsx
+++ b/src/renderer/src/components/sidebar/SidebarToolbar.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Download, FolderPlus, Settings } from 'lucide-react'
+import { Download, FolderPlus, Settings, X } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
@@ -8,30 +8,46 @@ const SidebarToolbar = React.memo(function SidebarToolbar() {
   const addRepo = useAppStore((s) => s.addRepo)
   const setActiveView = useAppStore((s) => s.setActiveView)
   const updateStatus = useAppStore((s) => s.updateStatus)
+  const dismissedUpdateVersion = useAppStore((s) => s.dismissedUpdateVersion)
+  const dismissUpdate = useAppStore((s) => s.dismissUpdate)
 
+  const updateVersion = 'version' in updateStatus ? updateStatus.version : null
   const showUpdateBanner =
-    updateStatus.state === 'downloaded' || updateStatus.state === 'available'
+    (updateStatus.state === 'downloaded' || updateStatus.state === 'available') &&
+    updateVersion !== dismissedUpdateVersion
 
   return (
     <div className="mt-auto shrink-0">
       {showUpdateBanner && (
-        <button
-          onClick={() =>
-            updateStatus.state === 'downloaded'
-              ? window.api.updater.quitAndInstall()
-              : undefined
-          }
-          className="flex items-center gap-1.5 w-full px-2 py-1.5 text-[11px] font-medium text-primary bg-primary/10 hover:bg-primary/15 transition-colors cursor-pointer border-t border-sidebar-border"
-        >
-          <Download className="size-3.5 shrink-0" />
-          {updateStatus.state === 'downloaded' ? (
-            <span>Restart now (update)</span>
-          ) : (
-            <span>
-              Downloading <span className="font-semibold">v{updateStatus.version}</span>…
-            </span>
-          )}
-        </button>
+        <div className="flex items-center border-t border-sidebar-border bg-primary/10">
+          <button
+            onClick={() =>
+              updateStatus.state === 'downloaded'
+                ? window.api.updater.quitAndInstall()
+                : undefined
+            }
+            className="flex items-center gap-1.5 flex-1 min-w-0 px-2 py-1.5 text-[11px] font-medium text-primary hover:bg-primary/15 transition-colors cursor-pointer"
+          >
+            <Download className="size-3.5 shrink-0" />
+            {updateStatus.state === 'downloaded' ? (
+              <span>Restart now (update)</span>
+            ) : (
+              <span>
+                Downloading <span className="font-semibold">v{updateStatus.version}</span>…
+              </span>
+            )}
+          </button>
+          <button
+            onClick={(e) => {
+              e.stopPropagation()
+              dismissUpdate()
+            }}
+            className="shrink-0 p-1 mr-1 rounded text-primary/60 hover:text-primary hover:bg-primary/15 transition-colors"
+            title="Dismiss"
+          >
+            <X className="size-3" />
+          </button>
+        </div>
       )}
       <div className="flex items-center justify-between px-2 py-1.5 border-t border-sidebar-border">
         <Tooltip>

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -31,6 +31,8 @@ export interface UISlice {
   hydratePersistedUI: (ui: PersistedUIState) => void
   updateStatus: UpdateStatus
   setUpdateStatus: (status: UpdateStatus) => void
+  dismissedUpdateVersion: string | null
+  dismissUpdate: () => void
 }
 
 export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set) => ({
@@ -78,5 +80,11 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set) => (
     }),
 
   updateStatus: { state: 'idle' },
-  setUpdateStatus: (status) => set({ updateStatus: status })
+  setUpdateStatus: (status) => set({ updateStatus: status }),
+  dismissedUpdateVersion: null,
+  dismissUpdate: () =>
+    set((s) => ({
+      dismissedUpdateVersion:
+        'version' in s.updateStatus ? s.updateStatus.version ?? null : null
+    }))
 })


### PR DESCRIPTION
## Summary
- Add `closeButton` to the sonner `<Toaster>` so the persistent "Version X is ready to install" toast can be dismissed via an X button
- Add an X dismiss button to the sidebar update banner with per-version tracking (reappears for new versions)
- New `dismissedUpdateVersion` / `dismissUpdate` state in the UI store

## Test plan
- [ ] Trigger an update download and verify the toast shows a close button
- [ ] Verify the sidebar update banner shows an X button that dismisses it
- [ ] Verify dismissing and then triggering a new version update shows the banner again

🤖 Generated with [Claude Code](https://claude.com/claude-code)