### PR TITLE
fix(editor): restore syntax highlighting for .tsx and .jsx files

### DIFF
--- a/src/renderer/src/lib/language-detect.ts
+++ b/src/renderer/src/lib/language-detect.ts
@@ -8,10 +8,14 @@ function extname(filePath: string): string {
 }
 
 const EXT_TO_LANGUAGE: Record<string, string> = {
+  // Why: Monaco's built-in language registry maps .tsx/.cts/.mts onto the
+  // 'typescript' language id and .jsx/.mjs/.cjs onto 'javascript' — there is
+  // no separate 'typescriptreact'/'javascriptreact' id. Returning the base id
+  // is what gives .tsx/.jsx files syntax highlighting in the editor.
   '.ts': 'typescript',
-  '.tsx': 'typescriptreact',
+  '.tsx': 'typescript',
   '.js': 'javascript',
-  '.jsx': 'javascriptreact',
+  '.jsx': 'javascript',
   '.mjs': 'javascript',
   '.cjs': 'javascript',
   '.json': 'json',

--- a/src/renderer/src/lib/monaco-setup.ts
+++ b/src/renderer/src/lib/monaco-setup.ts
@@ -22,9 +22,7 @@ globalThis.MonacoEnvironment = {
       case 'razor':
         return new htmlWorker()
       case 'typescript':
-      case 'typescriptreact':
       case 'javascript':
-      case 'javascriptreact':
         return new tsWorker()
       default:
         return new editorWorker()

--- a/src/renderer/src/lib/monaco-setup.ts
+++ b/src/renderer/src/lib/monaco-setup.ts
@@ -43,6 +43,21 @@ monacoTS.javascriptDefaults.setDiagnosticsOptions({
   diagnosticCodesToIgnore: [2307, 2792]
 })
 
+// Why: .tsx/.jsx files share the base 'typescript'/'javascript' language ids
+// in Monaco's registry (there is no separate 'typescriptreact' id), so the
+// compiler options on those defaults apply to both. Without jsx enabled, the
+// worker raises TS17004 "Cannot use JSX unless the '--jsx' flag is provided"
+// on every JSX tag. Preserve mode is enough to allow parsing without forcing
+// an emit transform (we never emit — this is a read-only language service).
+monacoTS.typescriptDefaults.setCompilerOptions({
+  ...monacoTS.typescriptDefaults.getCompilerOptions(),
+  jsx: monacoTS.JsxEmit.Preserve
+})
+monacoTS.javascriptDefaults.setCompilerOptions({
+  ...monacoTS.javascriptDefaults.getCompilerOptions(),
+  jsx: monacoTS.JsxEmit.Preserve
+})
+
 // Configure Monaco to use the locally bundled editor instead of CDN
 loader.config({ monaco })
 


### PR DESCRIPTION
## Summary

- `detectLanguage` was returning `'typescriptreact'` for `.tsx` and `'javascriptreact'` for `.jsx`, but Monaco's built-in registry only defines `'typescript'` (which covers `.ts`/`.tsx`/`.cts`/`.mts`) and `'javascript'` (which covers `.js`/`.jsx`/`.mjs`/`.cjs`). Unknown language ids fall back to plaintext, so `.tsx`/`.jsx` opened with no highlighting while `.ts`/`.js` worked fine.
- Map both extensions to the base ids Monaco actually registers.
- Drop the now-unreachable `typescriptreact`/`javascriptreact` cases from the Monaco worker switch in `monaco-setup.ts` — those labels never reached the switch since Monaco itself never emitted them.

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] Verified in Electron: opened a `.tsx` file — keywords, strings, and JSX content are colored.
- [x] Verified in Electron: opened a `.ts` file — still highlights as before.