### PR TITLE
fix: remove smooth scroll on settings navigation

### DIFF
--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -318,7 +318,7 @@ function Settings(): React.JSX.Element {
 
     if (scrollTargetId && pendingNavSectionId && visibleIds.has(pendingNavSectionId)) {
       const target = document.getElementById(scrollTargetId)
-      target?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+      target?.scrollIntoView({ block: 'start' })
       setActiveSectionId(pendingNavSectionId)
       pendingNavSectionRef.current = null
       pendingScrollTargetRef.current = null
@@ -385,7 +385,7 @@ function Settings(): React.JSX.Element {
     if (!target) {
       return
     }
-    target.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    target.scrollIntoView({ block: 'start' })
     setActiveSectionId(sectionId)
   }, [])
 


### PR DESCRIPTION
## Problem
Settings section navigation scrolls with a smooth animation that feels slow and distracting when switching between sections.

## Solution
Remove the smooth scroll behavior by omitting the `behavior: 'smooth'` parameter from `scrollIntoView` calls. Navigation now jumps instantly to the target section (consistent with VS Code, macOS System Settings, and GitHub settings).

Changes applied to both scroll trigger points:
- Pending section scroll on render (line 321)
- Sidebar section click handler (line 388)