### PR TITLE
docs: match X (Twitter) badge styling with others

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p align="center">
   <img src="https://img.shields.io/badge/Platform-macOS%20%7C%20Windows%20%7C%20Linux-blue?style=for-the-badge" alt="Supported Platforms" />
   <a href="https://discord.gg/fzjDKHxv8Q"><img src="https://img.shields.io/badge/Discord-Join-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Discord" /></a>
-  <a href="https://x.com/orca_build"><img src="https://img.shields.io/twitter/follow/orca_build?style=for-the-badge&logo=x&color=black" alt="Follow on X" /></a>
+  <a href="https://x.com/orca_build"><img src="https://img.shields.io/badge/X-Follow_@orca__build-000000?style=for-the-badge&logo=x&logoColor=white" alt="Follow on X" /></a>
 </p>
 
 <p align="center">

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -8,7 +8,7 @@
   <a href="https://github.com/stablyai/orca/stargazers"><img src="https://img.shields.io/github/stars/stablyai/orca?style=for-the-badge&color=black" alt="GitHub stars" /></a>
   <img src="https://img.shields.io/badge/Platform-macOS%20%7C%20Windows%20%7C%20Linux-black?style=for-the-badge" alt="Supported Platforms" />
   <a href="https://discord.gg/fzjDKHxv8Q"><img src="https://img.shields.io/badge/Discord-Join-black?style=for-the-badge&logo=discord&logoColor=white" alt="Discord" /></a>
-  <a href="https://x.com/orca_build"><img src="https://img.shields.io/twitter/follow/orca_build?style=for-the-badge&logo=x&color=black" alt="Follow on X" /></a>
+  <a href="https://x.com/orca_build"><img src="https://img.shields.io/badge/X-Follow_@orca__build-000000?style=for-the-badge&logo=x&logoColor=white" alt="Follow on X" /></a>
 </p>
 
 <p align="center">

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -8,7 +8,7 @@
   <a href="https://github.com/stablyai/orca/stargazers"><img src="https://img.shields.io/github/stars/stablyai/orca?style=for-the-badge&color=black" alt="GitHub stars" /></a>
   <img src="https://img.shields.io/badge/Platform-macOS%20%7C%20Windows%20%7C%20Linux-black?style=for-the-badge" alt="Supported Platforms" />
   <a href="https://discord.gg/fzjDKHxv8Q"><img src="https://img.shields.io/badge/Discord-Join-black?style=for-the-badge&logo=discord&logoColor=white" alt="Discord" /></a>
-  <a href="https://x.com/orca_build"><img src="https://img.shields.io/twitter/follow/orca_build?style=for-the-badge&logo=x&color=black" alt="Follow on X" /></a>
+  <a href="https://x.com/orca_build"><img src="https://img.shields.io/badge/X-Follow_@orca__build-000000?style=for-the-badge&logo=x&logoColor=white" alt="Follow on X" /></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Problem
The previous X (Twitter) badge used the `twitter/follow` endpoint, which rendered an empty black box on the right side instead of matching the `Label | Value` style of the other badges (like Platform and Discord).

## Solution
Switched from the dynamic `/twitter/follow` badge endpoint to a static custom badge URL (`/badge/X-Follow_@orca__build-000000`). This gives it a solid grey label section for the "X" logo and a black background section for the "FOLLOW @ORCA_BUILD" text, perfectly mirroring the formatting of the Discord and Platform badges.