### PR TITLE
fix: avoid Claude cache timer before first prompt

### DIFF
--- a/src/renderer/src/components/terminal-pane/cache-timer-seeding.test.ts
+++ b/src/renderer/src/components/terminal-pane/cache-timer-seeding.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import { shouldSeedCacheTimerOnInitialTitle } from './cache-timer-seeding'
+
+describe('shouldSeedCacheTimerOnInitialTitle', () => {
+  it('does not seed for fresh Claude tabs that have not been restored', () => {
+    expect(
+      shouldSeedCacheTimerOnInitialTitle({
+        rawTitle: '✳ Claude Code',
+        allowInitialIdleSeed: false,
+        existingTimerStartedAt: null,
+        promptCacheTimerEnabled: true
+      })
+    ).toBe(false)
+  })
+
+  it('seeds for restored Claude tabs that are already idle', () => {
+    expect(
+      shouldSeedCacheTimerOnInitialTitle({
+        rawTitle: '✳ Claude Code',
+        allowInitialIdleSeed: true,
+        existingTimerStartedAt: null,
+        promptCacheTimerEnabled: true
+      })
+    ).toBe(true)
+  })
+
+  it('does not seed for restored Claude tabs that are still working', () => {
+    expect(
+      shouldSeedCacheTimerOnInitialTitle({
+        rawTitle: '⠂ Claude Code',
+        allowInitialIdleSeed: true,
+        existingTimerStartedAt: null,
+        promptCacheTimerEnabled: true
+      })
+    ).toBe(false)
+  })
+
+  it('does not seed when a timer already exists for the pane', () => {
+    expect(
+      shouldSeedCacheTimerOnInitialTitle({
+        rawTitle: '✳ Claude Code',
+        allowInitialIdleSeed: true,
+        existingTimerStartedAt: Date.now(),
+        promptCacheTimerEnabled: true
+      })
+    ).toBe(false)
+  })
+
+  it('treats null settings as provisionally enabled during startup hydration', () => {
+    expect(
+      shouldSeedCacheTimerOnInitialTitle({
+        rawTitle: '✳ Claude Code',
+        allowInitialIdleSeed: true,
+        existingTimerStartedAt: null,
+        promptCacheTimerEnabled: null
+      })
+    ).toBe(true)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/cache-timer-seeding.ts
+++ b/src/renderer/src/components/terminal-pane/cache-timer-seeding.ts
@@ -1,0 +1,29 @@
+import { detectAgentStatusFromTitle, isClaudeAgent } from '@/lib/agent-status'
+
+export function shouldSeedCacheTimerOnInitialTitle(args: {
+  rawTitle: string
+  allowInitialIdleSeed: boolean
+  existingTimerStartedAt: number | null | undefined
+  promptCacheTimerEnabled: boolean | null
+}): boolean {
+  const { rawTitle, allowInitialIdleSeed, existingTimerStartedAt, promptCacheTimerEnabled } = args
+
+  if (!allowInitialIdleSeed || !isClaudeAgent(rawTitle)) {
+    return false
+  }
+
+  const status = detectAgentStatusFromTitle(rawTitle)
+  if (status === null || status === 'working') {
+    return false
+  }
+
+  if (existingTimerStartedAt != null) {
+    return false
+  }
+
+  // Why: the initial idle-title seed exists only for PTYs reattached during
+  // session restore. Fresh Claude launches also start idle before the first
+  // prompt, but no server-side prompt cache exists yet, so showing a TTL
+  // countdown there is incorrect.
+  return promptCacheTimerEnabled !== false
+}

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -1,13 +1,10 @@
 import type { PaneManager, ManagedPane } from '@/lib/pane-manager/pane-manager'
-import {
-  isGeminiTerminalTitle,
-  isClaudeAgent,
-  detectAgentStatusFromTitle
-} from '@/lib/agent-status'
+import { isGeminiTerminalTitle, isClaudeAgent } from '@/lib/agent-status'
 import { scheduleRuntimeGraphSync } from '@/runtime/sync-runtime-graph'
 import { useAppStore } from '@/store'
 import type { PtyTransport } from './pty-transport'
 import { createIpcPtyTransport, getEagerPtyBufferHandle } from './pty-transport'
+import { shouldSeedCacheTimerOnInitialTitle } from './cache-timer-seeding'
 
 type PtyConnectionDeps = {
   tabId: string
@@ -71,24 +68,27 @@ export function connectPanePty(
   // Why: on app restart, restored Claude tabs may already be idle when we first
   // see their title. The agent status tracker only fires onBecameIdle for
   // working→idle transitions, so the cache timer would never start for these
-  // sessions. This one-time flag seeds the timer on the first idle Claude title.
-  let hasSeededCacheTimer = false
+  // sessions. We only allow this one-time seed for reattached PTYs; fresh
+  // Claude launches also start idle, but they have no prompt cache yet.
+  let hasConsideredInitialCacheTimerSeed = false
+  let allowInitialIdleCacheSeed = false
 
   const onTitleChange = (title: string, rawTitle: string): void => {
     manager.setPaneGpuRendering(pane.id, !isGeminiTerminalTitle(rawTitle))
     deps.updateTabTitle(deps.tabId, title)
 
-    if (!hasSeededCacheTimer && isClaudeAgent(rawTitle)) {
-      hasSeededCacheTimer = true
-      const status = detectAgentStatusFromTitle(rawTitle)
-      if (status !== null && status !== 'working') {
-        const existing = useAppStore.getState().cacheTimerByKey[cacheKey]
-        if (existing == null) {
-          const settings = useAppStore.getState().settings
-          if (settings === null || settings.promptCacheTimerEnabled) {
-            deps.setCacheTimerStartedAt(cacheKey, Date.now())
-          }
-        }
+    if (!hasConsideredInitialCacheTimerSeed) {
+      hasConsideredInitialCacheTimerSeed = true
+      const state = useAppStore.getState()
+      if (
+        shouldSeedCacheTimerOnInitialTitle({
+          rawTitle,
+          allowInitialIdleSeed: allowInitialIdleCacheSeed,
+          existingTimerStartedAt: state.cacheTimerByKey[cacheKey],
+          promptCacheTimerEnabled: state.settings?.promptCacheTimerEnabled ?? null
+        })
+      ) {
+        deps.setCacheTimerStartedAt(cacheKey, Date.now())
       }
     }
   }
@@ -203,6 +203,7 @@ export function connectPanePty(
     // this guard, every split pane would try to share the same PTY ID, and the
     // last one's handler would overwrite the earlier ones' in the dispatcher.
     if (existingPtyId && getEagerPtyBufferHandle(existingPtyId)) {
+      allowInitialIdleCacheSeed = true
       // Why: this tab had a PTY eagerly spawned by reconnectPersistedTerminals().
       // Attach to it instead of spawning a duplicate. Startup commands are
       // intentionally skipped — the PTY was already spawned with a fresh shell.
@@ -216,6 +217,7 @@ export function connectPanePty(
         }
       })
     } else {
+      allowInitialIdleCacheSeed = false
       transport.connect({
         url: '',
         cols,


### PR DESCRIPTION
## Problem
The Claude prompt-cache countdown could appear before the user had sent the first Claude message. Orca seeded the timer from the first idle Claude title it saw, but a fresh Claude Code session also starts idle before any prompt cache exists.

## Solution
Only seed the initial idle countdown for PTYs that were reattached during session restore. Freshly spawned Claude terminals now skip that seed path and wait for a real working-to-idle transition after the first request. The seeding decision is isolated in a small helper with focused tests covering fresh tabs, restored tabs, working titles, existing timers, and startup settings hydration.

## Testing
- `pnpm test -- src/renderer/src/components/terminal-pane/cache-timer-seeding.test.ts src/renderer/src/lib/agent-status.test.ts`
- `pnpm exec oxlint src/renderer/src/components/terminal-pane/pty-connection.ts src/renderer/src/components/terminal-pane/cache-timer-seeding.ts src/renderer/src/components/terminal-pane/cache-timer-seeding.test.ts`
- `pnpm run typecheck:web`

Closes #420
