### PR TITLE
Fix keyboard shortcuts not working from browser tabs

### DIFF
--- a/src/main/browser/browser-manager.ts
+++ b/src/main/browser/browser-manager.ts
@@ -223,6 +223,7 @@ class BrowserManager {
   private readonly rendererWebContentsIdByTabId = new Map<string, number>()
   private readonly contextMenuCleanupByTabId = new Map<string, () => void>()
   private readonly grabShortcutCleanupByTabId = new Map<string, () => void>()
+  private readonly shortcutForwardingCleanupByTabId = new Map<string, () => void>()
   private readonly policyAttachedGuestIds = new Set<number>()
   private readonly pendingLoadFailuresByGuestId = new Map<
     number,
@@ -319,6 +320,7 @@ class BrowserManager {
 
     this.setupContextMenu(browserTabId, guest)
     this.setupGrabShortcut(browserTabId, guest)
+    this.setupShortcutForwarding(browserTabId, guest)
     this.flushPendingLoadFailure(browserTabId, webContentsId)
   }
 
@@ -337,6 +339,11 @@ class BrowserManager {
     if (shortcutCleanup) {
       shortcutCleanup()
       this.grabShortcutCleanupByTabId.delete(browserTabId)
+    }
+    const fwdCleanup = this.shortcutForwardingCleanupByTabId.get(browserTabId)
+    if (fwdCleanup) {
+      fwdCleanup()
+      this.shortcutForwardingCleanupByTabId.delete(browserTabId)
     }
     this.webContentsIdByTabId.delete(browserTabId)
     this.rendererWebContentsIdByTabId.delete(browserTabId)
@@ -870,6 +877,72 @@ class BrowserManager {
       } catch {
         // Why: browser tabs can outlive the guest webContents briefly during
         // teardown. Cleanup should be best-effort.
+      }
+    })
+  }
+
+  // Why: a focused webview guest is a separate Chromium process — keyboard
+  // events go to the guest's own webContents and never fire the renderer's
+  // window-level keydown handler or the main window's before-input-event.
+  // Intercept common app shortcuts on the guest and forward them to the
+  // renderer so they work consistently regardless of which surface has focus.
+  private setupShortcutForwarding(browserTabId: string, guest: Electron.WebContents): void {
+    const previousCleanup = this.shortcutForwardingCleanupByTabId.get(browserTabId)
+    if (previousCleanup) {
+      previousCleanup()
+      this.shortcutForwardingCleanupByTabId.delete(browserTabId)
+    }
+
+    const handler = (_event: Electron.Event, input: Electron.Input): void => {
+      if (input.type !== 'keyDown') {
+        return
+      }
+      const isMod = process.platform === 'darwin' ? input.meta : input.control
+      if (!isMod || input.alt) {
+        return
+      }
+
+      const rendererWcId = this.rendererWebContentsIdByTabId.get(browserTabId)
+      if (!rendererWcId) {
+        return
+      }
+      const rendererWc = webContents.fromId(rendererWcId)
+      if (!rendererWc || rendererWc.isDestroyed()) {
+        return
+      }
+
+      if (input.code === 'KeyB' && input.shift) {
+        rendererWc.send('ui:newBrowserTab')
+      } else if (input.code === 'KeyT' && !input.shift) {
+        rendererWc.send('ui:newTerminalTab')
+      } else if (input.code === 'KeyW' && !input.shift) {
+        rendererWc.send('ui:closeActiveTab')
+      } else if (input.shift && (input.code === 'BracketRight' || input.code === 'BracketLeft')) {
+        rendererWc.send('ui:switchTab', input.code === 'BracketRight' ? 1 : -1)
+      } else if (
+        input.code === 'KeyJ' &&
+        ((process.platform === 'darwin' && !input.shift) ||
+          (process.platform !== 'darwin' && input.shift))
+      ) {
+        rendererWc.send('ui:toggleWorktreePalette')
+      } else if (input.code === 'KeyP' && !input.shift) {
+        rendererWc.send('ui:openQuickOpen')
+      } else if (input.key >= '1' && input.key <= '9' && !input.shift) {
+        rendererWc.send('ui:jumpToWorktreeIndex', parseInt(input.key, 10) - 1)
+      } else {
+        return
+      }
+      // Why: preventDefault stops the guest page from also processing the chord
+      // (e.g. Cmd+T opening a browser-internal new-tab page).
+      _event.preventDefault()
+    }
+
+    guest.on('before-input-event', handler)
+    this.shortcutForwardingCleanupByTabId.set(browserTabId, () => {
+      try {
+        guest.off('before-input-event', handler)
+      } catch {
+        // Why: best-effort — guest may already be destroyed during teardown.
       }
     })
   }

