### PR TITLE
Fix stale GitHub CLI auth preflight state

### DIFF
--- a/src/main/ipc/preflight.test.ts
+++ b/src/main/ipc/preflight.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { handleMock, execFileAsyncMock } = vi.hoisted(() => ({
+  handleMock: vi.fn(),
+  execFileAsyncMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: handleMock
+  }
+}))
+
+vi.mock('util', async () => {
+  const actual = await vi.importActual('util')
+  return {
+    ...actual,
+    promisify: vi.fn(() => execFileAsyncMock)
+  }
+})
+
+import { _resetPreflightCache, registerPreflightHandlers, runPreflightCheck } from './preflight'
+
+type HandlerMap = Record<string, (_event?: unknown, args?: { force?: boolean }) => Promise<unknown>>
+
+describe('preflight', () => {
+  const handlers: HandlerMap = {}
+
+  beforeEach(() => {
+    handleMock.mockReset()
+    execFileAsyncMock.mockReset()
+    _resetPreflightCache()
+
+    for (const key of Object.keys(handlers)) {
+      delete handlers[key]
+    }
+
+    handleMock.mockImplementation((channel, handler) => {
+      handlers[channel] = handler
+    })
+  })
+
+  it('marks gh as authenticated when gh auth status exits successfully', async () => {
+    execFileAsyncMock
+      .mockResolvedValueOnce({ stdout: 'git version 2.0.0\n' })
+      .mockResolvedValueOnce({ stdout: 'gh version 2.0.0\n' })
+      .mockResolvedValueOnce({ stdout: 'github.com\n  - Active account: true\n' })
+
+    const status = await runPreflightCheck()
+
+    expect(status).toEqual({
+      git: { installed: true },
+      gh: { installed: true, authenticated: true }
+    })
+    expect(execFileAsyncMock).toHaveBeenNthCalledWith(3, 'gh', ['auth', 'status'], {
+      encoding: 'utf-8'
+    })
+  })
+
+  it('treats gh as unauthenticated when gh auth status fails without auth markers', async () => {
+    execFileAsyncMock
+      .mockResolvedValueOnce({ stdout: 'git version 2.0.0\n' })
+      .mockResolvedValueOnce({ stdout: 'gh version 2.0.0\n' })
+      .mockRejectedValueOnce({ stderr: 'You are not logged into any GitHub hosts.\n' })
+
+    const status = await runPreflightCheck()
+
+    expect(status.gh).toEqual({ installed: true, authenticated: false })
+  })
+
+  it('keeps older gh stderr success output from showing a false auth warning', async () => {
+    execFileAsyncMock
+      .mockResolvedValueOnce({ stdout: 'git version 2.0.0\n' })
+      .mockResolvedValueOnce({ stdout: 'gh version 2.0.0\n' })
+      .mockRejectedValueOnce({ stderr: 'Logged in to github.com account octocat\n' })
+
+    const status = await runPreflightCheck()
+
+    expect(status.gh).toEqual({ installed: true, authenticated: true })
+  })
+
+  it('re-runs the probe when forced so updated gh auth state is visible without relaunch', async () => {
+    execFileAsyncMock
+      .mockResolvedValueOnce({ stdout: 'git version 2.0.0\n' })
+      .mockResolvedValueOnce({ stdout: 'gh version 2.0.0\n' })
+      .mockRejectedValueOnce({ stderr: 'You are not logged into any GitHub hosts.\n' })
+      .mockResolvedValueOnce({ stdout: 'git version 2.0.0\n' })
+      .mockResolvedValueOnce({ stdout: 'gh version 2.0.0\n' })
+      .mockResolvedValueOnce({ stdout: 'github.com\n  - Active account: true\n' })
+
+    const firstStatus = await runPreflightCheck()
+    const refreshedStatus = await runPreflightCheck(true)
+
+    expect(firstStatus.gh).toEqual({ installed: true, authenticated: false })
+    expect(refreshedStatus.gh).toEqual({ installed: true, authenticated: true })
+    expect(execFileAsyncMock).toHaveBeenCalledTimes(6)
+  })
+
+  it('registers the preflight handler', async () => {
+    execFileAsyncMock
+      .mockResolvedValueOnce({ stdout: 'git version 2.0.0\n' })
+      .mockResolvedValueOnce({ stdout: 'gh version 2.0.0\n' })
+      .mockResolvedValueOnce({ stdout: 'github.com\n' })
+
+    registerPreflightHandlers()
+
+    const status = await handlers['preflight:check']()
+
+    expect(status).toEqual({
+      git: { installed: true },
+      gh: { installed: true, authenticated: true }
+    })
+  })
+
+  it('lets the IPC handler bypass the session cache when forced', async () => {
+    execFileAsyncMock
+      .mockResolvedValueOnce({ stdout: 'git version 2.0.0\n' })
+      .mockResolvedValueOnce({ stdout: 'gh version 2.0.0\n' })
+      .mockRejectedValueOnce({ stderr: 'You are not logged into any GitHub hosts.\n' })
+      .mockResolvedValueOnce({ stdout: 'git version 2.0.0\n' })
+      .mockResolvedValueOnce({ stdout: 'gh version 2.0.0\n' })
+      .mockResolvedValueOnce({ stdout: 'github.com\n  - Active account: true\n' })
+
+    registerPreflightHandlers()
+
+    const firstStatus = await handlers['preflight:check']()
+    const refreshedStatus = await handlers['preflight:check'](null, { force: true })
+
+    expect(firstStatus).toEqual({
+      git: { installed: true },
+      gh: { installed: true, authenticated: false }
+    })
+    expect(refreshedStatus).toEqual({
+      git: { installed: true },
+      gh: { installed: true, authenticated: true }
+    })
+  })
+})

