### PR TITLE
fix(terminal): clear drag-select state after Cmd/Ctrl+click on a link

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
@@ -106,7 +106,11 @@ describe('handleOscLink', () => {
     expect(openUrlMock).toHaveBeenCalledWith('https://example.com/')
     expect(createBrowserTabMock).not.toHaveBeenCalled()
     expect(preventDefault).toHaveBeenCalled()
-    expect(stopPropagation).toHaveBeenCalled()
+    // Why: we intentionally do NOT stopPropagation — xterm's SelectionService
+    // relies on the mouseup bubbling to ownerDocument to detach its drag-select
+    // mousemove listener. Stopping propagation was causing phantom selections
+    // after Cmd+clicking a link and then moving the mouse back over the terminal.
+    expect(stopPropagation).not.toHaveBeenCalled()
   })
 
   it('defaults to Orca when settings have not hydrated yet', () => {

--- a/src/renderer/src/components/terminal-pane/terminal-link-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-handlers.ts
@@ -235,8 +235,13 @@ export function handleOscLink(
   // Why: xterm renders URL links as clickable anchors. Once Orca decides to
   // handle a modified click itself, we must suppress the browser's default
   // anchor navigation or Electron will still launch the system browser.
+  // Note: we intentionally do NOT stopPropagation here — xterm's
+  // SelectionService listens for mouseup on ownerDocument to clear the
+  // pending drag-select state initiated by the mousedown of the same click.
+  // Stopping propagation leaves SelectionService's mousemove/mouseup handlers
+  // attached, so returning focus to the terminal and moving the mouse (even
+  // without holding a button) extends a selection until the next click/Esc.
   event?.preventDefault?.()
-  event?.stopPropagation?.()
 
   let parsed: URL
   try {

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -393,7 +393,18 @@ export function useTerminalPaneLifecycle({
         selectionDisposablesRef.current.set(pane.id, selectionDisposable)
         pane.terminal.options.linkHandler = {
           allowNonHttpProtocols: true,
-          activate: (event, text) => handleOscLink(text, event as MouseEvent | undefined, linkDeps),
+          activate: (event, text) => {
+            handleOscLink(text, event as MouseEvent | undefined, linkDeps)
+            // Why: Cmd/Ctrl+clicking a link activates Orca handling (open file,
+            // new browser tab, system browser) which can steal focus from the
+            // terminal before the click's mouseup reaches ownerDocument. Without
+            // that mouseup, xterm's SelectionService leaves its drag-select
+            // mousemove listener attached, so returning to the terminal and
+            // moving the mouse extends a selection until the next click/Esc.
+            // clearSelection() explicitly detaches those listeners (see
+            // SelectionService._removeMouseDownListeners).
+            pane.terminal.clearSelection()
+          },
           // Show bottom-left tooltip on hover for OSC 8 hyperlinks (e.g.
           // GitHub owner/repo#issue references emitted by CLI tools) — same
           // behaviour as the WebLinksAddon provides for plain-text URLs.
@@ -556,6 +567,14 @@ export function useTerminalPaneLifecycle({
           return
         }
         void handleOscLink(url, event, linkDeps)
+        // Why: Cmd/Ctrl+click on a plain-text URL (WebLinksAddon) takes focus
+        // away from the terminal before the click's mouseup reaches
+        // ownerDocument. That leaves xterm's SelectionService drag-select
+        // mousemove listener attached, so subsequent mouse motion extends a
+        // phantom selection until the next click/Esc. Explicitly clearing the
+        // selection also detaches those listeners (see
+        // SelectionService._removeMouseDownListeners).
+        managerRef.current?.getActivePane()?.terminal.clearSelection()
       }
     })
 


### PR DESCRIPTION
## Summary

- Cmd/Ctrl+clicking a terminal link activates Orca handling (open file, new browser tab, system browser) that steals focus before the click's `mouseup` bubbles to `ownerDocument`. xterm's `SelectionService` relies on that document-level `mouseup` to detach its drag-select `mousemove` listener, so returning to the terminal and moving the mouse kept extending a phantom selection until the next click or Esc.
- Explicitly call `terminal.clearSelection()` in both link activation paths (OSC 8 link handler and `WebLinksAddon` `onLinkClick`), which invokes xterm's `SelectionService._removeMouseDownListeners()` and tears down the orphaned listeners.
- Drop the `event.stopPropagation()` in `handleOscLink` that was also preventing the normal `mouseup` bubble path from reaching `ownerDocument`. `preventDefault()` is retained to keep Electron from opening the anchor in the system browser when Orca already handled the click.

Root cause trace:
- `node_modules/@xterm/xterm/src/browser/services/SelectionService.ts:497-515` attaches `mousemove`/`mouseup` on `ownerDocument` on `mousedown`, detaches on `mouseup`.
- `node_modules/@xterm/xterm/src/browser/services/SelectionService.ts:267-272` shows `clearSelection()` public API also calls `_removeMouseDownListeners()`.

## Test plan

- [x] `pnpm vitest run src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts` passes (updated assertion for `stopPropagation` not being called)
- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm run lint` on changed files clean
- [x] Manual: `echo https://example.com` → Cmd+click the URL → return to the terminal → move the mouse; no phantom selection extends
- [ ] Verify file paths (Cmd+click a `./foo.ts:12`) also no longer leave a drag-select armed
- [ ] Verify Shift+Cmd+click still routes to the system browser