### PR TITLE
fix: audit terminal shortcut interception

### DIFF
--- a/docs/term-shortcut-fix.md
+++ b/docs/term-shortcut-fix.md
@@ -1,0 +1,95 @@
+# Terminal Shortcut Audit And Fix Plan
+
+## Context
+
+Linked reports:
+
+- `#443`: `Ctrl+R` / `Cmd+R` reverse search was blocked in the terminal.
+- `#453`: fixed `#443` by removing the app-level reload accelerator conflict.
+- `#481`: reports `Ctrl+U` (`unix-line-discard`) being swallowed.
+- `#482`: reports `Ctrl+E` (`end-of-line`) being swallowed, but is marked not reproducible.
+
+The symptom across all four links is "terminal control chord does not reach readline", but the current code shows they are not all the same bug.
+
+## Findings
+
+1. `#443` and `#453` are directly related.
+   `CmdOrCtrl+R` was reserved above the renderer, so the terminal never saw the chord. `#453` fixed that by removing the reload accelerator and keeping only `Shift+CmdOrCtrl+R` for force reload.
+
+2. `#481` and `#482` are related to the same problem class, but not proven to share `#443`'s exact root cause.
+   Current `mainWindow.webContents.on('before-input-event', ...)` no longer reserves `R`, `U`, or `E`.
+   Current terminal renderer shortcut handling also does not reserve macOS `Ctrl+R`, `Ctrl+U`, or `Ctrl+E`.
+
+3. The real gap was auditability, not just one missing exception.
+   Shortcut interception lived in multiple places:
+   - main window `before-input-event`
+   - browser guest `before-input-event`
+   - terminal renderer `keydown` capture
+
+   That made it easy to fix one conflict (`Cmd/Ctrl+R`) while leaving the overall reservation surface implicit and hard to verify.
+
+## Reproduction Matrix
+
+Expected behavior from a focused terminal on macOS:
+
+- Pass through to shell/readline:
+  - `Ctrl+R`
+  - `Ctrl+U`
+  - `Ctrl+E`
+  - `Ctrl+A`
+  - `Ctrl+W`
+  - `Ctrl+K`
+  - `Alt+B`
+  - `Alt+F`
+  - `Alt+D`
+
+- Reserved by Orca:
+  - `Cmd+F`
+  - `Cmd+K`
+  - `Cmd+W`
+  - `Cmd+D`
+  - `Cmd+Shift+D`
+  - `Cmd+[`
+  - `Cmd+]`
+  - `Cmd+Shift+Enter`
+  - `Ctrl+Backspace`
+  - `Cmd+Backspace`
+  - `Cmd+Delete`
+  - `Alt+Backspace`
+
+Expected behavior from main-process/browser-guest forwarding:
+
+- Reserved:
+  - zoom shortcuts
+  - worktree palette
+  - quick open
+  - worktree index jump
+
+- Must never be reserved there:
+  - `Cmd/Ctrl+R`
+  - readline control chords like `Ctrl+U`, `Ctrl+E`, `Ctrl+R`
+
+## Plan
+
+1. Centralize the window-level shortcut allowlist into a shared pure helper.
+   Why: main-window and browser-guest forwarding should not drift apart, because either one can steal terminal input before the renderer sees it.
+
+2. Centralize terminal-pane shortcut classification into a pure helper.
+   Why: the terminal shortcut layer must stay an explicit allowlist so future shortcuts do not accidentally swallow readline chords.
+
+3. Add regression tests that enumerate both sides:
+   - allowed Orca shortcuts
+   - guaranteed shell passthrough chords
+
+4. Keep `#443` fixed and make the current status of `#481` / `#482` testable.
+   Why: even if one report later turns out to be environment-specific, Orca should still have an executable contract for what it reserves.
+
+## Implementation Notes
+
+- Shared helper added for main-process shortcut resolution.
+- Shared helper added for terminal-pane shortcut resolution.
+- Tests added to encode the allowlist and passthrough matrix explicitly.
+
+## Follow-Up Risk
+
+This change makes the current reservation surface auditable, but it does not redesign non-macOS terminal shortcuts. Orca still uses `Ctrl` as the primary modifier for several terminal actions on Linux/Windows, which is a separate UX question from the macOS control-chord regressions linked above.

