### PR TITLE
Refresh worktree quick jump UI

### DIFF
--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -1,5 +1,5 @@
 /* oxlint-disable max-lines */
-import React, { useCallback, useMemo, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { useAppStore } from '@/store'
 import {
@@ -11,216 +11,13 @@ import {
 } from '@/components/ui/command'
 import { branchName } from '@/lib/git-utils'
 import { sortWorktreesRecent } from '@/components/sidebar/smart-sort'
+import StatusIndicator from '@/components/sidebar/StatusIndicator'
+import { cn } from '@/lib/utils'
+import { getWorktreeStatus, getWorktreeStatusLabel } from '@/lib/worktree-status'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 import { findWorktreeById } from '@/store/slices/worktree-helpers'
-import type { Worktree, Repo } from '../../../shared/types'
-
-// ─── Search result types ────────────────────────────────────────────
-
-type MatchRange = { start: number; end: number }
-
-type PaletteMatchBase = { worktreeId: string }
-
-/** Empty query — all non-archived worktrees shown, no match metadata. */
-type PaletteMatchAll = PaletteMatchBase & {
-  matchedField: null
-  matchRange: null
-}
-
-/** Comment match — includes a truncated snippet centered on the matched range. */
-type PaletteMatchComment = PaletteMatchBase & {
-  matchedField: 'comment'
-  matchRange: MatchRange
-  snippet: string
-  /** Offset of the snippet start within the original comment, for highlight calculation. */
-  snippetOffset: number
-}
-
-/** Non-comment field match — range within the matched field's display value. */
-type PaletteMatchField = PaletteMatchBase & {
-  matchedField: 'displayName' | 'branch' | 'repo' | 'pr' | 'issue'
-  matchRange: MatchRange
-}
-
-type PaletteMatch = PaletteMatchAll | PaletteMatchComment | PaletteMatchField
-
-// ─── Search logic ───────────────────────────────────────────────────
-
-function extractCommentSnippet(
-  comment: string,
-  matchStart: number,
-  matchEnd: number
-): { snippet: string; snippetOffset: number } {
-  let snippetStart = Math.max(0, matchStart - 40)
-  let snippetEnd = Math.min(comment.length, matchEnd + 40)
-
-  // Snap to word boundaries (scan up to 10 chars)
-  for (let i = 0; i < 10 && snippetStart > 0; i++) {
-    if (/\s/.test(comment[snippetStart - 1])) {
-      break
-    }
-    snippetStart--
-  }
-  for (let i = 0; i < 10 && snippetEnd < comment.length; i++) {
-    if (/\s/.test(comment[snippetEnd])) {
-      break
-    }
-    snippetEnd++
-  }
-
-  const prefix = snippetStart > 0 ? '\u2026' : ''
-  const suffix = snippetEnd < comment.length ? '\u2026' : ''
-  const snippet = prefix + comment.slice(snippetStart, snippetEnd) + suffix
-
-  return { snippet, snippetOffset: snippetStart - prefix.length }
-}
-
-function searchWorktrees(
-  worktrees: Worktree[],
-  query: string,
-  repoMap: Map<string, Repo>,
-  prCache: Record<string, { data?: { number: number; title: string } | null }> | null,
-  issueCache: Record<string, { data?: { number: number; title: string } | null }> | null
-): PaletteMatch[] {
-  if (!query) {
-    return worktrees.map((w) => ({
-      worktreeId: w.id,
-      matchedField: null,
-      matchRange: null
-    }))
-  }
-
-  const q = query.toLowerCase()
-  const results: PaletteMatch[] = []
-
-  for (const w of worktrees) {
-    // Field priority: displayName > branch > repo > comment > pr > issue
-    const nameIdx = w.displayName.toLowerCase().indexOf(q)
-    if (nameIdx !== -1) {
-      results.push({
-        worktreeId: w.id,
-        matchedField: 'displayName',
-        matchRange: { start: nameIdx, end: nameIdx + q.length }
-      })
-      continue
-    }
-
-    const branch = branchName(w.branch)
-    const branchIdx = branch.toLowerCase().indexOf(q)
-    if (branchIdx !== -1) {
-      results.push({
-        worktreeId: w.id,
-        matchedField: 'branch',
-        matchRange: { start: branchIdx, end: branchIdx + q.length }
-      })
-      continue
-    }
-
-    const repoName = repoMap.get(w.repoId)?.displayName ?? ''
-    const repoIdx = repoName.toLowerCase().indexOf(q)
-    if (repoIdx !== -1) {
-      results.push({
-        worktreeId: w.id,
-        matchedField: 'repo',
-        matchRange: { start: repoIdx, end: repoIdx + q.length }
-      })
-      continue
-    }
-
-    if (w.comment) {
-      const commentIdx = w.comment.toLowerCase().indexOf(q)
-      if (commentIdx !== -1) {
-        const { snippet, snippetOffset } = extractCommentSnippet(
-          w.comment,
-          commentIdx,
-          commentIdx + q.length
-        )
-        results.push({
-          worktreeId: w.id,
-          matchedField: 'comment',
-          matchRange: { start: commentIdx, end: commentIdx + q.length },
-          snippet,
-          snippetOffset
-        })
-        continue
-      }
-    }
-
-    // Strip leading '#' for number matching, guard against bare '#'
-    const numQuery = q.startsWith('#') ? q.slice(1) : q
-    if (!numQuery) {
-      continue
-    }
-
-    // PR matching
-    const repo = repoMap.get(w.repoId)
-    const branchForPR = branchName(w.branch)
-    const prKey = repo && branchForPR ? `${repo.path}::${branchForPR}` : ''
-    const pr = prKey && prCache ? prCache[prKey]?.data : undefined
-
-    if (pr) {
-      const prNumStr = String(pr.number)
-      const prNumIdx = prNumStr.indexOf(numQuery)
-      if (prNumIdx !== -1) {
-        results.push({
-          worktreeId: w.id,
-          matchedField: 'pr',
-          matchRange: { start: prNumIdx, end: prNumIdx + numQuery.length }
-        })
-        continue
-      }
-      const prTitleIdx = pr.title.toLowerCase().indexOf(q)
-      if (prTitleIdx !== -1) {
-        results.push({
-          worktreeId: w.id,
-          matchedField: 'pr',
-          matchRange: { start: prTitleIdx, end: prTitleIdx + q.length }
-        })
-        continue
-      }
-    } else if (w.linkedPR != null) {
-      const prNumStr = String(w.linkedPR)
-      const prNumIdx = prNumStr.indexOf(numQuery)
-      if (prNumIdx !== -1) {
-        results.push({
-          worktreeId: w.id,
-          matchedField: 'pr',
-          matchRange: { start: prNumIdx, end: prNumIdx + numQuery.length }
-        })
-        continue
-      }
-    }
-
-    // Issue matching
-    if (w.linkedIssue != null) {
-      const issueNumStr = String(w.linkedIssue)
-      const issueNumIdx = issueNumStr.indexOf(numQuery)
-      if (issueNumIdx !== -1) {
-        results.push({
-          worktreeId: w.id,
-          matchedField: 'issue',
-          matchRange: { start: issueNumIdx, end: issueNumIdx + numQuery.length }
-        })
-        continue
-      }
-      const issueKey = repo ? `${repo.path}::${w.linkedIssue}` : ''
-      const issue = issueKey && issueCache ? issueCache[issueKey]?.data : undefined
-      if (issue?.title) {
-        const issueTitleIdx = issue.title.toLowerCase().indexOf(q)
-        if (issueTitleIdx !== -1) {
-          results.push({
-            worktreeId: w.id,
-            matchedField: 'issue',
-            matchRange: { start: issueTitleIdx, end: issueTitleIdx + q.length }
-          })
-          continue
-        }
-      }
-    }
-  }
-
-  return results
-}
+import { searchWorktrees, type MatchRange } from '@/lib/worktree-palette-search'
+import type { Worktree } from '../../../shared/types'
 
 // ─── Highlight helper ───────────────────────────────────────────────
 
@@ -246,14 +43,21 @@ function HighlightedText({
   )
 }
 
-// ─── Field badge labels ─────────────────────────────────────────────
+function PaletteState({ title, subtitle }: { title: string; subtitle: string }): React.JSX.Element {
+  return (
+    <div className="px-5 py-8 text-center">
+      <p className="text-sm font-medium text-foreground">{title}</p>
+      <p className="mt-1 text-xs text-muted-foreground">{subtitle}</p>
+    </div>
+  )
+}
 
-const FIELD_BADGES: Record<string, string> = {
-  branch: 'Branch',
-  repo: 'Repo',
-  comment: 'Comment',
-  pr: 'PR',
-  issue: 'Issue'
+function FooterKey({ children }: { children: React.ReactNode }): React.JSX.Element {
+  return (
+    <span className="rounded-full border border-border/60 bg-muted/35 px-2 py-0.5 text-[10px] font-medium text-foreground/85">
+      {children}
+    </span>
+  )
 }
 
 // ─── Component ──────────────────────────────────────────────────────
@@ -267,15 +71,20 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
   const prCache = useAppStore((s) => s.prCache)
   const issueCache = useAppStore((s) => s.issueCache)
   const activeWorktreeId = useAppStore((s) => s.activeWorktreeId)
+  const browserTabsByWorktree = useAppStore((s) => s.browserTabsByWorktree)
 
   const [query, setQuery] = useState('')
+  const [selectedWorktreeId, setSelectedWorktreeId] = useState('')
   const previousWorktreeIdRef = useRef<string | null>(null)
+  const wasVisibleRef = useRef(false)
 
   const repoMap = useMemo(() => new Map(repos.map((r) => [r.id, r])), [repos])
 
   // All non-archived worktrees sorted by recent signals
   const sortedWorktrees = useMemo(() => {
-    const all: Worktree[] = Object.values(worktreesByRepo).flat().filter((w) => !w.isArchived)
+    const all: Worktree[] = Object.values(worktreesByRepo)
+      .flat()
+      .filter((w) => !w.isArchived)
     return sortWorktreesRecent(all, tabsByWorktree, repoMap, prCache)
   }, [worktreesByRepo, tabsByWorktree, repoMap, prCache])
 
@@ -295,20 +104,35 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
   }, [sortedWorktrees])
 
   // Loading state: repos exist but worktreesByRepo is still empty
-  const isLoading =
-    repos.length > 0 && Object.keys(worktreesByRepo).length === 0
+  const isLoading = repos.length > 0 && Object.keys(worktreesByRepo).length === 0
 
-  const handleOpenChange = useCallback(
-    (open: boolean) => {
-      if (open) {
-        previousWorktreeIdRef.current = activeWorktreeId
-        setQuery('')
-      } else {
-        closeModal()
-      }
-    },
-    [closeModal, activeWorktreeId]
-  )
+  useEffect(() => {
+    if (visible && !wasVisibleRef.current) {
+      // Why: this dialog opens from external store state, so session reset must
+      // follow the controlled `visible` flag instead of relying on Radix open callbacks.
+      previousWorktreeIdRef.current = activeWorktreeId
+      setQuery('')
+      setSelectedWorktreeId('')
+    }
+
+    wasVisibleRef.current = visible
+  }, [visible, activeWorktreeId])
+
+  useEffect(() => {
+    if (!visible) {
+      return
+    }
+    if (matches.length === 0) {
+      setSelectedWorktreeId('')
+      return
+    }
+    if (!matches.some((match) => match.worktreeId === selectedWorktreeId)) {
+      // Why: the palette keeps live recent ordering while open. Control cmdk's
+      // selected value by worktree ID so background re-sorts keep the same
+      // logical worktree selected instead of drifting to a new visual index.
+      setSelectedWorktreeId(matches[0].worktreeId)
+    }
+  }, [visible, matches, selectedWorktreeId])
 
   const focusActiveSurface = useCallback(() => {
     // Why: double rAF — first waits for React to commit state (palette closes),
@@ -330,6 +154,20 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
     })
   }, [])
 
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (open) {
+        return
+      }
+
+      closeModal()
+      if (previousWorktreeIdRef.current) {
+        focusActiveSurface()
+      }
+    },
+    [closeModal, focusActiveSurface]
+  )
+
   const handleSelect = useCallback(
     (worktreeId: string) => {
       const state = useAppStore.getState()
@@ -340,6 +178,7 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
       }
       activateAndRevealWorktree(worktreeId)
       closeModal()
+      setSelectedWorktreeId('')
       focusActiveSurface()
     },
     [closeModal, focusActiveSurface]
