### PR TITLE
fix: remove --delete-branch from mergePR to prevent worktree error

### DIFF
--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -249,9 +249,13 @@ export async function mergePR(
 ): Promise<{ ok: true } | { ok: false; error: string }> {
   await acquire()
   try {
-    await execFileAsync('gh', ['pr', 'merge', String(prNumber), `--${method}`, '--delete-branch'], {
+    // Don't use --delete-branch: it tries to delete the local branch which
+    // fails when the user's worktree is checked out on it. Branch cleanup
+    // is handled by worktree deletion (local) and GitHub's auto-delete setting (remote).
+    await execFileAsync('gh', ['pr', 'merge', String(prNumber), `--${method}`], {
       cwd: repoPath,
-      encoding: 'utf-8'
+      encoding: 'utf-8',
+      env: { ...process.env, GH_PROMPT_DISABLED: '1' }
     })
     return { ok: true }
   } catch (err) {


### PR DESCRIPTION
## Problem

`gh pr merge --delete-branch` fails when the user's worktree is checked out on the branch being merged. Git refuses to delete a checked-out branch, causing the entire merge command to report failure even though the merge itself succeeded.

## Solution

- Removed `--delete-branch` from the `gh pr merge` call. Branch cleanup is separated:
  - **Local branch**: handled by worktree deletion
  - **Remote branch**: handled by GitHub's "Automatically delete head branches" repo setting
- Added `GH_PROMPT_DISABLED=1` env var to prevent interactive prompts in non-TTY environments