### PR TITLE
fix: make Cmd+J worktree jump scroll instant

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -252,7 +252,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
       aria-orientation="vertical"
       aria-activedescendant={activeDescendantId}
       onKeyDown={handleContainerKeyDown}
-      className="flex-1 overflow-auto pl-1 pr-2 scroll-smooth outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-inset pt-px [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+      className="flex-1 overflow-auto pl-1 pr-2 outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-inset pt-px [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
     >
       <div
         role="presentation"


### PR DESCRIPTION
## Summary

- Remove `scroll-smooth` from the virtualized sidebar viewport so Cmd+J palette reveals land immediately instead of animating the full cross-list distance at browser-default speed.
- Single-card stepping (Cmd+Shift+↑/↓) also now scrolls instantly — the movement is short enough to feel snappier instant, and it avoids state-machine fragility from toggling `scroll-behavior` inline (tanstack virtual can issue follow-up scroll corrections after dynamic item measurement).

## Test plan

- [ ] Open Cmd+J palette and jump to a worktree far down the list — card should center instantly.
- [ ] Cmd+Shift+↓ / Cmd+Shift+↑ stepping still moves the active selection and keeps the card in view.
- [ ] Cmd+J from a currently-scrolled-away list position still lands on the target.