### PR TITLE
feat(editor): open in-worktree .md links as preview edit tabs

### DIFF
--- a/src/renderer/src/assets/markdown-preview.css
+++ b/src/renderer/src/assets/markdown-preview.css
@@ -131,6 +131,7 @@
 /* Links use a proper blue instead of --primary (which is near-black/white and
    visually indistinguishable from body text). */
 .markdown-body a {
+  cursor: pointer !important;
   text-decoration: underline;
   text-decoration-color: color-mix(in srgb, currentColor 40%, transparent);
   text-underline-offset: 2px;

--- a/src/renderer/src/assets/rich-markdown-editor.css
+++ b/src/renderer/src/assets/rich-markdown-editor.css
@@ -484,11 +484,13 @@
   border-top: 1px solid var(--border);
 }
 
-.rich-markdown-editor a {
+.rich-markdown-editor a,
+.rich-markdown-editor .ProseMirror a {
   color: #0969da;
   text-decoration: underline;
   text-decoration-color: color-mix(in srgb, currentColor 40%, transparent);
   text-underline-offset: 2px;
+  cursor: pointer;
 }
 
 .dark .rich-markdown-editor a {

--- a/src/renderer/src/components/editor/EditorContent.tsx
+++ b/src/renderer/src/components/editor/EditorContent.tsx
@@ -176,6 +176,7 @@ export function EditorContent({
               fileId={activeFile.id}
               content={editorContent}
               filePath={activeFile.filePath}
+              worktreeId={activeFile.worktreeId}
               scrollCacheKey={`${editorViewStateKey}:rich`}
               onContentChange={onContentChangeWithFm}
               onDirtyStateHint={handleDirtyStateHint}
@@ -201,6 +202,7 @@ export function EditorContent({
               key={viewStateScopeId}
               content={currentContent}
               filePath={activeFile.filePath}
+              worktreeId={activeFile.worktreeId}
               scrollCacheKey={`${editorViewStateKey}:preview`}
             />
           </div>

--- a/src/renderer/src/components/editor/MarkdownPreview.tsx
+++ b/src/renderer/src/components/editor/MarkdownPreview.tsx
@@ -9,9 +9,11 @@ import type { Components } from 'react-markdown'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { useAppStore } from '@/store'
+import { toast } from 'sonner'
 import { computeEditorFontSize } from '@/lib/editor-font-zoom'
 import { scrollTopCache, setWithLRU } from '@/lib/scroll-cache'
 import { getMarkdownPreviewLinkTarget } from './markdown-preview-links'
+import { absolutePathToFileUri, resolveMarkdownLinkTarget } from './markdown-internal-links'
 import { useLocalImageSrc } from './useLocalImageSrc'
 import CodeBlockCopyButton from './CodeBlockCopyButton'
 import MermaidBlock from './MermaidBlock'
@@ -25,14 +27,27 @@ import {
 type MarkdownPreviewProps = {
   content: string
   filePath: string
+  worktreeId: string
   scrollCacheKey: string
 }
 
 export default function MarkdownPreview({
   content,
   filePath,
+  worktreeId,
   scrollCacheKey
 }: MarkdownPreviewProps): React.JSX.Element {
+  const activateMarkdownLink = useAppStore((s) => s.activateMarkdownLink)
+  const worktreeRoot = useAppStore((s) => {
+    for (const list of Object.values(s.worktreesByRepo)) {
+      const wt = list.find((w) => w.id === worktreeId)
+      if (wt) {
+        return wt.path
+      }
+    }
+    return null
+  })
+  const isMac = navigator.userAgent.includes('Mac')
   const rootRef = useRef<HTMLDivElement>(null)
   const bodyRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
@@ -240,30 +255,55 @@ export default function MarkdownPreview({
 
         event.preventDefault()
 
-        const target = getMarkdownPreviewLinkTarget(href, filePath)
-        if (!target) {
+        // Why: Cmd/Ctrl+Shift-click is the OS escape hatch — always hand the
+        // link to the system default handler, bypassing the classifier. For a
+        // dangling in-worktree .md, pre-check existence so the user sees a
+        // toast instead of the silent no-op from shell.openFileUri.
+        const modKey = isMac ? event.metaKey : event.ctrlKey
+        if (modKey && event.shiftKey) {
+          const osTarget = getMarkdownPreviewLinkTarget(href, filePath)
+          if (!osTarget) {
+            return
+          }
+          let parsed: URL
+          try {
+            parsed = new URL(osTarget)
+          } catch {
+            return
+          }
+          if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+            void window.api.shell.openUrl(parsed.toString())
+            return
+          }
+          if (parsed.protocol === 'file:') {
+            const classified = resolveMarkdownLinkTarget(href, filePath, worktreeRoot)
+            if (classified?.kind === 'markdown') {
+              // Why: use the classifier's stripped absolutePath (no `:line:col`
+              // or `#L10` suffix) so the OS handler receives a clean file URI.
+              const cleanUri = absolutePathToFileUri(classified.absolutePath)
+              void window.api.shell.pathExists(classified.absolutePath).then((exists) => {
+                if (!exists) {
+                  toast.error(`File not found: ${classified.relativePath}`)
+                  return
+                }
+                void window.api.shell.openFileUri(cleanUri)
+              })
+              return
+            }
+            void window.api.shell.openFileUri(parsed.toString())
+          }
           return
         }
 
-        let parsed: URL
-        try {
-          parsed = new URL(target)
-        } catch {
-          return
-        }
-
-        if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
-          void window.api.shell.openUrl(parsed.toString())
-          return
-        }
-
-        if (parsed.protocol === 'file:') {
-          void window.api.shell.openFileUri(parsed.toString())
-        }
+        void activateMarkdownLink(href, {
+          sourceFilePath: filePath,
+          worktreeId,
+          worktreeRoot
+        })
       }
 
       return (
-        <a {...props} href={href} onClick={handleClick}>
+        <a {...props} href={href} onClick={handleClick} style={{ cursor: 'pointer' }}>
           {children}
         </a>
       )

--- a/src/renderer/src/components/editor/RichMarkdownEditor.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownEditor.tsx
@@ -23,11 +23,17 @@ import { createRichMarkdownKeyHandler } from './rich-markdown-key-handler'
 import { normalizeSoftBreaks } from './rich-markdown-normalize'
 import { autoFocusRichEditor } from './rich-markdown-auto-focus'
 import { handleRichMarkdownCut } from './rich-markdown-cut-handler'
+import { toast } from 'sonner'
+import {
+  absolutePathToFileUri as toFileUrlForOsEscape,
+  resolveMarkdownLinkTarget
+} from './markdown-internal-links'
 
 type RichMarkdownEditorProps = {
   fileId: string
   content: string
   filePath: string
+  worktreeId: string
   scrollCacheKey: string
   onContentChange: (content: string) => void
   onDirtyStateHint: (dirty: boolean) => void
@@ -42,6 +48,7 @@ export default function RichMarkdownEditor({
   fileId,
   content,
   filePath,
+  worktreeId,
   scrollCacheKey,
   onContentChange,
   onDirtyStateHint,
@@ -49,6 +56,16 @@ export default function RichMarkdownEditor({
 }: RichMarkdownEditorProps): React.JSX.Element {
   const rootRef = useRef<HTMLDivElement | null>(null)
   const editorFontZoomLevel = useAppStore((s) => s.editorFontZoomLevel)
+  const activateMarkdownLink = useAppStore((s) => s.activateMarkdownLink)
+  const worktreeRoot = useAppStore((s) => {
+    for (const list of Object.values(s.worktreesByRepo)) {
+      const wt = list.find((w) => w.id === worktreeId)
+      if (wt) {
+        return wt.path
+      }
+    }
+    return null
+  })
   const scrollContainerRef = useRef<HTMLDivElement | null>(null)
   const [slashMenu, setSlashMenu] = useState<SlashMenuState | null>(null)
   const [selectedCommandIndex, setSelectedCommandIndex] = useState(0)
@@ -143,9 +160,11 @@ export default function RichMarkdownEditor({
         setSelectedCommandIndex,
         setSlashMenu
       }),
-      // Why: Cmd/Ctrl+click on a link opens it in the system browser, matching
-      // VS Code and other editor conventions. Without the modifier, clicks just
-      // position the cursor normally for editing.
+      // Why: Cmd/Ctrl-click activates links via the shared classifier +
+      // dispatcher, so in-worktree .md links open in an Orca tab instead of the
+      // OS default handler. Cmd/Ctrl+Shift-click is the OS escape hatch, kept
+      // symmetric with MarkdownPreview. Without a modifier the click falls
+      // through to TipTap's default cursor-positioning behavior.
       handleClick: (_view, _pos, event) => {
         const ed = editorRef.current
         if (!ed) {
@@ -154,10 +173,40 @@ export default function RichMarkdownEditor({
         const modKey = isMac ? event.metaKey : event.ctrlKey
         if (modKey && ed.isActive('link')) {
           const href = (ed.getAttributes('link').href as string) || ''
-          if (href) {
-            void window.api.shell.openUrl(href)
+          if (!href) {
+            return false
+          }
+          if (event.shiftKey) {
+            const classified = resolveMarkdownLinkTarget(href, filePath, worktreeRoot)
+            if (!classified) {
+              return true
+            }
+            if (classified.kind === 'external') {
+              void window.api.shell.openUrl(classified.url)
+              return true
+            }
+            if (classified.kind === 'markdown') {
+              void window.api.shell.pathExists(classified.absolutePath).then((exists) => {
+                if (!exists) {
+                  toast.error(`File not found: ${classified.relativePath}`)
+                  return
+                }
+                void window.api.shell.openFileUri(toFileUrlForOsEscape(classified.absolutePath))
+              })
+              return true
+            }
+            if (classified.kind === 'file') {
+              void window.api.shell.openFileUri(classified.uri)
+              return true
+            }
             return true
           }
+          void activateMarkdownLink(href, {
+            sourceFilePath: filePath,
+            worktreeId,
+            worktreeRoot
+          })
+          return true
         }
         return false
       }
@@ -294,7 +343,11 @@ export default function RichMarkdownEditor({
     handleLinkEditCancel,
     handleLinkOpen,
     toggleLinkFromToolbar
-  } = useLinkBubble(editor, rootRef, linkBubble, setLinkBubble, setIsEditingLink)
+  } = useLinkBubble(editor, rootRef, linkBubble, setLinkBubble, setIsEditingLink, {
+    sourceFilePath: filePath,
+    worktreeId,
+    worktreeRoot
+  })
 
   const {
     activeMatchIndex,

--- a/src/renderer/src/components/editor/markdown-internal-links.test.ts
+++ b/src/renderer/src/components/editor/markdown-internal-links.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest'
+import { resolveMarkdownLinkTarget } from './markdown-internal-links'
+
+// Tests run under happy-dom or similar; navigator.userAgent reflects the
+// test runner. The isDescendantOf containment check is therefore
+// case-insensitive on macOS/Windows runners and case-sensitive on Linux.
+// Most tests avoid case-differences so they pass on either host.
+
+const SOURCE = '/repo/docs/note.md'
+const ROOT = '/repo'
+
+describe('resolveMarkdownLinkTarget', () => {
+  it('classifies relative .md inside worktree as markdown', () => {
+    const r = resolveMarkdownLinkTarget('./guide.md', SOURCE, ROOT)
+    expect(r).toEqual({
+      kind: 'markdown',
+      absolutePath: '/repo/docs/guide.md',
+      relativePath: 'docs/guide.md'
+    })
+  })
+
+  it('classifies relative .md outside worktree as file', () => {
+    const r = resolveMarkdownLinkTarget('../../other/guide.md', SOURCE, ROOT)
+    expect(r?.kind).toBe('file')
+  })
+
+  it('classifies absolute .md inside worktree as markdown', () => {
+    const r = resolveMarkdownLinkTarget('/repo/docs/guide.md', SOURCE, ROOT)
+    expect(r?.kind).toBe('markdown')
+  })
+
+  it('extracts line from #L10', () => {
+    const r = resolveMarkdownLinkTarget('./guide.md#L10', SOURCE, ROOT)
+    expect(r).toMatchObject({ kind: 'markdown', line: 10, column: undefined })
+  })
+
+  it('extracts line+col from #L10C5', () => {
+    const r = resolveMarkdownLinkTarget('./guide.md#L10C5', SOURCE, ROOT)
+    expect(r).toMatchObject({ kind: 'markdown', line: 10, column: 5 })
+  })
+
+  it('extracts line+col from trailing :10:5 syntax', () => {
+    const r = resolveMarkdownLinkTarget('./guide.md:10:5', SOURCE, ROOT)
+    expect(r).toMatchObject({ kind: 'markdown', line: 10, column: 5 })
+  })
+
+  it('ignores non-line-col hashes', () => {
+    const r = resolveMarkdownLinkTarget('./guide.md#intro', SOURCE, ROOT)
+    expect(r).toMatchObject({ kind: 'markdown', line: undefined, column: undefined })
+  })
+
+  it('does not treat :note in a filename as a line anchor', () => {
+    const r = resolveMarkdownLinkTarget('./my:note.md', SOURCE, ROOT)
+    expect(r).toMatchObject({ kind: 'markdown', line: undefined })
+    expect((r as { absolutePath: string }).absolutePath).toContain('my:note.md')
+  })
+
+  it('does not treat a mid-name colon with digits as a line anchor', () => {
+    const r = resolveMarkdownLinkTarget('./weird:12name.md', SOURCE, ROOT)
+    expect(r).toMatchObject({ kind: 'markdown', line: undefined })
+  })
+
+  it('classifies http(s) as external', () => {
+    const r = resolveMarkdownLinkTarget('https://example.com', SOURCE, ROOT)
+    expect(r).toEqual({ kind: 'external', url: 'https://example.com/' })
+  })
+
+  it('classifies bare anchor as anchor', () => {
+    const r = resolveMarkdownLinkTarget('#heading-only', SOURCE, ROOT)
+    expect(r).toEqual({ kind: 'anchor' })
+  })
+
+  it('classifies non-markdown local file as file', () => {
+    const r = resolveMarkdownLinkTarget('./image.png', SOURCE, ROOT)
+    expect(r?.kind).toBe('file')
+  })
+
+  it('never returns markdown when worktreeRoot is null', () => {
+    const r = resolveMarkdownLinkTarget('./guide.md', SOURCE, null)
+    expect(r?.kind).toBe('file')
+  })
+
+  it('decodes URL-encoded spaces in the path', () => {
+    const r = resolveMarkdownLinkTarget('./my%20note.md', SOURCE, ROOT)
+    expect(r).toMatchObject({
+      kind: 'markdown',
+      absolutePath: '/repo/docs/my note.md'
+    })
+  })
+
+  it('returns null for empty href', () => {
+    expect(resolveMarkdownLinkTarget('', SOURCE, ROOT)).toBeNull()
+    expect(resolveMarkdownLinkTarget(undefined, SOURCE, ROOT)).toBeNull()
+  })
+})

--- a/src/renderer/src/components/editor/markdown-internal-links.ts
+++ b/src/renderer/src/components/editor/markdown-internal-links.ts
@@ -1,0 +1,211 @@
+// Pure classifier for markdown link targets. Called by the link-activation
+// dispatcher (activateMarkdownLink slice action) from three call sites —
+// MarkdownPreview, RichMarkdownEditor Cmd-click, RichMarkdownLinkBubble open —
+// so behavior stays consistent across preview/rich/bubble entry points.
+//
+// See docs/markdown-internal-link-opening-design.md for the full rationale.
+
+export type MarkdownLinkTarget =
+  | { kind: 'anchor' }
+  | { kind: 'external'; url: string }
+  | {
+      kind: 'markdown'
+      absolutePath: string
+      relativePath: string
+      line?: number
+      column?: number
+    }
+  | { kind: 'file'; uri: string }
+
+// Why: renderer runs with sandbox + contextIsolation, so process.platform is
+// unavailable. navigator.userAgent is the portable fallback (AGENTS.md).
+const ua = typeof navigator === 'undefined' ? '' : navigator.userAgent
+const isMacLike = ua.includes('Mac')
+const isWindowsLike = ua.includes('Windows')
+const caseInsensitiveFs = isMacLike || isWindowsLike
+
+const MARKDOWN_EXTENSIONS = new Set(['.md', '.mdx', '.markdown'])
+
+export function absolutePathToFileUri(filePath: string): string {
+  return toFileUrl(filePath)
+}
+
+function toFileUrl(filePath: string): string {
+  const normalizedPath = filePath.replaceAll('\\', '/')
+  const segments = normalizedPath.split('/').map((segment, index) => {
+    if (index === 0 && /^[A-Za-z]:$/.test(segment)) {
+      return segment
+    }
+    return encodeURIComponent(segment)
+  })
+  if (normalizedPath.startsWith('/')) {
+    return `file://${segments.join('/')}`
+  }
+  return `file:///${segments.join('/')}`
+}
+
+function fileUrlToAbsolutePath(url: URL): string {
+  let absolutePath = decodeURIComponent(url.pathname)
+  // Windows: "/C:/foo" → "C:/foo"
+  if (/^\/[A-Za-z]:\//.test(absolutePath)) {
+    absolutePath = absolutePath.slice(1)
+  }
+  return absolutePath
+}
+
+function normalizePathForCompare(p: string): string {
+  let np = p.replaceAll('\\', '/')
+  while (np.endsWith('/') && np.length > 1) {
+    np = np.slice(0, -1)
+  }
+  return np
+}
+
+function isDescendantOf(childAbs: string, parentAbs: string): boolean {
+  const child = normalizePathForCompare(childAbs)
+  const parent = normalizePathForCompare(parentAbs)
+  if (caseInsensitiveFs) {
+    const lc = child.toLowerCase()
+    const lp = parent.toLowerCase()
+    return lc === lp || lc.startsWith(`${lp}/`)
+  }
+  return child === parent || child.startsWith(`${parent}/`)
+}
+
+function hasMarkdownExtension(p: string): boolean {
+  const lastDot = p.lastIndexOf('.')
+  if (lastDot === -1) {
+    return false
+  }
+  return MARKDOWN_EXTENSIONS.has(p.slice(lastDot).toLowerCase())
+}
+
+// Extract `:line` or `:line:col` from the end of a path. Must anchor to
+// end-of-string and require digits so legal filenames containing `:` are not
+// silently truncated.
+function extractTrailingLineCol(path: string): { path: string; line?: number; column?: number } {
+  const match = /:(\d+)(?::(\d+))?$/.exec(path)
+  if (!match) {
+    return { path }
+  }
+  return {
+    path: path.slice(0, match.index),
+    line: Number(match[1]),
+    column: match[2] ? Number(match[2]) : undefined
+  }
+}
+
+// Parse `#L10` / `#L10C5` anchor (case-insensitive). Non-matching fragments
+// (e.g., `#heading`) return undefined so they flow through as normal links.
+function extractHashLineCol(hash: string): { line?: number; column?: number } {
+  if (!hash) {
+    return {}
+  }
+  const trimmed = hash.startsWith('#') ? hash.slice(1) : hash
+  const match = /^L(\d+)(?:C(\d+))?$/i.exec(trimmed)
+  if (!match) {
+    return {}
+  }
+  return {
+    line: Number(match[1]),
+    column: match[2] ? Number(match[2]) : undefined
+  }
+}
+
+function resolveRelativeToSource(rawHref: string, sourceFilePath: string): URL | null {
+  try {
+    return new URL(rawHref, toFileUrl(sourceFilePath))
+  } catch {
+    return null
+  }
+}
+
+function computeRelativePath(absolutePath: string, worktreeRoot: string): string {
+  const parent = normalizePathForCompare(worktreeRoot)
+  const child = normalizePathForCompare(absolutePath)
+  const prefix = `${parent}/`
+  if (caseInsensitiveFs) {
+    if (child.toLowerCase() === parent.toLowerCase()) {
+      return ''
+    }
+    if (child.toLowerCase().startsWith(prefix.toLowerCase())) {
+      return child.slice(prefix.length)
+    }
+  } else {
+    if (child === parent) {
+      return ''
+    }
+    if (child.startsWith(prefix)) {
+      return child.slice(prefix.length)
+    }
+  }
+  return child
+}
+
+export function resolveMarkdownLinkTarget(
+  rawHref: string | undefined,
+  sourceFilePath: string,
+  worktreeRoot: string | null
+): MarkdownLinkTarget | null {
+  if (rawHref === undefined || rawHref === '') {
+    return null
+  }
+  if (rawHref.startsWith('#')) {
+    return { kind: 'anchor' }
+  }
+
+  const resolved = resolveRelativeToSource(rawHref, sourceFilePath)
+  if (!resolved) {
+    return null
+  }
+
+  if (resolved.protocol === 'http:' || resolved.protocol === 'https:') {
+    return { kind: 'external', url: resolved.toString() }
+  }
+
+  if (resolved.protocol !== 'file:') {
+    return null
+  }
+
+  const rawAbsolutePath = fileUrlToAbsolutePath(resolved)
+
+  // Why: hash-based line anchor takes precedence; fall back to trailing
+  // `:line:col` syntax only if no hash anchor was found.
+  const hashParsed = extractHashLineCol(resolved.hash)
+  let line = hashParsed.line
+  let column = hashParsed.column
+
+  let pathForClassification = rawAbsolutePath
+  if (line === undefined) {
+    const trailing = extractTrailingLineCol(rawAbsolutePath)
+    if (trailing.line !== undefined) {
+      pathForClassification = trailing.path
+      line = trailing.line
+      column = trailing.column
+    }
+  }
+
+  if (
+    worktreeRoot !== null &&
+    hasMarkdownExtension(pathForClassification) &&
+    isDescendantOf(pathForClassification, worktreeRoot)
+  ) {
+    const relativePath = computeRelativePath(pathForClassification, worktreeRoot)
+    return {
+      kind: 'markdown',
+      absolutePath: pathForClassification,
+      relativePath,
+      line,
+      column
+    }
+  }
+
+  // Rebuild a file: URI without the line anchor so the OS handler gets a
+  // clean path. Use the original resolved URL minus the hash as an
+  // approximation; for trailing-colon paths there's no clean URL form,
+  // so we reconstruct from the stripped absolute path.
+  if (line === undefined) {
+    return { kind: 'file', uri: resolved.toString() }
+  }
+  return { kind: 'file', uri: toFileUrl(pathForClassification) }
+}

--- a/src/renderer/src/components/editor/useLinkBubble.ts
+++ b/src/renderer/src/components/editor/useLinkBubble.ts
@@ -2,6 +2,7 @@ import { useCallback } from 'react'
 import type { Editor } from '@tiptap/react'
 import { getLinkBubblePosition } from './RichMarkdownLinkBubble'
 import type { LinkBubbleState } from './RichMarkdownLinkBubble'
+import { useAppStore } from '@/store'
 
 /**
  * Extracts link-editing action handlers from the editor component to reduce
@@ -13,7 +14,12 @@ export function useLinkBubble(
   rootRef: React.RefObject<HTMLElement | null>,
   linkBubble: LinkBubbleState | null,
   setLinkBubble: (v: LinkBubbleState | null) => void,
-  setIsEditingLink: (v: boolean) => void
+  setIsEditingLink: (v: boolean) => void,
+  linkContext: {
+    sourceFilePath: string
+    worktreeId: string
+    worktreeRoot: string | null
+  }
 ): {
   handleLinkSave: (href: string) => void
   handleLinkRemove: () => void
@@ -88,11 +94,24 @@ export function useLinkBubble(
     editor?.commands.focus()
   }, [editor, linkBubble?.href, setLinkBubble, setIsEditingLink])
 
+  const activateMarkdownLink = useAppStore((s) => s.activateMarkdownLink)
+
   const handleLinkOpen = useCallback(() => {
-    if (linkBubble?.href) {
-      void window.api.shell.openUrl(linkBubble.href)
+    if (!linkBubble?.href) {
+      return
     }
-  }, [linkBubble?.href])
+    void activateMarkdownLink(linkBubble.href, {
+      sourceFilePath: linkContext.sourceFilePath,
+      worktreeId: linkContext.worktreeId,
+      worktreeRoot: linkContext.worktreeRoot
+    })
+  }, [
+    activateMarkdownLink,
+    linkBubble?.href,
+    linkContext.sourceFilePath,
+    linkContext.worktreeId,
+    linkContext.worktreeRoot
+  ])
 
   const toggleLinkFromToolbar = useCallback(() => {
     if (!editor) {

--- a/src/renderer/src/store/slices/editor.test.ts
+++ b/src/renderer/src/store/slices/editor.test.ts
@@ -1,9 +1,17 @@
 /* eslint-disable max-lines */
 
 import { createStore, type StoreApi } from 'zustand/vanilla'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 import { createEditorSlice } from './editor'
 import type { AppState } from '../types'
+
+const { toastErrorMock } = vi.hoisted(() => ({
+  toastErrorMock: vi.fn()
+}))
+
+vi.mock('sonner', () => ({
+  toast: { error: toastErrorMock }
+}))
 
 function createEditorStore(): StoreApi<AppState> {
   // Only the editor slice + activeWorktreeId are needed for these tests.
@@ -461,5 +469,137 @@ describe('createEditorSlice combined diff exclusions', () => {
         skippedConflicts: [{ path: 'src/conflict.ts', conflictKind: 'both_modified' }]
       })
     )
+  })
+})
+
+describe('createEditorSlice activateMarkdownLink', () => {
+  const openUrlMock = vi.fn()
+  const openFileUriMock = vi.fn()
+  const pathExistsMock = vi.fn()
+
+  beforeEach(() => {
+    toastErrorMock.mockReset()
+    openUrlMock.mockReset()
+    openFileUriMock.mockReset()
+    pathExistsMock.mockReset()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(globalThis as any).window = (globalThis as any).window ?? {}
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(globalThis as any).window.api = {
+      shell: {
+        openUrl: openUrlMock,
+        openFileUri: openFileUriMock,
+        pathExists: pathExistsMock
+      }
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(globalThis as any).requestAnimationFrame = (cb: (t: number) => void) => {
+      cb(0)
+      return 0
+    }
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('opens in-worktree markdown links as preview edit tabs', async () => {
+    const store = createEditorStore()
+    pathExistsMock.mockResolvedValue(true)
+
+    await store.getState().activateMarkdownLink('./guide.md', {
+      sourceFilePath: '/repo/docs/note.md',
+      worktreeId: 'wt-1',
+      worktreeRoot: '/repo'
+    })
+
+    expect(store.getState().openFiles).toEqual([
+      expect.objectContaining({
+        filePath: '/repo/docs/guide.md',
+        mode: 'edit',
+        isPreview: true
+      })
+    ])
+    expect(openFileUriMock).not.toHaveBeenCalled()
+    expect(openUrlMock).not.toHaveBeenCalled()
+  })
+
+  it('toasts when the markdown target is missing', async () => {
+    const store = createEditorStore()
+    pathExistsMock.mockResolvedValue(false)
+
+    await store.getState().activateMarkdownLink('./missing.md', {
+      sourceFilePath: '/repo/docs/note.md',
+      worktreeId: 'wt-1',
+      worktreeRoot: '/repo'
+    })
+
+    expect(toastErrorMock).toHaveBeenCalledWith('File not found: docs/missing.md')
+    expect(store.getState().openFiles).toEqual([])
+    expect(openFileUriMock).not.toHaveBeenCalled()
+  })
+
+  it('sets source view mode before opening when the link has a line anchor', async () => {
+    const store = createEditorStore()
+    pathExistsMock.mockResolvedValue(true)
+
+    await store.getState().activateMarkdownLink('./guide.md#L10', {
+      sourceFilePath: '/repo/docs/note.md',
+      worktreeId: 'wt-1',
+      worktreeRoot: '/repo'
+    })
+
+    expect(store.getState().markdownViewMode['/repo/docs/guide.md']).toBe('source')
+    expect(store.getState().pendingEditorReveal).toEqual({
+      filePath: '/repo/docs/guide.md',
+      line: 10,
+      column: 1,
+      matchLength: 0
+    })
+  })
+
+  it('delegates external links to shell.openUrl', async () => {
+    const store = createEditorStore()
+    await store.getState().activateMarkdownLink('https://example.com', {
+      sourceFilePath: '/repo/docs/note.md',
+      worktreeId: 'wt-1',
+      worktreeRoot: '/repo'
+    })
+    expect(openUrlMock).toHaveBeenCalledWith('https://example.com/')
+    expect(store.getState().openFiles).toEqual([])
+  })
+
+  it('delegates outside-worktree files to shell.openFileUri', async () => {
+    const store = createEditorStore()
+    await store.getState().activateMarkdownLink('./image.png', {
+      sourceFilePath: '/repo/docs/note.md',
+      worktreeId: 'wt-1',
+      worktreeRoot: '/repo'
+    })
+    expect(openFileUriMock).toHaveBeenCalledTimes(1)
+    expect(store.getState().openFiles).toEqual([])
+  })
+
+  it('activates same-file line anchors via setActiveFile without opening a new tab', async () => {
+    const store = createEditorStore()
+    pathExistsMock.mockResolvedValue(true)
+    store.getState().openFile({
+      filePath: '/repo/docs/note.md',
+      relativePath: 'docs/note.md',
+      worktreeId: 'wt-1',
+      language: 'markdown',
+      mode: 'edit'
+    })
+    const openCountBefore = store.getState().openFiles.length
+
+    await store.getState().activateMarkdownLink('./note.md#L3', {
+      sourceFilePath: '/repo/docs/note.md',
+      worktreeId: 'wt-1',
+      worktreeRoot: '/repo'
+    })
+
+    expect(store.getState().openFiles).toHaveLength(openCountBefore)
+    expect(store.getState().markdownViewMode['/repo/docs/note.md']).toBe('source')
+    expect(store.getState().pendingEditorReveal?.line).toBe(3)
   })
 })

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -2,6 +2,8 @@
 import type { StateCreator } from 'zustand'
 import type { AppState } from '../types'
 import { joinPath } from '@/lib/path'
+import { toast } from 'sonner'
+import { resolveMarkdownLinkTarget } from '@/components/editor/markdown-internal-links'
 import type {
   GitBranchChangeEntry,
   GitBranchCompareSummary,
@@ -163,8 +165,16 @@ export type EditorSlice = {
   setActiveTabType: (type: WorkspaceVisibleTabType) => void
   openFile: (
     file: Omit<OpenFile, 'id' | 'isDirty'>,
-    options?: { preview?: boolean; targetGroupId?: string }
+    options?: { preview?: boolean; targetGroupId?: string; recordReplacedPreview?: boolean }
   ) => void
+  // Why: dispatcher for markdown link activation. Lives on the slice because it
+  // sequences openFile, setMarkdownViewMode, and setPendingEditorReveal around
+  // an async Monaco remount — all reading/writing state in this slice. See
+  // docs/markdown-internal-link-opening-design.md.
+  activateMarkdownLink: (
+    rawHref: string | undefined,
+    ctx: { sourceFilePath: string; worktreeId: string; worktreeRoot: string | null }
+  ) => Promise<void>
   pinFile: (fileId: string, tabId?: string) => void
   closeFile: (fileId: string) => void
   closeAllFiles: () => void
@@ -401,6 +411,24 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
       const existing = s.openFiles.find((f) => f.id === id)
       const worktreeId = file.worktreeId
       const isPreview = options?.preview ?? false
+      const recordReplacedPreview = options?.recordReplacedPreview ?? false
+      // Why: resolve the target group up-front so preview replacement can be
+      // scoped to that group. Opening as preview in group B must not evict a
+      // preview tab belonging to group A (split tab groups).
+      const targetGroupId =
+        options?.targetGroupId ??
+        s.activeGroupIdByWorktree?.[worktreeId] ??
+        s.groupsByWorktree?.[worktreeId]?.[0]?.id ??
+        undefined
+      const previewTabByEntity = new Map<string, string>()
+      if (targetGroupId) {
+        const tabsForWorktree = s.unifiedTabsByWorktree?.[worktreeId] ?? []
+        for (const tab of tabsForWorktree) {
+          if (tab.groupId === targetGroupId && tab.isPreview && tab.contentType === 'editor') {
+            previewTabByEntity.set(tab.entityId, tab.id)
+          }
+        }
+      }
 
       const activeResult = {
         activeFileId: id,
@@ -446,12 +474,23 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
         }
       }
 
-      // If opening as preview, replace the existing preview tab for this worktree
+      // If opening as preview, replace the existing preview tab.
+      // Why: preview replacement is scoped to `worktreeId + targetGroupId` so
+      // link clicks in group B do not silently evict previews from group A.
+      // Falls back to worktree-wide when group plumbing is unavailable (e.g.
+      // in tests that don't populate unifiedTabsByWorktree), matching the
+      // prior behavior.
       let newFiles = s.openFiles
       if (isPreview) {
-        const existingPreviewIdx = s.openFiles.findIndex(
-          (f) => f.worktreeId === worktreeId && f.isPreview
-        )
+        const existingPreviewIdx = s.openFiles.findIndex((f) => {
+          if (f.worktreeId !== worktreeId || !f.isPreview) {
+            return false
+          }
+          if (previewTabByEntity.size === 0) {
+            return true
+          }
+          return previewTabByEntity.has(f.id)
+        })
         if (existingPreviewIdx !== -1) {
           const replacedPreview = s.openFiles[existingPreviewIdx]
           const nextEditorDrafts =
@@ -492,11 +531,29 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
                 }
               }
             : {}
+          // Why: link-activation replaces previews by default, so users walking
+          // A → B → C can't reach A via Cmd/Ctrl+Shift+T unless we push the
+          // evicted preview onto the recently-closed stack. Gated with
+          // recordReplacedPreview so file-explorer single-click (which
+          // semantically *wants* silent eviction) is unaffected.
+          let nextRecentlyClosed = s.recentlyClosedEditorTabsByWorktree
+          if (recordReplacedPreview && replacedPreview.id !== id) {
+            const { id: _rid, isDirty: _rdirty, ...snap } = replacedPreview
+            const stack = s.recentlyClosedEditorTabsByWorktree[worktreeId] ?? []
+            nextRecentlyClosed = {
+              ...s.recentlyClosedEditorTabsByWorktree,
+              [worktreeId]: [snap as ClosedEditorTabSnapshot, ...stack].slice(
+                0,
+                MAX_RECENT_CLOSED_EDITOR_TABS
+              )
+            }
+          }
           return {
             openFiles: newFiles,
             editorDrafts: nextEditorDrafts,
             editorCursorLine: nextEditorCursorLine,
             markdownViewMode: nextMarkdownViewMode,
+            recentlyClosedEditorTabsByWorktree: nextRecentlyClosed,
             ...previewTabBarUpdate,
             ...activeResult
           }
@@ -1593,6 +1650,82 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
   // Editor navigation
   pendingEditorReveal: null,
   setPendingEditorReveal: (reveal) => set({ pendingEditorReveal: reveal }),
+
+  activateMarkdownLink: async (rawHref, ctx) => {
+    const target = resolveMarkdownLinkTarget(rawHref, ctx.sourceFilePath, ctx.worktreeRoot)
+    if (!target) {
+      return
+    }
+    if (target.kind === 'anchor') {
+      return
+    }
+    if (target.kind === 'external') {
+      void window.api.shell.openUrl(target.url)
+      return
+    }
+    if (target.kind === 'file') {
+      void window.api.shell.openFileUri(target.uri)
+      return
+    }
+
+    // target.kind === 'markdown'
+    const { absolutePath, relativePath, line, column } = target
+    const exists = await window.api.shell.pathExists(absolutePath)
+    if (!exists) {
+      toast.error(`File not found: ${relativePath}`)
+      return
+    }
+
+    const state = get()
+    const existing = state.openFiles.find((f) => f.filePath === absolutePath)
+    const fileId = existing?.id ?? absolutePath
+
+    // Why: pendingEditorReveal is consumed by MonacoEditor on mount. If the
+    // file opens/stays in rich mode, the reveal is silently dropped. Flip to
+    // source before openFile/setActiveFile so Monaco is the surface that
+    // mounts or is already mounted when the reveal lands. Rich-mode line
+    // reveal is tracked as a follow-up (design doc §open-q 1).
+    if (line !== undefined) {
+      get().setMarkdownViewMode(fileId, 'source')
+    }
+
+    if (!existing) {
+      get().openFile(
+        {
+          filePath: absolutePath,
+          relativePath,
+          worktreeId: ctx.worktreeId,
+          language: 'markdown',
+          mode: 'edit'
+        },
+        {
+          preview: true,
+          targetGroupId: get().activeGroupIdByWorktree?.[ctx.worktreeId],
+          recordReplacedPreview: true
+        }
+      )
+    } else {
+      get().setActiveFile(existing.id)
+    }
+
+    if (line !== undefined) {
+      // Why: double-RAF matches search-match-open.ts. openFile may replace a
+      // preview, remounting Monaco asynchronously; the mount's own
+      // setPendingEditorReveal(null) would otherwise clobber a reveal scheduled
+      // in the same tick.
+      get().setPendingEditorReveal(null)
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          get().setPendingEditorReveal({
+            filePath: absolutePath,
+            line,
+            column: column ?? 1,
+            matchLength: 0
+          })
+        })
+      })
+    }
+  },
 
   // Why: only edit-mode files are restored — diffs and conflict views depend on
   // transient git state that may have changed between sessions. Restoring them


### PR DESCRIPTION
## Problem

Markdown links in the editor preview were opening externally instead of activating files within the worktree. Users had no way to quickly navigate between linked .md files using Cmd/Ctrl-click, a common editor pattern.

## Solution

Implemented a unified link classifier (`resolveMarkdownLinkTarget`) that routes all markdown link activation through a dispatcher (`activateMarkdownLink`). The classifier distinguishes between:

- **In-worktree .md files** → Open as preview edit tabs in the active group
- **External URLs** → Delegate to `shell.openUrl`
- **Non-markdown files** → Delegate to `shell.openFileUri`
- **Anchors** → Recognized but passed through (no action)

**Cmd/Ctrl-click:** Routes through the classifier to open in-worktree .md files as preview tabs.

**Cmd/Ctrl+Shift-click:** Preserved as the OS escape hatch—checks file existence first to show a toast for dangling targets.

**Line anchors:** Supports `#L10`, `#L10C5`, and `./file.md:10:5` syntax. When a line anchor is detected, the target file flips to source view before the reveal is scheduled.

**Preview tab replacement:** Scoped to the active tab group so link clicks in group B don't silently evict previews from group A. Evicted previews are pushed onto the recently-closed stack (`Cmd/Ctrl+Shift+T`) for recovery.

Includes full unit tests for the classifier and dispatcher, covering markdown/external/file/anchor cases, line-anchor detection, worktree-relative path resolution, and the recently-closed integration.