### PR TITLE
Promote primary worktree to top when searching by repo name

### DIFF
--- a/src/renderer/src/lib/worktree-palette-search.test.ts
+++ b/src/renderer/src/lib/worktree-palette-search.test.ts
@@ -101,6 +101,37 @@ describe('worktree-palette-search', () => {
     })
   })
 
+  it('promotes the primary worktree to the top when query matches a repo name', () => {
+    const worktrees = [
+      makeWorktree({
+        id: 'wt-feature',
+        branch: 'refs/heads/feature/foo',
+        displayName: 'foo feature',
+        isMainWorktree: false
+      }),
+      makeWorktree({
+        id: 'wt-bugfix',
+        branch: 'refs/heads/bugfix/bar',
+        displayName: 'bar bugfix',
+        isMainWorktree: false
+      }),
+      makeWorktree({
+        id: 'wt-main',
+        branch: 'refs/heads/main',
+        displayName: 'main',
+        isMainWorktree: true
+      })
+    ]
+
+    const results = searchWorktrees(worktrees, 'orca', repoMap, null, null)
+
+    // All three match on the repo name
+    expect(results).toHaveLength(3)
+    // The primary worktree should be first despite being last in input order
+    expect(results[0].worktreeId).toBe('wt-main')
+    expect(results[0].matchedField).toBe('repo')
+  })
+
   it('matches issue numbers with a leading hash and returns issue render context', () => {
     const results = searchWorktrees(
       [makeWorktree({ linkedIssue: 304 })],

--- a/src/renderer/src/lib/worktree-palette-search.ts
+++ b/src/renderer/src/lib/worktree-palette-search.ts
@@ -242,5 +242,28 @@ export function searchWorktrees(
     }
   }
 
+  // Promote primary worktrees when the query matches their repo name.
+  // When a user types a repo name, the primary branch is the most likely jump
+  // target — floating it to the top reduces selection friction. We only promote
+  // when matchedField is 'repo' so that stronger signals (displayName, branch)
+  // are not overridden by the promotion.
+  const worktreeById = new Map(worktrees.map((w) => [w.id, w]))
+  const promote = new Set<string>()
+  for (const r of results) {
+    if (r.matchedField === 'repo') {
+      const w = worktreeById.get(r.worktreeId)
+      if (w?.isMainWorktree) {
+        promote.add(r.worktreeId)
+      }
+    }
+  }
+  if (promote.size > 0) {
+    results.sort((a, b) => {
+      const ap = promote.has(a.worktreeId) ? 1 : 0
+      const bp = promote.has(b.worktreeId) ? 1 : 0
+      return bp - ap
+    })
+  }
+
   return results
 }


### PR DESCRIPTION
## Summary
- When typing a repo name in the CMD+J worktree palette, the primary branch worktree (`isMainWorktree`) is now promoted to the top of results
- Only triggers when the match is on the `repo` field, so stronger signals (displayName, branch matches) are not overridden
- Stable sort preserves relative order of all other results

## Test plan
- [x] Unit test added: primary worktree floats to top when query matches repo name
- [x] Existing tests pass (5/5)