### PR TITLE
feat: preserve sidebar sort order across restarts

### DIFF
--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -42,6 +42,7 @@ export function registerWorktreeHandlers(mainWindow: BrowserWindow, store: Store
   ipcMain.removeHandler('worktrees:create')
   ipcMain.removeHandler('worktrees:remove')
   ipcMain.removeHandler('worktrees:updateMeta')
+  ipcMain.removeHandler('worktrees:persistSortOrder')
   ipcMain.removeHandler('hooks:check')
 
   ipcMain.handle('worktrees:listAll', async () => {
@@ -249,6 +250,25 @@ export function registerWorktreeHandlers(mainWindow: BrowserWindow, store: Store
       return meta
     }
   )
+
+  // Why: the renderer continuously snapshots the computed sidebar order into
+  // sortOrder so that it can be restored on cold start (when ephemeral signals
+  // like running jobs and live terminals are gone). A single batch call avoids
+  // N individual updateMeta IPC round-trips; the persistence layer debounces
+  // the actual disk write.
+  ipcMain.handle('worktrees:persistSortOrder', (_event, args: { orderedIds: string[] }) => {
+    // Defensive: guard against malformed or missing input from the renderer.
+    if (!Array.isArray(args?.orderedIds) || args.orderedIds.length === 0) {
+      return
+    }
+    const now = Date.now()
+    for (let i = 0; i < args.orderedIds.length; i++) {
+      // Descending timestamps so that the first item has the highest
+      // sortOrder value (most recent), making b.sortOrder - a.sortOrder
+      // a natural "first wins" comparator on cold start.
+      store.setWorktreeMeta(args.orderedIds[i], { sortOrder: now - i * 1000 })
+    }
+  })
 
   ipcMain.handle('hooks:check', (_event, args: { repoId: string }) => {
     const repo = store.getRepo(args.repoId)

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -46,6 +46,7 @@ type WorktreesApi = {
   create: (args: CreateWorktreeArgs) => Promise<CreateWorktreeResult>
   remove: (args: { worktreeId: string; force?: boolean }) => Promise<void>
   updateMeta: (args: { worktreeId: string; updates: Partial<WorktreeMeta> }) => Promise<Worktree>
+  persistSortOrder: (args: { orderedIds: string[] }) => Promise<void>
   onChanged: (callback: (data: { repoId: string }) => void) => () => void
 }
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -139,6 +139,9 @@ const api = {
       updates: Record<string, unknown>
     }): Promise<unknown> => ipcRenderer.invoke('worktrees:updateMeta', args),
 
+    persistSortOrder: (args: { orderedIds: string[] }): Promise<void> =>
+      ipcRenderer.invoke('worktrees:persistSortOrder', args),
+
     onChanged: (callback: (data: { repoId: string }) => void): (() => void) => {
       const listener = (_event: Electron.IpcRendererEvent, data: { repoId: string }) =>
         callback(data)

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -39,6 +39,13 @@ const WorktreeList = React.memo(function WorktreeList() {
 
   const sortEpoch = useAppStore((s) => s.sortEpoch)
   const scrollRef = useRef<HTMLDivElement>(null)
+  // Why a latching ref: we need to distinguish "app just started, no PTYs
+  // have spawned yet" from "user closed all terminals mid-session." The
+  // former should use the persisted sortOrder; the latter should keep using
+  // the live smart score. A point-in-time `hasAnyLivePty` check conflates
+  // the two. This ref flips to true once any PTY is observed and never
+  // reverts, so the cold-start path is only used on actual cold start.
+  const sessionHasHadPty = useRef(false)
 
   const repoMap = useMemo(() => {
     const m = new Map<string, Repo>()
@@ -64,6 +71,28 @@ const WorktreeList = React.memo(function WorktreeList() {
     const allWorktrees: Worktree[] = Object.values(state.worktreesByRepo)
       .flat()
       .filter((w) => !w.isArchived)
+
+    // Why cold-start detection: the smart score is dominated by ephemeral
+    // signals (running jobs +60, live terminals +12, needs attention +35)
+    // that vanish after restart. Recomputing the smart score on cold start
+    // produces a shuffled ordering because those signals are gone while
+    // persistent ones (unread, linked PR) survive — changing relative ranks.
+    // Instead, restore the pre-shutdown order from the persisted sortOrder
+    // snapshot, and switch to the live smart score once PTYs start spawning.
+    if (sortBy === 'recent' && !sessionHasHadPty.current) {
+      const hasAnyLivePty = Object.values(state.tabsByWorktree)
+        .flat()
+        .some((t) => t.ptyId)
+      if (hasAnyLivePty) {
+        sessionHasHadPty.current = true
+      } else {
+        allWorktrees.sort(
+          (a, b) => b.sortOrder - a.sortOrder || a.displayName.localeCompare(b.displayName)
+        )
+        return allWorktrees.map((w) => w.id)
+      }
+    }
+
     const currentRepoMap = new Map(state.repos.map((r) => [r.id, r]))
     const currentTabs = state.tabsByWorktree
     allWorktrees.sort(
@@ -74,6 +103,16 @@ const WorktreeList = React.memo(function WorktreeList() {
     // its change signals that the sort order should be recomputed.
     // oxlint-disable-next-line react-hooks/exhaustive-deps
   }, [sortEpoch, sortBy, repos])
+
+  // Persist the computed sort order so the sidebar can be restored after
+  // restart. Only persist during live sessions (sessionHasHadPty latched) —
+  // on cold start we are *reading* the persisted order, not overwriting it.
+  useEffect(() => {
+    if (sortBy !== 'recent' || sortedIds.length === 0 || !sessionHasHadPty.current) {
+      return
+    }
+    void window.api.worktrees.persistSortOrder({ orderedIds: sortedIds })
+  }, [sortedIds, sortBy])
 
   // Flatten, filter, and apply stable sort order
   const visibleWorktrees = useMemo(() => {


### PR DESCRIPTION
## Summary
- Adds a new `worktrees:persistSortOrder` IPC handler that batch-persists the computed sidebar sort order as descending `sortOrder` timestamps
- Introduces cold-start detection in `WorktreeList` using a `sessionHasHadPty` latching ref — on cold start (before any PTY spawns), restores the pre-shutdown order from persisted `sortOrder` instead of recomputing the smart score (which would shuffle items since ephemeral signals like running jobs and live terminals are gone)
- Once PTYs start spawning, switches to the live smart score and continuously persists the computed order for the next restart

## Test plan
- [ ] Verify sidebar order is preserved after app restart
- [ ] Verify that once terminals are opened, live smart scoring takes over
- [ ] Verify switching sort modes (e.g., alphabetical) does not trigger sort order persistence
- [ ] Verify new worktrees without prior sortOrder appear at the bottom on cold start