### PR TITLE
Normalize Orca worktree branch selectors

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -179,6 +179,26 @@ describe('OrcaRuntimeService', () => {
     expect(shown.ptyId).toBe('pty-1')
   })
 
+  it('resolves branch selectors when worktrees store refs/heads-prefixed branches', async () => {
+    vi.mocked(listWorktrees).mockResolvedValueOnce([
+      {
+        path: '/tmp/worktree-a',
+        head: 'abc',
+        branch: 'refs/heads/Jinwoo-H/test-3a',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+
+    const runtime = new OrcaRuntimeService(store)
+
+    const worktree = await runtime.showManagedWorktree('branch:Jinwoo-H/test-3a')
+    expect(worktree).toMatchObject({
+      branch: 'refs/heads/Jinwoo-H/test-3a',
+      path: '/tmp/worktree-a'
+    })
+  })
+
   it('reads bounded terminal output and writes through the PTY controller', async () => {
     const writes: string[] = []
     const runtime = new OrcaRuntimeService(store)

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -781,7 +781,10 @@ export class OrcaRuntimeService {
     } else if (selector.startsWith('path:')) {
       candidates = worktrees.filter((worktree) => worktree.path === selector.slice(5))
     } else if (selector.startsWith('branch:')) {
-      candidates = worktrees.filter((worktree) => worktree.branch === selector.slice(7))
+      const branchSelector = selector.slice(7)
+      candidates = worktrees.filter((worktree) =>
+        branchSelectorMatches(worktree.branch, branchSelector)
+      )
     } else if (selector.startsWith('issue:')) {
       candidates = worktrees.filter(
         (worktree) =>
@@ -790,7 +793,9 @@ export class OrcaRuntimeService {
     } else {
       candidates = worktrees.filter(
         (worktree) =>
-          worktree.id === selector || worktree.path === selector || worktree.branch === selector
+          worktree.id === selector ||
+          worktree.path === selector ||
+          branchSelectorMatches(worktree.branch, selector)
       )
     }
 
@@ -1127,6 +1132,18 @@ function buildTerminalWaitResult(handle: string, leaf: RuntimeLeafRecord): Runti
     status: getTerminalState(leaf),
     exitCode: leaf.lastExitCode
   }
+}
+
+function branchSelectorMatches(branch: string, selector: string): boolean {
+  // Why: Git worktree data can report local branches as either `refs/heads/foo`
+  // or `foo` depending on which plumbing path produced the record. Orca's
+  // branch selectors should accept either form so newly created worktrees stay
+  // discoverable without exposing internal ref-shape differences to users.
+  return normalizeBranchRef(branch) === normalizeBranchRef(selector)
+}
+
+function normalizeBranchRef(branch: string): string {
+  return branch.startsWith('refs/heads/') ? branch.slice('refs/heads/'.length) : branch
 }
 
 function normalizeTerminalChunk(chunk: string): string {


### PR DESCRIPTION
## Summary
- normalize worktree branch selector matching so  resolves worktrees stored as 
- keep freshly created Orca worktrees discoverable through 
- add a regression test for refs-prefixed branch records

## Validation
- pnpm exec vitest run src/main/runtime/orca-runtime.test.ts
- pnpm exec tsc --noEmit -p tsconfig.node.json --composite false