### PR TITLE
feat: add Agent Explorer panel to right sidebar

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -447,7 +447,6 @@ function App(): React.JSX.Element {
         e.preventDefault()
         actions.setRightSidebarTab('explorer')
         actions.setRightSidebarOpen(true)
-        return
       }
 
       // Cmd/Ctrl+Shift+F — toggle right sidebar / search tab
@@ -455,7 +454,6 @@ function App(): React.JSX.Element {
         e.preventDefault()
         actions.setRightSidebarTab('search')
         actions.setRightSidebarOpen(true)
-        return
       }
 
       // Cmd/Ctrl+Shift+G — toggle right sidebar / source control tab.
@@ -469,6 +467,13 @@ function App(): React.JSX.Element {
         }
         e.preventDefault()
         actions.setRightSidebarTab('source-control')
+        actions.setRightSidebarOpen(true)
+      }
+
+      // Cmd/Ctrl+Shift+A — toggle right sidebar / agents tab
+      if (e.shiftKey && !e.altKey && e.key.toLowerCase() === 'a') {
+        e.preventDefault()
+        actions.setRightSidebarTab('agents')
         actions.setRightSidebarOpen(true)
       }
     }

--- a/src/renderer/src/components/right-sidebar/AgentsPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/AgentsPanel.tsx
@@ -1,0 +1,220 @@
+import React, { useCallback, useEffect, useState } from 'react'
+import { RefreshCw, ChevronDown } from 'lucide-react'
+import { useAppStore } from '@/store'
+import { cn } from '@/lib/utils'
+import { detectLanguage } from '@/lib/language-detect'
+import { basename } from '@/lib/path'
+import { useActiveWorktreePath } from './useActiveWorktreePath'
+import { useClaudeConfig } from './useClaudeConfig'
+
+type SectionKey = 'agents' | 'skills' | 'commands' | 'rules' | 'mcpServers'
+
+function SectionHeader({
+  label,
+  count,
+  isCollapsed,
+  onToggle
+}: {
+  label: string
+  count: number
+  isCollapsed: boolean
+  onToggle: () => void
+}): React.JSX.Element {
+  return (
+    <button
+      type="button"
+      className="flex flex-1 items-center gap-1 rounded-md px-0.5 py-0.5 text-left text-xs font-semibold uppercase tracking-wider text-foreground/70 hover:bg-accent hover:text-accent-foreground"
+      onClick={onToggle}
+    >
+      <ChevronDown
+        className={cn('size-3.5 shrink-0 transition-transform', isCollapsed && '-rotate-90')}
+      />
+      <span>{label}</span>
+      <span className="text-[11px] font-medium tabular-nums">{count}</span>
+    </button>
+  )
+}
+
+function ItemRow({
+  name,
+  description,
+  filePath,
+  relativePath,
+  worktreeId,
+  subtitle
+}: {
+  name: string
+  description: string
+  filePath: string
+  relativePath: string
+  worktreeId: string
+  subtitle?: string
+}): React.JSX.Element {
+  const openFile = useAppStore((s) => s.openFile)
+
+  const handleClick = useCallback(() => {
+    openFile(
+      {
+        filePath,
+        relativePath,
+        worktreeId,
+        language: detectLanguage(basename(filePath)),
+        mode: 'edit'
+      },
+      { preview: true }
+    )
+  }, [openFile, filePath, relativePath, worktreeId])
+
+  const truncatedDesc = description.length > 80 ? `${description.slice(0, 80)}…` : description
+
+  return (
+    <button
+      type="button"
+      className="flex flex-col w-full text-left px-3 py-1 hover:bg-accent/50 transition-colors cursor-pointer"
+      onClick={handleClick}
+    >
+      <span className="text-[12px] text-foreground leading-snug truncate">{name}</span>
+      {(truncatedDesc || subtitle) && (
+        <span className="text-[10px] text-muted-foreground leading-snug truncate">
+          {subtitle ? `${subtitle}${truncatedDesc ? ' · ' : ''}` : ''}
+          {truncatedDesc}
+        </span>
+      )}
+    </button>
+  )
+}
+
+const SECTIONS: {
+  key: SectionKey
+  label: string
+}[] = [
+  { key: 'agents', label: 'Agents' },
+  { key: 'skills', label: 'Skills' },
+  { key: 'commands', label: 'Commands' },
+  { key: 'rules', label: 'Rules' },
+  { key: 'mcpServers', label: 'MCP Servers' }
+]
+
+export default function AgentsPanel(): React.JSX.Element {
+  const activeWorktreeId = useAppStore((s) => s.activeWorktreeId)
+  const worktreesByRepo = useAppStore((s) => s.worktreesByRepo)
+  const worktreePath = useActiveWorktreePath(activeWorktreeId, worktreesByRepo)
+  const { config, loading, hasClaudeDir, scan } = useClaudeConfig(worktreePath)
+  const [collapsedSections, setCollapsedSections] = useState<Set<SectionKey>>(new Set())
+
+  useEffect(() => {
+    void scan()
+  }, [scan])
+
+  const toggleSection = useCallback((key: SectionKey) => {
+    setCollapsedSections((prev) => {
+      const next = new Set(prev)
+      if (next.has(key)) {
+        next.delete(key)
+      } else {
+        next.add(key)
+      }
+      return next
+    })
+  }, [])
+
+  if (!worktreePath) {
+    return (
+      <div className="px-4 py-6">
+        <div className="text-sm font-medium text-foreground">No worktree selected</div>
+        <div className="mt-1 text-xs text-muted-foreground">
+          Select a worktree to view agent configuration
+        </div>
+      </div>
+    )
+  }
+
+  if (!loading && !hasClaudeDir) {
+    return (
+      <div className="px-4 py-6">
+        <div className="text-sm font-medium text-foreground">No agent configuration found</div>
+        <div className="mt-1 text-xs text-muted-foreground">
+          Add a <code className="text-[11px] bg-muted px-1 rounded">.claude/</code> directory to
+          this worktree to configure agents, skills, commands, and rules
+        </div>
+      </div>
+    )
+  }
+
+  const totalItems =
+    config.agents.length +
+    config.skills.length +
+    config.commands.length +
+    config.rules.length +
+    config.mcpServers.length
+
+  return (
+    <div className="flex-1 overflow-auto scrollbar-sleek">
+      <div className="flex items-center justify-between px-3 py-2.5 border-b border-border">
+        <span className="text-[11px] font-semibold uppercase tracking-wider text-foreground">
+          Agents
+          {totalItems > 0 && (
+            <span className="ml-1 text-muted-foreground tabular-nums">{totalItems}</span>
+          )}
+        </span>
+        <button
+          className="p-1 rounded hover:bg-accent text-muted-foreground hover:text-foreground transition-colors"
+          title="Refresh"
+          onClick={() => void scan()}
+          disabled={loading}
+        >
+          <RefreshCw className={cn('size-3.5', loading && 'animate-spin')} />
+        </button>
+      </div>
+
+      {loading && totalItems === 0 && (
+        <div className="flex items-center justify-center py-8">
+          <RefreshCw className="size-4 animate-spin text-muted-foreground" />
+        </div>
+      )}
+
+      {SECTIONS.map(({ key, label }) => {
+        const items = config[key]
+        if (items.length === 0) {
+          return null
+        }
+
+        const isCollapsed = collapsedSections.has(key)
+
+        return (
+          <div key={key}>
+            <div className="group/section flex items-center pl-1 pr-3 pt-3 pb-1">
+              <SectionHeader
+                label={label}
+                count={items.length}
+                isCollapsed={isCollapsed}
+                onToggle={() => toggleSection(key)}
+              />
+            </div>
+            {!isCollapsed && (
+              <div className="flex flex-col">
+                {items.map((item) => (
+                  <ItemRow
+                    key={item.filePath}
+                    name={item.name}
+                    description={item.description}
+                    filePath={item.filePath}
+                    relativePath={item.relativePath}
+                    worktreeId={activeWorktreeId!}
+                    subtitle={
+                      key === 'agents'
+                        ? (item as (typeof config.agents)[number]).model
+                        : key === 'mcpServers'
+                          ? (item as (typeof config.mcpServers)[number]).type?.toUpperCase()
+                          : undefined
+                    }
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/renderer/src/components/right-sidebar/claude-config-types.ts
+++ b/src/renderer/src/components/right-sidebar/claude-config-types.ts
@@ -1,0 +1,56 @@
+export type AgentItem = {
+  name: string
+  description: string
+  filePath: string
+  relativePath: string
+  model?: string
+  tools?: string
+}
+
+export type SkillItem = {
+  name: string
+  description: string
+  filePath: string
+  relativePath: string
+}
+
+export type CommandItem = {
+  name: string
+  description: string
+  filePath: string
+  relativePath: string
+}
+
+export type RuleItem = {
+  name: string
+  description: string
+  filePath: string
+  relativePath: string
+  paths?: string[]
+}
+
+export type McpServerItem = {
+  name: string
+  description: string
+  filePath: string
+  relativePath: string
+  type: 'http' | 'stdio'
+  url?: string
+  command?: string
+}
+
+export type ClaudeConfig = {
+  agents: AgentItem[]
+  skills: SkillItem[]
+  commands: CommandItem[]
+  rules: RuleItem[]
+  mcpServers: McpServerItem[]
+}
+
+export const EMPTY_CONFIG: ClaudeConfig = {
+  agents: [],
+  skills: [],
+  commands: [],
+  rules: [],
+  mcpServers: []
+}

--- a/src/renderer/src/components/right-sidebar/index.tsx
+++ b/src/renderer/src/components/right-sidebar/index.tsx
@@ -1,5 +1,5 @@
 import React, { useLayoutEffect, useMemo, useRef } from 'react'
-import { Files, Search, GitBranch, ListChecks } from 'lucide-react'
+import { Files, Search, GitBranch, ListChecks, Bot } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { cn } from '@/lib/utils'
 import { useSidebarResize } from '@/hooks/useSidebarResize'
@@ -19,6 +19,7 @@ import FileExplorer from './FileExplorer'
 import SourceControl from './SourceControl'
 import SearchPanel from './Search'
 import ChecksPanel from './ChecksPanel'
+import AgentsPanel from './AgentsPanel'
 
 const MIN_WIDTH = 220
 const MAX_WIDTH = 500
@@ -105,6 +106,12 @@ const ACTIVITY_ITEMS: ActivityBarItem[] = [
     title: 'Checks',
     shortcut: `${isMac ? '\u21E7' : 'Shift+'}${mod}K`,
     gitOnly: true
+  },
+  {
+    id: 'agents',
+    icon: Bot,
+    title: 'Agents',
+    shortcut: `${isMac ? '\u21E7' : 'Shift+'}${mod}A`
   }
 ]
 
@@ -188,6 +195,7 @@ function RightSidebarInner(): React.JSX.Element {
       {effectiveTab === 'search' && <SearchPanel />}
       {effectiveTab === 'source-control' && <SourceControl />}
       {effectiveTab === 'checks' && <ChecksPanel />}
+      {effectiveTab === 'agents' && <AgentsPanel />}
     </div>
   )
 

--- a/src/renderer/src/components/right-sidebar/useClaudeConfig.ts
+++ b/src/renderer/src/components/right-sidebar/useClaudeConfig.ts
@@ -1,0 +1,276 @@
+import { useCallback, useRef, useState } from 'react'
+import { joinPath } from '@/lib/path'
+import { extractFrontMatter } from '@/components/editor/markdown-frontmatter'
+import type {
+  ClaudeConfig,
+  AgentItem,
+  SkillItem,
+  CommandItem,
+  RuleItem,
+  McpServerItem
+} from './claude-config-types'
+import { EMPTY_CONFIG } from './claude-config-types'
+
+type McpConfig = {
+  mcpServers?: Record<
+    string,
+    {
+      type?: string
+      url?: string
+      command?: string
+      description?: string
+    }
+  >
+}
+
+// Why: only handles flat key:value lines — not a full YAML parser. Quoted values
+// and block scalars (|, >) are not supported; the `---` delimiters from
+// extractFrontMatter's raw output are harmlessly skipped (no colon).
+function parseSimpleYaml(raw: string): Record<string, string> {
+  const result: Record<string, string> = {}
+  for (const line of raw.split('\n')) {
+    const colonIdx = line.indexOf(':')
+    if (colonIdx === -1) {
+      continue
+    }
+    const key = line.slice(0, colonIdx).trim()
+    const value = line.slice(colonIdx + 1).trim()
+    if (key && value) {
+      result[key] = value
+    }
+  }
+  return result
+}
+
+function sortByName<T extends { name: string }>(items: T[]): T[] {
+  return [...items].sort((a, b) => a.name.localeCompare(b.name))
+}
+
+/**
+ * Reads all .md files from a directory in parallel, extracts frontmatter,
+ * and maps each to a typed item via the provided transform function.
+ */
+async function scanMarkdownDir<T>(
+  dirPath: string,
+  worktreePath: string,
+  mapItem: (name: string, yaml: Record<string, string>, filePath: string, relativePath: string) => T
+): Promise<T[]> {
+  const entries = await window.api.fs.readDir({ dirPath }).catch(() => null)
+  if (!entries) {
+    return []
+  }
+
+  const mdEntries = entries.filter((e) => !e.isDirectory && e.name.endsWith('.md'))
+  const results = await Promise.all(
+    mdEntries.map(async (entry) => {
+      const filePath = joinPath(dirPath, entry.name)
+      const result = await window.api.fs.readFile({ filePath }).catch(() => null)
+      if (!result) {
+        return null
+      }
+      const fm = extractFrontMatter(result.content)
+      const yaml = fm ? parseSimpleYaml(fm.raw) : {}
+      const relativePath = filePath.slice(worktreePath.length + 1)
+      return mapItem(entry.name.replace(/\.md$/, ''), yaml, filePath, relativePath)
+    })
+  )
+  return results.filter((item): item is NonNullable<typeof item> => item !== null) as T[]
+}
+
+export function useClaudeConfig(worktreePath: string | null) {
+  const [config, setConfig] = useState<ClaudeConfig>(EMPTY_CONFIG)
+  const [loading, setLoading] = useState(false)
+  const [hasClaudeDir, setHasClaudeDir] = useState(false)
+  const scanIdRef = useRef(0)
+
+  const scan = useCallback(async () => {
+    if (!worktreePath) {
+      setConfig(EMPTY_CONFIG)
+      setHasClaudeDir(false)
+      return
+    }
+
+    const scanId = ++scanIdRef.current
+    setLoading(true)
+
+    try {
+      const claudeDir = joinPath(worktreePath, '.claude')
+      const dirEntries = await window.api.fs.readDir({ dirPath: claudeDir }).catch(() => null)
+
+      if (!dirEntries) {
+        setConfig(EMPTY_CONFIG)
+        setHasClaudeDir(false)
+        return
+      }
+
+      setHasClaudeDir(true)
+
+      if (scanIdRef.current !== scanId) {
+        return
+      }
+
+      const [agents, skills, commands, rules, mcpServers] = await Promise.all([
+        scanAgents(worktreePath, claudeDir),
+        scanSkills(worktreePath, claudeDir, dirEntries),
+        scanCommands(worktreePath, claudeDir),
+        scanRules(worktreePath, claudeDir, dirEntries),
+        scanMcpServers(worktreePath)
+      ])
+
+      if (scanIdRef.current !== scanId) {
+        return
+      }
+
+      setConfig({
+        agents: sortByName(agents),
+        skills: sortByName(skills),
+        commands: sortByName(commands),
+        rules: sortByName(rules),
+        mcpServers: sortByName(mcpServers)
+      })
+    } catch (err) {
+      console.warn('Failed to scan Claude config:', err)
+    } finally {
+      if (scanIdRef.current === scanId) {
+        setLoading(false)
+      }
+    }
+  }, [worktreePath])
+
+  return { config, loading, hasClaudeDir, scan }
+}
+
+async function scanAgents(worktreePath: string, claudeDir: string): Promise<AgentItem[]> {
+  return scanMarkdownDir(
+    joinPath(claudeDir, 'agents'),
+    worktreePath,
+    (name, yaml, filePath, relativePath) => ({
+      name,
+      description: yaml.description ?? '',
+      filePath,
+      relativePath,
+      model: yaml.model,
+      tools: yaml.tools
+    })
+  )
+}
+
+async function scanSkills(
+  worktreePath: string,
+  claudeDir: string,
+  dirEntries: { name: string; isDirectory: boolean }[]
+): Promise<SkillItem[]> {
+  // Why: skills use a subdirectory-per-skill layout (each contains SKILL.md),
+  // unlike agents/commands/rules which are flat .md files in a single directory.
+  const hasSkillsDir = dirEntries.some((e) => e.name === 'skills' && e.isDirectory)
+  if (!hasSkillsDir) {
+    return []
+  }
+
+  const skillsDir = joinPath(claudeDir, 'skills')
+  const skillDirs = await window.api.fs.readDir({ dirPath: skillsDir }).catch(() => null)
+  if (!skillDirs) {
+    return []
+  }
+
+  const dirOnly = skillDirs.filter((e) => e.isDirectory)
+  const results = await Promise.all(
+    dirOnly.map(async (entry) => {
+      const skillDir = joinPath(skillsDir, entry.name)
+      const skillMdPath = joinPath(skillDir, 'SKILL.md')
+      const result = await window.api.fs.readFile({ filePath: skillMdPath }).catch(() => null)
+      if (!result) {
+        return null
+      }
+      const fm = extractFrontMatter(result.content)
+      const yaml = fm ? parseSimpleYaml(fm.raw) : {}
+      return {
+        name: yaml.name ?? entry.name,
+        description: yaml.description ?? '',
+        filePath: skillMdPath,
+        relativePath: skillMdPath.slice(worktreePath.length + 1)
+      }
+    })
+  )
+  return results.filter((item): item is SkillItem => item !== null)
+}
+
+async function scanCommands(worktreePath: string, claudeDir: string): Promise<CommandItem[]> {
+  return scanMarkdownDir(
+    joinPath(claudeDir, 'commands'),
+    worktreePath,
+    (name, yaml, filePath, relativePath) => ({
+      name: yaml.name ?? name,
+      description: yaml.description ?? '',
+      filePath,
+      relativePath
+    })
+  )
+}
+
+async function scanRules(
+  worktreePath: string,
+  claudeDir: string,
+  dirEntries: { name: string; isDirectory: boolean }[]
+): Promise<RuleItem[]> {
+  const hasRulesDir = dirEntries.some((e) => e.name === 'rules' && e.isDirectory)
+  if (!hasRulesDir) {
+    return []
+  }
+
+  return scanMarkdownDir(
+    joinPath(claudeDir, 'rules'),
+    worktreePath,
+    (name, yaml, filePath, relativePath) => {
+      const pathsRaw = yaml.paths
+      const paths = pathsRaw
+        ? pathsRaw
+            .split(',')
+            .map((p: string) => p.trim())
+            .filter(Boolean)
+        : undefined
+      return {
+        name,
+        description: yaml.description ?? '',
+        filePath,
+        relativePath,
+        paths
+      }
+    }
+  )
+}
+
+async function scanMcpServers(worktreePath: string): Promise<McpServerItem[]> {
+  const mcpPath = joinPath(worktreePath, '.mcp.json')
+  const result = await window.api.fs.readFile({ filePath: mcpPath }).catch(() => null)
+  if (!result) {
+    return []
+  }
+
+  let config: McpConfig
+  try {
+    config = JSON.parse(result.content) as McpConfig
+  } catch {
+    return []
+  }
+
+  const servers = config.mcpServers
+  if (!servers) {
+    return []
+  }
+
+  const items: McpServerItem[] = []
+  for (const [name, server] of Object.entries(servers)) {
+    const isHttp = server.type === 'http' || !!server.url
+    items.push({
+      name,
+      description: server.description ?? '',
+      filePath: mcpPath,
+      relativePath: '.mcp.json',
+      type: isHttp ? 'http' : 'stdio',
+      url: server.url,
+      command: server.command
+    })
+  }
+  return items
+}

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -97,7 +97,7 @@ export type OpenFile = {
   mode: 'edit' | 'diff' | 'conflict-review'
 }
 
-export type RightSidebarTab = 'explorer' | 'search' | 'source-control' | 'checks'
+export type RightSidebarTab = 'explorer' | 'search' | 'source-control' | 'checks' | 'agents'
 export type ActivityBarPosition = 'top' | 'side'
 
 export type MarkdownViewMode = 'source' | 'rich'


### PR DESCRIPTION
## Summary

- Adds a new **Agents** tab (Bot icon) to the right sidebar activity bar, accessible via `Cmd/Ctrl+Shift+A`
- Scans the active worktree's `.claude/` directory and `.mcp.json` to display agents, skills, commands, rules, and MCP servers in collapsible sections
- Clicking any item opens the backing file as a preview tab in the editor

## Implementation

- **3 new files**: `claude-config-types.ts` (types), `useClaudeConfig.ts` (scanning hook), `AgentsPanel.tsx` (panel component)
- **3 modified files**: `editor.ts` (type union), `index.tsx` (tab registration), `App.tsx` (keyboard shortcut)
- File reads parallelized via `Promise.all` within each scan function; shared `scanMarkdownDir` helper eliminates duplication
- Frontmatter parsed with lightweight inline YAML parser (no new dependencies)
- Uses existing `window.api.fs` IPC APIs, `extractFrontMatter`, `useActiveWorktreePath`, and `detectLanguage`

## Test plan

- [ ] Open Orca, select a worktree with a `.claude/` directory
- [ ] Press `Cmd+Shift+A` -- Agents tab opens with populated sections
- [ ] Click an item -- file opens as a preview tab
- [ ] Switch worktrees -- panel rescans automatically
- [ ] Test a repo with no `.claude/` directory -- empty state message shows
- [ ] Test the refresh button -- re-scans and updates counts
- [ ] Verify tab appears for both git repos and folder-mode repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Risk: high
Historic risk metadata backfill based on the existing `risk:high` label.

## ELI5

Right sidebar Agents tab lists Claude agents, skills, commands, rules, and MCP servers from the worktree config; click to open the file in the editor.
