### PR TITLE
fix: update tests for Safari/Firefox browser detection and ZDOTDIR

### DIFF
--- a/src/main/browser/browser-cookie-import.test.ts
+++ b/src/main/browser/browser-cookie-import.test.ts
@@ -217,14 +217,17 @@ describe('detectInstalledBrowsers', () => {
       expect(browser).toHaveProperty('family')
       expect(browser).toHaveProperty('label')
       expect(browser).toHaveProperty('cookiesPath')
-      expect(browser).toHaveProperty('keychainService')
-      expect(browser).toHaveProperty('keychainAccount')
+      // keychainService/keychainAccount are only present for Chromium-based browsers
+      if (['chrome', 'edge', 'arc', 'chromium'].includes(browser.family)) {
+        expect(browser).toHaveProperty('keychainService')
+        expect(browser).toHaveProperty('keychainAccount')
+      }
     }
   })
 
   it('each detected browser has a valid family', () => {
     const browsers = detectInstalledBrowsers()
-    const validFamilies = ['chrome', 'edge', 'arc', 'chromium']
+    const validFamilies = ['chrome', 'edge', 'arc', 'chromium', 'firefox', 'safari']
     for (const browser of browsers) {
       expect(validFamilies).toContain(browser.family)
     }

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -493,12 +493,14 @@ describe('registerPtyHandlers', () => {
   it('spawns a plain POSIX login shell and queues startup commands for the live session', () => {
     const originalPlatform = process.platform
     const originalShell = process.env.SHELL
+    const originalZdotdir = process.env.ZDOTDIR
 
     Object.defineProperty(process, 'platform', {
       configurable: true,
       value: 'darwin'
     })
     process.env.SHELL = '/bin/zsh'
+    delete process.env.ZDOTDIR
 
     try {
       const [shell, args, options] = spawnAndGetCall({ cwd: '/tmp', command: 'printf "hello"' })
@@ -515,6 +517,11 @@ describe('registerPtyHandlers', () => {
         delete process.env.SHELL
       } else {
         process.env.SHELL = originalShell
+      }
+      if (originalZdotdir === undefined) {
+        delete process.env.ZDOTDIR
+      } else {
+        process.env.ZDOTDIR = originalZdotdir
       }
     }
   })


### PR DESCRIPTION
## Summary
- **browser-cookie-import.test.ts**: `detectInstalledBrowsers` now returns Safari and Firefox browsers which don't have `keychainService`/`keychainAccount` properties. Updated assertions to only check those fields for Chromium-based browsers, and added `'firefox'` and `'safari'` to the valid families list.
- **pty.test.ts**: The test expected `ORCA_ORIG_ZDOTDIR` to equal `$HOME`, but the implementation uses `ZDOTDIR || HOME`. Fixed by clearing `ZDOTDIR` during the test so the fallback to `HOME` is exercised correctly.

## Test plan
- [x] `pnpm test` passes all 197 test files (2081 tests)