### PR TITLE
fix: autofocus composer prompt and make "Use" open composer directly

### DIFF
--- a/src/renderer/src/components/NewWorkspaceComposerCard.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.tsx
@@ -160,6 +160,13 @@ function PromptPrefixTextarea({
         </span>
         <textarea
           ref={setRefs}
+          // Why: native autoFocus reliably focuses the prompt on initial mount
+          // — used by both the full-page composer and the Cmd+J modal so the
+          // user can start typing immediately without an extra tab. Running
+          // during React's mount means it beats Radix Dialog's FocusScope,
+          // which would otherwise land focus on the first focusable child
+          // (the "Workspace name" input that renders above this textarea).
+          autoFocus
           value={value}
           onChange={(event) => onChange(event.target.value)}
           onKeyDown={onKeyDown}

--- a/src/renderer/src/components/NewWorkspacePage.tsx
+++ b/src/renderer/src/components/NewWorkspacePage.tsx
@@ -702,10 +702,22 @@ export default function NewWorkspacePage(): React.JSX.Element {
                         </Tooltip>
 
                         <div className="flex items-center justify-start gap-1 lg:justify-end">
-                          <span className="inline-flex items-center gap-1 rounded-xl border border-border/50 bg-background/50 backdrop-blur-md px-3 py-1.5 text-sm text-foreground supports-[backdrop-filter]:bg-background/50">
+                          {/* Why: "Use" is the primary CTA — it should open
+                              the composer directly, skipping the read-only
+                              drawer that the row-click opens for previewing.
+                              Stop propagation so the row-level button that
+                              owns this grid doesn't also toggle the drawer. */}
+                          <button
+                            type="button"
+                            onClick={(e) => {
+                              e.stopPropagation()
+                              handleSelectWorkItem(item)
+                            }}
+                            className="inline-flex items-center gap-1 rounded-xl border border-border/50 bg-background/50 backdrop-blur-md px-3 py-1.5 text-sm text-foreground transition hover:bg-muted/60 supports-[backdrop-filter]:bg-background/50"
+                          >
                             Use
                             <ArrowRight className="size-4" />
-                          </span>
+                          </button>
                           <DropdownMenu modal={false}>
                             <DropdownMenuTrigger asChild>
                               <button


### PR DESCRIPTION
## Summary
- **Autofocus PROMPT in composer**: add native `autoFocus` on the prompt textarea so opening the composer (full page or Cmd+J modal) lands the cursor in the prompt field instead of the workspace-name input that renders above it.
- **Direct "Use" action**: make the "Use" pill in each GitHub work-item row a real button that opens the composer modal directly, skipping the read-only drawer. Clicking elsewhere on the row still opens the drawer preview.

## Test plan
- [ ] Open the new-workspace page — prompt textarea is focused, caret blinks inside it.
- [ ] Open the Cmd+J composer modal — prompt textarea is focused, not the workspace-name input.
- [ ] On the new-workspace page, click "Use" on a GitHub row — composer modal opens with the issue/PR linked, drawer does not open.
- [ ] Click elsewhere on the row (title area) — drawer opens as before.
- [ ] Drawer's own "Start workspace from …" button still opens the composer modal.