### PR TITLE
Fix Windows packaged Orca CLI launcher path resolution

### DIFF
--- a/resources/win32/bin/orca.cmd
+++ b/resources/win32/bin/orca.cmd
@@ -2,7 +2,11 @@
 setlocal
 set "SCRIPT_DIR=%~dp0"
 for %%I in ("%SCRIPT_DIR%..") do set "RESOURCES_DIR=%%~fI"
-for %%I in ("%RESOURCES_DIR%..") do set "APP_DIR=%%~fI"
+REM Why: once %%~fI canonicalizes RESOURCES_DIR it no longer ends with a slash,
+REM so Windows batch needs an explicit "\.." segment here. Without it the CLI
+REM launcher resolves APP_DIR back to resources/ and `orca open` cannot find
+REM Orca.exe on packaged Windows installs.
+for %%I in ("%RESOURCES_DIR%\..") do set "APP_DIR=%%~fI"
 set "ELECTRON=%APP_DIR%\Orca.exe"
 
 if not exist "%ELECTRON%" (

--- a/src/main/cli/windows-launcher-asset.test.ts
+++ b/src/main/cli/windows-launcher-asset.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from 'fs'
+import { join } from 'path'
+import { describe, expect, it } from 'vitest'
+
+describe('packaged Windows CLI launcher asset', () => {
+  it('walks from resources/bin back to the app root before locating Orca.exe', () => {
+    const launcherPath = join(process.cwd(), 'resources', 'win32', 'bin', 'orca.cmd')
+    const launcher = readFileSync(launcherPath, 'utf8')
+
+    expect(launcher).toContain('for %%I in ("%RESOURCES_DIR%\\..") do set "APP_DIR=%%~fI"')
+    expect(launcher).not.toContain('for %%I in ("%RESOURCES_DIR%..") do set "APP_DIR=%%~fI"')
+  })
+})


### PR DESCRIPTION
## Summary
- fix the packaged Windows esources/bin/orca.cmd launcher so it resolves the app root correctly before locating Orca.exe
- add a regression test that asserts the shipped Windows launcher asset walks from esources/bin back to the app root

## Validation
- reproduced the installed-launcher failure locally on Windows (Unable to locate Orca.exe next to ...\\resources)
- verified the corrected batch logic resolves APP_DIR to the Orca install root and finds Orca.exe
- pnpm vitest run src/main/cli/windows-launcher-asset.test.ts
- pnpm lint
- pnpm typecheck

## Manual verification
- patched the installed launcher locally to confirm the fix against the real orca command
- after the patch, orca open, orca status --json, orca repo list --json, and orca worktree ps --json all worked on Windows