### PR TITLE
fix: dispose hidden PTY listeners before kill

### DIFF
--- a/src/main/rate-limits/claude-pty.test.ts
+++ b/src/main/rate-limits/claude-pty.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { resolveClaudeCommandMock, spawnMock } = vi.hoisted(() => ({
+  resolveClaudeCommandMock: vi.fn(),
+  spawnMock: vi.fn()
+}))
+
+vi.mock('../codex-cli/command', () => ({
+  resolveClaudeCommand: resolveClaudeCommandMock
+}))
+
+vi.mock('node-pty', () => ({
+  spawn: spawnMock
+}))
+
+import { fetchViaPty } from './claude-pty'
+
+function makeDisposable() {
+  return { dispose: vi.fn() }
+}
+
+describe('fetchViaPty', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.clearAllMocks()
+    resolveClaudeCommandMock.mockReturnValue('claude')
+  })
+
+  it('disposes node-pty listeners before killing the hidden PTY on timeout', async () => {
+    const onDataDisposable = makeDisposable()
+    const onExitDisposable = makeDisposable()
+
+    spawnMock.mockReturnValue({
+      onData: vi.fn(() => onDataDisposable),
+      onExit: vi.fn(() => onExitDisposable),
+      write: vi.fn(),
+      kill: vi.fn()
+    })
+
+    const resultPromise = fetchViaPty()
+    await vi.advanceTimersByTimeAsync(25_000)
+    await resultPromise
+
+    const term = spawnMock.mock.results[0]?.value as { kill: ReturnType<typeof vi.fn> }
+    expect(onDataDisposable.dispose.mock.invocationCallOrder[0]).toBeLessThan(
+      term.kill.mock.invocationCallOrder[0]
+    )
+    expect(onExitDisposable.dispose.mock.invocationCallOrder[0]).toBeLessThan(
+      term.kill.mock.invocationCallOrder[0]
+    )
+  })
+})

--- a/src/main/rate-limits/claude-pty.ts
+++ b/src/main/rate-limits/claude-pty.ts
@@ -150,10 +150,20 @@ export async function fetchViaPty(): Promise<ProviderRateLimits> {
       rows: 40,
       env: { ...process.env, TERM: 'xterm-256color' }
     })
+    const termDisposables: { dispose: () => void }[] = []
+    const disposeTermListeners = (): void => {
+      for (const disposable of termDisposables.splice(0)) {
+        disposable.dispose()
+      }
+    }
 
     const timeout = setTimeout(() => {
       if (!resolved) {
         resolved = true
+        // Why: node-pty's NAPI callbacks can outlive the Electron JS
+        // environment if we kill the hidden PTY without disposing them first,
+        // which matches Orca's documented SIGABRT failure mode on shutdown.
+        disposeTermListeners()
         term.kill()
         // Even on timeout, try to parse whatever we collected
         // eslint-disable-next-line no-control-regex
@@ -205,6 +215,7 @@ export async function fetchViaPty(): Promise<ProviderRateLimits> {
       if (enterInterval) {
         clearInterval(enterInterval)
       }
+      disposeTermListeners()
       term.kill()
 
       // eslint-disable-next-line no-control-regex
@@ -243,7 +254,7 @@ export async function fetchViaPty(): Promise<ProviderRateLimits> {
       startEnterPresses()
     }, STARTUP_DELAY_MS)
 
-    term.onData((data) => {
+    const onDataDisposable = term.onData((data) => {
       output += data
 
       // eslint-disable-next-line no-control-regex
@@ -278,8 +289,12 @@ export async function fetchViaPty(): Promise<ProviderRateLimits> {
         }
       }
     })
+    if (onDataDisposable) {
+      termDisposables.push(onDataDisposable)
+    }
 
-    term.onExit(() => {
+    const onExitDisposable = term.onExit(() => {
+      disposeTermListeners()
       if (enterInterval) {
         clearInterval(enterInterval)
       }
@@ -299,5 +314,8 @@ export async function fetchViaPty(): Promise<ProviderRateLimits> {
         })
       }
     })
+    if (onExitDisposable) {
+      termDisposables.push(onExitDisposable)
+    }
   })
 }

--- a/src/main/rate-limits/codex-fetcher.test.ts
+++ b/src/main/rate-limits/codex-fetcher.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { childSpawnMock, resolveCodexCommandMock, ptySpawnMock } = vi.hoisted(() => ({
+  childSpawnMock: vi.fn(),
+  resolveCodexCommandMock: vi.fn(),
+  ptySpawnMock: vi.fn()
+}))
+
+vi.mock('node:child_process', () => ({
+  spawn: childSpawnMock
+}))
+
+vi.mock('../codex-cli/command', () => ({
+  resolveCodexCommand: resolveCodexCommandMock
+}))
+
+vi.mock('node-pty', () => ({
+  spawn: ptySpawnMock
+}))
+
+import { fetchCodexRateLimits } from './codex-fetcher'
+
+function makeDisposable() {
+  return { dispose: vi.fn() }
+}
+
+describe('fetchCodexRateLimits', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.clearAllMocks()
+    resolveCodexCommandMock.mockReturnValue('codex')
+  })
+
+  it('disposes node-pty listeners before killing the PTY fallback on timeout', async () => {
+    const onDataDisposable = makeDisposable()
+    const onExitDisposable = makeDisposable()
+
+    childSpawnMock.mockImplementation(() => {
+      throw new Error('rpc unavailable')
+    })
+    ptySpawnMock.mockReturnValue({
+      onData: vi.fn(() => onDataDisposable),
+      onExit: vi.fn(() => onExitDisposable),
+      write: vi.fn(),
+      kill: vi.fn()
+    })
+
+    const resultPromise = fetchCodexRateLimits()
+    await vi.advanceTimersByTimeAsync(15_000)
+    await resultPromise
+
+    const term = ptySpawnMock.mock.results[0]?.value as { kill: ReturnType<typeof vi.fn> }
+    expect(onDataDisposable.dispose.mock.invocationCallOrder[0]).toBeLessThan(
+      term.kill.mock.invocationCallOrder[0]
+    )
+    expect(onExitDisposable.dispose.mock.invocationCallOrder[0]).toBeLessThan(
+      term.kill.mock.invocationCallOrder[0]
+    )
+  })
+})

