### PR TITLE
fix(ui): increase active worktree card background contrast

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -218,7 +218,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
         className={cn(
           'group relative flex items-start gap-2.5 px-3 py-2 rounded-lg cursor-pointer transition-all duration-200 outline-none select-none mx-1',
           isActive
-            ? 'bg-accent/80 shadow-[0_1px_2px_rgba(0,0,0,0.03)] border border-border/60 dark:bg-accent/40 dark:border-border/40'
+            ? 'bg-black/[0.06] shadow-[0_1px_2px_rgba(0,0,0,0.03)] border border-border/60 dark:bg-white/[0.10] dark:border-border/40'
             : 'border border-transparent hover:bg-accent/40',
           isDeleting && 'opacity-50 grayscale cursor-not-allowed'
         )}


### PR DESCRIPTION
## Summary
- Increased the background contrast of the active worktree card in the sidebar so it's easier to distinguish at a glance
- Light mode: `bg-accent/80` → `bg-black/[0.06]`
- Dark mode: `bg-accent/40` → `bg-white/[0.10]`

## Test plan
- [ ] Verify active worktree card is visually distinct in light mode
- [ ] Verify active worktree card is visually distinct in dark mode