### PR TITLE
fix(terminal): refresh WebGL canvas after resume to prevent frozen terminal

### DIFF
--- a/src/renderer/src/lib/pane-manager/pane-manager.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager.ts
@@ -301,6 +301,18 @@ export class PaneManager {
     for (const pane of this.panes.values()) {
       if (pane.gpuRenderingEnabled && !pane.webglAddon) {
         attachWebgl(pane)
+        // Why: the fitPanes() optimization skips panes whose dimensions are
+        // unchanged (common when a worktree goes hidden→visible at the same
+        // window size). But the fresh WebGL canvas created by attachWebgl()
+        // has no painted content — without an explicit refresh the terminal
+        // appears frozen until something forces a dimension change (e.g. a
+        // split). This mirrors the onContextLoss handler in attachWebgl which
+        // calls the same refresh after falling back to the DOM renderer.
+        try {
+          pane.terminal.refresh(0, pane.terminal.rows - 1)
+        } catch {
+          /* ignore — pane may not be fully initialised yet */
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- After switching worktrees, `suspendRendering()` disposes WebGL addons and `resumeRendering()` recreates them. However, `fitPanes()` has a Windows perf optimization that skips panes whose dimensions haven't changed — so the fresh WebGL canvas never gets painted and the terminal appears frozen.
- Adds an explicit `terminal.refresh()` after `attachWebgl()` in `resumeRendering()`, mirroring the existing `onContextLoss` handler pattern in the same file.
- The fix is a single `refresh()` call that forces xterm.js to repaint the viewport onto the new WebGL canvas regardless of whether dimensions changed.

## Context
Reported in [Slack thread](https://stablygroup.slack.com/archives/C0AK2T3JEF4/p1776621529124589) — multiple users on 1.3.5-rc.1 experiencing frozen terminals after switching worktrees. Typing still went through (PTY was fine) but the terminal didn't render. Splitting the tab (which forces a dimension change) unfroze it.

## Test plan
- [ ] Open a worktree with a terminal (split panes for extra coverage)
- [ ] Switch to another worktree, do some work
- [ ] Switch back — terminal should render immediately without needing to split
- [ ] Verify no visual flash or rendering glitch on resume
- [ ] Verify Windows performance is not regressed (the `fitPanes` dimension-skip optimization still applies for the `fit()` call; only the lightweight `refresh()` is added)