### PR TITLE
[codex] Guard traffic light sync off macOS

### DIFF
--- a/src/main/window/createMainWindow.test.ts
+++ b/src/main/window/createMainWindow.test.ts
@@ -34,6 +34,7 @@ vi.mock('../browser/browser-manager', () => ({
 }))
 
 import { createMainWindow } from './createMainWindow'
+import { ipcMain } from 'electron'
 
 describe('createMainWindow', () => {
   beforeEach(() => {
@@ -41,6 +42,8 @@ describe('createMainWindow', () => {
     openExternalMock.mockReset()
     attachGuestPoliciesMock.mockReset()
     isMock.dev = false
+    vi.mocked(ipcMain.on).mockReset()
+    vi.mocked(ipcMain.removeListener).mockReset()
   })
 
   it('enables renderer sandboxing and opens external links safely', () => {
@@ -435,5 +438,53 @@ describe('createMainWindow', () => {
 
     windowHandlers['will-prevent-unload']()
     expect(onQuitAborted).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores traffic light sync IPC on non-macOS', () => {
+    const windowHandlers: Record<string, (...args: any[]) => void> = {}
+    const webContents = {
+      on: vi.fn((event, handler) => {
+        windowHandlers[event] = handler
+      }),
+      setZoomLevel: vi.fn(),
+      setBackgroundThrottling: vi.fn(),
+      invalidate: vi.fn(),
+      setWindowOpenHandler: vi.fn(),
+      send: vi.fn()
+    }
+    const browserWindowInstance = {
+      webContents,
+      on: vi.fn(),
+      isDestroyed: vi.fn(() => false),
+      isMaximized: vi.fn(() => true),
+      isFullScreen: vi.fn(() => false),
+      getSize: vi.fn(() => [1200, 800]),
+      setSize: vi.fn(),
+      setWindowButtonPosition: vi.fn(),
+      maximize: vi.fn(),
+      show: vi.fn(),
+      loadFile: vi.fn(),
+      loadURL: vi.fn()
+    }
+    browserWindowMock.mockImplementation(function () {
+      return browserWindowInstance
+    })
+
+    createMainWindow(null)
+
+    const syncListener = vi
+      .mocked(ipcMain.on)
+      .mock.calls.find(([channel]) => channel === 'ui:sync-traffic-lights')?.[1]
+
+    expect(syncListener).toBeTypeOf('function')
+
+    syncListener?.({} as never, 1.2)
+
+    if (process.platform === 'darwin') {
+      expect(browserWindowInstance.setWindowButtonPosition).toHaveBeenCalledWith({ x: 16, y: 18 })
+      return
+    }
+
+    expect(browserWindowInstance.setWindowButtonPosition).not.toHaveBeenCalled()
   })
 })

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -38,7 +38,7 @@ const TRAFFIC_LIGHT_RADIUS = 6
 const TRAFFIC_LIGHT_X = 16
 
 function syncTrafficLightPosition(win: BrowserWindow, zoomFactor: number): void {
-  if (win.isDestroyed()) {
+  if (process.platform !== 'darwin' || win.isDestroyed()) {
     return
   }
   const y = Math.round(TITLEBAR_CSS_CENTER * zoomFactor - TRAFFIC_LIGHT_RADIUS)

--- a/src/renderer/src/lib/ui-zoom.ts
+++ b/src/renderer/src/lib/ui-zoom.ts
@@ -1,3 +1,5 @@
+const isMac = navigator.userAgent.includes('Mac')
+
 /**
  * Apply a UI zoom level change: sets webFrame zoom via the preload API,
  * updates the CSS variable used to compensate the traffic-light pad,
@@ -7,7 +9,9 @@ export function applyUIZoom(level: number): void {
   const zoomFactor = Math.pow(1.2, level)
   window.api.ui.setZoomLevel(level)
   document.documentElement.style.setProperty('--ui-zoom-factor', String(zoomFactor))
-  window.api.ui.syncTrafficLights(zoomFactor)
+  if (isMac) {
+    window.api.ui.syncTrafficLights(zoomFactor)
+  }
 }
 
 /**
@@ -18,5 +22,7 @@ export function syncZoomCSSVar(): void {
   const level = window.api.ui.getZoomLevel()
   const zoomFactor = Math.pow(1.2, level)
   document.documentElement.style.setProperty('--ui-zoom-factor', String(zoomFactor))
-  window.api.ui.syncTrafficLights(zoomFactor)
+  if (isMac) {
+    window.api.ui.syncTrafficLights(zoomFactor)
+  }
 }


### PR DESCRIPTION
## Summary
- guard the main-process traffic light sync path so `BrowserWindow.setWindowButtonPosition()` never runs outside macOS
- skip renderer traffic light sync IPC on Linux and Windows while preserving the existing macOS behavior
- add a regression test covering the non-macOS IPC path

## Root Cause
Linux and Windows could still emit the zoom-sync IPC during startup, but the main process called a macOS-only BrowserWindow API unconditionally. That crashed startup with `TypeError: win.setWindowButtonPosition is not a function`.

## User Impact
This fixes app startup on Linux and Windows when the UI zoom sync path runs. There is no intended user-visible behavior change on macOS.

## Validation
- `pnpm lint` (passes; existing unrelated warning in `src/renderer/src/components/terminal-pane/TerminalPane.tsx`)
- `pnpm typecheck`
- `pnpm vitest run --config config/vitest.config.ts src/main/window/createMainWindow.test.ts src/renderer/src/hooks/useIpcEvents.test.ts`

## Cross-Platform Review
- main-process native window-button calls are now gated with `process.platform !== 'darwin'`
- renderer traffic-light sync IPC is only sent on macOS, matching existing renderer platform checks elsewhere in the codebase
- no path handling or shortcut behavior changed

## Security Review
- no new IPC channels or preload surface were added
- the change reduces exposure by avoiding unsupported native API calls on non-macOS platforms
- external navigation, guest webview policy, and privilege boundaries are unchanged

## Visual Changes
No visual change beyond preventing the startup crash on Linux and Windows.

## Platform Notes
- manually reproduced the failure on Linux from the startup stack trace and fixed the non-macOS path
- macOS behavior remains unchanged by construction but was not manually exercised in this environment

## X Handle
Not provided.
