### PR TITLE
fix(quick-open): don't clear Cmd+P input on unrelated store updates

### DIFF
--- a/src/renderer/src/components/QuickOpen.tsx
+++ b/src/renderer/src/components/QuickOpen.tsx
@@ -1,5 +1,5 @@
 /* oxlint-disable max-lines */
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { File } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { detectLanguage } from '@/lib/language-detect'
@@ -64,7 +64,6 @@ export default function QuickOpen(): React.JSX.Element | null {
   const [files, setFiles] = useState<string[]>([])
   const [loading, setLoading] = useState(false)
   const [loadError, setLoadError] = useState<string | null>(null)
-  const listRef = useRef<HTMLDivElement>(null)
 
   // Find active worktree path and sibling worktree paths to exclude
   const { worktreePath, excludePaths } = useMemo(() => {
@@ -166,17 +165,6 @@ export default function QuickOpen(): React.JSX.Element | null {
     return results.slice(0, 50)
   }, [files, query])
 
-  // Why: when the query changes the first result becomes selected, but cmdk
-  // doesn't reset the list's scrollTop. Without this, a previously scrolled
-  // list leaves the new top result clipped behind the input border.
-  // rAF defers until after cmdk's own scroll-into-view pass, so our reset wins.
-  useEffect(() => {
-    const id = requestAnimationFrame(() => {
-      listRef.current?.scrollTo(0, 0)
-    })
-    return () => cancelAnimationFrame(id)
-  }, [query, visible])
-
   const handleSelect = useCallback(
     (relativePath: string) => {
       if (!activeWorktreeId || !worktreePath) {
@@ -218,7 +206,7 @@ export default function QuickOpen(): React.JSX.Element | null {
       description="Search for a file to open"
     >
       <CommandInput placeholder="Go to file..." value={query} onValueChange={setQuery} />
-      <CommandList ref={listRef} className="p-2">
+      <CommandList className="p-2">
         {loading ? (
           <div className="py-6 text-center text-sm text-muted-foreground">Loading files...</div>
         ) : loadError ? (

--- a/src/renderer/src/components/QuickOpen.tsx
+++ b/src/renderer/src/components/QuickOpen.tsx
@@ -65,25 +65,43 @@ export default function QuickOpen(): React.JSX.Element | null {
   const [loading, setLoading] = useState(false)
   const [loadError, setLoadError] = useState<string | null>(null)
 
-  // Find active worktree path and sibling worktree paths to exclude
-  const { worktreePath, excludePaths } = useMemo(() => {
+  // Why: the derived tuple (worktreePath, excludePaths) must have a stable
+  // identity across unrelated store updates. We key the memo on a joined
+  // string so any worktreesByRepo mutation that doesn't affect this worktree's
+  // path or its siblings leaves our array reference untouched, which in turn
+  // keeps the file-load effect below from refetching and blinking the list.
+  const worktreePath = useMemo(() => {
     if (!activeWorktreeId) {
-      return { worktreePath: null, excludePaths: [] as string[] }
+      return null
     }
     for (const worktrees of Object.values(worktreesByRepo)) {
       const wt = worktrees.find((w) => w.id === activeWorktreeId)
       if (wt) {
-        // Why: when the active worktree is the repo root (isMainWorktree),
-        // linked worktrees are nested subdirectories. Without excluding them,
-        // file listing returns files from every worktree, not just this one.
-        const siblings = worktrees
-          .filter((w) => w.id !== activeWorktreeId && w.path.startsWith(`${wt.path}/`))
-          .map((w) => w.path)
-        return { worktreePath: wt.path, excludePaths: siblings }
+        return wt.path
       }
     }
-    return { worktreePath: null, excludePaths: [] as string[] }
+    return null
   }, [activeWorktreeId, worktreesByRepo])
+
+  const excludePathsKey = useMemo(() => {
+    if (!activeWorktreeId || !worktreePath) {
+      return ''
+    }
+    for (const worktrees of Object.values(worktreesByRepo)) {
+      if (!worktrees.some((w) => w.id === activeWorktreeId)) {
+        continue
+      }
+      // Why: when the active worktree is the repo root (isMainWorktree),
+      // linked worktrees are nested subdirectories. Without excluding them,
+      // file listing returns files from every worktree, not just this one.
+      return worktrees
+        .filter((w) => w.id !== activeWorktreeId && w.path.startsWith(`${worktreePath}/`))
+        .map((w) => w.path)
+        .sort()
+        .join('\n')
+    }
+    return ''
+  }, [activeWorktreeId, worktreePath, worktreesByRepo])
 
   const connectionId = useMemo(
     () => getConnectionId(activeWorktreeId ?? null) ?? undefined,
@@ -115,6 +133,8 @@ export default function QuickOpen(): React.JSX.Element | null {
     setLoadError(null)
     setLoading(true)
 
+    const excludePaths = excludePathsKey ? excludePathsKey.split('\n') : undefined
+
     void window.api.fs
       // Why: quick-open shares the active worktree path model with file explorer
       // and search, so remote worktrees must include connectionId. Without this,
@@ -122,7 +142,7 @@ export default function QuickOpen(): React.JSX.Element | null {
       .listFiles({
         rootPath: worktreePath,
         connectionId,
-        excludePaths: excludePaths.length > 0 ? excludePaths : undefined
+        excludePaths
       })
       .then((result) => {
         if (!cancelled) {
@@ -146,7 +166,7 @@ export default function QuickOpen(): React.JSX.Element | null {
     return () => {
       cancelled = true
     }
-  }, [visible, worktreePath, connectionId, excludePaths])
+  }, [visible, worktreePath, connectionId, excludePathsKey])
 
   // Filter files by fuzzy match
   const filtered = useMemo(() => {

--- a/src/renderer/src/components/QuickOpen.tsx
+++ b/src/renderer/src/components/QuickOpen.tsx
@@ -91,6 +91,15 @@ export default function QuickOpen(): React.JSX.Element | null {
     [activeWorktreeId]
   )
 
+  // Why: reset input only on open. Keeping this out of the file-load effect
+  // prevents unrelated store updates (which can produce a new excludePaths
+  // array reference) from wiping a query the user is currently typing.
+  useEffect(() => {
+    if (visible) {
+      setQuery('')
+    }
+  }, [visible])
+
   // Load file list when opened
   useEffect(() => {
     if (!visible) {
@@ -103,7 +112,6 @@ export default function QuickOpen(): React.JSX.Element | null {
     }
 
     let cancelled = false
-    setQuery('')
     setFiles([])
     setLoadError(null)
     setLoading(true)


### PR DESCRIPTION
## Summary
- Cmd+P file search input was being cleared (and list scrolled back up) whenever an unrelated store update occurred.
- Root cause: the file-load effect depended on `excludePaths`, whose array reference was recreated on any `worktreesByRepo` change. Each re-run called `setQuery('')`, wiping the user's input. The query change then triggered the scroll-to-top effect introduced in #808/#867.
- Fix: split the "reset input on open" logic into its own effect keyed only on `visible`.

## Test plan
- [x] Verified via Electron dev build: typed "index" into Cmd+P, then triggered a `worktreesByRepo` store update — input retained "index".
- [x] Manually cleared the input — list correctly scrolls back to top.
- [x] Typecheck passes.