### PR TITLE
fix: prevent agent badge clipping and portal tabs into titlebar

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -540,59 +540,61 @@ function App(): React.JSX.Element {
               </Tooltip>
             )}
             <div className="titlebar-title">Orca</div>
-            {settings?.showTitlebarAgentActivity !== false ? (
-              <HoverCard openDelay={200} closeDelay={100}>
-                <HoverCardTrigger asChild>
-                  <span
-                    className={`titlebar-agent-badge${activeAgentCount === 0 ? ' titlebar-agent-badge-idle' : ''}`}
-                    aria-label={`${activeAgentCount} ${activeAgentCount === 1 ? 'agent' : 'agents'} active`}
-                  >
-                    <span
-                      className={`titlebar-agent-badge-dot${activeAgentCount === 0 ? ' titlebar-agent-badge-dot-idle' : ''}`}
-                      aria-hidden
-                    />
-                    <span className="titlebar-agent-badge-count">{activeAgentCount}</span>
-                    <span className="titlebar-agent-badge-label">active</span>
-                  </span>
-                </HoverCardTrigger>
-                <HoverCardContent side="bottom" sideOffset={6} className="titlebar-agent-hovercard">
-                  <div className="titlebar-agent-hovercard-header">
-                    {activeAgentCount === 0
-                      ? 'No agents active'
-                      : `${activeAgentCount} ${activeAgentCount === 1 ? 'agent' : 'agents'} active`}
-                  </div>
-                  {activeAgentCount > 0 && (
-                    <div className="titlebar-agent-hovercard-list">
-                      {Object.entries(agentCountByWorktree).map(([worktreeId, count]) => {
-                        const wt = findWorktreeById(worktreesByRepo, worktreeId)
-                        return (
-                          <button
-                            key={worktreeId}
-                            className="titlebar-agent-hovercard-row"
-                            onClick={() => activateAndRevealWorktree(worktreeId)}
-                          >
-                            <span className="titlebar-agent-hovercard-name">
-                              {wt?.displayName ?? worktreeId}
-                            </span>
-                            <span className="titlebar-agent-hovercard-count">
-                              {count} <span className="titlebar-agent-hovercard-dot" />
-                            </span>
-                          </button>
-                        )
-                      })}
-                    </div>
-                  )}
-                </HoverCardContent>
-              </HoverCard>
-            ) : null}
           </div>
-          {/* Why: keep the center titlebar slot mounted even when no content is
-              using it. Collapsing this spacer lets the right-side controls jump
-              left in empty states; `invisible` preserves titlebar alignment
-              without reserving a second tab-rendering path. */}
+          {/* Why: agent badge is outside the sidebar-width container so it is
+              never clipped when the sidebar is narrow. */}
+          {settings?.showTitlebarAgentActivity !== false ? (
+            <HoverCard openDelay={200} closeDelay={100}>
+              <HoverCardTrigger asChild>
+                <span
+                  className={`titlebar-agent-badge${activeAgentCount === 0 ? ' titlebar-agent-badge-idle' : ''}`}
+                  aria-label={`${activeAgentCount} ${activeAgentCount === 1 ? 'agent' : 'agents'} active`}
+                >
+                  <span
+                    className={`titlebar-agent-badge-dot${activeAgentCount === 0 ? ' titlebar-agent-badge-dot-idle' : ''}`}
+                    aria-hidden
+                  />
+                  <span className="titlebar-agent-badge-count">{activeAgentCount}</span>
+                  <span className="titlebar-agent-badge-label">active</span>
+                </span>
+              </HoverCardTrigger>
+              <HoverCardContent side="bottom" sideOffset={6} className="titlebar-agent-hovercard">
+                <div className="titlebar-agent-hovercard-header">
+                  {activeAgentCount === 0
+                    ? 'No agents active'
+                    : `${activeAgentCount} ${activeAgentCount === 1 ? 'agent' : 'agents'} active`}
+                </div>
+                {activeAgentCount > 0 && (
+                  <div className="titlebar-agent-hovercard-list">
+                    {Object.entries(agentCountByWorktree).map(([worktreeId, count]) => {
+                      const wt = findWorktreeById(worktreesByRepo, worktreeId)
+                      return (
+                        <button
+                          key={worktreeId}
+                          className="titlebar-agent-hovercard-row"
+                          onClick={() => activateAndRevealWorktree(worktreeId)}
+                        >
+                          <span className="titlebar-agent-hovercard-name">
+                            {wt?.displayName ?? worktreeId}
+                          </span>
+                          <span className="titlebar-agent-hovercard-count">
+                            {count} <span className="titlebar-agent-hovercard-dot" />
+                          </span>
+                        </button>
+                      )
+                    })}
+                  </div>
+                )}
+              </HoverCardContent>
+            </HoverCard>
+          ) : null}
+          {/* Why: the center titlebar slot hosts portaled tabs from the active
+              group when no splits are active, saving a full row of vertical
+              space. The slot stays mounted even when empty so the right-side
+              controls don't jump left. */}
           <div
             id="titlebar-tabs"
