### PR TITLE
fix(editor): debounce rich markdown search and eliminate redundant doc walk

### DIFF
--- a/src/renderer/src/components/editor/markdown-preview-search.ts
+++ b/src/renderer/src/components/editor/markdown-preview-search.ts
@@ -24,9 +24,15 @@ export function findTextMatchRanges(text: string, query: string): { start: numbe
 
     matches.push({
       start: matchStart,
-      end: matchStart + query.length
+      // Why: use normalizedQuery.length (not query.length) because matchStart
+      // is an index into the locale-lowercased text. toLocaleLowerCase() can
+      // change string length (e.g. Turkish İ, German ß→ss), so the original
+      // query length would produce wrong range boundaries.
+      end: matchStart + normalizedQuery.length
     })
-    searchStart = matchStart + query.length
+    // Why: advance by at least 1 to guarantee forward progress even if a
+    // future locale edge-case produces a zero-length normalizedQuery.
+    searchStart = matchStart + Math.max(normalizedQuery.length, 1)
   }
 
   return matches

--- a/src/renderer/src/components/editor/rich-markdown-search.ts
+++ b/src/renderer/src/components/editor/rich-markdown-search.ts
@@ -16,6 +16,7 @@ type RichMarkdownSearchState = {
 
 type RichMarkdownSearchMeta = {
   activeIndex: number
+  matches: RichMarkdownSearchMatch[]
   query: string
 }
 
@@ -76,15 +77,28 @@ export function createRichMarkdownSearchPlugin(): Plugin<RichMarkdownSearchState
           }
         }
 
-        if (!meta && !tr.docChanged) {
-          return pluginState
+        // Why: when meta carries pre-computed matches from the React layer,
+        // build decorations directly without re-walking the document. When the
+        // doc changes without new meta (user edits while searching), remap
+        // existing decorations until the React layer recomputes and dispatches
+        // fresh matches. This avoids the old double-walk that froze the UI.
+        if (meta) {
+          return {
+            activeIndex,
+            decorations: buildSearchDecorationsFromMatches(tr.doc, meta.matches, activeIndex),
+            query
+          }
         }
 
-        return {
-          activeIndex,
-          decorations: buildSearchDecorations(tr.doc, query, activeIndex),
-          query
+        if (tr.docChanged) {
+          return {
+            activeIndex: pluginState.activeIndex,
+            decorations: pluginState.decorations.map(tr.mapping, tr.doc),
+            query: pluginState.query
+          }
         }
+
+        return pluginState
       }
     },
     props: {
@@ -95,12 +109,11 @@ export function createRichMarkdownSearchPlugin(): Plugin<RichMarkdownSearchState
   })
 }
 
-function buildSearchDecorations(
+function buildSearchDecorationsFromMatches(
   doc: ProseMirrorNode,
-  query: string,
+  matches: RichMarkdownSearchMatch[],
   activeIndex: number
 ): DecorationSet {
-  const matches = findRichMarkdownSearchMatches(doc, query)
   if (matches.length === 0) {
     return DecorationSet.empty
   }

--- a/src/renderer/src/components/editor/useRichMarkdownSearch.ts
+++ b/src/renderer/src/components/editor/useRichMarkdownSearch.ts
@@ -25,17 +25,28 @@ export function useRichMarkdownSearch({
   const [searchQuery, setSearchQuery] = useState('')
   const [rawActiveMatchIndex, setRawActiveMatchIndex] = useState(-1)
   const [searchRevision, setSearchRevision] = useState(0)
+  // Why: debouncing the query that drives match computation prevents the
+  // expensive full-doc walk from running on every keystroke — the old
+  // un-debounced path froze the main thread on large documents.
+  const [debouncedQuery, setDebouncedQuery] = useState('')
 
-  // Why: memoizing the match array avoids the old two-effect pattern where both
-  // effects independently called findRichMarkdownSearchMatches on every change.
+  useEffect(() => {
+    if (!searchQuery) {
+      setDebouncedQuery('')
+      return
+    }
+    const timer = setTimeout(() => setDebouncedQuery(searchQuery), 150)
+    return () => clearTimeout(timer)
+  }, [searchQuery])
+
   const matches = useMemo(() => {
-    if (!editor || !isSearchOpen || !searchQuery) {
+    if (!editor || !isSearchOpen || !debouncedQuery) {
       return []
     }
-    return findRichMarkdownSearchMatches(editor.state.doc, searchQuery)
+    return findRichMarkdownSearchMatches(editor.state.doc, debouncedQuery)
     // searchRevision is bumped on ProseMirror doc edits to trigger recomputation
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [editor, isSearchOpen, searchQuery, searchRevision])
+  }, [editor, isSearchOpen, debouncedQuery, searchRevision])
 
   const matchCount = matches.length
 
@@ -63,6 +74,7 @@ export function useRichMarkdownSearch({
   const closeSearch = useCallback(() => {
     setIsSearchOpen(false)
     setSearchQuery('')
+    setDebouncedQuery('')
     setRawActiveMatchIndex(-1)
   }, [])
 
@@ -128,15 +140,18 @@ export function useRichMarkdownSearch({
       return
     }
 
-    const query = isSearchOpen ? searchQuery : ''
+    const query = isSearchOpen ? debouncedQuery : ''
 
     // Why: combining decoration meta and selection+scrollIntoView into one
     // transaction avoids a split-dispatch where the first dispatch updates
     // editor.state and the second dispatch's scrollIntoView can be lost
     // when ProseMirror coalesces view updates.
+    // Why: passing pre-computed matches avoids the plugin re-walking the
+    // entire document — the old double-walk froze the UI on large files.
     const tr = editor.state.tr
     tr.setMeta(richMarkdownSearchPluginKey, {
       activeIndex: activeMatchIndex,
+      matches,
       query
     })
 
@@ -162,7 +177,7 @@ export function useRichMarkdownSearch({
         container.scrollTo({ top: targetScroll, behavior: 'instant' })
       }
     }
-  }, [activeMatchIndex, editor, isSearchOpen, matches, scrollContainerRef, searchQuery])
+  }, [activeMatchIndex, debouncedQuery, editor, isSearchOpen, matches, scrollContainerRef])
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent): void => {


### PR DESCRIPTION
## Summary

- Debounce search query (150ms) before computing matches to prevent the expensive full-doc walk from running on every keystroke
- Pass pre-computed matches to the ProseMirror plugin via transaction meta, eliminating the redundant second doc walk in `buildSearchDecorations`
- On doc changes without new meta, remap existing decorations instead of recomputing
- Fix `findTextMatchRanges` to use `normalizedQuery.length` instead of `query.length` for range boundaries — `toLocaleLowerCase()` can change string length (e.g. Turkish İ, German ß→ss), producing wrong match ranges

## Test plan

- [ ] Open a markdown file in the rich editor, press Cmd+F, type a query — verify highlights appear after a brief debounce
- [ ] Navigate matches with Enter/Shift+Enter — verify scroll-to-match still works
- [ ] Edit the document while search is open — verify decorations remap correctly and update when the React layer dispatches fresh matches
- [ ] Close search (Escape) — verify decorations clear immediately
- [ ] Search for a string containing locale-sensitive characters (e.g. `ß` matching `ss`) — verify correct highlight ranges