### PR TITLE
fix(terminal-host): avoid reattach to terminating session, force-kill on dispose

### DIFF
--- a/src/main/daemon/session.ts
+++ b/src/main/daemon/session.ts
@@ -178,6 +178,21 @@ export class Session {
     if (this._disposed) {
       return
     }
+
+    // Why: if kill() was called but the subprocess hasn't exited yet, our
+    // killTimer is the only thing that would forceKill a stuck subprocess.
+    // Clearing it below without force-killing would leak an orphaned process,
+    // so mirror forceDispose(): issue the force-kill, notify attached clients
+    // (handleSubprocessExit is guarded by _disposed and won't broadcast later),
+    // and clear the terminating flag for a consistent final state.
+    const wasTerminating = this._isTerminating && this._state !== 'exited'
+    const clientsToNotify = wasTerminating ? this.attachedClients.slice() : []
+    if (wasTerminating) {
+      this.subprocess.forceKill()
+      this._exitCode = -1
+      this._isTerminating = false
+    }
+
     this._disposed = true
     this._state = 'exited'
 
@@ -193,6 +208,10 @@ export class Session {
     this.attachedClients = []
     this.preReadyStdinQueue = []
     this.emulator.dispose()
+
+    for (const client of clientsToNotify) {
+      client.onExit(-1)
+    }
   }
 
   private handleSubprocessData(data: string): void {

--- a/src/main/daemon/terminal-host.ts
+++ b/src/main/daemon/terminal-host.ts
@@ -46,7 +46,12 @@ export class TerminalHost {
   async createOrAttach(opts: CreateOrAttachOptions): Promise<CreateOrAttachResult> {
     const existing = this.sessions.get(opts.sessionId)
 
-    if (existing && existing.isAlive) {
+    // Why: a session that has been asked to terminate (kill() called but the
+    // subprocess hasn't exited yet) must not be reattached. Reattaching would
+    // hand the caller a handle that races with the in-flight exit, and any
+    // subsequent operation (write/kill/resize) would fail once the subprocess
+    // finally exits. Treat terminating sessions the same as fully-exited ones.
+    if (existing && existing.isAlive && !existing.isTerminating) {
       const snapshot = existing.getSnapshot()
       existing.detachAllClients()
       const token = existing.attachClient(opts.streamClient)


### PR DESCRIPTION
## Problem

When a user calls `createOrAttach` on a session where `kill()` has been called but the subprocess hasn't exited yet (terminating state), the old code would reattach a new client to a handle that races with the in-flight exit. Any subsequent operation (write/kill/resize) would fail once the subprocess finally exits.

Additionally, when such a terminating session fell through to cleanup via `Session.dispose()`, the killTimer (which would force-kill a stuck subprocess) was cleared without force-killing. This would leak an orphaned process if the subprocess ignored the soft SIGTERM kill.

## Solution

**Terminal-host**: Add `!existing.isTerminating` guard to the reattach condition. Treat terminating sessions the same as fully-exited ones — don't reattach.

**Session**: In `dispose()`, detect the terminating-but-not-exited state and force-kill the subprocess before clearing the timer. Mirror `forceDispose()` behavior by:
- Calling `subprocess.forceKill()` and setting `_exitCode = -1`
- Clearing the `_isTerminating` flag for consistent final state
- Notifying attached clients with `onExit(-1)` before detaching them, since the late `handleSubprocessExit` callback will no-op due to `_disposed` guard