--- a/src/preload/api-types.d.ts
+++ b/src/preload/api-types.d.ts
@@ -346,6 +346,10 @@ export type PreloadApi = {
     onToggleWorktreePalette: (callback: () => void) => () => void
     onOpenQuickOpen: (callback: () => void) => () => void
     onJumpToWorktreeIndex: (callback: (index: number) => void) => () => void
+    onNewBrowserTab: (callback: () => void) => () => void
+    onNewTerminalTab: (callback: () => void) => () => void
+    onCloseActiveTab: (callback: () => void) => () => void
+    onSwitchTab: (callback: (direction: 1 | -1) => void) => () => void
     onActivateWorktree: (
       callback: (data: { repoId: string; worktreeId: string; setup?: WorktreeSetupLaunch }) => void
     ) => () => void

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -578,6 +578,26 @@ const api = {
       ipcRenderer.on('ui:jumpToWorktreeIndex', listener)
       return () => ipcRenderer.removeListener('ui:jumpToWorktreeIndex', listener)
     },
+    onNewBrowserTab: (callback: () => void): (() => void) => {
+      const listener = (_event: Electron.IpcRendererEvent) => callback()
+      ipcRenderer.on('ui:newBrowserTab', listener)
+      return () => ipcRenderer.removeListener('ui:newBrowserTab', listener)
+    },
+    onNewTerminalTab: (callback: () => void): (() => void) => {
+      const listener = (_event: Electron.IpcRendererEvent) => callback()
+      ipcRenderer.on('ui:newTerminalTab', listener)
+      return () => ipcRenderer.removeListener('ui:newTerminalTab', listener)
+    },
+    onCloseActiveTab: (callback: () => void): (() => void) => {
+      const listener = (_event: Electron.IpcRendererEvent) => callback()
+      ipcRenderer.on('ui:closeActiveTab', listener)
+      return () => ipcRenderer.removeListener('ui:closeActiveTab', listener)
+    },
+    onSwitchTab: (callback: (direction: 1 | -1) => void): (() => void) => {
+      const listener = (_event: Electron.IpcRendererEvent, direction: 1 | -1) => callback(direction)
+      ipcRenderer.on('ui:switchTab', listener)
+      return () => ipcRenderer.removeListener('ui:switchTab', listener)
+    },
     onActivateWorktree: (
       callback: (data: {
         repoId: string

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -1,13 +1,17 @@
 import { useEffect } from 'react'
 import { useAppStore } from '../store'
 import { applyUIZoom } from '@/lib/ui-zoom'
-import { activateAndRevealWorktree, ensureWorktreeHasInitialTerminal } from '@/lib/worktree-activation'
+import {
+  activateAndRevealWorktree,
+  ensureWorktreeHasInitialTerminal
+} from '@/lib/worktree-activation'
 import { getVisibleWorktreeIds } from '@/components/sidebar/visible-worktrees'
 import { nextEditorFontZoomLevel, computeEditorFontSize } from '@/lib/editor-font-zoom'
 import type { UpdateStatus } from '../../../shared/types'
 import { createUpdateToastController } from './update-toast-controller'
 import { zoomLevelToPercent, ZOOM_MIN, ZOOM_MAX } from '@/components/settings/SettingsConstants'
 import { dispatchZoomLevelChanged } from '@/lib/zoom-events'
+import { reconcileTabOrder } from '@/components/tab-bar/reconcile-order'
 
 const ZOOM_STEP = 0.5
 
@@ -161,6 +165,120 @@ export function useIpcEvents(): void {
           canGoBack: false,
           canGoForward: false
         })
+      })
+    )
+
+    // Shortcut forwarding for embedded browser guests whose webContents
+    // capture keyboard focus and bypass the renderer's window-level keydown.
+    unsubs.push(
+      window.api.ui.onNewBrowserTab(() => {
+        const store = useAppStore.getState()
+        const worktreeId = store.activeWorktreeId
+        if (worktreeId) {
+          store.createBrowserTab(worktreeId, 'about:blank', { title: 'New Browser Tab' })
+        }
+      })
+    )
+
+    unsubs.push(
+      window.api.ui.onNewTerminalTab(() => {
+        const store = useAppStore.getState()
+        const worktreeId = store.activeWorktreeId
+        if (!worktreeId) {
+          return
+        }
+        const newTab = store.createTab(worktreeId)
+        store.setActiveTabType('terminal')
+        // Why: replicate the full reconciliation from Terminal.tsx handleNewTab
+        // so the new tab appends at the visual end instead of jumping to index 0
+        // when tabBarOrderByWorktree is unset (e.g. restored worktrees).
+        const currentTerminals = store.tabsByWorktree[worktreeId] ?? []
+        const currentEditors = store.openFiles.filter((f) => f.worktreeId === worktreeId)
+        const currentBrowsers = store.browserTabsByWorktree[worktreeId] ?? []
+        const stored = store.tabBarOrderByWorktree[worktreeId]
+        const termIds = currentTerminals.map((t) => t.id)
+        const editorIds = currentEditors.map((f) => f.id)
+        const browserIds = currentBrowsers.map((tab) => tab.id)
+        const validIds = new Set([...termIds, ...editorIds, ...browserIds])
+        const base = (stored ?? []).filter((id) => validIds.has(id))
+        const inBase = new Set(base)
+        for (const id of [...termIds, ...editorIds, ...browserIds]) {
+          if (!inBase.has(id)) {
+            base.push(id)
+            inBase.add(id)
+          }
+        }
+        const order = base.filter((id) => id !== newTab.id)
+        order.push(newTab.id)
+        store.setTabBarOrder(worktreeId, order)
+      })
+    )
+
+    unsubs.push(
+      window.api.ui.onCloseActiveTab(() => {
+        const store = useAppStore.getState()
+        // Why: this IPC fires only from browser guest webContents, so
+        // activeTabType is always 'browser'. We intentionally skip the
+        // editor case — closing dirty editor files requires the save
+        // confirmation dialog which lives in Terminal.tsx component state.
+        if (store.activeTabType === 'browser' && store.activeBrowserTabId) {
+          store.closeBrowserTab(store.activeBrowserTabId)
+        }
+      })
+    )
+
+    unsubs.push(
+      window.api.ui.onSwitchTab((direction) => {
+        const store = useAppStore.getState()
+        const worktreeId = store.activeWorktreeId
+        if (!worktreeId) {
+          return
+        }
+        const terminalTabs = store.tabsByWorktree[worktreeId] ?? []
+        const editorFiles = store.openFiles.filter((f) => f.worktreeId === worktreeId)
+        const browserTabs = store.browserTabsByWorktree[worktreeId] ?? []
+        const terminalIds = terminalTabs.map((t) => t.id)
+        const editorIds = editorFiles.map((f) => f.id)
+        const browserIds = browserTabs.map((t) => t.id)
+        const reconciledOrder = reconcileTabOrder(
+          store.tabBarOrderByWorktree[worktreeId],
+          terminalIds,
+          editorIds,
+          browserIds
+        )
+        const terminalIdSet = new Set(terminalIds)
+        const editorIdSet = new Set(editorIds)
+        const browserIdSet = new Set(browserIds)
+        const allTabIds = reconciledOrder.map((id) => ({
+          type: terminalIdSet.has(id)
+            ? ('terminal' as const)
+            : editorIdSet.has(id)
+              ? ('editor' as const)
+              : browserIdSet.has(id)
+                ? ('browser' as const)
+                : (null as never),
+          id
+        }))
+        if (allTabIds.length > 1) {
+          const currentId =
+            store.activeTabType === 'editor'
+              ? store.activeFileId
+              : store.activeTabType === 'browser'
+                ? store.activeBrowserTabId
+                : store.activeTabId
+          const idx = allTabIds.findIndex((t) => t.id === currentId)
+          const next = allTabIds[(idx + direction + allTabIds.length) % allTabIds.length]
+          if (next.type === 'terminal') {
+            store.setActiveTab(next.id)
+            store.setActiveTabType('terminal')
+          } else if (next.type === 'browser') {
+            store.setActiveBrowserTab(next.id)
+            store.setActiveTabType('browser')
+          } else {
+            store.setActiveFile(next.id)
+            store.setActiveTabType('editor')
+          }
+        }
       })
     )
 


### PR DESCRIPTION
## Summary
- When a `<webview>` guest has focus, keyboard events go to the guest's own webContents and never reach the renderer's window-level keydown handler or the main window's `before-input-event`
- Added `setupShortcutForwarding()` in `BrowserManager` that listens on the guest's `before-input-event` and forwards app shortcuts to the renderer via IPC
- Shortcuts fixed: `⌘⇧B` (new browser tab), `⌘T` (new terminal tab), `⌘W` (close tab), `⌘⇧]/[` (switch tabs), `⌘J` (worktree palette), `⌘P` (quick open), `⌘1-9` (jump to worktree)

## Test plan
- [ ] Open a browser tab, verify `⌘⇧B` opens a new browser tab
- [ ] From a browser tab, verify `⌘T` opens a new terminal tab
- [ ] From a browser tab, verify `⌘W` closes the browser tab
- [ ] From a browser tab, verify `⌘⇧]` / `⌘⇧[` cycles through tabs
- [ ] From a browser tab, verify `⌘J` opens worktree palette
- [ ] From a browser tab, verify `⌘P` opens quick open
- [ ] From a browser tab, verify `⌘1-9` switches worktrees
- [ ] Verify all shortcuts still work from terminal tabs (no regression)