### PR TITLE
feat: add rightSidebarOpenByDefault setting

### DIFF
--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -68,6 +68,7 @@ describe('Store', () => {
     expect(settings.branchPrefix).toBe('git-username')
     expect(settings.theme).toBe('system')
     expect(settings.terminalFontSize).toBe(14)
+    expect(settings.rightSidebarOpenByDefault).toBe(false)
   })
 
   it('returns default UI state when no data file exists', async () => {
@@ -128,8 +129,25 @@ describe('Store', () => {
     expect(ui.sidebarWidth).toBe(280)
     // settings should preserve the overridden value
     expect(store.getSettings().theme).toBe('dark')
+    // new fields get defaults when missing from persisted data
+    expect(store.getSettings().rightSidebarOpenByDefault).toBe(false)
     // repos should be loaded
     expect(store.getRepos()).toHaveLength(1)
+  })
+
+  it('preserves rightSidebarOpenByDefault when set to true in persisted data', async () => {
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [],
+      worktreeMeta: {},
+      settings: { rightSidebarOpenByDefault: true },
+      ui: {},
+      githubCache: { pr: {}, issue: {} },
+      workspaceSession: {}
+    })
+
+    const store = await createStore()
+    expect(store.getSettings().rightSidebarOpenByDefault).toBe(true)
   })
 
   // ── 5. addRepo and getRepo ──────────────────────────────────────────
@@ -220,6 +238,17 @@ describe('Store', () => {
     expect(updated.terminalFontSize).toBe(16)
     // Other fields preserved
     expect(updated.branchPrefix).toBe('git-username')
+  })
+
+  it('updateSettings toggles rightSidebarOpenByDefault', async () => {
+    const store = await createStore()
+    expect(store.getSettings().rightSidebarOpenByDefault).toBe(false)
+
+    store.updateSettings({ rightSidebarOpenByDefault: true })
+    expect(store.getSettings().rightSidebarOpenByDefault).toBe(true)
+
+    store.updateSettings({ rightSidebarOpenByDefault: false })
+    expect(store.getSettings().rightSidebarOpenByDefault).toBe(false)
   })
 
   // ── 10. flush writes synchronously ─────────────────────────────────

--- a/src/renderer/src/components/settings/AppearancePane.tsx
+++ b/src/renderer/src/components/settings/AppearancePane.tsx
@@ -1,4 +1,5 @@
 import type { GlobalSettings } from '../../../../shared/types'
+import { Label } from '../ui/label'
 import { Separator } from '../ui/separator'
 import { UIZoomControl } from './UIZoomControl'
 
