### PR TITLE
feat: preview image files in editor diffs

### DIFF
--- a/src/main/git/status.test.ts
+++ b/src/main/git/status.test.ts
@@ -20,7 +20,7 @@ vi.mock('fs/promises', () => ({
   rm: rmMock
 }))
 
-import { discardChanges, isWithinWorktree } from './status'
+import { discardChanges, getDiff, isWithinWorktree } from './status'
 
 describe('discardChanges', () => {
   beforeEach(() => {
@@ -79,5 +79,48 @@ describe('discardChanges', () => {
 
   it('accepts in-tree Windows paths when resolving containment', async () => {
     expect(isWithinWorktree(path.win32, 'C:\\repo', 'C:\\repo\\src\\file.ts')).toBe(true)
+  })
+})
+
+describe('getDiff', () => {
+  beforeEach(() => {
+    execFileAsyncMock.mockReset()
+    readFileMock.mockReset()
+  })
+
+  it('returns base64 payloads for unstaged image diffs', async () => {
+    execFileAsyncMock.mockResolvedValueOnce({
+      stdout: Buffer.from([0x89, 0x50, 0x4e, 0x47])
+    })
+    readFileMock.mockResolvedValueOnce(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00]))
+
+    await expect(getDiff('/repo', 'image.png', false)).resolves.toEqual({
+      originalContent: Buffer.from([0x89, 0x50, 0x4e, 0x47]).toString('base64'),
+      modifiedContent: Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00]).toString('base64'),
+      isImage: true,
+      mimeType: 'image/png'
+    })
+
+    expect(execFileAsyncMock).toHaveBeenCalledWith('git', ['show', 'HEAD:image.png'], {
+      cwd: '/repo',
+      encoding: 'buffer',
+      maxBuffer: 10 * 1024 * 1024
+    })
+    expect(readFileMock).toHaveBeenCalledWith('/repo/image.png')
+  })
+
+  it('returns base64 payloads for staged image diffs', async () => {
+    execFileAsyncMock
+      .mockResolvedValueOnce({ stdout: Buffer.from([0x01, 0x02]) })
+      .mockResolvedValueOnce({ stdout: Buffer.from([0x03, 0x04]) })
+
+    await expect(getDiff('/repo', 'image.png', true)).resolves.toEqual({
+      originalContent: Buffer.from([0x01, 0x02]).toString('base64'),
+      modifiedContent: Buffer.from([0x03, 0x04]).toString('base64'),
+      isImage: true,
+      mimeType: 'image/png'
+    })
+
+    expect(readFileMock).not.toHaveBeenCalled()
   })
 })

--- a/src/main/git/status.ts
+++ b/src/main/git/status.ts
@@ -5,6 +5,16 @@ import * as path from 'path'
 import type { GitStatusEntry, GitFileStatus, GitDiffResult } from '../../shared/types'
 
 const execFileAsync = promisify(execFile)