@@ -363,21 +202,43 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
       onCloseAutoFocus={handleCloseAutoFocus}
       title="Open Worktree"
       description="Search across all worktrees by name, branch, comment, PR, or issue"
+      overlayClassName="bg-black/55 backdrop-blur-[2px]"
+      contentClassName="top-[13%] w-[736px] max-w-[94vw] overflow-hidden rounded-[22px] border border-border/70 bg-background/96 shadow-[0_26px_84px_rgba(0,0,0,0.32)] backdrop-blur-xl"
+      commandProps={{
+        loop: true,
+        value: selectedWorktreeId,
+        onValueChange: setSelectedWorktreeId,
+        className: 'bg-transparent'
+      }}
     >
       <CommandInput
         placeholder="Jump to worktree..."
         value={query}
         onValueChange={setQuery}
+        wrapperClassName="mx-3 mt-3 rounded-[16px] border border-border/55 bg-muted/28 px-3.5 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]"
+        iconClassName="mr-2.5 h-4 w-4 text-muted-foreground/60"
+        className="h-12 text-[14px] placeholder:text-muted-foreground/75"
       />
-      <CommandList>
+      <CommandList className="max-h-[min(460px,62vh)] px-2.5 pb-2.5 pt-1.5">
         {isLoading ? (
-          <div className="py-6 text-center text-sm text-muted-foreground">
-            Loading worktrees...
-          </div>
+          <PaletteState
+            title="Loading worktrees"
+            subtitle="Gathering your recent worktrees and activity state."
+          />
         ) : !hasWorktrees ? (
-          <CommandEmpty>No active worktrees. Create one to get started.</CommandEmpty>
+          <CommandEmpty className="py-0">
+            <PaletteState
+              title="No active worktrees"
+              subtitle="Create one to get started, then jump back here any time."
+            />
+          </CommandEmpty>
         ) : matches.length === 0 ? (
-          <CommandEmpty>No worktrees match your search.</CommandEmpty>
+          <CommandEmpty className="py-0">
+            <PaletteState
+              title="No worktrees match your search"
+              subtitle="Try a name, branch, repo, comment, PR, or issue."
+            />
+          </CommandEmpty>
         ) : (
           matches.map((match) => {
             const w = worktreeMap.get(match.worktreeId)
@@ -387,94 +248,102 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
             const repo = repoMap.get(w.repoId)
             const repoName = repo?.displayName ?? ''
             const branch = branchName(w.branch)
+            const status = getWorktreeStatus(
+              tabsByWorktree[w.id] ?? [],
+              browserTabsByWorktree[w.id] ?? []
+            )
+            const statusLabel = getWorktreeStatusLabel(status)
+            const isCurrentWorktree = activeWorktreeId === w.id
 
             return (
               <CommandItem
                 key={w.id}
                 value={w.id}
                 onSelect={() => handleSelect(w.id)}
-                className="flex items-center gap-2 px-3 py-2"
+                data-current={isCurrentWorktree ? 'true' : undefined}
+                className={cn(
+                  'mx-0.5 flex items-start gap-3 rounded-[14px] border border-transparent px-3 py-2.5 text-left outline-none transition-[background-color,border-color,box-shadow]',
+                  'data-[selected=true]:border-border/70 data-[selected=true]:bg-accent/55 data-[selected=true]:text-foreground data-[selected=true]:shadow-[inset_0_0_0_1px_rgba(255,255,255,0.03)]',
+                  'data-[current=true]:border-emerald-500/25 data-[current=true]:bg-emerald-500/[0.05]'
+                )}
               >
-                <div className="flex flex-col min-w-0 flex-1 gap-0.5">
-                  <div className="flex items-center gap-2 min-w-0">
-                    <span className="truncate text-sm font-medium text-foreground">
-                      {match.matchedField === 'displayName' ? (
-                        <HighlightedText
-                          text={w.displayName}
-                          matchRange={match.matchRange}
-                        />
-                      ) : (
-                        w.displayName
-                      )}
-                    </span>
-                    {/* Repo badge for multi-repo disambiguation */}
-                    {repoName && (
-                      <span
-                        className="shrink-0 rounded px-1.5 py-0.5 text-[10px] leading-none text-muted-foreground bg-muted"
-                        style={
-                          repo?.badgeColor
-                            ? {
-                                backgroundColor: `${repo.badgeColor}15`,
-                                color: repo.badgeColor
-                              }
-                            : undefined
-                        }
-                      >
-                        {match.matchedField === 'repo' ? (
-                          <HighlightedText
-                            text={repoName}
-                            matchRange={match.matchRange}
-                          />
-                        ) : (
-                          repoName
-                        )}
-                      </span>
-                    )}
-                    {/* Match-field badge */}
-                    {match.matchedField && FIELD_BADGES[match.matchedField] && (
-                      <span
-                        className="shrink-0 rounded px-1 py-0.5 text-[10px] leading-none text-muted-foreground/70 border border-border/50"
-                        aria-label={`Matched in ${FIELD_BADGES[match.matchedField]}`}
-                      >
-                        {FIELD_BADGES[match.matchedField]}
-                      </span>
-                    )}
+                <div className="mt-0.5 flex w-7 shrink-0 items-start justify-center">
+                  <div className="flex h-7 w-7 items-center justify-center rounded-full border border-border/45 bg-muted/35">
+                    <StatusIndicator status={status} aria-hidden="true" />
+                    <span className="sr-only">{statusLabel}</span>
                   </div>
-                  {/* Secondary info: branch + optional match snippet */}
-                  <div className="flex items-center gap-1.5 text-[11px] text-muted-foreground truncate">
-                    <span className="truncate">
-                      {match.matchedField === 'branch' ? (
-                        <HighlightedText text={branch} matchRange={match.matchRange} />
-                      ) : (
-                        branch
-                      )}
-                    </span>
-                    {match.matchedField === 'comment' && 'snippet' in match && (
-                      <>
-                        <span className="text-border">|</span>
-                        <span className="truncate italic">
-                          <HighlightedText
-                            text={match.snippet}
-                            matchRange={{
-                              start: match.matchRange.start - match.snippetOffset,
-                              end: match.matchRange.end - match.snippetOffset
-                            }}
-                          />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-start justify-between gap-2.5">
+                    <div className="min-w-0">
+                      <div className="flex min-w-0 items-center gap-2">
+                        <span className="truncate text-[14px] font-semibold tracking-[-0.01em] text-foreground">
+                          {match.displayNameRange ? (
+                            <HighlightedText
+                              text={w.displayName}
+                              matchRange={match.displayNameRange}
+                            />
+                          ) : (
+                            w.displayName
+                          )}
                         </span>
-                      </>
-                    )}
-                    {match.matchedField === 'pr' && (
-                      <>
-                        <span className="text-border">|</span>
-                        <span className="truncate">PR #{w.linkedPR}</span>
-                      </>
-                    )}
-                    {match.matchedField === 'issue' && (
-                      <>
-                        <span className="text-border">|</span>
-                        <span className="truncate">Issue #{w.linkedIssue}</span>
-                      </>
-                    )}
+                        {isCurrentWorktree && (
+                          <span className="shrink-0 rounded-[6px] border border-border/60 bg-background/45 px-1.5 py-0.5 text-[9px] font-medium leading-none text-muted-foreground/88 shadow-[inset_0_1px_0_rgba(255,255,255,0.02)]">
+                            Current
+                          </span>
+                        )}
+                      </div>
+                      <div className="mt-1 flex min-w-0 items-center gap-1.5 text-[12px] text-muted-foreground">
+                        <span className="truncate font-medium text-muted-foreground/92">
+                          {match.branchRange ? (
+                            <HighlightedText text={branch} matchRange={match.branchRange} />
+                          ) : (
+                            branch
+                          )}
+                        </span>
+                      </div>
+                      {match.supportingText && (
+                        <div className="mt-1.5 flex min-w-0 items-start gap-2 text-[12px] leading-5 text-muted-foreground/88">
+                          <span className="shrink-0 rounded-full border border-border/45 bg-background/45 px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-[0.12em] text-muted-foreground/75">
+                            {match.supportingText.label}
+                          </span>
+                          <span className="truncate">
+                            <HighlightedText
+                              text={match.supportingText.text}
+                              matchRange={match.supportingText.matchRange}
+                            />
+                          </span>
+                        </div>
+                      )}
+                    </div>
+                    <div className="flex shrink-0 flex-col items-end gap-1.5 pt-0.5">
+                      {repoName && (
+                        <span className="inline-flex max-w-[180px] items-center gap-1.5 rounded-[7px] border border-border/55 bg-muted/38 px-2 py-1 text-[10px] font-semibold leading-none text-foreground/92 shadow-[inset_0_1px_0_rgba(255,255,255,0.02)]">
+                          <span
+                            aria-hidden="true"
+                            className="size-1.5 shrink-0 rounded-full"
+                            style={
+                              repo?.badgeColor ? { backgroundColor: repo.badgeColor } : undefined
+                            }
+                          />
+                          <span className="truncate">
+                            {match.repoRange ? (
+                              <HighlightedText text={repoName} matchRange={match.repoRange} />
+                            ) : (
+                              repoName
+                            )}
+                          </span>
+                        </span>
+                      )}
+                      {match.badgeLabel && (
+                        <span
+                          className="rounded-full border border-border/40 bg-background/45 px-2 py-0.5 text-[9px] font-medium uppercase tracking-[0.12em] text-muted-foreground/82"
+                          aria-label={`Matched in ${match.badgeLabel}`}
+                        >
+                          {match.badgeLabel}
+                        </span>
+                      )}
+                    </div>
                   </div>
                 </div>
               </CommandItem>
@@ -482,9 +351,19 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
           })
         )}
       </CommandList>
+      <div className="flex items-center justify-end border-t border-border/60 px-3.5 py-2.5 text-[11px] text-muted-foreground/82">
+        <div className="flex items-center gap-2">
+          <FooterKey>Enter</FooterKey>
+          <span>Jump</span>
+          <FooterKey>Esc</FooterKey>
+          <span>Close</span>
+          <FooterKey>↑↓</FooterKey>
+          <span>Move</span>
+        </div>
+      </div>
       {/* Accessibility: announce result count changes */}
       <div aria-live="polite" className="sr-only">
-        {query.trim() ? `${resultCount} worktrees found` : ''}
+        {query.trim() ? `${resultCount} worktrees found` : `${resultCount} worktrees available`}
       </div>
     </CommandDialog>
   )

