### PR TITLE
fix(terminal): auto-respawn PTY daemon when it dies mid-session

### DIFF
--- a/src/main/daemon/client.ts
+++ b/src/main/daemon/client.ts
@@ -28,6 +28,11 @@ export class DaemonClient {
   private streamSocket: Socket | null = null
   private connected = false
   private disconnectArmed = false
+  // Why: after a disconnect + reconnect (daemon respawn), a stale 'close'
+  // event from the old sockets can fire. Without a generation check, that
+  // event would tear down the fresh connection. Each doConnect() increments
+  // the generation; handleDisconnect ignores events from old generations.
+  private connectionGeneration = 0
   // Why: multiple concurrent spawn() calls from simultaneous pane mounts
   // all call ensureConnected(). Without a lock, each starts a separate
   // connection attempt, overwriting sockets and triggering "Connection lost".
@@ -78,9 +83,10 @@ export class DaemonClient {
 
       this.connected = true
       this.disconnectArmed = true
+      this.connectionGeneration++
 
-      // Handle socket close
-      const handleClose = () => this.handleDisconnect()
+      const gen = this.connectionGeneration
+      const handleClose = () => this.handleDisconnect(gen)
       this.controlSocket.on('close', handleClose)
       this.controlSocket.on('error', handleClose)
       this.streamSocket.on('close', handleClose)
@@ -270,8 +276,8 @@ export class DaemonClient {
     this.streamSocket.on('data', (chunk) => parser.feed(chunk.toString()))
   }
 
-  private handleDisconnect(): void {
-    if (!this.disconnectArmed) {
+  private handleDisconnect(generation: number): void {
+    if (!this.disconnectArmed || generation !== this.connectionGeneration) {
       return
     }
     this.disconnectArmed = false

--- a/src/main/daemon/daemon-init.ts
+++ b/src/main/daemon/daemon-init.ts
@@ -160,7 +160,16 @@ export async function initDaemonPtyProvider(): Promise<void> {
   const newAdapter = new DaemonPtyAdapter({
     socketPath: info.socketPath,
     tokenPath: info.tokenPath,
-    historyPath: getHistoryDir()
+    historyPath: getHistoryDir(),
+    // Why: when the daemon process dies (e.g. killed by a signal, OOM, or
+    // cascading from a force-quit of child processes), the adapter's
+    // ensureConnected() detects the dead socket and calls this to fork a
+    // replacement daemon before retrying the connection.
+    respawn: async () => {
+      console.warn('[daemon] Daemon process died — respawning')
+      newSpawner.resetHandle()
+      await newSpawner.ensureRunning()
+    }
   })
 
   spawner = newSpawner

--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -641,4 +641,50 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       )
     })
   })
+
+  describe('respawn on daemon death', () => {
+    it('respawns the daemon and retries when the socket disappears', async () => {
+      let respawnServer: DaemonServer | undefined
+      const respawnFn = vi.fn(async () => {
+        respawnServer = new DaemonServer({
+          socketPath,
+          tokenPath,
+          spawnSubprocess: () => createMockSubprocess()
+        })
+        await respawnServer.start()
+      })
+
+      const respawnAdapter = new DaemonPtyAdapter({ socketPath, tokenPath, respawn: respawnFn })
+
+      // First spawn succeeds normally
+      const r1 = await respawnAdapter.spawn({ cols: 80, rows: 24 })
+      expect(r1.id).toBeDefined()
+
+      // Kill the server to simulate daemon death
+      await server.shutdown()
+
+      // Next spawn should detect the dead socket, call respawn, and succeed
+      const r2 = await respawnAdapter.spawn({ cols: 80, rows: 24 })
+      expect(r2.id).toBeDefined()
+      expect(respawnFn).toHaveBeenCalledOnce()
+
+      respawnAdapter.dispose()
+      await respawnServer?.shutdown()
+    })
+
+    it('propagates the error when no respawn callback is provided', async () => {
+      const noRespawnAdapter = new DaemonPtyAdapter({ socketPath, tokenPath })
+
+      // First spawn succeeds
+      await noRespawnAdapter.spawn({ cols: 80, rows: 24 })
+
+      // Kill the server
+      await server.shutdown()
+
+      // Next spawn should fail with the original socket error
+      await expect(noRespawnAdapter.spawn({ cols: 80, rows: 24 })).rejects.toThrow()
+
+      noRespawnAdapter.dispose()
+    })
+  })
 })

