### PR TITLE
fix: use >= in compareVersions fallback for ambiguous versions

### DIFF
--- a/src/main/updater-changelog.ts
+++ b/src/main/updater-changelog.ts
@@ -106,8 +106,14 @@ export async function fetchChangelog(
         if (localIndex < i) {
           continue
         }
-      } else if (compareVersions(localVersion, candidate.version) > 0) {
-        // localVersion is newer than this candidate — user already passed it.
+      } else if (compareVersions(localVersion, candidate.version) >= 0) {
+        // localVersion is newer than (or same as) this candidate — user already
+        // passed it. Why >=: compareVersions returns 0 both for genuinely equal
+        // versions and for unparseable strings. In the localIndex === -1 path,
+        // equal means localVersion literally matches the candidate but wasn't
+        // found by findIndex (shouldn't happen), and unparseable means we can't
+        // determine the relationship. Either way, skipping is the safe default
+        // to avoid showing stale content.
         continue
       }
 


### PR DESCRIPTION
## Summary
- Change `compareVersions` check from `> 0` to `>= 0` in the `localIndex === -1` fallback path
- `compareVersions` returns 0 for both genuinely equal versions and unparseable strings — skipping on `>= 0` avoids showing stale rich cards when the version relationship is ambiguous

## Test plan
- [x] Existing tests pass
- [x] Follow-up to #634