### PR TITLE
fix: boot to landing before shutting down active worktree

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
@@ -98,10 +98,17 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({ worktree, 
   }, [worktree.id, worktree.displayName, worktree.linkedIssue, worktree.comment, openModal])
 
   const handleCloseTerminals = useCallback(async () => {
-    await shutdownWorktreeTerminals(worktree.id)
+    // Why: shutting down the currently active worktree while its TerminalPane
+    // is still visible causes a visible "reboot" flicker and can crash the
+    // pane. clearTransientTerminalState nulls each tab's ptyId in place
+    // without bumping generation, so TerminalPane stays mounted while its
+    // PTYs are being killed; PTY exit callbacks then race against the live
+    // xterm instance. Boot the user to the landing page FIRST so the visible
+    // surface is detached before the async teardown runs.
     if (activeWorktreeId === worktree.id) {
       setActiveWorktree(null)
     }
+    await shutdownWorktreeTerminals(worktree.id)
   }, [worktree.id, shutdownWorktreeTerminals, activeWorktreeId, setActiveWorktree])
 
   const handleDelete = useCallback(() => {


### PR DESCRIPTION
## Summary
- Shutting down the active worktree via the sidebar context menu killed its PTYs while `TerminalPane` was still visible, causing a flicker/"reboot" effect and occasional crashes.
- `clearTransientTerminalState` nulls each tab's `ptyId` in place without bumping `generation`, so the pane stays mounted and PTY exit callbacks race against the live xterm instance.
- Fix in `src/renderer/src/components/sidebar/WorktreeContextMenu.tsx`: when the Shutdown target is the active worktree, call `setActiveWorktree(null)` first to swap the main surface to the Landing page, then await `shutdownWorktreeTerminals`.

## Test plan
- [ ] Open a worktree, click Shutdown from its context menu — verify the main pane flips to the Orca landing page immediately with no flicker or crash.
- [ ] Shutdown a non-active worktree — verify the active worktree is unaffected and its Shutdown still kills that worktree's PTYs.
- [ ] Existing unit tests: `pnpm vitest run src/renderer/src/store/slices/worktrees.test.ts src/renderer/src/components/sidebar`