### PR TITLE
feat: improve cookie import robustness and cross-platform support

### DIFF
--- a/src/main/browser/browser-cookie-import.ts
+++ b/src/main/browser/browser-cookie-import.ts
@@ -1,18 +1,20 @@
 /* eslint-disable max-lines -- Why: cookie import is a single pipeline (detect → decrypt → stage → swap)
    that must stay together so the encryption, schema, and staging steps remain in sync. */
 import { app, type BrowserWindow, dialog, session } from 'electron'
-import { execFileSync, execSync } from 'node:child_process'
+import { execFileSync } from 'node:child_process'
 import { createDecipheriv, pbkdf2Sync } from 'node:crypto'
 import {
   appendFileSync,
   copyFileSync,
   existsSync,
   mkdtempSync,
+  readFileSync,
+  readdirSync,
   rmSync,
-  unlinkSync,
-  writeFileSync
+  unlinkSync
 } from 'node:fs'
 import { readFile } from 'node:fs/promises'
+import { DatabaseSync } from 'node:sqlite'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -49,62 +51,329 @@ import { browserSessionRegistry } from './browser-session-registry'
 // Browser detection
 // ---------------------------------------------------------------------------
 
+export type BrowserProfile = {
+  name: string
+  directory: string
+}
+
 export type DetectedBrowser = {
   family: BrowserSessionProfileSource['browserFamily']
   label: string
   cookiesPath: string
-  keychainService: string
-  keychainAccount: string
+  keychainService?: string
+  keychainAccount?: string
+  profiles: BrowserProfile[]
+  selectedProfile: string
 }
 
