### PR TITLE
fix: resolve local images via IPC blob URLs in markdown editor

### DIFF
--- a/src/renderer/src/components/editor/MarkdownPreview.tsx
+++ b/src/renderer/src/components/editor/MarkdownPreview.tsx
@@ -8,7 +8,8 @@ import type { Components } from 'react-markdown'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { useAppStore } from '@/store'
-import { getMarkdownPreviewImageSrc, getMarkdownPreviewLinkTarget } from './markdown-preview-links'
+import { getMarkdownPreviewLinkTarget } from './markdown-preview-links'
+import { useLocalImageSrc } from './useLocalImageSrc'
 import {
   applyMarkdownPreviewSearchHighlights,
   clearMarkdownPreviewSearchHighlights,
@@ -175,9 +176,13 @@ export default function MarkdownPreview({
         </a>
       )
     },
-    img: ({ src, alt, ...props }) => (
-      <img {...props} src={getMarkdownPreviewImageSrc(src, filePath)} alt={alt ?? ''} />
-    )
+    img: function MarkdownImg({ src, alt, ...props }) {
+      // eslint-disable-next-line react-hooks/rules-of-hooks -- react-markdown
+      // instantiates component overrides as regular React components, so hooks
+      // are valid here despite the lowercase function name.
+      const resolvedSrc = useLocalImageSrc(src, filePath)
+      return <img {...props} src={resolvedSrc} alt={alt ?? ''} />
+    }
   }
 
   return (

--- a/src/renderer/src/components/editor/RichMarkdownEditor.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownEditor.tsx
@@ -171,6 +171,11 @@ export default function RichMarkdownEditor({
     if (!editor) {
       return
     }
+    // Why: the native file picker steals focus from the editor, which can cause
+    // ProseMirror to lose track of its selection. We snapshot the cursor position
+    // before the async dialog so we can insert the image exactly where the user
+    // intended, not at whatever position focus() falls back to afterward.
+    const insertPos = editor.state.selection.from
     try {
       const srcPath = await window.api.shell.pickImage()
       if (!srcPath) {
@@ -182,7 +187,14 @@ export default function RichMarkdownEditor({
       if (srcPath !== destPath) {
         await window.api.shell.copyFile({ srcPath, destPath })
       }
-      editor.chain().focus().setImage({ src: imageName }).run()
+      // Why: insertContentAt places the image at the exact saved position
+      // regardless of where focus lands after the native file dialog closes,
+      // whereas setTextSelection can be overridden by ProseMirror's focus logic.
+      editor
+        .chain()
+        .focus()
+        .insertContentAt(insertPos, { type: 'image', attrs: { src: imageName } })
+        .run()
     } catch (err) {
       toast.error(extractIpcErrorMessage(err, 'Failed to insert image.'))
     }

--- a/src/renderer/src/components/editor/markdown-preview-links.test.ts
+++ b/src/renderer/src/components/editor/markdown-preview-links.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { getMarkdownPreviewImageSrc, getMarkdownPreviewLinkTarget } from './markdown-preview-links'
+import {
+  getMarkdownPreviewImageSrc,
+  getMarkdownPreviewLinkTarget,
+  resolveImageAbsolutePath
+} from './markdown-preview-links'
 
 describe('getMarkdownPreviewLinkTarget', () => {
   it('resolves relative markdown links against the current file', () => {
@@ -36,5 +40,37 @@ describe('getMarkdownPreviewImageSrc', () => {
     expect(getMarkdownPreviewImageSrc('data:image/png;base64,abc', '/repo/docs/README.md')).toBe(
       'data:image/png;base64,abc'
     )
+  })
+})
+
+describe('resolveImageAbsolutePath', () => {
+  it('resolves a relative image src to an absolute filesystem path', () => {
+    expect(resolveImageAbsolutePath('diagram.png', '/repo/docs/README.md')).toBe(
+      '/repo/docs/diagram.png'
+    )
+  })
+
+  it('resolves parent-directory references', () => {
+    expect(resolveImageAbsolutePath('../assets/img.png', '/repo/docs/guides/README.md')).toBe(
+      '/repo/docs/assets/img.png'
+    )
+  })
+
+  it('resolves Windows paths', () => {
+    expect(resolveImageAbsolutePath('./diagram.png', 'C:\\repo\\docs\\README.md')).toBe(
+      'C:/repo/docs/diagram.png'
+    )
+  })
+
+  it('returns null for http URLs', () => {
+    expect(resolveImageAbsolutePath('https://example.com/img.png', '/repo/README.md')).toBeNull()
+  })
+
+  it('returns null for data URLs', () => {
+    expect(resolveImageAbsolutePath('data:image/png;base64,abc', '/repo/README.md')).toBeNull()
+  })
+
+  it('returns null for undefined src', () => {
+    expect(resolveImageAbsolutePath(undefined, '/repo/README.md')).toBeNull()
   })
 })

--- a/src/renderer/src/components/editor/markdown-preview-links.ts
+++ b/src/renderer/src/components/editor/markdown-preview-links.ts
@@ -73,3 +73,31 @@ export function getMarkdownPreviewImageSrc(
 
   return rawSrc
 }
+
+/**
+ * Resolves a relative image src against the markdown file path to produce an
+ * absolute filesystem path. Returns null for external URLs (http, https, data,
+ * blob) that don't need local file loading.
+ */
+export function resolveImageAbsolutePath(
+  rawSrc: string | undefined,
+  filePath: string
+): string | null {
+  if (!rawSrc) {
+    return null
+  }
+
+  const resolved = resolveMarkdownUrl(rawSrc, filePath)
+  if (!resolved || resolved.protocol !== 'file:') {
+    return null
+  }
+
+  // Convert file:///path/to/file → /path/to/file (Unix)
+  // Convert file:///C:/path/to/file → C:/path/to/file (Windows)
+  let absolutePath = decodeURIComponent(resolved.pathname)
+  if (/^\/[A-Za-z]:\//.test(absolutePath)) {
+    absolutePath = absolutePath.slice(1)
+  }
+
+  return absolutePath
+}

--- a/src/renderer/src/components/editor/rich-markdown-extensions.ts
+++ b/src/renderer/src/components/editor/rich-markdown-extensions.ts
@@ -2,7 +2,6 @@ import type { AnyExtension } from '@tiptap/core'
 import StarterKit from '@tiptap/starter-kit'
 import Link from '@tiptap/extension-link'
 import Image from '@tiptap/extension-image'
-import type { DOMOutputSpec } from '@tiptap/pm/model'
 import Placeholder from '@tiptap/extension-placeholder'
 import TaskList from '@tiptap/extension-task-list'
 import TaskItem from '@tiptap/extension-task-item'
@@ -11,7 +10,7 @@ import { TableCell } from '@tiptap/extension-table-cell'
 import { TableHeader } from '@tiptap/extension-table-header'
 import { TableRow } from '@tiptap/extension-table-row'
 import { Markdown } from '@tiptap/markdown'
-import { getMarkdownPreviewImageSrc } from './markdown-preview-links'
+import { loadLocalImageSrc, onImageCacheInvalidated } from './useLocalImageSrc'
 import { RawMarkdownHtmlBlock, RawMarkdownHtmlInline } from './raw-markdown-html'
 
 const RICH_MARKDOWN_PLACEHOLDER = 'Write markdown… Type / for blocks.'
@@ -31,20 +30,75 @@ export function createRichMarkdownExtensions({
     Link.configure({
       openOnClick: false
     }),
-    // Why: the default Image extension renders <img src="image.png"> which
-    // resolves against the app origin (localhost), not the file system. This
-    // custom extension overrides renderHTML to resolve relative src values to
-    // file:// URLs using the exact same resolver as preview mode, so nested
-    // paths and Windows drive roots stay consistent across both surfaces.
+    // Why: in dev mode the renderer is served from http://localhost, so
+    // file:// URLs in <img> tags are blocked by cross-origin restrictions.
+    // A nodeView loads local images via IPC → blob URL, which bypasses this
+    // and works identically in dev and production modes.
     Image.extend({
       addStorage() {
         return { filePath: '' }
       },
-      renderHTML({ HTMLAttributes }) {
-        const src = HTMLAttributes.src as string | undefined
-        const filePath = this.storage.filePath as string
-        const resolvedSrc = filePath ? getMarkdownPreviewImageSrc(src, filePath) : src
-        return ['img', { ...HTMLAttributes, src: resolvedSrc }] satisfies DOMOutputSpec
+      addNodeView() {
+        return ({ node, HTMLAttributes }) => {
+          // Why: wrapping the <img> in a container prevents the browser's
+          // native image drag (which sends image bytes) from conflicting with
+          // ProseMirror's node-level drag (which serializes the schema node
+          // for relocation within the document).
+          const dom = document.createElement('div')
+          dom.style.lineHeight = '0'
+
+          const img = document.createElement('img')
+          img.draggable = false
+          for (const [key, value] of Object.entries(HTMLAttributes)) {
+            if (key !== 'src' && value != null && value !== false) {
+              img.setAttribute(key, String(value))
+            }
+          }
+          dom.appendChild(img)
+
+          let currentSrc = node.attrs.src as string | undefined
+
+          const loadImage = (src: string | undefined): void => {
+            const fp = this.storage.filePath as string
+            if (src && fp) {
+              // Why: when IPC resolution fails (e.g. unsupported format),
+              // the ternary falls back to the raw src so the browser can
+              // attempt its own loading rather than leaving a broken image.
+              void loadLocalImageSrc(src, fp).then((resolved) => {
+                img.src = resolved ? resolved : src
+              })
+            } else if (src) {
+              img.src = src
+            }
+          }
+
+          loadImage(currentSrc)
+
+          // Why: when the user refocuses the window after deleting or replacing
+          // image files, the blob URL cache is cleared and this callback re-loads
+          // the image from disk so the editor reflects the current filesystem state.
+          const unsubscribe = onImageCacheInvalidated(() => {
+            loadImage(currentSrc)
+          })
+
+          return {
+            dom,
+            update: (updatedNode) => {
+              if (updatedNode.type.name !== 'image') {
+                return false
+              }
+              const newSrc = updatedNode.attrs.src as string | undefined
+              if (newSrc !== currentSrc) {
+                currentSrc = newSrc
+                loadImage(newSrc)
+              }
+              return true
+            },
+            destroy: () => {
+              unsubscribe()
+            }
+          }
+        }
       }
     }).configure({
       allowBase64: true

--- a/src/renderer/src/components/editor/useLocalImageSrc.ts
+++ b/src/renderer/src/components/editor/useLocalImageSrc.ts
@@ -1,0 +1,200 @@
+import { useEffect, useState } from 'react'
+import { resolveImageAbsolutePath } from './markdown-preview-links'
+
+// Why: the renderer is served from http://localhost in dev mode, so file://
+// URLs in <img> tags are blocked by cross-origin restrictions. Loading images
+// via the existing fs.readFile IPC and converting to blob URLs bypasses this
+// limitation and works identically in both dev and production modes.
+
+const BLOB_URL_CACHE_MAX_SIZE = 100
+const blobUrlCache = new Map<string, string>()
+
+// Why: blob URLs hold references to in-memory Blob objects; without eviction
+// the cache grows without bound and leaks memory. We evict the oldest entry
+// (Map iteration order is insertion order) and revoke its blob URL so the
+// browser can free the underlying data.
+function cacheBlobUrl(key: string, url: string): void {
+  blobUrlCache.set(key, url)
+  if (blobUrlCache.size > BLOB_URL_CACHE_MAX_SIZE) {
+    const oldest = blobUrlCache.keys().next().value
+    if (oldest !== undefined) {
+      const oldUrl = blobUrlCache.get(oldest)
+      blobUrlCache.delete(oldest)
+      if (oldUrl) {
+        URL.revokeObjectURL(oldUrl)
+      }
+    }
+  }
+}
+const cacheListeners = new Set<() => void>()
+let cacheGeneration = 0
+
+function base64ToBlobUrl(base64: string, mimeType: string): string {
+  const binary = atob(base64.replace(/\s/g, ''))
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i)
+  }
+  return URL.createObjectURL(new Blob([bytes], { type: mimeType }))
+}
+
+// Why: when the user switches back to the app after deleting or replacing
+// image files externally, clearing the cache ensures the preview picks up
+// the current filesystem state instead of showing stale in-memory blob URLs.
+// Old blob URLs are intentionally NOT revoked so that <img> elements keep
+// displaying until the fresh IPC load completes, avoiding a visible flash.
+function invalidateImageCache(): void {
+  blobUrlCache.clear()
+  cacheGeneration += 1
+  for (const listener of cacheListeners) {
+    listener()
+  }
+}
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('focus', invalidateImageCache)
+}
+
+/**
+ * Subscribe to cache invalidation events (fired on window re-focus).
+ * Returns an unsubscribe function.
+ */
+export function onImageCacheInvalidated(listener: () => void): () => void {
+  cacheListeners.add(listener)
+  return () => {
+    cacheListeners.delete(listener)
+  }
+}
+
+function isExternalUrl(src: string): boolean {
+  return (
+    src.startsWith('http://') ||
+    src.startsWith('https://') ||
+    src.startsWith('data:') ||
+    src.startsWith('blob:')
+  )
+}
+
+/**
+ * Resolves a raw markdown image src to a displayable URL. For local images,
+ * reads the file via IPC and returns a blob URL. For http/https/data URLs,
+ * returns the URL directly. Re-validates on window re-focus so deleted or
+ * replaced images are picked up.
+ */
+export function useLocalImageSrc(rawSrc: string | undefined, filePath: string): string | undefined {
+  const [generation, setGeneration] = useState(cacheGeneration)
+
+  useEffect(() => {
+    return onImageCacheInvalidated(() => setGeneration(cacheGeneration))
+  }, [])
+
+  const [displaySrc, setDisplaySrc] = useState<string | undefined>(() => {
+    if (!rawSrc) {
+      return undefined
+    }
+    if (isExternalUrl(rawSrc)) {
+      return rawSrc
+    }
+    const absolutePath = resolveImageAbsolutePath(rawSrc, filePath)
+    if (absolutePath && blobUrlCache.has(absolutePath)) {
+      return blobUrlCache.get(absolutePath)
+    }
+    return undefined
+  })
+
+  useEffect(() => {
+    if (!rawSrc) {
+      setDisplaySrc(undefined)
+      return
+    }
+
+    if (isExternalUrl(rawSrc)) {
+      setDisplaySrc(rawSrc)
+      return
+    }
+
+    const absolutePath = resolveImageAbsolutePath(rawSrc, filePath)
+    if (!absolutePath) {
+      setDisplaySrc(rawSrc)
+      return
+    }
+
+    if (blobUrlCache.has(absolutePath)) {
+      setDisplaySrc(blobUrlCache.get(absolutePath))
+      return
+    }
+
+    let cancelled = false
+    window.api.fs
+      .readFile({ filePath: absolutePath })
+      .then((result) => {
+        if (cancelled) {
+          return
+        }
+        if (result.isBinary && result.content) {
+          const url = base64ToBlobUrl(result.content, result.mimeType ?? 'image/png')
+          cacheBlobUrl(absolutePath, url)
+          setDisplaySrc(url)
+        } else {
+          // Why: if the file exists but is not binary (e.g. an SVG stored as
+          // text) or content is empty, fall back to the raw src so the browser
+          // can attempt its own loading rather than leaving a broken image.
+          setDisplaySrc(rawSrc)
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setDisplaySrc(rawSrc)
+        }
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [rawSrc, filePath, generation])
+
+  return displaySrc
+}
+
+/**
+ * Loads a local image via IPC and returns its blob URL, suitable for use
+ * outside React (e.g. ProseMirror nodeViews). Resolves from cache when
+ * available.
+ */
+export async function loadLocalImageSrc(rawSrc: string, filePath: string): Promise<string | null> {
+  if (
+    rawSrc.startsWith('http://') ||
+    rawSrc.startsWith('https://') ||
+    rawSrc.startsWith('data:') ||
+    rawSrc.startsWith('blob:')
+  ) {
+    return rawSrc
+  }
+
+  const absolutePath = resolveImageAbsolutePath(rawSrc, filePath)
+  if (!absolutePath) {
+    return null
+  }
+
+  const cached = blobUrlCache.get(absolutePath)
+  if (cached) {
+    return cached
+  }
+
+  try {
+    const result = await window.api.fs.readFile({ filePath: absolutePath })
+    if (result.isBinary && result.content) {
+      const url = base64ToBlobUrl(result.content, result.mimeType ?? 'image/png')
+      cacheBlobUrl(absolutePath, url)
+      return url
+    }
+    // Why: if the file is not binary (e.g. an SVG stored as text) or content
+    // is empty, return the raw src so the caller can still display something
+    // rather than treating it as a permanent failure.
+    return rawSrc
+  } catch {
+    // Fall through
+  }
+
+  return null
+}


### PR DESCRIPTION
## Problem

Local images referenced in markdown (both preview and rich editor) failed to display in dev mode. The renderer is served from `http://localhost`, so `file://` URLs in `<img>` tags are blocked by cross-origin restrictions.

## Solution

- Load local images via IPC `fs.readFile` → blob URL conversion, which bypasses cross-origin restrictions and works identically in dev and production modes
- Add `useLocalImageSrc` hook for react-markdown preview component
- Add `loadLocalImageSrc` async function for ProseMirror nodeView in rich editor
- Implement blob URL cache with LRU eviction (max 100 entries) and `URL.revokeObjectURL()` cleanup
- Add `resolveImageAbsolutePath` helper to convert relative markdown image paths to absolute filesystem paths with full test coverage
- Fix cursor position loss when inserting images via native file picker by snapshotting `editor.state.selection` before async dialog