### PR TITLE
fix(ui): submit dialog forms on Enter key

### DIFF
--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -1090,6 +1090,12 @@ export default function TaskPage(): React.JSX.Element {
                 autoFocus
                 value={newIssueTitle}
                 onChange={(e) => setNewIssueTitle(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
+                    e.preventDefault()
+                    void handleCreateNewIssue()
+                  }
+                }}
                 placeholder="Short summary"
                 disabled={newIssueSubmitting}
               />

--- a/src/renderer/src/components/settings/SshTargetForm.tsx
+++ b/src/renderer/src/components/settings/SshTargetForm.tsx
@@ -41,7 +41,13 @@ export function SshTargetForm({
   onCancel
 }: SshTargetFormProps): React.JSX.Element {
   return (
-    <div className="space-y-4 rounded-lg border border-border/50 bg-card/40 p-4">
+    <form
+      className="space-y-4 rounded-lg border border-border/50 bg-card/40 p-4"
+      onSubmit={(e) => {
+        e.preventDefault()
+        onSave()
+      }}
+    >
       <p className="text-sm font-medium">{editingId ? 'Edit SSH Target' : 'New SSH Target'}</p>
 
       <div className="grid grid-cols-2 gap-4">
@@ -119,13 +125,13 @@ export function SshTargetForm({
       </div>
 
       <div className="flex items-center gap-2">
-        <Button size="sm" onClick={onSave}>
+        <Button type="submit" size="sm">
           {editingId ? 'Save Changes' : 'Add Target'}
         </Button>
-        <Button variant="ghost" size="sm" onClick={onCancel}>
+        <Button type="button" variant="ghost" size="sm" onClick={onCancel}>
           Cancel
         </Button>
       </div>
-    </div>
+    </form>
   )
 }

--- a/src/renderer/src/components/sidebar/AddRepoSteps.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoSteps.tsx
@@ -242,6 +242,14 @@ export function RemoteStep({
             <Input
               value={remotePath}
               onChange={(e) => onRemotePathChange(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
+                  e.preventDefault()
+                  if (selectedTargetId && remotePath.trim() && !isAddingRemote) {
+                    onAdd()
+                  }
+                }
+              }}
               placeholder="/home/user/project"
               className="h-8 text-xs flex-1"
               disabled={isAddingRemote}
@@ -297,6 +305,15 @@ export function CloneStep({
   onPickDestination,
   onClone
 }: CloneStepProps): React.JSX.Element {
+  const canClone = !!cloneUrl.trim() && !!cloneDestination.trim() && !isCloning
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>): void => {
+    if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
+      e.preventDefault()
+      if (canClone) {
+        onClone()
+      }
+    }
+  }
   return (
     <>
       <DialogHeader>
@@ -310,6 +327,7 @@ export function CloneStep({
           <Input
             value={cloneUrl}
             onChange={(e) => onUrlChange(e.target.value)}
+            onKeyDown={handleKeyDown}
             placeholder="https://github.com/user/repo.git"
             className="h-8 text-xs"
             disabled={isCloning}
@@ -323,6 +341,7 @@ export function CloneStep({
             <Input
               value={cloneDestination}
               onChange={(e) => onDestChange(e.target.value)}
+              onKeyDown={handleKeyDown}
               placeholder="/path/to/destination"
               className="h-8 text-xs flex-1"
               disabled={isCloning}


### PR DESCRIPTION
## Summary

Closes #939. Pressing **Enter** now submits the data-entry dialogs that previously required the mouse:

- **Add Repository → Clone from URL** — Enter in the Git URL or Clone location inputs triggers Clone (respects the same enablement rule as the button).
- **Add Repository → Remote repo** — Enter in the Remote path input triggers Add remote repo.
- **Settings → SSH Targets → Add / Edit** — form wrapped in `<form onSubmit>`; the primary button is `type="submit"`, Cancel is explicitly `type="button"`.
- **Tasks → New GitHub issue** — plain Enter in the (single-line) Title input submits; Cmd/Ctrl+Enter from the textarea remains unchanged.

Each handler checks `e.nativeEvent.isComposing` to avoid submitting mid-IME and mirrors the existing disabled logic so Enter doesn't submit when the button wouldn't.

## Test plan
- [ ] Clone dialog: paste URL, Tab to destination, press Enter → clone starts
- [ ] Remote repo: select connected SSH target, type path, press Enter → add starts
- [ ] SSH Target form: fill required fields, press Enter from any input → save fires; Cancel button does not submit
- [ ] New GitHub issue: type title, press Enter → issue creation starts; Enter inside the Description textarea still inserts a newline
- [ ] IME: verify composing state does not trigger submit

🤖 Generated with [Claude Code](https://claude.com/claude-code)