### PR TITLE
feat(settings): add dedicated Agent Browser Use setup in Browser pane

### DIFF
--- a/src/renderer/src/components/settings/BrowserPane.tsx
+++ b/src/renderer/src/components/settings/BrowserPane.tsx
@@ -16,10 +16,15 @@ import {
 } from '../../../../shared/browser-url'
 import { SearchableSetting } from './SearchableSetting'
 import { matchesSettingsSearch } from './settings-search'
-import { BROWSER_PANE_SEARCH_ENTRIES } from './browser-search'
+import { BROWSER_PANE_SEARCH_ENTRIES as BROWSER_CORE_SEARCH_ENTRIES } from './browser-search'
+import { BROWSER_USE_PANE_SEARCH_ENTRIES } from './browser-use-search'
 import { BrowserProfileRow } from './BrowserProfileRow'
+import { BrowserUseSetup } from './BrowserUsePane'
 
-export { BROWSER_PANE_SEARCH_ENTRIES }
+export const BROWSER_PANE_SEARCH_ENTRIES = [
+  ...BROWSER_USE_PANE_SEARCH_ENTRIES,
+  ...BROWSER_CORE_SEARCH_ENTRIES
+]
 
 type BrowserPaneProps = {
   settings: GlobalSettings
@@ -51,13 +56,36 @@ export function BrowserPane({ settings, updateSettings }: BrowserPaneProps): Rea
     setHomePageDraft(browserDefaultUrl ?? '')
   }, [browserDefaultUrl])
 
