### PR TITLE
feat: add clickable file path links in terminal

### DIFF
--- a/src/main/ipc/shell.ts
+++ b/src/main/ipc/shell.ts
@@ -1,14 +1,84 @@
 import { ipcMain, shell } from 'electron'
+import { stat } from 'node:fs/promises'
+import { isAbsolute, normalize } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+async function pathExists(pathValue: string): Promise<boolean> {
+  try {
+    await stat(pathValue)
+    return true
+  } catch {
+    return false
+  }
+}
 
 export function registerShellHandlers(): void {
   ipcMain.handle('shell:openPath', (_event, path: string) => {
     shell.showItemInFolder(path)
   })
 
-  ipcMain.handle('shell:openExternal', (_event, url: string) => {
-    if (!url.startsWith('https://') && !url.startsWith('http://')) {
+  ipcMain.handle('shell:openUrl', (_event, rawUrl: string) => {
+    let parsed: URL
+    try {
+      parsed = new URL(rawUrl)
+    } catch {
       return
     }
-    return shell.openExternal(url)
+
+    if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+      return
+    }
+
+    return shell.openExternal(parsed.toString())
+  })
+
+  ipcMain.handle('shell:openFilePath', async (_event, filePath: string) => {
+    if (!isAbsolute(filePath)) {
+      return
+    }
+    const normalizedPath = normalize(filePath)
+    if (!(await pathExists(normalizedPath))) {
+      return
+    }
+    await shell.openPath(normalizedPath)
+  })
+
+  ipcMain.handle('shell:openFileUri', async (_event, rawUri: string) => {
+    let parsed: URL
+    try {
+      parsed = new URL(rawUri)
+    } catch {
+      return
+    }
+
+    if (parsed.protocol !== 'file:') {
+      return
+    }
+
+    // Only local files are supported. Remote hosts are intentionally rejected.
+    if (parsed.hostname && parsed.hostname !== 'localhost') {
+      return
+    }
+
+    let filePath: string
+    try {
+      filePath = fileURLToPath(parsed)
+    } catch {
+      return
+    }
+
+    const normalizedPath = normalize(filePath)
+    if (!isAbsolute(normalizedPath)) {
+      return
+    }
+    if (!(await pathExists(normalizedPath))) {
+      return
+    }
+
+    await shell.openPath(normalizedPath)
+  })
+
+  ipcMain.handle('shell:pathExists', async (_event, filePath: string): Promise<boolean> => {
+    return pathExists(filePath)
   })
 }

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -62,7 +62,10 @@ type SettingsApi = {
 
 type ShellApi = {
   openPath: (path: string) => Promise<void>
-  openExternal: (url: string) => Promise<void>
+  openUrl: (url: string) => Promise<void>
+  openFilePath: (path: string) => Promise<void>
+  openFileUri: (uri: string) => Promise<void>
+  pathExists: (path: string) => Promise<boolean>
 }
 
 type HooksApi = {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -10,7 +10,9 @@ document.addEventListener(
   'dragover',
   (e) => {
     e.preventDefault()
-    if (e.dataTransfer) e.dataTransfer.dropEffect = 'copy'
+    if (e.dataTransfer) {
+      e.dataTransfer.dropEffect = 'copy'
+    }
   },
   true
 )
@@ -21,13 +23,17 @@ document.addEventListener(
     e.preventDefault()
     e.stopPropagation()
     const files = e.dataTransfer?.files
-    if (!files || files.length === 0) return
+    if (!files || files.length === 0) {
+      return
+    }
 
     const paths: string[] = []
     for (let i = 0; i < files.length; i++) {
       // webUtils.getPathForFile is the Electron 28+ replacement for File.path
       const filePath = webUtils.getPathForFile(files[i])
-      if (filePath) paths.push(filePath)
+      if (filePath) {
+        paths.push(filePath)
+      }
     }
 
     if (paths.length > 0) {
@@ -144,7 +150,13 @@ const api = {
   shell: {
     openPath: (path: string): Promise<void> => ipcRenderer.invoke('shell:openPath', path),
 
-    openExternal: (url: string): Promise<void> => ipcRenderer.invoke('shell:openExternal', url)
+    openUrl: (url: string): Promise<void> => ipcRenderer.invoke('shell:openUrl', url),
+
+    openFilePath: (path: string): Promise<void> => ipcRenderer.invoke('shell:openFilePath', path),
+
+    openFileUri: (uri: string): Promise<void> => ipcRenderer.invoke('shell:openFileUri', uri),
+
+    pathExists: (path: string): Promise<boolean> => ipcRenderer.invoke('shell:pathExists', path)
   },
 
   hooks: {
@@ -205,7 +217,6 @@ const api = {
     discard: (args: { worktreePath: string; filePath: string }): Promise<void> =>
       ipcRenderer.invoke('git:discard', args)
   },
-
 
   ui: {
     get: (): Promise<unknown> => ipcRenderer.invoke('ui:get'),

--- a/src/renderer/src/components/editor/MonacoEditor.tsx
+++ b/src/renderer/src/components/editor/MonacoEditor.tsx
@@ -4,7 +4,7 @@ import type { editor } from 'monaco-editor'
 import { useAppStore } from '@/store'
 import '@/lib/monaco-setup'
 
-interface MonacoEditorProps {
+type MonacoEditorProps = {
   filePath: string
   content: string
   language: string
@@ -51,12 +51,37 @@ export default function MonacoEditor({
 
   // Update editor options when settings change
   useEffect(() => {
-    if (!editorRef.current || !settings) return
+    if (!editorRef.current || !settings) {
+      return
+    }
     editorRef.current.updateOptions({
       fontSize: settings.terminalFontSize,
       fontFamily: settings.terminalFontFamily || 'monospace'
     })
-  }, [settings?.terminalFontSize, settings?.terminalFontFamily])
+  }, [settings])
+
+  useEffect(() => {
+    const handler = (event: Event): void => {
+      const detail = (event as CustomEvent).detail as
+        | { filePath?: string; line?: number; column?: number | null }
+        | undefined
+      if (!detail || detail.filePath !== filePath || !detail.line) {
+        return
+      }
+      const editor = editorRef.current
+      if (!editor) {
+        return
+      }
+      const targetColumn = Math.max(1, detail.column ?? 1)
+      const targetLine = Math.max(1, detail.line)
+      editor.revealPositionInCenter({ lineNumber: targetLine, column: targetColumn })
+      editor.setPosition({ lineNumber: targetLine, column: targetColumn })
+      editor.focus()
+    }
+
+    window.addEventListener('orca:editor-reveal-location', handler as EventListener)
+    return () => window.removeEventListener('orca:editor-reveal-location', handler as EventListener)
+  }, [filePath])
 
   return (
     <Editor

--- a/src/renderer/src/components/terminal-pane/terminal-link-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-handlers.ts
@@ -1,0 +1,144 @@
+import type { IDisposable, ILink, ILinkProvider } from '@xterm/xterm'
+import { detectLanguage } from '@/lib/language-detect'
+import {
+  extractTerminalFileLinks,
+  isPathInsideWorktree,
+  resolveTerminalFileLink,
+  toWorktreeRelativePath
+} from '@/lib/terminal-links'
+import { useAppStore } from '@/store'
+import type { PaneManager } from '@/lib/pane-manager/pane-manager'
+
+export type LinkHandlerDeps = {
+  worktreeId: string
+  worktreePath: string
+  startupCwd: string
+  managerRef: React.RefObject<PaneManager | null>
+  linkProviderDisposablesRef: React.RefObject<Map<number, IDisposable>>
+  pathExistsCache: Map<string, boolean>
+}
+
+export function openDetectedFilePath(
+  filePath: string,
+  line: number | null,
+  column: number | null,
+  deps: Pick<LinkHandlerDeps, 'worktreeId' | 'worktreePath'>
+): void {
+  const { worktreeId, worktreePath } = deps
+
+  void (async () => {
+    const pathExists = await window.api.shell.pathExists(filePath)
+    if (!pathExists) {
+      return
+    }
+
+    if (worktreePath && isPathInsideWorktree(filePath, worktreePath)) {
+      const relativePath = toWorktreeRelativePath(filePath, worktreePath)
+      if (relativePath === null || relativePath.length === 0) {
+        return
+      }
+
+      const store = useAppStore.getState()
+      store.setActiveWorktree(worktreeId)
+      store.openFile({
+        filePath,
+        relativePath,
+        worktreeId,
+        language: detectLanguage(filePath),
+        mode: 'edit'
+      })
+
+      if (line !== null) {
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => {
+            window.dispatchEvent(
+              new CustomEvent('orca:editor-reveal-location', {
+                detail: { filePath, line, column }
+              })
+            )
+          })
+        })
+      }
+      return
+    }
+
+    await window.api.shell.openFilePath(filePath)
+  })()
+}
+
+export function createFilePathLinkProvider(paneId: number, deps: LinkHandlerDeps): ILinkProvider {
+  const { startupCwd, managerRef, pathExistsCache, worktreeId, worktreePath } = deps
+  return {
+    provideLinks: (bufferLineNumber, callback) => {
+      const pane = managerRef.current?.getPanes().find((candidate) => candidate.id === paneId)
+      if (!pane) {
+        callback(undefined)
+        return
+      }
+
+      const bufferLine = pane.terminal.buffer.active.getLine(bufferLineNumber - 1)
+      const lineText = bufferLine?.translateToString(true)
+      if (!lineText) {
+        callback(undefined)
+        return
+      }
+
+      const fileLinks = extractTerminalFileLinks(lineText)
+      if (fileLinks.length === 0) {
+        callback(undefined)
+        return
+      }
+
+      void Promise.all(
+        fileLinks.map(async (parsed): Promise<ILink | null> => {
+          const resolved = startupCwd ? resolveTerminalFileLink(parsed, startupCwd) : null
+          if (!resolved) {
+            return null
+          }
+
+          const cachedExists = pathExistsCache.get(resolved.absolutePath)
+          const exists = cachedExists ?? (await window.api.shell.pathExists(resolved.absolutePath))
+          pathExistsCache.set(resolved.absolutePath, exists)
+          if (!exists) {
+            return null
+          }
+
+          return {
+            range: {
+              start: { x: parsed.startIndex + 1, y: bufferLineNumber },
+              end: { x: parsed.endIndex + 1, y: bufferLineNumber }
+            },
+            text: parsed.displayText,
+            activate: () => {
+              openDetectedFilePath(resolved.absolutePath, resolved.line, resolved.column, {
+                worktreeId,
+                worktreePath
+              })
+            }
+          }
+        })
+      ).then((resolvedLinks) => {
+        const links = resolvedLinks.filter((link): link is ILink => link !== null)
+        callback(links.length > 0 ? links : undefined)
+      })
+    }
+  }
+}
+
+export function handleOscLink(rawText: string): void {
+  let parsed: URL
+  try {
+    parsed = new URL(rawText)
+  } catch {
+    return
+  }
+
+  if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+    void window.api.shell.openUrl(parsed.toString())
+    return
+  }
+
+  if (parsed.protocol === 'file:') {
+    void window.api.shell.openFileUri(parsed.toString())
+  }
+}

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -1,5 +1,9 @@
 import { useEffect, useRef } from 'react'
+import type { IDisposable } from '@xterm/xterm'
 import { PaneManager } from '@/lib/pane-manager/pane-manager'
+import { useAppStore } from '@/store'
+import { createFilePathLinkProvider, handleOscLink } from './terminal-link-handlers'
+import type { LinkHandlerDeps } from './terminal-link-handlers'
 import type { GlobalSettings, TerminalLayoutSnapshot } from '../../../../shared/types'
 import { buildFontFamily, replayTerminalLayout } from './layout-serialization'
 import { applyExpandedLayoutTo, restoreExpandedLayoutFrom } from './expand-collapse'
@@ -67,6 +71,7 @@ export function useTerminalPaneLifecycle({
 }: UseTerminalPaneLifecycleDeps): void {
   const systemPrefersDarkRef = useRef(systemPrefersDark)
   systemPrefersDarkRef.current = systemPrefersDark
+  const linkProviderDisposablesRef = useRef(new Map<number, IDisposable>())
 
   const applyAppearance = (manager: PaneManager): void => {
     const currentSettings = settingsRef.current
@@ -91,6 +96,24 @@ export function useTerminalPaneLifecycle({
     const expandedStyleSnapshots = expandedStyleSnapshotRef.current
     const paneTransports = paneTransportsRef.current
     const pendingWrites = pendingWritesRef.current
+    const linkDisposables = linkProviderDisposablesRef.current
+    const worktreePath =
+      useAppStore
+        .getState()
+        .allWorktrees()
+        .find((candidate) => candidate.id === worktreeId)?.path ??
+      cwd ??
+      ''
+    const startupCwd = cwd ?? worktreePath
+    const pathExistsCache = new Map<string, boolean>()
+    const linkDeps: LinkHandlerDeps = {
+      worktreeId,
+      worktreePath,
+      startupCwd,
+      managerRef,
+      linkProviderDisposablesRef,
+      pathExistsCache
+    }
     let resizeRaf: number | null = null
 
     const queueResizeAll = (focusActive: boolean): void => {
@@ -133,11 +156,24 @@ export function useTerminalPaneLifecycle({
 
     const manager = new PaneManager(container, {
       onPaneCreated: (pane) => {
+        const linkProviderDisposable = pane.terminal.registerLinkProvider(
+          createFilePathLinkProvider(pane.id, linkDeps)
+        )
+        linkProviderDisposablesRef.current.set(pane.id, linkProviderDisposable)
+        pane.terminal.options.linkHandler = {
+          allowNonHttpProtocols: true,
+          activate: (_event, text) => handleOscLink(text)
+        }
         applyAppearance(manager)
         connectPanePty(pane, manager, ptyDeps)
         queueResizeAll(true)
       },
       onPaneClosed: (paneId) => {
+        const linkProviderDisposable = linkProviderDisposablesRef.current.get(paneId)
+        if (linkProviderDisposable) {
+          linkProviderDisposable.dispose()
+          linkProviderDisposablesRef.current.delete(paneId)
+        }
         const transport = paneTransportsRef.current.get(paneId)
         if (transport) {
           transport.destroy?.()
@@ -176,7 +212,7 @@ export function useTerminalPaneLifecycle({
         }
       },
       onLinkClick: (url) => {
-        window.api.shell.openExternal(url)
+        void window.api.shell.openUrl(url)
       }
     })
 
@@ -217,6 +253,10 @@ export function useTerminalPaneLifecycle({
         cancelAnimationFrame(resizeRaf)
       }
       restoreExpandedLayoutFrom(expandedStyleSnapshots)
+      for (const disposable of linkDisposables.values()) {
+        disposable.dispose()
+      }
+      linkDisposables.clear()
       for (const transport of paneTransports.values()) {
         transport.destroy?.()
       }

--- a/src/renderer/src/lib/terminal-links.ts
+++ b/src/renderer/src/lib/terminal-links.ts
@@ -1,0 +1,168 @@
+export type ParsedTerminalFileLink = {
+  pathText: string
+  line: number | null
+  column: number | null
+  startIndex: number
+  endIndex: number
+  displayText: string
+}
+
+export type ResolvedTerminalFileLink = {
+  absolutePath: string
+  line: number | null
+  column: number | null
+}
+
+const FILE_LINK_CANDIDATE_REGEX =
+  /(?:\/|\.{1,2}\/|[A-Za-z0-9._-]+\/)[A-Za-z0-9._~\-/]*(?::\d+)?(?::\d+)?/g
+
+const LEADING_TRIM_CHARS = new Set(['(', '[', '{', '"', "'"])
+const TRAILING_TRIM_CHARS = new Set([')', ']', '}', '"', "'", ',', ';', '.'])
+
+function trimBoundaryPunctuation(
+  value: string,
+  startIndex: number
+): { text: string; startIndex: number; endIndex: number } | null {
+  let start = 0
+  let end = value.length
+
+  while (start < end && LEADING_TRIM_CHARS.has(value[start])) {
+    start += 1
+  }
+  while (end > start && TRAILING_TRIM_CHARS.has(value[end - 1])) {
+    end -= 1
+  }
+
+  if (start >= end) {
+    return null
+  }
+
+  return {
+    text: value.slice(start, end),
+    startIndex: startIndex + start,
+    endIndex: startIndex + end
+  }
+}
+
+function parsePathWithOptionalLineColumn(value: string): {
+  pathText: string
+  line: number | null
+  column: number | null
+} | null {
+  const match = /^(.*?)(?::(\d+))?(?::(\d+))?$/.exec(value)
+  if (!match) {
+    return null
+  }
+  const pathText = match[1]
+  if (!pathText || pathText.endsWith('/')) {
+    return null
+  }
+
+  const line = match[2] ? Number.parseInt(match[2], 10) : null
+  const column = match[3] ? Number.parseInt(match[3], 10) : null
+  if ((line !== null && line < 1) || (column !== null && column < 1)) {
+    return null
+  }
+
+  return { pathText, line, column }
+}
+
+function normalizeAbsolutePosixPath(pathValue: string): string {
+  const segments = pathValue.split('/')
+  const stack: string[] = []
+  for (const segment of segments) {
+    if (!segment || segment === '.') {
+      continue
+    }
+    if (segment === '..') {
+      if (stack.length > 0) {
+        stack.pop()
+      }
+      continue
+    }
+    stack.push(segment)
+  }
+  return `/${stack.join('/')}`
+}
+
+export function extractTerminalFileLinks(lineText: string): ParsedTerminalFileLink[] {
+  const results: ParsedTerminalFileLink[] = []
+  const matches = lineText.matchAll(FILE_LINK_CANDIDATE_REGEX)
+  for (const match of matches) {
+    const rawText = match[0]
+    const rawStart = match.index ?? 0
+
+    const trimmed = trimBoundaryPunctuation(rawText, rawStart)
+    if (!trimmed) {
+      continue
+    }
+
+    const candidateText = trimmed.text
+    if (candidateText.includes('://')) {
+      continue
+    }
+    const prefix = lineText.slice(0, trimmed.startIndex)
+    if (/[A-Za-z][A-Za-z0-9+.-]*:\/\/$/.test(prefix)) {
+      continue
+    }
+    if (!candidateText.includes('/')) {
+      continue
+    }
+
+    const parsed = parsePathWithOptionalLineColumn(candidateText)
+    if (!parsed) {
+      continue
+    }
+
+    results.push({
+      pathText: parsed.pathText,
+      line: parsed.line,
+      column: parsed.column,
+      startIndex: trimmed.startIndex,
+      endIndex: trimmed.endIndex,
+      displayText: candidateText
+    })
+  }
+
+  return results
+}
+
+export function resolveTerminalFileLink(
+  parsed: ParsedTerminalFileLink,
+  cwd: string
+): ResolvedTerminalFileLink | null {
+  if (!cwd.startsWith('/')) {
+    return null
+  }
+
+  const absolutePath = parsed.pathText.startsWith('/')
+    ? normalizeAbsolutePosixPath(parsed.pathText)
+    : normalizeAbsolutePosixPath(`${cwd.replace(/\/+$/, '')}/${parsed.pathText}`)
+
+  return {
+    absolutePath,
+    line: parsed.line,
+    column: parsed.column
+  }
+}
+
+export function isPathInsideWorktree(filePath: string, worktreePath: string): boolean {
+  const normalizedFile = normalizeAbsolutePosixPath(filePath)
+  const normalizedWorktree = normalizeAbsolutePosixPath(worktreePath)
+  if (normalizedFile === normalizedWorktree) {
+    return true
+  }
+  return normalizedFile.startsWith(`${normalizedWorktree}/`)
+}
+
+export function toWorktreeRelativePath(filePath: string, worktreePath: string): string | null {
+  const normalizedFile = normalizeAbsolutePosixPath(filePath)
+  const normalizedWorktree = normalizeAbsolutePosixPath(worktreePath)
+  if (normalizedFile === normalizedWorktree) {
+    return ''
+  }
+  if (!normalizedFile.startsWith(`${normalizedWorktree}/`)) {
+    return null
+  }
+  return normalizedFile.slice(normalizedWorktree.length + 1)
+}


### PR DESCRIPTION
## Summary
- Add terminal link detection that recognizes file paths (absolute and relative) with optional `:line:column` suffixes, opening them in the built-in editor or externally
- Split the single `shell:openExternal` IPC handler into dedicated `openUrl`, `openFilePath`, `openFileUri`, and `pathExists` handlers with proper URL parsing and path validation
- Register xterm link providers per terminal pane with path existence caching, and support OSC 8 hyperlinks for http(s) and file: protocols
- Add `orca:editor-reveal-location` custom event so clicking a terminal link jumps the Monaco editor to the exact line/column

## Test plan
- [ ] Verify clicking a file path like `src/main/index.ts:10:5` in the terminal opens the file at line 10, column 5 in the editor
- [ ] Verify relative paths (e.g., `./src/foo.ts`) resolve against the terminal's cwd
- [ ] Verify http/https URLs still open in the default browser
- [ ] Verify file: URIs open the file externally
- [ ] Verify non-existent paths are not clickable
- [ ] Verify paths outside the worktree open externally rather than in the editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)