### PR TITLE
fix: resolve invalid nested button DOM in worktree group headers

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -287,12 +287,20 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                 className="absolute left-0 right-0"
                 style={{ transform: `translateY(${vItem.start}px)` }}
               >
-                <button
+                <div
+                  role="button"
+                  tabIndex={0}
                   className={cn(
-                    'group mt-2 flex h-7 w-full items-center gap-1.5 px-1.5 text-left transition-all',
+                    'group mt-2 flex h-7 w-full items-center gap-1.5 px-1.5 text-left transition-all cursor-pointer',
                     row.repo ? 'overflow-hidden' : row.tone
                   )}
                   onClick={() => toggleGroup(row.key)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault()
+                      toggleGroup(row.key)
+                    }
+                  }}
                 >
                   {row.icon ? (
                     <div
@@ -354,7 +362,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                       )}
                     />
                   </div>
-                </button>
+                </div>
               </div>
             )
           }


### PR DESCRIPTION
## Summary
- The group header row in the sidebar worktree list used a `<button>` element that contained an inner `<Button>` for the "Create worktree for [repo]" action
- HTML does not allow `<button>` inside `<button>`, causing React DOM nesting warnings in the dev console
- Replaced the outer `<button>` with a `<div role="button">` with `tabIndex={0}` and keyboard handling (Enter/Space) to preserve full accessibility

## Test plan
- [ ] Enable **group by repo** in the sidebar
- [ ] Open browser dev console and verify no `<button> cannot be a descendant of <button>` warning appears
- [ ] Click a group header to toggle collapse — should still work
- [ ] Press Enter or Space on a focused group header — should toggle collapse
- [ ] Click the "+" button inside a group header — should open the create worktree modal