### PR TITLE
fix: align traffic lights with titlebar content at any zoom level

### DIFF
--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -49,6 +49,22 @@ function forceRepaint(window: BrowserWindow): void {
   }, 32)
 }
 
+// Why: the titlebar is 42px (border-box, 1px border-bottom).  The visual
+// center of the CSS-centered content sits at ~20 CSS px from the top.
+// At zoom factor z that becomes 20·z window px.  Traffic lights are
+// ~12px tall, so we position their top edge at (center − 6).
+const TITLEBAR_CSS_CENTER = 20
+const TRAFFIC_LIGHT_RADIUS = 6
+const TRAFFIC_LIGHT_X = 16
+
+function syncTrafficLightPosition(win: BrowserWindow, zoomFactor: number): void {
+  if (win.isDestroyed()) {
+    return
+  }
+  const y = Math.round(TITLEBAR_CSS_CENTER * zoomFactor - TRAFFIC_LIGHT_RADIUS)
+  win.setWindowButtonPosition({ x: TRAFFIC_LIGHT_X, y })
+}
+
 export function createMainWindow(store: Store | null): BrowserWindow {
   const mainWindow = new BrowserWindow({
     width: 1200,
@@ -59,7 +75,16 @@ export function createMainWindow(store: Store | null): BrowserWindow {
     autoHideMenuBar: true,
     backgroundColor: nativeTheme.shouldUseDarkColors ? '#0a0a0a' : '#ffffff',
     titleBarStyle: process.platform === 'darwin' ? 'hiddenInset' : undefined,
-    ...(process.platform === 'darwin' ? { trafficLightPosition: { x: 16, y: 12 } } : {}),
+    // Why: initial position for 1x zoom; syncTrafficLightPosition() adjusts
+    // dynamically when the user changes UI zoom.
+    ...(process.platform === 'darwin'
+      ? {
+          trafficLightPosition: {
+            x: TRAFFIC_LIGHT_X,
+            y: TITLEBAR_CSS_CENTER - TRAFFIC_LIGHT_RADIUS
+          }
+        }
+      : {}),
     icon: is.dev ? devIcon : icon,
     webPreferences: {
       preload: join(__dirname, '../preload/index.js'),
@@ -84,7 +109,14 @@ export function createMainWindow(store: Store | null): BrowserWindow {
   }
 
   mainWindow.webContents.on('dom-ready', () => {
-    mainWindow.webContents.setZoomLevel(store?.getUI().uiZoomLevel ?? 0)
+    const level = store?.getUI().uiZoomLevel ?? 0
+    mainWindow.webContents.setZoomLevel(level)
+    // Why: the native traffic lights sit at a fixed position in the window
+    // while CSS content scales with zoom.  We must reposition the buttons
+    // on startup so they stay vertically aligned with the zoomed titlebar.
+    if (process.platform === 'darwin') {
+      syncTrafficLightPosition(mainWindow, Math.pow(1.2, level))
+    }
   })
 
   mainWindow.on('ready-to-show', () => {
@@ -258,8 +290,15 @@ export function createMainWindow(store: Store | null): BrowserWindow {
       mainWindow.close()
     }
   }
+  const trafficLightChannel = 'ui:sync-traffic-lights'
+  const onSyncTrafficLights = (_event: Electron.IpcMainEvent, zoomFactor: number): void => {
+    syncTrafficLightPosition(mainWindow, zoomFactor)
+  }
+  ipcMain.on(trafficLightChannel, onSyncTrafficLights)
+
   ipcMain.on(confirmCloseChannel, onConfirmClose)
   mainWindow.on('closed', () => {
+    ipcMain.removeListener(trafficLightChannel, onSyncTrafficLights)
     ipcMain.removeListener(confirmCloseChannel, onConfirmClose)
   })
 

--- a/src/preload/api-types.d.ts
+++ b/src/preload/api-types.d.ts
@@ -374,6 +374,7 @@ export type PreloadApi = {
     ) => () => void
     getZoomLevel: () => number
     setZoomLevel: (level: number) => void
+    syncTrafficLights: (zoomFactor: number) => void
     onFullscreenChanged: (callback: (isFullScreen: boolean) => void) => () => void
     onWindowCloseRequested: (callback: () => void) => () => void
     confirmWindowClose: () => void

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -662,6 +662,8 @@ const api = {
     },
     getZoomLevel: (): number => webFrame.getZoomLevel(),
     setZoomLevel: (level: number): void => webFrame.setZoomLevel(level),
+    syncTrafficLights: (zoomFactor: number): void =>
+      ipcRenderer.send('ui:sync-traffic-lights', zoomFactor),
     onFullscreenChanged: (callback: (isFullScreen: boolean) => void): (() => void) => {
       const listener = (_event: Electron.IpcRendererEvent, isFullScreen: boolean) =>
         callback(isFullScreen)

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -480,23 +480,24 @@ function App(): React.JSX.Element {
             style={{ width: showSidebar && sidebarOpen ? sidebarWidth : undefined }}
           >
             <div className={isMac && !isFullScreen ? 'titlebar-traffic-light-pad' : 'pl-2'} />
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  className="sidebar-toggle"
-                  onClick={toggleSidebar}
-                  aria-label={showSidebar ? 'Toggle sidebar' : 'Sidebar unavailable in settings'}
-                  disabled={!showSidebar}
-                >
-                  <PanelLeft size={16} />
-                </button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom" sideOffset={6}>
-                {showSidebar
-                  ? `Toggle sidebar (${isMac ? '⌘B' : 'Ctrl+B'})`
-                  : 'Sidebar unavailable in settings'}
-              </TooltipContent>
-            </Tooltip>
+            {/* Why: hide the toggle entirely in settings so no disabled button
+                or stray Radix PopperAnchor portal appears in the titlebar. */}
+            {showSidebar && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    className="sidebar-toggle"
+                    onClick={toggleSidebar}
+                    aria-label="Toggle sidebar"
+                  >
+                    <PanelLeft size={16} />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" sideOffset={6}>
+                  {`Toggle sidebar (${isMac ? '⌘B' : 'Ctrl+B'})`}
+                </TooltipContent>
+              </Tooltip>
+            )}
             <div className="titlebar-title">Orca</div>
             {activeAgentCount > 0 ? (
               <Tooltip>

--- a/src/renderer/src/lib/ui-zoom.ts
+++ b/src/renderer/src/lib/ui-zoom.ts
@@ -1,10 +1,13 @@
 /**
- * Apply a UI zoom level change: sets webFrame zoom via the preload API
- * and updates the CSS variable used to compensate the traffic-light pad.
+ * Apply a UI zoom level change: sets webFrame zoom via the preload API,
+ * updates the CSS variable used to compensate the traffic-light pad,
+ * and repositions the native macOS traffic lights to stay aligned.
  */
 export function applyUIZoom(level: number): void {
+  const zoomFactor = Math.pow(1.2, level)
   window.api.ui.setZoomLevel(level)
-  document.documentElement.style.setProperty('--ui-zoom-factor', String(Math.pow(1.2, level)))
+  document.documentElement.style.setProperty('--ui-zoom-factor', String(zoomFactor))
+  window.api.ui.syncTrafficLights(zoomFactor)
 }
 
 /**
@@ -13,5 +16,7 @@ export function applyUIZoom(level: number): void {
  */
 export function syncZoomCSSVar(): void {
   const level = window.api.ui.getZoomLevel()
-  document.documentElement.style.setProperty('--ui-zoom-factor', String(Math.pow(1.2, level)))
+  const zoomFactor = Math.pow(1.2, level)
+  document.documentElement.style.setProperty('--ui-zoom-factor', String(zoomFactor))
+  window.api.ui.syncTrafficLights(zoomFactor)
 }


### PR DESCRIPTION
## Summary
- Dynamically reposition macOS traffic lights via `setWindowButtonPosition` when UI zoom changes, keeping them vertically aligned with the CSS-centered titlebar content at any zoom level
- Hide left sidebar toggle entirely in settings view (was disabled but visible), fixing the stray Radix `PopperAnchor` warning

## Test plan
- [ ] At 100% zoom, traffic lights align with "Orca" title and sidebar toggle
- [ ] Zoom in/out (Cmd+/Cmd-) — traffic lights stay vertically centered
- [ ] Open Settings — no sidebar toggle buttons visible in titlebar
- [ ] Non-Mac: no regressions (traffic light code is darwin-gated)

Closes #413