### PR TITLE
[codex] add managed OpenCode Go account switching

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -25,6 +25,7 @@ import { RateLimitService } from './rate-limits/service'
 import { attachMainWindowServices } from './window/attach-main-window-services'
 import { createMainWindow } from './window/createMainWindow'
 import { CodexAccountService } from './codex-accounts/service'
+import { OpenCodeAccountService } from './opencode-accounts/service'
 import { openCodeHookService } from './opencode/hook-service'
 
 let mainWindow: BrowserWindow | null = null
@@ -37,6 +38,7 @@ let stats: StatsCollector | null = null
 let claudeUsage: ClaudeUsageStore | null = null
 let codexUsage: CodexUsageStore | null = null
 let codexAccounts: CodexAccountService | null = null
+let openCodeAccounts: OpenCodeAccountService | null = null
 let runtime: OrcaRuntimeService | null = null
 let rateLimits: RateLimitService | null = null
 let runtimeRpc: OrcaRuntimeRpcServer | null = null
@@ -79,6 +81,9 @@ function openMainWindow(): BrowserWindow {
   if (!codexAccounts) {
     throw new Error('Codex account service must be initialized before opening the main window')
   }
+  if (!openCodeAccounts) {
+    throw new Error('OpenCode account service must be initialized before opening the main window')
+  }
 
   const window = createMainWindow(store, {
     getIsQuitting: () => isQuitting,
@@ -93,11 +98,16 @@ function openMainWindow(): BrowserWindow {
     claudeUsage,
     codexUsage,
     codexAccounts,
+    openCodeAccounts,
     rateLimits,
     window.webContents.id
   )
-  attachMainWindowServices(window, store, runtime, () =>
-    codexAccounts!.getSelectedManagedHomePath()
+  attachMainWindowServices(
+    window,
+    store,
+    runtime,
+    () => codexAccounts!.getSelectedManagedHomePath(),
+    () => openCodeAccounts!.getSelectedManagedDataPath()
   )
   rateLimits.attach(window)
   rateLimits.start()
@@ -125,6 +135,7 @@ app.whenReady().then(async () => {
   codexUsage = new CodexUsageStore(store)
   rateLimits = new RateLimitService()
   codexAccounts = new CodexAccountService(store, rateLimits)
+  openCodeAccounts = new OpenCodeAccountService(store)
   rateLimits.setCodexHomePathResolver(() => codexAccounts!.getSelectedManagedHomePath())
   runtime = new OrcaRuntimeService(store, stats)
   nativeTheme.themeSource = store.getSettings().theme ?? 'system'

--- a/src/main/ipc/opencode-accounts.ts
+++ b/src/main/ipc/opencode-accounts.ts
@@ -1,0 +1,20 @@
+import { ipcMain } from 'electron'
+import type { OpenCodeAccountService } from '../opencode-accounts/service'
+
+export function registerOpenCodeAccountHandlers(openCodeAccounts: OpenCodeAccountService): void {
+  ipcMain.handle('openCodeAccounts:list', () => openCodeAccounts.listAccounts())
+  ipcMain.handle('openCodeAccounts:add', (_event, args: { label: string; apiKey: string }) =>
+    openCodeAccounts.addAccount(args)
+  )
+  ipcMain.handle(
+    'openCodeAccounts:reauthenticate',
+    (_event, args: { accountId: string; label: string; apiKey: string }) =>
+      openCodeAccounts.reauthenticateAccount(args.accountId, args)
+  )
+  ipcMain.handle('openCodeAccounts:remove', (_event, args: { accountId: string }) =>
+    openCodeAccounts.removeAccount(args.accountId)
+  )
+  ipcMain.handle('openCodeAccounts:select', (_event, args: { accountId: string | null }) =>
+    openCodeAccounts.selectAccount(args.accountId)
+  )
+}

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -178,7 +178,8 @@ describe('registerPtyHandlers', () => {
   async function spawnAndGetEnv(
     argsEnv?: Record<string, string>,
     processEnvOverrides?: Record<string, string | undefined>,
-    getSelectedCodexHomePath?: () => string | null
+    getSelectedCodexHomePath?: () => string | null,
+    getSelectedOpenCodeDataPath?: () => string | null
   ): Promise<Record<string, string>> {
     const savedEnv: Record<string, string | undefined> = {}
     if (processEnvOverrides) {
@@ -196,7 +197,12 @@ describe('registerPtyHandlers', () => {
       // Clear previously registered handlers so re-registration doesn't
       // accumulate stale state across calls within one test.
       handlers.clear()
-      registerPtyHandlers(mainWindow as never, undefined, getSelectedCodexHomePath)
+      registerPtyHandlers(
+        mainWindow as never,
+        undefined,
+        getSelectedCodexHomePath,
+        getSelectedOpenCodeDataPath
+      )
       await handlers.get('pty:spawn')!(null, {
         cols: 80,
         rows: 24,
@@ -262,6 +268,16 @@ describe('registerPtyHandlers', () => {
       expect(env.CODEX_HOME).toBe('/tmp/orca-codex-home')
     })
 
+    it('injects the selected OpenCode data root into Orca terminal PTYs', async () => {
+      const env = await spawnAndGetEnv(
+        undefined,
+        undefined,
+        undefined,
+        () => '/tmp/orca-opencode-data'
+      )
+      expect(env.XDG_DATA_HOME).toBe('/tmp/orca-opencode-data')
+    })
+
     it('injects the OpenCode hook env into Orca terminal PTYs', async () => {
       // Why: clear any ambient OPENCODE_CONFIG_DIR so the mock's value is used
       const env = await spawnAndGetEnv(undefined, { OPENCODE_CONFIG_DIR: undefined })
@@ -285,6 +301,16 @@ describe('registerPtyHandlers', () => {
         () => null
       )
       expect(env.CODEX_HOME).toBe('/tmp/system-codex-home')
+    })
+
+    it('leaves ambient XDG_DATA_HOME untouched when the system OpenCode account is selected', async () => {
+      const env = await spawnAndGetEnv(
+        undefined,
+        { XDG_DATA_HOME: '/tmp/system-opencode-data' },
+        undefined,
+        () => null
+      )
+      expect(env.XDG_DATA_HOME).toBe('/tmp/system-opencode-data')
     })
   })
 

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -116,6 +116,7 @@ export function registerPtyHandlers(
   mainWindow: BrowserWindow,
   runtime?: OrcaRuntimeService,
   getSelectedCodexHomePath?: () => string | null,
+  getSelectedOpenCodeDataPath?: () => string | null,
   getSettings?: () => GlobalSettings
 ): void {
   // Remove any previously registered handlers so we can re-register them
@@ -131,6 +132,7 @@ export function registerPtyHandlers(
     isHistoryEnabled: () => getSettings?.()?.terminalScopeHistoryByWorktree ?? true,
     buildSpawnEnv: (id, baseEnv) => {
       const selectedCodexHomePath = getSelectedCodexHomePath?.() ?? null
+      const selectedOpenCodeDataPath = getSelectedOpenCodeDataPath?.() ?? null
 
       const openCodeHookEnv = openCodeHookService.buildPtyEnv(id)
       if (baseEnv.OPENCODE_CONFIG_DIR) {
@@ -155,6 +157,13 @@ export function registerPtyHandlers(
       // the user's external shells.
       if (selectedCodexHomePath) {
         baseEnv.CODEX_HOME = selectedCodexHomePath
+      }
+      if (selectedOpenCodeDataPath) {
+        // Why: OpenCode stores auth and per-install runtime state under
+        // `XDG_DATA_HOME/opencode`. Point only Orca PTYs at the managed data
+        // root so account switching stays scoped to Orca terminals and does
+        // not rewrite the user's global OpenCode credential selection.
+        baseEnv.XDG_DATA_HOME = selectedOpenCodeDataPath
       }
 
       return baseEnv

--- a/src/main/ipc/register-core-handlers.test.ts
+++ b/src/main/ipc/register-core-handlers.test.ts
@@ -15,6 +15,7 @@ const {
   registerFilesystemHandlersMock,
   registerRuntimeHandlersMock,
   registerCodexAccountHandlersMock,
+  registerOpenCodeAccountHandlersMock,
   registerClipboardHandlersMock,
   registerUpdaterHandlersMock,
   registerRateLimitHandlersMock,
@@ -36,6 +37,7 @@ const {
   registerFilesystemHandlersMock: vi.fn(),
   registerRuntimeHandlersMock: vi.fn(),
   registerCodexAccountHandlersMock: vi.fn(),
+  registerOpenCodeAccountHandlersMock: vi.fn(),
   registerClipboardHandlersMock: vi.fn(),
   registerUpdaterHandlersMock: vi.fn(),
   registerRateLimitHandlersMock: vi.fn(),
@@ -108,6 +110,10 @@ vi.mock('./codex-accounts', () => ({
   registerCodexAccountHandlers: registerCodexAccountHandlersMock
 }))
 
+vi.mock('./opencode-accounts', () => ({
+  registerOpenCodeAccountHandlers: registerOpenCodeAccountHandlersMock
+}))
+
 vi.mock('../window/attach-main-window-services', () => ({
   registerClipboardHandlers: registerClipboardHandlersMock,
   registerUpdaterHandlers: registerUpdaterHandlersMock
@@ -136,6 +142,7 @@ describe('registerCoreHandlers', () => {
     registerFilesystemHandlersMock.mockReset()
     registerRuntimeHandlersMock.mockReset()
     registerCodexAccountHandlersMock.mockReset()
+    registerOpenCodeAccountHandlersMock.mockReset()
     registerClipboardHandlersMock.mockReset()
     registerUpdaterHandlersMock.mockReset()
     registerRateLimitHandlersMock.mockReset()
@@ -151,6 +158,7 @@ describe('registerCoreHandlers', () => {
     const claudeUsage = { marker: 'claudeUsage' }
     const codexUsage = { marker: 'codexUsage' }
     const codexAccounts = { marker: 'codexAccounts' }
+    const openCodeAccounts = { marker: 'openCodeAccounts' }
     const rateLimits = { marker: 'rateLimits' }
 
     registerCoreHandlers(
@@ -160,12 +168,14 @@ describe('registerCoreHandlers', () => {
       claudeUsage as never,
       codexUsage as never,
       codexAccounts as never,
+      openCodeAccounts as never,
       rateLimits as never
     )
 
     expect(registerClaudeUsageHandlersMock).toHaveBeenCalledWith(claudeUsage)
     expect(registerCodexUsageHandlersMock).toHaveBeenCalledWith(codexUsage)
     expect(registerCodexAccountHandlersMock).toHaveBeenCalledWith(codexAccounts)
+    expect(registerOpenCodeAccountHandlersMock).toHaveBeenCalledWith(openCodeAccounts)
     expect(registerRateLimitHandlersMock).toHaveBeenCalledWith(rateLimits)
     expect(registerGitHubHandlersMock).toHaveBeenCalledWith(store, stats)
     expect(registerStatsHandlersMock).toHaveBeenCalledWith(stats)
@@ -194,6 +204,7 @@ describe('registerCoreHandlers', () => {
     const claudeUsage2 = { marker: 'claudeUsage2' }
     const codexUsage2 = { marker: 'codexUsage2' }
     const codexAccounts2 = { marker: 'codexAccounts2' }
+    const openCodeAccounts2 = { marker: 'openCodeAccounts2' }
     const rateLimits2 = { marker: 'rateLimits2' }
 
     registerCoreHandlers(
@@ -203,6 +214,7 @@ describe('registerCoreHandlers', () => {
       claudeUsage2 as never,
       codexUsage2 as never,
       codexAccounts2 as never,
+      openCodeAccounts2 as never,
       rateLimits2 as never,
       42
     )

--- a/src/main/ipc/register-core-handlers.ts
+++ b/src/main/ipc/register-core-handlers.ts
@@ -20,6 +20,7 @@ import { browserSessionRegistry } from '../browser/browser-session-registry'
 import { registerShellHandlers } from './shell'
 import { registerUIHandlers } from './ui'
 import { registerCodexAccountHandlers } from './codex-accounts'
+import { registerOpenCodeAccountHandlers } from './opencode-accounts'
 import { warmSystemFontFamilies } from '../system-fonts'
 import {
   registerClipboardHandlers,
@@ -29,6 +30,7 @@ import type { ClaudeUsageStore } from '../claude-usage/store'
 import type { CodexUsageStore } from '../codex-usage/store'
 import type { RateLimitService } from '../rate-limits/service'
 import type { CodexAccountService } from '../codex-accounts/service'
+import type { OpenCodeAccountService } from '../opencode-accounts/service'
 
 let registered = false
 
@@ -39,6 +41,7 @@ export function registerCoreHandlers(
   claudeUsage: ClaudeUsageStore,
   codexUsage: CodexUsageStore,
   codexAccounts: CodexAccountService,
+  openCodeAccounts: OpenCodeAccountService,
   rateLimits: RateLimitService,
   mainWindowWebContentsId: number | null = null
 ): void {
@@ -57,6 +60,7 @@ export function registerCoreHandlers(
   registerClaudeUsageHandlers(claudeUsage)
   registerCodexUsageHandlers(codexUsage)
   registerCodexAccountHandlers(codexAccounts)
+  registerOpenCodeAccountHandlers(openCodeAccounts)
   registerRateLimitHandlers(rateLimits)
   registerGitHubHandlers(store, stats)
   registerStatsHandlers(stats)

--- a/src/main/opencode-accounts/service.ts
+++ b/src/main/opencode-accounts/service.ts
@@ -1,0 +1,292 @@
+/* eslint-disable max-lines -- Why: this service intentionally keeps OpenCode
+account lifecycle, credential-file writes, and managed-path safety together so
+the trusted boundary around Orca-managed API keys stays easy to audit. */
+import { randomUUID } from 'node:crypto'
+import { existsSync, mkdirSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
+import { join, relative, resolve, sep } from 'node:path'
+import { app } from 'electron'
+import type {
+  OpenCodeAccountsState,
+  OpenCodeManagedAccount,
+  OpenCodeManagedAccountSummary
+} from '../../shared/types'
+import type { Store } from '../persistence'
+
+const OPENCODE_PROVIDER_ID = 'opencode-go'
+
+function normalizeField(value: string): string {
+  return value.trim()
+}
+
+function formatKeyHint(apiKey: string): string {
+  const trimmed = normalizeField(apiKey)
+  if (trimmed.length <= 8) {
+    return trimmed
+  }
+  return `${trimmed.slice(0, 4)}…${trimmed.slice(-4)}`
+}
+
+export class OpenCodeAccountService {
+  constructor(private readonly store: Store) {}
+
+  listAccounts(): OpenCodeAccountsState {
+    this.normalizeActiveSelection()
+    return this.getSnapshot()
+  }
+
+  addAccount(input: { label: string; apiKey: string }): OpenCodeAccountsState {
+    const label = this.requireLabel(input.label)
+    const apiKey = this.requireApiKey(input.apiKey)
+    const accountId = randomUUID()
+    const managedDataPath = this.createManagedDataRoot(accountId)
+
+    try {
+      this.writeManagedAuthFile(managedDataPath, apiKey)
+      const now = Date.now()
+      const account: OpenCodeManagedAccount = {
+        id: accountId,
+        label,
+        managedDataPath,
+        providerId: OPENCODE_PROVIDER_ID,
+        keyHint: formatKeyHint(apiKey),
+        createdAt: now,
+        updatedAt: now,
+        lastAuthenticatedAt: now
+      }
+
+      const settings = this.store.getSettings()
+      this.store.updateSettings({
+        openCodeManagedAccounts: [...settings.openCodeManagedAccounts, account],
+        activeOpenCodeManagedAccountId: account.id
+      })
+
+      return this.getSnapshot()
+    } catch (error) {
+      this.safeRemoveManagedDataRoot(managedDataPath)
+      throw error
+    }
+  }
+
+  reauthenticateAccount(
+    accountId: string,
+    input: { label: string; apiKey: string }
+  ): OpenCodeAccountsState {
+    const account = this.requireAccount(accountId)
+    const label = this.requireLabel(input.label)
+    const apiKey = this.requireApiKey(input.apiKey)
+    const managedDataPath = this.assertManagedDataPath(account.managedDataPath)
+    this.writeManagedAuthFile(managedDataPath, apiKey)
+
+    const settings = this.store.getSettings()
+    const now = Date.now()
+    this.store.updateSettings({
+      openCodeManagedAccounts: settings.openCodeManagedAccounts.map((entry) =>
+        entry.id === accountId
+          ? {
+              ...entry,
+              label,
+              keyHint: formatKeyHint(apiKey),
+              updatedAt: now,
+              lastAuthenticatedAt: now
+            }
+          : entry
+      )
+    })
+
+    return this.getSnapshot()
+  }
+
+  removeAccount(accountId: string): OpenCodeAccountsState {
+    const account = this.requireAccount(accountId)
+    const settings = this.store.getSettings()
+    const nextAccounts = settings.openCodeManagedAccounts.filter((entry) => entry.id !== accountId)
+    const nextActiveId =
+      settings.activeOpenCodeManagedAccountId === accountId
+        ? null
+        : settings.activeOpenCodeManagedAccountId
+
+    this.store.updateSettings({
+      openCodeManagedAccounts: nextAccounts,
+      activeOpenCodeManagedAccountId: nextActiveId
+    })
+
+    this.safeRemoveManagedDataRoot(account.managedDataPath)
+    return this.getSnapshot()
+  }
+
+  selectAccount(accountId: string | null): OpenCodeAccountsState {
+    if (accountId !== null) {
+      this.requireAccount(accountId)
+    }
+
+    this.store.updateSettings({
+      activeOpenCodeManagedAccountId: accountId
+    })
+
+    return this.getSnapshot()
+  }
+
+  getSelectedManagedDataPath(): string | null {
+    const account = this.getActiveAccount()
+    if (!account) {
+      return null
+    }
+
+    try {
+      return this.assertManagedDataPath(account.managedDataPath)
+    } catch (error) {
+      // Why: if the managed OpenCode data root disappears or is tampered with,
+      // the safest fallback is to clear Orca's override and let terminals use
+      // the ambient system OpenCode state instead of keeping a broken account
+      // selected.
+      this.store.updateSettings({ activeOpenCodeManagedAccountId: null })
+      console.warn('[opencode-accounts] Ignoring invalid managed data root:', error)
+      return null
+    }
+  }
+
+  private getSnapshot(): OpenCodeAccountsState {
+    const settings = this.store.getSettings()
+    return {
+      accounts: settings.openCodeManagedAccounts
+        .map((account) => this.toSummary(account))
+        .sort((a, b) => b.updatedAt - a.updatedAt),
+      activeAccountId: settings.activeOpenCodeManagedAccountId
+    }
+  }
+
+  private getActiveAccount(): OpenCodeManagedAccount | null {
+    this.normalizeActiveSelection()
+    const settings = this.store.getSettings()
+    if (!settings.activeOpenCodeManagedAccountId) {
+      return null
+    }
+    return (
+      settings.openCodeManagedAccounts.find(
+        (entry) => entry.id === settings.activeOpenCodeManagedAccountId
+      ) ?? null
+    )
+  }
+
+  private toSummary(account: OpenCodeManagedAccount): OpenCodeManagedAccountSummary {
+    return {
+      id: account.id,
+      label: account.label,
+      providerId: account.providerId,
+      keyHint: account.keyHint,
+      createdAt: account.createdAt,
+      updatedAt: account.updatedAt,
+      lastAuthenticatedAt: account.lastAuthenticatedAt
+    }
+  }
+
+  private requireAccount(accountId: string): OpenCodeManagedAccount {
+    const settings = this.store.getSettings()
+    const account = settings.openCodeManagedAccounts.find((entry) => entry.id === accountId)
+    if (!account) {
+      throw new Error('That OpenCode account no longer exists.')
+    }
+    return account
+  }
+
+  private normalizeActiveSelection(): void {
+    const settings = this.store.getSettings()
+    if (!settings.activeOpenCodeManagedAccountId) {
+      return
+    }
+    const hasActiveAccount = settings.openCodeManagedAccounts.some(
+      (entry) => entry.id === settings.activeOpenCodeManagedAccountId
+    )
+    if (!hasActiveAccount) {
+      this.store.updateSettings({ activeOpenCodeManagedAccountId: null })
+    }
+  }
+
+  private requireLabel(label: string): string {
+    const normalized = normalizeField(label)
+    if (!normalized) {
+      throw new Error('OpenCode account label is required.')
+    }
+    return normalized
+  }
+
+  private requireApiKey(apiKey: string): string {
+    const normalized = normalizeField(apiKey)
+    if (!normalized) {
+      throw new Error('OpenCode Go API key is required.')
+    }
+    return normalized
+  }
+
+  private getManagedAccountsRoot(): string {
+    const root = join(app.getPath('userData'), 'opencode-accounts')
+    mkdirSync(root, { recursive: true })
+    return root
+  }
+
+  private createManagedDataRoot(accountId: string): string {
+    const managedDataPath = join(this.getManagedAccountsRoot(), accountId, 'xdg-data')
+    mkdirSync(managedDataPath, { recursive: true })
+    // Why: OpenCode's XDG data root is not a single auth file. Leaving an
+    // ownership marker at the managed root lets Orca later prove the path is
+    // one it created before deleting anything recursively.
+    writeFileSync(join(managedDataPath, '.orca-managed-opencode-data'), `${accountId}\n`, 'utf-8')
+    return this.assertManagedDataPath(managedDataPath)
+  }
+
+  private assertManagedDataPath(candidatePath: string): string {
+    const rootPath = this.getManagedAccountsRoot()
+    const resolvedCandidate = resolve(candidatePath)
+    const resolvedRoot = resolve(rootPath)
+    const canonicalCandidate = realpathSync(resolvedCandidate)
+    const canonicalRoot = realpathSync(resolvedRoot)
+    const relativePath = relative(canonicalRoot, canonicalCandidate)
+    const escaped =
+      relativePath === '' ||
+      relativePath === '.' ||
+      relativePath.startsWith('..') ||
+      relativePath.includes(`..${sep}`)
+
+    if (escaped) {
+      throw new Error('Managed OpenCode data root escaped Orca account storage.')
+    }
+
+    if (!existsSync(join(canonicalCandidate, '.orca-managed-opencode-data'))) {
+      throw new Error('Managed OpenCode data root is missing Orca ownership marker.')
+    }
+
+    return canonicalCandidate
+  }
+
+  private writeManagedAuthFile(managedDataPath: string, apiKey: string): void {
+    const canonicalManagedDataPath = this.assertManagedDataPath(managedDataPath)
+    const providerDir = join(canonicalManagedDataPath, 'opencode')
+    mkdirSync(providerDir, { recursive: true })
+    writeFileSync(
+      join(providerDir, 'auth.json'),
+      JSON.stringify(
+        {
+          [OPENCODE_PROVIDER_ID]: {
+            type: 'api',
+            key: apiKey
+          }
+        },
+        null,
+        2
+      ),
+      'utf-8'
+    )
+  }
+
+  private safeRemoveManagedDataRoot(candidatePath: string): void {
+    let managedDataPath: string
+    try {
+      managedDataPath = this.assertManagedDataPath(candidatePath)
+    } catch (error) {
+      console.warn('[opencode-accounts] Refusing to remove untrusted managed data root:', error)
+      return
+    }
+
+    rmSync(managedDataPath, { recursive: true, force: true })
+  }
+}

--- a/src/main/opencode-accounts/service.ts
+++ b/src/main/opencode-accounts/service.ts
@@ -2,7 +2,7 @@
 account lifecycle, credential-file writes, and managed-path safety together so
 the trusted boundary around Orca-managed API keys stays easy to audit. */
 import { randomUUID } from 'node:crypto'
-import { existsSync, mkdirSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
 import { join, relative, resolve, sep } from 'node:path'
 import { app } from 'electron'
 import type {
@@ -105,12 +105,11 @@ export class OpenCodeAccountService {
         ? null
         : settings.activeOpenCodeManagedAccountId
 
+    this.safeRemoveManagedDataRoot(account.managedDataPath, account.id)
     this.store.updateSettings({
       openCodeManagedAccounts: nextAccounts,
       activeOpenCodeManagedAccountId: nextActiveId
     })
-
-    this.safeRemoveManagedDataRoot(account.managedDataPath)
     return this.getSnapshot()
   }
 
@@ -133,7 +132,7 @@ export class OpenCodeAccountService {
     }
 
     try {
-      return this.assertManagedDataPath(account.managedDataPath)
+      return this.assertManagedDataPath(account.managedDataPath, account.id)
     } catch (error) {
       // Why: if the managed OpenCode data root disappears or is tampered with,
       // the safest fallback is to clear Orca's override and let terminals use
@@ -231,10 +230,10 @@ export class OpenCodeAccountService {
     // ownership marker at the managed root lets Orca later prove the path is
     // one it created before deleting anything recursively.
     writeFileSync(join(managedDataPath, '.orca-managed-opencode-data'), `${accountId}\n`, 'utf-8')
-    return this.assertManagedDataPath(managedDataPath)
+    return this.assertManagedDataPath(managedDataPath, accountId)
   }
 
-  private assertManagedDataPath(candidatePath: string): string {
+  private assertManagedDataPath(candidatePath: string, expectedAccountId?: string): string {
     const rootPath = this.getManagedAccountsRoot()
     const resolvedCandidate = resolve(candidatePath)
     const resolvedRoot = resolve(rootPath)
@@ -251,8 +250,15 @@ export class OpenCodeAccountService {
       throw new Error('Managed OpenCode data root escaped Orca account storage.')
     }
 
-    if (!existsSync(join(canonicalCandidate, '.orca-managed-opencode-data'))) {
+    const markerPath = join(canonicalCandidate, '.orca-managed-opencode-data')
+    if (!existsSync(markerPath)) {
       throw new Error('Managed OpenCode data root is missing Orca ownership marker.')
+    }
+    if (expectedAccountId) {
+      const markerAccountId = readFileSync(markerPath, 'utf-8').trim()
+      if (markerAccountId !== expectedAccountId) {
+        throw new Error('Managed OpenCode data root marker did not match the saved account id.')
+      }
     }
 
     return canonicalCandidate
@@ -278,15 +284,20 @@ export class OpenCodeAccountService {
     )
   }
 
-  private safeRemoveManagedDataRoot(candidatePath: string): void {
+  private safeRemoveManagedDataRoot(candidatePath: string, expectedAccountId: string): void {
     let managedDataPath: string
     try {
-      managedDataPath = this.assertManagedDataPath(candidatePath)
+      managedDataPath = this.assertManagedDataPath(candidatePath, expectedAccountId)
     } catch (error) {
       console.warn('[opencode-accounts] Refusing to remove untrusted managed data root:', error)
-      return
+      throw error
     }
 
-    rmSync(managedDataPath, { recursive: true, force: true })
+    try {
+      rmSync(managedDataPath, { recursive: true, force: true })
+    } catch (error) {
+      console.warn('[opencode-accounts] Failed to remove managed data root:', error)
+      throw new Error('OpenCode account removal failed while deleting the managed data root.')
+    }
   }
 }

--- a/src/main/window/attach-main-window-services.ts
+++ b/src/main/window/attach-main-window-services.ts
@@ -27,11 +27,18 @@ export function attachMainWindowServices(
   mainWindow: BrowserWindow,
   store: Store,
   runtime: OrcaRuntimeService,
-  getSelectedCodexHomePath?: () => string | null
+  getSelectedCodexHomePath?: () => string | null,
+  getSelectedOpenCodeDataPath?: () => string | null
 ): void {
   registerRepoHandlers(mainWindow, store)
   registerWorktreeHandlers(mainWindow, store)
-  registerPtyHandlers(mainWindow, runtime, getSelectedCodexHomePath, () => store.getSettings())
+  registerPtyHandlers(
+    mainWindow,
+    runtime,
+    getSelectedCodexHomePath,
+    getSelectedOpenCodeDataPath,
+    () => store.getSettings()
+  )
   // Why: GC runs on a 10s delay so live worktree enumeration completes first.
   // Uses git worktree list (not store.getWorktreeMeta) because untouched
   // worktrees have no metadata entries — see design doc §7.6.

--- a/src/preload/api-types.d.ts
+++ b/src/preload/api-types.d.ts
@@ -19,6 +19,7 @@ import type {
   IssueInfo,
   NotificationDispatchRequest,
   NotificationDispatchResult,
+  OpenCodeAccountsState,
   OpenCodeStatusEvent,
   OrcaHooks,
   PersistedUIState,
@@ -301,6 +302,17 @@ export type PreloadApi = {
     reauthenticate: (args: { accountId: string }) => Promise<CodexRateLimitAccountsState>
     remove: (args: { accountId: string }) => Promise<CodexRateLimitAccountsState>
     select: (args: { accountId: string | null }) => Promise<CodexRateLimitAccountsState>
+  }
+  openCodeAccounts: {
+    list: () => Promise<OpenCodeAccountsState>
+    add: (args: { label: string; apiKey: string }) => Promise<OpenCodeAccountsState>
+    reauthenticate: (args: {
+      accountId: string
+      label: string
+      apiKey: string
+    }) => Promise<OpenCodeAccountsState>
+    remove: (args: { accountId: string }) => Promise<OpenCodeAccountsState>
+    select: (args: { accountId: string | null }) => Promise<OpenCodeAccountsState>
   }
   cli: {
     getInstallStatus: () => Promise<CliInstallStatus>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -364,6 +364,21 @@ const api = {
       ipcRenderer.invoke('codexAccounts:select', args)
   },
 
+  openCodeAccounts: {
+    list: (): Promise<unknown> => ipcRenderer.invoke('openCodeAccounts:list'),
+    add: (args: { label: string; apiKey: string }): Promise<unknown> =>
+      ipcRenderer.invoke('openCodeAccounts:add', args),
+    reauthenticate: (args: {
+      accountId: string
+      label: string
+      apiKey: string
+    }): Promise<unknown> => ipcRenderer.invoke('openCodeAccounts:reauthenticate', args),
+    remove: (args: { accountId: string }): Promise<unknown> =>
+      ipcRenderer.invoke('openCodeAccounts:remove', args),
+    select: (args: { accountId: string | null }): Promise<unknown> =>
+      ipcRenderer.invoke('openCodeAccounts:select', args)
+  },
+
   cli: {
     getInstallStatus: (): Promise<CliInstallStatus> => ipcRenderer.invoke('cli:getInstallStatus'),
     install: (): Promise<CliInstallStatus> => ipcRenderer.invoke('cli:install'),

--- a/src/renderer/src/components/settings/GeneralPane.tsx
+++ b/src/renderer/src/components/settings/GeneralPane.tsx
@@ -1091,15 +1091,8 @@ export function GeneralPane({ settings, updateSettings }: GeneralPaneProps): Rea
                 const isBusy = openCodeAction !== 'idle'
 
                 return (
-                  <button
+                  <div
                     key={account.id}
-                    type="button"
-                    onClick={() =>
-                      void runOpenCodeAccountAction(`select:${account.id}`, () =>
-                        window.api.openCodeAccounts.select({ accountId: account.id })
-                      )
-                    }
-                    disabled={isBusy}
                     className={`flex w-full items-center justify-between gap-3 rounded-md border px-3 py-2.5 text-left transition-colors ${
                       isActive
                         ? 'border-foreground/20 bg-accent/15'
@@ -1107,7 +1100,16 @@ export function GeneralPane({ settings, updateSettings }: GeneralPaneProps): Rea
                     }`}
                   >
                     <div className="flex w-full items-center justify-between gap-3 max-md:flex-col max-md:items-start">
-                      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                      <button
+                        type="button"
+                        onClick={() =>
+                          void runOpenCodeAccountAction(`select:${account.id}`, () =>
+                            window.api.openCodeAccounts.select({ accountId: account.id })
+                          )
+                        }
+                        disabled={isBusy}
+                        className="flex min-w-0 flex-1 flex-col gap-0.5 text-left"
+                      >
                         <div className="flex min-w-0 items-center gap-2">
                           <span className="truncate text-sm font-medium">{account.label}</span>
                           {isActive ? (
@@ -1128,7 +1130,7 @@ export function GeneralPane({ settings, updateSettings }: GeneralPaneProps): Rea
                             {formatAccountTimestamp(account.lastAuthenticatedAt)}
                           </span>
                         </div>
-                      </div>
+                      </button>
 
                       <div className="flex shrink-0 items-center justify-end gap-1 max-md:w-full max-md:flex-wrap">
                         <Button
@@ -1169,7 +1171,7 @@ export function GeneralPane({ settings, updateSettings }: GeneralPaneProps): Rea
                         </Button>
                       </div>
                     </div>
-                  </button>
+                  </div>
                 )
               })}
             </div>

--- a/src/renderer/src/components/settings/GeneralPane.tsx
+++ b/src/renderer/src/components/settings/GeneralPane.tsx
@@ -2,7 +2,11 @@
    splitting individual settings into separate files would scatter related controls without a
    meaningful abstraction boundary. */
 import { useEffect, useState } from 'react'
-import type { CodexRateLimitAccountsState, GlobalSettings } from '../../../../shared/types'
+import type {
+  CodexRateLimitAccountsState,
+  GlobalSettings,
+  OpenCodeAccountsState
+} from '../../../../shared/types'
 import { Badge } from '../ui/badge'
 import { Button } from '../ui/button'
 import { Input } from '../ui/input'
@@ -26,6 +30,7 @@ import {
   GENERAL_CACHE_TIMER_SEARCH_ENTRIES,
   GENERAL_CLI_SEARCH_ENTRIES,
   GENERAL_EDITOR_SEARCH_ENTRIES,
+  GENERAL_OPENCODE_ACCOUNTS_SEARCH_ENTRIES,
   GENERAL_PANE_SEARCH_ENTRIES,
   GENERAL_UPDATE_SEARCH_ENTRIES,
   GENERAL_WORKSPACE_SEARCH_ENTRIES
@@ -101,6 +106,16 @@ function getCodexAccountErrorDescription(error: unknown): string {
   return message || 'Codex sign-in failed. Please try again.'
 }
 
+function getOpenCodeAccountErrorDescription(error: unknown): string {
+  return (
+    String((error as Error)?.message ?? error)
+      .replace(/^Error occurred in handler for 'openCodeAccounts:[^']+':\s*/i, '')
+      .replace(/^Error invoking remote method 'openCodeAccounts:[^']+':\s*/i, '')
+      .replace(/^Error:\s*/i, '')
+      .trim() || 'OpenCode account update failed. Please try again.'
+  )
+}
+
 export function GeneralPane({ settings, updateSettings }: GeneralPaneProps): React.JSX.Element {
   const searchQuery = useAppStore((s) => s.settingsSearchQuery)
   const updateStatus = useAppStore((s) => s.updateStatus)
@@ -121,10 +136,23 @@ export function GeneralPane({ settings, updateSettings }: GeneralPaneProps): Rea
     accounts: [],
     activeAccountId: null
   })
+  const [openCodeAccounts, setOpenCodeAccounts] = useState<OpenCodeAccountsState>({
+    accounts: [],
+    activeAccountId: null
+  })
   const [codexAction, setCodexAction] = useState<
     'idle' | 'adding' | `reauth:${string}` | `remove:${string}` | `select:${string | 'system'}`
   >('idle')
+  const [openCodeAction, setOpenCodeAction] = useState<
+    'idle' | `save:${'add' | string}` | `remove:${string}` | `select:${string | 'system'}`
+  >('idle')
   const [removeAccountId, setRemoveAccountId] = useState<string | null>(null)
+  const [removeOpenCodeAccountId, setRemoveOpenCodeAccountId] = useState<string | null>(null)
+  const [openCodeDialogAccountId, setOpenCodeDialogAccountId] = useState<string | 'add' | null>(
+    null
+  )
+  const [openCodeLabelDraft, setOpenCodeLabelDraft] = useState('')
+  const [openCodeApiKeyDraft, setOpenCodeApiKeyDraft] = useState('')
 
   useEffect(() => {
     window.api.updater.getVersion().then(setAppVersion)
@@ -153,6 +181,31 @@ export function GeneralPane({ settings, updateSettings }: GeneralPaneProps): Rea
     }
 
     void loadCodexAccounts()
+
+    return () => {
+      stale = true
+    }
+  }, [])
+
+  useEffect(() => {
+    let stale = false
+
+    const loadOpenCodeAccounts = async (): Promise<void> => {
+      try {
+        const next = await window.api.openCodeAccounts.list()
+        if (!stale) {
+          setOpenCodeAccounts(next)
+        }
+      } catch (error) {
+        if (!stale) {
+          toast.error('Could not load OpenCode accounts.', {
+            description: String((error as Error)?.message ?? error)
+          })
+        }
+      }
+    }
+
+    void loadOpenCodeAccounts()
 
     return () => {
       stale = true
@@ -201,6 +254,11 @@ export function GeneralPane({ settings, updateSettings }: GeneralPaneProps): Rea
     await fetchSettings()
   }
 
+  const syncOpenCodeAccounts = async (next: OpenCodeAccountsState): Promise<void> => {
+    setOpenCodeAccounts(next)
+    await fetchSettings()
+  }
+
   const formatAccountTimestamp = (timestamp: number): string => {
     return new Date(timestamp).toLocaleString(undefined, {
       month: 'short',
@@ -240,6 +298,30 @@ export function GeneralPane({ settings, updateSettings }: GeneralPaneProps): Rea
       setCodexAction('idle')
     }
   }
+
+  const runOpenCodeAccountAction = async (
+    action: typeof openCodeAction,
+    operation: () => Promise<OpenCodeAccountsState>
+  ): Promise<void> => {
+    setOpenCodeAction(action)
+    try {
+      const next = await operation()
+      await syncOpenCodeAccounts(next)
+    } catch (error) {
+      toast.error('OpenCode account update failed.', {
+        description: getOpenCodeAccountErrorDescription(error)
+      })
+    } finally {
+      setOpenCodeAction('idle')
+    }
+  }
+
+  const selectedOpenCodeDialogAccount =
+    openCodeDialogAccountId && openCodeDialogAccountId !== 'add'
+      ? (openCodeAccounts.accounts.find((account) => account.id === openCodeDialogAccountId) ??
+        null)
+      : null
+  const openCodeDialogMode = openCodeDialogAccountId === 'add' ? 'add' : 'reauth'
 
   const visibleSections = [
     matchesSettingsSearch(searchQuery, GENERAL_WORKSPACE_SEARCH_ENTRIES) ? (
@@ -918,6 +1000,183 @@ export function GeneralPane({ settings, updateSettings }: GeneralPaneProps): Rea
         </SearchableSetting>
       </section>
     ) : null,
+    matchesSettingsSearch(searchQuery, GENERAL_OPENCODE_ACCOUNTS_SEARCH_ENTRIES) ? (
+      <section
+        key="opencode-accounts"
+        id="general-opencode-accounts"
+        className="space-y-4 scroll-mt-6"
+      >
+        <div className="space-y-1">
+          <h3 className="text-sm font-semibold">OpenCode Accounts</h3>
+          <p className="text-xs text-muted-foreground">
+            Add and switch between OpenCode Go credentials in Orca.
+          </p>
+          <p className="text-xs text-muted-foreground">
+            Orca stores managed OpenCode Go API keys in its local app data and injects the selected
+            one only into new Orca terminals.
+          </p>
+        </div>
+
+        <SearchableSetting
+          title="OpenCode Accounts"
+          description="Manage which OpenCode Go credential Orca uses for new terminal sessions."
+          keywords={['opencode', 'open code', 'account', 'api key', 'credential', 'switch']}
+          className="space-y-3 px-1 py-2"
+        >
+          <div className="flex items-center justify-between gap-3">
+            <div className="space-y-0.5">
+              <Label>Accounts</Label>
+              <p className="text-xs text-muted-foreground">
+                Add an OpenCode Go API key for Orca-managed switching.
+              </p>
+            </div>
+            <Button
+              variant="outline"
+              size="xs"
+              onClick={() => {
+                setOpenCodeDialogAccountId('add')
+                setOpenCodeLabelDraft('')
+                setOpenCodeApiKeyDraft('')
+              }}
+              disabled={openCodeAction !== 'idle'}
+              className="gap-1.5"
+            >
+              <Plus className="size-3" />
+              Add Account
+            </Button>
+          </div>
+
+          {openCodeAccounts.accounts.length === 0 ? (
+            <div className="rounded-md border border-dashed border-border/70 px-3 py-4 text-xs text-muted-foreground">
+              No managed OpenCode accounts yet. Orca will keep using your system default OpenCode
+              credential until you add one here.
+            </div>
+          ) : (
+            <div className="space-y-2">
+              <button
+                type="button"
+                onClick={() =>
+                  void runOpenCodeAccountAction('select:system', () =>
+                    window.api.openCodeAccounts.select({ accountId: null })
+                  )
+                }
+                disabled={openCodeAction !== 'idle'}
+                className={`flex w-full items-center justify-between gap-3 rounded-md border px-3 py-2.5 text-left transition-colors ${
+                  openCodeAccounts.activeAccountId === null
+                    ? 'border-foreground/20 bg-accent/15'
+                    : 'border-border/70 hover:border-border hover:bg-accent/8'
+                } disabled:cursor-default disabled:opacity-100`}
+              >
+                <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                  <div className="flex min-w-0 items-center gap-2">
+                    <span className="truncate text-sm font-medium">System default</span>
+                    {openCodeAccounts.activeAccountId === null ? (
+                      <Badge
+                        variant="outline"
+                        className="h-4 shrink-0 rounded px-1.5 text-[10px] font-medium leading-none text-foreground/80"
+                      >
+                        Active
+                      </Badge>
+                    ) : null}
+                  </div>
+                  <span className="truncate text-[11px] text-muted-foreground">
+                    Use your current system OpenCode credential.
+                  </span>
+                </div>
+              </button>
+              {openCodeAccounts.accounts.map((account) => {
+                const isActive = openCodeAccounts.activeAccountId === account.id
+                const isSaving = openCodeAction === `save:${account.id}`
+                const isRemoving = openCodeAction === `remove:${account.id}`
+                const isBusy = openCodeAction !== 'idle'
+
+                return (
+                  <button
+                    key={account.id}
+                    type="button"
+                    onClick={() =>
+                      void runOpenCodeAccountAction(`select:${account.id}`, () =>
+                        window.api.openCodeAccounts.select({ accountId: account.id })
+                      )
+                    }
+                    disabled={isBusy}
+                    className={`flex w-full items-center justify-between gap-3 rounded-md border px-3 py-2.5 text-left transition-colors ${
+                      isActive
+                        ? 'border-foreground/20 bg-accent/15'
+                        : 'border-border/70 hover:border-border hover:bg-accent/8'
+                    }`}
+                  >
+                    <div className="flex w-full items-center justify-between gap-3 max-md:flex-col max-md:items-start">
+                      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                        <div className="flex min-w-0 items-center gap-2">
+                          <span className="truncate text-sm font-medium">{account.label}</span>
+                          {isActive ? (
+                            <Badge
+                              variant="outline"
+                              className="h-4 shrink-0 rounded px-1.5 text-[10px] font-medium leading-none text-foreground/80"
+                            >
+                              Active
+                            </Badge>
+                          ) : null}
+                        </div>
+                        <div className="flex min-w-0 items-center gap-1.5 text-[11px] text-muted-foreground max-sm:flex-wrap">
+                          <span className="shrink-0">OpenCode Go</span>
+                          <span className="shrink-0 opacity-50">•</span>
+                          <span className="shrink-0">{account.keyHint}</span>
+                          <span className="shrink-0 opacity-50">•</span>
+                          <span className="shrink-0">
+                            {formatAccountTimestamp(account.lastAuthenticatedAt)}
+                          </span>
+                        </div>
+                      </div>
+
+                      <div className="flex shrink-0 items-center justify-end gap-1 max-md:w-full max-md:flex-wrap">
+                        <Button
+                          variant="ghost"
+                          size="xs"
+                          onClick={(event) => {
+                            event.stopPropagation()
+                            setOpenCodeDialogAccountId(account.id)
+                            setOpenCodeLabelDraft(account.label)
+                            setOpenCodeApiKeyDraft('')
+                          }}
+                          disabled={isBusy}
+                          className="h-6 px-2 text-muted-foreground hover:text-foreground"
+                        >
+                          {isSaving ? (
+                            <Loader2 className="size-3 animate-spin" />
+                          ) : (
+                            <RefreshCw className="size-3" />
+                          )}
+                          Re-authenticate
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="xs"
+                          onClick={(event) => {
+                            event.stopPropagation()
+                            setRemoveOpenCodeAccountId(account.id)
+                          }}
+                          disabled={isBusy}
+                          className="h-6 px-2 text-muted-foreground hover:text-destructive"
+                        >
+                          {isRemoving ? (
+                            <Loader2 className="size-3 animate-spin" />
+                          ) : (
+                            <Trash2 className="size-3" />
+                          )}
+                          Remove
+                        </Button>
+                      </div>
+                    </div>
+                  </button>
+                )
+              })}
+            </div>
+          )}
+        </SearchableSetting>
+      </section>
+    ) : null,
     matchesSettingsSearch(searchQuery, GENERAL_UPDATE_SEARCH_ENTRIES) ? (
       <section key="updates" className="space-y-4">
         <div className="space-y-1">
@@ -1020,6 +1279,106 @@ export function GeneralPane({ settings, updateSettings }: GeneralPaneProps): Rea
   return (
     <div className="space-y-8">
       <Dialog
+        open={openCodeDialogAccountId !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setOpenCodeDialogAccountId(null)
+            setOpenCodeLabelDraft('')
+            setOpenCodeApiKeyDraft('')
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {openCodeDialogMode === 'add'
+                ? 'Add OpenCode Account'
+                : 'Re-authenticate OpenCode Account'}
+            </DialogTitle>
+            <DialogDescription>
+              {openCodeDialogMode === 'add'
+                ? 'Save an OpenCode Go API key in Orca so you can switch accounts without changing your system credential.'
+                : 'Update the stored OpenCode Go API key for this Orca-managed account.'}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3">
+            <div className="space-y-2">
+              <Label htmlFor="opencode-account-label">Label</Label>
+              <Input
+                id="opencode-account-label"
+                value={openCodeLabelDraft}
+                onChange={(event) => setOpenCodeLabelDraft(event.target.value)}
+                placeholder="Work account"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="opencode-account-api-key">OpenCode Go API Key</Label>
+              <Input
+                id="opencode-account-api-key"
+                type="password"
+                value={openCodeApiKeyDraft}
+                onChange={(event) => setOpenCodeApiKeyDraft(event.target.value)}
+                placeholder={
+                  openCodeDialogMode === 'add'
+                    ? 'sk-...'
+                    : `Enter a new API key for ${selectedOpenCodeDialogAccount?.label ?? 'this account'}`
+                }
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => {
+                setOpenCodeDialogAccountId(null)
+                setOpenCodeLabelDraft('')
+                setOpenCodeApiKeyDraft('')
+              }}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={() => {
+                const label = openCodeLabelDraft.trim()
+                const apiKey = openCodeApiKeyDraft.trim()
+                if (!label || !apiKey) {
+                  toast.error('OpenCode account details are incomplete.', {
+                    description: 'Both a label and an OpenCode Go API key are required.'
+                  })
+                  return
+                }
+
+                const dialogAccountId = openCodeDialogAccountId
+                setOpenCodeDialogAccountId(null)
+                setOpenCodeLabelDraft('')
+                setOpenCodeApiKeyDraft('')
+
+                if (dialogAccountId === 'add') {
+                  void runOpenCodeAccountAction('save:add', () =>
+                    window.api.openCodeAccounts.add({ label, apiKey })
+                  )
+                  return
+                }
+
+                if (!dialogAccountId) {
+                  return
+                }
+
+                void runOpenCodeAccountAction(`save:${dialogAccountId}`, () =>
+                  window.api.openCodeAccounts.reauthenticate({
+                    accountId: dialogAccountId,
+                    label,
+                    apiKey
+                  })
+                )
+              }}
+            >
+              {openCodeDialogMode === 'add' ? 'Add Account' : 'Save API Key'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+      <Dialog
         open={removeAccountId !== null}
         onOpenChange={(open) => !open && setRemoveAccountId(null)}
       >
@@ -1045,6 +1404,40 @@ export function GeneralPane({ settings, updateSettings }: GeneralPaneProps): Rea
                 setRemoveAccountId(null)
                 void runCodexAccountAction(`remove:${accountId}`, () =>
                   window.api.codexAccounts.remove({ accountId })
+                )
+              }}
+            >
+              Remove Account
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+      <Dialog
+        open={removeOpenCodeAccountId !== null}
+        onOpenChange={(open) => !open && setRemoveOpenCodeAccountId(null)}
+      >
+        <DialogContent showCloseButton={false}>
+          <DialogHeader>
+            <DialogTitle>Remove OpenCode Account?</DialogTitle>
+            <DialogDescription>
+              Orca will delete the managed OpenCode credential for this saved account. If it is
+              currently active, Orca falls back to the system default OpenCode credential.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setRemoveOpenCodeAccountId(null)}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => {
+                const accountId = removeOpenCodeAccountId
+                if (!accountId) {
+                  return
+                }
+                setRemoveOpenCodeAccountId(null)
+                void runOpenCodeAccountAction(`remove:${accountId}`, () =>
+                  window.api.openCodeAccounts.remove({ accountId })
                 )
               }}
             >

--- a/src/renderer/src/components/settings/general-search.ts
+++ b/src/renderer/src/components/settings/general-search.ts
@@ -104,6 +104,19 @@ export const GENERAL_CODEX_ACCOUNTS_SEARCH_ENTRIES: SettingsSearchEntry[] = [
   }
 ]
 
+export const GENERAL_OPENCODE_ACCOUNTS_SEARCH_ENTRIES: SettingsSearchEntry[] = [
+  {
+    title: 'OpenCode Accounts',
+    description: 'Manage which saved OpenCode Go credential Orca injects into new terminals.',
+    keywords: ['opencode', 'open code', 'account', 'api key', 'credential', 'switch']
+  },
+  {
+    title: 'Active OpenCode Account',
+    description: 'Choose which saved OpenCode Go account powers new Orca OpenCode sessions.',
+    keywords: ['opencode', 'open code', 'account', 'switch', 'active', 'api key']
+  }
+]
+
 export const GENERAL_PANE_SEARCH_ENTRIES: SettingsSearchEntry[] = [
   ...GENERAL_WORKSPACE_SEARCH_ENTRIES,
   ...GENERAL_BROWSER_SEARCH_ENTRIES,
@@ -111,5 +124,6 @@ export const GENERAL_PANE_SEARCH_ENTRIES: SettingsSearchEntry[] = [
   ...GENERAL_CLI_SEARCH_ENTRIES,
   ...GENERAL_CACHE_TIMER_SEARCH_ENTRIES,
   ...GENERAL_CODEX_ACCOUNTS_SEARCH_ENTRIES,
+  ...GENERAL_OPENCODE_ACCOUNTS_SEARCH_ENTRIES,
   ...GENERAL_UPDATE_SEARCH_ENTRIES
 ]

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -117,6 +117,8 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     promptCacheTtlMs: 300_000,
     codexManagedAccounts: [],
     activeCodexManagedAccountId: null,
+    openCodeManagedAccounts: [],
+    activeOpenCodeManagedAccountId: null,
     terminalScopeHistoryByWorktree: true
   }
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -439,6 +439,32 @@ export type CodexRateLimitAccountsState = {
   activeAccountId: string | null
 }
 
+export type OpenCodeManagedAccount = {
+  id: string
+  label: string
+  managedDataPath: string
+  providerId: 'opencode-go'
+  keyHint: string
+  createdAt: number
+  updatedAt: number
+  lastAuthenticatedAt: number
+}
+
+export type OpenCodeManagedAccountSummary = {
+  id: string
+  label: string
+  providerId: 'opencode-go'
+  keyHint: string
+  createdAt: number
+  updatedAt: number
+  lastAuthenticatedAt: number
+}
+
+export type OpenCodeAccountsState = {
+  accounts: OpenCodeManagedAccountSummary[]
+  activeAccountId: string | null
+}
+
 export type GlobalSettings = {
   workspaceDir: string
   nestWorkspaces: boolean
@@ -491,6 +517,13 @@ export type GlobalSettings = {
    *  analytics and external terminal sessions. */
   codexManagedAccounts: CodexManagedAccount[]
   activeCodexManagedAccountId: string | null
+  /** Why: OpenCode account routing needs the same early main-process
+   *  availability as Codex account routing so new PTYs can launch against the
+   *  selected managed `XDG_DATA_HOME` before the renderer mounts. Persist the
+   *  account roster here, but keep it scoped to Orca-managed terminals only so
+   *  external shells continue using the user's ambient OpenCode auth. */
+  openCodeManagedAccounts: OpenCodeManagedAccount[]
+  activeOpenCodeManagedAccountId: string | null
   /** When true, each worktree gets its own shell history file so ArrowUp
    *  does not surface commands from other worktrees. Defaults to true.
    *  Disable to revert to shared global shell history. */


### PR DESCRIPTION
## What changed

This adds Orca-managed OpenCode Go account switching, modeled after Orca's existing managed Codex account flow.

- adds a main-process OpenCode account service that stores Orca-managed OpenCode Go credentials in isolated app-owned data roots
- persists the saved account roster and active selection in Orca settings
- injects the selected OpenCode account into new Orca PTYs via `XDG_DATA_HOME`, while leaving system-level OpenCode state untouched
- adds Settings UI to add, select, re-authenticate, and remove managed OpenCode accounts
- wires IPC/preload/types and PTY tests for the new account-routing path

## Why

OpenCode sessions inside Orca currently share the ambient system OpenCode credential, which makes multi-account switching awkward and couples Orca terminal behavior to the user's global CLI state.

This change gives Orca the same managed-account isolation pattern it already uses for Codex, but adapted to OpenCode's credential storage model.

## Impact

- users can save multiple OpenCode Go credentials locally in Orca
- switching accounts affects new Orca-launched OpenCode terminals only
- removing or deselecting a managed account falls back to the system default OpenCode credential

## Validation

- `pnpm test -- --run src/main/ipc/pty.test.ts src/main/ipc/register-core-handlers.test.ts`
- `pnpm typecheck:node`
- `pnpm typecheck:web`

Risk: high
Historic risk metadata backfill based on the existing `risk:high` label.

## ELI5

Managed OpenCode Go accounts like managed Codex: save multiple accounts in Orca, switch the active one, and inject it into new terminals without touching system OpenCode state.
