### PR TITLE
fix: restore sidebar text contrast and lowercase repo names

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -238,7 +238,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
         <div className="flex-1 min-w-0 flex flex-col gap-1.5">
           {/* Header row: Title and Checks */}
           <div className="flex items-center justify-between min-w-0 gap-2">
-            <div className="text-[13px] font-medium text-foreground/90 truncate leading-none">
+            <div className="text-[12px] font-semibold text-foreground truncate leading-tight">
               {worktree.displayName}
             </div>
 
@@ -288,7 +288,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
                   className="size-1.5 rounded-full"
                   style={{ backgroundColor: repo.badgeColor }}
                 />
-                <span className="text-[10px] font-medium text-foreground/70 truncate max-w-[6rem] leading-none">
+                <span className="text-[10px] font-semibold text-foreground truncate max-w-[6rem] leading-none lowercase">
                   {repo.displayName}
                 </span>
               </div>
@@ -302,7 +302,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
                 main
               </Badge>
             ) : (
-              <span className="text-[10.5px] text-muted-foreground/60 truncate font-mono leading-none tracking-normal">
+              <span className="text-[11px] text-muted-foreground truncate font-mono leading-none">
                 {branch}
               </span>
             )}

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -324,10 +324,10 @@ const WorktreeList = React.memo(function WorktreeList() {
 
                   <div className="min-w-0 flex-1">
                     <div className="flex items-center gap-1.5">
-                      <div className="truncate text-[11px] font-semibold tracking-[0.02em] uppercase text-muted-foreground/70 leading-none">
+                      <div className="truncate text-[13px] font-semibold leading-none lowercase">
                         {row.label}
                       </div>
-                      <div className="rounded-full bg-black/5 dark:bg-white/10 px-[5px] py-[1.5px] text-[8.5px] font-bold leading-none text-muted-foreground/70">
+                      <div className="rounded-full bg-black/12 px-1.5 py-0.5 text-[9px] font-medium leading-none text-muted-foreground/90">
                         {row.count}
                       </div>
                     </div>


### PR DESCRIPTION
## Summary
- Revert low-contrast text styles introduced in PR #85 for worktree names, branch labels, repo badges, and group headers
- Force repo names to display in lowercase

## Test plan
- [ ] Verify worktree name text is full contrast (not faded)
- [ ] Verify branch name text is readable
- [ ] Verify repo group headers are full contrast and lowercase
- [ ] Verify repo badge text in worktree cards is full contrast and lowercase

🤖 Generated with [Claude Code](https://claude.com/claude-code)