### PR TITLE
fix: paste on right-click in Windows terminals

### DIFF
--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -13,12 +13,14 @@ import type { OrcaHooks } from '../../../../shared/types'
 import { getRepoKindLabel, isFolderRepo } from '../../../../shared/repo-kind'
 import { useAppStore } from '../../store'
 import { useSystemPrefersDark } from '@/components/terminal-pane/use-system-prefers-dark'
+import { isWindowsUserAgent } from '@/components/terminal-pane/pane-helpers'
 import { SCROLLBACK_PRESETS_MB, getFallbackTerminalFonts } from './SettingsConstants'
 import { GeneralPane, GENERAL_PANE_SEARCH_ENTRIES } from './GeneralPane'
 import { AppearancePane, APPEARANCE_PANE_SEARCH_ENTRIES } from './AppearancePane'
 import { ShortcutsPane, SHORTCUTS_PANE_SEARCH_ENTRIES } from './ShortcutsPane'
-import { TerminalPane, TERMINAL_PANE_SEARCH_ENTRIES } from './TerminalPane'
+import { TerminalPane } from './TerminalPane'
 import { RepositoryPane, getRepositoryPaneSearchEntries } from './RepositoryPane'
+import { getTerminalPaneSearchEntries } from './terminal-search'
 import { GitPane, GIT_PANE_SEARCH_ENTRIES } from './GitPane'
 import { NotificationsPane, NOTIFICATIONS_PANE_SEARCH_ENTRIES } from './NotificationsPane'
 import { StatsPane, STATS_PANE_SEARCH_ENTRIES } from '../stats/StatsPane'
@@ -72,6 +74,14 @@ function Settings(): React.JSX.Element {
     Record<string, { hasHooks: boolean; hooks: OrcaHooks | null; mayNeedUpdate: boolean }>
   >({})
   const systemPrefersDark = useSystemPrefersDark()
+  const isWindows = isWindowsUserAgent()
+  // Why: the Terminal settings section shares one search index with the
+  // sidebar. We trim Windows-only entries on other platforms so search never
+  // reveals controls that the renderer will intentionally hide.
+  const terminalPaneSearchEntries = useMemo(
+    () => getTerminalPaneSearchEntries(isWindows),
+    [isWindows]
+  )
   const [scrollbackMode, setScrollbackMode] = useState<'preset' | 'custom'>('preset')
   const [prevScrollbackBytes, setPrevScrollbackBytes] = useState(settings?.terminalScrollbackBytes)
   const [terminalFontSuggestions, setTerminalFontSuggestions] = useState<string[]>(
@@ -236,7 +246,7 @@ function Settings(): React.JSX.Element {
         title: 'Terminal',
         description: 'Terminal appearance, previews, and defaults for new panes.',
         icon: SquareTerminal,
-        searchEntries: TERMINAL_PANE_SEARCH_ENTRIES
+        searchEntries: terminalPaneSearchEntries
       },
       {
         id: 'notifications',
@@ -267,7 +277,7 @@ function Settings(): React.JSX.Element {
         searchEntries: getRepositoryPaneSearchEntries(repo)
       }))
     ],
