### PR TITLE
fix: guard against empty branch in PR check status lookups

### DIFF
--- a/src/main/github/client.test.ts
+++ b/src/main/github/client.test.ts
@@ -97,6 +97,19 @@ describe('getPRForBranch', () => {
     expect(pr?.state).toBe('draft')
   })
 
+  it('returns null for empty branch (e.g. during rebase with detached HEAD)', async () => {
+    const pr = await getPRForBranch('/repo-root', '')
+    expect(pr).toBeNull()
+    // Should not call gh at all
+    expect(execFileAsyncMock).not.toHaveBeenCalled()
+  })
+
+  it('returns null for refs/heads/ only branch (detached after strip)', async () => {
+    const pr = await getPRForBranch('/repo-root', 'refs/heads/')
+    expect(pr).toBeNull()
+    expect(execFileAsyncMock).not.toHaveBeenCalled()
+  })
+
   it('returns null when pr list returns an empty array', async () => {
     execFileAsyncMock
       .mockResolvedValueOnce({ stdout: 'git@github.com:acme/widgets.git\n' })

--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -74,11 +74,18 @@ async function getOwnerRepo(repoPath: string): Promise<{ owner: string; repo: st
  * Returns null if gh is not installed, or no PR exists for the branch.
  */
 export async function getPRForBranch(repoPath: string, branch: string): Promise<PRInfo | null> {
+  // Strip refs/heads/ prefix if present
+  const branchName = branch.replace(/^refs\/heads\//, '')
+
+  // During a rebase the worktree is in detached HEAD and branch is empty.
+  // An empty --head filter causes gh to return an arbitrary PR — bail early.
+  if (!branchName) {
+    return null
+  }
+
   await acquire()
   try {
     const ownerRepo = await getOwnerRepo(repoPath)
-    // Strip refs/heads/ prefix if present
-    const branchName = branch.replace(/^refs\/heads\//, '')
     let data: {
       number: number
       title: string

--- a/src/renderer/src/components/right-sidebar/index.tsx
+++ b/src/renderer/src/components/right-sidebar/index.tsx
@@ -57,7 +57,12 @@ function getActiveChecksStatus(state: ReturnType<typeof useAppStore.getState>): 
     return null
   }
 
-  const prCacheKey = `${activeRepo.path}::${branchDisplayName(activeWorktree.branch)}`
+  const branch = branchDisplayName(activeWorktree.branch)
+  if (!branch) {
+    return null
+  }
+
+  const prCacheKey = `${activeRepo.path}::${branch}`
   return state.prCache[prCacheKey]?.data?.checksStatus ?? null
 }
 

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -126,7 +126,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
   const tabs = useAppStore((s) => s.tabsByWorktree[worktree.id] ?? EMPTY_TABS)
 
   const branch = branchDisplayName(worktree.branch)
-  const prCacheKey = repo ? `${repo.path}::${branch}` : ''
+  const prCacheKey = repo && branch ? `${repo.path}::${branch}` : ''
   const issueCacheKey = repo && worktree.linkedIssue ? `${repo.path}::${worktree.linkedIssue}` : ''
 
   // Subscribe to ONLY the specific cache entry, not entire prCache/issueCache

--- a/src/renderer/src/components/sidebar/worktree-list-groups.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.ts
@@ -65,7 +65,7 @@ export function getPRGroupKey(
 ): PRGroupKey {
   const repo = repoMap.get(worktree.repoId)
   const branch = branchName(worktree.branch)
-  const cacheKey = repo ? `${repo.path}::${branch}` : ''
+  const cacheKey = repo && branch ? `${repo.path}::${branch}` : ''
   const prEntry =
     cacheKey && prCache
       ? (prCache[cacheKey] as { data?: { state?: string } } | undefined)

--- a/src/renderer/src/store/slices/github-checks.test.ts
+++ b/src/renderer/src/store/slices/github-checks.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { syncPRChecksStatus, normalizeBranchName } from './github-checks'
+import type { AppState } from '../types'
+
+describe('normalizeBranchName', () => {
+  it('strips refs/heads/ prefix', () => {
+    expect(normalizeBranchName('refs/heads/main')).toBe('main')
+  })
+
+  it('returns branch as-is when no prefix', () => {
+    expect(normalizeBranchName('feature/foo')).toBe('feature/foo')
+  })
+
+  it('returns empty string for refs/heads/ only', () => {
+    expect(normalizeBranchName('refs/heads/')).toBe('')
+  })
+})
+
+describe('syncPRChecksStatus', () => {
+  const baseState = {
+    prCache: {
+      '/repo::main': {
+        fetchedAt: 0,
+        data: { checksStatus: 'neutral' as const }
+      }
+    }
+  } as unknown as AppState
+
+  it('returns null for undefined branch', () => {
+    expect(syncPRChecksStatus(baseState, '/repo', undefined, [])).toBeNull()
+  })
+
+  it('returns null for empty string branch', () => {
+    expect(syncPRChecksStatus(baseState, '/repo', '', [])).toBeNull()
+  })
+
+  it('returns null for refs/heads/ only (normalizes to empty)', () => {
+    expect(syncPRChecksStatus(baseState, '/repo', 'refs/heads/', [])).toBeNull()
+  })
+})

--- a/src/renderer/src/store/slices/github-checks.ts
+++ b/src/renderer/src/store/slices/github-checks.ts
@@ -39,11 +39,12 @@ export function syncPRChecksStatus(
   branch: string | undefined,
   checks: PRCheckDetail[]
 ): Partial<AppState> | null {
-  if (!branch) {
+  const normalized = branch ? normalizeBranchName(branch) : ''
+  if (!normalized) {
     return null
   }
 
-  const prCacheKey = `${repoPath}::${normalizeBranchName(branch)}`
+  const prCacheKey = `${repoPath}::${normalized}`
   const prEntry = state.prCache[prCacheKey]
   if (!prEntry?.data) {
     return null

--- a/src/renderer/src/store/slices/github.ts
+++ b/src/renderer/src/store/slices/github.ts
@@ -219,7 +219,7 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
         }
 
         const branch = wt.branch.replace(/^refs\/heads\//, '')
-        if (!wt.isBare) {
+        if (!wt.isBare && branch) {
           const prKey = `${repo.path}::${branch}`
           const prEntry = state.prCache[prKey]
           if (!prEntry || now - prEntry.fetchedAt >= CACHE_TTL) {


### PR DESCRIPTION
## Summary
- Guard all branch-to-cache-key paths against empty branch names (e.g. during rebase with detached HEAD)
- `getPRForBranch` now bails before acquiring the semaphore when branch is empty, preventing gh from returning arbitrary PRs
- Renderer components (`right-sidebar`, `WorktreeCard`, `worktree-list-groups`, `github.ts`, `github-checks.ts`) skip cache lookups when branch normalizes to empty

## Test plan
- [x] Added tests for `getPRForBranch` with empty and `refs/heads/`-only branch
- [x] Added tests for `syncPRChecksStatus` with undefined, empty, and `refs/heads/`-only branch
- [x] All 247 tests pass
- [x] Typecheck and lint clean