### PR TITLE
docs(electron-skill): harden playwright-cli usage against alias and port collisions

### DIFF
--- a/.agents/skills/electron/SKILL.md
+++ b/.agents/skills/electron/SKILL.md
@@ -42,54 +42,31 @@ command playwright-cli click e5
 command playwright-cli screenshot
 ```
 
-## Invoking `playwright-cli` — prefer `command` prefix
+## Always prefix with `command`
 
-Some developers alias `playwright-cli` in their shell (e.g. `alias playwright-cli='playwright-cli --persistent'`). Interactive aliases don't always fire under non-interactive shells like the Bash tool, and when they do, flags can leak into subcommands and cause `Unknown option: --persistent`.
+Use `command playwright-cli …` to bypass shell aliases (e.g. `alias playwright-cli='playwright-cli --persistent'`) that leak flags into subcommands. Behaves identically when no alias is set. All examples below use this form.
 
-To avoid both problems, **prefer `command playwright-cli …`** — it bypasses any alias and behaves identically when no alias is set. If you see `Unknown option: --persistent` or similar, the alias is leaking; switch to `command playwright-cli`. All examples below use this form.
+## Pick a free CDP port
 
-```bash
-command playwright-cli attach --cdp="http://localhost:9333"
-command playwright-cli snapshot
-command playwright-cli eval "document.title"
-```
-
-## Picking a CDP port — never trust 9333 blindly
-
-Another Orca worktree (or a stale dev server) may already hold port 9333. If you launch a new dev build and the port is taken, electron-vite will happily start *without* a debugger, and `curl http://localhost:9333/json` will return the OLD app — you'll attach to the wrong process and see an empty DOM or stale state.
-
-**Before launching, pick a free port:**
+Port 9333 is a convention, not a guarantee — another worktree may hold it, and electron-vite will start without a debugger, letting you silently attach to the old app.
 
 ```bash
-# Find a free port in the 9333–9350 range
 for p in 9333 9334 9335 9336 9337 9338 9339 9340; do
   if ! lsof -i :$p >/dev/null 2>&1; then PORT=$p; break; fi
 done
-echo "Using port $PORT"
+# After attach, verify you hit the right worktree:
+command playwright-cli eval "window.__store.getState().worktreesByRepo"
 ```
-
-**After attaching, verify you're talking to the right worktree** (not an old one on the same port):
-
-```bash
-command playwright-cli eval "(() => { const s = window.__store?.getState(); const wts = Object.values(s.worktreesByRepo || {}).flat(); const match = wts.find(w => w.path.includes('YOUR-WORKTREE-NAME')); return match ? 'correct worktree' : 'WRONG WORKTREE — detach'; })()"
-```
-
-If it's the wrong worktree, `command playwright-cli close` and relaunch on a different port.
 
 ## Launching Orca Dev Build with CDP
 
 Orca uses electron-vite for dev builds. The correct way to launch with CDP:
 
 ```bash
-# Pick a free port first (see section above)
-# Launch Orca dev with remote debugging (run in background)
+# Launch with remote debugging (PORT picked above)
 node config/scripts/run-electron-vite-dev.mjs --remote-debugging-port=$PORT 2>&1 &
 
-# Poll until CDP is listening, then attach
-for i in $(seq 1 10); do
-  sleep 3
-  if curl -s http://localhost:$PORT/json | grep -q '"type"'; then break; fi
-done
+# Wait for "DevTools listening on ws://..." in output, then attach
 command playwright-cli attach --cdp="http://localhost:$PORT"
 ```
 
@@ -97,7 +74,7 @@ command playwright-cli attach --cdp="http://localhost:$PORT"
 - Pass `--remote-debugging-port=NNNN` directly to the script — do NOT use `pnpm run dev -- --` (the double `--` breaks Chromium flag parsing)
 - electron-vite also supports `REMOTE_DEBUGGING_PORT` env var: `REMOTE_DEBUGGING_PORT=$PORT pnpm run dev`
 - The Zustand store is exposed at `window.__store` — use `window.__store.getState()` and `window.__store.getState().someAction()` to read/mutate state
