### PR TITLE
fix(feedback): include app version + OS metadata in submissions

### DIFF
--- a/src/main/ipc/feedback.ts
+++ b/src/main/ipc/feedback.ts
@@ -1,4 +1,5 @@
-import { ipcMain, net } from 'electron'
+import os from 'node:os'
+import { app, ipcMain, net } from 'electron'
 
 // Why: the production Mac build loads the renderer from a file:// origin, so a
 // cross-origin POST from fetch() triggers a CORS preflight that the feedback
@@ -14,11 +15,33 @@ export type FeedbackSubmitArgs = {
   githubEmail: string | null
 }
 
+type FeedbackSubmitBody = FeedbackSubmitArgs & {
+  appVersion: string
+  platform: NodeJS.Platform
+  osRelease: string
+  arch: string
+}
+
 export type FeedbackSubmitResult =
   | { ok: true }
   | { ok: false; status: number | null; error: string }
 
-async function postFeedback(url: string, body: FeedbackSubmitArgs): Promise<Response> {
+// Why: the Slack notification and any follow-up investigation need to know
+// which Orca build and which OS the feedback came from. The main process is
+// the only place with trusted access to these values (app.getVersion and the
+// node os module), so we enrich the payload here rather than trusting the
+// renderer.
+function buildSubmitBody(args: FeedbackSubmitArgs): FeedbackSubmitBody {
+  return {
+    ...args,
+    appVersion: app.getVersion(),
+    platform: process.platform,
+    osRelease: os.release(),
+    arch: process.arch
+  }
+}
+
+async function postFeedback(url: string, body: FeedbackSubmitBody): Promise<Response> {
   return net.fetch(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -26,7 +49,8 @@ async function postFeedback(url: string, body: FeedbackSubmitArgs): Promise<Resp
   })
 }
 
-export async function submitFeedback(body: FeedbackSubmitArgs): Promise<FeedbackSubmitResult> {
+export async function submitFeedback(args: FeedbackSubmitArgs): Promise<FeedbackSubmitResult> {
+  const body = buildSubmitBody(args)
   try {
     const res = await postFeedback(FEEDBACK_API_URL, body)
     if (res.ok) {


### PR DESCRIPTION
## Summary
- Main process now enriches every feedback submission with `app.getVersion()`, `process.platform`, `os.release()`, and `process.arch` before posting to the feedback webhook.
- These values are injected trustingly in main since the renderer can't produce trustworthy build/OS metadata.
- Backend change in [orca-marketing-website#XX](https://github.com/stablyai/orca-marketing-website/pull/new/feat/feedback-submit-metadata) adds the fields to the Slack block; it tolerates missing fields so this can ship independently.

## Test plan
- [ ] Submit feedback from the desktop app and confirm the Slack message shows *Orca Version* and *OS*.
- [ ] Check the "Submit anonymously" path still works.
- [ ] Verify typecheck passes (`pnpm typecheck`).