### PR TITLE
fix: return to Orca landing screen after closing last terminal

### DIFF
--- a/src/renderer/src/store/slices/store-cascades.test.ts
+++ b/src/renderer/src/store/slices/store-cascades.test.ts
@@ -795,6 +795,62 @@ describe('setActiveWorktree', () => {
     expect(replacement.title).toBe('Terminal 1')
   })
 
+  it('returns to the landing state when closing the last terminal tab in the active worktree', () => {
+    const store = createTestStore()
+    const wt = 'repo1::/path/wt1'
+    const groupId = 'group-1'
+    const tabId = 'tab-1'
+    const unifiedTabId = 'unified-tab-1'
+
+    seedStore(store, {
+      worktreesByRepo: {
+        repo1: [makeWorktree({ id: wt, repoId: 'repo1', path: '/path/wt1' })]
+      },
+      activeWorktreeId: wt,
+      activeTabId: tabId,
+      activeTabType: 'terminal',
+      activeTabIdByWorktree: { [wt]: tabId },
+      activeTabTypeByWorktree: { [wt]: 'terminal' },
+      tabsByWorktree: {
+        [wt]: [makeTab({ id: tabId, worktreeId: wt })]
+      },
+      unifiedTabsByWorktree: {
+        [wt]: [
+          makeUnifiedTab({
+            id: unifiedTabId,
+            entityId: tabId,
+            worktreeId: wt,
+            groupId,
+            contentType: 'terminal',
+            label: 'Terminal 1'
+          })
+        ]
+      },
+      groupsByWorktree: {
+        [wt]: [
+          makeTabGroup({
+            id: groupId,
+            worktreeId: wt,
+            activeTabId: unifiedTabId,
+            tabOrder: [unifiedTabId]
+          })
+        ]
+      },
+      activeGroupIdByWorktree: { [wt]: groupId },
+      layoutByWorktree: {
+        [wt]: { type: 'leaf', groupId }
+      }
+    })
+
+    store.getState().closeTab(tabId)
+
+    const s = store.getState()
+    expect(s.activeWorktreeId).toBeNull()
+    expect(s.activeTabId).toBeNull()
+    expect(s.tabsByWorktree[wt]).toEqual([])
+    expect(s.unifiedTabsByWorktree[wt]).toEqual([])
+  })
+
   it('keeps terminal numbering stable when a live agent renames an existing tab', () => {
     const store = createTestStore()
     const wt = 'repo1::/path/wt1'

--- a/src/renderer/src/store/slices/tabs.ts
+++ b/src/renderer/src/store/slices/tabs.ts
@@ -538,6 +538,12 @@ export const createTabsSlice: StateCreator<AppState, [], [], TabsSlice> = (set, 
         nextLayoutByWorktree = collapsedState.layoutByWorktree
         nextActiveGroupIdByWorktree = collapsedState.activeGroupIdByWorktree
       }
+      const shouldDeactivateWorktree =
+        current.activeWorktreeId === worktreeId &&
+        nextTabs.length === 0 &&
+        (current.tabsByWorktree[worktreeId] ?? []).length === 0 &&
+        (current.browserTabsByWorktree[worktreeId] ?? []).length === 0 &&
+        !current.openFiles.some((file) => file.worktreeId === worktreeId)
       return {
         unifiedTabsByWorktree: { ...current.unifiedTabsByWorktree, [worktreeId]: nextTabs },
         groupsByWorktree: {
@@ -546,7 +552,38 @@ export const createTabsSlice: StateCreator<AppState, [], [], TabsSlice> = (set, 
         },
         layoutByWorktree: nextLayoutByWorktree,
         activeGroupIdByWorktree: nextActiveGroupIdByWorktree,
-        ...(current.activeWorktreeId === worktreeId
+        // Why: the split-group model can legally derive "terminal with no
+        // active tab" after the final unified tab closes. That leaves the
+        // worktree selected but render-empty, so the workspace shows a blank
+        // pane instead of Orca's landing screen. When that happens, write the
+        // landing-state fallback directly instead of recomputing active-surface
+        // fields from a worktree that is no longer active.
+        ...(shouldDeactivateWorktree
+          ? {
+              activeWorktreeId: null,
+              activeTabId: null,
+              activeBrowserTabId: null,
+              activeFileId: null,
+              activeTabType: 'terminal' as const,
+              activeTabIdByWorktree: {
+                ...current.activeTabIdByWorktree,
+                [worktreeId]: null
+              },
+              activeBrowserTabIdByWorktree: {
+                ...current.activeBrowserTabIdByWorktree,
+                [worktreeId]: null
+              },
+              activeFileIdByWorktree: {
+                ...current.activeFileIdByWorktree,
+                [worktreeId]: null
+              },
+              activeTabTypeByWorktree: {
+                ...current.activeTabTypeByWorktree,
+                [worktreeId]: 'terminal'
+              }
+            }
+          : {}),
+        ...(!shouldDeactivateWorktree && current.activeWorktreeId === worktreeId
           ? buildActiveSurfacePatch(
               {
                 ...current,


### PR DESCRIPTION
## Problem
Closing the last terminal in the active worktree could leave Orca with the worktree still selected but no renderable surface. In the `Cmd+D` exit path, that state produced a blank workspace instead of returning to the Orca landing background.

## Solution
When `closeUnifiedTab` removes the final renderable surface for the active worktree, clear the active worktree and active surface fields so the renderer falls back to the landing state instead of trying to render an empty split-group workspace. Added a regression test that closes the last terminal tab in the active worktree and verifies the store returns to the landing-state selection.