### PR TITLE
fix(terminal): add proportional scroll fallback for sidebar resize

### DIFF
--- a/src/renderer/src/lib/pane-manager/pane-scroll.ts
+++ b/src/renderer/src/lib/pane-manager/pane-scroll.ts
@@ -69,6 +69,19 @@ export function restoreScrollState(terminal: Terminal, state: ScrollState): void
   if (target >= 0) {
     terminal.scrollToLine(target)
     forceViewportScrollbarSync(terminal)
+    return
+  }
+  // Why: content matching fails when the first visible line is blank or when
+  // reflow changes content beyond recognition. Without a fallback, the
+  // terminal stays wherever xterm.js left it after the reflow — often the
+  // top. Proportional positioning approximates the original scroll position
+  // by mapping the old ratio into the new buffer dimensions.
+  if (hintRatio !== undefined) {
+    const newTotalLines = terminal.buffer.active.baseY + terminal.rows
+    const fallbackLine = Math.round(hintRatio * newTotalLines)
+    const clampedLine = Math.min(fallbackLine, terminal.buffer.active.baseY)
+    terminal.scrollToLine(clampedLine)
+    forceViewportScrollbarSync(terminal)
   }
 }
 


### PR DESCRIPTION
## Summary
- Fixes terminal scrolling to top when toggling the right sidebar (Cmd+L)
- Root cause: `restoreScrollState` uses content-based line matching to find the original scroll position after xterm.js reflow. When the first visible line is blank (empty prompt, blank line between outputs) or content can't be matched after reflow, it returned -1 and **did nothing** — leaving the terminal wherever xterm.js put it (often the top)
- Adds a proportional fallback: when content matching fails, maps the old `viewportY/totalLines` ratio into the new buffer dimensions to approximate the original position
- This also improves scroll preservation for window resizes, font size changes, and any other layout change that triggers reflow

## Test plan
- [ ] Open a terminal with scrollback, scroll to middle
- [ ] Press Cmd+L to toggle sidebar — verify scroll position stays approximately the same
- [ ] Repeat with the viewport showing blank lines at the top
- [ ] Verify terminals at bottom still stay at bottom
- [ ] Verify drag-resize scroll preservation still works