### PR TITLE
fix: prevent stale terminal buffer flash on tab switch

### DIFF
--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.ts
@@ -62,12 +62,14 @@ export function useTerminalPaneGlobalEffects({
       return
     }
     if (isVisible) {
-      // Why: resumeRendering() creates WebGL contexts for each pane, which
-      // blocks the renderer for 100–500 ms per pane on Windows (ANGLE →
-      // D3D11).  Deferring it into the rAF that runs after the pending-write
-      // drain lets the browser paint one frame with the DOM renderer so the
-      // terminal content appears immediately.  WebGL takes over seamlessly
-      // in the next frame without a visible flash.
+      // Why: resume WebGL immediately so the terminal shows its last-known
+      // state on the first painted frame. Without this, the browser paints
+      // 1+ frames of stale xterm DOM-fallback content at wrong dimensions
+      // (the "stretched" flash). On macOS, WebGL context creation is ~5 ms
+      // — fast enough to feel instant. On Windows (ANGLE → D3D11) it can
+      // take 100–500 ms, but the alternative (deferring to a rAF) leaves
+      // the terminal visibly distorted, which is a worse UX tradeoff.
+      manager.resumeRendering()
 
       fitEpochRef.current++
       const epoch = fitEpochRef.current
@@ -113,10 +115,6 @@ export function useTerminalPaneGlobalEffects({
           return
         }
         fitRanForEpochRef.current = epoch
-        // Why: suspendRendering() disposes every WebGL addon while hidden. We
-        // defer recreation until this post-drain rAF so the browser can paint
-        // one responsive frame with the DOM renderer before WebGL setup runs.
-        mgr.resumeRendering()
         if (isActive) {
           fitAndFocusPanes(mgr)
           return


### PR DESCRIPTION
## Summary
- When switching terminal tabs within a worktree, the terminal briefly flashed stale xterm DOM-fallback content at wrong dimensions (the "stretched" look)
- Root cause: PR #641 moved `resumeRendering()` from synchronous into a deferred `requestAnimationFrame`, accidentally reverting the fix from PR #654
- Fix: move `resumeRendering()` back to synchronous execution when `isVisible` transitions to true, so WebGL is ready for the first painted frame

## What changed
Single file: `src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.ts`

1. **Synchronous `resumeRendering()`** — called immediately when `isVisible` becomes true, before scheduling the rAF for fit. On macOS (~5 ms) this is imperceptible. On Windows (ANGLE → D3D11, 100–500 ms) it blocks briefly, but the alternative (visible distortion) is a worse UX tradeoff.
2. **Removed deferred `resumeRendering()`** — no longer called inside `guardedFit` since WebGL is already restored by the time the rAF fires.

## Test plan
- [ ] Switch between terminal tabs with background agents running — no stretched flash
- [ ] Rapid tab switching (A→B→C quickly) — terminal appears correctly, no stuck state
- [ ] Split groups — switching between terminals in split groups works correctly
- [ ] Worktree switching — no regression from PR #654's fix
- [ ] Typecheck passes (`pnpm run typecheck`)
- [ ] Tests pass (`pnpm vitest run`)