### PR TITLE
fix(sidebar): make Pinned section visually distinct

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -99,11 +99,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
       if (!row) {
         return `__stale_${index}`
       }
-      return row.type === 'header'
-        ? `hdr:${row.key}`
-        : row.type === 'separator'
-          ? `sep:${row.key}`
-          : `wt:${row.worktree.id}`
+      return row.type === 'header' ? `hdr:${row.key}` : `wt:${row.worktree.id}`
     }
   })
 
@@ -268,21 +264,6 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
       >
         {virtualItems.map((vItem) => {
           const row = rows[vItem.index]
-
-          if (row.type === 'separator') {
-            return (
-              <div
-                key={vItem.key}
-                role="separator"
-                data-index={vItem.index}
-                ref={virtualizer.measureElement}
-                className="absolute left-0 right-0"
-                style={{ transform: `translateY(${vItem.start}px)` }}
-              >
-                <div className="mx-2 my-1.5 border-t border-foreground/15" />
-              </div>
-            )
-          }
 
           if (row.type === 'header') {
             return (

--- a/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
@@ -160,9 +160,9 @@ describe('buildRows with pinned worktrees', () => {
     expect(rows[1]).toMatchObject({ type: 'item', worktree: { id: 'wt-pinned' } })
   })
 
-  it('emits a separator between pinned and unpinned in groupBy none', () => {
+  it('emits an All header between pinned and unpinned in groupBy none', () => {
     const rows = buildRows('none', [unpinned1, pinned, unpinned2], repoMap, null, new Set())
-    expect(rows[2]).toMatchObject({ type: 'separator', key: 'sep:pinned' })
+    expect(rows[2]).toMatchObject({ type: 'header', key: 'all', label: 'All', count: 2 })
     expect(rows[3]).toMatchObject({ type: 'item', worktree: { id: 'wt-1' } })
     expect(rows[4]).toMatchObject({ type: 'item', worktree: { id: 'wt-2' } })
   })
@@ -187,13 +187,13 @@ describe('buildRows with pinned worktrees', () => {
   it('collapses pinned group when in collapsedGroups', () => {
     const rows = buildRows('none', [pinned, unpinned1], repoMap, null, new Set(['pinned']))
     expect(rows[0]).toMatchObject({ type: 'header', key: 'pinned' })
-    expect(rows[1]).toMatchObject({ type: 'separator' })
+    expect(rows[1]).toMatchObject({ type: 'header', key: 'all' })
     expect(rows[2]).toMatchObject({ type: 'item', worktree: { id: 'wt-1' } })
   })
 
-  it('does not emit separator when all worktrees are pinned', () => {
+  it('does not emit All header when all worktrees are pinned', () => {
     const allPinned = { ...unpinned1, isPinned: true }
     const rows = buildRows('none', [pinned, allPinned], repoMap, null, new Set())
-    expect(rows.some((r) => r.type === 'separator')).toBe(false)
+    expect(rows.some((r) => r.type === 'header' && r.key === 'all')).toBe(false)
   })
 })

--- a/src/renderer/src/components/sidebar/worktree-list-groups.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.ts
@@ -1,4 +1,12 @@
-import { CircleCheckBig, CircleDot, CircleX, FolderGit2, GitPullRequest } from 'lucide-react'
+import {
+  CircleCheckBig,
+  CircleDot,
+  CircleX,
+  FolderGit2,
+  GitPullRequest,
+  LayoutList,
+  Pin
+} from 'lucide-react'
 import type React from 'react'
 import type { Repo, Worktree } from '../../../../shared/types'
 import { branchName } from '@/lib/git-utils'
@@ -15,9 +23,8 @@ export type GroupHeaderRow = {
   repo?: Repo
 }
 
-export type SeparatorRow = { type: 'separator'; key: string }
 export type WorktreeRow = { type: 'item'; worktree: Worktree; repo: Repo | undefined }
-export type Row = GroupHeaderRow | SeparatorRow | WorktreeRow
+export type Row = GroupHeaderRow | WorktreeRow
 
 export type PRGroupKey = 'done' | 'in-review' | 'in-progress' | 'closed'
 
@@ -62,7 +69,16 @@ export const PINNED_GROUP_KEY = 'pinned'
 
 export const PINNED_GROUP_META = {
   label: 'Pinned',
-  tone: 'text-muted-foreground'
+  tone: 'text-foreground',
+  icon: Pin
+} as const
+
+export const ALL_GROUP_KEY = 'all'
+
+export const ALL_GROUP_META = {
+  label: 'All',
+  tone: 'text-foreground',
+  icon: LayoutList
 } as const
 
 export function getPRGroupKey(
@@ -114,7 +130,8 @@ function emitPinnedGroup(
     key: PINNED_GROUP_KEY,
     label: PINNED_GROUP_META.label,
     count: pinned.length,
-    tone: PINNED_GROUP_META.tone
+    tone: PINNED_GROUP_META.tone,
+    icon: PINNED_GROUP_META.icon
   })
   if (!collapsedGroups.has(PINNED_GROUP_KEY)) {
     for (const w of pinned) {
@@ -141,8 +158,21 @@ export function buildRows(
   const unpinned = pinnedIds.size > 0 ? worktrees.filter((w) => !pinnedIds.has(w.id)) : worktrees
 
   if (groupBy === 'none') {
+    // Without an "All" header, the unpinned block is visually indistinguishable
+    // from a continuation of the Pinned section — so when pinned items exist,
+    // mark the boundary with a sibling header that mirrors the Pinned one.
     if (pinnedIds.size > 0 && unpinned.length > 0) {
-      result.push({ type: 'separator', key: 'sep:pinned' })
+      result.push({
+        type: 'header',
+        key: ALL_GROUP_KEY,
+        label: ALL_GROUP_META.label,
+        count: unpinned.length,
+        tone: ALL_GROUP_META.tone,
+        icon: ALL_GROUP_META.icon
+      })
+      if (collapsedGroups.has(ALL_GROUP_KEY)) {
+        return result
+      }
     }
     for (const w of unpinned) {
       result.push({ type: 'item', worktree: w, repo: repoMap.get(w.repoId) })


### PR DESCRIPTION
## Summary
- Add a Pin icon to the Pinned header and bump its tone to `text-foreground` so it matches the visual weight of other group headers.
- Introduce an "All" sibling header (LayoutList icon, count badge) for the unpinned block when `groupBy='none'` and pinned items exist — replaces the faint divider that used to blend the two sections together.

## Test plan
- [x] `pnpm vitest run src/renderer/src/components/sidebar/` — 60/60 pass
- [x] `pnpm run typecheck` — clean
- [ ] Visual check: sidebar with 1+ pinned items in All / PR Status / Repo grouping modes
- [ ] Visual check: all-pinned (no "All" header) and collapsing behavior