### PR TITLE
Fix slow file search sidebar freezes

### DIFF
--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -3,6 +3,8 @@ import { ipcMain, shell } from 'electron'
 import { readdir, readFile, writeFile, stat, lstat } from 'fs/promises'
 import { extname, relative } from 'path'
 import { spawn } from 'child_process'
+import type { ChildProcessByStdio } from 'child_process'
+import type { Readable } from 'stream'
 import type { Store } from '../persistence'
 import type {
   DirEntry,
@@ -31,6 +33,9 @@ import {
 import { listQuickOpenFiles } from './filesystem-list-files'
 
 const MAX_FILE_SIZE = 5 * 1024 * 1024 // 5MB
+const DEFAULT_SEARCH_MAX_RESULTS = 2000
+const MAX_MATCHES_PER_FILE = 100
+const SEARCH_TIMEOUT_MS = 15000
 const IMAGE_MIME_TYPES: Record<string, string> = {
   '.png': 'image/png',
   '.jpg': 'image/jpeg',
@@ -60,6 +65,8 @@ function isBinaryBuffer(buffer: Buffer): boolean {
 }
 
 export function registerFilesystemHandlers(store: Store): void {
+  const activeTextSearches = new Map<string, ChildProcessByStdio<null, Readable, Readable>>()
+
   // ─── Filesystem ─────────────────────────────────────────
   ipcMain.handle('fs:readDir', async (_event, args: { dirPath: string }): Promise<DirEntry[]> => {
     const dirPath = await resolveAuthorizedPath(args.dirPath, store)
@@ -155,10 +162,13 @@ export function registerFilesystemHandlers(store: Store): void {
   )
 
   // ─── Search ────────────────────────────────────────────
-  ipcMain.handle('fs:search', async (_event, args: SearchOptions): Promise<SearchResult> => {
+  ipcMain.handle('fs:search', async (event, args: SearchOptions): Promise<SearchResult> => {
     const rootPath = await resolveAuthorizedPath(args.rootPath, store)
-
-    const maxResults = args.maxResults ?? 10000
+    const maxResults = Math.max(
+      1,
+      Math.min(args.maxResults ?? DEFAULT_SEARCH_MAX_RESULTS, DEFAULT_SEARCH_MAX_RESULTS)
+    )
+    const searchKey = `${event.sender.id}:${rootPath}`
 
     return new Promise((resolvePromise) => {
       const rgArgs: string[] = [
@@ -167,7 +177,7 @@ export function registerFilesystemHandlers(store: Store): void {
         '--glob',
         '!.git',
         '--max-count',
-        '200', // max matches per file
+        String(MAX_MATCHES_PER_FILE),
         '--max-filesize',
         `${Math.floor(MAX_FILE_SIZE / 1024 / 1024)}M`
       ]
@@ -200,17 +210,28 @@ export function registerFilesystemHandlers(store: Store): void {
 
       rgArgs.push('--', args.query, rootPath)
 
+      // Why: search requests are fired on each query/options change. If the
+      // previous ripgrep process keeps running, it can continue streaming and
+      // parsing thousands of matches on the Electron main thread after the UI
+      // no longer cares about that result, which is exactly the freeze users
+      // experience in large repos.
+      activeTextSearches.get(searchKey)?.kill()
+
       const fileMap = new Map<string, SearchFileResult>()
       let totalMatches = 0
       let truncated = false
       let stdoutBuffer = ''
       let resolved = false
+      let child: ChildProcessByStdio<null, Readable, Readable> | null = null
 
       const resolveOnce = (): void => {
         if (resolved) {
           return
         }
         resolved = true
+        if (activeTextSearches.get(searchKey) === child) {
+          activeTextSearches.delete(searchKey)
+        }
         clearTimeout(killTimeout)
         resolvePromise({
           files: Array.from(fileMap.values()),
@@ -250,7 +271,7 @@ export function registerFilesystemHandlers(store: Store): void {
             totalMatches++
             if (totalMatches >= maxResults) {
               truncated = true
-              child.kill()
+              child?.kill()
               break
             }
           }
@@ -259,10 +280,12 @@ export function registerFilesystemHandlers(store: Store): void {
         }
       }
 
-      const child = spawn('rg', rgArgs, { stdio: ['ignore', 'pipe', 'pipe'] })
+      const nextChild = spawn('rg', rgArgs, { stdio: ['ignore', 'pipe', 'pipe'] })
+      child = nextChild
+      activeTextSearches.set(searchKey, nextChild)
 
-      child.stdout.setEncoding('utf-8')
-      child.stdout.on('data', (chunk: string) => {
+      nextChild.stdout.setEncoding('utf-8')
+      nextChild.stdout.on('data', (chunk: string) => {
         stdoutBuffer += chunk
         const lines = stdoutBuffer.split('\n')
         stdoutBuffer = lines.pop() ?? ''
@@ -270,23 +293,22 @@ export function registerFilesystemHandlers(store: Store): void {
           processLine(line)
         }
       })
-      child.stderr.on('data', () => {
+      nextChild.stderr.on('data', () => {
         // Drain stderr so rg cannot block on a full pipe.
       })
 
-      child.once('error', () => {
+      nextChild.once('error', () => {
         resolveOnce()
       })
 
-      child.once('close', () => {
+      nextChild.once('close', () => {
         if (stdoutBuffer) {
           processLine(stdoutBuffer)
         }
         resolveOnce()
       })
 
-      // Kill after 30s if still running
-      const killTimeout = setTimeout(() => child.kill(), 30000)
+      const killTimeout = setTimeout(() => child?.kill(), SEARCH_TIMEOUT_MS)
     })
   })
 

--- a/src/renderer/src/components/right-sidebar/Search.tsx
+++ b/src/renderer/src/components/right-sidebar/Search.tsx
@@ -1,4 +1,5 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React, { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react'
+import { useVirtualizer } from '@tanstack/react-virtual'
 import {
   Search as SearchIcon,
   CaseSensitive,
@@ -13,7 +14,12 @@ import { useAppStore } from '@/store'
 import { detectLanguage } from '@/lib/language-detect'
 import { Button } from '@/components/ui/button'
 import type { SearchFileResult, SearchMatch } from '../../../../shared/types'
-import { ToggleButton, FileResultItem } from './SearchResultItems'
+import { buildSearchRows } from './search-rows'
+import { ToggleButton, FileResultRow, MatchResultRow } from './SearchResultItems'
+
+const SEARCH_DEBOUNCE_MS = 300
+const SEARCH_MAX_RESULTS = 2000
+const SEARCH_VIRTUAL_OVERSCAN = 12
 
 export default function Search(): React.JSX.Element {
   const activeWorktreeId = useAppStore((s) => s.activeWorktreeId)
@@ -46,6 +52,7 @@ export default function Search(): React.JSX.Element {
   const [showFilters, setShowFilters] = useState(false)
   const searchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const latestSearchIdRef = useRef(0)
+  const resultsScrollRef = useRef<HTMLDivElement>(null)
 
   const cancelPendingSearch = useCallback(() => {
     latestSearchIdRef.current += 1
@@ -89,6 +96,51 @@ export default function Search(): React.JSX.Element {
     }
   }, [worktreePath, cancelPendingSearch, setFileSearchResults])
 
+  // Why: large search result sets can update while the user is still typing.
+  // Deferring the heavy row-model update keeps the input responsive instead of
+  // blocking on a full sidebar rerender.
+  const deferredSearchResults = useDeferredValue(fileSearchResults)
+  const searchRows = useMemo(
+    () =>
+      buildSearchRows(
+        fileSearchQuery.trim() && worktreePath ? deferredSearchResults : null,
+        fileSearchCollapsedFiles
+      ),
+    [deferredSearchResults, fileSearchCollapsedFiles, fileSearchQuery, worktreePath]
+  )
+
+  const virtualizer = useVirtualizer({
+    count: searchRows.length,
+    getScrollElement: () => resultsScrollRef.current,
+    estimateSize: (index) => {
+      const row = searchRows[index]
+      if (!row) {
+        return 24
+      }
+      if (row.type === 'summary') {
+        return 24
+      }
+      if (row.type === 'file') {
+        return 26
+      }
+      return 22
+    },
+    overscan: SEARCH_VIRTUAL_OVERSCAN,
+    getItemKey: (index) => {
+      const row = searchRows[index]
+      if (!row) {
+        return `missing:${index}`
+      }
+      if (row.type === 'summary') {
+        return 'summary'
+      }
+      if (row.type === 'file') {
+        return `file:${row.fileResult.filePath}`
+      }
+      return `match:${row.fileResult.filePath}:${row.match.line}:${row.match.column}:${row.matchIndex}`
+    }
+  })
+
   // Execute search with debounce — reads fresh state inside setTimeout
   // to avoid stale closures when options change during debounce
   const executeSearch = useCallback(
@@ -120,7 +172,7 @@ export default function Search(): React.JSX.Element {
             useRegex: state.fileSearchUseRegex,
             includePattern: state.fileSearchIncludePattern || undefined,
             excludePattern: state.fileSearchExcludePattern || undefined,
-            maxResults: 10000
+            maxResults: SEARCH_MAX_RESULTS
           })
           if (latestSearchIdRef.current === searchId) {
             setFileSearchResults(results)
@@ -135,7 +187,7 @@ export default function Search(): React.JSX.Element {
             setFileSearchLoading(false)
           }
         }
-      }, 300)
+      }, SEARCH_DEBOUNCE_MS)
     },
     [worktreePath, setFileSearchResults, setFileSearchLoading]
   )
@@ -312,28 +364,55 @@ export default function Search(): React.JSX.Element {
       </div>
 
       {/* Results area */}
-      <div className="flex-1 min-h-0 overflow-y-auto scrollbar-sleek">
-        {fileSearchResults && (
-          <>
-            {/* Results summary */}
-            <div className="px-2 py-1 text-[10px] text-muted-foreground border-b border-border">
-              {fileSearchResults.totalMatches} result
-              {fileSearchResults.totalMatches !== 1 ? 's' : ''} in {fileSearchResults.files.length}{' '}
-              file{fileSearchResults.files.length !== 1 ? 's' : ''}
-              {fileSearchResults.truncated && ' (results truncated)'}
-            </div>
+      <div ref={resultsScrollRef} className="flex-1 min-h-0 overflow-y-auto scrollbar-sleek">
+        {searchRows.length > 0 && (
+          <div
+            className="relative w-full"
+            style={{
+              height: virtualizer.getTotalSize()
+            }}
+          >
+            {virtualizer.getVirtualItems().map((virtualRow) => {
+              const row = searchRows[virtualRow.index]
+              if (!row) {
+                return null
+              }
 
-            {/* File results */}
-            {fileSearchResults.files.map((fileResult) => (
-              <FileResultItem
-                key={fileResult.filePath}
-                fileResult={fileResult}
-                collapsed={fileSearchCollapsedFiles.has(fileResult.filePath)}
-                onToggleCollapse={() => toggleFileSearchCollapsedFile(fileResult.filePath)}
-                onMatchClick={(match) => handleMatchClick(fileResult, match)}
-              />
-            ))}
-          </>
+              return (
+                <div
+                  key={virtualRow.key}
+                  className="absolute left-0 top-0 w-full"
+                  style={{
+                    transform: `translateY(${virtualRow.start}px)`
+                  }}
+                >
+                  {row.type === 'summary' && (
+                    <div className="px-2 py-1 text-[10px] text-muted-foreground border-b border-border">
+                      {row.totalMatches} result{row.totalMatches !== 1 ? 's' : ''} in{' '}
+                      {row.fileCount} file{row.fileCount !== 1 ? 's' : ''}
+                      {row.truncated && ' (results truncated)'}
+                    </div>
+                  )}
+                  {row.type === 'file' && (
+                    <FileResultRow
+                      fileResult={row.fileResult}
+                      collapsed={row.collapsed}
+                      onToggleCollapse={() =>
+                        toggleFileSearchCollapsedFile(row.fileResult.filePath)
+                      }
+                    />
+                  )}
+                  {row.type === 'match' && (
+                    <MatchResultRow
+                      match={row.match}
+                      relativePath={row.fileResult.relativePath}
+                      onClick={() => handleMatchClick(row.fileResult, row.match)}
+                    />
+                  )}
+                </div>
+              )
+            })}
+          </div>
         )}
 
         {!fileSearchResults && fileSearchQuery && !fileSearchLoading && (

--- a/src/renderer/src/components/right-sidebar/SearchResultItems.tsx
+++ b/src/renderer/src/components/right-sidebar/SearchResultItems.tsx
@@ -43,16 +43,14 @@ export function ToggleButton({
 }
 
 // ─── File Result ──────────────────────────────────────────
-export function FileResultItem({
+export function FileResultRow({
   fileResult,
-  collapsed,
   onToggleCollapse,
-  onMatchClick
+  collapsed
 }: {
   fileResult: SearchFileResult
-  collapsed: boolean
   onToggleCollapse: () => void
-  onMatchClick: (match: SearchMatch) => void
+  collapsed: boolean
 }): React.JSX.Element {
   const fileName = basename(fileResult.relativePath)
   const parentDir = dirname(fileResult.relativePath)
@@ -95,23 +93,12 @@ export function FileResultItem({
           </ContextMenuItem>
         </ContextMenuContent>
       </ContextMenu>
-
-      {/* Matches */}
-      {!collapsed &&
-        fileResult.matches.map((match, i) => (
-          <MatchItem
-            key={`${match.line}:${match.column}:${i}`}
-            match={match}
-            relativePath={fileResult.relativePath}
-            onClick={() => onMatchClick(match)}
-          />
-        ))}
     </div>
   )
 }
 
 // ─── Match Item ───────────────────────────────────────────
-export function MatchItem({
+export function MatchResultRow({
   match,
   relativePath,
   onClick

--- a/src/renderer/src/components/right-sidebar/search-rows.test.ts
+++ b/src/renderer/src/components/right-sidebar/search-rows.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import { buildSearchRows } from './search-rows'
+
+describe('buildSearchRows', () => {
+  it('includes summary, file headers, and expanded matches in row order', () => {
+    const rows = buildSearchRows(
+      {
+        totalMatches: 3,
+        truncated: false,
+        files: [
+          {
+            filePath: '/repo/a.ts',
+            relativePath: 'a.ts',
+            matches: [
+              { line: 1, column: 1, matchLength: 3, lineContent: 'foo' },
+              { line: 2, column: 5, matchLength: 3, lineContent: 'bar foo' }
+            ]
+          },
+          {
+            filePath: '/repo/b.ts',
+            relativePath: 'nested/b.ts',
+            matches: [{ line: 8, column: 2, matchLength: 3, lineContent: ' foo' }]
+          }
+        ]
+      },
+      new Set<string>()
+    )
+
+    expect(rows.map((row) => row.type)).toEqual([
+      'summary',
+      'file',
+      'match',
+      'match',
+      'file',
+      'match'
+    ])
+  })
+
+  it('omits match rows for collapsed files', () => {
+    const rows = buildSearchRows(
+      {
+        totalMatches: 2,
+        truncated: true,
+        files: [
+          {
+            filePath: '/repo/a.ts',
+            relativePath: 'a.ts',
+            matches: [{ line: 1, column: 1, matchLength: 3, lineContent: 'foo' }]
+          },
+          {
+            filePath: '/repo/b.ts',
+            relativePath: 'b.ts',
+            matches: [{ line: 2, column: 1, matchLength: 3, lineContent: 'foo' }]
+          }
+        ]
+      },
+      new Set<string>(['/repo/a.ts'])
+    )
+
+    expect(rows.map((row) => row.type)).toEqual(['summary', 'file', 'file', 'match'])
+  })
+})

--- a/src/renderer/src/components/right-sidebar/search-rows.ts
+++ b/src/renderer/src/components/right-sidebar/search-rows.ts
@@ -1,0 +1,61 @@
+import type { SearchFileResult, SearchMatch, SearchResult } from '../../../../shared/types'
+
+export type SearchRow =
+  | {
+      type: 'summary'
+      totalMatches: number
+      fileCount: number
+      truncated: boolean
+    }
+  | {
+      type: 'file'
+      fileResult: SearchFileResult
+      collapsed: boolean
+    }
+  | {
+      type: 'match'
+      fileResult: SearchFileResult
+      match: SearchMatch
+      matchIndex: number
+    }
+
+export function buildSearchRows(
+  results: SearchResult | null,
+  collapsedFiles: ReadonlySet<string>
+): SearchRow[] {
+  if (!results) {
+    return []
+  }
+
+  const rows: SearchRow[] = [
+    {
+      type: 'summary',
+      totalMatches: results.totalMatches,
+      fileCount: results.files.length,
+      truncated: results.truncated
+    }
+  ]
+
+  for (const fileResult of results.files) {
+    const collapsed = collapsedFiles.has(fileResult.filePath)
+    rows.push({ type: 'file', fileResult, collapsed })
+
+    // Why: flattening the tree into rows lets the sidebar virtualize search
+    // output. Rendering every file header and every match at once is what made
+    // large ripgrep result sets freeze the renderer.
+    if (collapsed) {
+      continue
+    }
+
+    for (const [matchIndex, match] of fileResult.matches.entries()) {
+      rows.push({
+        type: 'match',
+        fileResult,
+        match,
+        matchIndex
+      })
+    }
+  }
+
+  return rows
+}


### PR DESCRIPTION
## Problem
The file search sidebar could freeze the app when searching large worktrees. Superseded ripgrep processes kept running, the main process kept parsing large result streams, and the renderer eagerly mounted the full nested result tree.

## Solution
Cancel superseded search jobs in the main process, cap search results more aggressively, and virtualize the sidebar row model so only visible search rows render. Added a focused row-flattening test for the virtualized search UI.