### PR TITLE
feat: add shift-select bulk source control actions

### DIFF
--- a/src/main/git/status.test.ts
+++ b/src/main/git/status.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- Why: git status/discard/chunking behavior is verified together here to keep the command contract readable in one place. */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import path from 'path'
 
@@ -26,6 +27,8 @@ vi.mock('fs', () => ({
 }))
 
 import {
+  bulkStageFiles,
+  bulkUnstageFiles,
   detectConflictOperation,
   discardChanges,
   getBranchCompare,
@@ -93,6 +96,57 @@ describe('discardChanges', () => {
 
   it('accepts in-tree Windows paths when resolving containment', async () => {
     expect(isWithinWorktree(path.win32, 'C:\\repo', 'C:\\repo\\src\\file.ts')).toBe(true)
+  })
+})
+
+describe('bulk git helpers', () => {
+  beforeEach(() => {
+    execFileAsyncMock.mockReset()
+  })
+
+  it('chunks bulk stage requests to avoid oversized argv payloads', async () => {
+    execFileAsyncMock.mockResolvedValue({ stdout: '' })
+
+    const filePaths = Array.from({ length: 201 }, (_, i) => `src/file-${i}.ts`)
+    await bulkStageFiles('/repo', filePaths)
+
+    expect(execFileAsyncMock).toHaveBeenCalledTimes(3)
+    expect(execFileAsyncMock).toHaveBeenNthCalledWith(
+      1,
+      'git',
+      ['add', '--', ...filePaths.slice(0, 100)],
+      {
+        cwd: '/repo',
+        encoding: 'utf-8'
+      }
+    )
+    expect(execFileAsyncMock).toHaveBeenNthCalledWith(
+      3,
+      'git',
+      ['add', '--', ...filePaths.slice(200)],
+      {
+        cwd: '/repo',
+        encoding: 'utf-8'
+      }
+    )
+  })
+
+  it('chunks bulk unstage requests to avoid oversized argv payloads', async () => {
+    execFileAsyncMock.mockResolvedValue({ stdout: '' })
+
+    const filePaths = Array.from({ length: 101 }, (_, i) => `src/file-${i}.ts`)
+    await bulkUnstageFiles('/repo', filePaths)
+
+    expect(execFileAsyncMock).toHaveBeenCalledTimes(2)
+    expect(execFileAsyncMock).toHaveBeenNthCalledWith(
+      2,
+      'git',
+      ['restore', '--staged', '--', ...filePaths.slice(100)],
+      {
+        cwd: '/repo',
+        encoding: 'utf-8'
+      }
+    )
   })
 })
 

--- a/src/main/git/status.ts
+++ b/src/main/git/status.ts
@@ -690,3 +690,31 @@ export function isWithinWorktree(
     pathApi.isAbsolute(relativeTarget)
   )
 }
+
+/**
+ * Bulk stage files in batches to avoid E2BIG.
+ */
+export async function bulkStageFiles(worktreePath: string, filePaths: string[]): Promise<void> {
+  if (filePaths.length === 0) {
+    return
+  }
+  const CHUNK_SIZE = 100
+  for (let i = 0; i < filePaths.length; i += CHUNK_SIZE) {
+    const chunk = filePaths.slice(i, i + CHUNK_SIZE)
+    await gitExecFileAsync(['add', '--', ...chunk], { cwd: worktreePath })
+  }
+}
+
+/**
+ * Bulk unstage files in batches to avoid E2BIG.
+ */
+export async function bulkUnstageFiles(worktreePath: string, filePaths: string[]): Promise<void> {
+  if (filePaths.length === 0) {
+    return
+  }
+  const CHUNK_SIZE = 100
+  for (let i = 0; i < filePaths.length; i += CHUNK_SIZE) {
+    const chunk = filePaths.slice(i, i + CHUNK_SIZE)
+    await gitExecFileAsync(['restore', '--staged', '--', ...chunk], { cwd: worktreePath })
+  }
+}

