### PR TITLE
fix: keep monaco diagnostics config type-safe

### DIFF
--- a/src/renderer/src/lib/monaco-setup.ts
+++ b/src/renderer/src/lib/monaco-setup.ts
@@ -1,5 +1,6 @@
 import { loader } from '@monaco-editor/react'
 import * as monaco from 'monaco-editor'
+import { typescript as monacoTS } from 'monaco-editor'
 import 'monaco-editor/min/vs/editor/editor.main.css'
 import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker'
 import jsonWorker from 'monaco-editor/esm/vs/language/json/json.worker?worker'
@@ -37,10 +38,10 @@ globalThis.MonacoEnvironment = {
 // import statement. Ignoring specific TS diagnostic codes (e.g., 2307, 2792)
 // removes this noise while keeping type checking, auto-complete, and basic
 // validation fully functional for local symbols.
-monaco.languages.typescript.typescriptDefaults.setDiagnosticsOptions({
+monacoTS.typescriptDefaults.setDiagnosticsOptions({
   diagnosticCodesToIgnore: [2307, 2792]
 })
-monaco.languages.typescript.javascriptDefaults.setDiagnosticsOptions({
+monacoTS.javascriptDefaults.setDiagnosticsOptions({
   diagnosticCodesToIgnore: [2307, 2792]
 })
 


### PR DESCRIPTION
## Summary

- PR #588 added `monaco.languages.typescript` calls to suppress false "Cannot find module" diagnostics, but `monaco.languages.typescript` is typed as `{ deprecated: true }` in monaco-editor 0.55, breaking `pnpm run typecheck`
- Uses Monaco's new top-level `typescript` named export (`import { typescript } from 'monaco-editor'`) which has full types, instead of the deprecated `monaco.languages.typescript` path

## Test plan

- [x] `pnpm run typecheck` passes
- [x] Open a TS/JS file with imports — no false "Cannot find module" errors
- [x] Syntax errors still show red squiggles