### PR TITLE
Support Pi titlebar status tracking

### DIFF
--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -13,7 +13,8 @@ const {
   accessSyncMock,
   spawnMock,
   openCodeBuildPtyEnvMock,
-  openCodeClearPtyMock
+  openCodeClearPtyMock,
+  piBuildPtyEnvMock
 } = vi.hoisted(() => ({
   handleMock: vi.fn(),
   onMock: vi.fn(),
@@ -24,7 +25,8 @@ const {
   accessSyncMock: vi.fn(),
   spawnMock: vi.fn(),
   openCodeBuildPtyEnvMock: vi.fn(),
-  openCodeClearPtyMock: vi.fn()
+  openCodeClearPtyMock: vi.fn(),
+  piBuildPtyEnvMock: vi.fn()
 }))
 
 vi.mock('electron', () => ({
@@ -56,6 +58,11 @@ vi.mock('../opencode/hook-service', () => ({
   }
 }))
 
+vi.mock('../pi/titlebar-extension-service', () => ({
+  piTitlebarExtensionService: {
+    buildPtyEnv: piBuildPtyEnvMock
+  }
+}))
 import { registerPtyHandlers } from './pty'
 
 describe('registerPtyHandlers', () => {
@@ -80,6 +87,7 @@ describe('registerPtyHandlers', () => {
     spawnMock.mockReset()
     openCodeBuildPtyEnvMock.mockReset()
     openCodeClearPtyMock.mockReset()
+    piBuildPtyEnvMock.mockReset()
     mainWindow.webContents.on.mockReset()
     mainWindow.webContents.send.mockReset()
 
@@ -94,6 +102,11 @@ describe('registerPtyHandlers', () => {
       ORCA_OPENCODE_PTY_ID: 'test-pty',
       OPENCODE_CONFIG_DIR: '/tmp/orca-opencode-config'
     })
+    piBuildPtyEnvMock.mockImplementation((existingPath?: string) => ({
+      PATH: existingPath ? `/tmp/orca-pi-bin:${existingPath}` : '/tmp/orca-pi-bin',
+      ORCA_PI_REAL_BIN: '/usr/local/bin/pi',
+      ORCA_PI_EXTENSION_PATH: '/tmp/orca-pi-ext.ts'
+    }))
     spawnMock.mockReturnValue({
       onData: vi.fn(),
       onExit: vi.fn(),
@@ -182,6 +195,13 @@ describe('registerPtyHandlers', () => {
       expect(env.OPENCODE_CONFIG_DIR).toBe('/tmp/orca-opencode-config')
     })
 
+    it('prepends the Pi wrapper env into Orca terminal PTYs', () => {
+      const env = spawnAndGetEnv(undefined, { PATH: '/usr/bin:/bin' })
+      expect(piBuildPtyEnvMock).toHaveBeenCalledWith('/usr/bin:/bin')
+      expect(env.PATH).toBe('/tmp/orca-pi-bin:/usr/bin:/bin')
+      expect(env.ORCA_PI_REAL_BIN).toBe('/usr/local/bin/pi')
+      expect(env.ORCA_PI_EXTENSION_PATH).toBe('/tmp/orca-pi-ext.ts')
+    })
     it('leaves ambient CODEX_HOME untouched when system default is selected', () => {
       const env = spawnAndGetEnv(undefined, { CODEX_HOME: '/tmp/system-codex-home' }, () => null)
       expect(env.CODEX_HOME).toBe('/tmp/system-codex-home')

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -14,7 +14,8 @@ const {
   spawnMock,
   openCodeBuildPtyEnvMock,
   openCodeClearPtyMock,
-  piBuildPtyEnvMock
+  piBuildPtyEnvMock,
+  piClearPtyMock
 } = vi.hoisted(() => ({
   handleMock: vi.fn(),
   onMock: vi.fn(),
@@ -26,7 +27,8 @@ const {
   spawnMock: vi.fn(),
   openCodeBuildPtyEnvMock: vi.fn(),
   openCodeClearPtyMock: vi.fn(),
-  piBuildPtyEnvMock: vi.fn()
+  piBuildPtyEnvMock: vi.fn(),
+  piClearPtyMock: vi.fn()
 }))
 
 vi.mock('electron', () => ({
@@ -60,7 +62,8 @@ vi.mock('../opencode/hook-service', () => ({
 
 vi.mock('../pi/titlebar-extension-service', () => ({
   piTitlebarExtensionService: {
-    buildPtyEnv: piBuildPtyEnvMock
+    buildPtyEnv: piBuildPtyEnvMock,
+    clearPty: piClearPtyMock
   }
 }))
 import { registerPtyHandlers } from './pty'
@@ -88,6 +91,7 @@ describe('registerPtyHandlers', () => {
     openCodeBuildPtyEnvMock.mockReset()
     openCodeClearPtyMock.mockReset()
     piBuildPtyEnvMock.mockReset()
+    piClearPtyMock.mockReset()
     mainWindow.webContents.on.mockReset()
     mainWindow.webContents.send.mockReset()
 
@@ -102,10 +106,10 @@ describe('registerPtyHandlers', () => {
       ORCA_OPENCODE_PTY_ID: 'test-pty',
       OPENCODE_CONFIG_DIR: '/tmp/orca-opencode-config'
     })
-    piBuildPtyEnvMock.mockImplementation((existingPath?: string) => ({
-      PATH: existingPath ? `/tmp/orca-pi-bin:${existingPath}` : '/tmp/orca-pi-bin',
-      ORCA_PI_REAL_BIN: '/usr/local/bin/pi',
-      ORCA_PI_EXTENSION_PATH: '/tmp/orca-pi-ext.ts'
+    piBuildPtyEnvMock.mockImplementation((_ptyId: string, existingAgentDir?: string) => ({
+      PI_CODING_AGENT_DIR: existingAgentDir
+        ? '/tmp/orca-pi-agent-overlay'
+        : '/tmp/orca-pi-agent-overlay'
     }))
     spawnMock.mockReturnValue({
       onData: vi.fn(),
@@ -195,12 +199,10 @@ describe('registerPtyHandlers', () => {
       expect(env.OPENCODE_CONFIG_DIR).toBe('/tmp/orca-opencode-config')
     })
 
-    it('prepends the Pi wrapper env into Orca terminal PTYs', () => {
-      const env = spawnAndGetEnv(undefined, { PATH: '/usr/bin:/bin' })
-      expect(piBuildPtyEnvMock).toHaveBeenCalledWith('/usr/bin:/bin')
-      expect(env.PATH).toBe('/tmp/orca-pi-bin:/usr/bin:/bin')
-      expect(env.ORCA_PI_REAL_BIN).toBe('/usr/local/bin/pi')
-      expect(env.ORCA_PI_EXTENSION_PATH).toBe('/tmp/orca-pi-ext.ts')
+    it('injects the Pi agent overlay env into Orca terminal PTYs', () => {
+      const env = spawnAndGetEnv(undefined, { PI_CODING_AGENT_DIR: '/tmp/user-pi-agent' })
+      expect(piBuildPtyEnvMock).toHaveBeenCalledWith(expect.any(String), '/tmp/user-pi-agent')
+      expect(env.PI_CODING_AGENT_DIR).toBe('/tmp/orca-pi-agent-overlay')
     })
     it('leaves ambient CODEX_HOME untouched when system default is selected', () => {
       const env = spawnAndGetEnv(undefined, { CODEX_HOME: '/tmp/system-codex-home' }, () => null)
@@ -365,5 +367,27 @@ describe('registerPtyHandlers', () => {
         process.env.SHELL = originalShell
       }
     }
+  })
+
+  it('cleans up provider-specific PTY overlays when a PTY is killed', () => {
+    const proc = {
+      onData: vi.fn(),
+      onExit: vi.fn(),
+      write: vi.fn(),
+      resize: vi.fn(),
+      kill: vi.fn()
+    }
+    spawnMock.mockReturnValue(proc)
+
+    registerPtyHandlers(mainWindow as never)
+    const spawnResult = handlers.get('pty:spawn')!(null, {
+      cols: 80,
+      rows: 24
+    }) as { id: string }
+
+    handlers.get('pty:kill')!(null, { id: spawnResult.id })
+
+    expect(openCodeClearPtyMock).toHaveBeenCalledWith(spawnResult.id)
+    expect(piClearPtyMock).toHaveBeenCalledWith(spawnResult.id)
   })
 })

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -26,6 +26,20 @@ let loadGeneration = 0
 const ptyLoadGeneration = new Map<string, number>()
 let didEnsureSpawnHelperExecutable = false
 
+function clearPtyState(id: string): void {
+  ptyProcesses.delete(id)
+  ptyShellName.delete(id)
+  ptyLoadGeneration.delete(id)
+}
+
+function clearProviderPtyState(id: string): void {
+  // Why: OpenCode and Pi both allocate PTY-scoped runtime state outside the
+  // node-pty process table. Centralizing provider cleanup avoids drift where a
+  // new teardown path forgets to remove one provider's overlay/hook state.
+  openCodeHookService.clearPty(id)
+  piTitlebarExtensionService.clearPty(id)
+}
+
 function getShellValidationError(shellPath: string): string | null {
   if (!existsSync(shellPath)) {
     return (
@@ -111,11 +125,8 @@ export function registerPtyHandlers(
         } catch {
           // Process may already be dead
         }
-        ptyProcesses.delete(id)
-        ptyShellName.delete(id)
-        ptyLoadGeneration.delete(id)
-        openCodeHookService.clearPty(id)
-        piTitlebarExtensionService.clearPty(id)
+        clearPtyState(id)
+        clearProviderPtyState(id)
         // Why: notify runtime so the agent detector can close out any live
         // agent sessions. Without this, killed PTYs would remain in the
         // detector's liveAgents map and accumulate inflated durations.
@@ -145,11 +156,8 @@ export function registerPtyHandlers(
       } catch {
         return false
       }
-      ptyProcesses.delete(ptyId)
-      ptyShellName.delete(ptyId)
-      ptyLoadGeneration.delete(ptyId)
-      openCodeHookService.clearPty(ptyId)
-      piTitlebarExtensionService.clearPty(ptyId)
+      clearPtyState(ptyId)
+      clearProviderPtyState(ptyId)
       runtime?.onPtyExit(ptyId, -1)
       return true
     }
@@ -357,11 +365,8 @@ export function registerPtyHandlers(
       })
 
       proc.onExit(({ exitCode }) => {
-        ptyProcesses.delete(id)
-        ptyShellName.delete(id)
-        ptyLoadGeneration.delete(id)
-        openCodeHookService.clearPty(id)
-        piTitlebarExtensionService.clearPty(id)
+        clearPtyState(id)
+        clearProviderPtyState(id)
         runtime?.onPtyExit(id, exitCode)
         if (!mainWindow.isDestroyed()) {
           mainWindow.webContents.send('pty:exit', { id, code: exitCode })
@@ -394,11 +399,8 @@ export function registerPtyHandlers(
       } catch {
         // Process may already be dead
       }
-      ptyProcesses.delete(args.id)
-      ptyShellName.delete(args.id)
-      ptyLoadGeneration.delete(args.id)
-      openCodeHookService.clearPty(args.id)
-      piTitlebarExtensionService.clearPty(args.id)
+      clearPtyState(args.id)
+      clearProviderPtyState(args.id)
       runtime?.onPtyExit(args.id, -1)
     }
   })
@@ -454,10 +456,7 @@ export function killAllPty(): void {
     } catch {
       // Process may already be dead
     }
-    ptyProcesses.delete(id)
-    ptyShellName.delete(id)
-    ptyLoadGeneration.delete(id)
-    openCodeHookService.clearPty(id)
-    piTitlebarExtensionService.clearPty(id)
+    clearPtyState(id)
+    clearProviderPtyState(id)
   }
 }

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -115,6 +115,7 @@ export function registerPtyHandlers(
         ptyShellName.delete(id)
         ptyLoadGeneration.delete(id)
         openCodeHookService.clearPty(id)
+        piTitlebarExtensionService.clearPty(id)
         // Why: notify runtime so the agent detector can close out any live
         // agent sessions. Without this, killed PTYs would remain in the
         // detector's liveAgents map and accumulate inflated durations.
@@ -148,6 +149,7 @@ export function registerPtyHandlers(
       ptyShellName.delete(ptyId)
       ptyLoadGeneration.delete(ptyId)
       openCodeHookService.clearPty(ptyId)
+      piTitlebarExtensionService.clearPty(ptyId)
       runtime?.onPtyExit(ptyId, -1)
       return true
     }
@@ -236,7 +238,13 @@ export function registerPtyHandlers(
         delete openCodeHookEnv.OPENCODE_CONFIG_DIR
       }
       Object.assign(spawnEnv, openCodeHookEnv)
-      Object.assign(spawnEnv, piTitlebarExtensionService.buildPtyEnv(spawnEnv.PATH))
+      // Why: PI_CODING_AGENT_DIR owns Pi's full config/session root. Build a
+      // PTY-scoped overlay from the caller's chosen root so Pi sessions keep
+      // their user state without sharing a mutable overlay across terminals.
+      Object.assign(
+        spawnEnv,
+        piTitlebarExtensionService.buildPtyEnv(id, spawnEnv.PI_CODING_AGENT_DIR)
+      )
 
       // Why: the selected Codex account should affect Codex launched inside
       // Orca terminals too, not just Orca's background quota fetches. Inject
@@ -353,6 +361,7 @@ export function registerPtyHandlers(
         ptyShellName.delete(id)
         ptyLoadGeneration.delete(id)
         openCodeHookService.clearPty(id)
+        piTitlebarExtensionService.clearPty(id)
         runtime?.onPtyExit(id, exitCode)
         if (!mainWindow.isDestroyed()) {
           mainWindow.webContents.send('pty:exit', { id, code: exitCode })
@@ -389,6 +398,7 @@ export function registerPtyHandlers(
       ptyShellName.delete(args.id)
       ptyLoadGeneration.delete(args.id)
       openCodeHookService.clearPty(args.id)
+      piTitlebarExtensionService.clearPty(args.id)
       runtime?.onPtyExit(args.id, -1)
     }
   })
@@ -448,5 +458,6 @@ export function killAllPty(): void {
     ptyShellName.delete(id)
     ptyLoadGeneration.delete(id)
     openCodeHookService.clearPty(id)
+    piTitlebarExtensionService.clearPty(id)
   }
 }

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -10,6 +10,7 @@ import * as pty from 'node-pty'
 import type { OrcaRuntimeService } from '../runtime/orca-runtime'
 import { parseWslPath } from '../wsl'
 import { openCodeHookService } from '../opencode/hook-service'
+import { piTitlebarExtensionService } from '../pi/titlebar-extension-service'
 
 let ptyCounter = 0
 const ptyProcesses = new Map<string, pty.IPty>()
@@ -235,6 +236,7 @@ export function registerPtyHandlers(
         delete openCodeHookEnv.OPENCODE_CONFIG_DIR
       }
       Object.assign(spawnEnv, openCodeHookEnv)
+      Object.assign(spawnEnv, piTitlebarExtensionService.buildPtyEnv(spawnEnv.PATH))
 
       // Why: the selected Codex account should affect Codex launched inside
       // Orca terminals too, not just Orca's background quota fetches. Inject

--- a/src/main/pi/titlebar-extension-service.ts
+++ b/src/main/pi/titlebar-extension-service.ts
@@ -1,10 +1,22 @@
-import { execFileSync } from 'child_process'
-import { mkdirSync, writeFileSync, chmodSync } from 'fs'
-import { delimiter, join } from 'path'
+import {
+  cpSync,
+  existsSync,
+  linkSync,
+  mkdirSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync
+} from 'fs'
+import { homedir } from 'os'
+import { basename, join } from 'path'
 import { app } from 'electron'
 
 const ORCA_PI_EXTENSION_FILE = 'orca-titlebar-spinner.ts'
-const ORCA_PI_WRAPPER_FILE = process.platform === 'win32' ? 'pi.cmd' : 'pi'
+const PI_AGENT_DIR_NAME = '.pi'
+const PI_AGENT_SUBDIR = 'agent'
+const PI_OVERLAY_DIR_NAME = 'pi-agent-overlays'
 
 function getPiTitlebarExtensionSource(): string {
   return [
@@ -68,85 +80,87 @@ function getPiTitlebarExtensionSource(): string {
   ].join('\n')
 }
 
-function getUnixWrapperSource(): string {
-  return [
-    '#!/bin/sh',
-    '# Why: Pi only loads extra titlebar behavior via extension files. Orca',
-    '# prepends this PTY-local wrapper to PATH so every `pi` launch gets the',
-    "# spinner extension without overwriting the user's PI_CODING_AGENT_DIR.",
-    'exec "$ORCA_PI_REAL_BIN" --extension "$ORCA_PI_EXTENSION_PATH" "$@"',
-    ''
-  ].join('\n')
+function getDefaultPiAgentDir(): string {
+  return join(homedir(), PI_AGENT_DIR_NAME, PI_AGENT_SUBDIR)
 }
 
-function getWindowsWrapperSource(): string {
-  return [
-    '@echo off',
-    'REM Why: Pi only exposes spinner title updates through an extension. Orca',
-    'REM prepends this PTY-local wrapper to PATH so every `pi` launch gets the',
-    "REM spinner extension without replacing the user's Pi config directory.",
-    '"%ORCA_PI_REAL_BIN%" --extension "%ORCA_PI_EXTENSION_PATH%" %*',
-    ''
-  ].join('\r\n')
-}
+function mirrorEntry(sourcePath: string, targetPath: string): void {
+  const sourceStats = statSync(sourcePath)
 
-function resolvePiBinary(): string | null {
-  try {
-    if (process.platform === 'win32') {
-      const stdout = execFileSync('where.exe', ['pi'], {
-        encoding: 'utf8',
-        stdio: ['ignore', 'pipe', 'ignore']
-      })
-      return (
-        stdout
-          .split(/\r?\n/)
-          .map((line) => line.trim())
-          .find(Boolean) || null
-      )
+  if (process.platform === 'win32') {
+    if (sourceStats.isDirectory()) {
+      symlinkSync(sourcePath, targetPath, 'junction')
+      return
     }
 
-    const stdout = execFileSync('which', ['pi'], {
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'ignore']
-    })
-    return stdout.trim() || null
-  } catch {
-    return null
+    try {
+      linkSync(sourcePath, targetPath)
+      return
+    } catch {
+      cpSync(sourcePath, targetPath)
+      return
+    }
   }
+
+  symlinkSync(sourcePath, targetPath, sourceStats.isDirectory() ? 'dir' : 'file')
 }
 
 export class PiTitlebarExtensionService {
-  buildPtyEnv(existingPath: string | undefined): Record<string, string> {
-    const realPiPath = resolvePiBinary()
-    if (!realPiPath) {
-      return {}
+  private getOverlayDir(ptyId: string): string {
+    return join(app.getPath('userData'), PI_OVERLAY_DIR_NAME, ptyId)
+  }
+
+  private mirrorAgentDir(sourceAgentDir: string, overlayDir: string): void {
+    if (!existsSync(sourceAgentDir)) {
+      return
     }
 
-    const runtimeDir = join(app.getPath('userData'), 'pi-runtime')
-    const binDir = join(runtimeDir, 'bin')
-    mkdirSync(binDir, { recursive: true })
+    for (const entry of readdirSync(sourceAgentDir, { withFileTypes: true })) {
+      const sourcePath = join(sourceAgentDir, entry.name)
 
-    const extensionPath = join(runtimeDir, ORCA_PI_EXTENSION_FILE)
-    writeFileSync(extensionPath, getPiTitlebarExtensionSource())
+      if (entry.name === 'extensions' && entry.isDirectory()) {
+        const overlayExtensionsDir = join(overlayDir, 'extensions')
+        mkdirSync(overlayExtensionsDir, { recursive: true })
+        for (const extensionEntry of readdirSync(sourcePath, { withFileTypes: true })) {
+          mirrorEntry(
+            join(sourcePath, extensionEntry.name),
+            join(overlayExtensionsDir, extensionEntry.name)
+          )
+        }
+        continue
+      }
 
-    const wrapperPath = join(binDir, ORCA_PI_WRAPPER_FILE)
-    writeFileSync(
-      wrapperPath,
-      process.platform === 'win32' ? getWindowsWrapperSource() : getUnixWrapperSource()
-    )
-    if (process.platform !== 'win32') {
-      chmodSync(wrapperPath, 0o755)
+      // Why: PI_CODING_AGENT_DIR controls Pi's entire state tree, not just
+      // extension discovery. Mirror the user's top-level Pi resources into the
+      // overlay so enabling Orca's titlebar extension preserves auth, sessions,
+      // skills, prompts, themes, and any future files Pi stores there.
+      mirrorEntry(sourcePath, join(overlayDir, basename(sourcePath)))
     }
+  }
+
+  buildPtyEnv(ptyId: string, existingAgentDir: string | undefined): Record<string, string> {
+    const sourceAgentDir = existingAgentDir || getDefaultPiAgentDir()
+    const overlayDir = this.getOverlayDir(ptyId)
+
+    rmSync(overlayDir, { recursive: true, force: true })
+    mkdirSync(overlayDir, { recursive: true })
+    this.mirrorAgentDir(sourceAgentDir, overlayDir)
+
+    const extensionsDir = join(overlayDir, 'extensions')
+    mkdirSync(extensionsDir, { recursive: true })
+    // Why: Pi auto-loads global extensions from PI_CODING_AGENT_DIR/extensions.
+    // Add Orca's titlebar extension alongside the user's existing extensions
+    // instead of replacing that directory, otherwise Orca terminals would
+    // silently disable the user's Pi customization inside Orca only.
+    writeFileSync(join(extensionsDir, ORCA_PI_EXTENSION_FILE), getPiTitlebarExtensionSource())
 
     return {
-      // Why: `pi` is launched manually inside an interactive shell, not through
-      // Orca's direct provider spawner. Prepending a wrapper directory is the
-      // only way to add the titlebar extension for arbitrary future `pi`
-      // commands without mutating the user's global Pi config directory.
-      PATH: existingPath ? `${binDir}${delimiter}${existingPath}` : binDir,
-      ORCA_PI_REAL_BIN: realPiPath,
-      ORCA_PI_EXTENSION_PATH: extensionPath
+      PI_CODING_AGENT_DIR: overlayDir
     }
+  }
+
+  clearPty(ptyId: string): void {
+    rmSync(this.getOverlayDir(ptyId), { recursive: true, force: true })
   }
 }
 

--- a/src/main/pi/titlebar-extension-service.ts
+++ b/src/main/pi/titlebar-extension-service.ts
@@ -1,0 +1,153 @@
+import { execFileSync } from 'child_process'
+import { mkdirSync, writeFileSync, chmodSync } from 'fs'
+import { delimiter, join } from 'path'
+import { app } from 'electron'
+
+const ORCA_PI_EXTENSION_FILE = 'orca-titlebar-spinner.ts'
+const ORCA_PI_WRAPPER_FILE = process.platform === 'win32' ? 'pi.cmd' : 'pi'
+
+function getPiTitlebarExtensionSource(): string {
+  return [
+    'const BRAILLE_FRAMES = [',
+    "  '\\u280b',",
+    "  '\\u2819',",
+    "  '\\u2839',",
+    "  '\\u2838',",
+    "  '\\u283c',",
+    "  '\\u2834',",
+    "  '\\u2826',",
+    "  '\\u2827',",
+    "  '\\u2807',",
+    "  '\\u280f'",
+    ']',
+    '',
+    'function getBaseTitle(pi) {',
+    '  const cwd = process.cwd().split(/[\\\\/]/).filter(Boolean).at(-1) || process.cwd()',
+    '  const session = pi.getSessionName()',
+    '  return session ? `\\u03c0 - ${session} - ${cwd}` : `\\u03c0 - ${cwd}`',
+    '}',
+    '',
+    'export default function (pi) {',
+    '  let timer = null',
+    '  let frameIndex = 0',
+    '',
+    '  function stopAnimation(ctx) {',
+    '    if (timer) {',
+    '      clearInterval(timer)',
+    '      timer = null',
+    '    }',
+    '    frameIndex = 0',
+    '    ctx.ui.setTitle(getBaseTitle(pi))',
+    '  }',
+    '',
+    '  function startAnimation(ctx) {',
+    '    stopAnimation(ctx)',
+    '    timer = setInterval(() => {',
+    '      const frame = BRAILLE_FRAMES[frameIndex % BRAILLE_FRAMES.length]',
+    '      const cwd = process.cwd().split(/[\\\\/]/).filter(Boolean).at(-1) || process.cwd()',
+    '      const session = pi.getSessionName()',
+    '      const title = session ? `${frame} \\u03c0 - ${session} - ${cwd}` : `${frame} \\u03c0 - ${cwd}`',
+    '      ctx.ui.setTitle(title)',
+    '      frameIndex++',
+    '    }, 80)',
+    '  }',
+    '',
+    "  pi.on('agent_start', async (_event, ctx) => {",
+    '    startAnimation(ctx)',
+    '  })',
+    '',
+    "  pi.on('agent_end', async (_event, ctx) => {",
+    '    stopAnimation(ctx)',
+    '  })',
+    '',
+    "  pi.on('session_shutdown', async (_event, ctx) => {",
+    '    stopAnimation(ctx)',
+    '  })',
+    '}',
+    ''
+  ].join('\n')
+}
+
+function getUnixWrapperSource(): string {
+  return [
+    '#!/bin/sh',
+    '# Why: Pi only loads extra titlebar behavior via extension files. Orca',
+    '# prepends this PTY-local wrapper to PATH so every `pi` launch gets the',
+    "# spinner extension without overwriting the user's PI_CODING_AGENT_DIR.",
+    'exec "$ORCA_PI_REAL_BIN" --extension "$ORCA_PI_EXTENSION_PATH" "$@"',
+    ''
+  ].join('\n')
+}
+
+function getWindowsWrapperSource(): string {
+  return [
+    '@echo off',
+    'REM Why: Pi only exposes spinner title updates through an extension. Orca',
+    'REM prepends this PTY-local wrapper to PATH so every `pi` launch gets the',
+    "REM spinner extension without replacing the user's Pi config directory.",
+    '"%ORCA_PI_REAL_BIN%" --extension "%ORCA_PI_EXTENSION_PATH%" %*',
+    ''
+  ].join('\r\n')
+}
+
+function resolvePiBinary(): string | null {
+  try {
+    if (process.platform === 'win32') {
+      const stdout = execFileSync('where.exe', ['pi'], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore']
+      })
+      return (
+        stdout
+          .split(/\r?\n/)
+          .map((line) => line.trim())
+          .find(Boolean) || null
+      )
+    }
+
+    const stdout = execFileSync('which', ['pi'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore']
+    })
+    return stdout.trim() || null
+  } catch {
+    return null
+  }
+}
+
+export class PiTitlebarExtensionService {
+  buildPtyEnv(existingPath: string | undefined): Record<string, string> {
+    const realPiPath = resolvePiBinary()
+    if (!realPiPath) {
+      return {}
+    }
+
+    const runtimeDir = join(app.getPath('userData'), 'pi-runtime')
+    const binDir = join(runtimeDir, 'bin')
+    mkdirSync(binDir, { recursive: true })
+
+    const extensionPath = join(runtimeDir, ORCA_PI_EXTENSION_FILE)
+    writeFileSync(extensionPath, getPiTitlebarExtensionSource())
+
+    const wrapperPath = join(binDir, ORCA_PI_WRAPPER_FILE)
+    writeFileSync(
+      wrapperPath,
+      process.platform === 'win32' ? getWindowsWrapperSource() : getUnixWrapperSource()
+    )
+    if (process.platform !== 'win32') {
+      chmodSync(wrapperPath, 0o755)
+    }
+
+    return {
+      // Why: `pi` is launched manually inside an interactive shell, not through
+      // Orca's direct provider spawner. Prepending a wrapper directory is the
+      // only way to add the titlebar extension for arbitrary future `pi`
+      // commands without mutating the user's global Pi config directory.
+      PATH: existingPath ? `${binDir}${delimiter}${existingPath}` : binDir,
+      ORCA_PI_REAL_BIN: realPiPath,
+      ORCA_PI_EXTENSION_PATH: extensionPath
+    }
+  }
+}
+
+export const piTitlebarExtensionService = new PiTitlebarExtensionService()

--- a/src/renderer/src/lib/agent-status.test.ts
+++ b/src/renderer/src/lib/agent-status.test.ts
@@ -153,6 +153,11 @@ describe('detectAgentStatusFromTitle', () => {
     expect(detectAgentStatusFromTitle('opencode')).toBe('idle')
   })
 
+  it('detects Pi idle titles', () => {
+    expect(detectAgentStatusFromTitle('π - my-project')).toBe('idle')
+    expect(detectAgentStatusFromTitle('π - session-name - my-project')).toBe('idle')
+  })
+
   // --- Case insensitivity ---
   it('is case-insensitive for agent names', () => {
     expect(detectAgentStatusFromTitle('CLAUDE')).toBe('idle')
@@ -204,6 +209,11 @@ describe('normalizeTerminalTitle', () => {
   it('leaves non-Gemini titles unchanged', () => {
     expect(normalizeTerminalTitle('⠂ Claude Code')).toBe('⠂ Claude Code')
     expect(normalizeTerminalTitle('bash')).toBe('bash')
+  })
+
+  it('collapses Pi spinner and idle titles to stable labels', () => {
+    expect(normalizeTerminalTitle('⠋ π - my-project')).toBe('⠋ Pi')
+    expect(normalizeTerminalTitle('π - my-project')).toBe('Pi')
   })
 })
 
@@ -289,6 +299,15 @@ describe('createAgentStatusTracker', () => {
 
     tracker.handleTitle('⠋ Codex is thinking') // working
     tracker.handleTitle('codex') // idle (bare name)
+    expect(onBecameIdle).toHaveBeenCalledTimes(1)
+  })
+
+  it('fires on Pi working → idle', () => {
+    const onBecameIdle = vi.fn()
+    const tracker = createAgentStatusTracker(onBecameIdle)
+
+    tracker.handleTitle('⠋ π - my-project')
+    tracker.handleTitle('π - my-project')
     expect(onBecameIdle).toHaveBeenCalledTimes(1)
   })
 

--- a/src/shared/agent-detection.ts
+++ b/src/shared/agent-detection.ts
@@ -17,6 +17,7 @@ const GEMINI_IDLE = '\u25C7' // ◇
 const GEMINI_PERMISSION = '\u270B' // ✋
 
 export const AGENT_NAMES = ['claude', 'codex', 'gemini', 'opencode', 'aider']
+const PI_IDLE_PREFIX = '\u03c0 - ' // π - (Pi titlebar extension idle format)
 
 // eslint-disable-next-line no-control-regex -- intentional terminal escape sequence matching
 const OSC_TITLE_RE = /\x1b\]([012]);([^\x07\x1b]*?)(?:\x07|\x1b\\)/g
@@ -45,6 +46,10 @@ export function isGeminiTerminalTitle(title: string): boolean {
     title.includes(GEMINI_IDLE) ||
     title.toLowerCase().includes('gemini')
   )
+}
+
+export function isPiTerminalTitle(title: string): boolean {
+  return title.startsWith(PI_IDLE_PREFIX)
 }
 
 function containsBrailleSpinner(title: string): boolean {
@@ -167,6 +172,22 @@ export function normalizeTerminalTitle(title: string): string {
     }
   }
 
+  // Why: Pi's titlebar extension animates every 80ms with different braille
+  // frames. Collapsing those frames into one stable label avoids renderer
+  // churn while preserving the working/idle transition Orca keys off.
+  if (
+    isPiTerminalTitle(title) ||
+    (containsBrailleSpinner(title) && title.includes(PI_IDLE_PREFIX))
+  ) {
+    const status = detectAgentStatusFromTitle(title)
+    if (status === 'working') {
+      return '\u280b Pi'
+    }
+    if (status === 'idle') {
+      return 'Pi'
+    }
+  }
+
   return title
 }
 
@@ -224,6 +245,10 @@ export function detectAgentStatusFromTitle(title: string): AgentStatus | null {
   // Claude Code uses ✳ prefix for idle — must check before braille/agent-name
   // because the title text is the task description, not "Claude Code".
   if (title.startsWith(`${CLAUDE_IDLE} `) || title === CLAUDE_IDLE) {
+    return 'idle'
+  }
+
+  if (isPiTerminalTitle(title)) {
     return 'idle'
   }
 


### PR DESCRIPTION
## Problem
Pi sessions in Orca only exposed a static `π - ...` title by default, so Orca could not reliably tell when Pi was actively working or when it had returned to idle. That meant the existing terminal activity spinner and completion notification flow did not work for Pi unless the user manually configured a titlebar extension.

## Solution
Add an Orca-managed Pi titlebar extension and inject it automatically into Orca PTYs by building a PTY-scoped `PI_CODING_AGENT_DIR` overlay. The overlay preserves the user's Pi state and existing extensions, while adding Orca's braille-spinner titlebar extension so Pi emits working and idle title transitions inside Orca. Orca now recognizes Pi idle titles, normalizes Pi spinner frames to a stable display label, and cleans up Pi PTY overlays alongside the existing provider PTY cleanup paths.