### PR TITLE
feat: add find in markdown preview

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -445,9 +445,95 @@
 /* ── Markdown Preview ────────────────────────────────── */
 
 .markdown-preview {
+  position: relative;
   padding: 24px 32px;
   font-size: 14px;
   line-height: 1.7;
+}
+
+.markdown-preview:focus-visible {
+  outline: none;
+}
+
+.markdown-preview-search {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  gap: 0;
+  width: fit-content;
+  max-width: min(100%, 460px);
+  margin-left: auto;
+  margin-right: -20px;
+  margin-bottom: 6px;
+  padding: 0 2px 0 4px;
+  border: 1px solid var(--border);
+  border-radius: 0 0 0 4px;
+  background: var(--background);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.16);
+}
+
+.markdown-preview-search-field {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  width: 220px;
+  border: 1px solid var(--ring);
+  background: var(--background);
+  flex: 0 1 auto;
+}
+
+.markdown-preview-search-status {
+  min-width: 0;
+  padding: 0 6px;
+  font-size: 12px;
+  color: var(--muted-foreground);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  line-height: 1;
+  flex: 0 0 auto;
+}
+
+.markdown-preview-search-divider {
+  width: 1px;
+  height: 16px;
+  margin: 0 2px;
+  background: var(--border);
+}
+
+.markdown-preview-search-input {
+  font-size: 13px;
+  line-height: 1;
+}
+
+.markdown-preview-search-input::placeholder {
+  color: var(--muted-foreground);
+}
+
+.markdown-preview-search-button {
+  width: 22px;
+  height: 22px;
+  min-width: 22px;
+  padding: 0;
+  border-radius: 2px;
+  color: var(--muted-foreground);
+}
+
+.markdown-preview-search-button:hover:not(:disabled) {
+  background: var(--accent);
+  color: var(--foreground);
+}
+
+.markdown-preview-search-match {
+  padding: 0;
+  border-radius: 2px;
+  background: color-mix(in srgb, #facc15 50%, transparent);
+  color: inherit;
+}
+
+.markdown-preview-search-match[data-active] {
+  background: color-mix(in srgb, #fb923c 60%, transparent);
 }
 
 .markdown-body h1,

--- a/src/renderer/src/components/editor/MarkdownPreview.tsx
+++ b/src/renderer/src/components/editor/MarkdownPreview.tsx
@@ -1,11 +1,20 @@
-import React from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import Markdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import remarkFrontmatter from 'remark-frontmatter'
 import rehypeHighlight from 'rehype-highlight'
+import { ChevronDown, ChevronUp, X } from 'lucide-react'
 import type { Components } from 'react-markdown'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
 import { useAppStore } from '@/store'
 import { getMarkdownPreviewImageSrc, getMarkdownPreviewLinkTarget } from './markdown-preview-links'
+import {
+  applyMarkdownPreviewSearchHighlights,
+  clearMarkdownPreviewSearchHighlights,
+  isMarkdownPreviewFindShortcut,
+  setActiveMarkdownPreviewSearchMatch
+} from './markdown-preview-search'
 
 type MarkdownPreviewProps = {
   content: string
@@ -16,10 +25,118 @@ export default function MarkdownPreview({
   content,
   filePath
 }: MarkdownPreviewProps): React.JSX.Element {
+  const rootRef = useRef<HTMLDivElement>(null)
+  const bodyRef = useRef<HTMLDivElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const matchesRef = useRef<HTMLElement[]>([])
+  const [isSearchOpen, setIsSearchOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const [matchCount, setMatchCount] = useState(0)
+  const [activeMatchIndex, setActiveMatchIndex] = useState(-1)
   const settings = useAppStore((s) => s.settings)
   const isDark =
     settings?.theme === 'dark' ||
     (settings?.theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)
+
+  const moveToMatch = useCallback((direction: 1 | -1) => {
+    const matches = matchesRef.current
+    if (matches.length === 0) {
+      return
+    }
+    setActiveMatchIndex((currentIndex) => {
+      const baseIndex = currentIndex >= 0 ? currentIndex : direction === 1 ? -1 : 0
+      const nextIndex = (baseIndex + direction + matches.length) % matches.length
+      return nextIndex
+    })
+  }, [])
+
+  const closeSearch = useCallback(() => {
+    setIsSearchOpen(false)
+    setQuery('')
+    setActiveMatchIndex(-1)
+  }, [])
+
+  useEffect(() => {
+    if (isSearchOpen) {
+      inputRef.current?.focus()
+      inputRef.current?.select()
+    }
+  }, [isSearchOpen])
+
+  useEffect(() => {
+    const body = bodyRef.current
+    if (!body) {
+      return
+    }
+
+    if (!isSearchOpen) {
+      matchesRef.current = []
+      setMatchCount(0)
+      clearMarkdownPreviewSearchHighlights(body)
+      return
+    }
+
+    // Search decorations are applied imperatively because the rendered preview is
+    // already owned by react-markdown. Rewriting the markdown AST for transient
+    // find state would make navigation and link rendering much harder to reason about.
+    const matches = applyMarkdownPreviewSearchHighlights(body, query)
+    matchesRef.current = matches
+    setMatchCount(matches.length)
+    setActiveMatchIndex((currentIndex) => {
+      if (matches.length === 0) {
+        return -1
+      }
+      if (currentIndex >= 0 && currentIndex < matches.length) {
+        return currentIndex
+      }
+      return 0
+    })
+
+    return () => clearMarkdownPreviewSearchHighlights(body)
+  }, [content, isSearchOpen, query])
+
+  useEffect(() => {
+    setActiveMarkdownPreviewSearchMatch(matchesRef.current, activeMatchIndex)
+  }, [activeMatchIndex, matchCount])
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      const root = rootRef.current
+      if (!root) {
+        return
+      }
+
+      const target = event.target
+      const targetInsidePreview = target instanceof Node && root.contains(target)
+      const targetIsEditable =
+        target instanceof HTMLElement &&
+        (target.isContentEditable || target.closest('input, textarea, select') !== null)
+
+      if (
+        isMarkdownPreviewFindShortcut(event, navigator.userAgent.includes('Mac')) &&
+        (isSearchOpen || targetInsidePreview || !targetIsEditable)
+      ) {
+        event.preventDefault()
+        event.stopPropagation()
+        setIsSearchOpen(true)
+        return
+      }
+
+      if (!isSearchOpen) {
+        return
+      }
+
+      if (event.key === 'Escape' && (targetInsidePreview || target === inputRef.current)) {
+        event.preventDefault()
+        event.stopPropagation()
+        closeSearch()
+        root.focus()
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown, { capture: true })
+    return () => window.removeEventListener('keydown', handleKeyDown, { capture: true })
+  }, [closeSearch, isSearchOpen, setIsSearchOpen])
 
   const components: Components = {
     a: ({ href, children, ...props }) => {
@@ -65,9 +182,83 @@ export default function MarkdownPreview({
 
   return (
     <div
+      ref={rootRef}
+      tabIndex={0}
       className={`markdown-preview h-full min-h-0 overflow-auto scrollbar-editor ${isDark ? 'markdown-dark' : 'markdown-light'}`}
     >
-      <div className="markdown-body">
+      {isSearchOpen ? (
+        <div className="markdown-preview-search" onKeyDown={(event) => event.stopPropagation()}>
+          <div className="markdown-preview-search-field">
+            <Input
+              ref={inputRef}
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter' && event.shiftKey) {
+                  event.preventDefault()
+                  moveToMatch(-1)
+                  return
+                }
+                if (event.key === 'Enter') {
+                  event.preventDefault()
+                  moveToMatch(1)
+                  return
+                }
+                if (event.key === 'Escape') {
+                  event.preventDefault()
+                  closeSearch()
+                  rootRef.current?.focus()
+                }
+              }}
+              placeholder="Find in preview"
+              className="markdown-preview-search-input h-7 !border-0 bg-transparent px-2 shadow-none focus-visible:!border-0 focus-visible:ring-0"
+              aria-label="Find in markdown preview"
+            />
+          </div>
+          <div className="markdown-preview-search-status">
+            {query && matchCount === 0
+              ? 'No results'
+              : `${matchCount === 0 ? 0 : activeMatchIndex + 1}/${matchCount}`}
+          </div>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            onClick={() => moveToMatch(-1)}
+            disabled={matchCount === 0}
+            title="Previous match"
+            aria-label="Previous match"
+            className="markdown-preview-search-button"
+          >
+            <ChevronUp size={14} />
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            onClick={() => moveToMatch(1)}
+            disabled={matchCount === 0}
+            title="Next match"
+            aria-label="Next match"
+            className="markdown-preview-search-button"
+          >
+            <ChevronDown size={14} />
+          </Button>
+          <div className="markdown-preview-search-divider" />
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            onClick={closeSearch}
+            title="Close search"
+            aria-label="Close search"
+            className="markdown-preview-search-button"
+          >
+            <X size={14} />
+          </Button>
+        </div>
+      ) : null}
+      <div ref={bodyRef} className="markdown-body">
         <Markdown
           components={components}
           remarkPlugins={[remarkGfm, remarkFrontmatter]}

--- a/src/renderer/src/components/editor/markdown-preview-search.test.ts
+++ b/src/renderer/src/components/editor/markdown-preview-search.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import { findTextMatchRanges, isMarkdownPreviewFindShortcut } from './markdown-preview-search'
+
+describe('isMarkdownPreviewFindShortcut', () => {
+  it('uses Cmd on macOS', () => {
+    expect(
+      isMarkdownPreviewFindShortcut(
+        {
+          key: 'f',
+          metaKey: true,
+          ctrlKey: false,
+          altKey: false,
+          shiftKey: false
+        },
+        true
+      )
+    ).toBe(true)
+    expect(
+      isMarkdownPreviewFindShortcut(
+        {
+          key: 'f',
+          metaKey: false,
+          ctrlKey: true,
+          altKey: false,
+          shiftKey: false
+        },
+        true
+      )
+    ).toBe(false)
+  })
+
+  it('uses Ctrl on non-macOS platforms', () => {
+    expect(
+      isMarkdownPreviewFindShortcut(
+        {
+          key: 'f',
+          metaKey: false,
+          ctrlKey: true,
+          altKey: false,
+          shiftKey: false
+        },
+        false
+      )
+    ).toBe(true)
+    expect(
+      isMarkdownPreviewFindShortcut(
+        {
+          key: 'f',
+          metaKey: true,
+          ctrlKey: false,
+          altKey: false,
+          shiftKey: false
+        },
+        false
+      )
+    ).toBe(false)
+  })
+})
+
+describe('findTextMatchRanges', () => {
+  it('finds case-insensitive literal matches', () => {
+    expect(findTextMatchRanges('Alpha beta ALPHA', 'alpha')).toEqual([
+      { start: 0, end: 5 },
+      { start: 11, end: 16 }
+    ])
+  })
+
+  it('skips overlapping matches so highlights remain stable per text node', () => {
+    expect(findTextMatchRanges('ababa', 'aba')).toEqual([{ start: 0, end: 3 }])
+  })
+
+  it('returns no matches for an empty query', () => {
+    expect(findTextMatchRanges('Alpha beta', '')).toEqual([])
+  })
+})

--- a/src/renderer/src/components/editor/markdown-preview-search.ts
+++ b/src/renderer/src/components/editor/markdown-preview-search.ts
@@ -1,0 +1,123 @@
+export function isMarkdownPreviewFindShortcut(
+  event: Pick<KeyboardEvent, 'key' | 'metaKey' | 'ctrlKey' | 'altKey' | 'shiftKey'>,
+  isMac: boolean
+): boolean {
+  const mod = isMac ? event.metaKey && !event.ctrlKey : event.ctrlKey && !event.metaKey
+  return mod && !event.altKey && !event.shiftKey && event.key.toLowerCase() === 'f'
+}
+
+export function findTextMatchRanges(text: string, query: string): { start: number; end: number }[] {
+  if (!query) {
+    return []
+  }
+
+  const normalizedText = text.toLocaleLowerCase()
+  const normalizedQuery = query.toLocaleLowerCase()
+  const matches: { start: number; end: number }[] = []
+  let searchStart = 0
+
+  while (searchStart <= normalizedText.length - normalizedQuery.length) {
+    const matchStart = normalizedText.indexOf(normalizedQuery, searchStart)
+    if (matchStart === -1) {
+      break
+    }
+
+    matches.push({
+      start: matchStart,
+      end: matchStart + query.length
+    })
+    searchStart = matchStart + query.length
+  }
+
+  return matches
+}
+
+export function clearMarkdownPreviewSearchHighlights(root: HTMLElement): void {
+  const highlights = root.querySelectorAll<HTMLElement>('[data-markdown-preview-search-match]')
+  for (const highlight of highlights) {
+    const textNode = document.createTextNode(highlight.textContent ?? '')
+    highlight.replaceWith(textNode)
+  }
+  root.normalize()
+}
+
+export function applyMarkdownPreviewSearchHighlights(
+  root: HTMLElement,
+  query: string
+): HTMLElement[] {
+  clearMarkdownPreviewSearchHighlights(root)
+
+  if (!query) {
+    return []
+  }
+
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
+    acceptNode(node) {
+      if (!(node.parentElement instanceof HTMLElement)) {
+        return NodeFilter.FILTER_REJECT
+      }
+      if (node.parentElement.closest('[data-markdown-preview-search-match]')) {
+        return NodeFilter.FILTER_REJECT
+      }
+      if (!node.textContent?.trim()) {
+        return NodeFilter.FILTER_REJECT
+      }
+      return NodeFilter.FILTER_ACCEPT
+    }
+  })
+
+  const textNodes: Text[] = []
+  let currentNode = walker.nextNode()
+  while (currentNode) {
+    if (currentNode instanceof Text) {
+      textNodes.push(currentNode)
+    }
+    currentNode = walker.nextNode()
+  }
+
+  const matches: HTMLElement[] = []
+  for (const textNode of textNodes) {
+    const text = textNode.textContent ?? ''
+    const ranges = findTextMatchRanges(text, query)
+    if (ranges.length === 0) {
+      continue
+    }
+
+    const fragment = document.createDocumentFragment()
+    let cursor = 0
+    for (const range of ranges) {
+      if (range.start > cursor) {
+        fragment.append(document.createTextNode(text.slice(cursor, range.start)))
+      }
+
+      const highlight = document.createElement('mark')
+      highlight.dataset.markdownPreviewSearchMatch = 'true'
+      highlight.className = 'markdown-preview-search-match'
+      highlight.textContent = text.slice(range.start, range.end)
+      fragment.append(highlight)
+      matches.push(highlight)
+      cursor = range.end
+    }
+
+    if (cursor < text.length) {
+      fragment.append(document.createTextNode(text.slice(cursor)))
+    }
+
+    textNode.replaceWith(fragment)
+  }
+
+  return matches
+}
+
+export function setActiveMarkdownPreviewSearchMatch(
+  matches: readonly HTMLElement[],
+  activeIndex: number
+): void {
+  for (const [index, match] of matches.entries()) {
+    const isActive = index === activeIndex
+    match.toggleAttribute('data-active', isActive)
+    if (isActive) {
+      match.scrollIntoView({ block: 'center', inline: 'nearest' })
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a find bar to the markdown preview with next/previous navigation and close controls
- highlight literal case-insensitive matches inside the rendered preview and keep the active match scrolled into view
- add tests for match range detection and cross-platform find shortcut handling

## Testing
- pnpm test -- markdown-preview-search.test.ts
- pnpm typecheck
- pnpm lint
- pnpm build