### PR TITLE
Fix update-related issues: macOS crash, duplicate notifications, version display

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -230,6 +230,7 @@ app.whenReady().then(() => {
 
   // Updater IPC
   ipcMain.handle('updater:getStatus', () => getUpdateStatus())
+  ipcMain.handle('updater:getVersion', () => app.getVersion())
   ipcMain.handle('updater:check', () => checkForUpdates())
   ipcMain.handle('updater:quitAndInstall', () => quitAndInstall())
 

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -21,7 +21,8 @@ export function checkForUpdates(): void {
     sendStatus({ state: 'not-available' })
     return
   }
-  sendStatus({ state: 'checking' })
+  // Don't send 'checking' here — the 'checking-for-update' event handler does it,
+  // and sending it from both places causes duplicate notifications (issue #35).
   autoUpdater.checkForUpdates().catch((err) => {
     sendStatus({ state: 'error', message: String(err?.message ?? err) })
   })
@@ -35,7 +36,8 @@ export function checkForUpdatesFromMenu(): void {
   }
 
   userInitiatedCheck = true
-  sendStatus({ state: 'checking', userInitiated: true })
+  // Don't send 'checking' here — the 'checking-for-update' event handler does it,
+  // and sending it from both places causes duplicate notifications (issue #35).
 
   autoUpdater.checkForUpdates().catch((err) => {
     userInitiatedCheck = false
@@ -44,18 +46,25 @@ export function checkForUpdatesFromMenu(): void {
 }
 
 export function quitAndInstall(): void {
-  // Graceful shutdown: close all windows before letting the updater restart.
-  // This prevents macOS from showing "quit unexpectedly" dialogs because
-  // autoUpdater.quitAndInstall() calls app.exit() which bypasses lifecycle.
-  const windows = BrowserWindow.getAllWindows()
-  for (const win of windows) {
-    win.removeAllListeners('close')
-    win.destroy()
+  if (process.platform === 'darwin') {
+    // On macOS, autoUpdater.quitAndInstall() calls app.exit() which bypasses
+    // the normal quit lifecycle, causing the "quit unexpectedly" crash dialog.
+    // Instead, use app.relaunch() + app.quit() which goes through the proper
+    // lifecycle. autoInstallOnAppQuit (set in setupAutoUpdater) ensures the
+    // update is applied during the quit process.
+    app.relaunch()
+    app.quit()
+  } else {
+    // On Windows/Linux, quitAndInstall works correctly with the NSIS installer.
+    const windows = BrowserWindow.getAllWindows()
+    for (const win of windows) {
+      win.removeAllListeners('close')
+      win.destroy()
+    }
+    setImmediate(() => {
+      autoUpdater.quitAndInstall(false, true)
+    })
   }
-
-  setImmediate(() => {
-    autoUpdater.quitAndInstall(false, true)
-  })
 }
 
 export function setupAutoUpdater(mainWindow: BrowserWindow): void {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -164,6 +164,7 @@ const api = {
 
   updater: {
     getStatus: (): Promise<unknown> => ipcRenderer.invoke('updater:getStatus'),
+    getVersion: (): Promise<string> => ipcRenderer.invoke('updater:getVersion'),
     check: (): Promise<void> => ipcRenderer.invoke('updater:check'),
     quitAndInstall: (): Promise<void> => ipcRenderer.invoke('updater:quitAndInstall'),
     onStatus: (callback: (status: unknown) => void): (() => void) => {

--- a/src/renderer/src/components/settings/GeneralPane.tsx
+++ b/src/renderer/src/components/settings/GeneralPane.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react'
 import type { GlobalSettings } from '../../../../shared/types'
 import { Button } from '../ui/button'
 import { Input } from '../ui/input'
@@ -18,6 +19,11 @@ export function GeneralPane({
   displayedGitUsername
 }: GeneralPaneProps): React.JSX.Element {
   const updateStatus = useAppStore((s) => s.updateStatus)
+  const [appVersion, setAppVersion] = useState<string | null>(null)
+
+  useEffect(() => {
+    window.api.updater.getVersion().then(setAppVersion)
+  }, [])
 
   const handleBrowseWorkspace = async () => {
     const path = await window.api.repos.pickFolder()
@@ -136,7 +142,9 @@ export function GeneralPane({
       <section className="space-y-4">
         <div className="space-y-1">
           <h2 className="text-sm font-semibold">Updates</h2>
-          <p className="text-xs text-muted-foreground">Check for new versions of Orca.</p>
+          <p className="text-xs text-muted-foreground">
+            Current version: {appVersion ?? '…'}
+          </p>
         </div>
 
         <div className="flex items-center gap-3">


### PR DESCRIPTION
## Summary
- **macOS crash on restart**: Use `app.relaunch()` + `app.quit()` instead of `autoUpdater.quitAndInstall()` on macOS, which calls `app.exit()` and bypasses the normal quit lifecycle causing the "quit unexpectedly" dialog
- **Duplicate notifications**: Remove redundant `sendStatus({ state: 'checking' })` calls from `checkForUpdates()` and `checkForUpdatesFromMenu()` — the `checking-for-update` event handler already emits this status, so it was firing twice
- **Version display**: Show current app version in the Settings > Updates section via new `updater:getVersion` IPC channel

Fixes #35

## Test plan
- [ ] On macOS, trigger "Restart to Update" and verify no crash dialog appears
- [ ] Check for updates from Settings and verify only one "Checking for updates..." toast appears
- [ ] Check for updates from menu bar and verify only one toast appears
- [ ] Verify current version number displays in Settings > Updates section
- [ ] Verify update flow still works end-to-end on Windows/Linux (NSIS path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)