### PR TITLE
Revert "feat: display worktree comments with line wrapping"

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -437,10 +437,8 @@ const WorktreeCard = React.memo(function WorktreeCard({
 
           {/* Meta section: Issue / PR Links / Comment
              ⚠ Layout coupling: the padding (py-0.5, mt-0.5), gap-[3px], and
-             line heights here are used to derive the size estimates in
-             WorktreeList's estimateSize. The comment row's estimate is
-             dynamic (based on content length + newlines). Update the
-             estimate function if changing spacing or line-height. */}
+             line heights here are used to derive the pixel constants in
+             WorktreeList's estimateSize. Update both if changing spacing. */}
           {((cardProps.includes('issue') && issue) ||
             (cardProps.includes('pr') && pr) ||
             (cardProps.includes('comment') && worktree.comment)) && (
@@ -558,12 +556,19 @@ const WorktreeCard = React.memo(function WorktreeCard({
               )}
 
               {cardProps.includes('comment') && worktree.comment && (
-                <div
-                  className="text-[11px] text-muted-foreground whitespace-pre-wrap break-words cursor-pointer -mx-1.5 px-1.5 py-0.5 hover:bg-background/40 hover:text-foreground rounded transition-colors leading-normal"
-                  onClick={handleEditComment}
-                >
-                  {worktree.comment}
-                </div>
+                <HoverCard openDelay={300}>
+                  <HoverCardTrigger asChild>
+                    <div
+                      className="text-[11px] text-muted-foreground truncate cursor-pointer -mx-1.5 px-1.5 py-0.5 hover:bg-background/40 hover:text-foreground rounded transition-colors leading-none"
+                      onClick={handleEditComment}
+                    >
+                      {worktree.comment}
+                    </div>
+                  </HoverCardTrigger>
+                  <HoverCardContent side="right" align="start" className="w-64 p-3 text-xs">
+                    <p className="whitespace-pre-wrap">{worktree.comment}</p>
+                  </HoverCardContent>
+                </HoverCard>
               )}
             </div>
           )}

--- a/src/renderer/src/components/sidebar/worktree-list-estimate.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-estimate.test.ts
@@ -84,27 +84,11 @@ describe('estimateRowHeight', () => {
     expect(estimateRowHeight(itemRow(worktree), ['pr'], repoMap, prCache)).toBe(52)
   })
 
-  it('estimates comment height based on content length', () => {
+  it('adds 22px for comment row', () => {
     const wt = { ...worktree, comment: 'todo: fix bug' }
     const base = estimateRowHeight(itemRow(worktree), ['comment'], repoMap, null)
     const withComment = estimateRowHeight(itemRow(wt), ['comment'], repoMap, null)
-    // 1 line × 17px + 4px padding + 2px mt-0.5 = 23
-    expect(withComment - base).toBe(23)
-  })
-
-  it('estimates multi-line comment height from newlines', () => {
-    const wt = { ...worktree, comment: 'first line\nsecond line\nthird line' }
-    const h = estimateRowHeight(itemRow(wt), ['comment'], repoMap, null)
-    // ceil(3 × 16.5) + 4px padding = 54, total = 52 + 54 + 2 = 108
-    expect(h).toBe(108)
-  })
-
-  it('estimates wrapped long lines in comment', () => {
-    // 70 chars wraps to 2 lines at ~35 chars/line
-    const wt = { ...worktree, comment: 'a'.repeat(70) }
-    const h = estimateRowHeight(itemRow(wt), ['comment'], repoMap, null)
-    // ceil(2 × 16.5) + 4 = 37, total = 52 + 37 + 2 = 91
-    expect(h).toBe(91)
+    expect(withComment - base).toBe(24) // 22px line + 2px mt-0.5
   })
 
   it('stacks all metadata lines correctly', () => {
@@ -113,9 +97,9 @@ describe('estimateRowHeight', () => {
       '/tmp/orca::feature/cool': { data: { number: 1 } }
     }
     const h = estimateRowHeight(itemRow(wt), ['issue', 'pr', 'comment'], repoMap, prCache)
-    // 52 base + 22 issue + 22 pr + (1×17+4) comment + 2 mt-0.5 = 119
+    // 52 base + 22 issue + 22 pr + 22 comment + 2 mt-0.5 = 120
     // (inter-card gap is handled by the virtualizer's `gap` option, not here)
-    expect(h).toBe(119)
+    expect(h).toBe(120)
   })
 
   it('strips refs/heads/ prefix when building PR cache key', () => {

--- a/src/renderer/src/components/sidebar/worktree-list-estimate.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-estimate.ts
@@ -2,11 +2,9 @@ import type { Repo } from '../../../../shared/types'
 import type { Row } from './worktree-list-groups'
 
 // Estimate the pixel height of a virtualizer row based on which metadata lines
-// will render. Fixed-height rows (base 52, issue/PR 22, mt-0.5 2) are coupled
-// to WorktreeCard's Tailwind classes; the comment row uses a dynamic estimate
-// because it renders with whitespace-pre-wrap.  See the coupling comment in
-// WorktreeCard's meta section.  The inter-card gap is handled by the
-// virtualizer's `gap` option, not here.
+// will render. Pixel constants (52, 22, 2) are coupled to WorktreeCard's
+// Tailwind classes — see the coupling comment in WorktreeCard's meta section.
+// The inter-card gap is handled by the virtualizer's `gap` option, not here.
 //
 // Uses prCache (not wt.linkedPR) because prCache is the actual data source
 // WorktreeCard checks when deciding to show the PR row.
@@ -33,16 +31,7 @@ export function estimateRowHeight(
     }
   }
   if (cardProps.includes('comment') && wt.comment) {
-    // Comment now renders with whitespace-pre-wrap + break-words, so its
-    // height depends on content.  Estimate visual lines from explicit newlines
-    // and character wrapping (~35 chars per line at typical sidebar width).
-    // Line-height is leading-normal (1.5 × 11px = 16.5px) + 4px padding (py-0.5).
-    const lines = wt.comment.split('\n')
-    let totalLines = 0
-    for (const line of lines) {
-      totalLines += Math.max(1, Math.ceil(line.length / 35))
-    }
-    h += Math.ceil(totalLines * 16.5) + 4
+    h += 22
   }
   if (h > 52) {
     h += 2


### PR DESCRIPTION
Reverts stablyai/orca#431
It introduced some regression on the gaps between worktree.  