### PR TITLE
perf: eliminate useEffect anti-patterns causing extra re-renders

### DIFF
--- a/src/renderer/src/components/QuickOpen.tsx
+++ b/src/renderer/src/components/QuickOpen.tsx
@@ -138,11 +138,6 @@ export default function QuickOpen(): React.JSX.Element | null {
     return results.slice(0, 50)
   }, [files, query])
 
-  // Reset selection when results change
-  useEffect(() => {
-    setSelectedIndex(0)
-  }, [filtered])
-
   // Scroll selected item into view
   useEffect(() => {
     if (!listRef.current) {
@@ -223,7 +218,10 @@ export default function QuickOpen(): React.JSX.Element | null {
             className="flex-1 bg-transparent text-sm py-2.5 outline-none text-foreground placeholder:text-muted-foreground"
             placeholder="Go to file..."
             value={query}
-            onChange={(e) => setQuery(e.target.value)}
+            onChange={(e) => {
+              setQuery(e.target.value)
+              setSelectedIndex(0)
+            }}
             onKeyDown={handleKeyDown}
             spellCheck={false}
           />

--- a/src/renderer/src/components/editor/EditorPanel.tsx
+++ b/src/renderer/src/components/editor/EditorPanel.tsx
@@ -53,14 +53,16 @@ export default function EditorPanel(): React.JSX.Element | null {
     null
   )
   const [sideBySide, setSideBySide] = useState(settings?.diffDefaultView === 'side-by-side')
+  const [prevDiffView, setPrevDiffView] = useState(settings?.diffDefaultView)
 
   // Why: When the user changes their global diff-view preference in Settings,
-  // sync the local toggle to match, even if they manually toggled it this session.
-  useEffect(() => {
+  // sync the local toggle to match during render (avoids flash of stale diff mode).
+  if (settings?.diffDefaultView !== prevDiffView) {
+    setPrevDiffView(settings?.diffDefaultView)
     if (settings?.diffDefaultView !== undefined) {
       setSideBySide(settings.diffDefaultView === 'side-by-side')
     }
-  }, [settings?.diffDefaultView])
+  }
 
   const openFilesRef = React.useRef(openFiles)
   openFilesRef.current = openFiles

--- a/src/renderer/src/components/editor/useRichMarkdownSearch.ts
+++ b/src/renderer/src/components/editor/useRichMarkdownSearch.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { RefObject } from 'react'
 import type { Editor } from '@tiptap/react'
 import { TextSelection } from '@tiptap/pm/state'
@@ -21,9 +21,32 @@ export function useRichMarkdownSearch({
   const searchInputRef = useRef<HTMLInputElement | null>(null)
   const [isSearchOpen, setIsSearchOpen] = useState(false)
   const [searchQuery, setSearchQuery] = useState('')
-  const [matchCount, setMatchCount] = useState(0)
-  const [activeMatchIndex, setActiveMatchIndex] = useState(-1)
+  const [rawActiveMatchIndex, setRawActiveMatchIndex] = useState(-1)
   const [searchRevision, setSearchRevision] = useState(0)
+
+  // Why: memoizing the match array avoids the old two-effect pattern where both
+  // effects independently called findRichMarkdownSearchMatches on every change.
+  const matches = useMemo(() => {
+    if (!editor || !isSearchOpen || !searchQuery) {
+      return []
+    }
+    return findRichMarkdownSearchMatches(editor.state.doc, searchQuery)
+    // searchRevision is bumped on ProseMirror doc edits to trigger recomputation
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [editor, isSearchOpen, searchQuery, searchRevision])
+
+  const matchCount = matches.length
+
+  // Clamp the user-controlled index to the valid range on every render.
+  // No state update needed — this is a pure derivation.
+  const activeMatchIndex =
+    !isSearchOpen || matchCount === 0
+      ? -1
+      : rawActiveMatchIndex >= 0 && rawActiveMatchIndex < matchCount
+        ? rawActiveMatchIndex
+        : matchCount > 0
+          ? 0
+          : -1
 
   const openSearch = useCallback(() => {
     setIsSearchOpen(true)
@@ -32,8 +55,7 @@ export function useRichMarkdownSearch({
   const closeSearch = useCallback(() => {
     setIsSearchOpen(false)
     setSearchQuery('')
-    setActiveMatchIndex(-1)
-    setMatchCount(0)
+    setRawActiveMatchIndex(-1)
   }, [])
 
   const moveToMatch = useCallback(
@@ -42,7 +64,7 @@ export function useRichMarkdownSearch({
         return
       }
 
-      setActiveMatchIndex((currentIndex) => {
+      setRawActiveMatchIndex((currentIndex) => {
         const baseIndex = currentIndex >= 0 ? currentIndex : direction === 1 ? -1 : 0
         return (baseIndex + direction + matchCount) % matchCount
       })
@@ -86,36 +108,9 @@ export function useRichMarkdownSearch({
     searchInputRef.current?.select()
   }, [isSearchOpen])
 
-  useEffect(() => {
-    if (!editor) {
-      return
-    }
-
-    if (!isSearchOpen || !searchQuery) {
-      setMatchCount(0)
-      setActiveMatchIndex(-1)
-      editor.view.dispatch(
-        editor.state.tr.setMeta(richMarkdownSearchPluginKey, {
-          activeIndex: -1,
-          query: ''
-        })
-      )
-      return
-    }
-
-    const matches = findRichMarkdownSearchMatches(editor.state.doc, searchQuery)
-    setMatchCount(matches.length)
-    setActiveMatchIndex((currentIndex) => {
-      if (matches.length === 0) {
-        return -1
-      }
-      if (currentIndex >= 0 && currentIndex < matches.length) {
-        return currentIndex
-      }
-      return 0
-    })
-  }, [editor, isSearchOpen, searchQuery, searchRevision])
-
+  // Why: single effect to sync search state to ProseMirror. The old two-effect
+  // chain (compute matches → set state → dispatch) caused an extra render cycle
+  // and called findRichMarkdownSearchMatches twice per change.
   useEffect(() => {
     if (!editor) {
       return
@@ -133,7 +128,6 @@ export function useRichMarkdownSearch({
       return
     }
 
-    const matches = findRichMarkdownSearchMatches(editor.state.doc, query)
     const activeMatch = matches[activeMatchIndex]
     if (!activeMatch) {
       return
@@ -147,7 +141,7 @@ export function useRichMarkdownSearch({
     tr.setSelection(TextSelection.create(tr.doc, activeMatch.from, activeMatch.to))
     tr.scrollIntoView()
     editor.view.dispatch(tr)
-  }, [activeMatchIndex, editor, isSearchOpen, searchQuery])
+  }, [activeMatchIndex, editor, isSearchOpen, matches, searchQuery])
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent): void => {

--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Keyboard, Palette, SlidersHorizontal, SquareTerminal } from 'lucide-react'
 import type { OrcaHooks } from '../../../../shared/types'
 import { useAppStore } from '../../store'
-import { getSystemPrefersDark } from '@/lib/terminal-theme'
+import { useSystemPrefersDark } from '@/components/terminal-pane/use-system-prefers-dark'
 import { SCROLLBACK_PRESETS_MB, getFallbackTerminalFonts } from './SettingsConstants'
 import { GeneralPane, GENERAL_PANE_SEARCH_ENTRIES } from './GeneralPane'
 import { AppearancePane, APPEARANCE_PANE_SEARCH_ENTRIES } from './AppearancePane'
@@ -50,9 +50,9 @@ function Settings(): React.JSX.Element {
   const [repoHooksMap, setRepoHooksMap] = useState<
     Record<string, { hasHooks: boolean; hooks: OrcaHooks | null }>
   >({})
-  const [systemPrefersDark, setSystemPrefersDark] = useState(getSystemPrefersDark())
+  const systemPrefersDark = useSystemPrefersDark()
   const [scrollbackMode, setScrollbackMode] = useState<'preset' | 'custom'>('preset')
-  const [prevSettings, setPrevSettings] = useState(settings)
+  const [prevScrollbackBytes, setPrevScrollbackBytes] = useState(settings?.terminalScrollbackBytes)
   const [terminalFontSuggestions, setTerminalFontSuggestions] = useState<string[]>(
     getFallbackTerminalFonts()
   )
@@ -90,16 +90,6 @@ function Settings(): React.JSX.Element {
   }, [clearSettingsTarget, settingsNavigationTarget])
 
   useEffect(() => {
-    const media = window.matchMedia('(prefers-color-scheme: dark)')
-    const handleChange = (event: MediaQueryListEvent): void => {
-      setSystemPrefersDark(event.matches)
-    }
-    setSystemPrefersDark(media.matches)
-    media.addEventListener('change', handleChange)
-    return () => media.removeEventListener('change', handleChange)
-  }, [])
-
-  useEffect(() => {
     if (terminalFontsLoadedRef.current) {
       return
     }
@@ -126,8 +116,10 @@ function Settings(): React.JSX.Element {
     }
   }, [])
 
-  if (settings !== prevSettings) {
-    setPrevSettings(settings)
+  // Why: only recompute scrollback mode when the byte value actually changes,
+  // not on every unrelated settings mutation.
+  if (settings?.terminalScrollbackBytes !== prevScrollbackBytes) {
+    setPrevScrollbackBytes(settings?.terminalScrollbackBytes)
     if (settings) {
       const scrollbackMb = Math.max(1, Math.round(settings.terminalScrollbackBytes / 1_000_000))
       setScrollbackMode(

--- a/src/renderer/src/components/terminal-pane/use-system-prefers-dark.ts
+++ b/src/renderer/src/components/terminal-pane/use-system-prefers-dark.ts
@@ -13,7 +13,6 @@ export function useSystemPrefersDark(): boolean {
     }
     const media = window.matchMedia('(prefers-color-scheme: dark)')
     const handleChange = (event: MediaQueryListEvent): void => setSystemPrefersDark(event.matches)
-    setSystemPrefersDark(media.matches)
     media.addEventListener('change', handleChange)
     return () => media.removeEventListener('change', handleChange)
   }, [])

--- a/src/renderer/src/components/terminal/useTerminalTabs.ts
+++ b/src/renderer/src/components/terminal/useTerminalTabs.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useAppStore } from '@/store'
 import { useShallow } from 'zustand/react/shallow'
 import { TOGGLE_TERMINAL_PANE_EXPAND_EVENT } from '@/constants/terminal'
@@ -74,7 +74,7 @@ function useTerminalTabsInner() {
   const tabBarOrder = activeWorktreeId ? tabBarOrderByWorktree[activeWorktreeId] : undefined
 
   // Build unified tab list respecting stored tab bar order
-  const unifiedTabs: UnifiedTerminalItem[] = (() => {
+  const unifiedTabs = useMemo<UnifiedTerminalItem[]>(() => {
     const terminalIdSet = new Set(tabs.map((t) => t.id))
     const editorIdSet = new Set(worktreeFiles.map((f) => f.id))
     const validIds = new Set([...terminalIdSet, ...editorIdSet])
@@ -94,10 +94,34 @@ function useTerminalTabsInner() {
       type: (terminalIdSet.has(id) ? 'terminal' : 'editor') as 'terminal' | 'editor',
       id
     }))
-  })()
+  }, [tabs, worktreeFiles, tabBarOrder])
 
   const [mountedWorktreeIds, setMountedWorktreeIds] = useState<string[]>([])
   const [initialTabCreationGuard, setInitialTabCreationGuard] = useState<string | null>(null)
+  const prevActiveWorktreeIdRef = useRef(activeWorktreeId)
+  const prevAllWorktreesRef = useRef(allWorktrees)
+
+  // Why: synchronize the keep-alive worktree set during render to avoid a
+  // one-frame flash where a newly-activated terminal pane is unmounted.
+  if (
+    activeWorktreeId !== prevActiveWorktreeIdRef.current ||
+    allWorktrees !== prevAllWorktreesRef.current
+  ) {
+    prevActiveWorktreeIdRef.current = activeWorktreeId
+    prevAllWorktreesRef.current = allWorktrees
+    setMountedWorktreeIds((current) => {
+      const allWorktreeIds = new Set(allWorktrees.map((worktree) => worktree.id))
+      const next = current.filter((id) => allWorktreeIds.has(id))
+      if (activeWorktreeId && !next.includes(activeWorktreeId)) {
+        next.push(activeWorktreeId)
+      }
+      if (next.length === current.length && next.every((id, index) => id === current[index])) {
+        return current
+      }
+      return next
+    })
+  }
+
   const mountedWorktrees = allWorktrees.filter((worktree) =>
     mountedWorktreeIds.includes(worktree.id)
   )
@@ -112,20 +136,6 @@ function useTerminalTabsInner() {
     setActiveTab(tabs[0].id)
     // eslint-disable-next-line react-hooks/exhaustive-deps -- tabs is derived from tabsByWorktree which is stable via useShallow
   }, [activeTabId, setActiveTab, tabsByWorktree, activeWorktreeId])
-
-  useEffect(() => {
-    setMountedWorktreeIds((current) => {
-      const allWorktreeIds = new Set(allWorktrees.map((worktree) => worktree.id))
-      const next = current.filter((id) => allWorktreeIds.has(id))
-      if (activeWorktreeId && !next.includes(activeWorktreeId)) {
-        next.push(activeWorktreeId)
-      }
-      if (next.length === current.length && next.every((id, index) => id === current[index])) {
-        return current
-      }
-      return next
-    })
-  }, [activeWorktreeId, allWorktrees])
 
   useEffect(() => {
     if (!workspaceSessionReady) {


### PR DESCRIPTION
## Summary
- **EditorPanel**: Replace `useEffect` syncing `sideBySide` from settings with render-during-render pattern — eliminates flash of stale diff mode
- **useTerminalTabs**: Wrap `unifiedTabs` IIFE in `useMemo`; replace `mountedWorktreeIds` effect with render-during-render — eliminates one-frame terminal pane unmount flash on worktree switch
- **useRichMarkdownSearch**: Memoize matches array, derive `matchCount` inline, consolidate two chained effects into one — eliminates double `findRichMarkdownSearchMatches` doc scan and extra render cycle per keystroke
- **QuickOpen**: Move `selectedIndex` reset from `useEffect(…, [filtered])` into the `onChange` handler — eliminates extra render cycle on every search keystroke
- **Settings**: Reuse existing `useSystemPrefersDark` hook (was duplicated inline); narrow `scrollbackMode` render-during-render check to `terminalScrollbackBytes` only (was comparing entire settings object)
- **use-system-prefers-dark**: Remove redundant `setSystemPrefersDark(media.matches)` — already covered by the `useState` initializer

## Test plan
- [x] Open a diff file, toggle side-by-side view, change the default in Settings — verify it syncs without flash
- [x] Switch between worktrees — verify terminal panes mount without flicker
- [x] Open rich markdown editor, use Cmd+F search — verify find/next/prev work correctly
- [x] Open Quick Open (Cmd+P), type a query — verify selection resets and navigation works
- [x] Open Settings, change theme and scrollback — verify both update correctly
- [x] Verify dark/light mode system preference changes propagate in both Settings and terminal pane

🤖 Generated with [Claude Code](https://claude.com/claude-code)