### PR TITLE
fix(tabs): raise selected tab contrast so it stands out from hover

### DIFF
--- a/src/renderer/src/components/tab-bar/BrowserTab.tsx
+++ b/src/renderer/src/components/tab-bar/BrowserTab.tsx
@@ -109,7 +109,7 @@ export default function BrowserTab({
           {...listeners}
           className={`group relative flex items-center h-full px-3 text-sm cursor-pointer select-none shrink-0 border-r border-border ${
             isActive
-              ? 'bg-accent/40 text-foreground border-b-transparent'
+              ? 'bg-accent text-foreground border-b-transparent'
               : 'bg-card text-muted-foreground hover:text-foreground hover:bg-accent/50'
           }`}
           onPointerDown={(e) => {

--- a/src/renderer/src/components/tab-bar/EditorFileTab.tsx
+++ b/src/renderer/src/components/tab-bar/EditorFileTab.tsx
@@ -185,7 +185,7 @@ export default function EditorFileTab({
           {...listeners}
           className={`group relative flex items-center h-full px-3 text-sm cursor-pointer select-none shrink-0 border-r border-border ${
             isActive
-              ? 'bg-accent/40 text-foreground border-b-transparent'
+              ? 'bg-accent text-foreground border-b-transparent'
               : 'bg-card text-muted-foreground hover:text-foreground hover:bg-accent/50'
           }`}
           onPointerDown={(e) => {

--- a/src/renderer/src/components/tab-bar/SortableTab.tsx
+++ b/src/renderer/src/components/tab-bar/SortableTab.tsx
@@ -157,7 +157,7 @@ export default function SortableTab({
           {...dragListeners}
           className={`group relative flex items-center h-full px-3 text-sm cursor-pointer select-none shrink-0 border-r border-border ${
             isActive
-              ? 'bg-accent/40 text-foreground border-b-transparent'
+              ? 'bg-accent text-foreground border-b-transparent'
               : 'bg-card text-muted-foreground hover:text-foreground hover:bg-accent/50'
           }`}
           onDoubleClick={(e) => {


### PR DESCRIPTION
## Summary
- Active tab used `bg-accent/40` while inactive hover used `bg-accent/50`, so hovering an inactive tab actually looked *more* prominent than the selected one — making it hard to tell which tab was active (reported by AmethystLiang in #bugs-and-feedback).
- Bumped the active state to full `bg-accent` in all three tab variants (editor files, terminals, browser tabs) so the visual order is now `inactive < hover < active`.
- Uses the existing `--accent` design token, so no new colors introduced and both light/dark themes get the boost.

Concrete contrast gain against the `--card` background:
- Light: selected was ~`#fafafa` (nearly invisible vs `#fff`) → now `#f5f5f5`
- Dark: selected was ~`#252525` → now `#404040` against `#171717`

## Test plan
- [x] Open several editor file tabs; verify the selected one is clearly distinguishable from the others in light mode
- [x] Same check in dark mode
- [x] Hover an inactive editor tab; verify the selected tab still looks more prominent than the hovered one
- [x] Repeat for terminal tabs and browser tabs
- [x] Verify drag/reorder and close-on-hover behavior still work (styling-only change, but worth a sanity check)

<img width="1123" height="47" alt="image" src="https://github.com/user-attachments/assets/59178cf1-8ca0-42ae-be8d-c3499713e1c1" />

<img width="1123" height="54" alt="image" src="https://github.com/user-attachments/assets/efebcab9-8173-4d9a-9e5e-a095db5a58cd" />
