### PR TITLE
fix: stabilize active worktree order in 'recent' sort

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -85,8 +85,23 @@ const WorktreeList = React.memo(function WorktreeList() {
       switch (sortBy) {
         case 'name':
           return a.displayName.localeCompare(b.displayName)
-        case 'recent':
+        case 'recent': {
+          const aTabs = tabsByWorktree?.[a.id] ?? []
+          const bTabs = tabsByWorktree?.[b.id] ?? []
+          const aActive = aTabs.some((t) => t.ptyId)
+          const bActive = bTabs.some((t) => t.ptyId)
+          // Active worktrees pin to top in stable (name) order
+          if (aActive && bActive) {
+            return a.displayName.localeCompare(b.displayName)
+          }
+          if (aActive) {
+            return -1
+          }
+          if (bActive) {
+            return 1
+          }
           return b.sortOrder - a.sortOrder
+        }
         case 'repo': {
           const ra = repoMap.get(a.repoId)?.displayName ?? ''
           const rb = repoMap.get(b.repoId)?.displayName ?? ''


### PR DESCRIPTION
## Summary
- Active worktrees (with live PTY connections) now pin to the top of the list in stable name order when using the "recent" sort
- Inactive worktrees continue to sort by recency below them
- Prevents the list from reshuffling every time you switch between active worktrees

## Test plan
- [ ] Switch to "recent" sort in the sidebar
- [ ] Open multiple worktrees so they have active PTY connections
- [ ] Click between active worktrees and verify they don't reorder
- [ ] Verify inactive worktrees still sort by most recently used

🤖 Generated with [Claude Code](https://claude.com/claude-code)