### PR TITLE
fix: exclude RC/prerelease versions from auto-updater

### DIFF
--- a/src/main/updater-events.ts
+++ b/src/main/updater-events.ts
@@ -9,7 +9,7 @@ import {
   isMacQuitAndInstallInFlight,
   resetMacInstallState
 } from './updater-mac-install'
-import { compareVersions } from './updater-fallback'
+import { compareVersions, isPrerelease } from './updater-fallback'
 
 type UpdaterHandlerContext = {
   clearAvailableUpdateContext: () => void
@@ -95,6 +95,15 @@ export function registerAutoUpdaterHandlers({
   autoUpdater.on('update-available', (info) => {
     const wasUserInitiated = getUserInitiatedCheck()
     setUserInitiatedCheck(false)
+    // RC releases are only meant to be installed by hand; the auto-updater must
+    // never offer them. We need this guard because allowPrerelease is enabled on
+    // electron-updater to work around a broken GitHub endpoint, which causes
+    // prerelease versions to slip through its normal filter.
+    if (isPrerelease(info.version)) {
+      clearAvailableUpdateContext()
+      sendStatus({ state: 'not-available', userInitiated: wasUserInitiated || undefined })
+      return
+    }
     // Guard against showing an update that isn't actually newer than what's running.
     // With allowPrerelease enabled, electron-updater may report the current or
     // even an older version as "available". Use semver comparison so we never
@@ -134,6 +143,13 @@ export function registerAutoUpdaterHandlers({
   })
 
   autoUpdater.on('update-downloaded', (info) => {
+    // Safety net: reject RC downloads that somehow slipped past the
+    // update-available guard. RC releases are manual-install only.
+    if (isPrerelease(info.version)) {
+      clearAvailableUpdateContext()
+      sendStatus({ state: 'not-available' })
+      return
+    }
     // Don't show the banner if the downloaded version isn't actually newer
     // than what's running. This catches the exact-same-version case as well
     // as stale cached updates from an older release.

--- a/src/main/updater-fallback.ts
+++ b/src/main/updater-fallback.ts
@@ -127,6 +127,18 @@ function compareIdentifiers(left: string, right: string): number {
   return left.localeCompare(right)
 }
 
+/** Returns true if the version string contains a prerelease tag (e.g. "-rc.1").
+ *  RC releases are only meant to be installed by hand, so the auto-updater must
+ *  never offer them. We need this guard because allowPrerelease is enabled on
+ *  electron-updater to work around a broken GitHub /releases/latest endpoint,
+ *  which means prerelease versions slip through its normal filter. */
+export function isPrerelease(version: string): boolean {
+  const parsed = parseVersion(version)
+  // Treat unparseable versions as prerelease so they are rejected early rather
+  // than slipping through to downstream guards.
+  return parsed === null || parsed.prerelease.length > 0
+}
+
 /** Returns negative if left < right, 0 if equal, positive if left > right. */
 export function compareVersions(left: string, right: string): number {
   const leftVersion = parseVersion(left)

--- a/src/main/updater.fallback.test.ts
+++ b/src/main/updater.fallback.test.ts
@@ -150,6 +150,19 @@ describe('updater fallback', () => {
     expect(compareVersions('v1.0.70-beta.2', '1.0.70-beta.1')).toBeGreaterThan(0)
   })
 
+  it('identifies prerelease versions correctly', async () => {
+    const { isPrerelease } = await import('./updater-fallback')
+
+    expect(isPrerelease('1.0.70-rc.1')).toBe(true)
+    expect(isPrerelease('1.0.70-rc.0')).toBe(true)
+    expect(isPrerelease('1.0.70-beta.1')).toBe(true)
+    expect(isPrerelease('1.0.70-alpha.3')).toBe(true)
+    expect(isPrerelease('v1.0.70-rc.1')).toBe(true)
+    expect(isPrerelease('1.0.70')).toBe(false)
+    expect(isPrerelease('v1.0.70')).toBe(false)
+    expect(isPrerelease('1.0.70+build.5')).toBe(false)
+  })
+
   it('falls back to the latest stable GitHub release when GitHub reports no published versions', async () => {
     mockReleaseLookupResponse()
     mockCheckFailure('No published versions on GitHub')

--- a/src/main/updater.test.ts
+++ b/src/main/updater.test.ts
@@ -258,6 +258,55 @@ describe('updater', () => {
     expect(setLastUpdateCheckAt).not.toHaveBeenCalled()
   })
 
+  it('treats an RC version from update-available as not-available', async () => {
+    autoUpdaterMock.checkForUpdates.mockResolvedValueOnce(undefined).mockImplementationOnce(() => {
+      autoUpdaterMock.emit('checking-for-update')
+      queueMicrotask(() => {
+        autoUpdaterMock.emit('update-available', { version: '1.0.52-rc.1' })
+      })
+      return Promise.resolve(null)
+    })
+
+    const sendMock = vi.fn()
+    const mainWindow = { webContents: { send: sendMock } }
+
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never)
+    checkForUpdatesFromMenu()
+    await vi.waitFor(() => {
+      const statuses = sendMock.mock.calls
+        .filter(([channel]) => channel === 'updater:status')
+        .map(([, status]) => status)
+      expect(statuses).toContainEqual(expect.objectContaining({ state: 'not-available' }))
+    })
+
+    const statuses = sendMock.mock.calls
+      .filter(([channel]) => channel === 'updater:status')
+      .map(([, status]) => status)
+
+    expect(statuses).not.toContainEqual(expect.objectContaining({ state: 'available' }))
+  })
+
+  it('treats an RC version from update-downloaded as not-available', async () => {
+    autoUpdaterMock.checkForUpdates.mockResolvedValueOnce(undefined)
+
+    const sendMock = vi.fn()
+    const mainWindow = { webContents: { send: sendMock } }
+
+    const { setupAutoUpdater } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never)
+    autoUpdaterMock.emit('update-downloaded', { version: '1.0.52-rc.0' })
+
+    const statuses = sendMock.mock.calls
+      .filter(([channel]) => channel === 'updater:status')
+      .map(([, status]) => status)
+
+    expect(statuses).toContainEqual({ state: 'not-available' })
+    expect(statuses).not.toContainEqual(expect.objectContaining({ state: 'downloaded' }))
+  })
+
   it('retries background checks sooner after a failed automatic check', async () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-04-03T12:00:00Z'))

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -287,7 +287,8 @@ export function setupAutoUpdater(
   autoUpdater.autoInstallOnAppQuit = true
   // Use allowPrerelease to bypass broken /releases/latest endpoint (returns 406)
   // and instead parse the version directly from the atom feed which works reliably.
-  // This is safe since we don't publish prerelease versions.
+  // RC/prerelease versions are filtered out in the update-available and
+  // update-downloaded event handlers so they are never offered to the user.
   autoUpdater.allowPrerelease = true
 
   if (autoUpdaterInitialized) {


### PR DESCRIPTION
## Summary
- Add `isPrerelease()` guard in both `update-available` and `update-downloaded` handlers so RC versions (e.g. `1.0.94-rc.1`) are never offered to users through auto-update
- Unparseable version strings are treated as prerelease (fail-closed) to reject them early
- Update comment on `allowPrerelease = true` to reflect the new filtering behavior

## Context
`allowPrerelease` is enabled on electron-updater to work around a broken GitHub `/releases/latest` endpoint (returns 406). This causes RC/prerelease versions to slip through. These guards ensure RC releases remain manual-install only.

## Test plan
- [x] Typecheck passes
- [x] All 529 tests pass
- [ ] Verify auto-updater does not offer RC versions when a new RC is published
- [ ] Verify auto-updater still offers stable versions correctly