### PR TITLE
fix: restore list markers in markdown preview

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -526,6 +526,25 @@
   padding-left: 1.5em;
 }
 
+/* Restore list markers inside markdown preview because the app-wide reset removes
+   them for navigation UI. Markdown content needs native list semantics to match
+   source documents, so this override should stay scoped to the preview surface. */
+.markdown-body ul {
+  list-style: disc;
+}
+
+.markdown-body ol {
+  list-style: decimal;
+}
+
+.markdown-body ul ul {
+  list-style: circle;
+}
+
+.markdown-body ul ul ul {
+  list-style: square;
+}
+
 .markdown-body li {
   margin: 0.25em 0;
 }


### PR DESCRIPTION
## Summary
- The app-wide CSS reset strips `list-style` from all elements, removing bullet points and numbers from markdown preview content
- Adds scoped `.markdown-body` overrides to restore native list markers (disc → circle → square for `ul`, decimal for `ol`)

## Test plan
- [ ] Open a markdown file with nested unordered and ordered lists
- [ ] Verify bullet markers (disc, circle, square) appear at each nesting level
- [ ] Verify ordered lists show decimal numbers
- [ ] Confirm no visual regressions in sidebar or other non-markdown list UI