### PR TITLE
fix: preserve terminal search shortcut and refresh right sidebar state

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -136,6 +136,8 @@ function createWindow(): BrowserWindow {
     }
   })
 
+
+
   // HMR for renderer base on electron-vite cli.
   // Load the remote URL for development or the local html file for production.
   if (is.dev && process.env['ELECTRON_RENDERER_URL']) {
@@ -261,6 +263,7 @@ app.whenReady().then(() => {
   registerFilesystemHandlers(store)
   warmSystemFontFamilies()
   setupAutoUpdater(mainWindow)
+
 
   // Updater IPC
   ipcMain.handle('updater:getStatus', () => getUpdateStatus())

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -206,6 +206,7 @@ const api = {
       ipcRenderer.invoke('git:discard', args)
   },
 
+
   ui: {
     get: (): Promise<unknown> => ipcRenderer.invoke('ui:get'),
     set: (args: Record<string, unknown>): Promise<void> => ipcRenderer.invoke('ui:set', args),

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -43,6 +43,7 @@ function App(): React.JSX.Element {
   const setRightSidebarOpen = useAppStore((s) => s.setRightSidebarOpen)
   const setRightSidebarTab = useAppStore((s) => s.setRightSidebarTab)
 
+
   // Subscribe to IPC push events
   useIpcEvents()
 
@@ -244,6 +245,7 @@ function App(): React.JSX.Element {
     window.addEventListener('keydown', onKeyDown, { capture: true })
     return () => window.removeEventListener('keydown', onKeyDown, { capture: true })
   }, [openModal, repos.length, setRightSidebarTab, setRightSidebarOpen])
+
 
   return (
     <div className="flex flex-col h-screen w-screen overflow-hidden">

--- a/src/renderer/src/components/right-sidebar/index.tsx
+++ b/src/renderer/src/components/right-sidebar/index.tsx
@@ -12,6 +12,7 @@ export default function RightSidebar(): React.JSX.Element {
   const setRightSidebarWidth = useAppStore((s) => s.setRightSidebarWidth)
   const rightSidebarTab = useAppStore((s) => s.rightSidebarTab)
   const setRightSidebarTab = useAppStore((s) => s.setRightSidebarTab)
+  const activeWorktreeId = useAppStore((s) => s.activeWorktreeId)
 
   // ─── Resize logic (handle on LEFT edge) ────────────
   const isResizing = useRef(false)
@@ -78,9 +79,13 @@ export default function RightSidebar(): React.JSX.Element {
         />
       </div>
 
-      {/* Tab content */}
+      {/* Tab content – key on worktreeId forces remount so stale file trees don't persist */}
       <div className="flex-1 min-h-0 overflow-hidden scrollbar-sleek-parent">
-        {rightSidebarTab === 'explorer' ? <FileExplorer /> : <SourceControl />}
+        {rightSidebarTab === 'explorer' ? (
+          <FileExplorer key={activeWorktreeId ?? 'none'} />
+        ) : (
+          <SourceControl key={activeWorktreeId ?? 'none'} />
+        )}
       </div>
 
       {/* Resize handle on LEFT side */}

--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
@@ -45,7 +45,8 @@ export function useTerminalKeyboardShortcuts({
         return
       }
 
-      // Cmd+F opens search
+      // Keep Cmd+F bound to the terminal search until the app has a real
+      // top-level find-in-page flow to fall back to.
       if (!e.shiftKey && e.key.toLowerCase() === 'f') {
         e.preventDefault()
         e.stopPropagation()


### PR DESCRIPTION
## Problem
The terminal shortcut change made `Cmd+F` stop working whenever focus was not inside an xterm element, but the app does not yet have a separate top-level find-in-page flow to handle that fallback. The right sidebar also kept stale explorer and source-control state when switching between worktrees.

## Solution
Keep `Cmd+F` bound to the existing terminal search flow until a real app-level find experience exists, and key the right sidebar content by `activeWorktreeId` so the explorer and source control panes remount when the active worktree changes.