### PR TITLE
style: reduce file & icon display size in sidebar views

### DIFF
--- a/src/renderer/src/components/right-sidebar/FileExplorer.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorer.tsx
@@ -272,7 +272,7 @@ export default function FileExplorer(): React.JSX.Element {
             >
               <button
                 className={cn(
-                  'flex items-center w-full py-1 px-2 gap-1.5 text-left text-[13px] transition-colors hover:bg-accent/60 rounded-sm',
+                  'flex items-center w-full py-1 px-2 gap-1 text-left text-xs transition-colors hover:bg-accent/60 rounded-sm',
                   isActive && !node.isDirectory && 'bg-accent text-accent-foreground'
                 )}
                 style={{ paddingLeft: `${node.depth * 16 + 8}px` }}
@@ -293,17 +293,17 @@ export default function FileExplorer(): React.JSX.Element {
                       )}
                     />
                     {isLoading ? (
-                      <Loader2 className="size-3.5 shrink-0 text-muted-foreground animate-spin" />
+                      <Loader2 className="size-3 shrink-0 text-muted-foreground animate-spin" />
                     ) : isExpanded ? (
-                      <FolderOpen className="size-3.5 shrink-0 text-muted-foreground" />
+                      <FolderOpen className="size-3 shrink-0 text-muted-foreground" />
                     ) : (
-                      <Folder className="size-3.5 shrink-0 text-muted-foreground" />
+                      <Folder className="size-3 shrink-0 text-muted-foreground" />
                     )}
                   </>
                 ) : (
                   <>
                     <span className="size-3 shrink-0" />
-                    <File className="size-3.5 shrink-0 text-muted-foreground" />
+                    <File className="size-3 shrink-0 text-muted-foreground" />
                   </>
                 )}
                 <span

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -671,7 +671,7 @@ function UncommittedEntryRow({
 
   return (
     <div
-      className="group flex cursor-pointer items-center gap-1.5 pl-7 pr-3 py-1 transition-colors hover:bg-accent/40"
+      className="group flex cursor-pointer items-center gap-1 pl-5 pr-3 py-1 transition-colors hover:bg-accent/40"
       draggable
       onDragStart={(e) => {
         const absolutePath = joinPath(worktreePath, entry.path)
@@ -680,13 +680,13 @@ function UncommittedEntryRow({
       }}
       onClick={onOpen}
     >
-      <StatusIcon className="size-4 shrink-0" style={{ color: STATUS_COLORS[entry.status] }} />
-      <span className="min-w-0 flex-1 truncate text-[13px]">
+      <StatusIcon className="size-3.5 shrink-0" style={{ color: STATUS_COLORS[entry.status] }} />
+      <span className="min-w-0 flex-1 truncate text-xs">
         <span className="text-foreground">{fileName}</span>
-        {dirPath && <span className="ml-1.5 text-xs text-muted-foreground">{dirPath}</span>}
+        {dirPath && <span className="ml-1.5 text-[11px] text-muted-foreground">{dirPath}</span>}
       </span>
       <span
-        className="w-4 shrink-0 text-center text-[11px] font-bold"
+        className="w-4 shrink-0 text-center text-[10px] font-bold"
         style={{ color: STATUS_COLORS[entry.status] }}
       >
         {STATUS_LABELS[entry.status]}
@@ -747,16 +747,16 @@ function BranchEntryRow({
 
   return (
     <div
-      className="group flex cursor-pointer items-center gap-1.5 pl-7 pr-3 py-1 transition-colors hover:bg-accent/40"
+      className="group flex cursor-pointer items-center gap-1 pl-5 pr-3 py-1 transition-colors hover:bg-accent/40"
       onClick={onOpen}
     >
-      <StatusIcon className="size-4 shrink-0" style={{ color: STATUS_COLORS[entry.status] }} />
-      <span className="min-w-0 flex-1 truncate text-[13px]">
+      <StatusIcon className="size-3.5 shrink-0" style={{ color: STATUS_COLORS[entry.status] }} />
+      <span className="min-w-0 flex-1 truncate text-xs">
         <span className="text-foreground">{fileName}</span>
-        {dirPath && <span className="ml-1.5 text-xs text-muted-foreground">{dirPath}</span>}
+        {dirPath && <span className="ml-1.5 text-[11px] text-muted-foreground">{dirPath}</span>}
       </span>
       <span
-        className="w-4 shrink-0 text-center text-[11px] font-bold"
+        className="w-4 shrink-0 text-center text-[10px] font-bold"
         style={{ color: STATUS_COLORS[entry.status] }}
       >
         {STATUS_LABELS[entry.status]}


### PR DESCRIPTION
## Summary
- Shrink icons and font sizes in Source Control (BranchEntryRow, UncommittedEntryRow) and File Explorer rows
- Reduce left padding and gaps for a more compact sidebar layout

## Test plan
- [ ] Verify Source Control file entries render smaller icons and text
- [ ] Verify File Explorer rows have smaller icons and text
- [ ] Confirm hover states and action buttons still work correctly