### PR TITLE
fix: show create-worktree action in jump palette only on empty results

### DIFF
--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -99,9 +99,10 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
     [sortedWorktrees, query, repoMap, prCache, issueCache]
   )
   const createWorktreeName = query.trim()
-  // Why: only surface the create-worktree action after the user has typed a query,
-  // so it doesn't clutter the default (empty-query) list of recent worktrees.
-  const showCreateAction = canCreateWorktree && createWorktreeName.length > 0
+  // Why: only surface the create-worktree action when the query yields no matches,
+  // so it doesn't clutter the list when existing worktrees already satisfy the search.
+  const showCreateAction =
+    canCreateWorktree && createWorktreeName.length > 0 && matches.length === 0
 
   // Build a map of worktreeId -> Worktree for quick lookup
   const worktreeMap = useMemo(() => {


### PR DESCRIPTION
## Summary
- The "Create worktree" item in Cmd+J now only appears when the search query produces no matching worktrees
- Keeps the list uncluttered when existing worktrees already satisfy the search

## Test plan
- [x] TypeScript typecheck passes
- [x] All 1075 tests pass
- [ ] Open Cmd+J, type a query that matches existing worktrees → "Create worktree" should NOT appear
- [ ] Type a query that matches nothing → "Create worktree" should appear with the typed name