### PR TITLE
feat: headless autosave controller & updater beforeunload bypass

### DIFF
--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -9,6 +9,10 @@ import {
   ORCA_EDITOR_SAVE_DIRTY_FILES_EVENT,
   type EditorSaveDirtyFilesDetail
 } from '../shared/editor-save-events'
+import {
+  ORCA_UPDATER_QUIT_AND_INSTALL_ABORTED_EVENT,
+  ORCA_UPDATER_QUIT_AND_INSTALL_STARTED_EVENT
+} from '../shared/updater-renderer-events'
 
 type NativeFileDropTarget = 'editor' | 'terminal'
 
@@ -275,6 +279,13 @@ const api = {
     check: (): Promise<void> => ipcRenderer.invoke('updater:check'),
     download: (): Promise<void> => ipcRenderer.invoke('updater:download'),
     quitAndInstall: async (): Promise<void> => {
+      // Why: quitAndInstall closes the BrowserWindow directly from the main
+      // process. Renderer beforeunload guards treat that like a normal window
+      // close unless we mark the updater path explicitly, and #300 introduced
+      // longer-lived editor dirty/autosave state that can otherwise veto the
+      // restart even after the update payload has been downloaded.
+      window.dispatchEvent(new Event(ORCA_UPDATER_QUIT_AND_INSTALL_STARTED_EVENT))
+
       // Why: we wrap the save attempt in try/catch so that a save failure
       // (e.g., unsupported dirty files or a write error) never silently
       // prevents the update from installing. The user already clicked
@@ -315,7 +326,12 @@ const api = {
       // update process bypasses the normal window close sequence (quitAndInstall
       // removes close listeners, preventing beforeunload from firing naturally).
       window.dispatchEvent(new Event('beforeunload'))
-      return ipcRenderer.invoke('updater:quitAndInstall')
+      try {
+        return await ipcRenderer.invoke('updater:quitAndInstall')
+      } catch (error) {
+        window.dispatchEvent(new Event(ORCA_UPDATER_QUIT_AND_INSTALL_ABORTED_EVENT))
+        throw error
+      }
     },
     onStatus: (callback: (status: unknown) => void): (() => void) => {
       const listener = (_event: Electron.IpcRendererEvent, status: unknown) => callback(status)

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -20,6 +20,7 @@ import {
   setRuntimeGraphSyncEnabled
 } from './runtime/sync-runtime-graph'
 import { useGlobalFileDrop } from './hooks/useGlobalFileDrop'
+import { registerUpdaterBeforeUnloadBypass } from './lib/updater-beforeunload'
 
 const isMac = navigator.userAgent.includes('Mac')
 
@@ -155,6 +156,8 @@ function App(): React.JSX.Element {
       setRuntimeGraphStoreStateGetter(null)
     }
   }, [])
+
+  useEffect(() => registerUpdaterBeforeUnloadBypass(), [])
 
   useEffect(() => {
     setRuntimeGraphSyncEnabled(workspaceSessionReady)

--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable max-lines */
+
 import { useEffect, useCallback, useRef, useState, lazy, Suspense } from 'react'
 import { TOGGLE_TERMINAL_PANE_EXPAND_EVENT } from '@/constants/terminal'
 import { useAppStore } from '../store'
@@ -12,7 +14,12 @@ import {
 import { Button } from '@/components/ui/button'
 import TabBar from './tab-bar/TabBar'
 import TerminalPane from './terminal-pane/TerminalPane'
-import { requestEditorSaveQuiesce } from './editor/editor-autosave'
+import {
+  ORCA_EDITOR_SAVE_AND_CLOSE_EVENT,
+  requestEditorSaveQuiesce
+} from './editor/editor-autosave'
+import { isUpdaterQuitAndInstallInProgress } from '@/lib/updater-beforeunload'
+import EditorAutosaveController from './editor/EditorAutosaveController'
 
 const EditorPanel = lazy(() => import('./editor/EditorPanel'))
 
@@ -75,14 +82,12 @@ export default function Terminal(): React.JSX.Element | null {
     if (!file) {
       return
     }
-    // EditorPanel stores edit buffers internally — we need to read the current content from the editor.
-    // The simplest approach: dispatch a custom event that the MonacoEditor listens for to trigger save,
-    // then close. But that's complex. Instead, just save via the editor ref approach.
-    // Actually, we can read the current content from the DOM's Monaco instance.
-    // Simpler: just close without saving is "Don't Save", and save is handled by a custom event.
-    // For now, trigger a save event that EditorPanel listens for.
+    // Why: save-and-close must flush the latest draft even when the visible
+    // editor panel has already unmounted. The headless autosave controller
+    // owns that write path now, so the dialog signals it through a custom
+    // event instead of poking at editor component refs.
     window.dispatchEvent(
-      new CustomEvent('orca:save-and-close', { detail: { fileId: saveDialogFileId } })
+      new CustomEvent(ORCA_EDITOR_SAVE_AND_CLOSE_EVENT, { detail: { fileId: saveDialogFileId } })
     )
     setSaveDialogFileId(null)
   }, [saveDialogFileId])
@@ -328,6 +333,12 @@ export default function Terminal(): React.JSX.Element | null {
   // Warn on window close if there are unsaved editor files
   useEffect(() => {
     const handler = (e: BeforeUnloadEvent): void => {
+      // Why: updater restarts intentionally close the app even if a hidden
+      // editor tab still reports dirty. Let ShipIt replace the bundle instead
+      // of vetoing quitAndInstall and leaving the old version running.
+      if (isUpdaterQuitAndInstallInProgress()) {
+        return
+      }
       const dirtyFiles = useAppStore.getState().openFiles.filter((f) => f.isDirty)
       if (dirtyFiles.length > 0) {
         e.preventDefault()
@@ -341,6 +352,8 @@ export default function Terminal(): React.JSX.Element | null {
     <div
       className={`flex flex-col flex-1 min-w-0 min-h-0 overflow-hidden${activeWorktreeId ? '' : ' hidden'}`}
     >
+      <EditorAutosaveController />
+
       {/* Animated tab bar container using CSS grid for smooth height animation */}
       <div
         className="grid transition-[grid-template-rows] duration-200 ease-in-out"
@@ -408,26 +421,20 @@ export default function Terminal(): React.JSX.Element | null {
           })}
       </div>
 
-      {/* Editor panel - keep mounted while files are open so autosave/discard
-          coordination and in-memory edit buffers survive tab switches. */}
-      {activeWorktreeId && openFiles.length > 0 && (
-        <div
-          className={
-            activeTabType === 'editor' && worktreeFiles.length > 0
-              ? 'flex flex-1 min-h-0'
-              : 'hidden'
+      {/* Why: v1.0.85 only mounted the visible editor surface, which kept
+          hidden editor effects out of app shutdown. Autosave now lives in the
+          narrow EditorAutosaveController above, so the full EditorPanel can go
+          back to the safer "mount only while visible" lifecycle. */}
+      {activeWorktreeId && activeTabType === 'editor' && worktreeFiles.length > 0 && (
+        <Suspense
+          fallback={
+            <div className="flex-1 flex items-center justify-center text-muted-foreground text-sm">
+              Loading editor...
+            </div>
           }
         >
-          <Suspense
-            fallback={
-              <div className="flex-1 flex items-center justify-center text-muted-foreground text-sm">
-                Loading editor...
-              </div>
-            }
-          >
-            <EditorPanel />
-          </Suspense>
-        </div>
+          <EditorPanel />
+        </Suspense>
       )}
 
       {/* Save confirmation dialog */}

--- a/src/renderer/src/components/editor/EditorAutosaveController.tsx
+++ b/src/renderer/src/components/editor/EditorAutosaveController.tsx
@@ -1,0 +1,13 @@
+import { useEffect } from 'react'
+import { attachAppEditorAutosaveController } from './editor-autosave-controller'
+
+export default function EditorAutosaveController(): null {
+  useEffect(() => {
+    // Why: autosave and quit coordination need to survive editor tab switches,
+    // but keeping the full EditorPanel mounted while hidden widened the restart
+    // surface too far. Keep only this narrow controller alive between mounts.
+    return attachAppEditorAutosaveController()
+  }, [])
+
+  return null
+}

--- a/src/renderer/src/components/editor/EditorPanel.tsx
+++ b/src/renderer/src/components/editor/EditorPanel.tsx
@@ -1,7 +1,8 @@
-/* eslint-disable max-lines -- Why: EditorPanel owns the editor tab save/load
-lifecycle end-to-end, including autosave coordination with external mutations.
-Keeping that state machine co-located avoids subtle regressions from splitting
-the tightly-coupled effects, refs, and event handlers across multiple modules. */
+/* eslint-disable max-lines -- Why: EditorPanel still owns the visible editor
+save/load/render lifecycle for many modes (edit, diff, conflict review), and
+keeping that UI state together is easier to reason about than scattering it
+across multiple components. Autosave now lives in a smaller headless controller
+so hidden editor UI no longer participates in shutdown. */
 import React, { useCallback, useEffect, useState, Suspense } from 'react'
 import { Columns2, FileText, Rows2 } from 'lucide-react'
 import { useAppStore } from '@/store'
@@ -13,18 +14,13 @@ import MarkdownViewToggle from './MarkdownViewToggle'
 import { EditorContent } from './EditorContent'
 import type { GitDiffResult } from '../../../../shared/types'
 import {
-  canAutoSaveOpenFile,
   getOpenFilesForExternalFileChange,
-  normalizeAutoSaveDelayMs,
+  ORCA_EDITOR_FILE_SAVED_EVENT,
   ORCA_EDITOR_EXTERNAL_FILE_CHANGE_EVENT,
-  ORCA_EDITOR_QUIESCE_FILE_SAVES_EVENT,
-  type EditorPathMutationTarget,
-  type EditorSaveQuiesceDetail
+  requestEditorFileSave,
+  type EditorFileSavedDetail,
+  type EditorPathMutationTarget
 } from './editor-autosave'
-import {
-  ORCA_EDITOR_SAVE_DIRTY_FILES_EVENT,
-  type EditorSaveDirtyFilesDetail
-} from '../../../../shared/editor-save-events'
 
 type FileContent = {
   content: string
@@ -45,13 +41,14 @@ export default function EditorPanel(): React.JSX.Element | null {
   const markdownViewMode = useAppStore((s) => s.markdownViewMode)
   const setMarkdownViewMode = useAppStore((s) => s.setMarkdownViewMode)
   const openFile = useAppStore((s) => s.openFile)
+  const editorDrafts = useAppStore((s) => s.editorDrafts)
+  const setEditorDraft = useAppStore((s) => s.setEditorDraft)
   const settings = useAppStore((s) => s.settings)
 
   const activeFile = openFiles.find((f) => f.id === activeFileId) ?? null
 
   const [fileContents, setFileContents] = useState<Record<string, FileContent>>({})
   const [diffContents, setDiffContents] = useState<Record<string, DiffContent>>({})
-  const [editBuffers, setEditBuffers] = useState<Record<string, string>>({})
   const [copiedPathToast, setCopiedPathToast] = useState<{ fileId: string; token: number } | null>(
     null
   )
@@ -65,32 +62,8 @@ export default function EditorPanel(): React.JSX.Element | null {
     }
   }, [settings?.diffDefaultView])
 
-  const autoSaveTimersRef = React.useRef<Map<string, number>>(new Map())
-  const autoSaveScheduledContentRef = React.useRef<Map<string, string>>(new Map())
-  const saveQueueRef = React.useRef<Map<string, Promise<void>>>(new Map())
-  const saveGenerationRef = React.useRef<Map<string, number>>(new Map())
   const openFilesRef = React.useRef(openFiles)
-  const fileContentsRef = React.useRef(fileContents)
-  const diffContentsRef = React.useRef(diffContents)
-  const editBuffersRef = React.useRef(editBuffers)
-  const autoSaveDelayMs = normalizeAutoSaveDelayMs(settings?.editorAutoSaveDelayMs)
   openFilesRef.current = openFiles
-  fileContentsRef.current = fileContents
-  diffContentsRef.current = diffContents
-  editBuffersRef.current = editBuffers
-
-  const clearAutoSaveTimer = useCallback((fileId: string): void => {
-    const timerId = autoSaveTimersRef.current.get(fileId)
-    if (timerId !== undefined) {
-      window.clearTimeout(timerId)
-      autoSaveTimersRef.current.delete(fileId)
-    }
-    autoSaveScheduledContentRef.current.delete(fileId)
-  }, [])
-
-  const bumpSaveGeneration = useCallback((fileId: string): void => {
-    saveGenerationRef.current.set(fileId, (saveGenerationRef.current.get(fileId) ?? 0) + 1)
-  }, [])
 
   // Load file content when active file changes
   useEffect(() => {
@@ -188,100 +161,12 @@ export default function EditorPanel(): React.JSX.Element | null {
     }
   }, [])
 
-  const queueSave = useCallback(
-    (file: OpenFile, fallbackContent: string): Promise<void> => {
-      clearAutoSaveTimer(file.id)
-      const saveGeneration = saveGenerationRef.current.get(file.id) ?? 0
-
-      const previousSave = saveQueueRef.current.get(file.id) ?? Promise.resolve()
-      const queuedSave = previousSave
-        .catch(() => undefined)
-        .then(async () => {
-          if ((saveGenerationRef.current.get(file.id) ?? 0) !== saveGeneration) {
-            return
-          }
-          if (!openFilesRef.current.some((openFile) => openFile.id === file.id)) {
-            return
-          }
-
-          const liveFile = openFilesRef.current.find((openFile) => openFile.id === file.id) ?? file
-          const contentToSave = editBuffersRef.current[file.id] ?? fallbackContent
-
-          try {
-            await window.api.fs.writeFile({ filePath: liveFile.filePath, content: contentToSave })
-            if ((saveGenerationRef.current.get(file.id) ?? 0) !== saveGeneration) {
-              return
-            }
-
-            if (liveFile.mode === 'edit') {
-              setFileContents((prev) => ({
-                ...prev,
-                [file.id]: { content: contentToSave, isBinary: false }
-              }))
-            } else {
-              setDiffContents((prev) => {
-                const existing = prev[file.id]
-                if (!existing || existing.kind !== 'text') {
-                  return prev
-                }
-                return {
-                  ...prev,
-                  [file.id]: { ...existing, modifiedContent: contentToSave }
-                }
-              })
-            }
-
-            const currentBuffer = editBuffersRef.current[file.id]
-            const stillDirty = currentBuffer !== undefined && currentBuffer !== contentToSave
-
-            markFileDirty(file.id, stillDirty)
-            setEditBuffers((prev) => {
-              const bufferedContent = prev[file.id]
-              if (bufferedContent === undefined || bufferedContent === contentToSave) {
-                const next = { ...prev }
-                delete next[file.id]
-                editBuffersRef.current = next
-                return next
-              }
-              editBuffersRef.current = prev
-              return prev
-            })
-          } catch (err) {
-            console.error('Save failed:', err)
-            throw err
-          }
-        })
-
-      let trackedSave: Promise<void>
-      trackedSave = queuedSave.finally(() => {
-        if (saveQueueRef.current.get(file.id) === trackedSave) {
-          saveQueueRef.current.delete(file.id)
-        }
-      })
-      saveQueueRef.current.set(file.id, trackedSave)
-      return trackedSave
-    },
-    [clearAutoSaveTimer, markFileDirty]
-  )
-
-  const quiesceFileSave = useCallback(
-    async (fileId: string): Promise<void> => {
-      const pendingSave = saveQueueRef.current.get(fileId)
-      clearAutoSaveTimer(fileId)
-      bumpSaveGeneration(fileId)
-      await pendingSave?.catch(() => undefined)
-    },
-    [bumpSaveGeneration, clearAutoSaveTimer]
-  )
-
   const handleContentChange = useCallback(
     (content: string) => {
       if (!activeFile) {
         return
       }
-      const nextBuffers = { ...editBuffersRef.current, [activeFile.id]: content }
-      editBuffersRef.current = nextBuffers
-      setEditBuffers(nextBuffers)
+      setEditorDraft(activeFile.id, content)
       if (activeFile.mode === 'edit') {
         // Compare against saved content to determine dirty state
         const saved = fileContents[activeFile.id]?.content ?? ''
@@ -292,19 +177,8 @@ export default function EditorPanel(): React.JSX.Element | null {
         const original = dc?.kind === 'text' ? dc.modifiedContent : ''
         markFileDirty(activeFile.id, content !== original)
       }
-
-      if (!settings?.editorAutoSave) {
-        clearAutoSaveTimer(activeFile.id)
-      }
     },
-    [
-      activeFile,
-      clearAutoSaveTimer,
-      diffContents,
-      fileContents,
-      markFileDirty,
-      settings?.editorAutoSave
-    ]
+    [activeFile, diffContents, fileContents, markFileDirty, setEditorDraft]
   )
 
   const handleSave = useCallback(
@@ -313,130 +187,11 @@ export default function EditorPanel(): React.JSX.Element | null {
         return
       }
       try {
-        await queueSave(activeFile, content)
+        await requestEditorFileSave({ fileId: activeFile.id, fallbackContent: content })
       } catch {}
     },
-    [activeFile, queueSave]
+    [activeFile]
   )
-
-  const getLatestWritableContent = useCallback((file: OpenFile): string | null => {
-    const bufferedContent = editBuffersRef.current[file.id]
-    if (bufferedContent !== undefined) {
-      return bufferedContent
-    }
-
-    if (file.mode === 'edit') {
-      return fileContentsRef.current[file.id]?.content ?? null
-    }
-
-    const diffContent = diffContentsRef.current[file.id]
-    return diffContent?.kind === 'text' ? diffContent.modifiedContent : null
-  }, [])
-
-  const getDuplicateDirtySavePaths = useCallback((files: OpenFile[]): string[] => {
-    const counts = new Map<string, number>()
-    for (const file of files) {
-      counts.set(file.filePath, (counts.get(file.filePath) ?? 0) + 1)
-    }
-    return Array.from(counts.entries())
-      .filter(([, count]) => count > 1)
-      .map(([filePath]) => filePath)
-  }, [])
-
-  // Handle save-and-close events from the save confirmation dialog
-  useEffect(() => {
-    const handler = async (event: Event): Promise<void> => {
-      const detail = (event as CustomEvent<EditorSaveDirtyFilesDetail>).detail
-      if (!detail) {
-        return
-      }
-
-      // Why: the entire handler body after the null guard is wrapped in a
-      // single try/catch so that any unexpected error (including from
-      // detail.claim()) always calls detail.reject() rather than leaving
-      // the promise in the preload hanging forever.
-      try {
-        detail.claim()
-
-        const dirtyFiles = openFilesRef.current.filter((file) => file.isDirty)
-        const unsupportedDirtyFiles = dirtyFiles.filter((file) => !canAutoSaveOpenFile(file))
-        if (unsupportedDirtyFiles.length > 0) {
-          detail.reject('Some unsaved editor changes cannot be auto-saved before restart.')
-          return
-        }
-
-        const duplicateDirtySavePaths = getDuplicateDirtySavePaths(dirtyFiles)
-        if (duplicateDirtySavePaths.length > 0) {
-          // Why: edit tabs and unstaged diff tabs can both target the same
-          // on-disk file while holding different in-memory buffers. Refusing the
-          // updater restart here is safer than racing two writes and silently
-          // picking whichever tab happens to save last.
-          detail.reject('Some unsaved files are open in multiple dirty tabs. Save them manually before restarting.')
-          return
-        }
-
-        await Promise.all(
-          dirtyFiles.map(async (file) => {
-            const content = getLatestWritableContent(file)
-            if (content === null) {
-              throw new Error(`Missing editor buffer for ${file.relativePath}`)
-            }
-            await queueSave(file, content)
-          })
-        )
-        detail.resolve()
-      } catch (error) {
-        detail.reject(String((error as Error)?.message ?? error))
-      }
-    }
-
-    window.addEventListener(ORCA_EDITOR_SAVE_DIRTY_FILES_EVENT, handler as EventListener)
-    return () =>
-      window.removeEventListener(ORCA_EDITOR_SAVE_DIRTY_FILES_EVENT, handler as EventListener)
-  }, [getDuplicateDirtySavePaths, getLatestWritableContent, queueSave])
-
-  useEffect(() => {
-    const handler = async (e: Event): Promise<void> => {
-      const { fileId } = (e as CustomEvent).detail as { fileId: string }
-      const file = useAppStore.getState().openFiles.find((f) => f.id === fileId)
-      if (!file) {
-        return
-      }
-      const buffer = editBuffersRef.current[fileId]
-      if (buffer !== undefined) {
-        try {
-          await queueSave(file, buffer)
-        } catch {
-          return // Don't close if save fails
-        }
-      }
-      useAppStore.getState().closeFile(fileId)
-    }
-    window.addEventListener('orca:save-and-close', handler as EventListener)
-    return () => window.removeEventListener('orca:save-and-close', handler as EventListener)
-  }, [queueSave])
-
-  useEffect(() => {
-    const handler = async (event: Event): Promise<void> => {
-      const detail = (event as CustomEvent<EditorSaveQuiesceDetail>).detail
-      if (!detail) {
-        return
-      }
-      detail.claim()
-
-      const matchingFiles =
-        'fileId' in detail
-          ? openFilesRef.current.filter((file) => file.id === detail.fileId)
-          : getOpenFilesForExternalFileChange(openFilesRef.current, detail)
-
-      await Promise.all(matchingFiles.map((file) => quiesceFileSave(file.id)))
-      detail.resolve()
-    }
-
-    window.addEventListener(ORCA_EDITOR_QUIESCE_FILE_SAVES_EVENT, handler as EventListener)
-    return () =>
-      window.removeEventListener(ORCA_EDITOR_QUIESCE_FILE_SAVES_EVENT, handler as EventListener)
-  }, [quiesceFileSave])
 
   useEffect(() => {
     const handler = (event: Event): void => {
@@ -449,24 +204,6 @@ export default function EditorPanel(): React.JSX.Element | null {
       if (matchingFiles.length === 0) {
         return
       }
-
-      const matchingIds = new Set(matchingFiles.map((file) => file.id))
-
-      for (const file of matchingFiles) {
-        clearAutoSaveTimer(file.id)
-        bumpSaveGeneration(file.id)
-        markFileDirty(file.id, false)
-      }
-
-      setEditBuffers((prev) => {
-        const next = { ...prev }
-        for (const fileId of matchingIds) {
-          delete next[fileId]
-        }
-        editBuffersRef.current = next
-        return next
-      })
-
       setFileContents((prev) => {
         const next = { ...prev }
         for (const file of matchingFiles) {
@@ -502,73 +239,8 @@ export default function EditorPanel(): React.JSX.Element | null {
     window.addEventListener(ORCA_EDITOR_EXTERNAL_FILE_CHANGE_EVENT, handler as EventListener)
     return () =>
       window.removeEventListener(ORCA_EDITOR_EXTERNAL_FILE_CHANGE_EVENT, handler as EventListener)
-  }, [bumpSaveGeneration, clearAutoSaveTimer, loadDiffContent, loadFileContent, markFileDirty])
+  }, [loadDiffContent, loadFileContent])
 
-  useEffect(() => {
-    const openFilesById = new Map(openFiles.map((file) => [file.id, file]))
-
-    for (const fileId of Array.from(autoSaveTimersRef.current.keys())) {
-      const file = openFilesById.get(fileId)
-      const buffer = editBuffers[fileId]
-      const shouldKeepTimer =
-        settings?.editorAutoSave &&
-        file &&
-        file.isDirty &&
-        canAutoSaveOpenFile(file) &&
-        buffer !== undefined
-      if (!shouldKeepTimer) {
-        clearAutoSaveTimer(fileId)
-      }
-    }
-
-    if (!settings?.editorAutoSave) {
-      return
-    }
-
-    for (const file of openFiles) {
-      const buffer = editBuffers[file.id]
-      if (!file.isDirty || buffer === undefined || !canAutoSaveOpenFile(file)) {
-        clearAutoSaveTimer(file.id)
-        continue
-      }
-
-      if (
-        autoSaveTimersRef.current.has(file.id) &&
-        autoSaveScheduledContentRef.current.get(file.id) === buffer
-      ) {
-        continue
-      }
-
-      clearAutoSaveTimer(file.id)
-      autoSaveScheduledContentRef.current.set(file.id, buffer)
-      const timerId = window.setTimeout(() => {
-        autoSaveTimersRef.current.delete(file.id)
-        autoSaveScheduledContentRef.current.delete(file.id)
-        void queueSave(file, buffer)
-      }, autoSaveDelayMs)
-      autoSaveTimersRef.current.set(file.id, timerId)
-    }
-  }, [
-    autoSaveDelayMs,
-    clearAutoSaveTimer,
-    editBuffers,
-    openFiles,
-    queueSave,
-    settings?.editorAutoSave
-  ])
-
-  useEffect(
-    () => () => {
-      for (const timerId of autoSaveTimersRef.current.values()) {
-        window.clearTimeout(timerId)
-      }
-      autoSaveTimersRef.current.clear()
-      autoSaveScheduledContentRef.current.clear()
-    },
-    []
-  )
-
-  // Clean up content caches when files are closed
   useEffect(() => {
     const openIds = new Set(openFiles.map((f) => f.id))
     setFileContents((prev) => {
@@ -589,17 +261,43 @@ export default function EditorPanel(): React.JSX.Element | null {
       }
       return next
     })
-    setEditBuffers((prev) => {
-      const next: Record<string, string> = {}
-      for (const [k, v] of Object.entries(prev)) {
-        if (openIds.has(k)) {
-          next[k] = v
-        }
-      }
-      editBuffersRef.current = next
-      return next
-    })
   }, [openFiles])
+
+  useEffect(() => {
+    const handler = (event: Event): void => {
+      const detail = (event as CustomEvent<EditorFileSavedDetail>).detail
+      if (!detail) {
+        return
+      }
+
+      const file = openFilesRef.current.find((openFile) => openFile.id === detail.fileId)
+      if (!file) {
+        return
+      }
+
+      if (file.mode === 'edit') {
+        setFileContents((prev) => ({
+          ...prev,
+          [file.id]: { content: detail.content, isBinary: false }
+        }))
+        return
+      }
+
+      setDiffContents((prev) => {
+        const existing = prev[file.id]
+        if (!existing || existing.kind !== 'text') {
+          return prev
+        }
+        return {
+          ...prev,
+          [file.id]: { ...existing, modifiedContent: detail.content }
+        }
+      })
+    }
+
+    window.addEventListener(ORCA_EDITOR_FILE_SAVED_EVENT, handler as EventListener)
+    return () => window.removeEventListener(ORCA_EDITOR_FILE_SAVED_EVENT, handler as EventListener)
+  }, [])
 
   const handleCopyPath = useCallback(async (): Promise<void> => {
     if (!activeFile) {
@@ -758,7 +456,7 @@ export default function EditorPanel(): React.JSX.Element | null {
           activeFile={activeFile}
           fileContents={fileContents}
           diffContents={diffContents}
-          editBuffers={editBuffers}
+          editBuffers={editorDrafts}
           worktreeEntries={worktreeEntries}
           resolvedLanguage={resolvedLanguage}
           isMarkdown={isMarkdown}

--- a/src/renderer/src/components/editor/editor-autosave-controller.test.ts
+++ b/src/renderer/src/components/editor/editor-autosave-controller.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createStore, type StoreApi } from 'zustand/vanilla'
+import { createEditorSlice } from '@/store/slices/editor'
+import type { AppState } from '@/store'
+import { ORCA_EDITOR_SAVE_DIRTY_FILES_EVENT } from '../../../../shared/editor-save-events'
+import { requestEditorSaveQuiesce } from './editor-autosave'
+import { attachEditorAutosaveController } from './editor-autosave-controller'
+
+type WindowStub = {
+  addEventListener: Window['addEventListener']
+  removeEventListener: Window['removeEventListener']
+  dispatchEvent: Window['dispatchEvent']
+  setTimeout: Window['setTimeout']
+  clearTimeout: Window['clearTimeout']
+  api: {
+    fs: {
+      writeFile: ReturnType<typeof vi.fn>
+    }
+  }
+}
+
+function createEditorStore(): StoreApi<AppState> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return createStore<any>()((...args: any[]) => ({
+    activeWorktreeId: 'wt-1',
+    settings: {
+      editorAutoSave: true,
+      editorAutoSaveDelayMs: 1000
+    },
+    ...createEditorSlice(...(args as Parameters<typeof createEditorSlice>))
+  })) as unknown as StoreApi<AppState>
+}
+
+async function requestDirtyFileSave(): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    let claimed = false
+    window.dispatchEvent(
+      new CustomEvent(ORCA_EDITOR_SAVE_DIRTY_FILES_EVENT, {
+        detail: {
+          claim: () => {
+            claimed = true
+          },
+          resolve,
+          reject: (message: string) => reject(new Error(message))
+        }
+      })
+    )
+
+    if (!claimed) {
+      resolve()
+    }
+  })
+}
+
+describe('attachEditorAutosaveController', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('saves dirty files even when the visible EditorPanel is not mounted', async () => {
+    const writeFile = vi.fn().mockResolvedValue(undefined)
+    const eventTarget = new EventTarget()
+    vi.stubGlobal('window', {
+      addEventListener: eventTarget.addEventListener.bind(eventTarget),
+      removeEventListener: eventTarget.removeEventListener.bind(eventTarget),
+      dispatchEvent: eventTarget.dispatchEvent.bind(eventTarget),
+      setTimeout: globalThis.setTimeout.bind(globalThis),
+      clearTimeout: globalThis.clearTimeout.bind(globalThis),
+      api: {
+        fs: {
+          writeFile
+        }
+      }
+    } satisfies WindowStub)
+
+    const store = createEditorStore()
+    store.getState().openFile({
+      filePath: '/repo/file.ts',
+      relativePath: 'file.ts',
+      worktreeId: 'wt-1',
+      language: 'typescript',
+      mode: 'edit'
+    })
+    store.getState().setEditorDraft('/repo/file.ts', 'edited')
+    store.getState().markFileDirty('/repo/file.ts', true)
+
+    const cleanup = attachEditorAutosaveController(store)
+    try {
+      await requestDirtyFileSave()
+
+      expect(writeFile).toHaveBeenCalledWith({
+        filePath: '/repo/file.ts',
+        content: 'edited'
+      })
+      expect(store.getState().openFiles[0]?.isDirty).toBe(false)
+      expect(store.getState().editorDrafts).toEqual({})
+    } finally {
+      cleanup()
+    }
+  })
+
+  it('quiesces pending autosave timers without needing the editor UI tree', async () => {
+    const writeFile = vi.fn().mockResolvedValue(undefined)
+    const eventTarget = new EventTarget()
+    vi.stubGlobal('window', {
+      addEventListener: eventTarget.addEventListener.bind(eventTarget),
+      removeEventListener: eventTarget.removeEventListener.bind(eventTarget),
+      dispatchEvent: eventTarget.dispatchEvent.bind(eventTarget),
+      setTimeout: globalThis.setTimeout.bind(globalThis),
+      clearTimeout: globalThis.clearTimeout.bind(globalThis),
+      api: {
+        fs: {
+          writeFile
+        }
+      }
+    } satisfies WindowStub)
+
+    const store = createEditorStore()
+    store.getState().openFile({
+      filePath: '/repo/file.ts',
+      relativePath: 'file.ts',
+      worktreeId: 'wt-1',
+      language: 'typescript',
+      mode: 'edit'
+    })
+
+    const cleanup = attachEditorAutosaveController(store)
+    try {
+      store.getState().setEditorDraft('/repo/file.ts', 'edited')
+      store.getState().markFileDirty('/repo/file.ts', true)
+
+      await requestEditorSaveQuiesce({ fileId: '/repo/file.ts' })
+      await vi.advanceTimersByTimeAsync(1000)
+
+      expect(writeFile).not.toHaveBeenCalled()
+      expect(store.getState().openFiles[0]?.isDirty).toBe(true)
+      expect(store.getState().editorDrafts['/repo/file.ts']).toBe('edited')
+    } finally {
+      cleanup()
+    }
+  })
+})

--- a/src/renderer/src/components/editor/editor-autosave-controller.ts
+++ b/src/renderer/src/components/editor/editor-autosave-controller.ts
@@ -1,0 +1,329 @@
+import type { StoreApi } from 'zustand'
+import { useAppStore } from '@/store'
+import type { AppState } from '@/store'
+import type { OpenFile } from '@/store/slices/editor'
+import {
+  canAutoSaveOpenFile,
+  getOpenFilesForExternalFileChange,
+  normalizeAutoSaveDelayMs,
+  ORCA_EDITOR_EXTERNAL_FILE_CHANGE_EVENT,
+  ORCA_EDITOR_FILE_SAVED_EVENT,
+  ORCA_EDITOR_QUIESCE_FILE_SAVES_EVENT,
+  ORCA_EDITOR_SAVE_AND_CLOSE_EVENT,
+  ORCA_EDITOR_SAVE_FILE_EVENT,
+  type EditorFileSavedDetail,
+  type EditorPathMutationTarget,
+  type EditorSaveFileDetail,
+  type EditorSaveQuiesceDetail
+} from './editor-autosave'
+import {
+  ORCA_EDITOR_SAVE_DIRTY_FILES_EVENT,
+  type EditorSaveDirtyFilesDetail
+} from '../../../../shared/editor-save-events'
+
+type AppStoreApi = Pick<StoreApi<AppState>, 'getState' | 'subscribe'>
+
+function getDuplicateDirtySavePaths(files: OpenFile[]): string[] {
+  const counts = new Map<string, number>()
+  for (const file of files) {
+    counts.set(file.filePath, (counts.get(file.filePath) ?? 0) + 1)
+  }
+  return Array.from(counts.entries())
+    .filter(([, count]) => count > 1)
+    .map(([filePath]) => filePath)
+}
+
+export function attachEditorAutosaveController(store: AppStoreApi): () => void {
+  const autoSaveTimers = new Map<string, number>()
+  const autoSaveScheduledContent = new Map<string, string>()
+  const saveQueue = new Map<string, Promise<void>>()
+  const saveGeneration = new Map<string, number>()
+
+  const clearAutoSaveTimer = (fileId: string): void => {
+    const timerId = autoSaveTimers.get(fileId)
+    if (timerId !== undefined) {
+      window.clearTimeout(timerId)
+      autoSaveTimers.delete(fileId)
+    }
+    autoSaveScheduledContent.delete(fileId)
+  }
+
+  const bumpSaveGeneration = (fileId: string): void => {
+    saveGeneration.set(fileId, (saveGeneration.get(fileId) ?? 0) + 1)
+  }
+
+  const queueSave = (file: OpenFile, fallbackContent: string): Promise<void> => {
+    clearAutoSaveTimer(file.id)
+    const queuedGeneration = saveGeneration.get(file.id) ?? 0
+
+    const previousSave = saveQueue.get(file.id) ?? Promise.resolve()
+    const queuedSave = previousSave
+      .catch(() => undefined)
+      .then(async () => {
+        if ((saveGeneration.get(file.id) ?? 0) !== queuedGeneration) {
+          return
+        }
+
+        const state = store.getState()
+        const liveFile = state.openFiles.find((openFile) => openFile.id === file.id) ?? null
+        if (!liveFile) {
+          return
+        }
+
+        const contentToSave = state.editorDrafts[file.id] ?? fallbackContent
+        await window.api.fs.writeFile({ filePath: liveFile.filePath, content: contentToSave })
+
+        if ((saveGeneration.get(file.id) ?? 0) !== queuedGeneration) {
+          return
+        }
+
+        const nextState = store.getState()
+        const currentDraft = nextState.editorDrafts[file.id]
+        const stillDirty = currentDraft !== undefined && currentDraft !== contentToSave
+        nextState.markFileDirty(file.id, stillDirty)
+        if (!stillDirty) {
+          nextState.clearEditorDraft(file.id)
+        }
+
+        window.dispatchEvent(
+          new CustomEvent<EditorFileSavedDetail>(ORCA_EDITOR_FILE_SAVED_EVENT, {
+            detail: { fileId: file.id, content: contentToSave }
+          })
+        )
+      })
+
+    let trackedSave: Promise<void>
+    trackedSave = queuedSave.finally(() => {
+      if (saveQueue.get(file.id) === trackedSave) {
+        saveQueue.delete(file.id)
+      }
+    })
+    saveQueue.set(file.id, trackedSave)
+    return trackedSave
+  }
+
+  const quiesceFileSave = async (fileId: string): Promise<void> => {
+    const pendingSave = saveQueue.get(fileId)
+    clearAutoSaveTimer(fileId)
+    bumpSaveGeneration(fileId)
+    await pendingSave?.catch(() => undefined)
+  }
+
+  const getLatestWritableContent = (file: OpenFile): string | null => {
+    // Why: only explicit user edits mark a tab dirty, and those edits are
+    // mirrored into editorDrafts on each change. The headless autosave
+    // controller deliberately depends on that narrow draft state instead of
+    // keeping the full editor UI mounted just to read component-local buffers.
+    return store.getState().editorDrafts[file.id] ?? null
+  }
+
+  const syncAutoSave = (): void => {
+    const state = store.getState()
+    const openFilesById = new Map(state.openFiles.map((file) => [file.id, file]))
+
+    for (const fileId of Array.from(autoSaveTimers.keys())) {
+      const file = openFilesById.get(fileId)
+      const draft = state.editorDrafts[fileId]
+      const shouldKeepTimer =
+        state.settings?.editorAutoSave &&
+        file &&
+        file.isDirty &&
+        canAutoSaveOpenFile(file) &&
+        draft !== undefined
+      if (!shouldKeepTimer) {
+        clearAutoSaveTimer(fileId)
+      }
+    }
+
+    if (!state.settings?.editorAutoSave) {
+      return
+    }
+
+    const autoSaveDelayMs = normalizeAutoSaveDelayMs(state.settings.editorAutoSaveDelayMs)
+    for (const file of state.openFiles) {
+      const draft = state.editorDrafts[file.id]
+      if (!file.isDirty || draft === undefined || !canAutoSaveOpenFile(file)) {
+        clearAutoSaveTimer(file.id)
+        continue
+      }
+
+      if (autoSaveTimers.has(file.id) && autoSaveScheduledContent.get(file.id) === draft) {
+        continue
+      }
+
+      clearAutoSaveTimer(file.id)
+      autoSaveScheduledContent.set(file.id, draft)
+      const timerId = window.setTimeout(() => {
+        autoSaveTimers.delete(file.id)
+        autoSaveScheduledContent.delete(file.id)
+        void queueSave(file, draft)
+      }, autoSaveDelayMs)
+      autoSaveTimers.set(file.id, timerId)
+    }
+  }
+
+  const handleSaveDirtyFiles = async (event: Event): Promise<void> => {
+    const detail = (event as CustomEvent<EditorSaveDirtyFilesDetail>).detail
+    if (!detail) {
+      return
+    }
+
+    try {
+      detail.claim()
+
+      const dirtyFiles = store.getState().openFiles.filter((file) => file.isDirty)
+      const unsupportedDirtyFiles = dirtyFiles.filter((file) => !canAutoSaveOpenFile(file))
+      if (unsupportedDirtyFiles.length > 0) {
+        detail.reject('Some unsaved editor changes cannot be auto-saved before restart.')
+        return
+      }
+
+      const duplicateDirtySavePaths = getDuplicateDirtySavePaths(dirtyFiles)
+      if (duplicateDirtySavePaths.length > 0) {
+        // Why: a hidden autosave controller still has to respect that edit tabs
+        // and unstaged diff tabs may point at the same path while holding
+        // different drafts. Refusing the restart is safer than choosing a
+        // winner implicitly and persisting whichever save races last.
+        detail.reject(
+          'Some unsaved files are open in multiple dirty tabs. Save them manually before restarting.'
+        )
+        return
+      }
+
+      await Promise.all(
+        dirtyFiles.map(async (file) => {
+          const content = getLatestWritableContent(file)
+          if (content === null) {
+            throw new Error(`Missing editor buffer for ${file.relativePath}`)
+          }
+          await queueSave(file, content)
+        })
+      )
+      detail.resolve()
+    } catch (error) {
+      detail.reject(String((error as Error)?.message ?? error))
+    }
+  }
+
+  const handleSaveAndClose = async (event: Event): Promise<void> => {
+    const { fileId } = (event as CustomEvent<{ fileId: string }>).detail
+    const file = store.getState().openFiles.find((openFile) => openFile.id === fileId)
+    if (!file) {
+      return
+    }
+
+    const draft = store.getState().editorDrafts[fileId]
+    if (draft !== undefined) {
+      try {
+        await queueSave(file, draft)
+      } catch {
+        return
+      }
+    }
+    store.getState().closeFile(fileId)
+  }
+
+  const handleSaveFile = async (event: Event): Promise<void> => {
+    const detail = (event as CustomEvent<EditorSaveFileDetail>).detail
+    if (!detail) {
+      return
+    }
+
+    try {
+      detail.claim()
+      const file = store.getState().openFiles.find((openFile) => openFile.id === detail.fileId)
+      if (!file) {
+        detail.resolve()
+        return
+      }
+
+      const content = store.getState().editorDrafts[file.id] ?? detail.fallbackContent
+      if (content === undefined) {
+        detail.resolve()
+        return
+      }
+
+      await queueSave(file, content)
+      detail.resolve()
+    } catch (error) {
+      detail.reject(String((error as Error)?.message ?? error))
+    }
+  }
+
+  const handleQuiesce = async (event: Event): Promise<void> => {
+    const detail = (event as CustomEvent<EditorSaveQuiesceDetail>).detail
+    if (!detail) {
+      return
+    }
+    detail.claim()
+
+    const matchingFiles =
+      'fileId' in detail
+        ? store.getState().openFiles.filter((file) => file.id === detail.fileId)
+        : getOpenFilesForExternalFileChange(store.getState().openFiles, detail)
+
+    await Promise.all(matchingFiles.map((file) => quiesceFileSave(file.id)))
+    detail.resolve()
+  }
+
+  const handleExternalFileChange = (event: Event): void => {
+    const detail = (event as CustomEvent<EditorPathMutationTarget>).detail
+    if (!detail) {
+      return
+    }
+
+    const state = store.getState()
+    const matchingFiles = getOpenFilesForExternalFileChange(state.openFiles, detail)
+    if (matchingFiles.length === 0) {
+      return
+    }
+
+    for (const file of matchingFiles) {
+      clearAutoSaveTimer(file.id)
+      bumpSaveGeneration(file.id)
+      state.markFileDirty(file.id, false)
+    }
+    state.clearEditorDrafts(matchingFiles.map((file) => file.id))
+  }
+
+  const unsubscribe = store.subscribe(syncAutoSave)
+  syncAutoSave()
+
+  window.addEventListener(ORCA_EDITOR_SAVE_DIRTY_FILES_EVENT, handleSaveDirtyFiles as EventListener)
+  window.addEventListener(ORCA_EDITOR_SAVE_AND_CLOSE_EVENT, handleSaveAndClose as EventListener)
+  window.addEventListener(ORCA_EDITOR_SAVE_FILE_EVENT, handleSaveFile as EventListener)
+  window.addEventListener(ORCA_EDITOR_QUIESCE_FILE_SAVES_EVENT, handleQuiesce as EventListener)
+  window.addEventListener(
+    ORCA_EDITOR_EXTERNAL_FILE_CHANGE_EVENT,
+    handleExternalFileChange as EventListener
+  )
+
+  return () => {
+    unsubscribe()
+    window.removeEventListener(
+      ORCA_EDITOR_SAVE_DIRTY_FILES_EVENT,
+      handleSaveDirtyFiles as EventListener
+    )
+    window.removeEventListener(
+      ORCA_EDITOR_SAVE_AND_CLOSE_EVENT,
+      handleSaveAndClose as EventListener
+    )
+    window.removeEventListener(ORCA_EDITOR_SAVE_FILE_EVENT, handleSaveFile as EventListener)
+    window.removeEventListener(ORCA_EDITOR_QUIESCE_FILE_SAVES_EVENT, handleQuiesce as EventListener)
+    window.removeEventListener(
+      ORCA_EDITOR_EXTERNAL_FILE_CHANGE_EVENT,
+      handleExternalFileChange as EventListener
+    )
+    for (const timerId of autoSaveTimers.values()) {
+      window.clearTimeout(timerId)
+    }
+    autoSaveTimers.clear()
+    autoSaveScheduledContent.clear()
+    saveQueue.clear()
+    saveGeneration.clear()
+  }
+}
+
+export function attachAppEditorAutosaveController(): () => void {
+  return attachEditorAutosaveController(useAppStore)
+}

--- a/src/renderer/src/components/editor/editor-autosave.test.ts
+++ b/src/renderer/src/components/editor/editor-autosave.test.ts
@@ -5,6 +5,7 @@ import {
   getOpenFilesForExternalFileChange,
   normalizeAutoSaveDelayMs,
   ORCA_EDITOR_QUIESCE_FILE_SAVES_EVENT,
+  requestEditorFileSave,
   requestEditorSaveQuiesce
 } from './editor-autosave'
 
@@ -128,6 +129,14 @@ describe('requestEditorSaveQuiesce', () => {
     } finally {
       window.removeEventListener(ORCA_EDITOR_QUIESCE_FILE_SAVES_EVENT, handler as EventListener)
     }
+  })
+})
+
+describe('requestEditorFileSave', () => {
+  it('rejects when no save controller claims the request', async () => {
+    await expect(requestEditorFileSave({ fileId: 'file-1' })).rejects.toThrow(
+      'Editor save controller is unavailable.'
+    )
   })
 })
 

--- a/src/renderer/src/components/editor/editor-autosave.ts
+++ b/src/renderer/src/components/editor/editor-autosave.ts
@@ -9,6 +9,9 @@ import { clampNumber } from '@/lib/terminal-theme'
 
 export const ORCA_EDITOR_QUIESCE_FILE_SAVES_EVENT = 'orca:editor-quiesce-file-saves'
 export const ORCA_EDITOR_EXTERNAL_FILE_CHANGE_EVENT = 'orca:editor-external-file-change'
+export const ORCA_EDITOR_SAVE_FILE_EVENT = 'orca:editor-save-file'
+export const ORCA_EDITOR_SAVE_AND_CLOSE_EVENT = 'orca:save-and-close'
+export const ORCA_EDITOR_FILE_SAVED_EVENT = 'orca:editor-file-saved'
 
 export type EditorPathMutationTarget = {
   worktreeId: string
@@ -21,6 +24,22 @@ export type EditorSaveQuiesceTarget = { fileId: string } | EditorPathMutationTar
 export type EditorSaveQuiesceDetail = EditorSaveQuiesceTarget & {
   claim: () => void
   resolve: () => void
+}
+
+export type EditorSaveFileTarget = {
+  fileId: string
+  fallbackContent?: string
+}
+
+export type EditorSaveFileDetail = EditorSaveFileTarget & {
+  claim: () => void
+  resolve: () => void
+  reject: (message: string) => void
+}
+
+export type EditorFileSavedDetail = {
+  fileId: string
+  content: string
 }
 
 export function canAutoSaveOpenFile(file: OpenFile): boolean {
@@ -82,6 +101,31 @@ export async function requestEditorSaveQuiesce(target: EditorSaveQuiesceTarget):
     // waiting on a quiesce listener that does not exist in that UI state.
     if (!claimed) {
       resolve()
+    }
+  })
+}
+
+export async function requestEditorFileSave(target: EditorSaveFileTarget): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    let claimed = false
+    window.dispatchEvent(
+      new CustomEvent<EditorSaveFileDetail>(ORCA_EDITOR_SAVE_FILE_EVENT, {
+        detail: {
+          ...target,
+          claim: () => {
+            claimed = true
+          },
+          resolve,
+          reject: (message) => reject(new Error(message))
+        }
+      })
+    )
+    // Why: a direct save request should never report success unless some
+    // controller actually accepted responsibility for writing the file. Unlike
+    // quiesce, silently no-oping here would make Cmd/Ctrl+S look successful
+    // while dropping the user's save entirely.
+    if (!claimed) {
+      reject(new Error('Editor save controller is unavailable.'))
     }
   })
 }

--- a/src/renderer/src/components/right-sidebar/useFileExplorerDragDrop.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerDragDrop.ts
@@ -4,6 +4,7 @@ import { toast } from 'sonner'
 import { useAppStore } from '@/store'
 import { basename, dirname, joinPath } from '@/lib/path'
 import { detectLanguage } from '@/lib/language-detect'
+import { requestEditorSaveQuiesce } from '@/components/editor/editor-autosave'
 
 function extractIpcErrorMessage(err: unknown, fallback: string): string {
   if (!(err instanceof Error)) {
@@ -56,8 +57,11 @@ export function useFileExplorerDragDrop({
   scrollRef
 }: UseFileExplorerDragDropParams): UseFileExplorerDragDropResult {
   const openFiles = useAppStore((s) => s.openFiles)
+  const editorDrafts = useAppStore((s) => s.editorDrafts)
   const closeFile = useAppStore((s) => s.closeFile)
   const openFile = useAppStore((s) => s.openFile)
+  const setEditorDraft = useAppStore((s) => s.setEditorDraft)
+  const markFileDirty = useAppStore((s) => s.markFileDirty)
 
   const [isRootDragOver, setIsRootDragOver] = useState(false)
   const rootDragCounterRef = useRef(0)
@@ -130,6 +134,21 @@ export function useFileExplorerDragDrop({
       const newPath = joinPath(destDir, fileName)
 
       const run = async (): Promise<void> => {
+        const filesToMove = openFiles.filter((file) => {
+          if (file.filePath === sourcePath) {
+            return true
+          }
+          return (
+            file.filePath.startsWith(`${sourcePath}/`) ||
+            file.filePath.startsWith(`${sourcePath}\\`)
+          )
+        })
+
+        // Why: a file move changes the write target path. Let any in-flight
+        // autosave settle first, then carry draft state forward to the new tab
+        // id so explorer drag-and-drop does not silently drop unsaved edits.
+        await Promise.all(filesToMove.map((file) => requestEditorSaveQuiesce({ fileId: file.id })))
+
         try {
           await window.api.fs.rename({ oldPath: sourcePath, newPath })
         } catch (err) {
@@ -142,7 +161,7 @@ export function useFileExplorerDragDrop({
         // Update any open editor tabs whose paths were under the moved item.
         // Since OpenFile.id === filePath, we close the old tab and reopen at
         // the new path so all derived state (relativePath, language) stays correct.
-        for (const file of openFiles) {
+        for (const file of filesToMove) {
           let oldFilePath: string | null = null
           if (file.filePath === sourcePath) {
             oldFilePath = sourcePath
@@ -159,8 +178,18 @@ export function useFileExplorerDragDrop({
           const suffix = oldFilePath.slice(sourcePath.length)
           const updatedPath = newPath + suffix
           const updatedRelative = updatedPath.slice(worktreePath.length + 1)
+          const draft = editorDrafts[file.id]
+          const wasDirty = file.isDirty
 
           closeFile(oldFilePath)
+
+          if (file.mode !== 'edit') {
+            // Why: diff/conflict tabs encode extra git state in their ids. A
+            // filesystem move invalidates that state, so closing them is safer
+            // than silently reopening the path as a normal edit tab.
+            continue
+          }
+
           openFile({
             filePath: updatedPath,
             relativePath: updatedRelative,
@@ -168,11 +197,28 @@ export function useFileExplorerDragDrop({
             language: detectLanguage(basename(updatedPath)),
             mode: 'edit'
           })
+
+          if (draft !== undefined) {
+            setEditorDraft(updatedPath, draft)
+          }
+          if (wasDirty) {
+            markFileDirty(updatedPath, true)
+          }
         }
       }
       void run()
     },
-    [worktreePath, activeWorktreeId, openFiles, closeFile, openFile, refreshDir]
+    [
+      worktreePath,
+      activeWorktreeId,
+      closeFile,
+      editorDrafts,
+      markFileDirty,
+      openFile,
+      openFiles,
+      refreshDir,
+      setEditorDraft
+    ]
   )
 
   const rootDragHandlers = {

--- a/src/renderer/src/components/terminal/useTerminalSaveDialog.ts
+++ b/src/renderer/src/components/terminal/useTerminalSaveDialog.ts
@@ -1,6 +1,9 @@
 import { useCallback, useState } from 'react'
 import type { OpenFile } from '@/store/slices/editor'
-import { requestEditorSaveQuiesce } from '@/components/editor/editor-autosave'
+import {
+  ORCA_EDITOR_SAVE_AND_CLOSE_EVENT,
+  requestEditorSaveQuiesce
+} from '@/components/editor/editor-autosave'
 
 type UseTerminalSaveDialogParams = {
   openFiles: OpenFile[]
@@ -46,7 +49,7 @@ export function useTerminalSaveDialog({
     }
 
     window.dispatchEvent(
-      new CustomEvent('orca:save-and-close', { detail: { fileId: saveDialogFileId } })
+      new CustomEvent(ORCA_EDITOR_SAVE_AND_CLOSE_EVENT, { detail: { fileId: saveDialogFileId } })
     )
     setSaveDialogFileId(null)
   }, [saveDialogFileId])

--- a/src/renderer/src/components/terminal/useTerminalShortcuts.ts
+++ b/src/renderer/src/components/terminal/useTerminalShortcuts.ts
@@ -1,5 +1,6 @@
 import { useEffect, useEffectEvent } from 'react'
 import type { UnifiedTerminalItem } from './useTerminalTabs'
+import { isUpdaterQuitAndInstallInProgress } from '@/lib/updater-beforeunload'
 
 type UseTerminalShortcutsParams = {
   activeWorktreeId: string | null
@@ -76,6 +77,9 @@ export function useTerminalShortcuts({
   })
 
   const handleBeforeUnload = useEffectEvent((event: BeforeUnloadEvent) => {
+    if (isUpdaterQuitAndInstallInProgress()) {
+      return
+    }
     if (!hasDirtyFiles) {
       return
     }

--- a/src/renderer/src/lib/updater-beforeunload.test.ts
+++ b/src/renderer/src/lib/updater-beforeunload.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  isUpdaterQuitAndInstallInProgress,
+  registerUpdaterBeforeUnloadBypass
+} from './updater-beforeunload'
+import {
+  ORCA_UPDATER_QUIT_AND_INSTALL_ABORTED_EVENT,
+  ORCA_UPDATER_QUIT_AND_INSTALL_STARTED_EVENT
+} from '../../../shared/updater-renderer-events'
+
+type WindowEventStub = Pick<Window, 'addEventListener' | 'removeEventListener' | 'dispatchEvent'>
+
+beforeEach(() => {
+  const eventTarget = new EventTarget()
+  vi.stubGlobal('window', {
+    addEventListener: eventTarget.addEventListener.bind(eventTarget),
+    removeEventListener: eventTarget.removeEventListener.bind(eventTarget),
+    dispatchEvent: eventTarget.dispatchEvent.bind(eventTarget)
+  } satisfies WindowEventStub)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('registerUpdaterBeforeUnloadBypass', () => {
+  it('tracks updater quit-and-install lifecycle events', () => {
+    const cleanup = registerUpdaterBeforeUnloadBypass()
+    expect(isUpdaterQuitAndInstallInProgress()).toBe(false)
+
+    window.dispatchEvent(new Event(ORCA_UPDATER_QUIT_AND_INSTALL_STARTED_EVENT))
+    expect(isUpdaterQuitAndInstallInProgress()).toBe(true)
+
+    window.dispatchEvent(new Event(ORCA_UPDATER_QUIT_AND_INSTALL_ABORTED_EVENT))
+    expect(isUpdaterQuitAndInstallInProgress()).toBe(false)
+
+    cleanup()
+  })
+
+  it('resets the bypass flag during cleanup', () => {
+    const cleanup = registerUpdaterBeforeUnloadBypass()
+
+    window.dispatchEvent(new Event(ORCA_UPDATER_QUIT_AND_INSTALL_STARTED_EVENT))
+    expect(isUpdaterQuitAndInstallInProgress()).toBe(true)
+
+    cleanup()
+    expect(isUpdaterQuitAndInstallInProgress()).toBe(false)
+  })
+})

--- a/src/renderer/src/lib/updater-beforeunload.ts
+++ b/src/renderer/src/lib/updater-beforeunload.ts
@@ -1,0 +1,31 @@
+import {
+  ORCA_UPDATER_QUIT_AND_INSTALL_ABORTED_EVENT,
+  ORCA_UPDATER_QUIT_AND_INSTALL_STARTED_EVENT
+} from '../../../shared/updater-renderer-events'
+
+let updaterQuitAndInstallInProgress = false
+
+export function isUpdaterQuitAndInstallInProgress(): boolean {
+  return updaterQuitAndInstallInProgress
+}
+
+export function registerUpdaterBeforeUnloadBypass(): () => void {
+  const markInProgress = (): void => {
+    updaterQuitAndInstallInProgress = true
+  }
+  const clearInProgress = (): void => {
+    updaterQuitAndInstallInProgress = false
+  }
+
+  window.addEventListener(ORCA_UPDATER_QUIT_AND_INSTALL_STARTED_EVENT, markInProgress)
+  window.addEventListener(ORCA_UPDATER_QUIT_AND_INSTALL_ABORTED_EVENT, clearInProgress)
+
+  return () => {
+    window.removeEventListener(ORCA_UPDATER_QUIT_AND_INSTALL_STARTED_EVENT, markInProgress)
+    window.removeEventListener(ORCA_UPDATER_QUIT_AND_INSTALL_ABORTED_EVENT, clearInProgress)
+    // Why: hot reloads can re-register this listener inside the same renderer.
+    // Reset the module flag on cleanup so a failed earlier install attempt
+    // cannot silently suppress future unsaved-change prompts.
+    updaterQuitAndInstallInProgress = false
+  }
+}

--- a/src/renderer/src/store/slices/editor.test.ts
+++ b/src/renderer/src/store/slices/editor.test.ts
@@ -1,3 +1,5 @@
+/* eslint-disable max-lines */
+
 import { createStore, type StoreApi } from 'zustand/vanilla'
 import { describe, expect, it } from 'vitest'
 import { createEditorSlice } from './editor'
@@ -165,6 +167,54 @@ describe('createEditorSlice pending editor reveal', () => {
 
     expect(store.getState().openFiles).toEqual([])
     expect(store.getState().pendingEditorReveal).toBeNull()
+  })
+})
+
+describe('createEditorSlice editor drafts', () => {
+  it('clears draft buffers when closing the file', () => {
+    const store = createEditorStore()
+
+    store.getState().openFile({
+      filePath: '/repo/src/file.ts',
+      relativePath: 'src/file.ts',
+      worktreeId: 'wt-1',
+      language: 'typescript',
+      mode: 'edit'
+    })
+    store.getState().setEditorDraft('/repo/src/file.ts', 'edited')
+
+    store.getState().closeFile('/repo/src/file.ts')
+
+    expect(store.getState().editorDrafts).toEqual({})
+  })
+
+  it('drops replaced preview drafts so hidden preview state cannot linger', () => {
+    const store = createEditorStore()
+
+    store.getState().openFile(
+      {
+        filePath: '/repo/docs/README.md',
+        relativePath: 'docs/README.md',
+        worktreeId: 'wt-1',
+        language: 'markdown',
+        mode: 'edit'
+      },
+      { preview: true }
+    )
+    store.getState().setEditorDraft('/repo/docs/README.md', 'draft')
+
+    store.getState().openFile(
+      {
+        filePath: '/repo/docs/guide.md',
+        relativePath: 'docs/guide.md',
+        worktreeId: 'wt-1',
+        language: 'markdown',
+        mode: 'edit'
+      },
+      { preview: true }
+    )
+
+    expect(store.getState().editorDrafts).toEqual({})
   })
 })
 

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -100,6 +100,15 @@ export type ActivityBarPosition = 'top' | 'side'
 export type MarkdownViewMode = 'source' | 'rich'
 
 export type EditorSlice = {
+  // Why: #300 originally kept EditorPanel mounted while hidden so unsaved
+  // drafts and autosave timers could survive tab switches. Drafts live in the
+  // store instead so the visible editor UI can unmount without losing edits or
+  // widening the app-shutdown surface.
+  editorDrafts: Record<string, string>
+  setEditorDraft: (fileId: string, content: string) => void
+  clearEditorDraft: (fileId: string) => void
+  clearEditorDrafts: (fileIds: string[]) => void
+
   // Markdown view mode per file (fileId -> mode)
   markdownViewMode: Record<string, MarkdownViewMode>
   setMarkdownViewMode: (fileId: string, mode: MarkdownViewMode) => void
@@ -241,6 +250,36 @@ export type EditorSlice = {
 }
 
 export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (set) => ({
+  editorDrafts: {},
+  setEditorDraft: (fileId, content) =>
+    set((s) => ({
+      editorDrafts: { ...s.editorDrafts, [fileId]: content }
+    })),
+  clearEditorDraft: (fileId) =>
+    set((s) => {
+      if (!(fileId in s.editorDrafts)) {
+        return s
+      }
+      const next = { ...s.editorDrafts }
+      delete next[fileId]
+      return { editorDrafts: next }
+    }),
+  clearEditorDrafts: (fileIds) =>
+    set((s) => {
+      if (fileIds.length === 0) {
+        return s
+      }
+      const next = { ...s.editorDrafts }
+      let changed = false
+      for (const fileId of fileIds) {
+        if (fileId in next) {
+          delete next[fileId]
+          changed = true
+        }
+      }
+      return changed ? { editorDrafts: next } : s
+    }),
+
   // Markdown view mode
   markdownViewMode: {},
   setMarkdownViewMode: (fileId, mode) =>
@@ -357,6 +396,12 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
         )
         if (existingPreviewIdx !== -1) {
           const replacedPreview = s.openFiles[existingPreviewIdx]
+          const nextEditorDrafts =
+            replacedPreview.id === id
+              ? s.editorDrafts
+              : Object.fromEntries(
+                  Object.entries(s.editorDrafts).filter(([fileId]) => fileId !== replacedPreview.id)
+                )
           const nextMarkdownViewMode =
             replacedPreview.id === id
               ? s.markdownViewMode
@@ -371,6 +416,7 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
           )
           return {
             openFiles: newFiles,
+            editorDrafts: nextEditorDrafts,
             markdownViewMode: nextMarkdownViewMode,
             ...activeResult
           }
@@ -407,6 +453,8 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
       const closedFile = s.openFiles.find((f) => f.id === fileId)
       const idx = s.openFiles.findIndex((f) => f.id === fileId)
       const newFiles = s.openFiles.filter((f) => f.id !== fileId)
+      const newEditorDrafts = { ...s.editorDrafts }
+      delete newEditorDrafts[fileId]
       const newMarkdownViewMode = { ...s.markdownViewMode }
       delete newMarkdownViewMode[fileId]
       let newActiveId = s.activeFileId
@@ -450,6 +498,7 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
 
       return {
         openFiles: newFiles,
+        editorDrafts: newEditorDrafts,
         activeFileId: newActiveId,
         activeTabType: newActiveTabType,
         activeFileIdByWorktree: newActiveFileIdByWorktree,
@@ -465,6 +514,7 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
       if (!activeWorktreeId) {
         return {
           openFiles: [],
+          editorDrafts: {},
           activeFileId: null,
           activeTabType: 'terminal',
           markdownViewMode: {},
@@ -474,6 +524,9 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
       // Only close files for the current worktree
       const newFiles = s.openFiles.filter((f) => f.worktreeId !== activeWorktreeId)
       const remainingFileIds = new Set(newFiles.map((f) => f.id))
+      const newEditorDrafts = Object.fromEntries(
+        Object.entries(s.editorDrafts).filter(([fileId]) => remainingFileIds.has(fileId))
+      )
       const newMarkdownViewMode = Object.fromEntries(
         Object.entries(s.markdownViewMode).filter(([fileId]) => remainingFileIds.has(fileId))
       )
@@ -483,6 +536,7 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
       newActiveTabTypeByWorktree[activeWorktreeId] = 'terminal'
       return {
         openFiles: newFiles,
+        editorDrafts: newEditorDrafts,
         activeFileId: null,
         activeTabType: 'terminal',
         markdownViewMode: newMarkdownViewMode,

--- a/src/shared/updater-renderer-events.ts
+++ b/src/shared/updater-renderer-events.ts
@@ -1,0 +1,2 @@
+export const ORCA_UPDATER_QUIT_AND_INSTALL_STARTED_EVENT = 'orca:updater-quit-and-install-started'
+export const ORCA_UPDATER_QUIT_AND_INSTALL_ABORTED_EVENT = 'orca:updater-quit-and-install-aborted'


### PR DESCRIPTION
## Summary
- Extracts editor autosave/save-queue logic from `EditorPanel` into a standalone headless `EditorAutosaveController` that survives tab switches without keeping the full editor UI mounted
- Moves editor draft buffers (`editBuffers`) from component state into the Zustand store (`editorDrafts`) so they persist across editor unmount/remount cycles
- Adds updater lifecycle events (`quit-and-install-started` / `aborted`) so `beforeunload` guards step aside during `quitAndInstall`, preventing stale dirty-file prompts from blocking app restarts
- Preserves draft state and dirty flags when dragging files in the explorer, quiescing in-flight autosaves before the move

## Test plan
- [x] Unit tests for `editor-autosave-controller` (dirty file save without editor UI, quiesce timers)
- [x] Unit tests for `updater-beforeunload` (lifecycle event tracking, cleanup reset)
- [x] Unit tests for `editor-autosave` (`requestEditorFileSave` rejection when unclaimed)
- [x] Unit tests for editor store drafts (close cleanup, preview replacement cleanup)
- [ ] Manual: open dirty editor tab, switch to terminal, trigger auto-update → files save and app restarts
- [ ] Manual: drag file with unsaved edits in explorer → draft and dirty state transfer to new path