### PR TITLE
style: remove PR title from source control tab

### DIFF
--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -366,7 +366,6 @@ export default function SourceControl(): React.JSX.Element {
               >
                 PR #{prInfo.number}
               </a>
-              <span className="text-muted-foreground truncate">{prInfo.title}</span>
             </div>
           )}
         </div>


### PR DESCRIPTION
## Summary
- Remove the PR title text from the tab switcher, keeping only the icon and clickable PR number