### PR TITLE
fix: slugify prompt fallback in composer workspace name

### DIFF
--- a/src/renderer/src/lib/new-workspace.test.ts
+++ b/src/renderer/src/lib/new-workspace.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+import { getWorkspaceSeedName } from './new-workspace'
+
+describe('getWorkspaceSeedName', () => {
+  it('prefers an explicit name', () => {
+    expect(
+      getWorkspaceSeedName({
+        explicitName: 'my-workspace',
+        prompt: 'anything',
+        linkedIssueNumber: null,
+        linkedPR: null
+      })
+    ).toBe('my-workspace')
+  })
+
+  it('uses linked issue/PR when no explicit name is provided', () => {
+    expect(
+      getWorkspaceSeedName({
+        explicitName: '',
+        prompt: '',
+        linkedIssueNumber: 7,
+        linkedPR: null
+      })
+    ).toBe('issue-7')
+    expect(
+      getWorkspaceSeedName({
+        explicitName: '',
+        prompt: '',
+        linkedIssueNumber: null,
+        linkedPR: 42
+      })
+    ).toBe('pr-42')
+  })
+
+  it('slugifies and truncates very long prompts', () => {
+    const longPrompt =
+      'Investigate the flaky login regression on iOS where the session cookie is dropped after background refresh and users get bounced to the splash screen.'
+    const seed = getWorkspaceSeedName({
+      explicitName: '',
+      prompt: longPrompt,
+      linkedIssueNumber: null,
+      linkedPR: null
+    })
+    expect(seed.length).toBeLessThanOrEqual(48)
+    expect(seed).toMatch(/^[a-z0-9._-]+$/)
+    expect(seed.startsWith('investigate-the-flaky-login')).toBe(true)
+  })
+
+  it('falls back to "workspace" when a prompt has no sluggable characters', () => {
+    expect(
+      getWorkspaceSeedName({
+        explicitName: '',
+        prompt: '🚀🚀🚀',
+        linkedIssueNumber: null,
+        linkedPR: null
+      })
+    ).toBe('workspace')
+    expect(
+      getWorkspaceSeedName({
+        explicitName: '',
+        prompt: '日本語だけ',
+        linkedIssueNumber: null,
+        linkedPR: null
+      })
+    ).toBe('workspace')
+  })
+
+  it('falls back to "workspace" for empty inputs', () => {
+    expect(
+      getWorkspaceSeedName({
+        explicitName: '',
+        prompt: '',
+        linkedIssueNumber: null,
+        linkedPR: null
+      })
+    ).toBe('workspace')
+  })
+})

--- a/src/renderer/src/lib/new-workspace.ts
+++ b/src/renderer/src/lib/new-workspace.ts
@@ -66,6 +66,24 @@ export function getSetupConfig(
   return null
 }
 
+// Why: branch names and on-disk worktree directories must be short, lowercase,
+// and ASCII-safe. Free-form text (prompts, GitHub titles) often contains
+// emoji, CJK, or hundreds of characters, which would otherwise make
+// sanitizeWorktreeName either produce a ludicrously long name or throw
+// "Invalid worktree name" when every character is stripped.
+function slugifyForWorkspaceName(input: string): string {
+  return input
+    .trim()
+    .toLowerCase()
+    .replace(/[\\/]+/g, '-')
+    .replace(/\s+/g, '-')
+    .replace(/[^a-z0-9._-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^[.-]+|[.-]+$/g, '')
+    .slice(0, 48)
+    .replace(/[-._]+$/g, '')
+}
+
 export function getLinkedWorkItemSuggestedName(item: GitHubWorkItem): string {
   const withoutLeadingNumber = item.title
     .trim()
@@ -75,15 +93,7 @@ export function getLinkedWorkItemSuggestedName(item: GitHubWorkItem): string {
     .replace(/\b#\d+\b/g, '')
     .trim()
   const seed = withoutLeadingNumber || item.title.trim()
-  return seed
-    .toLowerCase()
-    .replace(/[\\/]+/g, '-')
-    .replace(/\s+/g, '-')
-    .replace(/[^a-z0-9._-]+/g, '-')
-    .replace(/-+/g, '-')
-    .replace(/^[.-]+|[.-]+$/g, '')
-    .slice(0, 48)
-    .replace(/[-._]+$/g, '')
+  return slugifyForWorkspaceName(seed)
 }
 
 export function getWorkspaceSeedName(args: {
@@ -102,8 +112,16 @@ export function getWorkspaceSeedName(args: {
   if (linkedIssueNumber !== null) {
     return `issue-${linkedIssueNumber}`
   }
+  // Why: the prompt is free-form user text — it can easily exceed a sane
+  // branch-name length or be composed entirely of characters that
+  // sanitizeWorktreeName strips (emoji, CJK, punctuation). Slugify + truncate
+  // here so the downstream branch/path sanitizer always has a usable seed,
+  // and fall back to the stable default when the prompt collapses to empty.
   if (prompt.trim()) {
-    return prompt.trim()
+    const slug = slugifyForWorkspaceName(prompt)
+    if (slug) {
+      return slug
+    }
   }
   // Why: the prompt is optional in this flow. Fall back to a stable default
   // branch/workspace seed so users can launch an empty draft without first


### PR DESCRIPTION
## Summary
- When the user leaves the workspace name blank in `NewWorkspaceComposerModal` / `NewWorkspacePage` and has no linked issue/PR, the composer inferred the name from the raw prompt. That raw string was passed through to `createWorktree` → `sanitizeWorktreeName`, which either produced an absurdly long branch/directory name or threw `Invalid worktree name` when the prompt was entirely non-ASCII (emoji, CJK, pure punctuation).
- `getWorkspaceSeedName` in `src/renderer/src/lib/new-workspace.ts` now slugifies the prompt (lowercase, ASCII-safe, truncated to 48 chars) using the same helper that `getLinkedWorkItemSuggestedName` already relied on, and falls back to the existing `workspace` default when the slug collapses to empty.
- Added `src/renderer/src/lib/new-workspace.test.ts` covering explicit name, linked issue/PR, long prompts, emoji/CJK-only prompts, and empty input.

## Test plan
- [x] `pnpm test src/renderer/src/lib/new-workspace.test.ts` (5/5 passing)
- [x] `pnpm lint`
- [ ] Manual: open composer (Cmd+J), leave name empty, paste a 200-char prompt with emoji, hit submit — worktree should be created with a short slugged branch name instead of erroring.