### PR TITLE
feat(terminal): add Nerd Fonts to default font fallback chain

### DIFF
--- a/src/renderer/src/components/terminal-pane/layout-serialization.test.ts
+++ b/src/renderer/src/components/terminal-pane/layout-serialization.test.ts
@@ -76,7 +76,7 @@ describe('paneLeafId', () => {
 // buildFontFamily
 // ---------------------------------------------------------------------------
 const FULL_FALLBACK =
-  '"SF Mono", "Menlo", "Monaco", "Cascadia Mono", "Consolas", "DejaVu Sans Mono", "Liberation Mono", monospace'
+  '"SF Mono", "Menlo", "Monaco", "Cascadia Mono", "Consolas", "DejaVu Sans Mono", "Liberation Mono", "Symbols Nerd Font Mono", "MesloLGS Nerd Font", "JetBrainsMono Nerd Font", "Hack Nerd Font", monospace'
 
 describe('buildFontFamily', () => {
   it('puts custom font first with full cross-platform fallback chain', () => {
@@ -87,7 +87,7 @@ describe('buildFontFamily', () => {
   it('does not duplicate SF Mono when it is the input', () => {
     const result = buildFontFamily('SF Mono')
     expect(result).toBe(
-      '"SF Mono", "Menlo", "Monaco", "Cascadia Mono", "Consolas", "DejaVu Sans Mono", "Liberation Mono", monospace'
+      '"SF Mono", "Menlo", "Monaco", "Cascadia Mono", "Consolas", "DejaVu Sans Mono", "Liberation Mono", "Symbols Nerd Font Mono", "MesloLGS Nerd Font", "JetBrainsMono Nerd Font", "Hack Nerd Font", monospace'
     )
   })
 
@@ -104,14 +104,21 @@ describe('buildFontFamily', () => {
   it('does not duplicate when font name contains "sf mono" (case-insensitive)', () => {
     const result = buildFontFamily('My SF Mono Custom')
     expect(result).toBe(
-      '"My SF Mono Custom", "Menlo", "Monaco", "Cascadia Mono", "Consolas", "DejaVu Sans Mono", "Liberation Mono", monospace'
+      '"My SF Mono Custom", "Menlo", "Monaco", "Cascadia Mono", "Consolas", "DejaVu Sans Mono", "Liberation Mono", "Symbols Nerd Font Mono", "MesloLGS Nerd Font", "JetBrainsMono Nerd Font", "Hack Nerd Font", monospace'
     )
   })
 
   it('does not duplicate Consolas when it is the input', () => {
     const result = buildFontFamily('Consolas')
     expect(result).toBe(
-      '"Consolas", "SF Mono", "Menlo", "Monaco", "Cascadia Mono", "DejaVu Sans Mono", "Liberation Mono", monospace'
+      '"Consolas", "SF Mono", "Menlo", "Monaco", "Cascadia Mono", "DejaVu Sans Mono", "Liberation Mono", "Symbols Nerd Font Mono", "MesloLGS Nerd Font", "JetBrainsMono Nerd Font", "Hack Nerd Font", monospace'
+    )
+  })
+
+  it('does not duplicate MesloLGS Nerd Font when it is the input', () => {
+    const result = buildFontFamily('MesloLGS Nerd Font')
+    expect(result).toBe(
+      '"MesloLGS Nerd Font", "SF Mono", "Menlo", "Monaco", "Cascadia Mono", "Consolas", "DejaVu Sans Mono", "Liberation Mono", "Symbols Nerd Font Mono", "JetBrainsMono Nerd Font", "Hack Nerd Font", monospace'
     )
   })
 })

--- a/src/renderer/src/components/terminal-pane/layout-serialization.ts
+++ b/src/renderer/src/components/terminal-pane/layout-serialization.ts
@@ -63,6 +63,16 @@ export function collectLeafIdsInReplayCreationOrder(
 // usable font regardless of OS.  macOS-only fonts like SF Mono and Menlo are
 // harmless on other platforms (the browser skips them), while Cascadia Mono /
 // Consolas cover Windows and DejaVu Sans Mono / Liberation Mono cover Linux.
+//
+// Why Nerd Fonts are listed just before `monospace`: Powerline prompts (p10k,
+// starship, oh-my-zsh) and many shell plugins emit glyphs in the Unicode
+// Private Use Area (U+E000–U+F8FF) that no standard monospace font contains.
+// When the user's primary font (e.g. SF Mono) is missing those code points
+// the browser walks the fallback chain character-by-character, so adding
+// commonly-installed Nerd Fonts here lets PUA glyphs render correctly without
+// forcing the user to override their terminal font. Placed AFTER the regular
+// system fonts so ASCII text still renders in the user's chosen font rather
+// than being substituted by a Nerd Font variant.
 const FALLBACK_FONTS = [
   'SF Mono', // macOS 10.12+
   'Menlo', // macOS (older)
@@ -71,6 +81,10 @@ const FALLBACK_FONTS = [
   'Consolas', // Windows Vista+
   'DejaVu Sans Mono', // Linux (common)
   'Liberation Mono', // Linux (common)
+  'Symbols Nerd Font Mono', // purpose-built Nerd Fonts symbols-only fallback
+  'MesloLGS Nerd Font', // p10k's recommended font; very common on zsh setups
+  'JetBrainsMono Nerd Font', // widely installed; Ghostty ships a JBM-derived font
+  'Hack Nerd Font', // common Nerd Font among Linux developers
   'monospace' // ultimate generic fallback
 ] as const
 

--- a/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
+++ b/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
@@ -28,8 +28,11 @@ export function buildDefaultTerminalOptions(): ITerminalOptions {
     // Cross-platform fallback chain — ensures the terminal can always find a
     // usable monospace font regardless of OS, even if user settings haven't
     // loaded yet. macOS-only fonts are harmlessly skipped on other platforms.
+    // Must stay in sync with FALLBACK_FONTS in layout-serialization.ts; the
+    // trailing Nerd Fonts let Powerline/PUA glyphs render even at first paint
+    // before the user's configured terminalFontFamily is applied.
     fontFamily:
-      '"SF Mono", "Menlo", "Monaco", "Cascadia Mono", "Consolas", "DejaVu Sans Mono", "Liberation Mono", monospace',
+      '"SF Mono", "Menlo", "Monaco", "Cascadia Mono", "Consolas", "DejaVu Sans Mono", "Liberation Mono", "Symbols Nerd Font Mono", "MesloLGS Nerd Font", "JetBrainsMono Nerd Font", "Hack Nerd Font", monospace',
     fontWeight: '300',
     fontWeightBold: '500',
     scrollback: 10000,


### PR DESCRIPTION
## Summary

- Extends the terminal's cross-platform font fallback chain with four commonly-installed Nerd Fonts (`Symbols Nerd Font Mono`, `MesloLGS Nerd Font`, `JetBrainsMono Nerd Font`, `Hack Nerd Font`), listed just before `monospace`.
- Powerline prompts (p10k, starship, oh-my-zsh, spaceship) emit glyphs in the Unicode Private Use Area (U+E000–U+F8FF). With the default `terminalFontFamily` (SF Mono on macOS / Cascadia Mono on Windows / DejaVu Sans Mono on Linux), none of the fonts in the fallback chain contain those code points, so users see tofu boxes unless they explicitly switch their terminal font to a Nerd Font themselves — even when one is already installed system-wide.
- With this change, the browser walks the fallback chain glyph-by-glyph: ASCII still renders in the user's chosen primary font, and PUA glyphs fall back to whichever Nerd Font is available. If no Nerd Font is installed, behavior is unchanged.

## User-visible change

Screenshot of the default terminal font (`SF Mono`) on macOS running a p10k prompt:

**Before** — Powerline segment separators render as empty rectangles:
```
> echo -e '\ue0b0 \ue0b2 \uf07c \uf0a0'
  [][]  [][]  []   []
~/code/orca [] main
```

**After** — PUA glyphs fall back to `MesloLGS Nerd Font` (installed via `brew install --cask font-meslo-lg-nerd-font`):
```
> echo -e '\ue0b0 \ue0b2 \uf07c \uf0a0'
                
~/code/orca  main 
```

No effect on machines without any Nerd Font installed.

## Cross-platform notes

- **macOS / Linux / Windows** — CSS font-family is order-dependent and walks per-glyph. Missing fonts are silently skipped by the browser, so adding these Nerd Font names has no side effect on platforms where they're not installed.
- No changes to `path.join` usage, keyboard shortcuts, or platform-gated labels.
- Tested manually on macOS (arm64). No platform-specific behavior introduced.

## Test plan

- [x] `pnpm lint` passes.
- [x] `pnpm typecheck` passes.
- [x] `pnpm test -- layout-serialization` passes (added a new case asserting that `MesloLGS Nerd Font` as a user font does not get duplicated in the fallback chain; updated the existing cases to reflect the extended chain). Pre-existing `browser-cookie-import.test.ts` failures on `main` are unrelated.
- [x] `pnpm build` passes.
- [x] Manually verified in dev build: default font (`SF Mono`) now renders Powerline glyphs via fallback to `MesloLGS Nerd Font` when installed.

## Code review notes

- Light change: 3 files, +29/-5. No new dependencies, no IPC surface changes, no renderer/main boundary crossed.
- Security audit: CSS font-family tokens are hard-coded string literals from the source tree; no user input is interpolated anywhere in the font chain. No surface for injection.
- The fallback chain is duplicated in two places (`layout-serialization.ts` canonical list + `pane-lifecycle.ts` literal string used at first paint before settings load). Both kept in sync; a comment in `pane-lifecycle.ts` points to the canonical source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)