--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -686,5 +686,53 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
 
       noRespawnAdapter.dispose()
     })
+
+    it('coalesces concurrent respawns so only one daemon is forked', async () => {
+      let respawnServer: DaemonServer | undefined
+      const respawnFn = vi.fn(async () => {
+        respawnServer = new DaemonServer({
+          socketPath,
+          tokenPath,
+          spawnSubprocess: () => createMockSubprocess()
+        })
+        await respawnServer.start()
+      })
+
+      const respawnAdapter = new DaemonPtyAdapter({ socketPath, tokenPath, respawn: respawnFn })
+
+      // First spawn connects
+      await respawnAdapter.spawn({ cols: 80, rows: 24 })
+
+      // Kill daemon
+      await server.shutdown()
+
+      // Fire two spawns concurrently — both should succeed but only one respawn
+      const [r1, r2] = await Promise.all([
+        respawnAdapter.spawn({ cols: 80, rows: 24 }),
+        respawnAdapter.spawn({ cols: 80, rows: 24 })
+      ])
+      expect(r1.id).toBeDefined()
+      expect(r2.id).toBeDefined()
+      expect(respawnFn).toHaveBeenCalledOnce()
+
+      respawnAdapter.dispose()
+      await respawnServer?.shutdown()
+    })
+
+    it('propagates respawn failure to the caller', async () => {
+      const respawnFn = vi.fn(async () => {
+        throw new Error('Daemon entry file missing')
+      })
+
+      const respawnAdapter = new DaemonPtyAdapter({ socketPath, tokenPath, respawn: respawnFn })
+      await respawnAdapter.spawn({ cols: 80, rows: 24 })
+      await server.shutdown()
+
+      await expect(respawnAdapter.spawn({ cols: 80, rows: 24 })).rejects.toThrow(
+        'Daemon entry file missing'
+      )
+
+      respawnAdapter.dispose()
+    })
   })
 })

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -17,6 +17,9 @@ export type DaemonPtyAdapterOptions = {
   /** Directory for disk-based terminal history. When set, the adapter writes
    *  raw PTY output to disk for cold restore on daemon crash. */
   historyPath?: string
+  /** Called when the daemon socket is unreachable (process died). Expected to
+   *  fork a fresh daemon so the next connection attempt can succeed. */
+  respawn?: () => Promise<void>
 }
 
 const MAX_TOMBSTONES = 1000
@@ -32,6 +35,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
   private client: DaemonClient
   private historyManager: HistoryManager | null
   private historyReader: HistoryReader | null
+  private respawnFn: (() => Promise<void>) | null
   private dataListeners: ((payload: { id: string; data: string }) => void)[] = []
   private exitListeners: ((payload: { id: string; code: number }) => void)[] = []
   private removeEventListener: (() => void) | null = null
@@ -54,6 +58,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
     })
     this.historyManager = opts.historyPath ? new HistoryManager(opts.historyPath) : null
     this.historyReader = opts.historyPath ? new HistoryReader(opts.historyPath) : null
