### PR TITLE
fix(scripts): restrict ORCA_ELECTRON_VITE_CLI override to test environments

### DIFF
--- a/config/scripts/run-electron-vite-dev.mjs
+++ b/config/scripts/run-electron-vite-dev.mjs
@@ -11,8 +11,10 @@ delete process.env.ELECTRON_RUN_AS_NODE
 const require = createRequire(import.meta.url)
 // Why: tests inject a tiny fake CLI here so they can verify Ctrl+C tears down
 // the full child tree without depending on a real electron-vite install.
+// Restricted to test environments to prevent process injection via env in
+// production/dev runs where an attacker could control ORCA_ELECTRON_VITE_CLI.
 const electronViteCli =
-  process.env.ORCA_ELECTRON_VITE_CLI ||
+  (process.env.NODE_ENV === 'test' && process.env.ORCA_ELECTRON_VITE_CLI) ||
   path.join(path.dirname(require.resolve('electron-vite/package.json')), 'bin', 'electron-vite.js')
 const forwardedArgs = ['dev', ...process.argv.slice(2)]
 const child = spawn(process.execPath, [electronViteCli, ...forwardedArgs], {


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Security Fix (Medium severity)

In `config/scripts/run-electron-vite-dev.mjs`, the `ORCA_ELECTRON_VITE_CLI` environment variable can substitute the electron-vite CLI binary unconditionally. The existing comment documents this as a test affordance ("tests inject a tiny fake CLI here"), but without an environment guard the override is active in all contexts — including production dev runs where a compromised or attacker-controlled environment could substitute an arbitrary binary path.

**Impact**: Any process able to set environment variables in a `pnpm dev` run (e.g. a malicious `.env` file, a compromised dev toolchain script, or a supply-chain attack on a startup script) could redirect the spawned Node.js process to execute an arbitrary file.

## Fix

Guard the override with `process.env.NODE_ENV === 'test'` so the substitution only applies when the test runner explicitly sets that flag. The test behavior is fully preserved; dev and CI builds fall through to the real `electron-vite` binary unconditionally.

<!-- nlpm-metadata-begin
{"version":1,"findings":[]}
nlpm-metadata-end -->