### PR TITLE
perf: keep right sidebar mounted when closed to avoid remount freeze

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -121,7 +121,6 @@ function App(): React.JSX.Element {
   const showActiveOnly = useAppStore((s) => s.showActiveOnly)
   const filterRepoIds = useAppStore((s) => s.filterRepoIds)
   const persistedUIReady = useAppStore((s) => s.persistedUIReady)
-  const rightSidebarOpen = useAppStore((s) => s.rightSidebarOpen)
   const rightSidebarWidth = useAppStore((s) => s.rightSidebarWidth)
   const isFullScreen = useAppStore((s) => s.isFullScreen)
   const settings = useAppStore((s) => s.settings)
@@ -680,7 +679,14 @@ function App(): React.JSX.Element {
               {activeView === 'settings' ? <Settings /> : !activeWorktreeId ? <Landing /> : null}
             </div>
           </div>
-          {showSidebar && rightSidebarOpen ? <RightSidebar /> : null}
+          {/* Why: keep RightSidebar mounted even when closed so that its
+              child components (FileExplorer, SourceControl, etc.) and their
+              filesystem watchers + cached directory trees survive across
+              open/close toggles.  Without this, every Ctrl+L remounts the
+              entire subtree, triggering watchWorktree + readDir + branchCompare
+              IPC calls that freeze Windows for seconds.  The sidebar already
+              renders at width 0 when closed via useSidebarResize. */}
+          {showSidebar ? <RightSidebar /> : null}
         </div>
         <StatusBar />
       </TooltipProvider>

--- a/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
@@ -24,6 +24,13 @@ export default function ChecksPanel(): React.JSX.Element {
   const fetchPRForBranch = useAppStore((s) => s.fetchPRForBranch)
   const gitConflictOperationByWorktree = useAppStore((s) => s.gitConflictOperationByWorktree)
 
+  // Why: the sidebar stays mounted when closed (for performance). Gate
+  // polling on visibility so we don't fetch checks/comments in the background
+  // when the panel isn't visible to the user.
+  const rightSidebarOpen = useAppStore((s) => s.rightSidebarOpen)
+  const rightSidebarTab = useAppStore((s) => s.rightSidebarTab)
+  const isPanelVisible = rightSidebarOpen && rightSidebarTab === 'checks'
+
   const fetchPRChecks = useAppStore((s) => s.fetchPRChecks)
   const fetchPRComments = useAppStore((s) => s.fetchPRComments)
   const resolveReviewThread = useAppStore((s) => s.resolveReviewThread)
@@ -143,7 +150,7 @@ export default function ChecksPanel(): React.JSX.Element {
 
   // Fetch checks on mount + poll with exponential backoff
   useEffect(() => {
-    if (!prNumber) {
+    if (!prNumber || !isPanelVisible) {
       setChecks([])
       return
     }
@@ -171,7 +178,7 @@ export default function ChecksPanel(): React.JSX.Element {
         clearTimeout(pollRef.current)
       }
     }
-  }, [fetchChecks, prNumber])
+  }, [fetchChecks, isPanelVisible, prNumber])
 
   // Fetch comments once when PR changes (no polling — comments change infrequently).
   // The manual refresh path calls this directly; the auto-fetch effect below uses
@@ -200,7 +207,7 @@ export default function ChecksPanel(): React.JSX.Element {
   )
 
   useEffect(() => {
-    if (!repo || !prNumber) {
+    if (!repo || !prNumber || !isPanelVisible) {
       setComments([])
       return
     }
@@ -225,7 +232,7 @@ export default function ChecksPanel(): React.JSX.Element {
     return () => {
       cancelled = true
     }
-  }, [repo, prNumber, fetchPRComments])
+  }, [repo, prNumber, isPanelVisible, fetchPRComments])
 
   const handleRefresh = useCallback(async () => {
     if (!repo || !branch) {

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -160,7 +160,12 @@ function SourceControlInner(): React.JSX.Element {
   const conflictOperation = activeWorktreeId
     ? (gitConflictOperationByWorktree[activeWorktreeId] ?? 'unknown')
     : 'unknown'
-  const isBranchVisible = rightSidebarTab === 'source-control'
+  const rightSidebarOpen = useAppStore((s) => s.rightSidebarOpen)
+  // Why: gate polling on both the active tab AND the sidebar being open.
+  // The sidebar now stays mounted when closed (for performance), so without
+  // this guard the branchCompare interval and PR fetch would keep running
+  // with no visible consumer, wasting git process spawns and API calls.
+  const isBranchVisible = rightSidebarTab === 'source-control' && rightSidebarOpen
 
   useEffect(() => {
     if (!activeRepo || isFolder) {

--- a/src/renderer/src/components/right-sidebar/index.tsx
+++ b/src/renderer/src/components/right-sidebar/index.tsx
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect, useMemo, useRef } from 'react'
+import React, { useMemo } from 'react'
 import { Files, Search, GitBranch, ListChecks } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { cn } from '@/lib/utils'
@@ -136,21 +136,8 @@ function RightSidebarInner(): React.JSX.Element {
     ? rightSidebarTab
     : visibleItems[0].id
 
-  // Why: suppress CSS width transitions when the sidebar opens so the
-  // width snaps to 320 px instantly instead of animating from 0→320 px.
-  // Without this, Chromium fires the transition causing the terminal
-  // container to resize through intermediate widths. Each intermediate
-  // width triggers a synchronous xterm scrollback reflow that blocks the
-  // renderer for seconds on Windows.
-  //
-  // useLayoutEffect + direct DOM style manipulation runs synchronously
-  // BEFORE the browser paints, so the transition is killed before Chromium
-  // can start it.  A useState-based approach has a timing race: the state
-  // update triggers a re-render that arrives one frame too late.
-  const prevOpenRef = useRef(rightSidebarOpen)
-
   const activityBarSideWidth = activityBarPosition === 'side' ? ACTIVITY_BAR_SIDE_WIDTH : 0
-  const { containerRef, isResizing, onResizeStart } = useSidebarResize<HTMLDivElement>({
+  const { containerRef, onResizeStart } = useSidebarResize<HTMLDivElement>({
     isOpen: rightSidebarOpen,
     width: rightSidebarWidth,
     minWidth: MIN_WIDTH,
@@ -159,22 +146,6 @@ function RightSidebarInner(): React.JSX.Element {
     renderedExtraWidth: activityBarSideWidth,
     setWidth: setRightSidebarWidth
   })
-
-  useLayoutEffect(() => {
-    if (rightSidebarOpen && !prevOpenRef.current) {
-      const el = containerRef.current
-      if (el) {
-        // Kill the transition before the browser paints the width change.
-        el.style.transition = 'none'
-        // Restore CSS-class-driven transitions in the next frame so close
-        // animations and drag-resize still animate smoothly.
-        requestAnimationFrame(() => {
-          el.style.transition = ''
-        })
-      }
-    }
-    prevOpenRef.current = rightSidebarOpen
-  }, [rightSidebarOpen, containerRef])
 
   const panelContent = (
     <div className="flex flex-col flex-1 min-h-0 overflow-hidden scrollbar-sleek-parent">
@@ -206,8 +177,13 @@ function RightSidebarInner(): React.JSX.Element {
     <div
       ref={containerRef}
       className={cn(
-        'relative flex-shrink-0 flex flex-row overflow-visible',
-        isResizing ? 'transition-none' : 'transition-[width] duration-200'
+        'relative flex-shrink-0 flex flex-row',
+        // Why: overflow-visible is needed when open so the resize handle
+        // on the left edge remains interactive.  When closed (width 0),
+        // switch to overflow-hidden so the activity bar icons and panel
+        // content don't leak past the 0-width boundary (the component
+        // stays mounted for performance — see App.tsx).
+        rightSidebarOpen ? 'overflow-visible' : 'overflow-hidden'
       )}
     >
       {/* Panel content area */}


### PR DESCRIPTION
## Summary

- Keep `RightSidebar` component mounted when closed (width 0) instead of fully unmounting it on every Ctrl+L toggle
- Switch between `overflow-hidden` (closed) and `overflow-visible` (open) to prevent activity bar icons from leaking past the 0-width boundary while keeping the resize handle interactive when open
- Remove unused `rightSidebarOpen` selector from App.tsx

## Why

The previous conditional render (`rightSidebarOpen ? <RightSidebar /> : null`) caused a full remount on every sidebar toggle. Each remount triggered:
- FileExplorer mount → `watchWorktree` + `readDir` IPC calls
- SourceControl mount → `git:branchCompare` IPC  
- Terminal container resize → synchronous scrollback reflow

On Windows this froze the app for several seconds on every first Ctrl+L.

## Test plan

- [x] Ctrl+L to open sidebar — no freeze on first or subsequent opens
- [ ] Ctrl+L to close sidebar — content hidden, no visual leakage
- [ ] Activity bar icons not visible when sidebar is closed
- [ ] Resize handle works when sidebar is open
- [ ] Sidebar content correct after open (FileExplorer shows files, SourceControl shows status)
- [ ] macOS — verify no regressions