@@ -55,6 +56,44 @@ export function AppearancePane({
         </div>
 
         <UIZoomControl />
+      </section>
+
+      <Separator />
+
+      <section className="space-y-4">
+        <div className="space-y-1">
+          <h2 className="text-sm font-semibold">Layout</h2>
+          <p className="text-xs text-muted-foreground">
+            Default layout when creating new worktrees.
+          </p>
+        </div>
+
+        <div className="flex items-center justify-between gap-4 px-1 py-2">
+          <div className="space-y-0.5">
+            <Label>Open Right Sidebar by Default</Label>
+            <p className="text-xs text-muted-foreground">
+              Automatically expand the file explorer panel when creating a new worktree.
+            </p>
+          </div>
+          <button
+            role="switch"
+            aria-checked={settings.rightSidebarOpenByDefault}
+            onClick={() =>
+              updateSettings({
+                rightSidebarOpenByDefault: !settings.rightSidebarOpenByDefault
+              })
+            }
+            className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent transition-colors ${
+              settings.rightSidebarOpenByDefault ? 'bg-foreground' : 'bg-muted-foreground/30'
+            }`}
+          >
+            <span
+              className={`pointer-events-none block size-3.5 rounded-full bg-background shadow-sm transition-transform ${
+                settings.rightSidebarOpenByDefault ? 'translate-x-4' : 'translate-x-0.5'
+              }`}
+            />
+          </button>
+        </div>
       </section>
     </div>
   )

--- a/src/renderer/src/components/sidebar/AddWorktreeDialog.tsx
+++ b/src/renderer/src/components/sidebar/AddWorktreeDialog.tsx
@@ -41,6 +41,7 @@ const AddWorktreeDialog = React.memo(function AddWorktreeDialog() {
   const filterRepoIds = useAppStore((s) => s.filterRepoIds)
   const setFilterRepoIds = useAppStore((s) => s.setFilterRepoIds)
   const revealWorktreeInSidebar = useAppStore((s) => s.revealWorktreeInSidebar)
+  const setRightSidebarOpen = useAppStore((s) => s.setRightSidebarOpen)
   const worktreesByRepo = useAppStore((s) => s.worktreesByRepo)
   const settings = useAppStore((s) => s.settings)
 
@@ -137,6 +138,9 @@ const AddWorktreeDialog = React.memo(function AddWorktreeDialog() {
         }
         setActiveWorktree(wt.id)
         revealWorktreeInSidebar(wt.id)
+        if (settings?.rightSidebarOpenByDefault) {
+          setRightSidebarOpen(true)
+        }
       }
       handleOpenChange(false)
     } finally {
@@ -158,6 +162,8 @@ const AddWorktreeDialog = React.memo(function AddWorktreeDialog() {
     setFilterRepoIds,
     setActiveWorktree,
     revealWorktreeInSidebar,
+    setRightSidebarOpen,
+    settings?.rightSidebarOpenByDefault,
     handleOpenChange
   ])
 

--- a/src/renderer/src/store/slices/editor.test.ts
+++ b/src/renderer/src/store/slices/editor.test.ts
@@ -12,6 +12,35 @@ function createEditorStore(): StoreApi<AppState> {
   })) as unknown as StoreApi<AppState>
 }
 
+describe('createEditorSlice right sidebar state', () => {
+  it('right sidebar is closed by default', () => {
+    const store = createEditorStore()
+    expect(store.getState().rightSidebarOpen).toBe(false)
+  })
+
+  it('setRightSidebarOpen opens the sidebar', () => {
+    const store = createEditorStore()
+    store.getState().setRightSidebarOpen(true)
+    expect(store.getState().rightSidebarOpen).toBe(true)
+  })
+
+  it('setRightSidebarOpen(false) after open closes it', () => {
+    const store = createEditorStore()
+    store.getState().setRightSidebarOpen(true)
+    store.getState().setRightSidebarOpen(false)
+    expect(store.getState().rightSidebarOpen).toBe(false)
+  })
+
+  it('toggleRightSidebar flips the state', () => {
+    const store = createEditorStore()
+    expect(store.getState().rightSidebarOpen).toBe(false)
+    store.getState().toggleRightSidebar()
+    expect(store.getState().rightSidebarOpen).toBe(true)
+    store.getState().toggleRightSidebar()
+    expect(store.getState().rightSidebarOpen).toBe(false)
+  })
+})
+
 describe('createEditorSlice openDiff', () => {
   it('keeps staged and unstaged diffs in separate tabs', () => {
     const store = createEditorStore()

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -39,7 +39,8 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     terminalActivePaneOpacity: 1,
     terminalPaneOpacityTransitionMs: 140,
     terminalDividerThicknessPx: 1,
-    terminalScrollbackBytes: 10_000_000
+    terminalScrollbackBytes: 10_000_000,
+    rightSidebarOpenByDefault: false
   }
 }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -172,6 +172,7 @@ export type GlobalSettings = {
   terminalPaneOpacityTransitionMs: number
   terminalDividerThicknessPx: number
   terminalScrollbackBytes: number
+  rightSidebarOpenByDefault: boolean
 }
 
 export type PersistedUIState = {


### PR DESCRIPTION
## Problem
When creating a new worktree, the right sidebar (file explorer) is always closed by default. Users have no way to configure this behavior, requiring them to manually open the sidebar for every new worktree.

## Solution
Add a new global setting `rightSidebarOpenByDefault` that:
- Adds a toggle in the Appearance settings pane under Layout
- Automatically opens the right sidebar when creating a new worktree if enabled
- Defaults to false (preserving current behavior)
- Is properly persisted and tested

Changes include:
- Type definition and default constant for the new setting
- UI toggle in AppearancePane with proper accessibility attributes
- Integration in AddWorktreeDialog to respect the setting
- Tests for persistence and state management