### PR TITLE
fix: add pnpm/yarn/bun global bin paths and resolve claude CLI for GUI-launched apps

### DIFF
--- a/src/main/codex-cli/command.test.ts
+++ b/src/main/codex-cli/command.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
-import { resolveCodexCommand } from './command'
+import { resolveClaudeCommand, resolveCodexCommand } from './command'
 
 function makeExecutable(path: string): void {
   mkdirSync(dirname(path), { recursive: true })
@@ -36,9 +36,123 @@ describe('resolveCodexCommand', () => {
     expect(resolveCodexCommand({ platform: 'darwin', pathEnv: '', homePath: root })).toBe(v24Path)
   })
 
+  it('finds Codex in pnpm global bin on macOS', () => {
+    const root = mkdtempSync(join(tmpdir(), 'orca-codex-command-'))
+    const pnpmPath = join(root, 'Library', 'pnpm', 'codex')
+    makeExecutable(pnpmPath)
+
+    expect(resolveCodexCommand({ platform: 'darwin', pathEnv: '', homePath: root })).toBe(pnpmPath)
+  })
+
+  it('finds Codex in pnpm global bin on Linux', () => {
+    const root = mkdtempSync(join(tmpdir(), 'orca-codex-command-'))
+    const pnpmPath = join(root, '.local', 'share', 'pnpm', 'codex')
+    makeExecutable(pnpmPath)
+
+    expect(resolveCodexCommand({ platform: 'linux', pathEnv: '', homePath: root })).toBe(pnpmPath)
+  })
+
+  it('finds Codex in pnpm global bin on Windows', () => {
+    const root = mkdtempSync(join(tmpdir(), 'orca-codex-command-'))
+    const pnpmPath = join(root, 'AppData', 'Local', 'pnpm', 'codex.cmd')
+    makeExecutable(pnpmPath)
+
+    expect(resolveCodexCommand({ platform: 'win32', pathEnv: '', homePath: root })).toBe(pnpmPath)
+  })
+
+  it('finds Codex in yarn global bin on macOS', () => {
+    const root = mkdtempSync(join(tmpdir(), 'orca-codex-command-'))
+    const yarnPath = join(root, '.yarn', 'bin', 'codex')
+    makeExecutable(yarnPath)
+
+    expect(resolveCodexCommand({ platform: 'darwin', pathEnv: '', homePath: root })).toBe(yarnPath)
+  })
+
+  it('finds Codex in yarn global bin on Windows', () => {
+    const root = mkdtempSync(join(tmpdir(), 'orca-codex-command-'))
+    const yarnPath = join(root, 'AppData', 'Local', 'Yarn', 'bin', 'codex.cmd')
+    makeExecutable(yarnPath)
+
+    expect(resolveCodexCommand({ platform: 'win32', pathEnv: '', homePath: root })).toBe(yarnPath)
+  })
+
+  it('finds Codex in bun global bin', () => {
+    const root = mkdtempSync(join(tmpdir(), 'orca-codex-command-'))
+    const bunPath = join(root, '.bun', 'bin', 'codex')
+    makeExecutable(bunPath)
+
+    expect(resolveCodexCommand({ platform: 'linux', pathEnv: '', homePath: root })).toBe(bunPath)
+  })
+
+  it('finds Codex in bun global bin on Windows', () => {
+    const root = mkdtempSync(join(tmpdir(), 'orca-codex-command-'))
+    const bunPath = join(root, '.bun', 'bin', 'codex.exe')
+    makeExecutable(bunPath)
+
+    expect(resolveCodexCommand({ platform: 'win32', pathEnv: '', homePath: root })).toBe(bunPath)
+  })
+
   it('returns the bare command when no filesystem candidate exists', () => {
     const root = mkdtempSync(join(tmpdir(), 'orca-codex-command-'))
 
     expect(resolveCodexCommand({ platform: 'linux', pathEnv: '', homePath: root })).toBe('codex')
+  })
+})
+
+describe('resolveClaudeCommand', () => {
+  afterEach(() => {
+    delete process.env.PATH
+    delete process.env.Path
+  })
+
+  it('prefers claude already present on PATH', () => {
+    const root = mkdtempSync(join(tmpdir(), 'orca-claude-command-'))
+    const pathDir = join(root, 'bin')
+    const commandPath = join(pathDir, 'claude')
+    makeExecutable(commandPath)
+
+    expect(resolveClaudeCommand({ platform: 'darwin', pathEnv: pathDir, homePath: root })).toBe(
+      commandPath
+    )
+  })
+
+  it('falls back to the newest nvm-installed claude when PATH misses it', () => {
+    const root = mkdtempSync(join(tmpdir(), 'orca-claude-command-'))
+    const v22Path = join(root, '.nvm', 'versions', 'node', 'v22.14.0', 'bin', 'claude')
+    const v24Path = join(root, '.nvm', 'versions', 'node', 'v24.13.0', 'bin', 'claude')
+    makeExecutable(v22Path)
+    makeExecutable(v24Path)
+
+    expect(resolveClaudeCommand({ platform: 'darwin', pathEnv: '', homePath: root })).toBe(v24Path)
+  })
+
+  it('finds claude in pnpm global bin on macOS', () => {
+    const root = mkdtempSync(join(tmpdir(), 'orca-claude-command-'))
+    const pnpmPath = join(root, 'Library', 'pnpm', 'claude')
+    makeExecutable(pnpmPath)
+
+    expect(resolveClaudeCommand({ platform: 'darwin', pathEnv: '', homePath: root })).toBe(pnpmPath)
+  })
+
+  it('finds claude in yarn global bin', () => {
+    const root = mkdtempSync(join(tmpdir(), 'orca-claude-command-'))
+    const yarnPath = join(root, '.yarn', 'bin', 'claude')
+    makeExecutable(yarnPath)
+
+    expect(resolveClaudeCommand({ platform: 'linux', pathEnv: '', homePath: root })).toBe(yarnPath)
+  })
+
+  it('finds claude in bun global bin', () => {
+    const root = mkdtempSync(join(tmpdir(), 'orca-claude-command-'))
+    const bunPath = join(root, '.bun', 'bin', 'claude')
+    makeExecutable(bunPath)
+
+    expect(resolveClaudeCommand({ platform: 'darwin', pathEnv: '', homePath: root })).toBe(bunPath)
+  })
+
+  it('returns the bare command when no filesystem candidate exists', () => {
+    const root = mkdtempSync(join(tmpdir(), 'orca-claude-command-'))
+
+    expect(resolveClaudeCommand({ platform: 'linux', pathEnv: '', homePath: root })).toBe('claude')
   })
 })

