### PR TITLE
fix: make PDF preview fill available vertical space

### DIFF
--- a/src/renderer/src/components/editor/ImageDiffViewer.tsx
+++ b/src/renderer/src/components/editor/ImageDiffViewer.tsx
@@ -48,8 +48,22 @@ export default function ImageDiffViewer({
   mimeType,
   sideBySide
 }: ImageDiffViewerProps): JSX.Element {
+  // Why: in inline (single-column) mode the grid defaults to equal row
+  // heights. When one side is empty (e.g. a new untracked PDF), the "No
+  // preview" pane would waste half the vertical space. Using `auto` for
+  // empty panes lets them collapse to their content height so the pane
+  // with the actual preview fills the remaining space.
+  const gridRowStyle = !sideBySide
+    ? {
+        gridTemplateRows: `${originalContent ? '1fr' : 'auto'} ${modifiedContent ? '1fr' : 'auto'}`
+      }
+    : undefined
+
   return (
-    <div className={`grid h-full min-h-0 gap-3 p-3 ${sideBySide ? 'grid-cols-2' : 'grid-cols-1'}`}>
+    <div
+      className={`grid h-full min-h-0 gap-3 p-3 ${sideBySide ? 'grid-cols-2' : 'grid-cols-1'}`}
+      style={gridRowStyle}
+    >
       <ImageDiffPane
         label="Original"
         content={originalContent}

--- a/src/renderer/src/components/editor/ImageDiffViewer.tsx
+++ b/src/renderer/src/components/editor/ImageDiffViewer.tsx
@@ -49,19 +49,19 @@ export default function ImageDiffViewer({
   sideBySide
 }: ImageDiffViewerProps): JSX.Element {
   // Why: in inline (single-column) mode the grid defaults to equal row
-  // heights. When one side is empty (e.g. a new untracked PDF), the "No
-  // preview" pane would waste half the vertical space. Using `auto` for
-  // empty panes lets them collapse to their content height so the pane
-  // with the actual preview fills the remaining space.
+  // heights, which squishes each preview into half the panel. Using
+  // minmax(32rem, 1fr) ensures content panes are tall enough to show a
+  // full page, and overflow-y-auto lets the user scroll between them.
+  // Empty "No preview" panes collapse to auto height.
   const gridRowStyle = !sideBySide
     ? {
-        gridTemplateRows: `${originalContent ? '1fr' : 'auto'} ${modifiedContent ? '1fr' : 'auto'}`
+        gridTemplateRows: `${originalContent ? 'minmax(32rem, 1fr)' : 'auto'} ${modifiedContent ? 'minmax(32rem, 1fr)' : 'auto'}`
       }
     : undefined
 
   return (
     <div
-      className={`grid h-full min-h-0 gap-3 p-3 ${sideBySide ? 'grid-cols-2' : 'grid-cols-1'}`}
+      className={`grid h-full min-h-0 gap-3 p-3 ${sideBySide ? 'grid-cols-2' : 'grid-cols-1 overflow-y-auto'}`}
       style={gridRowStyle}
     >
       <ImageDiffPane

--- a/src/renderer/src/components/editor/ImageViewer.tsx
+++ b/src/renderer/src/components/editor/ImageViewer.tsx
@@ -96,7 +96,7 @@ export default function ImageViewer({
   }
 
   const previewPane = isPdf ? (
-    <div className="relative flex flex-1 items-center justify-center overflow-auto bg-muted/20 p-4">
+    <div className="relative flex flex-1 flex-col overflow-auto bg-muted/20 p-4">
       {/* Why: Electron's Chromium PDF viewer can fail to initialize inside a
           sandboxed iframe even when the Blob URL is valid. Using <embed> keeps
           the preview isolated to the browser's native PDF surface without
@@ -104,7 +104,7 @@ export default function ImageViewer({
       <embed
         src={previewUrl}
         type={mimeType}
-        className="h-full min-h-[24rem] w-full rounded-md border border-border/60 bg-background"
+        className="flex-1 min-h-[24rem] w-full rounded-md border border-border/60 bg-background"
       />
     </div>
   ) : (


### PR DESCRIPTION
## Summary
- **ImageViewer**: Switch the PDF embed wrapper from flex-row with `items-center` to `flex-col`, and change the `<embed>` from `h-full` to `flex-1` so it grows to fill all available vertical space
- **ImageDiffViewer**: In inline (single-column) diff mode, collapse empty "No preview" panes to `auto` grid row height so the pane with the actual PDF preview fills the remaining space

Closes #574

## Test plan
- [x] Open Orca with a repo that has a new/untracked PDF file
- [x] Click the PDF in the changed files list to open the diff view
- [x] Verify the "Original: No preview" section is collapsed to minimal height
- [x] Verify the PDF preview in the "Modified" section fills most of the vertical space
- [x] Toggle side-by-side mode and verify both panes still render correctly
- [x] Test with a modified PDF (both sides have content) to verify equal split still works