### PR TITLE
fix: terminal content not resizing on pane expand

### DIFF
--- a/src/renderer/src/components/terminal-pane/expand-collapse.ts
+++ b/src/renderer/src/components/terminal-pane/expand-collapse.ts
@@ -66,7 +66,10 @@ export function applyExpandedLayoutTo(
       }
       rememberPaneStyle(snapshots, child)
       if (child === current) {
-        child.style.display = ''
+        // Only update flex — do NOT reset display to '' because split
+        // containers rely on inline `display: flex` (no CSS class rule
+        // exists for it). Clearing it collapses the flex context, which
+        // prevents FitAddon from measuring the expanded dimensions.
         child.style.flex = '1 1 auto'
       } else {
         child.style.display = 'none'


### PR DESCRIPTION
## Summary
- When expanding a terminal pane (cmd+shift+enter), the pane background took the full screen but the xterm content and scrollbar remained at the old size
- Root cause: `applyExpandedLayoutTo` cleared `style.display` to `''` on visible elements during the DOM walk-up. `.pane-split` containers only have `display: flex` set inline (no CSS class rule exists), so clearing it caused fallback to `display: block`, breaking the flex layout chain. `FitAddon.fit()` then measured the unchanged container dimensions and computed the same cols/rows — no resize occurred
- Fix: only update `flex` on the visible element during expand, preserving its existing `display` value

## Test plan
- [ ] Open two terminal panes side-by-side
- [ ] Run something with scrollable output (e.g. Claude Code) in one pane
- [ ] Press cmd+shift+enter to expand that pane — terminal content should resize to fill the screen
- [ ] Press cmd+shift+enter again to collapse — terminal content should resize back to split size
- [ ] Verify normal window resize still works correctly with split panes