### PR TITLE
feat: add split editor button to tab header

### DIFF
--- a/src/renderer/src/components/tab-bar/TabBar.tsx
+++ b/src/renderer/src/components/tab-bar/TabBar.tsx
@@ -294,7 +294,7 @@ function TabBarInner({
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <button
-            className="mx-1 my-auto flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+            className="ml-0.5 my-auto flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent/50 hover:text-foreground"
             style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
             title="New tab"
           >

--- a/src/renderer/src/components/tab-group/TabGroupPanel.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.tsx
@@ -1,6 +1,7 @@
-import { lazy, Suspense } from 'react'
-import { X } from 'lucide-react'
+import { lazy, Suspense, useCallback, useEffect, useState } from 'react'
+import { Columns2, Rows2, X } from 'lucide-react'
 import { useAppStore } from '../../store'
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import TabBar from '../tab-bar/TabBar'
 import TerminalPane from '../terminal-pane/TerminalPane'
 import BrowserPane from '../browser-pane/BrowserPane'
@@ -13,6 +14,7 @@ export default function TabGroupPanel({
   worktreeId,
   isFocused,
   hasSplitGroups,
+  showSplitButton,
   reserveClosedExplorerToggleSpace,
   reserveCollapsedSidebarHeaderSpace
 }: {
@@ -20,11 +22,39 @@ export default function TabGroupPanel({
   worktreeId: string
   isFocused: boolean
   hasSplitGroups: boolean
+  showSplitButton: boolean
   reserveClosedExplorerToggleSpace: boolean
   reserveCollapsedSidebarHeaderSpace: boolean
 }): React.JSX.Element {
   const rightSidebarOpen = useAppStore((state) => state.rightSidebarOpen)
   const sidebarOpen = useAppStore((state) => state.sidebarOpen)
+
+  // Why: track Option/Alt key state so the split button icon can preview the
+  // alternate direction (down) before the user clicks, matching the modifier-
+  // toggle convention used in VS Code and macOS toolbars.
+  const [altHeld, setAltHeld] = useState(false)
+  useEffect(() => {
+    if (!showSplitButton) {
+      return
+    }
+    const down = (e: KeyboardEvent): void => {
+      if (e.key === 'Alt') {
+        setAltHeld(true)
+      }
+    }
+    const up = (e: KeyboardEvent): void => {
+      if (e.key === 'Alt') {
+        setAltHeld(false)
+      }
+    }
+    window.addEventListener('keydown', down)
+    window.addEventListener('keyup', up)
+    return () => {
+      window.removeEventListener('keydown', down)
+      window.removeEventListener('keyup', up)
+    }
+  }, [showSplitButton])
+
   const model = useTabGroupWorkspaceModel({ groupId, worktreeId })
   const {
     activeBrowserTab,
@@ -37,6 +67,15 @@ export default function TabGroupPanel({
     terminalTabs,
     worktreePath
   } = model
+
+  const handleSplit = useCallback(
+    (event: React.MouseEvent) => {
+      event.stopPropagation()
+      const direction = event.altKey ? 'down' : 'right'
+      commands.createSplitGroup(direction)
+    },
+    [commands]
+  )
 
   const tabBar = (
     <TabBar
@@ -158,6 +197,27 @@ export default function TabGroupPanel({
               width of that controls cluster instead of the old full sidebar
               width so tabs cap at the agent badge, not at the old divider. */}
           <div className="min-w-0 flex-1 h-full">{tabBar}</div>
+          {showSplitButton && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  aria-label={altHeld ? 'Split Editor Down' : 'Split Editor Right'}
+                  onClick={handleSplit}
+                  className="my-auto flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+                  style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+                >
+                  {altHeld ? <Rows2 size={16} /> : <Columns2 size={16} />}
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom" sideOffset={4}>
+                <div className="flex flex-col">
+                  <span>Split Right</span>
+                  <span className="text-muted-foreground">⌥ Split Down</span>
+                </div>
+              </TooltipContent>
+            </Tooltip>
+          )}
           {hasSplitGroups && (
             <button
               type="button"
@@ -167,7 +227,7 @@ export default function TabGroupPanel({
                 event.stopPropagation()
                 commands.closeGroup()
               }}
-              className="my-auto ml-1 mr-2 flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+              className="my-auto mr-1 flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent/50 hover:text-foreground"
             >
               <X className="size-4" />
             </button>

--- a/src/renderer/src/components/tab-group/TabGroupPanel.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.tsx
@@ -224,7 +224,7 @@ export default function TabGroupPanel({
                   {/* Why: split-button modifier hints appear in a shared header UI,
                       so the label must match the current platform's modifier
                       vocabulary instead of always showing Mac glyphs. */}
-                  <span className="text-muted-foreground">{isMac ? '⌥' : 'Alt'} Split Down</span>
+                  <span className="text-muted-foreground">[{isMac ? '⌥' : 'Alt'}] Split Down</span>
                 </div>
               </TooltipContent>
             </Tooltip>

--- a/src/renderer/src/components/tab-group/TabGroupPanel.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.tsx
@@ -8,6 +8,7 @@ import BrowserPane from '../browser-pane/BrowserPane'
 import { useTabGroupWorkspaceModel } from './useTabGroupWorkspaceModel'
 
 const EditorPanel = lazy(() => import('../editor/EditorPanel'))
+const isMac = navigator.userAgent.includes('Mac')
 
 export default function TabGroupPanel({
   groupId,
@@ -37,6 +38,9 @@ export default function TabGroupPanel({
     if (!showSplitButton) {
       return
     }
+    const clearAltHeld = (): void => {
+      setAltHeld(false)
+    }
     const down = (e: KeyboardEvent): void => {
       if (e.key === 'Alt') {
         setAltHeld(true)
@@ -44,14 +48,18 @@ export default function TabGroupPanel({
     }
     const up = (e: KeyboardEvent): void => {
       if (e.key === 'Alt') {
-        setAltHeld(false)
+        clearAltHeld()
       }
     }
     window.addEventListener('keydown', down)
     window.addEventListener('keyup', up)
+    // Why: if the user Alt+Tabs away, this window may never receive the keyup
+    // event, so clear the preview state on blur to avoid a stuck split-down icon.
+    window.addEventListener('blur', clearAltHeld)
     return () => {
       window.removeEventListener('keydown', down)
       window.removeEventListener('keyup', up)
+      window.removeEventListener('blur', clearAltHeld)
     }
   }, [showSplitButton])
 
@@ -177,7 +185,7 @@ export default function TabGroupPanel({
           per-group titles without making groups fight over one portal target. */}
       <div className="h-[42px] shrink-0 border-b border-border bg-card">
         <div
-          className={`flex h-full items-stretch${
+          className={`flex h-full items-stretch pr-1.5${
             reserveClosedExplorerToggleSpace && !rightSidebarOpen ? ' pr-10' : ''
           }`}
           style={{
@@ -213,7 +221,10 @@ export default function TabGroupPanel({
               <TooltipContent side="bottom" sideOffset={4}>
                 <div className="flex flex-col">
                   <span>Split Right</span>
-                  <span className="text-muted-foreground">⌥ Split Down</span>
+                  {/* Why: split-button modifier hints appear in a shared header UI,
+                      so the label must match the current platform's modifier
+                      vocabulary instead of always showing Mac glyphs. */}
+                  <span className="text-muted-foreground">{isMac ? '⌥' : 'Alt'} Split Down</span>
                 </div>
               </TooltipContent>
             </Tooltip>
@@ -227,7 +238,7 @@ export default function TabGroupPanel({
                 event.stopPropagation()
                 commands.closeGroup()
               }}
-              className="my-auto mr-1 flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+              className="my-auto flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent/50 hover:text-foreground"
             >
               <X className="size-4" />
             </button>

--- a/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
@@ -113,6 +113,9 @@ function SplitNode({
         // "focused", Cmd/Ctrl+W and split shortcuts can hit the wrong worktree.
         isFocused={isWorktreeActive && node.groupId === focusedGroupId}
         hasSplitGroups={hasSplitGroups}
+        // Why: only the top-right group renders the split button so it appears
+        // exactly once in the workspace, in the top-right corner of the header.
+        showSplitButton={touchesTopEdge && touchesRightEdge}
         reserveClosedExplorerToggleSpace={touchesTopEdge && touchesRightEdge}
         reserveCollapsedSidebarHeaderSpace={touchesTopEdge && touchesLeftEdge}
       />


### PR DESCRIPTION
## Summary
- Adds a split editor button (Columns2 icon) to the top-right of the workspace tab header, rendered once in the top-right tab group
- Click splits right; holding Option/Alt splits down, with the icon swapping to Rows2 to preview the alternate direction
- Two-line tooltip: "Split Right" with "⌥ Split Down" in muted text below
- Tightened spacing between the +, split, and close-group buttons

## Test plan
- [x] Click the split button — editor splits right with a new pane
- [x] Hold Option and click — editor splits down instead
- [x] Verify the icon changes from Columns2 to Rows2 while Option is held
- [x] Hover to confirm the two-line tooltip appears
- [x] With multiple split groups, verify the button only appears once (top-right group)
- [x] Verify no regressions with the + new tab dropdown or close-group X button

<img width="143" height="97" alt="image" src="https://github.com/user-attachments/assets/a8ca3e60-3464-493c-89b3-53a0fe27c4e3" />
