### PR TITLE
feat(browser): duplicate tab, search engine, address bar history fix

### DIFF
--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -394,6 +394,25 @@ function Terminal(): React.JSX.Element | null {
     createBrowserTab(activeWorktreeId, defaultUrl, { title: 'New Browser Tab' })
   }, [activeWorktreeId, createBrowserTab])
 
+  const handleDuplicateBrowserTab = useCallback(
+    (browserTabId: string) => {
+      if (!activeWorktreeId) {
+        return
+      }
+      const state = useAppStore.getState()
+      const tabs = state.browserTabsByWorktree[activeWorktreeId] ?? []
+      const source = tabs.find((t) => t.id === browserTabId)
+      if (!source) {
+        return
+      }
+      createBrowserTab(activeWorktreeId, source.url, {
+        title: source.title,
+        sessionProfileId: source.sessionProfileId
+      })
+    },
+    [activeWorktreeId, createBrowserTab]
+  )
+
   const handleNewFile = useCallback(async () => {
     if (!activeWorktreeId) {
       return
@@ -963,6 +982,7 @@ function Terminal(): React.JSX.Element | null {
             onCloseFile={handleCloseFile}
             onActivateBrowserTab={handleActivateBrowserTab}
             onCloseBrowserTab={handleCloseBrowserTab}
+            onDuplicateBrowserTab={handleDuplicateBrowserTab}
             onCloseAllFiles={closeAllFiles}
             onPinFile={pinFile}
             tabBarOrder={tabBarOrder}

--- a/src/renderer/src/components/browser-pane/BrowserAddressBar.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserAddressBar.tsx
@@ -156,11 +156,19 @@ export default function BrowserAddressBar({
     [open, suggestions, selectedValue, handleSelect]
   )
 
+  // Why: close the dropdown only when the input has lost focus AND there are
+  // no suggestions. Previously this closed unconditionally on empty suggestions,
+  // which caused the dropdown to vanish mid-typing when backspacing produced a
+  // query that didn't match any history entries. Keeping the popover open while
+  // focused lets the user continue editing and see results reappear.
   useEffect(() => {
     if (open && suggestions.length === 0) {
+      if (inputRef.current && document.activeElement === inputRef.current) {
+        return
+      }
       setOpen(false)
     }
-  }, [open, suggestions.length])
+  }, [open, suggestions.length, inputRef])
 
   // Why: auto-select the top suggestion so Enter navigates to the best match
   // without an extra ArrowDown. Fall back to clearing selection when nothing

--- a/src/renderer/src/components/browser-pane/BrowserAddressBar.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserAddressBar.tsx
@@ -56,9 +56,7 @@ export default function BrowserAddressBar({
     }
     const trimmed = value.trim()
     if (trimmed === '' || trimmed === 'about:blank' || trimmed.startsWith('data:')) {
-      return [...browserUrlHistory]
-        .sort((a, b) => b.lastVisitedAt - a.lastVisitedAt)
-        .slice(0, MAX_SUGGESTIONS)
+      return []
     }
 
     const scored = browserUrlHistory
@@ -75,11 +73,17 @@ export default function BrowserAddressBar({
       return
     }
     inputRef.current?.select()
-    if (browserUrlHistory.length > 0) {
+    const trimmed = value.trim()
+    if (
+      browserUrlHistory.length > 0 &&
+      trimmed !== '' &&
+      trimmed !== 'about:blank' &&
+      !trimmed.startsWith('data:')
+    ) {
       openedAtRef.current = Date.now()
       setOpen(true)
     }
-  }, [browserUrlHistory.length, inputRef])
+  }, [browserUrlHistory.length, inputRef, value])
 
   const handleBlur = useCallback(() => {
     // Why: delay close so that clicking a suggestion item registers before
@@ -204,7 +208,13 @@ export default function BrowserAddressBar({
           <Input
             ref={inputRef}
             value={value}
-            onChange={(event) => onChange(event.target.value)}
+            onChange={(event) => {
+              onChange(event.target.value)
+              if (event.target.value.trim() !== '' && browserUrlHistory.length > 0 && !open) {
+                openedAtRef.current = Date.now()
+                setOpen(true)
+              }
+            }}
             onFocus={handleFocus}
             onBlur={handleBlur}
             onKeyDown={handleKeyDown}

--- a/src/renderer/src/components/browser-pane/BrowserAddressBar.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserAddressBar.tsx
@@ -56,7 +56,9 @@ export default function BrowserAddressBar({
     }
     const trimmed = value.trim()
     if (trimmed === '' || trimmed === 'about:blank' || trimmed.startsWith('data:')) {
-      return []
+      return [...browserUrlHistory]
+        .sort((a, b) => b.lastVisitedAt - a.lastVisitedAt)
+        .slice(0, MAX_SUGGESTIONS)
     }
 
     const scored = browserUrlHistory
@@ -73,17 +75,11 @@ export default function BrowserAddressBar({
       return
     }
     inputRef.current?.select()
-    const trimmed = value.trim()
-    if (
-      browserUrlHistory.length > 0 &&
-      trimmed !== '' &&
-      trimmed !== 'about:blank' &&
-      !trimmed.startsWith('data:')
-    ) {
+    if (browserUrlHistory.length > 0) {
       openedAtRef.current = Date.now()
       setOpen(true)
     }
-  }, [browserUrlHistory.length, inputRef, value])
+  }, [browserUrlHistory.length, inputRef])
 
   const handleBlur = useCallback(() => {
     // Why: delay close so that clicking a suggestion item registers before
@@ -208,13 +204,7 @@ export default function BrowserAddressBar({
           <Input
             ref={inputRef}
             value={value}
-            onChange={(event) => {
-              onChange(event.target.value)
-              if (event.target.value.trim() !== '' && browserUrlHistory.length > 0 && !open) {
-                openedAtRef.current = Date.now()
-                setOpen(true)
-              }
-            }}
+            onChange={(event) => onChange(event.target.value)}
             onFocus={handleFocus}
             onBlur={handleBlur}
             onKeyDown={handleKeyDown}

--- a/src/renderer/src/components/browser-pane/BrowserPane.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPane.tsx
@@ -1548,7 +1548,8 @@ function BrowserPagePane({
 
   const submitAddressBar = (): void => {
     keepAddressBarFocusRef.current = false
-    const nextUrl = normalizeBrowserNavigationUrl(addressBarValue)
+    const searchEngine = useAppStore.getState().browserDefaultSearchEngine
+    const nextUrl = normalizeBrowserNavigationUrl(addressBarValue, searchEngine)
     if (!nextUrl) {
       onUpdatePageStateRef.current(browserTab.id, {
         loadError: {

--- a/src/renderer/src/components/settings/BrowserPane.tsx
+++ b/src/renderer/src/components/settings/BrowserPane.tsx
@@ -8,7 +8,11 @@ import { Label } from '../ui/label'
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '../ui/dialog'
 import { useAppStore } from '../../store'
 import { ORCA_BROWSER_BLANK_URL } from '../../../../shared/constants'
-import { normalizeBrowserNavigationUrl } from '../../../../shared/browser-url'
+import {
+  normalizeBrowserNavigationUrl,
+  SEARCH_ENGINE_LABELS,
+  type SearchEngine
+} from '../../../../shared/browser-url'
 import { SearchableSetting } from './SearchableSetting'
 import { matchesSettingsSearch } from './settings-search'
 import { BROWSER_PANE_SEARCH_ENTRIES } from './browser-search'
@@ -25,6 +29,8 @@ export function BrowserPane({ settings, updateSettings }: BrowserPaneProps): Rea
   const searchQuery = useAppStore((s) => s.settingsSearchQuery)
   const browserDefaultUrl = useAppStore((s) => s.browserDefaultUrl)
   const setBrowserDefaultUrl = useAppStore((s) => s.setBrowserDefaultUrl)
+  const browserDefaultSearchEngine = useAppStore((s) => s.browserDefaultSearchEngine)
+  const setBrowserDefaultSearchEngine = useAppStore((s) => s.setBrowserDefaultSearchEngine)
   const browserSessionProfiles = useAppStore((s) => s.browserSessionProfiles)
   const detectedBrowsers = useAppStore((s) => s.detectedBrowsers)
   const browserSessionImportState = useAppStore((s) => s.browserSessionImportState)
@@ -45,8 +51,9 @@ export function BrowserPane({ settings, updateSettings }: BrowserPaneProps): Rea
   }, [browserDefaultUrl])
 
   const showHomePage = matchesSettingsSearch(searchQuery, [BROWSER_PANE_SEARCH_ENTRIES[0]])
-  const showLinkRouting = matchesSettingsSearch(searchQuery, [BROWSER_PANE_SEARCH_ENTRIES[1]])
-  const showCookies = matchesSettingsSearch(searchQuery, [BROWSER_PANE_SEARCH_ENTRIES[2]])
+  const showSearchEngine = matchesSettingsSearch(searchQuery, [BROWSER_PANE_SEARCH_ENTRIES[1]])
+  const showLinkRouting = matchesSettingsSearch(searchQuery, [BROWSER_PANE_SEARCH_ENTRIES[2]])
+  const showCookies = matchesSettingsSearch(searchQuery, [BROWSER_PANE_SEARCH_ENTRIES[3]])
 
   return (
     <div className="space-y-4">
@@ -93,6 +100,36 @@ export function BrowserPane({ settings, updateSettings }: BrowserPaneProps): Rea
               Save
             </Button>
           </form>
+        </SearchableSetting>
+      ) : null}
+
+      {showSearchEngine ? (
+        <SearchableSetting
+          title="Default Search Engine"
+          description="Search engine used when typing non-URL text in the address bar."
+          keywords={['browser', 'search', 'engine', 'google', 'duckduckgo', 'bing', 'omnibox']}
+          className="flex items-center justify-between gap-4 px-1 py-2"
+        >
+          <div className="space-y-0.5">
+            <Label>Default Search Engine</Label>
+            <p className="text-xs text-muted-foreground">
+              Used when typing non-URL text in the address bar.
+            </p>
+          </div>
+          <select
+            value={browserDefaultSearchEngine ?? 'google'}
+            onChange={(e) => {
+              const value = e.target.value as SearchEngine
+              setBrowserDefaultSearchEngine(value === 'google' ? null : value)
+            }}
+            className="h-7 rounded-md border border-border bg-background px-2 text-xs"
+          >
+            {(Object.keys(SEARCH_ENGINE_LABELS) as SearchEngine[]).map((engine) => (
+              <option key={engine} value={engine}>
+                {SEARCH_ENGINE_LABELS[engine]}
+              </option>
+            ))}
+          </select>
         </SearchableSetting>
       ) : null}
 

--- a/src/renderer/src/components/settings/BrowserPane.tsx
+++ b/src/renderer/src/components/settings/BrowserPane.tsx
@@ -5,6 +5,7 @@ import type { GlobalSettings } from '../../../../shared/types'
 import { Button } from '../ui/button'
 import { Input } from '../ui/input'
 import { Label } from '../ui/label'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '../ui/dialog'
 import { useAppStore } from '../../store'
 import { ORCA_BROWSER_BLANK_URL } from '../../../../shared/constants'
@@ -116,20 +117,24 @@ export function BrowserPane({ settings, updateSettings }: BrowserPaneProps): Rea
               Used when typing non-URL text in the address bar.
             </p>
           </div>
-          <select
+          <Select
             value={browserDefaultSearchEngine ?? 'google'}
-            onChange={(e) => {
-              const value = e.target.value as SearchEngine
-              setBrowserDefaultSearchEngine(value === 'google' ? null : value)
+            onValueChange={(value) => {
+              const engine = value as SearchEngine
+              setBrowserDefaultSearchEngine(engine === 'google' ? null : engine)
             }}
-            className="h-7 rounded-md border border-border bg-background px-2 text-xs"
           >
-            {(Object.keys(SEARCH_ENGINE_LABELS) as SearchEngine[]).map((engine) => (
-              <option key={engine} value={engine}>
-                {SEARCH_ENGINE_LABELS[engine]}
-              </option>
-            ))}
-          </select>
+            <SelectTrigger className="h-7 w-36 text-xs">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {(Object.keys(SEARCH_ENGINE_LABELS) as SearchEngine[]).map((engine) => (
+                <SelectItem key={engine} value={engine} className="text-xs">
+                  {SEARCH_ENGINE_LABELS[engine]}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
         </SearchableSetting>
       ) : null}
 

--- a/src/renderer/src/components/settings/browser-search.ts
+++ b/src/renderer/src/components/settings/browser-search.ts
@@ -7,6 +7,11 @@ export const BROWSER_PANE_SEARCH_ENTRIES: SettingsSearchEntry[] = [
     keywords: ['browser', 'home', 'homepage', 'default', 'url', 'new tab', 'blank', 'landing']
   },
   {
+    title: 'Default Search Engine',
+    description: 'Search engine used when typing non-URL text in the address bar.',
+    keywords: ['browser', 'search', 'engine', 'google', 'duckduckgo', 'bing', 'omnibox', 'query']
+  },
+  {
     title: 'Terminal Link Routing',
     description:
       'Cmd/Ctrl+click opens terminal http(s) links in Orca. Shift+Cmd/Ctrl+click uses the system browser.',

--- a/src/renderer/src/components/tab-bar/BrowserTab.tsx
+++ b/src/renderer/src/components/tab-bar/BrowserTab.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
-import { Globe, X, ExternalLink, Columns2, Rows2 } from 'lucide-react'
+import { Globe, X, ExternalLink, Columns2, Rows2, Copy } from 'lucide-react'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -51,6 +51,7 @@ export default function BrowserTab({
   onClose,
   onCloseToRight,
   onSplitGroup,
+  onDuplicate,
   dragData
 }: {
   tab: BrowserTabState
@@ -60,6 +61,7 @@ export default function BrowserTab({
   onClose: () => void
   onCloseToRight: () => void
   onSplitGroup: (direction: 'left' | 'right' | 'up' | 'down', sourceVisibleTabId: string) => void
+  onDuplicate: () => void
   dragData: TabDragItemData
 }): React.JSX.Element {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
@@ -185,6 +187,11 @@ export default function BrowserTab({
           <DropdownMenuItem onSelect={() => onSplitGroup('right', tab.id)}>
             <Columns2 className="mr-1.5 size-3.5" />
             Split Right
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem onSelect={onDuplicate}>
+            <Copy className="mr-1.5 size-3.5" />
+            Duplicate Tab
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuItem onSelect={onClose}>Close</DropdownMenuItem>

--- a/src/renderer/src/components/tab-bar/TabBar.tsx
+++ b/src/renderer/src/components/tab-bar/TabBar.tsx
@@ -52,6 +52,7 @@ type TabBarProps = {
   onCloseFile?: (fileId: string) => void
   onActivateBrowserTab?: (tabId: string) => void
   onCloseBrowserTab?: (tabId: string) => void
+  onDuplicateBrowserTab?: (tabId: string) => void
   onCloseAllFiles?: () => void
   onPinFile?: (fileId: string, tabId?: string) => void
   tabBarOrder?: string[]
@@ -101,6 +102,7 @@ function TabBarInner({
   onCloseFile,
   onActivateBrowserTab,
   onCloseBrowserTab,
+  onDuplicateBrowserTab,
   onCloseAllFiles,
   onPinFile,
   tabBarOrder,
@@ -346,6 +348,7 @@ function TabBarInner({
                   onSplitGroup={(direction, sourceVisibleTabId) =>
                     onCreateSplitGroup?.(direction, sourceVisibleTabId)
                   }
+                  onDuplicate={() => onDuplicateBrowserTab?.(item.id)}
                   dragData={dragData}
                 />
               )

--- a/src/renderer/src/components/tab-group/TabGroupPanel.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.tsx
@@ -128,6 +128,7 @@ export default function TabGroupPanel({
           commands.closeItem(item.id)
         }
       }}
+      onDuplicateBrowserTab={commands.duplicateBrowserTab}
       onCloseAllFiles={commands.closeAllEditorTabsInGroup}
       onPinFile={(_fileId, tabId) => {
         if (!tabId) {

--- a/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.ts
+++ b/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.ts
@@ -408,6 +408,18 @@ export function useTabGroupWorkspaceModel({
         const defaultUrl = useAppStore.getState().browserDefaultUrl ?? 'about:blank'
         createBrowserTab(worktreeId, defaultUrl, { title: 'New Browser Tab' })
       },
+      duplicateBrowserTab: (browserTabId: string) => {
+        const state = useAppStore.getState()
+        const tabs = state.browserTabsByWorktree[worktreeId] ?? []
+        const source = tabs.find((t) => t.id === browserTabId)
+        if (!source) {
+          return
+        }
+        createBrowserTab(worktreeId, source.url, {
+          title: source.title,
+          sessionProfileId: source.sessionProfileId
+        })
+      },
       // Why: split-group actions must target their owning group explicitly.
       // Relying on the ambient activeGroupIdByWorktree breaks keyboard and
       // assistive-tech activation because the "+" menu can be triggered from

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -155,6 +155,8 @@ export type UISlice = {
   /** URL opened when a new browser tab is created. Null = blank tab (default). */
   browserDefaultUrl: string | null
   setBrowserDefaultUrl: (url: string | null) => void
+  browserDefaultSearchEngine: 'google' | 'duckduckgo' | 'bing' | null
+  setBrowserDefaultSearchEngine: (engine: 'google' | 'duckduckgo' | 'bing' | null) => void
 }
 
 export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get) => ({
@@ -338,6 +340,7 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
         dismissedUpdateVersion: ui.dismissedUpdateVersion ?? null,
         updateReassuranceSeen: ui.updateReassuranceSeen ?? false,
         browserDefaultUrl: ui.browserDefaultUrl ?? null,
+        browserDefaultSearchEngine: ui.browserDefaultSearchEngine ?? null,
         persistedUIReady: true
       }
     }),
@@ -402,5 +405,10 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
   setBrowserDefaultUrl: (url) => {
     void window.api.ui.set({ browserDefaultUrl: url }).catch(console.error)
     set({ browserDefaultUrl: url })
+  },
+  browserDefaultSearchEngine: null,
+  setBrowserDefaultSearchEngine: (engine) => {
+    void window.api.ui.set({ browserDefaultSearchEngine: engine }).catch(console.error)
+    set({ browserDefaultSearchEngine: engine })
   }
 })

--- a/src/shared/browser-url.test.ts
+++ b/src/shared/browser-url.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import { ORCA_BROWSER_BLANK_URL } from './constants'
-import { normalizeBrowserNavigationUrl, normalizeExternalBrowserUrl } from './browser-url'
+import {
+  normalizeBrowserNavigationUrl,
+  normalizeExternalBrowserUrl,
+  buildSearchUrl
+} from './browser-url'
 
 describe('browser-url helpers', () => {
   it('normalizes manual local-dev inputs to http', () => {
@@ -18,5 +22,50 @@ describe('browser-url helpers', () => {
     expect(normalizeBrowserNavigationUrl('file:///etc/passwd')).toBeNull()
     expect(normalizeBrowserNavigationUrl('javascript:alert(1)')).toBeNull()
     expect(normalizeExternalBrowserUrl('about:blank')).toBeNull()
+  })
+
+  it('returns null for non-URL input without search engine opt-in', () => {
+    expect(normalizeBrowserNavigationUrl('not a url')).toBeNull()
+  })
+
+  it('attempts https:// prefix for bare words without search opt-in', () => {
+    expect(normalizeBrowserNavigationUrl('singleword')).toBe('https://singleword/')
+  })
+
+  it('treats bare words and multi-word input as search queries when search is enabled', () => {
+    expect(normalizeBrowserNavigationUrl('react hooks', null)).toBe(
+      'https://www.google.com/search?q=react%20hooks'
+    )
+    expect(normalizeBrowserNavigationUrl('what is typescript', null)).toBe(
+      'https://www.google.com/search?q=what%20is%20typescript'
+    )
+    expect(normalizeBrowserNavigationUrl('singleword', null)).toBe(
+      'https://www.google.com/search?q=singleword'
+    )
+  })
+
+  it('respects the search engine parameter', () => {
+    expect(normalizeBrowserNavigationUrl('react hooks', 'duckduckgo')).toBe(
+      'https://duckduckgo.com/?q=react%20hooks'
+    )
+    expect(normalizeBrowserNavigationUrl('react hooks', 'bing')).toBe(
+      'https://www.bing.com/search?q=react%20hooks'
+    )
+  })
+
+  it('treats domain-like inputs as URLs, not searches', () => {
+    expect(normalizeBrowserNavigationUrl('example.com', null)).toBe('https://example.com/')
+    expect(normalizeBrowserNavigationUrl('github.com/org/repo', null)).toBe(
+      'https://github.com/org/repo'
+    )
+  })
+
+  it('builds search URLs correctly', () => {
+    expect(buildSearchUrl('hello world', 'google')).toBe(
+      'https://www.google.com/search?q=hello%20world'
+    )
+    expect(buildSearchUrl('hello world', 'duckduckgo')).toBe(
+      'https://duckduckgo.com/?q=hello%20world'
+    )
   })
 })

--- a/src/shared/browser-url.ts
+++ b/src/shared/browser-url.ts
@@ -3,7 +3,52 @@ import { ORCA_BROWSER_BLANK_URL } from './constants'
 const LOCAL_ADDRESS_PATTERN =
   /^(?:localhost|127(?:\.\d{1,3}){3}|0\.0\.0\.0|\[[0-9a-f:]+\])(?::\d+)?(?:\/.*)?$/i
 
-export function normalizeBrowserNavigationUrl(rawUrl: string): string | null {
+// Why: bare words like "react hooks" should trigger a search, but inputs that
+// look like domain names ("example.com", "foo.bar/path") should navigate directly.
+// A single-word input containing a dot with a valid TLD-like suffix is treated as
+// a URL attempt, not a search query.
+const LOOKS_LIKE_URL_PATTERN = /^[^\s]+\.[a-z]{2,}(\/.*)?$/i
+
+export type SearchEngine = 'google' | 'duckduckgo' | 'bing'
+
+export const SEARCH_ENGINE_LABELS: Record<SearchEngine, string> = {
+  google: 'Google',
+  duckduckgo: 'DuckDuckGo',
+  bing: 'Bing'
+}
+
+const SEARCH_ENGINE_URLS: Record<SearchEngine, string> = {
+  google: 'https://www.google.com/search?q=',
+  duckduckgo: 'https://duckduckgo.com/?q=',
+  bing: 'https://www.bing.com/search?q='
+}
+
+export const DEFAULT_SEARCH_ENGINE: SearchEngine = 'google'
+
+export function buildSearchUrl(
+  query: string,
+  engine: SearchEngine = DEFAULT_SEARCH_ENGINE
+): string {
+  return `${SEARCH_ENGINE_URLS[engine]}${encodeURIComponent(query)}`
+}
+
+function looksLikeSearchQuery(input: string): boolean {
+  if (input.includes(' ')) {
+    return true
+  }
+  if (LOOKS_LIKE_URL_PATTERN.test(input)) {
+    return false
+  }
+  if (input.includes('.') || input.includes(':')) {
+    return false
+  }
+  return true
+}
+
+export function normalizeBrowserNavigationUrl(
+  rawUrl: string,
+  searchEngine?: SearchEngine | null
+): string | null {
   const trimmed = rawUrl.trim()
   if (trimmed.length === 0 || trimmed === 'about:blank' || trimmed === ORCA_BROWSER_BLANK_URL) {
     return ORCA_BROWSER_BLANK_URL
@@ -21,11 +66,24 @@ export function normalizeBrowserNavigationUrl(rawUrl: string): string | null {
     const parsed = new URL(trimmed)
     return parsed.protocol === 'http:' || parsed.protocol === 'https:' ? parsed.toString() : null
   } catch {
+    // Why: search fallback is opt-in. The main process calls this function for
+    // URL validation (will-attach-webview, will-navigate) where non-URL text
+    // must be rejected, not converted to a search query. Only the address bar
+    // passes a search engine to enable the fallback.
+    const searchEnabled = searchEngine !== undefined
     try {
-      return new URL(`https://${trimmed}`).toString()
+      const withScheme = new URL(`https://${trimmed}`)
+      if (!searchEnabled || !looksLikeSearchQuery(trimmed)) {
+        return withScheme.toString()
+      }
     } catch {
+      // Not a valid URL even with https:// prefix
+    }
+
+    if (!searchEnabled) {
       return null
     }
+    return buildSearchUrl(trimmed, searchEngine ?? DEFAULT_SEARCH_ENGINE)
   }
 }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -736,6 +736,7 @@ export type PersistedUIState = {
   /** URL to navigate to when a new browser tab is opened. Null means blank tab.
    *  Phase 3 will expand this to a full BrowserSessionProfile per workspace. */
   browserDefaultUrl?: string | null
+  browserDefaultSearchEngine?: 'google' | 'duckduckgo' | 'bing' | null
   /** Saved window bounds so the app restores to the user's last position/size
    *  instead of maximizing on every launch. */
   windowBounds?: { x: number; y: number; width: number; height: number } | null


### PR DESCRIPTION
## Summary
- **Duplicate Tab**: Right-click a browser tab → "Duplicate Tab" copies URL, title, and session profile into a new tab
- **Default Search Engine**: Address bar now works as a search box for non-URL input (Google/DuckDuckGo/Bing configurable in Settings → Browser)
- **Address Bar History Fix**: History dropdown no longer disappears when backspacing — auto-close is gated on input focus state

## Test plan
- [ ] Right-click a browser tab → "Duplicate Tab" → verify new tab opens with same URL and session
- [ ] Type a search query (e.g. "react hooks") in the address bar → verify it navigates to a Google search
- [ ] Change default search engine in Settings → Browser → verify searches use the selected engine
- [ ] Type a URL (e.g. "github.com") → verify it navigates to the URL, not a search
- [ ] Click address bar, type partial text, backspace → verify history dropdown stays open while typing
- [ ] Existing tests: `pnpm vitest run src/shared/browser-url.test.ts` (9/9 pass)