### PR TITLE
feat: VS Code-style preview tabs for editor

### DIFF
--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -38,6 +38,7 @@ export default function Terminal(): React.JSX.Element | null {
   const setActiveFile = useAppStore((s) => s.setActiveFile)
   const closeFile = useAppStore((s) => s.closeFile)
   const closeAllFiles = useAppStore((s) => s.closeAllFiles)
+  const pinFile = useAppStore((s) => s.pinFile)
 
   const markFileDirty = useAppStore((s) => s.markFileDirty)
 
@@ -365,6 +366,7 @@ export default function Terminal(): React.JSX.Element | null {
               }}
               onCloseFile={handleCloseFile}
               onCloseAllFiles={closeAllFiles}
+              onPinFile={pinFile}
             />
           )}
         </div>

--- a/src/renderer/src/components/right-sidebar/FileExplorer.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorer.tsx
@@ -24,6 +24,7 @@ export default function FileExplorer(): React.JSX.Element {
   const expandedDirs = useAppStore((s) => s.expandedDirs)
   const toggleDir = useAppStore((s) => s.toggleDir)
   const openFile = useAppStore((s) => s.openFile)
+  const pinFile = useAppStore((s) => s.pinFile)
   const activeFileId = useAppStore((s) => s.activeFileId)
 
   // Find active worktree path
@@ -158,16 +159,29 @@ export default function FileExplorer(): React.JSX.Element {
       if (node.isDirectory) {
         toggleDir(activeWorktreeId, node.path)
       } else {
-        openFile({
-          filePath: node.path,
-          relativePath: node.relativePath,
-          worktreeId: activeWorktreeId,
-          language: detectLanguage(node.name),
-          mode: 'edit'
-        })
+        openFile(
+          {
+            filePath: node.path,
+            relativePath: node.relativePath,
+            worktreeId: activeWorktreeId,
+            language: detectLanguage(node.name),
+            mode: 'edit'
+          },
+          { preview: true }
+        )
       }
     },
     [activeWorktreeId, toggleDir, openFile]
+  )
+
+  const handleDoubleClick = useCallback(
+    (node: TreeNode) => {
+      if (!activeWorktreeId || node.isDirectory) {
+        return
+      }
+      pinFile(node.path)
+    },
+    [activeWorktreeId, pinFile]
   )
 
   if (!worktreePath) {
@@ -215,6 +229,7 @@ export default function FileExplorer(): React.JSX.Element {
                   e.dataTransfer.effectAllowed = 'copy'
                 }}
                 onClick={() => handleClick(node)}
+                onDoubleClick={() => handleDoubleClick(node)}
               >
                 {node.isDirectory ? (
                   <>

--- a/src/renderer/src/components/right-sidebar/Search.tsx
+++ b/src/renderer/src/components/right-sidebar/Search.tsx
@@ -188,13 +188,16 @@ export default function Search(): React.JSX.Element {
         matchLength: match.matchLength
       })
 
-      openFile({
-        filePath: fileResult.filePath,
-        relativePath: fileResult.relativePath,
-        worktreeId: activeWorktreeId,
-        language: detectLanguage(fileResult.relativePath),
-        mode: 'edit'
-      })
+      openFile(
+        {
+          filePath: fileResult.filePath,
+          relativePath: fileResult.relativePath,
+          worktreeId: activeWorktreeId,
+          language: detectLanguage(fileResult.relativePath),
+          mode: 'edit'
+        },
+        { preview: true }
+      )
     },
     [activeWorktreeId, openFile, setPendingEditorReveal]
   )

