### PR TITLE
Fix scrolling on markdown preview and use editor scrollbars

### DIFF
--- a/src/renderer/src/components/editor/CombinedDiffViewer.tsx
+++ b/src/renderer/src/components/editor/CombinedDiffViewer.tsx
@@ -292,7 +292,7 @@ export default function CombinedDiffViewer({ file }: { file: OpenFile }): React.
     ) : null
 
   return (
-    <div className="flex flex-col h-full">
+    <div className="flex flex-col flex-1 min-h-0">
       <div className="flex items-center justify-between px-3 py-1.5 border-b border-border bg-background/50 shrink-0">
         <span className="text-xs text-muted-foreground">
           {sections.length} changed files

--- a/src/renderer/src/components/editor/DiffViewer.tsx
+++ b/src/renderer/src/components/editor/DiffViewer.tsx
@@ -57,7 +57,7 @@ export default function DiffViewer({
   )
 
   return (
-    <div className="flex flex-col h-full">
+    <div className="flex flex-col flex-1 min-h-0">
       <div className="flex-1 min-h-0">
         <DiffEditor
           height="100%"

--- a/src/renderer/src/components/editor/EditorContent.tsx
+++ b/src/renderer/src/components/editor/EditorContent.tsx
@@ -135,9 +135,9 @@ export function EditorContent({
       )
     }
     return (
-      <div className="flex h-full min-h-0 flex-col">
+      <div className="flex flex-1 min-h-0 flex-col">
         {activeFile.conflict && <ConflictBanner file={activeFile} entry={activeConflictEntry} />}
-        <div className="min-h-0 flex-1">
+        <div className="min-h-0 flex-1 relative">
           {isMarkdown ? renderMarkdownContent(fc) : renderMonacoEditor(fc)}
         </div>
       </div>

--- a/src/renderer/src/components/editor/MarkdownPreview.tsx
+++ b/src/renderer/src/components/editor/MarkdownPreview.tsx
@@ -65,7 +65,7 @@ export default function MarkdownPreview({
 
   return (
     <div
-      className={`markdown-preview flex-1 min-h-0 overflow-auto ${isDark ? 'markdown-dark' : 'markdown-light'}`}
+      className={`markdown-preview h-full min-h-0 overflow-auto scrollbar-editor ${isDark ? 'markdown-dark' : 'markdown-light'}`}
     >
       <div className="markdown-body">
         <Markdown


### PR DESCRIPTION
Fixes the scrolling issue on markdown previews by updating the flex layout classes, and adds `scrollbar-editor` so the scrollbars match the main code doc / Monaco.