--- a/src/main/codex-cli/command.ts
+++ b/src/main/codex-cli/command.ts
@@ -2,18 +2,18 @@ import { existsSync, readdirSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { delimiter, dirname, join } from 'node:path'
 
-type ResolveCodexCommandOptions = {
+type ResolveCommandOptions = {
   pathEnv?: string | null
   platform?: NodeJS.Platform
   homePath?: string
 }
 
-function getExecutableNames(platform: NodeJS.Platform): string[] {
+function getExecutableNames(platform: NodeJS.Platform, commandName: string): string[] {
   if (platform === 'win32') {
-    return ['codex.cmd', 'codex.exe', 'codex.bat', 'codex']
+    return [`${commandName}.cmd`, `${commandName}.exe`, `${commandName}.bat`, commandName]
   }
 
-  return ['codex']
+  return [commandName]
 }
 
 function splitPath(pathEnv: string | null | undefined): string[] {
@@ -78,7 +78,7 @@ function getVersionManagerDirectories(
   // managers like nvm, so `spawn('codex')` can fail for users who installed
   // Codex under a Node-managed bin directory even though Terminal can run it.
   // Probe the newest installed nvm version explicitly so rate-limit tracking
-  // and account login use the same Codex binary the shell would expose.
+  // and account login use the same binary the shell would expose.
   const nvmVersionsDir = join(homePath, '.nvm', 'versions', 'node')
   if (existsSync(nvmVersionsDir)) {
     const nvmVersionDirectories = readdirSync(nvmVersionsDir, { withFileTypes: true })
@@ -87,24 +87,39 @@ function getVersionManagerDirectories(
       .sort(compareVersionDesc)
       .map((entry) => join(nvmVersionsDir, entry, 'bin'))
 
-    const firstNvmWithCodex = findFirstExecutable(nvmVersionDirectories, executableNames)
-    if (firstNvmWithCodex) {
-      directories.unshift(dirname(firstNvmWithCodex))
+    const firstNvmMatch = findFirstExecutable(nvmVersionDirectories, executableNames)
+    if (firstNvmMatch) {
+      directories.unshift(dirname(firstNvmMatch))
     }
   }
 
   if (platform === 'win32') {
     directories.push(join(homePath, 'AppData', 'Roaming', 'npm'))
+    directories.push(join(homePath, 'AppData', 'Local', 'pnpm'))
+    directories.push(join(homePath, 'AppData', 'Local', 'Yarn', 'bin'))
   } else {
     directories.push(join(homePath, '.local', 'bin'))
+    // Why: pnpm uses platform-specific global bin directories that differ from
+    // npm's ~/.local/bin. macOS follows the ~/Library convention while Linux
+    // uses the XDG-compatible ~/.local/share path. Without these, users who
+    // installed via `pnpm add -g` can't be found by the fallback probe.
+    if (platform === 'darwin') {
+      directories.push(join(homePath, 'Library', 'pnpm'))
+    } else {
+      directories.push(join(homePath, '.local', 'share', 'pnpm'))
+    }
+    directories.push(join(homePath, '.yarn', 'bin'))
   }
+
+  // Why: bun uses ~/.bun/bin on all platforms for globally installed packages.
+  directories.push(join(homePath, '.bun', 'bin'))
 
   return directories
 }
 
-export function resolveCodexCommand(options: ResolveCodexCommandOptions = {}): string {
+function resolveCommand(commandName: string, options: ResolveCommandOptions = {}): string {
   const platform = options.platform ?? process.platform
-  const executableNames = getExecutableNames(platform)
+  const executableNames = getExecutableNames(platform, commandName)
   const pathEnv = options.pathEnv ?? process.env.PATH ?? process.env.Path ?? null
   const pathCandidate = findFirstExecutable(splitPath(pathEnv), executableNames)
   if (pathCandidate) {
@@ -116,5 +131,13 @@ export function resolveCodexCommand(options: ResolveCodexCommandOptions = {}): s
     getVersionManagerDirectories(platform, homePath, executableNames),
     executableNames
   )
-  return versionManagerCandidate ?? 'codex'
+  return versionManagerCandidate ?? commandName
+}
+
+export function resolveCodexCommand(options: ResolveCommandOptions = {}): string {
+  return resolveCommand('codex', options)
+}
+
+export function resolveClaudeCommand(options: ResolveCommandOptions = {}): string {
+  return resolveCommand('claude', options)
 }

--- a/src/main/rate-limits/claude-pty.ts
+++ b/src/main/rate-limits/claude-pty.ts
@@ -1,4 +1,5 @@
 import type { ProviderRateLimits, RateLimitWindow } from '../../shared/rate-limit-types'
+import { resolveClaudeCommand } from '../codex-cli/command'
 
 const PTY_TIMEOUT_MS = 25_000
 
@@ -133,7 +134,17 @@ export async function fetchViaPty(): Promise<ProviderRateLimits> {
     let sentUsage = false
     let stopDetected = false
 
-    const term = pty.spawn('claude', [], {
+    const claudeCommand = resolveClaudeCommand()
+
+    // Why: node-pty cannot spawn .cmd/.bat batch scripts directly on Windows —
+    // those need cmd.exe as an interpreter. resolveClaudeCommand() may also fall
+    // back to bare 'claude' when it can't locate the binary on disk, yet cmd.exe
+    // can still find claude.cmd via PATHEXT. Always route through cmd.exe on win32.
+    const isWin32 = process.platform === 'win32'
+    const spawnFile = isWin32 ? 'cmd.exe' : claudeCommand
+    const spawnArgs = isWin32 ? ['/c', claudeCommand] : []
+
+    const term = pty.spawn(spawnFile, spawnArgs, {
       name: 'xterm-256color',
       cols: 120,
       rows: 40,

--- a/src/main/rate-limits/codex-fetcher.ts
+++ b/src/main/rate-limits/codex-fetcher.ts
@@ -291,11 +291,12 @@ async function fetchViaPty(options?: FetchCodexRateLimitsOptions): Promise<Provi
   const codexCommand = resolveCodexCommand()
 
   // Why: node-pty cannot spawn .cmd/.bat batch scripts directly on Windows —
-  // those need cmd.exe as an interpreter. Route through `cmd.exe /c <command>`
-  // so the PTY fallback works when Codex is installed via npm (codex.cmd).
-  const isWindowsBatchScript = process.platform === 'win32' && /\.(cmd|bat)$/i.test(codexCommand)
-  const spawnFile = isWindowsBatchScript ? 'cmd.exe' : codexCommand
-  const spawnArgs = isWindowsBatchScript ? ['/c', codexCommand] : []
+  // those need cmd.exe as an interpreter. resolveCodexCommand() may also fall
+  // back to bare 'codex' when it can't locate the binary on disk, yet cmd.exe
+  // can still find codex.cmd via PATHEXT. Always route through cmd.exe on win32.
+  const isWin32 = process.platform === 'win32'
+  const spawnFile = isWin32 ? 'cmd.exe' : codexCommand
+  const spawnArgs = isWin32 ? ['/c', codexCommand] : []
 
   return new Promise<ProviderRateLimits>((resolve) => {
     let output = ''


### PR DESCRIPTION
## Summary
- Generalize `resolveCodexCommand()` into a shared `resolveCommand()` helper, export new `resolveClaudeCommand()` for the Claude CLI
- Add pnpm, yarn, and bun global bin directories to the version manager probe so users who installed Codex/Claude via these package managers are found in GUI-launched Electron apps
- Wire `claude-pty.ts` to use `resolveClaudeCommand()` instead of bare `'claude'` — fixes the same PATH-inheritance bug that was already fixed for Codex
- Simplify Windows PTY spawn in both `claude-pty.ts` and `codex-fetcher.ts` to always route through `cmd.exe` on win32, fixing the bare-command PATHEXT fallback edge case

Subsumes and closes #638.

### New paths probed

| Package manager | macOS | Linux | Windows |
|---|---|---|---|
| pnpm | `~/Library/pnpm` | `~/.local/share/pnpm` | `AppData/Local/pnpm` |
| yarn | `~/.yarn/bin` | `~/.yarn/bin` | `AppData/Local/Yarn/bin` |
| bun | `~/.bun/bin` | `~/.bun/bin` | `~/.bun/bin` |

## Test plan
- [x] All 1526 existing + new tests pass
- [ ] Verify Codex usage tracking works when codex installed via pnpm/yarn/bun
- [ ] Verify Claude usage tracking works when claude installed via pnpm/yarn/bun
- [ ] Verify no regressions on macOS (GUI-launched app)
- [ ] Verify Windows PTY spawn works with bare command fallback