### PR TITLE
fix: return error objects from IPC repo handlers instead of throwing

### DIFF
--- a/src/main/ipc/repos-remote.test.ts
+++ b/src/main/ipc/repos-remote.test.ts
@@ -84,11 +84,11 @@ describe('repos:addRemote', () => {
         displayName: 'project'
       })
     )
-    expect(result).toHaveProperty('id')
-    expect(result).toHaveProperty('connectionId', 'conn-1')
+    expect(result).toHaveProperty('repo.id')
+    expect(result).toHaveProperty('repo.connectionId', 'conn-1')
   })
 
-  it('uses custom displayName when provided', async () => {
+    it('uses custom displayName when provided', async () => {
     const result = await handlers.get('repos:addRemote')!(null, {
       connectionId: 'conn-1',
       remotePath: '/home/user/project',
@@ -97,10 +97,11 @@ describe('repos:addRemote', () => {
 
     expect(mockStore.addRepo).toHaveBeenCalledWith(
       expect.objectContaining({
-        displayName: 'My Server Repo'
+        displayName: 'My Server Repo',
+        path: '/home/user/project'
       })
     )
-    expect(result).toHaveProperty('displayName', 'My Server Repo')
+    expect(result).toHaveProperty('repo.displayName', 'My Server Repo')
   })
 
   it('returns existing repo if same connectionId and path already added', async () => {
@@ -120,28 +121,26 @@ describe('repos:addRemote', () => {
       remotePath: '/home/user/project'
     })
 
-    expect(result).toEqual(existing)
+    expect(result).toEqual({ repo: existing })
     expect(mockStore.addRepo).not.toHaveBeenCalled()
   })
 
   it('throws when SSH connection is not found', async () => {
-    await expect(
-      handlers.get('repos:addRemote')!(null, {
-        connectionId: 'unknown-conn',
-        remotePath: '/home/user/project'
-      })
-    ).rejects.toThrow('SSH connection "unknown-conn" not found')
+    const result = await handlers.get('repos:addRemote')!(null, {
+      connectionId: 'unknown-conn',
+      remotePath: '/home/user/project'
+    })
+    expect(result).toEqual({ error: 'SSH connection "unknown-conn" not found or not connected' })
   })
 
   it('throws when remote path is not a git repo', async () => {
     mockGitProvider.isGitRepoAsync.mockResolvedValueOnce({ isRepo: false, rootPath: null })
 
-    await expect(
-      handlers.get('repos:addRemote')!(null, {
-        connectionId: 'conn-1',
-        remotePath: '/home/user/documents'
-      })
-    ).rejects.toThrow('Not a valid git repository')
+    const result = await handlers.get('repos:addRemote')!(null, {
+      connectionId: 'conn-1',
+      remotePath: '/home/user/documents'
+    })
+    expect(result).toEqual({ error: 'Not a valid git repository: /home/user/documents' })
     expect(mockStore.addRepo).not.toHaveBeenCalled()
   })
 
@@ -158,7 +157,7 @@ describe('repos:addRemote', () => {
         path: '/home/user/documents'
       })
     )
-    expect(result).toHaveProperty('kind', 'folder')
+    expect(result).toHaveProperty('repo.kind', 'folder')
   })
 
   it('uses rootPath from git detection when available', async () => {
@@ -178,7 +177,7 @@ describe('repos:addRemote', () => {
         path: '/home/user/project'
       })
     )
-    expect(result).toHaveProperty('path', '/home/user/project')
+    expect(result).toHaveProperty('repo.path', '/home/user/project')
   })
 
   it('notifies renderer when remote repo is added', async () => {

--- a/src/main/ipc/repos.ts
+++ b/src/main/ipc/repos.ts
@@ -49,7 +49,7 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
     return store.getRepos()
   })
 
-  ipcMain.handle('repos:add', async (_event, args: { path: string; kind?: 'git' | 'folder' }) => {
+  ipcMain.handle('repos:add', async (_event, args: { path: string; kind?: 'git' | 'folder' }): Promise<{ repo: Repo } | { error: string }> => {
     const repoKind = args.kind === 'folder' ? 'folder' : 'git'
     if (repoKind === 'git' && !isGitRepo(args.path)) {
       return { error: `Not a valid git repository: ${args.path}` }

--- a/src/main/ipc/repos.ts
+++ b/src/main/ipc/repos.ts
@@ -52,13 +52,13 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
   ipcMain.handle('repos:add', async (_event, args: { path: string; kind?: 'git' | 'folder' }) => {
     const repoKind = args.kind === 'folder' ? 'folder' : 'git'
     if (repoKind === 'git' && !isGitRepo(args.path)) {
-      throw new Error(`Not a valid git repository: ${args.path}`)
+      return { error: `Not a valid git repository: ${args.path}` }
     }
 
     // Check if already added
     const existing = store.getRepos().find((r) => r.path === args.path)
     if (existing) {
-      return existing
+      return { repo: existing }
     }
 
     const repo: Repo = {
@@ -73,7 +73,7 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
     store.addRepo(repo)
     await rebuildAuthorizedRootsCache(store)
     notifyReposChanged(mainWindow)
-    return repo
+    return { repo }
   })
 
   ipcMain.handle(
@@ -86,17 +86,17 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
         displayName?: string
         kind?: 'git' | 'folder'
       }
-    ): Promise<Repo> => {
+    ): Promise<{ repo: Repo } | { error: string }> => {
       const gitProvider = getSshGitProvider(args.connectionId)
       if (!gitProvider) {
-        throw new Error(`SSH connection "${args.connectionId}" not found or not connected`)
+        return { error: `SSH connection "${args.connectionId}" not found or not connected` }
       }
 
       const existing = store
         .getRepos()
         .find((r) => r.connectionId === args.connectionId && r.path === args.remotePath)
       if (existing) {
-        return existing
+        return { repo: existing }
       }
 
       const pathSegments = args.remotePath.replace(/\/+$/, '').split('/')
@@ -107,7 +107,7 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
 
       if (args.kind !== 'folder') {
         // Why: when kind is not explicitly 'folder', verify the remote path is
-        // a git repo. Throw on failure so the renderer can show the "Open as
+        // a git repo. Return an error on failure so the renderer can show the "Open as
         // Folder" confirmation dialog — matching the local add-repo behavior
         // where non-git directories require explicit user consent.
         try {
@@ -118,13 +118,13 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
               resolvedPath = check.rootPath
             }
           } else {
-            throw new Error(`Not a valid git repository: ${args.remotePath}`)
+            return { error: `Not a valid git repository: ${args.remotePath}` }
           }
         } catch (err) {
           if (err instanceof Error && err.message.includes('Not a valid git repository')) {
-            throw err
+            return { error: err.message }
           }
-          throw new Error(`Not a valid git repository: ${args.remotePath}`)
+          return { error: `Not a valid git repository: ${args.remotePath}` }
         }
       }
 
@@ -149,7 +149,7 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
         mux.notify('session.registerRoot', { rootPath: resolvedPath })
       }
 
-      return repo
+      return { repo }
     }
   )
 

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -10,13 +10,13 @@ import type { PreloadApi } from './api-types'
 
 type ReposApi = {
   list: () => Promise<Repo[]>
-  add: (args: { path: string; kind?: 'git' | 'folder' }) => Promise<Repo>
+  add: (args: { path: string; kind?: 'git' | 'folder' }) => Promise<{ repo: Repo } | { error: string }>
   addRemote: (args: {
     connectionId: string
     remotePath: string
     displayName?: string
     kind?: 'git' | 'folder'
-  }) => Promise<Repo>
+  }) => Promise<{ repo: Repo } | { error: string }>
   remove: (args: { repoId: string }) => Promise<void>
   update: (args: {
     repoId: string

--- a/src/renderer/src/components/sidebar/AddRepoSteps.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoSteps.tsx
@@ -80,10 +80,14 @@ export function useRemoteRepo(
     setIsAddingRemote(true)
     setRemoteError(null)
     try {
-      const repo = (await window.api.repos.addRemote({
+      const result = await window.api.repos.addRemote({
         connectionId: selectedTargetId,
         remotePath: remotePath.trim()
-      })) as Repo
+      })
+      if ('error' in result) {
+        throw new Error(result.error)
+      }
+      const repo = result.repo
 
       const state = useAppStore.getState()
       const existingIdx = state.repos.findIndex((r) => r.id === repo.id)

--- a/src/renderer/src/components/sidebar/NonGitFolderDialog.tsx
+++ b/src/renderer/src/components/sidebar/NonGitFolderDialog.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback } from 'react'
+import { toast } from 'sonner'
 import {
   Dialog,
   DialogContent,
@@ -40,8 +41,8 @@ const NonGitFolderDialog = React.memo(function NonGitFolderDialog() {
           await state.fetchWorktrees(repo.id)
         } catch (err) {
           // This code path calls addRemote directly (not through the store),
-          // so the store's toast handling does not apply — log for diagnostics.
-          console.error('Failed to add remote folder:', err)
+          // so the store's toast handling does not apply.
+          toast.error(err instanceof Error ? err.message : 'Failed to add remote folder')
         }
       })()
     } else if (folderPath) {

--- a/src/renderer/src/components/sidebar/NonGitFolderDialog.tsx
+++ b/src/renderer/src/components/sidebar/NonGitFolderDialog.tsx
@@ -24,11 +24,15 @@ const NonGitFolderDialog = React.memo(function NonGitFolderDialog() {
     if (connectionId && folderPath) {
       void (async () => {
         try {
-          const repo = await window.api.repos.addRemote({
+          const result = await window.api.repos.addRemote({
             connectionId,
             remotePath: folderPath,
             kind: 'folder'
           })
+          if ('error' in result) {
+            throw new Error(result.error)
+          }
+          const repo = result.repo
           const state = useAppStore.getState()
           if (!state.repos.some((r) => r.id === repo.id)) {
             useAppStore.setState({ repos: [...state.repos, repo] })

--- a/src/renderer/src/components/sidebar/NonGitFolderDialog.tsx
+++ b/src/renderer/src/components/sidebar/NonGitFolderDialog.tsx
@@ -38,8 +38,10 @@ const NonGitFolderDialog = React.memo(function NonGitFolderDialog() {
             useAppStore.setState({ repos: [...state.repos, repo] })
           }
           await state.fetchWorktrees(repo.id)
-        } catch {
-          // Best-effort — the toast from the store handles errors
+        } catch (err) {
+          // This code path calls addRemote directly (not through the store),
+          // so the store's toast handling does not apply — log for diagnostics.
+          console.error('Failed to add remote folder:', err)
         }
       })()
     } else if (folderPath) {

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -50,7 +50,11 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
       }
       let repo: Repo
       try {
-        repo = await window.api.repos.add({ path })
+        const result = await window.api.repos.add({ path })
+        if ('error' in result) {
+          throw new Error(result.error)
+        }
+        repo = result.repo
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err)
         if (!message.includes('Not a valid git repository')) {
@@ -93,7 +97,11 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
 
   addNonGitFolder: async (path) => {
     try {
-      const repo = await window.api.repos.add({ path, kind: 'folder' })
+      const result = await window.api.repos.add({ path, kind: 'folder' })
+      if ('error' in result) {
+        throw new Error(result.error)
+      }
+      const repo = result.repo
       const alreadyAdded = get().repos.some((r) => r.id === repo.id)
       set((s) => {
         if (s.repos.some((r) => r.id === repo.id)) {


### PR DESCRIPTION
## Summary
- Convert `repos:add` and `repos:addRemote` IPC handlers from throwing errors to returning `{ repo: Repo } | { error: string }` discriminated unions — Electron IPC does not preserve Error objects across the process boundary, causing opaque failures in the renderer
- Update all renderer call sites (`AddRepoSteps`, `NonGitFolderDialog`, `repos` store slice) to check for the error variant
- Add explicit return type annotation to `repos:add` handler and show a toast on remote folder add failure (previously swallowed silently)

## Test plan
- [x] Typecheck passes
- [x] Updated test expectations in `repos-remote.test.ts` to match new return shapes
- [ ] Manual: add a local git repo — should succeed as before
- [ ] Manual: add a non-git local folder — should show "Open as Folder" dialog
- [ ] Manual: add a remote git repo via SSH — should succeed
- [ ] Manual: add a remote non-git folder via SSH — should show dialog, then toast on failure