### PR TITLE
Add 'Add repo' option to repo filter dropdown

### DIFF
--- a/src/renderer/src/components/sidebar/SearchBar.tsx
+++ b/src/renderer/src/components/sidebar/SearchBar.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react'
-import { Search, X, Activity, FolderTree } from 'lucide-react'
+import { Search, X, Activity, FolderTree, FolderPlus } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
@@ -8,7 +8,8 @@ import {
   SelectTrigger,
   SelectValue,
   SelectContent,
-  SelectItem
+  SelectItem,
+  SelectSeparator
 } from '@/components/ui/select'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
@@ -22,6 +23,7 @@ const SearchBar = React.memo(function SearchBar() {
   const filterRepoId = useAppStore((s) => s.filterRepoId)
   const setFilterRepoId = useAppStore((s) => s.setFilterRepoId)
   const repos = useAppStore((s) => s.repos)
+  const addRepo = useAppStore((s) => s.addRepo)
   const selectedRepo = repos.find((r) => r.id === filterRepoId)
 
   const handleClear = useCallback(() => setSearchQuery(''), [setSearchQuery])
@@ -70,7 +72,13 @@ const SearchBar = React.memo(function SearchBar() {
           {repos.length > 1 && (
             <Select
               value={filterRepoId ?? '__all__'}
-              onValueChange={(v) => setFilterRepoId(v === '__all__' ? null : v)}
+              onValueChange={(v) => {
+                if (v === '__add__') {
+                  addRepo()
+                } else {
+                  setFilterRepoId(v === '__all__' ? null : v)
+                }
+              }}
             >
               <SelectTrigger
                 size="sm"
@@ -98,6 +106,13 @@ const SearchBar = React.memo(function SearchBar() {
                     <RepoDotLabel name={r.displayName} color={r.badgeColor} />
                   </SelectItem>
                 ))}
+                <SelectSeparator />
+                <SelectItem value="__add__">
+                  <span className="flex items-center gap-1.5 text-muted-foreground">
+                    <FolderPlus className="size-3.5" />
+                    Add repo
+                  </span>
+                </SelectItem>
               </SelectContent>
             </Select>
           )}


### PR DESCRIPTION
## Summary
- Adds an "Add repo" action at the bottom of the repo filter dropdown in the sidebar search bar, separated by a divider
- Uses the existing `addRepo()` store action (same as the toolbar button)

Closes #20

## Test plan
- [ ] Open the app with 2+ repos so the repo filter dropdown is visible
- [ ] Click the repo filter dropdown and verify "Add repo" appears at the bottom with a separator
- [ ] Click "Add repo" and verify the folder picker opens
- [ ] Verify selecting a normal repo filter still works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)