### PR TITLE
feat(updater): collapse update card into status bar

### DIFF
--- a/src/renderer/src/components/UpdateCard.test.ts
+++ b/src/renderer/src/components/UpdateCard.test.ts
@@ -184,6 +184,53 @@ describe('dismissUpdate nudge-aware', () => {
   })
 })
 
+// ── updateCardCollapsed ──────────────────────────────────────────────
+
+describe('updateCardCollapsed', () => {
+  it('defaults to false', () => {
+    const store = createTestStore()
+    expect(store.getState().updateCardCollapsed).toBe(false)
+  })
+
+  it('setUpdateCardCollapsed toggles the flag without persisting', () => {
+    const store = createTestStore()
+
+    store.getState().setUpdateCardCollapsed(true)
+    expect(store.getState().updateCardCollapsed).toBe(true)
+    expect(window.api.ui.set).not.toHaveBeenCalledWith(
+      expect.objectContaining({ updateCardCollapsed: expect.anything() })
+    )
+
+    store.getState().setUpdateCardCollapsed(false)
+    expect(store.getState().updateCardCollapsed).toBe(false)
+  })
+
+  it('resets to false on every state transition so new phases re-surface', () => {
+    const store = createTestStore()
+
+    setState(store, { state: 'downloading', percent: 20, version: '1.2.0' })
+    store.getState().setUpdateCardCollapsed(true)
+    expect(store.getState().updateCardCollapsed).toBe(true)
+
+    // Why: percent-only updates are not transitions and must not reset.
+    setState(store, { state: 'downloading', percent: 50, version: '1.2.0' })
+    expect(store.getState().updateCardCollapsed).toBe(true)
+
+    setState(store, { state: 'downloaded', version: '1.2.0' })
+    expect(store.getState().updateCardCollapsed).toBe(false)
+  })
+
+  it('re-surfaces the card when downloading transitions to error', () => {
+    const store = createTestStore()
+
+    setState(store, { state: 'downloading', percent: 80, version: '1.2.0' })
+    store.getState().setUpdateCardCollapsed(true)
+
+    setState(store, { state: 'error', message: 'ENOSPC' })
+    expect(store.getState().updateCardCollapsed).toBe(false)
+  })
+})
+
 // ── markUpdateReassuranceSeen ────────────────────────────────────────
 
 describe('markUpdateReassuranceSeen', () => {

--- a/src/renderer/src/components/UpdateCard.tsx
+++ b/src/renderer/src/components/UpdateCard.tsx
@@ -6,7 +6,7 @@ import { useAppStore } from '../store'
 import { Card } from './ui/card'
 import { Button } from './ui/button'
 import { Progress } from './ui/progress'
-import { AlertCircle, Check, Loader2, X } from 'lucide-react'
+import { AlertCircle, Check, Loader2, Minus, X } from 'lucide-react'
 import type { ChangelogData } from '../../../shared/types'
 
 // ── Helpers ──────────────────────────────────────────────────────────
@@ -85,6 +85,8 @@ export function UpdateCard() {
   const storeChangelog = useAppStore((s) => s.updateChangelog)
   const dismissedVersion = useAppStore((s) => s.dismissedUpdateVersion)
   const dismissUpdate = useAppStore((s) => s.dismissUpdate)
+  const collapsed = useAppStore((s) => s.updateCardCollapsed)
+  const setCollapsed = useAppStore((s) => s.setUpdateCardCollapsed)
   const reassuranceSeen = useAppStore((s) => s.updateReassuranceSeen)
   const markReassuranceSeen = useAppStore((s) => s.markUpdateReassuranceSeen)
   const hasStartedDownload = useRef(false)
@@ -263,6 +265,13 @@ export function UpdateCard() {
     }
   }
 
+  if (
+    collapsed &&
+    (status.state === 'downloading' || status.state === 'downloaded' || status.state === 'error')
+  ) {
+    return null
+  }
+
   // ── Shared helpers ────────────────────────────────────────────────
 
   const isRichMode = changelog?.release != null
@@ -338,10 +347,33 @@ export function UpdateCard() {
     setTimeout(handleClose, 150)
   }
 
-  // Escape key handler for accessibility
+  // Why: long-running phases (downloading, downloaded, error) minimize to the
+  // status bar instead of persistently dismissing. A dismiss during an active
+  // download would orphan the in-flight download with no surfaced recovery.
+  const handleCollapseWithAnimation = () => {
+    if (prefersReducedMotion) {
+      setCollapsed(true)
+      return
+    }
+    setExiting(true)
+    setTimeout(() => {
+      setCollapsed(true)
+      setExiting(false)
+    }, 150)
+  }
+
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Escape') {
-      e.preventDefault()
+    if (e.key !== 'Escape') {
+      return
+    }
+    e.preventDefault()
+    if (
+      status.state === 'downloading' ||
+      status.state === 'downloaded' ||
+      status.state === 'error'
+    ) {
+      handleCollapseWithAnimation()
+    } else {
       handleDismissWithAnimation()
     }
   }
@@ -392,7 +424,7 @@ export function UpdateCard() {
           message={errorCard.message}
           releaseUrl={errorCard.releaseUrl}
           primaryAction={errorCard.primaryAction}
-          onClose={handleDismissWithAnimation}
+          onClose={handleCollapseWithAnimation}
         />
       )
     }
