### PR TITLE
fix: restore worktree sidebar scroll viewport

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -721,7 +721,7 @@ function App(): React.JSX.Element {
                  layout so the terminal/editor reclaim the left edge instead of
                  leaving behind a content-width blank strip. */
               <div
-                className={`flex flex-col shrink-0${sidebarOpen ? '' : ' relative w-0 overflow-visible'}`}
+                className={`flex min-h-0 flex-col shrink-0${sidebarOpen ? '' : ' relative w-0 overflow-visible'}`}
               >
                 <div
                   className={`titlebar-left${sidebarOpen ? '' : ' absolute top-0 left-0 z-10'}`}
@@ -736,7 +736,14 @@ function App(): React.JSX.Element {
                 >
                   {titlebarLeftControls}
                 </div>
-                <Sidebar />
+                <div className="flex min-h-0 flex-1">
+                  {/* Why: the workspace-view wrapper adds a fixed 42px header
+                      above the sidebar. Without a flex-1/min-h-0 slot here,
+                      the sidebar falls back to its content height, so the
+                      worktree list loses its scroll viewport and the fixed
+                      bottom toolbar (including Add Repo) gets pushed offscreen. */}
+                  <Sidebar />
+                </div>
               </div>
             ) : (
               <Sidebar />

--- a/src/renderer/src/components/sidebar/index.tsx
+++ b/src/renderer/src/components/sidebar/index.tsx
@@ -47,7 +47,7 @@ function Sidebar(): React.JSX.Element {
       <div
         ref={containerRef}
         className={cn(
-          'relative flex-shrink-0 bg-sidebar flex flex-col overflow-hidden scrollbar-sleek-parent',
+          'relative min-h-0 flex-shrink-0 bg-sidebar flex flex-col overflow-hidden scrollbar-sleek-parent',
           isResizing ? 'transition-none' : 'transition-[width] duration-200'
         )}
         style={{


### PR DESCRIPTION
## Problem
A recent workspace chrome refactor moved the left sidebar into a wrapper with a fixed 42px header, but the new layout no longer gave the sidebar a bounded flex child. That let the sidebar size itself to its content height in workspace view, which broke the worktree list scroll viewport and pushed the fixed bottom toolbar off-screen. In practice this looked like the worktree bar not scrolling and the `Add Repo` button disappearing.

## Solution
Restore a shrinkable sidebar layout in workspace view by giving the new wrapper a `flex-1 min-h-0` content slot and marking the sidebar root as `min-h-0`. That preserves the intended header layout while re-establishing a bounded scroll container for the virtualized worktree list and keeping the bottom toolbar visible.

Verified can scroll
