### PR TITLE
Add Cmd+G / Cmd+Shift+G terminal search navigation

### DIFF
--- a/docs/superpowers/plans/2026-04-10-terminal-search-shortcuts.md
+++ b/docs/superpowers/plans/2026-04-10-terminal-search-shortcuts.md
@@ -200,7 +200,7 @@ Insert this block in `onKeyDown` right after the `if (e.repeat) return` check (l
       }
 ```
 
-Note: this block accesses `manager` which is declared further down. Move the `const manager = managerRef.current; if (!manager) return` check above the `isEditableTarget` guard as well, so the search handler can reference it. The full reordering inside `onKeyDown` becomes:
+Note: this block accesses `manager` which is declared further down. Move the `const manager = managerRef.current; if (!manager) return` check above the `isEditableTarget` guard as well, so the search handler can reference it. This reorder is safe — the code between the old `manager` position and `isEditableTarget` only computes `mod` and checks `altKey`, neither of which references `manager`. The minor behavioral change is that `!manager` now short-circuits before `isEditableTarget` runs, which is harmless (no manager means no terminal to handle shortcuts for). The full reordering inside `onKeyDown` becomes:
 
 ```
 if (e.repeat) return
@@ -265,70 +265,17 @@ git commit -m "feat: add Cmd+G / Cmd+Shift+G search navigation to keyboard handl
 
 ---
 
-### Task 3: Sync search state from `TerminalSearch` into the ref
+### Task 3: Wire `searchStateRef` through `TerminalPane`, `TerminalSearch`, and sync it
 
-**Files:**
-- Modify: `src/renderer/src/components/TerminalSearch.tsx`
-
-- [ ] **Step 1: Add `searchStateRef` prop to the component**
-
-Update the props type and destructuring:
-
-```ts
-type TerminalSearchProps = {
-  isOpen: boolean
-  onClose: () => void
-  searchAddon: SearchAddon | null
-  searchStateRef: React.MutableRefObject<{ query: string; caseSensitive: boolean; regex: boolean }>
-}
-
-export default function TerminalSearch({
-  isOpen,
-  onClose,
-  searchAddon,
-  searchStateRef
-}: TerminalSearchProps): React.JSX.Element | null {
-```
-
-- [ ] **Step 2: Sync the ref inside the existing incremental-search `useEffect`**
-
-The existing `useEffect` (lines 47–55) already runs whenever `query`, `caseSensitive`, or `regex` change. Add the ref sync at the top, before the early return on empty query:
-
-```ts
-  useEffect(() => {
-    // Keep the ref in sync so the keyboard handler (Cmd+G / Cmd+Shift+G)
-    // can read the current search state without lifting it to parent state.
-    searchStateRef.current = { query, caseSensitive, regex }
-
-    if (!query) {
-      searchAddon?.clearDecorations()
-      return
-    }
-    if (searchAddon && isOpen) {
-      searchAddon.findNext(query, { caseSensitive, regex, incremental: true })
-    }
-  }, [query, searchAddon, isOpen, caseSensitive, regex, searchStateRef])
-```
-
-Note: `searchStateRef` is added to the dependency array to satisfy the linter, though as a ref it never changes identity.
-
-- [ ] **Step 3: Commit**
-
-```bash
-git add src/renderer/src/components/TerminalSearch.tsx
-git commit -m "feat: sync search state into ref for keyboard handler access"
-```
-
----
-
-### Task 4: Wire `searchStateRef` through `TerminalPane`
+Tasks 3 modifies both `TerminalPane.tsx` and `TerminalSearch.tsx` together because `searchStateRef` is a required prop — modifying them separately would break TypeScript compilation between commits.
 
 **Files:**
 - Modify: `src/renderer/src/components/terminal-pane/TerminalPane.tsx`
+- Modify: `src/renderer/src/components/TerminalSearch.tsx`
 
-- [ ] **Step 1: Import `SearchState` and create the ref**
+- [ ] **Step 1: Import `SearchState` and create the ref in `TerminalPane`**
 
-Add the import at the top of the file alongside the existing `keyboard-handlers` import:
+Add the import at the top of `TerminalPane.tsx` alongside the existing `keyboard-handlers` import:
 
 ```ts
 import { useTerminalKeyboardShortcuts } from './keyboard-handlers'
@@ -381,21 +328,63 @@ Update the `TerminalSearch` JSX (around line 567) to include the new prop:
           />,
 ```
 
-- [ ] **Step 4: Run the full test suite to verify nothing is broken**
+- [ ] **Step 4: Add `searchStateRef` prop to `TerminalSearch`**
+
+In `TerminalSearch.tsx`, update the props type and destructuring:
+
+```ts
+type TerminalSearchProps = {
+  isOpen: boolean
+  onClose: () => void
+  searchAddon: SearchAddon | null
+  searchStateRef: React.MutableRefObject<{ query: string; caseSensitive: boolean; regex: boolean }>
+}
+
+export default function TerminalSearch({
+  isOpen,
+  onClose,
+  searchAddon,
+  searchStateRef
+}: TerminalSearchProps): React.JSX.Element | null {
+```
+
+- [ ] **Step 5: Sync the ref inside the existing incremental-search `useEffect`**
+
+The existing `useEffect` (lines 47–55) already runs whenever `query`, `caseSensitive`, or `regex` change. Add the ref sync at the top, before the early return on empty query. This ensures the ref stays in sync even when the query is cleared (so it reflects the true current state):
+
+```ts
+  useEffect(() => {
+    // Keep the ref in sync so the keyboard handler (Cmd+G / Cmd+Shift+G)
+    // can read the current search state without lifting it to parent state.
+    searchStateRef.current = { query, caseSensitive, regex }
+
+    if (!query) {
+      searchAddon?.clearDecorations()
+      return
+    }
+    if (searchAddon && isOpen) {
+      searchAddon.findNext(query, { caseSensitive, regex, incremental: true })
+    }
+  }, [query, searchAddon, isOpen, caseSensitive, regex, searchStateRef])
+```
+
+Note: `searchStateRef` is added to the dependency array to satisfy the linter, though as a ref it never changes identity.
+
+- [ ] **Step 6: Run the full test suite to verify nothing is broken**
 
 Run: `pnpm test`
 Expected: All tests pass (no regressions)
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 7: Commit**
 
 ```bash
-git add src/renderer/src/components/terminal-pane/TerminalPane.tsx
-git commit -m "feat: wire searchStateRef through TerminalPane to search and keyboard handler"
+git add src/renderer/src/components/terminal-pane/TerminalPane.tsx src/renderer/src/components/TerminalSearch.tsx
+git commit -m "feat: wire searchStateRef through TerminalPane and TerminalSearch"
 ```
 
 ---
 
