### PR TITLE
feat(browser): search suggestion in address bar dropdown

### DIFF
--- a/src/renderer/src/components/browser-pane/BrowserAddressBar.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserAddressBar.tsx
@@ -1,11 +1,26 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { Globe } from 'lucide-react'
+import { Globe, Search } from 'lucide-react'
 import { Input } from '@/components/ui/input'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { Command, CommandGroup, CommandItem, CommandList } from '@/components/ui/command'
 import { useAppStore } from '@/store'
+import {
+  buildSearchUrl,
+  looksLikeSearchQuery,
+  SEARCH_ENGINE_LABELS,
+  DEFAULT_SEARCH_ENGINE,
+  type SearchEngine
+} from '../../../../shared/browser-url'
 
 const MAX_SUGGESTIONS = 8
+
+type SuggestionEntry = {
+  url: string
+  title: string
+  lastVisitedAt: number
+  visitCount: number
+  isSearch?: boolean
+}
 
 type BrowserAddressBarProps = {
   value: string
@@ -47,39 +62,57 @@ export default function BrowserAddressBar({
   const [open, setOpen] = useState(false)
   const [selectedValue, setSelectedValue] = useState('')
   const browserUrlHistory = useAppStore((s) => s.browserUrlHistory)
+  const browserDefaultSearchEngine = useAppStore((s) => s.browserDefaultSearchEngine)
   const closingRef = useRef(false)
   const openedAtRef = useRef(0)
 
-  const suggestions = useMemo(() => {
-    if (browserUrlHistory.length === 0) {
-      return []
-    }
+  const searchEngine: SearchEngine =
+    (browserDefaultSearchEngine as SearchEngine | null) ?? DEFAULT_SEARCH_ENGINE
+
+  const suggestions = useMemo((): SuggestionEntry[] => {
     const trimmed = value.trim()
     if (trimmed === '' || trimmed === 'about:blank' || trimmed.startsWith('data:')) {
+      if (browserUrlHistory.length === 0) {
+        return []
+      }
       return [...browserUrlHistory]
         .sort((a, b) => b.lastVisitedAt - a.lastVisitedAt)
         .slice(0, MAX_SUGGESTIONS)
     }
 
-    const scored = browserUrlHistory
-      .map((entry) => ({ entry, score: scoreSuggestion(entry, trimmed) }))
-      .filter((item) => item.score >= 0)
-      .sort((a, b) => b.score - a.score)
-      .slice(0, MAX_SUGGESTIONS)
+    const historySuggestions: SuggestionEntry[] =
+      browserUrlHistory.length > 0
+        ? browserUrlHistory
+            .map((entry) => ({ entry, score: scoreSuggestion(entry, trimmed) }))
+            .filter((item) => item.score >= 0)
+            .sort((a, b) => b.score - a.score)
+            .slice(0, MAX_SUGGESTIONS - 1)
+            .map((item) => item.entry)
+        : []
 
-    return scored.map((item) => item.entry)
-  }, [browserUrlHistory, value])
+    const searchSuggestion: SuggestionEntry = {
+      url: buildSearchUrl(trimmed, searchEngine),
+      title: `${trimmed} — ${SEARCH_ENGINE_LABELS[searchEngine]} Search`,
+      lastVisitedAt: 0,
+      visitCount: 0,
+      isSearch: true
+    }
+
+    if (looksLikeSearchQuery(trimmed)) {
+      return [searchSuggestion, ...historySuggestions]
+    }
+
+    return [...historySuggestions.slice(0, MAX_SUGGESTIONS - 1), searchSuggestion]
+  }, [browserUrlHistory, value, searchEngine])
 
   const handleFocus = useCallback(() => {
     if (closingRef.current) {
       return
     }
     inputRef.current?.select()
-    if (browserUrlHistory.length > 0) {
-      openedAtRef.current = Date.now()
-      setOpen(true)
-    }
-  }, [browserUrlHistory.length, inputRef])
+    openedAtRef.current = Date.now()
+    setOpen(true)
+  }, [inputRef])
 
   const handleBlur = useCallback(() => {
     // Why: delay close so that clicking a suggestion item registers before
@@ -242,10 +275,22 @@ export default function BrowserAddressBar({
                     onSelect={() => handleSelect(entry.url)}
                     className="flex items-center gap-2 px-3 py-2"
                   >
-                    <Globe className="size-3.5 shrink-0 text-muted-foreground" />
+                    {entry.isSearch ? (
+                      <Search className="size-3.5 shrink-0 text-muted-foreground" />
+                    ) : (
+                      <Globe className="size-3.5 shrink-0 text-muted-foreground" />
+                    )}
                     <div className="flex min-w-0 flex-1 flex-col">
-                      <span className="truncate text-sm">{entry.title}</span>
-                      <span className="truncate text-xs text-muted-foreground">{entry.url}</span>
+                      {entry.isSearch ? (
+                        <span className="truncate text-sm">{entry.title}</span>
+                      ) : (
+                        <>
+                          <span className="truncate text-sm">{entry.title}</span>
+                          <span className="truncate text-xs text-muted-foreground">
+                            {entry.url}
+                          </span>
+                        </>
+                      )}
                     </div>
                   </CommandItem>
                 ))}

--- a/src/renderer/src/components/browser-pane/BrowserAddressBar.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserAddressBar.tsx
@@ -56,9 +56,7 @@ export default function BrowserAddressBar({
     }
     const trimmed = value.trim()
     if (trimmed === '' || trimmed === 'about:blank' || trimmed.startsWith('data:')) {
-      return [...browserUrlHistory]
-        .sort((a, b) => b.lastVisitedAt - a.lastVisitedAt)
-        .slice(0, MAX_SUGGESTIONS)
+      return []
     }
 
     const scored = browserUrlHistory
@@ -75,11 +73,17 @@ export default function BrowserAddressBar({
       return
     }
     inputRef.current?.select()
-    if (browserUrlHistory.length > 0) {
+    const trimmed = value.trim()
+    if (
+      browserUrlHistory.length > 0 &&
+      trimmed !== '' &&
+      trimmed !== 'about:blank' &&
+      !trimmed.startsWith('data:')
+    ) {
       openedAtRef.current = Date.now()
       setOpen(true)
     }
-  }, [browserUrlHistory.length, inputRef])
+  }, [browserUrlHistory.length, inputRef, value])
 
   const handleBlur = useCallback(() => {
     // Why: delay close so that clicking a suggestion item registers before
@@ -204,7 +208,13 @@ export default function BrowserAddressBar({
           <Input
             ref={inputRef}
             value={value}
-            onChange={(event) => onChange(event.target.value)}
+            onChange={(event) => {
+              onChange(event.target.value)
+              if (event.target.value.trim() !== '' && browserUrlHistory.length > 0 && !open) {
+                openedAtRef.current = Date.now()
+                setOpen(true)
+              }
+            }}
             onFocus={handleFocus}
             onBlur={handleBlur}
             onKeyDown={handleKeyDown}

--- a/src/renderer/src/components/browser-pane/BrowserAddressBar.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserAddressBar.tsx
@@ -56,7 +56,9 @@ export default function BrowserAddressBar({
     }
     const trimmed = value.trim()
     if (trimmed === '' || trimmed === 'about:blank' || trimmed.startsWith('data:')) {
-      return []
+      return [...browserUrlHistory]
+        .sort((a, b) => b.lastVisitedAt - a.lastVisitedAt)
+        .slice(0, MAX_SUGGESTIONS)
     }
 
     const scored = browserUrlHistory
@@ -73,17 +75,11 @@ export default function BrowserAddressBar({
       return
     }
     inputRef.current?.select()
-    const trimmed = value.trim()
-    if (
-      browserUrlHistory.length > 0 &&
-      trimmed !== '' &&
-      trimmed !== 'about:blank' &&
-      !trimmed.startsWith('data:')
-    ) {
+    if (browserUrlHistory.length > 0) {
       openedAtRef.current = Date.now()
       setOpen(true)
     }
-  }, [browserUrlHistory.length, inputRef, value])
+  }, [browserUrlHistory.length, inputRef])
 
   const handleBlur = useCallback(() => {
     // Why: delay close so that clicking a suggestion item registers before
@@ -208,13 +204,7 @@ export default function BrowserAddressBar({
           <Input
             ref={inputRef}
             value={value}
-            onChange={(event) => {
-              onChange(event.target.value)
-              if (event.target.value.trim() !== '' && browserUrlHistory.length > 0 && !open) {
-                openedAtRef.current = Date.now()
-                setOpen(true)
-              }
-            }}
+            onChange={(event) => onChange(event.target.value)}
             onFocus={handleFocus}
             onBlur={handleBlur}
             onKeyDown={handleKeyDown}

--- a/src/shared/browser-url.ts
+++ b/src/shared/browser-url.ts
@@ -32,7 +32,7 @@ export function buildSearchUrl(
   return `${SEARCH_ENGINE_URLS[engine]}${encodeURIComponent(query)}`
 }
 
-function looksLikeSearchQuery(input: string): boolean {
+export function looksLikeSearchQuery(input: string): boolean {
   if (input.includes(' ')) {
     return true
   }


### PR DESCRIPTION
## Summary
- Show a "query — Google Search" suggestion at the top of the address bar dropdown when input looks like a search query (like Chrome/Firefox omnibox)
- For URL-like inputs (e.g. "github.com"), the search suggestion appears last as a fallback
- Search icon distinguishes search suggestions from history entries
- Uses the styled Select component for the search engine settings dropdown (replaces native `<select>`)

## Test plan
- [ ] Type a search query (e.g. "test") in address bar → first suggestion should be "test — Google Search"
- [ ] Press Enter without arrow-keying → should navigate to Google search
- [ ] Type a URL-like input (e.g. "github.com") → history suggestions first, search option last
- [ ] Arrow down through suggestions → search suggestion has magnifying glass icon, history has globe
- [ ] Change search engine in settings → suggestion label updates (e.g. "test — DuckDuckGo Search")