### PR TITLE
fix: improve assertManagedHomePath error for cross-environment accounts

### DIFF
--- a/src/main/codex-accounts/service.ts
+++ b/src/main/codex-accounts/service.ts
@@ -245,6 +245,20 @@ export class CodexAccountService {
     const resolvedCandidate = resolve(candidatePath)
     const resolvedRoot = resolve(rootPath)
 
+    // Why: in dev mode, userData points to orca-dev/ while production uses
+    // orca/. Accounts created by the packaged app store production paths in
+    // settings. A quick prefix check before realpathSync avoids noisy errors
+    // when dev instances encounter production-rooted managed home paths.
+    if (!resolvedCandidate.startsWith(resolvedRoot + sep)) {
+      throw new Error(
+        `Managed Codex home is outside current storage root (expected under ${resolvedRoot}).`
+      )
+    }
+
+    if (!existsSync(resolvedCandidate)) {
+      throw new Error('Managed Codex home directory does not exist on disk.')
+    }
+
     // realpath() requires the leaf to exist. For pre-login add flow we create
     // the home directory first so the containment check still verifies the
     // canonical on-disk target rather than trusting persisted text blindly.


### PR DESCRIPTION
## Summary
- Add a prefix check and existence check before `realpathSync` in `assertManagedHomePath` so accounts from a different userData root (e.g., production paths in a dev session) produce a clear error message instead of "escaped Orca account storage"

### Problem
When running `pnpm dev`, all dev worktrees share `orca-dev/` for userData. If you previously added Codex accounts in the packaged app, their `managedHomePath` points to `orca/codex-accounts/...` (production). The constructor's `safeSyncCanonicalConfigToManagedHomes()` iterates these accounts and `assertManagedHomePath` throws a confusing "escaped Orca account storage" error 3x on every startup.

### Fix
Check the resolved path prefix before calling `realpathSync` (which would throw ENOENT on the non-existent production path). The new error message says: `Managed Codex home is outside current storage root (expected under ...)`.

## Test plan
- [x] TypeScript compiles clean
- [x] All codex-related tests pass
- [x] Pre-existing failures unrelated (missing `@xterm/headless`, browser detection)