### PR TITLE
feat(sidebar): rename Shutdown to Sleep with explanatory tooltip

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
@@ -14,10 +14,10 @@ import {
   BellOff,
   Link,
   MessageSquare,
+  Moon,
   Pencil,
   Pin,
   PinOff,
-  XCircle,
   Trash2
 } from 'lucide-react'
 import { useAppStore } from '@/store'
@@ -209,7 +209,7 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({ worktree, 
           <Tooltip>
             <TooltipTrigger asChild>
               <DropdownMenuItem onSelect={handleCloseTerminals} disabled={isDeleting}>
-                <XCircle className="size-3.5" />
+                <Moon className="size-3.5" />
                 Sleep
               </DropdownMenuItem>
             </TooltipTrigger>

--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
@@ -6,6 +6,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import {
   FolderOpen,
   Copy,
@@ -205,10 +206,18 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({ worktree, 
             {worktree.comment ? 'Edit Comment' : 'Add Comment'}
           </DropdownMenuItem>
           <DropdownMenuSeparator />
-          <DropdownMenuItem onSelect={handleCloseTerminals} disabled={isDeleting}>
-            <XCircle className="size-3.5" />
-            Shutdown
-          </DropdownMenuItem>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <DropdownMenuItem onSelect={handleCloseTerminals} disabled={isDeleting}>
+                <XCircle className="size-3.5" />
+                Sleep
+              </DropdownMenuItem>
+            </TooltipTrigger>
+            <TooltipContent side="right" sideOffset={8} className="max-w-[240px]">
+              Close all terminals in this workspace to free up memory and CPU. They&apos;ll be
+              re-created when you reopen it.
+            </TooltipContent>
+          </Tooltip>
           {/* Why: `git worktree remove` always rejects the main worktree, so we
              disable the item upfront. Radix forwards unknown props to the DOM
              element, so `title` works directly without a wrapper span — this


### PR DESCRIPTION
## Summary
- Rename the worktree right-click **Shutdown** action to **Sleep** to better convey the non-destructive, resumable nature of the action.
- Add a Radix tooltip anchored to the right of the dropdown (`side=\"right\"`, `sideOffset={8}`) explaining that the action closes all terminals to free memory/CPU and that they'll be re-created on reopen.

## Test plan
- [x] Right-click a workspace in the sidebar; confirm the item reads **Sleep** with the power/X icon.
- [x] Hover **Sleep**; confirm a dark tooltip appears to the right of the menu with the explanatory text.
- [x] Click **Sleep**; confirm terminals shut down as before.
- [x] Reopen the workspace; confirm terminals are re-created.

<img width="478" height="137" alt="image" src="https://github.com/user-attachments/assets/1f00d6aa-0b94-47e5-8c22-e557fd392147" />
