### PR TITLE
feat(terminal): expose FORCE_HYPERLINK as a user setting (default on)

### DIFF
--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -84,6 +84,7 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     terminalMacOptionAsAltMigrated: true,
     experimentalTerminalDaemon: false,
     experimentalTerminalDaemonNoticeShown: false,
+    terminalForceHyperlink: true,
     ...overrides
   }
 }

--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -78,6 +78,7 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     terminalMacOptionAsAltMigrated: true,
     experimentalTerminalDaemon: false,
     experimentalTerminalDaemonNoticeShown: false,
+    terminalForceHyperlink: true,
     ...overrides
   }
 }

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -146,6 +146,7 @@ export function registerPtyHandlers(
   if (localProvider instanceof LocalPtyProvider) {
     localProvider.configure({
       isHistoryEnabled: () => getSettings?.()?.terminalScopeHistoryByWorktree ?? true,
+      isForceHyperlinkEnabled: () => getSettings?.()?.terminalForceHyperlink ?? true,
       buildSpawnEnv: (id, baseEnv) => {
         const selectedCodexHomePath = getSelectedCodexHomePath?.() ?? null
 

--- a/src/main/providers/local-pty-provider.test.ts
+++ b/src/main/providers/local-pty-provider.test.ts
@@ -120,6 +120,22 @@ describe('LocalPtyProvider', () => {
       expect(spawnCall[2].env.CUSTOM_VAR).toBe('custom-value')
     })
 
+    it('sets FORCE_HYPERLINK=1 by default to preserve legacy behavior', async () => {
+      await provider.spawn({ cols: 80, rows: 24 })
+      const spawnCall = spawnMock.mock.calls.at(-1)!
+      expect(spawnCall[2].env.FORCE_HYPERLINK).toBe('1')
+    })
+
+    it('omits FORCE_HYPERLINK when isForceHyperlinkEnabled returns false', async () => {
+      // Why: users with heavy shell init (oh-my-zsh + p10k + nvm + pyenv) can
+      // disable FORCE_HYPERLINK from Settings. Verify the opt-out reaches the
+      // spawn env so OSC-8-reading tools stop emitting the extra escapes.
+      provider.configure({ isForceHyperlinkEnabled: () => false })
+      await provider.spawn({ cols: 80, rows: 24 })
+      const spawnCall = spawnMock.mock.calls.at(-1)!
+      expect(spawnCall[2].env.FORCE_HYPERLINK).toBeUndefined()
+    })
+
     it('combines HOMEDRIVE and HOMEPATH for Windows default cwd', async () => {
       const platform = Object.getOwnPropertyDescriptor(process, 'platform')
       const originalUserProfile = process.env.USERPROFILE

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -177,8 +177,7 @@ export class LocalPtyProvider implements IPtyProvider {
       // autodetection, bat/delta paging hints). Sourced from ORCA_APP_VERSION
       // which main/index.ts seeds from app.getVersion() at startup; the
       // fallback keeps tests and non-Electron runs working.
-      TERM_PROGRAM_VERSION: process.env.ORCA_APP_VERSION ?? '0.0.0-dev',
-      FORCE_HYPERLINK: '1'
+      TERM_PROGRAM_VERSION: process.env.ORCA_APP_VERSION ?? '0.0.0-dev'
     } as Record<string, string>
 
     spawnEnv.LANG ??= 'en_US.UTF-8'

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -92,6 +92,12 @@ export type LocalPtyProviderOptions = {
   /** Whether worktree-scoped shell history is enabled. When true (or absent)
    *  and a worktreeId is provided, HISTFILE is scoped per-worktree. */
   isHistoryEnabled?: () => boolean
+  /** Whether to set FORCE_HYPERLINK=1 in spawned PTYs. Historically always on;
+   *  now user-togglable because the extra OSC-8 emission branches in oh-my-zsh,
+   *  coreutils, and the Rust supports-hyperlinks crate can compound to a
+   *  significant shell-startup slowdown with heavy rc files. When absent,
+   *  defaults to the prior behavior (on). */
+  isForceHyperlinkEnabled?: () => boolean
   onSpawned?: (id: string) => void
   onExit?: (id: string, code: number) => void
   onData?: (id: string, data: string, timestamp: number) => void
@@ -179,6 +185,21 @@ export class LocalPtyProvider implements IPtyProvider {
       // fallback keeps tests and non-Electron runs working.
       TERM_PROGRAM_VERSION: process.env.ORCA_APP_VERSION ?? '0.0.0-dev'
     } as Record<string, string>
+
+    // Why: FORCE_HYPERLINK=1 is read by oh-my-zsh's supports_hyperlinks(), the
+    // Rust supports-hyperlinks crate, GNU coreutils, and other tooling.
+    // Forcing it on makes every subprocess invoked during shell init take
+    // extra branches and emit OSC-8 escapes, which compounded with a heavy
+    // zshrc (oh-my-zsh + p10k + nvm + pyenv + conda) can 3×+ the startup time
+    // — reported by users as a multi-minute-to-hour "terminal hang."
+    // We keep the historical default (on) so existing users don't lose link
+    // emission silently, but expose it as a toggle so users with heavy rc
+    // files can opt out. Orca's xterm still renders OSC-8 hyperlinks when
+    // tools emit them on their own detection, so link support is preserved
+    // for the typical modern CLI even when this toggle is off.
+    if (this.opts.isForceHyperlinkEnabled?.() ?? true) {
+      spawnEnv.FORCE_HYPERLINK = '1'
+    }
 
     spawnEnv.LANG ??= 'en_US.UTF-8'
 

--- a/src/renderer/src/components/settings/TerminalPane.tsx
+++ b/src/renderer/src/components/settings/TerminalPane.tsx
@@ -657,6 +657,58 @@ export function TerminalPane({
           ) : null}
         </SearchableSetting>
 
+        <SearchableSetting
+          title="Force Hyperlink Escapes"
+          description="Set FORCE_HYPERLINK=1 in every terminal so tools emit OSC-8 clickable links. Turn off if your shell startup is slow."
+          keywords={[
+            'terminal',
+            'hyperlink',
+            'link',
+            'osc',
+            'osc8',
+            'osc-8',
+            'force_hyperlink',
+            'slow',
+            'startup',
+            'zsh',
+            'zshrc',
+            'oh-my-zsh',
+            'p10k',
+            'powerlevel10k'
+          ]}
+          className="flex items-center justify-between gap-4 px-1 py-2"
+        >
+          <div className="space-y-0.5">
+            <Label>Force Hyperlink Escapes</Label>
+            <p className="text-xs text-muted-foreground">
+              Sets{' '}
+              <code className="rounded bg-muted px-1 py-0.5 text-[11px]">FORCE_HYPERLINK=1</code> in
+              every spawned terminal so tools like <code>ls</code>, <code>git</code>, and{' '}
+              <code>eza</code> emit OSC-8 clickable links. Disable if your shell startup feels slow
+              — heavy setups (oh-my-zsh, powerlevel10k, nvm, pyenv, conda) can take measurably
+              longer with this on. Only affects newly spawned terminals.
+            </p>
+          </div>
+          <button
+            role="switch"
+            aria-checked={settings.terminalForceHyperlink}
+            onClick={() =>
+              updateSettings({
+                terminalForceHyperlink: !settings.terminalForceHyperlink
+              })
+            }
+            className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent transition-colors ${
+              settings.terminalForceHyperlink ? 'bg-foreground' : 'bg-muted-foreground/30'
+            }`}
+          >
+            <span
+              className={`pointer-events-none block size-3.5 rounded-full bg-background shadow-sm transition-transform ${
+                settings.terminalForceHyperlink ? 'translate-x-4' : 'translate-x-0.5'
+              }`}
+            />
+          </button>
+        </SearchableSetting>
+
         {isMac ? (
           <SearchableSetting
             title="Option as Alt"

--- a/src/renderer/src/components/settings/terminal-search.ts
+++ b/src/renderer/src/components/settings/terminal-search.ts
@@ -108,6 +108,27 @@ export const TERMINAL_ADVANCED_SEARCH_ENTRIES: SettingsSearchEntry[] = [
     title: 'Scrollback Size',
     description: 'Maximum terminal scrollback buffer size.',
     keywords: ['terminal', 'scrollback', 'buffer', 'memory']
+  },
+  {
+    title: 'Force Hyperlink Escapes',
+    description:
+      'Set FORCE_HYPERLINK=1 in every terminal so tools emit OSC-8 clickable links. Turn off if your shell startup is slow.',
+    keywords: [
+      'terminal',
+      'hyperlink',
+      'link',
+      'osc',
+      'osc8',
+      'osc-8',
+      'force_hyperlink',
+      'slow',
+      'startup',
+      'zsh',
+      'zshrc',
+      'oh-my-zsh',
+      'p10k',
+      'powerlevel10k'
+    ]
   }
 ]
 

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -153,7 +153,12 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     terminalMacOptionAsAlt: 'auto',
     terminalMacOptionAsAltMigrated: false,
     experimentalTerminalDaemon: false,
-    experimentalTerminalDaemonNoticeShown: false
+    experimentalTerminalDaemonNoticeShown: false,
+    // Why: keep the historical default (on) so no existing user's terminal
+    // loses clickable-link emission on upgrade. Users with heavy zshrc setups
+    // can disable it from Settings → Terminal → Advanced to reclaim startup
+    // time.
+    terminalForceHyperlink: true
   }
 }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -714,6 +714,15 @@ export type GlobalSettings = {
    *  toast shown to users upgrading from v1.3.0 (where the daemon was on by
    *  default). Set to true the first time the toast fires so it never repeats. */
   experimentalTerminalDaemonNoticeShown: boolean
+  /** When true, Orca sets FORCE_HYPERLINK=1 in every spawned PTY's env. That
+   *  makes modern CLIs (oh-my-zsh's supports_hyperlinks(), coreutils, the Rust
+   *  supports-hyperlinks crate, etc.) emit OSC-8 hyperlink escapes even when
+   *  they would otherwise skip them. Defaults to true to preserve prior
+   *  behavior, but users with heavy shell init (large oh-my-zsh / p10k / nvm /
+   *  pyenv / conda setups) can measurably speed up terminal start by turning
+   *  this off — the extra branching and escape emission across the many
+   *  subshells fired during rc init can multiply startup time. */
+  terminalForceHyperlink: boolean
 }
 
 export type NotificationEventSource = 'agent-task-complete' | 'terminal-bell' | 'test'


### PR DESCRIPTION
## Summary

Users with heavy `.zshrc` files (oh-my-zsh + powerlevel10k + nvm + pyenv + conda, etc.) reported their Orca terminal taking an extremely long time — effectively never — to become ready for input after opening. Wiping the zshrc made it disappear, and VS Code's xterm (same library) worked fine for the same user.

Root cause: we set **`FORCE_HYPERLINK=1`** on every local PTY. This variable is a de-facto convention read by:

- oh-my-zsh's `supports_hyperlinks()` helper
- the Rust `supports-hyperlinks` crate (used by `delta`, `bat`, `eza`, `fd`, etc.)
- GNU coreutils with `--hyperlink=auto`

Forcing it on causes every subprocess spawned during shell init to take extra branches and emit OSC-8 escapes. Stacked with the dozens of subshells a heavy zshrc fires, it compounds into a significant startup slowdown — and on some users' real machines, effectively a hang.

## Repro & measurement

Sandboxed `$HOME` with oh-my-zsh + powerlevel10k + nvm + pyenv, spawned via Orca's `node-pty` module:

| Scenario | Time to prompt-ready |
|---|---|
| Current Orca (`zsh -l`, `TERM_PROGRAM=Orca`, **`FORCE_HYPERLINK=1`**) | **1964 ms** |
| Drop `FORCE_HYPERLINK` | 618 ms |
| VS-Code-like (`zsh -i`, `TERM_PROGRAM=vscode`) | 553 ms |

**3.2× slowdown from the variable alone**, on a clean sandbox with only the OMZ/p10k/nvm/pyenv core. Real setups layer more on top (conda init, gcloud completions, compaudit over Homebrew paths, corporate network).

## What ships

Keep the historical default (**on**) so no existing user silently loses clickable-link emission from tooling that checks this flag on upgrade. **But expose a toggle** under Settings → Terminal → Advanced so users with heavy rc files can disable it and reclaim startup time.

- `GlobalSettings.terminalForceHyperlink: boolean` (default `true`)
- `LocalPtyProvider` gets an `isForceHyperlinkEnabled` hook; the IPC layer wires it from the live settings snapshot
- New `SearchableSetting` row in the Advanced section with zshrc/oh-my-zsh/p10k search keywords so users troubleshooting slow startup can find it
- Two new unit tests cover the default-on and opt-out paths

## Test plan

- [ ] Install & open a terminal in a worktree with a heavy zshrc — default behavior unchanged (hyperlinks still emitted)
- [ ] Settings → Terminal → Advanced → turn off "Force Hyperlink Escapes" → open a new terminal → confirm `env | grep FORCE_HYPERLINK` is empty and shell-startup feels faster
- [ ] Settings search for "hyperlink" or "slow" or "startup" finds the toggle
- [ ] `pnpm vitest run src/main/providers/local-pty-provider.test.ts` (25/25)
- [ ] `pnpm typecheck` passes
