### PR TITLE
feat: reduce GitHub API usage with gh api --cache

### DIFF
--- a/src/main/github/client.test.ts
+++ b/src/main/github/client.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { deriveCheckStatus, mapPRState, mapCheckStatus, mapCheckConclusion } from './client'
+import { deriveCheckStatus, mapPRState, mapCheckStatus, mapCheckConclusion } from './mappers'
 
 describe('mapPRState', () => {
   it('returns draft when an open PR is marked as draft', () => {

--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -1,6 +1,15 @@
 import { execFile } from 'child_process'
 import { promisify } from 'util'
-import type { PRInfo, IssueInfo, CheckStatus, PRCheckDetail } from '../../shared/types'
+import type { PRInfo, IssueInfo, PRCheckDetail } from '../../shared/types'
+import {
+  mapCheckRunRESTStatus,
+  mapCheckRunRESTConclusion,
+  mapCheckStatus,
+  mapCheckConclusion,
+  mapPRState,
+  deriveCheckStatus,
+  mapIssueInfo
+} from './mappers'
 
 const execFileAsync = promisify(execFile)
 
@@ -28,6 +37,31 @@ function release(): void {
   if (next) {
     next()
   }
+}
+
+// ── Owner/repo resolution for gh api --cache ──────────────────────────
+const ownerRepoCache = new Map<string, { owner: string; repo: string } | null>()
+
+async function getOwnerRepo(repoPath: string): Promise<{ owner: string; repo: string } | null> {
+  if (ownerRepoCache.has(repoPath)) {
+    return ownerRepoCache.get(repoPath)!
+  }
+  try {
+    const { stdout } = await execFileAsync('git', ['remote', 'get-url', 'origin'], {
+      cwd: repoPath,
+      encoding: 'utf-8'
+    })
+    const match = stdout.trim().match(/github\.com[:/]([^/]+)\/([^/.]+?)(?:\.git)?$/)
+    if (match) {
+      const result = { owner: match[1], repo: match[2] }
+      ownerRepoCache.set(repoPath, result)
+      return result
+    }
+  } catch {
+    // ignore — non-GitHub remote or no remote
+  }
+  ownerRepoCache.set(repoPath, null)
+  return null
 }
 
 /**
@@ -71,26 +105,34 @@ export async function getPRForBranch(repoPath: string, branch: string): Promise<
 
 /**
  * Get a single issue by number.
+ * Uses gh api --cache so 304 Not Modified responses don't count against the rate limit.
  */
 export async function getIssue(repoPath: string, issueNumber: number): Promise<IssueInfo | null> {
+  const ownerRepo = await getOwnerRepo(repoPath)
   await acquire()
   try {
+    if (ownerRepo) {
+      const { stdout } = await execFileAsync(
+        'gh',
+        [
+          'api',
+          '--cache',
+          '300s',
+          `repos/${ownerRepo.owner}/${ownerRepo.repo}/issues/${issueNumber}`
+        ],
+        { cwd: repoPath, encoding: 'utf-8' }
+      )
+      const data = JSON.parse(stdout)
+      return mapIssueInfo(data)
+    }
+    // Fallback for non-GitHub remotes
     const { stdout } = await execFileAsync(
       'gh',
       ['issue', 'view', String(issueNumber), '--json', 'number,title,state,url,labels'],
-      {
-        cwd: repoPath,
-        encoding: 'utf-8'
-      }
+      { cwd: repoPath, encoding: 'utf-8' }
     )
     const data = JSON.parse(stdout)
-    return {
-      number: data.number,
-      title: data.title,
-      state: data.state?.toLowerCase() === 'open' ? 'open' : 'closed',
-      url: data.url,
-      labels: (data.labels || []).map((l: { name: string }) => l.name)
-    }
+    return mapIssueInfo(data)
   } catch {
     return null
   } finally {
@@ -100,32 +142,34 @@ export async function getIssue(repoPath: string, issueNumber: number): Promise<I
 
 /**
  * List issues for a repo.
+ * Uses gh api --cache so 304 Not Modified responses don't count against the rate limit.
  */
 export async function listIssues(repoPath: string, limit = 20): Promise<IssueInfo[]> {
+  const ownerRepo = await getOwnerRepo(repoPath)
   await acquire()
   try {
+    if (ownerRepo) {
+      const { stdout } = await execFileAsync(
+        'gh',
+        [
+          'api',
+          '--cache',
+          '120s',
+          `repos/${ownerRepo.owner}/${ownerRepo.repo}/issues?per_page=${limit}&state=open&sort=updated&direction=desc`
+        ],
+        { cwd: repoPath, encoding: 'utf-8' }
+      )
+      const data = JSON.parse(stdout) as unknown[]
+      return data.map((d) => mapIssueInfo(d as Parameters<typeof mapIssueInfo>[0]))
+    }
+    // Fallback for non-GitHub remotes
     const { stdout } = await execFileAsync(
       'gh',
       ['issue', 'list', '--json', 'number,title,state,url,labels', '--limit', String(limit)],
-      {
-        cwd: repoPath,
-        encoding: 'utf-8'
-      }
+      { cwd: repoPath, encoding: 'utf-8' }
     )
-    const data = JSON.parse(stdout) as {
-      number: number
-      title: string
-      state: string
-      url: string
-      labels: { name: string }[]
-    }[]
-    return data.map((d) => ({
-      number: d.number,
-      title: d.title,
-      state: d.state?.toLowerCase() === 'open' ? ('open' as const) : ('closed' as const),
-      url: d.url,
-      labels: (d.labels || []).map((l) => l.name)
-    }))
+    const data = JSON.parse(stdout) as unknown[]
+    return data.map((d) => mapIssueInfo(d as Parameters<typeof mapIssueInfo>[0]))
   } catch {
     return []
   } finally {
@@ -134,18 +178,50 @@ export async function listIssues(repoPath: string, limit = 20): Promise<IssueInf
 }
 
 /**
- * Get detailed check statuses for a PR by number.
+ * Get detailed check statuses for a PR.
+ * When branch is provided, uses gh api --cache with the check-runs REST endpoint
+ * so 304 Not Modified responses don't count against the rate limit.
  */
-export async function getPRChecks(repoPath: string, prNumber: number): Promise<PRCheckDetail[]> {
+export async function getPRChecks(
+  repoPath: string,
+  prNumber: number,
+  branch?: string
+): Promise<PRCheckDetail[]> {
+  const ownerRepo = branch ? await getOwnerRepo(repoPath) : null
   await acquire()
   try {
+    if (ownerRepo && branch) {
+      const { stdout } = await execFileAsync(
+        'gh',
+        [
+          'api',
+          '--cache',
+          '60s',
+          `repos/${ownerRepo.owner}/${ownerRepo.repo}/commits/${encodeURIComponent(branch)}/check-runs?per_page=100`
+        ],
+        { cwd: repoPath, encoding: 'utf-8' }
+      )
+      const data = JSON.parse(stdout) as {
+        check_runs: {
+          name: string
+          status: string
+          conclusion: string | null
+          html_url: string
+          details_url: string | null
+        }[]
+      }
+      return data.check_runs.map((d) => ({
+        name: d.name,
+        status: mapCheckRunRESTStatus(d.status),
+        conclusion: mapCheckRunRESTConclusion(d.status, d.conclusion),
+        url: d.details_url || d.html_url || null
+      }))
+    }
+    // Fallback: no branch provided or non-GitHub remote
     const { stdout } = await execFileAsync(
       'gh',
       ['pr', 'checks', String(prNumber), '--json', 'name,state,link'],
-      {
-        cwd: repoPath,
-        encoding: 'utf-8'
-      }
+      { cwd: repoPath, encoding: 'utf-8' }
     )
     const data = JSON.parse(stdout) as { name: string; state: string; link: string }[]
     return data.map((d) => ({
@@ -183,95 +259,4 @@ export async function updatePRTitle(
   } finally {
     release()
   }
-}
-
-export function mapCheckStatus(state: string): PRCheckDetail['status'] {
-  const s = state?.toUpperCase()
-  if (s === 'PENDING' || s === 'QUEUED') {
-    return 'queued'
-  }
-  if (s === 'IN_PROGRESS') {
-    return 'in_progress'
-  }
-  return 'completed'
-}
-
-export function mapCheckConclusion(state: string): PRCheckDetail['conclusion'] {
-  const s = state?.toUpperCase()
-  if (s === 'SUCCESS' || s === 'PASS') {
-    return 'success'
-  }
-  if (s === 'FAILURE' || s === 'FAIL') {
-    return 'failure'
-  }
-  if (s === 'CANCELLED') {
-    return 'cancelled'
-  }
-  if (s === 'TIMED_OUT') {
-    return 'timed_out'
-  }
-  if (s === 'SKIPPED') {
-    return 'skipped'
-  }
-  if (s === 'PENDING' || s === 'QUEUED' || s === 'IN_PROGRESS') {
-    return 'pending'
-  }
-  if (s === 'NEUTRAL') {
-    return 'neutral'
-  }
-  return null
-}
-
-export function mapPRState(state: string, isDraft?: boolean): PRInfo['state'] {
-  const s = state?.toUpperCase()
-  if (s === 'MERGED') {
-    return 'merged'
-  }
-  if (s === 'CLOSED') {
-    return 'closed'
-  }
-  if (isDraft) {
-    return 'draft'
-  }
-  return 'open'
-}
-
-export function deriveCheckStatus(rollup: unknown[] | null | undefined): CheckStatus {
-  if (!rollup || !Array.isArray(rollup) || rollup.length === 0) {
-    return 'neutral'
-  }
-
-  let hasFailure = false
-  let hasPending = false
-
-  for (const check of rollup as { status?: string; conclusion?: string; state?: string }[]) {
-    const conclusion = check.conclusion?.toUpperCase()
-    const status = check.status?.toUpperCase()
-    const state = check.state?.toUpperCase()
-
-    if (
-      conclusion === 'FAILURE' ||
-      conclusion === 'TIMED_OUT' ||
-      conclusion === 'CANCELLED' ||
-      state === 'FAILURE' ||
-      state === 'ERROR'
-    ) {
-      hasFailure = true
-    } else if (
-      status === 'IN_PROGRESS' ||
-      status === 'QUEUED' ||
-      status === 'PENDING' ||
-      state === 'PENDING'
-    ) {
-      hasPending = true
-    }
-  }
-
-  if (hasFailure) {
-    return 'failure'
-  }
-  if (hasPending) {
-    return 'pending'
-  }
-  return 'success'
 }

--- a/src/main/github/mappers.ts
+++ b/src/main/github/mappers.ts
@@ -1,0 +1,153 @@
+import type { PRInfo, IssueInfo, CheckStatus, PRCheckDetail } from '../../shared/types'
+
+// ── REST API check-runs mapping ───────────────────────────────────────
+// The REST check-runs endpoint returns separate status + conclusion fields
+// (unlike gh pr checks which merges them into a single "state" string).
+
+export function mapCheckRunRESTStatus(status: string): PRCheckDetail['status'] {
+  const s = status?.toLowerCase()
+  if (s === 'queued') {
+    return 'queued'
+  }
+  if (s === 'in_progress') {
+    return 'in_progress'
+  }
+  return 'completed'
+}
+
+const conclusionMap: Record<string, PRCheckDetail['conclusion']> = {
+  success: 'success',
+  failure: 'failure',
+  cancelled: 'cancelled',
+  timed_out: 'timed_out',
+  skipped: 'skipped',
+  neutral: 'neutral',
+  action_required: 'failure'
+}
+
+export function mapCheckRunRESTConclusion(
+  status: string,
+  conclusion: string | null
+): PRCheckDetail['conclusion'] {
+  if (status?.toLowerCase() !== 'completed') {
+    return 'pending'
+  }
+  if (!conclusion) {
+    return null
+  }
+  return conclusionMap[conclusion.toLowerCase()] ?? null
+}
+
+// ── gh pr checks mapping (single "state" string) ─────────────────────
+
+export function mapCheckStatus(state: string): PRCheckDetail['status'] {
+  const s = state?.toUpperCase()
+  if (s === 'PENDING' || s === 'QUEUED') {
+    return 'queued'
+  }
+  if (s === 'IN_PROGRESS') {
+    return 'in_progress'
+  }
+  return 'completed'
+}
+
+export function mapCheckConclusion(state: string): PRCheckDetail['conclusion'] {
+  const s = state?.toUpperCase()
+  if (s === 'SUCCESS' || s === 'PASS') {
+    return 'success'
+  }
+  if (s === 'FAILURE' || s === 'FAIL') {
+    return 'failure'
+  }
+  if (s === 'CANCELLED') {
+    return 'cancelled'
+  }
+  if (s === 'TIMED_OUT') {
+    return 'timed_out'
+  }
+  if (s === 'SKIPPED') {
+    return 'skipped'
+  }
+  if (s === 'PENDING' || s === 'QUEUED' || s === 'IN_PROGRESS') {
+    return 'pending'
+  }
+  if (s === 'NEUTRAL') {
+    return 'neutral'
+  }
+  return null
+}
+
+export function mapPRState(state: string, isDraft?: boolean): PRInfo['state'] {
+  const s = state?.toUpperCase()
+  if (s === 'MERGED') {
+    return 'merged'
+  }
+  if (s === 'CLOSED') {
+    return 'closed'
+  }
+  if (isDraft) {
+    return 'draft'
+  }
+  return 'open'
+}
+
+// ── Issue mapping ────────────────────────────────────────────────────
+// REST API returns html_url + lowercase state; gh issue view returns url + mixed-case state.
+// This helper normalises both shapes into IssueInfo.
+
+export function mapIssueInfo(data: {
+  number: number
+  title: string
+  state: string
+  url?: string
+  html_url?: string
+  labels?: { name: string }[]
+}): IssueInfo {
+  return {
+    number: data.number,
+    title: data.title,
+    state: data.state?.toLowerCase() === 'open' ? 'open' : 'closed',
+    url: data.html_url ?? data.url ?? '',
+    labels: (data.labels || []).map((l) => l.name)
+  }
+}
+
+export function deriveCheckStatus(rollup: unknown[] | null | undefined): CheckStatus {
+  if (!rollup || !Array.isArray(rollup) || rollup.length === 0) {
+    return 'neutral'
+  }
+
+  let hasFailure = false
+  let hasPending = false
+
+  for (const check of rollup as { status?: string; conclusion?: string; state?: string }[]) {
+    const conclusion = check.conclusion?.toUpperCase()
+    const status = check.status?.toUpperCase()
+    const state = check.state?.toUpperCase()
+
+    if (
+      conclusion === 'FAILURE' ||
+      conclusion === 'TIMED_OUT' ||
+      conclusion === 'CANCELLED' ||
+      state === 'FAILURE' ||
+      state === 'ERROR'
+    ) {
+      hasFailure = true
+    } else if (
+      status === 'IN_PROGRESS' ||
+      status === 'QUEUED' ||
+      status === 'PENDING' ||
+      state === 'PENDING'
+    ) {
+      hasPending = true
+    }
+  }
+
+  if (hasFailure) {
+    return 'failure'
+  }
+  if (hasPending) {
+    return 'pending'
+  }
+  return 'success'
+}

--- a/src/main/ipc/github.ts
+++ b/src/main/ipc/github.ts
@@ -28,10 +28,13 @@ export function registerGitHubHandlers(store: Store): void {
     return listIssues(repoPath, args.limit)
   })
 
-  ipcMain.handle('gh:prChecks', (_event, args: { repoPath: string; prNumber: number }) => {
-    const repoPath = assertRegisteredRepoPath(args.repoPath, store)
-    return getPRChecks(repoPath, args.prNumber)
-  })
+  ipcMain.handle(
+    'gh:prChecks',
+    (_event, args: { repoPath: string; prNumber: number; branch?: string }) => {
+      const repoPath = assertRegisteredRepoPath(args.repoPath, store)
+      return getPRChecks(repoPath, args.prNumber, args.branch)
+    }
+  )
 
   ipcMain.handle(
     'gh:updatePRTitle',

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -55,7 +55,11 @@ type GhApi = {
   prForBranch: (args: { repoPath: string; branch: string }) => Promise<PRInfo | null>
   issue: (args: { repoPath: string; number: number }) => Promise<IssueInfo | null>
   listIssues: (args: { repoPath: string; limit?: number }) => Promise<IssueInfo[]>
-  prChecks: (args: { repoPath: string; prNumber: number }) => Promise<PRCheckDetail[]>
+  prChecks: (args: {
+    repoPath: string
+    prNumber: number
+    branch?: string
+  }) => Promise<PRCheckDetail[]>
   updatePRTitle: (args: { repoPath: string; prNumber: number; title: string }) => Promise<boolean>
 }
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -142,7 +142,7 @@ const api = {
     listIssues: (args: { repoPath: string; limit?: number }): Promise<unknown[]> =>
       ipcRenderer.invoke('gh:listIssues', args),
 
-    prChecks: (args: { repoPath: string; prNumber: number }): Promise<unknown[]> =>
+    prChecks: (args: { repoPath: string; prNumber: number; branch?: string }): Promise<unknown[]> =>
       ipcRenderer.invoke('gh:prChecks', args),
 
     updatePRTitle: (args: {

--- a/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
@@ -96,15 +96,16 @@ export default function ChecksPanel(): React.JSX.Element {
   const branch = worktree ? worktree.branch.replace(/^refs\/heads\//, '') : ''
   const prCacheKey = repo && branch ? `${repo.path}::${branch}` : ''
   const pr: PRInfo | null = prCacheKey ? (prCache[prCacheKey]?.data ?? null) : null
+  const prNumber = pr?.number ?? null
 
   // Fetch checks via cached store method
   const fetchChecks = useCallback(async () => {
-    if (!repo || !pr) {
+    if (!repo || !prNumber) {
       return
     }
     setChecksLoading(true)
     try {
-      const result = await fetchPRChecks(repo.path, pr.number)
+      const result = await fetchPRChecks(repo.path, prNumber, branch)
       setChecks(result)
 
       // Exponential backoff: if checks haven't changed, double the interval (cap 120s).
@@ -121,11 +122,11 @@ export default function ChecksPanel(): React.JSX.Element {
     } finally {
       setChecksLoading(false)
     }
-  }, [repo, pr, fetchPRChecks])
+  }, [repo, prNumber, branch, fetchPRChecks])
 
   // Fetch checks on mount + poll with exponential backoff
   useEffect(() => {
-    if (!pr) {
+    if (!prNumber) {
       setChecks([])
       return
     }
@@ -153,7 +154,7 @@ export default function ChecksPanel(): React.JSX.Element {
         clearTimeout(pollRef.current)
       }
     }
-  }, [fetchChecks, pr])
+  }, [fetchChecks, prNumber])
 
   const handleRefresh = useCallback(async () => {
     if (!repo || !branch) {

--- a/src/renderer/src/store/slices/github.ts
+++ b/src/renderer/src/store/slices/github.ts
@@ -41,7 +41,7 @@ export type GitHubSlice = {
   checksCache: Record<string, CacheEntry<PRCheckDetail[]>>
   fetchPRForBranch: (repoPath: string, branch: string) => Promise<PRInfo | null>
   fetchIssue: (repoPath: string, number: number) => Promise<IssueInfo | null>
-  fetchPRChecks: (repoPath: string, prNumber: number) => Promise<PRCheckDetail[]>
+  fetchPRChecks: (repoPath: string, prNumber: number, branch?: string) => Promise<PRCheckDetail[]>
   initGitHubCache: () => Promise<void>
   refreshAllGitHub: () => void
   refreshGitHubForWorktree: (worktreeId: string) => void
@@ -138,7 +138,7 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
     return request
   },
 
-  fetchPRChecks: async (repoPath, prNumber) => {
+  fetchPRChecks: async (repoPath, prNumber, branch?) => {
     const cacheKey = `${repoPath}::pr-checks::${prNumber}`
     const cached = get().checksCache[cacheKey]
     if (isFresh(cached, CHECKS_CACHE_TTL)) {
@@ -154,7 +154,8 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
       try {
         const checks = (await window.api.gh.prChecks({
           repoPath,
-          prNumber
+          prNumber,
+          branch
         })) as PRCheckDetail[]
         set((s) => ({
           checksCache: { ...s.checksCache, [cacheKey]: { data: checks, fetchedAt: Date.now() } }


### PR DESCRIPTION
## Problem

GitHub API rate limits are strict (5,000 requests/hour for authenticated users). Polling PR checks, issues, and status repeatedly burns through the quota quickly, especially with multiple worktrees.

## Solution

Use `gh api --cache` for conditional requests:

- **getIssue() / listIssues()**: Switch to REST API endpoints (`gh api repos/{owner}/{repo}/issues`) with 5-minute caching so 304 Not Modified responses don't count toward rate limits
- **getPRChecks()**: When branch is provided, use the check-runs REST endpoint (`gh api repos/{owner}/{repo}/commits/{branch}/check-runs`) with 1-minute caching instead of `gh pr checks`
- **Helper**: Add `mapIssueInfo()` to normalize both REST API and `gh` CLI response shapes into consistent `IssueInfo` format
- **Architecture**: Extract all mapping functions into separate `mappers.ts` to keep `client.ts` within 300-line lint limit

## Impact

- Reduces unnecessary API calls via transparent caching
- Backward compatible: falls back to `gh` CLI for non-GitHub remotes
- Improves polling efficiency: ChecksPanel now uses stable `prNumber` reference instead of full PR object to prevent unnecessary teardown/reset of backoff