### PR TITLE
feat: nicer composer prompt scrollbar and inline '>' prefix

### DIFF
--- a/src/renderer/src/components/NewWorkspaceComposerCard.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.tsx
@@ -106,6 +106,68 @@ type NewWorkspaceComposerCardProps = {
   createError: string | null
 }
 
+function PromptPrefixTextarea({
+  textareaRef,
+  value,
+  onChange,
+  onKeyDown
+}: {
+  textareaRef?: React.RefObject<HTMLTextAreaElement | null>
+  value: string
+  onChange: (value: string) => void
+  onKeyDown: (event: React.KeyboardEvent<HTMLTextAreaElement>) => void
+}): React.JSX.Element {
+  const internalRef = React.useRef<HTMLTextAreaElement | null>(null)
+
+  const setRefs = React.useCallback(
+    (node: HTMLTextAreaElement | null) => {
+      internalRef.current = node
+      if (textareaRef) {
+        textareaRef.current = node
+      }
+    },
+    [textareaRef]
+  )
+
+  // Why: auto-size the textarea to its content and hoist scrolling onto the
+  // outer wrapper. Any JS-driven overlay sync (listening to `scroll`, updating
+  // `translateY`) always paints a frame behind the textarea's own scroll — on
+  // momentum scroll that shows up as visible wobble between the `>` and the
+  // typed text. Putting both elements inside the same native scroll container
+  // makes them move in lockstep with zero JS and no cross-layer paint delay.
+  React.useLayoutEffect(() => {
+    const el = internalRef.current
+    if (!el) {
+      return
+    }
+    el.style.height = 'auto'
+    el.style.height = `${el.scrollHeight}px`
+  }, [value])
+
+  return (
+    <div className="scrollbar-sleek h-[110px] overflow-auto">
+      <div className="relative">
+        <span
+          aria-hidden
+          className="pointer-events-none absolute left-4 top-4 select-none font-mono text-[15px] leading-7 font-bold text-foreground"
+        >
+          {'>'}
+        </span>
+        <textarea
+          ref={setRefs}
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+          onKeyDown={onKeyDown}
+          placeholder="Describe a task to start an agent, or leave blank..."
+          className="block min-h-[110px] w-full resize-none overflow-hidden bg-transparent py-4 pl-4 pr-4 font-mono text-[15px] leading-7 text-foreground outline-none placeholder:text-muted-foreground/50"
+          style={{ textIndent: '2ch' }}
+          spellCheck={false}
+        />
+      </div>
+    </div>
+  )
+}
+
 function LinearIcon({ className }: { className?: string }): React.JSX.Element {
   return (
     <svg viewBox="0 0 24 24" aria-hidden className={className} fill="currentColor">
@@ -257,20 +319,20 @@ export default function NewWorkspaceComposerCard({
           </div>
 
           <div className="flex flex-col rounded-[16px] border border-border/60 bg-input/30 shadow-sm transition focus-within:border-ring focus-within:ring-2 focus-within:ring-ring/20">
-            <div className="flex items-start">
-              <span className="select-none pl-4 pt-4 font-mono text-[15px] leading-7 font-bold text-foreground">
-                {'>'}
-              </span>
-              <textarea
-                ref={promptTextareaRef}
-                value={agentPrompt}
-                onChange={(event) => onAgentPromptChange(event.target.value)}
-                onKeyDown={onPromptKeyDown}
-                placeholder="Describe a task to start an agent, or leave blank..."
-                className="min-h-[110px] w-full resize-none bg-transparent py-4 pl-3 pr-4 font-mono text-[15px] leading-7 text-foreground outline-none placeholder:text-muted-foreground/50"
-                spellCheck={false}
-              />
-            </div>
+            {/* Why: the `>` is rendered as a visual overlay so it's not part of
+                the submitted prompt value, but it must behave like the first
+                character of line 1 — staying inline with line 1's text and
+                scrolling out of view with it when the textarea scrolls.
+                `text-indent: 2ch` on the textarea reserves space for `> ` on
+                line 1 only (wrapped continuation lines start at col 0, directly
+                below the `>`), and the overlay's `translateY` is driven by the
+                textarea's `scrollTop` to keep it pinned to its original line. */}
+            <PromptPrefixTextarea
+              textareaRef={promptTextareaRef}
+              value={agentPrompt}
+              onChange={onAgentPromptChange}
+              onKeyDown={onPromptKeyDown}
+            />
 
             {attachmentPaths.length > 0 || linkedWorkItem ? (
               <div className="flex flex-wrap gap-2 px-3">

--- a/src/renderer/src/components/NewWorkspaceComposerCard.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.tsx
@@ -319,14 +319,11 @@ export default function NewWorkspaceComposerCard({
           </div>
 
           <div className="flex flex-col rounded-[16px] border border-border/60 bg-input/30 shadow-sm transition focus-within:border-ring focus-within:ring-2 focus-within:ring-ring/20">
-            {/* Why: the `>` is rendered as a visual overlay so it's not part of
-                the submitted prompt value, but it must behave like the first
-                character of line 1 — staying inline with line 1's text and
-                scrolling out of view with it when the textarea scrolls.
-                `text-indent: 2ch` on the textarea reserves space for `> ` on
-                line 1 only (wrapped continuation lines start at col 0, directly
-                below the `>`), and the overlay's `translateY` is driven by the
-                textarea's `scrollTop` to keep it pinned to its original line. */}
+            {/* Why: the `>` is rendered as a visual overlay (aria-hidden) so
+                it's never part of the submitted prompt value. It must behave
+                like the first character of line 1 — inline with line 1's text
+                and scrolling out of view with it. See PromptPrefixTextarea for
+                how the shared-scroll-container approach avoids wobble. */}
             <PromptPrefixTextarea
               textareaRef={promptTextareaRef}
               value={agentPrompt}


### PR DESCRIPTION
## Summary
- Apply the existing `scrollbar-sleek` utility to the workspace composer prompt's scroll area (VS Code-style thin scrollbar instead of the default chunky one).
- Render the `>` prefix as a visual overlay anchored to the start of line 1. Typed text flows past it on line 1 via `text-indent: 2ch`, and wrapped continuation lines start at column 0 directly beneath it. The prefix is `aria-hidden` and never enters the submitted prompt value.
- Hoist scrolling onto an outer wrapper and auto-size the textarea to its content. Because the `>` and the typed text now live in the **same native scroll container**, they scroll in lockstep with zero JS — earlier attempts using a `scroll` listener and `translateY` wobbled on momentum scroll due to cross-layer paint delay.

## Test plan
- [ ] Open the new workspace composer (Cmd+J or the `+` button).
- [ ] Scrollbar on the prompt area is the sleek thin style, not the default.
- [ ] `>` appears at the start of line 1; typed text flows to its right.
- [ ] Type enough lines to overflow; wrapped/continuation lines appear at column 0 directly under the `>`.
- [ ] Scroll the prompt up and down (including momentum/trackpad flick): the `>` moves with line 1's text with no wobble.
- [ ] Scroll past line 1: the `>` clips cleanly under the top padding.
- [ ] Submit a prompt; confirm the `>` is not part of the submitted value.