### PR TITLE
feat: split smart sort and recent sort into separate modes

### DIFF
--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -385,13 +385,44 @@ describe('Store', () => {
     expect(ui.lastUpdateCheckAt).toBe(1234)
   })
 
-  it('migrates persisted smart sort to recent', async () => {
+  it('preserves persisted smart sort value', async () => {
     writeDataFile({
       schemaVersion: 1,
       repos: [],
       worktreeMeta: {},
       settings: {},
       ui: { sortBy: 'smart' },
+      githubCache: { pr: {}, issue: {} },
+      workspaceSession: {}
+    })
+
+    const store = await createStore()
+    expect(store.getUI().sortBy).toBe('smart')
+  })
+
+  it('migrates legacy recent sort to smart on first load', async () => {
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [],
+      worktreeMeta: {},
+      settings: {},
+      ui: { sortBy: 'recent' },
+      githubCache: { pr: {}, issue: {} },
+      workspaceSession: {}
+    })
+
+    const store = await createStore()
+    expect(store.getUI().sortBy).toBe('smart')
+    expect(store.getUI()._sortBySmartMigrated).toBe(true)
+  })
+
+  it('preserves new recent sort after migration flag is set', async () => {
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [],
+      worktreeMeta: {},
+      settings: {},
+      ui: { sortBy: 'recent', _sortBySmartMigrated: true },
       githubCache: { pr: {}, issue: {} },
       workspaceSession: {}
     })

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -1,3 +1,6 @@
+/* eslint-disable max-lines -- Why: persistence keeps schema defaults, migration,
+load/save, and flush logic in one file so the full storage contract is reviewable
+as a unit instead of being scattered across modules. */
 import { app } from 'electron'
 import { readFileSync, writeFileSync, mkdirSync, existsSync, renameSync } from 'fs'
 import { writeFile, rename, mkdir, rm } from 'fs/promises'
@@ -42,12 +45,9 @@ function getDataFile(): string {
   return _dataFile
 }
 
-function normalizeSortBy(sortBy: unknown): 'name' | 'recent' | 'repo' {
-  if (sortBy === 'recent' || sortBy === 'repo' || sortBy === 'name') {
+function normalizeSortBy(sortBy: unknown): 'name' | 'smart' | 'recent' | 'repo' {
+  if (sortBy === 'smart' || sortBy === 'recent' || sortBy === 'repo' || sortBy === 'name') {
     return sortBy
-  }
-  if (sortBy === 'smart') {
-    return 'recent'
   }
   return getDefaultUIState().sortBy
 }
@@ -88,11 +88,19 @@ export class Store {
               ...parsed.settings?.notifications
             }
           },
-          ui: {
-            ...defaults.ui,
-            ...parsed.ui,
-            sortBy: normalizeSortBy(parsed.ui?.sortBy)
-          },
+          // Why: 'recent' used to mean the weighted smart sort. One-shot
+          // migration moves it to 'smart'; the flag prevents re-firing after
+          // a user intentionally selects the new last-activity 'recent' sort.
+          ui: (() => {
+            const sort = normalizeSortBy(parsed.ui?.sortBy)
+            const migrate = !parsed.ui?._sortBySmartMigrated && sort === 'recent'
+            return {
+              ...defaults.ui,
+              ...parsed.ui,
+              sortBy: migrate ? ('smart' as const) : sort,
+              _sortBySmartMigrated: true
+            }
+          })(),
           workspaceSession: { ...defaults.workspaceSession, ...parsed.workspaceSession },
           sshTargets: (parsed.sshTargets ?? []).map(normalizeSshTarget)
         }

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -90,7 +90,7 @@ export class Store {
           },
           // Why: 'recent' used to mean the weighted smart sort. One-shot
           // migration moves it to 'smart'; the flag prevents re-firing after
-          // a user intentionally selects the new last-activity 'recent' sort.
+          // a user intentionally selects the new creation-time 'recent' sort.
           ui: (() => {
             const sort = normalizeSortBy(parsed.ui?.sortBy)
             const migrate = !parsed.ui?._sortBySmartMigrated && sort === 'recent'

--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -176,7 +176,7 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
     const all: Worktree[] = Object.values(worktreesByRepo).flat()
     // Why: browser-tab search is explicitly cross-worktree, so it must keep
     // indexing live browser pages even when their owning worktree is archived.
-    return sortWorktreesRecent(all, tabsByWorktree, repoMap, prCache)
+    return sortWorktreesSmart(all, tabsByWorktree, repoMap, prCache)
   }, [worktreesByRepo, tabsByWorktree, repoMap, prCache])
 
   // Why: browser rows need worktree lookups for repo badge colors, and browser

--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -11,7 +11,7 @@ import {
   CommandItem
 } from '@/components/ui/command'
 import { branchName } from '@/lib/git-utils'
-import { sortWorktreesRecent } from '@/components/sidebar/smart-sort'
+import { sortWorktreesSmart } from '@/components/sidebar/smart-sort'
 import StatusIndicator from '@/components/sidebar/StatusIndicator'
 import { cn } from '@/lib/utils'
 import { getWorktreeStatus, getWorktreeStatusLabel } from '@/lib/worktree-status'
@@ -169,7 +169,7 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
     const all: Worktree[] = Object.values(worktreesByRepo)
       .flat()
       .filter((w) => !w.isArchived)
