### PR TITLE
fix: bundle Monaco workers locally and fix JSX/TSX language detection

### DIFF
--- a/src/renderer/src/components/editor/EditorPanel.tsx
+++ b/src/renderer/src/components/editor/EditorPanel.tsx
@@ -1,16 +1,17 @@
 import React, { useCallback, useEffect, useState, lazy, Suspense } from 'react'
 import { useAppStore } from '@/store'
+import { detectLanguage } from '@/lib/language-detect'
 
 const MonacoEditor = lazy(() => import('./MonacoEditor'))
 const DiffViewer = lazy(() => import('./DiffViewer'))
 const CombinedDiffViewer = lazy(() => import('./CombinedDiffViewer'))
 
-interface FileContent {
+type FileContent = {
   content: string
   isBinary: boolean
 }
 
-interface DiffContent {
+type DiffContent = {
   originalContent: string
   modifiedContent: string
 }
@@ -28,12 +29,18 @@ export default function EditorPanel(): React.JSX.Element {
 
   // Load file content when active file changes
   useEffect(() => {
-    if (!activeFile) return
+    if (!activeFile) {
+      return
+    }
     if (activeFile.mode === 'edit') {
-      if (fileContents[activeFile.id]) return
+      if (fileContents[activeFile.id]) {
+        return
+      }
       void loadFileContent(activeFile.filePath, activeFile.id)
     } else if (activeFile.mode === 'diff' && activeFile.diffStaged !== undefined) {
-      if (diffContents[activeFile.id]) return
+      if (diffContents[activeFile.id]) {
+        return
+      }
       void loadDiffContent(activeFile)
     }
   }, [activeFile?.id]) // eslint-disable-line react-hooks/exhaustive-deps
@@ -51,7 +58,9 @@ export default function EditorPanel(): React.JSX.Element {
   }
 
   const loadDiffContent = async (file: typeof activeFile): Promise<void> => {
-    if (!file) return
+    if (!file) {
+      return
+    }
     try {
       // Extract worktree path from absolute file path and relative path
       const worktreePath = file.filePath.slice(
@@ -74,7 +83,9 @@ export default function EditorPanel(): React.JSX.Element {
 
   const handleContentChange = useCallback(
     (content: string) => {
-      if (!activeFile) return
+      if (!activeFile) {
+        return
+      }
       setEditBuffers((prev) => ({ ...prev, [activeFile.id]: content }))
       // Compare against saved content to determine dirty state
       const saved = fileContents[activeFile.id]?.content ?? ''
@@ -85,7 +96,9 @@ export default function EditorPanel(): React.JSX.Element {
 
   const handleSave = useCallback(
     async (content: string) => {
-      if (!activeFile) return
+      if (!activeFile) {
+        return
+      }
       try {
         await window.api.fs.writeFile({ filePath: activeFile.filePath, content })
         markFileDirty(activeFile.id, false)
@@ -105,7 +118,9 @@ export default function EditorPanel(): React.JSX.Element {
     const handler = async (e: Event): Promise<void> => {
       const { fileId } = (e as CustomEvent).detail as { fileId: string }
       const file = useAppStore.getState().openFiles.find((f) => f.id === fileId)
-      if (!file) return
+      if (!file) {
+        return
+      }
       const buffer = editBuffers[fileId]
       if (buffer !== undefined) {
         try {
@@ -132,29 +147,41 @@ export default function EditorPanel(): React.JSX.Element {
     setFileContents((prev) => {
       const next: Record<string, FileContent> = {}
       for (const [k, v] of Object.entries(prev)) {
-        if (openIds.has(k)) next[k] = v
+        if (openIds.has(k)) {
+          next[k] = v
+        }
       }
       return next
     })
     setDiffContents((prev) => {
       const next: Record<string, DiffContent> = {}
       for (const [k, v] of Object.entries(prev)) {
-        if (openIds.has(k)) next[k] = v
+        if (openIds.has(k)) {
+          next[k] = v
+        }
       }
       return next
     })
     setEditBuffers((prev) => {
       const next: Record<string, string> = {}
       for (const [k, v] of Object.entries(prev)) {
-        if (openIds.has(k)) next[k] = v
+        if (openIds.has(k)) {
+          next[k] = v
+        }
       }
       return next
     })
   }, [openFiles])
 
-  if (!activeFile) return <></>
+  if (!activeFile) {
+    return null
+  }
 
   const isCombinedDiff = activeFile.mode === 'diff' && activeFile.diffStaged === undefined
+  const resolvedLanguage =
+    activeFile.mode === 'diff'
+      ? detectLanguage(activeFile.relativePath)
+      : detectLanguage(activeFile.filePath)
 
   const loadingFallback = (
     <div className="flex items-center justify-center h-full text-muted-foreground text-sm">
@@ -188,7 +215,7 @@ export default function EditorPanel(): React.JSX.Element {
               <MonacoEditor
                 filePath={activeFile.filePath}
                 content={editBuffers[activeFile.id] ?? fc.content}
-                language={activeFile.language}
+                language={resolvedLanguage}
                 onContentChange={handleContentChange}
                 onSave={handleSave}
               />
@@ -208,7 +235,7 @@ export default function EditorPanel(): React.JSX.Element {
               <DiffViewer
                 originalContent={dc.originalContent}
                 modifiedContent={dc.modifiedContent}
-                language={activeFile.language}
+                language={resolvedLanguage}
                 filePath={activeFile.relativePath}
               />
             )

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -1,1 +1,11 @@
 /// <reference types="vite/client" />
+
+declare global {
+  var MonacoEnvironment:
+    | {
+        getWorker(workerId: string, label: string): Worker
+      }
+    | undefined
+}
+
+export {}

--- a/src/renderer/src/lib/language-detect.ts
+++ b/src/renderer/src/lib/language-detect.ts
@@ -1,15 +1,17 @@
 function extname(filePath: string): string {
   const lastDot = filePath.lastIndexOf('.')
   const lastSep = Math.max(filePath.lastIndexOf('/'), filePath.lastIndexOf('\\'))
-  if (lastDot <= lastSep) return ''
+  if (lastDot <= lastSep) {
+    return ''
+  }
   return filePath.slice(lastDot)
 }
 
 const EXT_TO_LANGUAGE: Record<string, string> = {
   '.ts': 'typescript',
-  '.tsx': 'typescript',
+  '.tsx': 'typescriptreact',
   '.js': 'javascript',
-  '.jsx': 'javascript',
+  '.jsx': 'javascriptreact',
   '.mjs': 'javascript',
   '.cjs': 'javascript',
   '.json': 'json',
@@ -89,7 +91,7 @@ const FILENAME_TO_LANGUAGE: Record<string, string> = {
 export function detectLanguage(filePath: string): string {
   // Check exact filename first
   const parts = filePath.split('/')
-  const filename = parts[parts.length - 1]
+  const filename = parts.at(-1)!
   if (FILENAME_TO_LANGUAGE[filename]) {
     return FILENAME_TO_LANGUAGE[filename]
   }

--- a/src/renderer/src/lib/monaco-setup.ts
+++ b/src/renderer/src/lib/monaco-setup.ts
@@ -1,5 +1,35 @@
 import { loader } from '@monaco-editor/react'
 import * as monaco from 'monaco-editor'
+import 'monaco-editor/min/vs/editor/editor.main.css'
+import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker'
+import jsonWorker from 'monaco-editor/esm/vs/language/json/json.worker?worker'
+import cssWorker from 'monaco-editor/esm/vs/language/css/css.worker?worker'
+import htmlWorker from 'monaco-editor/esm/vs/language/html/html.worker?worker'
+import tsWorker from 'monaco-editor/esm/vs/language/typescript/ts.worker?worker'
+
+globalThis.MonacoEnvironment = {
+  getWorker(_workerId, label) {
+    switch (label) {
+      case 'json':
+        return new jsonWorker()
+      case 'css':
+      case 'scss':
+      case 'less':
+        return new cssWorker()
+      case 'html':
+      case 'handlebars':
+      case 'razor':
+        return new htmlWorker()
+      case 'typescript':
+      case 'typescriptreact':
+      case 'javascript':
+      case 'javascriptreact':
+        return new tsWorker()
+      default:
+        return new editorWorker()
+    }
+  }
+}
 
 // Configure Monaco to use the locally bundled editor instead of CDN
 loader.config({ monaco })


### PR DESCRIPTION
## Summary
- Bundle Monaco web workers locally using Vite `?worker` imports instead of relying on CDN
- Fix `.tsx`/`.jsx` language IDs to use `typescriptreact`/`javascriptreact` (correct Monaco language IDs)
- Use `detectLanguage()` from file path in EditorPanel for proper language resolution
- Add global `MonacoEnvironment` type declaration

## Test plan
- [ ] Verify Monaco editor loads without CDN requests (check Network tab)
- [ ] Open a `.tsx` file and confirm syntax highlighting works correctly
- [ ] Open a `.jsx` file and confirm syntax highlighting works correctly
- [ ] Verify diff viewer also uses correct language highlighting

🤖 Generated with [Claude Code](https://claude.com/claude-code)