### PR TITLE
Fix terminal links opening externally on cmd/ctrl-click

### DIFF
--- a/src/renderer/src/components/settings/GeneralPane.tsx
+++ b/src/renderer/src/components/settings/GeneralPane.tsx
@@ -304,36 +304,18 @@ export function GeneralPane({ settings, updateSettings }: GeneralPaneProps): Rea
         </div>
 
         <SearchableSetting
-          title="Open Links In Orca"
-          description="Open terminal http(s) links in Orca browser tabs instead of the system browser."
+          title="Terminal Link Routing"
+          description="Cmd/Ctrl+click opens terminal http(s) links in Orca. Shift+Cmd/Ctrl+click uses the system browser."
           keywords={['browser', 'preview', 'links', 'localhost', 'webview']}
-          className="flex items-center justify-between gap-4 px-1 py-2"
+          className="px-1 py-2"
         >
           <div className="space-y-0.5">
-            <Label>Open Links In Orca</Label>
+            <Label>Terminal Link Routing</Label>
             <p className="text-xs text-muted-foreground">
-              Open terminal http(s) links in isolated Orca browser tabs instead of the system
-              browser.
+              Cmd/Ctrl+click opens terminal links in Orca. Shift+Cmd/Ctrl+click opens the same link
+              in your system browser.
             </p>
           </div>
