### PR TITLE
Quick style fixes: browser settings section + dialog footer gaps

### DIFF
--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -840,7 +840,7 @@ export default function Terminal(): React.JSX.Element | null {
                 : 'This file has unsaved changes.'}
             </DialogDescription>
           </DialogHeader>
-          <DialogFooter className="gap-2 sm:gap-0">
+          <DialogFooter className="gap-2">
             <Button type="button" variant="outline" size="sm" onClick={handleSaveDialogCancel}>
               Cancel
             </Button>
@@ -872,7 +872,7 @@ export default function Terminal(): React.JSX.Element | null {
               will be killed.
             </DialogDescription>
           </DialogHeader>
-          <DialogFooter className="gap-2 sm:gap-0">
+          <DialogFooter className="gap-2">
             <Button
               type="button"
               variant="outline"

--- a/src/renderer/src/components/settings/GeneralPane.tsx
+++ b/src/renderer/src/components/settings/GeneralPane.tsx
@@ -18,6 +18,7 @@ import {
 } from '../../../../shared/constants'
 import { clampNumber } from '@/lib/terminal-theme'
 import {
+  GENERAL_BROWSER_SEARCH_ENTRIES,
   GENERAL_CACHE_TIMER_SEARCH_ENTRIES,
   GENERAL_CLI_SEARCH_ENTRIES,
   GENERAL_EDITOR_SEARCH_ENTRIES,
@@ -158,6 +159,17 @@ export function GeneralPane({ settings, updateSettings }: GeneralPaneProps): Rea
             />
           </button>
         </SearchableSetting>
+
+      </section>
+    ) : null,
+    matchesSettingsSearch(searchQuery, GENERAL_BROWSER_SEARCH_ENTRIES) ? (
+      <section key="browser" className="space-y-4">
+        <div className="space-y-1">
+          <h3 className="text-sm font-semibold">Browser</h3>
+          <p className="text-xs text-muted-foreground">
+            Control how Orca handles links from the terminal.
+          </p>
+        </div>
 
         <SearchableSetting
           title="Open Links In Orca"

--- a/src/renderer/src/components/settings/general-search.ts
+++ b/src/renderer/src/components/settings/general-search.ts
@@ -60,8 +60,17 @@ export const GENERAL_CACHE_TIMER_SEARCH_ENTRIES: SettingsSearchEntry[] = [
   }
 ]
 
+export const GENERAL_BROWSER_SEARCH_ENTRIES: SettingsSearchEntry[] = [
+  {
+    title: 'Open Links In Orca',
+    description: 'Open terminal http(s) links in Orca browser tabs instead of the system browser.',
+    keywords: ['browser', 'preview', 'links', 'localhost', 'webview']
+  }
+]
+
 export const GENERAL_PANE_SEARCH_ENTRIES: SettingsSearchEntry[] = [
   ...GENERAL_WORKSPACE_SEARCH_ENTRIES,
+  ...GENERAL_BROWSER_SEARCH_ENTRIES,
   ...GENERAL_EDITOR_SEARCH_ENTRIES,
   ...GENERAL_CLI_SEARCH_ENTRIES,
   ...GENERAL_CACHE_TIMER_SEARCH_ENTRIES,

--- a/src/renderer/src/components/terminal-pane/CloseTerminalDialog.tsx
+++ b/src/renderer/src/components/terminal-pane/CloseTerminalDialog.tsx
@@ -34,7 +34,7 @@ export default function CloseTerminalDialog({
             killed.
           </DialogDescription>
         </DialogHeader>
-        <DialogFooter className="gap-2 sm:gap-0">
+        <DialogFooter className="gap-2">
           <Button type="button" variant="outline" size="sm" onClick={onCancel}>
             Cancel
           </Button>

--- a/src/renderer/src/components/terminal/TerminalShell.tsx
+++ b/src/renderer/src/components/terminal/TerminalShell.tsx
@@ -163,7 +163,7 @@ export function TerminalShell({
                 : 'This file has unsaved changes.'}
             </DialogDescription>
           </DialogHeader>
-          <DialogFooter className="gap-2 sm:gap-0">
+          <DialogFooter className="gap-2">
             <Button type="button" variant="outline" size="sm" onClick={onSaveDialogCancel}>
               Cancel
             </Button>


### PR DESCRIPTION
## Summary
- **Browser settings section**: Move "Open Links In Orca" out of the Workspace section into its own dedicated Browser section under General settings and register it in the search index — searching "browser" now finds the setting instead of showing "No settings found"
- **Dialog footer gaps**: Remove `sm:gap-0` from dialog footers in Terminal, TerminalShell, and CloseTerminalDialog so button spacing stays consistent at all breakpoints
- **Badge/icon color toning** (prior commit): Tone down primary badge and merged PR icon colors

## Test plan
- [ ] Open Settings, search "browser" → Browser section with "Open Links In Orca" toggle should appear
- [ ] Search "links", "preview", "webview" → same result
- [ ] Clear search → Browser section appears between Workspace and Editor under General
- [ ] Toggle still works (on/off persists)
- [ ] Dialog footers (close terminal, unsaved changes) have consistent button spacing on narrow and wide viewports