### PR TITLE
fix: Add --yes flag to gh pr merge command

### DIFF
--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -249,14 +249,11 @@ export async function mergePR(
 ): Promise<{ ok: true } | { ok: false; error: string }> {
   await acquire()
   try {
-    await execFileAsync(
-      'gh',
-      ['pr', 'merge', String(prNumber), `--${method}`, '--delete-branch', '--yes'],
-      {
-        cwd: repoPath,
-        encoding: 'utf-8'
-      }
-    )
+    await execFileAsync('gh', ['pr', 'merge', String(prNumber), `--${method}`, '--delete-branch'], {
+      cwd: repoPath,
+      encoding: 'utf-8',
+      env: { ...process.env, GH_PROMPT_DISABLED: '1' }
+    })
     return { ok: true }
   } catch (err) {
     const message =


### PR DESCRIPTION
## Problem

The `gh pr merge` command could hang waiting for interactive confirmation when called from `execFileAsync`, since the process may still detect a TTY in some environments. The `--yes` flag does not exist for `gh pr merge`.

## Solution

Set `GH_PROMPT_DISABLED=1` environment variable when invoking `gh pr merge` to ensure the command never prompts for confirmation, regardless of TTY detection.