+    this.respawnFn = opts.respawn ?? null
   }
 
   getHistoryManager(): HistoryManager | null {
@@ -61,6 +66,10 @@ export class DaemonPtyAdapter implements IPtyProvider {
   }
 
   async spawn(opts: PtySpawnOptions): Promise<PtySpawnResult> {
+    return this.withDaemonRetry(() => this.doSpawn(opts))
+  }
+
+  private async doSpawn(opts: PtySpawnOptions): Promise<PtySpawnResult> {
     await this.ensureConnected()
 
     const sessionId =
@@ -366,6 +375,28 @@ export class DaemonPtyAdapter implements IPtyProvider {
     this.setupEventRouting()
   }
 
+  // Why: when the daemon process dies, operations fail with ENOENT (socket
+  // gone), ECONNREFUSED, or "Connection lost" (socket closed mid-request).
+  // Rather than leaving all terminals permanently broken until app restart,
+  // this wrapper detects daemon-death errors, tears down the stale client
+  // state, forks a fresh daemon via respawnFn, reconnects, and retries the
+  // operation once. If respawn itself fails, the error propagates normally.
+  private async withDaemonRetry<T>(fn: () => Promise<T>): Promise<T> {
+    try {
+      return await fn()
+    } catch (err) {
+      if (!this.respawnFn || !isDaemonGoneError(err)) {
+        throw err
+      }
+      console.warn('[daemon] Operation failed, respawning:', (err as Error).message)
+      this.removeEventListener?.()
+      this.removeEventListener = null
+      this.client.disconnect()
+      await this.respawnFn()
+      return await fn()
+    }
+  }
+
   private setupEventRouting(): void {
     if (this.removeEventListener) {
       return
@@ -401,4 +432,22 @@ export class DaemonPtyAdapter implements IPtyProvider {
       }
     })
   }
+}
+
+// Why: ENOENT means the socket file was deleted (daemon crashed and cleaned
+// up, or was killed). ECONNREFUSED means the file exists but nothing is
+// listening (rare race). "Connection lost" / "Not connected" mean the daemon
+// died while we had an active or stale connection — the client detected the
+// socket close but we still tried to use it. All indicate the daemon is
+// gone and a respawn should be attempted.
+function isDaemonGoneError(err: unknown): boolean {
+  if (!(err instanceof Error)) {
+    return false
+  }
+  const code = (err as NodeJS.ErrnoException).code
+  if (code === 'ENOENT' || code === 'ECONNREFUSED') {
+    return true
+  }
+  const msg = err.message
+  return msg === 'Connection lost' || msg === 'Not connected'
 }

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -448,18 +448,18 @@ export class DaemonPtyAdapter implements IPtyProvider {
   }
 }
 
