### PR TITLE
fix(terminal): stop re-running composer prompt on user-initiated splits

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -19,13 +19,12 @@ export function connectPanePty(
   let disposed = false
   let connectFrame: number | null = null
   let startupInjectTimer: ReturnType<typeof setTimeout> | null = null
-  // Why: setup commands must only run once — in the initial pane of the tab.
-  // Capture and clear the startup reference synchronously so that panes
-  // created later by splits or layout restoration cannot re-execute the
-  // setup script, which would be confusing and potentially destructive.
-  // Note: this intentionally mutates `deps` so the caller's object no
-  // longer carries the startup payload — preventing any later consumer
-  // from accidentally replaying it.
+  // Why: startup commands must only run once — in the pane they were
+  // targeted at. Capture `deps.startup` into a local and clear the field on
+  // the (already spread-copied) `deps` so nothing else inside this function
+  // can accidentally re-read it. The caller is responsible for clearing its
+  // own outer reference, since `deps` here is a shallow copy and our
+  // mutation does not propagate back.
   const paneStartup = deps.startup ?? null
   deps.startup = undefined
 

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -293,6 +293,18 @@ export function useTerminalPaneLifecycle({
           ...ptyDeps,
           restoredLeafId
         })
+        // Why: connectPanePty receives a spread copy of ptyDeps, so the
+        // `deps.startup = undefined` it performs internally only clears its
+        // local copy. If we don't also clear the outer ptyDeps.startup here,
+        // a later user-initiated splitPane (e.g. Cmd+D, context-menu "Split
+        // Right") fires onPaneCreated again with the original startup still
+        // attached — which re-runs the initial composer prompt in the newly
+        // created pane. Clearing here ensures the initial-startup payload is
+        // consumed exactly once, by the first pane. Setup/issue splits
+        // inject their own payload via splitPaneWithOneShotStartup, which
+        // sets deps.startup immediately before splitPane() and is therefore
+        // unaffected by this clear.
+        ptyDeps.startup = null
         panePtyBindings.set(pane.id, panePtyBinding)
         scheduleRuntimeGraphSync()
         queueResizeAll(true)


### PR DESCRIPTION
## Summary

Fixes a bug where splitting a pane (Cmd+D / right-click "Split Right") after launching a worktree from the NewWorkspaceComposer would re-run the original composer prompt in the new pane.

## Root cause

`useTerminalPaneLifecycle` threads the composer's startup command through `ptyDeps.startup` and passes a **spread copy** `{ ...ptyDeps, restoredLeafId }` to `connectPanePty` in `onPaneCreated`. `connectPanePty` clears `deps.startup` inside itself, but that mutation only affects its local copy — the outer `ptyDeps.startup` stayed intact. Any subsequent user-initiated `splitPane` fired `onPaneCreated` again with the original startup still attached, re-executing the composer prompt.

The setup/issue-automation split paths avoided this via `splitPaneWithOneShotStartup`'s `finally { deps.startup = null }`, but the initial-pane path had no equivalent cleanup.

## Fix

Clear `ptyDeps.startup = null` in `onPaneCreated` immediately after `connectPanePty` consumes it, scoping the initial-startup payload to exactly one pane. `connectPanePty` captures `paneStartup` synchronously at the top of the function, so the closure it hands to the rAF still sees the correct value.

## Test plan

- [x] `pnpm exec vitest run src/renderer/src/components/terminal-pane` — 92/92 pass
- [x] `pnpm exec tsc --noEmit` — clean
- [ ] Manual: open NewWorkspaceComposer, enter a prompt, create the worktree, wait for the agent to start, split the pane with Cmd+D → new pane should be an idle shell, not a second copy of the agent
- [ ] Manual: verify setup-script split (new worktree in a repo with `setup` hook + `split-vertical` launch mode) still runs the setup command in its split
- [ ] Manual: verify issue-automation split (new worktree with a linked issue and a configured `issueCommand`) still runs the issue command in its split