### PR TITLE
feat: protocol-level health check for daemon reuse

### DIFF
--- a/src/main/daemon/daemon-init.ts
+++ b/src/main/daemon/daemon-init.ts
@@ -127,17 +127,66 @@ function healthCheckDaemon(socketPath: string, tokenPath: string): Promise<boole
   })
 }
 
+// Why: validates that a PID from the PID file is actually a daemon-entry
+// process before killing it. Without this check, a stale PID file left
+// after a daemon crash could cause us to SIGTERM an unrelated process
+// that reused the PID.
+function isDaemonProcess(pid: number): boolean {
+  try {
+    // Why: process.kill(pid, 0) throws if the process doesn't exist,
+    // but doesn't actually send a signal. If it succeeds, the process
+    // is alive — but could be unrelated. On macOS/Linux we can check
+    // the command line; on Windows we can't easily, so we accept the
+    // risk since named pipe ownership already gates correctness.
+    process.kill(pid, 0)
+  } catch {
+    return false
+  }
+
+  if (process.platform === 'win32') {
+    return true
+  }
+
+  try {
+    const cmdline = readFileSync(`/proc/${pid}/cmdline`, 'utf-8')
+    return cmdline.includes('daemon-entry')
+  } catch {
+    // Why: macOS doesn't have /proc. Fall back to checking if the socket
+    // is still owned by a listening process — if the PID file exists and
+    // the process is alive, it's likely our daemon since PIDs are recycled
+    // slowly on macOS.
+    return true
+  }
+}
+
+const KILL_WAIT_MS = 3000
+const KILL_POLL_MS = 100
+
 // Why: kills the stale daemon process (via PID file) and removes the socket
 // so a new daemon can bind. We do NOT send a shutdown RPC because
 // DaemonServer.shutdown() unconditionally kills all PTY sessions — that
 // would destroy warm-reattach terminals. SIGTERM lets the daemon's own
