### PR TITLE
Revert "Start new worktrees with a terminal by default"

### DIFF
--- a/src/renderer/src/store/slices/tabs.test.ts
+++ b/src/renderer/src/store/slices/tabs.test.ts
@@ -184,24 +184,6 @@ describe('TabsSlice', () => {
 
       expect(store.getState().groupsByWorktree[WT]).toHaveLength(1)
     })
-
-    it('createTab seeds the first terminal into unified tabs before a root group exists', () => {
-      const terminal = store.getState().createTab(WT)
-      const state = store.getState()
-
-      expect(state.tabsByWorktree[WT]).toHaveLength(1)
-      expect(state.unifiedTabsByWorktree[WT]).toEqual([
-        expect.objectContaining({
-          id: terminal.id,
-          entityId: terminal.id,
-          worktreeId: WT,
-          contentType: 'terminal'
-        })
-      ])
-      expect(state.groupsByWorktree[WT]).toHaveLength(1)
-      expect(state.groupsByWorktree[WT][0].activeTabId).toBe(terminal.id)
-      expect(state.groupsByWorktree[WT][0].tabOrder).toEqual([terminal.id])
-    })
   })
 
   // ─── closeUnifiedTab ────────────────────────────────────────────────

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -202,15 +202,12 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       }
     })
     const state = get()
-    const unifiedTabExists = (state.unifiedTabsByWorktree[worktreeId] ?? []).some(
-      (entry) => entry.contentType === 'terminal' && entry.entityId === id
-    )
-    if (!unifiedTabExists) {
-      // Why: worktree creation can seed the first terminal before Terminal.tsx
-      // mounts and creates that worktree's root group. createUnifiedTab knows
-      // how to create the missing group; gating on an existing group leaves the
-      // terminal in legacy tabsByWorktree only, so the brand-new worktree opens
-      // with an apparently empty tab strip until the user adds another tab.
+    const targetGroupId =
+      state.activeGroupIdByWorktree[worktreeId] ?? state.groupsByWorktree[worktreeId]?.[0]?.id
+    if (
+      targetGroupId &&
+      !state.findTabForEntityInGroup(worktreeId, targetGroupId, id, 'terminal')
+    ) {
       state.createUnifiedTab(worktreeId, 'terminal', {
         id,
         entityId: id,
@@ -218,7 +215,7 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         customLabel: tab.customTitle,
         color: tab.color
       })
-    } else {
+    } else if (targetGroupId) {
       state.activateTab(id)
     }
     return tab


### PR DESCRIPTION
## Summary
- Reverts #539 as part of rolling back the split-screen tab group changes (#520) and related follow-up PRs

## Test plan
- [ ] Verify app builds and runs correctly