-- Port 9333 is a convention, NOT a guarantee. Always probe before binding (see "Picking a CDP port" above).
+- Use port 9333 (not 9222) to avoid conflicts with other Electron apps
 
 ### Accessing Orca State via eval
 

--- a/.agents/skills/electron/SKILL.md
+++ b/.agents/skills/electron/SKILL.md
@@ -34,43 +34,82 @@ open -a "Slack" --args --remote-debugging-port=9222
 sleep 3
 
 # Attach playwright-cli to the app via CDP
-playwright-cli attach --cdp="http://localhost:9222"
+command playwright-cli attach --cdp="http://localhost:9222"
 
 # Standard workflow from here
-playwright-cli snapshot
-playwright-cli click e5
-playwright-cli screenshot
+command playwright-cli snapshot
+command playwright-cli click e5
+command playwright-cli screenshot
 ```
+
+## Invoking `playwright-cli` — prefer `command` prefix
+
+Some developers alias `playwright-cli` in their shell (e.g. `alias playwright-cli='playwright-cli --persistent'`). Interactive aliases don't always fire under non-interactive shells like the Bash tool, and when they do, flags can leak into subcommands and cause `Unknown option: --persistent`.
+
+To avoid both problems, **prefer `command playwright-cli …`** — it bypasses any alias and behaves identically when no alias is set. If you see `Unknown option: --persistent` or similar, the alias is leaking; switch to `command playwright-cli`. All examples below use this form.
+
+```bash
+command playwright-cli attach --cdp="http://localhost:9333"
+command playwright-cli snapshot
+command playwright-cli eval "document.title"
+```
+
+## Picking a CDP port — never trust 9333 blindly
+
+Another Orca worktree (or a stale dev server) may already hold port 9333. If you launch a new dev build and the port is taken, electron-vite will happily start *without* a debugger, and `curl http://localhost:9333/json` will return the OLD app — you'll attach to the wrong process and see an empty DOM or stale state.
+
+**Before launching, pick a free port:**
+
+```bash
+# Find a free port in the 9333–9350 range
+for p in 9333 9334 9335 9336 9337 9338 9339 9340; do
+  if ! lsof -i :$p >/dev/null 2>&1; then PORT=$p; break; fi
+done
+echo "Using port $PORT"
+```
+
+**After attaching, verify you're talking to the right worktree** (not an old one on the same port):
+
+```bash
+command playwright-cli eval "(() => { const s = window.__store?.getState(); const wts = Object.values(s.worktreesByRepo || {}).flat(); const match = wts.find(w => w.path.includes('YOUR-WORKTREE-NAME')); return match ? 'correct worktree' : 'WRONG WORKTREE — detach'; })()"
+```
+
+If it's the wrong worktree, `command playwright-cli close` and relaunch on a different port.
 
 ## Launching Orca Dev Build with CDP
 
 Orca uses electron-vite for dev builds. The correct way to launch with CDP:
 
 ```bash
+# Pick a free port first (see section above)
 # Launch Orca dev with remote debugging (run in background)
-node config/scripts/run-electron-vite-dev.mjs --remote-debugging-port=9333 2>&1 &
+node config/scripts/run-electron-vite-dev.mjs --remote-debugging-port=$PORT 2>&1 &
 
-# Wait for "DevTools listening on ws://..." in the output, then attach
-playwright-cli attach --cdp="http://localhost:9333"
+# Poll until CDP is listening, then attach
+for i in $(seq 1 10); do
+  sleep 3
+  if curl -s http://localhost:$PORT/json | grep -q '"type"'; then break; fi
+done
+command playwright-cli attach --cdp="http://localhost:$PORT"
 ```
 
 **Key details:**
 - Pass `--remote-debugging-port=NNNN` directly to the script — do NOT use `pnpm run dev -- --` (the double `--` breaks Chromium flag parsing)
