### PR TITLE
fix(browser): place CLI-created tabs in the active browser tab's group

### DIFF
--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -236,7 +236,20 @@ export function useIpcEvents(): void {
             window.api.ui.replyTabCreate({ requestId: data.requestId, error: 'No active worktree' })
             return
           }
-          const workspace = store.createBrowserTab(worktreeId, data.url, { title: data.url })
+          // Why: CLI-created tabs should land in the same group as the active
+          // browser tab, not the terminal's group (which is typically the
+          // UI-active group when an agent is running commands).
+          const activeBrowserTabId = store.activeBrowserTabIdByWorktree[worktreeId]
+          const activeBrowserUnifiedTab = activeBrowserTabId
+            ? (store.unifiedTabsByWorktree[worktreeId] ?? []).find(
+                (t) => t.contentType === 'browser' && t.entityId === activeBrowserTabId
+              )
+            : undefined
+
+          const workspace = store.createBrowserTab(worktreeId, data.url, {
+            title: data.url,
+            targetGroupId: activeBrowserUnifiedTab?.groupId
+          })
           // Why: registerGuest fires with the page ID (not workspace ID) as
           // browserPageId. Return the page ID so waitForTabRegistration can
           // correlate correctly.

--- a/src/renderer/src/store/slices/browser.test.ts
+++ b/src/renderer/src/store/slices/browser.test.ts
@@ -2,6 +2,69 @@ import { describe, expect, it } from 'vitest'
 import { createTestStore, makeTabGroup, makeWorktree, seedStore } from './store-test-helpers'
 
 describe('browser slice', () => {
+  it('places a new tab in the target group when targetGroupId is provided', () => {
+    const store = createTestStore()
+    const worktreeId = 'repo1::/tmp/wt-1'
+    seedStore(store, {
+      activeRepoId: 'repo1',
+      activeWorktreeId: worktreeId,
+      activeTabType: 'terminal',
+      worktreesByRepo: {
+        repo1: [makeWorktree({ id: worktreeId, repoId: 'repo1', path: '/tmp/wt-1' })]
+      },
+      groupsByWorktree: {
+        [worktreeId]: [
+          makeTabGroup({ id: 'terminal-group', worktreeId, activeTabId: null, tabOrder: [] }),
+          makeTabGroup({ id: 'browser-group', worktreeId, activeTabId: null, tabOrder: [] })
+        ]
+      },
+      activeGroupIdByWorktree: { [worktreeId]: 'terminal-group' },
+      browserTabsByWorktree: {},
+      unifiedTabsByWorktree: {}
+    })
+
+    const created = store.getState().createBrowserTab(worktreeId, 'https://example.com', {
+      title: 'Example',
+      targetGroupId: 'browser-group'
+    })
+
+    const unifiedTab = (store.getState().unifiedTabsByWorktree[worktreeId] ?? []).find(
+      (t) => t.contentType === 'browser' && t.entityId === created.id
+    )
+    expect(unifiedTab?.groupId).toBe('browser-group')
+  })
+
+  it('falls back to active group when targetGroupId is not provided', () => {
+    const store = createTestStore()
+    const worktreeId = 'repo1::/tmp/wt-1'
+    seedStore(store, {
+      activeRepoId: 'repo1',
+      activeWorktreeId: worktreeId,
+      activeTabType: 'terminal',
+      worktreesByRepo: {
+        repo1: [makeWorktree({ id: worktreeId, repoId: 'repo1', path: '/tmp/wt-1' })]
+      },
+      groupsByWorktree: {
+        [worktreeId]: [
+          makeTabGroup({ id: 'terminal-group', worktreeId, activeTabId: null, tabOrder: [] }),
+          makeTabGroup({ id: 'browser-group', worktreeId, activeTabId: null, tabOrder: [] })
+        ]
+      },
+      activeGroupIdByWorktree: { [worktreeId]: 'terminal-group' },
+      browserTabsByWorktree: {},
+      unifiedTabsByWorktree: {}
+    })
+
+    const created = store.getState().createBrowserTab(worktreeId, 'https://example.com', {
+      title: 'Example'
+    })
+
+    const unifiedTab = (store.getState().unifiedTabsByWorktree[worktreeId] ?? []).find(
+      (t) => t.contentType === 'browser' && t.entityId === created.id
+    )
+    expect(unifiedTab?.groupId).toBe('terminal-group')
+  })
+
   it('reopens the most recently closed browser tab in the same worktree', () => {
     const store = createTestStore()
     const worktreeId = 'repo1::/tmp/wt-1'

--- a/src/renderer/src/store/slices/browser.ts
+++ b/src/renderer/src/store/slices/browser.ts
@@ -18,6 +18,7 @@ type CreateBrowserTabOptions = {
   activate?: boolean
   title?: string
   sessionProfileId?: string | null
+  targetGroupId?: string
 }
 
 type CreateBrowserPageOptions = {
@@ -395,7 +396,8 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
     if (!alreadyHasUnifiedTab) {
       state.createUnifiedTab(worktreeId, 'browser', {
         entityId: workspaceId,
-        label: browserTab.title
+        label: browserTab.title,
+        targetGroupId: options?.targetGroupId
       })
     }
     return browserTab


### PR DESCRIPTION
## Summary
- When an agent creates a browser tab via `orca tab create`, the tab now lands in the same tab group as the active browser tab instead of the terminal's group
- Adds `targetGroupId` option to `CreateBrowserTabOptions` and threads it through to `createUnifiedTab`
- Falls back to the active group (current behavior) when no browser tab exists yet

## Context
Feedback from [Slack](https://stablygroup.slack.com/archives/C0AK2T3JEF4/p1776790977778869): when the AI opens a new browser tab via the CLI, it ends up in the terminal's tab group instead of alongside existing browser tabs.

Root cause: `createUnifiedTab` defaults to `activeGroupIdByWorktree` (the UI-focused group), which is the terminal's group when an agent is running.

Fix: In the CLI IPC handler (`onRequestTabCreate`), look up the active browser tab via `activeBrowserTabIdByWorktree` and pass its `groupId` as `targetGroupId`. Only the CLI path is affected — Cmd+T, right-click open, terminal links, and session restore are unchanged.

Closes #116

## Test plan
- [x] Added 2 unit tests: `targetGroupId` routes to correct group, omitting it falls back to active group
- [x] Existing tests pass (12/12)
- [x] Typecheck clean
- [ ] Manual: run `orca tab create --url <url>` while terminal group is active → new tab should appear in the browser group