### PR TITLE
fix: allow Option+Backspace word-delete in input fields

### DIFF
--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
@@ -140,11 +140,16 @@ export function useTerminalKeyboardShortcuts({
     }
 
     // Ctrl+Backspace → send \x17 (backward-kill-word) to PTY.
+    // Skip when focus is in an input/textarea so native word-delete still works.
     const onCtrlBackspace = (e: KeyboardEvent): void => {
       if (!e.ctrlKey || e.metaKey || e.altKey || e.shiftKey) {
         return
       }
       if (e.key !== 'Backspace') {
+        return
+      }
+      const tag = (e.target as HTMLElement)?.tagName
+      if (tag === 'INPUT' || tag === 'TEXTAREA') {
         return
       }
 
@@ -164,11 +169,16 @@ export function useTerminalKeyboardShortcuts({
     }
 
     // Alt+Backspace → send ESC + DEL (\x1b\x7f, backward-kill-word) to PTY.
+    // Skip when focus is in an input/textarea so native word-delete still works.
     const onAltBackspace = (e: KeyboardEvent): void => {
       if (!e.altKey || e.metaKey || e.ctrlKey || e.shiftKey) {
         return
       }
       if (e.key !== 'Backspace') {
+        return
+      }
+      const tag = (e.target as HTMLElement)?.tagName
+      if (tag === 'INPUT' || tag === 'TEXTAREA') {
         return
       }
 


### PR DESCRIPTION
## Summary
- Terminal keyboard handlers for Alt+Backspace and Ctrl+Backspace were registered globally with `capture: true`, intercepting the events even when focus was in an input or textarea
- This prevented native word-delete (Option+Backspace on macOS) from working in dialogs like Add Worktree
- Now both handlers skip PTY forwarding when the event target is an `INPUT` or `TEXTAREA`

## Test plan
- [ ] Open Add Worktree dialog, type a branch name, use Option+Backspace to delete a word — should work
- [ ] Verify Option+Backspace still works in terminal panes (backward-kill-word)
- [ ] Check other text inputs (worktree meta dialog, search, settings) also support Option+Backspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)