### PR TITLE
Split-screen tab groups with canonical group/item model

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -13,7 +13,7 @@ import { useShallow } from 'zustand/react/shallow'
 import { useIpcEvents } from './hooks/useIpcEvents'
 import Sidebar from './components/Sidebar'
 import Terminal from './components/Terminal'
-import { shutdownBufferCaptures } from './components/terminal-pane/TerminalPane'
+import { captureAllTerminalBuffers } from './components/terminal-pane/buffer-capture-registry'
 import Landing from './components/Landing'
 import Settings from './components/settings/Settings'
 import RightSidebar from './components/right-sidebar'
@@ -112,6 +112,11 @@ function App(): React.JSX.Element {
   const activeTabIdByWorktree = useAppStore((s) => s.activeTabIdByWorktree)
   const browserTabsByWorktree = useAppStore((s) => s.browserTabsByWorktree)
   const activeBrowserTabIdByWorktree = useAppStore((s) => s.activeBrowserTabIdByWorktree)
+  const unifiedTabsByWorktree = useAppStore((s) => s.unifiedTabsByWorktree)
+  const groupsByWorktree = useAppStore((s) => s.groupsByWorktree)
+  const layoutByWorktree = useAppStore((s) => s.layoutByWorktree)
+  const activeGroupIdByWorktree = useAppStore((s) => s.activeGroupIdByWorktree)
+  const hydrateTabsSession = useAppStore((s) => s.hydrateTabsSession)
 
   // Right sidebar + editor state
   const toggleRightSidebar = useAppStore((s) => s.toggleRightSidebar)
@@ -150,6 +155,7 @@ function App(): React.JSX.Element {
         if (!cancelled) {
           hydratePersistedUI(persistedUI)
           hydrateWorkspaceSession(session)
+          hydrateTabsSession(session)
           hydrateEditorSession(session)
           hydrateBrowserSession(session)
           await reconnectPersistedTerminals(abortController.signal)
@@ -203,6 +209,7 @@ function App(): React.JSX.Element {
     initGitHubCache,
     hydratePersistedUI,
     hydrateWorkspaceSession,
+    hydrateTabsSession,
     hydrateEditorSession,
     hydrateBrowserSession,
     reconnectPersistedTerminals
@@ -241,7 +248,11 @@ function App(): React.JSX.Element {
           activeFileIdByWorktree,
           activeTabTypeByWorktree,
           browserTabsByWorktree,
-          activeBrowserTabIdByWorktree
+          activeBrowserTabIdByWorktree,
+          unifiedTabsByWorktree,
+          groupsByWorktree,
+          layoutByWorktree,
+          activeGroupIdByWorktree
         })
       )
     }, 150)
@@ -258,6 +269,10 @@ function App(): React.JSX.Element {
     activeFileIdByWorktree,
     activeTabTypeByWorktree,
     activeTabIdByWorktree,
+    unifiedTabsByWorktree,
+    groupsByWorktree,
+    layoutByWorktree,
+    activeGroupIdByWorktree,
     browserTabsByWorktree,
     activeBrowserTabIdByWorktree
   ])
