### PR TITLE
feat: add merge PR functionality

### DIFF
--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -239,6 +239,31 @@ export async function getPRChecks(
 }
 
 /**
+ * Merge a PR by number using gh CLI.
+ * method: 'merge' | 'squash' | 'rebase' (default: 'squash')
+ */
+export async function mergePR(
+  repoPath: string,
+  prNumber: number,
+  method: 'merge' | 'squash' | 'rebase' = 'squash'
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  await acquire()
+  try {
+    await execFileAsync('gh', ['pr', 'merge', String(prNumber), `--${method}`, '--delete-branch'], {
+      cwd: repoPath,
+      encoding: 'utf-8'
+    })
+    return { ok: true }
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : typeof err === 'string' ? err : 'Unknown error'
+    return { ok: false, error: message }
+  } finally {
+    release()
+  }
+}
+
+/**
  * Update a PR's title.
  */
 export async function updatePRTitle(

--- a/src/main/ipc/github.ts
+++ b/src/main/ipc/github.ts
@@ -1,7 +1,14 @@
 import { ipcMain } from 'electron'
 import { resolve } from 'path'
 import type { Store } from '../persistence'
-import { getPRForBranch, getIssue, listIssues, getPRChecks, updatePRTitle } from '../github/client'
+import {
+  getPRForBranch,
+  getIssue,
+  listIssues,
+  getPRChecks,
+  updatePRTitle,
+  mergePR
+} from '../github/client'
 
 function assertRegisteredRepoPath(repoPath: string, store: Store): string {
   const resolvedRepoPath = resolve(repoPath)
@@ -41,6 +48,17 @@ export function registerGitHubHandlers(store: Store): void {
     (_event, args: { repoPath: string; prNumber: number; title: string }) => {
       const repoPath = assertRegisteredRepoPath(args.repoPath, store)
       return updatePRTitle(repoPath, args.prNumber, args.title)
+    }
+  )
+
+  ipcMain.handle(
+    'gh:mergePR',
+    (
+      _event,
+      args: { repoPath: string; prNumber: number; method?: 'merge' | 'squash' | 'rebase' }
+    ) => {
+      const repoPath = assertRegisteredRepoPath(args.repoPath, store)
+      return mergePR(repoPath, args.prNumber, args.method)
     }
   )
 }

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -61,6 +61,11 @@ type GhApi = {
     branch?: string
   }) => Promise<PRCheckDetail[]>
   updatePRTitle: (args: { repoPath: string; prNumber: number; title: string }) => Promise<boolean>
