### PR TITLE
Fix titlebar sidebar controls

### DIFF
--- a/src/main/browser/browser-manager.test.ts
+++ b/src/main/browser/browser-manager.test.ts
@@ -34,6 +34,8 @@ vi.mock('electron', () => ({
 import { browserManager } from './browser-manager'
 
 describe('browserManager', () => {
+  const rendererWebContentsId = 5001
+
   beforeEach(() => {
     shellOpenExternalMock.mockReset()
     menuBuildFromTemplateMock.mockReset()
@@ -109,9 +111,20 @@ describe('browserManager', () => {
     webContentsFromIdMock.mockReturnValue(guest)
 
     browserManager.attachGuestPolicies(guest as never)
-    browserManager.registerGuest({ browserTabId: 'browser-1', webContentsId: 101 })
+    browserManager.registerGuest({
+      browserTabId: 'browser-1',
+      webContentsId: 101,
+      // Why: registrations now record which renderer owns each guest so main
+      // can route load failures back to the correct window instead of dropping
+      // them once multiple renderers exist.
+      rendererWebContentsId
+    })
     browserManager.attachGuestPolicies({ ...guest, id: 102 } as never)
-    browserManager.registerGuest({ browserTabId: 'browser-2', webContentsId: 102 })
+    browserManager.registerGuest({
+      browserTabId: 'browser-2',
+      webContentsId: 102,
+      rendererWebContentsId
+    })
 
     browserManager.unregisterAll()
 
@@ -135,7 +148,11 @@ describe('browserManager', () => {
     }
     webContentsFromIdMock.mockReturnValue(mainWindowContents)
 
-    browserManager.registerGuest({ browserTabId: 'browser-evil', webContentsId: 1 })
+    browserManager.registerGuest({
+      browserTabId: 'browser-evil',
+      webContentsId: 1,
+      rendererWebContentsId
+    })
 
     // The guest should NOT be registered
     expect(browserManager.getGuestWebContentsId('browser-evil')).toBeNull()
@@ -156,7 +173,11 @@ describe('browserManager', () => {
     }
     webContentsFromIdMock.mockReturnValue(guest)
 
-    browserManager.registerGuest({ browserTabId: 'browser-1', webContentsId: 777 })
+    browserManager.registerGuest({
+      browserTabId: 'browser-1',
+      webContentsId: 777,
+      rendererWebContentsId
+    })
 
     expect(browserManager.getGuestWebContentsId('browser-1')).toBeNull()
     expect(menuBuildFromTemplateMock).not.toHaveBeenCalled()

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -7,6 +7,7 @@ import { Minimize2, PanelLeft, PanelRight } from 'lucide-react'
 import { TOGGLE_TERMINAL_PANE_EXPAND_EVENT } from '@/constants/terminal'
 import { syncZoomCSSVar } from '@/lib/ui-zoom'
 import { Toaster } from '@/components/ui/sonner'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { useAppStore } from './store'
 import { useIpcEvents } from './hooks/useIpcEvents'
 import Sidebar from './components/Sidebar'
@@ -564,54 +565,79 @@ function App(): React.JSX.Element {
 
   return (
     <div className="flex flex-col h-screen w-screen overflow-hidden">
-      <div className="titlebar">
-        {/* Why: the left section of the titlebar matches the sidebar width so
-            tabs start exactly where the sidebar ends, creating a clean vertical
-            alignment between the sidebar edge and the first tab. */}
-        <div
-          className="flex items-center shrink-0 overflow-hidden"
-          style={{ width: showSidebar && sidebarOpen ? sidebarWidth : undefined }}
-        >
-          <div className={isMac && !isFullScreen ? 'titlebar-traffic-light-pad' : 'pl-2'} />
-          <button
-            className="sidebar-toggle"
-            onClick={toggleSidebar}
-            title={showSidebar ? 'Toggle sidebar' : 'Sidebar unavailable in settings'}
-            aria-label={showSidebar ? 'Toggle sidebar' : 'Sidebar unavailable in settings'}
-            disabled={!showSidebar}
+      <TooltipProvider delayDuration={400}>
+        <div className="titlebar">
+          {/* Why: the left section of the titlebar matches the sidebar width so
+              tabs start exactly where the sidebar ends, creating a clean vertical
+              alignment between the sidebar edge and the first tab. */}
+          <div
+            className="flex items-center shrink-0 overflow-hidden"
+            style={{ width: showSidebar && sidebarOpen ? sidebarWidth : undefined }}
           >
-            <PanelLeft size={16} />
-          </button>
-          <div className="titlebar-title">Orca</div>
+            <div className={isMac && !isFullScreen ? 'titlebar-traffic-light-pad' : 'pl-2'} />
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  className="sidebar-toggle"
+                  onClick={toggleSidebar}
+                  aria-label={showSidebar ? 'Toggle sidebar' : 'Sidebar unavailable in settings'}
+                  disabled={!showSidebar}
+                >
+                  <PanelLeft size={16} />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom" sideOffset={6}>
+                {showSidebar
+                  ? `Toggle sidebar (${isMac ? '⌘B' : 'Ctrl+B'})`
+                  : 'Sidebar unavailable in settings'}
+              </TooltipContent>
+            </Tooltip>
+            <div className="titlebar-title">Orca</div>
+          </div>
+          {/* Why: keep the center titlebar slot mounted even when tabs are hidden.
+              Using `hidden` here collapsed the spacer entirely, which let the
+              right-sidebar toggle slide left in the no-tabs empty state. `invisible`
+              still suppresses any stale portal content without breaking the far-right
+              titlebar alignment. */}
+          <div
+            id="titlebar-tabs"
+            className={`flex flex-1 min-w-0 self-stretch${activeView === 'settings' || !activeWorktreeId ? ' invisible pointer-events-none' : ''}`}
+          />
+          {showTitlebarExpandButton && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  className="titlebar-icon-button"
+                  onClick={handleToggleExpand}
+                  aria-label="Collapse pane"
+                  disabled={!activeTabCanExpand}
+                >
+                  <Minimize2 size={14} />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom" sideOffset={6}>
+                Collapse pane
+              </TooltipContent>
+            </Tooltip>
+          )}
+          {showSidebar ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  className="sidebar-toggle mr-2"
+                  onClick={toggleRightSidebar}
+                  aria-label="Toggle right sidebar"
+                >
+                  <PanelRight size={16} />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom" sideOffset={6}>
+                {`Toggle right sidebar (${isMac ? '⌘L' : 'Ctrl+L'})`}
+              </TooltipContent>
+            </Tooltip>
+          ) : null}
         </div>
-        {/* Why: portal target for the TabBar rendered by Terminal.tsx.
-            Hidden when tabs should not be visible (settings view, no active worktree)
-            so the portal content does not leak through. */}
-        <div
-          id="titlebar-tabs"
-          className={`flex flex-1 min-w-0 self-stretch${activeView === 'settings' || !activeWorktreeId ? ' hidden' : ''}`}
-        />
-        {showTitlebarExpandButton && (
-          <button
-            className="titlebar-icon-button"
-            onClick={handleToggleExpand}
-            title="Collapse pane"
-            aria-label="Collapse pane"
-            disabled={!activeTabCanExpand}
-          >
-            <Minimize2 size={14} />
-          </button>
-        )}
-        <button
-          className="sidebar-toggle mr-2"
-          onClick={toggleRightSidebar}
-          title={`Toggle right sidebar (${isMac ? '⌘L' : 'Ctrl+L'})`}
-          aria-label="Toggle right sidebar"
-          disabled={!showSidebar}
-        >
-          <PanelRight size={16} />
-        </button>
-      </div>
+      </TooltipProvider>
       <div className="flex flex-row flex-1 min-h-0 overflow-hidden">
         {showSidebar ? <Sidebar /> : null}
         <div className="relative flex flex-1 min-w-0 min-h-0 overflow-hidden">


### PR DESCRIPTION
## Problem
The titlebar sidebar controls had a few regressions in Orca's renderer shell.

- The right sidebar toggle drifted left when the app opened without any tabs because the hidden tab portal also removed the titlebar spacer.
- The right sidebar toggle still appeared in the settings view even though the sidebar is unavailable there.
- The left and right titlebar collapse controls used native `title` tooltips instead of the shared Radix tooltip treatment used by sidebar buttons.

## Solution
Update `App.tsx` so the hidden titlebar tab slot remains mounted as an invisible spacer, which keeps the right sidebar toggle anchored to the far edge in the empty state. Hide the right sidebar toggle entirely in settings, and wrap the titlebar sidebar controls in the shared tooltip primitives while preserving the original button sizing and existing keyboard shortcut labels.
