### PR TITLE
Align workspace chrome and split tab headers

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -725,7 +725,14 @@ function App(): React.JSX.Element {
               >
                 <div
                   className={`titlebar-left${sidebarOpen ? '' : ' absolute top-0 left-0 z-10'}`}
-                  style={{ width: sidebarOpen ? sidebarWidth : undefined }}
+                  style={{
+                    // Why: the Sidebar resize hook updates the sidebar DOM width
+                    // directly during drag and only persists to Zustand on
+                    // mouseup. In workspace view, size this header from the
+                    // wrapper's live width so it tracks those in-flight resizes
+                    // instead of leaving a stale-width gap until the drag ends.
+                    width: sidebarOpen ? '100%' : undefined
+                  }}
                 >
                   {titlebarLeftControls}
                 </div>

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines */
-import { useEffect, useMemo } from 'react'
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { DEFAULT_STATUS_BAR_ITEMS, DEFAULT_WORKTREE_CARD_PROPERTIES } from '../../shared/constants'
 import { isGitRepoKind } from '../../shared/repo-kind'
 
@@ -124,8 +124,11 @@ function App(): React.JSX.Element {
   const filterRepoIds = useAppStore((s) => s.filterRepoIds)
   const persistedUIReady = useAppStore((s) => s.persistedUIReady)
   const rightSidebarWidth = useAppStore((s) => s.rightSidebarWidth)
+  const rightSidebarOpen = useAppStore((s) => s.rightSidebarOpen)
   const isFullScreen = useAppStore((s) => s.isFullScreen)
   const settings = useAppStore((s) => s.settings)
+  const titlebarLeftControlsRef = useRef<HTMLDivElement | null>(null)
+  const [collapsedSidebarHeaderWidth, setCollapsedSidebarHeaderWidth] = useState(0)
 
   // Subscribe to IPC push events
   useIpcEvents()
@@ -380,6 +383,10 @@ function App(): React.JSX.Element {
     !hasTabBar &&
     effectiveActiveTabExpanded
   const showSidebar = activeView !== 'settings'
+  // Why: when a worktree is active (split groups always enabled), the
+  // full-width titlebar is replaced by a sidebar-width left header so the
+  // terminal + tab groups extend to the very top of the window.
+  const workspaceActive = activeView !== 'settings' && activeWorktreeId !== null
 
   const handleToggleExpand = (): void => {
     if (!effectiveActiveTabId) {
@@ -479,196 +486,258 @@ function App(): React.JSX.Element {
     return () => window.removeEventListener('keydown', onKeyDown, { capture: true })
   }, [activeView, activeWorktreeId, actions, repos])
 
+  useLayoutEffect(() => {
+    const controls = titlebarLeftControlsRef.current
+    if (!controls) {
+      return
+    }
+
+    const updateWidth = (): void => {
+      setCollapsedSidebarHeaderWidth(controls.getBoundingClientRect().width)
+    }
+
+    updateWidth()
+    const observer = new ResizeObserver(() => {
+      updateWidth()
+    })
+    observer.observe(controls)
+    return () => observer.disconnect()
+  }, [activeAgentCount, isFullScreen, settings?.showTitlebarAgentActivity, showSidebar])
+
+  // Why: extracted so both the full-width titlebar (settings/landing) and
+  // the sidebar-width left header (workspace view) can share the same
+  // controls without duplicating the agent badge popover.
+  const titlebarLeftControls = (
+    <div ref={titlebarLeftControlsRef} className="flex h-full shrink-0 items-center">
+      <div className={isMac && !isFullScreen ? 'titlebar-traffic-light-pad' : 'pl-2'} />
+      {showSidebar && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              className="sidebar-toggle"
+              onClick={actions.toggleSidebar}
+              aria-label="Toggle sidebar"
+            >
+              <PanelLeft size={16} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom" sideOffset={6}>
+            {`Toggle sidebar (${isMac ? '⌘B' : 'Ctrl+B'})`}
+          </TooltipContent>
+        </Tooltip>
+      )}
+      {settings?.showTitlebarAgentActivity !== false ? (
+        <Popover>
+          <PopoverTrigger asChild>
+            <button
+              className={`titlebar-agent-badge${activeAgentCount === 0 ? ' titlebar-agent-badge-idle' : ''}`}
+              aria-label={`${activeAgentCount} ${activeAgentCount === 1 ? 'agent' : 'agents'} active`}
+            >
+              <span
+                className={`titlebar-agent-badge-dot${activeAgentCount === 0 ? ' titlebar-agent-badge-dot-idle' : ''}`}
+                aria-hidden
+              />
+              <span className="titlebar-agent-badge-count">{activeAgentCount}</span>
+            </button>
+          </PopoverTrigger>
+          <PopoverContent side="bottom" sideOffset={6} className="titlebar-agent-hovercard">
+            <div
+              className={`titlebar-agent-hovercard-header${activeAgentCount > 0 ? ' titlebar-agent-hovercard-header-with-list' : ''}`}
+            >
+              {activeAgentCount === 0
+                ? 'No agents active'
+                : `${activeAgentCount} ${activeAgentCount === 1 ? 'agent' : 'agents'} active`}
+            </div>
+            {activeAgentCount > 0 && (
+              <div className="titlebar-agent-hovercard-list">
+                {Object.entries(workingAgentsPerWorktree).map(([worktreeId, { agents }]) => {
+                  const wt = findWorktreeById(worktreesByRepo, worktreeId)
+                  // Why: when a transient git error causes worktreesByRepo to
+                  // lose a worktree, the raw worktreeId (uuid::path) is not
+                  // useful. Extract a cross-platform path basename as a
+                  // readable fallback.
+                  const sepIdx = worktreeId.indexOf('::')
+                  const pathPart = sepIdx !== -1 ? worktreeId.slice(sepIdx + 2) : worktreeId
+                  const fallbackName = pathPart.split(/[\\/]/).pop() || pathPart
+                  return (
+                    <div key={worktreeId}>
+                      <button
+                        className="titlebar-agent-hovercard-worktree"
+                        onClick={() => {
+                          // Why: if the worktree is missing from worktreesByRepo
+                          // (transient git error cleared the list), refresh the
+                          // repo's worktrees before navigating so the activation
+                          // lookup succeeds instead of silently failing.
+                          if (!wt) {
+                            const repoId = getRepoIdFromWorktreeId(worktreeId)
+                            void useAppStore
+                              .getState()
+                              .fetchWorktrees(repoId)
+                              .then(() => {
+                                activateAndRevealWorktree(worktreeId)
+                              })
+                            return
+                          }
+                          activateAndRevealWorktree(worktreeId)
+                        }}
+                      >
+                        <span className="titlebar-agent-hovercard-name">
+                          {wt?.displayName ?? fallbackName}
+                        </span>
+                      </button>
+                      {agents.map((agent, index) => (
+                        <button
+                          key={index}
+                          className="titlebar-agent-hovercard-agent"
+                          onClick={() => {
+                            activateAndRevealWorktree(worktreeId)
+                            useAppStore.getState().setActiveTab(agent.tabId)
+                            if (agent.paneId !== null) {
+                              // Why: a split-terminal tab can host multiple
+                              // agents. After selecting the tab, wait one
+                              // frame so the active TerminalPane can mount
+                              // and then focus the specific pane the user
+                              // clicked instead of leaving whichever pane
+                              // was previously active highlighted.
+                              requestAnimationFrame(() => {
+                                window.dispatchEvent(
+                                  new CustomEvent(FOCUS_TERMINAL_PANE_EVENT, {
+                                    detail: { tabId: agent.tabId, paneId: agent.paneId }
+                                  })
+                                )
+                              })
+                            }
+                          }}
+                        >
+                          <span className="titlebar-agent-hovercard-agent-label">
+                            {agent.label}
+                          </span>
+                          <span className="titlebar-agent-hovercard-agent-dot" />
+                        </button>
+                      ))}
+                    </div>
+                  )
+                })}
+              </div>
+            )}
+            <button
+              className="titlebar-agent-hovercard-hide"
+              onClick={() => {
+                void actions.updateSettings({ showTitlebarAgentActivity: false })
+                toast('Agent activity badge hidden', {
+                  description: 'You can turn it back on in Settings → Appearance.',
+                  duration: Infinity,
+                  dismissible: true
+                })
+              }}
+            >
+              Hide from titlebar
+            </button>
+          </PopoverContent>
+        </Popover>
+      ) : null}
+    </div>
+  )
+
+  const rightSidebarToggle = showSidebar ? (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          className="sidebar-toggle mr-2"
+          onClick={actions.toggleRightSidebar}
+          aria-label="Toggle right sidebar"
+        >
+          <PanelRight size={16} />
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom" sideOffset={6}>
+        {`Toggle right sidebar (${isMac ? '⌘L' : 'Ctrl+L'})`}
+      </TooltipContent>
+    </Tooltip>
+  ) : null
+
   return (
-    <div className="flex flex-col h-screen w-screen overflow-hidden">
+    <div
+      className="flex flex-col h-screen w-screen overflow-hidden"
+      style={
+        {
+          '--collapsed-sidebar-header-width': `${collapsedSidebarHeaderWidth}px`
+        } as React.CSSProperties
+      }
+    >
       <TooltipProvider delayDuration={400}>
-        <div className="titlebar">
-          {/* Why: the left section of the titlebar matches the sidebar width so
-              tabs start exactly where the sidebar ends, creating a clean vertical
-              alignment between the sidebar edge and the first tab. When the
-              sidebar is collapsed, shrink-0 prevents the flex-1 tab section from
-              squeezing this area, and mr-2 adds a gap before the first tab. */}
-          <div
-            className={`flex items-center${showSidebar && sidebarOpen ? ' overflow-hidden shrink-0' : ' shrink-0 mr-2'}`}
-            style={{ width: showSidebar && sidebarOpen ? sidebarWidth : undefined }}
-          >
-            <div className={isMac && !isFullScreen ? 'titlebar-traffic-light-pad' : 'pl-2'} />
-            {/* Why: hide the toggle entirely in settings so no disabled button
-                or stray Radix PopperAnchor portal appears in the titlebar. */}
-            {showSidebar && (
+        {/* Why: in workspace view (split groups always enabled), the full-width
+            titlebar is removed so tab groups + terminal extend to the top of
+            the window. Left titlebar controls move to a header above the sidebar.
+            Settings and landing views keep the full-width titlebar. */}
+        {!workspaceActive ? (
+          <div className="titlebar">
+            <div
+              className={`flex items-center${showSidebar && sidebarOpen ? ' overflow-hidden shrink-0' : ' shrink-0 mr-2'}`}
+              style={{ width: showSidebar && sidebarOpen ? sidebarWidth : undefined }}
+            >
+              {titlebarLeftControls}
+            </div>
+            <div
+              id="titlebar-tabs"
+              className={`flex flex-1 min-w-0 self-stretch${activeView === 'settings' || !activeWorktreeId ? ' invisible pointer-events-none' : ''}`}
+            />
+            {showTitlebarExpandButton && (
               <Tooltip>
                 <TooltipTrigger asChild>
                   <button
-                    className="sidebar-toggle"
-                    onClick={actions.toggleSidebar}
-                    aria-label="Toggle sidebar"
+                    className="titlebar-icon-button"
+                    onClick={handleToggleExpand}
+                    aria-label="Collapse pane"
+                    disabled={!activeTabCanExpand}
                   >
-                    <PanelLeft size={16} />
+                    <Minimize2 size={14} />
                   </button>
                 </TooltipTrigger>
                 <TooltipContent side="bottom" sideOffset={6}>
-                  {`Toggle sidebar (${isMac ? '⌘B' : 'Ctrl+B'})`}
+                  Collapse pane
                 </TooltipContent>
               </Tooltip>
             )}
-            <div className="titlebar-title">Orca</div>
-            {settings?.showTitlebarAgentActivity !== false ? (
-              <Popover>
-                <PopoverTrigger asChild>
-                  <button
-                    className={`titlebar-agent-badge${activeAgentCount === 0 ? ' titlebar-agent-badge-idle' : ''}`}
-                    aria-label={`${activeAgentCount} ${activeAgentCount === 1 ? 'agent' : 'agents'} active`}
-                  >
-                    <span
-                      className={`titlebar-agent-badge-dot${activeAgentCount === 0 ? ' titlebar-agent-badge-dot-idle' : ''}`}
-                      aria-hidden
-                    />
-                    <span className="titlebar-agent-badge-count">{activeAgentCount}</span>
-                  </button>
-                </PopoverTrigger>
-                <PopoverContent side="bottom" sideOffset={6} className="titlebar-agent-hovercard">
-                  <div
-                    className={`titlebar-agent-hovercard-header${activeAgentCount > 0 ? ' titlebar-agent-hovercard-header-with-list' : ''}`}
-                  >
-                    {activeAgentCount === 0
-                      ? 'No agents active'
-                      : `${activeAgentCount} ${activeAgentCount === 1 ? 'agent' : 'agents'} active`}
-                  </div>
-                  {activeAgentCount > 0 && (
-                    <div className="titlebar-agent-hovercard-list">
-                      {Object.entries(workingAgentsPerWorktree).map(([worktreeId, { agents }]) => {
-                        const wt = findWorktreeById(worktreesByRepo, worktreeId)
-                        // Why: when a transient git error causes worktreesByRepo to
-                        // lose a worktree, the raw worktreeId (uuid::path) is not
-                        // useful. Extract a cross-platform path basename as a
-                        // readable fallback.
-                        const sepIdx = worktreeId.indexOf('::')
-                        const pathPart = sepIdx !== -1 ? worktreeId.slice(sepIdx + 2) : worktreeId
-                        const fallbackName = pathPart.split(/[\\/]/).pop() || pathPart
-                        return (
-                          <div key={worktreeId}>
-                            <button
-                              className="titlebar-agent-hovercard-worktree"
-                              onClick={() => {
-                                // Why: if the worktree is missing from worktreesByRepo
-                                // (transient git error cleared the list), refresh the
-                                // repo's worktrees before navigating so the activation
-                                // lookup succeeds instead of silently failing.
-                                if (!wt) {
-                                  const repoId = getRepoIdFromWorktreeId(worktreeId)
-                                  void useAppStore
-                                    .getState()
-                                    .fetchWorktrees(repoId)
-                                    .then(() => {
-                                      activateAndRevealWorktree(worktreeId)
-                                    })
-                                  return
-                                }
-                                activateAndRevealWorktree(worktreeId)
-                              }}
-                            >
-                              <span className="titlebar-agent-hovercard-name">
-                                {wt?.displayName ?? fallbackName}
-                              </span>
-                            </button>
-                            {agents.map((agent, index) => (
-                              <button
-                                key={index}
-                                className="titlebar-agent-hovercard-agent"
-                                onClick={() => {
-                                  activateAndRevealWorktree(worktreeId)
-                                  useAppStore.getState().setActiveTab(agent.tabId)
-                                  if (agent.paneId !== null) {
-                                    // Why: a split-terminal tab can host multiple
-                                    // agents. After selecting the tab, wait one
-                                    // frame so the active TerminalPane can mount
-                                    // and then focus the specific pane the user
-                                    // clicked instead of leaving whichever pane
-                                    // was previously active highlighted.
-                                    requestAnimationFrame(() => {
-                                      window.dispatchEvent(
-                                        new CustomEvent(FOCUS_TERMINAL_PANE_EVENT, {
-                                          detail: { tabId: agent.tabId, paneId: agent.paneId }
-                                        })
-                                      )
-                                    })
-                                  }
-                                }}
-                              >
-                                <span className="titlebar-agent-hovercard-agent-label">
-                                  {agent.label}
-                                </span>
-                                <span className="titlebar-agent-hovercard-agent-dot" />
-                              </button>
-                            ))}
-                          </div>
-                        )
-                      })}
-                    </div>
-                  )}
-                  <button
-                    className="titlebar-agent-hovercard-hide"
-                    onClick={() => {
-                      void actions.updateSettings({ showTitlebarAgentActivity: false })
-                      toast('Agent activity badge hidden', {
-                        description: 'You can turn it back on in Settings → Appearance.',
-                        duration: Infinity,
-                        dismissible: true
-                      })
-                    }}
-                  >
-                    Hide from titlebar
-                  </button>
-                </PopoverContent>
-              </Popover>
-            ) : null}
+            {rightSidebarToggle}
           </div>
-          {/* Why: keep the center titlebar slot mounted even when tabs are hidden.
-              Using `hidden` here collapsed the spacer entirely, which let the
-              right-sidebar toggle slide left in the no-tabs empty state. `invisible`
-              still suppresses any stale portal content without breaking the far-right
-              titlebar alignment. */}
-          <div
-            id="titlebar-tabs"
-            className={`flex flex-1 min-w-0 self-stretch${activeView === 'settings' || !activeWorktreeId ? ' invisible pointer-events-none' : ''}`}
-          />
-          {showTitlebarExpandButton && (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  className="titlebar-icon-button"
-                  onClick={handleToggleExpand}
-                  aria-label="Collapse pane"
-                  disabled={!activeTabCanExpand}
-                >
-                  <Minimize2 size={14} />
-                </button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom" sideOffset={6}>
-                Collapse pane
-              </TooltipContent>
-            </Tooltip>
-          )}
-          {showSidebar ? (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  className="sidebar-toggle mr-2"
-                  onClick={actions.toggleRightSidebar}
-                  aria-label="Toggle right sidebar"
-                >
-                  <PanelRight size={16} />
-                </button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom" sideOffset={6}>
-                {`Toggle right sidebar (${isMac ? '⌘L' : 'Ctrl+L'})`}
-              </TooltipContent>
-            </Tooltip>
-          ) : null}
-        </div>
+        ) : null}
         <div className="flex flex-row flex-1 min-h-0 overflow-hidden">
-          {showSidebar ? <Sidebar /> : null}
+          {showSidebar ? (
+            workspaceActive ? (
+              /* Why: left column wraps the sidebar with a titlebar-height
+                 header above it. The header holds the same controls
+                 (traffic lights, sidebar toggle, "Orca" title, agent badge)
+                 that the full-width titlebar held while the center and right
+                 columns keep their own top strips at the same 42px height.
+                 When the sidebar is collapsed, take this header out of flex
+                 layout so the terminal/editor reclaim the left edge instead of
+                 leaving behind a content-width blank strip. */
+              <div
+                className={`flex flex-col shrink-0${sidebarOpen ? '' : ' relative w-0 overflow-visible'}`}
+              >
+                <div
+                  className={`titlebar-left${sidebarOpen ? '' : ' absolute top-0 left-0 z-10'}`}
+                  style={{ width: sidebarOpen ? sidebarWidth : undefined }}
+                >
+                  {titlebarLeftControls}
+                </div>
+                <Sidebar />
+              </div>
+            ) : (
+              <Sidebar />
+            )
+          ) : null}
           <div className="relative flex flex-1 min-w-0 min-h-0 overflow-hidden">
+            {/* Why: right sidebar toggle floats at the top-right of the center
+                column so it's always accessible whether the right sidebar is
+                open or closed. Its height matches the 42px workspace strip
+                used by the sidebar and tab rows. */}
+            {workspaceActive && !rightSidebarOpen && (
+              <div className="absolute top-0 right-0 z-10 flex items-center h-[42px]">
+                {rightSidebarToggle}
+              </div>
+            )}
             <div className="flex flex-1 min-w-0 min-h-0 flex-col">
               <div
                 className={
@@ -685,10 +754,7 @@ function App(): React.JSX.Element {
           {/* Why: keep RightSidebar mounted even when closed so that its
               child components (FileExplorer, SourceControl, etc.) and their
               filesystem watchers + cached directory trees survive across
-              open/close toggles.  Without this, every Ctrl+L remounts the
-              entire subtree, triggering watchWorktree + readDir + branchCompare
-              IPC calls that freeze Windows for seconds.  The sidebar already
-              renders at width 0 when closed via useSidebarResize. */}
+              open/close toggles. */}
           {showSidebar ? <RightSidebar /> : null}
         </div>
         <StatusBar />

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -502,7 +502,14 @@ function App(): React.JSX.Element {
     })
     observer.observe(controls)
     return () => observer.disconnect()
-  }, [activeAgentCount, isFullScreen, settings?.showTitlebarAgentActivity, showSidebar])
+  }, [
+    activeAgentCount,
+    isFullScreen,
+    settings?.showTitlebarAgentActivity,
+    showSidebar,
+    workspaceActive,
+    sidebarOpen
+  ])
 
   // Why: extracted so both the full-width titlebar (settings/landing) and
   // the sidebar-width left header (workspace view) can share the same

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -294,6 +294,24 @@
   user-select: none;
 }
 
+/* Why: workspace view still needs a full titlebar-height strip above the
+   sidebar so the native macOS traffic lights and sidebar chrome sit in the
+   same vertical band they use in settings/landing. The center and right
+   workspace columns are offset separately to align with this 42px baseline. */
+.titlebar-left {
+  height: 42px;
+  min-height: 42px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  overflow: hidden;
+  flex-shrink: 0;
+  background: var(--bg-titlebar, var(--card));
+  border-bottom: 1px solid var(--border);
+  -webkit-app-region: drag;
+  user-select: none;
+}
+
 .titlebar-traffic-light-pad {
   width: calc(80px / var(--ui-zoom-factor, 1));
   flex-shrink: 0;
@@ -328,21 +346,13 @@
   color: var(--muted-foreground);
 }
 
-.titlebar-title {
-  font-size: 13px;
-  font-weight: 500;
-  color: var(--muted-foreground);
-  margin-left: 8px;
-  white-space: nowrap;
-  flex-shrink: 0;
-}
-
 .titlebar-agent-badge {
   -webkit-app-region: no-drag;
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  margin-left: 10px;
+  margin-left: 4px;
+  margin-right: 8px;
   padding: 3px 8px;
   border-radius: 999px;
   border: 1px solid color-mix(in srgb, var(--border) 78%, transparent);

--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -123,18 +123,6 @@ function Terminal(): React.JSX.Element | null {
   const effectiveActiveLayout = activeWorktreeId
     ? getEffectiveLayoutForWorktree(activeWorktreeId)
     : undefined
-  const activeWorktree = activeWorktreeId
-    ? (allWorktrees.find((worktree) => worktree.id === activeWorktreeId) ?? null)
-    : null
-  const activeTerminalTab = tabs.find((tab) => tab.id === activeTabId) ?? null
-  const activeEditorFile = worktreeFiles.find((file) => file.id === activeFileId) ?? null
-  const activeBrowserTab = worktreeBrowserTabs.find((tab) => tab.id === activeBrowserTabId) ?? null
-  const activeSurfaceLabel =
-    activeTabType === 'browser'
-      ? (activeBrowserTab?.title ?? activeBrowserTab?.url ?? 'Browser')
-      : activeTabType === 'editor'
-        ? (activeEditorFile?.relativePath ?? activeEditorFile?.filePath ?? 'Editor')
-        : (activeTerminalTab?.customTitle ?? activeTerminalTab?.title ?? 'Terminal')
   const activeWorktreeBrowserTabIdsKey = activeWorktreeId
     ? (browserTabsByWorktree[activeWorktreeId] ?? []).map((tab) => tab.id).join(',')
     : ''
@@ -834,23 +822,9 @@ function Terminal(): React.JSX.Element | null {
           titlebarTabsTarget
         )}
 
-      {activeWorktreeId &&
-        effectiveActiveLayout &&
-        titlebarTabsTarget &&
-        createPortal(
-          <div className="flex h-full min-w-0 items-center px-3 text-xs text-muted-foreground">
-            {/* Why: split layouts can show several independent tab rows, so the
-                titlebar cannot host the real tabs without collapsing multiple
-                groups into one shared surface. A lightweight summary still uses
-                that otherwise empty strip and keeps the window chrome balanced. */}
-            <span className="truncate font-medium text-foreground/80">
-              {activeWorktree?.displayName ?? 'Workspace'}
-            </span>
-            <span className="px-2 text-border">/</span>
-            <span className="truncate">{activeSurfaceLabel}</span>
-          </div>,
-          titlebarTabsTarget
-        )}
+      {/* Why: the full-width titlebar is no longer rendered in workspace view
+          — tab groups + terminal extend to the top of the window instead.
+          The old summary label (workspace / active surface) is removed. */}
 
       {effectiveActiveLayout ? (
         <div className="relative flex flex-1 min-w-0 min-h-0 overflow-hidden">

--- a/src/renderer/src/components/right-sidebar/index.tsx
+++ b/src/renderer/src/components/right-sidebar/index.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react'
-import { Files, Search, GitBranch, ListChecks } from 'lucide-react'
+import { Files, Search, GitBranch, ListChecks, PanelRight } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { cn } from '@/lib/utils'
 import { useSidebarResize } from '@/hooks/useSidebarResize'
@@ -114,6 +114,7 @@ function RightSidebarInner(): React.JSX.Element {
   const setRightSidebarWidth = useAppStore((s) => s.setRightSidebarWidth)
   const rightSidebarTab = useAppStore((s) => s.rightSidebarTab)
   const setRightSidebarTab = useAppStore((s) => s.setRightSidebarTab)
+  const toggleRightSidebar = useAppStore((s) => s.toggleRightSidebar)
   const checksStatus = useAppStore(getActiveChecksStatus)
   const activityBarPosition = useAppStore((s) => s.activityBarPosition)
   const setActivityBarPosition = useAppStore((s) => s.setActivityBarPosition)
@@ -173,6 +174,24 @@ function RightSidebarInner(): React.JSX.Element {
     />
   ))
 
+  const closeButton = rightSidebarOpen ? (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          className="sidebar-toggle mr-1"
+          onClick={toggleRightSidebar}
+          aria-label="Toggle right sidebar"
+        >
+          <PanelRight size={16} />
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom" sideOffset={6}>
+        {`Toggle right sidebar (${isMac ? '⌘L' : 'Ctrl+L'})`}
+      </TooltipContent>
+    </Tooltip>
+  ) : null
+
   return (
     <div
       ref={containerRef}
@@ -197,8 +216,11 @@ function RightSidebarInner(): React.JSX.Element {
           /* ── Top activity bar: horizontal icon row ── */
           <ContextMenu>
             <ContextMenuTrigger asChild>
-              <div className="flex items-center border-b border-border h-[33px] min-h-[33px] px-1">
-                <TooltipProvider delayDuration={400}>{activityBarIcons}</TooltipProvider>
+              <div className="flex items-center justify-between border-b border-border h-[42px] min-h-[42px] pl-2 pr-1">
+                <TooltipProvider delayDuration={400}>
+                  <div className="flex items-center">{activityBarIcons}</div>
+                  {closeButton}
+                </TooltipProvider>
               </div>
             </ContextMenuTrigger>
             <ActivityBarPositionMenu
@@ -208,10 +230,11 @@ function RightSidebarInner(): React.JSX.Element {
           </ContextMenu>
         ) : (
           /* ── Side layout: static title header ── */
-          <div className="flex items-center h-[33px] min-h-[33px] px-3 border-b border-border">
+          <div className="flex items-center justify-between h-[42px] min-h-[42px] px-3 border-b border-border">
             <span className="text-[11px] font-semibold uppercase tracking-wider text-foreground">
               {visibleItems.find((item) => item.id === effectiveTab)?.title ?? ''}
             </span>
+            <TooltipProvider delayDuration={400}>{closeButton}</TooltipProvider>
           </div>
         )}
 
@@ -276,7 +299,7 @@ function ActivityBarButton({
         <button
           className={cn(
             'relative flex items-center justify-center transition-colors',
-            isTop ? 'h-[33px] w-9' : 'w-10 h-10',
+            isTop ? 'h-[42px] w-9' : 'w-10 h-10',
             active ? 'text-foreground' : 'text-muted-foreground/60 hover:text-muted-foreground'
           )}
           onClick={onClick}
@@ -289,7 +312,7 @@ function ActivityBarButton({
             <div
               className={cn(
                 'absolute rounded-full size-[7px] ring-1 ring-sidebar',
-                isTop ? 'top-[5px] right-[5px]' : 'top-[7px] right-[7px]',
+                isTop ? 'top-[8px] right-[5px]' : 'top-[7px] right-[7px]',
                 STATUS_DOT_COLOR[statusIndicator] ?? 'bg-muted-foreground'
               )}
             />

--- a/src/renderer/src/components/tab-group/TabGroupPanel.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.tsx
@@ -1,5 +1,6 @@
 import { lazy, Suspense } from 'react'
 import { X } from 'lucide-react'
+import { useAppStore } from '../../store'
 import TabBar from '../tab-bar/TabBar'
 import TerminalPane from '../terminal-pane/TerminalPane'
 import BrowserPane from '../browser-pane/BrowserPane'
@@ -11,13 +12,19 @@ export default function TabGroupPanel({
   groupId,
   worktreeId,
   isFocused,
-  hasSplitGroups
+  hasSplitGroups,
+  reserveClosedExplorerToggleSpace,
+  reserveCollapsedSidebarHeaderSpace
 }: {
   groupId: string
   worktreeId: string
   isFocused: boolean
   hasSplitGroups: boolean
+  reserveClosedExplorerToggleSpace: boolean
+  reserveCollapsedSidebarHeaderSpace: boolean
 }): React.JSX.Element {
+  const rightSidebarOpen = useAppStore((state) => state.rightSidebarOpen)
+  const sidebarOpen = useAppStore((state) => state.sidebarOpen)
   const model = useTabGroupWorkspaceModel({ groupId, worktreeId })
   const {
     activeBrowserTab,
@@ -115,7 +122,7 @@ export default function TabGroupPanel({
     <div
       className={`flex flex-col flex-1 min-w-0 min-h-0 overflow-hidden${
         hasSplitGroups
-          ? ` group/tab-group border ${isFocused ? 'border-accent' : 'border-border'}`
+          ? ` group/tab-group border-x border-b ${isFocused ? 'border-accent' : 'border-border'}`
           : ''
       }`}
       onPointerDown={commands.focusGroup}
@@ -129,9 +136,28 @@ export default function TabGroupPanel({
           can show multiple groups at once, while the window titlebar only has
           one shared center slot. Rendering true tab chrome here preserves
           per-group titles without making groups fight over one portal target. */}
-      <div className="shrink-0 border-b border-border bg-card">
-        <div className="flex items-stretch">
-          <div className="min-w-0 flex-1">{tabBar}</div>
+      <div className="h-[42px] shrink-0 border-b border-border bg-card">
+        <div
+          className={`flex h-full items-stretch${
+            reserveClosedExplorerToggleSpace && !rightSidebarOpen ? ' pr-10' : ''
+          }`}
+          style={{
+            paddingLeft:
+              reserveCollapsedSidebarHeaderSpace && !sidebarOpen
+                ? 'var(--collapsed-sidebar-header-width)'
+                : undefined
+          }}
+        >
+          {/* Why: when the right sidebar is closed, App.tsx renders a floating
+              explorer toggle in the top-right corner of the workspace. Only the
+              top-right tab group can sit underneath that button, so reserve
+              space in just that one header instead of pushing every group in. */}
+          {/* Why: collapsing the left worktree sidebar should let the terminal
+              reclaim the full left edge, but the top-left tab row should still
+              stop where the remaining titlebar controls end. Use the measured
+              width of that controls cluster instead of the old full sidebar
+              width so tabs cap at the agent badge, not at the old divider. */}
+          <div className="min-w-0 flex-1 h-full">{tabBar}</div>
           {hasSplitGroups && (
             <button
               type="button"
@@ -141,7 +167,7 @@ export default function TabGroupPanel({
                 event.stopPropagation()
                 commands.closeGroup()
               }}
-              className="mx-1 my-auto flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+              className="my-auto ml-1 mr-2 flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent/50 hover:text-foreground"
             >
               <X className="size-4" />
             </button>

--- a/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
@@ -85,7 +85,10 @@ function SplitNode({
   worktreeId,
   focusedGroupId,
   isWorktreeActive,
-  hasSplitGroups
+  hasSplitGroups,
+  touchesTopEdge,
+  touchesRightEdge,
+  touchesLeftEdge
 }: {
   node: TabGroupLayoutNode
   nodePath: string
@@ -93,6 +96,9 @@ function SplitNode({
   focusedGroupId?: string
   isWorktreeActive: boolean
   hasSplitGroups: boolean
+  touchesTopEdge: boolean
+  touchesRightEdge: boolean
+  touchesLeftEdge: boolean
 }): React.JSX.Element {
   const setTabGroupSplitRatio = useAppStore((state) => state.setTabGroupSplitRatio)
 
@@ -107,6 +113,8 @@ function SplitNode({
         // "focused", Cmd/Ctrl+W and split shortcuts can hit the wrong worktree.
         isFocused={isWorktreeActive && node.groupId === focusedGroupId}
         hasSplitGroups={hasSplitGroups}
+        reserveClosedExplorerToggleSpace={touchesTopEdge && touchesRightEdge}
+        reserveCollapsedSidebarHeaderSpace={touchesTopEdge && touchesLeftEdge}
       />
     )
   }
@@ -127,6 +135,9 @@ function SplitNode({
           focusedGroupId={focusedGroupId}
           isWorktreeActive={isWorktreeActive}
           hasSplitGroups={hasSplitGroups}
+          touchesTopEdge={touchesTopEdge}
+          touchesRightEdge={isHorizontal ? false : touchesRightEdge}
+          touchesLeftEdge={touchesLeftEdge}
         />
       </div>
       <ResizeHandle
@@ -141,6 +152,9 @@ function SplitNode({
           focusedGroupId={focusedGroupId}
           isWorktreeActive={isWorktreeActive}
           hasSplitGroups={hasSplitGroups}
+          touchesTopEdge={isHorizontal ? touchesTopEdge : false}
+          touchesRightEdge={touchesRightEdge}
+          touchesLeftEdge={isHorizontal ? false : touchesLeftEdge}
         />
       </div>
     </div>
@@ -167,6 +181,9 @@ export default function TabGroupSplitLayout({
         focusedGroupId={focusedGroupId}
         isWorktreeActive={isWorktreeActive}
         hasSplitGroups={layout.type === 'split'}
+        touchesTopEdge={true}
+        touchesRightEdge={true}
+        touchesLeftEdge={true}
       />
     </div>
   )


### PR DESCRIPTION
## Problem
The workspace chrome had become inconsistent after split-group and sidebar changes. The left worktree header, split tab headers, and right sidebar header did not align cleanly, the right sidebar toggle could overlap nearby controls, and collapsing the left sidebar left awkward whitespace and unstable tab positioning.

## Solution
Reworked the workspace renderer shell so the left titlebar controls are shared through a dedicated workspace header, aligned split-group tab rows to the same top-strip geometry, and moved the right-sidebar toggle into the sidebar header when open. Added targeted spacing/reservation logic for the top-right and top-left tab groups so collapsed sidebars preserve usable tab boundaries without leaving a full-height blank strip, and removed the extra Orca title text so the left controls pack tighter.

<img width="1509" height="877" alt="image" src="https://github.com/user-attachments/assets/c627aafa-5ca1-4ebf-90d1-ff1edb8acd18" />
<img width="1510" height="876" alt="image" src="https://github.com/user-attachments/assets/0af11ae9-8b2a-4018-90c2-fa29d994fdb4" />
<img width="1507" height="877" alt="image" src="https://github.com/user-attachments/assets/8e31f477-35a2-4f3b-b3e2-0f394151918a" />
