### PR TITLE
fix: hide duplicate empty state on Uncommitted tab

### DIFF
--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -381,7 +381,7 @@ export default function SourceControl(): React.JSX.Element {
         )}
 
         <div className="flex-1 overflow-auto scrollbar-sleek py-1">
-          {showGenericEmptyState ? (
+          {scope === 'all' && showGenericEmptyState ? (
             <EmptyState
               heading="No changes on this branch"
               supportingText={`This worktree is clean and this branch has no changes ahead of ${branchSummary.baseRef}`}


### PR DESCRIPTION
## Summary
- Scope the "No changes on this branch" empty state to only the All tab
- Previously both empty states showed on the Uncommitted tab when clean

## Test plan
- [ ] Uncommitted tab with no changes shows only "No uncommitted changes"
- [ ] All tab with no changes shows only "No changes on this branch"