### PR TITLE
Allow deleting files and folders from file explorer

### DIFF
--- a/src/main/ipc/filesystem.test.ts
+++ b/src/main/ipc/filesystem.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const handlers = new Map<string, (_event: unknown, args: unknown) => Promise<unknown> | unknown>()
 const {
   handleMock,
+  trashItemMock,
   readdirMock,
   readFileMock,
   writeFileMock,
@@ -19,6 +20,7 @@ const {
   listWorktreesMock
 } = vi.hoisted(() => ({
   handleMock: vi.fn(),
+  trashItemMock: vi.fn(),
   readdirMock: vi.fn(),
   readFileMock: vi.fn(),
   writeFileMock: vi.fn(),
@@ -38,6 +40,9 @@ const {
 vi.mock('electron', () => ({
   ipcMain: {
     handle: handleMock
+  },
+  shell: {
+    trashItem: trashItemMock
   }
 }))
 
@@ -85,6 +90,7 @@ describe('registerFilesystemHandlers', () => {
   beforeEach(() => {
     handlers.clear()
     handleMock.mockReset()
+    trashItemMock.mockReset()
     readdirMock.mockReset()
     readFileMock.mockReset()
     writeFileMock.mockReset()
@@ -108,6 +114,7 @@ describe('registerFilesystemHandlers', () => {
     listWorktreesMock.mockResolvedValue([
       { path: '/workspace/repo-feature', head: 'abc', branch: '', isBare: false }
     ])
+    trashItemMock.mockResolvedValue(undefined)
     statMock.mockResolvedValue({ size: 10, isDirectory: () => false, mtimeMs: 123 })
     lstatMock.mockRejectedValue(Object.assign(new Error('missing'), { code: 'ENOENT' }))
   })
@@ -174,6 +181,14 @@ describe('registerFilesystemHandlers', () => {
       isImage: true,
       mimeType: 'image/svg+xml'
     })
+  })
+
+  it('moves files to trash', async () => {
+    registerFilesystemHandlers(store as never)
+
+    await handlers.get('fs:deletePath')!(null, { targetPath: '/workspace/repo/file.txt' })
+
+    expect(trashItemMock).toHaveBeenCalledWith('/workspace/repo/file.txt')
   })
 
   it('keeps non-image binaries hidden from the editor payload', async () => {

--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines */
-import { ipcMain } from 'electron'
+import { ipcMain, shell } from 'electron'
 import { readdir, readFile, writeFile, stat, lstat } from 'fs/promises'
 import { extname, relative } from 'path'
 import { spawn } from 'child_process'
@@ -131,6 +131,12 @@ export function registerFilesystemHandlers(store: Store): void {
       await writeFile(filePath, args.content, 'utf-8')
     }
   )
+
+  ipcMain.handle('fs:deletePath', async (_event, args: { targetPath: string }): Promise<void> => {
+    const targetPath = await resolveAuthorizedPath(args.targetPath, store)
+
+    await shell.trashItem(targetPath)
+  })
 
   ipcMain.handle(
     'fs:stat',

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -132,6 +132,7 @@ type FsApi = {
     filePath: string
   }) => Promise<{ content: string; isBinary: boolean; isImage?: boolean; mimeType?: string }>
   writeFile: (args: { filePath: string; content: string }) => Promise<void>
+  deletePath: (args: { targetPath: string }) => Promise<void>
   stat: (args: {
     filePath: string
   }) => Promise<{ size: number; isDirectory: boolean; mtime: number }>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -219,6 +219,8 @@ const api = {
       ipcRenderer.invoke('fs:readFile', args),
     writeFile: (args: { filePath: string; content: string }): Promise<void> =>
       ipcRenderer.invoke('fs:writeFile', args),
+    deletePath: (args: { targetPath: string }): Promise<void> =>
+      ipcRenderer.invoke('fs:deletePath', args),
     stat: (args: {
       filePath: string
     }): Promise<{ size: number; isDirectory: boolean; mtime: number }> =>

--- a/src/renderer/src/components/right-sidebar/FileDeleteDialog.tsx
+++ b/src/renderer/src/components/right-sidebar/FileDeleteDialog.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog'
+import type { PendingDelete } from './file-explorer-types'
+
+type FileDeleteDialogProps = {
+  pendingDelete: PendingDelete | null
+  isDeleting: boolean
+  deleteDescription: string
+  deleteActionLabel: string
+  onClose: () => void
+  onConfirm: () => void
+}
+
+export function FileDeleteDialog({
+  pendingDelete,
+  isDeleting,
+  deleteDescription,
+  deleteActionLabel,
+  onClose,
+  onConfirm
+}: FileDeleteDialogProps): React.JSX.Element {
+  return (
+    <Dialog
+      open={pendingDelete !== null}
+      onOpenChange={(open) => {
+        if (!open) {
+          onClose()
+        }
+      }}
+    >
+      <DialogContent showCloseButton={false}>
+        <DialogHeader>
+          <DialogTitle>{deleteActionLabel}</DialogTitle>
+          <DialogDescription>{deleteDescription}</DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose} disabled={isDeleting}>
+            Cancel
+          </Button>
+          <Button onClick={onConfirm} disabled={isDeleting}>
+            {isDeleting ? 'Deleting…' : deleteActionLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/renderer/src/components/right-sidebar/FileExplorer.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorer.tsx
@@ -1,60 +1,63 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useVirtualizer } from '@tanstack/react-virtual'
-import { ChevronRight, File, Folder, FolderOpen, Loader2 } from 'lucide-react'
+import { Loader2 } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { detectLanguage } from '@/lib/language-detect'
 import { joinPath, normalizeRelativePath } from '@/lib/path'
-import { cn } from '@/lib/utils'
 import { ScrollArea } from '@/components/ui/scroll-area'
-import type { GitFileStatus } from '../../../../shared/types'
+import { FileDeleteDialog } from './FileDeleteDialog'
+import { FileExplorerRow } from './FileExplorerRow'
+import type { DirCache, TreeNode } from './file-explorer-types'
 import { splitPathSegments } from './path-tree'
-import {
-  buildStatusMap,
-  getDominantStatus,
-  shouldPropagateStatus,
-  STATUS_COLORS,
-  STATUS_LABELS
-} from './status-display'
-
-type TreeNode = {
-  name: string
-  path: string // absolute path
-  relativePath: string
-  isDirectory: boolean
-  depth: number
-}
-
-type DirCache = {
-  children: TreeNode[]
-  loading: boolean
-}
+import { buildFolderStatusMap, buildStatusMap, STATUS_COLORS } from './status-display'
+import { useFileDeletion } from './useFileDeletion'
+import { useFileExplorerReveal } from './useFileExplorerReveal'
 
 export default function FileExplorer(): React.JSX.Element {
   const activeWorktreeId = useAppStore((s) => s.activeWorktreeId)
   const worktreesByRepo = useAppStore((s) => s.worktreesByRepo)
   const expandedDirs = useAppStore((s) => s.expandedDirs)
   const toggleDir = useAppStore((s) => s.toggleDir)
+  const pendingExplorerReveal = useAppStore((s) => s.pendingExplorerReveal)
+  const clearPendingExplorerReveal = useAppStore((s) => s.clearPendingExplorerReveal)
   const openFile = useAppStore((s) => s.openFile)
   const pinFile = useAppStore((s) => s.pinFile)
   const activeFileId = useAppStore((s) => s.activeFileId)
   const gitStatusByWorktree = useAppStore((s) => s.gitStatusByWorktree)
+  const openFiles = useAppStore((s) => s.openFiles)
+  const closeFile = useAppStore((s) => s.closeFile)
 
-  // Find active worktree path
   const worktreePath = useMemo(() => {
     if (!activeWorktreeId) {
       return null
     }
+
     for (const worktrees of Object.values(worktreesByRepo)) {
-      const wt = worktrees.find((w) => w.id === activeWorktreeId)
-      if (wt) {
-        return wt.path
+      const worktree = worktrees.find((candidate) => candidate.id === activeWorktreeId)
+      if (worktree) {
+        return worktree.path
       }
     }
+
     return null
   }, [activeWorktreeId, worktreesByRepo])
 
   const [dirCache, setDirCache] = useState<Record<string, DirCache>>({})
+  const dirCacheRef = useRef(dirCache)
+  dirCacheRef.current = dirCache
+  const [selectedPath, setSelectedPath] = useState<string | null>(null)
+  const [flashingPath, setFlashingPath] = useState<string | null>(null)
   const scrollRef = useRef<HTMLDivElement>(null)
+  const flashTimeoutRef = useRef<number | null>(null)
+  const isMac = useMemo(() => navigator.userAgent.includes('Mac'), [])
+  const isWindows = useMemo(() => navigator.userAgent.includes('Windows'), [])
+
+  const clearFlashTimeout = useCallback(() => {
+    if (flashTimeoutRef.current !== null) {
+      window.clearTimeout(flashTimeoutRef.current)
+      flashTimeoutRef.current = null
+    }
+  }, [])
 
   const entries = useMemo(
     () => (activeWorktreeId ? (gitStatusByWorktree[activeWorktreeId] ?? []) : []),
@@ -63,38 +66,7 @@ export default function FileExplorer(): React.JSX.Element {
 
   const statusByRelativePath = useMemo(() => buildStatusMap(entries), [entries])
 
-  const folderStatusByRelativePath = useMemo(() => {
-    const folderStatuses = new Map<string, GitFileStatus[]>()
-
-    for (const entry of entries) {
-      if (!shouldPropagateStatus(entry.status)) {
-        continue
-      }
-
-      const segments = splitPathSegments(entry.path)
-      if (segments.length <= 1) {
-        continue
-      }
-
-      let currentPath = ''
-      for (const segment of segments.slice(0, -1)) {
-        currentPath = currentPath ? joinPath(currentPath, segment) : segment
-        const statuses = folderStatuses.get(currentPath)
-        if (statuses) {
-          statuses.push(entry.status)
-        } else {
-          folderStatuses.set(currentPath, [entry.status])
-        }
-      }
-    }
-
-    return new Map(
-      Array.from(folderStatuses.entries()).map(([folderPath, statuses]) => [
-        folderPath,
-        getDominantStatus(statuses)
-      ])
-    )
-  }, [entries])
+  const folderStatusByRelativePath = useMemo(() => buildFolderStatusMap(entries), [entries])
 
   const expanded = useMemo(
     () =>
@@ -102,34 +74,33 @@ export default function FileExplorer(): React.JSX.Element {
     [activeWorktreeId, expandedDirs]
   )
 
-  // Load directory contents
   const loadDir = useCallback(
-    async (dirPath: string, depth: number) => {
-      if (dirCache[dirPath]?.children.length > 0 || dirCache[dirPath]?.loading) {
+    async (dirPath: string, depth: number, options?: { force?: boolean }) => {
+      const cache = dirCacheRef.current
+      if (!options?.force && (cache[dirPath]?.children.length > 0 || cache[dirPath]?.loading)) {
         return
       }
 
       setDirCache((prev) => ({
         ...prev,
-        [dirPath]: { children: prev[dirPath]?.children ?? [], loading: true }
+        [dirPath]: {
+          children: options?.force ? [] : (prev[dirPath]?.children ?? []),
+          loading: true
+        }
       }))
 
       try {
-        const entries = (await window.api.fs.readDir({ dirPath })) as {
-          name: string
-          isDirectory: boolean
-        }[]
-
+        const entries = await window.api.fs.readDir({ dirPath })
         const children: TreeNode[] = entries
-          .filter((e) => !e.name.startsWith('.') || e.name === '.github')
-          .filter((e) => e.name !== 'node_modules' && e.name !== '.git')
-          .map((e) => ({
-            name: e.name,
-            path: joinPath(dirPath, e.name),
+          .filter((entry) => !entry.name.startsWith('.') || entry.name === '.github')
+          .filter((entry) => entry.name !== 'node_modules' && entry.name !== '.git')
+          .map((entry) => ({
+            name: entry.name,
+            path: joinPath(dirPath, entry.name),
             relativePath: worktreePath
-              ? normalizeRelativePath(joinPath(dirPath, e.name).slice(worktreePath.length + 1))
-              : e.name,
-            isDirectory: e.isDirectory,
+              ? normalizeRelativePath(joinPath(dirPath, entry.name).slice(worktreePath.length + 1))
+              : entry.name,
+            isDirectory: entry.isDirectory,
             depth: depth + 1
           }))
 
@@ -144,19 +115,59 @@ export default function FileExplorer(): React.JSX.Element {
         }))
       }
     },
-    [dirCache, worktreePath]
+    [worktreePath]
   )
 
-  // Load root when worktree changes
+  const refreshTree = useCallback(async () => {
+    if (!worktreePath) {
+      return
+    }
+
+    setDirCache({})
+    await loadDir(worktreePath, -1, { force: true })
+
+    await Promise.all(
+      Array.from(expanded).map(async (dirPath) => {
+        const depth = splitPathSegments(dirPath.slice(worktreePath.length + 1)).length - 1
+        await loadDir(dirPath, depth, { force: true })
+      })
+    )
+  }, [expanded, loadDir, worktreePath])
+
+  const {
+    pendingDelete,
+    isDeleting,
+    deleteShortcutLabel,
+    deleteActionLabel,
+    deleteDescription,
+    requestDelete,
+    closeDeleteDialog,
+    confirmDelete
+  } = useFileDeletion({
+    activeWorktreeId,
+    openFiles,
+    closeFile,
+    refreshTree,
+    selectedPath,
+    setSelectedPath,
+    isMac,
+    isWindows
+  })
+
   useEffect(() => {
     if (!worktreePath) {
       return
     }
+
+    setSelectedPath(null)
     setDirCache({})
     void loadDir(worktreePath, -1)
   }, [worktreePath]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Load expanded directories
+  useEffect(() => {
+    return clearFlashTimeout
+  }, [clearFlashTimeout])
+
   useEffect(() => {
     for (const dirPath of expanded) {
       if (!dirCache[dirPath]?.children.length && !dirCache[dirPath]?.loading) {
@@ -168,7 +179,6 @@ export default function FileExplorer(): React.JSX.Element {
     }
   }, [expanded]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Flatten tree into visible rows
   const flatRows = useMemo(() => {
     if (!worktreePath) {
       return []
@@ -194,6 +204,9 @@ export default function FileExplorer(): React.JSX.Element {
     return result
   }, [worktreePath, dirCache, expanded])
 
+  const rowsByPath = useMemo(() => new Map(flatRows.map((row) => [row.path, row])), [flatRows])
+  const rootCache = worktreePath ? dirCache[worktreePath] : undefined
+
   const virtualizer = useVirtualizer({
     count: flatRows.length,
     getScrollElement: () => scrollRef.current,
@@ -202,25 +215,45 @@ export default function FileExplorer(): React.JSX.Element {
     getItemKey: (index) => flatRows[index].path
   })
 
+  useFileExplorerReveal({
+    activeWorktreeId,
+    worktreePath,
+    pendingExplorerReveal,
+    clearPendingExplorerReveal,
+    expanded,
+    dirCache,
+    rootCache,
+    rowsByPath,
+    flatRows,
+    loadDir,
+    setSelectedPath,
+    setFlashingPath,
+    flashTimeoutRef,
+    virtualizer
+  })
+
   const handleClick = useCallback(
     (node: TreeNode) => {
       if (!activeWorktreeId) {
         return
       }
 
+      setSelectedPath(node.path)
+
       if (node.isDirectory) {
         toggleDir(activeWorktreeId, node.path)
-      } else {
-        openFile({
-          filePath: node.path,
-          relativePath: node.relativePath,
-          worktreeId: activeWorktreeId,
-          language: detectLanguage(node.name),
-          mode: 'edit'
-        })
+        return
       }
+
+      openFile({
+        filePath: node.path,
+        relativePath: node.relativePath,
+        worktreeId: activeWorktreeId,
+        language: detectLanguage(node.name),
+        mode: 'edit'
+      })
     },
-    [activeWorktreeId, toggleDir, openFile]
+    [activeWorktreeId, openFile, toggleDir]
   )
 
   const handleDoubleClick = useCallback(
@@ -228,6 +261,7 @@ export default function FileExplorer(): React.JSX.Element {
       if (!activeWorktreeId || node.isDirectory) {
         return
       }
+
       pinFile(node.path)
     },
     [activeWorktreeId, pinFile]
@@ -252,6 +286,38 @@ export default function FileExplorer(): React.JSX.Element {
     container.scrollTop += e.deltaY
   }, [])
 
+  const handleExplorerKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      const target = event.target
+      if (
+        !(target instanceof HTMLElement) ||
+        target instanceof HTMLInputElement ||
+        target instanceof HTMLTextAreaElement ||
+        target.isContentEditable
+      ) {
+        return
+      }
+
+      const selectedNode =
+        (selectedPath ? rowsByPath.get(selectedPath) : undefined) ??
+        (activeFileId ? rowsByPath.get(activeFileId) : undefined)
+      if (!selectedNode) {
+        return
+      }
+
+      const isDeleteShortcut =
+        event.key === 'Delete' || (isMac && event.key === 'Backspace' && event.metaKey)
+
+      if (!isDeleteShortcut) {
+        return
+      }
+
+      event.preventDefault()
+      requestDelete(selectedNode)
+    },
+    [activeFileId, isMac, requestDelete, rowsByPath, selectedPath]
+  )
+
   if (!worktreePath) {
     return (
       <div className="flex h-full items-center justify-center text-[11px] text-muted-foreground px-4 text-center">
@@ -261,101 +327,74 @@ export default function FileExplorer(): React.JSX.Element {
   }
 
   if (flatRows.length === 0) {
+    if (rootCache?.loading ?? true) {
+      return (
+        <div className="flex items-center justify-center h-full text-[11px] text-muted-foreground">
+          <Loader2 className="size-4 animate-spin" />
+        </div>
+      )
+    }
+
     return (
-      <div className="flex h-full items-center justify-center text-[11px] text-muted-foreground">
-        <Loader2 className="size-4 animate-spin" />
+      <div className="flex h-full items-center justify-center text-[11px] text-muted-foreground px-4 text-center">
+        No files in this worktree
       </div>
     )
   }
 
   return (
-    <ScrollArea
-      className="h-full min-h-0"
-      viewportRef={scrollRef}
-      viewportClassName="h-full min-h-0 py-2"
-      onWheelCapture={handleWheelCapture}
-    >
-      <div className="relative w-full" style={{ height: `${virtualizer.getTotalSize()}px` }}>
-        {virtualizer.getVirtualItems().map((vItem) => {
-          const node = flatRows[vItem.index]
-          const isExpanded = expanded.has(node.path)
-          const isLoading = node.isDirectory && dirCache[node.path]?.loading
-          const isActive = activeFileId === node.path
-          const normalizedRelativePath = normalizeRelativePath(node.relativePath)
-          const nodeStatus = node.isDirectory
-            ? (folderStatusByRelativePath.get(normalizedRelativePath) ?? null)
-            : (statusByRelativePath.get(normalizedRelativePath) ?? null)
-          const statusColor = nodeStatus ? STATUS_COLORS[nodeStatus] : null
+    <>
+      <ScrollArea
+        className="h-full min-h-0"
+        viewportRef={scrollRef}
+        viewportClassName="h-full min-h-0 py-2"
+        onWheelCapture={handleWheelCapture}
+        onKeyDownCapture={handleExplorerKeyDown}
+      >
+        <div className="relative w-full" style={{ height: `${virtualizer.getTotalSize()}px` }}>
+          {virtualizer.getVirtualItems().map((virtualItem) => {
+            const node = flatRows[virtualItem.index]
+            const normalizedRelativePath = normalizeRelativePath(node.relativePath)
+            const nodeStatus = node.isDirectory
+              ? (folderStatusByRelativePath.get(normalizedRelativePath) ?? null)
+              : (statusByRelativePath.get(normalizedRelativePath) ?? null)
 
-          return (
-            <div
-              key={vItem.key}
-              data-index={vItem.index}
-              ref={virtualizer.measureElement}
-              className="absolute left-0 right-0"
-              style={{ transform: `translateY(${vItem.start}px)` }}
-            >
-              <button
-                type="button"
-                className={cn(
-                  'flex items-center w-full py-1 px-2 gap-1 text-left text-xs transition-colors hover:bg-accent/60 rounded-sm',
-                  isActive && !node.isDirectory && 'bg-accent text-accent-foreground'
-                )}
-                style={{ paddingLeft: `${node.depth * 16 + 8}px` }}
-                data-explorer-draggable={!node.isDirectory ? 'true' : undefined}
-                draggable={!node.isDirectory}
-                onDragStart={(e) => {
-                  if (node.isDirectory) {
-                    e.preventDefault()
-                    return
-                  }
-                  e.dataTransfer.setData('text/x-orca-file-path', node.path)
-                  e.dataTransfer.effectAllowed = 'copy'
-                }}
-                onClick={() => handleClick(node)}
-                onDoubleClick={() => handleDoubleClick(node)}
+            return (
+              <div
+                key={virtualItem.key}
+                data-index={virtualItem.index}
+                ref={virtualizer.measureElement}
+                className="absolute left-0 right-0"
+                style={{ transform: `translateY(${virtualItem.start}px)` }}
               >
-                {node.isDirectory ? (
-                  <>
-                    <ChevronRight
-                      className={cn(
-                        'size-3 shrink-0 text-muted-foreground transition-transform',
-                        isExpanded && 'rotate-90'
-                      )}
-                    />
-                    {isLoading ? (
-                      <Loader2 className="size-3 shrink-0 text-muted-foreground animate-spin" />
-                    ) : isExpanded ? (
-                      <FolderOpen className="size-3 shrink-0 text-muted-foreground" />
-                    ) : (
-                      <Folder className="size-3 shrink-0 text-muted-foreground" />
-                    )}
-                  </>
-                ) : (
-                  <>
-                    <span className="size-3 shrink-0" />
-                    <File className="size-3 shrink-0 text-muted-foreground" />
-                  </>
-                )}
-                <span
-                  className={cn('truncate', isActive && !nodeStatus && 'text-accent-foreground')}
-                  style={nodeStatus ? { color: statusColor ?? undefined } : undefined}
-                >
-                  {node.name}
-                </span>
-                {nodeStatus && (
-                  <span
-                    className="ml-auto shrink-0 text-[10px] font-semibold tracking-wide"
-                    style={{ color: statusColor ?? undefined }}
-                  >
-                    {STATUS_LABELS[nodeStatus]}
-                  </span>
-                )}
-              </button>
-            </div>
-          )
-        })}
-      </div>
-    </ScrollArea>
+                <FileExplorerRow
+                  node={node}
+                  isExpanded={expanded.has(node.path)}
+                  isLoading={node.isDirectory && Boolean(dirCache[node.path]?.loading)}
+                  isSelected={selectedPath === node.path || activeFileId === node.path}
+                  isFlashing={flashingPath === node.path}
+                  nodeStatus={nodeStatus}
+                  statusColor={nodeStatus ? STATUS_COLORS[nodeStatus] : null}
+                  deleteShortcutLabel={deleteShortcutLabel}
+                  onClick={() => handleClick(node)}
+                  onDoubleClick={() => handleDoubleClick(node)}
+                  onSelect={() => setSelectedPath(node.path)}
+                  onRequestDelete={() => requestDelete(node)}
+                />
+              </div>
+            )
+          })}
+        </div>
+      </ScrollArea>
+
+      <FileDeleteDialog
+        pendingDelete={pendingDelete}
+        isDeleting={isDeleting}
+        deleteDescription={deleteDescription}
+        deleteActionLabel={deleteActionLabel}
+        onClose={closeDeleteDialog}
+        onConfirm={() => void confirmDelete()}
+      />
+    </>
   )
 }

--- a/src/renderer/src/components/right-sidebar/FileExplorerRow.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorerRow.tsx
@@ -1,0 +1,111 @@
+import React from 'react'
+import { ChevronRight, File, Folder, FolderOpen, Loader2, Trash2 } from 'lucide-react'
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuShortcut,
+  ContextMenuTrigger
+} from '@/components/ui/context-menu'
+import { cn } from '@/lib/utils'
+import type { GitFileStatus } from '../../../../shared/types'
+import { STATUS_LABELS } from './status-display'
+import type { TreeNode } from './file-explorer-types'
+
+type FileExplorerRowProps = {
+  node: TreeNode
+  isExpanded: boolean
+  isLoading: boolean
+  isSelected: boolean
+  isFlashing: boolean
+  nodeStatus: GitFileStatus | null
+  statusColor: string | null
+  deleteShortcutLabel: string
+  onClick: () => void
+  onDoubleClick: () => void
+  onSelect: () => void
+  onRequestDelete: () => void
+}
+
+export function FileExplorerRow({
+  node,
+  isExpanded,
+  isLoading,
+  isSelected,
+  isFlashing,
+  nodeStatus,
+  statusColor,
+  deleteShortcutLabel,
+  onClick,
+  onDoubleClick,
+  onSelect,
+  onRequestDelete
+}: FileExplorerRowProps): React.JSX.Element {
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
+        <button
+          className={cn(
+            'flex w-full items-center gap-1 rounded-sm px-2 py-1 text-left text-xs transition-colors hover:bg-accent/60',
+            isSelected && 'bg-accent text-accent-foreground',
+            isFlashing && 'bg-amber-400/20 ring-1 ring-inset ring-amber-400/70'
+          )}
+          style={{ paddingLeft: `${node.depth * 16 + 8}px` }}
+          draggable
+          onDragStart={(event) => {
+            event.dataTransfer.setData('text/x-orca-file-path', node.path)
+            event.dataTransfer.effectAllowed = 'copy'
+          }}
+          onClick={onClick}
+          onDoubleClick={onDoubleClick}
+          onFocus={onSelect}
+          onContextMenu={onSelect}
+        >
+          {node.isDirectory ? (
+            <>
+              <ChevronRight
+                className={cn(
+                  'size-3 shrink-0 text-muted-foreground transition-transform',
+                  isExpanded && 'rotate-90'
+                )}
+              />
+              {isLoading ? (
+                <Loader2 className="size-3 shrink-0 animate-spin text-muted-foreground" />
+              ) : isExpanded ? (
+                <FolderOpen className="size-3 shrink-0 text-muted-foreground" />
+              ) : (
+                <Folder className="size-3 shrink-0 text-muted-foreground" />
+              )}
+            </>
+          ) : (
+            <>
+              <span className="size-3 shrink-0" />
+              <File className="size-3 shrink-0 text-muted-foreground" />
+            </>
+          )}
+          <span
+            className={cn('truncate', isSelected && !nodeStatus && 'text-accent-foreground')}
+            style={nodeStatus ? { color: statusColor ?? undefined } : undefined}
+          >
+            {node.name}
+          </span>
+          {nodeStatus && (
+            <span
+              className="ml-auto shrink-0 text-[10px] font-semibold tracking-wide"
+              style={{ color: statusColor ?? undefined }}
+            >
+              {STATUS_LABELS[nodeStatus]}
+            </span>
+          )}
+        </button>
+      </ContextMenuTrigger>
+      <ContextMenuContent className="w-56">
+        <ContextMenuItem onSelect={onRequestDelete}>
+          <Trash2 className="size-3.5" />
+          Delete
+          <ContextMenuShortcut>{deleteShortcutLabel}</ContextMenuShortcut>
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
+  )
+}

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -12,7 +12,8 @@ import {
   FileMinus,
   FilePlus,
   FileQuestion,
-  ArrowRightLeft
+  ArrowRightLeft,
+  FolderOpen
 } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { detectLanguage } from '@/lib/language-detect'
@@ -20,6 +21,12 @@ import { basename, dirname, joinPath } from '@/lib/path'
 import { cn } from '@/lib/utils'
 import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from '@/components/ui/tooltip'
 import { Button } from '@/components/ui/button'
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger
+} from '@/components/ui/context-menu'
 import {
   Dialog,
   DialogContent,
@@ -73,6 +80,7 @@ export default function SourceControl(): React.JSX.Element {
   const updateRepo = useAppStore((s) => s.updateRepo)
   const beginGitBranchCompareRequest = useAppStore((s) => s.beginGitBranchCompareRequest)
   const setGitBranchCompareResult = useAppStore((s) => s.setGitBranchCompareResult)
+  const revealInExplorer = useAppStore((s) => s.revealInExplorer)
   const openDiff = useAppStore((s) => s.openDiff)
   const openBranchDiff = useAppStore((s) => s.openBranchDiff)
   const openAllDiffs = useAppStore((s) => s.openAllDiffs)
@@ -326,6 +334,7 @@ export default function SourceControl(): React.JSX.Element {
 
   const showGenericEmptyState =
     !hasUncommittedEntries && branchSummary?.status === 'ready' && branchEntries.length === 0
+  const currentWorktreeId = activeWorktree.id
 
   return (
     <>
@@ -429,6 +438,9 @@ export default function SourceControl(): React.JSX.Element {
                           key={`${entry.area}:${entry.path}`}
                           entry={entry}
                           worktreePath={worktreePath}
+                          onRevealInExplorer={() =>
+                            revealInExplorer(currentWorktreeId, joinPath(worktreePath, entry.path))
+                          }
                           onOpen={() => openUncommittedDiff(entry)}
                           onStage={() => void handleStage(entry.path)}
                           onUnstage={() => void handleUnstage(entry.path)}
@@ -477,6 +489,10 @@ export default function SourceControl(): React.JSX.Element {
                   <BranchEntryRow
                     key={`branch:${entry.path}`}
                     entry={entry}
+                    worktreePath={worktreePath}
+                    onRevealInExplorer={() =>
+                      revealInExplorer(currentWorktreeId, joinPath(worktreePath, entry.path))
+                    }
                     onOpen={() => openCommittedDiff(entry)}
                   />
                 ))}
@@ -662,6 +678,7 @@ function SectionHeader({
 function UncommittedEntryRow({
   entry,
   worktreePath,
+  onRevealInExplorer,
   onOpen,
   onStage,
   onUnstage,
@@ -669,6 +686,7 @@ function UncommittedEntryRow({
 }: {
   entry: GitStatusEntry
   worktreePath: string
+  onRevealInExplorer: () => void
   onOpen: () => void
   onStage: () => void
   onUnstage: () => void
@@ -681,74 +699,83 @@ function UncommittedEntryRow({
   const actions = getSourceControlActions(entry.area)
 
   return (
-    <div
-      className="group flex cursor-pointer items-center gap-1 pl-5 pr-3 py-1 transition-colors hover:bg-accent/40"
-      draggable
-      onDragStart={(e) => {
-        const absolutePath = joinPath(worktreePath, entry.path)
-        e.dataTransfer.setData('text/x-orca-file-path', absolutePath)
-        e.dataTransfer.effectAllowed = 'copy'
-      }}
-      onClick={onOpen}
+    <SourceControlEntryContextMenu
+      absolutePath={joinPath(worktreePath, entry.path)}
+      onRevealInExplorer={onRevealInExplorer}
     >
-      <StatusIcon className="size-3.5 shrink-0" style={{ color: STATUS_COLORS[entry.status] }} />
-      <span className="min-w-0 flex-1 truncate text-xs">
-        <span className="text-foreground">{fileName}</span>
-        {dirPath && <span className="ml-1.5 text-[11px] text-muted-foreground">{dirPath}</span>}
-      </span>
-      <span
-        className="w-4 shrink-0 text-center text-[10px] font-bold"
-        style={{ color: STATUS_COLORS[entry.status] }}
+      <div
+        className="group flex cursor-pointer items-center gap-1 pl-5 pr-3 py-1 transition-colors hover:bg-accent/40"
+        draggable
+        onDragStart={(e) => {
+          const absolutePath = joinPath(worktreePath, entry.path)
+          e.dataTransfer.setData('text/x-orca-file-path', absolutePath)
+          e.dataTransfer.effectAllowed = 'copy'
+        }}
+        onClick={onOpen}
       >
-        {STATUS_LABELS[entry.status]}
-      </span>
-      <div className="shrink-0 opacity-0 transition-opacity group-hover:opacity-100 flex items-center gap-0.5">
-        {actions.includes('discard') && (
-          <ActionButton
-            icon={Undo2}
-            title={entry.area === 'untracked' ? 'Revert untracked file' : 'Discard changes'}
-            onClick={(event) => {
-              event.stopPropagation()
-              if (
-                entry.area === 'untracked' &&
-                !window.confirm(`Delete untracked file "${entry.path}"? This cannot be undone.`)
-              ) {
-                return
-              }
-              void onDiscard()
-            }}
-          />
-        )}
-        {actions.includes('stage') && (
-          <ActionButton
-            icon={Plus}
-            title="Stage"
-            onClick={(event) => {
-              event.stopPropagation()
-              void onStage()
-            }}
-          />
-        )}
-        {actions.includes('unstage') && (
-          <ActionButton
-            icon={Minus}
-            title="Unstage"
-            onClick={(event) => {
-              event.stopPropagation()
-              void onUnstage()
-            }}
-          />
-        )}
+        <StatusIcon className="size-3.5 shrink-0" style={{ color: STATUS_COLORS[entry.status] }} />
+        <span className="min-w-0 flex-1 truncate text-xs">
+          <span className="text-foreground">{fileName}</span>
+          {dirPath && <span className="ml-1.5 text-[11px] text-muted-foreground">{dirPath}</span>}
+        </span>
+        <span
+          className="w-4 shrink-0 text-center text-[10px] font-bold"
+          style={{ color: STATUS_COLORS[entry.status] }}
+        >
+          {STATUS_LABELS[entry.status]}
+        </span>
+        <div className="shrink-0 opacity-0 transition-opacity group-hover:opacity-100 flex items-center gap-0.5">
+          {actions.includes('discard') && (
+            <ActionButton
+              icon={Undo2}
+              title={entry.area === 'untracked' ? 'Revert untracked file' : 'Discard changes'}
+              onClick={(event) => {
+                event.stopPropagation()
+                if (
+                  entry.area === 'untracked' &&
+                  !window.confirm(`Delete untracked file "${entry.path}"? This cannot be undone.`)
+                ) {
+                  return
+                }
+                void onDiscard()
+              }}
+            />
+          )}
+          {actions.includes('stage') && (
+            <ActionButton
+              icon={Plus}
+              title="Stage"
+              onClick={(event) => {
+                event.stopPropagation()
+                void onStage()
+              }}
+            />
+          )}
+          {actions.includes('unstage') && (
+            <ActionButton
+              icon={Minus}
+              title="Unstage"
+              onClick={(event) => {
+                event.stopPropagation()
+                void onUnstage()
+              }}
+            />
+          )}
+        </div>
       </div>
-    </div>
+    </SourceControlEntryContextMenu>
   )
 }
 
 function BranchEntryRow({
   entry,
+  worktreePath,
+  onRevealInExplorer,
   onOpen
 }: {
   entry: GitBranchChangeEntry
+  worktreePath: string
+  onRevealInExplorer: () => void
   onOpen: () => void
 }): React.JSX.Element {
   const StatusIcon = STATUS_ICONS[entry.status] ?? FileQuestion
@@ -757,22 +784,56 @@ function BranchEntryRow({
   const dirPath = parentDir === '.' ? '' : parentDir
 
   return (
-    <div
-      className="group flex cursor-pointer items-center gap-1 pl-5 pr-3 py-1 transition-colors hover:bg-accent/40"
-      onClick={onOpen}
+    <SourceControlEntryContextMenu
+      absolutePath={joinPath(worktreePath, entry.path)}
+      onRevealInExplorer={onRevealInExplorer}
     >
-      <StatusIcon className="size-3.5 shrink-0" style={{ color: STATUS_COLORS[entry.status] }} />
-      <span className="min-w-0 flex-1 truncate text-xs">
-        <span className="text-foreground">{fileName}</span>
-        {dirPath && <span className="ml-1.5 text-[11px] text-muted-foreground">{dirPath}</span>}
-      </span>
-      <span
-        className="w-4 shrink-0 text-center text-[10px] font-bold"
-        style={{ color: STATUS_COLORS[entry.status] }}
+      <div
+        className="group flex cursor-pointer items-center gap-1 pl-5 pr-3 py-1 transition-colors hover:bg-accent/40"
+        onClick={onOpen}
       >
-        {STATUS_LABELS[entry.status]}
-      </span>
-    </div>
+        <StatusIcon className="size-3.5 shrink-0" style={{ color: STATUS_COLORS[entry.status] }} />
+        <span className="min-w-0 flex-1 truncate text-xs">
+          <span className="text-foreground">{fileName}</span>
+          {dirPath && <span className="ml-1.5 text-[11px] text-muted-foreground">{dirPath}</span>}
+        </span>
+        <span
+          className="w-4 shrink-0 text-center text-[10px] font-bold"
+          style={{ color: STATUS_COLORS[entry.status] }}
+        >
+          {STATUS_LABELS[entry.status]}
+        </span>
+      </div>
+    </SourceControlEntryContextMenu>
+  )
+}
+
+function SourceControlEntryContextMenu({
+  absolutePath,
+  onRevealInExplorer,
+  children
+}: {
+  absolutePath?: string
+  onRevealInExplorer: () => void
+  children: React.ReactNode
+}): React.JSX.Element {
+  const handleOpenInFileExplorer = useCallback(() => {
+    if (!absolutePath) {
+      return
+    }
+    onRevealInExplorer()
+  }, [absolutePath, onRevealInExplorer])
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
+      <ContextMenuContent className="w-52">
+        <ContextMenuItem onSelect={handleOpenInFileExplorer} disabled={!absolutePath}>
+          <FolderOpen className="size-3.5" />
+          Open in File Explorer
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
   )
 }
 

--- a/src/renderer/src/components/right-sidebar/file-explorer-paths.ts
+++ b/src/renderer/src/components/right-sidebar/file-explorer-paths.ts
@@ -1,0 +1,49 @@
+import { joinPath, normalizeRelativePath } from '@/lib/path'
+import { splitPathSegments } from './path-tree'
+
+export function normalizeAbsolutePath(path: string): string {
+  const normalizedPath = path.replace(/[\\/]+/g, '/')
+
+  if (normalizedPath === '/') {
+    return normalizedPath
+  }
+
+  if (/^[A-Za-z]:\/$/.test(normalizedPath)) {
+    return normalizedPath
+  }
+
+  return normalizedPath.replace(/\/+$/, '')
+}
+
+export function isPathEqualOrDescendant(candidatePath: string, targetPath: string): boolean {
+  const normalizedCandidate = normalizeAbsolutePath(candidatePath)
+  const normalizedTarget = normalizeAbsolutePath(targetPath)
+  return (
+    normalizedCandidate === normalizedTarget ||
+    normalizedCandidate.startsWith(`${normalizedTarget}/`)
+  )
+}
+
+export function getRevealAncestorDirs(worktreePath: string, filePath: string): string[] | null {
+  const normalizedWorktreePath = normalizeAbsolutePath(worktreePath)
+  const normalizedTargetPath = normalizeAbsolutePath(filePath)
+  const prefix = `${normalizedWorktreePath}/`
+
+  if (normalizedTargetPath !== normalizedWorktreePath && !normalizedTargetPath.startsWith(prefix)) {
+    return null
+  }
+
+  const relativePath = normalizeRelativePath(
+    normalizedTargetPath === normalizedWorktreePath ? '' : normalizedTargetPath.slice(prefix.length)
+  )
+  const segments = splitPathSegments(relativePath)
+  const ancestorDirs: string[] = []
+  let currentPath = worktreePath
+
+  for (const segment of segments.slice(0, -1)) {
+    currentPath = joinPath(currentPath, segment)
+    ancestorDirs.push(currentPath)
+  }
+
+  return ancestorDirs
+}

--- a/src/renderer/src/components/right-sidebar/file-explorer-types.ts
+++ b/src/renderer/src/components/right-sidebar/file-explorer-types.ts
@@ -1,0 +1,16 @@
+export type TreeNode = {
+  name: string
+  path: string
+  relativePath: string
+  isDirectory: boolean
+  depth: number
+}
+
+export type DirCache = {
+  children: TreeNode[]
+  loading: boolean
+}
+
+export type PendingDelete = {
+  node: TreeNode
+}

--- a/src/renderer/src/components/right-sidebar/status-display.ts
+++ b/src/renderer/src/components/right-sidebar/status-display.ts
@@ -1,5 +1,6 @@
 import type { GitFileStatus, GitStatusEntry } from '../../../../shared/types'
-import { normalizeRelativePath } from '@/lib/path'
+import { joinPath, normalizeRelativePath } from '@/lib/path'
+import { splitPathSegments } from './path-tree'
 
 export const STATUS_LABELS: Record<GitFileStatus, string> = {
   modified: 'M',
@@ -56,6 +57,39 @@ export function buildStatusMap(entries: GitStatusEntry[]): Map<string, GitFileSt
   }
 
   return statusByPath
+}
+
+export function buildFolderStatusMap(entries: GitStatusEntry[]): Map<string, GitFileStatus | null> {
+  const folderStatuses = new Map<string, GitFileStatus[]>()
+
+  for (const entry of entries) {
+    if (!shouldPropagateStatus(entry.status)) {
+      continue
+    }
+
+    const segments = splitPathSegments(entry.path)
+    if (segments.length <= 1) {
+      continue
+    }
+
+    let currentPath = ''
+    for (const segment of segments.slice(0, -1)) {
+      currentPath = currentPath ? joinPath(currentPath, segment) : segment
+      const statuses = folderStatuses.get(currentPath)
+      if (statuses) {
+        statuses.push(entry.status)
+      } else {
+        folderStatuses.set(currentPath, [entry.status])
+      }
+    }
+  }
+
+  return new Map(
+    Array.from(folderStatuses.entries()).map(([folderPath, statuses]) => [
+      folderPath,
+      getDominantStatus(statuses)
+    ])
+  )
 }
 
 export function shouldPropagateStatus(status: GitFileStatus): boolean {

--- a/src/renderer/src/components/right-sidebar/useFileDeletion.ts
+++ b/src/renderer/src/components/right-sidebar/useFileDeletion.ts
@@ -1,0 +1,159 @@
+import { useCallback, useMemo, useState } from 'react'
+import type { Dispatch, SetStateAction } from 'react'
+import { toast } from 'sonner'
+import { useAppStore } from '@/store'
+import { isPathEqualOrDescendant } from './file-explorer-paths'
+import type { PendingDelete, TreeNode } from './file-explorer-types'
+
+type UseFileDeletionParams = {
+  activeWorktreeId: string | null
+  openFiles: {
+    id: string
+    filePath: string
+  }[]
+  closeFile: (fileId: string) => void
+  refreshTree: () => Promise<void>
+  selectedPath: string | null
+  setSelectedPath: Dispatch<SetStateAction<string | null>>
+  isMac: boolean
+  isWindows: boolean
+}
+
+type UseFileDeletionResult = {
+  pendingDelete: PendingDelete | null
+  isDeleting: boolean
+  deleteShortcutLabel: string
+  deleteActionLabel: string
+  deleteDescription: string
+  requestDelete: (node: TreeNode) => void
+  closeDeleteDialog: () => void
+  confirmDelete: () => Promise<void>
+}
+
+function getDeleteDescription(pendingDelete: PendingDelete | null, isWindows: boolean): string {
+  if (!pendingDelete) {
+    return ''
+  }
+
+  const destination = isWindows ? 'the Recycle Bin' : 'the Trash'
+  const { node } = pendingDelete
+
+  if (node.isDirectory) {
+    return `Are you sure you want to move '${node.name}' and its contents to ${destination}?`
+  }
+
+  return `Are you sure you want to move '${node.name}' to ${destination}?`
+}
+
+export function useFileDeletion({
+  activeWorktreeId,
+  openFiles,
+  closeFile,
+  refreshTree,
+  selectedPath,
+  setSelectedPath,
+  isMac,
+  isWindows
+}: UseFileDeletionParams): UseFileDeletionResult {
+  const [pendingDelete, setPendingDelete] = useState<PendingDelete | null>(null)
+  const [isDeleting, setIsDeleting] = useState(false)
+
+  const requestDelete = useCallback(
+    (node: TreeNode) => {
+      setSelectedPath(node.path)
+      setPendingDelete({ node })
+    },
+    [setSelectedPath]
+  )
+
+  const closeDeleteDialog = useCallback(() => {
+    setPendingDelete(null)
+  }, [])
+
+  const confirmDelete = useCallback(async () => {
+    if (!pendingDelete) {
+      return
+    }
+
+    const { node } = pendingDelete
+    setIsDeleting(true)
+
+    try {
+      await window.api.fs.deletePath({ targetPath: node.path })
+
+      const filesToClose = openFiles.filter((file) =>
+        isPathEqualOrDescendant(file.filePath, node.path)
+      )
+      for (const file of filesToClose) {
+        closeFile(file.id)
+      }
+
+      if (activeWorktreeId) {
+        useAppStore.setState((state) => {
+          const currentExpanded = state.expandedDirs[activeWorktreeId] ?? new Set<string>()
+          const nextExpanded = new Set(
+            Array.from(currentExpanded).filter(
+              (dirPath) => !isPathEqualOrDescendant(dirPath, node.path)
+            )
+          )
+
+          if (nextExpanded.size === currentExpanded.size) {
+            return state
+          }
+
+          return {
+            expandedDirs: {
+              ...state.expandedDirs,
+              [activeWorktreeId]: nextExpanded
+            }
+          }
+        })
+      }
+
+      setPendingDelete(null)
+      if (selectedPath && isPathEqualOrDescendant(selectedPath, node.path)) {
+        setSelectedPath(null)
+      }
+      await refreshTree()
+    } catch (error) {
+      const action = isWindows ? 'move to Recycle Bin' : 'move to Trash'
+      toast.error(error instanceof Error ? error.message : `Failed to ${action} '${node.name}'.`)
+    } finally {
+      setIsDeleting(false)
+    }
+  }, [
+    activeWorktreeId,
+    closeFile,
+    isWindows,
+    openFiles,
+    pendingDelete,
+    refreshTree,
+    selectedPath,
+    setSelectedPath
+  ])
+
+  const deleteActionLabel = isWindows ? 'Move to Recycle Bin' : 'Move to Trash'
+
+  return useMemo(
+    () => ({
+      pendingDelete,
+      isDeleting,
+      deleteShortcutLabel: isMac ? '⌘⌫' : 'Del',
+      deleteActionLabel,
+      deleteDescription: getDeleteDescription(pendingDelete, isWindows),
+      requestDelete,
+      closeDeleteDialog,
+      confirmDelete
+    }),
+    [
+      closeDeleteDialog,
+      confirmDelete,
+      deleteActionLabel,
+      isMac,
+      isDeleting,
+      isWindows,
+      pendingDelete,
+      requestDelete
+    ]
+  )
+}

--- a/src/renderer/src/components/right-sidebar/useFileExplorerReveal.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerReveal.ts
@@ -1,0 +1,181 @@
+import { useEffect, useMemo } from 'react'
+import type { Dispatch, RefObject, SetStateAction } from 'react'
+import type { Virtualizer } from '@tanstack/react-virtual'
+import { useAppStore } from '@/store'
+import { getRevealAncestorDirs } from './file-explorer-paths'
+import type { DirCache, TreeNode } from './file-explorer-types'
+
+type UseFileExplorerRevealParams = {
+  activeWorktreeId: string | null
+  worktreePath: string | null
+  pendingExplorerReveal: { worktreeId: string; filePath: string; requestId: number } | null
+  clearPendingExplorerReveal: () => void
+  expanded: Set<string>
+  dirCache: Record<string, DirCache>
+  rootCache: DirCache | undefined
+  rowsByPath: Map<string, TreeNode>
+  flatRows: TreeNode[]
+  loadDir: (dirPath: string, depth: number, options?: { force?: boolean }) => Promise<void>
+  setSelectedPath: Dispatch<SetStateAction<string | null>>
+  setFlashingPath: Dispatch<SetStateAction<string | null>>
+  flashTimeoutRef: RefObject<number | null>
+  virtualizer: Virtualizer<HTMLDivElement, Element>
+}
+
+export function useFileExplorerReveal({
+  activeWorktreeId,
+  worktreePath,
+  pendingExplorerReveal,
+  clearPendingExplorerReveal,
+  expanded,
+  dirCache,
+  rootCache,
+  rowsByPath,
+  flatRows,
+  loadDir,
+  setSelectedPath,
+  setFlashingPath,
+  flashTimeoutRef,
+  virtualizer
+}: UseFileExplorerRevealParams): void {
+  const pendingRevealAncestorDirs = useMemo(() => {
+    if (
+      !pendingExplorerReveal ||
+      !activeWorktreeId ||
+      pendingExplorerReveal.worktreeId !== activeWorktreeId ||
+      !worktreePath
+    ) {
+      return null
+    }
+
+    return getRevealAncestorDirs(worktreePath, pendingExplorerReveal.filePath)
+  }, [activeWorktreeId, pendingExplorerReveal, worktreePath])
+
+  useEffect(() => {
+    if (!pendingExplorerReveal || !activeWorktreeId || !worktreePath) {
+      return
+    }
+
+    if (!pendingRevealAncestorDirs) {
+      clearPendingExplorerReveal()
+      return
+    }
+
+    useAppStore.setState((state) => {
+      const currentExpanded = state.expandedDirs[activeWorktreeId] ?? new Set<string>()
+      const nextExpanded = new Set(currentExpanded)
+      let changed = false
+
+      for (const dirPath of pendingRevealAncestorDirs) {
+        if (!nextExpanded.has(dirPath)) {
+          nextExpanded.add(dirPath)
+          changed = true
+        }
+      }
+
+      if (!changed) {
+        return state
+      }
+
+      return {
+        expandedDirs: {
+          ...state.expandedDirs,
+          [activeWorktreeId]: nextExpanded
+        }
+      }
+    })
+
+    void (async () => {
+      await loadDir(worktreePath, -1)
+
+      for (let depth = 0; depth < pendingRevealAncestorDirs.length; depth += 1) {
+        await loadDir(pendingRevealAncestorDirs[depth], depth)
+      }
+    })()
+  }, [
+    activeWorktreeId,
+    clearPendingExplorerReveal,
+    loadDir,
+    pendingExplorerReveal,
+    pendingRevealAncestorDirs,
+    worktreePath
+  ])
+
+  useEffect(() => {
+    if (
+      !pendingExplorerReveal ||
+      !activeWorktreeId ||
+      pendingExplorerReveal.worktreeId !== activeWorktreeId ||
+      !worktreePath ||
+      !pendingRevealAncestorDirs
+    ) {
+      return
+    }
+
+    const targetPath = pendingExplorerReveal.filePath
+    const parentDirPath =
+      pendingRevealAncestorDirs.length > 0 ? pendingRevealAncestorDirs.at(-1)! : worktreePath
+    const parentDirCache = dirCache[parentDirPath]
+    const missingExpandedAncestor = pendingRevealAncestorDirs.find(
+      (dirPath) => !expanded.has(dirPath)
+    )
+    const missingAncestor = pendingRevealAncestorDirs.find((dirPath) => !rowsByPath.has(dirPath))
+    const parentDirStillLoading =
+      parentDirPath === worktreePath
+        ? (rootCache?.loading ?? true)
+        : (parentDirCache?.loading ?? true)
+    const parentDirKnown = parentDirPath === worktreePath ? !!rootCache : !!parentDirCache
+
+    if (
+      (rootCache?.loading ?? true) ||
+      missingExpandedAncestor ||
+      missingAncestor ||
+      parentDirStillLoading ||
+      !parentDirKnown
+    ) {
+      return
+    }
+
+    const fallbackPath = rowsByPath.has(parentDirPath) ? parentDirPath : null
+    const revealPath = rowsByPath.has(targetPath) ? targetPath : fallbackPath
+    if (!revealPath) {
+      clearPendingExplorerReveal()
+      return
+    }
+
+    clearPendingExplorerReveal()
+    setSelectedPath(revealPath)
+    setFlashingPath(revealPath)
+    if (flashTimeoutRef.current !== null) {
+      window.clearTimeout(flashTimeoutRef.current)
+    }
+    flashTimeoutRef.current = window.setTimeout(() => {
+      setFlashingPath((current) => (current === revealPath ? null : current))
+      flashTimeoutRef.current = null
+    }, 2000)
+
+    requestAnimationFrame(() => {
+      window.setTimeout(() => {
+        const targetIndex = flatRows.findIndex((row) => row.path === revealPath)
+        if (targetIndex !== -1) {
+          virtualizer.scrollToIndex(targetIndex, { align: 'center' })
+        }
+      }, 0)
+    })
+  }, [
+    activeWorktreeId,
+    clearPendingExplorerReveal,
+    dirCache,
+    expanded,
+    flatRows,
+    pendingExplorerReveal,
+    pendingRevealAncestorDirs,
+    rootCache,
+    rowsByPath,
+    setFlashingPath,
+    setSelectedPath,
+    flashTimeoutRef,
+    virtualizer,
+    worktreePath
+  ])
+}

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -67,6 +67,13 @@ export type EditorSlice = {
   // File explorer state
   expandedDirs: Record<string, Set<string>> // worktreeId -> set of expanded dir paths
   toggleDir: (worktreeId: string, dirPath: string) => void
+  pendingExplorerReveal: {
+    worktreeId: string
+    filePath: string
+    requestId: number
+  } | null
+  revealInExplorer: (worktreeId: string, filePath: string) => void
+  clearPendingExplorerReveal: () => void
 
   // Open files / editor tabs
   openFiles: OpenFile[]
@@ -190,6 +197,14 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
       }
       return { expandedDirs: { ...s.expandedDirs, [worktreeId]: next } }
     }),
+  pendingExplorerReveal: null,
+  revealInExplorer: (worktreeId, filePath) =>
+    set({
+      rightSidebarOpen: true,
+      rightSidebarTab: 'explorer',
+      pendingExplorerReveal: { worktreeId, filePath, requestId: Date.now() }
+    }),
+  clearPendingExplorerReveal: () => set({ pendingExplorerReveal: null }),
 
   // Open files
   openFiles: [],


### PR DESCRIPTION
## Summary
- Add file/folder deletion via right-click context menu in the file explorer, using Electron's `shell.trashItem` (moves to OS trash, safe & reversible)
- Add confirmation dialog before deletion showing the file/folder name
- Add "Reveal in Explorer" support to scroll to and highlight files in the sidebar
- Refactor FileExplorer into smaller composable modules (FileExplorerRow, FileDeleteDialog, useFileDeletion, useFileExplorerReveal, path utilities, types)

## Test plan
- [x] Unit tests for `fs:deletePath` IPC handler
- [ ] Right-click a file in the explorer → "Delete" option appears
- [ ] Confirm deletion dialog → file is moved to OS trash
- [ ] Cancel deletion dialog → file remains
- [ ] Right-click a folder → "Delete" option works for directories
- [ ] Deleted file tabs are closed automatically
- [ ] Reveal in explorer scrolls to and highlights the target file