### PR TITLE
fix: use neutral styling for delete worktree button on merged PRs

### DIFF
--- a/src/renderer/src/components/right-sidebar/PRActions.tsx
+++ b/src/renderer/src/components/right-sidebar/PRActions.tsx
@@ -126,7 +126,7 @@ export default function PRActions({
       <button
         className={cn(
           'w-full flex items-center justify-center gap-1.5 rounded-md px-3 py-1.5 text-[11px] font-medium transition-colors',
-          'bg-destructive text-destructive-foreground hover:bg-destructive/90'
+          'bg-secondary text-secondary-foreground hover:bg-secondary/80'
         )}
         onClick={handleDeleteWorktree}
       >


### PR DESCRIPTION
## Summary
- Changed the "Delete Worktree" button styling from destructive (red) to secondary (neutral) when a PR is already merged, since this is a routine cleanup action

## Test plan
- [ ] Verify merged PR view shows the delete worktree button with neutral styling