### PR TITLE
fix: display image files in editor instead of binary placeholder

### DIFF
--- a/src/main/git/status.ts
+++ b/src/main/git/status.ts
@@ -307,7 +307,13 @@ export async function getDiff(
     // Fallback
   }
 
-  return buildDiffResult(originalContent, modifiedContent, originalIsBinary, modifiedIsBinary)
+  return buildDiffResult(
+    originalContent,
+    modifiedContent,
+    originalIsBinary,
+    modifiedIsBinary,
+    filePath
+  )
 }
 
 export async function getBranchCompare(
@@ -390,7 +396,8 @@ export async function getBranchDiff(
       leftBlob.content,
       rightBlob.content,
       leftBlob.isBinary,
-      rightBlob.isBinary
+      rightBlob.isBinary,
+      args.filePath
     )
   } catch {
     return {
@@ -523,7 +530,7 @@ async function readGitBlobAtIndexPath(
       maxBuffer: MAX_GIT_SHOW_BYTES
     })) as { stdout: Buffer }
 
-    return { ...bufferToBlob(stdout), exists: true }
+    return { ...bufferToBlob(stdout, filePath), exists: true }
   } catch {
     return { content: '', isBinary: false, exists: false }
   }
@@ -541,7 +548,7 @@ async function readGitBlobAtOidPath(
       maxBuffer: MAX_GIT_SHOW_BYTES
     })) as { stdout: Buffer }
 
-    return { ...bufferToBlob(stdout), exists: true }
+    return { ...bufferToBlob(stdout, filePath), exists: true }
   } catch {
     return { content: '', isBinary: false, exists: false }
   }
