### PR TITLE
fix: remove macOS traffic light padding on Windows

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -390,7 +390,7 @@ function App(): React.JSX.Element {
   return (
     <div className="flex flex-col h-screen w-screen overflow-hidden">
       <div className="titlebar">
-        <div className="titlebar-traffic-light-pad" />
+        {navigator.userAgent.includes('Mac') && <div className="titlebar-traffic-light-pad" />}
         <button
           className="sidebar-toggle"
           onClick={toggleSidebar}


### PR DESCRIPTION
## Summary
- The `titlebar-traffic-light-pad` div always rendered with 80px width to reserve space for macOS traffic lights (close, minimize, maximize), even on Windows where those buttons don't exist
- This caused the "Orca" title and sidebar toggle/collapse buttons to be offset to the right unnecessarily on Windows
- Conditionally render the padding only on macOS, using the same `navigator.userAgent.includes('Mac')` pattern used elsewhere in the renderer

## Test plan
- [ ] Run on Windows: verify the title and buttons are flush left with no phantom gap
- [ ] Run on macOS: verify traffic light padding is still present and buttons don't overlap

Fixes https://github.com/stablyai/orca/issues/236