### PR TITLE
feat(agents): use claude --prefill for Use direct-launch draft

### DIFF
--- a/src/renderer/src/lib/launch-work-item-direct.ts
+++ b/src/renderer/src/lib/launch-work-item-direct.ts
@@ -3,7 +3,7 @@ import { useAppStore } from '@/store'
 import { AGENT_CATALOG } from '@/lib/agent-catalog'
 import { detectAgentsCached } from '@/lib/detect-agents-cached'
 import { waitForAgentReady } from '@/lib/agent-ready-wait'
-import { buildAgentStartupPlan } from '@/lib/tui-agent-startup'
+import { buildAgentDraftLaunchPlan, buildAgentStartupPlan } from '@/lib/tui-agent-startup'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 import {
   CLIENT_PLATFORM,
@@ -122,11 +122,24 @@ export async function launchWorkItemDirect(args: LaunchWorkItemDirectArgs): Prom
     linkedPR: item.type === 'pr' ? item.number : null
   })
 
-  // Why: launch the agent with no prompt so the first frame it draws is the
-  // empty input box. The URL paste below populates that input buffer, which
-  // gives the user a reviewable draft instead of a submitted request.
-  const startupPlan =
+  // Why: prefer a native "prefill" flag when the agent's CLI exposes one
+  // (e.g. `claude --prefill '<url>'`) — the TUI starts with the URL already
+  // in its input box, no submit, and we skip the readiness-wait + paste
+  // dance below. Fall back to launching with no prompt + bracketed-paste for
+  // every other agent so the URL lands as a draft instead of being
+  // auto-submitted as the first turn.
+  const draftLaunchPlan =
     effectiveAgent === null
+      ? null
+      : buildAgentDraftLaunchPlan({
+          agent: effectiveAgent,
+          draft: item.url,
+          cmdOverrides: settings?.agentCmdOverrides ?? {},
+          platform: CLIENT_PLATFORM
+        })
+  const startupPlan =
+    draftLaunchPlan ??
+    (effectiveAgent === null
       ? null
       : buildAgentStartupPlan({
           agent: effectiveAgent,
@@ -134,7 +147,7 @@ export async function launchWorkItemDirect(args: LaunchWorkItemDirectArgs): Prom
           cmdOverrides: settings?.agentCmdOverrides ?? {},
           platform: CLIENT_PLATFORM,
           allowEmptyPromptLaunch: true
-        })
+        }))
 
   let worktreeId: string
   let primaryTabId: string | null
@@ -184,8 +197,11 @@ export async function launchWorkItemDirect(args: LaunchWorkItemDirectArgs): Prom
 
   // Why: at this point the workspace is live and the agent (if any) has been
   // queued on `primaryTabId`. The paste step below is the only remaining
