### PR TITLE
fix: copy-on-selection for right-click paste in terminal

### DIFF
--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
@@ -155,13 +155,19 @@ export function useTerminalPaneContextMenu({
     const clickedPane = manager.getPanes().find((pane) => pane.container.contains(target)) ?? null
     contextPaneIdRef.current = clickedPane?.id ?? null
 
-    // Why: Windows users expect bare right-click to paste when that setting is
-    // enabled, but Ctrl+right-click must still reach the app menu so the menu
-    // remains discoverable. We keep the terminal pane target in sync first so
-    // the paste path uses the clicked split even though no menu opens.
+    // Why: Windows terminals treat right-click as copy-or-paste depending on
+    // whether text is selected. With a selection, right-click copies it and
+    // clears the selection; without one, it pastes. Ctrl+right-click still
+    // reaches the app menu so the menu remains discoverable.
     if (rightClickToPaste && !event.ctrlKey) {
       event.stopPropagation()
-      void onPaste()
+      const selection = clickedPane?.terminal.getSelection()
+      if (selection) {
+        void window.api.ui.writeClipboardText(selection)
+        clickedPane?.terminal.clearSelection()
+      } else {
+        void onPaste()
+      }
       return
     }
 


### PR DESCRIPTION
## Summary
Follow-up to #571. On Windows, right-click now matches native terminal behavior:
- Text selected → right-click copies and clears the selection
- Nothing selected → right-click pastes (existing behavior from #571)
- Ctrl+right-click → opens the context menu (unchanged)

Previously it always pasted.

## Test plan
- [x] Right-click with selection → copies + clears selection
- [x] Right-click without selection → pastes
- [x] Ctrl+right-click → opens context menu
- [x] Disabling `terminalRightClickToPaste` restores default context menu
- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean (only pre-existing unrelated errors)
- [x] `pnpm test` — 58 terminal-pane tests pass