### PR TITLE
docs(agents): tighten code-comment rule to short, why-only

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,10 @@
 # AGENTS.md
 
-## Code Comments: Document the "Why"
+## Code Comments: Document the "Why", Briefly
 
-When writing or modifying code driven by a design doc or non-obvious constraint, you **must** add a comment explaining **why** the code behaves the way it does.
+When writing or modifying code driven by a design doc or non-obvious constraint, add a comment explaining **why** the code behaves the way it does.
+
+Keep comments short — one or two lines. Capture only the non-obvious reason (safety constraint, compatibility shim, design-doc rule). Don't restate what the code does, narrate the mechanism, cite design-doc sections verbatim, or explain adjacent API choices unless they're the point.
 
 ## File and Module Naming
 


### PR DESCRIPTION
## Summary
- AI agents were generating wordy multi-paragraph \"Why:\" comments. Updated AGENTS.md §Code Comments to require short (1–2 line) comments that capture only the non-obvious reason — no restating what the code does, narrating mechanism, or verbatim design-doc citations.

## Test plan
- [x] AGENTS.md renders correctly