### PR TITLE
docs: update x (twitter) icon in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p align="center">
   <img src="https://img.shields.io/badge/Platform-macOS%20%7C%20Windows%20%7C%20Linux-blue?style=for-the-badge" alt="Supported Platforms" />
   <a href="https://discord.gg/fzjDKHxv8Q"><img src="https://img.shields.io/badge/Discord-Join-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Discord" /></a>
-  <a href="https://x.com/orca_build"><img src="https://img.shields.io/twitter/follow/orca_build?style=for-the-badge&color=1DA1F2" alt="Follow on X" /></a>
+  <a href="https://x.com/orca_build"><img src="https://img.shields.io/twitter/follow/orca_build?style=for-the-badge&logo=x&color=black" alt="Follow on X" /></a>
 </p>
 
 <p align="center">

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -8,7 +8,7 @@
   <a href="https://github.com/stablyai/orca/stargazers"><img src="https://img.shields.io/github/stars/stablyai/orca?style=for-the-badge&color=black" alt="GitHub stars" /></a>
   <img src="https://img.shields.io/badge/Platform-macOS%20%7C%20Windows%20%7C%20Linux-black?style=for-the-badge" alt="Supported Platforms" />
   <a href="https://discord.gg/fzjDKHxv8Q"><img src="https://img.shields.io/badge/Discord-Join-black?style=for-the-badge&logo=discord&logoColor=white" alt="Discord" /></a>
-  <a href="https://x.com/orca_build"><img src="https://img.shields.io/twitter/follow/orca_build?style=for-the-badge" alt="Follow on X" /></a>
+  <a href="https://x.com/orca_build"><img src="https://img.shields.io/twitter/follow/orca_build?style=for-the-badge&logo=x&color=black" alt="Follow on X" /></a>
 </p>
 
 <p align="center">

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -8,7 +8,7 @@
   <a href="https://github.com/stablyai/orca/stargazers"><img src="https://img.shields.io/github/stars/stablyai/orca?style=for-the-badge&color=black" alt="GitHub stars" /></a>
   <img src="https://img.shields.io/badge/Platform-macOS%20%7C%20Windows%20%7C%20Linux-black?style=for-the-badge" alt="Supported Platforms" />
   <a href="https://discord.gg/fzjDKHxv8Q"><img src="https://img.shields.io/badge/Discord-Join-black?style=for-the-badge&logo=discord&logoColor=white" alt="Discord" /></a>
-  <a href="https://x.com/orca_build"><img src="https://img.shields.io/twitter/follow/orca_build?style=for-the-badge" alt="Follow on X" /></a>
+  <a href="https://x.com/orca_build"><img src="https://img.shields.io/twitter/follow/orca_build?style=for-the-badge&logo=x&color=black" alt="Follow on X" /></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Problem
The Twitter/X icon in the README files was displaying the old Twitter blue color and potentially the old bird logo, which made the "X" hard to see and outdated.

## Solution
Updated the shields.io badge URL for the Twitter/X follow button in the English, Japanese, and Chinese READMEs to include `logo=x` and `color=black`. This ensures the new X logo is visible against a black background.