### PR TITLE
fix: harden editor path copy behavior

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -59,6 +59,7 @@
 :root {
   --radius: 0.625rem;
   --background: #fff;
+  --editor-surface: #ffffff;
   --foreground: #0a0a0a;
   --card: #fff;
   --card-foreground: #0a0a0a;
@@ -96,6 +97,7 @@
 
 .dark {
   --background: #0a0a0a;
+  --editor-surface: #1e1e1e;
   --foreground: #fafafa;
   --card: #171717;
   --card-foreground: #fafafa;
@@ -339,6 +341,80 @@
 .titlebar-icon-button:disabled:hover {
   background: none;
   color: var(--muted-foreground);
+}
+
+.editor-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-height: 52px;
+  padding: 10px 14px;
+  background: var(--editor-surface);
+  border-bottom: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
+  flex-shrink: 0;
+}
+
+.editor-header-text {
+  min-width: 0;
+  flex: 1;
+}
+
+.editor-header-path {
+  display: block;
+  padding: 0;
+  max-width: 100%;
+  border: none;
+  background: transparent;
+  color: var(--muted-foreground);
+  cursor: pointer;
+  font-size: 12px;
+  line-height: 1.2;
+  font-family:
+    ui-monospace,
+    SFMono-Regular,
+    SF Mono,
+    Menlo,
+    Consolas,
+    monospace;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-align: left;
+}
+
+.editor-header-path:hover,
+.editor-header-path:focus-visible {
+  color: var(--foreground);
+}
+
+.editor-header-path-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 4px;
+  min-width: 0;
+}
+
+.editor-header-copy-toast {
+  opacity: 0;
+  transform: translateY(2px);
+  transition:
+    opacity 120ms ease,
+    transform 120ms ease;
+  pointer-events: none;
+  flex-shrink: 0;
+  padding: 2px 6px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent) 72%, transparent);
+  color: var(--foreground);
+  font-size: 11px;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
+.editor-header-copy-toast.is-visible {
+  opacity: 1;
+  transform: translateY(0);
 }
 
 /* ── Content ─────────────────────────────────────────── */

--- a/src/renderer/src/components/editor/EditorPanel.tsx
+++ b/src/renderer/src/components/editor/EditorPanel.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useState, lazy, Suspense } from 'react'
 import { useAppStore } from '@/store'
 import { detectLanguage } from '@/lib/language-detect'
+import { getEditorHeaderCopyState } from './editor-header'
 
 const MonacoEditor = lazy(() => import('./MonacoEditor'))
 const DiffViewer = lazy(() => import('./DiffViewer'))
@@ -27,6 +28,9 @@ export default function EditorPanel(): React.JSX.Element | null {
   const [fileContents, setFileContents] = useState<Record<string, FileContent>>({})
   const [diffContents, setDiffContents] = useState<Record<string, DiffContent>>({})
   const [editBuffers, setEditBuffers] = useState<Record<string, string>>({})
+  const [copiedPathToast, setCopiedPathToast] = useState<{ fileId: string; token: number } | null>(
+    null
+  )
 
   // Load file content when active file changes
   useEffect(() => {
@@ -45,6 +49,14 @@ export default function EditorPanel(): React.JSX.Element | null {
       void loadDiffContent(activeFile)
     }
   }, [activeFile?.id]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    if (!copiedPathToast) {
+      return
+    }
+    const timeout = window.setTimeout(() => setCopiedPathToast(null), 1500)
+    return () => window.clearTimeout(timeout)
+  }, [copiedPathToast])
 
   const loadFileContent = async (filePath: string, id: string): Promise<void> => {
     try {
@@ -201,11 +213,28 @@ export default function EditorPanel(): React.JSX.Element | null {
     })
   }, [openFiles])
 
+  const handleCopyPath = useCallback(async (): Promise<void> => {
+    if (!activeFile) {
+      return
+    }
+    const copyState = getEditorHeaderCopyState(activeFile)
+    if (!copyState.copyText) {
+      return
+    }
+    try {
+      await window.api.ui.writeClipboardText(copyState.copyText)
+      setCopiedPathToast({ fileId: activeFile.id, token: Date.now() })
+    } catch {
+      setCopiedPathToast(null)
+    }
+  }, [activeFile])
+
   if (!activeFile) {
     return null
   }
 
   const isCombinedDiff = activeFile.mode === 'diff' && activeFile.diffStaged === undefined
