### PR TITLE
fix: prevent phantom notifications on worktree shutdown

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-dispatcher.ts
+++ b/src/renderer/src/components/terminal-pane/pty-dispatcher.ts
@@ -15,7 +15,30 @@ import type { OpenCodeStatusEvent } from '../../../../shared/types'
 export const ptyDataHandlers = new Map<string, (data: string) => void>()
 export const ptyExitHandlers = new Map<string, (code: number) => void>()
 export const openCodeStatusHandlers = new Map<string, (event: OpenCodeStatusEvent) => void>()
+/** Per-PTY teardown callbacks registered by each transport to clear closure
+ *  state (stale-title timer, agent tracker) that would otherwise fire after
+ *  the data handler is removed. */
+export const ptyTeardownHandlers = new Map<string, () => void>()
 let ptyDispatcherAttached = false
+
+/**
+ * Remove data and status handlers for the given PTY IDs so that any final
+ * data flushed by the main process during PTY teardown cannot trigger
+ * bell / agent-status notifications from a worktree that is being shut down.
+ * Also invokes per-transport teardown callbacks to cancel accumulated closure
+ * state (e.g. staleTitleTimer, agent tracker) that could independently fire
+ * stale notifications.
+ * Exit handlers are intentionally kept alive so the normal exit-cleanup
+ * path (unregister, clear stale timers, update store) still runs.
+ */
+export function unregisterPtyDataHandlers(ptyIds: string[]): void {
+  for (const id of ptyIds) {
+    ptyDataHandlers.delete(id)
+    openCodeStatusHandlers.delete(id)
+    ptyTeardownHandlers.get(id)?.()
+    ptyTeardownHandlers.delete(id)
+  }
+}
 
 export function ensurePtyDispatcher(): void {
   if (ptyDispatcherAttached) {

--- a/src/renderer/src/components/terminal-pane/pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.test.ts
@@ -239,6 +239,81 @@ describe('createIpcPtyTransport', () => {
     expect(transport.getPtyId()).toBeNull()
   })
 
+  it('unregisterPtyDataHandlers prevents final data burst from triggering notifications', async () => {
+    const { createIpcPtyTransport, unregisterPtyDataHandlers } = await import('./pty-transport')
+    const onBell = vi.fn()
+    const onTitleChange = vi.fn()
+    const onAgentBecameIdle = vi.fn()
+    const onAgentBecameWorking = vi.fn()
+    const onPtyExit = vi.fn()
+
+    const transport = createIpcPtyTransport({
+      onBell,
+      onTitleChange,
+      onAgentBecameIdle,
+      onAgentBecameWorking,
+      onPtyExit
+    })
+
+    await transport.connect({ url: '', callbacks: {} })
+
+    // Agent starts working
+    onData?.({ id: 'pty-1', data: '\u001b]0;. Claude working\u0007' })
+    expect(onAgentBecameWorking).toHaveBeenCalledTimes(1)
+
+    // Simulate shutdownWorktreeTerminals: unregister data handlers before kill
+    unregisterPtyDataHandlers(['pty-1'])
+
+    // Final data burst from main process (flushed before exit) — contains a
+    // title change from working to idle AND a BEL. Neither should trigger a
+    // notification because the data handler was removed.
+    onData?.({ id: 'pty-1', data: '\u001b]0;Claude done\u0007\u0007' })
+    expect(onAgentBecameIdle).not.toHaveBeenCalled()
+    expect(onBell).not.toHaveBeenCalled()
+
+    // Exit handler should still work (exit handlers are kept alive)
+    onExit?.({ id: 'pty-1', code: -1 })
+    expect(onPtyExit).toHaveBeenCalledWith('pty-1')
+  })
+
+  it('unregisterPtyDataHandlers cancels staleTitleTimer so it cannot fire stale idle transition', async () => {
+    vi.useFakeTimers()
+    try {
+      const { createIpcPtyTransport, unregisterPtyDataHandlers } = await import('./pty-transport')
+      const onTitleChange = vi.fn()
+      const onAgentBecameIdle = vi.fn()
+      const onAgentBecameWorking = vi.fn()
+
+      const transport = createIpcPtyTransport({
+        onTitleChange,
+        onAgentBecameIdle,
+        onAgentBecameWorking
+      })
+
+      await transport.connect({ url: '', callbacks: {} })
+
+      // Agent starts working — sets the title to a working indicator
+      onData?.({ id: 'pty-1', data: '\u001b]0;. Claude working\u0007' })
+      expect(onAgentBecameWorking).toHaveBeenCalledTimes(1)
+
+      // Data arrives without a title change — starts the 3 s staleTitleTimer
+      onData?.({ id: 'pty-1', data: 'some output without title\r\n' })
+
+      // Simulate shutdownWorktreeTerminals: unregister handlers which should
+      // cancel the pending staleTitleTimer AND reset the agent tracker so the
+      // accumulated working state cannot produce a stale idle transition.
+      unregisterPtyDataHandlers(['pty-1'])
+
+      // Advance past the 3 s stale-title timeout
+      vi.advanceTimersByTime(4000)
+
+      // The staleTitleTimer must NOT have fired onAgentBecameIdle
+      expect(onAgentBecameIdle).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('keeps the exit observer alive after detach so remounts do not reuse dead PTYs', async () => {
     const { createIpcPtyTransport } = await import('./pty-transport')
     const onPtyExit = vi.fn()

--- a/src/renderer/src/components/terminal-pane/pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.ts
@@ -10,6 +10,7 @@ import {
   ptyDataHandlers,
   ptyExitHandlers,
   openCodeStatusHandlers,
+  ptyTeardownHandlers,
   ensurePtyDispatcher,
   getEagerPtyBufferHandle
 } from './pty-dispatcher'
@@ -20,7 +21,8 @@ import { createBellDetector } from './bell-detector'
 export {
   ensurePtyDispatcher,
   getEagerPtyBufferHandle,
-  registerEagerPtyBuffer
+  registerEagerPtyBuffer,
+  unregisterPtyDataHandlers
 } from './pty-dispatcher'
 export type { EagerPtyHandle, PtyTransport, IpcPtyTransportOptions } from './pty-dispatcher'
 export { extractLastOscTitle } from '../../../../shared/agent-detection'
@@ -69,6 +71,7 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
     ptyDataHandlers.delete(id)
     ptyExitHandlers.delete(id)
     openCodeStatusHandlers.delete(id)
+    ptyTeardownHandlers.delete(id)
   }
 
   function unregisterPtyDataAndStatusHandlers(id: string): void {
@@ -152,13 +155,18 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
     })
   }
 
+  function clearAccumulatedState(): void {
+    if (staleTitleTimer) {
+      clearTimeout(staleTitleTimer)
+      staleTitleTimer = null
+    }
+    agentTracker?.reset()
+    openCodeStatus = null
+  }
+
   function registerPtyExitHandler(id: string): void {
     ptyExitHandlers.set(id, (code) => {
-      if (staleTitleTimer) {
-        clearTimeout(staleTitleTimer)
-        staleTitleTimer = null
-      }
-      openCodeStatus = null
+      clearAccumulatedState()
       connected = false
       ptyId = null
       unregisterPtyHandlers(id)
@@ -167,6 +175,13 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
       onPtyExit?.(id)
     })
     openCodeStatusHandlers.set(id, applyOpenCodeStatus)
+    // Why: shutdownWorktreeTerminals bypasses the transport layer — it
+    // kills PTYs directly via IPC without calling disconnect()/destroy().
+    // This teardown callback lets unregisterPtyDataHandlers cancel
+    // accumulated closure state (staleTitleTimer, agent tracker) that
+    // would otherwise fire stale notifications after the data handler
+    // is removed but before the exit event arrives.
+    ptyTeardownHandlers.set(id, clearAccumulatedState)
   }
 
   return {

--- a/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
+++ b/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
@@ -14,6 +14,20 @@ export function useNotificationDispatch(
   return useCallback(
     (event: { source: 'agent-task-complete' | 'terminal-bell'; terminalTitle?: string }) => {
       const state = useAppStore.getState()
+
+      // Why: shutdownWorktreeTerminals clears ptyIdsByTabId synchronously
+      // before killing PTYs asynchronously. Any notification arriving after
+      // that point is stale — e.g. a staleTitleTimer that fires 3 s after
+      // shutdown, or an agent tracker transition from accumulated closure
+      // state. Checking for live PTYs at dispatch time catches ALL phantom
+      // notification sources regardless of which timer or callback produced
+      // them, rather than trying to cancel each one individually.
+      const tabs = state.tabsByWorktree[worktreeId] ?? []
+      const hasLivePtys = tabs.some((tab) => (state.ptyIdsByTabId[tab.id] ?? []).length > 0)
+      if (!hasLivePtys) {
+        return
+      }
+
       const repoId = worktreeId.includes('::') ? worktreeId.slice(0, worktreeId.indexOf('::')) : ''
       const repo = state.repos.find((c) => c.id === repoId)
       const worktree = state.allWorktrees().find((c) => c.id === worktreeId)

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -12,7 +12,8 @@ import { isClaudeAgent, detectAgentStatusFromTitle } from '@/lib/agent-status'
 import { buildOrphanTerminalCleanupPatch, getOrphanTerminalIds } from './terminal-orphan-helpers'
 import {
   registerEagerPtyBuffer,
-  ensurePtyDispatcher
+  ensurePtyDispatcher,
+  unregisterPtyDataHandlers
 } from '@/components/terminal-pane/pty-transport'
 
 function getNextTerminalOrdinal(tabs: TerminalTab[]): number {
@@ -630,6 +631,15 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
   shutdownWorktreeTerminals: async (worktreeId) => {
     const tabs = get().tabsByWorktree[worktreeId] ?? []
     const ptyIds = tabs.flatMap((tab) => get().ptyIdsByTabId[tab.id] ?? [])
+
+    // Why: the main process flushes any remaining batched PTY data before
+    // sending the exit event (pty.ts onExit handler). Without this, that
+    // final data burst flows through the still-registered ptyDataHandlers
+    // where bell detection and agent-status tracking can fire system
+    // notifications for a worktree that is already being torn down —
+    // the "phantom alerts" users see after shutting down worktrees.
+    // Removing the data handlers first ensures the final flush is a no-op.
+    unregisterPtyDataHandlers(ptyIds)
 
     set((s) => {
       const nextTabsByWorktree = {

--- a/src/shared/agent-detection.ts
+++ b/src/shared/agent-detection.ts
@@ -126,6 +126,9 @@ export function createAgentStatusTracker(
   onAgentExited?: () => void
 ): {
   handleTitle: (title: string) => void
+  /** Clear accumulated status so a stale working→idle transition cannot fire
+   *  after the owning transport is torn down. */
+  reset: () => void
 } {
   let lastStatus: AgentStatus | null = null
 
@@ -151,6 +154,9 @@ export function createAgentStatusTracker(
       if (newStatus !== null) {
         lastStatus = newStatus
       }
+    },
+    reset(): void {
+      lastStatus = null
     }
   }
 }


### PR DESCRIPTION
## Summary
- Unregister PTY data handlers before killing PTYs during worktree shutdown so the final data flush cannot trigger bell/agent-status notifications
- Cancel accumulated closure state (staleTitleTimer, agent tracker) via teardown callbacks registered per-transport
- Add a `hasLivePtys` guard at notification dispatch time as a belt-and-suspenders safety net
- Add `reset()` to `createAgentStatusTracker` to clear stale working→idle transitions

## Test plan
- [x] New test: `unregisterPtyDataHandlers` prevents final data burst from triggering notifications
- [x] New test: `unregisterPtyDataHandlers` cancels `staleTitleTimer` so it cannot fire stale idle transition
- [ ] Manual: open worktree, run agent task, shut down worktree — verify no phantom notification appears