### PR TITLE
fix: improve scrollbar and file explorer scroll behavior

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -182,15 +182,16 @@
   }
 }
 
-/* ── Sleek scrollbar (hover-only, thin) ─────────────── */
+/* ── Sleek scrollbar (VS Code-like) ─────────────────── */
 
 .scrollbar-sleek {
   scrollbar-width: thin;
-  scrollbar-color: transparent transparent;
+  scrollbar-color: color-mix(in srgb, var(--muted-foreground, #737373) 34%, transparent) transparent;
 }
 
 .scrollbar-sleek::-webkit-scrollbar {
-  width: 6px;
+  width: 12px;
+  height: 12px;
 }
 
 .scrollbar-sleek::-webkit-scrollbar-track {
@@ -198,19 +199,24 @@
 }
 
 .scrollbar-sleek::-webkit-scrollbar-thumb {
-  background: transparent;
-  border-radius: 3px;
+  background: color-mix(in srgb, var(--muted-foreground, #737373) 28%, transparent);
+  border: 3px solid transparent;
+  border-radius: 0;
+  background-clip: padding-box;
+  min-height: 28px;
 }
 
-.scrollbar-sleek-parent:hover .scrollbar-sleek::-webkit-scrollbar-thumb,
-.scrollbar-sleek:hover::-webkit-scrollbar-thumb {
-  background: var(--muted-foreground, #737373);
-  opacity: 0.4;
+.scrollbar-sleek::-webkit-scrollbar-thumb:hover {
+  background-color: color-mix(in srgb, var(--muted-foreground, #737373) 48%, transparent);
+}
+
+.scrollbar-sleek::-webkit-scrollbar-thumb:active {
+  background-color: color-mix(in srgb, var(--foreground, #171717) 36%, transparent);
 }
 
 .scrollbar-sleek-parent:hover .scrollbar-sleek,
 .scrollbar-sleek:hover {
-  scrollbar-color: var(--muted-foreground, #737373) transparent;
+  scrollbar-color: color-mix(in srgb, var(--muted-foreground, #737373) 48%, transparent) transparent;
 }
 
 /* ── Editor-style scrollbar (matches Monaco) ────────── */

--- a/src/renderer/src/components/right-sidebar/FileExplorer.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorer.tsx
@@ -232,9 +232,28 @@ export default function FileExplorer(): React.JSX.Element {
     [activeWorktreeId, pinFile]
   )
 
+  const handleWheelCapture = useCallback((e: React.WheelEvent<HTMLDivElement>) => {
+    const container = scrollRef.current
+    if (!container || Math.abs(e.deltaY) <= Math.abs(e.deltaX)) {
+      return
+    }
+
+    const target = e.target
+    if (!(target instanceof Element) || !target.closest('[data-explorer-draggable="true"]')) {
+      return
+    }
+
+    if (container.scrollHeight <= container.clientHeight) {
+      return
+    }
+
+    e.preventDefault()
+    container.scrollTop += e.deltaY
+  }, [])
+
   if (!worktreePath) {
     return (
-      <div className="flex items-center justify-center h-full text-[11px] text-muted-foreground px-4 text-center">
+      <div className="flex h-full items-center justify-center text-[11px] text-muted-foreground px-4 text-center">
         Select a worktree to browse files
       </div>
     )
@@ -242,14 +261,18 @@ export default function FileExplorer(): React.JSX.Element {
 
   if (flatRows.length === 0) {
     return (
-      <div className="flex items-center justify-center h-full text-[11px] text-muted-foreground">
+      <div className="flex h-full items-center justify-center text-[11px] text-muted-foreground">
         <Loader2 className="size-4 animate-spin" />
       </div>
     )
   }
 
   return (
-    <div ref={scrollRef} className="flex-1 overflow-auto scrollbar-sleek py-2">
+    <div
+      ref={scrollRef}
+      className="h-full min-h-0 overflow-auto scrollbar-sleek py-2"
+      onWheelCapture={handleWheelCapture}
+    >
       <div className="relative w-full" style={{ height: `${virtualizer.getTotalSize()}px` }}>
         {virtualizer.getVirtualItems().map((vItem) => {
           const node = flatRows[vItem.index]
@@ -271,13 +294,19 @@ export default function FileExplorer(): React.JSX.Element {
               style={{ transform: `translateY(${vItem.start}px)` }}
             >
               <button
+                type="button"
                 className={cn(
                   'flex items-center w-full py-1 px-2 gap-1 text-left text-xs transition-colors hover:bg-accent/60 rounded-sm',
                   isActive && !node.isDirectory && 'bg-accent text-accent-foreground'
                 )}
                 style={{ paddingLeft: `${node.depth * 16 + 8}px` }}
-                draggable
+                data-explorer-draggable={!node.isDirectory ? 'true' : undefined}
+                draggable={!node.isDirectory}
                 onDragStart={(e) => {
+                  if (node.isDirectory) {
+                    e.preventDefault()
+                    return
+                  }
                   e.dataTransfer.setData('text/x-orca-file-path', node.path)
                   e.dataTransfer.effectAllowed = 'copy'
                 }}


### PR DESCRIPTION
## Summary
- Restyle scrollbar to VS Code-like always-visible appearance using `color-mix` with proper hover/active states
- Fix `background` shorthand resetting `background-clip: padding-box` in scrollbar thumb pseudo-states
- Add wheel capture handler in file explorer to prevent draggable file items from swallowing scroll events
- Fix flex overflow on scroll container (`h-full min-h-0`)
- Restrict drag to file items only (not directories)

## Test plan
- [ ] Verify scrollbar is visible and has correct VS Code-like styling (thin inset thumb)
- [ ] Hover/click scrollbar thumb and confirm visual feedback (opacity change)
- [ ] Scroll file explorer with many files — ensure smooth scrolling even when cursor is over draggable items
- [ ] Drag a file from explorer to editor — confirm drag still works
- [ ] Confirm directories are not draggable