### PR TITLE
Support spaces in worktree names

### DIFF
--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -43,27 +43,31 @@ export function registerWorktreeHandlers(mainWindow: BrowserWindow, store: Store
 
       const settings = store.getSettings()
 
+      const requestedName = args.name
+      // Sanitize name for use in branch names and directory paths
+      // (git branch names cannot contain spaces; collapse runs of spaces to a single hyphen)
+      const sanitizedName = args.name.replace(/\s+/g, '-')
+
       // Compute branch name with prefix
-      let branchName = args.name
+      let branchName = sanitizedName
       if (settings.branchPrefix === 'git-username') {
         const username = getGitUsername(repo.path)
         if (username) {
-          branchName = `${username}/${args.name}`
+          branchName = `${username}/${sanitizedName}`
         }
       } else if (settings.branchPrefix === 'custom' && settings.branchPrefixCustom) {
-        branchName = `${settings.branchPrefixCustom}/${args.name}`
+        branchName = `${settings.branchPrefixCustom}/${sanitizedName}`
       }
 
-      const requestedName = args.name
       branchName = await getAvailableBranchName(repo.path, branchName)
 
       // Compute worktree path
       let worktreePath: string
       if (settings.nestWorkspaces) {
         const repoName = basename(repo.path).replace(/\.git$/, '')
-        worktreePath = join(settings.workspaceDir, repoName, requestedName)
+        worktreePath = join(settings.workspaceDir, repoName, sanitizedName)
       } else {
-        worktreePath = join(settings.workspaceDir, requestedName)
+        worktreePath = join(settings.workspaceDir, sanitizedName)
       }
 
       // Determine base branch
@@ -78,7 +82,9 @@ export function registerWorktreeHandlers(mainWindow: BrowserWindow, store: Store
 
       const worktreeId = `${repo.id}::${worktreePath}`
       const metaUpdates: Partial<WorktreeMeta> =
-        branchName === requestedName ? {} : { displayName: requestedName }
+        branchName === requestedName && sanitizedName === requestedName
+          ? {}
+          : { displayName: requestedName }
       const meta = store.setWorktreeMeta(worktreeId, metaUpdates)
       const worktree = mergeWorktree(repo.id, created, meta)
 


### PR DESCRIPTION
## Summary
- Sanitize user-provided worktree names by replacing whitespace runs with hyphens for branch names and directory paths
- Preserve the original name (with spaces) as `displayName` in worktree metadata so it displays nicely in the sidebar

## Test plan
- [ ] Create a worktree with spaces in the name (e.g., "fix login bug")
- [ ] Verify the branch is created as `fix-login-bug` (with configured prefix)
- [ ] Verify the directory is created as `fix-login-bug`
- [ ] Verify the sidebar shows the original name "fix login bug"
- [ ] Create a worktree without spaces and confirm behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)