### PR TITLE
ci(release): retry electron install/publish on transient CDN failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,8 +102,17 @@ jobs:
         with:
           run_install: false
 
+      # Why: pnpm install triggers electron's postinstall, which downloads the
+      # Electron binary from GitHub release assets. GitHub's download CDN
+      # occasionally returns 504s that fail the whole release. Retry on
+      # failure so transient network errors don't require a manual re-run.
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: pnpm install --frozen-lockfile
 
       - name: Verify macOS signing environment
         if: matrix.platform == 'mac'
@@ -125,9 +134,20 @@ jobs:
       # be signed with an Apple cert whose chain Windows cannot validate,
       # breaking the auto-updater with "certificate chain could not be built
       # to a trusted root authority" (issue #631).
+      #
+      # Why retry: electron-builder downloads NSIS/winCodeSign/squirrel
+      # binaries and the Electron runtime from GitHub release assets during
+      # publish. GitHub's download CDN occasionally returns 504s that fail
+      # the whole release. Retry on failure so transient network errors
+      # don't require a manual re-run.
       - name: Publish release artifacts (macOS)
         if: matrix.platform == 'mac'
-        run: ${{ matrix.release_command }}
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 45
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: ${{ matrix.release_command }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CSC_LINK: ${{ secrets.MAC_CERTS }}
@@ -138,7 +158,12 @@ jobs:
 
       - name: Publish release artifacts
         if: matrix.platform != 'mac'
-        run: ${{ matrix.release_command }}
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 30
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: ${{ matrix.release_command }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Problem

Release workflows fail intermittently when GitHub's CDN returns 504 Service Unavailable errors during Electron binary and tooling downloads. These transient network errors force manual re-runs of the entire release pipeline.

## Solution

Wrap the dependency install and release-artifact publish steps with `nick-fields/retry@v3` action to automatically retry up to 3 times with 30-second backoff:
- Install dependencies: 3 retries with 10-minute timeout
- macOS publish: 3 retries with 45-minute timeout
- Linux/Windows publish: 3 retries with 30-minute timeout

This allows transient CDN errors to be recovered without manual intervention while preserving timeout safety for genuinely stuck builds.