### PR TITLE
fix(editor): overlay rich markdown find bar instead of shifting content

### DIFF
--- a/src/renderer/src/assets/rich-markdown-editor.css
+++ b/src/renderer/src/assets/rich-markdown-editor.css
@@ -48,18 +48,17 @@
 }
 
 .rich-markdown-search {
-  position: sticky;
-  top: 0;
+  /* Why: overlay the editor like Monaco's find widget instead of occupying
+     layout space — otherwise opening cmd+f shifts the document content down. */
+  position: absolute;
+  top: 8px;
+  right: 12px;
   z-index: 20;
   display: flex;
   align-items: center;
   gap: 0;
   width: fit-content;
-  max-width: min(100%, 460px);
-  margin-left: auto;
-  margin-right: 12px;
-  margin-top: 8px;
-  margin-bottom: 6px;
+  max-width: min(calc(100% - 24px), 460px);
   padding: 0 2px 0 4px;
   border: 1px solid var(--border);
   border-radius: 4px;

--- a/src/renderer/src/components/editor/RichMarkdownEditor.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownEditor.tsx
@@ -501,18 +501,23 @@ export default function RichMarkdownEditor({
         onImagePick={handleLocalImagePick}
       />
       {headerSlot}
-      <RichMarkdownSearchBar
-        activeMatchIndex={activeMatchIndex}
-        isOpen={isSearchOpen}
-        matchCount={matchCount}
-        onClose={closeSearch}
-        onMoveToMatch={moveToMatch}
-        onQueryChange={setSearchQuery}
-        query={searchQuery}
-        searchInputRef={searchInputRef}
-      />
-      <div ref={scrollContainerRef} className="min-h-0 flex-1 overflow-auto scrollbar-editor">
-        <EditorContent editor={editor} />
+      {/* Why: wrap scroll area + search bar in a relative container so the
+          search bar overlays the content (Monaco-style) instead of occupying
+          layout space and shifting the document down when opened. */}
+      <div className="relative min-h-0 flex-1">
+        <div ref={scrollContainerRef} className="h-full overflow-auto scrollbar-editor">
+          <EditorContent editor={editor} />
+        </div>
+        <RichMarkdownSearchBar
+          activeMatchIndex={activeMatchIndex}
+          isOpen={isSearchOpen}
+          matchCount={matchCount}
+          onClose={closeSearch}
+          onMoveToMatch={moveToMatch}
+          onQueryChange={setSearchQuery}
+          query={searchQuery}
+          searchInputRef={searchInputRef}
+        />
       </div>
       {linkBubble ? (
         <RichMarkdownLinkBubble


### PR DESCRIPTION
## Summary
- Cmd+F in the rich markdown editor opened a sticky search bar in the flex column, pushing document content down.
- Wrapped the scroll area + search bar in a `relative` container and made the search bar `position: absolute` top-right, so it overlays the content like Monaco's find widget.

## Test plan
- [ ] Open a markdown file in rich mode, press Cmd+F — search bar appears top-right, content does not shift.
- [ ] Close (Esc) — content remains in place, scroll position preserved.
- [ ] Next/previous match navigation still scrolls matches into view.