### PR TITLE
feat(terminal): add Windows default shell setting (PowerShell vs CMD)

### DIFF
--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -85,6 +85,7 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     experimentalTerminalDaemon: false,
     experimentalTerminalDaemonNoticeShown: false,
     terminalForceHyperlink: true,
+    terminalWindowsShell: 'powershell.exe',
     ...overrides
   }
 }

--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -79,6 +79,7 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     experimentalTerminalDaemon: false,
     experimentalTerminalDaemonNoticeShown: false,
     terminalForceHyperlink: true,
+    terminalWindowsShell: 'powershell.exe',
     ...overrides
   }
 }

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -455,6 +455,27 @@ describe('registerPtyHandlers', () => {
         expect.any(Object)
       )
     })
+
+    it('uses terminalWindowsShell setting over COMSPEC when provided', () => {
+      // Why: COMSPEC always points to cmd.exe on stock Windows, so without the
+      // setting the terminal would ignore the user's shell preference.
+      process.env.COMSPEC = 'C:\\Windows\\system32\\cmd.exe'
+
+      registerPtyHandlers(mainWindow as never, undefined, undefined, () => ({
+        terminalWindowsShell: 'powershell.exe'
+      } as never))
+      handlers.get('pty:spawn')!(null, { cols: 80, rows: 24 })
+
+      expect(spawnMock).toHaveBeenCalledWith(
+        'powershell.exe',
+        [
+          '-NoExit',
+          '-Command',
+          'try { . $PROFILE } catch {}; [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; [Console]::InputEncoding = [System.Text.Encoding]::UTF8'
+        ],
+        expect.any(Object)
+      )
+    })
   })
 
   it('rejects missing WSL worktree cwd instead of validating only the fallback Windows cwd', async () => {

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -147,6 +147,7 @@ export function registerPtyHandlers(
     localProvider.configure({
       isHistoryEnabled: () => getSettings?.()?.terminalScopeHistoryByWorktree ?? true,
       isForceHyperlinkEnabled: () => getSettings?.()?.terminalForceHyperlink ?? true,
+      getWindowsShell: () => getSettings?.()?.terminalWindowsShell,
       buildSpawnEnv: (id, baseEnv) => {
         const selectedCodexHomePath = getSelectedCodexHomePath?.() ?? null
 

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -98,6 +98,11 @@ export type LocalPtyProviderOptions = {
    *  significant shell-startup slowdown with heavy rc files. When absent,
    *  defaults to the prior behavior (on). */
   isForceHyperlinkEnabled?: () => boolean
+  /** Why: COMSPEC is always cmd.exe on a stock Windows machine, so reading it
+   *  directly would ignore the user's shell preference. This callback lets the
+   *  IPC layer inject the persisted setting without coupling the provider to the
+   *  settings store. Returns undefined when no preference is set. */
+  getWindowsShell?: () => string | undefined
   onSpawned?: (id: string) => void
   onExit?: (id: string, code: number) => void
   onData?: (id: string, data: string, timestamp: number) => void
@@ -134,7 +139,7 @@ export class LocalPtyProvider implements IPtyProvider {
       effectiveCwd = getDefaultCwd()
       validationCwd = cwd
     } else if (process.platform === 'win32') {
-      shellPath = process.env.COMSPEC || 'powershell.exe'
+      shellPath = this.opts.getWindowsShell?.() || process.env.COMSPEC || 'powershell.exe'
       // Why: use path.win32.basename so backslash-separated Windows paths
       // are parsed correctly even when tests mock process.platform on Linux CI.
       const shellBasename = pathWin32.basename(shellPath).toLowerCase()
@@ -447,7 +452,7 @@ export class LocalPtyProvider implements IPtyProvider {
 
   async getDefaultShell(): Promise<string> {
     if (process.platform === 'win32') {
-      return process.env.COMSPEC || 'powershell.exe'
+      return this.opts.getWindowsShell?.() || process.env.COMSPEC || 'powershell.exe'
     }
     return process.env.SHELL || '/bin/zsh'
   }

--- a/src/renderer/src/components/settings/TerminalPane.tsx
+++ b/src/renderer/src/components/settings/TerminalPane.tsx
@@ -329,11 +329,40 @@ export function TerminalPane({
           </SearchableSetting>
         </div>
 
-        {/* Why: the Windows-only right-click toggle lives in this section, so the
-            section must also match that search term or settings search would hide
-            the control even though it is present. */}
-        {isWindows &&
-          matchesSettingsSearch(searchQuery, TERMINAL_RIGHT_CLICK_TO_PASTE_SEARCH_ENTRY) && (
+        {/* Why: Windows-only controls live in this section so the section header
+            stays visible whenever any Windows setting matches the search query. */}
+        {isWindows && matchesSettingsSearch(searchQuery, TERMINAL_RIGHT_CLICK_TO_PASTE_SEARCH_ENTRY) && (
+          <>
+            <SearchableSetting
+              title="Default Shell"
+              description="Choose the default shell for new terminal panes on Windows."
+              keywords={['terminal', 'windows', 'shell', 'powershell', 'cmd', 'command prompt', 'default']}
+              className="space-y-2"
+            >
+              <Label>Default Shell</Label>
+              <div className="flex w-fit gap-1 rounded-md border border-border/50 p-1">
+                {([
+                  { label: 'PowerShell', value: 'powershell.exe' },
+                  { label: 'Command Prompt', value: 'cmd.exe' }
+                ] as const).map(({ label, value }) => (
+                  <button
+                    key={value}
+                    onClick={() => updateSettings({ terminalWindowsShell: value })}
+                    className={`rounded-sm px-3 py-1 text-sm transition-colors ${
+                      (settings.terminalWindowsShell ?? 'powershell.exe') === value
+                        ? 'bg-accent font-medium text-accent-foreground'
+                        : 'text-muted-foreground hover:text-foreground'
+                    }`}
+                  >
+                    {label}
+                  </button>
+                ))}
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Shell used when opening a new terminal pane. Takes effect for new terminals.
+              </p>
+            </SearchableSetting>
+
             <SearchableSetting
               title="Right-click to paste"
               description="On Windows, right-click pastes the clipboard into the terminal. Use Ctrl+right-click to open the context menu."
@@ -366,7 +395,8 @@ export function TerminalPane({
                 />
               </button>
             </SearchableSetting>
-          )}
+          </>
+        )}
 
         <SearchableSetting
           title="Focus Follows Mouse"

--- a/src/renderer/src/components/settings/TerminalPane.tsx
+++ b/src/renderer/src/components/settings/TerminalPane.tsx
@@ -36,7 +36,8 @@ import {
   TERMINAL_PANE_STYLE_SEARCH_ENTRIES,
   TERMINAL_RIGHT_CLICK_TO_PASTE_SEARCH_ENTRY,
   TERMINAL_SETUP_SCRIPT_SEARCH_ENTRIES,
-  TERMINAL_TYPOGRAPHY_SEARCH_ENTRIES
+  TERMINAL_TYPOGRAPHY_SEARCH_ENTRIES,
+  TERMINAL_WINDOWS_SHELL_SEARCH_ENTRY
 } from './terminal-search'
 import { useDetectedOptionAsAlt } from '@/lib/keyboard-layout/use-effective-mac-option-as-alt'
 import { detectedCategoryToDefault } from '@/lib/keyboard-layout/detect-option-as-alt'
@@ -90,6 +91,49 @@ export function TerminalPane({
     scrollbackMode === 'custom' ? 'custom' : isPreset ? `${scrollbackMb}` : 'custom'
 
   const visibleSections = [
+    isWindows && matchesSettingsSearch(searchQuery, TERMINAL_WINDOWS_SHELL_SEARCH_ENTRY) ? (
+      <section key="windows-shell" className="space-y-4">
+        <SearchableSetting
+          title="Default Shell"
+          description="Choose the default shell for new terminal panes on Windows."
+          keywords={[
+            'terminal',
+            'windows',
+            'shell',
+            'powershell',
+            'cmd',
+            'command prompt',
+            'default'
+          ]}
+          className="space-y-2"
+        >
+          <Label>Default Shell</Label>
+          <div className="flex w-fit gap-1 rounded-md border border-border/50 p-1">
+            {(
+              [
+                { label: 'PowerShell', value: 'powershell.exe' },
+                { label: 'Command Prompt', value: 'cmd.exe' }
+              ] as const
+            ).map(({ label, value }) => (
+              <button
+                key={value}
+                onClick={() => updateSettings({ terminalWindowsShell: value })}
+                className={`rounded-sm px-3 py-1 text-sm transition-colors ${
+                  (settings.terminalWindowsShell ?? 'powershell.exe') === value
+                    ? 'bg-accent font-medium text-accent-foreground'
+                    : 'text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Shell used when opening a new terminal pane. Takes effect for new terminals.
+          </p>
+        </SearchableSetting>
+      </section>
+    ) : null,
     matchesSettingsSearch(searchQuery, TERMINAL_TYPOGRAPHY_SEARCH_ENTRIES) ? (
       <section key="typography" className="space-y-4">
         <div className="space-y-1">
@@ -329,40 +373,11 @@ export function TerminalPane({
           </SearchableSetting>
         </div>
 
-        {/* Why: Windows-only controls live in this section so the section header
-            stays visible whenever any Windows setting matches the search query. */}
-        {isWindows && matchesSettingsSearch(searchQuery, TERMINAL_RIGHT_CLICK_TO_PASTE_SEARCH_ENTRY) && (
-          <>
-            <SearchableSetting
-              title="Default Shell"
-              description="Choose the default shell for new terminal panes on Windows."
-              keywords={['terminal', 'windows', 'shell', 'powershell', 'cmd', 'command prompt', 'default']}
-              className="space-y-2"
-            >
-              <Label>Default Shell</Label>
-              <div className="flex w-fit gap-1 rounded-md border border-border/50 p-1">
-                {([
-                  { label: 'PowerShell', value: 'powershell.exe' },
-                  { label: 'Command Prompt', value: 'cmd.exe' }
-                ] as const).map(({ label, value }) => (
-                  <button
-                    key={value}
-                    onClick={() => updateSettings({ terminalWindowsShell: value })}
-                    className={`rounded-sm px-3 py-1 text-sm transition-colors ${
-                      (settings.terminalWindowsShell ?? 'powershell.exe') === value
-                        ? 'bg-accent font-medium text-accent-foreground'
-                        : 'text-muted-foreground hover:text-foreground'
-                    }`}
-                  >
-                    {label}
-                  </button>
-                ))}
-              </div>
-              <p className="text-xs text-muted-foreground">
-                Shell used when opening a new terminal pane. Takes effect for new terminals.
-              </p>
-            </SearchableSetting>
-
+        {/* Why: the Windows-only right-click toggle lives in this section, so the
+            section must also match that search term or settings search would hide
+            the control even though it is present. */}
+        {isWindows &&
+          matchesSettingsSearch(searchQuery, TERMINAL_RIGHT_CLICK_TO_PASTE_SEARCH_ENTRY) && (
             <SearchableSetting
               title="Right-click to paste"
               description="On Windows, right-click pastes the clipboard into the terminal. Use Ctrl+right-click to open the context menu."
@@ -395,8 +410,7 @@ export function TerminalPane({
                 />
               </button>
             </SearchableSetting>
-          </>
-        )}
+          )}
 
         <SearchableSetting
           title="Focus Follows Mouse"

--- a/src/renderer/src/components/settings/terminal-search.ts
+++ b/src/renderer/src/components/settings/terminal-search.ts
@@ -175,12 +175,16 @@ export const TERMINAL_SETUP_SCRIPT_SEARCH_ENTRIES: SettingsSearchEntry[] = [
   }
 ]
 
-export const TERMINAL_WINDOWS_SEARCH_ENTRIES: SettingsSearchEntry[] = [
+export const TERMINAL_WINDOWS_SHELL_SEARCH_ENTRY: SettingsSearchEntry[] = [
   {
     title: 'Default Shell',
     description: 'Choose the default shell for new terminal panes on Windows.',
     keywords: ['terminal', 'windows', 'shell', 'powershell', 'cmd', 'command prompt', 'default']
-  },
+  }
+]
+
+export const TERMINAL_WINDOWS_SEARCH_ENTRIES: SettingsSearchEntry[] = [
+  ...TERMINAL_WINDOWS_SHELL_SEARCH_ENTRY,
   {
     title: 'Right-click to paste',
     description:
@@ -189,7 +193,14 @@ export const TERMINAL_WINDOWS_SEARCH_ENTRIES: SettingsSearchEntry[] = [
   }
 ]
 
-export const TERMINAL_RIGHT_CLICK_TO_PASTE_SEARCH_ENTRY = TERMINAL_WINDOWS_SEARCH_ENTRIES
+export const TERMINAL_RIGHT_CLICK_TO_PASTE_SEARCH_ENTRY: SettingsSearchEntry[] = [
+  {
+    title: 'Right-click to paste',
+    description:
+      'On Windows, right-click pastes the clipboard into the terminal. Use Ctrl+right-click to open the context menu.',
+    keywords: ['terminal', 'windows', 'right click', 'paste', 'context menu']
+  }
+]
 
 export function getTerminalPaneSearchEntries(platform: {
   isWindows: boolean

--- a/src/renderer/src/components/settings/terminal-search.ts
+++ b/src/renderer/src/components/settings/terminal-search.ts
@@ -177,6 +177,11 @@ export const TERMINAL_SETUP_SCRIPT_SEARCH_ENTRIES: SettingsSearchEntry[] = [
 
 export const TERMINAL_WINDOWS_SEARCH_ENTRIES: SettingsSearchEntry[] = [
   {
+    title: 'Default Shell',
+    description: 'Choose the default shell for new terminal panes on Windows.',
+    keywords: ['terminal', 'windows', 'shell', 'powershell', 'cmd', 'command prompt', 'default']
+  },
+  {
     title: 'Right-click to paste',
     description:
       'On Windows, right-click pastes the clipboard into the terminal. Use Ctrl+right-click to open the context menu.',

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -120,6 +120,10 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     // box. Other platforms ignore this field because the UI never exposes it,
     // and Ctrl+right-click still opens the context menu when paste is enabled.
     terminalRightClickToPaste: true,
+    // Why: COMSPEC on a stock Windows machine always resolves to cmd.exe, so
+    // falling back to COMSPEC would silently open CMD instead of PowerShell.
+    // Defaulting to powershell.exe matches what users expect from a modern IDE.
+    terminalWindowsShell: 'powershell.exe',
     // Default false: opt-in only (matches Ghostty's default). Existing users
     // on upgrade inherit this default via persistence.ts's
     // { ...defaults.settings, ...parsed.settings } merge, so enabling

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -654,6 +654,11 @@ export type GlobalSettings = {
    *  The setting stays Windows-only so macOS/Linux keep their existing context
    *  menu behavior and users can still reach the menu with Ctrl+right-click. */
   terminalRightClickToPaste: boolean
+  /** Why: COMSPEC always points to cmd.exe on stock Windows, so without an
+   *  explicit setting the terminal would always open CMD instead of the
+   *  user's preferred shell. Defaults to 'powershell.exe' which is the
+   *  modern choice for an IDE context. Only consulted on Windows. */
+  terminalWindowsShell: string
   terminalFocusFollowsMouse: boolean
   /** Why: mirrors X11 / gnome-terminal "copy on select" UX — making a terminal
    *  selection copies it to the system clipboard automatically, so users can


### PR DESCRIPTION
## Problem

On Windows, `COMSPEC` always resolves to `cmd.exe`, so the terminal always opened CMD regardless of user preference — even though the fallback in the code was `powershell.exe`.

```typescript
// Before: COMSPEC wins every time on a stock Windows machine
shellPath = process.env.COMSPEC || 'powershell.exe'
```

## Solution

Add a persisted `terminalWindowsShell` setting (defaulting to `powershell.exe`) and expose a selector at the top of **Settings → Terminal** so users can switch between PowerShell and Command Prompt.

## Changes

- **`src/shared/types.ts`** — `terminalWindowsShell: string` field added to `GlobalSettings`
- **`src/shared/constants.ts`** — default set to `'powershell.exe'`
- **`src/main/providers/local-pty-provider.ts`** — `getWindowsShell?` callback in `LocalPtyProviderOptions`; used in `spawn()` and `getDefaultShell()` with fallback chain: setting → `COMSPEC` → `powershell.exe`
- **`src/main/ipc/pty.ts`** — wires `getWindowsShell` from `getSettings()` in `configure()`
- **`src/renderer/src/components/settings/TerminalPane.tsx`** — Windows-only shell selector (PowerShell / Command Prompt) as the first item in Terminal settings, above Typography
- **`src/renderer/src/components/settings/terminal-search.ts`** — dedicated `TERMINAL_WINDOWS_SHELL_SEARCH_ENTRY` constant so the selector is independently searchable
- **`src/main/ipc/pty.test.ts`** — test verifying the setting takes precedence over `COMSPEC`

## Behaviour

Existing users upgrading get `powershell.exe` as default via the `{ ...defaults, ...persisted }` merge in `persistence.ts`. The fallback chain preserves backwards compatibility for any code paths that don't go through the settings store.