### PR TITLE
Publish stable GitHub release asset names

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -14,7 +14,7 @@ asarUnpack:
 win:
   executableName: Orca
 nsis:
-  artifactName: ${name}-${version}-setup.${ext}
+  artifactName: orca-windows-setup.${ext}
   shortcutName: ${productName}
   uninstallDisplayName: ${productName}
   createDesktopShortcut: always
@@ -39,7 +39,7 @@ mac:
         - x64
         - arm64
 dmg:
-  artifactName: ${name}-${version}-${arch}.${ext}
+  artifactName: orca-macos-${arch}.${ext}
 linux:
   target:
     - AppImage
@@ -47,7 +47,7 @@ linux:
   maintainer: stablyai
   category: Utility
 appImage:
-  artifactName: ${name}-${version}.${ext}
+  artifactName: orca-linux.${ext}
 npmRebuild: false
 publish:
   provider: github


### PR DESCRIPTION
## Problem
The website needs stable download URLs to avoid stale GitHub Releases API caching, but Orca currently publishes versioned asset names like `orca-1.0.60-setup.exe` and `orca-1.0.60-arm64.dmg`. That forces downstream consumers to query release metadata instead of linking directly to GitHub's built-in latest-download redirect.

## Solution
Change the published installer filenames to stable per-platform names: `orca-windows-setup.exe`, `orca-macos-arm64.dmg`, `orca-macos-x64.dmg`, and `orca-linux.AppImage`. That lets the marketing site and any future consumers link directly to `releases/latest/download/<filename>` with no GitHub API dependency or cache invalidation step.

## Notes
This should merge before the corresponding marketing-site PR: https://github.com/stablyai/orca-marketing-website/pull/13
