### PR TITLE
fix(terminal): support Ctrl/Cmd+Shift+C copy shortcut

### DIFF
--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
@@ -72,6 +72,25 @@ export function useTerminalKeyboardShortcuts({
         return
       }
 
+      // Cmd/Ctrl+Shift+C copies terminal selection via Electron clipboard.
+      // This ensures Linux terminal copy works consistently.
+      if (e.shiftKey && e.key.toLowerCase() === 'c') {
+        const pane = manager.getActivePane() ?? manager.getPanes()[0]
+        if (!pane) {
+          return
+        }
+        const selection = pane.terminal.getSelection()
+        if (!selection) {
+          return
+        }
+        e.preventDefault()
+        e.stopPropagation()
+        void window.api.ui.writeClipboardText(selection).catch(() => {
+          /* ignore clipboard write failures */
+        })
+        return
+      }
+
       // Keep Cmd+F bound to the terminal search until the app has a real
       // top-level find-in-page flow to fall back to.
       if (!e.shiftKey && e.key.toLowerCase() === 'f') {


### PR DESCRIPTION
## Summary
- add explicit terminal shortcut handling for `Ctrl+Shift+C` (Linux/Windows) and `Cmd+Shift+C` (macOS)
- copy active pane selection via Electron clipboard IPC
- keep behavior no-op when there is no terminal selection

## Why
`Ctrl+Shift+V` already worked via custom terminal paste interception, but copy had no matching keyboard shortcut handling in terminal context, so `Ctrl+Shift+C` did nothing.

## Testing
- manually verified in terminal: selecting text + `Ctrl+Shift+C` copies to clipboard
- `Ctrl+Shift+V` behavior unchanged
- attempted `pnpm -s typecheck`, but local environment is missing expected type dependencies (`@electron-toolkit/tsconfig`, `electron-vite/node`)