### PR TITLE
fix(worktrees): collapse internal '..' in sanitized branch names

### DIFF
--- a/src/main/ipc/worktree-logic.test.ts
+++ b/src/main/ipc/worktree-logic.test.ts
@@ -42,6 +42,15 @@ describe('sanitizeWorktreeName', () => {
     expect(sanitizeWorktreeName('.hidden-')).toBe('hidden')
   })
 
+  it('collapses internal consecutive dots so git check-ref-format accepts the branch', () => {
+    // Why: a prompt containing `../../` used to slugify to `..-..-foo` and
+    // survive sanitization with `..` intact. `git branch` then rejected it
+    // with "is not a valid branch name", breaking worktree creation from the
+    // composer's auto-named branches.
+    expect(sanitizeWorktreeName('for-..-..-feature')).toBe('for-.-.-feature')
+    expect(sanitizeWorktreeName('a..b...c')).toBe('a.b.c')
+  })
+
   it('throws for empty name', () => {
     expect(() => sanitizeWorktreeName('')).toThrow('Invalid worktree name')
   })

--- a/src/main/ipc/worktree-logic.ts
+++ b/src/main/ipc/worktree-logic.ts
@@ -13,6 +13,12 @@ export function sanitizeWorktreeName(input: string): string {
     .replace(/\s+/g, '-')
     .replace(/[^A-Za-z0-9._-]+/g, '-')
     .replace(/-+/g, '-')
+    // Why: git check-ref-format rejects any ref containing `..`, so a prompt
+    // like "../../foo" that survives slugification as `..-..-foo` would
+    // produce a branch name git refuses to create. Collapse runs of dots
+    // to a single dot before the leading/trailing trim so internal `..`
+    // sequences can't reach git.
+    .replace(/\.{2,}/g, '.')
     .replace(/^[.-]+|[.-]+$/g, '')
 
   if (!sanitized || sanitized === '.' || sanitized === '..') {

--- a/src/renderer/src/lib/new-workspace.test.ts
+++ b/src/renderer/src/lib/new-workspace.test.ts
@@ -65,6 +65,19 @@ describe('getWorkspaceSeedName', () => {
     ).toBe('workspace')
   })
 
+  it('does not leave internal ".." in the slug (git refuses such branches)', () => {
+    // Why: the original composer bug — a prompt containing "../../" in
+    // relative path references slugified to a name with internal `..`,
+    // which git rejects with "is not a valid branch name".
+    const seed = getWorkspaceSeedName({
+      explicitName: '',
+      prompt: 'For ../../ the sibling worktree from another repo',
+      linkedIssueNumber: null,
+      linkedPR: null
+    })
+    expect(seed).not.toMatch(/\.{2,}/)
+  })
+
   it('falls back to "workspace" for empty inputs', () => {
     expect(
       getWorkspaceSeedName({

--- a/src/renderer/src/lib/new-workspace.ts
+++ b/src/renderer/src/lib/new-workspace.ts
@@ -117,16 +117,23 @@ export function getSetupConfig(
 // sanitizeWorktreeName either produce a ludicrously long name or throw
 // "Invalid worktree name" when every character is stripped.
 function slugifyForWorkspaceName(input: string): string {
-  return input
-    .trim()
-    .toLowerCase()
-    .replace(/[\\/]+/g, '-')
-    .replace(/\s+/g, '-')
-    .replace(/[^a-z0-9._-]+/g, '-')
-    .replace(/-+/g, '-')
-    .replace(/^[.-]+|[.-]+$/g, '')
-    .slice(0, 48)
-    .replace(/[-._]+$/g, '')
+  return (
+    input
+      .trim()
+      .toLowerCase()
+      .replace(/[\\/]+/g, '-')
+      .replace(/\s+/g, '-')
+      .replace(/[^a-z0-9._-]+/g, '-')
+      .replace(/-+/g, '-')
+      // Why: git check-ref-format rejects any ref containing `..`, so a prompt
+      // like "../../foo" must not turn into a branch seed with internal `..`
+      // sequences (the main-process sanitizer collapses these too, but we
+      // mirror the rule here so the renderer preview matches the real name).
+      .replace(/\.{2,}/g, '.')
+      .replace(/^[.-]+|[.-]+$/g, '')
+      .slice(0, 48)
+      .replace(/[-._]+$/g, '')
+  )
 }
 
 export function getLinkedWorkItemSuggestedName(item: GitHubWorkItem): string {


### PR DESCRIPTION
## Summary
- New-workspace composer crashed with `fatal: '...' is not a valid branch name` when the prompt contained `../../` (or any sequence producing adjacent dots in the slug). Git's `check-ref-format` rejects any ref containing `..`, but our sanitizers only trimmed leading/trailing dots.
- `sanitizeWorktreeName` (main-process gatekeeper) now collapses runs of dots to a single dot before the leading/trailing trim, so a branch name git refuses can never be constructed.
- `slugifyForWorkspaceName` (renderer auto-name preview) mirrors the same rule so the name shown in the composer matches the real branch name that gets created.

## Test plan
- [x] `pnpm vitest run src/main/ipc/worktree-logic.test.ts src/renderer/src/lib/new-workspace.test.ts` — 47/47 pass, including new regression tests covering internal `..` collapsing.
- [ ] Manually: open the New Workspace composer, paste a prompt containing `../../` in it, and confirm the worktree is created without the "is not a valid branch name" error.