### PR TITLE
Improve auto-updater changelog fallback and dismiss bypass

### DIFF
--- a/src/main/updater-changelog.test.ts
+++ b/src/main/updater-changelog.test.ts
@@ -1,0 +1,205 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const fetchMock = vi.fn()
+
+vi.mock('electron', () => ({
+  net: { fetch: (...args: unknown[]) => fetchMock(...args) }
+}))
+
+import { fetchChangelog } from './updater-changelog'
+
+function jsonResponse(body: unknown): Response {
+  return { ok: true, json: () => Promise.resolve(body) } as unknown as Response
+}
+
+function makeEntries(
+  items: Array<{
+    version: string
+    title?: string
+    description?: string
+    mediaUrl?: string
+    releaseNotesUrl?: string
+  }>
+) {
+  return items.map((item) => ({
+    version: item.version,
+    title: item.title ?? `Release ${item.version}`,
+    description: item.description ?? '',
+    mediaUrl: item.mediaUrl,
+    releaseNotesUrl: item.releaseNotesUrl ?? `https://onorca.dev/changelog/${item.version}`
+  }))
+}
+
+describe('fetchChangelog', () => {
+  beforeEach(() => {
+    fetchMock.mockReset()
+  })
+
+  it('returns exact match when the incoming version has rich content', async () => {
+    const entries = makeEntries([
+      { version: '1.1.21', description: 'New feature', mediaUrl: 'https://onorca.dev/media/1.1.21.gif' },
+      { version: '1.1.20' },
+      { version: '1.1.19' }
+    ])
+    fetchMock.mockResolvedValue(jsonResponse(entries))
+
+
+    const result = await fetchChangelog('1.1.21', '1.1.19')
+
+    expect(result).not.toBeNull()
+    expect(result!.release.title).toBe('Release 1.1.21')
+    expect(result!.release.releaseNotesUrl).toBe('https://onorca.dev/changelog/1.1.21')
+    expect(result!.releasesBehind).toBe(2)
+  })
+
+  it('falls back to the most recent rich entry when incoming version is not in JSON', async () => {
+    // Incoming 1.1.21 is not in JSON; 1.1.17 has rich content.
+    // User is on 1.1.15 which is behind 1.1.17.
+    const entries = makeEntries([
+      { version: '1.1.17', description: 'Cool feature', mediaUrl: 'https://onorca.dev/media/1.1.17.gif', releaseNotesUrl: 'https://onorca.dev/changelog/1.1.17' },
+      { version: '1.1.16' },
+      { version: '1.1.15' }
+    ])
+    fetchMock.mockResolvedValue(jsonResponse(entries))
+
+
+    const result = await fetchChangelog('1.1.21', '1.1.15')
+
+    expect(result).not.toBeNull()
+    expect(result!.release.title).toBe('Release 1.1.17')
+    expect(result!.release.description).toBe('Cool feature')
+    // Why: fallback entries link to the generic changelog, not a version-specific page.
+    expect(result!.release.releaseNotesUrl).toBe('https://onorca.dev/changelog')
+    expect(result!.releasesBehind).toBe(2)
+  })
+
+  it('falls back when incoming version is in JSON but has no rich content', async () => {
+    // Incoming 1.1.21 exists but has empty description and no media.
+    // 1.1.17 has rich content.
+    const entries = makeEntries([
+      { version: '1.1.21', description: '', mediaUrl: undefined },
+      { version: '1.1.17', description: 'Great update', mediaUrl: 'https://onorca.dev/media/1.1.17.gif' },
+      { version: '1.1.15' }
+    ])
+    fetchMock.mockResolvedValue(jsonResponse(entries))
+
+
+    const result = await fetchChangelog('1.1.21', '1.1.15')
+
+    expect(result).not.toBeNull()
+    expect(result!.release.title).toBe('Release 1.1.17')
+    expect(result!.release.releaseNotesUrl).toBe('https://onorca.dev/changelog')
+    // releasesBehind is from local (index 2) to incoming (index 0) = 2
+    expect(result!.releasesBehind).toBe(2)
+  })
+
+  it('returns null when no entry has rich content', async () => {
+    const entries = makeEntries([
+      { version: '1.1.21', description: '' },
+      { version: '1.1.20', description: '' },
+      { version: '1.1.19', description: '' }
+    ])
+    fetchMock.mockResolvedValue(jsonResponse(entries))
+
+
+    const result = await fetchChangelog('1.1.21', '1.1.19')
+
+    expect(result).toBeNull()
+  })
+
+  it('treats description-only entries (no media) as non-rich', async () => {
+    // Exact match has a description but no mediaUrl — should not count as rich.
+    const entries = makeEntries([
+      { version: '1.1.21', description: 'Bug fixes and improvements' },
+      { version: '1.1.20', description: 'Minor tweaks' },
+      { version: '1.1.19' }
+    ])
+    fetchMock.mockResolvedValue(jsonResponse(entries))
+
+
+    const result = await fetchChangelog('1.1.21', '1.1.19')
+
+    expect(result).toBeNull()
+  })
+
+  it('skips rich entries that the user has already passed', async () => {
+    // User is on 1.1.18, which is ahead of the only rich entry (1.1.17).
+    const entries = makeEntries([
+      { version: '1.1.20', description: '' },
+      { version: '1.1.18' },
+      { version: '1.1.17', description: 'Old feature', mediaUrl: 'https://onorca.dev/media/old.gif' }
+    ])
+    fetchMock.mockResolvedValue(jsonResponse(entries))
+
+
+    const result = await fetchChangelog('1.1.20', '1.1.18')
+
+    // 1.1.18 is at index 1, 1.1.17 is at index 2 — user is already past it.
+    expect(result).toBeNull()
+  })
+
+  it('shows rich entry when local version is not in JSON (very old user)', async () => {
+    const entries = makeEntries([
+      { version: '1.1.20', description: '' },
+      { version: '1.1.17', description: 'Feature demo', mediaUrl: 'https://onorca.dev/media/demo.gif' }
+    ])
+    fetchMock.mockResolvedValue(jsonResponse(entries))
+
+
+    const result = await fetchChangelog('1.1.21', '1.0.0')
+
+    expect(result).not.toBeNull()
+    expect(result!.release.title).toBe('Release 1.1.17')
+    expect(result!.release.releaseNotesUrl).toBe('https://onorca.dev/changelog')
+    // releasesBehind is null because the local version isn't in the JSON.
+    expect(result!.releasesBehind).toBeNull()
+  })
+
+  it('returns null on non-ok HTTP response', async () => {
+    fetchMock.mockResolvedValue({ ok: false })
+
+
+    const result = await fetchChangelog('1.1.21', '1.1.19')
+
+    expect(result).toBeNull()
+  })
+
+  it('returns null on non-array JSON', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ bad: true }))
+
+
+    const result = await fetchChangelog('1.1.21', '1.1.19')
+
+    expect(result).toBeNull()
+  })
+
+  it('prefers exact match over fallback when both have rich content', async () => {
+    const entries = makeEntries([
+      { version: '1.1.21', description: 'Latest feature', mediaUrl: 'https://onorca.dev/media/latest.gif' },
+      { version: '1.1.17', description: 'Older feature', mediaUrl: 'https://onorca.dev/media/old.gif' },
+      { version: '1.1.15' }
+    ])
+    fetchMock.mockResolvedValue(jsonResponse(entries))
+
+
+    const result = await fetchChangelog('1.1.21', '1.1.15')
+
+    expect(result!.release.title).toBe('Release 1.1.21')
+    // Exact match keeps its own releaseNotesUrl.
+    expect(result!.release.releaseNotesUrl).toBe('https://onorca.dev/changelog/1.1.21')
+  })
+
+  it('strips version from the returned release object', async () => {
+    const entries = makeEntries([
+      { version: '1.1.17', description: 'Feature', mediaUrl: 'https://onorca.dev/media/demo.gif' },
+      { version: '1.1.15' }
+    ])
+    fetchMock.mockResolvedValue(jsonResponse(entries))
+
+
+    const result = await fetchChangelog('1.1.21', '1.1.15')
+
+    expect(result).not.toBeNull()
+    expect('version' in result!.release).toBe(false)
+  })
+})

