### PR TITLE
feat: show diff indicator in editor header and file tabs

### DIFF
--- a/src/renderer/src/components/editor/editor-header.test.ts
+++ b/src/renderer/src/components/editor/editor-header.test.ts
@@ -25,6 +25,40 @@ describe('getEditorHeaderCopyState', () => {
     })
   })
 
+  it('adds a diff suffix to single-file diff headers', () => {
+    expect(
+      getEditorHeaderCopyState(
+        makeOpenFile({
+          id: '/repo/file.ts::unstaged',
+          mode: 'diff',
+          diffStaged: false
+        })
+      )
+    ).toEqual({
+      copyText: '/repo/file.ts',
+      copyToastLabel: 'File path copied',
+      pathLabel: '/repo/file.ts (diff)',
+      pathTitle: '/repo/file.ts (diff)'
+    })
+  })
+
+  it('adds a staged diff suffix to staged diff headers', () => {
+    expect(
+      getEditorHeaderCopyState(
+        makeOpenFile({
+          id: '/repo/file.ts::staged',
+          mode: 'diff',
+          diffStaged: true
+        })
+      )
+    ).toEqual({
+      copyText: '/repo/file.ts',
+      copyToastLabel: 'File path copied',
+      pathLabel: '/repo/file.ts (diff staged)',
+      pathTitle: '/repo/file.ts (diff staged)'
+    })
+  })
+
   it('shows All Changes while still copying the worktree path', () => {
     expect(
       getEditorHeaderCopyState(

--- a/src/renderer/src/components/editor/editor-header.ts
+++ b/src/renderer/src/components/editor/editor-header.ts
@@ -1,4 +1,5 @@
 import type { OpenFile } from '@/store/slices/editor'
+import { getEditorDisplayLabel } from './editor-labels'
 
 export type EditorHeaderCopyState = {
   copyText: string | null
@@ -19,10 +20,12 @@ export function getEditorHeaderCopyState(file: OpenFile): EditorHeaderCopyState 
     }
   }
 
+  const displayLabel = getEditorDisplayLabel(file, 'fullPath')
+
   return {
     copyText: file.filePath,
     copyToastLabel: 'File path copied',
-    pathLabel: file.filePath,
-    pathTitle: file.filePath
+    pathLabel: displayLabel,
+    pathTitle: displayLabel
   }
 }

--- a/src/renderer/src/components/editor/editor-labels.ts
+++ b/src/renderer/src/components/editor/editor-labels.ts
@@ -1,0 +1,37 @@
+import type { OpenFile } from '@/store/slices/editor'
+import { basename } from '@/lib/path'
+
+type EditorLabelVariant = 'fileName' | 'relativePath' | 'fullPath'
+
+function getBaseLabel(file: OpenFile, variant: EditorLabelVariant): string {
+  if (file.mode === 'diff' && file.diffStaged === undefined) {
+    return file.relativePath
+  }
+
+  switch (variant) {
+    case 'fullPath':
+      return file.filePath
+    case 'relativePath':
+      return file.relativePath
+    case 'fileName':
+      return basename(file.relativePath)
+  }
+}
+
+function getDiffSuffix(file: OpenFile): string | null {
+  if (file.mode !== 'diff' || file.diffStaged === undefined) {
+    return null
+  }
+
+  return file.diffStaged ? 'diff staged' : 'diff'
+}
+
+export function getEditorDisplayLabel(
+  file: OpenFile,
+  variant: EditorLabelVariant = 'fileName'
+): string {
+  const baseLabel = getBaseLabel(file, variant)
+  const diffSuffix = getDiffSuffix(file)
+
+  return diffSuffix ? `${baseLabel} (${diffSuffix})` : baseLabel
+}

--- a/src/renderer/src/components/tab-bar/EditorFileTab.tsx
+++ b/src/renderer/src/components/tab-bar/EditorFileTab.tsx
@@ -9,7 +9,8 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
-import { basename, normalizeRelativePath } from '@/lib/path'
+import { normalizeRelativePath } from '@/lib/path'
+import { getEditorDisplayLabel } from '@/components/editor/editor-labels'
 import { STATUS_COLORS, STATUS_LABELS } from '../right-sidebar/status-display'
 import type { GitFileStatus } from '../../../../shared/types'
 import type { OpenFile } from '../../store/slices/editor'
@@ -47,7 +48,6 @@ export default function EditorFileTab({
     opacity: isDragging ? 0.8 : 1
   }
 
-  const fileName = basename(file.relativePath)
   const isDiff = file.mode === 'diff'
   const [menuOpen, setMenuOpen] = useState(false)
   const [menuPoint, setMenuPoint] = useState({ x: 0, y: 0 })
@@ -117,11 +117,7 @@ export default function EditorFileTab({
               className={`truncate max-w-[130px]${file.isPreview ? ' italic' : ''}`}
               style={tabStatusColor ? { color: tabStatusColor } : undefined}
             >
-              {isDiff
-                ? file.relativePath === 'All Changes'
-                  ? 'All Changes'
-                  : `${fileName} (diff${file.diffStaged ? ' staged' : ''})`
-                : fileName}
+              {getEditorDisplayLabel(file)}
             </span>
             {tabStatus && (
               <span


### PR DESCRIPTION
## Summary
- Extract shared `getEditorDisplayLabel()` into `editor-labels.ts` so both the tab bar and editor header display "(diff)" / "(diff staged)" suffixes consistently
- Editor header now shows the diff suffix in its path label and title
- Adds tests for single-file diff and staged diff header states

## Test plan
- [ ] Open a file in diff view → tab and header both show "(diff)" suffix
- [ ] Open a staged diff → tab and header both show "(diff staged)" suffix
- [ ] Open "All Changes" combined diff → header shows "All Changes" with no suffix
- [ ] Normal edit tabs remain unchanged