### PR TITLE
feat: default setup script to new tab

### DIFF
--- a/src/renderer/src/components/settings/TerminalPane.tsx
+++ b/src/renderer/src/components/settings/TerminalPane.tsx
@@ -436,6 +436,13 @@ export function TerminalPane({
             className="h-8 flex-wrap"
           >
             <ToggleGroupItem
+              value="new-tab"
+              className="h-8 px-3 text-xs"
+              aria-label="Run in a new tab"
+            >
+              New Tab
+            </ToggleGroupItem>
+            <ToggleGroupItem
               value="split-vertical"
               className="h-8 px-3 text-xs"
               aria-label="Split vertically"
@@ -448,13 +455,6 @@ export function TerminalPane({
               aria-label="Split horizontally"
             >
               Split Horizontally
-            </ToggleGroupItem>
-            <ToggleGroupItem
-              value="new-tab"
-              className="h-8 px-3 text-xs"
-              aria-label="Run in a new tab"
-            >
-              New Tab
             </ToggleGroupItem>
           </ToggleGroup>
           <p className="text-xs text-muted-foreground">

--- a/src/renderer/src/lib/worktree-activation.test.ts
+++ b/src/renderer/src/lib/worktree-activation.test.ts
@@ -6,7 +6,7 @@ import { useAppStore } from '@/store'
 function setSetupScriptLaunchMode(mode: SetupScriptLaunchMode | null): void {
   useAppStore.setState((state) => ({
     settings: state.settings
-      ? { ...state.settings, setupScriptLaunchMode: mode ?? 'split-vertical' }
+      ? { ...state.settings, setupScriptLaunchMode: mode ?? 'new-tab' }
       : mode !== null
         ? ({ setupScriptLaunchMode: mode } as unknown as typeof state.settings)
         : state.settings
@@ -14,7 +14,7 @@ function setSetupScriptLaunchMode(mode: SetupScriptLaunchMode | null): void {
 }
 
 afterEach(() => {
-  setSetupScriptLaunchMode('split-vertical')
+  setSetupScriptLaunchMode('new-tab')
 })
 
 function createMockStore(overrides: Record<string, unknown> = {}) {
@@ -32,8 +32,10 @@ function createMockStore(overrides: Record<string, unknown> = {}) {
 }
 
 describe('ensureWorktreeHasInitialTerminal', () => {
-  it('creates a tab and queues a setup split for newly created worktrees', () => {
-    const store = createMockStore()
+  it('creates a background Setup tab for newly created worktrees by default', () => {
+    let createdIndex = 0
+    const createTab = vi.fn(() => ({ id: `tab-${++createdIndex}` }))
+    const store = createMockStore({ createTab })
 
     ensureWorktreeHasInitialTerminal(store, 'wt-1', undefined, {
       runnerScriptPath: '/tmp/repo/.git/orca/setup-runner.sh',
@@ -43,17 +45,18 @@ describe('ensureWorktreeHasInitialTerminal', () => {
       }
     })
 
-    expect(store.createTab).toHaveBeenCalledWith('wt-1')
-    expect(store.setActiveTab).toHaveBeenCalledWith('tab-1')
-    expect(store.queueTabStartupCommand).not.toHaveBeenCalled()
-    expect(store.queueTabSetupSplit).toHaveBeenCalledWith('tab-1', {
+    expect(createTab).toHaveBeenCalledTimes(2)
+    expect(store.setActiveTab).toHaveBeenNthCalledWith(1, 'tab-1')
+    expect(store.setActiveTab).toHaveBeenLastCalledWith('tab-1')
+    expect(store.setTabCustomTitle).toHaveBeenCalledWith('tab-2', 'Setup')
+    expect(store.queueTabStartupCommand).toHaveBeenCalledWith('tab-2', {
       command: 'bash /tmp/repo/.git/orca/setup-runner.sh',
       env: {
         ORCA_ROOT_PATH: '/tmp/repo',
         ORCA_WORKTREE_PATH: '/tmp/worktrees/wt-1'
-      },
-      direction: 'vertical'
+      }
     })
+    expect(store.queueTabSetupSplit).not.toHaveBeenCalled()
   })
 
   it('creates a single tab without setup split when no setup is provided', () => {
@@ -140,6 +143,7 @@ describe('ensureWorktreeHasInitialTerminal', () => {
   })
 
   it('queues both setup split and issue command split when both are provided', () => {
+    setSetupScriptLaunchMode('split-vertical')
     const store = createMockStore()
 
     ensureWorktreeHasInitialTerminal(
@@ -175,6 +179,22 @@ describe('ensureWorktreeHasInitialTerminal', () => {
 
     expect(store.queueTabStartupCommand).not.toHaveBeenCalled()
     expect(store.queueTabIssueCommandSplit).not.toHaveBeenCalled()
+  })
+
+  it('queues a vertical setup split when setupScriptLaunchMode is split-vertical', () => {
+    setSetupScriptLaunchMode('split-vertical')
+    const store = createMockStore()
+
+    ensureWorktreeHasInitialTerminal(store, 'wt-1', undefined, {
+      runnerScriptPath: '/tmp/repo/.git/orca/setup-runner.sh',
+      envVars: { ORCA_ROOT_PATH: '/tmp/repo' }
+    })
+
+    expect(store.queueTabSetupSplit).toHaveBeenCalledWith('tab-1', {
+      command: 'bash /tmp/repo/.git/orca/setup-runner.sh',
+      env: { ORCA_ROOT_PATH: '/tmp/repo' },
+      direction: 'vertical'
+    })
   })
 
   it('queues a horizontal setup split when setupScriptLaunchMode is split-horizontal', () => {

--- a/src/renderer/src/lib/worktree-activation.ts
+++ b/src/renderer/src/lib/worktree-activation.ts
@@ -124,12 +124,12 @@ export function ensureWorktreeHasInitialTerminal(
   }
 
   // Why: the setup script launch location is user-configurable. The default
-  // 'split-vertical' preserves the historical behavior (right-side split so
-  // the main terminal stays immediately interactive); 'split-horizontal'
-  // swaps the split orientation; 'new-tab' creates a separate background
-  // tab titled "Setup" without stealing focus from the main terminal.
+  // 'new-tab' creates a separate background tab titled "Setup" without
+  // stealing focus from the main terminal, so setup output never crowds the
+  // primary pane; 'split-vertical' and 'split-horizontal' keep the setup
+  // output adjacent to the main terminal via a split.
   if (setup) {
-    const mode = useAppStore.getState().settings?.setupScriptLaunchMode ?? 'split-vertical'
+    const mode = useAppStore.getState().settings?.setupScriptLaunchMode ?? 'new-tab'
     const setupCommand = {
       command: buildSetupRunnerCommand(setup.runnerScriptPath),
       env: setup.envVars

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -107,7 +107,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     // { ...defaults.settings, ...parsed.settings } merge, so enabling
     // focus-follows-mouse never happens unexpectedly.
     terminalFocusFollowsMouse: false,
-    setupScriptLaunchMode: 'split-vertical',
+    setupScriptLaunchMode: 'new-tab',
     terminalScrollbackBytes: 10_000_000,
     openLinksInApp: true,
     rightSidebarOpenByDefault: true,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -547,9 +547,9 @@ export type TuiAgent =
 export type TaskViewPresetId = 'all' | 'issues' | 'review' | 'my-issues' | 'my-prs' | 'prs'
 
 /** Where the repo setup script runs when a worktree is created.
- *  - 'split-vertical': split the initial terminal pane with a vertical divider (default).
- *  - 'split-horizontal': split the initial terminal pane with a horizontal divider.
- *  - 'new-tab': open a background tab titled "Setup" and leave focus on the first tab. */
+ *  - 'new-tab': open a background tab titled "Setup" and leave focus on the first tab (default).
+ *  - 'split-vertical': split the initial terminal pane with a vertical divider.
+ *  - 'split-horizontal': split the initial terminal pane with a horizontal divider. */
 export type SetupScriptLaunchMode = 'split-vertical' | 'split-horizontal' | 'new-tab'
 
 /** Direction used when the setup script launch mode is a split. */
@@ -584,7 +584,8 @@ export type GlobalSettings = {
   terminalRightClickToPaste: boolean
   terminalFocusFollowsMouse: boolean
   /** Where the repo setup script runs on workspace create. Defaults to a
-   *  vertical split so the user's main terminal stays immediately usable. */
+   *  background "Setup" tab so the user's main terminal stays immediately
+   *  usable without the setup output crowding the initial pane. */
   setupScriptLaunchMode: SetupScriptLaunchMode
   terminalScrollbackBytes: number
   /** Why: opening arbitrary links inside Orca uses an isolated guest browser surface.


### PR DESCRIPTION
## Summary
- Change default `setupScriptLaunchMode` from `'split-vertical'` to `'new-tab'` so repo setup output runs in a background "Setup" tab on workspace create, keeping the primary terminal pane uncluttered.
- Reorder the Setup Script Location toggle in Terminal settings so "New Tab" is the first (default) option.
- Update doc comments and tests to reflect the new default; existing users on upgrade keep their configured mode via the settings merge in persistence.

## Test plan
- [x] `pnpm exec vitest run src/renderer/src/lib/worktree-activation.test.ts` — 11 passed
- [x] `pnpm run typecheck`
- [ ] Manually verify: creating a new worktree in a repo with a setup script opens a background "Setup" tab titled "Setup", leaves focus on the main terminal, and runs setup to completion
- [ ] Manually verify: switching the setting to "Split Vertically" / "Split Horizontally" still launches setup as a split