### PR TITLE
fix: route Cmd/Ctrl+N through main-process shortcut allowlist

### DIFF
--- a/src/main/browser/browser-guest-ui.ts
+++ b/src/main/browser/browser-guest-ui.ts
@@ -267,6 +267,8 @@ export function setupGuestShortcutForwarding(args: {
       renderer.send('ui:toggleWorktreePalette')
     } else if (action?.type === 'openQuickOpen') {
       renderer.send('ui:openQuickOpen')
+    } else if (action?.type === 'openNewWorkspace') {
+      renderer.send('ui:openNewWorkspace')
     } else if (action?.type === 'jumpToWorktreeIndex') {
       renderer.send('ui:jumpToWorktreeIndex', action.index)
     } else {

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -382,6 +382,14 @@ export function createMainWindow(
       return
     }
 
+    if (action.type === 'openNewWorkspace') {
+      // Why: routed through the main process so focus contexts that bypass
+      // the renderer's window-level keydown (contentEditable markdown editor,
+      // browser-guest webContents) still reach the new-workspace composer.
+      mainWindow.webContents.send('ui:openNewWorkspace')
+      return
+    }
+
     if (action.type === 'jumpToWorktreeIndex') {
       // Forward Cmd/Ctrl+1-9 for quick worktree switching
       mainWindow.webContents.send('ui:jumpToWorktreeIndex', action.index)

--- a/src/preload/api-types.d.ts
+++ b/src/preload/api-types.d.ts
@@ -613,6 +613,7 @@ export type PreloadApi = {
     onToggleRightSidebar: (callback: () => void) => () => void
     onToggleWorktreePalette: (callback: () => void) => () => void
     onOpenQuickOpen: (callback: () => void) => () => void
+    onOpenNewWorkspace: (callback: () => void) => () => void
     onJumpToWorktreeIndex: (callback: (index: number) => void) => () => void
     onNewBrowserTab: (callback: () => void) => () => void
     onRequestTabCreate: (

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1072,6 +1072,11 @@ const api = {
       ipcRenderer.on('ui:openQuickOpen', listener)
       return () => ipcRenderer.removeListener('ui:openQuickOpen', listener)
     },
+    onOpenNewWorkspace: (callback: () => void): (() => void) => {
+      const listener = (_event: Electron.IpcRendererEvent) => callback()
+      ipcRenderer.on('ui:openNewWorkspace', listener)
+      return () => ipcRenderer.removeListener('ui:openNewWorkspace', listener)
+    },
     onJumpToWorktreeIndex: (callback: (index: number) => void): (() => void) => {
       const listener = (_event: Electron.IpcRendererEvent, index: number) => callback(index)
       ipcRenderer.on('ui:jumpToWorktreeIndex', listener)

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable max-lines */
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { DEFAULT_STATUS_BAR_ITEMS, DEFAULT_WORKTREE_CARD_PROPERTIES } from '../../shared/constants'
-import { isGitRepoKind } from '../../shared/repo-kind'
 
 import { Minimize2, PanelLeft, PanelRight } from 'lucide-react'
 import { FOCUS_TERMINAL_PANE_EVENT, TOGGLE_TERMINAL_PANE_EXPAND_EVENT } from '@/constants/terminal'
@@ -116,7 +115,6 @@ function App(): React.JSX.Element {
   const expandedPaneByTabId = useAppStore((s) => s.expandedPaneByTabId)
   const canExpandPaneByTabId = useAppStore((s) => s.canExpandPaneByTabId)
   const workspaceSessionReady = useAppStore((s) => s.workspaceSessionReady)
-  const repos = useAppStore((s) => s.repos)
   const sidebarWidth = useAppStore((s) => s.sidebarWidth)
   const sidebarOpen = useAppStore((s) => s.sidebarOpen)
   const groupBy = useAppStore((s) => s.groupBy)
@@ -505,16 +503,11 @@ function App(): React.JSX.Element {
         return
       }
 
-      // Cmd/Ctrl+N — new workspace (opens the lightweight composer modal)
-      if (!e.altKey && !e.shiftKey && e.key.toLowerCase() === 'n') {
-        if (!repos.some((repo) => isGitRepoKind(repo))) {
-          return
-        }
-        dispatchClearModifierHints()
-        e.preventDefault()
-        actions.openModal('new-workspace-composer')
-        return
-      }
+      // Why: Cmd/Ctrl+N is handled via the main-process before-input-event
+      // allowlist (see window-shortcut-policy.ts / useIpcEvents.ts) so it works
+      // globally — including when focus lives inside the markdown rich editor
+      // (contentEditable) or a browser guest webContents, both of which bypass
+      // this renderer-side window keydown listener.
 
       // Why: the new-workspace composer should not be able to reveal the right
       // sidebar at all, because that surface is intentionally distraction-free.
@@ -566,7 +559,7 @@ function App(): React.JSX.Element {
 
     window.addEventListener('keydown', onKeyDown, { capture: true })
     return () => window.removeEventListener('keydown', onKeyDown, { capture: true })
-  }, [activeView, activeWorktreeId, actions, repos])
+  }, [activeView, activeWorktreeId, actions])
 
   useLayoutEffect(() => {
     const controls = titlebarLeftControlsRef.current

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -149,6 +149,7 @@ describe('useIpcEvents updater integration', () => {
           onToggleRightSidebar: () => () => {},
           onToggleWorktreePalette: () => () => {},
           onOpenQuickOpen: () => () => {},
+          onOpenNewWorkspace: () => () => {},
           onJumpToWorktreeIndex: () => () => {},
           onActivateWorktree: () => () => {},
           onNewBrowserTab: () => () => {},
@@ -317,6 +318,7 @@ describe('useIpcEvents updater integration', () => {
           onToggleRightSidebar: () => () => {},
           onToggleWorktreePalette: () => () => {},
           onOpenQuickOpen: () => () => {},
+          onOpenNewWorkspace: () => () => {},
           onJumpToWorktreeIndex: () => () => {},
           onActivateWorktree: () => () => {},
           onNewBrowserTab: () => () => {},
@@ -488,6 +490,7 @@ describe('useIpcEvents browser tab close routing', () => {
           onToggleRightSidebar: () => () => {},
           onToggleWorktreePalette: () => () => {},
           onOpenQuickOpen: () => () => {},
+          onOpenNewWorkspace: () => () => {},
           onJumpToWorktreeIndex: () => () => {},
           onActivateWorktree: () => () => {},
           onNewBrowserTab: () => () => {},
@@ -652,6 +655,7 @@ describe('useIpcEvents browser tab close routing', () => {
           onToggleRightSidebar: () => () => {},
           onToggleWorktreePalette: () => () => {},
           onOpenQuickOpen: () => () => {},
+          onOpenNewWorkspace: () => () => {},
           onJumpToWorktreeIndex: () => () => {},
           onActivateWorktree: () => () => {},
           onNewBrowserTab: () => () => {},
@@ -811,6 +815,7 @@ describe('useIpcEvents browser tab close routing', () => {
           onToggleRightSidebar: () => () => {},
           onToggleWorktreePalette: () => () => {},
           onOpenQuickOpen: () => () => {},
+          onOpenNewWorkspace: () => () => {},
           onJumpToWorktreeIndex: () => () => {},
           onActivateWorktree: () => () => {},
           onNewBrowserTab: () => () => {},
@@ -985,6 +990,7 @@ describe('useIpcEvents shortcut hint clearing', () => {
           onToggleRightSidebar: () => () => {},
           onToggleWorktreePalette: () => () => {},
           onOpenQuickOpen: () => () => {},
+          onOpenNewWorkspace: () => () => {},
           onJumpToWorktreeIndex: (listener: (index: number) => void) => {
             jumpToWorktreeRef.current = listener
             return () => {}

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -16,6 +16,7 @@ import { dispatchZoomLevelChanged } from '@/lib/zoom-events'
 import { resolveZoomTarget } from './resolve-zoom-target'
 import { handleSwitchTab } from './ipc-tab-switch'
 import { dispatchClearModifierHints } from './useModifierHint'
+import { isGitRepoKind } from '../../../shared/repo-kind'
 
 export { resolveZoomTarget } from './resolve-zoom-target'
 
@@ -76,6 +77,20 @@ export function useIpcEvents(): void {
         if (store.activeView === 'terminal' && store.activeWorktreeId !== null) {
           store.openModal('quick-open')
         }
+      })
+    )
+
+    unsubs.push(
+      window.api.ui.onOpenNewWorkspace(() => {
+        // Why: mirror the renderer's App.tsx Cmd+N guard — only open the
+        // composer when there is at least one real git repo configured, so
+        // users on a fresh install don't get a modal with nothing to target.
+        const store = useAppStore.getState()
+        if (!store.repos.some((repo) => isGitRepoKind(repo))) {
+          return
+        }
+        dispatchClearModifierHints()
+        store.openModal('new-workspace-composer')
       })
     )
 

--- a/src/shared/window-shortcut-policy.ts
+++ b/src/shared/window-shortcut-policy.ts
@@ -13,6 +13,7 @@ export type WindowShortcutAction =
   | { type: 'toggleLeftSidebar' }
   | { type: 'toggleRightSidebar' }
   | { type: 'openQuickOpen' }
+  | { type: 'openNewWorkspace' }
   | { type: 'jumpToWorktreeIndex'; index: number }
 
 export function isWindowShortcutModifierChord(
@@ -85,6 +86,14 @@ export function resolveWindowShortcutAction(
 
   if (input.code === 'KeyP' && !input.shift) {
     return { type: 'openQuickOpen' }
+  }
+
+  // Why: Cmd/Ctrl+N opens the new-workspace composer. Routed through the
+  // main process so it reaches the renderer even when focus lives inside
+  // a contentEditable surface (markdown rich editor) or a browser guest
+  // webContents, both of which bypass the renderer's window-level keydown.
+  if (input.code === 'KeyN' && !input.shift) {
+    return { type: 'openNewWorkspace' }
   }
 
   if (input.key && input.key >= '1' && input.key <= '9' && !input.shift) {


### PR DESCRIPTION
## Problem

Cmd/Ctrl+N to open the new-workspace composer was handled only in the renderer's window-level keydown listener. This meant it didn't fire when focus was inside a contentEditable surface (markdown rich editor preview) or a browser-guest webContents, both of which bypass the renderer's normal keyboard event propagation.

## Solution

Move Cmd/Ctrl+N handling into the main-process before-input-event allowlist (alongside other global shortcuts like Cmd+B, Cmd+L, Cmd+P) so it fires globally and reaches the renderer via IPC even when focus is in those special contexts.

The repo-guard logic (only open when at least one git repo is configured) is preserved by moving the check into the IPC handler in useIpcEvents.ts.