### PR TITLE
fix: invalidate filesystem-auth cache after CLI worktree creation

### DIFF
--- a/src/main/ipc/filesystem.test.ts
+++ b/src/main/ipc/filesystem.test.ts
@@ -370,6 +370,73 @@ describe('registerFilesystemHandlers', () => {
     expect(getBranchCompareMock).toHaveBeenCalledWith(externalWorktreePath, 'origin/main')
   })
 
+  it('rejects branchCompare for a worktree added after cache was built, then succeeds after invalidation', async () => {
+    // Reproduces the bug where CLI-created worktrees fail with
+    // "Access denied: unknown repository or worktree path" because the
+    // filesystem-auth cache was not invalidated after creation.
+    const cliWorktreePath = path.resolve('/external/cli-created-worktree')
+
+    // Step 1: register handlers and trigger initial cache build with only
+    // the original worktree in the listing.
+    registerFilesystemHandlers(store as never)
+
+    // Warm the cache by calling a git operation on the existing worktree.
+    getStatusMock.mockResolvedValue({ entries: [] })
+    await handlers.get('git:status')!(null, { worktreePath: WORKTREE_FEATURE_PATH })
+
+    // Step 2: simulate the CLI creating a new worktree — git now lists it,
+    // but the auth cache is stale.
+    listWorktreesMock.mockResolvedValue([
+      {
+        path: WORKTREE_FEATURE_PATH,
+        head: 'abc',
+        branch: '',
+        isBare: false,
+        isMainWorktree: false
+      },
+      {
+        path: cliWorktreePath,
+        head: 'def',
+        branch: 'refs/heads/cli-feature',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+
+    // Step 3: branchCompare on the new worktree should fail — this is the
+    // exact error the user reported.
+    await expect(
+      handlers.get('git:branchCompare')!(null, {
+        worktreePath: cliWorktreePath,
+        baseRef: 'origin/main'
+      })
+    ).rejects.toThrow('Access denied: unknown repository or worktree path')
+
+    // Step 4: invalidate the cache (what our fix does after CLI create).
+    invalidateAuthorizedRootsCache()
+
+    // Step 5: the same branchCompare should now succeed.
+    getBranchCompareMock.mockResolvedValue({
+      summary: {
+        baseRef: 'origin/main',
+        baseOid: 'base-oid',
+        compareRef: 'cli-feature',
+        headOid: 'head-oid',
+        mergeBase: 'merge-base-oid',
+        changedFiles: 0,
+        status: 'ready'
+      },
+      entries: []
+    })
+
+    await handlers.get('git:branchCompare')!(null, {
+      worktreePath: cliWorktreePath,
+      baseRef: 'origin/main'
+    })
+
+    expect(getBranchCompareMock).toHaveBeenCalledWith(cliWorktreePath, 'origin/main')
+  })
+
   it('routes branch diff queries through the pinned branch diff helper', async () => {
     getBranchDiffMock.mockResolvedValue({
       kind: 'text',

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -9,7 +9,8 @@ const {
   MOCK_GIT_WORKTREES,
   addWorktreeMock,
   computeWorktreePathMock,
-  ensurePathWithinWorkspaceMock
+  ensurePathWithinWorkspaceMock,
+  invalidateAuthorizedRootsCacheMock
 } = vi.hoisted(() => ({
   MOCK_GIT_WORKTREES: [
     {
@@ -22,7 +23,8 @@ const {
   ],
   addWorktreeMock: vi.fn(),
   computeWorktreePathMock: vi.fn(),
-  ensurePathWithinWorkspaceMock: vi.fn()
+  ensurePathWithinWorkspaceMock: vi.fn(),
+  invalidateAuthorizedRootsCacheMock: vi.fn()
 }))
 
 vi.mock('../git/worktree', () => ({
@@ -45,6 +47,10 @@ vi.mock('../ipc/worktree-logic', async (importOriginal) => {
   }
 })
 
+vi.mock('../ipc/filesystem-auth', () => ({
+  invalidateAuthorizedRootsCache: invalidateAuthorizedRootsCacheMock
+}))
+
 afterEach(() => {
   vi.mocked(listWorktrees).mockResolvedValue(MOCK_GIT_WORKTREES)
   vi.mocked(addWorktree).mockReset()
@@ -54,6 +60,7 @@ afterEach(() => {
   vi.mocked(getEffectiveHooks).mockReturnValue(null)
   computeWorktreePathMock.mockReset()
   ensurePathWithinWorkspaceMock.mockReset()
+  invalidateAuthorizedRootsCacheMock.mockReset()
 })
 
 const TEST_WINDOW_ID = 1
@@ -645,6 +652,37 @@ describe('OrcaRuntimeService', () => {
       }
     })
     expect(activateWorktree).toHaveBeenCalledWith('repo-1', expect.any(String), result.setup)
+  })
+
+  it('invalidates the filesystem-auth cache after CLI worktree creation', async () => {
+    // Reproduces: CLI-created worktrees fail with "Access denied: unknown
+    // repository or worktree path" because the filesystem-auth cache was
+    // not invalidated, so git:branchCompare could not resolve the new path.
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setNotifier({
+      worktreesChanged: vi.fn(),
+      reposChanged: vi.fn(),
+      activateWorktree: vi.fn()
+    })
+
+    computeWorktreePathMock.mockReturnValue('/tmp/workspaces/cli-worktree')
+    ensurePathWithinWorkspaceMock.mockReturnValue('/tmp/workspaces/cli-worktree')
+    vi.mocked(listWorktrees).mockResolvedValueOnce([
+      {
+        path: '/tmp/workspaces/cli-worktree',
+        head: 'abc',
+        branch: 'cli-worktree',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+
+    await runtime.createManagedWorktree({
+      repoSelector: 'id:repo-1',
+      name: 'cli-worktree'
+    })
+
+    expect(invalidateAuthorizedRootsCacheMock).toHaveBeenCalled()
   })
 
   it('preserves create-time metadata on later runtime listings when Windows path formatting differs', async () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -52,6 +52,7 @@ import {
   shouldSetDisplayName,
   areWorktreePathsEqual
 } from '../ipc/worktree-logic'
+import { invalidateAuthorizedRootsCache } from '../ipc/filesystem-auth'
 
 type RuntimeStore = {
   getRepos: Store['getRepos']
@@ -682,6 +683,12 @@ export class OrcaRuntimeService {
     // disk without becoming the active workspace in the UI.
     this.notifier?.activateWorktree(repo.id, worktree.id, setup)
     this.invalidateResolvedWorktreeCache()
+    // Why: the filesystem-auth layer maintains a separate cache of registered
+    // worktree roots used by git IPC handlers (branchCompare, diff, status, etc.)
+    // to authorize paths. Without invalidating it here, CLI-created worktrees
+    // are not recognized and all git operations fail with "Access denied:
+    // unknown repository or worktree path".
+    invalidateAuthorizedRootsCache()
     return {
       worktree,
       ...(setup ? { setup } : {})
@@ -745,6 +752,7 @@ export class OrcaRuntimeService {
         await gitExecFileAsync(['worktree', 'prune'], { cwd: repo.path }).catch(() => {})
         this.store.removeWorktreeMeta(worktree.id)
         this.invalidateResolvedWorktreeCache()
+        invalidateAuthorizedRootsCache()
         this.notifier?.worktreesChanged(repo.id)
         return
       }
@@ -753,6 +761,7 @@ export class OrcaRuntimeService {
 
     this.store.removeWorktreeMeta(worktree.id)
     this.invalidateResolvedWorktreeCache()
+    invalidateAuthorizedRootsCache()
     this.notifier?.worktreesChanged(repo.id)
   }
 


### PR DESCRIPTION
## Summary

- **Bug:** Worktrees created via `orca worktree create` (CLI) failed all git IPC operations (`branchCompare`, `diff`, `status`, etc.) with `"Access denied: unknown repository or worktree path"`
- **Root cause:** `OrcaRuntimeService.createManagedWorktree` only invalidated its own internal `resolvedWorktreeCache`, but never the `filesystem-auth` module's `registeredWorktreeRoots` cache — a completely separate cache used by `resolveRegisteredWorktreePath` to authorize git operations. The UI create path (`worktrees:create` IPC) correctly called `rebuildAuthorizedRootsCache`, but the CLI path was missing this.
- **Fix:** Added `invalidateAuthorizedRootsCache()` calls in `orca-runtime.ts` after worktree create and remove operations, matching the IPC handler behavior.

## Test plan

- [x] Added end-to-end reproduction test in `filesystem.test.ts` that demonstrates the stale-cache bug (step 3 rejects with the exact user-reported error) and verifies invalidation fixes it (step 5 succeeds)
- [x] Added unit test in `orca-runtime.test.ts` that asserts `invalidateAuthorizedRootsCache` is called after `createManagedWorktree`
- [x] Verified the runtime test **fails without the fix** (commented out the call → "expected to be called at least once")
- [x] All 36 tests pass, typecheck clean