### PR TITLE
fix(github): Needs My Review tab returns no results

### DIFF
--- a/src/main/github/client-work-items.test.ts
+++ b/src/main/github/client-work-items.test.ts
@@ -75,9 +75,7 @@ describe('listWorkItems', () => {
           }
         ])
       })
-
     const items = await listWorkItems('/repo-root', 10, 'assignee:@me')
-
     expect(ghExecFileAsyncMock).toHaveBeenNthCalledWith(
       1,
       [
@@ -156,9 +154,7 @@ describe('listWorkItems', () => {
         }
       ])
     })
-
     const items = await listWorkItems('/repo-root', 10, 'is:pr is:draft')
-
     expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(1)
     expect(ghExecFileAsyncMock).toHaveBeenCalledWith(
       [
@@ -193,6 +189,23 @@ describe('listWorkItems', () => {
     ])
   })
 
+  it('passes review-requested as a --search qualifier (gh CLI has no dedicated flag)', async () => {
+    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    ghExecFileAsyncMock.mockResolvedValueOnce({ stdout: '[]' })
+
+    await listWorkItems('/repo-root', 10, 'review-requested:@me is:open')
+
+    expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(1)
+    expect(ghExecFileAsyncMock).toHaveBeenCalledWith(
+      expect.arrayContaining(['--search', 'review-requested:@me']),
+      { cwd: '/repo-root' }
+    )
+    expect(ghExecFileAsyncMock).not.toHaveBeenCalledWith(
+      expect.arrayContaining(['--review-requested']),
+      expect.anything()
+    )
+  })
+
   it('returns open issues and PRs for the all-open preset query', async () => {
     getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
     ghExecFileAsyncMock
@@ -225,9 +238,7 @@ describe('listWorkItems', () => {
           }
         ])
       })
-
     const items = await listWorkItems('/repo-root', 10, 'is:open')
-
     expect(ghExecFileAsyncMock).toHaveBeenCalledWith(
       [
         'issue',

--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -305,17 +305,31 @@ function buildWorkItemListArgs(args: {
       out.push('--label', label)
     }
   }
-  if (kind === 'pr' && query.reviewRequested) {
-    out.push('--review-requested', query.reviewRequested)
-  }
-  if (kind === 'pr' && query.reviewedBy) {
-    out.push('--reviewed-by', query.reviewedBy)
-  }
-  if (kind === 'pr' && query.scope === 'pr' && query.state === 'open' && query.freeText === '') {
+  if (
+    kind === 'pr' &&
+    query.scope === 'pr' &&
+    query.state === 'open' &&
+    query.freeText === '' &&
+    !query.reviewRequested &&
+    !query.reviewedBy
+  ) {
     out.push('--draft')
   }
+
+  // review-requested and reviewed-by are not supported as standalone gh CLI flags,
+  // so they must be passed as GitHub search qualifiers via --search.
+  const searchParts: string[] = []
+  if (kind === 'pr' && query.reviewRequested) {
+    searchParts.push(`review-requested:${query.reviewRequested}`)
+  }
+  if (kind === 'pr' && query.reviewedBy) {
+    searchParts.push(`reviewed-by:${query.reviewedBy}`)
+  }
   if (query.freeText) {
-    out.push('--search', query.freeText)
+    searchParts.push(query.freeText)
+  }
+  if (searchParts.length > 0) {
+    out.push('--search', searchParts.join(' '))
   }
   return out
 }


### PR DESCRIPTION
## Summary
- The "Needs My Review" tab (`review-requested:@me is:open`) was returning "No matching GitHub work" because `gh pr list` doesn't support `--review-requested` or `--reviewed-by` as standalone flags — the command silently failed and returned empty results
- Changed `buildWorkItemListArgs()` to pass these qualifiers via `--search` instead (e.g., `--search "review-requested:@me"`), which is how `gh` CLI expects GitHub search qualifiers
- Also applies to `reviewed-by` queries

## Test plan
- [x] Added test verifying `review-requested:@me` is passed as `--search` qualifier, not as a standalone flag
- [x] All 2115 existing tests pass
- [x] TypeScript compiles clean
- [ ] Manual: open app → click "Needs My Review" tab → verify PRs appear