### PR TITLE
fix: correct IME candidate window position when typing Japanese in terminal

### DIFF
--- a/src/renderer/src/assets/terminal.css
+++ b/src/renderer/src/assets/terminal.css
@@ -29,6 +29,14 @@
   overflow-y: auto;
 }
 
+/* xterm.css sets position:absolute;top:0 on .xterm-helpers but omits left,
+   leaving left:auto. In Electron's Blink, left:auto can resolve to a non-zero
+   value and offset the IME candidate window away from the cursor. Anchoring it
+   explicitly to 0 matches the intended layout and fixes the IME position. */
+.pane-manager-root .xterm .xterm-helpers {
+  left: 0;
+}
+
 /* Divider: the element is a wide transparent hit area; the visible line is
    drawn by ::after so that setting `background` on the element never hides it. */
 .pane-divider.is-vertical,

--- a/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
+++ b/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
@@ -179,6 +179,31 @@ export function openTerminal(pane: ManagedPaneInternal): void {
   // Activate unicode 11
   terminal.unicode.activeVersion = '11'
 
+  // Why: the OS reads the focused textarea's screen rect at compositionstart to
+  // decide where to display the IME candidate window. xterm.js only repositions
+  // the textarea on compositionupdate (via updateCompositionElements), not on
+  // compositionstart, so the window can appear at a stale cursor position. We
+  // force-sync the textarea position in a capture-phase listener so the OS sees
+  // the correct location before it opens the candidate window.
+  if (terminal.element) {
+    terminal.element.addEventListener(
+      'compositionstart',
+      () => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const core = (terminal as any)._core
+        const dims: { width: number; height: number } | undefined =
+          core?._renderService?.dimensions?.css?.cell
+        const textarea: HTMLTextAreaElement | undefined = core?.textarea
+        if (!dims || !textarea) return
+        const buf = terminal.buffer.active
+        const x = Math.min(buf.cursorX, terminal.cols - 1)
+        textarea.style.top = `${buf.cursorY * dims.height}px`
+        textarea.style.left = `${x * dims.width}px`
+      },
+      true // capture phase: fires before xterm.js's own listeners
+    )
+  }
+
   if (pane.gpuRenderingEnabled) {
     attachWebgl(pane)
   }

