### PR TITLE
fix: prevent update banner from persisting after update

### DIFF
--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -85,7 +85,15 @@ export function setupAutoUpdater(mainWindow: BrowserWindow): void {
   })
 
   autoUpdater.on('update-available', (info) => {
+    const wasUserInitiated = userInitiatedCheck
     userInitiatedCheck = false
+    // Guard against re-downloading the version we're already running.
+    // With allowPrerelease enabled, electron-updater may consider the
+    // current version as an "available" update (same-version match).
+    if (info.version === app.getVersion()) {
+      sendStatus({ state: 'not-available', userInitiated: wasUserInitiated || undefined })
+      return
+    }
     sendStatus({ state: 'available', version: info.version })
   })
 
@@ -100,6 +108,11 @@ export function setupAutoUpdater(mainWindow: BrowserWindow): void {
   })
 
   autoUpdater.on('update-downloaded', (info) => {
+    // Don't show the banner if the downloaded version is the one already running.
+    if (info.version === app.getVersion()) {
+      sendStatus({ state: 'not-available' })
+      return
+    }
     sendStatus({ state: 'downloaded', version: info.version })
   })
 


### PR DESCRIPTION
## Problem
After updating the app and restarting, the update banner ("Version X is ready to install" + "Restart now") stays visible even though the user is already running the latest version. This creates an infinite loop: banner → restart → banner again.

## Solution
With `allowPrerelease` enabled, `electron-updater` may consider the current version as an "available" update via the atom feed. Added same-version guards in both the `update-available` and `update-downloaded` event handlers in `src/main/updater.ts` — if the reported version matches `app.getVersion()`, we emit `not-available` instead of showing the banner. Also preserved the `userInitiated` flag through the guard so user-initiated "Check for Updates" still shows the "You're on the latest version" toast.