### PR TITLE
fix: unpack out/shared/ from asar so CLI imports resolve

### DIFF
--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -15,7 +15,11 @@ module.exports = {
     '!{.env,.env.*,.npmrc,pnpm-lock.yaml}',
     '!{tsconfig.json,tsconfig.node.json,tsconfig.web.json}'
   ],
-  asarUnpack: ['out/cli/**', 'resources/**'],
+  // Why: the CLI entry-point lives in out/cli/ but imports shared modules
+  // from out/shared/ (e.g. runtime-bootstrap). Both directories must be
+  // unpacked so that Node's require() can resolve the cross-directory imports
+  // when the CLI runs outside the asar archive.
+  asarUnpack: ['out/cli/**', 'out/shared/**', 'resources/**'],
   win: {
     executableName: 'Orca',
     extraResources: [


### PR DESCRIPTION
## Summary
- Adds `out/shared/**` to `asarUnpack` in `electron-builder.config.cjs`
- The CLI entry-point (`out/cli/`) requires shared modules from `out/shared/` (e.g. `runtime-bootstrap`). Without unpacking both directories, Node's `require()` fails when the CLI runs outside the asar archive.
- Adds a "Why" comment explaining the constraint per project conventions.

## Test plan
- [ ] Build the app with `pnpm build` and verify the CLI commands work correctly
- [ ] Confirm `out/shared/` files are unpacked alongside `out/cli/` in the built artifact