### PR TITLE
feat: change default divider thickness to 3px

### DIFF
--- a/src/renderer/src/components/settings/TerminalThemePreview.tsx
+++ b/src/renderer/src/components/settings/TerminalThemePreview.tsx
@@ -14,7 +14,7 @@ export function TerminalThemePreview({
   title,
   description,
   appearance,
-  dividerThicknessPx = 1,
+  dividerThicknessPx = 3,
   inactivePaneOpacity = 0.9,
   activePaneOpacity = 1
 }: TerminalThemePreviewProps): React.JSX.Element {

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -50,7 +50,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     terminalInactivePaneOpacity: 0.8,
     terminalActivePaneOpacity: 1,
     terminalPaneOpacityTransitionMs: 140,
-    terminalDividerThicknessPx: 1,
+    terminalDividerThicknessPx: 3,
     terminalScrollbackBytes: 10_000_000,
     rightSidebarOpenByDefault: true
   }


### PR DESCRIPTION
## Summary
- Changes the default pane divider thickness from 1px to 3px for first-time users
- Updates the `TerminalThemePreview` component fallback to match the new default
- Existing users who have already customized the setting are unaffected

## Test plan
- [ ] Verify a fresh install shows 3px divider thickness
- [ ] Verify existing users with custom settings retain their preference
- [ ] Check the settings preview reflects the correct default thickness