-- electron-vite also supports `REMOTE_DEBUGGING_PORT` env var: `REMOTE_DEBUGGING_PORT=9333 pnpm run dev`
+- electron-vite also supports `REMOTE_DEBUGGING_PORT` env var: `REMOTE_DEBUGGING_PORT=$PORT pnpm run dev`
 - The Zustand store is exposed at `window.__store` — use `window.__store.getState()` and `window.__store.getState().someAction()` to read/mutate state
-- Use port 9333 (not 9222) to avoid conflicts with other Electron apps
+- Port 9333 is a convention, NOT a guarantee. Always probe before binding (see "Picking a CDP port" above).
 
 ### Accessing Orca State via eval
 
 ```bash
 # Read store state
-playwright-cli eval "(() => { const s = window.__store?.getState(); return JSON.stringify({ activeWorktreeId: s.activeWorktreeId, activeTabId: s.activeTabId, activeFileId: s.activeFileId, activeTabType: s.activeTabType }); })()"
+command playwright-cli eval "(() => { const s = window.__store?.getState(); return JSON.stringify({ activeWorktreeId: s.activeWorktreeId, activeTabId: s.activeTabId, activeFileId: s.activeFileId, activeTabType: s.activeTabType }); })()"
 
 # Open an editor file
-playwright-cli eval "(() => { const s = window.__store?.getState(); const wtId = s.activeWorktreeId; s.openFile({ worktreeId: wtId, filePath: '/path/to/file', relativePath: 'file.ts', mode: 'edit', language: 'typescript' }); return 'done'; })()"
+command playwright-cli eval "(() => { const s = window.__store?.getState(); const wtId = s.activeWorktreeId; s.openFile({ worktreeId: wtId, filePath: '/path/to/file', relativePath: 'file.ts', mode: 'edit', language: 'typescript' }); return 'done'; })()"
 
 # Close a file
-playwright-cli eval "(() => { window.__store.getState().closeFile('/path/to/file'); return 'closed'; })()"
+command playwright-cli eval "(() => { window.__store.getState().closeFile('/path/to/file'); return 'closed'; })()"
 ```
 
 ## Launching Electron Apps with CDP
@@ -128,18 +167,18 @@ lsof -i :9222
 curl -s http://localhost:9222/json
 
 # Attach playwright-cli
-playwright-cli attach --cdp="http://localhost:9222"
+command playwright-cli attach --cdp="http://localhost:9222"
 ```
 
 ## Attaching
 
 ```bash
 # Attach to a specific CDP port
-playwright-cli attach --cdp="http://localhost:9222"
+command playwright-cli attach --cdp="http://localhost:9222"
 
 # Attach with a named session (for controlling multiple apps)
-playwright-cli -s=slack attach --cdp="http://localhost:9222"
-playwright-cli -s=vscode attach --cdp="http://localhost:9223"
+command playwright-cli -s=slack attach --cdp="http://localhost:9222"
+command playwright-cli -s=vscode attach --cdp="http://localhost:9223"
 ```
 
 After `attach`, all subsequent commands (in that session) target the connected app.
@@ -150,10 +189,10 @@ Electron apps may have multiple windows or webviews. Use tab commands to list an
 
 ```bash
 # List all available targets
-playwright-cli tab-list
+command playwright-cli tab-list
 
 # Switch to a specific tab by index
-playwright-cli tab-select 2
+command playwright-cli tab-select 2
 ```
 
 If `tab-list` doesn't show all targets, query the CDP endpoint directly to see everything:
@@ -173,39 +212,39 @@ for i, t in enumerate(json.load(sys.stdin)):
 ```bash
 open -a "Slack" --args --remote-debugging-port=9222
 sleep 3
