### PR TITLE
fix: preserve macOS Option characters in terminal

### DIFF
--- a/src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest'
+import { buildDefaultTerminalOptions } from './pane-lifecycle'
+
+describe('buildDefaultTerminalOptions', () => {
+  it('leaves macOS Option available for keyboard layout characters', () => {
+    expect(buildDefaultTerminalOptions().macOptionIsMeta).toBe(false)
+  })
+})

--- a/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
+++ b/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
@@ -19,6 +19,31 @@ import { safeFit } from './pane-tree-ops'
 
 const ENABLE_WEBGL_RENDERER = true
 
+export function buildDefaultTerminalOptions(): ITerminalOptions {
+  return {
+    allowProposedApi: true,
+    cursorBlink: true,
+    cursorStyle: 'bar',
+    fontSize: 14,
+    // Cross-platform fallback chain — ensures the terminal can always find a
+    // usable monospace font regardless of OS, even if user settings haven't
+    // loaded yet. macOS-only fonts are harmlessly skipped on other platforms.
+    fontFamily:
+      '"SF Mono", "Menlo", "Monaco", "Cascadia Mono", "Consolas", "DejaVu Sans Mono", "Liberation Mono", monospace',
+    fontWeight: '300',
+    fontWeightBold: '500',
+    scrollback: 10000,
+    allowTransparency: false,
+    // Why: on macOS, non-US layouts rely on Option to compose real characters
+    // like @ (German Option+L) and EUR (German Option+E). Enabling xterm's
+    // Meta mode here makes Option behave like Esc+key instead, which steals
+    // those composed characters before they reach the shell.
+    macOptionIsMeta: false,
+    macOptionClickForcesSelection: true,
+    drawBoldTextInBrightColors: true
+  }
+}
+
 function getTerminalUrlOpenHint(): string {
   return navigator.userAgent.includes('Mac')
     ? '⌘+click to open or ⇧⌘+click for system browser'
@@ -48,22 +73,7 @@ export function createPaneDOM(
   // Build terminal options
   const userOpts = options.terminalOptions?.(id) ?? {}
   const terminalOpts: ITerminalOptions = {
-    allowProposedApi: true,
-    cursorBlink: true,
-    cursorStyle: 'bar',
-    fontSize: 14,
-    // Cross-platform fallback chain — ensures the terminal can always find a
-    // usable monospace font regardless of OS, even if user settings haven't
-    // loaded yet. macOS-only fonts are harmlessly skipped on other platforms.
-    fontFamily:
-      '"SF Mono", "Menlo", "Monaco", "Cascadia Mono", "Consolas", "DejaVu Sans Mono", "Liberation Mono", monospace',
-    fontWeight: '300',
-    fontWeightBold: '500',
-    scrollback: 10000,
-    allowTransparency: false,
-    macOptionIsMeta: true,
-    macOptionClickForcesSelection: true,
-    drawBoldTextInBrightColors: true,
+    ...buildDefaultTerminalOptions(),
     ...userOpts
   }
 


### PR DESCRIPTION
## Summary
- Fix Orca's terminal on macOS so non-US keyboard layouts can enter composed Option characters like `@` and `€` instead of having Option treated as terminal Meta input.
- Extract the default xterm option builder and add a regression test that locks `macOptionIsMeta` to `false`.
- No visual change.

## User-Visible Change
- On macOS, terminal tabs now allow layout-composed Option characters to reach the shell correctly. This fixes German-layout input such as `Option+L` -> `@` and `Option+E` -> `€`.

## Testing
- Verified manually in a local Orca dev build on macOS with a German keyboard layout: `Option+L` produced `@` and `Option+E` produced `€` in the terminal.
- `corepack pnpm lint`
- `corepack pnpm typecheck`
- `corepack pnpm test`
- `corepack pnpm run typecheck && corepack pnpm run build:relay && corepack pnpm run build:electron-vite && corepack pnpm run build:cli`

## Platform Notes
- macOS behavior changed intentionally to preserve keyboard-layout character composition in terminal input.
- Linux and Windows behavior is unchanged because `macOptionIsMeta` is only a macOS xterm setting.
- Cross-platform compatibility review: confirmed the change only affects xterm's macOS-specific Option handling and does not alter Orca's existing platform checks, shortcut labels, or non-macOS terminal behavior.

## AI Review Summary
- Cross-platform review: `macOptionIsMeta` is an xterm macOS-only flag, so setting it to `false` restores expected Option character composition on macOS while leaving Linux/Windows input paths unchanged.
- Security audit summary: low risk. The change only adjusts terminal client-side keyboard interpretation and adds a unit test; it does not expand IPC surface area, shell execution, filesystem access, or privilege boundaries.

## Additional Context
- Root cause: Orca initialized xterm with `macOptionIsMeta: true`, which caused xterm to treat Option as Meta/Esc input and swallow layout-composed characters before they reached the PTY.

## Contributor
- X handle: @a_parusel