### PR TITLE
Add quick open file navigation

### DIFF
--- a/src/main/ipc/filesystem-list-files.ts
+++ b/src/main/ipc/filesystem-list-files.ts
@@ -1,0 +1,101 @@
+import { spawn } from 'child_process'
+import { relative } from 'path'
+import type { Store } from '../persistence'
+import { resolveAuthorizedPath } from './filesystem-auth'
+
+function normalizeRelativePath(path: string): string {
+  return path.replace(/[\\/]+/g, '/').replace(/^\/+/, '')
+}
+
+function shouldIncludeQuickOpenPath(path: string): boolean {
+  const normalizedPath = normalizeRelativePath(path)
+  const segments = normalizedPath.split('/')
+  return segments.every((segment, index) => {
+    if (segment === 'node_modules') {
+      return false
+    }
+    if (segment.startsWith('.') && !(index === 0 && segment === '.github')) {
+      return false
+    }
+    return true
+  })
+}
+
+export async function listQuickOpenFiles(rootPath: string, store: Store): Promise<string[]> {
+  const authorizedRootPath = await resolveAuthorizedPath(rootPath, store)
+  return new Promise((resolve) => {
+    const files: string[] = []
+    let buf = ''
+    let done = false
+    const finish = (): void => {
+      if (done) {
+        return
+      }
+      done = true
+      clearTimeout(timer)
+      resolve(files)
+    }
+    const child = spawn(
+      'rg',
+      [
+        '--files',
+        '--hidden',
+        '--glob',
+        '!.git',
+        '--glob',
+        '!.git/**',
+        '--glob',
+        '!**/node_modules',
+        '--glob',
+        '!**/node_modules/**',
+        '--glob',
+        '!.*',
+        '--glob',
+        '!.*/*',
+        '--glob',
+        '!**/.*',
+        '--glob',
+        '!**/.*/**',
+        '--glob',
+        '.github',
+        '--glob',
+        '.github/**',
+        authorizedRootPath
+      ],
+      {
+        stdio: ['ignore', 'pipe', 'pipe']
+      }
+    )
+    child.stdout.setEncoding('utf-8')
+    child.stdout.on('data', (chunk: string) => {
+      buf += chunk
+      const lines = buf.split('\n')
+      buf = lines.pop() ?? ''
+      for (const line of lines) {
+        if (!line) {
+          continue
+        }
+        const relPath = normalizeRelativePath(relative(authorizedRootPath, line))
+        if (shouldIncludeQuickOpenPath(relPath)) {
+          files.push(relPath)
+        }
+      }
+    })
+    child.stderr.on('data', () => {
+      /* drain */
+    })
+    child.once('error', () => {
+      finish()
+    })
+    child.once('close', () => {
+      if (buf) {
+        const relPath = normalizeRelativePath(relative(authorizedRootPath, buf))
+        if (shouldIncludeQuickOpenPath(relPath)) {
+          files.push(relPath)
+        }
+      }
+      finish()
+    })
+    const timer = setTimeout(() => child.kill(), 10000)
+  })
+}

--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -18,6 +18,7 @@ import {
   validateGitRelativeFilePath,
   isENOENT
 } from './filesystem-auth'
