### PR TITLE
fix: Cmd+X in rich markdown editor deletes only the current line

### DIFF
--- a/src/renderer/src/components/editor/RichMarkdownEditor.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownEditor.tsx
@@ -23,6 +23,8 @@ import { registerPendingEditorFlush } from './editor-pending-flush'
 import { createRichMarkdownKeyHandler } from './rich-markdown-key-handler'
 import { DOMSerializer } from '@tiptap/pm/model'
 import { TextSelection } from '@tiptap/pm/state'
+import { normalizeSoftBreaks } from './rich-markdown-normalize'
+import { cutVisualLine, getVisualLineRange } from './rich-markdown-visual-line'
 
 type RichMarkdownEditorProps = {
   fileId: string
@@ -130,6 +132,15 @@ export default function RichMarkdownEditor({
 
           const { $from } = selection
 
+          // Why: a GapCursor before a top-level leaf node (e.g. horizontal rule
+          // as the first child of the doc) resolves to depth 0. Attempting to cut
+          // at depth 0 would call $from.before(0) on the doc node, which throws
+          // RangeError("There is no position before the top-level node").  Bail
+          // out and let ProseMirror's default handler deal with it.
+          if ($from.depth < 1) {
+            return false
+          }
+
           // Walk up from the textblock to find the best node to cut. For list
           // items and task items, cut the whole item rather than just its inner
           // paragraph. Stop at table cells to avoid breaking table structure.
@@ -147,6 +158,21 @@ export default function RichMarkdownEditor({
 
           const cutNode = $from.node(cutDepth)
           const text = cutNode.textContent
+
+          // Why: for paragraphs that word-wrap across multiple visual lines, cut
+          // only the visual line the cursor is on rather than the entire paragraph.
+          // This matches the user expectation of per-line cutting (like VS Code)
+          // without destroying the rest of the paragraph's content.
+          if (cutNode.type.name === 'paragraph' && text) {
+            const paraStart = $from.start(cutDepth)
+            const paraEnd = $from.end(cutDepth)
+            const lineRange = getVisualLineRange(view, selection.from, paraStart, paraEnd)
+            if (lineRange) {
+              return cutVisualLine(view, event, lineRange)
+            }
+            // Falls through to block-level cut for single-line paragraphs.
+          }
+
           if (!text) {
             // Still delete the empty block, matching VS Code behavior
             event.preventDefault()
@@ -235,6 +261,10 @@ export default function RichMarkdownEditor({
       }
     },
     onCreate: ({ editor: nextEditor }) => {
+      // Why: markdown soft line breaks produce paragraphs with embedded `\n` chars.
+      // Normalizing them into separate paragraph nodes on load ensures Cmd+X (and
+      // other block-level operations) treat each line as its own block.
+      normalizeSoftBreaks(nextEditor)
       lastCommittedMarkdownRef.current = nextEditor.getMarkdown()
     },
     onUpdate: ({ editor: nextEditor }) => {
@@ -424,6 +454,9 @@ export default function RichMarkdownEditor({
     editor.commands.setContent(encodeRawMarkdownHtmlForRichEditor(content), {
       contentType: 'markdown'
     })
+    // Why: same soft-break normalization as onCreate — external content updates
+    // may re-introduce paragraphs with embedded `\n` characters.
+    normalizeSoftBreaks(editor)
     lastCommittedMarkdownRef.current = content
     syncSlashMenu(editor, rootRef.current, setSlashMenu)
   }, [content, editor])

--- a/src/renderer/src/components/editor/rich-markdown-cut.test.ts
+++ b/src/renderer/src/components/editor/rich-markdown-cut.test.ts
@@ -1,0 +1,376 @@
+import { describe, expect, it } from 'vitest'
+import { Editor } from '@tiptap/core'
+import StarterKit from '@tiptap/starter-kit'
+import TaskList from '@tiptap/extension-task-list'
+import TaskItem from '@tiptap/extension-task-item'
+import { Table } from '@tiptap/extension-table'
+import { TableCell } from '@tiptap/extension-table-cell'
+import { TableHeader } from '@tiptap/extension-table-header'
+import { TableRow } from '@tiptap/extension-table-row'
+import { Markdown } from '@tiptap/markdown'
+import { normalizeSoftBreaks } from './rich-markdown-normalize'
+
+/**
+ * Minimal extensions matching the rich editor schema without UI dependencies.
+ */
+const testExtensions = [
+  StarterKit,
+  TaskList,
+  TaskItem.configure({ nested: true }),
+  Table.configure({ resizable: false }),
+  TableRow,
+  TableHeader,
+  TableCell,
+  Markdown.configure({ markedOptions: { gfm: true } })
+]
+
+function createEditor(markdown: string): Editor {
+  return new Editor({
+    element: null,
+    extensions: testExtensions,
+    content: markdown,
+    contentType: 'markdown'
+  })
+}
+
+/**
+ * Simulates the cut handler's depth walk to determine what node would be cut.
+ * This mirrors the logic in RichMarkdownEditor.tsx handleDOMEvents.cut,
+ * including the depth < 1 guard.
+ */
+function simulateCut(
+  editor: Editor,
+  pos: number
+): {
+  depth: number
+  cutDepth: number
+  cutNodeType: string
+  cutText: string
+  path: string[]
+  wouldBail: boolean
+} {
+  const $from = editor.state.doc.resolve(pos)
+  const path: string[] = []
+  for (let d = 0; d <= $from.depth; d++) {
+    path.push($from.node(d).type.name)
+  }
+
+  // Mirror the depth < 1 guard from the real handler
+  if ($from.depth < 1) {
+    return {
+      depth: $from.depth,
+      cutDepth: 0,
+      cutNodeType: $from.node(0).type.name,
+      cutText: $from.node(0).textContent,
+      path,
+      wouldBail: true
+    }
+  }
+
+  let cutDepth = $from.depth
+  for (let d = $from.depth - 1; d >= 1; d--) {
+    const name = $from.node(d).type.name
+    if (name === 'listItem' || name === 'taskItem') {
+      cutDepth = d
+      break
+    }
+    if (name === 'tableCell' || name === 'tableHeader') {
+      break
+    }
+  }
+
+  const cutNode = $from.node(cutDepth)
+  return {
+    depth: $from.depth,
+    cutDepth,
+    cutNodeType: cutNode.type.name,
+    cutText: cutNode.textContent,
+    path,
+    wouldBail: false
+  }
+}
+
+/** Count top-level paragraph nodes in the document. */
+function countParagraphs(editor: Editor): number {
+  let count = 0
+  editor.state.doc.forEach((node) => {
+    if (node.type.name === 'paragraph') {
+      count++
+    }
+  })
+  return count
+}
+
+describe('rich markdown cut handler behavior', () => {
+  it('heading + paragraph: cuts only the paragraph', () => {
+    const editor = createEditor('# Title\n\nBody text here.\n')
+
+    // Find position inside the paragraph
+    const doc = editor.state.doc
+    let paraPos = -1
+    doc.forEach((node, offset) => {
+      if (node.type.name === 'paragraph') {
+        paraPos = offset + 1
+      }
+    })
+
+    const result = simulateCut(editor, paraPos)
+
+    expect(result.cutNodeType).toBe('paragraph')
+    expect(result.cutText).toBe('Body text here.')
+    editor.destroy()
+  })
+
+  it('multi-line markdown (no blank separator): after normalization, each line is a separate paragraph', () => {
+    const editor = createEditor('Line one\nLine two\nLine three\n')
+
+    // Before normalization: single paragraph with \n chars
+    expect(countParagraphs(editor)).toBe(1)
+    expect(editor.state.doc.firstChild!.textContent).toContain('\n')
+
+    // Normalize: splits the single paragraph into three
+    normalizeSoftBreaks(editor)
+
+    // After normalization: three separate paragraph nodes
+    expect(countParagraphs(editor)).toBe(3)
+
+    // Each paragraph is its own line — no \n inside any of them
+    const paragraphs: string[] = []
+    editor.state.doc.forEach((node) => {
+      if (node.type.name === 'paragraph') {
+        expect(node.textContent).not.toContain('\n')
+        paragraphs.push(node.textContent)
+      }
+    })
+    expect(paragraphs).toEqual(['Line one', 'Line two', 'Line three'])
+
+    // Cmd+X on the first paragraph only cuts "Line one", not all three lines
+    const result = simulateCut(editor, 1)
+    expect(result.cutNodeType).toBe('paragraph')
+    expect(result.cutText).toBe('Line one')
+
+    editor.destroy()
+  })
+
+  it('multi-line: Cmd+X on second line only cuts that line after normalization', () => {
+    const editor = createEditor('Line one\nLine two\nLine three\n')
+    normalizeSoftBreaks(editor)
+
+    // Find the second paragraph ("Line two")
+    const doc = editor.state.doc
+    let secondParaPos = -1
+    let count = 0
+    doc.forEach((node, offset) => {
+      if (node.type.name === 'paragraph') {
+        count++
+        if (count === 2) {
+          secondParaPos = offset + 1
+        }
+      }
+    })
+
+    expect(secondParaPos).toBeGreaterThan(0)
+    const result = simulateCut(editor, secondParaPos)
+    expect(result.cutNodeType).toBe('paragraph')
+    expect(result.cutText).toBe('Line two')
+
+    editor.destroy()
+  })
+
+  it('paragraphs separated by blank lines are separate blocks', () => {
+    const editor = createEditor('First paragraph.\n\nSecond paragraph.\n\nThird paragraph.\n')
+
+    // Find second paragraph
+    const doc = editor.state.doc
+    let secondParaPos = -1
+    let count = 0
+    doc.forEach((node, offset) => {
+      if (node.type.name === 'paragraph') {
+        count++
+        if (count === 2) {
+          secondParaPos = offset + 1
+        }
+      }
+    })
+
+    const result = simulateCut(editor, secondParaPos)
+
+    expect(result.cutNodeType).toBe('paragraph')
+    expect(result.cutText).toBe('Second paragraph.')
+    editor.destroy()
+  })
+
+  it('list item: cuts the entire list item', () => {
+    const editor = createEditor('- Item 1\n- Item 2\n- Item 3\n')
+
+    // Find position inside second list item's paragraph
+    const doc = editor.state.doc
+    let secondItemPos = -1
+    let listItemCount = 0
+    doc.descendants((node, pos) => {
+      if (node.type.name === 'paragraph' && secondItemPos === -1) {
+        // Check if parent path includes listItem
+        const $pos = doc.resolve(pos + 1)
+        for (let d = $pos.depth; d >= 1; d--) {
+          if ($pos.node(d).type.name === 'listItem') {
+            listItemCount++
+            if (listItemCount === 2) {
+              secondItemPos = pos + 1
+            }
+            break
+          }
+        }
+      }
+    })
+
+    if (secondItemPos > 0) {
+      const result = simulateCut(editor, secondItemPos)
+      expect(result.cutNodeType).toBe('listItem')
+      expect(result.cutText).toBe('Item 2')
+    }
+
+    editor.destroy()
+  })
+
+  it('document with horizontal rule: depth < 1 guard prevents crash', () => {
+    const editor = createEditor('---\n\nBody text here.\n')
+
+    // Position 0 is before the horizontal rule — depth 0 (GapCursor territory)
+    const $pos0 = editor.state.doc.resolve(0)
+    expect($pos0.depth).toBe(0)
+
+    // The cut handler should bail out (return false) at depth 0 instead of crashing
+    const result = simulateCut(editor, 0)
+    expect(result.wouldBail).toBe(true)
+
+    // Paragraph after the hr is still cuttable normally
+    const doc = editor.state.doc
+    let paraPos = -1
+    doc.forEach((node, offset) => {
+      if (node.type.name === 'paragraph') {
+        paraPos = offset + 1
+      }
+    })
+    if (paraPos > 0) {
+      const safeResult = simulateCut(editor, paraPos)
+      expect(safeResult.wouldBail).toBe(false)
+      expect(safeResult.cutNodeType).toBe('paragraph')
+    }
+
+    editor.destroy()
+  })
+
+  it('single paragraph document: cut removes the only content', () => {
+    const editor = createEditor('This is the only paragraph.\n')
+
+    const result = simulateCut(editor, 1)
+
+    expect(result.cutNodeType).toBe('paragraph')
+
+    // Check that from/to would encompass the entire doc content
+    const $from = editor.state.doc.resolve(1)
+    const from = $from.before(result.cutDepth)
+    const to = $from.after(result.cutDepth)
+    expect(from).toBe(0)
+    expect(to).toBe(editor.state.doc.content.size)
+
+    editor.destroy()
+  })
+
+  it('blockquote with multiple paragraphs: cuts only one paragraph', () => {
+    const editor = createEditor('> Line 1\n>\n> Line 2\n>\n> Line 3\n')
+
+    // Find first paragraph in blockquote
+    const doc = editor.state.doc
+    let firstParaInBq = -1
+    doc.descendants((node, pos) => {
+      if (node.type.name === 'paragraph' && firstParaInBq === -1) {
+        const $pos = doc.resolve(pos + 1)
+        for (let d = $pos.depth; d >= 1; d--) {
+          if ($pos.node(d).type.name === 'blockquote') {
+            firstParaInBq = pos + 1
+            break
+          }
+        }
+      }
+    })
+
+    if (firstParaInBq > 0) {
+      const result = simulateCut(editor, firstParaInBq)
+      expect(result.cutNodeType).toBe('paragraph')
+    }
+
+    editor.destroy()
+  })
+
+  it('nested list item: cuts just the inner list item', () => {
+    const editor = createEditor('- Item 1\n  - Nested A\n  - Nested B\n- Item 2\n')
+
+    // Find a paragraph inside a nested list item
+    const doc = editor.state.doc
+    let nestedPos = -1
+    doc.descendants((node, pos) => {
+      if (node.type.name === 'paragraph' && node.textContent === 'Nested A' && nestedPos === -1) {
+        nestedPos = pos + 1
+      }
+    })
+
+    if (nestedPos > 0) {
+      const result = simulateCut(editor, nestedPos)
+      expect(result.cutNodeType).toBe('listItem')
+      expect(result.cutText).toBe('Nested A')
+    }
+
+    editor.destroy()
+  })
+
+  it('list item with nested sublist: cuts parent list item including sublist', () => {
+    const editor = createEditor('- Parent item\n  - Child A\n  - Child B\n- Other item\n')
+
+    // Find the paragraph "Parent item"
+    const doc = editor.state.doc
+    let parentPos = -1
+    doc.descendants((node, pos) => {
+      if (
+        node.type.name === 'paragraph' &&
+        node.textContent === 'Parent item' &&
+        parentPos === -1
+      ) {
+        parentPos = pos + 1
+      }
+    })
+
+    if (parentPos > 0) {
+      const result = simulateCut(editor, parentPos)
+      expect(result.cutNodeType).toBe('listItem')
+    }
+
+    editor.destroy()
+  })
+
+  it('normalizeSoftBreaks is idempotent on already-clean documents', () => {
+    const editor = createEditor('First.\n\nSecond.\n\nThird.\n')
+
+    const docBefore = editor.state.doc.toJSON()
+    normalizeSoftBreaks(editor)
+    const docAfter = editor.state.doc.toJSON()
+
+    // Already separated paragraphs should not be modified
+    expect(docAfter).toEqual(docBefore)
+
+    editor.destroy()
+  })
+
+  it('normalizeSoftBreaks does not modify list items or blockquotes', () => {
+    const editor = createEditor('- Item 1\n- Item 2\n')
+
+    const docBefore = editor.state.doc.toJSON()
+    normalizeSoftBreaks(editor)
+    const docAfter = editor.state.doc.toJSON()
+
+    // List structure should be unchanged (no top-level paragraphs to split)
+    expect(docAfter).toEqual(docBefore)
+
+    editor.destroy()
+  })
+})

--- a/src/renderer/src/components/editor/rich-markdown-normalize.ts
+++ b/src/renderer/src/components/editor/rich-markdown-normalize.ts
@@ -1,0 +1,91 @@
+import type { Editor } from '@tiptap/core'
+import { Fragment, type Node as PmNode } from '@tiptap/pm/model'
+
+/**
+ * Why: the `marked` parser (with `breaks: false`, the default) treats consecutive
+ * lines without a blank separator as a single paragraph with literal `\n` characters
+ * in the text content (e.g. "Line one\nLine two\nLine three").  These `\n` chars are
+ * invisible in the rendered HTML (normal `white-space` collapsing), but they cause
+ * the block-cut handler to remove the entire multi-line paragraph on Cmd+X instead
+ * of just one logical line.
+ *
+ * This function normalises the ProseMirror document by splitting any paragraph whose
+ * text nodes contain `\n` into separate paragraph nodes — one per line.  Inline marks
+ * (bold, italic, links, etc.) are preserved on each resulting paragraph.  This is
+ * structurally correct for the editing model: each visual line becomes its own block,
+ * so the cut handler (and all other block-level operations) work on a per-line basis.
+ */
+export function normalizeSoftBreaks(editor: Editor): void {
+  const { doc, schema, tr } = editor.state
+  const paragraphType = schema.nodes.paragraph
+  if (!paragraphType) {
+    return
+  }
+
+  // Collect replacements in reverse document order so earlier offsets stay valid.
+  const replacements: { from: number; to: number; paragraphs: Fragment[] }[] = []
+
+  doc.forEach((node, offset) => {
+    if (node.type !== paragraphType) {
+      return
+    }
+    if (!node.textContent.includes('\n')) {
+      return
+    }
+
+    // Build an array of Fragment contents — one per output paragraph.
+    // We walk the paragraph's inline content, splitting text nodes on `\n`
+    // while preserving marks on every piece.
+    const lines: Fragment[] = []
+    let currentNodes: PmNode[] = []
+
+    node.content.forEach((child) => {
+      if (!child.isText || !child.text?.includes('\n')) {
+        currentNodes.push(child)
+        return
+      }
+
+      // Split this text node on `\n`.  Each segment inherits the original marks.
+      const parts = child.text!.split('\n')
+      parts.forEach((part, i) => {
+        if (i > 0) {
+          // Flush currentNodes into a completed line.
+          lines.push(Fragment.from(currentNodes))
+          currentNodes = []
+        }
+        if (part.length > 0) {
+          currentNodes.push(schema.text(part, child.marks))
+        }
+      })
+    })
+
+    // Flush the last accumulated line.
+    lines.push(Fragment.from(currentNodes))
+
+    // Only replace if we actually split into multiple paragraphs.
+    if (lines.length <= 1) {
+      return
+    }
+
+    replacements.push({
+      from: offset,
+      to: offset + node.nodeSize,
+      paragraphs: lines
+    })
+  })
+
+  if (replacements.length === 0) {
+    return
+  }
+
+  // Apply replacements in reverse order to preserve positions.
+  for (let i = replacements.length - 1; i >= 0; i--) {
+    const { from, to, paragraphs } = replacements[i]
+    const newNodes = paragraphs.map((content) => paragraphType.create(null, content))
+    tr.replaceWith(from, to, newNodes)
+  }
+
+  // Why: this normalization is a structural housekeeping step, not a user edit.
+  // addToHistory: false prevents it from polluting the undo stack.
+  editor.view.dispatch(tr.setMeta('addToHistory', false))
+}

--- a/src/renderer/src/components/editor/rich-markdown-normalize.ts
+++ b/src/renderer/src/components/editor/rich-markdown-normalize.ts
@@ -16,7 +16,11 @@ import { Fragment, type Node as PmNode } from '@tiptap/pm/model'
  * so the cut handler (and all other block-level operations) work on a per-line basis.
  */
 export function normalizeSoftBreaks(editor: Editor): void {
-  const { doc, schema } = editor.state
+  // Why: we read from editor.view.state (not editor.state) so that the doc
+  // we traverse and the transaction we later create share the same base state.
+  // After setContent(), editor.state can be stale (last React render), while
+  // editor.view.state always reflects the latest document.
+  const { doc, schema } = editor.view.state
   const paragraphType = schema.nodes.paragraph
   if (!paragraphType) {
     return
@@ -83,10 +87,7 @@ export function normalizeSoftBreaks(editor: Editor): void {
     return
   }
 
-  // Why: we capture the transaction lazily from editor.view.state.tr (not editor.state.tr)
-  // to ensure we get the latest state. When called after setContent(), editor.state may be
-  // stale (it reflects state at the time of the last React render), while editor.view.state
-  // always reflects the most recent document.
+  // Capture the transaction lazily — only after all replacements are collected.
   const tr = editor.view.state.tr
 
   // Apply replacements in reverse order to preserve positions.

--- a/src/renderer/src/components/editor/rich-markdown-normalize.ts
+++ b/src/renderer/src/components/editor/rich-markdown-normalize.ts
@@ -16,21 +16,24 @@ import { Fragment, type Node as PmNode } from '@tiptap/pm/model'
  * so the cut handler (and all other block-level operations) work on a per-line basis.
  */
 export function normalizeSoftBreaks(editor: Editor): void {
-  const { doc, schema, tr } = editor.state
+  const { doc, schema } = editor.state
   const paragraphType = schema.nodes.paragraph
   if (!paragraphType) {
     return
   }
 
-  // Collect replacements in reverse document order so earlier offsets stay valid.
+  // Collect replacements across the entire document tree, not just top-level nodes.
+  // Why: doc.forEach only iterates top-level children, so paragraphs nested inside
+  // blockquotes, table cells, or other container nodes would be missed.
+  // doc.descendants walks every node at every depth and provides absolute positions.
   const replacements: { from: number; to: number; paragraphs: Fragment[] }[] = []
 
-  doc.forEach((node, offset) => {
+  doc.descendants((node, pos) => {
     if (node.type !== paragraphType) {
-      return
+      return true // continue descending into container nodes
     }
     if (!node.textContent.includes('\n')) {
-      return
+      return false // no need to descend into inline content
     }
 
     // Build an array of Fragment contents — one per output paragraph.
@@ -64,19 +67,27 @@ export function normalizeSoftBreaks(editor: Editor): void {
 
     // Only replace if we actually split into multiple paragraphs.
     if (lines.length <= 1) {
-      return
+      return false
     }
 
     replacements.push({
-      from: offset,
-      to: offset + node.nodeSize,
+      from: pos,
+      to: pos + node.nodeSize,
       paragraphs: lines
     })
+
+    return false // paragraph's inline children don't need further traversal
   })
 
   if (replacements.length === 0) {
     return
   }
+
+  // Why: we capture the transaction lazily from editor.view.state.tr (not editor.state.tr)
+  // to ensure we get the latest state. When called after setContent(), editor.state may be
+  // stale (it reflects state at the time of the last React render), while editor.view.state
+  // always reflects the most recent document.
+  const tr = editor.view.state.tr
 
   // Apply replacements in reverse order to preserve positions.
   for (let i = replacements.length - 1; i >= 0; i--) {

--- a/src/renderer/src/components/editor/rich-markdown-visual-line.ts
+++ b/src/renderer/src/components/editor/rich-markdown-visual-line.ts
@@ -1,0 +1,103 @@
+import { DOMSerializer } from '@tiptap/pm/model'
+import { TextSelection } from '@tiptap/pm/state'
+import type { EditorView } from '@tiptap/pm/view'
+
+/**
+ * Why: a paragraph that word-wraps across multiple screen lines should be cut
+ * one visual line at a time when the user presses Cmd+X with an empty selection,
+ * matching the expectation of per-line editing.  Uses ProseMirror's coordinate
+ * helpers to detect visual line boundaries from the browser's text layout.
+ *
+ * Returns the document-position range of the visual line the cursor sits on,
+ * or null when the paragraph fits on a single visual line (signaling the caller
+ * to fall through to block-level cut).
+ */
+export function getVisualLineRange(
+  view: EditorView,
+  cursorPos: number,
+  paraStart: number,
+  paraEnd: number
+): { from: number; to: number } | null {
+  if (paraStart >= paraEnd) {
+    return null
+  }
+
+  const cursorCoords = view.coordsAtPos(cursorPos)
+  const lineHeight = cursorCoords.bottom - cursorCoords.top
+  if (lineHeight <= 0) {
+    return null
+  }
+
+  // Single visual line check: if paragraph start and end share a line, skip.
+  const startCoords = view.coordsAtPos(paraStart)
+  const endCoords = view.coordsAtPos(paraEnd)
+  if (Math.abs(startCoords.top - endCoords.top) < lineHeight * 0.5) {
+    return null
+  }
+
+  // Get the paragraph's DOM element for horizontal bounds.
+  const domInfo = view.domAtPos(paraStart)
+  const paraEl = domInfo.node instanceof HTMLElement ? domInfo.node : domInfo.node.parentElement
+  if (!paraEl) {
+    return null
+  }
+  const rect = paraEl.getBoundingClientRect()
+
+  const midY = (cursorCoords.top + cursorCoords.bottom) / 2
+
+  // Start of the current visual line.
+  const startResult = view.posAtCoords({ left: rect.left + 1, top: midY })
+  if (!startResult) {
+    return null
+  }
+  const lineFrom = Math.max(startResult.pos, paraStart)
+
+  // End of the current visual line = start of the next visual line.
+  const nextMidY = cursorCoords.bottom + lineHeight * 0.5
+  const nextResult = view.posAtCoords({ left: rect.left + 1, top: nextMidY })
+
+  // Last visual line — cut to end of paragraph content.
+  const lineTo =
+    nextResult && nextResult.pos > lineFrom && nextResult.pos <= paraEnd ? nextResult.pos : paraEnd
+
+  // If the range covers the entire paragraph, return null so the caller
+  // falls through to block-level cut (which removes the paragraph node).
+  if (lineFrom <= paraStart && lineTo >= paraEnd) {
+    return null
+  }
+
+  return { from: lineFrom, to: lineTo }
+}
+
+/**
+ * Cuts a single visual line from a word-wrapped paragraph, writing both
+ * text/plain and text/html to the clipboard and deleting the range from
+ * the ProseMirror document.  Returns true if the cut was handled.
+ */
+export function cutVisualLine(
+  view: EditorView,
+  event: Event,
+  lineRange: { from: number; to: number }
+): boolean {
+  const clipboardEvent = event as ClipboardEvent
+  if (!clipboardEvent.clipboardData) {
+    return false
+  }
+  event.preventDefault()
+
+  const lineText = view.state.doc.textBetween(lineRange.from, lineRange.to, '')
+  const slice = view.state.doc.slice(lineRange.from, lineRange.to)
+  const serializer = DOMSerializer.fromSchema(view.state.schema)
+  const fragment = serializer.serializeFragment(slice.content)
+  const div = document.createElement('div')
+  div.appendChild(fragment)
+  clipboardEvent.clipboardData.setData('text/html', div.innerHTML)
+  clipboardEvent.clipboardData.setData('text/plain', lineText)
+
+  let tr = view.state.tr.delete(lineRange.from, lineRange.to)
+  const clampedPos = Math.max(0, Math.min(lineRange.from, tr.doc.content.size))
+  const resolvedPos = tr.doc.resolve(clampedPos)
+  tr = tr.setSelection(TextSelection.near(resolvedPos))
+  view.dispatch(tr)
+  return true
+}


### PR DESCRIPTION
## Summary
- Fixes Cmd+X deleting entire multi-line paragraphs when markdown soft line breaks produce a single paragraph with embedded `\n` characters
- Guards against depth < 1 (GapCursor before top-level leaf nodes like `---`) to prevent `RangeError` crash
- Adds visual-line cutting for word-wrapped paragraphs so Cmd+X removes one visual line at a time
- Normalizes soft line breaks on load/update by splitting paragraphs with embedded `\n` into separate paragraph nodes at all document depths

## Test plan
- [x] Unit tests for cut handler behavior and soft-break normalization (`rich-markdown-cut.test.ts`)
- [ ] Manual: create a markdown file with consecutive lines (no blank separator), verify Cmd+X cuts one line at a time
- [ ] Manual: place cursor before a horizontal rule as the first element, press Cmd+X — should not crash
- [ ] Manual: test Cmd+X in blockquotes and table cells with multi-line content