### PR TITLE
feat: add jump-to-file button in diff view

### DIFF
--- a/src/renderer/src/components/editor/EditorPanel.tsx
+++ b/src/renderer/src/components/editor/EditorPanel.tsx
@@ -1,8 +1,8 @@
 import React, { useCallback, useEffect, useState, Suspense } from 'react'
-import { Columns2, Rows2 } from 'lucide-react'
+import { Columns2, FileText, Rows2 } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { detectLanguage } from '@/lib/language-detect'
-import { getEditorHeaderCopyState } from './editor-header'
+import { getEditorHeaderCopyState, getEditorHeaderOpenFileState } from './editor-header'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import type { MarkdownViewMode } from '@/store/slices/editor'
 import MarkdownViewToggle from './MarkdownViewToggle'
@@ -24,8 +24,10 @@ export default function EditorPanel(): React.JSX.Element | null {
   const markFileDirty = useAppStore((s) => s.markFileDirty)
   const pendingEditorReveal = useAppStore((s) => s.pendingEditorReveal)
   const gitStatusByWorktree = useAppStore((s) => s.gitStatusByWorktree)
+  const gitBranchChangesByWorktree = useAppStore((s) => s.gitBranchChangesByWorktree)
   const markdownViewMode = useAppStore((s) => s.markdownViewMode)
   const setMarkdownViewMode = useAppStore((s) => s.setMarkdownViewMode)
+  const openFile = useAppStore((s) => s.openFile)
 
   const activeFile = openFiles.find((f) => f.id === activeFileId) ?? null
 
@@ -283,16 +285,49 @@ export default function EditorPanel(): React.JSX.Element | null {
       activeFile.diffSource === 'combined-branch')
   const headerCopyState = getEditorHeaderCopyState(activeFile)
   const worktreeEntries = gitStatusByWorktree[activeFile.worktreeId] ?? []
+  const branchEntries = gitBranchChangesByWorktree[activeFile.worktreeId] ?? []
   const resolvedLanguage =
     activeFile.mode === 'diff'
       ? detectLanguage(activeFile.relativePath)
       : detectLanguage(activeFile.filePath)
+  const matchingWorktreeEntry =
+    activeFile.mode === 'diff' && activeFile.diffSource !== 'branch'
+      ? (worktreeEntries.find(
+          (entry) =>
+            entry.path === activeFile.relativePath &&
+            (activeFile.diffSource === 'staged'
+              ? entry.area === 'staged'
+              : entry.area === 'unstaged')
+        ) ?? null)
+      : null
+  const matchingBranchEntry =
+    activeFile.mode === 'diff' && activeFile.diffSource === 'branch'
+      ? (branchEntries.find((entry) => entry.path === activeFile.relativePath) ?? null)
+      : null
+  const openFileState = getEditorHeaderOpenFileState(
+    activeFile,
+    matchingWorktreeEntry,
+    matchingBranchEntry
+  )
 
   const isMarkdown = resolvedLanguage === 'markdown'
   const mdViewMode: MarkdownViewMode =
     isMarkdown && activeFile.mode === 'edit'
       ? (markdownViewMode[activeFile.id] ?? 'source')
       : 'source'
+
+  const handleOpenDiffTargetFile = (): void => {
+    if (!openFileState.canOpen) {
+      return
+    }
+    openFile({
+      filePath: activeFile.filePath,
+      relativePath: activeFile.relativePath,
+      worktreeId: activeFile.worktreeId,
+      language: detectLanguage(activeFile.relativePath),
+      mode: 'edit'
+    })
+  }
 
   const loadingFallback = (
     <div className="flex items-center justify-center h-full text-muted-foreground text-sm">
@@ -322,6 +357,30 @@ export default function EditorPanel(): React.JSX.Element | null {
               </span>
             </div>
           </div>
+          {isSingleDiff && (
+            <TooltipProvider delayDuration={300}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    className="p-1 rounded hover:bg-accent text-muted-foreground hover:text-foreground transition-colors flex-shrink-0 disabled:opacity-50 disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
+                    onClick={handleOpenDiffTargetFile}
+                    aria-label="Open file"
+                    disabled={!openFileState.canOpen}
+                  >
+                    <FileText size={14} />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" sideOffset={4}>
+                  {openFileState.canOpen
+                    ? isMarkdown
+                      ? 'Open file tab to use markdown preview'
+                      : 'Open file tab'
+                    : 'This diff has no modified-side file to open'}
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          )}
           {isSingleDiff && (
             <TooltipProvider delayDuration={300}>
               <Tooltip>

--- a/src/renderer/src/components/editor/editor-header.test.ts
+++ b/src/renderer/src/components/editor/editor-header.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { getEditorHeaderCopyState } from './editor-header'
+import { getEditorHeaderCopyState, getEditorHeaderOpenFileState } from './editor-header'
 import type { OpenFile } from '@/store/slices/editor'
 
 function makeOpenFile(overrides: Partial<OpenFile> = {}): OpenFile {
@@ -76,5 +76,74 @@ describe('getEditorHeaderCopyState', () => {
       pathLabel: 'All Changes',
       pathTitle: '/repo/worktree'
     })
+  })
+})
+
+describe('getEditorHeaderOpenFileState', () => {
+  it('allows opening the file from a normal unstaged diff', () => {
+    expect(
+      getEditorHeaderOpenFileState(
+        makeOpenFile({
+          id: 'wt-1::diff::unstaged::file.ts',
+          mode: 'diff',
+          diffSource: 'unstaged'
+        }),
+        { path: 'file.ts', status: 'modified', area: 'unstaged' }
+      )
+    ).toEqual({ canOpen: true })
+  })
+
+  it('disables opening the file when the uncommitted diff is deleted', () => {
+    expect(
+      getEditorHeaderOpenFileState(
+        makeOpenFile({
+          id: 'wt-1::diff::unstaged::file.ts',
+          mode: 'diff',
+          diffSource: 'unstaged'
+        }),
+        { path: 'file.ts', status: 'deleted', area: 'unstaged' }
+      )
+    ).toEqual({ canOpen: false })
+  })
+
+  it('disables opening the file when the branch diff target is deleted', () => {
+    expect(
+      getEditorHeaderOpenFileState(
+        makeOpenFile({
+          id: 'wt-1::diff::branch::main::v1::file.ts',
+          mode: 'diff',
+          diffSource: 'branch'
+        }),
+        null,
+        { path: 'file.ts', status: 'deleted' }
+      )
+    ).toEqual({ canOpen: false })
+  })
+
+  it('keeps branch diff open enabled when the live compare entry is gone', () => {
+    expect(
+      getEditorHeaderOpenFileState(
+        makeOpenFile({
+          id: 'wt-1::diff::branch::main::v1::file.ts',
+          mode: 'diff',
+          diffSource: 'branch'
+        }),
+        null,
+        null
+      )
+    ).toEqual({ canOpen: true })
+  })
+
+  it('keeps the action enabled when live uncommitted metadata has already disappeared', () => {
+    expect(
+      getEditorHeaderOpenFileState(
+        makeOpenFile({
+          id: 'wt-1::diff::unstaged::file.ts',
+          mode: 'diff',
+          diffSource: 'unstaged'
+        }),
+        null
+      )
+    ).toEqual({ canOpen: true })
   })
 })

--- a/src/renderer/src/components/editor/editor-header.ts
+++ b/src/renderer/src/components/editor/editor-header.ts
@@ -1,4 +1,5 @@
 import type { OpenFile } from '@/store/slices/editor'
+import type { GitBranchChangeEntry, GitStatusEntry } from '../../../../shared/types'
 import { getEditorDisplayLabel } from './editor-labels'
 
 export type EditorHeaderCopyState = {
@@ -6,6 +7,10 @@ export type EditorHeaderCopyState = {
   copyToastLabel: string
   pathLabel: string
   pathTitle: string
+}
+
+export type EditorHeaderOpenFileState = {
+  canOpen: boolean
 }
 
 export function getEditorHeaderCopyState(file: OpenFile): EditorHeaderCopyState {
@@ -39,4 +44,33 @@ export function getEditorHeaderCopyState(file: OpenFile): EditorHeaderCopyState 
     pathLabel: displayLabel,
     pathTitle: displayLabel
   }
+}
+
+export function getEditorHeaderOpenFileState(
+  file: OpenFile,
+  worktreeEntry?: GitStatusEntry | null,
+  branchEntry?: GitBranchChangeEntry | null
+): EditorHeaderOpenFileState {
+  const isSingleDiff =
+    file.mode === 'diff' &&
+    file.diffSource !== undefined &&
+    file.diffSource !== 'combined-uncommitted' &&
+    file.diffSource !== 'combined-branch'
+
+  if (!isSingleDiff) {
+    return { canOpen: false }
+  }
+
+  if (file.diffSource === 'branch') {
+    return { canOpen: branchEntry?.status !== 'deleted' || !branchEntry }
+  }
+
+  // Why: diff tabs can outlive the current Source Control snapshot. If the
+  // live entry is missing, keep the action enabled instead of hiding a valid
+  // open-file path just because sidebar polling has moved on.
+  if (!worktreeEntry) {
+    return { canOpen: true }
+  }
+
+  return { canOpen: worktreeEntry.status !== 'deleted' }
 }

--- a/src/renderer/src/components/right-sidebar/FileExplorerRow.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorerRow.tsx
@@ -46,7 +46,7 @@ export function FileExplorerRow({
       <ContextMenuTrigger asChild>
         <button
           className={cn(
-            'flex w-full items-center gap-1 rounded-sm px-2 py-1 text-left text-xs transition-colors hover:bg-accent/60',
+            'flex w-full items-center gap-1 rounded-sm px-2 py-1 text-left text-xs transition-colors hover:bg-accent hover:text-foreground',
             isSelected && 'bg-accent text-accent-foreground',
             isFlashing && 'bg-amber-400/20 ring-1 ring-inset ring-amber-400/70'
           )}

--- a/src/renderer/src/components/tab-bar/EditorFileTab.tsx
+++ b/src/renderer/src/components/tab-bar/EditorFileTab.tsx
@@ -81,7 +81,7 @@ export default function EditorFileTab({
           {...listeners}
           className={`group relative flex items-center h-full px-3 text-sm cursor-pointer select-none shrink-0 border-r border-border ${
             isActive
-              ? 'bg-background text-foreground border-b-transparent'
+              ? 'bg-accent/40 text-foreground border-b-transparent'
               : 'bg-card text-muted-foreground hover:text-foreground hover:bg-accent/50'
           }`}
           onPointerDown={(e) => {
@@ -105,16 +105,20 @@ export default function EditorFileTab({
           }}
         >
           {isDiff ? (
-            <GitCompareArrows className="w-3.5 h-3.5 mr-1.5 shrink-0 text-muted-foreground" />
+            <GitCompareArrows
+              className={`w-3.5 h-3.5 mr-1.5 shrink-0 ${isActive ? 'text-foreground' : 'text-muted-foreground'}`}
+            />
           ) : (
-            <FileCode className="w-3.5 h-3.5 mr-1.5 shrink-0 text-muted-foreground" />
+            <FileCode
+              className={`w-3.5 h-3.5 mr-1.5 shrink-0 ${isActive ? 'text-foreground' : 'text-muted-foreground'}`}
+            />
           )}
           {file.isDirty && (
             <span className="mr-1 size-1.5 rounded-full bg-foreground/60 shrink-0" />
           )}
           <span className="mr-1.5 flex min-w-0 items-baseline gap-1.5">
             <span
-              className={`truncate max-w-[130px]${file.isPreview ? ' italic' : ''}`}
+              className={`truncate max-w-[130px]${file.isPreview ? ' italic' : ''}${isActive ? ' font-medium' : ''}`}
               style={tabStatusColor ? { color: tabStatusColor } : undefined}
             >
               {getEditorDisplayLabel(file)}

--- a/src/renderer/src/components/tab-bar/SortableTab.tsx
+++ b/src/renderer/src/components/tab-bar/SortableTab.tsx
@@ -126,7 +126,7 @@ export default function SortableTab({
           {...listeners}
           className={`group relative flex items-center h-full px-3 text-sm cursor-pointer select-none shrink-0 border-r border-border ${
             isActive
-              ? 'bg-background text-foreground border-b-transparent'
+              ? 'bg-accent/40 text-foreground border-b-transparent'
               : 'bg-card text-muted-foreground hover:text-foreground hover:bg-accent/50'
           }`}
           onPointerDown={(e) => {
@@ -144,8 +144,12 @@ export default function SortableTab({
             }
           }}
         >
-          <TerminalIcon className="w-3.5 h-3.5 mr-1.5 shrink-0 text-muted-foreground" />
-          <span className="truncate max-w-[130px] mr-1.5">{tab.customTitle ?? tab.title}</span>
+          <TerminalIcon
+            className={`w-3.5 h-3.5 mr-1.5 shrink-0 ${isActive ? 'text-foreground' : 'text-muted-foreground'}`}
+          />
+          <span className={`truncate max-w-[130px] mr-1.5${isActive ? ' font-medium' : ''}`}>
+            {tab.customTitle ?? tab.title}
+          </span>
           {tab.color && (
             <span
               className="mr-1.5 size-2 rounded-full shrink-0"


### PR DESCRIPTION
## Summary
- Add an "Open file" button in the diff editor header that opens the modified-side file in a regular edit tab, useful for accessing markdown preview from a diff view
- Button is intelligently disabled when the diff target is a deleted file (no file to open)
- Refine tab bar styling: active tabs now use accent background with bold text, and file explorer rows get consistent hover colors

## Test plan
- [ ] Open a diff (staged, unstaged, or branch) and verify the new file icon button appears in the header
- [ ] Click the button and confirm it opens the file in a regular edit tab
- [ ] Open a diff for a deleted file and verify the button is disabled with appropriate tooltip
- [ ] Verify active tab styling shows accent background and bold text
- [ ] Verify file explorer row hover colors are consistent