### PR TITLE
fix: preserve reverse search shortcut

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,5 +1,5 @@
 import { app, BrowserWindow, nativeImage, nativeTheme } from 'electron'
-import { electronApp, optimizer, is } from '@electron-toolkit/utils'
+import { electronApp, is } from '@electron-toolkit/utils'
 import devIcon from '../../resources/icon-dev.png?asset'
 import { Store, initDataPath } from './persistence'
 import { StatsCollector, initStatsPath } from './stats/collector'
@@ -84,10 +84,6 @@ app.whenReady().then(async () => {
     const dockIcon = nativeImage.createFromPath(devIcon)
     app.dock?.setIcon(dockIcon)
   }
-
-  app.on('browser-window-created', (_, window) => {
-    optimizer.watchWindowShortcuts(window)
-  })
 
   store = new Store()
   stats = new StatsCollector()

--- a/src/main/menu/register-app-menu.test.ts
+++ b/src/main/menu/register-app-menu.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { buildFromTemplateMock, setApplicationMenuMock, getFocusedWindowMock } = vi.hoisted(() => ({
+  buildFromTemplateMock: vi.fn(),
+  setApplicationMenuMock: vi.fn(),
+  getFocusedWindowMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  BrowserWindow: {
+    getFocusedWindow: getFocusedWindowMock
+  },
+  Menu: {
+    buildFromTemplate: buildFromTemplateMock,
+    setApplicationMenu: setApplicationMenuMock
+  },
+  app: {
+    name: 'Orca'
+  }
+}))
+
+import { registerAppMenu } from './register-app-menu'
+
+function buildMenuOptions() {
+  return {
+    onCheckForUpdates: vi.fn(),
+    onOpenSettings: vi.fn(),
+    onZoomIn: vi.fn(),
+    onZoomOut: vi.fn(),
+    onZoomReset: vi.fn()
+  }
+}
+
+describe('registerAppMenu', () => {
+  beforeEach(() => {
+    buildFromTemplateMock.mockReset()
+    setApplicationMenuMock.mockReset()
+    getFocusedWindowMock.mockReset()
+    buildFromTemplateMock.mockImplementation((template) => ({ template }))
+  })
+
+  it('uses a reload menu item without a ctrl/cmd+r accelerator', () => {
+    registerAppMenu(buildMenuOptions())
+
+    expect(buildFromTemplateMock).toHaveBeenCalledTimes(1)
+    const template = buildFromTemplateMock.mock.calls[0][0] as Electron.MenuItemConstructorOptions[]
+    const viewMenu = template.find((item) => item.label === 'View')
+
+    expect(viewMenu?.submenu).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: 'Reload'
+        }),
+        expect.objectContaining({
+          label: 'Force Reload',
+          accelerator: 'Shift+CmdOrCtrl+R'
+        })
+      ])
+    )
+
+    const submenu = viewMenu?.submenu as Electron.MenuItemConstructorOptions[]
+    const reloadItem = submenu.find((item) => item.label === 'Reload')
+    expect(reloadItem?.accelerator).toBeUndefined()
+  })
+
+  it('reloads the focused window from the view menu', () => {
+    const reloadMock = vi.fn()
+    const reloadIgnoringCacheMock = vi.fn()
+    getFocusedWindowMock.mockReturnValue({
+      webContents: {
+        reload: reloadMock,
+        reloadIgnoringCache: reloadIgnoringCacheMock
+      }
+    })
+
+    registerAppMenu(buildMenuOptions())
+
+    const template = buildFromTemplateMock.mock.calls[0][0] as Electron.MenuItemConstructorOptions[]
+    const viewMenu = template.find((item) => item.label === 'View')
+    const submenu = viewMenu?.submenu as Electron.MenuItemConstructorOptions[]
+    const reloadItem = submenu.find((item) => item.label === 'Reload')
+
+    reloadItem?.click?.({} as never, {} as never, {} as never)
+
+    expect(reloadMock).toHaveBeenCalledTimes(1)
+    expect(reloadIgnoringCacheMock).not.toHaveBeenCalled()
+  })
+
+  it('force reloads the focused window from the view menu', () => {
+    const reloadMock = vi.fn()
+    const reloadIgnoringCacheMock = vi.fn()
+    getFocusedWindowMock.mockReturnValue({
+      webContents: {
+        reload: reloadMock,
+        reloadIgnoringCache: reloadIgnoringCacheMock
+      }
+    })
+
+    registerAppMenu(buildMenuOptions())
+
+    const template = buildFromTemplateMock.mock.calls[0][0] as Electron.MenuItemConstructorOptions[]
+    const viewMenu = template.find((item) => item.label === 'View')
+    const submenu = viewMenu?.submenu as Electron.MenuItemConstructorOptions[]
+    const forceReloadItem = submenu.find((item) => item.label === 'Force Reload')
+
+    forceReloadItem?.click?.({} as never, {} as never, {} as never)
+
+    expect(reloadIgnoringCacheMock).toHaveBeenCalledTimes(1)
+    expect(reloadMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/menu/register-app-menu.ts
+++ b/src/main/menu/register-app-menu.ts
@@ -1,4 +1,4 @@
-import { Menu, app } from 'electron'
+import { BrowserWindow, Menu, app } from 'electron'
 
 type RegisterAppMenuOptions = {
   onOpenSettings: () => void
@@ -15,6 +15,20 @@ export function registerAppMenu({
   onZoomOut,
   onZoomReset
 }: RegisterAppMenuOptions): void {
+  const reloadFocusedWindow = (ignoreCache: boolean): void => {
+    const webContents = BrowserWindow.getFocusedWindow()?.webContents
+    if (!webContents) {
+      return
+    }
+
+    if (ignoreCache) {
+      webContents.reloadIgnoringCache()
+      return
+    }
+
+    webContents.reload()
+  }
+
   const template: Electron.MenuItemConstructorOptions[] = [
     {
       label: app.name,
@@ -54,8 +68,15 @@ export function registerAppMenu({
     {
       label: 'View',
       submenu: [
-        { role: 'reload' },
-        { role: 'forceReload' },
+        {
+          label: 'Reload',
+          click: () => reloadFocusedWindow(false)
+        },
+        {
+          label: 'Force Reload',
+          accelerator: 'Shift+CmdOrCtrl+R',
+          click: () => reloadFocusedWindow(true)
+        },
         { role: 'toggleDevTools' },
         { type: 'separator' },
         {

--- a/src/main/window/createMainWindow.test.ts
+++ b/src/main/window/createMainWindow.test.ts
@@ -269,13 +269,15 @@ describe('createMainWindow', () => {
 
     createMainWindow(null)
 
-    const preventDefault = vi.fn()
-    windowHandlers['before-input-event'](
-      { preventDefault } as never,
-      { type: 'keyDown', code: 'KeyR', key: 'r', meta: false, control: true, alt: false } as never
-    )
+    for (const input of [
+      { type: 'keyDown', code: 'KeyR', key: 'r', meta: false, control: true, alt: false },
+      { type: 'keyDown', code: 'KeyR', key: 'r', meta: true, control: false, alt: false }
+    ]) {
+      const preventDefault = vi.fn()
+      windowHandlers['before-input-event']({ preventDefault } as never, input as never)
+      expect(preventDefault).not.toHaveBeenCalled()
+    }
 
-    expect(preventDefault).not.toHaveBeenCalled()
     expect(webContents.send).not.toHaveBeenCalled()
   })
 

--- a/src/main/window/createMainWindow.test.ts
+++ b/src/main/window/createMainWindow.test.ts
@@ -1,9 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { browserWindowMock, openExternalMock, attachGuestPoliciesMock } = vi.hoisted(() => ({
+const { browserWindowMock, openExternalMock, attachGuestPoliciesMock, isMock } = vi.hoisted(() => ({
   browserWindowMock: vi.fn(),
   openExternalMock: vi.fn(),
-  attachGuestPoliciesMock: vi.fn()
+  attachGuestPoliciesMock: vi.fn(),
+  isMock: { dev: false }
 }))
 
 vi.mock('electron', () => ({
@@ -14,7 +15,7 @@ vi.mock('electron', () => ({
 }))
 
 vi.mock('@electron-toolkit/utils', () => ({
-  is: { dev: false }
+  is: isMock
 }))
 
 vi.mock('../../../resources/icon.png?asset', () => ({
@@ -38,6 +39,7 @@ describe('createMainWindow', () => {
     browserWindowMock.mockReset()
     openExternalMock.mockReset()
     attachGuestPoliciesMock.mockReset()
+    isMock.dev = false
   })
 
   it('enables renderer sandboxing and opens external links safely', () => {
@@ -52,7 +54,10 @@ describe('createMainWindow', () => {
       setWindowOpenHandler: vi.fn((handler) => {
         windowHandlers.windowOpen = handler
       }),
-      send: vi.fn()
+      send: vi.fn(),
+      isDevToolsOpened: vi.fn(),
+      openDevTools: vi.fn(),
+      closeDevTools: vi.fn()
     }
     const browserWindowInstance = {
       webContents,
@@ -228,5 +233,96 @@ describe('createMainWindow', () => {
     expect(webContents.send).toHaveBeenCalledTimes(2)
     expect(webContents.send).toHaveBeenNthCalledWith(1, 'terminal:zoom', 'out')
     expect(webContents.send).toHaveBeenNthCalledWith(2, 'terminal:zoom', 'in')
+  })
+
+  it('does not intercept ctrl/cmd+r in before-input-event', () => {
+    const windowHandlers: Record<string, (...args: any[]) => void> = {}
+    const webContents = {
+      on: vi.fn((event, handler) => {
+        windowHandlers[event] = handler
+      }),
+      setZoomLevel: vi.fn(),
+      setBackgroundThrottling: vi.fn(),
+      invalidate: vi.fn(),
+      setWindowOpenHandler: vi.fn(),
+      send: vi.fn(),
+      isDevToolsOpened: vi.fn(),
+      openDevTools: vi.fn(),
+      closeDevTools: vi.fn()
+    }
+    const browserWindowInstance = {
+      webContents,
+      on: vi.fn(),
+      isDestroyed: vi.fn(() => false),
+      isMaximized: vi.fn(() => true),
+      isFullScreen: vi.fn(() => false),
+      getSize: vi.fn(() => [1200, 800]),
+      setSize: vi.fn(),
+      maximize: vi.fn(),
+      show: vi.fn(),
+      loadFile: vi.fn(),
+      loadURL: vi.fn()
+    }
+    browserWindowMock.mockImplementation(function () {
+      return browserWindowInstance
+    })
+
+    createMainWindow(null)
+
+    const preventDefault = vi.fn()
+    windowHandlers['before-input-event'](
+      { preventDefault } as never,
+      { type: 'keyDown', code: 'KeyR', key: 'r', meta: false, control: true, alt: false } as never
+    )
+
+    expect(preventDefault).not.toHaveBeenCalled()
+    expect(webContents.send).not.toHaveBeenCalled()
+  })
+
+  it('toggles devtools on F12 in development', () => {
+    isMock.dev = true
+
+    const windowHandlers: Record<string, (...args: any[]) => void> = {}
+    const webContents = {
+      on: vi.fn((event, handler) => {
+        windowHandlers[event] = handler
+      }),
+      setZoomLevel: vi.fn(),
+      setBackgroundThrottling: vi.fn(),
+      invalidate: vi.fn(),
+      setWindowOpenHandler: vi.fn(),
+      send: vi.fn(),
+      isDevToolsOpened: vi.fn(() => false),
+      openDevTools: vi.fn(),
+      closeDevTools: vi.fn()
+    }
+    const browserWindowInstance = {
+      webContents,
+      on: vi.fn(),
+      isDestroyed: vi.fn(() => false),
+      isMaximized: vi.fn(() => true),
+      isFullScreen: vi.fn(() => false),
+      getSize: vi.fn(() => [1200, 800]),
+      setSize: vi.fn(),
+      maximize: vi.fn(),
+      show: vi.fn(),
+      loadFile: vi.fn(),
+      loadURL: vi.fn()
+    }
+    browserWindowMock.mockImplementation(function () {
+      return browserWindowInstance
+    })
+
+    createMainWindow(null)
+
+    const preventDefault = vi.fn()
+    windowHandlers['before-input-event'](
+      { preventDefault } as never,
+      { type: 'keyDown', code: 'F12', key: 'F12', meta: false, control: false, alt: false } as never
+    )
+
+    expect(preventDefault).toHaveBeenCalledTimes(1)
+    expect(webContents.openDevTools).toHaveBeenCalledWith({ mode: 'undocked' })
+    expect(webContents.closeDevTools).not.toHaveBeenCalled()
   })
 })

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -176,6 +176,16 @@ export function createMainWindow(store: Store | null): BrowserWindow {
       return
     }
 
+    if (is.dev && input.code === 'F12') {
+      event.preventDefault()
+      if (mainWindow.webContents.isDevToolsOpened()) {
+        mainWindow.webContents.closeDevTools()
+      } else {
+        mainWindow.webContents.openDevTools({ mode: 'undocked' })
+      }
+      return
+    }
+
     const modifierPressed = process.platform === 'darwin' ? input.meta : input.control
     if (!modifierPressed || input.alt) {
       return

--- a/src/renderer/src/components/settings/ShortcutsPane.tsx
+++ b/src/renderer/src/components/settings/ShortcutsPane.tsx
@@ -87,6 +87,11 @@ const SHORTCUT_GROUP_DEFINITIONS: ShortcutGroupDefinition[] = [
         action: 'Reset Size',
         searchKeywords: ['shortcut', 'zoom', 'reset', 'size', 'actual'],
         keys: ({ mod }) => [mod, '0']
+      },
+      {
+        action: 'Force Reload',
+        searchKeywords: ['shortcut', 'reload', 'refresh', 'force'],
+        keys: ({ mod, shift }) => [mod, shift, 'R']
       }
     ]
   },


### PR DESCRIPTION
## Summary

This fixes terminal reverse search being blocked by Orca's app-level reload shortcut handling.

Changes:
- stop using `optimizer.watchWindowShortcuts(window)`, which prevented `KeyR` with `Ctrl` or `Cmd` in packaged builds
- replace the default `Reload` / `Force Reload` menu roles with explicit menu items so plain reload no longer reserves `CmdOrCtrl+R`
- keep `Force Reload` on `Shift+CmdOrCtrl+R`
- preserve dev-only `F12` devtools behavior in the main window input handler
- update Settings > Shortcuts to list `Force Reload` with platform-correct shortcut labels

User-visible behavior:
- `Ctrl+R` now reaches the shell for reverse-i-search in terminal panes
- `Reload` remains available in the View menu, but no longer has a keyboard shortcut
- `Force Reload` is now the only reload shortcut: `⇧⌘R` on macOS and `Ctrl+Shift+R` on Linux/Windows

Closes #443.

Terminal reverse search:
<img width="239" height="56" alt="image" src="https://github.com/user-attachments/assets/00f21135-1726-41ca-8c34-653cb82df7d3" />

Force Reload shortcut update:
<img width="970" height="64" alt="image" src="https://github.com/user-attachments/assets/24c62cbc-c012-40a6-8fc9-7475c541a402" />

## Testing

Ran:
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`

Added regression coverage for:
- packaged main-window key handling no longer intercepting `Ctrl/Cmd+R`
- preserved dev-only `F12` behavior after removing the Electron toolkit shortcut hook
- menu wiring for `Reload` and `Force Reload`

Manual notes:
- verified packaged behavior on macOS via local packaged build
- Windows/Linux not manually smoke-tested, but the shortcut behavior is now driven by cross-platform menu wiring and platform-aware shortcut labels

## UI Notes

Minor visual change only:
- Settings > Shortcuts now shows `Force Reload`

No layout or styling changes beyond that shortcut row.

## AI Review Summary

Cross-platform compatibility review:
- removed the cross-platform `CmdOrCtrl+R` conflict at the menu layer instead of relying on renderer-only behavior
- preserved platform-aware shortcut labels in Settings (`⌘` / `⇧` on macOS, `Ctrl` / `Shift` on other platforms)
- kept the explicit `Shift+CmdOrCtrl+R` accelerator for `Force Reload`

Security audit summary:
- no new IPC channels, preload surface, or privilege expansion
- reload handling still operates through Electron `webContents` on the focused window only
- change reduces unexpected app-level interception of terminal control input without widening renderer privileges
