### PR TITLE
feat(file-explorer): double-click empty space to create new file

### DIFF
--- a/src/renderer/src/components/right-sidebar/FileExplorer.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorer.tsx
@@ -313,6 +313,16 @@ function FileExplorerInner(): React.JSX.Element {
             setBgMenuPoint({ x: e.clientX, y: e.clientY })
             setBgMenuOpen(true)
           }}
+          onDoubleClick={(e) => {
+            if (!worktreePath || inlineInput) {
+              return
+            }
+            const target = e.target as HTMLElement
+            if (target.closest('[data-slot="context-menu-trigger"]')) {
+              return
+            }
+            startNew('file', worktreePath, 0)
+          }}
         >
           {isLoading && (
             <div className="flex items-center justify-center h-full text-[11px] text-muted-foreground">


### PR DESCRIPTION
## Summary
Attaches an onDoubleClick handler to the explorer ScrollArea that opens the inline "New File" input at the worktree root. Rows keep their existing double-click behavior (pin preview, folder toggle, rename hotspot), the handler no-ops when the target is inside a row's ContextMenuTrigger or when an inline input is already active.

## Screenshots

https://github.com/user-attachments/assets/2d683782-e3e0-46b0-84d4-4d992b4de20b


## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`