### PR TITLE
fix: quick-open file search returns no results

### DIFF
--- a/src/main/ipc/filesystem-list-files.ts
+++ b/src/main/ipc/filesystem-list-files.ts
@@ -39,27 +39,12 @@ export async function listQuickOpenFiles(rootPath: string, store: Store): Promis
       'rg',
       [
         '--files',
-        '--hidden',
-        '--glob',
-        '!.git',
-        '--glob',
-        '!.git/**',
+        // Why: --hidden + positive re-inclusion globs (e.g. '.github') made
+        // ripgrep treat them as a whitelist, filtering out every non-dotfile.
+        // Without --hidden, rg skips dot-dirs by default and respects
+        // .gitignore, so normal files like CLAUDE.md are returned correctly.
         '--glob',
         '!**/node_modules',
-        '--glob',
-        '!**/node_modules/**',
-        '--glob',
-        '!.*',
-        '--glob',
-        '!.*/*',
-        '--glob',
-        '!**/.*',
-        '--glob',
-        '!**/.*/**',
-        '--glob',
-        '.github',
-        '--glob',
-        '.github/**',
         authorizedRootPath
       ],
       {


### PR DESCRIPTION
## Summary
- Fixed Cmd+P quick-open showing "No matching files" for all queries
- Root cause: ripgrep positive re-inclusion globs (`.github`, `.github/**`) acted as a whitelist, filtering out every non-dotfile
- Fix: drop `--hidden` flag so rg uses default behavior (skip hidden dirs, respect .gitignore, return all normal files)

## Test plan
- [ ] Press Cmd+P, type "claude.md" — CLAUDE.md should appear in results
- [ ] Press Cmd+P with no query — initial file list should show ~50 files
- [ ] Verify node_modules files are still excluded