### PR TITLE
fix: terminal shortcuts firing in wrong worktree

### DIFF
--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -148,7 +148,11 @@ export default function Terminal(): React.JSX.Element | null {
       mountedWorktreeIdsRef.current.delete(id)
     }
   }
-  const initialTabCreationGuardRef = useRef<string | null>(null)
+  // Why: tracks worktrees that have already been initialized (either by
+  // auto-creating a first tab or by having tabs on first activation). Once a
+  // worktree is in this set, closing all its tabs will NOT auto-spawn a
+  // replacement — the user explicitly chose to close them.
+  const initializedWorktreesRef = useRef(new Set<string>())
 
   // Auto-create first tab when worktree activates
   useEffect(() => {
@@ -156,27 +160,22 @@ export default function Terminal(): React.JSX.Element | null {
       return
     }
     if (!activeWorktreeId) {
-      initialTabCreationGuardRef.current = null
       return
     }
 
-    // Why: skip auto-creation if terminal tabs already exist, or if editor files
-    // are open for this worktree. The user may have intentionally closed all
-    // terminal tabs while keeping editors open — auto-spawning a terminal would
-    // be disruptive.
     if (tabs.length > 0 || worktreeFiles.length > 0 || worktreeBrowserTabs.length > 0) {
-      if (initialTabCreationGuardRef.current === activeWorktreeId) {
-        initialTabCreationGuardRef.current = null
-      }
+      initializedWorktreesRef.current.add(activeWorktreeId)
       return
     }
 
-    // In React StrictMode (dev), mount effects are intentionally invoked twice.
-    // Track the worktree we already initialized so we only create one first tab.
-    if (initialTabCreationGuardRef.current === activeWorktreeId) {
+    // Why: once a worktree has been initialized (had tabs or auto-created one),
+    // don't auto-create again. This prevents a new terminal from spawning
+    // immediately after the user closes the last tab. Also guards against
+    // React StrictMode double-invocation.
+    if (initializedWorktreesRef.current.has(activeWorktreeId)) {
       return
     }
-    initialTabCreationGuardRef.current = activeWorktreeId
+    initializedWorktreesRef.current.add(activeWorktreeId)
     createTab(activeWorktreeId)
   }, [
     workspaceSessionReady,
@@ -544,7 +543,11 @@ export default function Terminal(): React.JSX.Element | null {
               <TabGroupSplitLayout
                 layout={effectiveLayout}
                 worktreeId={worktree.id}
-                focusedGroupId={activeGroupIdByWorktree[worktree.id]}
+                // Why: hidden worktrees must not have a focused group, otherwise
+                // their TerminalPanes register window-level keydown handlers
+                // that fire alongside the visible worktree's handlers — causing
+                // shortcuts like Cmd+D to split panes in the wrong worktree.
+                focusedGroupId={isVisible ? activeGroupIdByWorktree[worktree.id] : undefined}
               />
             </div>
           )

--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
@@ -140,7 +140,7 @@ export function useTerminalKeyboardShortcuts({
 
       if (action.type === 'sendInput') {
         e.preventDefault()
-        e.stopPropagation()
+        e.stopImmediatePropagation()
         const pane = manager.getActivePane() ?? manager.getPanes()[0]
         if (!pane) {
           return
@@ -165,7 +165,7 @@ export function useTerminalKeyboardShortcuts({
           return
         }
         e.preventDefault()
-        e.stopPropagation()
+        e.stopImmediatePropagation()
         void window.api.ui.writeClipboardText(selection).catch(() => {
           /* ignore clipboard write failures */
         })
@@ -176,7 +176,7 @@ export function useTerminalKeyboardShortcuts({
       // top-level find-in-page flow to fall back to.
       if (action.type === 'toggleSearch') {
         e.preventDefault()
-        e.stopPropagation()
+        e.stopImmediatePropagation()
         setSearchOpen((prev) => !prev)
         return
       }
@@ -184,7 +184,7 @@ export function useTerminalKeyboardShortcuts({
       // Cmd+K clears active pane screen + scrollback.
       if (action.type === 'clearActivePane') {
         e.preventDefault()
-        e.stopPropagation()
+        e.stopImmediatePropagation()
         const pane = manager.getActivePane() ?? manager.getPanes()[0]
         if (pane) {
           pane.terminal.clear()
@@ -199,7 +199,7 @@ export function useTerminalKeyboardShortcuts({
           return
         }
         e.preventDefault()
-        e.stopPropagation()
+        e.stopImmediatePropagation()
 
         // Collapse expanded pane before switching
         if (expandedPaneIdRef.current !== null) {
@@ -228,7 +228,7 @@ export function useTerminalKeyboardShortcuts({
           return
         }
         e.preventDefault()
-        e.stopPropagation()
+        e.stopImmediatePropagation()
         const pane = manager.getActivePane() ?? panes[0]
         if (!pane) {
           return
@@ -243,7 +243,7 @@ export function useTerminalKeyboardShortcuts({
       // every pane instead of just the focused one.
       if (action.type === 'closeActivePane') {
         e.preventDefault()
-        e.stopPropagation()
+        e.stopImmediatePropagation()
         const pane = manager.getActivePane() ?? manager.getPanes()[0]
         if (!pane) {
           return
@@ -257,7 +257,7 @@ export function useTerminalKeyboardShortcuts({
       // (matches Ghostty behavior).
       if (action.type === 'splitActivePane') {
         e.preventDefault()
-        e.stopPropagation()
+        e.stopImmediatePropagation()
         if (expandedPaneIdRef.current !== null) {
           setExpandedPane(null)
           restoreExpandedLayout()


### PR DESCRIPTION
## Summary
- **Split pane in wrong worktree:** Hidden (but mounted) worktrees kept their `focusedGroupId`, so their TerminalPanes registered `window`-level keydown handlers alongside the visible worktree's. Cmd+D, Cmd+W, etc. fired in all worktrees because `stopPropagation` doesn't block sibling listeners on the same target.
- **Duplicate close dialog:** Same root cause — multiple `closeActivePane` handlers fired, showing the confirmation modal multiple times.
- **Auto-recreating tabs on close:** The auto-create-first-tab effect couldn't distinguish "worktree just activated with no tabs" from "user closed the last tab", so it spawned a replacement terminal immediately after every close.

## Changes
- **`Terminal.tsx`**: Pass `focusedGroupId={undefined}` for hidden worktrees so their TerminalPanes get `isActive=false` and never register keyboard handlers.
- **`keyboard-handlers.ts`**: Upgrade all `stopPropagation()` → `stopImmediatePropagation()` as defense-in-depth, so even if multiple handlers are active on `window`, only the first one processes the event.
- **`Terminal.tsx`**: Replace single-value `initialTabCreationGuardRef` with a `Set<string>` tracking initialized worktrees. Once a worktree has had tabs, closing all of them won't auto-spawn a replacement.

## Test plan
- [ ] Open two worktrees, switch between them, then Cmd+D in the active one — split should only appear in the visible worktree
- [ ] Split a pane, then Cmd+W — close dialog should appear at most once (only if a process is running)
- [ ] Close the last terminal tab (idle shell) — no replacement tab should auto-spawn
- [ ] Activate a brand-new worktree with no tabs — first terminal should still auto-create
- [ ] Cmd+T still creates new tabs in an empty worktree