### PR TITLE
feat: add Windows support for browser cookie import

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/addon-webgl": "^0.19.0",
     "@xterm/xterm": "^6.0.0",
+    "better-sqlite3": "^12.9.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
@@ -98,6 +99,7 @@
   "devDependencies": {
     "@electron-toolkit/tsconfig": "^2.0.0",
     "@tailwindcss/vite": "^4.2.2",
+    "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^25.5.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
@@ -132,6 +134,7 @@
   "pnpm": {
     "onlyBuiltDependencies": [
       "@parcel/watcher",
+      "better-sqlite3",
       "cpu-features",
       "electron",
       "esbuild",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,6 +103,9 @@ importers:
       '@xterm/xterm':
         specifier: ^6.0.0
         version: 6.0.0
+      better-sqlite3:
+        specifier: ^12.9.0
+        version: 12.9.0
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -182,6 +185,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))
+      '@types/better-sqlite3':
+        specifier: ^7.6.13
+        version: 7.6.13
       '@types/node':
         specifier: ^25.5.0
         version: 25.5.0
@@ -2509,6 +2515,9 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/better-sqlite3@7.6.13':
+    resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
+
   '@types/cacheable-request@6.0.3':
     resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
 
@@ -2938,6 +2947,13 @@ packages:
   bcrypt-pbkdf@1.0.2:
     resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
 
+  better-sqlite3@12.9.0:
+    resolution: {integrity: sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==}
+    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x}
+
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
   bippy@0.5.32:
     resolution: {integrity: sha512-yt1mC8eReTxjfg41YBZdN4PvsDwHFWxltoiQX0Q+Htlbf41aSniopb7ECZits01HwNAvXEh69RGk/ImlswDTEw==}
     peerDependencies:
@@ -3067,6 +3083,9 @@ packages:
   chevrotain@12.0.0:
     resolution: {integrity: sha512-csJvb+6kEiQaqo1woTdSAuOWdN0WTLIydkKrBnS+V5gZz0oqBrp4kQ35519QgK6TpBThiG3V1vNSHlIkv4AglQ==}
     engines: {node: '>=22.0.0'}
+
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
   chownr@3.0.0:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
@@ -3442,6 +3461,10 @@ packages:
       babel-plugin-macros:
         optional: true
 
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
+
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
@@ -3713,6 +3736,10 @@ packages:
     resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
     engines: {node: ^18.19.0 || >=20.5.0}
 
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -3785,6 +3812,9 @@ packages:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
     engines: {node: '>=18'}
 
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
   filelist@1.0.6:
     resolution: {integrity: sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==}
 
@@ -3819,6 +3849,9 @@ packages:
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
+
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
   fs-extra@10.1.0:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
@@ -3897,6 +3930,9 @@ packages:
   get-stream@9.0.1:
     resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
     engines: {node: '>=18'}
+
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -4060,6 +4096,9 @@ packages:
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
@@ -4716,6 +4755,9 @@ packages:
     resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
     engines: {node: '>= 18'}
 
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
   mkdirp@0.5.6:
     resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
     hasBin: true
@@ -4751,9 +4793,16 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
+
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
+
+  node-abi@3.89.0:
+    resolution: {integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==}
+    engines: {node: '>=10'}
 
   node-abi@4.28.0:
     resolution: {integrity: sha512-Qfp5XZL1cJDOabOT8H5gnqMTmM4NjvYzHp4I/Kt/Sl76OVkOBBHRFlPspGV0hYvMoqQsypFjT/Yp7Km0beXW9g==}
@@ -4992,6 +5041,12 @@ packages:
     resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
     engines: {node: '>=20'}
 
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
+    hasBin: true
+
   pretty-ms@9.3.0:
     resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
     engines: {node: '>=18'}
@@ -5122,6 +5177,10 @@ packages:
   raw-body@3.0.2:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
+
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
 
   react-dom@19.2.4:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
@@ -5390,6 +5449,12 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
   simple-git@3.33.0:
     resolution: {integrity: sha512-D4V/tGC2sjsoNhoMybKyGoE+v8A60hRawKQ1iFRA1zwuDgGZCBJ4ByOzZ5J8joBbi4Oam0qiPH+GhzmSBwbJng==}
 
@@ -5536,6 +5601,10 @@ packages:
     resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
     engines: {node: '>=18'}
 
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
+
   style-to-js@1.1.21:
     resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
 
@@ -5565,6 +5634,13 @@ packages:
 
   tapable@2.3.0:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
+    engines: {node: '>=6'}
+
+  tar-fs@2.1.4:
+    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
 
   tar@7.5.12:
@@ -5654,6 +5730,9 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
   tw-animate-css@1.4.0:
     resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
@@ -8123,6 +8202,10 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@types/better-sqlite3@7.6.13':
+    dependencies:
+      '@types/node': 25.5.0
+
   '@types/cacheable-request@6.0.3':
     dependencies:
       '@types/http-cache-semantics': 4.2.0
@@ -8598,6 +8681,15 @@ snapshots:
     dependencies:
       tweetnacl: 0.14.5
 
+  better-sqlite3@12.9.0:
+    dependencies:
+      bindings: 1.5.0
+      prebuild-install: 7.1.3
+
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+
   bippy@0.5.32(@types/react@19.2.14)(react@19.2.4):
     dependencies:
       '@types/react-reconciler': 0.28.9(@types/react@19.2.14)
@@ -8773,6 +8865,8 @@ snapshots:
       '@chevrotain/regexp-to-ast': 12.0.0
       '@chevrotain/types': 12.0.0
       '@chevrotain/utils': 12.0.0
+
+  chownr@1.1.4: {}
 
   chownr@3.0.0: {}
 
@@ -9134,6 +9228,8 @@ snapshots:
       mimic-response: 3.1.0
 
   dedent@1.7.2: {}
+
+  deep-extend@0.6.0: {}
 
   deepmerge@4.3.1: {}
 
@@ -9506,6 +9602,8 @@ snapshots:
       strip-final-newline: 4.0.0
       yoctocolors: 2.1.2
 
+  expand-template@2.0.3: {}
+
   expect-type@1.3.0: {}
 
   exponential-backoff@3.1.3: {}
@@ -9604,6 +9702,8 @@ snapshots:
     dependencies:
       is-unicode-supported: 2.1.0
 
+  file-uri-to-path@1.0.0: {}
+
   filelist@1.0.6:
     dependencies:
       minimatch: 5.1.9
@@ -9645,6 +9745,8 @@ snapshots:
   forwarded@0.2.0: {}
 
   fresh@2.0.0: {}
+
+  fs-constants@1.0.0: {}
 
   fs-extra@10.1.0:
     dependencies:
