### PR TITLE
Fix cursor jump when typing in markdown list items

### DIFF
--- a/src/renderer/src/components/editor/RichMarkdownEditor.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownEditor.tsx
@@ -443,6 +443,17 @@ export default function RichMarkdownEditor({
       return
     }
 
+    // Why: the debounced onUpdate serializes the editor and feeds it back
+    // through onContentChange → editorDrafts → the content prop.  If the
+    // user typed between the debounce firing and this effect running, the
+    // editor already contains newer content than the prop.  Comparing
+    // against lastCommittedMarkdownRef (which is set in the same tick as
+    // onContentChange) lets us recognise our own serialization and skip the
+    // destructive setContent that would reset the cursor mid-typing.
+    if (content === lastCommittedMarkdownRef.current) {
+      return
+    }
+
     const currentMarkdown = editor.getMarkdown()
     if (currentMarkdown === content) {
       return


### PR DESCRIPTION
## Summary
- Fixes intermittent cursor jump that occurs when typing in list entries in the rich markdown editor
- Root cause: debounced `onUpdate` serialization feeds back through the `content` prop; if the user types between the debounce firing and the `useEffect` running, the stale prop triggers `setContent`, resetting the cursor position
- Adds an early-return guard comparing the `content` prop against `lastCommittedMarkdownRef` to skip internal (self-originated) content updates while still allowing external file changes to overwrite the editor

## Test plan
- [x] All 1539 existing editor tests pass
- [ ] Open a markdown file in rich mode, type rapidly in a list item — cursor should stay in place
- [ ] Edit a markdown file externally while it's open in rich mode — editor should still pick up the external change
- [ ] Cmd+S should still save correctly