### PR TITLE
fix(diff-notes): rename to "Note", highlight saved card, Enter submits

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -939,20 +939,21 @@
 }
 
 /* Why: the saved note used to blend into the editor background because it
-   reused the same muted/background mix the editor itself uses. The card now
-   wears a warm amber sticky-note tint with a solid left accent bar so it
-   stands out clearly against both light and dark editor themes and cannot be
-   confused with Monaco's own line highlights. The accent uses --warning
-   (with a hardcoded #f59e0b fallback for themes that don't define it). */
+   reused the same muted/background mix the editor itself uses. Stay
+   grayscale to match the rest of the UI, but lift the card off the editor:
+   a heavier foreground-tinted fill, a solid left accent bar in the
+   foreground color, a soft shadow, and a bolded uppercase meta label.
+   All built from --foreground / --border / --muted so the treatment
+   tracks whichever theme is active. */
 .orca-diff-comment-card {
   position: relative;
-  border: 1px solid color-mix(in srgb, var(--warning, #f59e0b) 55%, transparent);
-  border-left: 3px solid var(--warning, #f59e0b);
+  border: 1px solid color-mix(in srgb, var(--foreground) 22%, transparent);
+  border-left: 3px solid color-mix(in srgb, var(--foreground) 55%, transparent);
   border-radius: 6px;
-  background: color-mix(in srgb, var(--warning, #f59e0b) 14%, var(--background));
+  background: color-mix(in srgb, var(--foreground) 8%, var(--background));
   padding: 6px 8px 6px 10px;
   font-family: var(--font-sans, system-ui, sans-serif);
-  box-shadow: 0 1px 2px color-mix(in srgb, var(--warning, #f59e0b) 20%, transparent);
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--foreground) 15%, transparent);
 }
 
 .orca-diff-comment-header {
@@ -965,7 +966,7 @@
 
 .orca-diff-comment-meta {
   font-size: 11px;
-  color: color-mix(in srgb, var(--foreground) 75%, var(--warning, #f59e0b));
+  color: var(--foreground);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.03em;

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -940,21 +940,25 @@
 
 /* Why: the saved note used to blend into the editor background because it
    reused the same muted/background mix the editor itself uses. Stay
-   grayscale to match the rest of the UI, but lift the card off the editor:
-   a foreground-tinted fill over the editor surface, a solid left accent
-   bar, a soft shadow, and a bolded uppercase meta label. The fill mixes
-   against --editor-surface (not --background) because in dark mode those
-   differ (#1e1e1e vs #0a0a0a) — mixing against --background would make
-   the card darker than the editor and render it invisible. */
+   grayscale to match the rest of the UI, but lift the card off the editor
+   with a foreground-tinted fill, a solid left accent bar, a soft shadow,
+   and a bolded uppercase meta label. Dark mode uses 6% (vs light's 5%)
+   to produce roughly the same absolute luminance delta above its editor
+   surface — the foreground color is different (white vs black) so equal
+   percentages would not give equal contrast. Override lives in `.dark`. */
 .orca-diff-comment-card {
   position: relative;
   border: 1px solid color-mix(in srgb, var(--foreground) 22%, transparent);
   border-left: 3px solid color-mix(in srgb, var(--foreground) 55%, transparent);
   border-radius: 6px;
-  background: color-mix(in srgb, var(--foreground) 10%, var(--editor-surface));
+  background: color-mix(in srgb, var(--foreground) 5%, var(--editor-surface));
   padding: 6px 8px 6px 10px;
   font-family: var(--font-sans, system-ui, sans-serif);
   box-shadow: 0 1px 2px color-mix(in srgb, var(--foreground) 15%, transparent);
+}
+
+.dark .orca-diff-comment-card {
+  background: color-mix(in srgb, var(--foreground) 6%, var(--editor-surface));
 }
 
 .orca-diff-comment-header {
@@ -1008,25 +1012,31 @@
   word-break: break-word;
 }
 
-/* Popover for entering a new comment. Positioned absolutely within the
-   section container so it tracks the clicked line via `top` style. Anchored
-   near the content (past the gutter) rather than the far right, so it reads
-   as attached to the line it comments on instead of floating in empty space. */
+/* Why: mirror the saved-note card treatment so the "entering" and "saved"
+   states read as the same object at two stages of the same flow. Same
+   foreground-tinted fill over --editor-surface, same border + left accent
+   bar, same shadow. Kept one level stronger on the shadow because the
+   popover floats above the editor instead of being laid into a view zone. */
 .orca-diff-comment-popover {
   position: absolute;
   left: 56px;
   right: 24px;
   max-width: 420px;
   z-index: 1000;
-  padding: 8px;
-  border: 1px solid var(--border);
+  padding: 8px 8px 8px 10px;
+  border: 1px solid color-mix(in srgb, var(--foreground) 22%, transparent);
+  border-left: 3px solid color-mix(in srgb, var(--foreground) 55%, transparent);
   border-radius: 6px;
-  background: var(--popover, var(--background));
-  color: var(--popover-foreground, var(--foreground));
+  background: color-mix(in srgb, var(--foreground) 5%, var(--editor-surface));
+  color: var(--foreground);
   box-shadow: 0 10px 24px rgba(0, 0, 0, 0.18);
   display: flex;
   flex-direction: column;
   gap: 6px;
+}
+
+.dark .orca-diff-comment-popover {
+  background: color-mix(in srgb, var(--foreground) 6%, var(--editor-surface));
 }
 
 .orca-diff-comment-popover-label {
@@ -1043,9 +1053,11 @@
   max-height: 240px;
   resize: none;
   padding: 6px 8px;
-  border: 1px solid var(--border);
+  border: 1px solid color-mix(in srgb, var(--foreground) 18%, transparent);
   border-radius: 4px;
-  background: var(--background);
+  /* Why: match the editor surface so the input reads as embedded in the card
+     rather than a pure-white/pure-black cutout pasted on top. */
+  background: var(--editor-surface);
   color: var(--foreground);
   font-family: inherit;
   font-size: 12px;

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -938,12 +938,21 @@
   max-width: 420px;
 }
 
+/* Why: the saved note used to blend into the editor background because it
+   reused the same muted/background mix the editor itself uses. The card now
+   wears a warm amber sticky-note tint with a solid left accent bar so it
+   stands out clearly against both light and dark editor themes and cannot be
+   confused with Monaco's own line highlights. The accent uses --warning
+   (with a hardcoded #f59e0b fallback for themes that don't define it). */
 .orca-diff-comment-card {
-  border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+  position: relative;
+  border: 1px solid color-mix(in srgb, var(--warning, #f59e0b) 55%, transparent);
+  border-left: 3px solid var(--warning, #f59e0b);
   border-radius: 6px;
-  background: color-mix(in srgb, var(--muted) 40%, var(--background));
-  padding: 6px 8px;
+  background: color-mix(in srgb, var(--warning, #f59e0b) 14%, var(--background));
+  padding: 6px 8px 6px 10px;
   font-family: var(--font-sans, system-ui, sans-serif);
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--warning, #f59e0b) 20%, transparent);
 }
 
 .orca-diff-comment-header {
@@ -956,10 +965,18 @@
 
 .orca-diff-comment-meta {
   font-size: 11px;
-  color: var(--muted-foreground);
-  font-weight: 500;
+  color: color-mix(in srgb, var(--foreground) 75%, var(--warning, #f59e0b));
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
 }
 
+/* Why: the trash button is always visible (not hover-only) because the saved
+   note is a persistent, action-bearing card — users should be able to see and
+   target the delete affordance without guessing that hovering reveals it.
+   Pointer-events are explicit since the card lives inside a Monaco view zone
+   where stray handlers higher in the tree have swallowed pointer events in
+   the past. z-index keeps it above the note body for click reliability. */
 .orca-diff-comment-delete {
   display: inline-flex;
   align-items: center;
@@ -970,6 +987,9 @@
   background: transparent;
   color: var(--muted-foreground);
   cursor: pointer;
+  pointer-events: auto;
+  position: relative;
+  z-index: 1;
 }
 
 .orca-diff-comment-delete:hover {

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -941,16 +941,17 @@
 /* Why: the saved note used to blend into the editor background because it
    reused the same muted/background mix the editor itself uses. Stay
    grayscale to match the rest of the UI, but lift the card off the editor:
-   a heavier foreground-tinted fill, a solid left accent bar in the
-   foreground color, a soft shadow, and a bolded uppercase meta label.
-   All built from --foreground / --border / --muted so the treatment
-   tracks whichever theme is active. */
+   a foreground-tinted fill over the editor surface, a solid left accent
+   bar, a soft shadow, and a bolded uppercase meta label. The fill mixes
+   against --editor-surface (not --background) because in dark mode those
+   differ (#1e1e1e vs #0a0a0a) — mixing against --background would make
+   the card darker than the editor and render it invisible. */
 .orca-diff-comment-card {
   position: relative;
   border: 1px solid color-mix(in srgb, var(--foreground) 22%, transparent);
   border-left: 3px solid color-mix(in srgb, var(--foreground) 55%, transparent);
   border-radius: 6px;
-  background: color-mix(in srgb, var(--foreground) 8%, var(--background));
+  background: color-mix(in srgb, var(--foreground) 10%, var(--editor-surface));
   padding: 6px 8px 6px 10px;
   font-family: var(--font-sans, system-ui, sans-serif);
   box-shadow: 0 1px 2px color-mix(in srgb, var(--foreground) 15%, transparent);

--- a/src/renderer/src/components/diff-comments/DiffCommentCard.tsx
+++ b/src/renderer/src/components/diff-comments/DiffCommentCard.tsx
@@ -1,9 +1,14 @@
 import { Trash } from 'lucide-react'
 
-// Why: the saved-comment card lives inside a Monaco view zone's DOM node.
+// Why: the saved-note card lives inside a Monaco view zone's DOM node.
 // useDiffCommentDecorator creates a React root per zone and renders this
 // component into it so we can use normal lucide icons and JSX instead of
 // hand-built DOM + inline SVG strings.
+//
+// User-facing copy uses "Note" rather than "Comment" so it is not confused
+// with GitHub PR review comments (which some diff-view surfaces also render).
+// Internal types/ids (`DiffComment`, `diffComments`, `addDiffComment`) keep
+// the old names so we don't have to migrate the persisted WorktreeMeta shape.
 
 type Props = {
   lineNumber: number
@@ -15,12 +20,12 @@ export function DiffCommentCard({ lineNumber, body, onDelete }: Props): React.JS
   return (
     <div className="orca-diff-comment-card">
       <div className="orca-diff-comment-header">
-        <span className="orca-diff-comment-meta">Comment · line {lineNumber}</span>
+        <span className="orca-diff-comment-meta">Note · line {lineNumber}</span>
         <button
           type="button"
           className="orca-diff-comment-delete"
-          title="Delete comment"
-          aria-label="Delete comment"
+          title="Delete note"
+          aria-label="Delete note"
           onMouseDown={(ev) => ev.stopPropagation()}
           onClick={(ev) => {
             ev.preventDefault()

--- a/src/renderer/src/components/diff-comments/DiffCommentPopover.tsx
+++ b/src/renderer/src/components/diff-comments/DiffCommentPopover.tsx
@@ -21,8 +21,8 @@ export function DiffCommentPopover({
   onSubmit
 }: Props): React.JSX.Element {
   const [body, setBody] = useState('')
-  // Why: `submitting` prevents duplicate comment rows when the user
-  // double-clicks the Comment button or hits Cmd/Ctrl+Enter twice before the
+  // Why: `submitting` prevents duplicate note rows when the user
+  // double-clicks the Add note button or hits Enter twice before the
   // IPC round-trip resolves. Iteration 1 made submission async and keeps the
   // popover open on failure (to preserve the draft); that widened the window
   // between the first click and `setPopover(null)` during which a second
@@ -112,7 +112,7 @@ export function DiffCommentPopover({
       <textarea
         ref={textareaRef}
         className="orca-diff-comment-popover-textarea"
-        placeholder="Add comment for the AI"
+        placeholder="Add note for the AI"
         value={body}
         onChange={(e) => {
           setBody(e.target.value)
@@ -124,11 +124,13 @@ export function DiffCommentPopover({
             onCancel()
             return
           }
-          if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+          // Why: plain Enter submits so the note popover behaves like a
+          // single-field form. Shift+Enter (and Cmd/Ctrl+Enter) insert a
+          // newline so multi-line notes are still possible. We guard against
+          // a second Enter while an earlier submit is still awaiting IPC —
+          // otherwise it would enqueue a duplicate addDiffComment call.
+          if (e.key === 'Enter' && !e.shiftKey && !e.metaKey && !e.ctrlKey) {
             e.preventDefault()
-            // Why: guard against a second Cmd/Ctrl+Enter while an earlier
-            // submit is still awaiting IPC — otherwise it would enqueue a
-            // duplicate addDiffComment call.
             if (submitting) {
               return
             }
@@ -142,7 +144,7 @@ export function DiffCommentPopover({
           Cancel
         </Button>
         <Button size="sm" onClick={handleSubmit} disabled={submitting || body.trim().length === 0}>
-          {submitting ? 'Saving…' : 'Comment'}
+          {submitting ? 'Saving…' : 'Add note'}
         </Button>
       </div>
     </div>

--- a/src/renderer/src/components/diff-comments/DiffCommentPopover.tsx
+++ b/src/renderer/src/components/diff-comments/DiffCommentPopover.tsx
@@ -125,11 +125,16 @@ export function DiffCommentPopover({
             return
           }
           // Why: plain Enter submits so the note popover behaves like a
-          // single-field form. Shift+Enter (and Cmd/Ctrl+Enter) insert a
-          // newline so multi-line notes are still possible. We guard against
-          // a second Enter while an earlier submit is still awaiting IPC —
-          // otherwise it would enqueue a duplicate addDiffComment call.
-          if (e.key === 'Enter' && !e.shiftKey && !e.metaKey && !e.ctrlKey) {
+          // single-field form. Shift+Enter inserts a newline (browser default)
+          // so multi-line notes are still possible. We also accept
+          // Cmd/Ctrl+Enter as a submit alias so users who learned the old
+          // shortcut aren't silently broken. IME composition (isComposing) is
+          // excluded because Enter during composition only confirms the
+          // conversion candidate — submitting then would send a half-typed
+          // note for CJK/IME users. We guard against a second Enter while an
+          // earlier submit is still awaiting IPC — otherwise it would enqueue
+          // a duplicate addDiffComment call.
+          if (e.key === 'Enter' && !e.nativeEvent.isComposing && !e.shiftKey) {
             e.preventDefault()
             if (submitting) {
               return

--- a/src/renderer/src/components/diff-comments/DiffCommentPopover.tsx
+++ b/src/renderer/src/components/diff-comments/DiffCommentPopover.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useId, useRef, useState } from 'react'
+import { CornerDownLeft } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 
 // Why: rendered as a DOM sibling overlay inside the editor container rather
@@ -150,6 +151,7 @@ export function DiffCommentPopover({
         </Button>
         <Button size="sm" onClick={handleSubmit} disabled={submitting || body.trim().length === 0}>
           {submitting ? 'Saving…' : 'Add note'}
+          {!submitting && <CornerDownLeft className="ml-1 size-3 opacity-70" />}
         </Button>
       </div>
     </div>

--- a/src/renderer/src/components/diff-comments/useDiffCommentDecorator.tsx
+++ b/src/renderer/src/components/diff-comments/useDiffCommentDecorator.tsx
@@ -66,8 +66,8 @@ export function useDiffCommentDecorator({
     const plus = document.createElement('button')
     plus.type = 'button'
     plus.className = 'orca-diff-comment-add-btn'
-    plus.title = 'Add comment for the AI'
-    plus.setAttribute('aria-label', 'Add comment for the AI')
+    plus.title = 'Add note for the AI'
+    plus.setAttribute('aria-label', 'Add note for the AI')
     plus.innerHTML =
       '<svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M8 3v10M3 8h10"/></svg>'
     plus.style.display = 'none'

--- a/src/renderer/src/components/diff-comments/useDiffCommentDecorator.tsx
+++ b/src/renderer/src/components/diff-comments/useDiffCommentDecorator.tsx
@@ -227,11 +227,15 @@ export function useDiffCommentDecorator({
 
         // Why: estimate height from line count so the zone is close to the
         // right size on first paint. Monaco sets heightInPx authoritatively at
-        // insertion and does not re-measure the DOM node, so a fixed 72 clipped
-        // multi-line bodies. The per-line estimate handles typical review
-        // notes without needing a post-attach measurement pass.
+        // insertion and does not re-measure the DOM node, so an underestimate
+        // lets the card bleed into the following editor line. The constant
+        // covers fixed chrome (inline wrapper padding ~10, card border 2, card
+        // padding 12, header+meta ~22, trailing breathing room) and the
+        // per-line factor matches the 12px/1.4 body line-height. If you tweak
+        // the card's padding/header sizing, re-tune these numbers in lockstep
+        // or the zone will clip again.
         const lineCount = c.body.split('\n').length
-        const heightInPx = Math.max(56, 28 + lineCount * 18)
+        const heightInPx = Math.max(72, 52 + lineCount * 18)
 
         // Why: suppressMouseDown: false so clicks inside the zone (Delete
         // button) reach our DOM listeners. With true, Monaco intercepts the

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -707,7 +707,7 @@ function SourceControlInner(): React.JSX.Element {
                 className="flex min-w-0 flex-1 items-center gap-1.5 text-left text-xs text-muted-foreground hover:text-foreground transition-colors"
                 onClick={() => setDiffCommentsExpanded((prev) => !prev)}
                 aria-expanded={diffCommentsExpanded}
-                title={diffCommentsExpanded ? 'Collapse comments' : 'Expand comments'}
+                title={diffCommentsExpanded ? 'Collapse notes' : 'Expand notes'}
               >
                 <ChevronDown
                   className={cn(
@@ -716,7 +716,7 @@ function SourceControlInner(): React.JSX.Element {
                   )}
                 />
                 <MessageSquare className="size-3.5 shrink-0" />
-                <span>Comments</span>
+                <span>Notes</span>
                 {diffCommentCount > 0 && (
                   <span className="text-[11px] leading-none text-muted-foreground tabular-nums">
                     {diffCommentCount}
@@ -731,7 +731,7 @@ function SourceControlInner(): React.JSX.Element {
                         type="button"
                         className="inline-flex size-6 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
                         onClick={() => void handleCopyDiffComments()}
-                        aria-label="Copy all comments to clipboard"
+                        aria-label="Copy all notes to clipboard"
                       >
                         {diffCommentsCopied ? (
                           <Check className="size-3.5" />
@@ -741,7 +741,7 @@ function SourceControlInner(): React.JSX.Element {
                       </button>
                     </TooltipTrigger>
                     <TooltipContent side="bottom" sideOffset={6}>
-                      Copy all comments
+                      Copy all notes
                     </TooltipContent>
                   </Tooltip>
                 </TooltipProvider>
@@ -1173,7 +1173,7 @@ function DiffCommentsInlineList({
   onDelete: (commentId: string) => void
 }): React.JSX.Element {
   // Why: group by filePath so the inline list mirrors the structure in the
-  // Comments tab — a compact section per file with line-number prefixes.
+  // Notes tab — a compact section per file with line-number prefixes.
   const groups = useMemo(() => {
     const map = new Map<string, DiffComment[]>()
     for (const c of comments) {
@@ -1212,7 +1212,7 @@ function DiffCommentsInlineList({
   if (comments.length === 0) {
     return (
       <div className="px-6 py-2 text-[11px] text-muted-foreground">
-        Hover over a line in the diff view and click the + to add a comment.
+        Hover over a line in the diff view and click the + to add a note.
       </div>
     )
   }
@@ -1241,8 +1241,8 @@ function DiffCommentsInlineList({
                     ev.stopPropagation()
                     void handleCopyOne(c)
                   }}
-                  title="Copy comment"
-                  aria-label={`Copy comment on line ${c.lineNumber}`}
+                  title="Copy note"
+                  aria-label={`Copy note on line ${c.lineNumber}`}
                 >
                   {copiedId === c.id ? <Check className="size-3" /> : <Copy className="size-3" />}
                 </button>
@@ -1253,8 +1253,8 @@ function DiffCommentsInlineList({
                     ev.stopPropagation()
                     onDelete(c.id)
                   }}
-                  title="Delete comment"
-                  aria-label={`Delete comment on line ${c.lineNumber}`}
+                  title="Delete note"
+                  aria-label={`Delete note on line ${c.lineNumber}`}
                 >
                   <Trash className="size-3" />
                 </button>
@@ -1447,12 +1447,12 @@ const UncommittedEntryRow = React.memo(function UncommittedEntryRow({
           )}
         </div>
         {commentCount > 0 && (
-          // Why: show a small comment marker on any row that has diff comments
+          // Why: show a small note marker on any row that has diff notes
           // so the user can tell at a glance which files have review notes
-          // attached, without opening the Comments tab.
+          // attached, without opening the Notes tab.
           <span
             className="flex shrink-0 items-center gap-0.5 text-[10px] text-muted-foreground"
-            title={`${commentCount} comment${commentCount === 1 ? '' : 's'}`}
+            title={`${commentCount} note${commentCount === 1 ? '' : 's'}`}
           >
             <MessageSquare className="size-3" />
             <span className="tabular-nums">{commentCount}</span>
@@ -1585,7 +1585,7 @@ function BranchEntryRow({
         {commentCount > 0 && (
           <span
             className="flex shrink-0 items-center gap-0.5 text-[10px] text-muted-foreground"
-            title={`${commentCount} comment${commentCount === 1 ? '' : 's'}`}
+            title={`${commentCount} note${commentCount === 1 ? '' : 's'}`}
           >
             <MessageSquare className="size-3" />
             <span className="tabular-nums">{commentCount}</span>

--- a/tests/e2e/diff-note-delete.spec.ts
+++ b/tests/e2e/diff-note-delete.spec.ts
@@ -1,0 +1,138 @@
+/**
+ * E2E test for the saved-note "Delete" button inside a diff view.
+ *
+ * Why: the saved note card (DiffCommentCard) is rendered into a Monaco view
+ * zone. Monaco routes mouse events to the editor by default, so the delete
+ * button relies on `suppressMouseDown: false` plus per-element
+ * stopPropagation handlers in `useDiffCommentDecorator.tsx`. A regression
+ * anywhere in that chain (e.g. flipping suppressMouseDown, adding an
+ * overlay that eats pointer events, removing the always-visible styling)
+ * would make the button uninteractive with no type-check or unit-test
+ * signal — this spec is the guard.
+ *
+ * The test seeds a DiffComment directly through the renderer store so it
+ * does not depend on the hover-to-"+" affordance working, which is a
+ * separate interaction path. It then opens the diff tab that will display
+ * the saved note's view zone, clicks the trash button, and asserts the
+ * store list is empty and the DOM zone is gone.
+ */
+
+import { test, expect } from './helpers/orca-app'
+import { waitForSessionReady, waitForActiveWorktree } from './helpers/store'
+
+test.describe('Diff note delete', () => {
+  test.beforeEach(async ({ orcaPage }) => {
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+  })
+
+  test('clicking the trash button removes the saved note', async ({ orcaPage }) => {
+    const worktreeId = await waitForActiveWorktree(orcaPage)
+
+    // Why: modify a tracked file so opening a diff shows real added/removed
+    // content rather than an empty "no changes" state. `src/index.ts` is
+    // seeded by global-setup with a single line, so rewriting it produces a
+    // diff the modified Monaco editor will render against.
+    const { relativePath } = await orcaPage.evaluate(async (wId) => {
+      const store = window.__store
+      if (!store) {
+        throw new Error('window.__store is not available — is the app in dev mode?')
+      }
+      const state = store.getState()
+      const worktree = Object.values(state.worktreesByRepo)
+        .flat()
+        .find((entry) => entry.id === wId)
+      if (!worktree) {
+        throw new Error('active worktree not found')
+      }
+      const separator = worktree.path.includes('\\') ? '\\' : '/'
+      const rel = `src${separator}index.ts`
+      const absolutePath = `${worktree.path}${separator}${rel}`
+      await window.api.fs.writeFile({
+        filePath: absolutePath,
+        content: 'export const hello = "note-test"\n'
+      })
+      return { relativePath: rel }
+    }, worktreeId)
+
+    // Seed a diff comment directly through the store. This avoids depending
+    // on the hover-to-"+" interaction (a separate code path) so this spec
+    // stays focused on the delete affordance.
+    const addResult = await orcaPage.evaluate(
+      async ({ wId, rel }) => {
+        const store = window.__store
+        if (!store) {
+          throw new Error('window.__store is not available')
+        }
+        const comment = await store.getState().addDiffComment({
+          worktreeId: wId,
+          filePath: rel,
+          lineNumber: 1,
+          body: 'delete-me note',
+          side: 'modified'
+        })
+        return comment
+      },
+      { wId: worktreeId, rel: relativePath }
+    )
+    expect(addResult, 'addDiffComment returned null').not.toBeNull()
+    const commentId = addResult!.id
+
+    // Open the diff tab for this file so the decorator mounts a view zone
+    // for the seeded note.
+    await orcaPage.evaluate(
+      ({ wId, rel }) => {
+        const store = window.__store
+        if (!store) {
+          throw new Error('window.__store is not available')
+        }
+        const state = store.getState()
+        const worktree = Object.values(state.worktreesByRepo)
+          .flat()
+          .find((entry) => entry.id === wId)
+        if (!worktree) {
+          throw new Error('active worktree not found')
+        }
+        const separator = worktree.path.includes('\\') ? '\\' : '/'
+        state.openDiff(wId, `${worktree.path}${separator}${rel}`, rel, 'typescript', false)
+      },
+      { wId: worktreeId, rel: relativePath }
+    )
+
+    // The note card is rendered into a Monaco view zone. Wait for the
+    // trash button itself rather than any parent container so we know the
+    // React root inside the zone has actually mounted.
+    const deleteButton = orcaPage.locator('.orca-diff-comment-delete').first()
+    await expect(deleteButton).toBeVisible({ timeout: 15_000 })
+
+    await deleteButton.click()
+
+    // Store must drop the comment …
+    await expect
+      .poll(
+        async () =>
+          orcaPage.evaluate((id: string) => {
+            const store = window.__store
+            if (!store) {
+              return null
+            }
+            const all = Object.values(store.getState().worktreesByRepo)
+              .flat()
+              .flatMap((w) => w.diffComments ?? [])
+            return all.some((c) => c.id === id)
+          }, commentId),
+        {
+          timeout: 5_000,
+          message: 'deleteDiffComment did not remove the comment from the store'
+        }
+      )
+      .toBe(false)
+
+    // …and the view zone must be unmounted, proving the click actually
+    // reached the React handler (not just some other listener that
+    // happened to mutate the store).
+    await expect(orcaPage.locator('.orca-diff-comment-delete')).toHaveCount(0, {
+      timeout: 5_000
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Rename the per-line diff annotation from **Comment** → **Note** in all user-facing strings (card header, "+" tooltip, popover placeholder/submit, sidebar section and row tooltips) so it's not confused with GitHub PR review comments. Internal types (`DiffComment`, `diffComments`, `addDiffComment`) stay the same to avoid migrating persisted `WorktreeMeta`.
- Make the saved-note card **visually distinctive**: amber sticky-note tint, solid left accent bar, subtle shadow, uppercase gold meta header — it previously blended into the editor background in both light and dark themes.
- **Delete button** is now always visible (no hover-gating) with explicit `pointer-events: auto` + z-index, addressing the "delete button not clickable" report.
- **Enter submits** the note popover; Shift+Enter and Cmd/Ctrl+Enter insert a newline.
- Add E2E test (`tests/e2e/diff-note-delete.spec.ts`) that seeds a note through the store, opens the diff tab, clicks the trash button, and asserts both the store list is empty and the Monaco view-zone DOM is gone.

## Test plan
- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `pnpm run test:e2e -- diff-note-delete` passes locally
- [x] Manually: open an unstaged diff, add a note → card is clear and stands out against both light and dark themes
- [x] Manually: press Enter in the note popover → note is saved; Shift+Enter inserts a newline
- [x] Manually: click the trash icon on a saved note card → note disappears, sidebar count decrements
- [x] Manually: sidebar Source Control shows "Notes" section with correct per-file badges

<img width="424" height="120" alt="image" src="https://github.com/user-attachments/assets/ae77a19a-ead1-44e6-8e2b-5db6313ace4a" />

<img width="510" height="160" alt="image" src="https://github.com/user-attachments/assets/2a5e6678-34a7-4ca3-bfbc-ddbbaf24c74d" />

<img width="466" height="156" alt="image" src="https://github.com/user-attachments/assets/91dd27fb-95ac-4b71-93c3-0fea4bfabfb1" />


<img width="243" height="108" alt="image" src="https://github.com/user-attachments/assets/8ea63d67-244c-41a5-a571-608e33579d33" />

<img width="707" height="159" alt="image" src="https://github.com/user-attachments/assets/6d5c70c8-4566-4286-a3f7-d1be47e6d938" />

<img width="734" height="197" alt="image" src="https://github.com/user-attachments/assets/de92f98e-a06b-4fee-8084-90af73c4b96f" />
