### PR TITLE
Add "No login required" to README features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,47 @@
 <p align="center">
+
   <a href="https://onOrca.dev"><img src="resources/build/icon.png" alt="Orca" width="128" /></a>
+
 </p>
 
 <h1 align="center">Orca</h1>
 
 <p align="center">
+
   <a href="https://github.com/stablyai/orca/stargazers"><img src="https://img.shields.io/github/stars/stablyai/orca?style=flat-square&color=black" alt="GitHub stars" /></a>
+
   <img src="https://img.shields.io/badge/Platform-macOS%20%7C%20Windows%20%7C%20Linux-black?style=flat-square" alt="Supported Platforms" />
+
   <img src="https://img.shields.io/badge/ships-150+-black?style=flat-square" alt="Ships" />
+
   <a href="https://discord.gg/fzjDKHxv8Q"><img src="https://img.shields.io/badge/Discord-Join-black?style=flat-square&logo=discord&logoColor=white" alt="Discord" /></a>
   <a href="https://x.com/orca_build"><img src="https://img.shields.io/twitter/follow/orca_build?style=social" alt="Follow on X" /></a>
+
 </p>
 
 <p align="center">
+
   <strong>The AI Orchestrator for 100x builders.</strong><br/>
   Run Claude Code, Codex, or OpenCode side-by-side across repos — each in its own worktree, tracked in one place.<br/>
   Available for <strong>macOS, Windows, and Linux</strong>.
+
 </p>
 
 <p align="center">
+
   <a href="https://onOrca.dev"><strong>Download at onOrca.dev</strong></a>
+
 </p>
 
 <p align="center">
+
   <img src="docs/assets/file-drag.gif" alt="Orca Screenshot" width="800" />
+
 </p>
 
 ## Features
 
+- **No login required** — Bring your own Claude Code or Codex subscription. No account walls, no extra tokens, no middleman.
 - **Worktree-native** — Every feature gets its own worktree. No stashing, no branch juggling. Spin up and switch instantly.
 - **Multi-agent terminals** — Run multiple AI agents side-by-side in tabs and panes. See which ones are active at a glance.
 - **Built-in source control** — Review AI-generated diffs, make quick edits, and commit without leaving Orca.
@@ -43,14 +57,16 @@
 
 ---
 
-## [New] Per Worktree Browser & Design Mode
+## [New] Per Worktree Browser &amp; Design Mode
 
 **See your app. Click any element. Drop it into the chat.**
 
 Orca ships with a built-in browser right inside your worktree. Preview your app as you build, then switch to Design Mode — click any UI element and it lands directly in your AI chat as context. No screenshots, no copy-pasting selectors. Just point at what you want to change and tell the agent what to do.
 
 <p align="center">
+
   <img src="docs/assets/orca-design-mode.gif" alt="Orca Design Mode — click any UI element and drop it into the chat" width="800" />
+
 </p>
 
 ---
@@ -67,11 +83,11 @@ npx skills add https://github.com/stablyai/orca --skill orca-cli
 
 ---
 
-## Community & Support
+## Community &amp; Support
 
-- **Discord:** Join the community on [**Discord**](https://discord.gg/fzjDKHxv8Q).
-- **Twitter / X:** Follow [**@orca_build**](https://x.com/orca_build) for updates and announcements.
-- **Feedback & Ideas:** We ship fast. Missing something? [Request a new feature](https://github.com/stablyai/orca/issues).
+- **Discord:** Join the community on **[Discord](https://discord.gg/fzjDKHxv8Q)**.
+- **Twitter / X:** Follow **[@orca_build](https://x.com/orca_build)** for updates and announcements.
+- **Feedback &amp; Ideas:** We ship fast. Missing something? [Request a new feature](https://github.com/stablyai/orca/issues).
 - **Show Support:** Star this repo to follow along with our daily ships.
 
 ---

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 
 ## Features
 
-- **No login required** — Bring your own Claude Code or Codex subscription. No account walls, no extra tokens, no middleman.
+- **No login required** — Bring your own Claude Code or Codex subscription.
 - **Worktree-native** — Every feature gets its own worktree. No stashing, no branch juggling. Spin up and switch instantly.
 - **Multi-agent terminals** — Run multiple AI agents side-by-side in tabs and panes. See which ones are active at a glance.
 - **Built-in source control** — Review AI-generated diffs, make quick edits, and commit without leaving Orca.
@@ -54,6 +54,20 @@
 
 - **[Download from onOrca.dev](https://onOrca.dev)**
 - Or download the latest binaries via the **[GitHub Releases page](https://github.com/stablyai/orca/releases)**.
+
+---
+
+## [New] Hot Swap Codex Accounts
+
+**Multiple Codex accounts? Switch in one click.**
+
+If you run multiple Codex accounts to get the best token deal, Orca lets you hot-swap between them instantly — no re-login, no config files. Just pick an account and keep building.
+
+<p align="center">
+
+  <img src="docs/assets/codex-account-switcher.gif" alt="Orca Codex Account Switcher — hot swap between multiple Codex accounts" width="800" />
+
+</p>
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds "No login required" as the first feature bullet in README
- Highlights that Orca uses your own Claude Code or Codex subscription — no account walls, no extra tokens, no middleman

## Test plan
- [ ] Verify README renders correctly on GitHub