### PR TITLE
fix(ci): remove explicit pnpm version to use packageManager field

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,7 +24,6 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: latest
           run_install: false
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,6 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: latest
           run_install: false
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- Remove `version: latest` from pnpm/action-setup in both PR and release workflows
- The action now reads the pnpm version from `package.json`'s `packageManager` field automatically
- Fixes CI failure: `Multiple versions of pnpm specified`

## Test plan
- [ ] PR checks pass on this PR itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)