### PR TITLE
feat: show git status across file navigation

### DIFF
--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -21,6 +21,10 @@ import {
 
 const MAX_FILE_SIZE = 5 * 1024 * 1024 // 5MB
 
+function normalizeRelativePath(path: string): string {
+  return path.replace(/[\\/]+/g, '/').replace(/^\/+/, '')
+}
+
 /**
  * Check if a buffer appears to be binary (contains null bytes in first 8KB).
  */
@@ -185,7 +189,7 @@ export function registerFilesystemHandlers(store: Store): void {
 
           const data = msg.data
           const absPath: string = data.path.text
-          const relPath = relative(rootPath, absPath)
+          const relPath = normalizeRelativePath(relative(rootPath, absPath))
 
           let fileResult = fileMap.get(absPath)
           if (!fileResult) {

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -91,6 +91,12 @@
   --sidebar-accent-foreground: #171717;
   --sidebar-border: #e5e5e5;
   --sidebar-ring: #a1a1a1;
+  --git-decoration-added: #587c0c;
+  --git-decoration-modified: #895503;
+  --git-decoration-deleted: #ad0707;
+  --git-decoration-renamed: #007acc;
+  --git-decoration-untracked: #007100;
+  --git-decoration-copied: #007acc;
 }
 
 /* ── Dark Mode ───────────────────────────────────────── */
@@ -129,6 +135,12 @@
   --sidebar-accent-foreground: #fafafa;
   --sidebar-border: rgb(255 255 255 / 0.07);
   --sidebar-ring: #525252;
+  --git-decoration-added: #81b88b;
+  --git-decoration-modified: #e2c08d;
+  --git-decoration-deleted: #c74e39;
+  --git-decoration-renamed: #73c991;
+  --git-decoration-untracked: #73c991;
+  --git-decoration-copied: #73c991;
 }
 
 /* ── Base Layer ──────────────────────────────────────── */

--- a/src/renderer/src/components/right-sidebar/FileExplorer.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorer.tsx
@@ -3,7 +3,17 @@ import { useVirtualizer } from '@tanstack/react-virtual'
 import { ChevronRight, File, Folder, FolderOpen, Loader2 } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { detectLanguage } from '@/lib/language-detect'
+import { joinPath, normalizeRelativePath } from '@/lib/path'
 import { cn } from '@/lib/utils'
+import type { GitFileStatus } from '../../../../shared/types'
+import { splitPathSegments } from './path-tree'
+import {
+  buildStatusMap,
+  getDominantStatus,
+  shouldPropagateStatus,
+  STATUS_COLORS,
+  STATUS_LABELS
+} from './status-display'
 
 type TreeNode = {
   name: string
@@ -26,6 +36,7 @@ export default function FileExplorer(): React.JSX.Element {
   const openFile = useAppStore((s) => s.openFile)
   const pinFile = useAppStore((s) => s.pinFile)
   const activeFileId = useAppStore((s) => s.activeFileId)
+  const gitStatusByWorktree = useAppStore((s) => s.gitStatusByWorktree)
 
   // Find active worktree path
   const worktreePath = useMemo(() => {
@@ -43,6 +54,46 @@ export default function FileExplorer(): React.JSX.Element {
 
   const [dirCache, setDirCache] = useState<Record<string, DirCache>>({})
   const scrollRef = useRef<HTMLDivElement>(null)
+
+  const entries = useMemo(
+    () => (activeWorktreeId ? (gitStatusByWorktree[activeWorktreeId] ?? []) : []),
+    [activeWorktreeId, gitStatusByWorktree]
+  )
+
+  const statusByRelativePath = useMemo(() => buildStatusMap(entries), [entries])
+
+  const folderStatusByRelativePath = useMemo(() => {
+    const folderStatuses = new Map<string, GitFileStatus[]>()
+
+    for (const entry of entries) {
+      if (!shouldPropagateStatus(entry.status)) {
+        continue
+      }
+
+      const segments = splitPathSegments(entry.path)
+      if (segments.length <= 1) {
+        continue
+      }
+
+      let currentPath = ''
+      for (const segment of segments.slice(0, -1)) {
+        currentPath = currentPath ? joinPath(currentPath, segment) : segment
+        const statuses = folderStatuses.get(currentPath)
+        if (statuses) {
+          statuses.push(entry.status)
+        } else {
+          folderStatuses.set(currentPath, [entry.status])
+        }
+      }
+    }
+
+    return new Map(
+      Array.from(folderStatuses.entries()).map(([folderPath, statuses]) => [
+        folderPath,
+        getDominantStatus(statuses)
+      ])
+    )
+  }, [entries])
 
   const expanded = useMemo(
     () =>
@@ -73,9 +124,9 @@ export default function FileExplorer(): React.JSX.Element {
           .filter((e) => e.name !== 'node_modules' && e.name !== '.git')
           .map((e) => ({
             name: e.name,
-            path: `${dirPath}/${e.name}`,
+            path: joinPath(dirPath, e.name),
             relativePath: worktreePath
-              ? `${dirPath}/${e.name}`.slice(worktreePath.length + 1)
+              ? normalizeRelativePath(joinPath(dirPath, e.name).slice(worktreePath.length + 1))
               : e.name,
             isDirectory: e.isDirectory,
             depth: depth + 1
@@ -109,7 +160,7 @@ export default function FileExplorer(): React.JSX.Element {
     for (const dirPath of expanded) {
       if (!dirCache[dirPath]?.children.length && !dirCache[dirPath]?.loading) {
         const depth = worktreePath
-          ? dirPath.slice(worktreePath.length + 1).split('/').length - 1
+          ? splitPathSegments(dirPath.slice(worktreePath.length + 1)).length - 1
           : 0
         void loadDir(dirPath, depth)
       }
@@ -159,16 +210,13 @@ export default function FileExplorer(): React.JSX.Element {
       if (node.isDirectory) {
         toggleDir(activeWorktreeId, node.path)
       } else {
-        openFile(
-          {
-            filePath: node.path,
-            relativePath: node.relativePath,
-            worktreeId: activeWorktreeId,
-            language: detectLanguage(node.name),
-            mode: 'edit'
-          },
-          { preview: true }
-        )
+        openFile({
+          filePath: node.path,
+          relativePath: node.relativePath,
+          worktreeId: activeWorktreeId,
+          language: detectLanguage(node.name),
+          mode: 'edit'
+        })
       }
     },
     [activeWorktreeId, toggleDir, openFile]
@@ -208,6 +256,11 @@ export default function FileExplorer(): React.JSX.Element {
           const isExpanded = expanded.has(node.path)
           const isLoading = node.isDirectory && dirCache[node.path]?.loading
           const isActive = activeFileId === node.path
+          const normalizedRelativePath = normalizeRelativePath(node.relativePath)
+          const nodeStatus = node.isDirectory
+            ? (folderStatusByRelativePath.get(normalizedRelativePath) ?? null)
+            : (statusByRelativePath.get(normalizedRelativePath) ?? null)
+          const statusColor = nodeStatus ? STATUS_COLORS[nodeStatus] : null
 
           return (
             <div
@@ -253,7 +306,20 @@ export default function FileExplorer(): React.JSX.Element {
                     <File className="size-3.5 shrink-0 text-muted-foreground" />
                   </>
                 )}
-                <span className="truncate">{node.name}</span>
+                <span
+                  className={cn('truncate', isActive && !nodeStatus && 'text-accent-foreground')}
+                  style={nodeStatus ? { color: statusColor ?? undefined } : undefined}
+                >
+                  {node.name}
+                </span>
+                {nodeStatus && (
+                  <span
+                    className="ml-auto shrink-0 text-[10px] font-semibold tracking-wide"
+                    style={{ color: statusColor ?? undefined }}
+                  >
+                    {STATUS_LABELS[nodeStatus]}
+                  </span>
+                )}
               </button>
             </div>
           )

--- a/src/renderer/src/components/right-sidebar/Search.tsx
+++ b/src/renderer/src/components/right-sidebar/Search.tsx
@@ -189,16 +189,13 @@ export default function Search(): React.JSX.Element {
         matchLength: match.matchLength
       })
 
-      openFile(
-        {
-          filePath: fileResult.filePath,
-          relativePath: fileResult.relativePath,
-          worktreeId: activeWorktreeId,
-          language: detectLanguage(fileResult.relativePath),
-          mode: 'edit'
-        },
-        { preview: true }
-      )
+      openFile({
+        filePath: fileResult.filePath,
+        relativePath: fileResult.relativePath,
+        worktreeId: activeWorktreeId,
+        language: detectLanguage(fileResult.relativePath),
+        mode: 'edit'
+      })
     },
     [activeWorktreeId, openFile, setPendingEditorReveal]
   )

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 import {
   ChevronDown,
   Minus,
@@ -18,32 +18,18 @@ import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import type { GitStatusEntry, GitStagingArea } from '../../../../shared/types'
 import { getSourceControlActions } from './source-control-actions'
+import { STATUS_COLORS, STATUS_LABELS } from './status-display'
 
-const STATUS_ICONS: Record<string, React.ComponentType<{ className?: string }>> = {
+const STATUS_ICONS: Record<
+  string,
+  React.ComponentType<{ className?: string; style?: React.CSSProperties }>
+> = {
   modified: FileEdit,
   added: FilePlus,
   deleted: FileMinus,
   renamed: ArrowRightLeft,
   untracked: FileQuestion,
   copied: FilePlus
-}
-
-const STATUS_LABELS: Record<string, string> = {
-  modified: 'M',
-  added: 'A',
-  deleted: 'D',
-  renamed: 'R',
-  untracked: 'U',
-  copied: 'C'
-}
-
-const STATUS_COLORS: Record<string, string> = {
-  modified: 'text-amber-500',
-  added: 'text-green-500',
-  deleted: 'text-red-500',
-  renamed: 'text-blue-500',
-  untracked: 'text-green-600',
-  copied: 'text-blue-400'
 }
 
 const SECTION_ORDER: GitStagingArea[] = ['staged', 'unstaged', 'untracked']
@@ -62,7 +48,6 @@ export default function SourceControl(): React.JSX.Element {
   const openAllDiffs = useAppStore((s) => s.openAllDiffs)
 
   const [collapsedSections, setCollapsedSections] = useState<Set<string>>(new Set())
-  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
   // Find active worktree path
   const worktreePath = useMemo(() => {
@@ -89,17 +74,6 @@ export default function SourceControl(): React.JSX.Element {
       // ignore
     }
   }, [activeWorktreeId, worktreePath, setGitStatus])
-
-  // Poll git status every 3 seconds
-  useEffect(() => {
-    void fetchStatus()
-    pollRef.current = setInterval(() => void fetchStatus(), 3000)
-    return () => {
-      if (pollRef.current) {
-        clearInterval(pollRef.current)
-      }
-    }
-  }, [fetchStatus])
 
   const entries = useMemo(
     () => (activeWorktreeId ? (gitStatusByWorktree[activeWorktreeId] ?? []) : []),
@@ -266,7 +240,10 @@ export default function SourceControl(): React.JSX.Element {
                     className="group flex items-center gap-1 px-3 py-0.5 hover:bg-accent/40 transition-colors cursor-pointer"
                     onClick={() => handleOpenDiff(entry)}
                   >
-                    <StatusIcon className={cn('size-3.5 shrink-0', STATUS_COLORS[entry.status])} />
+                    <StatusIcon
+                      className="size-3.5 shrink-0"
+                      style={{ color: STATUS_COLORS[entry.status] }}
+                    />
                     <span className="truncate text-[12px] flex-1 min-w-0">
                       <span className="text-foreground">{fileName}</span>
                       {dirPath && (
@@ -274,10 +251,8 @@ export default function SourceControl(): React.JSX.Element {
                       )}
                     </span>
                     <span
-                      className={cn(
-                        'text-[10px] font-bold shrink-0 w-4 text-center',
-                        STATUS_COLORS[entry.status]
-                      )}
+                      className="text-[10px] font-bold shrink-0 w-4 text-center"
+                      style={{ color: STATUS_COLORS[entry.status] }}
                     >
                       {STATUS_LABELS[entry.status]}
                     </span>

--- a/src/renderer/src/components/right-sidebar/index.tsx
+++ b/src/renderer/src/components/right-sidebar/index.tsx
@@ -17,6 +17,7 @@ import FileExplorer from './FileExplorer'
 import SourceControl from './SourceControl'
 import SearchPanel from './Search'
 import ChecksPanel from './ChecksPanel'
+import { useGitStatusPolling } from './useGitStatusPolling'
 
 const MIN_WIDTH = 220
 const MAX_WIDTH = 500
@@ -107,6 +108,8 @@ export default function RightSidebar(): React.JSX.Element {
   const checksStatus = useAppStore(getActiveChecksStatus)
   const activityBarPosition = useAppStore((s) => s.activityBarPosition)
   const setActivityBarPosition = useAppStore((s) => s.setActivityBarPosition)
+
+  useGitStatusPolling()
 
   // ─── Resize logic (handle on LEFT edge) ────────────
   const isResizing = useRef(false)

--- a/src/renderer/src/components/right-sidebar/path-tree.ts
+++ b/src/renderer/src/components/right-sidebar/path-tree.ts
@@ -1,0 +1,3 @@
+export function splitPathSegments(path: string): string[] {
+  return path.split(/[\\/]+/).filter(Boolean)
+}

--- a/src/renderer/src/components/right-sidebar/status-display.ts
+++ b/src/renderer/src/components/right-sidebar/status-display.ts
@@ -1,0 +1,63 @@
+import type { GitFileStatus, GitStatusEntry } from '../../../../shared/types'
+import { normalizeRelativePath } from '@/lib/path'
+
+export const STATUS_LABELS: Record<GitFileStatus, string> = {
+  modified: 'M',
+  added: 'A',
+  deleted: 'D',
+  renamed: 'R',
+  untracked: 'U',
+  copied: 'C'
+}
+
+export const STATUS_COLORS: Record<GitFileStatus, string> = {
+  modified: 'var(--git-decoration-modified)',
+  added: 'var(--git-decoration-added)',
+  deleted: 'var(--git-decoration-deleted)',
+  renamed: 'var(--git-decoration-renamed)',
+  untracked: 'var(--git-decoration-untracked)',
+  copied: 'var(--git-decoration-copied)'
+}
+
+const STATUS_PRIORITY: Record<GitFileStatus, number> = {
+  deleted: 5,
+  modified: 4,
+  added: 3,
+  untracked: 3,
+  renamed: 2,
+  copied: 1
+}
+
+export function getDominantStatus(statuses: Iterable<GitFileStatus>): GitFileStatus | null {
+  let dominantStatus: GitFileStatus | null = null
+  let dominantPriority = -1
+
+  for (const status of statuses) {
+    const priority = STATUS_PRIORITY[status]
+    if (priority > dominantPriority) {
+      dominantStatus = status
+      dominantPriority = priority
+    }
+  }
+
+  return dominantStatus
+}
+
+export function buildStatusMap(entries: GitStatusEntry[]): Map<string, GitFileStatus> {
+  const statusByPath = new Map<string, GitFileStatus>()
+
+  for (const entry of entries) {
+    const path = normalizeRelativePath(entry.path)
+    const existing = statusByPath.get(path)
+    const resolved = existing
+      ? (getDominantStatus([existing, entry.status]) ?? entry.status)
+      : entry.status
+    statusByPath.set(path, resolved)
+  }
+
+  return statusByPath
+}
+
+export function shouldPropagateStatus(status: GitFileStatus): boolean {
+  return status !== 'deleted'
+}

--- a/src/renderer/src/components/right-sidebar/useGitStatusPolling.ts
+++ b/src/renderer/src/components/right-sidebar/useGitStatusPolling.ts
@@ -1,0 +1,42 @@
+import { useCallback, useEffect, useMemo } from 'react'
+import { useAppStore } from '@/store'
+import type { GitStatusEntry } from '../../../../shared/types'
+
+const POLL_INTERVAL_MS = 3000
+
+export function useGitStatusPolling(): void {
+  const activeWorktreeId = useAppStore((s) => s.activeWorktreeId)
+  const worktreesByRepo = useAppStore((s) => s.worktreesByRepo)
+  const setGitStatus = useAppStore((s) => s.setGitStatus)
+
+  const worktreePath = useMemo(() => {
+    if (!activeWorktreeId) {
+      return null
+    }
+    for (const worktrees of Object.values(worktreesByRepo)) {
+      const wt = worktrees.find((w) => w.id === activeWorktreeId)
+      if (wt) {
+        return wt.path
+      }
+    }
+    return null
+  }, [activeWorktreeId, worktreesByRepo])
+
+  const fetchStatus = useCallback(async () => {
+    if (!activeWorktreeId || !worktreePath) {
+      return
+    }
+    try {
+      const entries = (await window.api.git.status({ worktreePath })) as GitStatusEntry[]
+      setGitStatus(activeWorktreeId, entries)
+    } catch {
+      // ignore
+    }
+  }, [activeWorktreeId, worktreePath, setGitStatus])
+
+  useEffect(() => {
+    void fetchStatus()
+    const intervalId = setInterval(() => void fetchStatus(), POLL_INTERVAL_MS)
+    return () => clearInterval(intervalId)
+  }, [fetchStatus])
+}

--- a/src/renderer/src/components/tab-bar/EditorFileTab.tsx
+++ b/src/renderer/src/components/tab-bar/EditorFileTab.tsx
@@ -9,6 +9,9 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
+import { basename, normalizeRelativePath } from '@/lib/path'
+import { STATUS_COLORS, STATUS_LABELS } from '../right-sidebar/status-display'
+import type { GitFileStatus } from '../../../../shared/types'
 import type { OpenFile } from '../../store/slices/editor'
 import { CLOSE_ALL_CONTEXT_MENUS_EVENT } from './SortableTab'
 
@@ -16,6 +19,7 @@ export default function EditorFileTab({
   file,
   isActive,
   hasTabsToRight,
+  statusByRelativePath,
   onActivate,
   onClose,
   onCloseToRight,
@@ -25,6 +29,7 @@ export default function EditorFileTab({
   file: OpenFile
   isActive: boolean
   hasTabsToRight: boolean
+  statusByRelativePath: Map<string, GitFileStatus>
   onActivate: () => void
   onClose: () => void
   onCloseToRight: () => void
@@ -42,10 +47,16 @@ export default function EditorFileTab({
     opacity: isDragging ? 0.8 : 1
   }
 
-  const fileName = file.relativePath.split('/').pop() ?? file.relativePath
+  const fileName = basename(file.relativePath)
   const isDiff = file.mode === 'diff'
   const [menuOpen, setMenuOpen] = useState(false)
   const [menuPoint, setMenuPoint] = useState({ x: 0, y: 0 })
+
+  const tabStatus =
+    file.relativePath === 'All Changes'
+      ? null
+      : (statusByRelativePath.get(normalizeRelativePath(file.relativePath)) ?? null)
+  const tabStatusColor = tabStatus ? STATUS_COLORS[tabStatus] : undefined
 
   useEffect(() => {
     const closeMenu = (): void => setMenuOpen(false)
@@ -101,12 +112,25 @@ export default function EditorFileTab({
           {file.isDirty && (
             <span className="mr-1 size-1.5 rounded-full bg-foreground/60 shrink-0" />
           )}
-          <span className={`truncate max-w-[130px] mr-1.5${file.isPreview ? ' italic' : ''}`}>
-            {isDiff
-              ? file.relativePath === 'All Changes'
-                ? 'All Changes'
-                : `${fileName} (diff${file.diffStaged ? ' staged' : ''})`
-              : fileName}
+          <span className="mr-1.5 flex min-w-0 items-baseline gap-1.5">
+            <span
+              className={`truncate max-w-[130px]${file.isPreview ? ' italic' : ''}`}
+              style={tabStatusColor ? { color: tabStatusColor } : undefined}
+            >
+              {isDiff
+                ? file.relativePath === 'All Changes'
+                  ? 'All Changes'
+                  : `${fileName} (diff${file.diffStaged ? ' staged' : ''})`
+                : fileName}
+            </span>
+            {tabStatus && (
+              <span
+                className="shrink-0 text-[10px] leading-none font-semibold tracking-wide"
+                style={{ color: tabStatusColor }}
+              >
+                {STATUS_LABELS[tabStatus]}
+              </span>
+            )}
           </span>
           <button
             className={`flex items-center justify-center w-4 h-4 rounded-sm shrink-0 ${

--- a/src/renderer/src/components/tab-bar/TabBar.tsx
+++ b/src/renderer/src/components/tab-bar/TabBar.tsx
@@ -10,6 +10,8 @@ import {
 import { SortableContext, horizontalListSortingStrategy, arrayMove } from '@dnd-kit/sortable'
 import { Plus } from 'lucide-react'
 import type { TerminalTab } from '../../../../shared/types'
+import { useAppStore } from '../../store'
+import { buildStatusMap } from '../right-sidebar/status-display'
 import type { OpenFile } from '../../store/slices/editor'
 import SortableTab from './SortableTab'
 import EditorFileTab from './EditorFileTab'
@@ -96,6 +98,12 @@ export default function TabBar({
     useSensor(PointerSensor, {
       activationConstraint: { distance: 5 }
     })
+  )
+
+  const gitStatusByWorktree = useAppStore((s) => s.gitStatusByWorktree)
+  const statusByRelativePath = useMemo(
+    () => buildStatusMap(gitStatusByWorktree[worktreeId] ?? []),
+    [worktreeId, gitStatusByWorktree]
   )
 
   const terminalMap = useMemo(() => new Map(tabs.map((t) => [t.id, t])), [tabs])
@@ -194,6 +202,7 @@ export default function TabBar({
                   file={item.data}
                   isActive={activeTabType === 'editor' && activeFileId === item.id}
                   hasTabsToRight={index < orderedItems.length - 1}
+                  statusByRelativePath={statusByRelativePath}
                   onActivate={() => onActivateFile?.(item.id)}
                   onClose={() => onCloseFile?.(item.id)}
                   onCloseToRight={() => onCloseToRight(item.id)}

--- a/src/renderer/src/lib/path.ts
+++ b/src/renderer/src/lib/path.ts
@@ -10,6 +10,10 @@ function getSeparator(path: string): '/' | '\\' {
   return path.includes('\\') ? '\\' : '/'
 }
 
+export function normalizeRelativePath(path: string): string {
+  return stripLeadingSeparators(path).replace(/[\\/]+/g, '/')
+}
+
 export function basename(path: string): string {
   const normalizedPath = stripTrailingSeparators(path)
   const lastSeparatorIndex = Math.max(


### PR DESCRIPTION
## Summary
- add shared git status polling and status resolution helpers for the right sidebar
- surface file change indicators in the file explorer and editor tabs
- simplify source control status rendering and normalize relative path handling

## Validation
- pnpm run typecheck
- pnpm run lint