### PR TITLE
fix: bypass gh CLI HTTP cache on manual PR checks refresh

### DIFF
--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -120,18 +120,21 @@ export async function getPRForBranch(repoPath: string, branch: string): Promise<
 export async function getPRChecks(
   repoPath: string,
   prNumber: number,
-  branch?: string
+  branch?: string,
+  options?: { noCache?: boolean }
 ): Promise<PRCheckDetail[]> {
   const ownerRepo = branch ? await getOwnerRepo(repoPath) : null
   await acquire()
   try {
     if (ownerRepo && branch) {
+      // Why: --cache 60s saves rate-limit budget during polling, but when the
+      // user explicitly clicks refresh we must skip it so gh fetches fresh data.
+      const cacheArgs = options?.noCache ? [] : ['--cache', '60s']
       const { stdout } = await execFileAsync(
         'gh',
         [
           'api',
-          '--cache',
-          '60s',
+          ...cacheArgs,
           `repos/${ownerRepo.owner}/${ownerRepo.repo}/commits/${encodeURIComponent(branch)}/check-runs?per_page=100`
         ],
         { cwd: repoPath, encoding: 'utf-8' }

--- a/src/main/ipc/github.ts
+++ b/src/main/ipc/github.ts
@@ -37,9 +37,11 @@ export function registerGitHubHandlers(store: Store): void {
 
   ipcMain.handle(
     'gh:prChecks',
-    (_event, args: { repoPath: string; prNumber: number; branch?: string }) => {
+    (_event, args: { repoPath: string; prNumber: number; branch?: string; noCache?: boolean }) => {
       const repoPath = assertRegisteredRepoPath(args.repoPath, store)
-      return getPRChecks(repoPath, args.prNumber, args.branch)
+      return getPRChecks(repoPath, args.prNumber, args.branch, {
+        noCache: args.noCache
+      })
     }
   )
 

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -71,6 +71,7 @@ type GhApi = {
     repoPath: string
     prNumber: number
     branch?: string
+    noCache?: boolean
   }) => Promise<PRCheckDetail[]>
   updatePRTitle: (args: { repoPath: string; prNumber: number; title: string }) => Promise<boolean>
   mergePR: (args: {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -186,8 +186,12 @@ const api = {
     listIssues: (args: { repoPath: string; limit?: number }): Promise<unknown[]> =>
       ipcRenderer.invoke('gh:listIssues', args),
 
-    prChecks: (args: { repoPath: string; prNumber: number; branch?: string }): Promise<unknown[]> =>
-      ipcRenderer.invoke('gh:prChecks', args),
+    prChecks: (args: {
+      repoPath: string
+      prNumber: number
+      branch?: string
+      noCache?: boolean
+    }): Promise<unknown[]> => ipcRenderer.invoke('gh:prChecks', args),
 
     updatePRTitle: (args: {
       repoPath: string

--- a/src/renderer/src/store/slices/github.ts
+++ b/src/renderer/src/store/slices/github.ts
@@ -193,7 +193,8 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
         const checks = (await window.api.gh.prChecks({
           repoPath,
           prNumber,
-          branch
+          branch,
+          noCache: options?.force
         })) as PRCheckDetail[]
         set((s) => {
           const nextState: Partial<AppState> = {


### PR DESCRIPTION
## Summary
- The `gh api --cache 60s` flag caused the gh CLI to return stale HTTP-cached check-run data even when the user explicitly clicked the refresh button
- Threads a `noCache` flag from the Zustand store through IPC to `getPRChecks`, skipping `--cache 60s` on manual refreshes
- Background polling continues to use `--cache 60s` for rate-limit efficiency

## Test plan
- [x] `pnpm run typecheck` passes
- [x] All 6 existing github store tests pass
- [ ] Manual: click refresh on a PR with in-progress checks → status updates immediately
- [ ] Manual: verify polling still works with backoff (no excessive API calls)