### PR TITLE
fix: position browser context menu at cursor with edge flipping

### DIFF
--- a/src/main/browser/browser-guest-ui.test.ts
+++ b/src/main/browser/browser-guest-ui.test.ts
@@ -1,0 +1,219 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { screenGetCursorScreenPointMock } = vi.hoisted(() => ({
+  screenGetCursorScreenPointMock: vi.fn(() => ({ x: 0, y: 0 }))
+}))
+
+vi.mock('electron', () => ({
+  screen: { getCursorScreenPoint: screenGetCursorScreenPointMock },
+  webContents: { fromId: vi.fn() }
+}))
+
+import { setupGuestContextMenu } from './browser-guest-ui'
+
+describe('setupGuestContextMenu', () => {
+  const browserTabId = 'tab-1'
+  let rendererSendMock: ReturnType<typeof vi.fn>
+  let guestOnMock: ReturnType<typeof vi.fn>
+  let guestOffMock: ReturnType<typeof vi.fn>
+
+  function makeGuest(overrides: Record<string, unknown> = {}) {
+    return {
+      getURL: vi.fn(() => 'https://example.com'),
+      canGoBack: vi.fn(() => true),
+      canGoForward: vi.fn(() => false),
+      on: guestOnMock,
+      off: guestOffMock,
+      ...overrides
+    } as unknown as Electron.WebContents
+  }
+
+  function makeRenderer() {
+    return { send: rendererSendMock } as unknown as Electron.WebContents
+  }
+
+  beforeEach(() => {
+    rendererSendMock = vi.fn()
+    guestOnMock = vi.fn()
+    guestOffMock = vi.fn()
+    screenGetCursorScreenPointMock.mockReturnValue({ x: 0, y: 0 })
+  })
+
+  function triggerContextMenu(
+    _guest: Electron.WebContents,
+    params: Partial<Electron.ContextMenuParams>
+  ) {
+    const handler = guestOnMock.mock.calls.find((call) => call[0] === 'context-menu')?.[1] as
+      | ((event: unknown, params: Electron.ContextMenuParams) => void)
+      | undefined
+
+    expect(handler).toBeTypeOf('function')
+    handler!({}, { x: 0, y: 0, linkURL: '', ...params } as Electron.ContextMenuParams)
+  }
+
+  it('passes through guest viewport coordinates (params.x/y) to the renderer', () => {
+    const guest = makeGuest()
+    const renderer = makeRenderer()
+
+    setupGuestContextMenu({
+      browserTabId,
+      guest,
+      resolveRenderer: () => renderer
+    })
+
+    triggerContextMenu(guest, { x: 150, y: 275 })
+
+    expect(rendererSendMock).toHaveBeenCalledWith(
+      'browser:context-menu-requested',
+      expect.objectContaining({ x: 150, y: 275 })
+    )
+  })
+
+  it('includes navigation state and page URL alongside coordinates', () => {
+    screenGetCursorScreenPointMock.mockReturnValue({ x: 500, y: 375 })
+    const guest = makeGuest({
+      getURL: vi.fn(() => 'https://test.dev/page'),
+      canGoBack: vi.fn(() => true),
+      canGoForward: vi.fn(() => true)
+    })
+    const renderer = makeRenderer()
+
+    setupGuestContextMenu({
+      browserTabId,
+      guest,
+      resolveRenderer: () => renderer
+    })
+
+    triggerContextMenu(guest, { x: 50, y: 75, linkURL: 'https://test.dev/link' })
+
+    expect(rendererSendMock).toHaveBeenCalledWith('browser:context-menu-requested', {
+      browserPageId: browserTabId,
+      x: 50,
+      y: 75,
+      screenX: 500,
+      screenY: 375,
+      pageUrl: 'https://test.dev/page',
+      linkUrl: 'https://test.dev/link',
+      canGoBack: true,
+      canGoForward: true
+    })
+  })
+
+  it('does not send when renderer is unavailable', () => {
+    const guest = makeGuest()
+
+    setupGuestContextMenu({
+      browserTabId,
+      guest,
+      resolveRenderer: () => null
+    })
+
+    triggerContextMenu(guest, { x: 100, y: 200 })
+
+    expect(rendererSendMock).not.toHaveBeenCalled()
+  })
+
+  it('cleans up context-menu listener on teardown', () => {
+    const guest = makeGuest()
+
+    const cleanup = setupGuestContextMenu({
+      browserTabId,
+      guest,
+      resolveRenderer: () => makeRenderer()
+    })
+
+    cleanup()
+
+    expect(guestOffMock).toHaveBeenCalledWith('context-menu', expect.any(Function))
+  })
+
+  describe('dismiss handler', () => {
+    function triggerMouseEvent(button: string, type: string = 'mouseDown') {
+      const beforeMouseHandler = guestOnMock.mock.calls.find(
+        (call) => call[0] === 'before-mouse-event'
+      )?.[1] as ((event: unknown, mouse: { type: string; button: string }) => void) | undefined
+
+      expect(beforeMouseHandler).toBeTypeOf('function')
+      beforeMouseHandler!({}, { type, button })
+    }
+
+    it('dismisses context menu on left-click', () => {
+      const guest = makeGuest()
+      const renderer = makeRenderer()
+
+      setupGuestContextMenu({
+        browserTabId,
+        guest,
+        resolveRenderer: () => renderer
+      })
+
+      triggerContextMenu(guest, { x: 100, y: 200 })
+      rendererSendMock.mockClear()
+
+      triggerMouseEvent('left')
+
+      expect(rendererSendMock).toHaveBeenCalledWith('browser:context-menu-dismissed', {
+        browserPageId: browserTabId
+      })
+    })
+
+    it('does not dismiss context menu on right-click', () => {
+      const guest = makeGuest()
+      const renderer = makeRenderer()
+
+      setupGuestContextMenu({
+        browserTabId,
+        guest,
+        resolveRenderer: () => renderer
+      })
+
+      triggerContextMenu(guest, { x: 100, y: 200 })
+      rendererSendMock.mockClear()
+
+      triggerMouseEvent('right')
+
+      expect(rendererSendMock).not.toHaveBeenCalledWith(
+        'browser:context-menu-dismissed',
+        expect.anything()
+      )
+    })
+
+    it('dismisses context menu on middle-click', () => {
+      const guest = makeGuest()
+      const renderer = makeRenderer()
+
+      setupGuestContextMenu({
+        browserTabId,
+        guest,
+        resolveRenderer: () => renderer
+      })
+
+      triggerContextMenu(guest, { x: 100, y: 200 })
+      rendererSendMock.mockClear()
+
+      triggerMouseEvent('middle')
+
+      expect(rendererSendMock).toHaveBeenCalledWith('browser:context-menu-dismissed', {
+        browserPageId: browserTabId
+      })
+    })
+
+    it('ignores non-mouseDown events', () => {
+      const guest = makeGuest()
+      const renderer = makeRenderer()
+
+      setupGuestContextMenu({
+        browserTabId,
+        guest,
+        resolveRenderer: () => renderer
+      })
+
+      triggerContextMenu(guest, { x: 100, y: 200 })
+      rendererSendMock.mockClear()
+
+      triggerMouseEvent('left', 'mouseMove')
+
+      expect(rendererSendMock).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/main/browser/browser-guest-ui.ts
+++ b/src/main/browser/browser-guest-ui.ts
@@ -1,4 +1,4 @@
-import { webContents } from 'electron'
+import { screen, webContents } from 'electron'
 import {
   normalizeBrowserNavigationUrl,
   normalizeExternalBrowserUrl
@@ -31,47 +31,22 @@ export function setupGuestContextMenu(args: {
       rawLinkUrl.length > 0
         ? (normalizeExternalBrowserUrl(rawLinkUrl) ?? normalizeBrowserNavigationUrl(rawLinkUrl))
         : null
-    const sendContextMenu = (viewportX: number, viewportY: number): void => {
-      renderer.send('browser:context-menu-requested', {
-        browserPageId: browserTabId,
-        x: viewportX,
-        y: viewportY,
-        pageUrl,
-        linkUrl,
-        canGoBack: guest.canGoBack(),
-        canGoForward: guest.canGoForward()
-      })
-    }
-
-    // Why: Electron reports guest context-menu coordinates in page space.
-    // Orca's renderer-owned menu needs viewport-relative coordinates so the
-    // menu appears under the cursor even after the page has scrolled.
-    if (typeof guest.executeJavaScript !== 'function') {
-      // Why: some tests and rare teardown edges only expose a minimal
-      // WebContents shape. Falling back to raw coordinates keeps the menu
-      // request best-effort instead of hard-failing on missing helpers.
-      sendContextMenu(params.x, params.y)
-      return
-    }
-
-    void guest
-      .executeJavaScript('({ scrollX: window.scrollX, scrollY: window.scrollY })', true)
-      .then((scroll) => {
-        const scrollX =
-          typeof scroll === 'object' && scroll && 'scrollX' in scroll
-            ? Number((scroll as { scrollX: unknown }).scrollX) || 0
-            : 0
-        const scrollY =
-          typeof scroll === 'object' && scroll && 'scrollY' in scroll
-            ? Number((scroll as { scrollY: unknown }).scrollY) || 0
-            : 0
-        sendContextMenu(params.x - scrollX, params.y - scrollY)
-      })
-      .catch(() => {
-        // Why: if the guest is tearing down, best-effort fallback to the raw
-        // coordinates is better than dropping the Orca menu entirely.
-        sendContextMenu(params.x, params.y)
-      })
+    // Why: send BOTH the guest viewport coordinates AND the OS screen cursor
+    // position. The renderer will try the screen cursor approach (which is
+    // immune to guest/renderer coordinate space mismatches) and fall back to
+    // guest coords if the screen API is unavailable.
+    const cursor = screen.getCursorScreenPoint()
+    renderer.send('browser:context-menu-requested', {
+      browserPageId: browserTabId,
+      x: params.x,
+      y: params.y,
+      screenX: cursor.x,
+      screenY: cursor.y,
+      pageUrl,
+      linkUrl,
+      canGoBack: guest.canGoBack(),
+      canGoForward: guest.canGoForward()
+    })
   }
 
   // Why: `before-mouse-event` fires for every mouse event (move, down, up,
@@ -97,6 +72,13 @@ export function setupGuestContextMenu(args: {
     removeDismissListener()
     dismissHandler = (_evt: Electron.Event, mouse: Electron.MouseInputEvent): void => {
       if (mouse.type !== 'mouseDown') {
+        return
+      }
+      // Why: a right-click mouseDown will be followed by a new context-menu
+      // event with updated coordinates. Sending a dismiss here would cause
+      // the renderer to briefly close the menu (trigger snaps to 0,0) then
+      // reopen it, producing a visible flash at the top-left corner.
+      if (mouse.button === 'right') {
         return
       }
       const renderer = resolveRenderer(browserTabId)

--- a/src/main/browser/browser-manager.test.ts
+++ b/src/main/browser/browser-manager.test.ts
@@ -9,7 +9,8 @@ const {
   guestSetBackgroundThrottlingMock,
   guestSetWindowOpenHandlerMock,
   guestOpenDevToolsMock,
-  webContentsFromIdMock
+  webContentsFromIdMock,
+  screenGetCursorScreenPointMock
 } = vi.hoisted(() => ({
   shellOpenExternalMock: vi.fn(),
   menuBuildFromTemplateMock: vi.fn(),
@@ -18,7 +19,8 @@ const {
   guestSetBackgroundThrottlingMock: vi.fn(),
   guestSetWindowOpenHandlerMock: vi.fn(),
   guestOpenDevToolsMock: vi.fn(),
-  webContentsFromIdMock: vi.fn()
+  webContentsFromIdMock: vi.fn(),
+  screenGetCursorScreenPointMock: vi.fn(() => ({ x: 0, y: 0 }))
 }))
 
 vi.mock('electron', () => ({
@@ -26,6 +28,9 @@ vi.mock('electron', () => ({
   shell: { openExternal: shellOpenExternalMock },
   Menu: {
     buildFromTemplate: menuBuildFromTemplateMock
+  },
+  screen: {
+    getCursorScreenPoint: screenGetCursorScreenPointMock
   },
   webContents: {
     fromId: webContentsFromIdMock

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -532,6 +532,8 @@ const api = {
         browserPageId: string
         x: number
         y: number
+        screenX: number
+        screenY: number
         pageUrl: string
         linkUrl: string | null
         canGoBack: boolean
@@ -544,6 +546,8 @@ const api = {
           browserPageId: string
           x: number
           y: number
+          screenX: number
+          screenY: number
           pageUrl: string
           linkUrl: string | null
           canGoBack: boolean

--- a/src/renderer/src/components/browser-pane/BrowserPane.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPane.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable max-lines */
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { cn } from '@/lib/utils'
 import {
   ArrowLeft,
@@ -387,6 +388,7 @@ function BrowserPagePane({
     linkUrl: string | null
     pageUrl: string
   } | null>(null)
+  const contextMenuRef = useRef<HTMLDivElement>(null)
   const [findOpen, setFindOpen] = useState(false)
   const grab = useGrabMode(browserTab.id)
   const createBrowserTab = useAppStore((s) => s.createBrowserTab)
@@ -594,9 +596,29 @@ function BrowserPagePane({
       if (event.browserPageId !== browserTab.id) {
         return
       }
+      // Why: convert the OS screen cursor position to the renderer's CSS
+      // viewport coordinates. This is the only approach immune to coordinate
+      // space mismatches between the guest process and the renderer (caused
+      // by UI zoom, DPI scaling, or Electron version differences).
+      // window.screenX/Y gives the window origin in the same screen
+      // coordinate system that screen.getCursorScreenPoint() uses. Dividing
+      // by the zoom factor converts screen points to CSS pixels.
+      const zoomFactor = Math.pow(1.2, window.api.ui.getZoomLevel())
+      const x = Math.round((event.screenX - window.screenX) / zoomFactor)
+      const y = Math.round((event.screenY - window.screenY) / zoomFactor)
+      console.debug(
+        '[context-menu] screen=(%d,%d) window=(%d,%d) zoom=%.2f → viewport=(%d,%d)',
+        event.screenX,
+        event.screenY,
+        window.screenX,
+        window.screenY,
+        zoomFactor,
+        x,
+        y
+      )
       setContextMenu({
-        x: event.x,
-        y: event.y,
+        x,
+        y,
         linkUrl: event.linkUrl,
         pageUrl: event.pageUrl
       })
@@ -611,6 +633,58 @@ function BrowserPagePane({
       setContextMenu(null)
     })
   }, [browserTab.id])
+
+  useEffect(() => {
+    if (!contextMenu) {
+      return
+    }
+    const handleKeyDown = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        setContextMenu(null)
+      }
+    }
+    window.addEventListener('keydown', handleKeyDown, true)
+    return () => window.removeEventListener('keydown', handleKeyDown, true)
+  }, [contextMenu])
+
+  // Why: position: fixed can be offset by ancestor CSS properties (backdrop-filter,
+  // transform, will-change) that create new containing blocks. Even with a Portal to
+  // document.body, global CSS or Electron chrome can shift the element. Measuring the
+  // actual rendered position and correcting before paint is immune to all of these.
+  // Additionally, flip the menu when it would overflow the viewport edge so right-clicking
+  // near the screen border keeps the entire menu visible.
+  useLayoutEffect(() => {
+    const el = contextMenuRef.current
+    if (!el || !contextMenu) {
+      return
+    }
+    el.style.left = `${contextMenu.x}px`
+    el.style.top = `${contextMenu.y}px`
+    const rect = el.getBoundingClientRect()
+
+    // Why: CSS containing blocks can shift "fixed" elements. Capture the offset
+    // between where we asked CSS to place the element and where it actually rendered.
+    const offsetX = contextMenu.x - rect.left
+    const offsetY = contextMenu.y - rect.top
+
+    let renderX = contextMenu.x
+    let renderY = contextMenu.y
+
+    // Flip so the opposite corner aligns with the cursor when the menu overflows.
+    if (rect.right > window.innerWidth) {
+      renderX = contextMenu.x - rect.width
+    }
+    if (rect.bottom > window.innerHeight) {
+      renderY = contextMenu.y - rect.height
+    }
+
+    renderX = Math.max(0, renderX)
+    renderY = Math.max(0, renderY)
+
+    el.style.left = `${renderX + offsetX}px`
+    el.style.top = `${renderY + offsetY}px`
+  }, [contextMenu])
 
   useEffect(() => {
     return window.api.browser.onDownloadRequested((event) => {
@@ -1545,109 +1619,132 @@ function BrowserPagePane({
         isActive ? 'z-10' : 'pointer-events-none hidden'
       )}
     >
-      {/* IPC-driven context menu — main intercepts guest right-clicks and sends
-          the event here so Orca can offer link actions that require renderer/store access. */}
-      <DropdownMenu
-        open={contextMenu !== null}
-        onOpenChange={(open) => {
-          if (!open) {
-            setContextMenu(null)
-          }
-        }}
-        modal={false}
-      >
-        <DropdownMenuTrigger asChild>
-          <button
-            aria-hidden
-            tabIndex={-1}
-            className="pointer-events-none fixed size-px opacity-0"
-            style={{
-              left: contextMenu?.x ?? 0,
-              top: contextMenu?.y ?? 0
-            }}
-          />
-        </DropdownMenuTrigger>
-        <DropdownMenuContent
-          className="min-w-[13rem] rounded-[11px] border-border/80 p-1 shadow-[0_16px_36px_rgba(0,0,0,0.24)]"
-          sideOffset={0}
-          align="start"
-        >
-          {contextMenu?.linkUrl ? (
+      {/* IPC-driven context menu — rendered in a Portal so position: fixed is
+          relative to the viewport, not affected by ancestor backdrop-filter or
+          transform properties that create new containing blocks. */}
+      {contextMenu
+        ? createPortal(
             <>
-              <DropdownMenuItem
-                onSelect={() => {
-                  if (contextMenu.linkUrl) {
-                    createBrowserTab(worktreeId, contextMenu.linkUrl, {
-                      title: contextMenu.linkUrl
-                    })
-                  }
-                }}
+              <div className="fixed inset-0 z-50" onPointerDown={() => setContextMenu(null)} />
+              <div
+                ref={contextMenuRef}
+                role="menu"
+                data-testid="browser-context-menu"
+                style={{ left: contextMenu.x, top: contextMenu.y }}
+                className="fixed z-50 min-w-[13rem] overflow-hidden rounded-[11px] border border-black/14 bg-[rgba(255,255,255,0.82)] p-1 text-black shadow-[0_16px_36px_rgba(0,0,0,0.24),inset_0_1px_0_rgba(255,255,255,0.14)] backdrop-blur-2xl dark:border-white/14 dark:bg-[rgba(0,0,0,0.72)] dark:text-white dark:shadow-[0_20px_44px_rgba(0,0,0,0.42),inset_0_1px_0_rgba(255,255,255,0.04)]"
               >
-                Open Link In Orca Browser
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onSelect={() => {
-                  if (contextMenu.linkUrl) {
-                    const targetUrl = normalizeExternalBrowserUrl(contextMenu.linkUrl)
+                {contextMenu.linkUrl ? (
+                  <>
+                    <button
+                      role="menuitem"
+                      className="relative flex w-full cursor-default items-center gap-2 rounded-[7px] px-2 py-0.5 text-[12px] leading-5 font-medium outline-none select-none hover:bg-black/8 dark:hover:bg-white/14"
+                      onClick={() => {
+                        createBrowserTab(worktreeId, contextMenu.linkUrl!, {
+                          title: contextMenu.linkUrl!
+                        })
+                        setContextMenu(null)
+                      }}
+                    >
+                      Open Link In Orca Browser
+                    </button>
+                    <button
+                      role="menuitem"
+                      className="relative flex w-full cursor-default items-center gap-2 rounded-[7px] px-2 py-0.5 text-[12px] leading-5 font-medium outline-none select-none hover:bg-black/8 dark:hover:bg-white/14"
+                      onClick={() => {
+                        const targetUrl = normalizeExternalBrowserUrl(contextMenu.linkUrl!)
+                        if (targetUrl) {
+                          void window.api.shell.openUrl(targetUrl)
+                        }
+                        setContextMenu(null)
+                      }}
+                    >
+                      Open Link In Default Browser
+                    </button>
+                    <button
+                      role="menuitem"
+                      className="relative flex w-full cursor-default items-center gap-2 rounded-[7px] px-2 py-0.5 text-[12px] leading-5 font-medium outline-none select-none hover:bg-black/8 dark:hover:bg-white/14"
+                      onClick={() => {
+                        void window.api.ui.writeClipboardText(contextMenu.linkUrl ?? '')
+                        setContextMenu(null)
+                      }}
+                    >
+                      Copy Link Address
+                    </button>
+                    <div className="my-1 h-px bg-border/70" />
+                  </>
+                ) : null}
+                <button
+                  role="menuitem"
+                  disabled={!browserTab.canGoBack}
+                  className="relative flex w-full cursor-default items-center gap-2 rounded-[7px] px-2 py-0.5 text-[12px] leading-5 font-medium outline-none select-none hover:bg-black/8 disabled:pointer-events-none disabled:opacity-50 dark:hover:bg-white/14"
+                  onClick={() => {
+                    webviewRef.current?.goBack()
+                    setContextMenu(null)
+                  }}
+                >
+                  Back
+                </button>
+                <button
+                  role="menuitem"
+                  disabled={!browserTab.canGoForward}
+                  className="relative flex w-full cursor-default items-center gap-2 rounded-[7px] px-2 py-0.5 text-[12px] leading-5 font-medium outline-none select-none hover:bg-black/8 disabled:pointer-events-none disabled:opacity-50 dark:hover:bg-white/14"
+                  onClick={() => {
+                    webviewRef.current?.goForward()
+                    setContextMenu(null)
+                  }}
+                >
+                  Forward
+                </button>
+                <button
+                  role="menuitem"
+                  className="relative flex w-full cursor-default items-center gap-2 rounded-[7px] px-2 py-0.5 text-[12px] leading-5 font-medium outline-none select-none hover:bg-black/8 dark:hover:bg-white/14"
+                  onClick={() => {
+                    webviewRef.current?.reload()
+                    setContextMenu(null)
+                  }}
+                >
+                  Reload
+                </button>
+                <div className="my-1 h-px bg-border/70" />
+                <button
+                  role="menuitem"
+                  className="relative flex w-full cursor-default items-center gap-2 rounded-[7px] px-2 py-0.5 text-[12px] leading-5 font-medium outline-none select-none hover:bg-black/8 dark:hover:bg-white/14"
+                  onClick={() => {
+                    const targetUrl = normalizeExternalBrowserUrl(contextMenu.pageUrl)
                     if (targetUrl) {
                       void window.api.shell.openUrl(targetUrl)
                     }
-                  }
-                }}
-              >
-                Open Link In Default Browser
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onSelect={() => {
-                  void window.api.ui.writeClipboardText(contextMenu?.linkUrl ?? '')
-                }}
-              >
-                Copy Link Address
-              </DropdownMenuItem>
-              <DropdownMenuSeparator />
-            </>
-          ) : null}
-          <DropdownMenuItem
-            disabled={!browserTab.canGoBack}
-            onSelect={() => webviewRef.current?.goBack()}
-          >
-            Back
-          </DropdownMenuItem>
-          <DropdownMenuItem
-            disabled={!browserTab.canGoForward}
-            onSelect={() => webviewRef.current?.goForward()}
-          >
-            Forward
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => webviewRef.current?.reload()}>Reload</DropdownMenuItem>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem
-            onSelect={() => {
-              const targetUrl = normalizeExternalBrowserUrl(contextMenu?.pageUrl ?? '')
-              if (targetUrl) {
-                void window.api.shell.openUrl(targetUrl)
-              }
-            }}
-          >
-            Open Page In Default Browser
-          </DropdownMenuItem>
-          <DropdownMenuItem
-            onSelect={() => {
-              void window.api.ui.writeClipboardText(contextMenu?.pageUrl ?? '')
-            }}
-          >
-            Copy Page URL
-          </DropdownMenuItem>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem
-            onSelect={() => {
-              void window.api.browser.openDevTools({ browserPageId: browserTab.id })
-            }}
-          >
-            Inspect Page
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
+                    setContextMenu(null)
+                  }}
+                >
+                  Open Page In Default Browser
+                </button>
+                <button
+                  role="menuitem"
+                  className="relative flex w-full cursor-default items-center gap-2 rounded-[7px] px-2 py-0.5 text-[12px] leading-5 font-medium outline-none select-none hover:bg-black/8 dark:hover:bg-white/14"
+                  onClick={() => {
+                    void window.api.ui.writeClipboardText(contextMenu.pageUrl)
+                    setContextMenu(null)
+                  }}
+                >
+                  Copy Page URL
+                </button>
+                <div className="my-1 h-px bg-border/70" />
+                <button
+                  role="menuitem"
+                  className="relative flex w-full cursor-default items-center gap-2 rounded-[7px] px-2 py-0.5 text-[12px] leading-5 font-medium outline-none select-none hover:bg-black/8 dark:hover:bg-white/14"
+                  onClick={() => {
+                    void window.api.browser.openDevTools({ browserPageId: browserTab.id })
+                    setContextMenu(null)
+                  }}
+                >
+                  Inspect Page
+                </button>
+              </div>
+            </>,
+            document.body
+          )
+        : null}
 
       {/* Browser Settings dialog — uses Radix Portal so layout is unaffected */}
       <Dialog open={settingsOpen} onOpenChange={setSettingsOpen}>

--- a/src/renderer/src/components/browser-pane/context-menu-positioning.test.ts
+++ b/src/renderer/src/components/browser-pane/context-menu-positioning.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Tests for the browser context menu positioning pipeline.
+ *
+ * Pipeline:
+ *   1. Main: captures screen.getCursorScreenPoint() at context-menu time
+ *   2. Main: sends screenX/screenY + guest params.x/y to renderer
+ *   3. Renderer: converts (screenX - window.screenX, screenY - window.screenY) / zoomFactor
+ *   4. Renderer: createPortal(div, document.body), position: fixed at those coords
+ *   5. Self-correction: useLayoutEffect measures getBoundingClientRect(),
+ *      adjusts left/top if CSS containing blocks shifted the element
+ *
+ * Invariant: the context menu's top-left corner is at the cursor.
+ */
+
+function computeViewportCoords(
+  screenX: number,
+  screenY: number,
+  windowScreenX: number,
+  windowScreenY: number,
+  zoomFactor: number
+): { x: number; y: number } {
+  return {
+    x: Math.round((screenX - windowScreenX) / zoomFactor),
+    y: Math.round((screenY - windowScreenY) / zoomFactor)
+  }
+}
+
+function computeCorrection(
+  targetX: number,
+  targetY: number,
+  measuredLeft: number,
+  measuredTop: number
+): { left: number; top: number; corrected: boolean } {
+  const dx = targetX - measuredLeft
+  const dy = targetY - measuredTop
+  if (Math.abs(dx) > 1 || Math.abs(dy) > 1) {
+    return { left: targetX + dx, top: targetY + dy, corrected: true }
+  }
+  return { left: targetX, top: targetY, corrected: false }
+}
+
+describe('screen-to-viewport coordinate conversion', () => {
+  it('converts screen coords to viewport at zoom 1.0', () => {
+    const result = computeViewportCoords(650, 400, 100, 50, 1.0)
+    expect(result.x).toBe(550)
+    expect(result.y).toBe(350)
+  })
+
+  it('converts screen coords to viewport at zoom 1.2', () => {
+    // Screen cursor at (700, 500), window at (100, 50), zoom 1.2
+    // Viewport = (600, 450) / 1.2 = (500, 375)
+    const result = computeViewportCoords(700, 500, 100, 50, 1.2)
+    expect(result.x).toBe(500)
+    expect(result.y).toBe(375)
+  })
+
+  it('converts screen coords to viewport at zoom 0.8 (zoomed out)', () => {
+    // (600 - 100) / 0.8 = 625
+    const result = computeViewportCoords(600, 450, 100, 50, 0.8)
+    expect(result.x).toBe(625)
+    expect(result.y).toBe(500)
+  })
+
+  it('handles cursor at window origin', () => {
+    const result = computeViewportCoords(100, 50, 100, 50, 1.0)
+    expect(result.x).toBe(0)
+    expect(result.y).toBe(0)
+  })
+
+  it('handles cursor at window origin with zoom', () => {
+    const result = computeViewportCoords(100, 50, 100, 50, 1.5)
+    expect(result.x).toBe(0)
+    expect(result.y).toBe(0)
+  })
+})
+
+describe('self-correction math', () => {
+  it('no correction when position matches target', () => {
+    const result = computeCorrection(300, 200, 300, 200)
+    expect(result.corrected).toBe(false)
+    expect(result.left).toBe(300)
+    expect(result.top).toBe(200)
+  })
+
+  it('no correction for sub-pixel differences (within 1px)', () => {
+    const result = computeCorrection(300, 200, 300.5, 200.8)
+    expect(result.corrected).toBe(false)
+  })
+
+  it('corrects positive offset (ancestor pushed element right/down)', () => {
+    const result = computeCorrection(300, 200, 350, 230)
+    expect(result.left).toBe(250)
+    expect(result.top).toBe(170)
+    expect(result.corrected).toBe(true)
+  })
+
+  it('corrects negative offset (ancestor pulled element left/up)', () => {
+    const result = computeCorrection(300, 200, 250, 170)
+    expect(result.left).toBe(350)
+    expect(result.top).toBe(230)
+    expect(result.corrected).toBe(true)
+  })
+
+  it('corrected position reconstructs to target after same offset', () => {
+    const target = { x: 400, y: 350 }
+    const offset = { x: 50, y: 30 }
+    const measured = { left: target.x + offset.x, top: target.y + offset.y }
+    const result = computeCorrection(target.x, target.y, measured.left, measured.top)
+    expect(result.left + offset.x).toBe(target.x)
+    expect(result.top + offset.y).toBe(target.y)
+  })
+})
+
+function computeEdgeFlip(
+  cursorX: number,
+  cursorY: number,
+  menuWidth: number,
+  menuHeight: number,
+  viewportWidth: number,
+  viewportHeight: number
+): { x: number; y: number } {
+  let x = cursorX
+  let y = cursorY
+  if (cursorX + menuWidth > viewportWidth) {
+    x = cursorX - menuWidth
+  }
+  if (cursorY + menuHeight > viewportHeight) {
+    y = cursorY - menuHeight
+  }
+  x = Math.max(0, x)
+  y = Math.max(0, y)
+  return { x, y }
+}
+
+describe('viewport edge flipping', () => {
+  const menuW = 208
+  const menuH = 300
+  const vw = 1440
+  const vh = 900
+
+  it('no flip when menu fits entirely', () => {
+    const result = computeEdgeFlip(400, 300, menuW, menuH, vw, vh)
+    expect(result.x).toBe(400)
+    expect(result.y).toBe(300)
+  })
+
+  it('flips left when menu overflows right edge', () => {
+    const result = computeEdgeFlip(1400, 300, menuW, menuH, vw, vh)
+    expect(result.x).toBe(1400 - menuW)
+    expect(result.y).toBe(300)
+  })
+
+  it('flips up when menu overflows bottom edge', () => {
+    const result = computeEdgeFlip(400, 750, menuW, menuH, vw, vh)
+    expect(result.x).toBe(400)
+    expect(result.y).toBe(750 - menuH)
+  })
+
+  it('flips both when menu overflows bottom-right corner', () => {
+    const result = computeEdgeFlip(1400, 750, menuW, menuH, vw, vh)
+    expect(result.x).toBe(1400 - menuW)
+    expect(result.y).toBe(750 - menuH)
+  })
+
+  it('clamps to zero if flip would go negative', () => {
+    const result = computeEdgeFlip(100, 50, menuW, menuH, vw, vh)
+    // 100 + 208 = 308 < 1440, no flip needed horizontally
+    expect(result.x).toBe(100)
+    // 50 + 300 = 350 < 900, no flip needed vertically
+    expect(result.y).toBe(50)
+
+    // Small viewport forces flip, but cursor near origin clamps to 0
+    const tight = computeEdgeFlip(50, 40, menuW, menuH, 200, 200)
+    // 50 - 208 = -158 → clamped to 0
+    expect(tight.x).toBe(0)
+    // 40 - 300 = -260 → clamped to 0
+    expect(tight.y).toBe(0)
+  })
+
+  it('exactly fits without flipping (edge-touching)', () => {
+    // Menu right edge exactly at viewport: 1232 + 208 = 1440
+    const result = computeEdgeFlip(1232, 600, menuW, menuH, vw, vh)
+    expect(result.x).toBe(1232)
+    expect(result.y).toBe(600)
+  })
+
+  it('flips when 1px past viewport', () => {
+    // 1233 + 208 = 1441 > 1440
+    const result = computeEdgeFlip(1233, 600, menuW, menuH, vw, vh)
+    expect(result.x).toBe(1233 - menuW)
+  })
+})
+
+describe('full pipeline', () => {
+  it('screen coords at zoom 1.0 → correct viewport position', () => {
+    const screenCursor = { x: 650, y: 400 }
+    const windowPos = { x: 100, y: 50 }
+
+    const menuPos = computeViewportCoords(
+      screenCursor.x,
+      screenCursor.y,
+      windowPos.x,
+      windowPos.y,
+      1.0
+    )
+
+    expect(menuPos.x).toBe(550)
+    expect(menuPos.y).toBe(350)
+  })
+
+  it('screen coords at zoom 1.44 → correctly scaled viewport position', () => {
+    // zoom level 2 → factor 1.2^2 = 1.44
+    const screenCursor = { x: 388, y: 194 }
+    const windowPos = { x: 100, y: 50 }
+
+    const menuPos = computeViewportCoords(
+      screenCursor.x,
+      screenCursor.y,
+      windowPos.x,
+      windowPos.y,
+      1.44
+    )
+
+    expect(menuPos.x).toBe(200)
+    expect(menuPos.y).toBe(100)
+  })
+
+  it('pipeline + self-correction compensates any CSS offset', () => {
+    const screenCursor = { x: 650, y: 400 }
+    const windowPos = { x: 100, y: 50 }
+
+    const menuPos = computeViewportCoords(
+      screenCursor.x,
+      screenCursor.y,
+      windowPos.x,
+      windowPos.y,
+      1.0
+    )
+    const cssOffset = { x: 60, y: 40 }
+    const measured = { left: menuPos.x + cssOffset.x, top: menuPos.y + cssOffset.y }
+
+    const corrected = computeCorrection(menuPos.x, menuPos.y, measured.left, measured.top)
+    expect(corrected.left + cssOffset.x).toBe(menuPos.x)
+    expect(corrected.top + cssOffset.y).toBe(menuPos.y)
+  })
+
+  it('works without correction when no CSS offset exists', () => {
+    const screenCursor = { x: 650, y: 400 }
+    const windowPos = { x: 100, y: 50 }
+
+    const menuPos = computeViewportCoords(
+      screenCursor.x,
+      screenCursor.y,
+      windowPos.x,
+      windowPos.y,
+      1.0
+    )
+    const corrected = computeCorrection(menuPos.x, menuPos.y, menuPos.x, menuPos.y)
+
+    expect(corrected.corrected).toBe(false)
+    expect(corrected.left).toBe(menuPos.x)
+    expect(corrected.top).toBe(menuPos.y)
+  })
+})

--- a/src/shared/browser-guest-events.ts
+++ b/src/shared/browser-guest-events.ts
@@ -42,6 +42,8 @@ export type BrowserContextMenuRequestedEvent = {
   browserPageId: string
   x: number
   y: number
+  screenX: number
+  screenY: number
   pageUrl: string
   linkUrl: string | null
   canGoBack: boolean


### PR DESCRIPTION
## Summary
- Use `screen.getCursorScreenPoint()` in main process as ground truth for cursor position, immune to guest/renderer coordinate space mismatches
- Convert screen coordinates to CSS viewport via `(screenX - window.screenX) / zoomFactor` in the renderer, handling UI zoom correctly
- Flip the context menu to the opposite side of the cursor when it would overflow viewport edges (right, bottom, or corner)
- Self-correct via `useLayoutEffect` + `getBoundingClientRect()` to compensate for any CSS containing block offsets
- Dismiss context menu on left/middle click in guest webview but skip right-click to avoid flash from dismiss-then-reopen

## Test plan
- [x] Unit tests for screen-to-viewport coordinate conversion at multiple zoom levels
- [x] Unit tests for CSS containing block self-correction math
- [x] Unit tests for viewport edge flipping (right, bottom, corner, clamp-to-zero, boundary)
- [x] Unit tests for context menu IPC dispatch (params passthrough, navigation state, renderer unavailable)
- [x] Unit tests for dismiss behavior (left-click, middle-click, right-click skip, mouseMove ignore)
- [x] Unit tests for cleanup/teardown
- [ ] Manual: right-click in browser pane → menu top-left at cursor
- [ ] Manual: right-click near right/bottom edge → menu flips direction
- [ ] Manual: right-click at various UI zoom levels → menu stays at cursor