### PR TITLE
feat: allow search for hidden files in quick-open

### DIFF
--- a/src/main/ipc/filesystem-list-files.test.ts
+++ b/src/main/ipc/filesystem-list-files.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+const { spawnMock, resolveAuthorizedPathMock } = vi.hoisted(() => ({
+  spawnMock: vi.fn(),
+  resolveAuthorizedPathMock: vi.fn()
+}))
+
+vi.mock('child_process', () => ({
+  spawn: spawnMock
+}))
+
+vi.mock('./filesystem-auth', () => ({
+  resolveAuthorizedPath: resolveAuthorizedPathMock
+}))
+
+import { listQuickOpenFiles } from './filesystem-list-files'
+import { EventEmitter } from 'events'
+import type { Store } from '../persistence'
+import type { ChildProcess } from 'child_process'
+
+function createMockProcess(): ChildProcess {
+  const p = new EventEmitter() as unknown as ChildProcess
+  ;(p as unknown as Record<string, unknown>).stdout = new EventEmitter()
+  ;(
+    (p as unknown as Record<string, unknown>).stdout as EventEmitter & {
+      setEncoding: () => void
+    }
+  ).setEncoding = vi.fn()
+  ;(p as unknown as Record<string, unknown>).stderr = new EventEmitter()
+  ;(p as unknown as Record<string, unknown>).kill = vi.fn()
+
+  return p
+}
+
+describe('filesystem-list-files', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resolveAuthorizedPathMock.mockImplementation(async (path) => path)
+  })
+
+  it('merges normal files and env files and filters correctly', async () => {
+    const p1 = createMockProcess()
+    const p2 = createMockProcess()
+
+    spawnMock.mockImplementation((_cmd, args: string[]) => {
+      if (args.includes('**/.env*')) {
+        return p2
+      }
+      return p1
+    })
+
+    const storeMock = {} as unknown as Store
+    const promise = listQuickOpenFiles('/mock/root', storeMock)
+
+    // Simulate stdout output for normal files
+    setTimeout(() => {
+      ;(p1.stdout as unknown as EventEmitter).emit('data', '/mock/root/file1.ts\n')
+      ;(p1.stdout as unknown as EventEmitter).emit('data', '/mock/root/node_modules/bad.js\n')
+      ;(p1.stdout as unknown as EventEmitter).emit('data', '/mock/root/.git/config\n')
+      ;(p1.stdout as unknown as EventEmitter).emit('data', '/mock/root/.github/workflows/ci.yml\n')
+      ;(p1.stdout as unknown as EventEmitter).emit('data', '/mock/root/dir1/') // incomplete line
+      ;(p1.stdout as unknown as EventEmitter).emit('data', 'file2.js\n')
+      p1.emit('close')
+
+      // Simulate stdout output for env files
+      ;(p2.stdout as unknown as EventEmitter).emit('data', '/mock/root/.env.local\n')
+      ;(p2.stdout as unknown as EventEmitter).emit('data', '/mock/root/file1.ts\n') // Duplicate
+      p2.emit('close')
+    }, 10)
+
+    const result = await promise
+
+    expect(result).toEqual(['file1.ts', '.github/workflows/ci.yml', 'dir1/file2.js', '.env.local'])
+  })
+
+  it('filters out .next, .cache, .stably, .vscode, .idea', async () => {
+    const p1 = createMockProcess()
+    const p2 = createMockProcess()
+
+    spawnMock.mockImplementation((_cmd, args: string[]) => {
+      if (args.includes('**/.env*')) {
+        return p2
+      }
+      return p1
+    })
+
+    const storeMock = {} as unknown as Store
+    const promise = listQuickOpenFiles('/mock/root', storeMock)
+
+    setTimeout(() => {
+      ;(p1.stdout as unknown as EventEmitter).emit('data', '/mock/root/.next/cache/1.js\n')
+      ;(p1.stdout as unknown as EventEmitter).emit('data', '/mock/root/.cache/data.json\n')
+      ;(p1.stdout as unknown as EventEmitter).emit('data', '/mock/root/.stably/config.json\n')
+      ;(p1.stdout as unknown as EventEmitter).emit('data', '/mock/root/.vscode/settings.json\n')
+      ;(p1.stdout as unknown as EventEmitter).emit('data', '/mock/root/.idea/workspace.xml\n')
+      ;(p1.stdout as unknown as EventEmitter).emit('data', '/mock/root/valid.ts\n')
+      p1.emit('close')
+
+      // Empty env result
+      p2.emit('close')
+    }, 10)
+
+    const result = await promise
+
+    expect(result).toEqual(['valid.ts'])
+  })
+})

--- a/src/main/ipc/filesystem-list-files.ts
+++ b/src/main/ipc/filesystem-list-files.ts
@@ -1,89 +1,170 @@
 import { spawn } from 'child_process'
