### PR TITLE
Scope zoom shortcuts to editor content outside terminal tabs

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -128,6 +128,7 @@ function App(): React.JSX.Element {
             showActiveOnly: false,
             filterRepoIds: [],
             uiZoomLevel: 0,
+            editorFontZoomLevel: 0,
             worktreeCardProperties: [...DEFAULT_WORKTREE_CARD_PROPERTIES],
             dismissedUpdateVersion: null,
             lastUpdateCheckAt: null

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -564,7 +564,7 @@
 .rich-markdown-editor {
   min-height: 100%;
   padding: 24px 32px 96px;
-  font-size: 14px;
+  font-size: calc(14px + (var(--editor-font-zoom-level, 0) * 1px));
   line-height: 1.7;
   outline: none;
 }
@@ -742,7 +742,7 @@
 .markdown-preview {
   position: relative;
   padding: 24px 32px;
-  font-size: 14px;
+  font-size: inherit;
   line-height: 1.7;
 }
 

--- a/src/renderer/src/components/editor/DiffSectionItem.tsx
+++ b/src/renderer/src/components/editor/DiffSectionItem.tsx
@@ -6,6 +6,7 @@ import type { editor as monacoEditor } from 'monaco-editor'
 import { joinPath } from '@/lib/path'
 import { detectLanguage } from '@/lib/language-detect'
 import { useAppStore } from '@/store'
+import { computeEditorFontSize } from '@/lib/editor-font-zoom'
 import type { GitDiffResult } from '../../../../shared/types'
 
 const ImageDiffViewer = lazy(() => import('./ImageDiffViewer'))
@@ -105,8 +106,13 @@ export function DiffSectionItem({
   handleSectionSaveRef: MutableRefObject<(index: number) => Promise<void>>
 }): React.JSX.Element {
   const openFile = useAppStore((s) => s.openFile)
+  const editorFontZoomLevel = useAppStore((s) => s.editorFontZoomLevel)
   const language = detectLanguage(section.path)
   const isEditable = section.area === 'unstaged'
+  const editorFontSize = computeEditorFontSize(
+    settings?.terminalFontSize ?? 13,
+    editorFontZoomLevel
+  )
 
   const lineStats = useMemo(
     () =>
@@ -280,7 +286,7 @@ export function DiffSectionItem({
                 renderSideBySide: sideBySide,
                 minimap: { enabled: false },
                 scrollBeyondLastLine: false,
-                fontSize: settings?.terminalFontSize ?? 13,
+                fontSize: editorFontSize,
                 fontFamily: settings?.terminalFontFamily || 'monospace',
                 lineNumbers: 'on',
                 automaticLayout: true,

--- a/src/renderer/src/components/editor/DiffViewer.tsx
+++ b/src/renderer/src/components/editor/DiffViewer.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useRef } from 'react'
 import { DiffEditor, type DiffOnMount } from '@monaco-editor/react'
 import { useAppStore } from '@/store'
 import '@/lib/monaco-setup'
+import { computeEditorFontSize } from '@/lib/editor-font-zoom'
 
 type DiffViewerProps = {
   originalContent: string
@@ -23,6 +24,11 @@ export default function DiffViewer({
   onSave
 }: DiffViewerProps): React.JSX.Element {
   const settings = useAppStore((s) => s.settings)
+  const editorFontZoomLevel = useAppStore((s) => s.editorFontZoomLevel)
+  const editorFontSize = computeEditorFontSize(
+    settings?.terminalFontSize ?? 13,
+    editorFontZoomLevel
+  )
   const isDark =
     settings?.theme === 'dark' ||
     (settings?.theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)
@@ -72,7 +78,7 @@ export default function DiffViewer({
             renderSideBySide: sideBySide,
             minimap: { enabled: false },
             scrollBeyondLastLine: false,
-            fontSize: settings?.terminalFontSize ?? 13,
+            fontSize: editorFontSize,
             fontFamily: settings?.terminalFontFamily || 'monospace',
             lineNumbers: 'on',
             automaticLayout: true,

--- a/src/renderer/src/components/editor/MarkdownPreview.tsx
+++ b/src/renderer/src/components/editor/MarkdownPreview.tsx
@@ -8,6 +8,7 @@ import type { Components } from 'react-markdown'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { useAppStore } from '@/store'
+import { computeEditorFontSize } from '@/lib/editor-font-zoom'
 import { getMarkdownPreviewLinkTarget } from './markdown-preview-links'
 import { useLocalImageSrc } from './useLocalImageSrc'
 import {
@@ -35,6 +36,8 @@ export default function MarkdownPreview({
   const [matchCount, setMatchCount] = useState(0)
   const [activeMatchIndex, setActiveMatchIndex] = useState(-1)
   const settings = useAppStore((s) => s.settings)
+  const editorFontZoomLevel = useAppStore((s) => s.editorFontZoomLevel)
+  const editorFontSize = computeEditorFontSize(14, editorFontZoomLevel)
   const isDark =
     settings?.theme === 'dark' ||
     (settings?.theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)
@@ -189,6 +192,7 @@ export default function MarkdownPreview({
     <div
       ref={rootRef}
       tabIndex={0}
+      style={{ fontSize: `${editorFontSize}px` }}
       className={`markdown-preview h-full min-h-0 overflow-auto scrollbar-editor ${isDark ? 'markdown-dark' : 'markdown-light'}`}
     >
       {isSearchOpen ? (

--- a/src/renderer/src/components/editor/MonacoEditor.tsx
+++ b/src/renderer/src/components/editor/MonacoEditor.tsx
@@ -11,6 +11,7 @@ import {
 import { useAppStore } from '@/store'
 import '@/lib/monaco-setup'
 import { setupContextualCopy } from './setup-contextual-copy'
+import { computeEditorFontSize } from '@/lib/editor-font-zoom'
 
 type MonacoEditorProps = {
   filePath: string
@@ -45,8 +46,13 @@ export default function MonacoEditor({
   }, [relativePath, language, onSave])
 
   const settings = useAppStore((s) => s.settings)
+  const editorFontZoomLevel = useAppStore((s) => s.editorFontZoomLevel)
   const setPendingEditorReveal = useAppStore((s) => s.setPendingEditorReveal)
   const setEditorCursorLine = useAppStore((s) => s.setEditorCursorLine)
+  const editorFontSize = computeEditorFontSize(
+    settings?.terminalFontSize ?? 13,
+    editorFontZoomLevel
+  )
 
   // Gutter context menu state
   const [gutterMenuOpen, setGutterMenuOpen] = useState(false)
@@ -137,10 +143,10 @@ export default function MonacoEditor({
       return
     }
     editorRef.current.updateOptions({
-      fontSize: settings.terminalFontSize,
+      fontSize: editorFontSize,
       fontFamily: settings.terminalFontFamily || 'monospace'
     })
-  }, [settings])
+  }, [editorFontSize, settings])
 
   useEffect(() => {
     const toastRef = copyToastTimeoutRef
@@ -201,7 +207,7 @@ export default function MonacoEditor({
           minimap: { enabled: false },
           scrollBeyondLastLine: false,
           wordWrap: 'on',
-          fontSize: settings?.terminalFontSize ?? 13,
+          fontSize: editorFontSize,
           fontFamily: settings?.terminalFontFamily || 'monospace',
           lineNumbers: 'on',
           renderLineHighlight: 'line',

--- a/src/renderer/src/components/editor/RichMarkdownEditor.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownEditor.tsx
@@ -4,6 +4,7 @@ import type { Editor } from '@tiptap/react'
 import { ImageIcon, List, ListOrdered, Quote } from 'lucide-react'
 import { toast } from 'sonner'
 import { cn } from '@/lib/utils'
+import { useAppStore } from '@/store'
 import { RichMarkdownToolbarButton } from './RichMarkdownToolbarButton'
 import { isMarkdownPreviewFindShortcut } from './markdown-preview-search'
 import { extractIpcErrorMessage, getImageCopyDestination } from './rich-markdown-image-utils'
@@ -40,6 +41,7 @@ export default function RichMarkdownEditor({
   onSave
 }: RichMarkdownEditorProps): React.JSX.Element {
   const rootRef = useRef<HTMLDivElement | null>(null)
+  const editorFontZoomLevel = useAppStore((s) => s.editorFontZoomLevel)
   const [slashMenu, setSlashMenu] = useState<SlashMenuState | null>(null)
   const [selectedCommandIndex, setSelectedCommandIndex] = useState(0)
   const isMac = navigator.userAgent.includes('Mac')
@@ -273,7 +275,11 @@ export default function RichMarkdownEditor({
   }, [content, editor])
 
   return (
-    <div ref={rootRef} className="rich-markdown-editor-shell">
+    <div
+      ref={rootRef}
+      className="rich-markdown-editor-shell"
+      style={{ '--editor-font-zoom-level': editorFontZoomLevel } as React.CSSProperties}
+    >
       <div className="rich-markdown-editor-toolbar">
         <RichMarkdownToolbarButton
           active={editor?.isActive('bold') ?? false}

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { resolveZoomTarget } from './useIpcEvents'
+
+function makeTarget(args: { hasXtermClass?: boolean; editorClosest?: boolean }): {
+  classList: { contains: (token: string) => boolean }
+  closest: (selector: string) => Element | null
+} {
+  const { hasXtermClass = false, editorClosest = false } = args
+  return {
+    classList: {
+      contains: (token: string) => hasXtermClass && token === 'xterm-helper-textarea'
+    },
+    closest: () => (editorClosest ? ({} as Element) : null)
+  }
+}
+
+describe('resolveZoomTarget', () => {
+  it('routes to terminal zoom when terminal tab is active', () => {
+    expect(
+      resolveZoomTarget({
+        activeView: 'terminal',
+        activeTabType: 'terminal',
+        activeElement: makeTarget({ hasXtermClass: true })
+      })
+    ).toBe('terminal')
+  })
+
+  it('routes to editor zoom for editor tabs', () => {
+    expect(
+      resolveZoomTarget({
+        activeView: 'terminal',
+        activeTabType: 'editor',
+        activeElement: makeTarget({})
+      })
+    ).toBe('editor')
+  })
+
+  it('routes to editor zoom when editor surface has focus during stale tab state', () => {
+    expect(
+      resolveZoomTarget({
+        activeView: 'terminal',
+        activeTabType: 'terminal',
+        activeElement: makeTarget({ editorClosest: true })
+      })
+    ).toBe('editor')
+  })
+
+  it('routes to ui zoom outside terminal view', () => {
+    expect(
+      resolveZoomTarget({
+        activeView: 'settings',
+        activeTabType: 'terminal',
+        activeElement: makeTarget({ hasXtermClass: true })
+      })
+    ).toBe('ui')
+  })
+})

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -2,10 +2,57 @@ import { useEffect } from 'react'
 import { useAppStore } from '../store'
 import { applyUIZoom } from '@/lib/ui-zoom'
 import { ensureWorktreeHasInitialTerminal } from '@/lib/worktree-activation'
+import { nextEditorFontZoomLevel } from '@/lib/editor-font-zoom'
 import type { UpdateStatus } from '../../../shared/types'
 import { createUpdateToastController } from './update-toast-controller'
 
 const ZOOM_STEP = 0.5
+
+export function resolveZoomTarget(args: {
+  activeView: 'terminal' | 'settings'
+  activeTabType: 'terminal' | 'editor'
+  activeElement: unknown
+}): 'terminal' | 'editor' | 'ui' {
+  const { activeView, activeTabType, activeElement } = args
+  const terminalInputFocused =
+    typeof activeElement === 'object' &&
+    activeElement !== null &&
+    'classList' in activeElement &&
+    typeof (activeElement as { classList?: { contains?: unknown } }).classList?.contains ===
+      'function' &&
+    (activeElement as { classList: { contains: (token: string) => boolean } }).classList.contains(
+      'xterm-helper-textarea'
+    )
+  const editorFocused =
+    typeof activeElement === 'object' &&
+    activeElement !== null &&
+    'closest' in activeElement &&
+    typeof (activeElement as { closest?: unknown }).closest === 'function' &&
+    Boolean(
+      (
+        activeElement as {
+          closest: (selector: string) => Element | null
+        }
+      ).closest(
+        '.monaco-editor, .diff-editor, .markdown-preview, .rich-markdown-editor, .rich-markdown-editor-shell'
+      )
+    )
+
+  if (activeView !== 'terminal') {
+    return 'ui'
+  }
+  if (activeTabType === 'editor' || editorFocused) {
+    return 'editor'
+  }
+  // Why: terminal tabs should keep using per-pane terminal font zoom even when
+  // focus leaves the xterm textarea (e.g. clicking tab bar/sidebar controls).
+  // Falling back to UI zoom here would resize the whole app for a terminal-only
+  // action and break parity with terminal zoom behavior.
+  if (activeTabType === 'terminal' || terminalInputFocused) {
+    return 'terminal'
+  }
+  return 'ui'
+}
 
 export function useIpcEvents(): void {
   useEffect(() => {
@@ -70,24 +117,31 @@ export function useIpcEvents(): void {
       })
     )
 
-    // Browser zoom fallback when no terminal is active
+    // Zoom handling for menu accelerators and keyboard fallback paths.
     unsubs.push(
       window.api.ui.onTerminalZoom((direction) => {
-        const { activeView } = useAppStore.getState()
-        if (activeView === 'terminal') {
+        const { activeView, activeTabType, editorFontZoomLevel, setEditorFontZoomLevel } =
+          useAppStore.getState()
+        const target = resolveZoomTarget({
+          activeView,
+          activeTabType,
+          activeElement: document.activeElement
+        })
+        if (target === 'terminal') {
           return
         }
-        const current = window.api.ui.getZoomLevel()
-        let next: number
-        if (direction === 'in') {
-          next = current + ZOOM_STEP
-        } else if (direction === 'out') {
-          next = current - ZOOM_STEP
-        } else {
-          next = 0
+        if (target === 'editor') {
+          const next = nextEditorFontZoomLevel(editorFontZoomLevel, direction)
+          setEditorFontZoomLevel(next)
+          void window.api.ui.set({ editorFontZoomLevel: next })
+          return
         }
+
+        const current = window.api.ui.getZoomLevel()
+        const next =
+          direction === 'in' ? current + ZOOM_STEP : direction === 'out' ? current - ZOOM_STEP : 0
         applyUIZoom(next)
-        window.api.ui.set({ uiZoomLevel: next })
+        void window.api.ui.set({ uiZoomLevel: next })
       })
     )
 

--- a/src/renderer/src/lib/editor-font-zoom.ts
+++ b/src/renderer/src/lib/editor-font-zoom.ts
@@ -1,0 +1,26 @@
+const EDITOR_FONT_ZOOM_MIN = -6
+const EDITOR_FONT_ZOOM_MAX = 18
+const EDITOR_FONT_ZOOM_STEP = 1
+
+export type EditorZoomDirection = 'in' | 'out' | 'reset'
+
+export function clampEditorFontZoomLevel(level: number): number {
+  return Math.max(EDITOR_FONT_ZOOM_MIN, Math.min(EDITOR_FONT_ZOOM_MAX, level))
+}
+
+export function nextEditorFontZoomLevel(current: number, direction: EditorZoomDirection): number {
+  if (direction === 'reset') {
+    return 0
+  }
+  if (direction === 'in') {
+    return clampEditorFontZoomLevel(current + EDITOR_FONT_ZOOM_STEP)
+  }
+  return clampEditorFontZoomLevel(current - EDITOR_FONT_ZOOM_STEP)
+}
+
+export function computeEditorFontSize(baseFontSize: number, zoomLevel: number): number {
+  // Why: Monaco and markdown surfaces become unreadable or visually broken at
+  // extreme values. Clamp after applying zoom so all editor-like surfaces stay
+  // within the same safe range regardless of their own default base size.
+  return Math.max(8, Math.min(32, baseFontSize + zoomLevel))
+}

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -49,6 +49,10 @@ export type UISlice = {
   revealWorktreeInSidebar: (worktreeId: string) => void
   clearPendingRevealWorktreeId: () => void
   persistedUIReady: boolean
+  uiZoomLevel: number
+  setUIZoomLevel: (level: number) => void
+  editorFontZoomLevel: number
+  setEditorFontZoomLevel: (level: number) => void
   hydratePersistedUI: (ui: PersistedUIState) => void
   updateStatus: UpdateStatus
   setUpdateStatus: (status: UpdateStatus) => void
@@ -106,6 +110,10 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set) => (
   revealWorktreeInSidebar: (worktreeId) => set({ pendingRevealWorktreeId: worktreeId }),
   clearPendingRevealWorktreeId: () => set({ pendingRevealWorktreeId: null }),
   persistedUIReady: false,
+  uiZoomLevel: 0,
+  setUIZoomLevel: (level) => set({ uiZoomLevel: level }),
+  editorFontZoomLevel: 0,
+  setEditorFontZoomLevel: (level) => set({ editorFontZoomLevel: level }),
 
   hydratePersistedUI: (ui) =>
     set((s) => {
@@ -125,6 +133,8 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set) => (
         // worktree list stable across restarts instead of silently widening it.
         showActiveOnly: ui.showActiveOnly,
         filterRepoIds: (ui.filterRepoIds ?? []).filter((repoId) => validRepoIds.has(repoId)),
+        uiZoomLevel: ui.uiZoomLevel ?? 0,
+        editorFontZoomLevel: ui.editorFontZoomLevel ?? 0,
         worktreeCardProperties: ui.worktreeCardProperties ?? [...DEFAULT_WORKTREE_CARD_PROPERTIES],
         dismissedUpdateVersion: ui.dismissedUpdateVersion ?? null,
         persistedUIReady: true

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -110,6 +110,7 @@ export function getDefaultUIState(): PersistedUIState {
     showActiveOnly: false,
     filterRepoIds: [],
     uiZoomLevel: 0,
+    editorFontZoomLevel: 0,
     worktreeCardProperties: [...DEFAULT_WORKTREE_CARD_PROPERTIES],
     dismissedUpdateVersion: null,
     lastUpdateCheckAt: null

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -246,6 +246,7 @@ export type PersistedUIState = {
   showActiveOnly: boolean
   filterRepoIds: string[]
   uiZoomLevel: number
+  editorFontZoomLevel: number
   worktreeCardProperties: WorktreeCardProperty[]
   dismissedUpdateVersion: string | null
   lastUpdateCheckAt: number | null


### PR DESCRIPTION
## Problem
Zoom shortcuts were inconsistent and confusing:
- In terminal tabs, zoom adjusted terminal font size.
- In file editors, the same shortcuts zoomed the whole window (sidebar, tabs, worktrees), not just file content.

Users expected zoom in editor context to affect only the file content surface.

## Solution
This change introduces context-aware zoom routing and a dedicated editor font zoom state:
- Added `resolveZoomTarget(...)` in renderer event handling to route zoom events by context:
  - terminal tab -> keep per-pane terminal font zoom behavior
  - editor tab or editor-focused surface -> apply editor font zoom only
  - non-terminal views -> keep UI/webFrame zoom fallback
- Added `editorFontZoomLevel` to persisted UI state and Zustand UI slice.
- Added shared helpers in `editor-font-zoom.ts` for clamping, stepping, and computing effective editor font sizes.
- Wired editor font zoom into all relevant file-content surfaces:
  - Monaco editor
  - Diff editors
  - Markdown preview
  - Rich markdown editor
- Added tests for zoom target resolution to prevent regressions.

## User-visible behavior
- In terminal tabs: Cmd/Ctrl +/-/0 still adjusts terminal font size.
- In file tabs (text/markdown/diff): Cmd/Ctrl +/-/0 now changes only file content font size.
- Sidebar/worktree list/tab chrome no longer scales when zooming file content.