### PR TITLE
fix: capture terminal buffers before quitAndInstall

### DIFF
--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -204,7 +204,13 @@ const api = {
     getVersion: (): Promise<string> => ipcRenderer.invoke('updater:getVersion'),
     check: (): Promise<void> => ipcRenderer.invoke('updater:check'),
     download: (): Promise<void> => ipcRenderer.invoke('updater:download'),
-    quitAndInstall: (): Promise<void> => ipcRenderer.invoke('updater:quitAndInstall'),
+    quitAndInstall: (): Promise<void> => {
+      // Dispatch beforeunload to trigger terminal buffer capture before the
+      // update process bypasses the normal window close sequence (quitAndInstall
+      // removes close listeners, preventing beforeunload from firing naturally).
+      window.dispatchEvent(new Event('beforeunload'))
+      return ipcRenderer.invoke('updater:quitAndInstall')
+    },
     onStatus: (callback: (status: unknown) => void): (() => void) => {
       const listener = (_event: Electron.IpcRendererEvent, status: unknown) => callback(status)
       ipcRenderer.on('updater:status', listener)


### PR DESCRIPTION
## Summary
- Fixes terminal scrollback not being restored after auto-update restarts
- `quitAndInstall()` removes window close listeners before quitting, which prevents `beforeunload` from firing — so the buffer capture handler from #224 never runs during updates
- Fix: dispatch `beforeunload` in the preload wrapper before calling the IPC

## Root cause
`updater.ts`'s `quitAndInstall()` calls `win.removeAllListeners('close')` to prevent windows from blocking the quit. This bypasses the normal close sequence, so `beforeunload` never fires and terminal buffers are never captured. Since auto-update is the most common restart path, this made #224's feature appear broken.

## Test plan
- [ ] Open app, type in terminal, trigger auto-update install → scrollback preserved on relaunch
- [ ] Normal Cmd+Q still works (beforeunload fires twice — harmless, sendSync is idempotent)

Fixes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)