### PR TITLE
fix: clarify Sleep tooltip to mention browser tabs

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
@@ -213,7 +213,7 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({ worktree, 
                 Sleep
               </DropdownMenuItem>
             </TooltipTrigger>
-            <TooltipContent side="right" sideOffset={8}>
+            <TooltipContent side="right" sideOffset={8} className="max-w-[240px] text-pretty">
               Close all active panels in this workspace to free up memory and CPU. They&apos;ll be
               restored when you reopen it.
             </TooltipContent>

--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
@@ -213,7 +213,7 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({ worktree, 
                 Sleep
               </DropdownMenuItem>
             </TooltipTrigger>
-            <TooltipContent side="right" sideOffset={8} className="max-w-[240px] text-pretty">
+            <TooltipContent side="right" sideOffset={8} className="max-w-[200px] text-pretty">
               Close all active panels in this workspace to free up memory and CPU. They&apos;ll be
               restored when you reopen it.
             </TooltipContent>

--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
@@ -213,9 +213,9 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({ worktree, 
                 Sleep
               </DropdownMenuItem>
             </TooltipTrigger>
-            <TooltipContent side="right" sideOffset={8} className="max-w-[240px]">
+            <TooltipContent side="right" sideOffset={8}>
               Close all active panels in this workspace to free up memory and CPU. They&apos;ll be
-              re-created when you reopen it.
+              restored when you reopen it.
             </TooltipContent>
           </Tooltip>
           {/* Why: `git worktree remove` always rejects the main worktree, so we

--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
@@ -214,8 +214,7 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({ worktree, 
               </DropdownMenuItem>
             </TooltipTrigger>
             <TooltipContent side="right" sideOffset={8} className="max-w-[200px] text-pretty">
-              Close all active panels in this workspace to free up memory and CPU. They&apos;ll be
-              restored when you reopen it.
+              Close all active panels in this workspace to free up memory and CPU.
             </TooltipContent>
           </Tooltip>
           {/* Why: `git worktree remove` always rejects the main worktree, so we

--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
@@ -214,8 +214,8 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({ worktree, 
               </DropdownMenuItem>
             </TooltipTrigger>
             <TooltipContent side="right" sideOffset={8} className="max-w-[240px]">
-              Close all terminals and browser tabs in this workspace to free up memory and CPU.
-              They&apos;ll be re-created when you reopen it.
+              Close all active panels in this workspace to free up memory and CPU. They&apos;ll be
+              re-created when you reopen it.
             </TooltipContent>
           </Tooltip>
           {/* Why: `git worktree remove` always rejects the main worktree, so we

--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
@@ -214,8 +214,8 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({ worktree, 
               </DropdownMenuItem>
             </TooltipTrigger>
             <TooltipContent side="right" sideOffset={8} className="max-w-[240px]">
-              Close all terminals in this workspace to free up memory and CPU. They&apos;ll be
-              re-created when you reopen it.
+              Close all terminals and browser tabs in this workspace to free up memory and CPU.
+              They&apos;ll be re-created when you reopen it.
             </TooltipContent>
           </Tooltip>
           {/* Why: `git worktree remove` always rejects the main worktree, so we


### PR DESCRIPTION
## Problem

The Sleep action closes both terminals and browser tabs in a workspace, but the tooltip only mentioned terminals. This made the feature misleading about its actual scope.

## Solution

Updated the tooltip text to accurately mention that both terminals and browser tabs are closed when Sleep is triggered, providing users with complete information about what will be freed up.

<img width="455" height="108" alt="image" src="https://github.com/user-attachments/assets/5d2f7b61-761f-448c-a216-1a6a338f2046" />
