### PR TITLE
feat: add New Markdown option to tab group plus icon

### DIFF
--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -2,10 +2,12 @@
 
 import React, { useEffect, useCallback, useMemo, useRef, useState, lazy, Suspense } from 'react'
 import { createPortal } from 'react-dom'
+import { toast } from 'sonner'
 import { TOGGLE_TERMINAL_PANE_EXPAND_EVENT } from '@/constants/terminal'
 import { useAppStore } from '../store'
 import { findWorktreeById } from '../store/slices/worktree-helpers'
-import { detectLanguage } from '../lib/language-detect'
+import { createUntitledMarkdownFile } from '../lib/create-untitled-markdown'
+import { extractIpcErrorMessage } from '../lib/ipc-error'
 import {
   Dialog,
   DialogContent,
@@ -294,38 +296,17 @@ function Terminal(): React.JSX.Element | null {
     if (!worktree) {
       return
     }
-    const baseName = 'untitled'
-    const ext = '.md'
-    let fileName = `${baseName}${ext}`
-    let filePath = `${worktree.path}/${fileName}`
-
-    // Why: createFile uses the 'wx' flag which fails if the file exists.
-    // Probe with pathExists to find the first unused name. Using pathExists
-    // instead of stat avoids noisy ENOENT errors in the main process log.
-    let counter = 2
-    const MAX_ATTEMPTS = 100
-    while (counter <= MAX_ATTEMPTS && (await window.api.shell.pathExists(filePath))) {
-      fileName = `${baseName}-${counter}${ext}`
-      filePath = `${worktree.path}/${fileName}`
-      counter++
-    }
-
     try {
-      await window.api.fs.createFile({ filePath })
-    } catch {
-      return
+      // Why: the global Cmd/Ctrl+Shift+N shortcut is handled here rather than
+      // inside a specific TabGroupPanel, so it must snapshot the store's
+      // current focused group explicitly. Otherwise split layouts fall back to
+      // the ambient/default group and open the file in the wrong pane.
+      const targetGroupId = useAppStore.getState().activeGroupIdByWorktree[activeWorktreeId]
+      const fileInfo = await createUntitledMarkdownFile(worktree.path, activeWorktreeId)
+      openFile(fileInfo, { preview: false, targetGroupId })
+    } catch (err) {
+      toast.error(extractIpcErrorMessage(err, 'Failed to create untitled markdown file.'))
     }
-    openFile(
-      {
-        filePath,
-        relativePath: fileName,
-        worktreeId: activeWorktreeId,
-        language: detectLanguage(fileName),
-        isUntitled: true,
-        mode: 'edit'
-      },
-      { preview: false }
-    )
   }, [activeWorktreeId, openFile])
 
   const handleCloseTab = useCallback(

--- a/src/renderer/src/components/tab-group/TabGroupPanel.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.tsx
@@ -65,6 +65,7 @@ export default function TabGroupPanel({
       onReorder={(_, order) => commands.reorderTabBar(order)}
       onNewTerminalTab={commands.newTerminalTab}
       onNewBrowserTab={commands.newBrowserTab}
+      onNewFileTab={commands.newFileTab}
       onSetCustomTitle={commands.setTabCustomTitle}
       onSetTabColor={commands.setTabColor}
       onTogglePaneExpand={() => {}}
@@ -118,6 +119,11 @@ export default function TabGroupPanel({
           : ''
       }`}
       onPointerDown={commands.focusGroup}
+      // Why: keyboard and assistive-tech users can move focus into an unfocused
+      // split group without generating a pointer event. Keeping the owning
+      // group in sync with DOM focus makes global shortcuts like New Markdown
+      // target the panel the user actually navigated into.
+      onFocusCapture={commands.focusGroup}
     >
       {/* Why: every split group must keep its own real tab row because the app
           can show multiple groups at once, while the window titlebar only has

--- a/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.ts
+++ b/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.ts
@@ -2,6 +2,7 @@
    group-scoped activation, close, split, and tab-order rules together so the extracted
    controller cannot drift from the TabGroupPanel surface it coordinates. */
 import { useCallback, useMemo } from 'react'
+import { toast } from 'sonner'
 import { useShallow } from 'zustand/react/shallow'
 import type { OpenFile } from '@/store/slices/editor'
 import type {
@@ -11,6 +12,8 @@ import type {
   TerminalTab
 } from '../../../../shared/types'
 import { useAppStore } from '../../store'
+import { createUntitledMarkdownFile } from '../../lib/create-untitled-markdown'
+import { extractIpcErrorMessage } from '../../lib/ipc-error'
 import { destroyPersistentWebview } from '../browser-pane/BrowserPane'
 
 export type GroupEditorItem = OpenFile & { tabId: string }
@@ -81,6 +84,7 @@ export function useTabGroupWorkspaceModel({
   const setTabCustomTitle = useAppStore((state) => state.setTabCustomTitle)
   const setTabColor = useAppStore((state) => state.setTabColor)
   const consumeSuppressedPtyExit = useAppStore((state) => state.consumeSuppressedPtyExit)
+  const openFile = useAppStore((state) => state.openFile)
 
   const group = useMemo(
     () => worktreeState.groups.find((item) => item.id === groupId) ?? null,
@@ -437,6 +441,22 @@ export function useTabGroupWorkspaceModel({
       newBrowserTab: () => {
         const defaultUrl = useAppStore.getState().browserDefaultUrl ?? 'about:blank'
         createBrowserTab(worktreeId, defaultUrl, { title: 'New Browser Tab' })
+      },
+      // Why: split-group actions must target their owning group explicitly.
+      // Relying on the ambient activeGroupIdByWorktree breaks keyboard and
+      // assistive-tech activation because the "+" menu can be triggered from
+      // an unfocused panel without first updating global group focus.
+      newFileTab: async () => {
+        const path = worktreeState.worktree?.path
+        if (!path) {
+          return
+        }
+        try {
+          const fileInfo = await createUntitledMarkdownFile(path, worktreeId)
+          openFile(fileInfo, { preview: false, targetGroupId: groupId })
+        } catch (err) {
+          toast.error(extractIpcErrorMessage(err, 'Failed to create untitled markdown file.'))
+        }
       },
       newTerminalTab: () => {
         const terminal = createTab(worktreeId, groupId)

--- a/src/renderer/src/components/terminal/TerminalShell.tsx
+++ b/src/renderer/src/components/terminal/TerminalShell.tsx
@@ -31,6 +31,7 @@ type TerminalShellProps = {
   onReorderTabs: (worktreeId: string, tabIds: string[]) => void
   onNewTerminalTab: () => void
   onNewBrowserTab: () => void
+  onNewFileTab?: () => void
   onSetCustomTitle: (tabId: string, title: string | null) => void
   onSetTabColor: (tabId: string, color: string | null) => void
   onTogglePaneExpand: (tabId: string) => void
@@ -67,6 +68,7 @@ export function TerminalShell({
   onReorderTabs,
   onNewTerminalTab,
   onNewBrowserTab,
+  onNewFileTab,
   onSetCustomTitle,
   onSetTabColor,
   onTogglePaneExpand,
@@ -105,6 +107,7 @@ export function TerminalShell({
               onReorder={onReorderTabs}
               onNewTerminalTab={onNewTerminalTab}
               onNewBrowserTab={onNewBrowserTab}
+              onNewFileTab={onNewFileTab}
               onSetCustomTitle={onSetCustomTitle}
               onSetTabColor={onSetTabColor}
               expandedPaneByTabId={expandedPaneByTabId}

--- a/src/renderer/src/lib/create-untitled-markdown.test.ts
+++ b/src/renderer/src/lib/create-untitled-markdown.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createUntitledMarkdownFile } from './create-untitled-markdown'
+
+describe('createUntitledMarkdownFile', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('retries with the next untitled name when createFile loses the EEXIST race', async () => {
+    const pathExists = vi.fn(async (filePath: string) => filePath.endsWith('untitled.md'))
+    const createFile = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('EEXIST: file already exists'))
+      .mockResolvedValueOnce(undefined)
+
+    vi.stubGlobal('window', {
+      api: {
+        shell: { pathExists },
+        fs: { createFile }
+      }
+    })
+
+    await expect(createUntitledMarkdownFile('/repo', 'wt-1')).resolves.toEqual({
+      filePath: '/repo/untitled-3.md',
+      relativePath: 'untitled-3.md',
+      worktreeId: 'wt-1',
+      language: 'markdown',
+      isUntitled: true,
+      mode: 'edit'
+    })
+
+    expect(createFile).toHaveBeenNthCalledWith(1, { filePath: '/repo/untitled-2.md' })
+    expect(createFile).toHaveBeenNthCalledWith(2, { filePath: '/repo/untitled-3.md' })
+  })
+
+  it('throws a descriptive error when untitled names are exhausted', async () => {
+    const pathExists = vi.fn(async () => true)
+    const createFile = vi.fn()
+
+    vi.stubGlobal('window', {
+      api: {
+        shell: { pathExists },
+        fs: { createFile }
+      }
+    })
+
+    await expect(createUntitledMarkdownFile('/repo', 'wt-1')).rejects.toThrow(
+      'Unable to create untitled markdown file after 100 attempts.'
+    )
+
+    expect(createFile).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/lib/create-untitled-markdown.ts
+++ b/src/renderer/src/lib/create-untitled-markdown.ts
@@ -1,0 +1,61 @@
+import { detectLanguage } from './language-detect'
+import { joinPath } from './path'
+
+/**
+ * Creates an untitled markdown file on disk and returns the metadata
+ * needed by the editor store's `openFile` action.
+ *
+ * Throws on permission errors or name-collision exhaustion so callers
+ * can surface the failure instead of silently dropping it.
+ */
+export async function createUntitledMarkdownFile(
+  worktreePath: string,
+  worktreeId: string
+): Promise<{
+  filePath: string
+  relativePath: string
+  worktreeId: string
+  language: string
+  isUntitled: true
+  mode: 'edit'
+}> {
+  const baseName = 'untitled'
+  const ext = '.md'
+  const MAX_ATTEMPTS = 100
+
+  // Why: createFile uses the 'wx' flag, so pathExists is only a hint. Another
+  // create can still win the race after our last probe, especially when the
+  // user fires the shortcut repeatedly or two split groups create files at
+  // nearly the same time. Retrying EEXIST keeps "New Markdown" advancing to
+  // the next untitled-N name instead of surfacing a spurious error toast.
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
+    const fileName = attempt === 1 ? `${baseName}${ext}` : `${baseName}-${attempt}${ext}`
+    const filePath = joinPath(worktreePath, fileName)
+
+    if (await window.api.shell.pathExists(filePath)) {
+      continue
+    }
+
+    try {
+      await window.api.fs.createFile({ filePath })
+
+      return {
+        filePath,
+        relativePath: fileName,
+        worktreeId,
+        language: detectLanguage(fileName),
+        isUntitled: true,
+        mode: 'edit'
+      }
+    } catch (err) {
+      const isEexist =
+        err instanceof Error && (err.message.includes('EEXIST') || err.message.includes('exists'))
+      if (isEexist && attempt < MAX_ATTEMPTS) {
+        continue
+      }
+      throw err
+    }
+  }
+
+  throw new Error(`Unable to create untitled markdown file after ${MAX_ATTEMPTS} attempts.`)
+}

--- a/src/renderer/src/lib/ipc-error.ts
+++ b/src/renderer/src/lib/ipc-error.ts
@@ -1,0 +1,12 @@
+/**
+ * Electron's ipcRenderer.invoke wraps errors as:
+ *   "Error invoking remote method 'channel': Error: actual message"
+ * Strip the wrapper so users see only the meaningful part.
+ */
+export function extractIpcErrorMessage(err: unknown, fallback: string): string {
+  if (!(err instanceof Error)) {
+    return fallback
+  }
+  const match = err.message.match(/Error invoking remote method '[^']*': (?:Error: )?(.+)/)
+  return match ? match[1] : err.message
+}

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -150,7 +150,10 @@ export type EditorSlice = {
   activeTabTypeByWorktree: Record<string, WorkspaceVisibleTabType> // worktreeId -> last active tab type
   activeTabType: WorkspaceVisibleTabType
   setActiveTabType: (type: WorkspaceVisibleTabType) => void
-  openFile: (file: Omit<OpenFile, 'id' | 'isDirty'>, options?: { preview?: boolean }) => void
+  openFile: (
+    file: Omit<OpenFile, 'id' | 'isDirty'>,
+    options?: { preview?: boolean; targetGroupId?: string }
+  ) => void
   pinFile: (fileId: string, tabId?: string) => void
   closeFile: (fileId: string) => void
   closeAllFiles: () => void
@@ -264,14 +267,17 @@ function openWorkspaceEditorItem(
   worktreeId: string,
   label: string,
   contentType: 'editor' | 'diff' | 'conflict-review',
-  isPreview?: boolean
+  isPreview?: boolean,
+  targetGroupId?: string
 ): string {
-  const targetGroupId =
-    state.activeGroupIdByWorktree?.[worktreeId] ?? state.groupsByWorktree?.[worktreeId]?.[0]?.id
-  if (!targetGroupId) {
+  const resolvedGroupId =
+    targetGroupId ??
+    state.activeGroupIdByWorktree?.[worktreeId] ??
+    state.groupsByWorktree?.[worktreeId]?.[0]?.id
+  if (!resolvedGroupId) {
     return fileId
   }
-  const existing = state.findTabForEntityInGroup?.(worktreeId, targetGroupId, fileId, contentType)
+  const existing = state.findTabForEntityInGroup?.(worktreeId, resolvedGroupId, fileId, contentType)
   if (existing) {
     state.activateTab?.(existing.id)
     return existing.id
@@ -280,7 +286,7 @@ function openWorkspaceEditorItem(
     entityId: fileId,
     label,
     isPreview,
-    targetGroupId
+    targetGroupId: resolvedGroupId
   })
   return created?.id ?? fileId
 }
@@ -525,7 +531,8 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
         : file.mode === 'diff'
           ? 'diff'
           : 'editor',
-      options?.preview ?? false
+      options?.preview ?? false,
+      options?.targetGroupId
     )
   },
 

--- a/src/renderer/src/store/slices/new-markdown.test.ts
+++ b/src/renderer/src/store/slices/new-markdown.test.ts
@@ -4,7 +4,7 @@ import { createStore, type StoreApi } from 'zustand/vanilla'
 import { describe, expect, it } from 'vitest'
 import { createEditorSlice } from './editor'
 import type { AppState } from '../types'
-import type { BrowserTab } from '../../../../shared/types'
+import type { BrowserTab, Tab, TabContentType, TabGroup } from '../../../../shared/types'
 
 function createEditorStore(overrides?: Partial<AppState>): StoreApi<AppState> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -312,6 +312,76 @@ describe('New Markdown — tab bar ordering with openFile', () => {
     expect(order.indexOf('t2')).toBeLessThan(order.indexOf('b2'))
     // New file at the end
     expect(order.at(-1)).toBe('/repo/untitled.md')
+  })
+})
+
+describe('New Markdown — split group targeting', () => {
+  it('opens into the explicitly requested group instead of the ambient active group', () => {
+    const createdTabs: {
+      worktreeId: string
+      contentType: TabContentType
+      entityId: string
+      label: string
+      targetGroupId?: string
+    }[] = []
+    const groups: TabGroup[] = [
+      { id: 'group-a', worktreeId: 'wt-1', activeTabId: null, tabOrder: [] },
+      { id: 'group-b', worktreeId: 'wt-1', activeTabId: null, tabOrder: [] }
+    ]
+    const existingTabs: Tab[] = []
+    const store = createEditorStore({
+      groupsByWorktree: { 'wt-1': groups },
+      unifiedTabsByWorktree: { 'wt-1': existingTabs },
+      activeGroupIdByWorktree: { 'wt-1': 'group-a' },
+      findTabForEntityInGroup: () => null,
+      createUnifiedTab: (worktreeId, contentType, init) => {
+        expect(init?.entityId).toBeTruthy()
+        expect(init?.label).toBeTruthy()
+        createdTabs.push({
+          worktreeId,
+          contentType,
+          entityId: init!.entityId!,
+          label: init!.label!,
+          targetGroupId: init?.targetGroupId
+        })
+        return {
+          id: 'tab-1',
+          worktreeId,
+          groupId: init?.targetGroupId ?? 'group-b',
+          contentType,
+          entityId: init?.entityId ?? '/repo/untitled.md',
+          label: init?.label ?? 'untitled.md',
+          customLabel: null,
+          color: null,
+          isPinned: false,
+          isPreview: false,
+          createdAt: 0,
+          sortOrder: 0
+        }
+      }
+    })
+
+    store.getState().openFile(
+      {
+        filePath: '/repo/untitled.md',
+        relativePath: 'untitled.md',
+        worktreeId: 'wt-1',
+        language: 'markdown',
+        isUntitled: true,
+        mode: 'edit'
+      },
+      { preview: false, targetGroupId: 'group-b' }
+    )
+
+    expect(createdTabs).toEqual([
+      {
+        worktreeId: 'wt-1',
+        contentType: 'editor',
+        entityId: '/repo/untitled.md',
+        label: 'untitled.md',
+        targetGroupId: 'group-b'
+      }
+    ])
   })
 })
 


### PR DESCRIPTION
## Summary
- Extract untitled markdown file creation into a reusable `createUntitledMarkdownFile` helper with EEXIST race-condition retry logic
- Add `newFileTab` command to `useTabGroupWorkspaceModel` so the per-group "+" menu can create markdown files targeting the correct split pane
- Extend `openFile` to accept an explicit `targetGroupId`, preventing files from landing in the wrong group in split layouts
- Add `onFocusCapture` to `TabGroupPanel` so keyboard/assistive-tech navigation keeps global group focus in sync
- Add `extractIpcErrorMessage` utility for cleaner error toasts from IPC calls

## Test plan
- [x] Unit tests for `createUntitledMarkdownFile` (EEXIST retry, name exhaustion)
- [x] Unit test for split group targeting (`openFile` with explicit `targetGroupId`)
- [x] Manual: verify "+" menu in tab bar shows New Markdown option and creates file in the correct split pane
- [x] Manual: verify Cmd+Shift+N still works and targets the focused group