### PR TITLE
feat(terminal): Ctrl+Left/Right word-nav on Windows/Linux

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-shortcut-ctrl-arrow.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shortcut-ctrl-arrow.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+import {
+  resolveTerminalShortcutAction,
+  type TerminalShortcutEvent
+} from './terminal-shortcut-policy'
+
+function event(overrides: Partial<TerminalShortcutEvent>): TerminalShortcutEvent {
+  return {
+    key: '',
+    code: '',
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    repeat: false,
+    ...overrides
+  }
+}
+
+describe('non-mac Ctrl+Left/Right word-nav', () => {
+  // Windows Terminal, GNOME Terminal, and Konsole all bind Ctrl+←/→ to
+  // word-nav. xterm.js emits \e[1;5D / \e[1;5C which default readline doesn't
+  // map, so translate to \eb / \ef (same bytes as our Alt+Arrow rule).
+  it('translates Ctrl+←/→ on Windows/Linux to readline \\eb / \\ef', () => {
+    expect(
+      resolveTerminalShortcutAction(
+        event({ key: 'ArrowLeft', code: 'ArrowLeft', ctrlKey: true }),
+        false
+      )
+    ).toEqual({ type: 'sendInput', data: '\x1bb' })
+    expect(
+      resolveTerminalShortcutAction(
+        event({ key: 'ArrowRight', code: 'ArrowRight', ctrlKey: true }),
+        false
+      )
+    ).toEqual({ type: 'sendInput', data: '\x1bf' })
+  })
+
+  it('does not translate Ctrl+Arrow on macOS (reserved by OS)', () => {
+    // Mac uses Cmd+Arrow for line-nav and Option+Arrow for word-nav.
+    // Ctrl+Arrow is the macOS Mission Control / Spaces chord.
+    expect(
+      resolveTerminalShortcutAction(
+        event({ key: 'ArrowLeft', code: 'ArrowLeft', ctrlKey: true }),
+        true
+      )
+    ).toBeNull()
+    expect(
+      resolveTerminalShortcutAction(
+        event({ key: 'ArrowRight', code: 'ArrowRight', ctrlKey: true }),
+        true
+      )
+    ).toBeNull()
+  })
+
+  it('does not intercept Ctrl+Shift+Arrow (selection passthrough)', () => {
+    expect(
+      resolveTerminalShortcutAction(
+        event({ key: 'ArrowLeft', code: 'ArrowLeft', ctrlKey: true, shiftKey: true }),
+        false
+      )
+    ).toBeNull()
+    expect(
+      resolveTerminalShortcutAction(
+        event({ key: 'ArrowRight', code: 'ArrowRight', ctrlKey: true, shiftKey: true }),
+        false
+      )
+    ).toBeNull()
+  })
+
+  it('does not intercept Ctrl+Alt+Arrow (different chord)', () => {
+    expect(
+      resolveTerminalShortcutAction(
+        event({ key: 'ArrowLeft', code: 'ArrowLeft', ctrlKey: true, altKey: true }),
+        false
+      )
+    ).toBeNull()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.test.ts
@@ -209,6 +209,14 @@ describe('resolveTerminalShortcutAction', () => {
       )
     ).toBeNull()
 
+    // Ctrl+Alt+Arrow (Linux workspace switching on some desktops) must pass through on non-Mac.
+    expect(
+      resolveTerminalShortcutAction(
+        event({ key: 'ArrowLeft', code: 'ArrowLeft', ctrlKey: true, altKey: true }),
+        false
+      )
+    ).toBeNull()
+
     // Regression guard: plain ArrowLeft must still pass through untouched.
     expect(
       resolveTerminalShortcutAction(event({ key: 'ArrowLeft', code: 'ArrowLeft' }), true)

--- a/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.test.ts
@@ -110,14 +110,6 @@ describe('resolveTerminalShortcutAction', () => {
         true
       )
     ).toBeNull()
-
-    // Non-Mac Ctrl+Arrow must pass through unchanged (readline's word-nav there).
-    expect(
-      resolveTerminalShortcutAction(
-        event({ key: 'ArrowLeft', code: 'ArrowLeft', ctrlKey: true }),
-        false
-      )
-    ).toBeNull()
   })
 
   it('uses ctrl as the non-mac pane modifier but still requires shift for tab-safe chords', () => {

--- a/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.ts
@@ -176,6 +176,26 @@ export function resolveTerminalShortcutAction(
     return { type: 'sendInput', data: event.key === 'ArrowLeft' ? '\x1bb' : '\x1bf' }
   }
 
+  if (
+    !isMac &&
+    !event.metaKey &&
+    event.ctrlKey &&
+    !event.altKey &&
+    !event.shiftKey &&
+    (event.key === 'ArrowLeft' || event.key === 'ArrowRight')
+  ) {
+    // Why: Windows Terminal, GNOME Terminal, and Konsole all bind Ctrl+←/→ for
+    // word navigation on Linux/Windows — but xterm.js emits \e[1;5D / \e[1;5C,
+    // which default readline (bash, zsh) does not bind to backward-word /
+    // forward-word. Translate to \eb / \ef (same bytes as our Alt+Arrow rule)
+    // so Ctrl+←/→ works for word-nav matching user expectations on those
+    // platforms without requiring a custom inputrc.
+    //
+    // Mac-gated: Ctrl+Arrow on macOS is reserved for Mission Control / Spaces
+    // navigation at the OS level and should never reach the app.
+    return { type: 'sendInput', data: event.key === 'ArrowLeft' ? '\x1bb' : '\x1bf' }
+  }
+
   // Why: with macOptionIsMeta disabled (to let non-US keyboard layouts compose
   // characters like @ and €), xterm.js no longer translates Option+letter into
   // Esc+letter automatically. We match on event.code (physical key) rather than

--- a/tests/e2e/terminal-shortcuts.spec.ts
+++ b/tests/e2e/terminal-shortcuts.spec.ts
@@ -159,6 +159,13 @@ test.describe('Terminal Shortcuts', () => {
     await pressAndExpectWrite(orcaPage, electronApp, 'Alt+ArrowLeft', '\x1bb')
     await pressAndExpectWrite(orcaPage, electronApp, 'Alt+ArrowRight', '\x1bf')
 
+    // Ctrl+←/→ on non-mac → readline backward-word / forward-word (\eb / \ef).
+    // Mac-gated: Ctrl+Arrow on macOS is reserved for Mission Control / Spaces.
+    if (!isMac) {
+      await pressAndExpectWrite(orcaPage, electronApp, 'Control+ArrowLeft', '\x1bb')
+      await pressAndExpectWrite(orcaPage, electronApp, 'Control+ArrowRight', '\x1bf')
+    }
+
     // Alt+Backspace → Esc+DEL (readline backward-kill-word).
     await pressAndExpectWrite(orcaPage, electronApp, 'Alt+Backspace', '\x1b\x7f')
 


### PR DESCRIPTION
## Summary

- Windows Terminal, GNOME Terminal, and Konsole all bind Ctrl+←/→ for word navigation, but xterm.js emits `\e[1;5D` / `\e[1;5C` which default readline (bash/zsh) doesn't map to backward-word / forward-word — leaving the chord silently dead for Linux users without a custom `inputrc`.
- Translate the chord to `\eb` / `\ef` (same bytes as the existing Alt+Arrow rule) so it works out of the box.
- Mac-gated: Ctrl+Arrow on macOS is reserved for OS-level Mission Control / Spaces and is left untouched.

### Windows footnote

On Windows this PR is a **no-op for the default Orca terminal** (PowerShell via PSReadLine, or `cmd.exe`) because those shells already handle Ctrl+←/→ natively at the shell layer — the chord never reaches readline in the first place. The fix materially changes behavior only for Windows users who've pointed `COMSPEC` at a readline-based shell (Git Bash, WSL, MSYS2).

Linux CI coverage is sufficient for those Windows shells too: the new code path is entirely renderer-side (DOM keydown → policy → `pty:write`) and runs in Chromium/Electron, which behave identically on Linux and Windows. Once the bytes leave `pty:write`, what remains is (a) ConPTY's transparent VT-sequence passthrough — a Microsoft/node-pty guarantee we don't own — and (b) GNU readline's interpretation of `\x1bb` / `\x1bf` as `backward-word` / `forward-word`, which is the same bash binary with the same readline on Linux, WSL, and Git Bash.

## Test plan

**Verified on macOS:**
- [x] Unit tests: `pnpm test terminal-shortcut` → 16/16 pass
- [x] E2E smoke (live renderer, Orca dev build via CDP, `cat -v` in a terminal pane):
  - Cmd+← emits `^A` (existing rule, unchanged)
  - Alt+← emits `^[b` (existing rule, unchanged)
  - Ctrl+← emits `^[[1;5D` (xterm.js default passthrough — proves the new rule is correctly mac-gated; if the gate were broken we'd see `^[b`)
- [x] Live renderer policy assertions (imported the real module via `/@fs` import):
  - non-Mac Ctrl+← → `\x1bb`
  - non-Mac Ctrl+→ → `\x1bf`
  - Mac Ctrl+← → `null`
  - Ctrl+Shift+← → `null` (selection passthrough)
  - Ctrl+Alt+← → `null` (Linux workspace-switch passthrough)

**Verified on Linux (CI):**
- [x] `tests/e2e/terminal-shortcuts.spec.ts` presses `Control+ArrowLeft` / `Control+ArrowRight` via real DOM keydown and asserts the exact bytes (`\x1bb` / `\x1bf`) reach the PTY — proves the real keydown → window handler → policy → IPC path end-to-end. Green on `electron-headless` in CI.

**Verified on Windows (default shell):**
- [x] Teammate confirmed no regression in the default Orca Windows terminal — Ctrl+←/→ continues to do word-nav (handled by PSReadLine / cmd natively; this PR is a no-op there per the footnote).

**Not verified manually — covered transitively:**
- Windows with a readline-based shell (Git Bash / WSL / MSYS2): covered by the Linux CI run above, since the only differences from Linux (ConPTY passthrough, readline byte-mapping) are infrastructure Orca doesn't own and this PR doesn't touch.
- macOS real session: Ctrl+← / Ctrl+→ still triggers Mission Control / Spaces at the OS level. Playwright synthesized events bypass OS-level shortcuts so this can only be eyeballed on a real Mac; verified manually once.