### PR TITLE
fix(ci): improve lint error reporting with github format

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -30,7 +30,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Lint
-        run: pnpm lint
+        run: pnpm exec oxlint --format github
 
       - name: Typecheck
         run: pnpm typecheck


### PR DESCRIPTION
## Summary
- Use `--format github` for oxlint in CI so lint errors include filenames as GitHub annotations
- Previously, errors like "File has too many lines (405)" didn't show which file was broken

## Test plan
- [x] Verified `pnpm exec oxlint --format github` produces `::error file=...` annotations locally