--- a/src/main/updater-changelog.test.ts
+++ b/src/main/updater-changelog.test.ts
@@ -13,13 +13,13 @@ function jsonResponse(body: unknown): Response {
 }
 
 function makeEntries(
-  items: Array<{
+  items: {
     version: string
     title?: string
     description?: string
     mediaUrl?: string
     releaseNotesUrl?: string
-  }>
+  }[]
 ) {
   return items.map((item) => ({
     version: item.version,

--- a/src/main/updater-changelog.ts
+++ b/src/main/updater-changelog.ts
@@ -9,9 +9,30 @@ type ChangelogEntry = {
   releaseNotesUrl: string
 }
 
+const CHANGELOG_URL = 'https://onorca.dev/changelog'
+
+function isValidEntry(entry: ChangelogEntry): boolean {
+  return (
+    typeof entry.title === 'string' &&
+    typeof entry.description === 'string' &&
+    typeof entry.releaseNotesUrl === 'string'
+  )
+}
+
+/** Returns true when the entry has showcase media (gif/screenshot) worth demoing. */
+function hasRichContent(entry: ChangelogEntry): boolean {
+  return Boolean(entry.mediaUrl)
+}
+
 /**
- * Fetches the remote changelog and extracts the entry for the incoming version,
- * plus a `releasesBehind` count relative to the local version.
+ * Fetches the remote changelog and finds the best entry to show the user.
+ *
+ * 1. If the incoming version has an exact match with rich content, use it.
+ * 2. Otherwise, find the most recent entry that has rich content. If the user's
+ *    local version is behind that entry, show it anyway — demoing an older
+ *    highlight is better than showing nothing. In this fallback case the
+ *    release notes link points to the generic changelog page instead of a
+ *    version-specific URL.
  *
  * Why net.fetch instead of fetch: Electron's `net` module respects the app's
  * proxy/certificate settings and has no CORS restrictions.
@@ -40,29 +61,63 @@ export async function fetchChangelog(
     }
     const entries = json as ChangelogEntry[]
 
-    const incomingIndex = entries.findIndex((e) => e.version === incomingVersion)
-    if (incomingIndex === -1) {
-      return null
-    }
-
-    const entry = entries[incomingIndex]
-    if (
-      typeof entry.title !== 'string' ||
-      typeof entry.description !== 'string' ||
-      typeof entry.releaseNotesUrl !== 'string'
-    ) {
-      return null
-    }
-
     const localIndex = entries.findIndex((e) => e.version === localVersion)
-    // Why: clamp to null when <= 0 — a zero or negative value means the JSON
-    // ordering invariant is violated, and the badge number would be misleading.
-    const releasesBehind =
-      localIndex === -1 ? null : localIndex - incomingIndex > 0 ? localIndex - incomingIndex : null
 
-    // Strip `version` before sending — it's redundant with UpdateStatus.version.
-    const { version: _, ...release } = entry
-    return { release, releasesBehind }
+    // ── Try exact match first ────────────────────────────────────────
+    const incomingIndex = entries.findIndex((e) => e.version === incomingVersion)
+    if (incomingIndex !== -1) {
+      const entry = entries[incomingIndex]
+      if (isValidEntry(entry) && hasRichContent(entry)) {
+        const releasesBehind =
+          localIndex === -1
+            ? null
+            : localIndex - incomingIndex > 0
+              ? localIndex - incomingIndex
+              : null
+        const { version: _, ...release } = entry
+        return { release, releasesBehind }
+      }
+    }
+
+    // ── Fallback: find the most recent entry with rich content ────────
+    // Why: releases often ship without rich media/description. Rather than
+    // showing the plain card, we look for the latest entry that does have
+    // rich content. As long as the user's local version is behind that
+    // entry, the demo is still relevant — it highlights something they
+    // haven't seen yet. We swap the release notes URL to the generic
+    // changelog page since the shown content doesn't match the incoming
+    // version.
+    for (let i = 0; i < entries.length; i++) {
+      const candidate = entries[i]
+      if (!isValidEntry(candidate) || !hasRichContent(candidate)) {
+        continue
+      }
+
+      // Only show this entry if the user's local version is behind it.
+      // When localIndex === -1 the local version isn't in the JSON at all,
+      // which typically means it's very old — safe to show the content.
+      if (localIndex !== -1 && localIndex <= i) {
+        continue
+      }
+
+      // Why: releasesBehind counts how far behind the user is from the
+      // incoming update, not from the shown content entry. When incomingIndex
+      // is -1, the incoming version is newer than anything in the JSON —
+      // treat it as being at the front (index 0) for counting purposes.
+      const effectiveIncomingIndex = incomingIndex !== -1 ? incomingIndex : 0
+      const releasesBehind =
+        localIndex === -1
+          ? null
+          : localIndex - effectiveIncomingIndex > 0
+            ? localIndex - effectiveIncomingIndex
+            : null
+      const { version: _, ...release } = candidate
+      // Why: the shown content is from an older entry, not the incoming version.
+      // Point to the generic changelog page so the link doesn't mislead.
+      return { release: { ...release, releaseNotesUrl: CHANGELOG_URL }, releasesBehind }
+    }
+
+    return null
   } finally {
     clearTimeout(timeout)
   }

--- a/src/renderer/src/components/UpdateCard.tsx
+++ b/src/renderer/src/components/UpdateCard.tsx
@@ -98,6 +98,12 @@ export function UpdateCard() {
   // Why: tracks whether the card is exiting so we can play the fade-out
   // animation before unmounting.
   const [exiting, setExiting] = useState(false)
+  // Why: when the user explicitly clicks "Check for Updates", the dismiss gate
+  // must be bypassed for the resulting 'available' card — otherwise the card
+  // flashes "Checking..." then vanishes because the same version was previously
+  // dismissed.  This ref tracks whether the current check cycle was user-initiated
+  // so the dismiss gate can let the result through.
+  const userInitiatedCycleRef = useRef(false)
 
   const changelog: ChangelogData | null = storeChangelog
 
@@ -188,6 +194,18 @@ export function UpdateCard() {
   const shouldShowDetailedErrorCard =
     status.state === 'error' && (hasStartedDownload.current || cachedVersion !== null)
 
+  // Why: track whether the current check cycle was user-initiated so the
+  // dismiss gate doesn't hide the result of an explicit "Check for Updates"
+  // click.  Without this, clicking "Check for Updates" when a version was
+  // previously dismissed causes the "Checking..." toast to flash briefly
+  // then vanish — the 'available' card is suppressed by the dismiss gate
+  // even though the user explicitly asked to see the result.
+  if (status.state === 'checking' && isUserInitiated) {
+    userInitiatedCycleRef.current = true
+  } else if (status.state === 'idle' || (status.state === 'checking' && !isUserInitiated)) {
+    userInitiatedCycleRef.current = false
+  }
+
   // Compact transient states: only show for user-initiated checks.
   if (status.state === 'checking' && !isUserInitiated) {
     return null
@@ -214,7 +232,10 @@ export function UpdateCard() {
   // Dismiss gate: if the user previously dismissed this version, hide the card
   // for passive reminder states. Keep active in-progress/error states visible so
   // explicit install actions can still surface progress and failures.
-  if (versionRef.current && dismissedVersion === versionRef.current) {
+  // Why: bypass the gate when the current cycle was user-initiated — the user
+  // explicitly asked to check, so they expect to see the result even if they
+  // dismissed the same version earlier.
+  if (versionRef.current && dismissedVersion === versionRef.current && !userInitiatedCycleRef.current) {
     if (status.state !== 'downloading' && status.state !== 'error') {
       return null
     }
@@ -237,6 +258,10 @@ export function UpdateCard() {
   // Why: the 'error' variant has no version field, so dismiss needs an
   // optional explicit version override for error/install-failure states.
   const handleClose = () => {
+    // Why: clear the user-initiated bypass so the dismiss gate re-engages
+    // immediately — otherwise the card would reappear on the next render
+    // because the bypass ref still overrides the persisted dismissal.
+    userInitiatedCycleRef.current = false
     if (status.state === 'error' && cachedVersion) {
       dismissUpdate(cachedVersion)
       return


### PR DESCRIPTION
## Summary
- **Changelog fallback logic**: When the incoming update version has no rich content (media/description), the updater now finds the most recent changelog entry with rich content to show the user — better than showing nothing. The fallback entry links to the generic changelog page.
- **User-initiated dismiss bypass**: Clicking "Check for Updates" now bypasses the dismiss gate, so users see the result even if they previously dismissed the same version.
- **Tests**: Adds comprehensive test suite for `fetchChangelog` covering exact match, fallback, edge cases, and error handling.

## Test plan
- [x] `pnpm typecheck` passes
- [x] 11 unit tests pass for `fetchChangelog`
- [ ] CI checks pass