### PR TITLE
fix: make release publish atomic to prevent update 404s

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Create release with auto-generated notes
-        run: gh release create ${{ github.ref_name }} --generate-notes --prerelease=${{ contains(github.ref_name, 'rc') }}
+      - name: Create draft release with auto-generated notes
+        run: gh release create ${{ github.ref_name }} --draft --generate-notes --prerelease=${{ contains(github.ref_name, 'rc') }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -75,5 +75,16 @@ jobs:
       - name: Build and release (Linux)
         if: matrix.platform == 'linux'
         run: pnpm build:linux --publish always
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-release:
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Publish release
+        run: gh release edit ${{ github.ref_name }} --draft=false --repo ${{ github.repository }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Creates the GitHub release as a **draft** so it's invisible to the auto-updater while builds are running
- Adds a `publish-release` job that undrafts the release only after all platform builds (mac, win, linux) succeed
- Prevents the 404 errors users hit when the auto-updater checks a partially-published release (e.g. `latest-mac.yml` missing while macOS build is still running)

## Test plan
- [ ] Tag a release and verify the GitHub release is created as a draft
- [ ] Verify all three platform builds upload artifacts to the draft release
- [ ] Verify the release is undrafted after all builds complete
- [ ] Verify auto-updater finds the release only after it's published

🤖 Generated with [Claude Code](https://claude.com/claude-code)