### PR TITLE
fix: show correct keyboard shortcuts on Windows in terminal context menu

### DIFF
--- a/src/renderer/src/components/terminal-pane/TerminalContextMenu.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalContextMenu.tsx
@@ -107,19 +107,13 @@ export default function TerminalContextMenu({
         <DropdownMenuItem onSelect={onSplitDown}>
           <PanelBottomOpen />
           Split Down
-          <DropdownMenuShortcut>
-            {mod}
-            {shift}D
-          </DropdownMenuShortcut>
+          <DropdownMenuShortcut>{`${mod}${shift}D`}</DropdownMenuShortcut>
         </DropdownMenuItem>
         {canExpandPane && (
           <DropdownMenuItem onSelect={onToggleExpand}>
             {menuPaneIsExpanded ? <Minimize2 /> : <Maximize2 />}
             {menuPaneIsExpanded ? 'Collapse Pane' : 'Expand Pane'}
-            <DropdownMenuShortcut>
-              {mod}
-              {shift}↩
-            </DropdownMenuShortcut>
+            <DropdownMenuShortcut>{`${mod}${shift}↩`}</DropdownMenuShortcut>
           </DropdownMenuItem>
         )}
         {canClosePane && (


### PR DESCRIPTION
## Problem

The terminal right-click context menu shows macOS shortcuts (`⌘C`, `⌘V`, `⌘D`, etc.) on all platforms, including Windows and Linux where the correct modifier is `Ctrl`.

## Solution

Detect the platform using `navigator.userAgent` and render the appropriate modifier symbol. On macOS the menu still shows `⌘`; on Windows/Linux it shows `Ctrl+`.

This follows the same pattern already used in `ShortcutsPane.tsx` and `WorktreeMetaDialog.tsx`.

## Changes

- `TerminalContextMenu.tsx`: added `isMac` / `mod` / `shift` locals, replaced five hardcoded shortcut strings with the dynamic values

Fixes #230