### PR TITLE
Add customizable local repo creation flow

### DIFF
--- a/src/main/browser/browser-guest-ui.ts
+++ b/src/main/browser/browser-guest-ui.ts
@@ -265,6 +265,8 @@ export function setupGuestShortcutForwarding(args: {
       renderer.send('ui:switchTab', input.code === 'BracketRight' ? 1 : -1)
     } else if (action?.type === 'toggleWorktreePalette') {
       renderer.send('ui:toggleWorktreePalette')
+    } else if (action?.type === 'openAddRepo') {
+      renderer.send('ui:openAddRepo')
     } else if (action?.type === 'openQuickOpen') {
       renderer.send('ui:openQuickOpen')
     } else if (action?.type === 'jumpToWorktreeIndex') {

--- a/src/main/browser/browser-manager.test.ts
+++ b/src/main/browser/browser-manager.test.ts
@@ -634,6 +634,15 @@ describe('browserManager', () => {
       },
       {
         type: 'keyDown',
+        code: 'KeyN',
+        key: 'N',
+        meta: isDarwin,
+        control: !isDarwin,
+        alt: false,
+        shift: true
+      },
+      {
+        type: 'keyDown',
         code: 'KeyL',
         key: 'l',
         meta: isDarwin,
@@ -672,9 +681,10 @@ describe('browserManager', () => {
     expect(rendererSendMock).toHaveBeenNthCalledWith(3, 'ui:closeActiveTab')
     expect(rendererSendMock).toHaveBeenNthCalledWith(4, 'ui:switchTab', 1)
     expect(rendererSendMock).toHaveBeenNthCalledWith(5, 'ui:openQuickOpen')
-    expect(rendererSendMock).toHaveBeenNthCalledWith(6, 'ui:focusBrowserAddressBar')
-    expect(rendererSendMock).toHaveBeenNthCalledWith(7, 'ui:reloadBrowserPage')
-    expect(rendererSendMock).toHaveBeenNthCalledWith(8, 'ui:hardReloadBrowserPage')
+    expect(rendererSendMock).toHaveBeenNthCalledWith(6, 'ui:openAddRepo')
+    expect(rendererSendMock).toHaveBeenNthCalledWith(7, 'ui:focusBrowserAddressBar')
+    expect(rendererSendMock).toHaveBeenNthCalledWith(8, 'ui:reloadBrowserPage')
+    expect(rendererSendMock).toHaveBeenNthCalledWith(9, 'ui:hardReloadBrowserPage')
   })
 
   it('cleans up prior guest listeners before re-registering the same tab', () => {

--- a/src/main/ipc/repos-create-local.test.ts
+++ b/src/main/ipc/repos-create-local.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+const {
+  handleMock,
+  mkdirMock,
+  rmMock,
+  gitExecFileAsyncMock,
+  rebuildAuthorizedRootsCacheMock,
+  mockStore
+} = vi.hoisted(() => ({
+  handleMock: vi.fn(),
+  mkdirMock: vi.fn(),
+  rmMock: vi.fn(),
+  gitExecFileAsyncMock: vi.fn(),
+  rebuildAuthorizedRootsCacheMock: vi.fn(),
+  mockStore: {
+    getRepos: vi.fn().mockReturnValue([]),
+    addRepo: vi.fn(),
+    removeRepo: vi.fn(),
+    getRepo: vi.fn(),
+    updateRepo: vi.fn()
+  }
+}))
+
+vi.mock('electron', () => ({
+  dialog: { showOpenDialog: vi.fn() },
+  ipcMain: {
+    handle: handleMock,
+    removeHandler: vi.fn()
+  }
+}))
+
+vi.mock('fs/promises', () => ({
+  mkdir: mkdirMock,
+  rm: rmMock
+}))
+
+vi.mock('../git/runner', () => ({
+  gitSpawn: vi.fn(),
+  gitExecFileAsync: gitExecFileAsyncMock
+}))
+
+vi.mock('../git/repo', () => ({
+  isGitRepo: vi.fn().mockReturnValue(true),
+  getGitUsername: vi.fn().mockReturnValue(''),
+  getRepoName: vi.fn().mockImplementation((path: string) => path.split('/').pop()),
+  getBaseRefDefault: vi.fn().mockResolvedValue('origin/main'),
+  searchBaseRefs: vi.fn().mockResolvedValue([])
+}))
+
+vi.mock('./filesystem-auth', () => ({
+  rebuildAuthorizedRootsCache: rebuildAuthorizedRootsCacheMock
+}))
+
+vi.mock('../providers/ssh-git-dispatch', () => ({
+  getSshGitProvider: vi.fn().mockReturnValue(undefined)
+}))
+
+import { registerRepoHandlers } from './repos'
+
+describe('repos:createLocal', () => {
+  const handlers = new Map<string, (_event: unknown, args: unknown) => unknown>()
+  const mockWindow = {
+    isDestroyed: () => false,
+    webContents: { send: vi.fn() }
+  }
+
+  beforeEach(() => {
+    handlers.clear()
+    handleMock.mockReset()
+    handleMock.mockImplementation((channel: string, handler: (...a: unknown[]) => unknown) => {
+      handlers.set(channel, handler)
+    })
+
+    mkdirMock.mockReset().mockResolvedValue(undefined)
+    rmMock.mockReset().mockResolvedValue(undefined)
+    gitExecFileAsyncMock.mockReset().mockResolvedValue({ stdout: '', stderr: '' })
+    rebuildAuthorizedRootsCacheMock.mockReset().mockResolvedValue(undefined)
+
+    mockStore.getRepos.mockReset().mockReturnValue([])
+    mockStore.addRepo.mockReset()
+    mockWindow.webContents.send.mockReset()
+
+    registerRepoHandlers(mockWindow as never, mockStore as never)
+  })
+
+  it('registers the repos:createLocal handler', () => {
+    expect(handlers.has('repos:createLocal')).toBe(true)
+  })
+
+  it('creates a local git repository', async () => {
+    const result = await handlers.get('repos:createLocal')!(null, {
+      parentPath: '/tmp/projects',
+      name: 'orca-new',
+      kind: 'git'
+    })
+
+    expect(mkdirMock).toHaveBeenCalledWith('/tmp/projects/orca-new', { recursive: false })
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(['init', 'orca-new'], {
+      cwd: '/tmp/projects'
+    })
+    expect(mockStore.addRepo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: '/tmp/projects/orca-new',
+        displayName: 'orca-new',
+        kind: 'git'
+      })
+    )
+    expect(rebuildAuthorizedRootsCacheMock).toHaveBeenCalled()
+    expect(mockWindow.webContents.send).toHaveBeenCalledWith('repos:changed')
+    expect(result).toHaveProperty('repo.kind', 'git')
+  })
+
+  it('creates a local folder without initializing git', async () => {
+    const result = await handlers.get('repos:createLocal')!(null, {
+      parentPath: '/tmp/projects',
+      name: 'notes',
+      kind: 'folder'
+    })
+
+    expect(mkdirMock).toHaveBeenCalledWith('/tmp/projects/notes', { recursive: false })
+    expect(gitExecFileAsyncMock).not.toHaveBeenCalled()
+    expect(mockStore.addRepo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: '/tmp/projects/notes',
+        kind: 'folder'
+      })
+    )
+    expect(result).toHaveProperty('repo.kind', 'folder')
+  })
+
+  it('rejects invalid folder names that contain path separators', async () => {
+    const result = await handlers.get('repos:createLocal')!(null, {
+      parentPath: '/tmp/projects',
+      name: 'nested/project',
+      kind: 'git'
+    })
+
+    expect(result).toEqual({ error: 'Name must be a single folder name' })
+    expect(mkdirMock).not.toHaveBeenCalled()
+    expect(mockStore.addRepo).not.toHaveBeenCalled()
+  })
+
+  it('cleans up the created folder when git init fails', async () => {
+    gitExecFileAsyncMock.mockRejectedValueOnce(new Error('git not found'))
+
+    const result = await handlers.get('repos:createLocal')!(null, {
+      parentPath: '/tmp/projects',
+      name: 'broken-repo',
+      kind: 'git'
+    })
+
+    expect(rmMock).toHaveBeenCalledWith('/tmp/projects/broken-repo', {
+      recursive: true,
+      force: true
+    })
+    expect(result).toEqual({
+      error: 'Failed to initialize git repository: git not found'
+    })
+    expect(mockStore.addRepo).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/ipc/repos.ts
+++ b/src/main/ipc/repos.ts
@@ -10,8 +10,8 @@ import { isFolderRepo } from '../../shared/repo-kind'
 import { REPO_COLORS } from '../../shared/constants'
 import { rebuildAuthorizedRootsCache } from './filesystem-auth'
 import type { ChildProcess } from 'child_process'
-import { rm } from 'fs/promises'
-import { gitSpawn } from '../git/runner'
+import { mkdir, rm } from 'fs/promises'
+import { gitExecFileAsync, gitSpawn } from '../git/runner'
 import { join, basename } from 'path'
 import {
   isGitRepo,
@@ -38,6 +38,7 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
   ipcMain.removeHandler('repos:update')
   ipcMain.removeHandler('repos:pickFolder')
   ipcMain.removeHandler('repos:pickDirectory')
+  ipcMain.removeHandler('repos:createLocal')
   ipcMain.removeHandler('repos:clone')
   ipcMain.removeHandler('repos:cloneAbort')
   ipcMain.removeHandler('repos:getGitUsername')
@@ -49,32 +50,38 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
     return store.getRepos()
   })
 
-  ipcMain.handle('repos:add', async (_event, args: { path: string; kind?: 'git' | 'folder' }): Promise<{ repo: Repo } | { error: string }> => {
-    const repoKind = args.kind === 'folder' ? 'folder' : 'git'
-    if (repoKind === 'git' && !isGitRepo(args.path)) {
-      return { error: `Not a valid git repository: ${args.path}` }
-    }
+  ipcMain.handle(
+    'repos:add',
+    async (
+      _event,
+      args: { path: string; kind?: 'git' | 'folder' }
+    ): Promise<{ repo: Repo } | { error: string }> => {
+      const repoKind = args.kind === 'folder' ? 'folder' : 'git'
+      if (repoKind === 'git' && !isGitRepo(args.path)) {
+        return { error: `Not a valid git repository: ${args.path}` }
+      }
 
-    // Check if already added
-    const existing = store.getRepos().find((r) => r.path === args.path)
-    if (existing) {
-      return { repo: existing }
-    }
+      // Check if already added
+      const existing = store.getRepos().find((r) => r.path === args.path)
+      if (existing) {
+        return { repo: existing }
+      }
 
-    const repo: Repo = {
-      id: randomUUID(),
-      path: args.path,
-      displayName: getRepoName(args.path),
-      badgeColor: REPO_COLORS[store.getRepos().length % REPO_COLORS.length],
-      addedAt: Date.now(),
-      kind: repoKind
-    }
+      const repo: Repo = {
+        id: randomUUID(),
+        path: args.path,
+        displayName: getRepoName(args.path),
+        badgeColor: REPO_COLORS[store.getRepos().length % REPO_COLORS.length],
+        addedAt: Date.now(),
+        kind: repoKind
+      }
 
-    store.addRepo(repo)
-    await rebuildAuthorizedRootsCache(store)
-    notifyReposChanged(mainWindow)
-    return { repo }
-  })
+      store.addRepo(repo)
+      await rebuildAuthorizedRootsCache(store)
+      notifyReposChanged(mainWindow)
+      return { repo }
+    }
+  )
 
   ipcMain.handle(
     'repos:addRemote',
@@ -200,6 +207,81 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
     }
     return result.filePaths[0]
   })
+
+  ipcMain.handle(
+    'repos:createLocal',
+    async (
+      _event,
+      args: { parentPath: string; name: string; kind?: 'git' | 'folder' }
+    ): Promise<{ repo: Repo } | { error: string }> => {
+      const parentPath = args.parentPath.trim()
+      const name = args.name.trim()
+      const repoKind = args.kind === 'folder' ? 'folder' : 'git'
+      if (!parentPath) {
+        return { error: 'Parent folder is required' }
+      }
+      if (!name) {
+        return { error: 'Name is required' }
+      }
+      if (name === '.' || name === '..' || name.includes('/') || name.includes('\\')) {
+        // Why: this flow asks for a project name, not an arbitrary path. Restrict
+        // to one segment so users can't accidentally escape the chosen parent folder.
+        return { error: 'Name must be a single folder name' }
+      }
+
+      const repoPath = join(parentPath, name)
+      const existing = store.getRepos().find((r) => r.path === repoPath)
+      if (existing) {
+        return { repo: existing }
+      }
+
+      try {
+        // Why: recursive false preserves "already exists" semantics so the UI can
+        // clearly report collisions instead of silently reusing unexpected paths.
+        await mkdir(repoPath, { recursive: false })
+      } catch (err) {
+        const error = err as NodeJS.ErrnoException
+        if (error.code === 'EEXIST') {
+          return { error: `A file or folder named "${name}" already exists.` }
+        }
+        if (error.code === 'ENOENT') {
+          return { error: `Parent folder does not exist: ${parentPath}` }
+        }
+        if (error.code === 'EACCES' || error.code === 'EPERM') {
+          return { error: `Permission denied creating "${repoPath}".` }
+        }
+        return { error: error.message || `Failed to create "${repoPath}".` }
+      }
+
+      if (repoKind === 'git') {
+        try {
+          // Why: initialize from the selected parent so WSL path detection in the
+          // shared git runner stays consistent with clone behavior.
+          await gitExecFileAsync(['init', name], { cwd: parentPath })
+        } catch (err) {
+          // Why: creating a "new repo" should be atomic from the user's perspective.
+          // If git init fails, remove the just-created folder to avoid half-created state.
+          await rm(repoPath, { recursive: true, force: true }).catch(() => {})
+          const message = err instanceof Error ? err.message : String(err)
+          return { error: `Failed to initialize git repository: ${message}` }
+        }
+      }
+
+      const repo: Repo = {
+        id: randomUUID(),
+        path: repoPath,
+        displayName: getRepoName(repoPath),
+        badgeColor: REPO_COLORS[store.getRepos().length % REPO_COLORS.length],
+        addedAt: Date.now(),
+        kind: repoKind
+      }
+
+      store.addRepo(repo)
+      await rebuildAuthorizedRootsCache(store)
+      notifyReposChanged(mainWindow)
+      return { repo }
+    }
+  )
 
   ipcMain.handle('repos:cloneAbort', async () => {
     if (activeCloneProc) {

--- a/src/main/window/createMainWindow.test.ts
+++ b/src/main/window/createMainWindow.test.ts
@@ -362,6 +362,59 @@ describe('createMainWindow', () => {
     expect(webContents.send).toHaveBeenNthCalledWith(2, 'ui:toggleWorktreePalette')
   })
 
+  it('forwards ctrl/cmd+shift+n to open Add Repo', () => {
+    const windowHandlers: Record<string, (...args: any[]) => void> = {}
+    const webContents = {
+      on: vi.fn((event, handler) => {
+        windowHandlers[event] = handler
+      }),
+      setZoomLevel: vi.fn(),
+      setBackgroundThrottling: vi.fn(),
+      invalidate: vi.fn(),
+      setWindowOpenHandler: vi.fn(),
+      send: vi.fn(),
+      isDevToolsOpened: vi.fn(),
+      openDevTools: vi.fn(),
+      closeDevTools: vi.fn()
+    }
+    const browserWindowInstance = {
+      webContents,
+      on: vi.fn(),
+      isDestroyed: vi.fn(() => false),
+      isMaximized: vi.fn(() => true),
+      isFullScreen: vi.fn(() => false),
+      getSize: vi.fn(() => [1200, 800]),
+      setSize: vi.fn(),
+      maximize: vi.fn(),
+      show: vi.fn(),
+      loadFile: vi.fn(),
+      loadURL: vi.fn()
+    }
+    browserWindowMock.mockImplementation(function () {
+      return browserWindowInstance
+    })
+
+    createMainWindow(null)
+
+    const isDarwin = process.platform === 'darwin'
+    const preventDefault = vi.fn()
+    windowHandlers['before-input-event'](
+      { preventDefault } as never,
+      {
+        type: 'keyDown',
+        code: 'KeyN',
+        key: 'N',
+        meta: isDarwin,
+        control: !isDarwin,
+        alt: false,
+        shift: true
+      } as never
+    )
+
+    expect(preventDefault).toHaveBeenCalledTimes(1)
+    expect(webContents.send).toHaveBeenCalledWith('ui:openAddRepo')
+  })
+
   it('toggles devtools on F12 in development', () => {
     isMock.dev = true
 

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -367,6 +367,11 @@ export function createMainWindow(
       return
     }
 
+    if (action.type === 'openAddRepo') {
+      mainWindow.webContents.send('ui:openAddRepo')
+      return
+    }
+
     if (action.type === 'toggleWorktreePalette') {
       // Why: embedded browser guests can keep keyboard focus inside Chromium's
       // guest webContents, which bypasses the renderer's window-level keydown

--- a/src/preload/api-types.d.ts
+++ b/src/preload/api-types.d.ts
@@ -247,7 +247,15 @@ export type PreloadApi = {
   }
   repos: {
     list: () => Promise<Repo[]>
-    add: (args: { path: string; kind?: 'git' | 'folder' }) => Promise<Repo>
+    add: (args: {
+      path: string
+      kind?: 'git' | 'folder'
+    }) => Promise<{ repo: Repo } | { error: string }>
+    createLocal: (args: {
+      parentPath: string
+      name: string
+      kind?: 'git' | 'folder'
+    }) => Promise<{ repo: Repo } | { error: string }>
     remove: (args: { repoId: string }) => Promise<void>
     update: (args: {
       repoId: string
@@ -264,7 +272,7 @@ export type PreloadApi = {
       remotePath: string
       displayName?: string
       kind?: 'git' | 'folder'
-    }) => Promise<Repo>
+    }) => Promise<{ repo: Repo } | { error: string }>
     onCloneProgress: (callback: (data: { phase: string; percent: number }) => void) => () => void
     getGitUsername: (args: { repoId: string }) => Promise<string>
     getBaseRefDefault: (args: { repoId: string }) => Promise<string>
@@ -575,6 +583,7 @@ export type PreloadApi = {
     onToggleLeftSidebar: (callback: () => void) => () => void
     onToggleRightSidebar: (callback: () => void) => () => void
     onToggleWorktreePalette: (callback: () => void) => () => void
+    onOpenAddRepo: (callback: () => void) => () => void
     onOpenQuickOpen: (callback: () => void) => () => void
     onJumpToWorktreeIndex: (callback: (index: number) => void) => () => void
     onNewBrowserTab: (callback: () => void) => () => void

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -18,6 +18,11 @@ type ReposApi = {
     path: string
     kind?: 'git' | 'folder'
   }) => Promise<{ repo: Repo } | { error: string }>
+  createLocal: (args: {
+    parentPath: string
+    name: string
+    kind?: 'git' | 'folder'
+  }) => Promise<{ repo: Repo } | { error: string }>
   addRemote: (args: {
     connectionId: string
     remotePath: string

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -175,6 +175,12 @@ const api = {
     add: (args: { path: string; kind?: 'git' | 'folder' }): Promise<unknown> =>
       ipcRenderer.invoke('repos:add', args),
 
+    createLocal: (args: {
+      parentPath: string
+      name: string
+      kind?: 'git' | 'folder'
+    }): Promise<unknown> => ipcRenderer.invoke('repos:createLocal', args),
+
     addRemote: (args: {
       connectionId: string
       remotePath: string
@@ -1019,6 +1025,11 @@ const api = {
       const listener = (_event: Electron.IpcRendererEvent) => callback()
       ipcRenderer.on('ui:toggleWorktreePalette', listener)
       return () => ipcRenderer.removeListener('ui:toggleWorktreePalette', listener)
+    },
+    onOpenAddRepo: (callback: () => void): (() => void) => {
+      const listener = (_event: Electron.IpcRendererEvent) => callback()
+      ipcRenderer.on('ui:openAddRepo', listener)
+      return () => ipcRenderer.removeListener('ui:openAddRepo', listener)
     },
     onOpenQuickOpen: (callback: () => void): (() => void) => {
       const listener = (_event: Electron.IpcRendererEvent) => callback()

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -516,6 +516,16 @@ function App(): React.JSX.Element {
         return
       }
 
+      // Why: Cmd/Ctrl+N already creates a worktree; keep Add Repo on the
+      // shifted variant so both "new workspace" and "new repo/folder" are
+      // reachable without colliding.
+      if (e.shiftKey && !e.altKey && e.key.toLowerCase() === 'n') {
+        dispatchClearModifierHints()
+        e.preventDefault()
+        actions.openModal('add-repo')
+        return
+      }
+
       // Why: the new-workspace composer should not be able to reveal the right
       // sidebar at all, because that surface is intentionally distraction-free.
       if (activeView === 'new-workspace') {

--- a/src/renderer/src/components/settings/ShortcutsPane.tsx
+++ b/src/renderer/src/components/settings/ShortcutsPane.tsx
@@ -45,6 +45,11 @@ const SHORTCUT_GROUP_DEFINITIONS: ShortcutGroupDefinition[] = [
         keys: ({ mod }) => [mod, 'N']
       },
       {
+        action: 'Add repository',
+        searchKeywords: ['shortcut', 'global', 'repo', 'repository', 'folder'],
+        keys: ({ mod, shift }) => [mod, shift, 'N']
+      },
+      {
         action: 'Toggle Sidebar',
         searchKeywords: ['shortcut', 'sidebar'],
         keys: ({ mod }) => [mod, 'B']

--- a/src/renderer/src/components/sidebar/AddRepoDialog.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoDialog.tsx
@@ -1,6 +1,7 @@
+/* eslint-disable max-lines -- Why: this modal coordinates multiple async add-repo flows (browse, clone, remote, and create-local) and keeps cross-step transition state in one place. */
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
-import { FolderOpen, GitBranchPlus, Settings, ArrowLeft, Globe, Monitor } from 'lucide-react'
+import { FolderOpen, ArrowLeft, Globe, Monitor } from 'lucide-react'
 import { useAppStore } from '@/store'
 import {
   Dialog,
@@ -11,8 +12,7 @@ import {
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
-import { LinkedWorktreeItem } from './LinkedWorktreeItem'
-import { RemoteStep, CloneStep, useRemoteRepo } from './AddRepoSteps'
+import { RemoteStep, CloneStep, CreateLocalStep, SetupStep, useRemoteRepo } from './AddRepoSteps'
 import { isGitRepoKind } from '../../../../shared/repo-kind'
 import type { Repo, Worktree } from '../../../../shared/types'
 
@@ -27,7 +27,7 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
   const openSettingsPage = useAppStore((s) => s.openSettingsPage)
   const openSettingsTarget = useAppStore((s) => s.openSettingsTarget)
 
-  const [step, setStep] = useState<'add' | 'clone' | 'remote' | 'setup'>('add')
+  const [step, setStep] = useState<'add' | 'clone' | 'remote' | 'create' | 'setup'>('add')
   const [addedRepo, setAddedRepo] = useState<Repo | null>(null)
   const [isAdding, setIsAdding] = useState(false)
   const [cloneUrl, setCloneUrl] = useState('')
@@ -37,6 +37,11 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
   const [cloneProgress, setCloneProgress] = useState<{ phase: string; percent: number } | null>(
     null
   )
+  const [createKind, setCreateKind] = useState<'git' | 'folder'>('git')
+  const [createName, setCreateName] = useState('')
+  const [createParentPath, setCreateParentPath] = useState('')
+  const [createError, setCreateError] = useState<string | null>(null)
+  const [isCreatingLocal, setIsCreatingLocal] = useState(false)
 
   // Why: monotonic ID so stale clone callbacks can detect they were superseded.
   const cloneGenRef = useRef(0)
@@ -93,6 +98,11 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
     setIsCloning(false)
     setCloneError(null)
     setCloneProgress(null)
+    setCreateKind('git')
+    setCreateName('')
+    setCreateParentPath('')
+    setCreateError(null)
+    setIsCreatingLocal(false)
     resetRemoteState()
   }, [resetRemoteState])
 
@@ -103,7 +113,7 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
     }
   }, [isOpen, resetState])
 
-  const isInputStep = step === 'add' || step === 'clone' || step === 'remote'
+  const isInputStep = step === 'add' || step === 'clone' || step === 'remote' || step === 'create'
 
   const handleBrowse = useCallback(async () => {
     setIsAdding(true)
@@ -176,6 +186,63 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
     }
   }, [cloneUrl, cloneDestination, fetchWorktrees])
 
+  const handlePickCreateParentPath = useCallback(async () => {
+    const dir = await window.api.repos.pickDirectory()
+    if (dir) {
+      setCreateParentPath(dir)
+      setCreateError(null)
+    }
+  }, [])
+
+  const handleCreateLocal = useCallback(async () => {
+    const name = createName.trim()
+    const parentPath = createParentPath.trim()
+    if (!name || !parentPath) {
+      return
+    }
+
+    setIsCreatingLocal(true)
+    setCreateError(null)
+    try {
+      const result = (await window.api.repos.createLocal({
+        name,
+        parentPath,
+        kind: createKind
+      })) as { repo: Repo } | { error: string }
+      if ('error' in result) {
+        throw new Error(result.error)
+      }
+      const repo = result.repo
+
+      // Why: eagerly upsert so downstream setup flow can resolve the created
+      // repo even before the global repos:changed event arrives.
+      const state = useAppStore.getState()
+      const existingIdx = state.repos.findIndex((r) => r.id === repo.id)
+      if (existingIdx === -1) {
+        useAppStore.setState({ repos: [...state.repos, repo] })
+      } else {
+        const updated = [...state.repos]
+        updated[existingIdx] = repo
+        useAppStore.setState({ repos: updated })
+      }
+
+      if (isGitRepoKind(repo)) {
+        toast.success('Repository created', { description: repo.displayName })
+        setAddedRepo(repo)
+        await fetchWorktrees(repo.id)
+        setStep('setup')
+      } else {
+        toast.success('Folder created', { description: repo.displayName })
+        closeModal()
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      setCreateError(message)
+    } finally {
+      setIsCreatingLocal(false)
+    }
+  }, [createName, createParentPath, createKind, fetchWorktrees, closeModal])
+
   const handleOpenWorktree = useCallback(
     (worktree: Worktree) => {
       activateAndRevealWorktree(worktree.id)
@@ -216,7 +283,7 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
       <DialogContent className="sm:max-w-lg">
         {/* Step indicator row — back button (step 2 only), dots, X is rendered by DialogContent */}
         <div className="flex items-center justify-center -mt-1">
-          {(step === 'clone' || step === 'remote') && (
+          {(step === 'clone' || step === 'remote' || step === 'create') && (
             <button
               className="absolute left-6 inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
               onClick={handleBack}
@@ -299,7 +366,38 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
                 </div>
               </Button>
             </div>
+
+            <div className="pt-3 flex justify-center">
+              <button
+                className="text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer underline underline-offset-2"
+                onClick={() => setStep('create')}
+              >
+                Create a new repo or folder
+              </button>
+            </div>
           </>
+        ) : step === 'create' ? (
+          <CreateLocalStep
+            name={createName}
+            parentPath={createParentPath}
+            kind={createKind}
+            isCreating={isCreatingLocal}
+            error={createError}
+            onNameChange={(value) => {
+              setCreateName(value)
+              setCreateError(null)
+            }}
+            onParentPathChange={(value) => {
+              setCreateParentPath(value)
+              setCreateError(null)
+            }}
+            onKindChange={(value) => {
+              setCreateKind(value)
+              setCreateError(null)
+            }}
+            onPickParentPath={handlePickCreateParentPath}
+            onCreate={handleCreateLocal}
+          />
         ) : step === 'remote' ? (
           <RemoteStep
             sshTargets={sshTargets}
@@ -336,63 +434,18 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
             onClone={handleClone}
           />
         ) : (
-          <>
-            <DialogHeader>
-              <DialogTitle>
-                {hasWorktrees ? 'Open or create a worktree' : 'Set up your first worktree'}
-              </DialogTitle>
-              <DialogDescription>
-                {hasWorktrees
-                  ? `${addedRepo?.displayName} has ${worktrees.length} worktree${worktrees.length !== 1 ? 's' : ''}. Open one to pick up where you left off, or create a new one.`
-                  : `Orca uses git worktrees as isolated task environments. Create one for ${addedRepo?.displayName} to get started.`}
-              </DialogDescription>
-            </DialogHeader>
-
-            {hasWorktrees && (
-              <div className="space-y-2">
-                <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-                  Existing worktrees
-                </p>
-                <div className="space-y-1.5 max-h-[40vh] overflow-y-auto scrollbar-sleek pr-1">
-                  {sortedWorktrees.map((wt) => (
-                    <LinkedWorktreeItem
-                      key={wt.id}
-                      worktree={wt}
-                      onOpen={() => handleOpenWorktree(wt)}
-                    />
-                  ))}
-                </div>
-              </div>
-            )}
-
-            <div className="flex flex-col gap-3 pt-2">
-              <Button onClick={handleCreateWorktree} className="w-full">
-                <GitBranchPlus className="size-4 mr-2" />
-                {hasWorktrees ? 'Create new worktree' : 'Create first worktree'}
-              </Button>
-
-              <div className="flex items-center justify-between">
-                <button
-                  className="inline-flex items-center justify-center gap-1.5 text-xs text-muted-foreground/70 hover:text-foreground transition-colors cursor-pointer"
-                  onClick={handleConfigureRepo}
-                >
-                  <Settings className="size-3" />
-                  Configure repo
-                </button>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="text-xs"
-                  onClick={() => {
-                    closeModal()
-                    resetState()
-                  }}
-                >
-                  Skip
-                </Button>
-              </div>
-            </div>
-          </>
+          <SetupStep
+            addedRepo={addedRepo}
+            sortedWorktrees={sortedWorktrees}
+            hasWorktrees={hasWorktrees}
+            onOpenWorktree={handleOpenWorktree}
+            onCreateWorktree={handleCreateWorktree}
+            onConfigureRepo={handleConfigureRepo}
+            onSkip={() => {
+              closeModal()
+              resetState()
+            }}
+          />
         )}
       </DialogContent>
     </Dialog>

--- a/src/renderer/src/components/sidebar/AddRepoSteps.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoSteps.tsx
@@ -1,26 +1,27 @@
+/* eslint-disable max-lines -- Why: step-specific hooks and views are intentionally colocated so add-repo wizard behavior stays synchronized across flows. */
 /**
- * Step views for AddRepoDialog: Clone, Remote, and Setup.
+ * Step views and flow hooks for AddRepoDialog.
  *
- * Why extracted: keeps AddRepoDialog.tsx under the 400-line oxlint limit
- * by moving the presentational JSX for each wizard step into separate components
- * while the parent retains all state and handlers.
+ * Why extracted: presentational JSX and per-step behavior live together so
+ * AddRepoDialog can focus on top-level orchestration and modal transitions.
  */
 import React, { useCallback, useRef, useState } from 'react'
 import { toast } from 'sonner'
-import { Folder, FolderOpen } from 'lucide-react'
+import { Folder, FolderOpen, FolderPlus, GitBranch, GitBranchPlus, Settings } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { RemoteFileBrowser } from './RemoteFileBrowser'
-import type { Repo } from '../../../../shared/types'
+import { LinkedWorktreeItem } from './LinkedWorktreeItem'
+import type { Repo, Worktree } from '../../../../shared/types'
 import type { SshTarget, SshConnectionState } from '../../../../shared/ssh-types'
 
 // ── Remote repo hook ────────────────────────────────────────────────
 
 export function useRemoteRepo(
   fetchWorktrees: (repoId: string) => Promise<void>,
-  setStep: (step: 'add' | 'clone' | 'remote' | 'setup') => void,
+  setStep: (step: 'add' | 'clone' | 'remote' | 'create' | 'setup') => void,
   setAddedRepo: (repo: Repo | null) => void,
   closeModal: () => void
 ) {
@@ -365,6 +366,193 @@ export function CloneStep({
             </div>
           </div>
         )}
+      </div>
+    </>
+  )
+}
+
+// ── Create-local step ───────────────────────────────────────────────
+
+type CreateLocalStepProps = {
+  name: string
+  parentPath: string
+  kind: 'git' | 'folder'
+  isCreating: boolean
+  error: string | null
+  onNameChange: (value: string) => void
+  onParentPathChange: (value: string) => void
+  onKindChange: (value: 'git' | 'folder') => void
+  onPickParentPath: () => void
+  onCreate: () => void
+}
+
+export function CreateLocalStep({
+  name,
+  parentPath,
+  kind,
+  isCreating,
+  error,
+  onNameChange,
+  onParentPathChange,
+  onKindChange,
+  onPickParentPath,
+  onCreate
+}: CreateLocalStepProps): React.JSX.Element {
+  const createLabel = kind === 'git' ? 'Create repository' : 'Create folder'
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>Create new repo or folder</DialogTitle>
+        <DialogDescription>
+          Choose a location, enter a name, and decide whether to initialize Git.
+        </DialogDescription>
+      </DialogHeader>
+
+      <div className="space-y-3 pt-1">
+        <div className="space-y-1">
+          <label className="text-[11px] font-medium text-muted-foreground">Type</label>
+          <div className="grid grid-cols-2 gap-2">
+            <Button
+              variant={kind === 'git' ? 'default' : 'outline'}
+              size="sm"
+              className="h-8 gap-1.5"
+              onClick={() => onKindChange('git')}
+              disabled={isCreating}
+            >
+              <GitBranch className="size-3.5" />
+              Git repo
+            </Button>
+            <Button
+              variant={kind === 'folder' ? 'default' : 'outline'}
+              size="sm"
+              className="h-8 gap-1.5"
+              onClick={() => onKindChange('folder')}
+              disabled={isCreating}
+            >
+              <FolderPlus className="size-3.5" />
+              Folder only
+            </Button>
+          </div>
+        </div>
+
+        <div className="space-y-1">
+          <label className="text-[11px] font-medium text-muted-foreground">Name</label>
+          <Input
+            value={name}
+            onChange={(e) => onNameChange(e.target.value)}
+            placeholder="my-project"
+            className="h-8 text-xs"
+            disabled={isCreating}
+            autoFocus
+          />
+        </div>
+
+        <div className="space-y-1">
+          <label className="text-[11px] font-medium text-muted-foreground">Location</label>
+          <div className="flex gap-2">
+            <Input
+              value={parentPath}
+              onChange={(e) => onParentPathChange(e.target.value)}
+              placeholder="/path/to/parent-folder"
+              className="h-8 text-xs flex-1"
+              disabled={isCreating}
+            />
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-8 px-2 shrink-0"
+              onClick={onPickParentPath}
+              disabled={isCreating}
+            >
+              <Folder className="size-3.5" />
+            </Button>
+          </div>
+        </div>
+
+        {error && <p className="text-[11px] text-destructive">{error}</p>}
+
+        <Button
+          onClick={onCreate}
+          disabled={!name.trim() || !parentPath.trim() || isCreating}
+          className="w-full"
+        >
+          {isCreating ? 'Creating...' : createLabel}
+        </Button>
+      </div>
+    </>
+  )
+}
+
+// ── Setup step ──────────────────────────────────────────────────────
+
+type SetupStepProps = {
+  addedRepo: Repo | null
+  sortedWorktrees: Worktree[]
+  hasWorktrees: boolean
+  onOpenWorktree: (worktree: Worktree) => void
+  onCreateWorktree: () => void
+  onConfigureRepo: () => void
+  onSkip: () => void
+}
+
+export function SetupStep({
+  addedRepo,
+  sortedWorktrees,
+  hasWorktrees,
+  onOpenWorktree,
+  onCreateWorktree,
+  onConfigureRepo,
+  onSkip
+}: SetupStepProps): React.JSX.Element {
+  const worktreesCount = sortedWorktrees.length
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>
+          {hasWorktrees ? 'Open or create a worktree' : 'Set up your first worktree'}
+        </DialogTitle>
+        <DialogDescription>
+          {hasWorktrees
+            ? `${addedRepo?.displayName} has ${worktreesCount} worktree${worktreesCount !== 1 ? 's' : ''}. Open one to pick up where you left off, or create a new one.`
+            : `Orca uses git worktrees as isolated task environments. Create one for ${addedRepo?.displayName} to get started.`}
+        </DialogDescription>
+      </DialogHeader>
+
+      {hasWorktrees && (
+        <div className="space-y-2">
+          <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+            Existing worktrees
+          </p>
+          <div className="space-y-1.5 max-h-[40vh] overflow-y-auto scrollbar-sleek pr-1">
+            {sortedWorktrees.map((worktree) => (
+              <LinkedWorktreeItem
+                key={worktree.id}
+                worktree={worktree}
+                onOpen={() => onOpenWorktree(worktree)}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div className="flex flex-col gap-3 pt-2">
+        <Button onClick={onCreateWorktree} className="w-full">
+          <GitBranchPlus className="size-4 mr-2" />
+          {hasWorktrees ? 'Create new worktree' : 'Create first worktree'}
+        </Button>
+
+        <div className="flex items-center justify-between">
+          <button
+            className="inline-flex items-center justify-center gap-1.5 text-xs text-muted-foreground/70 hover:text-foreground transition-colors cursor-pointer"
+            onClick={onConfigureRepo}
+          >
+            <Settings className="size-3" />
+            Configure repo
+          </button>
+          <Button variant="ghost" size="sm" className="text-xs" onClick={onSkip}>
+            Skip
+          </Button>
+        </div>
       </div>
     </>
   )

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -148,6 +148,7 @@ describe('useIpcEvents updater integration', () => {
           onToggleLeftSidebar: () => () => {},
           onToggleRightSidebar: () => () => {},
           onToggleWorktreePalette: () => () => {},
+          onOpenAddRepo: () => () => {},
           onOpenQuickOpen: () => () => {},
           onJumpToWorktreeIndex: () => () => {},
           onActivateWorktree: () => () => {},
@@ -310,6 +311,7 @@ describe('useIpcEvents updater integration', () => {
           onToggleLeftSidebar: () => () => {},
           onToggleRightSidebar: () => () => {},
           onToggleWorktreePalette: () => () => {},
+          onOpenAddRepo: () => () => {},
           onOpenQuickOpen: () => () => {},
           onJumpToWorktreeIndex: () => () => {},
           onActivateWorktree: () => () => {},
@@ -380,8 +382,10 @@ describe('useIpcEvents shortcut hint clearing', () => {
 
   it('clears modifier hints for main-process-forwarded shortcuts', async () => {
     const toggleLeftSidebarRef: { current: (() => void) | null } = { current: null }
+    const openAddRepoRef: { current: (() => void) | null } = { current: null }
     const jumpToWorktreeRef: { current: ((index: number) => void) | null } = { current: null }
     const toggleSidebar = vi.fn()
+    const openModal = vi.fn()
     const dispatchEvent = vi.fn()
     const activateAndRevealWorktree = vi.fn()
 
@@ -402,7 +406,7 @@ describe('useIpcEvents shortcut hint clearing', () => {
           toggleRightSidebar: vi.fn(),
           activeModal: 'none',
           closeModal: vi.fn(),
-          openModal: vi.fn(),
+          openModal,
           activeView: 'terminal',
           activeWorktreeId: 'wt-1',
           statusBarVisible: true,
@@ -478,6 +482,10 @@ describe('useIpcEvents shortcut hint clearing', () => {
           },
           onToggleRightSidebar: () => () => {},
           onToggleWorktreePalette: () => () => {},
+          onOpenAddRepo: (listener: () => void) => {
+            openAddRepoRef.current = listener
+            return () => {}
+          },
           onOpenQuickOpen: () => () => {},
           onJumpToWorktreeIndex: (listener: (index: number) => void) => {
             jumpToWorktreeRef.current = listener
@@ -525,18 +533,23 @@ describe('useIpcEvents shortcut hint clearing', () => {
     if (typeof toggleLeftSidebarRef.current !== 'function') {
       throw new Error('Expected toggle-left-sidebar listener to be registered')
     }
+    if (typeof openAddRepoRef.current !== 'function') {
+      throw new Error('Expected open-add-repo listener to be registered')
+    }
     if (typeof jumpToWorktreeRef.current !== 'function') {
       throw new Error('Expected jump-to-worktree listener to be registered')
     }
 
     toggleLeftSidebarRef.current()
+    openAddRepoRef.current()
     jumpToWorktreeRef.current(1)
 
     expect(dispatchEvent).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'orca:clear-modifier-hints' })
     )
-    expect(dispatchEvent).toHaveBeenCalledTimes(2)
+    expect(dispatchEvent).toHaveBeenCalledTimes(3)
     expect(toggleSidebar).toHaveBeenCalledTimes(1)
+    expect(openModal).toHaveBeenCalledWith('add-repo')
     expect(activateAndRevealWorktree).toHaveBeenCalledWith('wt-2')
   })
 })

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -70,6 +70,13 @@ export function useIpcEvents(): void {
     )
 
     unsubs.push(
+      window.api.ui.onOpenAddRepo(() => {
+        dispatchClearModifierHints()
+        useAppStore.getState().openModal('add-repo')
+      })
+    )
+
+    unsubs.push(
       window.api.ui.onOpenQuickOpen(() => {
         dispatchClearModifierHints()
         const store = useAppStore.getState()

--- a/src/shared/window-shortcut-policy.test.ts
+++ b/src/shared/window-shortcut-policy.test.ts
@@ -47,6 +47,13 @@ describe('resolveWindowShortcutAction', () => {
 
     expect(
       resolveWindowShortcutAction(
+        { code: 'KeyN', key: 'N', meta: true, control: false, alt: false, shift: true },
+        'darwin'
+      )
+    ).toEqual({ type: 'openAddRepo' })
+
+    expect(
+      resolveWindowShortcutAction(
         { code: 'Digit3', key: '3', meta: true, control: false, alt: false, shift: false },
         'darwin'
       )
@@ -67,6 +74,20 @@ describe('resolveWindowShortcutAction', () => {
         'win32'
       )
     ).toEqual({ type: 'toggleWorktreePalette' })
+
+    expect(
+      resolveWindowShortcutAction(
+        { code: 'KeyN', key: 'n', meta: false, control: true, alt: false, shift: false },
+        'win32'
+      )
+    ).toBeNull()
+
+    expect(
+      resolveWindowShortcutAction(
+        { code: 'KeyN', key: 'N', meta: false, control: true, alt: false, shift: true },
+        'win32'
+      )
+    ).toEqual({ type: 'openAddRepo' })
   })
 
   it('accepts all supported zoom key variants', () => {

--- a/src/shared/window-shortcut-policy.ts
+++ b/src/shared/window-shortcut-policy.ts
@@ -12,6 +12,7 @@ export type WindowShortcutAction =
   | { type: 'toggleWorktreePalette' }
   | { type: 'toggleLeftSidebar' }
   | { type: 'toggleRightSidebar' }
+  | { type: 'openAddRepo' }
   | { type: 'openQuickOpen' }
   | { type: 'jumpToWorktreeIndex'; index: number }
 
@@ -81,6 +82,13 @@ export function resolveWindowShortcutAction(
 
   if (input.code === 'KeyL' && !input.shift) {
     return { type: 'toggleRightSidebar' }
+  }
+
+  // Why: bare Cmd/Ctrl+N already opens the new-workspace composer in the
+  // renderer, so Add Repo uses the shifted variant to avoid shortcut
+  // collisions while still feeling like "new repository".
+  if (input.code === 'KeyN' && input.shift) {
+    return { type: 'openAddRepo' }
   }
 
   if (input.code === 'KeyP' && !input.shift) {


### PR DESCRIPTION
## Summary

Adds a **"Create local repo or folder"** flow to the Add Repo dialog, so users can spin up a new project directly from Orca instead of creating the folder elsewhere and re-importing it.

### What's new
- **IPC handler** `repos:createLocal` in `src/main/ipc/repos.ts`:
  - Validates parent path + name (rejects `/`, `\`, `.`, `..` to prevent escaping the parent).
  - `mkdir { recursive: false }` so collisions surface as `EEXIST` with a clear error.
  - `git init` when `kind === 'git'`; on failure, rolls back the folder (`rm -rf`) so state stays atomic.
  - Explicit errno handling: `EEXIST`, `ENOENT`, `EACCES`/`EPERM`.
  - Deduplicates against existing repos by absolute path.
- **UI**: new `CreateLocalStep` in `AddRepoSteps.tsx` with kind toggle (Git repo / Folder only), name input, parent-path picker.
- **Shortcut**: `Shift+Cmd/Ctrl+N` opens Add Repo — chosen over bare `Cmd+N` (already owned by new-workspace composer). Wired via shared `window-shortcut-policy` + main-process forwarding (`ui:openAddRepo`).
- **Preload bindings** for `createLocal` + `openAddRepo` event.

### Design notes
- Safety-first: non-recursive mkdir + atomic rollback on `git init` failure, so the filesystem never ends up half-created.
- `isEditableTarget` guard at `App.tsx:504` already short-circuits shortcuts when typing in inputs — no regression.
- Comments document the *why* per the repo's CLAUDE.md convention (recursive:false, rollback rationale, shortcut collision).

## Test plan

### Automated
- [x] `oxlint` on 17 PR files → **0 warnings, 0 errors**
- [x] Unit tests (46/46 pass) across:
  - `src/main/ipc/repos-create-local.test.ts` (new — 162 lines)
  - `src/shared/window-shortcut-policy.test.ts`
  - `src/main/window/createMainWindow.test.ts`
  - `src/main/browser/browser-manager.test.ts`
  - `src/renderer/src/hooks/useIpcEvents.test.ts`

### Manual
- [x] Open Add Repo → Create → pick parent folder, type name, select **Git repo** → verify `.git/` exists and repo appears in sidebar
- [x] Same flow with **Folder only** → no `.git/`, repo still appears
- [ ] Collision: try creating a name that already exists → error surfaces, no partial state
- [ ] Permission denied: pick a read-only parent → clear error, no partial state
- [ ] Shortcut: `Shift+Cmd/Ctrl+N` opens Add Repo from the main window and while a browser tab has focus
- [ ] Shortcut safety: `Shift+N` while typing in an input → does NOT open the dialog