### PR TITLE
fix: reduce Gemini terminal flashing

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -1,4 +1,5 @@
 import type { PaneManager, ManagedPane } from '@/lib/pane-manager/pane-manager'
+import { isGeminiTerminalTitle } from '@/lib/agent-status'
 import type { PtyTransport } from './pty-transport'
 import { createIpcPtyTransport } from './pty-transport'
 
@@ -23,6 +24,7 @@ export function connectPanePty(
 ): void {
   const onExit = (ptyId: string): void => {
     deps.clearTabPtyId(deps.tabId, ptyId)
+    manager.setPaneGpuRendering(pane.id, true)
     const panes = manager.getPanes()
     if (panes.length <= 1) {
       deps.onPtyExitRef.current(ptyId)
@@ -31,7 +33,8 @@ export function connectPanePty(
     manager.closePane(pane.id)
   }
 
-  const onTitleChange = (title: string): void => {
+  const onTitleChange = (title: string, rawTitle: string): void => {
+    manager.setPaneGpuRendering(pane.id, !isGeminiTerminalTitle(rawTitle))
     deps.updateTabTitle(deps.tabId, title)
   }
 

--- a/src/renderer/src/components/terminal-pane/pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.ts
@@ -1,7 +1,8 @@
 import {
   detectAgentStatusFromTitle,
   clearWorkingIndicators,
-  createAgentStatusTracker
+  createAgentStatusTracker,
+  normalizeTerminalTitle
 } from '@/lib/agent-status'
 
 export type PtyTransport = {
@@ -65,7 +66,7 @@ export function extractLastOscTitle(data: string): string | null {
 export type IpcPtyTransportOptions = {
   cwd?: string
   onPtyExit?: (ptyId: string) => void
-  onTitleChange?: (title: string) => void
+  onTitleChange?: (title: string, rawTitle: string) => void
   onPtySpawn?: (ptyId: string) => void
   onBell?: () => void
   onAgentBecameIdle?: () => void
@@ -132,8 +133,8 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
                 clearTimeout(staleTitleTimer)
                 staleTitleTimer = null
               }
-              lastEmittedTitle = title
-              onTitleChange(title)
+              lastEmittedTitle = normalizeTerminalTitle(title)
+              onTitleChange(lastEmittedTitle, title)
               agentTracker?.handleTitle(title)
             } else if (
               lastEmittedTitle &&
@@ -152,7 +153,7 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
                 ) {
                   const cleared = clearWorkingIndicators(lastEmittedTitle)
                   lastEmittedTitle = cleared
-                  onTitleChange(cleared)
+                  onTitleChange(cleared, cleared)
                 }
               }, STALE_TITLE_TIMEOUT)
             }

--- a/src/renderer/src/lib/agent-status.test.ts
+++ b/src/renderer/src/lib/agent-status.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   detectAgentStatusFromTitle,
   clearWorkingIndicators,
-  createAgentStatusTracker
+  createAgentStatusTracker,
+  isGeminiTerminalTitle,
+  normalizeTerminalTitle
 } from './agent-status'
 import { extractLastOscTitle } from '../components/terminal-pane/pty-transport'
 
@@ -185,6 +187,36 @@ describe('clearWorkingIndicators', () => {
   it('returns original title if no working indicators found', () => {
     expect(clearWorkingIndicators('* claude')).toBe('* claude')
     expect(clearWorkingIndicators('Terminal 1')).toBe('Terminal 1')
+  })
+})
+
+describe('normalizeTerminalTitle', () => {
+  it('collapses Gemini working titles to a stable label', () => {
+    expect(normalizeTerminalTitle('✦  Typing prompt... (workspace)')).toBe('✦ Gemini CLI')
+    expect(normalizeTerminalTitle('⏲  Working… (workspace)')).toBe('✦ Gemini CLI')
+  })
+
+  it('collapses Gemini idle and permission titles to stable labels', () => {
+    expect(normalizeTerminalTitle('◇  Ready (workspace)')).toBe('◇ Gemini CLI')
+    expect(normalizeTerminalTitle('✋  Action Required (workspace)')).toBe('✋ Gemini CLI')
+  })
+
+  it('leaves non-Gemini titles unchanged', () => {
+    expect(normalizeTerminalTitle('⠂ Claude Code')).toBe('⠂ Claude Code')
+    expect(normalizeTerminalTitle('bash')).toBe('bash')
+  })
+})
+
+describe('isGeminiTerminalTitle', () => {
+  it('detects Gemini titles by symbol or name', () => {
+    expect(isGeminiTerminalTitle('✦  Typing prompt... (workspace)')).toBe(true)
+    expect(isGeminiTerminalTitle('◇  Ready (workspace)')).toBe(true)
+    expect(isGeminiTerminalTitle('gemini waiting for input')).toBe(true)
+  })
+
+  it('does not match other terminal titles', () => {
+    expect(isGeminiTerminalTitle('⠂ Claude Code')).toBe(false)
+    expect(isGeminiTerminalTitle('bash')).toBe(false)
   })
 })
 

--- a/src/renderer/src/lib/agent-status.ts
+++ b/src/renderer/src/lib/agent-status.ts
@@ -9,6 +9,16 @@ const GEMINI_PERMISSION = '\u270B' // ✋
 
 const AGENT_NAMES = ['claude', 'codex', 'gemini', 'opencode', 'aider']
 
+export function isGeminiTerminalTitle(title: string): boolean {
+  return (
+    title.includes(GEMINI_PERMISSION) ||
+    title.includes(GEMINI_WORKING) ||
+    title.includes(GEMINI_SILENT_WORKING) ||
+    title.includes(GEMINI_IDLE) ||
+    title.toLowerCase().includes('gemini')
+  )
+}
+
 function containsBrailleSpinner(title: string): boolean {
   for (const char of title) {
     const codePoint = char.codePointAt(0)
@@ -87,6 +97,32 @@ export function createAgentStatusTracker(onBecameIdle: () => void): {
       }
     }
   }
+}
+
+/**
+ * Normalize high-churn agent titles into stable display labels before storing
+ * them in app state. Gemini CLI can emit per-keystroke title updates, which
+ * otherwise causes broad rerenders and visible flashing.
+ */
+export function normalizeTerminalTitle(title: string): string {
+  if (!title) {
+    return title
+  }
+
+  if (isGeminiTerminalTitle(title)) {
+    const status = detectAgentStatusFromTitle(title)
+    if (status === 'permission') {
+      return `${GEMINI_PERMISSION} Gemini CLI`
+    }
+    if (status === 'working') {
+      return `${GEMINI_WORKING} Gemini CLI`
+    }
+    if (status === 'idle') {
+      return `${GEMINI_IDLE} Gemini CLI`
+    }
+  }
+
+  return title
 }
 
 export function detectAgentStatusFromTitle(title: string): AgentStatus | null {

--- a/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
+++ b/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
@@ -17,6 +17,7 @@ import { safeFit } from './pane-tree-ops'
 // ---------------------------------------------------------------------------
 
 const TERMINAL_PADDING = 4
+const ENABLE_WEBGL_RENDERER = true
 
 export function createPaneDOM(
   id: number,
@@ -102,6 +103,7 @@ export function createPaneDOM(
     container,
     xtermContainer,
     linkTooltip,
+    gpuRenderingEnabled: ENABLE_WEBGL_RENDERER,
     fitAddon,
     searchAddon,
     unicode11Addon,
@@ -146,8 +148,9 @@ export function openTerminal(pane: ManagedPaneInternal): void {
   // Activate unicode 11
   terminal.unicode.activeVersion = '11'
 
-  // Attach GPU renderer
-  attachWebgl(pane)
+  if (pane.gpuRenderingEnabled) {
+    attachWebgl(pane)
+  }
 
   // Initial fit (deferred to ensure layout has settled)
   requestAnimationFrame(() => {
@@ -156,6 +159,10 @@ export function openTerminal(pane: ManagedPaneInternal): void {
 }
 
 export function attachWebgl(pane: ManagedPaneInternal): void {
+  if (!ENABLE_WEBGL_RENDERER || !pane.gpuRenderingEnabled) {
+    pane.webglAddon = null
+    return
+  }
   try {
     const webglAddon = new WebglAddon()
     webglAddon.onContextLoss(() => {

--- a/src/renderer/src/lib/pane-manager/pane-manager-types.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager-types.ts
@@ -43,6 +43,7 @@ export type ManagedPane = {
 export type ManagedPaneInternal = {
   xtermContainer: HTMLElement
   linkTooltip: HTMLElement
+  gpuRenderingEnabled: boolean
   webglAddon: WebglAddon | null
   unicode11Addon: Unicode11Addon
   webLinksAddon: WebLinksAddon

--- a/src/renderer/src/lib/pane-manager/pane-manager.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager.ts
@@ -209,6 +209,32 @@ export class PaneManager {
     applyRootBackground(this.root, this.styleOptions)
   }
 
+  setPaneGpuRendering(paneId: number, enabled: boolean): void {
+    const pane = this.panes.get(paneId)
+    if (!pane) {
+      return
+    }
+
+    pane.gpuRenderingEnabled = enabled
+
+    if (!enabled) {
+      if (pane.webglAddon) {
+        try {
+          pane.webglAddon.dispose()
+        } catch {
+          /* ignore */
+        }
+        pane.webglAddon = null
+      }
+      return
+    }
+
+    if (!pane.webglAddon) {
+      attachWebgl(pane)
+      safeFit(pane)
+    }
+  }
+
   /**
    * Suspend GPU rendering for all panes. Disposes WebGL addons to free
    * GPU contexts while keeping Terminal instances alive (scrollback, cursor,
@@ -233,7 +259,7 @@ export class PaneManager {
    */
   resumeRendering(): void {
     for (const pane of this.panes.values()) {
-      if (!pane.webglAddon) {
+      if (pane.gpuRenderingEnabled && !pane.webglAddon) {
         attachWebgl(pane)
       }
     }

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -150,11 +150,18 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
 
   updateTabTitle: (tabId, title) => {
     set((s) => {
+      let changed = false
       const next = { ...s.tabsByWorktree }
       for (const wId of Object.keys(next)) {
-        next[wId] = next[wId].map((t) => (t.id === tabId ? { ...t, title } : t))
+        next[wId] = next[wId].map((t) => {
+          if (t.id !== tabId || t.title === title) {
+            return t
+          }
+          changed = true
+          return { ...t, title }
+        })
       }
-      return { tabsByWorktree: next }
+      return changed ? { tabsByWorktree: next } : s
     })
   },
 


### PR DESCRIPTION
## Problem
Gemini CLI updates the terminal title at very high frequency, which causes repeated renderer and state updates in Orca. That led to visible flashing in Gemini-backed terminal panes, and the initial mitigation could leave panes stuck on the fallback renderer longer than intended.

## Solution
Normalize Gemini terminal titles into stable labels before storing them in app state, and skip terminal title store updates when the value did not actually change. Disable the WebGL renderer only while a pane is actively showing Gemini titles, preserve that per-pane GPU setting across suspend/resume, and re-enable GPU rendering when the PTY exits so panes recover cleanly after Gemini is done. Added targeted tests for Gemini title detection and normalization.
