### PR TITLE
fix terminal split remounts when daemon is disabled

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -1,3 +1,4 @@
+/* oxlint-disable max-lines */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 type StoreState = {
@@ -5,7 +6,7 @@ type StoreState = {
   worktreesByRepo: Record<string, { id: string; repoId: string; path: string }[]>
   repos: { id: string; connectionId?: string | null }[]
   cacheTimerByKey: Record<string, number | null>
-  settings: { promptCacheTimerEnabled?: boolean } | null
+  settings: { promptCacheTimerEnabled?: boolean; experimentalTerminalDaemon?: boolean } | null
   consumePendingColdRestore: ReturnType<typeof vi.fn>
   consumePendingSnapshot: ReturnType<typeof vi.fn>
 }
@@ -276,6 +277,13 @@ describe('connectPanePty', () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport()
     transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      settings: {
+        ...mockStoreState.settings,
+        experimentalTerminalDaemon: true
+      }
+    } as StoreState
     const pane = createPane(2)
     const manager = createManager(2)
     const deps = createDeps({
@@ -294,6 +302,77 @@ describe('connectPanePty', () => {
     expect(transport.attach).not.toHaveBeenCalled()
     await Promise.resolve()
     expect(deps.syncPanePtyLayoutBinding).toHaveBeenCalledWith(2, 'leaf-pty-2')
+  })
+
+  it('reuses the existing local PTY on split remount when the daemon is disabled', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    transportFactoryQueue.push(transport)
+
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: {
+        'wt-1': [{ id: 'tab-1', ptyId: 'pty-local-detached' }]
+      },
+      settings: {
+        ...mockStoreState.settings,
+        // Why: with the daemon off, split/remount should still keep the
+        // in-process PTY alive within the same app session. This regression
+        // came from treating every remount like a daemon session reattach.
+        experimentalTerminalDaemon: false
+      }
+    } as StoreState
+
+    const pane = createPane(2)
+    const manager = createManager(2)
+    const deps = createDeps({
+      restoredLeafId: 'pane:2',
+      restoredPtyIdByLeafId: { 'pane:2': 'pty-local-detached' }
+    })
+
+    connectPanePty(pane as never, manager as never, deps as never)
+
+    expect(transport.attach).toHaveBeenCalledWith(
+      expect.objectContaining({ existingPtyId: 'pty-local-detached' })
+    )
+    expect(transport.connect).not.toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: 'pty-local-detached' })
+    )
+    expect(deps.syncPanePtyLayoutBinding).toHaveBeenCalledWith(2, 'pty-local-detached')
+    expect(deps.updateTabPtyId).toHaveBeenCalledWith('tab-1', 'pty-local-detached')
+  })
+
+  it('reattaches via daemon sessionId when the daemon is enabled and an in-session PTY is live', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    transportFactoryQueue.push(transport)
+
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: {
+        'wt-1': [{ id: 'tab-1', ptyId: 'pty-local-detached' }]
+      },
+      settings: {
+        ...mockStoreState.settings,
+        // Why: complement of the daemon-off case — with the daemon on, the
+        // in-session remount path must go through connect({sessionId}) so
+        // the daemon's createOrAttach runs at the pane's real dimensions.
+        experimentalTerminalDaemon: true
+      }
+    } as StoreState
+
+    const pane = createPane(2)
+    const manager = createManager(2)
+    const deps = createDeps()
+
+    connectPanePty(pane as never, manager as never, deps as never)
+
+    expect(transport.connect).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: 'pty-local-detached' })
+    )
+    expect(transport.attach).not.toHaveBeenCalled()
+    await Promise.resolve()
+    expect(deps.syncPanePtyLayoutBinding).toHaveBeenCalledWith(2, 'pty-local-detached')
   })
 
   it('persists a restarted pane PTY id and uses it on the next remount', async () => {
@@ -325,6 +404,10 @@ describe('connectPanePty', () => {
       ...mockStoreState,
       tabsByWorktree: {
         'wt-1': [{ id: 'tab-1', ptyId: 'pty-restarted' }]
+      },
+      settings: {
+        ...mockStoreState.settings,
+        experimentalTerminalDaemon: true
       }
     }
 

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -335,9 +335,7 @@ describe('connectPanePty', () => {
     expect(transport.attach).toHaveBeenCalledWith(
       expect.objectContaining({ existingPtyId: 'pty-local-detached' })
     )
-    expect(transport.connect).not.toHaveBeenCalledWith(
-      expect.objectContaining({ sessionId: 'pty-local-detached' })
-    )
+    expect(transport.connect).not.toHaveBeenCalled()
     expect(deps.syncPanePtyLayoutBinding).toHaveBeenCalledWith(2, 'pty-local-detached')
     expect(deps.updateTabPtyId).toHaveBeenCalledWith('tab-1', 'pty-local-detached')
   })

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -375,13 +375,15 @@ export function connectPanePty(
         })
     } else if (detachedLivePtyId) {
       allowInitialIdleCacheSeed = false
-      deps.syncPanePtyLayoutBinding(pane.id, detachedLivePtyId)
-      deps.updateTabPtyId(deps.tabId, detachedLivePtyId)
       // Why: surface synchronous attach failures (e.g., the PTY died between
       // mount and remount, so window.api.pty.resize rejects) through
       // reportError so the pane shows a diagnostic instead of silently
       // leaving a blank surface. The deferred-reattach branch above uses
-      // `.catch(reportError)` for the same reason.
+      // `.catch(reportError)` for the same reason. Commit the pane/tab
+      // bindings only after attach returns: if attach throws, the stale
+      // ptyId must also be cleared from the tab and a fresh spawn kicked
+      // off — otherwise the next remount reads the same dead ptyId from
+      // the store and lands in this branch again in a loop.
       try {
         transport.attach({
           existingPtyId: detachedLivePtyId,
@@ -392,8 +394,12 @@ export function connectPanePty(
             onError: reportError
           }
         })
+        deps.syncPanePtyLayoutBinding(pane.id, detachedLivePtyId)
+        deps.updateTabPtyId(deps.tabId, detachedLivePtyId)
       } catch (err) {
         reportError(err instanceof Error ? err.message : String(err))
+        deps.clearTabPtyId(deps.tabId, detachedLivePtyId)
+        startFreshSpawn()
       }
     } else {
       allowInitialIdleCacheSeed = false

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -283,25 +283,45 @@ export function connectPanePty(
       deps.restoredLeafId && deps.restoredPtyIdByLeafId
         ? (deps.restoredPtyIdByLeafId[deps.restoredLeafId] ?? null)
         : null
-    const existingPtyId = useAppStore
-      .getState()
-      .tabsByWorktree[deps.worktreeId]?.find((t) => t.id === deps.tabId)?.ptyId
+    const storeSnapshot = useAppStore.getState()
+    const existingPtyId = storeSnapshot.tabsByWorktree[deps.worktreeId]?.find(
+      (t) => t.id === deps.tabId
+    )?.ptyId
 
-    // Why: deferred reattach (Option 2). Instead of eagerly spawning PTYs at
-    // default 80×24 during reconnectPersistedTerminals (which fills eager
-    // buffers with content at wrong dimensions), we defer the daemon's
-    // createOrAttach to this point where fitAddon provides real dimensions.
-    // The daemon returns snapshot/coldRestore data in the spawn result.
-    const reattachSessionId =
-      restoredPtyId ?? (existingPtyId && !hasExistingPaneTransport ? existingPtyId : null)
-    if (reattachSessionId) {
+    const daemonEnabled = storeSnapshot.settings?.experimentalTerminalDaemon === true
+    // Why: restored leaf PTYs usually come from a previous app session, so
+    // they normally go back through the daemon's createOrAttach RPC to
+    // recover snapshot or cold-restore data at the pane's real dimensions.
+    // But split remounts in the current app session also carry a leaf binding
+    // in the saved layout. When the daemon is off, treating that live local
+    // PTY like a daemon session ID incorrectly spawns a fresh shell because
+    // LocalPtyProvider ignores sessionId. The reliable distinction is whether
+    // the tab still owns that PTY right now: same-session remounts keep the
+    // tab-level ptyId populated, while daemon-off cold starts clear it during
+    // session hydration.
+    const restoredSessionId = restoredPtyId ?? null
+    const detachedLivePtyId =
+      existingPtyId && !hasExistingPaneTransport
+        ? restoredSessionId
+          ? restoredSessionId === existingPtyId
+            ? restoredSessionId
+            : null
+          : existingPtyId
+        : null
+    const deferredReattachSessionId =
+      restoredSessionId && restoredSessionId !== detachedLivePtyId
+        ? restoredSessionId
+        : daemonEnabled
+          ? detachedLivePtyId
+          : null
+    if (deferredReattachSessionId) {
       allowInitialIdleCacheSeed = true
 
       const reattachPromise = transport.connect({
         url: '',
         cols,
         rows,
-        sessionId: reattachSessionId,
+        sessionId: deferredReattachSessionId,
         callbacks: {
           onData: dataCallback,
           onError: reportError
@@ -353,6 +373,28 @@ export function connectPanePty(
         .catch((err) => {
           reportError(err instanceof Error ? err.message : String(err))
         })
+    } else if (detachedLivePtyId) {
+      allowInitialIdleCacheSeed = false
+      deps.syncPanePtyLayoutBinding(pane.id, detachedLivePtyId)
+      deps.updateTabPtyId(deps.tabId, detachedLivePtyId)
+      // Why: surface synchronous attach failures (e.g., the PTY died between
+      // mount and remount, so window.api.pty.resize rejects) through
+      // reportError so the pane shows a diagnostic instead of silently
+      // leaving a blank surface. The deferred-reattach branch above uses
+      // `.catch(reportError)` for the same reason.
+      try {
+        transport.attach({
+          existingPtyId: detachedLivePtyId,
+          cols,
+          rows,
+          callbacks: {
+            onData: dataCallback,
+            onError: reportError
+          }
+        })
+      } catch (err) {
+        reportError(err instanceof Error ? err.message : String(err))
+      }
     } else {
       allowInitialIdleCacheSeed = false
       const pendingSpawn = hasExistingPaneTransport


### PR DESCRIPTION
## Problem

PR #774 made persistent terminal sessions opt-in behind the experimental daemon toggle. That preserved daemon-backed restore across app restarts, but it accidentally also made split-pane remounts depend on the daemon path. When a terminal tab was split with the daemon disabled, the pane unmounted, `detach()` kept the live PTY around, and the remount path still called `connect({ sessionId })`. The non-daemon `LocalPtyProvider` does not implement `sessionId` reattach, so it spawned a fresh shell instead of reconnecting to the existing PTY.

## Solution

Distinguish same-session PTY remounts from true daemon restores in `pty-connection.ts`.

- If the pane is remounting within the current app session and the tab still owns the live PTY, reuse it with `attach({ existingPtyId })`.
- If the pane is restoring through the daemon, continue using `connect({ sessionId })` so daemon-backed create-or-attach, snapshots, and cold restore still work.
- Wrap the new `attach()` call in try/catch → `reportError`, and commit the pane/tab bindings only after `attach()` returns. If `attach()` throws (for example, the PTY died between mount and remount), clear the stale tab ptyId and kick off a fresh spawn so a dead id cannot trap subsequent remounts in a loop.
- Add regression tests that pin both branches explicitly: daemon off reuses the local PTY on split remount, and daemon on still uses `sessionId` reattach.

## Testing

- `pnpm vitest run src/renderer/src/components/terminal-pane/pty-connection.test.ts src/renderer/src/components/terminal-pane/pty-transport.test.ts`
- Manual: split a pane with the daemon toggle off — PTY survives the remount.
- Manual: split a pane with the daemon toggle on — deferred `connect({sessionId})` reattach still fires.
- Manual: enabled the daemon, started a Claude session, ⌘Q, re-launched — session restored from the daemon (verifies #774 behavior was not regressed).