### PR TITLE
feat: add zoom, pan, and fit-to-viewport to mermaid diagrams

### DIFF
--- a/src/renderer/src/assets/markdown-preview.css
+++ b/src/renderer/src/assets/markdown-preview.css
@@ -231,15 +231,71 @@
 }
 
 /* Mermaid diagram container */
-.mermaid-block svg {
-  max-width: 100%;
-  height: auto;
+.mermaid-block {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 }
+
+.mermaid-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.25rem;
+  color: var(--muted-foreground);
+}
+
+.mermaid-toolbar-button {
+  width: 1.5rem;
+  height: 1.5rem;
+  min-width: 1.5rem;
+  padding: 0;
+}
+
+.mermaid-toolbar-zoom {
+  min-width: 3.5rem;
+  text-align: center;
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+
+.mermaid-viewport {
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--border) 68%, transparent);
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--background) 92%, transparent);
+  cursor: grab;
+  touch-action: none;
+  user-select: none;
+  outline: none;
+}
+
+.mermaid-viewport:focus-visible {
+  border-color: color-mix(in srgb, var(--ring, var(--border)) 80%, transparent);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--ring, var(--border)) 30%, transparent);
+}
+
+.mermaid-viewport[data-panning] {
+  cursor: grabbing;
+}
+
+.mermaid-canvas {
+  padding: 0.75rem;
+  width: max-content;
+  min-width: 100%;
+}
+
+.mermaid-block svg {
+  display: block;
+  margin: 0 auto;
+}
+
 .mermaid-error {
   color: var(--color-warning, #d29922);
   font-size: 0.85em;
   margin-bottom: 0.5em;
 }
+
 /* Full-file mermaid diagram viewer — used when opening .mmd/.mermaid files
    in diagram mode. Centers the rendered SVG and adds padding so diagrams
    don't press against viewport edges. */

--- a/src/renderer/src/components/editor/MermaidBlock.tsx
+++ b/src/renderer/src/components/editor/MermaidBlock.tsx
@@ -28,18 +28,22 @@ const INITIAL_TRANSLATE: Translate = { x: 0, y: 0 }
 // where one render can clobber another's temporary DOM node. Serializing all
 // render calls through a single promise chain avoids this.
 //
-// The queue is replaced with a fresh promise after each render completes so
-// that old .then() closures (which capture containerRef, content, and id)
-// become unreachable and can be GC'd. Without this, the chain grows with
-// every MermaidBlock mount/unmount cycle for the lifetime of the renderer.
+// The queue tail is collapsed back to a single resolved promise only when the
+// completed render is still the newest scheduled job. That keeps renders fully
+// serialized while still dropping old .then() closures once the queue drains.
 let renderQueue: Promise<void> = Promise.resolve()
 
 function enqueueRender(fn: () => Promise<void>): void {
-  renderQueue = renderQueue.then(fn, fn).then(() => {
-    // Why: collapse the chain back to a single resolved promise so previous
-    // closures do not remain reachable through a growing .then() chain.
-    renderQueue = Promise.resolve()
+  const scheduled = renderQueue.then(fn, fn)
+  const tail = scheduled.finally(() => {
+    // Why: only collapse the queue when no newer render has already chained
+    // onto it. Resetting unconditionally would let later renders start early
+    // and reintroduce mermaid.render() races between blocks.
+    if (renderQueue === tail) {
+      renderQueue = Promise.resolve()
+    }
   })
+  renderQueue = tail
 }
 
 /**

--- a/src/renderer/src/components/editor/MermaidBlock.tsx
+++ b/src/renderer/src/components/editor/MermaidBlock.tsx
@@ -1,13 +1,27 @@
-import React, { useEffect, useId, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useId, useRef, useState } from 'react'
+import { Maximize2, Minus, Plus, RotateCcw } from 'lucide-react'
 import mermaid from 'mermaid'
 import DOMPurify from 'dompurify'
+import { Button } from '@/components/ui/button'
 import { getMermaidConfig } from './mermaid-config'
+import {
+  continuousMermaidZoom,
+  fitMermaidZoom,
+  getMermaidSvgBaseSize,
+  MERMAID_ZOOM_MAX,
+  MERMAID_ZOOM_MIN,
+  nudgeMermaidZoom
+} from './mermaid-zoom'
 
 type MermaidBlockProps = {
   content: string
   isDark: boolean
   htmlLabels?: boolean
 }
+
+type Translate = { x: number; y: number }
+
+const INITIAL_TRANSLATE: Translate = { x: 0, y: 0 }
 
 // Why: mermaid.render() manipulates global DOM state (element IDs, internal
 // parser state). Running multiple renders concurrently causes race conditions
@@ -38,8 +52,55 @@ export default function MermaidBlock({
   htmlLabels = true
 }: MermaidBlockProps): React.JSX.Element {
   const id = useId().replace(/:/g, '_')
+  const viewportRef = useRef<HTMLDivElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
   const [error, setError] = useState<string | null>(null)
+  const [zoom, setZoom] = useState(1)
+  const [translate, setTranslate] = useState<Translate>(INITIAL_TRANSLATE)
+  const [isPanning, setIsPanning] = useState(false)
+  const zoomRef = useRef(1)
+  const translateRef = useRef<Translate>(INITIAL_TRANSLATE)
+
+  const computeFitZoom = useCallback((): number => {
+    const viewport = viewportRef.current
+    const svg = containerRef.current?.querySelector('svg')
+    if (!viewport || !(svg instanceof SVGSVGElement)) {
+      return 1
+    }
+
+    const baseSize = getMermaidSvgBaseSize({
+      width: svg.getAttribute('width'),
+      height: svg.getAttribute('height'),
+      viewBox: svg.getAttribute('viewBox')
+    })
+    if (!baseSize) {
+      return 1
+    }
+
+    const rect = viewport.getBoundingClientRect()
+    return fitMermaidZoom({
+      svgWidth: baseSize.width,
+      svgHeight: baseSize.height,
+      viewportWidth: rect.width,
+      viewportHeight: rect.height
+    })
+  }, [])
+
+  const resetView = useCallback(() => {
+    setZoom(computeFitZoom())
+    setTranslate(INITIAL_TRANSLATE)
+  }, [computeFitZoom])
+
+  useEffect(() => {
+    setZoom(1)
+    setTranslate(INITIAL_TRANSLATE)
+  }, [content])
+
+  useEffect(() => {
+    zoomRef.current = zoom
+    translateRef.current = translate
+    applyMermaidTransform(containerRef.current, zoom, translate)
+  }, [zoom, translate])
 
   useEffect(() => {
     let cancelled = false
@@ -60,6 +121,11 @@ export default function MermaidBlock({
           containerRef.current.innerHTML = DOMPurify.sanitize(svg, {
             USE_PROFILES: { svg: true }
           })
+          applyMermaidTransform(
+            containerRef.current,
+            zoomRef.current,
+            translateRef.current
+          )
           setError(null)
         }
       } catch (err) {
@@ -72,13 +138,71 @@ export default function MermaidBlock({
       }
     }
 
-    // Serialize render calls through a module-level queue to avoid race
-    // conditions from concurrent mermaid.render() invocations.
     enqueueRender(render)
     return () => {
       cancelled = true
     }
   }, [content, htmlLabels, isDark, id])
+
+  const zoomPercent = Math.round(zoom * 100)
+
+  const handleWheel = (event: React.WheelEvent<HTMLDivElement>): void => {
+    if (!event.ctrlKey && !event.metaKey && !event.altKey) {
+      return
+    }
+
+    event.preventDefault()
+    setZoom((current) => continuousMermaidZoom(current, event.deltaY))
+  }
+
+  const handlePointerDown = (event: React.PointerEvent<HTMLDivElement>): void => {
+    if (event.button !== 0) {
+      return
+    }
+    const target = event.target as HTMLElement
+    if (target.closest('button, a, input')) {
+      return
+    }
+    setIsPanning(true)
+    event.currentTarget.setPointerCapture(event.pointerId)
+  }
+
+  const handlePointerMove = (event: React.PointerEvent<HTMLDivElement>): void => {
+    if (!isPanning) {
+      return
+    }
+    setTranslate((current) => ({
+      x: current.x + event.movementX,
+      y: current.y + event.movementY
+    }))
+  }
+
+  const handlePointerUp = (event: React.PointerEvent<HTMLDivElement>): void => {
+    setIsPanning(false)
+    if (event.currentTarget.hasPointerCapture?.(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId)
+    }
+  }
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>): void => {
+    if (event.target !== event.currentTarget) {
+      return
+    }
+    if (event.key === '+' || event.key === '=') {
+      event.preventDefault()
+      setZoom((current) => nudgeMermaidZoom(current, 1))
+    } else if (event.key === '-' || event.key === '_') {
+      event.preventDefault()
+      setZoom((current) => nudgeMermaidZoom(current, -1))
+    } else if (event.key === '0' || event.key === 'r') {
+      event.preventDefault()
+      resetView()
+    }
+  }
+
+  const handleDoubleClick = (): void => {
+    resetView()
+  }
 
   if (error) {
     return (
@@ -91,5 +215,106 @@ export default function MermaidBlock({
     )
   }
 
-  return <div className="mermaid-block" ref={containerRef} />
+  return (
+    <div className="mermaid-block">
+      <div className="mermaid-toolbar">
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          className="mermaid-toolbar-button"
+          onClick={() => setZoom((current) => nudgeMermaidZoom(current, -1))}
+          disabled={zoom <= MERMAID_ZOOM_MIN}
+          aria-label="Zoom out diagram"
+          title="Zoom out (-)"
+        >
+          <Minus />
+        </Button>
+        <span className="mermaid-toolbar-zoom">{zoomPercent}%</span>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          className="mermaid-toolbar-button"
+          onClick={resetView}
+          aria-label="Fit diagram to viewport"
+          title="Fit to viewport (0 or R)"
+        >
+          <Maximize2 />
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          className="mermaid-toolbar-button"
+          onClick={() => {
+            setZoom(1)
+            setTranslate(INITIAL_TRANSLATE)
+          }}
+          disabled={zoom === 1 && translate.x === 0 && translate.y === 0}
+          aria-label="Reset diagram zoom to 100%"
+          title="Reset to 100%"
+        >
+          <RotateCcw />
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          className="mermaid-toolbar-button"
+          onClick={() => setZoom((current) => nudgeMermaidZoom(current, 1))}
+          disabled={zoom >= MERMAID_ZOOM_MAX}
+          aria-label="Zoom in diagram"
+          title="Zoom in (+)"
+        >
+          <Plus />
+        </Button>
+      </div>
+      <div
+        ref={viewportRef}
+        className="mermaid-viewport"
+        data-panning={isPanning || undefined}
+        tabIndex={0}
+        role="group"
+        aria-label="Mermaid diagram viewport. Use plus and minus to zoom, zero or R to fit."
+        onWheel={handleWheel}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerUp}
+        onDoubleClick={handleDoubleClick}
+        onKeyDown={handleKeyDown}
+      >
+        <div className="mermaid-canvas">
+          <div ref={containerRef} />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function applyMermaidTransform(
+  container: HTMLDivElement | null,
+  zoom: number,
+  translate: Translate
+): void {
+  const svg = container?.querySelector('svg')
+  if (!(svg instanceof SVGSVGElement)) {
+    return
+  }
+
+  const baseSize = getMermaidSvgBaseSize({
+    width: svg.getAttribute('width'),
+    height: svg.getAttribute('height'),
+    viewBox: svg.getAttribute('viewBox')
+  })
+
+  // Why: Mermaid often emits a fixed-width SVG plus max-width: 100%.
+  // Scaling the wrapper alone leaves those diagrams at their intrinsic size, so
+  // we size the SVG itself and disable the responsive max-width clamp.
+  svg.style.maxWidth = 'none'
+  svg.style.width = baseSize ? `${baseSize.width * zoom}px` : `${zoom * 100}%`
+  svg.style.height = baseSize?.height ? `${baseSize.height * zoom}px` : 'auto'
+  svg.style.transform = `translate(${translate.x}px, ${translate.y}px)`
+  svg.style.transformOrigin = '0 0'
 }

--- a/src/renderer/src/components/editor/mermaid-zoom.test.ts
+++ b/src/renderer/src/components/editor/mermaid-zoom.test.ts
@@ -112,6 +112,16 @@ describe('getMermaidSvgBaseSize', () => {
     ).toEqual({ width: 320, height: 240 })
   })
 
+  it('falls back to the viewBox when svg dimensions are percentages', () => {
+    expect(
+      getMermaidSvgBaseSize({
+        width: '100%',
+        height: '100%',
+        viewBox: '0 0 320 240'
+      })
+    ).toEqual({ width: 320, height: 240 })
+  })
+
   it('returns null when neither dimensions nor a valid viewBox exist', () => {
     expect(
       getMermaidSvgBaseSize({

--- a/src/renderer/src/components/editor/mermaid-zoom.test.ts
+++ b/src/renderer/src/components/editor/mermaid-zoom.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest'
+import {
+  clampMermaidZoom,
+  continuousMermaidZoom,
+  fitMermaidZoom,
+  getMermaidSvgBaseSize,
+  MERMAID_ZOOM_MAX,
+  MERMAID_ZOOM_MIN,
+  MERMAID_ZOOM_STEP,
+  nudgeMermaidZoom
+} from './mermaid-zoom'
+
+describe('clampMermaidZoom', () => {
+  it('keeps zoom within the supported range', () => {
+    expect(clampMermaidZoom(MERMAID_ZOOM_MIN - 1)).toBe(MERMAID_ZOOM_MIN)
+    expect(clampMermaidZoom(MERMAID_ZOOM_MAX + 1)).toBe(MERMAID_ZOOM_MAX)
+  })
+
+  it('falls back to 100% for non-finite values', () => {
+    expect(clampMermaidZoom(Number.NaN)).toBe(1)
+  })
+})
+
+describe('nudgeMermaidZoom', () => {
+  it('steps zoom in both directions', () => {
+    expect(nudgeMermaidZoom(1, 1)).toBe(1 + MERMAID_ZOOM_STEP)
+    expect(nudgeMermaidZoom(1, -1)).toBe(1 - MERMAID_ZOOM_STEP)
+  })
+
+  it('clamps nudges at the bounds', () => {
+    expect(nudgeMermaidZoom(MERMAID_ZOOM_MAX, 1)).toBe(MERMAID_ZOOM_MAX)
+    expect(nudgeMermaidZoom(MERMAID_ZOOM_MIN, -1)).toBe(MERMAID_ZOOM_MIN)
+  })
+})
+
+describe('continuousMermaidZoom', () => {
+  it('zooms in on negative deltaY and out on positive deltaY', () => {
+    expect(continuousMermaidZoom(1, -100)).toBeGreaterThan(1)
+    expect(continuousMermaidZoom(1, 100)).toBeLessThan(1)
+  })
+
+  it('clamps within the supported range', () => {
+    expect(continuousMermaidZoom(MERMAID_ZOOM_MAX, -10_000)).toBe(MERMAID_ZOOM_MAX)
+    expect(continuousMermaidZoom(MERMAID_ZOOM_MIN, 10_000)).toBe(MERMAID_ZOOM_MIN)
+  })
+})
+
+describe('fitMermaidZoom', () => {
+  it('computes the largest scale that fits both dimensions with padding', () => {
+    const result = fitMermaidZoom({
+      svgWidth: 800,
+      svgHeight: 600,
+      viewportWidth: 432,
+      viewportHeight: 332,
+      padding: 16
+    })
+    // width-fit = (432-32)/800 = 0.5, height-fit = (332-32)/600 = 0.5
+    expect(result).toBeCloseTo(0.5, 5)
+  })
+
+  it('uses width-only fit when svg height is missing', () => {
+    const result = fitMermaidZoom({
+      svgWidth: 800,
+      svgHeight: null,
+      viewportWidth: 432,
+      viewportHeight: 100,
+      padding: 16
+    })
+    expect(result).toBeCloseTo(0.5, 5)
+  })
+
+  it('returns 1 when the svg has no width', () => {
+    expect(
+      fitMermaidZoom({
+        svgWidth: 0,
+        svgHeight: 100,
+        viewportWidth: 400,
+        viewportHeight: 400
+      })
+    ).toBe(1)
+  })
+
+  it('clamps the result to the supported range', () => {
+    const tiny = fitMermaidZoom({
+      svgWidth: 10,
+      svgHeight: 10,
+      viewportWidth: 10_000,
+      viewportHeight: 10_000
+    })
+    expect(tiny).toBe(MERMAID_ZOOM_MAX)
+  })
+})
+
+describe('getMermaidSvgBaseSize', () => {
+  it('prefers explicit svg dimensions when present', () => {
+    expect(
+      getMermaidSvgBaseSize({
+        width: '640',
+        height: '512px',
+        viewBox: '0 0 100 80'
+      })
+    ).toEqual({ width: 640, height: 512 })
+  })
+
+  it('falls back to the viewBox when width is missing', () => {
+    expect(
+      getMermaidSvgBaseSize({
+        width: null,
+        height: null,
+        viewBox: '0 0 320 240'
+      })
+    ).toEqual({ width: 320, height: 240 })
+  })
+
+  it('returns null when neither dimensions nor a valid viewBox exist', () => {
+    expect(
+      getMermaidSvgBaseSize({
+        width: 'auto',
+        height: null,
+        viewBox: 'invalid'
+      })
+    ).toBeNull()
+  })
+})

--- a/src/renderer/src/components/editor/mermaid-zoom.ts
+++ b/src/renderer/src/components/editor/mermaid-zoom.ts
@@ -1,0 +1,102 @@
+export const MERMAID_ZOOM_MIN = 0.1
+export const MERMAID_ZOOM_MAX = 8
+export const MERMAID_ZOOM_STEP = 0.25
+export const MERMAID_ZOOM_WHEEL_SENSITIVITY = 0.01
+export const MERMAID_FIT_PADDING = 16
+
+type MermaidSvgSize = {
+  width: number
+  height: number | null
+}
+
+export function clampMermaidZoom(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 1
+  }
+
+  return Math.max(MERMAID_ZOOM_MIN, Math.min(MERMAID_ZOOM_MAX, value))
+}
+
+export function nudgeMermaidZoom(current: number, direction: 1 | -1): number {
+  return clampMermaidZoom(current + direction * MERMAID_ZOOM_STEP)
+}
+
+// Why: trackpad pinch and modifier-wheel fire many small delta events. Stepping
+// by a fixed 0.25 feels jerky; an exponential curve lets small deltas produce
+// proportionally small scale changes for a smooth feel.
+export function continuousMermaidZoom(current: number, deltaY: number): number {
+  const factor = Math.exp(-deltaY * MERMAID_ZOOM_WHEEL_SENSITIVITY)
+  return clampMermaidZoom(current * factor)
+}
+
+type FitInputs = {
+  svgWidth: number
+  svgHeight: number | null
+  viewportWidth: number
+  viewportHeight: number
+  padding?: number
+}
+
+// Returns the zoom level that makes the SVG fit inside the viewport with
+// optional padding. If the SVG has no height we fall back to width-only fit so
+// the result is still useful (Mermaid sometimes omits height).
+export function fitMermaidZoom(inputs: FitInputs): number {
+  const padding = inputs.padding ?? MERMAID_FIT_PADDING
+  const availableWidth = Math.max(0, inputs.viewportWidth - padding * 2)
+  const availableHeight = Math.max(0, inputs.viewportHeight - padding * 2)
+
+  if (inputs.svgWidth <= 0 || availableWidth <= 0) {
+    return 1
+  }
+
+  const widthFit = availableWidth / inputs.svgWidth
+  if (inputs.svgHeight === null || inputs.svgHeight <= 0 || availableHeight <= 0) {
+    return clampMermaidZoom(widthFit)
+  }
+
+  const heightFit = availableHeight / inputs.svgHeight
+  return clampMermaidZoom(Math.min(widthFit, heightFit))
+}
+
+function parseMermaidDimension(value: string | null): number | null {
+  if (!value) {
+    return null
+  }
+
+  const match = value.trim().match(/^([0-9]+(?:\.[0-9]+)?)/)
+  if (!match) {
+    return null
+  }
+
+  const parsed = Number.parseFloat(match[1])
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+export function getMermaidSvgBaseSize(attributes: {
+  width: string | null
+  height: string | null
+  viewBox: string | null
+}): MermaidSvgSize | null {
+  const width = parseMermaidDimension(attributes.width)
+  const height = parseMermaidDimension(attributes.height)
+  if (width !== null) {
+    return { width, height }
+  }
+
+  if (!attributes.viewBox) {
+    return null
+  }
+
+  const parts = attributes.viewBox
+    .trim()
+    .split(/[\s,]+/)
+    .map((part) => Number.parseFloat(part))
+  if (parts.length !== 4 || parts.some((part) => !Number.isFinite(part))) {
+    return null
+  }
+
+  return {
+    width: parts[2],
+    height: parts[3]
+  }
+}

--- a/src/renderer/src/components/editor/mermaid-zoom.ts
+++ b/src/renderer/src/components/editor/mermaid-zoom.ts
@@ -63,7 +63,12 @@ function parseMermaidDimension(value: string | null): number | null {
     return null
   }
 
-  const match = value.trim().match(/^([0-9]+(?:\.[0-9]+)?)/)
+  const trimmed = value.trim()
+  if (trimmed.endsWith('%')) {
+    return null
+  }
+
+  const match = trimmed.match(/^([0-9]+(?:\.[0-9]+)?)(?:px)?$/)
   if (!match) {
     return null
   }


### PR DESCRIPTION
## Summary

- Scales the SVG element itself (not just the wrapper), so fixed-width Mermaid diagrams actually respond to zoom controls
- Toolbar with: zoom-out, zoom %, fit-to-viewport (Maximize2), reset-to-100% (RotateCcw), zoom-in
- Drag to pan when the diagram exceeds the viewport (pointer capture API)
- Double-click or press `0`/`R` to fit diagram to viewport; `+`/`-` to nudge zoom when viewport is focused
- Modifier+wheel / trackpad pinch uses an exponential curve for smooth continuous scaling
- Zoom range 0.1x–8x; viewport uses `overflow: hidden` with grab/grabbing cursor
- New `mermaid-zoom.ts` with pure helper functions and 13 unit tests
- Fully compatible with `htmlLabels` prop and `getMermaidConfig` used by `MermaidViewer`

## Root Cause

Mermaid emits many diagrams as fixed-size `<svg width="…">` elements. The previous approach only changed the wrapper width, so diagrams that already fit the pane appeared not to zoom at all. This PR scales the SVG element's own `width`/`height` attributes and disables the `max-width: 100%` clamp that was preventing the resize.

## Validation

```
pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/editor/mermaid-zoom.test.ts
# → 13 passed

pnpm exec tsc --noEmit -p config/tsconfig.web.json --pretty false
# → no new errors (pre-existing TS6307 errors in unrelated files are unchanged)
```