### PR TITLE
fix: support option/alt+arrow word navigation in terminal

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.test.ts
@@ -143,6 +143,58 @@ describe('resolveTerminalShortcutAction', () => {
     ).toBeNull()
   })
 
+  it('translates alt+arrow to readline word-nav escapes on both platforms', () => {
+    // macOS: option+←/→ → \eb / \ef (readline backward-word / forward-word)
+    expect(
+      resolveTerminalShortcutAction(
+        event({ key: 'ArrowLeft', code: 'ArrowLeft', altKey: true }),
+        true
+      )
+    ).toEqual({ type: 'sendInput', data: '\x1bb' })
+    expect(
+      resolveTerminalShortcutAction(
+        event({ key: 'ArrowRight', code: 'ArrowRight', altKey: true }),
+        true
+      )
+    ).toEqual({ type: 'sendInput', data: '\x1bf' })
+
+    // Linux/Windows: alt+←/→ produces the same escapes (platform-agnostic chord)
+    expect(
+      resolveTerminalShortcutAction(
+        event({ key: 'ArrowLeft', code: 'ArrowLeft', altKey: true }),
+        false
+      )
+    ).toEqual({ type: 'sendInput', data: '\x1bb' })
+    expect(
+      resolveTerminalShortcutAction(
+        event({ key: 'ArrowRight', code: 'ArrowRight', altKey: true }),
+        false
+      )
+    ).toEqual({ type: 'sendInput', data: '\x1bf' })
+
+    // alt+shift+arrow is a different chord (select-word in some shells) — don't
+    // intercept, let xterm.js / the shell handle it.
+    expect(
+      resolveTerminalShortcutAction(
+        event({ key: 'ArrowLeft', code: 'ArrowLeft', altKey: true, shiftKey: true }),
+        true
+      )
+    ).toBeNull()
+
+    // alt+ctrl+arrow is a different chord entirely — passthrough.
+    expect(
+      resolveTerminalShortcutAction(
+        event({ key: 'ArrowLeft', code: 'ArrowLeft', altKey: true, ctrlKey: true }),
+        true
+      )
+    ).toBeNull()
+
+    // Regression guard: plain ArrowLeft must still pass through untouched.
+    expect(
+      resolveTerminalShortcutAction(event({ key: 'ArrowLeft', code: 'ArrowLeft' }), true)
+    ).toBeNull()
+  })
+
   it('keeps Cmd+D and Cmd+Shift+D for split on macOS', () => {
     expect(
       resolveTerminalShortcutAction(event({ key: 'd', code: 'KeyD', metaKey: true }), true)

--- a/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.ts
@@ -130,6 +130,22 @@ export function resolveTerminalShortcutAction(
     return { type: 'sendInput', data: '\x1b\x7f' }
   }
 
+  if (
+    !event.metaKey &&
+    !event.ctrlKey &&
+    event.altKey &&
+    !event.shiftKey &&
+    (event.key === 'ArrowLeft' || event.key === 'ArrowRight')
+  ) {
+    // Why: xterm.js would otherwise emit \e[1;3D / \e[1;3C for option/alt+arrow,
+    // which default readline (bash, zsh) does not bind to backward-word /
+    // forward-word — so word navigation silently doesn't work without a custom
+    // inputrc. Translate to \eb / \ef (readline's default word-nav bindings) so
+    // option+←/→ on macOS and alt+←/→ on Linux/Windows behave like they do in
+    // iTerm2's "Esc+" option-key mode. Platform-agnostic: both produce altKey.
+    return { type: 'sendInput', data: event.key === 'ArrowLeft' ? '\x1bb' : '\x1bf' }
+  }
+
   // Why: the terminal shortcut layer is an explicit allowlist, not a generic
   // "modifier means app shortcut" rule. Keeping this list narrow prevents Orca
   // from swallowing readline/emacs control chords like Ctrl+R, Ctrl+U, Ctrl+E,


### PR DESCRIPTION
## Summary

`option+←/→` on macOS (`alt+←/→` on Linux/Windows) now navigates word-by-word in Orca's integrated terminal, matching iTerm2 / Ghostty / Terminal.app behavior with default shell configs. Before this fix, the keys emitted the xterm CSI sequences `\e[1;3D` / `\e[1;3C`, which readline doesn't bind — the cursor wouldn't move, and depending on the shell the escape bytes could appear at the prompt as literal garbage.

Fixes #696.

## Root cause

- Orca's terminal sets `macOptionIsMeta: true`, which is why `option+b` / `option+f` already work (xterm.js emits `\eb` / `\ef`, readline's default bindings).
- For the arrow keys, however, xterm.js emits CSI modifier sequences (`\e[1;3D` / `\e[1;3C`) that default readline doesn't recognize as word-nav.
- Fix: intercept alt+ArrowLeft/Right in `terminal-shortcut-policy.ts` (the pure allowlist introduced by #519) and translate to `\eb` / `\ef` before xterm.js sees the event. Same pattern iTerm2's "Esc+" option-key mode uses.

## Scope

One new `if` block in `terminal-shortcut-policy.ts`; one new `it(...)` block in its sibling test file covering macOS + Linux/Windows + three passthrough regression cases (`alt+shift+arrow`, `alt+ctrl+arrow`, plain arrow). No refactors.

## Platform testing

- [x] **macOS** (darwin 25.2.0, Apple Silicon): verified locally with `pnpm dev` — `cat` shows `^[b` / `^[f` on option+←/→; at a shell prompt, cursor jumps word-by-word. Regression checks pass: option+b, option+f, option+Backspace still work; Cmd+F still opens terminal search.
- [ ] **Linux / Windows**: not tested on hardware. The policy is platform-agnostic (same `altKey` semantics on all three OSes), and the unit test pins the non-Mac branch, so there's no reasonable path for this to regress on those platforms without also regressing on macOS.

## Before / after

<!-- screen recording attached by author -->

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 1716 tests pass
- [x] `pnpm build` — clean
- [x] Manual verification: `cat` with `option+←/→` before/after the fix on macOS

## AI code-review summary

- **Cross-platform keyboard behavior**: the new branch gates on `!metaKey && !ctrlKey && altKey && !shiftKey` and `key === 'ArrowLeft' | 'ArrowRight'` — the same shape as the existing `Alt+Backspace` branch directly above. On macOS this matches `option` only; on Linux/Windows it matches `alt` only. Other chords (`alt+shift`, `alt+ctrl`, `cmd+alt`) fall through to xterm.js unchanged, and unit tests pin that.
- **Security**: the branch only emits two fixed, hard-coded 2-byte escape sequences (`\x1bb`, `\x1bf`) — no user input is interpolated, no path traversal or injection surface. `sendInput` is the same IPC path already used by `Alt+Backspace`, `Cmd+Backspace`, `Cmd+Delete`, and `Shift+Enter`.
- **Shortcut-allowlist correctness**: the branch lives inside the centralized terminal-shortcut policy (the audit surface introduced by #519), so any future drift is visible via the pinned unit-test matrix.
- **Regression surface**: passthrough guards (`alt+shift+arrow`, `alt+ctrl+arrow`, plain arrow) are explicitly tested so a later edit to this file can't silently start swallowing select-word chords or plain cursor moves.

Related: #519 (terminal-shortcut audit), #443 (Ctrl+R), #586 (Ctrl+D / EOF split fix).

---

X/Twitter: @dylanklohr
