### PR TITLE
ci: check out PR head instead of merge ref in e2e workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -46,3 +46,9 @@ jobs:
 
   e2e:
     uses: ./.github/workflows/e2e.yml
+    # Why: check out the PR head directly instead of refs/pull/N/merge.
+    # The merge ref doesn't exist when the PR has conflicts or GitHub
+    # hasn't computed the merge commit yet, causing checkout to fail
+    # for reasons unrelated to the code under test.
+    with:
+      ref: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
## Summary
- The e2e reusable workflow (`.github/workflows/e2e.yml`) defaults `ref` to `github.ref`, which on `pull_request` events is `refs/pull/N/merge`.
- GitHub does not compute that ref when the PR has conflicts or hasn't yet computed the merge commit, so `actions/checkout` fails with `fatal: couldn't find remote ref refs/pull/N/merge` — unrelated to the code under test.
- Pass `github.event.pull_request.head.sha` from `pr.yml` so the e2e job checks out the PR head directly. No change to what is tested; only the checkout ref.

Motivating failure: #937, run https://github.com/stablyai/orca/actions/runs/24768962365/job/72470149899

## Test plan
- [ ] CI runs on this PR; e2e job checks out the PR head SHA and proceeds past the checkout step.