### PR TITLE
feat: add Star on GitHub button to landing page

### DIFF
--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -12,6 +12,47 @@ import {
   deriveCheckStatus
 } from './mappers'
 
+const ORCA_REPO = 'stablyai/orca'
+
+/**
+ * Check if the authenticated user has starred the Orca repo.
+ * Returns true if starred, false if not, null if unable to determine (gh unavailable).
+ */
+export async function checkOrcaStarred(): Promise<boolean | null> {
+  await acquire()
+  try {
+    await execFileAsync('gh', ['api', `user/starred/${ORCA_REPO}`], { encoding: 'utf-8' })
+    return true
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    // 404 means the user hasn't starred — the only expected "no" answer
+    if (message.includes('HTTP 404')) {
+      return false
+    }
+    // Anything else (gh not installed, not authenticated, network issue)
+    return null
+  } finally {
+    release()
+  }
+}
+
+/**
+ * Star the Orca repo for the authenticated user.
+ */
+export async function starOrca(): Promise<boolean> {
+  await acquire()
+  try {
+    await execFileAsync('gh', ['api', '-X', 'PUT', `user/starred/${ORCA_REPO}`], {
+      encoding: 'utf-8'
+    })
+    return true
+  } catch {
+    return false
+  } finally {
+    release()
+  }
+}
+
 /**
  * Get PR info for a given branch using gh CLI.
  * Returns null if gh is not installed, or no PR exists for the branch.

--- a/src/main/ipc/github.ts
+++ b/src/main/ipc/github.ts
@@ -7,7 +7,9 @@ import {
   listIssues,
   getPRChecks,
   updatePRTitle,
-  mergePR
+  mergePR,
+  checkOrcaStarred,
+  starOrca
 } from '../github/client'
 
 function assertRegisteredRepoPath(repoPath: string, store: Store): string {
@@ -71,4 +73,8 @@ export function registerGitHubHandlers(store: Store): void {
       return mergePR(repoPath, args.prNumber, args.method)
     }
   )
+
+  // Star operations target the Orca repo itself — no repoPath validation needed
+  ipcMain.handle('gh:checkOrcaStarred', () => checkOrcaStarred())
+  ipcMain.handle('gh:starOrca', () => starOrca())
 }

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -81,6 +81,8 @@ type GhApi = {
     prNumber: number
     method?: 'merge' | 'squash' | 'rebase'
   }) => Promise<{ ok: true } | { ok: false; error: string }>
+  checkOrcaStarred: () => Promise<boolean | null>
+  starOrca: () => Promise<boolean>
 }
 
 type SettingsApi = {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -220,7 +220,10 @@ const api = {
       prNumber: number
       method?: 'merge' | 'squash' | 'rebase'
     }): Promise<{ ok: true } | { ok: false; error: string }> =>
-      ipcRenderer.invoke('gh:mergePR', args)
+      ipcRenderer.invoke('gh:mergePR', args),
+
+    checkOrcaStarred: (): Promise<boolean | null> => ipcRenderer.invoke('gh:checkOrcaStarred'),
+    starOrca: (): Promise<boolean> => ipcRenderer.invoke('gh:starOrca')
   },
 
   settings: {

--- a/src/renderer/src/components/Landing.tsx
+++ b/src/renderer/src/components/Landing.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
-import { AlertTriangle, ExternalLink, FolderPlus, GitBranchPlus } from 'lucide-react'
+import { AlertTriangle, ExternalLink, FolderPlus, GitBranchPlus, Star } from 'lucide-react'
+import { cn } from '../lib/utils'
 import { useAppStore } from '../store'
 import logo from '../../../../resources/logo.svg'
 
@@ -22,6 +23,66 @@ function KeyCap({ label }: { label: string }): React.JSX.Element {
     <span className="inline-flex min-w-6 items-center justify-center rounded border border-border/80 bg-secondary/70 px-1.5 py-0.5 text-[10px] font-semibold text-muted-foreground">
       {label}
     </span>
+  )
+}
+
+type StarState = 'loading' | 'starred' | 'not-starred' | 'hidden'
+
+function GitHubStarButton(): React.JSX.Element | null {
+  const [state, setState] = useState<StarState>('loading')
+
+  useEffect(() => {
+    let cancelled = false
+    void window.api.gh.checkOrcaStarred().then((result) => {
+      if (cancelled) {
+        return
+      }
+      if (result === null) {
+        setState('hidden')
+      } else {
+        setState(result ? 'starred' : 'not-starred')
+      }
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const handleClick = async (): Promise<void> => {
+    if (state !== 'not-starred') {
+      return
+    }
+    setState('starred') // optimistic
+    const ok = await window.api.gh.starOrca()
+    if (!ok) {
+      setState('not-starred')
+    }
+  }
+
+  if (state === 'hidden') {
+    return null
+  }
+
+  return (
+    <button
+      className={cn(
+        'inline-flex items-center gap-2 rounded-full border px-4 py-1.5 text-[13px] font-medium transition-all duration-300',
+        state === 'loading' && 'pointer-events-none opacity-0',
+        state === 'not-starred' &&
+          'border-amber-400/30 text-amber-300/90 hover:border-amber-400/50 hover:bg-amber-400/[0.08] cursor-pointer',
+        state === 'starred' && 'border-amber-400/25 bg-amber-400/[0.06] text-amber-400/60'
+      )}
+      onClick={handleClick}
+      disabled={state === 'starred' || state === 'loading'}
+    >
+      <Star
+        className={cn(
+          'size-3.5 transition-all duration-300',
+          state === 'starred' ? 'fill-amber-400/60 text-amber-400/60' : 'text-amber-400/80'
+        )}
+      />
+      {state === 'starred' ? 'Starred on GitHub' : 'Star on GitHub'}
+    </button>
   )
 }
 
@@ -128,6 +189,8 @@ export default function Landing(): React.JSX.Element {
             <img src={logo} alt="Orca logo" className="size-12" />
           </div>
           <h1 className="text-4xl font-bold text-foreground tracking-tight">ORCA</h1>
+
+          <GitHubStarButton />
 
           {preflightIssues.length > 0 && <PreflightBanner issues={preflightIssues} />}
 


### PR DESCRIPTION
## Summary
- Adds a "Star on GitHub" button to the landing page, right below the ORCA heading
- Checks star status via `gh api` on mount; gracefully hides when `gh` CLI is unavailable or unauthenticated
- Optimistic UI update on click for a snappy feel, with silent revert on failure
- Warm amber pill-shaped button with smooth fade-in transition from loading state

## Test plan
- [ ] Verify button shows "Star on GitHub" with outline star when repo is not starred
- [ ] Click the button — should immediately show "Starred on GitHub" with filled star
- [ ] Reopen landing page — button should show "Starred on GitHub" (persisted via GitHub)
- [ ] With `gh` not installed or not authenticated — button should not appear
- [ ] No layout shift during the loading → resolved transition

🤖 Generated with [Claude Code](https://claude.com/claude-code)