### PR TITLE
fix: allow retry download from error state when update version is cached

### DIFF
--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -522,7 +522,17 @@ export function setupAutoUpdater(
 }
 
 export function downloadUpdate(): void {
-  if (currentStatus.state !== 'available' || downloadInFlight) {
+  if (downloadInFlight) {
+    return
+  }
+  // Why: permit retry from 'error' when we still have a cached availableVersion —
+  // a failed download leaves the status at 'error' but availableVersion intact,
+  // and the error card's "Retry Download" button must be able to restart the
+  // download. Without this, the button would appear to do nothing.
+  const canStart =
+    currentStatus.state === 'available' ||
+    (currentStatus.state === 'error' && hasNewerDownloadedVersion())
+  if (!canStart) {
     return
   }
   downloadInFlight = true


### PR DESCRIPTION
## Problem
'Retry Download' button on the update-error card does nothing when clicked.

## Solution
Allow `downloadUpdate()` to proceed from the 'error' state when `availableVersion` is still cached (i.e., when there's a concrete update version to retry). Download failures don't clear `availableVersion`, so retrying remains valid. The `downloadInFlight` guard still prevents double-starts.