### PR TITLE
fix(settings): replace nested button with div[role=button] in BrowserProfileRow

### DIFF
--- a/src/renderer/src/components/settings/BrowserProfileRow.tsx
+++ b/src/renderer/src/components/settings/BrowserProfileRow.tsx
@@ -79,11 +79,21 @@ export function BrowserProfileRow({
     ? `${BROWSER_FAMILY_LABELS[profile.source.browserFamily] ?? profile.source.browserFamily}${profile.source.profileName ? ` (${profile.source.profileName})` : ''}`
     : null
 
+  // Why: uses div[role=button] instead of <button> to avoid nested <button>
+  // elements — the dropdown trigger and trash actions inside also render as
+  // <button>, which is invalid HTML and causes React hydration warnings.
   return (
-    <button
-      type="button"
+    <div
+      role="button"
+      tabIndex={0}
       onClick={onSelect}
-      className={`flex w-full items-center gap-3 rounded-md border px-3 py-2.5 text-left transition-colors ${
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          onSelect()
+        }
+      }}
+      className={`flex w-full items-center gap-3 rounded-md border px-3 py-2.5 text-left transition-colors cursor-pointer ${
         isActive
           ? 'border-foreground/20 bg-accent/15'
           : 'border-border/70 hover:border-border hover:bg-accent/8'
@@ -187,6 +197,6 @@ export function BrowserProfileRow({
           </Button>
         )}
       </div>
-    </button>
+    </div>
   )
 }


### PR DESCRIPTION
## Summary
- Fixes invalid nested `<button>` HTML in `BrowserProfileRow` — the outer `<button>` wrapper contained dropdown trigger and trash `<button>` elements, causing React hydration warnings.
- Replaced outer `<button>` with `<div role="button" tabIndex={0}>` with Enter/Space keyboard handling to preserve accessibility.

## Test plan
- [ ] Open Settings → Browser → Session & Cookies section
- [ ] Verify profile rows are clickable and set the active profile
- [ ] Verify Enter and Space keys activate a focused profile row
- [ ] Verify "Import Cookies" dropdown opens and functions correctly
- [ ] Verify trash/clear button works on each row
- [ ] Confirm no React hydration warnings in the console