### PR TITLE
fix: sync pty size after terminal appearance changes

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-appearance.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-appearance.ts
@@ -6,12 +6,15 @@ import {
   resolvePaneStyleOptions,
   resolveEffectiveTerminalAppearance
 } from '@/lib/terminal-theme'
+import { buildFontFamily } from './layout-serialization'
+import type { PtyTransport } from './pty-transport'
 
 export function applyTerminalAppearance(
   manager: PaneManager,
   settings: GlobalSettings,
   systemPrefersDark: boolean,
-  paneFontSizes: Map<number, number>
+  paneFontSizes: Map<number, number>,
+  paneTransports: Map<number, PtyTransport>
 ): void {
   const appearance = resolveEffectiveTerminalAppearance(settings, systemPrefersDark)
   const paneStyles = resolvePaneStyleOptions(settings)
@@ -26,10 +29,15 @@ export function applyTerminalAppearance(
     pane.terminal.options.cursorBlink = settings.terminalCursorBlink
     const paneSize = paneFontSizes.get(pane.id)
     pane.terminal.options.fontSize = paneSize ?? settings.terminalFontSize
+    pane.terminal.options.fontFamily = buildFontFamily(settings.terminalFontFamily)
     try {
       pane.fitAddon.fit()
     } catch {
       /* ignore */
+    }
+    const transport = paneTransports.get(pane.id)
+    if (transport?.isConnected()) {
+      transport.resize(pane.terminal.cols, pane.terminal.rows)
     }
   }
 

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -82,7 +82,8 @@ export function useTerminalPaneLifecycle({
       manager,
       currentSettings,
       systemPrefersDarkRef.current,
-      paneFontSizesRef.current
+      paneFontSizesRef.current,
+      paneTransportsRef.current
     )
   }
 
@@ -275,15 +276,6 @@ export function useTerminalPaneLifecycle({
       return
     }
     applyAppearance(manager)
-    const fontFamily = buildFontFamily(settings.terminalFontFamily)
-    for (const pane of manager.getPanes()) {
-      pane.terminal.options.fontFamily = fontFamily
-      try {
-        pane.fitAddon.fit()
-      } catch {
-        /* ignore */
-      }
-    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [settings, systemPrefersDark])
 }


### PR DESCRIPTION
## Summary
- pass the pane transport map into terminal appearance updates
- apply font family changes inside the shared appearance path before fit and PTY resize
- resize connected PTYs after appearance changes so backend dimensions stay in sync

## Verification
- npm run typecheck