### PR TITLE
fix: allow single-digit values in NumberField input (#58)

### DIFF
--- a/src/renderer/src/components/settings/SettingsFormControls.tsx
+++ b/src/renderer/src/components/settings/SettingsFormControls.tsx
@@ -149,6 +149,33 @@ export function NumberField({
   onChange,
   suffix
 }: NumberFieldProps): React.JSX.Element {
+  const [draft, setDraft] = useState(Number.isFinite(value) ? String(value) : '')
+  const [prevValue, setPrevValue] = useState(value)
+
+  // Sync draft when the external value changes (e.g. from another source)
+  if (value !== prevValue) {
+    setPrevValue(value)
+    setDraft(Number.isFinite(value) ? String(value) : '')
+  }
+
+  const commit = (): void => {
+    const trimmed = draft.trim()
+    if (trimmed === '') {
+      // Empty input — reset to current value rather than committing 0
+      setDraft(Number.isFinite(value) ? String(value) : '')
+      return
+    }
+    const next = Number(trimmed)
+    if (Number.isFinite(next)) {
+      const clamped = Math.min(max, Math.max(min, next))
+      onChange(clamped)
+      setDraft(String(clamped))
+    } else {
+      // Reset to current value if input is invalid
+      setDraft(Number.isFinite(value) ? String(value) : '')
+    }
+  }
+
   return (
     <div className="space-y-2">
       <div className="space-y-1">
@@ -161,13 +188,13 @@ export function NumberField({
           min={min}
           max={max}
           step={step}
-          value={Number.isFinite(value) ? String(value) : ''}
-          onChange={(e) => {
-            const next = Number(e.target.value)
-            if (!Number.isFinite(next)) {
-              return
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={commit}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              commit()
             }
-            onChange(next)
           }}
           className="number-input-clean w-28 tabular-nums"
         />


### PR DESCRIPTION
## Problem

When typing a single-digit value (e.g. "5") in the divider thickness or opacity fields, the input would jump to a double-digit value with "1" stuck at the front (e.g. "15"). This made it impossible to set single-digit values.

The root cause: NumberField was calling `onChange` on every keystroke, which triggered immediate validation and clamping. When clearing the field to type a new value, the empty field would be clamped to the minimum (1), and the "1" would get stuck.

## Solution

Changed NumberField to use a draft/commit pattern:
- Input maintains local state as the user types (no immediate validation)
- Value is only validated and committed on blur or Enter keypress
- Empty input resets to the current value instead of committing 0
- This allows smooth, single-digit value entry while still maintaining min/max constraints

Fixes #58