### PR TITLE
fix(ui): prevent sidebar reordering on click

### DIFF
--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -174,8 +174,12 @@ export function registerWorktreeHandlers(mainWindow: BrowserWindow, store: Store
     'worktrees:updateMeta',
     (_event, args: { worktreeId: string; updates: Partial<WorktreeMeta> }) => {
       const meta = store.setWorktreeMeta(args.worktreeId, args.updates)
-      const { repoId } = parseWorktreeId(args.worktreeId)
-      notifyWorktreesChanged(mainWindow, repoId)
+      // Do NOT call notifyWorktreesChanged here. The renderer applies meta
+      // updates optimistically before calling this IPC, so a notification
+      // would trigger a redundant fetchWorktrees round-trip that bumps
+      // sortEpoch and reorders the sidebar — the exact bug PR #209 tried
+      // to fix (clicking a card would clear isUnread → updateMeta →
+      // worktrees:changed → fetchWorktrees → sortEpoch++ → re-sort).
       return meta
     }
   )

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -151,6 +151,7 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
   updateTabTitle: (tabId, title) => {
     set((s) => {
       let changed = false
+      let ownerWorktreeId: string | null = null
       const next = { ...s.tabsByWorktree }
       for (const wId of Object.keys(next)) {
         next[wId] = next[wId].map((t) => {
@@ -158,12 +159,24 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
             return t
           }
           changed = true
+          ownerWorktreeId = wId
           return { ...t, title }
         })
       }
+      if (!changed) {
+        return s
+      }
       // Agent status is derived from terminal titles and affects sort scoring,
-      // so a title change is a meaningful event that should allow re-sort.
-      return changed ? { tabsByWorktree: next, sortEpoch: s.sortEpoch + 1 } : s
+      // so a title change is a meaningful event that should allow re-sort —
+      // but only for background worktrees. Title changes in the active
+      // worktree are side-effects of PTY reconnection during worktree
+      // activation (generation bump → TerminalPane remount → new shell →
+      // title update). Bumping sortEpoch here would reorder the sidebar
+      // on click — the exact bug PR #209 intended to fix.
+      const isActive = ownerWorktreeId === s.activeWorktreeId
+      return isActive
+        ? { tabsByWorktree: next }
+        : { tabsByWorktree: next, sortEpoch: s.sortEpoch + 1 }
     })
   },
 

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -194,11 +194,21 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       if (!worktree) {
         return {}
       }
+      // Skip sortEpoch bump for the active worktree. Terminal events
+      // (PTY spawn, PTY exit) in the active worktree are side-effects of
+      // the user clicking the card or interacting with the terminal —
+      // re-sorting the sidebar in response would cause the exact reorder-
+      // on-click bug PR #209 intended to fix (e.g. dead-PTY reconnection
+      // after generation bump triggers updateTabPtyId → here).
+      // The lastActivityAt timestamp is still persisted so that the NEXT
+      // meaningful sortEpoch bump (from a background worktree event) will
+      // include this worktree's updated score.
+      const isActive = s.activeWorktreeId === worktreeId
       return {
         worktreesByRepo: applyWorktreeUpdates(s.worktreesByRepo, worktreeId, {
           lastActivityAt: now
         }),
-        sortEpoch: s.sortEpoch + 1
+        ...(isActive ? {} : { sortEpoch: s.sortEpoch + 1 })
       }
     })
 


### PR DESCRIPTION
## Summary
- Stop incrementing `sortEpoch` for events triggered by the **active** worktree (meta updates, terminal title changes, PTY activity) since these are side-effects of clicking a card or interacting with the terminal, not meaningful background activity
- Remove redundant `notifyWorktreesChanged` call from the `worktrees:updateMeta` IPC handler — renderer already applies meta updates optimistically
- Fixes the root cause of the sidebar reorder-on-click bug that PR #209 partially addressed

## Test plan
- [ ] Click a sidebar card → verify it does not jump/reorder
- [ ] Verify background worktree activity (e.g. agent completing a task) still re-sorts the sidebar correctly
- [ ] Verify marking a worktree as read (clearing `isUnread`) does not trigger a re-sort
- [ ] Verify terminal title changes in the active worktree do not cause reordering