### PR TITLE
feat: restore active terminals on app restart

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import { useEffect } from 'react'
 import { DEFAULT_WORKTREE_CARD_PROPERTIES } from '../../shared/constants'
 
@@ -60,6 +61,7 @@ function App(): React.JSX.Element {
   const initGitHubCache = useAppStore((s) => s.initGitHubCache)
   const refreshAllGitHub = useAppStore((s) => s.refreshAllGitHub)
   const hydrateWorkspaceSession = useAppStore((s) => s.hydrateWorkspaceSession)
+  const reconnectPersistedTerminals = useAppStore((s) => s.reconnectPersistedTerminals)
   const hydratePersistedUI = useAppStore((s) => s.hydratePersistedUI)
   const openModal = useAppStore((s) => s.openModal)
   const repos = useAppStore((s) => s.repos)
@@ -92,6 +94,10 @@ function App(): React.JSX.Element {
   // Fetch initial data + hydrate GitHub cache from disk
   useEffect(() => {
     let cancelled = false
+    // Why: AbortController must be declared outside the async block so the
+    // cleanup function can abort it. Under StrictMode the effect runs twice;
+    // without this, the first (unmounted) pass would keep spawning PTYs.
+    const abortController = new AbortController()
 
     void (async () => {
       try {
@@ -102,6 +108,7 @@ function App(): React.JSX.Element {
         if (!cancelled) {
           hydratePersistedUI(persistedUI)
           hydrateWorkspaceSession(session)
+          await reconnectPersistedTerminals(abortController.signal)
           syncZoomCSSVar()
         }
       } catch (error) {
@@ -128,6 +135,10 @@ function App(): React.JSX.Element {
             tabsByWorktree: {},
             terminalLayoutsByTabId: {}
           })
+          // Why: hydrateWorkspaceSession no longer sets workspaceSessionReady.
+          // The error path has no worktrees to reconnect, but must still flip
+          // the flag so auto-tab-creation and session writes are unblocked.
+          await reconnectPersistedTerminals()
         }
       }
       void fetchSettings()
@@ -136,6 +147,7 @@ function App(): React.JSX.Element {
 
     return () => {
       cancelled = true
+      abortController.abort()
     }
   }, [
     fetchRepos,
@@ -143,7 +155,8 @@ function App(): React.JSX.Element {
     fetchSettings,
     initGitHubCache,
     hydratePersistedUI,
-    hydrateWorkspaceSession
+    hydrateWorkspaceSession,
+    reconnectPersistedTerminals
   ])
 
   useEffect(() => {
@@ -165,12 +178,19 @@ function App(): React.JSX.Element {
       return
     }
     const timer = window.setTimeout(() => {
+      // Why: setWorkspaceSession is a full replacement, not a merge.
+      // Every call MUST include activeWorktreeIdsOnShutdown or it is
+      // silently erased from disk.
+      const activeWorktreeIdsOnShutdown = Object.entries(tabsByWorktree)
+        .filter(([, tabs]) => tabs.some((t) => t.ptyId))
+        .map(([worktreeId]) => worktreeId)
       void window.api.session.set({
         activeRepoId,
         activeWorktreeId,
         activeTabId,
         tabsByWorktree,
-        terminalLayoutsByTabId
+        terminalLayoutsByTabId,
+        activeWorktreeIdsOnShutdown
       })
     }, 150)
 
@@ -199,12 +219,16 @@ function App(): React.JSX.Element {
         }
       }
       const state = useAppStore.getState()
+      const activeWorktreeIdsOnShutdown = Object.entries(state.tabsByWorktree)
+        .filter(([, tabs]) => tabs.some((t) => t.ptyId))
+        .map(([worktreeId]) => worktreeId)
       window.api.session.setSync({
         activeRepoId: state.activeRepoId,
         activeWorktreeId: state.activeWorktreeId,
         activeTabId: state.activeTabId,
         tabsByWorktree: state.tabsByWorktree,
-        terminalLayoutsByTabId: state.terminalLayoutsByTabId
+        terminalLayoutsByTabId: state.terminalLayoutsByTabId,
+        activeWorktreeIdsOnShutdown
       })
     }
     window.addEventListener('beforeunload', captureAndFlush)

--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -113,7 +113,12 @@ export default function Terminal(): React.JSX.Element | null {
   // Only mount TerminalPanes for visited worktrees to prevent mass PTY
   // spawning when restoring a session with many saved worktree tabs.
   const mountedWorktreeIdsRef = useRef(new Set<string>())
-  if (activeWorktreeId) {
+  // Why: gated on workspaceSessionReady to prevent TerminalPane from mounting
+  // before reconnectPersistedTerminals() has finished eagerly spawning PTYs.
+  // Without this gate, Phase 1 (hydrateWorkspaceSession) sets activeWorktreeId
+  // with ptyId: null, and TerminalPane would call connectPanePty → pty:spawn,
+  // creating a duplicate PTY for the same tab.
+  if (activeWorktreeId && workspaceSessionReady) {
     mountedWorktreeIdsRef.current.add(activeWorktreeId)
   }
   // Prune IDs of worktrees that no longer exist (deleted/removed)

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -1,8 +1,9 @@
 import type { PaneManager, ManagedPane } from '@/lib/pane-manager/pane-manager'
 import { isGeminiTerminalTitle } from '@/lib/agent-status'
 import { scheduleRuntimeGraphSync } from '@/runtime/sync-runtime-graph'
+import { useAppStore } from '@/store'
 import type { PtyTransport } from './pty-transport'
-import { createIpcPtyTransport } from './pty-transport'
+import { createIpcPtyTransport, getEagerPtyBufferHandle } from './pty-transport'
 
 type PtyConnectionDeps = {
   tabId: string
@@ -82,7 +83,7 @@ export function connectPanePty(
     transport.resize(cols, rows)
   })
 
-  // Defer PTY spawn to next frame so FitAddon has time to calculate
+  // Defer PTY spawn/attach to next frame so FitAddon has time to calculate
   // the correct terminal dimensions from the laid-out container.
   deps.pendingWritesRef.current.set(pane.id, '')
   requestAnimationFrame(() => {
@@ -93,29 +94,60 @@ export function connectPanePty(
     }
     const cols = pane.terminal.cols
     const rows = pane.terminal.rows
-    transport.connect({
-      url: '',
-      cols,
-      rows,
-      callbacks: {
-        onConnect: () => {
-          if (paneStartup?.command) {
-            // Why: setup commands are injected only after the PTY reports a live
-            // shell connection. Writing earlier is racy with shell startup files
-            // and can drop characters on slower shells.
-            transport.sendInput(`${paneStartup.command}\r`)
-          }
-        },
-        onData: (data) => {
-          if (deps.isActiveRef.current) {
-            pane.terminal.write(data)
-          } else {
-            const pending = deps.pendingWritesRef.current
-            pending.set(pane.id, (pending.get(pane.id) ?? '') + data)
-          }
-        }
+
+    const dataCallback = (data: string): void => {
+      if (deps.isActiveRef.current) {
+        pane.terminal.write(data)
+      } else {
+        const pending = deps.pendingWritesRef.current
+        pending.set(pane.id, (pending.get(pane.id) ?? '') + data)
       }
-    })
+    }
+
+    // Why: re-read ptyId inside the rAF instead of capturing it before.
+    // The eagerly-spawned PTY could exit during the one-frame gap (e.g.,
+    // broken .bashrc), clearing the tab's ptyId. Reading it stale would
+    // cause attach() on a dead process, leaving the pane frozen.
+    const existingPtyId = useAppStore
+      .getState()
+      .tabsByWorktree[deps.worktreeId]?.find((t) => t.id === deps.tabId)?.ptyId
+
+    // Why: only attach if the eager buffer handle still exists. For split-pane
+    // tabs, replayTerminalLayout calls connectPanePty once per pane. The first
+    // pane consumes the handle via attach(); subsequent panes find no handle
+    // and fall through to connect(), which spawns their own fresh PTYs. Without
+    // this guard, every split pane would try to share the same PTY ID, and the
+    // last one's handler would overwrite the earlier ones' in the dispatcher.
+    if (existingPtyId && getEagerPtyBufferHandle(existingPtyId)) {
+      // Why: this tab had a PTY eagerly spawned by reconnectPersistedTerminals().
+      // Attach to it instead of spawning a duplicate. Startup commands are
+      // intentionally skipped — the PTY was already spawned with a fresh shell.
+      transport.attach({
+        existingPtyId,
+        cols,
+        rows,
+        callbacks: {
+          onData: dataCallback
+        }
+      })
+    } else {
+      transport.connect({
+        url: '',
+        cols,
+        rows,
+        callbacks: {
+          onConnect: () => {
+            if (paneStartup?.command) {
+              // Why: setup commands are injected only after the PTY reports a live
+              // shell connection. Writing earlier is racy with shell startup files
+              // and can drop characters on slower shells.
+              transport.sendInput(`${paneStartup.command}\r`)
+            }
+          },
+          onData: dataCallback
+        }
+      })
+    }
     scheduleRuntimeGraphSync()
   })
 }

--- a/src/renderer/src/components/terminal-pane/pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import {
   detectAgentStatusFromTitle,
   clearWorkingIndicators,
@@ -19,6 +20,21 @@ export type PtyTransport = {
       onExit?: (code: number) => void
     }
   }) => void | Promise<void>
+  /** Attach to an existing PTY that was eagerly spawned during startup.
+   *  Skips pty:spawn — registers handlers and replays buffered data instead. */
+  attach: (options: {
+    existingPtyId: string
+    cols?: number
+    rows?: number
+    callbacks: {
+      onConnect?: () => void
+      onDisconnect?: () => void
+      onData?: (data: string) => void
+      onStatus?: (shell: string) => void
+      onError?: (message: string, errors?: string[]) => void
+      onExit?: (code: number) => void
+    }
+  }) => void
   disconnect: () => void
   sendInput: (data: string) => boolean
   resize: (
@@ -38,7 +54,7 @@ const ptyDataHandlers = new Map<string, (data: string) => void>()
 const ptyExitHandlers = new Map<string, (code: number) => void>()
 let ptyDispatcherAttached = false
 
-function ensurePtyDispatcher(): void {
+export function ensurePtyDispatcher(): void {
   if (ptyDispatcherAttached) {
     return
   }
@@ -49,6 +65,76 @@ function ensurePtyDispatcher(): void {
   window.api.pty.onExit((payload) => {
     ptyExitHandlers.get(payload.id)?.(payload.code)
   })
+}
+
+// ─── Eager PTY buffer for reconnection on restart ───────────────────
+// Why: On startup, PTYs are spawned before TerminalPane mounts. Shell output
+// (prompt, MOTD) arrives via pty:data before xterm exists. These helpers buffer
+// that output so transport.attach() can replay it when the pane finally mounts.
+
+type EagerPtyHandle = { flush: () => string; dispose: () => void }
+const eagerPtyHandles = new Map<string, EagerPtyHandle>()
+
+export function getEagerPtyBufferHandle(ptyId: string): EagerPtyHandle | undefined {
+  return eagerPtyHandles.get(ptyId)
+}
+
+// Why: 512 KB matches the scrollback buffer cap used by TerminalPane's
+// serialization. Prevents unbounded memory growth if a restored shell
+// runs a long-lived command (e.g. tail -f) in a worktree the user never opens.
+const EAGER_BUFFER_MAX_BYTES = 512 * 1024
+
+export function registerEagerPtyBuffer(
+  ptyId: string,
+  onExit: (ptyId: string, code: number) => void
+): EagerPtyHandle {
+  ensurePtyDispatcher()
+
+  const buffer: string[] = []
+  let bufferBytes = 0
+
+  const dataHandler = (data: string): void => {
+    buffer.push(data)
+    bufferBytes += data.length
+    // Trim from the front when the buffer exceeds the cap, keeping the
+    // most recent output which contains the shell prompt.
+    while (bufferBytes > EAGER_BUFFER_MAX_BYTES && buffer.length > 1) {
+      bufferBytes -= buffer.shift()!.length
+    }
+  }
+  const exitHandler = (code: number): void => {
+    // Shell died before TerminalPane attached — clean up and notify the store
+    // so the tab's ptyId is cleared and connectPanePty falls through to connect().
+    ptyDataHandlers.delete(ptyId)
+    ptyExitHandlers.delete(ptyId)
+    eagerPtyHandles.delete(ptyId)
+    onExit(ptyId, code)
+  }
+
+  ptyDataHandlers.set(ptyId, dataHandler)
+  ptyExitHandlers.set(ptyId, exitHandler)
+
+  const handle: EagerPtyHandle = {
+    flush() {
+      const data = buffer.join('')
+      buffer.length = 0
+      return data
+    },
+    dispose() {
+      // Only remove if the current handler is still the temp one (compare by
+      // reference). After attach() replaces the handler this becomes a no-op.
+      if (ptyDataHandlers.get(ptyId) === dataHandler) {
+        ptyDataHandlers.delete(ptyId)
+      }
+      if (ptyExitHandlers.get(ptyId) === exitHandler) {
+        ptyExitHandlers.delete(ptyId)
+      }
+      eagerPtyHandles.delete(ptyId)
+    }
+  }
+
+  eagerPtyHandles.set(ptyId, handle)
+  return handle
 }
 
 // eslint-disable-next-line no-control-regex -- intentional terminal escape sequence matching
@@ -191,6 +277,94 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
         const msg = err instanceof Error ? err.message : String(err)
         storedCallbacks.onError?.(msg)
       }
+    },
+
+    attach(options) {
+      storedCallbacks = options.callbacks
+      ensurePtyDispatcher()
+
+      if (destroyed) {
+        return
+      }
+
+      const id = options.existingPtyId
+      ptyId = id
+      connected = true
+      // Why: intentionally skip onPtySpawn here. onPtySpawn feeds into
+      // updateTabPtyId → bumpWorktreeActivity, which would reset the
+      // worktree's lastActivityAt to now, destroying the recency sort order
+      // that reconnectPersistedTerminals explicitly preserved.
+
+      // Replace the temporary eager-buffer handlers with real xterm handlers.
+      ptyDataHandlers.set(id, (data) => {
+        storedCallbacks.onData?.(data)
+        if (onTitleChange) {
+          const title = extractLastOscTitle(data)
+          if (title !== null) {
+            if (staleTitleTimer) {
+              clearTimeout(staleTitleTimer)
+              staleTitleTimer = null
+            }
+            lastEmittedTitle = normalizeTerminalTitle(title)
+            onTitleChange(lastEmittedTitle, title)
+            agentTracker?.handleTitle(title)
+          } else if (
+            lastEmittedTitle &&
+            detectAgentStatusFromTitle(lastEmittedTitle) === 'working'
+          ) {
+            if (staleTitleTimer) {
+              clearTimeout(staleTitleTimer)
+            }
+            staleTitleTimer = setTimeout(() => {
+              staleTitleTimer = null
+              if (lastEmittedTitle && detectAgentStatusFromTitle(lastEmittedTitle) === 'working') {
+                const cleared = clearWorkingIndicators(lastEmittedTitle)
+                lastEmittedTitle = cleared
+                onTitleChange(cleared, cleared)
+                agentTracker?.handleTitle(cleared)
+              }
+            }, STALE_TITLE_TIMEOUT)
+          }
+        }
+        if (onBell && chunkContainsBell(data)) {
+          onBell()
+        }
+      })
+
+      ptyExitHandlers.set(id, (code) => {
+        if (staleTitleTimer) {
+          clearTimeout(staleTitleTimer)
+          staleTitleTimer = null
+        }
+        connected = false
+        ptyId = null
+        unregisterPtyHandlers(id)
+        storedCallbacks.onExit?.(code)
+        storedCallbacks.onDisconnect?.()
+        onPtyExit?.(id)
+      })
+
+      // Replay any data buffered between eager spawn and now. Route through
+      // the real data handler (not storedCallbacks.onData directly) so that
+      // OSC title extraction, agent status tracking, and bell detection all
+      // process the buffered output — otherwise restored tabs keep a default
+      // title until later output arrives.
+      const bufferHandle = getEagerPtyBufferHandle(id)
+      if (bufferHandle) {
+        const buffered = bufferHandle.flush()
+        if (buffered) {
+          ptyDataHandlers.get(id)?.(buffered)
+        }
+        bufferHandle.dispose()
+      }
+
+      // Resize to the actual terminal dimensions (eager spawn used defaults).
+      if (options.cols && options.rows) {
+        window.api.pty.resize(id, options.cols, options.rows)
+      }
+
+      storedCallbacks.onConnect?.()
+      storedCallbacks.onStatus?.('shell')
     },
 
     disconnect() {

--- a/src/renderer/src/store/slices/store-session-cascades.test.ts
+++ b/src/renderer/src/store/slices/store-session-cascades.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { create } from 'zustand'
 import type { AppState } from '../types'
@@ -223,8 +224,10 @@ describe('hydrateWorkspaceSession', () => {
     expect(s.terminalLayoutsByTabId['tab-valid']).toBeDefined()
     expect(s.terminalLayoutsByTabId['tab-invalid']).toBeUndefined()
 
-    // Session is marked ready
-    expect(s.workspaceSessionReady).toBe(true)
+    // Why: with two-phase hydration, workspaceSessionReady stays false after
+    // hydrateWorkspaceSession. It flips to true in reconnectPersistedTerminals()
+    // after all eager PTY spawns complete.
+    expect(s.workspaceSessionReady).toBe(false)
   })
 
   it('restores valid activeWorktreeId and activeTabId', () => {
@@ -311,5 +314,278 @@ describe('terminal slice behaviors', () => {
     const tab = store.getState().tabsByWorktree[worktreeId][0]
     expect(tab.ptyId).toBe('pty-1')
     expect(store.getState().ptyIdsByTabId['tab-1']).toEqual(['pty-1'])
+  })
+})
+
+// ─── Reconnect persisted terminals ──────────────────────────────────
+
+// Mock pty-transport's eager buffer registration
+vi.mock('@/components/terminal-pane/pty-transport', () => ({
+  registerEagerPtyBuffer: vi.fn().mockReturnValue({ flush: () => '', dispose: () => {} }),
+  ensurePtyDispatcher: vi.fn()
+}))
+
+describe('reconnectPersistedTerminals', () => {
+  let ptyIdCounter: number
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ptyIdCounter = 0
+    // Mock pty.spawn to return incrementing IDs
+    mockApi.pty.kill = vi.fn().mockResolvedValue(undefined)
+    ;(mockApi.pty as Record<string, unknown>).spawn = vi.fn().mockImplementation(() => {
+      ptyIdCounter++
+      return Promise.resolve({ id: `pty-${ptyIdCounter}` })
+    })
+  })
+
+  it('spawns PTYs for worktrees that were active at shutdown and sets workspaceSessionReady', async () => {
+    const store = createTestStore()
+    const wt1 = 'repo1::/path/wt1'
+    const wt2 = 'repo1::/path/wt2'
+
+    store.setState({
+      repos: [
+        { id: 'repo1', path: '/repo1', displayName: 'Repo 1', badgeColor: '#000', addedAt: 0 }
+      ],
+      worktreesByRepo: {
+        repo1: [
+          makeWorktree({ id: wt1, repoId: 'repo1', path: '/path/wt1' }),
+          makeWorktree({ id: wt2, repoId: 'repo1', path: '/path/wt2' })
+        ]
+      }
+    })
+
+    // Hydrate with activeWorktreeIdsOnShutdown indicating both worktrees had terminals
+    store.getState().hydrateWorkspaceSession({
+      activeRepoId: 'repo1',
+      activeWorktreeId: wt1,
+      activeTabId: 'tab1',
+      tabsByWorktree: {
+        [wt1]: [makeTab({ id: 'tab1', worktreeId: wt1, ptyId: 'old-pty-1' })],
+        [wt2]: [makeTab({ id: 'tab2', worktreeId: wt2, ptyId: 'old-pty-2' })]
+      },
+      terminalLayoutsByTabId: { tab1: makeLayout(), tab2: makeLayout() },
+      activeWorktreeIdsOnShutdown: [wt1, wt2]
+    })
+
+    // After hydration, workspaceSessionReady is false
+    expect(store.getState().workspaceSessionReady).toBe(false)
+    // ptyIds are cleared by clearTransientTerminalState
+    expect(store.getState().tabsByWorktree[wt1][0].ptyId).toBeNull()
+    expect(store.getState().tabsByWorktree[wt2][0].ptyId).toBeNull()
+    // pendingReconnectWorktreeIds is populated
+    expect(store.getState().pendingReconnectWorktreeIds).toEqual([wt1, wt2])
+
+    // Run reconnect
+    await store.getState().reconnectPersistedTerminals()
+
+    const s = store.getState()
+    // workspaceSessionReady is now true
+    expect(s.workspaceSessionReady).toBe(true)
+    // Tabs now have live ptyIds
+    expect(s.tabsByWorktree[wt1][0].ptyId).toBe('pty-1')
+    expect(s.tabsByWorktree[wt2][0].ptyId).toBe('pty-2')
+    // ptyIdsByTabId is populated
+    expect(s.ptyIdsByTabId['tab1']).toContain('pty-1')
+    expect(s.ptyIdsByTabId['tab2']).toContain('pty-2')
+    // pendingReconnectWorktreeIds is cleared
+    expect(s.pendingReconnectWorktreeIds).toEqual([])
+    // Spawn was called with correct cwd
+    expect((mockApi.pty as Record<string, unknown>).spawn).toHaveBeenCalledTimes(2)
+    expect((mockApi.pty as Record<string, unknown>).spawn).toHaveBeenCalledWith(
+      expect.objectContaining({ cwd: '/path/wt1' })
+    )
+    expect((mockApi.pty as Record<string, unknown>).spawn).toHaveBeenCalledWith(
+      expect.objectContaining({ cwd: '/path/wt2' })
+    )
+  })
+
+  it('sets workspaceSessionReady even with no pending worktrees', async () => {
+    const store = createTestStore()
+
+    store.setState({
+      repos: [
+        { id: 'repo1', path: '/repo1', displayName: 'Repo 1', badgeColor: '#000', addedAt: 0 }
+      ],
+      worktreesByRepo: { repo1: [] }
+    })
+
+    store.getState().hydrateWorkspaceSession({
+      activeRepoId: null,
+      activeWorktreeId: null,
+      activeTabId: null,
+      tabsByWorktree: {},
+      terminalLayoutsByTabId: {}
+    })
+
+    await store.getState().reconnectPersistedTerminals()
+    expect(store.getState().workspaceSessionReady).toBe(true)
+    expect((mockApi.pty as Record<string, unknown>).spawn).not.toHaveBeenCalled()
+  })
+
+  it('falls back to tab ptyIds when activeWorktreeIdsOnShutdown is absent (upgrade)', async () => {
+    const store = createTestStore()
+    const wt1 = 'repo1::/path/wt1'
+
+    store.setState({
+      repos: [
+        { id: 'repo1', path: '/repo1', displayName: 'Repo 1', badgeColor: '#000', addedAt: 0 }
+      ],
+      worktreesByRepo: {
+        repo1: [makeWorktree({ id: wt1, repoId: 'repo1', path: '/path/wt1' })]
+      }
+    })
+
+    // No activeWorktreeIdsOnShutdown — simulates session from older build
+    // The tab still has a ptyId from the raw session data
+    store.getState().hydrateWorkspaceSession({
+      activeRepoId: 'repo1',
+      activeWorktreeId: wt1,
+      activeTabId: 'tab1',
+      tabsByWorktree: {
+        [wt1]: [makeTab({ id: 'tab1', worktreeId: wt1, ptyId: 'old-pty' })]
+      },
+      terminalLayoutsByTabId: { tab1: makeLayout() }
+      // No activeWorktreeIdsOnShutdown field
+    })
+
+    // Should still detect wt1 as needing reconnection from raw ptyIds
+    expect(store.getState().pendingReconnectWorktreeIds).toEqual([wt1])
+
+    await store.getState().reconnectPersistedTerminals()
+    expect(store.getState().tabsByWorktree[wt1][0].ptyId).toBe('pty-1')
+  })
+
+  it('reconnects the correct tab per worktree (not always tabs[0])', async () => {
+    const store = createTestStore()
+    const wt1 = 'repo1::/path/wt1'
+
+    store.setState({
+      repos: [
+        { id: 'repo1', path: '/repo1', displayName: 'Repo 1', badgeColor: '#000', addedAt: 0 }
+      ],
+      worktreesByRepo: {
+        repo1: [makeWorktree({ id: wt1, repoId: 'repo1', path: '/path/wt1' })]
+      }
+    })
+
+    // Tab2 had the live PTY, not tab1
+    store.getState().hydrateWorkspaceSession({
+      activeRepoId: 'repo1',
+      activeWorktreeId: wt1,
+      activeTabId: 'tab2',
+      tabsByWorktree: {
+        [wt1]: [
+          makeTab({ id: 'tab1', worktreeId: wt1, ptyId: null }),
+          makeTab({ id: 'tab2', worktreeId: wt1, ptyId: 'old-pty-2' })
+        ]
+      },
+      terminalLayoutsByTabId: { tab1: makeLayout(), tab2: makeLayout() },
+      activeWorktreeIdsOnShutdown: [wt1]
+    })
+
+    await store.getState().reconnectPersistedTerminals()
+
+    // tab2 should get the PTY, not tab1
+    expect(store.getState().tabsByWorktree[wt1][0].ptyId).toBeNull() // tab1
+    expect(store.getState().tabsByWorktree[wt1][1].ptyId).toBe('pty-1') // tab2
+  })
+
+  it('reconnects multiple live tabs in the same worktree', async () => {
+    const store = createTestStore()
+    const wt1 = 'repo1::/path/wt1'
+
+    store.setState({
+      repos: [
+        { id: 'repo1', path: '/repo1', displayName: 'Repo 1', badgeColor: '#000', addedAt: 0 }
+      ],
+      worktreesByRepo: {
+        repo1: [makeWorktree({ id: wt1, repoId: 'repo1', path: '/path/wt1' })]
+      }
+    })
+
+    // Both tabs had live PTYs
+    store.getState().hydrateWorkspaceSession({
+      activeRepoId: 'repo1',
+      activeWorktreeId: wt1,
+      activeTabId: 'tab1',
+      tabsByWorktree: {
+        [wt1]: [
+          makeTab({ id: 'tab1', worktreeId: wt1, ptyId: 'old-pty-1' }),
+          makeTab({ id: 'tab2', worktreeId: wt1, ptyId: 'old-pty-2' })
+        ]
+      },
+      terminalLayoutsByTabId: { tab1: makeLayout(), tab2: makeLayout() },
+      activeWorktreeIdsOnShutdown: [wt1]
+    })
+
+    await store.getState().reconnectPersistedTerminals()
+
+    // Both tabs should have new PTYs
+    expect(store.getState().tabsByWorktree[wt1][0].ptyId).toBe('pty-1')
+    expect(store.getState().tabsByWorktree[wt1][1].ptyId).toBe('pty-2')
+  })
+
+  it('does not bump lastActivityAt for reconnected worktrees', async () => {
+    const store = createTestStore()
+    const wt1 = 'repo1::/path/wt1'
+
+    store.setState({
+      repos: [
+        { id: 'repo1', path: '/repo1', displayName: 'Repo 1', badgeColor: '#000', addedAt: 0 }
+      ],
+      worktreesByRepo: {
+        repo1: [makeWorktree({ id: wt1, repoId: 'repo1', path: '/path/wt1', lastActivityAt: 1000 })]
+      }
+    })
+
+    store.getState().hydrateWorkspaceSession({
+      activeRepoId: 'repo1',
+      activeWorktreeId: wt1,
+      activeTabId: 'tab1',
+      tabsByWorktree: {
+        [wt1]: [makeTab({ id: 'tab1', worktreeId: wt1, ptyId: 'old-pty' })]
+      },
+      terminalLayoutsByTabId: { tab1: makeLayout() },
+      activeWorktreeIdsOnShutdown: [wt1]
+    })
+
+    await store.getState().reconnectPersistedTerminals()
+
+    // updateMeta should NOT have been called — we bypassed bumpWorktreeActivity
+    expect(mockApi.worktrees.updateMeta).not.toHaveBeenCalled()
+  })
+
+  it('skips deleted worktrees in activeWorktreeIdsOnShutdown', async () => {
+    const store = createTestStore()
+    const existing = 'repo1::/path/wt1'
+    const deleted = 'repo1::/path/deleted'
+
+    store.setState({
+      repos: [
+        { id: 'repo1', path: '/repo1', displayName: 'Repo 1', badgeColor: '#000', addedAt: 0 }
+      ],
+      worktreesByRepo: {
+        repo1: [makeWorktree({ id: existing, repoId: 'repo1', path: '/path/wt1' })]
+      }
+    })
+
+    store.getState().hydrateWorkspaceSession({
+      activeRepoId: 'repo1',
+      activeWorktreeId: existing,
+      activeTabId: 'tab1',
+      tabsByWorktree: {
+        [existing]: [makeTab({ id: 'tab1', worktreeId: existing, ptyId: 'old' })]
+      },
+      terminalLayoutsByTabId: { tab1: makeLayout() },
+      activeWorktreeIdsOnShutdown: [existing, deleted]
+    })
+
+    // Deleted worktree should be filtered out
+    expect(store.getState().pendingReconnectWorktreeIds).toEqual([existing])
+
+    await store.getState().reconnectPersistedTerminals()
+    expect((mockApi.pty as Record<string, unknown>).spawn).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -8,6 +8,10 @@ import type {
 } from '../../../../shared/types'
 import { scheduleRuntimeGraphSync } from '@/runtime/sync-runtime-graph'
 import { clearTransientTerminalState, emptyLayoutSnapshot } from './terminal-helpers'
+import {
+  registerEagerPtyBuffer,
+  ensurePtyDispatcher
+} from '@/components/terminal-pane/pty-transport'
 
 export type TerminalSlice = {
   tabsByWorktree: Record<string, TerminalTab[]>
@@ -20,6 +24,8 @@ export type TerminalSlice = {
   pendingStartupByTabId: Record<string, { command: string; env?: Record<string, string> }>
   tabBarOrderByWorktree: Record<string, string[]>
   workspaceSessionReady: boolean
+  pendingReconnectWorktreeIds: string[]
+  pendingReconnectTabByWorktree: Record<string, string[]>
   createTab: (worktreeId: string) => TerminalTab
   closeTab: (tabId: string) => void
   reorderTabs: (worktreeId: string, tabIds: string[]) => void
@@ -43,6 +49,7 @@ export type TerminalSlice = {
     tabId: string
   ) => { command: string; env?: Record<string, string> } | null
   hydrateWorkspaceSession: (session: WorkspaceSessionState) => void
+  reconnectPersistedTerminals: (signal?: AbortSignal) => Promise<void>
 }
 
 export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> = (set, get) => ({
@@ -56,6 +63,8 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
   pendingStartupByTabId: {},
   tabBarOrderByWorktree: {},
   workspaceSessionReady: false,
+  pendingReconnectWorktreeIds: [],
+  pendingReconnectTabByWorktree: {},
 
   createTab: (worktreeId) => {
     const id = globalThis.crypto.randomUUID()
@@ -422,11 +431,41 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
           ? session.activeRepoId
           : null
 
+      // Why: workspaceSessionReady stays false here. It is set to true in
+      // reconnectPersistedTerminals() after all eager PTY spawns complete.
+      // This prevents TerminalPane from mounting and spawning duplicate PTYs
+      // before the reconnect phase has set ptyId on each tab.
+      // Why: fall back to deriving the list from tabsByWorktree ptyIds when
+      // activeWorktreeIdsOnShutdown is absent (upgrade from older build).
+      // The raw tabs still carry ptyId values before clearTransientTerminalState
+      // nulls them, so we can infer which worktrees had active terminals.
+      const shutdownIds =
+        session.activeWorktreeIdsOnShutdown ??
+        Object.entries(session.tabsByWorktree)
+          .filter(([, tabs]) => tabs.some((t) => t.ptyId))
+          .map(([wId]) => wId)
+      const pendingReconnectWorktreeIds = shutdownIds.filter((id) => validWorktreeIds.has(id))
+
+      // Why: capture which specific tabs had live PTYs per worktree from the
+      // raw session data BEFORE clearTransientTerminalState nulled the ptyIds.
+      // This ensures reconnectPersistedTerminals binds PTYs to the correct
+      // tabs, not just tabs[0], which matters for multi-tab worktrees.
+      const pendingReconnectTabByWorktree: Record<string, string[]> = {}
+      for (const worktreeId of pendingReconnectWorktreeIds) {
+        const rawTabs = session.tabsByWorktree[worktreeId] ?? []
+        const liveTabIds = rawTabs.filter((t) => t.ptyId && validTabIds.has(t.id)).map((t) => t.id)
+        if (liveTabIds.length > 0) {
+          pendingReconnectTabByWorktree[worktreeId] = liveTabIds
+        }
+      }
+
       return {
         activeRepoId,
         activeWorktreeId,
         activeTabId,
         tabsByWorktree,
+        pendingReconnectWorktreeIds,
+        pendingReconnectTabByWorktree,
         ptyIdsByTabId: Object.fromEntries(
           Object.values(tabsByWorktree)
             .flat()
@@ -434,9 +473,136 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         ),
         terminalLayoutsByTabId: Object.fromEntries(
           Object.entries(session.terminalLayoutsByTabId).filter(([tabId]) => validTabIds.has(tabId))
-        ),
-        workspaceSessionReady: true
+        )
       }
+    })
+  },
+
+  reconnectPersistedTerminals: async (signal) => {
+    const {
+      pendingReconnectWorktreeIds,
+      pendingReconnectTabByWorktree,
+      worktreesByRepo,
+      tabsByWorktree
+    } = get()
+    const ids = pendingReconnectWorktreeIds ?? []
+
+    if (ids.length === 0) {
+      set({
+        workspaceSessionReady: true,
+        pendingReconnectWorktreeIds: [],
+        pendingReconnectTabByWorktree: {}
+      })
+      return
+    }
+
+    const allWorktrees = Object.values(worktreesByRepo).flat()
+    const worktreeMap = new Map(allWorktrees.map((w) => [w.id, w]))
+    const spawnedPtyIds: string[] = []
+
+    // Why: ensure the global IPC listener for pty:data/pty:exit events is
+    // active before any spawn calls. This guarantees that data emitted
+    // immediately after spawn (before registerEagerPtyBuffer runs) is at
+    // least delivered to the dispatcher — and since registerEagerPtyBuffer
+    // runs synchronously in the microtask continuation after await spawn(),
+    // the handler will be in place before any macrotask-queued data arrives.
+    ensurePtyDispatcher()
+
+    for (const worktreeId of ids) {
+      if (signal?.aborted) {
+        // StrictMode unmount — kill any PTYs we already spawned and bail.
+        await Promise.allSettled(spawnedPtyIds.map((id) => window.api.pty.kill(id)))
+        return
+      }
+
+      const worktree = worktreeMap.get(worktreeId)
+      if (!worktree) {
+        continue
+      }
+
+      const tabs = tabsByWorktree[worktreeId] ?? []
+      // Why: pendingReconnectTabByWorktree was computed during hydration from
+      // the raw session data (before ptyIds were cleared). It tells us exactly
+      // which tabs had live PTYs in each worktree, so we reconnect all of them
+      // rather than just one arbitrary tab.
+      const targetTabIds = pendingReconnectTabByWorktree[worktreeId] ?? []
+      const tabsToReconnect: TerminalTab[] =
+        targetTabIds.length > 0
+          ? targetTabIds
+              .map((id) => tabs.find((t) => t.id === id))
+              .filter((t): t is TerminalTab => t != null)
+          : tabs.slice(0, 1) // fallback: first tab only
+      if (tabsToReconnect.length === 0) {
+        continue
+      }
+
+      for (const tab of tabsToReconnect) {
+        if (signal?.aborted) {
+          await Promise.allSettled(spawnedPtyIds.map((id) => window.api.pty.kill(id)))
+          return
+        }
+
+        try {
+          const { id: ptyId } = await window.api.pty.spawn({
+            cols: 80,
+            rows: 24,
+            cwd: worktree.path
+          })
+          spawnedPtyIds.push(ptyId)
+
+          if (signal?.aborted) {
+            await window.api.pty.kill(ptyId)
+            await Promise.allSettled(
+              spawnedPtyIds.filter((id) => id !== ptyId).map((id) => window.api.pty.kill(id))
+            )
+            return
+          }
+
+          const tabId = tab.id
+          // Why: re-check that the tab/worktree still exist after the async
+          // spawn. If the user deleted the worktree during the spawn round-
+          // trip, kill the orphan PTY immediately instead of registering it.
+          const currentTabs = get().tabsByWorktree[worktreeId]
+          if (!currentTabs?.some((t) => t.id === tabId)) {
+            void window.api.pty.kill(ptyId)
+            continue
+          }
+
+          // Why: register exit handler so that if the shell dies before
+          // TerminalPane attaches, the tab's ptyId is cleared and
+          // connectPanePty falls through to the normal connect() path.
+          registerEagerPtyBuffer(ptyId, (_exitedPtyId, _code) => {
+            get().clearTabPtyId(tabId, _exitedPtyId)
+          })
+
+          // Why: set ptyId directly instead of using updateTabPtyId to avoid
+          // bumpWorktreeActivity which would overwrite every reconnected
+          // worktree's lastActivityAt with the restart timestamp, destroying
+          // the relative recency sort order.
+          set((s) => {
+            const next = { ...s.tabsByWorktree }
+            if (!next[worktreeId]) {
+              return {}
+            }
+            next[worktreeId] = next[worktreeId].map((t) => (t.id === tabId ? { ...t, ptyId } : t))
+            return {
+              tabsByWorktree: next,
+              ptyIdsByTabId: {
+                ...s.ptyIdsByTabId,
+                [tabId]: [...(s.ptyIdsByTabId[tabId] ?? []), ptyId]
+              }
+            }
+          })
+        } catch {
+          // PTY spawn failure — this tab stays inactive, same as today.
+        }
+      }
+    }
+
+    set({
+      workspaceSessionReady: true,
+      pendingReconnectWorktreeIds: [],
+      pendingReconnectTabByWorktree: {}
     })
   }
 })

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -96,6 +96,10 @@ export type WorkspaceSessionState = {
   activeTabId: string | null
   tabsByWorktree: Record<string, TerminalTab[]>
   terminalLayoutsByTabId: Record<string, TerminalLayoutSnapshot>
+  /** Worktree IDs that had at least one tab with a live PTY at shutdown.
+   *  Used on startup to eagerly re-spawn PTY processes so the Active filter
+   *  works immediately after restart. */
+  activeWorktreeIdsOnShutdown?: string[]
 }
 
 // ─── GitHub ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Eagerly re-spawn PTY processes on startup for worktrees that had active terminals before shutdown, so the Active worktree filter works immediately after restart
- Two-phase hydration prevents duplicate PTY spawns: `workspaceSessionReady` stays false until all eager PTY spawns complete, gating `TerminalPane` mounting
- Upgrade-safe: falls back to deriving active worktrees from raw tab `ptyId` values when `activeWorktreeIdsOnShutdown` is absent (older session format)

## Design

On shutdown, compute which worktrees have live PTYs and persist as `activeWorktreeIdsOnShutdown` in the session. On startup:

1. **Phase 1** (`hydrateWorkspaceSession`): restore tabs with `ptyId: null`, store pending reconnect list — `workspaceSessionReady` stays `false`
2. **Phase 2** (`reconnectPersistedTerminals`): spawn PTYs for each previously-live tab, buffer shell output via `registerEagerPtyBuffer()`, set `ptyId` directly (bypassing `bumpWorktreeActivity` to preserve recency sort), then flip `workspaceSessionReady = true`
3. **Attach**: when `TerminalPane` mounts, `connectPanePty` detects existing `ptyId` + eager buffer handle → calls `transport.attach()` instead of `transport.connect()`, replaying buffered data through the title/bell parser

Key safeguards:
- 512KB buffer cap prevents unbounded memory for unopened worktrees
- Exit handler on eager PTYs clears stale `ptyId` if shell dies before attach
- AbortController connected to effect cleanup for StrictMode safety
- Re-checks tab existence after async spawn to prevent orphaned PTYs
- Split-pane guard: only the first pane attaches; subsequent panes spawn fresh

## Test plan

- [x] TypeScript compiles (`pnpm run typecheck`)
- [x] All 515 tests pass (`pnpm test`) — 7 new integration tests covering:
  - Happy path: spawn PTYs for active worktrees, verify ptyIds and ready flag
  - Empty session: ready flag still flips (no deadlock)
  - Upgrade fallback: sessions without `activeWorktreeIdsOnShutdown`
  - Correct tab targeting: reconnects the tab that had the live PTY, not `tabs[0]`
  - Multi-tab: both live tabs in a worktree get new PTYs
  - No activity bump: `lastActivityAt` preserved (recency sort intact)
  - Deleted worktrees: filtered out during hydration
- [ ] Manual: restart app with active worktrees, verify Active filter shows them immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)