### PR TITLE
feat(terminal): broadcast theme changes to PTYs via DEC mode 2031

### DIFF
--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -63,6 +63,8 @@ export default function TerminalPane({
     new Map()
   )
   const paneTransportsRef = useRef<Map<number, PtyTransport>>(new Map())
+  const paneMode2031Ref = useRef<Map<number, boolean>>(new Map())
+  const paneLastThemeModeRef = useRef<Map<number, 'dark' | 'light'>>(new Map())
   const panePtyBindingsRef = useRef<Map<number, IDisposable>>(new Map())
   const pendingWritesRef = useRef<Map<number, string>>(new Map())
   const isActiveRef = useRef(isActive)
@@ -341,6 +343,8 @@ export default function TerminalPane({
     expandedStyleSnapshotRef,
     paneFontSizesRef,
     paneTransportsRef,
+    paneMode2031Ref,
+    paneLastThemeModeRef,
     panePtyBindingsRef,
     pendingWritesRef,
     isActiveRef,

--- a/src/renderer/src/components/terminal-pane/terminal-appearance.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-appearance.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from 'vitest'
+import { maybePushMode2031Flip, mode2031SequenceFor } from './terminal-appearance'
+
+function fakeTransport(overrides?: { connected?: boolean; sendOk?: boolean }): {
+  isConnected: () => boolean
+  sendInput: ReturnType<typeof vi.fn<(data: string) => boolean>>
+} {
+  const connected = overrides?.connected ?? true
+  const sendOk = overrides?.sendOk ?? true
+  return {
+    isConnected: () => connected,
+    sendInput: vi.fn<(data: string) => boolean>(() => sendOk)
+  }
+}
+
+describe('mode2031SequenceFor', () => {
+  it('maps dark to CSI ?997;1n and light to CSI ?997;2n', () => {
+    expect(mode2031SequenceFor('dark')).toBe('\x1b[?997;1n')
+    expect(mode2031SequenceFor('light')).toBe('\x1b[?997;2n')
+  })
+})
+
+describe('maybePushMode2031Flip', () => {
+  it('does nothing when the pane has not subscribed to mode 2031', () => {
+    const transport = fakeTransport()
+    const subs = new Map<number, boolean>()
+    const last = new Map<number, 'dark' | 'light'>()
+
+    const pushed = maybePushMode2031Flip(1, 'dark', transport, subs, last)
+
+    expect(pushed).toBe(false)
+    expect(transport.sendInput).not.toHaveBeenCalled()
+    expect(last.has(1)).toBe(false)
+  })
+
+  it('pushes the current mode once after subscribe and records it', () => {
+    const transport = fakeTransport()
+    const subs = new Map([[1, true]])
+    const last = new Map<number, 'dark' | 'light'>()
+
+    const pushed = maybePushMode2031Flip(1, 'dark', transport, subs, last)
+
+    expect(pushed).toBe(true)
+    expect(transport.sendInput).toHaveBeenCalledTimes(1)
+    expect(transport.sendInput).toHaveBeenCalledWith('\x1b[?997;1n')
+    expect(last.get(1)).toBe('dark')
+  })
+
+  it('suppresses repeat pushes when the resolved mode has not changed', () => {
+    // This is the spam-gate: applyTerminalAppearance re-runs on every font /
+    // opacity / cursor tweak, and we must not emit CSI 997 on each one.
+    const transport = fakeTransport()
+    const subs = new Map([[1, true]])
+    const last = new Map<number, 'dark' | 'light'>()
+
+    maybePushMode2031Flip(1, 'dark', transport, subs, last)
+    maybePushMode2031Flip(1, 'dark', transport, subs, last)
+    maybePushMode2031Flip(1, 'dark', transport, subs, last)
+
+    expect(transport.sendInput).toHaveBeenCalledTimes(1)
+    expect(last.get(1)).toBe('dark')
+  })
+
+  it('emits again when the theme actually flips', () => {
+    const transport = fakeTransport()
+    const subs = new Map([[1, true]])
+    const last = new Map<number, 'dark' | 'light'>()
+
+    maybePushMode2031Flip(1, 'dark', transport, subs, last)
+    maybePushMode2031Flip(1, 'light', transport, subs, last)
+    maybePushMode2031Flip(1, 'dark', transport, subs, last)
+
+    expect(transport.sendInput.mock.calls.map((c) => c[0])).toEqual([
+      '\x1b[?997;1n',
+      '\x1b[?997;2n',
+      '\x1b[?997;1n'
+    ])
+    expect(last.get(1)).toBe('dark')
+  })
+
+  it('does not push when the transport is disconnected', () => {
+    const transport = fakeTransport({ connected: false })
+    const subs = new Map([[1, true]])
+    const last = new Map<number, 'dark' | 'light'>()
+
+    const pushed = maybePushMode2031Flip(1, 'dark', transport, subs, last)
+
+    expect(pushed).toBe(false)
+    expect(transport.sendInput).not.toHaveBeenCalled()
+    expect(last.has(1)).toBe(false)
+  })
+
+  it('leaves last-mode untouched when sendInput reports failure', () => {
+    // So a reconnect / retry will re-emit on the next appearance pass.
+    const transport = fakeTransport({ sendOk: false })
+    const subs = new Map([[1, true]])
+    const last = new Map<number, 'dark' | 'light'>()
+
+    const pushed = maybePushMode2031Flip(1, 'dark', transport, subs, last)
+
+    expect(pushed).toBe(false)
+    expect(transport.sendInput).toHaveBeenCalledTimes(1)
+    expect(last.has(1)).toBe(false)
+  })
+
+  it('tracks flip state per-pane', () => {
+    const transportA = fakeTransport()
+    const transportB = fakeTransport()
+    const subs = new Map([
+      [1, true],
+      [2, true]
+    ])
+    const last = new Map<number, 'dark' | 'light'>()
+
+    maybePushMode2031Flip(1, 'dark', transportA, subs, last)
+    maybePushMode2031Flip(2, 'light', transportB, subs, last)
+    maybePushMode2031Flip(1, 'dark', transportA, subs, last) // suppressed
+    maybePushMode2031Flip(2, 'dark', transportB, subs, last) // flip
+
+    expect(transportA.sendInput).toHaveBeenCalledTimes(1)
+    expect(transportB.sendInput).toHaveBeenCalledTimes(2)
+    expect(last.get(1)).toBe('dark')
+    expect(last.get(2)).toBe('dark')
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-appearance.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-appearance.ts
@@ -18,13 +18,16 @@ export function applyTerminalAppearance(
   systemPrefersDark: boolean,
   paneFontSizes: Map<number, number>,
   paneTransports: Map<number, PtyTransport>,
-  effectiveMacOptionAsAlt: EffectiveMacOptionAsAlt
+  effectiveMacOptionAsAlt: EffectiveMacOptionAsAlt,
+  paneMode2031: Map<number, boolean>,
+  paneLastThemeMode: Map<number, 'dark' | 'light'>
 ): void {
   const appearance = resolveEffectiveTerminalAppearance(settings, systemPrefersDark)
   const paneStyles = resolvePaneStyleOptions(settings)
   const theme: ITheme | null = appearance.theme ?? getBuiltinTheme(appearance.themeName)
   const paneBackground = theme?.background ?? '#000000'
   const terminalFontWeights = resolveTerminalFontWeights(settings.terminalFontWeight)
+  const mode2031Seq = appearance.mode === 'dark' ? '\x1b[?997;1n' : '\x1b[?997;2n'
 
   for (const pane of manager.getPanes()) {
     if (theme) {
@@ -55,6 +58,15 @@ export function applyTerminalAppearance(
     const transport = paneTransports.get(pane.id)
     if (transport?.isConnected()) {
       transport.resize(pane.terminal.cols, pane.terminal.rows)
+      // Gate on actual mode flip so font/size/opacity tweaks — which also
+      // re-run this function — don't spam subscribed TUIs with CSI 997.
+      if (
+        paneMode2031.get(pane.id) &&
+        paneLastThemeMode.get(pane.id) !== appearance.mode &&
+        transport.sendInput(mode2031Seq)
+      ) {
+        paneLastThemeMode.set(pane.id, appearance.mode)
+      }
     }
   }
 

--- a/src/renderer/src/components/terminal-pane/terminal-appearance.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-appearance.ts
@@ -12,6 +12,42 @@ import { captureScrollState, restoreScrollState } from '@/lib/pane-manager/pane-
 import type { PtyTransport } from './pty-transport'
 import type { EffectiveMacOptionAsAlt } from '@/lib/keyboard-layout/detect-option-as-alt'
 
+// Contour/Kitty "color-scheme update" protocol (DEC mode 2031 + CSI 997):
+// the terminal pushes `CSI ?997;1n` for dark and `CSI ?997;2n` for light to
+// subscribed TUIs. This helper is the single source of truth so the push
+// site in applyTerminalAppearance and the subscribe-time seed in the
+// lifecycle hook cannot drift.
+export function mode2031SequenceFor(mode: 'dark' | 'light'): string {
+  return mode === 'dark' ? '\x1b[?997;1n' : '\x1b[?997;2n'
+}
+
+// Gate on actual mode flip so font/size/opacity tweaks — which also re-run
+// applyTerminalAppearance — don't spam subscribed TUIs with CSI 997. The
+// subscribe/last-mode maps are mutated in place so callers share state with
+// the lifecycle hook's seed path.
+export function maybePushMode2031Flip(
+  paneId: number,
+  mode: 'dark' | 'light',
+  transport: Pick<PtyTransport, 'isConnected' | 'sendInput'>,
+  paneMode2031: Map<number, boolean>,
+  paneLastThemeMode: Map<number, 'dark' | 'light'>
+): boolean {
+  if (!transport.isConnected()) {
+    return false
+  }
+  if (!paneMode2031.get(paneId)) {
+    return false
+  }
+  if (paneLastThemeMode.get(paneId) === mode) {
+    return false
+  }
+  if (!transport.sendInput(mode2031SequenceFor(mode))) {
+    return false
+  }
+  paneLastThemeMode.set(paneId, mode)
+  return true
+}
+
 export function applyTerminalAppearance(
   manager: PaneManager,
   settings: GlobalSettings,
@@ -27,7 +63,6 @@ export function applyTerminalAppearance(
   const theme: ITheme | null = appearance.theme ?? getBuiltinTheme(appearance.themeName)
   const paneBackground = theme?.background ?? '#000000'
   const terminalFontWeights = resolveTerminalFontWeights(settings.terminalFontWeight)
-  const mode2031Seq = appearance.mode === 'dark' ? '\x1b[?997;1n' : '\x1b[?997;2n'
 
   for (const pane of manager.getPanes()) {
     if (theme) {
@@ -58,15 +93,7 @@ export function applyTerminalAppearance(
     const transport = paneTransports.get(pane.id)
     if (transport?.isConnected()) {
       transport.resize(pane.terminal.cols, pane.terminal.rows)
-      // Gate on actual mode flip so font/size/opacity tweaks — which also
-      // re-run this function — don't spam subscribed TUIs with CSI 997.
-      if (
-        paneMode2031.get(pane.id) &&
-        paneLastThemeMode.get(pane.id) !== appearance.mode &&
-        transport.sendInput(mode2031Seq)
-      ) {
-        paneLastThemeMode.set(pane.id, appearance.mode)
-      }
+      maybePushMode2031Flip(pane.id, appearance.mode, transport, paneMode2031, paneLastThemeMode)
     }
   }
 

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -25,6 +25,7 @@ import {
 import { applyExpandedLayoutTo, restoreExpandedLayoutFrom } from './expand-collapse'
 import { applyTerminalAppearance } from './terminal-appearance'
 import type { EffectiveMacOptionAsAlt } from '@/lib/keyboard-layout/detect-option-as-alt'
+import { resolveEffectiveTerminalAppearance } from '@/lib/terminal-theme'
 import { connectPanePty } from './pty-connection'
 import type { PtyTransport } from './pty-transport'
 import { fitAndFocusPanes, fitPanes } from './pane-helpers'
@@ -64,6 +65,8 @@ type UseTerminalPaneLifecycleDeps = {
   >
   paneFontSizesRef: React.RefObject<Map<number, number>>
   paneTransportsRef: React.RefObject<Map<number, PtyTransport>>
+  paneMode2031Ref: React.RefObject<Map<number, boolean>>
+  paneLastThemeModeRef: React.RefObject<Map<number, 'dark' | 'light'>>
   panePtyBindingsRef: React.RefObject<Map<number, IDisposable>>
   pendingWritesRef: React.RefObject<Map<number, string>>
   isActiveRef: React.RefObject<boolean>
@@ -140,6 +143,8 @@ export function useTerminalPaneLifecycle({
   expandedStyleSnapshotRef,
   paneFontSizesRef,
   paneTransportsRef,
+  paneMode2031Ref,
+  paneLastThemeModeRef,
   panePtyBindingsRef,
   pendingWritesRef,
   isActiveRef,
@@ -171,6 +176,7 @@ export function useTerminalPaneLifecycle({
   // Why: read settingsRef at fire time so toggling "copy on select" takes
   // effect without recreating panes.
   const selectionDisposablesRef = useRef(new Map<number, IDisposable>())
+  const mode2031DisposablesRef = useRef(new Map<number, IDisposable[]>())
 
   const applyAppearance = (manager: PaneManager): void => {
     const currentSettings = settingsRef.current
@@ -183,8 +189,29 @@ export function useTerminalPaneLifecycle({
       systemPrefersDarkRef.current,
       paneFontSizesRef.current,
       paneTransportsRef.current,
-      effectiveMacOptionAsAltRef.current
+      effectiveMacOptionAsAltRef.current,
+      paneMode2031Ref.current,
+      paneLastThemeModeRef.current
     )
+  }
+
+  const pushMode2031ForPane = (paneId: number): void => {
+    const transport = paneTransportsRef.current.get(paneId)
+    if (!transport?.isConnected()) {
+      return
+    }
+    const currentSettings = settingsRef.current
+    if (!currentSettings) {
+      return
+    }
+    const { mode } = resolveEffectiveTerminalAppearance(
+      currentSettings,
+      systemPrefersDarkRef.current
+    )
+    const seq = mode === 'dark' ? '\x1b[?997;1n' : '\x1b[?997;2n'
+    if (transport.sendInput(seq)) {
+      paneLastThemeModeRef.current.set(paneId, mode)
+    }
   }
 
   // Initialize PaneManager instance once
@@ -282,6 +309,29 @@ export function useTerminalPaneLifecycle({
 
     const manager = new PaneManager(container, {
       onPaneCreated: (pane) => {
+        // Install mode 2031 parser handlers before PTY attach so the child's
+        // initial CSI ?2031h (sent at startup) is captured.
+        const parser = pane.terminal.parser
+        const hasMode2031 = (params: (number | number[])[]): boolean =>
+          params.some((p) => (Array.isArray(p) ? p.includes(2031) : p === 2031))
+        const mode2031Disposables: IDisposable[] = [
+          parser.registerCsiHandler({ prefix: '?', final: 'h' }, (params) => {
+            if (hasMode2031(params)) {
+              paneMode2031Ref.current.set(pane.id, true)
+              pushMode2031ForPane(pane.id)
+            }
+            return false
+          }),
+          parser.registerCsiHandler({ prefix: '?', final: 'l' }, (params) => {
+            if (hasMode2031(params)) {
+              paneMode2031Ref.current.delete(pane.id)
+              paneLastThemeModeRef.current.delete(pane.id)
+            }
+            return false
+          })
+        ]
+        mode2031DisposablesRef.current.set(pane.id, mode2031Disposables)
+
         const linkProviderDisposable = pane.terminal.registerLinkProvider(
           createFilePathLinkProvider(pane.id, linkDeps, pane.linkTooltip, fileOpenLinkHint)
         )
@@ -349,6 +399,15 @@ export function useTerminalPaneLifecycle({
           selectionDisposable.dispose()
           selectionDisposablesRef.current.delete(paneId)
         }
+        const mode2031Disposables = mode2031DisposablesRef.current.get(paneId)
+        if (mode2031Disposables) {
+          for (const d of mode2031Disposables) {
+            d.dispose()
+          }
+          mode2031DisposablesRef.current.delete(paneId)
+        }
+        paneMode2031Ref.current.delete(paneId)
+        paneLastThemeModeRef.current.delete(paneId)
         const transport = paneTransportsRef.current.get(paneId)
         const panePtyBinding = panePtyBindings.get(paneId)
         if (panePtyBinding) {

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -23,7 +23,7 @@ import {
   restoreScrollbackBuffers
 } from './layout-serialization'
 import { applyExpandedLayoutTo, restoreExpandedLayoutFrom } from './expand-collapse'
-import { applyTerminalAppearance } from './terminal-appearance'
+import { applyTerminalAppearance, mode2031SequenceFor } from './terminal-appearance'
 import type { EffectiveMacOptionAsAlt } from '@/lib/keyboard-layout/detect-option-as-alt'
 import { resolveEffectiveTerminalAppearance } from '@/lib/terminal-theme'
 import { connectPanePty } from './pty-connection'
@@ -208,8 +208,7 @@ export function useTerminalPaneLifecycle({
       currentSettings,
       systemPrefersDarkRef.current
     )
-    const seq = mode === 'dark' ? '\x1b[?997;1n' : '\x1b[?997;2n'
-    if (transport.sendInput(seq)) {
+    if (transport.sendInput(mode2031SequenceFor(mode))) {
       paneLastThemeModeRef.current.set(paneId, mode)
     }
   }
@@ -314,6 +313,10 @@ export function useTerminalPaneLifecycle({
         const parser = pane.terminal.parser
         const hasMode2031 = (params: (number | number[])[]): boolean =>
           params.some((p) => (Array.isArray(p) ? p.includes(2031) : p === 2031))
+        // Why return false from both handlers: we only observe mode 2031.
+        // Returning false lets xterm's built-in DEC private mode handler
+        // continue processing the same sequence, so compound sequences like
+        // `CSI ?25;2031h` still update cursor visibility correctly.
         const mode2031Disposables: IDisposable[] = [
           parser.registerCsiHandler({ prefix: '?', final: 'h' }, (params) => {
             if (hasMode2031(params)) {


### PR DESCRIPTION
## Summary

Claude Code's `/theme auto` reads Orca's background via OSC 11 at startup (xterm.js answers that natively), so claude matches the terminal on launch. But when Orca's theme flips mid-session (dark to light or vice versa), claude had no signal: Orca never told running TUIs anything changed, so auto-theme stayed stuck wherever it started.

This wires the DEC private mode 2031 + CSI 997 protocol that Neovim, tmux, Kitty, and Ghostty use. A TUI sends `CSI ?2031h` to subscribe; when the theme flips, the terminal pushes `CSI ?997;1n (dark)` or `CSI ?997;2n (light)`. The TUI then re-queries OSC 11 and repaints.

- Per-pane subscription flag and last-emitted mode live on TerminalPane.
- The `CSI ?2031 h/l` handlers are installed in `onPaneCreated` before the PTY attaches so the child's initial subscribe is captured, and an immediate push on enable seeds the current mode without a query.
- `applyTerminalAppearance` only emits CSI 997 when the resolved mode actually flipped, so font/size/opacity tweaks that re-run the same effect don't spam subscribed TUIs.

## Screenshots

Before
https://github.com/user-attachments/assets/bd350b91-3e8d-46b0-ace5-e40c7ead567e


After
See the theme change automatically without having to reset claude's theme from the /theme command

https://github.com/user-attachments/assets/381c2fbc-0639-4231-bf2a-88abfd5bbd1b


## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`