### PR TITLE
fix: change Squash & merge button from purple to green

### DIFF
--- a/src/renderer/src/components/right-sidebar/PRActions.tsx
+++ b/src/renderer/src/components/right-sidebar/PRActions.tsx
@@ -78,7 +78,7 @@ export default function PRActions({
           <button
             className={cn(
               'flex-1 flex items-center justify-center gap-1.5 rounded-l-md px-3 py-1.5 text-[11px] font-medium transition-colors',
-              'bg-purple-600 text-white hover:bg-purple-700',
+              'bg-green-600 text-white hover:bg-green-700',
               'disabled:opacity-50 disabled:cursor-not-allowed'
             )}
             onClick={() => void handleMerge('squash')}
@@ -93,8 +93,8 @@ export default function PRActions({
           </button>
           <button
             className={cn(
-              'flex items-center px-1.5 rounded-r-md border-l border-purple-700/50 transition-colors',
-              'bg-purple-600 text-white hover:bg-purple-700',
+              'flex items-center px-1.5 rounded-r-md border-l border-green-700/50 transition-colors',
+              'bg-green-600 text-white hover:bg-green-700',
               'disabled:opacity-50 disabled:cursor-not-allowed'
             )}
             onClick={() => setMergeMenuOpen((v) => !v)}


### PR DESCRIPTION
## Summary
- Changed the Squash & merge button color from purple to green for a more neutral, GitHub-consistent appearance

## Test plan
- [ ] Verify the merge button renders in green on open PRs
- [ ] Verify the dropdown chevron border matches the new color

🤖 Generated with [Claude Code](https://claude.com/claude-code)