+import { listQuickOpenFiles } from './filesystem-list-files'
 
 const MAX_FILE_SIZE = 5 * 1024 * 1024 // 5MB
 const IMAGE_MIME_TYPES: Record<string, string> = {
@@ -146,6 +147,9 @@ export function registerFilesystemHandlers(store: Store): void {
     return new Promise((resolvePromise) => {
       const rgArgs: string[] = [
         '--json',
+        '--hidden',
+        '--glob',
+        '!.git',
         '--max-count',
         '200', // max matches per file
         '--max-filesize',
@@ -269,6 +273,13 @@ export function registerFilesystemHandlers(store: Store): void {
       const killTimeout = setTimeout(() => child.kill(), 30000)
     })
   })
+
+  // ─── List all files (for quick-open) ─────────────────────
+  ipcMain.handle(
+    'fs:listFiles',
+    async (_event, args: { rootPath: string }): Promise<string[]> =>
+      listQuickOpenFiles(args.rootPath, store)
+  )
 
   // ─── Git operations ─────────────────────────────────────
   ipcMain.handle(

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -134,6 +134,7 @@ type FsApi = {
   stat: (args: {
     filePath: string
   }) => Promise<{ size: number; isDirectory: boolean; mtime: number }>
+  listFiles: (args: { rootPath: string }) => Promise<string[]>
   search: (args: SearchOptions) => Promise<SearchResult>
 }
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -223,6 +223,8 @@ const api = {
       filePath: string
     }): Promise<{ size: number; isDirectory: boolean; mtime: number }> =>
       ipcRenderer.invoke('fs:stat', args),
+    listFiles: (args: { rootPath: string }): Promise<string[]> =>
+      ipcRenderer.invoke('fs:listFiles', args),
     search: (args: {
       query: string
       rootPath: string

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -10,6 +10,20 @@ import Terminal from './components/Terminal'
 import Landing from './components/Landing'
 import Settings from './components/settings/Settings'
 import RightSidebar from './components/right-sidebar'
+import QuickOpen from './components/QuickOpen'
+
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) {
+    return false
+  }
+  if (target.isContentEditable) {
+    return true
+  }
+  return (
+    target.closest('input, textarea, select, [contenteditable=""], [contenteditable="true"]') !==
+    null
+  )
+}
 
 function App(): React.JSX.Element {
   const toggleSidebar = useAppStore((s) => s.toggleSidebar)
@@ -43,6 +57,7 @@ function App(): React.JSX.Element {
   const rightSidebarWidth = useAppStore((s) => s.rightSidebarWidth)
   const setRightSidebarOpen = useAppStore((s) => s.setRightSidebarOpen)
   const setRightSidebarTab = useAppStore((s) => s.setRightSidebarTab)
+  const setQuickOpenVisible = useAppStore((s) => s.setQuickOpenVisible)
 
   // Subscribe to IPC push events
   useIpcEvents()
@@ -214,9 +229,25 @@ function App(): React.JSX.Element {
       if (e.repeat) {
         return
       }
+      if (isEditableTarget(e.target)) {
+        return
+      }
       // Accept Cmd on macOS, Ctrl on other platforms
       const mod = navigator.userAgent.includes('Mac') ? e.metaKey : e.ctrlKey
       if (!mod) {
+        return
+      }
+
+      // Cmd/Ctrl+P — quick open (go to file)
+      if (
+        !e.altKey &&
+        !e.shiftKey &&
+        e.key.toLowerCase() === 'p' &&
+        activeView !== 'settings' &&
+        activeWorktreeId !== null
+      ) {
+        e.preventDefault()
+        setQuickOpenVisible(true)
         return
       }
 
@@ -256,7 +287,15 @@ function App(): React.JSX.Element {
 
     window.addEventListener('keydown', onKeyDown, { capture: true })
     return () => window.removeEventListener('keydown', onKeyDown, { capture: true })
-  }, [openModal, repos.length, setRightSidebarTab, setRightSidebarOpen])
+  }, [
+    activeView,
+    activeWorktreeId,
+    openModal,
+    repos.length,
+    setRightSidebarTab,
+    setRightSidebarOpen,
+    setQuickOpenVisible
+  ])
 
   return (
     <div className="flex flex-col h-screen w-screen overflow-hidden">
@@ -311,6 +350,7 @@ function App(): React.JSX.Element {
         </div>
         {showSidebar && rightSidebarOpen ? <RightSidebar /> : null}
       </div>
+      <QuickOpen />
       <Toaster closeButton toastOptions={{ className: 'font-sans text-sm' }} />
     </div>
   )

--- a/src/renderer/src/components/QuickOpen.tsx
+++ b/src/renderer/src/components/QuickOpen.tsx
@@ -1,0 +1,264 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Search, File } from 'lucide-react'
+import { useAppStore } from '@/store'
+import { detectLanguage } from '@/lib/language-detect'
+import { joinPath } from '@/lib/path'
+
+/**
+ * Simple fuzzy match: checks if all characters in the query appear in order
+ * within the target string (case-insensitive). Returns a score (lower = better)
+ * or -1 if no match.
+ */
+function fuzzyMatch(query: string, target: string): number {
+  const q = query.toLowerCase()
+  const t = target.toLowerCase()
+  let qi = 0
+  let score = 0
+  let lastMatchIdx = -1
+
+  for (let ti = 0; ti < t.length && qi < q.length; ti++) {
+    if (t[ti] === q[qi]) {
+      // Bonus for consecutive matches
+      const gap = lastMatchIdx === -1 ? 0 : ti - lastMatchIdx - 1
+      score += gap
+      // Bonus for matching after separator (/ or .)
+      if (ti > 0 && (t[ti - 1] === '/' || t[ti - 1] === '.' || t[ti - 1] === '-')) {
+        score -= 5 // reward
+      }
+      lastMatchIdx = ti
+      qi++
+    }
+  }
+
+  if (qi < q.length) {
+    return -1 // not all chars matched
+  }
+
+  // Prefer matches where query appears in the filename (last segment)
+  const lastSlash = target.lastIndexOf('/')
+  const filename = target.slice(lastSlash + 1).toLowerCase()
+  if (filename.includes(q)) {
+    score -= 100 // strong reward for filename match
+  }
+
+  return score
+}
+
+export default function QuickOpen(): React.JSX.Element | null {
+  const visible = useAppStore((s) => s.quickOpenVisible)
+  const setVisible = useAppStore((s) => s.setQuickOpenVisible)
+  const activeWorktreeId = useAppStore((s) => s.activeWorktreeId)
+  const worktreesByRepo = useAppStore((s) => s.worktreesByRepo)
+  const openFile = useAppStore((s) => s.openFile)
+
+  const [query, setQuery] = useState('')
+  const [files, setFiles] = useState<string[]>([])
+  const [selectedIndex, setSelectedIndex] = useState(0)
+  const [loading, setLoading] = useState(false)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const listRef = useRef<HTMLDivElement>(null)
+
+  // Find active worktree path
+  const worktreePath = useMemo(() => {
+    if (!activeWorktreeId) {
+      return null
+    }
+    for (const worktrees of Object.values(worktreesByRepo)) {
+      const wt = worktrees.find((w) => w.id === activeWorktreeId)
+      if (wt) {
+        return wt.path
+      }
+    }
+    return null
+  }, [activeWorktreeId, worktreesByRepo])
+
+  // Load file list when opened
+  useEffect(() => {
+    if (!visible) {
+      return
+    }
+
+    if (!worktreePath) {
+      setFiles([])
+      setSelectedIndex(0)
+      return
+    }
+
+    let cancelled = false
+    setQuery('')
+    setSelectedIndex(0)
+    setFiles([])
+    setLoading(true)
+
+    void window.api.fs
+      .listFiles({ rootPath: worktreePath })
+      .then((result) => {
+        if (!cancelled) {
+          setFiles(result)
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setFiles([])
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoading(false)
+        }
+      })
+
+    // Focus input after mount
+    requestAnimationFrame(() => inputRef.current?.focus())
+
+    return () => {
+      cancelled = true
+    }
+  }, [visible, worktreePath])
+
+  // Filter files by fuzzy match
+  const filtered = useMemo(() => {
+    if (!query.trim()) {
+      // Show first 50 files when no query
+      return files.slice(0, 50).map((f) => ({ path: f, score: 0 }))
+    }
+    const results: { path: string; score: number }[] = []
+    for (const f of files) {
+      const score = fuzzyMatch(query.trim(), f)
+      if (score !== -1) {
+        results.push({ path: f, score })
+      }
+    }
+    results.sort((a, b) => a.score - b.score)
+    return results.slice(0, 50)
+  }, [files, query])
+
+  // Reset selection when results change
+  useEffect(() => {
+    setSelectedIndex(0)
+  }, [filtered])
+
+  // Scroll selected item into view
+  useEffect(() => {
+    if (!listRef.current) {
+      return
+    }
+    const item = listRef.current.children[selectedIndex] as HTMLElement | undefined
+    item?.scrollIntoView({ block: 'nearest' })
+  }, [selectedIndex])
+
+  const handleSelect = useCallback(
+    (relativePath: string) => {
+      if (!activeWorktreeId || !worktreePath) {
+        return
+      }
+      setVisible(false)
+      openFile({
+        filePath: joinPath(worktreePath, relativePath),
+        relativePath,
+        worktreeId: activeWorktreeId,
+        language: detectLanguage(relativePath),
+        mode: 'edit'
+      })
+    },
+    [activeWorktreeId, worktreePath, openFile, setVisible]
+  )
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        setVisible(false)
+        return
+      }
+      if (e.key === 'ArrowDown') {
+        e.preventDefault()
+        if (filtered.length > 0) {
+          setSelectedIndex((i) => Math.min(i + 1, filtered.length - 1))
+        }
+        return
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault()
+        if (filtered.length > 0) {
+          setSelectedIndex((i) => Math.max(i - 1, 0))
+        }
+        return
+      }
+      if (e.key === 'Enter') {
+        e.preventDefault()
+        const item = filtered[selectedIndex]
+        if (item) {
+          handleSelect(item.path)
+        }
+      }
+    },
+    [setVisible, filtered, selectedIndex, handleSelect]
+  )
+
+  if (!visible) {
+    return null
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center pt-8"
+      onClick={() => setVisible(false)}
+    >
+      <div
+        className="w-[660px] max-w-[90vw] bg-background border border-border rounded-lg shadow-2xl overflow-hidden pb-2"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Search input */}
+        <div className="flex items-center gap-2 px-3 border-b border-border">
+          <Search size={14} className="text-muted-foreground flex-shrink-0" />
+          <input
+            ref={inputRef}
+            type="text"
+            className="flex-1 bg-transparent text-sm py-2.5 outline-none text-foreground placeholder:text-muted-foreground"
+            placeholder="Go to file..."
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={handleKeyDown}
+            spellCheck={false}
+          />
+        </div>
+
+        {/* Results list */}
+        <div ref={listRef} className="max-h-[300px] overflow-y-auto scrollbar-sleek pb-2">
+          {loading && (
+            <div className="px-3 py-6 text-center text-xs text-muted-foreground">
+              Loading files...
+            </div>
+          )}
+          {filtered.length === 0 && query.trim() && (
+            <div className="px-3 py-6 text-center text-xs text-muted-foreground">
+              No matching files
+            </div>
+          )}
+          {filtered.map((item, idx) => {
+            const lastSlash = item.path.lastIndexOf('/')
+            const dir = lastSlash >= 0 ? item.path.slice(0, lastSlash) : ''
+            const filename = item.path.slice(lastSlash + 1)
+
+            return (
+              <button
+                key={item.path}
+                type="button"
+                className={`w-full flex items-center gap-2 px-3 py-1.5 text-left text-xs hover:bg-accent/50 ${
+                  idx === selectedIndex ? 'bg-accent' : ''
+                }`}
+                onClick={() => handleSelect(item.path)}
+                onMouseEnter={() => setSelectedIndex(idx)}
+              >
+                <File size={14} className="text-muted-foreground flex-shrink-0" />
+                <span className="truncate text-foreground">{filename}</span>
+                {dir && <span className="truncate text-muted-foreground ml-1">{dir}</span>}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/settings/ShortcutsPane.tsx
+++ b/src/renderer/src/components/settings/ShortcutsPane.tsx
@@ -21,6 +21,7 @@ export function ShortcutsPane(): React.JSX.Element {
       {
         title: 'Global',
         items: [
+          { action: 'Go to File', keys: [mod, 'P'] },
           { action: 'Create worktree', keys: [mod, 'N'] },
           { action: 'Toggle File Explorer', keys: [mod, shift, 'E'] },
           { action: 'Toggle Search', keys: [mod, shift, 'F'] },

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -97,6 +97,10 @@ export type EditorSlice = {
   setPendingEditorReveal: (
     reveal: { line: number; column: number; matchLength: number } | null
   ) => void
+
+  // Quick open (Cmd+P)
+  quickOpenVisible: boolean
+  setQuickOpenVisible: (visible: boolean) => void
 }
 
 export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (set) => ({
@@ -480,5 +484,9 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
 
   // Editor navigation
   pendingEditorReveal: null,
-  setPendingEditorReveal: (reveal) => set({ pendingEditorReveal: reveal })
+  setPendingEditorReveal: (reveal) => set({ pendingEditorReveal: reveal }),
+
+  // Quick open
+  quickOpenVisible: false,
+  setQuickOpenVisible: (visible) => set({ quickOpenVisible: visible })
 })


### PR DESCRIPTION
## Problem
Orca did not have a quick-open flow for jumping to files from the keyboard, and the filesystem search path was not exposing a dedicated file list API for that workflow.

## Solution
Add a Cmd/Ctrl+P quick-open modal that loads and fuzzy-filters worktree files through a new preload/main IPC API. Keep the shortcut cross-platform, block it while focus is in editable controls, and limit indexed files to the same practical project set used by the explorer by excluding `.git`, hidden paths, and `node_modules` while allowing `.github`.