### PR TITLE
fix: pass SSH connectionId for fs:listFiles

### DIFF
--- a/src/renderer/src/components/QuickOpen.tsx
+++ b/src/renderer/src/components/QuickOpen.tsx
@@ -4,6 +4,7 @@ import { File } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { detectLanguage } from '@/lib/language-detect'
 import { joinPath } from '@/lib/path'
+import { getConnectionId } from '@/lib/connection-context'
 import {
   CommandDialog,
   CommandInput,
@@ -79,6 +80,11 @@ export default function QuickOpen(): React.JSX.Element | null {
     return null
   }, [activeWorktreeId, worktreesByRepo])
 
+  const connectionId = useMemo(
+    () => getConnectionId(activeWorktreeId ?? null) ?? undefined,
+    [activeWorktreeId]
+  )
+
   // Load file list when opened
   useEffect(() => {
     if (!visible) {
@@ -97,7 +103,10 @@ export default function QuickOpen(): React.JSX.Element | null {
     setLoading(true)
 
     void window.api.fs
-      .listFiles({ rootPath: worktreePath })
+      // Why: quick-open shares the active worktree path model with file explorer
+      // and search, so remote worktrees must include connectionId. Without this,
+      // Windows resolves Linux roots (e.g. /home/*) as local C:\home\* paths.
+      .listFiles({ rootPath: worktreePath, connectionId })
       .then((result) => {
         if (!cancelled) {
           setFiles(result)
@@ -120,7 +129,7 @@ export default function QuickOpen(): React.JSX.Element | null {
     return () => {
       cancelled = true
     }
-  }, [visible, worktreePath])
+  }, [visible, worktreePath, connectionId])
 
   // Filter files by fuzzy match
   const filtered = useMemo(() => {


### PR DESCRIPTION
## Summary

Quick Open (Go to file) called `fs:listFiles` with only `rootPath`. For SSH worktrees, the main process treated the remote Linux path as a local path; on Windows that produced invalid paths (e.g. `C:\home\...`) and `ENOENT` on `realpath`. Quick Open now passes `connectionId` for the active worktree (same pattern as File Explorer and sidebar search) so listing runs through the SSH filesystem provider.

## Testing

- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed - Small, localized fix mirroring existing `getConnectionId` + `listFiles` usage elsewhere; no new test file added.

## AI Review Report

Change is limited to `QuickOpen.tsx`: resolve `connectionId` via `getConnectionId(activeWorktreeId)` and pass it to `window.api.fs.listFiles`. Matches existing IPC usage (`readDir`, `search`, etc.). Cross-platform: fix primarily affects Windows + SSH (path normalization); macOS/Linux local behavior unchanged when `connectionId` is undefined.

