### PR TITLE
fix(terminal): auto-focus newly created terminals

### DIFF
--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -19,6 +19,7 @@ import {
 import { Button } from '@/components/ui/button'
 import TabBar from './tab-bar/TabBar'
 import TerminalPane from './terminal-pane/TerminalPane'
+import { focusNewTerminalTab } from './terminal-pane/focus-new-tab'
 import {
   ORCA_EDITOR_SAVE_AND_CLOSE_EVENT,
   ORCA_EDITOR_REQUEST_CMD_SAVE_EVENT,
@@ -350,7 +351,12 @@ function Terminal(): React.JSX.Element | null {
     if (!shouldAutoCreateInitialTerminal(renderableTabCount)) {
       return
     }
-    createTab(activeWorktreeId)
+    const newTab = createTab(activeWorktreeId)
+    // Why: immediately after a workspace is created (or restored with no
+    // renderable tabs), the freshly-mounted xterm has no element to hold
+    // keyboard focus yet. Without this, the user's first keystroke lands on
+    // <body> and is dropped until they click into the terminal.
+    focusNewTerminalTab(newTab.id)
   }, [workspaceSessionReady, activeWorktreeId, createTab, reconcileWorktreeTabModel])
 
   const handleNewTab = useCallback(() => {
@@ -384,6 +390,11 @@ function Terminal(): React.JSX.Element | null {
     const order = base.filter((id) => id !== newTab.id)
     order.push(newTab.id)
     setTabBarOrder(activeWorktreeId, order)
+    // Why: Cmd+T and the legacy-titlebar TabBar both route through handleNewTab
+    // without going through Radix's onCloseAutoFocus path, so the new xterm
+    // never receives focus on its own. Trigger the deferred focus helper so the
+    // user can start typing immediately without clicking into the pane.
+    focusNewTerminalTab(newTab.id)
   }, [activeWorktreeId, createTab, setActiveTabType, setTabBarOrder])
 
   const handleNewBrowserTab = useCallback(() => {

--- a/src/renderer/src/components/tab-bar/TabBar.tsx
+++ b/src/renderer/src/components/tab-bar/TabBar.tsx
@@ -14,6 +14,7 @@ import EditorFileTab from './EditorFileTab'
 import BrowserTab from './BrowserTab'
 import { QuickLaunchAgentMenuItems } from './QuickLaunchButton'
 import { reconcileTabOrder } from './reconcile-order'
+import { focusNewTerminalTab } from '../terminal-pane/focus-new-tab'
 import type { TabDragItemData } from '../tab-group/useTabDragSplit'
 import {
   DropdownMenu,
@@ -169,21 +170,10 @@ function TabBarInner({
     // Why: creating a terminal from the "+" menu is a two-step focus race:
     // React must first mount the new TerminalPane/xterm, then Radix closes the
     // menu. Even after suppressing trigger focus restore, the terminal's hidden
-    // textarea may not exist until the next paint. Double-rAF waits for that
-    // commit so the new tab, not the "+" button, ends up owning keyboard focus.
-    requestAnimationFrame(() => {
-      requestAnimationFrame(() => {
-        const scoped = document.querySelector(
-          `[data-terminal-tab-id="${tabId}"] .xterm-helper-textarea`
-        ) as HTMLElement | null
-        if (scoped) {
-          scoped.focus()
-          return
-        }
-        const fallback = document.querySelector('.xterm-helper-textarea') as HTMLElement | null
-        fallback?.focus()
-      })
-    })
+    // textarea may not exist until the next paint. focusNewTerminalTab polls
+    // across rAFs so the new tab, not the "+" button, ends up owning keyboard
+    // focus even when WebGL setup pushes attachment past the first frame.
+    focusNewTerminalTab(tabId)
   }, [])
 
   // Horizontal wheel scrolling for the tab strip

--- a/src/renderer/src/components/terminal-pane/focus-new-tab.ts
+++ b/src/renderer/src/components/terminal-pane/focus-new-tab.ts
@@ -1,0 +1,39 @@
+// Why: opening a new terminal (Cmd+T, "+" dropdown, split-group "New Terminal",
+// or the auto-created first terminal on a freshly activated worktree) must leave
+// keyboard focus inside the new xterm, not on the trigger element or <body>. The
+// xterm.js instance isn't in the DOM until TerminalPane mounts and openTerminal()
+// runs — which happens at least one commit + paint after the createTab() state
+// update. Without a deferred focus step, the user has to click into the terminal
+// before they can type.
+//
+// We poll across rAFs (bounded) instead of using a single rAF because:
+//   - On Windows the WebGL context construction inside openTerminal can push the
+//     helper-textarea attachment past the first frame.
+//   - The legacy titlebar TabBar and split-group TabBar both animate and
+//     Radix's onCloseAutoFocus can fight us for focus on the same tick.
+//
+// Falls back to any xterm-helper-textarea on the page so Cmd+T still focuses the
+// new tab's terminal even if the [data-terminal-tab-id] node briefly isn't in the
+// tree (e.g. during the "legacy → split-group" transition on first mount).
+const MAX_FOCUS_ATTEMPTS = 20
+
+export function focusNewTerminalTab(tabId: string): void {
+  let attempts = 0
+  const tryFocus = (): void => {
+    attempts += 1
+    const scoped = document.querySelector(
+      `[data-terminal-tab-id="${tabId}"] .xterm-helper-textarea`
+    ) as HTMLElement | null
+    if (scoped) {
+      scoped.focus()
+      return
+    }
+    if (attempts >= MAX_FOCUS_ATTEMPTS) {
+      const fallback = document.querySelector('.xterm-helper-textarea') as HTMLElement | null
+      fallback?.focus()
+      return
+    }
+    requestAnimationFrame(tryFocus)
+  }
+  requestAnimationFrame(tryFocus)
+}


### PR DESCRIPTION
## Summary

Opening a new terminal (Cmd+T, the "+" dropdown's "New Terminal", or the auto-created first terminal on a freshly activated/restored worktree) now leaves keyboard focus inside the new xterm. Previously the user had to click into the pane before they could type.

Previously only the split-group "+" dropdown's `onCloseAutoFocus` path attempted this (via TabBar's inline double-rAF), and Cmd+T / workspace activation had no focus step at all.

## Changes

- **New** `src/renderer/src/components/terminal-pane/focus-new-tab.ts` — shared `focusNewTerminalTab(tabId)` helper that polls across rAFs (up to 20 frames) until `[data-terminal-tab-id="…"] .xterm-helper-textarea` is attached, then focuses it. Falls back to the first `.xterm-helper-textarea` if the scoped node briefly isn't in the tree (e.g. legacy → split-group transition). The bounded poll handles platforms where WebGL setup pushes attachment past the first frame.
- **Terminal.tsx**
  - `handleNewTab` (Cmd+T / legacy titlebar TabBar "New Terminal") now calls `focusNewTerminalTab(newTab.id)`.
  - The `workspaceSessionReady`/`activeWorktreeId` effect that auto-creates the first terminal on activation now focuses it.
- **TabBar.tsx** — replaced the inline double-rAF `focusTerminalTabSurface` body with a call to the shared helper so the "+" dropdown + QuickLaunch path benefits from the bounded-poll behavior.

## Test plan

Verified manually in a dev build via `/electron`:
- [x] Switching to a fresh worktree with no tabs: auto-created terminal receives keyboard focus — typed `x` landed at the prompt in the new pane.
- [x] Cmd+T from an existing terminal: new tab created, typed `a` landed at its prompt.
- [x] Clicking "+" → "New Terminal" in the tab dropdown: new tab created, typed `b` landed at its prompt.
- [x] `pnpm lint` clean (warnings are pre-existing).
- [x] `pnpm test -- --run src/renderer/src/components/terminal-pane/` passes (sole failure is an unrelated `codex-accounts` filesystem test).