### PR TITLE
Fix terminal padding with small inset

### DIFF
--- a/src/renderer/src/lib/pane-manager.ts
+++ b/src/renderer/src/lib/pane-manager.ts
@@ -339,11 +339,14 @@ export class PaneManager {
     container.className = 'pane'
     container.dataset.paneId = String(id)
 
-    // Create .xterm-container
+    // Create .xterm-container with small inset padding
+    const TERMINAL_PADDING = 4
     const xtermContainer = document.createElement('div')
     xtermContainer.className = 'xterm-container'
-    xtermContainer.style.width = '100%'
-    xtermContainer.style.height = '100%'
+    xtermContainer.style.width = `calc(100% - ${TERMINAL_PADDING}px)`
+    xtermContainer.style.height = `calc(100% - ${TERMINAL_PADDING}px)`
+    xtermContainer.style.marginTop = `${TERMINAL_PADDING}px`
+    xtermContainer.style.marginLeft = `${TERMINAL_PADDING}px`
     container.appendChild(xtermContainer)
 
     // Build terminal options


### PR DESCRIPTION
## Summary
- Adds 4px inset padding (top-left margin) to the xterm container so terminal content doesn't touch the pane edges
- Adjusts width/height with `calc()` to account for the margin offset

## Test plan
- [ ] Verify terminal text has visible padding from pane edges
- [ ] Verify terminal resizing still works correctly
- [ ] Check that split panes render padding consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)