### PR TITLE
fix: accurate rebase status detection and continuous status polling

### DIFF
--- a/src/main/git/status.test.ts
+++ b/src/main/git/status.test.ts
@@ -25,7 +25,14 @@ vi.mock('fs', () => ({
   existsSync: existsSyncMock
 }))
 
-import { discardChanges, getBranchCompare, getDiff, getStatus, isWithinWorktree } from './status'
+import {
+  detectConflictOperation,
+  discardChanges,
+  getBranchCompare,
+  getDiff,
+  getStatus,
+  isWithinWorktree
+} from './status'
 
 describe('discardChanges', () => {
   beforeEach(() => {
@@ -233,6 +240,39 @@ describe('getStatus', () => {
 
     expect(result.entries[0]?.status).toBe('modified')
     expect(result.entries[0]?.conflictKind).toBe('added_by_us')
+  })
+})
+
+describe('detectConflictOperation', () => {
+  beforeEach(() => {
+    readFileMock.mockReset()
+    existsSyncMock.mockReset()
+  })
+
+  it('ignores a stale REBASE_HEAD when no rebase directory exists', async () => {
+    readFileMock.mockResolvedValue('gitdir: /repo/.git/worktrees/feature\n')
+    existsSyncMock.mockImplementation((target: string) => {
+      if (target.endsWith('MERGE_HEAD')) {
+        return false
+      }
+      if (target.endsWith('CHERRY_PICK_HEAD')) {
+        return false
+      }
+      if (target.endsWith('rebase-merge')) {
+        return false
+      }
+      if (target.endsWith('rebase-apply')) {
+        return false
+      }
+      if (target.endsWith('REBASE_HEAD')) {
+        return true
+      }
+      return false
+    })
+
+    const result = await detectConflictOperation('/repo')
+
+    expect(result).toBe('unknown')
   })
 })
 

--- a/src/main/git/status.ts
+++ b/src/main/git/status.ts
@@ -231,28 +231,24 @@ async function getConflictCompatibilityStatus(
 // one poll cycle, which is acceptable. The renderer uses this to label the
 // merge summary ("Merge conflicts" vs "Rebase conflicts" vs generic "Conflicts").
 //
-// Why we also check rebase-merge/ and rebase-apply/ directories: during a
-// rebase, REBASE_HEAD only exists when the *current* step has a conflict.
-// Between steps (or after resolving and before `git rebase --continue`), the
-// rebase is still in progress but REBASE_HEAD is absent. The rebase-merge/ or
-// rebase-apply/ directory persists for the entire rebase, so checking it
-// catches the "rebase in progress, no conflicts on current step" case.
+// Why rebase detection relies on rebase-merge/ or rebase-apply/ directories
+// instead of REBASE_HEAD: those directories persist for the entire rebase, so
+// they cover both conflicting and non-conflicting steps. REBASE_HEAD, by
+// contrast, only exists on some steps and can also be left behind after a
+// completed rebase, which would make the UI show a stale "Rebasing" badge.
 export async function detectConflictOperation(worktreePath: string): Promise<GitConflictOperation> {
   const gitDir = await resolveGitDir(worktreePath)
   const mergeHead = path.join(gitDir, 'MERGE_HEAD')
-  const rebaseHead = path.join(gitDir, 'REBASE_HEAD')
   const cherryPickHead = path.join(gitDir, 'CHERRY_PICK_HEAD')
   const rebaseMergeDir = path.join(gitDir, 'rebase-merge')
   const rebaseApplyDir = path.join(gitDir, 'rebase-apply')
 
   let hasMergeHead = false
-  let hasRebaseHead = false
   let hasCherryPickHead = false
   let hasRebaseDir = false
 
   try {
     hasMergeHead = existsSync(mergeHead)
-    hasRebaseHead = existsSync(rebaseHead)
     hasCherryPickHead = existsSync(cherryPickHead)
     hasRebaseDir = existsSync(rebaseMergeDir) || existsSync(rebaseApplyDir)
   } catch {
@@ -262,7 +258,7 @@ export async function detectConflictOperation(worktreePath: string): Promise<Git
   if (hasMergeHead) {
     return 'merge'
   }
-  if (hasRebaseHead || hasRebaseDir) {
+  if (hasRebaseDir) {
     return 'rebase'
   }
   if (hasCherryPickHead) {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -14,6 +14,7 @@ import Landing from './components/Landing'
 import Settings from './components/settings/Settings'
 import RightSidebar from './components/right-sidebar'
 import QuickOpen from './components/QuickOpen'
+import { useGitStatusPolling } from './components/right-sidebar/useGitStatusPolling'
 
 function isEditableTarget(target: EventTarget | null): boolean {
   if (!(target instanceof HTMLElement)) {
@@ -73,6 +74,11 @@ function App(): React.JSX.Element {
 
   // Subscribe to IPC push events
   useIpcEvents()
+  // Why: git conflict-operation state also drives the worktree cards. Polling
+  // cannot live under RightSidebar because App unmounts that subtree when the
+  // sidebar is closed, which leaves stale "Rebasing"/"Merging" badges behind
+  // until some unrelated view remount happens to refresh them.
+  useGitStatusPolling()
 
   const settings = useAppStore((s) => s.settings)
 

--- a/src/renderer/src/components/right-sidebar/index.tsx
+++ b/src/renderer/src/components/right-sidebar/index.tsx
@@ -17,7 +17,6 @@ import FileExplorer from './FileExplorer'
 import SourceControl from './SourceControl'
 import SearchPanel from './Search'
 import ChecksPanel from './ChecksPanel'
-import { useGitStatusPolling } from './useGitStatusPolling'
 
 const MIN_WIDTH = 220
 const MAX_WIDTH = 500
@@ -113,8 +112,6 @@ export default function RightSidebar(): React.JSX.Element {
   const checksStatus = useAppStore(getActiveChecksStatus)
   const activityBarPosition = useAppStore((s) => s.activityBarPosition)
   const setActivityBarPosition = useAppStore((s) => s.setActivityBarPosition)
-
-  useGitStatusPolling()
 
   // ─── Resize logic (handle on LEFT edge) ────────────
   const isResizing = useRef(false)


### PR DESCRIPTION
## Problem
During rebasing, the UI sometimes leaves stale 'Rebasing' badges behind because it relies on checking `REBASE_HEAD` which is only present during conflicting steps of a rebase, and can sometimes be left behind even after the rebase finishes. Additionally, when the right sidebar is unmounted, worktree git status stops polling, preventing worktree cards from updating their states correctly.

## Solution
1. Changed rebase detection to exclusively check for `rebase-merge/` or `rebase-apply/` directories, which exist for the entire duration of a rebase operation.
2. Moved the `useGitStatusPolling()` hook from `RightSidebar` up to `App.tsx` so it can continue to poll in the background even when the sidebar is closed.