### PR TITLE
fix(sidebar): sort Recent mode by lastActivityAt, not sortOrder

### DIFF
--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -91,7 +91,7 @@ export class Store {
           },
           // Why: 'recent' used to mean the weighted smart sort. One-shot
           // migration moves it to 'smart'; the flag prevents re-firing after
-          // a user intentionally selects the new creation-time 'recent' sort.
+          // a user intentionally selects the new last-activity 'recent' sort.
           ui: (() => {
             const sort = normalizeSortBy(parsed.ui?.sortBy)
             const migrate = !parsed.ui?._sortBySmartMigrated && sort === 'recent'

--- a/src/renderer/src/components/sidebar/smart-sort.test.ts
+++ b/src/renderer/src/components/sidebar/smart-sort.test.ts
@@ -384,17 +384,17 @@ describe('buildWorktreeComparator', () => {
   })
 })
 
-describe('buildWorktreeComparator — recent (sortOrder / creation time)', () => {
-  it('sorts by sortOrder descending (newest first)', () => {
+describe('buildWorktreeComparator — recent (lastActivityAt)', () => {
+  it('sorts by lastActivityAt descending (most recent first)', () => {
     const older = makeWorktree({
       id: 'older',
       displayName: 'Older',
-      sortOrder: 1000
+      lastActivityAt: 1000
     })
     const newer = makeWorktree({
       id: 'newer',
       displayName: 'Newer',
-      sortOrder: 2000
+      lastActivityAt: 2000
     })
     const worktrees = [older, newer]
 
@@ -403,39 +403,61 @@ describe('buildWorktreeComparator — recent (sortOrder / creation time)', () =>
     expect(worktrees.map((w) => w.id)).toEqual(['newer', 'older'])
   })
 
-  it('sorts worktrees with sortOrder 0 to the bottom', () => {
-    const created = makeWorktree({
-      id: 'created',
-      displayName: 'Created',
-      sortOrder: 1000
+  it('sorts worktrees with lastActivityAt 0 to the bottom', () => {
+    const touched = makeWorktree({
+      id: 'touched',
+      displayName: 'Touched',
+      lastActivityAt: 1000
     })
     const legacy = makeWorktree({
       id: 'legacy',
       displayName: 'Legacy',
-      sortOrder: 0
+      lastActivityAt: 0
     })
-    const worktrees = [legacy, created]
+    const worktrees = [legacy, touched]
 
     worktrees.sort(buildWorktreeComparator('recent', null, repoMap, null, NOW))
 
-    expect(worktrees.map((w) => w.id)).toEqual(['created', 'legacy'])
+    expect(worktrees.map((w) => w.id)).toEqual(['touched', 'legacy'])
   })
 
-  it('falls back to alphabetical when sortOrder is equal', () => {
+  it('falls back to alphabetical when lastActivityAt is equal', () => {
     const bravo = makeWorktree({
       id: 'bravo',
       displayName: 'Bravo',
-      sortOrder: 1000
+      lastActivityAt: 1000
     })
     const alpha = makeWorktree({
       id: 'alpha',
       displayName: 'Alpha',
-      sortOrder: 1000
+      lastActivityAt: 1000
     })
     const worktrees = [bravo, alpha]
 
     worktrees.sort(buildWorktreeComparator('recent', null, repoMap, null, NOW))
 
     expect(worktrees.map((w) => w.id)).toEqual(['alpha', 'bravo'])
+  })
+
+  it('ignores sortOrder entirely — activity alone determines the order', () => {
+    // A worktree with a stale high sortOrder (e.g. baked in when meta was
+    // first created) must not outrank a worktree with fresher activity.
+    const staleHighOrder = makeWorktree({
+      id: 'stale-high-order',
+      displayName: 'Orca main',
+      sortOrder: 9_999_999_999_999,
+      lastActivityAt: 1000
+    })
+    const freshActive = makeWorktree({
+      id: 'fresh-active',
+      displayName: 'Other repo',
+      sortOrder: 1,
+      lastActivityAt: 5000
+    })
+    const worktrees = [staleHighOrder, freshActive]
+
+    worktrees.sort(buildWorktreeComparator('recent', null, repoMap, null, NOW))
+
+    expect(worktrees.map((w) => w.id)).toEqual(['fresh-active', 'stale-high-order'])
   })
 })

--- a/src/renderer/src/components/sidebar/smart-sort.ts
+++ b/src/renderer/src/components/sidebar/smart-sort.ts
@@ -145,7 +145,13 @@ export function buildWorktreeComparator(
         )
       }
       case 'recent':
-        return b.sortOrder - a.sortOrder || a.displayName.localeCompare(b.displayName)
+        // Why lastActivityAt (not sortOrder): sortOrder is a snapshot of the
+        // smart-sort ranking that only gets repersisted while the user is in
+        // "Smart" mode, so it's frozen in Recent mode and ignores new terminal
+        // events, meta edits, etc. lastActivityAt is the real "recency" signal
+        // — it's bumped by bumpWorktreeActivity (PTY spawn, background events)
+        // and by meaningful meta edits (comment, isUnread).
+        return b.lastActivityAt - a.lastActivityAt || a.displayName.localeCompare(b.displayName)
       case 'repo': {
         const ra = repoMap.get(a.repoId)?.displayName ?? ''
         const rb = repoMap.get(b.repoId)?.displayName ?? ''

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -280,10 +280,11 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
       // v1: sort was called 'smart' internally
       // v2: renamed 'smart' → 'recent' (same weighted-score behavior)
       // v3: 'smart' reintroduced as the weighted-score sort, 'recent' becomes
-      //     a creation-time sort. The one-shot migration from old 'recent'
-      //     to 'smart' now happens in the main process (persistence.ts load())
-      //     using the _sortBySmartMigrated flag — not here — so that users who
-      //     intentionally select the new 'recent' sort keep it across restarts.
+      //     a last-activity sort (worktree.lastActivityAt descending). The
+      //     one-shot migration from old 'recent' to 'smart' happens in the
+      //     main process (persistence.ts load()) using the _sortBySmartMigrated
+      //     flag — not here — so that users who intentionally select the new
+      //     'recent' sort keep it across restarts.
       const sortBy = ui.sortBy
       return {
         // Why: persisted UI data comes from disk and may be stale, corrupted,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -720,7 +720,7 @@ export type PersistedUIState = {
    *  (v1→v2 rename). When this flag is absent and sortBy is 'recent', the
    *  main-process load() migrates it to 'smart' and sets this flag so the
    *  migration never re-fires — allowing users to intentionally select the
-   *  new 'recent' (creation-time) sort without it being clobbered on restart. */
+   *  new 'recent' (last-activity) sort without it being clobbered on restart. */
   _sortBySmartMigrated?: boolean
   /** Snapshot of totalAgentsSpawned captured the first time we see the current
    *  app version. Why: the nag threshold counts agents spawned *since the


### PR DESCRIPTION
## Summary

The "Recent" sort in the sidebar was using `worktree.sortOrder`, which is only repersisted while the user is in **Smart** mode (via `persistSortOrder` in `WorktreeList.tsx`). In Recent mode the ordering was effectively frozen to the last Smart-sort snapshot — or, for worktrees whose meta was created while in Recent mode, to the `Date.now()` stamped when their meta record was first written. Terminal activity, comment edits, and unread marks on other worktrees never moved them up the list, while worktrees with stale-high `sortOrder` values (e.g. the user's most-used repo) stayed glued to the top.

Switch the `'recent'` comparator to `lastActivityAt` descending so that the events that already bump `lastActivityAt` (PTY spawn/exit via `bumpWorktreeActivity`, comment edits, unread marks, worktree creation) now actually re-rank the sidebar in Recent mode. `sortOrder` is no longer read by this comparator.

Also updated three comments (`types.ts`, `ui.ts`, `persistence.ts`) that described Recent as a "creation-time" sort, which is no longer accurate.

The existing one-shot `'recent' → 'smart'` migration (gated by `_sortBySmartMigrated`) is untouched, so users who were auto-migrated to Smart stay on Smart, and users who intentionally re-selected Recent keep it across restarts.

## Test plan

- [x] Unit tests updated in `smart-sort.test.ts` — new test verifies that a stale-high `sortOrder` does not outrank a worktree with fresher `lastActivityAt`
- [x] `pnpm vitest run` on sidebar/store/persistence suites: 310/310 passing
- [x] **Tested end-to-end in a dev instance**: selected "Recent" sort, confirmed that opening a new terminal in a worktree bumps it to the top of the Recent list. Also confirmed the pre-existing "active worktree skips sortEpoch" behavior (PR #209) still holds — the active worktree does not visibly jump while you're interacting with it, only after a background event fires