### PR TITLE
Fix PR status display: deduplicate concurrent requests and simplify cache logic

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -114,20 +114,12 @@ const WorktreeCard = React.memo(function WorktreeCard({
     return liveTabs.length > 0 ? 'active' : 'inactive'
   }, [hasTerminals, tabs])
 
-  // Fetch PR data (debounced via ref guard)
-  const prFetchedRef = useRef<string | null>(null)
+  // Fetch PR data on mount – the store's isFresh() check prevents redundant API calls
   useEffect(() => {
-    if (
-      repo &&
-      !worktree.isBare &&
-      pr === undefined &&
-      prCacheKey &&
-      prCacheKey !== prFetchedRef.current
-    ) {
-      prFetchedRef.current = prCacheKey
+    if (repo && !worktree.isBare && prCacheKey) {
       fetchPRForBranch(repo.path, branch)
     }
-  }, [repo, worktree.isBare, pr, fetchPRForBranch, branch, prCacheKey])
+  }, [repo, worktree.isBare, fetchPRForBranch, branch, prCacheKey])
 
   // Fetch issue data (debounced via ref guard)
   const issueFetchedRef = useRef<string | null>(null)

--- a/src/renderer/src/store/slices/github.ts
+++ b/src/renderer/src/store/slices/github.ts
@@ -9,6 +9,9 @@ export interface CacheEntry<T> {
 
 const CACHE_TTL = 300_000 // 5 minutes (stale data shown instantly, then refreshed)
 
+const inflightPRRequests = new Map<string, Promise<PRInfo | null>>()
+const inflightIssueRequests = new Map<string, Promise<IssueInfo | null>>()
+
 function isFresh<T>(entry: CacheEntry<T> | undefined): entry is CacheEntry<T> {
   return entry !== undefined && Date.now() - entry.fetchedAt < CACHE_TTL
 }
@@ -57,43 +60,61 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
     const cacheKey = `${repoPath}::${branch}`
     const cached = get().prCache[cacheKey]
     if (isFresh(cached)) return cached.data
+    const inflightRequest = inflightPRRequests.get(cacheKey)
+    if (inflightRequest) return inflightRequest
 
-    try {
-      const pr = await window.api.gh.prForBranch({ repoPath, branch })
-      set((s) => ({
-        prCache: { ...s.prCache, [cacheKey]: { data: pr, fetchedAt: Date.now() } }
-      }))
-      debouncedSaveCache(get())
-      return pr
-    } catch (err) {
-      console.error('Failed to fetch PR:', err)
-      set((s) => ({
-        prCache: { ...s.prCache, [cacheKey]: { data: null, fetchedAt: Date.now() } }
-      }))
-      debouncedSaveCache(get())
-      return null
-    }
+    const request = (async () => {
+      try {
+        const pr = await window.api.gh.prForBranch({ repoPath, branch })
+        set((s) => ({
+          prCache: { ...s.prCache, [cacheKey]: { data: pr, fetchedAt: Date.now() } }
+        }))
+        debouncedSaveCache(get())
+        return pr
+      } catch (err) {
+        console.error('Failed to fetch PR:', err)
+        set((s) => ({
+          prCache: { ...s.prCache, [cacheKey]: { data: null, fetchedAt: Date.now() } }
+        }))
+        debouncedSaveCache(get())
+        return null
+      } finally {
+        inflightPRRequests.delete(cacheKey)
+      }
+    })()
+
+    inflightPRRequests.set(cacheKey, request)
+    return request
   },
 
   fetchIssue: async (repoPath, number) => {
     const cacheKey = `${repoPath}::${number}`
     const cached = get().issueCache[cacheKey]
     if (isFresh(cached)) return cached.data
+    const inflightRequest = inflightIssueRequests.get(cacheKey)
+    if (inflightRequest) return inflightRequest
 
-    try {
-      const issue = await window.api.gh.issue({ repoPath, number })
-      set((s) => ({
-        issueCache: { ...s.issueCache, [cacheKey]: { data: issue, fetchedAt: Date.now() } }
-      }))
-      debouncedSaveCache(get())
-      return issue
-    } catch (err) {
-      console.error('Failed to fetch issue:', err)
-      set((s) => ({
-        issueCache: { ...s.issueCache, [cacheKey]: { data: null, fetchedAt: Date.now() } }
-      }))
-      debouncedSaveCache(get())
-      return null
-    }
+    const request = (async () => {
+      try {
+        const issue = await window.api.gh.issue({ repoPath, number })
+        set((s) => ({
+          issueCache: { ...s.issueCache, [cacheKey]: { data: issue, fetchedAt: Date.now() } }
+        }))
+        debouncedSaveCache(get())
+        return issue
+      } catch (err) {
+        console.error('Failed to fetch issue:', err)
+        set((s) => ({
+          issueCache: { ...s.issueCache, [cacheKey]: { data: null, fetchedAt: Date.now() } }
+        }))
+        debouncedSaveCache(get())
+        return null
+      } finally {
+        inflightIssueRequests.delete(cacheKey)
+      }
+    })()
+
+    inflightIssueRequests.set(cacheKey, request)
+    return request
   }
 })


### PR DESCRIPTION
## Problem

PR status wasn't updating properly when switching between worktrees because:
1. The ref-based debouncing in WorktreeCard prevented cache updates from triggering re-fetches
2. Concurrent requests for the same PR/issue could create duplicate API calls, leading to race conditions

## Solution

1. **Removed unnecessary debouncing**: Replaced the `prFetchedRef` guard with simplified effect logic that relies on the store's `isFresh()` cache TTL check to prevent redundant API calls
2. **Added request deduplication**: Implemented inflight request tracking using Maps to ensure that multiple concurrent requests for the same data return the same promise, eliminating duplicate API calls
3. **Simplified dependency tracking**: The PR fetch effect now only depends on cache key and repo changes, not PR data itself, allowing the cache logic to control fetch timing

## Changes

- `src/renderer/src/store/slices/github.ts`: Added `inflightPRRequests` and `inflightIssueRequests` Maps to deduplicate concurrent requests
- `src/renderer/src/components/sidebar/WorktreeCard.tsx`: Simplified PR fetch effect to use cache TTL instead of ref-based debouncing