--- a/src/main/browser/browser-manager.test.ts
+++ b/src/main/browser/browser-manager.test.ts
@@ -1,3 +1,4 @@
+/* oxlint-disable max-lines */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
@@ -202,5 +203,189 @@ describe('browserManager', () => {
     expect(guestSetWindowOpenHandlerMock).toHaveBeenCalledTimes(1)
     expect(guestOnMock.mock.calls.filter(([event]) => event === 'will-navigate')).toHaveLength(1)
     expect(guestOnMock.mock.calls.filter(([event]) => event === 'will-redirect')).toHaveLength(1)
+  })
+
+  it('does not forward ctrl/cmd+r or readline chords from browser guests', () => {
+    const rendererSendMock = vi.fn()
+    const guest = {
+      id: 404,
+      isDestroyed: vi.fn(() => false),
+      getType: vi.fn(() => 'webview'),
+      setBackgroundThrottling: guestSetBackgroundThrottlingMock,
+      setWindowOpenHandler: guestSetWindowOpenHandlerMock,
+      on: guestOnMock,
+      off: guestOffMock,
+      openDevTools: guestOpenDevToolsMock
+    }
+
+    webContentsFromIdMock.mockImplementation((id: number) => {
+      if (id === guest.id) {
+        return guest
+      }
+      if (id === rendererWebContentsId) {
+        return { isDestroyed: vi.fn(() => false), send: rendererSendMock }
+      }
+      return null
+    })
+
+    browserManager.attachGuestPolicies(guest as never)
+    browserManager.registerGuest({
+      browserTabId: 'browser-1',
+      webContentsId: guest.id,
+      rendererWebContentsId
+    })
+
+    const beforeInputHandler = guestOnMock.mock.calls
+      .filter(([event]) => event === 'before-input-event')
+      .at(-1)?.[1] as
+      | ((event: { preventDefault: () => void }, input: Record<string, unknown>) => void)
+      | undefined
+
+    expect(beforeInputHandler).toBeTypeOf('function')
+
+    for (const input of [
+      {
+        type: 'keyDown',
+        code: 'KeyR',
+        key: 'r',
+        meta: false,
+        control: true,
+        alt: false,
+        shift: false
+      },
+      {
+        type: 'keyDown',
+        code: 'KeyU',
+        key: 'u',
+        meta: false,
+        control: true,
+        alt: false,
+        shift: false
+      },
+      {
+        type: 'keyDown',
+        code: 'KeyE',
+        key: 'e',
+        meta: false,
+        control: true,
+        alt: false,
+        shift: false
+      },
+      {
+        type: 'keyDown',
+        code: 'KeyJ',
+        key: 'j',
+        meta: false,
+        control: true,
+        alt: false,
+        shift: false
+      }
+    ]) {
+      const preventDefault = vi.fn()
+      beforeInputHandler?.({ preventDefault }, input)
+      expect(preventDefault).not.toHaveBeenCalled()
+    }
+
+    expect(rendererSendMock).not.toHaveBeenCalled()
+  })
+
+  it('forwards browser guest tab shortcuts alongside shared window shortcuts', () => {
+    const isDarwin = process.platform === 'darwin'
+    const rendererSendMock = vi.fn()
+    const guest = {
+      id: 405,
+      isDestroyed: vi.fn(() => false),
+      getType: vi.fn(() => 'webview'),
+      setBackgroundThrottling: guestSetBackgroundThrottlingMock,
+      setWindowOpenHandler: guestSetWindowOpenHandlerMock,
+      on: guestOnMock,
+      off: guestOffMock,
+      openDevTools: guestOpenDevToolsMock
+    }
+
+    webContentsFromIdMock.mockImplementation((id: number) => {
+      if (id === guest.id) {
+        return guest
+      }
+      if (id === rendererWebContentsId) {
+        return { isDestroyed: vi.fn(() => false), send: rendererSendMock }
+      }
+      return null
+    })
+
+    browserManager.attachGuestPolicies(guest as never)
+    browserManager.registerGuest({
+      browserTabId: 'browser-1',
+      webContentsId: guest.id,
+      rendererWebContentsId
+    })
+
+    const beforeInputHandler = guestOnMock.mock.calls
+      .filter(([event]) => event === 'before-input-event')
+      .at(-1)?.[1] as
+      | ((event: { preventDefault: () => void }, input: Record<string, unknown>) => void)
+      | undefined
+
+    expect(beforeInputHandler).toBeTypeOf('function')
+
+    const inputs = [
+      {
+        type: 'keyDown',
+        code: 'KeyB',
+        key: 'b',
+        meta: isDarwin,
+        control: !isDarwin,
+        alt: false,
+        shift: true
+      },
+      {
+        type: 'keyDown',
+        code: 'KeyT',
+        key: 't',
+        meta: isDarwin,
+        control: !isDarwin,
+        alt: false,
+        shift: false
+      },
+      {
+        type: 'keyDown',
+        code: 'KeyW',
+        key: 'w',
+        meta: isDarwin,
+        control: !isDarwin,
+        alt: false,
+        shift: false
+      },
+      {
+        type: 'keyDown',
+        code: 'BracketRight',
+        key: '}',
+        meta: isDarwin,
+        control: !isDarwin,
+        alt: false,
+        shift: true
+      },
+      {
+        type: 'keyDown',
+        code: 'KeyP',
+        key: 'p',
+        meta: isDarwin,
+        control: !isDarwin,
+        alt: false,
+        shift: false
+      }
+    ]
+
+    for (const input of inputs) {
+      const preventDefault = vi.fn()
+      beforeInputHandler?.({ preventDefault }, input)
+      expect(preventDefault).toHaveBeenCalledTimes(1)
+    }
+
+    expect(rendererSendMock).toHaveBeenNthCalledWith(1, 'ui:newBrowserTab')
+    expect(rendererSendMock).toHaveBeenNthCalledWith(2, 'ui:newTerminalTab')
+    expect(rendererSendMock).toHaveBeenNthCalledWith(3, 'ui:closeActiveTab')
+    expect(rendererSendMock).toHaveBeenNthCalledWith(4, 'ui:switchTab', 1)
+    expect(rendererSendMock).toHaveBeenNthCalledWith(5, 'ui:openQuickOpen')
   })
 })

--- a/src/main/browser/browser-manager.ts
+++ b/src/main/browser/browser-manager.ts
@@ -7,6 +7,10 @@ import {
   normalizeBrowserNavigationUrl,
   normalizeExternalBrowserUrl
 } from '../../shared/browser-url'
