### PR TITLE
fix: new worktree not sorting to top with sort=recent

### DIFF
--- a/src/renderer/src/components/sidebar/smart-sort.test.ts
+++ b/src/renderer/src/components/sidebar/smart-sort.test.ts
@@ -354,4 +354,31 @@ describe('buildWorktreeComparator', () => {
 
     expect(worktrees.map((worktree) => worktree.id)).toEqual(['active', 'background'])
   })
+
+  it('ranks a just-created worktree above shutdown worktrees with passive signals', () => {
+    const justCreated = makeWorktree({
+      id: 'new',
+      displayName: 'New',
+      lastActivityAt: NOW
+    })
+    // Shutdown worktree with max passive signals but no recent activity
+    const shutdown = makeWorktree({
+      id: 'shutdown',
+      displayName: 'Shutdown',
+      isUnread: true,
+      linkedIssue: 42,
+      lastActivityAt: NOW - 2 * 24 * 60 * 60 * 1000
+    })
+    const prCache = {
+      '/tmp/repo-1::shutdown': {
+        data: { number: 17 },
+        fetchedAt: NOW
+      }
+    }
+    const worktrees = [shutdown, justCreated]
+
+    worktrees.sort(buildWorktreeComparator('recent', null, repoMap, prCache, NOW))
+
+    expect(worktrees.map((worktree) => worktree.id)).toEqual(['new', 'shutdown'])
+  })
 })

--- a/src/renderer/src/components/sidebar/smart-sort.ts
+++ b/src/renderer/src/components/sidebar/smart-sort.ts
@@ -73,7 +73,12 @@ function computeSmartScoreFromSignals(
   const activityAge = now - (worktree.lastActivityAt || 0)
   if (worktree.lastActivityAt > 0) {
     const ONE_DAY = 24 * 60 * 60 * 1000
-    score += 24 * Math.max(0, 1 - activityAge / ONE_DAY)
+    // Why 36: a just-created worktree has only this signal (no live tab yet,
+    // since the PTY spawns asynchronously after creation). Weight must exceed
+    // the max passive-signal combination for shutdown worktrees
+    // (isUnread 18 + PR 10 + issue 6 = 34) so brand-new worktrees always
+    // appear at the top of the "recent" sort immediately.
+    score += 36 * Math.max(0, 1 - activityAge / ONE_DAY)
   }
 
   return score
@@ -161,12 +166,12 @@ export function buildWorktreeComparator(
  *
  * Scoring:
  *   running AI job    → +60
+ *   recent activity   → +36 (decays over 24 hours)
  *   needs attention   → +35
  *   unread            → +18
  *   open terminal     → +12
  *   live branch PR    → +10
  *   linked issue      → +6
- *   recent activity   → +24 (decays over 24 hours)
  */
 export function computeSmartScore(
   worktree: Worktree,

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -231,12 +231,22 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         next[wId] = next[wId].map((t) => (t.id === tabId ? { ...t, ptyId } : t))
       }
       const existingPtyIds = s.ptyIdsByTabId[tabId] ?? []
+      // Why: when a brand-new tab in the active worktree receives its first
+      // PTY, the live-tab signal (+12) flips on. bumpWorktreeActivity (below)
+      // intentionally skips sortEpoch for the active worktree to prevent the
+      // reorder-on-click bug (PR #209), but that means the sort never sees
+      // the new signal. Bump sortEpoch here so a just-created worktree
+      // immediately reflects its live-tab score instead of waiting for an
+      // unrelated event to trigger a re-sort.
+      const isFirstPty = existingPtyIds.length === 0
+      const isActiveWorktree = worktreeId != null && s.activeWorktreeId === worktreeId
       return {
         tabsByWorktree: next,
         ptyIdsByTabId: {
           ...s.ptyIdsByTabId,
           [tabId]: existingPtyIds.includes(ptyId) ? existingPtyIds : [...existingPtyIds, ptyId]
-        }
+        },
+        ...(isFirstPty && isActiveWorktree ? { sortEpoch: s.sortEpoch + 1 } : {})
       }
     })
 


### PR DESCRIPTION
## Summary
- Increased activity decay weight from 24 → 36 so a just-created worktree (score 36) always outranks shutdown worktrees with max passive signals (isUnread 18 + PR 10 + issue 6 = 34)
- Bump `sortEpoch` when a tab receives its first-ever PTY in the active worktree, so the +12 live-tab signal triggers an immediate re-sort instead of waiting for an unrelated event
- Added test verifying a just-created worktree ranks above a shutdown worktree with max passive signals

## Test plan
- [ ] Create a new worktree with `sort=recent` while other worktrees are shutdown — it should appear at the top immediately
- [ ] Create a second worktree — the first should stay near the top, second at the very top
- [ ] Clicking an existing worktree should NOT cause sidebar reorder (PR #209 regression check)
- [ ] `npx vitest run` — 14/14 smart-sort tests pass, 51/51 store slice tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)