### PR TITLE
fix(file-explorer): prevent scroll snap after native file drop

### DIFF
--- a/src/renderer/src/components/right-sidebar/FileExplorer.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorer.tsx
@@ -182,14 +182,16 @@ function FileExplorerInner(): React.JSX.Element {
     refreshDir,
     refreshTree,
     inlineInput,
-    dragSourcePath
+    dragSourcePath,
+    isNativeDragOver
   })
 
   useFileExplorerImport({
     worktreePath,
     activeWorktreeId,
     refreshDir,
-    clearNativeDragState
+    clearNativeDragState,
+    setSelectedPath
   })
 
   const totalCount = flatRows.length + (inlineInputIndex >= 0 ? 1 : 0)

--- a/src/renderer/src/components/right-sidebar/useFileExplorerDragDrop.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerDragDrop.ts
@@ -232,7 +232,12 @@ export function useFileExplorerDragDrop({
     nativeRootDragCounterRef.current = 0
     setIsNativeDragOver(false)
     setNativeDropTargetDir(null)
-  }, [])
+    // Why: for native OS file drops the preload intercepts the drop event and
+    // stops propagation, so React's onDrop (which calls stopDragEdgeScroll)
+    // never fires. Without this, the edge-scroll rAF loop keeps running with
+    // the last recorded cursor Y, continuously overriding the user's scroll.
+    stopDragEdgeScroll()
+  }, [stopDragEdgeScroll])
 
   const rootDragHandlers = {
     onDragOver: useCallback(

--- a/src/renderer/src/components/right-sidebar/useFileExplorerImport.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerImport.ts
@@ -1,11 +1,12 @@
 import { useEffect, useRef } from 'react'
-import { useAppStore } from '@/store'
+import type { Dispatch, SetStateAction } from 'react'
 
 type UseFileExplorerImportParams = {
   worktreePath: string | null
   activeWorktreeId: string | null
   refreshDir: (dirPath: string) => Promise<void>
   clearNativeDragState: () => void
+  setSelectedPath: Dispatch<SetStateAction<string | null>>
 }
 
 /**
@@ -21,10 +22,9 @@ export function useFileExplorerImport({
   worktreePath,
   activeWorktreeId,
   refreshDir,
-  clearNativeDragState
+  clearNativeDragState,
+  setSelectedPath
 }: UseFileExplorerImportParams): void {
-  const revealInExplorer = useAppStore((s) => s.revealInExplorer)
-
   // Refs to avoid re-subscribing IPC listener on every render
   const worktreePathRef = useRef(worktreePath)
   worktreePathRef.current = worktreePath
@@ -34,8 +34,8 @@ export function useFileExplorerImport({
   refreshDirRef.current = refreshDir
   const clearNativeDragStateRef = useRef(clearNativeDragState)
   clearNativeDragStateRef.current = clearNativeDragState
-  const revealInExplorerRef = useRef(revealInExplorer)
-  revealInExplorerRef.current = revealInExplorer
+  const setSelectedPathRef = useRef(setSelectedPath)
+  setSelectedPathRef.current = setSelectedPath
 
   useEffect(() => {
     return window.api.ui.onFileDrop((data) => {
@@ -65,10 +65,14 @@ export function useFileExplorerImport({
           // Refresh the destination directory once per gesture
           await refreshDirRef.current(destinationDir)
 
-          // Reveal and flash the first successfully imported path
+          // Why: only select (highlight) the first imported file — don't trigger
+          // the full reveal machinery (scrollToIndex + flash) because the user
+          // already knows where they dropped the file. The reveal's aggressive
+          // scroll-to-center races with FS watcher refreshes and can snap the
+          // viewport back to the top of the tree.
           const imported = results.filter((r) => r.status === 'imported')
           if (imported.length > 0) {
-            revealInExplorerRef.current(wtId, imported[0].destPath)
+            setSelectedPathRef.current(imported[0].destPath)
           }
         } finally {
           clearNativeDragStateRef.current()

--- a/src/renderer/src/components/right-sidebar/useFileExplorerWatch.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerWatch.ts
@@ -23,6 +23,7 @@ type UseFileExplorerWatchParams = {
   refreshTree: () => Promise<void>
   inlineInput: InlineInput | null
   dragSourcePath: string | null
+  isNativeDragOver: boolean
 }
 
 export function getExternalFileChangeRelativePath(
@@ -76,7 +77,8 @@ export function useFileExplorerWatch({
   refreshDir,
   refreshTree,
   inlineInput,
-  dragSourcePath
+  dragSourcePath,
+  isNativeDragOver
 }: UseFileExplorerWatchParams): void {
   // Keep refs for values accessed inside the event handler to avoid
   // re-subscribing the IPC listener on every render.
@@ -94,6 +96,9 @@ export function useFileExplorerWatch({
 
   const dragSourceRef = useRef(dragSourcePath)
   dragSourceRef.current = dragSourcePath
+
+  const isNativeDragOverRef = useRef(isNativeDragOver)
+  isNativeDragOverRef.current = isNativeDragOver
 
   // Why: refreshDir and refreshTree are stored as refs so the merged
   // subscribe+event effect does not re-subscribe the IPC listener when
@@ -239,8 +244,15 @@ export function useFileExplorerWatch({
     const handleFsChanged = (payload: FsChangedPayload): void => {
       // Why: defer watcher-triggered refreshes while inline input or drag-drop
       // is active to avoid displacing the inline input row or shifting rows
-      // under the drag cursor (design §6.2).
-      if (inlineInputRef.current !== null || dragSourceRef.current !== null) {
+      // under the drag cursor (design §6.2). Native OS file drags (e.g. PDFs)
+      // never set dragSourcePath, so we also check isNativeDragOver to prevent
+      // FS create events from the import racing with the tree refresh and
+      // causing the virtualizer to snap the scroll position.
+      if (
+        inlineInputRef.current !== null ||
+        dragSourceRef.current !== null ||
+        isNativeDragOverRef.current
+      ) {
         deferredRef.current.push(payload)
         return
       }
@@ -259,7 +271,12 @@ export function useFileExplorerWatch({
 
   // ── Flush deferred events when interaction ends ────────────────────
   useEffect(() => {
-    if (inlineInput === null && dragSourcePath === null && deferredRef.current.length > 0) {
+    if (
+      inlineInput === null &&
+      dragSourcePath === null &&
+      !isNativeDragOver &&
+      deferredRef.current.length > 0
+    ) {
       const deferred = deferredRef.current.splice(0)
       // Why: replay every deferred payload through `processPayload` so the
       // tree cache reconciles to disk state after inline input or drag ends
@@ -279,5 +296,5 @@ export function useFileExplorerWatch({
         void refreshTreeRef.current()
       }
     }
-  }, [inlineInput, dragSourcePath, worktreePath])
+  }, [inlineInput, dragSourcePath, isNativeDragOver, worktreePath])
 }


### PR DESCRIPTION
## Summary
- Replaced `revealInExplorer` (scroll-to-center + flash) with `setSelectedPath` after native file import — the user already sees where they dropped the file, so the aggressive scroll is unnecessary and causes the viewport to snap back up.
- Added `isNativeDragOver` to the FS watcher deferral guard so create events during native OS drags (e.g. PDFs) are queued and flushed cleanly after the drag ends, matching the existing behavior for internal drags.

## Context
Reported bug: after dragging a PDF into the file explorer, scrolling down to find the added file would cause the list to auto-scroll back up. Root cause was a race between the reveal machinery's `scrollToIndex({ align: 'center' })` and concurrent FS watcher events that recomputed `flatRows` — native OS drags never set `dragSourcePath`, so the deferral guard didn't apply.

## Test plan
- [ ] Drag a PDF (or any external file) into the file explorer with a long file list
- [ ] Verify the file appears and is selected/highlighted without the viewport jumping
- [ ] Verify scrolling works normally after the drop
- [ ] Verify internal drag-and-drop (moving files within the explorer) still works
- [ ] Verify "Reveal in Explorer" from Source Control still scrolls and flashes correctly