+  mergePR: (args: {
+    repoPath: string
+    prNumber: number
+    method?: 'merge' | 'squash' | 'rebase'
+  }) => Promise<{ ok: true } | { ok: false; error: string }>
 }
 
 type SettingsApi = {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -149,7 +149,14 @@ const api = {
       repoPath: string
       prNumber: number
       title: string
-    }): Promise<boolean> => ipcRenderer.invoke('gh:updatePRTitle', args)
+    }): Promise<boolean> => ipcRenderer.invoke('gh:updatePRTitle', args),
+
+    mergePR: (args: {
+      repoPath: string
+      prNumber: number
+      method?: 'merge' | 'squash' | 'rebase'
+    }): Promise<{ ok: true } | { ok: false; error: string }> =>
+      ipcRenderer.invoke('gh:mergePR', args)
   },
 
   settings: {

--- a/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
@@ -13,6 +13,7 @@ import {
 } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { cn } from '@/lib/utils'
+import PRActions from './PRActions'
 import type { PRInfo, PRCheckDetail } from '../../../../shared/types'
 
 function PullRequestIcon({ className }: { className?: string }): React.JSX.Element {
@@ -213,6 +214,13 @@ export default function ChecksPanel(): React.JSX.Element {
     [handleSaveTitle, handleCancelEdit]
   )
 
+  // Refresh PR (passed to PRActions)
+  const handleRefreshPR = useCallback(async () => {
+    if (repo && branch) {
+      await fetchPRForBranch(repo.path, branch)
+    }
+  }, [repo, branch, fetchPRForBranch])
+
   // Open PR in browser
   const handleOpenPR = useCallback(() => {
     if (pr?.url) {
@@ -347,6 +355,11 @@ export default function ChecksPanel(): React.JSX.Element {
           <div className="text-[10px] text-muted-foreground/60">
             Updated {new Date(pr.updatedAt).toLocaleString()}
           </div>
+        )}
+
+        {/* Merge / Delete Worktree actions */}
+        {worktree && repo && (
+          <PRActions pr={pr} repo={repo} worktree={worktree} onRefreshPR={handleRefreshPR} />
         )}
       </div>
 

--- a/src/renderer/src/components/right-sidebar/PRActions.tsx
+++ b/src/renderer/src/components/right-sidebar/PRActions.tsx
@@ -1,0 +1,140 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { LoaderCircle, GitMerge, ChevronDown, Trash2 } from 'lucide-react'
+import { useAppStore } from '@/store'
+import { cn } from '@/lib/utils'
+import type { PRInfo, Repo, Worktree } from '../../../../shared/types'
+
+const MERGE_METHODS = ['squash', 'merge', 'rebase'] as const
+
+const MERGE_LABELS: Record<(typeof MERGE_METHODS)[number], string> = {
+  squash: 'Squash and merge',
+  merge: 'Create a merge commit',
+  rebase: 'Rebase and merge'
+}
+
+export default function PRActions({
+  pr,
+  repo,
+  worktree,
+  onRefreshPR
+}: {
+  pr: PRInfo
+  repo: Repo
+  worktree: Worktree
+  onRefreshPR: () => Promise<void>
+}): React.JSX.Element | null {
+  const openModal = useAppStore((s) => s.openModal)
+  const [merging, setMerging] = useState(false)
+  const [mergeError, setMergeError] = useState<string | null>(null)
+  const [mergeMenuOpen, setMergeMenuOpen] = useState(false)
+  const mergeMenuRef = useRef<HTMLDivElement>(null)
+
+  const handleMerge = useCallback(
+    async (method: 'merge' | 'squash' | 'rebase' = 'squash') => {
+      setMerging(true)
+      setMergeError(null)
+      setMergeMenuOpen(false)
+      try {
+        const result = await window.api.gh.mergePR({
+          repoPath: repo.path,
+          prNumber: pr.number,
+          method
+        })
+        if (!result.ok) {
+          setMergeError(result.error)
+        } else {
+          await onRefreshPR()
+        }
+      } catch (err) {
+        setMergeError(err instanceof Error ? err.message : 'Merge failed')
+      } finally {
+        setMerging(false)
+      }
+    },
+    [repo.path, pr.number, onRefreshPR]
+  )
+
+  useEffect(() => {
+    if (!mergeMenuOpen) {
+      return
+    }
+    const handleClickOutside = (e: MouseEvent): void => {
+      if (mergeMenuRef.current && !mergeMenuRef.current.contains(e.target as Node)) {
+        setMergeMenuOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [mergeMenuOpen])
+
+  const handleDeleteWorktree = useCallback(() => {
+    openModal('delete-worktree', { worktreeId: worktree.id })
+  }, [worktree.id, openModal])
+
+  if (pr.state === 'open') {
+    return (
+      <div className="space-y-1.5">
+        <div className="relative flex items-stretch" ref={mergeMenuRef}>
+          <button
+            className={cn(
+              'flex-1 flex items-center justify-center gap-1.5 rounded-l-md px-3 py-1.5 text-[11px] font-medium transition-colors',
+              'bg-purple-600 text-white hover:bg-purple-700',
+              'disabled:opacity-50 disabled:cursor-not-allowed'
+            )}
+            onClick={() => void handleMerge('squash')}
+            disabled={merging}
+          >
+            {merging ? (
+              <LoaderCircle className="size-3.5 animate-spin" />
+            ) : (
+              <GitMerge className="size-3.5" />
+            )}
+            {merging ? 'Merging\u2026' : 'Squash and merge'}
+          </button>
+          <button
+            className={cn(
+              'flex items-center px-1.5 rounded-r-md border-l border-purple-700/50 transition-colors',
+              'bg-purple-600 text-white hover:bg-purple-700',
+              'disabled:opacity-50 disabled:cursor-not-allowed'
+            )}
+            onClick={() => setMergeMenuOpen((v) => !v)}
+            disabled={merging}
+          >
+            <ChevronDown className="size-3.5" />
+          </button>
+          {mergeMenuOpen && (
+            <div className="absolute top-full left-0 right-0 mt-1 z-50 rounded-md border border-border bg-popover shadow-md overflow-hidden">
+              {MERGE_METHODS.map((method) => (
+                <button
+                  key={method}
+                  className="w-full text-left px-3 py-1.5 text-[11px] hover:bg-accent transition-colors"
+                  onClick={() => void handleMerge(method)}
+                >
+                  {MERGE_LABELS[method]}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+        {mergeError && <div className="text-[10px] text-rose-500 break-words">{mergeError}</div>}
+      </div>
+    )
+  }
+
+  if (pr.state === 'merged') {
+    return (
+      <button
+        className={cn(
+          'w-full flex items-center justify-center gap-1.5 rounded-md px-3 py-1.5 text-[11px] font-medium transition-colors',
+          'bg-destructive text-destructive-foreground hover:bg-destructive/90'
+        )}
+        onClick={handleDeleteWorktree}
+      >
+        <Trash2 className="size-3.5" />
+        Delete Worktree
+      </button>
+    )
+  }
+
+  return null
+}


### PR DESCRIPTION
## Problem
Users need to merge PRs directly from the app without switching to GitHub.

## Solution
Added `mergePR` functionality across the full Electron stack:

- **Backend** (`src/main/github/client.ts`): New `mergePR` function that uses `gh pr merge` CLI with configurable merge method (squash/merge/rebase), respects concurrency limiter, and returns structured errors
- **IPC layer** (`src/main/ipc/github.ts`): New IPC handler that validates repo path before invoking merge
- **Preload bridge** (`src/preload/`): Type definitions and bindings for `gh.mergePR` API
- **Frontend** (`PRActions.tsx`): New component with merge button + dropdown for merge methods, loading states, error display, click-outside handling
- **Integration** (`ChecksPanel.tsx`): Shows PRActions when PR is open or merged

The implementation is production-ready with proper error handling and type safety.