### PR TITLE
docs: remove star count badge, use colorful badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,9 @@
 <h1 align="center">Orca</h1>
 
 <p align="center">
-  <a href="https://github.com/stablyai/orca/stargazers"><img src="https://img.shields.io/github/stars/stablyai/orca?style=for-the-badge&color=black" alt="GitHub stars" /></a>
-  <img src="https://img.shields.io/badge/Platform-macOS%20%7C%20Windows%20%7C%20Linux-black?style=for-the-badge" alt="Supported Platforms" />
-  <a href="https://discord.gg/fzjDKHxv8Q"><img src="https://img.shields.io/badge/Discord-Join-black?style=for-the-badge&logo=discord&logoColor=white" alt="Discord" /></a>
-  <a href="https://x.com/orca_build"><img src="https://img.shields.io/twitter/follow/orca_build?style=for-the-badge" alt="Follow on X" /></a>
+  <img src="https://img.shields.io/badge/Platform-macOS%20%7C%20Windows%20%7C%20Linux-blue?style=for-the-badge" alt="Supported Platforms" />
+  <a href="https://discord.gg/fzjDKHxv8Q"><img src="https://img.shields.io/badge/Discord-Join-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Discord" /></a>
+  <a href="https://x.com/orca_build"><img src="https://img.shields.io/twitter/follow/orca_build?style=for-the-badge&color=1DA1F2" alt="Follow on X" /></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary
- Remove GitHub stars badge from README to reduce visual clutter
- Update remaining badges to use brand colors (blue platform, Discord purple, Twitter blue) instead of all-black

## Test plan
- [x] Visual check of badge rendering on GitHub