### PR TITLE
fix(tasks): drop redundant title-adjacent type icon on work-item rows

### DIFF
--- a/src/renderer/src/components/NewWorkspacePage.tsx
+++ b/src/renderer/src/components/NewWorkspacePage.tsx
@@ -767,16 +767,9 @@ export default function NewWorkspacePage(): React.JSX.Element {
                         </div>
 
                         <div className="min-w-0">
-                          <div className="flex items-center gap-2">
-                            {item.type === 'pr' ? (
-                              <GitPullRequest className="size-4 text-muted-foreground" />
-                            ) : (
-                              <CircleDot className="size-4 text-muted-foreground" />
-                            )}
-                            <h3 className="truncate text-[15px] font-semibold text-foreground">
-                              {item.title}
-                            </h3>
-                          </div>
+                          <h3 className="truncate text-[15px] font-semibold text-foreground">
+                            {item.title}
+                          </h3>
                           <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-muted-foreground">
                             <span>{item.author ?? 'unknown author'}</span>
                             <span>{selectedRepo?.displayName}</span>


### PR DESCRIPTION
## Summary
- Each row in the New Workspace tasks list rendered the issue/PR icon twice: once inside the `#<n>` pill (`size-3.5`) and again next to the title (`size-4`).
- The title-adjacent copy was pure duplicate signal, and the size mismatch made the duplication visually jarring.
- Keep the pill icon as the single type indicator; drop the second.

## Test plan
- [x] Verified in Orca dev build via `/electron`: opened NewWorkspacePage, inspected the title cell DOM — `svgCountInTitleCell: 0`, `#<n>` pill still shows the type icon.
- [ ] Visual check by reviewer: rows in the tasks list show one type icon (in the ID pill) instead of two.