### PR TITLE
Remove delete confirmation for untracked files

### DIFF
--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -970,12 +970,6 @@ function UncommittedEntryRow({
               title={entry.area === 'untracked' ? 'Revert untracked file' : 'Discard changes'}
               onClick={(event) => {
                 event.stopPropagation()
-                if (
-                  entry.area === 'untracked' &&
-                  !window.confirm(`Delete untracked file "${entry.path}"? This cannot be undone.`)
-                ) {
-                  return
-                }
                 void onDiscard()
               }}
             />


### PR DESCRIPTION
## Summary
- Remove the `window.confirm` dialog that asked "Delete untracked file X? This cannot be undone." when discarding untracked files in Source Control
- Discarding untracked files now behaves the same as discarding tracked file changes — immediate action without a confirmation prompt

## Test plan
- [ ] Open Source Control sidebar with an untracked file
- [ ] Click the discard (revert) button on the untracked file
- [ ] Verify file is deleted immediately without a confirmation dialog
- [ ] Verify discarding tracked file changes still works as before