### PR TITLE
fix: preserve 'show active only' filter when creating a worktree

### DIFF
--- a/src/renderer/src/components/sidebar/AddWorktreeDialog.tsx
+++ b/src/renderer/src/components/sidebar/AddWorktreeDialog.tsx
@@ -38,8 +38,6 @@ const AddWorktreeDialog = React.memo(function AddWorktreeDialog() {
   const setSidebarOpen = useAppStore((s) => s.setSidebarOpen)
   const searchQuery = useAppStore((s) => s.searchQuery)
   const setSearchQuery = useAppStore((s) => s.setSearchQuery)
-  const showActiveOnly = useAppStore((s) => s.showActiveOnly)
-  const setShowActiveOnly = useAppStore((s) => s.setShowActiveOnly)
   const filterRepoIds = useAppStore((s) => s.filterRepoIds)
   const setFilterRepoIds = useAppStore((s) => s.setFilterRepoIds)
   const revealWorktreeInSidebar = useAppStore((s) => s.revealWorktreeInSidebar)
@@ -134,9 +132,6 @@ const AddWorktreeDialog = React.memo(function AddWorktreeDialog() {
         if (searchQuery) {
           setSearchQuery('')
         }
-        if (showActiveOnly) {
-          setShowActiveOnly(false)
-        }
         if (filterRepoIds.length > 0 && !filterRepoIds.includes(repoId)) {
           setFilterRepoIds([])
         }
@@ -159,8 +154,6 @@ const AddWorktreeDialog = React.memo(function AddWorktreeDialog() {
     setSidebarOpen,
     searchQuery,
     setSearchQuery,
-    showActiveOnly,
-    setShowActiveOnly,
     filterRepoIds,
     setFilterRepoIds,
     setActiveWorktree,


### PR DESCRIPTION
## Summary
- Creating a new worktree no longer resets the "show active only" sidebar filter
- The `handleCreate` callback was explicitly calling `setShowActiveOnly(false)`, which is unnecessary since `setActiveWorktree` + `revealWorktreeInSidebar` already ensure the new worktree is visible
- Removed the filter reset and cleaned up unused `showActiveOnly`/`setShowActiveOnly` references

## Test plan
- [x] Enable "show active only" in sidebar
- [x] Create a new worktree
- [x] Verify the filter stays enabled and the new worktree appears in the filtered list
- [x] Verified via Electron automation (agent-browser + CDP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)