@@ -550,16 +557,18 @@ async function readGitBlobAtOidPath(
 async function readWorkingTreeFile(filePath: string): Promise<GitBlobReadResult> {
   try {
     const buffer = await readFile(filePath)
-    return bufferToBlob(buffer)
+    return bufferToBlob(buffer, filePath)
   } catch {
     return { content: '', isBinary: false, exists: false }
   }
 }
 
-function bufferToBlob(buffer: Buffer): GitBlobReadResult {
+function bufferToBlob(buffer: Buffer, filePath?: string): GitBlobReadResult {
   const isBinary = isBinaryBuffer(buffer)
+  // Return base64 for recognized image formats so the renderer can display them
+  const isImage = filePath ? !!IMAGE_MIME_TYPES[path.extname(filePath).toLowerCase()] : false
   return {
-    content: isBinary ? '' : buffer.toString('utf-8'),
+    content: isBinary ? (isImage ? buffer.toString('base64') : '') : buffer.toString('utf-8'),
     isBinary,
     exists: true
   }
@@ -579,15 +588,20 @@ function buildDiffResult(
   originalContent: string,
   modifiedContent: string,
   originalIsBinary: boolean,
-  modifiedIsBinary: boolean
+  modifiedIsBinary: boolean,
+  filePath?: string
 ): GitDiffResult {
   if (originalIsBinary || modifiedIsBinary) {
+    const mimeType = filePath ? IMAGE_MIME_TYPES[path.extname(filePath).toLowerCase()] : undefined
     return {
       kind: 'binary',
       originalContent,
       modifiedContent,
       originalIsBinary,
-      modifiedIsBinary
+      modifiedIsBinary,
+      // Include image metadata so the renderer can show image diffs instead of
+      // a generic "binary file changed" message.
+      ...(mimeType ? { isImage: true, mimeType } : {})
     } as GitDiffResult
   }
 
@@ -604,6 +618,17 @@ type GitBlobReadResult = {
   content: string
   isBinary: boolean
   exists: boolean
+}
+
+const IMAGE_MIME_TYPES: Record<string, string> = {
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.svg': 'image/svg+xml',
+  '.webp': 'image/webp',
+  '.bmp': 'image/bmp',
+  '.ico': 'image/x-icon'
 }
 
 /**

--- a/src/renderer/src/components/editor/DiffSectionItem.tsx
+++ b/src/renderer/src/components/editor/DiffSectionItem.tsx
@@ -1,4 +1,4 @@
-import React, { type MutableRefObject } from 'react'
+import React, { lazy, type MutableRefObject } from 'react'
 import { LazySection } from './LazySection'
 import { ChevronDown, ChevronRight } from 'lucide-react'
 import { DiffEditor, type DiffOnMount } from '@monaco-editor/react'
@@ -7,6 +7,8 @@ import { basename, dirname } from '@/lib/path'
 import { detectLanguage } from '@/lib/language-detect'
 import { cn } from '@/lib/utils'
 import type { GitDiffResult } from '../../../../shared/types'
+
+const ImageDiffViewer = lazy(() => import('./ImageDiffViewer'))
 
 type DiffSection = {
   key: string
@@ -143,16 +145,26 @@ export function DiffSectionItem({
               Loading...
             </div>
           ) : section.diffResult?.kind === 'binary' ? (
-            <div className="flex h-full items-center justify-center px-6 text-center">
-              <div className="space-y-2">
-                <div className="text-sm font-medium text-foreground">Binary file changed</div>
-                <div className="text-xs text-muted-foreground">
-                  {isBranchMode
-                    ? 'Text diff is unavailable for this file in branch compare.'
-                    : 'Text diff is unavailable for this file.'}
+            section.diffResult.isImage ? (
+              <ImageDiffViewer
+                originalContent={section.diffResult.originalContent}
+                modifiedContent={section.diffResult.modifiedContent}
+                filePath={section.path}
+                mimeType={section.diffResult.mimeType}
+                sideBySide={sideBySide}
+              />
+            ) : (
+              <div className="flex h-full items-center justify-center px-6 text-center">
+                <div className="space-y-2">
+                  <div className="text-sm font-medium text-foreground">Binary file changed</div>
+                  <div className="text-xs text-muted-foreground">
+                    {isBranchMode
+                      ? 'Text diff is unavailable for this file in branch compare.'
+                      : 'Text diff is unavailable for this file.'}
+                  </div>
                 </div>
               </div>
-            </div>
+            )
           ) : (
             <DiffEditor
               height="100%"

--- a/src/renderer/src/components/editor/EditorContent.tsx
+++ b/src/renderer/src/components/editor/EditorContent.tsx
@@ -9,10 +9,14 @@ const MonacoEditor = lazy(() => import('./MonacoEditor'))
 const DiffViewer = lazy(() => import('./DiffViewer'))
 const CombinedDiffViewer = lazy(() => import('./CombinedDiffViewer'))
 const MarkdownPreview = lazy(() => import('./MarkdownPreview'))
+const ImageViewer = lazy(() => import('./ImageViewer'))
+const ImageDiffViewer = lazy(() => import('./ImageDiffViewer'))
 
 type FileContent = {
   content: string
   isBinary: boolean
+  isImage?: boolean
+  mimeType?: string
 }
 
 type MarkdownViewMode = 'source' | 'preview'
@@ -128,6 +132,11 @@ export function EditorContent({
       )
     }
     if (fc.isBinary) {
+      if (fc.isImage) {
+        return (
+          <ImageViewer content={fc.content} filePath={activeFile.filePath} mimeType={fc.mimeType} />
+        )
+      }
       return (
         <div className="flex items-center justify-center h-full text-muted-foreground text-sm">
           Binary file — cannot display
@@ -155,6 +164,17 @@ export function EditorContent({
   }
   const isEditable = activeFile.diffSource === 'unstaged'
   if (dc.kind === 'binary') {
+    if (dc.isImage) {
+      return (
+        <ImageDiffViewer
+          originalContent={dc.originalContent}
+          modifiedContent={dc.modifiedContent}
+          filePath={activeFile.relativePath}
+          mimeType={dc.mimeType}
+          sideBySide={sideBySide}
+        />
+      )
+    }
     return (
       <div className="flex h-full items-center justify-center px-6 text-center">
         <div className="space-y-2">

--- a/src/renderer/src/components/editor/EditorPanel.tsx
+++ b/src/renderer/src/components/editor/EditorPanel.tsx
@@ -12,6 +12,8 @@ import type { GitDiffResult } from '../../../../shared/types'
 type FileContent = {
   content: string
   isBinary: boolean
+  isImage?: boolean
+  mimeType?: string
 }
 
 type DiffContent = GitDiffResult

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -296,6 +296,10 @@ export type GitDiffBinaryResult = {
   kind: 'binary'
   originalContent: string
   modifiedContent: string
+  /** True when both sides are a recognized image format (PNG, JPG, etc.) */
+  isImage?: boolean
+  /** MIME type for image rendering, e.g. "image/png" */
+  mimeType?: string
 } & (
   | { originalIsBinary: true; modifiedIsBinary: boolean }
   | { originalIsBinary: boolean; modifiedIsBinary: true }


### PR DESCRIPTION
## Summary
- Wire up existing `ImageViewer` and `ImageDiffViewer` components so image files (PNG, JPG, GIF, SVG, WebP, BMP, ICO) render visually instead of showing "Binary file — cannot display"
- Backend: `bufferToBlob()` now returns base64-encoded content for recognized image formats; `buildDiffResult()` attaches `isImage`/`mimeType` metadata to binary diff results
- Frontend: `EditorContent`, `EditorPanel`, and `DiffSectionItem` route image binaries to the image viewer components in both edit and diff modes

## Test plan
- [ ] Open a PNG/JPG file in the editor — should render the image instead of "Binary file — cannot display"
- [ ] Stage a changed image file — diff view should show side-by-side image comparison via `ImageDiffViewer`
- [ ] Open a non-image binary file — should still show the existing "Binary file changed" message
- [ ] Branch compare with image changes — combined diff view should render image diffs
- [ ] Verify no regressions on text file editing and diffing