### PR TITLE
feat: support front-matter in rich editor and preview

### DIFF
--- a/src/renderer/src/components/editor/EditorContent.tsx
+++ b/src/renderer/src/components/editor/EditorContent.tsx
@@ -7,6 +7,7 @@ import type { GitStatusEntry, GitDiffResult } from '../../../../shared/types'
 import { RICH_MARKDOWN_MAX_SIZE_BYTES } from '../../../../shared/constants'
 import { getMarkdownRenderMode } from './markdown-render-mode'
 import { getMarkdownRichModeUnsupportedMessage } from './markdown-rich-mode'
+import { extractFrontMatter, prependFrontMatter } from './markdown-frontmatter'
 
 const MonacoEditor = lazy(() => import('./MonacoEditor'))
 const DiffViewer = lazy(() => import('./DiffViewer'))
@@ -135,17 +136,38 @@ export function EditorContent({
     }
 
     if (renderMode === 'rich-editor') {
+      // Why: front-matter is stripped before the rich editor sees the content
+      // because Tiptap has no front-matter node and would silently drop it.
+      // The raw block is displayed as a read-only banner and recombined with
+      // the body on every content change and save so the edit buffer always
+      // holds the complete document.
+      const fm = extractFrontMatter(currentContent)
+      const editorContent = fm ? fm.body : currentContent
+
+      const onContentChangeWithFm = fm
+        ? (body: string): void => handleContentChange(prependFrontMatter(fm.raw, body))
+        : handleContentChange
+
+      const onSaveWithFm = fm
+        ? (body: string): Promise<void> => handleSave(prependFrontMatter(fm.raw, body))
+        : handleSave
+
       return (
-        // Why: same remount reasoning as MonacoEditor — see renderMonacoEditor.
-        <RichMarkdownEditor
-          key={activeFile.id}
-          fileId={activeFile.id}
-          content={currentContent}
-          filePath={activeFile.filePath}
-          onContentChange={handleContentChange}
-          onDirtyStateHint={handleDirtyStateHint}
-          onSave={handleSave}
-        />
+        <div className="flex h-full min-h-0 flex-col">
+          {fm && <FrontMatterBanner raw={fm.raw} />}
+          <div className="min-h-0 flex-1">
+            {/* Why: same remount reasoning as MonacoEditor — see renderMonacoEditor. */}
+            <RichMarkdownEditor
+              key={activeFile.id}
+              fileId={activeFile.id}
+              content={editorContent}
+              filePath={activeFile.filePath}
+              onContentChange={onContentChangeWithFm}
+              onDirtyStateHint={handleDirtyStateHint}
+              onSave={onSaveWithFm}
+            />
+          </div>
+        </div>
       )
     }
 
@@ -294,5 +316,31 @@ export function EditorContent({
       onContentChange={isEditable ? handleContentChange : undefined}
       onSave={isEditable ? handleSave : undefined}
     />
+  )
+}
+
+// Why: a minimal read-only banner that shows the raw front-matter content
+// above the rich editor so the user knows it exists and can switch to source
+// mode to edit it. Kept deliberately simple — no collapsible state — to avoid
+// layout shifts that would interfere with ProseMirror's scroll management.
+function FrontMatterBanner({ raw }: { raw: string }): React.JSX.Element {
+  // Strip the opening/closing delimiters to show only the YAML/TOML content.
+  const inner = raw
+    .replace(/^(?:---|\+\+\+)\r?\n/, '')
+    .replace(/\r?\n(?:---|\+\+\+)\r?\n?$/, '')
+    .trim()
+
+  return (
+    <div className="border-b border-border/60 bg-muted/40 px-3 py-2">
+      <div className="mb-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+        Front Matter
+        <span className="ml-2 font-normal normal-case tracking-normal opacity-70">
+          (edit in source mode)
+        </span>
+      </div>
+      <pre className="max-h-32 overflow-auto whitespace-pre-wrap text-xs text-muted-foreground font-mono scrollbar-editor">
+        {inner}
+      </pre>
+    </div>
   )
 }

--- a/src/renderer/src/components/editor/MarkdownPreview.tsx
+++ b/src/renderer/src/components/editor/MarkdownPreview.tsx
@@ -1,8 +1,9 @@
-import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import Markdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import remarkFrontmatter from 'remark-frontmatter'
 import rehypeHighlight from 'rehype-highlight'
+import { extractFrontMatter } from './markdown-frontmatter'
 import { ChevronDown, ChevronUp, X } from 'lucide-react'
 import type { Components } from 'react-markdown'
 import { Button } from '@/components/ui/button'
@@ -44,6 +45,17 @@ export default function MarkdownPreview({
   const isDark =
     settings?.theme === 'dark' ||
     (settings?.theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)
+
+  const frontMatter = useMemo(() => extractFrontMatter(content), [content])
+  const frontMatterInner = useMemo(() => {
+    if (!frontMatter) {
+      return ''
+    }
+    return frontMatter.raw
+      .replace(/^(?:---|\+\+\+)\r?\n/, '')
+      .replace(/\r?\n(?:---|\+\+\+)\r?\n?$/, '')
+      .trim()
+  }, [frontMatter])
 
   // Why: Each markdown viewing mode (source/rich/preview) produces different
   // DOM structures and content heights. A scroll position saved in source mode
@@ -369,6 +381,19 @@ export default function MarkdownPreview({
         </div>
       ) : null}
       <div ref={bodyRef} className="markdown-body">
+        {/* Why: remarkFrontmatter silently strips front-matter from rendered
+        output. We extract it ourselves and render it as a styled code block so
+        the user can see the metadata in preview mode. */}
+        {frontMatter && (
+          <div className="mb-4 rounded border border-border/60 bg-muted/40 px-3 py-2">
+            <div className="mb-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+              Front Matter
+            </div>
+            <pre className="max-h-48 overflow-auto whitespace-pre-wrap text-xs text-muted-foreground font-mono scrollbar-editor">
+              {frontMatterInner}
+            </pre>
+          </div>
+        )}
         <Markdown
           components={components}
           remarkPlugins={[remarkGfm, remarkFrontmatter]}

--- a/src/renderer/src/components/editor/markdown-frontmatter.test.ts
+++ b/src/renderer/src/components/editor/markdown-frontmatter.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import { extractFrontMatter, prependFrontMatter } from './markdown-frontmatter'
+
+describe('extractFrontMatter', () => {
+  it('extracts YAML front-matter delimited by ---', () => {
+    const content = '---\ntitle: Hello\ntags: [a, b]\n---\n# Body\n'
+    const result = extractFrontMatter(content)
+    expect(result).not.toBeNull()
+    expect(result!.raw).toBe('---\ntitle: Hello\ntags: [a, b]\n---\n')
+    expect(result!.body).toBe('# Body\n')
+  })
+
+  it('extracts TOML front-matter delimited by +++', () => {
+    const content = '+++\ntitle = "Hello"\n+++\nBody\n'
+    const result = extractFrontMatter(content)
+    expect(result).not.toBeNull()
+    expect(result!.raw).toBe('+++\ntitle = "Hello"\n+++\n')
+    expect(result!.body).toBe('Body\n')
+  })
+
+  it('returns null when there is no front-matter', () => {
+    expect(extractFrontMatter('# Just a heading\n')).toBeNull()
+    expect(extractFrontMatter('')).toBeNull()
+  })
+
+  it('does not match --- in the middle of the document', () => {
+    const content = '# Title\n\n---\nkey: val\n---\n'
+    expect(extractFrontMatter(content)).toBeNull()
+  })
+
+  it('handles front-matter with no body', () => {
+    const content = '---\ntitle: Hello\n---\n'
+    const result = extractFrontMatter(content)
+    expect(result).not.toBeNull()
+    expect(result!.body).toBe('')
+  })
+
+  it('handles CRLF line endings', () => {
+    const content = '---\r\ntitle: Hello\r\n---\r\n# Body\r\n'
+    const result = extractFrontMatter(content)
+    expect(result).not.toBeNull()
+    expect(result!.body).toBe('# Body\r\n')
+  })
+
+  it('handles empty front-matter block', () => {
+    const content = '---\n\n---\n# Body\n'
+    const result = extractFrontMatter(content)
+    expect(result).not.toBeNull()
+    expect(result!.raw).toBe('---\n\n---\n')
+    expect(result!.body).toBe('# Body\n')
+  })
+})
+
+describe('prependFrontMatter', () => {
+  it('reassembles front-matter and body', () => {
+    const raw = '---\ntitle: Hello\n---\n'
+    const body = '# Body\n'
+    expect(prependFrontMatter(raw, body)).toBe('---\ntitle: Hello\n---\n# Body\n')
+  })
+
+  it('adds trailing newline to raw if missing', () => {
+    const raw = '---\ntitle: Hello\n---'
+    const body = '# Body\n'
+    expect(prependFrontMatter(raw, body)).toBe('---\ntitle: Hello\n---\n# Body\n')
+  })
+
+  it('round-trips with extractFrontMatter', () => {
+    const original = '---\ntitle: Hello\ntags: [a, b]\n---\n# Body\n\nParagraph.\n'
+    const fm = extractFrontMatter(original)
+    expect(fm).not.toBeNull()
+    expect(prependFrontMatter(fm!.raw, fm!.body)).toBe(original)
+  })
+})

--- a/src/renderer/src/components/editor/markdown-frontmatter.ts
+++ b/src/renderer/src/components/editor/markdown-frontmatter.ts
@@ -1,0 +1,37 @@
+const FRONTMATTER_RE = /^(---|\+\+\+)\r?\n([\s\S]*?)\r?\n\1(?:\r?\n|$)/
+
+export type FrontMatter = {
+  /** The full raw front-matter block including delimiters and trailing newline. */
+  raw: string
+  /** The document body after the front-matter block. */
+  body: string
+}
+
+/**
+ * Extracts a YAML (`---`) or TOML (`+++`) front-matter block from the start
+ * of a markdown document. Returns null if no front-matter is present.
+ */
+export function extractFrontMatter(content: string): FrontMatter | null {
+  const match = content.match(FRONTMATTER_RE)
+  if (!match) {
+    return null
+  }
+
+  const raw = match[0]
+  const body = content.slice(raw.length)
+
+  return { raw, body }
+}
+
+/**
+ * Re-assembles a full markdown document from a raw front-matter block and body.
+ * Ensures exactly one newline separates the front-matter block from the body.
+ */
+export function prependFrontMatter(raw: string, body: string): string {
+  // Why: the raw block captured by extractFrontMatter may or may not end with
+  // a newline depending on whether the original document had a blank line after
+  // the closing delimiter. Normalising to exactly one trailing newline prevents
+  // accumulating extra blank lines on every save cycle.
+  const normalizedRaw = raw.endsWith('\n') ? raw : `${raw}\n`
+  return `${normalizedRaw}${body}`
+}

--- a/src/renderer/src/components/editor/markdown-rich-mode.test.ts
+++ b/src/renderer/src/components/editor/markdown-rich-mode.test.ts
@@ -45,4 +45,20 @@ describe('getMarkdownRichModeUnsupportedMessage', () => {
     expect(getMarkdownRichModeUnsupportedMessage('<Widget />\n')).toBeNull()
     expect(getMarkdownRichModeUnsupportedMessage('<div>block</div>\n')).toBeNull()
   })
+
+  it('allows markdown files with front-matter', () => {
+    expect(
+      getMarkdownRichModeUnsupportedMessage('---\ntitle: Hello\ntags: [a, b]\n---\n# Body\n')
+    ).toBeNull()
+  })
+
+  it('allows TOML front-matter delimited by +++', () => {
+    expect(getMarkdownRichModeUnsupportedMessage('+++\ntitle = "Hello"\n+++\nBody\n')).toBeNull()
+  })
+
+  it('allows front-matter with clean markdown body', () => {
+    expect(
+      getMarkdownRichModeUnsupportedMessage('---\ntitle: Docs\n---\n# Heading\n\n- one\n- two\n')
+    ).toBeNull()
+  })
 })

--- a/src/renderer/src/components/editor/markdown-rich-mode.ts
+++ b/src/renderer/src/components/editor/markdown-rich-mode.ts
@@ -1,7 +1,7 @@
 import { canRoundTripRichMarkdown, getRichMarkdownRoundTripOutput } from './markdown-round-trip'
+import { extractFrontMatter } from './markdown-frontmatter'
 
 export type MarkdownRichModeUnsupportedReason =
-  | 'frontmatter'
   | 'html-or-jsx'
   | 'reference-links'
   | 'footnotes'
@@ -15,16 +15,8 @@ type UnsupportedMatch = {
 
 const UNSUPPORTED_PATTERNS: UnsupportedMatch[] = [
   {
-    reason: 'frontmatter',
-    message: 'Frontmatter is only editable in source mode.',
-    // Why: Tiptap markdown support is beta and frontmatter is often consumed by
-    // static-site tooling. Falling back to source mode avoids silently dropping
-    // metadata that rich mode does not explicitly own.
-    pattern: /^(?:---|\+\+\+)\r?\n[\s\S]*?\r?\n(?:---|\+\+\+)(?:\r?\n|$)/
-  },
-  {
     reason: 'html-or-jsx',
-    message: 'HTML, JSX, or MDX content is only editable in source mode.',
+    message: 'Editable only in code mode because this file contains HTML, JSX, or MDX.',
     // Why: the rich editor preserves common embedded markup via placeholder
     // tokens before parsing, but any HTML shape that still fails round-trip
     // must fall back instead of risking silent source corruption.
@@ -32,37 +24,41 @@ const UNSUPPORTED_PATTERNS: UnsupportedMatch[] = [
   },
   {
     reason: 'reference-links',
-    message: 'Reference-style links are only editable in source mode.',
+    message: 'Editable only in code mode because this file contains reference-style links.',
     pattern: /^\[[^\]]+\]:\s+\S+/m
   },
   {
     reason: 'footnotes',
-    message: 'Footnotes are only editable in source mode.',
+    message: 'Editable only in code mode because this file contains footnotes.',
     pattern: /^\[\^[^\]]+\]:\s+/m
   }
 ]
 
 export function getMarkdownRichModeUnsupportedMessage(content: string): string | null {
-  const contentWithoutCode = stripMarkdownCode(content)
+  // Why: front-matter is handled externally — stripped before the rich editor
+  // sees the content and displayed as a read-only block. Only the body needs
+  // to pass the unsupported-content checks.
+  const fm = extractFrontMatter(content)
+  const body = fm ? fm.body : content
 
-  const frontmatterMatcher = UNSUPPORTED_PATTERNS[0]
-  if (frontmatterMatcher && frontmatterMatcher.pattern.test(contentWithoutCode)) {
-    return frontmatterMatcher.message
-  }
+  const contentWithoutCode = stripMarkdownCode(body)
 
-  if (canRoundTripRichMarkdown(content)) {
+  if (canRoundTripRichMarkdown(body)) {
     return null
   }
 
-  const htmlMatcher = UNSUPPORTED_PATTERNS[1]
+  // Why: HTML/JSX gets special treatment — if the round-trip output preserves
+  // the embedded markup, we allow rich mode even though the pattern matched.
+  // Looked up by reason (not index) so reordering the array won't break this.
+  const htmlMatcher = UNSUPPORTED_PATTERNS.find((m) => m.reason === 'html-or-jsx')
   if (htmlMatcher && htmlMatcher.pattern.test(contentWithoutCode)) {
-    const roundTripOutput = getRichMarkdownRoundTripOutput(content)
+    const roundTripOutput = getRichMarkdownRoundTripOutput(body)
     if (roundTripOutput && preservesEmbeddedHtml(contentWithoutCode, roundTripOutput)) {
       return null
     }
   }
 
-  for (const matcher of UNSUPPORTED_PATTERNS.slice(1)) {
+  for (const matcher of UNSUPPORTED_PATTERNS) {
     if (matcher.pattern.test(contentWithoutCode)) {
       return matcher.message
     }


### PR DESCRIPTION
## Summary
- Add `extractFrontMatter` / `prependFrontMatter` utilities to strip YAML/TOML front-matter from markdown before the rich editor processes it, preventing silent data loss
- Display front-matter as a read-only banner above the rich editor and as a styled block in preview mode
- Remove `frontmatter` from `UNSUPPORTED_PATTERNS` so files with front-matter can now use rich editing mode (body-only checks)
- Harden html-or-jsx matcher lookup to use `.find()` by reason instead of fragile array index

## Test plan
- [x] Unit tests for `extractFrontMatter` and `prependFrontMatter` (YAML, TOML, CRLF, empty body, round-trip)
- [x] Integration tests confirming `getMarkdownRichModeUnsupportedMessage` allows front-matter files
- [ ] Manual: open a `.md` file with YAML front-matter in rich mode — verify banner shows and content edits preserve front-matter on save
- [ ] Manual: open same file in preview mode — verify front-matter block renders above markdown
- [ ] Typecheck passes