### PR TITLE
fix: support Cmd+N and Esc on the tasks page

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -516,6 +516,17 @@ function App(): React.JSX.Element {
         return
       }
 
+      // Cmd/Ctrl+N — new workspace (opens the lightweight composer modal)
+      if (!e.altKey && !e.shiftKey && e.key.toLowerCase() === 'n') {
+        if (!repos.some((repo) => isGitRepoKind(repo))) {
+          return
+        }
+        dispatchClearModifierHints()
+        e.preventDefault()
+        actions.openModal('new-workspace-composer')
+        return
+      }
+
       // Why: the new-workspace composer should not be able to reveal the right
       // sidebar at all, because that surface is intentionally distraction-free.
       if (activeView === 'new-workspace') {
@@ -527,17 +538,6 @@ function App(): React.JSX.Element {
         dispatchClearModifierHints()
         e.preventDefault()
         actions.toggleRightSidebar()
-        return
-      }
-
-      // Cmd/Ctrl+N — new workspace (opens the lightweight composer modal)
-      if (!e.altKey && !e.shiftKey && e.key.toLowerCase() === 'n') {
-        if (!repos.some((repo) => isGitRepoKind(repo))) {
-          return
-        }
-        dispatchClearModifierHints()
-        e.preventDefault()
-        actions.openModal('new-workspace-composer')
         return
       }
 

--- a/src/renderer/src/components/NewWorkspacePage.tsx
+++ b/src/renderer/src/components/NewWorkspacePage.tsx
@@ -142,6 +142,7 @@ export default function NewWorkspacePage(): React.JSX.Element {
   const settings = useAppStore((s) => s.settings)
   const pageData = useAppStore((s) => s.newWorkspacePageData)
   const closeNewWorkspacePage = useAppStore((s) => s.closeNewWorkspacePage)
+  const activeModal = useAppStore((s) => s.activeModal)
   const repos = useAppStore((s) => s.repos)
   const activeRepoId = useAppStore((s) => s.activeRepoId)
   const openModal = useAppStore((s) => s.openModal)
@@ -443,11 +444,8 @@ export default function NewWorkspacePage(): React.JSX.Element {
   }, [newIssueBody, newIssueSubmitting, newIssueTitle, selectedRepo])
 
   useEffect(() => {
-    // Why: when the GitHub preview sheet is open, Radix's Dialog owns Esc —
-    // it closes the sheet on its own. Page-level capture would otherwise fire
-    // first and pop the tasks page while the user just meant to dismiss the
-    // preview.
-    if (drawerWorkItem || newIssueOpen) {
+    // Why: when a modal is open, let it own Esc dismissal.
+    if (drawerWorkItem || newIssueOpen || activeModal !== 'none') {
       return
     }
 
@@ -481,7 +479,7 @@ export default function NewWorkspacePage(): React.JSX.Element {
 
     window.addEventListener('keydown', onKeyDown, { capture: true })
     return () => window.removeEventListener('keydown', onKeyDown, { capture: true })
-  }, [closeNewWorkspacePage, drawerWorkItem, newIssueOpen])
+  }, [activeModal, closeNewWorkspacePage, drawerWorkItem, newIssueOpen])
 
   return (
     <div className="relative flex h-full min-h-0 flex-1 overflow-hidden bg-background text-foreground">


### PR DESCRIPTION
## Summary
- Move Cmd+N handler above the `activeView === 'new-workspace'` early-return in App.tsx so it opens the composer modal from the tasks page
- Add `activeModal !== 'none'` guard to NewWorkspacePage's Esc handler so it yields to the composer modal's own Esc dismissal
- Cmd+J already works on the tasks page (routed via main-process IPC, no activeView guard)

## Test plan
- [ ] Open tasks page → press Cmd+N → composer modal opens
- [ ] With composer modal open → press Esc → modal closes, tasks page stays
- [ ] Press Esc again → tasks page closes
- [ ] From terminal view → Cmd+N still opens composer
- [ ] From tasks page → Cmd+J still opens worktree palette
- [ ] From tasks page → Cmd+L does NOT open right sidebar (still blocked)