### PR TITLE
feat: UI improvements — Geist font, softer borders, and polish

### DIFF
--- a/src/renderer/src/components/right-sidebar/FileExplorer.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorer.tsx
@@ -187,7 +187,7 @@ export default function FileExplorer(): React.JSX.Element {
   }
 
   return (
-    <div ref={scrollRef} className="flex-1 overflow-auto scrollbar-sleek">
+    <div ref={scrollRef} className="flex-1 overflow-auto scrollbar-sleek py-2">
       <div className="relative w-full" style={{ height: `${virtualizer.getTotalSize()}px` }}>
         {virtualizer.getVirtualItems().map((vItem) => {
           const node = flatRows[vItem.index]

--- a/src/renderer/src/components/settings/AppearancePane.tsx
+++ b/src/renderer/src/components/settings/AppearancePane.tsx
@@ -21,7 +21,7 @@ export function AppearancePane({
           <p className="text-xs text-muted-foreground">Choose how Orca looks in the app window.</p>
         </div>
 
-        <div className="flex w-fit gap-1 rounded-md border p-1">
+        <div className="flex w-fit gap-1 rounded-md border border-border/50 p-1">
           {(['system', 'dark', 'light'] as const).map((option) => (
             <button
               key={option}

--- a/src/renderer/src/components/settings/GeneralPane.tsx
+++ b/src/renderer/src/components/settings/GeneralPane.tsx
@@ -43,7 +43,7 @@ export function GeneralPane({
         </div>
 
         <div className="space-y-2">
-          <Label className="text-sm">Workspace Directory</Label>
+          <Label>Workspace Directory</Label>
           <div className="flex gap-2">
             <Input
               value={settings.workspaceDir}
@@ -67,7 +67,7 @@ export function GeneralPane({
 
         <div className="flex items-center justify-between gap-4 px-1 py-2">
           <div className="space-y-0.5">
-            <Label className="text-sm">Nest Workspaces</Label>
+            <Label>Nest Workspaces</Label>
             <p className="text-xs text-muted-foreground">
               Create worktrees inside a repo-named subfolder.
             </p>
@@ -103,7 +103,7 @@ export function GeneralPane({
           </p>
         </div>
 
-        <div className="flex w-fit gap-1 rounded-md border p-1">
+        <div className="flex w-fit gap-1 rounded-md border border-border/50 p-1">
           {(['git-username', 'custom', 'none'] as const).map((option) => (
             <button
               key={option}

--- a/src/renderer/src/components/settings/HookEditor.tsx
+++ b/src/renderer/src/components/settings/HookEditor.tsx
@@ -19,7 +19,7 @@ export function HookEditor({
     repo.hookSettings?.mode === 'auto' && yamlScript ? 'yaml' : uiScript.trim() ? 'ui' : 'none'
 
   return (
-    <div className="space-y-3 rounded-2xl border bg-background/80 p-4 shadow-sm">
+    <div className="space-y-3 rounded-2xl border border-border/50 bg-background/80 p-4 shadow-sm">
       <div className="flex flex-wrap items-center justify-between gap-2">
         <div>
           <h5 className="text-sm font-semibold capitalize">{hookName}</h5>
@@ -36,7 +36,7 @@ export function HookEditor({
               ? 'border border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300'
               : effectiveSource === 'ui'
                 ? 'border border-sky-500/30 bg-sky-500/10 text-sky-700 dark:text-sky-300'
-                : 'border bg-muted text-muted-foreground'
+                : 'border border-border/50 bg-muted text-muted-foreground'
           }`}
         >
           {effectiveSource === 'yaml'
@@ -81,7 +81,7 @@ export function HookEditor({
               : 'echo "Cleaning up before archive"'
           }
           spellCheck={false}
-          className="min-h-[12rem] w-full resize-y rounded-xl border bg-background px-3 py-3 font-mono text-[12px] leading-5 outline-none transition-colors placeholder:text-muted-foreground/70 focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/30"
+          className="min-h-[12rem] w-full resize-y rounded-xl border border-border/50 bg-background px-3 py-3 font-mono text-[12px] leading-5 outline-none transition-colors placeholder:text-muted-foreground/70 focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/30"
         />
       </div>
     </div>

--- a/src/renderer/src/components/settings/RepositoryPane.tsx
+++ b/src/renderer/src/components/settings/RepositoryPane.tsx
@@ -155,7 +155,7 @@ export function RepositoryPane({
         </div>
 
         <div className="space-y-2">
-          <Label className="text-sm">Display Name</Label>
+          <Label>Display Name</Label>
           <Input
             value={repo.displayName}
             onChange={(e) =>
@@ -168,7 +168,7 @@ export function RepositoryPane({
         </div>
 
         <div className="space-y-2">
-          <Label className="text-sm">Badge Color</Label>
+          <Label>Badge Color</Label>
           <div className="flex flex-wrap gap-2">
             {REPO_COLORS.map((color) => (
               <button
@@ -187,7 +187,7 @@ export function RepositoryPane({
         </div>
 
         <div className="space-y-3">
-          <Label className="text-sm">Default Worktree Base</Label>
+          <Label>Default Worktree Base</Label>
           <div className="flex flex-wrap items-center justify-between gap-2">
             <div>
               <div className="text-sm font-medium text-foreground">{effectiveBaseRef}</div>
@@ -229,7 +229,7 @@ export function RepositoryPane({
 
           {!isSearchingBaseRefs && baseRefQuery.trim().length >= 2 ? (
             baseRefResults.length > 0 ? (
-              <ScrollArea className="h-48 rounded-md border">
+              <ScrollArea className="h-48 rounded-md border border-border/50">
                 <div className="p-1">
                   {baseRefResults.map((ref) => (
                     <button
@@ -273,7 +273,7 @@ export function RepositoryPane({
           </p>
         </div>
 
-        <div className="flex w-fit gap-1 rounded-xl border p-1">
+        <div className="flex w-fit gap-1 rounded-xl border border-border/50 p-1">
           {(['auto', 'override'] as const).map((mode) => (
             <button
               key={mode}

--- a/src/renderer/src/components/settings/SettingsFormControls.tsx
+++ b/src/renderer/src/components/settings/SettingsFormControls.tsx
@@ -57,7 +57,7 @@ export function ThemePicker({
   return (
     <div className="space-y-3">
       <div className="space-y-1">
-        <Label className="text-sm">{label}</Label>
+        <Label>{label}</Label>
         <p className="text-xs text-muted-foreground">{description}</p>
       </div>
       <Input
@@ -65,8 +65,8 @@ export function ThemePicker({
         onChange={(e) => onQueryChange(e.target.value)}
         placeholder="Search builtin themes"
       />
-      <div className="rounded-lg border">
-        <div className="flex items-center justify-between border-b px-3 py-2 text-xs text-muted-foreground">
+      <div className="rounded-lg border border-border/50">
+        <div className="flex items-center justify-between border-b border-border/50 px-3 py-2 text-xs text-muted-foreground">
           <span>Selected: {selectedTheme}</span>
           <span>
             Showing {filteredThemes.length}
@@ -117,7 +117,7 @@ export function ColorField({
   return (
     <div className="space-y-2">
       <div className="space-y-1">
-        <Label className="text-sm">{label}</Label>
+        <Label>{label}</Label>
         <p className="text-xs text-muted-foreground">{description}</p>
       </div>
       <div className="flex items-center gap-3">
@@ -179,7 +179,7 @@ export function NumberField({
   return (
     <div className="space-y-2">
       <div className="space-y-1">
-        <Label className="text-sm">{label}</Label>
+        <Label>{label}</Label>
         <p className="text-xs text-muted-foreground">{description}</p>
       </div>
       <div className="flex items-center gap-3">
@@ -300,7 +300,7 @@ export function FontAutocomplete({
       </div>
 
       {open ? (
-        <div className="absolute top-full z-20 mt-2 w-full overflow-hidden rounded-md border bg-popover shadow-md">
+        <div className="absolute top-full z-20 mt-2 w-full overflow-hidden rounded-md border border-border/50 bg-popover shadow-md">
           <ScrollArea className="max-h-64">
             <div className="p-1">
               {filteredSuggestions.length > 0 ? (

--- a/src/renderer/src/components/settings/TerminalPane.tsx
+++ b/src/renderer/src/components/settings/TerminalPane.tsx
@@ -62,7 +62,7 @@ export function TerminalPane({
         </div>
 
         <div className="space-y-2">
-          <Label className="text-sm">Font Size</Label>
+          <Label>Font Size</Label>
           <div className="flex items-center gap-2">
             <Button
               variant="outline"
@@ -104,7 +104,7 @@ export function TerminalPane({
         </div>
 
         <div className="space-y-2">
-          <Label className="text-sm">Font Family</Label>
+          <Label>Font Family</Label>
           <FontAutocomplete
             value={settings.terminalFontFamily}
             suggestions={terminalFontSuggestions}
@@ -125,8 +125,8 @@ export function TerminalPane({
 
         <div className="space-y-4">
           <div className="space-y-2">
-            <Label className="text-sm">Cursor Shape</Label>
-            <div className="flex w-fit gap-1 rounded-md border p-1">
+            <Label>Cursor Shape</Label>
+            <div className="flex w-fit gap-1 rounded-md border border-border/50 p-1">
               {(['bar', 'block', 'underline'] as const).map((option) => (
                 <button
                   key={option}
@@ -145,7 +145,7 @@ export function TerminalPane({
 
           <div className="flex items-center justify-between gap-4 px-1 py-2">
             <div className="space-y-0.5">
-              <Label className="text-sm">Blinking Cursor</Label>
+              <Label>Blinking Cursor</Label>
               <p className="text-xs text-muted-foreground">
                 Uses the blinking variant of the selected cursor shape.
               </p>
@@ -257,7 +257,7 @@ export function TerminalPane({
       <section className="space-y-4">
         <div className="flex items-center justify-between gap-4 px-1 py-2">
           <div className="space-y-0.5">
-            <Label className="text-sm">Use Separate Theme In Light Mode</Label>
+            <Label>Use Separate Theme In Light Mode</Label>
             <p className="text-xs text-muted-foreground">
               When disabled, light mode reuses the dark terminal theme.
             </p>
@@ -334,7 +334,7 @@ export function TerminalPane({
         </div>
 
         <div className="space-y-3">
-          <Label className="text-sm">Scrollback Size</Label>
+          <Label>Scrollback Size</Label>
           <ToggleGroup
             type="single"
             value={scrollbackToggleValue}

--- a/src/renderer/src/components/settings/TerminalThemePreview.tsx
+++ b/src/renderer/src/components/settings/TerminalThemePreview.tsx
@@ -30,12 +30,12 @@ export function TerminalThemePreview({
 
   return (
     <Card className="gap-4 overflow-hidden py-0">
-      <CardHeader className="gap-1 border-b py-4">
+      <CardHeader className="gap-1 border-b border-border/50 py-4">
         <CardTitle className="text-sm">{title}</CardTitle>
         <CardDescription>{description}</CardDescription>
       </CardHeader>
       <CardContent className="space-y-4 px-4 pb-4">
-        <div className="flex items-center justify-between rounded-md border bg-muted/40 px-3 py-2 text-xs">
+        <div className="flex items-center justify-between rounded-md border border-border/50 bg-muted/40 px-3 py-2 text-xs">
           <div className="min-w-0">
             <p className="font-medium text-foreground">{appearance.themeName}</p>
             <p className="text-muted-foreground">
@@ -47,14 +47,14 @@ export function TerminalThemePreview({
           <div className="flex items-center gap-2">
             <span className="text-muted-foreground">Divider</span>
             <span
-              className="size-4 rounded-sm border"
+              className="size-4 rounded-sm border border-border/50"
               style={{ backgroundColor: appearance.dividerColor }}
             />
           </div>
         </div>
 
         <div
-          className="overflow-hidden rounded-lg border"
+          className="overflow-hidden rounded-lg border border-border/50"
           style={{ backgroundColor: appearance.dividerColor }}
         >
           <div className="flex min-h-[220px]">

--- a/src/renderer/src/components/sidebar/SearchBar.tsx
+++ b/src/renderer/src/components/sidebar/SearchBar.tsx
@@ -63,14 +63,14 @@ const SearchBar = React.memo(function SearchBar() {
   )
 
   return (
-    <div className="px-2 pb-1">
+    <div className="px-2 pb-4">
       <div className="relative flex items-center">
         <Search className="absolute left-2 size-3.5 text-muted-foreground pointer-events-none" />
         <Input
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
           placeholder="Search..."
-          className="h-7 pl-7 pr-20 text-xs border-none bg-muted/50 shadow-none focus-visible:ring-1 focus-visible:ring-ring/30"
+          className="h-7 pl-7 pr-20 text-[11px] border-none bg-muted/50 shadow-none focus-visible:ring-1 focus-visible:ring-ring/30"
         />
         <div className="absolute right-1 flex items-center gap-0.5">
           {searchQuery && (
@@ -132,14 +132,13 @@ const SearchBar = React.memo(function SearchBar() {
                 ))}
                 <DropdownMenuSeparator />
                 <DropdownMenuItem
+                  inset
                   onSelect={() => {
                     addRepo()
                   }}
                 >
-                  <span className="flex items-center gap-1.5 text-muted-foreground">
-                    <FolderPlus className="size-3.5" />
-                    Add repo
-                  </span>
+                  <FolderPlus className="absolute left-2.5 size-3.5 text-muted-foreground" />
+                  Add repo
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -266,9 +266,9 @@ const WorktreeCard = React.memo(function WorktreeCard({
                 </Tooltip>
               )}
               {pr && (
-                <div
+                <span
                   className={cn(
-                    'text-[9px] font-semibold uppercase tracking-wider',
+                    'text-[9px] font-bold uppercase tracking-wider h-3.5 flex items-center',
                     pr.state === 'merged' && 'text-purple-500/80',
                     pr.state === 'open' && 'text-emerald-500/80',
                     pr.state === 'closed' && 'text-muted-foreground/60',
@@ -276,7 +276,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
                   )}
                 >
                   {prStateLabel(pr.state)}
-                </div>
+                </span>
               )}
             </div>
           </div>
@@ -363,7 +363,18 @@ const WorktreeCard = React.memo(function WorktreeCard({
                 <HoverCard openDelay={300}>
                   <HoverCardTrigger asChild>
                     <div className="flex items-center gap-1.5 min-w-0 cursor-default group/meta -mx-1.5 px-1.5 py-0.5 rounded transition-colors hover:bg-background/40">
-                      <PullRequestIcon className="size-3 shrink-0 text-muted-foreground opacity-60" />
+                      <PullRequestIcon
+                        className={cn(
+                          'size-3 shrink-0',
+                          pr.state === 'merged' && 'text-purple-500/80',
+                          pr.state === 'open' && 'text-emerald-500/80',
+                          pr.state === 'closed' && 'text-muted-foreground/60',
+                          pr.state === 'draft' && 'text-muted-foreground/50',
+                          (!pr.state ||
+                            !['merged', 'open', 'closed', 'draft'].includes(pr.state)) &&
+                            'text-muted-foreground opacity-60'
+                        )}
+                      />
                       <div className="flex-1 min-w-0 flex items-center gap-1.5 text-[11.5px] leading-none">
                         <a
                           href={pr.url}

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -306,17 +306,15 @@ const WorktreeList = React.memo(function WorktreeList() {
               >
                 <button
                   className={cn(
-                    'group mb-1 mt-2 flex h-7 w-full items-center gap-1.5 rounded-lg border border-transparent px-2 text-left transition-all',
-                    row.repo
-                      ? 'overflow-hidden hover:bg-accent/50'
-                      : cn(row.tone, 'hover:brightness-110')
+                    'group mb-1 mt-2 flex h-7 w-full items-center gap-1.5 px-1.5 text-left transition-all',
+                    row.repo ? 'overflow-hidden' : row.tone
                   )}
                   onClick={() => toggleGroup(row.key)}
                 >
                   <div
                     className={cn(
                       'flex size-4 shrink-0 items-center justify-center rounded-[4px]',
-                      row.repo ? 'text-foreground' : 'bg-black/5 dark:bg-white/10'
+                      row.repo ? 'text-foreground' : ''
                     )}
                     style={row.repo ? { color: row.repo.badgeColor } : undefined}
                   >

--- a/src/renderer/src/components/sidebar/worktree-list-groups.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.ts
@@ -34,27 +34,27 @@ export const PR_GROUP_META: Record<
   done: {
     label: 'Done',
     icon: CircleCheckBig,
-    tone: 'border-emerald-500/20 bg-emerald-500/10 text-emerald-700 dark:text-emerald-200'
+    tone: 'text-emerald-700 dark:text-emerald-200'
   },
   'in-review': {
     label: 'In review',
     icon: GitPullRequest,
-    tone: 'border-sky-500/20 bg-sky-500/10 text-sky-700 dark:text-sky-200'
+    tone: 'text-sky-700 dark:text-sky-200'
   },
   'in-progress': {
     label: 'In progress',
     icon: CircleDot,
-    tone: 'border-amber-500/20 bg-amber-500/10 text-amber-700 dark:text-amber-200'
+    tone: 'text-amber-700 dark:text-amber-200'
   },
   closed: {
     label: 'Closed',
     icon: CircleX,
-    tone: 'border-zinc-500/20 bg-zinc-500/10 text-zinc-600 dark:text-zinc-300'
+    tone: 'text-zinc-600 dark:text-zinc-300'
   }
 }
 
 export const REPO_GROUP_META = {
-  tone: 'border-border/70 bg-background/70 text-foreground',
+  tone: 'text-foreground',
   icon: FolderGit2
 } as const
 

--- a/src/renderer/src/components/ui/card.tsx
+++ b/src/renderer/src/components/ui/card.tsx
@@ -7,7 +7,7 @@ function Card({ className, ...props }: React.ComponentProps<'div'>) {
     <div
       data-slot="card"
       className={cn(
-        'flex flex-col gap-6 rounded-xl border bg-card py-6 text-card-foreground shadow-sm',
+        'flex flex-col gap-6 rounded-xl border border-border/50 bg-card py-6 text-card-foreground shadow-sm',
         className
       )}
       {...props}

--- a/src/renderer/src/components/ui/dialog.tsx
+++ b/src/renderer/src/components/ui/dialog.tsx
@@ -53,7 +53,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          'fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg',
+          'fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border border-border/50 bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg',
           className
         )}
         {...props}

--- a/src/renderer/src/components/ui/dropdown-menu.tsx
+++ b/src/renderer/src/components/ui/dropdown-menu.tsx
@@ -59,7 +59,7 @@ function DropdownMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "relative flex cursor-default items-center gap-2 rounded-[7px] px-2 py-0.5 text-[12px] leading-5 font-medium outline-hidden select-none focus:bg-black/8 dark:focus:bg-white/14 focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5 [&_svg:not([class*='text-'])]:text-muted-foreground data-[variant=destructive]:*:[svg]:text-destructive!",
+        "relative flex cursor-default items-center gap-2 rounded-[7px] px-2 py-0.5 text-[12px] leading-5 font-medium outline-hidden select-none focus:bg-black/8 dark:focus:bg-white/14 focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-7 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5 [&_svg:not([class*='text-'])]:text-muted-foreground data-[variant=destructive]:*:[svg]:text-destructive!",
         className
       )}
       {...props}
@@ -77,7 +77,7 @@ function DropdownMenuCheckboxItem({
     <DropdownMenuPrimitive.CheckboxItem
       data-slot="dropdown-menu-checkbox-item"
       className={cn(
-        "relative flex cursor-default items-center gap-2 rounded-[7px] py-1 pr-2 pl-8 text-[12px] leading-5 font-medium outline-hidden select-none focus:bg-black/8 dark:focus:bg-white/14 focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5",
+        "relative flex cursor-default items-center gap-2 rounded-[7px] py-1 pr-2 pl-7 text-[12px] leading-5 font-medium outline-hidden select-none focus:bg-black/8 dark:focus:bg-white/14 focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5",
         className
       )}
       checked={checked}
@@ -108,7 +108,7 @@ function DropdownMenuRadioItem({
     <DropdownMenuPrimitive.RadioItem
       data-slot="dropdown-menu-radio-item"
       className={cn(
-        "relative flex cursor-default items-center gap-2 rounded-[7px] py-1 pr-2 pl-8 text-[12px] leading-5 font-medium outline-hidden select-none focus:bg-black/8 dark:focus:bg-white/14 focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5",
+        "relative flex cursor-default items-center gap-2 rounded-[7px] py-1 pr-2 pl-7 text-[12px] leading-5 font-medium outline-hidden select-none focus:bg-black/8 dark:focus:bg-white/14 focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5",
         className
       )}
       {...props}
@@ -135,7 +135,7 @@ function DropdownMenuLabel({
       data-slot="dropdown-menu-label"
       data-inset={inset}
       className={cn(
-        'px-2 py-1 text-[11px] font-semibold text-muted-foreground data-[inset]:pl-8',
+        'px-2 py-1 text-[11px] font-semibold text-muted-foreground data-[inset]:pl-7',
         className
       )}
       {...props}
@@ -183,7 +183,7 @@ function DropdownMenuSubTrigger({
       data-slot="dropdown-menu-sub-trigger"
       data-inset={inset}
       className={cn(
-        "flex cursor-default items-center gap-2 rounded-[7px] px-2 py-0.5 text-[12px] leading-5 font-medium outline-hidden select-none focus:bg-black/8 dark:focus:bg-white/14 focus:text-accent-foreground data-[inset]:pl-8 data-[state=open]:bg-black/8 dark:data-[state=open]:bg-white/14 data-[state=open]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5 [&_svg:not([class*='text-'])]:text-muted-foreground",
+        "flex cursor-default items-center gap-2 rounded-[7px] px-2 py-0.5 text-[12px] leading-5 font-medium outline-hidden select-none focus:bg-black/8 dark:focus:bg-white/14 focus:text-accent-foreground data-[inset]:pl-7 data-[state=open]:bg-black/8 dark:data-[state=open]:bg-white/14 data-[state=open]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5 [&_svg:not([class*='text-'])]:text-muted-foreground",
         className
       )}
       {...props}

--- a/src/renderer/src/components/ui/hover-card.tsx
+++ b/src/renderer/src/components/ui/hover-card.tsx
@@ -26,7 +26,7 @@ function HoverCardContent({
         align={align}
         sideOffset={sideOffset}
         className={cn(
-          'z-50 w-64 origin-(--radix-hover-card-content-transform-origin) rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-hidden data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
+          'z-50 w-64 origin-(--radix-hover-card-content-transform-origin) rounded-md border border-border/50 bg-popover p-4 text-popover-foreground shadow-md outline-hidden data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
           className
         )}
         {...props}

--- a/src/renderer/src/components/ui/label.tsx
+++ b/src/renderer/src/components/ui/label.tsx
@@ -10,7 +10,7 @@ function Label({ className, ...props }: React.ComponentProps<typeof LabelPrimiti
     <LabelPrimitive.Root
       data-slot="label"
       className={cn(
-        'flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50',
+        'flex items-center gap-2 text-xs leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50',
         className
       )}
       {...props}

--- a/src/renderer/src/components/ui/select.tsx
+++ b/src/renderer/src/components/ui/select.tsx
@@ -56,7 +56,7 @@ function SelectContent({
       <SelectPrimitive.Content
         data-slot="select-content"
         className={cn(
-          'relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
+          'relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border border-border/50 bg-popover text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
           position === 'popper' &&
             'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
           className


### PR DESCRIPTION
## Summary
- **Geist Sans font**: Replace monospace body font with Geist Sans for a cleaner, more modern look
- **Orphaned worktree cleanup**: Handle deletion of worktrees no longer tracked by git, cleaning up disk and metadata
- **UI polish**: Soften border opacity across all UI components (`border-border/50`), reduce label size to `text-xs`, simplify worktree group tones, and color PR icons by state (merged=purple, open=green, closed=gray, draft=muted)

## Test plan
- [ ] Verify Geist Sans font renders correctly across all views
- [ ] Test orphaned worktree deletion (prune a worktree via git, then delete from UI)
- [ ] Check border appearance in dark and light mode
- [ ] Verify PR state colors display correctly on worktree cards
- [ ] Confirm dropdown menu alignment with updated inset values

🤖 Generated with [Claude Code](https://claude.com/claude-code)