### PR TITLE
Prevent branch name reuse across PR history

### DIFF
--- a/src/main/git/repo.ts
+++ b/src/main/git/repo.ts
@@ -289,17 +289,35 @@ async function hasGitRefAsync(path: string, ref: string): Promise<boolean> {
   }
 }
 
-export async function getAvailableBranchName(path: string, branchName: string): Promise<string> {
-  if (!(await hasGitRefAsync(path, `refs/heads/${branchName}`))) {
-    return branchName
+export type BranchConflictKind = 'local' | 'remote'
+
+export async function getBranchConflictKind(
+  path: string,
+  branchName: string
+): Promise<BranchConflictKind | null> {
+  if (await hasGitRefAsync(path, `refs/heads/${branchName}`)) {
+    return 'local'
   }
 
-  let suffix = 1
-  while (true) {
-    const candidate = `${branchName}-${suffix}`
-    if (!(await hasGitRefAsync(path, `refs/heads/${candidate}`))) {
-      return candidate
-    }
-    suffix += 1
+  try {
+    const { stdout } = await execFileAsync(
+      'git',
+      ['for-each-ref', '--format=%(refname)', 'refs/remotes'],
+      {
+        cwd: path,
+        encoding: 'utf-8'
+      }
+    )
+    // Why: refs have the form refs/remotes/<remote>/<branch>. We strip the
+    // first three segments so that e.g. "feature/dashboard" only matches
+    // "refs/remotes/origin/feature/dashboard", not "refs/remotes/origin/other/feature/dashboard".
+    const hasRemoteConflict = stdout.split('\n').some((ref) => {
+      const parts = ref.trim().split('/')
+      return parts.slice(3).join('/') === branchName
+    })
+
+    return hasRemoteConflict ? 'remote' : null
+  } catch {
+    return null
   }
 }

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -1,0 +1,177 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  handleMock,
+  removeHandlerMock,
+  listWorktreesMock,
+  addWorktreeMock,
+  removeWorktreeMock,
+  getGitUsernameMock,
+  getDefaultBaseRefMock,
+  getBranchConflictKindMock,
+  getPRForBranchMock,
+  getEffectiveHooksMock,
+  runHookMock,
+  hasHooksFileMock,
+  loadHooksMock
+} = vi.hoisted(() => ({
+  handleMock: vi.fn(),
+  removeHandlerMock: vi.fn(),
+  listWorktreesMock: vi.fn(),
+  addWorktreeMock: vi.fn(),
+  removeWorktreeMock: vi.fn(),
+  getGitUsernameMock: vi.fn(),
+  getDefaultBaseRefMock: vi.fn(),
+  getBranchConflictKindMock: vi.fn(),
+  getPRForBranchMock: vi.fn(),
+  getEffectiveHooksMock: vi.fn(),
+  runHookMock: vi.fn(),
+  hasHooksFileMock: vi.fn(),
+  loadHooksMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: handleMock,
+    removeHandler: removeHandlerMock
+  }
+}))
+
+vi.mock('../git/worktree', () => ({
+  listWorktrees: listWorktreesMock,
+  addWorktree: addWorktreeMock,
+  removeWorktree: removeWorktreeMock
+}))
+
+vi.mock('../git/repo', () => ({
+  getGitUsername: getGitUsernameMock,
+  getDefaultBaseRef: getDefaultBaseRefMock,
+  getBranchConflictKind: getBranchConflictKindMock
+}))
+
+vi.mock('../github/client', () => ({
+  getPRForBranch: getPRForBranchMock
+}))
+
+vi.mock('../hooks', () => ({
+  getEffectiveHooks: getEffectiveHooksMock,
+  loadHooks: loadHooksMock,
+  runHook: runHookMock,
+  hasHooksFile: hasHooksFileMock
+}))
+
+import { registerWorktreeHandlers } from './worktrees'
+
+type HandlerMap = Record<string, (_event: unknown, args: unknown) => unknown>
+
+describe('registerWorktreeHandlers', () => {
+  const handlers: HandlerMap = {}
+  const mainWindow = {
+    isDestroyed: () => false,
+    webContents: {
+      send: vi.fn()
+    }
+  }
+  const store = {
+    getRepos: vi.fn(),
+    getRepo: vi.fn(),
+    getSettings: vi.fn(),
+    getWorktreeMeta: vi.fn(),
+    setWorktreeMeta: vi.fn(),
+    removeWorktreeMeta: vi.fn()
+  }
+
+  beforeEach(() => {
+    handleMock.mockReset()
+    removeHandlerMock.mockReset()
+    listWorktreesMock.mockReset()
+    addWorktreeMock.mockReset()
+    removeWorktreeMock.mockReset()
+    getGitUsernameMock.mockReset()
+    getDefaultBaseRefMock.mockReset()
+    getBranchConflictKindMock.mockReset()
+    getPRForBranchMock.mockReset()
+    getEffectiveHooksMock.mockReset()
+    runHookMock.mockReset()
+    hasHooksFileMock.mockReset()
+    loadHooksMock.mockReset()
+    mainWindow.webContents.send.mockReset()
+    store.getRepos.mockReset()
+    store.getRepo.mockReset()
+    store.getSettings.mockReset()
+    store.getWorktreeMeta.mockReset()
+    store.setWorktreeMeta.mockReset()
+    store.removeWorktreeMeta.mockReset()
+
+    for (const key of Object.keys(handlers)) {
+      delete handlers[key]
+    }
+
+    handleMock.mockImplementation((channel, handler) => {
+      handlers[channel] = handler
+    })
+
+    store.getRepo.mockReturnValue({
+      id: 'repo-1',
+      path: '/workspace/repo',
+      displayName: 'repo',
+      badgeColor: '#000',
+      addedAt: 0,
+      worktreeBaseRef: null
+    })
+    store.getSettings.mockReturnValue({
+      branchPrefix: 'none',
+      nestWorkspaces: false,
+      workspaceDir: '/workspace'
+    })
+    store.getWorktreeMeta.mockReturnValue(undefined)
+    store.setWorktreeMeta.mockReturnValue({})
+    getGitUsernameMock.mockReturnValue('')
+    getDefaultBaseRefMock.mockReturnValue('origin/main')
+    getBranchConflictKindMock.mockResolvedValue(null)
+    getPRForBranchMock.mockResolvedValue(null)
+    getEffectiveHooksMock.mockReturnValue(null)
+    listWorktreesMock.mockResolvedValue([])
+
+    registerWorktreeHandlers(mainWindow as never, store as never)
+  })
+
+  it('rejects worktree creation when the branch already exists on a remote', async () => {
+    getBranchConflictKindMock.mockResolvedValue('remote')
+
+    await expect(
+      handlers['worktrees:create'](null, {
+        repoId: 'repo-1',
+        name: 'improve-dashboard'
+      })
+    ).rejects.toThrow(
+      'Branch "improve-dashboard" already exists on a remote. Pick a different worktree name.'
+    )
+
+    expect(getPRForBranchMock).not.toHaveBeenCalled()
+    expect(addWorktreeMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects worktree creation when the branch name already belongs to a PR', async () => {
+    getPRForBranchMock.mockResolvedValue({
+      number: 3127,
+      title: 'Existing PR',
+      state: 'merged',
+      url: 'https://example.com/pr/3127',
+      checksStatus: 'success',
+      updatedAt: '2026-04-01T00:00:00Z',
+      mergeable: 'UNKNOWN'
+    })
+
+    await expect(
+      handlers['worktrees:create'](null, {
+        repoId: 'repo-1',
+        name: 'improve-dashboard'
+      })
+    ).rejects.toThrow(
+      'Branch "improve-dashboard" already has PR #3127. Pick a different worktree name.'
+    )
+
+    expect(addWorktreeMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -4,8 +4,9 @@ import { execFileSync } from 'child_process'
 import { rm } from 'fs/promises'
 import type { Store } from '../persistence'
 import type { Worktree, WorktreeMeta } from '../../shared/types'
+import { getPRForBranch } from '../github/client'
 import { listWorktrees, addWorktree, removeWorktree } from '../git/worktree'
-import { getGitUsername, getDefaultBaseRef, getAvailableBranchName } from '../git/repo'
+import { getGitUsername, getDefaultBaseRef, getBranchConflictKind } from '../git/repo'
 import { getEffectiveHooks, loadHooks, runHook, hasHooksFile } from '../hooks'
 import {
   sanitizeWorktreeName,
@@ -74,8 +75,30 @@ export function registerWorktreeHandlers(mainWindow: BrowserWindow, store: Store
 
       // Compute branch name with prefix
       const username = getGitUsername(repo.path)
-      let branchName = computeBranchName(sanitizedName, settings, username)
-      branchName = await getAvailableBranchName(repo.path, branchName)
+      const branchName = computeBranchName(sanitizedName, settings, username)
+
+      const branchConflictKind = await getBranchConflictKind(repo.path, branchName)
+      if (branchConflictKind) {
+        throw new Error(
+          `Branch "${branchName}" already exists ${branchConflictKind === 'local' ? 'locally' : 'on a remote'}. Pick a different worktree name.`
+        )
+      }
+
+      // Why: the UI resolves PR status by branch name alone. Reusing a historical
+      // PR head name would make a fresh worktree inherit that old merged/closed PR
+      // immediately, so we reject the name instead of silently suffixing it.
+      // The lookup is best-effort — don't block creation if GitHub is unreachable.
+      let existingPR: Awaited<ReturnType<typeof getPRForBranch>> | null = null
+      try {
+        existingPR = await getPRForBranch(repo.path, branchName)
+      } catch {
+        // GitHub API may be unreachable, rate-limited, or token missing
+      }
+      if (existingPR) {
+        throw new Error(
+          `Branch "${branchName}" already has PR #${existingPR.number}. Pick a different worktree name.`
+        )
+      }
 
       // Compute worktree path
       let worktreePath = computeWorktreePath(sanitizedName, repo.path, settings)

--- a/src/renderer/src/components/sidebar/AddWorktreeDialog.tsx
+++ b/src/renderer/src/components/sidebar/AddWorktreeDialog.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback, useMemo, useRef } from 'react'
+import { toast } from 'sonner'
 import { useAppStore } from '@/store'
 import {
   Dialog,
@@ -50,6 +51,7 @@ const AddWorktreeDialog = React.memo(function AddWorktreeDialog() {
   const [name, setName] = useState('')
   const [linkedIssue, setLinkedIssue] = useState('')
   const [comment, setComment] = useState('')
+  const [createError, setCreateError] = useState<string | null>(null)
   const [creating, setCreating] = useState(false)
   const nameInputRef = useRef<HTMLInputElement>(null)
   const lastSuggestedNameRef = useRef('')
@@ -110,10 +112,13 @@ const AddWorktreeDialog = React.memo(function AddWorktreeDialog() {
     if (!repoId || !name.trim()) {
       return
     }
+    setCreateError(null)
     setCreating(true)
     try {
       const wt = await createWorktree(repoId, name.trim())
-      if (wt) {
+      // Meta update is best-effort — the worktree already exists, so don't
+      // block the success path if only the metadata write fails.
+      try {
         const metaUpdates: Record<string, unknown> = {}
         if (linkedIssue.trim()) {
           const linkedIssueNumber = parseGitHubIssueOrPRNumber(linkedIssue)
@@ -127,24 +132,30 @@ const AddWorktreeDialog = React.memo(function AddWorktreeDialog() {
         if (Object.keys(metaUpdates).length > 0) {
           await updateWorktreeMeta(wt.id, metaUpdates as { linkedIssue?: number; comment?: string })
         }
+      } catch {
+        console.error('Failed to update worktree meta after creation')
+      }
 
-        setActiveRepo(repoId)
-        setActiveView('terminal')
-        setSidebarOpen(true)
-        if (searchQuery) {
-          setSearchQuery('')
-        }
-        if (filterRepoIds.length > 0 && !filterRepoIds.includes(repoId)) {
-          setFilterRepoIds([])
-        }
-        setActiveWorktree(wt.id)
-        revealWorktreeInSidebar(wt.id)
-        if (settings?.rightSidebarOpenByDefault) {
-          setRightSidebarTab('explorer')
-          setRightSidebarOpen(true)
-        }
+      setActiveRepo(repoId)
+      setActiveView('terminal')
+      setSidebarOpen(true)
+      if (searchQuery) {
+        setSearchQuery('')
+      }
+      if (filterRepoIds.length > 0 && !filterRepoIds.includes(repoId)) {
+        setFilterRepoIds([])
+      }
+      setActiveWorktree(wt.id)
+      revealWorktreeInSidebar(wt.id)
+      if (settings?.rightSidebarOpenByDefault) {
+        setRightSidebarTab('explorer')
+        setRightSidebarOpen(true)
       }
       handleOpenChange(false)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to create worktree.'
+      setCreateError(message)
+      toast.error(message)
     } finally {
       setCreating(false)
     }
@@ -170,6 +181,26 @@ const AddWorktreeDialog = React.memo(function AddWorktreeDialog() {
     handleOpenChange
   ])
 
+  const handleNameChange = useCallback(
+    (value: string) => {
+      setName(value)
+      if (createError) {
+        setCreateError(null)
+      }
+    },
+    [createError]
+  )
+
+  const handleRepoChange = useCallback(
+    (value: string) => {
+      setRepoId(value)
+      if (createError) {
+        setCreateError(null)
+      }
+    },
+    [createError]
+  )
+
   // Auto-select repo when opening.
   React.useEffect(() => {
     if (resetTimeoutRef.current !== null) {
@@ -186,6 +217,7 @@ const AddWorktreeDialog = React.memo(function AddWorktreeDialog() {
       setName('')
       setLinkedIssue('')
       setComment('')
+      setCreateError(null)
       lastSuggestedNameRef.current = ''
       resetTimeoutRef.current = null
     }, DIALOG_CLOSE_RESET_DELAY_MS)
@@ -236,7 +268,7 @@ const AddWorktreeDialog = React.memo(function AddWorktreeDialog() {
         <DialogHeader>
           <DialogTitle className="text-sm">New Worktree</DialogTitle>
           <DialogDescription className="text-xs">
-            Create a new git worktree. The branch name will inherit from the name you provide.
+            Create a new git worktree on a fresh branch cut from the selected base ref.
           </DialogDescription>
         </DialogHeader>
 
@@ -244,7 +276,7 @@ const AddWorktreeDialog = React.memo(function AddWorktreeDialog() {
           {/* Repo selector */}
           <div className="space-y-1">
             <label className="text-[11px] font-medium text-muted-foreground">Repository</label>
-            <Select value={repoId} onValueChange={setRepoId}>
+            <Select value={repoId} onValueChange={handleRepoChange}>
               <SelectTrigger className="h-8 text-xs w-full">
                 <SelectValue placeholder="Select repo...">
                   {selectedRepo ? (
@@ -272,11 +304,12 @@ const AddWorktreeDialog = React.memo(function AddWorktreeDialog() {
             <Input
               ref={nameInputRef}
               value={name}
-              onChange={(e) => setName(e.target.value)}
+              onChange={(e) => handleNameChange(e.target.value)}
               placeholder="feature/my-feature"
               className="h-8 text-xs"
               autoFocus
             />
+            {createError && <p className="text-[10px] text-destructive">{createError}</p>}
           </div>
 
           {/* Link GH Issue */}

--- a/src/renderer/src/store/slices/worktree-helpers.ts
+++ b/src/renderer/src/store/slices/worktree-helpers.ts
@@ -19,7 +19,7 @@ export type WorktreeSlice = {
   sortEpoch: number
   fetchWorktrees: (repoId: string) => Promise<void>
   fetchAllWorktrees: () => Promise<void>
-  createWorktree: (repoId: string, name: string, baseBranch?: string) => Promise<Worktree | null>
+  createWorktree: (repoId: string, name: string, baseBranch?: string) => Promise<Worktree>
   removeWorktree: (
     worktreeId: string,
     force?: boolean

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -44,7 +44,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       return worktree
     } catch (err) {
       console.error('Failed to create worktree:', err)
-      return null
+      throw err
     }
   },
 


### PR DESCRIPTION
## Problem

When creating a new worktree with a computed branch name, if that branch name had been used before (e.g., a PR was created and merged), the UI would immediately inherit the stale PR status. This happened because the UI resolves PR state by branch name alone, without checking if the PR is actually active or has been closed/merged.

Additionally, the old code would silently suffix the branch name if it already existed locally, which violated the principle of "no silent renames" and could cause confusing behavior.

## Solution

- **Branch conflict detection**: Check if the branch name already exists locally, remotely, or in PR history before allowing creation. If any conflict is found, reject the worktree creation with a clear error message.
  - Local check: `git show-ref refs/heads/<name>`
  - Remote check: `git for-each-ref refs/remotes/` with proper path parsing
  - PR history check: `getPRForBranch()` with graceful fallback on API failures

- **Error handling improvements**:
  - Wrap `getPRForBranch` in try/catch so GitHub API outages don't block worktree creation
  - Fix remote branch name matching to use full path comparison (refs/remotes/<remote>/<branch>) instead of suffix matching, preventing false positives for branch names with `/` separators
  - Wrap `updateWorktreeMeta` in try/catch so meta-update failures don't trap the dialog in an error state for an already-created worktree

- **UI feedback**: Display inline error messages when branch creation fails, allowing users to pick a different name.

## Testing

- Unit tests added for `getBranchConflictKind()` covering local, remote, and no-conflict scenarios
- Dialog component now handles and displays creation errors inline