+  const headerCopyState = getEditorHeaderCopyState(activeFile)
   const resolvedLanguage =
     activeFile.mode === 'diff'
       ? detectLanguage(activeFile.relativePath)
@@ -219,6 +248,26 @@ export default function EditorPanel(): React.JSX.Element | null {
 
   return (
     <div className="flex flex-col flex-1 min-w-0 min-h-0">
+      <div className="editor-header">
+        <div className="editor-header-text">
+          <div className="editor-header-path-row">
+            <button
+              type="button"
+              className="editor-header-path"
+              onClick={() => void handleCopyPath()}
+              title={headerCopyState.pathTitle}
+            >
+              {headerCopyState.pathLabel}
+            </button>
+            <span
+              className={`editor-header-copy-toast${copiedPathToast?.fileId === activeFile.id ? ' is-visible' : ''}`}
+              aria-live="polite"
+            >
+              {headerCopyState.copyToastLabel}
+            </span>
+          </div>
+        </div>
+      </div>
       <Suspense fallback={loadingFallback}>
         {isCombinedDiff ? (
           <CombinedDiffViewer worktreePath={activeFile.filePath} />

--- a/src/renderer/src/components/editor/editor-header.test.ts
+++ b/src/renderer/src/components/editor/editor-header.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { getEditorHeaderCopyState } from './editor-header'
+import type { OpenFile } from '@/store/slices/editor'
+
+function makeOpenFile(overrides: Partial<OpenFile> = {}): OpenFile {
+  return {
+    id: '/repo/file.ts',
+    filePath: '/repo/file.ts',
+    relativePath: 'file.ts',
+    worktreeId: 'wt-1',
+    language: 'typescript',
+    isDirty: false,
+    mode: 'edit',
+    ...overrides
+  }
+}
+
+describe('getEditorHeaderCopyState', () => {
+  it('shows the absolute file path for normal file tabs', () => {
+    expect(getEditorHeaderCopyState(makeOpenFile())).toEqual({
+      copyText: '/repo/file.ts',
+      copyToastLabel: 'File path copied',
+      pathLabel: '/repo/file.ts',
+      pathTitle: '/repo/file.ts'
+    })
+  })
+
+  it('shows All Changes while still copying the worktree path', () => {
+    expect(
+      getEditorHeaderCopyState(
+        makeOpenFile({
+          id: 'wt-1::all-diffs',
+          filePath: '/repo/worktree',
+          relativePath: 'All Changes',
+          mode: 'diff',
+          diffStaged: undefined
+        })
+      )
+    ).toEqual({
+      copyText: '/repo/worktree',
+      copyToastLabel: 'Worktree path copied',
+      pathLabel: 'All Changes',
+      pathTitle: '/repo/worktree'
+    })
+  })
+})

--- a/src/renderer/src/components/editor/editor-header.ts
+++ b/src/renderer/src/components/editor/editor-header.ts
@@ -1,0 +1,28 @@
+import type { OpenFile } from '@/store/slices/editor'
+
+export type EditorHeaderCopyState = {
+  copyText: string | null
+  copyToastLabel: string
+  pathLabel: string
+  pathTitle: string
+}
+
+export function getEditorHeaderCopyState(file: OpenFile): EditorHeaderCopyState {
+  const isCombinedDiff = file.mode === 'diff' && file.diffStaged === undefined
+
+  if (isCombinedDiff) {
+    return {
+      copyText: file.filePath,
+      copyToastLabel: 'Worktree path copied',
+      pathLabel: file.relativePath,
+      pathTitle: file.filePath
+    }
+  }
+
+  return {
+    copyText: file.filePath,
+    copyToastLabel: 'File path copied',
+    pathLabel: file.filePath,
+    pathTitle: file.filePath
+  }
+}


### PR DESCRIPTION
## Problem
The editor gained a clickable path header, but the initial implementation had a few UI edge cases that could mislead users. Clipboard writes showed success even on failure, the success toast could linger across tab switches, repeated copies on the same tab did not refresh the toast timer, and the synthetic `All Changes` tab was presented like a normal file path.

## Solution
Add a small header-state helper that distinguishes normal files from the combined diff tab, and update the editor header to await clipboard writes before showing success. Scope the toast to the active file, refresh it on repeated copies, and add focused tests for the normal-file and `All Changes` behaviors.