-  // draft-specific work; bail out cleanly when either prerequisite is missing.
-  if (!primaryTabId || !startupPlan) {
+  // draft-specific work; bail out cleanly when either prerequisite is missing
+  // or when the agent was launched via a native prefill flag (draftLaunchPlan)
+  // — in that case the URL is already in its input box and pasting again
+  // would duplicate it.
+  if (!primaryTabId || !startupPlan || draftLaunchPlan) {
     return
   }
 

--- a/src/renderer/src/lib/tui-agent-startup.test.ts
+++ b/src/renderer/src/lib/tui-agent-startup.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { buildAgentStartupPlan, isShellProcess } from './tui-agent-startup'
+import {
+  buildAgentDraftLaunchPlan,
+  buildAgentStartupPlan,
+  isShellProcess
+} from './tui-agent-startup'
 
 describe('buildAgentStartupPlan', () => {
   it('passes Claude prompts as a positional interactive argument', () => {
@@ -115,6 +119,58 @@ describe('buildAgentStartupPlan', () => {
       launchCommand: "copilot -i 'Fix the bug'",
       expectedProcess: 'copilot',
       followupPrompt: null
+    })
+  })
+})
+
+describe('buildAgentDraftLaunchPlan', () => {
+  it('uses Claude --prefill to seed the input box without submitting', () => {
+    expect(
+      buildAgentDraftLaunchPlan({
+        agent: 'claude',
+        draft: 'https://github.com/acme/repo/issues/42',
+        cmdOverrides: {},
+        platform: 'darwin'
+      })
+    ).toEqual({
+      launchCommand: "claude --prefill 'https://github.com/acme/repo/issues/42'",
+      expectedProcess: 'claude'
+    })
+  })
+
+  it('returns null for agents without a documented prefill flag', () => {
+    expect(
+      buildAgentDraftLaunchPlan({
+        agent: 'codex',
+        draft: 'https://github.com/acme/repo/issues/42',
+        cmdOverrides: {},
+        platform: 'darwin'
+      })
+    ).toBeNull()
+  })
+
+  it('returns null for an empty draft so callers fall back cleanly', () => {
+    expect(
+      buildAgentDraftLaunchPlan({
+        agent: 'claude',
+        draft: '   ',
+        cmdOverrides: {},
+        platform: 'darwin'
+      })
+    ).toBeNull()
+  })
+
+  it('honors cmdOverrides so custom Claude install paths still prefill', () => {
+    expect(
+      buildAgentDraftLaunchPlan({
+        agent: 'claude',
+        draft: 'review this',
+        cmdOverrides: { claude: '/opt/anthropic/bin/claude' },
+        platform: 'linux'
+      })
+    ).toEqual({
+      launchCommand: "/opt/anthropic/bin/claude --prefill 'review this'",
+      expectedProcess: 'claude'
     })
   })
 })

--- a/src/renderer/src/lib/tui-agent-startup.ts
+++ b/src/renderer/src/lib/tui-agent-startup.ts
@@ -83,6 +83,40 @@ export function buildAgentStartupPlan(args: {
   }
 }
 
+export type AgentDraftLaunchPlan = {
+  launchCommand: string
+  expectedProcess: string
+}
+
+// Why: the "Use" direct-launch flow wants to open the agent TUI with the work
+// item URL already in the input box, but NOT submitted. Some CLIs expose a
+// native flag for exactly that (e.g. `claude --prefill '<text>'`), which is
+// strictly better than the post-launch bracketed-paste fallback because it
+// avoids the agent-readiness race and a 120ms settle. Returns null when the
+// agent has no such flag — callers fall back to paste-after-start.
+export function buildAgentDraftLaunchPlan(args: {
+  agent: TuiAgent
+  draft: string
+  cmdOverrides: Partial<Record<TuiAgent, string>>
+  platform: NodeJS.Platform
+}): AgentDraftLaunchPlan | null {
+  const { agent, draft, cmdOverrides, platform } = args
+  const config = TUI_AGENT_CONFIG[agent]
+  if (!config.draftPromptFlag) {
+    return null
+  }
+  const trimmed = draft.trim()
+  if (!trimmed) {
+    return null
+  }
+  const baseCommand = cmdOverrides[agent] ?? config.launchCmd
+  const quoted = quoteStartupArg(trimmed, platform)
+  return {
+    launchCommand: `${baseCommand} ${config.draftPromptFlag} ${quoted}`,
+    expectedProcess: config.expectedProcess
+  }
+}
+
 export function isShellProcess(processName: string): boolean {
   const normalized = processName.trim().toLowerCase()
   return (

--- a/src/shared/tui-agent-config.ts
+++ b/src/shared/tui-agent-config.ts
@@ -12,6 +12,14 @@ export type TuiAgentConfig = {
   launchCmd: string
   expectedProcess: string
   promptInjectionMode: AgentPromptInjectionMode
+  // Why: flag that launches the TUI with the given text pre-filled in the
+  // input box but NOT submitted, so the user still gets a reviewable draft.
+  // Only set when the CLI has documented native support — e.g. Claude's
+  // `--prefill`. The "Use" direct-launch flow prefers this over the
+  // post-launch bracketed-paste path because it avoids the agent-readiness
+  // race and the 120ms settle. Agents without native support keep using the
+  // paste-after-start path.
+  draftPromptFlag?: string
 }
 
 // Why: the new-workspace handoff depends on three pieces of per-agent
@@ -25,7 +33,8 @@ export const TUI_AGENT_CONFIG: Record<TuiAgent, TuiAgentConfig> = {
     detectCmd: 'claude',
     launchCmd: 'claude',
     expectedProcess: 'claude',
-    promptInjectionMode: 'argv'
+    promptInjectionMode: 'argv',
+    draftPromptFlag: '--prefill'
   },
   codex: {
     detectCmd: 'codex',


### PR DESCRIPTION
## Summary

The "Use" CTA on the Task page creates a workspace and drops the GitHub issue/PR URL into the agent's input box as a reviewable draft (not submitted). Today that's done via a post-launch bracketed-paste after `waitForAgentReady` + a 120ms settle — it works, but there's a real race window.

Claude Code exposes `--prefill <text>`, which launches the TUI with the text already in the input box and nothing submitted. For Claude users this replaces the readiness + paste dance entirely while preserving the "draft, don't send" contract.

## Changes

- `src/shared/tui-agent-config.ts` — add optional `draftPromptFlag` to `TuiAgentConfig`; set `'--prefill'` on `claude` only.
- `src/renderer/src/lib/tui-agent-startup.ts` — new `buildAgentDraftLaunchPlan` helper. Returns a launch command when the agent has a prefill flag, `null` otherwise.
- `src/renderer/src/lib/launch-work-item-direct.ts` — prefer the draft plan; skip the post-launch paste when one is used (pasting again would duplicate the URL). Every other agent keeps today's paste-after-ready path unchanged.
- Tests: prefill case for Claude, null fallback for agents without the flag, empty-draft fallback, and `cmdOverrides` honoring.

## Agent CLI survey

Checked every CLI we could run locally (codex, cursor-agent, droid, gemini, copilot, pi, opencode, aider) — **Claude is the only one with a documented "prefill but don't submit" flag today**. `gemini -i/--prompt-interactive` and `copilot -i/--interactive` both auto-execute. The `draftPromptFlag` shape lets us drop in additional agents as one-liners when they ship the equivalent.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint` (no new warnings)
- [x] `pnpm exec vitest run src/renderer/src/lib/tui-agent-startup.test.ts` — 14 tests pass
- [ ] Manual: on the Task page with Claude as default agent, click "Use" on a GH issue → Claude opens with the issue URL pre-filled in the input, not submitted
- [ ] Manual: repeat with a non-Claude default (codex/cursor/etc.) → behavior unchanged; URL still lands as a bracketed-paste draft after agent ready