### PR TITLE
fix(editor): debounce tombstone to avoid flash on macOS atomic writes

### DIFF
--- a/src/renderer/src/hooks/useEditorExternalWatch.test.ts
+++ b/src/renderer/src/hooks/useEditorExternalWatch.test.ts
@@ -1,12 +1,24 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { getOverflowExternalReloadTargets } from './useEditorExternalWatch'
-import { useAppStore } from '@/store'
+import { beforeEach, describe, expect, it, vi, afterEach } from 'vitest'
+import type { FsChangedPayload } from '../../../shared/types'
 
 vi.mock('@/store', () => ({
   useAppStore: {
     getState: vi.fn()
   }
 }))
+// Why: editor-autosave calls window.dispatchEvent at module scope paths; the
+// vitest 'node' environment has no window. Stub the two exports we use so the
+// handler can run headlessly.
+vi.mock('@/components/editor/editor-autosave', () => ({
+  notifyEditorExternalFileChange: vi.fn(),
+  getOpenFilesForExternalFileChange: vi.fn(() => [])
+}))
+
+import {
+  createExternalWatchEventHandler,
+  getOverflowExternalReloadTargets
+} from './useEditorExternalWatch'
+import { useAppStore } from '@/store'
 
 describe('getOverflowExternalReloadTargets', () => {
   const setExternalMutation = vi.fn()
@@ -61,5 +73,94 @@ describe('getOverflowExternalReloadTargets', () => {
       }
     ])
     expect(setExternalMutation).toHaveBeenCalledWith('file-1', null)
+  })
+})
+
+describe('createExternalWatchEventHandler tombstone coalescing', () => {
+  const setExternalMutation = vi.fn()
+  const findTarget = (
+    worktreePath: string
+  ):
+    | {
+        worktreeId: string
+        worktreePath: string
+        connectionId: string | undefined
+      }
+    | undefined =>
+    worktreePath === '/repo'
+      ? { worktreeId: 'wt-1', worktreePath: '/repo', connectionId: undefined }
+      : undefined
+
+  const fileNotes = {
+    id: 'file-notes',
+    worktreeId: 'wt-1',
+    worktreePath: '/repo',
+    filePath: '/repo/notes.md',
+    relativePath: 'notes.md',
+    mode: 'edit' as const,
+    isDirty: false
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    vi.mocked(useAppStore.getState).mockReturnValue({
+      openFiles: [fileNotes],
+      setExternalMutation
+    } as never)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  function payload(events: FsChangedPayload['events']): FsChangedPayload {
+    return { worktreePath: '/repo', events }
+  }
+
+  it('does not flash deleted when a create at the same path arrives in the next payload', () => {
+    // Simulates macOS atomic write: two back-to-back payloads, delete then create.
+    const { handleFsChanged, dispose } = createExternalWatchEventHandler(findTarget)
+    handleFsChanged(payload([{ kind: 'delete', absolutePath: '/repo/notes.md' }]))
+
+    // Advance less than the debounce window; the deleted tombstone must not
+    // have fired yet.
+    vi.advanceTimersByTime(10)
+    expect(setExternalMutation).not.toHaveBeenCalledWith('file-notes', 'deleted')
+
+    handleFsChanged(payload([{ kind: 'create', absolutePath: '/repo/notes.md' }]))
+
+    // Flush anything remaining; the pending tombstone should have been cancelled.
+    vi.advanceTimersByTime(500)
+    expect(setExternalMutation).not.toHaveBeenCalledWith('file-notes', 'deleted')
+
+    dispose()
+  })
+
+  it('still sets deleted after the debounce window for a naked delete', () => {
+    const { handleFsChanged, dispose } = createExternalWatchEventHandler(findTarget)
+    handleFsChanged(payload([{ kind: 'delete', absolutePath: '/repo/notes.md' }]))
+
+    expect(setExternalMutation).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(200)
+    expect(setExternalMutation).toHaveBeenCalledWith('file-notes', 'deleted')
+
+    dispose()
+  })
+
+  it('resolves batched delete+create in a single payload synchronously as renamed', () => {
+    const { handleFsChanged, dispose } = createExternalWatchEventHandler(findTarget)
+    handleFsChanged(
+      payload([
+        { kind: 'delete', absolutePath: '/repo/notes.md' },
+        { kind: 'create', absolutePath: '/repo/subdir/notes.md' }
+      ])
+    )
+
+    // The single-payload rename-correlated path must not defer — the decision
+    // is already correct because both events are visible at once.
+    expect(setExternalMutation).toHaveBeenCalledWith('file-notes', 'renamed')
+
+    dispose()
   })
 })

--- a/src/renderer/src/hooks/useEditorExternalWatch.ts
+++ b/src/renderer/src/hooks/useEditorExternalWatch.ts
@@ -1,3 +1,7 @@
+/* eslint-disable max-lines -- Why: the editor external-watch hook co-locates
+   target diffing, fs:changed dispatch, tombstone coalescing, and rename
+   correlation so the end-to-end event-to-store mutation contract stays
+   readable in one file. */
 import { useEffect, useMemo, useRef } from 'react'
 import { useAppStore } from '@/store'
 import { getConnectionId } from '@/lib/connection-context'
@@ -10,6 +14,7 @@ import {
 } from '@/components/editor/editor-autosave'
 import type { FsChangedPayload } from '../../../shared/types'
 import { findWorktreeById } from '@/store/slices/worktree-helpers'
+import type { OpenFile } from '@/store/slices/editor'
 
 // Why: atomic-write patterns (Claude Code's Edit tool, editors like vim,
 // VSCode) land as a short burst of `update` events — or `delete + create` on
@@ -49,6 +54,21 @@ type ExternalWatchNotification = {
   worktreeId: string
   worktreePath: string
   relativePath: string
+}
+
+// Why: macOS atomic writes (Claude Code Edit, vim :w, VSCode save) deliver a
+// delete event immediately followed by a create event for the same path. When
+// those two land in separate fs:changed payloads a few ms apart, the tab
+// flickers struck-through for one render before the follow-up create clears
+// it. Debouncing just the 'deleted' signal — keyed by absolute path — lets a
+// same-path create in the next payload cancel the tombstone before it ever
+// paints. A naked delete still resolves to 'deleted' after the window. The
+// in-payload rename correlation is unchanged.
+const EXTERNAL_MUTATION_DEBOUNCE_MS = 75
+
+type PendingDeleteTimer = {
+  fileId: string
+  timer: ReturnType<typeof setTimeout>
 }
 
 /**
@@ -142,132 +162,16 @@ export function useEditorExternalWatch(): void {
   // single always-mounted effect avoids re-subscribing on every targetsKey
   // change (which would otherwise miss events fired during re-subscription).
   useEffect(() => {
-    const handleFsChanged = (payload: FsChangedPayload): void => {
-      const target = targetsRef.current.find(
-        (t) => normalizeAbsolutePath(t.worktreePath) === normalizeAbsolutePath(payload.worktreePath)
+    const { handleFsChanged, dispose } = createExternalWatchEventHandler((worktreePath) =>
+      targetsRef.current.find(
+        (t) => normalizeAbsolutePath(t.worktreePath) === normalizeAbsolutePath(worktreePath)
       )
-      if (!target) {
-        return
-      }
-
-      // Why: when an external process removes (or `git mv`s) a file that's
-      // open in the editor, keep the tab alive and mark it as deleted/renamed
-      // so the user can see the mutation and still access their in-memory
-      // content. A paired create-event in the same batch signals a rename;
-      // a lone delete is a hard delete. Resurrection (same path comes back
-      // on disk) clears the mark further down.
-      const deletedOpenEditorIds = collectDeletedOpenEditorIds(payload, target.worktreeId)
-      // Why: correlate creates to deletes by basename OR parent directory to
-      // avoid mislabelling unrelated create+delete pairs in a batched payload
-      // as "renamed". When we can't correlate, default to 'deleted' — that's
-      // the least misleading fallback (it preserves in-memory content and
-      // doesn't claim a rename target that doesn't exist).
-      const hasPairedCreate =
-        deletedOpenEditorIds.length > 0 &&
-        hasRenameCorrelatedCreate(payload, target.worktreeId, deletedOpenEditorIds)
-      if (deletedOpenEditorIds.length > 0) {
-        const setExternalMutation = useAppStore.getState().setExternalMutation
-        const mutation = hasPairedCreate ? 'renamed' : 'deleted'
-        for (const fileId of deletedOpenEditorIds) {
-          setExternalMutation(fileId, mutation)
-        }
-      }
-
-      // Why: if a previously-deleted file reappears at the same path (e.g.
-      // the user ran `git checkout`), clear the tombstone so the tab returns
-      // to its normal state and any non-dirty content gets reloaded below.
-      const createOrUpdatePaths = new Set<string>()
-      for (const evt of payload.events) {
-        if (evt.isDirectory === true) {
-          continue
-        }
-        if (evt.kind === 'create' || evt.kind === 'update') {
-          createOrUpdatePaths.add(normalizeAbsolutePath(evt.absolutePath))
-        }
-      }
-      if (createOrUpdatePaths.size > 0) {
-        const state = useAppStore.getState()
-        for (const file of state.openFiles) {
-          if (
-            file.worktreeId === target.worktreeId &&
-            file.mode === 'edit' &&
-            file.externalMutation &&
-            createOrUpdatePaths.has(normalizeAbsolutePath(file.filePath))
-          ) {
-            state.setExternalMutation(file.id, null)
-          }
-        }
-      }
-
-      const changedFiles = new Set<string>()
-      for (const evt of payload.events) {
-        if (evt.kind === 'overflow') {
-          // Why: overflow payloads omit per-path create/update info, so any
-          // stale tombstone must be cleared conservatively before we decide
-          // which clean tabs to reload. Otherwise a file that reappeared on
-          // disk during the overrun stays struck through until some later
-          // path-specific event happens to clear it.
-          for (const notification of getOverflowExternalReloadTargets(target)) {
-            scheduleDebouncedExternalReload(notification)
-          }
-          // Why: `break` (not `return`) — the remaining code early-returns
-          // when changedFiles is empty, so breaking out is semantically
-          // equivalent and more robust to future code added after the loop.
-          break
-        }
-
-        if (evt.kind === 'update' && evt.isDirectory === true) {
-          continue
-        }
-
-        if (evt.kind === 'delete') {
-          // Why: delete events are already handled above by marking the tab
-          // as tombstoned. Feeding them into the reload pipeline would fire
-          // `readFile` against the ENOENT path and replace the in-memory
-          // content with "Error loading file..." — losing the user's view.
-          continue
-        }
-
-        const relativePath = getExternalFileChangeRelativePath(
-          target.worktreePath,
-          normalizeAbsolutePath(evt.absolutePath),
-          evt.isDirectory
-        )
-        if (relativePath) {
-          changedFiles.add(relativePath)
-        }
-      }
-
-      if (changedFiles.size === 0) {
-        return
-      }
-
-      // Why: skip notifying for any tab with unsaved edits so external writes
-      // don't silently destroy the user's work. Mirrors the dirty guard in
-      // `useFileExplorerHandlers`. Read `openFiles` once per payload to avoid
-      // N store reads for large batched events.
-      const openFilesSnapshot = useAppStore.getState().openFiles
-      for (const relativePath of changedFiles) {
-        const notification = {
-          worktreeId: target.worktreeId,
-          worktreePath: target.worktreePath,
-          relativePath
-        }
-        const matching = getOpenFilesForExternalFileChange(openFilesSnapshot, notification)
-        if (matching.length === 0) {
-          continue
-        }
-        if (matching.some((f) => f.isDirty)) {
-          continue
-        }
-        scheduleDebouncedExternalReload(notification)
-      }
-    }
-
+    )
     const unsubscribe = window.api.fs.onFsChanged(handleFsChanged)
 
     return () => {
       unsubscribe()
+      dispose()
       // Why: final unmount must tear down every outstanding subscription.
       // The differential watch effect above intentionally never unwatches on
       // cleanup, so this is the only place that clears them.
@@ -286,6 +190,218 @@ export function useEditorExternalWatch(): void {
       // attached once the editor tree is torn down.
     }
   }, [])
+}
+
+/**
+ * Builds the fs:changed handler used by `useEditorExternalWatch`. Exported
+ * so tests can drive the full event pipeline — including the debounced
+ * tombstone coalescer — without mounting the hook. See
+ * `EXTERNAL_MUTATION_DEBOUNCE_MS` for the macOS atomic-write rationale.
+ */
+export function createExternalWatchEventHandler(
+  findTarget: (worktreePath: string) => WatchedTarget | undefined
+): {
+  handleFsChanged: (payload: FsChangedPayload) => void
+  dispose: () => void
+} {
+  // Why: coalesce 'deleted' tombstones across back-to-back payloads so a
+  // same-path create arriving in the next payload (macOS atomic write)
+  // cancels the tombstone before the tab flashes. Keyed by normalized
+  // absolute path, scoped per-target. See EXTERNAL_MUTATION_DEBOUNCE_MS.
+  const pendingDeletes = new Map<string, PendingDeleteTimer>()
+  const pendingKey = (worktreeId: string, absolutePath: string): string =>
+    `${worktreeId}::${absolutePath}`
+
+  const handleFsChanged = (payload: FsChangedPayload): void => {
+    const target = findTarget(payload.worktreePath)
+    if (!target) {
+      return
+    }
+
+    // Why: collect create/update paths first so we can cancel any pending
+    // same-path delete before scheduling a new one. This is what absorbs
+    // the macOS atomic-write delete→create split across two payloads.
+    const createOrUpdatePaths = new Set<string>()
+    for (const evt of payload.events) {
+      if (evt.isDirectory === true) {
+        continue
+      }
+      if (evt.kind === 'create' || evt.kind === 'update') {
+        createOrUpdatePaths.add(normalizeAbsolutePath(evt.absolutePath))
+      }
+    }
+    for (const createdPath of createOrUpdatePaths) {
+      const key = pendingKey(target.worktreeId, createdPath)
+      const existing = pendingDeletes.get(key)
+      if (existing) {
+        clearTimeout(existing.timer)
+        pendingDeletes.delete(key)
+      }
+    }
+
+    // Why: when an external process removes (or `git mv`s) a file that's
+    // open in the editor, keep the tab alive and mark it as deleted/renamed
+    // so the user can see the mutation and still access their in-memory
+    // content. A paired create-event in the same batch signals a rename;
+    // a lone delete is a hard delete. Resurrection (same path comes back
+    // on disk) clears the mark further down.
+    // Why: snapshot openFiles once so the delete/rename helpers below share a
+    // consistent view and we don't pay N store reads per payload.
+    const openFilesAtStart = useAppStore.getState().openFiles
+    const deletedOpenEditorIds = collectDeletedOpenEditorIds(
+      payload,
+      target.worktreeId,
+      openFilesAtStart
+    )
+    // Why: correlate creates to deletes by basename OR parent directory to
+    // avoid mislabelling unrelated create+delete pairs in a batched payload
+    // as "renamed". When we can't correlate, default to 'deleted' — that's
+    // the least misleading fallback (it preserves in-memory content and
+    // doesn't claim a rename target that doesn't exist).
+    const hasPairedCreate =
+      deletedOpenEditorIds.length > 0 &&
+      hasRenameCorrelatedCreate(payload, target.worktreeId, deletedOpenEditorIds, openFilesAtStart)
+    if (deletedOpenEditorIds.length > 0) {
+      if (hasPairedCreate) {
+        // Why: single-payload delete+create is already correct — the rename
+        // label is visible in one render tick, so no debounce is needed.
+        const setExternalMutation = useAppStore.getState().setExternalMutation
+        for (const fileId of deletedOpenEditorIds) {
+          setExternalMutation(fileId, 'renamed')
+        }
+      } else {
+        // Why: defer the 'deleted' tombstone so a follow-up same-path create
+        // in the next payload can cancel it. Build a fileId → path map so we
+        // can key the timer by the deleted file's absolute path.
+        const deletePathByFileId = buildDeletePathByFileId(
+          payload,
+          target.worktreeId,
+          deletedOpenEditorIds,
+          openFilesAtStart
+        )
+        for (const fileId of deletedOpenEditorIds) {
+          const absolutePath = deletePathByFileId.get(fileId)
+          if (!absolutePath) {
+            continue
+          }
+          const key = pendingKey(target.worktreeId, absolutePath)
+          const existing = pendingDeletes.get(key)
+          if (existing) {
+            clearTimeout(existing.timer)
+            pendingDeletes.delete(key)
+          }
+          const timer = setTimeout(() => {
+            pendingDeletes.delete(key)
+            // Why: the debounce widens the window between scheduling the
+            // tombstone and applying it; the tab may have been closed or
+            // switched out of edit mode in between. Re-check both before
+            // writing so we don't resurrect state for a dropped fileId or
+            // tombstone a non-edit tab (mirrors the scheduling-time filter
+            // in `collectDeletedOpenEditorIds`).
+            const state = useAppStore.getState()
+            const stillEditing = state.openFiles.some((f) => f.id === fileId && f.mode === 'edit')
+            if (stillEditing) {
+              state.setExternalMutation(fileId, 'deleted')
+            }
+          }, EXTERNAL_MUTATION_DEBOUNCE_MS)
+          pendingDeletes.set(key, { fileId, timer })
+        }
+      }
+    }
+
+    // Why: if a previously-deleted file reappears at the same path (e.g.
+    // the user ran `git checkout`), clear the tombstone so the tab returns
+    // to its normal state and any non-dirty content gets reloaded below.
+    // `createOrUpdatePaths` was collected above.
+    if (createOrUpdatePaths.size > 0) {
+      const state = useAppStore.getState()
+      for (const file of state.openFiles) {
+        if (
+          file.worktreeId === target.worktreeId &&
+          file.mode === 'edit' &&
+          file.externalMutation &&
+          createOrUpdatePaths.has(normalizeAbsolutePath(file.filePath))
+        ) {
+          state.setExternalMutation(file.id, null)
+        }
+      }
+    }
+
+    const changedFiles = new Set<string>()
+    for (const evt of payload.events) {
+      if (evt.kind === 'overflow') {
+        // Why: overflow payloads omit per-path create/update info, so any
+        // stale tombstone must be cleared conservatively before we decide
+        // which clean tabs to reload. Otherwise a file that reappeared on
+        // disk during the overrun stays struck through until some later
+        // path-specific event happens to clear it.
+        for (const notification of getOverflowExternalReloadTargets(target)) {
+          scheduleDebouncedExternalReload(notification)
+        }
+        // Why: `break` (not `return`) — the remaining code early-returns
+        // when changedFiles is empty, so breaking out is semantically
+        // equivalent and more robust to future code added after the loop.
+        break
+      }
+
+      if (evt.kind === 'update' && evt.isDirectory === true) {
+        continue
+      }
+
+      if (evt.kind === 'delete') {
+        // Why: delete events are already handled above by marking the tab
+        // as tombstoned. Feeding them into the reload pipeline would fire
+        // `readFile` against the ENOENT path and replace the in-memory
+        // content with "Error loading file..." — losing the user's view.
+        continue
+      }
+
+      const relativePath = getExternalFileChangeRelativePath(
+        target.worktreePath,
+        normalizeAbsolutePath(evt.absolutePath),
+        evt.isDirectory
+      )
+      if (relativePath) {
+        changedFiles.add(relativePath)
+      }
+    }
+
+    if (changedFiles.size === 0) {
+      return
+    }
+
+    // Why: skip notifying for any tab with unsaved edits so external writes
+    // don't silently destroy the user's work. Mirrors the dirty guard in
+    // `useFileExplorerHandlers`. Read `openFiles` once per payload to avoid
+    // N store reads for large batched events.
+    const openFilesSnapshot = useAppStore.getState().openFiles
+    for (const relativePath of changedFiles) {
+      const notification = {
+        worktreeId: target.worktreeId,
+        worktreePath: target.worktreePath,
+        relativePath
+      }
+      const matching = getOpenFilesForExternalFileChange(openFilesSnapshot, notification)
+      if (matching.length === 0) {
+        continue
+      }
+      if (matching.some((f) => f.isDirty)) {
+        continue
+      }
+      scheduleDebouncedExternalReload(notification)
+    }
+  }
+
+  const dispose = (): void => {
+    // Why: clear in-flight debounced tombstone timers so they don't fire
+    // after disposal and touch a no-longer-relevant store.
+    for (const pending of pendingDeletes.values()) {
+      clearTimeout(pending.timer)
+    }
+    pendingDeletes.clear()
+  }
+
+  return { handleFsChanged, dispose }
 }
 
 export function getOverflowExternalReloadTargets(
@@ -316,7 +432,40 @@ export function getOverflowExternalReloadTargets(
   return notifications
 }
 
-function collectDeletedOpenEditorIds(payload: FsChangedPayload, worktreeId: string): string[] {
+function buildDeletePathByFileId(
+  payload: FsChangedPayload,
+  worktreeId: string,
+  deletedOpenEditorIds: string[],
+  openFiles: OpenFile[]
+): Map<string, string> {
+  const deletePaths = new Set<string>()
+  for (const evt of payload.events) {
+    if (evt.kind === 'delete') {
+      deletePaths.add(normalizeAbsolutePath(evt.absolutePath))
+    }
+  }
+  const result = new Map<string, string>()
+  if (deletePaths.size === 0) {
+    return result
+  }
+  const deletedIdSet = new Set(deletedOpenEditorIds)
+  for (const file of openFiles) {
+    if (!deletedIdSet.has(file.id) || file.worktreeId !== worktreeId) {
+      continue
+    }
+    const normalized = normalizeAbsolutePath(file.filePath)
+    if (deletePaths.has(normalized)) {
+      result.set(file.id, normalized)
+    }
+  }
+  return result
+}
+
+function collectDeletedOpenEditorIds(
+  payload: FsChangedPayload,
+  worktreeId: string,
+  openFiles: OpenFile[]
+): string[] {
   const deletePaths = new Set<string>()
   for (const evt of payload.events) {
     if (evt.kind === 'delete') {
@@ -326,9 +475,8 @@ function collectDeletedOpenEditorIds(payload: FsChangedPayload, worktreeId: stri
   if (deletePaths.size === 0) {
     return []
   }
-  const openFilesNow = useAppStore.getState().openFiles
   const result: string[] = []
-  for (const file of openFilesNow) {
+  for (const file of openFiles) {
     if (file.worktreeId !== worktreeId || file.mode !== 'edit') {
       continue
     }
@@ -355,15 +503,15 @@ function collectDeletedOpenEditorIds(payload: FsChangedPayload, worktreeId: stri
 function hasRenameCorrelatedCreate(
   payload: FsChangedPayload,
   worktreeId: string,
-  deletedOpenEditorIds: string[]
+  deletedOpenEditorIds: string[],
+  openFiles: OpenFile[]
 ): boolean {
   if (deletedOpenEditorIds.length === 0) {
     return false
   }
   const deletedIdSet = new Set(deletedOpenEditorIds)
-  const openFilesNow = useAppStore.getState().openFiles
   const deletedBasenames = new Set<string>()
-  for (const file of openFilesNow) {
+  for (const file of openFiles) {
     if (file.worktreeId !== worktreeId || file.mode !== 'edit') {
       continue
     }


### PR DESCRIPTION
## Summary

- macOS atomic writes (Claude Code Edit, vim `:w`, VSCode save) deliver a delete event immediately followed by a same-path create event in separate `fs:changed` payloads. The editor tab briefly flashed struck-through (tombstoned) for one render before the follow-up create cleared it.
- This debounces only the `'deleted'` signal by 75ms, keyed by absolute path. A same-path create arriving in the next payload cancels the pending tombstone before it ever paints.
- Naked deletes still resolve to `'deleted'` after the window. Single-payload delete+create rename correlation is unchanged and still fires synchronously (no debounce), since the decision is already correct at that point.

## Implementation notes

- Extracted the fs:changed handler into `createExternalWatchEventHandler(findTarget)` so the pending-delete map is scoped per-hook-mount and so tests can drive the full pipeline (including fake timers) without mounting the hook.
- The deferred `setExternalMutation('deleted')` re-checks `state.openFiles` at fire time so it does not resurrect state for a closed tab or tombstone a non-edit tab.
- `dispose()` clears in-flight timers on unmount.
- Snapshotted `openFiles` once per payload and passed it into the `collectDeletedOpenEditorIds` / `hasRenameCorrelatedCreate` helpers to avoid N store reads per payload.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm vitest run src/renderer/src/hooks/useEditorExternalWatch.test.ts` — 4 tests pass, including: same-path create in next payload cancels tombstone, naked delete still tombstones after the window, batched delete+create still resolves as `renamed` synchronously.
- [ ] Manual: on macOS, trigger a Claude Code `Edit` on an open file and confirm the tab does not flash struck-through.
- [ ] Manual: external `rm` of an open file still tombstones after ~75ms.
- [ ] Manual: `git mv` of an open file in one batched event still shows as `renamed` with no delay.