### PR TITLE
fix(editor): apply dark scrollbar styling to rich markdown editor

### DIFF
--- a/src/renderer/src/components/editor/RichMarkdownEditor.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownEditor.tsx
@@ -505,7 +505,7 @@ export default function RichMarkdownEditor({
         query={searchQuery}
         searchInputRef={searchInputRef}
       />
-      <div ref={scrollContainerRef} className="min-h-0 flex-1 overflow-auto">
+      <div ref={scrollContainerRef} className="min-h-0 flex-1 overflow-auto scrollbar-editor">
         <EditorContent editor={editor} />
       </div>
       {linkBubble ? (


### PR DESCRIPTION
## Summary
- The rich markdown editor's scroll container was missing the `scrollbar-editor` class, causing the default white browser scrollbar to render against the dark editor background.
- Added the class to match the styling already used by `MarkdownPreview`, `MermaidViewer`, and other editor components.

## Test plan
- [ ] Open a long `.md` file in the rich markdown editor
- [ ] Verify the scrollbar is dark/translucent gray, not white
- [ ] Confirm scrollbar hover state brightens correctly