### PR TITLE
feat: auto-expand right sidebar for new users

### DIFF
--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -68,7 +68,7 @@ describe('Store', () => {
     expect(settings.branchPrefix).toBe('git-username')
     expect(settings.theme).toBe('system')
     expect(settings.terminalFontSize).toBe(14)
-    expect(settings.rightSidebarOpenByDefault).toBe(false)
+    expect(settings.rightSidebarOpenByDefault).toBe(true)
   })
 
   it('returns default UI state when no data file exists', async () => {
@@ -130,7 +130,7 @@ describe('Store', () => {
     // settings should preserve the overridden value
     expect(store.getSettings().theme).toBe('dark')
     // new fields get defaults when missing from persisted data
-    expect(store.getSettings().rightSidebarOpenByDefault).toBe(false)
+    expect(store.getSettings().rightSidebarOpenByDefault).toBe(true)
     // repos should be loaded
     expect(store.getRepos()).toHaveLength(1)
   })
@@ -242,13 +242,13 @@ describe('Store', () => {
 
   it('updateSettings toggles rightSidebarOpenByDefault', async () => {
     const store = await createStore()
-    expect(store.getSettings().rightSidebarOpenByDefault).toBe(false)
-
-    store.updateSettings({ rightSidebarOpenByDefault: true })
     expect(store.getSettings().rightSidebarOpenByDefault).toBe(true)
 
     store.updateSettings({ rightSidebarOpenByDefault: false })
     expect(store.getSettings().rightSidebarOpenByDefault).toBe(false)
+
+    store.updateSettings({ rightSidebarOpenByDefault: true })
+    expect(store.getSettings().rightSidebarOpenByDefault).toBe(true)
   })
 
   // ── 10. flush writes synchronously ─────────────────────────────────

--- a/src/renderer/src/components/sidebar/AddWorktreeDialog.tsx
+++ b/src/renderer/src/components/sidebar/AddWorktreeDialog.tsx
@@ -42,6 +42,7 @@ const AddWorktreeDialog = React.memo(function AddWorktreeDialog() {
   const setFilterRepoIds = useAppStore((s) => s.setFilterRepoIds)
   const revealWorktreeInSidebar = useAppStore((s) => s.revealWorktreeInSidebar)
   const setRightSidebarOpen = useAppStore((s) => s.setRightSidebarOpen)
+  const setRightSidebarTab = useAppStore((s) => s.setRightSidebarTab)
   const worktreesByRepo = useAppStore((s) => s.worktreesByRepo)
   const settings = useAppStore((s) => s.settings)
 
@@ -139,6 +140,7 @@ const AddWorktreeDialog = React.memo(function AddWorktreeDialog() {
         setActiveWorktree(wt.id)
         revealWorktreeInSidebar(wt.id)
         if (settings?.rightSidebarOpenByDefault) {
+          setRightSidebarTab('explorer')
           setRightSidebarOpen(true)
         }
       }
@@ -163,6 +165,7 @@ const AddWorktreeDialog = React.memo(function AddWorktreeDialog() {
     setActiveWorktree,
     revealWorktreeInSidebar,
     setRightSidebarOpen,
+    setRightSidebarTab,
     settings?.rightSidebarOpenByDefault,
     handleOpenChange
   ])

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -40,7 +40,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     terminalPaneOpacityTransitionMs: 140,
     terminalDividerThicknessPx: 1,
     terminalScrollbackBytes: 10_000_000,
-    rightSidebarOpenByDefault: false
+    rightSidebarOpenByDefault: true
   }
 }
 


### PR DESCRIPTION
## Summary
- Change `rightSidebarOpenByDefault` default to `true` so new users discover the explorer panel immediately
- When creating a worktree with the setting enabled, switch to the explorer tab before opening the sidebar
- Update tests to reflect the new default

## Test plan
- [x] Updated persistence tests pass with new default value
- [ ] Verify new users see the right sidebar expanded on first launch
- [ ] Verify existing users with explicit `false` setting are unaffected
- [ ] Verify worktree creation opens sidebar to the explorer tab