### PR TITLE
test: verify auto-update notification flow

### DIFF
--- a/src/main/updater.test.ts
+++ b/src/main/updater.test.ts
@@ -277,4 +277,43 @@ describe('updater', () => {
     vi.advanceTimersByTime(60 * 1000)
     expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(2)
   })
+
+  it('reschedules the next automatic check 36 hours after finding an available update', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-03T12:00:00Z'))
+
+    autoUpdaterMock.checkForUpdates.mockImplementation(() => {
+      autoUpdaterMock.emit('checking-for-update')
+      queueMicrotask(() => {
+        autoUpdaterMock.emit('update-available', { version: '1.0.61' })
+      })
+      return Promise.resolve(undefined)
+    })
+
+    const sendMock = vi.fn()
+    const setLastUpdateCheckAt = vi.fn()
+    const mainWindow = { webContents: { send: sendMock } }
+
+    const { setupAutoUpdater } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never, {
+      getLastUpdateCheckAt: () => null,
+      setLastUpdateCheckAt
+    })
+
+    await vi.runAllTicks()
+
+    expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(1)
+    expect(setLastUpdateCheckAt).toHaveBeenCalledTimes(1)
+    expect(sendMock).toHaveBeenCalledWith('updater:status', {
+      state: 'available',
+      version: '1.0.61'
+    })
+
+    vi.advanceTimersByTime(35 * 60 * 60 * 1000 + 59 * 60 * 1000)
+    expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(1)
+
+    vi.advanceTimersByTime(60 * 1000)
+    expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(2)
+  })
 })

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from 'vitest'
+import type * as ReactModule from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { resolveZoomTarget } from './useIpcEvents'
 
 function makeTarget(args: { hasXtermClass?: boolean; editorClosest?: boolean }): {
@@ -53,5 +54,123 @@ describe('resolveZoomTarget', () => {
         activeElement: makeTarget({ hasXtermClass: true })
       })
     ).toBe('ui')
