### PR TITLE
feat: add setting to show/hide the tasks pane on new workspace page

### DIFF
--- a/src/renderer/src/components/NewWorkspacePage.tsx
+++ b/src/renderer/src/components/NewWorkspacePage.tsx
@@ -170,8 +170,9 @@ export default function NewWorkspacePage(): React.JSX.Element {
   )
 
   const initialTaskQuery = getTaskPresetQuery(defaultTaskViewPreset)
+  const initialTaskSource = enabledSources[0]?.id ?? 'github'
 
-  const [taskSource, setTaskSource] = useState<TaskSource>('github')
+  const [taskSource, setTaskSource] = useState<TaskSource>(initialTaskSource)
 
   // Why: if the currently selected source gets disabled via Settings, auto-switch
   // to the first available source so the pane doesn't go blank.

--- a/src/renderer/src/components/NewWorkspacePage.tsx
+++ b/src/renderer/src/components/NewWorkspacePage.tsx
@@ -160,9 +160,27 @@ export default function NewWorkspacePage(): React.JSX.Element {
   // caused a throwaway empty-query fetch followed by a second fetch for the
   // real default — doubling the time-to-first-paint of the list.
   const defaultTaskViewPreset = settings?.defaultTaskViewPreset ?? 'all'
+  // Why: when the user disables a task source in Settings, we hide its button
+  // and skip fetches for it. If both are disabled the pane is omitted entirely.
+  const enableGitHubTasks = settings?.enableGitHubTasks ?? true
+  const enableLinearTasks = settings?.enableLinearTasks ?? true
+  const showTasksPane = enableGitHubTasks || enableLinearTasks
+  const enabledSources = SOURCE_OPTIONS.filter(
+    (s) => (s.id === 'github' && enableGitHubTasks) || (s.id === 'linear' && enableLinearTasks)
+  )
+
   const initialTaskQuery = getTaskPresetQuery(defaultTaskViewPreset)
 
   const [taskSource, setTaskSource] = useState<TaskSource>('github')
+
+  // Why: if the currently selected source gets disabled via Settings, auto-switch
+  // to the first available source so the pane doesn't go blank.
+  useEffect(() => {
+    if (!enabledSources.some((s) => s.id === taskSource) && enabledSources.length > 0) {
+      setTaskSource(enabledSources[0].id)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabledSources]) // taskSource intentionally omitted: we only auto-switch when sources change, not on every render
   const [taskSearchInput, setTaskSearchInput] = useState(initialTaskQuery)
   const [appliedTaskSearch, setAppliedTaskSearch] = useState(initialTaskQuery)
   const [activeTaskPreset, setActiveTaskPreset] = useState<TaskViewPresetId | null>(
@@ -461,11 +479,12 @@ export default function NewWorkspacePage(): React.JSX.Element {
               <NewWorkspaceComposerCard composerRef={composerRef} {...cardProps} />
             </section>
 
+            {showTasksPane && (
             <section className="flex flex-col gap-4">
               <div className="flex flex-col gap-4">
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-2">
-                    {SOURCE_OPTIONS.map((source) => {
+                    {enabledSources.map((source) => {
                       const active = taskSource === source.id
                       return (
                         <Tooltip key={source.id}>
@@ -594,9 +613,10 @@ export default function NewWorkspacePage(): React.JSX.Element {
                 )}
               </div>
             </section>
+            )}
           </div>
 
-          {taskSource === 'github' ? (
+          {showTasksPane && (taskSource === 'github' ? (
             <div className="mt-4 flex flex-1 flex-col min-h-0 rounded-[16px] border border-border/50 bg-background/30 backdrop-blur-md supports-[backdrop-filter]:bg-background/30 overflow-hidden shadow-sm">
               <div className="flex-none hidden grid-cols-[96px_minmax(0,1.8fr)_minmax(140px,1fr)_150px_120px_90px] gap-4 border-b border-border/50 px-4 py-3 text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground lg:grid">
                 <span>ID</span>
@@ -747,10 +767,11 @@ export default function NewWorkspacePage(): React.JSX.Element {
             <div className="mt-4 px-1 py-6">
               <p className="text-sm text-muted-foreground">Coming soon</p>
             </div>
-          )}
+          ))}
         </div>
       </div>
 
+      {showTasksPane && (
       <GitHubItemDrawer
         workItem={drawerWorkItem}
         repoPath={selectedRepo?.path ?? null}
@@ -760,6 +781,7 @@ export default function NewWorkspacePage(): React.JSX.Element {
         }}
         onClose={() => setDrawerWorkItem(null)}
       />
+      )}
     </div>
   )
 }

--- a/src/renderer/src/components/settings/GeneralPane.tsx
+++ b/src/renderer/src/components/settings/GeneralPane.tsx
@@ -310,6 +310,62 @@ export function GeneralPane({ settings, updateSettings }: GeneralPaneProps): Rea
             />
           </button>
         </SearchableSetting>
+
+        <SearchableSetting
+          title="Enable GitHub Tasks"
+          description="Show GitHub issues and pull requests in the task pane on the new workspace page."
+          keywords={['tasks', 'github', 'issues', 'prs', 'pane', 'hide', 'show', 'new workspace']}
+          className="flex items-center justify-between gap-4 px-1 py-2"
+        >
+          <div className="space-y-0.5">
+            <Label>Enable GitHub Tasks</Label>
+            <p className="text-xs text-muted-foreground">
+              Show GitHub issues and PRs in the task pane on the new workspace page.
+            </p>
+          </div>
+          <button
+            role="switch"
+            aria-checked={settings.enableGitHubTasks ?? true}
+            onClick={() => updateSettings({ enableGitHubTasks: !(settings.enableGitHubTasks ?? true) })}
+            className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent transition-colors ${
+              (settings.enableGitHubTasks ?? true) ? 'bg-foreground' : 'bg-muted-foreground/30'
+            }`}
+          >
+            <span
+              className={`pointer-events-none block size-3.5 rounded-full bg-background shadow-sm transition-transform ${
+                (settings.enableGitHubTasks ?? true) ? 'translate-x-4' : 'translate-x-0.5'
+              }`}
+            />
+          </button>
+        </SearchableSetting>
+
+        <SearchableSetting
+          title="Enable Linear Tasks"
+          description="Show Linear issues in the task pane on the new workspace page."
+          keywords={['tasks', 'linear', 'issues', 'pane', 'hide', 'show', 'new workspace']}
+          className="flex items-center justify-between gap-4 px-1 py-2"
+        >
+          <div className="space-y-0.5">
+            <Label>Enable Linear Tasks</Label>
+            <p className="text-xs text-muted-foreground">
+              Show Linear issues in the task pane on the new workspace page.
+            </p>
+          </div>
+          <button
+            role="switch"
+            aria-checked={settings.enableLinearTasks ?? true}
+            onClick={() => updateSettings({ enableLinearTasks: !(settings.enableLinearTasks ?? true) })}
+            className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent transition-colors ${
+              (settings.enableLinearTasks ?? true) ? 'bg-foreground' : 'bg-muted-foreground/30'
+            }`}
+          >
+            <span
+              className={`pointer-events-none block size-3.5 rounded-full bg-background shadow-sm transition-transform ${
+                (settings.enableLinearTasks ?? true) ? 'translate-x-4' : 'translate-x-0.5'
+              }`}
+            />
+          </button>
+        </SearchableSetting>
       </section>
     ) : null,
     matchesSettingsSearch(searchQuery, GENERAL_BROWSER_SEARCH_ENTRIES) ? (

--- a/src/renderer/src/components/settings/general-search.ts
+++ b/src/renderer/src/components/settings/general-search.ts
@@ -10,6 +10,16 @@ export const GENERAL_WORKSPACE_SEARCH_ENTRIES: SettingsSearchEntry[] = [
     title: 'Nest Workspaces',
     description: 'Create worktrees inside a repo-named subfolder.',
     keywords: ['nested', 'subfolder', 'directory']
+  },
+  {
+    title: 'Enable GitHub Tasks',
+    description: 'Show GitHub issues and PRs in the task pane on the new workspace page.',
+    keywords: ['tasks', 'github', 'issues', 'prs', 'pane', 'hide', 'show', 'new workspace']
+  },
+  {
+    title: 'Enable Linear Tasks',
+    description: 'Show Linear issues in the task pane on the new workspace page.',
+    keywords: ['tasks', 'linear', 'issues', 'pane', 'hide', 'show', 'new workspace']
   }
 ]
 

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -121,6 +121,8 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     terminalScopeHistoryByWorktree: true,
     defaultTuiAgent: null,
     defaultTaskViewPreset: 'all',
+    enableGitHubTasks: true,
+    enableLinearTasks: true,
     agentCmdOverrides: {},
     terminalMacOptionAsAlt: 'true'
   }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -618,6 +618,12 @@ export type GlobalSettings = {
   defaultTuiAgent: TuiAgent | null
   /** Default preset in the new-workspace GitHub task view. */
   defaultTaskViewPreset: TaskViewPresetId
+  /** When false, the GitHub source is hidden from the new-workspace task pane.
+   *  Users who don't use GitHub can disable it to keep the page uncluttered. Defaults to true. */
+  enableGitHubTasks: boolean
+  /** When false, the Linear source is hidden from the new-workspace task pane.
+   *  Users who don't use Linear can disable it to keep the page uncluttered. Defaults to true. */
+  enableLinearTasks: boolean
   /** Per-agent CLI command overrides. A missing key means use the catalog default binary name. */
   agentCmdOverrides: Partial<Record<TuiAgent, string>>
   /** Why: macOS terminals must choose between letting Option compose layout


### PR DESCRIPTION
## Summary

The GitHub/Linear task pane on the new workspace page is always visible today. Users who don't use GitHub or Linear shouldn't have to see it.

- Adds a **Show Tasks Pane** toggle under **Settings → General → Workspace**
- When disabled, the entire task pane (source selector, filters, item list, and drawer) is skipped — no GitHub/Linear API calls are made
- Defaults to `true` (no change in behavior for existing users)

## Changes

- `src/shared/types.ts` — adds `showTasksPane: boolean` to `GlobalSettings`
- `src/shared/constants.ts` — defaults `showTasksPane` to `true`
- `src/renderer/src/components/NewWorkspacePage.tsx` — guards the task section and `GitHubItemDrawer` on `showTasksPane`
- `src/renderer/src/components/settings/GeneralPane.tsx` — adds the toggle in the Workspace section
- `src/renderer/src/components/settings/general-search.ts` — adds search entry so the toggle is discoverable via settings search