### PR TITLE
feat: enable split groups renderer path

### DIFF
--- a/docs/split-groups-rollout-pr6.md
+++ b/docs/split-groups-rollout-pr6.md
@@ -1,0 +1,14 @@
+# Split Groups PR 6: Enable Split Groups
+
+This branch turns split groups on after the earlier model, lifecycle, restore,
+and renderer-ownership branches are in place.
+
+Scope:
+- remove the temporary rollout gate from `Terminal.tsx`
+- make the split-group ownership path the active renderer path
+- keep only the small bootstrap fallback for cases where no layout exists yet
+
+What Is Actually Hooked Up In This PR:
+- split groups are live
+- `Terminal.tsx` always resolves through the split-group path when layout/group state exists
+- the temporary gate introduced in the dark-launch PR is removed instead of left behind as dead config

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "orca",
-  "version": "1.1.33-rc.3",
+  "version": "1.1.33-rc.4",
   "description": "An Electron application with React and TypeScript",
   "homepage": "https://github.com/stablyai/orca",
   "author": "stablyai",

--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -31,10 +31,6 @@ import { shouldAutoCreateInitialTerminal } from './terminal/initial-terminal'
 import CodexRestartChip from './CodexRestartChip'
 
 const EditorPanel = lazy(() => import('./editor/EditorPanel'))
-// Why: keep the split-group renderer path dark until dedicated Playwright
-// coverage lands. This branch keeps the implementation and correctness fixes,
-// but the user-visible rollout stays on the legacy workspace path by default.
-const ENABLE_SPLIT_GROUPS = false
 
 function Terminal(): React.JSX.Element | null {
   const activeWorktreeId = useAppStore((s) => s.activeWorktreeId)
@@ -120,9 +116,7 @@ function Terminal(): React.JSX.Element | null {
     [activeGroupIdByWorktree, groupsByWorktree, layoutByWorktree]
   )
   const effectiveActiveLayout = activeWorktreeId
-    ? ENABLE_SPLIT_GROUPS
-      ? getEffectiveLayoutForWorktree(activeWorktreeId)
-      : undefined
+    ? getEffectiveLayoutForWorktree(activeWorktreeId)
     : undefined
   const activeWorktree = activeWorktreeId
     ? (allWorktrees.find((worktree) => worktree.id === activeWorktreeId) ?? null)


### PR DESCRIPTION
## Summary
- Flips `ENABLE_SPLIT_GROUPS` to `true` in `Terminal.tsx`, making the split-group ownership path the active renderer path
- Builds on prerequisite work: dark-launch with correctness fixes (#643), split group surface ownership gating (#642), tab group workspace model extraction (#664), useEffect anti-pattern elimination (#665), memory leak fixes (#595), terminal jump-to-present (#660), and browser tab re-maximize fix (#666)
- Removes the temporary rollout gate introduced in the dark-launch PR instead of leaving it as dead config

## Context
This is PR 6 in the split groups rollout sequence. The earlier PRs landed the model, lifecycle, restore, and renderer-ownership foundations. This PR intentionally enables the feature now that those prerequisites are in place.

## Test plan
- [x] Verify split group layout renders correctly on app start
- [x] Verify creating, resizing, and closing split groups works
- [x] Verify terminal pane lifecycle (create/destroy) within split groups
- [x] Verify worktree switching preserves split group state
- [x] Verify fallback bootstrap path works when no layout/group state exists
- [x] Verify no regressions in single-pane (non-split) usage