### PR TITLE
Disambiguate terminal split from tab group split labels

### DIFF
--- a/src/renderer/src/components/settings/ShortcutsPane.tsx
+++ b/src/renderer/src/components/settings/ShortcutsPane.tsx
@@ -130,14 +130,14 @@ const SHORTCUT_GROUP_DEFINITIONS: ShortcutGroupDefinition[] = [
     title: 'Terminal Panes',
     items: [
       {
-        action: 'Split pane right',
+        action: 'Split terminal right',
         searchKeywords: ['shortcut', 'pane', 'split'],
         // Why: on Windows/Linux, Ctrl+D must pass through as EOF (#586),
         // so split-right requires Shift on non-Mac platforms.
         keys: ({ mod, shift }) => (mod === '⌘' ? [mod, 'D'] : [mod, shift, 'D'])
       },
       {
-        action: 'Split pane down',
+        action: 'Split terminal down',
         searchKeywords: ['shortcut', 'pane', 'split'],
         // Why: on Windows/Linux, Ctrl+Shift+D is taken by split-right (#586),
         // so split-down uses Alt+Shift+D following Windows Terminal convention.

--- a/src/renderer/src/components/terminal-pane/TerminalContextMenu.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalContextMenu.tsx
@@ -77,7 +77,7 @@ export default function TerminalContextMenu({
         />
       </DropdownMenuTrigger>
       <DropdownMenuContent
-        className="w-48"
+        className="w-52"
         sideOffset={0}
         align="start"
         onCloseAutoFocus={(e) => {
@@ -104,14 +104,14 @@ export default function TerminalContextMenu({
         <DropdownMenuSeparator />
         <DropdownMenuItem onSelect={onSplitRight}>
           <PanelRightOpen />
-          Split Right
+          Split Terminal Right
           {/* Why: on Windows/Linux, Ctrl+D must pass through as EOF (#586),
               so split-right requires Shift on non-Mac platforms. */}
           <DropdownMenuShortcut>{isMac ? `${mod}D` : `${mod}${shift}D`}</DropdownMenuShortcut>
         </DropdownMenuItem>
         <DropdownMenuItem onSelect={onSplitDown}>
           <PanelBottomOpen />
-          Split Down
+          Split Terminal Down
           {/* Why: on Windows/Linux, Alt+Shift+D is used for split-down because
               Ctrl+Shift+D is taken by split-right (#586). */}
           <DropdownMenuShortcut>{isMac ? `${mod}${shift}D` : `Alt+${shift}D`}</DropdownMenuShortcut>


### PR DESCRIPTION
## Summary
- Rename "Split Right" / "Split Down" → "Split Terminal Right" / "Split Terminal Down" in the terminal pane context menu and shortcuts settings, so they're clearly distinct from the tab group "Split Right/Down" actions
- Update shortcuts pane labels from "Split pane right/down" → "Split terminal right/down" to match
- Widen the terminal context menu (`w-48` → `w-52`) to prevent label wrapping

## Test plan
- [x] Right-click inside a terminal pane — verify menu says "Split Terminal Right" / "Split Terminal Down" and neither label wraps
- [x] Right-click a tab in the tab bar — verify menu still says "Split Right" / "Split Down" (unchanged)
- [x] Open Settings → Shortcuts → Terminal Panes — verify labels say "Split terminal right" / "Split terminal down"