### PR TITLE
fix: route terminal paste through electron clipboard

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,4 +1,13 @@
-import { app, shell, BrowserWindow, Menu, nativeImage, ipcMain, nativeTheme } from 'electron'
+import {
+  app,
+  shell,
+  BrowserWindow,
+  Menu,
+  nativeImage,
+  ipcMain,
+  nativeTheme,
+  clipboard
+} from 'electron'
 import { join } from 'path'
 import { electronApp, optimizer, is } from '@electron-toolkit/utils'
 import icon from '../../resources/icon.png?asset'
@@ -264,6 +273,10 @@ app.whenReady().then(() => {
   warmSystemFontFamilies()
   setupAutoUpdater(mainWindow)
 
+  // Clipboard: read text via Electron's native clipboard module so the
+  // renderer can bypass Chromium's clipboard pipeline (which holds
+  // NSPasteboard references and causes contention with CLI tools like Codex).
+  ipcMain.handle('clipboard:readText', () => clipboard.readText())
 
   // Updater IPC
   ipcMain.handle('updater:getStatus', () => getUpdateStatus())

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -100,6 +100,7 @@ type UIApi = {
   set: (args: Partial<PersistedUIState>) => Promise<void>
   onOpenSettings: (callback: () => void) => () => void
   onTerminalZoom: (callback: (direction: 'in' | 'out' | 'reset') => void) => () => void
+  readClipboardText: () => Promise<string>
   onFileDrop: (callback: (data: { path: string }) => void) => () => void
   getZoomLevel: () => number
   setZoomLevel: (level: number) => void

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -221,6 +221,7 @@ const api = {
       ipcRenderer.on('terminal:zoom', listener)
       return () => ipcRenderer.removeListener('terminal:zoom', listener)
     },
+    readClipboardText: (): Promise<string> => ipcRenderer.invoke('clipboard:readText'),
     onFileDrop: (callback: (data: { path: string }) => void): (() => void) => {
       const listener = (_event: Electron.IpcRendererEvent, data: { path: string }) => callback(data)
       ipcRenderer.on('terminal:file-drop', listener)

--- a/src/renderer/src/components/TerminalSearch.tsx
+++ b/src/renderer/src/components/TerminalSearch.tsx
@@ -72,6 +72,7 @@ export default function TerminalSearch({
 
   return (
     <div
+      data-terminal-search-root
       className="absolute top-2 right-2 z-50 flex items-center gap-1 rounded-lg border border-zinc-700 bg-zinc-800/95 px-2 py-1 shadow-lg backdrop-blur-sm"
       style={{ width: 300 }}
       onKeyDown={handleKeyDown}

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -436,6 +436,49 @@ export default function TerminalPane({
     })
   }, [isActive])
 
+  // Intercept paste events on the terminal to bypass Chromium's native
+  // clipboard pipeline. Chromium holds NSPasteboard references during format
+  // conversion, which can cause concurrent clipboard reads by CLI tools
+  // (e.g. Codex checking for images) to fail intermittently. Reading via
+  // Electron's clipboard module in the main process avoids this contention.
+  useEffect(() => {
+    if (!isActive) {
+      return
+    }
+    const container = containerRef.current
+    if (!container) {
+      return
+    }
+    const onPaste = (e: ClipboardEvent): void => {
+      const target = e.target
+      if (target instanceof Element && target.closest('[data-terminal-search-root]')) {
+        return
+      }
+      e.preventDefault()
+      e.stopPropagation()
+      const manager = managerRef.current
+      if (!manager) {
+        return
+      }
+      const pane = manager.getActivePane() ?? manager.getPanes()[0]
+      if (!pane) {
+        return
+      }
+      void window.api.ui
+        .readClipboardText()
+        .then((text) => {
+          if (text) {
+            pane.terminal.paste(text)
+          }
+        })
+        .catch(() => {
+          /* ignore clipboard read failures */
+        })
+    }
+    container.addEventListener('paste', onPaste, { capture: true })
+    return () => container.removeEventListener('paste', onPaste, { capture: true })
+  }, [isActive])
+
   const resolveMenuPane = () => {
     const manager = managerRef.current
     if (!manager) {
@@ -467,9 +510,9 @@ export default function TerminalPane({
     if (!pane) {
       return
     }
-    const text = await navigator.clipboard.readText()
+    const text = await window.api.ui.readClipboardText()
     if (text) {
-      paneTransportsRef.current.get(pane.id)?.sendInput(text)
+      pane.terminal.paste(text)
     }
   }
 


### PR DESCRIPTION
## Problem
Pasting into the terminal went through Chromium's clipboard pipeline, which can hold NSPasteboard references during format conversion and interfere with concurrent clipboard reads by CLI tools on macOS.

## Solution
Add a main-process clipboard text IPC, use it for terminal paste paths, and intercept terminal paste events so xterm receives text from Electron's native clipboard instead of Chromium. Preserve normal paste behavior for the terminal search input.