### PR TITLE
fix: refresh GitHub status on activity

### DIFF
--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -181,6 +181,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
 
   setActiveWorktree: (worktreeId) => {
     let shouldClearUnread = false
+    const prevActiveId = get().activeWorktreeId
     set((s) => {
       if (!worktreeId) {
         return { activeWorktreeId: null }
@@ -196,8 +197,8 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       }
     })
 
-    // Refresh GitHub data (PR + issue status) for the activated worktree
-    if (worktreeId) {
+    // Refresh GitHub data (PR + issue status) when switching to a different worktree
+    if (worktreeId && worktreeId !== prevActiveId) {
       get().refreshGitHubForWorktree(worktreeId)
     }
 


### PR DESCRIPTION
## Summary
- **Refresh GitHub data (PR/issue status) on activity**: triggers refresh when switching worktrees (`setActiveWorktree`) and when the window regains focus (`visibilitychange`)
- **New store actions**: `refreshAllGitHub` invalidates all cache entries and re-fetches; `refreshGitHubForWorktree` does the same for a single worktree
- **Background poll for issues**: 5-minute interval fallback in WorktreeCard ensures issue data stays fresh even without user interaction
- **Fix**: skip redundant GitHub refresh when re-clicking the already-active worktree

## Test plan
- [ ] Switch between worktrees and verify PR/issue badges update
- [ ] Tab away from the app, change a PR/issue status on GitHub, tab back — verify the status updates
- [ ] Click the same worktree card repeatedly — verify no unnecessary API calls in network tab
- [ ] Leave app open on a worktree with a linked issue for >5 minutes — verify issue data refreshes via background poll

🤖 Generated with [Claude Code](https://claude.com/claude-code)