### PR TITLE
fix: show error toast when quitAndInstall fails

### DIFF
--- a/src/renderer/src/components/settings/GeneralPane.tsx
+++ b/src/renderer/src/components/settings/GeneralPane.tsx
@@ -10,6 +10,7 @@ import { Separator } from '../ui/separator'
 import { Download, FolderOpen, Loader2, RefreshCw } from 'lucide-react'
 import { useAppStore } from '../../store'
 import { CliSection } from './CliSection'
+import { toast } from 'sonner'
 import {
   DEFAULT_EDITOR_AUTO_SAVE_DELAY_MS,
   MAX_EDITOR_AUTO_SAVE_DELAY_MS,
@@ -82,6 +83,14 @@ export function GeneralPane({
     )
     updateSettings({ editorAutoSaveDelayMs: next })
     setAutoSaveDelayDraft(String(next))
+  }
+
+  const handleRestartToUpdate = (): void => {
+    void window.api.updater.quitAndInstall().catch((error) => {
+      toast.error('Could not restart to install the update.', {
+        description: String((error as Error)?.message ?? error)
+      })
+    })
   }
 
   const visibleSections = [
@@ -359,12 +368,7 @@ export function GeneralPane({
                   : `Install Update (${updateStatus.version})`}
               </Button>
             ) : updateStatus.state === 'downloaded' ? (
-              <Button
-                variant="default"
-                size="sm"
-                onClick={() => window.api.updater.quitAndInstall()}
-                className="gap-2"
-              >
+              <Button variant="default" size="sm" onClick={handleRestartToUpdate} className="gap-2">
                 <Download className="size-3.5" />
                 Restart to Update ({updateStatus.version})
               </Button>

--- a/src/renderer/src/hooks/update-toast-controller.ts
+++ b/src/renderer/src/hooks/update-toast-controller.ts
@@ -43,6 +43,19 @@ export function createUpdateToastController(deps?: {
   // finish in one step instead of showing a second bottom-right prompt.
   let autoRestartAfterDownload = false
 
+  const showRestartFailure = (message: string): void => {
+    toastApi.error('Could not restart to install the update.', {
+      description: message
+    })
+  }
+
+  const requestRestartInstall = (): void => {
+    void updaterApi.quitAndInstall().catch((error) => {
+      autoRestartAfterDownload = false
+      showRestartFailure(String((error as Error)?.message ?? error))
+    })
+  }
+
   return {
     handleStatus(status) {
       // Why: update checks are a new lifecycle. Clearing the one-click
@@ -123,7 +136,7 @@ export function createUpdateToastController(deps?: {
         toastApi.dismiss(downloadToastId)
         if (autoRestartAfterDownload) {
           autoRestartAfterDownload = false
-          void updaterApi.quitAndInstall()
+          requestRestartInstall()
           return
         }
         const releaseUrl = getReleaseUrl(status)
@@ -142,7 +155,7 @@ export function createUpdateToastController(deps?: {
           action: {
             label: 'Restart Now',
             onClick: () => {
-              void updaterApi.quitAndInstall()
+              requestRestartInstall()
             }
           }
         })


### PR DESCRIPTION
## Summary
- All 3 renderer-side `quitAndInstall()` call sites now catch errors and show an error toast instead of failing silently
- Settings pane "Restart to Update" button, auto-restart-after-download path, and "Restart Now" toast action are all covered
- Resets `autoRestartAfterDownload` flag on failure to prevent stuck auto-restart state

## Test plan
- [ ] Verify "Restart to Update" in settings shows toast on quitAndInstall failure
- [ ] Verify auto-restart-after-download shows toast on failure and doesn't retry
- [ ] Verify "Restart Now" toast action shows error toast on failure
- [ ] Verify normal successful update flow still works (app quits and installs)