### PR TITLE
fix: restore markdown source editor layout

### DIFF
--- a/src/renderer/src/components/editor/EditorContent.tsx
+++ b/src/renderer/src/components/editor/EditorContent.tsx
@@ -128,7 +128,11 @@ export function EditorContent({
       )
     }
 
-    return <div className="min-h-0 flex-1">{renderMonacoEditor(fc)}</div>
+    // Why: Monaco sizes itself against the immediate parent when `height="100%"`
+    // is used. Markdown source mode briefly wrapped it in a non-flex container
+    // with no explicit height, which made the code surface collapse even though
+    // the surrounding editor pane was tall enough.
+    return <div className="h-full min-h-0">{renderMonacoEditor(fc)}</div>
   }
 
   if (activeFile.mode === 'conflict-review') {


### PR DESCRIPTION
## Problem
Markdown files opened in source mode could render a collapsed Monaco surface because the immediate wrapper around the editor did not provide a real height. Monaco uses `height="100%"`, so the markdown source view ended up with a blank or nearly blank code area.

## Solution
Give the markdown source-mode Monaco wrapper an explicit full-height container instead of a flex-only sizing class that only works inside a flex parent. This restores the expected editor height without affecting markdown preview or rich mode.
