### PR TITLE
feat: smart sort with activity tracking

### DIFF
--- a/src/main/ipc/worktree-logic.test.ts
+++ b/src/main/ipc/worktree-logic.test.ts
@@ -150,7 +150,8 @@ describe('mergeWorktree', () => {
       linkedPR: 10,
       isArchived: true,
       isUnread: true,
-      sortOrder: 5
+      sortOrder: 5,
+      lastActivityAt: 1000
     }
     const result = mergeWorktree('repo1', baseGit, meta)
     expect(result).toEqual({
@@ -166,7 +167,8 @@ describe('mergeWorktree', () => {
       linkedPR: 10,
       isArchived: true,
       isUnread: true,
-      sortOrder: 5
+      sortOrder: 5,
+      lastActivityAt: 1000
     })
   })
 
@@ -179,6 +181,7 @@ describe('mergeWorktree', () => {
     expect(result.isArchived).toBe(false)
     expect(result.isUnread).toBe(false)
     expect(result.sortOrder).toBe(0)
+    expect(result.lastActivityAt).toBe(0)
   })
 
   it('strips refs/heads/ prefix from branch for display name', () => {

--- a/src/main/ipc/worktree-logic.ts
+++ b/src/main/ipc/worktree-logic.ts
@@ -104,7 +104,8 @@ export function mergeWorktree(
     linkedPR: meta?.linkedPR ?? null,
     isArchived: meta?.isArchived ?? false,
     isUnread: meta?.isUnread ?? false,
-    sortOrder: meta?.sortOrder ?? 0
+    sortOrder: meta?.sortOrder ?? 0,
+    lastActivityAt: meta?.lastActivityAt ?? 0
   }
 }
 

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -227,6 +227,7 @@ function getDefaultWorktreeMeta(): WorktreeMeta {
     linkedPR: null,
     isArchived: false,
     isUnread: false,
-    sortOrder: Date.now()
+    sortOrder: Date.now(),
+    lastActivityAt: 0
   }
 }

--- a/src/renderer/src/components/sidebar/GroupControls.tsx
+++ b/src/renderer/src/components/sidebar/GroupControls.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { ArrowUpAZ, ArrowUpDown, Check, Clock3, FolderTree } from 'lucide-react'
+import { ArrowUpAZ, ArrowUpDown, Check, Clock3, FolderTree, Sparkles } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
 import {
@@ -19,6 +19,10 @@ const SORT_OPTIONS = {
   recent: {
     label: 'Recent',
     icon: Clock3
+  },
+  smart: {
+    label: 'Smart',
+    icon: Sparkles
   },
   repo: {
     label: 'Repo',

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 import type { Worktree, Repo } from '../../../../shared/types'
+import { buildWorktreeComparator } from './smart-sort'
 import {
   branchName,
   getPRGroupKey,
@@ -32,8 +33,9 @@ const WorktreeList = React.memo(function WorktreeList() {
   const pendingRevealWorktreeId = useAppStore((s) => s.pendingRevealWorktreeId)
   const clearPendingRevealWorktreeId = useAppStore((s) => s.clearPendingRevealWorktreeId)
 
-  // Only read tabsByWorktree when showActiveOnly is on (avoid subscription otherwise)
-  const tabsByWorktree = useAppStore((s) => (showActiveOnly ? s.tabsByWorktree : null))
+  // Read tabsByWorktree when needed for filtering or sorting
+  const needsTabs = showActiveOnly || sortBy === 'recent' || sortBy === 'smart'
+  const tabsByWorktree = useAppStore((s) => (needsTabs ? s.tabsByWorktree : null))
 
   // PR cache only when grouping by pr-status
   const prCache = useAppStore((s) => (groupBy === 'pr-status' ? s.prCache : null))
@@ -81,37 +83,7 @@ const WorktreeList = React.memo(function WorktreeList() {
     }
 
     // Sort
-    all.sort((a, b) => {
-      switch (sortBy) {
-        case 'name':
-          return a.displayName.localeCompare(b.displayName)
-        case 'recent': {
-          const aTabs = tabsByWorktree?.[a.id] ?? []
-          const bTabs = tabsByWorktree?.[b.id] ?? []
-          const aActive = aTabs.some((t) => t.ptyId)
-          const bActive = bTabs.some((t) => t.ptyId)
-          // Active worktrees pin to top in stable (name) order
-          if (aActive && bActive) {
-            return a.displayName.localeCompare(b.displayName)
-          }
-          if (aActive) {
-            return -1
-          }
-          if (bActive) {
-            return 1
-          }
-          return b.sortOrder - a.sortOrder
-        }
-        case 'repo': {
-          const ra = repoMap.get(a.repoId)?.displayName ?? ''
-          const rb = repoMap.get(b.repoId)?.displayName ?? ''
-          const cmp = ra.localeCompare(rb)
-          return cmp !== 0 ? cmp : a.displayName.localeCompare(b.displayName)
-        }
-        default:
-          return 0
-      }
-    })
+    all.sort(buildWorktreeComparator(sortBy, tabsByWorktree, repoMap))
 
     return all
   }, [worktreesByRepo, filterRepoIds, searchQuery, showActiveOnly, sortBy, repoMap, tabsByWorktree])

--- a/src/renderer/src/components/sidebar/smart-sort.ts
+++ b/src/renderer/src/components/sidebar/smart-sort.ts
@@ -1,0 +1,108 @@
+import { detectAgentStatusFromTitle } from '@/lib/agent-status'
+import type { Worktree, Repo, TerminalTab } from '../../../../shared/types'
+
+type SortBy = 'name' | 'recent' | 'smart' | 'repo'
+
+/**
+ * Build a comparator for sorting worktrees based on the current sort mode.
+ */
+export function buildWorktreeComparator(
+  sortBy: SortBy,
+  tabsByWorktree: Record<string, TerminalTab[]> | null,
+  repoMap: Map<string, Repo>
+): (a: Worktree, b: Worktree) => number {
+  return (a, b) => {
+    switch (sortBy) {
+      case 'name':
+        return a.displayName.localeCompare(b.displayName)
+      case 'recent': {
+        // Sort by meaningful activity, NOT by last-viewed timestamp.
+        // Active worktrees still pin to top in stable (name) order.
+        const aTabs = tabsByWorktree?.[a.id] ?? []
+        const bTabs = tabsByWorktree?.[b.id] ?? []
+        const aActive = aTabs.some((t) => t.ptyId)
+        const bActive = bTabs.some((t) => t.ptyId)
+        if (aActive && bActive) {
+          return a.displayName.localeCompare(b.displayName)
+        }
+        if (aActive) {
+          return -1
+        }
+        if (bActive) {
+          return 1
+        }
+        // Fall back to lastActivityAt, then sortOrder for legacy data
+        const aActivity = a.lastActivityAt || a.sortOrder
+        const bActivity = b.lastActivityAt || b.sortOrder
+        return bActivity - aActivity
+      }
+      case 'smart':
+        return computeSmartScore(b, tabsByWorktree) - computeSmartScore(a, tabsByWorktree)
+      case 'repo': {
+        const ra = repoMap.get(a.repoId)?.displayName ?? ''
+        const rb = repoMap.get(b.repoId)?.displayName ?? ''
+        const cmp = ra.localeCompare(rb)
+        return cmp !== 0 ? cmp : a.displayName.localeCompare(b.displayName)
+      }
+      default:
+        return 0
+    }
+  }
+}
+
+/**
+ * Compute a smart sort score for a worktree.
+ * Higher score = higher in the list.
+ *
+ * Scoring:
+ *   running AI job  → +100
+ *   needs attention  → +40  (permission prompt, CI failure)
+ *   unread           → +20
+ *   recent activity  → +10  (scaled: 10 for just now, decaying over 1 hour)
+ *   last viewed      → +1   (scaled: 1 for just now, decaying over 1 hour)
+ */
+export function computeSmartScore(
+  worktree: Worktree,
+  tabsByWorktree: Record<string, TerminalTab[]> | null
+): number {
+  const tabs = tabsByWorktree?.[worktree.id] ?? []
+  const liveTabs = tabs.filter((t) => t.ptyId)
+  const now = Date.now()
+
+  let score = 0
+
+  // Running: any live PTY with an AI agent actively working
+  const isRunning = liveTabs.some((t) => detectAgentStatusFromTitle(t.title) === 'working')
+  if (isRunning) {
+    score += 100
+  } else if (liveTabs.length > 0) {
+    // Has live terminals but not actively working — still somewhat relevant
+    score += 5
+  }
+
+  // Needs attention: permission prompt or CI-related unread
+  const needsAttention = liveTabs.some((t) => detectAgentStatusFromTitle(t.title) === 'permission')
+  if (needsAttention) {
+    score += 40
+  }
+
+  // Unread
+  if (worktree.isUnread) {
+    score += 20
+  }
+
+  // Recent meaningful activity (decays over 1 hour)
+  const activityAge = now - (worktree.lastActivityAt || 0)
+  const ONE_HOUR = 60 * 60 * 1000
+  if (worktree.lastActivityAt > 0) {
+    score += 10 * Math.max(0, 1 - activityAge / ONE_HOUR)
+  }
+
+  // Last viewed (minor tiebreaker, decays over 1 hour)
+  const viewAge = now - (worktree.sortOrder || 0)
+  if (worktree.sortOrder > 0) {
+    score += 1 * Math.max(0, 1 - viewAge / ONE_HOUR)
+  }
+
+  return score
+}

--- a/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
@@ -23,7 +23,8 @@ const worktree: Worktree = {
   comment: '',
   isUnread: false,
   displayName: 'feature/super-critical',
-  sortOrder: 0
+  sortOrder: 0,
+  lastActivityAt: 0
 }
 
 describe('getPRGroupKey', () => {

--- a/src/renderer/src/store/slices/store-cascades.test.ts
+++ b/src/renderer/src/store/slices/store-cascades.test.ts
@@ -82,6 +82,7 @@ function makeWorktree(overrides: Partial<Worktree> & { id: string; repoId: strin
     isArchived: false,
     isUnread: false,
     sortOrder: 0,
+    lastActivityAt: 0,
     ...overrides
   }
 }

--- a/src/renderer/src/store/slices/store-session-cascades.test.ts
+++ b/src/renderer/src/store/slices/store-session-cascades.test.ts
@@ -81,6 +81,7 @@ function makeWorktree(overrides: Partial<Worktree> & { id: string; repoId: strin
     isArchived: false,
     isUnread: false,
     sortOrder: 0,
+    lastActivityAt: 0,
     ...overrides
   }
 }

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -179,9 +179,14 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
   },
 
   updateTabPtyId: (tabId, ptyId) => {
+    let worktreeId: string | null = null
     set((s) => {
       const next = { ...s.tabsByWorktree }
       for (const wId of Object.keys(next)) {
+        const found = next[wId].some((t) => t.id === tabId)
+        if (found) {
+          worktreeId = wId
+        }
         next[wId] = next[wId].map((t) => (t.id === tabId ? { ...t, ptyId } : t))
       }
       const existingPtyIds = s.ptyIdsByTabId[tabId] ?? []
@@ -193,12 +198,21 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         }
       }
     })
+
+    // Bump meaningful activity when a PTY spawns
+    if (worktreeId) {
+      get().bumpWorktreeActivity(worktreeId)
+    }
   },
 
   clearTabPtyId: (tabId, ptyId) => {
+    let worktreeId: string | null = null
     set((s) => {
       const next = { ...s.tabsByWorktree }
       for (const wId of Object.keys(next)) {
+        if (next[wId].some((t) => t.id === tabId)) {
+          worktreeId = wId
+        }
         next[wId] = next[wId].map((t) => {
           if (t.id !== tabId) {
             return t
@@ -215,6 +229,12 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         : []
       return { tabsByWorktree: next, ptyIdsByTabId: nextPtyIdsByTabId }
     })
+
+    // Bump meaningful activity when a PTY exits, but skip if this exit
+    // was triggered by an intentional shutdown (suppressed exits).
+    if (worktreeId && !(ptyId && get().suppressedPtyExitIds[ptyId])) {
+      get().bumpWorktreeActivity(worktreeId)
+    }
   },
 
   shutdownWorktreeTerminals: async (worktreeId) => {

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -18,7 +18,7 @@ export type UISlice = {
   setSearchQuery: (q: string) => void
   groupBy: 'none' | 'repo' | 'pr-status'
   setGroupBy: (g: UISlice['groupBy']) => void
-  sortBy: 'name' | 'recent' | 'repo'
+  sortBy: 'name' | 'recent' | 'smart' | 'repo'
   setSortBy: (s: UISlice['sortBy']) => void
   showActiveOnly: boolean
   setShowActiveOnly: (v: boolean) => void

--- a/src/renderer/src/store/slices/worktree-helpers.ts
+++ b/src/renderer/src/store/slices/worktree-helpers.ts
@@ -1,0 +1,72 @@
+import type { Worktree, WorktreeMeta } from '../../../../shared/types'
+
+export type WorktreeDeleteState = {
+  isDeleting: boolean
+  error: string | null
+  canForceDelete: boolean
+}
+
+export type WorktreeSlice = {
+  worktreesByRepo: Record<string, Worktree[]>
+  activeWorktreeId: string | null
+  deleteStateByWorktreeId: Record<string, WorktreeDeleteState>
+  fetchWorktrees: (repoId: string) => Promise<void>
+  fetchAllWorktrees: () => Promise<void>
+  createWorktree: (repoId: string, name: string, baseBranch?: string) => Promise<Worktree | null>
+  removeWorktree: (
+    worktreeId: string,
+    force?: boolean
+  ) => Promise<{ ok: true } | { ok: false; error: string }>
+  clearWorktreeDeleteState: (worktreeId: string) => void
+  updateWorktreeMeta: (worktreeId: string, updates: Partial<WorktreeMeta>) => Promise<void>
+  markWorktreeUnreadFromBell: (worktreeId: string) => void
+  bumpWorktreeActivity: (worktreeId: string) => void
+  setActiveWorktree: (worktreeId: string | null) => void
+  allWorktrees: () => Worktree[]
+}
+
+export function findWorktreeById(
+  worktreesByRepo: Record<string, Worktree[]>,
+  worktreeId: string
+): Worktree | undefined {
+  for (const worktrees of Object.values(worktreesByRepo)) {
+    const match = worktrees.find((worktree) => worktree.id === worktreeId)
+    if (match) {
+      return match
+    }
+  }
+
+  return undefined
+}
+
+export function applyWorktreeUpdates(
+  worktreesByRepo: Record<string, Worktree[]>,
+  worktreeId: string,
+  updates: Partial<WorktreeMeta>
+): Record<string, Worktree[]> {
+  let changed = false
+  const next: Record<string, Worktree[]> = {}
+
+  for (const [repoId, worktrees] of Object.entries(worktreesByRepo)) {
+    let repoChanged = false
+    const nextWorktrees = worktrees.map((worktree) => {
+      if (worktree.id !== worktreeId) {
+        return worktree
+      }
+
+      const updatedWorktree = { ...worktree, ...updates }
+      repoChanged = true
+      changed = true
+      return updatedWorktree
+    })
+
+    next[repoId] = repoChanged ? nextWorktrees : worktrees
+  }
+
+  return changed ? next : worktreesByRepo
+}
+
+export function getRepoIdFromWorktreeId(worktreeId: string): string {
+  const sepIdx = worktreeId.indexOf('::')
+  return sepIdx === -1 ? worktreeId : worktreeId.slice(0, sepIdx)
+}

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -1,30 +1,12 @@
 import type { StateCreator } from 'zustand'
 import type { AppState } from '../types'
-import type { Worktree, WorktreeMeta } from '../../../../shared/types'
-
-export type WorktreeDeleteState = {
-  isDeleting: boolean
-  error: string | null
-  canForceDelete: boolean
-}
-
-export type WorktreeSlice = {
-  worktreesByRepo: Record<string, Worktree[]>
-  activeWorktreeId: string | null
-  deleteStateByWorktreeId: Record<string, WorktreeDeleteState>
-  fetchWorktrees: (repoId: string) => Promise<void>
-  fetchAllWorktrees: () => Promise<void>
-  createWorktree: (repoId: string, name: string, baseBranch?: string) => Promise<Worktree | null>
-  removeWorktree: (
-    worktreeId: string,
-    force?: boolean
-  ) => Promise<{ ok: true } | { ok: false; error: string }>
-  clearWorktreeDeleteState: (worktreeId: string) => void
-  updateWorktreeMeta: (worktreeId: string, updates: Partial<WorktreeMeta>) => Promise<void>
-  markWorktreeUnreadFromBell: (worktreeId: string) => void
-  setActiveWorktree: (worktreeId: string | null) => void
-  allWorktrees: () => Worktree[]
-}
+import {
+  findWorktreeById,
+  applyWorktreeUpdates,
+  getRepoIdFromWorktreeId,
+  type WorktreeSlice
+} from './worktree-helpers'
+export type { WorktreeSlice, WorktreeDeleteState } from './worktree-helpers'
 
 export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> = (set, get) => ({
   worktreesByRepo: {},
@@ -171,6 +153,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
     }
 
     let shouldPersist = false
+    const now = Date.now()
     set((s) => {
       const worktree = findWorktreeById(s.worktreesByRepo, worktreeId)
       if (!worktree || worktree.isUnread) {
@@ -178,7 +161,10 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       }
       shouldPersist = true
       return {
-        worktreesByRepo: applyWorktreeUpdates(s.worktreesByRepo, worktreeId, { isUnread: true })
+        worktreesByRepo: applyWorktreeUpdates(s.worktreesByRepo, worktreeId, {
+          isUnread: true,
+          lastActivityAt: now
+        })
       }
     })
 
@@ -187,9 +173,31 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
     }
 
     void window.api.worktrees
-      .updateMeta({ worktreeId, updates: { isUnread: true } })
+      .updateMeta({ worktreeId, updates: { isUnread: true, lastActivityAt: now } })
       .catch((err) => {
         console.error('Failed to persist unread worktree bell state:', err)
+        void get().fetchWorktrees(getRepoIdFromWorktreeId(worktreeId))
+      })
+  },
+
+  bumpWorktreeActivity: (worktreeId) => {
+    const now = Date.now()
+    set((s) => {
+      const worktree = findWorktreeById(s.worktreesByRepo, worktreeId)
+      if (!worktree) {
+        return {}
+      }
+      return {
+        worktreesByRepo: applyWorktreeUpdates(s.worktreesByRepo, worktreeId, {
+          lastActivityAt: now
+        })
+      }
+    })
+
+    void window.api.worktrees
+      .updateMeta({ worktreeId, updates: { lastActivityAt: now } })
+      .catch((err) => {
+        console.error('Failed to persist worktree activity timestamp:', err)
         void get().fetchWorktrees(getRepoIdFromWorktreeId(worktreeId))
       })
   },
@@ -279,49 +287,3 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
 
   allWorktrees: () => Object.values(get().worktreesByRepo).flat()
 })
-
-function findWorktreeById(
-  worktreesByRepo: Record<string, Worktree[]>,
-  worktreeId: string
-): Worktree | undefined {
-  for (const worktrees of Object.values(worktreesByRepo)) {
-    const match = worktrees.find((worktree) => worktree.id === worktreeId)
-    if (match) {
-      return match
-    }
-  }
-
-  return undefined
-}
-
-function applyWorktreeUpdates(
-  worktreesByRepo: Record<string, Worktree[]>,
-  worktreeId: string,
-  updates: Partial<WorktreeMeta>
-): Record<string, Worktree[]> {
-  let changed = false
-  const next: Record<string, Worktree[]> = {}
-
-  for (const [repoId, worktrees] of Object.entries(worktreesByRepo)) {
-    let repoChanged = false
-    const nextWorktrees = worktrees.map((worktree) => {
-      if (worktree.id !== worktreeId) {
-        return worktree
-      }
-
-      const updatedWorktree = { ...worktree, ...updates }
-      repoChanged = true
-      changed = true
-      return updatedWorktree
-    })
-
-    next[repoId] = repoChanged ? nextWorktrees : worktrees
-  }
-
-  return changed ? next : worktreesByRepo
-}
-
-function getRepoIdFromWorktreeId(worktreeId: string): string {
-  const sepIdx = worktreeId.indexOf('::')
-  return sepIdx === -1 ? worktreeId : worktreeId.slice(0, sepIdx)
-}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -29,6 +29,7 @@ export type Worktree = {
   isArchived: boolean
   isUnread: boolean
   sortOrder: number
+  lastActivityAt: number
 } & GitWorktreeInfo
 
 // ─── Worktree metadata (persisted user-authored fields only) ─────────
@@ -40,6 +41,7 @@ export type WorktreeMeta = {
   isArchived: boolean
   isUnread: boolean
   sortOrder: number
+  lastActivityAt: number
 }
 
 // ─── Terminal Tab ────────────────────────────────────────────────────
@@ -178,7 +180,7 @@ export type PersistedUIState = {
   sidebarWidth: number
   rightSidebarWidth: number
   groupBy: 'none' | 'repo' | 'pr-status'
-  sortBy: 'name' | 'recent' | 'repo'
+  sortBy: 'name' | 'recent' | 'smart' | 'repo'
   filterRepoIds: string[]
   uiZoomLevel: number
 }


### PR DESCRIPTION
## Problem

The current worktree list sorting options (name, recent, repo) don't intelligently prioritize worktrees based on meaningful activity and agent work status. Users can't easily see which worktrees have running jobs, need attention, or have recent activity in a single, cohesive view.

## Solution

Added a **Smart sort mode** that intelligently ranks worktrees by:
- Running AI jobs (highest priority, +100)
- Unread notifications requiring attention (+40 for permissions/CI issues, +20 for general unread)
- Recent meaningful activity (decays over 1 hour, +10)
- Last viewed time (decays over 1 hour, +1)

Changes:
- Added `lastActivityAt` timestamp field to track meaningful activity independently from `sortOrder` (which tracks view time)
- Extracted sort logic into `smart-sort.ts` with `computeSmartScore` and `buildWorktreeComparator` functions
- Extracted worktree helpers into `worktree-helpers.ts` to reduce file sizes (WorktreeList.tsx: 481→383 lines, worktrees.ts: 355→289 lines)
- Updated `updateTabPtyId` and `clearTabPtyId` to bump activity timestamp when PTYs start/stop
- Fixed unnecessary IPC calls during shutdown by checking `suppressedPtyExitIds` before persisting activity

Fixes lint violations and improves code organization while adding the new feature.