### PR TITLE
fix: clear browser tab state on worktree shutdown

### DIFF
--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -451,12 +451,35 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         delete nextPendingIssueCommandSplitByTabId[tab.id]
       }
 
+      // Why: browser tabs are factored into getWorktreeStatus — leaving them
+      // behind after shutdown keeps the sidebar dot green even though all
+      // terminals are dead.  Clearing them here ensures the status indicator
+      // transitions to inactive.
+      const nextBrowserTabsByWorktree = { ...s.browserTabsByWorktree }
+      const hadBrowserTabs = (nextBrowserTabsByWorktree[worktreeId] ?? []).length > 0
+      delete nextBrowserTabsByWorktree[worktreeId]
+      const nextActiveBrowserTabIdByWorktree = { ...s.activeBrowserTabIdByWorktree }
+      delete nextActiveBrowserTabIdByWorktree[worktreeId]
+
+      // Why: when shutting down the active worktree, the global
+      // activeBrowserTabId and activeTabType may still point at a browser
+      // surface that no longer exists.  Reset them so the workspace does not
+      // render a blank browser pane.  Background worktrees do not own the
+      // global surface, so we leave them untouched.
+      const isActiveWorktree = s.activeWorktreeId === worktreeId
+      const shouldResetGlobalBrowser = isActiveWorktree && hadBrowserTabs
+
       return {
         tabsByWorktree: nextTabsByWorktree,
         ptyIdsByTabId: nextPtyIdsByTabId,
         suppressedPtyExitIds: nextSuppressedPtyExitIds,
         pendingSetupSplitByTabId: nextPendingSetupSplitByTabId,
-        pendingIssueCommandSplitByTabId: nextPendingIssueCommandSplitByTabId
+        pendingIssueCommandSplitByTabId: nextPendingIssueCommandSplitByTabId,
+        browserTabsByWorktree: nextBrowserTabsByWorktree,
+        activeBrowserTabIdByWorktree: nextActiveBrowserTabIdByWorktree,
+        ...(shouldResetGlobalBrowser
+          ? { activeBrowserTabId: null, activeTabType: 'terminal' as const }
+          : {})
       }
     })
 


### PR DESCRIPTION
## Summary
- Clears `browserTabsByWorktree` and `activeBrowserTabIdByWorktree` when shutting down worktree terminals
- Fixes bug where the sidebar status dot stays green after all terminals are dead, because browser tabs are factored into `getWorktreeStatus` and were left behind after shutdown

## Test plan
- [ ] Shut down a worktree that has browser tabs open — sidebar dot should transition to inactive
- [ ] Shut down a worktree with no browser tabs — behavior unchanged
- [ ] Remove a worktree (which calls shutdownWorktreeTerminals internally) — no double-delete errors