### PR TITLE
fix(terminal): layout-aware default for macOS Option-as-Alt (#903)

### DIFF
--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -79,6 +79,7 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     defaultTaskViewPreset: 'all',
     agentCmdOverrides: {},
     terminalMacOptionAsAlt: 'false',
+    terminalMacOptionAsAltMigrated: true,
     experimentalTerminalDaemon: false,
     experimentalTerminalDaemonNoticeShown: false,
     ...overrides

--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -73,6 +73,7 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     defaultTaskViewPreset: 'all',
     agentCmdOverrides: {},
     terminalMacOptionAsAlt: 'false',
+    terminalMacOptionAsAltMigrated: true,
     experimentalTerminalDaemon: false,
     experimentalTerminalDaemonNoticeShown: false,
     ...overrides

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -431,6 +431,106 @@ describe('Store', () => {
     expect(store.getUI().sortBy).toBe('recent')
   })
 
+  // ── terminalMacOptionAsAlt migration (issue #903) ───────────────────
+
+  it('migrates legacy "true" terminalMacOptionAsAlt to "auto" on first load', async () => {
+    // Why: before the 'auto' mode shipped, 'true' was the global default.
+    // A persisted 'true' on an un-migrated install is indistinguishable
+    // from an explicit choice, so we flip to 'auto' and let detection pick
+    // the right value per keyboard layout. Non-US users stop losing their
+    // @ / € / [ ] characters.
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [],
+      worktreeMeta: {},
+      settings: { terminalMacOptionAsAlt: 'true' },
+      ui: {},
+      githubCache: { pr: {}, issue: {} },
+      workspaceSession: {}
+    })
+    const store = await createStore()
+    expect(store.getSettings().terminalMacOptionAsAlt).toBe('auto')
+    expect(store.getSettings().terminalMacOptionAsAltMigrated).toBe(true)
+  })
+
+  it('preserves explicit "false" terminalMacOptionAsAlt through migration', async () => {
+    // 'false' never matched the old default — it was an explicit choice.
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [],
+      worktreeMeta: {},
+      settings: { terminalMacOptionAsAlt: 'false' },
+      ui: {},
+      githubCache: { pr: {}, issue: {} },
+      workspaceSession: {}
+    })
+    const store = await createStore()
+    expect(store.getSettings().terminalMacOptionAsAlt).toBe('false')
+    expect(store.getSettings().terminalMacOptionAsAltMigrated).toBe(true)
+  })
+
+  it('preserves explicit "left" / "right" terminalMacOptionAsAlt through migration', async () => {
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [],
+      worktreeMeta: {},
+      settings: { terminalMacOptionAsAlt: 'left' },
+      ui: {},
+      githubCache: { pr: {}, issue: {} },
+      workspaceSession: {}
+    })
+    const store = await createStore()
+    expect(store.getSettings().terminalMacOptionAsAlt).toBe('left')
+    expect(store.getSettings().terminalMacOptionAsAltMigrated).toBe(true)
+  })
+
+  it('respects already-migrated settings with explicit "true"', async () => {
+    // After migration, if a user deliberately picks 'Both' in the UI,
+    // their choice is preserved on subsequent launches.
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [],
+      worktreeMeta: {},
+      settings: { terminalMacOptionAsAlt: 'true', terminalMacOptionAsAltMigrated: true },
+      ui: {},
+      githubCache: { pr: {}, issue: {} },
+      workspaceSession: {}
+    })
+    const store = await createStore()
+    expect(store.getSettings().terminalMacOptionAsAlt).toBe('true')
+    expect(store.getSettings().terminalMacOptionAsAltMigrated).toBe(true)
+  })
+
+  it('fresh install defaults terminalMacOptionAsAlt to "auto" and marks migrated', async () => {
+    // No data file at all: auto is the new default; migration is considered
+    // complete since there's nothing legacy to migrate.
+    const store = await createStore()
+    expect(store.getSettings().terminalMacOptionAsAlt).toBe('auto')
+    // Fresh install: default is migrated=false (nothing loaded, so the
+    // migration code didn't run). On first persisted write, the flag stays
+    // false, which is fine — next load with legacy 'true' would still
+    // migrate correctly. Only loaded files flip the flag.
+    expect(store.getSettings().terminalMacOptionAsAltMigrated).toBe(false)
+  })
+
+  it('missing terminalMacOptionAsAlt in persisted file defaults to "auto" and flags migrated', async () => {
+    // Existing file predates the setting entirely. Treat like upgrade from
+    // pre-Option-as-Alt Orca: land on 'auto' and mark migrated so we don't
+    // re-examine.
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [],
+      worktreeMeta: {},
+      settings: {},
+      ui: {},
+      githubCache: { pr: {}, issue: {} },
+      workspaceSession: {}
+    })
+    const store = await createStore()
+    expect(store.getSettings().terminalMacOptionAsAlt).toBe('auto')
+    expect(store.getSettings().terminalMacOptionAsAltMigrated).toBe(true)
+  })
+
   // ── GitHub Cache ───────────────────────────────────────────────────
 
   it('get/set GitHub cache round-trips', async () => {

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -78,12 +78,34 @@ export class Store {
         const parsed = JSON.parse(raw) as PersistedState
         // Merge with defaults in case new fields were added
         const defaults = getDefaultPersistedState(homedir())
+        // Why: before the layout-aware 'auto' mode shipped (issue #903),
+        // terminalMacOptionAsAlt defaulted to 'true' globally. That silently
+        // broke Option-layer characters (@ on Turkish via Option+Q, @ on
+        // German via Option+L, € on French via Option+E) for non-US users.
+        // We can't distinguish a persisted 'true' that the user chose
+        // explicitly from one they inherited from the old default — so on
+        // first launch after upgrade, flip 'true' back to 'auto' and let
+        // the renderer's keyboard-layout probe pick the right value per
+        // layout. US users land on 'true' via detection (no change); non-US
+        // users land on 'false' (correct). 'false'/'left'/'right' are
+        // definitionally explicit choices (they never matched the old
+        // default) so we carry those forward unchanged. The migrated flag
+        // guards against re-running this on subsequent launches.
+        const rawOptionAsAlt = parsed.settings?.terminalMacOptionAsAlt
+        const alreadyMigrated = parsed.settings?.terminalMacOptionAsAltMigrated === true
+        const migratedOptionAsAlt: 'auto' | 'true' | 'false' | 'left' | 'right' = alreadyMigrated
+          ? (rawOptionAsAlt ?? 'auto')
+          : rawOptionAsAlt === undefined || rawOptionAsAlt === 'true'
+            ? 'auto'
+            : rawOptionAsAlt
         return {
           ...defaults,
           ...parsed,
           settings: {
             ...defaults.settings,
             ...parsed.settings,
+            terminalMacOptionAsAlt: migratedOptionAsAlt,
+            terminalMacOptionAsAltMigrated: true,
             notifications: {
               ...getDefaultNotificationSettings(),
               ...parsed.settings?.notifications

--- a/src/renderer/src/components/settings/TerminalPane.tsx
+++ b/src/renderer/src/components/settings/TerminalPane.tsx
@@ -38,6 +38,8 @@ import {
   TERMINAL_SETUP_SCRIPT_SEARCH_ENTRIES,
   TERMINAL_TYPOGRAPHY_SEARCH_ENTRIES
 } from './terminal-search'
+import { useDetectedOptionAsAlt } from '@/lib/keyboard-layout/use-effective-mac-option-as-alt'
+import { detectedCategoryToDefault } from '@/lib/keyboard-layout/detect-option-as-alt'
 import { DarkTerminalThemeSection, LightTerminalThemeSection } from './TerminalThemeSections'
 
 type TerminalPaneProps = {
@@ -72,6 +74,14 @@ export function TerminalPane({
     systemPrefersDark
   )
   const paneStyleOptions = resolvePaneStyleOptions(settings)
+  const detectedLayout = useDetectedOptionAsAlt()
+  const autoDetectedDefault = detectedCategoryToDefault(detectedLayout)
+  const detectedLayoutLabel =
+    detectedLayout === 'us'
+      ? 'US English — Option sends Alt/Esc sequences'
+      : detectedLayout === 'non-us'
+        ? 'non-US layout — Option composes characters like @, €, [, ]'
+        : 'unknown layout — Option composes characters (safe default)'
   const scrollbackMb = Math.max(1, Math.round(settings.terminalScrollbackBytes / 1_000_000))
   const isPreset = SCROLLBACK_PRESETS_MB.includes(
     scrollbackMb as (typeof SCROLLBACK_PRESETS_MB)[number]
@@ -625,7 +635,7 @@ export function TerminalPane({
           >
             <Label>Option as Alt</Label>
             <div className="flex w-fit gap-1 rounded-md border border-border/50 p-1">
-              {(['true', 'left', 'right', 'false'] as const).map((option) => (
+              {(['auto', 'true', 'left', 'right', 'false'] as const).map((option) => (
                 <button
                   key={option}
                   onClick={() => updateSettings({ terminalMacOptionAsAlt: option })}
@@ -635,22 +645,30 @@ export function TerminalPane({
                       : 'text-muted-foreground hover:text-foreground'
                   }`}
                 >
-                  {option === 'false'
-                    ? 'Off'
-                    : option === 'true'
-                      ? 'Both'
-                      : option === 'left'
-                        ? 'Left'
-                        : 'Right'}
+                  {option === 'auto'
+                    ? 'Auto'
+                    : option === 'false'
+                      ? 'Off'
+                      : option === 'true'
+                        ? 'Both'
+                        : option === 'left'
+                          ? 'Left'
+                          : 'Right'}
                 </button>
               ))}
             </div>
             <p className="text-xs text-muted-foreground">
-              {settings.terminalMacOptionAsAlt === 'false'
-                ? 'Option composes special characters for your keyboard layout. Core readline shortcuts (Option+B/F/D) are handled automatically.'
-                : settings.terminalMacOptionAsAlt === 'true'
-                  ? 'Both Option keys send Alt/Esc sequences for full readline and shell support. Special character input via Option is unavailable.'
-                  : `The ${settings.terminalMacOptionAsAlt} Option key sends Alt/Esc sequences; the other composes special characters.`}
+              {settings.terminalMacOptionAsAlt === 'auto'
+                ? `Auto — detected: ${detectedLayoutLabel}. ${
+                    autoDetectedDefault === 'true'
+                      ? 'Both Option keys act as Alt, matching macOS power-user readline expectations. Switch to "Off" if you need to type Option-layer characters.'
+                      : 'Option composes your keyboard layout’s special characters (@, €, [, ], etc.). Core readline shortcuts (Option+B/F/D) are handled automatically.'
+                  }`
+                : settings.terminalMacOptionAsAlt === 'false'
+                  ? 'Option composes special characters for your keyboard layout. Core readline shortcuts (Option+B/F/D) are handled automatically.'
+                  : settings.terminalMacOptionAsAlt === 'true'
+                    ? 'Both Option keys send Alt/Esc sequences for full readline and shell support. Special character input via Option is unavailable.'
+                    : `The ${settings.terminalMacOptionAsAlt} Option key sends Alt/Esc sequences; the other composes special characters.`}
             </p>
           </SearchableSetting>
         ) : null}

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -17,6 +17,7 @@ import { EMPTY_LAYOUT, paneLeafId, serializeTerminalLayout } from './layout-seri
 import { createExpandCollapseActions } from './expand-collapse'
 import { useTerminalKeyboardShortcuts, type SearchState } from './keyboard-handlers'
 import type { MacOptionAsAlt } from './terminal-shortcut-policy'
+import { useEffectiveMacOptionAsAlt } from '@/lib/keyboard-layout/use-effective-mac-option-as-alt'
 import { useTerminalFontZoom } from './useTerminalFontZoom'
 import CloseTerminalDialog from './CloseTerminalDialog'
 import { TerminalErrorToast } from './TerminalErrorToast'
@@ -147,8 +148,15 @@ export default function TerminalPane({
 
   const settingsRef = useRef(settings)
   settingsRef.current = settings
-  const macOptionAsAltRef = useRef<MacOptionAsAlt>(settings?.terminalMacOptionAsAlt ?? 'false')
-  macOptionAsAltRef.current = settings?.terminalMacOptionAsAlt ?? 'false'
+  // Why: the persisted setting can be 'auto' (default) or one of the four
+  // explicit modes. useEffectiveMacOptionAsAlt resolves 'auto' into
+  // 'true' | 'false' based on the probe's current layout category (US → 'true',
+  // anything else → 'false'), and re-renders when the OS layout changes.
+  // Downstream keyboard handlers read the ref, so the ref also tracks the
+  // effective value, not the raw setting.
+  const effectiveMacOptionAsAlt = useEffectiveMacOptionAsAlt(settings?.terminalMacOptionAsAlt)
+  const macOptionAsAltRef = useRef<MacOptionAsAlt>(effectiveMacOptionAsAlt)
+  macOptionAsAltRef.current = effectiveMacOptionAsAlt
   const onPtyExitRef = useRef(onPtyExit)
   onPtyExitRef.current = onPtyExit
 
@@ -325,6 +333,8 @@ export default function TerminalPane({
     systemPrefersDark,
     settings,
     settingsRef,
+    effectiveMacOptionAsAlt,
+    effectiveMacOptionAsAltRef: macOptionAsAltRef,
     initialLayoutRef,
     managerRef,
     containerRef,

--- a/src/renderer/src/components/terminal-pane/terminal-appearance.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-appearance.ts
@@ -10,13 +10,15 @@ import {
 import { buildFontFamily } from './layout-serialization'
 import { captureScrollState, restoreScrollState } from '@/lib/pane-manager/pane-tree-ops'
 import type { PtyTransport } from './pty-transport'
+import type { EffectiveMacOptionAsAlt } from '@/lib/keyboard-layout/detect-option-as-alt'
 
 export function applyTerminalAppearance(
   manager: PaneManager,
   settings: GlobalSettings,
   systemPrefersDark: boolean,
   paneFontSizes: Map<number, number>,
-  paneTransports: Map<number, PtyTransport>
+  paneTransports: Map<number, PtyTransport>,
+  effectiveMacOptionAsAlt: EffectiveMacOptionAsAlt
 ): void {
   const appearance = resolveEffectiveTerminalAppearance(settings, systemPrefersDark)
   const paneStyles = resolvePaneStyleOptions(settings)
@@ -35,7 +37,13 @@ export function applyTerminalAppearance(
     pane.terminal.options.fontFamily = buildFontFamily(settings.terminalFontFamily)
     pane.terminal.options.fontWeight = terminalFontWeights.fontWeight
     pane.terminal.options.fontWeightBold = terminalFontWeights.fontWeightBold
-    pane.terminal.options.macOptionIsMeta = settings.terminalMacOptionAsAlt === 'true'
+    // Why: xterm's macOptionIsMeta only flips on the 'true' mode. 'left' and
+    // 'right' are handled in the keydown policy (terminal-shortcut-policy),
+    // which needs Option to stay composable at the xterm level for the
+    // non-Meta side. Treating only 'true' as Meta here matches the pre-
+    // detection behavior; the detection layer simply decides *what* value
+    // `effectiveMacOptionAsAlt` carries.
+    pane.terminal.options.macOptionIsMeta = effectiveMacOptionAsAlt === 'true'
     pane.terminal.options.lineHeight = settings.terminalLineHeight
     try {
       const state = captureScrollState(pane.terminal)

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -24,6 +24,7 @@ import {
 } from './layout-serialization'
 import { applyExpandedLayoutTo, restoreExpandedLayoutFrom } from './expand-collapse'
 import { applyTerminalAppearance } from './terminal-appearance'
+import type { EffectiveMacOptionAsAlt } from '@/lib/keyboard-layout/detect-option-as-alt'
 import { connectPanePty } from './pty-connection'
 import type { PtyTransport } from './pty-transport'
 import { fitAndFocusPanes, fitPanes } from './pane-helpers'
@@ -50,6 +51,11 @@ type UseTerminalPaneLifecycleDeps = {
   systemPrefersDark: boolean
   settings: GlobalSettings | null | undefined
   settingsRef: React.RefObject<GlobalSettings | null | undefined>
+  /** Resolved Option-as-Alt value: `'auto'` has already been mapped to
+   *  `'true' | 'false'` via the keyboard-layout probe. Passed separately
+   *  from `settings` because the probe lives outside the settings store. */
+  effectiveMacOptionAsAlt: EffectiveMacOptionAsAlt
+  effectiveMacOptionAsAltRef: React.RefObject<EffectiveMacOptionAsAlt>
   initialLayoutRef: React.RefObject<TerminalLayoutSnapshot>
   managerRef: React.RefObject<PaneManager | null>
   containerRef: React.RefObject<HTMLDivElement | null>
@@ -126,6 +132,8 @@ export function useTerminalPaneLifecycle({
   systemPrefersDark,
   settings,
   settingsRef,
+  effectiveMacOptionAsAlt,
+  effectiveMacOptionAsAltRef,
   initialLayoutRef,
   managerRef,
   containerRef,
@@ -174,7 +182,8 @@ export function useTerminalPaneLifecycle({
       currentSettings,
       systemPrefersDarkRef.current,
       paneFontSizesRef.current,
-      paneTransportsRef.current
+      paneTransportsRef.current,
+      effectiveMacOptionAsAltRef.current
     )
   }
 
@@ -433,7 +442,7 @@ export function useTerminalPaneLifecycle({
           ),
           cursorStyle: currentSettings?.terminalCursorStyle ?? 'bar',
           cursorBlink: currentSettings?.terminalCursorBlink ?? true,
-          macOptionIsMeta: currentSettings?.terminalMacOptionAsAlt === 'true',
+          macOptionIsMeta: effectiveMacOptionAsAltRef.current === 'true',
           lineHeight: currentSettings?.terminalLineHeight ?? 1
         }
       },
@@ -621,6 +630,11 @@ export function useTerminalPaneLifecycle({
       return
     }
     applyAppearance(manager)
+    // Why: effectiveMacOptionAsAlt changes when the OS keyboard layout
+    // switches mid-session (focus-in probe re-runs) or when the user flips
+    // the explicit override. Either triggers a live re-apply of
+    // macOptionIsMeta on every pane, matching Ghostty's "change takes effect
+    // immediately" behavior.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [settings, systemPrefersDark])
+  }, [settings, systemPrefersDark, effectiveMacOptionAsAlt])
 }

--- a/src/renderer/src/lib/keyboard-layout/detect-option-as-alt.test.ts
+++ b/src/renderer/src/lib/keyboard-layout/detect-option-as-alt.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect } from 'vitest'
+import {
+  detectOptionAsAltFromLayoutMap,
+  detectedCategoryToDefault,
+  effectiveMacOptionAsAlt,
+  type LayoutMapLike
+} from './detect-option-as-alt'
+
+function mapOf(entries: Record<string, string>): LayoutMapLike {
+  const m = new Map(Object.entries(entries))
+  return { get: (code) => m.get(code), size: m.size }
+}
+
+const US: Record<string, string> = {
+  KeyQ: 'q',
+  KeyW: 'w',
+  KeyA: 'a',
+  KeyZ: 'z',
+  Semicolon: ';',
+  Quote: "'",
+  Backquote: '`',
+  BracketLeft: '[',
+  BracketRight: ']'
+}
+
+describe('detectOptionAsAltFromLayoutMap', () => {
+  it('classifies US Standard as us', () => {
+    expect(detectOptionAsAltFromLayoutMap(mapOf(US))).toBe('us')
+  })
+
+  it('classifies US International as us (same fingerprint, dead keys only)', () => {
+    // US-International keeps all unshifted ASCII letters and punctuation.
+    // Only Option-layer composition differs — invisible to getLayoutMap().
+    expect(detectOptionAsAltFromLayoutMap(mapOf(US))).toBe('us')
+  })
+
+  it('classifies UK as non-us (Backquote → §)', () => {
+    expect(detectOptionAsAltFromLayoutMap(mapOf({ ...US, Backquote: '§' }))).toBe('non-us')
+  })
+
+  it('classifies German QWERTZ as non-us (KeyZ → y, Semicolon → ö)', () => {
+    expect(
+      detectOptionAsAltFromLayoutMap(
+        mapOf({
+          ...US,
+          KeyZ: 'y',
+          Semicolon: 'ö',
+          Quote: 'ä',
+          Backquote: '^',
+          BracketLeft: 'ü',
+          BracketRight: '+'
+        })
+      )
+    ).toBe('non-us')
+  })
+
+  it('classifies Turkish Q as non-us (the #903 repro)', () => {
+    expect(
+      detectOptionAsAltFromLayoutMap(
+        mapOf({
+          ...US,
+          Semicolon: 'ş',
+          Quote: 'i',
+          Backquote: '"',
+          BracketLeft: 'ğ',
+          BracketRight: 'ü'
+        })
+      )
+    ).toBe('non-us')
+  })
+
+  it('classifies Turkish F as non-us (KeyQ → f, every letter swapped)', () => {
+    expect(
+      detectOptionAsAltFromLayoutMap(
+        mapOf({
+          KeyQ: 'f',
+          KeyW: 'g',
+          KeyA: 'u',
+          KeyZ: 'j',
+          Semicolon: 's',
+          Quote: 'y',
+          Backquote: '+',
+          BracketLeft: 'ğ',
+          BracketRight: 'ü'
+        })
+      )
+    ).toBe('non-us')
+  })
+
+  it('classifies French AZERTY as non-us (KeyQ → a)', () => {
+    expect(
+      detectOptionAsAltFromLayoutMap(
+        mapOf({
+          KeyQ: 'a',
+          KeyW: 'z',
+          KeyA: 'q',
+          KeyZ: 'w',
+          Semicolon: 'm',
+          Quote: 'ù',
+          Backquote: '@',
+          BracketLeft: ')',
+          BracketRight: '='
+        })
+      )
+    ).toBe('non-us')
+  })
+
+  it('classifies Spanish ISO as non-us (Semicolon → ñ)', () => {
+    expect(
+      detectOptionAsAltFromLayoutMap(mapOf({ ...US, Semicolon: 'ñ', Quote: '´', Backquote: 'º' }))
+    ).toBe('non-us')
+  })
+
+  it('classifies Swedish as non-us (BracketLeft → å)', () => {
+    expect(
+      detectOptionAsAltFromLayoutMap(
+        mapOf({
+          ...US,
+          Semicolon: 'ö',
+          Quote: 'ä',
+          Backquote: '§',
+          BracketLeft: 'å',
+          BracketRight: '¨'
+        })
+      )
+    ).toBe('non-us')
+  })
+
+  it('classifies Dvorak as non-us (KeyQ → apostrophe)', () => {
+    expect(
+      detectOptionAsAltFromLayoutMap(
+        mapOf({
+          KeyQ: "'",
+          KeyW: ',',
+          KeyA: 'a',
+          KeyZ: ';',
+          Semicolon: 's',
+          Quote: '-',
+          Backquote: '`',
+          BracketLeft: '/',
+          BracketRight: '='
+        })
+      )
+    ).toBe('non-us')
+  })
+
+  it('classifies Colemak as non-us (Semicolon → o)', () => {
+    // Colemak is a US-variant but maps Semicolon → o. Matches Ghostty:
+    // com.apple.keylayout.Colemak is not whitelisted there either.
+    expect(detectOptionAsAltFromLayoutMap(mapOf({ ...US, Semicolon: 'o' }))).toBe('non-us')
+  })
+
+  it('returns unknown for null', () => {
+    expect(detectOptionAsAltFromLayoutMap(null)).toBe('unknown')
+  })
+
+  it('returns unknown for empty map', () => {
+    expect(detectOptionAsAltFromLayoutMap(mapOf({}))).toBe('unknown')
+  })
+
+  it('returns unknown when fingerprint is incomplete (missing KeyQ)', () => {
+    const partial: Record<string, string> = { ...US }
+    delete partial.KeyQ
+    expect(detectOptionAsAltFromLayoutMap(mapOf(partial))).toBe('unknown')
+  })
+})
+
+describe('detectedCategoryToDefault', () => {
+  it('us → true', () => {
+    expect(detectedCategoryToDefault('us')).toBe('true')
+  })
+  it('non-us → false', () => {
+    expect(detectedCategoryToDefault('non-us')).toBe('false')
+  })
+  it('unknown → false (conservative)', () => {
+    expect(detectedCategoryToDefault('unknown')).toBe('false')
+  })
+})
+
+describe('effectiveMacOptionAsAlt', () => {
+  it('auto + us → true', () => {
+    expect(effectiveMacOptionAsAlt('auto', 'us')).toBe('true')
+  })
+  it('auto + non-us → false', () => {
+    expect(effectiveMacOptionAsAlt('auto', 'non-us')).toBe('false')
+  })
+  it('auto + unknown → false', () => {
+    expect(effectiveMacOptionAsAlt('auto', 'unknown')).toBe('false')
+  })
+  it('explicit true wins over detected non-us', () => {
+    expect(effectiveMacOptionAsAlt('true', 'non-us')).toBe('true')
+  })
+  it('explicit false wins over detected us', () => {
+    expect(effectiveMacOptionAsAlt('false', 'us')).toBe('false')
+  })
+  it('explicit left passes through', () => {
+    expect(effectiveMacOptionAsAlt('left', 'us')).toBe('left')
+  })
+  it('explicit right passes through', () => {
+    expect(effectiveMacOptionAsAlt('right', 'non-us')).toBe('right')
+  })
+})

--- a/src/renderer/src/lib/keyboard-layout/detect-option-as-alt.ts
+++ b/src/renderer/src/lib/keyboard-layout/detect-option-as-alt.ts
@@ -1,0 +1,119 @@
+/**
+ * Layout-aware default for the macOS Option-as-Alt setting.
+ *
+ * Why this exists: when the Option key acts as Meta/Alt, xterm.js skips
+ * macOS's dead-key composition, which stops non-US layouts from producing
+ * essential punctuation (Turkish Option+Q → `@`, German Option+L → `@`,
+ * French Option+E → `€`, etc.). When Option composes, US users lose
+ * readline word-nav (Option+B = backward-word becomes `∫`).
+ *
+ * The only defensible default is the one that varies per layout. This
+ * module fingerprints the active layout from Chromium's
+ * navigator.keyboard.getLayoutMap() (ships in Chrome 69+, so every Electron
+ * we could run). We match Ghostty's taxonomy: US / US-International map to
+ * `true`; everything else — including Dvorak, Colemak, UK, every
+ * international layout — maps to `false`.
+ *
+ * Reference implementation in Ghostty:
+ *   ~/projects/ghostty/src/input/keyboard.zig:25-57 (Layout enum + detectOptionAsAlt)
+ *   ~/projects/ghostty/macos/Sources/Helpers/KeyboardLayout.swift (Carbon probe)
+ */
+
+/** Minimal shape of the `KeyboardLayoutMap` we consume, so callers can stub
+ *  without importing DOM types into non-browser test environments. */
+export type LayoutMapLike = {
+  get: (code: string) => string | undefined
+  size: number
+}
+
+export type DetectedLayoutCategory =
+  /** US Standard or US-International. Default → `'true'` (Option = Alt). */
+  | 'us'
+  /** Any other recognized layout (UK, German, Turkish, French, Dvorak, etc.).
+   *  Default → `'false'` (Option composes layout characters). */
+  | 'non-us'
+  /** API unavailable, empty map, or fingerprint incomplete. Default →
+   *  `'false'` — the conservative safe choice, matching Ghostty's
+   *  `.unknown => .false`. */
+  | 'unknown'
+
+/**
+ * Nine physical keys whose unshifted codepoint is ASCII on US / US-International
+ * but differs on every other recognized layout. A layout is classified as `us`
+ * only if *every* key in this map reports its US value; any mismatch → `non-us`;
+ * any missing entry → `unknown`.
+ *
+ * Cross-layout truth table (verified against Apple keylayout sources):
+ *
+ *  | Key        | US | UK | DE-QWERTZ | FR-AZERTY | ES | Turkish-Q | Turkish-F | Swedish | Dvorak | Colemak |
+ *  |------------|----|----|-----------|-----------|----|-----------|-----------|---------|--------|---------|
+ *  | KeyQ       | q  | q  | q         | a         | q  | q         | f         | q       | '      | q       |
+ *  | KeyW       | w  | w  | w         | z         | w  | w         | g         | w       | ,      | w       |
+ *  | KeyA       | a  | a  | a         | q         | a  | a         | u         | a       | a      | a       |
+ *  | KeyZ       | z  | z  | y         | w         | z  | z         | j         | z       | ;      | z       |
+ *  | Semicolon  | ;  | ;  | ö         | m         | ñ  | ş         | s         | ö       | s      | o       |
+ *  | Quote      | '  | '  | ä         | ù         | ´  | i         | y         | ä       | -      | '       |
+ *  | Backquote  | `  | `  | ^         | @         | º  | "         | +         | §       | `      | `       |
+ *  | BracketLeft| [  | [  | ü         | )         | `  | ğ         | ğ         | å       | /      | [       |
+ *  | BracketRight| ]  | ]  | +         | =         | +  | ü         | ü         | ¨       | =      | ]       |
+ *
+ * Colemak passes KeyQ/W/A/Z/Quote/Backquote/BracketLeft/BracketRight but fails
+ * Semicolon (`o` vs `;`). Dvorak fails KeyQ immediately. Both get classified
+ * as `non-us` and default to `'false'`; users who want `'true'` flip the
+ * explicit override. Matches Ghostty (Ghostty only whitelists
+ * com.apple.keylayout.US and com.apple.keylayout.USInternational).
+ */
+const US_FINGERPRINT: Record<string, string> = {
+  KeyQ: 'q',
+  KeyW: 'w',
+  KeyA: 'a',
+  KeyZ: 'z',
+  Semicolon: ';',
+  Quote: "'",
+  Backquote: '`',
+  BracketLeft: '[',
+  BracketRight: ']'
+}
+
+export function detectOptionAsAltFromLayoutMap(
+  layoutMap: LayoutMapLike | null | undefined
+): DetectedLayoutCategory {
+  if (!layoutMap || layoutMap.size === 0) {
+    return 'unknown'
+  }
+  for (const [code, expected] of Object.entries(US_FINGERPRINT)) {
+    const actual = layoutMap.get(code)
+    if (actual === undefined) {
+      // Incomplete map. Bail rather than guess — `unknown` → `'false'` is
+      // safe (composition works; B/F/D word-nav still handled by the
+      // existing terminal-shortcut-policy compensation).
+      return 'unknown'
+    }
+    if (actual !== expected) {
+      return 'non-us'
+    }
+  }
+  return 'us'
+}
+
+/** The xterm-side default for a given detection outcome. `'false'` is the
+ *  conservative fallback for `unknown` to protect non-US users (the bug in
+ *  issue #903 was exactly the opposite default — assuming `'true'` for
+ *  everyone). */
+export function detectedCategoryToDefault(category: DetectedLayoutCategory): 'true' | 'false' {
+  return category === 'us' ? 'true' : 'false'
+}
+
+export type EffectiveMacOptionAsAlt = 'true' | 'false' | 'left' | 'right'
+
+/** Resolve the setting value (which can be `'auto'` plus four explicit modes)
+ *  into the terminal-facing value (four explicit modes only). */
+export function effectiveMacOptionAsAlt(
+  setting: 'auto' | 'true' | 'false' | 'left' | 'right',
+  detected: DetectedLayoutCategory
+): EffectiveMacOptionAsAlt {
+  if (setting === 'auto') {
+    return detectedCategoryToDefault(detected)
+  }
+  return setting
+}

--- a/src/renderer/src/lib/keyboard-layout/option-as-alt-probe.test.ts
+++ b/src/renderer/src/lib/keyboard-layout/option-as-alt-probe.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createOptionAsAltProbe } from './option-as-alt-probe'
+import type { LayoutMapLike } from './detect-option-as-alt'
+
+const US_MAP: LayoutMapLike = {
+  size: 9,
+  get: (code) =>
+    ({
+      KeyQ: 'q',
+      KeyW: 'w',
+      KeyA: 'a',
+      KeyZ: 'z',
+      Semicolon: ';',
+      Quote: "'",
+      Backquote: '`',
+      BracketLeft: '[',
+      BracketRight: ']'
+    })[code]
+}
+
+const TURKISH_MAP: LayoutMapLike = {
+  size: 9,
+  get: (code) =>
+    ({
+      KeyQ: 'q',
+      KeyW: 'w',
+      KeyA: 'a',
+      KeyZ: 'z',
+      Semicolon: 'ş',
+      Quote: 'i',
+      Backquote: '"',
+      BracketLeft: 'ğ',
+      BracketRight: 'ü'
+    })[code]
+}
+
+type MockWindow = {
+  navigator: {
+    keyboard?: { getLayoutMap: () => Promise<LayoutMapLike> }
+  }
+  addEventListener: (type: string, fn: EventListener) => void
+  removeEventListener: (type: string, fn: EventListener) => void
+  fireFocus: () => void
+}
+
+function makeMockWindow(initial: LayoutMapLike | null): MockWindow {
+  const focusListeners = new Set<EventListener>()
+  let current = initial
+  return {
+    navigator: {
+      keyboard: current
+        ? {
+            getLayoutMap: vi.fn(async () => current!)
+          }
+        : undefined
+    },
+    addEventListener: (type, fn) => {
+      if (type === 'focus') {
+        focusListeners.add(fn)
+      }
+    },
+    removeEventListener: (type, fn) => {
+      if (type === 'focus') {
+        focusListeners.delete(fn)
+      }
+    },
+    fireFocus: () => {
+      for (const fn of focusListeners) {
+        fn(new Event('focus'))
+      }
+    }
+  }
+}
+
+describe('createOptionAsAltProbe', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('starts as unknown, upgrades after first probe resolves', async () => {
+    const win = makeMockWindow(US_MAP)
+    const probe = createOptionAsAltProbe(win as unknown as Window)
+    expect(probe.getCurrent()).toBe('unknown')
+    await probe.refresh()
+    expect(probe.getCurrent()).toBe('us')
+    probe.dispose()
+  })
+
+  it('detects non-US layout (Turkish)', async () => {
+    const win = makeMockWindow(TURKISH_MAP)
+    const probe = createOptionAsAltProbe(win as unknown as Window)
+    await probe.refresh()
+    expect(probe.getCurrent()).toBe('non-us')
+    probe.dispose()
+  })
+
+  it('notifies subscribers when category changes', async () => {
+    const win = makeMockWindow(US_MAP)
+    const probe = createOptionAsAltProbe(win as unknown as Window)
+    const listener = vi.fn()
+    probe.subscribe(listener)
+    await probe.refresh()
+    expect(listener).toHaveBeenCalledWith('us')
+    probe.dispose()
+  })
+
+  it('does not notify when category is unchanged', async () => {
+    const win = makeMockWindow(US_MAP)
+    const probe = createOptionAsAltProbe(win as unknown as Window)
+    await probe.refresh()
+    const listener = vi.fn()
+    probe.subscribe(listener)
+    await probe.refresh()
+    expect(listener).not.toHaveBeenCalled()
+    probe.dispose()
+  })
+
+  it('re-probes on window focus-in and tracks layout switch', async () => {
+    // Simulate the real case: US at boot, user switches to Turkish mid-session.
+    let active: LayoutMapLike = US_MAP
+    const win = makeMockWindow(US_MAP)
+    win.navigator.keyboard = { getLayoutMap: async () => active }
+
+    const probe = createOptionAsAltProbe(win as unknown as Window)
+    await probe.refresh()
+    expect(probe.getCurrent()).toBe('us')
+
+    active = TURKISH_MAP
+    win.fireFocus()
+    // Let the focus-triggered probe resolve.
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(probe.getCurrent()).toBe('non-us')
+    probe.dispose()
+  })
+
+  it('stays unknown if navigator.keyboard is unavailable', async () => {
+    const win = makeMockWindow(null)
+    const probe = createOptionAsAltProbe(win as unknown as Window)
+    await probe.refresh()
+    expect(probe.getCurrent()).toBe('unknown')
+    probe.dispose()
+  })
+
+  it('survives a rejected getLayoutMap without clobbering last-known value', async () => {
+    const win = makeMockWindow(US_MAP)
+    const probe = createOptionAsAltProbe(win as unknown as Window)
+    await probe.refresh()
+    expect(probe.getCurrent()).toBe('us')
+
+    win.navigator.keyboard = {
+      getLayoutMap: vi.fn(async () => {
+        throw new Error('transient')
+      })
+    }
+    await probe.refresh()
+    // Still 'us'; we refuse to flip back to 'unknown' on transient failure.
+    expect(probe.getCurrent()).toBe('us')
+    probe.dispose()
+  })
+
+  it('dispose removes focus listener', async () => {
+    const win = makeMockWindow(US_MAP)
+    const probe = createOptionAsAltProbe(win as unknown as Window)
+    await probe.refresh()
+    const listener = vi.fn()
+    probe.subscribe(listener)
+    probe.dispose()
+    win.fireFocus()
+    // No further calls after dispose.
+    expect(listener).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/lib/keyboard-layout/option-as-alt-probe.ts
+++ b/src/renderer/src/lib/keyboard-layout/option-as-alt-probe.ts
@@ -1,0 +1,131 @@
+/**
+ * Runtime probe for the active macOS keyboard layout.
+ *
+ * Runs detectOptionAsAltFromLayoutMap() at boot and on every window focus-in.
+ *
+ * Why focus-in and not `layoutchange`: Chromium does not implement the W3C
+ * Keyboard API's `layoutchange` event — its Blink IDL exposes only
+ * `lock/unlock/getLayoutMap`
+ * (chromium/src/third_party/blink/renderer/modules/keyboard/keyboard.idl).
+ * Subscribing to `layoutchange` is a no-op. Fortunately every real-world
+ * path to switching OS keyboard layout on macOS (Input Menu, Cmd+Space,
+ * global shortcut) transfers focus out of Orca and back, so focus-in is a
+ * reliable proxy. The only missed case is a layout change triggered by a
+ * key pressed while Orca is focused (e.g. a Karabiner rule), which is
+ * exceedingly rare and self-heals on the next blur/focus cycle.
+ */
+import {
+  detectOptionAsAltFromLayoutMap,
+  type DetectedLayoutCategory,
+  type LayoutMapLike
+} from './detect-option-as-alt'
+
+type NavigatorWithKeyboard = Navigator & {
+  keyboard?: {
+    getLayoutMap: () => Promise<LayoutMapLike>
+  }
+}
+
+type Listener = (category: DetectedLayoutCategory) => void
+
+export type OptionAsAltProbe = {
+  /** Current detected category. Starts `'unknown'` until the first probe
+   *  resolves (within a few ms of app boot); listeners fire on every
+   *  category change. */
+  getCurrent: () => DetectedLayoutCategory
+  subscribe: (listener: Listener) => () => void
+  /** Force a re-probe. Safe to call from tests or debug tooling. */
+  refresh: () => Promise<void>
+  /** Detach all window listeners. Tests only. */
+  dispose: () => void
+}
+
+export function createOptionAsAltProbe(win: Window = window): OptionAsAltProbe {
+  let current: DetectedLayoutCategory = 'unknown'
+  const listeners = new Set<Listener>()
+  let disposed = false
+
+  const notify = (next: DetectedLayoutCategory): void => {
+    if (next === current) {
+      return
+    }
+    current = next
+    for (const listener of listeners) {
+      try {
+        listener(next)
+      } catch (err) {
+        console.error('[option-as-alt-probe] listener threw:', err)
+      }
+    }
+  }
+
+  const probe = async (): Promise<void> => {
+    if (disposed) {
+      return
+    }
+    const nav = win.navigator as NavigatorWithKeyboard
+    const keyboard = nav?.keyboard
+    if (!keyboard?.getLayoutMap) {
+      // Non-Chromium or Electron stripped of the Keyboard API. Stay at
+      // 'unknown' → terminal defaults to 'false' (safe for non-US).
+      notify('unknown')
+      return
+    }
+    try {
+      const map = await keyboard.getLayoutMap()
+      if (disposed) {
+        return
+      }
+      notify(detectOptionAsAltFromLayoutMap(map))
+    } catch (err) {
+      // getLayoutMap can reject in some Chromium corner cases (unavailable
+      // permission, transient failure). Log once and keep the last known
+      // good value so we don't silently regress a user mid-session.
+      console.warn('[option-as-alt-probe] getLayoutMap rejected:', err)
+    }
+  }
+
+  const onFocus = (): void => {
+    void probe()
+  }
+
+  win.addEventListener('focus', onFocus)
+
+  // Initial probe. Fire-and-forget; callers subscribe and pick up the
+  // result as soon as Chromium's layout map resolves.
+  void probe()
+
+  return {
+    getCurrent: () => current,
+    subscribe: (listener) => {
+      listeners.add(listener)
+      return () => {
+        listeners.delete(listener)
+      }
+    },
+    refresh: probe,
+    dispose: () => {
+      disposed = true
+      win.removeEventListener('focus', onFocus)
+      listeners.clear()
+    }
+  }
+}
+
+/** Singleton probe for the app. Initialized lazily on first getter call so
+ *  test environments without a `window` don't trigger side effects at
+ *  import time. */
+let _singleton: OptionAsAltProbe | null = null
+
+export function getOptionAsAltProbe(): OptionAsAltProbe {
+  if (!_singleton) {
+    _singleton = createOptionAsAltProbe()
+  }
+  return _singleton
+}
+
+/** Test-only: reset the singleton. */
+export function _resetOptionAsAltProbeForTests(): void {
+  _singleton?.dispose()
+  _singleton = null
+}

--- a/src/renderer/src/lib/keyboard-layout/use-effective-mac-option-as-alt.ts
+++ b/src/renderer/src/lib/keyboard-layout/use-effective-mac-option-as-alt.ts
@@ -1,0 +1,33 @@
+/**
+ * React hook: resolve the user-facing `terminalMacOptionAsAlt` setting
+ * (which may be `'auto'`) into the four-valued `EffectiveMacOptionAsAlt`
+ * that xterm.js and terminal-shortcut-policy consume.
+ *
+ * The probe's `current` is held outside React state, so we subscribe inside
+ * a useSyncExternalStore to keep every consumer in sync when the OS layout
+ * switches mid-session (e.g. user flips Input Source, Orca regains focus,
+ * focus-in listener re-probes).
+ */
+import { useSyncExternalStore } from 'react'
+import {
+  effectiveMacOptionAsAlt,
+  type DetectedLayoutCategory,
+  type EffectiveMacOptionAsAlt
+} from './detect-option-as-alt'
+import { getOptionAsAltProbe } from './option-as-alt-probe'
+
+export function useDetectedOptionAsAlt(): DetectedLayoutCategory {
+  const probe = getOptionAsAltProbe()
+  return useSyncExternalStore(
+    (notify) => probe.subscribe(() => notify()),
+    () => probe.getCurrent(),
+    () => 'unknown' as const
+  )
+}
+
+export function useEffectiveMacOptionAsAlt(
+  setting: 'auto' | 'true' | 'false' | 'left' | 'right' | undefined
+): EffectiveMacOptionAsAlt {
+  const detected = useDetectedOptionAsAlt()
+  return effectiveMacOptionAsAlt(setting ?? 'auto', detected)
+}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -142,7 +142,14 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     skipDeleteWorktreeConfirm: false,
     defaultTaskViewPreset: 'all',
     agentCmdOverrides: {},
-    terminalMacOptionAsAlt: 'true',
+    // Why: 'auto' runs a layout-aware probe at boot (see
+    // src/renderer/src/lib/keyboard-layout/*) that picks 'true' for US and
+    // US-International and 'false' for every other layout. This mirrors
+    // Ghostty's detectOptionAsAlt() and ensures users on Turkish, German,
+    // French, etc. can type Option+Q/L/E characters like @, €, [, ] out of
+    // the box (issue #903) while US users keep Option-as-Alt readline chords.
+    terminalMacOptionAsAlt: 'auto',
+    terminalMacOptionAsAltMigrated: false,
     experimentalTerminalDaemon: false,
     experimentalTerminalDaemonNoticeShown: false
   }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -661,11 +661,24 @@ export type GlobalSettings = {
   agentCmdOverrides: Partial<Record<TuiAgent, string>>
   /** Why: macOS terminals must choose between letting Option compose layout
    *  characters (@ on German, € on French) or treating Option as Meta/Esc for
-   *  readline shortcuts. Mirrors Ghostty's macos-option-as-alt setting.
-   *  'false' = compose (default, for non-US keyboards);
-   *  'true' = full Meta on both Option keys;
+   *  readline shortcuts. Mirrors Ghostty's macos-option-as-alt setting — and
+   *  like Ghostty, defaults to 'auto', which fingerprints the active keyboard
+   *  layout via navigator.keyboard.getLayoutMap() at runtime and picks
+   *  'true' for US / US-International and 'false' for everything else.
+   *  'auto'  = layout-aware (default). See docs/terminal-option-key-layout-aware-default.md.
+   *  'false' = compose (for non-US keyboards);
+   *  'true'  = full Meta on both Option keys;
    *  'left' / 'right' = only that Option key acts as Meta, the other composes. */
-  terminalMacOptionAsAlt: 'true' | 'false' | 'left' | 'right'
+  terminalMacOptionAsAlt: 'auto' | 'true' | 'false' | 'left' | 'right'
+  /** One-shot migration guard for the 'auto' rollout. Before this field landed,
+   *  the field defaulted to 'true' for everyone, meaning a persisted 'true'
+   *  could either be an explicit user choice or just the old default. On first
+   *  launch after upgrade, if this flag is false and the persisted value is
+   *  'true', we reset to 'auto' so non-US users stop getting their keyboard
+   *  broken by the stale global default. US users land on 'true' anyway via
+   *  detection, so no visible behavior change. Then we flip this flag to true
+   *  and never migrate again. */
+  terminalMacOptionAsAltMigrated: boolean
   /** Experimental: persist terminal sessions across app restarts via an
    *  out-of-process daemon (src/main/daemon/**). Opt-in because the daemon
    *  protocol is still stabilizing — some sessions have been observed to go


### PR DESCRIPTION
## Summary

Fixes #903. Non-US macOS users (Turkish, German, French, Spanish, Swedish, etc.) could not type Option-layer characters like \`@\`, \`€\`, \`[\`, \`]\` in the embedded terminal because Orca defaulted \`macOptionIsMeta\` to \`true\` globally.

- Detect the active keyboard layout via Chromium's \`navigator.keyboard.getLayoutMap()\` and fingerprint against the US layer. US / US-International keep Alt-as-Meta (so power-user readline shortcuts work). Every other layout gets Option-composed input.
- New \`'auto'\` value for \`terminalMacOptionAsAlt\` is the default. Explicit \`'true'\` / \`'false'\` / \`'left'\` / \`'right'\` still work as manual overrides in Settings.
- One-shot migration flips a persisted \`'true'\` to \`'auto'\` on first launch after upgrade (the old default was indistinguishable from an explicit choice). Explicit \`'false'\` / \`'left'\` / \`'right'\` are preserved unchanged. Guarded by a \`terminalMacOptionAsAltMigrated\` flag so user's post-migration \`'true'\` choice sticks.
- Re-probes on \`window\` focus-in. Chromium does not ship the W3C Keyboard API \`layoutchange\` event, but every real macOS layout-switch path (Input Menu, Cmd+Space, global shortcut) transfers focus out of the app and back, so focus-in is a reliable proxy.

## Test plan

- [x] \`pnpm typecheck\` passes
- [x] \`pnpm lint\` passes
- [x] \`pnpm test\` — all new tests pass (69 across detection, probe, and persistence migration). One pre-existing flake in \`codex-accounts/service.test.ts\` reproduces on \`main\` without these changes.
- [ ] **Manual on macOS (reviewer):** add a Turkish or German layout in System Settings > Keyboard. Open a terminal in Orca. Switch to the non-US layout and press Option+Q (Turkish) or Option+L (German). Expect \`@\` to land in the shell. Switch back to US and press Option+B: expect backward-word readline. The Terminal settings pane should show \"Auto\" selected with a helper line naming the detected layout.
- [ ] **Manual migration check:** on a build that previously persisted \`terminalMacOptionAsAlt: 'true'\`, upgrade to this build: the setting should flip to \`'auto'\` on first launch and stay there on subsequent launches unless the user picks a different value.