### PR TITLE
fix: force-refresh PR status and checks on manual refresh

### DIFF
--- a/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
@@ -29,6 +29,7 @@ export default function ChecksPanel(): React.JSX.Element {
   const [checks, setChecks] = useState<PRCheckDetail[]>([])
   const [checksLoading, setChecksLoading] = useState(false)
   const [emptyRefreshing, setEmptyRefreshing] = useState(false)
+  const [isRefreshing, setIsRefreshing] = useState(false)
   const [editingTitle, setEditingTitle] = useState(false)
   const [titleDraft, setTitleDraft] = useState('')
   const [titleSaving, setTitleSaving] = useState(false)
@@ -65,30 +66,39 @@ export default function ChecksPanel(): React.JSX.Element {
   }, [repo, branch, fetchPRForBranch])
 
   // Fetch checks via cached store method
-  const fetchChecks = useCallback(async () => {
-    if (!repo || !prNumber) {
-      return
-    }
-    setChecksLoading(true)
-    try {
-      const result = await fetchPRChecks(repo.path, prNumber, branch)
-      setChecks(result)
+  const fetchChecks = useCallback(
+    async ({
+      force = false,
+      prNumberOverride
+    }: { force?: boolean; prNumberOverride?: number | null } = {}) => {
+      const targetPRNumber = prNumberOverride ?? prNumber
+      if (!repo || !targetPRNumber) {
+        return
+      }
+      setChecksLoading(true)
+      try {
+        const result = await fetchPRChecks(repo.path, targetPRNumber, branch, { force })
+        setChecks(result)
 
-      // Exponential backoff: if checks haven't changed, double the interval (cap 120s).
-      // If they changed, reset to 30s.
-      const signature = JSON.stringify(result.map((c) => `${c.name}:${c.status}:${c.conclusion}`))
-      pollIntervalRef.current =
-        signature === prevChecksRef.current
-          ? Math.min(pollIntervalRef.current * 2, 120_000)
-          : 30_000
-      prevChecksRef.current = signature
-    } catch (err) {
-      console.warn('Failed to fetch PR checks:', err)
-      setChecks([])
-    } finally {
-      setChecksLoading(false)
-    }
-  }, [repo, prNumber, branch, fetchPRChecks])
+        // Exponential backoff: if checks haven't changed, double the interval (cap 120s).
+        // If they changed, reset to 30s.
+        const signature = JSON.stringify(
+          result.map((c) => `${c.name}:${c.status}:${c.conclusion}`)
+        )
+        pollIntervalRef.current =
+          signature === prevChecksRef.current
+            ? Math.min(pollIntervalRef.current * 2, 120_000)
+            : 30_000
+        prevChecksRef.current = signature
+      } catch (err) {
+        console.warn('Failed to fetch PR checks:', err)
+        setChecks([])
+      } finally {
+        setChecksLoading(false)
+      }
+    },
+    [repo, prNumber, branch, fetchPRChecks]
+  )
 
   // Fetch checks on mount + poll with exponential backoff
   useEffect(() => {
@@ -126,9 +136,17 @@ export default function ChecksPanel(): React.JSX.Element {
     if (!repo || !branch) {
       return
     }
-    // Refresh PR data + checks
-    await fetchPRForBranch(repo.path, branch)
-    await fetchChecks()
+    setIsRefreshing(true)
+    try {
+      const refreshedPR = await fetchPRForBranch(repo.path, branch, { force: true })
+      if (refreshedPR) {
+        await fetchChecks({ force: true, prNumberOverride: refreshedPR.number })
+      } else {
+        setChecks([])
+      }
+    } finally {
+      setIsRefreshing(false)
+    }
   }, [repo, branch, fetchPRForBranch, fetchChecks])
 
   const handleStartEdit = useCallback(() => {
@@ -159,7 +177,7 @@ export default function ChecksPanel(): React.JSX.Element {
       })
       if (ok) {
         // Re-fetch PR to get updated title
-        await fetchPRForBranch(repo.path, branch)
+        await fetchPRForBranch(repo.path, branch, { force: true })
       }
     } finally {
       setTitleSaving(false)
@@ -182,7 +200,7 @@ export default function ChecksPanel(): React.JSX.Element {
   // Refresh PR (passed to PRActions)
   const handleRefreshPR = useCallback(async () => {
     if (repo && branch) {
-      await fetchPRForBranch(repo.path, branch)
+      await fetchPRForBranch(repo.path, branch, { force: true })
     }
   }, [repo, branch, fetchPRForBranch])
 
@@ -275,8 +293,9 @@ export default function ChecksPanel(): React.JSX.Element {
             className="p-1 rounded hover:bg-accent text-muted-foreground hover:text-foreground transition-colors"
             title="Refresh"
             onClick={() => void handleRefresh()}
+            disabled={isRefreshing}
           >
-            <RefreshCw className={cn('size-3.5', checksLoading && 'animate-spin')} />
+            <RefreshCw className={cn('size-3.5', isRefreshing && 'animate-spin')} />
           </button>
           <button
             className="p-1 rounded hover:bg-accent text-muted-foreground hover:text-foreground transition-colors"

--- a/src/renderer/src/store/slices/github.ts
+++ b/src/renderer/src/store/slices/github.ts
@@ -7,6 +7,10 @@ export type CacheEntry<T> = {
   fetchedAt: number
 }
 
+type FetchOptions = {
+  force?: boolean
+}
+
 const CACHE_TTL = 300_000 // 5 minutes (stale data shown instantly, then refreshed)
 const CHECKS_CACHE_TTL = 60_000 // 1 minute — checks change more frequently
 
@@ -39,9 +43,18 @@ export type GitHubSlice = {
   prCache: Record<string, CacheEntry<PRInfo>>
   issueCache: Record<string, CacheEntry<IssueInfo>>
   checksCache: Record<string, CacheEntry<PRCheckDetail[]>>
-  fetchPRForBranch: (repoPath: string, branch: string) => Promise<PRInfo | null>
+  fetchPRForBranch: (
+    repoPath: string,
+    branch: string,
+    options?: FetchOptions
+  ) => Promise<PRInfo | null>
   fetchIssue: (repoPath: string, number: number) => Promise<IssueInfo | null>
-  fetchPRChecks: (repoPath: string, prNumber: number, branch?: string) => Promise<PRCheckDetail[]>
+  fetchPRChecks: (
+    repoPath: string,
+    prNumber: number,
+    branch?: string,
+    options?: FetchOptions
+  ) => Promise<PRCheckDetail[]>
   initGitHubCache: () => Promise<void>
   refreshAllGitHub: () => void
   refreshGitHubForWorktree: (worktreeId: string) => void
@@ -66,10 +79,10 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
     }
   },
 
-  fetchPRForBranch: async (repoPath, branch) => {
+  fetchPRForBranch: async (repoPath, branch, options): Promise<PRInfo | null> => {
     const cacheKey = `${repoPath}::${branch}`
     const cached = get().prCache[cacheKey]
-    if (isFresh(cached)) {
+    if (!options?.force && isFresh(cached)) {
       return cached.data
     }
 
@@ -138,10 +151,10 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
     return request
   },
 
-  fetchPRChecks: async (repoPath, prNumber, branch?) => {
+  fetchPRChecks: async (repoPath, prNumber, branch, options): Promise<PRCheckDetail[]> => {
     const cacheKey = `${repoPath}::pr-checks::${prNumber}`
     const cached = get().checksCache[cacheKey]
-    if (isFresh(cached, CHECKS_CACHE_TTL)) {
+    if (!options?.force && isFresh(cached, CHECKS_CACHE_TTL)) {
       return cached.data ?? []
     }
 


### PR DESCRIPTION
## Summary
- Added `force` option to `fetchPRForBranch` and `fetchPRChecks` to bypass cache TTL on manual refresh
- Updated ChecksPanel refresh handler to force-fetch fresh PR data and checks, using the refreshed PR number
- Added `isRefreshing` state for proper loading indicator on the refresh button

## Test plan
- [ ] Click refresh button in ChecksPanel — should fetch fresh data (not cached)
- [ ] Verify polling still uses cached data with exponential backoff
- [ ] Verify refresh button shows spinner while refreshing and is disabled during refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)