### PR TITLE
fix: improve PDF viewer by hiding sidebar and removing padding

### DIFF
--- a/src/renderer/src/components/editor/ImageViewer.tsx
+++ b/src/renderer/src/components/editor/ImageViewer.tsx
@@ -96,15 +96,15 @@ export default function ImageViewer({
   }
 
   const previewPane = isPdf ? (
-    <div className="relative flex flex-1 flex-col overflow-auto bg-muted/20 p-4">
+    <div className="relative flex flex-1 flex-col overflow-auto">
       {/* Why: Electron's Chromium PDF viewer can fail to initialize inside a
           sandboxed iframe even when the Blob URL is valid. Using <embed> keeps
           the preview isolated to the browser's native PDF surface without
           depending on iframe document execution. */}
       <embed
-        src={previewUrl}
+        src={`${previewUrl}#navpanes=0`}
         type={mimeType}
-        className="flex-1 min-h-[24rem] w-full rounded-md border border-border/60 bg-background"
+        className="flex-1 min-h-[24rem] w-full bg-background"
       />
     </div>
   ) : (


### PR DESCRIPTION
## Summary

- Hide the Chromium PDF sidebar by default via `#navpanes=0` URL fragment — sidebar is still toggleable via the hamburger menu
- Remove padding (`p-4`), background (`bg-muted/20`), and border (`rounded-md border border-border/60`) from the PDF embed container so the viewer uses the full available space

## Test plan

- [ ] Open a PDF file in the editor and verify the sidebar is hidden by default
- [ ] Verify the sidebar can still be toggled via the hamburger menu (top-left)
- [ ] Verify no padding/gaps around the PDF viewer
- [ ] Verify image previews are unaffected