### PR TITLE
Change New Markdown shortcut from ⌘⇧N to ⌘⇧M

### DIFF
--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -285,7 +285,7 @@ function Terminal(): React.JSX.Element | null {
       return
     }
     try {
-      // Why: the global Cmd/Ctrl+Shift+N shortcut is handled here rather than
+      // Why: the global Cmd/Ctrl+Shift+M shortcut is handled here rather than
       // inside a specific TabGroupPanel, so it must snapshot the store's
       // current focused group explicitly. Otherwise split layouts fall back to
       // the ambient/default group and open the file in the wrong pane.
@@ -558,8 +558,8 @@ function Terminal(): React.JSX.Element | null {
         }
       }
 
-      // Cmd/Ctrl+Shift+N - new file
-      if (mod && e.shiftKey && e.key.toLowerCase() === 'n' && !e.repeat) {
+      // Cmd/Ctrl+Shift+M - new markdown file
+      if (mod && e.shiftKey && e.key.toLowerCase() === 'm' && !e.repeat) {
         e.preventDefault()
         void handleNewFile()
         return

--- a/src/renderer/src/components/settings/ShortcutsPane.tsx
+++ b/src/renderer/src/components/settings/ShortcutsPane.tsx
@@ -105,9 +105,19 @@ const SHORTCUT_GROUP_DEFINITIONS: ShortcutGroupDefinition[] = [
     title: 'Terminal Tabs',
     items: [
       {
-        action: 'New tab',
-        searchKeywords: ['shortcut', 'tab'],
+        action: 'New Terminal',
+        searchKeywords: ['shortcut', 'tab', 'terminal'],
         keys: ({ mod }) => [mod, 'T']
+      },
+      {
+        action: 'New Browser Tab',
+        searchKeywords: ['shortcut', 'tab', 'browser'],
+        keys: ({ mod, shift }) => [mod, shift, 'B']
+      },
+      {
+        action: 'New Markdown',
+        searchKeywords: ['shortcut', 'tab', 'markdown', 'file'],
+        keys: ({ mod, shift }) => [mod, shift, 'M']
       },
       {
         action: 'Close active tab / pane',

--- a/src/renderer/src/components/tab-bar/TabBar.tsx
+++ b/src/renderer/src/components/tab-bar/TabBar.tsx
@@ -32,7 +32,7 @@ import {
 const isMac = navigator.userAgent.includes('Mac')
 const NEW_TERMINAL_SHORTCUT = isMac ? '⌘T' : 'Ctrl+T'
 const NEW_BROWSER_SHORTCUT = isMac ? '⌘⇧B' : 'Ctrl+Shift+B'
-const NEW_FILE_SHORTCUT = isMac ? '⌘⇧N' : 'Ctrl+Shift+N'
+const NEW_FILE_SHORTCUT = isMac ? '⌘⇧M' : 'Ctrl+Shift+M'
 
 type TabBarProps = {
   tabs: TerminalTab[]


### PR DESCRIPTION
## Summary
- Changes the "New Markdown" keyboard shortcut from `⌘⇧N` / `Ctrl+Shift+N` to `⌘⇧M` / `Ctrl+Shift+M`. The old shortcut conflicts with VS Code and Chrome's "New Window" convention; `⌘⇧M` is a clear mnemonic for **M**arkdown and doesn't clash with any existing binding.
- Adds the "New Browser Tab" (`⌘⇧B`) and "New Markdown" (`⌘⇧M`) entries to the Settings > Keyboard Shortcuts pane, which were previously missing. Renames the existing "New tab" label to "New Terminal" for clarity.

## Test plan
- [ ] Press `⌘⇧M` (Mac) / `Ctrl+Shift+M` (Win/Linux) → should create a new untitled markdown file
- [ ] Press `⌘⇧N` → should no longer create a markdown file
- [ ] Open Settings > Keyboard Shortcuts → verify "New Terminal", "New Browser Tab", and "New Markdown" all appear with correct key combos
- [ ] Verify `⌘T`, `⌘⇧B` still work for terminal and browser tab creation