-// Why: ENOENT means the socket file was deleted (daemon crashed and cleaned
-// up, or was killed). ECONNREFUSED means the file exists but nothing is
-// listening (rare race). "Connection lost" / "Not connected" mean the daemon
-// died while we had an active or stale connection — the client detected the
-// socket close but we still tried to use it. All indicate the daemon is
-// gone and a respawn should be attempted.
+// Why: ENOENT/ECONNREFUSED with syscall 'connect' mean the socket is
+// unreachable (daemon died). Checking syscall avoids false positives from
+// token-file ENOENT (readFileSync), which has no syscall or syscall='open'.
+// "Connection lost" / "Not connected" mean the daemon died while we had an
+// active or stale connection. All indicate the daemon is gone and a respawn
+// should be attempted.
 function isDaemonGoneError(err: unknown): boolean {
   if (!(err instanceof Error)) {
     return false
   }
-  const code = (err as NodeJS.ErrnoException).code
-  if (code === 'ENOENT' || code === 'ECONNREFUSED') {
+  const errno = err as NodeJS.ErrnoException
+  if ((errno.code === 'ENOENT' || errno.code === 'ECONNREFUSED') && errno.syscall === 'connect') {
     return true
   }
   const msg = err.message

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -36,6 +36,11 @@ export class DaemonPtyAdapter implements IPtyProvider {
   private historyManager: HistoryManager | null
   private historyReader: HistoryReader | null
   private respawnFn: (() => Promise<void>) | null
+  // Why: multiple pane mounts can call spawn() concurrently. If the daemon is
+  // dead, all calls enter withDaemonRetry's catch block at once. Without a
+  // lock, each would fork its own daemon process. This promise coalesces
+  // concurrent respawns so only the first caller forks; the rest await it.
+  private respawnPromise: Promise<void> | null = null
   private dataListeners: ((payload: { id: string; data: string }) => void)[] = []
   private exitListeners: ((payload: { id: string; code: number }) => void)[] = []
   private removeEventListener: (() => void) | null = null
@@ -388,13 +393,22 @@ export class DaemonPtyAdapter implements IPtyProvider {
       if (!this.respawnFn || !isDaemonGoneError(err)) {
         throw err
       }
-      console.warn('[daemon] Operation failed, respawning:', (err as Error).message)
-      this.removeEventListener?.()
-      this.removeEventListener = null
-      this.client.disconnect()
-      await this.respawnFn()
+      if (!this.respawnPromise) {
+        this.respawnPromise = this.doRespawn().finally(() => {
+          this.respawnPromise = null
+        })
+      }
+      await this.respawnPromise
       return await fn()
     }
+  }
+
+  private async doRespawn(): Promise<void> {
+    console.warn('[daemon] Daemon died — respawning')
+    this.removeEventListener?.()
+    this.removeEventListener = null
+    this.client.disconnect()
+    await this.respawnFn!()
   }
 
   private setupEventRouting(): void {

--- a/src/main/daemon/daemon-spawner.ts
+++ b/src/main/daemon/daemon-spawner.ts
@@ -42,6 +42,13 @@ export class DaemonSpawner {
     return { socketPath: this.socketPath, tokenPath: this.tokenPath }
   }
 
+  // Why: after the daemon process dies unexpectedly, the cached handle is
+  // stale. Clearing it lets the next ensureRunning() fork a fresh daemon
+  // instead of returning the dead socket path.
+  resetHandle(): void {
+    this.handle = null
+  }
+
   async shutdown(): Promise<void> {
     if (!this.handle) {
       return


### PR DESCRIPTION
## Summary

- When the PTY daemon process dies mid-session (e.g. killed by a signal, OOM, or cascading from force-quitting child processes like `pn dev`), all terminals froze permanently with `connect ENOENT daemon-v1.sock` because there was zero recovery logic
- Adds lazy daemon respawn: on daemon-death errors (ENOENT, ECONNREFUSED, "Connection lost"), tears down stale client state, forks a fresh daemon, and retries the operation once
- Adds `DaemonSpawner.resetHandle()` to clear the stale process handle so `ensureRunning()` can fork a replacement

### Root cause
After the daemon is spawned, `child.unref()` + `child.disconnect()` drops all visibility into the daemon's lifecycle. If the daemon dies:
1. `DaemonSpawner.handle` stays non-null → `ensureRunning()` returns stale socket path
2. `DaemonClient.handleDisconnect()` fires but nothing subscribes to trigger a re-spawn
3. All subsequent `pty:spawn` calls fail with `ENOENT` permanently

### Fix
- `DaemonPtyAdapter.withDaemonRetry()` wraps operations and catches daemon-death errors
- On failure, it disconnects the stale client, calls the `respawn` callback (which resets the spawner handle and forks a new daemon), then retries
- `isDaemonGoneError()` identifies all error signatures: `ENOENT`, `ECONNREFUSED`, `Connection lost`, `Not connected`

Fixes: https://stablygroup.slack.com/archives/C060NMM0KEC/p1776735313881809

## Test plan
- [x] New unit tests: "respawns the daemon and retries when the socket disappears" and "propagates the error when no respawn callback is provided"
- [x] All 42 existing daemon adapter tests pass
- [x] Typecheck and lint clean
- [ ] Manual: enable experimental terminal daemon, open terminals, force-kill the daemon process, verify new terminal spawn succeeds automatically