-            className={`flex flex-1 min-w-0 self-stretch${activeView === 'settings' || !activeWorktreeId ? ' invisible pointer-events-none' : ''}`}
+            className={`flex flex-1 min-w-0 self-stretch items-stretch${activeView === 'settings' || !activeWorktreeId ? ' invisible pointer-events-none' : ''}`}
           />
           {showTitlebarExpandButton && (
             <Tooltip>

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -294,6 +294,13 @@
   user-select: none;
 }
 
+/* When tabs are portaled into the titlebar, the slot inherits the
+   titlebar's drag region — opt the tab strip out so tabs stay
+   clickable and scrollable. */
+#titlebar-tabs > .terminal-tab-strip {
+  -webkit-app-region: no-drag;
+}
+
 .titlebar-traffic-light-pad {
   width: calc(80px / var(--ui-zoom-factor, 1));
   flex-shrink: 0;
@@ -352,6 +359,7 @@
   font-weight: 600;
   line-height: 1;
   white-space: nowrap;
+  flex-shrink: 0;
   cursor: pointer;
 }
 

--- a/src/renderer/src/components/tab-group/TabGroupPanel.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable max-lines -- Why: group panels intentionally co-locate group-scoped tab chrome, activation/close handlers, and surface rendering so split groups cannot drift into a separate behavior path from the original root group. */
-import { lazy, Suspense, useCallback, useMemo } from 'react'
+import { lazy, Suspense, useCallback, useEffect, useMemo, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { X } from 'lucide-react'
 import { useShallow } from 'zustand/react/shallow'
 import type { OpenFile } from '@/store/slices/editor'
@@ -420,6 +421,22 @@ export default function TabGroupPanel({
     />
   )
 
+  /* Why: when there are no splits the tab bar is portaled into the
+     titlebar's #titlebar-tabs slot so the titlebar row doubles as the
+     tab strip, saving ~36 px of vertical space. When the user creates a
+     split, every group renders its own inline tab bar so each pane keeps
+     its own chrome — no visual "jump". */
+  const [titlebarSlot, setTitlebarSlot] = useState<HTMLElement | null>(null)
+  useEffect(() => {
+    if (!hasSplitGroups) {
+      setTitlebarSlot(document.getElementById('titlebar-tabs'))
+    } else {
+      setTitlebarSlot(null)
+    }
+  }, [hasSplitGroups])
+
+  const portalToTitlebar = !hasSplitGroups && titlebarSlot !== null
+
   return (
     <div
       className={`flex flex-col flex-1 min-w-0 min-h-0 overflow-hidden${
@@ -429,28 +446,27 @@ export default function TabGroupPanel({
       }`}
       onPointerDown={() => focusGroup(worktreeId, groupId)}
     >
-      {/* Why: every group, including the initial unsplit root, must render its
-          chrome inside the same panel stack. Portaling the first group's tabs
-          into the window titlebar created a second vertical frame of reference,
-          so the first split appeared to "jump down" when later groups rendered
-          inline below it. */}
-      <div className="flex items-stretch h-9 shrink-0 border-b border-border bg-card">
-        {tabBar}
-        {hasSplitGroups && (
-          <button
-            type="button"
-            aria-label="Close tab group"
-            title="Close tab group"
-            onClick={(event) => {
-              event.stopPropagation()
-              handleCloseGroup()
-            }}
-            className="mr-1 my-1 flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground opacity-0 transition-opacity hover:bg-accent/50 hover:text-foreground group-hover/tab-group:opacity-100 focus:opacity-100"
-          >
-            <X className="size-4" />
-          </button>
-        )}
-      </div>
+      {portalToTitlebar ? (
+        createPortal(tabBar, titlebarSlot)
+      ) : (
+        <div className="flex items-stretch h-9 shrink-0 border-b border-border bg-card">
+          {tabBar}
+          {hasSplitGroups && (
+            <button
+              type="button"
+              aria-label="Close tab group"
+              title="Close tab group"
+              onClick={(event) => {
+                event.stopPropagation()
+                handleCloseGroup()
+              }}
+              className="mr-1 my-1 flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground opacity-0 transition-opacity hover:bg-accent/50 hover:text-foreground group-hover/tab-group:opacity-100 focus:opacity-100"
+            >
+              <X className="size-4" />
+            </button>
+          )}
+        </div>
+      )}
 
       <div className="relative flex-1 min-h-0 overflow-hidden">
         {groupTabs


### PR DESCRIPTION
## Summary

Two titlebar layout fixes:

### 1. Agent badge clipping
The active-agent badge ("● 1 active") was rendered inside the sidebar-width-constrained container with `overflow-hidden`, causing it to get clipped when the sidebar is narrow.

**Fix**: Moved the badge out of the constrained container so it sits as a direct child of the titlebar flex row. Added `flex-shrink: 0` to prevent compression.

**Before**:
<img width="151" height="122" alt="image" src="https://github.com/user-attachments/assets/2fd913dd-bc7b-46d8-a78e-30e2b074b7af" />

The badge text gets cut off — "1 active" becomes "1 activ..."

### 2. Tabs in titlebar (save vertical space)
The titlebar row was entirely empty in its center section (`#titlebar-tabs` was an invisible spacer), while tabs rendered in a separate 36px row below it — wasting vertical screen real estate.

**Fix**: When there are no split groups, the tab bar is portaled into the titlebar's `#titlebar-tabs` slot via `createPortal`, so the titlebar doubles as the tab strip. When splits are active, each group renders its own inline tab bar as before — avoiding the visual "jump" issue noted in the previous implementation.

## Changes

| File | What |
|------|------|
| `App.tsx` | Moved agent badge outside sidebar-width container; updated `#titlebar-tabs` to accept portaled tabs with `items-stretch` |
| `TabGroupPanel.tsx` | Portal tab bar into `#titlebar-tabs` when `!hasSplitGroups`; fall back to inline rendering for splits |
| `main.css` | Added `flex-shrink: 0` to badge; added `#titlebar-tabs > .terminal-tab-strip` no-drag rule for portaled tabs |

## Test plan

- [ ] Open Orca with a narrow sidebar — verify the agent badge ("● N active") is fully visible and not clipped
- [ ] Toggle `showTitlebarAgentActivity` off in Settings → Appearance — badge should disappear
- [ ] With a single worktree (no splits): tabs should render in the titlebar row, no separate tab strip below
- [ ] Create a split (⌘D or drag): both groups should show their own inline tab bars
- [ ] Close the split: tabs should portal back into the titlebar
- [ ] Verify tabs are clickable and scrollable when in the titlebar (no drag region interference)