### PR TITLE
Ensure setup commands run only once per tab

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -24,6 +24,16 @@ export function connectPanePty(
   manager: PaneManager,
   deps: PtyConnectionDeps
 ): void {
+  // Why: setup commands must only run once — in the initial pane of the tab.
+  // Capture and clear the startup reference synchronously so that panes
+  // created later by splits or layout restoration cannot re-execute the
+  // setup script, which would be confusing and potentially destructive.
+  // Note: this intentionally mutates `deps` so the caller's object no
+  // longer carries the startup payload — preventing any later consumer
+  // from accidentally replaying it.
+  const paneStartup = deps.startup ?? null
+  deps.startup = undefined
+
   const onExit = (ptyId: string): void => {
     deps.clearTabPtyId(deps.tabId, ptyId)
     // The runtime graph is the CLI's source for live terminal bindings, so
@@ -55,7 +65,7 @@ export function connectPanePty(
 
   const transport = createIpcPtyTransport({
     cwd: deps.cwd,
-    env: deps.startup?.env,
+    env: paneStartup?.env,
     onPtyExit: onExit,
     onTitleChange,
     onPtySpawn,
@@ -89,11 +99,11 @@ export function connectPanePty(
       rows,
       callbacks: {
         onConnect: () => {
-          if (deps.startup?.command) {
+          if (paneStartup?.command) {
             // Why: setup commands are injected only after the PTY reports a live
             // shell connection. Writing earlier is racy with shell startup files
             // and can drop characters on slower shells.
-            transport.sendInput(`${deps.startup.command}\r`)
+            transport.sendInput(`${paneStartup.command}\r`)
           }
         },
         onData: (data) => {


### PR DESCRIPTION
## Problem

When a user splits a pane or restores a layout in the terminal, the setup script could be re-executed multiple times in the same tab. This is confusing and potentially destructive if the setup command has side effects.

## Solution

Capture the startup reference synchronously at the beginning of `connectPanePty()` and clear `deps.startup` to `undefined` immediately. This prevents any subsequent pane creation (from splits or layout restoration) from accessing and re-executing the setup script. The local `paneStartup` variable holds the captured reference and is used safely within the async callbacks.

Added documentation to clarify the intentional mutation of the caller's `deps` object, following project standards.