### PR TITLE
feat: support dragging tabs into new split panes

### DIFF
--- a/src/renderer/src/assets/terminal.css
+++ b/src/renderer/src/assets/terminal.css
@@ -125,7 +125,8 @@
 
 /* ── Drop overlay ─────────────────────────────────────── */
 
-.pane-drop-overlay {
+.pane-drop-overlay,
+.tab-drop-overlay {
   position: absolute;
   z-index: 9999;
   background: rgba(59, 130, 246, 0.2);

--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -796,7 +796,6 @@ function Terminal(): React.JSX.Element | null {
             onClose={handleCloseTab}
             onCloseOthers={handleCloseOthers}
             onCloseToRight={handleCloseTabsToRight}
-            onReorder={setTabBarOrder}
             onNewTerminalTab={handleNewTab}
             onNewBrowserTab={handleNewBrowserTab}
             onNewFileTab={handleNewFile}

--- a/src/renderer/src/components/tab-bar/BrowserTab.tsx
+++ b/src/renderer/src/components/tab-bar/BrowserTab.tsx
@@ -13,6 +13,7 @@ import { ORCA_BROWSER_BLANK_URL } from '../../../../shared/constants'
 import type { BrowserTab as BrowserTabState } from '../../../../shared/types'
 import { CLOSE_ALL_CONTEXT_MENUS_EVENT } from './SortableTab'
 import { getLiveBrowserUrl } from '../browser-pane/browser-runtime'
+import type { TabDragItemData } from '../tab-group/useTabDragSplit'
 
 function formatBrowserTabUrlLabel(url: string): string {
   if (url === ORCA_BROWSER_BLANK_URL || url === 'about:blank') {
@@ -49,7 +50,8 @@ export default function BrowserTab({
   onActivate,
   onClose,
   onCloseToRight,
-  onSplitGroup
+  onSplitGroup,
+  dragData
 }: {
   tab: BrowserTabState
   isActive: boolean
@@ -58,9 +60,11 @@ export default function BrowserTab({
   onClose: () => void
   onCloseToRight: () => void
   onSplitGroup: (direction: 'left' | 'right' | 'up' | 'down', sourceVisibleTabId: string) => void
+  dragData: TabDragItemData
 }): React.JSX.Element {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
-    id: tab.id
+    id: tab.id,
+    data: dragData
   })
   const [menuOpen, setMenuOpen] = useState(false)
   const [menuPoint, setMenuPoint] = useState({ x: 0, y: 0 })

--- a/src/renderer/src/components/tab-bar/EditorFileTab.tsx
+++ b/src/renderer/src/components/tab-bar/EditorFileTab.tsx
@@ -24,6 +24,7 @@ import { STATUS_COLORS, STATUS_LABELS } from '../right-sidebar/status-display'
 import type { GitFileStatus } from '../../../../shared/types'
 import type { OpenFile } from '../../store/slices/editor'
 import { CLOSE_ALL_CONTEXT_MENUS_EVENT } from './SortableTab'
+import type { TabDragItemData } from '../tab-group/useTabDragSplit'
 
 const isMac = navigator.userAgent.includes('Mac')
 const isLinux = navigator.userAgent.includes('Linux')
@@ -45,7 +46,8 @@ export default function EditorFileTab({
   onCloseToRight,
   onCloseAll,
   onPin,
-  onSplitGroup
+  onSplitGroup,
+  dragData
 }: {
   file: OpenFile & { tabId?: string }
   isActive: boolean
@@ -57,12 +59,14 @@ export default function EditorFileTab({
   onCloseAll: () => void
   onPin?: () => void
   onSplitGroup: (direction: 'left' | 'right' | 'up' | 'down', sourceVisibleTabId: string) => void
+  dragData: TabDragItemData
 }): React.JSX.Element {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     // Why: split groups can duplicate the same open file into multiple visible
     // tabs. Using the unified tab ID keeps each rendered tab draggable as a
     // distinct item instead of collapsing every copy onto the file entity ID.
-    id: file.tabId ?? file.id
+    id: file.tabId ?? file.id,
+    data: dragData
   })
 
   const style = {

--- a/src/renderer/src/components/tab-bar/SortableTab.tsx
+++ b/src/renderer/src/components/tab-bar/SortableTab.tsx
@@ -20,6 +20,7 @@ import {
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import type { TerminalTab } from '../../../../shared/types'
+import type { TabDragItemData } from '../tab-group/useTabDragSplit'
 
 type SortableTabProps = {
   tab: TerminalTab
@@ -35,6 +36,7 @@ type SortableTabProps = {
   onSetTabColor: (tabId: string, color: string | null) => void
   onToggleExpand: (tabId: string) => void
   onSplitGroup: (direction: 'left' | 'right' | 'up' | 'down', sourceVisibleTabId: string) => void
+  dragData: TabDragItemData
 }
 
 export const TAB_COLORS = [
@@ -65,10 +67,12 @@ export default function SortableTab({
   onSetCustomTitle,
   onSetTabColor,
   onToggleExpand,
-  onSplitGroup
+  onSplitGroup,
+  dragData
 }: SortableTabProps): React.JSX.Element {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
-    id: tab.id
+    id: tab.id,
+    data: dragData
   })
 
   const style = {

--- a/src/renderer/src/components/tab-bar/TabBar.tsx
+++ b/src/renderer/src/components/tab-bar/TabBar.tsx
@@ -1,13 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef } from 'react'
-import {
-  DndContext,
-  closestCenter,
-  PointerSensor,
-  useSensor,
-  useSensors,
-  type DragEndEvent
-} from '@dnd-kit/core'
-import { SortableContext, horizontalListSortingStrategy, arrayMove } from '@dnd-kit/sortable'
+import { SortableContext, horizontalListSortingStrategy } from '@dnd-kit/sortable'
 import { FilePlus, Globe, Plus, TerminalSquare } from 'lucide-react'
 import type {
   BrowserTab as BrowserTabState,
@@ -21,6 +13,7 @@ import SortableTab from './SortableTab'
 import EditorFileTab from './EditorFileTab'
 import BrowserTab from './BrowserTab'
 import { reconcileTabOrder } from './reconcile-order'
+import type { TabDragItemData } from '../tab-group/useTabDragSplit'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -35,15 +28,15 @@ const NEW_BROWSER_SHORTCUT = isMac ? '⌘⇧B' : 'Ctrl+Shift+B'
 const NEW_FILE_SHORTCUT = isMac ? '⌘⇧M' : 'Ctrl+Shift+M'
 
 type TabBarProps = {
-  tabs: TerminalTab[]
+  tabs: (TerminalTab & { unifiedTabId?: string })[]
   activeTabId: string | null
+  groupId?: string
   worktreeId: string
   expandedPaneByTabId: Record<string, boolean>
   onActivate: (tabId: string) => void
   onClose: (tabId: string) => void
   onCloseOthers: (tabId: string) => void
   onCloseToRight: (tabId: string) => void
-  onReorder: (worktreeId: string, order: string[]) => void
   onNewTerminalTab: () => void
   onNewBrowserTab: () => void
   onNewFileTab?: () => void
@@ -51,7 +44,7 @@ type TabBarProps = {
   onSetTabColor: (tabId: string, color: string | null) => void
   onTogglePaneExpand: (tabId: string) => void
   editorFiles?: (OpenFile & { tabId?: string })[]
-  browserTabs?: BrowserTabState[]
+  browserTabs?: (BrowserTabState & { tabId?: string })[]
   activeFileId?: string | null
   activeBrowserTabId?: string | null
   activeTabType?: WorkspaceVisibleTabType
@@ -69,20 +62,30 @@ type TabBarProps = {
 }
 
 type TabItem =
-  | { type: 'terminal'; id: string; data: TerminalTab }
-  | { type: 'editor'; id: string; data: OpenFile & { tabId?: string } }
-  | { type: 'browser'; id: string; data: BrowserTabState }
+  | {
+      type: 'terminal'
+      id: string
+      unifiedTabId: string
+      data: TerminalTab & { unifiedTabId?: string }
+    }
+  | { type: 'editor'; id: string; unifiedTabId: string; data: OpenFile & { tabId?: string } }
+  | {
+      type: 'browser'
+      id: string
+      unifiedTabId: string
+      data: BrowserTabState & { tabId?: string }
+    }
 
 function TabBarInner({
   tabs,
   activeTabId,
+  groupId,
   worktreeId,
   expandedPaneByTabId,
   onActivate,
   onClose,
   onCloseOthers,
   onCloseToRight,
-  onReorder,
   onNewTerminalTab,
   onNewBrowserTab,
   onNewFileTab,
@@ -103,13 +106,8 @@ function TabBarInner({
   tabBarOrder,
   onCreateSplitGroup
 }: TabBarProps): React.JSX.Element {
-  const sensors = useSensors(
-    useSensor(PointerSensor, {
-      activationConstraint: { distance: 5 }
-    })
-  )
-
   const gitStatusByWorktree = useAppStore((s) => s.gitStatusByWorktree)
+  const resolvedGroupId = groupId ?? worktreeId
   const statusByRelativePath = useMemo(
     () => buildStatusMap(gitStatusByWorktree[worktreeId] ?? []),
     [worktreeId, gitStatusByWorktree]
@@ -136,42 +134,33 @@ function TabBarInner({
     for (const id of ids) {
       const terminal = terminalMap.get(id)
       if (terminal) {
-        items.push({ type: 'terminal', id, data: terminal })
+        items.push({
+          type: 'terminal',
+          id,
+          unifiedTabId: terminal.unifiedTabId ?? terminal.id,
+          data: terminal
+        })
         continue
       }
       const file = editorMap.get(id)
       if (file) {
-        items.push({ type: 'editor', id, data: file })
+        items.push({ type: 'editor', id, unifiedTabId: file.tabId ?? file.id, data: file })
         continue
       }
       const browserTab = browserMap.get(id)
       if (browserTab) {
-        items.push({ type: 'browser', id, data: browserTab })
+        items.push({
+          type: 'browser',
+          id,
+          unifiedTabId: browserTab.tabId ?? browserTab.id,
+          data: browserTab
+        })
       }
     }
     return items
   }, [tabBarOrder, terminalIds, editorFileIds, browserTabIds, terminalMap, editorMap, browserMap])
 
   const sortableIds = useMemo(() => orderedItems.map((item) => item.id), [orderedItems])
-
-  const handleDragEnd = useCallback(
-    (event: DragEndEvent) => {
-      const { active, over } = event
-      if (!over || active.id === over.id) {
-        return
-      }
-
-      const oldIndex = sortableIds.indexOf(active.id as string)
-      const newIndex = sortableIds.indexOf(over.id as string)
-      if (oldIndex === -1 || newIndex === -1) {
-        return
-      }
-
-      const newOrder = arrayMove(sortableIds, oldIndex, newIndex)
-      onReorder(worktreeId, newOrder)
-    },
-    [sortableIds, worktreeId, onReorder]
-  )
 
   const focusTerminalTabSurface = useCallback((tabId: string) => {
     // Why: creating a terminal from the "+" menu is a two-step focus race:
@@ -221,76 +210,86 @@ function TabBarInner({
       // editor drop zone.
       data-native-file-drop-target="editor"
     >
-      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
-        <SortableContext items={sortableIds} strategy={horizontalListSortingStrategy}>
-          {/* Why: no-drag lets tab interactions work inside the titlebar's drag
-              region. The outer container inherits drag so empty space after the
-              "+" button remains window-draggable. */}
-          <div
-            ref={tabStripRef}
-            className="terminal-tab-strip flex items-stretch overflow-x-auto overflow-y-hidden"
-            style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
-          >
-            {orderedItems.map((item, index) => {
-              if (item.type === 'terminal') {
-                return (
-                  <SortableTab
-                    key={item.id}
-                    tab={item.data}
-                    tabCount={tabs.length}
-                    hasTabsToRight={index < orderedItems.length - 1}
-                    isActive={activeTabType === 'terminal' && item.id === activeTabId}
-                    isExpanded={expandedPaneByTabId[item.id] === true}
-                    onActivate={onActivate}
-                    onClose={onClose}
-                    onCloseOthers={onCloseOthers}
-                    onCloseToRight={onCloseToRight}
-                    onSetCustomTitle={onSetCustomTitle}
-                    onSetTabColor={onSetTabColor}
-                    onToggleExpand={onTogglePaneExpand}
-                    onSplitGroup={(direction, sourceVisibleTabId) =>
-                      onCreateSplitGroup?.(direction, sourceVisibleTabId)
-                    }
-                  />
-                )
-              }
-              if (item.type === 'browser') {
-                return (
-                  <BrowserTab
-                    key={item.id}
-                    tab={item.data}
-                    isActive={activeTabType === 'browser' && activeBrowserTabId === item.id}
-                    hasTabsToRight={index < orderedItems.length - 1}
-                    onActivate={() => onActivateBrowserTab?.(item.id)}
-                    onClose={() => onCloseBrowserTab?.(item.id)}
-                    onCloseToRight={() => onCloseToRight(item.id)}
-                    onSplitGroup={(direction, sourceVisibleTabId) =>
-                      onCreateSplitGroup?.(direction, sourceVisibleTabId)
-                    }
-                  />
-                )
-              }
+      <SortableContext items={sortableIds} strategy={horizontalListSortingStrategy}>
+        {/* Why: no-drag lets tab interactions work inside the titlebar's drag
+            region. The outer container inherits drag so empty space after the
+            "+" button remains window-draggable. */}
+        <div
+          ref={tabStripRef}
+          className="terminal-tab-strip flex items-stretch overflow-x-auto overflow-y-hidden"
+          style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+        >
+          {orderedItems.map((item, index) => {
+            const dragData: TabDragItemData = {
+              kind: 'tab',
+              worktreeId,
+              groupId: resolvedGroupId,
+              unifiedTabId: item.unifiedTabId,
+              visibleTabId: item.id,
+              tabType: item.type
+            }
+
+            if (item.type === 'terminal') {
               return (
-                <EditorFileTab
+                <SortableTab
                   key={item.id}
-                  file={item.data}
-                  isActive={activeTabType === 'editor' && activeFileId === item.id}
+                  tab={item.data}
+                  tabCount={tabs.length}
                   hasTabsToRight={index < orderedItems.length - 1}
-                  statusByRelativePath={statusByRelativePath}
-                  onActivate={() => onActivateFile?.(item.id)}
-                  onClose={() => onCloseFile?.(item.id)}
-                  onCloseToRight={() => onCloseToRight(item.id)}
-                  onCloseAll={() => onCloseAllFiles?.()}
-                  onPin={() => onPinFile?.(item.data.id, item.data.tabId)}
+                  isActive={activeTabType === 'terminal' && item.id === activeTabId}
+                  isExpanded={expandedPaneByTabId[item.id] === true}
+                  onActivate={onActivate}
+                  onClose={onClose}
+                  onCloseOthers={onCloseOthers}
+                  onCloseToRight={onCloseToRight}
+                  onSetCustomTitle={onSetCustomTitle}
+                  onSetTabColor={onSetTabColor}
+                  onToggleExpand={onTogglePaneExpand}
                   onSplitGroup={(direction, sourceVisibleTabId) =>
                     onCreateSplitGroup?.(direction, sourceVisibleTabId)
                   }
+                  dragData={dragData}
                 />
               )
-            })}
-          </div>
-        </SortableContext>
-      </DndContext>
+            }
+            if (item.type === 'browser') {
+              return (
+                <BrowserTab
+                  key={item.id}
+                  tab={item.data}
+                  isActive={activeTabType === 'browser' && activeBrowserTabId === item.id}
+                  hasTabsToRight={index < orderedItems.length - 1}
+                  onActivate={() => onActivateBrowserTab?.(item.id)}
+                  onClose={() => onCloseBrowserTab?.(item.id)}
+                  onCloseToRight={() => onCloseToRight(item.id)}
+                  onSplitGroup={(direction, sourceVisibleTabId) =>
+                    onCreateSplitGroup?.(direction, sourceVisibleTabId)
+                  }
+                  dragData={dragData}
+                />
+              )
+            }
+            return (
+              <EditorFileTab
+                key={item.id}
+                file={item.data}
+                isActive={activeTabType === 'editor' && activeFileId === item.id}
+                hasTabsToRight={index < orderedItems.length - 1}
+                statusByRelativePath={statusByRelativePath}
+                onActivate={() => onActivateFile?.(item.id)}
+                onClose={() => onCloseFile?.(item.id)}
+                onCloseToRight={() => onCloseToRight(item.id)}
+                onCloseAll={() => onCloseAllFiles?.()}
+                onPin={() => onPinFile?.(item.data.id, item.data.tabId)}
+                onSplitGroup={(direction, sourceVisibleTabId) =>
+                  onCreateSplitGroup?.(direction, sourceVisibleTabId)
+                }
+                dragData={dragData}
+              />
+            )
+          })}
+        </div>
+      </SortableContext>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <button

--- a/src/renderer/src/components/tab-group/TabGroupDropOverlay.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupDropOverlay.tsx
@@ -17,5 +17,7 @@ function getOverlayStyle(zone: TabDropZone): CSSProperties {
 }
 
 export default function TabGroupDropOverlay({ zone }: { zone: TabDropZone }): React.JSX.Element {
-  return <div className="tab-drop-overlay absolute" style={getOverlayStyle(zone)} />
+  return (
+    <div aria-hidden="true" className="tab-drop-overlay absolute" style={getOverlayStyle(zone)} />
+  )
 }

--- a/src/renderer/src/components/tab-group/TabGroupDropOverlay.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupDropOverlay.tsx
@@ -1,0 +1,21 @@
+import type { CSSProperties } from 'react'
+import type { TabDropZone } from './useTabDragSplit'
+
+function getOverlayStyle(zone: TabDropZone): CSSProperties {
+  switch (zone) {
+    case 'up':
+      return { top: 0, left: 0, width: '100%', height: '50%' }
+    case 'down':
+      return { top: '50%', left: 0, width: '100%', height: '50%' }
+    case 'left':
+      return { top: 0, left: 0, width: '50%', height: '100%' }
+    case 'right':
+      return { top: 0, left: '50%', width: '50%', height: '100%' }
+    case 'center':
+      return { inset: 0 }
+  }
+}
+
+export default function TabGroupDropOverlay({ zone }: { zone: TabDropZone }): React.JSX.Element {
+  return <div className="tab-drop-overlay absolute" style={getOverlayStyle(zone)} />
+}

--- a/src/renderer/src/components/tab-group/TabGroupPanel.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.tsx
@@ -1,4 +1,5 @@
 import { lazy, Suspense } from 'react'
+import { useDroppable } from '@dnd-kit/core'
 import { Columns2, Ellipsis, Rows2, X } from 'lucide-react'
 import { useAppStore } from '../../store'
 import {
@@ -12,6 +13,8 @@ import TabBar from '../tab-bar/TabBar'
 import TerminalPane from '../terminal-pane/TerminalPane'
 import BrowserPane from '../browser-pane/BrowserPane'
 import { useTabGroupWorkspaceModel } from './useTabGroupWorkspaceModel'
+import TabGroupDropOverlay from './TabGroupDropOverlay'
+import { getTabPaneBodyDroppableId, type TabDropZone } from './useTabDragSplit'
 
 const EditorPanel = lazy(() => import('../editor/EditorPanel'))
 
@@ -21,7 +24,9 @@ export default function TabGroupPanel({
   isFocused,
   hasSplitGroups,
   reserveClosedExplorerToggleSpace,
-  reserveCollapsedSidebarHeaderSpace
+  reserveCollapsedSidebarHeaderSpace,
+  isTabDragActive = false,
+  activeDropZone = null
 }: {
   groupId: string
   worktreeId: string
@@ -29,6 +34,8 @@ export default function TabGroupPanel({
   hasSplitGroups: boolean
   reserveClosedExplorerToggleSpace: boolean
   reserveCollapsedSidebarHeaderSpace: boolean
+  isTabDragActive?: boolean
+  activeDropZone?: TabDropZone | null
 }): React.JSX.Element {
   const rightSidebarOpen = useAppStore((state) => state.rightSidebarOpen)
   const sidebarOpen = useAppStore((state) => state.sidebarOpen)
@@ -45,11 +52,21 @@ export default function TabGroupPanel({
     terminalTabs,
     worktreePath
   } = model
+  const { setNodeRef: setBodyDropRef } = useDroppable({
+    id: getTabPaneBodyDroppableId(groupId),
+    data: {
+      kind: 'pane-body',
+      groupId,
+      worktreeId
+    },
+    disabled: !isTabDragActive
+  })
 
   const tabBar = (
     <TabBar
       tabs={terminalTabs}
       activeTabId={activeTab?.contentType === 'terminal' ? activeTab.entityId : null}
+      groupId={groupId}
       worktreeId={worktreeId}
       expandedPaneByTabId={model.expandedPaneByTabId}
       onActivate={commands.activateTerminal}
@@ -77,7 +94,6 @@ export default function TabGroupPanel({
           commands.closeToRight(item.id)
         }
       }}
-      onReorder={(_, order) => commands.reorderTabBar(order)}
       onNewTerminalTab={commands.newTerminalTab}
       onNewBrowserTab={commands.newBrowserTab}
       onNewFileTab={commands.newFileTab}
@@ -249,7 +265,8 @@ export default function TabGroupPanel({
         </div>
       </div>
 
-      <div className="relative flex-1 min-h-0 overflow-hidden">
+      <div ref={setBodyDropRef} className="relative flex-1 min-h-0 overflow-hidden">
+        {activeDropZone ? <TabGroupDropOverlay zone={activeDropZone} /> : null}
         {model.groupTabs
           .filter((item) => item.contentType === 'terminal')
           .map((item) => (

--- a/src/renderer/src/components/tab-group/TabGroupSplitLayout.test.ts
+++ b/src/renderer/src/components/tab-group/TabGroupSplitLayout.test.ts
@@ -14,6 +14,20 @@ vi.mock('./TabGroupPanel', () => ({
   default: (props: unknown) => ({ __mock: 'TabGroupPanel', props })
 }))
 
+vi.mock('./useTabDragSplit', () => ({
+  useTabDragSplit: () => ({
+    activeDrag: null,
+    collisionDetection: vi.fn(),
+    hoveredDropTarget: null,
+    onDragCancel: vi.fn(),
+    onDragEnd: vi.fn(),
+    onDragMove: vi.fn(),
+    onDragOver: vi.fn(),
+    onDragStart: vi.fn(),
+    sensors: []
+  })
+}))
+
 import TabGroupSplitLayout from './TabGroupSplitLayout'
 
 describe('TabGroupSplitLayout', () => {
@@ -25,7 +39,7 @@ describe('TabGroupSplitLayout', () => {
       isWorktreeActive
     })
 
-    const splitNodeElement = element.props.children
+    const splitNodeElement = element.props.children.props.children
     const tabGroupPanelElement = splitNodeElement.type(splitNodeElement.props)
     return tabGroupPanelElement.props as {
       groupId: string
@@ -77,7 +91,7 @@ describe('TabGroupSplitLayout', () => {
       isWorktreeActive: true
     })
 
-    const splitNodeElement = element.props.children
+    const splitNodeElement = element.props.children.props.children
     const rootElement = splitNodeElement.type(splitNodeElement.props)
     const leftChild = rootElement.props.children[0].props.children
     const rightChild = rootElement.props.children[2].props.children

--- a/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
@@ -1,7 +1,9 @@
 import { useCallback, useState } from 'react'
+import { DndContext } from '@dnd-kit/core'
 import type { TabGroupLayoutNode } from '../../../../shared/types'
 import { useAppStore } from '../../store'
 import TabGroupPanel from './TabGroupPanel'
+import { type TabDropZone, useTabDragSplit } from './useTabDragSplit'
 
 const MIN_RATIO = 0.15
 const MAX_RATIO = 0.85
@@ -88,7 +90,10 @@ function SplitNode({
   hasSplitGroups,
   touchesTopEdge,
   touchesRightEdge,
-  touchesLeftEdge
+  touchesLeftEdge,
+  isTabDragActive,
+  activeDropGroupId,
+  activeDropZone
 }: {
   node: TabGroupLayoutNode
   nodePath: string
@@ -99,6 +104,9 @@ function SplitNode({
   touchesTopEdge: boolean
   touchesRightEdge: boolean
   touchesLeftEdge: boolean
+  isTabDragActive: boolean
+  activeDropGroupId: string | null
+  activeDropZone: TabDropZone | null
 }): React.JSX.Element {
   const setTabGroupSplitRatio = useAppStore((state) => state.setTabGroupSplitRatio)
 
@@ -115,6 +123,8 @@ function SplitNode({
         hasSplitGroups={hasSplitGroups}
         reserveClosedExplorerToggleSpace={touchesTopEdge && touchesRightEdge}
         reserveCollapsedSidebarHeaderSpace={touchesTopEdge && touchesLeftEdge}
+        isTabDragActive={isTabDragActive}
+        activeDropZone={activeDropGroupId === node.groupId ? activeDropZone : null}
       />
     )
   }
@@ -138,6 +148,9 @@ function SplitNode({
           touchesTopEdge={touchesTopEdge}
           touchesRightEdge={isHorizontal ? false : touchesRightEdge}
           touchesLeftEdge={touchesLeftEdge}
+          isTabDragActive={isTabDragActive}
+          activeDropGroupId={activeDropGroupId}
+          activeDropZone={activeDropZone}
         />
       </div>
       <ResizeHandle
@@ -155,6 +168,9 @@ function SplitNode({
           touchesTopEdge={isHorizontal ? touchesTopEdge : false}
           touchesRightEdge={touchesRightEdge}
           touchesLeftEdge={isHorizontal ? false : touchesLeftEdge}
+          isTabDragActive={isTabDragActive}
+          activeDropGroupId={activeDropGroupId}
+          activeDropZone={activeDropZone}
         />
       </div>
     </div>
@@ -172,19 +188,34 @@ export default function TabGroupSplitLayout({
   focusedGroupId?: string
   isWorktreeActive: boolean
 }): React.JSX.Element {
+  const dragSplit = useTabDragSplit({ worktreeId, enabled: isWorktreeActive })
+
   return (
-    <div className="flex flex-1 min-w-0 min-h-0 overflow-hidden">
-      <SplitNode
-        node={layout}
-        nodePath=""
-        worktreeId={worktreeId}
-        focusedGroupId={focusedGroupId}
-        isWorktreeActive={isWorktreeActive}
-        hasSplitGroups={layout.type === 'split'}
-        touchesTopEdge={true}
-        touchesRightEdge={true}
-        touchesLeftEdge={true}
-      />
-    </div>
+    <DndContext
+      sensors={dragSplit.sensors}
+      collisionDetection={dragSplit.collisionDetection}
+      onDragStart={dragSplit.onDragStart}
+      onDragMove={dragSplit.onDragMove}
+      onDragOver={dragSplit.onDragOver}
+      onDragEnd={dragSplit.onDragEnd}
+      onDragCancel={dragSplit.onDragCancel}
+    >
+      <div className="flex flex-1 min-w-0 min-h-0 overflow-hidden">
+        <SplitNode
+          node={layout}
+          nodePath=""
+          worktreeId={worktreeId}
+          focusedGroupId={focusedGroupId}
+          isWorktreeActive={isWorktreeActive}
+          hasSplitGroups={layout.type === 'split'}
+          touchesTopEdge={true}
+          touchesRightEdge={true}
+          touchesLeftEdge={true}
+          isTabDragActive={dragSplit.activeDrag !== null}
+          activeDropGroupId={dragSplit.hoveredDropTarget?.groupId ?? null}
+          activeDropZone={dragSplit.hoveredDropTarget?.zone ?? null}
+        />
+      </div>
+    </DndContext>
   )
 }

--- a/src/renderer/src/components/tab-group/useTabDragSplit.test.ts
+++ b/src/renderer/src/components/tab-group/useTabDragSplit.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import type { TabGroup } from '../../../../shared/types'
+import type { TabDragItemData } from './useTabDragSplit'
+import { canDropTabIntoPaneBody } from './useTabDragSplit'
+
+function makeGroup(id: string, tabOrder: string[]): TabGroup {
+  return {
+    id,
+    worktreeId: 'wt-1',
+    activeTabId: tabOrder[0] ?? null,
+    tabOrder
+  }
+}
+
+function makeDragData(groupId: string, unifiedTabId = 'tab-1'): TabDragItemData {
+  return {
+    kind: 'tab',
+    worktreeId: 'wt-1',
+    groupId,
+    unifiedTabId,
+    visibleTabId: unifiedTabId,
+    tabType: 'editor'
+  }
+}
+
+describe('canDropTabIntoPaneBody', () => {
+  it('rejects pane-body drops that would split a single tab onto itself', () => {
+    expect(
+      canDropTabIntoPaneBody({
+        activeDrag: makeDragData('group-1'),
+        groupsByWorktree: { 'wt-1': [makeGroup('group-1', ['tab-1'])] },
+        overGroupId: 'group-1',
+        worktreeId: 'wt-1'
+      })
+    ).toBe(false)
+  })
+
+  it('allows same-group pane-body drops when the group still has other tabs', () => {
+    expect(
+      canDropTabIntoPaneBody({
+        activeDrag: makeDragData('group-1'),
+        groupsByWorktree: { 'wt-1': [makeGroup('group-1', ['tab-1', 'tab-2'])] },
+        overGroupId: 'group-1',
+        worktreeId: 'wt-1'
+      })
+    ).toBe(true)
+  })
+
+  it('allows pane-body drops into a different group', () => {
+    expect(
+      canDropTabIntoPaneBody({
+        activeDrag: makeDragData('group-1'),
+        groupsByWorktree: {
+          'wt-1': [makeGroup('group-1', ['tab-1']), makeGroup('group-2', ['tab-2'])]
+        },
+        overGroupId: 'group-2',
+        worktreeId: 'wt-1'
+      })
+    ).toBe(true)
+  })
+})

--- a/src/renderer/src/components/tab-group/useTabDragSplit.ts
+++ b/src/renderer/src/components/tab-group/useTabDragSplit.ts
@@ -1,0 +1,362 @@
+import { useCallback, useMemo, useState } from 'react'
+import {
+  closestCenter,
+  pointerWithin,
+  PointerSensor,
+  type CollisionDetection,
+  type DragEndEvent,
+  type DragMoveEvent,
+  type DragOverEvent,
+  type DragStartEvent,
+  type UniqueIdentifier,
+  useSensor,
+  useSensors
+} from '@dnd-kit/core'
+import { arrayMove } from '@dnd-kit/sortable'
+import type { TabGroup } from '../../../../shared/types'
+import { useAppStore } from '../../store'
+import type { TabSplitDirection } from '../../store/slices/tabs'
+
+export type TabDropZone = 'center' | TabSplitDirection
+
+export type TabDragItemData = {
+  kind: 'tab'
+  worktreeId: string
+  groupId: string
+  unifiedTabId: string
+  visibleTabId: string
+  tabType: 'terminal' | 'editor' | 'browser'
+}
+
+export type TabPaneDropData = {
+  kind: 'pane-body'
+  worktreeId: string
+  groupId: string
+}
+
+export type HoveredTabDropTarget = {
+  groupId: string
+  zone: TabDropZone
+}
+
+export function canDropTabIntoPaneBody({
+  activeDrag,
+  groupsByWorktree,
+  overGroupId,
+  worktreeId
+}: {
+  activeDrag: TabDragItemData | null
+  groupsByWorktree: Record<string, TabGroup[]>
+  overGroupId: string
+  worktreeId: string
+}): boolean {
+  if (!activeDrag || activeDrag.worktreeId !== worktreeId) {
+    return false
+  }
+
+  const overGroup = (groupsByWorktree[worktreeId] ?? []).find((group) => group.id === overGroupId)
+  if (!overGroup) {
+    return false
+  }
+
+  // Why: splitting the only tab in a group onto that same group's body is a
+  // visual no-op. The store already rejects that drop, so the hover layer must
+  // suppress the pane overlay too or the user sees a split affordance that can
+  // never produce a layout change.
+  if (activeDrag.groupId === overGroupId && overGroup.tabOrder.length <= 1) {
+    return false
+  }
+
+  return true
+}
+
+function isTabDragData(value: unknown): value is TabDragItemData {
+  return Boolean(value) && typeof value === 'object' && (value as TabDragItemData).kind === 'tab'
+}
+
+function isPaneDropData(value: unknown): value is TabPaneDropData {
+  return (
+    Boolean(value) && typeof value === 'object' && (value as TabPaneDropData).kind === 'pane-body'
+  )
+}
+
+function getDragCenter(
+  event: Pick<DragMoveEvent, 'active' | 'delta'>
+): { x: number; y: number } | null {
+  const translated = event.active.rect.current.translated
+  if (translated) {
+    return {
+      x: translated.left + translated.width / 2,
+      y: translated.top + translated.height / 2
+    }
+  }
+
+  const initial = event.active.rect.current.initial
+  if (!initial) {
+    return null
+  }
+
+  return {
+    x: initial.left + initial.width / 2 + event.delta.x,
+    y: initial.top + initial.height / 2 + event.delta.y
+  }
+}
+
+function resolveDropZone(
+  rect: { left: number; top: number; width: number; height: number },
+  point: { x: number; y: number }
+): TabDropZone {
+  const localX = point.x - rect.left
+  const localY = point.y - rect.top
+  const edgeWidthThreshold = rect.width * 0.1
+  const edgeHeightThreshold = rect.height * 0.1
+  const splitWidthThreshold = rect.width / 3
+
+  // Why: VS Code keeps a center "merge" zone while biasing side-by-side drops
+  // toward left/right, which feels much more stable than a generic nearest-edge
+  // calculation once a workspace has nested splits.
+  if (
+    localX > edgeWidthThreshold &&
+    localX < rect.width - edgeWidthThreshold &&
+    localY > edgeHeightThreshold &&
+    localY < rect.height - edgeHeightThreshold
+  ) {
+    return 'center'
+  }
+
+  if (localX < splitWidthThreshold) {
+    return 'left'
+  }
+  if (localX > splitWidthThreshold * 2) {
+    return 'right'
+  }
+  return localY < rect.height / 2 ? 'up' : 'down'
+}
+
+const collisionDetection: CollisionDetection = (args) => {
+  const pointerCollisions = pointerWithin(args)
+  return pointerCollisions.length > 0 ? pointerCollisions : closestCenter(args)
+}
+
+export function getTabPaneBodyDroppableId(groupId: string): UniqueIdentifier {
+  return `tab-group-pane-body:${groupId}`
+}
+
+export function useTabDragSplit({
+  worktreeId,
+  enabled = true
+}: {
+  worktreeId: string
+  /** When false (e.g. for hidden worktrees), returns empty sensors so no
+   *  DndContext pointer listeners are registered on the document. Multiple
+   *  simultaneous DndContext instances with active sensors can interfere. */
+  enabled?: boolean
+}): {
+  activeDrag: TabDragItemData | null
+  collisionDetection: CollisionDetection
+  hoveredDropTarget: HoveredTabDropTarget | null
+  onDragCancel: () => void
+  onDragEnd: (event: DragEndEvent) => void
+  onDragMove: (event: DragMoveEvent) => void
+  onDragOver: (event: DragOverEvent) => void
+  onDragStart: (event: DragStartEvent) => void
+  sensors: ReturnType<typeof useSensors>
+} {
+  const reorderUnifiedTabs = useAppStore((state) => state.reorderUnifiedTabs)
+  const dropUnifiedTab = useAppStore((state) => state.dropUnifiedTab)
+  const [activeDrag, setActiveDrag] = useState<TabDragItemData | null>(null)
+  const [hoveredDropTarget, setHoveredDropTarget] = useState<HoveredTabDropTarget | null>(null)
+
+  const pointerSensor = useSensor(PointerSensor, {
+    activationConstraint: { distance: 5 }
+  })
+  const activeSensors = useSensors(pointerSensor)
+  const emptySensors = useSensors()
+  // Why: hidden worktrees stay mounted so their PTYs survive worktree
+  // switches, but their DndContext should not register pointer listeners
+  // on the document. Multiple active DndContext instances can interfere
+  // with each other.
+  const sensors = enabled ? activeSensors : emptySensors
+
+  const clearDragState = useCallback(() => {
+    setActiveDrag(null)
+    setHoveredDropTarget(null)
+  }, [])
+
+  const updateHoveredPane = useCallback((event: DragMoveEvent | DragOverEvent) => {
+    const overData = event.over?.data.current
+    if (!event.over || !isPaneDropData(overData)) {
+      // Why: using functional updater to avoid a new null reference when
+      // the state is already null — prevents unnecessary re-renders during
+      // high-frequency onDragMove events.
+      setHoveredDropTarget((prev) => (prev === null ? prev : null))
+      return
+    }
+
+    const activeData = event.active.data.current
+    if (
+      !isTabDragData(activeData) ||
+      !canDropTabIntoPaneBody({
+        activeDrag: activeData,
+        groupsByWorktree: useAppStore.getState().groupsByWorktree,
+        overGroupId: overData.groupId,
+        worktreeId
+      })
+    ) {
+      setHoveredDropTarget((prev) => (prev === null ? prev : null))
+      return
+    }
+
+    const center = getDragCenter(event)
+    if (!center) {
+      setHoveredDropTarget((prev) => (prev === null ? prev : null))
+      return
+    }
+
+    // Why: onDragMove fires at pointer-move frequency (~60 fps). Creating
+    // a new { groupId, zone } object every time would trigger a state
+    // update and full re-render of the SplitNode tree on every frame even
+    // when nothing meaningful changed. The functional updater lets us
+    // compare against the previous value and return the same reference
+    // when groupId and zone are unchanged.
+    setHoveredDropTarget((prev) => {
+      const zone = resolveDropZone(event.over!.rect, center)
+      if (prev?.groupId === overData.groupId && prev?.zone === zone) {
+        return prev
+      }
+      return { groupId: overData.groupId, zone }
+    })
+  }, [])
+
+  const onDragStart = useCallback(
+    (event: DragStartEvent) => {
+      const dragData = event.active.data.current
+      if (!isTabDragData(dragData) || dragData.worktreeId !== worktreeId) {
+        clearDragState()
+        return
+      }
+
+      setActiveDrag(dragData)
+    },
+    [clearDragState, worktreeId]
+  )
+
+  const onDragMove = useCallback(
+    (event: DragMoveEvent) => {
+      updateHoveredPane(event)
+    },
+    [updateHoveredPane]
+  )
+
+  const onDragOver = useCallback(
+    (event: DragOverEvent) => {
+      updateHoveredPane(event)
+    },
+    [updateHoveredPane]
+  )
+
+  const onDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const activeData = event.active.data.current
+      const overData = event.over?.data.current
+
+      if (!event.over || !isTabDragData(activeData) || activeData.worktreeId !== worktreeId) {
+        clearDragState()
+        return
+      }
+
+      if (isTabDragData(overData)) {
+        if (activeData.unifiedTabId === overData.unifiedTabId) {
+          clearDragState()
+          return
+        }
+
+        const state = useAppStore.getState()
+        const groups = state.groupsByWorktree[worktreeId] ?? []
+        const targetGroup = groups.find((group) => group.id === overData.groupId)
+        if (!targetGroup) {
+          clearDragState()
+          return
+        }
+
+        if (activeData.groupId === overData.groupId) {
+          const oldIndex = targetGroup.tabOrder.indexOf(activeData.unifiedTabId)
+          const newIndex = targetGroup.tabOrder.indexOf(overData.unifiedTabId)
+          if (oldIndex !== -1 && newIndex !== -1 && oldIndex !== newIndex) {
+            reorderUnifiedTabs(
+              overData.groupId,
+              arrayMove(targetGroup.tabOrder, oldIndex, newIndex)
+            )
+          }
+        } else {
+          const targetIndex = targetGroup.tabOrder.indexOf(overData.unifiedTabId)
+          dropUnifiedTab(activeData.unifiedTabId, {
+            groupId: overData.groupId,
+            index: targetIndex === -1 ? targetGroup.tabOrder.length : targetIndex
+          })
+        }
+
+        clearDragState()
+        return
+      }
+
+      if (isPaneDropData(overData)) {
+        if (
+          !canDropTabIntoPaneBody({
+            activeDrag: activeData,
+            groupsByWorktree: useAppStore.getState().groupsByWorktree,
+            overGroupId: overData.groupId,
+            worktreeId
+          })
+        ) {
+          clearDragState()
+          return
+        }
+
+        const center = getDragCenter(event)
+        if (center) {
+          const zone = resolveDropZone(event.over.rect, center)
+          dropUnifiedTab(activeData.unifiedTabId, {
+            groupId: overData.groupId,
+            splitDirection: zone === 'center' ? undefined : zone
+          })
+        }
+      }
+
+      clearDragState()
+    },
+    [clearDragState, dropUnifiedTab, reorderUnifiedTabs, worktreeId]
+  )
+
+  // Why: dnd-kit fires onDragCancel (not onDragEnd) when the user presses
+  // Escape or the drag is otherwise aborted. Without this handler the
+  // activeDrag and hoveredDropTarget state would remain stale, leaving the
+  // drop overlay visible indefinitely.
+  const onDragCancel = useCallback(() => {
+    clearDragState()
+  }, [clearDragState])
+
+  return useMemo(
+    () => ({
+      activeDrag,
+      collisionDetection,
+      hoveredDropTarget,
+      onDragCancel,
+      onDragEnd,
+      onDragMove,
+      onDragOver,
+      onDragStart,
+      sensors
+    }),
+    [
+      activeDrag,
+      hoveredDropTarget,
+      onDragCancel,
+      onDragEnd,
+      onDragMove,
+      onDragOver,
+      onDragStart,
+      sensors
+    ]
+  )
+}

--- a/src/renderer/src/components/tab-group/useTabDragSplit.ts
+++ b/src/renderer/src/components/tab-group/useTabDragSplit.ts
@@ -183,50 +183,53 @@ export function useTabDragSplit({
     setHoveredDropTarget(null)
   }, [])
 
-  const updateHoveredPane = useCallback((event: DragMoveEvent | DragOverEvent) => {
-    const overData = event.over?.data.current
-    if (!event.over || !isPaneDropData(overData)) {
-      // Why: using functional updater to avoid a new null reference when
-      // the state is already null — prevents unnecessary re-renders during
-      // high-frequency onDragMove events.
-      setHoveredDropTarget((prev) => (prev === null ? prev : null))
-      return
-    }
-
-    const activeData = event.active.data.current
-    if (
-      !isTabDragData(activeData) ||
-      !canDropTabIntoPaneBody({
-        activeDrag: activeData,
-        groupsByWorktree: useAppStore.getState().groupsByWorktree,
-        overGroupId: overData.groupId,
-        worktreeId
-      })
-    ) {
-      setHoveredDropTarget((prev) => (prev === null ? prev : null))
-      return
-    }
-
-    const center = getDragCenter(event)
-    if (!center) {
-      setHoveredDropTarget((prev) => (prev === null ? prev : null))
-      return
-    }
-
-    // Why: onDragMove fires at pointer-move frequency (~60 fps). Creating
-    // a new { groupId, zone } object every time would trigger a state
-    // update and full re-render of the SplitNode tree on every frame even
-    // when nothing meaningful changed. The functional updater lets us
-    // compare against the previous value and return the same reference
-    // when groupId and zone are unchanged.
-    setHoveredDropTarget((prev) => {
-      const zone = resolveDropZone(event.over!.rect, center)
-      if (prev?.groupId === overData.groupId && prev?.zone === zone) {
-        return prev
+  const updateHoveredPane = useCallback(
+    (event: DragMoveEvent | DragOverEvent) => {
+      const overData = event.over?.data.current
+      if (!event.over || !isPaneDropData(overData)) {
+        // Why: using functional updater to avoid a new null reference when
+        // the state is already null — prevents unnecessary re-renders during
+        // high-frequency onDragMove events.
+        setHoveredDropTarget((prev) => (prev === null ? prev : null))
+        return
       }
-      return { groupId: overData.groupId, zone }
-    })
-  }, [])
+
+      const activeData = event.active.data.current
+      if (
+        !isTabDragData(activeData) ||
+        !canDropTabIntoPaneBody({
+          activeDrag: activeData,
+          groupsByWorktree: useAppStore.getState().groupsByWorktree,
+          overGroupId: overData.groupId,
+          worktreeId
+        })
+      ) {
+        setHoveredDropTarget((prev) => (prev === null ? prev : null))
+        return
+      }
+
+      const center = getDragCenter(event)
+      if (!center) {
+        setHoveredDropTarget((prev) => (prev === null ? prev : null))
+        return
+      }
+
+      // Why: onDragMove fires at pointer-move frequency (~60 fps). Creating
+      // a new { groupId, zone } object every time would trigger a state
+      // update and full re-render of the SplitNode tree on every frame even
+      // when nothing meaningful changed. The functional updater lets us
+      // compare against the previous value and return the same reference
+      // when groupId and zone are unchanged.
+      setHoveredDropTarget((prev) => {
+        const zone = resolveDropZone(event.over!.rect, center)
+        if (prev?.groupId === overData.groupId && prev?.zone === zone) {
+          return prev
+        }
+        return { groupId: overData.groupId, zone }
+      })
+    },
+    [worktreeId]
+  )
 
   const onDragStart = useCallback(
     (event: DragStartEvent) => {
@@ -316,10 +319,18 @@ export function useTabDragSplit({
         const center = getDragCenter(event)
         if (center) {
           const zone = resolveDropZone(event.over.rect, center)
-          dropUnifiedTab(activeData.unifiedTabId, {
-            groupId: overData.groupId,
-            splitDirection: zone === 'center' ? undefined : zone
-          })
+          // Why: a center drop onto the tab's own pane body is a no-op in the
+          // store (non-split same-group drops are ignored), but
+          // canDropTabIntoPaneBody still allows it when the source group has
+          // >1 tab — so the overlay advertises "center" as a valid target.
+          // Skip the call in that case to avoid misleading the user via a
+          // drop that silently does nothing.
+          if (zone !== 'center' || activeData.groupId !== overData.groupId) {
+            dropUnifiedTab(activeData.unifiedTabId, {
+              groupId: overData.groupId,
+              splitDirection: zone === 'center' ? undefined : zone
+            })
+          }
         }
       }
 

--- a/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.ts
+++ b/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.ts
@@ -17,6 +17,7 @@ import { extractIpcErrorMessage } from '../../lib/ipc-error'
 import { destroyPersistentWebview } from '../browser-pane/BrowserPane'
 
 export type GroupEditorItem = OpenFile & { tabId: string }
+export type GroupBrowserItem = BrowserTabState & { tabId: string }
 
 const EMPTY_GROUPS: readonly TabGroup[] = []
 const EMPTY_UNIFIED_TABS: readonly Tab[] = []
@@ -25,6 +26,7 @@ const EMPTY_RUNTIME_TERMINAL_TABS: readonly TerminalTab[] = []
 
 type TerminalTabItem = {
   id: string
+  unifiedTabId: string
   ptyId: null
   worktreeId: string
   title: string
@@ -103,6 +105,7 @@ export function useTabGroupWorkspaceModel({
         .filter((item) => item.contentType === 'terminal')
         .map((item) => ({
           id: item.entityId,
+          unifiedTabId: item.id,
           ptyId: null,
           worktreeId,
           title: item.label,
@@ -131,15 +134,15 @@ export function useTabGroupWorkspaceModel({
     [groupTabs, worktreeState.openFiles]
   )
 
-  const browserItems = useMemo(
+  const browserItems = useMemo<GroupBrowserItem[]>(
     () =>
       groupTabs
         .filter((item) => item.contentType === 'browser')
         .map((item) => {
           const bt = worktreeState.browserTabs.find((candidate) => candidate.id === item.entityId)
-          return bt ?? null
+          return bt ? { ...bt, tabId: item.id } : null
         })
-        .filter((item): item is BrowserTabState => item !== null),
+        .filter((item): item is GroupBrowserItem => item !== null),
     [groupTabs, worktreeState.browserTabs]
   )
 

--- a/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.ts
+++ b/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.ts
@@ -68,7 +68,6 @@ export function useTabGroupWorkspaceModel({
   const closeUnifiedTab = useAppStore((state) => state.closeUnifiedTab)
   const closeOtherTabs = useAppStore((state) => state.closeOtherTabs)
   const closeTabsToRight = useAppStore((state) => state.closeTabsToRight)
-  const reorderUnifiedTabs = useAppStore((state) => state.reorderUnifiedTabs)
   const createEmptySplitGroup = useAppStore((state) => state.createEmptySplitGroup)
   const closeEmptyGroup = useAppStore((state) => state.closeEmptyGroup)
   const createTab = useAppStore((state) => state.createTab)
@@ -379,28 +378,6 @@ export function useTabGroupWorkspaceModel({
     }
   }, [closeItem, groupTabs])
 
-  const reorderTabBar = useCallback(
-    (order: string[]) => {
-      if (!group) {
-        return
-      }
-      const itemOrder = order
-        .map(
-          (visibleId) =>
-            groupTabs.find((item) =>
-              item.contentType === 'terminal' || item.contentType === 'browser'
-                ? item.entityId === visibleId
-                : item.id === visibleId
-            )?.id
-        )
-        .filter((value): value is string => Boolean(value))
-      const orderedIds = new Set(itemOrder)
-      const remainingIds = group.tabOrder.filter((itemId) => !orderedIds.has(itemId))
-      reorderUnifiedTabs(groupId, itemOrder.concat(remainingIds))
-    },
-    [group, groupId, groupTabs, reorderUnifiedTabs]
-  )
-
   const tabBarOrder = useMemo(
     () =>
       (group?.tabOrder ?? []).map((itemId) => {
@@ -467,7 +444,6 @@ export function useTabGroupWorkspaceModel({
         setActiveTabType('terminal')
       },
       pinFile,
-      reorderTabBar,
       setTabColor,
       setTabCustomTitle
     }

--- a/src/renderer/src/components/terminal/TerminalShell.tsx
+++ b/src/renderer/src/components/terminal/TerminalShell.tsx
@@ -28,7 +28,6 @@ type TerminalShellProps = {
   onCloseTab: (tabId: string) => void
   onCloseOthers: (tabId: string) => void
   onCloseTabsToRight: (tabId: string) => void
-  onReorderTabs: (worktreeId: string, tabIds: string[]) => void
   onNewTerminalTab: () => void
   onNewBrowserTab: () => void
   onNewFileTab?: () => void
@@ -65,7 +64,6 @@ export function TerminalShell({
   onCloseTab,
   onCloseOthers,
   onCloseTabsToRight,
-  onReorderTabs,
   onNewTerminalTab,
   onNewBrowserTab,
   onNewFileTab,
@@ -104,7 +102,6 @@ export function TerminalShell({
               onClose={onCloseTab}
               onCloseOthers={onCloseOthers}
               onCloseToRight={onCloseTabsToRight}
-              onReorder={onReorderTabs}
               onNewTerminalTab={onNewTerminalTab}
               onNewBrowserTab={onNewBrowserTab}
               onNewFileTab={onNewFileTab}

--- a/src/renderer/src/store/slices/tabs.test.ts
+++ b/src/renderer/src/store/slices/tabs.test.ts
@@ -393,6 +393,86 @@ describe('TabsSlice', () => {
       expect(state.groupsByWorktree[WT][0].tabOrder).toEqual([t1.id, 'file-b.ts'])
       expect(state.layoutByWorktree[WT]).toEqual({ type: 'leaf', groupId: sourceGroupId })
     })
+
+    it('drops a unified tab into another group and collapses an emptied source group', () => {
+      const tab = store.getState().createUnifiedTab(WT, 'editor', {
+        id: 'file-a.ts',
+        label: 'file-a.ts'
+      })
+      const sourceGroupId = store.getState().groupsByWorktree[WT][0].id
+      const targetGroupId = store.getState().createEmptySplitGroup(WT, sourceGroupId, 'right')
+      expect(targetGroupId).toBeTruthy()
+
+      const moved = store.getState().dropUnifiedTab(tab.id, { groupId: targetGroupId! })
+
+      expect(moved).toBe(true)
+      const state = store.getState()
+      expect(state.groupsByWorktree[WT]).toHaveLength(1)
+      expect(state.groupsByWorktree[WT][0].id).toBe(targetGroupId)
+      expect(state.groupsByWorktree[WT][0].tabOrder).toEqual([tab.id])
+      expect(state.layoutByWorktree[WT]).toEqual({ type: 'leaf', groupId: targetGroupId })
+      expect(state.activeGroupIdByWorktree[WT]).toBe(targetGroupId)
+    })
+
+    it('drops a unified tab onto a pane edge to create a sibling split', () => {
+      const first = store.getState().createUnifiedTab(WT, 'editor', {
+        id: 'file-a.ts',
+        label: 'file-a.ts'
+      })
+      const second = store.getState().createUnifiedTab(WT, 'editor', {
+        id: 'file-b.ts',
+        label: 'file-b.ts'
+      })
+      const sourceGroupId = store.getState().groupsByWorktree[WT][0].id
+
+      const moved = store.getState().dropUnifiedTab(second.id, {
+        groupId: sourceGroupId,
+        splitDirection: 'right'
+      })
+
+      expect(moved).toBe(true)
+      const state = store.getState()
+      expect(state.groupsByWorktree[WT]).toHaveLength(2)
+
+      const originGroup = state.groupsByWorktree[WT].find((group) => group.id === sourceGroupId)
+      expect(originGroup?.tabOrder).toEqual([first.id])
+
+      const movedTab = state.unifiedTabsByWorktree[WT].find((tab) => tab.id === second.id)
+      const newGroupId = movedTab?.groupId
+      expect(newGroupId).toBeTruthy()
+      expect(newGroupId).not.toBe(sourceGroupId)
+      expect(state.groupsByWorktree[WT].find((group) => group.id === newGroupId)?.tabOrder).toEqual(
+        [second.id]
+      )
+
+      const layout = state.layoutByWorktree[WT]
+      expect(layout.type).toBe('split')
+      if (layout.type !== 'split') {
+        throw new Error('expected split layout after edge drop')
+      }
+      expect(layout.direction).toBe('horizontal')
+      expect(layout.first).toEqual({ type: 'leaf', groupId: sourceGroupId })
+      expect(layout.second).toEqual({ type: 'leaf', groupId: newGroupId })
+    })
+
+    it('treats splitting the only tab onto its own pane body as a no-op', () => {
+      const onlyTab = store.getState().createUnifiedTab(WT, 'editor', {
+        id: 'file-a.ts',
+        label: 'file-a.ts'
+      })
+      const sourceGroupId = store.getState().groupsByWorktree[WT][0].id
+
+      const moved = store.getState().dropUnifiedTab(onlyTab.id, {
+        groupId: sourceGroupId,
+        splitDirection: 'down'
+      })
+
+      expect(moved).toBe(false)
+      const state = store.getState()
+      expect(state.groupsByWorktree[WT]).toHaveLength(1)
+      expect(state.groupsByWorktree[WT][0].tabOrder).toEqual([onlyTab.id])
+      expect(state.layoutByWorktree[WT]).toEqual({ type: 'leaf', groupId: sourceGroupId })
+    })
   })
 
   // ─── setTabLabel / setTabCustomLabel / setUnifiedTabColor ─────────

--- a/src/renderer/src/store/slices/tabs.ts
+++ b/src/renderer/src/store/slices/tabs.ts
@@ -77,6 +77,14 @@ export type TabsSlice = {
     targetGroupId: string,
     opts?: { index?: number; activate?: boolean }
   ) => boolean
+  dropUnifiedTab: (
+    tabId: string,
+    target: {
+      groupId: string
+      index?: number
+      splitDirection?: TabSplitDirection
+    }
+  ) => boolean
   copyUnifiedTabToGroup: (
     tabId: string,
     targetGroupId: string,
@@ -884,6 +892,153 @@ export const createTabsSlice: StateCreator<AppState, [], [], TabsSlice> = (set, 
           [worktreeId]: nextGroups
         },
         activeGroupIdByWorktree: nextActiveGroupIdByWorktree
+      }
+    })
+    return moved
+  },
+
+  dropUnifiedTab: (tabId, target) => {
+    let moved = false
+    set((state) => {
+      const foundTab = findTabAndWorktree(state.unifiedTabsByWorktree, tabId)
+      const foundTarget = findGroupAndWorktree(state.groupsByWorktree, target.groupId)
+      if (!foundTab || !foundTarget || foundTab.worktreeId !== foundTarget.worktreeId) {
+        return {}
+      }
+
+      const { tab, worktreeId } = foundTab
+      const sourceGroup = findGroupForTab(state.groupsByWorktree, worktreeId, tab.groupId)
+      const targetGroup = foundTarget.group
+      if (!sourceGroup) {
+        return {}
+      }
+
+      const isSplitDrop = Boolean(target.splitDirection)
+      if (!isSplitDrop && tab.groupId === target.groupId) {
+        return {}
+      }
+      if (isSplitDrop && tab.groupId === target.groupId && sourceGroup.tabOrder.length <= 1) {
+        // Why: dragging the final tab in a group onto that same group's edge
+        // would create a transient sibling only to collapse the source
+        // immediately, leaving the layout unchanged while still churning focus
+        // and group IDs. Treat that as a no-op instead of faking a split.
+        return {}
+      }
+
+      moved = true
+
+      let nextGroups = state.groupsByWorktree[worktreeId] ?? []
+      let nextLayoutByWorktree = state.layoutByWorktree
+      let nextActiveGroupIdByWorktree = state.activeGroupIdByWorktree
+      let resolvedTargetGroupId = target.groupId
+
+      if (target.splitDirection) {
+        const newGroupId = globalThis.crypto.randomUUID()
+        const newGroup: TabGroup = {
+          id: newGroupId,
+          worktreeId,
+          activeTabId: null, // Placeholder; properly set in the nextGroups.map() below
+          tabOrder: []
+        }
+        const currentLayout =
+          nextLayoutByWorktree[worktreeId] ?? ({ type: 'leaf', groupId: target.groupId } as const)
+        const replacement = buildSplitNode(
+          target.groupId,
+          newGroupId,
+          target.splitDirection === 'left' || target.splitDirection === 'right'
+            ? 'horizontal'
+            : 'vertical',
+          target.splitDirection === 'left' || target.splitDirection === 'up' ? 'first' : 'second'
+        )
+
+        resolvedTargetGroupId = newGroupId
+        nextGroups = [...nextGroups, newGroup]
+        nextLayoutByWorktree = {
+          ...nextLayoutByWorktree,
+          [worktreeId]: replaceLeaf(currentLayout, target.groupId, replacement)
+        }
+        nextActiveGroupIdByWorktree = {
+          ...nextActiveGroupIdByWorktree,
+          [worktreeId]: newGroupId
+        }
+      }
+
+      const sourceOrder = sourceGroup.tabOrder.filter((id) => id !== tabId)
+      const destinationGroup =
+        nextGroups.find((group) => group.id === resolvedTargetGroupId) ?? targetGroup
+      const targetOrder = [...destinationGroup.tabOrder]
+      const targetIndex = Math.max(
+        0,
+        Math.min(target.index ?? targetOrder.length, targetOrder.length)
+      )
+      targetOrder.splice(targetIndex, 0, tabId)
+
+      nextGroups = nextGroups.map((group) => {
+        if (group.id === sourceGroup.id) {
+          return {
+            ...group,
+            activeTabId:
+              group.activeTabId === tabId ? pickNeighbor(group.tabOrder, tabId) : group.activeTabId,
+            tabOrder: sourceOrder
+          }
+        }
+        if (group.id === resolvedTargetGroupId) {
+          return {
+            ...group,
+            activeTabId: tabId,
+            tabOrder: targetOrder
+          }
+        }
+        return group
+      })
+
+      if (sourceOrder.length === 0) {
+        nextGroups = nextGroups.filter((group) => group.id !== sourceGroup.id)
+        const collapsedState = collapseGroupLayout(
+          nextLayoutByWorktree,
+          nextActiveGroupIdByWorktree,
+          worktreeId,
+          sourceGroup.id,
+          resolvedTargetGroupId
+        )
+        nextLayoutByWorktree = collapsedState.layoutByWorktree
+        nextActiveGroupIdByWorktree = collapsedState.activeGroupIdByWorktree
+      } else {
+        nextActiveGroupIdByWorktree = {
+          ...nextActiveGroupIdByWorktree,
+          [worktreeId]: resolvedTargetGroupId
+        }
+      }
+
+      const nextUnifiedTabsByWorktree = {
+        ...state.unifiedTabsByWorktree,
+        [worktreeId]: (state.unifiedTabsByWorktree[worktreeId] ?? []).map((candidate) =>
+          candidate.id === tabId ? { ...candidate, groupId: resolvedTargetGroupId } : candidate
+        )
+      }
+      const nextGroupsByWorktree = {
+        ...state.groupsByWorktree,
+        [worktreeId]: nextGroups
+      }
+
+      return {
+        unifiedTabsByWorktree: nextUnifiedTabsByWorktree,
+        groupsByWorktree: nextGroupsByWorktree,
+        layoutByWorktree: nextLayoutByWorktree,
+        activeGroupIdByWorktree: nextActiveGroupIdByWorktree,
+        ...(state.activeWorktreeId === worktreeId
+          ? buildActiveSurfacePatch(
+              {
+                ...state,
+                unifiedTabsByWorktree: nextUnifiedTabsByWorktree,
+                groupsByWorktree: nextGroupsByWorktree,
+                layoutByWorktree: nextLayoutByWorktree,
+                activeGroupIdByWorktree: nextActiveGroupIdByWorktree
+              },
+              worktreeId,
+              resolvedTargetGroupId
+            )
+          : {})
       }
     })
     return moved


### PR DESCRIPTION
## Problem
Users could create split groups from header actions, but the tab strip itself could not drag tabs across groups or into new pane splits. That made tab management less direct, and the drag UI could still show a split affordance for a single-tab pane even when the store would reject the drop as a no-op.

## Solution
Move tab drag handling into the split-layout DnD context so tabs can be reordered within a group, dropped into another group, or dropped on a pane body to create a new split. Add pane-body overlays and shared drag metadata for terminal, editor, and browser tabs, wire the store with a `dropUnifiedTab` path that collapses emptied groups correctly, and suppress same-pane single-tab split drops in both the UI and store. Add focused tests for the new drag-drop behavior and the no-op guard.