### PR TITLE
fix(editor): focus find input on Cmd+F when search is already open

### DIFF
--- a/src/renderer/src/components/editor/MarkdownPreview.tsx
+++ b/src/renderer/src/components/editor/MarkdownPreview.tsx
@@ -154,16 +154,24 @@ export default function MarkdownPreview({
   }, [scrollCacheKey, renderedContent])
 
   const moveToMatch = useCallback((direction: 1 | -1) => {
-    const matches = matchesRef.current
-    if (matches.length === 0) {
+    if (matchesRef.current.length === 0) {
       return
     }
-    setActiveMatchIndex((currentIndex) => {
-      const baseIndex = currentIndex >= 0 ? currentIndex : direction === 1 ? -1 : 0
-      const nextIndex = (baseIndex + direction + matches.length) % matches.length
-      return nextIndex
+    setActiveMatchIndex((cur) => {
+      const base = cur >= 0 ? cur : direction === 1 ? -1 : 0
+      return (base + direction + matchesRef.current.length) % matchesRef.current.length
     })
   }, [])
+
+  const openSearch = useCallback(() => {
+    if (isSearchOpen) {
+      // Why: same-value setState is a no-op so the focus effect won't re-fire.
+      inputRef.current?.focus()
+      inputRef.current?.select()
+    } else {
+      setIsSearchOpen(true)
+    }
+  }, [isSearchOpen])
 
   const closeSearch = useCallback(() => {
     setIsSearchOpen(false)
@@ -197,15 +205,9 @@ export default function MarkdownPreview({
     const matches = applyMarkdownPreviewSearchHighlights(body, query)
     matchesRef.current = matches
     setMatchCount(matches.length)
-    setActiveMatchIndex((currentIndex) => {
-      if (matches.length === 0) {
-        return -1
-      }
-      if (currentIndex >= 0 && currentIndex < matches.length) {
-        return currentIndex
-      }
-      return 0
-    })
+    setActiveMatchIndex((cur) =>
+      matches.length === 0 ? -1 : cur >= 0 && cur < matches.length ? cur : 0
+    )
 
     return () => clearMarkdownPreviewSearchHighlights(body)
   }, [renderedContent, isSearchOpen, query])
@@ -230,7 +232,7 @@ export default function MarkdownPreview({
       ) {
         event.preventDefault()
         event.stopPropagation()
-        setIsSearchOpen(true)
+        openSearch()
         return
       }
 
@@ -248,7 +250,7 @@ export default function MarkdownPreview({
 
     window.addEventListener('keydown', handleKeyDown, { capture: true })
     return () => window.removeEventListener('keydown', handleKeyDown, { capture: true })
-  }, [closeSearch, isSearchOpen, setIsSearchOpen])
+  }, [closeSearch, isSearchOpen, openSearch])
 
   const components: Components = {
     a: ({ href, children, ...props }) => {

--- a/src/renderer/src/components/editor/useRichMarkdownSearch.ts
+++ b/src/renderer/src/components/editor/useRichMarkdownSearch.ts
@@ -51,8 +51,14 @@ export function useRichMarkdownSearch({
           : -1
 
   const openSearch = useCallback(() => {
-    setIsSearchOpen(true)
-  }, [])
+    if (isSearchOpen) {
+      // Why: same-value setState is a no-op so the focus effect won't re-fire.
+      searchInputRef.current?.focus()
+      searchInputRef.current?.select()
+    } else {
+      setIsSearchOpen(true)
+    }
+  }, [isSearchOpen])
 
   const closeSearch = useCallback(() => {
     setIsSearchOpen(false)


### PR DESCRIPTION
## Summary
- When the find dialog is already visible in a markdown file (e.g. after switching windows and back), pressing Cmd+F would open the dialog but not focus it — keystrokes would land in the editor body instead of the search input
- Root cause: `setIsSearchOpen(true)` is a no-op when `isSearchOpen` is already `true`, so React skips the re-render and the `useEffect` that calls `.focus()` never re-fires
- Fix: imperatively focus and select the search input when Cmd+F is pressed while the dialog is already open, in both `useRichMarkdownSearch.ts` (rich editor) and `MarkdownPreview.tsx` (preview mode)

## Test plan
- [ ] Open a markdown file in the rich editor
- [ ] Press Cmd+F to open the find dialog — verify it focuses the input
- [ ] Switch to another window, then switch back
- [ ] Press Cmd+F again — verify the find input is focused and typing goes into it (not the editor body)
- [ ] Repeat the above steps in markdown preview mode
- [ ] Verify closing find with Escape still works correctly
- [ ] Verify find next/previous navigation still works