+  })
+})
+
+describe('useIpcEvents updater integration', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.unstubAllGlobals()
+  })
+
+  it('routes updater status events into store state and update toasts', async () => {
+    const setUpdateStatus = vi.fn()
+    const handleStatus = vi.fn()
+    let statusListener: ((status: unknown) => void) | null = null
+
+    vi.doMock('react', async () => {
+      const actual = await vi.importActual<typeof ReactModule>('react')
+      return {
+        ...actual,
+        useEffect: (effect: () => void | (() => void)) => {
+          effect()
+        }
+      }
+    })
+
+    vi.doMock('../store', () => ({
+      useAppStore: {
+        getState: () => ({
+          setUpdateStatus,
+          fetchRepos: vi.fn(),
+          fetchWorktrees: vi.fn(),
+          setActiveView: vi.fn(),
+          activeModal: null,
+          closeModal: vi.fn(),
+          openModal: vi.fn(),
+          activeWorktreeId: 'wt-1',
+          activeView: 'terminal',
+          setActiveRepo: vi.fn(),
+          setActiveWorktree: vi.fn(),
+          revealWorktreeInSidebar: vi.fn(),
+          setIsFullScreen: vi.fn(),
+          updateBrowserTabPageState: vi.fn(),
+          activeTabType: 'terminal',
+          editorFontZoomLevel: 0,
+          setEditorFontZoomLevel: vi.fn(),
+          settings: { terminalFontSize: 13 }
+        })
+      }
+    }))
+
+    vi.doMock('./update-toast-controller', () => ({
+      createUpdateToastController: () => ({
+        handleStatus
+      })
+    }))
+
+    vi.doMock('@/lib/ui-zoom', () => ({
+      applyUIZoom: vi.fn()
+    }))
+    vi.doMock('@/lib/worktree-activation', () => ({
+      activateAndRevealWorktree: vi.fn(),
+      ensureWorktreeHasInitialTerminal: vi.fn()
+    }))
+    vi.doMock('@/components/sidebar/visible-worktrees', () => ({
+      getVisibleWorktreeIds: () => []
+    }))
+    vi.doMock('@/lib/editor-font-zoom', () => ({
+      nextEditorFontZoomLevel: vi.fn(() => 0),
+      computeEditorFontSize: vi.fn(() => 13)
+    }))
+    vi.doMock('@/components/settings/SettingsConstants', () => ({
+      zoomLevelToPercent: vi.fn(() => 100),
+      ZOOM_MIN: -3,
+      ZOOM_MAX: 3
+    }))
+    vi.doMock('@/lib/zoom-events', () => ({
+      dispatchZoomLevelChanged: vi.fn()
+    }))
+
+    vi.stubGlobal('window', {
+      api: {
+        repos: { onChanged: () => () => {} },
+        worktrees: { onChanged: () => () => {} },
+        ui: {
+          onOpenSettings: () => () => {},
+          onToggleWorktreePalette: () => () => {},
+          onOpenQuickOpen: () => () => {},
+          onJumpToWorktreeIndex: () => () => {},
+          onActivateWorktree: () => () => {},
+          onFullscreenChanged: () => () => {},
+          onTerminalZoom: () => () => {},
+          getZoomLevel: () => 0,
+          set: vi.fn()
+        },
+        updater: {
+          getStatus: () => Promise.resolve({ state: 'idle' }),
+          onStatus: (listener: (status: unknown) => void) => {
+            statusListener = listener
+            return () => {}
+          }
+        },
+        browser: {
+          onGuestLoadFailed: () => () => {}
+        }
+      }
+    })
+
+    const { useIpcEvents } = await import('./useIpcEvents')
+
+    useIpcEvents()
+    await Promise.resolve()
+
+    expect(setUpdateStatus).toHaveBeenCalledWith({ state: 'idle' })
+
+    const availableStatus = { state: 'available', version: '1.2.3' }
+    statusListener?.(availableStatus)
+
+    expect(setUpdateStatus).toHaveBeenCalledWith(availableStatus)
+    expect(handleStatus).toHaveBeenCalledWith(availableStatus)
   })
 })

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -66,7 +66,9 @@ describe('useIpcEvents updater integration', () => {
   it('routes updater status events into store state and update toasts', async () => {
     const setUpdateStatus = vi.fn()
     const handleStatus = vi.fn()
-    let statusListener: ((status: unknown) => void) | null = null
+    const updaterStatusListenerRef: { current: ((status: unknown) => void) | null } = {
+      current: null
+    }
 
     vi.doMock('react', async () => {
       const actual = await vi.importActual<typeof ReactModule>('react')
@@ -150,7 +152,7 @@ describe('useIpcEvents updater integration', () => {
         updater: {
           getStatus: () => Promise.resolve({ state: 'idle' }),
           onStatus: (listener: (status: unknown) => void) => {
-            statusListener = listener
+            updaterStatusListenerRef.current = listener
             return () => {}
           }
         },
@@ -168,7 +170,10 @@ describe('useIpcEvents updater integration', () => {
     expect(setUpdateStatus).toHaveBeenCalledWith({ state: 'idle' })
 
     const availableStatus = { state: 'available', version: '1.2.3' }
-    statusListener?.(availableStatus)
+    if (typeof updaterStatusListenerRef.current !== 'function') {
+      throw new Error('Expected updater status listener to be registered')
+    }
+    updaterStatusListenerRef.current(availableStatus)
 
     expect(setUpdateStatus).toHaveBeenCalledWith(availableStatus)
     expect(handleStatus).toHaveBeenCalledWith(availableStatus)

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -144,6 +144,7 @@ describe('useIpcEvents updater integration', () => {
           onOpenQuickOpen: () => () => {},
           onJumpToWorktreeIndex: () => () => {},
           onActivateWorktree: () => () => {},
+          onNewBrowserTab: () => () => {},
           onFullscreenChanged: () => () => {},
           onTerminalZoom: () => () => {},
           getZoomLevel: () => 0,


### PR DESCRIPTION
## Summary
- add a main-process test that verifies automatic update checks reschedule 36 hours after update-available
- add a renderer hook test that verifies updater status events update store state and drive the in-app update notification toast
- run the focused updater/notification vitest suite

## Testing
- pnpm exec vitest run --config config/vitest.config.ts src/main/updater.test.ts src/main/updater.check-failure.test.ts src/renderer/src/hooks/update-toast-controller.test.ts src/renderer/src/hooks/useIpcEvents.test.ts