### PR TITLE
Fix new file and folder creation UX

### DIFF
--- a/src/main/ipc/filesystem-mutations.test.ts
+++ b/src/main/ipc/filesystem-mutations.test.ts
@@ -89,7 +89,7 @@ describe('registerFilesystemMutationHandlers', () => {
 
     await expect(
       handlers.get('fs:createFile')!(null, { filePath: '/workspace/repo/existing.ts' })
-    ).rejects.toThrow('EEXIST')
+    ).rejects.toThrow("A file or folder named 'existing.ts' already exists in this location")
   })
 
   it('rejects file creation outside allowed roots', async () => {
@@ -117,7 +117,7 @@ describe('registerFilesystemMutationHandlers', () => {
 
     await expect(
       handlers.get('fs:createDir')!(null, { dirPath: '/workspace/repo/src' })
-    ).rejects.toThrow('A file or folder already exists at this path')
+    ).rejects.toThrow("A file or folder named 'src' already exists in this location")
 
     expect(mkdirMock).not.toHaveBeenCalled()
   })
@@ -158,7 +158,7 @@ describe('registerFilesystemMutationHandlers', () => {
         oldPath: '/workspace/repo/old.ts',
         newPath: '/workspace/repo/new.ts'
       })
-    ).rejects.toThrow('A file or folder already exists at this path')
+    ).rejects.toThrow("A file or folder named 'new.ts' already exists in this location")
 
     expect(renameMock).not.toHaveBeenCalled()
   })

--- a/src/main/ipc/filesystem-mutations.ts
+++ b/src/main/ipc/filesystem-mutations.ts
@@ -1,8 +1,27 @@
 import { ipcMain } from 'electron'
 import { lstat, mkdir, rename, writeFile } from 'fs/promises'
-import { dirname } from 'path'
+import { basename, dirname } from 'path'
 import type { Store } from '../persistence'
 import { resolveAuthorizedPath, isENOENT } from './filesystem-auth'
