### PR TITLE
fix: correct worktree card height estimates

### DIFF
--- a/src/renderer/src/components/sidebar/worktree-list-estimate.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-estimate.test.ts
@@ -48,63 +48,63 @@ describe('estimateRowHeight', () => {
     expect(estimateRowHeight(header, [], repoMap, null)).toBe(38)
   })
 
-  it('returns base height (52) for items with no metadata', () => {
-    expect(estimateRowHeight(itemRow(worktree), [], repoMap, null)).toBe(52)
+  it('returns base height (55) for items with no metadata', () => {
+    expect(estimateRowHeight(itemRow(worktree), [], repoMap, null)).toBe(55)
   })
 
-  it('adds 22px for issue row when linkedIssue is set', () => {
+  it('adds 24px for issue row when linkedIssue is set', () => {
     const wt = { ...worktree, linkedIssue: 42 }
     const base = estimateRowHeight(itemRow(worktree), ['issue'], repoMap, null)
     const withIssue = estimateRowHeight(itemRow(wt), ['issue'], repoMap, null)
-    expect(withIssue - base).toBe(24) // 22px line + 2px mt-0.5
+    expect(withIssue - base).toBe(24) // 16px row + 8px meta-section spacing
   })
 
   it('does not add issue height when cardProps excludes issue', () => {
     const wt = { ...worktree, linkedIssue: 42 }
-    expect(estimateRowHeight(itemRow(wt), [], repoMap, null)).toBe(52)
+    expect(estimateRowHeight(itemRow(wt), [], repoMap, null)).toBe(55)
   })
 
-  it('adds 22px for PR row when prCache has data', () => {
+  it('adds 24px for PR row when prCache has data', () => {
     const prCache = {
       '/tmp/orca::feature/cool': { data: { number: 1 } }
     }
     const base = estimateRowHeight(itemRow(worktree), ['pr'], repoMap, null)
     const withPR = estimateRowHeight(itemRow(worktree), ['pr'], repoMap, prCache)
-    expect(withPR - base).toBe(24) // 22px line + 2px mt-0.5
+    expect(withPR - base).toBe(24) // 16px row + 8px meta-section spacing
   })
 
   it('does not add PR height when prCache is null', () => {
-    expect(estimateRowHeight(itemRow(worktree), ['pr'], repoMap, null)).toBe(52)
+    expect(estimateRowHeight(itemRow(worktree), ['pr'], repoMap, null)).toBe(55)
   })
 
   it('does not add PR height when prCache entry has no data', () => {
     const prCache = {
       '/tmp/orca::feature/cool': { data: null }
     }
-    expect(estimateRowHeight(itemRow(worktree), ['pr'], repoMap, prCache)).toBe(52)
+    expect(estimateRowHeight(itemRow(worktree), ['pr'], repoMap, prCache)).toBe(55)
   })
 
   it('estimates comment height based on content length', () => {
     const wt = { ...worktree, comment: 'todo: fix bug' }
     const base = estimateRowHeight(itemRow(worktree), ['comment'], repoMap, null)
     const withComment = estimateRowHeight(itemRow(wt), ['comment'], repoMap, null)
-    // 1 line × 17px + 4px padding + 2px mt-0.5 = 23
-    expect(withComment - base).toBe(23)
+    // 1 line × ceil(16.5)=17 + 4px py-0.5 + 8px meta spacing = 29
+    expect(withComment - base).toBe(29)
   })
 
   it('estimates multi-line comment height from newlines', () => {
     const wt = { ...worktree, comment: 'first line\nsecond line\nthird line' }
     const h = estimateRowHeight(itemRow(wt), ['comment'], repoMap, null)
-    // ceil(3 × 16.5) + 4px padding = 54, total = 52 + 54 + 2 = 108
-    expect(h).toBe(108)
+    // base 55 + ceil(3 × 16.5)=50 + 4px py-0.5 + 8px meta spacing = 117
+    expect(h).toBe(117)
   })
 
   it('estimates wrapped long lines in comment', () => {
     // 70 chars wraps to 2 lines at ~35 chars/line
     const wt = { ...worktree, comment: 'a'.repeat(70) }
     const h = estimateRowHeight(itemRow(wt), ['comment'], repoMap, null)
-    // ceil(2 × 16.5) + 4 = 37, total = 52 + 37 + 2 = 91
-    expect(h).toBe(91)
+    // base 55 + ceil(2 × 16.5)=33 + 4px py-0.5 + 8px meta spacing = 100
+    expect(h).toBe(100)
   })
 
   it('stacks all metadata lines correctly', () => {
@@ -113,9 +113,9 @@ describe('estimateRowHeight', () => {
       '/tmp/orca::feature/cool': { data: { number: 1 } }
     }
     const h = estimateRowHeight(itemRow(wt), ['issue', 'pr', 'comment'], repoMap, prCache)
-    // 52 base + 22 issue + 22 pr + (1×17+4) comment + 2 mt-0.5 = 119
+    // 55 base + 16 issue + 16 pr + (17+4) comment + 8 meta spacing + 2×3 gaps = 122
     // (inter-card gap is handled by the virtualizer's `gap` option, not here)
-    expect(h).toBe(119)
+    expect(h).toBe(122)
   })
 
   it('strips refs/heads/ prefix when building PR cache key', () => {
@@ -124,6 +124,12 @@ describe('estimateRowHeight', () => {
       '/tmp/orca::my-branch': { data: { number: 5 } }
     }
     const h = estimateRowHeight(itemRow(wt), ['pr'], repoMap, prCache)
-    expect(h).toBe(76) // 52 + 22 + 2
+    expect(h).toBe(79) // 55 + 16 + 8
+  })
+
+  it('adds 1px when both status and unread are in cardProps', () => {
+    expect(estimateRowHeight(itemRow(worktree), ['status', 'unread'], repoMap, null)).toBe(56)
+    expect(estimateRowHeight(itemRow(worktree), ['status'], repoMap, null)).toBe(55)
+    expect(estimateRowHeight(itemRow(worktree), ['unread'], repoMap, null)).toBe(55)
   })
 })

--- a/src/renderer/src/components/sidebar/worktree-list-estimate.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-estimate.ts
@@ -2,11 +2,9 @@ import type { Repo } from '../../../../shared/types'
 import type { Row } from './worktree-list-groups'
 
 // Estimate the pixel height of a virtualizer row based on which metadata lines
-// will render. Fixed-height rows (base 52, issue/PR 22, mt-0.5 2) are coupled
-// to WorktreeCard's Tailwind classes; the comment row uses a dynamic estimate
-// because it renders with whitespace-pre-wrap.  See the coupling comment in
-// WorktreeCard's meta section.  The inter-card gap is handled by the
-// virtualizer's `gap` option, not here.
+// will render.  All pixel constants are coupled to WorktreeCard's Tailwind
+// classes (see the coupling comment in WorktreeCard's meta section).  The
+// inter-card gap is handled by the virtualizer's `gap` option, not here.
 //
 // Uses prCache (not wt.linkedPR) because prCache is the actual data source
 // WorktreeCard checks when deciding to show the PR row.
@@ -20,32 +18,55 @@ export function estimateRowHeight(
     return 38
   }
   const wt = row.worktree
-  let h = 52 // base: py-2 + title + subtitle + gaps
+
+  // Base: border(2) + py-2(16) + title leading-tight(15) + gap-1.5(6)
+  //       + subtitle row with badges(16) = 55.
+  // Why 55 not 52: the old value omitted the 2px border and used 14px for
+  // the title instead of the actual 15px (12px × 1.25 leading-tight).
+  // When both status and unread indicators are visible, the left column
+  // (pt-[2px] + StatusIndicator h-3 + gap-2 + unread button size-4 = 38px)
+  // is 1px taller than the content column (37px).
+  let h = 55
+  if (cardProps.includes('status') && cardProps.includes('unread')) {
+    h += 1
+  }
+
+  // Count meta rows (issue, PR, comment) to add per-section spacing once.
+  let metaCount = 0
+
   if (cardProps.includes('issue') && wt.linkedIssue) {
-    h += 22
+    h += 16 // py-0.5(4) + icon size-3(12)
+    metaCount++
   }
   if (cardProps.includes('pr')) {
     const repo = repoMap.get(wt.repoId)
     const branch = wt.branch.replace(/^refs\/heads\//, '')
     const prKey = repo && branch ? `${repo.path}::${branch}` : ''
     if (prKey && prCache?.[prKey]?.data) {
-      h += 22
+      h += 16 // py-0.5(4) + icon size-3(12)
+      metaCount++
     }
   }
   if (cardProps.includes('comment') && wt.comment) {
-    // Comment now renders with whitespace-pre-wrap + break-words, so its
-    // height depends on content.  Estimate visual lines from explicit newlines
-    // and character wrapping (~35 chars per line at typical sidebar width).
-    // Line-height is leading-normal (1.5 × 11px = 16.5px) + 4px padding (py-0.5).
+    // Comment renders with whitespace-pre-wrap + break-words, so its height
+    // depends on content.  Estimate visual lines from explicit newlines and
+    // character wrapping (~35 chars per line at typical sidebar width).
+    // Line-height is leading-normal (1.5 × 11px = 16.5px) + py-0.5(4px).
     const lines = wt.comment.split('\n')
     let totalLines = 0
     for (const line of lines) {
       totalLines += Math.max(1, Math.ceil(line.length / 35))
     }
     h += Math.ceil(totalLines * 16.5) + 4
+    metaCount++
   }
-  if (h > 52) {
-    h += 2
+
+  if (metaCount > 0) {
+    // Spacing before the meta section: parent flex gap-1.5(6) + mt-0.5(2).
+    h += 8
+    // gap-[3px] between sibling meta rows.
+    h += (metaCount - 1) * 3
   }
+
   return h
 }


### PR DESCRIPTION
## Summary
- Recalibrate virtualizer row height constants to match actual WorktreeCard CSS layout
- Base height 52→55 (accounts for 2px border + actual 15px title leading-tight)
- Meta row heights 22→16 (py-0.5 + icon size-3), with proper gap-1.5/mt-0.5/gap-[3px] spacing
- Add +1px adjustment when both status and unread indicators are visible (left column taller)

## Test plan
- [x] All existing `estimateRowHeight` tests updated and passing
- [x] New test for status+unread indicator height bump
- [x] TypeScript typecheck passes