### PR TITLE
fix: clear repo filter after creating worktree

### DIFF
--- a/src/renderer/src/components/sidebar/AddWorktreeDialog.tsx
+++ b/src/renderer/src/components/sidebar/AddWorktreeDialog.tsx
@@ -128,7 +128,7 @@ const AddWorktreeDialog = React.memo(function AddWorktreeDialog() {
         setSidebarOpen(true)
         setSearchQuery('')
         setShowActiveOnly(false)
-        setFilterRepoId(repoId)
+        setFilterRepoId(null)
         setActiveWorktree(wt.id)
         revealWorktreeInSidebar(wt.id)
       }


### PR DESCRIPTION
## Summary
- After creating a worktree, clears the sidebar repo filter (`setFilterRepoId(null)`) instead of auto-filtering to the current repo
- The newly created worktree is still scrolled into view via `revealWorktreeInSidebar`

## Test plan
- [ ] Create a new worktree from a repo
- [ ] Verify the sidebar shows all worktrees (not filtered to current repo)
- [ ] Verify the new worktree is visible and selected in the sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)