### PR TITLE
fix: correct terminal split icon arrow directions

### DIFF
--- a/src/renderer/src/components/terminal-pane/TerminalContextMenu.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalContextMenu.tsx
@@ -4,8 +4,8 @@ import {
   Eraser,
   Maximize2,
   Minimize2,
-  PanelBottomOpen,
-  PanelRightOpen,
+  PanelBottomClose,
+  PanelRightClose,
   Pencil,
   X
 } from 'lucide-react'
@@ -103,14 +103,14 @@ export default function TerminalContextMenu({
         </DropdownMenuItem>
         <DropdownMenuSeparator />
         <DropdownMenuItem onSelect={onSplitRight}>
-          <PanelRightOpen />
+          <PanelRightClose />
           Split Terminal Right
           {/* Why: on Windows/Linux, Ctrl+D must pass through as EOF (#586),
               so split-right requires Shift on non-Mac platforms. */}
           <DropdownMenuShortcut>{isMac ? `${mod}D` : `${mod}${shift}D`}</DropdownMenuShortcut>
         </DropdownMenuItem>
         <DropdownMenuItem onSelect={onSplitDown}>
-          <PanelBottomOpen />
+          <PanelBottomClose />
           Split Terminal Down
           {/* Why: on Windows/Linux, Alt+Shift+D is used for split-down because
               Ctrl+Shift+D is taken by split-right (#586). */}


### PR DESCRIPTION
## Summary
- Terminal context menu split icons (`PanelRightOpen`, `PanelBottomOpen`) had arrows pointing opposite to the split direction (left and up)
- Switched to `PanelRightClose`/`PanelBottomClose` variants which point right and down, matching the action

## Test plan
- [x] Right-click in a terminal pane and verify the "Split Terminal Right" icon arrow points right
- [x] Verify the "Split Terminal Down" icon arrow points down

<img width="262" height="237" alt="image" src="https://github.com/user-attachments/assets/3d546f58-9e6b-4ff3-b4c2-d092275838f5" />
