### PR TITLE
fix: bundle xterm deps into daemon-entry to fix packaged build crash

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -6,11 +6,29 @@ import tailwindcss from '@tailwindcss/vite'
 export default defineConfig({
   main: {
     build: {
+      // Why: daemon-entry.js is asar-unpacked so child_process.fork() can
+      // execute it from disk. Node's module resolution from the unpacked
+      // directory cannot reach into app.asar, so pure-JS dependencies used
+      // by the daemon must be bundled rather than externalized.
+      externalizeDeps: {
+        exclude: ['@xterm/headless', '@xterm/addon-serialize']
+      },
       rollupOptions: {
         input: {
           index: resolve('src/main/index.ts'),
           'daemon-entry': resolve('src/main/daemon/daemon-entry.ts')
         }
+      }
+    },
+    // Why: @xterm/headless declares "exports": null in package.json, which
+    // prevents Vite's default resolver from finding the CJS entry. Point
+    // directly at the published main file so the bundler can inline it.
+    resolve: {
+      alias: {
+        '@xterm/headless': resolve('node_modules/@xterm/headless/lib-headless/xterm-headless.js'),
+        '@xterm/addon-serialize': resolve(
+          'node_modules/@xterm/addon-serialize/lib/addon-serialize.js'
+        )
       }
     }
   },

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -155,7 +155,12 @@ app.whenReady().then(async () => {
   // Why: daemon must start before openMainWindow because registerPtyHandlers
   // (called inside) relies on the provider already being set. Starting it
   // alongside the other parallel servers keeps cold-start latency flat.
-  await initDaemonPtyProvider()
+  // Why: catch so the app still opens even if the daemon fails. The local
+  // PTY provider remains as the fallback — terminals will still work, just
+  // without cross-restart persistence.
+  await initDaemonPtyProvider().catch((error) => {
+    console.error('[daemon] Failed to start daemon PTY provider, falling back to local:', error)
+  })
 
   // Why: both server binds are independent and neither blocks window creation.
   // Parallelizing them with the window open shaves ~100-200ms off cold start.


### PR DESCRIPTION
## Summary
- **Root cause:** PR #729 added `daemon-entry.js` as an asar-unpacked entry point (needed for `child_process.fork()`), but its pure-JS dependencies (`@xterm/headless`, `@xterm/addon-serialize`) remained inside `app.asar`. Node's module resolution from the unpacked directory can't reach into the asar archive, so the daemon crashes with `Cannot find module` — causing an unhandled rejection that prevents the window from ever opening.
- **Fix:** Configure electron-vite to bundle these two packages into the daemon entry instead of externalizing them. Also add resolve aliases because `@xterm/headless` declares `"exports": null` which blocks Vite's resolver.
- **Resilience:** Add `.catch()` around `initDaemonPtyProvider()` so the app still opens (falling back to the local PTY provider) if the daemon fails for any reason.

## Test plan
- [x] `pnpm run build:electron-vite` succeeds
- [x] `daemon-entry.js` output no longer has external requires for `@xterm/headless` or `@xterm/addon-serialize`
- [x] Packaged app (`electron-builder --dir`) launches without `UnhandledPromiseRejectionWarning`
- [x] Daemon starts successfully in packaged build (verified with `ELECTRON_RUN_AS_NODE=1` fork test)
- [x] All existing tests pass (191/191 test files; 2 pre-existing failures in browser-cookie-import unrelated to this change)