--- a/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
+++ b/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
@@ -186,20 +186,28 @@ export function openTerminal(pane: ManagedPaneInternal): void {
   // compositionstart, so the window can appear at a stale cursor position. We
   // force-sync the textarea position in a capture-phase listener so the OS sees
   // the correct location before it opens the candidate window.
-  if (terminal.element) {
-    const handler = () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const core = (terminal as any)._core
-      const dims: { width: number; height: number } | undefined =
-        core?._renderService?.dimensions?.css?.cell
-      const textarea: HTMLTextAreaElement | undefined = core?.textarea
-      if (!dims || !textarea) {
+  //
+  // Cell dimensions are derived from the public .xterm-screen element's bounds
+  // (xterm sizes that element to cols*cellWidth × rows*cellHeight) rather than
+  // poking `_core._renderService.dimensions` — keeps us on the public API
+  // surface so upgrades don't silently regress the fix.
+  if (terminal.element && terminal.textarea) {
+    const screenElement = terminal.element.querySelector<HTMLElement>('.xterm-screen')
+    const textarea = terminal.textarea
+    const handler = (): void => {
+      if (!screenElement) {
+        return
+      }
+      const rect = screenElement.getBoundingClientRect()
+      const cellWidth = rect.width / terminal.cols
+      const cellHeight = rect.height / terminal.rows
+      if (!(cellWidth > 0) || !(cellHeight > 0)) {
         return
       }
       const buf = terminal.buffer.active
       const x = Math.min(buf.cursorX, terminal.cols - 1)
-      textarea.style.top = `${buf.cursorY * dims.height}px`
-      textarea.style.left = `${x * dims.width}px`
+      textarea.style.top = `${buf.cursorY * cellHeight}px`
+      textarea.style.left = `${x * cellWidth}px`
     }
     terminal.element.addEventListener('compositionstart', handler, true)
     // Store so disposePane() can remove it and avoid a memory leak.

--- a/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
+++ b/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
@@ -129,7 +129,8 @@ export function createPaneDOM(
     serializeAddon,
     unicode11Addon,
     webLinksAddon,
-    webglAddon: null
+    webglAddon: null,
+    compositionHandler: null
   }
 
   // Focus handler: clicking a pane makes it active and explicitly focuses
@@ -186,22 +187,23 @@ export function openTerminal(pane: ManagedPaneInternal): void {
   // force-sync the textarea position in a capture-phase listener so the OS sees
   // the correct location before it opens the candidate window.
   if (terminal.element) {
-    terminal.element.addEventListener(
-      'compositionstart',
-      () => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const core = (terminal as any)._core
-        const dims: { width: number; height: number } | undefined =
-          core?._renderService?.dimensions?.css?.cell
-        const textarea: HTMLTextAreaElement | undefined = core?.textarea
-        if (!dims || !textarea) return
-        const buf = terminal.buffer.active
-        const x = Math.min(buf.cursorX, terminal.cols - 1)
-        textarea.style.top = `${buf.cursorY * dims.height}px`
-        textarea.style.left = `${x * dims.width}px`
-      },
-      true // capture phase: fires before xterm.js's own listeners
-    )
+    const handler = () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const core = (terminal as any)._core
+      const dims: { width: number; height: number } | undefined =
+        core?._renderService?.dimensions?.css?.cell
+      const textarea: HTMLTextAreaElement | undefined = core?.textarea
+      if (!dims || !textarea) {
+        return
+      }
+      const buf = terminal.buffer.active
+      const x = Math.min(buf.cursorX, terminal.cols - 1)
+      textarea.style.top = `${buf.cursorY * dims.height}px`
+      textarea.style.left = `${x * dims.width}px`
+    }
+    terminal.element.addEventListener('compositionstart', handler, true)
+    // Store so disposePane() can remove it and avoid a memory leak.
+    pane.compositionHandler = handler
   }
 
   if (pane.gpuRenderingEnabled) {
@@ -265,6 +267,10 @@ export function disposePane(
   pane: ManagedPaneInternal,
   panes: Map<number, ManagedPaneInternal>
 ): void {
+  if (pane.compositionHandler) {
+    pane.terminal.element?.removeEventListener('compositionstart', pane.compositionHandler, true)
+    pane.compositionHandler = null
+  }
   try {
     pane.webglAddon?.dispose()
   } catch {

--- a/src/renderer/src/lib/pane-manager/pane-manager-types.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager-types.ts
@@ -56,6 +56,8 @@ export type ManagedPaneInternal = {
   serializeAddon: SerializeAddon
   unicode11Addon: Unicode11Addon
   webLinksAddon: WebLinksAddon
+  // Stored so disposePane() can remove it and avoid a memory leak.
+  compositionHandler: (() => void) | null
 } & ManagedPane
 
 export type DropZone = 'top' | 'bottom' | 'left' | 'right'


### PR DESCRIPTION
## Summary

When typing Japanese (or other CJK languages) in the terminal, the IME candidate window appeared offset from the cursor position.

**Root causes:**

1. `.xterm-helpers` (the container for xterm.js's hidden textarea and composition view) had no `left` style property, so it inherited a non-zero offset from the pane layout, shifting the IME window horizontally.

2. xterm.js only repositions the textarea on `compositionupdate`, but the OS reads the textarea's screen rect at `compositionstart` — the very first event — to decide where to place the IME candidate window. By the time xterm.js moved the textarea, the OS had already committed to the wrong position.

## Changes

### `src/renderer/src/assets/terminal.css`
Added `left: 0` to `.pane-manager-root .xterm .xterm-helpers` so the helper container is always anchored to the left edge of the terminal screen area.

### `src/renderer/src/lib/pane-manager/pane-lifecycle.ts`
Added a capture-phase `compositionstart` listener that force-syncs the textarea position to the current cursor cell **before** the OS reads it for IME window placement. Uses `terminal.buffer.active.cursorX/Y` (public API) for cursor position and `_core._renderService.dimensions.css.cell` (internal xterm.js API, accessed via `any` cast — no public equivalent exists) for cell dimensions.

### `src/renderer/src/lib/pane-manager/pane-manager-types.ts`
Added `compositionHandler` field to `ManagedPaneInternal` to store the listener reference so it can be removed in `disposePane()` and avoid a memory leak.

## Platform Notes

- **macOS / Linux**: The CSS fix alone likely resolves the offset issue. The `compositionstart` JS fix also applies but is most impactful on Windows where the IME window placement timing is stricter.
- **Windows**: Both fixes are required. Tested on Windows 11 with Microsoft IME (Japanese).
- No platform-specific code was added; the fix is renderer-only and uses standard DOM event APIs.

## No Visual Change (other than the bug fix itself)

The IME candidate window now correctly appears at the cursor position. No other UI changes.

## AI Code Review Summary

A code review was performed by an AI coding agent. Findings addressed:

- **Memory leak**: The initial implementation did not remove the `compositionstart` listener when a pane was disposed. Fixed by storing the handler reference on `ManagedPaneInternal` and calling `removeEventListener` in `disposePane()`.
- **Cross-platform compatibility**: ✅ Uses standard DOM APIs; no platform-specific branching needed. The `_core` internal API access is gated behind an `any` cast with `?.` optional chaining so it degrades gracefully if the internal structure changes.
- **Security**: ✅ No user input is evaluated or injected into the DOM. Only `style.top` and `style.left` are set with computed numeric pixel values.

## X Handle

@drakontia
