### PR TITLE
fix: align shortcut labels and remove shift-enter terminal intercept

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeMetaDialog.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeMetaDialog.tsx
@@ -35,6 +35,7 @@ const WorktreeMetaDialog = React.memo(function WorktreeMetaDialog() {
   const [issueInput, setIssueInput] = useState('')
   const [commentInput, setCommentInput] = useState('')
   const [saving, setSaving] = useState(false)
+  const isMac = navigator.userAgent.includes('Mac')
 
   const issueInputRef = useRef<HTMLInputElement>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
@@ -202,7 +203,7 @@ const WorktreeMetaDialog = React.memo(function WorktreeMetaDialog() {
               className="w-full min-w-0 rounded-md border border-input bg-transparent px-3 py-2 text-xs shadow-xs transition-[color,box-shadow] outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 resize-none max-h-60 overflow-y-auto"
             />
             <p className="text-[10px] text-muted-foreground">
-              Press Enter or Cmd+Enter to save, Shift+Enter for a new line.
+              Press Enter or {isMac ? 'Cmd' : 'Ctrl'}+Enter to save, Shift+Enter for a new line.
             </p>
           </div>
         </div>

--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
@@ -241,42 +241,13 @@ export function useTerminalKeyboardShortcuts({
       transport?.sendInput('\x1b\x7f')
     }
 
-    // Shift+Enter → insert a literal newline into the shell command line.
-    const onShiftEnter = (e: KeyboardEvent): void => {
-      if (!e.shiftKey || e.metaKey || e.altKey || e.ctrlKey) {
-        return
-      }
-      if (e.key !== 'Enter') {
-        return
-      }
-      if (isEditableTarget(e.target)) {
-        return
-      }
-
-      const manager = managerRef.current
-      if (!manager) {
-        return
-      }
-
-      e.preventDefault()
-      e.stopPropagation()
-      const pane = manager.getActivePane() ?? manager.getPanes()[0]
-      if (!pane) {
-        return
-      }
-      const transport = paneTransportsRef.current.get(pane.id)
-      transport?.sendInput('\x16\x0a')
-    }
-
     window.addEventListener('keydown', onKeyDown, { capture: true })
     window.addEventListener('keydown', onCtrlBackspace, { capture: true })
     window.addEventListener('keydown', onAltBackspace, { capture: true })
-    window.addEventListener('keydown', onShiftEnter, { capture: true })
     return () => {
       window.removeEventListener('keydown', onKeyDown, { capture: true })
       window.removeEventListener('keydown', onCtrlBackspace, { capture: true })
       window.removeEventListener('keydown', onAltBackspace, { capture: true })
-      window.removeEventListener('keydown', onShiftEnter, { capture: true })
     }
   }, [
     isActive,


### PR DESCRIPTION
## Summary
- remove the terminal-level Shift+Enter intercept so the terminal no longer captures that key globally
- update the worktree metadata dialog hint to show Cmd on macOS and Ctrl on Linux/Windows

## Validation
- pnpm run lint
- pnpm run typecheck
- pnpm run test