### PR TITLE
fix(ui): enable scroll-wheel in CommandList inside Dialog

### DIFF
--- a/src/renderer/src/components/ui/command.tsx
+++ b/src/renderer/src/components/ui/command.tsx
@@ -107,8 +107,12 @@ function CommandInput({
   )
 }
 
-function CommandList({ className, ...props }: React.ComponentProps<typeof CommandPrimitive.List>) {
-  const listRef = React.useRef<HTMLDivElement>(null)
+function CommandList({
+  className,
+  ref,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.List>) {
+  const internalRef = React.useRef<HTMLDivElement>(null)
 
   // Why: Radix Dialog applies react-remove-scroll which calls preventDefault()
   // on wheel events for portaled elements (e.g. Popover) outside the Dialog's
@@ -117,7 +121,7 @@ function CommandList({ className, ...props }: React.ComponentProps<typeof Comman
   // directly on the list takes over scrolling manually so it works regardless
   // of whether a scroll-lock is active.
   React.useEffect(() => {
-    const el = listRef.current
+    const el = internalRef.current
     if (!el) {
       return
     }
@@ -132,9 +136,21 @@ function CommandList({ className, ...props }: React.ComponentProps<typeof Comman
     return () => el.removeEventListener('wheel', onWheel)
   }, [])
 
+  const mergedRef = React.useCallback(
+    (node: HTMLDivElement | null) => {
+      internalRef.current = node
+      if (typeof ref === 'function') {
+        ref(node)
+      } else if (ref) {
+        ref.current = node
+      }
+    },
+    [ref]
+  )
+
   return (
     <CommandPrimitive.List
-      ref={listRef}
+      ref={mergedRef}
       data-slot="command-list"
       className={cn(
         'max-h-[min(400px,60vh)] overflow-y-auto overflow-x-hidden scrollbar-sleek scroll-pb-4 scroll-pt-4',

--- a/src/renderer/src/components/ui/command.tsx
+++ b/src/renderer/src/components/ui/command.tsx
@@ -108,8 +108,33 @@ function CommandInput({
 }
 
 function CommandList({ className, ...props }: React.ComponentProps<typeof CommandPrimitive.List>) {
+  const listRef = React.useRef<HTMLDivElement>(null)
+
+  // Why: Radix Dialog applies react-remove-scroll which calls preventDefault()
+  // on wheel events for portaled elements (e.g. Popover) outside the Dialog's
+  // DOM tree. The scrollbar renders (CSS overflow works) but the browser never
+  // scrolls because the native event is cancelled. A non-passive wheel listener
+  // directly on the list takes over scrolling manually so it works regardless
+  // of whether a scroll-lock is active.
+  React.useEffect(() => {
+    const el = listRef.current
+    if (!el) {
+      return
+    }
+    const onWheel = (e: WheelEvent): void => {
+      if (el.scrollHeight <= el.clientHeight) {
+        return
+      }
+      e.preventDefault()
+      el.scrollTop += e.deltaY
+    }
+    el.addEventListener('wheel', onWheel, { passive: false })
+    return () => el.removeEventListener('wheel', onWheel)
+  }, [])
+
   return (
     <CommandPrimitive.List
+      ref={listRef}
       data-slot="command-list"
       className={cn(
         'max-h-[min(400px,60vh)] overflow-y-auto overflow-x-hidden scrollbar-sleek scroll-pb-4 scroll-pt-4',


### PR DESCRIPTION
## Summary
- Radix Dialog's `react-remove-scroll` blocks native wheel events on portaled elements (Popover) outside the Dialog DOM tree
- This caused the Repository and Agent dropdowns in the Create Workspace modal to show a scrollbar but ignore the scroll wheel
- Adds a non-passive `wheel` listener on `CommandList` that manually applies `scrollTop += deltaY`, bypassing the scroll lock

## Test plan
- [ ] Open Create Workspace dialog, open the Repository dropdown with enough items to scroll — verify scroll wheel works
- [ ] Open the Agent dropdown with enough items to scroll — verify scroll wheel works
- [ ] Open Cmd+P (quick-open) which also uses CommandList — verify scrolling still works normally outside a Dialog context
- [ ] Verify scrollbar drag still works in all dropdowns
- [ ] Verify keyboard navigation (arrow keys) still scrolls items into view