### PR TITLE
fix: show update prompt for unrecognized orca.yaml keys

### DIFF
--- a/src/main/hooks.test.ts
+++ b/src/main/hooks.test.ts
@@ -153,6 +153,14 @@ describe('hasUnrecognizedOrcaYamlKeys', () => {
     expect(hasUnrecognizedOrcaYamlKeys('/test/repo')).toBe(true)
   })
 
+  it('returns true when an unknown key has no trailing space (block-value form)', async () => {
+    const fs = await import('fs')
+    vi.mocked(fs.readFileSync).mockReturnValue('futureFeature:\n  nested: value\n')
+
+    const { hasUnrecognizedOrcaYamlKeys } = await import('./hooks')
+    expect(hasUnrecognizedOrcaYamlKeys('/test/repo')).toBe(true)
+  })
+
   it('returns true when the file mixes recognised and unrecognised keys', async () => {
     const fs = await import('fs')
     vi.mocked(fs.readFileSync).mockReturnValue(

--- a/src/main/hooks.test.ts
+++ b/src/main/hooks.test.ts
@@ -144,6 +144,54 @@ describe('parseOrcaYaml', () => {
   })
 })
 
+describe('hasUnrecognizedOrcaYamlKeys', () => {
+  it('returns true when the file contains only keys this version does not handle', async () => {
+    const fs = await import('fs')
+    vi.mocked(fs.readFileSync).mockReturnValue('futureFeature: |\n  some config\n')
+
+    const { hasUnrecognizedOrcaYamlKeys } = await import('./hooks')
+    expect(hasUnrecognizedOrcaYamlKeys('/test/repo')).toBe(true)
+  })
+
+  it('returns true when the file mixes recognised and unrecognised keys', async () => {
+    const fs = await import('fs')
+    vi.mocked(fs.readFileSync).mockReturnValue(
+      'scripts:\n  setup: |\n    pnpm install\nnewFeature: enabled\n'
+    )
+
+    const { hasUnrecognizedOrcaYamlKeys } = await import('./hooks')
+    expect(hasUnrecognizedOrcaYamlKeys('/test/repo')).toBe(true)
+  })
+
+  it('returns false when the file contains only recognised keys', async () => {
+    const fs = await import('fs')
+    vi.mocked(fs.readFileSync).mockReturnValue(
+      'scripts:\n  setup: |\n    pnpm install\nissueCommand: |\n  claude -p "test"\n'
+    )
+
+    const { hasUnrecognizedOrcaYamlKeys } = await import('./hooks')
+    expect(hasUnrecognizedOrcaYamlKeys('/test/repo')).toBe(false)
+  })
+
+  it('returns false when the file is empty or has no top-level keys', async () => {
+    const fs = await import('fs')
+    vi.mocked(fs.readFileSync).mockReturnValue('# just a comment\n')
+
+    const { hasUnrecognizedOrcaYamlKeys } = await import('./hooks')
+    expect(hasUnrecognizedOrcaYamlKeys('/test/repo')).toBe(false)
+  })
+
+  it('returns false when the file cannot be read', async () => {
+    const fs = await import('fs')
+    vi.mocked(fs.readFileSync).mockImplementation(() => {
+      throw new Error('ENOENT')
+    })
+
+    const { hasUnrecognizedOrcaYamlKeys } = await import('./hooks')
+    expect(hasUnrecognizedOrcaYamlKeys('/test/repo')).toBe(false)
+  })
+})
+
 describe('readIssueCommand', () => {
   it('prefers the local override over the shared orca.yaml command', async () => {
     const fs = await import('fs')

--- a/src/main/hooks.ts
+++ b/src/main/hooks.ts
@@ -146,7 +146,10 @@ export function hasUnrecognizedOrcaYamlKeys(repoPath: string): boolean {
   try {
     const content = readFileSync(join(repoPath, 'orca.yaml'), 'utf-8')
     return content.split(/\r?\n/).some((line) => {
-      const m = line.match(/^([A-Za-z][A-Za-z0-9_-]*):\s/)
+      // Why: bare `key:` at end-of-line (no trailing space) is valid YAML for
+      // a mapping with a block value on the next line. Match both forms so
+      // newer keys like `futureFeature:\n  nested` are still detected.
+      const m = line.match(/^([A-Za-z][A-Za-z0-9_-]*):(\s|$)/)
       return m != null && !RECOGNIZED_ORCA_YAML_KEYS.has(m[1])
     })
   } catch {

--- a/src/main/hooks.ts
+++ b/src/main/hooks.ts
@@ -131,6 +131,29 @@ export function hasHooksFile(repoPath: string): boolean {
   return existsSync(join(repoPath, 'orca.yaml'))
 }
 
+// Why: when a newer Orca release adds a top-level key to `orca.yaml` (like
+// `issueCommand` was added here), older versions that don't recognise it will
+// return `null` from `parseOrcaYaml` and show a confusing "could not be parsed"
+// error.  Detecting well-formed but unrecognised keys lets the UI suggest an
+// update instead of implying the file is broken.
+const RECOGNIZED_ORCA_YAML_KEYS = new Set(['scripts', 'issueCommand'])
+
+/**
+ * Return true when `orca.yaml` contains at least one top-level key that this
+ * version of Orca does not handle.
+ */
+export function hasUnrecognizedOrcaYamlKeys(repoPath: string): boolean {
+  try {
+    const content = readFileSync(join(repoPath, 'orca.yaml'), 'utf-8')
+    return content.split(/\r?\n/).some((line) => {
+      const m = line.match(/^([A-Za-z][A-Za-z0-9_-]*):\s/)
+      return m != null && !RECOGNIZED_ORCA_YAML_KEYS.has(m[1])
+    })
+  } catch {
+    return false
+  }
+}
+
 // ─── Issue command files ────────────────────────────────────────────────
 // Why: `orca.yaml` is the tracked, project-wide defaults surface, while
 // `.orca/issue-command` remains the per-user override. Keeping the local file in

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -23,6 +23,7 @@ import {
   readIssueCommand,
   runHook,
   hasHooksFile,
+  hasUnrecognizedOrcaYamlKeys,
   shouldRunSetupForCreate,
   writeIssueCommand
 } from '../hooks'
@@ -301,14 +302,20 @@ export function registerWorktreeHandlers(mainWindow: BrowserWindow, store: Store
   ipcMain.handle('hooks:check', (_event, args: { repoId: string }) => {
     const repo = store.getRepo(args.repoId)
     if (!repo || isFolderRepo(repo)) {
-      return { hasHooks: false, hooks: null }
+      return { hasHooks: false, hooks: null, mayNeedUpdate: false }
     }
 
     const has = hasHooksFile(repo.path)
     const hooks = has ? loadHooks(repo.path) : null
+    // Why: when a newer Orca version adds a top-level key to `orca.yaml`, older
+    // versions that don't recognise it return null and show "could not be parsed".
+    // Detecting well-formed but unrecognised keys lets the UI suggest updating
+    // instead of implying the file is broken.
+    const mayNeedUpdate = has && !hooks && hasUnrecognizedOrcaYamlKeys(repo.path)
     return {
       hasHooks: has,
-      hooks
+      hooks,
+      mayNeedUpdate
     }
   })
 

--- a/src/preload/api-types.d.ts
+++ b/src/preload/api-types.d.ts
@@ -241,7 +241,9 @@ export type PreloadApi = {
   }
   browser: BrowserApi
   hooks: {
-    check: (args: { repoId: string }) => Promise<{ hasHooks: boolean; hooks: OrcaHooks | null }>
+    check: (args: {
+      repoId: string
+    }) => Promise<{ hasHooks: boolean; hooks: OrcaHooks | null; mayNeedUpdate: boolean }>
     readIssueCommand: (args: { repoId: string }) => Promise<{
       localContent: string | null
       sharedContent: string | null

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -357,7 +357,9 @@ const api = {
   },
 
   hooks: {
-    check: (args: { repoId: string }): Promise<{ hasHooks: boolean; hooks: unknown }> =>
+    check: (args: {
+      repoId: string
+    }): Promise<{ hasHooks: boolean; hooks: unknown; mayNeedUpdate: boolean }> =>
       ipcRenderer.invoke('hooks:check', args),
 
     readIssueCommand: (args: {

--- a/src/renderer/src/components/settings/RepositoryHooksSection.tsx
+++ b/src/renderer/src/components/settings/RepositoryHooksSection.tsx
@@ -122,7 +122,7 @@ function ExampleTemplateCard({
   return (
     <div className="space-y-2">
       <p className="text-[10px] tracking-[0.18em] text-muted-foreground">
-        Example `orca.yaml` template
+        Example <code className="rounded bg-muted px-1 py-0.5">orca.yaml</code> template
       </p>
       <div className="relative rounded-lg border border-border/50 bg-background/70">
         <Button

--- a/src/renderer/src/components/settings/RepositoryHooksSection.tsx
+++ b/src/renderer/src/components/settings/RepositoryHooksSection.tsx
@@ -274,18 +274,7 @@ export function RepositoryHooksSection({
               </p>
             </div>
           ) : yamlState === 'update-available' ? (
-            <div className="flex items-start gap-3 rounded-xl border border-amber-500/20 bg-background/60 p-4">
-              <div className="flex size-11 shrink-0 items-center justify-center rounded-xl bg-amber-500/12 text-amber-600 dark:text-amber-300">
-                <AlertTriangle className="size-5" />
-              </div>
-              <p className="text-sm leading-6 text-muted-foreground">
-                {/* Why: a file with well-formed YAML keys that this version doesn't handle
-                could be from a newer Orca release or could be a typo. Keep the same warning
-                tone as the parse-error state but add the update hint. */}
-                The file contains keys this version of Orca does not recognize. Check the file for
-                typos, or update Orca if a newer version is available.
-              </p>
-            </div>
+            <ExampleTemplateCard copiedTemplate={copiedTemplate} onCopyTemplate={onCopyTemplate} />
           ) : yamlState === 'invalid' ? (
             <div className="space-y-5">
               <div className="flex items-start gap-3 rounded-xl border border-amber-500/20 bg-background/60 p-4">

--- a/src/renderer/src/components/settings/RepositoryHooksSection.tsx
+++ b/src/renderer/src/components/settings/RepositoryHooksSection.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines -- Why: the YAML status card, issue-command editor, policy grid, and legacy-hook section form one cohesive settings surface; splitting them across files would scatter tightly coupled state and prop drilling. */
 import { useCallback, useEffect, useRef, useState } from 'react'
 import type { OrcaHooks, Repo, SetupRunPolicy } from '../../../../shared/types'
-import { AlertTriangle, ArrowUpCircle } from 'lucide-react'
+import { AlertTriangle } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '../ui/button'
 import { SearchableSetting } from './SearchableSetting'
@@ -49,11 +49,11 @@ const YAML_STATE_STYLES: Record<
       'Shared hook and issue-automation defaults are defined in the repo and available to everyone who uses it.'
   },
   'update-available': {
-    card: 'border-sky-500/20 bg-sky-500/5',
-    title: 'text-sky-700 dark:text-sky-300',
-    heading: 'Update available',
+    card: 'border-amber-500/20 bg-amber-500/5',
+    title: 'text-amber-700 dark:text-amber-300',
+    heading: '`orca.yaml` could not be parsed',
     description:
-      'Your `orca.yaml` contains configuration keys that this version of Orca does not recognize. Update Orca to use the latest features.'
+      'The file contains configuration keys that this version of Orca does not recognize. You may need to update Orca, or check the file for typos.'
   },
   invalid: {
     card: 'border-amber-500/20 bg-amber-500/5',
@@ -274,16 +274,16 @@ export function RepositoryHooksSection({
               </p>
             </div>
           ) : yamlState === 'update-available' ? (
-            <div className="flex items-start gap-3 rounded-xl border border-sky-500/20 bg-background/60 p-4">
-              <div className="flex size-11 shrink-0 items-center justify-center rounded-xl bg-sky-500/12 text-sky-600 dark:text-sky-300">
-                <ArrowUpCircle className="size-5" />
+            <div className="flex items-start gap-3 rounded-xl border border-amber-500/20 bg-background/60 p-4">
+              <div className="flex size-11 shrink-0 items-center justify-center rounded-xl bg-amber-500/12 text-amber-600 dark:text-amber-300">
+                <AlertTriangle className="size-5" />
               </div>
               <p className="text-sm leading-6 text-muted-foreground">
-                {/* Why: a file with well-formed YAML keys that this version doesn't handle is
-                almost certainly authored for a newer Orca release. Suggesting an update is
-                far less confusing than "could not be parsed", which implies the file is broken. */}
-                Your `orca.yaml` uses configuration keys that were introduced in a newer version of
-                Orca. Update to the latest release so all settings take effect.
+                {/* Why: a file with well-formed YAML keys that this version doesn't handle
+                could be from a newer Orca release or could be a typo. Keep the same warning
+                tone as the parse-error state but add the update hint. */}
+                The file contains keys this version of Orca does not recognize. Check the file for
+                typos, or update Orca if a newer version is available.
               </p>
             </div>
           ) : yamlState === 'invalid' ? (

--- a/src/renderer/src/components/settings/RepositoryHooksSection.tsx
+++ b/src/renderer/src/components/settings/RepositoryHooksSection.tsx
@@ -1,6 +1,7 @@
+/* eslint-disable max-lines -- Why: the YAML status card, issue-command editor, policy grid, and legacy-hook section form one cohesive settings surface; splitting them across files would scatter tightly coupled state and prop drilling. */
 import { useCallback, useEffect, useRef, useState } from 'react'
 import type { OrcaHooks, Repo, SetupRunPolicy } from '../../../../shared/types'
-import { AlertTriangle } from 'lucide-react'
+import { AlertTriangle, ArrowUpCircle } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '../ui/button'
 import { SearchableSetting } from './SearchableSetting'
@@ -9,6 +10,7 @@ type RepositoryHooksSectionProps = {
   repo: Repo
   yamlHooks: OrcaHooks | null
   hasHooksFile: boolean
+  mayNeedUpdate: boolean
   copiedTemplate: boolean
   onCopyTemplate: () => void
   onClearLegacyHooks: () => void
@@ -34,6 +36,40 @@ const EXAMPLE_TEMPLATE = `scripts:
     echo "Cleaning up before archive"
 issueCommand: |
   claude -p "Read issue #{{issue}} and write a design doc to docs/design-{{issue}}.md covering the approach, edge cases, and test plan." && codex exec "Review docs/design-{{issue}}.md for gaps, missing edge cases, or unclear requirements. Add feedback at the bottom."`
+
+const YAML_STATE_STYLES: Record<
+  string,
+  { card: string; title: string; heading: string; description: string }
+> = {
+  loaded: {
+    card: 'border-emerald-500/20 bg-emerald-500/5',
+    title: 'text-emerald-700 dark:text-emerald-300',
+    heading: 'Using `orca.yaml`',
+    description:
+      'Shared hook and issue-automation defaults are defined in the repo and available to everyone who uses it.'
+  },
+  'update-available': {
+    card: 'border-sky-500/20 bg-sky-500/5',
+    title: 'text-sky-700 dark:text-sky-300',
+    heading: 'Update available',
+    description:
+      'Your `orca.yaml` contains configuration keys that this version of Orca does not recognize. Update Orca to use the latest features.'
+  },
+  invalid: {
+    card: 'border-amber-500/20 bg-amber-500/5',
+    title: 'text-amber-700 dark:text-amber-300',
+    heading: '`orca.yaml` could not be parsed',
+    description:
+      'The core configuration file exists in the repo root, but Orca could not parse the supported hook definitions yet.'
+  },
+  missing: {
+    card: 'border-border/50 bg-muted/20',
+    title: 'text-foreground',
+    heading: 'No `orca.yaml` detected',
+    description:
+      'Add an `orca.yaml` file to enable shared setup, archive, or issue-automation defaults for this repo. Example template:'
+  }
+}
 
 /** Shared button grid for setup run-policy selectors. */
 function PolicyOptionGrid<P extends string>({
@@ -112,12 +148,22 @@ export function RepositoryHooksSection({
   repo,
   yamlHooks,
   hasHooksFile,
+  mayNeedUpdate,
   copiedTemplate,
   onCopyTemplate,
   onClearLegacyHooks,
   onUpdateSetupRunPolicy
 }: RepositoryHooksSectionProps): React.JSX.Element {
-  const yamlState = yamlHooks ? 'loaded' : hasHooksFile ? 'invalid' : 'missing'
+  // Why: distinguish "file has unrecognised top-level keys" from "file is
+  // genuinely malformed" so users see a helpful update prompt instead of a
+  // confusing parse-error when a newer Orca version adds keys to `orca.yaml`.
+  const yamlState = yamlHooks
+    ? 'loaded'
+    : hasHooksFile
+      ? mayNeedUpdate
+        ? 'update-available'
+        : 'invalid'
+      : 'missing'
   const hs = repo.hookSettings
   const legacyHookEntries = (['setup', 'archive'] as const)
     .map((hookName) => [hookName, hs?.scripts[hookName]?.trim() ?? ''] as const)
@@ -206,37 +252,13 @@ export function RepositoryHooksSection({
         description="Shared setup, archive, and issue automation commands for this repository."
         keywords={['hooks', 'setup', 'archive', 'yaml']}
       >
-        <div
-          className={`space-y-3 rounded-xl border p-4 ${
-            yamlState === 'loaded'
-              ? 'border-emerald-500/20 bg-emerald-500/5'
-              : yamlState === 'invalid'
-                ? 'border-amber-500/20 bg-amber-500/5'
-                : 'border-border/50 bg-muted/20'
-          }`}
-        >
+        <div className={`space-y-3 rounded-xl border p-4 ${YAML_STATE_STYLES[yamlState].card}`}>
           <div className="space-y-1">
-            <p
-              className={`text-sm font-medium ${
-                yamlState === 'loaded'
-                  ? 'text-emerald-700 dark:text-emerald-300'
-                  : yamlState === 'invalid'
-                    ? 'text-amber-700 dark:text-amber-300'
-                    : 'text-foreground'
-              }`}
-            >
-              {yamlState === 'loaded'
-                ? 'Using `orca.yaml`'
-                : yamlState === 'invalid'
-                  ? '`orca.yaml` could not be parsed'
-                  : 'No `orca.yaml` detected'}
+            <p className={`text-sm font-medium ${YAML_STATE_STYLES[yamlState].title}`}>
+              {YAML_STATE_STYLES[yamlState].heading}
             </p>
             <p className="text-xs text-muted-foreground">
-              {yamlState === 'loaded'
-                ? 'Shared hook and issue-automation defaults are defined in the repo and available to everyone who uses it.'
-                : yamlState === 'invalid'
-                  ? 'The core configuration file exists in the repo root, but Orca could not parse the supported hook definitions yet.'
-                  : 'Add an `orca.yaml` file to enable shared setup, archive, or issue-automation defaults for this repo. Example template:'}
+              {YAML_STATE_STYLES[yamlState].description}
             </p>
           </div>
 
@@ -249,6 +271,19 @@ export function RepositoryHooksSection({
               </div>
               <p className="text-xs text-muted-foreground">
                 Edit `orca.yaml` in the repository if you need to change these shared commands.
+              </p>
+            </div>
+          ) : yamlState === 'update-available' ? (
+            <div className="flex items-start gap-3 rounded-xl border border-sky-500/20 bg-background/60 p-4">
+              <div className="flex size-11 shrink-0 items-center justify-center rounded-xl bg-sky-500/12 text-sky-600 dark:text-sky-300">
+                <ArrowUpCircle className="size-5" />
+              </div>
+              <p className="text-sm leading-6 text-muted-foreground">
+                {/* Why: a file with well-formed YAML keys that this version doesn't handle is
+                almost certainly authored for a newer Orca release. Suggesting an update is
+                far less confusing than "could not be parsed", which implies the file is broken. */}
+                Your `orca.yaml` uses configuration keys that were introduced in a newer version of
+                Orca. Update to the latest release so all settings take effect.
               </p>
             </div>
           ) : yamlState === 'invalid' ? (

--- a/src/renderer/src/components/settings/RepositoryPane.tsx
+++ b/src/renderer/src/components/settings/RepositoryPane.tsx
@@ -18,6 +18,7 @@ type RepositoryPaneProps = {
   repo: Repo
   yamlHooks: OrcaHooks | null
   hasHooksFile: boolean
+  mayNeedUpdate: boolean
   updateRepo: (repoId: string, updates: Partial<Repo>) => void
   removeRepo: (repoId: string) => void
 }
@@ -95,6 +96,7 @@ export function RepositoryPane({
   repo,
   yamlHooks,
   hasHooksFile,
+  mayNeedUpdate,
   updateRepo,
   removeRepo
 }: RepositoryPaneProps): React.JSX.Element {
@@ -273,6 +275,7 @@ export function RepositoryPane({
         repo={repo}
         yamlHooks={yamlHooks}
         hasHooksFile={hasHooksFile}
+        mayNeedUpdate={mayNeedUpdate}
         copiedTemplate={copiedTemplate}
         onCopyTemplate={() => void handleCopyTemplate()}
         onClearLegacyHooks={handleClearLegacyHooks}

--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -69,7 +69,7 @@ function Settings(): React.JSX.Element {
   const setSettingsSearchQuery = useAppStore((s) => s.setSettingsSearchQuery)
 
   const [repoHooksMap, setRepoHooksMap] = useState<
-    Record<string, { hasHooks: boolean; hooks: OrcaHooks | null }>
+    Record<string, { hasHooks: boolean; hooks: OrcaHooks | null; mayNeedUpdate: boolean }>
   >({})
   const systemPrefersDark = useSystemPrefersDark()
   const [scrollbackMode, setScrollbackMode] = useState<'preset' | 'custom'>('preset')
@@ -155,19 +155,24 @@ function Settings(): React.JSX.Element {
       const results = await Promise.all(
         repos.map(async (repo) => {
           if (isFolderRepo(repo)) {
-            return [repo.id, { hasHooks: false, hooks: null }] as const
+            return [repo.id, { hasHooks: false, hooks: null, mayNeedUpdate: false }] as const
           }
           try {
             const result = await window.api.hooks.check({ repoId: repo.id })
             return [repo.id, result] as const
           } catch {
-            return [repo.id, { hasHooks: false, hooks: null }] as const
+            return [repo.id, { hasHooks: false, hooks: null, mayNeedUpdate: false }] as const
           }
         })
       )
 
       if (!stale) {
-        setRepoHooksMap(Object.fromEntries(results))
+        setRepoHooksMap(
+          Object.fromEntries(results) as Record<
+            string,
+            { hasHooks: boolean; hooks: OrcaHooks | null; mayNeedUpdate: boolean }
+          >
+        )
       }
     }
 
@@ -478,6 +483,7 @@ function Settings(): React.JSX.Element {
                         repo={repo}
                         yamlHooks={repoHooksState?.hooks ?? null}
                         hasHooksFile={repoHooksState?.hasHooks ?? false}
+                        mayNeedUpdate={repoHooksState?.mayNeedUpdate ?? false}
                         updateRepo={updateRepo}
                         removeRepo={removeRepo}
                       />


### PR DESCRIPTION
## Summary
- When `orca.yaml` contains top-level keys that the running Orca version doesn't recognize (e.g. a future key, or `issueCommand` on older builds), the parser returns null and the UI shows a confusing "could not be parsed" error with repair steps that don't help
- Added `hasUnrecognizedOrcaYamlKeys()` to detect well-formed but unrecognised YAML keys, and a `mayNeedUpdate` flag through the `hooks:check` IPC path
- New `update-available` state in settings keeps the amber warning style but replaces the description with: "The file contains configuration keys that this version of Orca does not recognize. You may need to update Orca, or check the file for typos." — no repair steps or template, since the file isn't malformed
- Forward-compatible: any future key additions to `orca.yaml` will automatically trigger this hint on older versions

## Test plan
- [x] Verify a repo with an unrecognized key (e.g. `issueCommand2:`) shows the "could not be parsed" amber card with the "you may need to update" description (not the repair steps)
- [x] Verify a repo with `scripts:` + `issueCommand:` still shows "Using `orca.yaml`" (green)
- [x] Verify a genuinely malformed `orca.yaml` (e.g. bad indentation, no valid top-level keys) still shows the amber parse error **with** repair steps and template
- [x] Verify a repo with no `orca.yaml` still shows "No `orca.yaml` detected"
- [x] Unit tests pass (`pnpm test -- --run src/main/hooks.test.ts`)