### PR TITLE
feat: add isMainWorktree field to GitWorktreeInfo

### DIFF
--- a/src/main/git/worktree.test.ts
+++ b/src/main/git/worktree.test.ts
@@ -22,19 +22,22 @@ bare
         path: '/repo',
         head: 'abc123',
         branch: 'refs/heads/main',
-        isBare: false
+        isBare: false,
+        isMainWorktree: true
       },
       {
         path: '/repo-feature',
         head: 'def456',
         branch: 'refs/heads/feature/test',
-        isBare: false
+        isBare: false,
+        isMainWorktree: false
       },
       {
         path: '/repo-bare',
         head: '0000000',
         branch: '',
-        isBare: true
+        isBare: true,
+        isMainWorktree: false
       }
     ])
   })
@@ -57,7 +60,8 @@ branch refs/heads/main
         path: '/single-repo',
         head: 'aaa111',
         branch: 'refs/heads/main',
-        isBare: false
+        isBare: false,
+        isMainWorktree: true
       }
     ])
   })
@@ -72,7 +76,8 @@ detached
         path: '/repo-detached',
         head: 'abc123',
         branch: '',
-        isBare: false
+        isBare: false,
+        isMainWorktree: true
       }
     ])
   })
@@ -92,13 +97,15 @@ branch refs/heads/dev
         path: '/repo-a',
         head: 'aaa111',
         branch: 'refs/heads/main',
-        isBare: false
+        isBare: false,
+        isMainWorktree: true
       },
       {
         path: '/repo-b',
         head: 'bbb222',
         branch: 'refs/heads/dev',
-        isBare: false
+        isBare: false,
+        isMainWorktree: false
       }
     ])
   })
@@ -112,7 +119,8 @@ branch refs/heads/main
         path: '/repo-no-head',
         head: '',
         branch: 'refs/heads/main',
-        isBare: false
+        isBare: false,
+        isMainWorktree: true
       }
     ])
   })
@@ -127,7 +135,8 @@ branch refs/heads/main
         path: '/path/to/my worktree',
         head: 'ccc333',
         branch: 'refs/heads/main',
-        isBare: false
+        isBare: false,
+        isMainWorktree: true
       }
     ])
   })
@@ -150,19 +159,22 @@ bare
         path: '/bare-one',
         head: '0000000',
         branch: '',
-        isBare: true
+        isBare: true,
+        isMainWorktree: true
       },
       {
         path: '/regular',
         head: 'abc123',
         branch: 'refs/heads/main',
-        isBare: false
+        isBare: false,
+        isMainWorktree: false
       },
       {
         path: '/bare-two',
         head: '1111111',
         branch: '',
-        isBare: true
+        isBare: true,
+        isMainWorktree: false
       }
     ])
   })

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -38,7 +38,8 @@ export function parseWorktreeList(output: string): GitWorktreeInfo[] {
     }
 
     if (path) {
-      worktrees.push({ path, head, branch, isBare })
+      // `git worktree list` always emits the main working tree first.
+      worktrees.push({ path, head, branch, isBare, isMainWorktree: worktrees.length === 0 })
     }
   }
 

