### PR TITLE
fix(sidebar): focus newly-added non-git folder in workspace

### DIFF
--- a/src/renderer/src/components/sidebar/NonGitFolderDialog.tsx
+++ b/src/renderer/src/components/sidebar/NonGitFolderDialog.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 import { useAppStore } from '@/store'
+import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 
 const NonGitFolderDialog = React.memo(function NonGitFolderDialog() {
   const activeModal = useAppStore((s) => s.activeModal)
@@ -39,6 +40,14 @@ const NonGitFolderDialog = React.memo(function NonGitFolderDialog() {
             useAppStore.setState({ repos: [...state.repos, repo] })
           }
           await state.fetchWorktrees(repo.id)
+          // Why: mirror the local non-git folder flow — without this the
+          // dialog closes and the UI shows no visible change, making the
+          // add feel like a no-op. Activating the synthetic folder
+          // worktree reveals it in the sidebar and opens the workspace.
+          const folderWorktree = useAppStore.getState().worktreesByRepo[repo.id]?.[0]
+          if (folderWorktree) {
+            activateAndRevealWorktree(folderWorktree.id)
+          }
         } catch (err) {
           // This code path calls addRemote directly (not through the store),
           // so the store's toast handling does not apply.

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -114,6 +114,18 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
       } else {
         toast.success('Folder added', { description: repo.displayName })
       }
+      // Why: without focusing the new folder, the UI looks unchanged after
+      // the dialog closes and users think nothing happened. Fetch the
+      // synthetic folder worktree and route through the standard activation
+      // sequence so the sidebar reveals and opens the folder the same way
+      // clicking a worktree card does. Lazy-imported to avoid a circular
+      // module load (worktree-activation imports the store root).
+      await get().fetchWorktrees(repo.id)
+      const folderWorktree = get().worktreesByRepo[repo.id]?.[0]
+      if (folderWorktree) {
+        const { activateAndRevealWorktree } = await import('../../lib/worktree-activation')
+        activateAndRevealWorktree(folderWorktree.id)
+      }
       return repo
     } catch (err) {
       console.error('Failed to add folder:', err)


### PR DESCRIPTION
## Summary
- After adding a non-git folder, route through the standard worktree activation sequence so the sidebar reveals and opens it (previously the dialog closed with no visible UI change, making the add feel like a no-op).
- Applied in both the store's `addFolder` flow and `NonGitFolderDialog`'s direct `addRemote` path so both entry points behave the same.

## Test plan
- [x] Add a new non-git folder via the sidebar and verify it is revealed and opened in the workspace.
- [x] Add a non-git remote folder via the dialog's addRemote path and verify the same focus behavior.
- [x] Confirm existing git-repo add flows are unaffected.