### PR TITLE
Start new worktrees with a terminal by default

### DIFF
--- a/src/renderer/src/store/slices/tabs.test.ts
+++ b/src/renderer/src/store/slices/tabs.test.ts
@@ -184,6 +184,24 @@ describe('TabsSlice', () => {
 
       expect(store.getState().groupsByWorktree[WT]).toHaveLength(1)
     })
+
+    it('createTab seeds the first terminal into unified tabs before a root group exists', () => {
+      const terminal = store.getState().createTab(WT)
+      const state = store.getState()
+
+      expect(state.tabsByWorktree[WT]).toHaveLength(1)
+      expect(state.unifiedTabsByWorktree[WT]).toEqual([
+        expect.objectContaining({
+          id: terminal.id,
+          entityId: terminal.id,
+          worktreeId: WT,
+          contentType: 'terminal'
+        })
+      ])
+      expect(state.groupsByWorktree[WT]).toHaveLength(1)
+      expect(state.groupsByWorktree[WT][0].activeTabId).toBe(terminal.id)
+      expect(state.groupsByWorktree[WT][0].tabOrder).toEqual([terminal.id])
+    })
   })
 
   // ─── closeUnifiedTab ────────────────────────────────────────────────

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -202,12 +202,15 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       }
     })
     const state = get()
-    const targetGroupId =
-      state.activeGroupIdByWorktree[worktreeId] ?? state.groupsByWorktree[worktreeId]?.[0]?.id
-    if (
-      targetGroupId &&
-      !state.findTabForEntityInGroup(worktreeId, targetGroupId, id, 'terminal')
-    ) {
+    const unifiedTabExists = (state.unifiedTabsByWorktree[worktreeId] ?? []).some(
+      (entry) => entry.contentType === 'terminal' && entry.entityId === id
+    )
+    if (!unifiedTabExists) {
+      // Why: worktree creation can seed the first terminal before Terminal.tsx
+      // mounts and creates that worktree's root group. createUnifiedTab knows
+      // how to create the missing group; gating on an existing group leaves the
+      // terminal in legacy tabsByWorktree only, so the brand-new worktree opens
+      // with an apparently empty tab strip until the user adds another tab.
       state.createUnifiedTab(worktreeId, 'terminal', {
         id,
         entityId: id,
@@ -215,7 +218,7 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         customLabel: tab.customTitle,
         color: tab.color
       })
-    } else if (targetGroupId) {
+    } else {
       state.activateTab(id)
     }
     return tab


### PR DESCRIPTION
## Problem
New worktrees could create a legacy terminal entry before the terminal view had created a root tab group. That left the worktree with no visible terminal tab on first open, so users had to manually add one before they could start working.

## Solution
Update terminal tab creation to always seed the unified tab/group model for the first terminal, even when the worktree has not mounted a root group yet. Add a regression test covering first-terminal creation before any group exists so new worktrees reliably open with a terminal by default.