-  const showHomePage = matchesSettingsSearch(searchQuery, [BROWSER_PANE_SEARCH_ENTRIES[0]])
-  const showSearchEngine = matchesSettingsSearch(searchQuery, [BROWSER_PANE_SEARCH_ENTRIES[1]])
-  const showLinkRouting = matchesSettingsSearch(searchQuery, [BROWSER_PANE_SEARCH_ENTRIES[2]])
-  const showCookies = matchesSettingsSearch(searchQuery, [BROWSER_PANE_SEARCH_ENTRIES[3]])
+  const showHomePage = matchesSettingsSearch(searchQuery, [BROWSER_CORE_SEARCH_ENTRIES[0]])
+  const showSearchEngine = matchesSettingsSearch(searchQuery, [BROWSER_CORE_SEARCH_ENTRIES[1]])
+  const showLinkRouting = matchesSettingsSearch(searchQuery, [BROWSER_CORE_SEARCH_ENTRIES[2]])
+  const showCookies = matchesSettingsSearch(searchQuery, [BROWSER_CORE_SEARCH_ENTRIES[3]])
+  const showBrowserUse = matchesSettingsSearch(searchQuery, BROWSER_USE_PANE_SEARCH_ENTRIES)
+
+  const scrollToSessionCookies = (): void => {
+    // Why: the "Session & Cookies" block is search-gated, so if the user has
+    // filtered to a query that excludes it the target element won't be in the
+    // DOM. Clear the search first, then scroll on the next frame so the block
+    // has mounted.
+    useAppStore.getState().setSettingsSearchQuery('')
+    // Why: double RAF to ensure React has committed the re-render triggered by
+    // the store update before we query the DOM — a single RAF can fire before
+    // commit and miss the newly-mounted element.
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        const el = document.getElementById('browser-session-cookies')
+        if (!el) {
+          return
+        }
+        el.scrollIntoView({ behavior: 'smooth', block: 'start' })
+      })
+    })
+  }
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-6">
+      {showBrowserUse ? <BrowserUseSetup onConfigureMoreBrowsers={scrollToSessionCookies} /> : null}
+
       {showHomePage ? (
         <SearchableSetting
           title="Default Home Page"
@@ -171,6 +199,7 @@ export function BrowserPane({ settings, updateSettings }: BrowserPaneProps): Rea
 
       {showCookies ? (
         <SearchableSetting
+          id="browser-session-cookies"
           title="Session & Cookies"
           description="Manage browser profiles and import cookies from Chrome, Edge, or other browsers."
           keywords={[

--- a/src/renderer/src/components/settings/BrowserUseExamples.tsx
+++ b/src/renderer/src/components/settings/BrowserUseExamples.tsx
@@ -1,0 +1,63 @@
+import { Copy, Sparkles } from 'lucide-react'
+import { toast } from 'sonner'
+import { Button } from '../ui/button'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/tooltip'
+
+const EXAMPLE_PROMPTS: string[] = [
+  'Using Orca CLI, open https://github.com/notifications and click the first unread pull request.',
+  "Take a screenshot of my open Linear board with the Orca CLI and tell me what's blocked.",
+  'With Orca CLI, go to our staging app, log in (my cookies are imported), and verify the checkout flow works.'
+]
+
+async function handleCopyText(text: string, label: string): Promise<void> {
+  try {
+    await window.api.ui.writeClipboardText(text)
+    toast.success(`Copied ${label}.`)
+  } catch (error) {
+    toast.error(error instanceof Error ? error.message : 'Failed to copy.')
+  }
+}
+
+export function BrowserUseExamples(): React.JSX.Element {
+  return (
+    <div className="rounded-xl border border-border/60 bg-card/50 p-4">
+      <div className="flex items-center gap-2">
+        <Sparkles className="size-3.5 text-muted-foreground" />
+        <p className="text-sm font-medium">Try it — example prompts</p>
+      </div>
+      <p className="mt-1 text-xs text-muted-foreground">
+        Paste any of these into Claude Code, Codex, or another agent in a project where the skill is
+        installed.
+      </p>
+      <ul className="mt-3 space-y-2">
+        {EXAMPLE_PROMPTS.map((prompt) => (
+          <li
+            key={prompt}
+            className="flex items-start gap-2 rounded-lg border border-border/50 bg-background/60 px-3 py-2"
+          >
+            <p className="flex-1 text-[11px] leading-relaxed text-foreground/90">
+              &ldquo;{prompt}&rdquo;
+            </p>
+            <TooltipProvider delayDuration={250}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon-xs"
+                    onClick={() => void handleCopyText(prompt, 'prompt')}
+                    aria-label="Copy example prompt"
+                  >
+                    <Copy className="size-3.5" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="left" sideOffset={6}>
+                  Copy
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/src/renderer/src/components/settings/BrowserUsePane.tsx
+++ b/src/renderer/src/components/settings/BrowserUsePane.tsx
@@ -1,0 +1,383 @@
+import { useEffect, useState } from 'react'
+import { Import, Loader2 } from 'lucide-react'
+import { toast } from 'sonner'
+import type { CliInstallStatus } from '../../../../shared/cli-install-types'
+import { Button } from '../ui/button'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/tooltip'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuPortal,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger
+} from '../ui/dropdown-menu'
+import { useAppStore } from '../../store'
+import { BROWSER_FAMILY_LABELS } from '../../../../shared/constants'
+import { SearchableSetting } from './SearchableSetting'
+import { matchesSettingsSearch } from './settings-search'
+import { BROWSER_USE_PANE_SEARCH_ENTRIES } from './browser-use-search'
+import { BrowserUseExamples } from './BrowserUseExamples'
+import { StepBadge } from './BrowserUseStepBadge'
+import { BrowserUseSkillStep } from './BrowserUseSkillStep'
+
+const ORCA_SKILL_INSTALL_COMMAND =
+  'npx skills add https://github.com/stablyai/orca --skill orca-cli'
+
+type BrowserUseSetupProps = {
+  onConfigureMoreBrowsers?: () => void
+}
+
+export function BrowserUseSetup({
+  onConfigureMoreBrowsers
+}: BrowserUseSetupProps = {}): React.JSX.Element {
+  const searchQuery = useAppStore((s) => s.settingsSearchQuery)
+  const browserSessionProfiles = useAppStore((s) => s.browserSessionProfiles)
+  const detectedBrowsers = useAppStore((s) => s.detectedBrowsers)
+  const fetchBrowserSessionProfiles = useAppStore((s) => s.fetchBrowserSessionProfiles)
+  const fetchDetectedBrowsers = useAppStore((s) => s.fetchDetectedBrowsers)
+  const browserSessionImportState = useAppStore((s) => s.browserSessionImportState)
+
+  const [cliStatus, setCliStatus] = useState<CliInstallStatus | null>(null)
+  const [cliLoading, setCliLoading] = useState(true)
+  const [cliBusy, setCliBusy] = useState(false)
+
+  // Why: the toggle gates only whether we show the setup instructions. We
+  // persist it in localStorage instead of global settings because it has no
+  // functional effect elsewhere in the app — it's a UI affordance local to
+  // this pane, consistent with the skill-installed marker below.
+  const [browserUseEnabled, setBrowserUseEnabled] = useState<boolean>(() => {
+    return localStorage.getItem('orca.browserUse.enabled') === '1'
+  })
+
+  const toggleBrowserUse = (value: boolean): void => {
+    setBrowserUseEnabled(value)
+    localStorage.setItem('orca.browserUse.enabled', value ? '1' : '0')
+  }
+
+  const refreshCli = async (): Promise<void> => {
+    setCliLoading(true)
+    try {
+      setCliStatus(await window.api.cli.getInstallStatus())
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to load CLI status.')
+    } finally {
+      setCliLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    // Why: skip IPC work when the feature is toggled off — the component
+    // returns early below and none of this data is rendered.
+    if (!browserUseEnabled) {
+      return
+    }
+    void refreshCli()
+    void fetchBrowserSessionProfiles()
+    void fetchDetectedBrowsers()
+  }, [browserUseEnabled, fetchBrowserSessionProfiles, fetchDetectedBrowsers])
+
+  const defaultProfile = browserSessionProfiles.find((p) => p.id === 'default')
+  const anyProfileHasCookies = browserSessionProfiles.some((p) => p.source != null)
+  const cookiesImported = !!defaultProfile?.source || anyProfileHasCookies
+
+  const cliEnabled = cliStatus?.state === 'installed'
+  const cliSupported = cliStatus?.supported ?? false
+
+  // Why: the skill install step is a copy-and-run command that happens in the
+  // user's terminal. We cannot detect completion from the app, so we let the
+  // user mark it done explicitly after copying — this avoids falsely implying
+  // progress and keeps the guided flow honest.
+  const [skillInstalled, setSkillInstalled] = useState<boolean>(() => {
+    return localStorage.getItem('orca.browserUse.skillInstalled') === '1'
+  })
+
+  const markSkillInstalled = (value: boolean): void => {
+    setSkillInstalled(value)
+    localStorage.setItem('orca.browserUse.skillInstalled', value ? '1' : '0')
+  }
+
+  const handleEnableCli = async (): Promise<void> => {
+    setCliBusy(true)
+    try {
+      const next = await window.api.cli.install()
+      setCliStatus(next)
+      toast.success('Registered `orca` in PATH.')
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to register `orca` in PATH.')
+    } finally {
+      setCliBusy(false)
+    }
+  }
+
+  const handleCopySkillCommand = async (): Promise<void> => {
+    try {
+      await window.api.ui.writeClipboardText(ORCA_SKILL_INSTALL_COMMAND)
+      toast.success('Copied install command. Run it in your agent project.')
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to copy command.')
+    }
+  }
+
+  const handleImportFromBrowser = async (
+    browserFamily: string,
+    browserProfile?: string
+  ): Promise<void> => {
+    const profileId = 'default'
+    const result = await useAppStore
+      .getState()
+      .importCookiesFromBrowser(profileId, browserFamily, browserProfile)
+    if (result.ok) {
+      const browser = detectedBrowsers.find((b) => b.family === browserFamily)
+      toast.success(
+        `Imported ${result.summary.importedCookies} cookies from ${browser?.label ?? browserFamily}${browserProfile ? ` (${browserProfile})` : ''}.`
+      )
+    } else {
+      toast.error(result.reason)
+    }
+  }
+
+  const handleImportFromFile = async (): Promise<void> => {
+    const result = await useAppStore.getState().importCookiesToProfile('default')
+    if (result.ok) {
+      toast.success(`Imported ${result.summary.importedCookies} cookies from file.`)
+    } else if (result.reason !== 'canceled') {
+      toast.error(result.reason)
+    }
+  }
+
+  const isImportingDefault =
+    browserSessionImportState?.profileId === 'default' &&
+    browserSessionImportState.status === 'importing'
+
+  const showStep1 = matchesSettingsSearch(searchQuery, [BROWSER_USE_PANE_SEARCH_ENTRIES[0]])
+  const showStep2 = matchesSettingsSearch(searchQuery, [BROWSER_USE_PANE_SEARCH_ENTRIES[1]])
+  const showStep3 = matchesSettingsSearch(searchQuery, [BROWSER_USE_PANE_SEARCH_ENTRIES[2]])
+
+  const completedCount = [cliEnabled, skillInstalled, cookiesImported].filter(Boolean).length
+  const allDone = completedCount === 3
+
+  const sourceLabel = defaultProfile?.source
+    ? `${BROWSER_FAMILY_LABELS[defaultProfile.source.browserFamily] ?? defaultProfile.source.browserFamily}${defaultProfile.source.profileName ? ` (${defaultProfile.source.profileName})` : ''}`
+    : null
+
+  const toggleSwitch = (
+    <button
+      role="switch"
+      aria-checked={browserUseEnabled}
+      aria-label="Enable Agent Browser Use"
+      onClick={() => toggleBrowserUse(!browserUseEnabled)}
+      className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent transition-colors ${
+        browserUseEnabled ? 'bg-foreground' : 'bg-muted-foreground/30'
+      }`}
+    >
+      <span
+        className={`inline-block h-3.5 w-3.5 transform rounded-full bg-background shadow-sm transition-transform ${
+          browserUseEnabled ? 'translate-x-4' : 'translate-x-0.5'
+        }`}
+      />
+    </button>
+  )
+
+  if (!browserUseEnabled) {
+    return (
+      <div className="flex items-center justify-between gap-4 px-1 py-2">
+        <div className="space-y-0.5">
+          <p className="text-sm font-medium">Agent Browser Use</p>
+          <p className="text-xs text-muted-foreground">
+            Let coding agents drive this browser with your logins.
+          </p>
+        </div>
+        {toggleSwitch}
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-3 rounded-2xl border border-border/60 bg-card/30 p-4">
+      <div className="flex items-center justify-between gap-3">
+        <div className="space-y-0.5">
+          <p className="text-sm font-semibold">Agent Browser Use</p>
+          <p className="text-xs text-muted-foreground">
+            Let coding agents drive this browser with your logins. Finish the three steps below.
+          </p>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <span
+            className={`rounded-full px-2 py-0.5 text-[10px] font-medium ${
+              allDone
+                ? 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-400'
+                : 'bg-muted text-muted-foreground'
+            }`}
+          >
+            {completedCount}/3
+          </span>
+          {toggleSwitch}
+        </div>
+      </div>
+
+      {showStep1 ? (
+        <SearchableSetting
+          title="Enable Orca CLI"
+          description="Register the orca shell command so agents can drive the browser."
+          keywords={BROWSER_USE_PANE_SEARCH_ENTRIES[0].keywords}
+          className="rounded-xl border border-border/60 bg-card/50 p-4"
+        >
+          <div className="flex items-start gap-3">
+            <StepBadge
+              index={1}
+              state={cliEnabled ? 'done' : cliBusy ? 'in-progress' : 'pending'}
+            />
+            <div className="min-w-0 flex-1 space-y-1">
+              <p className="text-sm font-medium">Enable Orca CLI</p>
+              <p className="text-xs text-muted-foreground">
+                Registers the <code className="rounded bg-muted px-1 py-0.5 text-[11px]">orca</code>{' '}
+                command so agents can orchestrate the browser from their shell.
+              </p>
+              {cliStatus?.commandPath && cliEnabled ? (
+                <p className="text-[11px] text-muted-foreground">
+                  Installed at{' '}
+                  <code className="rounded bg-muted px-1 py-0.5">{cliStatus.commandPath}</code>
+                </p>
+              ) : null}
+            </div>
+            <TooltipProvider delayDuration={250}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span>
+                    <Button
+                      size="sm"
+                      variant={cliEnabled ? 'outline' : 'default'}
+                      disabled={cliLoading || cliBusy || !cliSupported || cliEnabled}
+                      onClick={() => void handleEnableCli()}
+                    >
+                      {cliBusy ? 'Registering…' : cliEnabled ? 'Enabled' : 'Enable'}
+                    </Button>
+                  </span>
+                </TooltipTrigger>
+                {!cliSupported && !cliLoading && cliStatus?.detail ? (
+                  <TooltipContent side="left" sideOffset={6}>
+                    {cliStatus.detail}
+                  </TooltipContent>
+                ) : null}
+              </Tooltip>
+            </TooltipProvider>
+          </div>
+        </SearchableSetting>
+      ) : null}
+
+      {showStep2 ? (
+        <SearchableSetting
+          title="Install Browser Use Skill"
+          description="Install the orca-cli agent skill so agents know how to use the browser."
+          keywords={BROWSER_USE_PANE_SEARCH_ENTRIES[1].keywords}
+          className={`rounded-xl border border-border/60 bg-card/50 p-4 ${
+            cliEnabled ? '' : 'opacity-60'
+          }`}
+        >
+          <BrowserUseSkillStep
+            command={ORCA_SKILL_INSTALL_COMMAND}
+            skillInstalled={skillInstalled}
+            onCopy={() => void handleCopySkillCommand()}
+            onToggleInstalled={() => markSkillInstalled(!skillInstalled)}
+          />
+        </SearchableSetting>
+      ) : null}
+
+      {showStep3 ? (
+        <SearchableSetting
+          title="Import Browser Cookies"
+          description="Import cookies from Chrome, Edge, or other browsers so agents can reuse your logins."
+          keywords={BROWSER_USE_PANE_SEARCH_ENTRIES[2].keywords}
+          className={`rounded-xl border border-border/60 bg-card/50 p-4 ${
+            cliEnabled && skillInstalled ? '' : 'opacity-60'
+          }`}
+        >
+          <div className="flex items-start gap-3">
+            <StepBadge
+              index={3}
+              state={cookiesImported ? 'done' : isImportingDefault ? 'in-progress' : 'pending'}
+            />
+            <div className="min-w-0 flex-1 space-y-1">
+              <p className="text-sm font-medium">Import Browser Cookies</p>
+              <p className="text-xs text-muted-foreground">
+                Bring your existing logins into Orca so agents can reach authenticated pages.
+                Imports into the default profile.
+              </p>
+              {sourceLabel ? (
+                <p className="text-[11px] text-muted-foreground">
+                  Last imported from {sourceLabel}
+                </p>
+              ) : null}
+              {onConfigureMoreBrowsers ? (
+                <button
+                  type="button"
+                  onClick={onConfigureMoreBrowsers}
+                  className="text-[11px] text-muted-foreground underline underline-offset-2 hover:text-foreground"
+                >
+                  Manage profiles for separate logins
+                </button>
+              ) : null}
+            </div>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant={cookiesImported ? 'outline' : 'default'}
+                  size="sm"
+                  disabled={isImportingDefault}
+                  className="gap-1.5"
+                >
+                  {isImportingDefault ? (
+                    <Loader2 className="size-3.5 animate-spin" />
+                  ) : (
+                    <Import className="size-3.5" />
+                  )}
+                  {cookiesImported ? 'Re-import' : 'Import'}
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                {detectedBrowsers.map((browser) =>
+                  browser.profiles.length > 1 ? (
+                    <DropdownMenuSub key={browser.family}>
+                      <DropdownMenuSubTrigger>From {browser.label}</DropdownMenuSubTrigger>
+                      <DropdownMenuPortal>
+                        <DropdownMenuSubContent>
+                          {browser.profiles.map((bp) => (
+                            <DropdownMenuItem
+                              key={bp.directory}
+                              onSelect={() =>
+                                void handleImportFromBrowser(browser.family, bp.directory)
+                              }
+                            >
+                              {bp.name}
+                            </DropdownMenuItem>
+                          ))}
+                        </DropdownMenuSubContent>
+                      </DropdownMenuPortal>
+                    </DropdownMenuSub>
+                  ) : (
+                    <DropdownMenuItem
+                      key={browser.family}
+                      onSelect={() => void handleImportFromBrowser(browser.family)}
+                    >
+                      From {browser.label}
+                    </DropdownMenuItem>
+                  )
+                )}
+                {detectedBrowsers.length > 0 ? <DropdownMenuSeparator /> : null}
+                <DropdownMenuItem onSelect={() => void handleImportFromFile()}>
+                  From File…
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        </SearchableSetting>
+      ) : null}
+
+      <BrowserUseExamples />
+    </div>
+  )
+}

--- a/src/renderer/src/components/settings/BrowserUsePane.tsx
+++ b/src/renderer/src/components/settings/BrowserUsePane.tsx
@@ -81,8 +81,11 @@ export function BrowserUseSetup({
   }, [browserUseEnabled, fetchBrowserSessionProfiles, fetchDetectedBrowsers])
 
   const defaultProfile = browserSessionProfiles.find((p) => p.id === 'default')
-  const anyProfileHasCookies = browserSessionProfiles.some((p) => p.source != null)
-  const cookiesImported = !!defaultProfile?.source || anyProfileHasCookies
+  // Why: this step explicitly imports into the default profile, so completion
+  // must track that profile only. Marking done when a non-default profile has
+  // cookies would mislead users into thinking agents can reach their logins
+  // when the default profile — the one agents use — is still empty.
+  const cookiesImported = !!defaultProfile?.source
 
   const cliEnabled = cliStatus?.state === 'installed'
   const cliSupported = cliStatus?.supported ?? false
@@ -158,7 +161,6 @@ export function BrowserUseSetup({
   const showStep3 = matchesSettingsSearch(searchQuery, [BROWSER_USE_PANE_SEARCH_ENTRIES[2]])
 
   const completedCount = [cliEnabled, skillInstalled, cookiesImported].filter(Boolean).length
-  const allDone = completedCount === 3
 
   const sourceLabel = defaultProfile?.source
     ? `${BROWSER_FAMILY_LABELS[defaultProfile.source.browserFamily] ?? defaultProfile.source.browserFamily}${defaultProfile.source.profileName ? ` (${defaultProfile.source.profileName})` : ''}`
@@ -208,7 +210,7 @@ export function BrowserUseSetup({
         <div className="flex shrink-0 items-center gap-2">
           <span
             className={`rounded-full px-2 py-0.5 text-[10px] font-medium ${
-              allDone
+              completedCount === 3
                 ? 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-400'
                 : 'bg-muted text-muted-foreground'
             }`}
@@ -281,6 +283,7 @@ export function BrowserUseSetup({
           <BrowserUseSkillStep
             command={ORCA_SKILL_INSTALL_COMMAND}
             skillInstalled={skillInstalled}
+            disabled={!cliEnabled}
             onCopy={() => void handleCopySkillCommand()}
             onToggleInstalled={() => markSkillInstalled(!skillInstalled)}
           />

--- a/src/renderer/src/components/settings/BrowserUseSkillStep.tsx
+++ b/src/renderer/src/components/settings/BrowserUseSkillStep.tsx
@@ -1,0 +1,69 @@
+import { Copy } from 'lucide-react'
+import { Button } from '../ui/button'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/tooltip'
+import { StepBadge } from './BrowserUseStepBadge'
+
+type Props = {
+  command: string
+  skillInstalled: boolean
+  onCopy: () => void
+  onToggleInstalled: () => void
+}
+
+export function BrowserUseSkillStep({
+  command,
+  skillInstalled,
+  onCopy,
+  onToggleInstalled
+}: Props): React.JSX.Element {
+  return (
+    <div className="flex items-start gap-3">
+      <StepBadge index={2} state={skillInstalled ? 'done' : 'pending'} />
+      <div className="min-w-0 flex-1 space-y-2">
+        <div className="space-y-1">
+          <p className="text-sm font-medium">Install Browser Use Skill</p>
+          <p className="text-xs text-muted-foreground">
+            Run this in your agent project — once per project — so Claude Code, Codex, and other
+            agents learn to drive Orca&apos;s browser.
+          </p>
+        </div>
+        <div className="flex max-w-full items-center gap-2 rounded-lg border border-border/60 bg-background/60 px-3 py-2">
+          <code className="flex-1 overflow-x-auto whitespace-nowrap text-[11px] text-muted-foreground">
+            {command}
+          </code>
+          <TooltipProvider delayDuration={250}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon-xs"
+                  onClick={onCopy}
+                  aria-label="Copy skill install command"
+                >
+                  <Copy className="size-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom" sideOffset={6}>
+                Copy
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        </div>
+        <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
+          <span>
+            {skillInstalled
+              ? 'Marked as installed on this machine.'
+              : "Check off once you've run it in your project."}
+          </span>
+          <button
+            type="button"
+            className="underline-offset-2 hover:text-foreground hover:underline"
+            onClick={onToggleInstalled}
+          >
+            {skillInstalled ? 'Undo' : 'I ran it'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/settings/BrowserUseSkillStep.tsx
+++ b/src/renderer/src/components/settings/BrowserUseSkillStep.tsx
@@ -6,6 +6,7 @@ import { StepBadge } from './BrowserUseStepBadge'
 type Props = {
   command: string
   skillInstalled: boolean
+  disabled?: boolean
   onCopy: () => void
   onToggleInstalled: () => void
 }
@@ -13,6 +14,7 @@ type Props = {
 export function BrowserUseSkillStep({
   command,
   skillInstalled,
+  disabled = false,
   onCopy,
   onToggleInstalled
 }: Props): React.JSX.Element {
@@ -57,8 +59,9 @@ export function BrowserUseSkillStep({
           </span>
           <button
             type="button"
-            className="underline-offset-2 hover:text-foreground hover:underline"
+            className="underline-offset-2 hover:text-foreground hover:underline disabled:cursor-not-allowed disabled:no-underline disabled:hover:text-muted-foreground"
             onClick={onToggleInstalled}
+            disabled={disabled}
           >
             {skillInstalled ? 'Undo' : 'I ran it'}
           </button>

--- a/src/renderer/src/components/settings/BrowserUseStepBadge.tsx
+++ b/src/renderer/src/components/settings/BrowserUseStepBadge.tsx
@@ -1,0 +1,31 @@
+import { Check, Loader2 } from 'lucide-react'
+
+export type StepState = 'pending' | 'done' | 'in-progress'
+
+export function StepBadge({
+  index,
+  state
+}: {
+  index: number
+  state: StepState
+}): React.JSX.Element {
+  if (state === 'done') {
+    return (
+      <div className="flex size-6 shrink-0 items-center justify-center rounded-full bg-emerald-500/15 text-emerald-600 dark:text-emerald-400">
+        <Check className="size-3.5" />
+      </div>
+    )
+  }
+  if (state === 'in-progress') {
+    return (
+      <div className="flex size-6 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground">
+        <Loader2 className="size-3.5 animate-spin" />
+      </div>
+    )
+  }
+  return (
+    <div className="flex size-6 shrink-0 items-center justify-center rounded-full border border-border/70 text-xs font-medium text-muted-foreground">
+      {index}
+    </div>
+  )
+}

--- a/src/renderer/src/components/settings/SearchableSetting.tsx
+++ b/src/renderer/src/components/settings/SearchableSetting.tsx
@@ -5,6 +5,7 @@ import { matchesSettingsSearch, type SettingsSearchEntry } from './settings-sear
 type SearchableSettingProps = SettingsSearchEntry & {
   children: React.ReactNode
   className?: string
+  id?: string
 }
 
 export function SearchableSetting({
@@ -12,12 +13,17 @@ export function SearchableSetting({
   description,
   keywords,
   children,
-  className
+  className,
+  id
 }: SearchableSettingProps): React.JSX.Element | null {
   const query = useAppStore((state) => state.settingsSearchQuery)
   if (!matchesSettingsSearch(query, { title, description, keywords })) {
     return null
   }
 
-  return <div className={className}>{children}</div>
+  return (
+    <div className={className} id={id}>
+      {children}
+    </div>
+  )
 }

--- a/src/renderer/src/components/settings/browser-use-search.ts
+++ b/src/renderer/src/components/settings/browser-use-search.ts
@@ -1,0 +1,39 @@
+import type { SettingsSearchEntry } from './settings-search'
+
+export const BROWSER_USE_PANE_SEARCH_ENTRIES: SettingsSearchEntry[] = [
+  {
+    title: 'Enable Orca CLI',
+    description: 'Register the orca shell command so agents can drive the browser.',
+    keywords: ['browser use', 'cli', 'orca', 'path', 'command', 'shell', 'enable', 'setup']
+  },
+  {
+    title: 'Install Browser Use Skill',
+    description: 'Install the orca-cli agent skill so agents know how to use the browser.',
+    keywords: [
+      'browser use',
+      'skill',
+      'agent',
+      'install',
+      'orca-cli',
+      'npx',
+      'agent-browser',
+      'automation'
+    ]
+  },
+  {
+    title: 'Import Browser Cookies',
+    description:
+      'Import cookies from Chrome, Edge, or other browsers so agents can reuse your logins.',
+    keywords: [
+      'browser use',
+      'cookies',
+      'session',
+      'import',
+      'login',
+      'auth',
+      'chrome',
+      'edge',
+      'arc'
+    ]
+  }
+]


### PR DESCRIPTION
## Problem

Agent Browser Use requires three setup steps (enable CLI, install skill, import cookies) but there's no guided onboarding in the settings. Users must hunt through disparate UI surfaces, and there's no visual progress indicator for completion.

## Solution

Adds a dedicated Browser Use setup card to the Browser settings pane with:
- 3-step guided flow with progress badges
- Local enable toggle to collapse/expand the panel
- Search integration so users find it by querying 'browser use', 'cli', 'skill', etc.
- Example prompts to try after setup
- Link from Step 3 (cookies) back to Session & Cookies for multi-profile configuration