### PR TITLE
ci: run E2E tests on every PR, surface on release (non-blocking)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,59 @@
+name: E2E
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: Ref to check out (defaults to the calling workflow's ref)
+        required: false
+        type: string
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      # Why: electron-vite's globalSetup invokes a full app build, which
+      # compiles native modules via node-gyp. Mirrors the install step in
+      # pr.yml's verify job so E2E doesn't hit missing-toolchain errors.
+      - name: Install native build tools
+        run: sudo apt-get update && sudo apt-get install -y build-essential python3
+
+      # Why: Electron on Linux needs an X display even when the app
+      # suppresses mainWindow.show() via ORCA_E2E_HEADLESS. xvfb provides a
+      # virtual framebuffer so Chromium can initialize without a real display.
+      - name: Install xvfb
+        run: sudo apt-get install -y xvfb
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run E2E tests
+        run: xvfb-run --auto-servernum pnpm run test:e2e
+
+      # Why: Playwright retains traces/screenshots only on failure. Uploading
+      # them as an artifact makes post-mortem debugging on CI possible without
+      # re-running locally.
+      - name: Upload Playwright traces
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-traces
+          path: tests/test-results/
+          retention-days: 7
+          if-no-files-found: ignore

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -54,6 +54,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: playwright-traces
-          path: tests/test-results/
+          path: test-results/
           retention-days: 7
           if-no-files-found: ignore

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -43,3 +43,6 @@ jobs:
 
       - name: Build
         run: pnpm build
+
+  e2e:
+    uses: ./.github/workflows/e2e.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,10 +63,17 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  e2e:
+    needs: resolve-release
+    uses: ./.github/workflows/e2e.yml
+    with:
+      ref: ${{ needs.resolve-release.outputs.ref }}
+
   release:
     needs:
       - resolve-release
       - create-release
+      - e2e
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,12 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  # Why: E2E runs alongside the release for visibility (failures surface as a
+  # red check on the tag), but it is NOT in `release`'s needs list. Releases
+  # already take a while and the suite is already a required check on PRs, so
+  # gating here would mostly just delay shipping without adding much signal.
+  # Matches the pattern used by noqa's app deploy, which runs E2E with
+  # continue-on-error so failures are visible but don't block the deploy.
   e2e:
     needs: resolve-release
     uses: ./.github/workflows/e2e.yml
@@ -73,7 +79,6 @@ jobs:
     needs:
       - resolve-release
       - create-release
-      - e2e
     strategy:
       fail-fast: false
       matrix:

--- a/tests/e2e/worktree.spec.ts
+++ b/tests/e2e/worktree.spec.ts
@@ -24,7 +24,6 @@ test.describe('New Worktree', () => {
    * - new worktree
    */
   test('create-worktree modal can be opened', async ({ orcaPage }) => {
-    expect(1).toBe(2)
     await orcaPage.evaluate(() => {
       // Why: hidden Electron E2E runs do not expose the same reliable keyboard
       // and sidebar button interactions as a visible window. Opening the modal

--- a/tests/e2e/worktree.spec.ts
+++ b/tests/e2e/worktree.spec.ts
@@ -24,6 +24,7 @@ test.describe('New Worktree', () => {
    * - new worktree
    */
   test('create-worktree modal can be opened', async ({ orcaPage }) => {
+    expect(1).toBe(2)
     await orcaPage.evaluate(() => {
       // Why: hidden Electron E2E runs do not expose the same reliable keyboard
       // and sidebar button interactions as a visible window. Opening the modal

--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -26,6 +26,11 @@ export default defineConfig({
   // substantially. The few visible-window tests that still rely on real
   // pointer interaction are marked serial in their spec file instead.
   fullyParallel: true,
+  // Why: Playwright defaults to workers=1 on CI, which would serialize all
+  // specs on the ubuntu-latest runner (4 vCPUs) and waste headroom. Each test
+  // launches an isolated Electron instance with its own userData dir, so they
+  // don't share state — we can safely fan out to match the runner's vCPU count.
+  workers: process.env.CI ? 4 : undefined,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
   reporter: 'list',


### PR DESCRIPTION
## Summary
- Adds a reusable `.github/workflows/e2e.yml` that runs the Playwright Electron suite under `xvfb` on `ubuntu-latest`
- Wires it into `pr.yml` as a parallel job so every PR runs all 23 E2E tests
- Wires it into `release.yml` alongside the platform builds (not in the `release` job's `needs` list) — failures surface as a red check on the tag but do not block shipping, matching the pattern noqa uses for its deploy workflow
- Sets `workers: 4` in `playwright.config.ts` when `CI=true` so the runner's vCPUs are actually used (Playwright defaults to 1 on CI, which would serialize the suite)
- Uploads `test-results/` as a `playwright-traces` artifact on failure (7-day retention) for post-mortem debugging

## Why this shape
- E2E runtime is ~1 minute with the current suite, so the PR overhead is negligible
- Public-repo Actions minutes are unlimited, and fork PRs are gated by the repo's "Require approval for first-time contributors" Actions setting — no secrets are exposed to `pull_request` triggers
- Release already takes a while across macOS/Windows/Linux. Gating it on E2E would mostly delay shipping without adding much signal since E2E is already a required PR check

## Test plan
- [x] PR run passes: `e2e / e2e` green on run #24638390742 (3m25s)
- [x] Artifact upload verified end-to-end: induced a temporary failure, CI produced a `playwright-traces` artifact (160 KB) containing `error-context.md`, `test-failed-1.png`, and `trace.zip` for both the original and retry attempts; reverted the injected failure
- [x] Trace path fix confirmed — Playwright writes to `<cwd>/test-results/` (repo root), so the workflow uploads from `test-results/` rather than `tests/test-results/`