### PR TITLE
fix(quick-open): exclude sibling worktree files from Cmd+P results

### DIFF
--- a/src/main/ipc/filesystem-list-files.ts
+++ b/src/main/ipc/filesystem-list-files.ts
@@ -45,8 +45,28 @@ function shouldIncludeQuickOpenPath(path: string): boolean {
   return true
 }
 
-export async function listQuickOpenFiles(rootPath: string, store: Store): Promise<string[]> {
+export async function listQuickOpenFiles(
+  rootPath: string,
+  store: Store,
+  excludePaths?: string[]
+): Promise<string[]> {
   const authorizedRootPath = await resolveAuthorizedPath(rootPath, store)
+
+  // Why: when the main worktree sits at the repo root, linked worktrees are
+  // nested subdirectories. Without excluding them, rg/git lists files from
+  // every worktree instead of just the active one.
+  const excludeGlobs: string[] = []
+  if (excludePaths?.length) {
+    const normalizedRoot = `${authorizedRootPath.replace(/[\\/]+$/, '')}/`
+    for (const abs of excludePaths) {
+      const rel = abs.startsWith(normalizedRoot)
+        ? abs.slice(normalizedRoot.length)
+        : relative(authorizedRootPath, abs).replace(/\\/g, '/')
+      if (rel && !rel.startsWith('..') && !rel.startsWith('/')) {
+        excludeGlobs.push(rel)
+      }
+    }
+  }
 
   // Why: checking rg availability upfront avoids a race condition where
   // spawn('rg') emits 'close' before 'error' on some platforms, causing
@@ -54,7 +74,7 @@ export async function listQuickOpenFiles(rootPath: string, store: Store): Promis
   // can run. The result is cached after the first check.
   const rgAvailable = await checkRgAvailable(authorizedRootPath)
   if (!rgAvailable) {
-    return listFilesWithGit(authorizedRootPath)
+    return listFilesWithGit(authorizedRootPath, excludeGlobs)
   }
 
   // Why: We try fast string slicing first (O(1) per file), but fall back to
@@ -164,6 +184,7 @@ export async function listQuickOpenFiles(rootPath: string, store: Store): Promis
   // Why: On Windows, rg outputs '\'-separated paths. Forcing '/' via
   // --path-separator avoids per-line backslash replacement in processLine.
   const rgSepArgs = sep === '\\' ? ['--path-separator', '/'] : []
+  const rgExcludeArgs = excludeGlobs.flatMap((g) => ['--glob', `!${g}/**`])
 
   await Promise.all([
     runRg([
@@ -174,6 +195,7 @@ export async function listQuickOpenFiles(rootPath: string, store: Store): Promis
       '!**/node_modules',
       '--glob',
       '!**/.git',
+      ...rgExcludeArgs,
       authorizedRootPath
     ]),
     runRg([
@@ -187,6 +209,7 @@ export async function listQuickOpenFiles(rootPath: string, store: Store): Promis
       '!**/node_modules',
       '--glob',
       '!**/.git',
+      ...rgExcludeArgs,
       authorizedRootPath
     ])
   ])
@@ -202,8 +225,9 @@ export async function listQuickOpenFiles(rootPath: string, store: Store): Promis
  * surfaces .env* files that are typically gitignored but users frequently need in
  * quick-open (mirrors the second rg call with --no-ignore-vcs).
  */
-function listFilesWithGit(rootPath: string): Promise<string[]> {
+function listFilesWithGit(rootPath: string, excludeGlobs: string[] = []): Promise<string[]> {
   const files = new Set<string>()
+  const excludePrefixes = excludeGlobs.map((g) => `${g.replace(/\\/g, '/')}/`)
 
   const runGitLsFiles = (args: string[]): Promise<void> => {
     return new Promise((resolve) => {
@@ -223,6 +247,9 @@ function listFilesWithGit(rootPath: string): Promise<string[]> {
           line = line.substring(0, line.length - 1)
         }
         if (!line) {
+          return
+        }
+        if (excludePrefixes.some((p) => line.startsWith(p))) {
           return
         }
         if (shouldIncludeQuickOpenPath(line)) {

--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -425,7 +425,10 @@ export function registerFilesystemHandlers(store: Store): void {
   // ─── List all files (for quick-open) ─────────────────────
   ipcMain.handle(
     'fs:listFiles',
-    async (_event, args: { rootPath: string; connectionId?: string }): Promise<string[]> => {
+    async (
+      _event,
+      args: { rootPath: string; connectionId?: string; excludePaths?: string[] }
+    ): Promise<string[]> => {
       if (args.connectionId) {
         const provider = getSshFilesystemProvider(args.connectionId)
         if (!provider) {
@@ -433,7 +436,7 @@ export function registerFilesystemHandlers(store: Store): void {
         }
         return provider.listFiles(args.rootPath)
       }
-      return listQuickOpenFiles(args.rootPath, store)
+      return listQuickOpenFiles(args.rootPath, store, args.excludePaths)
     }
   )
 

--- a/src/preload/api-types.d.ts
+++ b/src/preload/api-types.d.ts
@@ -489,7 +489,11 @@ export type PreloadApi = {
       filePath: string
       connectionId?: string
     }) => Promise<{ size: number; isDirectory: boolean; mtime: number }>
-    listFiles: (args: { rootPath: string; connectionId?: string }) => Promise<string[]>
+    listFiles: (args: {
+      rootPath: string
+      connectionId?: string
+      excludePaths?: string[]
+    }) => Promise<string[]>
     search: (args: SearchOptions & { connectionId?: string }) => Promise<SearchResult>
     importExternalPaths: (args: { sourcePaths: string[]; destDir: string }) => Promise<{
       results: (

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -896,8 +896,11 @@ const api = {
       connectionId?: string
     }): Promise<{ size: number; isDirectory: boolean; mtime: number }> =>
       ipcRenderer.invoke('fs:stat', args),
-    listFiles: (args: { rootPath: string; connectionId?: string }): Promise<string[]> =>
-      ipcRenderer.invoke('fs:listFiles', args),
+    listFiles: (args: {
+      rootPath: string
+      connectionId?: string
+      excludePaths?: string[]
+    }): Promise<string[]> => ipcRenderer.invoke('fs:listFiles', args),
     search: (args: {
       query: string
       rootPath: string

--- a/src/renderer/src/components/QuickOpen.tsx
+++ b/src/renderer/src/components/QuickOpen.tsx
@@ -66,18 +66,24 @@ export default function QuickOpen(): React.JSX.Element | null {
   const [loadError, setLoadError] = useState<string | null>(null)
   const listRef = useRef<HTMLDivElement>(null)
 
-  // Find active worktree path
-  const worktreePath = useMemo(() => {
+  // Find active worktree path and sibling worktree paths to exclude
+  const { worktreePath, excludePaths } = useMemo(() => {
     if (!activeWorktreeId) {
-      return null
+      return { worktreePath: null, excludePaths: [] as string[] }
     }
     for (const worktrees of Object.values(worktreesByRepo)) {
       const wt = worktrees.find((w) => w.id === activeWorktreeId)
       if (wt) {
-        return wt.path
+        // Why: when the active worktree is the repo root (isMainWorktree),
+        // linked worktrees are nested subdirectories. Without excluding them,
+        // file listing returns files from every worktree, not just this one.
+        const siblings = worktrees
+          .filter((w) => w.id !== activeWorktreeId && w.path.startsWith(`${wt.path}/`))
+          .map((w) => w.path)
+        return { worktreePath: wt.path, excludePaths: siblings }
       }
     }
-    return null
+    return { worktreePath: null, excludePaths: [] as string[] }
   }, [activeWorktreeId, worktreesByRepo])
 
   const connectionId = useMemo(
@@ -106,7 +112,11 @@ export default function QuickOpen(): React.JSX.Element | null {
       // Why: quick-open shares the active worktree path model with file explorer
       // and search, so remote worktrees must include connectionId. Without this,
       // Windows resolves Linux roots (e.g. /home/*) as local C:\home\* paths.
-      .listFiles({ rootPath: worktreePath, connectionId })
+      .listFiles({
+        rootPath: worktreePath,
+        connectionId,
+        excludePaths: excludePaths.length > 0 ? excludePaths : undefined
+      })
       .then((result) => {
         if (!cancelled) {
           setFiles(result)
@@ -129,7 +139,7 @@ export default function QuickOpen(): React.JSX.Element | null {
     return () => {
       cancelled = true
     }
-  }, [visible, worktreePath, connectionId])
+  }, [visible, worktreePath, connectionId, excludePaths])
 
   // Filter files by fuzzy match
   const filtered = useMemo(() => {
@@ -151,8 +161,12 @@ export default function QuickOpen(): React.JSX.Element | null {
   // Why: when the query changes the first result becomes selected, but cmdk
   // doesn't reset the list's scrollTop. Without this, a previously scrolled
   // list leaves the new top result clipped behind the input border.
+  // rAF defers until after cmdk's own scroll-into-view pass, so our reset wins.
   useEffect(() => {
-    listRef.current?.scrollTo(0, 0)
+    const id = requestAnimationFrame(() => {
+      listRef.current?.scrollTo(0, 0)
+    })
+    return () => cancelAnimationFrame(id)
   }, [query, visible])
 
   const handleSelect = useCallback(


### PR DESCRIPTION
## Summary
- When the active worktree is the repo root (main worktree), linked worktrees are nested subdirectories. `rg --files` listed files from every worktree instead of just the active one. Now computes sibling worktree paths and passes them as `--glob` exclusions to rg (and prefix filters for the git fallback).
- Wraps scroll-to-top in `requestAnimationFrame` so it runs after cmdk's scroll-into-view pass, fixing the issue where clearing the search query didn't scroll back to top.

## Test plan
- [ ] Open Cmd+P on the main worktree — should only show files from the main worktree, not from linked worktrees
- [ ] Open Cmd+P on a linked worktree — should still show only that worktree's files
- [ ] Type a query, scroll down in results, then clear the query — list should scroll back to top
- [ ] Verify remote/SSH worktrees still work (excludePaths not sent for remote connections)