### PR TITLE
Rename WORKTREES to WORKSPACES in sidebar

### DIFF
--- a/src/renderer/src/components/sidebar/SidebarHeader.tsx
+++ b/src/renderer/src/components/sidebar/SidebarHeader.tsx
@@ -47,7 +47,7 @@ const SidebarHeader = React.memo(function SidebarHeader() {
   return (
     <div className="flex items-center justify-between px-4 pt-3 pb-1">
       <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground select-none">
-        Worktrees
+        Workspaces
       </span>
       <div className="flex items-center gap-1.5 shrink-0">
         <DropdownMenu>

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -1,4 +1,7 @@
-/* eslint-disable max-lines */
+/* eslint-disable max-lines --
+ * Why: this slice test keeps the worktree store scenarios in one file so the
+ * shared mock store setup stays consistent across closely related behaviors.
+ */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { create } from 'zustand'
 import type { AppState } from '../types'


### PR DESCRIPTION
## Problem
The sidebar header still labeled the worktree list as "WORKTREES", which no longer matches the product terminology.

## Solution
Rename the sidebar header text in `SidebarHeader` from `Worktrees` to `Workspaces` so the UI uses the updated naming.
