### PR TITLE
Make sidebar more compact

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -222,7 +222,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
     <WorktreeContextMenu worktree={worktree}>
       <div
         className={cn(
-          'group relative flex items-start gap-2.5 px-3 py-2 rounded-lg cursor-pointer transition-all duration-200 outline-none select-none mx-1',
+          'group relative flex items-start gap-2.5 px-2 py-2 rounded-lg cursor-pointer transition-all duration-200 outline-none select-none mx-1',
           isActive
             ? 'bg-black/[0.06] shadow-[0_1px_2px_rgba(0,0,0,0.03)] border border-border/60 dark:bg-white/[0.10] dark:border-border/40'
             : 'border border-transparent hover:bg-accent/40',


### PR DESCRIPTION
## Summary
- Reduce worktree card horizontal padding (`px-3` → `px-2`) for a more compact sidebar layout

## Test plan
- [x] Visual inspection of sidebar cards
- [x] Existing estimate height tests pass (px doesn't affect height)