### PR TITLE
fix(worktree): seed nav history with hydrated active worktree

### DIFF
--- a/src/renderer/src/store/slices/terminals-hydration.test.ts
+++ b/src/renderer/src/store/slices/terminals-hydration.test.ts
@@ -80,6 +80,7 @@ globalThis.window = { api: mockApi }
 
 import type { WorkspaceSessionState } from '../../../../shared/types'
 import { createTestStore, makeLayout, makeTab, makeWorktree, seedStore } from './store-test-helpers'
+import { canGoBackWorktreeHistory } from './worktree-nav-history'
 
 describe('hydrateWorkspaceSession', () => {
   beforeEach(() => {
@@ -155,6 +156,12 @@ describe('hydrateWorkspaceSession', () => {
     const store = createTestStore()
     seedStore(store, { worktreesByRepo: {} })
 
+    // Why: pre-seed non-default stale values so the assertions below can only
+    // pass if hydration actively overwrites the fields. Without this, the
+    // slice's default `[]` / `-1` would satisfy the expectations even if
+    // hydrateWorkspaceSession never touched nav history in this branch.
+    store.setState({ worktreeNavHistory: ['stale-a', 'stale-b'], worktreeNavHistoryIndex: 1 })
+
     const session: WorkspaceSessionState = {
       activeRepoId: null,
       activeWorktreeId: null,
@@ -177,6 +184,12 @@ describe('hydrateWorkspaceSession', () => {
     const store = createTestStore()
     seedStore(store, { worktreesByRepo: { repo1: [] } })
 
+    // Why: pre-seed non-default stale values so the assertions below can only
+    // pass if hydration actively overwrites the fields. Without this, the
+    // slice's default `[]` / `-1` would satisfy the expectations even if
+    // hydrateWorkspaceSession never cleared nav history for an invalid worktree.
+    store.setState({ worktreeNavHistory: ['stale-a', 'stale-b'], worktreeNavHistoryIndex: 1 })
+
     const session: WorkspaceSessionState = {
       activeRepoId: 'repo1',
       activeWorktreeId: 'repo1::/missing',
@@ -190,5 +203,39 @@ describe('hydrateWorkspaceSession', () => {
     expect(store.getState().activeWorktreeId).toBeNull()
     expect(store.getState().worktreeNavHistory).toEqual([])
     expect(store.getState().worktreeNavHistoryIndex).toBe(-1)
+  })
+
+  it('records a subsequent visit on top of the hydration seed so Back is enabled after the first click', () => {
+    // Why: pins down the PR's user-visible contract — after hydration seeds
+    // the restored worktree at index 0, the very first sidebar click appends
+    // a new entry at index 1, which is what makes Back enabled immediately.
+    // Without the seed, the first click would produce a single-entry history
+    // and Back would stay disabled until a second click.
+    const store = createTestStore()
+    const wt1 = 'repo1::/wt-1'
+    const wt2 = 'repo1::/wt-2'
+    seedStore(store, {
+      worktreesByRepo: {
+        repo1: [
+          makeWorktree({ id: wt1, repoId: 'repo1', path: '/wt-1' }),
+          makeWorktree({ id: wt2, repoId: 'repo1', path: '/wt-2' })
+        ]
+      }
+    })
+
+    const session: WorkspaceSessionState = {
+      activeRepoId: 'repo1',
+      activeWorktreeId: wt1,
+      activeTabId: null,
+      tabsByWorktree: {},
+      terminalLayoutsByTabId: {}
+    }
+
+    store.getState().hydrateWorkspaceSession(session)
+    store.getState().recordWorktreeVisit(wt2)
+
+    expect(store.getState().worktreeNavHistory).toEqual([wt1, wt2])
+    expect(store.getState().worktreeNavHistoryIndex).toBe(1)
+    expect(canGoBackWorktreeHistory(store.getState())).toBe(true)
   })
 })

--- a/src/renderer/src/store/slices/terminals-hydration.test.ts
+++ b/src/renderer/src/store/slices/terminals-hydration.test.ts
@@ -122,4 +122,73 @@ describe('hydrateWorkspaceSession', () => {
       buffersByLeafId: { 'pane:1': 'buffer' }
     })
   })
+
+  it('seeds worktree nav history with the restored active worktree', () => {
+    // Why: without seeding, the first sidebar click after startup becomes the
+    // only history entry, so Back stays disabled until the user clicks a
+    // second worktree. Seeding here ensures the restored worktree is already
+    // at index 0 so the very first user-driven switch has a prior entry to
+    // go Back to.
+    const store = createTestStore()
+    const worktreeId = 'repo1::/wt-1'
+    seedStore(store, {
+      worktreesByRepo: {
+        repo1: [makeWorktree({ id: worktreeId, repoId: 'repo1', path: '/wt-1' })]
+      }
+    })
+
+    const session: WorkspaceSessionState = {
+      activeRepoId: 'repo1',
+      activeWorktreeId: worktreeId,
+      activeTabId: null,
+      tabsByWorktree: {},
+      terminalLayoutsByTabId: {}
+    }
+
+    store.getState().hydrateWorkspaceSession(session)
+
+    expect(store.getState().worktreeNavHistory).toEqual([worktreeId])
+    expect(store.getState().worktreeNavHistoryIndex).toBe(0)
+  })
+
+  it('leaves nav history empty when no active worktree is restored', () => {
+    const store = createTestStore()
+    seedStore(store, { worktreesByRepo: {} })
+
+    const session: WorkspaceSessionState = {
+      activeRepoId: null,
+      activeWorktreeId: null,
+      activeTabId: null,
+      tabsByWorktree: {},
+      terminalLayoutsByTabId: {}
+    }
+
+    store.getState().hydrateWorkspaceSession(session)
+
+    expect(store.getState().worktreeNavHistory).toEqual([])
+    expect(store.getState().worktreeNavHistoryIndex).toBe(-1)
+  })
+
+  it('drops invalid restored worktree from nav history seed', () => {
+    // Why: hydrateWorkspaceSession validates activeWorktreeId against the
+    // current worktreesByRepo and sets it to null when stale. The history
+    // seed must follow that validation, not the raw session field — otherwise
+    // a deleted worktree would sit at history[0] and fail activation on Back.
+    const store = createTestStore()
+    seedStore(store, { worktreesByRepo: { repo1: [] } })
+
+    const session: WorkspaceSessionState = {
+      activeRepoId: 'repo1',
+      activeWorktreeId: 'repo1::/missing',
+      activeTabId: null,
+      tabsByWorktree: {},
+      terminalLayoutsByTabId: {}
+    }
+
+    store.getState().hydrateWorkspaceSession(session)
+
+    expect(store.getState().activeWorktreeId).toBeNull()
+    expect(store.getState().worktreeNavHistory).toEqual([])
+    expect(store.getState().worktreeNavHistoryIndex).toBe(-1)
+  })
 })

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -1139,6 +1139,15 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         pendingReconnectWorktreeIds,
         pendingReconnectTabByWorktree,
         pendingReconnectPtyIdByTabId,
+        // Why: seed worktree nav history with the hydrated active worktree so
+        // the first user-driven activation (e.g. a sidebar click to a different
+        // worktree) has a prior entry to go Back to. Without this the restored
+        // startup worktree is never recorded — recordWorktreeVisit only runs
+        // inside activateAndRevealWorktree, which hydration bypasses — so Back
+        // stays disabled until a second click produces the first-ever history
+        // pair.
+        worktreeNavHistory: activeWorktreeId ? [activeWorktreeId] : [],
+        worktreeNavHistoryIndex: activeWorktreeId ? 0 : -1,
         ptyIdsByTabId: Object.fromEntries(
           Object.values(tabsByWorktree)
             .flat()


### PR DESCRIPTION
## Summary
- On startup, `hydrateWorkspaceSession` restored `activeWorktreeId` but never recorded it in `worktreeNavHistory`. Only `activateAndRevealWorktree` calls `recordWorktreeVisit`, and hydration bypasses that path — so the first sidebar click became the sole history entry and Back stayed disabled until a second click produced the first-ever history pair.
- Seed `worktreeNavHistory` with the validated `activeWorktreeId` at index 0 inside `hydrateWorkspaceSession`. When no active worktree is restored (Landing) or the restored id is stale, history stays empty and the index stays at `-1`.
- Added unit tests in `terminals-hydration.test.ts` covering: seed on valid restore, no-seed when no active worktree, no-seed when restored worktree is invalid, and the end-to-end "first click enables Back" contract.

## Test plan
- [x] `pnpm exec vitest run src/renderer/src/store/slices/terminals-hydration.test.ts` — all 5 tests pass
- [x] `pnpm exec vitest run src/renderer/src/store/slices/worktree-nav-history.test.ts` — slice tests still pass
- [x] `pnpm typecheck`
- [x] Manual: start Orca, click a different workspace in the sidebar, confirm Back is immediately enabled and returns to the startup workspace