### PR TITLE
fix: delete local branch when removing worktree

### DIFF
--- a/src/main/git/remove-worktree.test.ts
+++ b/src/main/git/remove-worktree.test.ts
@@ -1,0 +1,270 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { execFileMock, execFileSyncMock } = vi.hoisted(() => ({
+  execFileMock: vi.fn(),
+  execFileSyncMock: vi.fn()
+}))
+
+vi.mock('child_process', () => ({
+  execFile: execFileMock,
+  execFileSync: execFileSyncMock
+}))
+
+import { removeWorktree } from './worktree'
+
+type MockResult = {
+  error?: Error
+  stdout?: string
+  stderr?: string
+}
+
+function mockGitCommands(results: Record<string, MockResult>): void {
+  const callCounts = new Map<string, number>()
+  execFileMock.mockImplementation(
+    (
+      file: string,
+      args: string[],
+      options: { cwd: string; encoding: string } | ((...params: unknown[]) => void),
+      callback?: (...params: unknown[]) => void
+    ) => {
+      const resolvedCallback = typeof options === 'function' ? options : callback
+      const key = `${file} ${args.join(' ')}`
+      const callCount = (callCounts.get(key) ?? 0) + 1
+      callCounts.set(key, callCount)
+      const result = results[`${key}#${callCount}`] ?? results[key] ?? {}
+
+      if (result.error) {
+        const error = Object.assign(result.error, {
+          stdout: result.stdout ?? '',
+          stderr: result.stderr ?? ''
+        })
+        resolvedCallback?.(error, result.stdout ?? '', result.stderr ?? '')
+        return
+      }
+
+      resolvedCallback?.(null, result.stdout ?? '', result.stderr ?? '')
+    }
+  )
+}
+
+function getGitCalls(): string[] {
+  return execFileMock.mock.calls.map((call) => `${call[0]} ${call[1].join(' ')}`)
+}
+
+function expectGitCallOrder(calls: string[], beforeCall: string, afterCall: string): void {
+  expect(calls.indexOf(beforeCall)).toBeGreaterThanOrEqual(0)
+  expect(calls.indexOf(afterCall)).toBeGreaterThan(calls.indexOf(beforeCall))
+}
+
+describe('removeWorktree', () => {
+  beforeEach(() => {
+    execFileMock.mockReset()
+    execFileSyncMock.mockReset()
+  })
+
+  it('removes the worktree, prunes stale refs, and deletes its local branch', async () => {
+    mockGitCommands({
+      'git worktree list --porcelain': {
+        stdout: `worktree /repo
+HEAD abc123
+branch refs/heads/main
+
+worktree /repo-feature
+HEAD def456
+branch refs/heads/feature/test
+`
+      },
+      'git worktree list --porcelain#2': {
+        stdout: `worktree /repo
+HEAD abc123
+branch refs/heads/main
+`
+      }
+    })
+
+    await removeWorktree('/repo', '/repo-feature')
+
+    const calls = getGitCalls()
+    expect(calls).toEqual(
+      expect.arrayContaining([
+        'git worktree remove /repo-feature',
+        'git worktree prune',
+        'git branch -D feature/test'
+      ])
+    )
+    expectGitCallOrder(calls, 'git worktree remove /repo-feature', 'git worktree prune')
+    expectGitCallOrder(calls, 'git worktree prune', 'git branch -D feature/test')
+  })
+
+  it('skips branch deletion when another worktree still points at the branch', async () => {
+    mockGitCommands({
+      'git worktree list --porcelain': {
+        stdout: `worktree /repo
+HEAD abc123
+branch refs/heads/main
+
+worktree /repo-feature
+HEAD def456
+branch refs/heads/feature/test
+
+worktree /repo-feature-copy
+HEAD def456
+branch refs/heads/feature/test
+`
+      },
+      'git worktree list --porcelain#2': {
+        stdout: `worktree /repo
+HEAD abc123
+branch refs/heads/main
+
+worktree /repo-feature-copy
+HEAD def456
+branch refs/heads/feature/test
+`
+      }
+    })
+
+    await removeWorktree('/repo', '/repo-feature')
+
+    const calls = getGitCalls()
+    expect(calls).toEqual(
+      expect.arrayContaining([
+        'git worktree remove /repo-feature',
+        'git worktree prune',
+        'git worktree list --porcelain'
+      ])
+    )
+    expect(calls).not.toContain('git branch -D feature/test')
+    expectGitCallOrder(calls, 'git worktree remove /repo-feature', 'git worktree prune')
+  })
+
+  it('deletes the branch after prune removes stale sibling worktree entries', async () => {
+    mockGitCommands({
+      'git worktree list --porcelain': {
+        stdout: `worktree /repo
+HEAD abc123
+branch refs/heads/main
+
+worktree /repo-feature
+HEAD def456
+branch refs/heads/feature/test
+
+worktree /repo-stale
+HEAD 0000000
+branch refs/heads/feature/test
+prunable gitdir file points to non-existent location
+`
+      },
+      'git worktree list --porcelain#2': {
+        stdout: `worktree /repo
+HEAD abc123
+branch refs/heads/main
+`
+      }
+    })
+
+    await removeWorktree('/repo', '/repo-feature')
+
+    const calls = getGitCalls()
+    expect(calls).toEqual(
+      expect.arrayContaining([
+        'git worktree remove /repo-feature',
+        'git worktree prune',
+        'git branch -D feature/test'
+      ])
+    )
+    expectGitCallOrder(calls, 'git worktree prune', 'git branch -D feature/test')
+  })
+
+  it('passes --force before the worktree path when forced removal is requested', async () => {
+    mockGitCommands({
+      'git worktree list --porcelain': {
+        stdout: `worktree /repo
+HEAD abc123
+branch refs/heads/main
+
+worktree /repo-feature
+HEAD def456
+branch refs/heads/feature/test
+`
+      },
+      'git worktree list --porcelain#2': {
+        stdout: `worktree /repo
+HEAD abc123
+branch refs/heads/main
+`
+      }
+    })
+
+    await removeWorktree('/repo', '/repo-feature', true)
+
+    expect(getGitCalls()).toContain('git worktree remove --force /repo-feature')
+  })
+
+  it('matches Windows worktree paths before deleting the branch', async () => {
+    mockGitCommands({
+      'git worktree list --porcelain': {
+        stdout: `worktree C:/repo
+HEAD abc123
+branch refs/heads/main
+
+worktree C:/Workspaces/Delete-Branch-Ui-Test
+HEAD def456
+branch refs/heads/feature/test
+`
+      },
+      'git worktree list --porcelain#2': {
+        stdout: `worktree C:/repo
+HEAD abc123
+branch refs/heads/main
+`
+      }
+    })
+
+    await removeWorktree('C:\\repo', 'c:\\workspaces\\delete-branch-ui-test')
+
+    const calls = getGitCalls()
+    expect(calls).toEqual(
+      expect.arrayContaining([
+        'git worktree remove c:\\workspaces\\delete-branch-ui-test',
+        'git worktree prune',
+        'git branch -D feature/test'
+      ])
+    )
+  })
+
+  it('keeps removal successful when branch cleanup fails', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    mockGitCommands({
+      'git worktree list --porcelain': {
+        stdout: `worktree /repo
+HEAD abc123
+branch refs/heads/main
+
+worktree /repo-feature
+HEAD def456
+branch refs/heads/feature/test
+`
+      },
+      'git worktree list --porcelain#2': {
+        stdout: `worktree /repo
+HEAD abc123
+branch refs/heads/main
+`
+      },
+      'git branch -D feature/test': {
+        error: new Error('branch delete failed'),
+        stderr: 'branch delete failed'
+      }
+    })
+
+    await expect(removeWorktree('/repo', '/repo-feature')).resolves.toBeUndefined()
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[git] Failed to delete local branch "feature/test" after removing worktree',
+      expect.any(Error)
+    )
+
+    warnSpy.mockRestore()
+  })
+})

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -1,8 +1,46 @@
 import { execFile, execFileSync } from 'child_process'