--- a/src/renderer/src/components/tab-bar/EditorFileTab.tsx
+++ b/src/renderer/src/components/tab-bar/EditorFileTab.tsx
@@ -19,7 +19,8 @@ export default function EditorFileTab({
   onActivate,
   onClose,
   onCloseToRight,
-  onCloseAll
+  onCloseAll,
+  onPin
 }: {
   file: OpenFile
   isActive: boolean
@@ -28,6 +29,7 @@ export default function EditorFileTab({
   onClose: () => void
   onCloseToRight: () => void
   onCloseAll: () => void
+  onPin?: () => void
 }): React.JSX.Element {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: file.id
@@ -78,6 +80,11 @@ export default function EditorFileTab({
             onActivate()
             listeners?.onPointerDown?.(e)
           }}
+          onDoubleClick={() => {
+            if (file.isPreview && onPin) {
+              onPin()
+            }
+          }}
           onMouseDown={(e) => {
             if (e.button === 1) {
               e.preventDefault()
@@ -94,7 +101,7 @@ export default function EditorFileTab({
           {file.isDirty && (
             <span className="mr-1 size-1.5 rounded-full bg-foreground/60 shrink-0" />
           )}
-          <span className="truncate max-w-[130px] mr-1.5">
+          <span className={`truncate max-w-[130px] mr-1.5${file.isPreview ? ' italic' : ''}`}>
             {isDiff
               ? file.relativePath === 'All Changes'
                 ? 'All Changes'

--- a/src/renderer/src/components/tab-bar/TabBar.tsx
+++ b/src/renderer/src/components/tab-bar/TabBar.tsx
@@ -34,6 +34,7 @@ type TabBarProps = {
   onActivateFile?: (fileId: string) => void
   onCloseFile?: (fileId: string) => void
   onCloseAllFiles?: () => void
+  onPinFile?: (fileId: string) => void
   tabBarOrder?: string[]
 }
 
@@ -88,6 +89,7 @@ export default function TabBar({
   onActivateFile,
   onCloseFile,
   onCloseAllFiles,
+  onPinFile,
   tabBarOrder
 }: TabBarProps): React.JSX.Element {
   const sensors = useSensors(
@@ -196,6 +198,7 @@ export default function TabBar({
                   onClose={() => onCloseFile?.(item.id)}
                   onCloseToRight={() => onCloseToRight(item.id)}
                   onCloseAll={() => onCloseAllFiles?.()}
+                  onPin={() => onPinFile?.(item.id)}
                 />
               )
             })}

--- a/src/renderer/src/components/terminal/TerminalShell.tsx
+++ b/src/renderer/src/components/terminal/TerminalShell.tsx
@@ -37,6 +37,7 @@ type TerminalShellProps = {
   onActivateFile: (fileId: string) => void
   onCloseFile: (fileId: string) => void
   onCloseAllFiles: () => void
+  onPinFile: (fileId: string) => void
   onPtyExit: (tabId: string, ptyId: string) => void
   tabBarOrder?: string[]
   editorPanel: ReactNode
@@ -72,6 +73,7 @@ export function TerminalShell({
   onActivateFile,
   onCloseFile,
   onCloseAllFiles,
+  onPinFile,
   onPtyExit,
   tabBarOrder,
   editorPanel,
@@ -112,6 +114,7 @@ export function TerminalShell({
               onActivateFile={onActivateFile}
               onCloseFile={onCloseFile}
               onCloseAllFiles={onCloseAllFiles}
+              onPinFile={onPinFile}
               tabBarOrder={tabBarOrder}
             />
           )}

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -12,6 +12,7 @@ export type OpenFile = {
   isDirty: boolean
   mode: 'edit' | 'diff'
   diffStaged?: boolean
+  isPreview?: boolean // preview tabs are replaced when another file is single-clicked
 }
 
 export type RightSidebarTab = 'explorer' | 'search' | 'source-control' | 'checks'
@@ -40,7 +41,8 @@ export type EditorSlice = {
   activeTabTypeByWorktree: Record<string, 'terminal' | 'editor'> // worktreeId -> last active tab type
   activeTabType: 'terminal' | 'editor'
   setActiveTabType: (type: 'terminal' | 'editor') => void
-  openFile: (file: Omit<OpenFile, 'id' | 'isDirty'>) => void
+  openFile: (file: Omit<OpenFile, 'id' | 'isDirty'>, options?: { preview?: boolean }) => void
+  pinFile: (fileId: string) => void
   closeFile: (fileId: string) => void
   closeAllFiles: () => void
   setActiveFile: (fileId: string) => void
@@ -134,36 +136,72 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
       }
     }),
 
-  openFile: (file) =>
+  openFile: (file, options) =>
     set((s) => {
       const id = file.filePath
       const existing = s.openFiles.find((f) => f.id === id)
       const worktreeId = file.worktreeId
+      const isPreview = options?.preview ?? false
+
+      const activeResult = {
+        activeFileId: id,
+        activeTabType: 'editor' as const,
+        activeFileIdByWorktree: { ...s.activeFileIdByWorktree, [worktreeId]: id },
+        activeTabTypeByWorktree: { ...s.activeTabTypeByWorktree, [worktreeId]: 'editor' as const }
+      }
+
       if (existing) {
-        if (existing.mode === file.mode && existing.diffStaged === file.diffStaged) {
-          return {
-            activeFileId: id,
-            activeTabType: 'editor',
-            activeFileIdByWorktree: { ...s.activeFileIdByWorktree, [worktreeId]: id },
-            activeTabTypeByWorktree: { ...s.activeTabTypeByWorktree, [worktreeId]: 'editor' }
-          }
+        // If opening as non-preview, also pin the existing tab
+        const updatedPreview = isPreview ? existing.isPreview : false
+        if (
+          existing.mode === file.mode &&
+          existing.diffStaged === file.diffStaged &&
+          existing.isPreview === updatedPreview
+        ) {
+          return activeResult
         }
         return {
           openFiles: s.openFiles.map((f) =>
-            f.id === id ? { ...f, mode: file.mode, diffStaged: file.diffStaged } : f
+            f.id === id
+              ? { ...f, mode: file.mode, diffStaged: file.diffStaged, isPreview: updatedPreview }
+              : f
           ),
-          activeFileId: id,
-          activeTabType: 'editor',
-          activeFileIdByWorktree: { ...s.activeFileIdByWorktree, [worktreeId]: id },
-          activeTabTypeByWorktree: { ...s.activeTabTypeByWorktree, [worktreeId]: 'editor' }
+          ...activeResult
         }
       }
+
+      // If opening as preview, replace the existing preview tab for this worktree
+      let newFiles = s.openFiles
+      if (isPreview) {
+        const existingPreviewIdx = s.openFiles.findIndex(
+          (f) => f.worktreeId === worktreeId && f.isPreview
+        )
+        if (existingPreviewIdx !== -1) {
+          // Replace in-place to preserve tab position
+          newFiles = s.openFiles.map((f, i) =>
+            i === existingPreviewIdx ? { ...file, id, isDirty: false, isPreview: true } : f
+          )
+          return { openFiles: newFiles, ...activeResult }
+        }
+      }
+
       return {
-        openFiles: [...s.openFiles, { ...file, id, isDirty: false }],
-        activeFileId: id,
-        activeTabType: 'editor',
-        activeFileIdByWorktree: { ...s.activeFileIdByWorktree, [worktreeId]: id },
-        activeTabTypeByWorktree: { ...s.activeTabTypeByWorktree, [worktreeId]: 'editor' }
+        openFiles: [
+          ...newFiles,
+          { ...file, id, isDirty: false, isPreview: isPreview || undefined }
+        ],
+        ...activeResult
+      }
+    }),
+
+  pinFile: (fileId) =>
+    set((s) => {
+      const file = s.openFiles.find((f) => f.id === fileId)
+      if (!file?.isPreview) {
+        return s
+      }
+      return {
+        openFiles: s.openFiles.map((f) => (f.id === fileId ? { ...f, isPreview: undefined } : f))
       }
     }),
 
@@ -274,7 +312,11 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
 
   markFileDirty: (fileId, dirty) =>
     set((s) => ({
-      openFiles: s.openFiles.map((f) => (f.id === fileId ? { ...f, isDirty: dirty } : f))
+      openFiles: s.openFiles.map((f) =>
+        f.id === fileId
+          ? { ...f, isDirty: dirty, ...(dirty && f.isPreview ? { isPreview: undefined } : {}) }
+          : f
+      )
     })),
 
   openDiff: (worktreeId, filePath, relativePath, language, staged) =>


### PR DESCRIPTION
## Summary
- Single-clicking a file in the explorer or search results opens it in a **preview tab** (italic text), matching VS Code behavior
- Clicking another file **replaces** the preview tab instead of adding a new one, preventing tab clutter
- **Double-clicking** in the file explorer or on the tab itself pins it as a permanent tab
- **Editing** a preview file auto-pins it (promotes to permanent)
- Terminal link clicks still open as permanent tabs (more intentional action)

Addresses feedback from [Slack thread](https://stablygroup.slack.com/archives/C0AK2T3JEF4/p1774560851001029).

## Test plan
- [x] Single-click file in explorer → opens as preview tab (italic text)
- [x] Single-click another file → replaces the preview tab in-place
- [x] Double-click file in explorer → pins it (non-italic, permanent)
- [x] Double-click on preview tab → pins it
- [x] Edit a preview file → auto-pins
- [x] Search result click → opens as preview tab
- [x] Typecheck and lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)