### PR TITLE
fix: improve settings page visual separation

### DIFF
--- a/src/renderer/src/components/settings/RepositoryPane.tsx
+++ b/src/renderer/src/components/settings/RepositoryPane.tsx
@@ -175,7 +175,7 @@ export function RepositoryPane({
 
   const visibleSections = [
     matchesSettingsSearch(searchQuery, identityEntries) ? (
-      <section key="identity" className="space-y-6">
+      <section key="identity" className="space-y-8">
         <div className="flex items-start justify-between gap-4">
           <div className="space-y-1">
             <h3 className="text-sm font-semibold">Identity</h3>

--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -387,7 +387,7 @@ function Settings(): React.JSX.Element {
 
       <div className="flex min-h-0 flex-1 flex-col">
         <div ref={contentScrollRef} className="min-h-0 flex-1 overflow-y-auto scrollbar-sleek">
-          <div className="flex w-full max-w-5xl flex-col gap-10 px-8 py-8">
+          <div className="flex w-full max-w-5xl flex-col gap-10 px-8 py-10">
             {visibleNavSections.length === 0 ? (
               <div className="flex min-h-[24rem] items-center justify-center rounded-2xl border border-dashed border-border/60 bg-card/30 text-sm text-muted-foreground">
                 No settings found for &quot;{settingsSearchQuery.trim()}&quot;

--- a/src/renderer/src/components/settings/SettingsSection.tsx
+++ b/src/renderer/src/components/settings/SettingsSection.tsx
@@ -29,8 +29,11 @@ export function SettingsSection({
       id={id}
       data-settings-section={id}
       className={
+        // Why: these sections already contain many internal borders and cards, so a lone divider
+        // line gets lost in the visual noise. Giving each section its own padded surface creates a
+        // clear outer silhouette that still works when the inner content changes.
         className ??
-        'space-y-8 scroll-mt-6 border-b border-border/40 pb-10 last:border-b-0 last:pb-0'
+        'scroll-mt-6 space-y-8 rounded-2xl border border-border/60 bg-card/35 px-6 py-6 shadow-sm'
       }
     >
       <div className="space-y-1">

--- a/src/renderer/src/components/settings/SettingsSection.tsx
+++ b/src/renderer/src/components/settings/SettingsSection.tsx
@@ -25,7 +25,14 @@ export function SettingsSection({
   }
 
   return (
-    <section id={id} data-settings-section={id} className={className ?? 'space-y-6 scroll-mt-6'}>
+    <section
+      id={id}
+      data-settings-section={id}
+      className={
+        className ??
+        'space-y-8 scroll-mt-6 border-b border-border/40 pb-10 last:border-b-0 last:pb-0'
+      }
+    >
       <div className="space-y-1">
         <h2 className="text-xl font-semibold">{title}</h2>
         <p className="text-sm text-muted-foreground">{description}</p>


### PR DESCRIPTION
## Summary
- Replace the plain top-level section divider treatment with a distinct card-style section container for settings pages
- Give each settings section its own rounded border, background, padding, and subtle shadow so sections remain easy to distinguish even though dividers and borders are already used throughout the surrounding UI
- Keep the existing settings structure and behavior intact while making the page easier to scan

Closes #447

## Test plan
- [x] Open the settings page and verify each top-level section reads as its own container
- [x] Check repo settings and verify Identity and Worktree Hooks feel clearly separated from surrounding content
- [x] Verify all panes still look consistent across General, Git, Appearance, Terminal, Notifications, Shortcuts, Stats, and repo sections
- [x] Test light and dark mode
- [x] Test settings search filtering still works correctly
- [x] Verify sidebar scroll-tracking still highlights the correct section

<img width="1008" height="78" alt="image" src="https://github.com/user-attachments/assets/d3992c7c-fa4e-460a-ac6d-cae2fb6a73b0" />