@@ -280,13 +295,7 @@ function App(): React.JSX.Element {
       if (!useAppStore.getState().workspaceSessionReady) {
         return
       }
-      for (const capture of shutdownBufferCaptures) {
-        try {
-          capture()
-        } catch {
-          // Don't let one pane's failure block the rest.
-        }
-      }
+      captureAllTerminalBuffers()
       const state = useAppStore.getState()
       window.api.session.setSync(buildWorkspaceSessionPayload(state))
       shutdownBuffersCaptured = true
@@ -302,16 +311,10 @@ function App(): React.JSX.Element {
   useEffect(() => {
     const PERIODIC_SAVE_INTERVAL_MS = 3 * 60_000
     const timer = window.setInterval(() => {
-      if (!useAppStore.getState().workspaceSessionReady || shutdownBufferCaptures.size === 0) {
+      if (!useAppStore.getState().workspaceSessionReady) {
         return
       }
-      for (const capture of shutdownBufferCaptures) {
-        try {
-          capture()
-        } catch {
-          // Don't let one pane's failure block the rest.
-        }
-      }
+      captureAllTerminalBuffers()
       const state = useAppStore.getState()
       void window.api.session.set(buildWorkspaceSessionPayload(state))
     }, PERIODIC_SAVE_INTERVAL_MS)
@@ -583,11 +586,10 @@ function App(): React.JSX.Element {
               </HoverCard>
             ) : null}
           </div>
-          {/* Why: keep the center titlebar slot mounted even when tabs are hidden.
-              Using `hidden` here collapsed the spacer entirely, which let the
-              right-sidebar toggle slide left in the no-tabs empty state. `invisible`
-              still suppresses any stale portal content without breaking the far-right
-              titlebar alignment. */}
+          {/* Why: keep the center titlebar slot mounted even when no content is
+              using it. Collapsing this spacer lets the right-side controls jump
+              left in empty states; `invisible` preserves titlebar alignment
+              without reserving a second tab-rendering path. */}
           <div
             id="titlebar-tabs"
             className={`flex flex-1 min-w-0 self-stretch${activeView === 'settings' || !activeWorktreeId ? ' invisible pointer-events-none' : ''}`}

--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -1,8 +1,5 @@
 /* eslint-disable max-lines */
-
 import { useEffect, useCallback, useRef, useState, lazy, Suspense } from 'react'
-import { createPortal } from 'react-dom'
-import { TOGGLE_TERMINAL_PANE_EXPAND_EVENT } from '@/constants/terminal'
 import { useAppStore } from '../store'
 import {
   Dialog,
@@ -13,8 +10,6 @@ import {
   DialogTitle
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
-import { RefreshCw } from 'lucide-react'
-import TabBar from './tab-bar/TabBar'
 import TerminalPane from './terminal-pane/TerminalPane'
 import {
   ORCA_EDITOR_SAVE_AND_CLOSE_EVENT,
@@ -22,8 +17,9 @@ import {
 } from './editor/editor-autosave'
 import { isUpdaterQuitAndInstallInProgress } from '@/lib/updater-beforeunload'
 import EditorAutosaveController from './editor/EditorAutosaveController'
-import BrowserPane, { destroyPersistentWebview } from './browser-pane/BrowserPane'
+import { destroyPersistentWebview } from './browser-pane/BrowserPane'
 import { reconcileTabOrder } from './tab-bar/reconcile-order'
+import TabGroupSplitLayout from './tab-group/TabGroupSplitLayout'
 
 const EditorPanel = lazy(() => import('./editor/EditorPanel'))
 
@@ -37,46 +33,35 @@ export default function Terminal(): React.JSX.Element | null {
   const closeTab = useAppStore((s) => s.closeTab)
   const setActiveTab = useAppStore((s) => s.setActiveTab)
   const setActiveWorktree = useAppStore((s) => s.setActiveWorktree)
-  const setTabCustomTitle = useAppStore((s) => s.setTabCustomTitle)
-  const setTabColor = useAppStore((s) => s.setTabColor)
   const consumeSuppressedPtyExit = useAppStore((s) => s.consumeSuppressedPtyExit)
-  const ptyIdsByTabId = useAppStore((s) => s.ptyIdsByTabId)
-  const codexRestartNoticeByPtyId = useAppStore((s) => s.codexRestartNoticeByPtyId)
-  const queueCodexPaneRestarts = useAppStore((s) => s.queueCodexPaneRestarts)
-  const clearCodexRestartNotice = useAppStore((s) => s.clearCodexRestartNotice)
-  const expandedPaneByTabId = useAppStore((s) => s.expandedPaneByTabId)
   const workspaceSessionReady = useAppStore((s) => s.workspaceSessionReady)
   const openFiles = useAppStore((s) => s.openFiles)
-  const activeFileId = useAppStore((s) => s.activeFileId)
   const activeBrowserTabId = useAppStore((s) => s.activeBrowserTabId)
   const activeTabType = useAppStore((s) => s.activeTabType)
   const setActiveTabType = useAppStore((s) => s.setActiveTabType)
   const setActiveFile = useAppStore((s) => s.setActiveFile)
   const closeFile = useAppStore((s) => s.closeFile)
-  const closeAllFiles = useAppStore((s) => s.closeAllFiles)
-  const pinFile = useAppStore((s) => s.pinFile)
   const browserTabsByWorktree = useAppStore((s) => s.browserTabsByWorktree)
+  const groupsByWorktree = useAppStore((s) => s.groupsByWorktree)
+  const layoutByWorktree = useAppStore((s) => s.layoutByWorktree)
+  const activeGroupIdByWorktree = useAppStore((s) => s.activeGroupIdByWorktree)
+  const ensureWorktreeRootGroup = useAppStore((s) => s.ensureWorktreeRootGroup)
   const createBrowserTab = useAppStore((s) => s.createBrowserTab)
   const closeBrowserTab = useAppStore((s) => s.closeBrowserTab)
   const setActiveBrowserTab = useAppStore((s) => s.setActiveBrowserTab)
-  const updateBrowserTabPageState = useAppStore((s) => s.updateBrowserTabPageState)
-  const setBrowserTabUrl = useAppStore((s) => s.setBrowserTabUrl)
 
   const markFileDirty = useAppStore((s) => s.markFileDirty)
   const setTabBarOrder = useAppStore((s) => s.setTabBarOrder)
-  const tabBarOrderByWorktree = useAppStore((s) => s.tabBarOrderByWorktree)
-  const tabBarOrder = activeWorktreeId ? tabBarOrderByWorktree[activeWorktreeId] : undefined
 
   const tabs = activeWorktreeId ? (tabsByWorktree[activeWorktreeId] ?? []) : []
   const allWorktrees = Object.values(worktreesByRepo).flat()
 
-  // Why: the TabBar is rendered into the titlebar via a portal so tabs share
-  // the same row as the "Orca" title. The target element is created by App.tsx.
-  // Uses useEffect because the DOM element doesn't exist during the render phase.
-  const [titlebarTabsTarget, setTitlebarTabsTarget] = useState<HTMLElement | null>(null)
   useEffect(() => {
-    setTitlebarTabsTarget(document.getElementById('titlebar-tabs'))
-  }, [])
+    if (!activeWorktreeId) {
+      return
+    }
+    ensureWorktreeRootGroup(activeWorktreeId)
+  }, [activeWorktreeId, ensureWorktreeRootGroup])
 
   // Filter editor files to only show those belonging to the active worktree
   const worktreeFiles = activeWorktreeId
@@ -85,6 +70,20 @@ export default function Terminal(): React.JSX.Element | null {
   const worktreeBrowserTabs = activeWorktreeId
     ? (browserTabsByWorktree[activeWorktreeId] ?? [])
     : []
+  const activeGroups = activeWorktreeId ? (groupsByWorktree[activeWorktreeId] ?? []) : []
+  const activeLayout = activeWorktreeId ? layoutByWorktree[activeWorktreeId] : undefined
+  const effectiveActiveLayout =
+    activeLayout ??
+    (activeWorktreeId
+      ? (() => {
+          const fallbackGroupId =
+            activeGroupIdByWorktree[activeWorktreeId] ?? activeGroups[0]?.id ?? null
+          if (!fallbackGroupId) {
+            return undefined
+          }
+          return { type: 'leaf', groupId: fallbackGroupId } as const
+        })()
+      : undefined)
   const activeWorktreeBrowserTabIdsKey = activeWorktreeId
     ? (browserTabsByWorktree[activeWorktreeId] ?? []).map((tab) => tab.id).join(',')
     : ''
@@ -364,114 +363,6 @@ export default function Terminal(): React.JSX.Element | null {
     [consumeSuppressedPtyExit, handleCloseTab]
   )
 
-  const handleCloseOthers = useCallback(
-    (tabId: string) => {
-      if (!activeWorktreeId) {
-        return
-      }
-      const state = useAppStore.getState()
-      const order = state.tabBarOrderByWorktree[activeWorktreeId] ?? []
-      for (const id of order) {
-        if (id === tabId) {
-          continue
-        }
-        if ((state.tabsByWorktree[activeWorktreeId] ?? []).some((tab) => tab.id === id)) {
-          closeTab(id)
-        } else if (
-          state.openFiles.some((file) => file.worktreeId === activeWorktreeId && file.id === id)
-        ) {
-          if (
-            state.activeFileId === id &&
-            state.openFiles.find((file) => file.id === id)?.isDirty
-          ) {
-            continue
-          }
-          closeFile(id)
-        } else if (
-          (state.browserTabsByWorktree[activeWorktreeId] ?? []).some((tab) => tab.id === id)
-        ) {
-          destroyPersistentWebview(id)
-          closeBrowserTab(id)
-        }
-      }
-    },
-    [activeWorktreeId, closeBrowserTab, closeFile, closeTab]
-  )
-
-  const handleCloseTabsToRight = useCallback(
-    (tabId: string) => {
-      if (!activeWorktreeId) {
-        return
-      }
-      const state = useAppStore.getState()
-      const currentOrder = state.tabBarOrderByWorktree[activeWorktreeId] ?? []
-      const index = currentOrder.findIndex((id) => id === tabId)
-      if (index === -1) {
-        return
-      }
-      const rightIds = currentOrder.slice(index + 1)
-      for (const id of rightIds) {
-        if ((state.tabsByWorktree[activeWorktreeId] ?? []).some((tab) => tab.id === id)) {
-          closeTab(id)
-        } else if (
-          state.openFiles.some((file) => file.worktreeId === activeWorktreeId && file.id === id)
-        ) {
-          closeFile(id)
-        } else if (
-          (state.browserTabsByWorktree[activeWorktreeId] ?? []).some((tab) => tab.id === id)
-        ) {
-          destroyPersistentWebview(id)
-          closeBrowserTab(id)
-        }
-      }
-    },
-    [activeWorktreeId, closeBrowserTab, closeFile, closeTab]
-  )
-
-  const handleActivateTab = useCallback(
-    (tabId: string) => {
-      setActiveTab(tabId)
-      setActiveTabType('terminal')
-    },
-    [setActiveTab, setActiveTabType]
-  )
-
-  const handleTogglePaneExpand = useCallback(
-    (tabId: string) => {
-      setActiveTab(tabId)
-      requestAnimationFrame(() => {
-        window.dispatchEvent(
-          new CustomEvent(TOGGLE_TERMINAL_PANE_EXPAND_EVENT, {
-            detail: { tabId }
-          })
-        )
-      })
-    },
-    [setActiveTab]
-  )
-
-  const handleActivateBrowserTab = useCallback(
-    (tabId: string) => {
-      setActiveBrowserTab(tabId)
-      setActiveTabType('browser')
-    },
-    [setActiveBrowserTab, setActiveTabType]
-  )
-
-  const handleBrowserTabPageStateUpdate = useCallback(
-    (tabId: string, updates: Parameters<typeof updateBrowserTabPageState>[1]) => {
-      updateBrowserTabPageState(tabId, updates)
-    },
-    [updateBrowserTabPageState]
-  )
-
-  const handleBrowserTabSetUrl = useCallback(
-    (tabId: string, url: string) => {
-      setBrowserTabUrl(tabId, url)
-    },
-    [setBrowserTabUrl]
-  )
-
   // Keyboard shortcuts
   useEffect(() => {
     if (!activeWorktreeId) {
@@ -703,181 +594,73 @@ export default function Terminal(): React.JSX.Element | null {
     >
       <EditorAutosaveController />
 
-      {/* Why: the tab bar is rendered into the titlebar via a portal so it
-          shares the same visual row as the "Orca" title. The portal target
-          (#titlebar-tabs) lives in App.tsx's titlebar. */}
-      {activeWorktreeId &&
-        titlebarTabsTarget &&
-        createPortal(
-          <TabBar
-            tabs={tabs}
-            activeTabId={activeTabId}
+      {/* Why: every worktree now renders through the canonical group layout,
+          including the original single group. Keeping the first group inline
+          avoids a "tabs in the titlebar first, tabs in the pane after split"
+          mismatch, so split creation no longer changes the vertical position
+          of the tab strip. */}
+      {activeWorktreeId && effectiveActiveLayout ? (
+        <div className="flex flex-1 min-w-0 min-h-0 overflow-hidden">
+          <TabGroupSplitLayout
+            layout={effectiveActiveLayout}
             worktreeId={activeWorktreeId}
-            onActivate={handleActivateTab}
-            onClose={handleCloseTab}
-            onCloseOthers={handleCloseOthers}
-            onCloseToRight={handleCloseTabsToRight}
-            onReorder={setTabBarOrder}
-            onNewTerminalTab={handleNewTab}
-            onNewBrowserTab={handleNewBrowserTab}
-            onSetCustomTitle={setTabCustomTitle}
-            onSetTabColor={setTabColor}
-            expandedPaneByTabId={expandedPaneByTabId}
-            onTogglePaneExpand={handleTogglePaneExpand}
-            editorFiles={worktreeFiles}
-            browserTabs={worktreeBrowserTabs}
-            activeFileId={activeFileId}
-            activeBrowserTabId={activeBrowserTabId}
-            activeTabType={activeTabType}
-            onActivateFile={(fileId) => {
-              setActiveFile(fileId)
-              setActiveTabType('editor')
-            }}
-            onCloseFile={handleCloseFile}
-            onActivateBrowserTab={handleActivateBrowserTab}
-            onCloseBrowserTab={handleCloseBrowserTab}
-            onCloseAllFiles={closeAllFiles}
-            onPinFile={pinFile}
-            tabBarOrder={tabBarOrder}
-          />,
-          titlebarTabsTarget
-        )}
+            focusedGroupId={activeGroupIdByWorktree[activeWorktreeId]}
+          />
+        </div>
+      ) : (
+        <>
+          {/* Terminal panes container - hidden when editor or browser tab active */}
+          <div
+            className={`relative flex-1 min-h-0 overflow-hidden ${
+              (activeTabType === 'editor' && worktreeFiles.length > 0) ||
+              (activeTabType === 'browser' && worktreeBrowserTabs.length > 0)
+                ? 'hidden'
+                : ''
+            }`}
+          >
+            {allWorktrees
+              .filter((wt) => mountedWorktreeIdsRef.current.has(wt.id))
+              .map((worktree) => {
+                const worktreeTabs = tabsByWorktree[worktree.id] ?? []
+                const isVisible = activeView !== 'settings' && worktree.id === activeWorktreeId
 
-      {/* Terminal panes container - hidden when editor tab active */}
-      <div
-        className={`relative flex-1 min-h-0 overflow-hidden ${
-          // Why: only hide the terminal container when another tab type has
-          // content to display. Hiding unconditionally for non-terminal types
-          // causes a blank screen when activeTabType is stale (e.g. 'editor'
-          // with no files after session restore). The terminal stays visible
-          // as a fallback until another surface is ready.
-          (activeTabType === 'editor' && worktreeFiles.length > 0) ||
-          (activeTabType === 'browser' && worktreeBrowserTabs.length > 0)
-            ? 'hidden'
-            : ''
-        }`}
-      >
-        {allWorktrees
-          .filter((wt) => mountedWorktreeIdsRef.current.has(wt.id))
-          .map((worktree) => {
-            const worktreeTabs = tabsByWorktree[worktree.id] ?? []
-            const isVisible = activeView !== 'settings' && worktree.id === activeWorktreeId
-
-            return (
-              <div
-                key={worktree.id}
-                className={isVisible ? 'absolute inset-0' : 'absolute inset-0 hidden'}
-                aria-hidden={!isVisible}
-              >
-                {(() => {
-                  const staleWorktreePtyIds = worktreeTabs.flatMap((tab) =>
-                    (ptyIdsByTabId[tab.id] ?? []).filter((ptyId) =>
-                      Boolean(codexRestartNoticeByPtyId[ptyId])
-                    )
-                  )
-                  if (staleWorktreePtyIds.length === 0) {
-                    return null
-                  }
-                  // Why: account switching is global, but repeating the same
-                  // stale-session prompt in every affected Codex pane quickly
-                  // turns into noise. Keep one worktree-scoped chip in the
-                  // same visual corner so users get the same prompt style
-                  // without having to dismiss it in every pane.
-                  return (
-                    <div className="pointer-events-none absolute right-3 top-3 z-20">
-                      <div className="pointer-events-auto flex items-center gap-2 rounded-lg border border-border/80 bg-popover/95 px-2 py-1.5 shadow-lg backdrop-blur-sm">
-                        <span className="text-[11px] text-muted-foreground">
-                          Codex is using the previous account
-                        </span>
-                        <div className="flex items-center gap-1.5">
-                          <button
-                            type="button"
-                            onClick={() => queueCodexPaneRestarts(staleWorktreePtyIds)}
-                            className="inline-flex items-center gap-1.5 rounded-md bg-foreground px-2 py-1 text-[11px] font-medium text-background transition-colors hover:opacity-90"
-                          >
-                            <RefreshCw className="size-3" />
-                            Restart
-                          </button>
-                          <button
-                            type="button"
-                            onClick={() => {
-                              for (const ptyId of staleWorktreePtyIds) {
-                                clearCodexRestartNotice(ptyId)
-                              }
-                            }}
-                            className="rounded-md px-1.5 py-1 text-[11px] text-muted-foreground transition-colors hover:bg-accent/60 hover:text-foreground"
-                          >
-                            Dismiss
-                          </button>
-                        </div>
-                      </div>
-                    </div>
-                  )
-                })()}
-                {worktreeTabs.map((tab) => (
-                  <TerminalPane
-                    key={`${tab.id}-${tab.generation ?? 0}`}
-                    tabId={tab.id}
-                    worktreeId={worktree.id}
-                    cwd={worktree.path}
-                    isActive={isVisible && tab.id === activeTabId && activeTabType === 'terminal'}
-                    onPtyExit={(ptyId) => handlePtyExit(tab.id, ptyId)}
-                    onCloseTab={() => handleCloseTab(tab.id)}
-                  />
-                ))}
-              </div>
-            )
-          })}
-      </div>
-
-      {/* Browser panes container — hidden when active tab is not a browser tab.
-          Only the active browser tab for the active worktree is mounted; others
-          are parked in a hidden off-screen container by BrowserPane to preserve
-          their webview guest process across tab switches. */}
-      <div
-        className={`relative flex-1 min-h-0 overflow-hidden ${activeTabType !== 'browser' ? 'hidden' : ''}`}
-      >
-        {allWorktrees.map((worktree) => {
-          const browserTabs = browserTabsByWorktree[worktree.id] ?? []
-          const isVisibleWorktree = activeView !== 'settings' && worktree.id === activeWorktreeId
-          if (browserTabs.length === 0) {
-            return null
-          }
-          return (
-            <div
-              key={`browser-${worktree.id}`}
-              className={isVisibleWorktree ? 'absolute inset-0' : 'absolute inset-0 hidden'}
-              aria-hidden={!isVisibleWorktree}
-            >
-              {isVisibleWorktree && activeTabType === 'browser'
-                ? browserTabs
-                    .filter((browserTab) => browserTab.id === activeBrowserTabId)
-                    .map((browserTab) => (
-                      <BrowserPane
-                        key={browserTab.id}
-                        browserTab={browserTab}
-                        onUpdatePageState={handleBrowserTabPageStateUpdate}
-                        onSetUrl={handleBrowserTabSetUrl}
+                return (
+                  <div
+                    key={worktree.id}
+                    className={isVisible ? 'absolute inset-0' : 'absolute inset-0 hidden'}
+                    aria-hidden={!isVisible}
+                  >
+                    {worktreeTabs.map((tab) => (
+                      <TerminalPane
+                        key={`${tab.id}-${tab.generation ?? 0}`}
+                        tabId={tab.id}
+                        worktreeId={worktree.id}
+                        cwd={worktree.path}
+                        isActive={
+                          isVisible && tab.id === activeTabId && activeTabType === 'terminal'
+                        }
+                        onPtyExit={(ptyId) => handlePtyExit(tab.id, ptyId)}
+                        onCloseTab={() => handleCloseTab(tab.id)}
                       />
-                    ))
-                : null}
-            </div>
-          )
-        })}
-      </div>
+                    ))}
+                  </div>
+                )
+              })}
+          </div>
 
-      {activeWorktreeId && activeTabType === 'editor' && worktreeFiles.length > 0 && (
-        <Suspense
-          fallback={
-            <div className="flex-1 flex items-center justify-center text-muted-foreground text-sm">
-              Loading editor...
-            </div>
-          }
-        >
-          <EditorPanel />
-        </Suspense>
+          {activeWorktreeId && activeTabType === 'editor' && worktreeFiles.length > 0 && (
+            <Suspense
+              fallback={
+                <div className="flex-1 flex items-center justify-center text-muted-foreground text-sm">
+                  Loading editor...
+                </div>
+              }
+            >
+              <EditorPanel />
+            </Suspense>
+          )}
+        </>
       )}
-
       {/* Save confirmation dialog */}
       <Dialog
         open={saveDialogFileId !== null}

--- a/src/renderer/src/components/editor/EditorPanel.tsx
+++ b/src/renderer/src/components/editor/EditorPanel.tsx
@@ -31,9 +31,16 @@ type FileContent = {
 
 type DiffContent = GitDiffResult
 
-export default function EditorPanel(): React.JSX.Element | null {
+export default function EditorPanel({
+  activeFileId: activeFileIdProp
+}: {
+  activeFileId?: string | null
+} = {}): React.JSX.Element | null {
   const openFiles = useAppStore((s) => s.openFiles)
-  const activeFileId = useAppStore((s) => s.activeFileId)
+  // Why: hooks must be called unconditionally — React requires the same hooks
+  // in the same order on every render regardless of props.
+  const globalActiveFileId = useAppStore((s) => s.activeFileId)
+  const activeFileId = activeFileIdProp ?? globalActiveFileId
   const markFileDirty = useAppStore((s) => s.markFileDirty)
   const pendingEditorReveal = useAppStore((s) => s.pendingEditorReveal)
   const gitStatusByWorktree = useAppStore((s) => s.gitStatusByWorktree)

--- a/src/renderer/src/components/editor/MonacoEditor.tsx
+++ b/src/renderer/src/components/editor/MonacoEditor.tsx
@@ -316,6 +316,11 @@ export default function MonacoEditor({
           }
         }}
         path={filePath}
+        // Why: when editor tabs are split across groups, multiple Editor instances
+        // share the same Monaco model (keyed by path). The default behavior disposes
+        // the model on unmount, which blanks every other editor showing that file.
+        // keepCurrentModel prevents model disposal so sibling editors survive.
+        keepCurrentModel
       />
 
       {toastNode}

--- a/src/renderer/src/components/tab-bar/EditorFileTab.tsx
+++ b/src/renderer/src/components/tab-bar/EditorFileTab.tsx
@@ -9,6 +9,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
+
 import { normalizeRelativePath } from '@/lib/path'
 import { getEditorDisplayLabel } from '@/components/editor/editor-labels'
 import { STATUS_COLORS, STATUS_LABELS } from '../right-sidebar/status-display'

--- a/src/renderer/src/components/tab-bar/SortableTab.tsx
+++ b/src/renderer/src/components/tab-bar/SortableTab.tsx
@@ -9,6 +9,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
+
 import {
   Dialog,
   DialogContent,

--- a/src/renderer/src/components/tab-bar/TabBar.tsx
+++ b/src/renderer/src/components/tab-bar/TabBar.tsx
@@ -8,7 +8,7 @@ import {
   type DragEndEvent
 } from '@dnd-kit/core'
 import { SortableContext, horizontalListSortingStrategy, arrayMove } from '@dnd-kit/sortable'
-import { Globe, Plus, TerminalSquare } from 'lucide-react'
+import { Columns2, Globe, Plus, Rows2, TerminalSquare } from 'lucide-react'
 import type {
   BrowserTab as BrowserTabState,
   TerminalTab,
@@ -48,7 +48,7 @@ type TabBarProps = {
   onSetCustomTitle: (tabId: string, title: string | null) => void
   onSetTabColor: (tabId: string, color: string | null) => void
   onTogglePaneExpand: (tabId: string) => void
-  editorFiles?: OpenFile[]
+  editorFiles?: (OpenFile & { tabId?: string })[]
   browserTabs?: BrowserTabState[]
   activeFileId?: string | null
   activeBrowserTabId?: string | null
@@ -58,13 +58,14 @@ type TabBarProps = {
   onActivateBrowserTab?: (tabId: string) => void
   onCloseBrowserTab?: (tabId: string) => void
   onCloseAllFiles?: () => void
-  onPinFile?: (fileId: string) => void
+  onPinFile?: (fileId: string, tabId?: string) => void
   tabBarOrder?: string[]
+  onCreateSplitGroup?: (direction: 'right' | 'down') => void
 }
 
 type TabItem =
   | { type: 'terminal'; id: string; data: TerminalTab }
-  | { type: 'editor'; id: string; data: OpenFile }
+  | { type: 'editor'; id: string; data: OpenFile & { tabId?: string } }
   | { type: 'browser'; id: string; data: BrowserTabState }
 
 export default function TabBar({
@@ -93,7 +94,8 @@ export default function TabBar({
   onCloseBrowserTab,
   onCloseAllFiles,
   onPinFile,
-  tabBarOrder
+  tabBarOrder,
+  onCreateSplitGroup
 }: TabBarProps): React.JSX.Element {
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -108,14 +110,17 @@ export default function TabBar({
   )
 
   const terminalMap = useMemo(() => new Map(tabs.map((t) => [t.id, t])), [tabs])
-  const editorMap = useMemo(() => new Map((editorFiles ?? []).map((f) => [f.id, f])), [editorFiles])
+  const editorMap = useMemo(
+    () => new Map((editorFiles ?? []).map((f) => [f.tabId ?? f.id, f])),
+    [editorFiles]
+  )
   const browserMap = useMemo(
     () => new Map((browserTabs ?? []).map((t) => [t.id, t])),
     [browserTabs]
   )
 
   const terminalIds = useMemo(() => tabs.map((t) => t.id), [tabs])
-  const editorFileIds = useMemo(() => editorFiles?.map((f) => f.id) ?? [], [editorFiles])
+  const editorFileIds = useMemo(() => editorFiles?.map((f) => f.tabId ?? f.id) ?? [], [editorFiles])
   const browserTabIds = useMemo(() => browserTabs?.map((tab) => tab.id) ?? [], [browserTabs])
 
   // Build the unified ordered list, reconciling stored order with current items
@@ -243,7 +248,7 @@ export default function TabBar({
                   onClose={() => onCloseFile?.(item.id)}
                   onCloseToRight={() => onCloseToRight(item.id)}
                   onCloseAll={() => onCloseAllFiles?.()}
-                  onPin={() => onPinFile?.(item.id)}
+                  onPin={() => onPinFile?.(item.data.id, item.data.tabId)}
                 />
               )
             })}
@@ -281,6 +286,28 @@ export default function TabBar({
             New Browser Tab
             <DropdownMenuShortcut>{NEW_BROWSER_SHORTCUT}</DropdownMenuShortcut>
           </DropdownMenuItem>
+          {onCreateSplitGroup && (
+            <>
+              {/* Why: v1 split groups only create empty neighboring groups from
+                  the plus menu. Reusing per-tab context actions here would
+                  duplicate tab content and reintroduce the runtime identity
+                  bugs this layout-only flow is meant to avoid. */}
+              <DropdownMenuItem
+                onSelect={() => onCreateSplitGroup('right')}
+                className="gap-2 rounded-[7px] px-2 py-0.5 text-[12px] leading-5 font-medium"
+              >
+                <Columns2 className="size-4 text-muted-foreground" />
+                New Group Right
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onSelect={() => onCreateSplitGroup('down')}
+                className="gap-2 rounded-[7px] px-2 py-0.5 text-[12px] leading-5 font-medium"
+              >
+                <Rows2 className="size-4 text-muted-foreground" />
+                New Group Down
+              </DropdownMenuItem>
+            </>
+          )}
         </DropdownMenuContent>
       </DropdownMenu>
     </div>

--- a/src/renderer/src/components/tab-group/TabGroupPanel.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.tsx
@@ -399,7 +399,10 @@ export default function TabGroupPanel({
         }
       }}
       onCloseAllFiles={closeAllFiles}
-      onPinFile={(tabId) => {
+      onPinFile={(_fileId, tabId) => {
+        if (!tabId) {
+          return
+        }
         const item = groupTabs.find((candidate) => candidate.id === tabId)
         if (!item) {
           return

--- a/src/renderer/src/components/tab-group/TabGroupPanel.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.tsx
@@ -1,0 +1,513 @@
+/* eslint-disable max-lines -- Why: group panels intentionally co-locate group-scoped tab chrome, activation/close handlers, and surface rendering so split groups cannot drift into a separate behavior path from the original root group. */
+import { lazy, Suspense, useCallback, useMemo } from 'react'
+import { X } from 'lucide-react'
+import { useShallow } from 'zustand/react/shallow'
+import type { OpenFile } from '@/store/slices/editor'
+import type { BrowserTab as BrowserTabState } from '../../../../shared/types'
+import { useAppStore } from '../../store'
+import TabBar from '../tab-bar/TabBar'
+import TerminalPane from '../terminal-pane/TerminalPane'
+import BrowserPane, { destroyPersistentWebview } from '../browser-pane/BrowserPane'
+
+const EditorPanel = lazy(() => import('../editor/EditorPanel'))
+
+type GroupEditorItem = OpenFile & { tabId: string }
+const EMPTY_GROUPS: readonly never[] = []
+const EMPTY_TABS: readonly never[] = []
+const EMPTY_RUNTIME_TERMINALS: readonly never[] = []
+const EMPTY_BROWSER_TABS: readonly never[] = []
+
+export default function TabGroupPanel({
+  groupId,
+  worktreeId,
+  isFocused,
+  hasSplitGroups
+}: {
+  groupId: string
+  worktreeId: string
+  isFocused: boolean
+  hasSplitGroups: boolean
+}): React.JSX.Element {
+  const worktreeGroups = useAppStore(
+    useShallow((state) => state.groupsByWorktree[worktreeId] ?? EMPTY_GROUPS)
+  )
+  const worktreeUnifiedTabs = useAppStore(
+    useShallow((state) => state.unifiedTabsByWorktree[worktreeId] ?? EMPTY_TABS)
+  )
+  const openFiles = useAppStore((state) => state.openFiles)
+  const worktree = useAppStore(
+    useShallow(
+      (state) =>
+        Object.values(state.worktreesByRepo)
+          .flat()
+          .find((candidate) => candidate.id === worktreeId) ?? null
+    )
+  )
+  const focusGroup = useAppStore((state) => state.focusGroup)
+  const activateTab = useAppStore((state) => state.activateTab)
+  const closeUnifiedTab = useAppStore((state) => state.closeUnifiedTab)
+  const closeOtherTabs = useAppStore((state) => state.closeOtherTabs)
+  const closeTabsToRight = useAppStore((state) => state.closeTabsToRight)
+  const reorderUnifiedTabs = useAppStore((state) => state.reorderUnifiedTabs)
+  const createEmptySplitGroup = useAppStore((state) => state.createEmptySplitGroup)
+  const closeEmptyGroup = useAppStore((state) => state.closeEmptyGroup)
+  const createTab = useAppStore((state) => state.createTab)
+  const closeTab = useAppStore((state) => state.closeTab)
+  const setActiveTab = useAppStore((state) => state.setActiveTab)
+  const setActiveFile = useAppStore((state) => state.setActiveFile)
+  const setActiveTabType = useAppStore((state) => state.setActiveTabType)
+  const setTabCustomTitle = useAppStore((state) => state.setTabCustomTitle)
+  const setTabColor = useAppStore((state) => state.setTabColor)
+  const consumeSuppressedPtyExit = useAppStore((state) => state.consumeSuppressedPtyExit)
+  const createBrowserTab = useAppStore((state) => state.createBrowserTab)
+  const closeFile = useAppStore((state) => state.closeFile)
+  const closeAllFiles = useAppStore((state) => state.closeAllFiles)
+  const pinFile = useAppStore((state) => state.pinFile)
+  const expandedPaneByTabId = useAppStore((state) => state.expandedPaneByTabId)
+  const browserTabsByWorktree = useAppStore((state) => state.browserTabsByWorktree)
+  const runtimeTerminalTabs = useAppStore(
+    (state) => state.tabsByWorktree[worktreeId] ?? EMPTY_RUNTIME_TERMINALS
+  )
+  const closeBrowserTab = useAppStore((state) => state.closeBrowserTab)
+  const setActiveBrowserTab = useAppStore((state) => state.setActiveBrowserTab)
+  const updateBrowserTabPageState = useAppStore((state) => state.updateBrowserTabPageState)
+  const setBrowserTabUrl = useAppStore((state) => state.setBrowserTabUrl)
+
+  const group = useMemo(
+    () => worktreeGroups.find((item) => item.id === groupId) ?? null,
+    [groupId, worktreeGroups]
+  )
+  const groupTabs = useMemo(
+    () => worktreeUnifiedTabs.filter((item) => item.groupId === groupId),
+    [groupId, worktreeUnifiedTabs]
+  )
+
+  const activeItemId = group?.activeTabId ?? null
+  const activeTab = groupTabs.find((item) => item.id === activeItemId) ?? null
+
+  const terminalTabs = useMemo(
+    () =>
+      groupTabs
+        .filter((item) => item.contentType === 'terminal')
+        .map((item) => ({
+          id: item.entityId,
+          ptyId: null,
+          worktreeId,
+          title: item.label,
+          customTitle: item.customLabel,
+          color: item.color,
+          sortOrder: item.sortOrder,
+          createdAt: item.createdAt
+        })),
+    [groupTabs, worktreeId]
+  )
+
+  const editorItems = useMemo<GroupEditorItem[]>(
+    () =>
+      groupTabs
+        .filter(
+          (item) =>
+            item.contentType === 'editor' ||
+            item.contentType === 'diff' ||
+            item.contentType === 'conflict-review'
+        )
+        .map((item) => {
+          const file = openFiles.find((candidate) => candidate.id === item.entityId)
+          return file ? { ...file, tabId: item.id } : null
+        })
+        .filter((item): item is GroupEditorItem => item !== null),
+    [groupTabs, openFiles]
+  )
+
+  const worktreeBrowserTabs = useMemo(
+    () => browserTabsByWorktree[worktreeId] ?? EMPTY_BROWSER_TABS,
+    [browserTabsByWorktree, worktreeId]
+  )
+
+  const browserItems = useMemo(
+    () =>
+      groupTabs
+        .filter((item) => item.contentType === 'browser')
+        .map((item) => {
+          const bt = worktreeBrowserTabs.find((candidate) => candidate.id === item.entityId)
+          return bt ?? null
+        })
+        .filter((item): item is BrowserTabState => item !== null),
+    [groupTabs, worktreeBrowserTabs]
+  )
+
+  const activeBrowserTab = useMemo(
+    () =>
+      activeTab?.contentType === 'browser'
+        ? (worktreeBrowserTabs.find((bt) => bt.id === activeTab.entityId) ?? null)
+        : null,
+    [activeTab, worktreeBrowserTabs]
+  )
+
+  const runtimeTerminalTabById = useMemo(
+    () => new Map(runtimeTerminalTabs.map((tab) => [tab.id, tab])),
+    [runtimeTerminalTabs]
+  )
+
+  const closeEditorIfUnreferenced = useCallback(
+    (entityId: string, closingTabId: string) => {
+      const otherReference = (useAppStore.getState().unifiedTabsByWorktree[worktreeId] ?? []).some(
+        (item) =>
+          item.id !== closingTabId &&
+          item.entityId === entityId &&
+          (item.contentType === 'editor' ||
+            item.contentType === 'diff' ||
+            item.contentType === 'conflict-review')
+      )
+      if (!otherReference) {
+        closeFile(entityId)
+      }
+    },
+    [closeFile, worktreeId]
+  )
+
+  const handleActivateTerminal = useCallback(
+    (terminalId: string) => {
+      const item = groupTabs.find(
+        (candidate) => candidate.entityId === terminalId && candidate.contentType === 'terminal'
+      )
+      if (!item) {
+        return
+      }
+      focusGroup(worktreeId, groupId)
+      activateTab(item.id)
+      setActiveTab(terminalId)
+      setActiveTabType('terminal')
+    },
+    [activateTab, focusGroup, groupId, groupTabs, setActiveTab, setActiveTabType, worktreeId]
+  )
+
+  const handleActivateEditor = useCallback(
+    (tabId: string) => {
+      const item = groupTabs.find((candidate) => candidate.id === tabId)
+      if (!item) {
+        return
+      }
+      focusGroup(worktreeId, groupId)
+      activateTab(item.id)
+      setActiveFile(item.entityId)
+      setActiveTabType('editor')
+    },
+    [activateTab, focusGroup, groupId, groupTabs, setActiveFile, setActiveTabType, worktreeId]
+  )
+
+  const handleActivateBrowser = useCallback(
+    (browserTabId: string) => {
+      const item = groupTabs.find(
+        (candidate) => candidate.entityId === browserTabId && candidate.contentType === 'browser'
+      )
+      if (!item) {
+        return
+      }
+      focusGroup(worktreeId, groupId)
+      activateTab(item.id)
+      setActiveBrowserTab(browserTabId)
+      setActiveTabType('browser')
+    },
+    [activateTab, focusGroup, groupId, groupTabs, setActiveBrowserTab, setActiveTabType, worktreeId]
+  )
+
+  const handleClose = useCallback(
+    (itemId: string) => {
+      const item = groupTabs.find((candidate) => candidate.id === itemId)
+      if (!item) {
+        return
+      }
+      if (item.contentType === 'terminal') {
+        closeTab(item.entityId)
+      } else if (item.contentType === 'browser') {
+        destroyPersistentWebview(item.entityId)
+        closeBrowserTab(item.entityId)
+      } else {
+        closeEditorIfUnreferenced(item.entityId, item.id)
+        closeUnifiedTab(item.id)
+      }
+    },
+    [closeBrowserTab, closeEditorIfUnreferenced, closeTab, closeUnifiedTab, groupTabs]
+  )
+
+  const handleCloseGroup = useCallback(() => {
+    const items = [...(useAppStore.getState().unifiedTabsByWorktree[worktreeId] ?? [])].filter(
+      (item) => item.groupId === groupId
+    )
+    for (const item of items) {
+      if (item.contentType === 'terminal') {
+        closeTab(item.entityId)
+      } else if (item.contentType === 'browser') {
+        destroyPersistentWebview(item.entityId)
+        closeBrowserTab(item.entityId)
+      } else {
+        closeEditorIfUnreferenced(item.entityId, item.id)
+        closeUnifiedTab(item.id)
+      }
+    }
+    // Why: split creation can leave intentionally empty groups behind. Closing
+    // the group chrome must collapse those placeholders too, not just groups
+    // that still own tabs.
+    closeEmptyGroup(worktreeId, groupId)
+  }, [
+    closeBrowserTab,
+    closeEditorIfUnreferenced,
+    closeEmptyGroup,
+    closeTab,
+    closeUnifiedTab,
+    groupId,
+    worktreeId
+  ])
+
+  const handleCreateSplitGroup = useCallback(
+    (direction: 'right' | 'down') => {
+      focusGroup(worktreeId, groupId)
+      createEmptySplitGroup(worktreeId, groupId, direction)
+    },
+    [createEmptySplitGroup, focusGroup, groupId, worktreeId]
+  )
+
+  const handleCloseOthers = useCallback(
+    (itemId: string) => {
+      const closedIds = closeOtherTabs(itemId)
+      for (const closedId of closedIds) {
+        const item = groupTabs.find((candidate) => candidate.id === closedId)
+        if (!item) {
+          continue
+        }
+        if (item.contentType === 'terminal') {
+          closeTab(item.entityId)
+        } else if (item.contentType === 'browser') {
+          destroyPersistentWebview(item.entityId)
+          closeBrowserTab(item.entityId)
+        } else {
+          closeEditorIfUnreferenced(item.entityId, item.id)
+        }
+      }
+    },
+    [closeBrowserTab, closeEditorIfUnreferenced, closeOtherTabs, closeTab, groupTabs]
+  )
+
+  const handleCloseToRight = useCallback(
+    (itemId: string) => {
+      const closedIds = closeTabsToRight(itemId)
+      for (const closedId of closedIds) {
+        const item = groupTabs.find((candidate) => candidate.id === closedId)
+        if (!item) {
+          continue
+        }
+        if (item.contentType === 'terminal') {
+          closeTab(item.entityId)
+        } else if (item.contentType === 'browser') {
+          destroyPersistentWebview(item.entityId)
+          closeBrowserTab(item.entityId)
+        } else {
+          closeEditorIfUnreferenced(item.entityId, item.id)
+        }
+      }
+    },
+    [closeBrowserTab, closeEditorIfUnreferenced, closeTabsToRight, closeTab, groupTabs]
+  )
+
+  const tabBar = (
+    <TabBar
+      tabs={terminalTabs}
+      activeTabId={activeTab?.contentType === 'terminal' ? activeTab.entityId : null}
+      worktreeId={worktreeId}
+      expandedPaneByTabId={expandedPaneByTabId}
+      onActivate={handleActivateTerminal}
+      onClose={(terminalId) => {
+        const item = groupTabs.find(
+          (candidate) => candidate.entityId === terminalId && candidate.contentType === 'terminal'
+        )
+        if (item) {
+          handleClose(item.id)
+        }
+      }}
+      onCloseOthers={(terminalId) => {
+        const item = groupTabs.find(
+          (candidate) => candidate.entityId === terminalId && candidate.contentType === 'terminal'
+        )
+        if (item) {
+          handleCloseOthers(item.id)
+        }
+      }}
+      onCloseToRight={(terminalId) => {
+        const item = groupTabs.find(
+          (candidate) => candidate.entityId === terminalId && candidate.contentType === 'terminal'
+        )
+        if (item) {
+          handleCloseToRight(item.id)
+        }
+      }}
+      onReorder={(_, order) => {
+        if (!group) {
+          return
+        }
+        const itemOrder = order
+          .map(
+            (entityId) =>
+              groupTabs.find(
+                (item) => item.contentType === 'terminal' && item.entityId === entityId
+              )?.id
+          )
+          .filter((value): value is string => Boolean(value))
+          .concat(
+            group.tabOrder.filter(
+              (itemId) =>
+                !groupTabs.find((item) => item.contentType === 'terminal' && item.id === itemId)
+            )
+          )
+        reorderUnifiedTabs(groupId, itemOrder)
+      }}
+      onNewTerminalTab={() => {
+        const terminal = createTab(worktreeId)
+        setActiveTab(terminal.id)
+        setActiveTabType('terminal')
+      }}
+      onNewBrowserTab={() => {
+        createBrowserTab(worktreeId, 'about:blank', { title: 'New Browser Tab' })
+      }}
+      onSetCustomTitle={setTabCustomTitle}
+      onSetTabColor={setTabColor}
+      onTogglePaneExpand={() => {}}
+      editorFiles={editorItems}
+      browserTabs={browserItems}
+      activeFileId={
+        activeTab?.contentType === 'terminal' || activeTab?.contentType === 'browser'
+          ? null
+          : activeTab?.id
+      }
+      activeBrowserTabId={activeTab?.contentType === 'browser' ? activeTab.entityId : null}
+      activeTabType={
+        activeTab?.contentType === 'terminal'
+          ? 'terminal'
+          : activeTab?.contentType === 'browser'
+            ? 'browser'
+            : 'editor'
+      }
+      onActivateFile={handleActivateEditor}
+      onCloseFile={handleClose}
+      onActivateBrowserTab={handleActivateBrowser}
+      onCloseBrowserTab={(browserTabId) => {
+        const item = groupTabs.find(
+          (candidate) => candidate.entityId === browserTabId && candidate.contentType === 'browser'
+        )
+        if (item) {
+          handleClose(item.id)
+        }
+      }}
+      onCloseAllFiles={closeAllFiles}
+      onPinFile={(tabId) => {
+        const item = groupTabs.find((candidate) => candidate.id === tabId)
+        if (!item) {
+          return
+        }
+        pinFile(item.entityId, item.id)
+      }}
+      tabBarOrder={(group?.tabOrder ?? []).map((itemId) => {
+        const item = groupTabs.find((candidate) => candidate.id === itemId)
+        if (!item) {
+          return itemId
+        }
+        return item.contentType === 'terminal' ? item.entityId : item.id
+      })}
+      onCreateSplitGroup={handleCreateSplitGroup}
+    />
+  )
+
+  return (
+    <div
+      className={`flex flex-col flex-1 min-w-0 min-h-0 overflow-hidden${
+        hasSplitGroups
+          ? ` group/tab-group border ${isFocused ? 'border-accent' : 'border-border'}`
+          : ''
+      }`}
+      onPointerDown={() => focusGroup(worktreeId, groupId)}
+    >
+      {/* Why: every group, including the initial unsplit root, must render its
+          chrome inside the same panel stack. Portaling the first group's tabs
+          into the window titlebar created a second vertical frame of reference,
+          so the first split appeared to "jump down" when later groups rendered
+          inline below it. */}
+      <div className="flex items-stretch h-9 shrink-0 border-b border-border bg-card">
+        {tabBar}
+        {hasSplitGroups && (
+          <button
+            type="button"
+            aria-label="Close tab group"
+            title="Close tab group"
+            onClick={(event) => {
+              event.stopPropagation()
+              handleCloseGroup()
+            }}
+            className="mr-1 my-1 flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground opacity-0 transition-opacity hover:bg-accent/50 hover:text-foreground group-hover/tab-group:opacity-100 focus:opacity-100"
+          >
+            <X className="size-4" />
+          </button>
+        )}
+      </div>
+
+      <div className="relative flex-1 min-h-0 overflow-hidden">
+        {groupTabs
+          .filter((item) => item.contentType === 'terminal')
+          .map((item) => (
+            <TerminalPane
+              key={`${item.entityId}-${runtimeTerminalTabById.get(item.entityId)?.generation ?? 0}`}
+              tabId={item.entityId}
+              worktreeId={worktreeId}
+              cwd={worktree?.path}
+              isActive={
+                isFocused && activeTab?.id === item.id && activeTab.contentType === 'terminal'
+              }
+              // Why: in multi-group splits, the active terminal in each group
+              // must remain visible (display:flex) so the user sees its output,
+              // but only the focused group's terminal should receive keyboard
+              // input. isVisible controls rendering; isActive controls focus.
+              isVisible={activeTab?.id === item.id && activeTab.contentType === 'terminal'}
+              onPtyExit={(ptyId) => {
+                if (consumeSuppressedPtyExit(ptyId)) {
+                  return
+                }
+                handleClose(item.id)
+              }}
+              onCloseTab={() => handleClose(item.id)}
+            />
+          ))}
+
+        {activeTab &&
+          activeTab.contentType !== 'terminal' &&
+          activeTab.contentType !== 'browser' && (
+            <div className="absolute inset-0 flex min-h-0 min-w-0">
+              {/* Why: split groups render editor/browser content inside a
+                  plain relative pane body instead of the legacy flex column in
+                  Terminal.tsx. Anchoring the surface to `absolute inset-0`
+                  recreates the bounded viewport those panes expect, so plain
+                  overflow containers like MarkdownPreview can actually scroll
+                  instead of expanding to content height. */}
+              <Suspense
+                fallback={
+                  <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
+                    Loading editor...
+                  </div>
+                }
+              >
+                <EditorPanel activeFileId={activeTab.entityId} />
+              </Suspense>
+            </div>
+          )}
+
+        {activeBrowserTab && (
+          <div className="absolute inset-0 flex min-h-0 min-w-0">
+            <BrowserPane
+              browserTab={activeBrowserTab}
+              onUpdatePageState={updateBrowserTabPageState}
+              onSetUrl={setBrowserTabUrl}
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
@@ -1,0 +1,141 @@
+import { useCallback, useRef, useState } from 'react'
+import type { TabGroupLayoutNode } from '../../../../shared/types'
+import TabGroupPanel from './TabGroupPanel'
+
+const MIN_RATIO = 0.15
+const MAX_RATIO = 0.85
+
+function ResizeHandle({
+  direction,
+  containerRef,
+  onRatioChange
+}: {
+  direction: 'horizontal' | 'vertical'
+  containerRef: React.RefObject<HTMLDivElement | null>
+  onRatioChange: (ratio: number) => void
+}): React.JSX.Element {
+  const isHorizontal = direction === 'horizontal'
+  const [dragging, setDragging] = useState(false)
+
+  const onPointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      e.preventDefault()
+      const container = containerRef.current
+      if (!container) {
+        return
+      }
+      setDragging(true)
+      const target = e.currentTarget as HTMLElement
+      target.setPointerCapture(e.pointerId)
+
+      const onPointerMove = (ev: PointerEvent): void => {
+        const rect = container.getBoundingClientRect()
+        const ratio = isHorizontal
+          ? (ev.clientX - rect.left) / rect.width
+          : (ev.clientY - rect.top) / rect.height
+        onRatioChange(Math.min(MAX_RATIO, Math.max(MIN_RATIO, ratio)))
+      }
+
+      const onPointerUp = (): void => {
+        setDragging(false)
+        target.releasePointerCapture(e.pointerId)
+        target.removeEventListener('pointermove', onPointerMove)
+        target.removeEventListener('pointerup', onPointerUp)
+      }
+
+      target.addEventListener('pointermove', onPointerMove)
+      target.addEventListener('pointerup', onPointerUp)
+    },
+    [containerRef, isHorizontal, onRatioChange]
+  )
+
+  return (
+    <div
+      className={`shrink-0 ${isHorizontal ? 'w-1 cursor-col-resize' : 'h-1 cursor-row-resize'} ${
+        dragging ? 'bg-accent' : 'bg-border hover:bg-accent/50'
+      }`}
+      onPointerDown={onPointerDown}
+    />
+  )
+}
+
+function SplitNode({
+  node,
+  worktreeId,
+  focusedGroupId,
+  hasSplitGroups
+}: {
+  node: TabGroupLayoutNode
+  worktreeId: string
+  focusedGroupId?: string
+  hasSplitGroups: boolean
+}): React.JSX.Element {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [ratio, setRatio] = useState(0.5)
+
+  if (node.type === 'leaf') {
+    return (
+      <TabGroupPanel
+        groupId={node.groupId}
+        worktreeId={worktreeId}
+        isFocused={node.groupId === focusedGroupId}
+        hasSplitGroups={hasSplitGroups}
+      />
+    )
+  }
+
+  const isHorizontal = node.direction === 'horizontal'
+
+  return (
+    <div
+      ref={containerRef}
+      className="flex flex-1 min-w-0 min-h-0 overflow-hidden"
+      style={{ flexDirection: isHorizontal ? 'row' : 'column' }}
+    >
+      <div className="flex min-w-0 min-h-0 overflow-hidden" style={{ flex: `${ratio} 1 0%` }}>
+        <SplitNode
+          node={node.first}
+          worktreeId={worktreeId}
+          focusedGroupId={focusedGroupId}
+          hasSplitGroups={hasSplitGroups}
+        />
+      </div>
+      <ResizeHandle
+        direction={isHorizontal ? 'horizontal' : 'vertical'}
+        containerRef={containerRef}
+        onRatioChange={setRatio}
+      />
+      <div className="flex min-w-0 min-h-0 overflow-hidden" style={{ flex: `${1 - ratio} 1 0%` }}>
+        <SplitNode
+          node={node.second}
+          worktreeId={worktreeId}
+          focusedGroupId={focusedGroupId}
+          hasSplitGroups={hasSplitGroups}
+        />
+      </div>
+    </div>
+  )
+}
+
+export default function TabGroupSplitLayout({
+  layout,
+  worktreeId,
+  focusedGroupId
+}: {
+  layout: TabGroupLayoutNode
+  worktreeId: string
+  focusedGroupId?: string
+}): React.JSX.Element {
+  const hasSplitGroups = layout.type === 'split'
+
+  return (
+    <div className="flex flex-1 min-w-0 min-h-0 overflow-hidden">
+      <SplitNode
+        node={layout}
+        worktreeId={worktreeId}
+        focusedGroupId={focusedGroupId}
+        hasSplitGroups={hasSplitGroups}
+      />
+    </div>
+  )
+}

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -26,11 +26,7 @@ import { useTerminalPaneLifecycle } from './use-terminal-pane-lifecycle'
 import { useTerminalPaneContextMenu } from './use-terminal-pane-context-menu'
 import { useNotificationDispatch } from './use-notification-dispatch'
 import { connectPanePty } from './pty-connection'
-
-/** Global set of buffer-capture callbacks, one per mounted TerminalPane.
- *  The beforeunload handler in App.tsx invokes every callback to populate
- *  Zustand with serialized buffers before flushing the session to disk. */
-export const shutdownBufferCaptures = new Set<() => void>()
+import { registerTerminalBufferCapture } from './buffer-capture-registry'
 
 const MAX_BUFFER_BYTES = 512 * 1024
 
@@ -39,6 +35,11 @@ type TerminalPaneProps = {
   worktreeId: string
   cwd?: string
   isActive: boolean
+  // Why: in multi-group splits, the active tab in each group must be visible
+  // (display: flex) but only the focused group's terminal should receive
+  // keyboard input. When provided, isVisible controls display independently
+  // of isActive. When omitted, isActive controls both (single-group behavior).
+  isVisible?: boolean
   onPtyExit: (ptyId: string) => void
   onCloseTab: () => void
 }
@@ -48,6 +49,7 @@ export default function TerminalPane({
   worktreeId,
   cwd,
   isActive,
+  isVisible,
   onPtyExit,
   onCloseTab
 }: TerminalPaneProps): React.JSX.Element {
@@ -61,8 +63,11 @@ export default function TerminalPane({
   const paneTransportsRef = useRef<Map<number, PtyTransport>>(new Map())
   const panePtyBindingsRef = useRef<Map<number, IDisposable>>(new Map())
   const pendingWritesRef = useRef<Map<number, string>>(new Map())
+  const effectiveVisible = isVisible ?? isActive
   const isActiveRef = useRef(isActive)
   isActiveRef.current = isActive
+  const effectiveVisibleRef = useRef(effectiveVisible)
+  effectiveVisibleRef.current = effectiveVisible
 
   const [expandedPaneId, setExpandedPaneId] = useState<number | null>(null)
   const [searchOpen, setSearchOpen] = useState(false)
@@ -268,6 +273,7 @@ export default function TerminalPane({
     panePtyBindingsRef,
     pendingWritesRef,
     isActiveRef,
+    effectiveVisibleRef,
     onPtyExitRef,
     onPtyErrorRef,
     clearTabPtyId,
@@ -397,6 +403,7 @@ export default function TerminalPane({
   useTerminalPaneGlobalEffects({
     tabId,
     isActive,
+    isVisible,
     managerRef,
     containerRef,
     paneTransportsRef,
@@ -540,80 +547,85 @@ export default function TerminalPane({
     }
   }, [paneTitles, renamingPaneId])
 
+  const captureTerminalSnapshot = useCallback((): void => {
+    const manager = managerRef.current
+    const container = containerRef.current
+    if (!manager || !container) {
+      return
+    }
+    const panes = manager.getPanes()
+    if (panes.length === 0) {
+      return
+    }
+    // Flush pending background PTY output into terminals before serializing.
+    // terminal.write() is async so some trailing bytes may be lost — best effort.
+    for (const pane of panes) {
+      const pending = pendingWritesRef.current.get(pane.id)
+      if (pending) {
+        pane.terminal.write(pending)
+        pendingWritesRef.current.set(pane.id, '')
+      }
+    }
+    const buffers: Record<string, string> = {}
+    for (const pane of panes) {
+      try {
+        const leafId = paneLeafId(pane.id)
+        let scrollback = pane.terminal.options.scrollback ?? 10_000
+        let serialized = pane.serializeAddon.serialize({ scrollback })
+        // Cap at 512KB — binary search for largest scrollback that fits.
+        if (serialized.length > MAX_BUFFER_BYTES && scrollback > 1) {
+          let lo = 1
+          let hi = scrollback
+          let best = ''
+          while (lo <= hi) {
+            const mid = Math.floor((lo + hi) / 2)
+            const attempt = pane.serializeAddon.serialize({ scrollback: mid })
+            if (attempt.length <= MAX_BUFFER_BYTES) {
+              best = attempt
+              lo = mid + 1
+            } else {
+              hi = mid - 1
+            }
+          }
+          serialized = best
+        }
+        if (serialized.length > 0) {
+          buffers[leafId] = serialized
+        }
+      } catch {
+        // Serialization failure for one pane should not block others.
+      }
+    }
+    const activePaneId = manager.getActivePane()?.id ?? panes[0]?.id ?? null
+    const layout = serializeTerminalLayout(container, activePaneId, expandedPaneIdRef.current)
+    if (Object.keys(buffers).length > 0) {
+      layout.buffersByLeafId = buffers
+    }
+    // Merge pane titles so the snapshot doesn't silently drop them.
+    const titleEntries = panes
+      .filter((p) => paneTitlesRef.current[p.id])
+      .map((p) => [paneLeafId(p.id), paneTitlesRef.current[p.id]] as const)
+    if (titleEntries.length > 0) {
+      layout.titlesByLeafId = Object.fromEntries(titleEntries)
+    }
+    setTabLayout(tabId, layout)
+  }, [setTabLayout, tabId])
+
   // Register a capture callback for shutdown. The beforeunload handler in
   // App.tsx calls all registered callbacks to serialize terminal buffers.
   useEffect(() => {
-    const captureBuffers = (): void => {
-      const manager = managerRef.current
-      const container = containerRef.current
-      if (!manager || !container) {
-        return
-      }
-      const panes = manager.getPanes()
-      if (panes.length === 0) {
-        return
-      }
-      // Flush pending background PTY output into terminals before serializing.
-      // terminal.write() is async so some trailing bytes may be lost — best effort.
-      for (const pane of panes) {
-        const pending = pendingWritesRef.current.get(pane.id)
-        if (pending) {
-          pane.terminal.write(pending)
-          pendingWritesRef.current.set(pane.id, '')
-        }
-      }
-      const buffers: Record<string, string> = {}
-      for (const pane of panes) {
-        try {
-          const leafId = paneLeafId(pane.id)
-          let scrollback = pane.terminal.options.scrollback ?? 10_000
-          let serialized = pane.serializeAddon.serialize({ scrollback })
-          // Cap at 512KB — binary search for largest scrollback that fits.
-          if (serialized.length > MAX_BUFFER_BYTES && scrollback > 1) {
-            let lo = 1
-            let hi = scrollback
-            let best = ''
-            while (lo <= hi) {
-              const mid = Math.floor((lo + hi) / 2)
-              const attempt = pane.serializeAddon.serialize({ scrollback: mid })
-              if (attempt.length <= MAX_BUFFER_BYTES) {
-                best = attempt
-                lo = mid + 1
-              } else {
-                hi = mid - 1
-              }
-            }
-            serialized = best
-          }
-          if (serialized.length > 0) {
-            buffers[leafId] = serialized
-          }
-        } catch {
-          // Serialization failure for one pane should not block others.
-        }
-      }
-      const activePaneId = manager.getActivePane()?.id ?? panes[0]?.id ?? null
-      const layout = serializeTerminalLayout(container, activePaneId, expandedPaneIdRef.current)
-      if (Object.keys(buffers).length > 0) {
-        layout.buffersByLeafId = buffers
-      }
-      // Merge pane titles so the shutdown snapshot doesn't silently drop them.
-      // Why: the old early-return on empty buffers skipped this entirely, which
-      // meant titles were lost on restart when the terminal had no scrollback
-      // content (e.g. fresh pane, cleared screen).
-      const titleEntries = panes
-        .filter((p) => paneTitlesRef.current[p.id])
-        .map((p) => [paneLeafId(p.id), paneTitlesRef.current[p.id]] as const)
-      if (titleEntries.length > 0) {
-        layout.titlesByLeafId = Object.fromEntries(titleEntries)
-      }
-      setTabLayout(tabId, layout)
-    }
-    shutdownBufferCaptures.add(captureBuffers)
+    return registerTerminalBufferCapture(captureTerminalSnapshot)
+  }, [captureTerminalSnapshot])
+
+  useEffect(() => {
     return () => {
-      shutdownBufferCaptures.delete(captureBuffers)
+      // Why: split-group layout changes remount TerminalPane even when the PTY
+      // keeps running. Capture live xterm scrollback here so the next mount can
+      // restore the visible terminal state instead of attaching to the right
+      // shell with an empty viewport.
+      captureTerminalSnapshot()
     }
-  }, [tabId, setTabLayout])
+  }, [captureTerminalSnapshot])
 
   const handleStartRename = useCallback((paneId: number) => {
     setRenameValue(paneTitlesRef.current[paneId] ?? '')
@@ -694,7 +706,7 @@ export default function TerminalPane({
     : null
 
   const terminalContainerStyle: CSSProperties = {
-    display: isActive ? 'flex' : 'none',
+    display: effectiveVisible ? 'flex' : 'none',
     ['--orca-terminal-divider-color' as string]:
       effectiveAppearance?.dividerColor ?? DEFAULT_TERMINAL_DIVIDER_DARK,
     ['--orca-terminal-divider-color-strong' as string]: normalizeColor(
@@ -740,7 +752,7 @@ export default function TerminalPane({
           transport.sendInput(shellEscapePath(filePath))
         }}
       />
-      {terminalError && isActive && (
+      {terminalError && effectiveVisible && (
         <TerminalErrorToast error={terminalError} onDismiss={() => setTerminalError(null)} />
       )}
       {activePane?.container &&

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -331,8 +331,12 @@ export default function TerminalPane({
         paneTransportsRef,
         pendingWritesRef,
         isActiveRef,
+        effectiveVisibleRef,
         onPtyExitRef,
         onPtyErrorRef,
+        // Why: Codex restarts create a fresh PTY — there is no prior layout
+        // snapshot to reattach from, so an empty map is correct.
+        restoredPtyIdByPaneId: new Map(),
         clearTabPtyId,
         consumeSuppressedPtyExit: useAppStore.getState().consumeSuppressedPtyExit,
         updateTabTitle,

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -608,6 +608,19 @@ export default function TerminalPane({
     if (titleEntries.length > 0) {
       layout.titlesByLeafId = Object.fromEntries(titleEntries)
     }
+    // Why: multi-pane terminals each have their own PTY, but the tab only
+    // stores the last pane's ptyId. Capture per-leaf PTY IDs so each pane
+    // can re-attach to its own shell after a layout-only remount instead
+    // of all panes racing onto the single tab-level ptyId.
+    const ptyIdEntries = panes
+      .map((p) => {
+        const ptyId = paneTransportsRef.current.get(p.id)?.getPtyId()
+        return ptyId ? ([paneLeafId(p.id), ptyId] as const) : null
+      })
+      .filter((entry): entry is readonly [string, string] => entry !== null)
+    if (ptyIdEntries.length > 0) {
+      layout.ptyIdsByLeafId = Object.fromEntries(ptyIdEntries)
+    }
     setTabLayout(tabId, layout)
   }, [setTabLayout, tabId])
 

--- a/src/renderer/src/components/terminal-pane/buffer-capture-registry.ts
+++ b/src/renderer/src/components/terminal-pane/buffer-capture-registry.ts
@@ -1,0 +1,20 @@
+const terminalBufferCaptures = new Set<() => void>()
+
+export function registerTerminalBufferCapture(capture: () => void): () => void {
+  terminalBufferCaptures.add(capture)
+  return () => {
+    terminalBufferCaptures.delete(capture)
+  }
+}
+
+export function captureAllTerminalBuffers(): void {
+  for (const capture of terminalBufferCaptures) {
+    try {
+      capture()
+    } catch {
+      // Why: split-layout transitions should still proceed even if one pane's
+      // buffer snapshot fails. Best-effort capture is enough to keep the rest
+      // of the workspace stable.
+    }
+  }
+}

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -4,7 +4,7 @@ import { isGeminiTerminalTitle, isClaudeAgent } from '@/lib/agent-status'
 import { scheduleRuntimeGraphSync } from '@/runtime/sync-runtime-graph'
 import { useAppStore } from '@/store'
 import type { PtyTransport } from './pty-transport'
-import { createIpcPtyTransport } from './pty-transport'
+import { createIpcPtyTransport, getEagerPtyBufferHandle } from './pty-transport'
 import { shouldSeedCacheTimerOnInitialTitle } from './cache-timer-seeding'
 
 type PtyConnectionDeps = {
@@ -18,6 +18,11 @@ type PtyConnectionDeps = {
   effectiveVisibleRef: React.RefObject<boolean>
   onPtyExitRef: React.RefObject<(ptyId: string) => void>
   onPtyErrorRef?: React.RefObject<(paneId: number, message: string) => void>
+  /** Per-pane PTY IDs restored from a layout snapshot. Populated by the
+   *  lifecycle hook after `replayTerminalLayout` maps old leaf IDs to new
+   *  pane IDs — consumed inside the deferred rAF to re-attach each pane
+   *  to its own shell instead of all panes racing onto the single tab-level ptyId. */
+  restoredPtyIdByPaneId: Map<number, string>
   clearTabPtyId: (tabId: string, ptyId: string) => void
   consumeSuppressedPtyExit: (ptyId: string) => boolean
   updateTabTitle: (tabId: string, title: string) => void
@@ -215,19 +220,31 @@ export function connectPanePty(
       .getState()
       .tabsByWorktree[deps.worktreeId]?.find((t) => t.id === deps.tabId)?.ptyId
 
-    // Why: layout-only remounts (for example creating a new tab group around an
-    // existing terminal) preserve the tab's live PTY in Zustand. Re-attach to
-    // any existing PTY ID here so remounting the UI does not spawn a fresh
-    // shell and wipe the user's in-progress session. The eager-buffer handle is
-    // only needed to replay startup output after full app restore.
-    if (existingPtyId) {
+    // Resolve which PTY to re-attach to, if any. Three cases, in priority order:
+    //
+    // 1. Layout remount — per-pane PTY from snapshot, verified live. The snapshot
+    //    captures per-leaf PTY IDs so each pane re-attaches to its own shell. We
+    //    validate the snapshot ID is still live (present in ptyIdsByTabId) to avoid
+    //    attaching to a stale ID from a previous app session on disk.
+    // 2. Startup reconnect — first pane consumes the eager buffer handle from the
+    //    backend. Only fires on app restore, never on layout remount (live PTYs
+    //    don't have eager handles).
+    // 3. Fallback for single-pane tabs or pre-snapshot-era layouts where no
+    //    per-leaf PTY IDs were captured. The tab-level ptyId is correct when
+    //    there is only one pane.
+    const leafPtyId = deps.restoredPtyIdByPaneId.get(pane.id) ?? null
+    const livePtyIds = new Set(useAppStore.getState().ptyIdsByTabId[deps.tabId] ?? [])
+
+    const reattachPtyId =
+      (leafPtyId && livePtyIds.has(leafPtyId) && leafPtyId) ||
+      (existingPtyId && getEagerPtyBufferHandle(existingPtyId) && existingPtyId) ||
+      (existingPtyId && !leafPtyId && existingPtyId) ||
+      null
+
+    if (reattachPtyId) {
       allowInitialIdleCacheSeed = true
-      // Why: this tab already has a live PTY, either from startup reconnect or
-      // from a layout-only remount that preserved the shell. Attach to it
-      // instead of spawning a duplicate. Startup commands are intentionally
-      // skipped — the PTY was already spawned with a fresh shell.
       transport.attach({
-        existingPtyId,
+        existingPtyId: reattachPtyId,
         cols,
         rows,
         callbacks: {
@@ -236,6 +253,7 @@ export function connectPanePty(
         }
       })
     } else {
+      // Fresh shell — no existing PTY to reattach.
       allowInitialIdleCacheSeed = false
       transport.connect({
         url: '',

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -235,10 +235,18 @@ export function connectPanePty(
     const leafPtyId = deps.restoredPtyIdByPaneId.get(pane.id) ?? null
     const livePtyIds = new Set(useAppStore.getState().ptyIdsByTabId[deps.tabId] ?? [])
 
+    // Why: the tab-level ptyId fallback (case 3) must only fire when this is
+    // the sole pane in the tab. When a user splits a pane (Cmd+D), the new
+    // pane has no leafPtyId but the tab already has a live PTY from the
+    // original pane. Without this guard, attach() replaces the original
+    // pane's data handler in the singleton dispatcher (keyed by ptyId),
+    // causing the original pane to lose output while both panes share one
+    // shell's input — the exact "type in left, appears in right" bug.
+    const isSinglePaneFallback = !leafPtyId && manager.getPanes().length <= 1
     const reattachPtyId =
       (leafPtyId && livePtyIds.has(leafPtyId) && leafPtyId) ||
       (existingPtyId && getEagerPtyBufferHandle(existingPtyId) && existingPtyId) ||
-      (existingPtyId && !leafPtyId && existingPtyId) ||
+      (isSinglePaneFallback && existingPtyId) ||
       null
 
     if (reattachPtyId) {

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -4,7 +4,7 @@ import { isGeminiTerminalTitle, isClaudeAgent } from '@/lib/agent-status'
 import { scheduleRuntimeGraphSync } from '@/runtime/sync-runtime-graph'
 import { useAppStore } from '@/store'
 import type { PtyTransport } from './pty-transport'
-import { createIpcPtyTransport, getEagerPtyBufferHandle } from './pty-transport'
+import { createIpcPtyTransport } from './pty-transport'
 import { shouldSeedCacheTimerOnInitialTitle } from './cache-timer-seeding'
 
 type PtyConnectionDeps = {
@@ -15,6 +15,7 @@ type PtyConnectionDeps = {
   paneTransportsRef: React.RefObject<Map<number, PtyTransport>>
   pendingWritesRef: React.RefObject<Map<number, string>>
   isActiveRef: React.RefObject<boolean>
+  effectiveVisibleRef: React.RefObject<boolean>
   onPtyExitRef: React.RefObject<(ptyId: string) => void>
   onPtyErrorRef?: React.RefObject<(paneId: number, message: string) => void>
   clearTabPtyId: (tabId: string, ptyId: string) => void
@@ -194,7 +195,11 @@ export function connectPanePty(
     }
 
     const dataCallback = (data: string): void => {
-      if (deps.isActiveRef.current) {
+      // Why: in split-group mode, a non-focused group's terminal is visible
+      // (display:flex) but not active (no keyboard focus). PTY output must
+      // still be written to xterm so the user sees content. Only buffer
+      // output when the terminal is truly hidden (e.g., a background tab).
+      if (deps.effectiveVisibleRef.current) {
         pane.terminal.write(data)
       } else {
         const pending = deps.pendingWritesRef.current
@@ -210,17 +215,17 @@ export function connectPanePty(
       .getState()
       .tabsByWorktree[deps.worktreeId]?.find((t) => t.id === deps.tabId)?.ptyId
 
-    // Why: only attach if the eager buffer handle still exists. For split-pane
-    // tabs, replayTerminalLayout calls connectPanePty once per pane. The first
-    // pane consumes the handle via attach(); subsequent panes find no handle
-    // and fall through to connect(), which spawns their own fresh PTYs. Without
-    // this guard, every split pane would try to share the same PTY ID, and the
-    // last one's handler would overwrite the earlier ones' in the dispatcher.
-    if (existingPtyId && getEagerPtyBufferHandle(existingPtyId)) {
+    // Why: layout-only remounts (for example creating a new tab group around an
+    // existing terminal) preserve the tab's live PTY in Zustand. Re-attach to
+    // any existing PTY ID here so remounting the UI does not spawn a fresh
+    // shell and wipe the user's in-progress session. The eager-buffer handle is
+    // only needed to replay startup output after full app restore.
+    if (existingPtyId) {
       allowInitialIdleCacheSeed = true
-      // Why: this tab had a PTY eagerly spawned by reconnectPersistedTerminals().
-      // Attach to it instead of spawning a duplicate. Startup commands are
-      // intentionally skipped — the PTY was already spawned with a fresh shell.
+      // Why: this tab already has a live PTY, either from startup reconnect or
+      // from a layout-only remount that preserved the shell. Attach to it
+      // instead of spawning a duplicate. Startup commands are intentionally
+      // skipped — the PTY was already spawned with a fresh shell.
       transport.attach({
         existingPtyId,
         cols,

--- a/src/renderer/src/components/terminal-pane/pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.ts
@@ -46,6 +46,7 @@ export type PtyTransport = {
   ) => boolean
   isConnected: () => boolean
   getPtyId: () => string | null
+  preserve?: () => void
   destroy?: () => void | Promise<void>
 }
 
@@ -447,6 +448,25 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
         unregisterPtyHandlers(id)
         storedCallbacks.onDisconnect?.()
       }
+    },
+
+    preserve() {
+      if (staleTitleTimer) {
+        clearTimeout(staleTitleTimer)
+        staleTitleTimer = null
+      }
+      if (!ptyId) {
+        destroyed = true
+        connected = false
+        return
+      }
+      const id = ptyId
+      // Why: split-group creation currently remounts TerminalPane while the
+      // underlying terminal tab still exists. We must detach this renderer's
+      // listeners without killing the PTY so the next mount can re-attach to
+      // the same live shell instead of spawning a fresh one and losing work.
+      unregisterPtyHandlers(id)
+      connected = false
     },
 
     sendInput(data: string): boolean {

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.ts
@@ -8,6 +8,9 @@ import type { PtyTransport } from './pty-transport'
 type UseTerminalPaneGlobalEffectsArgs = {
   tabId: string
   isActive: boolean
+  // Why: in multi-group splits, isVisible controls rendering/display while
+  // isActive controls keyboard focus. When not provided, isActive is used.
+  isVisible?: boolean
   managerRef: React.RefObject<PaneManager | null>
   containerRef: React.RefObject<HTMLDivElement | null>
   paneTransportsRef: React.RefObject<Map<number, PtyTransport>>
@@ -19,6 +22,7 @@ type UseTerminalPaneGlobalEffectsArgs = {
 export function useTerminalPaneGlobalEffects({
   tabId,
   isActive,
+  isVisible,
   managerRef,
   containerRef,
   paneTransportsRef,
@@ -26,14 +30,15 @@ export function useTerminalPaneGlobalEffects({
   isActiveRef,
   toggleExpandPane
 }: UseTerminalPaneGlobalEffectsArgs): void {
-  const wasActiveRef = useRef(false)
+  const wasVisibleRef = useRef(false)
 
   useEffect(() => {
+    const effectiveVisible = isVisible ?? isActive
     const manager = managerRef.current
     if (!manager) {
       return
     }
-    if (isActive) {
+    if (effectiveVisible) {
       manager.resumeRendering()
       for (const [paneId, pendingBuffer] of pendingWritesRef.current.entries()) {
         if (pendingBuffer.length > 0) {
@@ -44,14 +49,23 @@ export function useTerminalPaneGlobalEffects({
           pendingWritesRef.current.set(paneId, '')
         }
       }
-      requestAnimationFrame(() => fitAndFocusPanes(manager))
-    } else if (wasActiveRef.current) {
+      // Why: fit all visible panes so they fill their container, but only
+      // focus the terminal when the pane is the keyboard-active one. This
+      // prevents non-focused split groups from stealing xterm focus.
+      requestAnimationFrame(() => {
+        if (isActive) {
+          fitAndFocusPanes(manager)
+        } else {
+          fitPanes(manager)
+        }
+      })
+    } else if (wasVisibleRef.current) {
       manager.suspendRendering()
     }
-    wasActiveRef.current = isActive
+    wasVisibleRef.current = effectiveVisible
     isActiveRef.current = isActive
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isActive])
+  }, [isActive, isVisible])
 
   useEffect(() => {
     const onToggleExpand = (event: Event): void => {

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -192,6 +192,7 @@ export function useTerminalPaneLifecycle({
       worktreeId,
       cwd,
       startup,
+      restoredPtyIdByPaneId: new Map<number, string>(),
       paneTransportsRef,
       pendingWritesRef,
       isActiveRef,
@@ -336,6 +337,22 @@ export function useTerminalPaneLifecycle({
     managerRef.current = manager
     const restoredPaneByLeafId = replayTerminalLayout(manager, initialLayoutRef.current, isActive)
 
+    // Why: populate the per-pane PTY ID map *synchronously* after replay but
+    // before the rAF callbacks in connectPanePty fire. replayTerminalLayout
+    // creates panes (scheduling rAFs for PTY attach), then returns the
+    // old-leafId → new-paneId mapping. We translate the snapshot's
+    // leafId → ptyId entries into paneId → ptyId here so the deferred rAFs
+    // can look up the correct PTY for each pane.
+    const savedPtyIds = initialLayoutRef.current.ptyIdsByLeafId
+    if (savedPtyIds) {
+      for (const [leafId, ptyId] of Object.entries(savedPtyIds)) {
+        const paneId = restoredPaneByLeafId.get(leafId)
+        if (paneId != null) {
+          ptyDeps.restoredPtyIdByPaneId.set(paneId, ptyId)
+        }
+      }
+    }
+
     restoreScrollbackBuffers(
       manager,
       initialLayoutRef.current.buffersByLeafId,
@@ -448,12 +465,15 @@ export function useTerminalPaneLifecycle({
         disposable.dispose()
       }
       linkDisposables.clear()
+      const terminalTabStillExists = (useAppStore.getState().tabsByWorktree[worktreeId] ?? []).some(
+        (tab) => tab.id === tabId
+      )
       for (const transport of paneTransports.values()) {
-        if (transport.getPtyId()) {
-          // Why: split-group layout changes can temporarily unmount the whole
-          // TerminalPane tree even though the tab is still open. Preserve live
-          // PTYs across that renderer remount so opening a neighboring group
-          // does not restart the user's shell or running command.
+        if (terminalTabStillExists && transport.getPtyId()) {
+          // Why: only preserve PTYs when this unmount is a layout-only remount
+          // and the terminal tab still exists in store. Real close paths remove
+          // the tab before React unmounts, so preserving here would leak the
+          // backend shell after the UI tab is gone.
           transport.preserve?.()
         } else {
           transport.destroy?.()

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -50,6 +50,7 @@ type UseTerminalPaneLifecycleDeps = {
   panePtyBindingsRef: React.RefObject<Map<number, IDisposable>>
   pendingWritesRef: React.RefObject<Map<number, string>>
   isActiveRef: React.RefObject<boolean>
+  effectiveVisibleRef: React.RefObject<boolean>
   onPtyExitRef: React.RefObject<(ptyId: string) => void>
   onPtyErrorRef?: React.RefObject<(paneId: number, message: string) => void>
   clearTabPtyId: (tabId: string, ptyId: string) => void
@@ -94,6 +95,7 @@ export function useTerminalPaneLifecycle({
   panePtyBindingsRef,
   pendingWritesRef,
   isActiveRef,
+  effectiveVisibleRef,
   onPtyExitRef,
   onPtyErrorRef,
   clearTabPtyId,
@@ -193,6 +195,7 @@ export function useTerminalPaneLifecycle({
       paneTransportsRef,
       pendingWritesRef,
       isActiveRef,
+      effectiveVisibleRef,
       onPtyExitRef,
       onPtyErrorRef,
       clearTabPtyId,
@@ -446,7 +449,15 @@ export function useTerminalPaneLifecycle({
       }
       linkDisposables.clear()
       for (const transport of paneTransports.values()) {
-        transport.destroy?.()
+        if (transport.getPtyId()) {
+          // Why: split-group layout changes can temporarily unmount the whole
+          // TerminalPane tree even though the tab is still open. Preserve live
+          // PTYs across that renderer remount so opening a neighboring group
+          // does not restart the user's shell or running command.
+          transport.preserve?.()
+        } else {
+          transport.destroy?.()
+        }
       }
       for (const panePtyBinding of panePtyBindings.values()) {
         panePtyBinding.dispose()

--- a/src/renderer/src/lib/workspace-session.ts
+++ b/src/renderer/src/lib/workspace-session.ts
@@ -20,6 +20,10 @@ type WorkspaceSessionSnapshot = Pick<
   | 'activeTabTypeByWorktree'
   | 'browserTabsByWorktree'
   | 'activeBrowserTabIdByWorktree'
+  | 'unifiedTabsByWorktree'
+  | 'groupsByWorktree'
+  | 'layoutByWorktree'
+  | 'activeGroupIdByWorktree'
 >
 
 /** Build the editor-file portion of the workspace session for persistence.
@@ -87,6 +91,12 @@ export function buildWorkspaceSessionPayload(
     // field silently disables eager terminal reconnect on the next restart.
     activeWorktreeIdsOnShutdown,
     activeTabIdByWorktree: snapshot.activeTabIdByWorktree,
+    // Why: the unified tab/group model is persisted alongside legacy fields so
+    // builds with TabGroupSplitLayout can restore group layouts on restart.
+    unifiedTabs: snapshot.unifiedTabsByWorktree,
+    tabGroups: snapshot.groupsByWorktree,
+    tabGroupLayouts: snapshot.layoutByWorktree,
+    activeGroupIdByWorktree: snapshot.activeGroupIdByWorktree,
     ...buildEditorSessionData(
       snapshot.openFiles,
       snapshot.activeFileIdByWorktree,

--- a/src/renderer/src/store/slices/browser.ts
+++ b/src/renderer/src/store/slices/browser.ts
@@ -152,10 +152,22 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
           : s.pendingAddressBarFocusByTabId
       }
     })
+    // Why: wire browser tabs into the unified tab group system so they appear
+    // in each group's tab bar and can live alongside terminals and editors,
+    // matching the pattern terminals use (see createTab in terminals.ts).
+    const state = get()
+    const targetGroupId =
+      state.activeGroupIdByWorktree[worktreeId] ?? state.groupsByWorktree[worktreeId]?.[0]?.id
+    if (targetGroupId && !state.findTabForEntityInGroup(worktreeId, targetGroupId, id, 'browser')) {
+      state.createUnifiedTab(worktreeId, 'browser', {
+        entityId: id,
+        label: options?.title ?? normalizedUrl
+      })
+    }
     return browserTab
   },
 
-  closeBrowserTab: (tabId) =>
+  closeBrowserTab: (tabId) => {
     set((s) => {
       let owningWorktreeId: string | null = null
       const nextBrowserTabsByWorktree: Record<string, BrowserTab[]> = {}
@@ -205,7 +217,6 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
           nextActiveTabType = fallbackTabType
         }
       }
-
       return {
         browserTabsByWorktree: nextBrowserTabsByWorktree,
         activeBrowserTabId:
@@ -222,9 +233,20 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
         ),
         activeTabTypeByWorktree: nextActiveTabTypeByWorktree
       }
-    }),
+    })
+    // Why: sync browser tab closure with the unified tab group system so the
+    // group removes the tab from its tab bar and collapses if empty.
+    for (const tabs of Object.values(get().unifiedTabsByWorktree)) {
+      const workspaceItem = tabs.find(
+        (entry) => entry.contentType === 'browser' && entry.entityId === tabId
+      )
+      if (workspaceItem) {
+        get().closeUnifiedTab(workspaceItem.id)
+      }
+    }
+  },
 
-  setActiveBrowserTab: (tabId) =>
+  setActiveBrowserTab: (tabId) => {
     set((s) => {
       const browserTab = Object.values(s.browserTabsByWorktree)
         .flat()
@@ -244,7 +266,15 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
           [browserTab.worktreeId]: 'browser'
         }
       }
-    }),
+    })
+    // Sync with unified tab system — same pattern as setActiveTab in terminals.ts
+    const item = Object.values(get().unifiedTabsByWorktree)
+      .flat()
+      .find((entry) => entry.contentType === 'browser' && entry.entityId === tabId)
+    if (item) {
+      get().activateTab(item.id)
+    }
+  },
 
   consumeAddressBarFocusRequest: (tabId) => {
     if (!get().pendingAddressBarFocusByTabId[tabId]) {
@@ -260,7 +290,7 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
     return true
   },
 
-  updateBrowserTabPageState: (tabId, updates) =>
+  updateBrowserTabPageState: (tabId, updates) => {
     set((s) => ({
       browserTabsByWorktree: Object.fromEntries(
         Object.entries(s.browserTabsByWorktree).map(([worktreeId, tabs]) => [
@@ -281,7 +311,17 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
           )
         ])
       )
-    })),
+    }))
+    // Keep unified tab label in sync with browser page title
+    if (updates.title) {
+      const item = Object.values(get().unifiedTabsByWorktree)
+        .flat()
+        .find((entry) => entry.contentType === 'browser' && entry.entityId === tabId)
+      if (item) {
+        get().setTabLabel(item.id, updates.title)
+      }
+    }
+  },
 
   setBrowserTabUrl: (tabId, url) =>
     set((s) => ({
@@ -302,7 +342,7 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
       )
     })),
 
-  hydrateBrowserSession: (session) =>
+  hydrateBrowserSession: (session) => {
     set((s) => {
       const persistedTabsByWorktree = session.browserTabsByWorktree ?? {}
       const persistedActiveBrowserTabIdByWorktree = session.activeBrowserTabIdByWorktree ?? {}
@@ -412,4 +452,22 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
         activeTabType
       }
     })
+    // Why: sessions saved before browser tabs were integrated into the unified
+    // tab group system won't have browser entries in unifiedTabs. Create them
+    // now so existing browser tabs appear in group tab bars after upgrade.
+    const state = get()
+    for (const [worktreeId, browserTabs] of Object.entries(state.browserTabsByWorktree)) {
+      for (const bt of browserTabs) {
+        const exists = (state.unifiedTabsByWorktree[worktreeId] ?? []).some(
+          (t) => t.contentType === 'browser' && t.entityId === bt.id
+        )
+        if (!exists) {
+          state.createUnifiedTab(worktreeId, 'browser', {
+            entityId: bt.id,
+            label: bt.title
+          })
+        }
+      }
+    }
+  }
 })

--- a/src/renderer/src/store/slices/editor.test.ts
+++ b/src/renderer/src/store/slices/editor.test.ts
@@ -3,6 +3,7 @@
 import { createStore, type StoreApi } from 'zustand/vanilla'
 import { describe, expect, it } from 'vitest'
 import { createEditorSlice } from './editor'
+import { createTabsSlice } from './tabs'
 import type { AppState } from '../types'
 
 function createEditorStore(): StoreApi<AppState> {
@@ -13,6 +14,7 @@ function createEditorStore(): StoreApi<AppState> {
     browserTabsByWorktree: {},
     activeBrowserTabId: null,
     activeBrowserTabIdByWorktree: {},
+    ...createTabsSlice(...(args as Parameters<typeof createTabsSlice>)),
     ...createEditorSlice(...(args as Parameters<typeof createEditorSlice>))
   })) as unknown as StoreApi<AppState>
 }
@@ -127,6 +129,129 @@ describe('createEditorSlice markdown view state', () => {
         isPreview: true
       })
     ])
+  })
+
+  it('replaces preview tabs only inside the active split group', () => {
+    const store = createEditorStore()
+
+    store.getState().openFile(
+      {
+        filePath: '/repo/docs/README.md',
+        relativePath: 'docs/README.md',
+        worktreeId: 'wt-1',
+        language: 'markdown',
+        mode: 'edit'
+      },
+      { preview: true }
+    )
+
+    const originalPreview = store
+      .getState()
+      .unifiedTabsByWorktree['wt-1'].find((tab) => tab.entityId === '/repo/docs/README.md')
+    expect(originalPreview).toBeTruthy()
+
+    const splitGroupId = store
+      .getState()
+      .createEmptySplitGroup('wt-1', originalPreview!.groupId, 'right')
+    expect(splitGroupId).toBeTruthy()
+
+    store.getState().openFile(
+      {
+        filePath: '/repo/docs/guide.md',
+        relativePath: 'docs/guide.md',
+        worktreeId: 'wt-1',
+        language: 'markdown',
+        mode: 'edit'
+      },
+      { preview: true }
+    )
+
+    let tabs = store.getState().unifiedTabsByWorktree['wt-1']
+    expect(
+      tabs.find(
+        (tab) => tab.groupId === originalPreview!.groupId && tab.entityId === '/repo/docs/README.md'
+      )
+    ).toBeTruthy()
+    expect(
+      tabs.find((tab) => tab.groupId === splitGroupId && tab.entityId === '/repo/docs/guide.md')
+    ).toBeTruthy()
+    expect(
+      store
+        .getState()
+        .openFiles.map((file) => file.id)
+        .sort()
+    ).toEqual(['/repo/docs/README.md', '/repo/docs/guide.md'])
+
+    store.getState().openFile(
+      {
+        filePath: '/repo/docs/tutorial.md',
+        relativePath: 'docs/tutorial.md',
+        worktreeId: 'wt-1',
+        language: 'markdown',
+        mode: 'edit'
+      },
+      { preview: true }
+    )
+
+    tabs = store.getState().unifiedTabsByWorktree['wt-1']
+    expect(
+      tabs.find(
+        (tab) => tab.groupId === originalPreview!.groupId && tab.entityId === '/repo/docs/README.md'
+      )
+    ).toBeTruthy()
+    expect(
+      tabs.find((tab) => tab.groupId === splitGroupId && tab.entityId === '/repo/docs/guide.md')
+    ).toBeFalsy()
+    expect(
+      tabs.find((tab) => tab.groupId === splitGroupId && tab.entityId === '/repo/docs/tutorial.md')
+    ).toBeTruthy()
+    expect(
+      store
+        .getState()
+        .openFiles.map((file) => file.id)
+        .sort()
+    ).toEqual(['/repo/docs/README.md', '/repo/docs/tutorial.md'])
+  })
+})
+
+describe('createEditorSlice pinFile', () => {
+  it('pins only the targeted split-tab instance for a shared file', () => {
+    const store = createEditorStore()
+
+    const original = store.getState().createUnifiedTab('wt-1', 'editor', {
+      entityId: '/repo/docs/README.md',
+      label: 'docs/README.md',
+      isPreview: true
+    })
+    const splitGroupId = store.getState().createEmptySplitGroup('wt-1', original.groupId, 'right')
+    expect(splitGroupId).toBeTruthy()
+    const duplicate = store.getState().createUnifiedTab('wt-1', 'editor', {
+      entityId: '/repo/docs/README.md',
+      label: 'docs/README.md',
+      isPreview: true,
+      targetGroupId: splitGroupId ?? undefined
+    })
+
+    store.setState({
+      openFiles: [
+        {
+          id: '/repo/docs/README.md',
+          filePath: '/repo/docs/README.md',
+          relativePath: 'docs/README.md',
+          worktreeId: 'wt-1',
+          language: 'markdown',
+          isDirty: false,
+          mode: 'edit',
+          isPreview: true
+        }
+      ]
+    })
+
+    store.getState().pinFile('/repo/docs/README.md', duplicate.id)
+
+    const tabs = store.getState().unifiedTabsByWorktree['wt-1']
+    expect(tabs.find((tab) => tab.id === original.id)?.isPinned).not.toBe(true)
+    expect(tabs.find((tab) => tab.id === duplicate.id)?.isPinned).toBe(true)
   })
 })
 

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -146,7 +146,7 @@ export type EditorSlice = {
   activeTabType: WorkspaceVisibleTabType
   setActiveTabType: (type: WorkspaceVisibleTabType) => void
   openFile: (file: Omit<OpenFile, 'id' | 'isDirty'>, options?: { preview?: boolean }) => void
-  pinFile: (fileId: string) => void
+  pinFile: (fileId: string, tabId?: string) => void
   closeFile: (fileId: string) => void
   closeAllFiles: () => void
   setActiveFile: (fileId: string) => void
@@ -251,7 +251,39 @@ export type EditorSlice = {
   hydrateEditorSession: (session: WorkspaceSessionState) => void
 }
 
-export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (set) => ({
+function openWorkspaceEditorItem(
+  state: AppState,
+  fileId: string,
+  worktreeId: string,
+  label: string,
+  contentType: 'editor' | 'diff' | 'conflict-review',
+  isPreview?: boolean
+): string {
+  const activeGroupIdByWorktree = state.activeGroupIdByWorktree ?? {}
+  const groupsByWorktree = state.groupsByWorktree ?? {}
+  const targetGroupId =
+    activeGroupIdByWorktree[worktreeId] ?? groupsByWorktree[worktreeId]?.[0]?.id ?? ''
+  if (!state.findTabForEntityInGroup || !state.createUnifiedTab || !state.activateTab) {
+    return fileId
+  }
+  const existing = state.findTabForEntityInGroup(worktreeId, targetGroupId, fileId, contentType)
+  if (existing) {
+    state.activateTab(existing.id)
+    return existing.id
+  }
+  return state.createUnifiedTab(worktreeId, contentType, {
+    entityId: fileId,
+    label,
+    isPreview,
+    targetGroupId
+  }).id
+}
+
+function isEditorWorkspaceItemContentType(contentType: string): boolean {
+  return contentType === 'editor' || contentType === 'diff' || contentType === 'conflict-review'
+}
+
+export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (set, get) => ({
   editorDrafts: {},
   setEditorDraft: (fileId, content) =>
     set((s) => ({
@@ -339,7 +371,21 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
       }
     }),
 
-  openFile: (file, options) =>
+  openFile: (file, options) => {
+    const stateBeforeOpen = get()
+    const activeGroupIdByWorktree = stateBeforeOpen.activeGroupIdByWorktree ?? {}
+    const groupsByWorktree = stateBeforeOpen.groupsByWorktree ?? {}
+    const unifiedTabsByWorktree = stateBeforeOpen.unifiedTabsByWorktree ?? {}
+    const targetGroupId =
+      activeGroupIdByWorktree[file.worktreeId] ?? groupsByWorktree[file.worktreeId]?.[0]?.id ?? null
+    const replacedPreviewEntityId =
+      options?.preview && targetGroupId
+        ? ((unifiedTabsByWorktree[file.worktreeId] ?? []).find(
+            (item) =>
+              item.groupId === targetGroupId && item.contentType === 'editor' && item.isPreview
+          )?.entityId ?? null)
+        : null
+
     set((s) => {
       const id = file.filePath
       const existing = s.openFiles.find((f) => f.id === id)
@@ -390,52 +436,6 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
         }
       }
 
-      // If opening as preview, replace the existing preview tab for this worktree
-      let newFiles = s.openFiles
-      if (isPreview) {
-        const existingPreviewIdx = s.openFiles.findIndex(
-          (f) => f.worktreeId === worktreeId && f.isPreview
-        )
-        if (existingPreviewIdx !== -1) {
-          const replacedPreview = s.openFiles[existingPreviewIdx]
-          const nextEditorDrafts =
-            replacedPreview.id === id
-              ? s.editorDrafts
-              : Object.fromEntries(
-                  Object.entries(s.editorDrafts).filter(([fileId]) => fileId !== replacedPreview.id)
-                )
-          const nextMarkdownViewMode =
-            replacedPreview.id === id
-              ? s.markdownViewMode
-              : Object.fromEntries(
-                  Object.entries(s.markdownViewMode).filter(
-                    ([fileId]) => fileId !== replacedPreview.id
-                  )
-                )
-          // Replace in-place to preserve tab position
-          newFiles = s.openFiles.map((f, i) =>
-            i === existingPreviewIdx ? { ...file, id, isDirty: false, isPreview: true } : f
-          )
-          // Swap the old preview ID for the new one in the stored tab bar order
-          const prevOrder = s.tabBarOrderByWorktree?.[worktreeId]
-          const previewTabBarUpdate = prevOrder
-            ? {
-                tabBarOrderByWorktree: {
-                  ...s.tabBarOrderByWorktree,
-                  [worktreeId]: prevOrder.map((eid) => (eid === replacedPreview.id ? id : eid))
-                }
-              }
-            : {}
-          return {
-            openFiles: newFiles,
-            editorDrafts: nextEditorDrafts,
-            markdownViewMode: nextMarkdownViewMode,
-            ...previewTabBarUpdate,
-            ...activeResult
-          }
-        }
-      }
-
       // Why: append the new file to the persisted tab bar order so it appears
       // at the end of the tab bar. Without this, reconcileOrder in TabBar
       // falls back to type-grouped ordering (terminals first) when the stored
@@ -456,21 +456,70 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
             inBase.add(eid)
           }
         }
-        base.push(id)
+        // Why: preview replacement is scoped to the active split group, not the
+        // whole worktree. When a group's preview swaps from file A to file B,
+        // update the legacy tab-bar order in place so single-group mode keeps
+        // the tab position stable without deleting unrelated editor state.
+        if (isPreview && replacedPreviewEntityId && replacedPreviewEntityId !== id) {
+          const replacedIndex = base.indexOf(replacedPreviewEntityId)
+          if (replacedIndex !== -1) {
+            base[replacedIndex] = id
+          } else {
+            base.push(id)
+          }
+        } else {
+          base.push(id)
+        }
         tabBarUpdate.tabBarOrderByWorktree = { ...s.tabBarOrderByWorktree, [worktreeId]: base }
       }
 
       return {
         openFiles: [
-          ...newFiles,
+          ...s.openFiles,
           { ...file, id, isDirty: false, isPreview: isPreview || undefined }
         ],
         ...tabBarUpdate,
         ...activeResult
       }
-    }),
+    })
+    const stateAfterSet = get()
+    const hasTabsSlice =
+      Boolean(stateAfterSet.findTabForEntityInGroup) &&
+      Boolean(stateAfterSet.createUnifiedTab) &&
+      Boolean(stateAfterSet.activateTab)
+    if (hasTabsSlice) {
+      void openWorkspaceEditorItem(
+        stateAfterSet,
+        file.filePath,
+        file.worktreeId,
+        file.relativePath,
+        file.mode === 'conflict-review'
+          ? 'conflict-review'
+          : file.mode === 'diff'
+            ? 'diff'
+            : 'editor',
+        options?.preview ?? false
+      )
+    }
+    if (hasTabsSlice && replacedPreviewEntityId && replacedPreviewEntityId !== file.filePath) {
+      const stateAfterOpen = get()
+      const stillReferenced = Object.values(stateAfterOpen.unifiedTabsByWorktree ?? {})
+        .flat()
+        .some(
+          (item) =>
+            item.entityId === replacedPreviewEntityId &&
+            isEditorWorkspaceItemContentType(item.contentType)
+        )
+      // Why: preview replacement now happens per split group in unifiedTabs.
+      // Only drop the backing OpenFile when no editor workspace item still
+      // references that document, otherwise another group would lose its tab.
+      if (!stillReferenced) {
+        stateAfterOpen.closeFile(replacedPreviewEntityId)
+      }
+    }
+  },
 
-  pinFile: (fileId) =>
+  pinFile: (fileId, tabId) => {
     set((s) => {
       const file = s.openFiles.find((f) => f.id === fileId)
       if (!file?.isPreview) {
@@ -479,7 +528,19 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
       return {
         openFiles: s.openFiles.map((f) => (f.id === fileId ? { ...f, isPreview: undefined } : f))
       }
-    }),
+    })
+    const state = get()
+    for (const tabs of Object.values(state.unifiedTabsByWorktree ?? {})) {
+      for (const item of tabs) {
+        // Why: split groups can show the same document in multiple tab instances.
+        // Pinning should only affect the tab instance the user acted on, not
+        // every other group that happens to reference the same file.
+        if (item.entityId === fileId && (!tabId || item.id === tabId)) {
+          state.pinTab(item.id)
+        }
+      }
+    }
+  },
 
   // Why: closing a tab does NOT clear Resolved locally state. If the file is
   // still present in Changes or Staged Changes, the continuity badge should
@@ -567,7 +628,19 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
       }
     }),
 
-  closeAllFiles: () =>
+  closeAllFiles: () => {
+    const state = get()
+    const activeWorktreeId = state.activeWorktreeId
+    const closingItemIds = Object.values(state.unifiedTabsByWorktree ?? {})
+      .flat()
+      .filter(
+        (item) =>
+          (item.contentType === 'editor' ||
+            item.contentType === 'diff' ||
+            item.contentType === 'conflict-review') &&
+          (!activeWorktreeId || item.worktreeId === activeWorktreeId)
+      )
+      .map((item) => item.id)
     set((s) => {
       const activeWorktreeId = s.activeWorktreeId
       if (!activeWorktreeId) {
@@ -615,9 +688,13 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
         // to an old match unexpectedly.
         pendingEditorReveal: null
       }
-    }),
+    })
+    for (const itemId of closingItemIds) {
+      get().closeUnifiedTab?.(itemId)
+    }
+  },
 
-  setActiveFile: (fileId) =>
+  setActiveFile: (fileId) => {
     set((s) => {
       const file = s.openFiles.find((f) => f.id === fileId)
       const worktreeId = file?.worktreeId
@@ -627,7 +704,26 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
           ? { ...s.activeFileIdByWorktree, [worktreeId]: fileId }
           : s.activeFileIdByWorktree
       }
-    }),
+    })
+    const state = get()
+    const worktreeId = state.activeWorktreeId
+    if (!worktreeId) {
+      return
+    }
+    const groupId =
+      (state.activeGroupIdByWorktree ?? {})[worktreeId] ??
+      (state.groupsByWorktree ?? {})[worktreeId]?.[0]?.id
+    if (!groupId) {
+      return
+    }
+    const item =
+      state.findTabForEntityInGroup(worktreeId, groupId, fileId, 'editor') ??
+      state.findTabForEntityInGroup(worktreeId, groupId, fileId, 'diff') ??
+      state.findTabForEntityInGroup(worktreeId, groupId, fileId, 'conflict-review')
+    if (item && state.activateTab) {
+      state.activateTab(item.id)
+    }
+  },
 
   reorderFiles: (fileIds) =>
     set((s) => {
@@ -656,7 +752,7 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
       )
     })),
 
-  openDiff: (worktreeId, filePath, relativePath, language, staged) =>
+  openDiff: (worktreeId, filePath, relativePath, language, staged) => {
     set((s) => {
       const diffSource: DiffSource = staged ? 'staged' : 'unstaged'
       const id = `${worktreeId}::diff::${diffSource}::${relativePath}`
@@ -704,12 +800,21 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
         activeFileIdByWorktree: { ...s.activeFileIdByWorktree, [worktreeId]: id },
         activeTabTypeByWorktree: { ...s.activeTabTypeByWorktree, [worktreeId]: 'editor' }
       }
-    }),
+    })
+    openWorkspaceEditorItem(
+      get(),
+      `${worktreeId}::diff::${staged ? 'staged' : 'unstaged'}::${relativePath}`,
+      worktreeId,
+      relativePath,
+      'diff'
+    )
+  },
 
-  openBranchDiff: (worktreeId, worktreePath, entry, compare, language) =>
+  openBranchDiff: (worktreeId, worktreePath, entry, compare, language) => {
+    const branchCompare = toBranchCompareSnapshot(compare)
+    const itemEntityId = `${worktreeId}::diff::branch::${compare.baseRef}::${branchCompare.compareVersion}::${entry.path}`
     set((s) => {
-      const branchCompare = toBranchCompareSnapshot(compare)
-      const id = `${worktreeId}::diff::branch::${compare.baseRef}::${branchCompare.compareVersion}::${entry.path}`
+      const id = itemEntityId
       const existing = s.openFiles.find((f) => f.id === id)
       if (existing) {
         return {
@@ -755,9 +860,11 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
         activeFileIdByWorktree: { ...s.activeFileIdByWorktree, [worktreeId]: id },
         activeTabTypeByWorktree: { ...s.activeTabTypeByWorktree, [worktreeId]: 'editor' }
       }
-    }),
+    })
+    openWorkspaceEditorItem(get(), itemEntityId, worktreeId, entry.path, 'diff')
+  },
 
-  openAllDiffs: (worktreeId, worktreePath, alternate, areaFilter) =>
+  openAllDiffs: (worktreeId, worktreePath, alternate, areaFilter) => {
     set((s) => {
       const relevantEntries = (s.gitStatusByWorktree[worktreeId] ?? []).filter((entry) => {
         if (areaFilter) {
@@ -819,9 +926,23 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
         activeFileIdByWorktree: { ...s.activeFileIdByWorktree, [worktreeId]: id },
         activeTabTypeByWorktree: { ...s.activeTabTypeByWorktree, [worktreeId]: 'editor' }
       }
-    }),
+    })
+    openWorkspaceEditorItem(
+      get(),
+      areaFilter
+        ? `${worktreeId}::all-diffs::uncommitted::${areaFilter}`
+        : `${worktreeId}::all-diffs::uncommitted`,
+      worktreeId,
+      areaFilter
+        ? ({ staged: 'Staged Changes', unstaged: 'Changes', untracked: 'Untracked Files' }[
+            areaFilter
+          ] ?? 'All Changes')
+        : 'All Changes',
+      'diff'
+    )
+  },
 
-  openConflictFile: (worktreeId, worktreePath, entry, language) =>
+  openConflictFile: (worktreeId, worktreePath, entry, language) => {
     set((s) => {
       const absolutePath = joinPath(worktreePath, entry.path)
       const id = absolutePath
@@ -889,14 +1010,22 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
             ? s.trackedConflictPathsByWorktree
             : { ...s.trackedConflictPathsByWorktree, [worktreeId]: nextTracked }
       }
-    }),
+    })
+    openWorkspaceEditorItem(
+      get(),
+      joinPath(worktreePath, entry.path),
+      worktreeId,
+      entry.path,
+      'editor'
+    )
+  },
 
   // Why: Review conflicts is launched from Source Control into the editor area,
   // not from Checks. Merge-conflict review is source-control work, not CI/PR
   // status. The tab renders from a stored snapshot (entries + timestamp), not
   // from live status on every paint, so the list is stable even if the live
   // unresolved set changes between polls.
-  openConflictReview: (worktreeId, worktreePath, entries, source) =>
+  openConflictReview: (worktreeId, worktreePath, entries, source) => {
     set((s) => {
       const id = `${worktreeId}::conflict-review`
       const conflictReview: ConflictReviewState = {
@@ -947,11 +1076,19 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
         activeFileIdByWorktree: { ...s.activeFileIdByWorktree, [worktreeId]: id },
         activeTabTypeByWorktree: { ...s.activeTabTypeByWorktree, [worktreeId]: 'editor' }
       }
-    }),
+    })
+    openWorkspaceEditorItem(
+      get(),
+      `${worktreeId}::conflict-review`,
+      worktreeId,
+      'Conflict Review',
+      'conflict-review'
+    )
+  },
 
-  openBranchAllDiffs: (worktreeId, worktreePath, compare, alternate) =>
+  openBranchAllDiffs: (worktreeId, worktreePath, compare, alternate) => {
+    const branchCompare = toBranchCompareSnapshot(compare)
     set((s) => {
-      const branchCompare = toBranchCompareSnapshot(compare)
       const branchEntriesSnapshot = s.gitBranchChangesByWorktree[worktreeId] ?? []
       const id = `${worktreeId}::all-diffs::branch::${compare.baseRef}::${branchCompare.compareVersion}`
       const existing = s.openFiles.find((f) => f.id === id)
@@ -999,7 +1136,15 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
         activeFileIdByWorktree: { ...s.activeFileIdByWorktree, [worktreeId]: id },
         activeTabTypeByWorktree: { ...s.activeTabTypeByWorktree, [worktreeId]: 'editor' }
       }
-    }),
+    })
+    openWorkspaceEditorItem(
+      get(),
+      `${worktreeId}::all-diffs::branch::${compare.baseRef}::${branchCompare.compareVersion}`,
+      worktreeId,
+      'All Changes',
+      'diff'
+    )
+  },
 
   // Cursor line tracking
   editorCursorLine: {},

--- a/src/renderer/src/store/slices/store-test-helpers.ts
+++ b/src/renderer/src/store/slices/store-test-helpers.ts
@@ -117,6 +117,7 @@ export function makeUnifiedTab(
   overrides: Partial<Tab> & { id: string; worktreeId: string; groupId: string }
 ): Tab {
   return {
+    entityId: overrides.id,
     contentType: 'terminal',
     label: 'Terminal 1',
     customLabel: null,

--- a/src/renderer/src/store/slices/tabs-helpers.test.ts
+++ b/src/renderer/src/store/slices/tabs-helpers.test.ts
@@ -13,6 +13,7 @@ function makeTab(overrides: Partial<Tab> & { id: string; worktreeId: string }): 
   return {
     groupId: 'g1',
     contentType: 'terminal',
+    entityId: overrides.id,
     label: overrides.id,
     customLabel: null,
     color: null,

--- a/src/renderer/src/store/slices/tabs-helpers.ts
+++ b/src/renderer/src/store/slices/tabs-helpers.ts
@@ -1,4 +1,4 @@
-import type { Tab, TabGroup } from '../../../../shared/types'
+import type { Tab, TabContentType, TabGroup, WorkspaceSessionState } from '../../../../shared/types'
 
 export function findTabAndWorktree(
   tabsByWorktree: Record<string, Tab[]>,
@@ -82,6 +82,33 @@ export function pickNeighbor(tabOrder: string[], closingTabId: string): string |
 
 export function updateGroup(groups: TabGroup[], updated: TabGroup): TabGroup[] {
   return groups.map((g) => (g.id === updated.id ? updated : g))
+}
+
+export function isTransientEditorContentType(contentType: TabContentType): boolean {
+  return contentType === 'diff' || contentType === 'conflict-review'
+}
+
+export function getPersistedEditFileIdsByWorktree(
+  session: WorkspaceSessionState
+): Record<string, Set<string>> {
+  return Object.fromEntries(
+    Object.entries(session.openFilesByWorktree ?? {}).map(([worktreeId, files]) => [
+      worktreeId,
+      new Set(files.map((file) => file.filePath))
+    ])
+  )
+}
+
+export function selectHydratedActiveGroupId(
+  groups: TabGroup[],
+  persistedActiveGroupId?: string
+): string | undefined {
+  const preferredGroups = groups.filter((group) => group.tabOrder.length > 0)
+  const candidates = preferredGroups.length > 0 ? preferredGroups : groups
+  if (persistedActiveGroupId && candidates.some((group) => group.id === persistedActiveGroupId)) {
+    return persistedActiveGroupId
+  }
+  return candidates[0]?.id
 }
 
 /**

--- a/src/renderer/src/store/slices/tabs-helpers.ts
+++ b/src/renderer/src/store/slices/tabs-helpers.ts
@@ -13,6 +13,24 @@ export function findTabAndWorktree(
   return null
 }
 
+export function findTabByEntityInGroup(
+  tabsByWorktree: Record<string, Tab[]>,
+  worktreeId: string,
+  groupId: string,
+  entityId: string,
+  contentType?: Tab['contentType']
+): Tab | null {
+  const tabs = tabsByWorktree[worktreeId] ?? []
+  return (
+    tabs.find(
+      (tab) =>
+        tab.groupId === groupId &&
+        tab.entityId === entityId &&
+        (contentType ? tab.contentType === contentType : true)
+    ) ?? null
+  )
+}
+
 export function findGroupForTab(
   groupsByWorktree: Record<string, TabGroup[]>,
   worktreeId: string,
@@ -25,13 +43,16 @@ export function findGroupForTab(
 export function ensureGroup(
   groupsByWorktree: Record<string, TabGroup[]>,
   activeGroupIdByWorktree: Record<string, string>,
-  worktreeId: string
+  worktreeId: string,
+  preferredGroupId?: string
 ): {
   group: TabGroup
   groupsByWorktree: Record<string, TabGroup[]>
   activeGroupIdByWorktree: Record<string, string>
 } {
-  const existing = groupsByWorktree[worktreeId]?.[0]
+  const existing =
+    groupsByWorktree[worktreeId]?.find((group) => group.id === preferredGroupId) ??
+    groupsByWorktree[worktreeId]?.[0]
   if (existing) {
     return { group: existing, groupsByWorktree, activeGroupIdByWorktree }
   }

--- a/src/renderer/src/store/slices/tabs-hydration.test.ts
+++ b/src/renderer/src/store/slices/tabs-hydration.test.ts
@@ -22,6 +22,7 @@ describe('buildHydratedTabState – unified format', () => {
         w1: [
           {
             id: 't1',
+            entityId: 't1',
             groupId: 'g1',
             worktreeId: 'w1',
             contentType: 'terminal',
@@ -33,6 +34,7 @@ describe('buildHydratedTabState – unified format', () => {
           },
           {
             id: 'f1',
+            entityId: 'f1',
             groupId: 'g1',
             worktreeId: 'w1',
             contentType: 'editor',
@@ -62,6 +64,7 @@ describe('buildHydratedTabState – unified format', () => {
         w1: [
           {
             id: 't1',
+            entityId: 't1',
             groupId: 'g1',
             worktreeId: 'w1',
             contentType: 'terminal',
@@ -75,6 +78,7 @@ describe('buildHydratedTabState – unified format', () => {
         w_gone: [
           {
             id: 't2',
+            entityId: 't2',
             groupId: 'g2',
             worktreeId: 'w_gone',
             contentType: 'terminal',
@@ -104,6 +108,7 @@ describe('buildHydratedTabState – unified format', () => {
         w1: [
           {
             id: 't1',
+            entityId: 't1',
             groupId: 'g1',
             worktreeId: 'w1',
             contentType: 'terminal',
@@ -131,6 +136,81 @@ describe('buildHydratedTabState – unified format', () => {
     const group = result.groupsByWorktree.w1[0]
     expect(group.activeTabId).toBeNull()
     expect(group.tabOrder).toEqual(['t1'])
+  })
+
+  it('drops transient editor-like tabs that have no restored backing file state', () => {
+    const session: WorkspaceSessionState = {
+      ...makeBaseSession(),
+      unifiedTabs: {
+        w1: [
+          {
+            id: 'editor-1',
+            entityId: '/repo/src/index.ts',
+            groupId: 'g1',
+            worktreeId: 'w1',
+            contentType: 'editor',
+            label: 'src/index.ts',
+            customLabel: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1
+          },
+          {
+            id: 'diff-1',
+            entityId: 'w1::diff::unstaged::src/index.ts',
+            groupId: 'g1',
+            worktreeId: 'w1',
+            contentType: 'diff',
+            label: 'src/index.ts',
+            customLabel: null,
+            color: null,
+            sortOrder: 1,
+            createdAt: 2
+          },
+          {
+            id: 'conflict-1',
+            entityId: 'w1::conflict-review',
+            groupId: 'g1',
+            worktreeId: 'w1',
+            contentType: 'conflict-review',
+            label: 'Conflict Review',
+            customLabel: null,
+            color: null,
+            sortOrder: 2,
+            createdAt: 3
+          }
+        ]
+      },
+      tabGroups: {
+        w1: [
+          {
+            id: 'g1',
+            worktreeId: 'w1',
+            activeTabId: 'diff-1',
+            tabOrder: ['editor-1', 'diff-1', 'conflict-1']
+          }
+        ]
+      },
+      openFilesByWorktree: {
+        w1: [
+          {
+            filePath: '/repo/src/index.ts',
+            relativePath: 'src/index.ts',
+            worktreeId: 'w1',
+            language: 'typescript'
+          }
+        ]
+      }
+    }
+
+    const result = buildHydratedTabState(session, new Set(['w1']))
+    expect(result.unifiedTabsByWorktree.w1.map((tab) => tab.id)).toEqual(['editor-1'])
+    expect(result.groupsByWorktree.w1[0]).toEqual({
+      id: 'g1',
+      worktreeId: 'w1',
+      activeTabId: null,
+      tabOrder: ['editor-1']
+    })
   })
 })
 

--- a/src/renderer/src/store/slices/tabs-hydration.test.ts
+++ b/src/renderer/src/store/slices/tabs-hydration.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- Why: hydration test suite covers both unified and legacy formats with verbose session fixtures that inflate line count. */
 import { describe, it, expect, vi } from 'vitest'
 import type { WorkspaceSessionState } from '../../../../shared/types'
 import { buildHydratedTabState } from './tabs-hydration'
@@ -134,7 +135,7 @@ describe('buildHydratedTabState – unified format', () => {
 
     const result = buildHydratedTabState(session, new Set(['w1']))
     const group = result.groupsByWorktree.w1[0]
-    expect(group.activeTabId).toBeNull()
+    expect(group.activeTabId).toBe('t1')
     expect(group.tabOrder).toEqual(['t1'])
   })
 
@@ -208,9 +209,63 @@ describe('buildHydratedTabState – unified format', () => {
     expect(result.groupsByWorktree.w1[0]).toEqual({
       id: 'g1',
       worktreeId: 'w1',
-      activeTabId: null,
+      activeTabId: 'editor-1',
       tabOrder: ['editor-1']
     })
+  })
+
+  it('prefers a non-empty restored group when the persisted active group loses all tabs', () => {
+    const session: WorkspaceSessionState = {
+      ...makeBaseSession(),
+      unifiedTabs: {
+        w1: [
+          {
+            id: 'editor-1',
+            entityId: '/repo/src/index.ts',
+            groupId: 'g1',
+            worktreeId: 'w1',
+            contentType: 'editor',
+            label: 'src/index.ts',
+            customLabel: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1
+          },
+          {
+            id: 'diff-1',
+            entityId: 'w1::diff::unstaged::src/index.ts',
+            groupId: 'g2',
+            worktreeId: 'w1',
+            contentType: 'diff',
+            label: 'src/index.ts',
+            customLabel: null,
+            color: null,
+            sortOrder: 1,
+            createdAt: 2
+          }
+        ]
+      },
+      tabGroups: {
+        w1: [
+          { id: 'g1', worktreeId: 'w1', activeTabId: 'editor-1', tabOrder: ['editor-1'] },
+          { id: 'g2', worktreeId: 'w1', activeTabId: 'diff-1', tabOrder: ['diff-1'] }
+        ]
+      },
+      activeGroupIdByWorktree: { w1: 'g2' },
+      openFilesByWorktree: {
+        w1: [
+          {
+            filePath: '/repo/src/index.ts',
+            relativePath: 'src/index.ts',
+            worktreeId: 'w1',
+            language: 'typescript'
+          }
+        ]
+      }
+    }
+
+    const result = buildHydratedTabState(session, new Set(['w1']))
+    expect(result.activeGroupIdByWorktree.w1).toBe('g1')
   })
 })
 

--- a/src/renderer/src/store/slices/tabs-hydration.ts
+++ b/src/renderer/src/store/slices/tabs-hydration.ts
@@ -1,13 +1,14 @@
 import type { Tab, TabGroup, WorkspaceSessionState } from '../../../../shared/types'
+import {
+  getPersistedEditFileIdsByWorktree,
+  isTransientEditorContentType,
+  selectHydratedActiveGroupId
+} from './tabs-helpers'
 
 type HydratedTabState = {
   unifiedTabsByWorktree: Record<string, Tab[]>
   groupsByWorktree: Record<string, TabGroup[]>
   activeGroupIdByWorktree: Record<string, string>
-}
-
-function isTransientEditorContentType(contentType: Tab['contentType']): boolean {
-  return contentType === 'diff' || contentType === 'conflict-review'
 }
 
 function hydrateUnifiedFormat(
@@ -17,12 +18,7 @@ function hydrateUnifiedFormat(
   const tabsByWorktree: Record<string, Tab[]> = {}
   const groupsByWorktree: Record<string, TabGroup[]> = {}
   const activeGroupIdByWorktree: Record<string, string> = {}
-  const persistedEditFileIdsByWorktree = Object.fromEntries(
-    Object.entries(session.openFilesByWorktree ?? {}).map(([worktreeId, files]) => [
-      worktreeId,
-      new Set(files.map((file) => file.filePath))
-    ])
-  )
+  const persistedEditFileIdsByWorktree = getPersistedEditFileIdsByWorktree(session)
 
   for (const [worktreeId, tabs] of Object.entries(session.unifiedTabs!)) {
     if (!validWorktreeIds.has(worktreeId)) {
@@ -56,14 +52,27 @@ function hydrateUnifiedFormat(
     }
 
     const validTabIds = new Set((tabsByWorktree[worktreeId] ?? []).map((t) => t.id))
-    const validatedGroups = groups.map((g) => ({
-      ...g,
-      tabOrder: g.tabOrder.filter((tid) => validTabIds.has(tid)),
-      activeTabId: g.activeTabId && validTabIds.has(g.activeTabId) ? g.activeTabId : null
-    }))
+    const validatedGroups = groups.map((g) => {
+      const tabOrder = g.tabOrder.filter((tid) => validTabIds.has(tid))
+      return {
+        ...g,
+        tabOrder,
+        // Why: restore can drop transient tabs with no backing file state. If
+        // the saved active tab disappears, promote the first surviving tab so
+        // the restored group still shows content immediately.
+        activeTabId:
+          g.activeTabId && validTabIds.has(g.activeTabId) ? g.activeTabId : (tabOrder[0] ?? null)
+      }
+    })
 
     groupsByWorktree[worktreeId] = validatedGroups
-    activeGroupIdByWorktree[worktreeId] = validatedGroups[0].id
+    const activeGroupId = selectHydratedActiveGroupId(
+      validatedGroups,
+      session.activeGroupIdByWorktree?.[worktreeId]
+    )
+    if (activeGroupId) {
+      activeGroupIdByWorktree[worktreeId] = activeGroupId
+    }
   }
 
   return { unifiedTabsByWorktree: tabsByWorktree, groupsByWorktree, activeGroupIdByWorktree }

--- a/src/renderer/src/store/slices/tabs-hydration.ts
+++ b/src/renderer/src/store/slices/tabs-hydration.ts
@@ -6,6 +6,10 @@ type HydratedTabState = {
   activeGroupIdByWorktree: Record<string, string>
 }
 
+function isTransientEditorContentType(contentType: Tab['contentType']): boolean {
+  return contentType === 'diff' || contentType === 'conflict-review'
+}
+
 function hydrateUnifiedFormat(
   session: WorkspaceSessionState,
   validWorktreeIds: Set<string>
@@ -13,6 +17,12 @@ function hydrateUnifiedFormat(
   const tabsByWorktree: Record<string, Tab[]> = {}
   const groupsByWorktree: Record<string, TabGroup[]> = {}
   const activeGroupIdByWorktree: Record<string, string> = {}
+  const persistedEditFileIdsByWorktree = Object.fromEntries(
+    Object.entries(session.openFilesByWorktree ?? {}).map(([worktreeId, files]) => [
+      worktreeId,
+      new Set(files.map((file) => file.filePath))
+    ])
+  )
 
   for (const [worktreeId, tabs] of Object.entries(session.unifiedTabs!)) {
     if (!validWorktreeIds.has(worktreeId)) {
@@ -21,9 +31,20 @@ function hydrateUnifiedFormat(
     if (tabs.length === 0) {
       continue
     }
-    tabsByWorktree[worktreeId] = [...tabs].sort(
-      (a, b) => a.sortOrder - b.sortOrder || a.createdAt - b.createdAt
-    )
+    const persistedEditFileIds = persistedEditFileIdsByWorktree[worktreeId] ?? new Set<string>()
+    tabsByWorktree[worktreeId] = [...tabs]
+      .filter((tab) => {
+        if (!isTransientEditorContentType(tab.contentType)) {
+          return true
+        }
+        // Why: persisted unified tabs can still contain transient diff or
+        // conflict-review entries from pre-fix sessions, but editor hydration
+        // intentionally restores only edit-mode files. Drop those orphaned
+        // editor-like tabs here so restored split groups never point at a pane
+        // with no backing OpenFile state.
+        return persistedEditFileIds.has(tab.entityId ?? tab.id)
+      })
+      .sort((a, b) => a.sortOrder - b.sortOrder || a.createdAt - b.createdAt)
   }
 
   for (const [worktreeId, groups] of Object.entries(session.tabGroups!)) {
@@ -71,6 +92,7 @@ function hydrateLegacyFormat(
     for (const tt of terminalTabs) {
       tabs.push({
         id: tt.id,
+        entityId: tt.id,
         groupId,
         worktreeId,
         contentType: 'terminal',
@@ -88,6 +110,7 @@ function hydrateLegacyFormat(
     for (const ef of editorFiles) {
       tabs.push({
         id: ef.filePath,
+        entityId: ef.filePath,
         groupId,
         worktreeId,
         contentType: 'editor',

--- a/src/renderer/src/store/slices/tabs.test.ts
+++ b/src/renderer/src/store/slices/tabs.test.ts
@@ -644,6 +644,91 @@ describe('TabsSlice', () => {
       expect(state.groupsByWorktree[WT][0].activeTabId).toBe('/file.ts')
     })
 
+    it('prefers a non-empty restored group when the persisted active group loses its tab', () => {
+      store.setState({
+        worktreesByRepo: {
+          repo1: [
+            {
+              id: WT,
+              repoId: 'repo1',
+              path: '/tmp/feature',
+              head: 'abc',
+              branch: 'feature',
+              isBare: false,
+              isMainWorktree: false,
+              displayName: 'feature',
+              comment: '',
+              linkedIssue: null,
+              linkedPR: null,
+              isArchived: false,
+              isUnread: false,
+              sortOrder: 0,
+              lastActivityAt: 0
+            }
+          ]
+        }
+      })
+
+      store.getState().hydrateTabsSession({
+        activeRepoId: 'repo1',
+        activeWorktreeId: WT,
+        activeTabId: null,
+        tabsByWorktree: {},
+        terminalLayoutsByTabId: {},
+        unifiedTabs: {
+          [WT]: [
+            {
+              id: 'editor-1',
+              entityId: '/file.ts',
+              groupId: 'g-1',
+              worktreeId: WT,
+              contentType: 'editor',
+              label: 'file.ts',
+              customLabel: null,
+              color: null,
+              sortOrder: 0,
+              createdAt: 1
+            },
+            {
+              id: 'diff-1',
+              entityId: `${WT}::diff::unstaged::file.ts`,
+              groupId: 'g-2',
+              worktreeId: WT,
+              contentType: 'diff',
+              label: 'file.ts',
+              customLabel: null,
+              color: null,
+              sortOrder: 1,
+              createdAt: 2
+            }
+          ]
+        },
+        tabGroups: {
+          [WT]: [
+            { id: 'g-1', worktreeId: WT, activeTabId: 'editor-1', tabOrder: ['editor-1'] },
+            { id: 'g-2', worktreeId: WT, activeTabId: 'diff-1', tabOrder: ['diff-1'] }
+          ]
+        },
+        activeGroupIdByWorktree: { [WT]: 'g-2' },
+        openFilesByWorktree: {
+          [WT]: [
+            {
+              filePath: '/file.ts',
+              relativePath: 'file.ts',
+              worktreeId: WT,
+              language: 'typescript'
+            }
+          ]
+        }
+      })
+
+      const state = store.getState()
+      expect(state.activeGroupIdByWorktree[WT]).toBe('g-1')
+      expect(state.groupsByWorktree[WT].find((group) => group.id === 'g-1')?.activeTabId).toBe(
+        'editor-1'
+      )
+    })
+
     it('filters out invalid worktree IDs during hydration', () => {
       store.setState({ worktreesByRepo: {} })
 

--- a/src/renderer/src/store/slices/tabs.test.ts
+++ b/src/renderer/src/store/slices/tabs.test.ts
@@ -124,7 +124,7 @@ describe('TabsSlice', () => {
 
   describe('createUnifiedTab', () => {
     it('creates a terminal tab and auto-creates a group', () => {
-      const tab = store.getState().createUnifiedTab(WT, 'terminal')
+      const tab = store.getState().createUnifiedTab(WT, 'terminal', { label: 'Terminal' })
 
       expect(tab.contentType).toBe('terminal')
       expect(tab.worktreeId).toBe(WT)
@@ -149,8 +149,8 @@ describe('TabsSlice', () => {
     })
 
     it('activates the newly created tab', () => {
-      const tab1 = store.getState().createUnifiedTab(WT, 'terminal')
-      const tab2 = store.getState().createUnifiedTab(WT, 'terminal')
+      const tab1 = store.getState().createUnifiedTab(WT, 'terminal', { label: 'Terminal' })
+      const tab2 = store.getState().createUnifiedTab(WT, 'terminal', { label: 'Terminal' })
 
       const group = store.getState().groupsByWorktree[WT][0]
       expect(group.activeTabId).toBe(tab2.id)
@@ -179,7 +179,7 @@ describe('TabsSlice', () => {
     })
 
     it('reuses the existing group for the worktree', () => {
-      store.getState().createUnifiedTab(WT, 'terminal')
+      store.getState().createUnifiedTab(WT, 'terminal', { label: 'Terminal' })
       store.getState().createUnifiedTab(WT, 'editor', { id: 'f.ts', label: 'f.ts' })
 
       expect(store.getState().groupsByWorktree[WT]).toHaveLength(1)
@@ -190,9 +190,9 @@ describe('TabsSlice', () => {
 
   describe('closeUnifiedTab', () => {
     it('removes the tab and selects right neighbor', () => {
-      store.getState().createUnifiedTab(WT, 'terminal')
-      const t2 = store.getState().createUnifiedTab(WT, 'terminal')
-      const t3 = store.getState().createUnifiedTab(WT, 'terminal')
+      store.getState().createUnifiedTab(WT, 'terminal', { label: 'Terminal' })
+      const t2 = store.getState().createUnifiedTab(WT, 'terminal', { label: 'Terminal' })
+      const t3 = store.getState().createUnifiedTab(WT, 'terminal', { label: 'Terminal' })
 
       // Activate t2 so closing it tests neighbor selection
       store.getState().activateTab(t2.id)
@@ -207,8 +207,8 @@ describe('TabsSlice', () => {
     })
 
     it('selects left neighbor when closing the rightmost tab', () => {
-      const t1 = store.getState().createUnifiedTab(WT, 'terminal')
-      const t2 = store.getState().createUnifiedTab(WT, 'terminal')
+      const t1 = store.getState().createUnifiedTab(WT, 'terminal', { label: 'Terminal' })
+      const t2 = store.getState().createUnifiedTab(WT, 'terminal', { label: 'Terminal' })
       // t2 is already active (last created)
 
       const result = store.getState().closeUnifiedTab(t2.id)
@@ -218,19 +218,19 @@ describe('TabsSlice', () => {
     })
 
     it('returns wasLastTab: true when closing the only tab', () => {
-      const t1 = store.getState().createUnifiedTab(WT, 'terminal')
+      const t1 = store.getState().createUnifiedTab(WT, 'terminal', { label: 'Terminal' })
 
       const result = store.getState().closeUnifiedTab(t1.id)
 
       expect(result?.wasLastTab).toBe(true)
       expect(store.getState().unifiedTabsByWorktree[WT]).toHaveLength(0)
-      expect(store.getState().groupsByWorktree[WT][0].activeTabId).toBeNull()
+      expect(store.getState().groupsByWorktree[WT]).toEqual([])
     })
 
     it('does not change active tab when closing a non-active tab', () => {
-      const t1 = store.getState().createUnifiedTab(WT, 'terminal')
-      store.getState().createUnifiedTab(WT, 'terminal')
-      const t3 = store.getState().createUnifiedTab(WT, 'terminal')
+      const t1 = store.getState().createUnifiedTab(WT, 'terminal', { label: 'Terminal' })
+      store.getState().createUnifiedTab(WT, 'terminal', { label: 'Terminal' })
+      const t3 = store.getState().createUnifiedTab(WT, 'terminal', { label: 'Terminal' })
       // t3 is active
 
       store.getState().closeUnifiedTab(t1.id)
@@ -248,8 +248,8 @@ describe('TabsSlice', () => {
 
   describe('activateTab', () => {
     it('sets the active tab on the group', () => {
-      const t1 = store.getState().createUnifiedTab(WT, 'terminal')
-      store.getState().createUnifiedTab(WT, 'terminal')
+      const t1 = store.getState().createUnifiedTab(WT, 'terminal', { label: 'Terminal' })
+      store.getState().createUnifiedTab(WT, 'terminal', { label: 'Terminal' })
 
       store.getState().activateTab(t1.id)
 
@@ -275,9 +275,9 @@ describe('TabsSlice', () => {
 
   describe('reorderUnifiedTabs', () => {
     it('updates tabOrder on the group and sortOrder on tabs', () => {
-      const t1 = store.getState().createUnifiedTab(WT, 'terminal')
-      const t2 = store.getState().createUnifiedTab(WT, 'terminal')
-      const t3 = store.getState().createUnifiedTab(WT, 'terminal')
+      const t1 = store.getState().createUnifiedTab(WT, 'terminal', { label: 'Terminal' })
+      const t2 = store.getState().createUnifiedTab(WT, 'terminal', { label: 'Terminal' })
+      const t3 = store.getState().createUnifiedTab(WT, 'terminal', { label: 'Terminal' })
 
       const groupId = store.getState().groupsByWorktree[WT][0].id
       store.getState().reorderUnifiedTabs(groupId, [t3.id, t1.id, t2.id])
@@ -295,26 +295,26 @@ describe('TabsSlice', () => {
 
   describe('tab property setters', () => {
     it('setTabLabel updates the label', () => {
-      const tab = store.getState().createUnifiedTab(WT, 'terminal')
+      const tab = store.getState().createUnifiedTab(WT, 'terminal', { label: 'Terminal' })
       store.getState().setTabLabel(tab.id, 'zsh')
       expect(store.getState().unifiedTabsByWorktree[WT][0].label).toBe('zsh')
     })
 
     it('setTabCustomLabel updates customLabel', () => {
-      const tab = store.getState().createUnifiedTab(WT, 'terminal')
+      const tab = store.getState().createUnifiedTab(WT, 'terminal', { label: 'Terminal' })
       store.getState().setTabCustomLabel(tab.id, 'my-term')
       expect(store.getState().unifiedTabsByWorktree[WT][0].customLabel).toBe('my-term')
     })
 
     it('setTabCustomLabel clears customLabel with null', () => {
-      const tab = store.getState().createUnifiedTab(WT, 'terminal')
+      const tab = store.getState().createUnifiedTab(WT, 'terminal', { label: 'Terminal' })
       store.getState().setTabCustomLabel(tab.id, 'my-term')
       store.getState().setTabCustomLabel(tab.id, null)
       expect(store.getState().unifiedTabsByWorktree[WT][0].customLabel).toBeNull()
     })
 
     it('setUnifiedTabColor updates color', () => {
-      const tab = store.getState().createUnifiedTab(WT, 'terminal')
+      const tab = store.getState().createUnifiedTab(WT, 'terminal', { label: 'Terminal' })
       store.getState().setUnifiedTabColor(tab.id, '#ff0000')
       expect(store.getState().unifiedTabsByWorktree[WT][0].color).toBe('#ff0000')
     })
@@ -338,7 +338,7 @@ describe('TabsSlice', () => {
     })
 
     it('unpins a tab', () => {
-      const tab = store.getState().createUnifiedTab(WT, 'terminal')
+      const tab = store.getState().createUnifiedTab(WT, 'terminal', { label: 'Terminal' })
       store.getState().pinTab(tab.id)
       store.getState().unpinTab(tab.id)
       expect(store.getState().unifiedTabsByWorktree[WT][0].isPinned).toBe(false)
@@ -349,9 +349,9 @@ describe('TabsSlice', () => {
 
   describe('closeOtherTabs', () => {
     it('closes all tabs except the target and pinned tabs', () => {
-      const t1 = store.getState().createUnifiedTab(WT, 'terminal')
-      const t2 = store.getState().createUnifiedTab(WT, 'terminal')
-      const t3 = store.getState().createUnifiedTab(WT, 'terminal')
+      const t1 = store.getState().createUnifiedTab(WT, 'terminal', { label: 'Terminal' })
+      const t2 = store.getState().createUnifiedTab(WT, 'terminal', { label: 'Terminal' })
+      const t3 = store.getState().createUnifiedTab(WT, 'terminal', { label: 'Terminal' })
 
       store.getState().pinTab(t1.id)
 
@@ -365,8 +365,8 @@ describe('TabsSlice', () => {
     })
 
     it('activates the target tab', () => {
-      const t1 = store.getState().createUnifiedTab(WT, 'terminal')
-      store.getState().createUnifiedTab(WT, 'terminal')
+      const t1 = store.getState().createUnifiedTab(WT, 'terminal', { label: 'Terminal' })
+      store.getState().createUnifiedTab(WT, 'terminal', { label: 'Terminal' })
 
       store.getState().closeOtherTabs(t1.id)
 
@@ -374,7 +374,7 @@ describe('TabsSlice', () => {
     })
 
     it('returns empty when nothing to close', () => {
-      const t1 = store.getState().createUnifiedTab(WT, 'terminal')
+      const t1 = store.getState().createUnifiedTab(WT, 'terminal', { label: 'Terminal' })
       const closed = store.getState().closeOtherTabs(t1.id)
       expect(closed).toEqual([])
     })
@@ -384,10 +384,10 @@ describe('TabsSlice', () => {
 
   describe('closeTabsToRight', () => {
     it('closes unpinned tabs to the right of target', () => {
-      const t1 = store.getState().createUnifiedTab(WT, 'terminal')
-      const t2 = store.getState().createUnifiedTab(WT, 'terminal')
-      const t3 = store.getState().createUnifiedTab(WT, 'terminal')
-      const t4 = store.getState().createUnifiedTab(WT, 'terminal')
+      const t1 = store.getState().createUnifiedTab(WT, 'terminal', { label: 'Terminal' })
+      const t2 = store.getState().createUnifiedTab(WT, 'terminal', { label: 'Terminal' })
+      const t3 = store.getState().createUnifiedTab(WT, 'terminal', { label: 'Terminal' })
+      const t4 = store.getState().createUnifiedTab(WT, 'terminal', { label: 'Terminal' })
 
       store.getState().pinTab(t3.id)
 
@@ -399,8 +399,8 @@ describe('TabsSlice', () => {
     })
 
     it('activates target if active tab was closed', () => {
-      const t1 = store.getState().createUnifiedTab(WT, 'terminal')
-      store.getState().createUnifiedTab(WT, 'terminal')
+      const t1 = store.getState().createUnifiedTab(WT, 'terminal', { label: 'Terminal' })
+      store.getState().createUnifiedTab(WT, 'terminal', { label: 'Terminal' })
       // last created tab is active
 
       store.getState().closeTabsToRight(t1.id)
@@ -413,7 +413,7 @@ describe('TabsSlice', () => {
 
   describe('getActiveTab / getTab', () => {
     it('getActiveTab returns the active tab for a worktree', () => {
-      const t1 = store.getState().createUnifiedTab(WT, 'terminal')
+      const t1 = store.getState().createUnifiedTab(WT, 'terminal', { label: 'Terminal' })
       store.getState().createUnifiedTab(WT, 'editor', { id: 'f.ts', label: 'f.ts' })
 
       store.getState().activateTab(t1.id)
@@ -426,12 +426,55 @@ describe('TabsSlice', () => {
     })
 
     it('getTab finds a tab by id across worktrees', () => {
-      const tab = store.getState().createUnifiedTab(WT, 'terminal')
+      const tab = store.getState().createUnifiedTab(WT, 'terminal', { label: 'Terminal' })
       expect(store.getState().getTab(tab.id)?.id).toBe(tab.id)
     })
 
     it('getTab returns null for unknown id', () => {
       expect(store.getState().getTab('unknown')).toBeNull()
+    })
+  })
+
+  describe('createEmptySplitGroup', () => {
+    it('creates an empty neighboring group and focuses it', () => {
+      const original = store.getState().createUnifiedTab(WT, 'terminal', { label: 'Terminal' })
+
+      const newGroupId = store.getState().createEmptySplitGroup(WT, original.groupId, 'right')
+
+      expect(newGroupId).toBeTruthy()
+      expect(store.getState().activeGroupIdByWorktree[WT]).toBe(newGroupId)
+      expect(store.getState().groupsByWorktree[WT]).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: newGroupId,
+            worktreeId: WT,
+            activeTabId: null,
+            tabOrder: []
+          })
+        ])
+      )
+      expect(store.getState().layoutByWorktree[WT]).toEqual({
+        type: 'split',
+        direction: 'horizontal',
+        first: { type: 'leaf', groupId: original.groupId },
+        second: { type: 'leaf', groupId: newGroupId }
+      })
+    })
+
+    it('closes an empty split group and focuses the remaining sibling', () => {
+      const original = store.getState().createUnifiedTab(WT, 'terminal', { label: 'Terminal' })
+      const newGroupId = store.getState().createEmptySplitGroup(WT, original.groupId, 'right')
+
+      expect(newGroupId).toBeTruthy()
+      expect(store.getState().closeEmptyGroup(WT, newGroupId!)).toBe(true)
+      expect(store.getState().groupsByWorktree[WT]).toEqual([
+        expect.objectContaining({ id: original.groupId })
+      ])
+      expect(store.getState().layoutByWorktree[WT]).toEqual({
+        type: 'leaf',
+        groupId: original.groupId
+      })
+      expect(store.getState().activeGroupIdByWorktree[WT]).toBe(original.groupId)
     })
   })
 
@@ -519,7 +562,7 @@ describe('TabsSlice', () => {
       expect(terminal2?.customLabel).toBe('dev')
       expect(terminal2?.color).toBe('#f00')
 
-      const editor = tabs.find((t) => t.id === '/tmp/feature/src/main.ts')
+      const editor = tabs.find((t) => t.entityId === '/tmp/feature/src/main.ts')
       expect(editor?.contentType).toBe('editor')
       expect(editor?.label).toBe('src/main.ts')
 
@@ -527,7 +570,7 @@ describe('TabsSlice', () => {
       const groups = state.groupsByWorktree[WT]
       expect(groups).toHaveLength(1)
       expect(groups[0].activeTabId).toBe('term-1')
-      expect(groups[0].tabOrder).toEqual(['term-1', 'term-2', '/tmp/feature/src/main.ts'])
+      expect(groups[0].tabOrder).toEqual(['term-1', 'term-2', editor?.id])
     })
 
     it('hydrates from unified format', () => {
@@ -559,6 +602,7 @@ describe('TabsSlice', () => {
       const tabs: Tab[] = [
         {
           id: 't-1',
+          entityId: 't-1',
           groupId,
           worktreeId: WT,
           contentType: 'terminal',
@@ -570,6 +614,7 @@ describe('TabsSlice', () => {
         },
         {
           id: '/file.ts',
+          entityId: '/file.ts',
           groupId,
           worktreeId: WT,
           contentType: 'editor',
@@ -631,7 +676,7 @@ describe('TabsSlice', () => {
 
   describe('cross-content-type neighbor selection', () => {
     it('selects an editor tab as neighbor when closing a terminal tab', () => {
-      const term = store.getState().createUnifiedTab(WT, 'terminal')
+      const term = store.getState().createUnifiedTab(WT, 'terminal', { label: 'Terminal' })
       const editor = store.getState().createUnifiedTab(WT, 'editor', {
         id: 'file.ts',
         label: 'file.ts'
@@ -645,7 +690,7 @@ describe('TabsSlice', () => {
     })
 
     it('selects a terminal tab as neighbor when closing an editor tab', () => {
-      const term = store.getState().createUnifiedTab(WT, 'terminal')
+      const term = store.getState().createUnifiedTab(WT, 'terminal', { label: 'Terminal' })
       const editor = store.getState().createUnifiedTab(WT, 'editor', {
         id: 'file.ts',
         label: 'file.ts'

--- a/src/renderer/src/store/slices/tabs.ts
+++ b/src/renderer/src/store/slices/tabs.ts
@@ -1,32 +1,57 @@
+/* eslint-disable max-lines -- Why: split-tab group state has to update layout, per-group focus, tab membership, and session hydration atomically. Keeping those transitions in one slice avoids split-brain behavior between the workspace item model and the legacy content slices. */
 import type { StateCreator } from 'zustand'
 import type { AppState } from '../types'
-import type { Tab, TabGroup, TabContentType, WorkspaceSessionState } from '../../../../shared/types'
+import type {
+  Tab,
+  TabContentType,
+  TabGroup,
+  TabGroupLayoutNode,
+  WorkspaceSessionState
+} from '../../../../shared/types'
 import {
-  findTabAndWorktree,
-  findGroupForTab,
   ensureGroup,
+  findGroupForTab,
+  findTabAndWorktree,
+  findTabByEntityInGroup,
+  patchTab,
   pickNeighbor,
-  updateGroup,
-  patchTab
+  updateGroup
 } from './tabs-helpers'
-import { buildHydratedTabState } from './tabs-hydration'
+import { captureAllTerminalBuffers } from '../../components/terminal-pane/buffer-capture-registry'
+
+export type TabSplitDirection = 'left' | 'right' | 'up' | 'down'
 
 export type TabsSlice = {
-  // ─── State ──────────────────────────────────────────────────────────
   unifiedTabsByWorktree: Record<string, Tab[]>
   groupsByWorktree: Record<string, TabGroup[]>
   activeGroupIdByWorktree: Record<string, string>
-
-  // ─── Actions ────────────────────────────────────────────────────────
+  layoutByWorktree: Record<string, TabGroupLayoutNode>
   createUnifiedTab: (
     worktreeId: string,
     contentType: TabContentType,
-    init?: Partial<Pick<Tab, 'id' | 'label' | 'customLabel' | 'color' | 'isPreview' | 'isPinned'>>
+    init: {
+      entityId?: string
+      id?: string
+      label: string
+      customLabel?: string | null
+      color?: string | null
+      isPreview?: boolean
+      isPinned?: boolean
+      targetGroupId?: string
+    }
   ) => Tab
+  getTab: (tabId: string) => Tab | null
+  getActiveTab: (worktreeId: string) => Tab | null
+  findTabForEntityInGroup: (
+    worktreeId: string,
+    groupId: string,
+    entityId: string,
+    contentType?: TabContentType
+  ) => Tab | null
+  activateTab: (tabId: string) => void
   closeUnifiedTab: (
     tabId: string
   ) => { closedTabId: string; wasLastTab: boolean; worktreeId: string } | null
-  activateTab: (tabId: string) => void
   reorderUnifiedTabs: (groupId: string, tabIds: string[]) => void
   setTabLabel: (tabId: string, label: string) => void
   setTabCustomLabel: (tabId: string, label: string | null) => void
@@ -35,72 +60,361 @@ export type TabsSlice = {
   unpinTab: (tabId: string) => void
   closeOtherTabs: (tabId: string) => string[]
   closeTabsToRight: (tabId: string) => string[]
-  getActiveTab: (worktreeId: string) => Tab | null
-  getTab: (tabId: string) => Tab | null
+  ensureWorktreeRootGroup: (worktreeId: string) => string
+  focusGroup: (worktreeId: string, groupId: string) => void
+  closeEmptyGroup: (worktreeId: string, groupId: string) => boolean
+  createEmptySplitGroup: (
+    worktreeId: string,
+    sourceGroupId: string,
+    direction: TabSplitDirection
+  ) => string | null
   hydrateTabsSession: (session: WorkspaceSessionState) => void
+}
+
+function isTransientEditorContentType(contentType: TabContentType): boolean {
+  return contentType === 'diff' || contentType === 'conflict-review'
+}
+
+function getPersistedEditFileIdsByWorktree(
+  session: WorkspaceSessionState
+): Record<string, Set<string>> {
+  return Object.fromEntries(
+    Object.entries(session.openFilesByWorktree ?? {}).map(([worktreeId, files]) => [
+      worktreeId,
+      new Set(files.map((file) => file.filePath))
+    ])
+  )
+}
+
+function buildSplitNode(
+  existingGroupId: string,
+  newGroupId: string,
+  direction: 'horizontal' | 'vertical',
+  position: 'first' | 'second'
+): TabGroupLayoutNode {
+  const existingLeaf: TabGroupLayoutNode = { type: 'leaf', groupId: existingGroupId }
+  const newLeaf: TabGroupLayoutNode = { type: 'leaf', groupId: newGroupId }
+  return {
+    type: 'split',
+    direction,
+    first: position === 'first' ? newLeaf : existingLeaf,
+    second: position === 'second' ? newLeaf : existingLeaf
+  }
+}
+
+function replaceLeaf(
+  root: TabGroupLayoutNode,
+  targetGroupId: string,
+  replacement: TabGroupLayoutNode
+): TabGroupLayoutNode {
+  if (root.type === 'leaf') {
+    return root.groupId === targetGroupId ? replacement : root
+  }
+  return {
+    ...root,
+    first: replaceLeaf(root.first, targetGroupId, replacement),
+    second: replaceLeaf(root.second, targetGroupId, replacement)
+  }
+}
+
+function findSiblingGroupId(root: TabGroupLayoutNode, targetGroupId: string): string | null {
+  if (root.type === 'leaf') {
+    return null
+  }
+  if (root.first.type === 'leaf' && root.first.groupId === targetGroupId) {
+    return root.second.type === 'leaf' ? root.second.groupId : findFirstLeaf(root.second)
+  }
+  if (root.second.type === 'leaf' && root.second.groupId === targetGroupId) {
+    return root.first.type === 'leaf' ? root.first.groupId : findFirstLeaf(root.first)
+  }
+  return (
+    findSiblingGroupId(root.first, targetGroupId) ?? findSiblingGroupId(root.second, targetGroupId)
+  )
+}
+
+function findFirstLeaf(root: TabGroupLayoutNode): string {
+  return root.type === 'leaf' ? root.groupId : findFirstLeaf(root.first)
+}
+
+function removeLeaf(root: TabGroupLayoutNode, targetGroupId: string): TabGroupLayoutNode | null {
+  if (root.type === 'leaf') {
+    return root.groupId === targetGroupId ? null : root
+  }
+  if (root.first.type === 'leaf' && root.first.groupId === targetGroupId) {
+    return root.second
+  }
+  if (root.second.type === 'leaf' && root.second.groupId === targetGroupId) {
+    return root.first
+  }
+  const first = removeLeaf(root.first, targetGroupId)
+  const second = removeLeaf(root.second, targetGroupId)
+  if (first === null) {
+    return second
+  }
+  if (second === null) {
+    return first
+  }
+  return { ...root, first, second }
+}
+
+function collapseGroupLayout(
+  layoutByWorktree: Record<string, TabGroupLayoutNode>,
+  activeGroupIdByWorktree: Record<string, string>,
+  worktreeId: string,
+  groupId: string,
+  fallbackGroupId?: string | null
+): {
+  layoutByWorktree: Record<string, TabGroupLayoutNode>
+  activeGroupIdByWorktree: Record<string, string>
+} {
+  const currentLayout = layoutByWorktree[worktreeId]
+  if (!currentLayout) {
+    return { layoutByWorktree, activeGroupIdByWorktree }
+  }
+  const siblingId = findSiblingGroupId(currentLayout, groupId)
+  const collapsed = removeLeaf(currentLayout, groupId)
+  const nextLayoutByWorktree = { ...layoutByWorktree }
+  if (collapsed) {
+    nextLayoutByWorktree[worktreeId] = collapsed
+  } else {
+    delete nextLayoutByWorktree[worktreeId]
+  }
+  return {
+    layoutByWorktree: nextLayoutByWorktree,
+    activeGroupIdByWorktree: {
+      ...activeGroupIdByWorktree,
+      [worktreeId]: siblingId ?? fallbackGroupId ?? activeGroupIdByWorktree[worktreeId]
+    }
+  }
+}
+
+function hydrateTabsState(session: WorkspaceSessionState, validWorktreeIds: Set<string>) {
+  const unifiedTabsByWorktree: Record<string, Tab[]> = {}
+  const groupsByWorktree: Record<string, TabGroup[]> = {}
+  const activeGroupIdByWorktree: Record<string, string> = {}
+  const layoutByWorktree: Record<string, TabGroupLayoutNode> = {}
+
+  if (session.unifiedTabs && session.tabGroups) {
+    const persistedEditFileIdsByWorktree = getPersistedEditFileIdsByWorktree(session)
+    for (const [worktreeId, tabs] of Object.entries(session.unifiedTabs)) {
+      if (!validWorktreeIds.has(worktreeId) || tabs.length === 0) {
+        continue
+      }
+      const persistedEditFileIds = persistedEditFileIdsByWorktree[worktreeId] ?? new Set<string>()
+      unifiedTabsByWorktree[worktreeId] = tabs
+        .map((tab) => ({
+          ...tab,
+          entityId: tab.entityId ?? tab.id
+        }))
+        .filter((tab) => {
+          if (!isTransientEditorContentType(tab.contentType)) {
+            return true
+          }
+          // Why: workspace session restore intentionally skips transient diff
+          // and conflict-review OpenFiles. If their unified tab instances are
+          // kept anyway, split groups restore chrome for panes that have no
+          // backing editor state and render blank content after restart.
+          return persistedEditFileIds.has(tab.entityId)
+        })
+    }
+    for (const [worktreeId, groups] of Object.entries(session.tabGroups)) {
+      if (!validWorktreeIds.has(worktreeId) || groups.length === 0) {
+        continue
+      }
+      const validTabIds = new Set((unifiedTabsByWorktree[worktreeId] ?? []).map((tab) => tab.id))
+      groupsByWorktree[worktreeId] = groups.map((group) => ({
+        ...group,
+        tabOrder: group.tabOrder.filter((tabId) => validTabIds.has(tabId)),
+        activeTabId:
+          group.activeTabId && validTabIds.has(group.activeTabId) ? group.activeTabId : null
+      }))
+      activeGroupIdByWorktree[worktreeId] =
+        session.activeGroupIdByWorktree?.[worktreeId] &&
+        groupsByWorktree[worktreeId].some(
+          (group) => group.id === session.activeGroupIdByWorktree?.[worktreeId]
+        )
+          ? session.activeGroupIdByWorktree[worktreeId]!
+          : groupsByWorktree[worktreeId][0].id
+      layoutByWorktree[worktreeId] = session.tabGroupLayouts?.[worktreeId] ?? {
+        type: 'leaf',
+        groupId: groupsByWorktree[worktreeId][0].id
+      }
+    }
+    return { unifiedTabsByWorktree, groupsByWorktree, activeGroupIdByWorktree, layoutByWorktree }
+  }
+
+  for (const worktreeId of validWorktreeIds) {
+    const terminalTabs = session.tabsByWorktree[worktreeId] ?? []
+    const editorFiles = session.openFilesByWorktree?.[worktreeId] ?? []
+    if (terminalTabs.length === 0 && editorFiles.length === 0) {
+      continue
+    }
+    const groupId = globalThis.crypto.randomUUID()
+    const items: Tab[] = []
+    const tabOrder: string[] = []
+    for (const terminal of terminalTabs) {
+      items.push({
+        id: terminal.id,
+        entityId: terminal.id,
+        groupId,
+        worktreeId,
+        contentType: 'terminal',
+        label: terminal.title,
+        customLabel: terminal.customTitle,
+        color: terminal.color,
+        sortOrder: items.length,
+        createdAt: terminal.createdAt
+      })
+      tabOrder.push(terminal.id)
+    }
+    for (const editorFile of editorFiles) {
+      const itemId = globalThis.crypto.randomUUID()
+      items.push({
+        id: itemId,
+        entityId: editorFile.filePath,
+        groupId,
+        worktreeId,
+        contentType: 'editor',
+        label: editorFile.relativePath,
+        customLabel: null,
+        color: null,
+        sortOrder: items.length,
+        createdAt: Date.now(),
+        isPreview: editorFile.isPreview
+      })
+      tabOrder.push(itemId)
+    }
+    unifiedTabsByWorktree[worktreeId] = items
+    groupsByWorktree[worktreeId] = [
+      {
+        id: groupId,
+        worktreeId,
+        activeTabId: tabOrder[0] ?? null,
+        tabOrder
+      }
+    ]
+    activeGroupIdByWorktree[worktreeId] = groupId
+    layoutByWorktree[worktreeId] = { type: 'leaf', groupId }
+  }
+
+  return { unifiedTabsByWorktree, groupsByWorktree, activeGroupIdByWorktree, layoutByWorktree }
 }
 
 export const createTabsSlice: StateCreator<AppState, [], [], TabsSlice> = (set, get) => ({
   unifiedTabsByWorktree: {},
   groupsByWorktree: {},
   activeGroupIdByWorktree: {},
+  layoutByWorktree: {},
 
   createUnifiedTab: (worktreeId, contentType, init) => {
-    const id = init?.id ?? globalThis.crypto.randomUUID()
-    let tab!: Tab
+    const id = init.id ?? globalThis.crypto.randomUUID()
+    let created!: Tab
+    set((state) => {
+      const { group, groupsByWorktree, activeGroupIdByWorktree } = ensureGroup(
+        state.groupsByWorktree,
+        state.activeGroupIdByWorktree,
+        worktreeId,
+        init.targetGroupId ?? state.activeGroupIdByWorktree[worktreeId]
+      )
+      const existingTabs = state.unifiedTabsByWorktree[worktreeId] ?? []
 
-    set((s) => {
-      const {
-        group,
-        groupsByWorktree: nextGroups,
-        activeGroupIdByWorktree: nextActiveGroups
-      } = ensureGroup(s.groupsByWorktree, s.activeGroupIdByWorktree, worktreeId)
-
-      const existing = s.unifiedTabsByWorktree[worktreeId] ?? []
-
-      // If opening a preview tab, replace any existing preview in the same group
-      let filtered = existing
-      let removedPreviewId: string | null = null
-      if (init?.isPreview) {
-        const existingPreview = existing.find((t) => t.isPreview && t.groupId === group.id)
+      let nextTabs = existingTabs
+      let nextOrder = [...group.tabOrder]
+      if (init.isPreview) {
+        const existingPreview = existingTabs.find(
+          (tab) => tab.groupId === group.id && tab.isPreview && tab.contentType === contentType
+        )
         if (existingPreview) {
-          filtered = existing.filter((t) => t.id !== existingPreview.id)
-          removedPreviewId = existingPreview.id
+          nextTabs = existingTabs.filter((tab) => tab.id !== existingPreview.id)
+          nextOrder = nextOrder.filter((tabId) => tabId !== existingPreview.id)
         }
       }
 
-      tab = {
+      created = {
         id,
+        entityId: init.entityId ?? id,
         groupId: group.id,
         worktreeId,
         contentType,
-        label: init?.label ?? (contentType === 'terminal' ? `Terminal ${existing.length + 1}` : id),
-        customLabel: init?.customLabel ?? null,
-        color: init?.color ?? null,
-        sortOrder: filtered.length,
+        label: init.label,
+        customLabel: init.customLabel ?? null,
+        color: init.color ?? null,
+        sortOrder: nextOrder.length,
         createdAt: Date.now(),
-        isPreview: init?.isPreview,
-        isPinned: init?.isPinned
+        isPreview: init.isPreview,
+        isPinned: init.isPinned
       }
 
-      const newTabOrder = removedPreviewId
-        ? group.tabOrder.filter((tid) => tid !== removedPreviewId)
-        : [...group.tabOrder]
-      newTabOrder.push(tab.id)
-
-      const updatedGroupObj: TabGroup = { ...group, activeTabId: tab.id, tabOrder: newTabOrder }
-
+      nextOrder.push(created.id)
       return {
-        unifiedTabsByWorktree: { ...s.unifiedTabsByWorktree, [worktreeId]: [...filtered, tab] },
-        groupsByWorktree: {
-          ...nextGroups,
-          [worktreeId]: updateGroup(nextGroups[worktreeId] ?? [], updatedGroupObj)
+        unifiedTabsByWorktree: {
+          ...state.unifiedTabsByWorktree,
+          [worktreeId]: [...nextTabs, created]
         },
-        activeGroupIdByWorktree: nextActiveGroups
+        groupsByWorktree: {
+          ...groupsByWorktree,
+          [worktreeId]: updateGroup(groupsByWorktree[worktreeId] ?? [], {
+            ...group,
+            activeTabId: created.id,
+            tabOrder: nextOrder
+          })
+        },
+        activeGroupIdByWorktree,
+        layoutByWorktree: {
+          ...state.layoutByWorktree,
+          [worktreeId]: state.layoutByWorktree[worktreeId] ?? { type: 'leaf', groupId: group.id }
+        }
       }
     })
+    return created
+  },
 
-    return tab
+  getTab: (tabId) => findTabAndWorktree(get().unifiedTabsByWorktree, tabId)?.tab ?? null,
+
+  getActiveTab: (worktreeId) => {
+    const state = get()
+    const groupId = state.activeGroupIdByWorktree[worktreeId]
+    const group = (state.groupsByWorktree[worktreeId] ?? []).find(
+      (candidate) => candidate.id === groupId
+    )
+    if (!group?.activeTabId) {
+      return null
+    }
+    return (
+      (state.unifiedTabsByWorktree[worktreeId] ?? []).find((tab) => tab.id === group.activeTabId) ??
+      null
+    )
+  },
+
+  findTabForEntityInGroup: (worktreeId, groupId, entityId, contentType) =>
+    findTabByEntityInGroup(get().unifiedTabsByWorktree, worktreeId, groupId, entityId, contentType),
+
+  activateTab: (tabId) => {
+    set((state) => {
+      const found = findTabAndWorktree(state.unifiedTabsByWorktree, tabId)
+      if (!found) {
+        return {}
+      }
+      const { tab, worktreeId } = found
+      return {
+        unifiedTabsByWorktree: {
+          ...state.unifiedTabsByWorktree,
+          [worktreeId]: (state.unifiedTabsByWorktree[worktreeId] ?? []).map((item) =>
+            item.id === tabId ? { ...item, isPreview: false } : item
+          )
+        },
+        groupsByWorktree: {
+          ...state.groupsByWorktree,
+          [worktreeId]: (state.groupsByWorktree[worktreeId] ?? []).map((group) =>
+            group.id === tab.groupId ? { ...group, activeTabId: tabId } : group
+          )
+        },
+        activeGroupIdByWorktree: {
+          ...state.activeGroupIdByWorktree,
+          [worktreeId]: tab.groupId
+        }
+      }
+    })
   },
 
   closeUnifiedTab: (tabId) => {
@@ -109,114 +423,104 @@ export const createTabsSlice: StateCreator<AppState, [], [], TabsSlice> = (set, 
     if (!found) {
       return null
     }
-
     const { tab, worktreeId } = found
     const group = findGroupForTab(state.groupsByWorktree, worktreeId, tab.groupId)
     if (!group) {
       return null
     }
-
-    const remainingOrder = group.tabOrder.filter((tid) => tid !== tabId)
+    const remainingOrder = group.tabOrder.filter((id) => id !== tabId)
     const wasLastTab = remainingOrder.length === 0
+    const nextActiveTabId =
+      group.activeTabId === tabId
+        ? wasLastTab
+          ? null
+          : pickNeighbor(group.tabOrder, tabId)
+        : group.activeTabId
 
-    let newActiveTabId = group.activeTabId
-    if (group.activeTabId === tabId) {
-      newActiveTabId = wasLastTab ? null : pickNeighbor(group.tabOrder, tabId)
+    if (wasLastTab && state.layoutByWorktree[worktreeId]) {
+      // Why: collapsing a split group remounts the surviving terminal pane
+      // tree. Capture buffers before changing layout so the next mount sees the
+      // latest prompt line instead of racing an unmount-time snapshot.
+      captureAllTerminalBuffers()
     }
 
-    set((s) => {
-      const tabs = s.unifiedTabsByWorktree[worktreeId] ?? []
-      const nextTabs = tabs.filter((t) => t.id !== tabId)
-      const updatedGroupObj: TabGroup = {
-        ...group,
-        activeTabId: newActiveTabId,
-        tabOrder: remainingOrder
+    set((current) => {
+      const nextTabs = (current.unifiedTabsByWorktree[worktreeId] ?? []).filter(
+        (item) => item.id !== tabId
+      )
+      const nextGroups = (current.groupsByWorktree[worktreeId] ?? []).map((candidate) =>
+        candidate.id === group.id
+          ? { ...candidate, activeTabId: nextActiveTabId, tabOrder: remainingOrder }
+          : candidate
+      )
+      let nextLayoutByWorktree = current.layoutByWorktree
+      let nextActiveGroupIdByWorktree = current.activeGroupIdByWorktree
+      if (wasLastTab && current.layoutByWorktree[worktreeId]) {
+        const nextCollapsedState = collapseGroupLayout(
+          current.layoutByWorktree,
+          current.activeGroupIdByWorktree,
+          worktreeId,
+          group.id,
+          nextGroups[0]?.id ?? null
+        )
+        nextLayoutByWorktree = nextCollapsedState.layoutByWorktree
+        nextActiveGroupIdByWorktree = nextCollapsedState.activeGroupIdByWorktree
       }
-
       return {
-        unifiedTabsByWorktree: { ...s.unifiedTabsByWorktree, [worktreeId]: nextTabs },
+        unifiedTabsByWorktree: { ...current.unifiedTabsByWorktree, [worktreeId]: nextTabs },
         groupsByWorktree: {
-          ...s.groupsByWorktree,
-          [worktreeId]: updateGroup(s.groupsByWorktree[worktreeId] ?? [], updatedGroupObj)
-        }
+          ...current.groupsByWorktree,
+          [worktreeId]: wasLastTab
+            ? nextGroups.filter((candidate) => candidate.id !== group.id)
+            : nextGroups
+        },
+        layoutByWorktree: nextLayoutByWorktree,
+        activeGroupIdByWorktree: nextActiveGroupIdByWorktree
       }
     })
 
     return { closedTabId: tabId, wasLastTab, worktreeId }
   },
 
-  activateTab: (tabId) => {
-    set((s) => {
-      const found = findTabAndWorktree(s.unifiedTabsByWorktree, tabId)
-      if (!found) {
-        return {}
-      }
-
-      const { tab, worktreeId } = found
-      const groups = s.groupsByWorktree[worktreeId] ?? []
-      const updatedGroups = groups.map((g) =>
-        g.id === tab.groupId ? { ...g, activeTabId: tabId } : g
-      )
-
-      let updatedTabs = s.unifiedTabsByWorktree[worktreeId]
-      if (tab.isPreview) {
-        updatedTabs = updatedTabs.map((t) => (t.id === tabId ? { ...t, isPreview: false } : t))
-      }
-
-      return {
-        unifiedTabsByWorktree: { ...s.unifiedTabsByWorktree, [worktreeId]: updatedTabs },
-        groupsByWorktree: { ...s.groupsByWorktree, [worktreeId]: updatedGroups }
-      }
-    })
-  },
-
   reorderUnifiedTabs: (groupId, tabIds) => {
-    set((s) => {
-      for (const [worktreeId, groups] of Object.entries(s.groupsByWorktree)) {
-        const group = groups.find((g) => g.id === groupId)
+    set((state) => {
+      for (const [worktreeId, groups] of Object.entries(state.groupsByWorktree)) {
+        const group = groups.find((candidate) => candidate.id === groupId)
         if (!group) {
           continue
         }
-
-        const updatedGroupObj: TabGroup = { ...group, tabOrder: tabIds }
-        const tabs = s.unifiedTabsByWorktree[worktreeId] ?? []
-        const orderMap = new Map(tabIds.map((id, i) => [id, i]))
-        const updatedTabs = tabs.map((t) => {
-          const newOrder = orderMap.get(t.id)
-          return newOrder !== undefined ? { ...t, sortOrder: newOrder } : t
-        })
-
+        const orderMap = new Map(tabIds.map((id, index) => [id, index]))
         return {
           groupsByWorktree: {
-            ...s.groupsByWorktree,
-            [worktreeId]: updateGroup(groups, updatedGroupObj)
+            ...state.groupsByWorktree,
+            [worktreeId]: updateGroup(groups, { ...group, tabOrder: tabIds })
           },
-          unifiedTabsByWorktree: { ...s.unifiedTabsByWorktree, [worktreeId]: updatedTabs }
+          unifiedTabsByWorktree: {
+            ...state.unifiedTabsByWorktree,
+            [worktreeId]: (state.unifiedTabsByWorktree[worktreeId] ?? []).map((tab) => {
+              const sortOrder = orderMap.get(tab.id)
+              return sortOrder === undefined ? tab : { ...tab, sortOrder }
+            })
+          }
         }
       }
       return {}
     })
   },
 
-  setTabLabel: (tabId, label) => {
-    set((s) => patchTab(s.unifiedTabsByWorktree, tabId, { label }) ?? {})
-  },
-
-  setTabCustomLabel: (tabId, label) => {
-    set((s) => patchTab(s.unifiedTabsByWorktree, tabId, { customLabel: label }) ?? {})
-  },
-
-  setUnifiedTabColor: (tabId, color) => {
-    set((s) => patchTab(s.unifiedTabsByWorktree, tabId, { color }) ?? {})
-  },
-
-  pinTab: (tabId) => {
-    set((s) => patchTab(s.unifiedTabsByWorktree, tabId, { isPinned: true, isPreview: false }) ?? {})
-  },
-
-  unpinTab: (tabId) => {
-    set((s) => patchTab(s.unifiedTabsByWorktree, tabId, { isPinned: false }) ?? {})
-  },
+  setTabLabel: (tabId, label) =>
+    set((state) => patchTab(state.unifiedTabsByWorktree, tabId, { label }) ?? {}),
+  setTabCustomLabel: (tabId, label) =>
+    set((state) => patchTab(state.unifiedTabsByWorktree, tabId, { customLabel: label }) ?? {}),
+  setUnifiedTabColor: (tabId, color) =>
+    set((state) => patchTab(state.unifiedTabsByWorktree, tabId, { color }) ?? {}),
+  pinTab: (tabId) =>
+    set(
+      (state) =>
+        patchTab(state.unifiedTabsByWorktree, tabId, { isPinned: true, isPreview: false }) ?? {}
+    ),
+  unpinTab: (tabId) =>
+    set((state) => patchTab(state.unifiedTabsByWorktree, tabId, { isPinned: false }) ?? {}),
 
   closeOtherTabs: (tabId) => {
     const state = get()
@@ -224,39 +528,17 @@ export const createTabsSlice: StateCreator<AppState, [], [], TabsSlice> = (set, 
     if (!found) {
       return []
     }
-
     const { tab, worktreeId } = found
     const group = findGroupForTab(state.groupsByWorktree, worktreeId, tab.groupId)
     if (!group) {
       return []
     }
-
-    const tabs = state.unifiedTabsByWorktree[worktreeId] ?? []
-    const closedIds = tabs
-      .filter((t) => t.id !== tabId && !t.isPinned && t.groupId === group.id)
-      .map((t) => t.id)
-
-    if (closedIds.length === 0) {
-      return []
+    const closedIds = (state.unifiedTabsByWorktree[worktreeId] ?? [])
+      .filter((item) => item.groupId === group.id && item.id !== tabId && !item.isPinned)
+      .map((item) => item.id)
+    for (const id of closedIds) {
+      get().closeUnifiedTab(id)
     }
-
-    const closedSet = new Set(closedIds)
-
-    set((s) => {
-      const currentTabs = s.unifiedTabsByWorktree[worktreeId] ?? []
-      const remainingTabs = currentTabs.filter((t) => !closedSet.has(t.id))
-      const remainingOrder = group.tabOrder.filter((tid) => !closedSet.has(tid))
-      const updatedGroupObj: TabGroup = { ...group, activeTabId: tabId, tabOrder: remainingOrder }
-
-      return {
-        unifiedTabsByWorktree: { ...s.unifiedTabsByWorktree, [worktreeId]: remainingTabs },
-        groupsByWorktree: {
-          ...s.groupsByWorktree,
-          [worktreeId]: updateGroup(s.groupsByWorktree[worktreeId] ?? [], updatedGroupObj)
-        }
-      }
-    })
-
     return closedIds
   },
 
@@ -266,87 +548,148 @@ export const createTabsSlice: StateCreator<AppState, [], [], TabsSlice> = (set, 
     if (!found) {
       return []
     }
-
     const { tab, worktreeId } = found
     const group = findGroupForTab(state.groupsByWorktree, worktreeId, tab.groupId)
     if (!group) {
       return []
     }
-
-    const idx = group.tabOrder.indexOf(tabId)
-    if (idx === -1) {
+    const index = group.tabOrder.indexOf(tabId)
+    if (index === -1) {
       return []
     }
+    const closableIds = group.tabOrder
+      .slice(index + 1)
+      .filter(
+        (id) =>
+          !(state.unifiedTabsByWorktree[worktreeId] ?? []).find((tab) => tab.id === id)?.isPinned
+      )
+    for (const id of closableIds) {
+      get().closeUnifiedTab(id)
+    }
+    return closableIds
+  },
 
-    const idsToRight = group.tabOrder.slice(idx + 1)
-    const tabs = state.unifiedTabsByWorktree[worktreeId] ?? []
-    const tabMap = new Map(tabs.map((t) => [t.id, t]))
-
-    const closedIds = idsToRight.filter((tid) => {
-      const t = tabMap.get(tid)
-      return t && !t.isPinned
-    })
-
-    if (closedIds.length === 0) {
-      return []
+  ensureWorktreeRootGroup: (worktreeId) => {
+    const existingGroups = get().groupsByWorktree[worktreeId] ?? []
+    if (existingGroups.length > 0) {
+      const existingActiveGroupId = get().activeGroupIdByWorktree[worktreeId]
+      return existingActiveGroupId ?? existingGroups[0].id
     }
 
-    const closedSet = new Set(closedIds)
-
-    set((s) => {
-      const currentTabs = s.unifiedTabsByWorktree[worktreeId] ?? []
-      const remainingTabs = currentTabs.filter((t) => !closedSet.has(t.id))
-      const remainingOrder = group.tabOrder.filter((tid) => !closedSet.has(tid))
-
-      const newActiveTabId = closedSet.has(group.activeTabId ?? '') ? tabId : group.activeTabId
-      const updatedGroupObj: TabGroup = {
-        ...group,
-        activeTabId: newActiveTabId,
-        tabOrder: remainingOrder
+    const groupId = globalThis.crypto.randomUUID()
+    set((state) => ({
+      // Why: a freshly selected worktree can legitimately have zero tabs, but
+      // split-tab affordances still need a canonical root group so the titlebar
+      // tab strip remains visible and can open/split the first tab.
+      groupsByWorktree: {
+        ...state.groupsByWorktree,
+        [worktreeId]: [{ id: groupId, worktreeId, activeTabId: null, tabOrder: [] }]
+      },
+      layoutByWorktree: {
+        ...state.layoutByWorktree,
+        [worktreeId]: { type: 'leaf', groupId }
+      },
+      activeGroupIdByWorktree: {
+        ...state.activeGroupIdByWorktree,
+        [worktreeId]: groupId
       }
+    }))
+    return groupId
+  },
 
+  focusGroup: (worktreeId, groupId) =>
+    set((state) => ({
+      activeGroupIdByWorktree: { ...state.activeGroupIdByWorktree, [worktreeId]: groupId }
+    })),
+
+  closeEmptyGroup: (worktreeId, groupId) => {
+    const state = get()
+    const group = (state.groupsByWorktree[worktreeId] ?? []).find(
+      (candidate) => candidate.id === groupId
+    )
+    if (!group || group.tabOrder.length > 0) {
+      return false
+    }
+    // Why: removing an empty split neighbor still rewrites the layout tree and
+    // remounts the surviving terminal pane. Capture buffers first so visible
+    // terminal state survives the remount.
+    captureAllTerminalBuffers()
+    set((current) => {
+      const remainingGroups = (current.groupsByWorktree[worktreeId] ?? []).filter(
+        (candidate) => candidate.id !== groupId
+      )
+      const nextCollapsedState = collapseGroupLayout(
+        current.layoutByWorktree,
+        current.activeGroupIdByWorktree,
+        worktreeId,
+        groupId,
+        remainingGroups[0]?.id ?? null
+      )
       return {
-        unifiedTabsByWorktree: { ...s.unifiedTabsByWorktree, [worktreeId]: remainingTabs },
         groupsByWorktree: {
-          ...s.groupsByWorktree,
-          [worktreeId]: updateGroup(s.groupsByWorktree[worktreeId] ?? [], updatedGroupObj)
+          ...current.groupsByWorktree,
+          [worktreeId]: remainingGroups
+        },
+        layoutByWorktree: nextCollapsedState.layoutByWorktree,
+        activeGroupIdByWorktree: nextCollapsedState.activeGroupIdByWorktree
+      }
+    })
+    return true
+  },
+
+  createEmptySplitGroup: (worktreeId, sourceGroupId, direction) => {
+    const groups = get().groupsByWorktree[worktreeId] ?? []
+    if (!groups.some((group) => group.id === sourceGroupId)) {
+      return null
+    }
+    // Why: creating a neighboring group rewrites the layout from leaf -> split,
+    // which remounts the existing terminal pane. Capture buffers before the
+    // mutation so partially typed commands are present in the next mount's
+    // restored xterm viewport.
+    captureAllTerminalBuffers()
+    const newGroupId = globalThis.crypto.randomUUID()
+    // Why: v1 split groups only create empty neighboring groups. Cloning the
+    // current tab here would duplicate terminal/browser runtime identities or
+    // implicitly create another editor instance, which is exactly the cross-slice
+    // ownership bug this layout-only split flow is meant to avoid.
+    const splitDirection = direction === 'left' || direction === 'right' ? 'horizontal' : 'vertical'
+    const position = direction === 'left' || direction === 'up' ? 'first' : 'second'
+    set((current) => {
+      const layout = current.layoutByWorktree[worktreeId] ?? {
+        type: 'leaf',
+        groupId: sourceGroupId
+      }
+      return {
+        groupsByWorktree: {
+          ...current.groupsByWorktree,
+          [worktreeId]: [
+            ...(current.groupsByWorktree[worktreeId] ?? []),
+            { id: newGroupId, worktreeId, activeTabId: null, tabOrder: [] }
+          ]
+        },
+        layoutByWorktree: {
+          ...current.layoutByWorktree,
+          [worktreeId]: replaceLeaf(
+            layout,
+            sourceGroupId,
+            buildSplitNode(sourceGroupId, newGroupId, splitDirection, position)
+          )
+        },
+        activeGroupIdByWorktree: {
+          ...current.activeGroupIdByWorktree,
+          [worktreeId]: newGroupId
         }
       }
     })
-
-    return closedIds
-  },
-
-  getActiveTab: (worktreeId) => {
-    const state = get()
-    const activeGroupId = state.activeGroupIdByWorktree[worktreeId]
-    if (!activeGroupId) {
-      return null
-    }
-
-    const groups = state.groupsByWorktree[worktreeId] ?? []
-    const group = groups.find((g) => g.id === activeGroupId)
-    if (!group?.activeTabId) {
-      return null
-    }
-
-    const tabs = state.unifiedTabsByWorktree[worktreeId] ?? []
-    return tabs.find((t) => t.id === group.activeTabId) ?? null
-  },
-
-  getTab: (tabId) => {
-    const state = get()
-    const found = findTabAndWorktree(state.unifiedTabsByWorktree, tabId)
-    return found?.tab ?? null
+    return newGroupId
   },
 
   hydrateTabsSession: (session) => {
-    const state = get()
     const validWorktreeIds = new Set(
-      Object.values(state.worktreesByRepo)
+      Object.values(get().worktreesByRepo)
         .flat()
-        .map((w) => w.id)
+        .map((worktree) => worktree.id)
     )
-    set(buildHydratedTabState(session, validWorktreeIds))
+    set(hydrateTabsState(session, validWorktreeIds))
   }
 })

--- a/src/renderer/src/store/slices/tabs.ts
+++ b/src/renderer/src/store/slices/tabs.ts
@@ -13,8 +13,11 @@ import {
   findGroupForTab,
   findTabAndWorktree,
   findTabByEntityInGroup,
+  getPersistedEditFileIdsByWorktree,
+  isTransientEditorContentType,
   patchTab,
   pickNeighbor,
+  selectHydratedActiveGroupId,
   updateGroup
 } from './tabs-helpers'
 import { captureAllTerminalBuffers } from '../../components/terminal-pane/buffer-capture-registry'
@@ -69,21 +72,6 @@ export type TabsSlice = {
     direction: TabSplitDirection
   ) => string | null
   hydrateTabsSession: (session: WorkspaceSessionState) => void
-}
-
-function isTransientEditorContentType(contentType: TabContentType): boolean {
-  return contentType === 'diff' || contentType === 'conflict-review'
-}
-
-function getPersistedEditFileIdsByWorktree(
-  session: WorkspaceSessionState
-): Record<string, Set<string>> {
-  return Object.fromEntries(
-    Object.entries(session.openFilesByWorktree ?? {}).map(([worktreeId, files]) => [
-      worktreeId,
-      new Set(files.map((file) => file.filePath))
-    ])
-  )
 }
 
 function buildSplitNode(
@@ -222,19 +210,27 @@ function hydrateTabsState(session: WorkspaceSessionState, validWorktreeIds: Set<
         continue
       }
       const validTabIds = new Set((unifiedTabsByWorktree[worktreeId] ?? []).map((tab) => tab.id))
-      groupsByWorktree[worktreeId] = groups.map((group) => ({
-        ...group,
-        tabOrder: group.tabOrder.filter((tabId) => validTabIds.has(tabId)),
-        activeTabId:
-          group.activeTabId && validTabIds.has(group.activeTabId) ? group.activeTabId : null
-      }))
-      activeGroupIdByWorktree[worktreeId] =
-        session.activeGroupIdByWorktree?.[worktreeId] &&
-        groupsByWorktree[worktreeId].some(
-          (group) => group.id === session.activeGroupIdByWorktree?.[worktreeId]
-        )
-          ? session.activeGroupIdByWorktree[worktreeId]!
-          : groupsByWorktree[worktreeId][0].id
+      groupsByWorktree[worktreeId] = groups.map((group) => {
+        const tabOrder = group.tabOrder.filter((tabId) => validTabIds.has(tabId))
+        return {
+          ...group,
+          tabOrder,
+          // Why: restore can drop transient tabs that no longer have backing
+          // editor state. Promote the first surviving tab so the hydrated group
+          // still renders content immediately instead of coming back blank.
+          activeTabId:
+            group.activeTabId && validTabIds.has(group.activeTabId)
+              ? group.activeTabId
+              : (tabOrder[0] ?? null)
+        }
+      })
+      const activeGroupId = selectHydratedActiveGroupId(
+        groupsByWorktree[worktreeId],
+        session.activeGroupIdByWorktree?.[worktreeId]
+      )
+      if (activeGroupId) {
+        activeGroupIdByWorktree[worktreeId] = activeGroupId
+      }
       layoutByWorktree[worktreeId] = session.tabGroupLayouts?.[worktreeId] ?? {
         type: 'leaf',
         groupId: groupsByWorktree[worktreeId][0].id

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -46,7 +46,7 @@ export type TerminalSlice = {
   workspaceSessionReady: boolean
   pendingReconnectWorktreeIds: string[]
   pendingReconnectTabByWorktree: Record<string, string[]>
-  createTab: (worktreeId: string) => TerminalTab
+  createTab: (worktreeId: string, tabId?: string) => TerminalTab
   closeTab: (tabId: string) => void
   reorderTabs: (worktreeId: string, tabIds: string[]) => void
   setTabBarOrder: (worktreeId: string, order: string[]) => void
@@ -175,8 +175,8 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
     }
   },
 
-  createTab: (worktreeId) => {
-    const id = globalThis.crypto.randomUUID()
+  createTab: (worktreeId, tabId) => {
+    const id = tabId ?? globalThis.crypto.randomUUID()
     let tab!: TerminalTab
     set((s) => {
       const existing = s.tabsByWorktree[worktreeId] ?? []
@@ -201,6 +201,23 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         terminalLayoutsByTabId: { ...s.terminalLayoutsByTabId, [tab.id]: emptyLayoutSnapshot() }
       }
     })
+    const state = get()
+    const targetGroupId =
+      state.activeGroupIdByWorktree[worktreeId] ?? state.groupsByWorktree[worktreeId]?.[0]?.id
+    if (
+      targetGroupId &&
+      !state.findTabForEntityInGroup(worktreeId, targetGroupId, id, 'terminal')
+    ) {
+      state.createUnifiedTab(worktreeId, 'terminal', {
+        id,
+        entityId: id,
+        label: tab.title,
+        customLabel: tab.customTitle,
+        color: tab.color
+      })
+    } else if (targetGroupId) {
+      state.activateTab(id)
+    }
     return tab
   },
 
@@ -263,6 +280,15 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         cacheTimerByKey: nextCacheTimer
       }
     })
+    const item = get().unifiedTabsByWorktree
+    for (const tabs of Object.values(item)) {
+      const workspaceItem = tabs.find(
+        (entry) => entry.contentType === 'terminal' && entry.entityId === tabId
+      )
+      if (workspaceItem) {
+        get().closeUnifiedTab(workspaceItem.id)
+      }
+    }
   },
 
   reorderTabs: (worktreeId, tabIds) => {
@@ -311,7 +337,7 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
     })
   },
 
-  setActiveTab: (tabId) =>
+  setActiveTab: (tabId) => {
     set((s) => {
       const worktreeId = s.activeWorktreeId
       return {
@@ -320,7 +346,16 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
           ? { ...s.activeTabIdByWorktree, [worktreeId]: tabId }
           : s.activeTabIdByWorktree
       }
-    }),
+    })
+    const item = Object.values(get().unifiedTabsByWorktree)
+      .flat()
+      .find((entry) => entry.contentType === 'terminal' && entry.entityId === tabId)
+    if (item) {
+      get().activateTab(item.id)
+    }
+  },
+
+  // Keep the canonical workspace item label in sync with terminal runtime title.
 
   updateTabTitle: (tabId, title) => {
     set((s) => {
@@ -353,6 +388,12 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         ? { tabsByWorktree: next }
         : { tabsByWorktree: next, sortEpoch: s.sortEpoch + 1 }
     })
+    const item = Object.values(get().unifiedTabsByWorktree)
+      .flat()
+      .find((entry) => entry.contentType === 'terminal' && entry.entityId === tabId)
+    if (item) {
+      get().setTabLabel(item.id, title)
+    }
   },
 
   setRuntimePaneTitle: (tabId, paneId, title) => {
@@ -399,6 +440,12 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       scheduleRuntimeGraphSync()
       return { tabsByWorktree: next }
     })
+    const item = Object.values(get().unifiedTabsByWorktree)
+      .flat()
+      .find((entry) => entry.contentType === 'terminal' && entry.entityId === tabId)
+    if (item) {
+      get().setTabCustomLabel(item.id, title)
+    }
   },
 
   setTabColor: (tabId, color) => {
@@ -409,6 +456,12 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       }
       return { tabsByWorktree: next }
     })
+    const item = Object.values(get().unifiedTabsByWorktree)
+      .flat()
+      .find((entry) => entry.contentType === 'terminal' && entry.entityId === tabId)
+    if (item) {
+      get().setUnifiedTabColor(item.id, color)
+    }
   },
 
   updateTabPtyId: (tabId, ptyId) => {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -55,16 +55,31 @@ export type WorktreeMeta = {
   lastActivityAt: number
 }
 
+// ─── Tab Group Layout ─────────────────────────────────────────────
+export type TabGroupSplitDirection = 'horizontal' | 'vertical'
+
+export type TabGroupLayoutNode =
+  | { type: 'leaf'; groupId: string }
+  | {
+      type: 'split'
+      direction: TabGroupSplitDirection
+      first: TabGroupLayoutNode
+      second: TabGroupLayoutNode
+    }
+
 // ─── Unified Tab ────────────────────────────────────────────────────
 export type TabContentType = 'terminal' | 'editor' | 'diff' | 'conflict-review' | 'browser'
 
 export type WorkspaceVisibleTabType = 'terminal' | 'editor' | 'browser'
 
 export type Tab = {
-  id: string // UUID for terminals, filePath for editors (preserves current convention)
+  id: string // workspace item instance ID
   groupId: string
   worktreeId: string
   contentType: TabContentType
+  /** Underlying runtime/document entity. Terminal items point at a terminal tab
+   *  runtime ID; editor/diff items point at the shared document/file ID. */
+  entityId: string
   label: string // display title (auto-derived from PTY or filename)
   customLabel: string | null
   color: string | null
@@ -181,6 +196,8 @@ export type WorkspaceSessionState = {
   unifiedTabs?: Record<string, Tab[]>
   /** Tab group model — present alongside unifiedTabs. */
   tabGroups?: Record<string, TabGroup[]>
+  tabGroupLayouts?: Record<string, TabGroupLayoutNode>
+  activeGroupIdByWorktree?: Record<string, string>
 }
 
 // ─── GitHub ──────────────────────────────────────────────────────────

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -154,6 +154,9 @@ export type TerminalLayoutSnapshot = {
   /** User-assigned pane titles, keyed by leafId (e.g. "pane:3").
    *  Persisted alongside buffers via the existing session:set flow. */
   titlesByLeafId?: Record<string, string>
+  /** Live PTY IDs per leaf, captured during layout snapshots so multi-pane
+   *  terminals can re-attach each pane to its own shell after a remount. */
+  ptyIdsByLeafId?: Record<string, string>
 }
 
 /** Minimal subset of OpenFile persisted across restarts.


### PR DESCRIPTION
## Summary

Re-lands split-screen tab groups (originally PR #393, reverted in PR #403) with a fundamentally revised architecture. The previous attempt overlaid groups on top of multiple competing tab authorities (terminal, editor, browser slices), requiring constant cross-slice synchronization that broke tab switching. This implementation uses a canonical group/item model where `TabsSlice` owns tab membership, order, and per-group activation, while domain slices retain only content/runtime state.

### What's included

**Core tab group architecture**
- `TabGroupPanel` and `TabGroupSplitLayout` components for rendering split groups
- `TabGroupLayoutNode` tree for split layout with split/focus/close/move actions
- Single-group mode uses the same state model (one group = one leaf)
- Group focus drives keyboard tab cycling and new-tab placement
- Session persistence and hydration for group/item/layout state

**Terminal split-group support**
- Terminals render from group/item state while PTY lifecycle stays in `TerminalSlice`
- Per-leaf PTY ID snapshots so multi-pane terminals re-attach each pane to its own shell across layout remounts
- Three-priority reattach strategy: snapshot PTY (verified live) > eager buffer handle (startup reconnect) > tab-level fallback
- Unmount cleanup guards PTY preservation to layout-only remounts, preventing leaked backend shells

**Editor split-group support**
- Editor tab instances point at shared underlying document state
- Preview replacement and pin/close are group-local at the tab-instance layer
- Same file can appear in multiple groups without corruption

**Browser split-group support**
- Browser tabs participate in the unified tab group model

**Hydration fixes**
- Promote first surviving tab as activeTabId when transient tabs (diff, conflict-review) are dropped during restore
- Prefer non-empty groups when selecting the active group after restore
- Extract shared hydration helpers to `tabs-helpers.ts`

**Bug fixes**
- Fix `onPinFile` in `TabGroupPanel` to use unified tab UUID instead of file path (was silently no-oping)
- Remove stale split action modules (`tab-group-layout-ops.ts`, `tabs-bulk-actions.ts`, `tabs-split-actions.ts`) from the reverted PR #393

## Test plan
- [x] Split a terminal tab into a new group, verify both groups render independently
- [x] Split-pane terminal across groups: verify each pane re-attaches to its own shell on remount
- [x] Open the same editor file in two groups, edit in one, verify the other reflects changes
- [x] Close the last tab in a group, verify the group collapses and focus moves correctly
- [ ] Restart the app with split groups open, verify layout, active tabs, and PTYs restore correctly
- [ ] Restart with a persisted diff tab that has no backing file state, verify active group falls back to one with surviving tabs
- [x] Keyboard terminal open (Cmd+t) operates within the focused group
- [x] Single-group mode behaves identically to pre-split UX
- [x] `pnpm test` passes for tabs, tabs-hydration, tabs-helpers, and editor test suites

<img width="1509" height="869" alt="image" src="https://github.com/user-attachments/assets/027d8104-d7c1-4aad-ad18-bafdf01e7b73" />
