### PR TITLE
Show landing page when no worktree is active

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -287,7 +287,7 @@ function App(): React.JSX.Element {
         <div className="relative flex flex-1 min-w-0 min-h-0 overflow-hidden">
           <div
             className={
-              activeView === 'settings'
+              activeView === 'settings' || !activeWorktreeId
                 ? 'hidden flex-1 min-w-0 min-h-0'
                 : 'flex flex-1 min-w-0 min-h-0'
             }


### PR DESCRIPTION
## Summary
- Hide the terminal view when no active worktree is selected, showing the Landing page instead
- Update README: add "cross-platform" to description and adjust formatting

## Test plan
- [ ] Launch app with no worktrees — verify Landing page is shown instead of empty terminal
- [ ] Select a worktree — verify terminal renders normally
- [ ] Open settings — verify settings view still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)