+
+/**
+ * Re-throw filesystem errors with user-friendly messages.
+ * The `wx` flag on writeFile throws a raw EEXIST with no helpful message,
+ * so we catch it here and provide context the renderer can display directly.
+ */
+function rethrowWithUserMessage(error: unknown, targetPath: string): never {
+  const name = basename(targetPath)
+  if (error instanceof Error && 'code' in error) {
+    const code = (error as NodeJS.ErrnoException).code
+    if (code === 'EEXIST') {
+      throw new Error(`A file or folder named '${name}' already exists in this location`)
+    }
+    if (code === 'EACCES' || code === 'EPERM') {
+      throw new Error(`Permission denied: unable to create '${name}'`)
+    }
+  }
+  throw error
+}
 
 /**
  * Ensure `targetPath` does not already exist. Throws if it does.
@@ -15,7 +34,9 @@ import { resolveAuthorizedPath, isENOENT } from './filesystem-auth'
 async function assertNotExists(targetPath: string): Promise<void> {
   try {
     await lstat(targetPath)
-    throw new Error('A file or folder already exists at this path')
+    throw new Error(
+      `A file or folder named '${basename(targetPath)}' already exists in this location`
+    )
   } catch (error) {
     if (!isENOENT(error)) {
       throw error
@@ -31,8 +52,12 @@ export function registerFilesystemMutationHandlers(store: Store): void {
   ipcMain.handle('fs:createFile', async (_event, args: { filePath: string }): Promise<void> => {
     const filePath = await resolveAuthorizedPath(args.filePath, store)
     await mkdir(dirname(filePath), { recursive: true })
-    // Use the 'wx' flag for atomic create-if-not-exists, avoiding TOCTOU races
-    await writeFile(filePath, '', { encoding: 'utf-8', flag: 'wx' })
+    try {
+      // Use the 'wx' flag for atomic create-if-not-exists, avoiding TOCTOU races
+      await writeFile(filePath, '', { encoding: 'utf-8', flag: 'wx' })
+    } catch (error) {
+      rethrowWithUserMessage(error, filePath)
+    }
   })
 
   ipcMain.handle('fs:createDir', async (_event, args: { dirPath: string }): Promise<void> => {

--- a/src/renderer/src/components/right-sidebar/FileExplorer.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorer.tsx
@@ -182,6 +182,16 @@ export default function FileExplorer(): React.JSX.Element {
     virtualizer
   })
 
+  // Scroll the inline input into view so the virtualizer renders it.
+  // Without this, an input created at the end of a long tree (e.g. from
+  // the background context menu) can fall outside the visible + overscan
+  // range and never appear.
+  useEffect(() => {
+    if (inlineInputIndex >= 0) {
+      virtualizer.scrollToIndex(inlineInputIndex, { align: 'auto' })
+    }
+  }, [inlineInputIndex, virtualizer])
+
   const selectedNode = selectedPath ? (rowsByPath.get(selectedPath) ?? null) : null
   useFileExplorerKeys({
     containerRef: scrollRef,

--- a/src/renderer/src/components/right-sidebar/FileExplorerRow.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorerRow.tsx
@@ -50,9 +50,16 @@ export function InlineInputRow({
   const inputRef = useRef<HTMLInputElement>(null)
   const blurTimeout = useRef<ReturnType<typeof setTimeout> | null>(null)
   const submitted = useRef(false)
+  // Grace period flag: when a menu (context or dropdown) closes, its focus
+  // management can momentarily steal focus from this input before the user
+  // has a chance to type. During the grace window we re-focus on blur instead
+  // of auto-submitting, which would dismiss the empty input.
+  const focusSettled = useRef(false)
+  const settleTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {
     submitted.current = false
+    focusSettled.current = false
 
     // Schedule focus after any pending focus-restore from menu close
     const raf = requestAnimationFrame(() => {
@@ -69,11 +76,20 @@ export function InlineInputRow({
           el.select()
         }
       }
+      // Allow enough time for the menu close focus management to finish
+      // before treating blur events as intentional user actions.
+      settleTimer.current = setTimeout(() => {
+        settleTimer.current = null
+        focusSettled.current = true
+      }, 200)
     })
     return () => {
       cancelAnimationFrame(raf)
       if (blurTimeout.current) {
         clearTimeout(blurTimeout.current)
+      }
+      if (settleTimer.current) {
+        clearTimeout(settleTimer.current)
       }
     }
   }, [inlineInput])
@@ -133,6 +149,13 @@ export function InlineInputRow({
             (e.relatedTarget.closest('[data-slot="context-menu-trigger"]') ||
               e.relatedTarget.closest('[data-slot="dropdown-menu-trigger"]'))
           ) {
+            requestAnimationFrame(() => inputRef.current?.focus())
+            return
+          }
+          // During the grace period after mount, menu close focus management
+          // may shift focus away (often relatedTarget is null). Re-focus
+          // instead of dismissing the still-empty input.
+          if (!focusSettled.current) {
             requestAnimationFrame(() => inputRef.current?.focus())
             return
           }

--- a/src/renderer/src/components/right-sidebar/useFileExplorerInlineInput.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerInlineInput.ts
@@ -1,10 +1,24 @@
 import { useCallback, useMemo, useState } from 'react'
 import type React from 'react'
+import { toast } from 'sonner'
 import { useAppStore } from '@/store'
 import { detectLanguage } from '@/lib/language-detect'
 import { dirname, joinPath } from '@/lib/path'
 import type { InlineInput } from './FileExplorerRow'
 import type { TreeNode } from './file-explorer-types'
+
+/**
+ * Electron's ipcRenderer.invoke wraps errors as:
+ *   "Error invoking remote method 'channel': Error: actual message"
+ * Strip the wrapper so users see only the meaningful part.
+ */
+function extractIpcErrorMessage(err: unknown, fallback: string): string {
+  if (!(err instanceof Error)) {
+    return fallback
+  }
+  const match = err.message.match(/Error invoking remote method '[^']*': (?:Error: )?(.+)/)
+  return match ? match[1] : err.message
+}
 
 type UseFileExplorerInlineInputParams = {
   activeWorktreeId: string | null
@@ -113,7 +127,9 @@ export function useFileExplorerInlineInput({
               newPath: joinPath(parentDir, name)
             })
           } catch (err) {
-            console.error('Rename failed:', err)
+            toast.error(
+              extractIpcErrorMessage(err, `Failed to rename '${inlineInput.existingName}'.`)
+            )
           }
           await refreshDir(parentDir)
         } else {
@@ -135,7 +151,7 @@ export function useFileExplorerInlineInput({
           } catch (err) {
             // Refresh the directory even on failure so the tree stays consistent
             await refreshDir(inlineInput.parentPath)
-            console.error('Create failed:', err)
+            toast.error(extractIpcErrorMessage(err, `Failed to create '${name}'.`))
           }
         }
       }


### PR DESCRIPTION
## Problem

When creating new files or folders in the file explorer, users encounter:
1. Confusing, unhelpful error messages (raw EEXIST errors without context)
2. Inline input fields that disappear when opened from context menus in long file trees
3. Silent failures with no feedback to the user

## Solution

- **Backend error handling**: Convert raw filesystem errors (EEXIST, EACCES, EPERM) into user-friendly messages that include the filename (e.g., "A file or folder named 'foo.ts' already exists in this location")
- **Virtual scrolling**: Auto-scroll the virtualizer to keep inline input visible, preventing inputs created at the end of long trees from falling outside the render window
- **Focus grace period**: Add a 200ms grace period after inline input mounts to prevent menu close focus management from unexpectedly stealing focus
- **User feedback**: Show clear error toast notifications instead of logging silently to console