-playwright-cli attach --cdp="http://localhost:9222"
-playwright-cli snapshot
+command playwright-cli attach --cdp="http://localhost:9222"
+command playwright-cli snapshot
 # Read the snapshot output to identify UI elements
-playwright-cli click e10   # Navigate to a section
-playwright-cli snapshot    # Re-snapshot after navigation
+command playwright-cli click e10   # Navigate to a section
+command playwright-cli snapshot    # Re-snapshot after navigation
 ```
 
 ### Take Screenshots of Desktop Apps
 
 ```bash
-playwright-cli attach --cdp="http://localhost:9222"
-playwright-cli screenshot
-playwright-cli screenshot e5  # Screenshot a specific element
-playwright-cli screenshot --filename=app-state.png
+command playwright-cli attach --cdp="http://localhost:9222"
+command playwright-cli screenshot
+command playwright-cli screenshot e5  # Screenshot a specific element
+command playwright-cli screenshot --filename=app-state.png
 ```
 
 ### Extract Data from a Desktop App
 
 ```bash
-playwright-cli attach --cdp="http://localhost:9222"
-playwright-cli snapshot
-playwright-cli eval "document.title"
-playwright-cli eval "el => el.textContent" e5
+command playwright-cli attach --cdp="http://localhost:9222"
+command playwright-cli snapshot
+command playwright-cli eval "document.title"
+command playwright-cli eval "el => el.textContent" e5
 ```
 
 ### Fill Forms in Desktop Apps
 
 ```bash
-playwright-cli attach --cdp="http://localhost:9222"
-playwright-cli snapshot
-playwright-cli fill e3 "search query"
-playwright-cli press Enter
-playwright-cli snapshot
+command playwright-cli attach --cdp="http://localhost:9222"
+command playwright-cli snapshot
+command playwright-cli fill e3 "search query"
+command playwright-cli press Enter
+command playwright-cli snapshot
 ```
 
 ### Run Multiple Apps Simultaneously
@@ -214,14 +253,14 @@ Use named sessions to control multiple Electron apps at the same time:
 
 ```bash
 # Attach to Slack
-playwright-cli -s=slack attach --cdp="http://localhost:9222"
+command playwright-cli -s=slack attach --cdp="http://localhost:9222"
 
 # Attach to VS Code
-playwright-cli -s=vscode attach --cdp="http://localhost:9223"
+command playwright-cli -s=vscode attach --cdp="http://localhost:9223"
 
 # Interact with each independently
-playwright-cli -s=slack snapshot
-playwright-cli -s=vscode snapshot
+command playwright-cli -s=slack snapshot
+command playwright-cli -s=vscode snapshot
 ```
 
 ### Run Custom Playwright Code
@@ -229,7 +268,7 @@ playwright-cli -s=vscode snapshot
 For advanced scenarios, use `run-code` to execute arbitrary Playwright code:
 
 ```bash
-playwright-cli run-code "async page => {
+command playwright-cli run-code "async page => {
   await page.waitForSelector('.loading', { state: 'hidden' });
   const items = await page.locator('.item').allTextContents();
   return items;
@@ -284,11 +323,11 @@ If an app is built with Electron, it supports `--remote-debugging-port` and can 
 
 ```bash
 # Close the playwright-cli session (does NOT kill the Electron app)
-playwright-cli close
+command playwright-cli close
 
 # Close a named session
-playwright-cli -s=slack close
+command playwright-cli -s=slack close
 
 # Close all playwright-cli sessions
-playwright-cli close-all
+command playwright-cli close-all
 ```


### PR DESCRIPTION
## Summary
- Prefer `command playwright-cli` in all examples to bypass user shell aliases that leak flags like `--persistent` into subcommands.
- Add CDP port probing guidance (loop 9333–9340) so agents don't attach to a stale dev server left by another worktree.
- Add a post-attach verification snippet that confirms the connected app is the intended worktree before proceeding.

## Test plan
- [ ] Skim rendered SKILL.md on GitHub to confirm formatting