@@ -412,7 +444,7 @@ export function UpdateCard() {
         <ReadyToInstallContent
           version={status.version}
           onRestart={handleInstallRetry}
-          onClose={handleDismissWithAnimation}
+          onClose={handleCollapseWithAnimation}
         />
       )
     }
@@ -430,6 +462,7 @@ export function UpdateCard() {
           mediaLoaded={mediaLoaded}
           onMediaError={() => setMediaFailed(true)}
           onMediaLoad={() => setMediaLoaded(true)}
+          onCollapse={handleCollapseWithAnimation}
         />
       )
     }
@@ -668,7 +701,8 @@ function DownloadingContent({
   mediaFailed,
   mediaLoaded,
   onMediaError,
-  onMediaLoad
+  onMediaLoad,
+  onCollapse
 }: {
   version: string
   percent: number
@@ -678,6 +712,7 @@ function DownloadingContent({
   mediaLoaded: boolean
   onMediaError: () => void
   onMediaLoad: () => void
+  onCollapse: () => void
 }) {
   const release = changelog?.release
   const showMedia =
@@ -691,7 +726,15 @@ function DownloadingContent({
         ) : (
           <h3 className="text-sm font-semibold">Downloading Update</h3>
         )}
-        <div className="size-7 shrink-0 min-w-[44px] min-h-[44px] -m-2" />
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-7 shrink-0 min-w-[44px] min-h-[44px] -m-2"
+          onClick={onCollapse}
+          aria-label="Minimize to status bar"
+        >
+          <Minus className="size-3.5" />
+        </Button>
       </div>
 
       {showMedia && release?.mediaUrl && (
@@ -765,9 +808,9 @@ function ErrorCardContent({
           size="icon"
           className="size-7 shrink-0 min-w-[44px] min-h-[44px] -m-2"
           onClick={onClose}
-          aria-label="Dismiss"
+          aria-label="Minimize to status bar"
         >
-          <X className="size-3.5" />
+          <Minus className="size-3.5" />
         </Button>
       </div>
 
@@ -814,9 +857,9 @@ function ReadyToInstallContent({
           size="icon"
           className="size-7 shrink-0 min-w-[44px] min-h-[44px] -m-2"
           onClick={onClose}
-          aria-label="Dismiss"
+          aria-label="Minimize to status bar"
         >
-          <X className="size-3.5" />
+          <Minus className="size-3.5" />
         </Button>
       </div>
 

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -21,6 +21,7 @@ import { ClaudeIcon, OpenAIIcon } from './icons'
 import { markLiveCodexSessionsForRestart } from '@/lib/codex-session-restart'
 import { SshStatusSegment } from './SshStatusSegment'
 import { SessionsStatusSegment } from './SessionsStatusSegment'
+import { UpdateStatusSegment } from './UpdateStatusSegment'
 
 function getCodexAccountLabel(
   state: CodexRateLimitAccountsState,
@@ -520,6 +521,7 @@ function StatusBarInner(): React.JSX.Element | null {
       <div className="flex-1" />
 
       <div className="flex items-center gap-3">
+        <UpdateStatusSegment compact={compact} iconOnly={iconOnly} />
         {showSessions && <SessionsStatusSegment compact={compact} iconOnly={iconOnly} />}
         {showSsh && <SshStatusSegment compact={compact} iconOnly={iconOnly} />}
       </div>

--- a/src/renderer/src/components/status-bar/UpdateStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/UpdateStatusSegment.tsx
@@ -1,0 +1,72 @@
+import React from 'react'
+import { AlertCircle, CheckCircle2, Download } from 'lucide-react'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { useAppStore } from '../../store'
+
+// Why: always rendered (not gated by `statusBarItems`). When the update card
+// is collapsed, this segment is the only way back to it — hiding it would
+// strand the user with an orphaned download or install.
+export function UpdateStatusSegment({
+  iconOnly
+}: {
+  compact: boolean
+  iconOnly: boolean
+}): React.JSX.Element | null {
+  const status = useAppStore((s) => s.updateStatus)
+  const collapsed = useAppStore((s) => s.updateCardCollapsed)
+  const setCollapsed = useAppStore((s) => s.setUpdateCardCollapsed)
+
+  if (status.state !== 'downloading' && status.state !== 'downloaded' && status.state !== 'error') {
+    return null
+  }
+
+  const segment = (() => {
+    if (status.state === 'downloading') {
+      const pct = Math.max(0, Math.min(100, Math.round(status.percent)))
+      return {
+        icon: <Download className="size-3 text-muted-foreground" />,
+        label: `${pct}%`,
+        tooltip: `Orca v${status.version} downloading… ${pct}%`,
+        ariaLabel: `Update downloading, ${pct} percent. Click to expand.`
+      }
+    }
+    if (status.state === 'downloaded') {
+      return {
+        icon: <CheckCircle2 className="size-3 text-emerald-500" />,
+        label: 'Update ready',
+        tooltip: `Orca v${status.version} ready to install`,
+        ariaLabel: 'Update ready to install. Click to expand.'
+      }
+    }
+    return {
+      icon: <AlertCircle className="size-3 text-yellow-500" />,
+      label: 'Update failed',
+      tooltip: 'Update failed — click to see details',
+      ariaLabel: 'Update failed. Click to expand.'
+    }
+  })()
+
+  const handleClick = () => {
+    setCollapsed(!collapsed)
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          onClick={handleClick}
+          className="inline-flex items-center gap-1.5 cursor-pointer rounded px-1 py-0.5 hover:bg-accent/70"
+          aria-label={segment.ariaLabel}
+          aria-expanded={!collapsed}
+        >
+          {segment.icon}
+          {!iconOnly && <span className="text-[11px] tabular-nums">{segment.label}</span>}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="top" sideOffset={6}>
+        {segment.tooltip}
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -147,6 +147,10 @@ export type UISlice = {
   dismissedUpdateVersion: string | null
   dismissUpdate: (versionOverride?: string) => void
   clearDismissedUpdateVersion: () => void
+  // Why: ephemeral and renderer-only — never persisted and never crosses IPC.
+  // Resets every session and on every phase transition (see setUpdateStatus).
+  updateCardCollapsed: boolean
+  setUpdateCardCollapsed: (collapsed: boolean) => void
   updateReassuranceSeen: boolean
   markUpdateReassuranceSeen: () => void
   isFullScreen: boolean
@@ -344,7 +348,10 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
 
   updateStatus: { state: 'idle' },
   setUpdateStatus: (status) => {
-    const update: Partial<Pick<UISlice, 'updateStatus' | 'updateChangelog'>> = {
+    const prevState = get().updateStatus.state
+    const update: Partial<
+      Pick<UISlice, 'updateStatus' | 'updateChangelog' | 'updateCardCollapsed'>
+    > = {
       updateStatus: status
     }
     if (status.state === 'available') {
@@ -364,6 +371,11 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
     }
     // For 'downloading', 'downloaded', 'error': leave updateChangelog untouched
     // so the card can keep showing rich content from the original 'available'.
+    if (status.state !== prevState) {
+      // Why: re-surface the card on every phase transition so a prior collapse
+      // of `downloading` doesn't bury the `downloaded`/`error` that follows.
+      update.updateCardCollapsed = false
+    }
     set(update)
   },
   updateChangelog: null,
@@ -391,6 +403,8 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
       }
       return { dismissedUpdateVersion }
     }),
+  updateCardCollapsed: false,
+  setUpdateCardCollapsed: (collapsed) => set({ updateCardCollapsed: collapsed }),
   updateReassuranceSeen: false,
   markUpdateReassuranceSeen: () => {
     void window.api.ui.set({ updateReassuranceSeen: true }).catch(console.error)


### PR DESCRIPTION
## Summary

The update card stayed pinned to the bottom-right for the entire `downloading` / `downloaded` / `error` lifecycle with no minimize affordance, covering screen real estate during slow downloads and updates. The `X` on downloaded/error also persistently dismisses the version, which silently orphans in-flight downloads.

This adds an always-on status-bar segment that surfaces progress / ready / error state, plus an ephemeral `updateCardCollapsed` flag that the card's new minimize button and Escape key set in those three phases. The flag is renderer-only and resets on every phase transition so a collapsed `downloading` cannot bury the `downloaded` / `error` that follows.

## Screenshots


https://github.com/user-attachments/assets/f2b17734-b753-4a66-8a3e-08536314e4aa

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`