### PR TITLE
feat: add release notes links to update UI

### DIFF
--- a/src/renderer/src/components/settings/GeneralPane.tsx
+++ b/src/renderer/src/components/settings/GeneralPane.tsx
@@ -187,13 +187,36 @@ export function GeneralPane({
         <p className="text-xs text-muted-foreground">
           {updateStatus.state === 'idle' && 'Updates are checked automatically on launch.'}
           {updateStatus.state === 'checking' && 'Checking for updates...'}
-          {updateStatus.state === 'available' &&
-            `Version ${updateStatus.version} is available. Click "Install Update" to download.`}
+          {updateStatus.state === 'available' && (
+            <>
+              Version {updateStatus.version} is available. Click &quot;Install Update&quot; to
+              download.{' '}
+              <a
+                href={`https://github.com/stablyai/orca/releases/tag/v${updateStatus.version}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline hover:text-foreground"
+              >
+                Release notes
+              </a>
+            </>
+          )}
           {updateStatus.state === 'not-available' && 'You\u2019re on the latest version.'}
           {updateStatus.state === 'downloading' &&
             `Downloading v${updateStatus.version}... ${updateStatus.percent}%`}
-          {updateStatus.state === 'downloaded' &&
-            `Version ${updateStatus.version} is ready to install.`}
+          {updateStatus.state === 'downloaded' && (
+            <>
+              Version {updateStatus.version} is ready to install.{' '}
+              <a
+                href={`https://github.com/stablyai/orca/releases/tag/v${updateStatus.version}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline hover:text-foreground"
+              >
+                Release notes
+              </a>
+            </>
+          )}
           {updateStatus.state === 'error' && `Update error: ${updateStatus.message}`}
         </p>
       </section>

--- a/src/renderer/src/components/sidebar/SidebarToolbar.tsx
+++ b/src/renderer/src/components/sidebar/SidebarToolbar.tsx
@@ -48,6 +48,17 @@ const SidebarToolbar = React.memo(function SidebarToolbar() {
               </span>
             )}
           </button>
+          {updateVersion && (
+            <a
+              href={`https://github.com/stablyai/orca/releases/tag/v${updateVersion}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={(e) => e.stopPropagation()}
+              className="shrink-0 px-1.5 py-1 mr-0.5 text-[10px] text-primary/60 hover:text-primary underline transition-colors"
+            >
+              Notes
+            </a>
+          )}
           <button
             onClick={(e) => {
               e.stopPropagation()

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -60,6 +60,16 @@ export function useIpcEvents(): void {
           }
           checkingToastId = undefined
           availableToastId = toast.info(`Version ${status.version} is available.`, {
+            description: createElement(
+              'a',
+              {
+                href: `https://github.com/stablyai/orca/releases/tag/v${status.version}`,
+                target: '_blank',
+                rel: 'noopener noreferrer',
+                style: { textDecoration: 'underline' }
+              },
+              'Release notes'
+            ),
             duration: Infinity,
             action: {
               label: 'Install',
@@ -82,6 +92,16 @@ export function useIpcEvents(): void {
           }
           toast.dismiss(downloadToastId)
           toast.success(`Version ${status.version} is ready to install.`, {
+            description: createElement(
+              'a',
+              {
+                href: `https://github.com/stablyai/orca/releases/tag/v${status.version}`,
+                target: '_blank',
+                rel: 'noopener noreferrer',
+                style: { textDecoration: 'underline' }
+              },
+              'Release notes'
+            ),
             duration: Infinity,
             action: {
               label: 'Restart Now',


### PR DESCRIPTION
## Problem
When Orca surfaces an available update, users can install it immediately, but they cannot inspect what changed from the update UI itself.

## Solution
Add direct release notes links to the update surfaces in settings, the sidebar update banner, and updater toasts so users can review the tagged GitHub release before installing or restarting.
