### PR TITLE
fix(settings): trigger RC channel and hidden-experimental via plain Shift

### DIFF
--- a/src/main/menu/register-app-menu.test.ts
+++ b/src/main/menu/register-app-menu.test.ts
@@ -110,7 +110,7 @@ describe('registerAppMenu', () => {
     expect(reloadMock).not.toHaveBeenCalled()
   })
 
-  it('includes prereleases when Check for Updates is clicked with cmd+shift', () => {
+  it('includes prereleases when Check for Updates is clicked with shift held', () => {
     const options = buildMenuOptions()
     registerAppMenu(options)
 
@@ -119,15 +119,11 @@ describe('registerAppMenu', () => {
     const submenu = appMenu?.submenu as Electron.MenuItemConstructorOptions[]
     const item = submenu.find((entry) => entry.label === 'Check for Updates...')
 
+    item?.click?.({} as never, undefined as never, { shiftKey: true } as Electron.KeyboardEvent)
     item?.click?.(
       {} as never,
       undefined as never,
       { metaKey: true, shiftKey: true } as Electron.KeyboardEvent
-    )
-    item?.click?.(
-      {} as never,
-      undefined as never,
-      { ctrlKey: true, shiftKey: true } as Electron.KeyboardEvent
     )
     item?.click?.({} as never, undefined as never, {} as Electron.KeyboardEvent)
     item?.click?.({} as never, undefined as never, { metaKey: true } as Electron.KeyboardEvent)

--- a/src/main/menu/register-app-menu.ts
+++ b/src/main/menu/register-app-menu.ts
@@ -38,17 +38,14 @@ export function registerAppMenu({
         { role: 'about' },
         {
           label: 'Check for Updates...',
-          // Why: holding Cmd+Shift (or Ctrl+Shift on win/linux) while clicking
-          // opts this check into the release-candidate channel. The event
-          // carries the modifier keys down from the native menu — we only act
-          // on the mouse chord, not accelerator-triggered invocations (there
-          // is no accelerator on this item, so triggeredByAccelerator should
-          // always be false here, but guarding makes the intent explicit).
+          // Why: holding Shift while clicking opts this check into the
+          // release-candidate channel. The event carries the modifier keys
+          // down from the native menu — we only act on the mouse chord, not
+          // accelerator-triggered invocations (there is no accelerator on
+          // this item, so triggeredByAccelerator should always be false here,
+          // but guarding makes the intent explicit).
           click: (_menuItem, _window, event) => {
-            const includePrerelease =
-              !event.triggeredByAccelerator &&
-              (event.metaKey === true || event.ctrlKey === true) &&
-              event.shiftKey === true
+            const includePrerelease = !event.triggeredByAccelerator && event.shiftKey === true
             onCheckForUpdates({ includePrerelease })
           }
         },

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -25,10 +25,10 @@ let currentStatus: UpdateStatus = { state: 'idle' }
 let userInitiatedCheck = false
 let onBeforeQuitCleanup: (() => void) | null = null
 let autoUpdaterInitialized = false
-// Why: Cmd+Shift-clicking "Check for Updates" opts the user into the RC
-// release channel for the rest of this process. We switch to the GitHub
-// provider with allowPrerelease=true so both the check AND any follow-up
-// download resolve against the same (possibly prerelease) release manifest.
+// Why: Shift-clicking "Check for Updates" opts the user into the RC release
+// channel for the rest of this process. We switch to the GitHub provider
+// with allowPrerelease=true so both the check AND any follow-up download
+// resolve against the same (possibly prerelease) release manifest.
 // Resetting only after the check would leave a downloaded RC pointing at a
 // feed URL that no longer advertises it. See design comment in
 // enableIncludePrerelease.

--- a/src/renderer/src/components/settings/ExperimentalPane.tsx
+++ b/src/renderer/src/components/settings/ExperimentalPane.tsx
@@ -14,7 +14,7 @@ type ExperimentalPaneProps = {
   settings: GlobalSettings
   updateSettings: (updates: Partial<GlobalSettings>) => void
   /** Hidden-experimental group is only rendered once the user has unlocked
-   *  it via Cmd+Shift-clicking the Experimental sidebar entry. */
+   *  it via Shift-clicking the Experimental sidebar entry. */
   hiddenExperimentalUnlocked?: boolean
 }
 

--- a/src/renderer/src/components/settings/GeneralPane.tsx
+++ b/src/renderer/src/components/settings/GeneralPane.tsx
@@ -768,12 +768,12 @@ export function GeneralPane({ settings, updateSettings }: GeneralPaneProps): Rea
             <Button
               variant="outline"
               size="sm"
-              // Why: Cmd+Shift-click (Ctrl+Shift on win/linux) opts this check
-              // into the release-candidate channel. Keep the affordance hidden
-              // — it's a power-user shortcut, not a discoverable toggle.
+              // Why: Shift-click opts this check into the release-candidate
+              // channel. Keep the affordance hidden — it's a power-user
+              // shortcut, not a discoverable toggle.
               onClick={(event) =>
                 window.api.updater.check({
-                  includePrerelease: (event.metaKey || event.ctrlKey) && event.shiftKey
+                  includePrerelease: event.shiftKey
                 })
               }
               disabled={updateStatus.state === 'checking' || updateStatus.state === 'downloading'}

--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -137,7 +137,7 @@ function Settings(): React.JSX.Element {
     getFallbackTerminalFonts()
   )
   const [activeSectionId, setActiveSectionId] = useState('general')
-  // Why: the hidden-experimental group is an unlock — Cmd+Shift-clicking the
+  // Why: the hidden-experimental group is an unlock — Shift-clicking the
   // Experimental sidebar entry reveals it for the remainder of the session.
   // Not persisted on purpose: it's a power-user affordance we don't want to
   // leak through into a normal reopen of Settings.
@@ -474,17 +474,12 @@ function Settings(): React.JSX.Element {
       sectionId: string,
       modifiers?: { metaKey: boolean; ctrlKey: boolean; shiftKey: boolean; altKey: boolean }
     ) => {
-      // Why: Cmd+Shift-clicking (Ctrl+Shift on win/linux) the Experimental
-      // sidebar entry unlocks a hidden power-user group. Keep this scoped to
-      // the Experimental row so normal shortcut combos on other rows don't
-      // accidentally flip state. The unlock persists for the life of the
-      // Settings view (resets when Settings is reopened).
-      if (
-        sectionId === 'experimental' &&
-        modifiers &&
-        (modifiers.metaKey || modifiers.ctrlKey) &&
-        modifiers.shiftKey
-      ) {
+      // Why: Shift-clicking the Experimental sidebar entry unlocks a hidden
+      // power-user group. Keep this scoped to the Experimental row so normal
+      // shortcut combos on other rows don't accidentally flip state. The
+      // unlock persists for the life of the Settings view (resets when
+      // Settings is reopened).
+      if (sectionId === 'experimental' && modifiers?.shiftKey) {
         setHiddenExperimentalUnlocked((previous) => !previous)
       }
       scrollSectionIntoView(sectionId, contentScrollRef.current)


### PR DESCRIPTION
## Summary
- Follow-up to #887: the Cmd+Shift chord didn't work reliably in practice.
- **Hold Shift while clicking "Check for Updates"** (app menu or Settings > General) opts into the RC release channel — now keyed off `event.shiftKey` alone in both the menu handler and the Settings button onClick.
- **Shift-click the Experimental sidebar entry** toggles the hidden-experimental group — the gate in \`scrollToSection\` now checks only \`modifiers.shiftKey\`.

## Test plan
- [x] \`pnpm run typecheck\` clean
- [x] \`pnpm run lint\` clean on changed files (2 pre-existing warnings elsewhere)
- [x] Updated unit tests (\`src/main/menu/register-app-menu.test.ts\`) — Shift alone, Shift+Cmd, no modifier, and Cmd alone — pass
- [x] Empirically verified in the running app via CDP:
  - Plain click on Experimental sidebar entry → hidden section does NOT appear
  - Shift-click → orange "Hidden experimental" section + "Placeholder toggle" appear
  - Shift-click again → section hides
  - Settings > General "Check for Updates" onClick reads \`event.shiftKey\` directly