### PR TITLE
fix(editor): stop fading identifiers in .tsx/.jsx diffs

### DIFF
--- a/src/renderer/src/lib/monaco-setup.ts
+++ b/src/renderer/src/lib/monaco-setup.ts
@@ -33,15 +33,31 @@ globalThis.MonacoEnvironment = {
 // Why: Monaco's built-in TypeScript worker runs in isolation without filesystem
 // access, so it cannot resolve imports to project files that aren't open as
 // editor models. This produces false "Cannot find module" diagnostics for every
-// import statement. Ignoring specific TS diagnostic codes (e.g., 2307, 2792)
-// removes this noise while keeping type checking, auto-complete, and basic
-// validation fully functional for local symbols.
-monacoTS.typescriptDefaults.setDiagnosticsOptions({
-  diagnosticCodesToIgnore: [2307, 2792]
-})
-monacoTS.javascriptDefaults.setDiagnosticsOptions({
-  diagnosticCodesToIgnore: [2307, 2792]
-})
+// import statement (2307/2792) and false "unused import/local" diagnostics
+// (6133/6138/6192/6196/6198/6205) because cross-file references are invisible
+// to the worker. Those "unused" diagnostics carry the `reportsUnnecessary` tag,
+// which Monaco renders by fading the identifier to 0.667 opacity via
+// `.squiggly-inline-unnecessary` — in a diff view that looks like Orca's
+// diff renderer is muting lines. Disable suggestion diagnostics entirely
+// (where most of these originate) and ignore the specific error codes that
+// still fire as semantic diagnostics. Keep syntax + semantic validation on
+// so genuine parse errors and type mismatches in the open model still surface.
+const diagnosticsOptions = {
+  noSuggestionDiagnostics: true,
+  diagnosticCodesToIgnore: [
+    2307, // Cannot find module
+    2792, // Cannot find module (did you mean …)
+    6133, // 'x' is declared but its value is never read
+    6138, // Property 'x' is declared but its value is never read
+    6192, // All imports in import declaration are unused
+    6196, // 'x' is declared but never used
+    6198, // All destructured elements are unused
+    6205, // All type parameters are unused
+    6385 // 'x' is deprecated
+  ]
+}
+monacoTS.typescriptDefaults.setDiagnosticsOptions(diagnosticsOptions)
+monacoTS.javascriptDefaults.setDiagnosticsOptions(diagnosticsOptions)
 
 // Why: .tsx/.jsx files share the base 'typescript'/'javascript' language ids
 // in Monaco's registry (there is no separate 'typescriptreact' id), so the


### PR DESCRIPTION
## Summary

Follow-up to #878. After `.tsx`/`.jsx` were routed to Monaco's base `typescript`/`javascript` language ids, the TS worker started running semantic analysis on files it cannot fully resolve — no tsconfig, no filesystem, no sibling models. Every imported component and destructured prop came back tagged as "unused", which Monaco renders at `opacity: 0.667` via `.squiggly-inline-unnecessary`. In a diff view this looks like Orca is dimming arbitrary lines — see the reports in [Slack](https://stablygroup.slack.com/archives/C0ASMDT6LQZ/p1776877852127819).

Fix (`src/renderer/src/lib/monaco-setup.ts`):

- Set `noSuggestionDiagnostics: true` on the TS/JS defaults so the worker stops emitting the suggestion-level "unnecessary" markers.
- Expand `diagnosticCodesToIgnore` with the unused/deprecated codes (`6133`, `6138`, `6192`, `6196`, `6198`, `6205`, `6385`) that still fire as semantic diagnostics.
- Keep syntax + semantic validation on — genuine parse errors and type mismatches on the open model still surface.

## Test plan

- [x] Reproduced: opened a `.tsx` diff in the dev app, counted `.squiggly-inline-unnecessary` spans — **10** (e.g. `ChevronDown`, `TooltipTrigger`, `event`, `type=\"button\"`).
- [x] After the fix, same diff → **0** faded spans.
- [x] `pnpm run typecheck`
- [x] `pnpm run lint` (no new warnings)