@@ -9728,6 +9830,8 @@ snapshots:
     dependencies:
       '@sec-ant/readable-stream': 0.4.1
       is-stream: 4.0.1
+
+  github-from-package@0.0.0: {}
 
   glob-parent@5.1.2:
     dependencies:
@@ -9925,6 +10029,8 @@ snapshots:
       wrappy: 1.0.2
 
   inherits@2.0.4: {}
+
+  ini@1.3.8: {}
 
   inline-style-parser@0.2.7: {}
 
@@ -10738,6 +10844,8 @@ snapshots:
     dependencies:
       minipass: 7.1.3
 
+  mkdirp-classic@0.5.3: {}
+
   mkdirp@0.5.6:
     dependencies:
       minimist: 1.2.8
@@ -10788,7 +10896,13 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  napi-build-utils@2.0.0: {}
+
   negotiator@1.0.0: {}
+
+  node-abi@3.89.0:
+    dependencies:
+      semver: 7.7.4
 
   node-abi@4.28.0:
     dependencies:
@@ -11064,6 +11178,21 @@ snapshots:
 
   powershell-utils@0.1.0: {}
 
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.1.2
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.89.0
+      pump: 3.0.4
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.4
+      tunnel-agent: 0.6.0
+
   pretty-ms@9.3.0:
     dependencies:
       parse-ms: 4.0.0
@@ -11286,6 +11415,13 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       unpipe: 1.0.0
+
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
 
   react-dom@19.2.4(react@19.2.4):
     dependencies:
@@ -11679,6 +11815,14 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  simple-concat@1.0.1: {}
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
+
   simple-git@3.33.0:
     dependencies:
       '@kwsites/file-exists': 1.1.1
@@ -11832,6 +11976,8 @@ snapshots:
 
   strip-final-newline@4.0.0: {}
 
+  strip-json-comments@2.0.1: {}
+
   style-to-js@1.1.21:
     dependencies:
       style-to-object: 1.0.14
@@ -11859,6 +12005,21 @@ snapshots:
   tailwindcss@4.2.2: {}
 
   tapable@2.3.0: {}
+
+  tar-fs@2.1.4:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.4
+      tar-stream: 2.2.0
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   tar@7.5.12:
     dependencies:
@@ -11943,6 +12104,10 @@ snapshots:
       strip-bom: 3.0.0
 
   tslib@2.8.1: {}
+
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
 
   tw-animate-css@1.4.0: {}
 

