### PR TITLE
feat: enable open-links-in-app by default

### DIFF
--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -101,7 +101,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     // focus-follows-mouse never happens unexpectedly.
     terminalFocusFollowsMouse: false,
     terminalScrollbackBytes: 10_000_000,
-    openLinksInApp: false,
+    openLinksInApp: true,
     rightSidebarOpenByDefault: true,
     notifications: getDefaultNotificationSettings(),
     diffDefaultView: 'inline',


### PR DESCRIPTION
## Summary
- Changed `openLinksInApp` default from `false` to `true` so links open inside Orca by default

## Test plan
- [ ] Verify new installs / fresh configs get `openLinksInApp: true`
- [ ] Verify existing users with explicit `false` in their config are unaffected