--- a/src/main/ipc/filesystem.test.ts
+++ b/src/main/ipc/filesystem.test.ts
@@ -17,7 +17,9 @@ const {
   getBranchCompareMock,
   getBranchDiffMock,
   stageFileMock,
+  bulkStageFilesMock,
   unstageFileMock,
+  bulkUnstageFilesMock,
   discardChangesMock,
   listWorktreesMock
 } = vi.hoisted(() => ({
@@ -34,7 +36,9 @@ const {
   getBranchCompareMock: vi.fn(),
   getBranchDiffMock: vi.fn(),
   stageFileMock: vi.fn(),
+  bulkStageFilesMock: vi.fn(),
   unstageFileMock: vi.fn(),
+  bulkUnstageFilesMock: vi.fn(),
   discardChangesMock: vi.fn(),
   listWorktreesMock: vi.fn()
 }))
@@ -63,7 +67,9 @@ vi.mock('../git/status', () => ({
   getBranchCompare: getBranchCompareMock,
   getBranchDiff: getBranchDiffMock,
   stageFile: stageFileMock,
+  bulkStageFiles: bulkStageFilesMock,
   unstageFile: unstageFileMock,
+  bulkUnstageFiles: bulkUnstageFilesMock,
   discardChanges: discardChangesMock
 }))
 
@@ -112,7 +118,9 @@ describe('registerFilesystemHandlers', () => {
       getBranchCompareMock,
       getBranchDiffMock,
       stageFileMock,
+      bulkStageFilesMock,
       unstageFileMock,
+      bulkUnstageFilesMock,
       discardChangesMock,
       listWorktreesMock
     ]) {
@@ -153,9 +161,9 @@ describe('registerFilesystemHandlers', () => {
 
     registerFilesystemHandlers(store as never)
 
-    await expect(
-      handlers.get('fs:readFile')!(null, { filePath: linkPath })
-    ).rejects.toThrow('Access denied: path resolves outside allowed directories')
+    await expect(handlers.get('fs:readFile')!(null, { filePath: linkPath })).rejects.toThrow(
+      'Access denied: path resolves outside allowed directories'
+    )
 
     expect(readFileMock).not.toHaveBeenCalled()
   })
@@ -261,6 +269,35 @@ describe('registerFilesystemHandlers', () => {
     ).rejects.toThrow('Access denied: unknown repository or worktree path')
 
     expect(getStatusMock).not.toHaveBeenCalled()
+  })
+
+  it('normalizes git file paths for bulk stage requests', async () => {
+    bulkStageFilesMock.mockResolvedValue(undefined)
+
+    registerFilesystemHandlers(store as never)
+
+    await handlers.get('git:bulkStage')!(null, {
+      worktreePath: WORKTREE_FEATURE_PATH,
+      filePaths: ['./src/../src/file.ts', 'nested//child.ts']
+    })
+
+    expect(bulkStageFilesMock).toHaveBeenCalledWith(WORKTREE_FEATURE_PATH, [
+      path.join('src', 'file.ts'),
+      path.join('nested', 'child.ts')
+    ])
+  })
+
+  it('rejects bulk unstage requests that escape the selected worktree', async () => {
+    registerFilesystemHandlers(store as never)
+
+    await expect(
+      handlers.get('git:bulkUnstage')!(null, {
+        worktreePath: WORKTREE_FEATURE_PATH,
+        filePaths: ['src/file.ts', '../outside.txt']
+      })
+    ).rejects.toThrow('Access denied: git file path escapes the selected worktree')
+
+    expect(bulkUnstageFilesMock).not.toHaveBeenCalled()
   })
 
   it('routes branch compare queries through the git compare helper', async () => {

--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -22,6 +22,8 @@ import {
   getDiff,
   stageFile,
   unstageFile,
+  bulkStageFiles,
+  bulkUnstageFiles,
   discardChanges,
   getBranchCompare,
   getBranchDiff
@@ -458,6 +460,24 @@ export function registerFilesystemHandlers(store: Store): void {
       const worktreePath = await resolveRegisteredWorktreePath(args.worktreePath, store)
       const filePath = validateGitRelativeFilePath(worktreePath, args.filePath)
       await discardChanges(worktreePath, filePath)
+    }
+  )
+
+  ipcMain.handle(
+    'git:bulkStage',
+    async (_event, args: { worktreePath: string; filePaths: string[] }): Promise<void> => {
+      const worktreePath = await resolveRegisteredWorktreePath(args.worktreePath, store)
+      const filePaths = args.filePaths.map((p) => validateGitRelativeFilePath(worktreePath, p))
+      await bulkStageFiles(worktreePath, filePaths)
+    }
+  )
+
+  ipcMain.handle(
+    'git:bulkUnstage',
+    async (_event, args: { worktreePath: string; filePaths: string[] }): Promise<void> => {
+      const worktreePath = await resolveRegisteredWorktreePath(args.worktreePath, store)
+      const filePaths = args.filePaths.map((p) => validateGitRelativeFilePath(worktreePath, p))
+      await bulkUnstageFiles(worktreePath, filePaths)
     }
   )
 

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -242,7 +242,9 @@ type GitApi = {
     oldPath?: string
   }) => Promise<GitDiffResult>
   stage: (args: { worktreePath: string; filePath: string }) => Promise<void>
+  bulkStage: (args: { worktreePath: string; filePaths: string[] }) => Promise<void>
   unstage: (args: { worktreePath: string; filePath: string }) => Promise<void>
+  bulkUnstage: (args: { worktreePath: string; filePaths: string[] }) => Promise<void>
   discard: (args: { worktreePath: string; filePath: string }) => Promise<void>
   remoteFileUrl: (args: {
     worktreePath: string

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -453,8 +453,12 @@ const api = {
     }): Promise<unknown> => ipcRenderer.invoke('git:branchDiff', args),
     stage: (args: { worktreePath: string; filePath: string }): Promise<void> =>
       ipcRenderer.invoke('git:stage', args),
+    bulkStage: (args: { worktreePath: string; filePaths: string[] }): Promise<void> =>
+      ipcRenderer.invoke('git:bulkStage', args),
     unstage: (args: { worktreePath: string; filePath: string }): Promise<void> =>
       ipcRenderer.invoke('git:unstage', args),
+    bulkUnstage: (args: { worktreePath: string; filePaths: string[] }): Promise<void> =>
+      ipcRenderer.invoke('git:bulkUnstage', args),
     discard: (args: { worktreePath: string; filePath: string }): Promise<void> =>
       ipcRenderer.invoke('git:discard', args),
     remoteFileUrl: (args: {

--- a/src/renderer/src/components/right-sidebar/BulkActionBar.tsx
+++ b/src/renderer/src/components/right-sidebar/BulkActionBar.tsx
@@ -1,0 +1,72 @@
+import { Plus, Minus, X, Loader2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+
+export function BulkActionBar({
+  selectedCount,
+  stageableCount,
+  unstageableCount,
+  onStage,
+  onUnstage,
+  onClear,
+  isExecuting
+}: {
+  selectedCount: number
+  stageableCount: number
+  unstageableCount: number
+  onStage: () => void
+  onUnstage: () => void
+  onClear: () => void
+  isExecuting: boolean
+}) {
+  return (
+    <div className="absolute bottom-0 left-0 right-0 p-2 bg-background/95 backdrop-blur-sm border-t border-border shadow-lg animate-in slide-in-from-bottom-2 z-10">
+      <div className="flex items-center gap-2 justify-between bg-accent/30 p-1.5 pr-2 rounded-md border border-border/50">
+        <div className="flex items-center gap-2 text-xs font-medium text-foreground ml-1">
+          {isExecuting ? (
+            <Loader2 className="size-3.5 animate-spin text-muted-foreground" />
+          ) : (
+            <span className="tabular-nums">{selectedCount} selected</span>
+          )}
+        </div>
+        <div className="flex items-center gap-1.5">
+          {stageableCount > 0 && (
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              className="h-7 px-2 text-[11px]"
+              onClick={onStage}
+              disabled={isExecuting}
+            >
+              <Plus className="mr-1 size-3" />
+              Stage ({stageableCount})
+            </Button>
+          )}
+          {unstageableCount > 0 && (
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              className="h-7 px-2 text-[11px]"
+              onClick={onUnstage}
+              disabled={isExecuting}
+            >
+              <Minus className="mr-1 size-3" />
+              Unstage ({unstageableCount})
+            </Button>
+          )}
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7 ml-0.5 text-muted-foreground hover:text-foreground hover:bg-muted"
+            onClick={onClear}
+            disabled={isExecuting}
+          >
+            <X className="size-3.5" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -25,6 +25,8 @@ import { cn } from '@/lib/utils'
 import { isFolderRepo } from '../../../../shared/repo-kind'
 import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from '@/components/ui/tooltip'
 import { Button } from '@/components/ui/button'
+import { BulkActionBar } from './BulkActionBar'
+import { useSourceControlSelection, type FlatEntry } from './useSourceControlSelection'
 import {
   ContextMenu,
   ContextMenuContent,
@@ -92,6 +94,7 @@ const CONFLICT_KIND_LABELS: Record<GitConflictKind, string> = {
 }
 
 export default function SourceControl(): React.JSX.Element {
+  const sourceControlRef = useRef<HTMLDivElement>(null)
   const activeWorktreeId = useAppStore((s) => s.activeWorktreeId)
   const rightSidebarTab = useAppStore((s) => s.rightSidebarTab)
   const repos = useAppStore((s) => s.repos)
@@ -213,6 +216,119 @@ export default function SourceControl(): React.JSX.Element {
     return groups
   }, [entries])
 
+  const flatEntries = useMemo(() => {
+    const arr: FlatEntry[] = []
+    for (const area of SECTION_ORDER) {
+      if (!collapsedSections.has(area)) {
+        for (const entry of grouped[area]) {
+          arr.push({ key: `${area}::${entry.path}`, entry, area })
+        }
+      }
+    }
+    return arr
+  }, [grouped, collapsedSections])
+
+  const [isExecutingBulk, setIsExecutingBulk] = useState(false)
+
+  const handleOpenDiff = useCallback(
+    (entry: GitStatusEntry) => {
+      if (!activeWorktreeId || !worktreePath) {
+        return
+      }
+      if (entry.conflictKind && entry.conflictStatus) {
+        if (entry.conflictStatus === 'unresolved') {
+          trackConflictPath(activeWorktreeId, entry.path, entry.conflictKind)
+        }
+        openConflictFile(activeWorktreeId, worktreePath, entry, detectLanguage(entry.path))
+        return
+      }
+      openDiff(
+        activeWorktreeId,
+        joinPath(worktreePath, entry.path),
+        entry.path,
+        detectLanguage(entry.path),
+        entry.area === 'staged'
+      )
+    },
+    [activeWorktreeId, worktreePath, trackConflictPath, openConflictFile, openDiff]
+  )
+
+  const { selectedKeys, handleSelect, handleContextMenu, clearSelection } =
+    useSourceControlSelection({
+      flatEntries,
+      onOpenDiff: handleOpenDiff,
+      containerRef: sourceControlRef
+    })
+
+  // clear selection on scope change
+  useEffect(() => {
+    clearSelection()
+  }, [scope, clearSelection])
+
+  // Clear selection on worktree or tab change
+  useEffect(() => {
+    clearSelection()
+  }, [activeWorktreeId, rightSidebarTab, clearSelection])
+
+  const flatEntriesByKey = useMemo(
+    () => new Map(flatEntries.map((entry) => [entry.key, entry])),
+    [flatEntries]
+  )
+
+  const selectedEntries = useMemo(
+    () =>
+      Array.from(selectedKeys)
+        .map((key) => flatEntriesByKey.get(key))
+        .filter((entry): entry is FlatEntry => Boolean(entry)),
+    [selectedKeys, flatEntriesByKey]
+  )
+
+  const bulkStagePaths = useMemo(
+    () =>
+      selectedEntries
+        .filter(
+          (entry) =>
+            (entry.area === 'unstaged' || entry.area === 'untracked') &&
+            entry.entry.conflictStatus !== 'unresolved'
+        )
+        .map((entry) => entry.entry.path),
+    [selectedEntries]
+  )
+
+  const bulkUnstagePaths = useMemo(
+    () =>
+      selectedEntries.filter((entry) => entry.area === 'staged').map((entry) => entry.entry.path),
+    [selectedEntries]
+  )
+
+  const selectedKeySet = selectedKeys
+
+  const handleBulkStage = useCallback(async () => {
+    if (!worktreePath || bulkStagePaths.length === 0) {
+      return
+    }
+    setIsExecutingBulk(true)
+    try {
+      await window.api.git.bulkStage({ worktreePath, filePaths: bulkStagePaths })
+      clearSelection()
+    } finally {
+      setIsExecutingBulk(false)
+    }
+  }, [worktreePath, bulkStagePaths, clearSelection])
+
+  const handleBulkUnstage = useCallback(async () => {
+    if (!worktreePath || bulkUnstagePaths.length === 0) {
+      return
+    }
+    setIsExecutingBulk(true)
+    try {
+      await window.api.git.bulkUnstage({ worktreePath, filePaths: bulkUnstagePaths })
+      clearSelection()
+    } finally {
+      setIsExecutingBulk(false)
+    }
+  }, [worktreePath, bulkUnstagePaths, clearSelection])
+
   const unresolvedConflicts = useMemo(
     () => entries.filter((entry) => entry.conflictStatus === 'unresolved' && entry.conflictKind),
     [entries]
@@ -305,35 +421,6 @@ export default function SourceControl(): React.JSX.Element {
       return next
     })
   }, [])
-
-  const openUncommittedDiff = useCallback(
-    (entry: GitStatusEntry) => {
-      if (!activeWorktreeId || !worktreePath) {
-        return
-      }
-      // Why: unresolved conflicts must NOT go through openDiff(). The current
-      // diff pipeline reads normal index and worktree content, not merge stages,
-      // so routing conflicts into the two-way diff viewer would show misleading
-      // content. Instead, we use the conflict-aware open path (openConflictFile)
-      // which opens an editable file view or a placeholder, depending on whether
-      // a working-tree file exists.
-      if (entry.conflictKind && entry.conflictStatus) {
-        if (entry.conflictStatus === 'unresolved') {
-          trackConflictPath(activeWorktreeId, entry.path, entry.conflictKind)
-        }
-        openConflictFile(activeWorktreeId, worktreePath, entry, detectLanguage(entry.path))
-        return
-      }
-      openDiff(
-        activeWorktreeId,
-        joinPath(worktreePath, entry.path),
-        entry.path,
-        detectLanguage(entry.path),
-        entry.area === 'staged'
-      )
-    },
-    [activeWorktreeId, openConflictFile, openDiff, trackConflictPath, worktreePath]
-  )
 
   const openCommittedDiff = useCallback(
     (entry: GitBranchChangeEntry) => {
@@ -432,7 +519,7 @@ export default function SourceControl(): React.JSX.Element {
 
   return (
     <>
-      <div className="flex h-full flex-col overflow-hidden">
+      <div ref={sourceControlRef} className="relative flex h-full flex-col overflow-hidden">
         <div className="flex items-center px-3 pt-2 border-b border-border">
           {(['all', 'uncommitted'] as const).map((value) => (
             <button
@@ -483,7 +570,10 @@ export default function SourceControl(): React.JSX.Element {
           </div>
         )}
 
-        <div className="flex-1 overflow-auto scrollbar-sleek py-1">
+        <div
+          className="relative flex-1 overflow-auto scrollbar-sleek py-1"
+          style={{ paddingBottom: selectedKeys.size > 0 ? 50 : undefined }}
+        >
           {unresolvedConflictReviewEntries.length > 0 && (
             <div className="px-3 pb-2">
               <ConflictSummaryCard
@@ -580,20 +670,26 @@ export default function SourceControl(): React.JSX.Element {
                       }
                     />
                     {!isCollapsed &&
-                      items.map((entry) => (
-                        <UncommittedEntryRow
-                          key={`${entry.area}:${entry.path}`}
-                          entry={entry}
-                          worktreePath={worktreePath}
-                          onRevealInExplorer={() =>
-                            revealInExplorer(currentWorktreeId, joinPath(worktreePath, entry.path))
-                          }
-                          onOpen={() => openUncommittedDiff(entry)}
-                          onStage={() => void handleStage(entry.path)}
-                          onUnstage={() => void handleUnstage(entry.path)}
-                          onDiscard={() => void handleDiscard(entry.path)}
-                        />
-                      ))}
+                      items.map((entry) => {
+                        const key = `${entry.area}::${entry.path}`
+                        return (
+                          <UncommittedEntryRow
+                            key={key}
+                            entryKey={key}
+                            entry={entry}
+                            currentWorktreeId={currentWorktreeId}
+                            worktreePath={worktreePath}
+                            selected={selectedKeySet.has(key)}
+                            onSelect={handleSelect}
+                            onContextMenu={handleContextMenu}
+                            onRevealInExplorer={revealInExplorer}
+                            onOpen={handleOpenDiff}
+                            onStage={handleStage}
+                            onUnstage={handleUnstage}
+                            onDiscard={handleDiscard}
+                          />
+                        )
+                      })}
                   </div>
                 )
               })}
@@ -640,16 +736,27 @@ export default function SourceControl(): React.JSX.Element {
                   <BranchEntryRow
                     key={`branch:${entry.path}`}
                     entry={entry}
+                    currentWorktreeId={currentWorktreeId}
                     worktreePath={worktreePath}
-                    onRevealInExplorer={() =>
-                      revealInExplorer(currentWorktreeId, joinPath(worktreePath, entry.path))
-                    }
+                    onRevealInExplorer={revealInExplorer}
                     onOpen={() => openCommittedDiff(entry)}
                   />
                 ))}
             </div>
           )}
         </div>
+
+        {selectedKeys.size > 0 && (
+          <BulkActionBar
+            selectedCount={selectedKeys.size}
+            stageableCount={bulkStagePaths.length}
+            unstageableCount={bulkUnstagePaths.length}
+            onStage={handleBulkStage}
+            onUnstage={handleBulkUnstage}
+            onClear={clearSelection}
+            isExecuting={isExecutingBulk}
+          />
+        )}
       </div>
 
       <Dialog open={baseRefDialogOpen} onOpenChange={setBaseRefDialogOpen}>
@@ -912,22 +1019,32 @@ function OperationBanner({
   )
 }
 
-function UncommittedEntryRow({
+const UncommittedEntryRow = React.memo(function UncommittedEntryRow({
+  entryKey,
   entry,
+  currentWorktreeId,
   worktreePath,
+  selected,
+  onSelect,
+  onContextMenu,
   onRevealInExplorer,
   onOpen,
   onStage,
   onUnstage,
   onDiscard
 }: {
+  entryKey: string
   entry: GitStatusEntry
+  currentWorktreeId: string
   worktreePath: string
-  onRevealInExplorer: () => void
-  onOpen: () => void
-  onStage: () => void
-  onUnstage: () => void
-  onDiscard: () => void
+  selected?: boolean
+  onSelect?: (e: React.MouseEvent, key: string, entry: GitStatusEntry) => void
+  onContextMenu?: (key: string) => void
+  onRevealInExplorer: (worktreeId: string, absolutePath: string) => void
+  onOpen: (entry: GitStatusEntry) => void
+  onStage: (filePath: string) => Promise<void>
+  onUnstage: (filePath: string) => Promise<void>
+  onDiscard: (filePath: string) => Promise<void>
 }): React.JSX.Element {
   const StatusIcon = STATUS_ICONS[entry.status] ?? FileQuestion
   const fileName = basename(entry.path)
@@ -958,11 +1075,20 @@ function UncommittedEntryRow({
 
   return (
     <SourceControlEntryContextMenu
+      currentWorktreeId={currentWorktreeId}
       absolutePath={joinPath(worktreePath, entry.path)}
       onRevealInExplorer={onRevealInExplorer}
+      onOpenChange={(open) => {
+        if (open && onContextMenu) {
+          onContextMenu(entryKey)
+        }
+      }}
     >
       <div
-        className="group relative flex cursor-pointer items-center gap-1 pl-5 pr-3 py-1 transition-colors hover:bg-accent/40"
+        className={cn(
+          'group relative flex cursor-pointer items-center gap-1 pl-5 pr-3 py-1 transition-colors hover:bg-accent/40',
+          selected && 'bg-accent/60'
+        )}
         draggable
         onDragStart={(e) => {
           if (isUnresolvedConflict && entry.status === 'deleted') {
@@ -973,7 +1099,13 @@ function UncommittedEntryRow({
           e.dataTransfer.setData('text/x-orca-file-path', absolutePath)
           e.dataTransfer.effectAllowed = 'copy'
         }}
-        onClick={onOpen}
+        onClick={(e) => {
+          if (onSelect) {
+            onSelect(e, entryKey, entry)
+          } else {
+            onOpen(entry)
+          }
+        }}
       >
         <StatusIcon className="size-3.5 shrink-0" style={{ color: STATUS_COLORS[entry.status] }} />
         <div className="min-w-0 flex-1 text-xs">
@@ -1002,7 +1134,7 @@ function UncommittedEntryRow({
               title={entry.area === 'untracked' ? 'Revert untracked file' : 'Discard changes'}
               onClick={(event) => {
                 event.stopPropagation()
-                void onDiscard()
+                void onDiscard(entry.path)
               }}
             />
           )}
@@ -1012,7 +1144,7 @@ function UncommittedEntryRow({
               title="Stage"
               onClick={(event) => {
                 event.stopPropagation()
-                void onStage()
+                void onStage(entry.path)
               }}
             />
           )}
@@ -1022,7 +1154,7 @@ function UncommittedEntryRow({
               title="Unstage"
               onClick={(event) => {
                 event.stopPropagation()
-                void onUnstage()
+                void onUnstage(entry.path)
               }}
             />
           )}
@@ -1030,7 +1162,7 @@ function UncommittedEntryRow({
       </div>
     </SourceControlEntryContextMenu>
   )
-}
+})
 
 function ConflictBadge({ entry }: { entry: GitStatusEntry }): React.JSX.Element {
   const isUnresolvedConflict = entry.conflictStatus === 'unresolved'
@@ -1070,13 +1202,15 @@ function ConflictBadge({ entry }: { entry: GitStatusEntry }): React.JSX.Element 
 
 function BranchEntryRow({
   entry,
+  currentWorktreeId,
   worktreePath,
   onRevealInExplorer,
   onOpen
 }: {
   entry: GitBranchChangeEntry
+  currentWorktreeId: string
   worktreePath: string
-  onRevealInExplorer: () => void
+  onRevealInExplorer: (worktreeId: string, absolutePath: string) => void
   onOpen: () => void
 }): React.JSX.Element {
   const StatusIcon = STATUS_ICONS[entry.status] ?? FileQuestion
@@ -1086,6 +1220,7 @@ function BranchEntryRow({
 
   return (
     <SourceControlEntryContextMenu
+      currentWorktreeId={currentWorktreeId}
       absolutePath={joinPath(worktreePath, entry.path)}
       onRevealInExplorer={onRevealInExplorer}
     >
@@ -1110,23 +1245,27 @@ function BranchEntryRow({
 }
 
 function SourceControlEntryContextMenu({
+  currentWorktreeId,
   absolutePath,
   onRevealInExplorer,
+  onOpenChange,
   children
 }: {
+  currentWorktreeId: string
   absolutePath?: string
-  onRevealInExplorer: () => void
+  onRevealInExplorer: (worktreeId: string, absolutePath: string) => void
+  onOpenChange?: (open: boolean) => void
   children: React.ReactNode
 }): React.JSX.Element {
   const handleOpenInFileExplorer = useCallback(() => {
     if (!absolutePath) {
       return
     }
-    onRevealInExplorer()
-  }, [absolutePath, onRevealInExplorer])
+    onRevealInExplorer(currentWorktreeId, absolutePath)
+  }, [absolutePath, currentWorktreeId, onRevealInExplorer])
 
   return (
-    <ContextMenu>
+    <ContextMenu onOpenChange={onOpenChange}>
       <ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
       <ContextMenuContent className="w-52">
         <ContextMenuItem onSelect={handleOpenInFileExplorer} disabled={!absolutePath}>

--- a/src/renderer/src/components/right-sidebar/useSourceControlSelection.test.ts
+++ b/src/renderer/src/components/right-sidebar/useSourceControlSelection.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import type { GitStatusEntry } from '../../../../shared/types'
+import {
+  getSelectionRangeKeys,
+  reconcileSelectionKeys,
+  type FlatEntry
+} from './useSourceControlSelection'
+
+function makeEntry(
+  key: string,
+  area: FlatEntry['area'],
+  path: string,
+  status: GitStatusEntry['status'] = 'modified'
+): FlatEntry {
+  return {
+    key,
+    area,
+    entry: {
+      path,
+      area,
+      status
+    }
+  }
+}
+
+describe('reconcileSelectionKeys', () => {
+  it('drops selections that no longer exist in the visible list', () => {
+    const flatEntries = [
+      makeEntry('unstaged::a.ts', 'unstaged', 'a.ts'),
+      makeEntry('staged::b.ts', 'staged', 'b.ts')
+    ]
+
+    expect(
+      reconcileSelectionKeys(new Set(['unstaged::a.ts', 'untracked::gone.ts']), flatEntries)
+    ).toEqual(new Set(['unstaged::a.ts']))
+  })
+})
+
+describe('getSelectionRangeKeys', () => {
+  it('selects an inclusive range across visible sections', () => {
+    const flatEntries = [
+      makeEntry('unstaged::a.ts', 'unstaged', 'a.ts'),
+      makeEntry('unstaged::b.ts', 'unstaged', 'b.ts'),
+      makeEntry('staged::c.ts', 'staged', 'c.ts'),
+      makeEntry('untracked::d.ts', 'untracked', 'd.ts')
+    ]
+
+    expect(getSelectionRangeKeys(flatEntries, 'unstaged::b.ts', 'untracked::d.ts')).toEqual(
+      new Set(['unstaged::b.ts', 'staged::c.ts', 'untracked::d.ts'])
+    )
+  })
+
+  it('returns null when the anchor is no longer visible', () => {
+    const flatEntries = [
+      makeEntry('staged::c.ts', 'staged', 'c.ts'),
+      makeEntry('untracked::d.ts', 'untracked', 'd.ts')
+    ]
+
+    expect(getSelectionRangeKeys(flatEntries, 'unstaged::b.ts', 'untracked::d.ts')).toBeNull()
+  })
+})

--- a/src/renderer/src/components/right-sidebar/useSourceControlSelection.ts
+++ b/src/renderer/src/components/right-sidebar/useSourceControlSelection.ts
@@ -1,0 +1,187 @@
+import { useState, useCallback, useEffect, useRef, type RefObject } from 'react'
+import type { GitStatusEntry } from '../../../../shared/types'
+
+export type FlatEntry = {
+  key: string
+  entry: GitStatusEntry
+  area: 'unstaged' | 'staged' | 'untracked'
+}
+
+export function reconcileSelectionKeys(
+  selectedKeys: ReadonlySet<string>,
+  flatEntries: FlatEntry[]
+): Set<string> {
+  const validKeys = new Set(flatEntries.map((e) => e.key))
+  const nextSelected = new Set<string>()
+
+  for (const key of selectedKeys) {
+    if (validKeys.has(key)) {
+      nextSelected.add(key)
+    }
+  }
+
+  return nextSelected
+}
+
+export function getSelectionRangeKeys(
+  flatEntries: FlatEntry[],
+  anchorKey: string | null,
+  currentKey: string
+): Set<string> | null {
+  const anchorIndex = flatEntries.findIndex((e) => e.key === anchorKey)
+  const currentIndex = flatEntries.findIndex((e) => e.key === currentKey)
+  if (anchorIndex === -1 || currentIndex === -1) {
+    return null
+  }
+
+  const start = Math.min(anchorIndex, currentIndex)
+  const end = Math.max(anchorIndex, currentIndex)
+  const nextSelected = new Set<string>()
+  for (let i = start; i <= end; i++) {
+    nextSelected.add(flatEntries[i].key)
+  }
+  return nextSelected
+}
+
+export function useSourceControlSelection({
+  flatEntries,
+  onOpenDiff,
+  containerRef
+}: {
+  flatEntries: FlatEntry[]
+  onOpenDiff: (entry: GitStatusEntry) => void
+  containerRef: RefObject<HTMLElement | null>
+}) {
+  const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set())
+  const [anchorKey, setAnchorKey] = useState<string | null>(null)
+  const flatEntriesRef = useRef(flatEntries)
+  const anchorKeyRef = useRef<string | null>(anchorKey)
+  const selectedKeysRef = useRef(selectedKeys)
+  const onOpenDiffRef = useRef(onOpenDiff)
+
+  useEffect(() => {
+    flatEntriesRef.current = flatEntries
+  }, [flatEntries])
+
+  useEffect(() => {
+    anchorKeyRef.current = anchorKey
+  }, [anchorKey])
+
+  useEffect(() => {
+    selectedKeysRef.current = selectedKeys
+  }, [selectedKeys])
+
+  useEffect(() => {
+    onOpenDiffRef.current = onOpenDiff
+  }, [onOpenDiff])
+
+  // Clear stale selections if entries disappear
+  useEffect(() => {
+    const validKeys = new Set(flatEntries.map((e) => e.key))
+    const nextSelected = reconcileSelectionKeys(selectedKeys, flatEntries)
+    const changed = nextSelected.size !== selectedKeys.size
+
+    if (changed) {
+      setSelectedKeys(nextSelected)
+    }
+
+    if (anchorKey && !validKeys.has(anchorKey)) {
+      setAnchorKey(null)
+    }
+  }, [flatEntries, selectedKeys, anchorKey])
+
+  const handleSelect = useCallback((e: React.MouseEvent, key: string, entry: GitStatusEntry) => {
+    const isShift = e.shiftKey
+    const isCmdOrCtrl = e.metaKey || e.ctrlKey
+
+    if (isShift) {
+      const nextSelected = getSelectionRangeKeys(flatEntriesRef.current, anchorKeyRef.current, key)
+      if (nextSelected) {
+        setSelectedKeys(nextSelected)
+        return
+      }
+
+      // Why: when the anchor row disappears from the visible list because a
+      // section collapsed or status changed, the next Shift-click should
+      // fall back to the single-click behavior instead of selecting from a
+      // stale invisible anchor.
+      setSelectedKeys(new Set())
+      setAnchorKey(key)
+      onOpenDiffRef.current(entry)
+    } else if (isCmdOrCtrl) {
+      // Toggle individual
+      setSelectedKeys((prev) => {
+        const next = new Set(prev)
+        if (next.has(key)) {
+          next.delete(key)
+          // Keep anchorKey as is
+        } else {
+          next.add(key)
+          setAnchorKey(key)
+        }
+        return next
+      })
+    } else {
+      // Plain click
+      setSelectedKeys((prev) => {
+        if (prev.size > 0) {
+          return new Set()
+        }
+        return prev
+      })
+      setAnchorKey(key)
+      onOpenDiffRef.current(entry)
+    }
+  }, [])
+
+  const handleContextMenu = useCallback((key: string) => {
+    if (!selectedKeysRef.current.has(key)) {
+      setSelectedKeys(new Set([key]))
+      setAnchorKey(key)
+    }
+  }, [])
+
+  const clearSelection = useCallback(() => {
+    setSelectedKeys(new Set())
+    setAnchorKey(null)
+  }, [])
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && selectedKeys.size > 0) {
+        e.preventDefault()
+        clearSelection()
+      }
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [selectedKeys.size, clearSelection])
+
+  useEffect(() => {
+    const handlePointerDown = (e: MouseEvent) => {
+      if (selectedKeys.size === 0) {
+        return
+      }
+
+      const container = containerRef.current
+      const target = e.target
+      if (!container || !(target instanceof Node) || container.contains(target)) {
+        return
+      }
+
+      clearSelection()
+    }
+
+    // Why: use capture so outside clicks clear the selection before the next
+    // UI surface handles the pointer event, matching standard desktop list UX.
+    document.addEventListener('pointerdown', handlePointerDown, true)
+    return () => document.removeEventListener('pointerdown', handlePointerDown, true)
+  }, [selectedKeys.size, containerRef, clearSelection])
+
+  return {
+    selectedKeys,
+    handleSelect,
+    handleContextMenu,
+    clearSelection
+  }
+}


### PR DESCRIPTION
## Summary
- add shift-click and cmd/ctrl-click multi-select for uncommitted source control rows
- add bulk stage/unstage IPC and git chunking to avoid E2BIG on large selections
- add regression tests for selection logic and bulk git/file-system handlers

Closes #425