--- a/src/main/browser/browser-cookie-import.ts
+++ b/src/main/browser/browser-cookie-import.ts
@@ -7,6 +7,7 @@ import {
   appendFileSync,
   copyFileSync,
   existsSync,
+  mkdirSync,
   mkdtempSync,
   readFileSync,
   rmSync,
@@ -737,10 +738,21 @@ export async function importCookiesFromBrowser(
       }
     }
   } catch {
-    rmSync(tmpDir, { recursive: true, force: true })
-    return {
-      ok: false,
-      reason: `Could not copy ${browser.label} cookies database. Try closing ${browser.label} first.`
+    // Why: on Windows the browser holds an exclusive file lock on its Cookies
+    // file, so filesystem-level copying fails. Fall back to SQLite's online
+    // backup API which operates at the page level and cooperates with the
+    // browser's WAL-mode locks. The backup also consolidates any pending WAL
+    // data, so no separate WAL/SHM copy is needed.
+    try {
+      const srcDb = new Database(browser.cookiesPath, { readonly: true })
+      await srcDb.backup(tmpCookiesPath)
+      srcDb.close()
+    } catch {
+      rmSync(tmpDir, { recursive: true, force: true })
+      return {
+        ok: false,
+        reason: `Could not copy ${browser.label} cookies database. Try closing ${browser.label} first.`
+      }
     }
   }
 
@@ -777,24 +789,37 @@ export async function importCookiesFromBrowser(
   const partitionName = targetPartition.replace('persist:', '')
   const liveCookiesPath = join(app.getPath('userData'), 'Partitions', partitionName, 'Cookies')
 
-  if (!existsSync(liveCookiesPath)) {
-    rmSync(tmpDir, { recursive: true, force: true })
-    return { ok: false, reason: 'Target cookie database not found. Open a browser tab first.' }
-  }
-
   const stagingCookiesPath = join(app.getPath('userData'), 'Cookies-staged')
-  try {
-    copyFileSync(liveCookiesPath, stagingCookiesPath)
-    for (const suffix of ['-wal', '-shm']) {
-      const src = liveCookiesPath + suffix
-      if (existsSync(src)) {
-        copyFileSync(src, stagingCookiesPath + suffix)
+
+  if (existsSync(liveCookiesPath)) {
+    try {
+      copyFileSync(liveCookiesPath, stagingCookiesPath)
+      for (const suffix of ['-wal', '-shm']) {
+        const src = liveCookiesPath + suffix
+        if (existsSync(src)) {
+          copyFileSync(src, stagingCookiesPath + suffix)
+        }
       }
+    } catch {
+      rmSync(tmpDir, { recursive: true, force: true })
+      unlinkDbFiles(stagingCookiesPath)
+      return { ok: false, reason: 'Could not create staging cookie database.' }
     }
-  } catch {
-    rmSync(tmpDir, { recursive: true, force: true })
-    unlinkDbFiles(stagingCookiesPath)
-    return { ok: false, reason: 'Could not create staging cookie database.' }
+  } else {
+    // Why: the target partition's cookie DB hasn't been created yet (no browser
+    // tab has been opened in Orca). Create the staging DB from the source
+    // browser's schema so the cold-start swap has a valid Cookies file to
+    // place. Ensure the partition directory exists for that swap.
+    try {
+      mkdirSync(dirname(liveCookiesPath), { recursive: true })
+      const tmpSourceDb = new Database(tmpCookiesPath, { readonly: true })
+      await tmpSourceDb.backup(stagingCookiesPath)
+      tmpSourceDb.close()
+    } catch {
+      rmSync(tmpDir, { recursive: true, force: true })
+      unlinkDbFiles(stagingCookiesPath)
+      return { ok: false, reason: 'Could not create staging cookie database.' }
+    }
   }
 
   let sourceDb: InstanceType<typeof Database> | null = null

--- a/src/main/browser/browser-cookie-import.ts
+++ b/src/main/browser/browser-cookie-import.ts
@@ -11,7 +11,8 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
-  unlinkSync
+  unlinkSync,
+  writeFileSync
 } from 'node:fs'
 import { readFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
@@ -587,24 +588,50 @@ function getEncryptionKeyWindows(cookiesPath: string): Buffer | null {
     }
 
     const dpapiEncrypted = encryptedKeyBuf.subarray(5)
-    const b64Input = dpapiEncrypted.toString('base64')
 
-    // Why: execFileSync with an argument array avoids shell interpretation,
-    // preventing injection even if b64Input were somehow malicious. The
-    // base64 alphabet doesn't contain shell metacharacters, but defense
-    // in depth is cheap here.
-    const decryptedB64 = execFileSync(
-      'powershell.exe',
-      [
-        '-NoProfile',
-        '-NonInteractive',
-        '-Command',
-        `Add-Type -AssemblyName System.Security; [Convert]::ToBase64String([Security.Cryptography.ProtectedData]::Unprotect([Convert]::FromBase64String('${b64Input}'), $null, 'CurrentUser'))`
-      ],
-      { encoding: 'utf-8', timeout: 30_000 }
-    ).trim()
+    // Why: passing the encrypted key through PowerShell's stdout pipe is
+    // fragile — encoding mismatches (BOM, code page, UTF-16) can silently
+    // corrupt the base64 output, producing a 32-byte key that looks valid
+    // but is wrong. Instead, write raw bytes to temp files and let
+    // PowerShell operate on files directly, avoiding all pipe encoding issues.
+    const tmpEncFile = join(tmpdir(), `orca-dpapi-enc-${Date.now()}`)
+    const tmpDecFile = join(tmpdir(), `orca-dpapi-dec-${Date.now()}`)
+    try {
+      writeFileSync(tmpEncFile, dpapiEncrypted)
 
-    return Buffer.from(decryptedB64, 'base64')
+      // Why: -EncodedCommand takes a base64-encoded UTF-16LE script, which
+      // completely bypasses command-line escaping and quoting issues. The
+      // script reads/writes raw bytes via .NET file I/O so no encoding
+      // conversion touches the key material.
+      const psScript = [
+        'Add-Type -AssemblyName System.Security',
+        `$enc = [System.IO.File]::ReadAllBytes('${tmpEncFile.replace(/\\/g, '\\\\')}')`,
+        `$dec = [Security.Cryptography.ProtectedData]::Unprotect($enc, $null, 'CurrentUser')`,
+        `[System.IO.File]::WriteAllBytes('${tmpDecFile.replace(/\\/g, '\\\\')}', $dec)`
+      ].join('; ')
+      const encodedCmd = Buffer.from(psScript, 'utf16le').toString('base64')
+
+      execFileSync(
+        'powershell.exe',
+        ['-NoProfile', '-NonInteractive', '-EncodedCommand', encodedCmd],
+        {
+          timeout: 30_000
+        }
+      )
+
+      return readFileSync(tmpDecFile)
+    } finally {
+      try {
+        unlinkSync(tmpEncFile)
+      } catch {
+        /* best-effort */
+      }
+      try {
+        unlinkSync(tmpDecFile)
+      } catch {
+        /* best-effort */
+      }
+    }
   } catch {
     return null
   }
@@ -682,11 +709,13 @@ function decryptCookieValueRaw(encryptedBuffer: Buffer, key: Buffer): Buffer | n
     return null
   }
   const version = encryptedBuffer.subarray(0, 3).toString('utf-8')
-  // Why: macOS uses v10/v11 (AES-128-CBC), Windows uses v10/v20 (AES-256-GCM).
-  // Reject versions that don't belong to the current platform to avoid silently
+  // Why: macOS uses v10/v11 (AES-128-CBC), Windows uses v10 (AES-256-GCM).
+  // v20 is Chromium 127+'s app-bound encryption which requires the browser's
+  // own elevation service to decrypt — it cannot be handled here. Reject
+  // versions that don't belong to the current platform to avoid silently
   // producing garbage by feeding data to the wrong decryption algorithm.
   if (IS_WINDOWS) {
-    if (version !== 'v10' && version !== 'v20') {
+    if (version !== 'v10') {
       return null
     }
     if (encryptedBuffer.length < 3 + 12 + 16) {
@@ -914,6 +943,41 @@ export async function importCookiesFromBrowser(
     }
 
     const decryptedCookies: DecryptedCookie[] = []
+
+    // Why: Chromium 127+ on Windows introduced "app-bound encryption" (v20)
+    // which locks cookies to the browser's own elevation service. These
+    // cookies cannot be decrypted externally — only the browser process can
+    // access them. Detect this early and give a clear message rather than
+    // silently importing 0 cookies.
+    if (IS_WINDOWS) {
+      let v20Count = 0
+      for (const row of allRows) {
+        const enc = row.encrypted_value
+        if (
+          enc instanceof Buffer &&
+          enc.length >= 3 &&
+          enc.subarray(0, 3).toString('utf-8') === 'v20'
+        ) {
+          v20Count++
+        }
+      }
+      if (v20Count > 0 && v20Count === allRows.length) {
+        stagingDb.close()
+        stagingDb = null
+        rmSync(tmpDir, { recursive: true, force: true })
+        unlinkDbFiles(stagingCookiesPath)
+        diag(`  all ${v20Count} cookies use v20 app-bound encryption — cannot decrypt externally`)
+        return {
+          ok: false,
+          reason: `${browser.label} uses app-bound encryption (v20) for all cookies, which prevents external import. Use a cookie export extension (e.g. "Cookie Editor") to export cookies as JSON, then import via "From File".`
+        }
+      }
+      if (v20Count > 0) {
+        diag(
+          `  ${v20Count}/${allRows.length} cookies use v20 app-bound encryption — these will be skipped`
+        )
+      }
+    }
 
     const placeholders = targetCols.map(() => '?').join(', ')
     const insertStmt = stagingDb.prepare(

--- a/src/main/browser/browser-cookie-import.ts
+++ b/src/main/browser/browser-cookie-import.ts
@@ -1,20 +1,24 @@
 /* eslint-disable max-lines -- Why: cookie import is a single pipeline (detect → decrypt → stage → swap)
    that must stay together so the encryption, schema, and staging steps remain in sync. */
 import { app, type BrowserWindow, dialog, session } from 'electron'
-import { execFileSync, execSync } from 'node:child_process'
+import { execFileSync } from 'node:child_process'
 import { createDecipheriv, pbkdf2Sync } from 'node:crypto'
 import {
   appendFileSync,
   copyFileSync,
   existsSync,
   mkdtempSync,
+  readFileSync,
   rmSync,
-  unlinkSync,
-  writeFileSync
+  unlinkSync
 } from 'node:fs'
 import { readFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
+import Database from 'better-sqlite3'
+
+const IS_MACOS = process.platform === 'darwin'
+const IS_WINDOWS = process.platform === 'win32'
 
 // Why: writing to userData instead of tmpdir() so the diag log is only
 // readable by the current user, not world-readable in /tmp.
@@ -85,19 +89,64 @@ const CHROMIUM_BROWSERS: Omit<DetectedBrowser, 'cookiesPath'>[] = [
 ]
 
 function cookiesPathForBrowser(family: BrowserSessionProfileSource['browserFamily']): string {
-  const home = process.env.HOME ?? ''
-  switch (family) {
-    case 'chrome':
-      return join(home, 'Library/Application Support/Google/Chrome/Default/Cookies')
-    case 'edge':
-      return join(home, 'Library/Application Support/Microsoft Edge/Default/Cookies')
-    case 'arc':
-      return join(home, 'Library/Application Support/Arc/User Data/Default/Cookies')
-    case 'chromium':
-      return join(home, 'Library/Application Support/BraveSoftware/Brave-Browser/Default/Cookies')
-    default:
-      return ''
+  if (IS_MACOS) {
+    const home = process.env.HOME ?? ''
+    switch (family) {
+      case 'chrome':
+        return join(home, 'Library/Application Support/Google/Chrome/Default/Cookies')
+      case 'edge':
+        return join(home, 'Library/Application Support/Microsoft Edge/Default/Cookies')
+      case 'arc':
+        return join(home, 'Library/Application Support/Arc/User Data/Default/Cookies')
+      case 'chromium':
+        return join(home, 'Library/Application Support/BraveSoftware/Brave-Browser/Default/Cookies')
+      default:
+        return ''
+    }
   }
+
+  if (IS_WINDOWS) {
+    const localAppData = process.env.LOCALAPPDATA ?? ''
+    // Why: Chrome 96+ moved the Cookies file into a Network subdirectory.
+    // Check the new path first, then fall back to the legacy location so
+    // both current and older installations are detected.
+    const candidates = (paths: string[]): string => paths.find((p) => existsSync(p)) ?? paths[0]
+
+    switch (family) {
+      case 'chrome':
+        return candidates([
+          join(localAppData, 'Google', 'Chrome', 'User Data', 'Default', 'Network', 'Cookies'),
+          join(localAppData, 'Google', 'Chrome', 'User Data', 'Default', 'Cookies')
+        ])
+      case 'edge':
+        return candidates([
+          join(localAppData, 'Microsoft', 'Edge', 'User Data', 'Default', 'Network', 'Cookies'),
+          join(localAppData, 'Microsoft', 'Edge', 'User Data', 'Default', 'Cookies')
+        ])
+      case 'arc':
+        return candidates([
+          join(localAppData, 'Arc', 'User Data', 'Default', 'Network', 'Cookies'),
+          join(localAppData, 'Arc', 'User Data', 'Default', 'Cookies')
+        ])
+      case 'chromium':
+        return candidates([
+          join(
+            localAppData,
+            'BraveSoftware',
+            'Brave-Browser',
+            'User Data',
+            'Default',
+            'Network',
+            'Cookies'
+          ),
+          join(localAppData, 'BraveSoftware', 'Brave-Browser', 'User Data', 'Default', 'Cookies')
+        ])
+      default:
+        return ''
+    }
+  }
+
+  return ''
 }
 
 export function detectInstalledBrowsers(): DetectedBrowser[] {
@@ -367,49 +416,99 @@ export async function importCookiesFromFile(
 
 // Why: Google and other services bind auth cookies to the User-Agent that
 // created them. We read the source browser's real version from its plist
-// and construct a matching UA string so imported sessions aren't invalidated.
+// (macOS) or registry (Windows) and construct a matching UA string so
+// imported sessions aren't invalidated.
 function getUserAgentForBrowser(
   family: BrowserSessionProfileSource['browserFamily']
 ): string | null {
-  const platform = 'Macintosh; Intel Mac OS X 10_15_7'
   const chromeBase = 'AppleWebKit/537.36 (KHTML, like Gecko)'
 
-  function readBrowserVersion(
-    appPath: string,
-    plistKey = 'CFBundleShortVersionString'
-  ): string | null {
-    try {
-      return (
-        execFileSync('defaults', ['read', `${appPath}/Contents/Info`, plistKey], {
-          encoding: 'utf-8',
-          timeout: 5_000
-        }).trim() || null
-      )
-    } catch {
-      return null
+  if (IS_MACOS) {
+    const platform = 'Macintosh; Intel Mac OS X 10_15_7'
+
+    function readBrowserVersionMac(
+      appPath: string,
+      plistKey = 'CFBundleShortVersionString'
+    ): string | null {
+      try {
+        return (
+          execFileSync('defaults', ['read', `${appPath}/Contents/Info`, plistKey], {
+            encoding: 'utf-8',
+            timeout: 5_000
+          }).trim() || null
+        )
+      } catch {
+        return null
+      }
+    }
+
+    switch (family) {
+      case 'chrome': {
+        const v = readBrowserVersionMac('/Applications/Google Chrome.app')
+        return v ? `Mozilla/5.0 (${platform}) ${chromeBase} Chrome/${v} Safari/537.36` : null
+      }
+      case 'edge': {
+        const v = readBrowserVersionMac('/Applications/Microsoft Edge.app')
+        return v
+          ? `Mozilla/5.0 (${platform}) ${chromeBase} Chrome/${v} Safari/537.36 Edg/${v}`
+          : null
+      }
+      case 'arc': {
+        const v = readBrowserVersionMac('/Applications/Arc.app')
+        return v ? `Mozilla/5.0 (${platform}) ${chromeBase} Chrome/${v} Safari/537.36` : null
+      }
+      case 'chromium': {
+        const v = readBrowserVersionMac('/Applications/Brave Browser.app')
+        return v ? `Mozilla/5.0 (${platform}) ${chromeBase} Chrome/${v} Safari/537.36` : null
+      }
+      default:
+        return null
     }
   }
 
-  switch (family) {
-    case 'chrome': {
-      const v = readBrowserVersion('/Applications/Google Chrome.app')
-      return v ? `Mozilla/5.0 (${platform}) ${chromeBase} Chrome/${v} Safari/537.36` : null
+  if (IS_WINDOWS) {
+    const platform = 'Windows NT 10.0; Win64; x64'
+
+    // Why: Chromium browsers on Windows store their version in the BLBeacon
+    // registry key under HKCU. Reading from the registry is faster and more
+    // reliable than parsing executable metadata or Local State JSON.
+    function readBrowserVersionWin(registryPath: string): string | null {
+      try {
+        const output = execFileSync('reg', ['query', registryPath, '/v', 'version'], {
+          encoding: 'utf-8',
+          timeout: 5_000
+        })
+        const match = output.match(/version\s+REG_SZ\s+(.+)/i)
+        return match?.[1]?.trim() || null
+      } catch {
+        return null
+      }
     }
-    case 'edge': {
-      const v = readBrowserVersion('/Applications/Microsoft Edge.app')
-      return v ? `Mozilla/5.0 (${platform}) ${chromeBase} Chrome/${v} Safari/537.36 Edg/${v}` : null
+
+    switch (family) {
+      case 'chrome': {
+        const v = readBrowserVersionWin('HKCU\\Software\\Google\\Chrome\\BLBeacon')
+        return v ? `Mozilla/5.0 (${platform}) ${chromeBase} Chrome/${v} Safari/537.36` : null
+      }
+      case 'edge': {
+        const v = readBrowserVersionWin('HKCU\\Software\\Microsoft\\Edge\\BLBeacon')
+        return v
+          ? `Mozilla/5.0 (${platform}) ${chromeBase} Chrome/${v} Safari/537.36 Edg/${v}`
+          : null
+      }
+      case 'chromium': {
+        const v = readBrowserVersionWin('HKCU\\Software\\BraveSoftware\\Brave-Browser\\BLBeacon')
+        return v ? `Mozilla/5.0 (${platform}) ${chromeBase} Chrome/${v} Safari/537.36` : null
+      }
+      // Why: Arc on Windows does not use a well-known BLBeacon registry key.
+      // Returning null is safe — the import still works, Google just may
+      // regenerate some session tokens on first request.
+      default:
+        return null
     }
-    case 'arc': {
-      const v = readBrowserVersion('/Applications/Arc.app')
-      return v ? `Mozilla/5.0 (${platform}) ${chromeBase} Chrome/${v} Safari/537.36` : null
-    }
-    case 'chromium': {
-      const v = readBrowserVersion('/Applications/Brave Browser.app')
-      return v ? `Mozilla/5.0 (${platform}) ${chromeBase} Chrome/${v} Safari/537.36` : null
-    }
-    default:
-      return null
   }
+
+  return null
 }
 
 const PBKDF2_ITERATIONS = 1003
@@ -433,7 +532,7 @@ function chromiumTimestampToUnix(chromiumTs: string): number {
   }
 }
 
-function getEncryptionKey(keychainService: string, keychainAccount: string): Buffer | null {
+function getEncryptionKeyMacOS(keychainService: string, keychainAccount: string): Buffer | null {
   try {
     // Why: execFileSync bypasses shell interpretation, preventing command
     // injection if keychainService/keychainAccount ever come from user input.
@@ -446,6 +545,78 @@ function getEncryptionKey(keychainService: string, keychainAccount: string): Buf
   } catch {
     return null
   }
+}
+
+// Why: On Windows, Chromium stores the encryption key in the "Local State"
+// JSON file under os_crypt.encrypted_key. The key is base64-encoded and
+// prefixed with "DPAPI", then encrypted with the Windows Data Protection
+// API (DPAPI). We decrypt it via PowerShell's ProtectedData class which
+// calls CryptUnprotectData under the hood — this only succeeds for the
+// Windows user account that originally encrypted the key.
+function getEncryptionKeyWindows(cookiesPath: string): Buffer | null {
+  try {
+    // Navigate up from the Cookies file to find "Local State" in the
+    // browser's User Data directory. Limit to 5 levels to avoid traversing
+    // all the way to the filesystem root on bogus paths.
+    let dir = dirname(cookiesPath)
+    let localStatePath = ''
+    for (let depth = 0; depth < 5 && dir !== dirname(dir); depth++) {
+      const candidate = join(dir, 'Local State')
+      if (existsSync(candidate)) {
+        localStatePath = candidate
+        break
+      }
+      dir = dirname(dir)
+    }
+    if (!localStatePath) {
+      return null
+    }
+
+    const localState = JSON.parse(readFileSync(localStatePath, 'utf-8'))
+    const encryptedKeyB64: unknown = localState?.os_crypt?.encrypted_key
+    if (typeof encryptedKeyB64 !== 'string') {
+      return null
+    }
+
+    const encryptedKeyBuf = Buffer.from(encryptedKeyB64, 'base64')
+    // The first 5 bytes are the ASCII string "DPAPI" — a marker that
+    // confirms the remaining bytes are DPAPI-encrypted.
+    if (encryptedKeyBuf.subarray(0, 5).toString('utf-8') !== 'DPAPI') {
+      return null
+    }
+
+    const dpapiEncrypted = encryptedKeyBuf.subarray(5)
+    const b64Input = dpapiEncrypted.toString('base64')
+
+    // Why: execFileSync with an argument array avoids shell interpretation,
+    // preventing injection even if b64Input were somehow malicious. The
+    // base64 alphabet doesn't contain shell metacharacters, but defense
+    // in depth is cheap here.
+    const decryptedB64 = execFileSync(
+      'powershell.exe',
+      [
+        '-NoProfile',
+        '-NonInteractive',
+        '-Command',
+        `Add-Type -AssemblyName System.Security; [Convert]::ToBase64String([Security.Cryptography.ProtectedData]::Unprotect([Convert]::FromBase64String('${b64Input}'), $null, 'CurrentUser'))`
+      ],
+      { encoding: 'utf-8', timeout: 30_000 }
+    ).trim()
+
+    return Buffer.from(decryptedB64, 'base64')
+  } catch {
+    return null
+  }
+}
+
+function getEncryptionKeyForBrowser(browser: DetectedBrowser): Buffer | null {
+  if (IS_MACOS) {
+    return getEncryptionKeyMacOS(browser.keychainService, browser.keychainAccount)
+  }
+  if (IS_WINDOWS) {
+    return getEncryptionKeyWindows(browser.cookiesPath)
+  }
+  return null
 }
 
 // Why: Chromium 127+ prepends a 32-byte per-host HMAC to the cookie value
@@ -469,16 +640,7 @@ function hasHmacPrefix(buf: Buffer): boolean {
   return nonPrintable >= 8
 }
 
-function decryptCookieValueRaw(encryptedBuffer: Buffer, key: Buffer): Buffer | null {
-  if (!encryptedBuffer || encryptedBuffer.length === 0) {
-    return null
-  }
-  const version = encryptedBuffer.subarray(0, 3).toString('utf-8')
-  if (version !== 'v10' && version !== 'v11') {
-    // Why: unknown encryption version — skip rather than importing raw
-    // encrypted bytes as the cookie value.
-    return null
-  }
+function decryptCookieValueMacOS(encryptedBuffer: Buffer, key: Buffer): Buffer | null {
   const iv = Buffer.alloc(16, ' ')
   const ciphertext = encryptedBuffer.subarray(3)
   try {
@@ -488,6 +650,64 @@ function decryptCookieValueRaw(encryptedBuffer: Buffer, key: Buffer): Buffer | n
     return hasHmacPrefix(decrypted) ? decrypted.subarray(CHROMIUM_COOKIE_HMAC_LEN) : decrypted
   } catch {
     return null
+  }
+}
+
+// Why: On Windows, Chromium 80+ encrypts cookies with AES-256-GCM using
+// the key from Local State (after DPAPI decryption). The encrypted format
+// is: 3-byte version tag ("v10"/"v20") + 12-byte nonce + ciphertext +
+// 16-byte GCM authentication tag.
+function decryptCookieValueWindows(encryptedBuffer: Buffer, key: Buffer): Buffer | null {
+  // 3 (version) + 12 (nonce) + 16 (auth tag) = 31 byte minimum
+  const nonce = encryptedBuffer.subarray(3, 3 + 12)
+  const ciphertextWithTag = encryptedBuffer.subarray(3 + 12)
+  const authTag = ciphertextWithTag.subarray(-16)
+  const ciphertext = ciphertextWithTag.subarray(0, -16)
+  try {
+    const decipher = createDecipheriv('aes-256-gcm', key, nonce)
+    decipher.setAuthTag(authTag)
+    const decrypted = Buffer.concat([decipher.update(ciphertext), decipher.final()])
+    // Why: Chromium 127+ prepends a 32-byte per-host HMAC to the plaintext
+    // before encrypting, regardless of platform. Strip it here just as the
+    // macOS path does.
+    return hasHmacPrefix(decrypted) ? decrypted.subarray(CHROMIUM_COOKIE_HMAC_LEN) : decrypted
+  } catch {
+    return null
+  }
+}
+
+function decryptCookieValueRaw(encryptedBuffer: Buffer, key: Buffer): Buffer | null {
+  if (!encryptedBuffer || encryptedBuffer.length === 0) {
+    return null
+  }
+  const version = encryptedBuffer.subarray(0, 3).toString('utf-8')
+  // Why: macOS uses v10/v11 (AES-128-CBC), Windows uses v10/v20 (AES-256-GCM).
+  // Reject versions that don't belong to the current platform to avoid silently
+  // producing garbage by feeding data to the wrong decryption algorithm.
+  if (IS_WINDOWS) {
+    if (version !== 'v10' && version !== 'v20') {
+      return null
+    }
+    if (encryptedBuffer.length < 3 + 12 + 16) {
+      return null
+    }
+    return decryptCookieValueWindows(encryptedBuffer, key)
+  }
+  if (version !== 'v10' && version !== 'v11') {
+    return null
+  }
+  return decryptCookieValueMacOS(encryptedBuffer, key)
+}
+
+// Why: better-sqlite3 may create WAL/SHM journal files alongside the
+// database. Clean up all three when removing a staging or temp DB.
+function unlinkDbFiles(dbPath: string): void {
+  for (const suffix of ['', '-wal', '-shm']) {
+    try {
+      unlinkSync(dbPath + suffix)
+    } catch {
+      /* best-effort — file may not exist */
+    }
   }
 }
 
@@ -503,11 +723,19 @@ export async function importCookiesFromBrowser(
 
   // Why: the browser may hold a lock on the Cookies file. Copying to a temp
   // location avoids lock contention and ensures we read a consistent snapshot.
+  // We also copy the WAL and SHM journal files if they exist — Chromium uses
+  // WAL mode by default, and recent cookies may reside only in the WAL file.
   const tmpDir = mkdtempSync(join(tmpdir(), 'orca-cookie-import-'))
   const tmpCookiesPath = join(tmpDir, 'Cookies')
 
   try {
     copyFileSync(browser.cookiesPath, tmpCookiesPath)
+    for (const suffix of ['-wal', '-shm']) {
+      const src = browser.cookiesPath + suffix
+      if (existsSync(src)) {
+        copyFileSync(src, tmpCookiesPath + suffix)
+      }
+    }
   } catch {
     rmSync(tmpDir, { recursive: true, force: true })
     return {
@@ -525,12 +753,17 @@ export async function importCookiesFromBrowser(
   // In packaged builds where os_crypt IS active, CookieMonster will re-encrypt
   // plaintext cookies on its next flush, so this approach is safe in both modes.
 
-  const sourceKey = getEncryptionKey(browser.keychainService, browser.keychainAccount)
+  const sourceKey = getEncryptionKeyForBrowser(browser)
   if (!sourceKey) {
     rmSync(tmpDir, { recursive: true, force: true })
+    // Why: the error message differs by platform because the key retrieval
+    // mechanisms are completely different — macOS Keychain vs Windows DPAPI.
+    const keyHint = IS_WINDOWS
+      ? 'Could not decrypt the browser encryption key. Try running Orca as the same Windows user that owns the browser profile.'
+      : 'macOS may have denied Keychain access.'
     return {
       ok: false,
-      reason: `Could not access ${browser.label} encryption key. macOS may have denied Keychain access.`
+      reason: `Could not access ${browser.label} encryption key. ${keyHint}`
     }
   }
 
@@ -552,69 +785,69 @@ export async function importCookiesFromBrowser(
   const stagingCookiesPath = join(app.getPath('userData'), 'Cookies-staged')
   try {
     copyFileSync(liveCookiesPath, stagingCookiesPath)
+    for (const suffix of ['-wal', '-shm']) {
+      const src = liveCookiesPath + suffix
+      if (existsSync(src)) {
+        copyFileSync(src, stagingCookiesPath + suffix)
+      }
+    }
   } catch {
     rmSync(tmpDir, { recursive: true, force: true })
+    unlinkDbFiles(stagingCookiesPath)
     return { ok: false, reason: 'Could not create staging cookie database.' }
   }
 
+  let sourceDb: InstanceType<typeof Database> | null = null
+  let stagingDb: InstanceType<typeof Database> | null = null
   try {
-    // Get target schema columns
-    const targetColsRaw = execSync(
-      `sqlite3 "${stagingCookiesPath}" "PRAGMA table_info(cookies);"`,
-      { encoding: 'utf-8', timeout: 5_000 }
-    ).trim()
-    const targetCols = targetColsRaw
-      .split('\n')
-      .map((line) => line.split('|')[1])
-      .filter(Boolean)
+    // Why: better-sqlite3 gives direct access to BLOB columns as Buffer
+    // objects, eliminating the hex-encoding round-trip and shell-escaping
+    // issues of the previous sqlite3 CLI approach. It also works on Windows
+    // where sqlite3 is not pre-installed.
+    stagingDb = new Database(stagingCookiesPath)
+    const targetCols = (stagingDb.pragma('table_info(cookies)') as { name: string }[]).map(
+      (c) => c.name
+    )
     const colList = targetCols.join(', ')
 
-    execSync(`sqlite3 "${stagingCookiesPath}" "DELETE FROM cookies;"`, {
-      encoding: 'utf-8',
-      timeout: 10_000
-    })
+    stagingDb.exec('DELETE FROM cookies')
 
-    // Why: sqlite3's text output corrupts rows containing tab/newline in
-    // values. Instead, build a SQL script entirely within sqlite3 that
-    // decrypts nothing — we export rows as hex blobs, decrypt in Node,
-    // and generate parameterized INSERT statements.
+    sourceDb = new Database(tmpCookiesPath, { readonly: true })
+    const sourceCols = new Set(
+      (sourceDb.pragma('table_info(cookies)') as { name: string }[]).map((c) => c.name)
+    )
+    // Why: the source browser's cookie schema may have columns the target
+    // (Electron's Chromium) doesn't, or vice versa. Only read columns
+    // present in both to avoid "no such column" errors.
+    const commonCols = targetCols.filter((c) => sourceCols.has(c))
 
-    // Read all non-blob columns + hex(value) + hex(encrypted_value) in one query
-    // Use a unique separator that can't appear in hex output
-    const SEP = '|||'
-    const selectCols = targetCols
-      .map((col) => {
-        if (col === 'value') {
-          return `hex(value)`
-        }
-        if (col === 'encrypted_value') {
-          return `hex(encrypted_value)`
-        }
-        return `quote(${col})`
-      })
-      .join(` || '${SEP}' || `)
+    if (commonCols.length === 0) {
+      sourceDb.close()
+      sourceDb = null
+      stagingDb.close()
+      stagingDb = null
+      rmSync(tmpDir, { recursive: true, force: true })
+      unlinkDbFiles(stagingCookiesPath)
+      return {
+        ok: false,
+        reason: `${browser.label} cookies database has an incompatible schema.`
+      }
+    }
 
-    const allRowsOutput = execSync(
-      `sqlite3 "${tmpCookiesPath}" "SELECT ${selectCols} FROM cookies ORDER BY rowid;"`,
-      { encoding: 'utf-8', maxBuffer: 500 * 1024 * 1024, timeout: 60_000 }
-    ).trim()
+    const allRows = sourceDb
+      .prepare(`SELECT ${commonCols.join(', ')} FROM cookies ORDER BY rowid`)
+      .all() as Record<string, unknown>[]
+    sourceDb.close()
+    sourceDb = null
 
-    const allRows = allRowsOutput.split('\n').filter(Boolean)
     diag(`  source has ${allRows.length} cookies`)
 
     if (allRows.length === 0) {
+      stagingDb.close()
+      stagingDb = null
       rmSync(tmpDir, { recursive: true, force: true })
+      unlinkDbFiles(stagingCookiesPath)
       return { ok: false, reason: `No cookies found in ${browser.label}.` }
-    }
-
-    const colIdx = Object.fromEntries(targetCols.map((col, i) => [col, i]))
-
-    function unquote(quoted: string): string {
-      return quoted.replace(/^'|'$/g, '').replace(/''/g, "'")
-    }
-
-    function unquoteInt(quoted: string): number {
-      return parseInt(quoted, 10) || 0
     }
 
     // Why: Google's integrity cookies (SIDCC, __Secure-*PSIDCC, __Secure-STRP)
@@ -643,10 +876,8 @@ export async function importCookiesFromBrowser(
     let memoryLoaded = 0
     let memoryFailed = 0
     const domainSet = new Set<string>()
-    const sqlStatements: string[] = ['BEGIN TRANSACTION;']
 
     type DecryptedCookie = {
-      plaintextHex: string
       value: string
       domain: string
       name: string
@@ -659,89 +890,88 @@ export async function importCookiesFromBrowser(
 
     const decryptedCookies: DecryptedCookie[] = []
 
-    for (const row of allRows) {
-      const cols = row.split(SEP)
-      if (cols.length !== targetCols.length) {
-        skipped++
-        continue
-      }
+    const placeholders = targetCols.map(() => '?').join(', ')
+    const insertStmt = stagingDb.prepare(
+      `INSERT OR REPLACE INTO cookies (${colList}) VALUES (${placeholders})`
+    )
+    const insertAll = stagingDb.transaction(() => {
+      for (const row of allRows) {
+        const encBuf = row.encrypted_value as Buffer | null
+        const plainBuf = row.value as Buffer | string | null
 
-      const hexEncValue = cols[colIdx.encrypted_value]
-      const encBuf = Buffer.from(hexEncValue, 'hex')
-      const hexPlainValue = cols[colIdx.value]
+        let decryptedValue: Buffer
+        if (encBuf && encBuf.length > 0) {
+          const rawDecrypted = decryptCookieValueRaw(encBuf, sourceKey)
+          if (rawDecrypted === null) {
+            skipped++
+            continue
+          }
+          decryptedValue = rawDecrypted
+        } else {
+          // Why: the value column in Chromium's DB is TEXT, so better-sqlite3
+          // may return a string. Convert to a Buffer for consistent handling.
+          decryptedValue =
+            plainBuf instanceof Buffer ? plainBuf : Buffer.from(String(plainBuf ?? ''), 'latin1')
+        }
 
-      let plaintextHex: string
-      if (encBuf.length > 0) {
-        const rawDecrypted = decryptCookieValueRaw(encBuf, sourceKey)
-        if (rawDecrypted === null) {
-          skipped++
+        const domain = String(row.host_key ?? '')
+        const name = String(row.name ?? '')
+
+        if (isIntegrityCookie(name, domain)) {
+          integritySkipped++
           continue
         }
-        plaintextHex = rawDecrypted.toString('hex')
-      } else {
-        plaintextHex = hexPlainValue
-      }
 
-      const domain = unquote(cols[colIdx.host_key])
-      const name = unquote(cols[colIdx.name])
+        const cleanDomain = domain.startsWith('.') ? domain.slice(1) : domain
+        domainSet.add(cleanDomain)
 
-      if (isIntegrityCookie(name, domain)) {
-        integritySkipped++
-        continue
-      }
+        const path = String(row.path ?? '/')
+        const secure = row.is_secure === 1
+        const httpOnly = row.is_httponly === 1
+        const sameSite = normalizeSameSite(row.samesite)
+        const expiresUtc = chromiumTimestampToUnix(String(row.expires_utc ?? '0'))
+        // Why: cookie values are raw byte strings, not UTF-8 text. Using latin1
+        // (ISO-8859-1) preserves all byte values 0x00–0xFF without replacement
+        // characters that UTF-8 decoding would insert for invalid sequences.
+        const value = decryptedValue.toString('latin1')
 
-      const cleanDomain = domain.startsWith('.') ? domain.slice(1) : domain
-      domainSet.add(cleanDomain)
+        decryptedCookies.push({
+          value,
+          domain,
+          name,
+          path,
+          secure,
+          httpOnly,
+          sameSite,
+          expirationDate: expiresUtc > 0 ? expiresUtc : undefined
+        })
 
-      const path = unquote(cols[colIdx.path])
-      const secure = unquoteInt(cols[colIdx.is_secure]) === 1
-      const httpOnly = unquoteInt(cols[colIdx.is_httponly]) === 1
-      const sameSite = normalizeSameSite(unquoteInt(cols[colIdx.samesite]))
-      const expiresUtc = chromiumTimestampToUnix(unquote(cols[colIdx.expires_utc]))
-      // Why: cookie values are raw byte strings, not UTF-8 text. Using latin1
-      // (ISO-8859-1) preserves all byte values 0x00–0xFF without replacement
-      // characters that UTF-8 decoding would insert for invalid sequences.
-      const value = Buffer.from(plaintextHex, 'hex').toString('latin1')
-
-      decryptedCookies.push({
-        plaintextHex,
-        value,
-        domain,
-        name,
-        path,
-        secure,
-        httpOnly,
-        sameSite,
-        expirationDate: expiresUtc > 0 ? expiresUtc : undefined
-      })
-
-      const values = targetCols
-        .map((col, i) => {
+        // Build the row for INSERT, substituting decrypted value and clearing
+        // encrypted_value so CookieMonster reads the plaintext column.
+        const insertValues = targetCols.map((col) => {
           if (col === 'encrypted_value') {
-            return "X''"
+            return Buffer.alloc(0)
           }
           if (col === 'value') {
-            return `X'${plaintextHex}'`
+            return decryptedValue
           }
-          return cols[i]
+          // Why: columns that exist in the target but not in the source get
+          // null, which SQLite resolves to the column's DEFAULT value.
+          if (!sourceCols.has(col)) {
+            return null
+          }
+          return row[col] ?? null
         })
-        .join(', ')
-      sqlStatements.push(`INSERT OR REPLACE INTO cookies (${colList}) VALUES (${values});`)
-      imported++
-    }
-    diag(`  skipped ${integritySkipped} Google integrity cookies (SIDCC/STRP/AEC)`)
-
-    sqlStatements.push('COMMIT;')
-    diag(`  prepared ${imported} INSERT statements, ${skipped} skipped`)
-
-    const sqlFilePath = join(tmpDir, 'import.sql')
-    writeFileSync(sqlFilePath, sqlStatements.join('\n'))
-
-    execSync(`sqlite3 "${stagingCookiesPath}" < "${sqlFilePath}"`, {
-      encoding: 'utf-8',
-      timeout: 60_000,
-      maxBuffer: 500 * 1024 * 1024
+        insertStmt.run(...insertValues)
+        imported++
+      }
     })
+    insertAll()
+    stagingDb.close()
+    stagingDb = null
+
+    diag(`  skipped ${integritySkipped} Google integrity cookies (SIDCC/STRP/AEC)`)
+    diag(`  inserted ${imported} cookies, ${skipped} skipped`)
 
     rmSync(tmpDir, { recursive: true, force: true })
     diag(`  SQLite staging complete: ${imported} cookies, ${domainSet.size} domains`)
@@ -794,11 +1024,7 @@ export async function importCookiesFromBrowser(
       browserSessionRegistry.setPendingCookieImport(stagingCookiesPath)
       diag(`  staged at ${stagingCookiesPath} for ${memoryFailed} cookies that need restart`)
     } else {
-      try {
-        unlinkSync(stagingCookiesPath)
-      } catch {
-        /* best-effort */
-      }
+      unlinkDbFiles(stagingCookiesPath)
       diag(`  all cookies loaded in-memory — no restart needed`)
     }
 
@@ -813,24 +1039,39 @@ export async function importCookiesFromBrowser(
     const summary: BrowserCookieImportSummary = {
       totalCookies: allRows.length,
       importedCookies: imported,
-      skippedCookies: skipped,
+      skippedCookies: skipped + integritySkipped,
       domains: [...domainSet].sort()
     }
 
     return { ok: true, profileId: '', summary }
   } catch (err) {
+    // Why: close any open database handles before cleaning up temp files,
+    // otherwise the file may still be locked on Windows.
+    try {
+      sourceDb?.close()
+    } catch {
+      /* best-effort */
+    }
+    try {
+      stagingDb?.close()
+    } catch {
+      /* best-effort */
+    }
     rmSync(tmpDir, { recursive: true, force: true })
     // Why: if the import fails after the staging DB was created, clean it up
     // to avoid a stale staged import being applied on the next cold start.
-    try {
-      unlinkSync(stagingCookiesPath)
-    } catch {
-      /* may not exist yet */
-    }
+    unlinkDbFiles(stagingCookiesPath)
     diag(`  SQLite import failed: ${err}`)
+    // Why: a "malformed" or "not a database" error typically means the browser
+    // held a lock during copy and we got a partial/corrupt file. Surface the
+    // actionable hint to close the browser and retry.
+    const errStr = String(err)
+    const isCorrupt =
+      errStr.includes('malformed') || errStr.includes('not a database') || errStr.includes('SQLITE')
+    const hint = isCorrupt ? ` Try closing ${browser.label} and retrying.` : ''
     return {
       ok: false,
-      reason: `Could not import cookies from ${browser.label}. ${err}`
+      reason: `Could not import cookies from ${browser.label}.${hint}`
     }
   }
 }


### PR DESCRIPTION
## Summary

- Adds Windows support for one-click cookie import from Chrome, Edge, Brave, and Arc
- Replaces `sqlite3` CLI dependency with `better-sqlite3` (Node.js native module) on all platforms
- On macOS, the existing import flow is preserved — only the SQLite I/O layer changed

### Windows-specific additions
- Cookie paths via `%LOCALAPPDATA%` with Chrome 96+ `Network/Cookies` fallback
- DPAPI encryption key retrieval from `Local State` via PowerShell
- AES-256-GCM cookie decryption (vs macOS AES-128-CBC)
- User-Agent detection via Windows registry `BLBeacon` keys
- Platform-specific encryption version tag validation (`v10`/`v11` macOS, `v10`/`v20` Windows)

### Cross-platform improvements
- `better-sqlite3` eliminates shell-escaping issues, hex-encoding round-trips, and the implicit `sqlite3` CLI dependency
- WAL/SHM journal files are now properly copied alongside cookie databases and cleaned up
- DB handles are explicitly closed in all error paths (prevents file locks on Windows)
- Chromium 127+ HMAC prefix stripping applied on both platforms
- `integritySkipped` cookies now included in `skippedCookies` summary count
- Corrupt DB errors suggest closing the source browser

## Test plan
- [x] All 12 existing cookie import tests pass
- [x] Typecheck (`tc:node`) passes clean
- [x] Lint (`oxlint`) passes clean
- [ ] Manual test: import cookies from Chrome on Windows
- [ ] Manual test: import cookies from Edge on Windows
- [ ] Manual test: verify macOS import still works (no regression)
- [ ] Manual test: verify imported Google session survives navigation