### PR TITLE
Support GitHub Copilot CLI agent detection

### DIFF
--- a/src/renderer/src/lib/agent-status.test.ts
+++ b/src/renderer/src/lib/agent-status.test.ts
@@ -245,6 +245,12 @@ describe('getAgentLabel', () => {
     expect(getAgentLabel('⠂ Claude Code')).toBe('Claude Code')
     expect(getAgentLabel('⠋ Codex is thinking')).toBe('Codex')
   })
+
+  it('labels GitHub Copilot CLI', () => {
+    expect(getAgentLabel('copilot working')).toBe('GitHub Copilot')
+    expect(getAgentLabel('copilot idle')).toBe('GitHub Copilot')
+    expect(getAgentLabel('GitHub Copilot CLI')).toBe('GitHub Copilot')
+  })
 })
 
 describe('createAgentStatusTracker', () => {

--- a/src/shared/agent-detection.ts
+++ b/src/shared/agent-detection.ts
@@ -16,7 +16,7 @@ const GEMINI_SILENT_WORKING = '\u23F2' // ⏲
 const GEMINI_IDLE = '\u25C7' // ◇
 const GEMINI_PERMISSION = '\u270B' // ✋
 
-export const AGENT_NAMES = ['claude', 'codex', 'gemini', 'opencode', 'aider']
+export const AGENT_NAMES = ['claude', 'codex', 'copilot', 'gemini', 'opencode', 'aider']
 const PI_IDLE_PREFIX = '\u03c0 - ' // π - (Pi titlebar extension idle format)
 
 // eslint-disable-next-line no-control-regex -- intentional terminal escape sequence matching
@@ -254,6 +254,9 @@ export function getAgentLabel(title: string): string | null {
   // heuristic so mixed-agent hovercards stay truthful.
   if (lower.includes('codex')) {
     return 'Codex'
+  }
+  if (lower.includes('copilot')) {
+    return 'GitHub Copilot'
   }
   if (lower.includes('opencode')) {
     return 'OpenCode'


### PR DESCRIPTION
## Description

Fix the green "Agent Active" indicator in the upper left of Orca to recognize when running under GitHub Copilot CLI.

### User-Facing Change

The status indicator now correctly displays when executing commands in GitHub Copilot CLI terminals, properly recognizing the agent type alongside existing agents (Claude Code, Codex, OpenCode, Aider, etc.).

### Changes Made

- Added `'copilot'` to the `AGENT_NAMES` list in `src/shared/agent-detection.ts`
- Implemented GitHub Copilot CLI label detection in `getAgentLabel()` function
- Added comprehensive test coverage for GitHub Copilot CLI labeling

### Technical Details

The agent detection system works by extracting OSC title sequences from terminal output and detecting agent presence. The fix adds support for the `'copilot'` agent name used by GitHub Copilot CLI.

### Testing

✅ All agent-status tests pass (62/62)
✅ Linting passes (0 warnings, 0 errors)
✅ Type checking passes
✅ Build succeeds

Note: The `pnpm test` command shows some pre-existing daemon socket permission test failures on Windows (unrelated to this change). The agent-status tests that cover this implementation all pass.

### No Visual Changes

This is a bug fix for existing functionality—the agent detection now simply works correctly for GitHub Copilot CLI.

---

*X (Twitter) handle: [@drakontia](https://x.com/drakontia)*