--- a/src/main/rate-limits/codex-fetcher.ts
+++ b/src/main/rate-limits/codex-fetcher.ts
@@ -315,10 +315,20 @@ async function fetchViaPty(options?: FetchCodexRateLimitsOptions): Promise<Provi
         ...(options?.codexHomePath ? { CODEX_HOME: options.codexHomePath } : {})
       }
     })
+    const termDisposables: { dispose: () => void }[] = []
+    const disposeTermListeners = (): void => {
+      for (const disposable of termDisposables.splice(0)) {
+        disposable.dispose()
+      }
+    }
 
     const timeout = setTimeout(() => {
       if (!resolved) {
         resolved = true
+        // Why: killing a hidden PTY without disposing node-pty's NAPI listener
+        // handles leaves ThreadSafeFunction callbacks alive into Electron
+        // shutdown, which can abort the app while Node cleans up its env.
+        disposeTermListeners()
         term.kill()
         resolve({
           provider: 'codex',
@@ -331,7 +341,7 @@ async function fetchViaPty(options?: FetchCodexRateLimitsOptions): Promise<Provi
       }
     }, PTY_TIMEOUT_MS)
 
-    term.onData((data) => {
+    const onDataDisposable = term.onData((data) => {
       output += data
 
       // Wait for prompt, then send /status
@@ -349,6 +359,7 @@ async function fetchViaPty(options?: FetchCodexRateLimitsOptions): Promise<Provi
           }
           resolved = true
           clearTimeout(timeout)
+          disposeTermListeners()
           term.kill()
 
           // eslint-disable-next-line no-control-regex
@@ -366,8 +377,12 @@ async function fetchViaPty(options?: FetchCodexRateLimitsOptions): Promise<Provi
         }, 500)
       }
     })
+    if (onDataDisposable) {
+      termDisposables.push(onDataDisposable)
+    }
 
-    term.onExit(() => {
+    const onExitDisposable = term.onExit(() => {
+      disposeTermListeners()
       if (!resolved) {
         resolved = true
         clearTimeout(timeout)
@@ -384,6 +399,9 @@ async function fetchViaPty(options?: FetchCodexRateLimitsOptions): Promise<Provi
         })
       }
     })
+    if (onExitDisposable) {
+      termDisposables.push(onExitDisposable)
+    }
   })
 }
 


### PR DESCRIPTION
## Summary
- dispose `node-pty` listener handles before killing the hidden Claude/Codex rate-limit PTYs
- add regression tests that lock the dispose-before-kill order down for both fallback paths
- keep the change scoped to the hidden rate-limit probes that match the shutdown crash signature

## Crash analysis
The macOS crash report aborts in `pty.node` while `Napi::ThreadSafeFunction::CallJS` is running during `node::FreeEnvironment()` cleanup. Orca already documents this failure mode in `LocalPtyProvider`: if a PTY is killed without disposing its `onData` / `onExit` listeners first, the native N-API callbacks can survive into Electron shutdown and abort the app.

The remaining unguarded `node-pty` usages were the hidden rate-limit PTY probes in `claude-pty.ts` and `codex-fetcher.ts`. Those probes killed their PTYs on timeout/finalize without first disposing the listener handles.

## Verification
- `pnpm exec vitest run --config config/vitest.config.ts src/main/rate-limits/claude-pty.test.ts src/main/rate-limits/codex-fetcher.test.ts src/main/ipc/pty.test.ts`
- `pnpm typecheck:node`