-// signal handler run its cleanup.
-function killStaleDaemon(runtimeDir: string, socketPath: string): void {
+// signal handler run its cleanup. We wait for the process to exit so the
+// named pipe (Windows) or socket is released before the new daemon binds.
+async function killStaleDaemon(runtimeDir: string, socketPath: string): Promise<void> {
   const pidPath = getDaemonPidPath(runtimeDir)
   try {
     const pid = parseInt(readFileSync(pidPath, 'utf-8').trim(), 10)
-    if (!isNaN(pid)) {
+    if (!isNaN(pid) && isDaemonProcess(pid)) {
       process.kill(pid, 'SIGTERM')
+
+      // Why: wait for the process to actually exit so the socket/pipe is
+      // released. Without this, the new daemon's listen() can fail with
+      // EADDRINUSE on Windows where named pipes can't be unlinked.
+      const deadline = Date.now() + KILL_WAIT_MS
+      while (Date.now() < deadline) {
+        try {
+          process.kill(pid, 0)
+        } catch {
+          break
+        }
+        await new Promise((r) => setTimeout(r, KILL_POLL_MS))
+      }
     }
   } catch {
     // PID file missing or process already dead
@@ -170,7 +219,7 @@ function createOutOfProcessLauncher(runtimeDir: string): DaemonLauncher {
     // Why: health check failed — either no daemon, crashed daemon with
     // stale socket, or alive-but-broken daemon. Kill the old process
     // (via PID file) and remove the socket so a new daemon can bind.
-    killStaleDaemon(runtimeDir, socketPath)
+    await killStaleDaemon(runtimeDir, socketPath)
 
     const entryPath = getDaemonEntryPath()
     const child = fork(entryPath, ['--socket', socketPath, '--token', tokenPath], {

--- a/src/main/daemon/daemon-init.ts
+++ b/src/main/daemon/daemon-init.ts
@@ -1,7 +1,7 @@
 import { join } from 'path'
 import { app } from 'electron'
 import { mkdirSync, existsSync, unlinkSync, readFileSync, writeFileSync } from 'fs'
-import { fork } from 'child_process'
+import { fork, execFileSync } from 'child_process'
 import { connect, type Socket } from 'net'
 import { DaemonSpawner, getDaemonPidPath, type DaemonLauncher } from './daemon-spawner'
 import { DaemonPtyAdapter } from './daemon-pty-adapter'
@@ -133,29 +133,36 @@ function healthCheckDaemon(socketPath: string, tokenPath: string): Promise<boole
 // that reused the PID.
 function isDaemonProcess(pid: number): boolean {
   try {
-    // Why: process.kill(pid, 0) throws if the process doesn't exist,
-    // but doesn't actually send a signal. If it succeeds, the process
-    // is alive — but could be unrelated. On macOS/Linux we can check
-    // the command line; on Windows we can't easily, so we accept the
-    // risk since named pipe ownership already gates correctness.
     process.kill(pid, 0)
   } catch {
     return false
   }
 
   if (process.platform === 'win32') {
+    // Why: Windows named pipe ownership already gates whether the new
+    // daemon can bind. If the old process isn't our daemon, the pipe
+    // name won't conflict and no kill is needed. If it IS our daemon,
+    // the pipe name matches and we need to kill it. WMIC/tasklist
+    // checks are fragile and slow — accept the small risk.
     return true
   }
 
   try {
+    // Why: /proc exists on Linux but not macOS. Check command line
+    // to confirm this PID is actually running daemon-entry.
     const cmdline = readFileSync(`/proc/${pid}/cmdline`, 'utf-8')
     return cmdline.includes('daemon-entry')
   } catch {
-    // Why: macOS doesn't have /proc. Fall back to checking if the socket
-    // is still owned by a listening process — if the PID file exists and
-    // the process is alive, it's likely our daemon since PIDs are recycled
-    // slowly on macOS.
-    return true
+    // macOS: use ps to check the process command
+    try {
+      const output = execFileSync('ps', ['-p', String(pid), '-o', 'command='], {
+        encoding: 'utf-8',
+        timeout: 2000
+      })
+      return output.includes('daemon-entry')
+    } catch {
+      return false
+    }
   }
 }
 
@@ -330,4 +337,10 @@ export async function shutdownDaemon(): Promise<void> {
   adapter = null
   await spawner?.shutdown()
   spawner = null
+
+  try {
+    unlinkSync(getDaemonPidPath(getRuntimeDir()))
+  } catch {
+    // Best-effort — PID file may not exist
+  }
 }

--- a/src/main/daemon/daemon-init.ts
+++ b/src/main/daemon/daemon-init.ts
@@ -1,11 +1,14 @@
 import { join } from 'path'
 import { app } from 'electron'
-import { mkdirSync, existsSync, unlinkSync } from 'fs'
+import { mkdirSync, existsSync, unlinkSync, readFileSync } from 'fs'
 import { fork } from 'child_process'
-import { connect } from 'net'
+import { connect, type Socket } from 'net'
 import { DaemonSpawner, type DaemonLauncher } from './daemon-spawner'
 import { DaemonPtyAdapter } from './daemon-pty-adapter'
 import { setLocalPtyProvider } from '../ipc/pty'
+import { PROTOCOL_VERSION } from './types'
+import { encodeNdjson } from './ndjson'
+import type { HelloMessage, HelloResponse, RpcResponse } from './types'
 
 let spawner: DaemonSpawner | null = null
 let adapter: DaemonPtyAdapter | null = null
@@ -31,46 +34,142 @@ function getDaemonEntryPath(): string {
   return join(basePath, 'out', 'main', 'daemon-entry.js')
 }
 
-// Why: before spawning a new daemon, check if an existing one is alive by
-// attempting a TCP connection to the socket. If it connects, the daemon
-// survived from a previous app session — reuse it instead of spawning.
-function probeSocket(socketPath: string): Promise<boolean> {
+const HEALTH_CHECK_TIMEOUT_MS = 3000
+
+// Why: a raw TCP connect (the old probeSocket) only proves the socket is
+// listening — it cannot detect a daemon that accepted connections but is
+// otherwise broken (hung, corrupt state, stale binary). A full protocol-level
+// health check (connect → hello → ping RPC) confirms the daemon can actually
+// process requests. If it fails, the caller kills and respawns rather than
+// handing a broken daemon to the rest of the app.
+function healthCheckDaemon(socketPath: string, tokenPath: string): Promise<boolean> {
   return new Promise((resolve) => {
     if (process.platform !== 'win32' && !existsSync(socketPath)) {
       resolve(false)
       return
     }
-    const sock = connect({ path: socketPath })
+
+    let token: string
+    try {
+      token = readFileSync(tokenPath, 'utf-8').trim()
+    } catch {
+      resolve(false)
+      return
+    }
+
     const timer = setTimeout(() => {
       sock.destroy()
       resolve(false)
-    }, 1000)
-    sock.on('connect', () => {
+    }, HEALTH_CHECK_TIMEOUT_MS)
+
+    const fail = (): void => {
       clearTimeout(timer)
       sock.destroy()
-      resolve(true)
-    })
-    sock.on('error', () => {
-      clearTimeout(timer)
       resolve(false)
+    }
+
+    const sock: Socket = connect({ path: socketPath })
+    sock.on('error', fail)
+
+    sock.on('connect', () => {
+      const hello: HelloMessage = {
+        type: 'hello',
+        version: PROTOCOL_VERSION,
+        token,
+        clientId: 'health-check',
+        role: 'control'
+      }
+      sock.write(encodeNdjson(hello))
+
+      let buffer = ''
+      sock.on('data', (chunk: Buffer) => {
+        buffer += chunk.toString()
+        let newlineIdx: number
+        while ((newlineIdx = buffer.indexOf('\n')) !== -1) {
+          const line = buffer.slice(0, newlineIdx)
+          buffer = buffer.slice(newlineIdx + 1)
+          if (line.length === 0) {
+            continue
+          }
+
+          let msg: Record<string, unknown>
+          try {
+            msg = JSON.parse(line) as Record<string, unknown>
+          } catch {
+            fail()
+            return
+          }
+
+          if (msg.type === 'hello') {
+            if (!(msg as HelloResponse).ok) {
+              fail()
+              return
+            }
+            sock.write(encodeNdjson({ id: 'health-1', type: 'ping' }))
+            continue
+          }
+
+          if (msg.id === 'health-1') {
+            clearTimeout(timer)
+            sock.destroy()
+            resolve((msg as RpcResponse).ok === true)
+            return
+          }
+        }
+      })
     })
   })
 }
 
+// Why: sends SIGTERM to whatever process is listening on the socket, then
+// removes the stale socket file. Used when the health check detects a
+// broken daemon that needs to be replaced.
+async function killStaleDaemon(socketPath: string): Promise<void> {
+  try {
+    // Why: connect and send a shutdown request so the daemon cleans up
+    // gracefully. If this fails, the socket removal below still lets a
+    // new daemon bind.
+    const sock = connect({ path: socketPath })
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(() => {
+        sock.destroy()
+        resolve()
+      }, 1000)
+      sock.on('connect', () => {
+        sock.destroy()
+        clearTimeout(timer)
+        resolve()
+      })
+      sock.on('error', () => {
+        clearTimeout(timer)
+        resolve()
+      })
+    })
+  } catch {
+    // Best-effort
+  }
+
+  if (process.platform !== 'win32' && existsSync(socketPath)) {
+    try {
+      unlinkSync(socketPath)
+    } catch {
+      // Best-effort
+    }
+  }
+}
+
 function createOutOfProcessLauncher(): DaemonLauncher {
   return async (socketPath, tokenPath) => {
-    const alive = await probeSocket(socketPath)
-    if (alive) {
-      // Why: daemon is already running from a previous app session.
-      // No new process to manage — return a no-op shutdown handle.
+    const healthy = await healthCheckDaemon(socketPath, tokenPath)
+    if (healthy) {
+      // Why: daemon is already running from a previous app session and
+      // responded to a full protocol-level ping. Safe to reuse.
       return { shutdown: async () => {} }
     }
 
-    // Why: stale socket file from a crashed daemon blocks the new server
-    // from binding. Remove it before spawning.
-    if (process.platform !== 'win32' && existsSync(socketPath)) {
-      unlinkSync(socketPath)
-    }
+    // Why: health check failed — either no daemon, crashed daemon with
+    // stale socket, or alive-but-broken daemon. Clean up before spawning.
+    await killStaleDaemon(socketPath)
 
     const entryPath = getDaemonEntryPath()
     const child = fork(entryPath, ['--socket', socketPath, '--token', tokenPath], {

--- a/src/main/daemon/daemon-init.ts
+++ b/src/main/daemon/daemon-init.ts
@@ -160,17 +160,29 @@ async function killStaleDaemon(socketPath: string, tokenPath: string): Promise<v
           role: 'control'
         }
         sock.write(encodeNdjson(hello))
-        sock.write(
-          encodeNdjson({ id: 'shutdown-1', type: 'shutdown', payload: { killSessions: false } })
-        )
-        // Why: give the daemon a moment to process the shutdown before
-        // tearing down the connection. The daemon calls process.nextTick
-        // on shutdown, so a small delay lets it start cleanup.
-        setTimeout(() => {
-          clearTimeout(timer)
-          sock.destroy()
-          resolve()
-        }, 500)
+
+        // Why: must wait for the hello ack before sending the shutdown RPC.
+        // If both messages arrive in the same TCP chunk, the daemon's pre-auth
+        // parser consumes both lines — the second is rejected as "Expected hello"
+        // and the connection is destroyed without processing shutdown.
+        let buffer = ''
+        sock.on('data', (chunk: Buffer) => {
+          buffer += chunk.toString()
+          if (!buffer.includes('\n')) {
+            return
+          }
+          sock.write(
+            encodeNdjson({ id: 'shutdown-1', type: 'shutdown', payload: { killSessions: false } })
+          )
+          // Why: give the daemon a moment to process the shutdown before
+          // tearing down the connection. The daemon calls process.nextTick
+          // on shutdown, so a small delay lets it start cleanup.
+          setTimeout(() => {
+            clearTimeout(timer)
+            sock.destroy()
+            resolve()
+          }, 500)
+        })
       })
     })
   } catch {

--- a/src/main/daemon/daemon-init.ts
+++ b/src/main/daemon/daemon-init.ts
@@ -57,19 +57,21 @@ function healthCheckDaemon(socketPath: string, tokenPath: string): Promise<boole
       return
     }
 
-    const timer = setTimeout(() => {
-      sock.destroy()
-      resolve(false)
-    }, HEALTH_CHECK_TIMEOUT_MS)
-
-    const fail = (): void => {
+    let settled = false
+    const settle = (result: boolean): void => {
+      if (settled) {
+        return
+      }
+      settled = true
       clearTimeout(timer)
       sock.destroy()
-      resolve(false)
+      resolve(result)
     }
 
+    const timer = setTimeout(() => settle(false), HEALTH_CHECK_TIMEOUT_MS)
+
     const sock: Socket = connect({ path: socketPath })
-    sock.on('error', fail)
+    sock.on('error', () => settle(false))
 
     sock.on('connect', () => {
       const hello: HelloMessage = {
@@ -83,6 +85,9 @@ function healthCheckDaemon(socketPath: string, tokenPath: string): Promise<boole
 
       let buffer = ''
       sock.on('data', (chunk: Buffer) => {
+        if (settled) {
+          return
+        }
         buffer += chunk.toString()
         let newlineIdx: number
         while ((newlineIdx = buffer.indexOf('\n')) !== -1) {
@@ -96,13 +101,13 @@ function healthCheckDaemon(socketPath: string, tokenPath: string): Promise<boole
           try {
             msg = JSON.parse(line) as Record<string, unknown>
           } catch {
-            fail()
+            settle(false)
             return
           }
 
           if (msg.type === 'hello') {
             if (!(msg as HelloResponse).ok) {
-              fail()
+              settle(false)
               return
             }
             sock.write(encodeNdjson({ id: 'health-1', type: 'ping' }))
@@ -110,12 +115,10 @@ function healthCheckDaemon(socketPath: string, tokenPath: string): Promise<boole
           }
 
           if (msg.id === 'health-1') {
-            clearTimeout(timer)
-            sock.destroy()
             // Why: treat any coherent RPC response as healthy, even
             // { ok: false } from an older daemon that doesn't know "ping".
             // The daemon parsed, routed, and replied — it's alive.
-            resolve(msg.id !== undefined)
+            settle(true)
             return
           }
         }
@@ -124,75 +127,12 @@ function healthCheckDaemon(socketPath: string, tokenPath: string): Promise<boole
   })
 }
 
-// Why: asks the stale daemon to shut down gracefully via an authenticated
-// shutdown RPC, then removes the socket file. If the daemon is unresponsive
-// (the reason we're killing it), the timeout ensures we don't block forever
-// and the socket removal lets a new daemon bind regardless.
-async function killStaleDaemon(socketPath: string, tokenPath: string): Promise<void> {
-  try {
-    let token: string
-    try {
-      token = readFileSync(tokenPath, 'utf-8').trim()
-    } catch {
-      // No token file — daemon can't be authenticated, just clean socket
-      removeStaleDaemonSocket(socketPath)
-      return
-    }
-
-    const sock = connect({ path: socketPath })
-    await new Promise<void>((resolve) => {
-      const timer = setTimeout(() => {
-        sock.destroy()
-        resolve()
-      }, 2000)
-
-      sock.on('error', () => {
-        clearTimeout(timer)
-        resolve()
-      })
-
-      sock.on('connect', () => {
-        const hello: HelloMessage = {
-          type: 'hello',
-          version: PROTOCOL_VERSION,
-          token,
-          clientId: 'shutdown-probe',
-          role: 'control'
-        }
-        sock.write(encodeNdjson(hello))
-
-        // Why: must wait for the hello ack before sending the shutdown RPC.
-        // If both messages arrive in the same TCP chunk, the daemon's pre-auth
-        // parser consumes both lines — the second is rejected as "Expected hello"
-        // and the connection is destroyed without processing shutdown.
-        let buffer = ''
-        sock.on('data', (chunk: Buffer) => {
-          buffer += chunk.toString()
-          if (!buffer.includes('\n')) {
-            return
-          }
-          sock.write(
-            encodeNdjson({ id: 'shutdown-1', type: 'shutdown', payload: { killSessions: false } })
-          )
-          // Why: give the daemon a moment to process the shutdown before
-          // tearing down the connection. The daemon calls process.nextTick
-          // on shutdown, so a small delay lets it start cleanup.
-          setTimeout(() => {
-            clearTimeout(timer)
-            sock.destroy()
-            resolve()
-          }, 500)
-        })
-      })
-    })
-  } catch {
-    // Best-effort
-  }
-
-  removeStaleDaemonSocket(socketPath)
-}
-
-function removeStaleDaemonSocket(socketPath: string): void {
+// Why: only removes the stale socket file so a new daemon can bind.
+// We intentionally do NOT send a shutdown RPC because DaemonServer.shutdown()
+// unconditionally kills all PTY sessions — sending it would destroy
+// warm-reattach terminals. The orphaned daemon process will exit naturally
+// when its socket is unlinked (new connections fail, existing ones close).
+function cleanupStaleDaemonSocket(socketPath: string): void {
   if (process.platform !== 'win32' && existsSync(socketPath)) {
     try {
       unlinkSync(socketPath)
@@ -213,7 +153,7 @@ function createOutOfProcessLauncher(): DaemonLauncher {
 
     // Why: health check failed — either no daemon, crashed daemon with
     // stale socket, or alive-but-broken daemon. Clean up before spawning.
-    await killStaleDaemon(socketPath, tokenPath)
+    cleanupStaleDaemonSocket(socketPath)
 
     const entryPath = getDaemonEntryPath()
     const child = fork(entryPath, ['--socket', socketPath, '--token', tokenPath], {

--- a/src/main/daemon/daemon-init.ts
+++ b/src/main/daemon/daemon-init.ts
@@ -139,12 +139,15 @@ function isDaemonProcess(pid: number): boolean {
   }
 
   if (process.platform === 'win32') {
-    // Why: Windows named pipe ownership already gates whether the new
-    // daemon can bind. If the old process isn't our daemon, the pipe
-    // name won't conflict and no kill is needed. If it IS our daemon,
-    // the pipe name matches and we need to kill it. WMIC/tasklist
-    // checks are fragile and slow — accept the small risk.
-    return true
+    try {
+      const output = execFileSync('tasklist', ['/FI', `PID eq ${pid}`, '/FO', 'CSV', '/NH'], {
+        encoding: 'utf-8',
+        timeout: 3000
+      })
+      return output.includes('node') || output.includes('Electron') || output.includes('orca')
+    } catch {
+      return false
+    }
   }
 
   try {

--- a/src/main/daemon/daemon-init.ts
+++ b/src/main/daemon/daemon-init.ts
@@ -8,7 +8,7 @@ import { DaemonPtyAdapter } from './daemon-pty-adapter'
 import { setLocalPtyProvider } from '../ipc/pty'
 import { PROTOCOL_VERSION } from './types'
 import { encodeNdjson } from './ndjson'
-import type { HelloMessage, HelloResponse, RpcResponse } from './types'
+import type { HelloMessage, HelloResponse } from './types'
 
 let spawner: DaemonSpawner | null = null
 let adapter: DaemonPtyAdapter | null = null
@@ -112,7 +112,10 @@ function healthCheckDaemon(socketPath: string, tokenPath: string): Promise<boole
           if (msg.id === 'health-1') {
             clearTimeout(timer)
             sock.destroy()
-            resolve((msg as RpcResponse).ok === true)
+            // Why: treat any coherent RPC response as healthy, even
+            // { ok: false } from an older daemon that doesn't know "ping".
+            // The daemon parsed, routed, and replied — it's alive.
+            resolve(msg.id !== undefined)
             return
           }
         }
@@ -121,34 +124,63 @@ function healthCheckDaemon(socketPath: string, tokenPath: string): Promise<boole
   })
 }
 
-// Why: sends SIGTERM to whatever process is listening on the socket, then
-// removes the stale socket file. Used when the health check detects a
-// broken daemon that needs to be replaced.
-async function killStaleDaemon(socketPath: string): Promise<void> {
+// Why: asks the stale daemon to shut down gracefully via an authenticated
+// shutdown RPC, then removes the socket file. If the daemon is unresponsive
+// (the reason we're killing it), the timeout ensures we don't block forever
+// and the socket removal lets a new daemon bind regardless.
+async function killStaleDaemon(socketPath: string, tokenPath: string): Promise<void> {
   try {
-    // Why: connect and send a shutdown request so the daemon cleans up
-    // gracefully. If this fails, the socket removal below still lets a
-    // new daemon bind.
+    let token: string
+    try {
+      token = readFileSync(tokenPath, 'utf-8').trim()
+    } catch {
+      // No token file — daemon can't be authenticated, just clean socket
+      removeStaleDaemonSocket(socketPath)
+      return
+    }
+
     const sock = connect({ path: socketPath })
     await new Promise<void>((resolve) => {
       const timer = setTimeout(() => {
         sock.destroy()
         resolve()
-      }, 1000)
-      sock.on('connect', () => {
-        sock.destroy()
-        clearTimeout(timer)
-        resolve()
-      })
+      }, 2000)
+
       sock.on('error', () => {
         clearTimeout(timer)
         resolve()
+      })
+
+      sock.on('connect', () => {
+        const hello: HelloMessage = {
+          type: 'hello',
+          version: PROTOCOL_VERSION,
+          token,
+          clientId: 'shutdown-probe',
+          role: 'control'
+        }
+        sock.write(encodeNdjson(hello))
+        sock.write(
+          encodeNdjson({ id: 'shutdown-1', type: 'shutdown', payload: { killSessions: false } })
+        )
+        // Why: give the daemon a moment to process the shutdown before
+        // tearing down the connection. The daemon calls process.nextTick
+        // on shutdown, so a small delay lets it start cleanup.
+        setTimeout(() => {
+          clearTimeout(timer)
+          sock.destroy()
+          resolve()
+        }, 500)
       })
     })
   } catch {
     // Best-effort
   }
 
+  removeStaleDaemonSocket(socketPath)
+}
+
+function removeStaleDaemonSocket(socketPath: string): void {
   if (process.platform !== 'win32' && existsSync(socketPath)) {
     try {
       unlinkSync(socketPath)
@@ -169,7 +201,7 @@ function createOutOfProcessLauncher(): DaemonLauncher {
 
     // Why: health check failed — either no daemon, crashed daemon with
     // stale socket, or alive-but-broken daemon. Clean up before spawning.
-    await killStaleDaemon(socketPath)
+    await killStaleDaemon(socketPath, tokenPath)
 
     const entryPath = getDaemonEntryPath()
     const child = fork(entryPath, ['--socket', socketPath, '--token', tokenPath], {

--- a/src/main/daemon/daemon-init.ts
+++ b/src/main/daemon/daemon-init.ts
@@ -186,13 +186,26 @@ async function killStaleDaemon(runtimeDir: string, socketPath: string): Promise<
       // released. Without this, the new daemon's listen() can fail with
       // EADDRINUSE on Windows where named pipes can't be unlinked.
       const deadline = Date.now() + KILL_WAIT_MS
+      let exited = false
       while (Date.now() < deadline) {
         try {
           process.kill(pid, 0)
         } catch {
+          exited = true
           break
         }
         await new Promise((r) => setTimeout(r, KILL_POLL_MS))
+      }
+
+      // Why: if the daemon's event loop is wedged, SIGTERM never runs the
+      // JS handler. Escalate to SIGKILL to guarantee the process dies and
+      // releases the socket/pipe.
+      if (!exited) {
+        try {
+          process.kill(pid, 'SIGKILL')
+        } catch {
+          // Already dead
+        }
       }
     }
   } catch {

--- a/src/main/daemon/daemon-init.ts
+++ b/src/main/daemon/daemon-init.ts
@@ -1,9 +1,9 @@
 import { join } from 'path'
 import { app } from 'electron'
-import { mkdirSync, existsSync, unlinkSync, readFileSync } from 'fs'
+import { mkdirSync, existsSync, unlinkSync, readFileSync, writeFileSync } from 'fs'
 import { fork } from 'child_process'
 import { connect, type Socket } from 'net'
-import { DaemonSpawner, type DaemonLauncher } from './daemon-spawner'
+import { DaemonSpawner, getDaemonPidPath, type DaemonLauncher } from './daemon-spawner'
 import { DaemonPtyAdapter } from './daemon-pty-adapter'
 import { setLocalPtyProvider } from '../ipc/pty'
 import { PROTOCOL_VERSION } from './types'
@@ -127,12 +127,28 @@ function healthCheckDaemon(socketPath: string, tokenPath: string): Promise<boole
   })
 }
 
-// Why: only removes the stale socket file so a new daemon can bind.
-// We intentionally do NOT send a shutdown RPC because DaemonServer.shutdown()
-// unconditionally kills all PTY sessions — sending it would destroy
-// warm-reattach terminals. The orphaned daemon process will exit naturally
-// when its socket is unlinked (new connections fail, existing ones close).
-function cleanupStaleDaemonSocket(socketPath: string): void {
+// Why: kills the stale daemon process (via PID file) and removes the socket
+// so a new daemon can bind. We do NOT send a shutdown RPC because
+// DaemonServer.shutdown() unconditionally kills all PTY sessions — that
+// would destroy warm-reattach terminals. SIGTERM lets the daemon's own
+// signal handler run its cleanup.
+function killStaleDaemon(runtimeDir: string, socketPath: string): void {
+  const pidPath = getDaemonPidPath(runtimeDir)
+  try {
+    const pid = parseInt(readFileSync(pidPath, 'utf-8').trim(), 10)
+    if (!isNaN(pid)) {
+      process.kill(pid, 'SIGTERM')
+    }
+  } catch {
+    // PID file missing or process already dead
+  }
+
+  try {
+    unlinkSync(pidPath)
+  } catch {
+    // Best-effort
+  }
+
   if (process.platform !== 'win32' && existsSync(socketPath)) {
     try {
       unlinkSync(socketPath)
@@ -142,7 +158,7 @@ function cleanupStaleDaemonSocket(socketPath: string): void {
   }
 }
 
-function createOutOfProcessLauncher(): DaemonLauncher {
+function createOutOfProcessLauncher(runtimeDir: string): DaemonLauncher {
   return async (socketPath, tokenPath) => {
     const healthy = await healthCheckDaemon(socketPath, tokenPath)
     if (healthy) {
@@ -152,8 +168,9 @@ function createOutOfProcessLauncher(): DaemonLauncher {
     }
 
     // Why: health check failed — either no daemon, crashed daemon with
-    // stale socket, or alive-but-broken daemon. Clean up before spawning.
-    cleanupStaleDaemonSocket(socketPath)
+    // stale socket, or alive-but-broken daemon. Kill the old process
+    // (via PID file) and remove the socket so a new daemon can bind.
+    killStaleDaemon(runtimeDir, socketPath)
 
     const entryPath = getDaemonEntryPath()
     const child = fork(entryPath, ['--socket', socketPath, '--token', tokenPath], {
@@ -189,6 +206,11 @@ function createOutOfProcessLauncher(): DaemonLauncher {
       child.on('message', (msg: unknown) => {
         if (msg && typeof msg === 'object' && (msg as { type?: string }).type === 'ready') {
           clearTimeout(timer)
+
+          if (child.pid) {
+            writeFileSync(getDaemonPidPath(runtimeDir), String(child.pid), { mode: 0o600 })
+          }
+
           // Why: disconnect IPC channel and unref so Electron can exit
           // without waiting for the daemon. The daemon keeps running.
           child.disconnect()
@@ -225,7 +247,7 @@ export async function initDaemonPtyProvider(): Promise<void> {
 
   const newSpawner = new DaemonSpawner({
     runtimeDir,
-    launcher: createOutOfProcessLauncher()
+    launcher: createOutOfProcessLauncher(runtimeDir)
   })
 
   // Why: assign spawner/adapter only after both succeed. If ensureRunning()

--- a/src/main/daemon/daemon-server.ts
+++ b/src/main/daemon/daemon-server.ts
@@ -260,6 +260,9 @@ export class DaemonServer {
       case 'listSessions':
         return { sessions: this.host.listSessions() }
 
+      case 'ping':
+        return { pong: true }
+
       case 'shutdown':
         if (request.payload.killSessions) {
           this.host.dispose()

--- a/src/main/daemon/daemon-spawner.ts
+++ b/src/main/daemon/daemon-spawner.ts
@@ -66,3 +66,7 @@ export function getDaemonSocketPath(runtimeDir: string): string {
 export function getDaemonTokenPath(runtimeDir: string): string {
   return join(runtimeDir, `daemon-v${PROTOCOL_VERSION}.token`)
 }
+
+export function getDaemonPidPath(runtimeDir: string): string {
+  return join(runtimeDir, `daemon-v${PROTOCOL_VERSION}.pid`)
+}

--- a/src/main/daemon/types.ts
+++ b/src/main/daemon/types.ts
@@ -141,6 +141,11 @@ export type ShutdownRequest = {
   }
 }
 
+export type PingRequest = {
+  id: string
+  type: 'ping'
+}
+
 export type DaemonRequest =
   | CreateOrAttachRequest
   | CancelCreateOrAttachRequest
@@ -153,6 +158,7 @@ export type DaemonRequest =
   | GetCwdRequest
   | ClearScrollbackRequest
   | ShutdownRequest
+  | PingRequest
 
 // ─── RPC Responses (Daemon → Client, on control socket) ────────────
 


### PR DESCRIPTION
## Summary
- Replaces the raw TCP socket probe (`probeSocket`) with a full protocol-level health check (connect → hello → ping RPC) before reusing an existing daemon from a previous app session
- Adds a `ping` RPC type to the daemon protocol — lightest possible responsiveness check
- If the health check fails, automatically kills the stale daemon (via PID file) and spawns a fresh one — no manual `pkill -f daemon-entry` needed
- Preserves terminal persistence across app updates: healthy daemons (even from older builds) are reused as long as they respond to protocol messages

## What changed

### Health check (`healthCheckDaemon`)
- Connects to the daemon socket, performs a full hello handshake, then sends a ping RPC
- Uses a `settled` guard so concurrent timeout/error/success paths can't resolve the promise multiple times
- Treats any coherent RPC response as healthy (even `ok: false` from older daemons that don't know `ping`) — backwards compatible

### Stale daemon cleanup (`killStaleDaemon`)
- Reads a PID file to find the stale daemon's process ID
- Validates the PID is actually a daemon-entry process before killing:
  - Linux: reads `/proc/<pid>/cmdline`
  - macOS: uses `ps -p <pid> -o command=`
  - Windows: uses `tasklist /FI "PID eq <pid>"`
- Sends SIGTERM, polls for exit (up to 3s), escalates to SIGKILL if the event loop is wedged
- Removes the socket file (Unix) after the process exits so the new daemon can bind
- PID file is cleaned up in `shutdownDaemon()` to prevent stale PIDs on next launch

### New files/exports
- `getDaemonPidPath()` in `daemon-spawner.ts` — path for the PID file
- `PingRequest` type in `types.ts` — added to the `DaemonRequest` union
- `ping` handler in `daemon-server.ts` — returns `{ pong: true }`

## Context
After the posix_spawnp fix (PR #762), one teammate still hit the error because their machine had a stale daemon from the previous RC. The old daemon survived the app update (by design — terminal persistence) but was built without the node-pty patch. The simple TCP probe said "alive" and reused it.

## Test plan
- [ ] Launch app, verify terminal works
- [ ] Quit and relaunch — verify daemon is reused (no new spawn)
- [ ] Kill daemon manually (`pkill -f daemon-entry`), relaunch — verify app auto-spawns a new one
- [ ] Corrupt the token file, relaunch — verify health check fails and respawns
- [ ] Verify PID file exists at `~/Library/Application Support/Orca/daemon/daemon-v1.pid`
- [ ] After explicit shutdown, verify PID file is cleaned up