### PR TITLE
fix: debounce sidebar sort and refresh activity on comment edit

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -15,6 +15,11 @@ import { computeVisibleWorktreeIds, setVisibleWorktreeIds } from './visible-work
 import { estimateRowHeight } from './worktree-list-estimate'
 import { useModifierHint } from '@/hooks/useModifierHint'
 
+// How long to wait after a sortEpoch bump before actually re-sorting.
+// Prevents jarring position shifts when background events (AI starting work,
+// terminal title changes) trigger score recalculations.
+const SORT_SETTLE_MS = 3_000
+
 const WorktreeList = React.memo(function WorktreeList() {
   // ── Granular selectors (each is a primitive or shallow-stable ref) ──
   const worktreesByRepo = useAppStore((s) => s.worktreesByRepo)
@@ -47,6 +52,52 @@ const WorktreeList = React.memo(function WorktreeList() {
   const issueCache = useAppStore((s) => (searchQuery ? s.issueCache : null))
 
   const sortEpoch = useAppStore((s) => s.sortEpoch)
+
+  // Count of non-archived worktrees — used to detect structural changes
+  // (add/remove) vs. pure reorders (score shifts) so the debounce below
+  // can apply immediately when the list shape changes.
+  const worktreeCount = useMemo(() => {
+    let count = 0
+    for (const ws of Object.values(worktreesByRepo)) {
+      for (const w of ws) {
+        if (!w.isArchived) {
+          count++
+        }
+      }
+    }
+    return count
+  }, [worktreesByRepo])
+
+  // Why debounce: sort scores include a time-decaying activity component.
+  // Recomputing instantly on every sortEpoch bump (e.g. AI starting work,
+  // terminal title changes) recalculates all scores with a fresh `now`,
+  // causing worktrees to visibly jump even when the triggering event isn't
+  // about the worktree the user is looking at.  Settling for a few seconds
+  // lets rapid-fire events coalesce and prevents mid-interaction surprises.
+  //
+  // However, structural changes (worktree created or removed) must apply
+  // immediately — a new worktree should appear at its correct sorted
+  // position, not at the bottom for 3 seconds.
+  const [debouncedSortEpoch, setDebouncedSortEpoch] = useState(sortEpoch)
+  const prevWorktreeCountRef = useRef(worktreeCount)
+  useEffect(() => {
+    if (debouncedSortEpoch === sortEpoch) {
+      return
+    }
+
+    // Detect add/remove by comparing worktree count.
+    const structuralChange = worktreeCount !== prevWorktreeCountRef.current
+    prevWorktreeCountRef.current = worktreeCount
+
+    if (structuralChange) {
+      setDebouncedSortEpoch(sortEpoch)
+      return
+    }
+
+    const timer = setTimeout(() => setDebouncedSortEpoch(sortEpoch), SORT_SETTLE_MS)
+    return () => clearTimeout(timer)
+  }, [sortEpoch, debouncedSortEpoch, worktreeCount])
+
   const scrollRef = useRef<HTMLDivElement>(null)
   // Why a latching ref: we need to distinguish "app just started, no PTYs
   // have spawned yet" from "user closed all terminals mid-session." The
@@ -108,10 +159,11 @@ const WorktreeList = React.memo(function WorktreeList() {
       buildWorktreeComparator(sortBy, currentTabs, currentRepoMap, state.prCache, Date.now())
     )
     return allWorktrees.map((w) => w.id)
-    // sortEpoch is an intentional trigger: it's not read inside the memo, but
-    // its change signals that the sort order should be recomputed.
+    // debouncedSortEpoch is an intentional trigger: it's not read inside the
+    // memo, but its change signals that the sort order should be recomputed.
+    // The debounce prevents jarring mid-interaction position shifts.
     // oxlint-disable-next-line react-hooks/exhaustive-deps
-  }, [sortEpoch, sortBy, repos])
+  }, [debouncedSortEpoch, sortBy, repos])
 
   // Persist the computed sort order so the sidebar can be restored after
   // restart. Only persist during live sessions (sessionHasHadPty latched) —

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -186,15 +186,22 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
   },
 
   updateWorktreeMeta: async (worktreeId, updates) => {
+    // Why: editing a comment is meaningful interaction with the worktree.
+    // Without refreshing lastActivityAt, the time-decay score has decayed
+    // since the previous sort, so a re-sort causes the worktree to drop in
+    // ranking even though the user just touched it. Bumping the timestamp
+    // keeps the recency signal fresh so the worktree holds its position.
+    const enriched = 'comment' in updates ? { ...updates, lastActivityAt: Date.now() } : updates
+
     set((s) => {
-      const nextWorktrees = applyWorktreeUpdates(s.worktreesByRepo, worktreeId, updates)
+      const nextWorktrees = applyWorktreeUpdates(s.worktreesByRepo, worktreeId, enriched)
       return nextWorktrees === s.worktreesByRepo
         ? {}
         : { worktreesByRepo: nextWorktrees, sortEpoch: s.sortEpoch + 1 }
     })
 
     try {
-      await window.api.worktrees.updateMeta({ worktreeId, updates })
+      await window.api.worktrees.updateMeta({ worktreeId, updates: enriched })
     } catch (err) {
       console.error('Failed to update worktree meta:', err)
       void get().fetchWorktrees(getRepoIdFromWorktreeId(worktreeId))


### PR DESCRIPTION
## Summary
- Debounce sort-epoch changes by 3 seconds before re-sorting the sidebar, preventing jarring position shifts from background events (AI starting work, terminal title changes)
- Structural changes (worktree added/removed) bypass the debounce and apply immediately
- Comment edits now bump `lastActivityAt` so the worktree holds its ranking instead of dropping due to decayed recency

## Test plan
- [x] All 678 unit tests pass (84 test files)
- [ ] Edit a worktree comment and verify the worktree doesn't jump position
- [ ] Start AI work on a worktree and verify the sidebar doesn't immediately reshuffle
- [ ] Create a new worktree and verify it appears at the correct position immediately (no 3s delay)