--- a/src/main/ipc/filesystem.test.ts
+++ b/src/main/ipc/filesystem.test.ts
@@ -112,7 +112,13 @@ describe('registerFilesystemHandlers', () => {
 
     realpathMock.mockImplementation(async (targetPath: string) => targetPath)
     listWorktreesMock.mockResolvedValue([
-      { path: '/workspace/repo-feature', head: 'abc', branch: '', isBare: false }
+      {
+        path: '/workspace/repo-feature',
+        head: 'abc',
+        branch: '',
+        isBare: false,
+        isMainWorktree: false
+      }
     ])
     trashItemMock.mockResolvedValue(undefined)
     statMock.mockResolvedValue({ size: 10, isDirectory: () => false, mtimeMs: 123 })

--- a/src/main/ipc/worktree-logic.test.ts
+++ b/src/main/ipc/worktree-logic.test.ts
@@ -139,7 +139,8 @@ describe('mergeWorktree', () => {
     path: '/workspaces/feature',
     head: 'abc123',
     branch: 'refs/heads/feature-x',
-    isBare: false
+    isBare: false,
+    isMainWorktree: false
   }
 
   it('merges with full metadata', () => {
@@ -161,6 +162,7 @@ describe('mergeWorktree', () => {
       head: 'abc123',
       branch: 'refs/heads/feature-x',
       isBare: false,
+      isMainWorktree: false,
       displayName: 'My Feature',
       comment: 'WIP',
       linkedIssue: 42,
@@ -194,7 +196,8 @@ describe('mergeWorktree', () => {
       path: '/workspaces/bare-repo',
       head: '000000',
       branch: '',
-      isBare: true
+      isBare: true,
+      isMainWorktree: false
     }
     const result = mergeWorktree('repo1', bareGit, undefined)
     expect(result.displayName).toBe('bare-repo')

--- a/src/main/ipc/worktree-logic.ts
+++ b/src/main/ipc/worktree-logic.ts
@@ -1,5 +1,5 @@
 import { basename, join, resolve, relative, isAbsolute } from 'path'
-import type { Worktree, WorktreeMeta } from '../../shared/types'
+import type { GitWorktreeInfo, Worktree, WorktreeMeta } from '../../shared/types'
 
 /**
  * Sanitize a worktree name for use in branch names and directory paths.
@@ -87,7 +87,7 @@ export function shouldSetDisplayName(
  */
 export function mergeWorktree(
   repoId: string,
-  git: { path: string; head: string; branch: string; isBare: boolean },
+  git: GitWorktreeInfo,
   meta: WorktreeMeta | undefined
 ): Worktree {
   const branchShort = git.branch.replace(/^refs\/heads\//, '')
@@ -98,6 +98,7 @@ export function mergeWorktree(
     head: git.head,
     branch: git.branch,
     isBare: git.isBare,
+    isMainWorktree: git.isMainWorktree,
     displayName: meta?.displayName || branchShort || basename(git.path),
     comment: meta?.comment || '',
     linkedIssue: meta?.linkedIssue ?? null,

--- a/src/renderer/src/components/sidebar/smart-sort.test.ts
+++ b/src/renderer/src/components/sidebar/smart-sort.test.ts
@@ -25,6 +25,7 @@ function makeWorktree(overrides: Partial<Worktree> = {}): Worktree {
     branch: overrides.branch ?? `refs/heads/${overrides.id ?? 'wt-1'}`,
     head: overrides.head ?? 'abc123',
     isBare: overrides.isBare ?? false,
+    isMainWorktree: overrides.isMainWorktree ?? false,
     linkedIssue: overrides.linkedIssue ?? null,
     linkedPR: overrides.linkedPR ?? null,
     isArchived: overrides.isArchived ?? false,

--- a/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
@@ -17,6 +17,7 @@ const worktree: Worktree = {
   branch: 'refs/heads/feature/super-critical',
   head: 'abc123',
   isBare: false,
+  isMainWorktree: false,
   linkedIssue: null,
   linkedPR: null,
   isArchived: false,

--- a/src/renderer/src/store/slices/store-cascades.test.ts
+++ b/src/renderer/src/store/slices/store-cascades.test.ts
@@ -75,6 +75,7 @@ function makeWorktree(overrides: Partial<Worktree> & { id: string; repoId: strin
     head: 'abc123',
     branch: 'refs/heads/feature',
     isBare: false,
+    isMainWorktree: false,
     displayName: 'feature',
     comment: '',
     linkedIssue: null,

--- a/src/renderer/src/store/slices/store-session-cascades.test.ts
+++ b/src/renderer/src/store/slices/store-session-cascades.test.ts
@@ -74,6 +74,7 @@ function makeWorktree(overrides: Partial<Worktree> & { id: string; repoId: strin
     head: 'abc123',
     branch: 'refs/heads/feature',
     isBare: false,
+    isMainWorktree: false,
     displayName: 'feature',
     comment: '',
     linkedIssue: null,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -16,6 +16,9 @@ export type GitWorktreeInfo = {
   head: string
   branch: string
   isBare: boolean
+  /** True for the repo's main working tree (the first entry from `git worktree list`).
+   *  Linked worktrees created via `git worktree add` have this set to false. */
+  isMainWorktree: boolean
 }
 
 // ─── Worktree (app-level, enriched) ──────────────────────────────────


### PR DESCRIPTION
## Summary
- Add `isMainWorktree` boolean to `GitWorktreeInfo` type to distinguish the repo's main working tree from linked worktrees
- Set the field in `parseWorktreeList` using the git guarantee that the main worktree is always the first entry
- Update `mergeWorktree` to accept `GitWorktreeInfo` directly and pass through the new field
- Update all test fixtures across 7 test files with correct `isMainWorktree` values

## Test plan
- [x] All 287 existing tests pass
- [x] No new TypeScript type errors introduced
- [x] Verified all consumers of `GitWorktreeInfo` and `Worktree` include the new field