-import { relative } from 'path'
+import { relative, sep } from 'path'
 import type { Store } from '../persistence'
 import { resolveAuthorizedPath } from './filesystem-auth'
 
-function normalizeRelativePath(path: string): string {
-  return path.replace(/[\\/]+/g, '/').replace(/^\/+/, '')
-}
+// Why: We use --hidden to surface dotfiles users commonly edit (e.g. .env,
+// .github workflows, .eslintrc) but must still exclude non-editable hidden
+// directories that would clutter quick-open results. A blocklist is used
+// instead of an allowlist so that novel dotfiles (e.g. .dockerignore) are
+// discoverable by default. Keep this list limited to tool-generated dirs
+// that are never hand-edited.
+const HIDDEN_DIR_BLOCKLIST = new Set([
+  '.git',
+  '.next',
+  '.nuxt',
+  '.cache',
+  '.stably',
+  '.vscode',
+  '.idea',
+  '.yarn',
+  '.pnpm-store',
+  '.terraform',
+  '.docker',
+  '.husky'
+])
 
+// Why: Avoids allocating a segments array per path. Walks the string to
+// extract each '/'-delimited segment and checks it against the blocklist.
 function shouldIncludeQuickOpenPath(path: string): boolean {
-  const normalizedPath = normalizeRelativePath(path)
-  const segments = normalizedPath.split('/')
-  return segments.every((segment, index) => {
-    if (segment === 'node_modules') {
+  let start = 0
+  const len = path.length
+  while (start < len) {
+    let end = path.indexOf('/', start)
+    if (end === -1) {
+      end = len
+    }
+    const segment = path.substring(start, end)
+    if (segment === 'node_modules' || HIDDEN_DIR_BLOCKLIST.has(segment)) {
       return false
     }
-    if (segment.startsWith('.') && !(index === 0 && segment === '.github')) {
-      return false
-    }
-    return true
-  })
+    start = end + 1
+  }
+  return true
 }
 
 export async function listQuickOpenFiles(rootPath: string, store: Store): Promise<string[]> {
   const authorizedRootPath = await resolveAuthorizedPath(rootPath, store)
-  return new Promise((resolve) => {
-    const files: string[] = []
-    let buf = ''
-    let done = false
-    const finish = (): void => {
-      if (done) {
-        return
+
+  // Why: We try fast string slicing first (O(1) per file), but fall back to
+  // path.relative() if the rg output doesn't start with the expected prefix.
+  // This handles edge cases where symlinks, bind mounts, Windows junctions,
+  // or custom ripgreprc --path-separator settings cause a mismatch.
+  const normalizedPrefix = `${authorizedRootPath.replace(/[\\/]+/g, '/').replace(/\/$/, '')}/`
+  const prefixLen = normalizedPrefix.length
+
+  const files = new Set<string>()
+
+  const runRg = (args: string[]): Promise<void> => {
+    return new Promise((resolve) => {
+      let buf = ''
+      let done = false
+      const finish = (): void => {
+        if (done) {
+          return
+        }
+        done = true
+        clearTimeout(timer)
+        resolve()
       }
-      done = true
-      clearTimeout(timer)
-      resolve(files)
-    }
-    const child = spawn(
-      'rg',
-      [
-        '--files',
-        // Why: --hidden + positive re-inclusion globs (e.g. '.github') made
-        // ripgrep treat them as a whitelist, filtering out every non-dotfile.
-        // Without --hidden, rg skips dot-dirs by default and respects
-        // .gitignore, so normal files like CLAUDE.md are returned correctly.
-        '--glob',
-        '!**/node_modules',
-        authorizedRootPath
-      ],
-      {
-        stdio: ['ignore', 'pipe', 'pipe']
-      }
-    )
-    child.stdout.setEncoding('utf-8')
-    child.stdout.on('data', (chunk: string) => {
-      buf += chunk
-      const lines = buf.split('\n')
-      buf = lines.pop() ?? ''
-      for (let line of lines) {
-        line = line.replace(/\r$/, '')
+
+      const processLine = (line: string): void => {
+        if (line.charCodeAt(line.length - 1) === 13 /* \r */) {
+          line = line.substring(0, line.length - 1)
+        }
         if (!line) {
-          continue
+          return
         }
-        const relPath = normalizeRelativePath(relative(authorizedRootPath, line))
+        // Why: Normalize separators to '/' so the prefix check works on all
+        // platforms (Windows rg uses '\', macOS/Linux use '/').
+        const normalized = line.replace(/\\/g, '/')
+        let relPath: string
+        if (normalized.startsWith(normalizedPrefix)) {
+          relPath = normalized.substring(prefixLen)
+        } else {
+          // Fallback: symlink resolution or path-separator mismatch between
+          // Node and rg — use path.relative() which handles all edge cases.
+          relPath = relative(authorizedRootPath, line).replace(/\\/g, '/')
+          if (relPath.startsWith('..') || relPath.startsWith('/')) {
+            // Safety: path escapes the root — skip it entirely
+            return
+          }
+        }
         if (shouldIncludeQuickOpenPath(relPath)) {
-          files.push(relPath)
+          files.add(relPath)
         }
       }
-    })
-    child.stderr.on('data', () => {
-      /* drain */
-    })
-    child.once('error', () => {
-      finish()
-    })
-    child.once('close', () => {
-      if (buf) {
-        // [Fix]: Strip trailing \r on Windows for the final buffered chunk
-        buf = buf.replace(/\r$/, '')
-        const relPath = normalizeRelativePath(relative(authorizedRootPath, buf))
-        if (shouldIncludeQuickOpenPath(relPath)) {
-          files.push(relPath)
+
+      const child = spawn('rg', args, { stdio: ['ignore', 'pipe', 'pipe'] })
+      child.stdout.setEncoding('utf-8')
+      child.stdout.on('data', (chunk: string) => {
+        buf += chunk
+        let start = 0
+        let newlineIdx = buf.indexOf('\n', start)
+        while (newlineIdx !== -1) {
+          processLine(buf.substring(start, newlineIdx))
+          start = newlineIdx + 1
+          newlineIdx = buf.indexOf('\n', start)
         }
-      }
-      finish()
+        // Keep the incomplete trailing segment for the next chunk
+        buf = start < buf.length ? buf.substring(start) : ''
+      })
+      child.stderr.on('data', () => {
+        /* drain */
+      })
+      child.once('error', () => {
+        finish()
+      })
+      child.once('close', () => {
+        if (buf) {
+          processLine(buf)
+        }
+        finish()
+      })
+      const timer = setTimeout(() => child.kill(), 10000)
     })
-    const timer = setTimeout(() => child.kill(), 10000)
-  })
+  }
+
+  // Why: --hidden is needed so users can quick-open dotfiles they commonly
+  // edit (.env, .github/*, .eslintrc, etc.). Without it, rg skips all
+  // dot-prefixed paths. The HIDDEN_DIR_BLOCKLIST in shouldIncludeQuickOpenPath
+  // filters out tool-generated dirs that would clutter results.
+  //
+  // The second rg call adds --no-ignore-vcs to also surface .env* files that
+  // are typically in .gitignore. These are included because users frequently
+  // need to view/edit .env files from quick-open, and excluding them would
+  // force users to navigate manually. The files are read-only in search
+  // results — they are not committed or exposed outside the local editor.
+
+  // Why: On Windows, rg outputs '\'-separated paths. Forcing '/' via
+  // --path-separator avoids per-line backslash replacement in processLine.
+  const rgSepArgs = sep === '\\' ? ['--path-separator', '/'] : []
+
+  await Promise.all([
+    runRg([
+      '--files',
+      '--hidden',
+      ...rgSepArgs,
+      '--glob',
+      '!**/node_modules',
+      '--glob',
+      '!**/.git',
+      authorizedRootPath
+    ]),
+    runRg([
+      '--files',
+      '--hidden',
+      '--no-ignore-vcs',
+      ...rgSepArgs,
+      '--glob',
+      '**/.env*',
+      '--glob',
+      '!**/node_modules',
+      '--glob',
+      '!**/.git',
+      authorizedRootPath
+    ])
+  ])
+
+  return Array.from(files)
 }


### PR DESCRIPTION
## Summary
- Enable `--hidden` flag for ripgrep so dotfiles users commonly edit (`.env`, `.github/*`, `.eslintrc`, etc.) appear in quick-open results
- Replace the "block all dot-prefixed paths" approach with a `HIDDEN_DIR_BLOCKLIST` of tool-generated dirs (`.git`, `.next`, `.cache`, `.vscode`, `.idea`, `.yarn`, `.pnpm-store`, etc.)
- Add a second `rg` call with `--no-ignore-vcs` to surface `.env*` files that are normally gitignored
- Fix cross-platform path handling: normalize separators to `/`, use `--path-separator /` on Windows, and fall back to `path.relative()` when symlinks/junctions cause prefix mismatch
- Guard against path traversal in the `path.relative()` fallback (skip paths starting with `..` or `/`)
- Collect results into a shared `Set` (instead of two arrays + spread dedup) for better performance

## Test plan
- [ ] Verify hidden dotfiles (`.github/workflows/*.yml`, `.eslintrc`, `.prettierrc`) appear in quick-open
- [ ] Verify `.env` and `.env.local` files appear in quick-open (even though gitignored)
- [ ] Verify blocklisted dirs (`.git`, `.next`, `.cache`, `.vscode`, `.idea`) do NOT appear
- [ ] Verify `node_modules` files are still excluded
- [ ] Test on Windows: paths should resolve correctly with backslash separators
- [ ] Test with a symlinked repo root to confirm the `path.relative()` fallback works