### PR TITLE
fix: route Claude and Codex PTY spawns through cmd.exe on Windows

### DIFF
--- a/src/main/rate-limits/claude-pty.ts
+++ b/src/main/rate-limits/claude-pty.ts
@@ -127,13 +127,21 @@ function describeClaudeUsageFailure(output: string): string {
 export async function fetchViaPty(): Promise<ProviderRateLimits> {
   const pty = await import('node-pty')
 
+  // Why: node-pty cannot spawn .cmd/.bat batch scripts directly on Windows —
+  // those need cmd.exe as an interpreter. The bare 'claude' command may resolve
+  // to claude.cmd (e.g. when installed via npm). Routing through cmd.exe /c
+  // lets Windows handle PATHEXT resolution and find the correct executable.
+  const isWin32 = process.platform === 'win32'
+  const spawnFile = isWin32 ? 'cmd.exe' : 'claude'
+  const spawnArgs = isWin32 ? ['/c', 'claude'] : []
+
   return new Promise<ProviderRateLimits>((resolve) => {
     let output = ''
     let resolved = false
     let sentUsage = false
     let stopDetected = false
 
-    const term = pty.spawn('claude', [], {
+    const term = pty.spawn(spawnFile, spawnArgs, {
       name: 'xterm-256color',
       cols: 120,
       rows: 40,

--- a/src/main/rate-limits/codex-fetcher.ts
+++ b/src/main/rate-limits/codex-fetcher.ts
@@ -293,9 +293,12 @@ async function fetchViaPty(options?: FetchCodexRateLimitsOptions): Promise<Provi
   // Why: node-pty cannot spawn .cmd/.bat batch scripts directly on Windows —
   // those need cmd.exe as an interpreter. Route through `cmd.exe /c <command>`
   // so the PTY fallback works when Codex is installed via npm (codex.cmd).
-  const isWindowsBatchScript = process.platform === 'win32' && /\.(cmd|bat)$/i.test(codexCommand)
-  const spawnFile = isWindowsBatchScript ? 'cmd.exe' : codexCommand
-  const spawnArgs = isWindowsBatchScript ? ['/c', codexCommand] : []
+  // We also route bare commands (no extension) through cmd.exe because
+  // resolveCodexCommand() may fall back to 'codex' when it can't locate the
+  // binary on disk, yet cmd.exe can still find codex.cmd via PATHEXT.
+  const isWin32 = process.platform === 'win32'
+  const spawnFile = isWin32 ? 'cmd.exe' : codexCommand
+  const spawnArgs = isWin32 ? ['/c', codexCommand] : []
 
   return new Promise<ProviderRateLimits>((resolve) => {
     let output = ''


### PR DESCRIPTION
## Summary
- Fix Claude usage tracking on Windows — `claude-pty.ts` spawned `'claude'` directly via node-pty, hitting the same `.cmd` batch script issue. Now routes through `cmd.exe /c` on win32.
- Fix Codex PTY fallback gap — the previous fix only routed through `cmd.exe` when the resolved command had a `.cmd`/`.bat` extension, missing the bare `'codex'` fallback case when `resolveCodexCommand()` can't locate the binary on disk. Simplified to always use `cmd.exe /c` on win32.

Follow-up to #562. All changes are guarded by `process.platform === 'win32'` — zero impact on macOS/Linux.

## Test plan
- [ ] Verify Claude usage tracking works on Windows (no "PTY timeout")
- [ ] Verify Codex usage tracking works on Windows when codex is not directly on PATH (resolves via PATHEXT)
- [ ] Verify no regressions on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)