### PR TITLE
fix(ui): unify split download button

### DIFF
--- a/src/renderer/src/components/sidebar/SidebarToolbar.tsx
+++ b/src/renderer/src/components/sidebar/SidebarToolbar.tsx
@@ -21,44 +21,50 @@ const SidebarToolbar = React.memo(function SidebarToolbar() {
   return (
     <div className="mt-auto shrink-0">
       {showUpdateBanner && (
-        <div className="flex items-center border-t border-sidebar-border bg-primary/10">
-          <button
-            onClick={() => {
-              if (updateStatus.state === 'downloaded') {
-                window.api.updater.quitAndInstall()
-              } else if (updateStatus.state === 'available') {
-                window.api.updater.download()
-              }
-            }}
-            disabled={updateStatus.state === 'downloading'}
-            className="flex items-center gap-1.5 flex-1 min-w-0 px-2 py-1.5 text-[11px] font-medium text-primary hover:bg-primary/15 transition-colors cursor-pointer disabled:opacity-60 disabled:cursor-default"
-          >
-            <Download className="size-3.5 shrink-0" />
-            {updateStatus.state === 'downloaded' ? (
-              <span>Restart now (update)</span>
-            ) : updateStatus.state === 'downloading' ? (
-              <span>
-                Downloading <span className="font-semibold">v{updateVersion}</span>…{' '}
-                {updateStatus.percent}%
-              </span>
-            ) : (
-              <span>
-                Update <span className="font-semibold">v{updateStatus.version}</span> available —
-                Install
-              </span>
-            )}
-          </button>
-          <button
+        <button
+          onClick={() => {
+            if (updateStatus.state === 'downloaded') {
+              window.api.updater.quitAndInstall()
+            } else if (updateStatus.state === 'available') {
+              window.api.updater.download()
+            }
+          }}
+          disabled={updateStatus.state === 'downloading'}
+          className="group flex items-center gap-1.5 w-full px-2 py-1.5 text-[11px] font-medium text-primary hover:bg-primary/15 transition-colors cursor-pointer disabled:opacity-60 disabled:cursor-default border-t border-sidebar-border bg-primary/10"
+        >
+          <Download className="size-3.5 shrink-0" />
+          {updateStatus.state === 'downloaded' ? (
+            <span>Restart now (update)</span>
+          ) : updateStatus.state === 'downloading' ? (
+            <span>
+              Downloading <span className="font-semibold">v{updateVersion}</span>…{' '}
+              {updateStatus.percent}%
+            </span>
+          ) : (
+            <span>
+              Update <span className="font-semibold">v{updateStatus.version}</span> available
+              — Install
+            </span>
+          )}
+          <span
+            role="button"
+            tabIndex={0}
             onClick={(e) => {
               e.stopPropagation()
               dismissUpdate()
             }}
-            className="shrink-0 p-1 mr-1 rounded text-primary/60 hover:text-primary hover:bg-primary/15 transition-colors"
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.stopPropagation()
+                dismissUpdate()
+              }
+            }}
+            className="ml-auto shrink-0 p-0.5 rounded text-primary/40 hover:text-primary hover:bg-primary/20 opacity-0 group-hover:opacity-100 transition-all"
             title="Dismiss"
           >
             <X className="size-3" />
-          </button>
-        </div>
+          </span>
+        </button>
       )}
       <div className="flex items-center justify-between px-2 py-1.5 border-t border-sidebar-border">
         <Tooltip>


### PR DESCRIPTION
## Summary
- Merged the separate download/install button and dismiss (X) button into a single unified button element
- The dismiss icon now only appears on hover, eliminating the visual split appearance
- Added keyboard accessibility (Enter/Space) for the dismiss action

## Test plan
- [ ] Verify update banner renders as a single cohesive button
- [ ] Verify dismiss (X) appears on hover and dismisses the banner
- [ ] Verify download/install/restart actions still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)