### PR TITLE
fix: stabilize search result editor reveal

### DIFF
--- a/src/renderer/src/components/editor/EditorContent.tsx
+++ b/src/renderer/src/components/editor/EditorContent.tsx
@@ -44,7 +44,12 @@ export function EditorContent({
   isMarkdown: boolean
   mdViewMode: MarkdownViewMode
   sideBySide: boolean
-  pendingEditorReveal: { line?: number; column?: number; matchLength?: number } | null
+  pendingEditorReveal: {
+    filePath?: string
+    line?: number
+    column?: number
+    matchLength?: number
+  } | null
   handleContentChange: (content: string) => void
   handleSave: (content: string) => Promise<void>
 }): React.JSX.Element {
@@ -69,9 +74,19 @@ export function EditorContent({
       language={resolvedLanguage}
       onContentChange={handleContentChange}
       onSave={handleSave}
-      revealLine={pendingEditorReveal?.line}
-      revealColumn={pendingEditorReveal?.column}
-      revealMatchLength={pendingEditorReveal?.matchLength}
+      revealLine={
+        pendingEditorReveal?.filePath === activeFile.filePath ? pendingEditorReveal.line : undefined
+      }
+      revealColumn={
+        pendingEditorReveal?.filePath === activeFile.filePath
+          ? pendingEditorReveal.column
+          : undefined
+      }
+      revealMatchLength={
+        pendingEditorReveal?.filePath === activeFile.filePath
+          ? pendingEditorReveal.matchLength
+          : undefined
+      }
     />
   )
 

--- a/src/renderer/src/components/editor/MonacoEditor.tsx
+++ b/src/renderer/src/components/editor/MonacoEditor.tsx
@@ -85,7 +85,10 @@ export default function MonacoEditor({
 
       // If there's a pending reveal at mount time, execute it now
       const reveal = useAppStore.getState().pendingEditorReveal
-      if (reveal) {
+      // Why: search-result navigation sets the reveal before openFile switches
+      // the active tab. Without scoping consumption to the destination file,
+      // the previously mounted editor can clear the reveal on the first click.
+      if (reveal?.filePath === filePath) {
         performReveal(editorInstance, reveal.line, reveal.column, reveal.matchLength)
         useAppStore.getState().setPendingEditorReveal(null)
       } else {

--- a/src/renderer/src/components/right-sidebar/Search.tsx
+++ b/src/renderer/src/components/right-sidebar/Search.tsx
@@ -11,10 +11,10 @@ import {
   Loader2
 } from 'lucide-react'
 import { useAppStore } from '@/store'
-import { detectLanguage } from '@/lib/language-detect'
 import { Button } from '@/components/ui/button'
 import type { SearchFileResult, SearchMatch } from '../../../../shared/types'
 import { buildSearchRows } from './search-rows'
+import { cancelRevealFrame, openMatchResult } from './search-match-open'
 import { ToggleButton, FileResultRow, MatchResultRow } from './SearchResultItems'
 
 const SEARCH_DEBOUNCE_MS = 300
@@ -53,6 +53,8 @@ export default function Search(): React.JSX.Element {
   const searchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const latestSearchIdRef = useRef(0)
   const resultsScrollRef = useRef<HTMLDivElement>(null)
+  const revealRafRef = useRef<number | null>(null)
+  const revealInnerRafRef = useRef<number | null>(null)
 
   const cancelPendingSearch = useCallback(() => {
     latestSearchIdRef.current += 1
@@ -86,6 +88,8 @@ export default function Search(): React.JSX.Element {
   useEffect(() => {
     return () => {
       cancelPendingSearch()
+      cancelRevealFrame(revealRafRef)
+      cancelRevealFrame(revealInnerRafRef)
     }
   }, [cancelPendingSearch])
 
@@ -233,20 +237,14 @@ export default function Search(): React.JSX.Element {
       if (!activeWorktreeId) {
         return
       }
-
-      // Set pending navigation so editor scrolls to the match
-      setPendingEditorReveal({
-        line: match.line,
-        column: match.column,
-        matchLength: match.matchLength
-      })
-
-      openFile({
-        filePath: fileResult.filePath,
-        relativePath: fileResult.relativePath,
-        worktreeId: activeWorktreeId,
-        language: detectLanguage(fileResult.relativePath),
-        mode: 'edit'
+      openMatchResult({
+        activeWorktreeId,
+        fileResult,
+        match,
+        openFile,
+        setPendingEditorReveal,
+        revealRafRef,
+        revealInnerRafRef
       })
     },
     [activeWorktreeId, openFile, setPendingEditorReveal]

--- a/src/renderer/src/components/right-sidebar/SearchResultItems.tsx
+++ b/src/renderer/src/components/right-sidebar/SearchResultItems.tsx
@@ -132,6 +132,14 @@ export function MatchResultRow({
           type="button"
           variant="ghost"
           className="min-h-[18px] h-auto w-full justify-start gap-1 rounded-none py-px pr-2 pl-7 text-left"
+          onMouseDown={(event) => {
+            // Why: clicking a result should move focus into the opened editor.
+            // If the sidebar button takes focus first, the browser can restore
+            // it after the click and make the initial reveal feel flaky.
+            if (event.button === 0) {
+              event.preventDefault()
+            }
+          }}
           onClick={onClick}
         >
           <span className="text-[10px] text-muted-foreground flex-shrink-0 w-8 text-right tabular-nums mt-px">

--- a/src/renderer/src/components/right-sidebar/search-match-open.ts
+++ b/src/renderer/src/components/right-sidebar/search-match-open.ts
@@ -1,0 +1,70 @@
+import { detectLanguage } from '@/lib/language-detect'
+import type { SearchFileResult, SearchMatch } from '../../../../shared/types'
+
+export function cancelRevealFrame(frameRef: React.RefObject<number | null>): void {
+  if (frameRef.current !== null) {
+    cancelAnimationFrame(frameRef.current)
+    frameRef.current = null
+  }
+}
+
+export function openMatchResult(params: {
+  activeWorktreeId: string
+  fileResult: SearchFileResult
+  match: SearchMatch
+  openFile: (file: {
+    filePath: string
+    relativePath: string
+    worktreeId: string
+    language: string
+    mode: 'edit'
+  }) => void
+  setPendingEditorReveal: (
+    reveal: {
+      filePath: string
+      line: number
+      column: number
+      matchLength: number
+    } | null
+  ) => void
+  revealRafRef: React.RefObject<number | null>
+  revealInnerRafRef: React.RefObject<number | null>
+}): void {
+  const {
+    activeWorktreeId,
+    fileResult,
+    match,
+    openFile,
+    setPendingEditorReveal,
+    revealRafRef,
+    revealInnerRafRef
+  } = params
+
+  openFile({
+    filePath: fileResult.filePath,
+    relativePath: fileResult.relativePath,
+    worktreeId: activeWorktreeId,
+    language: detectLanguage(fileResult.relativePath),
+    mode: 'edit'
+  })
+
+  cancelRevealFrame(revealRafRef)
+  cancelRevealFrame(revealInnerRafRef)
+  setPendingEditorReveal(null)
+
+  // Why: opening a result can replace the active tab and mount Monaco
+  // asynchronously. Matching terminal-link navigation, wait two frames so
+  // the destination editor owns focus/layout before we ask it to reveal.
+  revealRafRef.current = requestAnimationFrame(() => {
+    revealInnerRafRef.current = requestAnimationFrame(() => {
+      setPendingEditorReveal({
+        filePath: fileResult.filePath,
+        line: match.line,
+        column: match.column,
+        matchLength: match.matchLength
+      })
+      cancelRevealFrame(revealRafRef)
+      cancelRevealFrame(revealInnerRafRef)
+    })
+  })
+}

--- a/src/renderer/src/store/slices/editor.test.ts
+++ b/src/renderer/src/store/slices/editor.test.ts
@@ -125,6 +125,49 @@ describe('createEditorSlice markdown preview state', () => {
   })
 })
 
+describe('createEditorSlice pending editor reveal', () => {
+  it('stores the destination file path with the reveal payload', () => {
+    const store = createEditorStore()
+
+    store.getState().setPendingEditorReveal({
+      filePath: '/repo/src/file.ts',
+      line: 42,
+      column: 7,
+      matchLength: 5
+    })
+
+    expect(store.getState().pendingEditorReveal).toEqual({
+      filePath: '/repo/src/file.ts',
+      line: 42,
+      column: 7,
+      matchLength: 5
+    })
+  })
+
+  it('clears pending reveal when closing all files in the active worktree', () => {
+    const store = createEditorStore()
+
+    store.getState().openFile({
+      filePath: '/repo/src/file.ts',
+      relativePath: 'src/file.ts',
+      worktreeId: 'wt-1',
+      language: 'typescript',
+      mode: 'edit'
+    })
+    store.getState().setPendingEditorReveal({
+      filePath: '/repo/src/file.ts',
+      line: 42,
+      column: 7,
+      matchLength: 5
+    })
+
+    store.getState().closeAllFiles()
+
+    expect(store.getState().openFiles).toEqual([])
+    expect(store.getState().pendingEditorReveal).toBeNull()
+  })
+})
+
 describe('createEditorSlice conflict status reconciliation', () => {
   it('tracks unresolved conflicts when opened through the conflict-safe entry point', () => {
     const store = createEditorStore()

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -217,9 +217,14 @@ export type EditorSlice = {
   clearFileSearch: () => void
 
   // Editor navigation (for search result → go-to-line)
-  pendingEditorReveal: { line: number; column: number; matchLength: number } | null
+  pendingEditorReveal: {
+    filePath: string
+    line: number
+    column: number
+    matchLength: number
+  } | null
   setPendingEditorReveal: (
-    reveal: { line: number; column: number; matchLength: number } | null
+    reveal: { filePath: string; line: number; column: number; matchLength: number } | null
   ) => void
 
   // Quick open (Cmd+P)
@@ -454,7 +459,8 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
           openFiles: [],
           activeFileId: null,
           activeTabType: 'terminal',
-          markdownViewMode: {}
+          markdownViewMode: {},
+          pendingEditorReveal: null
         }
       }
       // Only close files for the current worktree
@@ -473,7 +479,12 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
         activeTabType: 'terminal',
         markdownViewMode: newMarkdownViewMode,
         activeFileIdByWorktree: newActiveFileIdByWorktree,
-        activeTabTypeByWorktree: newActiveTabTypeByWorktree
+        activeTabTypeByWorktree: newActiveTabTypeByWorktree,
+        // Why: search-result navigation queues a one-shot reveal for the next
+        // editor mount. If the worktree closes all editor tabs before that
+        // reveal is consumed, keeping it around would make a later reopen jump
+        // to an old match unexpectedly.
+        pendingEditorReveal: null
       }
     }),
 


### PR DESCRIPTION
## Problem
Search result navigation could consume the pending reveal in the wrong editor tab, which made the first click flaky and could leave stale reveal state behind after tabs were closed.

## Solution
Scope pending reveal state to the destination file, defer applying the reveal until the target Monaco editor is mounted, preserve editor focus when clicking results, and clear stale reveal state when closing all files. Added regression coverage for the reveal store behavior.