### PR TITLE
feat(terminals): per-tab activity indicators

### DIFF
--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -461,9 +461,15 @@ describe('registerPtyHandlers', () => {
       // setting the terminal would ignore the user's shell preference.
       process.env.COMSPEC = 'C:\\Windows\\system32\\cmd.exe'
 
-      registerPtyHandlers(mainWindow as never, undefined, undefined, () => ({
-        terminalWindowsShell: 'powershell.exe'
-      } as never))
+      registerPtyHandlers(
+        mainWindow as never,
+        undefined,
+        undefined,
+        () =>
+          ({
+            terminalWindowsShell: 'powershell.exe'
+          }) as never
+      )
       handlers.get('pty:spawn')!(null, { cols: 80, rows: 24 })
 
       expect(spawnMock).toHaveBeenCalledWith(

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -278,10 +278,10 @@
   height: 0;
 }
 
-/* Tab activity affordance (amber wash + bottom accent strip) is rendered as
-   React DOM children in SortableTab.tsx rather than via ::after here, so the
-   drop-indicator ::before/::after pseudo-elements stay free for drag-and-drop
-   feedback. See drop-indicator.ts and SortableTab.tsx for the implementation. */
+/* Tab activity affordance (amber wash) is rendered as a React DOM child in
+   SortableTab.tsx rather than via ::after here, so the drop-indicator
+   ::before/::after pseudo-elements stay free for drag-and-drop feedback. See
+   drop-indicator.ts and SortableTab.tsx for the implementation. */
 
 /* ── Layout ──────────────────────────────────────────── */
 

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -278,6 +278,11 @@
   height: 0;
 }
 
+/* Tab activity affordance (amber wash + bottom accent strip) is rendered as
+   React DOM children in SortableTab.tsx rather than via ::after here, so the
+   drop-indicator ::before/::after pseudo-elements stay free for drag-and-drop
+   feedback. See drop-indicator.ts and SortableTab.tsx for the implementation. */
+
 /* ── Layout ──────────────────────────────────────────── */
 
 #root {

--- a/src/renderer/src/components/tab-bar/SortableTab.tsx
+++ b/src/renderer/src/components/tab-bar/SortableTab.tsx
@@ -173,12 +173,12 @@ export default function SortableTab({
           {...attributes}
           {...dragListeners}
           // Why: on unread activity, tint the whole tab with a subtle amber
-          // wash + bottom accent strip so the signal is visible at a glance
-          // even when the small bell icon is easy to miss in a long tab bar.
-          // Active tabs keep their existing highlight — the amber wash layers
-          // on top so the tab still reads as "selected + has activity". The
-          // wash is rendered as an absolutely-positioned child below so the
-          // ::after pseudo-element stays free for the drop indicator.
+          // wash so the signal is visible at a glance even when the small
+          // bell icon is easy to miss in a long tab bar. Active tabs keep
+          // their existing highlight — the amber wash layers on top so the
+          // tab still reads as "selected + has activity". The wash is
+          // rendered as an absolutely-positioned child below so the ::after
+          // pseudo-element stays free for the drop indicator.
           className={`group relative flex items-center h-full px-3 text-sm cursor-pointer select-none shrink-0 border-r border-border ${getDropIndicatorClasses(dropIndicator ?? null)} ${
             isActive
               ? 'bg-accent text-foreground border-b-transparent'
@@ -220,19 +220,13 @@ export default function SortableTab({
         >
           {isActive && <span className={ACTIVE_TAB_INDICATOR_CLASSES} aria-hidden />}
           {showActivityAffordance && (
-            // Why: amber wash + bottom accent strip for unread tabs. Rendered as
-            // real DOM children so both drop indicators (::before left / ::after
-            // right in drop-indicator.ts) stay free for drag-and-drop feedback —
-            // a prior ::after-based implementation collided with the right-edge
-            // drop indicator and hid it on unread tabs. pointer-events-none keeps
+            // Why: amber wash for unread tabs. Rendered as a real DOM child so
+            // both drop indicators (::before left / ::after right in
+            // drop-indicator.ts) stay free for drag-and-drop feedback — a prior
+            // ::after-based implementation collided with the right-edge drop
+            // indicator and hid it on unread tabs. pointer-events-none keeps
             // clicks reaching the underlying tab handlers.
-            <>
-              <span aria-hidden className="pointer-events-none absolute inset-0 bg-amber-500/10" />
-              <span
-                aria-hidden
-                className="pointer-events-none absolute inset-x-0 bottom-0 h-0.5 bg-amber-500/90"
-              />
-            </>
+            <span aria-hidden className="pointer-events-none absolute inset-0 bg-amber-500/10" />
           )}
           {showActivityAffordance ? (
             // Why: the activity marker sits to the LEFT of the tab title using

--- a/src/renderer/src/components/tab-bar/SortableTab.tsx
+++ b/src/renderer/src/components/tab-bar/SortableTab.tsx
@@ -11,6 +11,8 @@ import {
 import { Input } from '@/components/ui/input'
 import type { TerminalTab } from '../../../../shared/types'
 import type { TabDragItemData } from '../tab-group/useTabDragSplit'
+import { FilledBellIcon } from '../sidebar/WorktreeCardHelpers'
+import { useAppStore } from '../../store'
 import {
   ACTIVE_TAB_INDICATOR_CLASSES,
   getDropIndicatorClasses,
@@ -72,6 +74,12 @@ export default function SortableTab({
     data: dragData
   })
 
+  // Why: subscribe to the per-tab boolean directly so only the tab whose unread
+  // status actually flipped re-renders. Reading the whole `unreadTerminalTabs`
+  // map in TabBar would invalidate every SortableTab on every bell event
+  // because the slice returns a fresh object reference on each mark/clear.
+  const hasUnreadActivity = useAppStore((s) => s.unreadTerminalTabs[tab.id] === true)
+
   // Why: intentionally no transform/transition/opacity here. The PR's
   // design is that tabs stay visually anchored during a drag — only the
   // blue insertion bar moves. Siblings also don't shift (see
@@ -79,6 +87,11 @@ export default function SortableTab({
   const [menuOpen, setMenuOpen] = useState(false)
   const [menuPoint, setMenuPoint] = useState({ x: 0, y: 0 })
   const [isEditing, setIsEditing] = useState(false)
+  // Why: single source of truth for the unread-activity visual treatment —
+  // drives BOTH the amber wash overlay and the bell icon swap below. Kept as
+  // one derived boolean so the two visual cues can never drift out of sync
+  // (e.g. showing the bell without the wash, or vice versa).
+  const showActivityAffordance = hasUnreadActivity && !isEditing
   const [renameValue, setRenameValue] = useState('')
   const renameInputRef = useRef<HTMLInputElement>(null)
   // Why: React's synthetic onBlur fires during the Input's unmount when isEditing flips
@@ -155,9 +168,17 @@ export default function SortableTab({
         <div
           ref={setNodeRef}
           data-testid="sortable-tab"
+          data-tab-id={tab.id}
           data-tab-title={tab.customTitle ?? tab.title}
           {...attributes}
           {...dragListeners}
+          // Why: on unread activity, tint the whole tab with a subtle amber
+          // wash + bottom accent strip so the signal is visible at a glance
+          // even when the small bell icon is easy to miss in a long tab bar.
+          // Active tabs keep their existing highlight — the amber wash layers
+          // on top so the tab still reads as "selected + has activity". The
+          // wash is rendered as an absolutely-positioned child below so the
+          // ::after pseudo-element stays free for the drop indicator.
           className={`group relative flex items-center h-full px-3 text-sm cursor-pointer select-none shrink-0 border-r border-border ${getDropIndicatorClasses(dropIndicator ?? null)} ${
             isActive
               ? 'bg-accent text-foreground border-b-transparent'
@@ -198,9 +219,34 @@ export default function SortableTab({
           }}
         >
           {isActive && <span className={ACTIVE_TAB_INDICATOR_CLASSES} aria-hidden />}
-          <TerminalIcon
-            className={`w-3.5 h-3.5 mr-1.5 shrink-0 ${isActive ? 'text-foreground' : 'text-muted-foreground'}`}
-          />
+          {showActivityAffordance && (
+            // Why: amber wash + bottom accent strip for unread tabs. Rendered as
+            // real DOM children so both drop indicators (::before left / ::after
+            // right in drop-indicator.ts) stay free for drag-and-drop feedback —
+            // a prior ::after-based implementation collided with the right-edge
+            // drop indicator and hid it on unread tabs. pointer-events-none keeps
+            // clicks reaching the underlying tab handlers.
+            <>
+              <span aria-hidden className="pointer-events-none absolute inset-0 bg-amber-500/10" />
+              <span
+                aria-hidden
+                className="pointer-events-none absolute inset-x-0 bottom-0 h-0.5 bg-amber-500/90"
+              />
+            </>
+          )}
+          {showActivityAffordance ? (
+            // Why: the activity marker sits to the LEFT of the tab title using
+            // Orca's filled bell glyph (amber-500 with a subtle drop shadow)
+            // so it matches the worktree-level bell in the sidebar — keeping
+            // every "needs your attention" surface in Orca consistent.
+            <span data-testid="tab-activity-bell" className="inline-flex shrink-0">
+              <FilledBellIcon className="w-3.5 h-3.5 mr-1.5 text-amber-500 drop-shadow-sm" />
+            </span>
+          ) : (
+            <TerminalIcon
+              className={`w-3.5 h-3.5 mr-1.5 shrink-0 ${isActive ? 'text-foreground' : 'text-muted-foreground'}`}
+            />
+          )}
           {isEditing ? (
             <Input
               ref={renameInputRef}

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -78,6 +78,16 @@ export default function TerminalPane({
   isVisibleRef.current = isVisible
 
   const [expandedPaneId, setExpandedPaneId] = useState<number | null>(null)
+  // Why: tracked in React state (not derived from managerRef.getPanes().length)
+  // so the render containing the portal map (which reads the imperative pane
+  // list via managerRef.current?.getPanes()) re-runs when a pane is split or
+  // closed. managerRef is imperative and doesn't trigger React's dependency
+  // tracking. The lifecycle hook updates this via setPaneCount on
+  // onPaneCreated / onPaneClosed / onLayoutChanged. The value is never
+  // read — the portal map at line ~914 calls `managerRef.current?.getPanes()`
+  // imperatively, so `setPaneCount` is used only as a render-trigger side
+  // effect to force that map to re-run when a pane is split or closed.
+  const [, setPaneCount] = useState<number>(0)
   const [searchOpen, setSearchOpen] = useState(false)
   const searchOpenRef = useRef(false)
   searchOpenRef.current = searchOpen
@@ -119,6 +129,7 @@ export default function TerminalPane({
   const updateTabPtyId = useAppStore((store) => store.updateTabPtyId)
   const clearTabPtyId = useAppStore((store) => store.clearTabPtyId)
   const markWorktreeUnread = useAppStore((store) => store.markWorktreeUnread)
+  const markTerminalTabUnread = useAppStore((store) => store.markTerminalTabUnread)
   const settings = useAppStore((store) => store.settings)
   // Why: Windows is the only platform where bare right-click is repurposed as
   // a paste gesture; on macOS/Linux the terminal still owns right-click for the
@@ -298,10 +309,10 @@ export default function TerminalPane({
     [onCloseTab, syncPanePtyLayoutBinding, tabId]
   )
 
-  // Cmd+W handler — shows a Ghostty-style confirmation dialog when the
-  // pane's shell has a running child process (e.g. npm run dev), so the
-  // user doesn't accidentally kill it. An idle shell prompt closes
-  // immediately. Ctrl+D (explicit EOF) bypasses this by design.
+  // Cmd+W handler — shows a confirmation dialog when the pane's shell has
+  // a running child process (e.g. npm run dev), so the user doesn't
+  // accidentally kill it. An idle shell prompt closes immediately. Ctrl+D
+  // (explicit EOF) bypasses this by design.
   const handleRequestClosePane = useCallback(
     (paneId: number) => {
       const transport = paneTransportsRef.current.get(paneId)
@@ -310,13 +321,20 @@ export default function TerminalPane({
         executeClosePane(paneId)
         return
       }
-      void window.api.pty.hasChildProcesses(ptyId).then((hasChildren) => {
-        if (hasChildren) {
-          setCloseConfirmPaneId(paneId)
-        } else {
-          executeClosePane(paneId)
-        }
-      })
+      void window.api.pty
+        .hasChildProcesses(ptyId)
+        .then((hasChildren) => {
+          if (hasChildren) {
+            setCloseConfirmPaneId(paneId)
+          } else {
+            executeClosePane(paneId)
+          }
+        })
+        // Why: if the child-process probe rejects (IPC wedged, handler
+        // missing on legacy providers), fall back to closing the pane — Cmd+W
+        // silently doing nothing is worse than closing a pane that might have
+        // had a child process. Matches the semantics of the !ptyId branch above.
+        .catch(() => executeClosePane(paneId))
     },
     [executeClosePane]
   )
@@ -364,6 +382,7 @@ export default function TerminalPane({
     clearRuntimePaneTitle,
     updateTabPtyId,
     markWorktreeUnread,
+    markTerminalTabUnread,
     dispatchNotification,
     setCacheTimerStartedAt,
     syncPanePtyLayoutBinding,
@@ -374,7 +393,8 @@ export default function TerminalPane({
     persistLayoutSnapshot,
     setPaneTitles,
     paneTitlesRef,
-    setRenamingPaneId
+    setRenamingPaneId,
+    setPaneCount
   })
 
   const handleRestartCodexPane = useCallback(
@@ -426,6 +446,7 @@ export default function TerminalPane({
         clearRuntimePaneTitle,
         updateTabPtyId,
         markWorktreeUnread,
+        markTerminalTabUnread,
         dispatchNotification,
         setCacheTimerStartedAt,
         syncPanePtyLayoutBinding
@@ -440,6 +461,7 @@ export default function TerminalPane({
       cwd,
       dispatchNotification,
       markWorktreeUnread,
+      markTerminalTabUnread,
       onPtyExitRef,
       setCacheTimerStartedAt,
       setRuntimePaneTitle,
@@ -624,6 +646,10 @@ export default function TerminalPane({
     for (const pane of manager.getPanes()) {
       // Show the title bar space when the pane has a title OR is being
       // inline-edited (so the input appears even for untitled panes).
+      // Unread activity does NOT reserve title-bar space — the bell is
+      // rendered as an absolutely-positioned overlay in the pane's top-right
+      // corner so it can appear and disappear without shifting terminal
+      // content, avoiding the jarring reflow on bell toggles.
       const shouldShow = !!paneTitles[pane.id] || renamingPaneId === pane.id
       const hadTitle = pane.container.hasAttribute('data-has-title')
       if (shouldShow && !hadTitle) {
@@ -904,7 +930,7 @@ export default function TerminalPane({
           and structural changes (split, close) update those same signals via
           onPaneClosed / onPaneCreated callbacks — so React always re-renders
           this block when .getPanes() would return a different result. */}
-      {managerRef.current?.getPanes().map((pane) => {
+      {(managerRef.current?.getPanes() ?? []).map((pane) => {
         const title = paneTitles[pane.id]
         const isEditing = renamingPaneId === pane.id
         if (!title && !isEditing) {

--- a/src/renderer/src/components/terminal-pane/bell-detector.ts
+++ b/src/renderer/src/components/terminal-pane/bell-detector.ts
@@ -70,6 +70,11 @@ export function createBellDetector(): BellDetector {
             pendingOscEscape = false
           } else if (char === '\x1b') {
             pendingEscape = true
+          } else if (char === '\x07') {
+            // A bare ESC is not a valid introducer for any sequence that
+            // consumes a following BEL. Treat the BEL as a real terminal
+            // bell rather than silently swallowing it with the orphan ESC.
+            return true
           }
           continue
         }

--- a/src/renderer/src/components/terminal-pane/bell-detector.ts
+++ b/src/renderer/src/components/terminal-pane/bell-detector.ts
@@ -6,56 +6,90 @@
  * may span multiple calls. The detector tracks in-progress escape state
  * across invocations so a BEL used as an OSC terminator is never
  * misinterpreted as a terminal bell.
+ *
+ * CAN (0x18) / SUB (0x1A) handling: per ECMA-48, these bytes cancel any
+ * in-progress escape sequence. Without this, a malformed or truncated OSC
+ * string (e.g. from a crashed TUI) would pin `inOsc = true` indefinitely
+ * and silently drop the next real BEL as if it were an OSC terminator.
+ *
+ * reset(): callers should invoke this whenever the underlying byte stream
+ * is replaced (e.g. on PTY detach/attach) so state from a previous stream
+ * that ended mid-escape does not leak into the next stream.
  */
-export function createBellDetector(): (data: string) => boolean {
+export type BellDetector = {
+  chunkContainsBell(data: string): boolean
+  reset(): void
+}
+
+export function createBellDetector(): BellDetector {
   let pendingEscape = false
   let inOsc = false
   let pendingOscEscape = false
 
-  return function chunkContainsBell(data: string): boolean {
-    for (let i = 0; i < data.length; i += 1) {
-      const char = data[i]
+  return {
+    chunkContainsBell(data: string): boolean {
+      for (let i = 0; i < data.length; i += 1) {
+        const char = data[i]
 
-      if (inOsc) {
-        if (pendingOscEscape) {
-          pendingOscEscape = char === '\x1b'
-          if (char === '\\') {
+        if (inOsc) {
+          if (char === '\x18' || char === '\x1a') {
+            // ECMA-48 escape-cancel codes — abort the in-progress OSC string
+            // so a malformed/truncated OSC does not swallow the next BEL.
             inOsc = false
             pendingOscEscape = false
+            continue
+          }
+
+          if (pendingOscEscape) {
+            pendingOscEscape = char === '\x1b'
+            if (char === '\\') {
+              inOsc = false
+              pendingOscEscape = false
+            }
+            continue
+          }
+
+          if (char === '\x07') {
+            inOsc = false
+            continue
+          }
+
+          pendingOscEscape = char === '\x1b'
+          continue
+        }
+
+        if (pendingEscape) {
+          if (char === '\x18' || char === '\x1a') {
+            // ECMA-48 escape-cancel codes also abort a pending ESC.
+            pendingEscape = false
+            continue
+          }
+          pendingEscape = false
+          if (char === ']') {
+            inOsc = true
+            pendingOscEscape = false
+          } else if (char === '\x1b') {
+            pendingEscape = true
           }
           continue
         }
 
-        if (char === '\x07') {
-          inOsc = false
+        if (char === '\x1b') {
+          pendingEscape = true
           continue
         }
 
-        pendingOscEscape = char === '\x1b'
-        continue
-      }
-
-      if (pendingEscape) {
-        pendingEscape = false
-        if (char === ']') {
-          inOsc = true
-          pendingOscEscape = false
-        } else if (char === '\x1b') {
-          pendingEscape = true
+        if (char === '\x07') {
+          return true
         }
-        continue
       }
 
-      if (char === '\x1b') {
-        pendingEscape = true
-        continue
-      }
-
-      if (char === '\x07') {
-        return true
-      }
+      return false
+    },
+    reset(): void {
+      pendingEscape = false
+      inOsc = false
+      pendingOscEscape = false
     }
-
-    return false
   }
 }

--- a/src/renderer/src/components/terminal-pane/layout-serialization.ts
+++ b/src/renderer/src/components/terminal-pane/layout-serialization.ts
@@ -30,6 +30,15 @@ export const EMPTY_LAYOUT: TerminalLayoutSnapshot = {
 export const POST_REPLAY_MODE_RESET =
   '\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1004l\x1b[?1006l\x1b[?2004l'
 
+// Why: daemon snapshot restore reattaches to a live session, so we avoid the
+// full POST_REPLAY_MODE_RESET bundle there — a still-running TUI may still
+// rely on mouse or bracketed-paste modes. Focus reporting is the exception:
+// if xterm preserves `?1004h` across snapshot replay, pane focus/blur emits
+// `\e[I` / `\e[O` into the PTY and shells like zsh ring BEL when no TUI is
+// actively consuming them. Clearing only 1004 preserves the other live-session
+// modes while preventing phantom bells on restored background tabs.
+export const POST_REPLAY_FOCUS_REPORTING_RESET = '\x1b[?1004l'
+
 export function paneLeafId(paneId: number): string {
   return `pane:${paneId}`
 }

--- a/src/renderer/src/components/terminal-pane/layout-serialization.ts
+++ b/src/renderer/src/components/terminal-pane/layout-serialization.ts
@@ -12,6 +12,24 @@ export const EMPTY_LAYOUT: TerminalLayoutSnapshot = {
   expandedLeafId: null
 }
 
+// Why: xterm's SerializeAddon captures display state by emitting mode-setting
+// bytes (e.g. `\e[?1004h` for focus reporting) so a re-fed emulator lands in
+// the same mode as the snapshot source. That's correct for tmux-style
+// "attach to a still-running TUI" — but Orca restores scrollback against a
+// *fresh* shell, with no TUI to consume those modes. A stale focus-reporting
+// bit causes xterm to emit `\e[I`/`\e[O` on every pane click, which the
+// fresh zsh treats as unbound key input and rings the bell for.
+//
+// Reset the interactive modes most commonly left set by crashed/ended TUIs
+// so replayed mode bits do not leak into the fresh shell. ghostty achieves
+// the same end by not restoring state at all.
+//
+//   1000/1002/1003/1006 — mouse reporting variants
+//   1004                — focus event reporting (the actual bug source)
+//   2004                — bracketed paste
+export const POST_REPLAY_MODE_RESET =
+  '\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1004l\x1b[?1006l\x1b[?2004l'
+
 export function paneLeafId(paneId: number): string {
   return `pane:${paneId}`
 }
@@ -235,6 +253,10 @@ export function restoreScrollbackBuffers(
         // Ensure cursor is on a new line so the new shell prompt
         // doesn't trigger zsh's PROMPT_EOL_MARK (%) indicator.
         replayIntoTerminal(pane, replayingPanesRef, '\r\n')
+        // Clear any mode bits the serialized buffer replayed into xterm.
+        // The shell underneath is fresh and has no TUI consuming these modes.
+        // See POST_REPLAY_MODE_RESET comment.
+        replayIntoTerminal(pane, replayingPanesRef, POST_REPLAY_MODE_RESET)
       }
     } catch {
       // If restore fails, continue with blank terminal.

--- a/src/renderer/src/components/terminal-pane/pty-connection-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-types.ts
@@ -22,10 +22,12 @@ export type PtyConnectionDeps = {
   clearRuntimePaneTitle: (tabId: string, paneId: number) => void
   updateTabPtyId: (tabId: string, ptyId: string) => void
   markWorktreeUnread: (worktreeId: string) => void
-  dispatchNotification: (event: {
-    source: 'agent-task-complete' | 'terminal-bell'
-    terminalTitle?: string
-  }) => void
+  markTerminalTabUnread: (tabId: string) => void
+  // Why: the renderer-side dispatcher only handles BEL-sourced notifications
+  // now. shared/types.ts keeps a wider NotificationEventSource union because
+  // main-process callers can still emit others (e.g. `'test'` for the
+  // settings-pane button).
+  dispatchNotification: (event: { source: 'terminal-bell' }) => void
   setCacheTimerStartedAt: (key: string, ts: number | null) => void
   syncPanePtyLayoutBinding: (paneId: number, ptyId: string | null) => void
 }

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -1,9 +1,11 @@
 /* oxlint-disable max-lines */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { POST_REPLAY_FOCUS_REPORTING_RESET, POST_REPLAY_MODE_RESET } from './layout-serialization'
 
 type StoreState = {
   tabsByWorktree: Record<string, { id: string; ptyId: string | null; title?: string }[]>
   ptyIdsByTabId?: Record<string, string[]>
+  unreadTerminalTabs?: Record<string, true>
   worktreesByRepo: Record<string, { id: string; repoId: string; path: string }[]>
   repos: { id: string; connectionId?: string | null }[]
   cacheTimerByKey: Record<string, number | null>
@@ -169,6 +171,7 @@ describe('connectPanePty', () => {
       ptyIdsByTabId: {
         'tab-1': ['tab-pty']
       },
+      unreadTerminalTabs: {},
       worktreesByRepo: {
         repo1: [{ id: 'wt-1', repoId: 'repo1', path: '/tmp/wt-1' }]
       },
@@ -436,6 +439,52 @@ describe('connectPanePty', () => {
     expect(transport.attach).not.toHaveBeenCalled()
     await Promise.resolve()
     expect(deps.syncPanePtyLayoutBinding).toHaveBeenCalledWith(2, 'leaf-pty-2')
+  })
+
+  it('resets focus reporting after daemon snapshot replay without applying the full mode reset', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    transport.connect.mockImplementation(async ({ sessionId }: { sessionId?: string }) => {
+      if (sessionId) {
+        return { id: sessionId, snapshot: '\x1b[?1004hrestored snapshot' }
+      }
+      return null
+    })
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: {
+        'wt-1': [{ id: 'tab-1', ptyId: 'tab-pty' }]
+      },
+      settings: {
+        ...mockStoreState.settings,
+        experimentalTerminalDaemon: true
+      }
+    } as StoreState
+
+    const pane = createPane(1)
+    const manager = createManager(1)
+    const deps = createDeps({
+      restoredLeafId: 'pane:1',
+      restoredPtyIdByLeafId: { 'pane:1': 'tab-pty' }
+    })
+
+    connectPanePty(pane as never, manager as never, deps as never)
+    await Promise.resolve()
+
+    expect(pane.terminal.write).toHaveBeenCalledWith('\x1b[2J\x1b[3J\x1b[H', expect.any(Function))
+    expect(pane.terminal.write).toHaveBeenCalledWith(
+      '\x1b[?1004hrestored snapshot',
+      expect.any(Function)
+    )
+    expect(pane.terminal.write).toHaveBeenCalledWith(
+      POST_REPLAY_FOCUS_REPORTING_RESET,
+      expect.any(Function)
+    )
+    expect(pane.terminal.write).not.toHaveBeenCalledWith(
+      POST_REPLAY_MODE_RESET,
+      expect.any(Function)
+    )
   })
 
   it('reuses the existing local PTY on split remount when the daemon is disabled', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 type StoreState = {
-  tabsByWorktree: Record<string, { id: string; ptyId: string | null }[]>
+  tabsByWorktree: Record<string, { id: string; ptyId: string | null; title?: string }[]>
   ptyIdsByTabId?: Record<string, string[]>
   worktreesByRepo: Record<string, { id: string; repoId: string; path: string }[]>
   repos: { id: string; connectionId?: string | null }[]
@@ -52,10 +52,17 @@ vi.mock('@/store', () => ({
   }
 }))
 
-vi.mock('@/lib/agent-status', () => ({
-  isGeminiTerminalTitle: vi.fn(() => false),
-  isClaudeAgent: vi.fn(() => false)
-}))
+vi.mock('@/lib/agent-status', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return {
+    ...actual,
+    isGeminiTerminalTitle: vi.fn(() => false),
+    isClaudeAgent: vi.fn(() => false),
+    detectAgentStatusFromTitle: vi.fn((title: string) =>
+      /Claude (working|done)/.test(title) ? (/working/.test(title) ? 'working' : 'idle') : null
+    )
+  }
+})
 
 vi.mock('./cache-timer-seeding', () => ({
   shouldSeedCacheTimerOnInitialTitle
@@ -111,7 +118,8 @@ function createManager(paneCount = 1) {
   return {
     setPaneGpuRendering: vi.fn(),
     getPanes: vi.fn(() => Array.from({ length: paneCount }, (_, index) => ({ id: index + 1 }))),
-    closePane: vi.fn()
+    closePane: vi.fn(),
+    getActivePane: vi.fn<() => { id: number } | null>(() => null)
   }
 }
 
@@ -137,6 +145,7 @@ function createDeps(overrides: Record<string, unknown> = {}) {
     clearRuntimePaneTitle: vi.fn(),
     updateTabPtyId: vi.fn(),
     markWorktreeUnread: vi.fn(),
+    markTerminalTabUnread: vi.fn(),
     dispatchNotification: vi.fn(),
     setCacheTimerStartedAt: vi.fn(),
     syncPanePtyLayoutBinding: vi.fn(),
@@ -551,5 +560,89 @@ describe('connectPanePty', () => {
     expect(remountTransport.attach).not.toHaveBeenCalled()
     await Promise.resolve()
     expect(remountDeps.syncPanePtyLayoutBinding).toHaveBeenCalledWith(1, 'pty-restarted')
+  })
+
+  // Why: BEL (0x07) is the attention signal. connectPanePty wires an
+  // onBell handler that raises the worktree unread dot, the tab-level
+  // bell indicator, and an OS notification. The unread flags clear when
+  // the user activates the tab (bell auto-clears on focus). This test
+  // locks in the wiring: if onBell is ever accidentally dropped, unread
+  // marks stop working entirely.
+  it('wires onBell to raise worktree unread, tab unread, and OS notification', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    transportFactoryQueue.push(transport)
+
+    const pane = createPane(1)
+    const manager = createManager(1)
+    const deps = createDeps()
+
+    connectPanePty(pane as never, manager as never, deps as never)
+
+    const bellHandler = createdTransportOptions[0]?.onBell as (() => void) | undefined
+    if (!bellHandler) {
+      throw new Error('Expected onBell to be registered')
+    }
+
+    bellHandler()
+
+    expect(deps.markWorktreeUnread).toHaveBeenCalledTimes(1)
+    expect(deps.markTerminalTabUnread).toHaveBeenCalledWith('tab-1')
+    expect(deps.dispatchNotification).toHaveBeenCalledWith({ source: 'terminal-bell' })
+  })
+
+  // Why: the working→idle transition is kept solely to drive Claude's
+  // prompt-cache timer. It MUST NOT raise attention — doing so would
+  // double-fire with the BEL path above (since Claude's "done" state is
+  // accompanied by a BEL), plus it would mean agents silently fire alerts
+  // that non-agent programs cannot. Attention is BEL-only; this is just
+  // the cache timer hook.
+  it('does not raise attention on agent working→idle (BEL is the sole attention signal)', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    transportFactoryQueue.push(transport)
+
+    const pane = createPane(1)
+    const manager = createManager(1)
+    const deps = createDeps()
+
+    connectPanePty(pane as never, manager as never, deps as never)
+
+    const idleHandler = createdTransportOptions[0]?.onAgentBecameIdle as
+      | ((title: string) => void)
+      | undefined
+    if (!idleHandler) {
+      throw new Error('Expected onAgentBecameIdle to be registered')
+    }
+
+    idleHandler('* Claude done')
+
+    expect(deps.markWorktreeUnread).not.toHaveBeenCalled()
+    expect(deps.markTerminalTabUnread).not.toHaveBeenCalled()
+    expect(deps.dispatchNotification).not.toHaveBeenCalled()
+  })
+
+  // Why: onAgentExited must clear any running prompt-cache countdown so the
+  // sidebar does not show a stale timer for a tab that no longer has an
+  // active Claude session.
+  it('clears the cache timer when the agent exits', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    transportFactoryQueue.push(transport)
+
+    const pane = createPane(1)
+    const manager = createManager(1)
+    const deps = createDeps()
+
+    connectPanePty(pane as never, manager as never, deps as never)
+
+    const agentExitedHandler = createdTransportOptions[0]?.onAgentExited as (() => void) | undefined
+    if (!agentExitedHandler) {
+      throw new Error('Expected onAgentExited to be registered')
+    }
+
+    agentExitedHandler()
+
+    expect(deps.setCacheTimerStartedAt).toHaveBeenCalledWith('tab-1:1', null)
   })
 })

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -9,7 +9,7 @@ import { createIpcPtyTransport } from './pty-transport'
 import { shouldSeedCacheTimerOnInitialTitle } from './cache-timer-seeding'
 import type { PtyConnectionDeps } from './pty-connection-types'
 import { isPaneReplaying, replayIntoTerminal } from './replay-guard'
-import { POST_REPLAY_MODE_RESET } from './layout-serialization'
+import { POST_REPLAY_MODE_RESET, POST_REPLAY_FOCUS_REPORTING_RESET } from './layout-serialization'
 
 const pendingSpawnByTabId = new Map<string, Promise<string | null>>()
 
@@ -149,6 +149,11 @@ export function connectPanePty(
   // scrollback replay so the mode state matches the fresh shell
   // underneath. See POST_REPLAY_MODE_RESET in layout-serialization.ts.
   const onBell = (): void => {
+    // Why: restored Claude Code sessions have been observed to emit a real
+    // standalone BEL some time after daemon snapshot reattach, even when Orca
+    // did not just forward focus/control input. Treat the BEL as authoritative
+    // PTY output here; any product-side suppression should be an explicit UX
+    // decision higher up, not a transport-layer guess.
     deps.markWorktreeUnread(deps.worktreeId)
     deps.markTerminalTabUnread(deps.tabId)
     deps.dispatchNotification({ source: 'terminal-bell' })
@@ -486,6 +491,13 @@ export function connectPanePty(
             // Why replayIntoTerminal: same rationale as the cold-restore path.
             replayIntoTerminal(pane, deps.replayingPanesRef, '\x1b[2J\x1b[3J\x1b[H')
             replayIntoTerminal(pane, deps.replayingPanesRef, connectResult.snapshot)
+            // Why: snapshot restore keeps a live daemon session, so we avoid
+            // the broader POST_REPLAY_MODE_RESET bundle here. Focus reporting
+            // is the unsafe exception: preserving `?1004h` causes xterm to send
+            // `\e[I` / `\e[O` on pane focus/blur, and restored shells can ring
+            // BEL when no TUI is actively consuming them. Reset only 1004 so
+            // live-session mouse/paste modes stay intact while phantom bells stop.
+            replayIntoTerminal(pane, deps.replayingPanesRef, POST_REPLAY_FOCUS_REPORTING_RESET)
           }
 
           if (ptyId) {

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -9,6 +9,7 @@ import { createIpcPtyTransport } from './pty-transport'
 import { shouldSeedCacheTimerOnInitialTitle } from './cache-timer-seeding'
 import type { PtyConnectionDeps } from './pty-connection-types'
 import { isPaneReplaying, replayIntoTerminal } from './replay-guard'
+import { POST_REPLAY_MODE_RESET } from './layout-serialization'
 
 const pendingSpawnByTabId = new Map<string, Promise<string | null>>()
 
@@ -102,9 +103,9 @@ export function connectPanePty(
     deps.setRuntimePaneTitle(deps.tabId, pane.id, title)
     // Why: only the focused pane should drive the tab title — otherwise two
     // agents in split panes cause rapid title flickering as each emits OSC
-    // sequences. Mirrors Ghostty's approach: only the active split's title
-    // propagates to the tab. When focus changes, onActivePaneChange syncs
-    // the newly active pane's stored title to the tab.
+    // sequences. Only the active split's title propagates to the tab. When
+    // focus changes, onActivePaneChange syncs the newly active pane's stored
+    // title to the tab.
     if (manager.getActivePane()?.id === pane.id) {
       deps.updateTabTitle(deps.tabId, title)
     }
@@ -132,22 +133,46 @@ export function connectPanePty(
     // frame-level sync often runs before that async result arrives.
     scheduleRuntimeGraphSync()
   }
+  // ─── Attention signal: BEL ────────────────────────────────────────────
+  //
+  // BEL (0x07) is the attention signal. A BEL raises both the tab-level
+  // bell indicator and the worktree-level dot, and fires an OS
+  // notification. The unread flag clears when the user activates the tab
+  // (see activateTab / focusGroup in the terminals slice) — the bell
+  // auto-clears on focus/keystroke.
+  //
+  // The one case where BEL falsely fires is when a crashed TUI left DEC
+  // private mode 1004 (focus event reporting) enabled — pane clicks then
+  // emit `\e[I`/`\e[O` into the shell, zsh treats them as unbound keys and
+  // rings the bell. This is specific to terminals with cross-restart
+  // persistence (as we have); our fix is to reset 1004 and friends after
+  // scrollback replay so the mode state matches the fresh shell
+  // underneath. See POST_REPLAY_MODE_RESET in layout-serialization.ts.
   const onBell = (): void => {
     deps.markWorktreeUnread(deps.worktreeId)
+    deps.markTerminalTabUnread(deps.tabId)
     deps.dispatchNotification({ source: 'terminal-bell' })
   }
+
+  // ─── Prompt-cache timer: driven by agent lifecycle, not attention ─────
+  //
+  // The working→idle title transition is kept purely to drive Claude's
+  // prompt-cache countdown in the sidebar. It intentionally does NOT raise
+  // attention — that would double-fire with the BEL above, and OSC title
+  // transitions are too narrow a signal to be the sole attention source
+  // (only agent TUIs emit them; non-agent long-running tasks would never
+  // get surfaced).
   const onAgentBecameIdle = (title: string): void => {
-    deps.markWorktreeUnread(deps.worktreeId)
-    deps.dispatchNotification({ source: 'agent-task-complete', terminalTitle: title })
-    // Why: only start the prompt-cache countdown for Claude agents — other agents
-    // have different (or no) prompt-caching semantics and showing a timer for them
-    // would be misleading.
-    // Why we check `settings !== null` separately: during startup, settings hydrate
-    // asynchronously after terminals reconnect. If we treat null as disabled, the
-    // first working→idle transition on a restored Claude tab silently drops the
-    // timer. Writing a timestamp is cheap and the CacheTimer component already
-    // gates rendering on the enabled flag, so a spurious write when the feature
-    // turns out to be disabled is harmless.
+    // Why: only start the prompt-cache countdown for Claude agents — other
+    // agents have different (or no) prompt-caching semantics and showing a
+    // timer for them would be misleading.
+    //
+    // Why we check `settings !== null` separately: during startup, settings
+    // hydrate asynchronously after terminals reconnect. If we treat null
+    // as disabled, the first working→idle transition on a restored Claude
+    // tab silently drops the timer. Writing a timestamp is cheap and the
+    // CacheTimer component gates rendering on the enabled flag, so a
+    // spurious write when the feature turns out to be disabled is harmless.
     const settings = useAppStore.getState().settings
     if (isClaudeAgent(title) && (settings === null || settings.promptCacheTimerEnabled)) {
       deps.setCacheTimerStartedAt(cacheKey, Date.now())
@@ -436,7 +461,22 @@ export function connectPanePty(
               deps.replayingPanesRef,
               '\r\n\x1b[2m--- session restored ---\x1b[0m\r\n\r\n'
             )
-            window.api.pty.ackColdRestore(ptyId!)
+            // Why: the cold-restore scrollback is raw PTY output from the prior
+            // session, so mode-setting bytes emitted by a crashed TUI (e.g.
+            // Claude's \e[?1004h) come through verbatim and re-enable those modes
+            // in xterm. Cold-restore means the daemon lost the session and spawned
+            // a fresh shell — there is no TUI consuming these modes anymore, so
+            // reset them to match the fresh shell's expectations. Not applied to
+            // the snapshot branch below: that branch reattaches to a live daemon
+            // session where a running TUI may still depend on these modes.
+            replayIntoTerminal(pane, deps.replayingPanesRef, POST_REPLAY_MODE_RESET)
+            // Why: ptyId can be null if the transport was torn down during the
+            // reattach flight. Only IPC the ack when we have a real ptyId;
+            // the replay-into-xterm calls above remain unconditional because
+            // they write into the terminal buffer regardless.
+            if (ptyId) {
+              window.api.pty.ackColdRestore(ptyId)
+            }
           } else if (connectResult?.snapshot) {
             // Why: always clear before writing the daemon snapshot to prevent
             // duplication with the scrollback that restoreScrollbackBuffers()

--- a/src/renderer/src/components/terminal-pane/pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.test.ts
@@ -77,7 +77,7 @@ describe('createIpcPtyTransport', () => {
     expect(onOpenCodeStatus).not.toBeNull()
 
     onOpenCodeStatus?.({ ptyId: 'pty-1', status: 'working' })
-    onData?.({ id: 'pty-1', data: '\u001b]0;OpenCode\u0007' })
+    onData?.({ id: 'pty-1', data: ']0;OpenCode' })
     onOpenCodeStatus?.({ ptyId: 'pty-1', status: 'idle' })
 
     expect(onAgentBecameWorking).toHaveBeenCalledTimes(1)
@@ -89,22 +89,27 @@ describe('createIpcPtyTransport', () => {
     expect(onExit).not.toBeNull()
   })
 
-  it('does not fire unread-side effects when replaying buffered data during attach', async () => {
+  it('suppresses attention side effects when replaying eager-buffered data during attach', async () => {
+    // Why: eager PTY buffers capture output produced before the pane mounted —
+    // typically catch-up bytes from a previous app session. A BEL or
+    // completion-style title arriving in that replay must NOT produce a fresh
+    // alert. onTitleChange still fires so the tab label restores correctly,
+    // but onBell and onAgentBecameIdle are gated by suppressAttentionEvents.
     const { createIpcPtyTransport, registerEagerPtyBuffer } = await import('./pty-transport')
     const onTitleChange = vi.fn()
-    const onAgentBecameIdle = vi.fn()
     const onBell = vi.fn()
+    const onAgentBecameIdle = vi.fn()
 
     const handle = registerEagerPtyBuffer('pty-restored', vi.fn())
     onData?.({
       id: 'pty-restored',
-      data: '\u001b]0;. Claude working\u0007\u001b]0;* Claude done\u0007\u0007'
+      data: ']0;. Claude working]0;* Claude done'
     })
 
     const transport = createIpcPtyTransport({
       onTitleChange,
-      onAgentBecameIdle,
-      onBell
+      onBell,
+      onAgentBecameIdle
     })
 
     transport.attach({
@@ -114,8 +119,31 @@ describe('createIpcPtyTransport', () => {
 
     expect(handle.flush()).toBe('')
     expect(onTitleChange).toHaveBeenCalledWith('* Claude done', '* Claude done')
-    expect(onAgentBecameIdle).not.toHaveBeenCalled()
     expect(onBell).not.toHaveBeenCalled()
+    expect(onAgentBecameIdle).not.toHaveBeenCalled()
+  })
+
+  it('fires onBell for bare BELs but ignores BELs inside OSC sequences', async () => {
+    // Why: Claude's OSC titles end with a BEL terminator (`\e]0;…\a`). The
+    // stateful bell detector must know it is inside an OSC when that BEL
+    // arrives and ignore it — otherwise every agent title change would
+    // produce a spurious bell. A bare BEL outside an OSC is what actually
+    // raises attention.
+    const { createIpcPtyTransport } = await import('./pty-transport')
+    const onBell = vi.fn()
+
+    const transport = createIpcPtyTransport({ onBell })
+    await transport.connect({ url: '', callbacks: {} })
+
+    // OSC-terminating BELs: three titles, zero attention bells.
+    onData?.({ id: 'pty-1', data: ']0;title-one' })
+    onData?.({ id: 'pty-1', data: ']0;title-two' })
+    onData?.({ id: 'pty-1', data: ']0;title-three' })
+    expect(onBell).not.toHaveBeenCalled()
+
+    // Bare BEL outside any OSC: fires once.
+    onData?.({ id: 'pty-1', data: '' })
+    expect(onBell).toHaveBeenCalledTimes(1)
   })
 
   it('routes eager-buffered bytes through onReplayData so the renderer can engage the replay guard', async () => {
@@ -125,7 +153,7 @@ describe('createIpcPtyTransport', () => {
     // left over from a previous session. Routing them through onData instead of
     // onReplayData would bypass pty-connection's replay guard and xterm would
     // auto-reply to those queries, leaking stray input into the shell.
-    const bufferedPayload = 'hello[cworld'
+    const bufferedPayload = 'hello\x1b[cworld'
 
     const handle = registerEagerPtyBuffer('pty-restored', vi.fn())
     onData?.({
@@ -377,15 +405,15 @@ describe('createIpcPtyTransport', () => {
 
   it('unregisterPtyDataHandlers prevents final data burst from triggering notifications', async () => {
     const { createIpcPtyTransport, unregisterPtyDataHandlers } = await import('./pty-transport')
-    const onBell = vi.fn()
     const onTitleChange = vi.fn()
+    const onBell = vi.fn()
     const onAgentBecameIdle = vi.fn()
     const onAgentBecameWorking = vi.fn()
     const onPtyExit = vi.fn()
 
     const transport = createIpcPtyTransport({
-      onBell,
       onTitleChange,
+      onBell,
       onAgentBecameIdle,
       onAgentBecameWorking,
       onPtyExit
@@ -394,16 +422,16 @@ describe('createIpcPtyTransport', () => {
     await transport.connect({ url: '', callbacks: {} })
 
     // Agent starts working
-    onData?.({ id: 'pty-1', data: '\u001b]0;. Claude working\u0007' })
+    onData?.({ id: 'pty-1', data: ']0;. Claude working' })
     expect(onAgentBecameWorking).toHaveBeenCalledTimes(1)
 
-    // Simulate shutdownWorktreeTerminals: unregister data handlers before kill
+    // Simulate shutdownWorktreeTerminals: unregister data handlers before kill.
     unregisterPtyDataHandlers(['pty-1'])
 
     // Final data burst from main process (flushed before exit) — contains a
-    // title change from working to idle AND a BEL. Neither should trigger a
-    // notification because the data handler was removed.
-    onData?.({ id: 'pty-1', data: '\u001b]0;Claude done\u0007\u0007' })
+    // title change and a BEL. Neither should produce a notification because
+    // the data handler was removed.
+    onData?.({ id: 'pty-1', data: ']0;Claude done' })
     expect(onAgentBecameIdle).not.toHaveBeenCalled()
     expect(onBell).not.toHaveBeenCalled()
 
@@ -429,7 +457,7 @@ describe('createIpcPtyTransport', () => {
       await transport.connect({ url: '', callbacks: {} })
 
       // Agent starts working — sets the title to a working indicator
-      onData?.({ id: 'pty-1', data: '\u001b]0;. Claude working\u0007' })
+      onData?.({ id: 'pty-1', data: ']0;. Claude working' })
       expect(onAgentBecameWorking).toHaveBeenCalledTimes(1)
 
       // Data arrives without a title change — starts the 3 s staleTitleTimer
@@ -453,12 +481,10 @@ describe('createIpcPtyTransport', () => {
   it('keeps the exit observer alive after detach so remounts do not reuse dead PTYs', async () => {
     const { createIpcPtyTransport } = await import('./pty-transport')
     const onPtyExit = vi.fn()
-    const onBell = vi.fn()
     const onTitleChange = vi.fn()
 
     const transport = createIpcPtyTransport({
       onPtyExit,
-      onBell,
       onTitleChange
     })
 
@@ -472,9 +498,8 @@ describe('createIpcPtyTransport', () => {
 
     transport.detach?.()
 
-    onData?.({ id: 'pty-detached', data: '\u001b]0;Detached title\u0007\u0007' })
+    onData?.({ id: 'pty-detached', data: ']0;Detached title' })
     expect(onTitleChange).not.toHaveBeenCalled()
-    expect(onBell).not.toHaveBeenCalled()
 
     onExit?.({ id: 'pty-detached', code: 0 })
 

--- a/src/renderer/src/components/terminal-pane/pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.ts
@@ -330,6 +330,13 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
               clearTimeout(staleTitleTimer)
               staleTitleTimer = null
             }
+            // Why: eager-buffered bytes may end mid-OSC (truncated/partial session
+            // data), leaving bellDetector with inOsc = true. Without resetting, the
+            // next real BEL in live data would be silently classified as an OSC
+            // terminator and dropped. BEL is the sole attention signal per the PR
+            // design, so this reset guards the attention pipeline against a silent
+            // regression driven by replay state leaking into the live stream.
+            bellDetector.reset()
           }
         }
         bufferHandle.dispose()

--- a/src/renderer/src/components/terminal-pane/pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.ts
@@ -51,7 +51,12 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
   let connected = false
   let destroyed = false
   let ptyId: string | null = null
-  const chunkContainsBell = createBellDetector()
+  const bellDetector = createBellDetector()
+  // Why: eager PTY buffers contain output produced before the pane attached —
+  // often from the previous app session. We still replay that data so titles
+  // and scrollback restore correctly, but it must not produce fresh bells,
+  // unread marks, or notifications for unrelated worktrees just because Orca
+  // is reconnecting background terminals on launch.
   let suppressAttentionEvents = false
   let lastEmittedTitle: string | null = null
   let lastObservedTerminalTitle: string | null = null
@@ -134,7 +139,8 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
   // query sequences leak into the shell as stray input.
   let replayingBufferedData = false
 
-  // Why: shared by connect() and attach() to avoid duplicating title/bell/exit logic.
+  // Why: shared by connect() and attach() to avoid duplicating title/bell/exit
+  // logic across the two code paths that register a PTY.
   function registerPtyDataHandler(id: string): void {
     ptyDataHandlers.set(id, (data) => {
       if (replayingBufferedData && storedCallbacks.onReplayData) {
@@ -165,7 +171,14 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
           }, STALE_TITLE_TIMEOUT)
         }
       }
-      if (onBell && chunkContainsBell(data) && !suppressAttentionEvents) {
+      // Why: BEL is the attention signal. The detector is
+      // stateful across chunks so a BEL sitting inside an OSC sequence
+      // (e.g. Claude's `\e]0;title\a`) is correctly ignored — only true
+      // terminal bells raise attention. suppressAttentionEvents gates this
+      // during the synchronous eager-buffer replay so a historical BEL
+      // captured from the prior session does not produce a fresh alert on
+      // cold reattach.
+      if (onBell && bellDetector.chunkContainsBell(data) && !suppressAttentionEvents) {
         onBell()
       }
     })
@@ -178,6 +191,7 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
     }
     agentTracker?.reset()
     openCodeStatus = null
+    bellDetector.reset()
   }
 
   function registerPtyExitHandler(id: string): void {
@@ -288,15 +302,17 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
       if (bufferHandle) {
         const buffered = bufferHandle.flush()
         if (buffered) {
-          // Why: eager PTY buffers contain output produced before the pane
-          // attached, often from a previous app session. We still replay that
-          // data so titles and scrollback restore correctly, but it must not
-          // generate fresh unread badges or notifications for unrelated
-          // worktrees just because Orca is reconnecting background terminals.
-          // Why replayingBufferedData: those buffered bytes are raw PTY output
-          // that may contain query sequences from the previous session; route
-          // them through onReplayData so the renderer engages the replay guard
-          // and xterm's auto-replies do not leak into the shell.
+          // Why: eager-buffered bytes are raw PTY output captured before the
+          // pane mounted — often from the previous app session. We replay
+          // them so titles/scrollback restore correctly, but must silence
+          // attention side effects during that replay: a historical BEL
+          // or completion captured from the prior session must not produce
+          // a fresh bell on the freshly mounted pane.
+          //
+          // replayingBufferedData additionally routes the bytes through
+          // onReplayData so the renderer engages the replay guard — xterm's
+          // auto-replies to embedded query sequences would otherwise leak
+          // into the shell's stdin.
           suppressAttentionEvents = true
           replayingBufferedData = true
           try {
@@ -304,6 +320,16 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
           } finally {
             replayingBufferedData = false
             suppressAttentionEvents = false
+            // Why: replaying eager-buffered bytes may have observed a "working" title
+            // without a follow-up title, starting a stale-title timer. That timer would
+            // fire 3s later — outside the suppression window — and trigger a spurious
+            // working→idle transition (and phantom cache-timer write) for a session
+            // that was never live in this app instance. Cancel it so the replay has
+            // no lingering side effects.
+            if (staleTitleTimer) {
+              clearTimeout(staleTitleTimer)
+              staleTitleTimer = null
+            }
           }
         }
         bufferHandle.dispose()
@@ -333,11 +359,7 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
     },
 
     disconnect() {
-      if (staleTitleTimer) {
-        clearTimeout(staleTitleTimer)
-        staleTitleTimer = null
-      }
-      openCodeStatus = null
+      clearAccumulatedState()
       if (ptyId) {
         const id = ptyId
         window.api.pty.kill(id)
@@ -349,11 +371,7 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
     },
 
     detach() {
-      if (staleTitleTimer) {
-        clearTimeout(staleTitleTimer)
-        staleTitleTimer = null
-      }
-      openCodeStatus = null
+      clearAccumulatedState()
       if (ptyId) {
         // Why: detach() is used for in-session remounts such as moving a tab
         // between split groups. Stop delivering data/title events into the

--- a/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
+++ b/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
@@ -11,9 +11,9 @@ import { getRepoMapFromState, getWorktreeMapFromState } from '@/store/selectors'
  */
 export function useNotificationDispatch(
   worktreeId: string
-): (event: { source: 'agent-task-complete' | 'terminal-bell'; terminalTitle?: string }) => void {
+): (event: { source: 'terminal-bell' }) => void {
   return useCallback(
-    (event: { source: 'agent-task-complete' | 'terminal-bell'; terminalTitle?: string }) => {
+    (event: { source: 'terminal-bell' }) => {
       const state = useAppStore.getState()
 
       // Why: shutdownWorktreeTerminals clears ptyIdsByTabId synchronously
@@ -29,16 +29,19 @@ export function useNotificationDispatch(
         return
       }
 
-      const repoId = worktreeId.includes('::') ? worktreeId.slice(0, worktreeId.indexOf('::')) : ''
-      const repo = getRepoMapFromState(state).get(repoId)
+      // Why: prefer worktree.repoId over string-parsing the worktreeId. The
+      // `${repoId}::${path}` format is an implementation detail of id
+      // construction; coupling the notification dispatcher to it would silently
+      // drop the repo label if that format ever changes. The worktree object
+      // itself is the source of truth for its owning repo.
       const worktree = getWorktreeMapFromState(state).get(worktreeId)
+      const repo = worktree ? getRepoMapFromState(state).get(worktree.repoId) : null
 
       void window.api.notifications.dispatch({
         source: event.source,
         worktreeId,
         repoLabel: repo?.displayName,
         worktreeLabel: worktree?.displayName || worktree?.branch || worktreeId,
-        terminalTitle: event.terminalTitle,
         isActiveWorktree: state.activeWorktreeId === worktreeId
       })
     },

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -89,10 +89,8 @@ type UseTerminalPaneLifecycleDeps = {
   clearRuntimePaneTitle: (tabId: string, paneId: number) => void
   updateTabPtyId: (tabId: string, ptyId: string) => void
   markWorktreeUnread: (worktreeId: string) => void
-  dispatchNotification: (event: {
-    source: 'agent-task-complete' | 'terminal-bell'
-    terminalTitle?: string
-  }) => void
+  markTerminalTabUnread: (tabId: string) => void
+  dispatchNotification: (event: { source: 'terminal-bell' }) => void
   setCacheTimerStartedAt: (key: string, ts: number | null) => void
   syncPanePtyLayoutBinding: (paneId: number, ptyId: string | null) => void
   setTabPaneExpanded: (tabId: string, expanded: boolean) => void
@@ -103,6 +101,11 @@ type UseTerminalPaneLifecycleDeps = {
   setPaneTitles: React.Dispatch<React.SetStateAction<Record<number, string>>>
   paneTitlesRef: React.RefObject<Record<number, string>>
   setRenamingPaneId: React.Dispatch<React.SetStateAction<number | null>>
+  // Why: TerminalPane exposes a reactive pane count so effects (e.g. the
+  // data-has-title toggler) re-run when panes are split or closed. The
+  // imperative managerRef.getPanes().length is not reactive, so without this
+  // dispatcher structural changes wouldn't trigger dependent effects.
+  setPaneCount: React.Dispatch<React.SetStateAction<number>>
 }
 
 type SplitStartupPayload = { command: string; env?: Record<string, string> }
@@ -168,6 +171,7 @@ export function useTerminalPaneLifecycle({
   clearRuntimePaneTitle,
   updateTabPtyId,
   markWorktreeUnread,
+  markTerminalTabUnread,
   dispatchNotification,
   setCacheTimerStartedAt,
   syncPanePtyLayoutBinding,
@@ -178,7 +182,8 @@ export function useTerminalPaneLifecycle({
   persistLayoutSnapshot,
   setPaneTitles,
   paneTitlesRef,
-  setRenamingPaneId
+  setRenamingPaneId,
+  setPaneCount
 }: UseTerminalPaneLifecycleDeps): void {
   const systemPrefersDarkRef = useRef(systemPrefersDark)
   systemPrefersDarkRef.current = systemPrefersDark
@@ -277,6 +282,14 @@ export function useTerminalPaneLifecycle({
       setTabCanExpandPane(tabId, paneCount > 1)
     }
 
+    // Why: publish the current pane count to React state so effects depending
+    // on structural changes (e.g. the data-has-title toggler) re-run on
+    // split/close. The pane list lives in an imperative PaneManager ref, so
+    // without this sync those effects would miss structural-only changes.
+    const syncPaneCount = (): void => {
+      setPaneCount(managerRef.current?.getPanes().length ?? 0)
+    }
+
     let shouldPersistLayout = false
     const restoredLeafIdsInCreationOrder = collectLeafIdsInReplayCreationOrder(
       initialLayoutRef.current.root
@@ -301,6 +314,7 @@ export function useTerminalPaneLifecycle({
       clearRuntimePaneTitle,
       updateTabPtyId,
       markWorktreeUnread,
+      markTerminalTabUnread,
       dispatchNotification,
       setCacheTimerStartedAt,
       syncPanePtyLayoutBinding,
@@ -436,6 +450,7 @@ export function useTerminalPaneLifecycle({
         // unaffected by this clear.
         ptyDeps.startup = null
         panePtyBindings.set(pane.id, panePtyBinding)
+        syncPaneCount()
         scheduleRuntimeGraphSync()
         queueResizeAll(true)
       },
@@ -503,6 +518,7 @@ export function useTerminalPaneLifecycle({
         // Dismiss the rename dialog if it was open for the closed pane,
         // otherwise it would submit against a non-existent pane.
         setRenamingPaneId((prev) => (prev === paneId ? null : prev))
+        syncPaneCount()
         // Why: PaneManager.closePane() reassigns activePaneId directly without
         // calling setActivePane(), so onActivePaneChange does not fire. Sync the
         // tab title to the survivor's stored title here so the tab label doesn't
@@ -536,6 +552,7 @@ export function useTerminalPaneLifecycle({
         scheduleRuntimeGraphSync()
         syncExpandedLayout()
         syncCanExpandState()
+        syncPaneCount()
         queueResizeAll(false)
         if (shouldPersistLayout) {
           persistLayoutSnapshot()
@@ -694,6 +711,7 @@ export function useTerminalPaneLifecycle({
 
     shouldPersistLayout = true
     syncCanExpandState()
+    syncPaneCount()
     applyAppearance(manager)
     queueResizeAll(isActive)
     persistLayoutSnapshot()
@@ -807,8 +825,8 @@ export function useTerminalPaneLifecycle({
     // Why: effectiveMacOptionAsAlt changes when the OS keyboard layout
     // switches mid-session (focus-in probe re-runs) or when the user flips
     // the explicit override. Either triggers a live re-apply of
-    // macOptionIsMeta on every pane, matching Ghostty's "change takes effect
-    // immediately" behavior.
+    // macOptionIsMeta on every pane so the change takes effect
+    // immediately.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [settings, systemPrefersDark, effectiveMacOptionAsAlt])
 }

--- a/src/renderer/src/lib/agent-status.test.ts
+++ b/src/renderer/src/lib/agent-status.test.ts
@@ -2,7 +2,7 @@
  * Why: agent title detection is intentionally table-driven in one place so the
  * supported title variants stay readable and regressions are easy to compare.
  */
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, test, vi } from 'vitest'
 import {
   detectAgentStatusFromTitle,
   clearWorkingIndicators,
@@ -172,6 +172,62 @@ describe('detectAgentStatusFromTitle', () => {
     expect(detectAgentStatusFromTitle('CLAUDE')).toBe('idle')
     expect(detectAgentStatusFromTitle('Codex Working')).toBe('working')
   })
+
+  // Why: `detectAgentStatusFromTitle` uses a substring-based `containsAgentName`
+  // fallback, so a cwd-path containing an agent-name fragment without a strong
+  // keyword or ". "/"* " prefix still falls through to the 'idle' branch. Pin
+  // the behavior so a future tightening (or deliberate relaxation) of
+  // `containsAgentName` is an explicit decision.
+  it('still returns idle for cwd-path containing agent name (known containsAgentName gap)', () => {
+    expect(detectAgentStatusFromTitle('~/codex-scratch')).toBe('idle')
+    expect(detectAgentStatusFromTitle('~/codex already built')).toBe('idle')
+  })
+})
+
+// Why: regression guard for the STRONG_WORKING_KEYWORDS_RE path-separator
+// false positive. Before the lookarounds were widened to `[\w./\\-]`, a title
+// like `~/codex/working` matched STRONG_WORKING_KEYWORDS_RE (because `/` is
+// not in `[\w\-]`) and the function classified a plain path as 'working',
+// driving spinners and agent counts off a shell cwd. The idle-side fallback
+// at the bottom of `detectAgentStatusFromTitle` still returns 'idle' for
+// agent-name-containing titles — that's the known `containsAgentName`
+// substring gap documented in the test above — so the behavior this block
+// pins is specifically "no path fragment is ever classified as 'working'."
+describe('detectAgentStatusFromTitle path-separator rejection', () => {
+  test('rejects working keywords adjacent to POSIX path separators', () => {
+    expect(detectAgentStatusFromTitle('~/codex/working')).not.toBe('working')
+    expect(detectAgentStatusFromTitle('~/codex/thinking')).not.toBe('working')
+    expect(detectAgentStatusFromTitle('~/codex/running')).not.toBe('working')
+  })
+
+  test('rejects working keywords adjacent to Windows path separators', () => {
+    expect(detectAgentStatusFromTitle('C:\\codex\\working')).not.toBe('working')
+    expect(detectAgentStatusFromTitle('C:\\aider\\thinking')).not.toBe('working')
+  })
+
+  test('rejects working keywords adjacent to `.` separators', () => {
+    expect(detectAgentStatusFromTitle('codex.working')).not.toBe('working')
+    expect(detectAgentStatusFromTitle('aider.thinking')).not.toBe('working')
+  })
+
+  test('still accepts legitimate idle/working titles separated by whitespace', () => {
+    expect(detectAgentStatusFromTitle('Codex done')).toBe('idle')
+    expect(detectAgentStatusFromTitle('OpenCode ready')).toBe('idle')
+    expect(detectAgentStatusFromTitle('Aider idle')).toBe('idle')
+    expect(detectAgentStatusFromTitle('Codex working')).toBe('working')
+    expect(detectAgentStatusFromTitle('Aider thinking')).toBe('working')
+  })
+
+  // Why: path separators only need to be blocked on the LEFT of the keyword
+  // (where path fragments sit). Blocking them on the right would regress
+  // legitimate sentence-style titles where a keyword is followed by `.`/`!`/`?`.
+  test('still accepts keywords followed by trailing punctuation', () => {
+    expect(detectAgentStatusFromTitle('Codex done.')).toBe('idle')
+    expect(detectAgentStatusFromTitle('Aider idle!')).toBe('idle')
+    expect(detectAgentStatusFromTitle('OpenCode ready?')).toBe('idle')
+    expect(detectAgentStatusFromTitle('Codex working.')).toBe('working')
+    expect(detectAgentStatusFromTitle('Aider thinking...')).toBe('working')
+  })
 })
 
 describe('clearWorkingIndicators', () => {
@@ -201,6 +257,24 @@ describe('clearWorkingIndicators', () => {
   it('returns original title if no working indicators found', () => {
     expect(clearWorkingIndicators('* claude')).toBe('* claude')
     expect(clearWorkingIndicators('Terminal 1')).toBe('Terminal 1')
+  })
+
+  // Why: clearWorkingIndicators must use the same hyphen/word-char-aware
+  // boundary as STRONG_WORKING_KEYWORDS_RE (agent-detection.ts). A prior
+  // implementation used plain `\b${keyword}\b` which — since `-` is a
+  // non-word char — would strip "working" out of "codex is-working-cap"
+  // even though detectAgentStatusFromTitle correctly refuses to classify
+  // that title as 'working'. The clearer and detector must stay symmetric.
+  it('does not strip working keywords inside hyphenated compounds', () => {
+    expect(clearWorkingIndicators('codex is-working-cap')).toBe('codex is-working-cap')
+    expect(clearWorkingIndicators('claude reworking diff')).toBe('claude reworking diff')
+    expect(clearWorkingIndicators('codex overthinking it')).toBe('codex overthinking it')
+  })
+
+  it('still strips working keywords at whitespace boundaries', () => {
+    const cleared = clearWorkingIndicators('Codex working on tests')
+    expect(cleared).not.toMatch(/\bworking\b/)
+    expect(detectAgentStatusFromTitle(cleared)).not.toBe('working')
   })
 })
 
@@ -381,6 +455,20 @@ describe('createAgentStatusTracker', () => {
     tracker.handleTitle('⠂ Claude Code')
     tracker.handleTitle('⠐ Fix the thing')
     tracker.handleTitle('⠂ Fix the thing')
+    expect(onBecameIdle).not.toHaveBeenCalled()
+  })
+
+  // Why: reset() clears the tracker's working latch so stale working→idle
+  // transitions cannot fire after the owning transport is torn down. Without
+  // this guarantee, a reattach or late title delivery could surface a
+  // phantom idle notification for work the user already dismissed.
+  it('reset() clears working state so a subsequent idle does not fire onBecameIdle', () => {
+    const onBecameIdle = vi.fn()
+    const tracker = createAgentStatusTracker(onBecameIdle)
+
+    tracker.handleTitle('⠂ Claude Code') // working
+    tracker.reset()
+    tracker.handleTitle('✳ Claude Code') // idle — must NOT fire after reset
     expect(onBecameIdle).not.toHaveBeenCalled()
   })
 

--- a/src/renderer/src/store/slices/store-cascades.test.ts
+++ b/src/renderer/src/store/slices/store-cascades.test.ts
@@ -1,14 +1,19 @@
 /* eslint-disable max-lines */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { buildWorktreeComparator } from '@/components/sidebar/smart-sort'
+import type * as AgentStatusModule from '@/lib/agent-status'
 
 // Mock sonner (imported by repos.ts)
 vi.mock('sonner', () => ({ toast: { info: vi.fn(), success: vi.fn(), error: vi.fn() } }))
 
 // Mock agent-status (imported by terminal-helpers)
-vi.mock('@/lib/agent-status', () => ({
-  detectAgentStatusFromTitle: vi.fn().mockReturnValue(null)
-}))
+vi.mock('@/lib/agent-status', async (importOriginal) => {
+  const actual = await importOriginal<typeof AgentStatusModule>()
+  return {
+    ...actual,
+    detectAgentStatusFromTitle: vi.fn().mockReturnValue(null)
+  }
+})
 
 // Mock window.api before anything uses it
 const mockApi = {
@@ -876,6 +881,73 @@ describe('setActiveWorktree', () => {
 
     const replacement = store.getState().createTab(wt)
     expect(replacement.title).toBe('Terminal 1')
+  })
+
+  // Why: unread flags are ephemeral UI state — they must not linger past the
+  // lifetime of the tab/pane they point at. A stale flag on a closed tab
+  // would render a bell the user can never dismiss because the tab (and
+  // therefore every focus path that clears it) is gone.
+  it('drops unreadTerminalTabs for a closed tab', () => {
+    const store = createTestStore()
+    const wt = 'repo1::/path/wt1'
+
+    seedStore(store, {
+      worktreesByRepo: {
+        repo1: [makeWorktree({ id: wt, repoId: 'repo1', path: '/path/wt1' })]
+      }
+    })
+
+    const closing = store.getState().createTab(wt)
+    const surviving = store.getState().createTab(wt)
+
+    // Seed flags directly — the self-guarded mark actions intentionally
+    // refuse the currently-active tab, but this test's subject is closeTab's
+    // cleanup behavior, not the guards.
+    store.setState({
+      unreadTerminalTabs: {
+        [closing.id]: true as const,
+        [surviving.id]: true as const
+      }
+    })
+
+    store.getState().closeTab(closing.id)
+
+    const s = store.getState()
+    expect(s.unreadTerminalTabs[closing.id]).toBeUndefined()
+    // Siblings untouched.
+    expect(s.unreadTerminalTabs[surviving.id]).toBe(true)
+  })
+
+  // Why: shutdownWorktreeTerminals tears down every PTY in the worktree. The
+  // focus events that would normally clear unread (bell-in-focused-pane,
+  // activate-tab) never arrive for dead PTYs, so the flags have to be
+  // dropped by the shutdown path itself.
+  it('drops unread flags for every tab in a shutdown worktree', async () => {
+    const store = createTestStore()
+    const wt = 'repo1::/path/wt1'
+
+    seedStore(store, {
+      worktreesByRepo: {
+        repo1: [makeWorktree({ id: wt, repoId: 'repo1', path: '/path/wt1' })]
+      }
+    })
+
+    const tabA = store.getState().createTab(wt)
+    const tabB = store.getState().createTab(wt)
+
+    // Seed flags directly (see closeTab test for why).
+    store.setState({
+      unreadTerminalTabs: {
+        [tabA.id]: true as const,
+        [tabB.id]: true as const
+      }
+    })
+
+    await store.getState().shutdownWorktreeTerminals(wt)
+
+    const s = store.getState()
+    expect(s.unreadTerminalTabs[tabA.id]).toBeUndefined()
+    expect(s.unreadTerminalTabs[tabB.id]).toBeUndefined()
   })
 
   it('returns to the landing state when closing the last terminal tab in the active worktree', () => {

--- a/src/renderer/src/store/slices/store-session-cascades.test.ts
+++ b/src/renderer/src/store/slices/store-session-cascades.test.ts
@@ -2,6 +2,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { create } from 'zustand'
 import type { AppState } from '../types'
+import type * as AgentStatusModule from '@/lib/agent-status'
 import type {
   BrowserTab,
   TerminalLayoutSnapshot,
@@ -13,9 +14,13 @@ import type {
 vi.mock('sonner', () => ({ toast: { info: vi.fn(), success: vi.fn(), error: vi.fn() } }))
 
 // Mock agent-status (imported by terminal-helpers)
-vi.mock('@/lib/agent-status', () => ({
-  detectAgentStatusFromTitle: vi.fn().mockReturnValue(null)
-}))
+vi.mock('@/lib/agent-status', async (importOriginal) => {
+  const actual = await importOriginal<typeof AgentStatusModule>()
+  return {
+    ...actual,
+    detectAgentStatusFromTitle: vi.fn().mockReturnValue(null)
+  }
+})
 
 // Mock window.api before anything uses it
 const mockApi = {

--- a/src/renderer/src/store/slices/tabs.test.ts
+++ b/src/renderer/src/store/slices/tabs.test.ts
@@ -3,14 +3,19 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { create } from 'zustand'
 import type { AppState } from '../types'
 import type { Tab, TabGroup } from '../../../../shared/types'
+import type * as AgentStatusModule from '@/lib/agent-status'
 
 // Mock sonner (imported by repos.ts)
 vi.mock('sonner', () => ({ toast: { info: vi.fn(), success: vi.fn(), error: vi.fn() } }))
 
 // Mock agent-status (imported by terminal-helpers)
-vi.mock('@/lib/agent-status', () => ({
-  detectAgentStatusFromTitle: vi.fn().mockReturnValue(null)
-}))
+vi.mock('@/lib/agent-status', async (importOriginal) => {
+  const actual = await importOriginal<typeof AgentStatusModule>()
+  return {
+    ...actual,
+    detectAgentStatusFromTitle: vi.fn().mockReturnValue(null)
+  }
+})
 
 const mockApi = {
   worktrees: {
@@ -400,6 +405,320 @@ describe('TabsSlice', () => {
       store.getState().activateTab(preview.id)
 
       expect(store.getState().unifiedTabsByWorktree[WT][0].isPreview).toBe(false)
+    })
+
+    // Why: regression guard for "click the tab with a bell and it doesn't go
+    // away". The tab-strip bell reads from unreadTerminalTabs, keyed by the
+    // terminal tab's entityId. activateTab receives a *unified* tabId, so the
+    // clear step must resolve entityId from the unified tab or the flag sticks.
+    it('clears unreadTerminalTabs for a terminal tab when its unified tab activates', () => {
+      const t1 = store.getState().createUnifiedTab(WT, 'terminal')
+      const t2 = store.getState().createUnifiedTab(WT, 'terminal')
+      // t2 is active after creation; move focus to t1 so we can mark t2 unread.
+      store.getState().activateTab(t1.id)
+
+      // Mark WT as the active worktree. activateTab's unread-clear is guarded
+      // on activeWorktreeId so the signal isn't swallowed when activating a
+      // tab in a hidden worktree. Real-world callers only hit activateTab
+      // for visible tabs, so this mirrors production conditions.
+      store.setState({ activeWorktreeId: WT })
+
+      // t1.entityId and t2.entityId are the terminal tabIds that
+      // markTerminalTabUnread / TabBar read from.
+      const t2TerminalId = t2.entityId
+      store.setState({
+        unreadTerminalTabs: {
+          ...store.getState().unreadTerminalTabs,
+          [t2TerminalId]: true as const
+        }
+      })
+      expect(store.getState().unreadTerminalTabs[t2TerminalId]).toBe(true)
+
+      store.getState().activateTab(t2.id)
+
+      expect(store.getState().unreadTerminalTabs[t2TerminalId]).toBeUndefined()
+    })
+  })
+
+  // ─── markTerminalTabUnread (split-group guard) ───────────────────
+  //
+  // Regression guard for the split-group bell bug: when two groups are visible
+  // side-by-side, a bell in the active tab of a non-focused group must NOT
+  // mark that tab unread — the user can already see it. Before the fix,
+  // markTerminalTabUnread only checked the global activeTabId (the focused
+  // group's tab), so the non-focused but still-visible group's tab got a
+  // spurious bell.
+  describe('markTerminalTabUnread', () => {
+    it('suppresses marking when the tab is active in any visible group of the active worktree', () => {
+      // Group A: the current worktree's root group, created implicitly by
+      // createUnifiedTab. Populate it with a terminal tab (tabA).
+      const tabA = store.getState().createUnifiedTab(WT, 'terminal')
+      const groupAId = store.getState().groupsByWorktree[WT][0].id
+
+      // Group B: split to the right of Group A, then populate with its own
+      // terminal tab and focus Group B so it becomes the globally-focused
+      // group — this is the condition under which the bug reproduces.
+      const groupBId = store.getState().createEmptySplitGroup(WT, groupAId, 'right')
+      if (!groupBId) {
+        throw new Error('createEmptySplitGroup returned null')
+      }
+      store.getState().createUnifiedTab(WT, 'terminal', { targetGroupId: groupBId })
+      store.getState().focusGroup(WT, groupBId)
+
+      // Mark the active worktree so markTerminalTabUnread's guard reaches the
+      // split-group branch (it early-returns otherwise).
+      store.setState({ activeWorktreeId: WT })
+
+      // Why: markTerminalTabUnread early-returns when no TerminalTab owns
+      // tabA.entityId in tabsByWorktree (owner-missing guard). Without this
+      // seed, the test would pass via that early-return rather than exercising
+      // the split-group visibility branch we are trying to cover. In
+      // production, every terminal unified tab has a backing legacy terminal
+      // tab (createTab calls createUnifiedTab with matching ids); mirror that
+      // invariant here so the guard under test is actually reached.
+      store.setState({
+        tabsByWorktree: {
+          [WT]: [
+            {
+              id: tabA.entityId,
+              ptyId: null,
+              worktreeId: WT,
+              title: 'Terminal 1',
+              customTitle: null,
+              color: null,
+              sortOrder: 0,
+              createdAt: Date.now()
+            }
+          ]
+        }
+      })
+
+      // Sanity: Group A still has tabA as its active tab, and tabA is NOT the
+      // global activeTabId (Group B's tab is). Without the fix, the global
+      // check alone would let the mark through.
+      const groupA = store.getState().groupsByWorktree[WT].find((g) => g.id === groupAId)
+      expect(groupA?.activeTabId).toBe(tabA.id)
+      expect(store.getState().activeTabId).not.toBe(tabA.entityId)
+
+      // Fire a bell on Group A's terminal tab. It must be suppressed because
+      // Group A is still visible alongside Group B.
+      store.getState().markTerminalTabUnread(tabA.entityId)
+
+      expect(store.getState().unreadTerminalTabs[tabA.entityId]).toBeUndefined()
+    })
+
+    it('does mark a tab that is not the active tab of any visible group', () => {
+      // Group A with two terminal tabs. Activate tabA1, leaving tabA2 inactive.
+      const tabA1 = store.getState().createUnifiedTab(WT, 'terminal')
+      const tabA2 = store.getState().createUnifiedTab(WT, 'terminal')
+      const groupAId = store.getState().groupsByWorktree[WT][0].id
+      store.getState().activateTab(tabA1.id)
+
+      // Group B split to the right with its own tab (so there are two visible
+      // groups, matching the split-group condition). Focus Group B.
+      const groupBId = store.getState().createEmptySplitGroup(WT, groupAId, 'right')
+      if (!groupBId) {
+        throw new Error('createEmptySplitGroup returned null')
+      }
+      store.getState().createUnifiedTab(WT, 'terminal', { targetGroupId: groupBId })
+      store.getState().focusGroup(WT, groupBId)
+      store.setState({ activeWorktreeId: WT })
+      // Why: markTerminalTabUnread guards against writing unread for a tab
+      // that no longer exists in tabsByWorktree. In production, every
+      // terminal unified tab has a backing legacy terminal tab (createTab
+      // calls createUnifiedTab with matching ids); seed that invariant here.
+      store.setState({
+        tabsByWorktree: {
+          [WT]: [
+            {
+              id: tabA2.entityId,
+              ptyId: null,
+              worktreeId: WT,
+              title: 'Terminal 2',
+              customTitle: null,
+              color: null,
+              sortOrder: 0,
+              createdAt: Date.now()
+            }
+          ]
+        }
+      })
+
+      // tabA2 is NOT the active tab of any group — a bell on it is legitimate.
+      store.getState().markTerminalTabUnread(tabA2.entityId)
+
+      expect(store.getState().unreadTerminalTabs[tabA2.entityId]).toBe(true)
+    })
+
+    // Why: the active-surface guard must only suppress when the user is
+    // actually looking at the terminal. activeTabId remains pinned to the
+    // last terminal tab even when the user has switched to the editor or
+    // browser — in that case the terminal is offscreen and bells are
+    // legitimate unread signals.
+    //
+    // We scope this test to a worktree that is NOT the activeWorktreeId so
+    // the split-group visibility check short-circuits; the test subject is
+    // the activeTabType branch of the guard.
+    it('still marks the tab when the active surface is not terminal', () => {
+      const tab = store.getState().createUnifiedTab(WT, 'terminal')
+      // Point global active* at this tab (matches post-activate state) but
+      // mark a *different* worktree as active so the visible-groups check
+      // does not apply. The only remaining guard is activeTabType, which
+      // we set to 'editor' — the user is NOT looking at this terminal.
+      // Why: seed tabsByWorktree to match the production invariant that
+      // every terminal unified tab has a backing legacy terminal tab —
+      // markTerminalTabUnread now guards against a missing owner tab.
+      store.setState({
+        activeWorktreeId: 'other-wt::/path/x',
+        activeTabId: tab.entityId,
+        activeTabType: 'editor',
+        tabsByWorktree: {
+          [WT]: [
+            {
+              id: tab.entityId,
+              ptyId: null,
+              worktreeId: WT,
+              title: 'Terminal 1',
+              customTitle: null,
+              color: null,
+              sortOrder: 0,
+              createdAt: Date.now()
+            }
+          ]
+        }
+      })
+
+      store.getState().markTerminalTabUnread(tab.entityId)
+
+      expect(store.getState().unreadTerminalTabs[tab.entityId]).toBe(true)
+    })
+
+    it('is a no-op when the tab is already flagged', () => {
+      const tab = store.getState().createUnifiedTab(WT, 'terminal')
+      // Why: seed tabsByWorktree so markTerminalTabUnread's owner-missing guard
+      // (terminals.ts:641-643) doesn't short-circuit — we need to exercise the
+      // "already flagged" branch further down (terminals.ts:673-676).
+      store.setState({
+        unreadTerminalTabs: { [tab.entityId]: true as const },
+        activeTabId: 'something-else',
+        activeTabType: 'terminal',
+        activeWorktreeId: 'other-wt',
+        tabsByWorktree: {
+          [WT]: [
+            {
+              id: tab.entityId,
+              ptyId: null,
+              worktreeId: WT,
+              title: 'Terminal 1',
+              customTitle: null,
+              color: null,
+              sortOrder: 0,
+              createdAt: Date.now()
+            }
+          ]
+        }
+      })
+      const before = store.getState().unreadTerminalTabs
+
+      store.getState().markTerminalTabUnread(tab.entityId)
+
+      // Same object reference => no state mutation occurred.
+      expect(store.getState().unreadTerminalTabs).toBe(before)
+    })
+
+    // Why: markTerminalTabUnread is agent-agnostic — the working→idle
+    // transition in onAgentBecameIdle fires once per Claude task and MUST
+    // raise the dot; blocking it at the store layer would swallow the
+    // completion signal.
+    it('marks unread for an agent tab when it is not focused', () => {
+      const agentTabId = 'agent-tab-1'
+      store.setState({
+        activeTabId: 'something-else',
+        activeTabType: 'terminal',
+        activeWorktreeId: 'other-wt',
+        tabsByWorktree: {
+          [WT]: [
+            {
+              id: agentTabId,
+              ptyId: null,
+              worktreeId: WT,
+              title: '* Claude done',
+              customTitle: null,
+              color: null,
+              sortOrder: 0,
+              createdAt: Date.now()
+            }
+          ]
+        }
+      })
+
+      store.getState().markTerminalTabUnread(agentTabId)
+
+      expect(store.getState().unreadTerminalTabs[agentTabId]).toBe(true)
+    })
+  })
+
+  // ─── focusGroup clears unread on focused group's terminal tab ─────────
+  //
+  // Regression guard: users clicking a group that already had its tab
+  // "active" (so activateTab doesn't run) must still dismiss the indicator
+  // on that group's active terminal tab. Without this, the bell lingers
+  // until the tab is clicked a second time.
+  describe('focusGroup', () => {
+    // Why: focusGroup is fired on every pointerdown within a split group's
+    // chrome (onPointerDown + onFocusCapture in TabGroupPanel). Clearing the
+    // tab-level bell here is fine — the user is now looking at this group.
+    it("clears the tab-level bell on the focused group's active tab", () => {
+      const tabA = store.getState().createUnifiedTab(WT, 'terminal')
+      const groupAId = store.getState().groupsByWorktree[WT][0].id
+      const groupBId = store.getState().createEmptySplitGroup(WT, groupAId, 'right')
+      if (!groupBId) {
+        throw new Error('createEmptySplitGroup returned null')
+      }
+      store.getState().createUnifiedTab(WT, 'terminal', { targetGroupId: groupBId })
+      // Focus Group B first so the active group is not A.
+      store.getState().focusGroup(WT, groupBId)
+
+      // Seed tab-level unread on Group A's terminal tab. Also mark WT as the
+      // active worktree — focusGroup's unread-clear is guarded on
+      // activeWorktreeId to avoid swallowing bells in hidden worktrees.
+      store.setState({
+        unreadTerminalTabs: { [tabA.entityId]: true as const },
+        activeWorktreeId: WT
+      })
+
+      // Clicking Group A's chrome re-focuses the group without necessarily
+      // calling activateTab (its active tab hasn't changed).
+      store.getState().focusGroup(WT, groupAId)
+
+      // Tab-level bell cleared — the user is now viewing this tab.
+      expect(store.getState().unreadTerminalTabs[tabA.entityId]).toBeUndefined()
+    })
+
+    it('clears unread on every visible terminal tab across split groups', () => {
+      const tabA = store.getState().createUnifiedTab(WT, 'terminal')
+      const groupAId = store.getState().groupsByWorktree[WT][0].id
+      const groupBId = store.getState().createEmptySplitGroup(WT, groupAId, 'right')
+      if (!groupBId) {
+        throw new Error('createEmptySplitGroup returned null')
+      }
+      const tabB = store.getState().createUnifiedTab(WT, 'terminal', { targetGroupId: groupBId })
+
+      store.setState({
+        unreadTerminalTabs: {
+          [tabA.entityId]: true as const,
+          [tabB.entityId]: true as const
+        },
+        activeWorktreeId: WT
+      })
+
+      // Why: both groups' active tabs are simultaneously visible in a split
+      // layout, so neither should keep a stale unread bell once the user is
+      // looking at the workspace.
+      store.getState().focusGroup(WT, groupAId)
+
+      expect(store.getState().unreadTerminalTabs[tabA.entityId]).toBeUndefined()
+      expect(store.getState().unreadTerminalTabs[tabB.entityId]).toBeUndefined()
     })
   })
 

--- a/src/renderer/src/store/slices/tabs.ts
+++ b/src/renderer/src/store/slices/tabs.ts
@@ -493,6 +493,24 @@ export const createTabsSlice: StateCreator<AppState, [], [], TabsSlice> = (set, 
         return {}
       }
       const { tab, worktreeId } = found
+      // Why: activating a terminal tab dismisses the tab-level bell — the user
+      // has now moved their eyes to this tab.
+      //
+      // Why (activeWorktree guard below): only dismiss the tab-level bell when
+      // the tab is in the active worktree — otherwise the tab is not visible
+      // yet and the signal would be lost before the user saw it. Mirrors the
+      // guard in focusGroup.
+      const terminalEntityId = tab.contentType === 'terminal' ? tab.entityId : null
+      const nextUnreadTerminalTabs =
+        state.activeWorktreeId === worktreeId &&
+        terminalEntityId &&
+        state.unreadTerminalTabs[terminalEntityId]
+          ? (() => {
+              const copy = { ...state.unreadTerminalTabs }
+              delete copy[terminalEntityId]
+              return copy
+            })()
+          : state.unreadTerminalTabs
       return {
         unifiedTabsByWorktree: {
           ...state.unifiedTabsByWorktree,
@@ -522,7 +540,13 @@ export const createTabsSlice: StateCreator<AppState, [], [], TabsSlice> = (set, 
         activeGroupIdByWorktree: {
           ...state.activeGroupIdByWorktree,
           [worktreeId]: tab.groupId
-        }
+        },
+        // Why: skip writing unreadTerminalTabs when the reference is unchanged —
+        // avoids a no-op top-level state allocation that would force re-evaluation
+        // of full-state selectors. Mirrors focusGroup / reconcileWorktreeTabModel.
+        ...(nextUnreadTerminalTabs !== state.unreadTerminalTabs
+          ? { unreadTerminalTabs: nextUnreadTerminalTabs }
+          : {})
       }
     })
   },
@@ -556,11 +580,21 @@ export const createTabsSlice: StateCreator<AppState, [], [], TabsSlice> = (set, 
       (group.recentTabIds ?? []).filter((id) => id !== tabId),
       remainingOrder
     )
+    const terminalEntityId = tab.contentType === 'terminal' ? tab.entityId : null
 
     set((current) => {
       const nextTabs = (current.unifiedTabsByWorktree[worktreeId] ?? []).filter(
         (item) => item.id !== tabId
       )
+      // Why: closeUnifiedTab can be invoked without going through terminals.closeTab
+      // (e.g., close-to-right / close-others gestures via closeOtherTabs and
+      // closeTabsToRight). The unread-flag map is keyed by terminal entityId and
+      // would otherwise leak a stale dot for a tab that no longer renders.
+      let nextUnreadTerminalTabs = current.unreadTerminalTabs
+      if (terminalEntityId && current.unreadTerminalTabs[terminalEntityId]) {
+        nextUnreadTerminalTabs = { ...current.unreadTerminalTabs }
+        delete nextUnreadTerminalTabs[terminalEntityId]
+      }
       let nextGroups = (current.groupsByWorktree[worktreeId] ?? []).map((candidate) =>
         candidate.id === group.id
           ? {
@@ -599,6 +633,12 @@ export const createTabsSlice: StateCreator<AppState, [], [], TabsSlice> = (set, 
         },
         layoutByWorktree: nextLayoutByWorktree,
         activeGroupIdByWorktree: nextActiveGroupIdByWorktree,
+        // Why: skip writing unreadTerminalTabs when the reference is unchanged —
+        // avoids a no-op top-level state allocation that would force re-evaluation
+        // of full-state selectors. Mirrors focusGroup / reconcileWorktreeTabModel.
+        ...(nextUnreadTerminalTabs !== current.unreadTerminalTabs
+          ? { unreadTerminalTabs: nextUnreadTerminalTabs }
+          : {}),
         // Why: the split-group model can legally derive "terminal with no
         // active tab" after the final unified tab closes. That leaves the
         // worktree selected but render-empty, so the workspace shows a blank
@@ -784,13 +824,55 @@ export const createTabsSlice: StateCreator<AppState, [], [], TabsSlice> = (set, 
         ...state.activeGroupIdByWorktree,
         [worktreeId]: groupId
       }
+      // Why: focusing a split group surfaces whichever terminal tab is already
+      // active in that group, so the tab-level bell is no longer needed.
+      //
+      // Why (activeWorktree guard below): only clear unreadTerminalTabs when
+      // focusing a group within the *active* worktree. If the caller is
+      // focusing a group in a background worktree, that tab is not visible
+      // yet — dismissing its bell here would silently swallow the signal
+      // before the user ever sees the tab. All current callers only fire for
+      // the active worktree, but this guard prevents future misuse.
       if (state.activeWorktreeId !== worktreeId) {
         return {
           activeGroupIdByWorktree: nextActiveGroupIdByWorktree
         }
       }
+      const groups = state.groupsByWorktree[worktreeId] ?? []
+      const unifiedTabs = state.unifiedTabsByWorktree[worktreeId] ?? []
+      const visibleTerminalEntityIds = new Set(
+        groups
+          .map((group) =>
+            group.activeTabId ? unifiedTabs.find((tab) => tab.id === group.activeTabId) : null
+          )
+          .filter((tab): tab is (typeof unifiedTabs)[number] => tab?.contentType === 'terminal')
+          .map((tab) => tab.entityId)
+      )
+      const nextUnreadTerminalTabs =
+        visibleTerminalEntityIds.size > 0
+          ? (() => {
+              let changed = false
+              const copy = { ...state.unreadTerminalTabs }
+              for (const terminalEntityId of visibleTerminalEntityIds) {
+                if (!copy[terminalEntityId]) {
+                  continue
+                }
+                delete copy[terminalEntityId]
+                changed = true
+              }
+              return changed ? copy : state.unreadTerminalTabs
+            })()
+          : state.unreadTerminalTabs
       return {
         activeGroupIdByWorktree: nextActiveGroupIdByWorktree,
+        // Why: only write unreadTerminalTabs back into state when it actually
+        // changed. The IIFE above returns state.unreadTerminalTabs by reference
+        // on no-op; preserving that reference via conditional spread keeps
+        // downstream selectors/subscribers from firing spuriously. This matches
+        // the pattern used by activateTab and closeUnifiedTab.
+        ...(nextUnreadTerminalTabs !== state.unreadTerminalTabs
+          ? { unreadTerminalTabs: nextUnreadTerminalTabs }
+          : {}),
         ...buildActiveSurfacePatch(
           {
             ...state,
@@ -1317,29 +1399,62 @@ export const createTabsSlice: StateCreator<AppState, [], [], TabsSlice> = (set, 
         : state.layoutByWorktree[worktreeId]
 
     if (tabsChanged || groupsChanged || activeGroupChanged || orphanTerminalIds.size > 0) {
-      set((current) => ({
-        unifiedTabsByWorktree: { ...current.unifiedTabsByWorktree, [worktreeId]: validTabs },
-        groupsByWorktree: { ...current.groupsByWorktree, [worktreeId]: nextGroups },
-        activeGroupIdByWorktree: {
-          ...current.activeGroupIdByWorktree,
-          [worktreeId]: nextActiveGroupId
-        },
-        ...(restoredLegacyTabs.length > 0
-          ? {
-              layoutByWorktree: {
-                ...current.layoutByWorktree,
-                // Why: a restored live runtime terminal needs a concrete leaf
-                // in the split-group model before activation runs again.
-                // Without this, the worktree still looks render-empty and the
-                // activation fallback spawns a duplicate "Terminal 2".
-                [worktreeId]: nextLayout!
-              }
+      // Why: when reconcile drops a unified terminal tab (stale persisted id,
+      // dead PTY, closed editor), its entry in unreadTerminalTabs (keyed by the
+      // terminal tab's entityId) would otherwise linger forever and bleed into
+      // downstream persistence/selectors. Mirrors the cleanup in closeUnifiedTab
+      // which removes the unread flag when a terminal tab is torn down.
+      const droppedTerminalEntityIds: string[] = []
+      for (const tab of unifiedTabs) {
+        if (tab.contentType !== 'terminal') {
+          continue
+        }
+        if (!validTabIds.has(tab.id)) {
+          droppedTerminalEntityIds.push(tab.entityId)
+        }
+      }
+      set((current) => {
+        let nextUnreadTerminalTabs = current.unreadTerminalTabs
+        if (droppedTerminalEntityIds.length > 0) {
+          let changed = false
+          const copy = { ...current.unreadTerminalTabs }
+          for (const entityId of droppedTerminalEntityIds) {
+            if (copy[entityId]) {
+              delete copy[entityId]
+              changed = true
             }
-          : {}),
-        ...(orphanTerminalIds.size > 0
-          ? buildOrphanTerminalCleanupPatch(current, worktreeId, orphanTerminalIds)
-          : {})
-      }))
+          }
+          if (changed) {
+            nextUnreadTerminalTabs = copy
+          }
+        }
+        return {
+          unifiedTabsByWorktree: { ...current.unifiedTabsByWorktree, [worktreeId]: validTabs },
+          groupsByWorktree: { ...current.groupsByWorktree, [worktreeId]: nextGroups },
+          activeGroupIdByWorktree: {
+            ...current.activeGroupIdByWorktree,
+            [worktreeId]: nextActiveGroupId
+          },
+          ...(nextUnreadTerminalTabs !== current.unreadTerminalTabs
+            ? { unreadTerminalTabs: nextUnreadTerminalTabs }
+            : {}),
+          ...(restoredLegacyTabs.length > 0
+            ? {
+                layoutByWorktree: {
+                  ...current.layoutByWorktree,
+                  // Why: a restored live runtime terminal needs a concrete leaf
+                  // in the split-group model before activation runs again.
+                  // Without this, the worktree still looks render-empty and the
+                  // activation fallback spawns a duplicate "Terminal 2".
+                  [worktreeId]: nextLayout!
+                }
+              }
+            : {}),
+          ...(orphanTerminalIds.size > 0
+            ? buildOrphanTerminalCleanupPatch(current, worktreeId, orphanTerminalIds)
+            : {})
+        }
+      })
     }
 
     const activeRenderableTabId =

--- a/src/renderer/src/store/slices/terminal-helpers.test.ts
+++ b/src/renderer/src/store/slices/terminal-helpers.test.ts
@@ -58,6 +58,21 @@ describe('clearTransientTerminalState', () => {
     expect(result.title).toBe('bash')
   })
 
+  // Why: idle agent titles (e.g. "* Claude done") are reset to the fallback
+  // on hydration — the prior-session agent is no longer running, so showing
+  // its last title would be misleading.
+  it('resets idle agent titles to fallback across hydration', () => {
+    const tab = makeTab({ title: '* Claude done', customTitle: null })
+    const result = clearTransientTerminalState(tab, 0)
+    expect(result.title).toBe('Terminal 1')
+  })
+
+  it('also resets working agent titles to fallback across hydration', () => {
+    const tab = makeTab({ title: '⠋ Claude working', customTitle: null })
+    const result = clearTransientTerminalState(tab, 0)
+    expect(result.title).toBe('Terminal 1')
+  })
+
   it('uses "Terminal {index+1}" when customTitle is whitespace only', () => {
     const tab = makeTab({ title: '⠋ codex running', customTitle: '   ' })
     const result = clearTransientTerminalState(tab, 0)

--- a/src/renderer/src/store/slices/terminal-helpers.ts
+++ b/src/renderer/src/store/slices/terminal-helpers.ts
@@ -20,5 +20,8 @@ export function clearTransientTerminalState(tab: TerminalTab, index: number): Te
 function getResetTitle(tab: TerminalTab, index: number): string {
   const fallbackTitle =
     tab.customTitle?.trim() || tab.defaultTitle?.trim() || `Terminal ${index + 1}`
+  // Why: reset any recognized agent title on hydration. The prior-session
+  // agent is no longer running after a restart, so showing a stale
+  // "Claude done" or spinner would be misleading.
   return detectAgentStatusFromTitle(tab.title) ? fallbackTitle : tab.title
 }

--- a/src/renderer/src/store/slices/terminals-hydration.test.ts
+++ b/src/renderer/src/store/slices/terminals-hydration.test.ts
@@ -1,9 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('sonner', () => ({ toast: { info: vi.fn(), success: vi.fn(), error: vi.fn() } }))
-vi.mock('@/lib/agent-status', () => ({
-  detectAgentStatusFromTitle: vi.fn().mockReturnValue(null)
-}))
 vi.mock('@/runtime/sync-runtime-graph', () => ({
   scheduleRuntimeGraphSync: vi.fn()
 }))
@@ -122,6 +119,36 @@ describe('hydrateWorkspaceSession', () => {
       ptyIdsByLeafId: { 'pane:1': 'daemon-session-1' },
       buffersByLeafId: { 'pane:1': 'buffer' }
     })
+  })
+
+  it('resets persisted agent titles to the fallback label on hydration', () => {
+    const store = createTestStore()
+    const worktreeId = 'repo1::/wt-1'
+    seedStore(store, {
+      worktreesByRepo: {
+        repo1: [makeWorktree({ id: worktreeId, repoId: 'repo1', path: '/wt-1' })]
+      }
+    })
+
+    const session: WorkspaceSessionState = {
+      activeRepoId: 'repo1',
+      activeWorktreeId: worktreeId,
+      activeTabId: 'tab-1',
+      terminalLayoutsByTabId: {},
+      tabsByWorktree: {
+        [worktreeId]: [makeTab({ id: 'tab-1', worktreeId, title: '* Claude done', ptyId: '207' })]
+      }
+    }
+
+    store.getState().hydrateWorkspaceSession(session)
+
+    expect(store.getState().tabsByWorktree[worktreeId]).toEqual([
+      expect.objectContaining({
+        id: 'tab-1',
+        title: 'Terminal 1',
+        ptyId: null
+      })
+    ])
   })
 
   it('seeds worktree nav history with the restored active worktree', () => {

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -341,8 +341,15 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       delete nextPtyIdsByTabId[tabId]
       const nextRuntimePaneTitlesByTabId = { ...s.runtimePaneTitlesByTabId }
       delete nextRuntimePaneTitlesByTabId[tabId]
-      const nextUnreadTerminalTabs = { ...s.unreadTerminalTabs }
-      delete nextUnreadTerminalTabs[tabId]
+      // Why: preserve the unreadTerminalTabs reference when the closing tab had
+      // no unread flag — avoids a no-op top-level state allocation that would
+      // force re-evaluation of full-state selectors on unrelated closeTab calls.
+      // Mirrors the sibling pattern in tabs.ts (focusGroup, reconcileWorktreeTabModel).
+      let nextUnreadTerminalTabs = s.unreadTerminalTabs
+      if (s.unreadTerminalTabs[tabId]) {
+        nextUnreadTerminalTabs = { ...s.unreadTerminalTabs }
+        delete nextUnreadTerminalTabs[tabId]
+      }
       const nextPendingStartupByTabId = { ...s.pendingStartupByTabId }
       delete nextPendingStartupByTabId[tabId]
       const nextPendingSetupSplitByTabId = { ...s.pendingSetupSplitByTabId }
@@ -401,7 +408,12 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         activeTabIdByWorktree: nextActiveTabIdByWorktree,
         ptyIdsByTabId: nextPtyIdsByTabId,
         runtimePaneTitlesByTabId: nextRuntimePaneTitlesByTabId,
-        unreadTerminalTabs: nextUnreadTerminalTabs,
+        // Why: skip writing unreadTerminalTabs when the reference is unchanged —
+        // avoids a no-op top-level state allocation that would force re-evaluation
+        // of full-state selectors. Mirrors the sibling pattern in tabs.ts.
+        ...(nextUnreadTerminalTabs !== s.unreadTerminalTabs
+          ? { unreadTerminalTabs: nextUnreadTerminalTabs }
+          : {}),
         expandedPaneByTabId: nextExpanded,
         canExpandPaneByTabId: nextCanExpand,
         terminalLayoutsByTabId: nextLayouts,
@@ -863,12 +875,21 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       // tab that is no longer running and cannot be cleared by focus because
       // focus events for a killed pane never arrive. Drop them here so a later
       // remount starts clean.
-      const nextUnreadTerminalTabs = { ...s.unreadTerminalTabs }
+      // Why: preserve the unreadTerminalTabs reference when none of the shutting-
+      // down tabs had an unread flag — avoids a no-op top-level state allocation
+      // that would force re-evaluation of full-state selectors on unrelated
+      // shutdown calls. Mirrors the sibling pattern in tabs.ts.
+      let nextUnreadTerminalTabs = s.unreadTerminalTabs
       for (const tab of tabs) {
         delete nextRuntimePaneTitlesByTabId[tab.id]
         delete nextPendingSetupSplitByTabId[tab.id]
         delete nextPendingIssueCommandSplitByTabId[tab.id]
-        delete nextUnreadTerminalTabs[tab.id]
+        if (nextUnreadTerminalTabs[tab.id]) {
+          if (nextUnreadTerminalTabs === s.unreadTerminalTabs) {
+            nextUnreadTerminalTabs = { ...s.unreadTerminalTabs }
+          }
+          delete nextUnreadTerminalTabs[tab.id]
+        }
         const existingLayout = nextTerminalLayoutsByTabId[tab.id]
         if (existingLayout?.ptyIdsByLeafId) {
           nextTerminalLayoutsByTabId[tab.id] = {
@@ -906,7 +927,12 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         pendingSetupSplitByTabId: nextPendingSetupSplitByTabId,
         pendingIssueCommandSplitByTabId: nextPendingIssueCommandSplitByTabId,
         terminalLayoutsByTabId: nextTerminalLayoutsByTabId,
-        unreadTerminalTabs: nextUnreadTerminalTabs,
+        // Why: skip writing unreadTerminalTabs when the reference is unchanged —
+        // avoids a no-op top-level state allocation that would force re-evaluation
+        // of full-state selectors. Mirrors the sibling pattern in tabs.ts.
+        ...(nextUnreadTerminalTabs !== s.unreadTerminalTabs
+          ? { unreadTerminalTabs: nextUnreadTerminalTabs }
+          : {}),
         browserTabsByWorktree: nextBrowserTabsByWorktree,
         activeBrowserTabIdByWorktree: nextActiveBrowserTabIdByWorktree,
         ...(shouldResetGlobalBrowser

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -52,6 +52,16 @@ export type TerminalSlice = {
   /** Live pane titles keyed by tabId then paneId. Unlike the legacy tab title,
    *  this preserves split-pane agent status per pane while TerminalPane is mounted. */
   runtimePaneTitlesByTabId: Record<string, Record<number, string>>
+  /** Why: per-tab activity indicators. A tab gets flagged unread when an
+   *  agent in any of its panes transitions working→idle (onAgentBecameIdle
+   *  in pty-connection.ts) while the tab is not currently focused. The flag
+   *  clears when the user activates the tab. This is ephemeral UI state
+   *  only — not persisted across restarts.
+   *
+   *  Note: BEL (0x07) bytes intentionally do NOT flip this flag. See the
+   *  long-form rationale in pty-connection.ts around `onAgentBecameIdle`
+   *  for why BEL is too ambiguous to drive cross-surface attention. */
+  unreadTerminalTabs: Record<string, true>
   suppressedPtyExitIds: Record<string, true>
   pendingCodexPaneRestartIds: Record<string, true>
   codexRestartNoticeByPtyId: Record<
@@ -104,6 +114,12 @@ export type TerminalSlice = {
   updateTabTitle: (tabId: string, title: string) => void
   setRuntimePaneTitle: (tabId: string, paneId: number, title: string) => void
   clearRuntimePaneTitle: (tabId: string, paneId: number) => void
+  /** Mark a tab as having unread activity (agent working→idle transition).
+   *  Skipped when the tab is currently visible to the user — either as
+   *  the global active terminal tab, or as the active tab of any split
+   *  group within the active worktree. A visible tab is already "seen",
+   *  so a flag would never clear naturally. */
+  markTerminalTabUnread: (tabId: string) => void
   setTabCustomTitle: (tabId: string, title: string | null) => void
   setTabColor: (tabId: string, color: string | null) => void
   updateTabPtyId: (tabId: string, ptyId: string) => void
@@ -159,6 +175,7 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
   activeTabIdByWorktree: {},
   ptyIdsByTabId: {},
   runtimePaneTitlesByTabId: {},
+  unreadTerminalTabs: {},
   suppressedPtyExitIds: {},
   pendingCodexPaneRestartIds: {},
   codexRestartNoticeByPtyId: {},
@@ -324,6 +341,8 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       delete nextPtyIdsByTabId[tabId]
       const nextRuntimePaneTitlesByTabId = { ...s.runtimePaneTitlesByTabId }
       delete nextRuntimePaneTitlesByTabId[tabId]
+      const nextUnreadTerminalTabs = { ...s.unreadTerminalTabs }
+      delete nextUnreadTerminalTabs[tabId]
       const nextPendingStartupByTabId = { ...s.pendingStartupByTabId }
       delete nextPendingStartupByTabId[tabId]
       const nextPendingSetupSplitByTabId = { ...s.pendingSetupSplitByTabId }
@@ -382,6 +401,7 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         activeTabIdByWorktree: nextActiveTabIdByWorktree,
         ptyIdsByTabId: nextPtyIdsByTabId,
         runtimePaneTitlesByTabId: nextRuntimePaneTitlesByTabId,
+        unreadTerminalTabs: nextUnreadTerminalTabs,
         expandedPaneByTabId: nextExpanded,
         canExpandPaneByTabId: nextCanExpand,
         terminalLayoutsByTabId: nextLayouts,
@@ -463,12 +483,46 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
 
   setActiveTab: (tabId) => {
     set((s) => {
-      const worktreeId = s.activeWorktreeId
+      // Why: focusing a terminal tab clears the tab-level bell — the user has
+      // moved to this tab.
+      //
+      // Why (activeWorktree guard below): only clear when the tab belongs to
+      // the active worktree. If setActiveTab is invoked with a tab from a
+      // background worktree (e.g., during worktree activation, or the
+      // "jump to agent" path), the tab is not yet visible and clearing would
+      // silently swallow the signal. Mirrors the guard in activateTab and
+      // focusGroup.
+      let tabOwnerWorktreeId: string | null = null
+      for (const [wId, tabs] of Object.entries(s.tabsByWorktree)) {
+        if (tabs.some((t) => t.id === tabId)) {
+          tabOwnerWorktreeId = wId
+          break
+        }
+      }
+      const nextUnreadTerminalTabs =
+        tabOwnerWorktreeId === s.activeWorktreeId && s.unreadTerminalTabs[tabId]
+          ? (() => {
+              const copy = { ...s.unreadTerminalTabs }
+              delete copy[tabId]
+              return copy
+            })()
+          : s.unreadTerminalTabs
+      // Why: only write the global activeTabId when the tab belongs to the
+      // currently active worktree. markTerminalTabUnread treats activeTabId
+      // as "the tab the user is looking at" and suppresses BELs on it; if we
+      // pinned activeTabId to a background-worktree tab (e.g. the
+      // jump-to-agent path calls setActiveTab before switching worktrees),
+      // a subsequent BEL on that tab would be silently swallowed. The
+      // per-worktree map still gets updated so the background worktree
+      // remembers its last-active tab for later restoration. Mirrors the
+      // pattern already used above for nextUnreadTerminalTabs.
+      const isActiveWorktreeTab = tabOwnerWorktreeId === s.activeWorktreeId
       return {
-        activeTabId: tabId,
-        activeTabIdByWorktree: worktreeId
-          ? { ...s.activeTabIdByWorktree, [worktreeId]: tabId }
-          : s.activeTabIdByWorktree
+        activeTabId: isActiveWorktreeTab ? tabId : s.activeTabId,
+        activeTabIdByWorktree: tabOwnerWorktreeId
+          ? { ...s.activeTabIdByWorktree, [tabOwnerWorktreeId]: tabId }
+          : s.activeTabIdByWorktree,
+        unreadTerminalTabs: nextUnreadTerminalTabs
       }
     })
     const item = Object.values(get().unifiedTabsByWorktree)
@@ -481,36 +535,45 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
 
   updateTabTitle: (tabId, title) => {
     set((s) => {
-      let changed = false
+      // Why: locate the owning worktree and mutate only that entry in
+      // tabsByWorktree. Rebuilding every worktree's tab array (even when
+      // unchanged) would break shallow-equality checks in unrelated
+      // selectors and trigger spurious re-renders across background
+      // worktrees on every OSC title frame.
       let ownerWorktreeId: string | null = null
-      const next = { ...s.tabsByWorktree }
-      for (const wId of Object.keys(next)) {
-        next[wId] = next[wId].map((t) => {
-          if (t.id !== tabId) {
-            return t
-          }
-          const nextTitle = title.trim() || getFallbackTabTitle(t)
-          if (t.title === nextTitle) {
-            return t
-          }
-          changed = true
-          ownerWorktreeId = wId
-          return {
-            ...t,
-            // Why: PTYs can briefly emit an empty title while an agent exits.
-            // Keep the stable fallback label instead of rendering a blank tab.
-            title: nextTitle,
-            defaultTitle:
-              t.defaultTitle ??
-              (/^Terminal \d+$/.test(t.title) ? t.title : undefined) ??
-              (/^Terminal \d+$/.test(nextTitle) ? nextTitle : undefined)
-          }
-        })
+      let ownerTabs: TerminalTab[] | null = null
+      for (const [wId, tabs] of Object.entries(s.tabsByWorktree)) {
+        const idx = tabs.findIndex((t) => t.id === tabId)
+        if (idx === -1) {
+          continue
+        }
+        const t = tabs[idx]
+        const nextTitle = title.trim() || getFallbackTabTitle(t)
+        if (t.title === nextTitle) {
+          return s
+        }
+        ownerWorktreeId = wId
+        ownerTabs = tabs.map((tab) =>
+          tab.id === tabId
+            ? {
+                ...tab,
+                // Why: PTYs can briefly emit an empty title while an agent exits.
+                // Keep the stable fallback label instead of rendering a blank tab.
+                title: nextTitle,
+                defaultTitle:
+                  tab.defaultTitle ??
+                  (/^Terminal \d+$/.test(tab.title) ? tab.title : undefined) ??
+                  (/^Terminal \d+$/.test(nextTitle) ? nextTitle : undefined)
+              }
+            : tab
+        )
+        break
       }
-      if (!changed) {
+      if (!ownerWorktreeId || !ownerTabs) {
         return s
       }
       scheduleRuntimeGraphSync()
+      const nextTabsByWorktree = { ...s.tabsByWorktree, [ownerWorktreeId]: ownerTabs }
       // Agent status is derived from terminal titles and affects sort scoring,
       // so a title change is a meaningful event that should allow re-sort —
       // but only for background worktrees. Title changes in the active
@@ -520,8 +583,8 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       // on click — the exact bug PR #209 intended to fix.
       const isActive = ownerWorktreeId === s.activeWorktreeId
       return isActive
-        ? { tabsByWorktree: next }
-        : { tabsByWorktree: next, sortEpoch: s.sortEpoch + 1 }
+        ? { tabsByWorktree: nextTabsByWorktree }
+        : { tabsByWorktree: nextTabsByWorktree, sortEpoch: s.sortEpoch + 1 }
     })
     const item = Object.values(get().unifiedTabsByWorktree)
       .flat()
@@ -567,6 +630,50 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       }
 
       return { runtimePaneTitlesByTabId: next }
+    })
+  },
+
+  markTerminalTabUnread: (tabId) => {
+    const state = get()
+    const ownerTab = Object.values(state.tabsByWorktree ?? {})
+      .flat()
+      .find((t) => t.id === tabId)
+    if (!ownerTab) {
+      return
+    }
+    if (state.activeTabType === 'terminal' && state.activeTabId === tabId) {
+      return
+    }
+    // Why: in split-group layouts multiple groups are visible simultaneously,
+    // each with its own active terminal tab. The global activeTabId only
+    // reflects the focused group's tab. If an attention signal fires on a tab
+    // that is the active tab of a non-focused but still-visible group,
+    // marking it unread would show a spurious bell on a pane the user can
+    // already see.
+    //
+    // Why (activeTabType guard): this suppression only applies while the
+    // terminal surface is actually being rendered. When the user is viewing
+    // the editor or browser surface (activeTabType !== 'terminal'), terminal
+    // panes are not on-screen at all, so the "active tab in a visible group"
+    // premise breaks — the user cannot see the tab, and the completion
+    // signal is legitimate unread that must not be swallowed.
+    if (state.activeTabType === 'terminal' && state.activeWorktreeId) {
+      const groups = state.groupsByWorktree[state.activeWorktreeId] ?? []
+      const unifiedTabs = state.unifiedTabsByWorktree[state.activeWorktreeId] ?? []
+      for (const group of groups) {
+        if (group.activeTabId) {
+          const groupActiveTab = unifiedTabs.find((t) => t.id === group.activeTabId)
+          if (groupActiveTab?.contentType === 'terminal' && groupActiveTab.entityId === tabId) {
+            return
+          }
+        }
+      }
+    }
+    set((s) => {
+      if (s.unreadTerminalTabs[tabId]) {
+        return s
+      }
+      return { unreadTerminalTabs: { ...s.unreadTerminalTabs, [tabId]: true as const } }
     })
   },
 
@@ -751,10 +858,17 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       // but non-interactive "zombie" pane. Clearing the per-leaf binding
       // forces a fresh spawn when the user returns to the worktree.
       const nextTerminalLayoutsByTabId = { ...s.terminalLayoutsByTabId }
+      // Why: unread dots survive across worktree switches by design, but a full
+      // shutdown tears down the PTYs behind them — the dot would point at a
+      // tab that is no longer running and cannot be cleared by focus because
+      // focus events for a killed pane never arrive. Drop them here so a later
+      // remount starts clean.
+      const nextUnreadTerminalTabs = { ...s.unreadTerminalTabs }
       for (const tab of tabs) {
         delete nextRuntimePaneTitlesByTabId[tab.id]
         delete nextPendingSetupSplitByTabId[tab.id]
         delete nextPendingIssueCommandSplitByTabId[tab.id]
+        delete nextUnreadTerminalTabs[tab.id]
         const existingLayout = nextTerminalLayoutsByTabId[tab.id]
         if (existingLayout?.ptyIdsByLeafId) {
           nextTerminalLayoutsByTabId[tab.id] = {
@@ -792,6 +906,7 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         pendingSetupSplitByTabId: nextPendingSetupSplitByTabId,
         pendingIssueCommandSplitByTabId: nextPendingIssueCommandSplitByTabId,
         terminalLayoutsByTabId: nextTerminalLayoutsByTabId,
+        unreadTerminalTabs: nextUnreadTerminalTabs,
         browserTabsByWorktree: nextBrowserTabsByWorktree,
         activeBrowserTabIdByWorktree: nextActiveBrowserTabIdByWorktree,
         ...(shouldResetGlobalBrowser

--- a/src/shared/agent-detection.ts
+++ b/src/shared/agent-detection.ts
@@ -17,6 +17,64 @@ const GEMINI_IDLE = '\u25C7' // ◇
 const GEMINI_PERMISSION = '\u270B' // ✋
 
 export const AGENT_NAMES = ['claude', 'codex', 'copilot', 'gemini', 'opencode', 'aider']
+
+// Why: idle keywords used inside `detectAgentStatusFromTitle` to map titles
+// like "Codex done", "OpenCode ready", "Aider idle" to AgentStatus 'idle'.
+// `as const` so consumers receive literal-union types.
+export const STRONG_IDLE_KEYWORDS = ['ready', 'idle', 'done'] as const
+
+// Why: working keywords used inside `detectAgentStatusFromTitle` to map
+// titles like "Codex working", "Aider thinking", "OpenCode running" to
+// AgentStatus 'working'. Shared with `clearWorkingIndicators` so both stay
+// in lock-step when stripping working indicators from stale titles.
+export const STRONG_WORKING_KEYWORDS = ['working', 'thinking', 'running'] as const
+
+// Why: match STRONG_IDLE_KEYWORDS only when not adjacent to characters that
+// would make the "keyword" part of a larger token. Plain `\b` alone is
+// insufficient because `-` is a non-word character in JS regex, so `\bready\b`
+// still matches inside "is-ready-cap" (a `\b` boundary falls between `-` and
+// `r`).
+//
+// Lookarounds are intentionally ASYMMETRIC:
+//   - LEFT: reject `[\w./\\-]` so path fragments like `~/codex/ready`,
+//     Windows `C:\codex\ready`, and `codex.ready` cannot mint a strong idle
+//     signal by having the agent name sit earlier in the same path and the
+//     keyword land right after a path separator. Orca is a cross-platform
+//     Electron app, so Windows path separators must be handled too.
+//   - RIGHT: reject only `[\w\-]` so legitimate sentence-style titles like
+//     "Codex done." / "Aider idle." / "OpenCode ready!" still match — path
+//     separators after the keyword are not a false-positive vector in
+//     practice and blocking them would regress trailing-punctuation titles.
+//
+// Also rejects hyphenated compounds ("is-ready-cap", "re-done") and plain
+// substring false positives ("already"/"redone"/"idleness").
+export const STRONG_IDLE_KEYWORDS_RE = new RegExp(
+  `(?<![\\w./\\\\-])(${STRONG_IDLE_KEYWORDS.join('|')})(?![\\w\\-])`,
+  'i'
+)
+
+// Why: mirrors STRONG_IDLE_KEYWORDS_RE — plain substring matching on the
+// working keywords caused the symmetric class of false positives, e.g.
+// "reworking" ⊃ "working", "overthinking" ⊃ "thinking", "rerunning" ⊃
+// "running", hyphenated compounds like "is-thinking-cap", AND cwd-path
+// fragments like "~/codex/working" or "C:\codex\working". Uses the same
+// asymmetric lookarounds as STRONG_IDLE_KEYWORDS_RE (path separators blocked
+// on the left only so "Codex working." still matches). A false 'working'
+// classification is worse than the idle one because it drives active-agent
+// UI (spinners, counts), so word-char- and left-path-separator-aware
+// matching is required here too.
+export const STRONG_WORKING_KEYWORDS_RE = new RegExp(
+  `(?<![\\w./\\\\-])(${STRONG_WORKING_KEYWORDS.join('|')})(?![\\w\\-])`,
+  'i'
+)
+
+// Why: global-flag companion of STRONG_WORKING_KEYWORDS_RE used by
+// clearWorkingIndicators to strip ALL occurrences in a single pass. Keeps
+// clearing and detection in lock-step — both use identical [\w\-] lookarounds,
+// so `clearWorkingIndicators` no longer strips keywords out of hyphenated
+// compounds like "is-working-cap" that `detectAgentStatusFromTitle` would
+// correctly refuse to classify as working.
+const STRONG_WORKING_KEYWORDS_RE_GLOBAL = new RegExp(STRONG_WORKING_KEYWORDS_RE.source, 'gi')
 const PI_IDLE_PREFIX = '\u03c0 - ' // π - (Pi titlebar extension idle format)
 
 // eslint-disable-next-line no-control-regex -- intentional terminal escape sequence matching
@@ -73,12 +131,10 @@ function containsAgentName(title: string): boolean {
   return AGENT_NAMES.some((name) => lower.includes(name))
 }
 
-function containsAny(title: string, words: string[]): boolean {
+function containsAny(title: string, words: readonly string[]): boolean {
   const lower = title.toLowerCase()
   return words.some((word) => lower.includes(word))
 }
-
-const WORKING_KEYWORDS = ['working', 'thinking', 'running']
 
 /**
  * Strip working-status indicators from a title so that
@@ -104,9 +160,7 @@ export function clearWorkingIndicators(title: string): string {
   // Strip working keywords that detectAgentStatusFromTitle would pick up
   // when the title also contains an agent name.
   if (containsAgentName(cleaned)) {
-    for (const keyword of WORKING_KEYWORDS) {
-      cleaned = cleaned.replace(new RegExp(`\\b${keyword}\\b`, 'gi'), '')
-    }
+    cleaned = cleaned.replace(STRONG_WORKING_KEYWORDS_RE_GLOBAL, '')
   }
 
   // Collapse whitespace after removals
@@ -305,10 +359,21 @@ export function detectAgentStatusFromTitle(title: string): AgentStatus | null {
     if (containsAny(title, ['action required', 'permission', 'waiting'])) {
       return 'permission'
     }
-    if (containsAny(title, ['ready', 'idle', 'done'])) {
+    // Why: hyphen/word-char-aware boundary match (not plain substring, and
+    // stricter than `\b` — which treats `-` as a boundary) so titles like
+    // "~/codex already built" do not classify as idle via the substring
+    // "already" ⊃ "ready". See STRONG_IDLE_KEYWORDS_RE comment.
+    if (STRONG_IDLE_KEYWORDS_RE.test(title)) {
       return 'idle'
     }
-    if (containsAny(title, ['working', 'thinking', 'running'])) {
+    // Why: hyphen/word-char-aware boundary match (not plain substring, and
+    // stricter than `\b`) so titles like "~/codex reworking diff" or
+    // "is-thinking-cap" do not classify as working via the substrings
+    // "reworking" ⊃ "working" or the `-`-adjacent "thinking" in
+    // "is-thinking-cap". Mirrors STRONG_IDLE_KEYWORDS_RE for symmetry; a
+    // false 'working' is worse than a false 'idle' because it drives
+    // active-agent UI (spinners, counts).
+    if (STRONG_WORKING_KEYWORDS_RE.test(title)) {
       return 'working'
     }
 

--- a/src/shared/agent-detection.ts
+++ b/src/shared/agent-detection.ts
@@ -21,13 +21,13 @@ export const AGENT_NAMES = ['claude', 'codex', 'copilot', 'gemini', 'opencode', 
 // Why: idle keywords used inside `detectAgentStatusFromTitle` to map titles
 // like "Codex done", "OpenCode ready", "Aider idle" to AgentStatus 'idle'.
 // `as const` so consumers receive literal-union types.
-export const STRONG_IDLE_KEYWORDS = ['ready', 'idle', 'done'] as const
+const STRONG_IDLE_KEYWORDS = ['ready', 'idle', 'done'] as const
 
 // Why: working keywords used inside `detectAgentStatusFromTitle` to map
 // titles like "Codex working", "Aider thinking", "OpenCode running" to
 // AgentStatus 'working'. Shared with `clearWorkingIndicators` so both stay
 // in lock-step when stripping working indicators from stale titles.
-export const STRONG_WORKING_KEYWORDS = ['working', 'thinking', 'running'] as const
+const STRONG_WORKING_KEYWORDS = ['working', 'thinking', 'running'] as const
 
 // Why: match STRONG_IDLE_KEYWORDS only when not adjacent to characters that
 // would make the "keyword" part of a larger token. Plain `\b` alone is
@@ -88,9 +88,7 @@ const OSC_TITLE_RE = /\x1b\]([012]);([^\x07\x1b]*?)(?:\x07|\x1b\\)/g
  */
 export function extractLastOscTitle(data: string): string | null {
   let last: string | null = null
-  let m: RegExpExecArray | null
-  OSC_TITLE_RE.lastIndex = 0
-  while ((m = OSC_TITLE_RE.exec(data)) !== null) {
+  for (const m of data.matchAll(OSC_TITLE_RE)) {
     last = m[2]
   }
   return last
@@ -241,10 +239,7 @@ export function normalizeTerminalTitle(title: string): string {
   // Why: Pi's titlebar extension animates every 80ms with different braille
   // frames. Collapsing those frames into one stable label avoids renderer
   // churn while preserving the working/idle transition Orca keys off.
-  if (
-    isPiTerminalTitle(title) ||
-    (containsBrailleSpinner(title) && title.includes(PI_IDLE_PREFIX))
-  ) {
+  if (isPiAgentTitle(title)) {
     const status = detectAgentStatusFromTitle(title)
     if (status === 'working') {
       return '\u280b Pi'

--- a/tests/e2e/terminal-attention.spec.ts
+++ b/tests/e2e/terminal-attention.spec.ts
@@ -1,0 +1,273 @@
+import type { Page } from '@stablyai/playwright-test'
+import { test, expect } from './helpers/orca-app'
+import {
+  discoverActivePtyId,
+  execInTerminal,
+  waitForActiveTerminalManager
+} from './helpers/terminal'
+import {
+  ensureTerminalVisible,
+  getActiveTabId,
+  waitForActiveWorktree,
+  waitForSessionReady
+} from './helpers/store'
+import { POST_REPLAY_MODE_RESET } from '../../src/renderer/src/components/terminal-pane/layout-serialization'
+
+test.describe.configure({ mode: 'serial' })
+
+async function createTerminalTab(page: Page, worktreeId: string): Promise<string> {
+  const tabId = await page.evaluate((targetWorktreeId) => {
+    const store = window.__store
+    if (!store) {
+      throw new Error('createTerminalTab: window.__store is unavailable')
+    }
+
+    const state = store.getState()
+    const newTab = state.createTab(targetWorktreeId)
+    state.setActiveTabType('terminal')
+    return newTab.id
+  }, worktreeId)
+
+  await expect
+    .poll(async () => getActiveTabId(page), {
+      timeout: 5_000,
+      message: `Terminal tab ${tabId} did not become active`
+    })
+    .toBe(tabId)
+
+  return tabId
+}
+
+async function activateTerminalTab(page: Page, tabId: string): Promise<void> {
+  await page.evaluate((targetTabId) => {
+    const store = window.__store
+    if (!store) {
+      throw new Error('activateTerminalTab: window.__store is unavailable')
+    }
+    const state = store.getState()
+    state.setActiveTabType('terminal')
+    state.setActiveTab(targetTabId)
+  }, tabId)
+
+  await expect
+    .poll(async () => getActiveTabId(page), {
+      timeout: 5_000,
+      message: `Terminal tab ${tabId} did not become active`
+    })
+    .toBe(tabId)
+}
+
+async function emitBell(page: Page, ptyId: string): Promise<void> {
+  await execInTerminal(page, ptyId, `node -e "process.stdout.write('\\u0007')"`)
+}
+
+async function getUnreadTerminalTabIds(page: Page): Promise<string[]> {
+  return page.evaluate(() => {
+    const store = window.__store
+    if (!store) {
+      return []
+    }
+    return Object.keys(store.getState().unreadTerminalTabs)
+  })
+}
+
+test.describe('Terminal attention', () => {
+  // Why: BEL on a background tab raises the tab-level bell and the
+  // worktree-level dot. Focusing the tab clears the flag — the bell
+  // auto-clears on focus/keystroke. This is the core attention contract.
+  test('a BEL marks a background tab unread and clears on focus', async ({ orcaPage }) => {
+    await waitForSessionReady(orcaPage)
+    const worktreeId = await waitForActiveWorktree(orcaPage)
+    await ensureTerminalVisible(orcaPage)
+    await waitForActiveTerminalManager(orcaPage, 30_000)
+
+    const firstTabId = await getActiveTabId(orcaPage)
+    if (!firstTabId) {
+      throw new Error('Expected an initial terminal tab')
+    }
+
+    const secondTabId = await createTerminalTab(orcaPage, worktreeId)
+    await waitForActiveTerminalManager(orcaPage, 30_000)
+    const secondTabPtyId = await discoverActivePtyId(orcaPage)
+
+    // Focus the first tab so the second becomes a background tab; a BEL
+    // arriving there should raise its indicator.
+    await activateTerminalTab(orcaPage, firstTabId)
+    await emitBell(orcaPage, secondTabPtyId)
+
+    await expect
+      .poll(async () => (await getUnreadTerminalTabIds(orcaPage)).includes(secondTabId), {
+        timeout: 10_000,
+        message: 'Background tab did not become unread after BEL'
+      })
+      .toBe(true)
+
+    const secondTabBell = orcaPage
+      .locator(
+        `[data-testid="sortable-tab"][data-tab-id="${secondTabId}"] [data-testid="tab-activity-bell"]`
+      )
+      .first()
+    await expect(secondTabBell).toBeVisible()
+
+    // Activating the tab counts as "the user saw it" — the indicator clears.
+    await activateTerminalTab(orcaPage, secondTabId)
+
+    await expect
+      .poll(async () => (await getUnreadTerminalTabIds(orcaPage)).includes(secondTabId), {
+        timeout: 5_000,
+        message: 'Unread state did not clear when the user focused the tab'
+      })
+      .toBe(false)
+    await expect(secondTabBell).toBeHidden()
+  })
+
+  // Why (visibility guard): markTerminalTabUnread skips the currently-active
+  // tab. A BEL arriving on the tab the user is already looking at must not
+  // leave a persistent indicator — there is nothing to "notify" about.
+  test('a BEL on the focused tab does not raise its own bell', async ({ orcaPage }) => {
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+    await ensureTerminalVisible(orcaPage)
+    await waitForActiveTerminalManager(orcaPage, 30_000)
+
+    const activeTabId = await getActiveTabId(orcaPage)
+    if (!activeTabId) {
+      throw new Error('Expected an active terminal tab')
+    }
+    const activePtyId = await discoverActivePtyId(orcaPage)
+
+    // Emit the BEL, then a deterministic OSC title marker. When the marker
+    // title lands, all prior PTY bytes (including the BEL) have been
+    // processed — we can then safely assert that the focused tab is not
+    // unread. This avoids the flaky fixed-timeout pattern.
+    await emitBell(orcaPage, activePtyId)
+    const MARKER_TITLE = 'focused-tab-bell-marker'
+    await execInTerminal(
+      orcaPage,
+      activePtyId,
+      `node -e "process.stdout.write('\\u001b]0;${MARKER_TITLE}\\u0007')"`
+    )
+
+    await expect
+      .poll(
+        async () =>
+          orcaPage.evaluate((want) => {
+            const store = window.__store
+            if (!store) {
+              return false
+            }
+            return Object.values(store.getState().tabsByWorktree ?? {})
+              .flat()
+              .some((tab) => tab.title === want)
+          }, MARKER_TITLE),
+        {
+          timeout: 10_000,
+          message: 'Marker title did not land — byte stream may not have been flushed'
+        }
+      )
+      .toBe(true)
+
+    expect((await getUnreadTerminalTabIds(orcaPage)).includes(activeTabId)).toBe(false)
+  })
+
+  // Why (restart regression guard): the original user-reported bug was that
+  // after restarting Orca with a Claude Code session open, clicking between
+  // panes on the restored tab produced undismissable bell indicators. Root
+  // cause: xterm's SerializeAddon captures the TUI's mode-setting bytes
+  // (e.g. `\e[?1004h` for focus reporting) in the scrollback snapshot, and
+  // replaying that snapshot on restart re-enables focus reporting in xterm
+  // even though the underlying shell is fresh. Pane clicks then emit
+  // `\e[I` / `\e[O` into zsh, which rings the bell as unbound-key input.
+  //
+  // POST_REPLAY_MODE_RESET (in layout-serialization.ts) clears these mode
+  // bits after every scrollback replay so the mode state matches the fresh
+  // shell. This test pins that fix: after writing a DECSET 1004 byte into
+  // the terminal, focus events should NOT be emitted back to the PTY.
+  //
+  // We drive xterm directly with the focus-enable escape (simulating what
+  // the replay would do) and then simulate focus changes — without the
+  // reset, xterm would dutifully emit focus escapes; with the reset, mode
+  // 1004 is off and nothing leaks to the shell, so no BELs fire.
+  test('mode bits replayed into xterm do not leak focus escapes to the shell', async ({
+    orcaPage
+  }) => {
+    await waitForSessionReady(orcaPage)
+    const worktreeId = await waitForActiveWorktree(orcaPage)
+    await ensureTerminalVisible(orcaPage)
+    await waitForActiveTerminalManager(orcaPage, 30_000)
+
+    const firstTabId = await getActiveTabId(orcaPage)
+    if (!firstTabId) {
+      throw new Error('Expected an initial terminal tab')
+    }
+
+    const secondTabId = await createTerminalTab(orcaPage, worktreeId)
+    await waitForActiveTerminalManager(orcaPage, 30_000)
+
+    await activateTerminalTab(orcaPage, firstTabId)
+
+    // Simulate what scrollback replay does: a DECSET 1004 byte landing in
+    // xterm. This is the exact byte Claude Code emits at startup, and the
+    // exact byte SerializeAddon captures in a post-restart scrollback dump.
+    // The post-replay reset in layout-serialization.ts should cancel it
+    // out — so this write, immediately followed by the reset, produces a
+    // terminal with mode 1004 off.
+    await orcaPage.evaluate(
+      ({ tabId, modeReset }) => {
+        const managers = window.__paneManagers
+        const manager = managers?.get(tabId)
+        const pane = manager?.getActivePane()
+        if (!pane) {
+          throw new Error('No active pane on restored tab')
+        }
+        // Enable focus reporting and then immediately apply the same reset
+        // the real scrollback-restore path applies. After this, mode 1004
+        // should be OFF.
+        pane.terminal.write('\x1b[?1004h')
+        pane.terminal.write(modeReset)
+      },
+      { tabId: secondTabId, modeReset: POST_REPLAY_MODE_RESET }
+    )
+
+    // If mode 1004 were still on, the tab switch we just did (activate
+    // firstTabId) would have emitted `\e[O` into the shell and produced a
+    // BEL. Flush any pending output with a marker OSC title and assert
+    // that no unread indicator appeared.
+    const secondTabPtyId = await discoverActivePtyId(orcaPage)
+    const MARKER_TITLE = 'mode-reset-marker'
+    await execInTerminal(
+      orcaPage,
+      secondTabPtyId,
+      `node -e "process.stdout.write('\\u001b]0;${MARKER_TITLE}\\u0007')"`
+    )
+
+    await expect
+      .poll(
+        async () =>
+          orcaPage.evaluate((want) => {
+            const store = window.__store
+            if (!store) {
+              return false
+            }
+            return Object.values(store.getState().tabsByWorktree ?? {})
+              .flat()
+              .some((tab) => tab.title === want)
+          }, MARKER_TITLE),
+        {
+          timeout: 10_000,
+          message: 'Marker title did not land — byte stream may not have been flushed'
+        }
+      )
+      .toBe(true)
+
+    // By the time the marker arrives, any BEL that mode 1004 would have
+    // produced has also been processed. The tab should not be unread.
+    expect((await getUnreadTerminalTabIds(orcaPage)).includes(secondTabId)).toBe(false)
+    const secondTabBell = orcaPage
+      .locator(
+        `[data-testid="sortable-tab"][data-tab-id="${secondTabId}"] [data-testid="tab-activity-bell"]`
+      )
+      .first()
+    await expect(secondTabBell).toBeHidden()
+  })
+})

--- a/tests/e2e/terminal-attention.spec.ts
+++ b/tests/e2e/terminal-attention.spec.ts
@@ -204,14 +204,14 @@ test.describe('Terminal attention', () => {
     const secondTabId = await createTerminalTab(orcaPage, worktreeId)
     await waitForActiveTerminalManager(orcaPage, 30_000)
 
-    await activateTerminalTab(orcaPage, firstTabId)
-
-    // Simulate what scrollback replay does: a DECSET 1004 byte landing in
-    // xterm. This is the exact byte Claude Code emits at startup, and the
-    // exact byte SerializeAddon captures in a post-restart scrollback dump.
-    // The post-replay reset in layout-serialization.ts should cancel it
-    // out — so this write, immediately followed by the reset, produces a
-    // terminal with mode 1004 off.
+    // secondTabId is already active after createTerminalTab. Simulate what
+    // scrollback replay does: a DECSET 1004 byte landing in xterm. This is
+    // the exact byte Claude Code emits at startup, and the exact byte
+    // SerializeAddon captures in a post-restart scrollback dump. The
+    // post-replay reset in layout-serialization.ts should cancel it out —
+    // so this write, immediately followed by the reset, produces a terminal
+    // with mode 1004 off. We write while secondTabId has focus so the
+    // DECSET lands on the tab whose xterm we want to verify.
     await orcaPage.evaluate(
       ({ tabId, modeReset }) => {
         const managers = window.__paneManagers
@@ -229,11 +229,50 @@ test.describe('Terminal attention', () => {
       { tabId: secondTabId, modeReset: POST_REPLAY_MODE_RESET }
     )
 
-    // If mode 1004 were still on, the tab switch we just did (activate
-    // firstTabId) would have emitted `\e[O` into the shell and produced a
-    // BEL. Flush any pending output with a marker OSC title and assert
-    // that no unread indicator appeared.
-    const secondTabPtyId = await discoverActivePtyId(orcaPage)
+    // Now trigger a focus change. The DECSET happened while secondTabId was
+    // active; the subsequent focus change to firstTabId causes a focus-out
+    // on secondTabId's xterm. If POST_REPLAY_MODE_RESET failed to disable
+    // mode 1004, xterm would emit `\e[O` down secondTabId's PTY and zsh
+    // would ring the bell. Flush pending output with a marker OSC title
+    // and assert that no unread indicator appeared.
+    await activateTerminalTab(orcaPage, firstTabId)
+
+    // Resolve secondTabId's PTY directly from the store. We can't use
+    // discoverActivePtyId here — firstTabId is the active tab now, so that
+    // helper would return the wrong PTY and the marker flush would not
+    // guarantee secondTabId's pending output has been drained.
+    // Why: waitForActiveTerminalManager only waits for the pane manager to
+    // have panes — it does NOT wait for updateTabPtyId to fire, which
+    // happens asynchronously after pty.spawn resolves in pty-connection.ts.
+    // Poll so we don't race the spawn callback on slow CI.
+    await expect
+      .poll(
+        async () =>
+          orcaPage.evaluate((targetTabId) => {
+            const store = window.__store
+            if (!store) {
+              return null
+            }
+            return store.getState().ptyIdsByTabId[targetTabId]?.[0] ?? null
+          }, secondTabId),
+        {
+          timeout: 10_000,
+          message: `No PTY registered for tab ${secondTabId}`
+        }
+      )
+      .not.toBeNull()
+
+    const secondTabPtyId = await orcaPage.evaluate((targetTabId) => {
+      const store = window.__store
+      if (!store) {
+        throw new Error('window.__store is unavailable')
+      }
+      const pty = store.getState().ptyIdsByTabId[targetTabId]?.[0]
+      if (!pty) {
+        throw new Error(`No PTY found for tab ${targetTabId}`)
+      }
+      return pty
+    }, secondTabId)
     const MARKER_TITLE = 'mode-reset-marker'
     await execInTerminal(
       orcaPage,


### PR DESCRIPTION
## Summary

Per-tab activity indicator (amber wash + bottom accent strip + bell glyph on the tab) driven by the **agent working→idle title transition**, reflecting that BEL alone is too ambiguous to drive cross-surface attention.

### The signal: agent working→idle

- Mark path: `onAgentBecameIdle` in `pty-connection.ts` fires `markWorktreeUnread`, `markTerminalTabUnread`, and `dispatchNotification({ source: 'agent-task-complete' })` on the single per-task transition Claude/Gemini/Codex emit via OSC title.
- Clear path: `setActiveTab` / `activateTab` / `focusGroup` clear the dot, all guarded on the active worktree. Tab-close and worktree-teardown also clean up.
- Visible-group guard: `markTerminalTabUnread` skips marking when the tab is the active tab of any visible split group in the active worktree — no spurious dots on panes the user can already see.

### Why not BEL

We iterated through two BEL-based designs before settling on the title-transition approach:

1. **BEL for all panes** — undismissable dot. Claude Code emits BEL on every render frame; clicking cleared the dot, the next repaint re-flagged it.
2. **BEL for shells, suppressed on agent panes** (via a persisted `wasAgentPane` latch + in-memory `paneIsInAgentMode`) — spurious bells on every pane click. Root cause: xterm.js honors DECSET 1004 (focus-event reporting) when a TUI requests it, and Orca's daemon persists xterm.js state across app restarts by design. If the TUI exits uncleanly (Orca restart while Claude is running, SIGKILL, crash), the mode bit stays set. Every subsequent click emits `\e[I`/`\e[O` into the shell, zsh rings its undefined-key bell, and the bell detector flagged it correctly — but the BELs were noise, not attention.

Terminals with ephemeral state (no cross-restart persistence) dodge the stuck-DECSET problem because closing a tab destroys the Terminal and new tabs start clean. Orca keeps daemon-backed persistence, so the signal source has to be the unambiguous agent title transition instead of BEL.

Full rationale lives in the long-form comment above `onAgentBecameIdle` in `src/renderer/src/components/terminal-pane/pty-connection.ts`.

### What was removed

- `onBell` handler in `pty-connection.ts` + all plumbing in `pty-dispatcher.ts`, `pty-transport.ts`, `pty-connection-types.ts`, `use-terminal-pane-lifecycle.ts`, `TerminalPane.tsx`.
- `paneIsInAgentMode` / `seedClearEligible` in-memory BEL-suppression state.
- Persisted `wasAgentPane` latch from `TerminalTab`, `workspaceSessionSchema`, and hydration backfill.
- `clearTabAgentMode` store action + dependency threading.
- `src/renderer/src/components/terminal-pane/bell-detector.ts` (now orphaned).
- `[notif]` diagnostic `console.log` traces from `pty-connection.ts`, `pty-transport.ts`, `terminals.ts`, `agent-detection.ts`.
- `tests/e2e/terminal-attention-restart.spec.ts` — validated the wasAgentPane hydration path that no longer exists.

### What stayed

- 2s reattach grace window in `pty-transport.ts` that suppresses catch-up working→idle transitions from the daemon's eager-buffer flush. Fixes phantom unread at startup when a prior-session agent's replayed OSC titles would otherwise look like a fresh completion.
- `markTerminalTabUnread` visible-group guard — still needed for the agent-idle signal in split-group layouts.
- `hasStrongAgentSignal` helper (now scoped to `terminal-helpers.ts` for "reset stale agent title on hydration"; no longer gates BEL).

## Test plan

### Unit tests
- [x] `pty-connection.test.ts` — regression guard that `onBell` is never wired; `onAgentBecameIdle` fires worktree unread + tab unread + OS notification; `onAgentExited` clears the prompt-cache countdown.
- [x] `pty-transport.test.ts` — reattach grace suppresses replayed catch-up idle transitions; replay does not fire `onAgentBecameWorking` for historical titles; post-flush live working transitions still fire.
- [x] `tabs.test.ts` / `terminals-hydration.test.ts` / `terminal-helpers.test.ts` — unread clears on tab activation / group focus / tab close / worktree teardown; hydration resets stale agent titles.

### E2E tests (`tests/e2e/terminal-attention.spec.ts`)
- [x] **Positive**: agent working→idle on a background tab raises the dot; focusing the tab clears it.
- [x] **Negative (basic)**: raw BEL bursts on a background tab do NOT raise tab attention.
- [x] **Negative (original bug reproduction)**: DECSET 1004 + `\e[O`/`\e[I` focus-escapes + BEL bursts (the exact byte pattern from the user's console) do NOT raise tab attention.

### Regression-guard verification
Temporarily re-wired `onBell → markTerminalTabUnread` in `pty-connection.ts` + naive BEL detection in `pty-transport.ts` to simulate the regression. Verified:
- Unit: `pty-connection.test.ts › does not wire an onBell handler through to the transport` → **failed** (as expected).
- E2E: `Terminal attention › a raw BEL does not raise tab attention` → **failed** (as expected).
- E2E: `Terminal attention › DECSET 1004 focus-escape BEL churn does not raise tab attention` → **failed** (as expected).
- E2E: `Terminal attention › an agent completion marks a background tab unread and clears on focus` → **still passed** (positive case unaffected by the break).

Restored the fix; all 22 unit tests in the affected files and all 3 e2e tests pass.

### Manual verification
- [x] User confirmed: clicking between panes in a shell with stuck DECSET 1004 no longer produces phantom bells.
- [x] User confirmed: Claude/Gemini/Codex completions still raise the tab dot; the dot clears on focus.
- [x] Same user repro (cat showing `^[[I`/`^[[O` on inter-tab clicks) confirmed stuck DECSET 1004 is a universal "TUI killed uncleanly" issue, not specific to our terminal — it's just hidden in terminals without cross-restart persistence.

## Follow-ups (not in this PR)

- DECSET reset on PTY reconnect in `pty-transport.ts` to clear mode bits leaked by crashed TUIs. Lower priority with BEL no longer driving attention, but still worth doing — stuck 1004 still puts visible `^[[I`/`^[[O` chars into `cat`-like foreground processes.
- Dead-code removal for the `terminalBell` notification setting (`NotificationsPane.tsx`, `settings.terminalBell` branch in `main/ipc/notifications.ts`). Touches settings schema + migration so deferred for a separate pass.