### PR TITLE
fix: prevent stale PR cache overwrites on force refresh

### DIFF
--- a/src/renderer/src/store/slices/github.test.ts
+++ b/src/renderer/src/store/slices/github.test.ts
@@ -193,3 +193,38 @@ describe('createGitHubSlice.fetchPRChecks', () => {
     })
   })
 })
+
+describe('createGitHubSlice.fetchPRForBranch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApi.gh.prForBranch.mockResolvedValue(null)
+  })
+
+  it('lets a forced refresh bypass a non-forced inflight request and keeps the newer result', async () => {
+    const store = createTestStore()
+    const repoPath = '/repo'
+    const branch = 'feature/test'
+    const prCacheKey = `${repoPath}::${branch}`
+
+    let resolveInitial: ((value: null) => void) | undefined
+    const initialRequest = new Promise<null>((resolve) => {
+      resolveInitial = resolve
+    })
+
+    mockApi.gh.prForBranch
+      .mockReturnValueOnce(initialRequest)
+      .mockResolvedValueOnce(makePR({ number: 99, title: 'Forced refresh PR' }))
+
+    const initialFetch = store.getState().fetchPRForBranch(repoPath, branch)
+    const forcedFetch = store.getState().fetchPRForBranch(repoPath, branch, { force: true })
+
+    await expect(forcedFetch).resolves.toMatchObject({ number: 99, title: 'Forced refresh PR' })
+    expect(mockApi.gh.prForBranch).toHaveBeenCalledTimes(2)
+    expect(store.getState().prCache[prCacheKey]?.data).toMatchObject({ number: 99 })
+
+    resolveInitial?.(null)
+    await expect(initialFetch).resolves.toBeNull()
+
+    expect(store.getState().prCache[prCacheKey]?.data).toMatchObject({ number: 99 })
+  })
+})

--- a/src/renderer/src/store/slices/github.ts
+++ b/src/renderer/src/store/slices/github.ts
@@ -15,9 +15,13 @@ type FetchOptions = {
 const CACHE_TTL = 300_000 // 5 minutes (stale data shown instantly, then refreshed)
 const CHECKS_CACHE_TTL = 60_000 // 1 minute — checks change more frequently
 
-const inflightPRRequests = new Map<string, Promise<PRInfo | null>>()
+const inflightPRRequests = new Map<
+  string,
+  { promise: Promise<PRInfo | null>; force: boolean; generation: number }
+>()
 const inflightIssueRequests = new Map<string, Promise<IssueInfo | null>>()
 const inflightChecksRequests = new Map<string, Promise<PRCheckDetail[]>>()
+const prRequestGenerations = new Map<string, number>()
 
 function isFresh<T>(entry: CacheEntry<T> | undefined, ttl = CACHE_TTL): entry is CacheEntry<T> {
   return entry !== undefined && Date.now() - entry.fetchedAt < ttl
@@ -88,31 +92,45 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
     }
 
     const inflightRequest = inflightPRRequests.get(cacheKey)
-    if (inflightRequest) {
-      return inflightRequest
+    if (inflightRequest && (!options?.force || inflightRequest.force)) {
+      return inflightRequest.promise
     }
+
+    const generation = (prRequestGenerations.get(cacheKey) ?? 0) + 1
+    prRequestGenerations.set(cacheKey, generation)
 
     const request = (async () => {
       try {
         const pr = await window.api.gh.prForBranch({ repoPath, branch })
-        set((s) => ({
-          prCache: { ...s.prCache, [cacheKey]: { data: pr, fetchedAt: Date.now() } }
-        }))
-        debouncedSaveCache(get())
+        if (prRequestGenerations.get(cacheKey) === generation) {
+          set((s) => ({
+            prCache: { ...s.prCache, [cacheKey]: { data: pr, fetchedAt: Date.now() } }
+          }))
+          debouncedSaveCache(get())
+        }
         return pr
       } catch (err) {
         console.error('Failed to fetch PR:', err)
-        set((s) => ({
-          prCache: { ...s.prCache, [cacheKey]: { data: null, fetchedAt: Date.now() } }
-        }))
-        debouncedSaveCache(get())
+        if (prRequestGenerations.get(cacheKey) === generation) {
+          set((s) => ({
+            prCache: { ...s.prCache, [cacheKey]: { data: null, fetchedAt: Date.now() } }
+          }))
+          debouncedSaveCache(get())
+        }
         return null
       } finally {
-        inflightPRRequests.delete(cacheKey)
+        const activeRequest = inflightPRRequests.get(cacheKey)
+        if (activeRequest?.generation === generation) {
+          inflightPRRequests.delete(cacheKey)
+        }
       }
     })()
 
-    inflightPRRequests.set(cacheKey, request)
+    inflightPRRequests.set(cacheKey, {
+      promise: request,
+      force: Boolean(options?.force),
+      generation
+    })
     return request
   },
 


### PR DESCRIPTION
## Summary
- allow a forced PR refresh to bypass a non-forced in-flight request
- prevent older request results from overwriting newer cache state by tracking request generations
- add a regression test covering the forced-refresh race

## Verification
- pnpm exec vitest run src/renderer/src/store/slices/github.test.ts
- pnpm test
- pnpm run typecheck
- pnpm lint
- pnpm run build