### PR TITLE
style: remove redundant PR state label from worktree card

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -265,19 +265,6 @@ const WorktreeCard = React.memo(function WorktreeCard({
                   </TooltipContent>
                 </Tooltip>
               )}
-              {pr && (
-                <span
-                  className={cn(
-                    'text-[9px] font-bold uppercase tracking-wider h-3.5 flex items-center',
-                    pr.state === 'merged' && 'text-purple-500/80',
-                    pr.state === 'open' && 'text-emerald-500/80',
-                    pr.state === 'closed' && 'text-muted-foreground/60',
-                    pr.state === 'draft' && 'text-muted-foreground/50'
-                  )}
-                >
-                  {prStateLabel(pr.state)}
-                </span>
-              )}
             </div>
           </div>
 


### PR DESCRIPTION
## Summary
- Removes the inline PR state text label (MERGED/OPEN/CLOSED/DRAFT) from the WorktreeCard header row
- The PR state remains accessible via tooltip, reducing visual clutter in the card header

## Test plan
- [ ] Verify worktree cards render without the PR state text label
- [ ] Verify PR state is still visible in the card tooltip

🤖 Generated with [Claude Code](https://claude.com/claude-code)