### PR TITLE
fix: guard WorktreeList getItemKey against stale virtualizer cache

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -323,6 +323,14 @@ const WorktreeList = React.memo(function WorktreeList() {
     gap: 6,
     getItemKey: (index) => {
       const row = rows[index]
+      // Why: when rows shrink (group collapse, worktree removal) the
+      // virtualizer's elementsCache can still hold stale entries whose
+      // data-index exceeds the new rows length. measureElement calls
+      // getItemKey for those stale indices, so we need a fallback to
+      // avoid "Cannot read properties of undefined (reading 'type')".
+      if (!row) {
+        return `__stale_${index}`
+      }
       return row.type === 'header' ? `hdr:${row.key}` : `wt:${row.worktree.id}`
     }
   })


### PR DESCRIPTION
## Summary
- Fixes crash: `Cannot read properties of undefined (reading 'type')` in `WorktreeList.getItemKey`
- When `rows` shrinks (group collapse, worktree removal) while PR/issue cache updates trigger `useLayoutEffect` re-measurement, the virtualizer's `elementsCache` holds stale entries with out-of-bounds indices — accessing `rows[index].type` throws
- Adds a null guard returning a fallback key `__stale_${index}`, matching the pattern already used by FileExplorer and Search virtualizers

## Test plan
- [x] TypeScript typecheck passes
- [ ] Verify crash no longer reproduces: group worktrees, collapse a group while PR data is loading
- [ ] Verify worktree list still renders and scrolls correctly after fix