-    [repos]
+    [repos, terminalPaneSearchEntries]
   )
 
   const visibleNavSections = useMemo(
@@ -433,7 +443,7 @@ function Settings(): React.JSX.Element {
                   id="terminal"
                   title="Terminal"
                   description="Terminal appearance, previews, and defaults for new panes."
-                  searchEntries={TERMINAL_PANE_SEARCH_ENTRIES}
+                  searchEntries={terminalPaneSearchEntries}
                 >
                   <TerminalPane
                     settings={settings}

--- a/src/renderer/src/components/settings/TerminalPane.tsx
+++ b/src/renderer/src/components/settings/TerminalPane.tsx
@@ -300,15 +300,15 @@ export function TerminalPane({
           matchesSettingsSearch(searchQuery, TERMINAL_RIGHT_CLICK_TO_PASTE_SEARCH_ENTRY) && (
             <SearchableSetting
               title="Right-click to paste"
-              description="On Windows, right-click pastes the clipboard into the terminal. Ctrl+right-click still opens the context menu."
+              description="On Windows, right-click pastes the clipboard into the terminal. Use Ctrl+right-click to open the context menu."
               keywords={['terminal', 'windows', 'right click', 'paste', 'context menu']}
               className="flex items-center justify-between gap-4 px-1 py-2"
             >
               <div className="space-y-0.5">
                 <Label>Right-click to paste</Label>
                 <p className="text-xs text-muted-foreground">
-                  On Windows, right-click pastes the clipboard into the terminal. Ctrl+right-click
-                  still opens the context menu.
+                  On Windows, right-click pastes the clipboard into the terminal. Use
+                  Ctrl+right-click to open the context menu.
                 </p>
               </div>
               <button

--- a/src/renderer/src/components/settings/TerminalPane.tsx
+++ b/src/renderer/src/components/settings/TerminalPane.tsx
@@ -26,18 +26,17 @@ import { SCROLLBACK_PRESETS_MB } from './SettingsConstants'
 import { SearchableSetting } from './SearchableSetting'
 import { matchesSettingsSearch } from './settings-search'
 import { useAppStore } from '../../store'
+import { isWindowsUserAgent } from '@/components/terminal-pane/pane-helpers'
 import {
   TERMINAL_ADVANCED_SEARCH_ENTRIES,
   TERMINAL_CURSOR_SEARCH_ENTRIES,
   TERMINAL_DARK_THEME_SEARCH_ENTRIES,
   TERMINAL_LIGHT_THEME_SEARCH_ENTRIES,
-  TERMINAL_PANE_SEARCH_ENTRIES,
   TERMINAL_PANE_STYLE_SEARCH_ENTRIES,
+  TERMINAL_RIGHT_CLICK_TO_PASTE_SEARCH_ENTRY,
   TERMINAL_TYPOGRAPHY_SEARCH_ENTRIES
 } from './terminal-search'
 import { DarkTerminalThemeSection, LightTerminalThemeSection } from './TerminalThemeSections'
-
-export { TERMINAL_PANE_SEARCH_ENTRIES }
 
 type TerminalPaneProps = {
   settings: GlobalSettings
@@ -57,6 +56,7 @@ export function TerminalPane({
   setScrollbackMode
 }: TerminalPaneProps): React.JSX.Element {
   const searchQuery = useAppStore((state) => state.settingsSearchQuery)
+  const isWindows = isWindowsUserAgent()
   const [themeSearchDark, setThemeSearchDark] = useState('')
   const [themeSearchLight, setThemeSearchLight] = useState('')
 
@@ -238,12 +238,13 @@ export function TerminalPane({
         </div>
       </section>
     ) : null,
-    matchesSettingsSearch(searchQuery, TERMINAL_PANE_STYLE_SEARCH_ENTRIES) ? (
+    (matchesSettingsSearch(searchQuery, TERMINAL_PANE_STYLE_SEARCH_ENTRIES) ||
+      (isWindows && matchesSettingsSearch(searchQuery, TERMINAL_RIGHT_CLICK_TO_PASTE_SEARCH_ENTRY))) ? (
       <section key="pane-styling" className="space-y-4">
         <div className="space-y-1">
           <h3 className="text-sm font-semibold">Pane Styling</h3>
           <p className="text-xs text-muted-foreground">
-            Control inactive pane dimming, divider thickness, and transition timing.
+            Control inactive pane dimming, divider thickness, mouse behavior, and transition timing.
           </p>
         </div>
 
@@ -291,6 +292,45 @@ export function TerminalPane({
             />
           </SearchableSetting>
         </div>
+
+        {/* Why: the Windows-only right-click toggle lives in this section, so the
+            section must also match that search term or settings search would hide
+            the control even though it is present. */}
+        {isWindows &&
+          matchesSettingsSearch(searchQuery, TERMINAL_RIGHT_CLICK_TO_PASTE_SEARCH_ENTRY) && (
+            <SearchableSetting
+              title="Right-click to paste"
+              description="On Windows, right-click pastes the clipboard into the terminal. Ctrl+right-click still opens the context menu."
+              keywords={['terminal', 'windows', 'right click', 'paste', 'context menu']}
+              className="flex items-center justify-between gap-4 px-1 py-2"
+            >
+              <div className="space-y-0.5">
+                <Label>Right-click to paste</Label>
+                <p className="text-xs text-muted-foreground">
+                  On Windows, right-click pastes the clipboard into the terminal. Ctrl+right-click
+                  still opens the context menu.
+                </p>
+              </div>
+              <button
+                role="switch"
+                aria-checked={settings.terminalRightClickToPaste}
+                onClick={() =>
+                  updateSettings({
+                    terminalRightClickToPaste: !settings.terminalRightClickToPaste
+                  })
+                }
+                className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent transition-colors ${
+                  settings.terminalRightClickToPaste ? 'bg-foreground' : 'bg-muted-foreground/30'
+                }`}
+              >
+                <span
+                  className={`pointer-events-none block size-3.5 rounded-full bg-background shadow-sm transition-transform ${
+                    settings.terminalRightClickToPaste ? 'translate-x-4' : 'translate-x-0.5'
+                  }`}
+                />
+              </button>
+            </SearchableSetting>
+          )}
 
         <SearchableSetting
           title="Focus Follows Mouse"

--- a/src/renderer/src/components/settings/terminal-search.test.ts
+++ b/src/renderer/src/components/settings/terminal-search.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { getTerminalPaneSearchEntries } from './terminal-search'
+
+describe('getTerminalPaneSearchEntries', () => {
+  it('includes the Windows right-click setting on Windows', () => {
+    const entries = getTerminalPaneSearchEntries(true)
+    expect(entries.some((entry) => entry.title === 'Right-click to paste')).toBe(true)
+  })
+
+  it('omits the Windows right-click setting elsewhere', () => {
+    const entries = getTerminalPaneSearchEntries(false)
+    expect(entries.some((entry) => entry.title === 'Right-click to paste')).toBe(false)
+  })
+})

--- a/src/renderer/src/components/settings/terminal-search.ts
+++ b/src/renderer/src/components/settings/terminal-search.ts
@@ -93,10 +93,12 @@ export const TERMINAL_WINDOWS_SEARCH_ENTRIES: SettingsSearchEntry[] = [
   {
     title: 'Right-click to paste',
     description:
-      'On Windows, right-click pastes the clipboard into the terminal. Ctrl+right-click still opens the context menu.',
+      'On Windows, right-click pastes the clipboard into the terminal. Use Ctrl+right-click to open the context menu.',
     keywords: ['terminal', 'windows', 'right click', 'paste', 'context menu']
   }
 ]
+
+export const TERMINAL_RIGHT_CLICK_TO_PASTE_SEARCH_ENTRY = TERMINAL_WINDOWS_SEARCH_ENTRIES
 
 export function getTerminalPaneSearchEntries(isWindows: boolean): SettingsSearchEntry[] {
   // Why: the settings search index must mirror the visible controls. Keeping

--- a/src/renderer/src/components/settings/terminal-search.ts
+++ b/src/renderer/src/components/settings/terminal-search.ts
@@ -89,11 +89,26 @@ export const TERMINAL_ADVANCED_SEARCH_ENTRIES: SettingsSearchEntry[] = [
   }
 ]
 
-export const TERMINAL_PANE_SEARCH_ENTRIES: SettingsSearchEntry[] = [
-  ...TERMINAL_TYPOGRAPHY_SEARCH_ENTRIES,
-  ...TERMINAL_CURSOR_SEARCH_ENTRIES,
-  ...TERMINAL_PANE_STYLE_SEARCH_ENTRIES,
-  ...TERMINAL_DARK_THEME_SEARCH_ENTRIES,
-  ...TERMINAL_LIGHT_THEME_SEARCH_ENTRIES,
-  ...TERMINAL_ADVANCED_SEARCH_ENTRIES
+export const TERMINAL_WINDOWS_SEARCH_ENTRIES: SettingsSearchEntry[] = [
+  {
+    title: 'Right-click to paste',
+    description:
+      'On Windows, right-click pastes the clipboard into the terminal. Ctrl+right-click still opens the context menu.',
+    keywords: ['terminal', 'windows', 'right click', 'paste', 'context menu']
+  }
 ]
+
+export function getTerminalPaneSearchEntries(isWindows: boolean): SettingsSearchEntry[] {
+  // Why: the settings search index must mirror the visible controls. Keeping
+  // the Windows-only paste toggle out of non-Windows search results prevents
+  // users from landing on an option the UI intentionally hides.
+  return [
+    ...TERMINAL_TYPOGRAPHY_SEARCH_ENTRIES,
+    ...TERMINAL_CURSOR_SEARCH_ENTRIES,
+    ...TERMINAL_PANE_STYLE_SEARCH_ENTRIES,
+    ...(isWindows ? TERMINAL_WINDOWS_SEARCH_ENTRIES : []),
+    ...TERMINAL_DARK_THEME_SEARCH_ENTRIES,
+    ...TERMINAL_LIGHT_THEME_SEARCH_ENTRIES,
+    ...TERMINAL_ADVANCED_SEARCH_ENTRIES
+  ]
+}

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -12,7 +12,7 @@ import {
 import type { PaneManager } from '@/lib/pane-manager/pane-manager'
 import TerminalSearch from '@/components/TerminalSearch'
 import type { PtyTransport } from './pty-transport'
-import { fitPanes, shellEscapePath } from './pane-helpers'
+import { fitPanes, isWindowsUserAgent, shellEscapePath } from './pane-helpers'
 import { EMPTY_LAYOUT, paneLeafId, serializeTerminalLayout } from './layout-serialization'
 import { createExpandCollapseActions } from './expand-collapse'
 import { useTerminalKeyboardShortcuts, type SearchState } from './keyboard-handlers'
@@ -109,6 +109,11 @@ export default function TerminalPane({
   const clearTabPtyId = useAppStore((store) => store.clearTabPtyId)
   const markWorktreeUnread = useAppStore((store) => store.markWorktreeUnread)
   const settings = useAppStore((store) => store.settings)
+  // Why: Windows is the only platform where bare right-click is repurposed as
+  // a paste gesture; on macOS/Linux the terminal still owns right-click for the
+  // context menu. The settings default keeps the Windows shortcut feeling native
+  // without changing the other platforms' interaction model.
+  const rightClickToPaste = isWindowsUserAgent() && (settings?.terminalRightClickToPaste ?? true)
   const [startup] = useState(() => useAppStore.getState().pendingStartupByTabId[tabId])
   const consumeTabStartupCommand = useAppStore((store) => store.consumeTabStartupCommand)
   const [setupSplit] = useState(() => useAppStore.getState().pendingSetupSplitByTabId[tabId])
@@ -690,7 +695,8 @@ export default function TerminalPane({
     managerRef,
     toggleExpandPane,
     onRequestClosePane: handleRequestClosePane,
-    onSetTitle: handleStartRename
+    onSetTitle: handleStartRename,
+    rightClickToPaste
   })
 
   const effectiveAppearance = settings

--- a/src/renderer/src/components/terminal-pane/pane-helpers.test.ts
+++ b/src/renderer/src/components/terminal-pane/pane-helpers.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it } from 'vitest'
-import { shellEscapePath } from './pane-helpers'
+import { isWindowsUserAgent, shellEscapePath } from './pane-helpers'
+
+describe('isWindowsUserAgent', () => {
+  it('detects Windows user agents', () => {
+    expect(isWindowsUserAgent('Mozilla/5.0 (Windows NT 10.0; Win64; x64)')).toBe(true)
+  })
+
+  it('ignores non-Windows user agents', () => {
+    expect(isWindowsUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)')).toBe(false)
+  })
+})
 
 describe('shellEscapePath', () => {
   it('keeps safe POSIX paths unquoted', () => {

--- a/src/renderer/src/components/terminal-pane/pane-helpers.ts
+++ b/src/renderer/src/components/terminal-pane/pane-helpers.ts
@@ -30,7 +30,9 @@ export function fitAndFocusPanes(manager: PaneManager): void {
   focusActivePane(manager)
 }
 
-function isWindowsUserAgent(userAgent: string): boolean {
+export function isWindowsUserAgent(
+  userAgent: string = typeof navigator === 'undefined' ? '' : navigator.userAgent
+): boolean {
   return userAgent.includes('Windows')
 }
 

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
@@ -153,6 +153,12 @@ export function useTerminalPaneContextMenu({
     }
     const clickedPane = manager.getPanes().find((pane) => pane.container.contains(target)) ?? null
     contextPaneIdRef.current = clickedPane?.id ?? null
+    if (navigator.userAgent.includes('Windows')) {
+      // Why: Windows terminals default to right-click paste, and showing the
+      // context menu steals focus so pasted text isn't ready to submit.
+      void onPaste()
+      return
+    }
     const bounds = event.currentTarget.getBoundingClientRect()
     setPoint({ x: event.clientX - bounds.left, y: event.clientY - bounds.top })
     setOpen(true)

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
@@ -8,6 +8,7 @@ type UseTerminalPaneContextMenuDeps = {
   toggleExpandPane: (paneId: number) => void
   onRequestClosePane: (paneId: number) => void
   onSetTitle: (paneId: number) => void
+  rightClickToPaste: boolean
 }
 
 type TerminalMenuState = {
@@ -32,7 +33,8 @@ export function useTerminalPaneContextMenu({
   managerRef,
   toggleExpandPane,
   onRequestClosePane,
-  onSetTitle
+  onSetTitle,
+  rightClickToPaste
 }: UseTerminalPaneContextMenuDeps): TerminalMenuState {
   const contextPaneIdRef = useRef<number | null>(null)
   const menuOpenedAtRef = useRef(0)
@@ -139,7 +141,6 @@ export function useTerminalPaneContextMenu({
 
   const onContextMenuCapture = (event: React.MouseEvent<HTMLDivElement>): void => {
     event.preventDefault()
-    menuOpenedAtRef.current = Date.now()
     window.dispatchEvent(new Event(CLOSE_ALL_CONTEXT_MENUS_EVENT))
     const manager = managerRef.current
     if (!manager) {
@@ -153,12 +154,18 @@ export function useTerminalPaneContextMenu({
     }
     const clickedPane = manager.getPanes().find((pane) => pane.container.contains(target)) ?? null
     contextPaneIdRef.current = clickedPane?.id ?? null
-    if (navigator.userAgent.includes('Windows')) {
-      // Why: Windows terminals default to right-click paste, and showing the
-      // context menu steals focus so pasted text isn't ready to submit.
+
+    // Why: Windows users expect bare right-click to paste when that setting is
+    // enabled, but Ctrl+right-click must still reach the app menu so the menu
+    // remains discoverable. We keep the terminal pane target in sync first so
+    // the paste path uses the clicked split even though no menu opens.
+    if (rightClickToPaste && !event.ctrlKey) {
+      event.stopPropagation()
       void onPaste()
       return
     }
+
+    menuOpenedAtRef.current = Date.now()
     const bounds = event.currentTarget.getBoundingClientRect()
     setPoint({ x: event.clientX - bounds.left, y: event.clientY - bounds.top })
     setOpen(true)

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -98,6 +98,10 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     terminalActivePaneOpacity: 1,
     terminalPaneOpacityTransitionMs: 140,
     terminalDividerThicknessPx: 3,
+    // Default true so Windows users get native right-click paste out of the
+    // box. Other platforms ignore this field because the UI never exposes it,
+    // and Ctrl+right-click still opens the context menu when paste is enabled.
+    terminalRightClickToPaste: true,
     // Default false: opt-in only (matches Ghostty's default). Existing users
     // on upgrade inherit this default via persistence.ts's
     // { ...defaults.settings, ...parsed.settings } merge, so enabling

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -459,6 +459,10 @@ export type GlobalSettings = {
   terminalActivePaneOpacity: number
   terminalPaneOpacityTransitionMs: number
   terminalDividerThicknessPx: number
+  /** Why: Windows terminals conventionally use right-click as a paste gesture.
+   *  The setting stays Windows-only so macOS/Linux keep their existing context
+   *  menu behavior and users can still reach the menu with Ctrl+right-click. */
+  terminalRightClickToPaste: boolean
   terminalFocusFollowsMouse: boolean
   terminalScrollbackBytes: number
   /** Why: opening arbitrary links inside Orca uses an isolated guest browser surface.


### PR DESCRIPTION
## Summary
Fixes #560 by pasting on right-click in Windows terminal panes instead of opening the context menu, so focus stays in the input.

## Screenshots
No visual change.

## Testing
- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Not run (UI-only change, no local pnpm install in this environment).

## AI Review Report
Reviewed the terminal context menu flow to ensure the right-click path now reuses the existing clipboard paste helper on Windows only. Confirmed macOS/Linux behavior is unchanged, and the targeted pane is still resolved before pasting. Cross-platform check: the change gates on `navigator.userAgent.includes('Windows')`, so shortcuts, labels, and paths on macOS/Linux are unaffected.

## Security Audit
Reviewed clipboard access and paste plumbing. The change reuses existing IPC clipboard reads and image temp-file handling without adding new input sources, command execution, or path manipulation. No new auth, IPC, or dependency risks introduced.

## Notes
Windows-only behavior: right-click now pastes directly and does not open the terminal context menu.

Update: added a Windows-only "Right-click to paste" terminal setting (default on) and kept Ctrl+right-click as the escape hatch for the context menu. Non-Windows platforms do not show the setting.
