### PR TITLE
fix(terminal): focus terminal after file-tree drop (#978)

### DIFF
--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -854,6 +854,11 @@ export default function TerminalPane({
             return
           }
           transport.sendInput(shellEscapePath(filePath))
+          // Move focus to the terminal so the user can keep typing where the
+          // dropped path just landed. Without this, focus stays on the file
+          // tree row that originated the drag and subsequent keystrokes do
+          // not reach the pty — #978.
+          pane.terminal.focus()
         }}
       />
       {terminalError && isActive && (


### PR DESCRIPTION
Closes #978.

## Problem

When a user drags a file from the file tree and drops it into the terminal pane, the path is inserted into the pty but focus stays on the file tree row that originated the drag. Typing does not continue in the terminal, which breaks the common "drag path, then keep typing arguments" workflow described in the issue.

## Fix

In \`src/renderer/src/components/terminal-pane/TerminalPane.tsx\`, call \`pane.terminal.focus()\` after \`transport.sendInput(shellEscapePath(filePath))\` so the pty receives subsequent keystrokes immediately.

The same \`pane.terminal.focus()\` pattern is already used elsewhere for focus restoration after pane-level actions (see \`use-terminal-pane-context-menu.ts\`, \`pane-helpers.ts:33\`, \`keyboard-handlers.ts:148\`), so this keeps the drop handler consistent with those paths.

## Verification

- \`pnpm run typecheck:web\` — passes (clean)
- \`pnpm run lint\` — clean for this file (the 2 pre-existing warnings are in \`useDiffCommentDecorator.tsx\`, unrelated)
- \`pnpm exec oxfmt --check\` on the changed file — formatted correctly