### PR TITLE
fix(feedback): proxy submission through main process to bypass CORS

### DIFF
--- a/src/main/ipc/feedback.ts
+++ b/src/main/ipc/feedback.ts
@@ -1,0 +1,67 @@
+import { ipcMain, net } from 'electron'
+
+// Why: the production Mac build loads the renderer from a file:// origin, so a
+// cross-origin POST from fetch() triggers a CORS preflight that the feedback
+// endpoint rejects. Electron's net module runs in the main process and is not
+// subject to CORS, so we proxy the submission through IPC. This mirrors the
+// same pattern used by updater-changelog.ts and updater-nudge.ts.
+const FEEDBACK_API_URL = 'https://api.onorca.dev/v1/feedback'
+const FEEDBACK_API_FALLBACK_URL = 'https://www.onorca.dev/v1/feedback'
+
+export type FeedbackSubmitArgs = {
+  feedback: string
+  githubLogin: string | null
+  githubEmail: string | null
+}
+
+export type FeedbackSubmitResult =
+  | { ok: true }
+  | { ok: false; status: number | null; error: string }
+
+async function postFeedback(url: string, body: FeedbackSubmitArgs): Promise<Response> {
+  return net.fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body)
+  })
+}
+
+export async function submitFeedback(body: FeedbackSubmitArgs): Promise<FeedbackSubmitResult> {
+  try {
+    const res = await postFeedback(FEEDBACK_API_URL, body)
+    if (res.ok) {
+      return { ok: true }
+    }
+    // Why: DNS for api.onorca.dev can lag behind a deploy. Only fall back on
+    // 404/5xx-style results and network errors — don't mask real 4xx responses
+    // from a healthy host.
+    if (res.status === 404 || res.status >= 500) {
+      const fallback = await postFeedback(FEEDBACK_API_FALLBACK_URL, body)
+      if (fallback.ok) {
+        return { ok: true }
+      }
+      return { ok: false, status: fallback.status, error: `status ${fallback.status}` }
+    }
+    return { ok: false, status: res.status, error: `status ${res.status}` }
+  } catch (error) {
+    // Why: falling back on any network-level failure preserves the prior
+    // behavior where DNS/connect failures on the primary host transparently
+    // try the website-hosted versioned endpoint.
+    try {
+      const fallback = await postFeedback(FEEDBACK_API_FALLBACK_URL, body)
+      if (fallback.ok) {
+        return { ok: true }
+      }
+      return { ok: false, status: fallback.status, error: `status ${fallback.status}` }
+    } catch (fallbackError) {
+      const message = fallbackError instanceof Error ? fallbackError.message : String(fallbackError)
+      const primaryMessage = error instanceof Error ? error.message : String(error)
+      return { ok: false, status: null, error: `${primaryMessage}; fallback: ${message}` }
+    }
+  }
+}
+
+export function registerFeedbackHandlers(): void {
+  ipcMain.removeHandler('feedback:submit')
+  ipcMain.handle('feedback:submit', (_event, args: FeedbackSubmitArgs) => submitFeedback(args))
+}

