### PR TITLE
feat: double-click to edit worktree details

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -75,6 +75,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
   isActive
 }: WorktreeCardProps) {
   const setActiveWorktree = useAppStore((s) => s.setActiveWorktree)
+  const openModal = useAppStore((s) => s.openModal)
   const updateWorktreeMeta = useAppStore((s) => s.updateWorktreeMeta)
   const fetchPRForBranch = useAppStore((s) => s.fetchPRForBranch)
   const fetchIssue = useAppStore((s) => s.fetchIssue)
@@ -150,6 +151,14 @@ const WorktreeCard = React.memo(function WorktreeCard({
     setActiveWorktree(worktree.id)
   }, [worktree.id, setActiveWorktree])
 
+  const handleDoubleClick = useCallback(() => {
+    openModal('edit-meta', {
+      worktreeId: worktree.id,
+      currentIssue: worktree.linkedIssue,
+      currentComment: worktree.comment
+    })
+  }, [worktree.id, worktree.linkedIssue, worktree.comment, openModal])
+
   const handleToggleUnreadQuick = useCallback(
     (event: React.MouseEvent<HTMLButtonElement>) => {
       event.preventDefault()
@@ -172,6 +181,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
           isDeleting && 'opacity-70'
         )}
         onClick={handleClick}
+        onDoubleClick={handleDoubleClick}
         aria-busy={isDeleting}
       >
         {isDeleting && (

--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
@@ -48,12 +48,22 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({ worktree, 
   }, [worktree.id, worktree.isUnread, updateWorktreeMeta])
 
   const handleLinkIssue = useCallback(() => {
-    openModal('link-issue', { worktreeId: worktree.id, currentIssue: worktree.linkedIssue })
-  }, [worktree.id, worktree.linkedIssue, openModal])
+    openModal('edit-meta', {
+      worktreeId: worktree.id,
+      currentIssue: worktree.linkedIssue,
+      currentComment: worktree.comment,
+      focus: 'issue'
+    })
+  }, [worktree.id, worktree.linkedIssue, worktree.comment, openModal])
 
   const handleComment = useCallback(() => {
-    openModal('edit-comment', { worktreeId: worktree.id, currentComment: worktree.comment })
-  }, [worktree.id, worktree.comment, openModal])
+    openModal('edit-meta', {
+      worktreeId: worktree.id,
+      currentIssue: worktree.linkedIssue,
+      currentComment: worktree.comment,
+      focus: 'comment'
+    })
+  }, [worktree.id, worktree.linkedIssue, worktree.comment, openModal])
 
   const handleCloseTerminals = useCallback(async () => {
     await shutdownWorktreeTerminals(worktree.id)

--- a/src/renderer/src/components/sidebar/WorktreeMetaDialog.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeMetaDialog.tsx
@@ -11,6 +11,7 @@ import {
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { parseGitHubIssueOrPRNumber } from '@/lib/github-links'
+import type { WorktreeMeta } from '../../../../shared/types'
 
 const WorktreeMetaDialog = React.memo(function WorktreeMetaDialog() {
   const activeModal = useAppStore((s) => s.activeModal)
@@ -18,20 +19,21 @@ const WorktreeMetaDialog = React.memo(function WorktreeMetaDialog() {
   const closeModal = useAppStore((s) => s.closeModal)
   const updateWorktreeMeta = useAppStore((s) => s.updateWorktreeMeta)
 
-  const isLinkIssue = activeModal === 'link-issue'
-  const isEditComment = activeModal === 'edit-comment'
-  const isOpen = isLinkIssue || isEditComment
+  const isEditMeta = activeModal === 'edit-meta'
+  const isOpen = isEditMeta
 
   const worktreeId = typeof modalData.worktreeId === 'string' ? modalData.worktreeId : ''
   const currentIssue =
     typeof modalData.currentIssue === 'number' ? String(modalData.currentIssue) : ''
   const currentComment =
     typeof modalData.currentComment === 'string' ? modalData.currentComment : ''
+  const focusField = typeof modalData.focus === 'string' ? modalData.focus : 'comment'
 
   const [issueInput, setIssueInput] = useState('')
   const [commentInput, setCommentInput] = useState('')
   const [saving, setSaving] = useState(false)
 
+  const issueInputRef = useRef<HTMLInputElement>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const prevIsOpenRef = useRef(false)
   if (isOpen && !prevIsOpenRef.current) {
@@ -50,20 +52,17 @@ const WorktreeMetaDialog = React.memo(function WorktreeMetaDialog() {
   }, [])
 
   useEffect(() => {
-    if (isEditComment) {
+    if (isEditMeta) {
       autoResize()
     }
-  }, [isEditComment, commentInput, autoResize])
+  }, [isEditMeta, commentInput, autoResize])
 
   const canSave = useMemo(() => {
     if (!worktreeId) {
       return false
     }
-    if (isLinkIssue) {
-      return issueInput.trim() === '' || parseGitHubIssueOrPRNumber(issueInput) !== null
-    }
-    return true
-  }, [worktreeId, isLinkIssue, issueInput])
+    return issueInput.trim() === '' || parseGitHubIssueOrPRNumber(issueInput) !== null
+  }, [worktreeId, issueInput])
 
   const handleOpenChange = useCallback(
     (open: boolean) => {
@@ -80,28 +79,24 @@ const WorktreeMetaDialog = React.memo(function WorktreeMetaDialog() {
     }
     setSaving(true)
     try {
-      if (isLinkIssue) {
-        const trimmed = issueInput.trim()
-        const linkedIssueNumber = parseGitHubIssueOrPRNumber(trimmed)
-        if (trimmed === '' || linkedIssueNumber !== null) {
-          await updateWorktreeMeta(worktreeId, { linkedIssue: linkedIssueNumber })
-        }
-      } else if (isEditComment) {
-        await updateWorktreeMeta(worktreeId, { comment: commentInput.trim() })
+      const trimmedIssue = issueInput.trim()
+      const linkedIssueNumber = parseGitHubIssueOrPRNumber(trimmedIssue)
+      const finalLinkedIssue =
+        trimmedIssue === '' ? null : linkedIssueNumber !== null ? linkedIssueNumber : undefined
+
+      const updates: Partial<WorktreeMeta> = {
+        comment: commentInput.trim()
       }
+      if (finalLinkedIssue !== undefined) {
+        updates.linkedIssue = finalLinkedIssue
+      }
+
+      await updateWorktreeMeta(worktreeId, updates)
       closeModal()
     } finally {
       setSaving(false)
     }
-  }, [
-    worktreeId,
-    isLinkIssue,
-    isEditComment,
-    issueInput,
-    commentInput,
-    updateWorktreeMeta,
-    closeModal
-  ])
+  }, [worktreeId, issueInput, commentInput, updateWorktreeMeta, closeModal])
 
   const handleCommentKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -113,35 +108,52 @@ const WorktreeMetaDialog = React.memo(function WorktreeMetaDialog() {
     [handleSave]
   )
 
+  const handleIssueKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter') {
+        e.preventDefault()
+        handleSave()
+      }
+    },
+    [handleSave]
+  )
+
   return (
     <Dialog open={isOpen} onOpenChange={handleOpenChange}>
-      <DialogContent className="max-w-md" onOpenAutoFocus={(e) => e.preventDefault()}>
+      <DialogContent
+        className="max-w-md"
+        onOpenAutoFocus={(e) => {
+          e.preventDefault()
+          if (focusField === 'issue') {
+            issueInputRef.current?.focus()
+          } else {
+            textareaRef.current?.focus()
+          }
+        }}
+      >
         <DialogHeader>
-          <DialogTitle className="text-sm">
-            {isLinkIssue ? 'Link GH Issue/PR' : 'Edit Comment'}
-          </DialogTitle>
+          <DialogTitle className="text-sm">Edit Worktree Details</DialogTitle>
           <DialogDescription className="text-xs">
-            {isLinkIssue
-              ? 'Add an issue/PR number or URL to link this worktree. Leave blank to remove the link.'
-              : 'Add or edit notes for this worktree.'}
+            Edit the GitHub issue link and notes for this worktree.
           </DialogDescription>
         </DialogHeader>
 
-        {isLinkIssue ? (
+        <div className="space-y-4">
           <div className="space-y-1">
             <label className="text-[11px] font-medium text-muted-foreground">GH Issue / PR</label>
             <Input
+              ref={issueInputRef}
               value={issueInput}
               onChange={(e) => setIssueInput(e.target.value)}
+              onKeyDown={handleIssueKeyDown}
               placeholder="Issue/PR # or GitHub URL"
               className="h-8 text-xs"
-              autoFocus
             />
             <p className="text-[10px] text-muted-foreground">
-              Paste an issue or PR URL, or enter a number.
+              Paste an issue or PR URL, or enter a number. Leave blank to remove the link.
             </p>
           </div>
-        ) : (
+
           <div className="space-y-1">
             <label className="text-[11px] font-medium text-muted-foreground">Comment</label>
             <textarea
@@ -151,14 +163,13 @@ const WorktreeMetaDialog = React.memo(function WorktreeMetaDialog() {
               onKeyDown={handleCommentKeyDown}
               placeholder="Notes about this worktree..."
               rows={3}
-              autoFocus
               className="w-full min-w-0 rounded-md border border-input bg-transparent px-3 py-2 text-xs shadow-xs transition-[color,box-shadow] outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 resize-none max-h-60 overflow-y-auto"
             />
             <p className="text-[10px] text-muted-foreground">
               Press Enter to save, Shift+Enter for a new line.
             </p>
           </div>
-        )}
+        </div>
 
         <DialogFooter>
           <Button

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -2,7 +2,7 @@ import type { StateCreator } from 'zustand'
 import type { AppState } from '../types'
 import type { PersistedUIState, UpdateStatus } from '../../../../shared/types'
 
-export interface UISlice {
+export type UISlice = {
   sidebarOpen: boolean
   sidebarWidth: number
   toggleSidebar: () => void
@@ -10,7 +10,7 @@ export interface UISlice {
   setSidebarWidth: (width: number) => void
   activeView: 'terminal' | 'settings'
   setActiveView: (view: UISlice['activeView']) => void
-  activeModal: 'none' | 'create-worktree' | 'link-issue' | 'edit-comment' | 'delete-worktree'
+  activeModal: 'none' | 'create-worktree' | 'edit-meta' | 'delete-worktree'
   modalData: Record<string, unknown>
   openModal: (modal: UISlice['activeModal'], data?: Record<string, unknown>) => void
   closeModal: () => void
@@ -84,7 +84,6 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set) => (
   dismissedUpdateVersion: null,
   dismissUpdate: () =>
     set((s) => ({
-      dismissedUpdateVersion:
-        'version' in s.updateStatus ? s.updateStatus.version ?? null : null
+      dismissedUpdateVersion: 'version' in s.updateStatus ? (s.updateStatus.version ?? null) : null
     }))
 })


### PR DESCRIPTION
## Summary
- Unified the separate "Link Issue" and "Edit Comment" modals into a single "Edit Worktree Details" dialog
- Added double-click on worktree cards to open the unified meta editor
- Context menu "Link Issue" and "Comment" items now open the same dialog, auto-focusing the relevant field

## Test plan
- [ ] Double-click a worktree card → unified dialog opens with comment field focused
- [ ] Right-click → "Link Issue" → dialog opens with issue field focused
- [ ] Right-click → "Comment" → dialog opens with comment field focused
- [ ] Save with both fields populated → both issue link and comment are saved
- [ ] Clear issue field and save → issue link is removed
- [ ] Enter key in issue field saves; Enter in comment saves, Shift+Enter adds newline

🤖 Generated with [Claude Code](https://claude.com/claude-code)