### PR TITLE
fix: prevent Create button stuck disabled on repo re-select

### DIFF
--- a/src/renderer/src/components/sidebar/AddWorktreeDialog.tsx
+++ b/src/renderer/src/components/sidebar/AddWorktreeDialog.tsx
@@ -263,6 +263,13 @@ const AddWorktreeDialog = React.memo(function AddWorktreeDialog() {
 
   const handleRepoChange = useCallback(
     (value: string) => {
+      // Why: re-selecting the already-active repo resets checkedHooksRepoId and
+      // hasLoadedIssueCommand to null/false, but the useEffect that reloads them
+      // depends on [isOpen, repoId] — since repoId didn't change the effect never
+      // re-fires, leaving the Create button permanently disabled.
+      if (value === repoId) {
+        return
+      }
       setRepoId(value)
       setYamlHooks(null)
       setCheckedHooksRepoId(null)
@@ -276,7 +283,7 @@ const AddWorktreeDialog = React.memo(function AddWorktreeDialog() {
         setCreateError(null)
       }
     },
-    [createError]
+    [createError, repoId]
   )
 
   const handleOpenSetupSettings = useCallback(() => {


### PR DESCRIPTION
## Summary
- Fixes a bug where re-selecting the same repository in the "New Worktree" dialog's combobox would leave the Create button permanently disabled
- `handleRepoChange` reset `checkedHooksRepoId` and `hasLoadedIssueCommand`, but the useEffect that restores them depends on `[isOpen, repoId]` — since `repoId` didn't actually change, the effect never re-fired
- Added an early return when the selected repo hasn't changed, and added `repoId` to the callback's dependency array

## Test plan
- [ ] Open the New Worktree dialog
- [ ] Select a repo from the combobox
- [ ] Open the combobox and select the same repo again
- [ ] Verify the repo still appears selected and the Create button remains enabled
- [ ] Verify switching to a different repo still works correctly (resets hooks, setup, etc.)