### PR TITLE
fix: scope macOS signing secrets to mac-only CI step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,15 @@ jobs:
       - name: Build app
         run: pnpm build:release
 
-      - name: Publish release artifacts
+      # Why: macOS signing secrets (CSC_LINK, CSC_KEY_PASSWORD) must NOT be
+      # passed to non-macOS builds. electron-builder uses CSC_LINK as the
+      # code-signing certificate on any platform, so leaking the Apple
+      # Developer ID cert to the Windows build causes the NSIS installer to
+      # be signed with an Apple cert whose chain Windows cannot validate,
+      # breaking the auto-updater with "certificate chain could not be built
+      # to a trusted root authority" (issue #631).
+      - name: Publish release artifacts (macOS)
+        if: matrix.platform == 'mac'
         run: ${{ matrix.release_command }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -79,6 +87,12 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+
+      - name: Publish release artifacts
+        if: matrix.platform != 'mac'
+        run: ${{ matrix.release_command }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish-release:
     needs: release


### PR DESCRIPTION
## Summary

- Fixes the Windows auto-updater failure caused by the NSIS installer being signed with an Apple Developer ID certificate instead of a Windows Authenticode certificate
- Splits the shared "Publish release artifacts" CI step into a mac-specific step (with signing secrets) and a generic step (GH_TOKEN only) for Windows/Linux
- Regression was introduced in #579/#584 when platform-specific build steps were consolidated into one shared step, leaking `CSC_LINK` and `CSC_KEY_PASSWORD` to all platforms

Closes #631

## Test plan

- [ ] Verify the workflow YAML is valid (CI should pass the workflow lint)
- [ ] Tag an RC release (e.g. `v1.1.31-rc.0`) and confirm the Windows `.exe` is no longer signed with the Apple Developer ID cert: run `Get-AuthenticodeSignature .\orca-windows-setup.exe` in PowerShell — status should be `NotSigned`
- [ ] Confirm macOS DMG is still properly signed and notarized
- [ ] Install the RC on Windows, then tag a final release and verify the auto-updater completes without the "certificate chain" error