--- a/src/main/ipc/preflight.ts
+++ b/src/main/ipc/preflight.ts
@@ -32,14 +32,13 @@ async function isGhAuthenticated(): Promise<boolean> {
     await execFileAsync('gh', ['auth', 'status'], {
       encoding: 'utf-8'
     })
-    // Why: newer gh versions can change the human-readable wording, but a zero
-    // exit from `gh auth status` still means the CLI has a usable login.
+    // Why: for plain-text `gh auth status`, exit 0 means gh did not detect any
+    // authentication issues for the checked hosts/accounts.
     return true
   } catch (error) {
-    // Why: older gh builds wrote successful auth details to stderr, and some
-    // environments surface partial output on the thrown error object. Keep a
-    // compatibility fallback so we do not show a false "not authenticated"
-    // banner just because the text landed on an unexpected stream.
+    // Why: some environments may surface partial command output on the thrown
+    // error object. Keep a compatibility fallback so we avoid a false auth
+    // warning if success markers are present despite a non-zero result.
     const stdout = (error as { stdout?: string }).stdout ?? ''
     const stderr = (error as { stderr?: string }).stderr ?? ''
     const output = `${stdout}\n${stderr}`

--- a/src/main/ipc/preflight.ts
+++ b/src/main/ipc/preflight.ts
@@ -13,6 +13,11 @@ export type PreflightStatus = {
 // The check only runs once per app session — relaunch to re-check.
 let cached: PreflightStatus | null = null
 
+/** @internal - tests need a clean preflight cache between cases. */
+export function _resetPreflightCache(): void {
+  cached = null
+}
+
 async function isCommandAvailable(command: string): Promise<boolean> {
   try {
     await execFileAsync(command, ['--version'])
@@ -24,20 +29,26 @@ async function isCommandAvailable(command: string): Promise<boolean> {
 
 async function isGhAuthenticated(): Promise<boolean> {
   try {
-    const { stdout } = await execFileAsync('gh', ['auth', 'status'], {
+    await execFileAsync('gh', ['auth', 'status'], {
       encoding: 'utf-8'
     })
-    return stdout.includes('Logged in')
+    // Why: newer gh versions can change the human-readable wording, but a zero
+    // exit from `gh auth status` still means the CLI has a usable login.
+    return true
   } catch (error) {
-    // gh auth status writes to stderr and exits 1 when not authenticated,
-    // but also writes "Logged in" to stderr when authenticated on older versions.
+    // Why: older gh builds wrote successful auth details to stderr, and some
+    // environments surface partial output on the thrown error object. Keep a
+    // compatibility fallback so we do not show a false "not authenticated"
+    // banner just because the text landed on an unexpected stream.
+    const stdout = (error as { stdout?: string }).stdout ?? ''
     const stderr = (error as { stderr?: string }).stderr ?? ''
-    return stderr.includes('Logged in')
+    const output = `${stdout}\n${stderr}`
+    return output.includes('Logged in') || output.includes('Active account: true')
   }
 }
 
-async function runPreflightCheck(): Promise<PreflightStatus> {
-  if (cached) {
+export async function runPreflightCheck(force = false): Promise<PreflightStatus> {
+  if (cached && !force) {
     return cached
   }
 
@@ -57,7 +68,10 @@ async function runPreflightCheck(): Promise<PreflightStatus> {
 }
 
 export function registerPreflightHandlers(): void {
-  ipcMain.handle('preflight:check', async (): Promise<PreflightStatus> => {
-    return runPreflightCheck()
-  })
+  ipcMain.handle(
+    'preflight:check',
+    async (_event, args?: { force?: boolean }): Promise<PreflightStatus> => {
+      return runPreflightCheck(args?.force)
+    }
+  )
 }

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -259,7 +259,7 @@ type PreflightStatus = {
 }
 
 type PreflightApi = {
-  check: () => Promise<PreflightStatus>
+  check: (args?: { force?: boolean }) => Promise<PreflightStatus>
 }
 
 type StatsApi = {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -274,10 +274,12 @@ const api = {
   },
 
   preflight: {
-    check: (): Promise<{
+    check: (args?: {
+      force?: boolean
+    }): Promise<{
       git: { installed: boolean }
       gh: { installed: boolean; authenticated: boolean }
-    }> => ipcRenderer.invoke('preflight:check')
+    }> => ipcRenderer.invoke('preflight:check', args)
   },
 
   notifications: {

--- a/src/renderer/src/components/Landing.tsx
+++ b/src/renderer/src/components/Landing.tsx
@@ -19,6 +19,43 @@ type PreflightIssue = {
   fixUrl: string
 }
 
+function getPreflightIssues(status: {
+  git: { installed: boolean }
+  gh: { installed: boolean; authenticated: boolean }
+}): PreflightIssue[] {
+  const issues: PreflightIssue[] = []
+
+  if (!status.git.installed) {
+    issues.push({
+      id: 'git',
+      title: 'Git is not installed',
+      description: 'Git is required for Git repositories, source control, and worktree management.',
+      fixLabel: 'Install Git',
+      fixUrl: 'https://git-scm.com/downloads'
+    })
+  }
+
+  if (!status.gh.installed) {
+    issues.push({
+      id: 'gh',
+      title: 'GitHub CLI is not installed',
+      description: 'Orca uses the GitHub CLI (gh) to show pull requests, issues, and checks.',
+      fixLabel: 'Install GitHub CLI',
+      fixUrl: 'https://cli.github.com'
+    })
+  } else if (!status.gh.authenticated) {
+    issues.push({
+      id: 'gh-auth',
+      title: 'GitHub CLI is not authenticated',
+      description: 'Run "gh auth login" in a terminal to connect your GitHub account.',
+      fixLabel: 'Learn more',
+      fixUrl: 'https://cli.github.com/manual/gh_auth_login'
+    })
+  }
+
+  return issues
+}
+
 function KeyCap({ label }: { label: string }): React.JSX.Element {
   return (
     <span className="inline-flex min-w-6 items-center justify-center rounded border border-border/80 bg-secondary/70 px-1.5 py-0.5 text-[10px] font-semibold text-muted-foreground">
@@ -126,50 +163,50 @@ export default function Landing(): React.JSX.Element {
 
   useEffect(() => {
     let cancelled = false
+    const refreshPreflight = (force = false): void => {
+      void window.api.preflight.check(force ? { force: true } : undefined).then((status) => {
+        if (cancelled) {
+          return
+        }
+        setPreflightIssues(getPreflightIssues(status))
+      })
+    }
 
-    void window.api.preflight.check().then((status) => {
-      if (cancelled) {
-        return
+    refreshPreflight()
+
+    // Why: users often install/authenticate gh outside Orca. Re-check when the
+    // window becomes active again so the landing warning clears without relaunch.
+    const handleWindowActive = (): void => {
+      if (document.visibilityState === 'visible') {
+        refreshPreflight(true)
       }
+    }
 
-      const issues: PreflightIssue[] = []
-
-      if (!status.git.installed) {
-        issues.push({
-          id: 'git',
-          title: 'Git is not installed',
-          description:
-            'Git is required for Git repositories, source control, and worktree management.',
-          fixLabel: 'Install Git',
-          fixUrl: 'https://git-scm.com/downloads'
-        })
-      }
-
-      if (!status.gh.installed) {
-        issues.push({
-          id: 'gh',
-          title: 'GitHub CLI is not installed',
-          description: 'Orca uses the GitHub CLI (gh) to show pull requests, issues, and checks.',
-          fixLabel: 'Install GitHub CLI',
-          fixUrl: 'https://cli.github.com'
-        })
-      } else if (!status.gh.authenticated) {
-        issues.push({
-          id: 'gh-auth',
-          title: 'GitHub CLI is not authenticated',
-          description: 'Run "gh auth login" in a terminal to connect your GitHub account.',
-          fixLabel: 'Learn more',
-          fixUrl: 'https://cli.github.com/manual/gh_auth_login'
-        })
-      }
-
-      setPreflightIssues(issues)
-    })
+    document.addEventListener('visibilitychange', handleWindowActive)
+    window.addEventListener('focus', handleWindowActive)
 
     return () => {
       cancelled = true
+      document.removeEventListener('visibilitychange', handleWindowActive)
+      window.removeEventListener('focus', handleWindowActive)
     }
   }, [])
+
+  useEffect(() => {
+    if (preflightIssues.length === 0) {
+      return
+    }
+
+    // Why: some users complete `gh auth login` without ever leaving the Orca
+    // window. Poll only while a warning is visible so the banner self-clears.
+    const intervalId = window.setInterval(() => {
+      void window.api.preflight.check({ force: true }).then((status) => {
+        setPreflightIssues(getPreflightIssues(status))
+      })
+    }, 30000)
+
+    return () => window.clearInterval(intervalId)
+  }, [preflightIssues.length])
 
   const shortcuts = useMemo<ShortcutItem[]>(
     () => [


### PR DESCRIPTION
## Problem
Users could see a false "GitHub CLI is not authenticated" warning on the landing page because the preflight auth probe depended on matching specific `gh auth status` text, and the result was cached for the rest of the app session. If the warning appeared and the user then ran `gh auth login`, Orca would keep showing the stale warning until restart.

## Solution
Treat a successful `gh auth status` exit as authenticated, keep a compatibility fallback for older stderr-based output, and add a forced preflight refresh path through IPC/preload. Update the landing page to re-check preflight when the window becomes active again and poll every 30 seconds only while a preflight warning is visible, so the banner can clear without relaunch.

## Testing
Unable to run `pnpm test -- src/main/ipc/preflight.test.ts` in this worktree because `node_modules` is missing and `vitest` is not installed locally.