### PR TITLE
feat: add terminal line height setting

### DIFF
--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -42,6 +42,7 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     terminalFontSize: 14,
     terminalFontFamily: 'JetBrains Mono',
     terminalFontWeight: 500,
+    terminalLineHeight: 1,
     terminalCursorStyle: 'block',
     terminalCursorBlink: false,
     terminalThemeDark: 'orca-dark',

--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -36,6 +36,7 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     terminalFontSize: 14,
     terminalFontFamily: 'JetBrains Mono',
     terminalFontWeight: 500,
+    terminalLineHeight: 1,
     terminalCursorStyle: 'block',
     terminalCursorBlink: false,
     terminalThemeDark: 'orca-dark',

--- a/src/renderer/src/components/settings/TerminalPane.tsx
+++ b/src/renderer/src/components/settings/TerminalPane.tsx
@@ -171,6 +171,28 @@ export function TerminalPane({
             }
           />
         </SearchableSetting>
+
+        <SearchableSetting
+          title="Line Height"
+          description="Controls the terminal line height multiplier."
+          keywords={['terminal', 'typography', 'line height', 'spacing']}
+        >
+          <NumberField
+            label="Line Height"
+            description="Controls the terminal line height multiplier."
+            value={settings.terminalLineHeight}
+            defaultValue={1}
+            min={1}
+            max={3}
+            step={0.1}
+            suffix="1 to 3"
+            onChange={(value) =>
+              updateSettings({
+                terminalLineHeight: clampNumber(value, 1, 3)
+              })
+            }
+          />
+        </SearchableSetting>
       </section>
     ) : null,
     matchesSettingsSearch(searchQuery, TERMINAL_CURSOR_SEARCH_ENTRIES) ? (

--- a/src/renderer/src/components/settings/terminal-search.ts
+++ b/src/renderer/src/components/settings/terminal-search.ts
@@ -15,6 +15,11 @@ export const TERMINAL_TYPOGRAPHY_SEARCH_ENTRIES: SettingsSearchEntry[] = [
     title: 'Font Weight',
     description: 'Controls the terminal text font weight.',
     keywords: ['terminal', 'typography', 'weight']
+  },
+  {
+    title: 'Line Height',
+    description: 'Controls the terminal line height multiplier.',
+    keywords: ['terminal', 'typography', 'line height', 'spacing']
   }
 ]
 

--- a/src/renderer/src/components/terminal-pane/terminal-appearance.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-appearance.ts
@@ -36,6 +36,7 @@ export function applyTerminalAppearance(
     pane.terminal.options.fontWeight = terminalFontWeights.fontWeight
     pane.terminal.options.fontWeightBold = terminalFontWeights.fontWeightBold
     pane.terminal.options.macOptionIsMeta = settings.terminalMacOptionAsAlt === 'true'
+    pane.terminal.options.lineHeight = settings.terminalLineHeight
     try {
       const state = captureScrollState(pane.terminal)
       pane.fitAddon.fit()

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -433,7 +433,8 @@ export function useTerminalPaneLifecycle({
           ),
           cursorStyle: currentSettings?.terminalCursorStyle ?? 'bar',
           cursorBlink: currentSettings?.terminalCursorBlink ?? true,
-          macOptionIsMeta: currentSettings?.terminalMacOptionAsAlt === 'true'
+          macOptionIsMeta: currentSettings?.terminalMacOptionAsAlt === 'true',
+          lineHeight: currentSettings?.terminalLineHeight ?? 1
         }
       },
       onLinkClick: (event, url) => {

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -104,6 +104,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     terminalFontSize: 14,
     terminalFontFamily: defaultTerminalFontFamily(),
     terminalFontWeight: DEFAULT_TERMINAL_FONT_WEIGHT,
+    terminalLineHeight: 1,
     terminalCursorStyle: 'bar',
     terminalCursorBlink: true,
     terminalThemeDark: 'Ghostty Default Style Dark',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -575,6 +575,7 @@ export type GlobalSettings = {
   terminalFontSize: number
   terminalFontFamily: string
   terminalFontWeight: number
+  terminalLineHeight: number
   terminalCursorStyle: 'bar' | 'block' | 'underline'
   terminalCursorBlink: boolean
   terminalThemeDark: string


### PR DESCRIPTION
Add a configurable line height multiplier (1-3) to terminal appearance settings under Typography, persisted and applied to all terminal panes.

## Summary

You can now configure the line height to use for setting up the terminal panes. 

## Screenshots

<img width="2210" height="1300" alt="CleanShot 2026-04-16 at 11 11 36@2x" src="https://github.com/user-attachments/assets/805e43d5-bc11-4f97-8ef7-81c95e4c0cda" />


## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`