### PR TITLE
fix(source-control): do not reset defaultBaseRef on worktree switch

### DIFF
--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -274,7 +274,13 @@ function SourceControlInner(): React.JSX.Element {
     setScope('all')
     setCollapsedSections(new Set())
     setBaseRefDialogOpen(false)
-    setDefaultBaseRef('origin/main')
+    // Why: do NOT reset defaultBaseRef here. It is repo-scoped, not
+    // worktree-scoped, and is resolved by the effect above on activeRepo
+    // change. Resetting it to a hard-coded 'origin/main' on every worktree
+    // switch within the same repo clobbered the correct value (e.g.
+    // 'origin/master' for repos whose default branch isn't main), causing
+    // a persistent "Branch compare unavailable" until the user switched
+    // repos and back to re-trigger the resolver.
     setFilterQuery('')
     setIsExecutingBulk(false)
   }, [activeWorktreeId])


### PR DESCRIPTION
## Problem
When switching between worktrees within the same repository, the source control sidebar showed a persistent "Branch compare unavailable" error if the repo's default branch wasn't `main` (e.g., repos with `master` as default).

## Solution
Removed the hardcoded `setDefaultBaseRef('origin/main')` from the worktree-switch reset effect. The defaultBaseRef resolver is repo-scoped (resolved once per repo), so resetting it on every worktree switch within the same repo clobbered the correct value. The resolver now works as intended: it initializes on first mount and only re-resolves when the active repo changes.

## Testing
- Manually tested in orca-internal worktree: branch compare now resolves correctly without the transient error
- Switching between worktrees in the same repo no longer resets the base ref to a stale value