+const IMAGE_MIME_TYPES: Record<string, string> = {
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.svg': 'image/svg+xml',
+  '.webp': 'image/webp',
+  '.bmp': 'image/bmp',
+  '.ico': 'image/x-icon'
+}
 
 /**
  * Parse `git status --porcelain=v2` output into structured entries.
@@ -95,6 +105,21 @@ export async function getDiff(
   filePath: string,
   staged: boolean
 ): Promise<GitDiffResult> {
+  const mimeType = IMAGE_MIME_TYPES[path.extname(filePath).toLowerCase()]
+  if (mimeType) {
+    const originalBuffer = await readGitFileVersion(worktreePath, filePath, 'head')
+    const modifiedBuffer = staged
+      ? await readGitFileVersion(worktreePath, filePath, 'index')
+      : await readWorkingTreeFile(worktreePath, filePath)
+
+    return {
+      originalContent: originalBuffer?.toString('base64') ?? '',
+      modifiedContent: modifiedBuffer?.toString('base64') ?? '',
+      isImage: true,
+      mimeType
+    }
+  }
+
   let originalContent = ''
   let modifiedContent = ''
 
@@ -137,6 +162,32 @@ export async function getDiff(
   }
 
   return { originalContent, modifiedContent }
+}
+
+async function readGitFileVersion(
+  worktreePath: string,
+  filePath: string,
+  source: 'head' | 'index'
+): Promise<Buffer | null> {
+  try {
+    const objectSpec = source === 'head' ? `HEAD:${filePath}` : `:${filePath}`
+    const { stdout } = await execFileAsync('git', ['show', objectSpec], {
+      cwd: worktreePath,
+      encoding: 'buffer',
+      maxBuffer: 10 * 1024 * 1024
+    })
+    return stdout
+  } catch {
+    return null
+  }
+}
+
+async function readWorkingTreeFile(worktreePath: string, filePath: string): Promise<Buffer | null> {
+  try {
+    return await readFile(path.join(worktreePath, filePath))
+  } catch {
+    return null
+  }
 }
 
 /**

--- a/src/main/ipc/filesystem.test.ts
+++ b/src/main/ipc/filesystem.test.ts
@@ -136,6 +136,52 @@ describe('registerFilesystemHandlers', () => {
     expect(writeFileMock).not.toHaveBeenCalled()
   })
 
+  it('returns base64 content for supported image binaries', async () => {
+    statMock.mockResolvedValue({ size: 4, isDirectory: () => false, mtimeMs: 123 })
+    readFileMock.mockResolvedValue(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00]))
+
+    registerFilesystemHandlers(store as never)
+
+    await expect(
+      handlers.get('fs:readFile')!(null, { filePath: '/workspace/repo/image.png' })
+    ).resolves.toEqual({
+      content: Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00]).toString('base64'),
+      isBinary: true,
+      isImage: true,
+      mimeType: 'image/png'
+    })
+  })
+
+  it('returns base64 content for supported text-based images', async () => {
+    statMock.mockResolvedValue({ size: 32, isDirectory: () => false, mtimeMs: 123 })
+    readFileMock.mockResolvedValue(Buffer.from('<svg xmlns="http://www.w3.org/2000/svg" />'))
+
+    registerFilesystemHandlers(store as never)
+
+    await expect(
+      handlers.get('fs:readFile')!(null, { filePath: '/workspace/repo/image.svg' })
+    ).resolves.toEqual({
+      content: Buffer.from('<svg xmlns="http://www.w3.org/2000/svg" />').toString('base64'),
+      isBinary: true,
+      isImage: true,
+      mimeType: 'image/svg+xml'
+    })
+  })
+
+  it('keeps non-image binaries hidden from the editor payload', async () => {
+    statMock.mockResolvedValue({ size: 4, isDirectory: () => false, mtimeMs: 123 })
+    readFileMock.mockResolvedValue(Buffer.from([0x00, 0x01, 0x02]))
+
+    registerFilesystemHandlers(store as never)
+
+    await expect(
+      handlers.get('fs:readFile')!(null, { filePath: '/workspace/repo/archive.zip' })
+    ).resolves.toEqual({
+      content: '',
+      isBinary: true
+    })
+  })
+
   it('normalizes repo worktree paths and keeps git file paths relative', async () => {
     stageFileMock.mockResolvedValue(undefined)
 

--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -1,6 +1,6 @@
 import { ipcMain } from 'electron'
 import { readdir, readFile, writeFile, stat, lstat } from 'fs/promises'
-import { relative } from 'path'
+import { extname, relative } from 'path'
 import { spawn } from 'child_process'
 import type { Store } from '../persistence'
 import type {
@@ -20,6 +20,16 @@ import {
 } from './filesystem-auth'
 
 const MAX_FILE_SIZE = 5 * 1024 * 1024 // 5MB
+const IMAGE_MIME_TYPES: Record<string, string> = {
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.svg': 'image/svg+xml',
+  '.webp': 'image/webp',
+  '.bmp': 'image/bmp',
+  '.ico': 'image/x-icon'
+}
 
 function normalizeRelativePath(path: string): string {
   return path.replace(/[\\/]+/g, '/').replace(/^\/+/, '')
@@ -60,7 +70,10 @@ export function registerFilesystemHandlers(store: Store): void {
 
   ipcMain.handle(
     'fs:readFile',
-    async (_event, args: { filePath: string }): Promise<{ content: string; isBinary: boolean }> => {
+    async (
+      _event,
+      args: { filePath: string }
+    ): Promise<{ content: string; isBinary: boolean; isImage?: boolean; mimeType?: string }> => {
       const filePath = await resolveAuthorizedPath(args.filePath, store)
       const stats = await stat(filePath)
       if (stats.size > MAX_FILE_SIZE) {
@@ -70,6 +83,16 @@ export function registerFilesystemHandlers(store: Store): void {
       }
 
       const buffer = await readFile(filePath)
+      const mimeType = IMAGE_MIME_TYPES[extname(filePath).toLowerCase()]
+      if (mimeType) {
+        return {
+          content: buffer.toString('base64'),
+          isBinary: true,
+          isImage: true,
+          mimeType
+        }
+      }
+
       if (isBinaryBuffer(buffer)) {
         return { content: '', isBinary: true }
       }

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -127,7 +127,9 @@ type UIApi = {
 
 type FsApi = {
   readDir: (args: { dirPath: string }) => Promise<DirEntry[]>
-  readFile: (args: { filePath: string }) => Promise<{ content: string; isBinary: boolean }>
+  readFile: (args: {
+    filePath: string
+  }) => Promise<{ content: string; isBinary: boolean; isImage?: boolean; mimeType?: string }>
   writeFile: (args: { filePath: string; content: string }) => Promise<void>
   stat: (args: {
     filePath: string

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -213,7 +213,9 @@ const api = {
       dirPath: string
     }): Promise<{ name: string; isDirectory: boolean; isSymlink: boolean }[]> =>
       ipcRenderer.invoke('fs:readDir', args),
-    readFile: (args: { filePath: string }): Promise<{ content: string; isBinary: boolean }> =>
+    readFile: (args: {
+      filePath: string
+    }): Promise<{ content: string; isBinary: boolean; isImage?: boolean; mimeType?: string }> =>
       ipcRenderer.invoke('fs:readFile', args),
     writeFile: (args: { filePath: string; content: string }): Promise<void> =>
       ipcRenderer.invoke('fs:writeFile', args),

--- a/src/renderer/src/components/editor/EditorPanel.tsx
+++ b/src/renderer/src/components/editor/EditorPanel.tsx
@@ -6,6 +6,8 @@ import { getEditorHeaderCopyState } from './editor-header'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import type { MarkdownViewMode } from '@/store/slices/editor'
 import MarkdownViewToggle from './MarkdownViewToggle'
+import ImageDiffViewer from './ImageDiffViewer'
+import ImageViewer from './ImageViewer'
 
 const MonacoEditor = lazy(() => import('./MonacoEditor'))
 const DiffViewer = lazy(() => import('./DiffViewer'))
@@ -15,11 +17,15 @@ const MarkdownPreview = lazy(() => import('./MarkdownPreview'))
 type FileContent = {
   content: string
   isBinary: boolean
+  isImage?: boolean
+  mimeType?: string
 }
 
 type DiffContent = {
   originalContent: string
   modifiedContent: string
+  isImage?: boolean
+  mimeType?: string
 }
 
 export default function EditorPanel(): React.JSX.Element | null {
@@ -345,6 +351,15 @@ export default function EditorPanel(): React.JSX.Element | null {
               )
             }
             if (fc.isBinary) {
+              if (fc.isImage) {
+                return (
+                  <ImageViewer
+                    content={fc.content}
+                    filePath={activeFile.filePath}
+                    mimeType={fc.mimeType}
+                  />
+                )
+              }
               return (
                 <div className="flex items-center justify-center h-full text-muted-foreground text-sm">
                   Binary file — cannot display
@@ -365,6 +380,17 @@ export default function EditorPanel(): React.JSX.Element | null {
             }
             // Unstaged diffs are editable (right side = working tree file)
             const isEditable = activeFile.diffStaged === false
+            if (dc.isImage) {
+              return (
+                <ImageDiffViewer
+                  originalContent={dc.originalContent}
+                  modifiedContent={editBuffers[activeFile.id] ?? dc.modifiedContent}
+                  filePath={activeFile.filePath}
+                  mimeType={dc.mimeType}
+                  sideBySide={sideBySide}
+                />
+              )
+            }
             return (
               <DiffViewer
                 originalContent={dc.originalContent}

--- a/src/renderer/src/components/editor/ImageDiffViewer.tsx
+++ b/src/renderer/src/components/editor/ImageDiffViewer.tsx
@@ -1,0 +1,67 @@
+import { type JSX } from 'react'
+import ImageViewer from './ImageViewer'
+
+type ImageDiffViewerProps = {
+  originalContent: string
+  modifiedContent: string
+  filePath: string
+  mimeType?: string
+  sideBySide: boolean
+}
+
+function ImageDiffPane({
+  label,
+  content,
+  filePath,
+  mimeType
+}: {
+  label: string
+  content: string
+  filePath: string
+  mimeType?: string
+}): JSX.Element {
+  if (!content) {
+    return (
+      <div className="flex h-full min-h-0 flex-col overflow-hidden rounded-md bg-muted/10">
+        <div className="px-3 py-2 text-xs font-medium text-muted-foreground">{label}</div>
+        <div className="flex flex-1 items-center justify-center bg-muted/20 p-6 text-sm text-muted-foreground">
+          No image
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col overflow-hidden rounded-md bg-muted/10">
+      <div className="px-3 py-2 text-xs font-medium text-muted-foreground">{label}</div>
+      <div className="min-h-0 flex-1">
+        <ImageViewer content={content} filePath={filePath} mimeType={mimeType} />
+      </div>
+    </div>
+  )
+}
+
+export default function ImageDiffViewer({
+  originalContent,
+  modifiedContent,
+  filePath,
+  mimeType,
+  sideBySide
+}: ImageDiffViewerProps): JSX.Element {
+  return (
+    <div className={`grid h-full min-h-0 gap-3 p-3 ${sideBySide ? 'grid-cols-2' : 'grid-cols-1'}`}>
+      <ImageDiffPane
+        label="Original"
+        content={originalContent}
+        filePath={filePath}
+        mimeType={mimeType}
+      />
+      <ImageDiffPane
+        label="Modified"
+        content={modifiedContent}
+        filePath={filePath}
+        mimeType={mimeType}
+      />
+    </div>
+  )
+}

--- a/src/renderer/src/components/editor/ImageViewer.tsx
+++ b/src/renderer/src/components/editor/ImageViewer.tsx
@@ -1,0 +1,163 @@
+import { Image as ImageIcon, RotateCcw, X, ZoomIn, ZoomOut } from 'lucide-react'
+import { type JSX, useMemo, useState } from 'react'
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
+
+const FALLBACK_IMAGE_MIME_TYPE = 'image/png'
+const MIN_ZOOM = 0.25
+const MAX_ZOOM = 8
+const ZOOM_STEP = 1.25
+
+type ImageViewerProps = {
+  content: string
+  filePath: string
+  mimeType?: string
+}
+
+export default function ImageViewer({
+  content,
+  filePath,
+  mimeType = FALLBACK_IMAGE_MIME_TYPE
+}: ImageViewerProps): JSX.Element {
+  const [imageError, setImageError] = useState(false)
+  const [isPopupOpen, setIsPopupOpen] = useState(false)
+  const [zoom, setZoom] = useState(1)
+  const [imageDimensions, setImageDimensions] = useState<{ width: number; height: number } | null>(
+    null
+  )
+
+  const filename = useMemo(() => filePath.split(/[/\\]/).pop() || filePath, [filePath])
+  const cleanedContent = useMemo(() => content.replace(/\s/g, ''), [content])
+  const dataUrl = useMemo(
+    () => `data:${mimeType};base64,${cleanedContent}`,
+    [cleanedContent, mimeType]
+  )
+  const estimatedSize = useMemo(() => {
+    const bytes = Math.floor((cleanedContent.length * 3) / 4)
+    if (bytes < 1024) {
+      return `${bytes} B`
+    }
+    if (bytes < 1024 * 1024) {
+      return `${(bytes / 1024).toFixed(1)} KB`
+    }
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+  }, [cleanedContent])
+  const zoomPercent = Math.round(zoom * 100)
+
+  if (imageError) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-3 bg-muted/20 p-8 text-sm text-muted-foreground">
+        <ImageIcon size={40} />
+        <div>Failed to load image preview</div>
+        <div className="max-w-md break-all text-center text-xs">{filename}</div>
+      </div>
+    )
+  }
+
+  const imagePane = (
+    <div
+      className="flex flex-1 items-center justify-center overflow-auto bg-muted/20 p-4 cursor-pointer"
+      onClick={() => setIsPopupOpen(true)}
+      title="Open image in popup"
+    >
+      <div
+        className="flex items-center justify-center"
+        style={{ transform: `scale(${zoom})`, transformOrigin: 'center center' }}
+      >
+        <img
+          src={dataUrl}
+          alt={filename}
+          className="max-h-full max-w-full object-contain"
+          onLoad={(event) => {
+            const img = event.currentTarget
+            setImageDimensions({ width: img.naturalWidth, height: img.naturalHeight })
+          }}
+          onError={() => setImageError(true)}
+        />
+      </div>
+    </div>
+  )
+
+  return (
+    <>
+      <div className="flex h-full min-h-0 flex-col">
+        {imagePane}
+        <div className="flex items-center gap-4 border-t px-4 py-2 text-xs text-muted-foreground">
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              className="rounded p-1 hover:bg-accent hover:text-foreground disabled:opacity-50"
+              onClick={() => setZoom((prev) => Math.max(MIN_ZOOM, prev / ZOOM_STEP))}
+              disabled={zoom <= MIN_ZOOM}
+              title="Zoom out"
+            >
+              <ZoomOut size={14} />
+            </button>
+            <button
+              type="button"
+              className="rounded p-1 hover:bg-accent hover:text-foreground disabled:opacity-50"
+              onClick={() => setZoom(1)}
+              disabled={zoom === 1}
+              title="Reset zoom"
+            >
+              <RotateCcw size={14} />
+            </button>
+            <button
+              type="button"
+              className="rounded p-1 hover:bg-accent hover:text-foreground disabled:opacity-50"
+              onClick={() => setZoom((prev) => Math.min(MAX_ZOOM, prev * ZOOM_STEP))}
+              disabled={zoom >= MAX_ZOOM}
+              title="Zoom in"
+            >
+              <ZoomIn size={14} />
+            </button>
+            <span className="ml-1 tabular-nums">{zoomPercent}%</span>
+          </div>
+          <span className="min-w-0 truncate" title={filename}>
+            {filename}
+          </span>
+          {imageDimensions && (
+            <span>
+              {imageDimensions.width} x {imageDimensions.height}
+            </span>
+          )}
+          <span>{estimatedSize}</span>
+        </div>
+      </div>
+      <Dialog open={isPopupOpen} onOpenChange={setIsPopupOpen}>
+        <DialogContent
+          showCloseButton={false}
+          className="top-1/2 left-1/2 h-[80vh] w-[70vw] max-w-[70vw] -translate-x-1/2 -translate-y-1/2 gap-0 overflow-hidden border border-border/60 bg-background p-0 shadow-2xl sm:max-w-[70vw]"
+        >
+          <DialogTitle className="sr-only">{filename}</DialogTitle>
+          <div className="flex items-center justify-between border-b border-border/60 bg-background/95 px-3 py-2">
+            <div className="min-w-0 truncate text-sm font-medium text-foreground">{filename}</div>
+            <button
+              type="button"
+              className="inline-flex items-center gap-1 rounded-md border border-border/60 bg-background px-2 py-1 text-xs text-muted-foreground hover:bg-accent hover:text-foreground"
+              onClick={() => setIsPopupOpen(false)}
+            >
+              <X size={14} />
+              <span>Close</span>
+            </button>
+          </div>
+          <div className="flex h-[calc(100%-4.5rem)] w-full min-h-0 items-center justify-center overflow-auto bg-muted/20 p-4">
+            <div
+              className="flex items-center justify-center"
+              style={{ transform: `scale(${zoom})`, transformOrigin: 'center center' }}
+            >
+              <img
+                src={dataUrl}
+                alt={filename}
+                className="block max-h-full max-w-full object-contain"
+              />
+            </div>
+          </div>
+          <div className="flex items-center justify-between border-t border-border/60 bg-background/95 px-3 py-2 text-xs text-muted-foreground">
+            <div>Press Esc to close</div>
+            <div className="tabular-nums">{zoomPercent}%</div>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -221,6 +221,8 @@ export type GitStatusEntry = {
 export type GitDiffResult = {
   originalContent: string
   modifiedContent: string
+  isImage?: boolean
+  mimeType?: string
 }
 
 // ─── Search ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- render supported image files directly in the editor instead of showing the generic binary placeholder
- render supported image diffs with dedicated image viewers and pass image metadata through the main/preload/shared types
- add test coverage for image diff payloads and text-based image previews such as SVG

## Verification
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm build