### PR TITLE
Support dragging source control files into terminals

### DIFF
--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -238,6 +238,12 @@ export default function SourceControl(): React.JSX.Element {
                   <div
                     key={`${area}:${entry.path}`}
                     className="group flex items-center gap-1 px-3 py-0.5 hover:bg-accent/40 transition-colors cursor-pointer"
+                    draggable
+                    onDragStart={(e) => {
+                      const absolutePath = joinPath(worktreePath, entry.path)
+                      e.dataTransfer.setData('text/x-orca-file-path', absolutePath)
+                      e.dataTransfer.effectAllowed = 'copy'
+                    }}
                     onClick={() => handleOpenDiff(entry)}
                   >
                     <StatusIcon

--- a/src/renderer/src/components/terminal-pane/pane-helpers.test.ts
+++ b/src/renderer/src/components/terminal-pane/pane-helpers.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { shellEscapePath } from './pane-helpers'
+
+describe('shellEscapePath', () => {
+  it('keeps safe POSIX paths unquoted', () => {
+    expect(shellEscapePath('/tmp/file.txt', 'Macintosh')).toBe('/tmp/file.txt')
+  })
+
+  it('single-quotes POSIX paths with shell-special characters', () => {
+    expect(shellEscapePath("/tmp/it's here.txt", 'Linux')).toBe("'/tmp/it'\\''s here.txt'")
+  })
+
+  it('keeps safe Windows paths unquoted', () => {
+    expect(shellEscapePath('C:\\Users\\orca\\file.txt', 'Windows')).toBe(
+      'C:\\Users\\orca\\file.txt'
+    )
+  })
+
+  it('double-quotes Windows paths with spaces', () => {
+    expect(shellEscapePath('C:\\Users\\orca\\my file.txt', 'Windows')).toBe(
+      '"C:\\Users\\orca\\my file.txt"'
+    )
+  })
+
+  it('double-quotes Windows paths with cmd separators', () => {
+    expect(shellEscapePath('C:\\Users\\orca\\a&b.txt', 'Windows')).toBe(
+      '"C:\\Users\\orca\\a&b.txt"'
+    )
+  })
+})

--- a/src/renderer/src/components/terminal-pane/pane-helpers.ts
+++ b/src/renderer/src/components/terminal-pane/pane-helpers.ts
@@ -21,9 +21,21 @@ export function fitAndFocusPanes(manager: PaneManager): void {
   focusActivePane(manager)
 }
 
-export function shellEscapePath(path: string): string {
+function isWindowsUserAgent(userAgent: string): boolean {
+  return userAgent.includes('Windows')
+}
+
+export function shellEscapePath(
+  path: string,
+  userAgent: string = typeof navigator === 'undefined' ? '' : navigator.userAgent
+): string {
+  if (isWindowsUserAgent(userAgent)) {
+    return /^[a-zA-Z0-9_./@:\\-]+$/.test(path) ? path : `"${path}"`
+  }
+
   if (/^[a-zA-Z0-9_./@:-]+$/.test(path)) {
     return path
   }
+
   return `'${path.replace(/'/g, "'\\''")}'`
 }


### PR DESCRIPTION
## Problem
Source control entries could be opened in the diff view, but they could not be dragged into the terminal the way file explorer entries can. The terminal drop path escaping was also POSIX-only, which would break dragged file paths on Windows.

## Solution
Make source control rows draggable by sending the active worktree file path through the existing in-app drag payload. Update terminal path escaping to quote paths appropriately for Windows and POSIX shells, and add tests covering both behaviors.