-    return sortWorktreesRecent(all, tabsByWorktree, repoMap, prCache)
+    return sortWorktreesSmart(all, tabsByWorktree, repoMap, prCache)
   }, [worktreesByRepo, tabsByWorktree, repoMap, prCache])
 
   const browserSortedWorktrees = useMemo(() => {

--- a/src/renderer/src/components/sidebar/SidebarHeader.tsx
+++ b/src/renderer/src/components/sidebar/SidebarHeader.tsx
@@ -27,6 +27,7 @@ const PROPERTY_OPTIONS: { id: WorktreeCardProperty; label: string }[] = [
 
 const SORT_OPTIONS = [
   { id: 'name', label: 'Name' },
+  { id: 'smart', label: 'Smart' },
   { id: 'recent', label: 'Recent' },
   { id: 'repo', label: 'Repo' }
 ] as const

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -402,7 +402,7 @@ const WorktreeList = React.memo(function WorktreeList() {
   const clearPendingRevealWorktreeId = useAppStore((s) => s.clearPendingRevealWorktreeId)
 
   // Read tabsByWorktree when needed for filtering or sorting
-  const needsTabs = showActiveOnly || sortBy === 'recent'
+  const needsTabs = showActiveOnly || sortBy === 'smart'
   const tabsByWorktree = useAppStore((s) => (needsTabs ? s.tabsByWorktree : null))
   const browserTabsByWorktree = useAppStore((s) =>
     showActiveOnly ? s.browserTabsByWorktree : null
@@ -410,10 +410,10 @@ const WorktreeList = React.memo(function WorktreeList() {
 
   const cardProps = useAppStore((s) => s.worktreeCardProperties)
 
-  // PR cache is needed for PR-status grouping, recent sorting, search,
+  // PR cache is needed for PR-status grouping, smart sorting, search,
   // and when the PR card property is visible.
   const prCache = useAppStore((s) =>
-    groupBy === 'pr-status' || sortBy === 'recent' || searchQuery || cardProps.includes('pr')
+    groupBy === 'pr-status' || sortBy === 'smart' || searchQuery || cardProps.includes('pr')
       ? s.prCache
       : null
   )
@@ -507,7 +507,7 @@ const WorktreeList = React.memo(function WorktreeList() {
     // persistent ones (unread, linked PR) survive — changing relative ranks.
     // Instead, restore the pre-shutdown order from the persisted sortOrder
     // snapshot, and switch to the live smart score once PTYs start spawning.
-    if (sortBy === 'recent' && !sessionHasHadPty.current) {
+    if (sortBy === 'smart' && !sessionHasHadPty.current) {
       const hasAnyLivePty = Object.values(state.tabsByWorktree)
         .flat()
         .some((t) => t.ptyId)
@@ -537,7 +537,7 @@ const WorktreeList = React.memo(function WorktreeList() {
   // restart. Only persist during live sessions (sessionHasHadPty latched) —
   // on cold start we are *reading* the persisted order, not overwriting it.
   useEffect(() => {
-    if (sortBy !== 'recent' || sortedIds.length === 0 || !sessionHasHadPty.current) {
+    if (sortBy !== 'smart' || sortedIds.length === 0 || !sessionHasHadPty.current) {
       return
     }
     void window.api.worktrees.persistSortOrder({ orderedIds: sortedIds })

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -458,14 +458,18 @@ const WorktreeList = React.memo(function WorktreeList() {
     const structuralChange = worktreeCount !== prevWorktreeCountRef.current
     prevWorktreeCountRef.current = worktreeCount
 
-    if (structuralChange) {
+    // Why: 'recent' sort order only changes on explicit user action (clicking
+    // a worktree), not from background signal churn like smart sort. Applying
+    // immediately avoids a 3-second lag between clicking and seeing the
+    // worktree move to the top.
+    if (structuralChange || sortBy === 'recent') {
       setDebouncedSortEpoch(sortEpoch)
       return
     }
 
     const timer = setTimeout(() => setDebouncedSortEpoch(sortEpoch), SORT_SETTLE_MS)
     return () => clearTimeout(timer)
-  }, [sortEpoch, debouncedSortEpoch, worktreeCount])
+  }, [sortEpoch, debouncedSortEpoch, worktreeCount, sortBy])
 
   // Why a latching ref: we need to distinguish "app just started, no PTYs
   // have spawned yet" from "user closed all terminals mid-session." The

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -458,18 +458,14 @@ const WorktreeList = React.memo(function WorktreeList() {
     const structuralChange = worktreeCount !== prevWorktreeCountRef.current
     prevWorktreeCountRef.current = worktreeCount
 
-    // Why: 'recent' sort order only changes on explicit user action (clicking
-    // a worktree), not from background signal churn like smart sort. Applying
-    // immediately avoids a 3-second lag between clicking and seeing the
-    // worktree move to the top.
-    if (structuralChange || sortBy === 'recent') {
+    if (structuralChange) {
       setDebouncedSortEpoch(sortEpoch)
       return
     }
 
     const timer = setTimeout(() => setDebouncedSortEpoch(sortEpoch), SORT_SETTLE_MS)
     return () => clearTimeout(timer)
-  }, [sortEpoch, debouncedSortEpoch, worktreeCount, sortBy])
+  }, [sortEpoch, debouncedSortEpoch, worktreeCount])
 
   // Why a latching ref: we need to distinguish "app just started, no PTYs
   // have spawned yet" from "user closed all terminals mid-session." The

--- a/src/renderer/src/components/sidebar/smart-sort.test.ts
+++ b/src/renderer/src/components/sidebar/smart-sort.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines */
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { Repo, TerminalTab, Worktree } from '../../../../shared/types'
-import { buildWorktreeComparator, computeSmartScore, type RecentSortOverride } from './smart-sort'
+import { buildWorktreeComparator, computeSmartScore, type SmartSortOverride } from './smart-sort'
 
 const NOW = new Date('2026-03-27T12:00:00.000Z').getTime()
 
@@ -295,7 +295,7 @@ describe('buildWorktreeComparator', () => {
     const tabsByWorktree = {
       [background.id]: [makeTab({ worktreeId: background.id, title: 'Claude Code - working' })]
     }
-    const recentSortOverrides: Record<string, RecentSortOverride> = {
+    const smartSortOverrides: Record<string, SmartSortOverride> = {
       [activeAfterClick.id]: {
         worktree: activeBeforeClick,
         tabs: [],
@@ -304,7 +304,7 @@ describe('buildWorktreeComparator', () => {
     }
 
     worktrees.sort(
-      buildWorktreeComparator('smart', tabsByWorktree, repoMap, null, NOW, recentSortOverrides)
+      buildWorktreeComparator('smart', tabsByWorktree, repoMap, null, NOW, smartSortOverrides)
     )
 
     expect(worktrees.map((worktree) => worktree.id)).toEqual(['background', 'active'])
@@ -324,7 +324,7 @@ describe('buildWorktreeComparator', () => {
       lastActivityAt: NOW - 2 * 60_000
     })
     const worktrees = [background, activeAfterClick]
-    const recentSortOverrides: Record<string, RecentSortOverride> = {
+    const smartSortOverrides: Record<string, SmartSortOverride> = {
       [activeAfterClick.id]: {
         worktree: activeBeforeClick,
         tabs: [],
@@ -332,7 +332,7 @@ describe('buildWorktreeComparator', () => {
       }
     }
 
-    worktrees.sort(buildWorktreeComparator('smart', null, repoMap, null, NOW, recentSortOverrides))
+    worktrees.sort(buildWorktreeComparator('smart', null, repoMap, null, NOW, smartSortOverrides))
 
     expect(worktrees.map((worktree) => worktree.id)).toEqual(['active', 'background'])
   })

--- a/src/renderer/src/components/sidebar/smart-sort.test.ts
+++ b/src/renderer/src/components/sidebar/smart-sort.test.ts
@@ -164,7 +164,7 @@ describe('buildWorktreeComparator', () => {
     vi.restoreAllMocks()
   })
 
-  it('sorts recent mode by ongoing work signals before alphabetical order', () => {
+  it('sorts smart mode by ongoing work signals before alphabetical order', () => {
     const active = makeWorktree({
       id: 'active',
       displayName: 'z-active',
@@ -183,7 +183,7 @@ describe('buildWorktreeComparator', () => {
 
     const worktrees = [recent, stale, active]
 
-    worktrees.sort(buildWorktreeComparator('recent', null, repoMap, null, NOW))
+    worktrees.sort(buildWorktreeComparator('smart', null, repoMap, null, NOW))
 
     expect(worktrees.map((worktree) => worktree.id)).toEqual(['active', 'recent', 'stale'])
   })
@@ -204,7 +204,7 @@ describe('buildWorktreeComparator', () => {
 
     const worktrees = [second, first]
 
-    worktrees.sort(buildWorktreeComparator('recent', null, repoMap, null, NOW))
+    worktrees.sort(buildWorktreeComparator('smart', null, repoMap, null, NOW))
 
     expect(worktrees.map((worktree) => worktree.id)).toEqual(['first', 'second'])
   })
@@ -225,7 +225,7 @@ describe('buildWorktreeComparator', () => {
 
     const worktrees = [beta, alpha]
 
-    worktrees.sort(buildWorktreeComparator('recent', null, repoMap, null, NOW))
+    worktrees.sort(buildWorktreeComparator('smart', null, repoMap, null, NOW))
 
     expect(worktrees.map((worktree) => worktree.id)).toEqual(['alpha', 'beta'])
   })
@@ -254,7 +254,7 @@ describe('buildWorktreeComparator', () => {
       }
     }
 
-    worktrees.sort(buildWorktreeComparator('recent', null, repoMap, prCache, NOW))
+    worktrees.sort(buildWorktreeComparator('smart', null, repoMap, prCache, NOW))
 
     expect(worktrees.map((worktree) => worktree.id)).toEqual(['live-pr', 'stale-linked'])
   })
@@ -273,7 +273,7 @@ describe('buildWorktreeComparator', () => {
     })
     const worktrees = [plain, coldCache]
 
-    worktrees.sort(buildWorktreeComparator('recent', null, repoMap, {}, NOW))
+    worktrees.sort(buildWorktreeComparator('smart', null, repoMap, {}, NOW))
 
     expect(worktrees.map((worktree) => worktree.id)).toEqual(['cold-cache', 'plain'])
   })
@@ -304,7 +304,7 @@ describe('buildWorktreeComparator', () => {
     }
 
     worktrees.sort(
-      buildWorktreeComparator('recent', tabsByWorktree, repoMap, null, NOW, recentSortOverrides)
+      buildWorktreeComparator('smart', tabsByWorktree, repoMap, null, NOW, recentSortOverrides)
     )
 
     expect(worktrees.map((worktree) => worktree.id)).toEqual(['background', 'active'])
@@ -332,7 +332,7 @@ describe('buildWorktreeComparator', () => {
       }
     }
 
-    worktrees.sort(buildWorktreeComparator('recent', null, repoMap, null, NOW, recentSortOverrides))
+    worktrees.sort(buildWorktreeComparator('smart', null, repoMap, null, NOW, recentSortOverrides))
 
     expect(worktrees.map((worktree) => worktree.id)).toEqual(['active', 'background'])
   })
@@ -351,7 +351,7 @@ describe('buildWorktreeComparator', () => {
     })
     const worktrees = [background, activeAfterClick]
 
-    worktrees.sort(buildWorktreeComparator('recent', null, repoMap, null, NOW))
+    worktrees.sort(buildWorktreeComparator('smart', null, repoMap, null, NOW))
 
     expect(worktrees.map((worktree) => worktree.id)).toEqual(['active', 'background'])
   })
@@ -378,8 +378,64 @@ describe('buildWorktreeComparator', () => {
     }
     const worktrees = [shutdown, justCreated]
 
-    worktrees.sort(buildWorktreeComparator('recent', null, repoMap, prCache, NOW))
+    worktrees.sort(buildWorktreeComparator('smart', null, repoMap, prCache, NOW))
 
     expect(worktrees.map((worktree) => worktree.id)).toEqual(['new', 'shutdown'])
+  })
+})
+
+describe('buildWorktreeComparator — recent (lastActivityAt)', () => {
+  it('sorts by lastActivityAt descending', () => {
+    const older = makeWorktree({
+      id: 'older',
+      displayName: 'Older',
+      lastActivityAt: NOW - 60_000
+    })
+    const newer = makeWorktree({
+      id: 'newer',
+      displayName: 'Newer',
+      lastActivityAt: NOW - 10_000
+    })
+    const worktrees = [older, newer]
+
+    worktrees.sort(buildWorktreeComparator('recent', null, repoMap, null, NOW))
+
+    expect(worktrees.map((w) => w.id)).toEqual(['newer', 'older'])
+  })
+
+  it('sorts worktrees with lastActivityAt 0 to the bottom', () => {
+    const active = makeWorktree({
+      id: 'active',
+      displayName: 'Active',
+      lastActivityAt: NOW - 60_000
+    })
+    const neverOpened = makeWorktree({
+      id: 'never',
+      displayName: 'Never Opened',
+      lastActivityAt: 0
+    })
+    const worktrees = [neverOpened, active]
+
+    worktrees.sort(buildWorktreeComparator('recent', null, repoMap, null, NOW))
+
+    expect(worktrees.map((w) => w.id)).toEqual(['active', 'never'])
+  })
+
+  it('falls back to alphabetical when lastActivityAt is equal', () => {
+    const bravo = makeWorktree({
+      id: 'bravo',
+      displayName: 'Bravo',
+      lastActivityAt: NOW - 60_000
+    })
+    const alpha = makeWorktree({
+      id: 'alpha',
+      displayName: 'Alpha',
+      lastActivityAt: NOW - 60_000
+    })
+    const worktrees = [bravo, alpha]
+
+    worktrees.sort(buildWorktreeComparator('recent', null, repoMap, null, NOW))
+
+    expect(worktrees.map((w) => w.id)).toEqual(['alpha', 'bravo'])
   })
 })

--- a/src/renderer/src/components/sidebar/smart-sort.test.ts
+++ b/src/renderer/src/components/sidebar/smart-sort.test.ts
@@ -384,17 +384,17 @@ describe('buildWorktreeComparator', () => {
   })
 })
 
-describe('buildWorktreeComparator — recent (lastActivityAt)', () => {
-  it('sorts by lastActivityAt descending', () => {
+describe('buildWorktreeComparator — recent (sortOrder / creation time)', () => {
+  it('sorts by sortOrder descending (newest first)', () => {
     const older = makeWorktree({
       id: 'older',
       displayName: 'Older',
-      lastActivityAt: NOW - 60_000
+      sortOrder: 1000
     })
     const newer = makeWorktree({
       id: 'newer',
       displayName: 'Newer',
-      lastActivityAt: NOW - 10_000
+      sortOrder: 2000
     })
     const worktrees = [older, newer]
 
@@ -403,34 +403,34 @@ describe('buildWorktreeComparator — recent (lastActivityAt)', () => {
     expect(worktrees.map((w) => w.id)).toEqual(['newer', 'older'])
   })
 
-  it('sorts worktrees with lastActivityAt 0 to the bottom', () => {
-    const active = makeWorktree({
-      id: 'active',
-      displayName: 'Active',
-      lastActivityAt: NOW - 60_000
+  it('sorts worktrees with sortOrder 0 to the bottom', () => {
+    const created = makeWorktree({
+      id: 'created',
+      displayName: 'Created',
+      sortOrder: 1000
     })
-    const neverOpened = makeWorktree({
-      id: 'never',
-      displayName: 'Never Opened',
-      lastActivityAt: 0
+    const legacy = makeWorktree({
+      id: 'legacy',
+      displayName: 'Legacy',
+      sortOrder: 0
     })
-    const worktrees = [neverOpened, active]
+    const worktrees = [legacy, created]
 
     worktrees.sort(buildWorktreeComparator('recent', null, repoMap, null, NOW))
 
-    expect(worktrees.map((w) => w.id)).toEqual(['active', 'never'])
+    expect(worktrees.map((w) => w.id)).toEqual(['created', 'legacy'])
   })
 
-  it('falls back to alphabetical when lastActivityAt is equal', () => {
+  it('falls back to alphabetical when sortOrder is equal', () => {
     const bravo = makeWorktree({
       id: 'bravo',
       displayName: 'Bravo',
-      lastActivityAt: NOW - 60_000
+      sortOrder: 1000
     })
     const alpha = makeWorktree({
       id: 'alpha',
       displayName: 'Alpha',
-      lastActivityAt: NOW - 60_000
+      sortOrder: 1000
     })
     const worktrees = [bravo, alpha]
 

--- a/src/renderer/src/components/sidebar/smart-sort.ts
+++ b/src/renderer/src/components/sidebar/smart-sort.ts
@@ -5,7 +5,7 @@ import type { Worktree, Repo, TerminalTab } from '../../../../shared/types'
 type SortBy = 'name' | 'smart' | 'recent' | 'repo'
 
 type PRCacheEntry = { data: object | null; fetchedAt: number }
-export type RecentSortOverride = {
+export type SmartSortOverride = {
   worktree: Worktree
   tabs: TerminalTab[]
   hasRecentPRSignal: boolean
@@ -86,10 +86,10 @@ function getSmartSortCandidate(
   tabsByWorktree: Record<string, TerminalTab[]> | null,
   repoMap: Map<string, Repo>,
   prCache: Record<string, PRCacheEntry> | null,
-  recentSortOverrides: Record<string, RecentSortOverride> | null
-): RecentSortOverride {
+  smartSortOverrides: Record<string, SmartSortOverride> | null
+): SmartSortOverride {
   return (
-    recentSortOverrides?.[worktree.id] ?? {
+    smartSortOverrides?.[worktree.id] ?? {
       worktree,
       tabs: tabsByWorktree?.[worktree.id] ?? [],
       hasRecentPRSignal: hasRecentPRSignal(worktree, repoMap, prCache)
@@ -106,7 +106,7 @@ export function buildWorktreeComparator(
   repoMap: Map<string, Repo>,
   prCache: Record<string, PRCacheEntry> | null,
   now: number = Date.now(),
-  recentSortOverrides: Record<string, RecentSortOverride> | null = null
+  smartSortOverrides: Record<string, SmartSortOverride> | null = null
 ): (a: Worktree, b: Worktree) => number {
   return (a, b) => {
     switch (sortBy) {
@@ -118,14 +118,14 @@ export function buildWorktreeComparator(
           tabsByWorktree,
           repoMap,
           prCache,
-          recentSortOverrides
+          smartSortOverrides
         )
         const smartB = getSmartSortCandidate(
           b,
           tabsByWorktree,
           repoMap,
           prCache,
-          recentSortOverrides
+          smartSortOverrides
         )
         return (
           computeSmartScoreFromSignals(

--- a/src/renderer/src/components/sidebar/smart-sort.ts
+++ b/src/renderer/src/components/sidebar/smart-sort.ts
@@ -2,7 +2,7 @@ import { detectAgentStatusFromTitle } from '@/lib/agent-status'
 import { branchName } from '@/lib/git-utils'
 import type { Worktree, Repo, TerminalTab } from '../../../../shared/types'
 
-type SortBy = 'name' | 'recent' | 'repo'
+type SortBy = 'name' | 'smart' | 'recent' | 'repo'
 
 type PRCacheEntry = { data: object | null; fetchedAt: number }
 export type RecentSortOverride = {
@@ -74,14 +74,14 @@ function computeSmartScoreFromSignals(
     // since the PTY spawns asynchronously after creation). Weight must exceed
     // the max passive-signal combination for shutdown worktrees
     // (isUnread 18 + PR 10 + issue 6 = 34) so brand-new worktrees always
-    // appear at the top of the "recent" sort immediately.
+    // appear at the top of the "smart" sort immediately.
     score += 36 * Math.max(0, 1 - activityAge / ONE_DAY)
   }
 
   return score
 }
 
-function getRecentSortCandidate(
+function getSmartSortCandidate(
   worktree: Worktree,
   tabsByWorktree: Record<string, TerminalTab[]> | null,
   repoMap: Map<string, Repo>,
@@ -112,61 +112,64 @@ export function buildWorktreeComparator(
     switch (sortBy) {
       case 'name':
         return a.displayName.localeCompare(b.displayName)
-      case 'recent': {
-        const recentA = getRecentSortCandidate(
+      case 'smart': {
+        const smartA = getSmartSortCandidate(
           a,
           tabsByWorktree,
           repoMap,
           prCache,
           recentSortOverrides
         )
-        const recentB = getRecentSortCandidate(
+        const smartB = getSmartSortCandidate(
           b,
           tabsByWorktree,
           repoMap,
           prCache,
           recentSortOverrides
         )
-        // Recent means meaningful recent work, not selection time.
         return (
           computeSmartScoreFromSignals(
-            recentB.worktree,
-            recentB.tabs,
-            recentB.hasRecentPRSignal,
+            smartB.worktree,
+            smartB.tabs,
+            smartB.hasRecentPRSignal,
             now
           ) -
             computeSmartScoreFromSignals(
-              recentA.worktree,
-              recentA.tabs,
-              recentA.hasRecentPRSignal,
+              smartA.worktree,
+              smartA.tabs,
+              smartA.hasRecentPRSignal,
               now
             ) ||
-          recentB.worktree.lastActivityAt - recentA.worktree.lastActivityAt ||
+          smartB.worktree.lastActivityAt - smartA.worktree.lastActivityAt ||
           a.displayName.localeCompare(b.displayName)
         )
       }
+      case 'recent':
+        return b.lastActivityAt - a.lastActivityAt || a.displayName.localeCompare(b.displayName)
       case 'repo': {
         const ra = repoMap.get(a.repoId)?.displayName ?? ''
         const rb = repoMap.get(b.repoId)?.displayName ?? ''
         const cmp = ra.localeCompare(rb)
         return cmp !== 0 ? cmp : a.displayName.localeCompare(b.displayName)
       }
-      default:
-        return 0
+      default: {
+        const _exhaustive: never = sortBy
+        return _exhaustive
+      }
     }
   }
 }
 
 /**
- * Sort worktrees by recent-work signals, handling the cold-start / warm
- * distinction in one place. On cold start (no live PTYs yet), falls back to
- * persisted `sortOrder` descending with alphabetical `displayName` fallback.
+ * Sort worktrees by weighted smart-score signals, handling the cold-start /
+ * warm distinction in one place. On cold start (no live PTYs yet), falls back
+ * to persisted `sortOrder` descending with alphabetical `displayName` fallback.
  * Once any PTY is alive, uses the full smart-score comparator.
  *
  * Both the palette and `getVisibleWorktreeIds()` import this to avoid
  * duplicating the cold/warm branching logic.
  */
-export function sortWorktreesRecent(
+export function sortWorktreesSmart(
   worktrees: Worktree[],
   tabsByWorktree: Record<string, TerminalTab[]>,
   repoMap: Map<string, Repo>,
@@ -184,7 +187,7 @@ export function sortWorktreesRecent(
   }
 
   return [...worktrees].sort(
-    buildWorktreeComparator('recent', tabsByWorktree, repoMap, prCache, Date.now())
+    buildWorktreeComparator('smart', tabsByWorktree, repoMap, prCache, Date.now())
   )
 }
 
@@ -213,7 +216,7 @@ export function computeSmartScore(
     tabsByWorktree?.[worktree.id] ?? [],
     // Why: branch-aware PR cache is the freshest signal, but off-screen
     // worktrees may not have fetched it yet. Fall back to persisted linkedPR
-    // only while that branch cache entry is still cold so recent sorting stays
+    // only while that branch cache entry is still cold so smart sorting stays
     // stable on launch without reviving stale PRs after a cache miss resolves.
     repoMap ? hasRecentPRSignal(worktree, repoMap, prCache) : worktree.linkedPR !== null,
     now

--- a/src/renderer/src/components/sidebar/smart-sort.ts
+++ b/src/renderer/src/components/sidebar/smart-sort.ts
@@ -145,7 +145,7 @@ export function buildWorktreeComparator(
         )
       }
       case 'recent':
-        return b.lastActivityAt - a.lastActivityAt || a.displayName.localeCompare(b.displayName)
+        return b.sortOrder - a.sortOrder || a.displayName.localeCompare(b.displayName)
       case 'repo': {
         const ra = repoMap.get(a.repoId)?.displayName ?? ''
         const rb = repoMap.get(b.repoId)?.displayName ?? ''

--- a/src/renderer/src/components/sidebar/visible-worktrees.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.ts
@@ -1,7 +1,7 @@
 import type { Worktree, Repo, TerminalTab } from '../../../../shared/types'
 import type { AppState } from '@/store/types'
 import { matchesSearch } from './worktree-list-groups'
-import { buildWorktreeComparator, sortWorktreesRecent } from './smart-sort'
+import { buildWorktreeComparator, sortWorktreesSmart } from './smart-sort'
 import { useAppStore } from '@/store'
 
 /**
@@ -120,13 +120,10 @@ export function getVisibleWorktreeIds(): string[] {
 
   let sortedIds: string[]
 
-  if (state.sortBy === 'recent') {
-    sortedIds = sortWorktreesRecent(
-      allWorktrees,
-      state.tabsByWorktree,
-      repoMap,
-      state.prCache
-    ).map((w) => w.id)
+  if (state.sortBy === 'smart') {
+    sortedIds = sortWorktreesSmart(allWorktrees, state.tabsByWorktree, repoMap, state.prCache).map(
+      (w) => w.id
+    )
   } else {
     const sorted = [...allWorktrees].sort(
       buildWorktreeComparator(

--- a/src/renderer/src/store/slices/store-cascades.test.ts
+++ b/src/renderer/src/store/slices/store-cascades.test.ts
@@ -320,8 +320,9 @@ describe('setActiveWorktree', () => {
 
     const worktree = store.getState().worktreesByRepo.repo1[0]
     expect(worktree.sortOrder).toBe(123)
-    // Why: setActiveWorktree now persists lastActivityAt for the recent sort,
-    // but must never touch sortOrder which is managed by persistSortOrder.
+    // Why: setActiveWorktree persists lastActivityAt for the smart sort's
+    // time-decay signal, but must never touch sortOrder which is managed
+    // by persistSortOrder.
     expect(mockApi.worktrees.updateMeta).toHaveBeenCalledWith(
       expect.objectContaining({
         worktreeId,

--- a/src/renderer/src/store/slices/store-cascades.test.ts
+++ b/src/renderer/src/store/slices/store-cascades.test.ts
@@ -320,7 +320,14 @@ describe('setActiveWorktree', () => {
 
     const worktree = store.getState().worktreesByRepo.repo1[0]
     expect(worktree.sortOrder).toBe(123)
-    expect(mockApi.worktrees.updateMeta).not.toHaveBeenCalled()
+    // Why: setActiveWorktree now persists lastActivityAt for the recent sort,
+    // but must never touch sortOrder which is managed by persistSortOrder.
+    expect(mockApi.worktrees.updateMeta).toHaveBeenCalledWith(
+      expect.objectContaining({
+        worktreeId,
+        updates: expect.not.objectContaining({ sortOrder: expect.anything() })
+      })
+    )
   })
 
   it('falls back to the worktree browser tab when the restored editor id belongs to a different worktree', () => {

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -170,7 +170,7 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set) => (
       // v1: sort was called 'smart' internally
       // v2: renamed 'smart' → 'recent' (same weighted-score behavior)
       // v3: 'smart' reintroduced as the weighted-score sort, 'recent' becomes
-      //     a true last-activity sort. The one-shot migration from old 'recent'
+      //     a creation-time sort. The one-shot migration from old 'recent'
       //     to 'smart' now happens in the main process (persistence.ts load())
       //     using the _sortBySmartMigrated flag — not here — so that users who
       //     intentionally select the new 'recent' sort keep it across restarts.

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -12,8 +12,6 @@ import {
   DEFAULT_WORKTREE_CARD_PROPERTIES
 } from '../../../../shared/constants'
 
-type LegacyPersistedSortBy = PersistedUIState['sortBy'] | 'smart'
-
 const MIN_SIDEBAR_WIDTH = 220
 const MAX_SIDEBAR_WIDTH = 500
 
@@ -56,7 +54,7 @@ export type UISlice = {
   setSearchQuery: (q: string) => void
   groupBy: 'none' | 'repo' | 'pr-status'
   setGroupBy: (g: UISlice['groupBy']) => void
-  sortBy: 'name' | 'recent' | 'repo'
+  sortBy: 'name' | 'smart' | 'recent' | 'repo'
   setSortBy: (s: UISlice['sortBy']) => void
   showActiveOnly: boolean
   setShowActiveOnly: (v: boolean) => void
@@ -168,7 +166,15 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set) => (
   hydratePersistedUI: (ui) =>
     set((s) => {
       const validRepoIds = new Set(s.repos.map((repo) => repo.id))
-      const sortBy = (ui.sortBy as LegacyPersistedSortBy) === 'smart' ? 'recent' : ui.sortBy
+      // Migration history:
+      // v1: sort was called 'smart' internally
+      // v2: renamed 'smart' → 'recent' (same weighted-score behavior)
+      // v3: 'smart' reintroduced as the weighted-score sort, 'recent' becomes
+      //     a true last-activity sort. The one-shot migration from old 'recent'
+      //     to 'smart' now happens in the main process (persistence.ts load())
+      //     using the _sortBySmartMigrated flag — not here — so that users who
+      //     intentionally select the new 'recent' sort keep it across restarts.
+      const sortBy = ui.sortBy
       return {
         // Why: persisted UI data comes from disk and may be stale, corrupted,
         // or manually edited. Clamp widths during hydration so invalid values

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines */
 import type { StateCreator } from 'zustand'
 import type { AppState } from '../types'
-import type { Worktree, WorkspaceVisibleTabType } from '../../../../shared/types'
+import type { Worktree, WorkspaceVisibleTabType, WorktreeMeta } from '../../../../shared/types'
 import {
   findWorktreeById,
   applyWorktreeUpdates,
@@ -354,9 +354,9 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       // re-sorting the sidebar in response would cause the exact reorder-
       // on-click bug PR #209 intended to fix (e.g. dead-PTY reconnection
       // after generation bump triggers updateTabPtyId → here).
-      // The lastActivityAt timestamp is still persisted so that the NEXT
-      // meaningful sortEpoch bump (from a background worktree event) will
-      // include this worktree's updated score.
+      // For 'recent' sort, the active worktree already has the latest
+      // lastActivityAt from setActiveWorktree, so it's already at the top;
+      // additional bumps here would only cause unnecessary re-sort work.
       const isActive = s.activeWorktreeId === worktreeId
       return {
         worktreesByRepo: applyWorktreeUpdates(s.worktreesByRepo, worktreeId, {
@@ -378,6 +378,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
     const reconciledActiveTabId = worktreeId
       ? get().reconcileWorktreeTabModel(worktreeId).activeRenderableTabId
       : null
+    const now = Date.now()
     let shouldClearUnread = false
     set((s) => {
       if (!worktreeId) {
@@ -496,6 +497,16 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
             ? restoredTabId
             : (worktreeTabs[0]?.id ?? null)
 
+      // Why: bump lastActivityAt on selection so the 'recent' sort (which
+      // orders by last interaction time) reflects the user's navigation.
+      // For 'smart' sort, do NOT bump sortEpoch — that would re-sort the
+      // sidebar on every click, causing the reorder-on-click bug (PR #209).
+      // For 'recent' sort, reordering on click IS the expected behavior:
+      // the most recently selected worktree should move to the top.
+      const metaUpdates: Partial<WorktreeMeta> = { lastActivityAt: now }
+      if (shouldClearUnread) {
+        metaUpdates.isUnread = false
+      }
       return {
         activeWorktreeId: worktreeId,
         activeFileId,
@@ -503,11 +514,8 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
         activeTabType,
         activeTabTypeByWorktree: { ...s.activeTabTypeByWorktree, [worktreeId]: activeTabType },
         activeTabId,
-        worktreesByRepo: applyWorktreeUpdates(
-          s.worktreesByRepo,
-          worktreeId,
-          shouldClearUnread ? { isUnread: false } : {}
-        )
+        worktreesByRepo: applyWorktreeUpdates(s.worktreesByRepo, worktreeId, metaUpdates),
+        ...(s.sortBy === 'recent' ? { sortEpoch: s.sortEpoch + 1 } : {})
       }
     })
 
@@ -540,13 +548,11 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       return
     }
 
-    const updates: Parameters<typeof window.api.worktrees.updateMeta>[0]['updates'] = {}
+    const updates: Parameters<typeof window.api.worktrees.updateMeta>[0]['updates'] = {
+      lastActivityAt: now
+    }
     if (shouldClearUnread) {
       updates.isUnread = false
-    }
-
-    if (Object.keys(updates).length === 0) {
-      return
     }
 
     void window.api.worktrees.updateMeta({ worktreeId, updates }).catch((err) => {

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -354,9 +354,9 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       // re-sorting the sidebar in response would cause the exact reorder-
       // on-click bug PR #209 intended to fix (e.g. dead-PTY reconnection
       // after generation bump triggers updateTabPtyId → here).
-      // For 'recent' sort, the active worktree already has the latest
-      // lastActivityAt from setActiveWorktree, so it's already at the top;
-      // additional bumps here would only cause unnecessary re-sort work.
+      // The lastActivityAt timestamp is still persisted so that the NEXT
+      // meaningful sortEpoch bump (from a background worktree event) will
+      // include this worktree's updated smart-sort score.
       const isActive = s.activeWorktreeId === worktreeId
       return {
         worktreesByRepo: applyWorktreeUpdates(s.worktreesByRepo, worktreeId, {

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -499,16 +499,14 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
 
       // Why: bump lastActivityAt on selection so the 'recent' sort (which
       // orders by last interaction time) reflects the user's navigation.
-      // For 'recent' sort, bump sortEpoch only when switching TO a different
-      // worktree — the re-sort settles the *previous* worktree into its new
-      // recency position while the user's attention is already on the target.
-      // This avoids the jarring visual of items teleporting while you watch.
+      // For 'smart' sort, do NOT bump sortEpoch — that would re-sort the
+      // sidebar on every click, causing the reorder-on-click bug (PR #209).
+      // For 'recent' sort, bump sortEpoch so the list reorders immediately;
+      // WorktreeList applies a FLIP animation to smooth the visual transition.
       const metaUpdates: Partial<WorktreeMeta> = { lastActivityAt: now }
       if (shouldClearUnread) {
         metaUpdates.isUnread = false
       }
-      const isSwitch =
-        s.sortBy === 'recent' && s.activeWorktreeId !== null && s.activeWorktreeId !== worktreeId
       return {
         activeWorktreeId: worktreeId,
         activeFileId,
@@ -517,7 +515,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
         activeTabTypeByWorktree: { ...s.activeTabTypeByWorktree, [worktreeId]: activeTabType },
         activeTabId,
         worktreesByRepo: applyWorktreeUpdates(s.worktreesByRepo, worktreeId, metaUpdates),
-        ...(isSwitch ? { sortEpoch: s.sortEpoch + 1 } : {})
+        ...(s.sortBy === 'recent' ? { sortEpoch: s.sortEpoch + 1 } : {})
       }
     })
 

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -497,12 +497,11 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
             ? restoredTabId
             : (worktreeTabs[0]?.id ?? null)
 
-      // Why: bump lastActivityAt on selection so the 'recent' sort (which
-      // orders by last interaction time) reflects the user's navigation.
-      // For 'smart' sort, do NOT bump sortEpoch — that would re-sort the
-      // sidebar on every click, causing the reorder-on-click bug (PR #209).
-      // For 'recent' sort, bump sortEpoch so the list reorders immediately;
-      // WorktreeList applies a FLIP animation to smooth the visual transition.
+      // Why: bump lastActivityAt so the smart sort's time-decay signal
+      // reflects navigation recency. Do NOT bump sortEpoch — that would
+      // re-sort the sidebar on every click, causing the reorder-on-click
+      // bug (PR #209). The timestamp is persisted so the next sortEpoch
+      // bump (from a background event) includes this worktree's updated score.
       const metaUpdates: Partial<WorktreeMeta> = { lastActivityAt: now }
       if (shouldClearUnread) {
         metaUpdates.isUnread = false
@@ -514,8 +513,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
         activeTabType,
         activeTabTypeByWorktree: { ...s.activeTabTypeByWorktree, [worktreeId]: activeTabType },
         activeTabId,
-        worktreesByRepo: applyWorktreeUpdates(s.worktreesByRepo, worktreeId, metaUpdates),
-        ...(s.sortBy === 'recent' ? { sortEpoch: s.sortEpoch + 1 } : {})
+        worktreesByRepo: applyWorktreeUpdates(s.worktreesByRepo, worktreeId, metaUpdates)
       }
     })
 

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -499,14 +499,16 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
 
       // Why: bump lastActivityAt on selection so the 'recent' sort (which
       // orders by last interaction time) reflects the user's navigation.
-      // For 'smart' sort, do NOT bump sortEpoch — that would re-sort the
-      // sidebar on every click, causing the reorder-on-click bug (PR #209).
-      // For 'recent' sort, reordering on click IS the expected behavior:
-      // the most recently selected worktree should move to the top.
+      // For 'recent' sort, bump sortEpoch only when switching TO a different
+      // worktree — the re-sort settles the *previous* worktree into its new
+      // recency position while the user's attention is already on the target.
+      // This avoids the jarring visual of items teleporting while you watch.
       const metaUpdates: Partial<WorktreeMeta> = { lastActivityAt: now }
       if (shouldClearUnread) {
         metaUpdates.isUnread = false
       }
+      const isSwitch =
+        s.sortBy === 'recent' && s.activeWorktreeId !== null && s.activeWorktreeId !== worktreeId
       return {
         activeWorktreeId: worktreeId,
         activeFileId,
@@ -515,7 +517,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
         activeTabTypeByWorktree: { ...s.activeTabTypeByWorktree, [worktreeId]: activeTabType },
         activeTabId,
         worktreesByRepo: applyWorktreeUpdates(s.worktreesByRepo, worktreeId, metaUpdates),
-        ...(s.sortBy === 'recent' ? { sortEpoch: s.sortEpoch + 1 } : {})
+        ...(isSwitch ? { sortEpoch: s.sortEpoch + 1 } : {})
       }
     })
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -559,7 +559,7 @@ export type PersistedUIState = {
   sidebarWidth: number
   rightSidebarWidth: number
   groupBy: 'none' | 'repo' | 'pr-status'
-  sortBy: 'name' | 'recent' | 'repo'
+  sortBy: 'name' | 'smart' | 'recent' | 'repo'
   showActiveOnly: boolean
   filterRepoIds: string[]
   uiZoomLevel: number
@@ -586,6 +586,12 @@ export type PersistedUIState = {
   windowBounds?: { x: number; y: number; width: number; height: number } | null
   /** Whether the window was maximized when it was last closed. */
   windowMaximized?: boolean
+  /** One-shot migration flag: 'recent' used to mean the weighted smart sort
+   *  (v1→v2 rename). When this flag is absent and sortBy is 'recent', the
+   *  main-process load() migrates it to 'smart' and sets this flag so the
+   *  migration never re-fires — allowing users to intentionally select the
+   *  new 'recent' (last-activity) sort without it being clobbered on restart. */
+  _sortBySmartMigrated?: boolean
 }
 
 // ─── Persistence shape ──────────────────────────────────────────────

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -590,7 +590,7 @@ export type PersistedUIState = {
    *  (v1→v2 rename). When this flag is absent and sortBy is 'recent', the
    *  main-process load() migrates it to 'smart' and sets this flag so the
    *  migration never re-fires — allowing users to intentionally select the
-   *  new 'recent' (last-activity) sort without it being clobbered on restart. */
+   *  new 'recent' (creation-time) sort without it being clobbered on restart. */
   _sortBySmartMigrated?: boolean
 }
 


### PR DESCRIPTION
## Summary
- Rename the old "recent" sort (weighted smart scoring) to **"Smart"** and introduce a true **"Recent"** sort that orders worktrees by creation time (`sortOrder`)
- One-shot migration via `_sortBySmartMigrated` flag ensures existing users on the old "recent" are transparently moved to "smart" without breaking users who later intentionally choose the new "Recent"
- The new "Recent" sort is static — it only changes when worktrees are added or removed, so there is no jarring reordering during normal use

## What changed
- **`smart-sort.ts`**: `SortBy` union gains `'smart'`; old `case 'recent'` (weighted score) → `case 'smart'`; new `case 'recent'` sorts by `sortOrder` descending (creation time); `sortWorktreesRecent` → `sortWorktreesSmart`; `RecentSortOverride` → `SmartSortOverride`; `getRecentSortCandidate` → `getSmartSortCandidate`
- **`persistence.ts`**: `normalizeSortBy` accepts `'smart'`; `load()` one-shot migration with `_sortBySmartMigrated` flag
- **`worktrees.ts`**: `setActiveWorktree` bumps `lastActivityAt` for smart sort's time-decay signal (does not affect recent sort order)
- **`WorktreeList.tsx`**: subscription gating updated (`sortBy === 'smart'` for tabs/PR cache); cold-start detection scoped to smart sort; debounce bypass not needed for recent (static order)
- **`ui.ts`**: `hydratePersistedUI` passes `sortBy` through without re-migrating (migration lives in main process)
- **`SidebarHeader.tsx`**: sort dropdown now shows Name / Smart / Recent / Repo
- **`types.ts`**: `PersistedUIState.sortBy` includes `'smart'`; new `_sortBySmartMigrated` flag

## Test plan
- [x] `pnpm run typecheck` passes
- [x] `pnpm vitest run` — all tests pass (smart-sort, persistence, store-session-cascades)
- [x] CI green
- [ ] Manual: set sort to "Recent" → worktrees ordered by creation time (newest first)
- [ ] Manual: existing user on old "recent" → upgrades → sort shows "Smart" with same weighted behavior
- [ ] Manual: user picks new "Recent" → restarts → sort stays "Recent" (not re-migrated)
- [ ] Manual: "Smart" sort still suppresses reorder-on-click (PR #209 behavior preserved)