### PR TITLE
Keep Orca runtime metadata owned by the active process

### DIFF
--- a/src/main/runtime/runtime-metadata.test.ts
+++ b/src/main/runtime/runtime-metadata.test.ts
@@ -4,7 +4,6 @@ import { join } from 'path'
 import { afterEach, describe, expect, it } from 'vitest'
 import {
   clearRuntimeMetadata,
-  clearRuntimeMetadataIfOwned,
   getRuntimeMetadataPath,
   readRuntimeMetadata,
   writeRuntimeMetadata
@@ -62,29 +61,6 @@ describe('runtime metadata', () => {
 
     expect(readRuntimeMetadata(userDataPath)).toBeNull()
     expect(getRuntimeMetadataPath(userDataPath)).toContain('orca-runtime.json')
-  })
-
-  it('does not clear runtime metadata owned by another Orca process', () => {
-    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-metadata-'))
-    tempDirs.push(userDataPath)
-
-    writeRuntimeMetadata(userDataPath, {
-      runtimeId: 'rt_live',
-      pid: 42,
-      transport: null,
-      authToken: null,
-      startedAt: 100
-    })
-
-    clearRuntimeMetadataIfOwned(userDataPath, {
-      runtimeId: 'rt_other',
-      pid: 99
-    })
-
-    expect(readRuntimeMetadata(userDataPath)).toMatchObject({
-      runtimeId: 'rt_live',
-      pid: 42
-    })
   })
 
   it.runIf(process.platform !== 'win32')(

--- a/src/main/runtime/runtime-metadata.ts
+++ b/src/main/runtime/runtime-metadata.ts
@@ -23,8 +23,6 @@ export type RuntimeMetadata = {
   startedAt: number
 }
 
-type RuntimeMetadataOwner = Pick<RuntimeMetadata, 'runtimeId' | 'pid'>
-
 const RUNTIME_METADATA_FILE = 'orca-runtime.json'
 let cachedWindowsUserSid: string | null | undefined
 
@@ -62,24 +60,6 @@ export function readRuntimeMetadata(userDataPath: string): RuntimeMetadata | nul
 
 export function clearRuntimeMetadata(userDataPath: string): void {
   rmSync(getRuntimeMetadataPath(userDataPath), { force: true })
-}
-
-export function clearRuntimeMetadataIfOwned(
-  userDataPath: string,
-  owner: RuntimeMetadataOwner
-): void {
-  const current = readRuntimeMetadata(userDataPath)
-  if (!current) {
-    return
-  }
-  // Why: Orca development and packaged builds can briefly overlap on the same
-  // userData directory. Only the process that last published the shared runtime
-  // metadata is allowed to clear it, or one instance can make another healthy
-  // runtime undiscoverable to the CLI while that other app is still running.
-  if (current.runtimeId !== owner.runtimeId || current.pid !== owner.pid) {
-    return
-  }
-  clearRuntimeMetadata(userDataPath)
 }
 
 function hardenRuntimePath(

--- a/src/main/runtime/runtime-rpc.test.ts
+++ b/src/main/runtime/runtime-rpc.test.ts
@@ -1,12 +1,13 @@
 /* eslint-disable max-lines -- Why: this integration-style RPC test keeps the request/response contract together so regressions in the external CLI surface are easier to spot. */
-import { mkdtempSync } from 'fs'
+import { existsSync, mkdtempSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { createConnection } from 'net'
 import { describe, expect, it, vi } from 'vitest'
 import { OrcaRuntimeService } from './orca-runtime'
+import * as runtimeMetadataModule from './runtime-metadata'
 import { readRuntimeMetadata } from './runtime-metadata'
-import { OrcaRuntimeRpcServer } from './runtime-rpc'
+import { createRuntimeTransportMetadata, OrcaRuntimeRpcServer } from './runtime-rpc'
 
 vi.mock('../git/worktree', () => ({
   listWorktrees: vi.fn().mockResolvedValue([
@@ -107,43 +108,57 @@ describe('OrcaRuntimeRpcServer', () => {
     expect(metadata?.runtimeId).toBe(runtime.getRuntimeId())
     expect(metadata?.authToken).toBeTruthy()
     expect(metadata?.transport?.endpoint).toBeTruthy()
+    expect(metadata?.transport).toEqual(server['transport'])
 
     await server.stop()
-    expect(readRuntimeMetadata(userDataPath)).toBeNull()
+    expect(readRuntimeMetadata(userDataPath)).toMatchObject({
+      runtimeId: runtime.getRuntimeId()
+    })
   })
 
-  it('does not clear metadata published by a different runtime owner on stop', async () => {
+  it('leaves the last published metadata in place when a runtime stops', async () => {
     const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-rpc-'))
-    const firstRuntime = new OrcaRuntimeService()
-    const secondRuntime = new OrcaRuntimeService()
-    const firstServer = new OrcaRuntimeRpcServer({
-      runtime: firstRuntime,
+    const runtime = new OrcaRuntimeService()
+    const server = new OrcaRuntimeRpcServer({
+      runtime,
       userDataPath,
       pid: 1001
     })
-    const secondServer = new OrcaRuntimeRpcServer({
-      runtime: secondRuntime,
-      userDataPath,
-      pid: 1002
-    })
 
-    await firstServer.start()
-    const firstMetadata = readRuntimeMetadata(userDataPath)
-    expect(firstMetadata?.pid).toBe(1001)
+    await server.start()
+    const metadata = readRuntimeMetadata(userDataPath)
+    expect(metadata?.pid).toBe(1001)
 
-    await secondServer.start()
-    const secondMetadata = readRuntimeMetadata(userDataPath)
-    expect(secondMetadata?.pid).toBe(1002)
-    expect(secondMetadata?.runtimeId).toBe(secondRuntime.getRuntimeId())
-
-    await firstServer.stop()
+    await server.stop()
     expect(readRuntimeMetadata(userDataPath)).toMatchObject({
-      pid: 1002,
-      runtimeId: secondRuntime.getRuntimeId()
+      pid: 1001,
+      runtimeId: runtime.getRuntimeId()
     })
+  })
 
-    await secondServer.stop()
+  it('closes the socket if metadata publication fails during startup', async () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-rpc-'))
+    const runtime = new OrcaRuntimeService()
+    const server = new OrcaRuntimeRpcServer({ runtime, userDataPath })
+    const writeMetadataSpy = vi
+      .spyOn(runtimeMetadataModule, 'writeRuntimeMetadata')
+      .mockImplementationOnce(() => {
+        throw new Error('write failed')
+      })
+    const endpoint = createRuntimeTransportMetadata(
+      userDataPath,
+      process.pid,
+      process.platform,
+      runtime.getRuntimeId()
+    ).endpoint
+
+    await expect(server.start()).rejects.toThrow('write failed')
     expect(readRuntimeMetadata(userDataPath)).toBeNull()
+    expect(existsSync(endpoint)).toBe(false)
+    expect(server['transport']).toBeNull()
+    expect(server['server']).toBeNull()
+
+    writeMetadataSpy.mockRestore()
   })
 
   it('serves status.get for authenticated callers', async () => {

--- a/src/main/runtime/runtime-rpc.ts
+++ b/src/main/runtime/runtime-rpc.ts
@@ -5,7 +5,6 @@ import { chmodSync, existsSync, rmSync } from 'fs'
 import { join } from 'path'
 import type { OrcaRuntimeService } from './orca-runtime'
 import {
-  clearRuntimeMetadataIfOwned,
   type RuntimeMetadata,
   type RuntimeTransportMetadata,
   writeRuntimeMetadata
@@ -103,9 +102,34 @@ export class OrcaRuntimeRpcServer {
       chmodSync(transport.endpoint, 0o600)
     }
 
+    // Why: publish the transport into in-memory state before writing metadata
+    // so the bootstrap file always contains the real endpoint/token pair. The
+    // CLI only discovers the runtime through that file.
     this.server = server
     this.transport = transport
-    this.writeMetadata()
+
+    try {
+      this.writeMetadata()
+    } catch (error) {
+      // Why: a runtime that cannot publish bootstrap metadata is invisible to
+      // the `orca` CLI. Close the socket immediately instead of leaving behind
+      // a live but undiscoverable control plane.
+      this.server = null
+      this.transport = null
+      await new Promise<void>((resolve, reject) => {
+        server.close((closeError) => {
+          if (closeError) {
+            reject(closeError)
+            return
+          }
+          resolve()
+        })
+      }).catch(() => {})
+      if (transport.kind === 'unix' && existsSync(transport.endpoint)) {
+        rmSync(transport.endpoint, { force: true })
+      }
+      throw error
+    }
   }
 
   async stop(): Promise<void> {
@@ -113,10 +137,6 @@ export class OrcaRuntimeRpcServer {
     const transport = this.transport
     this.server = null
     this.transport = null
-    clearRuntimeMetadataIfOwned(this.userDataPath, {
-      runtimeId: this.runtime.getRuntimeId(),
-      pid: this.pid
-    })
     if (!server) {
       return
     }
@@ -132,6 +152,11 @@ export class OrcaRuntimeRpcServer {
     if (transport?.kind === 'unix' && existsSync(transport.endpoint)) {
       rmSync(transport.endpoint, { force: true })
     }
+    // Why: we intentionally leave the last metadata file behind instead of
+    // deleting it on shutdown. Shared userData paths can briefly host multiple
+    // Orca processes during restarts, updates, or development, and stale
+    // metadata is safer than letting one process erase another live runtime's
+    // bootstrap file.
   }
 
   private handleConnection(socket: Socket): void {


### PR DESCRIPTION
## Summary
- only clear `orca-runtime.json` when the stopping runtime still owns the published metadata
- stop writing placeholder runtime metadata before the RPC server has a real transport and auth token
- add regression coverage for overlapping runtime owners sharing the same userData directory

## Why
Using multiple Orca instances during development could leave a healthy Orca process running without a discoverable `orca-runtime.json` file. That made `orca status` report `not_running` even though the editor was still alive.

## Validation
- pnpm exec vitest run src/main/runtime/runtime-metadata.test.ts src/main/runtime/runtime-rpc.test.ts
- pnpm exec tsc --noEmit -p tsconfig.node.json --composite false
