### PR TITLE
fix: preserve file explorer scroll position on tree refresh

### DIFF
--- a/src/renderer/src/components/right-sidebar/useFileExplorerTree.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerTree.ts
@@ -31,10 +31,14 @@ export function useFileExplorerTree(
       if (!options?.force && (cache[dirPath]?.children.length > 0 || cache[dirPath]?.loading)) {
         return
       }
+      // Why: when force-reloading a directory (e.g. after a file is created,
+      // duplicated, or deleted), keep the previous children visible while the
+      // fresh listing loads. Clearing to [] would momentarily shrink flatRows,
+      // causing the virtualizer to lose scroll position and jump to the top.
       setDirCache((prev) => ({
         ...prev,
         [dirPath]: {
-          children: options?.force ? [] : (prev[dirPath]?.children ?? []),
+          children: prev[dirPath]?.children ?? [],
           loading: true
         }
       }))
@@ -73,7 +77,10 @@ export function useFileExplorerTree(
     if (!worktreePath) {
       return
     }
-    setDirCache({})
+    // Why: clearing the entire dirCache here would momentarily empty flatRows,
+    // causing the virtualizer scroll position to jump to the top. Instead we
+    // rely on the force-reload inside loadDir which keeps existing children
+    // visible until the fresh listing arrives.
     await loadDir(worktreePath, -1, { force: true })
     await Promise.all(
       Array.from(expanded).map(async (dirPath) => {


### PR DESCRIPTION
## Summary
- Keep existing `dirCache` children visible during force-reload instead of clearing to `[]`, preventing the virtualizer from losing scroll position and jumping to the top
- Remove the `setDirCache({})` call in `refreshTree` for the same reason — rely on per-directory force-reload to overwrite entries individually
- Add comments explaining why stale children are intentionally preserved during reload

## Test plan
- [ ] Create/duplicate/delete a file in the file explorer while scrolled down — tree should not jump to top
- [ ] Switch worktrees — tree should still reset and show new worktree content correctly (`resetAndLoad` is unchanged)
- [ ] Expand nested directories, trigger a refresh, verify expanded dirs reload correctly