### PR TITLE
fix: set UTF-8 console code page on Windows to prevent garbled CJK characters

### DIFF
--- a/src/main/ipc/pty-encoding.test.ts
+++ b/src/main/ipc/pty-encoding.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Tests for Windows UTF-8 encoding fix.
+ *
+ * Unit tests demonstrate the GBK/UTF-8 encoding mismatch that causes garbled
+ * CJK characters. Integration tests spawn real shell processes to verify the
+ * code page and encoding are correctly set by our shell arguments.
+ *
+ * Why child_process instead of node-pty: node-pty's ConPTY backend requires
+ * a real console handle (AttachConsole), which vitest workers don't have.
+ * child_process.spawn is sufficient to verify the shell arguments produce
+ * the correct encoding configuration.
+ */
+import { execSync } from 'child_process'
+import { describe, expect, it } from 'vitest'
+
+const isWindows = process.platform === 'win32'
+
+describe('Windows PTY UTF-8 encoding', () => {
+  // Why: GBK (code page 936) is the default console encoding on Chinese Windows.
+  // When ConPTY uses GBK internally and node-pty decodes the pipe as UTF-8,
+  // CJK characters are garbled. This test proves the root cause: GBK-encoded
+  // bytes are invalid or produce wrong characters when decoded as UTF-8.
+  describe('encoding mismatch (root cause)', () => {
+    it('GBK-encoded CJK bytes produce garbled output when decoded as UTF-8', () => {
+      // "你好" in GBK is [0xC4, 0xE3, 0xBA, 0xC3]
+      const gbkBytes = Buffer.from([0xc4, 0xe3, 0xba, 0xc3])
+
+      // Decoding GBK bytes as UTF-8 produces replacement characters
+      const garbled = gbkBytes.toString('utf8')
+      expect(garbled).not.toBe('你好')
+      expect(garbled).toContain('\ufffd')
+    })
+
+    it('UTF-8 encoded CJK bytes decode correctly', () => {
+      // "你好" in UTF-8 is [0xE4, 0xBD, 0xA0, 0xE5, 0xA5, 0xBD]
+      const utf8Bytes = Buffer.from([0xe4, 0xbd, 0xa0, 0xe5, 0xa5, 0xbd])
+
+      expect(utf8Bytes.toString('utf8')).toBe('你好')
+    })
+
+    it('multi-byte split across buffer boundaries produces replacement chars', () => {
+      // Simulates ConPTY pipe read splitting a 3-byte UTF-8 char "你" across reads.
+      // First read gets bytes [0xE4, 0xBD], second read gets [0xA0].
+      // If each chunk is decoded independently (no StringDecoder), the result is garbled.
+      const chunk1 = Buffer.from([0xe4, 0xbd])
+      const chunk2 = Buffer.from([0xa0])
+
+      const decoded1 = chunk1.toString('utf8') // incomplete sequence → replacement char
+      const decoded2 = chunk2.toString('utf8') // orphan continuation byte → replacement char
+
+      // Concatenating independently decoded chunks does NOT produce "你"
+      expect(decoded1 + decoded2).not.toBe('你')
+    })
+
+    it('StringDecoder correctly handles split multi-byte sequences', () => {
+      // This is what node-pty does internally — StringDecoder buffers incomplete
+      // trailing bytes and prepends them to the next write.
+      const { StringDecoder } = require('string_decoder')
+      const decoder = new StringDecoder('utf8')
+
+      const chunk1 = Buffer.from([0xe4, 0xbd])
+      const chunk2 = Buffer.from([0xa0])
+
+      const result = decoder.write(chunk1) + decoder.write(chunk2)
+      expect(result).toBe('你')
+    })
+  })
+
+  describe.skipIf(!isWindows)('real shell encoding verification', () => {
+    it('cmd.exe /K chcp 65001 sets code page to UTF-8', () => {
+      // Spawn cmd.exe with the same args our fix uses, then query the code page.
+      const output = execSync('cmd.exe /C "chcp 65001 > nul && chcp"', {
+        encoding: 'utf-8',
+        timeout: 10_000
+      })
+
+      expect(output).toContain('65001')
+    })
+
+    it('cmd.exe echoes CJK characters correctly with code page 65001', () => {
+      const output = execSync('cmd.exe /C "chcp 65001 > nul && echo 你好世界"', {
+        encoding: 'utf-8',
+        timeout: 10_000
+      })
+
+      expect(output).toContain('你好世界')
+    })
+
+    it('powershell.exe outputs UTF-8 after setting Console encoding', () => {
+      const output = execSync(
+        'powershell.exe -NoProfile -Command "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; [Console]::OutputEncoding.BodyName"',
+        {
+          encoding: 'utf-8',
+          timeout: 15_000
+        }
+      )
+
+      expect(output.trim()).toBe('utf-8')
+    })
+
+    it('powershell.exe outputs CJK characters correctly with UTF-8 encoding', () => {
+      const output = execSync(
+        'powershell.exe -NoProfile -Command "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; Write-Output \'你好世界\'"',
+        {
+          encoding: 'utf-8',
+          timeout: 15_000
+        }
+      )
+
+      expect(output.trim()).toBe('你好世界')
+    })
+
+    it('try/catch in profile loading does not prevent encoding from being set', () => {
+      // Simulates a broken $PROFILE that throws a terminating error.
+      // Our fix wraps it in try/catch so encoding is still set afterward.
+      const output = execSync(
+        'powershell.exe -NoProfile -Command "try { throw \'profile broken\' } catch {}; [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; [Console]::OutputEncoding.BodyName"',
+        {
+          encoding: 'utf-8',
+          timeout: 15_000
+        }
+      )
+
+      expect(output.trim()).toBe('utf-8')
+    })
+
+    it('without try/catch, a terminating error prevents encoding from being set', () => {
+      // Proves that WITHOUT the try/catch fix, a broken profile would prevent
+      // the encoding commands from executing. This is the bug the second review caught.
+      try {
+        execSync(
+          'powershell.exe -NoProfile -Command "throw \'profile broken\'; [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; [Console]::OutputEncoding.BodyName"',
+          {
+            encoding: 'utf-8',
+            timeout: 15_000
+          }
+        )
+        // If we get here, the throw didn't halt execution (shouldn't happen)
+        expect.unreachable('throw should have caused a non-zero exit code')
+      } catch (err: unknown) {
+        // The command fails because the throw halts execution before
+        // the encoding line runs — proving why try/catch is necessary.
+        const error = err as { status: number; stderr: string }
+        expect(error.status).not.toBe(0)
+      }
+    })
+  })
+})

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -239,6 +239,7 @@ describe('registerPtyHandlers', () => {
       } else {
         process.env.COMSPEC = originalComspec
       }
+      delete process.env.PYTHONUTF8
     })
 
     it('passes chcp 65001 to cmd.exe for UTF-8 console output', () => {
@@ -265,7 +266,7 @@ describe('registerPtyHandlers', () => {
         [
           '-NoExit',
           '-Command',
-          '[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; [Console]::InputEncoding = [System.Text.Encoding]::UTF8'
+          '. $PROFILE 2>$null; [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; [Console]::InputEncoding = [System.Text.Encoding]::UTF8'
         ],
         expect.any(Object)
       )
@@ -282,7 +283,7 @@ describe('registerPtyHandlers', () => {
         [
           '-NoExit',
           '-Command',
-          '[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; [Console]::InputEncoding = [System.Text.Encoding]::UTF8'
+          '. $PROFILE 2>$null; [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; [Console]::InputEncoding = [System.Text.Encoding]::UTF8'
         ],
         expect.any(Object)
       )
@@ -309,8 +310,6 @@ describe('registerPtyHandlers', () => {
       const spawnCall = spawnMock.mock.calls.at(-1)!
       const env = spawnCall[2].env as Record<string, string>
       expect(env.PYTHONUTF8).toBe('0')
-
-      delete process.env.PYTHONUTF8
     })
   })
 

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines -- Why: PTY spawn env behavior is easiest to verify in
 one focused file because the registration helper is stateful and each spawn-path
 assertion reuses the same mocked IPC and node-pty harness. */
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
   handleMock,
@@ -212,6 +212,105 @@ describe('registerPtyHandlers', () => {
     it('leaves ambient CODEX_HOME untouched when system default is selected', () => {
       const env = spawnAndGetEnv(undefined, { CODEX_HOME: '/tmp/system-codex-home' }, () => null)
       expect(env.CODEX_HOME).toBe('/tmp/system-codex-home')
+    })
+  })
+
+  describe('Windows UTF-8 code page', () => {
+    let originalPlatform: string
+    let originalComspec: string | undefined
+
+    beforeEach(() => {
+      originalPlatform = process.platform
+      originalComspec = process.env.COMSPEC
+      Object.defineProperty(process, 'platform', {
+        configurable: true,
+        value: 'win32'
+      })
+      process.env.USERPROFILE = 'C:\\Users\\test'
+    })
+
+    afterEach(() => {
+      Object.defineProperty(process, 'platform', {
+        configurable: true,
+        value: originalPlatform
+      })
+      if (originalComspec === undefined) {
+        delete process.env.COMSPEC
+      } else {
+        process.env.COMSPEC = originalComspec
+      }
+    })
+
+    it('passes chcp 65001 to cmd.exe for UTF-8 console output', () => {
+      process.env.COMSPEC = 'C:\\Windows\\system32\\cmd.exe'
+
+      registerPtyHandlers(mainWindow as never)
+      handlers.get('pty:spawn')!(null, { cols: 80, rows: 24 })
+
+      expect(spawnMock).toHaveBeenCalledWith(
+        'C:\\Windows\\system32\\cmd.exe',
+        ['/K', 'chcp 65001 > nul'],
+        expect.any(Object)
+      )
+    })
+
+    it('sets Console encoding for powershell.exe', () => {
+      process.env.COMSPEC = 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe'
+
+      registerPtyHandlers(mainWindow as never)
+      handlers.get('pty:spawn')!(null, { cols: 80, rows: 24 })
+
+      expect(spawnMock).toHaveBeenCalledWith(
+        'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe',
+        [
+          '-NoExit',
+          '-Command',
+          '[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; [Console]::InputEncoding = [System.Text.Encoding]::UTF8'
+        ],
+        expect.any(Object)
+      )
+    })
+
+    it('sets Console encoding for pwsh.exe', () => {
+      process.env.COMSPEC = 'C:\\Program Files\\PowerShell\\7\\pwsh.exe'
+
+      registerPtyHandlers(mainWindow as never)
+      handlers.get('pty:spawn')!(null, { cols: 80, rows: 24 })
+
+      expect(spawnMock).toHaveBeenCalledWith(
+        'C:\\Program Files\\PowerShell\\7\\pwsh.exe',
+        [
+          '-NoExit',
+          '-Command',
+          '[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; [Console]::InputEncoding = [System.Text.Encoding]::UTF8'
+        ],
+        expect.any(Object)
+      )
+    })
+
+    it('sets PYTHONUTF8=1 in the spawn environment on Windows', () => {
+      process.env.COMSPEC = 'C:\\Windows\\system32\\cmd.exe'
+
+      registerPtyHandlers(mainWindow as never)
+      handlers.get('pty:spawn')!(null, { cols: 80, rows: 24 })
+
+      const spawnCall = spawnMock.mock.calls.at(-1)!
+      const env = spawnCall[2].env as Record<string, string>
+      expect(env.PYTHONUTF8).toBe('1')
+    })
+
+    it('does not override an existing PYTHONUTF8 value', () => {
+      process.env.COMSPEC = 'C:\\Windows\\system32\\cmd.exe'
+      process.env.PYTHONUTF8 = '0'
+
+      registerPtyHandlers(mainWindow as never)
+      handlers.get('pty:spawn')!(null, { cols: 80, rows: 24 })
+
+      const spawnCall = spawnMock.mock.calls.at(-1)!
+      const env = spawnCall[2].env as Record<string, string>
+      expect(env.PYTHONUTF8).toBe('0')
+
+      delete process.env.PYTHONUTF8
     })
   })
 

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -266,7 +266,7 @@ describe('registerPtyHandlers', () => {
         [
           '-NoExit',
           '-Command',
-          '. $PROFILE 2>$null; [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; [Console]::InputEncoding = [System.Text.Encoding]::UTF8'
+          'try { . $PROFILE } catch {}; [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; [Console]::InputEncoding = [System.Text.Encoding]::UTF8'
         ],
         expect.any(Object)
       )
@@ -283,7 +283,7 @@ describe('registerPtyHandlers', () => {
         [
           '-NoExit',
           '-Command',
-          '. $PROFILE 2>$null; [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; [Console]::InputEncoding = [System.Text.Encoding]::UTF8'
+          'try { . $PROFILE } catch {}; [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; [Console]::InputEncoding = [System.Text.Encoding]::UTF8'
         ],
         expect.any(Object)
       )
@@ -310,6 +310,19 @@ describe('registerPtyHandlers', () => {
       const spawnCall = spawnMock.mock.calls.at(-1)!
       const env = spawnCall[2].env as Record<string, string>
       expect(env.PYTHONUTF8).toBe('0')
+    })
+
+    it('passes no encoding args for unrecognized shells', () => {
+      process.env.COMSPEC = 'C:\\Program Files\\Git\\bin\\bash.exe'
+
+      registerPtyHandlers(mainWindow as never)
+      handlers.get('pty:spawn')!(null, { cols: 80, rows: 24 })
+
+      expect(spawnMock).toHaveBeenCalledWith(
+        'C:\\Program Files\\Git\\bin\\bash.exe',
+        [],
+        expect.any(Object)
+      )
     })
   })
 

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -248,10 +248,15 @@ export function registerPtyHandlers(
         if (shellBasename === 'cmd.exe') {
           shellArgs = ['/K', 'chcp 65001 > nul']
         } else if (shellBasename === 'powershell.exe' || shellBasename === 'pwsh.exe') {
+          // Why: `-NoExit -Command` alone skips the user's $PROFILE, breaking
+          // custom prompts (oh-my-posh, starship), aliases, and PSReadLine
+          // configuration. Dot-sourcing $PROFILE first restores the normal
+          // startup experience. PowerShell silently ignores a missing $PROFILE,
+          // so this is safe even when no profile file exists.
           shellArgs = [
             '-NoExit',
             '-Command',
-            '[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; [Console]::InputEncoding = [System.Text.Encoding]::UTF8'
+            '. $PROFILE 2>$null; [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; [Console]::InputEncoding = [System.Text.Encoding]::UTF8'
           ]
         } else {
           shellArgs = []

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -3,7 +3,7 @@ main-process module so spawn-time environment scoping, lifecycle cleanup,
 foreground-process inspection, and renderer IPC stay behind a single audited
 boundary. Splitting it by line count would scatter tightly coupled terminal
 process behavior across files without a cleaner ownership seam. */
-import { basename } from 'path'
+import { basename, win32 as pathWin32 } from 'path'
 import { existsSync, accessSync, statSync, chmodSync, constants as fsConstants } from 'fs'
 import { type BrowserWindow, ipcMain } from 'electron'
 import * as pty from 'node-pty'
@@ -235,7 +235,9 @@ export function registerPtyHandlers(
         validationCwd = cwd
       } else if (process.platform === 'win32') {
         shellPath = process.env.COMSPEC || 'powershell.exe'
-        const shellBasename = basename(shellPath).toLowerCase()
+        // Why: use path.win32.basename so backslash-separated Windows paths
+        // are parsed correctly even when tests mock process.platform on Linux CI.
+        const shellBasename = pathWin32.basename(shellPath).toLowerCase()
         // Why: On CJK Windows (Chinese, Japanese, Korean), the console code page
         // defaults to the system ANSI code page (e.g. 936/GBK for Chinese).
         // ConPTY encodes its output pipe using this code page, but node-pty

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -251,12 +251,14 @@ export function registerPtyHandlers(
           // Why: `-NoExit -Command` alone skips the user's $PROFILE, breaking
           // custom prompts (oh-my-posh, starship), aliases, and PSReadLine
           // configuration. Dot-sourcing $PROFILE first restores the normal
-          // startup experience. PowerShell silently ignores a missing $PROFILE,
-          // so this is safe even when no profile file exists.
+          // startup experience. The try/catch ensures a broken profile (e.g.
+          // terminating errors from strict-mode violations or failing module
+          // imports) cannot prevent the encoding commands from executing —
+          // otherwise the CJK fix would silently fail for those users.
           shellArgs = [
             '-NoExit',
             '-Command',
-            '. $PROFILE 2>$null; [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; [Console]::InputEncoding = [System.Text.Encoding]::UTF8'
+            'try { . $PROFILE } catch {}; [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; [Console]::InputEncoding = [System.Text.Encoding]::UTF8'
           ]
         } else {
           shellArgs = []

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -235,7 +235,27 @@ export function registerPtyHandlers(
         validationCwd = cwd
       } else if (process.platform === 'win32') {
         shellPath = process.env.COMSPEC || 'powershell.exe'
-        shellArgs = []
+        const shellBasename = basename(shellPath).toLowerCase()
+        // Why: On CJK Windows (Chinese, Japanese, Korean), the console code page
+        // defaults to the system ANSI code page (e.g. 936/GBK for Chinese).
+        // ConPTY encodes its output pipe using this code page, but node-pty
+        // always decodes as UTF-8. Without switching to code page 65001 (UTF-8),
+        // multi-byte CJK characters are garbled because the GBK/Shift-JIS/EUC-KR
+        // byte sequences are misinterpreted as UTF-8. This is especially visible
+        // with split-screen terminals where multiple ConPTY instances amplify the
+        // issue. Setting the code page at shell startup ensures all subsequent
+        // output — including from child processes — uses UTF-8.
+        if (shellBasename === 'cmd.exe') {
+          shellArgs = ['/K', 'chcp 65001 > nul']
+        } else if (shellBasename === 'powershell.exe' || shellBasename === 'pwsh.exe') {
+          shellArgs = [
+            '-NoExit',
+            '-Command',
+            '[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; [Console]::InputEncoding = [System.Text.Encoding]::UTF8'
+          ]
+        } else {
+          shellArgs = []
+        }
         effectiveCwd = cwd
         validationCwd = cwd
       } else {
@@ -303,6 +323,15 @@ export function registerPtyHandlers(
       // We default LANG to en_US.UTF-8 but let the inherited or caller-provided
       // env override it so user locale preferences are respected.
       spawnEnv.LANG ??= 'en_US.UTF-8'
+
+      // Why: On Windows, LANG alone does not control the console code page.
+      // Programs like Python and Node.js check their own encoding env vars
+      // independently. PYTHONUTF8=1 makes Python use UTF-8 for stdio regardless
+      // of the Windows console code page, preventing garbled CJK output from
+      // Python scripts run inside the terminal.
+      if (process.platform === 'win32') {
+        spawnEnv.PYTHONUTF8 ??= '1'
+      }
 
       let ptyProcess: pty.IPty | undefined
       let primaryError: string | null = null


### PR DESCRIPTION
## Summary
- On CJK Windows (Chinese, Japanese, Korean), the console code page defaults to the system ANSI code page (e.g. 936/GBK for Chinese). ConPTY encodes its output pipe using this code page, but node-pty always decodes as UTF-8, causing garbled multi-byte characters — especially visible with split-screen terminals.
- Fix by setting the code page to UTF-8 (65001) at shell startup: `chcp 65001` for CMD, `[Console]::OutputEncoding = UTF8` for PowerShell/pwsh, and `PYTHONUTF8=1` env var for Python programs.
- Mirrors the existing `LANG=en_US.UTF-8` fix (which only helps macOS/Linux) with the Windows-equivalent approach.

## Test plan
- [ ] Verify on Chinese Windows: open split-screen terminals, run commands that produce Chinese output — characters should render correctly
- [ ] Verify CMD terminals start with code page 65001 (`chcp` should report 65001)
- [ ] Verify PowerShell terminals have UTF-8 encoding (`[Console]::OutputEncoding` should show UTF-8)
- [ ] Verify non-CJK Windows systems are unaffected (code page change is transparent for ASCII/Latin text)
- [ ] Verify Python scripts in terminal output UTF-8 correctly (`python -c "print('你好')"`)
- [ ] Unit tests pass for cmd.exe, powershell.exe, and pwsh.exe code page setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)