### PR TITLE
feat(terminal): set TERM_PROGRAM_VERSION on PTY env

### DIFF
--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -35,7 +35,11 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
     ...opts.env,
     TERM: 'xterm-256color',
     COLORTERM: 'truecolor',
-    TERM_PROGRAM: 'Orca'
+    TERM_PROGRAM: 'Orca',
+    // Why: TUIs feature-gate on TERM_PROGRAM_VERSION. The daemon is forked
+    // by main (daemon-init.ts:93) with the parent's env, so ORCA_APP_VERSION
+    // — set in src/main/index.ts from app.getVersion() — is inherited here.
+    TERM_PROGRAM_VERSION: process.env.ORCA_APP_VERSION ?? '0.0.0-dev'
   } as Record<string, string>
 
   env.LANG ??= 'en_US.UTF-8'

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -55,6 +55,11 @@ let runtimeRpc: OrcaRuntimeRpcServer | null = null
 let starNag: StarNagService | null = null
 
 installUncaughtPipeErrorGuard()
+// Why: propagate the Orca app version into `process.env` so PTY-env
+// construction in both main (local-pty-provider) and the forked daemon
+// (pty-subprocess) can set `TERM_PROGRAM_VERSION` without re-importing
+// electron. The daemon inherits `process.env` via fork (daemon-init.ts:93).
+process.env.ORCA_APP_VERSION = app.getVersion()
 patchPackagedProcessPath()
 // Why: patchPackagedProcessPath seeds a minimal list of well-known system
 // dirs synchronously so early IPC (e.g. preflight before the shell spawn

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -261,6 +261,16 @@ describe('registerPtyHandlers', () => {
       expect(env.TERM_PROGRAM).toBe('Orca')
     })
 
+    it('surfaces ORCA_APP_VERSION as TERM_PROGRAM_VERSION for TUI feature gating', async () => {
+      const env = await spawnAndGetEnv(undefined, { ORCA_APP_VERSION: '1.2.3-test' })
+      expect(env.TERM_PROGRAM_VERSION).toBe('1.2.3-test')
+    })
+
+    it('falls back to a placeholder version when ORCA_APP_VERSION is unset', async () => {
+      const env = await spawnAndGetEnv(undefined, { ORCA_APP_VERSION: undefined })
+      expect(env.TERM_PROGRAM_VERSION).toBe('0.0.0-dev')
+    })
+
     it('injects the selected Codex home into Orca terminal PTYs', async () => {
       const env = await spawnAndGetEnv(undefined, undefined, () => '/tmp/orca-codex-home')
       expect(env.CODEX_HOME).toBe('/tmp/orca-codex-home')

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -173,6 +173,11 @@ export class LocalPtyProvider implements IPtyProvider {
       TERM: 'xterm-256color',
       COLORTERM: 'truecolor',
       TERM_PROGRAM: 'Orca',
+      // Why: TUIs feature-gate on TERM_PROGRAM_VERSION (Neovim's termcap
+      // autodetection, bat/delta paging hints). Sourced from ORCA_APP_VERSION
+      // which main/index.ts seeds from app.getVersion() at startup; the
+      // fallback keeps tests and non-Electron runs working.
+      TERM_PROGRAM_VERSION: process.env.ORCA_APP_VERSION ?? '0.0.0-dev',
       FORCE_HYPERLINK: '1'
     } as Record<string, string>
 


### PR DESCRIPTION
## Summary

TUIs feature-gate on `TERM_PROGRAM_VERSION` (Neovim's terminal autodetection, bat/delta styling hints, etc.). We already set `TERM_PROGRAM=Orca` but left the version unset, so tools can't distinguish Orca builds or tell when version-gated features are safe to enable.

This plumbs the Electron app version from `app.getVersion()` through to the spawned shell:

- `src/main/index.ts` seeds `process.env.ORCA_APP_VERSION` once at startup.
- `src/main/providers/local-pty-provider.ts` (main process) reads it into the spawn env.
- `src/main/daemon/pty-subprocess.ts` (daemon) reads it from the inherited env (daemon is `fork()`'d with `{ ...process.env }` — see `daemon-init.ts:93`).

Keeps `local-pty-provider.ts` free of electron imports. Fallback `0.0.0-dev` covers test runs and any non-Electron invocation path.

## Testing

- [x] New tests in `src/main/ipc/pty.test.ts` assert the env var is propagated and that the fallback path works when `ORCA_APP_VERSION` is unset.
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` (affected files: 42/42 passing)