### PR TITLE
update readme: reorder sections, add Discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
   <a href="https://github.com/stablyai/orca/stargazers"><img src="https://img.shields.io/github/stars/stablyai/orca?style=flat-square&color=black" alt="GitHub stars" /></a>
   <img src="https://img.shields.io/badge/Platform-macOS%20%7C%20Windows%20%7C%20Linux-black?style=flat-square" alt="Supported Platforms" />
   <img src="https://img.shields.io/badge/ships-150+-black?style=flat-square" alt="Ships" />
+  <a href="https://discord.gg/fzjDKHxv8Q"><img src="https://img.shields.io/badge/Discord-Join-black?style=flat-square&logo=discord&logoColor=white" alt="Discord" /></a>
   <a href="https://x.com/orca_build"><img src="https://img.shields.io/twitter/follow/orca_build?style=social" alt="Follow on X" /></a>
 </p>
 
@@ -24,6 +25,23 @@
 <p align="center">
   <img src="docs/assets/file-drag.gif" alt="Orca Screenshot" width="800" />
 </p>
+
+## Features
+
+- **Worktree-native** — Every feature gets its own worktree. No stashing, no branch juggling. Spin up and switch instantly.
+- **Multi-agent terminals** — Run multiple AI agents side-by-side in tabs and panes. See which ones are active at a glance.
+- **Built-in source control** — Review AI-generated diffs, make quick edits, and commit without leaving Orca.
+- **GitHub integration** — PRs, issues, and Actions checks linked to each worktree automatically.
+- **Notifications** — Know when an agent finishes or needs attention. Mark threads unread to come back later.
+
+---
+
+## Install
+
+- **[Download from onOrca.dev](https://onOrca.dev)**
+- Or download the latest binaries via the **[GitHub Releases page](https://github.com/stablyai/orca/releases)**.
+
+---
 
 ## [New] Built-in Browser & Design Mode
 
@@ -49,27 +67,9 @@ npx skills add https://github.com/stablyai/orca --skill orca-cli
 
 ---
 
-## Features
-
-- **Worktree-native** — Every feature gets its own worktree. No stashing, no branch juggling. Spin up and switch instantly.
-- **Multi-agent terminals** — Run multiple AI agents side-by-side in tabs and panes. See which ones are active at a glance.
-- **Built-in source control** — Review AI-generated diffs, make quick edits, and commit without leaving Orca.
-- **GitHub integration** — PRs, issues, and Actions checks linked to each worktree automatically.
-- **Notifications** — Know when an agent finishes or needs attention. Mark threads unread to come back later.
-
----
-
-## Install
-
-Get started today:
-
-- **[Download from onOrca.dev](https://onOrca.dev)**
-- Or download the latest binaries via the **[GitHub Releases page](https://github.com/stablyai/orca/releases)**.
-
----
-
 ## Community & Support
 
+- **Discord:** Join the community on [**Discord**](https://discord.gg/fzjDKHxv8Q).
 - **Twitter / X:** Follow [**@orca_build**](https://x.com/orca_build) for updates and announcements.
 - **Feedback & Ideas:** We ship fast. Missing something? [Request a new feature](https://github.com/stablyai/orca/issues).
 - **Show Support:** Star this repo to follow along with our daily ships.


### PR DESCRIPTION
## Summary
- Move Features and Install sections above the [New] sections for better visibility
- Remove "Get started today:" text from Install section
- Add Discord badge to header badges
- Add Discord link as first item in Community & Support section

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm Discord badge and link work