### PR TITLE
build(deps): bump electron from 41.1.0 to 41.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "@types/ws": "^8.18.1",
     "@typescript/native-preview": "7.0.0-dev.20260406.1",
     "@vitejs/plugin-react": "^5.2.0",
-    "electron": "^41.1.0",
+    "electron": "^41.2.2",
     "electron-builder": "^26.8.1",
     "electron-vite": "^5.0.0",
     "husky": "^9.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,10 +27,10 @@ importers:
         version: 3.2.2(react@19.2.4)
       '@electron-toolkit/preload':
         specifier: ^3.0.2
-        version: 3.0.2(electron@41.1.0)
+        version: 3.0.2(electron@41.2.2)
       '@electron-toolkit/utils':
         specifier: ^4.0.0
-        version: 4.0.0(electron@41.1.0)
+        version: 4.0.0(electron@41.2.2)
       '@monaco-editor/react':
         specifier: ^4.7.0
         version: 4.7.0(monaco-editor@0.55.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -231,8 +231,8 @@ importers:
         specifier: ^5.2.0
         version: 5.2.0(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))
       electron:
-        specifier: ^41.1.0
-        version: 41.1.0
+        specifier: ^41.2.2
+        version: 41.2.2
       electron-builder:
         specifier: ^26.8.1
         version: 26.8.1(electron-builder-squirrel-windows@26.8.1)
@@ -3639,8 +3639,8 @@ packages:
     resolution: {integrity: sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==}
     engines: {node: '>=8.0.0'}
 
-  electron@41.1.0:
-    resolution: {integrity: sha512-0XRFyxRqetmqtkkBvV++wGbHYJ7bD++f6EgJW8y9kX4pPRagwlmKDtzqXZhKiu0DIQppm3sXxzHWK9GYP91OKQ==}
+  electron@41.2.2:
+    resolution: {integrity: sha512-3rzz/hVIpF726W9g7nleQzyF2IOEZbzZnUTUYGhMaEfsoab8fDyOYAWbdBdo4+DczS1Ifz11rdYo8IAAGcRx/g==}
     engines: {node: '>= 12.20.55'}
     hasBin: true
 
@@ -6374,17 +6374,17 @@ snapshots:
     dependencies:
       '@noble/ciphers': 1.3.0
 
-  '@electron-toolkit/preload@3.0.2(electron@41.1.0)':
+  '@electron-toolkit/preload@3.0.2(electron@41.2.2)':
     dependencies:
-      electron: 41.1.0
+      electron: 41.2.2
 
   '@electron-toolkit/tsconfig@2.0.0(@types/node@25.5.0)':
     dependencies:
       '@types/node': 25.5.0
 
-  '@electron-toolkit/utils@4.0.0(electron@41.1.0)':
+  '@electron-toolkit/utils@4.0.0(electron@41.2.2)':
     dependencies:
-      electron: 41.1.0
+      electron: 41.2.2
 
   '@electron/asar@3.4.1':
     dependencies:
@@ -9425,7 +9425,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron@41.1.0:
+  electron@41.2.2:
     dependencies:
       '@electron/get': 2.0.3
       '@types/node': 24.12.2


### PR DESCRIPTION
## Summary

- Bumps Electron from `41.1.0` to `41.2.2`
- Electron 41.2.x upgrades the bundled Chromium, fixing compatibility issues with Google Sheets and other Google Workspace apps that reject older browser versions
- The previous version caused "This browser version is no longer supported" warnings on Google Sheets

## Test plan

- [ ] Open a browser tab in Orca and navigate to Google Sheets — should load without unsupported browser warnings
- [ ] Verify existing browser functionality (navigation, tabs, grab mode) still works