-const CHROMIUM_BROWSERS: Omit<DetectedBrowser, 'cookiesPath'>[] = [
+type ChromiumBrowserDef = {
+  family: BrowserSessionProfileSource['browserFamily']
+  label: string
+  keychainService: string
+  keychainAccount: string
+  // Why: each platform stores browser data in a different location. The per-platform
+  // root paths are resolved at detection time via browserRootPath().
+  macRoot?: string
+  winRoot?: string
+  linuxRoot?: string
+}
+
+const CHROMIUM_BROWSERS: ChromiumBrowserDef[] = [
   {
     family: 'chrome',
     label: 'Google Chrome',
     keychainService: 'Chrome Safe Storage',
-    keychainAccount: 'Chrome'
+    keychainAccount: 'Chrome',
+    macRoot: 'Google/Chrome',
+    winRoot: 'Google/Chrome/User Data',
+    linuxRoot: 'google-chrome'
   },
   {
     family: 'edge',
     label: 'Microsoft Edge',
     keychainService: 'Microsoft Edge Safe Storage',
-    keychainAccount: 'Microsoft Edge'
+    keychainAccount: 'Microsoft Edge',
+    macRoot: 'Microsoft Edge',
+    winRoot: 'Microsoft/Edge/User Data',
+    linuxRoot: 'microsoft-edge'
   },
   {
     family: 'arc',
     label: 'Arc',
     keychainService: 'Arc Safe Storage',
-    keychainAccount: 'Arc'
+    keychainAccount: 'Arc',
+    macRoot: 'Arc/User Data'
   },
   {
     family: 'chromium',
     label: 'Brave',
     keychainService: 'Brave Safe Storage',
-    keychainAccount: 'Brave'
+    keychainAccount: 'Brave',
+    macRoot: 'BraveSoftware/Brave-Browser',
+    winRoot: 'BraveSoftware/Brave-Browser/User Data',
+    linuxRoot: 'BraveSoftware/Brave-Browser'
   }
 ]
 
-function cookiesPathForBrowser(family: BrowserSessionProfileSource['browserFamily']): string {
-  const home = process.env.HOME ?? ''
-  switch (family) {
-    case 'chrome':
-      return join(home, 'Library/Application Support/Google/Chrome/Default/Cookies')
-    case 'edge':
-      return join(home, 'Library/Application Support/Microsoft Edge/Default/Cookies')
-    case 'arc':
-      return join(home, 'Library/Application Support/Arc/User Data/Default/Cookies')
-    case 'chromium':
-      return join(home, 'Library/Application Support/BraveSoftware/Brave-Browser/Default/Cookies')
-    default:
-      return ''
+function browserRootPath(def: ChromiumBrowserDef): string | null {
+  if (process.platform === 'darwin') {
+    if (!def.macRoot) {
+      return null
+    }
+    const home = process.env.HOME ?? ''
+    return join(home, 'Library', 'Application Support', def.macRoot)
+  }
+  if (process.platform === 'win32') {
+    if (!def.winRoot) {
+      return null
+    }
+    const localAppData = process.env.LOCALAPPDATA ?? ''
+    if (!localAppData) {
+      return null
+    }
+    return join(localAppData, def.winRoot)
+  }
+  // Linux
+  if (!def.linuxRoot) {
+    return null
+  }
+  const configHome = process.env.XDG_CONFIG_HOME ?? join(process.env.HOME ?? '', '.config')
+  return join(configHome, def.linuxRoot)
+}
+
+// Why: Chromium 96+ moved the cookies DB from <Profile>/Cookies to
+// <Profile>/Network/Cookies. Try the newer path first, fall back to legacy.
+function resolveCookiesPath(profileDir: string): string | null {
+  const networkPath = join(profileDir, 'Network', 'Cookies')
+  if (existsSync(networkPath)) {
+    return networkPath
+  }
+  const legacyPath = join(profileDir, 'Cookies')
+  if (existsSync(legacyPath)) {
+    return legacyPath
+  }
+  return null
+}
+
+// Why: Chrome's Local State JSON contains profile.info_cache which maps profile
+// directory names (e.g. "Default", "Profile 1") to metadata including the
+// user-visible display name. This lets us show human-readable names in the picker.
+function discoverProfiles(browserRoot: string): BrowserProfile[] {
+  try {
+    const localStatePath = join(browserRoot, 'Local State')
+    if (!existsSync(localStatePath)) {
+      return [{ name: 'Default', directory: 'Default' }]
+    }
+    const raw = readFileSync(localStatePath, 'utf-8')
+    const localState = JSON.parse(raw)
+    const infoCache = localState?.profile?.info_cache
+    if (!infoCache || typeof infoCache !== 'object') {
+      return [{ name: 'Default', directory: 'Default' }]
+    }
+    const profiles: BrowserProfile[] = []
+    for (const [dir, info] of Object.entries(infoCache)) {
+      const profileName = (info as { name?: string })?.name ?? dir
+      profiles.push({ name: profileName, directory: dir })
+    }
+    return profiles.length > 0 ? profiles : [{ name: 'Default', directory: 'Default' }]
+  } catch {
+    return [{ name: 'Default', directory: 'Default' }]
   }
 }
 
+// ---------------------------------------------------------------------------
+// Firefox detection
+// ---------------------------------------------------------------------------
+
+function firefoxProfilesRoot(): string | null {
+  if (process.platform === 'darwin') {
+    const home = process.env.HOME ?? ''
+    return join(home, 'Library', 'Application Support', 'Firefox', 'Profiles')
+  }
+  if (process.platform === 'win32') {
+    const appData = process.env.APPDATA ?? ''
+    return appData ? join(appData, 'Mozilla', 'Firefox', 'Profiles') : null
+  }
+  const home = process.env.HOME ?? ''
+  return join(home, '.mozilla', 'firefox')
+}
+
+function discoverFirefoxProfiles(): BrowserProfile[] {
+  const profilesRoot = firefoxProfilesRoot()
+  if (!profilesRoot) {
+    return []
+  }
+  try {
+    if (!existsSync(profilesRoot)) {
+      return []
+    }
+    const entries = readdirSync(profilesRoot, { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name)
+    // Why: Firefox profile dirs are named <random>.<name> (e.g. "abc123.default-release").
+    // Prefer 'default-release' as it's the primary user profile on most installs.
+    const sorted = entries.sort((a, b) => {
+      if (a.includes('default-release')) {
+        return -1
+      }
+      if (b.includes('default-release')) {
+        return 1
+      }
+      if (a.includes('default')) {
+        return -1
+      }
+      if (b.includes('default')) {
+        return 1
+      }
+      return 0
+    })
+    return sorted.map((dir) => {
+      const label = dir.includes('.') ? dir.split('.').slice(1).join('.') : dir
+      return { name: label, directory: dir }
+    })
+  } catch {
+    return []
+  }
+}
+
+function detectFirefox(): DetectedBrowser | null {
+  const profilesRoot = firefoxProfilesRoot()
+  if (!profilesRoot) {
+    return null
+  }
+  const profiles = discoverFirefoxProfiles()
+  for (const profile of profiles) {
+    const cookiesPath = join(profilesRoot, profile.directory, 'cookies.sqlite')
+    if (existsSync(cookiesPath)) {
+      return {
+        family: 'firefox',
+        label: 'Firefox',
+        cookiesPath,
+        profiles,
+        selectedProfile: profile.directory
+      }
+    }
+  }
+  return null
+}
+
+// ---------------------------------------------------------------------------
+// Safari detection
+// ---------------------------------------------------------------------------
+
+const MAC_EPOCH_DELTA = 978_307_200
+
+function detectSafari(): DetectedBrowser | null {
+  if (process.platform !== 'darwin') {
+    return null
+  }
+  const home = process.env.HOME ?? ''
+  const candidates = [
+    join(home, 'Library', 'Cookies', 'Cookies.binarycookies'),
+    join(
+      home,
+      'Library',
+      'Containers',
+      'com.apple.Safari',
+      'Data',
+      'Library',
+      'Cookies',
+      'Cookies.binarycookies'
+    )
+  ]
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) {
+      return {
+        family: 'safari',
+        label: 'Safari',
+        cookiesPath: candidate,
+        profiles: [{ name: 'Default', directory: 'Default' }],
+        selectedProfile: 'Default'
+      }
+    }
+  }
+  return null
+}
+
 export function detectInstalledBrowsers(): DetectedBrowser[] {
-  return CHROMIUM_BROWSERS.map((browser) => ({
+  const detected: DetectedBrowser[] = []
+  for (const browser of CHROMIUM_BROWSERS) {
+    const root = browserRootPath(browser)
+    if (!root) {
+      continue
+    }
+    const profiles = discoverProfiles(root)
+    // Why: a browser is "detected" if at least one profile has a cookies DB.
+    // Use the first profile with a valid cookies path as the default selection.
+    for (const profile of profiles) {
+      const profileDir = join(root, profile.directory)
+      const cookiesPath = resolveCookiesPath(profileDir)
+      if (cookiesPath) {
+        detected.push({
+          family: browser.family,
+          label: browser.label,
+          keychainService: browser.keychainService,
+          keychainAccount: browser.keychainAccount,
+          cookiesPath,
+          profiles,
+          selectedProfile: profile.directory
+        })
+        break
+      }
+    }
+  }
+
+  const firefox = detectFirefox()
+  if (firefox) {
+    detected.push(firefox)
+  }
+
+  const safari = detectSafari()
+  if (safari) {
+    detected.push(safari)
+  }
+
+  return detected
+}
+
+// Why: when the user selects a different profile from the picker, we need to
+// resolve the cookies path for that profile. Returns a new DetectedBrowser
+// with the updated cookiesPath and selectedProfile, or null if the profile
+// has no cookies DB.
+export function selectBrowserProfile(
+  browser: DetectedBrowser,
+  profileDirectory: string
+): DetectedBrowser | null {
+  if (browser.family === 'firefox') {
+    const profilesRoot = firefoxProfilesRoot()
+    if (!profilesRoot) {
+      return null
+    }
+    const cookiesPath = join(profilesRoot, profileDirectory, 'cookies.sqlite')
+    if (!existsSync(cookiesPath)) {
+      return null
+    }
+    return { ...browser, cookiesPath, selectedProfile: profileDirectory }
+  }
+
+  const browserDef = CHROMIUM_BROWSERS.find((b) => b.family === browser.family)
+  if (!browserDef) {
+    return null
+  }
+  const root = browserRootPath(browserDef)
+  if (!root) {
+    return null
+  }
+  const profileDir = join(root, profileDirectory)
+  const cookiesPath = resolveCookiesPath(profileDir)
+  if (!cookiesPath) {
+    return null
+  }
+  return {
     ...browser,
-    cookiesPath: cookiesPathForBrowser(browser.family)
-  })).filter((browser) => existsSync(browser.cookiesPath))
+    cookiesPath,
+    selectedProfile: profileDirectory
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -371,6 +640,12 @@ export async function importCookiesFromFile(
 function getUserAgentForBrowser(
   family: BrowserSessionProfileSource['browserFamily']
 ): string | null {
+  // Why: UA spoofing uses macOS-specific plist reading. On other platforms,
+  // skip UA override — the default Electron UA is acceptable.
+  if (process.platform !== 'darwin') {
+    return null
+  }
+
   const platform = 'Macintosh; Intel Mac OS X 10_15_7'
   const chromeBase = 'AppleWebKit/537.36 (KHTML, like Gecko)'
 
@@ -418,12 +693,15 @@ const PBKDF2_SALT = 'saltysalt'
 
 const CHROMIUM_EPOCH_OFFSET = 11644473600n
 
-function chromiumTimestampToUnix(chromiumTs: string): number {
-  if (!chromiumTs || chromiumTs === '0') {
+function chromiumTimestampToUnix(chromiumTs: bigint | number | string): number {
+  if (!chromiumTs || chromiumTs === 0n || chromiumTs === 0 || chromiumTs === '0') {
     return 0
   }
   try {
-    const ts = BigInt(chromiumTs)
+    const ts =
+      typeof chromiumTs === 'bigint'
+        ? chromiumTs
+        : BigInt(typeof chromiumTs === 'number' ? Math.round(chromiumTs) : chromiumTs)
     if (ts === 0n) {
       return 0
     }
@@ -433,17 +711,139 @@ function chromiumTimestampToUnix(chromiumTs: string): number {
   }
 }
 
-function getEncryptionKey(keychainService: string, keychainAccount: string): Buffer | null {
+// Why: each platform uses a different mechanism to protect the Chromium cookie encryption key.
+// macOS: PBKDF2(keychain password, "saltysalt", 1003 iterations) → AES-128-CBC
+// Linux: PBKDF2(keyring password or "peanuts", "saltysalt", 1 iteration) → AES-128-CBC
+// Windows: DPAPI-encrypted master key from Local State → AES-256-GCM
+
+type EncryptionKeyResult = {
+  key: Buffer
+  mode: 'aes-128-cbc' | 'aes-256-gcm'
+  // Why: Linux v10 cookies use a hardcoded "peanuts" password while v11 uses the
+  // keyring password. We need both keys to decrypt the full cookie set.
+  fallbackKey?: Buffer
+}
+
+function getEncryptionKey(
+  keychainService: string,
+  keychainAccount: string,
+  browser?: DetectedBrowser
+): EncryptionKeyResult | null {
+  if (process.platform === 'darwin') {
+    return getMacEncryptionKey(keychainService, keychainAccount)
+  }
+  if (process.platform === 'linux') {
+    return getLinuxEncryptionKey(keychainService, keychainAccount)
+  }
+  if (process.platform === 'win32' && browser) {
+    return getWindowsEncryptionKey(browser)
+  }
+  return null
+}
+
+function getMacEncryptionKey(
+  keychainService: string,
+  keychainAccount: string
+): EncryptionKeyResult | null {
   try {
-    // Why: execFileSync bypasses shell interpretation, preventing command
-    // injection if keychainService/keychainAccount ever come from user input.
     const raw = execFileSync(
       'security',
       ['find-generic-password', '-s', keychainService, '-a', keychainAccount, '-w'],
       { encoding: 'utf-8', timeout: 30_000 }
     ).trim()
-    return pbkdf2Sync(raw, PBKDF2_SALT, PBKDF2_ITERATIONS, PBKDF2_KEY_LENGTH, 'sha1')
+    return {
+      key: pbkdf2Sync(raw, PBKDF2_SALT, PBKDF2_ITERATIONS, PBKDF2_KEY_LENGTH, 'sha1'),
+      mode: 'aes-128-cbc'
+    }
   } catch {
+    return null
+  }
+}
+
+function getLinuxEncryptionKey(
+  keychainService: string,
+  keychainAccount: string
+): EncryptionKeyResult | null {
+  // Why: Linux v10 cookies use the hardcoded password "peanuts" with 1 PBKDF2
+  // iteration. v11 cookies use the actual keyring password. We derive both keys
+  // so the decrypt function can try each based on the version prefix.
+  const v10Key = pbkdf2Sync('peanuts', PBKDF2_SALT, 1, PBKDF2_KEY_LENGTH, 'sha1')
+
+  let keyringPassword = ''
+  try {
+    // Why: GNOME keyring stores the Chrome Safe Storage password via secret-tool.
+    keyringPassword = execFileSync(
+      'secret-tool',
+      ['lookup', 'service', keychainService, 'account', keychainAccount],
+      { encoding: 'utf-8', timeout: 5_000 }
+    ).trim()
+  } catch {
+    // Why: fall back to application-based lookup used by newer Chromium versions.
+    try {
+      const app = keychainAccount.toLowerCase().replace(' ', '')
+      keyringPassword = execFileSync('secret-tool', ['lookup', 'application', app], {
+        encoding: 'utf-8',
+        timeout: 5_000
+      }).trim()
+    } catch {
+      diag('  Linux keyring unavailable — v11 cookies may fail to decrypt')
+    }
+  }
+
+  const v11Key = pbkdf2Sync(keyringPassword, PBKDF2_SALT, 1, PBKDF2_KEY_LENGTH, 'sha1')
+  return { key: v11Key, mode: 'aes-128-cbc', fallbackKey: v10Key }
+}
+
+function getWindowsEncryptionKey(browser: DetectedBrowser): EncryptionKeyResult | null {
+  const browserDef = CHROMIUM_BROWSERS.find((b) => b.family === browser.family)
+  if (!browserDef) {
+    return null
+  }
+  const root = browserRootPath(browserDef)
+  if (!root) {
+    return null
+  }
+
+  const localStatePath = join(root, 'Local State')
+  if (!existsSync(localStatePath)) {
+    return null
+  }
+
+  try {
+    const raw = readFileSync(localStatePath, 'utf-8')
+    const localState = JSON.parse(raw)
+    const encryptedKeyB64 = localState?.os_crypt?.encrypted_key
+    if (typeof encryptedKeyB64 !== 'string') {
+      return null
+    }
+
+    const encryptedKey = Buffer.from(encryptedKeyB64, 'base64')
+    const dpapiPrefix = Buffer.from('DPAPI', 'utf-8')
+    if (!encryptedKey.subarray(0, dpapiPrefix.length).equals(dpapiPrefix)) {
+      return null
+    }
+
+    // Why: PowerShell DPAPI decrypt is the only way to access the master key
+    // without native addons. The key is passed via stdin to prevent injection.
+    const dpapiData = encryptedKey.subarray(dpapiPrefix.length).toString('base64')
+    const script = [
+      'try { Add-Type -AssemblyName System.Security.Cryptography.ProtectedData -ErrorAction Stop }',
+      'catch { try { Add-Type -AssemblyName System.Security -ErrorAction Stop } catch {} };',
+      '$in=[Convert]::FromBase64String([Console]::In.ReadLine());',
+      '$out=[System.Security.Cryptography.ProtectedData]::Unprotect($in,$null,',
+      '[System.Security.Cryptography.DataProtectionScope]::CurrentUser);',
+      '[Convert]::ToBase64String($out)'
+    ].join('')
+
+    const result = execFileSync(
+      'powershell',
+      ['-NoProfile', '-NonInteractive', '-Command', script],
+      { encoding: 'utf-8', timeout: 10_000, input: dpapiData }
+    ).trim()
+
+    return { key: Buffer.from(result, 'base64'), mode: 'aes-256-gcm' }
+  } catch (err) {
+    diag(`  Windows DPAPI key extraction failed: ${err}`)
     return null
   }
 }
@@ -469,27 +869,351 @@ function hasHmacPrefix(buf: Buffer): boolean {
   return nonPrintable >= 8
 }
 
-function decryptCookieValueRaw(encryptedBuffer: Buffer, key: Buffer): Buffer | null {
+function stripHmac(buf: Buffer): Buffer {
+  return hasHmacPrefix(buf) ? buf.subarray(CHROMIUM_COOKIE_HMAC_LEN) : buf
+}
+
+function decryptCookieValueRaw(
+  encryptedBuffer: Buffer,
+  keyResult: EncryptionKeyResult
+): Buffer | null {
   if (!encryptedBuffer || encryptedBuffer.length === 0) {
     return null
   }
   const version = encryptedBuffer.subarray(0, 3).toString('utf-8')
-  if (version !== 'v10' && version !== 'v11') {
-    // Why: unknown encryption version — skip rather than importing raw
-    // encrypted bytes as the cookie value.
+  if (!/^v\d\d$/.test(version)) {
     return null
   }
-  const iv = Buffer.alloc(16, ' ')
+
+  if (keyResult.mode === 'aes-256-gcm') {
+    return decryptAes256Gcm(encryptedBuffer.subarray(3), keyResult.key)
+  }
+
+  // AES-128-CBC (macOS and Linux)
   const ciphertext = encryptedBuffer.subarray(3)
+  if (!ciphertext.length) {
+    return Buffer.alloc(0)
+  }
+
+  // Why: Linux v10 uses "peanuts" key, v11 uses keyring key. Try the primary
+  // key first, then fallback. macOS uses the same key for both versions.
+  const keysToTry =
+    version === 'v10' && keyResult.fallbackKey
+      ? [keyResult.fallbackKey, keyResult.key]
+      : [keyResult.key, ...(keyResult.fallbackKey ? [keyResult.fallbackKey] : [])]
+
+  for (const key of keysToTry) {
+    try {
+      const iv = Buffer.alloc(16, ' ')
+      const decipher = createDecipheriv('aes-128-cbc', key, iv)
+      decipher.setAutoPadding(true)
+      const decrypted = Buffer.concat([decipher.update(ciphertext), decipher.final()])
+      return stripHmac(decrypted)
+    } catch {
+      continue
+    }
+  }
+  return null
+}
+
+function decryptAes256Gcm(payload: Buffer, key: Buffer): Buffer | null {
+  // Why: Windows AES-256-GCM layout is: [12-byte nonce][ciphertext][16-byte auth tag]
+  if (payload.length < 12 + 16) {
+    return null
+  }
+  const nonce = payload.subarray(0, 12)
+  const authTag = payload.subarray(-16)
+  const ciphertext = payload.subarray(12, -16)
   try {
-    const decipher = createDecipheriv('aes-128-cbc', key, iv)
-    decipher.setAutoPadding(true)
+    const decipher = createDecipheriv('aes-256-gcm', key, nonce)
+    decipher.setAuthTag(authTag)
     const decrypted = Buffer.concat([decipher.update(ciphertext), decipher.final()])
-    return hasHmacPrefix(decrypted) ? decrypted.subarray(CHROMIUM_COOKIE_HMAC_LEN) : decrypted
+    return stripHmac(decrypted)
   } catch {
     return null
   }
 }
+
+// ---------------------------------------------------------------------------
+// Safari binary cookie parser
+// ---------------------------------------------------------------------------
+
+function decodeSafariBinaryCookies(buffer: Buffer): ValidatedCookie[] {
+  if (buffer.length < 8) {
+    return []
+  }
+  if (buffer.subarray(0, 4).toString('utf8') !== 'cook') {
+    return []
+  }
+
+  const pageCount = buffer.readUInt32BE(4)
+  let cursor = 8
+  const pageSizes: number[] = []
+  for (let i = 0; i < pageCount; i++) {
+    pageSizes.push(buffer.readUInt32BE(cursor))
+    cursor += 4
+  }
+
+  const cookies: ValidatedCookie[] = []
+  for (const pageSize of pageSizes) {
+    const page = buffer.subarray(cursor, cursor + pageSize)
+    cursor += pageSize
+    cookies.push(...decodeSafariPage(page))
+  }
+  return cookies
+}
+
+function decodeSafariPage(page: Buffer): ValidatedCookie[] {
+  if (page.length < 16) {
+    return []
+  }
+  if (page.readUInt32BE(0) !== 0x00000100) {
+    return []
+  }
+
+  const cookieCount = page.readUInt32LE(4)
+  const offsets: number[] = []
+  let cursor = 8
+  for (let i = 0; i < cookieCount; i++) {
+    offsets.push(page.readUInt32LE(cursor))
+    cursor += 4
+  }
+
+  const cookies: ValidatedCookie[] = []
+  for (const offset of offsets) {
+    const cookie = decodeSafariCookie(page.subarray(offset))
+    if (cookie) {
+      cookies.push(cookie)
+    }
+  }
+  return cookies
+}
+
+function decodeSafariCookie(buf: Buffer): ValidatedCookie | null {
+  if (buf.length < 48) {
+    return null
+  }
+  const size = buf.readUInt32LE(0)
+  if (size < 48 || size > buf.length) {
+    return null
+  }
+
+  const flags = buf.readUInt32LE(8)
+  const secure = (flags & 1) !== 0
+  const httpOnly = (flags & 4) !== 0
+
+  const urlOffset = buf.readUInt32LE(16)
+  const nameOffset = buf.readUInt32LE(20)
+  const pathOffset = buf.readUInt32LE(24)
+  const valueOffset = buf.readUInt32LE(28)
+
+  // Why: Safari stores dates as Mac absolute time (seconds since 2001-01-01).
+  const expiration = buf.length >= 48 ? buf.readDoubleLE(40) : 0
+
+  const name = readCString(buf, nameOffset, size)
+  if (!name) {
+    return null
+  }
+  const value = readCString(buf, valueOffset, size) ?? ''
+  const path = readCString(buf, pathOffset, size) ?? '/'
+  const rawUrl = readCString(buf, urlOffset, size) ?? ''
+
+  // Why: Safari stores the domain in the URL field, not as a separate domain column.
+  const domain = rawUrl.startsWith('.') ? rawUrl : rawUrl || null
+  if (!domain) {
+    return null
+  }
+
+  const url = deriveUrl(domain, secure)
+  if (!url) {
+    return null
+  }
+
+  const expirationDate = expiration > 0 ? Math.round(expiration + MAC_EPOCH_DELTA) : undefined
+
+  return {
+    url,
+    name,
+    value,
+    domain,
+    path,
+    secure,
+    httpOnly,
+    sameSite: 'unspecified',
+    expirationDate
+  }
+}
+
+function readCString(buf: Buffer, offset: number, end: number): string | null {
+  if (offset <= 0 || offset >= end) {
+    return null
+  }
+  let cursor = offset
+  while (cursor < end && buf[cursor] !== 0) {
+    cursor++
+  }
+  if (cursor >= end) {
+    return null
+  }
+  return buf.toString('utf8', offset, cursor)
+}
+
+// ---------------------------------------------------------------------------
+// Firefox import
+// ---------------------------------------------------------------------------
+
+async function importCookiesFromFirefox(
+  browser: DetectedBrowser,
+  targetPartition: string
+): Promise<BrowserCookieImportResult> {
+  diag(`importCookiesFromFirefox: partition="${targetPartition}"`)
+
+  const tmpDir = mkdtempSync(join(tmpdir(), 'orca-cookie-import-'))
+  const tmpCookiesPath = join(tmpDir, 'cookies.sqlite')
+
+  try {
+    copyFileSync(browser.cookiesPath, tmpCookiesPath)
+    for (const suffix of ['-wal', '-shm'] as const) {
+      const sidecar = browser.cookiesPath + suffix
+      if (existsSync(sidecar)) {
+        try {
+          copyFileSync(sidecar, tmpCookiesPath + suffix)
+        } catch {
+          /* best-effort */
+        }
+      }
+    }
+  } catch {
+    rmSync(tmpDir, { recursive: true, force: true })
+    return {
+      ok: false,
+      reason: 'Could not copy Firefox cookies database. Try closing Firefox first.'
+    }
+  }
+
+  try {
+    const db = new DatabaseSync(tmpCookiesPath, { readOnly: true })
+    type FirefoxRow = {
+      name: string
+      value: string
+      host: string
+      path: string
+      expiry: number
+      isSecure: number
+      isHttpOnly: number
+      sameSite: number
+    }
+    const rows = db
+      .prepare(
+        'SELECT name, value, host, path, expiry, isSecure, isHttpOnly, sameSite FROM moz_cookies'
+      )
+      .all() as FirefoxRow[]
+    db.close()
+
+    diag(`  Firefox source has ${rows.length} cookies`)
+    if (rows.length === 0) {
+      rmSync(tmpDir, { recursive: true, force: true })
+      return { ok: false, reason: 'No cookies found in Firefox.' }
+    }
+
+    const now = Math.floor(Date.now() / 1000)
+    const validated: ValidatedCookie[] = []
+    for (const row of rows) {
+      if (!row.name || !row.host) {
+        continue
+      }
+      if (row.expiry > 0 && row.expiry < now) {
+        continue
+      }
+
+      const domain = row.host
+      const secure = row.isSecure === 1
+      const url = deriveUrl(domain, secure)
+      if (!url) {
+        continue
+      }
+
+      validated.push({
+        url,
+        name: row.name,
+        value: row.value ?? '',
+        domain,
+        path: row.path || '/',
+        secure,
+        httpOnly: row.isHttpOnly === 1,
+        sameSite: normalizeSameSite(row.sameSite),
+        expirationDate: row.expiry > 0 ? row.expiry : undefined
+      })
+    }
+
+    rmSync(tmpDir, { recursive: true, force: true })
+
+    if (validated.length === 0) {
+      return { ok: false, reason: 'No valid cookies found in Firefox.' }
+    }
+
+    return importValidatedCookies(validated, rows.length, targetPartition)
+  } catch (err) {
+    rmSync(tmpDir, { recursive: true, force: true })
+    diag(`  Firefox import failed: ${err}`)
+    return { ok: false, reason: `Could not import cookies from Firefox. ${err}` }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Safari import
+// ---------------------------------------------------------------------------
+
+async function importCookiesFromSafari(
+  browser: DetectedBrowser,
+  targetPartition: string
+): Promise<BrowserCookieImportResult> {
+  diag(`importCookiesFromSafari: partition="${targetPartition}"`)
+
+  let data: Buffer
+  try {
+    data = readFileSync(browser.cookiesPath)
+  } catch (err) {
+    diag(`  Safari read failed: ${err}`)
+    // Why: Safari's Cookies.binarycookies lives inside a macOS sandbox container.
+    // Reading it requires Full Disk Access in System Settings → Privacy & Security.
+    const isPermError =
+      err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'EPERM'
+    if (isPermError) {
+      return {
+        ok: false,
+        reason:
+          'macOS denied access to Safari cookies. Grant Full Disk Access to Orca in System Settings → Privacy & Security → Full Disk Access.'
+      }
+    }
+    return { ok: false, reason: `Could not read Safari cookies. ${err}` }
+  }
+
+  try {
+    const cookies = decodeSafariBinaryCookies(data)
+    diag(`  Safari source has ${cookies.length} cookies`)
+
+    if (cookies.length === 0) {
+      return { ok: false, reason: 'No cookies found in Safari.' }
+    }
+
+    const now = Math.floor(Date.now() / 1000)
+    const valid = cookies.filter((c) => !c.expirationDate || c.expirationDate > now)
+
+    if (valid.length === 0) {
+      return { ok: false, reason: 'All Safari cookies are expired.' }
+    }
+
+    return importValidatedCookies(valid, cookies.length, targetPartition)
+  } catch (err) {
+    diag(`  Safari import failed: ${err}`)
+    return { ok: false, reason: `Could not import cookies from Safari. ${err}` }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Import dispatcher
+// ---------------------------------------------------------------------------
 
 export async function importCookiesFromBrowser(
   browser: DetectedBrowser,
@@ -501,6 +1225,13 @@ export async function importCookiesFromBrowser(
     return { ok: false, reason: `${browser.label} cookies database not found.` }
   }
 
+  if (browser.family === 'firefox') {
+    return importCookiesFromFirefox(browser, targetPartition)
+  }
+  if (browser.family === 'safari') {
+    return importCookiesFromSafari(browser, targetPartition)
+  }
+
   // Why: the browser may hold a lock on the Cookies file. Copying to a temp
   // location avoids lock contention and ensures we read a consistent snapshot.
   const tmpDir = mkdtempSync(join(tmpdir(), 'orca-cookie-import-'))
@@ -508,6 +1239,22 @@ export async function importCookiesFromBrowser(
 
   try {
     copyFileSync(browser.cookiesPath, tmpCookiesPath)
+    // Why: when the source browser is running, it uses WAL journal mode. The most
+    // recently written cookies (including fresh auth tokens) may only exist in the
+    // WAL sidecar file, not yet flushed to the main DB. Copying WAL + SHM ensures
+    // our snapshot reflects the browser's current state.
+    for (const suffix of ['-wal', '-shm'] as const) {
+      const sidecar = browser.cookiesPath + suffix
+      if (existsSync(sidecar)) {
+        try {
+          copyFileSync(sidecar, tmpCookiesPath + suffix)
+        } catch {
+          // Why: sidecar copy is best-effort. The main DB alone may still have
+          // enough cookies for a usable session; missing the WAL just means
+          // we might miss the very latest writes.
+        }
+      }
+    }
   } catch {
     rmSync(tmpDir, { recursive: true, force: true })
     return {
@@ -525,12 +1272,13 @@ export async function importCookiesFromBrowser(
   // In packaged builds where os_crypt IS active, CookieMonster will re-encrypt
   // plaintext cookies on its next flush, so this approach is safe in both modes.
 
-  const sourceKey = getEncryptionKey(browser.keychainService, browser.keychainAccount)
+  // Why: only Chromium browsers reach this point — Firefox/Safari dispatched above.
+  const sourceKey = getEncryptionKey(browser.keychainService!, browser.keychainAccount!, browser)
   if (!sourceKey) {
     rmSync(tmpDir, { recursive: true, force: true })
     return {
       ok: false,
-      reason: `Could not access ${browser.label} encryption key. macOS may have denied Keychain access.`
+      reason: `Could not access ${browser.label} encryption key. The OS may have denied access.`
     }
   }
 
@@ -557,64 +1305,37 @@ export async function importCookiesFromBrowser(
     return { ok: false, reason: 'Could not create staging cookie database.' }
   }
 
+  let sourceDb: InstanceType<typeof DatabaseSync> | null = null
+  let stagingDb: InstanceType<typeof DatabaseSync> | null = null
+
   try {
-    // Get target schema columns
-    const targetColsRaw = execSync(
-      `sqlite3 "${stagingCookiesPath}" "PRAGMA table_info(cookies);"`,
-      { encoding: 'utf-8', timeout: 5_000 }
-    ).trim()
-    const targetCols = targetColsRaw
-      .split('\n')
-      .map((line) => line.split('|')[1])
-      .filter(Boolean)
+    // Why: Chromium stores timestamps as microseconds since 1601, which can exceed
+    // Number.MAX_SAFE_INTEGER (~9e15). readBigInts ensures no precision loss.
+    sourceDb = new DatabaseSync(tmpCookiesPath, { readOnly: true, readBigInts: true })
+    stagingDb = new DatabaseSync(stagingCookiesPath)
+
+    type PragmaRow = { name: string }
+    const targetCols: string[] = (
+      stagingDb.prepare('PRAGMA table_info(cookies)').all() as PragmaRow[]
+    ).map((r) => r.name)
     const colList = targetCols.join(', ')
 
-    execSync(`sqlite3 "${stagingCookiesPath}" "DELETE FROM cookies;"`, {
-      encoding: 'utf-8',
-      timeout: 10_000
-    })
+    stagingDb.exec('DELETE FROM cookies')
 
-    // Why: sqlite3's text output corrupts rows containing tab/newline in
-    // values. Instead, build a SQL script entirely within sqlite3 that
-    // decrypts nothing — we export rows as hex blobs, decrypt in Node,
-    // and generate parameterized INSERT statements.
+    const sourceRows = sourceDb.prepare('SELECT * FROM cookies ORDER BY rowid').all() as Record<
+      string,
+      unknown
+    >[]
+    sourceDb.close()
+    sourceDb = null
 
-    // Read all non-blob columns + hex(value) + hex(encrypted_value) in one query
-    // Use a unique separator that can't appear in hex output
-    const SEP = '|||'
-    const selectCols = targetCols
-      .map((col) => {
-        if (col === 'value') {
-          return `hex(value)`
-        }
-        if (col === 'encrypted_value') {
-          return `hex(encrypted_value)`
-        }
-        return `quote(${col})`
-      })
-      .join(` || '${SEP}' || `)
+    diag(`  source has ${sourceRows.length} cookies`)
 
-    const allRowsOutput = execSync(
-      `sqlite3 "${tmpCookiesPath}" "SELECT ${selectCols} FROM cookies ORDER BY rowid;"`,
-      { encoding: 'utf-8', maxBuffer: 500 * 1024 * 1024, timeout: 60_000 }
-    ).trim()
-
-    const allRows = allRowsOutput.split('\n').filter(Boolean)
-    diag(`  source has ${allRows.length} cookies`)
-
-    if (allRows.length === 0) {
+    if (sourceRows.length === 0) {
+      stagingDb.close()
+      stagingDb = null
       rmSync(tmpDir, { recursive: true, force: true })
       return { ok: false, reason: `No cookies found in ${browser.label}.` }
-    }
-
-    const colIdx = Object.fromEntries(targetCols.map((col, i) => [col, i]))
-
-    function unquote(quoted: string): string {
-      return quoted.replace(/^'|'$/g, '').replace(/''/g, "'")
-    }
-
-    function unquoteInt(quoted: string): number {
-      return parseInt(quoted, 10) || 0
     }
 
     // Why: Google's integrity cookies (SIDCC, __Secure-*PSIDCC, __Secure-STRP)
@@ -643,10 +1364,9 @@ export async function importCookiesFromBrowser(
     let memoryLoaded = 0
     let memoryFailed = 0
     const domainSet = new Set<string>()
-    const sqlStatements: string[] = ['BEGIN TRANSACTION;']
 
     type DecryptedCookie = {
-      plaintextHex: string
+      decryptedValue: Buffer
       value: string
       domain: string
       name: string
@@ -659,31 +1379,37 @@ export async function importCookiesFromBrowser(
 
     const decryptedCookies: DecryptedCookie[] = []
 
-    for (const row of allRows) {
-      const cols = row.split(SEP)
-      if (cols.length !== targetCols.length) {
-        skipped++
-        continue
-      }
+    const placeholders = targetCols.map(() => '?').join(', ')
+    const insertStmt = stagingDb.prepare(
+      `INSERT OR REPLACE INTO cookies (${colList}) VALUES (${placeholders})`
+    )
 
-      const hexEncValue = cols[colIdx.encrypted_value]
-      const encBuf = Buffer.from(hexEncValue, 'hex')
-      const hexPlainValue = cols[colIdx.value]
+    stagingDb.exec('BEGIN TRANSACTION')
 
-      let plaintextHex: string
-      if (encBuf.length > 0) {
-        const rawDecrypted = decryptCookieValueRaw(encBuf, sourceKey)
-        if (rawDecrypted === null) {
+    for (const sourceRow of sourceRows) {
+      const encRaw = sourceRow.encrypted_value
+      const encBuf =
+        encRaw instanceof Uint8Array ? Buffer.from(encRaw) : encRaw ? Buffer.from([]) : null
+      const plainRaw = sourceRow.value
+
+      let decryptedValue: Buffer
+      if (encBuf && encBuf.length > 0) {
+        const raw = decryptCookieValueRaw(encBuf, sourceKey)
+        if (!raw) {
           skipped++
           continue
         }
-        plaintextHex = rawDecrypted.toString('hex')
+        decryptedValue = raw
+      } else if (plainRaw instanceof Uint8Array) {
+        decryptedValue = Buffer.from(plainRaw)
+      } else if (typeof plainRaw === 'string') {
+        decryptedValue = Buffer.from(plainRaw, 'latin1')
       } else {
-        plaintextHex = hexPlainValue
+        decryptedValue = Buffer.alloc(0)
       }
 
-      const domain = unquote(cols[colIdx.host_key])
-      const name = unquote(cols[colIdx.name])
+      const domain = sourceRow.host_key as string
+      const name = sourceRow.name as string
 
       if (isIntegrityCookie(name, domain)) {
         integritySkipped++
@@ -693,18 +1419,18 @@ export async function importCookiesFromBrowser(
       const cleanDomain = domain.startsWith('.') ? domain.slice(1) : domain
       domainSet.add(cleanDomain)
 
-      const path = unquote(cols[colIdx.path])
-      const secure = unquoteInt(cols[colIdx.is_secure]) === 1
-      const httpOnly = unquoteInt(cols[colIdx.is_httponly]) === 1
-      const sameSite = normalizeSameSite(unquoteInt(cols[colIdx.samesite]))
-      const expiresUtc = chromiumTimestampToUnix(unquote(cols[colIdx.expires_utc]))
+      const path = sourceRow.path as string
+      const secure = sourceRow.is_secure === 1n
+      const httpOnly = sourceRow.is_httponly === 1n
+      const sameSite = normalizeSameSite(Number(sourceRow.samesite ?? 0))
+      const expiresUtc = chromiumTimestampToUnix(sourceRow.expires_utc as bigint)
       // Why: cookie values are raw byte strings, not UTF-8 text. Using latin1
       // (ISO-8859-1) preserves all byte values 0x00–0xFF without replacement
       // characters that UTF-8 decoding would insert for invalid sequences.
-      const value = Buffer.from(plaintextHex, 'hex').toString('latin1')
+      const value = decryptedValue.toString('latin1')
 
       decryptedCookies.push({
-        plaintextHex,
+        decryptedValue,
         value,
         domain,
         name,
@@ -715,33 +1441,33 @@ export async function importCookiesFromBrowser(
         expirationDate: expiresUtc > 0 ? expiresUtc : undefined
       })
 
-      const values = targetCols
-        .map((col, i) => {
-          if (col === 'encrypted_value') {
-            return "X''"
-          }
-          if (col === 'value') {
-            return `X'${plaintextHex}'`
-          }
-          return cols[i]
-        })
-        .join(', ')
-      sqlStatements.push(`INSERT OR REPLACE INTO cookies (${colList}) VALUES (${values});`)
+      const params = targetCols.map((col) => {
+        if (col === 'encrypted_value') {
+          return Buffer.alloc(0)
+        }
+        if (col === 'value') {
+          return decryptedValue
+        }
+        const v = sourceRow[col]
+        if (v instanceof Uint8Array) {
+          return Buffer.from(v)
+        }
+        if (v === undefined || v === null) {
+          return null
+        }
+        if (typeof v === 'number' || typeof v === 'bigint' || typeof v === 'string') {
+          return v
+        }
+        return String(v)
+      })
+      insertStmt.run(...params)
       imported++
     }
     diag(`  skipped ${integritySkipped} Google integrity cookies (SIDCC/STRP/AEC)`)
 
-    sqlStatements.push('COMMIT;')
-    diag(`  prepared ${imported} INSERT statements, ${skipped} skipped`)
-
-    const sqlFilePath = join(tmpDir, 'import.sql')
-    writeFileSync(sqlFilePath, sqlStatements.join('\n'))
-
-    execSync(`sqlite3 "${stagingCookiesPath}" < "${sqlFilePath}"`, {
-      encoding: 'utf-8',
-      timeout: 60_000,
-      maxBuffer: 500 * 1024 * 1024
-    })
+    stagingDb.exec('COMMIT')
+    stagingDb.close()
+    stagingDb = null
 
     rmSync(tmpDir, { recursive: true, force: true })
     diag(`  SQLite staging complete: ${imported} cookies, ${domainSet.size} domains`)
@@ -811,7 +1537,7 @@ export async function importCookiesFromBrowser(
     }
 
     const summary: BrowserCookieImportSummary = {
-      totalCookies: allRows.length,
+      totalCookies: sourceRows.length,
       importedCookies: imported,
       skippedCookies: skipped,
       domains: [...domainSet].sort()
@@ -819,6 +1545,16 @@ export async function importCookiesFromBrowser(
 
     return { ok: true, profileId: '', summary }
   } catch (err) {
+    try {
+      sourceDb?.close()
+    } catch {
+      /* may already be closed */
+    }
+    try {
+      stagingDb?.close()
+    } catch {
+      /* may already be closed */
+    }
     rmSync(tmpDir, { recursive: true, force: true })
     // Why: if the import fails after the staging DB was created, clean it up
     // to avoid a stale staged import being applied on the next cold start.

--- a/src/main/browser/browser-cookie-import.ts
+++ b/src/main/browser/browser-cookie-import.ts
@@ -403,18 +403,38 @@ type ValidatedCookie = {
   expirationDate: number | undefined
 }
 
+// Why: Chromium's SQLite schema uses CookieSameSiteForStorage enum:
+// 0=UNSPECIFIED, 1=NO_RESTRICTION(None), 2=LAX, 3=STRICT.
+// This differs from Firefox (0=None, 1=Lax, 2=Strict).
+function chromiumSameSite(raw: number): 'unspecified' | 'no_restriction' | 'lax' | 'strict' {
+  switch (raw) {
+    case 1:
+      return 'no_restriction'
+    case 2:
+      return 'lax'
+    case 3:
+      return 'strict'
+    default:
+      return 'unspecified'
+  }
+}
+
+function firefoxSameSite(raw: number): 'unspecified' | 'no_restriction' | 'lax' | 'strict' {
+  switch (raw) {
+    case 0:
+      return 'no_restriction'
+    case 1:
+      return 'lax'
+    case 2:
+      return 'strict'
+    default:
+      return 'unspecified'
+  }
+}
+
 function normalizeSameSite(raw: unknown): 'unspecified' | 'no_restriction' | 'lax' | 'strict' {
   if (typeof raw === 'number') {
-    switch (raw) {
-      case 0:
-        return 'no_restriction'
-      case 1:
-        return 'lax'
-      case 2:
-        return 'strict'
-      default:
-        return 'unspecified'
-    }
+    return chromiumSameSite(raw)
   }
   if (typeof raw !== 'string') {
     return 'unspecified'
@@ -529,7 +549,7 @@ async function importValidatedCookies(
         for (let i = 0; i < val.length; i++) {
           const code = val.charCodeAt(i)
           if (code < 0x20 || code > 0x7e) {
-            badInfo = `pos=${i} char=U+${code.toString(16).padStart(4, '0')} context="${val.substring(Math.max(0, i - 5), i + 5)}"`
+            badInfo = `pos=${i} char=U+${code.toString(16).padStart(4, '0')}`
             break
           }
         }
@@ -780,7 +800,7 @@ function getLinuxEncryptionKey(
   } catch {
     // Why: fall back to application-based lookup used by newer Chromium versions.
     try {
-      const app = keychainAccount.toLowerCase().replace(' ', '')
+      const app = keychainAccount.toLowerCase().replaceAll(' ', '')
       keyringPassword = execFileSync('secret-tool', ['lookup', 'application', app], {
         encoding: 'utf-8',
         timeout: 5_000
@@ -948,6 +968,9 @@ function decodeSafariBinaryCookies(buffer: Buffer): ValidatedCookie[] {
 
   const pageCount = buffer.readUInt32BE(4)
   let cursor = 8
+  if (cursor + pageCount * 4 > buffer.length) {
+    return []
+  }
   const pageSizes: number[] = []
   for (let i = 0; i < pageCount; i++) {
     pageSizes.push(buffer.readUInt32BE(cursor))
@@ -972,6 +995,9 @@ function decodeSafariPage(page: Buffer): ValidatedCookie[] {
   }
 
   const cookieCount = page.readUInt32LE(4)
+  if (8 + cookieCount * 4 > page.length) {
+    return []
+  }
   const offsets: number[] = []
   let cursor = 8
   for (let i = 0; i < cookieCount; i++) {
@@ -993,8 +1019,10 @@ function decodeSafariCookie(buf: Buffer): ValidatedCookie | null {
   if (buf.length < 48) {
     return null
   }
-  const size = buf.readUInt32LE(0)
-  if (size < 48 || size > buf.length) {
+  // Why: size is read from the binary file and could be attacker-controlled.
+  // Clamp to buf.length so readCString cannot escape the cookie's subarray.
+  const size = Math.min(buf.readUInt32LE(0), buf.length)
+  if (size < 48) {
     return null
   }
 
@@ -1045,7 +1073,7 @@ function decodeSafariCookie(buf: Buffer): ValidatedCookie | null {
 }
 
 function readCString(buf: Buffer, offset: number, end: number): string | null {
-  if (offset <= 0 || offset >= end) {
+  if (offset < 0 || offset >= end) {
     return null
   }
   let cursor = offset
@@ -1141,7 +1169,7 @@ async function importCookiesFromFirefox(
         path: row.path || '/',
         secure,
         httpOnly: row.isHttpOnly === 1,
-        sameSite: normalizeSameSite(row.sameSite),
+        sameSite: firefoxSameSite(row.sameSite),
         expirationDate: row.expiry > 0 ? row.expiry : undefined
       })
     }
@@ -1156,7 +1184,10 @@ async function importCookiesFromFirefox(
   } catch (err) {
     rmSync(tmpDir, { recursive: true, force: true })
     diag(`  Firefox import failed: ${err}`)
-    return { ok: false, reason: `Could not import cookies from Firefox. ${err}` }
+    return {
+      ok: false,
+      reason: 'Could not import cookies from Firefox. Try closing Firefox first.'
+    }
   }
 }
 
@@ -1186,7 +1217,7 @@ async function importCookiesFromSafari(
           'macOS denied access to Safari cookies. Grant Full Disk Access to Orca in System Settings → Privacy & Security → Full Disk Access.'
       }
     }
-    return { ok: false, reason: `Could not read Safari cookies. ${err}` }
+    return { ok: false, reason: 'Could not read Safari cookies.' }
   }
 
   try {
@@ -1207,7 +1238,7 @@ async function importCookiesFromSafari(
     return importValidatedCookies(valid, cookies.length, targetPartition)
   } catch (err) {
     diag(`  Safari import failed: ${err}`)
-    return { ok: false, reason: `Could not import cookies from Safari. ${err}` }
+    return { ok: false, reason: 'Could not import cookies from Safari.' }
   }
 }
 
@@ -1388,8 +1419,10 @@ export async function importCookiesFromBrowser(
 
     for (const sourceRow of sourceRows) {
       const encRaw = sourceRow.encrypted_value
-      const encBuf =
-        encRaw instanceof Uint8Array ? Buffer.from(encRaw) : encRaw ? Buffer.from([]) : null
+      // Why: node:sqlite returns BLOB columns as Uint8Array. Any other truthy type
+      // means the schema is unexpected — treat it as missing rather than creating
+      // an empty buffer that would silently produce a blank cookie value.
+      const encBuf = encRaw instanceof Uint8Array ? Buffer.from(encRaw) : null
       const plainRaw = sourceRow.value
 
       let decryptedValue: Buffer
@@ -1422,7 +1455,7 @@ export async function importCookiesFromBrowser(
       const path = sourceRow.path as string
       const secure = sourceRow.is_secure === 1n
       const httpOnly = sourceRow.is_httponly === 1n
-      const sameSite = normalizeSameSite(Number(sourceRow.samesite ?? 0))
+      const sameSite = chromiumSameSite(Number(sourceRow.samesite ?? 0))
       const expiresUtc = chromiumTimestampToUnix(sourceRow.expires_utc as bigint)
       // Why: cookie values are raw byte strings, not UTF-8 text. Using latin1
       // (ISO-8859-1) preserves all byte values 0x00–0xFF without replacement
@@ -1566,7 +1599,7 @@ export async function importCookiesFromBrowser(
     diag(`  SQLite import failed: ${err}`)
     return {
       ok: false,
-      reason: `Could not import cookies from ${browser.label}. ${err}`
+      reason: `Could not import cookies from ${browser.label}. Check the diag log for details.`
     }
   }
 }

--- a/src/main/ipc/browser.ts
+++ b/src/main/ipc/browser.ts
@@ -7,6 +7,7 @@ import {
   pickCookieFile,
   importCookiesFromFile,
   detectInstalledBrowsers,
+  selectBrowserProfile,
   importCookiesFromBrowser
 } from '../browser/browser-cookie-import'
 import type { DetectedBrowser } from '../browser/browser-cookie-import'
@@ -324,7 +325,7 @@ export function registerBrowserHandlers(): void {
     'browser:session:importFromBrowser',
     async (
       event,
-      args: { profileId: string; browserFamily: string }
+      args: { profileId: string; browserFamily: string; browserProfile?: string }
     ): Promise<BrowserCookieImportResult> => {
       if (!isTrustedBrowserRenderer(event.sender)) {
         return { ok: false, reason: 'Not authorized' }
@@ -335,16 +336,32 @@ export function registerBrowserHandlers(): void {
       }
 
       const browsers = detectInstalledBrowsers()
-      const browser = browsers.find((b) => b.family === args.browserFamily)
+      let browser = browsers.find((b) => b.family === args.browserFamily)
       if (!browser) {
         return { ok: false, reason: 'Browser not found on this system.' }
       }
 
+      // Why: if the user selected a non-default profile from the picker,
+      // resolve the cookies path for that specific profile.
+      if (args.browserProfile && args.browserProfile !== browser.selectedProfile) {
+        const reselected = selectBrowserProfile(browser, args.browserProfile)
+        if (!reselected) {
+          return {
+            ok: false,
+            reason: `No cookies database found for profile "${args.browserProfile}".`
+          }
+        }
+        browser = reselected
+      }
+
       const result = await importCookiesFromBrowser(browser, profile.partition)
       if (result.ok) {
+        const profileName =
+          browser.profiles.find((p) => p.directory === browser.selectedProfile)?.name ??
+          browser.selectedProfile
         browserSessionRegistry.updateProfileSource(args.profileId, {
           browserFamily: browser.family,
-          profileName: 'Default',
+          profileName,
           importedAt: Date.now()
         })
         return { ...result, profileId: args.profileId }

--- a/src/main/ipc/browser.ts
+++ b/src/main/ipc/browser.ts
@@ -10,7 +10,6 @@ import {
   selectBrowserProfile,
   importCookiesFromBrowser
 } from '../browser/browser-cookie-import'
-import type { DetectedBrowser } from '../browser/browser-cookie-import'
 import type {
   BrowserSetGrabModeArgs,
   BrowserSetGrabModeResult,
@@ -314,12 +313,30 @@ export function registerBrowserHandlers(): void {
   ipcMain.removeHandler('browser:session:detectBrowsers')
   ipcMain.removeHandler('browser:session:importFromBrowser')
 
-  ipcMain.handle('browser:session:detectBrowsers', (event): DetectedBrowser[] => {
-    if (!isTrustedBrowserRenderer(event.sender)) {
-      return []
+  ipcMain.handle(
+    'browser:session:detectBrowsers',
+    (
+      event
+    ): {
+      family: string
+      label: string
+      profiles: { name: string; directory: string }[]
+      selectedProfile: string
+    }[] => {
+      if (!isTrustedBrowserRenderer(event.sender)) {
+        return []
+      }
+      // Why: the renderer only needs family/label/profiles for the UI picker.
+      // Strip cookiesPath, keychainService, and keychainAccount to avoid
+      // exposing filesystem paths and credential store identifiers to the renderer.
+      return detectInstalledBrowsers().map((b) => ({
+        family: b.family,
+        label: b.label,
+        profiles: b.profiles,
+        selectedProfile: b.selectedProfile
+      }))
     }
-    return detectInstalledBrowsers()
-  })
+  )
 
   ipcMain.handle(
     'browser:session:importFromBrowser',
@@ -333,6 +350,16 @@ export function registerBrowserHandlers(): void {
       const profile = browserSessionRegistry.getProfile(args.profileId)
       if (!profile) {
         return { ok: false, reason: 'Session profile not found.' }
+      }
+
+      // Why: browserProfile comes from the renderer and is used to construct
+      // a filesystem path. Reject traversal characters to prevent a compromised
+      // renderer from reading arbitrary files via the cookie import pipeline.
+      if (
+        args.browserProfile &&
+        (/[/\\]/.test(args.browserProfile) || args.browserProfile.includes('..'))
+      ) {
+        return { ok: false, reason: 'Invalid browser profile name.' }
       }
 
       const browsers = detectInstalledBrowsers()

--- a/src/preload/api-types.d.ts
+++ b/src/preload/api-types.d.ts
@@ -133,13 +133,21 @@ export type BrowserApi = {
   sessionImportFromBrowser: (args: {
     profileId: string
     browserFamily: string
+    browserProfile?: string
   }) => Promise<BrowserCookieImportResult>
   sessionClearDefaultCookies: () => Promise<boolean>
+}
+
+export type DetectedBrowserProfileInfo = {
+  name: string
+  directory: string
 }
 
 export type DetectedBrowserInfo = {
   family: BrowserSessionProfileSource['browserFamily']
   label: string
+  profiles: DetectedBrowserProfileInfo[]
+  selectedProfile: string
 }
 
 export type PreflightStatus = {

--- a/src/renderer/src/store/slices/browser.ts
+++ b/src/renderer/src/store/slices/browser.ts
@@ -85,11 +85,17 @@ export type BrowserSlice = {
   deleteBrowserSessionProfile: (profileId: string) => Promise<boolean>
   importCookiesToProfile: (profileId: string) => Promise<BrowserCookieImportResult>
   clearBrowserSessionImportState: () => void
-  detectedBrowsers: { family: string; label: string }[]
+  detectedBrowsers: {
+    family: string
+    label: string
+    profiles: { name: string; directory: string }[]
+    selectedProfile: string
+  }[]
   fetchDetectedBrowsers: () => Promise<void>
   importCookiesFromBrowser: (
     profileId: string,
-    browserFamily: string
+    browserFamily: string,
+    browserProfile?: string
   ) => Promise<BrowserCookieImportResult>
   clearDefaultSessionCookies: () => Promise<boolean>
   browserUrlHistory: BrowserHistoryEntry[]
@@ -1159,6 +1165,8 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
       const browsers = (await window.api.browser.sessionDetectBrowsers()) as {
         family: string
         label: string
+        profiles: { name: string; directory: string }[]
+        selectedProfile: string
       }[]
       set({ detectedBrowsers: browsers })
     } catch {
@@ -1166,7 +1174,7 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
     }
   },
 
-  importCookiesFromBrowser: async (profileId, browserFamily) => {
+  importCookiesFromBrowser: async (profileId, browserFamily, browserProfile?) => {
     set({
       browserSessionImportState: {
         profileId,
@@ -1178,7 +1186,8 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
     try {
       const result = (await window.api.browser.sessionImportFromBrowser({
         profileId,
-        browserFamily
+        browserFamily,
+        browserProfile
       })) as BrowserCookieImportResult
       if (result.ok) {
         set({

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -181,7 +181,7 @@ export type BrowserTab = BrowserWorkspace
 export type BrowserSessionProfileScope = 'default' | 'isolated' | 'imported'
 
 export type BrowserSessionProfileSource = {
-  browserFamily: 'chrome' | 'chromium' | 'arc' | 'edge' | 'manual'
+  browserFamily: 'chrome' | 'chromium' | 'arc' | 'edge' | 'firefox' | 'safari' | 'manual'
   profileName?: string
   importedAt: number
 }


### PR DESCRIPTION
## Summary

- **Fix logged-out-after-import bugs**: copy WAL/SHM sidecars, probe `Network/Cookies` path (Chrome 96+), discover multi-profile setups from `Local State` JSON
- **Replace sqlite3 CLI with node:sqlite**: eliminates text-parsing corruption, shell injection surface, and dependency on system `sqlite3` binary
- **Add Firefox + Safari**: Firefox reads plaintext `moz_cookies` table; Safari parses `Cookies.binarycookies` binary format with clear EPERM guidance for Full Disk Access
- **Add Windows + Linux**: Windows uses DPAPI master key + AES-256-GCM; Linux uses GNOME `secret-tool` with `peanuts` fallback for v10 cookies
- **Skip Google integrity cookies** (SIDCC, AEC, `__Secure-*PSIDCC`) that cause CookieMismatch when imported into a different browser
- **Handle bigint timestamps**: Chromium `expires_utc` values exceed `Number.MAX_SAFE_INTEGER`; source DB opened with `readBigInts: true`

## Test plan

- [ ] Import cookies from Chrome/Edge on macOS — verify sites stay logged in
- [ ] Import from a non-Default Chrome profile
- [ ] Import from Firefox on macOS
- [ ] Attempt Safari import — verify clear FDA permission error message
- [ ] Verify 31 failed cookies are picked up after app restart (staging DB)
- [ ] Smoke test on Windows (DPAPI path) and Linux (secret-tool path) if available