### PR TITLE
fix(updater): show download progress toast and toast feedback for settings check

### DIFF
--- a/src/main/window/attach-main-window-services.ts
+++ b/src/main/window/attach-main-window-services.ts
@@ -5,7 +5,7 @@ import { registerRepoHandlers } from '../ipc/repos'
 import { registerWorktreeHandlers } from '../ipc/worktrees'
 import { registerPtyHandlers } from '../ipc/pty'
 import {
-  checkForUpdates,
+  checkForUpdatesFromMenu,
   downloadUpdate,
   getUpdateStatus,
   quitAndInstall,
@@ -57,7 +57,7 @@ export function registerUpdaterHandlers(): void {
 
   ipcMain.handle('updater:getStatus', () => getUpdateStatus())
   ipcMain.handle('updater:getVersion', () => app.getVersion())
-  ipcMain.handle('updater:check', () => checkForUpdates())
+  ipcMain.handle('updater:check', () => checkForUpdatesFromMenu())
   ipcMain.handle('updater:download', () => downloadUpdate())
   ipcMain.handle('updater:quitAndInstall', () => quitAndInstall())
 }

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -35,6 +35,7 @@ export function useIpcEvents(): void {
 
     let checkingToastId: string | number | undefined
     let availableToastId: string | number | undefined
+    const downloadToastId = 'update-download-progress'
     unsubs.push(
       window.api.updater.onStatus((raw) => {
         const status = raw as UpdateStatus
@@ -65,11 +66,16 @@ export function useIpcEvents(): void {
             toast.dismiss(availableToastId)
             availableToastId = undefined
           }
+          toast.loading(`Downloading v${status.version}… ${status.percent}%`, {
+            id: downloadToastId,
+            duration: Infinity
+          })
         } else if (status.state === 'downloaded') {
           if (availableToastId) {
             toast.dismiss(availableToastId)
             availableToastId = undefined
           }
+          toast.dismiss(downloadToastId)
           toast.success(`Version ${status.version} is ready to install.`, {
             duration: Infinity,
             action: {
@@ -77,12 +83,15 @@ export function useIpcEvents(): void {
               onClick: () => window.api.updater.quitAndInstall()
             }
           })
-        } else if (status.state === 'error' && 'userInitiated' in status && status.userInitiated) {
-          toast.error('Could not check for updates.', {
-            description: status.message,
-            id: checkingToastId
-          })
-          checkingToastId = undefined
+        } else if (status.state === 'error') {
+          toast.dismiss(downloadToastId)
+          if ('userInitiated' in status && status.userInitiated) {
+            toast.error('Could not check for updates.', {
+              description: status.message,
+              id: checkingToastId
+            })
+            checkingToastId = undefined
+          }
         }
       })
     )


### PR DESCRIPTION
## Summary
- Show a real-time download progress toast in the bottom-right corner during update downloads (e.g. "Downloading v1.0.51… 45%")
- Make the Settings "Check for Updates" button use the user-initiated flow so it shows toast notifications (checking, result, errors) — same as the menu "Check for Updates"
- Properly dismiss the download toast on completion or error

## Test plan
- [x] Build succeeds
- [x] Validated via Electron CDP: "Check for Updates" in Settings shows toast feedback
- [ ] When a real update is available, clicking "Install" shows a progress toast that updates in-place
- [ ] Toast dismisses when download completes, replaced by "ready to install" toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)