### PR TITLE
fix: restore packaged app CLI PATH resolution

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -4,6 +4,36 @@ import { electronApp, optimizer, is } from '@electron-toolkit/utils'
 import icon from '../../resources/icon.png?asset'
 import devIcon from '../../resources/icon-dev.png?asset'
 
+// Packaged Electron apps on macOS/Linux don't inherit the user's shell PATH,
+// so CLI tools installed via Homebrew / nix / snap / etc. (e.g. `gh`) can't be
+// found. Augment PATH once at startup with common binary directories.
+// Windows GUI apps inherit the full system PATH, so no fix is needed there.
+if (app.isPackaged && process.platform !== 'win32') {
+  const home = process.env.HOME ?? ''
+  const extraPaths = [
+    '/opt/homebrew/bin', // macOS ARM Homebrew
+    '/opt/homebrew/sbin',
+    '/usr/local/bin', // macOS Intel Homebrew / common
+    '/usr/local/sbin',
+    '/snap/bin', // Ubuntu snap packages
+    '/home/linuxbrew/.linuxbrew/bin', // Linuxbrew
+    '/nix/var/nix/profiles/default/bin' // nix (system)
+  ]
+  if (home) {
+    extraPaths.push(
+      join(home, '.local/bin'), // Linux user-local (pipx, cargo, etc.)
+      join(home, '.nix-profile/bin') // nix (user)
+    )
+  }
+  const sep = ':'
+  const currentPath = process.env.PATH ?? ''
+  const existing = new Set(currentPath.split(sep))
+  const missing = extraPaths.filter((p) => !existing.has(p))
+  if (missing.length) {
+    process.env.PATH = [...missing, ...currentPath.split(sep).filter(Boolean)].join(sep)
+  }
+}
+
 import { Store } from './persistence'
 import { registerRepoHandlers } from './ipc/repos'
 import { registerWorktreeHandlers } from './ipc/worktrees'
@@ -87,9 +117,13 @@ function createWindow(): BrowserWindow {
 
   // Handle zoom shortcuts reliably via before-input-event
   mainWindow.webContents.on('before-input-event', (_event, input) => {
-    if (input.type !== 'keyDown') return
+    if (input.type !== 'keyDown') {
+      return
+    }
     const mod = process.platform === 'darwin' ? input.meta : input.control
-    if (!mod || input.alt) return
+    if (!mod || input.alt) {
+      return
+    }
     if (input.key === '=' || input.key === '+') {
       _event.preventDefault()
       mainWindow.webContents.send('terminal:zoom', 'in')


### PR DESCRIPTION
## Problem
Packaged macOS and Linux builds do not inherit the user's shell PATH, so CLI tools such as `gh` can be missing at runtime. The initial PATH augmentation fixed that generally, but it could insert relative entries like `.local/bin` when `HOME` is unset and could also append an empty PATH segment when no original PATH exists.

## Solution
Add common packaged-app PATH prefixes only for non-Windows packaged builds, but gate home-relative entries behind a real `HOME` value and rebuild the final PATH from non-empty segments only. Also normalize two single-line guard clauses in the same file so the staged-file lint hook passes cleanly.