### PR TITLE
fix: avoid stale worktree card remeasurement

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -394,9 +394,17 @@ const WorktreeList = React.memo(function WorktreeList() {
 
   useLayoutEffect(() => {
     virtualizer.elementsCache.forEach((element) => {
+      // Why: elementsCache can hold stale DOM nodes whose data-index
+      // exceeds the current rows length (e.g. after a group collapse).
+      // Measuring a stale element feeds a detached node's size into the
+      // virtualizer, corrupting layout and causing overlapping cards.
+      const idx = parseInt(element.getAttribute('data-index') ?? '', 10)
+      if (Number.isNaN(idx) || idx >= rows.length) {
+        return
+      }
       virtualizer.measureElement(element)
     })
-  }, [prCacheLen, issueCacheLen, virtualizer])
+  }, [prCacheLen, issueCacheLen, virtualizer, rows.length])
 
   const navigateWorktree = useCallback(
     (direction: 'up' | 'down') => {

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -323,6 +323,14 @@ const WorktreeList = React.memo(function WorktreeList() {
     gap: 6,
     getItemKey: (index) => {
       const row = rows[index]
+      // Why: when rows shrink (group collapse, worktree removal) the
+      // virtualizer's elementsCache can still hold stale entries whose
+      // data-index exceeds the new rows length. measureElement calls
+      // getItemKey for those stale indices, so we need a fallback to
+      // avoid "Cannot read properties of undefined (reading 'type')".
+      if (!row) {
+        return `__stale_${index}`
+      }
       return row.type === 'header' ? `hdr:${row.key}` : `wt:${row.worktree.id}`
     }
   })


### PR DESCRIPTION
## Summary
- fixes the worktree card layout corruption introduced by the crash fix in #625
- keeps the stale-index null guard in `getItemKey`, but stops the async remeasurement pass from measuring stale virtual rows
- only remeasures rows whose `data-index` still exists in the current `rows` array

## Test plan
- [x] `pnpm -s typecheck`
- [ ] manual repro in Orca: collapse/remove grouped worktrees while PR data updates and confirm cards stay stable
