### PR TITLE
fix: persist repo sidebar filters

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -34,6 +34,7 @@ function App(): React.JSX.Element {
   const sidebarWidth = useAppStore((s) => s.sidebarWidth)
   const groupBy = useAppStore((s) => s.groupBy)
   const sortBy = useAppStore((s) => s.sortBy)
+  const filterRepoIds = useAppStore((s) => s.filterRepoIds)
   const persistedUIReady = useAppStore((s) => s.persistedUIReady)
 
   // Right sidebar + editor state
@@ -73,6 +74,7 @@ function App(): React.JSX.Element {
             rightSidebarWidth: 350,
             groupBy: 'none',
             sortBy: 'name',
+            filterRepoIds: [],
             uiZoomLevel: 0
           })
           hydrateWorkspaceSession({
@@ -135,12 +137,13 @@ function App(): React.JSX.Element {
         sidebarWidth,
         rightSidebarWidth,
         groupBy,
-        sortBy
+        sortBy,
+        filterRepoIds
       })
     }, 150)
 
     return () => window.clearTimeout(timer)
-  }, [persistedUIReady, sidebarWidth, rightSidebarWidth, groupBy, sortBy])
+  }, [persistedUIReady, sidebarWidth, rightSidebarWidth, groupBy, sortBy, filterRepoIds])
 
   // Apply theme to document
   useEffect(() => {

--- a/src/renderer/src/components/sidebar/AddWorktreeDialog.tsx
+++ b/src/renderer/src/components/sidebar/AddWorktreeDialog.tsx
@@ -36,8 +36,11 @@ const AddWorktreeDialog = React.memo(function AddWorktreeDialog() {
   const setActiveWorktree = useAppStore((s) => s.setActiveWorktree)
   const setActiveView = useAppStore((s) => s.setActiveView)
   const setSidebarOpen = useAppStore((s) => s.setSidebarOpen)
+  const searchQuery = useAppStore((s) => s.searchQuery)
   const setSearchQuery = useAppStore((s) => s.setSearchQuery)
+  const showActiveOnly = useAppStore((s) => s.showActiveOnly)
   const setShowActiveOnly = useAppStore((s) => s.setShowActiveOnly)
+  const filterRepoIds = useAppStore((s) => s.filterRepoIds)
   const setFilterRepoIds = useAppStore((s) => s.setFilterRepoIds)
   const revealWorktreeInSidebar = useAppStore((s) => s.revealWorktreeInSidebar)
   const worktreesByRepo = useAppStore((s) => s.worktreesByRepo)
@@ -128,9 +131,15 @@ const AddWorktreeDialog = React.memo(function AddWorktreeDialog() {
         setActiveRepo(repoId)
         setActiveView('terminal')
         setSidebarOpen(true)
-        setSearchQuery('')
-        setShowActiveOnly(false)
-        setFilterRepoIds([])
+        if (searchQuery) {
+          setSearchQuery('')
+        }
+        if (showActiveOnly) {
+          setShowActiveOnly(false)
+        }
+        if (filterRepoIds.length > 0 && !filterRepoIds.includes(repoId)) {
+          setFilterRepoIds([])
+        }
         setActiveWorktree(wt.id)
         revealWorktreeInSidebar(wt.id)
       }
@@ -148,8 +157,11 @@ const AddWorktreeDialog = React.memo(function AddWorktreeDialog() {
     setActiveRepo,
     setActiveView,
     setSidebarOpen,
+    searchQuery,
     setSearchQuery,
+    showActiveOnly,
     setShowActiveOnly,
+    filterRepoIds,
     setFilterRepoIds,
     setActiveWorktree,
     revealWorktreeInSidebar,

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -23,7 +23,14 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
   fetchRepos: async () => {
     try {
       const repos = await window.api.repos.list()
-      set({ repos })
+      set((s) => {
+        const validRepoIds = new Set(repos.map((repo) => repo.id))
+        return {
+          repos,
+          activeRepoId: s.activeRepoId && validRepoIds.has(s.activeRepoId) ? s.activeRepoId : null,
+          filterRepoIds: s.filterRepoIds.filter((repoId) => validRepoIds.has(repoId))
+        }
+      })
     } catch (err) {
       console.error('Failed to fetch repos:', err)
     }
@@ -94,6 +101,7 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
         return {
           repos: s.repos.filter((r) => r.id !== repoId),
           activeRepoId: s.activeRepoId === repoId ? null : s.activeRepoId,
+          filterRepoIds: s.filterRepoIds.filter((id) => id !== repoId),
           worktreesByRepo: nextWorktrees,
           tabsByWorktree: nextTabs,
           ptyIdsByTabId: nextPtyIdsByTabId,

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -71,12 +71,16 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set) => (
   persistedUIReady: false,
 
   hydratePersistedUI: (ui) =>
-    set({
-      sidebarWidth: ui.sidebarWidth,
-      rightSidebarWidth: ui.rightSidebarWidth ?? 280,
-      groupBy: ui.groupBy,
-      sortBy: ui.sortBy,
-      persistedUIReady: true
+    set((s) => {
+      const validRepoIds = new Set(s.repos.map((repo) => repo.id))
+      return {
+        sidebarWidth: ui.sidebarWidth,
+        rightSidebarWidth: ui.rightSidebarWidth ?? 280,
+        groupBy: ui.groupBy,
+        sortBy: ui.sortBy,
+        filterRepoIds: (ui.filterRepoIds ?? []).filter((repoId) => validRepoIds.has(repoId)),
+        persistedUIReady: true
+      }
     }),
 
   updateStatus: { state: 'idle' },

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -73,6 +73,7 @@ export function getDefaultUIState(): PersistedUIState {
     rightSidebarWidth: 350,
     groupBy: 'none',
     sortBy: 'name',
+    filterRepoIds: [],
     uiZoomLevel: 0
   }
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -164,6 +164,7 @@ export type PersistedUIState = {
   rightSidebarWidth: number
   groupBy: 'none' | 'repo' | 'pr-status'
   sortBy: 'name' | 'recent' | 'repo'
+  filterRepoIds: string[]
   uiZoomLevel: number
 }
 


### PR DESCRIPTION
## Summary
- persist `filterRepoIds` in the UI state so repo filters survive reloads
- clear stale repo filters when repos are removed and when persisted UI is hydrated
- avoid unnecessary sidebar filter resets when creating a worktree in an already-visible repo

## Validation
- `npm run typecheck`
- `npm run build`

## Notes
- `npm run lint` still fails on unrelated baseline issues in `src/renderer/src/store/slices/editor.ts` and `src/renderer/src/components/editor/MonacoEditor.tsx`.