### PR TITLE
fix: exclude xterm helper textarea from editable target check

### DIFF
--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
@@ -7,6 +7,13 @@ function isEditableTarget(target: EventTarget | null): boolean {
     return false
   }
 
+  // xterm.js focuses a hidden <textarea class="xterm-helper-textarea"> for
+  // keyboard input.  That element IS an editable target, but we must NOT
+  // suppress terminal shortcuts when the terminal itself is focused.
+  if (target.classList.contains('xterm-helper-textarea')) {
+    return false
+  }
+
   if (target.isContentEditable) {
     return true
   }


### PR DESCRIPTION
## Summary
- PR #103 added a blanket `isEditableTarget()` guard at the top of the main `onKeyDown` handler to prevent terminal shortcuts from intercepting keystrokes in UI inputs
- However, xterm.js uses a hidden `<textarea class="xterm-helper-textarea">` for keyboard input — so when the terminal itself is focused, `isEditableTarget` returned `true` and **all** terminal shortcuts were suppressed
- This broke Cmd+D (split pane), Shift+Enter (newline), Cmd+K (clear), Cmd+F (search), Cmd+W (close pane), etc.
- Fix: early-return `false` from `isEditableTarget` when the target has class `xterm-helper-textarea`

## Test plan
- [ ] Cmd+D splits pane when terminal is focused
- [ ] Shift+Enter inserts newline in terminal
- [ ] Cmd+F opens terminal search
- [ ] Cmd+K clears terminal
- [ ] Typing in terminal search input still works normally (shortcuts don't intercept)
- [ ] Typing in worktree dialog textarea still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)