### PR TITLE
feat: onboarding empty state UX

### DIFF
--- a/src/renderer/src/components/Landing.tsx
+++ b/src/renderer/src/components/Landing.tsx
@@ -1,176 +1,76 @@
-import { useEffect, useMemo, useState } from 'react'
-import { AlertTriangle, ExternalLink, FolderPlus, GitBranchPlus } from 'lucide-react'
+import { useCallback, useMemo, useState } from 'react'
 import { useAppStore } from '../store'
-import logo from '../../../../resources/logo.svg'
+import NoReposLanding from './landing/NoReposLanding'
+import RepoOnboarding, { isOnboardingDismissed } from './landing/RepoOnboarding'
 
-type ShortcutItem = {
-  id: string
-  keys: string[]
-  action: string
-}
-
-type PreflightIssue = {
-  id: string
-  title: string
-  description: string
-  fixLabel: string
-  fixUrl: string
-}
-
-function KeyCap({ label }: { label: string }): React.JSX.Element {
-  return (
-    <span className="inline-flex min-w-6 items-center justify-center rounded border border-border/80 bg-secondary/70 px-1.5 py-0.5 text-[10px] font-semibold text-muted-foreground">
-      {label}
-    </span>
-  )
-}
-
-function PreflightBanner({ issues }: { issues: PreflightIssue[] }): React.JSX.Element {
-  return (
-    <div className="w-full rounded-lg border border-yellow-500/30 bg-yellow-500/5 p-4 space-y-3">
-      <div className="flex items-center gap-2 text-yellow-500">
-        <AlertTriangle className="size-4 shrink-0" />
-        <span className="text-sm font-medium">Missing dependencies</span>
-      </div>
-      <div className="space-y-2.5">
-        {issues.map((issue) => (
-          <div key={issue.id} className="flex items-start justify-between gap-3">
-            <div className="min-w-0">
-              <p className="text-sm font-medium text-foreground">{issue.title}</p>
-              <p className="text-xs text-muted-foreground mt-0.5">{issue.description}</p>
-            </div>
-            <button
-              className="inline-flex items-center gap-1 shrink-0 text-xs font-medium text-blue-400 hover:text-blue-300 transition-colors cursor-pointer"
-              onClick={() => window.api.shell.openUrl(issue.fixUrl)}
-            >
-              {issue.fixLabel}
-              <ExternalLink className="size-3" />
-            </button>
-          </div>
-        ))}
-      </div>
-    </div>
-  )
-}
-
+/**
+ * Landing is the orchestration shell for Orca's empty/onboarding states.
+ * It derives one of four states from the store and delegates rendering:
+ *
+ *   1. no-repos                          → NoReposLanding
+ *   2. repo-selected-main-checkout-only  → RepoOnboarding (create-focused)
+ *   3. repo-selected-with-linked         → RepoOnboarding (open-focused)
+ *   4. repo-selected-with-active         → should not reach Landing (App.tsx gates this)
+ *
+ * Why this is a separate shell: the design doc specifies splitting Landing into
+ * sub-components to avoid a monolith while keeping Landing as the routing layer.
+ */
 export default function Landing(): React.JSX.Element {
   const repos = useAppStore((s) => s.repos)
-  const addRepo = useAppStore((s) => s.addRepo)
-  const openModal = useAppStore((s) => s.openModal)
+  const activeRepoId = useAppStore((s) => s.activeRepoId)
+  const worktreesByRepo = useAppStore((s) => s.worktreesByRepo)
 
-  const canCreateWorktree = repos.length > 0
+  // Force re-render when a repo is dismissed so we show the correct fallback
+  const [dismissEpoch, setDismissEpoch] = useState(0)
 
-  const [preflightIssues, setPreflightIssues] = useState<PreflightIssue[]>([])
-
-  useEffect(() => {
-    let cancelled = false
-
-    void window.api.preflight.check().then((status) => {
-      if (cancelled) {
-        return
-      }
-
-      const issues: PreflightIssue[] = []
-
-      if (!status.git.installed) {
-        issues.push({
-          id: 'git',
-          title: 'Git is not installed',
-          description: 'Orca requires Git to manage repositories and worktrees.',
-          fixLabel: 'Install Git',
-          fixUrl: 'https://git-scm.com/downloads'
-        })
-      }
-
-      if (!status.gh.installed) {
-        issues.push({
-          id: 'gh',
-          title: 'GitHub CLI is not installed',
-          description: 'Orca uses the GitHub CLI (gh) to show pull requests, issues, and checks.',
-          fixLabel: 'Install GitHub CLI',
-          fixUrl: 'https://cli.github.com'
-        })
-      } else if (!status.gh.authenticated) {
-        issues.push({
-          id: 'gh-auth',
-          title: 'GitHub CLI is not authenticated',
-          description: 'Run "gh auth login" in a terminal to connect your GitHub account.',
-          fixLabel: 'Learn more',
-          fixUrl: 'https://cli.github.com/manual/gh_auth_login'
-        })
-      }
-
-      setPreflightIssues(issues)
-    })
-
-    return () => {
-      cancelled = true
-    }
-  }, [])
-
-  const shortcuts = useMemo<ShortcutItem[]>(
-    () => [
-      { id: 'create', keys: ['⌘', 'N'], action: 'Create worktree' },
-      { id: 'up', keys: ['⌘', '⇧', '↑'], action: 'Move up worktree' },
-      { id: 'down', keys: ['⌘', '⇧', '↓'], action: 'Move down worktree' }
-    ],
-    []
+  const activeRepo = useMemo(
+    () => repos.find((r) => r.id === activeRepoId) ?? null,
+    [repos, activeRepoId]
   )
 
+  // Why: onboarding surfaces only linked worktrees (not the main checkout) because
+  // the main checkout is not what users mean by "existing worktrees" and treating it
+  // as openable from onboarding muddies the decision the UI is trying to help with.
+  // This reuses the same git-derived worktree list Orca trusts everywhere else —
+  // no second detection path needed.
+  const linkedWorktrees = useMemo(() => {
+    if (!activeRepoId) {
+      return []
+    }
+    return (worktreesByRepo[activeRepoId] ?? []).filter((w) => !w.isMainWorktree)
+  }, [activeRepoId, worktreesByRepo])
+
+  const handleDismiss = useCallback(() => {
+    setDismissEpoch((e) => e + 1)
+  }, [])
+
+  // State 1: no repos at all
+  if (repos.length === 0) {
+    return <NoReposLanding />
+  }
+
+  // States 2/3: repo selected, show onboarding (unless dismissed)
+  // Why: onboarding is shown only when the *selected* repo has no active linked
+  // worktree, keeping the repo-centric mental model. The dismissal check uses
+  // dismissEpoch to react to in-session dismissals without persisting to disk.
+  if (activeRepo && !isOnboardingDismissed(activeRepo.id)) {
+    return (
+      <RepoOnboarding
+        key={`${activeRepo.id}-${dismissEpoch}`}
+        repo={activeRepo}
+        linkedWorktrees={linkedWorktrees}
+        onDismiss={handleDismiss}
+      />
+    )
+  }
+
+  // Fallback: repos exist but none selected, or onboarding was dismissed.
+  // Show a minimal prompt so the user isn't staring at a blank screen.
   return (
     <div className="absolute inset-0 flex items-center justify-center bg-background">
-      <div className="w-full max-w-lg px-6">
-        <div className="flex flex-col items-center gap-4 py-8">
-          <div
-            className="flex items-center justify-center size-20 rounded-2xl border border-border/80 shadow-lg shadow-black/40"
-            style={{ backgroundColor: '#12181e' }}
-          >
-            <img src={logo} alt="Orca logo" className="size-12" />
-          </div>
-          <h1 className="text-4xl font-bold text-foreground tracking-tight">ORCA</h1>
-
-          {preflightIssues.length > 0 && <PreflightBanner issues={preflightIssues} />}
-
-          <p className="text-sm text-muted-foreground text-center">
-            {canCreateWorktree
-              ? 'Select a worktree from the sidebar to begin.'
-              : 'Add a repository to get started.'}
-          </p>
-
-          <div className="flex items-center justify-center gap-2.5 flex-wrap">
-            <button
-              className="inline-flex items-center gap-1.5 bg-secondary/70 border border-border/80 text-foreground font-medium text-sm px-4 py-2 rounded-md cursor-pointer hover:bg-accent transition-colors"
-              onClick={addRepo}
-            >
-              <FolderPlus className="size-3.5" />
-              Add Repo
-            </button>
-
-            <button
-              className="inline-flex items-center gap-1.5 bg-secondary/70 border border-border/80 text-foreground font-medium text-sm px-4 py-2 rounded-md transition-colors disabled:opacity-40 disabled:cursor-not-allowed enabled:cursor-pointer enabled:hover:bg-accent"
-              disabled={!canCreateWorktree}
-              title={!canCreateWorktree ? 'Add a repo first' : undefined}
-              onClick={() => openModal('create-worktree')}
-            >
-              <GitBranchPlus className="size-3.5" />
-              Create Worktree
-            </button>
-          </div>
-
-          <div className="mt-6 w-full max-w-xs space-y-2">
-            {shortcuts.map((shortcut) => (
-              <div key={shortcut.id} className="grid grid-cols-[1fr_auto] items-center gap-3">
-                <span className="text-sm text-muted-foreground">{shortcut.action}</span>
-                <div className="flex items-center gap-1">
-                  {shortcut.keys.map((key) => (
-                    <KeyCap key={`${shortcut.id}-${key}`} label={key} />
-                  ))}
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      </div>
+      <p className="text-sm text-muted-foreground">
+        Select a worktree from the sidebar or create a new one.
+      </p>
     </div>
   )
 }

--- a/src/renderer/src/components/landing/KeyboardShortcuts.tsx
+++ b/src/renderer/src/components/landing/KeyboardShortcuts.tsx
@@ -1,0 +1,41 @@
+import { useMemo } from 'react'
+
+type ShortcutItem = {
+  id: string
+  keys: string[]
+  action: string
+}
+
+function KeyCap({ label }: { label: string }): React.JSX.Element {
+  return (
+    <span className="inline-flex min-w-6 items-center justify-center rounded border border-border/80 bg-secondary/70 px-1.5 py-0.5 text-[10px] font-semibold text-muted-foreground">
+      {label}
+    </span>
+  )
+}
+
+export default function KeyboardShortcuts(): React.JSX.Element {
+  const shortcuts = useMemo<ShortcutItem[]>(
+    () => [
+      { id: 'create', keys: ['⌘', 'N'], action: 'Create worktree' },
+      { id: 'up', keys: ['⌘', '⇧', '↑'], action: 'Move up worktree' },
+      { id: 'down', keys: ['⌘', '⇧', '↓'], action: 'Move down worktree' }
+    ],
+    []
+  )
+
+  return (
+    <div className="mt-6 w-full max-w-xs space-y-2">
+      {shortcuts.map((shortcut) => (
+        <div key={shortcut.id} className="grid grid-cols-[1fr_auto] items-center gap-3">
+          <span className="text-sm text-muted-foreground">{shortcut.action}</span>
+          <div className="flex items-center gap-1">
+            {shortcut.keys.map((key) => (
+              <KeyCap key={`${shortcut.id}-${key}`} label={key} />
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/renderer/src/components/landing/NoReposLanding.tsx
+++ b/src/renderer/src/components/landing/NoReposLanding.tsx
@@ -1,0 +1,58 @@
+import { FolderPlus, GitBranchPlus } from 'lucide-react'
+import { useAppStore } from '../../store'
+import logo from '../../../../../resources/logo.svg'
+import PreflightBanner, { usePreflightIssues } from './PreflightBanner'
+import KeyboardShortcuts from './KeyboardShortcuts'
+
+export default function NoReposLanding(): React.JSX.Element {
+  const repos = useAppStore((s) => s.repos)
+  const addRepo = useAppStore((s) => s.addRepo)
+  const openModal = useAppStore((s) => s.openModal)
+  const preflightIssues = usePreflightIssues()
+
+  const canCreateWorktree = repos.length > 0
+
+  return (
+    <div className="absolute inset-0 flex items-center justify-center bg-background">
+      <div className="w-full max-w-lg px-6">
+        <div className="flex flex-col items-center gap-4 py-8">
+          <div
+            className="flex items-center justify-center size-20 rounded-2xl border border-border/80 shadow-lg shadow-black/40"
+            style={{ backgroundColor: '#12181e' }}
+          >
+            <img src={logo} alt="Orca logo" className="size-12" />
+          </div>
+          <h1 className="text-4xl font-bold text-foreground tracking-tight">ORCA</h1>
+
+          <PreflightBanner issues={preflightIssues} />
+
+          <p className="text-sm text-muted-foreground text-center">
+            Add a repository to get started.
+          </p>
+
+          <div className="flex items-center justify-center gap-2.5 flex-wrap">
+            <button
+              className="inline-flex items-center gap-1.5 bg-secondary/70 border border-border/80 text-foreground font-medium text-sm px-4 py-2 rounded-md cursor-pointer hover:bg-accent transition-colors"
+              onClick={addRepo}
+            >
+              <FolderPlus className="size-3.5" />
+              Add Repo
+            </button>
+
+            <button
+              className="inline-flex items-center gap-1.5 bg-secondary/70 border border-border/80 text-foreground font-medium text-sm px-4 py-2 rounded-md transition-colors disabled:opacity-40 disabled:cursor-not-allowed enabled:cursor-pointer enabled:hover:bg-accent"
+              disabled={!canCreateWorktree}
+              title={!canCreateWorktree ? 'Add a repo first' : undefined}
+              onClick={() => openModal('create-worktree')}
+            >
+              <GitBranchPlus className="size-3.5" />
+              Create Worktree
+            </button>
+          </div>
+
+          <KeyboardShortcuts />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/landing/PreflightBanner.tsx
+++ b/src/renderer/src/components/landing/PreflightBanner.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useState } from 'react'
+import { AlertTriangle, ExternalLink } from 'lucide-react'
+
+type PreflightIssue = {
+  id: string
+  title: string
+  description: string
+  fixLabel: string
+  fixUrl: string
+}
+
+export function usePreflightIssues(): PreflightIssue[] {
+  const [issues, setIssues] = useState<PreflightIssue[]>([])
+
+  useEffect(() => {
+    let cancelled = false
+
+    void window.api.preflight.check().then((status) => {
+      if (cancelled) {
+        return
+      }
+
+      const found: PreflightIssue[] = []
+
+      if (!status.git.installed) {
+        found.push({
+          id: 'git',
+          title: 'Git is not installed',
+          description: 'Orca requires Git to manage repositories and worktrees.',
+          fixLabel: 'Install Git',
+          fixUrl: 'https://git-scm.com/downloads'
+        })
+      }
+
+      if (!status.gh.installed) {
+        found.push({
+          id: 'gh',
+          title: 'GitHub CLI is not installed',
+          description: 'Orca uses the GitHub CLI (gh) to show pull requests, issues, and checks.',
+          fixLabel: 'Install GitHub CLI',
+          fixUrl: 'https://cli.github.com'
+        })
+      } else if (!status.gh.authenticated) {
+        found.push({
+          id: 'gh-auth',
+          title: 'GitHub CLI is not authenticated',
+          description: 'Run "gh auth login" in a terminal to connect your GitHub account.',
+          fixLabel: 'Learn more',
+          fixUrl: 'https://cli.github.com/manual/gh_auth_login'
+        })
+      }
+
+      setIssues(found)
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return issues
+}
+
+export default function PreflightBanner({
+  issues
+}: {
+  issues: PreflightIssue[]
+}): React.JSX.Element | null {
+  if (issues.length === 0) {
+    return null
+  }
+
+  return (
+    <div className="w-full rounded-lg border border-yellow-500/30 bg-yellow-500/5 p-4 space-y-3">
+      <div className="flex items-center gap-2 text-yellow-500">
+        <AlertTriangle className="size-4 shrink-0" />
+        <span className="text-sm font-medium">Missing dependencies</span>
+      </div>
+      <div className="space-y-2.5">
+        {issues.map((issue) => (
+          <div key={issue.id} className="flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <p className="text-sm font-medium text-foreground">{issue.title}</p>
+              <p className="text-xs text-muted-foreground mt-0.5">{issue.description}</p>
+            </div>
+            <button
+              className="inline-flex items-center gap-1 shrink-0 text-xs font-medium text-blue-400 hover:text-blue-300 transition-colors cursor-pointer"
+              onClick={() => window.api.shell.openUrl(issue.fixUrl)}
+            >
+              {issue.fixLabel}
+              <ExternalLink className="size-3" />
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/landing/RepoOnboarding.tsx
+++ b/src/renderer/src/components/landing/RepoOnboarding.tsx
@@ -1,0 +1,207 @@
+import { useCallback, useMemo, useState } from 'react'
+import { GitBranchPlus, Settings, SkipForward, ChevronDown } from 'lucide-react'
+import { useAppStore } from '../../store'
+import { ensureWorktreeHasInitialTerminal } from '../../lib/worktree-activation'
+import type { Repo, Worktree } from '../../../../shared/types'
+import PreflightBanner, { usePreflightIssues } from './PreflightBanner'
+import KeyboardShortcuts from './KeyboardShortcuts'
+
+// Why: session-scoped (not persisted to disk) so users see onboarding again after
+// restarting the app. Avoids nagging on every repo switch while still surfacing
+// guidance when the app freshly launches with no worktrees.
+const dismissedRepoIds = new Set<string>()
+
+const MAX_VISIBLE_WORKTREES = 5
+
+type RepoOnboardingProps = {
+  repo: Repo
+  linkedWorktrees: Worktree[]
+  onDismiss: () => void
+}
+
+function LinkedWorktreeItem({ worktree }: { worktree: Worktree }): React.JSX.Element {
+  const setActiveWorktree = useAppStore((s) => s.setActiveWorktree)
+  const revealWorktreeInSidebar = useAppStore((s) => s.revealWorktreeInSidebar)
+
+  const handleOpen = useCallback(() => {
+    setActiveWorktree(worktree.id)
+    // Why: opening an existing linked worktree from onboarding should create an
+    // initial terminal tab using the same activation path as post-create. This is
+    // a visibility/activation improvement, not a filesystem mutation — no git
+    // worktree add, no disk changes, no setup runner.
+    ensureWorktreeHasInitialTerminal(useAppStore.getState(), worktree.id)
+    revealWorktreeInSidebar(worktree.id)
+  }, [worktree.id, setActiveWorktree, revealWorktreeInSidebar])
+
+  // Show branch name without refs/heads/ prefix for readability
+  const branchLabel = worktree.branch.replace(/^refs\/heads\//, '')
+
+  return (
+    <button
+      className="group flex items-center justify-between gap-3 w-full rounded-md border border-border/60 bg-secondary/30 px-3 py-2 text-left transition-colors hover:bg-accent cursor-pointer"
+      onClick={handleOpen}
+    >
+      <div className="min-w-0">
+        <p className="text-sm font-medium text-foreground truncate">{worktree.displayName}</p>
+        {branchLabel !== worktree.displayName && (
+          <p className="text-xs text-muted-foreground truncate mt-0.5">{branchLabel}</p>
+        )}
+      </div>
+      <span className="shrink-0 text-xs font-medium text-muted-foreground group-hover:text-foreground transition-colors">
+        Open
+      </span>
+    </button>
+  )
+}
+
+export default function RepoOnboarding({
+  repo,
+  linkedWorktrees,
+  onDismiss
+}: RepoOnboardingProps): React.JSX.Element {
+  const openModal = useAppStore((s) => s.openModal)
+  const setActiveView = useAppStore((s) => s.setActiveView)
+  const openSettingsTarget = useAppStore((s) => s.openSettingsTarget)
+
+  const preflightIssues = usePreflightIssues()
+  const [showAll, setShowAll] = useState(false)
+
+  const hasLinkedWorktrees = linkedWorktrees.length > 0
+  const hasOverflow = linkedWorktrees.length > MAX_VISIBLE_WORKTREES
+
+  // Why: sort by recent activity (lastActivityAt) with alphabetical fallback for
+  // worktrees not yet opened in Orca. This matches the existing buildWorktreeComparator
+  // behavior and avoids promising a sort criterion (like "last checked out") that has
+  // no data source in git worktree list.
+  const sortedWorktrees = useMemo(() => {
+    return [...linkedWorktrees].sort((a, b) => {
+      if (a.lastActivityAt !== b.lastActivityAt) {
+        return b.lastActivityAt - a.lastActivityAt
+      }
+      return a.displayName.localeCompare(b.displayName)
+    })
+  }, [linkedWorktrees])
+
+  const visibleWorktrees = showAll
+    ? sortedWorktrees
+    : sortedWorktrees.slice(0, MAX_VISIBLE_WORKTREES)
+
+  const handleCreateWorktree = useCallback(() => {
+    openModal('create-worktree', { preselectedRepoId: repo.id })
+  }, [openModal, repo.id])
+
+  const handleConfigureRepo = useCallback(() => {
+    openSettingsTarget({ pane: 'repo', repoId: repo.id })
+    setActiveView('settings')
+  }, [openSettingsTarget, setActiveView, repo.id])
+
+  const handleDismiss = useCallback(() => {
+    dismissedRepoIds.add(repo.id)
+    onDismiss()
+  }, [repo.id, onDismiss])
+
+  return (
+    <div className="absolute inset-0 overflow-y-auto bg-background">
+      <div className="flex min-h-full items-center justify-center">
+        <div className="w-full max-w-lg px-6">
+          <div className="flex flex-col items-center gap-5 py-8">
+            <PreflightBanner issues={preflightIssues} />
+
+            {/* Headline */}
+            <div className="text-center space-y-2">
+              <h1 className="text-2xl font-bold text-foreground tracking-tight">
+                {hasLinkedWorktrees ? 'Open or create a worktree' : 'Set up your first worktree'}
+              </h1>
+              <p className="text-sm text-muted-foreground">
+                {hasLinkedWorktrees ? (
+                  <>
+                    <span className="font-medium text-foreground">{repo.displayName}</span> has{' '}
+                    {linkedWorktrees.length} worktree{linkedWorktrees.length !== 1 && 's'}. Open one
+                    to pick up where you left off, or create a new one.
+                  </>
+                ) : (
+                  <>
+                    Orca uses git worktrees as isolated task environments.
+                    <br />
+                    Create one for{' '}
+                    <span className="font-medium text-foreground">{repo.displayName}</span> to get
+                    started.
+                  </>
+                )}
+              </p>
+            </div>
+
+            {/* Existing linked worktrees */}
+            {hasLinkedWorktrees && (
+              <div className="w-full space-y-2">
+                <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                  Existing worktrees
+                </p>
+                <div className="space-y-1.5">
+                  {visibleWorktrees.map((wt) => (
+                    <LinkedWorktreeItem key={wt.id} worktree={wt} />
+                  ))}
+                </div>
+                {hasOverflow && (
+                  <button
+                    className="flex items-center gap-1 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors cursor-pointer mx-auto"
+                    onClick={() => setShowAll((v) => !v)}
+                  >
+                    <ChevronDown
+                      className={`size-3 transition-transform ${showAll ? 'rotate-180' : ''}`}
+                    />
+                    {showAll ? 'Show less' : `View all ${linkedWorktrees.length} worktrees`}
+                  </button>
+                )}
+              </div>
+            )}
+
+            {/* Primary CTA */}
+            <div className="flex items-center justify-center gap-2.5 flex-wrap w-full">
+              <button
+                className="inline-flex items-center gap-1.5 bg-primary text-primary-foreground font-medium text-sm px-4 py-2 rounded-md cursor-pointer hover:bg-primary/90 transition-colors"
+                onClick={handleCreateWorktree}
+              >
+                <GitBranchPlus className="size-3.5" />
+                {hasLinkedWorktrees ? 'Create new worktree' : 'Create first worktree'}
+              </button>
+            </div>
+
+            {/* Secondary CTAs */}
+            <div className="flex items-center justify-center gap-3 flex-wrap">
+              <button
+                className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+                onClick={handleConfigureRepo}
+              >
+                <Settings className="size-3.5" />
+                Configure repo
+              </button>
+
+              <span className="text-border">|</span>
+
+              <button
+                className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+                onClick={handleDismiss}
+              >
+                <SkipForward className="size-3.5" />
+                Skip for now
+              </button>
+            </div>
+
+            <KeyboardShortcuts />
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/** Check whether onboarding has been dismissed for the given repo this session. */
+export function isOnboardingDismissed(repoId: string): boolean {
+  return dismissedRepoIds.has(repoId)
+}
+
+/** Clear dismissal for a repo (e.g., if all its worktrees are removed). */
+export function clearOnboardingDismissal(repoId: string): void {
+  dismissedRepoIds.delete(repoId)
+}

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -52,6 +52,21 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
         }
         return { repos: [...s.repos, repo] }
       })
+
+      // Why: auto-select the newly added repo only when no repo is currently selected
+      // so first-time users land on the repo onboarding panel immediately, while users
+      // staging multiple repos in sequence are not forced through a dismiss cycle.
+      // Defensive: treat a stale activeRepoId (pointing to a removed repo) as null.
+      const state = get()
+      const currentActiveId = state.activeRepoId
+      const activeRepoStillExists =
+        currentActiveId !== null && state.repos.some((r) => r.id === currentActiveId)
+      if (!activeRepoStillExists) {
+        set({ activeRepoId: repo.id })
+        // Fetch worktrees so the onboarding panel can show linked worktrees immediately
+        void get().fetchWorktrees(repo.id)
+      }
+
       if (alreadyAdded) {
         toast.info('Repo already added', { description: repo.displayName })
       } else {


### PR DESCRIPTION
## Summary
- Split the generic Landing screen into repo-contextual onboarding states: no-repos, repo with main checkout only, and repo with existing linked worktrees
- Auto-select newly added repo when no repo is currently selected so first-time users land on the onboarding panel immediately
- Surface existing linked worktrees with Open action (activates worktree + creates initial terminal, no git operations)
- Add session-scoped "Skip for now" dismissal, Configure Repo shortcut to settings, and Create Worktree with pre-selected repo
- Extract PreflightBanner and KeyboardShortcuts into shared components

## Test plan
- [ ] Fresh launch (no repos): see logo + "Add a repository to get started" + preflight checks + shortcuts
- [ ] Add a repo with no linked worktrees: see "Set up your first worktree" onboarding panel
- [ ] Add a repo with existing linked worktrees: see worktree list with Open buttons
- [ ] Click "Open" on a linked worktree: activates it with a terminal tab
- [ ] Click "Create first/new worktree": opens create dialog with repo pre-selected
- [ ] Click "Configure repo": navigates to repo settings pane
- [ ] Click "Skip for now": dismisses onboarding, shows fallback text
- [ ] Add a second repo while first is selected: no context switch
- [ ] "View all" / "Show less" toggle works and scrolls when list is long
- [ ] Restart app after skip: onboarding reappears (session-scoped dismissal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)