### PR TITLE
fix: reapply terminal shortcuts firing in wrong worktree

### DIFF
--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -168,7 +168,11 @@ export default function Terminal(): React.JSX.Element | null {
       mountedWorktreeIdsRef.current.delete(id)
     }
   }
-  const initialTabCreationGuardRef = useRef<string | null>(null)
+  // Why: tracks worktrees that have already been initialized (either by
+  // auto-creating a first tab or by having tabs on first activation). Once a
+  // worktree is in this set, closing all its tabs will NOT auto-spawn a
+  // replacement — the user explicitly chose to close them.
+  const initializedWorktreesRef = useRef(new Set<string>())
 
   // Auto-create first tab when worktree activates
   useEffect(() => {
@@ -176,27 +180,22 @@ export default function Terminal(): React.JSX.Element | null {
       return
     }
     if (!activeWorktreeId) {
-      initialTabCreationGuardRef.current = null
       return
     }
 
-    // Why: skip auto-creation if terminal tabs already exist, or if editor files
-    // are open for this worktree. The user may have intentionally closed all
-    // terminal tabs while keeping editors open — auto-spawning a terminal would
-    // be disruptive.
     if (tabs.length > 0 || worktreeFiles.length > 0 || worktreeBrowserTabs.length > 0) {
-      if (initialTabCreationGuardRef.current === activeWorktreeId) {
-        initialTabCreationGuardRef.current = null
-      }
+      initializedWorktreesRef.current.add(activeWorktreeId)
       return
     }
 
-    // In React StrictMode (dev), mount effects are intentionally invoked twice.
-    // Track the worktree we already initialized so we only create one first tab.
-    if (initialTabCreationGuardRef.current === activeWorktreeId) {
+    // Why: once a worktree has been initialized (had tabs or auto-created one),
+    // don't auto-create again. This prevents a new terminal from spawning
+    // immediately after the user closes the last tab. Also guards against
+    // React StrictMode double-invocation.
+    if (initializedWorktreesRef.current.has(activeWorktreeId)) {
       return
     }
-    initialTabCreationGuardRef.current = activeWorktreeId
+    initializedWorktreesRef.current.add(activeWorktreeId)
     createTab(activeWorktreeId)
   }, [
     workspaceSessionReady,

--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
@@ -140,7 +140,7 @@ export function useTerminalKeyboardShortcuts({
 
       if (action.type === 'sendInput') {
         e.preventDefault()
-        e.stopPropagation()
+        e.stopImmediatePropagation()
         const pane = manager.getActivePane() ?? manager.getPanes()[0]
         if (!pane) {
           return
@@ -165,7 +165,7 @@ export function useTerminalKeyboardShortcuts({
           return
         }
         e.preventDefault()
-        e.stopPropagation()
+        e.stopImmediatePropagation()
         void window.api.ui.writeClipboardText(selection).catch(() => {
           /* ignore clipboard write failures */
         })
@@ -176,7 +176,7 @@ export function useTerminalKeyboardShortcuts({
       // top-level find-in-page flow to fall back to.
       if (action.type === 'toggleSearch') {
         e.preventDefault()
-        e.stopPropagation()
+        e.stopImmediatePropagation()
         setSearchOpen((prev) => !prev)
         return
       }
@@ -184,7 +184,7 @@ export function useTerminalKeyboardShortcuts({
       // Cmd+K clears active pane screen + scrollback.
       if (action.type === 'clearActivePane') {
         e.preventDefault()
-        e.stopPropagation()
+        e.stopImmediatePropagation()
         const pane = manager.getActivePane() ?? manager.getPanes()[0]
         if (pane) {
           pane.terminal.clear()
@@ -199,7 +199,7 @@ export function useTerminalKeyboardShortcuts({
           return
         }
         e.preventDefault()
-        e.stopPropagation()
+        e.stopImmediatePropagation()
 
         // Collapse expanded pane before switching
         if (expandedPaneIdRef.current !== null) {
@@ -228,7 +228,7 @@ export function useTerminalKeyboardShortcuts({
           return
         }
         e.preventDefault()
-        e.stopPropagation()
+        e.stopImmediatePropagation()
         const pane = manager.getActivePane() ?? panes[0]
         if (!pane) {
           return
@@ -243,7 +243,7 @@ export function useTerminalKeyboardShortcuts({
       // every pane instead of just the focused one.
       if (action.type === 'closeActivePane') {
         e.preventDefault()
-        e.stopPropagation()
+        e.stopImmediatePropagation()
         const pane = manager.getActivePane() ?? manager.getPanes()[0]
         if (!pane) {
           return
@@ -257,7 +257,7 @@ export function useTerminalKeyboardShortcuts({
       // (matches Ghostty behavior).
       if (action.type === 'splitActivePane') {
         e.preventDefault()
-        e.stopPropagation()
+        e.stopImmediatePropagation()
         if (expandedPaneIdRef.current !== null) {
           setExpandedPane(null)
           restoreExpandedLayout()


### PR DESCRIPTION
## Summary
- Reapplies the fixes from #542 which were reverted in #546 as part of the #520 revert chain
- Replaces single-value `initialTabCreationGuardRef` with a `Set<string>` so closing the last tab no longer auto-spawns a replacement terminal
- Upgrades all `stopPropagation()` → `stopImmediatePropagation()` as defense-in-depth against duplicate window-level keydown handlers

The `focusedGroupId` change from #542 is omitted because it targeted `TabGroupSplitLayout` from #520, which remains reverted. The current code already gates `isActive` on `isVisible`, providing the same protection.

## Test plan
- [x] Open two worktrees, switch between them, then Cmd+D in the active one — split should only appear in the visible worktree
- [x] Split a pane, then Cmd+W — close dialog should appear at most once
- [x] Close the last terminal tab (idle shell) — no replacement tab should auto-spawn
- [x] Activate a brand-new worktree with no tabs — first terminal should still auto-create