### PR TITLE
fix(editor): improve rich markdown table readability

### DIFF
--- a/src/renderer/src/assets/rich-markdown-editor.css
+++ b/src/renderer/src/assets/rich-markdown-editor.css
@@ -298,8 +298,6 @@
 .rich-markdown-editor th {
   font-weight: 600;
   font-size: 0.85em;
-  text-transform: uppercase;
-  letter-spacing: 0.03em;
   background: color-mix(in srgb, var(--foreground) 4%, transparent);
 }
 

--- a/src/renderer/src/assets/rich-markdown-editor.css
+++ b/src/renderer/src/assets/rich-markdown-editor.css
@@ -297,11 +297,14 @@
 
 .rich-markdown-editor th {
   font-weight: 600;
-  font-size: 0.85em;
   background: color-mix(in srgb, var(--foreground) 4%, transparent);
 }
 
-.rich-markdown-editor tr:nth-child(even) td {
+/* Why: Tiptap tables render as <tbody> only with the first <tr> containing
+   <th> cells. Striping odd rows (1, 3, 5) skips the header row — which has
+   no <td> — and starts alternation from the second data row, avoiding a
+   shaded band directly adjacent to the header. */
+.rich-markdown-editor tr:nth-child(odd) td {
   background: color-mix(in srgb, var(--foreground) 1.5%, transparent);
 }
 

--- a/src/renderer/src/assets/rich-markdown-editor.css
+++ b/src/renderer/src/assets/rich-markdown-editor.css
@@ -280,6 +280,33 @@
   background: color-mix(in srgb, var(--foreground) 2%, transparent);
 }
 
+.rich-markdown-editor table {
+  width: 100%;
+  margin: 1em 0;
+  border-collapse: collapse;
+  font-size: 0.95em;
+}
+
+.rich-markdown-editor th,
+.rich-markdown-editor td {
+  padding: 8px 14px;
+  border: 1px solid var(--border);
+  text-align: left;
+  vertical-align: top;
+}
+
+.rich-markdown-editor th {
+  font-weight: 600;
+  font-size: 0.85em;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  background: color-mix(in srgb, var(--foreground) 4%, transparent);
+}
+
+.rich-markdown-editor tr:nth-child(even) td {
+  background: color-mix(in srgb, var(--foreground) 1.5%, transparent);
+}
+
 .rich-markdown-editor code {
   padding: 0.2em 0.4em;
   border-radius: 5px;


### PR DESCRIPTION
## Summary
- add visible cell borders to rich markdown tables so formatted tables are easier to scan in the editor
- add subtle header and alternating row styling to improve separation without changing markdown content or table behavior
- keep the change scoped to the rich markdown surface; preview mode already had table separators

## Why
Rich markdown tables were hard to read because adjacent cells visually ran together. Adding clear cell boundaries greatly enhances readability, especially for wider tables with dense content.

## Testing
- `corepack pnpm lint`
- `corepack pnpm typecheck`
- `corepack pnpm test`
- `corepack pnpm build:relay && corepack pnpm build:electron-vite && corepack pnpm build:cli`

## Screenshots
- Omitted for now; can be added manually after PR creation if needed.

## AI Code Review Summary
- Reviewed the change for cross-platform compatibility: CSS-only styling scoped to `.rich-markdown-editor` with no macOS/Linux/Windows-specific code paths, shortcuts, or path handling.
- Checked for regressions in adjacent markdown surfaces: preview mode already had table borders, and this update only affects the rich editor table presentation.
- Basic security audit: no new network access, file system access, HTML injection, or privilege boundaries changed; the patch only adjusts static table styling.

## Platform Notes
- Expected to behave the same on macOS, Linux, and Windows because the change only updates shared renderer CSS.
- Verified locally in Orca dev mode on macOS.

## X Handle
- @a_parusel