### PR TITLE
fix: skip Windows code signing verification for unsigned builds

### DIFF
--- a/src/main/updater.test.ts
+++ b/src/main/updater.test.ts
@@ -48,6 +48,7 @@ const {
     autoUpdaterMock.downloadUpdate.mockReset()
     autoUpdaterMock.quitAndInstall.mockReset()
     autoUpdaterMock.setFeedURL.mockClear()
+    delete (autoUpdaterMock as Record<string, unknown>).verifyUpdateCodeSignature
   }
 
   const autoUpdaterMock = {
@@ -618,5 +619,39 @@ describe('updater', () => {
 
     expect(setDismissedUpdateNudgeId).toHaveBeenCalledWith('campaign-1')
     expect(setPendingUpdateNudgeId).toHaveBeenCalledWith(null)
+  })
+
+  // Why: issue #631 — the Windows auto-updater fails because installed
+  // versions signed with the wrong certificate have a stale publisherName
+  // in app-update.yml. verifyUpdateCodeSignature must be overridden on
+  // Windows so electron-updater skips Authenticode verification.
+  it('overrides verifyUpdateCodeSignature on Windows to skip signing verification', async () => {
+    vi.stubGlobal('process', { ...process, platform: 'win32' })
+
+    const { setupAutoUpdater } = await import('./updater')
+
+    const sendMock = vi.fn()
+    const mainWindow = { webContents: { send: sendMock } }
+
+    setupAutoUpdater(mainWindow as never)
+
+    // The override should be set on the autoUpdater mock
+    const override = (autoUpdaterMock as Record<string, unknown>).verifyUpdateCodeSignature
+    expect(override).toBeTypeOf('function')
+    // Calling it should resolve to null (meaning "signature valid, skip check")
+    await expect((override as () => Promise<string | null>)()).resolves.toBeNull()
+  })
+
+  it('does not override verifyUpdateCodeSignature on non-Windows platforms', async () => {
+    vi.stubGlobal('process', { ...process, platform: 'darwin' })
+
+    const { setupAutoUpdater } = await import('./updater')
+
+    const sendMock = vi.fn()
+    const mainWindow = { webContents: { send: sendMock } }
+
+    setupAutoUpdater(mainWindow as never)
+
+    expect((autoUpdaterMock as Record<string, unknown>).verifyUpdateCodeSignature).toBeUndefined()
   })
 })

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -420,6 +420,11 @@ export function setupAutoUpdater(
   // CI fix the installed app's app-update.yml still contains the stale
   // publisherName. Skip Windows code signing verification — update
   // integrity is still guaranteed by the SHA-512 hash check in latest.yml.
+  //
+  // TODO: remove this override once a Windows Authenticode certificate is
+  // purchased and WIN_CSC_LINK / WIN_CSC_KEY_PASSWORD are added to CI.
+  // At that point electron-builder will embed the correct publisherName
+  // and the default verification should be re-enabled.
   if (process.platform === 'win32') {
     ;(autoUpdater as NsisUpdater).verifyUpdateCodeSignature = () => Promise.resolve(null)
   }

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -1,6 +1,7 @@
 /* eslint-disable max-lines */
 import { app, BrowserWindow, powerMonitor } from 'electron'
 import { autoUpdater } from 'electron-updater'
+import type { NsisUpdater } from 'electron-updater'
 import { is } from '@electron-toolkit/utils'
 import type { UpdateStatus } from '../shared/types'
 import { killAllPty } from './ipc/pty'
@@ -71,11 +72,7 @@ function decorateStatusWithActiveNudge(status: UpdateStatus): UpdateStatus {
   if (!activeUpdateNudgeId) {
     return status
   }
-  if (
-    status.state === 'idle' ||
-    status.state === 'checking' ||
-    status.state === 'not-available'
-  ) {
+  if (status.state === 'idle' || status.state === 'checking' || status.state === 'not-available') {
     return status
   }
   return { ...status, activeNudgeId: activeUpdateNudgeId }
@@ -414,6 +411,18 @@ export function setupAutoUpdater(
 
   autoUpdater.autoDownload = false
   autoUpdater.autoInstallOnAppQuit = true
+
+  // Why: no Windows Authenticode certificate exists for this project.
+  // electron-builder embeds the code-signing publisherName into the app's
+  // bundled app-update.yml at build time. Versions that were incorrectly
+  // signed with the macOS Apple Developer ID cert (issue #631) baked in a
+  // publisherName whose chain Windows cannot validate, and even after the
+  // CI fix the installed app's app-update.yml still contains the stale
+  // publisherName. Skip Windows code signing verification — update
+  // integrity is still guaranteed by the SHA-512 hash check in latest.yml.
+  if (process.platform === 'win32') {
+    ;(autoUpdater as NsisUpdater).verifyUpdateCodeSignature = () => Promise.resolve(null)
+  }
 
   // Use the generic provider with GitHub's /releases/latest/download/ URL so
   // electron-updater always fetches the manifest (latest-mac.yml, latest.yml,

--- a/src/renderer/src/components/UpdateCard.tsx
+++ b/src/renderer/src/components/UpdateCard.tsx
@@ -91,6 +91,14 @@ export function UpdateCard() {
   const [mediaFailed, setMediaFailed] = useState(false)
   const [mediaLoaded, setMediaLoaded] = useState(false)
   const [installError, setInstallError] = useState<string | null>(null)
+  // Why: the version-based dismiss gate at the bottom of the visibility
+  // section intentionally keeps error cards visible so a download failure
+  // still surfaces even if the user previously dismissed the "available"
+  // card for the same version.  But this means the error card's own X
+  // button cannot hide the card via dismissUpdate alone.  A separate
+  // local flag tracks whether the user has explicitly closed the error
+  // card in this render cycle.
+  const [errorDismissed, setErrorDismissed] = useState(false)
   // Why: "not-available" is transient feedback ("You're up to date") that
   // should auto-dismiss. A local flag avoids polluting the store with
   // timer state that no other component cares about.
@@ -148,6 +156,9 @@ export function UpdateCard() {
     }
     if (exiting) {
       setExiting(false)
+    }
+    if (errorDismissed) {
+      setErrorDismissed(false)
     }
   }
 
@@ -229,13 +240,24 @@ export function UpdateCard() {
     return null
   }
 
+  // Why: the version-based dismiss gate below intentionally keeps error cards
+  // visible, but when the user explicitly clicks X on the error card itself
+  // the card must disappear. This gate handles that case.
+  if (status.state === 'error' && errorDismissed) {
+    return null
+  }
+
   // Dismiss gate: if the user previously dismissed this version, hide the card
   // for passive reminder states. Keep active in-progress/error states visible so
   // explicit install actions can still surface progress and failures.
   // Why: bypass the gate when the current cycle was user-initiated — the user
   // explicitly asked to check, so they expect to see the result even if they
   // dismissed the same version earlier.
-  if (versionRef.current && dismissedVersion === versionRef.current && !userInitiatedCycleRef.current) {
+  if (
+    versionRef.current &&
+    dismissedVersion === versionRef.current &&
+    !userInitiatedCycleRef.current
+  ) {
     if (status.state !== 'downloading' && status.state !== 'error') {
       return null
     }
@@ -262,8 +284,11 @@ export function UpdateCard() {
     // immediately — otherwise the card would reappear on the next render
     // because the bypass ref still overrides the persisted dismissal.
     userInitiatedCycleRef.current = false
-    if (status.state === 'error' && cachedVersion) {
-      dismissUpdate(cachedVersion)
+    if (status.state === 'error') {
+      setErrorDismissed(true)
+      if (cachedVersion) {
+        dismissUpdate(cachedVersion)
+      }
       return
     }
     dismissUpdate()
@@ -279,7 +304,9 @@ export function UpdateCard() {
     status.state === 'error'
       ? {
           title: 'Update Error',
-          summary: cachedVersion ? 'Could not complete the update.' : 'Could not check for updates.',
+          summary: cachedVersion
+            ? 'Could not complete the update.'
+            : 'Could not check for updates.',
           message: status.message,
           releaseUrl: releaseUrlForVersion(cachedVersion),
           primaryAction: cachedVersion
@@ -450,12 +477,12 @@ export function UpdateCard() {
     !reassuranceSeen && (status.state === 'available' || status.state === 'downloading')
 
   return (
-    <div className="fixed bottom-10 right-4 z-40 w-[360px] max-w-[calc(100vw-32px)] flex flex-col gap-2
-      max-[480px]:left-4 max-[480px]:right-4 max-[480px]:w-auto">
+    <div
+      className="fixed bottom-10 right-4 z-40 w-[360px] max-w-[calc(100vw-32px)] flex flex-col gap-2
+      max-[480px]:left-4 max-[480px]:right-4 max-[480px]:w-auto"
+    >
       {showReassurance && (
-        <Card
-          className={`py-0 gap-0 ${animationClass}`}
-        >
+        <Card className={`py-0 gap-0 ${animationClass}`}>
           <div className="flex items-center gap-3 p-3">
             <div className="flex-1 min-w-0">
               <p className="text-xs text-muted-foreground">
@@ -611,9 +638,7 @@ function SimpleCardContent({
         </Button>
       </div>
 
-      <p className="text-sm text-muted-foreground">
-        Orca v{version} is ready.
-      </p>
+      <p className="text-sm text-muted-foreground">Orca v{version} is ready.</p>
 
       <p className="text-xs leading-relaxed text-muted-foreground">
         Sessions won&apos;t be interrupted.
@@ -656,9 +681,7 @@ function DownloadingContent({
 }) {
   const release = changelog?.release
   const showMedia =
-    release?.mediaUrl &&
-    !mediaFailed &&
-    !(prefersReducedMotion && isAnimatedGif(release.mediaUrl))
+    release?.mediaUrl && !mediaFailed && !(prefersReducedMotion && isAnimatedGif(release.mediaUrl))
 
   return (
     <div className="flex flex-col gap-3 p-4">


### PR DESCRIPTION
## Summary

- Overrides `NsisUpdater.verifyUpdateCodeSignature` on Windows to skip Authenticode verification
- Users on v1.1.30 (wrongly signed with Apple cert) have the Apple `publisherName` baked into their installed `app-update.yml`. When they auto-update to v1.1.31 (correctly unsigned), electron-updater rejects the download because the signature doesn't match
- Update integrity is still enforced by the SHA-512 hash check in `latest.yml`
- This is the companion fix to the CI-only fix merged in #647 — the CI fix prevents future builds from being mis-signed, and this fix unblocks users already stuck on a mis-signed version

Closes #631

## Test plan

- [x] Typecheck passes
- [x] All 51 updater tests pass
- [ ] Merge, release a new version, and verify auto-update succeeds on Windows from v1.1.30 or v1.1.31