--- a/src/main/ipc/register-core-handlers.test.ts
+++ b/src/main/ipc/register-core-handlers.test.ts
@@ -6,6 +6,7 @@ const {
   registerClaudeUsageHandlersMock,
   registerCodexUsageHandlersMock,
   registerGitHubHandlersMock,
+  registerFeedbackHandlersMock,
   registerStatsHandlersMock,
   registerNotificationHandlersMock,
   registerSettingsHandlersMock,
@@ -28,6 +29,7 @@ const {
   registerClaudeUsageHandlersMock: vi.fn(),
   registerCodexUsageHandlersMock: vi.fn(),
   registerGitHubHandlersMock: vi.fn(),
+  registerFeedbackHandlersMock: vi.fn(),
   registerStatsHandlersMock: vi.fn(),
   registerNotificationHandlersMock: vi.fn(),
   registerSettingsHandlersMock: vi.fn(),
@@ -64,6 +66,10 @@ vi.mock('./codex-usage', () => ({
 
 vi.mock('./github', () => ({
   registerGitHubHandlers: registerGitHubHandlersMock
+}))
+
+vi.mock('./feedback', () => ({
+  registerFeedbackHandlers: registerFeedbackHandlersMock
 }))
 
 vi.mock('./stats', () => ({
@@ -133,6 +139,7 @@ describe('registerCoreHandlers', () => {
     registerClaudeUsageHandlersMock.mockReset()
     registerCodexUsageHandlersMock.mockReset()
     registerGitHubHandlersMock.mockReset()
+    registerFeedbackHandlersMock.mockReset()
     registerStatsHandlersMock.mockReset()
     registerNotificationHandlersMock.mockReset()
     registerSettingsHandlersMock.mockReset()
@@ -175,6 +182,7 @@ describe('registerCoreHandlers', () => {
     expect(registerCodexAccountHandlersMock).toHaveBeenCalledWith(codexAccounts)
     expect(registerRateLimitHandlersMock).toHaveBeenCalledWith(rateLimits)
     expect(registerGitHubHandlersMock).toHaveBeenCalledWith(store, stats)
+    expect(registerFeedbackHandlersMock).toHaveBeenCalled()
     expect(registerStatsHandlersMock).toHaveBeenCalledWith(stats)
     expect(registerNotificationHandlersMock).toHaveBeenCalledWith(store)
     expect(registerSettingsHandlersMock).toHaveBeenCalledWith(store)

--- a/src/main/ipc/register-core-handlers.ts
+++ b/src/main/ipc/register-core-handlers.ts
@@ -9,6 +9,7 @@ import { registerFilesystemWatcherHandlers } from './filesystem-watcher'
 import { registerClaudeUsageHandlers } from './claude-usage'
 import { registerCodexUsageHandlers } from './codex-usage'
 import { registerGitHubHandlers } from './github'
+import { registerFeedbackHandlers } from './feedback'
 import { registerStatsHandlers } from './stats'
 import { registerRateLimitHandlers } from './rate-limits'
 import { registerRuntimeHandlers } from './runtime'
@@ -61,6 +62,7 @@ export function registerCoreHandlers(
   registerCodexAccountHandlers(codexAccounts)
   registerRateLimitHandlers(rateLimits)
   registerGitHubHandlers(store, stats)
+  registerFeedbackHandlers()
   registerStatsHandlers(stats)
   registerNotificationHandlers(store)
   registerSettingsHandlers(store)

--- a/src/preload/api-types.d.ts
+++ b/src/preload/api-types.d.ts
@@ -312,6 +312,13 @@ export type PreloadApi = {
     onExit: (callback: (data: { id: string; code: number }) => void) => () => void
     onOpenCodeStatus: (callback: (event: OpenCodeStatusEvent) => void) => () => void
   }
+  feedback: {
+    submit: (args: {
+      feedback: string
+      githubLogin: string | null
+      githubEmail: string | null
+    }) => Promise<{ ok: true } | { ok: false; status: number | null; error: string }>
+  }
   gh: {
     viewer: () => Promise<GitHubViewer | null>
     repoSlug: (args: { repoPath: string }) => Promise<{ owner: string; repo: string } | null>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -326,6 +326,15 @@ const api = {
     }
   },
 
+  feedback: {
+    submit: (args: {
+      feedback: string
+      githubLogin: string | null
+      githubEmail: string | null
+    }): Promise<{ ok: true } | { ok: false; status: number | null; error: string }> =>
+      ipcRenderer.invoke('feedback:submit', args)
+  },
+
   gh: {
     viewer: (): Promise<unknown> => ipcRenderer.invoke('gh:viewer'),
 

--- a/src/renderer/src/components/sidebar/SidebarToolbar.tsx
+++ b/src/renderer/src/components/sidebar/SidebarToolbar.tsx
@@ -18,8 +18,6 @@ import type { GitHubViewer } from '../../../../shared/types'
 const GITHUB_ISSUES_URL = 'https://github.com/stablyai/orca/issues/'
 const DISCORD_URL = 'https://discord.gg/fzjDKHxv8Q'
 const X_URL = 'https://x.com/orca_build'
-const FEEDBACK_API_URL = 'https://api.onorca.dev/v1/feedback'
-const FEEDBACK_API_FALLBACK_URL = 'https://www.onorca.dev/v1/feedback'
 
 type SubmitIdentity = {
   githubLogin: string | null
@@ -41,37 +39,6 @@ function getSubmitIdentity(viewer: GitHubViewer | null, anonymous: boolean): Sub
   return {
     githubLogin: viewer.login,
     githubEmail: viewer.email
-  }
-}
-
-async function submitFeedback(body: {
-  feedback: string
-  githubLogin: string | null
-  githubEmail: string | null
-}): Promise<Response> {
-  try {
-    return await fetch(FEEDBACK_API_URL, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body)
-    })
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error)
-    // Why: DNS for the dedicated api.onorca.dev host can lag behind a deploy.
-    // Falling back to the verified website-hosted versioned endpoint keeps
-    // feedback submission working instead of forcing users to wait on DNS.
-    if (
-      message.includes('ERR_NAME_NOT_RESOLVED') ||
-      message.includes('ENOTFOUND') ||
-      message.includes('Failed to fetch')
-    ) {
-      return fetch(FEEDBACK_API_FALLBACK_URL, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body)
-      })
-    }
-    throw error
   }
 }
 
@@ -129,17 +96,19 @@ function FeedbackDialog({
     setIsSubmitting(true)
     try {
       const identity = getSubmitIdentity(viewer, submitAnonymously)
-      const response = await submitFeedback({
-        // Why: showing the exact GitHub identity in the dialog makes the
-        // default attribution explicit, and this flag lets users opt out
-        // without having to disconnect gh for the rest of Orca.
+      // Why: submission is proxied through the main process via IPC because
+      // the packaged Mac build loads the renderer from file://, which makes
+      // cross-origin fetch() fail CORS preflight. Electron's net module in
+      // the main process has no CORS restrictions and works uniformly in dev
+      // and prod.
+      const result = await window.api.feedback.submit({
         feedback: trimmed,
         githubLogin: identity.githubLogin,
         githubEmail: identity.githubEmail
       })
 
-      if (!response.ok) {
-        throw new Error(`Feedback request failed with status ${response.status}`)
+      if (!result.ok) {
+        throw new Error(`Feedback request failed: ${result.error}`)
       }
 
       toast.success('Thanks for the feedback.')


### PR DESCRIPTION
## Summary
- Packaged Mac build loads the renderer from `file://`, so a renderer `fetch()` POST to `api.onorca.dev` fails CORS preflight — producing *"Failed to submit feedback"*. Dev (`http://localhost`) worked because it's a normal HTTP origin.
- Moved submission into the main process via a new `feedback:submit` IPC handler that uses Electron's `net.fetch` (no CORS restrictions), mirroring the existing pattern in `updater-changelog.ts` and `updater-nudge.ts`.
- Renderer now calls `window.api.feedback.submit(...)`; primary/fallback URL logic lives in `src/main/ipc/feedback.ts`.

## Test plan
- [x] `pnpm typecheck:node` / `typecheck:web` / `typecheck:cli` clean
- [x] `pnpm test` (2108 passed)
- [ ] Manual: submit feedback from a packaged Mac build and confirm success toast.
- [ ] Manual: submit feedback in `pn dev` and confirm no regression.