+import {
+  isWindowShortcutModifierChord,
+  resolveWindowShortcutAction
+} from '../../shared/window-shortcut-policy'
 import type {
   BrowserGrabCancelReason,
   BrowserGrabPayload,
@@ -897,10 +901,18 @@ class BrowserManager {
       if (input.type !== 'keyDown') {
         return
       }
-      const isMod = process.platform === 'darwin' ? input.meta : input.control
-      if (!isMod || input.alt) {
+      // Why: browser guests need a broader modifier-chord gate than the main
+      // window because they also forward guest-specific tab shortcuts
+      // (Cmd/Ctrl+T/W/Shift+B/Shift+[ / ]) in addition to the shared allowlist
+      // handled by resolveWindowShortcutAction().
+      if (!isWindowShortcutModifierChord(input, process.platform)) {
         return
       }
+
+      // Why: centralizing the shared subset still keeps guest forwarding in
+      // lockstep with the main window for the chords that must never steal
+      // readline control input above the terminal.
+      const action = resolveWindowShortcutAction(input, process.platform)
 
       const rendererWcId = this.rendererWebContentsIdByTabId.get(browserTabId)
       if (!rendererWcId) {
@@ -919,16 +931,12 @@ class BrowserManager {
         rendererWc.send('ui:closeActiveTab')
       } else if (input.shift && (input.code === 'BracketRight' || input.code === 'BracketLeft')) {
         rendererWc.send('ui:switchTab', input.code === 'BracketRight' ? 1 : -1)
-      } else if (
-        input.code === 'KeyJ' &&
-        ((process.platform === 'darwin' && !input.shift) ||
-          (process.platform !== 'darwin' && input.shift))
-      ) {
+      } else if (action?.type === 'toggleWorktreePalette') {
         rendererWc.send('ui:toggleWorktreePalette')
-      } else if (input.code === 'KeyP' && !input.shift) {
+      } else if (action?.type === 'openQuickOpen') {
         rendererWc.send('ui:openQuickOpen')
-      } else if (input.key >= '1' && input.key <= '9' && !input.shift) {
-        rendererWc.send('ui:jumpToWorktreeIndex', parseInt(input.key, 10) - 1)
+      } else if (action?.type === 'jumpToWorktreeIndex') {
+        rendererWc.send('ui:jumpToWorktreeIndex', action.index)
       } else {
         return
       }

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -10,27 +10,7 @@ import {
   normalizeBrowserNavigationUrl,
   normalizeExternalBrowserUrl
 } from '../../shared/browser-url'
-
-function isZoomInShortcut(input: Electron.Input): boolean {
-  return input.key === '=' || input.key === '+' || input.code === 'NumpadAdd'
-}
-
-function isZoomOutShortcut(input: Electron.Input): boolean {
-  // Why: Electron reports Cmd/Ctrl+Minus differently across layouts and devices:
-  // some emit '-' while shifted layouts emit '_', and other layouts/devices
-  // report symbolic names like "Minus"/"Subtract" in either key or code.
-  // We accept all known variants so zoom out remains reachable everywhere.
-  const key = (input.key ?? '').toLowerCase()
-  const code = (input.code ?? '').toLowerCase()
-  return (
-    key === '-' ||
-    key === '_' ||
-    key.includes('minus') ||
-    key.includes('subtract') ||
-    code.includes('minus') ||
-    code.includes('subtract')
-  )
-}
+import { resolveWindowShortcutAction } from '../../shared/window-shortcut-policy'
 
 function forceRepaint(window: BrowserWindow): void {
   if (window.isDestroyed()) {
@@ -218,42 +198,39 @@ export function createMainWindow(store: Store | null): BrowserWindow {
       return
     }
 
-    const modifierPressed = process.platform === 'darwin' ? input.meta : input.control
-    if (!modifierPressed || input.alt) {
+    // Why: keep the main-process interception surface as an explicit allowlist.
+    // Anything outside this helper must continue to the renderer/PTTY so
+    // readline control chords are not silently stolen above the terminal.
+    const action = resolveWindowShortcutAction(input, process.platform)
+    if (!action) {
       return
     }
 
-    if (isZoomInShortcut(input)) {
-      event.preventDefault()
-      mainWindow.webContents.send('terminal:zoom', 'in')
-    } else if (isZoomOutShortcut(input)) {
-      event.preventDefault()
-      mainWindow.webContents.send('terminal:zoom', 'out')
-    } else if (input.key === '0' && !input.shift) {
-      event.preventDefault()
-      mainWindow.webContents.send('terminal:zoom', 'reset')
-    } else if (
-      input.code === 'KeyJ' &&
-      ((process.platform === 'darwin' && !input.shift) ||
-        (process.platform !== 'darwin' && input.shift))
-    ) {
+    event.preventDefault()
+
+    if (action.type === 'zoom') {
+      mainWindow.webContents.send('terminal:zoom', action.direction)
+      return
+    }
+
+    if (action.type === 'toggleWorktreePalette') {
       // Why: embedded browser guests can keep keyboard focus inside Chromium's
       // guest webContents, which bypasses the renderer's window-level keydown
       // listener. Forward the worktree-switch shortcut through the main window
       // so Cmd+J (macOS) or Ctrl+Shift+J (Win/Linux) works consistently from browser tabs too.
-      // We use Ctrl+Shift+J on Win/Linux because Ctrl+J is the ASCII Line Feed control code
-      // and intercepting it would break standard terminal usage (like Enter in shells or Vim).
-      event.preventDefault()
       mainWindow.webContents.send('ui:toggleWorktreePalette')
-    } else if (input.code === 'KeyP' && !input.shift) {
+      return
+    }
+
+    if (action.type === 'openQuickOpen') {
       // Forward Cmd/Ctrl+P to trigger Quick Open
-      event.preventDefault()
       mainWindow.webContents.send('ui:openQuickOpen')
-    } else if (input.key >= '1' && input.key <= '9' && !input.shift) {
+      return
+    }
+
+    if (action.type === 'jumpToWorktreeIndex') {
       // Forward Cmd/Ctrl+1-9 for quick worktree switching
-      event.preventDefault()
-      const index = parseInt(input.key, 10) - 1
-      mainWindow.webContents.send('ui:jumpToWorktreeIndex', index)
+      mainWindow.webContents.send('ui:jumpToWorktreeIndex', action.index)
     }
   })
 

--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
@@ -1,6 +1,7 @@
 import { useEffect } from 'react'
 import type { PaneManager } from '@/lib/pane-manager/pane-manager'
 import type { PtyTransport } from './pty-transport'
+import { resolveTerminalShortcutAction } from './terminal-shortcut-policy'
 
 function isEditableTarget(target: EventTarget | null): boolean {
   if (!(target instanceof HTMLElement)) {
@@ -98,22 +99,19 @@ export function useTerminalKeyboardShortcuts({
 
     const isMac = navigator.userAgent.includes('Mac')
     const onKeyDown = (e: KeyboardEvent): void => {
-      if (e.repeat) {
-        return
-      }
-      // Moved above isEditableTarget so the Cmd+G handler can reference it.
       const manager = managerRef.current
       if (!manager) {
         return
       }
 
-      // Cmd+G / Cmd+Shift+G navigates terminal search matches.
-      // Placed before the isEditableTarget guard so it works when focus
-      // is in the search input. Uses its own mod-key check because this
-      // runs before the shared `mod` variable is declared.
-      // preventDefault suppresses macOS/Electron's native "find next".
+      // Cmd+G / Cmd+Shift+G navigates terminal search matches even when focus
+      // is inside the search input itself, so this check must run before the
+      // editable-target guard would otherwise bypass all terminal shortcuts.
       const direction = matchSearchNavigate(e, isMac, searchOpenRef.current, searchStateRef.current)
       if (direction !== null) {
+        if (e.repeat) {
+          return
+        }
         e.preventDefault()
         e.stopPropagation()
         const pane = manager.getActivePane() ?? manager.getPanes()[0]
@@ -133,14 +131,30 @@ export function useTerminalKeyboardShortcuts({
       if (isEditableTarget(e.target)) {
         return
       }
-      const mod = isMac ? e.metaKey && !e.ctrlKey : e.ctrlKey && !e.metaKey
-      if (!mod || e.altKey) {
+
+      const action = resolveTerminalShortcutAction(e, isMac)
+      if (!action) {
+        return
+      }
+
+      if (action.type === 'sendInput') {
+        e.preventDefault()
+        e.stopPropagation()
+        const pane = manager.getActivePane() ?? manager.getPanes()[0]
+        if (!pane) {
+          return
+        }
+        paneTransportsRef.current.get(pane.id)?.sendInput(action.data)
+        return
+      }
+
+      if (e.repeat) {
         return
       }
 
       // Cmd/Ctrl+Shift+C copies terminal selection via Electron clipboard.
       // This ensures Linux terminal copy works consistently.
-      if (e.shiftKey && e.key.toLowerCase() === 'c') {
+      if (action.type === 'copySelection') {
         const pane = manager.getActivePane() ?? manager.getPanes()[0]
         if (!pane) {
           return
@@ -159,7 +173,7 @@ export function useTerminalKeyboardShortcuts({
 
       // Keep Cmd+F bound to the terminal search until the app has a real
       // top-level find-in-page flow to fall back to.
-      if (!e.shiftKey && e.key.toLowerCase() === 'f') {
+      if (action.type === 'toggleSearch') {
         e.preventDefault()
         e.stopPropagation()
         setSearchOpen((prev) => !prev)
@@ -167,7 +181,7 @@ export function useTerminalKeyboardShortcuts({
       }
 
       // Cmd+K clears active pane screen + scrollback.
-      if (!e.shiftKey && e.key.toLowerCase() === 'k') {
+      if (action.type === 'clearActivePane') {
         e.preventDefault()
         e.stopPropagation()
         const pane = manager.getActivePane() ?? manager.getPanes()[0]
@@ -178,7 +192,7 @@ export function useTerminalKeyboardShortcuts({
       }
 
       // Cmd+[ / Cmd+] cycles active split pane focus.
-      if (!e.shiftKey && (e.code === 'BracketLeft' || e.code === 'BracketRight')) {
+      if (action.type === 'focusPane') {
         const panes = manager.getPanes()
         if (panes.length < 2) {
           return
@@ -200,14 +214,14 @@ export function useTerminalKeyboardShortcuts({
           return
         }
 
-        const dir = e.code === 'BracketRight' ? 1 : -1
+        const dir = action.direction === 'next' ? 1 : -1
         const nextPane = panes[(currentIdx + dir + panes.length) % panes.length]
         manager.setActivePane(nextPane.id, { focus: true })
         return
       }
 
       // Cmd+Shift+Enter expands/collapses the active pane to full terminal area.
-      if (e.shiftKey && e.key === 'Enter' && (e.code === 'Enter' || e.code === 'NumpadEnter')) {
+      if (action.type === 'toggleExpandActivePane') {
         const panes = manager.getPanes()
         if (panes.length < 2) {
           return
@@ -226,7 +240,7 @@ export function useTerminalKeyboardShortcuts({
       // pane remains). Always intercepted here so the tab-level handler in
       // Terminal.tsx never closes the entire tab directly — that would kill
       // every pane instead of just the focused one.
-      if (!e.shiftKey && e.key.toLowerCase() === 'w') {
+      if (action.type === 'closeActivePane') {
         e.preventDefault()
         e.stopPropagation()
         const pane = manager.getActivePane() ?? manager.getPanes()[0]
@@ -240,7 +254,7 @@ export function useTerminalKeyboardShortcuts({
       // Cmd+D / Cmd+Shift+D split the active pane in the focused tab only.
       // Exit expanded mode first so the new split gets proper dimensions
       // (matches Ghostty behavior).
-      if (e.key.toLowerCase() === 'd') {
+      if (action.type === 'splitActivePane') {
         e.preventDefault()
         e.stopPropagation()
         if (expandedPaneIdRef.current !== null) {
@@ -253,153 +267,13 @@ export function useTerminalKeyboardShortcuts({
         if (!pane) {
           return
         }
-        manager.splitPane(pane.id, e.shiftKey ? 'horizontal' : 'vertical')
+        manager.splitPane(pane.id, action.direction)
       }
-    }
-
-    // Shift+Enter → send CSI 13;2 u (Kitty keyboard protocol) to PTY so
-    // CLI apps like Claude Code can distinguish it from plain Enter and
-    // insert a newline.  xterm.js sends bare \r for both by default, and
-    // its attachCustomKeyEventHandler doesn't call preventDefault, so the
-    // browser still fires keypress and xterm processes it.  Intercepting
-    // here in the capture phase with full suppression avoids the double-send.
-    const onShiftEnter = (e: KeyboardEvent): void => {
-      if (!e.shiftKey || e.metaKey || e.ctrlKey || e.altKey) {
-        return
-      }
-      if (e.key !== 'Enter') {
-        return
-      }
-      if (isEditableTarget(e.target)) {
-        return
-      }
-      const manager = managerRef.current
-      if (!manager) {
-        return
-      }
-      e.preventDefault()
-      e.stopPropagation()
-      const pane = manager.getActivePane() ?? manager.getPanes()[0]
-      if (!pane) {
-        return
-      }
-      paneTransportsRef.current.get(pane.id)?.sendInput('\x1b[13;2u')
-    }
-
-    // Ctrl+Backspace → send \x17 (backward-kill-word) to PTY.
-    // Skip when focus is in an input/textarea so native word-delete still works.
-    const onCtrlBackspace = (e: KeyboardEvent): void => {
-      if (!e.ctrlKey || e.metaKey || e.altKey || e.shiftKey) {
-        return
-      }
-      if (e.key !== 'Backspace') {
-        return
-      }
-      if (isEditableTarget(e.target)) {
-        return
-      }
-      const manager = managerRef.current
-      if (!manager) {
-        return
-      }
-      e.preventDefault()
-      e.stopPropagation()
-      const pane = manager.getActivePane() ?? manager.getPanes()[0]
-      if (!pane) {
-        return
-      }
-      paneTransportsRef.current.get(pane.id)?.sendInput('\x17')
-    }
-
-    // Cmd+Backspace → send \x15 (Ctrl+U, kill to beginning of line) to PTY.
-    // Mirrors Warp's behavior where Cmd+Backspace deletes the whole line to
-    // the left of the cursor. Skip editable targets so browser inputs are unaffected.
-    const onCmdBackspace = (e: KeyboardEvent): void => {
-      if (!e.metaKey || e.ctrlKey || e.altKey || e.shiftKey) {
-        return
-      }
-      if (e.key !== 'Backspace') {
-        return
-      }
-      if (isEditableTarget(e.target)) {
-        return
-      }
-      const manager = managerRef.current
-      if (!manager) {
-        return
-      }
-      e.preventDefault()
-      e.stopPropagation()
-      const pane = manager.getActivePane() ?? manager.getPanes()[0]
-      if (!pane) {
-        return
-      }
-      paneTransportsRef.current.get(pane.id)?.sendInput('\x15')
-    }
-
-    // Cmd+Delete → send \x0b (Ctrl+K, kill to end of line) to PTY.
-    // Mirrors Warp's "Delete All Right" behavior. Skip editable targets.
-    const onCmdDelete = (e: KeyboardEvent): void => {
-      if (!e.metaKey || e.ctrlKey || e.altKey || e.shiftKey) {
-        return
-      }
-      if (e.key !== 'Delete') {
-        return
-      }
-      if (isEditableTarget(e.target)) {
-        return
-      }
-      const manager = managerRef.current
-      if (!manager) {
-        return
-      }
-      e.preventDefault()
-      e.stopPropagation()
-      const pane = manager.getActivePane() ?? manager.getPanes()[0]
-      if (!pane) {
-        return
-      }
-      paneTransportsRef.current.get(pane.id)?.sendInput('\x0b')
-    }
-
-    // Alt+Backspace → send ESC + DEL (\x1b\x7f, backward-kill-word) to PTY.
-    // Skip when focus is in an input/textarea so native word-delete still works.
-    const onAltBackspace = (e: KeyboardEvent): void => {
-      if (!e.altKey || e.metaKey || e.ctrlKey || e.shiftKey) {
-        return
-      }
-      if (e.key !== 'Backspace') {
-        return
-      }
-      if (isEditableTarget(e.target)) {
-        return
-      }
-      const manager = managerRef.current
-      if (!manager) {
-        return
-      }
-      e.preventDefault()
-      e.stopPropagation()
-      const pane = manager.getActivePane() ?? manager.getPanes()[0]
-      if (!pane) {
-        return
-      }
-      paneTransportsRef.current.get(pane.id)?.sendInput('\x1b\x7f')
     }
 
     window.addEventListener('keydown', onKeyDown, { capture: true })
-    window.addEventListener('keydown', onShiftEnter, { capture: true })
-    window.addEventListener('keydown', onCtrlBackspace, { capture: true })
-    window.addEventListener('keydown', onAltBackspace, { capture: true })
-    window.addEventListener('keydown', onCmdBackspace, { capture: true })
-    window.addEventListener('keydown', onCmdDelete, { capture: true })
     return () => {
       window.removeEventListener('keydown', onKeyDown, { capture: true })
-      window.removeEventListener('keydown', onShiftEnter, { capture: true })
-      window.removeEventListener('keydown', onCtrlBackspace, { capture: true })
-      window.removeEventListener('keydown', onAltBackspace, { capture: true })
-      window.removeEventListener('keydown', onCmdBackspace, { capture: true })
-      window.removeEventListener('keydown', onCmdDelete, { capture: true })
     }
   }, [
     isActive,

--- a/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest'
+import {
+  resolveTerminalShortcutAction,
+  type TerminalShortcutEvent
+} from './terminal-shortcut-policy'
+
+function event(overrides: Partial<TerminalShortcutEvent>): TerminalShortcutEvent {
+  return {
+    key: '',
+    code: '',
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    repeat: false,
+    ...overrides
+  }
+}
+
+describe('resolveTerminalShortcutAction', () => {
+  it('preserves macOS readline and alt-word chords for the shell', () => {
+    const passthroughCases = [
+      event({ key: 'r', code: 'KeyR', ctrlKey: true }),
+      event({ key: 'u', code: 'KeyU', ctrlKey: true }),
+      event({ key: 'e', code: 'KeyE', ctrlKey: true }),
+      event({ key: 'a', code: 'KeyA', ctrlKey: true }),
+      event({ key: 'w', code: 'KeyW', ctrlKey: true }),
+      event({ key: 'k', code: 'KeyK', ctrlKey: true }),
+      event({ key: 'b', code: 'KeyB', altKey: true }),
+      event({ key: 'f', code: 'KeyF', altKey: true }),
+      event({ key: 'd', code: 'KeyD', altKey: true })
+    ]
+
+    for (const input of passthroughCases) {
+      expect(resolveTerminalShortcutAction(input, true)).toBeNull()
+    }
+  })
+
+  it('resolves the explicit macOS terminal shortcut allowlist', () => {
+    expect(
+      resolveTerminalShortcutAction(event({ key: 'f', code: 'KeyF', metaKey: true }), true)
+    ).toEqual({
+      type: 'toggleSearch'
+    })
+    expect(
+      resolveTerminalShortcutAction(event({ key: 'k', code: 'KeyK', metaKey: true }), true)
+    ).toEqual({
+      type: 'clearActivePane'
+    })
+    expect(
+      resolveTerminalShortcutAction(event({ key: 'w', code: 'KeyW', metaKey: true }), true)
+    ).toEqual({
+      type: 'closeActivePane'
+    })
+    expect(
+      resolveTerminalShortcutAction(event({ key: 'd', code: 'KeyD', metaKey: true }), true)
+    ).toEqual({ type: 'splitActivePane', direction: 'vertical' })
+    expect(
+      resolveTerminalShortcutAction(
+        event({ key: 'd', code: 'KeyD', metaKey: true, shiftKey: true }),
+        true
+      )
+    ).toEqual({ type: 'splitActivePane', direction: 'horizontal' })
+    expect(
+      resolveTerminalShortcutAction(event({ key: '[', code: 'BracketLeft', metaKey: true }), true)
+    ).toEqual({ type: 'focusPane', direction: 'previous' })
+    expect(
+      resolveTerminalShortcutAction(event({ key: ']', code: 'BracketRight', metaKey: true }), true)
+    ).toEqual({ type: 'focusPane', direction: 'next' })
+  })
+
+  it('keeps shift-enter and delete helpers explicit', () => {
+    expect(
+      resolveTerminalShortcutAction(event({ key: 'Enter', code: 'Enter', shiftKey: true }), true)
+    ).toEqual({
+      type: 'sendInput',
+      data: '\x1b[13;2u'
+    })
+    expect(resolveTerminalShortcutAction(event({ key: 'Backspace', ctrlKey: true }), true)).toEqual(
+      { type: 'sendInput', data: '\x17' }
+    )
+    expect(resolveTerminalShortcutAction(event({ key: 'Backspace', metaKey: true }), true)).toEqual(
+      { type: 'sendInput', data: '\x15' }
+    )
+    expect(resolveTerminalShortcutAction(event({ key: 'Delete', metaKey: true }), true)).toEqual({
+      type: 'sendInput',
+      data: '\x0b'
+    })
+    expect(resolveTerminalShortcutAction(event({ key: 'Backspace', altKey: true }), true)).toEqual({
+      type: 'sendInput',
+      data: '\x1b\x7f'
+    })
+  })
+
+  it('uses ctrl as the non-mac pane modifier but still requires shift for tab-safe chords', () => {
+    expect(
+      resolveTerminalShortcutAction(event({ key: 'f', code: 'KeyF', ctrlKey: true }), false)
+    ).toEqual({ type: 'toggleSearch' })
+    expect(
+      resolveTerminalShortcutAction(
+        event({ key: 'c', code: 'KeyC', ctrlKey: true, shiftKey: true }),
+        false
+      )
+    ).toEqual({ type: 'copySelection' })
+    expect(
+      resolveTerminalShortcutAction(event({ key: 'r', code: 'KeyR', ctrlKey: true }), false)
+    ).toBeNull()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.ts
@@ -1,0 +1,112 @@
+export type TerminalShortcutEvent = {
+  key: string
+  code?: string
+  metaKey: boolean
+  ctrlKey: boolean
+  altKey: boolean
+  shiftKey: boolean
+  repeat?: boolean
+}
+
+export type TerminalShortcutAction =
+  | { type: 'copySelection' }
+  | { type: 'toggleSearch' }
+  | { type: 'clearActivePane' }
+  | { type: 'focusPane'; direction: 'next' | 'previous' }
+  | { type: 'toggleExpandActivePane' }
+  | { type: 'closeActivePane' }
+  | { type: 'splitActivePane'; direction: 'vertical' | 'horizontal' }
+  | { type: 'sendInput'; data: string }
+
+export function resolveTerminalShortcutAction(
+  event: TerminalShortcutEvent,
+  isMac: boolean
+): TerminalShortcutAction | null {
+  const mod = isMac ? event.metaKey && !event.ctrlKey : event.ctrlKey && !event.metaKey
+  if (!event.repeat && mod && !event.altKey) {
+    const lowerKey = event.key.toLowerCase()
+
+    if (event.shiftKey && lowerKey === 'c') {
+      return { type: 'copySelection' }
+    }
+
+    if (!event.shiftKey && lowerKey === 'f') {
+      return { type: 'toggleSearch' }
+    }
+
+    if (!event.shiftKey && lowerKey === 'k') {
+      return { type: 'clearActivePane' }
+    }
+
+    if (!event.shiftKey && (event.code === 'BracketLeft' || event.code === 'BracketRight')) {
+      return {
+        type: 'focusPane',
+        direction: event.code === 'BracketRight' ? 'next' : 'previous'
+      }
+    }
+
+    if (
+      event.shiftKey &&
+      event.key === 'Enter' &&
+      (event.code === 'Enter' || event.code === 'NumpadEnter')
+    ) {
+      return { type: 'toggleExpandActivePane' }
+    }
+
+    if (!event.shiftKey && lowerKey === 'w') {
+      return { type: 'closeActivePane' }
+    }
+
+    if (lowerKey === 'd') {
+      return {
+        type: 'splitActivePane',
+        direction: event.shiftKey ? 'horizontal' : 'vertical'
+      }
+    }
+  }
+
+  if (
+    !event.metaKey &&
+    !event.ctrlKey &&
+    !event.altKey &&
+    event.shiftKey &&
+    event.key === 'Enter'
+  ) {
+    return { type: 'sendInput', data: '\x1b[13;2u' }
+  }
+
+  if (
+    event.ctrlKey &&
+    !event.metaKey &&
+    !event.altKey &&
+    !event.shiftKey &&
+    event.key === 'Backspace'
+  ) {
+    return { type: 'sendInput', data: '\x17' }
+  }
+
+  if (isMac && event.metaKey && !event.ctrlKey && !event.altKey && !event.shiftKey) {
+    if (event.key === 'Backspace') {
+      return { type: 'sendInput', data: '\x15' }
+    }
+    if (event.key === 'Delete') {
+      return { type: 'sendInput', data: '\x0b' }
+    }
+  }
+
+  if (
+    !event.metaKey &&
+    !event.ctrlKey &&
+    event.altKey &&
+    !event.shiftKey &&
+    event.key === 'Backspace'
+  ) {
+    return { type: 'sendInput', data: '\x1b\x7f' }
+  }
+
+  // Why: the terminal shortcut layer is an explicit allowlist, not a generic
+  // "modifier means app shortcut" rule. Keeping this list narrow prevents Orca
+  // from swallowing readline/emacs control chords like Ctrl+R, Ctrl+U, Ctrl+E,
+  // Alt+B, Alt+F, and Alt+D when the shell owns terminal focus.
+  return null
+}

--- a/src/shared/window-shortcut-policy.test.ts
+++ b/src/shared/window-shortcut-policy.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isWindowShortcutModifierChord,
+  resolveWindowShortcutAction,
+  type WindowShortcutInput
+} from './window-shortcut-policy'
+
+describe('resolveWindowShortcutAction', () => {
+  it('keeps ctrl/cmd+r and readline control chords out of the main-process allowlist', () => {
+    const macCases: WindowShortcutInput[] = [
+      { code: 'KeyR', key: 'r', meta: true, control: false, alt: false, shift: false },
+      { code: 'KeyR', key: 'r', meta: false, control: true, alt: false, shift: false },
+      { code: 'KeyU', key: 'u', meta: false, control: true, alt: false, shift: false },
+      { code: 'KeyE', key: 'e', meta: false, control: true, alt: false, shift: false }
+    ]
+
+    for (const input of macCases) {
+      expect(resolveWindowShortcutAction(input, 'darwin')).toBeNull()
+    }
+
+    const nonMacCases: WindowShortcutInput[] = [
+      { code: 'KeyR', key: 'r', meta: false, control: true, alt: false, shift: false },
+      { code: 'KeyU', key: 'u', meta: false, control: true, alt: false, shift: false },
+      { code: 'KeyE', key: 'e', meta: false, control: true, alt: false, shift: false },
+      { code: 'KeyJ', key: 'j', meta: false, control: true, alt: false, shift: false }
+    ]
+
+    for (const input of nonMacCases) {
+      expect(resolveWindowShortcutAction(input, 'linux')).toBeNull()
+    }
+  })
+
+  it('resolves the explicit window shortcut allowlist on macOS', () => {
+    expect(
+      resolveWindowShortcutAction(
+        { code: 'KeyJ', key: 'j', meta: true, control: false, alt: false, shift: false },
+        'darwin'
+      )
+    ).toEqual({ type: 'toggleWorktreePalette' })
+
+    expect(
+      resolveWindowShortcutAction(
+        { code: 'KeyP', key: 'p', meta: true, control: false, alt: false, shift: false },
+        'darwin'
+      )
+    ).toEqual({ type: 'openQuickOpen' })
+
+    expect(
+      resolveWindowShortcutAction(
+        { code: 'Digit3', key: '3', meta: true, control: false, alt: false, shift: false },
+        'darwin'
+      )
+    ).toEqual({ type: 'jumpToWorktreeIndex', index: 2 })
+  })
+
+  it('requires shift for the non-mac worktree palette shortcut', () => {
+    expect(
+      resolveWindowShortcutAction(
+        { code: 'KeyJ', key: 'j', meta: false, control: true, alt: false, shift: false },
+        'win32'
+      )
+    ).toBeNull()
+
+    expect(
+      resolveWindowShortcutAction(
+        { code: 'KeyJ', key: 'j', meta: false, control: true, alt: false, shift: true },
+        'win32'
+      )
+    ).toEqual({ type: 'toggleWorktreePalette' })
+  })
+
+  it('accepts all supported zoom key variants', () => {
+    const zoomInCases: WindowShortcutInput[] = [
+      { key: '=', meta: true, control: false, alt: false, shift: false },
+      { key: '+', meta: true, control: false, alt: false, shift: true },
+      { code: 'NumpadAdd', key: '', meta: true, control: false, alt: false, shift: false }
+    ]
+    for (const input of zoomInCases) {
+      expect(resolveWindowShortcutAction(input, 'darwin')).toEqual({
+        type: 'zoom',
+        direction: 'in'
+      })
+    }
+
+    const zoomOutCases: WindowShortcutInput[] = [
+      { key: '-', meta: false, control: true, alt: false, shift: false },
+      { key: '_', meta: false, control: true, alt: false, shift: true },
+      { key: 'Minus', meta: false, control: true, alt: false, shift: false },
+      { code: 'NumpadSubtract', key: '', meta: false, control: true, alt: false, shift: false }
+    ]
+    for (const input of zoomOutCases) {
+      expect(resolveWindowShortcutAction(input, 'linux')).toEqual({
+        type: 'zoom',
+        direction: 'out'
+      })
+    }
+
+    expect(
+      resolveWindowShortcutAction(
+        { key: '0', meta: false, control: true, alt: false, shift: false },
+        'linux'
+      )
+    ).toEqual({ type: 'zoom', direction: 'reset' })
+  })
+
+  it('exposes the shared platform modifier gate used by browser guests', () => {
+    expect(
+      isWindowShortcutModifierChord({ meta: true, control: false, alt: false }, 'darwin')
+    ).toBe(true)
+    expect(isWindowShortcutModifierChord({ meta: false, control: true, alt: false }, 'linux')).toBe(
+      true
+    )
+    expect(isWindowShortcutModifierChord({ meta: false, control: true, alt: true }, 'linux')).toBe(
+      false
+    )
+  })
+})

--- a/src/shared/window-shortcut-policy.ts
+++ b/src/shared/window-shortcut-policy.ts
@@ -1,0 +1,85 @@
+export type WindowShortcutInput = {
+  key?: string
+  code?: string
+  alt?: boolean
+  meta?: boolean
+  control?: boolean
+  shift?: boolean
+}
+
+export type WindowShortcutAction =
+  | { type: 'zoom'; direction: 'in' | 'out' | 'reset' }
+  | { type: 'toggleWorktreePalette' }
+  | { type: 'openQuickOpen' }
+  | { type: 'jumpToWorktreeIndex'; index: number }
+
+export function isWindowShortcutModifierChord(
+  input: Pick<WindowShortcutInput, 'meta' | 'control' | 'alt'>,
+  platform: NodeJS.Platform
+): boolean {
+  const modifierPressed = platform === 'darwin' ? input.meta : input.control
+  return Boolean(modifierPressed) && !input.alt
+}
+
+function isZoomInShortcut(input: WindowShortcutInput): boolean {
+  return input.key === '=' || input.key === '+' || input.code === 'NumpadAdd'
+}
+
+function isZoomOutShortcut(input: WindowShortcutInput): boolean {
+  // Why: Electron reports Cmd/Ctrl+Minus differently across layouts and devices:
+  // some emit '-' while shifted layouts emit '_', and other layouts/devices
+  // report symbolic names like "Minus"/"Subtract" in either key or code.
+  // We accept all known variants so zoom out remains reachable everywhere.
+  const key = (input.key ?? '').toLowerCase()
+  const code = (input.code ?? '').toLowerCase()
+  return (
+    key === '-' ||
+    key === '_' ||
+    key.includes('minus') ||
+    key.includes('subtract') ||
+    code.includes('minus') ||
+    code.includes('subtract')
+  )
+}
+
+export function resolveWindowShortcutAction(
+  input: WindowShortcutInput,
+  platform: NodeJS.Platform
+): WindowShortcutAction | null {
+  if (!isWindowShortcutModifierChord(input, platform)) {
+    return null
+  }
+
+  if (isZoomInShortcut(input)) {
+    return { type: 'zoom', direction: 'in' }
+  }
+
+  if (isZoomOutShortcut(input)) {
+    return { type: 'zoom', direction: 'out' }
+  }
+
+  if (input.key === '0' && !input.shift) {
+    return { type: 'zoom', direction: 'reset' }
+  }
+
+  if (
+    input.code === 'KeyJ' &&
+    ((platform === 'darwin' && !input.shift) || (platform !== 'darwin' && input.shift))
+  ) {
+    return { type: 'toggleWorktreePalette' }
+  }
+
+  if (input.code === 'KeyP' && !input.shift) {
+    return { type: 'openQuickOpen' }
+  }
+
+  if (input.key && input.key >= '1' && input.key <= '9' && !input.shift) {
+    return { type: 'jumpToWorktreeIndex', index: parseInt(input.key, 10) - 1 }
+  }
+
+  // Why: this helper is the explicit allowlist for main-process interception.
+  // Anything not listed here must keep flowing to the renderer/PTTY so readline
+  // chords like Ctrl+R, Ctrl+U, and Ctrl+E are not accidentally stolen by a
+  // future shortcut addition.
+  return null
+}


### PR DESCRIPTION
## Problem

Terminal control chords were hard to reason about because Orca intercepted shortcuts in three different places: the main window, browser guests, and the terminal renderer. That made it easy to fix one conflict (`Cmd/Ctrl+R` in #443 / #453) without having an explicit contract for which shortcuts must always keep reaching readline.

The linked reports (#481 and #482) exposed the broader issue: shortcut interception was not centralized or auditable, so regressions around terminal control keys were likely to recur.

## Solution

Centralize shortcut interception into explicit allowlist helpers and add regression tests around the reservation surface.

- add a shared window shortcut policy used by both the main window and browser-guest forwarding paths
- add a terminal shortcut policy helper so terminal pane interception is explicit and testable
- preserve the terminal search navigation behavior added on `main` while merging it with the new allowlist-based terminal shortcut handling
- add regression tests that enumerate which chords Orca reserves and which control/readline chords must remain passthrough
- document the issue relationship, reproduction matrix, and follow-up risk in `docs/term-shortcut-fix.md`

## Testing

- `pnpm exec vitest run --config config/vitest.config.ts src/shared/window-shortcut-policy.test.ts src/renderer/src/components/terminal-pane/terminal-shortcut-policy.test.ts src/main/window/createMainWindow.test.ts src/main/menu/register-app-menu.test.ts src/main/browser/browser-manager.test.ts`

Fixes #482 , #481 