### PR TITLE
feat: check git and gh availability on landing page

### DIFF
--- a/src/main/ipc/preflight.ts
+++ b/src/main/ipc/preflight.ts
@@ -1,0 +1,63 @@
+import { ipcMain } from 'electron'
+import { execFile } from 'child_process'
+import { promisify } from 'util'
+
+const execFileAsync = promisify(execFile)
+
+export type PreflightStatus = {
+  git: { installed: boolean }
+  gh: { installed: boolean; authenticated: boolean }
+}
+
+// Why: cache the result so repeated Landing mounts don't re-spawn processes.
+// The check only runs once per app session — relaunch to re-check.
+let cached: PreflightStatus | null = null
+
+async function isCommandAvailable(command: string): Promise<boolean> {
+  try {
+    await execFileAsync(command, ['--version'])
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function isGhAuthenticated(): Promise<boolean> {
+  try {
+    const { stdout } = await execFileAsync('gh', ['auth', 'status'], {
+      encoding: 'utf-8'
+    })
+    return stdout.includes('Logged in')
+  } catch (error) {
+    // gh auth status writes to stderr and exits 1 when not authenticated,
+    // but also writes "Logged in" to stderr when authenticated on older versions.
+    const stderr = (error as { stderr?: string }).stderr ?? ''
+    return stderr.includes('Logged in')
+  }
+}
+
+async function runPreflightCheck(): Promise<PreflightStatus> {
+  if (cached) {
+    return cached
+  }
+
+  const [gitInstalled, ghInstalled] = await Promise.all([
+    isCommandAvailable('git'),
+    isCommandAvailable('gh')
+  ])
+
+  const ghAuthenticated = ghInstalled ? await isGhAuthenticated() : false
+
+  cached = {
+    git: { installed: gitInstalled },
+    gh: { installed: ghInstalled, authenticated: ghAuthenticated }
+  }
+
+  return cached
+}
+
+export function registerPreflightHandlers(): void {
+  ipcMain.handle('preflight:check', async (): Promise<PreflightStatus> => {
+    return runPreflightCheck()
+  })
+}

--- a/src/main/ipc/register-core-handlers.test.ts
+++ b/src/main/ipc/register-core-handlers.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
   registerCliHandlersMock,
+  registerPreflightHandlersMock,
   registerGitHubHandlersMock,
   registerSettingsHandlersMock,
   registerShellHandlersMock,
@@ -13,6 +14,7 @@ const {
   registerUpdaterHandlersMock
 } = vi.hoisted(() => ({
   registerCliHandlersMock: vi.fn(),
+  registerPreflightHandlersMock: vi.fn(),
   registerGitHubHandlersMock: vi.fn(),
   registerSettingsHandlersMock: vi.fn(),
   registerShellHandlersMock: vi.fn(),
@@ -26,6 +28,10 @@ const {
 
 vi.mock('./cli', () => ({
   registerCliHandlers: registerCliHandlersMock
+}))
+
+vi.mock('./preflight', () => ({
+  registerPreflightHandlers: registerPreflightHandlersMock
 }))
 
 vi.mock('./github', () => ({
@@ -66,6 +72,7 @@ import { registerCoreHandlers } from './register-core-handlers'
 describe('registerCoreHandlers', () => {
   beforeEach(() => {
     registerCliHandlersMock.mockReset()
+    registerPreflightHandlersMock.mockReset()
     registerGitHubHandlersMock.mockReset()
     registerSettingsHandlersMock.mockReset()
     registerShellHandlersMock.mockReset()
@@ -90,6 +97,7 @@ describe('registerCoreHandlers', () => {
     expect(registerFilesystemHandlersMock).toHaveBeenCalledWith(store)
     expect(registerRuntimeHandlersMock).toHaveBeenCalledWith(runtime)
     expect(registerCliHandlersMock).toHaveBeenCalled()
+    expect(registerPreflightHandlersMock).toHaveBeenCalled()
     expect(registerShellHandlersMock).toHaveBeenCalled()
     expect(registerClipboardHandlersMock).toHaveBeenCalled()
     expect(registerUpdaterHandlersMock).toHaveBeenCalled()

--- a/src/main/ipc/register-core-handlers.ts
+++ b/src/main/ipc/register-core-handlers.ts
@@ -1,4 +1,5 @@
 import { registerCliHandlers } from './cli'
+import { registerPreflightHandlers } from './preflight'
 import type { Store } from '../persistence'
 import type { OrcaRuntimeService } from '../runtime/orca-runtime'
 import { registerFilesystemHandlers } from './filesystem'
@@ -16,6 +17,7 @@ import {
 
 export function registerCoreHandlers(store: Store, runtime: OrcaRuntimeService): void {
   registerCliHandlers()
+  registerPreflightHandlers()
   registerGitHubHandlers(store)
   registerSettingsHandlers(store)
   registerShellHandlers()

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -209,6 +209,15 @@ type GitApi = {
   }) => Promise<string | null>
 }
 
+type PreflightStatus = {
+  git: { installed: boolean }
+  gh: { installed: boolean; authenticated: boolean }
+}
+
+type PreflightApi = {
+  check: () => Promise<PreflightStatus>
+}
+
 type Api = {
   repos: ReposApi
   worktrees: WorktreesApi
@@ -216,6 +225,7 @@ type Api = {
   gh: GhApi
   settings: SettingsApi
   cli: CliApi
+  preflight: PreflightApi
   shell: ShellApi
   hooks: HooksApi
   cache: CacheApi

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -222,6 +222,13 @@ const api = {
     remove: (): Promise<CliInstallStatus> => ipcRenderer.invoke('cli:remove')
   },
 
+  preflight: {
+    check: (): Promise<{
+      git: { installed: boolean }
+      gh: { installed: boolean; authenticated: boolean }
+    }> => ipcRenderer.invoke('preflight:check')
+  },
+
   shell: {
     openPath: (path: string): Promise<void> => ipcRenderer.invoke('shell:openPath', path),
 

--- a/src/renderer/src/components/Landing.tsx
+++ b/src/renderer/src/components/Landing.tsx
@@ -1,5 +1,5 @@
-import { useMemo } from 'react'
-import { FolderPlus, GitBranchPlus } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+import { AlertTriangle, ExternalLink, FolderPlus, GitBranchPlus } from 'lucide-react'
 import { useAppStore } from '../store'
 import logo from '../../../../resources/logo.svg'
 
@@ -7,6 +7,14 @@ type ShortcutItem = {
   id: string
   keys: string[]
   action: string
+}
+
+type PreflightIssue = {
+  id: string
+  title: string
+  description: string
+  fixLabel: string
+  fixUrl: string
 }
 
 function KeyCap({ label }: { label: string }): React.JSX.Element {
@@ -17,12 +25,88 @@ function KeyCap({ label }: { label: string }): React.JSX.Element {
   )
 }
 
+function PreflightBanner({ issues }: { issues: PreflightIssue[] }): React.JSX.Element {
+  return (
+    <div className="w-full rounded-lg border border-yellow-500/30 bg-yellow-500/5 p-4 space-y-3">
+      <div className="flex items-center gap-2 text-yellow-500">
+        <AlertTriangle className="size-4 shrink-0" />
+        <span className="text-sm font-medium">Missing dependencies</span>
+      </div>
+      <div className="space-y-2.5">
+        {issues.map((issue) => (
+          <div key={issue.id} className="flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <p className="text-sm font-medium text-foreground">{issue.title}</p>
+              <p className="text-xs text-muted-foreground mt-0.5">{issue.description}</p>
+            </div>
+            <button
+              className="inline-flex items-center gap-1 shrink-0 text-xs font-medium text-blue-400 hover:text-blue-300 transition-colors cursor-pointer"
+              onClick={() => window.api.shell.openUrl(issue.fixUrl)}
+            >
+              {issue.fixLabel}
+              <ExternalLink className="size-3" />
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
 export default function Landing(): React.JSX.Element {
   const repos = useAppStore((s) => s.repos)
   const addRepo = useAppStore((s) => s.addRepo)
   const openModal = useAppStore((s) => s.openModal)
 
   const canCreateWorktree = repos.length > 0
+
+  const [preflightIssues, setPreflightIssues] = useState<PreflightIssue[]>([])
+
+  useEffect(() => {
+    let cancelled = false
+
+    void window.api.preflight.check().then((status) => {
+      if (cancelled) {
+        return
+      }
+
+      const issues: PreflightIssue[] = []
+
+      if (!status.git.installed) {
+        issues.push({
+          id: 'git',
+          title: 'Git is not installed',
+          description: 'Orca requires Git to manage repositories and worktrees.',
+          fixLabel: 'Install Git',
+          fixUrl: 'https://git-scm.com/downloads'
+        })
+      }
+
+      if (!status.gh.installed) {
+        issues.push({
+          id: 'gh',
+          title: 'GitHub CLI is not installed',
+          description: 'Orca uses the GitHub CLI (gh) to show pull requests, issues, and checks.',
+          fixLabel: 'Install GitHub CLI',
+          fixUrl: 'https://cli.github.com'
+        })
+      } else if (!status.gh.authenticated) {
+        issues.push({
+          id: 'gh-auth',
+          title: 'GitHub CLI is not authenticated',
+          description: 'Run "gh auth login" in a terminal to connect your GitHub account.',
+          fixLabel: 'Learn more',
+          fixUrl: 'https://cli.github.com/manual/gh_auth_login'
+        })
+      }
+
+      setPreflightIssues(issues)
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
 
   const shortcuts = useMemo<ShortcutItem[]>(
     () => [
@@ -44,6 +128,8 @@ export default function Landing(): React.JSX.Element {
             <img src={logo} alt="Orca logo" className="size-12" />
           </div>
           <h1 className="text-4xl font-bold text-foreground tracking-tight">ORCA</h1>
+
+          {preflightIssues.length > 0 && <PreflightBanner issues={preflightIssues} />}
 
           <p className="text-sm text-muted-foreground text-center">
             {canCreateWorktree


### PR DESCRIPTION
## Summary
- Adds a preflight dependency check for `git` and `gh` CLI on app startup
- Shows a yellow warning banner on the landing page if git is missing, gh is missing, or gh is not authenticated — each with a description and link to install/fix
- Check runs once per session (cached in main process), nothing shown while loading or when everything is fine

## Test plan
- [ ] Launch app with git/gh installed and authenticated — no banner appears
- [ ] Temporarily rename `git` binary, relaunch — "Git is not installed" banner with install link
- [ ] Temporarily rename `gh` binary, relaunch — "GitHub CLI is not installed" banner with install link  
- [ ] Run `gh auth logout`, relaunch — "GitHub CLI is not authenticated" banner with learn more link
- [ ] Verify links open in external browser
- [ ] Verify banner disappears after navigating to a worktree and back (cached result, no re-check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)