### PR TITLE
Refresh xterm viewport after real pane fits

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -94,6 +94,7 @@ function createMockTransport(initialPtyId: string | null = null): MockTransport 
 function createPane(paneId: number) {
   return {
     id: paneId,
+    pendingDragScrollState: null,
     terminal: {
       cols: 120,
       rows: 40,
@@ -551,5 +552,67 @@ describe('connectPanePty', () => {
     expect(remountTransport.attach).not.toHaveBeenCalled()
     await Promise.resolve()
     expect(remountDeps.syncPanePtyLayoutBinding).toHaveBeenCalledWith(1, 'pty-restarted')
+  })
+
+  it('coalesces drag-time terminal resizes into one final PTY resize', async () => {
+    const queuedFrames: FrameRequestCallback[] = []
+    const originalRequestAnimationFrame = globalThis.requestAnimationFrame
+    const originalCancelAnimationFrame = globalThis.cancelAnimationFrame
+    globalThis.requestAnimationFrame = vi.fn((callback: FrameRequestCallback) => {
+      queuedFrames.push(callback)
+      return queuedFrames.length
+    })
+    globalThis.cancelAnimationFrame = vi.fn()
+
+    try {
+      const { connectPanePty } = await import('./pty-connection')
+
+      const transport = createMockTransport('pty-live')
+      transportFactoryQueue.push(transport)
+      const pane = createPane(1)
+      pane.pendingDragScrollState = {
+        wasAtBottom: true,
+        firstVisibleLineContent: '',
+        viewportY: 0,
+        totalLines: 40
+      }
+      let onResizeHandler: ((size: { cols: number; rows: number }) => void) | null = null
+      pane.terminal.onResize = vi.fn(((handler: (size: { cols: number; rows: number }) => void) => {
+        onResizeHandler = handler
+        return { dispose: vi.fn() }
+      }) as typeof pane.terminal.onResize)
+      const manager = createManager(1)
+      const deps = createDeps()
+
+      connectPanePty(pane as never, manager as never, deps as never)
+      const connectFrame = queuedFrames.shift()
+      connectFrame?.(0)
+
+      expect(onResizeHandler).toBeDefined()
+      if (!onResizeHandler) {
+        throw new Error('expected onResize handler to be registered')
+      }
+
+      onResizeHandler({ cols: 100, rows: 30 })
+      onResizeHandler({ cols: 101, rows: 31 })
+
+      expect(transport.resize).not.toHaveBeenCalled()
+
+      const dragFrame = queuedFrames.shift()
+      dragFrame?.(16)
+
+      expect(transport.resize).not.toHaveBeenCalled()
+      expect(queuedFrames).toHaveLength(1)
+
+      pane.pendingDragScrollState = null
+      const flushFrame = queuedFrames.shift()
+      flushFrame?.(32)
+
+      expect(transport.resize).toHaveBeenCalledTimes(1)
+      expect(transport.resize).toHaveBeenCalledWith(101, 31)
+    } finally {
+      globalThis.requestAnimationFrame = originalRequestAnimationFrame
+      globalThis.cancelAnimationFrame = originalCancelAnimationFrame
+    }
   })
 })

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -554,65 +554,39 @@ describe('connectPanePty', () => {
     expect(remountDeps.syncPanePtyLayoutBinding).toHaveBeenCalledWith(1, 'pty-restarted')
   })
 
-  it('coalesces drag-time terminal resizes into one final PTY resize', async () => {
-    const queuedFrames: FrameRequestCallback[] = []
-    const originalRequestAnimationFrame = globalThis.requestAnimationFrame
-    const originalCancelAnimationFrame = globalThis.cancelAnimationFrame
-    globalThis.requestAnimationFrame = vi.fn((callback: FrameRequestCallback) => {
-      queuedFrames.push(callback)
-      return queuedFrames.length
-    })
-    globalThis.cancelAnimationFrame = vi.fn()
+  it('forwards drag-time terminal resizes live once xterm emits them', async () => {
+    const { connectPanePty } = await import('./pty-connection')
 
-    try {
-      const { connectPanePty } = await import('./pty-connection')
-
-      const transport = createMockTransport('pty-live')
-      transportFactoryQueue.push(transport)
-      const pane = createPane(1)
-      pane.pendingDragScrollState = {
-        wasAtBottom: true,
-        firstVisibleLineContent: '',
-        viewportY: 0,
-        totalLines: 40
-      }
-      let onResizeHandler: ((size: { cols: number; rows: number }) => void) | null = null
-      pane.terminal.onResize = vi.fn(((handler: (size: { cols: number; rows: number }) => void) => {
-        onResizeHandler = handler
-        return { dispose: vi.fn() }
-      }) as typeof pane.terminal.onResize)
-      const manager = createManager(1)
-      const deps = createDeps()
-
-      connectPanePty(pane as never, manager as never, deps as never)
-      const connectFrame = queuedFrames.shift()
-      connectFrame?.(0)
-
-      expect(onResizeHandler).toBeDefined()
-      if (!onResizeHandler) {
-        throw new Error('expected onResize handler to be registered')
-      }
-
-      onResizeHandler({ cols: 100, rows: 30 })
-      onResizeHandler({ cols: 101, rows: 31 })
-
-      expect(transport.resize).not.toHaveBeenCalled()
-
-      const dragFrame = queuedFrames.shift()
-      dragFrame?.(16)
-
-      expect(transport.resize).not.toHaveBeenCalled()
-      expect(queuedFrames).toHaveLength(1)
-
-      pane.pendingDragScrollState = null
-      const flushFrame = queuedFrames.shift()
-      flushFrame?.(32)
-
-      expect(transport.resize).toHaveBeenCalledTimes(1)
-      expect(transport.resize).toHaveBeenCalledWith(101, 31)
-    } finally {
-      globalThis.requestAnimationFrame = originalRequestAnimationFrame
-      globalThis.cancelAnimationFrame = originalCancelAnimationFrame
+    const transport = createMockTransport('pty-live')
+    transportFactoryQueue.push(transport)
+    const pane = createPane(1)
+    pane.pendingDragScrollState = {
+      wasAtBottom: true,
+      firstVisibleLineContent: '',
+      viewportY: 0,
+      totalLines: 40
     }
+    let onResizeHandler: ((size: { cols: number; rows: number }) => void) | null = null
+    pane.terminal.onResize = vi.fn(((handler: (size: { cols: number; rows: number }) => void) => {
+      onResizeHandler = handler
+      return { dispose: vi.fn() }
+    }) as typeof pane.terminal.onResize)
+    const manager = createManager(1)
+    const deps = createDeps()
+
+    connectPanePty(pane as never, manager as never, deps as never)
+    await Promise.resolve()
+
+    expect(onResizeHandler).toBeDefined()
+    if (!onResizeHandler) {
+      throw new Error('expected onResize handler to be registered')
+    }
+
+    onResizeHandler({ cols: 100, rows: 30 })
+    onResizeHandler({ cols: 101, rows: 31 })
+
+    expect(transport.resize).toHaveBeenCalledTimes(2)
+    expect(transport.resize).toHaveBeenNthCalledWith(1, 100, 30)
+    expect(transport.resize).toHaveBeenNthCalledWith(2, 101, 31)
   })
 })

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -46,8 +46,6 @@ export function connectPanePty(
 ): IDisposable {
   let disposed = false
   let connectFrame: number | null = null
-  let pendingDragResize: { cols: number; rows: number } | null = null
-  let pendingDragResizeFrame: number | null = null
   let startupInjectTimer: ReturnType<typeof setTimeout> | null = null
   // Why: startup commands must only run once — in the pane they were
   // targeted at. Capture `deps.startup` into a local and clear the field on
@@ -216,40 +214,10 @@ export function connectPanePty(
     transport.sendInput(data)
   })
 
-  const flushPendingDragResize = (): void => {
-    pendingDragResizeFrame = null
-    if (disposed) {
-      return
-    }
-    if (pane.pendingDragScrollState) {
-      pendingDragResizeFrame = requestAnimationFrame(flushPendingDragResize)
-      return
-    }
-    if (!pendingDragResize) {
-      return
-    }
-    const { cols, rows } = pendingDragResize
-    pendingDragResize = null
-    transport.resize(cols, rows)
-  }
-
   const onResizeDisposable = pane.terminal.onResize(({ cols, rows }) => {
-    if (pane.pendingDragScrollState) {
-      pendingDragResize = { cols, rows }
-      if (pendingDragResizeFrame === null) {
-        // Why: Codex/Ink-style TUIs can leave xterm visually corrupted after a
-        // storm of intermediate SIGWINCH events from divider drags. Keep xterm
-        // fitted live so the pane stays usable, but only forward the final
-        // settled rows/cols to the PTY once the drag completes.
-        pendingDragResizeFrame = requestAnimationFrame(flushPendingDragResize)
-      }
-      return
-    }
-    pendingDragResize = null
-    if (pendingDragResizeFrame !== null) {
-      cancelAnimationFrame(pendingDragResizeFrame)
-      pendingDragResizeFrame = null
-    }
+    // Why: pane-tree-ops already throttles drag-time xterm fits to a safe
+    // cadence. Once the grid actually changes, the PTY should see that same
+    // live size so Codex can reflow during the drag instead of only on drop.
     transport.resize(cols, rows)
   })
 
@@ -595,10 +563,6 @@ export function connectPanePty(
         // handler wiring from the current pane.
         cancelAnimationFrame(connectFrame)
         connectFrame = null
-      }
-      if (pendingDragResizeFrame !== null) {
-        cancelAnimationFrame(pendingDragResizeFrame)
-        pendingDragResizeFrame = null
       }
       onDataDisposable.dispose()
       onResizeDisposable.dispose()

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -46,6 +46,8 @@ export function connectPanePty(
 ): IDisposable {
   let disposed = false
   let connectFrame: number | null = null
+  let pendingDragResize: { cols: number; rows: number } | null = null
+  let pendingDragResizeFrame: number | null = null
   let startupInjectTimer: ReturnType<typeof setTimeout> | null = null
   // Why: startup commands must only run once — in the pane they were
   // targeted at. Capture `deps.startup` into a local and clear the field on
@@ -214,7 +216,40 @@ export function connectPanePty(
     transport.sendInput(data)
   })
 
+  const flushPendingDragResize = (): void => {
+    pendingDragResizeFrame = null
+    if (disposed) {
+      return
+    }
+    if (pane.pendingDragScrollState) {
+      pendingDragResizeFrame = requestAnimationFrame(flushPendingDragResize)
+      return
+    }
+    if (!pendingDragResize) {
+      return
+    }
+    const { cols, rows } = pendingDragResize
+    pendingDragResize = null
+    transport.resize(cols, rows)
+  }
+
   const onResizeDisposable = pane.terminal.onResize(({ cols, rows }) => {
+    if (pane.pendingDragScrollState) {
+      pendingDragResize = { cols, rows }
+      if (pendingDragResizeFrame === null) {
+        // Why: Codex/Ink-style TUIs can leave xterm visually corrupted after a
+        // storm of intermediate SIGWINCH events from divider drags. Keep xterm
+        // fitted live so the pane stays usable, but only forward the final
+        // settled rows/cols to the PTY once the drag completes.
+        pendingDragResizeFrame = requestAnimationFrame(flushPendingDragResize)
+      }
+      return
+    }
+    pendingDragResize = null
+    if (pendingDragResizeFrame !== null) {
+      cancelAnimationFrame(pendingDragResizeFrame)
+      pendingDragResizeFrame = null
+    }
     transport.resize(cols, rows)
   })
 
@@ -560,6 +595,10 @@ export function connectPanePty(
         // handler wiring from the current pane.
         cancelAnimationFrame(connectFrame)
         connectFrame = null
+      }
+      if (pendingDragResizeFrame !== null) {
+        cancelAnimationFrame(pendingDragResizeFrame)
+        pendingDragResizeFrame = null
       }
       onDataDisposable.dispose()
       onResizeDisposable.dispose()

--- a/src/renderer/src/lib/pane-manager/pane-divider.ts
+++ b/src/renderer/src/lib/pane-manager/pane-divider.ts
@@ -1,4 +1,5 @@
 import type { PaneStyleOptions, ManagedPaneInternal } from './pane-manager-types'
+import type { RefitOptions } from './pane-tree-ops'
 
 // ---------------------------------------------------------------------------
 // Divider creation & drag-to-resize
@@ -15,7 +16,7 @@ export function createDivider(
   isVertical: boolean,
   styleOptions: PaneStyleOptions,
   callbacks: {
-    refitPanesUnder: (el: HTMLElement) => void
+    refitPanesUnder: (el: HTMLElement, opts?: RefitOptions) => void
     lockDragScroll: (el: HTMLElement) => void
     unlockDragScroll: (el: HTMLElement) => void
     onLayoutChanged?: () => void
@@ -46,7 +47,7 @@ function attachDividerDrag(
   divider: HTMLElement,
   isVertical: boolean,
   callbacks: {
-    refitPanesUnder: (el: HTMLElement) => void
+    refitPanesUnder: (el: HTMLElement, opts?: RefitOptions) => void
     lockDragScroll: (el: HTMLElement) => void
     unlockDragScroll: (el: HTMLElement) => void
     onLayoutChanged?: () => void
@@ -133,11 +134,11 @@ function attachDividerDrag(
     // Final refit at the exact drop position, then unlock drag scroll state
     // so the authoritative restore uses the original pre-drag scroll position
     if (prevEl) {
-      callbacks.refitPanesUnder(prevEl)
+      callbacks.refitPanesUnder(prevEl, { allowWhileDragLocked: true })
       callbacks.unlockDragScroll(prevEl)
     }
     if (nextEl) {
-      callbacks.refitPanesUnder(nextEl)
+      callbacks.refitPanesUnder(nextEl, { allowWhileDragLocked: true })
       callbacks.unlockDragScroll(nextEl)
     }
     prevEl = null
@@ -163,9 +164,9 @@ function attachDividerDrag(
     prev.style.flex = '1 1 0%'
     next.style.flex = '1 1 0%'
 
-    callbacks.refitPanesUnder(prev)
+    callbacks.refitPanesUnder(prev, { allowWhileDragLocked: true })
     callbacks.unlockDragScroll(prev)
-    callbacks.refitPanesUnder(next)
+    callbacks.refitPanesUnder(next, { allowWhileDragLocked: true })
     callbacks.unlockDragScroll(next)
     callbacks.onLayoutChanged?.()
   }

--- a/src/renderer/src/lib/pane-manager/pane-drag-reorder.ts
+++ b/src/renderer/src/lib/pane-manager/pane-drag-reorder.ts
@@ -1,6 +1,7 @@
 import type { DropZone, ManagedPaneInternal } from './pane-manager-types'
 import type { PaneStyleOptions } from './pane-manager-types'
 import { detachPaneFromTree, insertPaneNextTo } from './pane-tree-ops'
+import type { RefitOptions } from './pane-tree-ops'
 
 // ---------------------------------------------------------------------------
 // Drag-to-reorder panes
@@ -20,7 +21,7 @@ export type DragReorderCallbacks = {
   safeFit: (pane: ManagedPaneInternal) => void
   applyPaneOpacity: () => void
   applyDividerStyles: () => void
-  refitPanesUnder: (el: HTMLElement) => void
+  refitPanesUnder: (el: HTMLElement, opts?: RefitOptions) => void
   lockDragScroll: (el: HTMLElement) => void
   unlockDragScroll: (el: HTMLElement) => void
   onLayoutChanged?: () => void

--- a/src/renderer/src/lib/pane-manager/pane-drag-scroll.ts
+++ b/src/renderer/src/lib/pane-manager/pane-drag-scroll.ts
@@ -8,6 +8,11 @@ import { captureScrollState, restoreScrollState } from './pane-scroll'
 
 export function lockDragScroll(el: HTMLElement, panes: Map<number, ManagedPaneInternal>): void {
   for (const pane of findManagedPanesUnder(el, panes)) {
+    if (pane.pendingDragFitTimeoutId !== null) {
+      clearTimeout(pane.pendingDragFitTimeoutId)
+      pane.pendingDragFitTimeoutId = null
+    }
+    pane.lastDragFitAtMs = null
     if (!pane.pendingDragScrollState) {
       pane.pendingDragScrollState = captureScrollState(pane.terminal)
     }
@@ -16,6 +21,11 @@ export function lockDragScroll(el: HTMLElement, panes: Map<number, ManagedPaneIn
 
 export function unlockDragScroll(el: HTMLElement, panes: Map<number, ManagedPaneInternal>): void {
   for (const pane of findManagedPanesUnder(el, panes)) {
+    if (pane.pendingDragFitTimeoutId !== null) {
+      clearTimeout(pane.pendingDragFitTimeoutId)
+      pane.pendingDragFitTimeoutId = null
+    }
+    pane.lastDragFitAtMs = null
     if (pane.pendingDragScrollState) {
       try {
         restoreScrollState(pane.terminal, pane.pendingDragScrollState)

--- a/src/renderer/src/lib/pane-manager/pane-fit-resize-observer.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-fit-resize-observer.test.ts
@@ -49,6 +49,8 @@ function createPane(): ManagedPaneInternal {
     } as never,
     fitResizeObserver: null,
     pendingObservedFitRafId: null,
+    pendingDragFitTimeoutId: null,
+    lastDragFitAtMs: null,
     searchAddon: {} as never,
     serializeAddon: {} as never,
     unicode11Addon: {} as never,
@@ -89,6 +91,7 @@ describe('attachPaneFitResizeObserver', () => {
   })
 
   afterEach(() => {
+    vi.useRealTimers()
     vi.unstubAllGlobals()
     vi.restoreAllMocks()
   })
@@ -124,7 +127,8 @@ describe('attachPaneFitResizeObserver', () => {
     expect(pane.pendingObservedFitRafId).toBeNull()
   })
 
-  it('skips drag-time fits while a divider drag lock is active', () => {
+  it('keeps drag-time fits throttled instead of dropping them completely', () => {
+    vi.useFakeTimers()
     const pane = createPane()
     pane.pendingSplitScrollState = null
     pane.pendingDragScrollState = {
@@ -133,11 +137,18 @@ describe('attachPaneFitResizeObserver', () => {
       viewportY: 0,
       totalLines: 24
     } satisfies ScrollState
+    pane.lastDragFitAtMs = 0
+    vi.spyOn(performance, 'now').mockImplementation(() => 10)
 
     attachPaneFitResizeObserver(pane)
     mockResizeObservers[0]?.trigger()
     flushAnimationFrames()
 
     expect(pane.fitAddon.fit).not.toHaveBeenCalled()
+
+    vi.spyOn(performance, 'now').mockImplementation(() => 50)
+    vi.advanceTimersByTime(40)
+
+    expect(pane.fitAddon.fit).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/renderer/src/lib/pane-manager/pane-fit-resize-observer.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-fit-resize-observer.test.ts
@@ -123,4 +123,21 @@ describe('attachPaneFitResizeObserver', () => {
     expect(pane.fitAddon.fit).not.toHaveBeenCalled()
     expect(pane.pendingObservedFitRafId).toBeNull()
   })
+
+  it('skips drag-time fits while a divider drag lock is active', () => {
+    const pane = createPane()
+    pane.pendingSplitScrollState = null
+    pane.pendingDragScrollState = {
+      wasAtBottom: true,
+      firstVisibleLineContent: '',
+      viewportY: 0,
+      totalLines: 24
+    } satisfies ScrollState
+
+    attachPaneFitResizeObserver(pane)
+    mockResizeObservers[0]?.trigger()
+    flushAnimationFrames()
+
+    expect(pane.fitAddon.fit).not.toHaveBeenCalled()
+  })
 })

--- a/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
+++ b/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
@@ -134,6 +134,8 @@ export function createPaneDOM(
     fitAddon,
     fitResizeObserver: null,
     pendingObservedFitRafId: null,
+    pendingDragFitTimeoutId: null,
+    lastDragFitAtMs: null,
     searchAddon,
     serializeAddon,
     unicode11Addon,

--- a/src/renderer/src/lib/pane-manager/pane-manager-types.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager-types.ts
@@ -62,6 +62,8 @@ export type ManagedPaneInternal = {
   webglAddon: WebglAddon | null
   fitResizeObserver: ResizeObserver | null
   pendingObservedFitRafId: number | null
+  pendingDragFitTimeoutId: ReturnType<typeof setTimeout> | null
+  lastDragFitAtMs: number | null
   serializeAddon: SerializeAddon
   unicode11Addon: Unicode11Addon
   webLinksAddon: WebLinksAddon

--- a/src/renderer/src/lib/pane-manager/pane-tree-ops.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-tree-ops.test.ts
@@ -27,7 +27,8 @@ function createPane({
     },
     scrollToBottom: vi.fn(),
     scrollToLine: vi.fn(),
-    scrollLines: vi.fn()
+    scrollLines: vi.fn(),
+    refresh: vi.fn()
   }
 
   return {
@@ -79,6 +80,7 @@ describe('safeFit', () => {
     safeFit(pane)
 
     expect(pane.fitAddon.fit).toHaveBeenCalledTimes(1)
+    expect(pane.terminal.refresh).toHaveBeenCalledWith(0, pane.terminal.rows - 1)
   })
 
   it('still refits when a split-scroll lock is active and the grid changed', () => {
@@ -98,5 +100,19 @@ describe('safeFit', () => {
     safeFit(pane)
 
     expect(pane.fitAddon.fit).toHaveBeenCalledTimes(1)
+    expect(pane.terminal.refresh).toHaveBeenCalledWith(0, pane.terminal.rows - 1)
+  })
+
+  it('does not refresh when the pane grid dimensions did not change', () => {
+    const pane = createPane({
+      proposedCols: 120,
+      proposedRows: 32,
+      terminalCols: 120,
+      terminalRows: 32
+    })
+
+    safeFit(pane)
+
+    expect(pane.terminal.refresh).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/lib/pane-manager/pane-tree-ops.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-tree-ops.test.ts
@@ -44,6 +44,8 @@ function createPane({
     } as never,
     fitResizeObserver: null,
     pendingObservedFitRafId: null,
+    pendingDragFitTimeoutId: null,
+    lastDragFitAtMs: null,
     searchAddon: {} as never,
     serializeAddon: {} as never,
     unicode11Addon: {} as never,
@@ -103,7 +105,7 @@ describe('safeFit', () => {
     expect(pane.terminal.refresh).toHaveBeenCalledWith(0, pane.terminal.rows - 1)
   })
 
-  it('skips drag-time refits while a drag scroll lock is active', () => {
+  it('fits immediately on the first drag-time resize', () => {
     const pane = createPane({
       proposedCols: 100,
       proposedRows: 32,
@@ -119,8 +121,8 @@ describe('safeFit', () => {
 
     safeFit(pane)
 
-    expect(pane.fitAddon.fit).not.toHaveBeenCalled()
-    expect(pane.terminal.refresh).not.toHaveBeenCalled()
+    expect(pane.fitAddon.fit).toHaveBeenCalledTimes(1)
+    expect(pane.terminal.refresh).toHaveBeenCalledWith(0, pane.terminal.rows - 1)
   })
 
   it('still performs the final refit when drag-time fits are explicitly allowed', () => {
@@ -141,6 +143,47 @@ describe('safeFit', () => {
 
     expect(pane.fitAddon.fit).toHaveBeenCalledTimes(1)
     expect(pane.terminal.refresh).toHaveBeenCalledWith(0, pane.terminal.rows - 1)
+  })
+
+  it('throttles repeated drag-time refits to a capped cadence', () => {
+    vi.useFakeTimers()
+    const nowSpy = vi.spyOn(performance, 'now')
+    const pane = createPane({
+      proposedCols: 100,
+      proposedRows: 32,
+      terminalCols: 120,
+      terminalRows: 32
+    })
+    pane.pendingDragScrollState = {
+      wasAtBottom: true,
+      firstVisibleLineContent: '',
+      viewportY: 0,
+      totalLines: 32
+    } satisfies ScrollState
+
+    let nowMs = 0
+    nowSpy.mockImplementation(() => nowMs)
+
+    safeFit(pane)
+    expect(pane.fitAddon.fit).toHaveBeenCalledTimes(1)
+
+    pane.fitAddon.fit.mockClear()
+    ;(pane.terminal.refresh as ReturnType<typeof vi.fn>).mockClear()
+
+    nowMs = 10
+    safeFit(pane)
+
+    expect(pane.fitAddon.fit).not.toHaveBeenCalled()
+    expect(pane.pendingDragFitTimeoutId).not.toBeNull()
+
+    nowMs = 50
+    vi.advanceTimersByTime(40)
+
+    expect(pane.fitAddon.fit).toHaveBeenCalledTimes(1)
+    expect(pane.terminal.refresh).toHaveBeenCalledWith(0, pane.terminal.rows - 1)
+
+    nowSpy.mockRestore()
+    vi.useRealTimers()
   })
 
   it('does not refresh when the pane grid dimensions did not change', () => {

--- a/src/renderer/src/lib/pane-manager/pane-tree-ops.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-tree-ops.test.ts
@@ -103,6 +103,46 @@ describe('safeFit', () => {
     expect(pane.terminal.refresh).toHaveBeenCalledWith(0, pane.terminal.rows - 1)
   })
 
+  it('skips drag-time refits while a drag scroll lock is active', () => {
+    const pane = createPane({
+      proposedCols: 100,
+      proposedRows: 32,
+      terminalCols: 120,
+      terminalRows: 32
+    })
+    pane.pendingDragScrollState = {
+      wasAtBottom: true,
+      firstVisibleLineContent: '',
+      viewportY: 0,
+      totalLines: 32
+    } satisfies ScrollState
+
+    safeFit(pane)
+
+    expect(pane.fitAddon.fit).not.toHaveBeenCalled()
+    expect(pane.terminal.refresh).not.toHaveBeenCalled()
+  })
+
+  it('still performs the final refit when drag-time fits are explicitly allowed', () => {
+    const pane = createPane({
+      proposedCols: 100,
+      proposedRows: 32,
+      terminalCols: 120,
+      terminalRows: 32
+    })
+    pane.pendingDragScrollState = {
+      wasAtBottom: true,
+      firstVisibleLineContent: '',
+      viewportY: 0,
+      totalLines: 32
+    } satisfies ScrollState
+
+    safeFit(pane, { allowWhileDragLocked: true })
+
+    expect(pane.fitAddon.fit).toHaveBeenCalledTimes(1)
+    expect(pane.terminal.refresh).toHaveBeenCalledWith(0, pane.terminal.rows - 1)
+  })
+
   it('does not refresh when the pane grid dimensions did not change', () => {
     const pane = createPane({
       proposedCols: 120,

--- a/src/renderer/src/lib/pane-manager/pane-tree-ops.ts
+++ b/src/renderer/src/lib/pane-manager/pane-tree-ops.ts
@@ -22,6 +22,8 @@ export type RefitOptions = {
   allowWhileDragLocked?: boolean
 }
 
+const DRAG_REFIT_INTERVAL_MS = 50
+
 function getProposedDimensions(pane: ManagedPaneInternal): { cols: number; rows: number } | null {
   try {
     return pane.fitAddon.proposeDimensions() ?? null
@@ -42,6 +44,31 @@ function refreshViewport(pane: ManagedPaneInternal): void {
   }
 }
 
+function getNowMs(): number {
+  return typeof performance !== 'undefined' ? performance.now() : Date.now()
+}
+
+function clearScheduledDragFit(pane: ManagedPaneInternal): void {
+  if (pane.pendingDragFitTimeoutId === null) {
+    return
+  }
+  clearTimeout(pane.pendingDragFitTimeoutId)
+  pane.pendingDragFitTimeoutId = null
+}
+
+function scheduleDragFit(pane: ManagedPaneInternal, delayMs: number): void {
+  if (pane.pendingDragFitTimeoutId !== null) {
+    return
+  }
+  // Why: Codex/Ink TUIs break under resize storms, but removing drag-time
+  // fits entirely makes split resizing feel dead. A capped cadence keeps the
+  // pane responsive without re-entering the worst-case xterm path every frame.
+  pane.pendingDragFitTimeoutId = setTimeout(() => {
+    pane.pendingDragFitTimeoutId = null
+    safeFit(pane)
+  }, delayMs)
+}
+
 export function safeFit(pane: ManagedPaneInternal, opts: RefitOptions = {}): void {
   try {
     const dims = getProposedDimensions(pane)
@@ -51,11 +78,21 @@ export function safeFit(pane: ManagedPaneInternal, opts: RefitOptions = {}): voi
       // churn, which was causing visible terminal blinking while resizing.
       return
     }
-    // Why: repeated xterm fits while a divider is actively being dragged can
-    // corrupt browser-side rendering for Codex/Ink TUIs. Keep the pane flexing
-    // live, but defer the terminal grid resize until the drag settles.
-    if (pane.pendingDragScrollState && !opts.allowWhileDragLocked) {
-      return
+    if (!pane.pendingDragScrollState) {
+      clearScheduledDragFit(pane)
+      pane.lastDragFitAtMs = null
+    } else if (opts.allowWhileDragLocked) {
+      clearScheduledDragFit(pane)
+    } else {
+      const now = getNowMs()
+      const lastFitAt = pane.lastDragFitAtMs
+      const remainingMs =
+        lastFitAt === null ? 0 : Math.max(0, DRAG_REFIT_INTERVAL_MS - (now - lastFitAt))
+      if (remainingMs > 0) {
+        scheduleDragFit(pane, remainingMs)
+        return
+      }
+      pane.lastDragFitAtMs = now
     }
     if (pane.pendingSplitScrollState) {
       pane.fitAddon.fit()
@@ -79,32 +116,7 @@ export function safeFit(pane: ManagedPaneInternal, opts: RefitOptions = {}): voi
 
 export function fitAllPanesInternal(panes: Map<number, ManagedPaneInternal>): void {
   for (const pane of panes.values()) {
-    try {
-      const dims = getProposedDimensions(pane)
-      if (dims && dims.cols === pane.terminal.cols && dims.rows === pane.terminal.rows) {
-        continue
-      }
-      if (pane.pendingDragScrollState) {
-        continue
-      }
-      if (pane.pendingSplitScrollState) {
-        pane.fitAddon.fit()
-        refreshViewport(pane)
-        continue
-      }
-      if (pane.pendingDragScrollState) {
-        pane.fitAddon.fit()
-        restoreScrollState(pane.terminal, pane.pendingDragScrollState)
-        refreshViewport(pane)
-        continue
-      }
-      const state = captureScrollState(pane.terminal)
-      pane.fitAddon.fit()
-      restoreScrollState(pane.terminal, state)
-      refreshViewport(pane)
-    } catch {
-      /* ignore */
-    }
+    safeFit(pane)
   }
 }
 

--- a/src/renderer/src/lib/pane-manager/pane-tree-ops.ts
+++ b/src/renderer/src/lib/pane-manager/pane-tree-ops.ts
@@ -12,10 +12,14 @@ type TreeOpsCallbacks = {
   getRoot: () => HTMLElement
   getStyleOptions: () => PaneStyleOptions
   safeFit: (pane: ManagedPaneInternal) => void
-  refitPanesUnder: (el: HTMLElement) => void
+  refitPanesUnder: (el: HTMLElement, opts?: RefitOptions) => void
   lockDragScroll: (el: HTMLElement) => void
   unlockDragScroll: (el: HTMLElement) => void
   onLayoutChanged?: () => void
+}
+
+export type RefitOptions = {
+  allowWhileDragLocked?: boolean
 }
 
 function getProposedDimensions(pane: ManagedPaneInternal): { cols: number; rows: number } | null {
@@ -38,13 +42,19 @@ function refreshViewport(pane: ManagedPaneInternal): void {
   }
 }
 
-export function safeFit(pane: ManagedPaneInternal): void {
+export function safeFit(pane: ManagedPaneInternal, opts: RefitOptions = {}): void {
   try {
     const dims = getProposedDimensions(pane)
     if (dims && dims.cols === pane.terminal.cols && dims.rows === pane.terminal.rows) {
       // Why: divider drags fire refits every frame, but most frames do not
       // cross a cell boundary. Skipping those avoids FitAddon.clear()+refresh()
       // churn, which was causing visible terminal blinking while resizing.
+      return
+    }
+    // Why: repeated xterm fits while a divider is actively being dragged can
+    // corrupt browser-side rendering for Codex/Ink TUIs. Keep the pane flexing
+    // live, but defer the terminal grid resize until the drag settles.
+    if (pane.pendingDragScrollState && !opts.allowWhileDragLocked) {
       return
     }
     if (pane.pendingSplitScrollState) {
@@ -74,6 +84,9 @@ export function fitAllPanesInternal(panes: Map<number, ManagedPaneInternal>): vo
       if (dims && dims.cols === pane.terminal.cols && dims.rows === pane.terminal.rows) {
         continue
       }
+      if (pane.pendingDragScrollState) {
+        continue
+      }
       if (pane.pendingSplitScrollState) {
         pane.fitAddon.fit()
         refreshViewport(pane)
@@ -95,13 +108,17 @@ export function fitAllPanesInternal(panes: Map<number, ManagedPaneInternal>): vo
   }
 }
 
-export function refitPanesUnder(el: HTMLElement, panes: Map<number, ManagedPaneInternal>): void {
+export function refitPanesUnder(
+  el: HTMLElement,
+  panes: Map<number, ManagedPaneInternal>,
+  opts?: RefitOptions
+): void {
   // If the element is a pane, refit it
   if (el.classList.contains('pane')) {
     const paneId = Number(el.dataset.paneId)
     const pane = panes.get(paneId)
     if (pane) {
-      safeFit(pane)
+      safeFit(pane, opts)
     }
     return
   }
@@ -113,7 +130,7 @@ export function refitPanesUnder(el: HTMLElement, panes: Map<number, ManagedPaneI
       const paneId = Number((paneEl as HTMLElement).dataset.paneId)
       const pane = panes.get(paneId)
       if (pane) {
-        safeFit(pane)
+        safeFit(pane, opts)
       }
     }
   }

--- a/src/renderer/src/lib/pane-manager/pane-tree-ops.ts
+++ b/src/renderer/src/lib/pane-manager/pane-tree-ops.ts
@@ -26,6 +26,18 @@ function getProposedDimensions(pane: ManagedPaneInternal): { cols: number; rows:
   }
 }
 
+function refreshViewport(pane: ManagedPaneInternal): void {
+  try {
+    // Why: xterm's resize path updates the buffer/viewport state, but complex
+    // TUIs like Codex can still leave the last rows visually stale until the
+    // next paint-triggering write. Refreshing after a real fit keeps the
+    // bottom-of-screen prompt/status rows visible through repeated drags.
+    pane.terminal.refresh(0, pane.terminal.rows - 1)
+  } catch {
+    /* ignore */
+  }
+}
+
 export function safeFit(pane: ManagedPaneInternal): void {
   try {
     const dims = getProposedDimensions(pane)
@@ -37,16 +49,19 @@ export function safeFit(pane: ManagedPaneInternal): void {
     }
     if (pane.pendingSplitScrollState) {
       pane.fitAddon.fit()
+      refreshViewport(pane)
       return
     }
     if (pane.pendingDragScrollState) {
       pane.fitAddon.fit()
       restoreScrollState(pane.terminal, pane.pendingDragScrollState)
+      refreshViewport(pane)
       return
     }
     const state = captureScrollState(pane.terminal)
     pane.fitAddon.fit()
     restoreScrollState(pane.terminal, state)
+    refreshViewport(pane)
   } catch {
     // Container may not have dimensions yet
   }
@@ -61,16 +76,19 @@ export function fitAllPanesInternal(panes: Map<number, ManagedPaneInternal>): vo
       }
       if (pane.pendingSplitScrollState) {
         pane.fitAddon.fit()
+        refreshViewport(pane)
         continue
       }
       if (pane.pendingDragScrollState) {
         pane.fitAddon.fit()
         restoreScrollState(pane.terminal, pane.pendingDragScrollState)
+        refreshViewport(pane)
         continue
       }
       const state = captureScrollState(pane.terminal)
       pane.fitAddon.fit()
       restoreScrollState(pane.terminal, state)
+      refreshViewport(pane)
     } catch {
       /* ignore */
     }


### PR DESCRIPTION
## Problem
Dragging terminal panes can change the xterm grid size without forcing a repaint of the visible viewport. For terminal UIs like Codex, that can leave the bottom rows visually stale until new output arrives.

## Solution
Refresh the xterm viewport after every real pane fit, while keeping the existing no-op-fit guard so unchanged drag frames still skip extra work. Add tests that pin the new refresh-on-fit behavior and confirm no refresh happens when the grid dimensions stay the same.
