### PR TITLE
fix: preserve terminal scroll position when splitting panes

### DIFF
--- a/src/renderer/src/lib/pane-manager/pane-manager.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager.ts
@@ -97,7 +97,21 @@ export class PaneManager {
     const isVertical = direction === 'vertical'
     const divider = this.createDividerWrapped(isVertical)
 
+    // Why: wrapInSplit reparents the existing container via replaceChild +
+    // appendChild, which can cause the browser to reset scrollTop on xterm's
+    // viewport element to 0 during the next layout. Capture the scroll-at-
+    // bottom state now, before the DOM reparenting corrupts it.
+    const buf = existing.terminal.buffer.active
+    const wasAtBottom = buf.viewportY >= buf.baseY
+
     wrapInSplit(existing.container, newPane.container, isVertical, divider, opts)
+
+    // Why: immediately restore the scroll position after DOM reparenting so
+    // that xterm's internal viewportY stays correct when the browser fires
+    // asynchronous scroll events during its layout phase.
+    if (wasAtBottom) {
+      existing.terminal.scrollToBottom()
+    }
 
     // Open terminal for new pane
     openTerminal(newPane)
@@ -111,13 +125,24 @@ export class PaneManager {
       newPane.terminal.focus()
     }
 
-    // Refit existing pane since it now shares space
-    safeFit(existing)
-
     updateMultiPaneState(this.getDragCallbacks())
 
     void this.options.onPaneCreated?.(this.toPublic(newPane))
     this.options.onLayoutChanged?.()
+
+    // Why: belt-and-suspenders for the scroll position — the deferred
+    // fitPanes (from onLayoutChanged → queueResizeAll) reflows the buffer
+    // for the new column count, which changes baseY. If the browser's
+    // rendering pipeline fired a scroll event that reset viewportY between
+    // our synchronous scrollToBottom above and the rAF, safeFit's
+    // wasAtBottom check would read false and skip scrollToBottom. This
+    // final rAF runs after fitPanes (FIFO ordering) and unconditionally
+    // restores the scroll-to-bottom state.
+    if (wasAtBottom) {
+      requestAnimationFrame(() => {
+        existing.terminal.scrollToBottom()
+      })
+    }
 
     return this.toPublic(newPane)
   }


### PR DESCRIPTION
## Summary
- Fixes terminal scroll jumping to the top when splitting a pane (e.g., Cmd+D or "Split Right")
- Root cause: `wrapInSplit()` uses `replaceChild` + `appendChild` to reparent the existing terminal container, which causes the browser to reset `scrollTop` on xterm's viewport element to 0. The existing `safeFit` then reads `wasAtBottom = false` and skips `scrollToBottom()`
- Also removes a synchronous `safeFit(existing)` call that ran before the browser flex layout had settled, causing a premature PTY resize with wrong dimensions

## Test plan
- [ ] Open a terminal and generate enough output to have scrollback (e.g., run several commands)
- [ ] Scroll to the bottom of the terminal
- [ ] Split the terminal (Cmd+D or right-click → Split Right)
- [ ] Verify the original terminal stays scrolled to the bottom
- [ ] Verify PTY output renders correctly without needing to manually scroll
- [ ] Test split-down (Cmd+Shift+D) as well
- [ ] Test splitting when the terminal is scrolled partway up (should preserve that position)