### PR TITLE
fix: resolve Radix Dialog a11y warnings and duplicate React key

### DIFF
--- a/src/renderer/src/components/NewWorkspaceComposerModal.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerModal.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect } from 'react'
 import { useAppStore } from '@/store'
-import { Dialog, DialogContent } from '@/components/ui/dialog'
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog'
 import NewWorkspaceComposerCard from '@/components/NewWorkspaceComposerCard'
 import { useComposerState } from '@/hooks/useComposerState'
 import type { LinkedWorkItemSummary } from '@/lib/new-workspace'
@@ -122,6 +122,10 @@ function ComposerModalBody({
           promptTextareaRef.current?.focus()
         }}
       >
+        <DialogTitle className="sr-only">Create New Workspace</DialogTitle>
+        <DialogDescription className="sr-only">
+          Configure a name and prompt for the new workspace.
+        </DialogDescription>
         <NewWorkspaceComposerCard
           containerClassName="bg-card/98 shadow-2xl supports-[backdrop-filter]:bg-card/95"
           composerRef={composerRef}

--- a/src/renderer/src/components/editor/ImageViewer.tsx
+++ b/src/renderer/src/components/editor/ImageViewer.tsx
@@ -1,6 +1,6 @@
 import { Image as ImageIcon, RotateCcw, X, ZoomIn, ZoomOut } from 'lucide-react'
 import { type JSX, useEffect, useMemo, useState } from 'react'
-import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog'
 
 const FALLBACK_IMAGE_MIME_TYPE = 'image/png'
 const MIN_ZOOM = 0.25
@@ -191,6 +191,7 @@ export default function ImageViewer({
             className="top-1/2 left-1/2 h-[80vh] w-[70vw] max-w-[70vw] -translate-x-1/2 -translate-y-1/2 gap-0 overflow-hidden border border-border/60 bg-background p-0 shadow-2xl sm:max-w-[70vw]"
           >
             <DialogTitle className="sr-only">{filename}</DialogTitle>
+            <DialogDescription className="sr-only">Full-size image preview</DialogDescription>
             <div className="flex items-center justify-between border-b border-border/60 bg-background/95 px-3 py-2">
               <div className="min-w-0 truncate text-sm font-medium text-foreground">{filename}</div>
               <button

--- a/src/renderer/src/lib/agent-catalog.tsx
+++ b/src/renderer/src/lib/agent-catalog.tsx
@@ -173,13 +173,6 @@ export const AGENT_CATALOG: AgentCatalogEntry[] = [
     cmd: 'hermes',
     faviconDomain: 'nousresearch.com',
     homepageUrl: 'https://hermes-agent.nousresearch.com/docs/'
-  },
-  {
-    id: 'copilot',
-    label: 'GitHub Copilot',
-    cmd: 'copilot',
-    faviconDomain: 'github.com',
-    homepageUrl: 'https://docs.github.com/en/copilot/how-tos/set-up/install-copilot-cli'
   }
 ]
 


### PR DESCRIPTION
## Summary
- Add visually-hidden `DialogTitle` and `DialogDescription` to `NewWorkspaceComposerModal` and `ImageViewer` to fix Radix UI console warnings about missing accessible labels
- Remove duplicate `copilot` entry in `AGENT_CATALOG` that caused React's "two children with the same key" warning when opening the new workspace composer

## Test plan
- [ ] Open the new workspace composer modal (+ button) and confirm no console warnings about `DialogTitle`, `DialogDescription`, or `aria-describedby`
- [ ] Open an image file in the editor and click to open the popup — confirm no console warnings
- [ ] Verify the agent selector dropdown in the composer shows GitHub Copilot exactly once