### PR TITLE
Add New GitHub issue dialog to tasks page

### DIFF
--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -11,7 +11,7 @@ import type {
 import { getPRConflictSummary } from './conflict-summary'
 import { execFileAsync, ghExecFileAsync, acquire, release, getOwnerRepo } from './gh-utils'
 export { _resetOwnerRepoCache } from './gh-utils'
-export { getIssue, listIssues } from './issues'
+export { getIssue, listIssues, createIssue } from './issues'
 import {
   mapCheckRunRESTStatus,
   mapCheckRunRESTConclusion,

--- a/src/main/github/issues.ts
+++ b/src/main/github/issues.ts
@@ -71,3 +71,53 @@ export async function listIssues(repoPath: string, limit = 20): Promise<IssueInf
     release()
   }
 }
+
+/**
+ * Create a new GitHub issue. Uses `gh api` with explicit owner/repo so the
+ * call does not depend on the current working directory having a remote that
+ * matches the repo the user picked in the tasks page.
+ */
+export async function createIssue(
+  repoPath: string,
+  title: string,
+  body: string
+): Promise<{ ok: true; number: number; url: string } | { ok: false; error: string }> {
+  const trimmedTitle = title.trim()
+  if (!trimmedTitle) {
+    return { ok: false, error: 'Title is required' }
+  }
+  const ownerRepo = await getOwnerRepo(repoPath)
+  if (!ownerRepo) {
+    return { ok: false, error: 'Could not resolve GitHub owner/repo for this repository' }
+  }
+  await acquire()
+  try {
+    const { stdout } = await ghExecFileAsync(
+      [
+        'api',
+        '-X',
+        'POST',
+        `repos/${ownerRepo.owner}/${ownerRepo.repo}/issues`,
+        '-f',
+        `title=${trimmedTitle}`,
+        '-f',
+        `body=${body}`
+      ],
+      { cwd: repoPath }
+    )
+    const data = JSON.parse(stdout) as { number?: number; html_url?: string; url?: string }
+    if (typeof data.number !== 'number') {
+      return { ok: false, error: 'Unexpected response from GitHub' }
+    }
+    return {
+      ok: true,
+      number: data.number,
+      url: String(data.html_url ?? data.url ?? '')
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    return { ok: false, error: message }
+  } finally {
+    release()
+  }
+}

--- a/src/main/ipc/github.ts
+++ b/src/main/ipc/github.ts
@@ -10,6 +10,7 @@ import {
   listIssues,
   listWorkItems,
   getWorkItem,
+  createIssue,
   getAuthenticatedViewer,
   getPRChecks,
   getPRComments,
@@ -60,6 +61,14 @@ export function registerGitHubHandlers(store: Store, stats: StatsCollector): voi
     const repo = assertRegisteredRepo(args.repoPath, store)
     return listIssues(repo.path, args.limit)
   })
+
+  ipcMain.handle(
+    'gh:createIssue',
+    (_event, args: { repoPath: string; title: string; body: string }) => {
+      const repo = assertRegisteredRepo(args.repoPath, store)
+      return createIssue(repo.path, args.title, args.body)
+    }
+  )
 
   ipcMain.handle(
     'gh:listWorkItems',

--- a/src/preload/api-types.d.ts
+++ b/src/preload/api-types.d.ts
@@ -343,6 +343,11 @@ export type PreloadApi = {
       baseSha: string
     }) => Promise<GitHubPRFileContents>
     listIssues: (args: { repoPath: string; limit?: number }) => Promise<IssueInfo[]>
