### PR TITLE
fix: worktree list right-side padding

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -248,8 +248,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
       aria-orientation="vertical"
       aria-activedescendant={activeDescendantId}
       onKeyDown={handleContainerKeyDown}
-      className="flex-1 overflow-auto pl-1 scrollbar-sleek scroll-smooth outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-inset pt-px"
-      style={{ scrollbarGutter: 'stable' }}
+      className="flex-1 overflow-auto pl-1 pr-2 scroll-smooth outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-inset pt-px [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
     >
       <div
         role="presentation"


### PR DESCRIPTION
## Summary
- Hide the worktree list scrollbar and add `pr-2` right padding so cards don't touch the sidebar edge
- Remove `scrollbarGutter: 'stable'` which reserved space for a scrollbar that caused asymmetric spacing

## Test plan
- [ ] Verify worktree cards have balanced left/right spacing in the sidebar
- [ ] Scroll a long worktree list to confirm scrolling still works with hidden scrollbar