### PR TITLE
fix(ssh): register relay roots on connect and retry file explorer load

### DIFF
--- a/src/main/ipc/ssh-relay-helpers.ts
+++ b/src/main/ipc/ssh-relay-helpers.ts
@@ -25,6 +25,24 @@ import {
 import { registerSshGitProvider, unregisterSshGitProvider } from '../providers/ssh-git-dispatch'
 import type { SshPortForwardManager } from '../ssh/ssh-port-forward'
 import type { SshConnectionManager } from '../ssh/ssh-connection'
+import type { Store } from '../persistence'
+
+// Why: the relay's RelayContext starts with rootsRegistered=false and rejects
+// all FS operations until at least one root is registered via
+// session.registerRoot. This must be called after every relay deploy — both
+// initial connect and reconnection — because each deploy creates a fresh
+// RelayContext on the remote host.
+export function registerRelayRoots(
+  mux: SshChannelMultiplexer,
+  connectionId: string,
+  store: Store
+): void {
+  for (const repo of store.getRepos()) {
+    if (repo.connectionId === connectionId) {
+      mux.notify('session.registerRoot', { rootPath: repo.path })
+    }
+  }
+}
 
 export function cleanupConnection(
   targetId: string,
@@ -98,7 +116,8 @@ export async function reestablishRelayStack(
   getMainWindow: () => BrowserWindow | null,
   connectionManager: SshConnectionManager | null,
   activeMultiplexers: Map<string, SshChannelMultiplexer>,
-  portForwardManager?: SshPortForwardManager | null
+  portForwardManager?: SshPortForwardManager | null,
+  store?: Store | null
 ): Promise<void> {
   const conn = connectionManager?.getConnection(targetId)
   if (!conn) {
@@ -153,6 +172,10 @@ export async function reestablishRelayStack(
 
     const mux = new SshChannelMultiplexer(transport)
     activeMultiplexers.set(targetId, mux)
+
+    if (store) {
+      registerRelayRoots(mux, targetId, store)
+    }
 
     const ptyProvider = new SshPtyProvider(targetId, mux)
     registerSshPtyProvider(targetId, ptyProvider)

--- a/src/main/ipc/ssh.test.ts
+++ b/src/main/ipc/ssh.test.ts
@@ -30,7 +30,8 @@ const {
   mockMux: {
     dispose: vi.fn(),
     isDisposed: vi.fn().mockReturnValue(false),
-    onNotification: vi.fn()
+    onNotification: vi.fn(),
+    notify: vi.fn()
   },
   mockPtyProvider: {
     onData: vi.fn(),
@@ -142,7 +143,7 @@ import type { SshTarget } from '../../shared/ssh-types'
 
 describe('SSH IPC handlers', () => {
   const handlers = new Map<string, (_event: unknown, args: unknown) => unknown>()
-  const mockStore = {} as never
+  const mockStore = { getRepos: () => [] } as never
   const mockWindow = {
     isDestroyed: () => false,
     webContents: { send: vi.fn() }

--- a/src/main/ipc/ssh.ts
+++ b/src/main/ipc/ssh.ts
@@ -13,7 +13,12 @@ import { registerSshGitProvider } from '../providers/ssh-git-dispatch'
 import { SshPortForwardManager } from '../ssh/ssh-port-forward'
 import type { SshTarget, SshConnectionState, SshConnectionStatus } from '../../shared/ssh-types'
 import { isAuthError } from '../ssh/ssh-connection-utils'
-import { cleanupConnection, wireUpSshPtyEvents, reestablishRelayStack } from './ssh-relay-helpers'
+import {
+  cleanupConnection,
+  wireUpSshPtyEvents,
+  reestablishRelayStack,
+  registerRelayRoots
+} from './ssh-relay-helpers'
 import { registerSshBrowseHandler } from './ssh-browse'
 import { requestCredential, registerCredentialHandler } from './ssh-passphrase'
 
@@ -90,7 +95,8 @@ export function registerSshHandlers(
           getMainWindow,
           connectionManager,
           activeMultiplexers,
-          portForwardManager
+          portForwardManager,
+          store
         )
       }
     }
@@ -171,6 +177,8 @@ export function registerSshHandlers(
 
       const mux = new SshChannelMultiplexer(transport)
       activeMultiplexers.set(args.targetId, mux)
+
+      registerRelayRoots(mux, args.targetId, store)
 
       const ptyProvider = new SshPtyProvider(args.targetId, mux)
       registerSshPtyProvider(args.targetId, ptyProvider)

--- a/src/renderer/src/components/right-sidebar/FileExplorer.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorer.tsx
@@ -27,6 +27,7 @@ import { useFileExplorerWatch } from './useFileExplorerWatch'
 function FileExplorerInner(): React.JSX.Element {
   const activeWorktreeId = useAppStore((s) => s.activeWorktreeId)
   const worktreesByRepo = useAppStore((s) => s.worktreesByRepo)
+  const sshConnectedGeneration = useAppStore((s) => s.sshConnectedGeneration)
   const expandedDirs = useAppStore((s) => s.expandedDirs)
   const toggleDir = useAppStore((s) => s.toggleDir)
   const pendingExplorerReveal = useAppStore((s) => s.pendingExplorerReveal)
@@ -136,6 +137,21 @@ function FileExplorerInner(): React.JSX.Element {
     resetAndLoad()
     clearFileExplorerUndoHistory()
   }, [worktreePath]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Why: on app startup the file explorer loads before SSH providers are
+  // registered, so readDir fails for remote worktrees. When the SSH
+  // connection is later established, sshConnectedGeneration bumps and this
+  // effect retries the load. Only retries when there was a prior error to
+  // avoid redundant reloads for local worktrees.
+  const sshGenRef = useRef(sshConnectedGeneration)
+  useEffect(() => {
+    if (sshConnectedGeneration > sshGenRef.current) {
+      sshGenRef.current = sshConnectedGeneration
+      if (worktreePath && rootError) {
+        resetAndLoad()
+      }
+    }
+  }, [sshConnectedGeneration]) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => clearFlashTimeout, [clearFlashTimeout])
 

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -463,6 +463,11 @@ export function useIpcEvents(): void {
         }
 
         if (state.status === 'connected') {
+          // Why: the file explorer may have tried (and failed) to load the tree
+          // before the SSH connection was established. Bumping the generation
+          // lets it detect that providers are now available and retry.
+          store.bumpSshConnectedGeneration()
+
           void Promise.all(remoteRepos.map((r) => store.fetchWorktrees(r.id))).then(() => {
             // Why: terminal panes that failed to spawn (no PTY provider on cold
             // start) sit inert. Bumping generation forces TerminalPane to remount

--- a/src/renderer/src/store/slices/ssh.ts
+++ b/src/renderer/src/store/slices/ssh.ts
@@ -15,16 +15,22 @@ export type SshSlice = {
    * so components can look up labels without per-component IPC calls. */
   sshTargetLabels: Map<string, string>
   sshCredentialQueue: SshCredentialRequest[]
+  /** Incremented when an SSH target transitions to 'connected'. Allows
+   * components like the file explorer to re-trigger data loads that failed
+   * before the connection was established. */
+  sshConnectedGeneration: number
   setSshConnectionState: (targetId: string, state: SshConnectionState) => void
   setSshTargetLabels: (labels: Map<string, string>) => void
   enqueueSshCredentialRequest: (req: SshCredentialRequest) => void
   removeSshCredentialRequest: (requestId: string) => void
+  bumpSshConnectedGeneration: () => void
 }
 
 export const createSshSlice: StateCreator<AppState, [], [], SshSlice> = (set) => ({
   sshConnectionStates: new Map(),
   sshTargetLabels: new Map(),
   sshCredentialQueue: [],
+  sshConnectedGeneration: 0,
 
   setSshConnectionState: (targetId, state) =>
     set((s) => {
@@ -39,5 +45,7 @@ export const createSshSlice: StateCreator<AppState, [], [], SshSlice> = (set) =>
   removeSshCredentialRequest: (requestId) =>
     set((s) => ({
       sshCredentialQueue: s.sshCredentialQueue.filter((req) => req.requestId !== requestId)
-    }))
+    })),
+  bumpSshConnectedGeneration: () =>
+    set((s) => ({ sshConnectedGeneration: s.sshConnectedGeneration + 1 }))
 })


### PR DESCRIPTION
## Summary

- **Relay root registration on connect/reconnect**: `session.registerRoot` was only sent during `repos:add`, not on app restart or SSH reconnection. Each relay deploy creates a fresh `RelayContext` with `rootsRegistered=false`, so all FS operations failed with "No workspace roots registered yet." Now `registerRelayRoots()` is called after every relay deploy — both initial connect and reconnection.
- **File explorer retry after SSH connect**: The file explorer loads immediately on app startup before SSH providers are registered, fails with "No filesystem provider for connection," and never retries. Added `sshConnectedGeneration` counter (same pattern as terminal tab generation) that bumps when SSH transitions to `connected`, triggering the file explorer to retry if it had a prior error.

Closes #912

## Test plan

- [x] Connect to SSH target, add remote repo → file tree populates
- [x] Quit and relaunch → reconnect via popup → file tree populates after reconnect
- [x] Existing unit tests pass (19/19 SSH tests, 188/188 relay+filesystem tests)