### PR TITLE
Fix terminal zoom shortcuts on Linux layouts

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -67,6 +67,15 @@ app.whenReady().then(async () => {
     onCheckForUpdates: () => checkForUpdatesFromMenu(),
     onOpenSettings: () => {
       mainWindow?.webContents.send('ui:openSettings')
+    },
+    onZoomIn: () => {
+      mainWindow?.webContents.send('terminal:zoom', 'in')
+    },
+    onZoomOut: () => {
+      mainWindow?.webContents.send('terminal:zoom', 'out')
+    },
+    onZoomReset: () => {
+      mainWindow?.webContents.send('terminal:zoom', 'reset')
     }
   })
   registerCoreHandlers(store, runtime)

--- a/src/main/menu/register-app-menu.ts
+++ b/src/main/menu/register-app-menu.ts
@@ -3,11 +3,17 @@ import { Menu, app } from 'electron'
 type RegisterAppMenuOptions = {
   onOpenSettings: () => void
   onCheckForUpdates: () => void
+  onZoomIn: () => void
+  onZoomOut: () => void
+  onZoomReset: () => void
 }
 
 export function registerAppMenu({
   onOpenSettings,
-  onCheckForUpdates
+  onCheckForUpdates,
+  onZoomIn,
+  onZoomOut,
+  onZoomReset
 }: RegisterAppMenuOptions): void {
   const template: Electron.MenuItemConstructorOptions[] = [
     {
@@ -53,19 +59,31 @@ export function registerAppMenu({
         { role: 'toggleDevTools' },
         { type: 'separator' },
         {
-          label: 'Actual Size',
+          label: 'Reset Size',
           accelerator: 'CmdOrCtrl+0',
-          registerAccelerator: false
+          // Why: Some keyboard layouts/platforms intercept Cmd/Ctrl+zoom chords
+          // before before-input-event fires. Binding the menu accelerator gives
+          // us a reliable cross-platform fallback path.
+          click: () => onZoomReset()
         },
         {
           label: 'Zoom In',
           accelerator: 'CmdOrCtrl+=',
-          registerAccelerator: false
+          click: () => onZoomIn()
         },
         {
           label: 'Zoom Out',
           accelerator: 'CmdOrCtrl+-',
-          registerAccelerator: false
+          click: () => onZoomOut()
+        },
+        {
+          label: 'Zoom Out (Shift Alias)',
+          // Why: Some Linux keyboard layouts report the top-row minus chord as
+          // an underscore accelerator. Keep this hidden alias so Ctrl+- and
+          // Ctrl+_ can both route to terminal zoom out.
+          accelerator: 'CmdOrCtrl+_',
+          visible: false,
+          click: () => onZoomOut()
         },
         { type: 'separator' },
         { role: 'togglefullscreen' }

--- a/src/main/window/createMainWindow.test.ts
+++ b/src/main/window/createMainWindow.test.ts
@@ -96,4 +96,87 @@ describe('createMainWindow', () => {
     expect(fileNavigationPreventDefault).toHaveBeenCalledTimes(1)
     expect(openExternalMock).toHaveBeenCalledTimes(4)
   })
+
+  it('supports all minus key variants for terminal zoom out', () => {
+    const windowHandlers: Record<string, (...args: any[]) => void> = {}
+    const webContents = {
+      on: vi.fn((event, handler) => {
+        windowHandlers[event] = handler
+      }),
+      setZoomLevel: vi.fn(),
+      setWindowOpenHandler: vi.fn(),
+      send: vi.fn()
+    }
+    const browserWindowInstance = {
+      webContents,
+      on: vi.fn(),
+      maximize: vi.fn(),
+      show: vi.fn(),
+      loadFile: vi.fn(),
+      loadURL: vi.fn()
+    }
+    browserWindowMock.mockImplementation(function () {
+      return browserWindowInstance
+    })
+
+    createMainWindow(null)
+
+    const beforeInputEvent = windowHandlers['before-input-event']
+
+    for (const input of [
+      { type: 'keyDown', control: true, meta: false, alt: false, key: '-' },
+      { type: 'keyDown', control: true, meta: false, alt: false, key: '_' },
+      { type: 'keyDown', control: true, meta: false, alt: false, key: 'Minus' },
+      { type: 'keyDown', control: true, meta: false, alt: false, key: 'Subtract' },
+      { type: 'keyDown', control: true, meta: false, alt: false, key: '', code: 'Minus' },
+      { type: 'keyDown', control: true, meta: false, alt: false, key: '', code: 'NumpadSubtract' }
+    ]) {
+      const preventDefault = vi.fn()
+      beforeInputEvent({ preventDefault } as never, input as never)
+      expect(preventDefault).toHaveBeenCalledTimes(1)
+    }
+
+    expect(webContents.send).toHaveBeenCalledTimes(6)
+    expect(webContents.send).toHaveBeenNthCalledWith(1, 'terminal:zoom', 'out')
+    expect(webContents.send).toHaveBeenNthCalledWith(2, 'terminal:zoom', 'out')
+    expect(webContents.send).toHaveBeenNthCalledWith(3, 'terminal:zoom', 'out')
+    expect(webContents.send).toHaveBeenNthCalledWith(4, 'terminal:zoom', 'out')
+    expect(webContents.send).toHaveBeenNthCalledWith(5, 'terminal:zoom', 'out')
+    expect(webContents.send).toHaveBeenNthCalledWith(6, 'terminal:zoom', 'out')
+  })
+
+  it('routes Electron zoom command events to terminal zoom', () => {
+    const windowHandlers: Record<string, (...args: any[]) => void> = {}
+    const webContents = {
+      on: vi.fn((event, handler) => {
+        windowHandlers[event] = handler
+      }),
+      setZoomLevel: vi.fn(),
+      setWindowOpenHandler: vi.fn(),
+      send: vi.fn()
+    }
+    const browserWindowInstance = {
+      webContents,
+      on: vi.fn(),
+      maximize: vi.fn(),
+      show: vi.fn(),
+      loadFile: vi.fn(),
+      loadURL: vi.fn()
+    }
+    browserWindowMock.mockImplementation(function () {
+      return browserWindowInstance
+    })
+
+    createMainWindow(null)
+
+    const onZoomChanged = windowHandlers['zoom-changed']
+    const preventDefault = vi.fn()
+    onZoomChanged({ preventDefault } as never, 'out')
+    onZoomChanged({ preventDefault } as never, 'in')
+
+    expect(preventDefault).toHaveBeenCalledTimes(2)
+    expect(webContents.send).toHaveBeenCalledTimes(2)
+    expect(webContents.send).toHaveBeenNthCalledWith(1, 'terminal:zoom', 'out')
+    expect(webContents.send).toHaveBeenNthCalledWith(2, 'terminal:zoom', 'in')
+  })
 })

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -25,6 +25,27 @@ function normalizeExternalUrl(rawUrl: string): string | null {
   }
 }
 
+function isZoomInShortcut(input: Electron.Input): boolean {
+  return input.key === '=' || input.key === '+' || input.code === 'NumpadAdd'
+}
+
+function isZoomOutShortcut(input: Electron.Input): boolean {
+  // Why: Electron reports Cmd/Ctrl+Minus differently across layouts and devices:
+  // some emit '-' while shifted layouts emit '_', and other layouts/devices
+  // report symbolic names like "Minus"/"Subtract" in either key or code.
+  // We accept all known variants so zoom out remains reachable everywhere.
+  const key = (input.key ?? '').toLowerCase()
+  const code = (input.code ?? '').toLowerCase()
+  return (
+    key === '-' ||
+    key === '_' ||
+    key.includes('minus') ||
+    key.includes('subtract') ||
+    code.includes('minus') ||
+    code.includes('subtract')
+  )
+}
+
 export function createMainWindow(store: Store | null): BrowserWindow {
   const mainWindow = new BrowserWindow({
     width: 1200,
@@ -103,15 +124,27 @@ export function createMainWindow(store: Store | null): BrowserWindow {
       return
     }
 
-    if (input.key === '=' || input.key === '+') {
+    if (isZoomInShortcut(input)) {
       event.preventDefault()
       mainWindow.webContents.send('terminal:zoom', 'in')
-    } else if (input.key === '-') {
+    } else if (isZoomOutShortcut(input)) {
       event.preventDefault()
       mainWindow.webContents.send('terminal:zoom', 'out')
     } else if (input.key === '0' && !input.shift) {
       event.preventDefault()
       mainWindow.webContents.send('terminal:zoom', 'reset')
+    }
+  })
+
+  mainWindow.webContents.on('zoom-changed', (event, zoomDirection) => {
+    // Why: Some keyboard layouts/platforms consume Ctrl/Cmd+Minus before
+    // before-input-event fires, but still emit Electron's zoom command. We
+    // reroute that command to terminal zoom so zoom-out remains reachable.
+    event.preventDefault()
+    if (zoomDirection === 'in') {
+      mainWindow.webContents.send('terminal:zoom', 'in')
+    } else if (zoomDirection === 'out') {
+      mainWindow.webContents.send('terminal:zoom', 'out')
     }
   })
 

--- a/src/renderer/src/components/settings/ShortcutsPane.tsx
+++ b/src/renderer/src/components/settings/ShortcutsPane.tsx
@@ -72,6 +72,21 @@ const SHORTCUT_GROUP_DEFINITIONS: ShortcutGroupDefinition[] = [
         action: 'Toggle Source Control',
         searchKeywords: ['shortcut', 'source control'],
         keys: ({ mod, shift }) => [mod, shift, 'G']
+      },
+      {
+        action: 'Zoom In',
+        searchKeywords: ['shortcut', 'zoom', 'in', 'scale'],
+        keys: ({ mod, shift }) => (mod === 'Ctrl' ? [mod, shift, '+'] : [mod, '+'])
+      },
+      {
+        action: 'Zoom Out',
+        searchKeywords: ['shortcut', 'zoom', 'out', 'scale'],
+        keys: ({ mod, shift }) => (mod === 'Ctrl' ? [mod, shift, '-'] : [mod, '-'])
+      },
+      {
+        action: 'Reset Size',
+        searchKeywords: ['shortcut', 'zoom', 'reset', 'size', 'actual'],
+        keys: ({ mod }) => [mod, '0']
       }
     ]
   },


### PR DESCRIPTION
## Problem
On Linux keyboard layouts, `Ctrl+-` (top-row minus) did not reliably zoom out in the terminal. In some cases the chord was consumed before `before-input-event`, while zoom-in and menu-driven zoom still worked. The shortcuts UI also did not list zoom shortcuts, and the View menu label used "Actual Size" instead of "Reset Size".

## Solution
- Hardened terminal zoom shortcut matching in the main window input handler to accept multiple minus key representations (`-`, `_`, `Minus`, `Subtract`, and matching `code` variants), plus numpad add for zoom-in.
- Added a `zoom-changed` fallback bridge so Electron zoom commands are rerouted to terminal zoom when low-level key events are not delivered.
- Wired View menu zoom actions to explicit callbacks (`Zoom In`, `Zoom Out`, `Reset Size`) and renamed "Actual Size" to "Reset Size".
- Added a hidden Linux alias accelerator (`CmdOrCtrl+_`) for zoom out to support layouts where minus is reported through underscore.
- Added/updated tests for minus-key variants and `zoom-changed` routing.
- Updated the Settings > Keyboard Shortcuts list to include `Zoom In`, `Zoom Out`, and `Reset Size` entries.
