### PR TITLE
fix(ui): show initial file list in quick-open panel

### DIFF
--- a/src/renderer/src/components/QuickOpen.tsx
+++ b/src/renderer/src/components/QuickOpen.tsx
@@ -225,7 +225,7 @@ export default function QuickOpen(): React.JSX.Element | null {
         </div>
 
         {/* Results list — only rendered when there is content to avoid empty padding */}
-        {(loading || query.trim()) && (
+        {(loading || query.trim() || filtered.length > 0) && (
           <div ref={listRef} className="max-h-[300px] overflow-y-auto scrollbar-sleek pb-1">
             {loading && (
               <div className="px-3 py-6 text-center text-xs text-muted-foreground">


### PR DESCRIPTION
## Summary
- Fixed a regression from #211 where the quick-open (Cmd+P) results container was hidden when no query was typed, preventing the default 50-file list from showing
- The conditional guard `(loading || query.trim())` was missing `filtered.length > 0`

## Test plan
- [ ] Press Cmd+P — initial file list (up to 50 files) should appear immediately
- [ ] Type a query — filtered results should show
- [ ] Clear the query — initial file list should reappear
- [ ] When no worktree is active, no empty padding below the input