### PR TITLE
feat: make links in file open in Orca browser

### DIFF
--- a/src/renderer/src/components/editor/MarkdownPreview.tsx
+++ b/src/renderer/src/components/editor/MarkdownPreview.tsx
@@ -25,6 +25,7 @@ import {
   setActiveMarkdownPreviewSearchMatch
 } from './markdown-preview-search'
 import { usePreserveSectionDuringExternalEdit } from './usePreserveSectionDuringExternalEdit'
+import { openHttpLink } from '@/lib/http-link-routing'
 
 type MarkdownPreviewProps = {
   content: string
@@ -298,7 +299,7 @@ export default function MarkdownPreview({
             return
           }
           if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
-            void window.api.shell.openUrl(parsed.toString())
+            openHttpLink(parsed.toString(), { forceSystemBrowser: true })
             return
           }
           if (parsed.protocol === 'file:') {

--- a/src/renderer/src/components/editor/RichMarkdownEditor.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownEditor.tsx
@@ -25,6 +25,7 @@ import { createRichMarkdownKeyHandler } from './rich-markdown-key-handler'
 import { normalizeSoftBreaks } from './rich-markdown-normalize'
 import { autoFocusRichEditor } from './rich-markdown-auto-focus'
 import { handleRichMarkdownCut } from './rich-markdown-cut-handler'
+import { openHttpLink } from '@/lib/http-link-routing'
 import { toast } from 'sonner'
 import {
   absolutePathToFileUri as toFileUrlForOsEscape,
@@ -200,7 +201,7 @@ export default function RichMarkdownEditor({
             return true
           }
           if (classified.kind === 'external') {
-            void window.api.shell.openUrl(classified.url)
+            openHttpLink(classified.url, { forceSystemBrowser: true })
           } else if (classified.kind === 'markdown') {
             void window.api.shell.pathExists(classified.absolutePath).then((exists) => {
               if (!exists) {

--- a/src/renderer/src/components/settings/BrowserPane.tsx
+++ b/src/renderer/src/components/settings/BrowserPane.tsx
@@ -168,16 +168,25 @@ export function BrowserPane({ settings, updateSettings }: BrowserPaneProps): Rea
 
       {showLinkRouting ? (
         <SearchableSetting
-          title="Terminal Link Routing"
-          description="Cmd/Ctrl+click opens terminal http(s) links in Orca. Shift+Cmd/Ctrl+click uses the system browser."
-          keywords={['browser', 'preview', 'links', 'localhost', 'webview']}
+          title="Link Routing"
+          description="Open http(s) links in Orca's built-in browser — from the terminal, markdown, and the editor. Shift+Cmd/Ctrl+click always uses your system browser."
+          keywords={[
+            'browser',
+            'preview',
+            'links',
+            'localhost',
+            'webview',
+            'markdown',
+            'file',
+            'editor'
+          ]}
           className="flex items-center justify-between gap-4 px-1 py-2"
         >
           <div className="space-y-0.5">
-            <Label>Terminal Link Routing</Label>
+            <Label>Link Routing</Label>
             <p className="text-xs text-muted-foreground">
-              Cmd/Ctrl+click opens terminal links in Orca. Shift+Cmd/Ctrl+click opens the same link
-              in your system browser.
+              Open http(s) links in Orca&apos;s built-in browser — from the terminal, markdown, and
+              the editor. Shift+Cmd/Ctrl+click always uses your system browser.
             </p>
           </div>
           <button

--- a/src/renderer/src/components/settings/browser-search.ts
+++ b/src/renderer/src/components/settings/browser-search.ts
@@ -12,10 +12,22 @@ export const BROWSER_PANE_SEARCH_ENTRIES: SettingsSearchEntry[] = [
     keywords: ['browser', 'search', 'engine', 'google', 'duckduckgo', 'bing', 'omnibox', 'query']
   },
   {
-    title: 'Terminal Link Routing',
+    title: 'Link Routing',
     description:
-      'Cmd/Ctrl+click opens terminal http(s) links in Orca. Shift+Cmd/Ctrl+click uses the system browser.',
-    keywords: ['browser', 'preview', 'links', 'localhost', 'webview', 'shift', 'cmd', 'ctrl']
+      "Open http(s) links in Orca's built-in browser — from the terminal, markdown, and the editor. Shift+Cmd/Ctrl+click always uses your system browser.",
+    keywords: [
+      'browser',
+      'preview',
+      'links',
+      'localhost',
+      'webview',
+      'shift',
+      'cmd',
+      'ctrl',
+      'markdown',
+      'file',
+      'editor'
+    ]
   },
   {
     title: 'Session & Cookies',

--- a/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
@@ -8,6 +8,7 @@ import {
   isTerminalLinkActivation,
   openDetectedFilePath
 } from './terminal-link-handlers'
+import { registerHttpLinkStoreAccessor } from '@/lib/http-link-routing'
 
 const openUrlMock = vi.fn()
 const openFileUriMock = vi.fn()
@@ -50,6 +51,7 @@ function setPlatform(userAgent: string): void {
 beforeEach(() => {
   vi.clearAllMocks()
   storeState.settings = undefined
+  registerHttpLinkStoreAccessor(() => storeState)
   vi.stubGlobal('window', {
     api: {
       shell: {
@@ -123,7 +125,10 @@ describe('handleOscLink', () => {
 
     handleOscLink('https://example.com', { metaKey: true, ctrlKey: false, shiftKey: false }, deps)
 
-    expect(createBrowserTabMock).toHaveBeenCalledWith('wt-1', 'https://example.com/')
+    expect(createBrowserTabMock).toHaveBeenCalledWith('wt-1', 'https://example.com/', {
+      activate: true
+    })
+    expect(setActiveWorktreeMock).toHaveBeenCalledWith('wt-1')
     expect(openUrlMock).not.toHaveBeenCalled()
   })
 

--- a/src/renderer/src/components/terminal-pane/terminal-link-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-handlers.ts
@@ -11,6 +11,7 @@ import { getConnectionId } from '@/lib/connection-context'
 import { absolutePathToFileUri } from '@/components/editor/markdown-internal-links'
 import type { PaneManager } from '@/lib/pane-manager/pane-manager'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
+import { openHttpLink } from '@/lib/http-link-routing'
 
 export type LinkHandlerDeps = {
   worktreeId: string
@@ -257,19 +258,10 @@ export function handleOscLink(
   }
 
   if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
-    const store = useAppStore.getState()
-    // Why: openLinksInApp controls whether Cmd/Ctrl+click routes http(s) URLs
-    // into Orca's embedded browser or passes them to the system browser.
-    // Shift is always the explicit override to the system browser regardless of
-    // the setting. Default is true so new installs get in-app routing.
-    const routeToOrca =
-      deps.worktreeId && !event?.shiftKey && store.settings?.openLinksInApp !== false
-    if (routeToOrca) {
-      store.setActiveWorktree(deps.worktreeId)
-      store.createBrowserTab(deps.worktreeId, parsed.toString())
-      return
-    }
-    void window.api.shell.openUrl(parsed.toString())
+    openHttpLink(parsed.toString(), {
+      worktreeId: deps.worktreeId,
+      forceSystemBrowser: Boolean(event?.shiftKey)
+    })
     return
   }
 

--- a/src/renderer/src/lib/http-link-routing.test.ts
+++ b/src/renderer/src/lib/http-link-routing.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { openHttpLink, registerHttpLinkStoreAccessor } from './http-link-routing'
+
+const openUrlMock = vi.fn()
+const setActiveWorktreeMock = vi.fn()
+const createBrowserTabMock = vi.fn()
+
+const storeState = {
+  settings: undefined as { openLinksInApp?: boolean } | undefined,
+  setActiveWorktree: setActiveWorktreeMock,
+  createBrowserTab: createBrowserTabMock
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  storeState.settings = undefined
+  registerHttpLinkStoreAccessor(() => storeState)
+  vi.stubGlobal('window', {
+    api: {
+      shell: {
+        openUrl: openUrlMock
+      }
+    }
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('openHttpLink', () => {
+  it('routes into Orca when openLinksInApp is on and a worktree is known', () => {
+    storeState.settings = { openLinksInApp: true }
+
+    openHttpLink('https://example.com/', { worktreeId: 'wt-1' })
+
+    expect(setActiveWorktreeMock).toHaveBeenCalledWith('wt-1')
+    expect(createBrowserTabMock).toHaveBeenCalledWith('wt-1', 'https://example.com/', {
+      activate: true
+    })
+    expect(openUrlMock).not.toHaveBeenCalled()
+  })
+
+  it('defaults to Orca routing when settings have not hydrated', () => {
+    storeState.settings = undefined
+
+    openHttpLink('https://example.com/', { worktreeId: 'wt-1' })
+
+    expect(createBrowserTabMock).toHaveBeenCalled()
+    expect(openUrlMock).not.toHaveBeenCalled()
+  })
+
+  it('routes to the system browser when openLinksInApp is off', () => {
+    storeState.settings = { openLinksInApp: false }
+
+    openHttpLink('https://example.com/', { worktreeId: 'wt-1' })
+
+    expect(openUrlMock).toHaveBeenCalledWith('https://example.com/')
+    expect(createBrowserTabMock).not.toHaveBeenCalled()
+  })
+
+  it('routes to the system browser when no worktree id is provided', () => {
+    storeState.settings = { openLinksInApp: true }
+
+    openHttpLink('https://example.com/', { worktreeId: '' })
+
+    expect(openUrlMock).toHaveBeenCalledWith('https://example.com/')
+    expect(createBrowserTabMock).not.toHaveBeenCalled()
+  })
+
+  it('forceSystemBrowser overrides the setting even when a worktree is active', () => {
+    storeState.settings = { openLinksInApp: true }
+
+    openHttpLink('https://example.com/', { worktreeId: 'wt-1', forceSystemBrowser: true })
+
+    expect(openUrlMock).toHaveBeenCalledWith('https://example.com/')
+    expect(createBrowserTabMock).not.toHaveBeenCalled()
+    expect(setActiveWorktreeMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/lib/http-link-routing.ts
+++ b/src/renderer/src/lib/http-link-routing.ts
@@ -1,0 +1,45 @@
+export type OpenHttpLinkOptions = {
+  worktreeId?: string | null
+  forceSystemBrowser?: boolean
+}
+
+type StoreAccessor = () => {
+  settings?: { openLinksInApp?: boolean } | null
+  setActiveWorktree: (worktreeId: string) => void
+  createBrowserTab: (worktreeId: string, url: string, opts: { activate: boolean }) => unknown
+}
+
+// Why: store access is injected via registerHttpLinkStoreAccessor rather than
+// a direct `import '@/store'` to avoid a circular import — store/slices/editor.ts
+// imports this module, and '@/store' transitively imports editor.ts. Without
+// the break, several renderer test files that load this module first see
+// `createEditorSlice` as undefined at store/index.ts initialization.
+let storeAccessor: StoreAccessor | null = null
+
+export function registerHttpLinkStoreAccessor(fn: StoreAccessor): void {
+  storeAccessor = fn
+}
+
+// Scope: http(s) URLs only. file: URIs and in-worktree markdown targets are
+// owned by resolveMarkdownLinkTarget and must stay on that path — this helper
+// is only invoked on target.kind === 'external' (and for the terminal's http
+// branch). Shift+Cmd/Ctrl is the escape hatch: callers pass forceSystemBrowser
+// to bypass the setting entirely.
+export function openHttpLink(url: string, opts: OpenHttpLinkOptions = {}): void {
+  const { worktreeId, forceSystemBrowser } = opts
+  const state = storeAccessor?.()
+  const routeToOrca =
+    !forceSystemBrowser && Boolean(worktreeId) && state?.settings?.openLinksInApp !== false
+
+  if (routeToOrca && worktreeId && state) {
+    // Why: http clicks from inside a worktree should not push a worktree-switch
+    // history entry — the user isn't changing worktrees, they're opening a tab
+    // in the one they're already in. activateAndRevealWorktree is reserved for
+    // file-link jumps that genuinely switch worktrees.
+    state.setActiveWorktree(worktreeId)
+    state.createBrowserTab(worktreeId, url, { activate: true })
+    return
+  }
+
+  void window.api.shell.openUrl(url)
+}

--- a/src/renderer/src/store/index.ts
+++ b/src/renderer/src/store/index.ts
@@ -18,6 +18,7 @@ import { createDiffCommentsSlice } from './slices/diffComments'
 import { createDetectedAgentsSlice } from './slices/detected-agents'
 import { createWorktreeNavHistorySlice } from './slices/worktree-nav-history'
 import { e2eConfig } from '@/lib/e2e-config'
+import { registerHttpLinkStoreAccessor } from '@/lib/http-link-routing'
 
 export const useAppStore = create<AppState>()((...a) => ({
   ...createRepoSlice(...a),
@@ -38,6 +39,8 @@ export const useAppStore = create<AppState>()((...a) => ({
   ...createDetectedAgentsSlice(...a),
   ...createWorktreeNavHistorySlice(...a)
 }))
+
+registerHttpLinkStoreAccessor(() => useAppStore.getState())
 
 export type { AppState } from './types'
 

--- a/src/renderer/src/store/slices/editor.test.ts
+++ b/src/renderer/src/store/slices/editor.test.ts
@@ -13,6 +13,11 @@ vi.mock('sonner', () => ({
   toast: { error: toastErrorMock }
 }))
 
+const { openHttpLinkMock } = vi.hoisted(() => ({ openHttpLinkMock: vi.fn() }))
+vi.mock('@/lib/http-link-routing', () => ({
+  openHttpLink: openHttpLinkMock
+}))
+
 function createEditorStore(): StoreApi<AppState> {
   // Only the editor slice + activeWorktreeId are needed for these tests.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -482,6 +487,7 @@ describe('createEditorSlice activateMarkdownLink', () => {
     openUrlMock.mockReset()
     openFileUriMock.mockReset()
     pathExistsMock.mockReset()
+    openHttpLinkMock.mockReset()
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ;(globalThis as any).window = (globalThis as any).window ?? {}
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -558,14 +564,15 @@ describe('createEditorSlice activateMarkdownLink', () => {
     })
   })
 
-  it('delegates external links to shell.openUrl', async () => {
+  it('delegates external links to openHttpLink with the ctx worktreeId', async () => {
     const store = createEditorStore()
     await store.getState().activateMarkdownLink('https://example.com', {
       sourceFilePath: '/repo/docs/note.md',
       worktreeId: 'wt-1',
       worktreeRoot: '/repo'
     })
-    expect(openUrlMock).toHaveBeenCalledWith('https://example.com/')
+    expect(openHttpLinkMock).toHaveBeenCalledWith('https://example.com/', { worktreeId: 'wt-1' })
+    expect(openUrlMock).not.toHaveBeenCalled()
     expect(store.getState().openFiles).toEqual([])
   })
 

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -4,6 +4,7 @@ import type { AppState } from '../types'
 import { joinPath } from '@/lib/path'
 import { toast } from 'sonner'
 import { resolveMarkdownLinkTarget } from '@/components/editor/markdown-internal-links'
+import { openHttpLink } from '@/lib/http-link-routing'
 import type {
   GitBranchChangeEntry,
   GitBranchCompareSummary,
@@ -1705,7 +1706,7 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
       return
     }
     if (target.kind === 'external') {
-      void window.api.shell.openUrl(target.url)
+      openHttpLink(target.url, { worktreeId: ctx.worktreeId })
       return
     }
     if (target.kind === 'file') {


### PR DESCRIPTION
## Problem
Links in markdown files and the rich editor were opening in the system browser only, limiting the utility of Orca's built-in preview for local development.

## Solution
- Extract HTTP link opening logic into a centralized `openHttpLink` module with consistent routing rules
- Update markdown preview, rich editor, and terminal link handlers to use this shared module
- Preserve Shift+Cmd/Ctrl as an escape hatch to force system browser
- Maintain the `openLinksInApp` setting as the default behavior control