### PR TITLE
Persist active worktree filter

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -67,6 +67,7 @@ function App(): React.JSX.Element {
   const sidebarWidth = useAppStore((s) => s.sidebarWidth)
   const groupBy = useAppStore((s) => s.groupBy)
   const sortBy = useAppStore((s) => s.sortBy)
+  const showActiveOnly = useAppStore((s) => s.showActiveOnly)
   const filterRepoIds = useAppStore((s) => s.filterRepoIds)
   const persistedUIReady = useAppStore((s) => s.persistedUIReady)
 
@@ -114,6 +115,7 @@ function App(): React.JSX.Element {
             rightSidebarWidth: 350,
             groupBy: 'none',
             sortBy: 'name',
+            showActiveOnly: false,
             filterRepoIds: [],
             uiZoomLevel: 0,
             worktreeCardProperties: [...DEFAULT_WORKTREE_CARD_PROPERTIES],
@@ -221,12 +223,21 @@ function App(): React.JSX.Element {
         rightSidebarWidth,
         groupBy,
         sortBy,
+        showActiveOnly,
         filterRepoIds
       })
     }, 150)
 
     return () => window.clearTimeout(timer)
-  }, [persistedUIReady, sidebarWidth, rightSidebarWidth, groupBy, sortBy, filterRepoIds])
+  }, [
+    persistedUIReady,
+    sidebarWidth,
+    rightSidebarWidth,
+    groupBy,
+    sortBy,
+    showActiveOnly,
+    filterRepoIds
+  ])
 
   // Apply theme to document
   useEffect(() => {

--- a/src/renderer/src/store/slices/ui.test.ts
+++ b/src/renderer/src/store/slices/ui.test.ts
@@ -66,4 +66,16 @@ describe('createUISlice hydratePersistedUI', () => {
     expect(store.getState().sidebarWidth).toBe(320)
     expect(store.getState().rightSidebarWidth).toBe(360)
   })
+
+  it('restores the active-only filter from persisted UI state', () => {
+    const store = createUIStore()
+
+    store.getState().hydratePersistedUI(
+      makePersistedUI({
+        showActiveOnly: true
+      })
+    )
+
+    expect(store.getState().showActiveOnly).toBe(true)
+  })
 })

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -118,6 +118,10 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set) => (
         rightSidebarWidth: sanitizePersistedSidebarWidth(ui.rightSidebarWidth, s.rightSidebarWidth),
         groupBy: ui.groupBy,
         sortBy,
+        // Why: "Active only" is part of the user's sidebar working set, not a
+        // transient render detail. Restoring it on launch keeps the filtered
+        // worktree list stable across restarts instead of silently widening it.
+        showActiveOnly: ui.showActiveOnly,
         filterRepoIds: (ui.filterRepoIds ?? []).filter((repoId) => validRepoIds.has(repoId)),
         worktreeCardProperties: ui.worktreeCardProperties ?? [...DEFAULT_WORKTREE_CARD_PROPERTIES],
         dismissedUpdateVersion: ui.dismissedUpdateVersion ?? null,

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -87,6 +87,7 @@ export function getDefaultUIState(): PersistedUIState {
     rightSidebarWidth: 350,
     groupBy: 'none',
     sortBy: 'name',
+    showActiveOnly: false,
     filterRepoIds: [],
     uiZoomLevel: 0,
     worktreeCardProperties: [...DEFAULT_WORKTREE_CARD_PROPERTIES],

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -232,6 +232,7 @@ export type PersistedUIState = {
   rightSidebarWidth: number
   groupBy: 'none' | 'repo' | 'pr-status'
   sortBy: 'name' | 'recent' | 'repo'
+  showActiveOnly: boolean
   filterRepoIds: string[]
   uiZoomLevel: number
   worktreeCardProperties: WorktreeCardProperty[]


### PR DESCRIPTION
## Problem
The sidebar's "Active only" worktree filter lived only in renderer state, so closing and reopening Orca always reset the filter to off.

## Solution
Add `showActiveOnly` to the persisted UI state, restore it during renderer hydration, include it in the UI save effect, and add a focused store test covering hydration of the persisted flag.
