### PR TITLE
fix: stamp lastActivityAt on new worktrees to prevent scroll misfire

### DIFF
--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -106,13 +106,15 @@ export function registerWorktreeHandlers(mainWindow: BrowserWindow, store: Store
       }
 
       const worktreeId = `${repo.id}::${worktreePath}`
-      const metaUpdates: Partial<WorktreeMeta> = shouldSetDisplayName(
-        requestedName,
-        branchName,
-        sanitizedName
-      )
-        ? { displayName: requestedName }
-        : {}
+      const metaUpdates: Partial<WorktreeMeta> = {
+        // Stamp activity so the worktree sorts into its final position
+        // immediately — prevents scroll-to-reveal racing with a later
+        // bumpWorktreeActivity that would re-sort the list.
+        lastActivityAt: Date.now(),
+        ...(shouldSetDisplayName(requestedName, branchName, sanitizedName)
+          ? { displayName: requestedName }
+          : {})
+      }
       const meta = store.setWorktreeMeta(worktreeId, metaUpdates)
       const worktree = mergeWorktree(repo.id, created, meta)
 


### PR DESCRIPTION
## Summary
- New worktrees were created with `lastActivityAt: 0`, placing them low in "recent" sort order
- `revealWorktreeInSidebar` would scroll to that position, then a PTY spawn would bump activity and re-sort the worktree to the top — leaving the user scrolled to the wrong place
- Fix: set `lastActivityAt: Date.now()` at creation time so the worktree lands in its final sort position before the scroll effect fires

## Test plan
- [ ] Create a new worktree with "most recent" sort active
- [ ] Verify the sidebar scrolls to the correct position (top of list)
- [ ] Verify the worktree doesn't visibly jump/re-sort after appearing

🤖 Generated with [Claude Code](https://claude.com/claude-code)