### PR TITLE
fix: preserve scroll position when resizing terminal panes

### DIFF
--- a/src/renderer/src/components/terminal-pane/expand-collapse.ts
+++ b/src/renderer/src/components/terminal-pane/expand-collapse.ts
@@ -101,7 +101,12 @@ export function createExpandCollapseActions(state: ExpandCollapseState) {
       const panes = manager.getPanes()
       for (const p of panes) {
         try {
+          const buf = p.terminal.buffer.active
+          const wasAtBottom = buf.viewportY >= buf.baseY
           p.fitAddon.fit()
+          if (wasAtBottom) {
+            p.terminal.scrollToBottom()
+          }
         } catch {
           /* container may not have dimensions */
         }

--- a/src/renderer/src/components/terminal-pane/pane-helpers.ts
+++ b/src/renderer/src/components/terminal-pane/pane-helpers.ts
@@ -3,7 +3,16 @@ import type { PaneManager } from '@/lib/pane-manager/pane-manager'
 export function fitPanes(manager: PaneManager): void {
   for (const pane of manager.getPanes()) {
     try {
+      // Why: fitAddon.fit() triggers a terminal reflow that can leave the viewport
+      // at a stale scroll offset, making the terminal appear scrolled up after a
+      // resize. Capture whether the terminal was at the bottom before fitting and
+      // restore that position afterwards so the user's prompt stays visible.
+      const buf = pane.terminal.buffer.active
+      const wasAtBottom = buf.viewportY >= buf.baseY
       pane.fitAddon.fit()
+      if (wasAtBottom) {
+        pane.terminal.scrollToBottom()
+      }
     } catch {
       /* ignore */
     }

--- a/src/renderer/src/components/terminal-pane/terminal-appearance.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-appearance.ts
@@ -35,7 +35,14 @@ export function applyTerminalAppearance(
     pane.terminal.options.fontWeight = terminalFontWeights.fontWeight
     pane.terminal.options.fontWeightBold = terminalFontWeights.fontWeightBold
     try {
+      // Why: preserve scroll-to-bottom state across the reflow so appearance
+      // changes (theme, font size, etc.) don't make the terminal scroll up.
+      const buf = pane.terminal.buffer.active
+      const wasAtBottom = buf.viewportY >= buf.baseY
       pane.fitAddon.fit()
+      if (wasAtBottom) {
+        pane.terminal.scrollToBottom()
+      }
     } catch {
       /* ignore */
     }

--- a/src/renderer/src/components/terminal-pane/useTerminalFontZoom.ts
+++ b/src/renderer/src/components/terminal-pane/useTerminalFontZoom.ts
@@ -50,7 +50,12 @@ export function useTerminalFontZoom({
 
       pane.terminal.options.fontSize = nextSize
       try {
+        const buf = pane.terminal.buffer.active
+        const wasAtBottom = buf.viewportY >= buf.baseY
         pane.fitAddon.fit()
+        if (wasAtBottom) {
+          pane.terminal.scrollToBottom()
+        }
       } catch {
         /* ignore */
       }

--- a/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
+++ b/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
@@ -204,7 +204,12 @@ export function attachWebgl(pane: ManagedPaneInternal): void {
       // to initialise before we ask it to repaint.
       requestAnimationFrame(() => {
         try {
+          const buf = pane.terminal.buffer.active
+          const wasAtBottom = buf.viewportY >= buf.baseY
           pane.fitAddon.fit()
+          if (wasAtBottom) {
+            pane.terminal.scrollToBottom()
+          }
           pane.terminal.refresh(0, pane.terminal.rows - 1)
         } catch {
           /* ignore — pane may have been disposed in the meantime */

--- a/src/renderer/src/lib/pane-manager/pane-tree-ops.ts
+++ b/src/renderer/src/lib/pane-manager/pane-tree-ops.ts
@@ -15,7 +15,15 @@ type TreeOpsCallbacks = {
 
 export function safeFit(pane: ManagedPaneInternal): void {
   try {
+    // Why: fitAddon.fit() triggers a terminal reflow that can leave the viewport
+    // at a stale scroll offset, making the terminal appear scrolled up after a
+    // resize. Preserve the scroll-to-bottom state across the reflow.
+    const buf = pane.terminal.buffer.active
+    const wasAtBottom = buf.viewportY >= buf.baseY
     pane.fitAddon.fit()
+    if (wasAtBottom) {
+      pane.terminal.scrollToBottom()
+    }
   } catch {
     // Container may not have dimensions yet
   }


### PR DESCRIPTION
## Summary
- `fitAddon.fit()` triggers an xterm.js buffer reflow that can leave the viewport at a stale scroll offset, making the terminal appear scrolled up away from the prompt after a resize
- Before each `fit()` call, capture whether the terminal was scrolled to the bottom (`viewportY >= baseY`), then restore via `scrollToBottom()` afterwards
- Applied consistently across all 6 call sites: ResizeObserver, split/close operations, appearance changes, expand/collapse, font zoom, and WebGL fallback

## Test plan
- [x] TypeScript typecheck passes
- [x] All 871 unit tests pass
- [ ] Manual: resize terminal pane by dragging window edges — prompt stays visible
- [ ] Manual: scroll up in terminal, then resize — scroll position is preserved (not snapped to bottom)
- [ ] Manual: split panes, close panes — no scroll jump
- [ ] Manual: change font size (Cmd+/Cmd-) — no scroll jump