### PR TITLE
fix(sidebar): raise contrast on 'Don't ask again' checkbox

### DIFF
--- a/src/renderer/src/components/sidebar/DeleteWorktreeDialog.tsx
+++ b/src/renderer/src/components/sidebar/DeleteWorktreeDialog.tsx
@@ -207,13 +207,13 @@ const DeleteWorktreeDialog = React.memo(function DeleteWorktreeDialog() {
             role="checkbox"
             aria-checked={dontAskAgain}
             onClick={() => setDontAskAgain((prev) => !prev)}
-            className="flex items-center gap-2 rounded-sm px-1 py-1 text-xs text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            className="flex items-center gap-2 rounded-sm px-1 py-1 text-xs text-foreground/80 transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             <span
               className={`flex size-4 items-center justify-center rounded-sm border transition-colors ${
                 dontAskAgain
                   ? 'border-foreground bg-foreground text-background'
-                  : 'border-muted-foreground/50 bg-transparent'
+                  : 'border-muted-foreground bg-transparent'
               }`}
             >
               {dontAskAgain ? <Check className="size-3" strokeWidth={3} /> : null}


### PR DESCRIPTION
## Summary
- The "Don't ask again" label and unchecked checkbox border in the delete worktree dialog were rendered with `text-muted-foreground` / `border-muted-foreground/50`, which is too faint to see against the dialog background.
- Bumped the label to `text-foreground/80` and the unchecked border to `border-muted-foreground` so the control is clearly visible at rest while preserving the checked and hover styling.

## Test plan
- [ ] Open the delete worktree confirmation dialog; verify the "Don't ask again" label and checkbox are clearly legible in both light and dark mode.
- [ ] Hover the control — label still brightens to `text-foreground`.
- [ ] Toggle the checkbox — checked state still renders filled.