### PR TITLE
fix(sidebar): keep resize stable when dragging over PDF viewer

### DIFF
--- a/src/renderer/src/hooks/useSidebarResize.ts
+++ b/src/renderer/src/hooks/useSidebarResize.ts
@@ -62,12 +62,22 @@ export function useSidebarResize<T extends HTMLElement>({
   const startWidthRef = useRef(width)
   const draftWidthRef = useRef(width)
   const frameRef = useRef<number | null>(null)
+  const overlayRef = useRef<HTMLDivElement | null>(null)
   const [isResizing, setIsResizing] = useState(false)
+
+  const removeDragOverlay = useCallback(() => {
+    const overlay = overlayRef.current
+    if (overlay && overlay.parentNode) {
+      overlay.parentNode.removeChild(overlay)
+    }
+    overlayRef.current = null
+  }, [])
 
   const resetDocumentStyles = useCallback(() => {
     document.body.style.cursor = ''
     document.body.style.userSelect = ''
-  }, [])
+    removeDragOverlay()
+  }, [removeDragOverlay])
 
   const applyRenderedWidth = useCallback(
     (nextWidth: number) => {
@@ -177,6 +187,23 @@ export function useSidebarResize<T extends HTMLElement>({
       draftWidthRef.current = width
       document.body.style.cursor = 'col-resize'
       document.body.style.userSelect = 'none'
+
+      // Why: native plugins like Chromium's PDF <embed> capture pointer events
+      // internally, so dragging across them swallows the `mouseup` on the
+      // window and the resize never stops — the sidebar ends up following the
+      // cursor indefinitely. A full-viewport transparent overlay above all
+      // content keeps mouse events flowing to the window listeners for the
+      // duration of the drag.
+      if (!overlayRef.current) {
+        const overlay = document.createElement('div')
+        overlay.style.position = 'fixed'
+        overlay.style.inset = '0'
+        overlay.style.zIndex = '2147483647'
+        overlay.style.cursor = 'col-resize'
+        overlay.style.background = 'transparent'
+        document.body.appendChild(overlay)
+        overlayRef.current = overlay
+      }
     },
     [width]
   )


### PR DESCRIPTION
## Summary
- Sidebar resize handle kept following the cursor when a PDF viewer tab was active because Chromium's native PDF `<embed>` captures pointer events internally and the `mouseup` never reaches the window.
- Fix: mount a full-viewport transparent overlay during drag (`src/renderer/src/hooks/useSidebarResize.ts`), so mouse events propagate to the window listeners and `stopResize` fires as expected.
- Behavior is unchanged for other tabs (terminal, editor) since the overlay is only present mid-drag.

## Test plan
- [x] `pnpm exec vitest run src/renderer/src/hooks/useSidebarResize.test.ts` (5/5 pass)
- [x] `pnpm exec tsc --noEmit`
- [ ] Manual: open a PDF tab, drag left/right sidebar resize handle across it, release mouse — resize stops on mouseup, does not follow cursor.
- [ ] Manual: verify terminal and editor tabs still resize normally.