### PR TITLE
fix(browser): make address bar Enter match typed intent, not Google Search

### DIFF
--- a/src/renderer/src/components/browser-pane/BrowserAddressBar.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserAddressBar.tsx
@@ -7,6 +7,7 @@ import { useAppStore } from '@/store'
 import {
   buildSearchUrl,
   looksLikeSearchQuery,
+  normalizeBrowserNavigationUrl,
   SEARCH_ENGINE_LABELS,
   DEFAULT_SEARCH_ENGINE,
   type SearchEngine
@@ -17,9 +18,10 @@ const MAX_SUGGESTIONS = 8
 type SuggestionEntry = {
   url: string
   title: string
+  subtitle: string
   lastVisitedAt: number
   visitCount: number
-  isSearch?: boolean
+  isSearch: boolean
 }
 
 type BrowserAddressBarProps = {
@@ -78,6 +80,7 @@ export default function BrowserAddressBar({
       return [...browserUrlHistory]
         .sort((a, b) => b.lastVisitedAt - a.lastVisitedAt)
         .slice(0, MAX_SUGGESTIONS)
+        .map((entry) => ({ ...entry, subtitle: entry.url, isSearch: false }))
     }
 
     const historySuggestions: SuggestionEntry[] =
@@ -87,22 +90,45 @@ export default function BrowserAddressBar({
             .filter((item) => item.score >= 0)
             .sort((a, b) => b.score - a.score)
             .slice(0, MAX_SUGGESTIONS - 1)
-            .map((item) => item.entry)
+            .map((item) => ({ ...item.entry, subtitle: item.entry.url, isSearch: false }))
         : []
 
-    const searchSuggestion: SuggestionEntry = {
-      url: buildSearchUrl(trimmed, searchEngine),
-      title: `${trimmed} — ${SEARCH_ENGINE_LABELS[searchEngine]} Search`,
-      lastVisitedAt: 0,
-      visitCount: 0,
-      isSearch: true
+    // Why: the top row of the dropdown must always mirror what pressing Enter
+    // will do — i.e. what `normalizeBrowserNavigationUrl` resolves to. Chrome
+    // and Firefox omniboxes work this way: for URL-like inputs the top row is
+    // the typed URL itself (navigate), and for bare queries it is the search.
+    // The earlier implementation appended a "Google Search" row as a fallback
+    // for URL-like inputs, which then got auto-selected when no history
+    // matched — so Enter on "www.example.com" hit Google instead of the site.
+    const isQuery = looksLikeSearchQuery(trimmed)
+    const topAction: SuggestionEntry = isQuery
+      ? {
+          url: buildSearchUrl(trimmed, searchEngine),
+          title: trimmed,
+          subtitle: `${SEARCH_ENGINE_LABELS[searchEngine]} Search`,
+          lastVisitedAt: 0,
+          visitCount: 0,
+          isSearch: true
+        }
+      : {
+          url: normalizeBrowserNavigationUrl(trimmed, searchEngine) ?? trimmed,
+          title: trimmed,
+          subtitle: '',
+          lastVisitedAt: 0,
+          visitCount: 0,
+          isSearch: false
+        }
+
+    // Why: if a history row already targets the same URL as the top action,
+    // skip the synthetic top row — the history row is more informative (real
+    // page title) and will be auto-selected, so Enter still navigates to the
+    // same place.
+    const duplicateIdx = historySuggestions.findIndex((h) => h.url === topAction.url)
+    if (duplicateIdx >= 0) {
+      return historySuggestions.slice(0, MAX_SUGGESTIONS)
     }
 
-    if (looksLikeSearchQuery(trimmed)) {
-      return [searchSuggestion, ...historySuggestions]
-    }
-
-    return [...historySuggestions.slice(0, MAX_SUGGESTIONS - 1), searchSuggestion]
+    return [topAction, ...historySuggestions].slice(0, MAX_SUGGESTIONS)
   }, [browserUrlHistory, value, searchEngine])
 
   const handleFocus = useCallback(() => {
@@ -281,16 +307,12 @@ export default function BrowserAddressBar({
                       <Globe className="size-3.5 shrink-0 text-muted-foreground" />
                     )}
                     <div className="flex min-w-0 flex-1 flex-col">
-                      {entry.isSearch ? (
-                        <span className="truncate text-sm">{entry.title}</span>
-                      ) : (
-                        <>
-                          <span className="truncate text-sm">{entry.title}</span>
-                          <span className="truncate text-xs text-muted-foreground">
-                            {entry.url}
-                          </span>
-                        </>
-                      )}
+                      <span className="truncate text-sm">{entry.title}</span>
+                      {entry.subtitle ? (
+                        <span className="truncate text-xs text-muted-foreground">
+                          {entry.subtitle}
+                        </span>
+                      ) : null}
                     </div>
                   </CommandItem>
                 ))}


### PR DESCRIPTION
## Summary

Follow-up to #893. The address bar was dispatching Enter to **Google Search** for URL-like inputs (e.g. `www.example.com`), which is the opposite of how Chrome/Firefox omniboxes behave. This rewires the dropdown so the top row always mirrors what `normalizeBrowserNavigationUrl` will actually do on submit.

## Repro on #893

1. Clear history (or type a query that doesn't match any history entry).
2. Type `www.example.com` in the address bar.
3. Press Enter.
4. **Before:** navigates to `https://www.google.com/search?q=www.example.com`.
5. **After:** navigates to `https://www.example.com`.

## Root cause

#893 built the suggestion list like this:

```ts
if (looksLikeSearchQuery(trimmed)) {
  return [searchSuggestion, ...historySuggestions]
}
return [...historySuggestions.slice(0, MAX - 1), searchSuggestion]
```

For URL-like input, a synthetic "[input] — Google Search" row was appended **as a fallback** at the end of the list. If history had no matches, that fallback became `suggestions[0]`, and the existing auto-select-first effect (`setSelectedValue(suggestions[0]?.url ?? '')`) highlighted it. `handleKeyDown`'s Enter branch then resolved to the highlighted row and called `onNavigate(googleSearchUrl)` — bypassing `submitAddressBar` / `normalizeBrowserNavigationUrl` entirely.

Two independent bugs combined:

1. **Semantic mismatch.** `looksLikeSearchQuery` already classifies `www.example.com` as a URL, but the dropdown still offered a search row. Adding "just in case you meant to search" is fine; *defaulting to it on Enter* is not.
2. **Divergent commit paths.** Typing Enter with nothing highlighted went through `submitAddressBar` → `normalizeBrowserNavigationUrl` (correct). Typing Enter with a highlighted row went through `handleSelect(match.url)` (direct navigate). Those two paths can disagree, and here they did.

## The fix

Make the top row always be **the canonical commit action** — the exact URL that `submitAddressBar` would navigate to. That's what Chrome and Firefox do: the first row is always "what Enter does right now."

- URL-like input → top row is `{ title: input, url: normalizeBrowserNavigationUrl(input) }` with a globe icon and no subtitle.
- Query-like input → top row is `{ title: input, subtitle: "Google Search" }` with a search icon.
- If a history row already targets the same URL, suppress the synthetic top row (the history row has a real page title, so it's strictly better).

Now whether the user presses Enter cold or after arrow-keying, both paths land on the same URL, and that URL matches what `normalizeBrowserNavigationUrl` resolves — the single source of truth.

## Notes for future address-bar work

- **Never have two code paths decide what Enter does.** If the dropdown's first row and the form's submit handler can disagree, they eventually will. Keep them routed through one normalizer.
- **Fallbacks aren't free.** A synthetic "search fallback" row looks harmless until auto-select-first makes it the default. Fallback rows belong last *and* must not be auto-highlighted.
- `looksLikeSearchQuery` is already the arbiter of search-vs-URL; lean on it instead of building parallel logic in the suggestion builder.

## Test plan

- [x] Type `www.example.com` → top row is "www.example.com" (globe icon), Enter navigates to `https://www.example.com`.
- [x] Type `example.com/path` → navigates to `https://example.com/path`.
- [x] Type `react hooks` → top row is "react hooks — Google Search" (search icon), Enter hits Google.
- [x] Type `localhost:3000` → navigates to `http://localhost:3000`.
- [x] Type a substring of a visited URL → history row wins (no duplicate synthetic row).
- [x] Change default search engine in settings → subtitle updates ("DuckDuckGo Search", "Bing Search").
- [x] Empty address bar on focus → shows history only, no synthetic row.