### PR TITLE
fix: resolve issues page flickering and tile memory exhaustion

### DIFF
--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -972,7 +972,7 @@ export default function TaskPage(): React.JSX.Element {
                             {item.labels.slice(0, 3).map((label) => (
                               <span
                                 key={label}
-                                className="rounded-full border border-border/50 bg-background/50 backdrop-blur-md px-1.5 py-0 text-[10px] text-muted-foreground supports-[backdrop-filter]:bg-background/50"
+                                className="rounded-full border border-border/50 bg-background/80 px-1.5 py-0 text-[10px] text-muted-foreground"
                               >
                                 {label}
                               </span>
@@ -1020,7 +1020,7 @@ export default function TaskPage(): React.JSX.Element {
                               e.stopPropagation()
                               handleUseWorkItem(item)
                             }}
-                            className="inline-flex items-center gap-1 rounded-md border border-border/50 bg-background/50 backdrop-blur-md px-2 py-1 text-[11px] text-foreground transition hover:bg-muted/60 supports-[backdrop-filter]:bg-background/50"
+                            className="inline-flex items-center gap-1 rounded-md border border-border/50 bg-background/80 px-2 py-1 text-[11px] text-foreground transition hover:bg-muted/60"
                           >
                             Use
                             <ArrowRight className="size-3" />

--- a/src/renderer/src/components/tab-group/useTabDragSplit.ts
+++ b/src/renderer/src/components/tab-group/useTabDragSplit.ts
@@ -167,16 +167,16 @@ export function useTabDragSplit({
   const [activeDrag, setActiveDrag] = useState<TabDragItemData | null>(null)
   const [hoveredDropTarget, setHoveredDropTarget] = useState<HoveredTabDropTarget | null>(null)
 
-  const pointerSensor = useSensor(PointerSensor, {
-    activationConstraint: { distance: 5 }
-  })
-  const activeSensors = useSensors(pointerSensor)
-  const emptySensors = useSensors()
   // Why: hidden worktrees stay mounted so their PTYs survive worktree
-  // switches, but their DndContext should not register pointer listeners
-  // on the document. Multiple active DndContext instances can interfere
-  // with each other.
-  const sensors = enabled ? activeSensors : emptySensors
+  // switches, but their DndContext should not activate drags. We use an
+  // impossible activation distance rather than switching between
+  // useSensors(ptr) / useSensors(), because dnd-kit internally spreads
+  // the sensors array into a useEffect dependency list — changing its
+  // length between renders violates React's rules of hooks.
+  const pointerSensor = useSensor(PointerSensor, {
+    activationConstraint: { distance: enabled ? 5 : Number.MAX_SAFE_INTEGER }
+  })
+  const sensors = useSensors(pointerSensor)
 
   const clearDragState = useCallback(() => {
     setActiveDrag(null)


### PR DESCRIPTION
## Summary
- **useEffect dep array size change**: `useTabDragSplit` toggled between `useSensors(pointerSensor)` (length 1) and `useSensors()` (length 0) based on `enabled`. dnd-kit spreads the sensors array into an internal `useEffect` dependency list, so changing its length violates React's rules of hooks — causing constant re-renders and the console error. Fixed by always passing one sensor with `Number.MAX_SAFE_INTEGER` activation distance when disabled.
- **Tile memory exhaustion**: Each row in the issues list applied `backdrop-blur-md` to label badges (up to 3) and the "Use" button. With 36 rows, that's ~144 separate compositor layers, exceeding Chromium's tile memory budget and causing blank rows / glitchy rendering. Replaced with opaque `bg-background/80`.

Regression from #732 (`feat: support dragging tabs into new split panes`).

## Test plan
- [ ] Open the issues page with 20+ items — verify no blank rows or flickering
- [ ] Check console for absence of `tile memory limits exceeded` warnings
- [ ] Check console for absence of `useEffect changed size between renders` error
- [ ] Verify label badges and "Use" buttons still look correct visually
- [ ] Verify tab drag-and-drop still works in the active worktree
- [ ] Verify hidden worktrees do not interfere with drag in the active one