### PR TITLE
fix: restore terminal focus after context menu copy/paste

### DIFF
--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
@@ -76,6 +76,11 @@ export function useTerminalPaneContextMenu({
     if (selection) {
       await window.api.ui.writeClipboardText(selection)
     }
+    // Why: Radix returns focus to the menu trigger (the pane container) on
+    // close, but xterm.js only accepts input when its own helper textarea is
+    // focused. Without this, the user has to click the pane again before
+    // typing works (see #592).
+    pane.terminal.focus()
   }
 
   const onPaste = async (): Promise<void> => {
@@ -86,6 +91,7 @@ export function useTerminalPaneContextMenu({
     const text = await window.api.ui.readClipboardText()
     if (text) {
       pane.terminal.paste(text)
+      pane.terminal.focus()
       return
     }
     // Why: clipboard has no text — check for an image (e.g. screenshot).
@@ -95,6 +101,11 @@ export function useTerminalPaneContextMenu({
     if (filePath) {
       pane.terminal.paste(filePath)
     }
+    // Why: Radix returns focus to the menu trigger (the pane container) on
+    // close, but xterm.js only accepts input when its own helper textarea is
+    // focused. Without this, the user has to click the pane again before
+    // typing works (see #592).
+    pane.terminal.focus()
   }
 
   const onSplitRight = (): void => {


### PR DESCRIPTION
## Summary
- Fixes #592: selecting Copy or Paste from the terminal right-click context menu left the terminal unfocused, so the user had to click the pane again before typing.
- Radix returns focus to the menu trigger (the pane container) when the menu closes, but xterm.js only receives keyboard input when its own helper textarea is focused. After each context-menu Copy/Paste action we now call `pane.terminal.focus()` so input continues to flow immediately.
- Only touches `onCopy` and `onPaste` in `use-terminal-pane-context-menu.ts`; no other code paths or platforms are affected.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] Manual (Orca dev via `/electron` + playwright-cli): right-clicked a terminal pane, confirmed context menu opens; clicked Paste — verified `document.activeElement` is `.xterm-helper-textarea` after menu closes; repeated for Copy — same result.
- [ ] Manual verification on Windows (Windows-specific right-click-to-paste path is untouched, but worth a sanity check since the bug was reported there).