### PR TITLE
fix(terminal): prevent WebGL context leak and atomic generation bump

### DIFF
--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.ts
@@ -34,7 +34,14 @@ export function useTerminalPaneGlobalEffects({
   isVisibleRef,
   toggleExpandPane
 }: UseTerminalPaneGlobalEffectsArgs): void {
-  const wasVisibleRef = useRef(false)
+  // Why: starts as `true` so the first render with isVisible=false triggers
+  // suspendRendering(). Without this, background worktrees that mount hidden
+  // (isVisible=false from the start) never suspend their WebGL contexts —
+  // openTerminal() unconditionally creates a WebGL addon, but this effect
+  // only suspends on true→false transitions. The leaked contexts exhaust
+  // Chromium's ~8-context budget, causing "webglcontextlost" on visible
+  // terminals and making them unresponsive.
+  const wasVisibleRef = useRef(true)
 
   // Why: tracks any in-progress chunked pending-write flush so the cleanup
   // function can cancel it if the pane deactivates mid-flush.

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -529,6 +529,27 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       // side-effects limited to unread clearing; true activity signals such as
       // PTY lifecycle and explicit edits still flow through bumpWorktreeActivity.
       const metaUpdates: Partial<WorktreeMeta> = shouldClearUnread ? { isUnread: false } : {}
+
+      // Why: the generation bump for dead-PTY tabs MUST happen in the same
+      // set() as the activation. Two separate set() calls let React/Zustand
+      // render the old (dead-transport) TerminalPane as visible for one frame
+      // before the generation bump unmounts it — that intermediate render
+      // resumes the pane with a transport stuck at connected=false/ptyId=null,
+      // and user input is silently dropped.
+      const tabs = s.tabsByWorktree[worktreeId ?? ''] ?? []
+      const allDead = worktreeId && tabs.length > 0 && tabs.every((tab) => !tab.ptyId)
+      const tabsByWorktreeUpdate = allDead
+        ? {
+            tabsByWorktree: {
+              ...s.tabsByWorktree,
+              [worktreeId!]: tabs.map((tab) => ({
+                ...tab,
+                generation: (tab.generation ?? 0) + 1
+              }))
+            }
+          }
+        : {}
+
       return {
         activeWorktreeId: worktreeId,
         activeFileId,
@@ -538,27 +559,10 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
         activeTabId,
         ...(shouldClearUnread
           ? { worktreesByRepo: applyWorktreeUpdates(s.worktreesByRepo, worktreeId, metaUpdates) }
-          : {})
+          : {}),
+        ...tabsByWorktreeUpdate
       }
     })
-
-    // If the worktree has tabs but all PTYs are dead (e.g. after shutdown),
-    // bump generation so TerminalPanes remount with fresh PTY connections.
-    if (worktreeId) {
-      const tabs = get().tabsByWorktree[worktreeId] ?? []
-      const allDead = tabs.length > 0 && tabs.every((tab) => !tab.ptyId)
-      if (allDead) {
-        set((s) => ({
-          tabsByWorktree: {
-            ...s.tabsByWorktree,
-            [worktreeId]: (s.tabsByWorktree[worktreeId] ?? []).map((tab) => ({
-              ...tab,
-              generation: (tab.generation ?? 0) + 1
-            }))
-          }
-        }))
-      }
-    }
 
     // Why: force-refreshing GitHub data on every switch burned API rate limit
     // quota and added 200-800ms latency. Only refresh when cache is actually


### PR DESCRIPTION
## Summary
- **WebGL context leak**: background worktrees that mount hidden (`isVisible=false`) never called `suspendRendering()` because `wasVisibleRef` started as `false` — the effect only suspends on `true→false` transitions. Each hidden mount leaked a GPU context until Chromium's ~8-context budget was exhausted, causing `webglcontextlost` on visible terminals and making them unresponsive. Fix: initialize `wasVisibleRef` to `true` so the first hidden render triggers suspend.
- **Two-`set()` race in `setActiveWorktree`**: the activation and generation bump were separate `set()` calls, allowing React/Zustand to render the old dead-transport pane as visible for one frame before remounting. That intermediate render left the transport at `connected=false` with no `ptyId`, silently dropping user input. Fix: merge both updates into a single atomic `set()` call.

## Context
Follow-up to #797 and #801 which addressed related terminal unresponsiveness paths. The WebGL leak was confirmed via production console logs showing `webglcontextlost`, `INVALID_OPERATION: delete: object does not belong to this context`, and `webgl context not restored; firing onContextLoss`. The transport race was confirmed via diagnostic logging showing `sendInput dropped: connected=false, ptyId=null, destroyed=false`.

## Test plan
- [ ] Open 5+ worktrees, switch between them repeatedly — no `webglcontextlost` errors in DevTools console
- [ ] Shut down a worktree with an active terminal, click back into it — terminal should be responsive
- [ ] Soak test: use the app normally for an extended session — terminals should remain responsive