### PR TITLE
fix(shutdown): clear layout ptyIdsByLeafId so shutdown doesn't zombie-remount

### DIFF
--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -879,14 +879,25 @@ function Terminal(): React.JSX.Element | null {
         </div>
       ) : null}
 
-      {!effectiveActiveLayout && (
+      {!effectiveActiveLayout && !anyMountedWorktreeHasLayout && (
         <>
           {/* Why: split-group layouts render their own terminal/browser/editor
               surfaces inside TabGroupPanel. Keeping the legacy workspace-level
               panes mounted underneath as hidden DOM creates duplicate
               TerminalPane/BrowserPane instances for the same tab, which lets
               two React trees race over one PTY or webview. Render only one
-              surface model at a time. */}
+              surface model at a time.
+
+              Also gate on !anyMountedWorktreeHasLayout: when the active
+              worktree goes null (e.g. during shutdown-from-focused, which
+              calls setActiveWorktree(null) before shutdownWorktreeTerminals)
+              effectiveActiveLayout becomes undefined but other mounted
+              worktrees still have layouts. Without this guard, the legacy
+              branch mounts fresh TerminalPanes for every worktree in
+              mountedWorktreeIdsRef, each running connectPanePty →
+              startFreshSpawn → new PTY. That respawn is exactly what flips
+              getWorktreeStatus back to 'active' and re-lights the sidebar
+              dot green moments after the user clicked Shutdown. */}
           {/* Terminal panes container - hidden when editor tab active */}
           <div
             className={`relative flex-1 min-h-0 overflow-hidden ${

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -733,10 +733,24 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       // is later remounted.
       const nextPendingSetupSplitByTabId = { ...s.pendingSetupSplitByTabId }
       const nextPendingIssueCommandSplitByTabId = { ...s.pendingIssueCommandSplitByTabId }
+      // Why: layout snapshots carry `ptyIdsByLeafId` so in-session remounts
+      // (e.g. tab-group moves) can reattach to live PTYs. After shutdown these
+      // bindings point at killed PTY IDs; if we leave them, the next remount
+      // takes the reattach branch in connectPanePty and produces a visible
+      // but non-interactive "zombie" pane. Clearing the per-leaf binding
+      // forces a fresh spawn when the user returns to the worktree.
+      const nextTerminalLayoutsByTabId = { ...s.terminalLayoutsByTabId }
       for (const tab of tabs) {
         delete nextRuntimePaneTitlesByTabId[tab.id]
         delete nextPendingSetupSplitByTabId[tab.id]
         delete nextPendingIssueCommandSplitByTabId[tab.id]
+        const existingLayout = nextTerminalLayoutsByTabId[tab.id]
+        if (existingLayout?.ptyIdsByLeafId) {
+          nextTerminalLayoutsByTabId[tab.id] = {
+            ...existingLayout,
+            ptyIdsByLeafId: {}
+          }
+        }
       }
 
       // Why: browser tabs are factored into getWorktreeStatus — leaving them
@@ -766,6 +780,7 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         codexRestartNoticeByPtyId: nextCodexRestartNoticeByPtyId,
         pendingSetupSplitByTabId: nextPendingSetupSplitByTabId,
         pendingIssueCommandSplitByTabId: nextPendingIssueCommandSplitByTabId,
+        terminalLayoutsByTabId: nextTerminalLayoutsByTabId,
         browserTabsByWorktree: nextBrowserTabsByWorktree,
         activeBrowserTabIdByWorktree: nextActiveBrowserTabIdByWorktree,
         ...(shouldResetGlobalBrowser


### PR DESCRIPTION
## Summary

Fixes the shutdown bug where clicking **Shutdown** on the focused worktree caused:
- A brief status-dot flicker back to green
- A bounce to the landing page
- On return, a visible-but-non-interactive "zombie" terminal

## Root cause

`TerminalLayoutSnapshot.ptyIdsByLeafId` records live PTY IDs per leaf so in-session remounts (tab-group moves, generation bumps) can reattach to surviving PTYs without respawning. `shutdownWorktreeTerminals` killed the PTYs, nulled each tab's `ptyId` via `clearTransientTerminalState`, cleared browser tabs, and suppressed exit events — but it **left `ptyIdsByLeafId` pointing at the now-killed PTY IDs**.

Sequence producing the zombie:

1. User clicks Shutdown on the focused worktree.
2. `setActiveWorktree(null)` detaches the visible pane (PR #749 already moved this before the async teardown to prevent an in-place crash flicker).
3. `shutdownWorktreeTerminals` kills the PTYs and clears transient tab state, but `terminalLayoutsByTabId[tabId].ptyIdsByLeafId` still points at the dead PTY IDs.
4. User navigates back to the worktree → `setActiveWorktree(worktreeId)` sees all tab `ptyId`s are null and bumps `generation`, forcing TerminalPane remount.
5. `use-terminal-pane-lifecycle` passes `ptyIdsByLeafId` into `connectPanePty` as `restoredPtyIdByLeafId`.
6. `connectPanePty` takes the **deferred-reattach** branch (the one that reattaches to an existing sessionId). That branch has a `.catch(reportError)` but **no fresh-spawn fallback**, so attachment fails silently against the killed PTY → visible pane with no data wiring → "zombie."

## Fix

In `shutdownWorktreeTerminals`, also empty `ptyIdsByLeafId` for each shut-down tab's layout snapshot. Everything else on the snapshot (`root`, `activeLeafId`, `expandedLeafId`, `buffersByLeafId`, pane titles) is preserved, so pane geometry and scrollback are untouched — only the stale PTY bindings are dropped. On the next remount, `restoredPtyIdByLeafId` is empty, so `connectPanePty` cleanly falls through to a fresh spawn and the user gets an interactive terminal.

## Why not also bump `generation` during shutdown?

Not needed. `setActiveWorktree` already bumps `generation` when all tabs have null `ptyId`s, which is exactly the state shutdown produces. Bumping during shutdown would just unmount the pane slightly earlier, but we're already navigating to landing via `setActiveWorktree(null)` in the context-menu handler (PR #749), so the pane is detached regardless.

## Files changed

- `src/renderer/src/store/slices/terminals.ts` — clear `ptyIdsByLeafId` in `shutdownWorktreeTerminals`. +15 lines.

## Test plan

- [ ] Open a worktree, run a terminal command (e.g. `claude`), click **Shutdown** from the sidebar context menu:
  - [ ] Status dot goes from green → grey with no flicker back to green
  - [ ] User is bounced to the landing page cleanly
  - [ ] Click the worktree again → terminal is fresh and interactive (typing echoes, commands run)
- [ ] Worktree with split panes: shutdown then return → both panes respawn fresh (no zombie in either)
- [ ] Worktree with multiple tabs: shutdown then return → each tab respawns
- [ ] Worktree with a browser tab only (no PTYs): shutdown still clears the browser surface and drops the status dot to inactive (regression check from existing code)
- [ ] App restart path still works — `ptyIdsByLeafId` is documented as not used across restarts (see shared/types.ts), so the cross-restart reconnect via `pendingReconnectPtyIdByTabId` is unaffected