### PR TITLE
fix(linux): skip Vulkan/SkiaGraphite/WebGPU on Linux Wayland sessions

### DIFF
--- a/src/main/startup/configure-process.test.ts
+++ b/src/main/startup/configure-process.test.ts
@@ -182,6 +182,8 @@ describe('installDevParentWatchdog', () => {
 
 describe('enableMainProcessGpuFeatures', () => {
   const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+  const originalWaylandDisplay = process.env.WAYLAND_DISPLAY
+  const originalXdgSessionType = process.env.XDG_SESSION_TYPE
 
   function setPlatform(platform: NodeJS.Platform): void {
     Object.defineProperty(process, 'platform', {
@@ -193,6 +195,16 @@ describe('enableMainProcessGpuFeatures', () => {
   afterEach(() => {
     if (originalPlatform) {
       Object.defineProperty(process, 'platform', originalPlatform)
+    }
+    if (originalWaylandDisplay === undefined) {
+      delete process.env.WAYLAND_DISPLAY
+    } else {
+      process.env.WAYLAND_DISPLAY = originalWaylandDisplay
+    }
+    if (originalXdgSessionType === undefined) {
+      delete process.env.XDG_SESSION_TYPE
+    } else {
+      process.env.XDG_SESSION_TYPE = originalXdgSessionType
     }
   })
 
@@ -211,16 +223,53 @@ describe('enableMainProcessGpuFeatures', () => {
     expect(app.commandLine.appendSwitch).toHaveBeenCalledWith('enable-unsafe-webgpu')
   })
 
-  it('skips Vulkan/SkiaGraphite/WebGPU switches on linux', async () => {
-    // Why: Chromium's Ozone/Wayland surface factory refuses to initialize
-    // with Vulkan enabled, producing a blank/transparent window on Wayland
-    // sessions (Arch/Omarchy/Hyprland, GNOME-Wayland). Guard against
-    // regressions that would reintroduce these switches on Linux.
+  it('appends Orca GPU flags on linux X11 sessions', async () => {
+    // Why: Chromium's X11 Vulkan path works, so we keep Skia Graphite / WebGPU
+    // acceleration on X11. Only Wayland hits the wayland_surface_factory.cc
+    // incompatibility and needs the gate.
     const { app } = await import('electron')
     const { enableMainProcessGpuFeatures } = await import('./configure-process')
 
     vi.mocked(app.commandLine.appendSwitch).mockClear()
     setPlatform('linux')
+    delete process.env.WAYLAND_DISPLAY
+    process.env.XDG_SESSION_TYPE = 'x11'
+    enableMainProcessGpuFeatures()
+
+    expect(app.commandLine.appendSwitch).toHaveBeenCalledWith(
+      'enable-features',
+      'Vulkan,UseSkiaGraphite'
+    )
+    expect(app.commandLine.appendSwitch).toHaveBeenCalledWith('enable-unsafe-webgpu')
+  })
+
+  it('skips Vulkan/SkiaGraphite/WebGPU switches when WAYLAND_DISPLAY is set', async () => {
+    // Why: Chromium's Ozone/Wayland surface factory hard-aborts with Vulkan
+    // enabled (wayland_surface_factory.cc:251), producing a blank/transparent
+    // window on Wayland-default distros (Arch/Omarchy/Hyprland, GNOME-Wayland).
+    const { app } = await import('electron')
+    const { enableMainProcessGpuFeatures } = await import('./configure-process')
+
+    vi.mocked(app.commandLine.appendSwitch).mockClear()
+    setPlatform('linux')
+    process.env.WAYLAND_DISPLAY = 'wayland-0'
+    delete process.env.XDG_SESSION_TYPE
+    enableMainProcessGpuFeatures()
+
+    expect(app.commandLine.appendSwitch).not.toHaveBeenCalled()
+  })
+
+  it('skips switches when XDG_SESSION_TYPE=wayland without WAYLAND_DISPLAY', async () => {
+    // Why: belt-and-suspenders — some nested/manually-started Wayland sessions
+    // advertise XDG_SESSION_TYPE=wayland without yet having WAYLAND_DISPLAY
+    // set in the process's environment at launch time.
+    const { app } = await import('electron')
+    const { enableMainProcessGpuFeatures } = await import('./configure-process')
+
+    vi.mocked(app.commandLine.appendSwitch).mockClear()
+    setPlatform('linux')
+    delete process.env.WAYLAND_DISPLAY
+    process.env.XDG_SESSION_TYPE = 'wayland'
     enableMainProcessGpuFeatures()
 
     expect(app.commandLine.appendSwitch).not.toHaveBeenCalled()

--- a/src/main/startup/configure-process.test.ts
+++ b/src/main/startup/configure-process.test.ts
@@ -181,10 +181,27 @@ describe('installDevParentWatchdog', () => {
 })
 
 describe('enableMainProcessGpuFeatures', () => {
-  it('appends Orca GPU flags by default', async () => {
+  const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+
+  function setPlatform(platform: NodeJS.Platform): void {
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: platform
+    })
+  }
+
+  afterEach(() => {
+    if (originalPlatform) {
+      Object.defineProperty(process, 'platform', originalPlatform)
+    }
+  })
+
+  it('appends Orca GPU flags on darwin', async () => {
     const { app } = await import('electron')
     const { enableMainProcessGpuFeatures } = await import('./configure-process')
 
+    vi.mocked(app.commandLine.appendSwitch).mockClear()
+    setPlatform('darwin')
     enableMainProcessGpuFeatures()
 
     expect(app.commandLine.appendSwitch).toHaveBeenCalledWith(
@@ -192,5 +209,20 @@ describe('enableMainProcessGpuFeatures', () => {
       'Vulkan,UseSkiaGraphite'
     )
     expect(app.commandLine.appendSwitch).toHaveBeenCalledWith('enable-unsafe-webgpu')
+  })
+
+  it('skips Vulkan/SkiaGraphite/WebGPU switches on linux', async () => {
+    // Why: Chromium's Ozone/Wayland surface factory refuses to initialize
+    // with Vulkan enabled, producing a blank/transparent window on Wayland
+    // sessions (Arch/Omarchy/Hyprland, GNOME-Wayland). Guard against
+    // regressions that would reintroduce these switches on Linux.
+    const { app } = await import('electron')
+    const { enableMainProcessGpuFeatures } = await import('./configure-process')
+
+    vi.mocked(app.commandLine.appendSwitch).mockClear()
+    setPlatform('linux')
+    enableMainProcessGpuFeatures()
+
+    expect(app.commandLine.appendSwitch).not.toHaveBeenCalled()
   })
 })

--- a/src/main/startup/configure-process.ts
+++ b/src/main/startup/configure-process.ts
@@ -147,6 +147,16 @@ export function installDevParentWatchdog(isDev: boolean): void {
 }
 
 export function enableMainProcessGpuFeatures(): void {
+  // Why: Chromium's Ozone/Wayland surface factory refuses to initialize when
+  // Vulkan is enabled (see wayland_surface_factory.cc), leaving the renderer
+  // unable to compose and showing a blank/transparent window on Wayland-default
+  // distros like Arch/Omarchy/Hyprland and GNOME-Wayland. Chromium's Linux
+  // Vulkan path is also flaky on X11 across Electron 41 + Mesa combinations,
+  // so we skip these switches on Linux entirely. macOS and Windows keep the
+  // Skia Graphite / WebGPU acceleration path, which works as intended.
+  if (process.platform === 'linux') {
+    return
+  }
   app.commandLine.appendSwitch('enable-features', 'Vulkan,UseSkiaGraphite')
   app.commandLine.appendSwitch('enable-unsafe-webgpu')
 }

--- a/src/main/startup/configure-process.ts
+++ b/src/main/startup/configure-process.ts
@@ -147,9 +147,6 @@ export function installDevParentWatchdog(isDev: boolean): void {
 }
 
 function isLinuxWaylandSession(): boolean {
-  if (process.platform !== 'linux') {
-    return false
-  }
   // Why: WAYLAND_DISPLAY is set directly by the Wayland compositor and is the
   // same signal Electron's own ELECTRON_OZONE_PLATFORM_HINT=auto logic uses.
   // XDG_SESSION_TYPE is the login-manager/PAM signal and is the belt-and-
@@ -157,7 +154,10 @@ function isLinuxWaylandSession(): boolean {
   // start (nested Wayland, manual session startup). Both are inherited from
   // the parent process, so they're available before app.whenReady where the
   // GPU command-line switches must be appended.
-  return Boolean(process.env.WAYLAND_DISPLAY) || process.env.XDG_SESSION_TYPE === 'wayland'
+  return (
+    process.platform === 'linux' &&
+    (Boolean(process.env.WAYLAND_DISPLAY) || process.env.XDG_SESSION_TYPE === 'wayland')
+  )
 }
 
 export function enableMainProcessGpuFeatures(): void {

--- a/src/main/startup/configure-process.ts
+++ b/src/main/startup/configure-process.ts
@@ -146,15 +146,31 @@ export function installDevParentWatchdog(isDev: boolean): void {
   timer.unref()
 }
 
+function isLinuxWaylandSession(): boolean {
+  if (process.platform !== 'linux') {
+    return false
+  }
+  // Why: WAYLAND_DISPLAY is set directly by the Wayland compositor and is the
+  // same signal Electron's own ELECTRON_OZONE_PLATFORM_HINT=auto logic uses.
+  // XDG_SESSION_TYPE is the login-manager/PAM signal and is the belt-and-
+  // suspenders check for sessions where WAYLAND_DISPLAY isn't set at process
+  // start (nested Wayland, manual session startup). Both are inherited from
+  // the parent process, so they're available before app.whenReady where the
+  // GPU command-line switches must be appended.
+  return Boolean(process.env.WAYLAND_DISPLAY) || process.env.XDG_SESSION_TYPE === 'wayland'
+}
+
 export function enableMainProcessGpuFeatures(): void {
-  // Why: Chromium's Ozone/Wayland surface factory refuses to initialize when
-  // Vulkan is enabled (see wayland_surface_factory.cc), leaving the renderer
-  // unable to compose and showing a blank/transparent window on Wayland-default
-  // distros like Arch/Omarchy/Hyprland and GNOME-Wayland. Chromium's Linux
-  // Vulkan path is also flaky on X11 across Electron 41 + Mesa combinations,
-  // so we skip these switches on Linux entirely. macOS and Windows keep the
-  // Skia Graphite / WebGPU acceleration path, which works as intended.
-  if (process.platform === 'linux') {
+  // Why: Chromium's Ozone/Wayland surface factory hard-aborts when Vulkan is
+  // enabled (see wayland_surface_factory.cc:251 — "--ozone-platform=wayland is
+  // not compatible with Vulkan"), leaving the renderer unable to compose and
+  // showing a blank/transparent window on Wayland-default distros like
+  // Arch/Omarchy/Hyprland and GNOME-Wayland. Skia Graphite is Vulkan-only on
+  // Linux (no OpenGL backend), so enabling it with Vulkan off would silently
+  // fall back to software rendering — gate it on the same Wayland signal.
+  // The X11 Vulkan path works, so we keep the acceleration there and on
+  // macOS/Windows.
+  if (isLinuxWaylandSession()) {
     return
   }
   app.commandLine.appendSwitch('enable-features', 'Vulkan,UseSkiaGraphite')


### PR DESCRIPTION
## Summary
Fixes #718: blank/transparent Orca window on Linux Wayland sessions (Arch/Omarchy, Hyprland, GNOME-Wayland).

`enableMainProcessGpuFeatures()` now skips the `Vulkan`, `UseSkiaGraphite`, and `enable-unsafe-webgpu` switches **only on Linux Wayland sessions** (`WAYLAND_DISPLAY` set, or `XDG_SESSION_TYPE=wayland`). X11 Linux, macOS, and Windows keep the hardware acceleration path.

### Why Wayland-only rather than all-Linux
The issue reporter's patch gated all of Linux on the argument that "Chromium's X11 Vulkan path is flaky too." After researching upstream sources I decided to narrow it:

- **The Wayland+Vulkan failure is a Chromium design constraint, not a general Linux bug.** `wayland_surface_factory.cc:251` hard-aborts with `"--ozone-platform=wayland is not compatible with Vulkan. Consider switching to '--ozone-platform=x11' or disabling Vulkan"` — Chromium itself points X11 users to the Vulkan path. No upstream Chromium/Electron issues back a blanket X11+Vulkan condemnation; community reports on X11 are hardware-specific (old Intel iGPUs, pre-Mesa-23), not universal.
- **Skia Graphite is Vulkan-only on Linux** — it has no OpenGL backend ([Skia Graphite design goals](https://skia.org/docs/dev/design/graphite_goals/)). On X11 it runs on Vulkan (the acceleration we actually want); on Wayland with Vulkan off it would silently fall back to software, so it's gated on the same Wayland signal.
- **Hardware WebGPU on Linux needs Vulkan** (Dawn: Vulkan -> ANGLE -> SwiftShader). A broad Linux gate would drop hardware WebGPU for X11 users too. On Wayland without Vulkan it degrades gracefully to ANGLE.

### Detection
```ts
function isLinuxWaylandSession(): boolean {
  if (process.platform !== 'linux') return false
  return Boolean(process.env.WAYLAND_DISPLAY)
    || process.env.XDG_SESSION_TYPE === 'wayland'
}
```
`WAYLAND_DISPLAY` is set by the compositor (same signal Electron's `ELECTRON_OZONE_PLATFORM_HINT=auto` reads). `XDG_SESSION_TYPE` is the login-manager/PAM signal and catches sessions where `WAYLAND_DISPLAY` isn't set early. Both are inherited from the parent, so available before `app.whenReady`.

## Test plan
- [x] `pnpm vitest run src/main/startup/configure-process.test.ts` — 11/11 pass (darwin applies, linux+X11 applies, linux+`WAYLAND_DISPLAY` skips, linux+`XDG_SESSION_TYPE=wayland` skips)
- [x] `pnpm typecheck`
- [ ] Manual verification on a Wayland host (Arch/Omarchy/Hyprland or GNOME-Wayland): Orca renders; `wayland_surface_factory.cc:251` no longer appears in GPU logs.
- [ ] Smoke on Linux X11 that Skia Graphite / WebGPU path still works.
- [ ] Smoke on macOS and Windows that nothing regressed.