### PR TITLE
fix(updater): show feedback when check-for-update hits a mid-release draft

### DIFF
--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -130,6 +130,16 @@ async function sendCheckFailureStatus(message: string, userInitiated?: boolean):
             String((fallbackError as Error)?.message ?? fallbackError)
           )
         }
+
+        // The fallback confirmed there is no published version newer than the
+        // current one (the only "newer" entry is a draft mid-release).  Tell
+        // the user they're up-to-date so clicking "Check for Updates" doesn't
+        // appear to silently do nothing.
+        if (userInitiated) {
+          clearAvailableUpdateContext()
+          sendStatus({ state: 'not-available', userInitiated: true })
+          return
+        }
       }
 
       console.warn('[updater] benign check failure:', message)


### PR DESCRIPTION
## Summary
- During a mid-release (draft version on GitHub), clicking "Check for Updates" would silently return to idle — appearing to do nothing
- Now shows "You're on the latest version" toast when the fallback confirms no published update is newer than the current version
- Only applies to transition failures (mid-release drafts), not network errors like `net::ERR_FAILED`

## Test plan
- [ ] Simulate a mid-release draft scenario and click "Check for Updates" — should show "You're on the latest version" toast
- [ ] Verify automatic background checks still silently go to idle (no toast)
- [ ] Verify network errors still behave as before (silent for auto, error toast for manual)