### PR TITLE
fix(sidebar): collapsed group overlap on restart

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -10,7 +10,12 @@ import { cn } from '@/lib/utils'
 import type { Worktree, Repo } from '../../../../shared/types'
 import { isGitRepoKind } from '../../../../shared/repo-kind'
 import { buildWorktreeComparator } from './smart-sort'
-import { type Row, buildRows, getGroupKeyForWorktree } from './worktree-list-groups'
+import {
+  type GroupHeaderRow,
+  type Row,
+  buildRows,
+  getGroupKeyForWorktree
+} from './worktree-list-groups'
 import { computeVisibleWorktreeIds, setVisibleWorktreeIds } from './visible-worktrees'
 import { useModifierHint } from '@/hooks/useModifierHint'
 
@@ -611,7 +616,18 @@ const WorktreeList = React.memo(function WorktreeList() {
     () => buildRows(groupBy, worktrees, repoMap, prCache, collapsedGroups),
     [groupBy, worktrees, repoMap, prCache, collapsedGroups]
   )
-  const viewportResetKey = `${groupBy}:${rows.length}`
+  // Why: rows.length alone can stay the same when items migrate between
+  // groups (e.g., PR cache loads on restart and a collapsed group absorbs
+  // an item while its header is added — net row count unchanged). Including
+  // the header keys ensures the virtualizer remounts when group structure
+  // changes, preventing stale height measurements from causing overlap.
+  const viewportResetKey = useMemo(() => {
+    const headers = rows
+      .filter((r): r is GroupHeaderRow => r.type === 'header')
+      .map((r) => r.key)
+      .join(',')
+    return `${groupBy}:${rows.length}:${headers}`
+  }, [groupBy, rows])
 
   // Why: derive the rendered item order from the post-buildRows() row list,
   // not the flat `worktrees` array, because grouping (groupBy: 'repo' or


### PR DESCRIPTION
## Summary
- On restart, when the PR cache loads asynchronously and reclassifies worktrees into groups, items can migrate to a collapsed group (e.g., "Done"). If a header is added (+1 row) while a collapsed item is removed (-1 row), `rows.length` stays the same and the virtualizer's `viewportResetKey` doesn't change — leaving stale height measurements that cause visual overlap.
- The fix includes group header keys in `viewportResetKey` so the virtualizer remounts whenever group structure changes (headers appearing/disappearing), not just when row count changes.

## Test plan
- [ ] Open app with PR-status grouping and "Done" collapsed, restart — verify "Done" section renders correctly with no overlapping items
- [ ] Toggle collapse/expand on groups — verify no visual glitches
- [ ] Change grouping mode (none → repo → pr-status) — verify clean transitions