--- a/src/renderer/src/components/sidebar/StatusIndicator.tsx
+++ b/src/renderer/src/components/sidebar/StatusIndicator.tsx
@@ -1,27 +1,32 @@
 import React from 'react'
 import { cn } from '@/lib/utils'
+import type { WorktreeStatus } from '@/lib/worktree-status'
 
-type Status = 'active' | 'working' | 'permission' | 'inactive'
-
-type StatusIndicatorProps = {
-  status: Status
-  className?: string
+type StatusIndicatorProps = React.ComponentProps<'span'> & {
+  status: WorktreeStatus
 }
 
 const StatusIndicator = React.memo(function StatusIndicator({
   status,
-  className
+  className,
+  ...props
 }: StatusIndicatorProps) {
   if (status === 'working') {
     return (
-      <span className={cn('inline-flex h-3 w-3 items-center justify-center shrink-0', className)}>
+      <span
+        className={cn('inline-flex h-3 w-3 shrink-0 items-center justify-center', className)}
+        {...props}
+      >
         <span className="block size-2 rounded-full border-2 border-emerald-500 border-t-transparent animate-spin" />
       </span>
     )
   }
 
   return (
-    <span className={cn('inline-flex h-3 w-3 items-center justify-center shrink-0', className)}>
+    <span
+      className={cn('inline-flex h-3 w-3 shrink-0 items-center justify-center', className)}
+      {...props}
+    >
       <span
         className={cn(
           'block size-2 rounded-full',
@@ -37,4 +42,4 @@ const StatusIndicator = React.memo(function StatusIndicator({
 })
 
 export default StatusIndicator
-export type { Status }
+export type { WorktreeStatus as Status }

--- a/src/renderer/src/components/sidebar/WorktreeCard.test.ts
+++ b/src/renderer/src/components/sidebar/WorktreeCard.test.ts
@@ -13,7 +13,7 @@ vi.mock('@/lib/agent-status', () => ({
   })
 }))
 
-import { getWorktreeStatus } from './WorktreeCard'
+import { getWorktreeStatus } from '@/lib/worktree-status'
 
 function makeTerminalTab(title: string): TerminalTab {
   return {
@@ -34,11 +34,11 @@ describe('getWorktreeStatus', () => {
   })
 
   it('keeps terminal agent states higher priority than browser presence', () => {
-    expect(
-      getWorktreeStatus([makeTerminalTab('permission needed')], [{ id: 'browser-1' }])
-    ).toBe('permission')
-    expect(
-      getWorktreeStatus([makeTerminalTab('working hard')], [{ id: 'browser-1' }])
-    ).toBe('working')
+    expect(getWorktreeStatus([makeTerminalTab('permission needed')], [{ id: 'browser-1' }])).toBe(
+      'permission'
+    )
+    expect(getWorktreeStatus([makeTerminalTab('working hard')], [{ id: 'browser-1' }])).toBe(
+      'working'
+    )
   })
 })

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -10,7 +10,7 @@ import CacheTimer from './CacheTimer'
 import CommentMarkdown from './CommentMarkdown'
 import WorktreeContextMenu from './WorktreeContextMenu'
 import { cn } from '@/lib/utils'
-import { detectAgentStatusFromTitle } from '@/lib/agent-status'
+import { getWorktreeStatus, type WorktreeStatus } from '@/lib/worktree-status'
 import { getRepoKindLabel, isFolderRepo } from '../../../../shared/repo-kind'
 import type {
   Worktree,
@@ -22,7 +22,6 @@ import type {
   GitConflictOperation,
   TerminalTab
 } from '../../../../shared/types'
-import type { Status } from './StatusIndicator'
 
 function branchDisplayName(branch: string): string {
   return branch.replace(/^refs\/heads\//, '')
@@ -54,24 +53,6 @@ const CONFLICT_OPERATION_LABELS: Record<Exclude<GitConflictOperation, 'unknown'>
 // ── Stable empty array for tabs fallback ─────────────────────────
 const EMPTY_TABS: TerminalTab[] = []
 const EMPTY_BROWSER_TABS: { id: string }[] = []
-
-export function getWorktreeStatus(tabs: TerminalTab[], browserTabs: { id: string }[]): Status {
-  const liveTabs = tabs.filter((tab) => tab.ptyId)
-  if (liveTabs.some((tab) => detectAgentStatusFromTitle(tab.title) === 'permission')) {
-    return 'permission'
-  }
-  if (liveTabs.some((tab) => detectAgentStatusFromTitle(tab.title) === 'working')) {
-    return 'working'
-  }
-  if (liveTabs.length > 0 || browserTabs.length > 0) {
-    // Why: browser-only worktrees are still active from the user's point of
-    // view even when they have no PTY-backed terminal. The sidebar filter
-    // already treats them as active, so the card badge must stay consistent
-    // instead of showing a misleading inactive dot.
-    return 'active'
-  }
-  return 'inactive'
-}
 
 type WorktreeCardProps = {
   worktree: Worktree
@@ -173,7 +154,10 @@ const WorktreeCard = React.memo(function WorktreeCard({
   const isDeleting = deleteState?.isDeleting ?? false
 
   // Derive status
-  const status: Status = useMemo(() => getWorktreeStatus(tabs, browserTabs), [tabs, browserTabs])
+  const status: WorktreeStatus = useMemo(
+    () => getWorktreeStatus(tabs, browserTabs),
+    [tabs, browserTabs]
+  )
 
   const showPR = cardProps.includes('pr')
   const showCI = cardProps.includes('ci')

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -20,6 +20,31 @@ import { useModifierHint } from '@/hooks/useModifierHint'
 // terminal title changes) trigger score recalculations.
 const SORT_SETTLE_MS = 3_000
 
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) {
+    return false
+  }
+
+  // xterm uses a hidden textarea for terminal input. Treating it like a normal
+  // text field would make the sidebar's app-level worktree shortcuts unreachable.
+  if (target.classList.contains('xterm-helper-textarea')) {
+    return false
+  }
+
+  if (target.isContentEditable) {
+    return true
+  }
+
+  return (
+    target.closest('input, textarea, select, [contenteditable=""], [contenteditable="true"]') !==
+    null
+  )
+}
+
+function getWorktreeOptionId(worktreeId: string): string {
+  return `worktree-list-option-${encodeURIComponent(worktreeId)}`
+}
+
 const WorktreeList = React.memo(function WorktreeList() {
   // ── Granular selectors (each is a primitive or shallow-stable ref) ──
   const worktreesByRepo = useAppStore((s) => s.worktreesByRepo)
@@ -32,6 +57,7 @@ const WorktreeList = React.memo(function WorktreeList() {
   const showActiveOnly = useAppStore((s) => s.showActiveOnly)
   const filterRepoIds = useAppStore((s) => s.filterRepoIds)
   const openModal = useAppStore((s) => s.openModal)
+  const activeModal = useAppStore((s) => s.activeModal)
   const pendingRevealWorktreeId = useAppStore((s) => s.pendingRevealWorktreeId)
   const clearPendingRevealWorktreeId = useAppStore((s) => s.clearPendingRevealWorktreeId)
 
@@ -218,7 +244,11 @@ const WorktreeList = React.memo(function WorktreeList() {
 
   // Cmd+1–9 hint overlay: map worktree ID → hint number (1–9) for the first
   // 9 visible worktrees. Only populated while the user holds the modifier key.
-  const { showHints } = useModifierHint()
+  // Why suppress during modals: shortcuts like Cmd+J can open overlays via IPC
+  // before the renderer observes the second key in the combo, which leaves the
+  // bare-modifier timer armed. Hint badges are only useful while the sidebar is
+  // the active navigation surface, so any modal should clear and disable them.
+  const { showHints } = useModifierHint(activeModal === 'none')
 
   // Collapsed group state
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set())
@@ -252,6 +282,10 @@ const WorktreeList = React.memo(function WorktreeList() {
         .filter((r): r is Extract<Row, { type: 'item' }> => r.type === 'item')
         .map((r) => r.worktree),
     [rows]
+  )
+  const activeWorktreeRowIndex = useMemo(
+    () => rows.findIndex((row) => row.type === 'item' && row.worktree.id === activeWorktreeId),
+    [rows, activeWorktreeId]
   )
 
   // Why layout effect instead of effect: the global Cmd/Ctrl+1–9 key handler
@@ -385,7 +419,16 @@ const WorktreeList = React.memo(function WorktreeList() {
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      const mod = navigator.userAgent.includes('Mac') ? e.metaKey : e.ctrlKey
+      // Why: these shortcuts are for the sidebar navigation surface. Once a
+      // modal opens or focus is inside an editor/input, the host should leave
+      // the keystroke alone so overlays and text editing keep native behavior.
+      if (activeModal !== 'none' || isEditableTarget(e.target)) {
+        return
+      }
+
+      const mod = navigator.userAgent.includes('Mac')
+        ? e.metaKey && !e.ctrlKey
+        : e.ctrlKey && !e.metaKey
       if (mod && !e.shiftKey && e.key === '0') {
         scrollRef.current?.focus()
         e.preventDefault()
@@ -400,7 +443,7 @@ const WorktreeList = React.memo(function WorktreeList() {
 
     window.addEventListener('keydown', handleKeyDown, { capture: true })
     return () => window.removeEventListener('keydown', handleKeyDown, { capture: true })
-  }, [navigateWorktree])
+  }, [activeModal, navigateWorktree])
 
   const handleContainerKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
@@ -461,21 +504,38 @@ const WorktreeList = React.memo(function WorktreeList() {
     )
   }
 
+  const virtualItems = virtualizer.getVirtualItems()
+  const activeDescendantId =
+    activeWorktreeId != null &&
+    activeWorktreeRowIndex !== -1 &&
+    virtualItems.some((item) => item.index === activeWorktreeRowIndex)
+      ? getWorktreeOptionId(activeWorktreeId)
+      : undefined
+
   return (
     <div
       ref={scrollRef}
       tabIndex={0}
+      role="listbox"
+      aria-label="Worktrees"
+      aria-orientation="vertical"
+      aria-activedescendant={activeDescendantId}
       onKeyDown={handleContainerKeyDown}
       className="flex-1 overflow-auto px-1 scrollbar-sleek scroll-smooth outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-inset pt-px"
     >
-      <div className="relative w-full" style={{ height: `${virtualizer.getTotalSize()}px` }}>
-        {virtualizer.getVirtualItems().map((vItem) => {
+      <div
+        role="presentation"
+        className="relative w-full"
+        style={{ height: `${virtualizer.getTotalSize()}px` }}
+      >
+        {virtualItems.map((vItem) => {
           const row = rows[vItem.index]
 
           if (row.type === 'header') {
             return (
               <div
                 key={vItem.key}
+                role="presentation"
                 data-index={vItem.index}
                 ref={virtualizer.measureElement}
                 className="absolute left-0 right-0"
@@ -554,6 +614,9 @@ const WorktreeList = React.memo(function WorktreeList() {
           return (
             <div
               key={vItem.key}
+              id={getWorktreeOptionId(row.worktree.id)}
+              role="option"
+              aria-selected={activeWorktreeId === row.worktree.id}
               data-index={vItem.index}
               ref={virtualizer.measureElement}
               className="absolute left-0 right-0"

--- a/src/renderer/src/components/ui/command.tsx
+++ b/src/renderer/src/components/ui/command.tsx
@@ -26,21 +26,35 @@ function CommandDialog({
   description = 'Search for a command to run...',
   shouldFilter,
   onCloseAutoFocus,
+  contentClassName,
+  overlayClassName,
+  commandProps,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Root> & {
   title?: string
   description?: string
   shouldFilter?: boolean
   onCloseAutoFocus?: (e: Event) => void
+  contentClassName?: string
+  overlayClassName?: string
+  commandProps?: React.ComponentProps<typeof CommandPrimitive>
 }) {
+  const { className: commandClassName, ...commandRootProps } = commandProps ?? {}
+
   return (
     <DialogPrimitive.Root {...props}>
       <DialogPrimitive.Portal>
         <DialogPrimitive.Overlay
-          className="fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0"
+          className={cn(
+            'fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0',
+            overlayClassName
+          )}
         />
         <DialogPrimitive.Content
-          className="fixed top-[20%] left-[50%] z-50 w-[660px] max-w-[90vw] translate-x-[-50%] rounded-lg border border-border bg-popover shadow-lg outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95"
+          className={cn(
+            'fixed top-[20%] left-[50%] z-50 w-[660px] max-w-[90vw] translate-x-[-50%] rounded-lg border border-border bg-popover shadow-lg outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
+            contentClassName
+          )}
           onCloseAutoFocus={onCloseAutoFocus}
         >
           <DialogPrimitive.Title className="sr-only">{title}</DialogPrimitive.Title>
@@ -49,7 +63,11 @@ function CommandDialog({
           </DialogPrimitive.Description>
           <Command
             shouldFilter={shouldFilter}
-            className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3"
+            className={cn(
+              '[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3',
+              commandClassName
+            )}
+            {...commandRootProps}
           >
             {children}
           </Command>
@@ -61,11 +79,19 @@ function CommandDialog({
 
 function CommandInput({
   className,
+  wrapperClassName,
+  iconClassName,
   ...props
-}: React.ComponentProps<typeof CommandPrimitive.Input>) {
+}: React.ComponentProps<typeof CommandPrimitive.Input> & {
+  wrapperClassName?: string
+  iconClassName?: string
+}) {
   return (
-    <div className="flex items-center border-b border-border px-3" data-cmdk-input-wrapper="">
-      <SearchIcon className="mr-2 h-4 w-4 shrink-0 opacity-50" />
+    <div
+      className={cn('flex items-center border-b border-border px-3', wrapperClassName)}
+      data-cmdk-input-wrapper=""
+    >
+      <SearchIcon className={cn('mr-2 h-4 w-4 shrink-0 opacity-50', iconClassName)} />
       <CommandPrimitive.Input
         data-slot="command-input"
         className={cn(
@@ -82,13 +108,19 @@ function CommandList({ className, ...props }: React.ComponentProps<typeof Comman
   return (
     <CommandPrimitive.List
       data-slot="command-list"
-      className={cn('max-h-[min(400px,60vh)] overflow-y-auto overflow-x-hidden scrollbar-sleek', className)}
+      className={cn(
+        'max-h-[min(400px,60vh)] overflow-y-auto overflow-x-hidden scrollbar-sleek scroll-pb-4 scroll-pt-4',
+        className
+      )}
       {...props}
     />
   )
 }
 
-function CommandEmpty({ className, ...props }: React.ComponentProps<typeof CommandPrimitive.Empty>) {
+function CommandEmpty({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Empty>) {
   return (
     <CommandPrimitive.Empty
       data-slot="command-empty"
@@ -114,10 +146,7 @@ function CommandGroup({
   )
 }
 
-function CommandItem({
-  className,
-  ...props
-}: React.ComponentProps<typeof CommandPrimitive.Item>) {
+function CommandItem({ className, ...props }: React.ComponentProps<typeof CommandPrimitive.Item>) {
   return (
     <CommandPrimitive.Item
       data-slot="command-item"

--- a/src/renderer/src/hooks/useModifierHint.ts
+++ b/src/renderer/src/hooks/useModifierHint.ts
@@ -17,7 +17,7 @@ const MOD_KEY = isMac ? 'Meta' : 'Control'
  * - Window blur resets state to handle Cmd+Tab away without a keyup event.
  * - `e.repeat` events are ignored so the timer only starts once.
  */
-export function useModifierHint(): { showHints: boolean } {
+export function useModifierHint(enabled: boolean = true): { showHints: boolean } {
   const [showHints, setShowHints] = useState(false)
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
@@ -28,6 +28,11 @@ export function useModifierHint(): { showHints: boolean } {
         timerRef.current = null
       }
       setShowHints(false)
+    }
+
+    if (!enabled) {
+      clear()
+      return undefined
     }
 
     const onKeyDown = (e: KeyboardEvent): void => {
@@ -71,7 +76,7 @@ export function useModifierHint(): { showHints: boolean } {
       window.removeEventListener('keyup', onKeyUp)
       window.removeEventListener('blur', clear)
     }
-  }, [])
+  }, [enabled])
 
   return { showHints }
 }

--- a/src/renderer/src/lib/worktree-palette-search.test.ts
+++ b/src/renderer/src/lib/worktree-palette-search.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest'
+import { searchWorktrees } from './worktree-palette-search'
+import type { Repo, Worktree } from '../../../shared/types'
+
+function makeWorktree(overrides: Partial<Worktree> = {}): Worktree {
+  return {
+    id: 'wt-1',
+    repoId: 'repo-1',
+    path: '/tmp/wt-1',
+    head: 'abc123',
+    branch: 'refs/heads/feature/worktree-jump',
+    isBare: false,
+    isMainWorktree: false,
+    displayName: 'Jump Palette',
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    isArchived: false,
+    isUnread: false,
+    sortOrder: 0,
+    lastActivityAt: 0,
+    ...overrides
+  }
+}
+
+const repoMap = new Map<string, Repo>([
+  [
+    'repo-1',
+    {
+      id: 'repo-1',
+      path: '/repo/orca',
+      displayName: 'stablyai/orca',
+      badgeColor: '#22c55e',
+      addedAt: 0
+    }
+  ]
+])
+
+describe('worktree-palette-search', () => {
+  it('returns every worktree with no match metadata for an empty query', () => {
+    const results = searchWorktrees([makeWorktree()], '', repoMap, null, null)
+
+    expect(results).toEqual([
+      {
+        worktreeId: 'wt-1',
+        matchedField: null,
+        displayNameRange: null,
+        branchRange: null,
+        repoRange: null,
+        badgeLabel: null,
+        supportingText: null
+      }
+    ])
+  })
+
+  it('returns a truncated comment snippet with the highlighted match range', () => {
+    const results = searchWorktrees(
+      [
+        makeWorktree({
+          comment:
+            'This worktree carries the quick jump refresh implementation details for the new palette.'
+        })
+      ],
+      'implementation',
+      repoMap,
+      null,
+      null
+    )
+
+    expect(results).toHaveLength(1)
+    expect(results[0].badgeLabel).toBe('Comment')
+    expect(results[0].supportingText?.label).toBe('Comment')
+    expect(results[0].supportingText?.text).toContain('implementation')
+    expect(
+      results[0].supportingText?.text.slice(
+        results[0].supportingText.matchRange!.start,
+        results[0].supportingText.matchRange!.end
+      )
+    ).toBe('implementation')
+  })
+
+  it('keeps PR title matches in the search result model instead of inferring them during render', () => {
+    const results = searchWorktrees(
+      [makeWorktree({ branch: 'refs/heads/feature/palette-refresh', linkedPR: 426 })],
+      'quick jump',
+      repoMap,
+      {
+        '/repo/orca::feature/palette-refresh': {
+          data: {
+            number: 426,
+            title: 'Refresh the worktree quick jump palette'
+          }
+        }
+      },
+      null
+    )
+
+    expect(results).toHaveLength(1)
+    expect(results[0].badgeLabel).toBe('PR')
+    expect(results[0].supportingText).toEqual({
+      label: 'PR',
+      text: 'Refresh the worktree quick jump palette',
+      matchRange: { start: 21, end: 31 }
+    })
+  })
+
+  it('matches issue numbers with a leading hash and returns issue render context', () => {
+    const results = searchWorktrees(
+      [makeWorktree({ linkedIssue: 304 })],
+      '#304',
+      repoMap,
+      null,
+      null
+    )
+
+    expect(results).toHaveLength(1)
+    expect(results[0].badgeLabel).toBe('Issue')
+    expect(results[0].supportingText).toEqual({
+      label: 'Issue',
+      text: 'Issue #304',
+      matchRange: { start: 7, end: 10 }
+    })
+  })
+})

--- a/src/renderer/src/lib/worktree-palette-search.ts
+++ b/src/renderer/src/lib/worktree-palette-search.ts
@@ -1,0 +1,259 @@
+import { branchName } from '@/lib/git-utils'
+import type { Repo, Worktree } from '../../../shared/types'
+
+export type MatchRange = { start: number; end: number }
+
+export type PaletteMatchedField = 'displayName' | 'branch' | 'repo' | 'comment' | 'pr' | 'issue'
+
+export type PaletteSupportingText = {
+  label: 'Comment' | 'PR' | 'Issue'
+  text: string
+  matchRange: MatchRange | null
+}
+
+export type PaletteSearchResult = {
+  worktreeId: string
+  matchedField: PaletteMatchedField | null
+  displayNameRange: MatchRange | null
+  branchRange: MatchRange | null
+  repoRange: MatchRange | null
+  badgeLabel: 'Branch' | 'Repo' | 'Comment' | 'PR' | 'Issue' | null
+  supportingText: PaletteSupportingText | null
+}
+
+type PRCacheEntry = { data?: { number: number; title: string } | null } | undefined
+type IssueCacheEntry = { data?: { number: number; title: string } | null } | undefined
+
+function extractCommentSnippet(
+  comment: string,
+  matchStart: number,
+  matchEnd: number
+): { text: string; matchRange: MatchRange } {
+  let snippetStart = Math.max(0, matchStart - 40)
+  let snippetEnd = Math.min(comment.length, matchEnd + 40)
+
+  for (let i = 0; i < 10 && snippetStart > 0; i++) {
+    if (/\s/.test(comment[snippetStart - 1])) {
+      break
+    }
+    snippetStart--
+  }
+  for (let i = 0; i < 10 && snippetEnd < comment.length; i++) {
+    if (/\s/.test(comment[snippetEnd])) {
+      break
+    }
+    snippetEnd++
+  }
+
+  const prefix = snippetStart > 0 ? '\u2026' : ''
+  const suffix = snippetEnd < comment.length ? '\u2026' : ''
+  return {
+    text: `${prefix}${comment.slice(snippetStart, snippetEnd)}${suffix}`,
+    matchRange: {
+      start: prefix.length + matchStart - snippetStart,
+      end: prefix.length + matchEnd - snippetStart
+    }
+  }
+}
+
+function makeResult(
+  worktreeId: string,
+  matchedField: PaletteMatchedField | null,
+  overrides: Partial<Omit<PaletteSearchResult, 'worktreeId' | 'matchedField'>> = {}
+): PaletteSearchResult {
+  return {
+    worktreeId,
+    matchedField,
+    displayNameRange: null,
+    branchRange: null,
+    repoRange: null,
+    badgeLabel:
+      matchedField === 'branch'
+        ? 'Branch'
+        : matchedField === 'repo'
+          ? 'Repo'
+          : matchedField === 'comment'
+            ? 'Comment'
+            : matchedField === 'pr'
+              ? 'PR'
+              : matchedField === 'issue'
+                ? 'Issue'
+                : null,
+    supportingText: null,
+    ...overrides
+  }
+}
+
+export function searchWorktrees(
+  worktrees: Worktree[],
+  query: string,
+  repoMap: Map<string, Repo>,
+  prCache: Record<string, PRCacheEntry> | null,
+  issueCache: Record<string, IssueCacheEntry> | null
+): PaletteSearchResult[] {
+  if (!query) {
+    return worktrees.map((worktree) => makeResult(worktree.id, null))
+  }
+
+  const q = query.toLowerCase()
+  const numericQuery = q.startsWith('#') ? q.slice(1) : q
+  const results: PaletteSearchResult[] = []
+
+  for (const worktree of worktrees) {
+    const nameIndex = worktree.displayName.toLowerCase().indexOf(q)
+    if (nameIndex !== -1) {
+      results.push(
+        makeResult(worktree.id, 'displayName', {
+          displayNameRange: { start: nameIndex, end: nameIndex + q.length }
+        })
+      )
+      continue
+    }
+
+    const branch = branchName(worktree.branch)
+    const branchIndex = branch.toLowerCase().indexOf(q)
+    if (branchIndex !== -1) {
+      results.push(
+        makeResult(worktree.id, 'branch', {
+          branchRange: { start: branchIndex, end: branchIndex + q.length }
+        })
+      )
+      continue
+    }
+
+    const repoName = repoMap.get(worktree.repoId)?.displayName ?? ''
+    const repoIndex = repoName.toLowerCase().indexOf(q)
+    if (repoIndex !== -1) {
+      results.push(
+        makeResult(worktree.id, 'repo', {
+          repoRange: { start: repoIndex, end: repoIndex + q.length }
+        })
+      )
+      continue
+    }
+
+    if (worktree.comment) {
+      const commentIndex = worktree.comment.toLowerCase().indexOf(q)
+      if (commentIndex !== -1) {
+        const snippet = extractCommentSnippet(
+          worktree.comment,
+          commentIndex,
+          commentIndex + q.length
+        )
+        results.push(
+          makeResult(worktree.id, 'comment', {
+            supportingText: {
+              label: 'Comment',
+              text: snippet.text,
+              matchRange: snippet.matchRange
+            }
+          })
+        )
+        continue
+      }
+    }
+
+    if (!numericQuery) {
+      continue
+    }
+
+    const repo = repoMap.get(worktree.repoId)
+    const prKey = repo ? `${repo.path}::${branch}` : ''
+    const pr = prKey && prCache ? prCache[prKey]?.data : undefined
+
+    if (pr) {
+      const prText = `PR #${pr.number}`
+      const prNumberIndex = String(pr.number).indexOf(numericQuery)
+      if (prNumberIndex !== -1) {
+        results.push(
+          makeResult(worktree.id, 'pr', {
+            supportingText: {
+              label: 'PR',
+              text: prText,
+              matchRange: {
+                start: 'PR #'.length + prNumberIndex,
+                end: 'PR #'.length + prNumberIndex + numericQuery.length
+              }
+            }
+          })
+        )
+        continue
+      }
+
+      const prTitleIndex = pr.title.toLowerCase().indexOf(q)
+      if (prTitleIndex !== -1) {
+        results.push(
+          makeResult(worktree.id, 'pr', {
+            supportingText: {
+              label: 'PR',
+              text: pr.title,
+              matchRange: { start: prTitleIndex, end: prTitleIndex + q.length }
+            }
+          })
+        )
+        continue
+      }
+    } else if (worktree.linkedPR != null) {
+      const prText = `PR #${worktree.linkedPR}`
+      const prNumberIndex = String(worktree.linkedPR).indexOf(numericQuery)
+      if (prNumberIndex !== -1) {
+        results.push(
+          makeResult(worktree.id, 'pr', {
+            supportingText: {
+              label: 'PR',
+              text: prText,
+              matchRange: {
+                start: 'PR #'.length + prNumberIndex,
+                end: 'PR #'.length + prNumberIndex + numericQuery.length
+              }
+            }
+          })
+        )
+        continue
+      }
+    }
+
+    if (worktree.linkedIssue == null) {
+      continue
+    }
+
+    const issueText = `Issue #${worktree.linkedIssue}`
+    const issueNumberIndex = String(worktree.linkedIssue).indexOf(numericQuery)
+    if (issueNumberIndex !== -1) {
+      results.push(
+        makeResult(worktree.id, 'issue', {
+          supportingText: {
+            label: 'Issue',
+            text: issueText,
+            matchRange: {
+              start: 'Issue #'.length + issueNumberIndex,
+              end: 'Issue #'.length + issueNumberIndex + numericQuery.length
+            }
+          }
+        })
+      )
+      continue
+    }
+
+    const issueKey = repo ? `${repo.path}::${worktree.linkedIssue}` : ''
+    const issue = issueKey && issueCache ? issueCache[issueKey]?.data : undefined
+    if (!issue?.title) {
+      continue
+    }
+
+    const issueTitleIndex = issue.title.toLowerCase().indexOf(q)
+    if (issueTitleIndex !== -1) {
+      results.push(
+        makeResult(worktree.id, 'issue', {
+          supportingText: {
+            label: 'Issue',
+            text: issue.title,
+            matchRange: { start: issueTitleIndex, end: issueTitleIndex + q.length }
+          }
+        })
+      )
+    }
+  }
+
+  return results
+}

--- a/src/renderer/src/lib/worktree-status.test.ts
+++ b/src/renderer/src/lib/worktree-status.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { getWorktreeStatus, getWorktreeStatusLabel } from './worktree-status'
+
+describe('worktree-status', () => {
+  it('prioritizes permission over other live activity states', () => {
+    const status = getWorktreeStatus(
+      [
+        { ptyId: 'pty-working', title: 'claude [working]' },
+        { ptyId: 'pty-permission', title: 'claude [permission]' }
+      ],
+      [{ id: 'browser-1' }]
+    )
+
+    expect(status).toBe('permission')
+    expect(getWorktreeStatusLabel(status)).toBe('Needs permission')
+  })
+
+  it('treats browser-only worktrees as active', () => {
+    const status = getWorktreeStatus([], [{ id: 'browser-1' }])
+
+    expect(status).toBe('active')
+  })
+
+  it('returns inactive when neither tabs nor browser state are live', () => {
+    expect(getWorktreeStatus([], [])).toBe('inactive')
+  })
+})

--- a/src/renderer/src/lib/worktree-status.ts
+++ b/src/renderer/src/lib/worktree-status.ts
@@ -1,0 +1,36 @@
+import { detectAgentStatusFromTitle } from '@/lib/agent-status'
+import type { TerminalTab } from '../../../shared/types'
+
+export type WorktreeStatus = 'active' | 'working' | 'permission' | 'inactive'
+
+const STATUS_LABELS: Record<WorktreeStatus, string> = {
+  active: 'Active',
+  working: 'Working',
+  permission: 'Needs permission',
+  inactive: 'Inactive'
+}
+
+export function getWorktreeStatus(
+  tabs: Pick<TerminalTab, 'ptyId' | 'title'>[],
+  browserTabs: { id: string }[]
+): WorktreeStatus {
+  const liveTabs = tabs.filter((tab) => tab.ptyId)
+  if (liveTabs.some((tab) => detectAgentStatusFromTitle(tab.title) === 'permission')) {
+    return 'permission'
+  }
+  if (liveTabs.some((tab) => detectAgentStatusFromTitle(tab.title) === 'working')) {
+    return 'working'
+  }
+  if (liveTabs.length > 0 || browserTabs.length > 0) {
+    // Why: browser-only worktrees are still active from the user's point of
+    // view even when they have no PTY-backed terminal. The sidebar filter
+    // already treats them as active, so every navigation surface must reuse
+    // that rule instead of showing a misleading inactive dot.
+    return 'active'
+  }
+  return 'inactive'
+}
+
+export function getWorktreeStatusLabel(status: WorktreeStatus): string {
+  return STATUS_LABELS[status]
+}


### PR DESCRIPTION
## Summary

Refresh the worktree quick jump palette so it feels more like a dedicated switcher than a stock command list.

This PR:
- refreshes the palette chrome, spacing, row hierarchy, footer hints, and repo/current chip treatment
- adds sidebar-style live worktree status indicators to each result row
- extracts shared worktree status and palette search/result-shaping helpers so the palette and sidebar use the same activity rules
- keeps palette selection stable by `worktreeId` while live recent ordering changes
- fixes sidebar quick-swap shortcut handling so modal overlays do not show or react to the `Cmd/Ctrl+1-9` hint state incorrectly
- adds accessibility fixes for both the palette rows and the keyboard-focusable sidebar worktree list

## Screenshots


https://github.com/user-attachments/assets/5d99675d-e54b-4184-b7d9-6f9f88c450b2



## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Additional verification run locally:
- `pnpm exec vitest run src/renderer/src/lib/worktree-status.test.ts src/renderer/src/lib/worktree-palette-search.test.ts src/renderer/src/lib/worktree-activation.test.ts src/renderer/src/components/sidebar/WorktreeCard.test.ts --config config/vitest.config.ts`
- `pnpm run typecheck:web`

## AI Review Report

Ran an AI review/fix loop over the changed renderer files. The review explicitly checked cross-platform compatibility for macOS, Linux, and Windows, including shortcut handling, shortcut labels, path behavior, and Electron overlay interactions touched by this PR.

Main findings from review:
- the palette session reset depended on `onOpenChange(true)` even though the dialog is opened from external store state
- the refreshed palette rows overrode their accessible name with an incomplete `aria-label`
- the new sidebar keyboard handler was too global and could steal editor/input shortcuts or switch worktrees behind open modals
- the tabbable sidebar worktree list container needed explicit accessibility semantics

Changes made in response:
- moved palette-open initialization to a `visible`-driven effect
- removed the incomplete palette `aria-label` override so row content drives the accessible name again
- guarded sidebar worktree shortcuts for modal-open and editable-target cases
- added listbox semantics and active-descendant wiring to the focusable sidebar worktree list container

## Security Audit

Reviewed the touched code for basic renderer-side security risks.

Checked areas:
- input handling for palette search and keyboard shortcut events
- path handling and worktree/repo identity plumbing in the extracted helper modules
- command execution and IPC surface changes in the touched files
- accidental cross-overlay behavior that could trigger actions on the wrong worktree
- dependency usage in the shared `cmdk` wrapper changes

Summary:
- no new command execution, auth, secrets, or IPC exposure risks were introduced by this PR
- no new path-joining or filesystem mutation logic was added in the touched code
- the main practical safety issue found was shortcut scope: worktree navigation shortcuts could fire in the wrong context; that was fixed before opening this PR
- no additional security follow-up is currently required for the changed files

## Notes

- Cross-platform shortcut behavior remains runtime-gated: modifier-key logic continues to distinguish macOS vs Linux/Windows.
