### PR TITLE
fix: resolve TypeScript build errors

### DIFF
--- a/src/renderer/src/components/editor/EditorPanel.tsx
+++ b/src/renderer/src/components/editor/EditorPanel.tsx
@@ -16,7 +16,7 @@ type DiffContent = {
   modifiedContent: string
 }
 
-export default function EditorPanel(): React.JSX.Element {
+export default function EditorPanel(): React.JSX.Element | null {
   const openFiles = useAppStore((s) => s.openFiles)
   const activeFileId = useAppStore((s) => s.activeFileId)
   const markFileDirty = useAppStore((s) => s.markFileDirty)

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -192,7 +192,6 @@ export default function TerminalPane({
 
   const contextMenu = useTerminalPaneContextMenu({
     managerRef,
-    paneTransportsRef,
     toggleExpandPane
   })
 

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
@@ -1,12 +1,9 @@
 import { useEffect, useRef, useState } from 'react'
 import type { ManagedPane, PaneManager } from '@/lib/pane-manager/pane-manager'
-import type { PtyTransport } from './pty-transport'
-
 const CLOSE_ALL_CONTEXT_MENUS_EVENT = 'orca-close-all-context-menus'
 
 type UseTerminalPaneContextMenuDeps = {
   managerRef: React.RefObject<PaneManager | null>
-  paneTransportsRef: React.RefObject<Map<number, PtyTransport>>
   toggleExpandPane: (paneId: number) => void
 }
 
@@ -29,7 +26,6 @@ type TerminalMenuState = {
 
 export function useTerminalPaneContextMenu({
   managerRef,
-  paneTransportsRef,
   toggleExpandPane
 }: UseTerminalPaneContextMenuDeps): TerminalMenuState {
   const contextPaneIdRef = useRef<number | null>(null)


### PR DESCRIPTION
## Summary
- Remove unused `paneTransportsRef` parameter from `useTerminalPaneContextMenu` hook and its call site
- Fix `EditorPanel` return type from `React.JSX.Element` to `React.JSX.Element | null` to match `return null` early exit

## Test plan
- [x] `pnpm run typecheck` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)