### PR TITLE
fix: Cmd+Shift+G opens sidebar during terminal search

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -391,6 +391,13 @@ function App(): React.JSX.Element {
       if (e.repeat) {
         return
       }
+      // Why: child-component handlers (e.g. terminal search Cmd+G / Cmd+Shift+G)
+      // register on the same window capture phase and fire first. If they already
+      // called preventDefault, this handler must not also act on the event —
+      // otherwise both actions execute (e.g. search navigation AND sidebar open).
+      if (e.defaultPrevented) {
+        return
+      }
       // Accept Cmd on macOS, Ctrl on other platforms
       const mod = isMac ? e.metaKey : e.ctrlKey
 
@@ -447,8 +454,15 @@ function App(): React.JSX.Element {
         return
       }
 
-      // Cmd/Ctrl+Shift+G — toggle right sidebar / source control tab
+      // Cmd/Ctrl+Shift+G — toggle right sidebar / source control tab.
+      // Skip when terminal search is open — Cmd+Shift+G means "find previous"
+      // in that context (handled by keyboard-handlers.ts). Both listeners share
+      // the window capture phase and registration order can vary with React
+      // effect re-runs, so a DOM check is the reliable coordination mechanism.
       if (e.shiftKey && !e.altKey && e.key.toLowerCase() === 'g') {
+        if (document.querySelector('[data-terminal-search-root]')) {
+          return
+        }
         e.preventDefault()
         setRightSidebarTab('source-control')
         setRightSidebarOpen(true)

--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
@@ -107,13 +107,14 @@ export function useTerminalKeyboardShortcuts({
       // Cmd+G / Cmd+Shift+G navigates terminal search matches even when focus
       // is inside the search input itself, so this check must run before the
       // editable-target guard would otherwise bypass all terminal shortcuts.
+      // stopImmediatePropagation prevents App.tsx's Cmd+Shift+G (source-control sidebar) from also firing.
       const direction = matchSearchNavigate(e, isMac, searchOpenRef.current, searchStateRef.current)
       if (direction !== null) {
         if (e.repeat) {
           return
         }
         e.preventDefault()
-        e.stopPropagation()
+        e.stopImmediatePropagation()
         const pane = manager.getActivePane() ?? manager.getPanes()[0]
         if (!pane) {
           return


### PR DESCRIPTION
## Summary
- Cmd+Shift+G was opening the source control sidebar even when terminal search was active, because both `App.tsx` and `keyboard-handlers.ts` registered capture-phase `keydown` listeners on `window` with no coordination
- Added a DOM check in `App.tsx` to skip Cmd+Shift+G when `[data-terminal-search-root]` is present (terminal search is open) — reliable regardless of listener registration order
- Added `defaultPrevented` guard in `App.tsx` as a general defense against duplicate handling
- Upgraded `stopPropagation` → `stopImmediatePropagation` in the terminal search handler

## Test plan
- [ ] Open terminal search (Cmd+F), type a query, press Cmd+Shift+G → should navigate to previous match, sidebar should NOT open
- [ ] Close terminal search, press Cmd+Shift+G → should open source control sidebar as before
- [ ] Verify other App.tsx shortcuts still work: Cmd+B (left sidebar), Cmd+L (right sidebar), Cmd+Shift+E (explorer), Cmd+Shift+F (search)