### PR TITLE
fix(updater): throttle wake/focus update checks to daily cadence

### DIFF
--- a/src/main/updater-events.ts
+++ b/src/main/updater-events.ts
@@ -101,6 +101,10 @@ export function registerAutoUpdaterHandlers({
     // Guard: don't show an update that isn't actually newer than what's running.
     if (compareVersions(info.version, app.getVersion()) <= 0) {
       clearAvailableUpdateContext()
+      recordCompletedUpdateCheck()
+      if (!wasUserInitiated) {
+        scheduleAutomaticUpdateCheck(24 * 60 * 60 * 1000)
+      }
       sendStatus({ state: 'not-available', userInitiated: wasUserInitiated || undefined })
       return
     }

--- a/src/main/updater-events.ts
+++ b/src/main/updater-events.ts
@@ -13,6 +13,7 @@ import { compareVersions } from './updater-fallback'
 import { fetchChangelog } from './updater-changelog'
 
 type UpdaterHandlerContext = {
+  clearBackgroundCheckLaunchPending: () => void
   clearAvailableUpdateContext: () => void
   getCurrentStatus: () => UpdateStatus
   getKnownReleaseUrl: () => string | undefined
@@ -31,6 +32,7 @@ type UpdaterHandlerContext = {
 }
 
 export function registerAutoUpdaterHandlers({
+  clearBackgroundCheckLaunchPending,
   clearAvailableUpdateContext,
   getCurrentStatus,
   getKnownReleaseUrl,
@@ -88,12 +90,14 @@ export function registerAutoUpdaterHandlers({
   })
 
   autoUpdater.on('checking-for-update', () => {
+    clearBackgroundCheckLaunchPending()
     resetMacInstallState()
     clearAvailableUpdateContext()
     sendStatus({ state: 'checking', userInitiated: getUserInitiatedCheck() || undefined })
   })
 
   autoUpdater.on('update-available', (info) => {
+    clearBackgroundCheckLaunchPending()
     // --- synchronous preamble (runs before any await) ---
     const wasUserInitiated = getUserInitiatedCheck()
     setUserInitiatedCheck(false)
@@ -142,6 +146,7 @@ export function registerAutoUpdaterHandlers({
   })
 
   autoUpdater.on('update-not-available', () => {
+    clearBackgroundCheckLaunchPending()
     resetMacInstallState()
     const wasUserInitiated = getUserInitiatedCheck()
     setUserInitiatedCheck(false)
@@ -154,6 +159,7 @@ export function registerAutoUpdaterHandlers({
   })
 
   autoUpdater.on('download-progress', (progress) => {
+    clearBackgroundCheckLaunchPending()
     sendStatus({
       state: 'downloading',
       percent: Math.round(progress.percent),
@@ -162,6 +168,7 @@ export function registerAutoUpdaterHandlers({
   })
 
   autoUpdater.on('update-downloaded', (info) => {
+    clearBackgroundCheckLaunchPending()
     // Don't show the banner if the downloaded version isn't actually newer
     // than what's running. This catches the exact-same-version case as well
     // as stale cached updates from an older release.
@@ -183,6 +190,7 @@ export function registerAutoUpdaterHandlers({
   })
 
   autoUpdater.on('error', (err) => {
+    clearBackgroundCheckLaunchPending()
     resetMacInstallState()
     const wasUserInitiated = getUserInitiatedCheck()
     setUserInitiatedCheck(false)

--- a/src/main/updater.test.ts
+++ b/src/main/updater.test.ts
@@ -339,6 +339,59 @@ describe('updater', () => {
     expect(setLastUpdateCheckAt).not.toHaveBeenCalled()
   })
 
+  it('deduplicates rapid focus-triggered daily checks before checking status arrives', async () => {
+    let lastUpdateCheckAt = Date.now()
+    const mainWindow = { webContents: { send: vi.fn() } }
+
+    autoUpdaterMock.checkForUpdates.mockImplementation(() => new Promise(() => {}))
+
+    const { setupAutoUpdater } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never, {
+      getLastUpdateCheckAt: () => lastUpdateCheckAt
+    })
+
+    lastUpdateCheckAt = Date.now() - 25 * 60 * 60 * 1000
+    appMock.emit('browser-window-focus')
+    appMock.emit('browser-window-focus')
+
+    expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not persist lastUpdateCheckAt when a focus-triggered check fails benignly', async () => {
+    let lastUpdateCheckAt = Date.now()
+    const setLastUpdateCheckAt = vi.fn()
+    const sendMock = vi.fn()
+    const mainWindow = { webContents: { send: sendMock } }
+
+    autoUpdaterMock.checkForUpdates.mockImplementation(() => {
+      autoUpdaterMock.emit('checking-for-update')
+      queueMicrotask(() => {
+        autoUpdaterMock.emit('error', new Error('net::ERR_FAILED'))
+      })
+      return Promise.reject(new Error('net::ERR_FAILED'))
+    })
+
+    const { setupAutoUpdater } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never, {
+      getLastUpdateCheckAt: () => lastUpdateCheckAt,
+      setLastUpdateCheckAt
+    })
+
+    lastUpdateCheckAt = Date.now() - 25 * 60 * 60 * 1000
+    appMock.emit('browser-window-focus')
+
+    await vi.waitFor(() => {
+      const statuses = sendMock.mock.calls
+        .filter(([channel]) => channel === 'updater:status')
+        .map(([, status]) => status)
+      expect(statuses).toContainEqual({ state: 'idle' })
+    })
+
+    expect(setLastUpdateCheckAt).not.toHaveBeenCalled()
+  })
+
   it('retries background checks sooner after a failed automatic check', async () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-04-03T12:00:00Z'))

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -41,6 +41,7 @@ let autoUpdateCheckTimer: ReturnType<typeof setTimeout> | null = null
 let nudgeCheckTimer: ReturnType<typeof setTimeout> | null = null
 let pendingQuitAndInstallTimer: ReturnType<typeof setTimeout> | null = null
 let persistLastUpdateCheckAt: ((timestamp: number) => void) | null = null
+let _getLastUpdateCheckAt: (() => number | null) | null = null
 let activeUpdateNudgeId: string | null = null
 let awaitingNudgeCheckOutcome = false
 let nudgeCheckInFlight = false
@@ -428,6 +429,7 @@ export function setupAutoUpdater(
   mainWindowRef = mainWindow
   onBeforeQuitCleanup = opts?.onBeforeQuit ?? null
   persistLastUpdateCheckAt = opts?.setLastUpdateCheckAt ?? null
+  _getLastUpdateCheckAt = opts?.getLastUpdateCheckAt ?? null
   _getPendingUpdateNudgeId = opts?.getPendingUpdateNudgeId ?? null
   _getDismissedUpdateNudgeId = opts?.getDismissedUpdateNudgeId ?? null
   _setPendingUpdateNudgeId = opts?.setPendingUpdateNudgeId ?? null
@@ -502,12 +504,23 @@ export function setupAutoUpdater(
   void checkForUpdateNudge()
   scheduleUpdateNudgeCheck()
 
-  powerMonitor.on('resume', () => {
+  const checkDailyOnWake = () => {
     void checkForUpdateNudge()
-  })
-  app.on('browser-window-focus', () => {
-    void checkForUpdateNudge()
-  })
+    // Why: in-flight checks haven't persisted a timestamp yet, so the 24h
+    // gate below would pass and re-fire on rapid focus events.
+    if (currentStatus.state === 'checking' || currentStatus.state === 'downloading') {
+      return
+    }
+    const lastCheck = _getLastUpdateCheckAt?.() ?? null
+    const msSince = lastCheck === null ? Number.POSITIVE_INFINITY : Date.now() - lastCheck
+    if (msSince >= AUTO_UPDATE_CHECK_INTERVAL_MS) {
+      runBackgroundUpdateCheck()
+      scheduleAutomaticUpdateCheck(AUTO_UPDATE_CHECK_INTERVAL_MS)
+    }
+  }
+
+  powerMonitor.on('resume', checkDailyOnWake)
+  app.on('browser-window-focus', checkDailyOnWake)
 
   const lastUpdateCheckAt = opts?.getLastUpdateCheckAt?.() ?? null
   const msSinceLastCheck =

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -42,6 +42,7 @@ let nudgeCheckTimer: ReturnType<typeof setTimeout> | null = null
 let pendingQuitAndInstallTimer: ReturnType<typeof setTimeout> | null = null
 let persistLastUpdateCheckAt: ((timestamp: number) => void) | null = null
 let _getLastUpdateCheckAt: (() => number | null) | null = null
+let backgroundCheckLaunchPending = false
 let activeUpdateNudgeId: string | null = null
 let awaitingNudgeCheckOutcome = false
 let nudgeCheckInFlight = false
@@ -125,6 +126,10 @@ function sendStatus(status: UpdateStatus): void {
   }
   currentStatus = decoratedStatus
   mainWindowRef?.webContents.send('updater:status', decoratedStatus)
+}
+
+function clearBackgroundCheckLaunchPending(): void {
+  backgroundCheckLaunchPending = false
 }
 
 function sendErrorStatus(message: string, userInitiated?: boolean): void {
@@ -255,6 +260,9 @@ function recordCompletedUpdateCheck(): void {
 function runBackgroundUpdateCheck(
   nudgeId: string | null = getPersistedPendingUpdateNudgeId()
 ): void {
+  if (backgroundCheckLaunchPending || currentStatus.state === 'checking') {
+    return
+  }
   if (!app.isPackaged || is.dev) {
     sendStatus({ state: 'not-available' })
     return
@@ -265,9 +273,15 @@ function runBackgroundUpdateCheck(
   // the persisted pending id for ordinary background checks so a nudge-driven
   // card can still be dismissed correctly after relaunch or a later 24h check.
   activeUpdateNudgeId = nudgeId
+  // Why: autoUpdater.checkForUpdates() is async and 'checking-for-update'
+  // arrives on a later tick, so a second focus/resume event can slip in before
+  // currentStatus flips to 'checking'. Track the launch in memory to dedupe
+  // that gap without persisting a successful-check timestamp before the result.
+  backgroundCheckLaunchPending = true
   // Don't send 'checking' here — the 'checking-for-update' event handler does it,
   // and sending it from both places causes duplicate notifications (issue #35).
   autoUpdater.checkForUpdates().catch((err) => {
+    backgroundCheckLaunchPending = false
     void sendCheckFailureStatus(String(err?.message ?? err))
   })
 }
@@ -490,6 +504,7 @@ export function setupAutoUpdater(
     recordCompletedUpdateCheck,
     sendStatus,
     scheduleAutomaticUpdateCheck,
+    clearBackgroundCheckLaunchPending,
     setAvailableReleaseUrl: (releaseUrl) => {
       availableReleaseUrl = releaseUrl
     },
@@ -506,18 +521,16 @@ export function setupAutoUpdater(
 
   const checkDailyOnWake = () => {
     void checkForUpdateNudge()
-    if (currentStatus.state === 'checking' || currentStatus.state === 'downloading') {
+    if (
+      backgroundCheckLaunchPending ||
+      currentStatus.state === 'checking' ||
+      currentStatus.state === 'downloading'
+    ) {
       return
     }
     const lastCheck = _getLastUpdateCheckAt?.() ?? null
     const msSince = lastCheck === null ? Number.POSITIVE_INFINITY : Date.now() - lastCheck
     if (msSince >= AUTO_UPDATE_CHECK_INTERVAL_MS) {
-      // Why: autoUpdater.checkForUpdates() is async and 'checking-for-update'
-      // fires on a later tick, so the state guard above can't block two rapid
-      // focus events (common on macOS window cycling) from both firing a
-      // check. Persist the timestamp synchronously to close the 24h gate
-      // before the second event arrives; a later completion just refreshes it.
-      recordCompletedUpdateCheck()
       runBackgroundUpdateCheck()
       scheduleAutomaticUpdateCheck(AUTO_UPDATE_CHECK_INTERVAL_MS)
     }

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -506,14 +506,18 @@ export function setupAutoUpdater(
 
   const checkDailyOnWake = () => {
     void checkForUpdateNudge()
-    // Why: in-flight checks haven't persisted a timestamp yet, so the 24h
-    // gate below would pass and re-fire on rapid focus events.
     if (currentStatus.state === 'checking' || currentStatus.state === 'downloading') {
       return
     }
     const lastCheck = _getLastUpdateCheckAt?.() ?? null
     const msSince = lastCheck === null ? Number.POSITIVE_INFINITY : Date.now() - lastCheck
     if (msSince >= AUTO_UPDATE_CHECK_INTERVAL_MS) {
+      // Why: autoUpdater.checkForUpdates() is async and 'checking-for-update'
+      // fires on a later tick, so the state guard above can't block two rapid
+      // focus events (common on macOS window cycling) from both firing a
+      // check. Persist the timestamp synchronously to close the 24h gate
+      // before the second event arrives; a later completion just refreshes it.
+      recordCompletedUpdateCheck()
       runBackgroundUpdateCheck()
       scheduleAutomaticUpdateCheck(AUTO_UPDATE_CHECK_INTERVAL_MS)
     }


### PR DESCRIPTION
## Summary
- Wake/focus handlers now gate `runBackgroundUpdateCheck()` behind the same 24h interval as the scheduled timer, so rapid resume/focus events no longer fire repeated update checks
- Persist the last-check timestamp synchronously before the async `autoUpdater.checkForUpdates()` call to avoid a race where two focus events on the same tick both pass the 24h gate
- Record completed-check timestamp and reschedule the auto-check timer in `update-available` when the reported version isn't newer than what's running, keeping the non-newer branch consistent with the `update-not-available` branch

## Test plan
- [ ] Launch packaged build, trigger rapid window focus cycles — only one check fires within 24h
- [ ] Sleep/wake machine — check runs once if >=24h since last
- [ ] Mock an `update-available` with a not-newer version — verify status goes `not-available` and next scheduled check is ~24h out