-### Task 5: TypeScript build verification
+### Task 4: TypeScript build verification
 
 **Files:** None (verification only)
 

--- a/docs/superpowers/plans/2026-04-10-terminal-search-shortcuts.md
+++ b/docs/superpowers/plans/2026-04-10-terminal-search-shortcuts.md
@@ -330,14 +330,20 @@ Update the `TerminalSearch` JSX (around line 567) to include the new prop:
 
 - [ ] **Step 4: Add `searchStateRef` prop to `TerminalSearch`**
 
-In `TerminalSearch.tsx`, update the props type and destructuring:
+In `TerminalSearch.tsx`, import the `SearchState` type from `keyboard-handlers` and use it in the props type. This keeps the type definition in one place so it can't silently diverge:
+
+```ts
+import type { SearchState } from '@/components/terminal-pane/keyboard-handlers'
+```
+
+Then update the props type and destructuring:
 
 ```ts
 type TerminalSearchProps = {
   isOpen: boolean
   onClose: () => void
   searchAddon: SearchAddon | null
-  searchStateRef: React.MutableRefObject<{ query: string; caseSensitive: boolean; regex: boolean }>
+  searchStateRef: React.MutableRefObject<SearchState>
 }
 
 export default function TerminalSearch({

--- a/docs/superpowers/plans/2026-04-10-terminal-search-shortcuts.md
+++ b/docs/superpowers/plans/2026-04-10-terminal-search-shortcuts.md
@@ -1,0 +1,413 @@
+# Terminal Search Next/Previous Shortcuts — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `Cmd+G` / `Cmd+Shift+G` shortcuts to navigate terminal search matches when the search bar is open.
+
+**Architecture:** A `searchStateRef` bridges the search query/options from `TerminalSearch` (which owns the state) to `keyboard-handlers.ts` (which handles the shortcut). The `Cmd+G` handler is placed before the `isEditableTarget` guard so it works even when focus is in the search input.
+
+**Tech Stack:** React, TypeScript, xterm.js (`@xterm/addon-search`), Vitest
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `src/renderer/src/components/terminal-pane/keyboard-handlers.ts` | Modify | Add `Cmd+G` / `Cmd+Shift+G` handler |
+| `src/renderer/src/components/TerminalSearch.tsx` | Modify | Accept and sync `searchStateRef` |
+| `src/renderer/src/components/terminal-pane/TerminalPane.tsx` | Modify | Create and wire `searchStateRef` |
+| `src/renderer/src/components/terminal-pane/keyboard-handlers.test.ts` | Create | Test the new shortcut handler logic |
+
+---
+
+### Task 1: Extract and test the `Cmd+G` / `Cmd+Shift+G` key-matching logic
+
+The keyboard handler uses a capture-phase `window` listener with DOM dependencies (`e.target`, `pane.terminal.focus()`). Rather than mocking all of that, we test the **decision logic** in isolation: given a key event shape + search state, should the handler fire findNext, findPrevious, or do nothing?
+
+**Files:**
+- Create: `src/renderer/src/components/terminal-pane/keyboard-handlers.test.ts`
+
+- [ ] **Step 1: Write failing tests for the search-navigate decision logic**
+
+We'll test a pure helper function `matchSearchNavigate` that we'll extract in Task 2. For now, write the tests against the expected interface.
+
+```ts
+// src/renderer/src/components/terminal-pane/keyboard-handlers.test.ts
+import { describe, it, expect } from 'vitest'
+import { matchSearchNavigate } from './keyboard-handlers'
+
+function makeKeyEvent(overrides: Partial<{
+  key: string
+  metaKey: boolean
+  ctrlKey: boolean
+  shiftKey: boolean
+  altKey: boolean
+}>): Pick<KeyboardEvent, 'key' | 'metaKey' | 'ctrlKey' | 'shiftKey' | 'altKey'> {
+  return {
+    key: 'g',
+    metaKey: false,
+    ctrlKey: false,
+    shiftKey: false,
+    altKey: false,
+    ...overrides
+  }
+}
+
+describe('matchSearchNavigate', () => {
+  const isMac = true
+  const searchState = { query: 'hello', caseSensitive: false, regex: false }
+
+  it('returns "next" for Cmd+G on macOS', () => {
+    const e = makeKeyEvent({ metaKey: true })
+    expect(matchSearchNavigate(e, isMac, true, searchState)).toBe('next')
+  })
+
+  it('returns "previous" for Cmd+Shift+G on macOS', () => {
+    const e = makeKeyEvent({ metaKey: true, shiftKey: true })
+    expect(matchSearchNavigate(e, isMac, true, searchState)).toBe('previous')
+  })
+
+  it('returns null when search is closed', () => {
+    const e = makeKeyEvent({ metaKey: true })
+    expect(matchSearchNavigate(e, isMac, false, searchState)).toBeNull()
+  })
+
+  it('returns null when query is empty', () => {
+    const e = makeKeyEvent({ metaKey: true })
+    expect(matchSearchNavigate(e, isMac, true, { query: '', caseSensitive: false, regex: false })).toBeNull()
+  })
+
+  it('returns null for wrong key', () => {
+    const e = makeKeyEvent({ metaKey: true, key: 'f' })
+    expect(matchSearchNavigate(e, isMac, true, searchState)).toBeNull()
+  })
+
+  it('returns null when alt is pressed', () => {
+    const e = makeKeyEvent({ metaKey: true, altKey: true })
+    expect(matchSearchNavigate(e, isMac, true, searchState)).toBeNull()
+  })
+
+  it('returns "next" for Ctrl+G on Linux/Windows', () => {
+    const e = makeKeyEvent({ ctrlKey: true })
+    expect(matchSearchNavigate(e, false, true, searchState)).toBe('next')
+  })
+
+  it('returns null for Ctrl+G on macOS (wrong modifier)', () => {
+    const e = makeKeyEvent({ ctrlKey: true })
+    expect(matchSearchNavigate(e, true, true, searchState)).toBeNull()
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm test -- src/renderer/src/components/terminal-pane/keyboard-handlers.test.ts`
+Expected: FAIL — `matchSearchNavigate` is not exported from `keyboard-handlers`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/renderer/src/components/terminal-pane/keyboard-handlers.test.ts
+git commit -m "test: add failing tests for search-navigate key matching"
+```
+
+---
+
+### Task 2: Implement `matchSearchNavigate` and wire it into the keyboard handler
+
+**Files:**
+- Modify: `src/renderer/src/components/terminal-pane/keyboard-handlers.ts`
+
+- [ ] **Step 1: Add the `SearchState` type and `matchSearchNavigate` function**
+
+Add this above the `useTerminalKeyboardShortcuts` function:
+
+```ts
+export type SearchState = {
+  query: string
+  caseSensitive: boolean
+  regex: boolean
+}
+
+/**
+ * Pure decision function for Cmd+G / Cmd+Shift+G search navigation.
+ * Returns 'next', 'previous', or null (no match).
+ * Extracted so the key-matching logic is testable without DOM dependencies.
+ */
+export function matchSearchNavigate(
+  e: Pick<KeyboardEvent, 'key' | 'metaKey' | 'ctrlKey' | 'shiftKey' | 'altKey'>,
+  isMac: boolean,
+  searchOpen: boolean,
+  searchState: SearchState
+): 'next' | 'previous' | null {
+  if (e.altKey) return null
+  const mod = isMac ? e.metaKey && !e.ctrlKey : e.ctrlKey && !e.metaKey
+  if (!mod) return null
+  if (e.key.toLowerCase() !== 'g') return null
+  if (!searchOpen) return null
+  if (!searchState.query) return null
+  return e.shiftKey ? 'previous' : 'next'
+}
+```
+
+- [ ] **Step 2: Add `searchOpen` and `searchStateRef` to the deps type**
+
+Update the `KeyboardHandlersDeps` type — add two new fields:
+
+```ts
+type KeyboardHandlersDeps = {
+  isActive: boolean
+  managerRef: React.RefObject<PaneManager | null>
+  paneTransportsRef: React.RefObject<Map<number, PtyTransport>>
+  expandedPaneIdRef: React.RefObject<number | null>
+  setExpandedPane: (paneId: number | null) => void
+  restoreExpandedLayout: () => void
+  refreshPaneSizes: (focusActive: boolean) => void
+  persistLayoutSnapshot: () => void
+  toggleExpandPane: (paneId: number) => void
+  setSearchOpen: React.Dispatch<React.SetStateAction<boolean>>
+  onRequestClosePane: (paneId: number) => void
+  searchOpen: boolean
+  searchStateRef: React.RefObject<SearchState>
+}
+```
+
+- [ ] **Step 3: Add the `Cmd+G` handler inside `onKeyDown`, before the `isEditableTarget` guard**
+
+Insert this block in `onKeyDown` right after the `if (e.repeat) return` check (line 62) and before `if (isEditableTarget(e.target))` (line 64):
+
+```ts
+      // Cmd+G / Cmd+Shift+G navigates terminal search matches.
+      // Placed before the isEditableTarget guard so it works when focus
+      // is in the search input. Uses its own mod-key check because this
+      // runs before the shared `mod` variable is declared.
+      // preventDefault suppresses macOS/Electron's native "find next".
+      const direction = matchSearchNavigate(e, isMac, searchOpen, searchStateRef.current)
+      if (direction !== null) {
+        e.preventDefault()
+        e.stopPropagation()
+        const pane = manager.getActivePane() ?? manager.getPanes()[0]
+        if (!pane) return
+        const { query, caseSensitive, regex } = searchStateRef.current
+        if (direction === 'next') {
+          pane.searchAddon.findNext(query, { caseSensitive, regex })
+        } else {
+          pane.searchAddon.findPrevious(query, { caseSensitive, regex })
+        }
+        pane.terminal.focus()
+        return
+      }
+```
+
+Note: this block accesses `manager` which is declared further down. Move the `const manager = managerRef.current; if (!manager) return` check above the `isEditableTarget` guard as well, so the search handler can reference it. The full reordering inside `onKeyDown` becomes:
+
+```
+if (e.repeat) return
+const manager = managerRef.current    // ← moved up from line 72
+if (!manager) return                  // ← moved up from line 73
+// Cmd+G / Cmd+Shift+G handler (new)
+if (isEditableTarget(e.target)) return
+const mod = ...
+```
+
+- [ ] **Step 4: Add `searchOpen` and `searchStateRef` to the destructuring and useEffect deps array**
+
+Update the function signature destructuring to include `searchOpen` and `searchStateRef`. Add both to the `useEffect` dependency array (alongside the existing entries):
+
+```ts
+export function useTerminalKeyboardShortcuts({
+  isActive,
+  managerRef,
+  paneTransportsRef,
+  expandedPaneIdRef,
+  setExpandedPane,
+  restoreExpandedLayout,
+  refreshPaneSizes,
+  persistLayoutSnapshot,
+  toggleExpandPane,
+  setSearchOpen,
+  onRequestClosePane,
+  searchOpen,
+  searchStateRef
+}: KeyboardHandlersDeps): void {
+  useEffect(() => {
+    // ...
+  }, [
+    isActive,
+    managerRef,
+    paneTransportsRef,
+    expandedPaneIdRef,
+    setExpandedPane,
+    restoreExpandedLayout,
+    refreshPaneSizes,
+    persistLayoutSnapshot,
+    toggleExpandPane,
+    setSearchOpen,
+    onRequestClosePane,
+    searchOpen,
+    searchStateRef
+  ])
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pnpm test -- src/renderer/src/components/terminal-pane/keyboard-handlers.test.ts`
+Expected: All 8 tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/renderer/src/components/terminal-pane/keyboard-handlers.ts src/renderer/src/components/terminal-pane/keyboard-handlers.test.ts
+git commit -m "feat: add Cmd+G / Cmd+Shift+G search navigation to keyboard handler"
+```
+
+---
+
+### Task 3: Sync search state from `TerminalSearch` into the ref
+
+**Files:**
+- Modify: `src/renderer/src/components/TerminalSearch.tsx`
+
+- [ ] **Step 1: Add `searchStateRef` prop to the component**
+
+Update the props type and destructuring:
+
+```ts
+type TerminalSearchProps = {
+  isOpen: boolean
+  onClose: () => void
+  searchAddon: SearchAddon | null
+  searchStateRef: React.MutableRefObject<{ query: string; caseSensitive: boolean; regex: boolean }>
+}
+
+export default function TerminalSearch({
+  isOpen,
+  onClose,
+  searchAddon,
+  searchStateRef
+}: TerminalSearchProps): React.JSX.Element | null {
+```
+
+- [ ] **Step 2: Sync the ref inside the existing incremental-search `useEffect`**
+
+The existing `useEffect` (lines 47–55) already runs whenever `query`, `caseSensitive`, or `regex` change. Add the ref sync at the top, before the early return on empty query:
+
+```ts
+  useEffect(() => {
+    // Keep the ref in sync so the keyboard handler (Cmd+G / Cmd+Shift+G)
+    // can read the current search state without lifting it to parent state.
+    searchStateRef.current = { query, caseSensitive, regex }
+
+    if (!query) {
+      searchAddon?.clearDecorations()
+      return
+    }
+    if (searchAddon && isOpen) {
+      searchAddon.findNext(query, { caseSensitive, regex, incremental: true })
+    }
+  }, [query, searchAddon, isOpen, caseSensitive, regex, searchStateRef])
+```
+
+Note: `searchStateRef` is added to the dependency array to satisfy the linter, though as a ref it never changes identity.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/renderer/src/components/TerminalSearch.tsx
+git commit -m "feat: sync search state into ref for keyboard handler access"
+```
+
+---
+
+### Task 4: Wire `searchStateRef` through `TerminalPane`
+
+**Files:**
+- Modify: `src/renderer/src/components/terminal-pane/TerminalPane.tsx`
+
+- [ ] **Step 1: Import `SearchState` and create the ref**
+
+Add the import at the top of the file alongside the existing `keyboard-handlers` import:
+
+```ts
+import { useTerminalKeyboardShortcuts } from './keyboard-handlers'
+```
+
+becomes:
+
+```ts
+import { useTerminalKeyboardShortcuts, type SearchState } from './keyboard-handlers'
+```
+
+Then add the ref near the other refs (after `const [searchOpen, setSearchOpen] = useState(false)` on line 65):
+
+```ts
+  const searchStateRef = useRef<SearchState>({ query: '', caseSensitive: false, regex: false })
+```
+
+- [ ] **Step 2: Pass `searchOpen` and `searchStateRef` to `useTerminalKeyboardShortcuts`**
+
+Update the call (around line 263) to include the two new fields:
+
+```ts
+  useTerminalKeyboardShortcuts({
+    isActive,
+    managerRef,
+    paneTransportsRef,
+    expandedPaneIdRef,
+    setExpandedPane,
+    restoreExpandedLayout,
+    refreshPaneSizes,
+    persistLayoutSnapshot,
+    toggleExpandPane,
+    setSearchOpen,
+    onRequestClosePane: handleRequestClosePane,
+    searchOpen,
+    searchStateRef
+  })
+```
+
+- [ ] **Step 3: Pass `searchStateRef` to `TerminalSearch`**
+
+Update the `TerminalSearch` JSX (around line 567) to include the new prop:
+
+```tsx
+          <TerminalSearch
+            isOpen={searchOpen}
+            onClose={() => setSearchOpen(false)}
+            searchAddon={activePane.searchAddon ?? null}
+            searchStateRef={searchStateRef}
+          />,
+```
+
+- [ ] **Step 4: Run the full test suite to verify nothing is broken**
+
+Run: `pnpm test`
+Expected: All tests pass (no regressions)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/renderer/src/components/terminal-pane/TerminalPane.tsx
+git commit -m "feat: wire searchStateRef through TerminalPane to search and keyboard handler"
+```
+
+---
+
+### Task 5: TypeScript build verification
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run the TypeScript compiler to check for type errors**
+
+Run: `pnpm run typecheck` (or the equivalent — check `package.json` scripts)
+If no `typecheck` script exists, run: `npx tsc --noEmit`
+Expected: No type errors
+
+- [ ] **Step 2: Run the full test suite one final time**
+
+Run: `pnpm test`
+Expected: All tests pass
+
+- [ ] **Step 3: Commit if any fixes were needed, otherwise skip**

--- a/docs/superpowers/specs/2026-04-10-terminal-search-shortcuts-design.md
+++ b/docs/superpowers/specs/2026-04-10-terminal-search-shortcuts-design.md
@@ -1,0 +1,49 @@
+# Terminal Search Next/Previous Shortcuts
+
+## Summary
+
+Add `Cmd+G` (find next) and `Cmd+Shift+G` (find previous) keyboard shortcuts to navigate terminal search matches. These follow macOS native conventions and only activate when the search bar is already open.
+
+## Requirements
+
+- `Cmd+G` calls `findNext` on the active pane's `SearchAddon`
+- `Cmd+Shift+G` calls `findPrevious` on the active pane's `SearchAddon`
+- Shortcuts are no-ops when the search bar is closed
+- After navigating, focus moves to the terminal (not the search input)
+- Shortcuts are not documented in ShortcutsPane (consistent with `Cmd+F`)
+
+## Architecture
+
+### Data bridge: `searchStateRef`
+
+The search query and options (`caseSensitive`, `regex`) live as local state in `TerminalSearch.tsx`. The keyboard handler in `keyboard-handlers.ts` needs read access to call `searchAddon.findNext(query, opts)`.
+
+A `MutableRefObject<{ query: string; caseSensitive: boolean; regex: boolean }>` is created in `TerminalPane` and passed to both components. `TerminalSearch` writes to it on state changes; the keyboard handler reads from it on `Cmd+G` / `Cmd+Shift+G`. This follows the existing ref-bridge pattern used throughout `TerminalPane` (e.g., `paneTitlesRef`, `isActiveRef`, `settingsRef`).
+
+### Changes by file
+
+**`TerminalPane.tsx`**
+- Create `searchStateRef = useRef({ query: '', caseSensitive: false, regex: false })`
+- Pass `searchStateRef` to `TerminalSearch` as a new prop
+- Pass `searchOpen` and `searchStateRef` to `useTerminalKeyboardShortcuts`
+
+**`TerminalSearch.tsx`**
+- Accept `searchStateRef: React.MutableRefObject<{ query: string; caseSensitive: boolean; regex: boolean }>` prop
+- Sync the ref whenever `query`, `caseSensitive`, or `regex` changes (inside the existing `useEffect` or via direct assignment after `setState`)
+
+**`keyboard-handlers.ts`**
+- Add `searchOpen` (boolean) and `searchStateRef` to `KeyboardHandlersDeps`
+- Add handler for `Cmd+G` / `Cmd+Shift+G` inside `onKeyDown`:
+  - Guard: `searchOpen` must be true and `searchStateRef.current.query` must be non-empty
+  - Read `query`, `caseSensitive`, `regex` from `searchStateRef.current`
+  - Get active pane's `searchAddon` via `manager.getActivePane().searchAddon`
+  - Call `findNext` or `findPrevious` with the current options
+  - Call `pane.terminal.focus()` to return focus to the terminal
+  - `preventDefault` + `stopPropagation`
+
+### Edge cases
+
+- **No query**: no-op (empty string guard)
+- **No active pane**: no-op (existing pane guard)
+- **Search closed**: no-op (`searchOpen` guard)
+- **Key repeat**: filtered by existing `if (e.repeat) return` at top of `onKeyDown`

--- a/docs/superpowers/specs/2026-04-10-terminal-search-shortcuts-design.md
+++ b/docs/superpowers/specs/2026-04-10-terminal-search-shortcuts-design.md
@@ -29,17 +29,18 @@ A `MutableRefObject<{ query: string; caseSensitive: boolean; regex: boolean }>` 
 
 **`TerminalSearch.tsx`**
 - Accept `searchStateRef: React.MutableRefObject<{ query: string; caseSensitive: boolean; regex: boolean }>` prop
-- Sync the ref whenever `query`, `caseSensitive`, or `regex` changes (inside the existing `useEffect` or via direct assignment after `setState`)
+- Sync the ref whenever `query`, `caseSensitive`, or `regex` changes — inside the existing `useEffect` that already depends on `[query, caseSensitive, regex]`, so all three values are kept in sync together
 
 **`keyboard-handlers.ts`**
 - Add `searchOpen` (boolean) and `searchStateRef` to `KeyboardHandlersDeps`
-- Add handler for `Cmd+G` / `Cmd+Shift+G` inside `onKeyDown`:
+- Exempt `[data-terminal-search-root]` descendants from the `isEditableTarget` early return for `Cmd+G` / `Cmd+Shift+G`. Without this, pressing the shortcut while the search input has focus would be silently swallowed. The paste handler in `TerminalPane` already uses this same `data-terminal-search-root` exemption pattern.
+- Add handler for `Cmd+G` / `Cmd+Shift+G` inside `onKeyDown`, placed before the `isEditableTarget` guard:
   - Guard: `searchOpen` must be true and `searchStateRef.current.query` must be non-empty
   - Read `query`, `caseSensitive`, `regex` from `searchStateRef.current`
   - Get active pane's `searchAddon` via `manager.getActivePane().searchAddon`
-  - Call `findNext` or `findPrevious` with the current options
+  - Call `findNext` or `findPrevious` with `{ caseSensitive, regex }` (no `incremental` — matches the chevron button behavior, not the live-typing behavior)
   - Call `pane.terminal.focus()` to return focus to the terminal
-  - `preventDefault` + `stopPropagation`
+  - `preventDefault` + `stopPropagation` — important to suppress macOS/Electron's native "find next" which could otherwise trigger the built-in find bar
 
 ### Edge cases
 
@@ -47,3 +48,4 @@ A `MutableRefObject<{ query: string; caseSensitive: boolean; regex: boolean }>` 
 - **No active pane**: no-op (existing pane guard)
 - **Search closed**: no-op (`searchOpen` guard)
 - **Key repeat**: filtered by existing `if (e.repeat) return` at top of `onKeyDown`
+- **Focus in search input**: `Cmd+G` / `Cmd+Shift+G` must bypass the `isEditableTarget` guard for search input descendants (see keyboard-handlers.ts changes above)

--- a/docs/superpowers/specs/2026-04-10-terminal-search-shortcuts-design.md
+++ b/docs/superpowers/specs/2026-04-10-terminal-search-shortcuts-design.md
@@ -29,13 +29,13 @@ A `MutableRefObject<{ query: string; caseSensitive: boolean; regex: boolean }>` 
 
 **`TerminalSearch.tsx`**
 - Accept `searchStateRef: React.MutableRefObject<{ query: string; caseSensitive: boolean; regex: boolean }>` prop
-- Sync the ref whenever `query`, `caseSensitive`, or `regex` changes — inside the existing `useEffect` that already depends on `[query, caseSensitive, regex]`, so all three values are kept in sync together
+- Sync the ref whenever `query`, `caseSensitive`, or `regex` changes — inside the existing `useEffect` that already depends on `[query, caseSensitive, regex]`, so all three values are kept in sync together. Note: the existing effect has an early return when query is empty (`clearDecorations`), so the ref won't update on clear — this is benign because the keyboard handler already guards on non-empty query
 
 **`keyboard-handlers.ts`**
 - Add `searchOpen` (boolean) and `searchStateRef` to `KeyboardHandlersDeps`
 - Exempt `[data-terminal-search-root]` descendants from the `isEditableTarget` early return for `Cmd+G` / `Cmd+Shift+G`. Without this, pressing the shortcut while the search input has focus would be silently swallowed. The paste handler in `TerminalPane` already uses this same `data-terminal-search-root` exemption pattern.
-- Add handler for `Cmd+G` / `Cmd+Shift+G` inside `onKeyDown`, placed before the `isEditableTarget` guard:
-  - Guard: `searchOpen` must be true and `searchStateRef.current.query` must be non-empty
+- Add handler for `Cmd+G` / `Cmd+Shift+G` inside `onKeyDown`, placed before the `isEditableTarget` guard. Because this runs before the `const mod = ...` declaration, the handler must perform its own mod-key check (`isMac ? e.metaKey && !e.ctrlKey : e.ctrlKey && !e.metaKey`) and key match (`e.key.toLowerCase() === 'g'`) inline:
+  - Guard: mod key active, key is `g`, `searchOpen` is true, `searchStateRef.current.query` is non-empty
   - Read `query`, `caseSensitive`, `regex` from `searchStateRef.current`
   - Get active pane's `searchAddon` via `manager.getActivePane().searchAddon`
   - Call `findNext` or `findPrevious` with `{ caseSensitive, regex }` (no `incremental` — matches the chevron button behavior, not the live-typing behavior)

--- a/src/renderer/src/components/TerminalSearch.tsx
+++ b/src/renderer/src/components/TerminalSearch.tsx
@@ -2,17 +2,20 @@ import { useEffect, useRef, useState, useCallback } from 'react'
 import { ChevronUp, ChevronDown, X, CaseSensitive, Regex } from 'lucide-react'
 import type { SearchAddon } from '@xterm/addon-search'
 import { Button } from '@/components/ui/button'
+import type { SearchState } from '@/components/terminal-pane/keyboard-handlers'
 
 type TerminalSearchProps = {
   isOpen: boolean
   onClose: () => void
   searchAddon: SearchAddon | null
+  searchStateRef: React.RefObject<SearchState>
 }
 
 export default function TerminalSearch({
   isOpen,
   onClose,
-  searchAddon
+  searchAddon,
+  searchStateRef
 }: TerminalSearchProps): React.JSX.Element | null {
   const inputRef = useRef<HTMLInputElement>(null)
   const [query, setQuery] = useState('')
@@ -45,6 +48,10 @@ export default function TerminalSearch({
   }, [isOpen, searchAddon])
 
   useEffect(() => {
+    // Keep the ref in sync so the keyboard handler (Cmd+G / Cmd+Shift+G)
+    // can read the current search state without lifting it to parent state.
+    searchStateRef.current = { query, caseSensitive, regex }
+
     if (!query) {
       searchAddon?.clearDecorations()
       return
@@ -52,7 +59,7 @@ export default function TerminalSearch({
     if (searchAddon && isOpen) {
       searchAddon.findNext(query, { caseSensitive, regex, incremental: true })
     }
-  }, [query, searchAddon, isOpen, caseSensitive, regex])
+  }, [query, searchAddon, isOpen, caseSensitive, regex, searchStateRef])
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -14,7 +14,7 @@ import type { PtyTransport } from './pty-transport'
 import { fitPanes, shellEscapePath } from './pane-helpers'
 import { EMPTY_LAYOUT, paneLeafId, serializeTerminalLayout } from './layout-serialization'
 import { createExpandCollapseActions } from './expand-collapse'
-import { useTerminalKeyboardShortcuts } from './keyboard-handlers'
+import { useTerminalKeyboardShortcuts, type SearchState } from './keyboard-handlers'
 import { useTerminalFontZoom } from './useTerminalFontZoom'
 import CloseTerminalDialog from './CloseTerminalDialog'
 import { TerminalErrorToast } from './TerminalErrorToast'
@@ -63,6 +63,7 @@ export default function TerminalPane({
 
   const [expandedPaneId, setExpandedPaneId] = useState<number | null>(null)
   const [searchOpen, setSearchOpen] = useState(false)
+  const searchStateRef = useRef<SearchState>({ query: '', caseSensitive: false, regex: false })
   const [closeConfirmPaneId, setCloseConfirmPaneId] = useState<number | null>(null)
   const [terminalError, setTerminalError] = useState<string | null>(null)
 
@@ -271,7 +272,9 @@ export default function TerminalPane({
     persistLayoutSnapshot,
     toggleExpandPane,
     setSearchOpen,
-    onRequestClosePane: handleRequestClosePane
+    onRequestClosePane: handleRequestClosePane,
+    searchOpen,
+    searchStateRef
   })
 
   useTerminalPaneGlobalEffects({
@@ -568,6 +571,7 @@ export default function TerminalPane({
             isOpen={searchOpen}
             onClose={() => setSearchOpen(false)}
             searchAddon={activePane.searchAddon ?? null}
+            searchStateRef={searchStateRef}
           />,
           activePane.container
         )}

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -63,6 +63,8 @@ export default function TerminalPane({
 
   const [expandedPaneId, setExpandedPaneId] = useState<number | null>(null)
   const [searchOpen, setSearchOpen] = useState(false)
+  const searchOpenRef = useRef(false)
+  searchOpenRef.current = searchOpen
   const searchStateRef = useRef<SearchState>({ query: '', caseSensitive: false, regex: false })
   const [closeConfirmPaneId, setCloseConfirmPaneId] = useState<number | null>(null)
   const [terminalError, setTerminalError] = useState<string | null>(null)
@@ -273,7 +275,7 @@ export default function TerminalPane({
     toggleExpandPane,
     setSearchOpen,
     onRequestClosePane: handleRequestClosePane,
-    searchOpen,
+    searchOpenRef,
     searchStateRef
   })
 

--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.test.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.test.ts
@@ -1,0 +1,69 @@
+// src/renderer/src/components/terminal-pane/keyboard-handlers.test.ts
+import { describe, it, expect } from 'vitest'
+import { matchSearchNavigate } from './keyboard-handlers'
+
+function makeKeyEvent(
+  overrides: Partial<{
+    key: string
+    metaKey: boolean
+    ctrlKey: boolean
+    shiftKey: boolean
+    altKey: boolean
+  }>
+): Pick<KeyboardEvent, 'key' | 'metaKey' | 'ctrlKey' | 'shiftKey' | 'altKey'> {
+  return {
+    key: 'g',
+    metaKey: false,
+    ctrlKey: false,
+    shiftKey: false,
+    altKey: false,
+    ...overrides
+  }
+}
+
+describe('matchSearchNavigate', () => {
+  const isMac = true
+  const searchState = { query: 'hello', caseSensitive: false, regex: false }
+
+  it('returns "next" for Cmd+G on macOS', () => {
+    const e = makeKeyEvent({ metaKey: true })
+    expect(matchSearchNavigate(e, isMac, true, searchState)).toBe('next')
+  })
+
+  it('returns "previous" for Cmd+Shift+G on macOS', () => {
+    const e = makeKeyEvent({ metaKey: true, shiftKey: true })
+    expect(matchSearchNavigate(e, isMac, true, searchState)).toBe('previous')
+  })
+
+  it('returns null when search is closed', () => {
+    const e = makeKeyEvent({ metaKey: true })
+    expect(matchSearchNavigate(e, isMac, false, searchState)).toBeNull()
+  })
+
+  it('returns null when query is empty', () => {
+    const e = makeKeyEvent({ metaKey: true })
+    expect(
+      matchSearchNavigate(e, isMac, true, { query: '', caseSensitive: false, regex: false })
+    ).toBeNull()
+  })
+
+  it('returns null for wrong key', () => {
+    const e = makeKeyEvent({ metaKey: true, key: 'f' })
+    expect(matchSearchNavigate(e, isMac, true, searchState)).toBeNull()
+  })
+
+  it('returns null when alt is pressed', () => {
+    const e = makeKeyEvent({ metaKey: true, altKey: true })
+    expect(matchSearchNavigate(e, isMac, true, searchState)).toBeNull()
+  })
+
+  it('returns "next" for Ctrl+G on Linux/Windows', () => {
+    const e = makeKeyEvent({ ctrlKey: true })
+    expect(matchSearchNavigate(e, false, true, searchState)).toBe('next')
+  })
+
+  it('returns null for Ctrl+G on macOS (wrong modifier)', () => {
+    const e = makeKeyEvent({ ctrlKey: true })
+    expect(matchSearchNavigate(e, true, true, searchState)).toBeNull()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.test.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.test.ts
@@ -62,6 +62,11 @@ describe('matchSearchNavigate', () => {
     expect(matchSearchNavigate(e, false, true, searchState)).toBe('next')
   })
 
+  it('returns "previous" for Ctrl+Shift+G on Linux/Windows', () => {
+    const e = makeKeyEvent({ ctrlKey: true, shiftKey: true })
+    expect(matchSearchNavigate(e, false, true, searchState)).toBe('previous')
+  })
+
   it('returns null for Ctrl+G on macOS (wrong modifier)', () => {
     const e = makeKeyEvent({ ctrlKey: true })
     expect(matchSearchNavigate(e, true, true, searchState)).toBeNull()

--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
@@ -72,7 +72,7 @@ type KeyboardHandlersDeps = {
   toggleExpandPane: (paneId: number) => void
   setSearchOpen: React.Dispatch<React.SetStateAction<boolean>>
   onRequestClosePane: (paneId: number) => void
-  searchOpen: boolean
+  searchOpenRef: React.RefObject<boolean>
   searchStateRef: React.RefObject<SearchState>
 }
 
@@ -88,7 +88,7 @@ export function useTerminalKeyboardShortcuts({
   toggleExpandPane,
   setSearchOpen,
   onRequestClosePane,
-  searchOpen,
+  searchOpenRef,
   searchStateRef
 }: KeyboardHandlersDeps): void {
   useEffect(() => {
@@ -112,7 +112,7 @@ export function useTerminalKeyboardShortcuts({
       // is in the search input. Uses its own mod-key check because this
       // runs before the shared `mod` variable is declared.
       // preventDefault suppresses macOS/Electron's native "find next".
-      const direction = matchSearchNavigate(e, isMac, searchOpen, searchStateRef.current)
+      const direction = matchSearchNavigate(e, isMac, searchOpenRef.current, searchStateRef.current)
       if (direction !== null) {
         e.preventDefault()
         e.stopPropagation()
@@ -358,7 +358,7 @@ export function useTerminalKeyboardShortcuts({
     toggleExpandPane,
     setSearchOpen,
     onRequestClosePane,
-    searchOpen,
+    searchOpenRef,
     searchStateRef
   ])
 }

--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
@@ -24,6 +24,42 @@ function isEditableTarget(target: EventTarget | null): boolean {
   return editableAncestor !== null
 }
 
+export type SearchState = {
+  query: string
+  caseSensitive: boolean
+  regex: boolean
+}
+
+/**
+ * Pure decision function for Cmd+G / Cmd+Shift+G search navigation.
+ * Returns 'next', 'previous', or null (no match).
+ * Extracted so the key-matching logic is testable without DOM dependencies.
+ */
+export function matchSearchNavigate(
+  e: Pick<KeyboardEvent, 'key' | 'metaKey' | 'ctrlKey' | 'shiftKey' | 'altKey'>,
+  isMac: boolean,
+  searchOpen: boolean,
+  searchState: SearchState
+): 'next' | 'previous' | null {
+  if (e.altKey) {
+    return null
+  }
+  const mod = isMac ? e.metaKey && !e.ctrlKey : e.ctrlKey && !e.metaKey
+  if (!mod) {
+    return null
+  }
+  if (e.key.toLowerCase() !== 'g') {
+    return null
+  }
+  if (!searchOpen) {
+    return null
+  }
+  if (!searchState.query) {
+    return null
+  }
+  return e.shiftKey ? 'previous' : 'next'
+}
+
 type KeyboardHandlersDeps = {
   isActive: boolean
   managerRef: React.RefObject<PaneManager | null>
@@ -36,6 +72,8 @@ type KeyboardHandlersDeps = {
   toggleExpandPane: (paneId: number) => void
   setSearchOpen: React.Dispatch<React.SetStateAction<boolean>>
   onRequestClosePane: (paneId: number) => void
+  searchOpen: boolean
+  searchStateRef: React.RefObject<SearchState>
 }
 
 export function useTerminalKeyboardShortcuts({
@@ -49,7 +87,9 @@ export function useTerminalKeyboardShortcuts({
   persistLayoutSnapshot,
   toggleExpandPane,
   setSearchOpen,
-  onRequestClosePane
+  onRequestClosePane,
+  searchOpen,
+  searchStateRef
 }: KeyboardHandlersDeps): void {
   useEffect(() => {
     if (!isActive) {
@@ -61,16 +101,40 @@ export function useTerminalKeyboardShortcuts({
       if (e.repeat) {
         return
       }
+      // Moved above isEditableTarget so the Cmd+G handler can reference it.
+      const manager = managerRef.current
+      if (!manager) {
+        return
+      }
+
+      // Cmd+G / Cmd+Shift+G navigates terminal search matches.
+      // Placed before the isEditableTarget guard so it works when focus
+      // is in the search input. Uses its own mod-key check because this
+      // runs before the shared `mod` variable is declared.
+      // preventDefault suppresses macOS/Electron's native "find next".
+      const direction = matchSearchNavigate(e, isMac, searchOpen, searchStateRef.current)
+      if (direction !== null) {
+        e.preventDefault()
+        e.stopPropagation()
+        const pane = manager.getActivePane() ?? manager.getPanes()[0]
+        if (!pane) {
+          return
+        }
+        const { query, caseSensitive, regex } = searchStateRef.current
+        if (direction === 'next') {
+          pane.searchAddon.findNext(query, { caseSensitive, regex })
+        } else {
+          pane.searchAddon.findPrevious(query, { caseSensitive, regex })
+        }
+        pane.terminal.focus()
+        return
+      }
+
       if (isEditableTarget(e.target)) {
         return
       }
       const mod = isMac ? e.metaKey && !e.ctrlKey : e.ctrlKey && !e.metaKey
       if (!mod || e.altKey) {
-        return
-      }
-
-      const manager = managerRef.current
-      if (!manager) {
         return
       }
 
@@ -293,6 +357,8 @@ export function useTerminalKeyboardShortcuts({
     persistLayoutSnapshot,
     toggleExpandPane,
     setSearchOpen,
-    onRequestClosePane
+    onRequestClosePane,
+    searchOpen,
+    searchStateRef
   ])
 }


### PR DESCRIPTION
## Summary

- Add `Cmd+G` (find next) and `Cmd+Shift+G` (find previous) keyboard shortcuts to navigate terminal search matches when the search bar is already open
- Extract `matchSearchNavigate` as a pure, testable decision function for key-matching logic
- Use a `searchStateRef` bridge so the keyboard handler can read search query/options without lifting state out of `TerminalSearch`
- Shortcuts follow macOS conventions (`Ctrl+G` / `Ctrl+Shift+G` on Linux/Windows)
- Focus returns to the terminal after navigating, search bar stays visible

## Test plan

- [x] `Cmd+G` navigates to next match when search is open with a query
- [x] `Cmd+Shift+G` navigates to previous match
- [x] Both shortcuts are no-ops when search bar is closed
- [x] Both shortcuts are no-ops when query is empty
- [x] Shortcuts work from both the search input and the terminal
- [x] `Ctrl+G` / `Ctrl+Shift+G` works on Linux/Windows
- [x] 9 unit tests for `matchSearchNavigate` covering all branches
- [x] Full test suite passes (726 tests)