### PR TITLE
feat: display worktree comments with line wrapping

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -430,8 +430,10 @@ const WorktreeCard = React.memo(function WorktreeCard({
 
           {/* Meta section: Issue / PR Links / Comment
              ⚠ Layout coupling: the padding (py-0.5, mt-0.5), gap-[3px], and
-             line heights here are used to derive the pixel constants in
-             WorktreeList's estimateSize. Update both if changing spacing. */}
+             line heights here are used to derive the size estimates in
+             WorktreeList's estimateSize. The comment row's estimate is
+             dynamic (based on content length + newlines). Update the
+             estimate function if changing spacing or line-height. */}
           {((cardProps.includes('issue') && issue) ||
             (cardProps.includes('pr') && pr) ||
             (cardProps.includes('comment') && worktree.comment)) && (
@@ -549,19 +551,12 @@ const WorktreeCard = React.memo(function WorktreeCard({
               )}
 
               {cardProps.includes('comment') && worktree.comment && (
-                <HoverCard openDelay={300}>
-                  <HoverCardTrigger asChild>
-                    <div
-                      className="text-[11px] text-muted-foreground truncate cursor-pointer -mx-1.5 px-1.5 py-0.5 hover:bg-background/40 hover:text-foreground rounded transition-colors leading-none"
-                      onClick={handleEditComment}
-                    >
-                      {worktree.comment}
-                    </div>
-                  </HoverCardTrigger>
-                  <HoverCardContent side="right" align="start" className="w-64 p-3 text-xs">
-                    <p className="whitespace-pre-wrap">{worktree.comment}</p>
-                  </HoverCardContent>
-                </HoverCard>
+                <div
+                  className="text-[11px] text-muted-foreground whitespace-pre-wrap break-words cursor-pointer -mx-1.5 px-1.5 py-0.5 hover:bg-background/40 hover:text-foreground rounded transition-colors leading-normal"
+                  onClick={handleEditComment}
+                >
+                  {worktree.comment}
+                </div>
               )}
             </div>
           )}

--- a/src/renderer/src/components/sidebar/worktree-list-estimate.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-estimate.test.ts
@@ -84,11 +84,27 @@ describe('estimateRowHeight', () => {
     expect(estimateRowHeight(itemRow(worktree), ['pr'], repoMap, prCache)).toBe(52)
   })
 
-  it('adds 22px for comment row', () => {
+  it('estimates comment height based on content length', () => {
     const wt = { ...worktree, comment: 'todo: fix bug' }
     const base = estimateRowHeight(itemRow(worktree), ['comment'], repoMap, null)
     const withComment = estimateRowHeight(itemRow(wt), ['comment'], repoMap, null)
-    expect(withComment - base).toBe(24) // 22px line + 2px mt-0.5
+    // 1 line × 17px + 4px padding + 2px mt-0.5 = 23
+    expect(withComment - base).toBe(23)
+  })
+
+  it('estimates multi-line comment height from newlines', () => {
+    const wt = { ...worktree, comment: 'first line\nsecond line\nthird line' }
+    const h = estimateRowHeight(itemRow(wt), ['comment'], repoMap, null)
+    // ceil(3 × 16.5) + 4px padding = 54, total = 52 + 54 + 2 = 108
+    expect(h).toBe(108)
+  })
+
+  it('estimates wrapped long lines in comment', () => {
+    // 70 chars wraps to 2 lines at ~35 chars/line
+    const wt = { ...worktree, comment: 'a'.repeat(70) }
+    const h = estimateRowHeight(itemRow(wt), ['comment'], repoMap, null)
+    // ceil(2 × 16.5) + 4 = 37, total = 52 + 37 + 2 = 91
+    expect(h).toBe(91)
   })
 
   it('stacks all metadata lines correctly', () => {
@@ -97,9 +113,9 @@ describe('estimateRowHeight', () => {
       '/tmp/orca::feature/cool': { data: { number: 1 } }
     }
     const h = estimateRowHeight(itemRow(wt), ['issue', 'pr', 'comment'], repoMap, prCache)
-    // 52 base + 22 issue + 22 pr + 22 comment + 2 mt-0.5 = 120
+    // 52 base + 22 issue + 22 pr + (1×17+4) comment + 2 mt-0.5 = 119
     // (inter-card gap is handled by the virtualizer's `gap` option, not here)
-    expect(h).toBe(120)
+    expect(h).toBe(119)
   })
 
   it('strips refs/heads/ prefix when building PR cache key', () => {

--- a/src/renderer/src/components/sidebar/worktree-list-estimate.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-estimate.ts
@@ -2,9 +2,11 @@ import type { Repo } from '../../../../shared/types'
 import type { Row } from './worktree-list-groups'
 
 // Estimate the pixel height of a virtualizer row based on which metadata lines
-// will render. Pixel constants (52, 22, 2) are coupled to WorktreeCard's
-// Tailwind classes — see the coupling comment in WorktreeCard's meta section.
-// The inter-card gap is handled by the virtualizer's `gap` option, not here.
+// will render. Fixed-height rows (base 52, issue/PR 22, mt-0.5 2) are coupled
+// to WorktreeCard's Tailwind classes; the comment row uses a dynamic estimate
+// because it renders with whitespace-pre-wrap.  See the coupling comment in
+// WorktreeCard's meta section.  The inter-card gap is handled by the
+// virtualizer's `gap` option, not here.
 //
 // Uses prCache (not wt.linkedPR) because prCache is the actual data source
 // WorktreeCard checks when deciding to show the PR row.
@@ -31,7 +33,16 @@ export function estimateRowHeight(
     }
   }
   if (cardProps.includes('comment') && wt.comment) {
-    h += 22
+    // Comment now renders with whitespace-pre-wrap + break-words, so its
+    // height depends on content.  Estimate visual lines from explicit newlines
+    // and character wrapping (~35 chars per line at typical sidebar width).
+    // Line-height is leading-normal (1.5 × 11px = 16.5px) + 4px padding (py-0.5).
+    const lines = wt.comment.split('\n')
+    let totalLines = 0
+    for (const line of lines) {
+      totalLines += Math.max(1, Math.ceil(line.length / 35))
+    }
+    h += Math.ceil(totalLines * 16.5) + 4
   }
   if (h > 52) {
     h += 2


### PR DESCRIPTION
## Summary
- Replace HoverCard tooltip with inline `whitespace-pre-wrap` rendering so multi-line worktree comments are visible at a glance without hovering
- Update `estimateRowHeight` to dynamically calculate comment row height based on content length and newline count (~35 chars/line wrap estimate, 16.5px line-height)
- Add tests for multi-line and long-line wrapping comment height estimation

## Test plan
- [ ] Verify single-line comments render inline without truncation
- [ ] Verify multi-line comments (with newlines) display all lines wrapped
- [ ] Verify long single-line comments wrap correctly at sidebar width
- [ ] Verify virtualizer scroll doesn't jump/jank with variable-height comment rows
- [ ] Run `pnpm test` — all estimate tests pass