### PR TITLE
fix: free WebGL contexts for hidden worktrees to prevent terminal dying

### DIFF
--- a/src/renderer/src/components/tab-group/TabGroupPanel.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.tsx
@@ -21,6 +21,7 @@ const EditorPanel = lazy(() => import('../editor/EditorPanel'))
 export default function TabGroupPanel({
   groupId,
   worktreeId,
+  isWorktreeActive,
   isFocused,
   hasSplitGroups,
   reserveClosedExplorerToggleSpace,
@@ -30,6 +31,7 @@ export default function TabGroupPanel({
 }: {
   groupId: string
   worktreeId: string
+  isWorktreeActive: boolean
   isFocused: boolean
   hasSplitGroups: boolean
   reserveClosedExplorerToggleSpace: boolean
@@ -281,8 +283,15 @@ export default function TabGroupPanel({
               // Why: in multi-group splits, the active terminal in each group
               // must remain visible (display:flex) so the user sees its output,
               // but only the focused group's terminal should receive keyboard
-              // input. isVisible controls rendering; isActive controls focus.
-              isVisible={activeTab?.id === item.id && activeTab.contentType === 'terminal'}
+              // input. Hidden worktrees stay mounted offscreen, so `isVisible`
+              // must also respect worktree visibility or those detached panes
+              // keep their WebGL renderers alive and exhaust Chromium's context
+              // budget across worktrees.
+              isVisible={
+                isWorktreeActive &&
+                activeTab?.id === item.id &&
+                activeTab.contentType === 'terminal'
+              }
               onPtyExit={(ptyId) => {
                 if (commands.consumeSuppressedPtyExit(ptyId)) {
                   return
@@ -319,9 +328,14 @@ export default function TabGroupPanel({
           <div
             key={bt.id}
             className="absolute inset-0 flex min-h-0 min-w-0"
-            style={{ display: activeBrowserTab?.id === bt.id ? undefined : 'none' }}
+            style={{
+              display: isWorktreeActive && activeBrowserTab?.id === bt.id ? undefined : 'none'
+            }}
           >
-            <BrowserPane browserTab={bt} isActive={activeBrowserTab?.id === bt.id} />
+            <BrowserPane
+              browserTab={bt}
+              isActive={isWorktreeActive && activeBrowserTab?.id === bt.id}
+            />
           </div>
         ))}
       </div>

--- a/src/renderer/src/components/tab-group/TabGroupSplitLayout.test.ts
+++ b/src/renderer/src/components/tab-group/TabGroupSplitLayout.test.ts
@@ -44,6 +44,7 @@ describe('TabGroupSplitLayout', () => {
     return tabGroupPanelElement.props as {
       groupId: string
       worktreeId: string
+      isWorktreeActive: boolean
       isFocused: boolean
       hasSplitGroups: boolean
       reserveClosedExplorerToggleSpace: boolean
@@ -56,6 +57,7 @@ describe('TabGroupSplitLayout', () => {
       expect.objectContaining({
         groupId: 'group-1',
         worktreeId: 'wt-1',
+        isWorktreeActive: false,
         isFocused: false,
         hasSplitGroups: false,
         reserveClosedExplorerToggleSpace: true,
@@ -69,6 +71,7 @@ describe('TabGroupSplitLayout', () => {
       expect.objectContaining({
         groupId: 'group-1',
         worktreeId: 'wt-1',
+        isWorktreeActive: true,
         isFocused: true,
         hasSplitGroups: false,
         reserveClosedExplorerToggleSpace: true,

--- a/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
@@ -115,6 +115,7 @@ function SplitNode({
       <TabGroupPanel
         groupId={node.groupId}
         worktreeId={worktreeId}
+        isWorktreeActive={isWorktreeActive}
         // Why: hidden worktrees stay mounted so their PTYs and split layouts
         // survive worktree switches, but only the visible worktree may own the
         // global terminal shortcuts. If an offscreen group's pane stays


### PR DESCRIPTION
## Summary
- Hidden worktrees stay mounted so their PTYs and split layouts survive worktree switches, but each terminal's `WebglAddon` kept its GPU context attached. Across many worktrees this exhausts Chromium's ~16-context cap, `onContextLoss` fires, and terminals render blank or with only the bottom of the buffer visible (the "dead terminal" state).
- Thread `isWorktreeActive` from `TabGroupSplitLayout` down to `TabGroupPanel` and include it in the `TerminalPane` / `BrowserPane` `isVisible` predicate. When a worktree becomes inactive, the existing `suspendRendering()` path disposes the `WebglAddon`. `resumeRendering()` re-attaches on the next activation — the same lifecycle `onContextLoss` recovery and the GPU-toggle setting already exercise, so no new xterm state is at risk.

## Why this is safe
- `WebglAddon` is a renderer plugin; disposing it leaves the `Terminal` instance (buffer, scrollback, cursor) fully intact. xterm.js falls back to its DOM renderer automatically.
- PTY state lives in the out-of-process daemon (PR #729), so no terminal output can be lost via the renderer lifecycle.
- `onContextLoss` (`pane-lifecycle.ts`) and `setPaneGpuRendering` (`pane-manager.ts`) already perform the same dispose/reattach operation in production today.

## Test plan
- [x] `pnpm typecheck` passes
- [x] `TabGroupSplitLayout.test.ts` passes (updated to assert `isWorktreeActive` prop)
- [x] Manual: switch rapidly between 5+ worktrees and confirm no `[terminal] WebGL context lost` warnings in DevTools
- [x] Manual: switch away from a worktree with an actively-running Claude agent, wait, switch back — scrollback should be intact and output resumes cleanly
- [x] Manual: multi-pane split layout — all panes in the active worktree continue to render; hidden-worktree panes correctly re-paint on return