### PR TITLE
Simplify new workspace quick-create and wire Use button to direct launch

### DIFF
--- a/src/renderer/src/components/NewWorkspaceComposerCard.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.tsx
@@ -381,6 +381,23 @@ export default function NewWorkspaceComposerCard({
   createError
 }: NewWorkspaceComposerCardProps): React.JSX.Element {
   const { isFileDragOver, dragHandlers } = useComposerFileDragOver()
+  const focusNameInput = React.useCallback(() => {
+    // Why: after the repo picker commits a choice, moving focus to the name
+    // field keeps the keyboard flow progressing through the form instead of
+    // trapping the user in the repo popover interaction.
+    requestAnimationFrame(() => {
+      nameInputRef?.current?.focus()
+    })
+  }, [nameInputRef])
+  const focusPromptInput = React.useCallback(() => {
+    // Why: agent selection is usually the last configuration step before the
+    // actual task description, so hand focus to the prompt once Radix closes
+    // the menu and keep the user in a straight keyboard-only flow.
+    requestAnimationFrame(() => {
+      promptTextareaRef?.current?.focus()
+    })
+  }, [promptTextareaRef])
+
   return (
     <div className="grid gap-3">
       <div
@@ -409,6 +426,7 @@ export default function NewWorkspaceComposerCard({
                 repos={eligibleRepos}
                 value={repoId}
                 onValueChange={onRepoChange}
+                onValueSelected={focusNameInput}
                 placeholder="Choose repository"
                 triggerClassName="h-9"
                 autoOpenOnMount={repoAutoOpen}
@@ -629,7 +647,10 @@ export default function NewWorkspaceComposerCard({
 
               <Select
                 value={tuiAgent}
-                onValueChange={(value) => onTuiAgentChange(value as TuiAgent)}
+                onValueChange={(value) => {
+                  onTuiAgentChange(value as TuiAgent)
+                  focusPromptInput()
+                }}
               >
                 <SelectTrigger
                   size="sm"

--- a/src/renderer/src/components/NewWorkspaceComposerCard.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.tsx
@@ -256,10 +256,7 @@ export default function NewWorkspaceComposerCard({
       )}
     >
       <div className="space-y-4">
-        {/* Why: w-fit keeps the label+icon row the same width as the combobox
-            trigger beneath it so the action icon visually anchors to the
-            trigger's right edge rather than stretching to the dialog edge. */}
-        <div className="w-fit space-y-1">
+        <div className="space-y-1">
           <div className="flex items-center justify-between gap-2">
             <label className="text-[11px] font-medium text-muted-foreground">Repository</label>
             <Tooltip>
@@ -295,7 +292,7 @@ export default function NewWorkspaceComposerCard({
             // ring-ring/50, 3px) onto :focus so the autofocused repo trigger
             // paints the familiar field ring instead of leaving no visible
             // focus state.
-            triggerClassName="h-8 border-input text-xs focus:border-ring focus:ring-[3px] focus:ring-ring/50"
+            triggerClassName="h-8 w-full border-input text-xs focus:border-ring focus:ring-[3px] focus:ring-ring/50"
             showStandaloneAddButton={false}
           />
         </div>
@@ -313,7 +310,7 @@ export default function NewWorkspaceComposerCard({
           />
         </div>
 
-        <div className="w-fit space-y-1">
+        <div className="space-y-1">
           <div className="flex items-center justify-between gap-2">
             <label className="text-[11px] font-medium text-muted-foreground">Agent</label>
             <Tooltip>
@@ -341,7 +338,7 @@ export default function NewWorkspaceComposerCard({
             onOpenManageAgents={onOpenAgentSettings}
             defaultAgent={defaultTuiAgent}
             onSetDefault={handleSetDefaultAgent}
-            triggerClassName="h-8 border-input text-xs focus:border-ring focus:ring-[3px] focus:ring-ring/50"
+            triggerClassName="h-8 w-full border-input text-xs focus:border-ring focus:ring-[3px] focus:ring-ring/50"
           />
         </div>
 

--- a/src/renderer/src/components/NewWorkspaceComposerCard.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.tsx
@@ -164,13 +164,6 @@ function PromptPrefixTextarea({
         </span>
         <textarea
           ref={setRefs}
-          // Why: native autoFocus reliably focuses the prompt on initial mount
-          // — used by both the full-page composer and the Cmd+J modal so the
-          // user can start typing immediately without an extra tab. Running
-          // during React's mount means it beats Radix Dialog's FocusScope,
-          // which would otherwise land focus on the first focusable child
-          // (the "Workspace name" input that renders above this textarea).
-          autoFocus
           value={value}
           onChange={(event) => onChange(event.target.value)}
           onKeyDown={onKeyDown}
@@ -399,33 +392,41 @@ export default function NewWorkspaceComposerCard({
         onDragEnter={dragHandlers.onDragEnter}
         onDragLeave={dragHandlers.onDragLeave}
         className={cn(
-          'rounded-[20px] border border-border/50 bg-background/40 p-3 shadow-lg backdrop-blur-xl supports-[backdrop-filter]:bg-background/40 transition',
+          'rounded-2xl border border-border/50 bg-background/40 p-3 shadow-lg backdrop-blur-xl supports-[backdrop-filter]:bg-background/40 transition',
           isFileDragOver && 'border-ring ring-2 ring-ring/30',
           containerClassName
         )}
       >
         <div className="grid gap-3">
-          <div className="flex items-center justify-between gap-3">
-            <input
-              ref={nameInputRef}
-              type="text"
-              value={name}
-              onChange={onNameChange}
-              placeholder="[Optional] Workspace name"
-              className="h-9 min-w-0 flex-1 bg-transparent px-1 text-[14px] font-medium text-foreground outline-none placeholder:text-muted-foreground/80"
-            />
-            <div className="w-[240px] shrink-0">
+          <div className="grid gap-3 sm:grid-cols-[auto_minmax(0,1fr)] sm:items-end">
+            <div className="grid gap-1.5">
+              <div className="px-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                Repository
+              </div>
               <RepoCombobox
                 repos={eligibleRepos}
                 value={repoId}
                 onValueChange={onRepoChange}
-                placeholder="Select a repository"
-                triggerClassName="h-9 w-full rounded-[10px] border border-border/50 bg-background/50 px-3 text-sm font-medium shadow-sm transition hover:bg-muted/50 focus:ring-2 focus:ring-ring/20 focus:outline-none backdrop-blur-md supports-[backdrop-filter]:bg-background/50"
+                placeholder="Choose repository"
+                triggerClassName="h-9"
               />
             </div>
+            <label className="grid gap-1.5">
+              <span className="px-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                Workspace
+              </span>
+              <input
+                ref={nameInputRef}
+                type="text"
+                value={name}
+                onChange={onNameChange}
+                placeholder="[Optional] Workspace name"
+                className="h-9 min-w-0 flex-1 bg-transparent px-1 text-[14px] font-medium text-foreground outline-none placeholder:text-muted-foreground/80"
+              />
+            </label>
           </div>
 
-          <div className="flex flex-col rounded-[16px] border border-border/60 bg-input/30 shadow-sm transition focus-within:border-ring focus-within:ring-2 focus-within:ring-ring/20">
+          <div className="flex flex-col rounded-xl border border-input bg-input/30 shadow-xs transition focus-within:border-ring focus-within:ring-[3px] focus-within:ring-ring/50">
             {/* Why: the `>` is rendered as a visual overlay (aria-hidden) so
                 it's never part of the submitted prompt value. It must behave
                 like the first character of line 1 — inline with line 1's text
@@ -457,14 +458,16 @@ export default function NewWorkspaceComposerCard({
                     <span className="truncate" title={linkedWorkItem.url}>
                       {linkedWorkItem.title}
                     </span>
-                    <button
+                    <Button
                       type="button"
+                      variant="ghost"
+                      size="icon-xs"
                       aria-label={`Remove linked ${linkedWorkItem.type} #${linkedWorkItem.number}`}
                       onClick={onRemoveLinkedWorkItem}
-                      className="shrink-0 text-muted-foreground transition hover:text-foreground"
+                      className="size-5 shrink-0 rounded-full text-muted-foreground"
                     >
                       <X className="size-3.5" />
-                    </button>
+                    </Button>
                   </div>
                 ) : null}
                 {attachmentPaths.map((pathValue) => (
@@ -476,14 +479,16 @@ export default function NewWorkspaceComposerCard({
                     <span className="truncate" title={pathValue}>
                       {getAttachmentLabel(pathValue)}
                     </span>
-                    <button
+                    <Button
                       type="button"
+                      variant="ghost"
+                      size="icon-xs"
                       aria-label={`Remove attachment ${getAttachmentLabel(pathValue)}`}
                       onClick={() => onRemoveAttachment(pathValue)}
-                      className="shrink-0 text-muted-foreground transition hover:text-foreground"
+                      className="size-5 shrink-0 rounded-full text-muted-foreground"
                     >
                       <X className="size-3.5" />
-                    </button>
+                    </Button>
                   </div>
                 ))}
               </div>
@@ -498,9 +503,8 @@ export default function NewWorkspaceComposerCard({
                         <DropdownMenuTrigger asChild>
                           <Button
                             type="button"
-                            variant="ghost"
-                            size="icon"
-                            className="h-8 w-8 rounded-full bg-transparent p-0 text-foreground hover:bg-muted/60 hover:text-foreground"
+                            variant="outline"
+                            size="icon-sm"
                             aria-label="Add attachment"
                           >
                             <Plus className="size-4" />
@@ -528,8 +532,8 @@ export default function NewWorkspaceComposerCard({
                         <PopoverTrigger asChild>
                           <Button
                             type="button"
-                            variant="ghost"
-                            className="h-8 w-8 rounded-full bg-muted/55 p-0 text-foreground backdrop-blur-md hover:bg-muted/75 hover:text-foreground supports-[backdrop-filter]:bg-muted/50"
+                            variant="outline"
+                            size="icon-sm"
                             aria-label="Link GitHub issue or pull request"
                           >
                             <Github className="size-3.5" />
@@ -604,9 +608,10 @@ export default function NewWorkspaceComposerCard({
                     <span>
                       <Button
                         type="button"
-                        variant="ghost"
+                        variant="outline"
+                        size="icon-sm"
                         disabled
-                        className="h-8 w-8 rounded-full bg-muted/35 p-0 text-muted-foreground/70 backdrop-blur-md supports-[backdrop-filter]:bg-muted/30"
+                        className="text-muted-foreground/70"
                         aria-label="Link Linear issue"
                       >
                         <LinearIcon className="size-3.5" />
@@ -626,7 +631,7 @@ export default function NewWorkspaceComposerCard({
                 <SelectTrigger
                   size="sm"
                   className={cn(
-                    'h-8 rounded-full border-border/50 bg-background/50 px-3 backdrop-blur-md supports-[backdrop-filter]:bg-background/50 transition-opacity',
+                    'h-8 min-w-[124px] transition-opacity',
                     !agentPrompt.trim() &&
                       !linkedOnlyTemplatePreview &&
                       'opacity-60 hover:opacity-100 grayscale-[0.5]'
@@ -653,7 +658,7 @@ export default function NewWorkspaceComposerCard({
                   <div className="border-t border-border/50 px-1 pb-0.5 pt-1">
                     <button
                       type="button"
-                      className="flex w-full items-center gap-1.5 rounded-sm px-2 py-1.5 text-xs text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
+                      className="flex w-full items-center gap-1.5 rounded-sm px-2 py-1.5 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
                       onPointerDown={(event) => event.preventDefault()}
                       onClick={onOpenAgentSettings}
                     >
@@ -675,13 +680,7 @@ export default function NewWorkspaceComposerCard({
           </div>
 
           <div className="flex items-center justify-between">
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              className="rounded-full px-2.5 text-muted-foreground hover:text-foreground"
-              onClick={onToggleAdvanced}
-            >
+            <Button type="button" variant="ghost" size="sm" onClick={onToggleAdvanced}>
               Advanced
               <ChevronDown
                 className={cn('size-4 transition-transform', advancedOpen && 'rotate-180')}
@@ -689,16 +688,11 @@ export default function NewWorkspaceComposerCard({
             </Button>
 
             <div className="flex justify-end">
-              <Button
-                onClick={() => void onCreate()}
-                disabled={createDisabled}
-                size="sm"
-                className="rounded-full px-3"
-              >
+              <Button onClick={() => void onCreate()} disabled={createDisabled} size="sm">
                 {creating ? <LoaderCircle className="size-4 animate-spin" /> : null}
                 {agentPrompt.trim() || linkedOnlyTemplatePreview
                   ? 'Start Agent'
-                  : 'Create Worktree'}
+                  : 'Create Workspace'}
                 <span className="ml-1 rounded-full border border-white/20 p-1 text-current/80">
                   <CornerDownLeft className="size-3" />
                 </span>
@@ -723,7 +717,7 @@ export default function NewWorkspaceComposerCard({
                     value={note}
                     onChange={(event) => onNoteChange(event.target.value)}
                     placeholder="Write a note"
-                    className="h-10 rounded-xl border-border/60 bg-input/30 shadow-sm"
+                    className="h-10"
                   />
                 </div>
 
@@ -781,30 +775,22 @@ export default function NewWorkspaceComposerCard({
                           Run setup now?
                         </div>
                         <div className="flex flex-wrap items-center gap-2">
-                          <button
+                          <Button
                             type="button"
                             onClick={() => onSetupDecisionChange('run')}
-                            className={cn(
-                              'rounded-full border px-3.5 py-2 text-xs font-medium transition',
-                              setupDecision === 'run'
-                                ? 'border-emerald-500/40 bg-emerald-500/12 text-foreground shadow-sm'
-                                : 'border-border/70 bg-muted/35 text-foreground/75 hover:text-foreground'
-                            )}
+                            variant={setupDecision === 'run' ? 'default' : 'outline'}
+                            size="sm"
                           >
                             Run setup now
-                          </button>
-                          <button
+                          </Button>
+                          <Button
                             type="button"
                             onClick={() => onSetupDecisionChange('skip')}
-                            className={cn(
-                              'rounded-full border px-3.5 py-2 text-xs font-medium transition',
-                              setupDecision === 'skip'
-                                ? 'border-border/70 bg-foreground/10 text-foreground shadow-sm'
-                                : 'border-border/70 bg-muted/35 text-foreground/75 hover:text-foreground'
-                            )}
+                            variant={setupDecision === 'skip' ? 'secondary' : 'outline'}
+                            size="sm"
                           >
                             Skip for now
-                          </button>
+                          </Button>
                         </div>
                         {!setupDecision ? (
                           <div className="text-xs text-muted-foreground">

--- a/src/renderer/src/components/NewWorkspaceComposerCard.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.tsx
@@ -2,20 +2,16 @@
 composer card markup together so the inline and modal variants share one UI
 surface without splitting the controlled form into hard-to-follow fragments. */
 import React from 'react'
-import { Check, ChevronDown, CornerDownLeft, LoaderCircle, Terminal } from 'lucide-react'
+import { Check, ChevronDown, CornerDownLeft, LoaderCircle } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue
-} from '@/components/ui/select'
 import RepoCombobox from '@/components/repo/RepoCombobox'
-import { AGENT_CATALOG, AgentIcon } from '@/lib/agent-catalog'
+import AgentCombobox from '@/components/agent/AgentCombobox'
+import { AGENT_CATALOG } from '@/lib/agent-catalog'
 import { cn } from '@/lib/utils'
 import type { TuiAgent } from '../../../shared/types'
+
+const isMac = typeof navigator !== 'undefined' && navigator.userAgent.includes('Mac')
 
 type RepoOption = React.ComponentProps<typeof RepoCombobox>['repos'][number]
 
@@ -229,256 +225,215 @@ export default function NewWorkspaceComposerCard({
   )
 
   return (
-    <div className="grid gap-3">
-      <div
-        ref={composerRef}
-        // Why: preload classifies native OS file drops by the nearest
-        // `data-native-file-drop-target` marker in the composedPath. Tagging
-        // the composer root makes drops anywhere on the card (modal or full
-        // page) route to the composer attachment handler instead of falling
-        // back to the default editor-open behavior.
-        data-native-file-drop-target="composer"
-        onDragEnter={dragHandlers.onDragEnter}
-        onDragLeave={dragHandlers.onDragLeave}
-        className={cn(
-          'rounded-2xl border border-border/50 bg-background/40 p-3 shadow-lg backdrop-blur-xl supports-[backdrop-filter]:bg-background/40 transition',
-          isFileDragOver && 'border-ring ring-2 ring-ring/30',
-          containerClassName
-        )}
-      >
-        <div className="grid gap-3">
-          <div className="grid gap-4">
-            <div className="grid gap-1.5">
-              <div className="px-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
-                Repository
+    <div
+      ref={composerRef}
+      // Why: preload classifies native OS file drops by the nearest
+      // `data-native-file-drop-target` marker in the composedPath. Tagging
+      // the composer root makes drops anywhere on the card route to the
+      // composer attachment handler instead of falling back to the default
+      // editor-open behavior.
+      data-native-file-drop-target="composer"
+      onDragEnter={dragHandlers.onDragEnter}
+      onDragLeave={dragHandlers.onDragLeave}
+      className={cn(
+        'grid gap-1 rounded-md transition',
+        isFileDragOver && 'ring-2 ring-ring/30',
+        containerClassName
+      )}
+    >
+      <div className="space-y-4">
+        <div className="space-y-1">
+          <label className="text-[11px] font-medium text-muted-foreground">Repository</label>
+          <RepoCombobox
+            repos={eligibleRepos}
+            value={repoId}
+            onValueChange={onRepoChange}
+            onValueSelected={focusNameInput}
+            placeholder="Choose repository"
+            // Why: programmatic .focus() from the Dialog's onOpenAutoFocus
+            // handler does not reliably trigger :focus-visible in Chromium.
+            // Mirror the Input component's standard ring (border-ring +
+            // ring-ring/50, 3px) onto :focus so the autofocused repo trigger
+            // paints the familiar field ring instead of leaving no visible
+            // focus state.
+            triggerClassName="h-8 border-input text-xs focus:border-ring focus:ring-[3px] focus:ring-ring/50"
+            showStandaloneAddButton={false}
+          />
+        </div>
+
+        <div className="space-y-1">
+          <label className="text-[11px] font-medium text-muted-foreground">Workspace</label>
+          <Input
+            ref={nameInputRef}
+            value={name}
+            onChange={onNameChange}
+            placeholder="Optional workspace name"
+            className="h-8 text-xs"
+          />
+        </div>
+
+        <div className="space-y-1">
+          <label className="text-[11px] font-medium text-muted-foreground">Agent</label>
+          <AgentCombobox
+            agents={visibleQuickAgents}
+            value={quickAgent}
+            onValueChange={onQuickAgentChange}
+            onOpenManageAgents={onOpenAgentSettings}
+            triggerClassName="h-8 border-input text-xs focus:border-ring focus:ring-[3px] focus:ring-ring/50"
+          />
+        </div>
+
+        <div
+          className={cn(
+            'grid overflow-hidden transition-[grid-template-rows,opacity] duration-200 ease-out',
+            advancedOpen ? 'grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0'
+          )}
+          aria-hidden={!advancedOpen}
+        >
+          <div className="min-h-0">
+            <div className="space-y-4 pt-1">
+              <div className="space-y-1">
+                <label className="text-[11px] font-medium text-muted-foreground">Note</label>
+                <textarea
+                  value={note}
+                  onChange={(event) => onNoteChange(event.target.value)}
+                  onInput={(event) => {
+                    // Why: start at one-line height, grow to fit content so a short
+                    // note keeps the dialog compact while longer notes get room to
+                    // breathe without a scroll bar until the max-h clamps growth.
+                    const ta = event.currentTarget
+                    ta.style.height = 'auto'
+                    ta.style.height = `${ta.scrollHeight}px`
+                  }}
+                  placeholder="Write a note"
+                  rows={1}
+                  className="w-full min-w-0 resize-none overflow-hidden rounded-md border border-input bg-transparent px-3 py-1.5 text-xs shadow-xs transition-[color,box-shadow] outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 max-h-40"
+                />
               </div>
-              <RepoCombobox
-                repos={eligibleRepos}
-                value={repoId}
-                onValueChange={onRepoChange}
-                onValueSelected={focusNameInput}
-                placeholder="Choose repository"
-                // Why: programmatic .focus() from the Dialog's onOpenAutoFocus
-                // handler does not reliably trigger :focus-visible in
-                // Chromium. Mirror the Input component's standard ring
-                // (border-ring + ring-ring/50, 3px) onto :focus so the
-                // autofocused repo trigger paints the familiar field ring
-                // instead of leaving no visible focus state.
-                triggerClassName="h-9 focus:border-ring focus:ring-[3px] focus:ring-ring/50"
-                showStandaloneAddButton={false}
-              />
-            </div>
-            <label className="grid max-w-full gap-1.5">
-              <span className="px-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
-                Workspace
-              </span>
-              <input
-                ref={nameInputRef}
-                type="text"
-                value={name}
-                onChange={onNameChange}
-                placeholder="[Optional] Workspace name"
-                className="h-9 min-w-0 flex-1 bg-transparent px-1 text-[14px] font-medium text-foreground outline-none placeholder:text-muted-foreground/80"
-              />
-            </label>
-            <div className="grid gap-1.5">
-              <span className="px-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
-                Agent
-              </span>
-              <Select
-                value={quickAgent ?? '__none__'}
-                onValueChange={(value) => {
-                  onQuickAgentChange(value === '__none__' ? null : (value as TuiAgent))
-                }}
-              >
-                <SelectTrigger size="sm" className="h-9 min-w-[148px]">
-                  <SelectValue>
-                    <span className="flex items-center gap-2">
-                      {quickAgent ? (
-                        <AgentIcon agent={quickAgent} />
-                      ) : (
-                        <Terminal className="size-4" />
-                      )}
-                      <span>
-                        {quickAgent
-                          ? (AGENT_CATALOG.find((a) => a.id === quickAgent)?.label ?? quickAgent)
-                          : 'Blank Terminal'}
-                      </span>
+
+              {setupConfig ? (
+                <div className="space-y-2">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <label className="text-[11px] font-medium text-muted-foreground">
+                      Setup script
+                    </label>
+                    <span className="rounded-full border border-border/70 bg-muted/45 px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.14em] text-foreground/70">
+                      {setupConfig.source === 'yaml' ? 'orca.yaml' : 'legacy hooks'}
                     </span>
-                  </SelectValue>
-                </SelectTrigger>
-                <SelectContent align="end">
-                  <SelectItem value="__none__">
-                    <span className="flex items-center gap-2">
-                      <Terminal className="size-4" />
-                      <span>Blank Terminal</span>
-                    </span>
-                  </SelectItem>
-                  {visibleQuickAgents.map((option) => (
-                    <SelectItem key={option.id} value={option.id}>
-                      <span className="flex items-center gap-2">
-                        <AgentIcon agent={option.id} />
-                        <span>{option.label}</span>
-                      </span>
-                    </SelectItem>
-                  ))}
-                  <div className="border-t border-border/50 px-1 pb-0.5 pt-1">
-                    <button
-                      type="button"
-                      className="flex w-full items-center gap-1.5 rounded-sm px-2 py-1.5 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
-                      onPointerDown={(event) => event.preventDefault()}
-                      onClick={onOpenAgentSettings}
-                    >
-                      Manage agents
-                      <svg
-                        className="size-3"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="2"
-                      >
-                        <path d="M5 12h14M12 5l7 7-7 7" />
-                      </svg>
-                    </button>
                   </div>
-                </SelectContent>
-              </Select>
-            </div>
-          </div>
 
-          <div className="flex items-center justify-between">
-            <Button type="button" variant="ghost" size="sm" onClick={onToggleAdvanced}>
-              Advanced
-              <ChevronDown
-                className={cn('size-4 transition-transform', advancedOpen && 'rotate-180')}
-              />
-            </Button>
-
-            <div className="flex justify-end">
-              <Button onClick={() => void onCreate()} disabled={createDisabled} size="sm">
-                {creating ? <LoaderCircle className="size-4 animate-spin" /> : null}
-                Create Workspace
-                <span className="ml-1 rounded-full border border-white/20 p-1 text-current/80">
-                  <CornerDownLeft className="size-3" />
-                </span>
-              </Button>
-            </div>
-          </div>
-
-          <div
-            className={cn(
-              'grid overflow-hidden transition-[grid-template-rows,opacity] duration-200 ease-out',
-              advancedOpen ? 'grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0'
-            )}
-            aria-hidden={!advancedOpen}
-          >
-            <div className="min-h-0 px-3 pt-3">
-              <div className="grid gap-5 pb-3">
-                <div className="grid gap-1.5">
-                  <label className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
-                    Note
-                  </label>
-                  <Input
-                    value={note}
-                    onChange={(event) => onNoteChange(event.target.value)}
-                    placeholder="Write a note"
-                    className="h-10"
-                  />
-                </div>
-
-                {setupConfig ? (
-                  <div className="grid gap-3">
-                    <div className="flex flex-wrap items-start justify-between gap-3">
-                      <label className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
-                        Setup script
-                      </label>
-                      <span className="rounded-full border border-border/70 bg-muted/45 px-2.5 py-1 text-[10px] font-medium uppercase tracking-[0.16em] text-foreground/70 shadow-sm">
-                        {setupConfig.source === 'yaml' ? 'orca.yaml' : 'legacy hooks'}
-                      </span>
-                    </div>
-
-                    {/* Why: `orca.yaml` is the committed source of truth for shared setup,
-                        so the preview reconstructs the real YAML shape instead of showing a raw
-                        shell blob that hides where the command came from. */}
-                    <SetupCommandPreview
-                      setupConfig={setupConfig}
-                      headerAction={
-                        requiresExplicitSetupChoice ? null : (
-                          <label className="group flex items-center gap-2 text-xs text-foreground">
-                            <span
+                  {/* Why: `orca.yaml` is the committed source of truth for shared setup,
+                      so the preview reconstructs the real YAML shape instead of showing a raw
+                      shell blob that hides where the command came from. */}
+                  <SetupCommandPreview
+                    setupConfig={setupConfig}
+                    headerAction={
+                      requiresExplicitSetupChoice ? null : (
+                        <label className="group flex items-center gap-2 text-xs text-foreground">
+                          <span
+                            className={cn(
+                              'flex size-4 items-center justify-center rounded-[3px] border transition shadow-sm',
+                              resolvedSetupDecision === 'run'
+                                ? 'border-emerald-500/60 bg-emerald-500 text-white'
+                                : 'border-foreground/20 bg-background dark:border-white/20 dark:bg-muted/10'
+                            )}
+                          >
+                            <Check
                               className={cn(
-                                'flex size-4 items-center justify-center rounded-[3px] border transition shadow-sm',
-                                resolvedSetupDecision === 'run'
-                                  ? 'border-emerald-500/60 bg-emerald-500 text-white'
-                                  : 'border-foreground/20 bg-background dark:border-white/20 dark:bg-muted/10'
+                                'size-3 transition-opacity',
+                                resolvedSetupDecision === 'run' ? 'opacity-100' : 'opacity-0'
                               )}
-                            >
-                              <Check
-                                className={cn(
-                                  'size-3 transition-opacity',
-                                  resolvedSetupDecision === 'run' ? 'opacity-100' : 'opacity-0'
-                                )}
-                              />
-                            </span>
-                            <input
-                              type="checkbox"
-                              checked={resolvedSetupDecision === 'run'}
-                              onChange={(event) =>
-                                onSetupDecisionChange(event.target.checked ? 'run' : 'skip')
-                              }
-                              className="sr-only"
                             />
-                            <span>Run setup command</span>
-                          </label>
-                        )
-                      }
-                    />
+                          </span>
+                          <input
+                            type="checkbox"
+                            checked={resolvedSetupDecision === 'run'}
+                            onChange={(event) =>
+                              onSetupDecisionChange(event.target.checked ? 'run' : 'skip')
+                            }
+                            className="sr-only"
+                          />
+                          <span>Run setup command</span>
+                        </label>
+                      )
+                    }
+                  />
 
-                    {requiresExplicitSetupChoice ? (
-                      <div className="grid gap-2.5">
-                        <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
-                          Run setup now?
-                        </div>
-                        <div className="flex flex-wrap items-center gap-2">
-                          <Button
-                            type="button"
-                            onClick={() => onSetupDecisionChange('run')}
-                            variant={setupDecision === 'run' ? 'default' : 'outline'}
-                            size="sm"
-                          >
-                            Run setup now
-                          </Button>
-                          <Button
-                            type="button"
-                            onClick={() => onSetupDecisionChange('skip')}
-                            variant={setupDecision === 'skip' ? 'secondary' : 'outline'}
-                            size="sm"
-                          >
-                            Skip for now
-                          </Button>
-                        </div>
-                        {!setupDecision ? (
-                          <div className="text-xs text-muted-foreground">
-                            {shouldWaitForSetupCheck
-                              ? 'Checking setup configuration...'
-                              : 'Choose whether to run setup before creating this workspace.'}
-                          </div>
-                        ) : null}
+                  {requiresExplicitSetupChoice ? (
+                    <div className="space-y-2">
+                      <div className="text-[11px] font-medium text-muted-foreground">
+                        Run setup now?
                       </div>
-                    ) : null}
-                  </div>
-                ) : null}
-              </div>
+                      <div className="flex flex-wrap items-center gap-2">
+                        <Button
+                          type="button"
+                          onClick={() => onSetupDecisionChange('run')}
+                          variant={setupDecision === 'run' ? 'default' : 'outline'}
+                          size="sm"
+                        >
+                          Run setup now
+                        </Button>
+                        <Button
+                          type="button"
+                          onClick={() => onSetupDecisionChange('skip')}
+                          variant={setupDecision === 'skip' ? 'secondary' : 'outline'}
+                          size="sm"
+                        >
+                          Skip for now
+                        </Button>
+                      </div>
+                      {!setupDecision ? (
+                        <div className="text-xs text-muted-foreground">
+                          {shouldWaitForSetupCheck
+                            ? 'Checking setup configuration...'
+                            : 'Choose whether to run setup before creating this workspace.'}
+                        </div>
+                      ) : null}
+                    </div>
+                  ) : null}
+                </div>
+              ) : null}
             </div>
           </div>
         </div>
       </div>
 
       {createError ? (
-        <div className="rounded-xl border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+        <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
           {createError}
         </div>
       ) : null}
+
+      <div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={onToggleAdvanced}
+          className="-ml-2 text-xs"
+        >
+          Advanced
+          <ChevronDown
+            className={cn('size-4 transition-transform', advancedOpen && 'rotate-180')}
+          />
+        </Button>
+      </div>
+
+      <div className="flex justify-end">
+        <Button
+          onClick={() => void onCreate()}
+          disabled={createDisabled}
+          size="sm"
+          className="text-xs"
+        >
+          {creating ? <LoaderCircle className="size-4 animate-spin" /> : null}
+          Create Workspace
+          <span className="ml-1 inline-flex items-center gap-0.5 rounded border border-white/20 px-1.5 py-0.5 text-[10px] font-medium leading-none text-current/80">
+            <span>{isMac ? '⌘' : 'Ctrl'}</span>
+            <CornerDownLeft className="size-3" />
+          </span>
+        </Button>
+      </div>
     </div>
   )
 }

--- a/src/renderer/src/components/NewWorkspaceComposerCard.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.tsx
@@ -5,25 +5,14 @@ import React from 'react'
 import {
   Check,
   ChevronDown,
-  CircleDot,
   CornerDownLeft,
-  GitPullRequest,
-  Github,
+  Folder,
+  FolderPlus,
   LoaderCircle,
-  Paperclip,
-  Plus,
-  X
+  Settings2
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
-import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList
-} from '@/components/ui/command'
 import {
   Select,
   SelectContent,
@@ -31,65 +20,28 @@ import {
   SelectTrigger,
   SelectValue
 } from '@/components/ui/select'
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuShortcut,
-  DropdownMenuTrigger
-} from '@/components/ui/dropdown-menu'
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import RepoCombobox from '@/components/repo/RepoCombobox'
 import { AGENT_CATALOG, AgentIcon } from '@/lib/agent-catalog'
+import { useAppStore } from '@/store'
 import { cn } from '@/lib/utils'
-import type { GitHubWorkItem, TuiAgent } from '../../../shared/types'
+import type { TuiAgent } from '../../../shared/types'
+import { isGitRepoKind } from '../../../shared/repo-kind'
 
 type RepoOption = React.ComponentProps<typeof RepoCombobox>['repos'][number]
-
-type LinkedWorkItemSummary = {
-  type: 'issue' | 'pr'
-  number: number
-  title: string
-  url: string
-} | null
 
 type NewWorkspaceComposerCardProps = {
   containerClassName?: string
   composerRef?: React.RefObject<HTMLDivElement | null>
   nameInputRef?: React.RefObject<HTMLInputElement | null>
-  promptTextareaRef?: React.RefObject<HTMLTextAreaElement | null>
   repoAutoOpen?: boolean
+  quickAgent: TuiAgent | null
+  onQuickAgentChange: (agent: TuiAgent | null) => void
   eligibleRepos: RepoOption[]
   repoId: string
   onRepoChange: (value: string) => void
   name: string
   onNameChange: (event: React.ChangeEvent<HTMLInputElement>) => void
-  agentPrompt: string
-  onAgentPromptChange: (value: string) => void
-  onPromptKeyDown: (event: React.KeyboardEvent<HTMLTextAreaElement>) => void
-  linkedOnlyTemplatePreview: string | null
-  attachmentPaths: string[]
-  getAttachmentLabel: (pathValue: string) => string
-  onAddAttachment: () => void
-  onRemoveAttachment: (pathValue: string) => void
-  addAttachmentShortcut: string
-  linkedWorkItem: LinkedWorkItemSummary
-  onRemoveLinkedWorkItem: () => void
-  linkPopoverOpen: boolean
-  onLinkPopoverOpenChange: (open: boolean) => void
-  linkQuery: string
-  onLinkQueryChange: (value: string) => void
-  filteredLinkItems: GitHubWorkItem[]
-  linkItemsLoading: boolean
-  linkDirectLoading: boolean
-  normalizedLinkQuery: {
-    query: string
-    repoMismatch: string | null
-  }
-  onSelectLinkedItem: (item: GitHubWorkItem) => void
-  tuiAgent: TuiAgent
-  onTuiAgentChange: (value: TuiAgent) => void
   detectedAgentIds: Set<TuiAgent> | null
   onOpenAgentSettings: () => void
   advancedOpen: boolean
@@ -106,93 +58,6 @@ type NewWorkspaceComposerCardProps = {
   shouldWaitForSetupCheck: boolean
   resolvedSetupDecision: 'run' | 'skip' | null
   createError: string | null
-}
-
-function PromptPrefixTextarea({
-  textareaRef,
-  value,
-  onChange,
-  onKeyDown,
-  placeholder,
-  placeholderTone
-}: {
-  textareaRef?: React.RefObject<HTMLTextAreaElement | null>
-  value: string
-  onChange: (value: string) => void
-  onKeyDown: (event: React.KeyboardEvent<HTMLTextAreaElement>) => void
-  placeholder: string
-  placeholderTone: 'muted' | 'ghost-prompt'
-}): React.JSX.Element {
-  const internalRef = React.useRef<HTMLTextAreaElement | null>(null)
-
-  const setRefs = React.useCallback(
-    (node: HTMLTextAreaElement | null) => {
-      internalRef.current = node
-      if (textareaRef) {
-        textareaRef.current = node
-      }
-    },
-    [textareaRef]
-  )
-
-  // Why: auto-size the textarea to its content and hoist scrolling onto the
-  // outer wrapper. Any JS-driven overlay sync (listening to `scroll`, updating
-  // `translateY`) always paints a frame behind the textarea's own scroll — on
-  // momentum scroll that shows up as visible wobble between the `>` and the
-  // typed text. Putting both elements inside the same native scroll container
-  // makes them move in lockstep with zero JS and no cross-layer paint delay.
-  React.useLayoutEffect(() => {
-    const el = internalRef.current
-    if (!el) {
-      return
-    }
-    el.style.height = 'auto'
-    el.style.height = `${el.scrollHeight}px`
-  }, [value])
-
-  return (
-    // Why: allow the composer to grow with the user's prompt up to ~20 rows
-    // (560px at leading-7 ≈ 28px/row) before scrolling. The inner textarea's
-    // JS-driven auto-resize sets its own height to scrollHeight, so the wrapper
-    // simply follows until the max-height cap engages and hands off to scroll.
-    <div className="scrollbar-sleek max-h-[560px] overflow-auto">
-      <div className="relative">
-        <span
-          aria-hidden
-          className="pointer-events-none absolute left-4 top-4 select-none text-[15px] leading-7 font-semibold text-foreground"
-        >
-          {'>'}
-        </span>
-        <textarea
-          ref={setRefs}
-          value={value}
-          onChange={(event) => onChange(event.target.value)}
-          onKeyDown={onKeyDown}
-          placeholder={placeholder}
-          // Why: the "ghost-prompt" tone previews the exact issueCommand
-          // template that will be sent to the agent when the user submits with
-          // only a linked work item. Emphasising it with higher contrast makes
-          // it obvious this is a real pending prompt, not instructional copy.
-          className={cn(
-            'block min-h-[110px] w-full resize-none overflow-hidden bg-transparent py-4 pl-4 pr-4 text-[15px] leading-7 text-foreground outline-none',
-            placeholderTone === 'ghost-prompt'
-              ? 'placeholder:text-foreground/70'
-              : 'placeholder:text-muted-foreground/50'
-          )}
-          style={{ textIndent: '2ch' }}
-          spellCheck={false}
-        />
-      </div>
-    </div>
-  )
-}
-
-function LinearIcon({ className }: { className?: string }): React.JSX.Element {
-  return (
-    <svg viewBox="0 0 24 24" aria-hidden className={className} fill="currentColor">
-      <path d="M2.886 4.18A11.982 11.982 0 0 1 11.99 0C18.624 0 24 5.376 24 12.009c0 3.64-1.62 6.903-4.18 9.105L2.887 4.18ZM1.817 5.626l16.556 16.556c-.524.33-1.075.62-1.65.866L.951 7.277c.247-.575.537-1.126.866-1.65ZM.322 9.163l14.515 14.515c-.71.172-1.443.282-2.195.322L0 11.358a12 12 0 0 1 .322-2.195Zm-.17 4.862 9.823 9.824a12.02 12.02 0 0 1-9.824-9.824Z" />
-    </svg>
-  )
 }
 
 function renderSetupYamlPreview(command: string): React.JSX.Element[] {
@@ -334,35 +199,14 @@ export default function NewWorkspaceComposerCard({
   containerClassName,
   composerRef,
   nameInputRef,
-  promptTextareaRef,
   repoAutoOpen = false,
+  quickAgent,
+  onQuickAgentChange,
   eligibleRepos,
   repoId,
   onRepoChange,
   name,
   onNameChange,
-  agentPrompt,
-  onAgentPromptChange,
-  onPromptKeyDown,
-  linkedOnlyTemplatePreview,
-  attachmentPaths,
-  getAttachmentLabel,
-  onAddAttachment,
-  onRemoveAttachment,
-  addAttachmentShortcut,
-  linkedWorkItem,
-  onRemoveLinkedWorkItem,
-  linkPopoverOpen,
-  onLinkPopoverOpenChange,
-  linkQuery,
-  onLinkQueryChange,
-  filteredLinkItems,
-  linkItemsLoading,
-  linkDirectLoading,
-  normalizedLinkQuery,
-  onSelectLinkedItem,
-  tuiAgent,
-  onTuiAgentChange,
   detectedAgentIds,
   onOpenAgentSettings,
   advancedOpen,
@@ -381,6 +225,10 @@ export default function NewWorkspaceComposerCard({
   createError
 }: NewWorkspaceComposerCardProps): React.JSX.Element {
   const { isFileDragOver, dragHandlers } = useComposerFileDragOver()
+  const addRepo = useAppStore((s) => s.addRepo)
+  const fetchWorktrees = useAppStore((s) => s.fetchWorktrees)
+  const [isAddingRepo, setIsAddingRepo] = React.useState(false)
+
   const focusNameInput = React.useCallback(() => {
     // Why: after the repo picker commits a choice, moving focus to the name
     // field keeps the keyboard flow progressing through the form instead of
@@ -389,14 +237,32 @@ export default function NewWorkspaceComposerCard({
       nameInputRef?.current?.focus()
     })
   }, [nameInputRef])
-  const focusPromptInput = React.useCallback(() => {
-    // Why: agent selection is usually the last configuration step before the
-    // actual task description, so hand focus to the prompt once Radix closes
-    // the menu and keep the user in a straight keyboard-only flow.
-    requestAnimationFrame(() => {
-      promptTextareaRef?.current?.focus()
-    })
-  }, [promptTextareaRef])
+
+  const visibleQuickAgents = React.useMemo(
+    () =>
+      AGENT_CATALOG.filter((agent) => detectedAgentIds === null || detectedAgentIds.has(agent.id)),
+    [detectedAgentIds]
+  )
+
+  const handleAddRepo = React.useCallback(async (): Promise<void> => {
+    if (isAddingRepo) {
+      return
+    }
+    setIsAddingRepo(true)
+    try {
+      const repo = await addRepo()
+      if (!repo) {
+        return
+      }
+      if (isGitRepoKind(repo)) {
+        await fetchWorktrees(repo.id)
+      }
+      onRepoChange(repo.id)
+      focusNameInput()
+    } finally {
+      setIsAddingRepo(false)
+    }
+  }, [addRepo, fetchWorktrees, focusNameInput, isAddingRepo, onRepoChange])
 
   return (
     <div className="grid gap-3">
@@ -417,10 +283,32 @@ export default function NewWorkspaceComposerCard({
         )}
       >
         <div className="grid gap-3">
-          <div className="grid gap-3 sm:grid-cols-[auto_minmax(0,1fr)] sm:items-end">
+          <div className="grid gap-4">
             <div className="grid gap-1.5">
-              <div className="px-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
-                Repository
+              <div className="flex items-center justify-between gap-2 px-1">
+                <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                  Repository
+                </div>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon-xs"
+                      disabled={isAddingRepo}
+                      onClick={() => void handleAddRepo()}
+                      className="size-5 shrink-0 rounded-sm text-muted-foreground hover:text-foreground"
+                      aria-label={
+                        isAddingRepo ? 'Adding folder or repository' : 'Add folder or repository'
+                      }
+                    >
+                      <FolderPlus className="size-3" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent side="top" sideOffset={6}>
+                    Add repo
+                  </TooltipContent>
+                </Tooltip>
               </div>
               <RepoCombobox
                 repos={eligibleRepos}
@@ -429,10 +317,11 @@ export default function NewWorkspaceComposerCard({
                 onValueSelected={focusNameInput}
                 placeholder="Choose repository"
                 triggerClassName="h-9"
-                autoOpenOnMount={repoAutoOpen}
+                autoFocusTriggerOnMount={repoAutoOpen}
+                showStandaloneAddButton={false}
               />
             </div>
-            <label className="grid gap-1.5">
+            <label className="grid max-w-full gap-1.5">
               <span className="px-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
                 Workspace
               </span>
@@ -445,233 +334,59 @@ export default function NewWorkspaceComposerCard({
                 className="h-9 min-w-0 flex-1 bg-transparent px-1 text-[14px] font-medium text-foreground outline-none placeholder:text-muted-foreground/80"
               />
             </label>
-          </div>
-
-          <div className="flex flex-col rounded-xl border border-input bg-input/30 shadow-xs transition focus-within:border-ring focus-within:ring-[3px] focus-within:ring-ring/50">
-            {/* Why: the `>` is rendered as a visual overlay (aria-hidden) so
-                it's never part of the submitted prompt value. It must behave
-                like the first character of line 1 — inline with line 1's text
-                and scrolling out of view with it. See PromptPrefixTextarea for
-                how the shared-scroll-container approach avoids wobble. */}
-            <PromptPrefixTextarea
-              textareaRef={promptTextareaRef}
-              value={agentPrompt}
-              onChange={onAgentPromptChange}
-              onKeyDown={onPromptKeyDown}
-              placeholder={
-                linkedOnlyTemplatePreview ?? 'Describe a task to start an agent, or leave blank...'
-              }
-              placeholderTone={linkedOnlyTemplatePreview ? 'ghost-prompt' : 'muted'}
-            />
-
-            {attachmentPaths.length > 0 || linkedWorkItem ? (
-              <div className="flex flex-wrap gap-2 px-3">
-                {linkedWorkItem ? (
-                  <div className="inline-flex max-w-full items-center gap-2 rounded-full border border-border/50 bg-background/60 px-3 py-1 text-xs text-foreground transition hover:bg-muted/60 supports-[backdrop-filter]:bg-background/50">
-                    {linkedWorkItem.type === 'pr' ? (
-                      <GitPullRequest className="size-3.5 shrink-0" />
-                    ) : (
-                      <CircleDot className="size-3.5 shrink-0" />
-                    )}
-                    <span className="shrink-0 font-mono text-muted-foreground">
-                      #{linkedWorkItem.number}
-                    </span>
-                    <span className="truncate" title={linkedWorkItem.url}>
-                      {linkedWorkItem.title}
-                    </span>
+            <div className="grid gap-1.5">
+              <div className="flex items-center justify-between gap-2 px-1">
+                <span className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                  Agent
+                </span>
+                <Tooltip>
+                  <TooltipTrigger asChild>
                     <Button
                       type="button"
                       variant="ghost"
                       size="icon-xs"
-                      aria-label={`Remove linked ${linkedWorkItem.type} #${linkedWorkItem.number}`}
-                      onClick={onRemoveLinkedWorkItem}
-                      className="size-5 shrink-0 rounded-full text-muted-foreground"
+                      onClick={onOpenAgentSettings}
+                      className="size-5 shrink-0 rounded-sm text-muted-foreground hover:text-foreground"
+                      aria-label="Open agent settings"
                     >
-                      <X className="size-3.5" />
+                      <Settings2 className="size-3" />
                     </Button>
-                  </div>
-                ) : null}
-                {attachmentPaths.map((pathValue) => (
-                  <div
-                    key={pathValue}
-                    className="inline-flex max-w-full items-center gap-2 rounded-full border border-border/50 bg-background/60 px-3 py-1 text-xs text-foreground transition hover:bg-muted/60 supports-[backdrop-filter]:bg-background/50"
-                  >
-                    <Paperclip className="size-3.5 shrink-0" />
-                    <span className="truncate" title={pathValue}>
-                      {getAttachmentLabel(pathValue)}
-                    </span>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon-xs"
-                      aria-label={`Remove attachment ${getAttachmentLabel(pathValue)}`}
-                      onClick={() => onRemoveAttachment(pathValue)}
-                      className="size-5 shrink-0 rounded-full text-muted-foreground"
-                    >
-                      <X className="size-3.5" />
-                    </Button>
-                  </div>
-                ))}
-              </div>
-            ) : null}
-
-            <div className="flex items-center justify-between px-3 pb-3 pt-2">
-              <div className="flex items-center gap-1.5">
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <div>
-                      <DropdownMenu modal={false}>
-                        <DropdownMenuTrigger asChild>
-                          <Button
-                            type="button"
-                            variant="outline"
-                            size="icon-sm"
-                            aria-label="Add attachment"
-                          >
-                            <Plus className="size-4" />
-                          </Button>
-                        </DropdownMenuTrigger>
-                        <DropdownMenuContent align="start">
-                          <DropdownMenuItem onSelect={() => onAddAttachment()}>
-                            <Paperclip className="size-4" />
-                            Add attachment
-                            <DropdownMenuShortcut>{addAttachmentShortcut}</DropdownMenuShortcut>
-                          </DropdownMenuItem>
-                        </DropdownMenuContent>
-                      </DropdownMenu>
-                    </div>
                   </TooltipTrigger>
                   <TooltipContent side="top" sideOffset={6}>
-                    Add files
-                  </TooltipContent>
-                </Tooltip>
-
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <div>
-                      <Popover open={linkPopoverOpen} onOpenChange={onLinkPopoverOpenChange}>
-                        <PopoverTrigger asChild>
-                          <Button
-                            type="button"
-                            variant="outline"
-                            size="icon-sm"
-                            aria-label="Link GitHub issue or pull request"
-                          >
-                            <Github className="size-3.5" />
-                          </Button>
-                        </PopoverTrigger>
-                        <PopoverContent align="start" className="w-80 p-0">
-                          <Command shouldFilter={false}>
-                            <CommandInput
-                              autoFocus
-                              placeholder="Search issues or pull requests..."
-                              value={linkQuery}
-                              onValueChange={onLinkQueryChange}
-                            />
-                            <CommandList className="max-h-[280px]">
-                              {filteredLinkItems.length === 0 ? (
-                                <CommandEmpty>
-                                  {normalizedLinkQuery.repoMismatch
-                                    ? `GitHub URL must match ${normalizedLinkQuery.repoMismatch}.`
-                                    : linkItemsLoading || linkDirectLoading
-                                      ? normalizedLinkQuery.query.trim()
-                                        ? 'Searching...'
-                                        : 'Loading...'
-                                      : normalizedLinkQuery.query.trim()
-                                        ? 'No issues or pull requests found.'
-                                        : 'No recent issues or pull requests found.'}
-                                </CommandEmpty>
-                              ) : null}
-                              {filteredLinkItems.length > 0 ? (
-                                <CommandGroup
-                                  heading={
-                                    normalizedLinkQuery.query.trim()
-                                      ? `${filteredLinkItems.length} result${filteredLinkItems.length === 1 ? '' : 's'}`
-                                      : 'Recent issues & pull requests'
-                                  }
-                                >
-                                  {filteredLinkItems.map((item) => (
-                                    <CommandItem
-                                      key={item.id}
-                                      value={`${item.type}-${item.number}-${item.title}`}
-                                      onSelect={() => onSelectLinkedItem(item)}
-                                      className="group"
-                                    >
-                                      {item.type === 'pr' ? (
-                                        <GitPullRequest className="size-3.5 shrink-0 text-muted-foreground" />
-                                      ) : (
-                                        <CircleDot className="size-3.5 shrink-0 text-muted-foreground" />
-                                      )}
-                                      <span className="shrink-0 font-mono text-xs text-muted-foreground">
-                                        #{item.number}
-                                      </span>
-                                      <span className="min-w-0 flex-1 truncate text-xs">
-                                        {item.title}
-                                      </span>
-                                      <Check className="size-3.5 shrink-0 opacity-0 group-data-[selected=true]:opacity-100" />
-                                    </CommandItem>
-                                  ))}
-                                </CommandGroup>
-                              ) : null}
-                            </CommandList>
-                          </Command>
-                        </PopoverContent>
-                      </Popover>
-                    </div>
-                  </TooltipTrigger>
-                  <TooltipContent side="top" sideOffset={6}>
-                    Add GH Issue / PR
-                  </TooltipContent>
-                </Tooltip>
-
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span>
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="icon-sm"
-                        disabled
-                        className="text-muted-foreground/70"
-                        aria-label="Link Linear issue"
-                      >
-                        <LinearIcon className="size-3.5" />
-                      </Button>
-                    </span>
-                  </TooltipTrigger>
-                  <TooltipContent side="top" sideOffset={6}>
-                    coming soon
+                    Configure agents
                   </TooltipContent>
                 </Tooltip>
               </div>
-
               <Select
-                value={tuiAgent}
+                value={quickAgent ?? '__none__'}
                 onValueChange={(value) => {
-                  onTuiAgentChange(value as TuiAgent)
-                  focusPromptInput()
+                  onQuickAgentChange(value === '__none__' ? null : (value as TuiAgent))
                 }}
               >
-                <SelectTrigger
-                  size="sm"
-                  className={cn(
-                    'h-8 min-w-[124px] transition-opacity',
-                    !agentPrompt.trim() &&
-                      !linkedOnlyTemplatePreview &&
-                      'opacity-60 hover:opacity-100 grayscale-[0.5]'
-                  )}
-                >
+                <SelectTrigger size="sm" className="h-9 min-w-[148px]">
                   <SelectValue>
                     <span className="flex items-center gap-2">
-                      <AgentIcon agent={tuiAgent} />
-                      <span>{AGENT_CATALOG.find((a) => a.id === tuiAgent)?.label ?? tuiAgent}</span>
+                      {quickAgent ? (
+                        <AgentIcon agent={quickAgent} />
+                      ) : (
+                        <Folder className="size-4" />
+                      )}
+                      <span>
+                        {quickAgent
+                          ? (AGENT_CATALOG.find((a) => a.id === quickAgent)?.label ?? quickAgent)
+                          : 'No agent'}
+                      </span>
                     </span>
                   </SelectValue>
                 </SelectTrigger>
                 <SelectContent align="end">
-                  {AGENT_CATALOG.filter(
-                    (a) => detectedAgentIds === null || detectedAgentIds.has(a.id)
-                  ).map((option) => (
+                  <SelectItem value="__none__">
+                    <span className="flex items-center gap-2">
+                      <Folder className="size-4" />
+                      <span>No agent</span>
+                    </span>
+                  </SelectItem>
+                  {visibleQuickAgents.map((option) => (
                     <SelectItem key={option.id} value={option.id}>
                       <span className="flex items-center gap-2">
                         <AgentIcon agent={option.id} />
@@ -714,9 +429,7 @@ export default function NewWorkspaceComposerCard({
             <div className="flex justify-end">
               <Button onClick={() => void onCreate()} disabled={createDisabled} size="sm">
                 {creating ? <LoaderCircle className="size-4 animate-spin" /> : null}
-                {agentPrompt.trim() || linkedOnlyTemplatePreview
-                  ? 'Start Agent'
-                  : 'Create Workspace'}
+                Create Workspace
                 <span className="ml-1 rounded-full border border-white/20 p-1 text-current/80">
                   <CornerDownLeft className="size-3" />
                 </span>

--- a/src/renderer/src/components/NewWorkspaceComposerCard.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.tsx
@@ -2,15 +2,7 @@
 composer card markup together so the inline and modal variants share one UI
 surface without splitting the controlled form into hard-to-follow fragments. */
 import React from 'react'
-import {
-  Check,
-  ChevronDown,
-  CornerDownLeft,
-  Folder,
-  FolderPlus,
-  LoaderCircle,
-  Settings2
-} from 'lucide-react'
+import { Check, ChevronDown, CornerDownLeft, LoaderCircle, Terminal } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import {
@@ -20,13 +12,10 @@ import {
   SelectTrigger,
   SelectValue
 } from '@/components/ui/select'
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import RepoCombobox from '@/components/repo/RepoCombobox'
 import { AGENT_CATALOG, AgentIcon } from '@/lib/agent-catalog'
-import { useAppStore } from '@/store'
 import { cn } from '@/lib/utils'
 import type { TuiAgent } from '../../../shared/types'
-import { isGitRepoKind } from '../../../shared/repo-kind'
 
 type RepoOption = React.ComponentProps<typeof RepoCombobox>['repos'][number]
 
@@ -34,7 +23,6 @@ type NewWorkspaceComposerCardProps = {
   containerClassName?: string
   composerRef?: React.RefObject<HTMLDivElement | null>
   nameInputRef?: React.RefObject<HTMLInputElement | null>
-  repoAutoOpen?: boolean
   quickAgent: TuiAgent | null
   onQuickAgentChange: (agent: TuiAgent | null) => void
   eligibleRepos: RepoOption[]
@@ -199,7 +187,6 @@ export default function NewWorkspaceComposerCard({
   containerClassName,
   composerRef,
   nameInputRef,
-  repoAutoOpen = false,
   quickAgent,
   onQuickAgentChange,
   eligibleRepos,
@@ -225,9 +212,6 @@ export default function NewWorkspaceComposerCard({
   createError
 }: NewWorkspaceComposerCardProps): React.JSX.Element {
   const { isFileDragOver, dragHandlers } = useComposerFileDragOver()
-  const addRepo = useAppStore((s) => s.addRepo)
-  const fetchWorktrees = useAppStore((s) => s.fetchWorktrees)
-  const [isAddingRepo, setIsAddingRepo] = React.useState(false)
 
   const focusNameInput = React.useCallback(() => {
     // Why: after the repo picker commits a choice, moving focus to the name
@@ -243,26 +227,6 @@ export default function NewWorkspaceComposerCard({
       AGENT_CATALOG.filter((agent) => detectedAgentIds === null || detectedAgentIds.has(agent.id)),
     [detectedAgentIds]
   )
-
-  const handleAddRepo = React.useCallback(async (): Promise<void> => {
-    if (isAddingRepo) {
-      return
-    }
-    setIsAddingRepo(true)
-    try {
-      const repo = await addRepo()
-      if (!repo) {
-        return
-      }
-      if (isGitRepoKind(repo)) {
-        await fetchWorktrees(repo.id)
-      }
-      onRepoChange(repo.id)
-      focusNameInput()
-    } finally {
-      setIsAddingRepo(false)
-    }
-  }, [addRepo, fetchWorktrees, focusNameInput, isAddingRepo, onRepoChange])
 
   return (
     <div className="grid gap-3">
@@ -285,30 +249,8 @@ export default function NewWorkspaceComposerCard({
         <div className="grid gap-3">
           <div className="grid gap-4">
             <div className="grid gap-1.5">
-              <div className="flex items-center justify-between gap-2 px-1">
-                <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
-                  Repository
-                </div>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon-xs"
-                      disabled={isAddingRepo}
-                      onClick={() => void handleAddRepo()}
-                      className="size-5 shrink-0 rounded-sm text-muted-foreground hover:text-foreground"
-                      aria-label={
-                        isAddingRepo ? 'Adding folder or repository' : 'Add folder or repository'
-                      }
-                    >
-                      <FolderPlus className="size-3" />
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent side="top" sideOffset={6}>
-                    Add repo
-                  </TooltipContent>
-                </Tooltip>
+              <div className="px-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                Repository
               </div>
               <RepoCombobox
                 repos={eligibleRepos}
@@ -316,8 +258,13 @@ export default function NewWorkspaceComposerCard({
                 onValueChange={onRepoChange}
                 onValueSelected={focusNameInput}
                 placeholder="Choose repository"
-                triggerClassName="h-9"
-                autoFocusTriggerOnMount={repoAutoOpen}
+                // Why: programmatic .focus() from the Dialog's onOpenAutoFocus
+                // handler does not reliably trigger :focus-visible in
+                // Chromium. Mirror the Input component's standard ring
+                // (border-ring + ring-ring/50, 3px) onto :focus so the
+                // autofocused repo trigger paints the familiar field ring
+                // instead of leaving no visible focus state.
+                triggerClassName="h-9 focus:border-ring focus:ring-[3px] focus:ring-ring/50"
                 showStandaloneAddButton={false}
               />
             </div>
@@ -335,28 +282,9 @@ export default function NewWorkspaceComposerCard({
               />
             </label>
             <div className="grid gap-1.5">
-              <div className="flex items-center justify-between gap-2 px-1">
-                <span className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
-                  Agent
-                </span>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon-xs"
-                      onClick={onOpenAgentSettings}
-                      className="size-5 shrink-0 rounded-sm text-muted-foreground hover:text-foreground"
-                      aria-label="Open agent settings"
-                    >
-                      <Settings2 className="size-3" />
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent side="top" sideOffset={6}>
-                    Configure agents
-                  </TooltipContent>
-                </Tooltip>
-              </div>
+              <span className="px-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                Agent
+              </span>
               <Select
                 value={quickAgent ?? '__none__'}
                 onValueChange={(value) => {
@@ -369,12 +297,12 @@ export default function NewWorkspaceComposerCard({
                       {quickAgent ? (
                         <AgentIcon agent={quickAgent} />
                       ) : (
-                        <Folder className="size-4" />
+                        <Terminal className="size-4" />
                       )}
                       <span>
                         {quickAgent
                           ? (AGENT_CATALOG.find((a) => a.id === quickAgent)?.label ?? quickAgent)
-                          : 'No agent'}
+                          : 'Blank Terminal'}
                       </span>
                     </span>
                   </SelectValue>
@@ -382,8 +310,8 @@ export default function NewWorkspaceComposerCard({
                 <SelectContent align="end">
                   <SelectItem value="__none__">
                     <span className="flex items-center gap-2">
-                      <Folder className="size-4" />
-                      <span>No agent</span>
+                      <Terminal className="size-4" />
+                      <span>Blank Terminal</span>
                     </span>
                   </SelectItem>
                   {visibleQuickAgents.map((option) => (

--- a/src/renderer/src/components/NewWorkspaceComposerCard.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.tsx
@@ -2,14 +2,24 @@
 composer card markup together so the inline and modal variants share one UI
 surface without splitting the controlled form into hard-to-follow fragments. */
 import React from 'react'
-import { Check, ChevronDown, CornerDownLeft, LoaderCircle } from 'lucide-react'
+import {
+  Check,
+  ChevronDown,
+  CornerDownLeft,
+  FolderPlus,
+  LoaderCircle,
+  Settings2
+} from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import RepoCombobox from '@/components/repo/RepoCombobox'
 import AgentCombobox from '@/components/agent/AgentCombobox'
 import { AGENT_CATALOG } from '@/lib/agent-catalog'
+import { useAppStore } from '@/store'
 import { cn } from '@/lib/utils'
 import type { TuiAgent } from '../../../shared/types'
+import { isGitRepoKind } from '../../../shared/repo-kind'
 
 const isMac = typeof navigator !== 'undefined' && navigator.userAgent.includes('Mac')
 
@@ -44,32 +54,6 @@ type NewWorkspaceComposerCardProps = {
   createError: string | null
 }
 
-function renderSetupYamlPreview(command: string): React.JSX.Element[] {
-  const lines = ['scripts:', '  setup: |', ...command.split('\n').map((line) => `    ${line}`)]
-
-  return lines.map((line, index) => {
-    const keyMatch = line.match(/^(\s*)([a-zA-Z][\w-]*)(:\s*)(\|)?$/)
-    if (keyMatch) {
-      return (
-        <div key={`${line}-${index}`} className="whitespace-pre">
-          <span className="text-muted-foreground">{keyMatch[1]}</span>
-          <span className="font-semibold text-sky-600 dark:text-sky-300">{keyMatch[2]}</span>
-          <span className="text-muted-foreground">{keyMatch[3]}</span>
-          {keyMatch[4] ? (
-            <span className="text-amber-600 dark:text-amber-300">{keyMatch[4]}</span>
-          ) : null}
-        </div>
-      )
-    }
-
-    return (
-      <div key={`${line}-${index}`} className="whitespace-pre">
-        <span className="text-emerald-700 dark:text-emerald-300/95">{line}</span>
-      </div>
-    )
-  })
-}
-
 function SetupCommandPreview({
   setupConfig,
   headerAction
@@ -81,13 +65,11 @@ function SetupCommandPreview({
     return (
       <div className="rounded-2xl border border-border/60 bg-muted/40 shadow-inner">
         <div className="flex items-center justify-between gap-3 border-b border-border/60 px-4 py-2.5">
-          <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-muted-foreground">
-            orca.yaml
-          </div>
+          <div className="font-mono text-[11px] text-muted-foreground">orca.yaml</div>
           {headerAction}
         </div>
-        <pre className="overflow-x-auto px-4 py-4 font-mono text-[12px] leading-6 text-foreground">
-          {renderSetupYamlPreview(setupConfig.command)}
+        <pre className="overflow-x-auto whitespace-pre-wrap break-words px-4 py-3 font-mono text-[12px] leading-5 text-emerald-700 dark:text-emerald-300/95">
+          {setupConfig.command}
         </pre>
       </div>
     )
@@ -208,6 +190,18 @@ export default function NewWorkspaceComposerCard({
   createError
 }: NewWorkspaceComposerCardProps): React.JSX.Element {
   const { isFileDragOver, dragHandlers } = useComposerFileDragOver()
+  const addRepo = useAppStore((s) => s.addRepo)
+  const fetchWorktrees = useAppStore((s) => s.fetchWorktrees)
+  const defaultTuiAgent = useAppStore((s) => s.settings?.defaultTuiAgent ?? null)
+  const updateSettings = useAppStore((s) => s.updateSettings)
+  const [isAddingRepo, setIsAddingRepo] = React.useState(false)
+
+  const handleSetDefaultAgent = React.useCallback(
+    (next: TuiAgent | 'blank' | null) => {
+      updateSettings({ defaultTuiAgent: next })
+    },
+    [updateSettings]
+  )
 
   const focusNameInput = React.useCallback(() => {
     // Why: after the repo picker commits a choice, moving focus to the name
@@ -223,6 +217,26 @@ export default function NewWorkspaceComposerCard({
       AGENT_CATALOG.filter((agent) => detectedAgentIds === null || detectedAgentIds.has(agent.id)),
     [detectedAgentIds]
   )
+
+  const handleAddRepo = React.useCallback(async (): Promise<void> => {
+    if (isAddingRepo) {
+      return
+    }
+    setIsAddingRepo(true)
+    try {
+      const repo = await addRepo()
+      if (!repo) {
+        return
+      }
+      if (isGitRepoKind(repo)) {
+        await fetchWorktrees(repo.id)
+      }
+      onRepoChange(repo.id)
+      focusNameInput()
+    } finally {
+      setIsAddingRepo(false)
+    }
+  }, [addRepo, fetchWorktrees, focusNameInput, isAddingRepo, onRepoChange])
 
   return (
     <div
@@ -242,8 +256,33 @@ export default function NewWorkspaceComposerCard({
       )}
     >
       <div className="space-y-4">
-        <div className="space-y-1">
-          <label className="text-[11px] font-medium text-muted-foreground">Repository</label>
+        {/* Why: w-fit keeps the label+icon row the same width as the combobox
+            trigger beneath it so the action icon visually anchors to the
+            trigger's right edge rather than stretching to the dialog edge. */}
+        <div className="w-fit space-y-1">
+          <div className="flex items-center justify-between gap-2">
+            <label className="text-[11px] font-medium text-muted-foreground">Repository</label>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-xs"
+                  disabled={isAddingRepo}
+                  onClick={() => void handleAddRepo()}
+                  className="size-5 shrink-0 rounded-sm text-muted-foreground hover:text-foreground"
+                  aria-label={
+                    isAddingRepo ? 'Adding folder or repository' : 'Add folder or repository'
+                  }
+                >
+                  <FolderPlus className="size-3" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="top" sideOffset={6}>
+                Add repo
+              </TooltipContent>
+            </Tooltip>
+          </div>
           <RepoCombobox
             repos={eligibleRepos}
             value={repoId}
@@ -262,23 +301,46 @@ export default function NewWorkspaceComposerCard({
         </div>
 
         <div className="space-y-1">
-          <label className="text-[11px] font-medium text-muted-foreground">Workspace</label>
+          <label className="text-[11px] font-medium text-muted-foreground">
+            Workspace Name <span className="text-muted-foreground/70">[Optional]</span>
+          </label>
           <Input
             ref={nameInputRef}
             value={name}
             onChange={onNameChange}
-            placeholder="Optional workspace name"
+            placeholder="Workspace name"
             className="h-8 text-xs"
           />
         </div>
 
-        <div className="space-y-1">
-          <label className="text-[11px] font-medium text-muted-foreground">Agent</label>
+        <div className="w-fit space-y-1">
+          <div className="flex items-center justify-between gap-2">
+            <label className="text-[11px] font-medium text-muted-foreground">Agent</label>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-xs"
+                  onClick={onOpenAgentSettings}
+                  className="size-5 shrink-0 rounded-sm text-muted-foreground hover:text-foreground"
+                  aria-label="Open agent settings"
+                >
+                  <Settings2 className="size-3" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="top" sideOffset={6}>
+                Configure agents
+              </TooltipContent>
+            </Tooltip>
+          </div>
           <AgentCombobox
             agents={visibleQuickAgents}
             value={quickAgent}
             onValueChange={onQuickAgentChange}
             onOpenManageAgents={onOpenAgentSettings}
+            defaultAgent={defaultTuiAgent}
+            onSetDefault={handleSetDefaultAgent}
             triggerClassName="h-8 border-input text-xs focus:border-ring focus:ring-[3px] focus:ring-ring/50"
           />
         </div>
@@ -291,7 +353,11 @@ export default function NewWorkspaceComposerCard({
           aria-hidden={!advancedOpen}
         >
           <div className="min-h-0">
-            <div className="space-y-4 pt-1">
+            {/* Why: px-1 insets the content 4px on each side so the Note
+                textarea's 3px outset focus ring has horizontal breathing room
+                inside the overflow-hidden drawer above. Without it the ring
+                gets clipped on the right edge when the field is focused. */}
+            <div className="space-y-4 px-1 pt-1">
               <div className="space-y-1">
                 <label className="text-[11px] font-medium text-muted-foreground">Note</label>
                 <textarea

--- a/src/renderer/src/components/NewWorkspaceComposerCard.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.tsx
@@ -59,6 +59,7 @@ type NewWorkspaceComposerCardProps = {
   composerRef?: React.RefObject<HTMLDivElement | null>
   nameInputRef?: React.RefObject<HTMLInputElement | null>
   promptTextareaRef?: React.RefObject<HTMLTextAreaElement | null>
+  repoAutoOpen?: boolean
   eligibleRepos: RepoOption[]
   repoId: string
   onRepoChange: (value: string) => void
@@ -334,6 +335,7 @@ export default function NewWorkspaceComposerCard({
   composerRef,
   nameInputRef,
   promptTextareaRef,
+  repoAutoOpen = false,
   eligibleRepos,
   repoId,
   onRepoChange,
@@ -409,6 +411,7 @@ export default function NewWorkspaceComposerCard({
                 onValueChange={onRepoChange}
                 placeholder="Choose repository"
                 triggerClassName="h-9"
+                autoOpenOnMount={repoAutoOpen}
               />
             </div>
             <label className="grid gap-1.5">

--- a/src/renderer/src/components/NewWorkspaceComposerModal.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerModal.tsx
@@ -62,16 +62,6 @@ function ComposerModalBody({
       onCreated: onClose
     })
 
-  // Why: focusing the first text field is more predictable than landing on a
-  // combobox trigger; users can immediately type a name while the repo choice
-  // remains visible and one click away.
-  useEffect(() => {
-    const frame = requestAnimationFrame(() => {
-      nameInputRef.current?.focus()
-    })
-    return () => cancelAnimationFrame(frame)
-  }, [nameInputRef])
-
   // Enter submits, Esc first blurs the focused input (like the full page).
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent): void => {
@@ -121,8 +111,10 @@ function ComposerModalBody({
         className="max-w-[calc(100vw-2rem)] border-none bg-transparent p-0 shadow-none sm:max-w-[920px]"
         showCloseButton={false}
         onOpenAutoFocus={(event) => {
+          // Why: the repo combobox opens itself on mount and then focuses the
+          // search input inside its popover. Prevent Dialog from stealing focus
+          // to another control before that handoff completes.
           event.preventDefault()
-          nameInputRef.current?.focus()
         }}
       >
         <DialogTitle className="sr-only">Create New Workspace</DialogTitle>
@@ -134,6 +126,7 @@ function ComposerModalBody({
           composerRef={composerRef}
           nameInputRef={nameInputRef}
           promptTextareaRef={promptTextareaRef}
+          repoAutoOpen
           {...cardProps}
         />
       </DialogContent>

--- a/src/renderer/src/components/NewWorkspaceComposerModal.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerModal.tsx
@@ -1,6 +1,12 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { useAppStore } from '@/store'
-import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog'
 import NewWorkspaceComposerCard from '@/components/NewWorkspaceComposerCard'
 import { useComposerState } from '@/hooks/useComposerState'
 import { AGENT_CATALOG } from '@/lib/agent-catalog'
@@ -89,7 +95,7 @@ function ComposerModalBody({
     await submitQuick(quickAgent)
   }, [quickAgent, submitQuick])
 
-  // Enter submits, Esc first blurs the focused input (like the full page).
+  // Cmd/Ctrl+Enter submits, Esc first blurs the focused input (like the full page).
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent): void => {
       if (event.key !== 'Enter' && event.key !== 'Escape') {
@@ -116,6 +122,14 @@ function ComposerModalBody({
         return
       }
 
+      // Why: require the platform modifier (Cmd on macOS, Ctrl elsewhere) so
+      // plain Enter inside fields (notes, repo search) doesn't accidentally
+      // submit — users can type or confirm selections without triggering
+      // workspace creation.
+      const hasModifier = event.metaKey || event.ctrlKey
+      if (!hasModifier) {
+        return
+      }
       if (!composerRef.current?.contains(target)) {
         return
       }
@@ -135,8 +149,7 @@ function ComposerModalBody({
   return (
     <Dialog open onOpenChange={onOpenChange}>
       <DialogContent
-        className="max-w-[calc(100vw-2rem)] border-none bg-transparent p-0 shadow-none sm:max-w-[480px]"
-        showCloseButton={false}
+        className="sm:max-w-md"
         onOpenAutoFocus={(event) => {
           // Why: Radix's FocusScope fires this once the dialog has mounted and
           // the DOM is ready. preventDefault stops it from focusing the first
@@ -154,12 +167,13 @@ function ComposerModalBody({
           trigger?.focus({ preventScroll: true })
         }}
       >
-        <DialogTitle className="sr-only">Create New Workspace</DialogTitle>
-        <DialogDescription className="sr-only">
-          Configure a name and prompt for the new workspace.
-        </DialogDescription>
+        <DialogHeader>
+          <DialogTitle className="text-sm">Create Workspace</DialogTitle>
+          <DialogDescription className="text-xs">
+            Pick a repository and agent to spin up a new workspace.
+          </DialogDescription>
+        </DialogHeader>
         <NewWorkspaceComposerCard
-          containerClassName="bg-card/98 shadow-2xl supports-[backdrop-filter]:bg-card/95"
           composerRef={composerRef}
           nameInputRef={nameInputRef}
           quickAgent={quickAgent}

--- a/src/renderer/src/components/NewWorkspaceComposerModal.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerModal.tsx
@@ -1,14 +1,15 @@
-import React, { useCallback, useEffect } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { useAppStore } from '@/store'
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog'
 import NewWorkspaceComposerCard from '@/components/NewWorkspaceComposerCard'
 import { useComposerState } from '@/hooks/useComposerState'
+import { AGENT_CATALOG } from '@/lib/agent-catalog'
 import type { LinkedWorkItemSummary } from '@/lib/new-workspace'
 import { shouldSuppressEnterSubmit } from '@/lib/new-workspace-enter-guard'
+import type { TuiAgent } from '../../../shared/types'
 
 type ComposerModalData = {
   prefilledName?: string
-  prefilledPrompt?: string
   initialRepoId?: string
   linkedWorkItem?: LinkedWorkItemSummary | null
 }
@@ -52,15 +53,41 @@ function ComposerModalBody({
   onClose: () => void
   onOpenChange: (open: boolean) => void
 }): React.JSX.Element {
-  const { cardProps, composerRef, promptTextareaRef, nameInputRef, submit, createDisabled } =
-    useComposerState({
-      initialName: modalData.prefilledName ?? '',
-      initialPrompt: modalData.prefilledPrompt ?? '',
-      initialLinkedWorkItem: modalData.linkedWorkItem ?? null,
-      initialRepoId: modalData.initialRepoId,
-      persistDraft: false,
-      onCreated: onClose
-    })
+  const settings = useAppStore((s) => s.settings)
+  const { cardProps, composerRef, nameInputRef, submitQuick, createDisabled } = useComposerState({
+    initialName: modalData.prefilledName ?? '',
+    // Why: the modal is quick-create only now, so prompt-prefill state is
+    // intentionally ignored even if older callers still send it.
+    initialPrompt: '',
+    initialLinkedWorkItem: modalData.linkedWorkItem ?? null,
+    initialRepoId: modalData.initialRepoId,
+    persistDraft: false,
+    onCreated: onClose
+  })
+  const [quickAgentTouched, setQuickAgentTouched] = useState(false)
+  const preferredQuickAgent = useMemo<TuiAgent | null>(() => {
+    if (settings?.defaultTuiAgent) {
+      return settings.defaultTuiAgent
+    }
+    const detected = cardProps.detectedAgentIds
+    return AGENT_CATALOG.find((agent) => detected === null || detected.has(agent.id))?.id ?? null
+  }, [cardProps.detectedAgentIds, settings?.defaultTuiAgent])
+  const [quickAgent, setQuickAgent] = useState<TuiAgent | null>(preferredQuickAgent)
+
+  useEffect(() => {
+    if (!quickAgentTouched) {
+      setQuickAgent(preferredQuickAgent)
+    }
+  }, [preferredQuickAgent, quickAgentTouched])
+
+  const handleQuickAgentChange = useCallback((agent: TuiAgent | null) => {
+    setQuickAgentTouched(true)
+    setQuickAgent(agent)
+  }, [])
+
+  const handleCreate = useCallback(async (): Promise<void> => {
+    await submitQuick(quickAgent)
+  }, [quickAgent, submitQuick])
 
   // Enter submits, Esc first blurs the focused input (like the full page).
   useEffect(() => {
@@ -95,15 +122,15 @@ function ComposerModalBody({
       if (createDisabled) {
         return
       }
-      if (shouldSuppressEnterSubmit(event, target instanceof HTMLTextAreaElement)) {
+      if (shouldSuppressEnterSubmit(event, false)) {
         return
       }
       event.preventDefault()
-      void submit()
+      void handleCreate()
     }
     window.addEventListener('keydown', onKeyDown, { capture: true })
     return () => window.removeEventListener('keydown', onKeyDown, { capture: true })
-  }, [composerRef, createDisabled, onClose, submit])
+  }, [composerRef, createDisabled, handleCreate, onClose])
 
   return (
     <Dialog open onOpenChange={onOpenChange}>
@@ -111,9 +138,10 @@ function ComposerModalBody({
         className="max-w-[calc(100vw-2rem)] border-none bg-transparent p-0 shadow-none sm:max-w-[920px]"
         showCloseButton={false}
         onOpenAutoFocus={(event) => {
-          // Why: the repo combobox opens itself on mount and then focuses the
-          // search input inside its popover. Prevent Dialog from stealing focus
-          // to another control before that handoff completes.
+          // Why: the repo field is still the first keyboard stop, but we no
+          // longer expand its suggestion list on mount. Prevent Dialog from
+          // moving focus elsewhere so the combobox trigger can claim focus
+          // after the dialog settles without covering the rest of the form.
           event.preventDefault()
         }}
       >
@@ -125,9 +153,11 @@ function ComposerModalBody({
           containerClassName="bg-card/98 shadow-2xl supports-[backdrop-filter]:bg-card/95"
           composerRef={composerRef}
           nameInputRef={nameInputRef}
-          promptTextareaRef={promptTextareaRef}
+          quickAgent={quickAgent}
+          onQuickAgentChange={handleQuickAgentChange}
           repoAutoOpen
           {...cardProps}
+          onCreate={() => void handleCreate()}
         />
       </DialogContent>
     </Dialog>

--- a/src/renderer/src/components/NewWorkspaceComposerModal.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerModal.tsx
@@ -135,14 +135,23 @@ function ComposerModalBody({
   return (
     <Dialog open onOpenChange={onOpenChange}>
       <DialogContent
-        className="max-w-[calc(100vw-2rem)] border-none bg-transparent p-0 shadow-none sm:max-w-[920px]"
+        className="max-w-[calc(100vw-2rem)] border-none bg-transparent p-0 shadow-none sm:max-w-[480px]"
         showCloseButton={false}
         onOpenAutoFocus={(event) => {
-          // Why: the repo field is still the first keyboard stop, but we no
-          // longer expand its suggestion list on mount. Prevent Dialog from
-          // moving focus elsewhere so the combobox trigger can claim focus
-          // after the dialog settles without covering the rest of the form.
+          // Why: Radix's FocusScope fires this once the dialog has mounted and
+          // the DOM is ready. preventDefault stops it from focusing the first
+          // tabbable (which would otherwise steal focus to whatever ships
+          // first in markup); we then focus the repo combobox trigger so the
+          // guessed value sits as a confirmed selection without opening its
+          // popover — matching the "default = selection, typing = search"
+          // combobox pattern. Doing it here (instead of a child rAF) avoids
+          // Strict-Mode effect double-invocation dropping the focus call.
           event.preventDefault()
+          const content = event.currentTarget as HTMLElement
+          const trigger = content.querySelector<HTMLElement>(
+            '[data-repo-combobox-root="true"][role="combobox"]'
+          )
+          trigger?.focus({ preventScroll: true })
         }}
       >
         <DialogTitle className="sr-only">Create New Workspace</DialogTitle>
@@ -155,7 +164,6 @@ function ComposerModalBody({
           nameInputRef={nameInputRef}
           quickAgent={quickAgent}
           onQuickAgentChange={handleQuickAgentChange}
-          repoAutoOpen
           {...cardProps}
           onCreate={() => void handleCreate()}
         />

--- a/src/renderer/src/components/NewWorkspaceComposerModal.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerModal.tsx
@@ -8,6 +8,7 @@ import {
   DialogTitle
 } from '@/components/ui/dialog'
 import NewWorkspaceComposerCard from '@/components/NewWorkspaceComposerCard'
+import AgentSettingsDialog from '@/components/agent/AgentSettingsDialog'
 import { useComposerState } from '@/hooks/useComposerState'
 import { AGENT_CATALOG } from '@/lib/agent-catalog'
 import type { LinkedWorkItemSummary } from '@/lib/new-workspace'
@@ -70,10 +71,22 @@ function ComposerModalBody({
     persistDraft: false,
     onCreated: onClose
   })
+  // Why: the composer's built-in `onOpenAgentSettings` handler navigates to
+  // the settings page and closes the modal. For the quick-create flow we want
+  // a less disruptive affordance — a nested dialog layered over the composer
+  // so the user can tweak agents without losing their in-progress workspace
+  // name/repo selection.
+  const [agentSettingsOpen, setAgentSettingsOpen] = useState(false)
   const [quickAgentTouched, setQuickAgentTouched] = useState(false)
   const preferredQuickAgent = useMemo<TuiAgent | null>(() => {
-    if (settings?.defaultTuiAgent) {
-      return settings.defaultTuiAgent
+    const pref = settings?.defaultTuiAgent
+    if (pref === 'blank') {
+      // Why: 'blank' is the explicit "no agent" preference — the quick agent
+      // model already uses null to mean "blank terminal", so translate here.
+      return null
+    }
+    if (pref) {
+      return pref
     }
     const detected = cardProps.detectedAgentIds
     return AGENT_CATALOG.find((agent) => detected === null || detected.has(agent.id))?.id ?? null
@@ -179,9 +192,11 @@ function ComposerModalBody({
           quickAgent={quickAgent}
           onQuickAgentChange={handleQuickAgentChange}
           {...cardProps}
+          onOpenAgentSettings={() => setAgentSettingsOpen(true)}
           onCreate={() => void handleCreate()}
         />
       </DialogContent>
+      <AgentSettingsDialog open={agentSettingsOpen} onOpenChange={setAgentSettingsOpen} />
     </Dialog>
   )
 }

--- a/src/renderer/src/components/NewWorkspaceComposerModal.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerModal.tsx
@@ -62,13 +62,15 @@ function ComposerModalBody({
       onCreated: onClose
     })
 
-  // Autofocus the prompt textarea on open.
+  // Why: focusing the first text field is more predictable than landing on a
+  // combobox trigger; users can immediately type a name while the repo choice
+  // remains visible and one click away.
   useEffect(() => {
     const frame = requestAnimationFrame(() => {
-      promptTextareaRef.current?.focus()
+      nameInputRef.current?.focus()
     })
     return () => cancelAnimationFrame(frame)
-  }, [promptTextareaRef])
+  }, [nameInputRef])
 
   // Enter submits, Esc first blurs the focused input (like the full page).
   useEffect(() => {
@@ -116,11 +118,11 @@ function ComposerModalBody({
   return (
     <Dialog open onOpenChange={onOpenChange}>
       <DialogContent
-        className="max-w-[calc(100vw-2rem)] border-none bg-transparent p-0 shadow-none sm:max-w-[880px]"
+        className="max-w-[calc(100vw-2rem)] border-none bg-transparent p-0 shadow-none sm:max-w-[920px]"
         showCloseButton={false}
         onOpenAutoFocus={(event) => {
           event.preventDefault()
-          promptTextareaRef.current?.focus()
+          nameInputRef.current?.focus()
         }}
       >
         <DialogTitle className="sr-only">Create New Workspace</DialogTitle>

--- a/src/renderer/src/components/NewWorkspacePage.tsx
+++ b/src/renderer/src/components/NewWorkspacePage.tsx
@@ -40,6 +40,7 @@ import GitHubItemDrawer from '@/components/GitHubItemDrawer'
 import { cn } from '@/lib/utils'
 import { getLinkedWorkItemSuggestedName, getTaskPresetQuery } from '@/lib/new-workspace'
 import type { LinkedWorkItemSummary } from '@/lib/new-workspace'
+import { launchWorkItemDirect } from '@/lib/launch-work-item-direct'
 import { isGitRepoKind } from '../../../shared/repo-kind'
 import type { GitHubWorkItem, TaskViewPresetId } from '../../../shared/types'
 import { shouldSuppressEnterSubmit } from '@/lib/new-workspace-enter-guard'
@@ -213,8 +214,8 @@ export default function NewWorkspacePage(): React.JSX.Element {
     return getCachedWorkItems(selectedRepo.path, WORK_ITEM_LIMIT, initialTaskQuery.trim()) ?? []
   })
   // Why: clicking a GitHub row opens this drawer for a read-only preview.
-  // The composer modal is only opened by the drawer's "Use" button, which
-  // calls the same handleSelectWorkItem as the old direct row-click flow.
+  // Drawer's "Use" button routes through the same direct-launch flow as the
+  // row-level "Use" CTA so behavior is consistent regardless of entry point.
   const [drawerWorkItem, setDrawerWorkItem] = useState<GitHubWorkItem | null>(null)
   const [newIssueOpen, setNewIssueOpen] = useState(false)
   const [newIssueTitle, setNewIssueTitle] = useState('')
@@ -362,11 +363,8 @@ export default function NewWorkspacePage(): React.JSX.Element {
     [handleApplyTaskSearch]
   )
 
-  const handleSelectWorkItem = useCallback(
+  const openComposerForItem = useCallback(
     (item: GitHubWorkItem): void => {
-      // Why: selecting a task from the list opens the same lightweight composer
-      // modal used by Cmd+J, so the prompt path is identical whether the user
-      // arrives via palette URL, picked issue/PR, or chose one from this list.
       const linkedWorkItem: LinkedWorkItemSummary = {
         type: item.type,
         number: item.number,
@@ -380,6 +378,23 @@ export default function NewWorkspacePage(): React.JSX.Element {
       })
     },
     [openModal, repoId]
+  )
+
+  const handleUseWorkItem = useCallback(
+    (item: GitHubWorkItem): void => {
+      // Why: the "Use" CTA is the primary way to start work from this page, so
+      // skip the composer for the common case and create+activate the workspace
+      // immediately, launch the user's default agent, and paste the work item
+      // URL into the agent's input as a reviewable draft. Fall back to the
+      // composer modal only when explicit per-workspace decisions are required
+      // (setupRunPolicy === 'ask') or the repo/agent resolution fails.
+      void launchWorkItemDirect({
+        item,
+        repoId,
+        openModalFallback: () => openComposerForItem(item)
+      })
+    },
+    [openComposerForItem, repoId]
   )
 
   const handleCreateNewIssue = useCallback(async (): Promise<void> => {
@@ -814,7 +829,7 @@ export default function NewWorkspacePage(): React.JSX.Element {
                             type="button"
                             onClick={(e) => {
                               e.stopPropagation()
-                              handleSelectWorkItem(item)
+                              handleUseWorkItem(item)
                             }}
                             className="inline-flex items-center gap-1 rounded-xl border border-border/50 bg-background/50 backdrop-blur-md px-3 py-1.5 text-sm text-foreground transition hover:bg-muted/60 supports-[backdrop-filter]:bg-background/50"
                           >
@@ -933,7 +948,7 @@ export default function NewWorkspacePage(): React.JSX.Element {
         repoPath={selectedRepo?.path ?? null}
         onUse={(item) => {
           setDrawerWorkItem(null)
-          handleSelectWorkItem(item)
+          handleUseWorkItem(item)
         }}
         onClose={() => setDrawerWorkItem(null)}
       />

--- a/src/renderer/src/components/agent/AgentCombobox.tsx
+++ b/src/renderer/src/components/agent/AgentCombobox.tsx
@@ -1,0 +1,252 @@
+import React, { useCallback, useMemo, useState } from 'react'
+import { Check, ChevronsUpDown, Terminal } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import {
+  Command,
+  CommandEmpty,
+  CommandInput,
+  CommandItem,
+  CommandList
+} from '@/components/ui/command'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { AgentIcon, type AgentCatalogEntry } from '@/lib/agent-catalog'
+import { cn } from '@/lib/utils'
+import type { TuiAgent } from '../../../../shared/types'
+
+type AgentComboboxProps = {
+  agents: AgentCatalogEntry[]
+  value: TuiAgent | null
+  onValueChange: (agent: TuiAgent | null) => void
+  onValueSelected?: (agent: TuiAgent | null) => void
+  onOpenManageAgents?: () => void
+  triggerClassName?: string
+}
+
+const BLANK_VALUE = '__none__'
+
+function searchAgents(agents: AgentCatalogEntry[], rawQuery: string): AgentCatalogEntry[] {
+  const query = rawQuery.trim().toLowerCase()
+  if (!query) {
+    return agents
+  }
+  // Why: cheap prefix-favored sort — label matches starting earlier in the
+  // string outrank later matches, mirroring repo-search semantics so the
+  // two comboboxes feel consistent.
+  const matches: { agent: AgentCatalogEntry; score: number; index: number }[] = []
+  agents.forEach((agent, index) => {
+    const labelIdx = agent.label.toLowerCase().indexOf(query)
+    const idIdx = agent.id.toLowerCase().indexOf(query)
+    const score = labelIdx !== -1 ? labelIdx : idIdx !== -1 ? 1000 + idIdx : -1
+    if (score !== -1) {
+      matches.push({ agent, score, index })
+    }
+  })
+  matches.sort((a, b) => a.score - b.score || a.index - b.index)
+  return matches.map((m) => m.agent)
+}
+
+export default function AgentCombobox({
+  agents,
+  value,
+  onValueChange,
+  onValueSelected,
+  onOpenManageAgents,
+  triggerClassName
+}: AgentComboboxProps): React.JSX.Element {
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  // Why: controlled cmdk selection so hovering the footer (which lives outside
+  // the cmdk tree) can clear the list's highlighted item — otherwise cmdk keeps
+  // the last-hovered agent visually selected while the mouse is on the footer.
+  const [commandValue, setCommandValue] = useState('')
+  const triggerRef = React.useRef<HTMLButtonElement | null>(null)
+
+  const selectedAgent = useMemo<AgentCatalogEntry | null>(
+    () => (value ? (agents.find((agent) => agent.id === value) ?? null) : null),
+    [agents, value]
+  )
+  const filteredAgents = useMemo(() => searchAgents(agents, query), [agents, query])
+  const blankMatchesQuery = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    if (!q) {
+      return true
+    }
+    return 'blank terminal'.includes(q) || 'terminal'.startsWith(q)
+  }, [query])
+
+  React.useEffect(() => {
+    if (!open) {
+      return
+    }
+    setCommandValue(value ?? BLANK_VALUE)
+    const frame = requestAnimationFrame(() => {
+      const searchInput = document.querySelector<HTMLInputElement>(
+        '[data-agent-combobox-root="true"] [data-slot="command-input"]'
+      )
+      if (!searchInput) {
+        return
+      }
+      searchInput.focus()
+      // Why: when a printable keydown on the trigger seeded the query, the user
+      // expects the next keystroke to append to what they typed — not replace
+      // it — so drop the caret at the end instead of selecting all.
+      const end = searchInput.value.length
+      searchInput.setSelectionRange(end, end)
+    })
+    return () => cancelAnimationFrame(frame)
+  }, [open, value])
+
+  const handleOpenChange = useCallback((nextOpen: boolean) => {
+    setOpen(nextOpen)
+    if (!nextOpen) {
+      setQuery('')
+    }
+  }, [])
+
+  const handleSelect = useCallback(
+    (nextValue: TuiAgent | null) => {
+      onValueChange(nextValue)
+      setOpen(false)
+      setQuery('')
+      onValueSelected?.(nextValue)
+    },
+    [onValueChange, onValueSelected]
+  )
+
+  // Why: mirror RepoCombobox's trigger-keydown handling — the button-style
+  // trigger treats the current value as a confirmed selection. Plain focus does
+  // not open the dropdown. Only explicit intent opens: Arrow keys open without
+  // filtering; a printable non-whitespace char opens AND seeds the search
+  // query (treating the keystroke as the start of a new search).
+  const handleTriggerKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLButtonElement>) => {
+      if (open) {
+        return
+      }
+      if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+        event.preventDefault()
+        setOpen(true)
+        return
+      }
+      if (event.metaKey || event.ctrlKey || event.altKey) {
+        return
+      }
+      if (event.key.length === 1 && /\S/.test(event.key)) {
+        event.preventDefault()
+        setQuery(event.key)
+        setOpen(true)
+      }
+    },
+    [open]
+  )
+
+  return (
+    <div className="flex items-center">
+      <Popover open={open} onOpenChange={handleOpenChange}>
+        <PopoverTrigger asChild>
+          <Button
+            ref={triggerRef}
+            type="button"
+            variant="outline"
+            role="combobox"
+            aria-expanded={open}
+            onKeyDown={handleTriggerKeyDown}
+            className={cn(
+              'h-8 min-w-[184px] justify-between px-3 text-xs font-normal',
+              triggerClassName
+            )}
+            data-agent-combobox-root="true"
+          >
+            {selectedAgent ? (
+              <span className="inline-flex min-w-0 items-center gap-1.5">
+                <AgentIcon agent={selectedAgent.id} />
+                <span className="truncate">{selectedAgent.label}</span>
+              </span>
+            ) : (
+              <span className="inline-flex min-w-0 items-center gap-1.5">
+                <Terminal className="size-3.5" />
+                <span className="truncate">Blank Terminal</span>
+              </span>
+            )}
+            <ChevronsUpDown className="size-3.5 opacity-50" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent
+          align="start"
+          className="w-72 p-0"
+          data-agent-combobox-root="true"
+          onOpenAutoFocus={(event) => event.preventDefault()}
+        >
+          <Command shouldFilter={false} value={commandValue} onValueChange={setCommandValue}>
+            <CommandInput placeholder="Search agents..." value={query} onValueChange={setQuery} />
+            <CommandList>
+              <CommandEmpty>No agents match your search.</CommandEmpty>
+              {blankMatchesQuery ? (
+                <CommandItem
+                  key={BLANK_VALUE}
+                  value={BLANK_VALUE}
+                  onSelect={() => handleSelect(null)}
+                  className="items-center gap-2 px-3 py-1.5"
+                >
+                  <Check
+                    className={cn(
+                      'size-4 text-foreground',
+                      value === null ? 'opacity-100' : 'opacity-0'
+                    )}
+                  />
+                  <span className="inline-flex min-w-0 flex-1 items-center gap-1.5">
+                    <Terminal className="size-3.5" />
+                    <span className="truncate">Blank Terminal</span>
+                  </span>
+                </CommandItem>
+              ) : null}
+              {filteredAgents.map((agent) => (
+                <CommandItem
+                  key={agent.id}
+                  value={agent.id}
+                  onSelect={() => handleSelect(agent.id)}
+                  className="items-center gap-2 px-3 py-1.5"
+                >
+                  <Check
+                    className={cn(
+                      'size-4 text-foreground',
+                      value === agent.id ? 'opacity-100' : 'opacity-0'
+                    )}
+                  />
+                  <span className="inline-flex min-w-0 flex-1 items-center gap-1.5">
+                    <AgentIcon agent={agent.id} />
+                    <span className="truncate">{agent.label}</span>
+                  </span>
+                </CommandItem>
+              ))}
+            </CommandList>
+            {onOpenManageAgents ? (
+              <div className="border-t border-border">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  onClick={onOpenManageAgents}
+                  onMouseDown={(event) => event.preventDefault()}
+                  onMouseEnter={() => setCommandValue('')}
+                  className="h-9 w-full justify-start rounded-none px-3 text-xs font-normal text-muted-foreground"
+                >
+                  Manage agents
+                  <svg
+                    className="ml-auto size-3"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    aria-hidden
+                  >
+                    <path d="M5 12h14M12 5l7 7-7 7" />
+                  </svg>
+                </Button>
+              </div>
+            ) : null}
+          </Command>
+        </PopoverContent>
+      </Popover>
+    </div>
+  )
+}

--- a/src/renderer/src/components/agent/AgentCombobox.tsx
+++ b/src/renderer/src/components/agent/AgentCombobox.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useState } from 'react'
-import { Check, ChevronsUpDown, Terminal } from 'lucide-react'
+import { Check, ChevronsUpDown, Star, Terminal } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
   Command,
@@ -8,10 +8,18 @@ import {
   CommandItem,
   CommandList
 } from '@/components/ui/command'
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger
+} from '@/components/ui/context-menu'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { AgentIcon, type AgentCatalogEntry } from '@/lib/agent-catalog'
 import { cn } from '@/lib/utils'
 import type { TuiAgent } from '../../../../shared/types'
+
+type DefaultAgentPreference = TuiAgent | 'blank' | null
 
 type AgentComboboxProps = {
   agents: AgentCatalogEntry[]
@@ -19,10 +27,70 @@ type AgentComboboxProps = {
   onValueChange: (agent: TuiAgent | null) => void
   onValueSelected?: (agent: TuiAgent | null) => void
   onOpenManageAgents?: () => void
+  /** Current saved default agent preference. Used to render a subtle "default"
+   *  indicator in the list and to tell which right-click menu item is the
+   *  currently-applied choice. */
+  defaultAgent?: DefaultAgentPreference
+  /** Optional handler for right-click "Set as default" action. When provided,
+   *  each list item (including Blank Terminal) gets a context menu. */
+  onSetDefault?: (agent: DefaultAgentPreference) => void
   triggerClassName?: string
 }
 
 const BLANK_VALUE = '__none__'
+
+type ItemRenderArgs = {
+  key: string
+  itemValue: string
+  isChecked: boolean
+  isDefault: boolean
+  onSelect: () => void
+  onSetDefault?: () => void
+  icon: React.ReactNode
+  label: string
+}
+
+function renderItem({
+  key,
+  itemValue,
+  isChecked,
+  isDefault,
+  onSelect,
+  onSetDefault,
+  icon,
+  label
+}: ItemRenderArgs): React.ReactNode {
+  const row = (
+    <CommandItem
+      key={key}
+      value={itemValue}
+      onSelect={onSelect}
+      className="items-center gap-2 px-3 py-1.5"
+    >
+      <Check className={cn('size-4 text-foreground', isChecked ? 'opacity-100' : 'opacity-0')} />
+      <span className="inline-flex min-w-0 flex-1 items-center gap-1.5">
+        {icon}
+        <span className="truncate">{label}</span>
+      </span>
+    </CommandItem>
+  )
+  if (!onSetDefault) {
+    return row
+  }
+  return (
+    // Why: z-[70] sits above PopoverContent's z-[60] so the right-click menu
+    // renders in front of the still-open combobox popover instead of behind it.
+    <ContextMenu key={key}>
+      <ContextMenuTrigger asChild>{row}</ContextMenuTrigger>
+      <ContextMenuContent className="z-[70]">
+        <ContextMenuItem onSelect={onSetDefault} disabled={isDefault}>
+          <Star className="size-3.5" />
+          {isDefault ? 'Current default' : 'Set as default'}
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
+  )
+}
 
 function searchAgents(agents: AgentCatalogEntry[], rawQuery: string): AgentCatalogEntry[] {
   const query = rawQuery.trim().toLowerCase()
@@ -51,6 +119,8 @@ export default function AgentCombobox({
   onValueChange,
   onValueSelected,
   onOpenManageAgents,
+  defaultAgent,
+  onSetDefault,
   triggerClassName
 }: AgentComboboxProps): React.JSX.Element {
   const [open, setOpen] = useState(false)
@@ -181,44 +251,30 @@ export default function AgentCombobox({
             <CommandInput placeholder="Search agents..." value={query} onValueChange={setQuery} />
             <CommandList>
               <CommandEmpty>No agents match your search.</CommandEmpty>
-              {blankMatchesQuery ? (
-                <CommandItem
-                  key={BLANK_VALUE}
-                  value={BLANK_VALUE}
-                  onSelect={() => handleSelect(null)}
-                  className="items-center gap-2 px-3 py-1.5"
-                >
-                  <Check
-                    className={cn(
-                      'size-4 text-foreground',
-                      value === null ? 'opacity-100' : 'opacity-0'
-                    )}
-                  />
-                  <span className="inline-flex min-w-0 flex-1 items-center gap-1.5">
-                    <Terminal className="size-3.5" />
-                    <span className="truncate">Blank Terminal</span>
-                  </span>
-                </CommandItem>
-              ) : null}
-              {filteredAgents.map((agent) => (
-                <CommandItem
-                  key={agent.id}
-                  value={agent.id}
-                  onSelect={() => handleSelect(agent.id)}
-                  className="items-center gap-2 px-3 py-1.5"
-                >
-                  <Check
-                    className={cn(
-                      'size-4 text-foreground',
-                      value === agent.id ? 'opacity-100' : 'opacity-0'
-                    )}
-                  />
-                  <span className="inline-flex min-w-0 flex-1 items-center gap-1.5">
-                    <AgentIcon agent={agent.id} />
-                    <span className="truncate">{agent.label}</span>
-                  </span>
-                </CommandItem>
-              ))}
+              {blankMatchesQuery
+                ? renderItem({
+                    key: BLANK_VALUE,
+                    itemValue: BLANK_VALUE,
+                    isChecked: value === null,
+                    isDefault: defaultAgent === 'blank',
+                    onSelect: () => handleSelect(null),
+                    onSetDefault: onSetDefault ? () => onSetDefault('blank') : undefined,
+                    icon: <Terminal className="size-3.5" />,
+                    label: 'Blank Terminal'
+                  })
+                : null}
+              {filteredAgents.map((agent) =>
+                renderItem({
+                  key: agent.id,
+                  itemValue: agent.id,
+                  isChecked: value === agent.id,
+                  isDefault: defaultAgent === agent.id,
+                  onSelect: () => handleSelect(agent.id),
+                  onSetDefault: onSetDefault ? () => onSetDefault(agent.id) : undefined,
+                  icon: <AgentIcon agent={agent.id} />,
+                  label: agent.label
+                })
+              )}
             </CommandList>
             {onOpenManageAgents ? (
               <div className="border-t border-border">

--- a/src/renderer/src/components/agent/AgentCombobox.tsx
+++ b/src/renderer/src/components/agent/AgentCombobox.tsx
@@ -211,7 +211,7 @@ export default function AgentCombobox({
   )
 
   return (
-    <div className="flex items-center">
+    <div className="flex w-full items-center">
       <Popover open={open} onOpenChange={handleOpenChange}>
         <PopoverTrigger asChild>
           <Button
@@ -243,7 +243,7 @@ export default function AgentCombobox({
         </PopoverTrigger>
         <PopoverContent
           align="start"
-          className="w-72 p-0"
+          className="w-[var(--radix-popover-trigger-width)] min-w-[18rem] p-0"
           data-agent-combobox-root="true"
           onOpenAutoFocus={(event) => event.preventDefault()}
         >

--- a/src/renderer/src/components/agent/AgentSettingsDialog.tsx
+++ b/src/renderer/src/components/agent/AgentSettingsDialog.tsx
@@ -1,0 +1,47 @@
+import React from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog'
+import { AgentsPane } from '@/components/settings/AgentsPane'
+import { useAppStore } from '@/store'
+
+type AgentSettingsDialogProps = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export default function AgentSettingsDialog({
+  open,
+  onOpenChange
+}: AgentSettingsDialogProps): React.JSX.Element | null {
+  const settings = useAppStore((s) => s.settings)
+  const updateSettings = useAppStore((s) => s.updateSettings)
+
+  if (!settings) {
+    return null
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      {/* Why: widen past the default sm:max-w-lg so the agent rows have room
+          for the name + pills + action cluster without wrapping, while a
+          bounded max-h plus overflow-y keeps the list scrollable when many
+          agents are detected. */}
+      <DialogContent className="sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle className="text-sm">Agents</DialogTitle>
+          <DialogDescription className="text-xs">
+            Manage AI agents, set a default, and customize commands.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="scrollbar-sleek -mr-2 max-h-[70vh] overflow-y-auto pr-2">
+          <AgentsPane settings={settings} updateSettings={updateSettings} />
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/renderer/src/components/repo/RepoCombobox.tsx
+++ b/src/renderer/src/components/repo/RepoCombobox.tsx
@@ -24,7 +24,6 @@ type RepoComboboxProps = {
   placeholder?: string
   triggerClassName?: string
   autoOpenOnMount?: boolean
-  autoFocusTriggerOnMount?: boolean
   showStandaloneAddButton?: boolean
 }
 
@@ -36,7 +35,6 @@ export default function RepoCombobox({
   placeholder = 'Select repo...',
   triggerClassName,
   autoOpenOnMount = false,
-  autoFocusTriggerOnMount = false,
   showStandaloneAddButton = true
 }: RepoComboboxProps): React.JSX.Element {
   const [open, setOpen] = useState(false)
@@ -49,7 +47,6 @@ export default function RepoCombobox({
   const fetchWorktrees = useAppStore((s) => s.fetchWorktrees)
   const [isAdding, setIsAdding] = useState(false)
   const autoOpenedRef = React.useRef(false)
-  const autoFocusedRef = React.useRef(false)
   const triggerRef = React.useRef<HTMLButtonElement | null>(null)
 
   const selectedRepo = useMemo(
@@ -67,19 +64,6 @@ export default function RepoCombobox({
   }, [autoOpenOnMount])
 
   React.useEffect(() => {
-    if (!autoFocusTriggerOnMount || autoFocusedRef.current) {
-      return
-    }
-    autoFocusedRef.current = true
-    setOpen(false)
-    setQuery('')
-    const frame = requestAnimationFrame(() => {
-      triggerRef.current?.focus()
-    })
-    return () => cancelAnimationFrame(frame)
-  }, [autoFocusTriggerOnMount])
-
-  React.useEffect(() => {
     if (!open) {
       return
     }
@@ -88,8 +72,15 @@ export default function RepoCombobox({
       const repoSearchInput = document.querySelector<HTMLInputElement>(
         '[data-repo-combobox-root="true"] [data-slot="command-input"]'
       )
-      repoSearchInput?.focus()
-      repoSearchInput?.select()
+      if (!repoSearchInput) {
+        return
+      }
+      repoSearchInput.focus()
+      // Why: when a printable keydown on the trigger seeded the query, the
+      // user expects the next keystroke to append to what they typed — not
+      // replace it — so drop the caret at the end instead of selecting all.
+      const end = repoSearchInput.value.length
+      repoSearchInput.setSelectionRange(end, end)
     })
     return () => cancelAnimationFrame(frame)
   }, [open, value])
@@ -112,6 +103,36 @@ export default function RepoCombobox({
       onValueSelected?.(repoId)
     },
     [onValueChange, onValueSelected]
+  )
+
+  // Why: the button-style trigger treats the current value as a confirmed
+  // selection — plain focus does not open the dropdown. We only open on
+  // explicit intent: ArrowDown/ArrowUp opens without filtering, and a printable
+  // non-whitespace character opens *and* seeds the search query (treating the
+  // keystroke as the start of a new search per the combobox pattern).
+  const handleTriggerKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLButtonElement>) => {
+      if (open) {
+        return
+      }
+      if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+        event.preventDefault()
+        setOpen(true)
+        return
+      }
+      if (event.metaKey || event.ctrlKey || event.altKey) {
+        return
+      }
+      // Why: restrict to visible characters so whitespace/Enter keep their
+      // native button semantics (Space/Enter = click = open-without-filter via
+      // the PopoverTrigger) instead of leaking into the query as a stray char.
+      if (event.key.length === 1 && /\S/.test(event.key)) {
+        event.preventDefault()
+        setQuery(event.key)
+        setOpen(true)
+      }
+    },
+    [open]
   )
 
   const handleAddFolder = useCallback(async () => {
@@ -144,6 +165,7 @@ export default function RepoCombobox({
             variant="outline"
             role="combobox"
             aria-expanded={open}
+            onKeyDown={handleTriggerKeyDown}
             className={cn(
               'h-8 min-w-[184px] justify-between px-3 text-xs font-normal',
               triggerClassName

--- a/src/renderer/src/components/repo/RepoCombobox.tsx
+++ b/src/renderer/src/components/repo/RepoCombobox.tsx
@@ -156,7 +156,7 @@ export default function RepoCombobox({
   }, [addRepo, fetchWorktrees, isAdding, onValueChange])
 
   return (
-    <div className="flex items-center gap-1.5">
+    <div className="flex w-full items-center gap-1.5">
       <Popover open={open} onOpenChange={handleOpenChange}>
         <PopoverTrigger asChild>
           <Button
@@ -194,7 +194,7 @@ export default function RepoCombobox({
         </PopoverTrigger>
         <PopoverContent
           align="start"
-          className="w-80 p-0"
+          className="w-[var(--radix-popover-trigger-width)] min-w-[18rem] p-0"
           data-repo-combobox-root="true"
           onOpenAutoFocus={(event) => event.preventDefault()}
         >

--- a/src/renderer/src/components/repo/RepoCombobox.tsx
+++ b/src/renderer/src/components/repo/RepoCombobox.tsx
@@ -24,6 +24,8 @@ type RepoComboboxProps = {
   placeholder?: string
   triggerClassName?: string
   autoOpenOnMount?: boolean
+  autoFocusTriggerOnMount?: boolean
+  showStandaloneAddButton?: boolean
 }
 
 export default function RepoCombobox({
@@ -33,7 +35,9 @@ export default function RepoCombobox({
   onValueSelected,
   placeholder = 'Select repo...',
   triggerClassName,
-  autoOpenOnMount = false
+  autoOpenOnMount = false,
+  autoFocusTriggerOnMount = false,
+  showStandaloneAddButton = true
 }: RepoComboboxProps): React.JSX.Element {
   const [open, setOpen] = useState(false)
   const [query, setQuery] = useState('')
@@ -45,6 +49,8 @@ export default function RepoCombobox({
   const fetchWorktrees = useAppStore((s) => s.fetchWorktrees)
   const [isAdding, setIsAdding] = useState(false)
   const autoOpenedRef = React.useRef(false)
+  const autoFocusedRef = React.useRef(false)
+  const triggerRef = React.useRef<HTMLButtonElement | null>(null)
 
   const selectedRepo = useMemo(
     () => repos.find((repo) => repo.id === value) ?? null,
@@ -61,6 +67,17 @@ export default function RepoCombobox({
   }, [autoOpenOnMount])
 
   React.useEffect(() => {
+    if (!autoFocusTriggerOnMount || autoFocusedRef.current) {
+      return
+    }
+    autoFocusedRef.current = true
+    const frame = requestAnimationFrame(() => {
+      triggerRef.current?.focus()
+    })
+    return () => cancelAnimationFrame(frame)
+  }, [autoFocusTriggerOnMount])
+
+  React.useEffect(() => {
     if (!open) {
       return
     }
@@ -73,7 +90,7 @@ export default function RepoCombobox({
       repoSearchInput?.select()
     })
     return () => cancelAnimationFrame(frame)
-  }, [open])
+  }, [open, value])
 
   const handleOpenChange = useCallback((nextOpen: boolean) => {
     setOpen(nextOpen)
@@ -120,6 +137,7 @@ export default function RepoCombobox({
       <Popover open={open} onOpenChange={handleOpenChange}>
         <PopoverTrigger asChild>
           <Button
+            ref={triggerRef}
             type="button"
             variant="outline"
             role="combobox"
@@ -217,19 +235,21 @@ export default function RepoCombobox({
         </PopoverContent>
       </Popover>
 
-      {/* Why: keep the add-repo action visible even when the repo selector is
-          collapsed so adding a new source stays one click away in the compact composer header. */}
-      <Button
-        type="button"
-        variant="outline"
-        size="default"
-        disabled={isAdding}
-        onClick={() => void handleAddFolder()}
-        className="size-9 shrink-0 p-0"
-        aria-label={isAdding ? 'Adding folder or repository' : 'Add folder or repository'}
-      >
-        <FolderPlus className="size-3.5" />
-      </Button>
+      {showStandaloneAddButton ? (
+        /* Why: keep the add-repo action visible even when the repo selector is
+            collapsed so adding a new source stays one click away in the compact composer header. */
+        <Button
+          type="button"
+          variant="outline"
+          size="default"
+          disabled={isAdding}
+          onClick={() => void handleAddFolder()}
+          className="size-9 shrink-0 p-0"
+          aria-label={isAdding ? 'Adding folder or repository' : 'Add folder or repository'}
+        >
+          <FolderPlus className="size-3.5" />
+        </Button>
+      ) : null}
     </div>
   )
 }

--- a/src/renderer/src/components/repo/RepoCombobox.tsx
+++ b/src/renderer/src/components/repo/RepoCombobox.tsx
@@ -20,6 +20,7 @@ type RepoComboboxProps = {
   repos: Repo[]
   value: string
   onValueChange: (repoId: string) => void
+  onValueSelected?: (repoId: string) => void
   placeholder?: string
   triggerClassName?: string
   autoOpenOnMount?: boolean
@@ -29,6 +30,7 @@ export default function RepoCombobox({
   repos,
   value,
   onValueChange,
+  onValueSelected,
   placeholder = 'Select repo...',
   triggerClassName,
   autoOpenOnMount = false
@@ -88,8 +90,9 @@ export default function RepoCombobox({
       onValueChange(repoId)
       setOpen(false)
       setQuery('')
+      onValueSelected?.(repoId)
     },
-    [onValueChange]
+    [onValueChange, onValueSelected]
   )
 
   const handleAddFolder = useCallback(async () => {

--- a/src/renderer/src/components/repo/RepoCombobox.tsx
+++ b/src/renderer/src/components/repo/RepoCombobox.tsx
@@ -71,6 +71,8 @@ export default function RepoCombobox({
       return
     }
     autoFocusedRef.current = true
+    setOpen(false)
+    setQuery('')
     const frame = requestAnimationFrame(() => {
       triggerRef.current?.focus()
     })

--- a/src/renderer/src/components/repo/RepoCombobox.tsx
+++ b/src/renderer/src/components/repo/RepoCombobox.tsx
@@ -87,99 +87,116 @@ export default function RepoCombobox({
   }, [addRepo, fetchWorktrees, isAdding, onValueChange])
 
   return (
-    <Popover open={open} onOpenChange={handleOpenChange}>
-      <PopoverTrigger asChild>
-        <Button
-          type="button"
-          variant="outline"
-          role="combobox"
-          aria-expanded={open}
-          className={cn('h-8 w-full justify-between px-3 text-xs font-normal', triggerClassName)}
-          data-repo-combobox-root="true"
-        >
-          {selectedRepo ? (
-            <span className="inline-flex min-w-0 items-center gap-1.5">
-              <RepoDotLabel
-                name={selectedRepo.displayName}
-                color={selectedRepo.badgeColor}
-                dotClassName="size-1.5"
-              />
-              {selectedRepo.connectionId && (
-                <span className="shrink-0 inline-flex items-center gap-0.5 rounded bg-muted px-1 py-0.5 text-[9px] font-medium leading-none text-muted-foreground">
-                  <Globe className="size-2.5" />
-                  SSH
-                </span>
-              )}
-            </span>
-          ) : (
-            <span className="text-muted-foreground">{placeholder}</span>
-          )}
-          <ChevronsUpDown className="size-3.5 opacity-50" />
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent
-        align="start"
-        className="w-[var(--radix-popover-trigger-width)] p-0"
-        data-repo-combobox-root="true"
-      >
-        <Command shouldFilter={false} value={commandValue} onValueChange={setCommandValue}>
-          <CommandInput
-            autoFocus
-            placeholder="Search repos/folders..."
-            value={query}
-            onValueChange={setQuery}
-          />
-          <CommandList>
-            <CommandEmpty>No repos/folders match your search.</CommandEmpty>
-            {filteredRepos.map((repo) => (
-              <CommandItem
-                key={repo.id}
-                value={repo.id}
-                onSelect={() => handleSelect(repo.id)}
-                className="items-center gap-2 px-3 py-2"
-              >
-                <Check
-                  className={cn(
-                    'size-4 text-foreground',
-                    value === repo.id ? 'opacity-100' : 'opacity-0'
-                  )}
+    <div className="flex items-center gap-1.5">
+      <Popover open={open} onOpenChange={handleOpenChange}>
+        <PopoverTrigger asChild>
+          <Button
+            type="button"
+            variant="outline"
+            role="combobox"
+            aria-expanded={open}
+            className={cn(
+              'h-8 min-w-[184px] justify-between px-3 text-xs font-normal',
+              triggerClassName
+            )}
+            data-repo-combobox-root="true"
+          >
+            {selectedRepo ? (
+              <span className="inline-flex min-w-0 items-center gap-1.5">
+                <RepoDotLabel
+                  name={selectedRepo.displayName}
+                  color={selectedRepo.badgeColor}
+                  dotClassName="size-1.5"
                 />
-                <div className="min-w-0 flex-1">
-                  <span className="inline-flex items-center gap-1.5">
-                    <RepoDotLabel
-                      name={repo.displayName}
-                      color={repo.badgeColor}
-                      className="max-w-full"
-                    />
-                    {repo.connectionId && (
-                      <span className="shrink-0 inline-flex items-center gap-0.5 rounded bg-muted px-1 py-0.5 text-[9px] font-medium leading-none text-muted-foreground">
-                        <Globe className="size-2.5" />
-                        SSH
-                      </span>
-                    )}
+                {selectedRepo.connectionId && (
+                  <span className="shrink-0 inline-flex items-center gap-0.5 rounded bg-muted px-1 py-0.5 text-[9px] font-medium leading-none text-muted-foreground">
+                    <Globe className="size-2.5" />
+                    SSH
                   </span>
-                  <p className="mt-0.5 truncate text-[11px] text-muted-foreground">{repo.path}</p>
-                </div>
-              </CommandItem>
-            ))}
-          </CommandList>
-          {/* Why: pinned footer (outside CommandList's scroll container) so the
-              add action stays visible regardless of list length or scroll position. */}
-          <div className="border-t border-border">
-            <button
-              type="button"
-              disabled={isAdding}
-              onClick={handleAddFolder}
-              onMouseDown={(event) => event.preventDefault()}
-              onMouseEnter={() => setCommandValue('')}
-              className="flex w-full items-center gap-2 px-3 py-2 text-left text-xs text-foreground transition-colors hover:bg-accent hover:text-accent-foreground disabled:cursor-not-allowed disabled:opacity-60"
-            >
-              <FolderPlus className="size-3.5 text-muted-foreground" />
-              <span>{isAdding ? 'Adding folder/repo…' : 'Add folder/repo'}</span>
-            </button>
-          </div>
-        </Command>
-      </PopoverContent>
-    </Popover>
+                )}
+              </span>
+            ) : (
+              <span className="text-muted-foreground">{placeholder}</span>
+            )}
+            <ChevronsUpDown className="size-3.5 opacity-50" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent align="start" className="w-80 p-0" data-repo-combobox-root="true">
+          <Command shouldFilter={false} value={commandValue} onValueChange={setCommandValue}>
+            <CommandInput
+              autoFocus
+              placeholder="Search repos/folders..."
+              value={query}
+              onValueChange={setQuery}
+            />
+            <CommandList>
+              <CommandEmpty>No repos/folders match your search.</CommandEmpty>
+              {filteredRepos.map((repo) => (
+                <CommandItem
+                  key={repo.id}
+                  value={repo.id}
+                  onSelect={() => handleSelect(repo.id)}
+                  className="items-center gap-2 px-3 py-2"
+                >
+                  <Check
+                    className={cn(
+                      'size-4 text-foreground',
+                      value === repo.id ? 'opacity-100' : 'opacity-0'
+                    )}
+                  />
+                  <div className="min-w-0 flex-1">
+                    <span className="inline-flex items-center gap-1.5">
+                      <RepoDotLabel
+                        name={repo.displayName}
+                        color={repo.badgeColor}
+                        className="max-w-full"
+                      />
+                      {repo.connectionId && (
+                        <span className="shrink-0 inline-flex items-center gap-0.5 rounded bg-muted px-1 py-0.5 text-[9px] font-medium leading-none text-muted-foreground">
+                          <Globe className="size-2.5" />
+                          SSH
+                        </span>
+                      )}
+                    </span>
+                    <p className="mt-0.5 truncate text-[11px] text-muted-foreground">{repo.path}</p>
+                  </div>
+                </CommandItem>
+              ))}
+            </CommandList>
+            {/* Why: keep the in-list add action available for users who open
+                the picker expecting the historical footer affordance, while
+                the separate header icon covers the compact one-click path. */}
+            <div className="border-t border-border">
+              <Button
+                type="button"
+                variant="ghost"
+                disabled={isAdding}
+                onClick={() => void handleAddFolder()}
+                onMouseDown={(event) => event.preventDefault()}
+                onMouseEnter={() => setCommandValue('')}
+                className="h-9 w-full justify-start rounded-none px-3 text-xs font-normal"
+              >
+                <FolderPlus className="size-3.5 text-muted-foreground" />
+                <span>{isAdding ? 'Adding folder/repo…' : 'Add folder/repo'}</span>
+              </Button>
+            </div>
+          </Command>
+        </PopoverContent>
+      </Popover>
+
+      {/* Why: keep the add-repo action visible even when the repo selector is
+          collapsed so adding a new source stays one click away in the compact composer header. */}
+      <Button
+        type="button"
+        variant="outline"
+        size="default"
+        disabled={isAdding}
+        onClick={() => void handleAddFolder()}
+        className="size-9 p-0"
+        aria-label={isAdding ? 'Adding folder or repository' : 'Add folder or repository'}
+      >
+        <FolderPlus className="size-3.5" />
+      </Button>
+    </div>
   )
 }

--- a/src/renderer/src/components/repo/RepoCombobox.tsx
+++ b/src/renderer/src/components/repo/RepoCombobox.tsx
@@ -22,6 +22,7 @@ type RepoComboboxProps = {
   onValueChange: (repoId: string) => void
   placeholder?: string
   triggerClassName?: string
+  autoOpenOnMount?: boolean
 }
 
 export default function RepoCombobox({
@@ -29,7 +30,8 @@ export default function RepoCombobox({
   value,
   onValueChange,
   placeholder = 'Select repo...',
-  triggerClassName
+  triggerClassName,
+  autoOpenOnMount = false
 }: RepoComboboxProps): React.JSX.Element {
   const [open, setOpen] = useState(false)
   const [query, setQuery] = useState('')
@@ -40,12 +42,36 @@ export default function RepoCombobox({
   const addRepo = useAppStore((s) => s.addRepo)
   const fetchWorktrees = useAppStore((s) => s.fetchWorktrees)
   const [isAdding, setIsAdding] = useState(false)
+  const autoOpenedRef = React.useRef(false)
 
   const selectedRepo = useMemo(
     () => repos.find((repo) => repo.id === value) ?? null,
     [repos, value]
   )
   const filteredRepos = useMemo(() => searchRepos(repos, query), [repos, query])
+
+  React.useEffect(() => {
+    if (!autoOpenOnMount || autoOpenedRef.current) {
+      return
+    }
+    autoOpenedRef.current = true
+    setOpen(true)
+  }, [autoOpenOnMount])
+
+  React.useEffect(() => {
+    if (!open) {
+      return
+    }
+    setCommandValue(value)
+    const frame = requestAnimationFrame(() => {
+      const repoSearchInput = document.querySelector<HTMLInputElement>(
+        '[data-repo-combobox-root="true"] [data-slot="command-input"]'
+      )
+      repoSearchInput?.focus()
+      repoSearchInput?.select()
+    })
+    return () => cancelAnimationFrame(frame)
+  }, [open])
 
   const handleOpenChange = useCallback((nextOpen: boolean) => {
     setOpen(nextOpen)
@@ -121,10 +147,14 @@ export default function RepoCombobox({
             <ChevronsUpDown className="size-3.5 opacity-50" />
           </Button>
         </PopoverTrigger>
-        <PopoverContent align="start" className="w-80 p-0" data-repo-combobox-root="true">
+        <PopoverContent
+          align="start"
+          className="w-80 p-0"
+          data-repo-combobox-root="true"
+          onOpenAutoFocus={(event) => event.preventDefault()}
+        >
           <Command shouldFilter={false} value={commandValue} onValueChange={setCommandValue}>
             <CommandInput
-              autoFocus
               placeholder="Search repos/folders..."
               value={query}
               onValueChange={setQuery}
@@ -192,7 +222,7 @@ export default function RepoCombobox({
         size="default"
         disabled={isAdding}
         onClick={() => void handleAddFolder()}
-        className="size-9 p-0"
+        className="size-9 shrink-0 p-0"
         aria-label={isAdding ? 'Adding folder or repository' : 'Add folder or repository'}
       >
         <FolderPlus className="size-3.5" />

--- a/src/renderer/src/components/settings/AgentsPane.tsx
+++ b/src/renderer/src/components/settings/AgentsPane.tsx
@@ -232,7 +232,7 @@ export function AgentsPane({ settings, updateSettings }: AgentsPaneProps): React
   const defaultAgent = settings.defaultTuiAgent
   const cmdOverrides = settings.agentCmdOverrides ?? {}
 
-  const setDefault = (id: TuiAgent | null): void => {
+  const setDefault = (id: TuiAgent | 'blank' | null): void => {
     updateSettings({ defaultTuiAgent: id })
   }
 
@@ -251,7 +251,12 @@ export function AgentsPane({ settings, updateSettings }: AgentsPaneProps): React
     (a) => detectedIds !== null && !detectedIds.has(a.id)
   )
 
-  const isAutoDefault = defaultAgent === null || !detectedIds?.has(defaultAgent)
+  // Why: 'blank' is an explicit no-agent preference, not an auto fallback,
+  // so the Auto pill should only light up when the default is null OR when a
+  // selected agent id is no longer detected on PATH.
+  const isAutoDefault =
+    defaultAgent === null || (defaultAgent !== 'blank' && !detectedIds?.has(defaultAgent))
+  const isBlankDefault = defaultAgent === 'blank'
 
   return (
     <div className="space-y-8">
@@ -260,8 +265,7 @@ export function AgentsPane({ settings, updateSettings }: AgentsPaneProps): React
         <div className="space-y-1">
           <h3 className="text-sm font-semibold">Default Agent</h3>
           <p className="text-xs text-muted-foreground">
-            Pre-selected agent when opening a new workspace. Set to Auto to use the first detected
-            agent.
+            Pre-selected agent when opening a new workspace.
           </p>
         </div>
 
@@ -279,6 +283,25 @@ export function AgentsPane({ settings, updateSettings }: AgentsPaneProps): React
           >
             {isAutoDefault && <Check className="size-3.5" />}
             Auto
+          </button>
+
+          {/* Why: users who prefer to open a raw shell by default need a
+              first-class "no agent" choice here — without it, the Auto pill
+              is the closest option but silently launches the first detected
+              agent, which is the opposite of what they want. */}
+          <button
+            type="button"
+            onClick={() => setDefault('blank')}
+            className={cn(
+              'flex items-center gap-2 rounded-xl border px-3 py-2 text-sm transition-all',
+              isBlankDefault
+                ? 'border-foreground/20 bg-foreground/8 font-medium ring-1 ring-foreground/15'
+                : 'border-border/50 bg-muted/30 text-muted-foreground hover:border-border hover:bg-muted/50 hover:text-foreground'
+            )}
+          >
+            <Terminal className="size-3.5" />
+            No agent (blank terminal)
+            {isBlankDefault && <Check className="size-3.5" />}
           </button>
 
           {/* Detected agent pills */}

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -247,10 +247,16 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     }
     return initialLinkedWorkItem?.type === 'pr' ? initialLinkedWorkItem.number : null
   })
+  // Why: the long-form composer's agent selection is a required TuiAgent (not
+  // null/blank), so 'blank' preferences from global settings must collapse to
+  // the Claude default here — the blank-terminal affordance only lives in the
+  // quick-create flow.
+  const fallbackDefaultAgent: TuiAgent =
+    settings?.defaultTuiAgent && settings.defaultTuiAgent !== 'blank'
+      ? settings.defaultTuiAgent
+      : 'claude'
   const [tuiAgent, setTuiAgent] = useState<TuiAgent>(
-    persistDraft
-      ? (newWorkspaceDraft?.agent ?? settings?.defaultTuiAgent ?? 'claude')
-      : (settings?.defaultTuiAgent ?? 'claude')
+    persistDraft ? (newWorkspaceDraft?.agent ?? fallbackDefaultAgent) : fallbackDefaultAgent
   )
   const [detectedAgentIds, setDetectedAgentIds] = useState<Set<TuiAgent> | null>(null)
 

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -108,6 +108,7 @@ export type UseComposerStateResult = {
   promptTextareaRef: React.RefObject<HTMLTextAreaElement | null>
   nameInputRef: React.RefObject<HTMLInputElement | null>
   submit: () => Promise<void>
+  submitQuick: (agent: TuiAgent | null) => Promise<void>
   /** Invoked by the Enter handler to re-check whether submission should fire. */
   createDisabled: boolean
 }
@@ -168,6 +169,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       setSidebarOpen: s.setSidebarOpen,
       setRightSidebarOpen: s.setRightSidebarOpen,
       setRightSidebarTab: s.setRightSidebarTab,
+      closeModal: s.closeModal,
       openSettingsPage: s.openSettingsPage,
       openSettingsTarget: s.openSettingsTarget
     }))
@@ -180,6 +182,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     setSidebarOpen,
     setRightSidebarOpen,
     setRightSidebarTab,
+    closeModal,
     openSettingsPage,
     openSettingsTarget
   } = actions
@@ -841,7 +844,29 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
   const handleOpenAgentSettings = useCallback((): void => {
     openSettingsTarget({ pane: 'agents', repoId: null })
     openSettingsPage()
-  }, [openSettingsPage, openSettingsTarget])
+    closeModal()
+  }, [closeModal, openSettingsPage, openSettingsTarget])
+
+  const applyWorktreeMeta = useCallback(
+    async (
+      worktreeId: string,
+      meta: {
+        linkedIssue?: number
+        linkedPR?: number
+        comment?: string
+      }
+    ): Promise<void> => {
+      if (Object.keys(meta).length === 0) {
+        return
+      }
+      try {
+        await updateWorktreeMeta(worktreeId, meta)
+      } catch {
+        console.error('Failed to update worktree meta after creation')
+      }
+    },
+    [updateWorktreeMeta]
+  )
 
   const submit = useCallback(async (): Promise<void> => {
     const workspaceName = workspaceSeedName
@@ -867,27 +892,11 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       )
       const worktree = result.worktree
 
-      try {
-        const metaUpdates: {
-          linkedIssue?: number
-          linkedPR?: number
-          comment?: string
-        } = {}
-        if (parsedLinkedIssueNumber !== null) {
-          metaUpdates.linkedIssue = parsedLinkedIssueNumber
-        }
-        if (linkedPR !== null) {
-          metaUpdates.linkedPR = linkedPR
-        }
-        if (note.trim()) {
-          metaUpdates.comment = note.trim()
-        }
-        if (Object.keys(metaUpdates).length > 0) {
-          await updateWorktreeMeta(worktree.id, metaUpdates)
-        }
-      } catch {
-        console.error('Failed to update worktree meta after creation')
-      }
+      await applyWorktreeMeta(worktree.id, {
+        ...(parsedLinkedIssueNumber !== null ? { linkedIssue: parsedLinkedIssueNumber } : {}),
+        ...(linkedPR !== null ? { linkedPR } : {}),
+        ...(note.trim() ? { comment: note.trim() } : {})
+      })
 
       const issueCommand = shouldRunIssueAutomation
         ? {
@@ -934,6 +943,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
   }, [
     clearNewWorkspaceDraft,
     createWorktree,
+    applyWorktreeMeta,
     issueCommandTemplate,
     linkedPR,
     linkedWorkItem?.url,
@@ -956,9 +966,100 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     shouldWaitForIssueAutomationCheck,
     shouldWaitForSetupCheck,
     startupPrompt,
-    updateWorktreeMeta,
     workspaceSeedName
   ])
+
+  const submitQuick = useCallback(
+    async (agent: TuiAgent | null): Promise<void> => {
+      const workspaceName = getWorkspaceSeedName({
+        explicitName: name,
+        prompt: '',
+        linkedIssueNumber: null,
+        linkedPR: null
+      })
+      if (
+        !repoId ||
+        !workspaceName ||
+        !selectedRepo ||
+        shouldWaitForSetupCheck ||
+        (requiresExplicitSetupChoice && !setupDecision)
+      ) {
+        return
+      }
+
+      setCreateError(null)
+      setCreating(true)
+      try {
+        const result = await createWorktree(
+          repoId,
+          workspaceName,
+          undefined,
+          (resolvedSetupDecision ?? 'inherit') as SetupDecision
+        )
+        const worktree = result.worktree
+
+        const trimmedNote = note.trim()
+        await applyWorktreeMeta(worktree.id, trimmedNote ? { comment: trimmedNote } : {})
+
+        const startupPlan =
+          agent === null
+            ? null
+            : buildAgentStartupPlan({
+                agent,
+                prompt: '',
+                cmdOverrides: settings?.agentCmdOverrides ?? {},
+                platform: CLIENT_PLATFORM,
+                allowEmptyPromptLaunch: true
+              })
+
+        activateAndRevealWorktree(worktree.id, {
+          setup: result.setup,
+          ...(startupPlan ? { startup: { command: startupPlan.launchCommand } } : {})
+        })
+        if (startupPlan) {
+          void ensureAgentStartupInTerminal({
+            worktreeId: worktree.id,
+            startup: startupPlan
+          })
+        }
+        setSidebarOpen(true)
+        if (settings?.rightSidebarOpenByDefault) {
+          setRightSidebarTab('explorer')
+          setRightSidebarOpen(true)
+        }
+        if (persistDraft) {
+          clearNewWorkspaceDraft()
+        }
+        onCreated?.()
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Failed to create worktree.'
+        setCreateError(message)
+        toast.error(message)
+      } finally {
+        setCreating(false)
+      }
+    },
+    [
+      applyWorktreeMeta,
+      clearNewWorkspaceDraft,
+      createWorktree,
+      name,
+      note,
+      onCreated,
+      persistDraft,
+      repoId,
+      requiresExplicitSetupChoice,
+      resolvedSetupDecision,
+      selectedRepo,
+      settings?.agentCmdOverrides,
+      settings?.rightSidebarOpenByDefault,
+      setRightSidebarOpen,
+      setRightSidebarTab,
+      setSidebarOpen,
+      setupDecision,
+      shouldWaitForSetupCheck
+    ]
+  )
 
   const createDisabled =
     !repoId ||
@@ -1021,6 +1122,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     promptTextareaRef,
     nameInputRef,
     submit,
+    submitQuick,
     createDisabled
   }
 }

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -11,6 +11,7 @@ import { parseGitHubIssueOrPRNumber, normalizeGitHubLinkQuery } from '@/lib/gith
 import type { RepoSlug } from '@/lib/github-links'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 import { buildAgentStartupPlan } from '@/lib/tui-agent-startup'
+import { detectAgentsCached } from '@/lib/detect-agents-cached'
 import { isGitRepoKind } from '../../../shared/repo-kind'
 import type {
   GitHubWorkItem,
@@ -121,28 +122,6 @@ export type UseComposerStateResult = {
 // modal wins when both are present, and the page takes over once the modal
 // closes.
 const composerDropStack: symbol[] = []
-
-// Why: agent detection runs `which` for every agent binary on PATH — an IPC
-// round-trip that takes 50–200ms. The set of installed agents doesn't change
-// within a session, so cache the promise at module scope to collapse all
-// mounts (page + modal, reopen, etc.) onto a single resolve.
-let detectAgentsPromise: Promise<TuiAgent[]> | null = null
-function detectAgentsCached(): Promise<TuiAgent[]> {
-  if (detectAgentsPromise) {
-    return detectAgentsPromise
-  }
-  const pending = window.api.preflight
-    .detectAgents()
-    .then((ids) => ids as TuiAgent[])
-    .catch(() => {
-      // Allow a retry on the next mount if detection blew up (e.g. IPC
-      // timeout during cold start).
-      detectAgentsPromise = null
-      return [] as TuiAgent[]
-    })
-  detectAgentsPromise = pending
-  return pending
-}
 
 export function useComposerState(options: UseComposerStateOptions): UseComposerStateResult {
   const {

--- a/src/renderer/src/lib/agent-ready-wait.ts
+++ b/src/renderer/src/lib/agent-ready-wait.ts
@@ -1,0 +1,117 @@
+import { detectAgentStatusFromTitle } from '../../../shared/agent-detection'
+import { isShellProcess } from '@/lib/tui-agent-startup'
+import { useAppStore } from '@/store'
+
+// Why: agent CLIs vary widely in how they signal readiness. Title-based
+// detection (OSC titles parsed by detectAgentStatusFromTitle) is the tightest
+// signal we have — an agent that emits "✳ " or ". "/"* " prefixes has fully
+// taken over the PTY. For agents that don't set titles, fall back to
+// foreground-process equality (the launched binary is alive and owns the fg
+// job), then finally to the presence of any non-shell child process. A hard
+// timeout prevents the Use-button flow from hanging on a missing binary.
+export type AgentReadyReason = 'title-idle' | 'foreground-match' | 'child-process' | 'timeout'
+
+export type AgentReadyResult = {
+  ready: boolean
+  reason: AgentReadyReason
+}
+
+const DEFAULT_TIMEOUT_MS = 5000
+const POLL_INTERVAL_MS = 120
+
+function resolvePrimaryPtyId(tabId: string): string | null {
+  const state = useAppStore.getState()
+  const ptyIds = state.ptyIdsByTabId[tabId]
+  return ptyIds?.[0] ?? null
+}
+
+function titleSuggestsReady(tabId: string): boolean {
+  const state = useAppStore.getState()
+  const paneTitles = state.runtimePaneTitlesByTabId[tabId]
+  const titles: string[] = []
+  if (paneTitles) {
+    for (const title of Object.values(paneTitles)) {
+      if (title) {
+        titles.push(title)
+      }
+    }
+  }
+  // Why: fall back to the persisted tab.title when runtime pane titles haven't
+  // been populated yet (e.g. the TerminalPane has not mounted a title handler
+  // for this tab). Finding the tab by id walks every worktree, which is fine
+  // at poll rates — the map is small.
+  if (titles.length === 0) {
+    for (const tabs of Object.values(state.tabsByWorktree)) {
+      const tab = tabs.find((t) => t.id === tabId)
+      if (tab?.title) {
+        titles.push(tab.title)
+        break
+      }
+    }
+  }
+  return titles.some((title) => detectAgentStatusFromTitle(title) === 'idle')
+}
+
+/**
+ * Wait until the agent we launched on `tabId` is ready to accept typed input.
+ *
+ * Checks, in order of preference:
+ *   1. Terminal title reports an idle agent status.
+ *   2. Foreground process name matches `expectedProcess`.
+ *   3. PTY has at least one non-shell child process (after a brief grace
+ *      period so we don't accept the shell's own transient children).
+ *
+ * Resolves early on the first match, or after `timeoutMs` with
+ * `{ ready: false, reason: 'timeout' }`. Never rejects.
+ */
+export async function waitForAgentReady(
+  tabId: string,
+  expectedProcess: string,
+  opts?: { timeoutMs?: number }
+): Promise<AgentReadyResult> {
+  const timeoutMs = opts?.timeoutMs ?? DEFAULT_TIMEOUT_MS
+  const deadline = Date.now() + timeoutMs
+  let attempt = 0
+
+  while (Date.now() < deadline) {
+    if (attempt > 0) {
+      await new Promise((resolve) => window.setTimeout(resolve, POLL_INTERVAL_MS))
+    }
+    attempt += 1
+
+    if (titleSuggestsReady(tabId)) {
+      return { ready: true, reason: 'title-idle' }
+    }
+
+    const ptyId = resolvePrimaryPtyId(tabId)
+    if (!ptyId) {
+      continue
+    }
+
+    try {
+      const foreground = (await window.api.pty.getForegroundProcess(ptyId))?.toLowerCase() ?? ''
+      if (
+        foreground === expectedProcess ||
+        foreground.startsWith(`${expectedProcess}.`) ||
+        foreground.endsWith(`/${expectedProcess}`)
+      ) {
+        return { ready: true, reason: 'foreground-match' }
+      }
+
+      // Why: child-process check is the weakest signal (it fires for any
+      // non-shell subprocess, including `ls` or `git`). Gate it behind a few
+      // polls so the shell's own startup children don't spoof readiness on
+      // cold-start. Never accept it while the foreground is still a shell.
+      if (attempt >= 4 && !isShellProcess(foreground)) {
+        const hasChildProcesses = await window.api.pty.hasChildProcesses(ptyId)
+        if (hasChildProcesses) {
+          return { ready: true, reason: 'child-process' }
+        }
+      }
+    } catch {
+      // Swallow transient PTY inspection errors and keep polling.
+    }
+  }
+
+  return { ready: false, reason: 'timeout' }
+}

--- a/src/renderer/src/lib/detect-agents-cached.ts
+++ b/src/renderer/src/lib/detect-agents-cached.ts
@@ -1,0 +1,25 @@
+import type { TuiAgent } from '../../../shared/types'
+
+// Why: agent detection runs `which` for every agent binary on PATH — an IPC
+// round-trip that takes 50–200ms. The set of installed agents doesn't change
+// within a session, so cache the promise at module scope to collapse all
+// callers (composer page, quick-composer modal, "Use this task" flow, etc.)
+// onto a single resolve.
+let detectAgentsPromise: Promise<TuiAgent[]> | null = null
+
+export function detectAgentsCached(): Promise<TuiAgent[]> {
+  if (detectAgentsPromise) {
+    return detectAgentsPromise
+  }
+  const pending = window.api.preflight
+    .detectAgents()
+    .then((ids) => ids as TuiAgent[])
+    .catch(() => {
+      // Allow a retry on the next mount if detection blew up (e.g. IPC
+      // timeout during cold start).
+      detectAgentsPromise = null
+      return [] as TuiAgent[]
+    })
+  detectAgentsPromise = pending
+  return pending
+}

--- a/src/renderer/src/lib/launch-work-item-direct.ts
+++ b/src/renderer/src/lib/launch-work-item-direct.ts
@@ -1,0 +1,214 @@
+import { toast } from 'sonner'
+import { useAppStore } from '@/store'
+import { AGENT_CATALOG } from '@/lib/agent-catalog'
+import { detectAgentsCached } from '@/lib/detect-agents-cached'
+import { waitForAgentReady } from '@/lib/agent-ready-wait'
+import { buildAgentStartupPlan } from '@/lib/tui-agent-startup'
+import { activateAndRevealWorktree } from '@/lib/worktree-activation'
+import {
+  CLIENT_PLATFORM,
+  getLinkedWorkItemSuggestedName,
+  getSetupConfig,
+  getWorkspaceSeedName
+} from '@/lib/new-workspace'
+import type {
+  GitHubWorkItem,
+  OrcaHooks,
+  RepoHookSettings,
+  SetupDecision,
+  TuiAgent
+} from '../../../shared/types'
+
+// Why: bracketed paste markers let modern TUIs treat the inserted text as a
+// single atomic paste — Claude Code / Codex / Gemini put it in their input
+// buffer as a draft instead of echoing character-by-character. Intentionally
+// omit a trailing '\r' so the draft never auto-submits; the user gets to
+// review and send the prompt themselves.
+const BRACKETED_PASTE_BEGIN = '\x1b[200~'
+const BRACKETED_PASTE_END = '\x1b[201~'
+
+export type LaunchWorkItemDirectArgs = {
+  item: GitHubWorkItem
+  repoId: string
+  /** Called when the flow cannot proceed without user input (setup policy is
+   *  `ask`, or the selected repo cannot resolve). Callers wire this to the
+   *  existing modal opener so the user still gets a path forward. */
+  openModalFallback: () => void
+}
+
+function pickAgent(
+  preferred: TuiAgent | 'blank' | null | undefined,
+  detected: Set<TuiAgent>
+): TuiAgent | null {
+  // Why: honor the explicit default when the agent is actually installed. A
+  // stale preference (uninstalled binary) must not block the flow — fall
+  // through to the first matching detected agent in catalog order, which
+  // matches the quick-composer's auto-pick behavior and keeps the experience
+  // consistent regardless of where the user launches the workspace from.
+  if (preferred && preferred !== 'blank' && detected.has(preferred)) {
+    return preferred
+  }
+  for (const entry of AGENT_CATALOG) {
+    if (detected.has(entry.id)) {
+      return entry.id
+    }
+  }
+  return null
+}
+
+async function resolveSetupDecision(
+  repoId: string,
+  repo: { hookSettings?: RepoHookSettings }
+): Promise<{ kind: 'decided'; decision: SetupDecision } | { kind: 'needs-modal' }> {
+  let yamlHooks: OrcaHooks | null = null
+  try {
+    const result = await window.api.hooks.check({ repoId })
+    yamlHooks = (result.hooks as OrcaHooks | null) ?? null
+  } catch {
+    yamlHooks = null
+  }
+  const setupConfig = getSetupConfig(repo, yamlHooks)
+  if (!setupConfig) {
+    // Why: no setup script configured → the decision is irrelevant but `inherit`
+    // keeps the main-side behavior consistent with callers that don't pass one.
+    return { kind: 'decided', decision: 'inherit' }
+  }
+  const policy = repo.hookSettings?.setupRunPolicy ?? 'run-by-default'
+  if (policy === 'ask') {
+    return { kind: 'needs-modal' }
+  }
+  return {
+    kind: 'decided',
+    decision: policy === 'run-by-default' ? 'run' : 'skip'
+  }
+}
+
+/**
+ * "Use" flow: create the workspace, activate it, launch the default agent,
+ * and paste the work item URL into the agent's prompt as a draft (no submit).
+ *
+ * Falls back to `openModalFallback()` when:
+ *   - the repo's `setupRunPolicy` is `'ask'` (the user must pick per-workspace)
+ *   - the repo can't be resolved from `repoId`
+ *   - no compatible agent is detected on PATH
+ *
+ * Best-effort: after the workspace is created and activated, failures during
+ * the agent-readiness or paste steps only toast a notice — the user still
+ * has a usable workspace and can paste the URL themselves.
+ */
+export async function launchWorkItemDirect(args: LaunchWorkItemDirectArgs): Promise<void> {
+  const { item, repoId, openModalFallback } = args
+  const store = useAppStore.getState()
+  const repo = store.repos.find((r) => r.id === repoId)
+  if (!repo) {
+    openModalFallback()
+    return
+  }
+
+  const settings = store.settings
+  const detectedIds = new Set(await detectAgentsCached())
+  const effectiveAgent = pickAgent(settings?.defaultTuiAgent, detectedIds)
+
+  const setupResolution = await resolveSetupDecision(repoId, repo)
+  if (setupResolution.kind === 'needs-modal') {
+    openModalFallback()
+    return
+  }
+
+  const workspaceName = getWorkspaceSeedName({
+    explicitName: getLinkedWorkItemSuggestedName(item),
+    prompt: '',
+    linkedIssueNumber: item.type === 'issue' ? item.number : null,
+    linkedPR: item.type === 'pr' ? item.number : null
+  })
+
+  // Why: launch the agent with no prompt so the first frame it draws is the
+  // empty input box. The URL paste below populates that input buffer, which
+  // gives the user a reviewable draft instead of a submitted request.
+  const startupPlan =
+    effectiveAgent === null
+      ? null
+      : buildAgentStartupPlan({
+          agent: effectiveAgent,
+          prompt: '',
+          cmdOverrides: settings?.agentCmdOverrides ?? {},
+          platform: CLIENT_PLATFORM,
+          allowEmptyPromptLaunch: true
+        })
+
+  let worktreeId: string
+  let primaryTabId: string | null
+  try {
+    const result = await store.createWorktree(
+      repoId,
+      workspaceName,
+      undefined,
+      setupResolution.decision
+    )
+    worktreeId = result.worktree.id
+
+    const activation = activateAndRevealWorktree(worktreeId, {
+      setup: result.setup,
+      ...(startupPlan ? { startup: { command: startupPlan.launchCommand } } : {})
+    })
+    if (!activation) {
+      // Worktree vanished between create and activate — extremely unlikely but
+      // worth handling explicitly rather than silently dropping the URL.
+      toast.error('Workspace created but could not be activated.')
+      return
+    }
+    primaryTabId = activation.primaryTabId
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to create workspace.'
+    toast.error(message)
+    return
+  }
+
+  const meta: { linkedIssue?: number; linkedPR?: number } = {}
+  if (item.type === 'issue') {
+    meta.linkedIssue = item.number
+  } else {
+    meta.linkedPR = item.number
+  }
+  try {
+    await store.updateWorktreeMeta(worktreeId, meta)
+  } catch {
+    // Meta update is non-critical for the draft flow — continue.
+  }
+
+  store.setSidebarOpen(true)
+  if (settings?.rightSidebarOpenByDefault) {
+    store.setRightSidebarTab('explorer')
+    store.setRightSidebarOpen(true)
+  }
+
+  // Why: at this point the workspace is live and the agent (if any) has been
+  // queued on `primaryTabId`. The paste step below is the only remaining
+  // draft-specific work; bail out cleanly when either prerequisite is missing.
+  if (!primaryTabId || !startupPlan) {
+    return
+  }
+
+  const readyResult = await waitForAgentReady(primaryTabId, startupPlan.expectedProcess, {
+    timeoutMs: 5000
+  })
+  if (!readyResult.ready) {
+    toast.message(
+      'Agent took too long to start. The workspace is ready — paste the issue URL when the agent is idle.'
+    )
+    return
+  }
+
+  const finalState = useAppStore.getState()
+  const ptyId = finalState.ptyIdsByTabId[primaryTabId]?.[0]
+  if (!ptyId) {
+    return
+  }
+
+  // Why: some TUIs buffer input while they paint their first frame even after
+  // the foreground/title signal flips ready. One extra tick lets the input box
+  // render before we shove bytes into the PTY.
+  await new Promise((resolve) => window.setTimeout(resolve, 120))
+
+  window.api.pty.write(ptyId, `${BRACKETED_PASTE_BEGIN}${item.url}${BRACKETED_PASTE_END}`)
+}

--- a/src/renderer/src/lib/tui-agent-startup.ts
+++ b/src/renderer/src/lib/tui-agent-startup.ts
@@ -20,15 +20,24 @@ export function buildAgentStartupPlan(args: {
   prompt: string
   cmdOverrides: Partial<Record<TuiAgent, string>>
   platform: NodeJS.Platform
+  allowEmptyPromptLaunch?: boolean
 }): AgentStartupPlan | null {
-  const { agent, prompt, cmdOverrides, platform } = args
+  const { agent, prompt, cmdOverrides, platform, allowEmptyPromptLaunch = false } = args
   const trimmedPrompt = prompt.trim()
-  if (!trimmedPrompt) {
-    return null
-  }
-
   const config = TUI_AGENT_CONFIG[agent]
   const baseCommand = cmdOverrides[agent] ?? config.launchCmd
+
+  if (!trimmedPrompt) {
+    if (!allowEmptyPromptLaunch) {
+      return null
+    }
+    return {
+      launchCommand: baseCommand,
+      expectedProcess: config.expectedProcess,
+      followupPrompt: null
+    }
+  }
+
   const quotedPrompt = quoteStartupArg(trimmedPrompt, platform)
 
   if (config.promptInjectionMode === 'argv') {

--- a/src/renderer/src/lib/worktree-activation.ts
+++ b/src/renderer/src/lib/worktree-activation.ts
@@ -43,6 +43,16 @@ type WorktreeActivationStore = {
  * internally via `findWorktreeById`. Returns early without side effects
  * if the worktree is not found (e.g. deleted between palette open and select).
  */
+export type ActivateAndRevealResult = {
+  /** Id of the primary terminal tab seeded with `opts.startup`, when one was
+   *  created during this activation call. Callers that want to target the
+   *  exact pane the startup command ran in (e.g. to await agent readiness
+   *  and paste follow-up text) should use this rather than peeking at
+   *  `activeTabIdByWorktree`, which may point at another tab if setup or
+   *  issue-command scripts opened their own. */
+  primaryTabId: string | null
+}
+
 export function activateAndRevealWorktree(
   worktreeId: string,
   opts?: {
@@ -50,7 +60,7 @@ export function activateAndRevealWorktree(
     setup?: WorktreeSetupLaunch
     issueCommand?: IssueCommandLaunch
   }
-): boolean {
+): ActivateAndRevealResult | false {
   const state = useAppStore.getState()
   const wt = findWorktreeById(state.worktreesByRepo, worktreeId)
   if (!wt) {
@@ -72,7 +82,7 @@ export function activateAndRevealWorktree(
   state.setActiveWorktree(worktreeId)
 
   // 4. Ensure a focusable surface exists for externally-created worktrees
-  ensureWorktreeHasInitialTerminal(
+  const primaryTabId = ensureWorktreeHasInitialTerminal(
     useAppStore.getState(),
     worktreeId,
     opts?.startup,
@@ -94,7 +104,7 @@ export function activateAndRevealWorktree(
   // 6. Reveal in sidebar
   state.revealWorktreeInSidebar(worktreeId)
 
-  return true
+  return { primaryTabId }
 }
 
 export function ensureWorktreeHasInitialTerminal(
@@ -103,13 +113,13 @@ export function ensureWorktreeHasInitialTerminal(
   startup?: { command: string; env?: Record<string, string> },
   setup?: WorktreeSetupLaunch,
   issueCommand?: IssueCommandLaunch
-): void {
+): string | null {
   const { renderableTabCount } = store.reconcileWorktreeTabModel(worktreeId)
   // Why: activation can now restore editor- or browser-only worktrees from the
   // reconciled tab-group model. Creating a terminal just because the legacy
   // terminal slice is empty would reopen worktrees with an unexpected extra tab.
   if (!shouldAutoCreateInitialTerminal(renderableTabCount)) {
-    return
+    return null
   }
 
   const terminalTab = store.createTab(worktreeId)
@@ -171,4 +181,6 @@ export function ensureWorktreeHasInitialTerminal(
         : { command: issueCommand.command, env: issueCommand.env }
     store.queueTabIssueCommandSplit(terminalTab.id, queuedIssueCommand)
   }
+
+  return terminalTab.id
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -628,8 +628,11 @@ export type GlobalSettings = {
    *  does not surface commands from other worktrees. Defaults to true.
    *  Disable to revert to shared global shell history. */
   terminalScopeHistoryByWorktree: boolean
-  /** Which agent to pre-select in the new-workspace composer. null = auto (first detected). */
-  defaultTuiAgent: TuiAgent | null
+  /** Which agent to pre-select in the new-workspace composer.
+   *  - null: auto (first detected agent)
+   *  - 'blank': blank terminal (no agent launched)
+   *  - TuiAgent: a specific agent id */
+  defaultTuiAgent: TuiAgent | 'blank' | null
   /** Why: worktree deletion is destructive (git worktree remove + rm -rf of the
    *  working directory), so Orca shows a confirmation dialog by default. Users
    *  who delete frequently can opt into skipping the dialog via a "Don't ask


### PR DESCRIPTION
## Summary
- Rebuild the new workspace quick-create dialog around a compact shared composer card, with focused repo/agent comboboxes, autofocus flow, and a collapsible Advanced section for notes and setup decisions.
- Wire the work-item row Use button to a new direct-launch flow that creates the workspace, activates it, starts the detected default agent, waits for it to become ready, and pastes the issue/PR URL as an unsubmitted draft — falling back to the modal when setup policy is ask or no agent is detected.
- Stretch the repo and agent combobox dropdowns to match their trigger width so they align with the Workspace Name input, and add per-item "Set as default" right-click handling in the agent picker.

## Test plan
- [x] Lint clean (`pnpm -s run lint`)
- [x] Verified quick-create dialog end-to-end via CDP: repo select → name → agent → create creates worktree with expected args
- [x] Verified Use button flow launches workspace, activates it, starts the agent, and reaches readiness
- [x] Visually confirmed dropdowns render full trigger width in quick-create dialog
- [ ] Smoke-check Use fallback path when `setupRunPolicy === 'ask'` opens the composer modal