### PR TITLE
Add checks status indicator to activity bar

### DIFF
--- a/src/renderer/src/components/right-sidebar/index.tsx
+++ b/src/renderer/src/components/right-sidebar/index.tsx
@@ -3,6 +3,7 @@ import { Files, Search, GitBranch, ListChecks } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { cn } from '@/lib/utils'
 import type { RightSidebarTab, ActivityBarPosition } from '@/store/slices/editor'
+import type { CheckStatus } from '../../../../shared/types'
 import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from '@/components/ui/tooltip'
 import {
   ContextMenu,
@@ -22,6 +23,43 @@ const MAX_WIDTH = 500
 
 const ACTIVITY_BAR_SIDE_WIDTH = 40
 
+function branchDisplayName(branch: string): string {
+  return branch.replace(/^refs\/heads\//, '')
+}
+
+function findWorktreeById(
+  worktreesByRepo: ReturnType<typeof useAppStore.getState>['worktreesByRepo'],
+  worktreeId: string | null
+) {
+  if (!worktreeId) {
+    return null
+  }
+
+  for (const worktrees of Object.values(worktreesByRepo)) {
+    const worktree = worktrees.find((entry) => entry.id === worktreeId)
+    if (worktree) {
+      return worktree
+    }
+  }
+
+  return null
+}
+
+function getActiveChecksStatus(state: ReturnType<typeof useAppStore.getState>): CheckStatus | null {
+  const activeWorktree = findWorktreeById(state.worktreesByRepo, state.activeWorktreeId)
+  if (!activeWorktree) {
+    return null
+  }
+
+  const activeRepo = state.repos.find((repo) => repo.id === activeWorktree.repoId)
+  if (!activeRepo) {
+    return null
+  }
+
+  const prCacheKey = `${activeRepo.path}::${branchDisplayName(activeWorktree.branch)}`
+  return state.prCache[prCacheKey]?.data?.checksStatus ?? null
+}
+
 type ActivityBarItem = {
   id: RightSidebarTab
   icon: React.ComponentType<{ size?: number; className?: string }>
@@ -40,6 +78,12 @@ const ACTIVITY_ITEMS: ActivityBarItem[] = [
     shortcut: `${isMac ? '\u21E7' : 'Shift+'}${mod}E`
   },
   {
+    id: 'search',
+    icon: Search,
+    title: 'Search',
+    shortcut: `${isMac ? '\u21E7' : 'Shift+'}${mod}F`
+  },
+  {
     id: 'source-control',
     icon: GitBranch,
     title: 'Source Control',
@@ -50,8 +94,7 @@ const ACTIVITY_ITEMS: ActivityBarItem[] = [
     icon: ListChecks,
     title: 'Checks',
     shortcut: `${isMac ? '\u21E7' : 'Shift+'}${mod}K`
-  },
-  { id: 'search', icon: Search, title: 'Search', shortcut: `${isMac ? '\u21E7' : 'Shift+'}${mod}F` }
+  }
 ]
 
 export default function RightSidebar(): React.JSX.Element {
@@ -61,6 +104,7 @@ export default function RightSidebar(): React.JSX.Element {
   const rightSidebarTab = useAppStore((s) => s.rightSidebarTab)
   const setRightSidebarTab = useAppStore((s) => s.setRightSidebarTab)
   const activeWorktreeId = useAppStore((s) => s.activeWorktreeId)
+  const checksStatus = useAppStore(getActiveChecksStatus)
   const activityBarPosition = useAppStore((s) => s.activityBarPosition)
   const setActivityBarPosition = useAppStore((s) => s.setActivityBarPosition)
 
@@ -128,6 +172,7 @@ export default function RightSidebar(): React.JSX.Element {
       active={rightSidebarTab === item.id}
       onClick={() => setRightSidebarTab(item.id)}
       layout={activityBarPosition}
+      statusIndicator={item.id === 'checks' ? checksStatus : null}
     />
   ))
 
@@ -192,17 +237,27 @@ export default function RightSidebar(): React.JSX.Element {
   )
 }
 
+// ─── Status indicator dot color mapping ──────
+const STATUS_DOT_COLOR: Record<CheckStatus, string> = {
+  success: 'bg-emerald-500',
+  failure: 'bg-rose-500',
+  pending: 'bg-amber-500',
+  neutral: 'bg-muted-foreground'
+}
+
 // ─── Activity Bar Button (shared for top + side) ──────
 function ActivityBarButton({
   item,
   active,
   onClick,
-  layout
+  layout,
+  statusIndicator
 }: {
   item: ActivityBarItem
   active: boolean
   onClick: () => void
   layout: 'top' | 'side'
+  statusIndicator?: CheckStatus | null
 }): React.JSX.Element {
   const Icon = item.icon
   const isTop = layout === 'top'
@@ -220,6 +275,17 @@ function ActivityBarButton({
           aria-label={`${item.title} (${item.shortcut})`}
         >
           <Icon size={isTop ? 16 : 18} />
+
+          {/* Status indicator dot */}
+          {statusIndicator && statusIndicator !== 'neutral' && (
+            <div
+              className={cn(
+                'absolute rounded-full size-[7px] ring-1 ring-sidebar',
+                isTop ? 'top-[5px] right-[5px]' : 'top-[7px] right-[7px]',
+                STATUS_DOT_COLOR[statusIndicator] ?? 'bg-muted-foreground'
+              )}
+            />
+          )}
 
           {/* Active indicator */}
           {active && isTop && (

--- a/src/renderer/src/store/slices/github-checks.ts
+++ b/src/renderer/src/store/slices/github-checks.ts
@@ -1,0 +1,69 @@
+import type { AppState } from '../types'
+import type { PRCheckDetail, CheckStatus } from '../../../../shared/types'
+
+export function normalizeBranchName(branch: string): string {
+  return branch.replace(/^refs\/heads\//, '')
+}
+
+export function deriveCheckStatusFromChecks(checks: PRCheckDetail[]): CheckStatus {
+  if (checks.length === 0) {
+    return 'neutral'
+  }
+
+  let hasPending = false
+
+  for (const check of checks) {
+    if (
+      check.conclusion === 'failure' ||
+      check.conclusion === 'timed_out' ||
+      check.conclusion === 'cancelled'
+    ) {
+      return 'failure'
+    }
+
+    if (
+      check.status === 'queued' ||
+      check.status === 'in_progress' ||
+      check.conclusion === 'pending'
+    ) {
+      hasPending = true
+    }
+  }
+
+  return hasPending ? 'pending' : 'success'
+}
+
+export function syncPRChecksStatus(
+  state: AppState,
+  repoPath: string,
+  branch: string | undefined,
+  checks: PRCheckDetail[]
+): Partial<AppState> | null {
+  if (!branch) {
+    return null
+  }
+
+  const prCacheKey = `${repoPath}::${normalizeBranchName(branch)}`
+  const prEntry = state.prCache[prCacheKey]
+  if (!prEntry?.data) {
+    return null
+  }
+
+  const nextStatus = deriveCheckStatusFromChecks(checks)
+  if (prEntry.data.checksStatus === nextStatus) {
+    return null
+  }
+
+  return {
+    prCache: {
+      ...state.prCache,
+      [prCacheKey]: {
+        ...prEntry,
+        data: {
+          ...prEntry.data,
+          checksStatus: nextStatus
+        }
+      }
+    }
+  }
+}

--- a/src/renderer/src/store/slices/github.test.ts
+++ b/src/renderer/src/store/slices/github.test.ts
@@ -1,0 +1,195 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { create } from 'zustand'
+import { createGitHubSlice } from './github'
+import type { AppState } from '../types'
+import type { PRInfo } from '../../../../shared/types'
+
+const mockApi = {
+  gh: {
+    prForBranch: vi.fn().mockResolvedValue(null),
+    issue: vi.fn().mockResolvedValue(null),
+    prChecks: vi.fn().mockResolvedValue([])
+  },
+  cache: {
+    getGitHub: vi.fn().mockResolvedValue(null),
+    setGitHub: vi.fn().mockResolvedValue(undefined)
+  }
+}
+
+// @ts-expect-error test window mock
+globalThis.window = { api: mockApi }
+
+function createTestStore() {
+  return create<AppState>()(
+    (...a) =>
+      ({
+        ...createGitHubSlice(...a)
+      }) as AppState
+  )
+}
+
+function makePR(overrides: Partial<PRInfo> = {}): PRInfo {
+  return {
+    number: 12,
+    title: 'Test PR',
+    state: 'open',
+    url: 'https://example.com/pr/12',
+    checksStatus: 'pending',
+    updatedAt: '2026-03-28T00:00:00Z',
+    ...overrides
+  }
+}
+
+describe('createGitHubSlice.fetchPRChecks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApi.gh.prChecks.mockResolvedValue([])
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('updates the matching PR cache entry with derived check status', async () => {
+    const store = createTestStore()
+    const repoPath = '/repo'
+    const branch = 'feature/test'
+    const prCacheKey = `${repoPath}::${branch}`
+
+    store.setState({
+      prCache: {
+        [prCacheKey]: {
+          data: makePR({ checksStatus: 'pending' }),
+          fetchedAt: 1
+        }
+      }
+    })
+
+    mockApi.gh.prChecks.mockResolvedValue([
+      { name: 'build', status: 'completed', conclusion: 'success', url: null },
+      { name: 'lint', status: 'completed', conclusion: 'success', url: null }
+    ])
+
+    await store.getState().fetchPRChecks(repoPath, 12, branch, { force: true })
+
+    expect(store.getState().prCache[prCacheKey]?.data?.checksStatus).toBe('success')
+  })
+
+  it('marks the PR cache entry as failure when any check fails', async () => {
+    const store = createTestStore()
+    const repoPath = '/repo'
+    const branch = 'feature/test'
+    const prCacheKey = `${repoPath}::${branch}`
+
+    store.setState({
+      prCache: {
+        [prCacheKey]: {
+          data: makePR({ checksStatus: 'pending' }),
+          fetchedAt: 1
+        }
+      }
+    })
+
+    mockApi.gh.prChecks.mockResolvedValue([
+      { name: 'build', status: 'completed', conclusion: 'success', url: null },
+      { name: 'integration', status: 'completed', conclusion: 'failure', url: null }
+    ])
+
+    await store.getState().fetchPRChecks(repoPath, 12, branch, { force: true })
+
+    expect(store.getState().prCache[prCacheKey]?.data?.checksStatus).toBe('failure')
+  })
+
+  it('normalizes refs/heads branch names before updating PR cache status', async () => {
+    const store = createTestStore()
+    const repoPath = '/repo'
+    const branch = 'feature/test'
+    const prCacheKey = `${repoPath}::${branch}`
+
+    store.setState({
+      prCache: {
+        [prCacheKey]: {
+          data: makePR({ checksStatus: 'pending' }),
+          fetchedAt: 1
+        }
+      }
+    })
+
+    mockApi.gh.prChecks.mockResolvedValue([
+      { name: 'build', status: 'completed', conclusion: 'success', url: null }
+    ])
+
+    await store.getState().fetchPRChecks(repoPath, 12, `refs/heads/${branch}`, { force: true })
+
+    expect(store.getState().prCache[prCacheKey]?.data?.checksStatus).toBe('success')
+  })
+
+  it('persists the updated PR cache after deriving a new checks status', async () => {
+    vi.useFakeTimers()
+
+    const store = createTestStore()
+    const repoPath = '/repo'
+    const branch = 'feature/test'
+    const prCacheKey = `${repoPath}::${branch}`
+
+    store.setState({
+      prCache: {
+        [prCacheKey]: {
+          data: makePR({ checksStatus: 'pending' }),
+          fetchedAt: 1
+        }
+      }
+    })
+
+    mockApi.gh.prChecks.mockResolvedValue([
+      { name: 'build', status: 'completed', conclusion: 'success', url: null }
+    ])
+
+    await store.getState().fetchPRChecks(repoPath, 12, branch, { force: true })
+    await vi.advanceTimersByTimeAsync(1000)
+
+    expect(mockApi.cache.setGitHub).toHaveBeenCalledWith({
+      cache: {
+        pr: store.getState().prCache,
+        issue: store.getState().issueCache
+      }
+    })
+  })
+
+  it('syncs PR status from a fresh checks cache hit without refetching', async () => {
+    vi.useFakeTimers()
+
+    const store = createTestStore()
+    const repoPath = '/repo'
+    const branch = 'feature/test'
+    const prCacheKey = `${repoPath}::${branch}`
+    const checksCacheKey = `${repoPath}::pr-checks::12`
+
+    store.setState({
+      prCache: {
+        [prCacheKey]: {
+          data: makePR({ checksStatus: 'pending' }),
+          fetchedAt: 1
+        }
+      },
+      checksCache: {
+        [checksCacheKey]: {
+          data: [{ name: 'build', status: 'completed', conclusion: 'success', url: null }],
+          fetchedAt: Date.now()
+        }
+      }
+    })
+
+    await store.getState().fetchPRChecks(repoPath, 12, branch)
+    await vi.advanceTimersByTimeAsync(1000)
+
+    expect(mockApi.gh.prChecks).not.toHaveBeenCalled()
+    expect(store.getState().prCache[prCacheKey]?.data?.checksStatus).toBe('success')
+    expect(mockApi.cache.setGitHub).toHaveBeenCalledWith({
+      cache: {
+        pr: store.getState().prCache,
+        issue: store.getState().issueCache
+      }
+    })
+  })
+})

--- a/src/renderer/src/store/slices/github.ts
+++ b/src/renderer/src/store/slices/github.ts
@@ -1,6 +1,7 @@
 import type { StateCreator } from 'zustand'
 import type { AppState } from '../types'
 import type { PRInfo, IssueInfo, PRCheckDetail, Worktree } from '../../../../shared/types'
+import { syncPRChecksStatus } from './github-checks'
 
 export type CacheEntry<T> = {
   data: T | null
@@ -155,7 +156,13 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
     const cacheKey = `${repoPath}::pr-checks::${prNumber}`
     const cached = get().checksCache[cacheKey]
     if (!options?.force && isFresh(cached, CHECKS_CACHE_TTL)) {
-      return cached.data ?? []
+      const cachedChecks = cached.data ?? []
+      const prStatusUpdate = syncPRChecksStatus(get(), repoPath, branch, cachedChecks)
+      if (prStatusUpdate) {
+        set(prStatusUpdate)
+        debouncedSaveCache(get())
+      }
+      return cachedChecks
     }
 
     const inflightRequest = inflightChecksRequests.get(cacheKey)
@@ -170,9 +177,19 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
           prNumber,
           branch
         })) as PRCheckDetail[]
-        set((s) => ({
-          checksCache: { ...s.checksCache, [cacheKey]: { data: checks, fetchedAt: Date.now() } }
-        }))
+        set((s) => {
+          const nextState: Partial<AppState> = {
+            checksCache: { ...s.checksCache, [cacheKey]: { data: checks, fetchedAt: Date.now() } }
+          }
+
+          const prStatusUpdate = syncPRChecksStatus(s, repoPath, branch, checks)
+          if (prStatusUpdate?.prCache) {
+            nextState.prCache = prStatusUpdate.prCache
+          }
+
+          return nextState
+        })
+        debouncedSaveCache(get())
         return checks
       } catch (err) {
         console.error('Failed to fetch PR checks:', err)


### PR DESCRIPTION
## Summary
- Show a colored status dot (green/red/amber) on the Checks tab in the right sidebar activity bar reflecting CI check results
- Extract check status derivation logic into a dedicated `github-checks` module with `deriveCheckStatusFromChecks` and `syncPRChecksStatus` helpers
- Sync computed checks status back into PR cache on both fresh fetches and cache hits
- Reorder activity bar tabs: Search now appears before Source Control
- Add unit tests for the checks status sync behavior

## Test plan
- [ ] Verify colored dot appears on Checks tab when a PR has checks running/passed/failed
- [ ] Verify dot is hidden when checks status is neutral (no checks)
- [ ] Verify Search tab appears before Source Control in the activity bar
- [ ] Run `pnpm vitest` to confirm new unit tests pass