### PR TITLE
fix: pointer cursor on titlebar agent badge hover

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -365,6 +365,15 @@
   cursor: pointer;
 }
 
+/* Why: the titlebar is a drag region, and descendant elements inherit that
+   region unless they opt out. Without this, hovering the dot/count spans
+   inside the badge showed the default cursor instead of pointer because the
+   drag region overrode the button's cursor. pointer-events: none forwards
+   hover/click hit-testing to the button, which already has no-drag set. */
+.titlebar-agent-badge > * {
+  pointer-events: none;
+}
+
 .titlebar-agent-badge:hover {
   background: var(--accent);
   border-color: var(--border);


### PR DESCRIPTION
## Summary
- The titlebar agent activity badge (pill in the top-left showing active agent count) showed the default arrow cursor instead of a pointer when hovering the dot or count spans inside it.
- Root cause: the titlebar is a `-webkit-app-region: drag` region and the child spans inherited that, overriding the button's `cursor: pointer`.
- Fix: `pointer-events: none` on the badge's direct children, so hover/click hit-test the button itself (which already sets `-webkit-app-region: no-drag` and `cursor: pointer`).

## Test plan
- [ ] Hover the agent badge in the titlebar — cursor should be a pointer across the entire pill (including over the colored dot and the count number).
- [ ] Click still opens the agent popover; click targets unchanged.