### PR TITLE
fix: prevent title bar flickering with multiple split-pane agents

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -98,7 +98,14 @@ export function connectPanePty(
   const onTitleChange = (title: string, rawTitle: string): void => {
     manager.setPaneGpuRendering(pane.id, !isGeminiTerminalTitle(rawTitle))
     deps.setRuntimePaneTitle(deps.tabId, pane.id, title)
-    deps.updateTabTitle(deps.tabId, title)
+    // Why: only the focused pane should drive the tab title — otherwise two
+    // agents in split panes cause rapid title flickering as each emits OSC
+    // sequences. Mirrors Ghostty's approach: only the active split's title
+    // propagates to the tab. When focus changes, onActivePaneChange syncs
+    // the newly active pane's stored title to the tab.
+    if (manager.getActivePane()?.id === pane.id) {
+      deps.updateTabTitle(deps.tabId, title)
+    }
 
     if (!hasConsideredInitialCacheTimerSeed) {
       hasConsideredInitialCacheTimerSeed = true

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -306,10 +306,19 @@ export function useTerminalPaneLifecycle({
         setRenamingPaneId((prev) => (prev === paneId ? null : prev))
         scheduleRuntimeGraphSync()
       },
-      onActivePaneChange: () => {
+      onActivePaneChange: (pane) => {
         scheduleRuntimeGraphSync()
         if (shouldPersistLayout) {
           persistLayoutSnapshot()
+        }
+        // Why: when the user switches focus between split panes, update the
+        // tab title to the newly active pane's last-known title so the tab
+        // label reflects the focused agent — not a stale title from the
+        // previously focused pane.
+        const paneTitles = useAppStore.getState().runtimePaneTitlesByTabId[tabId] ?? {}
+        const paneTitle = paneTitles[pane.id]
+        if (paneTitle) {
+          updateTabTitle(tabId, paneTitle)
         }
       },
       onLayoutChanged: () => {

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -304,6 +304,18 @@ export function useTerminalPaneLifecycle({
         // Dismiss the rename dialog if it was open for the closed pane,
         // otherwise it would submit against a non-existent pane.
         setRenamingPaneId((prev) => (prev === paneId ? null : prev))
+        // Why: PaneManager.closePane() reassigns activePaneId directly without
+        // calling setActivePane(), so onActivePaneChange does not fire. Sync the
+        // tab title to the survivor's stored title here so the tab label doesn't
+        // stay stuck on the closed pane's last title.
+        const newActivePane = managerRef.current?.getActivePane()
+        if (newActivePane) {
+          const paneTitles = useAppStore.getState().runtimePaneTitlesByTabId[tabId] ?? {}
+          const activeTitle = paneTitles[newActivePane.id]
+          if (activeTitle) {
+            updateTabTitle(tabId, activeTitle)
+          }
+        }
         scheduleRuntimeGraphSync()
       },
       onActivePaneChange: (pane) => {


### PR DESCRIPTION
## Summary
- Only the focused pane now drives the tab title — unfocused panes still store their titles per-pane via `runtimePaneTitlesByTabId` but no longer race to update the shared tab label
- When the user switches focus between split panes, `onActivePaneChange` syncs the tab title to the newly active pane's stored title
- Mirrors Ghostty's approach where only the active split propagates its title to the window/tab

Closes stablyai/orca-internal#56

## Test plan
- [ ] Open a terminal tab, split it into two panes
- [ ] Run two agent CLIs (e.g. Codex + Pi, or two Claude Code instances) in each pane
- [ ] Verify the tab title shows only the focused pane's agent title without flickering
- [ ] Click between panes and verify the tab title updates to the newly focused pane's title
- [ ] Verify single-pane tabs still update titles normally