### PR TITLE
feat: support Cmd+X cut-line in rich markdown editor

### DIFF
--- a/src/renderer/src/components/editor/RichMarkdownEditor.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownEditor.tsx
@@ -21,6 +21,8 @@ import { useLinkBubble } from './useLinkBubble'
 import { useEditorScrollRestore } from './useEditorScrollRestore'
 import { registerPendingEditorFlush } from './editor-pending-flush'
 import { createRichMarkdownKeyHandler } from './rich-markdown-key-handler'
+import { DOMSerializer } from '@tiptap/pm/model'
+import { TextSelection } from '@tiptap/pm/state'
 
 type RichMarkdownEditorProps = {
   fileId: string
@@ -112,6 +114,87 @@ export default function RichMarkdownEditor({
     editorProps: {
       attributes: {
         class: 'rich-markdown-editor'
+      },
+      // Why: Electron's app menu `{ role: 'cut' }` binds Cmd/Ctrl+X at the
+      // main-process level, so the keystroke never reaches handleKeyDown.
+      // Instead, the menu dispatches a native cut command which fires this
+      // DOM event. For empty selections we cut the current block (like VS
+      // Code and Notion); for non-empty selections we defer to ProseMirror's
+      // built-in clipboard serializer.
+      handleDOMEvents: {
+        cut: (view, event) => {
+          const { selection } = view.state
+          if (!selection.empty) {
+            return false
+          }
+
+          const { $from } = selection
+
+          // Walk up from the textblock to find the best node to cut. For list
+          // items and task items, cut the whole item rather than just its inner
+          // paragraph. Stop at table cells to avoid breaking table structure.
+          let cutDepth = $from.depth
+          for (let d = $from.depth - 1; d >= 1; d--) {
+            const name = $from.node(d).type.name
+            if (name === 'listItem' || name === 'taskItem') {
+              cutDepth = d
+              break
+            }
+            if (name === 'tableCell' || name === 'tableHeader') {
+              break
+            }
+          }
+
+          const cutNode = $from.node(cutDepth)
+          const text = cutNode.textContent
+          if (!text) {
+            // Still delete the empty block, matching VS Code behavior
+            event.preventDefault()
+            const from = $from.before(cutDepth)
+            const to = $from.after(cutDepth)
+            let tr = view.state.tr.delete(from, to)
+            // Why: after deleting the last block the old `from` offset may exceed
+            // the new document length, so we clamp and use TextSelection.near() to
+            // land on the closest valid cursor position.
+            const clampedPos = Math.max(0, Math.min(from, tr.doc.content.size))
+            const resolvedPos = tr.doc.resolve(clampedPos)
+            tr = tr.setSelection(TextSelection.near(resolvedPos))
+            view.dispatch(tr)
+            return true
+          }
+
+          const clipboardEvent = event as ClipboardEvent
+          // Why: if clipboardData is null (e.g. synthetic events), we must not
+          // preventDefault and then delete -- that would lose content without
+          // placing it on the clipboard. Fall back to browser default instead.
+          if (!clipboardEvent.clipboardData) {
+            return false
+          }
+          event.preventDefault()
+
+          // Why: writing both text/html and text/plain preserves inline formatting
+          // (bold, italic, links) on round-trip cut-then-paste, while still giving
+          // a plain-text fallback for external targets.
+          const serializer = DOMSerializer.fromSchema(view.state.schema)
+          const fragment = serializer.serializeFragment(cutNode.content)
+          const div = document.createElement('div')
+          div.appendChild(fragment)
+          clipboardEvent.clipboardData.setData('text/html', div.innerHTML)
+          clipboardEvent.clipboardData.setData('text/plain', text)
+
+          const from = $from.before(cutDepth)
+          const to = $from.after(cutDepth)
+          let tr = view.state.tr.delete(from, to)
+          // Why: after deleting the last block the old `from` offset may exceed
+          // the new document length, so we clamp and use TextSelection.near() to
+          // land on the closest valid cursor position.
+          const clampedPos = Math.max(0, Math.min(from, tr.doc.content.size))
+          const resolvedPos = tr.doc.resolve(clampedPos)
+          tr = tr.setSelection(TextSelection.near(resolvedPos))
+          view.dispatch(tr)
+
+          return true
+        }
       },
       handleKeyDown: createRichMarkdownKeyHandler({
         isMac,

--- a/src/renderer/src/components/editor/RichMarkdownToolbar.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownToolbar.tsx
@@ -10,6 +10,7 @@ import {
   List,
   ListOrdered,
   ListTodo,
+  Pilcrow,
   Quote
 } from 'lucide-react'
 import { RichMarkdownToolbarButton } from './RichMarkdownToolbarButton'
@@ -41,6 +42,7 @@ export function RichMarkdownToolbar({
         return null
       }
       return {
+        paragraph: ed.isActive('paragraph'),
         h1: ed.isActive('heading', { level: 1 }),
         h2: ed.isActive('heading', { level: 2 }),
         h3: ed.isActive('heading', { level: 3 }),
@@ -58,6 +60,13 @@ export function RichMarkdownToolbar({
 
   return (
     <div className="rich-markdown-editor-toolbar">
+      <RichMarkdownToolbarButton
+        active={active?.paragraph ?? false}
+        label="Body text"
+        onClick={() => editor?.chain().focus().setParagraph().run()}
+      >
+        <Pilcrow className="size-3.5" />
+      </RichMarkdownToolbarButton>
       <RichMarkdownToolbarButton
         active={active?.h1 ?? false}
         label="Heading 1"


### PR DESCRIPTION
## Summary

- **Cut current block on Cmd/Ctrl+X with empty selection** — Electron's `role: 'cut'` menu intercepts the keystroke at the main-process level, so the editor never sees a `keydown`. This PR handles the resulting DOM `cut` event instead. When the selection is empty, it cuts the current block (paragraph, list item, or task item), matching VS Code and Notion behavior.
- **Preserve rich formatting on clipboard** — Writes both `text/html` and `text/plain` so inline formatting (bold, italic, links) survives round-trip cut-then-paste.
- **Add paragraph (body text) button to toolbar** — Adds a pilcrow button to convert headings back to normal paragraphs.

## Details

- Walks up from the textblock to cut the whole list/task item rather than just its inner paragraph; stops at table cells to avoid breaking table structure.
- Deletes empty blocks on Cmd+X (no clipboard write needed), matching VS Code.
- Guards against null `clipboardData` to prevent silent data loss.
- Clamps cursor position after deletion to avoid `RangeError` when cutting the last block.

## Test plan

- [ ] Open rich markdown editor, place cursor on a non-empty paragraph, press Cmd+X — line is cut and appears on clipboard with formatting
- [ ] Paste back — formatting (bold, italic, links) is preserved
- [ ] Cmd+X on an empty line — line is deleted
- [ ] Cmd+X inside a list item — entire list item is cut
- [ ] Cmd+X inside a task item — entire task item is cut
- [ ] Cmd+X inside a table cell — only the cell paragraph is cut, table structure intact
- [ ] Cmd+X when only one block exists — block is deleted, cursor lands in new empty paragraph
- [ ] Select text and Cmd+X — default ProseMirror cut behavior (not intercepted)
- [ ] Click paragraph (pilcrow) toolbar button — converts heading to paragraph