### PR TITLE
feat: add Cmd/Ctrl+L to toggle right sidebar visibility

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -371,6 +371,13 @@ function App(): React.JSX.Element {
         return
       }
 
+      // Cmd/Ctrl+L — toggle right sidebar
+      if (!e.altKey && !e.shiftKey && e.key.toLowerCase() === 'l') {
+        e.preventDefault()
+        toggleRightSidebar()
+        return
+      }
+
       // Cmd/Ctrl+N — create worktree
       if (!e.altKey && !e.shiftKey && e.key.toLowerCase() === 'n') {
         if (repos.length === 0) {
@@ -413,6 +420,7 @@ function App(): React.JSX.Element {
     openModal,
     repos.length,
     toggleSidebar,
+    toggleRightSidebar,
     setRightSidebarTab,
     setRightSidebarOpen,
     setQuickOpenVisible
@@ -447,7 +455,7 @@ function App(): React.JSX.Element {
         <button
           className="sidebar-toggle mr-2"
           onClick={toggleRightSidebar}
-          title="Toggle right sidebar"
+          title={`Toggle right sidebar (${isMac ? '⌘L' : 'Ctrl+L'})`}
           aria-label="Toggle right sidebar"
           disabled={!showSidebar}
         >

--- a/src/renderer/src/components/settings/ShortcutsPane.tsx
+++ b/src/renderer/src/components/settings/ShortcutsPane.tsx
@@ -44,6 +44,11 @@ const SHORTCUT_GROUP_DEFINITIONS: ShortcutGroupDefinition[] = [
         keys: ({ mod }) => [mod, 'B']
       },
       {
+        action: 'Toggle Right Sidebar',
+        searchKeywords: ['shortcut', 'sidebar', 'right'],
+        keys: ({ mod }) => [mod, 'L']
+      },
+      {
         action: 'Move up worktree',
         searchKeywords: ['shortcut', 'global', 'worktree', 'move'],
         keys: ({ mod, shift }) => [mod, shift, '↑']


### PR DESCRIPTION
## Summary
- Adds `Cmd+L` (macOS) / `Ctrl+L` (Windows/Linux) keyboard shortcut to toggle the right sidebar, matching the convention used by Cursor and other modern IDEs for secondary sidebar toggle
- Mirrors the existing `Cmd+B` / `Ctrl+B` shortcut for the left sidebar
- Adds the shortcut to the Settings > Keyboard Shortcuts documentation
- Shows the keybinding in the titlebar button tooltip for discoverability

Closes #332

## Test plan
- [ ] Press `Cmd+L` (macOS) or `Ctrl+L` (Windows/Linux) — right sidebar should toggle open/closed
- [ ] Verify `Cmd+B` still toggles the left sidebar
- [ ] Open Settings > Keyboard Shortcuts — "Toggle Right Sidebar" should appear with the correct key combo
- [ ] Hover over the right sidebar toggle button in the titlebar — tooltip should show the shortcut

🤖 Generated with [Claude Code](https://claude.com/claude-code)