### PR TITLE
fix(sidebar): make left sidebar expand/collapse instant

### DIFF
--- a/src/renderer/src/components/sidebar/index.tsx
+++ b/src/renderer/src/components/sidebar/index.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect } from 'react'
 import { useAppStore } from '@/store'
-import { cn } from '@/lib/utils'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import { useSidebarResize } from '@/hooks/useSidebarResize'
 import SidebarHeader from './SidebarHeader'
@@ -33,7 +32,7 @@ function Sidebar(): React.JSX.Element {
     }
   }, [repoCount, fetchAllWorktrees])
 
-  const { containerRef, isResizing, onResizeStart } = useSidebarResize<HTMLDivElement>({
+  const { containerRef, onResizeStart } = useSidebarResize<HTMLDivElement>({
     isOpen: sidebarOpen,
     width: sidebarWidth,
     minWidth: MIN_WIDTH,
@@ -46,10 +45,7 @@ function Sidebar(): React.JSX.Element {
     <TooltipProvider delayDuration={400}>
       <div
         ref={containerRef}
-        className={cn(
-          'relative min-h-0 flex-shrink-0 bg-sidebar flex flex-col overflow-hidden scrollbar-sleek-parent',
-          isResizing ? 'transition-none' : 'transition-[width] duration-200'
-        )}
+        className="relative min-h-0 flex-shrink-0 bg-sidebar flex flex-col overflow-hidden scrollbar-sleek-parent"
       >
         {/* Fixed controls */}
         <SidebarNav />


### PR DESCRIPTION
## Summary
- Remove the 200ms `transition-[width]` on the left sidebar container so expand/collapse snaps instantly
- Drop the now-unused `isResizing` destructure and `cn` import

## Test plan
- [ ] Toggle left sidebar open/closed — width changes instantly, no animation
- [ ] Drag the sidebar resize handle — still smooth and tracks the pointer