-          <button
-            role="switch"
-            aria-checked={settings.openLinksInApp}
-            onClick={() =>
-              updateSettings({
-                openLinksInApp: !settings.openLinksInApp
-              })
-            }
-            className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent transition-colors ${
-              settings.openLinksInApp ? 'bg-foreground' : 'bg-muted-foreground/30'
-            }`}
-          >
-            <span
-              className={`pointer-events-none block size-3.5 rounded-full bg-background shadow-sm transition-transform ${
-                settings.openLinksInApp ? 'translate-x-4' : 'translate-x-0.5'
-              }`}
-            />
-          </button>
         </SearchableSetting>
       </section>
     ) : null,

--- a/src/renderer/src/components/settings/general-search.ts
+++ b/src/renderer/src/components/settings/general-search.ts
@@ -62,9 +62,10 @@ export const GENERAL_CACHE_TIMER_SEARCH_ENTRIES: SettingsSearchEntry[] = [
 
 export const GENERAL_BROWSER_SEARCH_ENTRIES: SettingsSearchEntry[] = [
   {
-    title: 'Open Links In Orca',
-    description: 'Open terminal http(s) links in Orca browser tabs instead of the system browser.',
-    keywords: ['browser', 'preview', 'links', 'localhost', 'webview']
+    title: 'Terminal Link Routing',
+    description:
+      'Cmd/Ctrl+click opens terminal http(s) links in Orca. Shift+Cmd/Ctrl+click uses the system browser.',
+    keywords: ['browser', 'preview', 'links', 'localhost', 'webview', 'shift', 'cmd', 'ctrl']
   }
 ]
 

--- a/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
@@ -73,6 +73,7 @@ describe('isTerminalLinkActivation', () => {
 describe('handleOscLink', () => {
   it('opens http links only when the platform modifier is pressed', () => {
     setPlatform('Macintosh')
+    storeState.settings = { openLinksInApp: false }
 
     handleOscLink('https://example.com', { metaKey: false, ctrlKey: false }, deps)
     expect(openUrlMock).not.toHaveBeenCalled()
@@ -98,6 +99,16 @@ describe('handleOscLink', () => {
     expect(openUrlMock).not.toHaveBeenCalled()
     expect(preventDefault).toHaveBeenCalled()
     expect(stopPropagation).toHaveBeenCalled()
+  })
+
+  it('defaults to Orca when settings have not hydrated yet', () => {
+    setPlatform('Macintosh')
+    storeState.settings = undefined
+
+    handleOscLink('https://example.com', { metaKey: true, ctrlKey: false, shiftKey: false }, deps)
+
+    expect(createBrowserTabMock).toHaveBeenCalledWith('wt-1', 'https://example.com/')
+    expect(openUrlMock).not.toHaveBeenCalled()
   })
 
   it('uses the system browser for shift+cmd/ctrl+click even when Orca browser tabs are enabled', () => {

--- a/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
@@ -71,20 +71,16 @@ describe('isTerminalLinkActivation', () => {
 })
 
 describe('handleOscLink', () => {
-  it('opens http links only when the platform modifier is pressed', () => {
+  it('ignores http links without the platform modifier', () => {
     setPlatform('Macintosh')
-    storeState.settings = { openLinksInApp: false }
 
     handleOscLink('https://example.com', { metaKey: false, ctrlKey: false }, deps)
     expect(openUrlMock).not.toHaveBeenCalled()
-
-    handleOscLink('https://example.com', { metaKey: true, ctrlKey: false }, deps)
-    expect(openUrlMock).toHaveBeenCalledWith('https://example.com/')
   })
 
-  it('keeps cmd/ctrl+click in Orca when the in-app browser setting is enabled', () => {
+  it('uses Orca for cmd/ctrl+click even when the setting is off', () => {
     setPlatform('Macintosh')
-    storeState.settings = { openLinksInApp: true }
+    storeState.settings = { openLinksInApp: false }
     const preventDefault = vi.fn()
     const stopPropagation = vi.fn()
 
@@ -116,6 +112,20 @@ describe('handleOscLink', () => {
     storeState.settings = { openLinksInApp: true }
 
     handleOscLink('https://example.com', { metaKey: false, ctrlKey: true, shiftKey: true }, deps)
+
+    expect(openUrlMock).toHaveBeenCalledWith('https://example.com/')
+    expect(createBrowserTabMock).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the system browser when no worktree owns the terminal pane', () => {
+    setPlatform('Macintosh')
+    storeState.settings = { openLinksInApp: true }
+
+    handleOscLink(
+      'https://example.com',
+      { metaKey: true, ctrlKey: false, shiftKey: false },
+      { worktreeId: '', worktreePath: '/tmp' }
+    )
 
     expect(openUrlMock).toHaveBeenCalledWith('https://example.com/')
     expect(createBrowserTabMock).not.toHaveBeenCalled()

--- a/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
@@ -84,12 +84,20 @@ describe('handleOscLink', () => {
   it('keeps cmd/ctrl+click in Orca when the in-app browser setting is enabled', () => {
     setPlatform('Macintosh')
     storeState.settings = { openLinksInApp: true }
+    const preventDefault = vi.fn()
+    const stopPropagation = vi.fn()
 
-    handleOscLink('https://example.com', { metaKey: true, ctrlKey: false, shiftKey: false }, deps)
+    handleOscLink(
+      'https://example.com',
+      { metaKey: true, ctrlKey: false, shiftKey: false, preventDefault, stopPropagation },
+      deps
+    )
 
     expect(createBrowserTabMock).toHaveBeenCalledWith('wt-1', 'https://example.com/')
     expect(setActiveWorktreeMock).toHaveBeenCalledWith('wt-1')
     expect(openUrlMock).not.toHaveBeenCalled()
+    expect(preventDefault).toHaveBeenCalled()
+    expect(stopPropagation).toHaveBeenCalled()
   })
 
   it('uses the system browser for shift+cmd/ctrl+click even when Orca browser tabs are enabled', () => {

--- a/src/renderer/src/components/terminal-pane/terminal-link-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-handlers.ts
@@ -200,9 +200,12 @@ export function handleOscLink(
     // Why: when the user opts into Orca's browser tabs, terminal links should
     // stay worktree-scoped instead of escaping to the system browser. We still
     // fall back externally when the setting is off or no worktree owns the pane.
+    // Missing settings should still follow Orca's persisted default (`true`);
+    // otherwise a terminal link clicked before settings hydration flashes open
+    // in the system browser even though the app-wide default is in-app tabs.
     // Shift is the explicit escape hatch for "open this one in my system browser"
     // without forcing the user to toggle the global in-app browser preference.
-    if (store.settings?.openLinksInApp && deps.worktreeId && !event?.shiftKey) {
+    if (store.settings?.openLinksInApp !== false && deps.worktreeId && !event?.shiftKey) {
       store.setActiveWorktree(deps.worktreeId)
       store.createBrowserTab(deps.worktreeId, parsed.toString())
       return

--- a/src/renderer/src/components/terminal-pane/terminal-link-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-handlers.ts
@@ -197,15 +197,10 @@ export function handleOscLink(
 
   if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
     const store = useAppStore.getState()
-    // Why: when the user opts into Orca's browser tabs, terminal links should
-    // stay worktree-scoped instead of escaping to the system browser. We still
-    // fall back externally when the setting is off or no worktree owns the pane.
-    // Missing settings should still follow Orca's persisted default (`true`);
-    // otherwise a terminal link clicked before settings hydration flashes open
-    // in the system browser even though the app-wide default is in-app tabs.
-    // Shift is the explicit escape hatch for "open this one in my system browser"
-    // without forcing the user to toggle the global in-app browser preference.
-    if (store.settings?.openLinksInApp !== false && deps.worktreeId && !event?.shiftKey) {
+    // Why: terminal URL clicks are now always worktree-scoped by default so
+    // Cmd/Ctrl+click reliably stays inside Orca's browser. Shift is the only
+    // escape hatch for opening the same URL in the system browser instead.
+    if (deps.worktreeId && !event?.shiftKey) {
       store.setActiveWorktree(deps.worktreeId)
       store.createBrowserTab(deps.worktreeId, parsed.toString())
       return

--- a/src/renderer/src/components/terminal-pane/terminal-link-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-handlers.ts
@@ -19,7 +19,7 @@ export type LinkHandlerDeps = {
 }
 
 type TerminalLinkEvent = Pick<MouseEvent, 'metaKey' | 'ctrlKey'> &
-  Partial<Pick<MouseEvent, 'shiftKey'>>
+  Partial<Pick<MouseEvent, 'shiftKey' | 'preventDefault' | 'stopPropagation'>>
 
 function isMacPlatform(): boolean {
   return navigator.userAgent.includes('Mac')
@@ -181,6 +181,12 @@ export function handleOscLink(
   if (!isTerminalLinkActivation(event)) {
     return
   }
+
+  // Why: xterm renders URL links as clickable anchors. Once Orca decides to
+  // handle a modified click itself, we must suppress the browser's default
+  // anchor navigation or Electron will still launch the system browser.
+  event?.preventDefault?.()
+  event?.stopPropagation?.()
 
   let parsed: URL
   try {


### PR DESCRIPTION
## Problem
After the terminal link routing change landed, Cmd/Ctrl+click on terminal URLs could still open the system browser because xterm's anchor click default navigation was not being suppressed when Orca handled the modified click itself.

## Solution
Consume accepted modified terminal-link click events before routing them. This prevents Electron from following the underlying anchor automatically, so plain Cmd/Ctrl+click stays in Orca while Shift+Cmd/Ctrl+click remains the explicit system-browser path. Added a regression test that asserts the default click handlers are suppressed when Orca opens the link internally.