+    createIssue: (args: {
+      repoPath: string
+      title: string
+      body: string
+    }) => Promise<{ ok: true; number: number; url: string } | { ok: false; error: string }>
     listWorkItems: (args: {
       repoPath: string
       limit?: number

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -104,6 +104,11 @@ type GhApi = {
     baseSha: string
   }) => Promise<GitHubPRFileContents>
   listIssues: (args: { repoPath: string; limit?: number }) => Promise<IssueInfo[]>
+  createIssue: (args: {
+    repoPath: string
+    title: string
+    body: string
+  }) => Promise<{ ok: true; number: number; url: string } | { ok: false; error: string }>
   listWorkItems: (args: {
     repoPath: string
     limit?: number

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -367,6 +367,13 @@ const api = {
     listIssues: (args: { repoPath: string; limit?: number }): Promise<unknown[]> =>
       ipcRenderer.invoke('gh:listIssues', args),
 
+    createIssue: (args: {
+      repoPath: string
+      title: string
+      body: string
+    }): Promise<{ ok: true; number: number; url: string } | { ok: false; error: string }> =>
+      ipcRenderer.invoke('gh:createIssue', args),
+
     listWorkItems: (args: {
       repoPath: string
       limit?: number

--- a/src/renderer/src/components/GitHubItemDrawer.tsx
+++ b/src/renderer/src/components/GitHubItemDrawer.tsx
@@ -446,6 +446,34 @@ export default function GitHubItemDrawer({
 
   const requestIdRef = useRef(0)
 
+  // Why: when this drawer opens immediately after another Radix overlay
+  // (e.g. the New Issue dialog) closed, Radix may leave `pointer-events: none`
+  // on <body>. That silently kills clicks on the header's Close/open-in-GitHub
+  // buttons. Poll a few frames to clear it whenever Radix re-applies it during
+  // its own mount sequence.
+  useEffect(() => {
+    if (!workItem) {
+      return
+    }
+    let cancelled = false
+    let count = 0
+    const tick = (): void => {
+      if (cancelled) {
+        return
+      }
+      if (document.body.style.pointerEvents === 'none') {
+        document.body.style.pointerEvents = ''
+      }
+      if (count++ < 5) {
+        requestAnimationFrame(tick)
+      }
+    }
+    tick()
+    return () => {
+      cancelled = true
+    }
+  }, [workItem])
+
   useEffect(() => {
     if (!workItem || !repoPath) {
       setDetails(null)

--- a/src/renderer/src/components/NewWorkspacePage.tsx
+++ b/src/renderer/src/components/NewWorkspacePage.tsx
@@ -11,6 +11,7 @@ import {
   Github,
   GitPullRequest,
   LoaderCircle,
+  Plus,
   RefreshCw,
   Search,
   X
@@ -19,6 +20,14 @@ import { toast } from 'sonner'
 import { useAppStore } from '@/store'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -206,6 +215,10 @@ export default function NewWorkspacePage(): React.JSX.Element {
   // The composer modal is only opened by the drawer's "Use" button, which
   // calls the same handleSelectWorkItem as the old direct row-click flow.
   const [drawerWorkItem, setDrawerWorkItem] = useState<GitHubWorkItem | null>(null)
+  const [newIssueOpen, setNewIssueOpen] = useState(false)
+  const [newIssueTitle, setNewIssueTitle] = useState('')
+  const [newIssueBody, setNewIssueBody] = useState('')
+  const [newIssueSubmitting, setNewIssueSubmitting] = useState(false)
 
   const filteredWorkItems = useMemo(() => {
     if (!activeTaskPreset) {
@@ -368,12 +381,73 @@ export default function NewWorkspacePage(): React.JSX.Element {
     [openModal, repoId]
   )
 
+  const handleCreateNewIssue = useCallback(async (): Promise<void> => {
+    if (!selectedRepo) {
+      return
+    }
+    const title = newIssueTitle.trim()
+    if (!title || newIssueSubmitting) {
+      return
+    }
+    setNewIssueSubmitting(true)
+    try {
+      const result = await window.api.gh.createIssue({
+        repoPath: selectedRepo.path,
+        title,
+        body: newIssueBody
+      })
+      if (!result.ok) {
+        toast.error(result.error || 'Failed to create issue.')
+        return
+      }
+      toast.success(`Opened issue #${result.number}`, {
+        action: result.url
+          ? {
+              label: 'View',
+              onClick: () => window.open(result.url, '_blank')
+            }
+          : undefined
+      })
+      setNewIssueOpen(false)
+      setNewIssueTitle('')
+      setNewIssueBody('')
+      // Why: bump the nonce so the list refetches and shows the new issue.
+      setTaskRefreshNonce((current) => current + 1)
+
+      // Why: auto-open the new issue in the side drawer so the user sees
+      // exactly what was filed. Use an optimistic stub first so the drawer
+      // has immediate content, then refine with the full `workItem` fetch.
+      const stub: GitHubWorkItem = {
+        id: `issue:${String(result.number)}`,
+        type: 'issue',
+        number: result.number,
+        title,
+        state: 'open',
+        url: result.url,
+        labels: [],
+        updatedAt: new Date().toISOString(),
+        author: null
+      }
+      setDrawerWorkItem(stub)
+      void window.api.gh
+        .workItem({ repoPath: selectedRepo.path, number: result.number })
+        .then((full) => {
+          if (full) {
+            setDrawerWorkItem(full)
+          }
+        })
+        .catch(() => {})
+    } finally {
+      setNewIssueSubmitting(false)
+    }
+  }, [newIssueBody, newIssueSubmitting, newIssueTitle, selectedRepo])
+
   useEffect(() => {
     // Why: when the GitHub preview sheet is open, Radix's Dialog owns Esc —
     // it closes the sheet on its own. Page-level capture would otherwise fire
     // first and pop the tasks page while the user just meant to dismiss the
     // preview.
-    if (drawerWorkItem) {
+    if (drawerWorkItem || newIssueOpen) {
       return
     }
 
@@ -407,7 +481,7 @@ export default function NewWorkspacePage(): React.JSX.Element {
 
     window.addEventListener('keydown', onKeyDown, { capture: true })
     return () => window.removeEventListener('keydown', onKeyDown, { capture: true })
-  }, [closeNewWorkspacePage, drawerWorkItem])
+  }, [closeNewWorkspacePage, drawerWorkItem, newIssueOpen])
 
   return (
     <div className="relative flex h-full min-h-0 flex-1 overflow-hidden bg-background text-foreground">
@@ -514,6 +588,27 @@ export default function NewWorkspacePage(): React.JSX.Element {
                       </div>
 
                       <div className="flex shrink-0 items-center gap-2">
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Button
+                              variant="outline"
+                              size="icon"
+                              onClick={() => {
+                                setNewIssueTitle('')
+                                setNewIssueBody('')
+                                setNewIssueOpen(true)
+                              }}
+                              disabled={!selectedRepo}
+                              aria-label="New GitHub issue"
+                              className="border-border/50 bg-transparent hover:bg-muted/50 backdrop-blur-md supports-[backdrop-filter]:bg-transparent"
+                            >
+                              <Plus className="size-4" />
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent side="bottom" sideOffset={6}>
+                            New GitHub issue
+                          </TooltipContent>
+                        </Tooltip>
                         <Tooltip>
                           <TooltipTrigger asChild>
                             <Button
@@ -760,6 +855,80 @@ export default function NewWorkspacePage(): React.JSX.Element {
           )}
         </div>
       </div>
+
+      <Dialog
+        open={newIssueOpen}
+        onOpenChange={(open) => {
+          if (!newIssueSubmitting) {
+            setNewIssueOpen(open)
+          }
+        }}
+      >
+        <DialogContent
+          className="sm:max-w-lg"
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
+              event.preventDefault()
+              void handleCreateNewIssue()
+            }
+          }}
+        >
+          <DialogHeader>
+            <DialogTitle>New GitHub issue</DialogTitle>
+            <DialogDescription>
+              Opens a new issue in {selectedRepo?.displayName ?? 'this repository'}.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex flex-col gap-3">
+            <div className="flex flex-col gap-1">
+              <label className="text-[11px] font-medium text-muted-foreground">Title</label>
+              <Input
+                autoFocus
+                value={newIssueTitle}
+                onChange={(e) => setNewIssueTitle(e.target.value)}
+                placeholder="Short summary"
+                disabled={newIssueSubmitting}
+              />
+            </div>
+            <div className="flex flex-col gap-1">
+              <label className="text-[11px] font-medium text-muted-foreground">
+                Description (optional, markdown)
+              </label>
+              <textarea
+                value={newIssueBody}
+                onChange={(e) => setNewIssueBody(e.target.value)}
+                placeholder="What's going on?"
+                rows={6}
+                disabled={newIssueSubmitting}
+                className="w-full min-w-0 rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs transition-[color,box-shadow] outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 resize-none max-h-60 overflow-y-auto"
+              />
+            </div>
+            <p className="text-[10px] text-muted-foreground">Cmd/Ctrl+Enter to submit.</p>
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setNewIssueOpen(false)}
+              disabled={newIssueSubmitting}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={() => void handleCreateNewIssue()}
+              disabled={!selectedRepo || !newIssueTitle.trim() || newIssueSubmitting}
+            >
+              {newIssueSubmitting ? (
+                <>
+                  <LoaderCircle className="size-4 animate-spin" />
+                  Creating…
+                </>
+              ) : (
+                'Create issue'
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       <GitHubItemDrawer
         workItem={drawerWorkItem}


### PR DESCRIPTION
## Problem
Users can't create a new GitHub issue directly from the tasks page. They must navigate away, go to GitHub, and create it manually before returning to add it to their tasks list. This is disruptive to the workflow.

## Solution
Added a + button on the tasks page that opens a dialog to create a new GitHub issue in the selected repository. The dialog accepts a title and optional description (markdown supported). After creating the issue, the tasks list automatically refreshes so the new issue appears in the list immediately, ready to be added to a task.

### Implementation details
- New `createIssue` function in `src/main/github/issues.ts` that uses `gh api` to create issues via GitHub's REST API
- Wired through main/preload IPC layers (`gh:createIssue` handler, preload bindings)
- New Issue dialog in NewWorkspacePage with title/body inputs
- Keyboard shortcut: Cmd/Ctrl+Enter to submit
- Also fixed a Radix overlay bug where `pointer-events: none` was left on <body> after the New Issue dialog closed, preventing clicks on GitHubItemDrawer's header buttons