### PR TITLE
fix(terminal): clear screen before daemon restore to prevent duplicated output

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -372,13 +372,21 @@ export function connectPanePty(
           }
 
           if (connectResult?.coldRestore) {
+            // Why: restoreScrollbackBuffers() already wrote the saved xterm
+            // buffer before this rAF ran. The cold-restore scrollback from
+            // disk history overlaps with that content. Without clearing first,
+            // the terminal shows duplicated output.
+            pane.terminal.write('\x1b[2J\x1b[3J\x1b[H')
             pane.terminal.write(connectResult.coldRestore.scrollback)
             pane.terminal.write('\r\n\x1b[2m--- session restored ---\x1b[0m\r\n\r\n')
             window.api.pty.ackColdRestore(ptyId!)
           } else if (connectResult?.snapshot) {
-            if (!connectResult.isAlternateScreen) {
-              pane.terminal.write('\x1b[2J\x1b[3J\x1b[H')
-            }
+            // Why: always clear before writing the daemon snapshot to prevent
+            // duplication with the scrollback that restoreScrollbackBuffers()
+            // wrote earlier. The alt-screen case previously skipped this,
+            // leaving stale scrollback in the normal buffer that reappeared
+            // when the user exited the TUI (e.g. Claude Code).
+            pane.terminal.write('\x1b[2J\x1b[3J\x1b[H')
             pane.terminal.write(connectResult.snapshot)
           }
 


### PR DESCRIPTION
## Summary
- Fixes duplicated terminal output on app restart when the terminal daemon is enabled (#81)
- `restoreScrollbackBuffers()` writes saved xterm content during mount, then the daemon reattach writes overlapping cold-restore scrollback or live snapshot — both appear in the terminal
- Adds `\x1b[2J\x1b[3J\x1b[H` (clear screen + scrollback + cursor home) before both cold-restore and snapshot writes so the daemon's authoritative content replaces the stale buffer
- Removes the `isAlternateScreen` guard that skipped the clear, which left stale scrollback in the normal buffer that reappeared when exiting a TUI (e.g. Claude Code)

## Test plan
- [ ] Enable `experimentalTerminalDaemon` in Settings → Experimental
- [ ] Run a Claude Code session, restart the app — verify terminal output appears once, not duplicated
- [ ] With Claude Code TUI active at shutdown, restart — verify no stale scrollback appears when exiting the TUI
- [ ] Disable `experimentalTerminalDaemon`, restart — verify scrollback restore still works as before (no regression)
- [ ] Verify split-pane terminals restore correctly with daemon enabled