### PR TITLE
feat: support multi-repo sidebar filtering

### DIFF
--- a/src/renderer/src/components/sidebar/AddWorktreeDialog.tsx
+++ b/src/renderer/src/components/sidebar/AddWorktreeDialog.tsx
@@ -38,7 +38,7 @@ const AddWorktreeDialog = React.memo(function AddWorktreeDialog() {
   const setSidebarOpen = useAppStore((s) => s.setSidebarOpen)
   const setSearchQuery = useAppStore((s) => s.setSearchQuery)
   const setShowActiveOnly = useAppStore((s) => s.setShowActiveOnly)
-  const setFilterRepoId = useAppStore((s) => s.setFilterRepoId)
+  const setFilterRepoIds = useAppStore((s) => s.setFilterRepoIds)
   const revealWorktreeInSidebar = useAppStore((s) => s.revealWorktreeInSidebar)
   const worktreesByRepo = useAppStore((s) => s.worktreesByRepo)
   const settings = useAppStore((s) => s.settings)
@@ -130,7 +130,7 @@ const AddWorktreeDialog = React.memo(function AddWorktreeDialog() {
         setSidebarOpen(true)
         setSearchQuery('')
         setShowActiveOnly(false)
-        setFilterRepoId(null)
+        setFilterRepoIds([])
         setActiveWorktree(wt.id)
         revealWorktreeInSidebar(wt.id)
       }
@@ -150,7 +150,7 @@ const AddWorktreeDialog = React.memo(function AddWorktreeDialog() {
     setSidebarOpen,
     setSearchQuery,
     setShowActiveOnly,
-    setFilterRepoId,
+    setFilterRepoIds,
     setActiveWorktree,
     revealWorktreeInSidebar,
     handleOpenChange

--- a/src/renderer/src/components/sidebar/SearchBar.tsx
+++ b/src/renderer/src/components/sidebar/SearchBar.tsx
@@ -4,13 +4,13 @@ import { useAppStore } from '@/store'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import {
-  Select,
-  SelectTrigger,
-  SelectValue,
-  SelectContent,
-  SelectItem,
-  SelectSeparator
-} from '@/components/ui/select'
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 import RepoDotLabel from '@/components/repo/RepoDotLabel'
@@ -20,11 +20,41 @@ const SearchBar = React.memo(function SearchBar() {
   const setSearchQuery = useAppStore((s) => s.setSearchQuery)
   const showActiveOnly = useAppStore((s) => s.showActiveOnly)
   const setShowActiveOnly = useAppStore((s) => s.setShowActiveOnly)
-  const filterRepoId = useAppStore((s) => s.filterRepoId)
-  const setFilterRepoId = useAppStore((s) => s.setFilterRepoId)
+  const filterRepoIds = useAppStore((s) => s.filterRepoIds)
+  const setFilterRepoIds = useAppStore((s) => s.setFilterRepoIds)
   const repos = useAppStore((s) => s.repos)
   const addRepo = useAppStore((s) => s.addRepo)
-  const selectedRepo = repos.find((r) => r.id === filterRepoId)
+  const selectedRepos = repos.filter((r) => filterRepoIds.includes(r.id))
+
+  const handleToggleRepo = useCallback(
+    (repoId: string) => {
+      setFilterRepoIds(
+        filterRepoIds.includes(repoId)
+          ? filterRepoIds.filter((id) => id !== repoId)
+          : [...filterRepoIds, repoId]
+      )
+    },
+    [filterRepoIds, setFilterRepoIds]
+  )
+
+  const repoTriggerLabel =
+    selectedRepos.length === 0 ? (
+      <span className="flex items-center gap-1">
+        <FolderTree className="size-3 text-muted-foreground" />
+        <span>All</span>
+      </span>
+    ) : selectedRepos.length === 1 ? (
+      <RepoDotLabel
+        name={selectedRepos[0].displayName}
+        color={selectedRepos[0].badgeColor}
+        dotClassName="size-1"
+      />
+    ) : (
+      <span className="flex items-center gap-1">
+        <FolderTree className="size-3 text-muted-foreground" />
+        <span>{selectedRepos.length} repos</span>
+      </span>
+    )
 
   const handleClear = useCallback(() => setSearchQuery(''), [setSearchQuery])
   const handleToggleActive = useCallback(
@@ -70,51 +100,49 @@ const SearchBar = React.memo(function SearchBar() {
             </TooltipContent>
           </Tooltip>
           {repos.length > 1 && (
-            <Select
-              value={filterRepoId ?? '__all__'}
-              onValueChange={(v) => {
-                if (v === '__add__') {
-                  addRepo()
-                } else {
-                  setFilterRepoId(v === '__all__' ? null : v)
-                }
-              }}
-            >
-              <SelectTrigger
-                size="sm"
-                className="h-5 w-auto gap-1 border-none bg-transparent px-1 text-[10px] shadow-none focus-visible:ring-0"
-              >
-                <SelectValue>
-                  {selectedRepo ? (
-                    <RepoDotLabel
-                      name={selectedRepo.displayName}
-                      color={selectedRepo.badgeColor}
-                      dotClassName="size-1"
-                    />
-                  ) : (
-                    <span className="flex items-center gap-1">
-                      <FolderTree className="size-3 text-muted-foreground" />
-                      <span>All</span>
-                    </span>
-                  )}
-                </SelectValue>
-              </SelectTrigger>
-              <SelectContent position="popper" align="end">
-                <SelectItem value="__all__">All repos</SelectItem>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  type="button"
+                  aria-label="Filter repositories"
+                  className="h-5 w-auto gap-1 border-none bg-transparent px-1 text-[10px] font-normal shadow-none hover:bg-accent/60 focus-visible:ring-0"
+                >
+                  {repoTriggerLabel}
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem
+                  onSelect={() => {
+                    setFilterRepoIds([])
+                  }}
+                >
+                  All repos
+                </DropdownMenuItem>
                 {repos.map((r) => (
-                  <SelectItem key={r.id} value={r.id}>
+                  <DropdownMenuCheckboxItem
+                    key={r.id}
+                    checked={filterRepoIds.includes(r.id)}
+                    onCheckedChange={() => handleToggleRepo(r.id)}
+                    onSelect={(event) => event.preventDefault()}
+                  >
                     <RepoDotLabel name={r.displayName} color={r.badgeColor} />
-                  </SelectItem>
+                  </DropdownMenuCheckboxItem>
                 ))}
-                <SelectSeparator />
-                <SelectItem value="__add__">
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
+                  onSelect={() => {
+                    addRepo()
+                  }}
+                >
                   <span className="flex items-center gap-1.5 text-muted-foreground">
                     <FolderPlus className="size-3.5" />
                     Add repo
                   </span>
-                </SelectItem>
-              </SelectContent>
-            </Select>
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
           )}
         </div>
       </div>

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -27,7 +27,7 @@ const WorktreeList = React.memo(function WorktreeList() {
   const groupBy = useAppStore((s) => s.groupBy)
   const sortBy = useAppStore((s) => s.sortBy)
   const showActiveOnly = useAppStore((s) => s.showActiveOnly)
-  const filterRepoId = useAppStore((s) => s.filterRepoId)
+  const filterRepoIds = useAppStore((s) => s.filterRepoIds)
   const openModal = useAppStore((s) => s.openModal)
   const pendingRevealWorktreeId = useAppStore((s) => s.pendingRevealWorktreeId)
   const clearPendingRevealWorktreeId = useAppStore((s) => s.clearPendingRevealWorktreeId)
@@ -56,8 +56,9 @@ const WorktreeList = React.memo(function WorktreeList() {
     all = all.filter((w) => !w.isArchived)
 
     // Filter by repo
-    if (filterRepoId) {
-      all = all.filter((w) => w.repoId === filterRepoId)
+    if (filterRepoIds.length > 0) {
+      const selectedRepoIds = new Set(filterRepoIds)
+      all = all.filter((w) => selectedRepoIds.has(w.repoId))
     }
 
     // Filter by search
@@ -98,7 +99,7 @@ const WorktreeList = React.memo(function WorktreeList() {
     })
 
     return all
-  }, [worktreesByRepo, filterRepoId, searchQuery, showActiveOnly, sortBy, repoMap, tabsByWorktree])
+  }, [worktreesByRepo, filterRepoIds, searchQuery, showActiveOnly, sortBy, repoMap, tabsByWorktree])
 
   // Collapsed group state
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set())
@@ -260,16 +261,16 @@ const WorktreeList = React.memo(function WorktreeList() {
     [openModal]
   )
 
-  const hasFilters = !!(searchQuery || showActiveOnly || filterRepoId)
+  const hasFilters = !!(searchQuery || showActiveOnly || filterRepoIds.length)
   const setSearchQuery = useAppStore((s) => s.setSearchQuery)
   const setShowActiveOnly = useAppStore((s) => s.setShowActiveOnly)
-  const setFilterRepoId = useAppStore((s) => s.setFilterRepoId)
+  const setFilterRepoIds = useAppStore((s) => s.setFilterRepoIds)
 
   const clearFilters = useCallback(() => {
     setSearchQuery('')
     setShowActiveOnly(false)
-    setFilterRepoId(null)
-  }, [setSearchQuery, setShowActiveOnly, setFilterRepoId])
+    setFilterRepoIds([])
+  }, [setSearchQuery, setShowActiveOnly, setFilterRepoIds])
 
   if (worktrees.length === 0) {
     return (

--- a/src/renderer/src/store/selectors.ts
+++ b/src/renderer/src/store/selectors.ts
@@ -38,7 +38,7 @@ export const useSearchQuery = () => useAppStore((s) => s.searchQuery)
 export const useGroupBy = () => useAppStore((s) => s.groupBy)
 export const useSortBy = () => useAppStore((s) => s.sortBy)
 export const useShowActiveOnly = () => useAppStore((s) => s.showActiveOnly)
-export const useFilterRepoId = () => useAppStore((s) => s.filterRepoId)
+export const useFilterRepoIds = () => useAppStore((s) => s.filterRepoIds)
 
 // ─── GitHub ─────────────────────────────────────────────────────────
 export const usePRCache = () => useAppStore((s) => s.prCache)

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -22,8 +22,8 @@ export type UISlice = {
   setSortBy: (s: UISlice['sortBy']) => void
   showActiveOnly: boolean
   setShowActiveOnly: (v: boolean) => void
-  filterRepoId: string | null
-  setFilterRepoId: (id: string | null) => void
+  filterRepoIds: string[]
+  setFilterRepoIds: (ids: string[]) => void
   pendingRevealWorktreeId: string | null
   revealWorktreeInSidebar: (worktreeId: string) => void
   clearPendingRevealWorktreeId: () => void
@@ -62,8 +62,8 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set) => (
   showActiveOnly: false,
   setShowActiveOnly: (v) => set({ showActiveOnly: v }),
 
-  filterRepoId: null,
-  setFilterRepoId: (id) => set({ filterRepoId: id }),
+  filterRepoIds: [],
+  setFilterRepoIds: (ids) => set({ filterRepoIds: ids }),
 
   pendingRevealWorktreeId: null,
   revealWorktreeInSidebar: (worktreeId) => set({ pendingRevealWorktreeId: worktreeId }),


### PR DESCRIPTION
## Problem
The sidebar repo filter only allowed a single repository at a time, which made it awkward to narrow the worktree list across a subset of repos. Clearing filters after creating a worktree also depended on the old single-select state shape.

## Solution
Replace the single-select repo filter with a dropdown menu that supports selecting multiple repositories, update the sidebar filtering logic to accept multiple repo IDs, and reset the new filter state in the add-worktree and clear-filters flows.
