### PR TITLE
fix: strip ELECTRON_RUN_AS_NODE from dev script environment

### DIFF
--- a/config/scripts/run-electron-vite-dev.mjs
+++ b/config/scripts/run-electron-vite-dev.mjs
@@ -2,6 +2,12 @@ import { spawn } from 'node:child_process'
 import { createRequire } from 'node:module'
 import path from 'node:path'
 
+// Why: Electron-based hosts (e.g. Claude Code, VS Code) set
+// ELECTRON_RUN_AS_NODE=1 in their terminal environment. If this leaks into
+// the electron-vite spawn, the Electron binary boots as plain Node and
+// require('electron') returns the npm stub instead of the built-in API.
+delete process.env.ELECTRON_RUN_AS_NODE
+
 const require = createRequire(import.meta.url)
 // Why: tests inject a tiny fake CLI here so they can verify Ctrl+C tears down
 // the full child tree without depending on a real electron-vite install.


### PR DESCRIPTION
## Summary

- Deletes `ELECTRON_RUN_AS_NODE` from `process.env` in `run-electron-vite-dev.mjs` before electron-vite spawns the Electron binary
- Fixes `pnpm dev` crashing with `TypeError: Cannot read properties of undefined (reading 'isPackaged')` when run from Electron-based terminals

## Context

Electron-based terminals (Claude Code, VS Code) set `ELECTRON_RUN_AS_NODE=1` in their shell environment. This env var leaks into `pnpm dev` → electron-vite → `spawn(electronPath, ...)`, causing the Electron binary to boot as plain Node.js instead of an Electron main process. As a result, `require('electron')` returns the npm package's path string instead of the built-in Electron API, and `electron.app` is `undefined`.

The fix is a single `delete process.env.ELECTRON_RUN_AS_NODE` before the spawn call. Production builds and the daemon fork (which intentionally sets the var) are unaffected.

## Test plan

- [ ] Run `pnpm dev` from Claude Code's integrated terminal — should launch without the `isPackaged` crash
- [ ] Run `pnpm dev` from a standalone terminal (iTerm, Terminal.app) — should continue to work as before
- [ ] Verify daemon PTY persistence still works (daemon fork sets its own `ELECTRON_RUN_AS_NODE`)