### PR TITLE
fix: stop sending cursor style escape sequences to PTY

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-appearance.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-appearance.ts
@@ -2,26 +2,19 @@ import type { ITheme } from '@xterm/xterm'
 import type { PaneManager } from '@/lib/pane-manager/pane-manager'
 import type { GlobalSettings } from '../../../../shared/types'
 import {
-  getCursorStyleSequence,
   getBuiltinTheme,
   resolvePaneStyleOptions,
   resolveEffectiveTerminalAppearance
 } from '@/lib/terminal-theme'
-import type { PtyTransport } from './pty-transport'
 
 export function applyTerminalAppearance(
   manager: PaneManager,
   settings: GlobalSettings,
   systemPrefersDark: boolean,
-  paneFontSizes: Map<number, number>,
-  paneTransports: Map<number, PtyTransport>
+  paneFontSizes: Map<number, number>
 ): void {
   const appearance = resolveEffectiveTerminalAppearance(settings, systemPrefersDark)
   const paneStyles = resolvePaneStyleOptions(settings)
-  const cursorSequence = getCursorStyleSequence(
-    settings.terminalCursorStyle,
-    settings.terminalCursorBlink
-  )
   const theme: ITheme | null = appearance.theme ?? getBuiltinTheme(appearance.themeName)
   const paneBackground = theme?.background ?? '#000000'
 
@@ -38,8 +31,6 @@ export function applyTerminalAppearance(
     } catch {
       /* ignore */
     }
-    const transport = paneTransports.get(pane.id)
-    transport?.sendInput(cursorSequence)
   }
 
   manager.setPaneStyleOptions({

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -82,8 +82,7 @@ export function useTerminalPaneLifecycle({
       manager,
       currentSettings,
       systemPrefersDarkRef.current,
-      paneFontSizesRef.current,
-      paneTransportsRef.current
+      paneFontSizesRef.current
     )
   }
 


### PR DESCRIPTION
## Summary
- Removed `sendInput(cursorSequence)` call that was sending DECSCUSR escape sequences (e.g. `\e[5 q`) to the shell process as literal input
- The shell doesn't interpret these sequences, causing `[5 q` to appear as random text in the terminal
- Cursor style was already correctly applied via `xterm.js` terminal options (`cursorStyle`, `cursorBlink`)

## Test plan
- [ ] Open a terminal in Orca and verify `[5 q` no longer appears
- [ ] Change cursor style in settings and verify the cursor updates visually
- [ ] Toggle dark/light mode and verify no escape sequence text appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)