### PR TITLE
fix(sidebar): make pinned-group divider visible in both themes

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -279,7 +279,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                 className="absolute left-0 right-0"
                 style={{ transform: `translateY(${vItem.start}px)` }}
               >
-                <div className="mx-2 my-1.5 border-t border-border/60" />
+                <div className="mx-2 my-1.5 border-t border-foreground/15" />
               </div>
             )
           }


### PR DESCRIPTION
## Summary
- The separator between the Pinned group and the rest of the worktree list was using `border-border/60`. In dark mode, `--border` is already `rgb(255 255 255 / 0.07)`, so stacking a 60% opacity on top produced ~4% white on a near-black background — effectively invisible. Light mode (`#e5e5e5` at 60%) was also barely perceptible.
- Swap to `border-foreground/15`, which inverts between themes and keeps the divider at a consistent, legible contrast without overpowering the surrounding cards.

## Test plan
- [x] Verified in dark mode via `/electron` — divider clearly visible between the pinned item and the first unpinned worktree.
- [x] Verified in light mode — divider clearly visible (black at 15% on white).
- [x] Confirmed computed color via `getComputedStyle`: `oklab(... / 0.15)` vs. the prior ~4% effective opacity.