### PR TITLE
fix: refresh GitHub status on active worktree reselect

### DIFF
--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -196,7 +196,6 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
 
   setActiveWorktree: (worktreeId) => {
     let shouldClearUnread = false
-    const prevActiveId = get().activeWorktreeId
     const now = Date.now()
     set((s) => {
       if (!worktreeId) {
@@ -255,8 +254,9 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       }
     }
 
-    // Refresh GitHub data (PR + issue status) when switching to a different worktree
-    if (worktreeId && worktreeId !== prevActiveId) {
+    // Refresh GitHub data (PR + issue status) on every explicit worktree selection.
+    // Re-selecting the active worktree is a user-driven refresh path for stale PR state.
+    if (worktreeId) {
       get().refreshGitHubForWorktree(worktreeId)
     }
 


### PR DESCRIPTION
## Problem
PR and issue status for the active worktree could go stale because clicking an already-selected worktree did not trigger a GitHub refresh.

## Solution
Always call `refreshGitHubForWorktree` on explicit worktree selection so reselecting the active worktree acts as a manual refresh path for stale GitHub state.