### PR TITLE
feat(editor): open HTML preview to the side

### DIFF
--- a/src/main/browser/browser-manager.ts
+++ b/src/main/browser/browser-manager.ts
@@ -449,6 +449,15 @@ export class BrowserManager {
       if (url.startsWith('blob:https://') || url.startsWith('blob:http://')) {
         return
       }
+      // Why: file:// is permitted at `will-attach-webview` so the preview pane
+      // can render local HTML the user explicitly opened. After that initial
+      // load, a page must not be able to redirect the guest to file:// — that
+      // would let a remote page probe the local filesystem. Keep the in-guest
+      // navigation guard strict even though initial attach is permissive.
+      if (url.startsWith('file:')) {
+        event.preventDefault()
+        return
+      }
       if (!normalizeBrowserNavigationUrl(url)) {
         // Why: `will-attach-webview` only validates the initial src. Main must
         // keep enforcing the same allowlist for later guest navigations too.

--- a/src/renderer/src/components/editor/EditorPanel.tsx
+++ b/src/renderer/src/components/editor/EditorPanel.tsx
@@ -5,11 +5,12 @@ across multiple components. Autosave now lives in a smaller headless controller
 so hidden editor UI no longer participates in shutdown. */
 import React, { useCallback, useEffect, useRef, useState, Suspense } from 'react'
 import * as monaco from 'monaco-editor'
-import { Columns2, Copy, ExternalLink, FileText, MoreHorizontal, Rows2 } from 'lucide-react'
+import { Columns2, Copy, Eye, ExternalLink, FileText, MoreHorizontal, Rows2 } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { findWorktreeById } from '@/store/slices/worktree-helpers'
 import { getConnectionId } from '@/lib/connection-context'
 import { detectLanguage } from '@/lib/language-detect'
+import { canPreviewLanguage, openFilePreviewToSide } from '@/lib/file-preview'
 import { getEditorHeaderCopyState, getEditorHeaderOpenFileState } from './editor-header'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import {
@@ -705,6 +706,28 @@ function EditorPanelInner({
 
   const isMarkdown = resolvedLanguage === 'markdown'
   const isMermaid = resolvedLanguage === 'mermaid'
+  // Why: "Open Preview to the Side" only applies to edit-mode tabs whose
+  // language has a registered renderer. Diff tabs already have their own
+  // toggle set and there is no clear semantic for previewing a diff.
+  const canOpenPreviewToSide = activeFile.mode === 'edit' && canPreviewLanguage(resolvedLanguage)
+  const handleOpenPreviewToSide = (): void => {
+    // Split-pane layouts mount one EditorPanel per pane, each with its own
+    // activeViewStateId (the unified-tab id). Resolve the owning group from
+    // that tab so the preview lands beside *this* pane rather than whichever
+    // group happens to be the ambient active one.
+    const state = useAppStore.getState()
+    const sourceGroupId = activeViewStateId
+      ? ((state.unifiedTabsByWorktree[activeFile.worktreeId] ?? []).find(
+          (t) => t.id === activeViewStateId
+        )?.groupId ?? null)
+      : null
+    openFilePreviewToSide({
+      language: resolvedLanguage,
+      filePath: activeFile.filePath,
+      worktreeId: activeFile.worktreeId,
+      sourceGroupId
+    })
+  }
   // Why: mermaid files reuse the same per-file view mode store as markdown.
   // Both default to 'rich' (rendered view) and fall back to 'source' (Monaco).
   const hasViewModeToggle = (isMarkdown || isMermaid) && activeFile.mode === 'edit'
@@ -818,6 +841,25 @@ function EditorPanelInner({
                       ? 'Open file tab to use rich markdown editing'
                       : 'Open file tab'
                     : 'This diff has no modified-side file to open'}
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          )}
+          {canOpenPreviewToSide && (
+            <TooltipProvider delayDuration={300}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    className="p-1 rounded hover:bg-accent text-muted-foreground hover:text-foreground transition-colors flex-shrink-0"
+                    onClick={handleOpenPreviewToSide}
+                    aria-label="Open Preview to the Side"
+                  >
+                    <Eye size={14} />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" sideOffset={4}>
+                  Open Preview to the Side
                 </TooltipContent>
               </Tooltip>
             </TooltipProvider>

--- a/src/renderer/src/lib/file-preview.ts
+++ b/src/renderer/src/lib/file-preview.ts
@@ -1,0 +1,61 @@
+import { absolutePathToFileUri } from '@/components/editor/markdown-internal-links'
+import { useAppStore } from '@/store'
+import { findSiblingGroupId } from '@/store/slices/tabs'
+
+export type PreviewableLanguage = 'html'
+
+export function canPreviewLanguage(language: string): language is PreviewableLanguage {
+  return language === 'html'
+}
+
+// Why: "Open Preview to the Side" mirrors the VS Code pattern — the rendered
+// view goes into the group to the right of the editor, creating a right split
+// if one doesn't already exist. Keeps the editor source visible alongside the
+// preview instead of replacing the active tab.
+export function openFilePreviewToSide(params: {
+  language: string
+  filePath: string
+  worktreeId: string
+  sourceGroupId: string | null
+}): void {
+  if (!canPreviewLanguage(params.language)) {
+    return
+  }
+
+  const state = useAppStore.getState()
+  const worktreeId = params.worktreeId
+
+  // Resolve the group this action originated from. Prefer the caller-supplied
+  // id (the tab's own group under split-pane layouts), fall back to the
+  // worktree's active group.
+  const sourceGroupId =
+    params.sourceGroupId ??
+    state.activeGroupIdByWorktree[worktreeId] ??
+    state.groupsByWorktree[worktreeId]?.[0]?.id ??
+    null
+  if (!sourceGroupId) {
+    return
+  }
+
+  const layout = state.layoutByWorktree[worktreeId] ?? null
+  const existingSibling = layout ? findSiblingGroupId(layout, sourceGroupId) : null
+
+  let targetGroupId = existingSibling
+  if (!targetGroupId) {
+    // Why: no split yet — create one to the right so the preview lands beside
+    // the editor. createEmptySplitGroup returns the new (empty) group id.
+    targetGroupId = state.createEmptySplitGroup(worktreeId, sourceGroupId, 'right')
+  }
+  if (!targetGroupId) {
+    return
+  }
+
+  const fileUrl = absolutePathToFileUri(params.filePath)
+  const title = params.filePath.split(/[/\\]/).pop() ?? params.filePath
+
+  state.createBrowserTab(worktreeId, fileUrl, {
+    title,
+    targetGroupId,
+    activate: true
+  })
+}

--- a/src/renderer/src/store/slices/browser.ts
+++ b/src/renderer/src/store/slices/browser.ts
@@ -18,6 +18,9 @@ type CreateBrowserTabOptions = {
   activate?: boolean
   title?: string
   sessionProfileId?: string | null
+  // Why: callers like "Open Preview to the Side" need to place the new browser
+  // tab in a specific (sibling or newly-split) group rather than the ambient
+  // active group. Defaults to the worktree's current active group.
   targetGroupId?: string
 }
 

--- a/src/renderer/src/store/slices/tabs.ts
+++ b/src/renderer/src/store/slices/tabs.ts
@@ -159,7 +159,7 @@ function findFirstLeaf(root: TabGroupLayoutNode): string {
   return root.type === 'leaf' ? root.groupId : findFirstLeaf(root.first)
 }
 
-function findSiblingGroupId(root: TabGroupLayoutNode, targetGroupId: string): string | null {
+export function findSiblingGroupId(root: TabGroupLayoutNode, targetGroupId: string): string | null {
   if (root.type === 'leaf') {
     return null
   }

--- a/src/shared/browser-url.test.ts
+++ b/src/shared/browser-url.test.ts
@@ -19,9 +19,25 @@ describe('browser-url helpers', () => {
   })
 
   it('rejects non-web schemes for in-app navigation', () => {
-    expect(normalizeBrowserNavigationUrl('file:///etc/passwd')).toBeNull()
     expect(normalizeBrowserNavigationUrl('javascript:alert(1)')).toBeNull()
     expect(normalizeExternalBrowserUrl('about:blank')).toBeNull()
+  })
+
+  // Why: "Open Preview to the Side" on an HTML file loads the file via file://
+  // in the browser pane. The guest webview is sandboxed (see
+  // createMainWindow.ts will-attach-webview), so rendering local HTML cannot
+  // escalate privileges beyond what the editor already grants.
+  it('allows file:// URLs so local HTML can be previewed', () => {
+    expect(normalizeBrowserNavigationUrl('file:///Users/me/site/index.html')).toBe(
+      'file:///Users/me/site/index.html'
+    )
+  })
+
+  // Why: in-app preview is fine (sandboxed webview), but handing file:// to
+  // shell.openExternal would let a remote page drive Finder/Explorer to
+  // arbitrary paths. External-open paths must still refuse file://.
+  it('rejects file:// for external opens even though it is allowed in-app', () => {
+    expect(normalizeExternalBrowserUrl('file:///etc/passwd')).toBeNull()
   })
 
   it('returns null for non-URL input without search engine opt-in', () => {

--- a/src/shared/browser-url.ts
+++ b/src/shared/browser-url.ts
@@ -64,7 +64,18 @@ export function normalizeBrowserNavigationUrl(
 
   try {
     const parsed = new URL(trimmed)
-    return parsed.protocol === 'http:' || parsed.protocol === 'https:' ? parsed.toString() : null
+    // Why: file:// is allowed so the browser pane can render local files the
+    // user already has access to via the editor (e.g. "Open Preview to the
+    // Side" on an HTML file). The guest webview is still sandboxed
+    // (nodeIntegration off, contextIsolation on, webSecurity on; see
+    // createMainWindow.ts will-attach-webview), so the loaded page cannot
+    // escalate privileges. Other non-web schemes (javascript:, arbitrary
+    // data: URIs) remain rejected.
+    return parsed.protocol === 'http:' ||
+      parsed.protocol === 'https:' ||
+      parsed.protocol === 'file:'
+      ? parsed.toString()
+      : null
   } catch {
     // Why: search fallback is opt-in. The main process calls this function for
     // URL validation (will-attach-webview, will-navigate) where non-URL text
@@ -89,5 +100,15 @@ export function normalizeBrowserNavigationUrl(
 
 export function normalizeExternalBrowserUrl(rawUrl: string): string | null {
   const normalized = normalizeBrowserNavigationUrl(rawUrl)
-  return normalized === ORCA_BROWSER_BLANK_URL ? null : normalized
+  if (normalized === null || normalized === ORCA_BROWSER_BLANK_URL) {
+    return null
+  }
+  // Why: external-link opening (shell.openExternal, will-navigate) must only
+  // hand off http(s) targets to the OS. file:// is allowed for the in-app
+  // browser pane (local HTML preview), but forwarding it to openExternal
+  // would let a remote page smuggle arbitrary file paths into Finder/Explorer.
+  if (normalized.startsWith('file:')) {
+    return null
+  }
+  return normalized
 }


### PR DESCRIPTION
## Summary
- Adds an **Open Preview to the Side** button (Eye icon) to the editor title bar for HTML files. Clicking it renders the file in a browser pane in a right-split group via `file://`, mirroring VS Code's Markdown preview pattern.
- Wires preview support through a small helper (`openFilePreviewToSide`) so additional previewable languages can plug in later via `canPreviewLanguage`.
- Threads a `targetGroupId` option into `createBrowserTab` so the new tab lands in the split group (existing right sibling or a freshly-created right split), not the ambient active group.

## Security
- `normalizeBrowserNavigationUrl` now allows `file://` so the browser pane can load local files. The guest webview is sandboxed (`nodeIntegration` off, `contextIsolation` on, `webSecurity` on) — loaded HTML cannot escalate privileges beyond what the editor already grants.
- `normalizeExternalBrowserUrl` still rejects `file://` so a page cannot trick `shell.openExternal` into driving Finder/Explorer to arbitrary paths.
- `browser-manager`'s guest `will-navigate` guard rejects `file://` after initial attach — a remote page that loads first cannot redirect the guest to local files.

## Test plan
- [x] `pnpm vitest run` — all existing tests pass (only pre-existing unrelated `codex-accounts` flake)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] Manual (CDP): open `.html` in editor → Eye button appears in title bar → click → renders in right split via `file://`
- [x] Manual: button absent for `.ts` and `.md` files
- [x] Manual: re-clicking with an existing right sibling reuses it instead of creating another split