### PR TITLE
fix(ui): invert GitHub Copilot icon in dark mode

### DIFF
--- a/src/renderer/src/lib/agent-catalog.tsx
+++ b/src/renderer/src/lib/agent-catalog.tsx
@@ -282,6 +282,7 @@ export function AgentIcon({
         alt=""
         aria-hidden
         style={{ borderRadius: 2 }}
+        className={agent === 'copilot' ? 'dark:invert' : undefined}
       />
     )
   }


### PR DESCRIPTION
## Problem
The GitHub Copilot icon was unreadable when using the app in dark mode as its default color was indistinguishable against dark backgrounds.

## Solution
Added a `dark:invert` tailwind class for the `copilot` catalog entry in the `AgentIcon` component so the SVG turns white in dark mode.