-import { promisify } from 'util'
+import { posix, win32 } from 'path'
 import type { GitWorktreeInfo } from '../../shared/types'
 
-const execFileAsync = promisify(execFile)
+function runGit(
+  repoPath: string,
+  args: string[]
+): Promise<{
+  stdout: string
+  stderr: string
+}> {
+  return new Promise((resolve, reject) => {
+    execFile('git', args, { cwd: repoPath, encoding: 'utf-8' }, (error, stdout, stderr) => {
+      if (error) {
+        reject(Object.assign(error, { stdout, stderr }))
+        return
+      }
+      resolve({ stdout, stderr })
+    })
+  })
+}
+
+function normalizeLocalBranchRef(branch: string): string {
+  return branch.replace(/^refs\/heads\//, '')
+}
+
+function areWorktreePathsEqual(
+  leftPath: string,
+  rightPath: string,
+  platform = process.platform
+): boolean {
+  if (platform === 'win32' || looksLikeWindowsPath(leftPath) || looksLikeWindowsPath(rightPath)) {
+    return (
+      win32.normalize(win32.resolve(leftPath)).toLowerCase() ===
+      win32.normalize(win32.resolve(rightPath)).toLowerCase()
+    )
+  }
+  return posix.normalize(posix.resolve(leftPath)) === posix.normalize(posix.resolve(rightPath))
+}
+
+function looksLikeWindowsPath(pathValue: string): boolean {
+  return /^[A-Za-z]:[\\/]/.test(pathValue) || pathValue.startsWith('\\\\')
+}
 
 /**
  * Parse the porcelain output of `git worktree list --porcelain`.
@@ -51,10 +89,7 @@ export function parseWorktreeList(output: string): GitWorktreeInfo[] {
  */
 export async function listWorktrees(repoPath: string): Promise<GitWorktreeInfo[]> {
   try {
-    const { stdout } = await execFileAsync('git', ['worktree', 'list', '--porcelain'], {
-      cwd: repoPath,
-      encoding: 'utf-8'
-    })
+    const { stdout } = await runGit(repoPath, ['worktree', 'list', '--porcelain'])
     return parseWorktreeList(stdout)
   } catch {
     return []
@@ -93,12 +128,44 @@ export async function removeWorktree(
   worktreePath: string,
   force = false
 ): Promise<void> {
-  const args = ['worktree', 'remove', worktreePath]
+  const worktreesBeforeRemoval = await listWorktrees(repoPath)
+  const removedWorktree = worktreesBeforeRemoval.find((worktree) =>
+    areWorktreePathsEqual(worktree.path, worktreePath)
+  )
+  const branchName = normalizeLocalBranchRef(removedWorktree?.branch ?? '')
+
+  const args = ['worktree', 'remove']
   if (force) {
     args.push('--force')
   }
-  await execFileAsync('git', args, {
-    cwd: repoPath,
-    encoding: 'utf-8'
-  })
+  args.push(worktreePath)
+  await runGit(repoPath, args)
+  await runGit(repoPath, ['worktree', 'prune'])
+
+  if (!branchName) {
+    return
+  }
+
+  // Why: `git worktree list` can still include stale sibling records until
+  // `git worktree prune` runs. Re-list after prune so branch cleanup only skips
+  // when a still-live worktree actually keeps that branch checked out.
+  const worktreesAfterPrune = await listWorktrees(repoPath)
+  const branchStillInUse = worktreesAfterPrune.some(
+    (worktree) => normalizeLocalBranchRef(worktree.branch) === branchName
+  )
+  if (branchStillInUse) {
+    return
+  }
+
+  try {
+    // Why: `git worktree remove` only detaches the filesystem entry. Orca also
+    // drops the now-unused local branch here so delete-worktree does not leave
+    // behind orphaned feature branches unless another worktree still points at it.
+    await runGit(repoPath, ['branch', '-D', branchName])
+  } catch (error) {
+    console.warn(
+      `[git] Failed to delete local branch "${branchName}" after removing worktree`,
+      error
+    )
+  }
 }


### PR DESCRIPTION
## Summary
- delete the local branch after removing a worktree when no live worktree still uses it
- prune and re-list worktrees before deciding whether branch cleanup is safe
- add regression coverage for stale/prunable entries, forced removal ordering, and Windows path matching

## Validation
- pnpm test -- src/main/git/worktree.test.ts src/main/git/remove-worktree.test.ts src/main/ipc/worktrees.test.ts src/main/ipc/worktrees-windows.test.ts src/main/runtime/orca-runtime.test.ts
- pnpm run typecheck:node
- pnpm exec oxlint src/main/git/worktree.ts src/main/git/worktree.test.ts src/main/git/remove-worktree.test.ts

## Electron check
- launched Orca via Electron dev mode and exercised the create-worktree UI with a throwaway branch/worktree
- cleaned up the throwaway worktree and branch after the run