### PR TITLE
fix: improve title bar agent label spacing

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -514,9 +514,11 @@ function App(): React.JSX.Element {
         <div className="titlebar">
           {/* Why: the left section of the titlebar matches the sidebar width so
               tabs start exactly where the sidebar ends, creating a clean vertical
-              alignment between the sidebar edge and the first tab. */}
+              alignment between the sidebar edge and the first tab. When the
+              sidebar is collapsed, shrink-0 prevents the flex-1 tab section from
+              squeezing this area, and mr-2 adds a gap before the first tab. */}
           <div
-            className={`flex items-center overflow-hidden mr-2${showSidebar && sidebarOpen ? ' shrink-0' : ' min-w-0'}`}
+            className={`flex items-center${showSidebar && sidebarOpen ? ' overflow-hidden shrink-0' : ' shrink-0 mr-2'}`}
             style={{ width: showSidebar && sidebarOpen ? sidebarWidth : undefined }}
           >
             <div className={isMac && !isFullScreen ? 'titlebar-traffic-light-pad' : 'pl-2'} />
@@ -551,7 +553,6 @@ function App(): React.JSX.Element {
                       aria-hidden
                     />
                     <span className="titlebar-agent-badge-count">{activeAgentCount}</span>
-                    <span className="titlebar-agent-badge-label">active</span>
                   </span>
                 </HoverCardTrigger>
                 <HoverCardContent side="bottom" sideOffset={6} className="titlebar-agent-hovercard">

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -516,7 +516,7 @@ function App(): React.JSX.Element {
               tabs start exactly where the sidebar ends, creating a clean vertical
               alignment between the sidebar edge and the first tab. */}
           <div
-            className={`flex items-center overflow-hidden${showSidebar && sidebarOpen ? ' shrink-0' : ' min-w-0'}`}
+            className={`flex items-center overflow-hidden mr-2${showSidebar && sidebarOpen ? ' shrink-0' : ' min-w-0'}`}
             style={{ width: showSidebar && sidebarOpen ? sidebarWidth : undefined }}
           >
             <div className={isMac && !isFullScreen ? 'titlebar-traffic-light-pad' : 'pl-2'} />

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { create } from 'zustand'
 import type { AppState } from '../types'
@@ -265,8 +266,12 @@ describe('removeWorktree state cleanup', () => {
         'repo1::/path/wt2': [{ id: 'tab-2', worktreeId: 'repo1::/path/wt2' }]
       },
       groupsByWorktree: {
-        'repo1::/path/wt1': [{ id: 'group-1', worktreeId: 'repo1::/path/wt1', activeTabId: 'tab-1' }],
-        'repo1::/path/wt2': [{ id: 'group-2', worktreeId: 'repo1::/path/wt2', activeTabId: 'tab-2' }]
+        'repo1::/path/wt1': [
+          { id: 'group-1', worktreeId: 'repo1::/path/wt1', activeTabId: 'tab-1' }
+        ],
+        'repo1::/path/wt2': [
+          { id: 'group-2', worktreeId: 'repo1::/path/wt2', activeTabId: 'tab-2' }
+        ]
       },
       activeGroupIdByWorktree: {
         'repo1::/path/wt1': 'group-1',


### PR DESCRIPTION
## Summary
- Fix title bar left section layout when sidebar is collapsed: apply `shrink-0` and `mr-2` to prevent the tab section from squeezing the logo/agent area and add a gap before the first tab
- Move `overflow-hidden` to only apply when the sidebar is open (not needed when collapsed since width is intrinsic)
- Remove the "active" text label from the agent badge for a cleaner, more compact appearance

## Test plan
- [ ] Open app with sidebar open — verify titlebar left section aligns with sidebar edge
- [ ] Collapse sidebar — verify logo/agent badge area doesn't get squeezed, and there's a small gap before the first tab
- [ ] Resize window to minimum width with sidebar collapsed — verify no overflow issues
- [ ] Check agent badge shows count but no "active" text label