### PR TITLE
fix(terminal): open .html/.htm paths directly in Orca's browser

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { handleOscLink, isTerminalLinkActivation } from './terminal-link-handlers'
+import {
+  getTerminalHtmlFileOpenHint,
+  handleOscLink,
+  isTerminalLinkActivation,
+  openDetectedFilePath
+} from './terminal-link-handlers'
 
 const openUrlMock = vi.fn()
 const openFileUriMock = vi.fn()
@@ -128,6 +133,45 @@ describe('handleOscLink', () => {
 
     expect(openUrlMock).toHaveBeenCalledWith('https://example.com/')
     expect(createBrowserTabMock).not.toHaveBeenCalled()
+  })
+
+  it('routes .html file paths straight into the embedded browser', async () => {
+    setPlatform('Macintosh')
+
+    openDetectedFilePath('/tmp/report.html', null, null, deps)
+
+    // openDetectedFilePath is async (fire-and-forget), so flush the microtask queue
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    // Why: .html should not open Monaco — it should render in the browser tab.
+    expect(openFileMock).not.toHaveBeenCalled()
+    expect(createBrowserTabMock).toHaveBeenCalledWith(
+      'wt-1',
+      'file:///tmp/report.html',
+      expect.objectContaining({ title: 'report.html', activate: true })
+    )
+  })
+
+  it('also routes .htm paths to the embedded browser', async () => {
+    setPlatform('Macintosh')
+
+    openDetectedFilePath('/tmp/legacy.HTM', null, null, deps)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(openFileMock).not.toHaveBeenCalled()
+    expect(createBrowserTabMock).toHaveBeenCalledWith(
+      'wt-1',
+      'file:///tmp/legacy.HTM',
+      expect.objectContaining({ title: 'legacy.HTM' })
+    )
+  })
+
+  it('advertises the browser-open behavior in the html hover hint', () => {
+    setPlatform('Macintosh')
+    expect(getTerminalHtmlFileOpenHint()).toBe('⌘+click to open in browser')
+
+    setPlatform('Windows')
+    expect(getTerminalHtmlFileOpenHint()).toBe('Ctrl+click to open in browser')
   })
 
   it('opens file links in Orca instead of via shell when the platform modifier is pressed', async () => {

--- a/src/renderer/src/components/terminal-pane/terminal-link-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-handlers.ts
@@ -8,6 +8,7 @@ import {
 } from '@/lib/terminal-links'
 import { useAppStore } from '@/store'
 import { getConnectionId } from '@/lib/connection-context'
+import { absolutePathToFileUri } from '@/components/editor/markdown-internal-links'
 import type { PaneManager } from '@/lib/pane-manager/pane-manager'
 
 export type LinkHandlerDeps = {
@@ -30,10 +31,32 @@ export function getTerminalFileOpenHint(): string {
   return isMacPlatform() ? '⌘+click to open' : 'Ctrl+click to open'
 }
 
+// Why: .html/.htm files are routed straight into Orca's embedded browser rather
+// than the Monaco editor (which would just show the source), matching the
+// standalone "Open Preview to the Side" entry point. Advertise the different
+// behavior in the hover tooltip so users know a click will render the page.
+export function getTerminalHtmlFileOpenHint(): string {
+  return isMacPlatform() ? '⌘+click to open in browser' : 'Ctrl+click to open in browser'
+}
+
 export function getTerminalUrlOpenHint(): string {
   return isMacPlatform()
     ? '⌘+click to open or ⇧⌘+click for system browser'
     : 'Ctrl+click to open or Shift+Ctrl+click for system browser'
+}
+
+function isHtmlFilePath(filePath: string): boolean {
+  return /\.html?$/i.test(filePath)
+}
+
+function openHtmlFileInBrowser(filePath: string, worktreeId: string): void {
+  const store = useAppStore.getState()
+  if (worktreeId) {
+    store.setActiveWorktree(worktreeId)
+  }
+  const fileUrl = absolutePathToFileUri(filePath)
+  const title = filePath.split(/[/\\]/).pop() ?? filePath
+  store.createBrowserTab(worktreeId, fileUrl, { title, activate: true })
 }
 
 export function openDetectedFilePath(
@@ -59,6 +82,15 @@ export function openDetectedFilePath(
 
     if (statResult.isDirectory) {
       await window.api.shell.openFilePath(filePath)
+      return
+    }
+
+    // Why: .html/.htm files render in Orca's embedded browser instead of opening
+    // as source in Monaco — ⌘/Ctrl+click on an HTML path in the terminal should
+    // feel like clicking an http link and render the page, not dump HTML source.
+    // Mirrors the editor's "Open Preview to the Side" action.
+    if (isHtmlFilePath(filePath)) {
+      openHtmlFileInBrowser(filePath, worktreeId)
       return
     }
 
@@ -155,7 +187,14 @@ export function createFilePathLinkProvider(
               })
             },
             hover: () => {
-              linkTooltip.textContent = `${resolved.absolutePath} (${openLinkHint})`
+              // Why: HTML files get a distinct hint because ⌘/Ctrl+click opens
+              // them rendered in the embedded browser, not as source in the
+              // editor — parallels the "open in system browser" affordance
+              // shown for http URLs.
+              const hint = isHtmlFilePath(resolved.absolutePath)
+                ? getTerminalHtmlFileOpenHint()
+                : openLinkHint
+              linkTooltip.textContent = `${resolved.absolutePath} (${hint})`
               linkTooltip.style.display = ''
             },
             leave: () => {


### PR DESCRIPTION
## Summary
Follow-up to #908. Cmd/Ctrl+click on an `.html`/`.htm` path in the terminal now renders the page in a new Orca browser tab instead of loading the source into Monaco. Mirrors how terminal http(s) URLs already route into the embedded browser, and reuses the same `file://` plumbing that PR #908 added for "Open Preview to the Side".

- `openDetectedFilePath` short-circuits HTML paths to `createBrowserTab(fileUrl)` — skipping `openFile` / Monaco entirely.
- Terminal hover tooltip for HTML paths now reads "⌘+click to open in browser" (or Ctrl variant) so the different behavior is discoverable, parallel to the existing URL hint.

## Test plan
- [x] `pnpm vitest run src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts` — 11 passed (3 new)
- [x] `pnpm vitest run src/renderer/src` — 848 passed
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (2 pre-existing warnings unrelated)
- [ ] Manual: `echo /tmp/sample.html` in a terminal → hover shows "open in browser" hint → ⌘+click → renders in a new browser tab (live-testing terminal hover+modified-click is awkward to script; covered by unit tests exercising `openDetectedFilePath` for .html/.htm plus shared `createBrowserTab`/`absolutePathToFileUri` paths validated by #908)