### PR TITLE
fix(tabs): walk active group order on keyboard tab switch

### DIFF
--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -30,7 +30,7 @@ import EditorAutosaveController from './editor/EditorAutosaveController'
 import type { TabGroupLayoutNode } from '../../../shared/types'
 import BrowserPane, { destroyPersistentWebview } from './browser-pane/BrowserPane'
 import BrowserPaneOverlayLayer from './browser-pane/BrowserPaneOverlayLayer'
-import { reconcileTabOrder } from './tab-bar/reconcile-order'
+import { handleSwitchTab } from '../hooks/ipc-tab-switch'
 import TabGroupSplitLayout from './tab-group/TabGroupSplitLayout'
 import { shouldAutoCreateInitialTerminal } from './terminal/initial-terminal'
 import {
@@ -745,58 +745,13 @@ function Terminal(): React.JSX.Element | null {
         (e.code === 'BracketRight' || e.code === 'BracketLeft') &&
         !e.repeat
       ) {
-        const state = useAppStore.getState()
-        const currentTerminalTabs = state.tabsByWorktree[activeWorktreeId] ?? []
-        const currentEditorFiles = state.openFiles.filter((f) => f.worktreeId === activeWorktreeId)
-        const currentBrowserTabs = state.browserTabsByWorktree[activeWorktreeId] ?? []
-        const terminalIds = currentTerminalTabs.map((t) => t.id)
-        const editorIds = currentEditorFiles.map((f) => f.id)
-        const browserIds = currentBrowserTabs.map((t) => t.id)
-        // Why: use reconcileTabOrder instead of raw tabBarOrderByWorktree so
-        // tab switching works even when the stored order is unset (e.g. for
-        // worktrees restored from session whose initial tabs were created
-        // without populating tabBarOrderByWorktree).
-        const reconciledOrder = reconcileTabOrder(
-          state.tabBarOrderByWorktree[activeWorktreeId],
-          terminalIds,
-          editorIds,
-          browserIds
-        )
-        const terminalIdSet = new Set(terminalIds)
-        const editorIdSet = new Set(editorIds)
-        const browserIdSet = new Set(browserIds)
-        const allTabIds = reconciledOrder.map((id) => ({
-          type: terminalIdSet.has(id)
-            ? ('terminal' as const)
-            : editorIdSet.has(id)
-              ? ('editor' as const)
-              : browserIdSet.has(id)
-                ? ('browser' as const)
-                : (null as never),
-          id
-        }))
-
-        if (allTabIds.length > 1) {
+        // Why: delegate to the shared handleSwitchTab used by the IPC shortcut
+        // so both code paths share one implementation. See getActiveTabNavOrder
+        // for the stale legacy-order bug this replaces. handleSwitchTab returns
+        // true when it switched so we preventDefault only when we actually
+        // consumed the key.
+        if (handleSwitchTab(e.code === 'BracketRight' ? 1 : -1)) {
           e.preventDefault()
-          const currentId =
-            state.activeTabType === 'editor'
-              ? state.activeFileId
-              : state.activeTabType === 'browser'
-                ? state.activeBrowserTabId
-                : state.activeTabId
-          const idx = allTabIds.findIndex((t) => t.id === currentId)
-          const dir = e.code === 'BracketRight' ? 1 : -1
-          const next = allTabIds[(idx + dir + allTabIds.length) % allTabIds.length]
-          if (next.type === 'terminal') {
-            setActiveTab(next.id)
-            state.setActiveTabType('terminal')
-          } else if (next.type === 'browser') {
-            state.setActiveBrowserTab(next.id)
-            state.setActiveTabType('browser')
-          } else {
-            state.setActiveFile(next.id)
-            state.setActiveTabType('editor')
-          }
         }
       }
     }
@@ -810,8 +765,7 @@ function Terminal(): React.JSX.Element | null {
     handleCloseTab,
     handleCloseBrowserTab,
     closeBrowserTab,
-    handleCloseFile,
-    setActiveTab
+    handleCloseFile
   ])
 
   // Warn on window close if there are unsaved editor files

--- a/src/renderer/src/components/tab-bar/group-tab-order.test.ts
+++ b/src/renderer/src/components/tab-bar/group-tab-order.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it } from 'vitest'
+import type { Tab, TabGroup } from '../../../../shared/types'
+import type { AppState } from '../../store/types'
+import { getActiveTabNavOrder, getGroupVisibleTabOrder } from './group-tab-order'
+
+function terminalTab(id: string, groupId: string, entityId: string, sortOrder: number): Tab {
+  return {
+    id,
+    entityId,
+    groupId,
+    worktreeId: 'wt',
+    contentType: 'terminal',
+    label: entityId,
+    customLabel: null,
+    color: null,
+    sortOrder,
+    createdAt: sortOrder
+  }
+}
+
+function editorTab(id: string, groupId: string, entityId: string, sortOrder: number): Tab {
+  return {
+    id,
+    entityId,
+    groupId,
+    worktreeId: 'wt',
+    contentType: 'editor',
+    label: entityId,
+    customLabel: null,
+    color: null,
+    sortOrder,
+    createdAt: sortOrder
+  }
+}
+
+function browserTab(id: string, groupId: string, entityId: string, sortOrder: number): Tab {
+  return {
+    id,
+    entityId,
+    groupId,
+    worktreeId: 'wt',
+    contentType: 'browser',
+    label: entityId,
+    customLabel: null,
+    color: null,
+    sortOrder,
+    createdAt: sortOrder
+  }
+}
+
+describe('getGroupVisibleTabOrder', () => {
+  it('returns terminal/browser tabs keyed by entityId and editor tabs keyed by unified id', () => {
+    const group: TabGroup = {
+      id: 'g1',
+      worktreeId: 'wt',
+      activeTabId: 'tab-t1',
+      tabOrder: ['tab-t1', 'tab-e1', 'tab-t2']
+    }
+    const tabs: Tab[] = [
+      terminalTab('tab-t1', 'g1', 'term-1', 0),
+      editorTab('tab-e1', 'g1', '/repo/file.md', 1),
+      terminalTab('tab-t2', 'g1', 'term-2', 2)
+    ]
+    expect(
+      getGroupVisibleTabOrder(
+        group,
+        tabs,
+        new Set(['term-1', 'term-2']),
+        new Set(['/repo/file.md']),
+        new Set()
+      )
+    ).toEqual([
+      { type: 'terminal', id: 'term-1' },
+      { type: 'editor', id: 'tab-e1' },
+      { type: 'terminal', id: 'term-2' }
+    ])
+  })
+
+  it('walks tabs in the reordered group.tabOrder sequence (regression: drag-reordered tabs)', () => {
+    // Original visual order was [term-1, term-2, term-3]; user dragged
+    // term-1 to the end so tabOrder is now [tab-t2, tab-t3, tab-t1]. The
+    // pre-fix keyboard nav read the stale tabBarOrderByWorktree and cycled
+    // 3 → 1 → 2 instead of 3 → 2 → 1. This walks the new canonical order.
+    const group: TabGroup = {
+      id: 'g1',
+      worktreeId: 'wt',
+      activeTabId: 'tab-t1',
+      tabOrder: ['tab-t2', 'tab-t3', 'tab-t1']
+    }
+    const tabs: Tab[] = [
+      terminalTab('tab-t1', 'g1', 'term-1', 0),
+      terminalTab('tab-t2', 'g1', 'term-2', 1),
+      terminalTab('tab-t3', 'g1', 'term-3', 2)
+    ]
+    expect(
+      getGroupVisibleTabOrder(
+        group,
+        tabs,
+        new Set(['term-1', 'term-2', 'term-3']),
+        new Set(),
+        new Set()
+      ).map((t) => t.id)
+    ).toEqual(['term-2', 'term-3', 'term-1'])
+  })
+
+  it('skips tabs whose backing entity is not present', () => {
+    const group: TabGroup = {
+      id: 'g1',
+      worktreeId: 'wt',
+      activeTabId: 'tab-t1',
+      tabOrder: ['tab-t1', 'tab-t2']
+    }
+    const tabs: Tab[] = [
+      terminalTab('tab-t1', 'g1', 'term-1', 0),
+      terminalTab('tab-t2', 'g1', 'term-zombie', 1)
+    ]
+    expect(getGroupVisibleTabOrder(group, tabs, new Set(['term-1']), new Set(), new Set())).toEqual(
+      [{ type: 'terminal', id: 'term-1' }]
+    )
+  })
+
+  it('includes browser tabs keyed by entityId in the declared group order', () => {
+    const group: TabGroup = {
+      id: 'g1',
+      worktreeId: 'wt',
+      activeTabId: 'tab-b1',
+      tabOrder: ['tab-t1', 'tab-b1', 'tab-e1']
+    }
+    const tabs: Tab[] = [
+      terminalTab('tab-t1', 'g1', 'term-1', 0),
+      browserTab('tab-b1', 'g1', 'browser-1', 1),
+      editorTab('tab-e1', 'g1', '/repo/file.md', 2)
+    ]
+    expect(
+      getGroupVisibleTabOrder(
+        group,
+        tabs,
+        new Set(['term-1']),
+        new Set(['/repo/file.md']),
+        new Set(['browser-1'])
+      )
+    ).toEqual([
+      { type: 'terminal', id: 'term-1' },
+      { type: 'browser', id: 'browser-1' },
+      { type: 'editor', id: 'tab-e1' }
+    ])
+  })
+})
+
+type NavState = Pick<
+  AppState,
+  | 'activeGroupIdByWorktree'
+  | 'groupsByWorktree'
+  | 'unifiedTabsByWorktree'
+  | 'tabBarOrderByWorktree'
+  | 'tabsByWorktree'
+  | 'openFiles'
+  | 'browserTabsByWorktree'
+>
+
+function makeState(overrides: Partial<NavState>): NavState {
+  return {
+    activeGroupIdByWorktree: {},
+    groupsByWorktree: {},
+    unifiedTabsByWorktree: {},
+    tabBarOrderByWorktree: {},
+    tabsByWorktree: {},
+    openFiles: [],
+    browserTabsByWorktree: {},
+    ...overrides
+  }
+}
+
+describe('getActiveTabNavOrder', () => {
+  it('uses the active group order and ignores the stale legacy order after drag-reorder', () => {
+    const group: TabGroup = {
+      id: 'g1',
+      worktreeId: 'wt',
+      activeTabId: 'tab-t1',
+      // Drag-reordered: canonical order is [t2, t3, t1]
+      tabOrder: ['tab-t2', 'tab-t3', 'tab-t1']
+    }
+    const tabs: Tab[] = [
+      terminalTab('tab-t1', 'g1', 'term-1', 0),
+      terminalTab('tab-t2', 'g1', 'term-2', 1),
+      terminalTab('tab-t3', 'g1', 'term-3', 2)
+    ]
+    const state = makeState({
+      activeGroupIdByWorktree: { wt: 'g1' },
+      groupsByWorktree: { wt: [group] },
+      unifiedTabsByWorktree: { wt: tabs },
+      // Stale legacy order still in insertion order:
+      tabBarOrderByWorktree: { wt: ['term-1', 'term-2', 'term-3'] },
+      tabsByWorktree: {
+        // @ts-expect-error — minimal TerminalTab shape; nav helper only reads `id`
+        wt: [{ id: 'term-1' }, { id: 'term-2' }, { id: 'term-3' }]
+      }
+    })
+    expect(getActiveTabNavOrder(state, 'wt').map((t) => t.id)).toEqual([
+      'term-2',
+      'term-3',
+      'term-1'
+    ])
+  })
+
+  it('falls back to the legacy reconciled order when no active group exists', () => {
+    const state = makeState({
+      tabBarOrderByWorktree: { wt: ['term-1', 'e1', 'term-2'] },
+      tabsByWorktree: {
+        // @ts-expect-error — minimal shape
+        wt: [{ id: 'term-1' }, { id: 'term-2' }]
+      },
+      // @ts-expect-error — minimal shape
+      openFiles: [{ id: 'e1', worktreeId: 'wt' }]
+    })
+    expect(getActiveTabNavOrder(state, 'wt')).toEqual([
+      { type: 'terminal', id: 'term-1' },
+      { type: 'editor', id: 'e1' },
+      { type: 'terminal', id: 'term-2' }
+    ])
+  })
+})

--- a/src/renderer/src/components/tab-bar/group-tab-order.ts
+++ b/src/renderer/src/components/tab-bar/group-tab-order.ts
@@ -1,0 +1,154 @@
+import type { Tab, TabGroup } from '../../../../shared/types'
+import type { AppState } from '../../store/types'
+import { reconcileTabOrder } from './reconcile-order'
+
+export type VisibleTabRef = {
+  type: 'terminal' | 'editor' | 'browser'
+  id: string
+}
+
+/**
+ * Compute the visible tab-strip order for a single group.
+ *
+ * Why: keyboard navigation (Cmd/Ctrl+Shift+[ / ]) and the IPC switch-tab
+ * shortcut must walk tabs in the same order the TabBar renders them. The
+ * TabBar derives its order from `group.tabOrder` (the canonical split-group
+ * state, updated by drag/drop via `reorderUnifiedTabs`). Reading from the
+ * legacy `tabBarOrderByWorktree` drifts out of sync because that store is
+ * only written when tabs are created/closed — drag-reordering updates
+ * `group.tabOrder` but not the legacy flat order, which surfaces as
+ * keyboard nav cycling tabs in a stale sequence (e.g. 3 → 1 → 2 instead of
+ * 3 → 2 → 1). This helper returns the exact ids TabBar uses, keyed the same
+ * way (terminal→entityId, browser→entityId, editor→unified tab id), so both
+ * code paths share a single source of truth.
+ *
+ * Note: TabBar's reconciler appends entities present in state but missing
+ * from `group.tabOrder` (an invariant-repair fallback). This helper
+ * intentionally does not mirror that append — appending silently would
+ * reintroduce the class of order-drift this change fixes. In practice
+ * `group.tabOrder` is kept in sync on tab create/close, so the divergence
+ * only matters during hydration races and is preferable to cycling tabs
+ * in a phantom order.
+ *
+ * Scope is intentionally per-group: with split layouts each group has its
+ * own tab strip, and users expect the shortcut to cycle within the strip
+ * they're looking at. Tabs that belong to the group but lack a matching
+ * entity (e.g. terminal-runtime tab still being hydrated, or an editor
+ * whose file has been closed) are skipped so navigation never lands on a
+ * phantom tab.
+ */
+export function getGroupVisibleTabOrder(
+  group: TabGroup,
+  groupTabs: readonly Tab[],
+  terminalEntityIds: ReadonlySet<string>,
+  editorEntityIds: ReadonlySet<string>,
+  browserEntityIds: ReadonlySet<string>
+): VisibleTabRef[] {
+  const tabsById = new Map(groupTabs.map((t) => [t.id, t]))
+  const result: VisibleTabRef[] = []
+  // Dedupe per category: terminal/browser key by entityId (multiple tabs
+  // can theoretically point at the same runtime entity), editor keys by
+  // unified tab id. Keeping the keyspaces separate avoids a cross-type
+  // collision from dropping a legitimate tab.
+  const seenTerminals = new Set<string>()
+  const seenBrowsers = new Set<string>()
+  const seenEditors = new Set<string>()
+  for (const unifiedId of group.tabOrder) {
+    const tab = tabsById.get(unifiedId)
+    if (!tab) {
+      continue
+    }
+    if (tab.contentType === 'terminal') {
+      if (!terminalEntityIds.has(tab.entityId) || seenTerminals.has(tab.entityId)) {
+        continue
+      }
+      seenTerminals.add(tab.entityId)
+      result.push({ type: 'terminal', id: tab.entityId })
+    } else if (tab.contentType === 'browser') {
+      if (!browserEntityIds.has(tab.entityId) || seenBrowsers.has(tab.entityId)) {
+        continue
+      }
+      seenBrowsers.add(tab.entityId)
+      result.push({ type: 'browser', id: tab.entityId })
+    } else {
+      if (!editorEntityIds.has(tab.entityId) || seenEditors.has(tab.id)) {
+        continue
+      }
+      seenEditors.add(tab.id)
+      result.push({ type: 'editor', id: tab.id })
+    }
+  }
+  return result
+}
+
+/**
+ * Resolve the visible tab order the active surface is showing, for keyboard
+ * navigation.
+ *
+ * Prefers the active group's `group.tabOrder` so drag-reordered tabs cycle
+ * in the order the user sees. Falls back to the legacy
+ * `tabBarOrderByWorktree` path when no active group exists yet — this covers
+ * sessions restored before the split-group model hydrated and the
+ * pre-layout titlebar TabBar fallback rendered by Terminal.tsx. The fallback
+ * still drifts for drag-reorders (the legacy store never learns about
+ * them), but worktrees without a group cannot have split-aware drag in the
+ * first place, so in practice only the active-group path matters once
+ * layouts are established.
+ */
+export function getActiveTabNavOrder(
+  state: Pick<
+    AppState,
+    | 'activeGroupIdByWorktree'
+    | 'groupsByWorktree'
+    | 'unifiedTabsByWorktree'
+    | 'tabBarOrderByWorktree'
+    | 'tabsByWorktree'
+    | 'openFiles'
+    | 'browserTabsByWorktree'
+  >,
+  worktreeId: string
+): VisibleTabRef[] {
+  const terminalIds = (state.tabsByWorktree[worktreeId] ?? []).map((t) => t.id)
+  const editorIds = state.openFiles.filter((f) => f.worktreeId === worktreeId).map((f) => f.id)
+  const browserIds = (state.browserTabsByWorktree[worktreeId] ?? []).map((t) => t.id)
+
+  const activeGroupId = state.activeGroupIdByWorktree[worktreeId]
+  const group = activeGroupId
+    ? (state.groupsByWorktree[worktreeId] ?? []).find((g) => g.id === activeGroupId)
+    : undefined
+
+  if (group) {
+    const groupTabs = (state.unifiedTabsByWorktree[worktreeId] ?? []).filter(
+      (tab) => tab.groupId === group.id
+    )
+    return getGroupVisibleTabOrder(
+      group,
+      groupTabs,
+      new Set(terminalIds),
+      new Set(editorIds),
+      new Set(browserIds)
+    )
+  }
+
+  // Legacy fallback: no split-group layout yet for this worktree.
+  const visibleIds = reconcileTabOrder(
+    state.tabBarOrderByWorktree[worktreeId],
+    terminalIds,
+    editorIds,
+    browserIds
+  )
+  const terminalIdSet = new Set(terminalIds)
+  const editorIdSet = new Set(editorIds)
+  const browserIdSet = new Set(browserIds)
+  const result: VisibleTabRef[] = []
+  for (const id of visibleIds) {
+    if (terminalIdSet.has(id)) {
+      result.push({ type: 'terminal', id })
+    } else if (editorIdSet.has(id)) {
+      result.push({ type: 'editor', id })
+    } else if (browserIdSet.has(id)) {
+      result.push({ type: 'browser', id })
+    }
+  }
+  return result
+}

--- a/src/renderer/src/hooks/ipc-tab-switch.ts
+++ b/src/renderer/src/hooks/ipc-tab-switch.ts
@@ -1,59 +1,41 @@
 import { useAppStore } from '../store'
-import { reconcileTabOrder } from '@/components/tab-bar/reconcile-order'
+import { getActiveTabNavOrder } from '@/components/tab-bar/group-tab-order'
 
 /**
  * Handle Cmd/Ctrl+Tab direction switching across terminal, editor, and browser tabs.
  * Extracted from useIpcEvents to keep file size under the max-lines lint threshold.
+ * Returns true if a tab switch occurred, false otherwise.
  */
-export function handleSwitchTab(direction: number): void {
+export function handleSwitchTab(direction: number): boolean {
   const store = useAppStore.getState()
   const worktreeId = store.activeWorktreeId
   if (!worktreeId) {
-    return
+    return false
   }
-  const terminalTabs = store.tabsByWorktree[worktreeId] ?? []
-  const editorFiles = store.openFiles.filter((f) => f.worktreeId === worktreeId)
-  const browserTabs = store.browserTabsByWorktree[worktreeId] ?? []
-  const terminalIds = terminalTabs.map((t) => t.id)
-  const editorIds = editorFiles.map((f) => f.id)
-  const browserIds = browserTabs.map((t) => t.id)
-  const reconciledOrder = reconcileTabOrder(
-    store.tabBarOrderByWorktree[worktreeId],
-    terminalIds,
-    editorIds,
-    browserIds
-  )
-  const terminalIdSet = new Set(terminalIds)
-  const editorIdSet = new Set(editorIds)
-  const browserIdSet = new Set(browserIds)
-  const allTabIds = reconciledOrder.map((id) => ({
-    type: terminalIdSet.has(id)
-      ? ('terminal' as const)
-      : editorIdSet.has(id)
-        ? ('editor' as const)
-        : browserIdSet.has(id)
-          ? ('browser' as const)
-          : (null as never),
-    id
-  }))
-  if (allTabIds.length > 1) {
-    const currentId =
-      store.activeTabType === 'editor'
-        ? store.activeFileId
-        : store.activeTabType === 'browser'
-          ? store.activeBrowserTabId
-          : store.activeTabId
-    const idx = allTabIds.findIndex((t) => t.id === currentId)
-    const next = allTabIds[(idx + direction + allTabIds.length) % allTabIds.length]
-    if (next.type === 'terminal') {
-      store.setActiveTab(next.id)
-      store.setActiveTabType('terminal')
-    } else if (next.type === 'browser') {
-      store.setActiveBrowserTab(next.id)
-      store.setActiveTabType('browser')
-    } else {
-      store.setActiveFile(next.id)
-      store.setActiveTabType('editor')
-    }
+  // Why: walk the active group's visible order so drag-reordered tabs cycle
+  // in the sequence the user sees. See getActiveTabNavOrder for the stale
+  // legacy-order bug this replaces.
+  const allTabIds = getActiveTabNavOrder(store, worktreeId)
+  if (allTabIds.length <= 1) {
+    return false
   }
+  const currentId =
+    store.activeTabType === 'editor'
+      ? store.activeFileId
+      : store.activeTabType === 'browser'
+        ? store.activeBrowserTabId
+        : store.activeTabId
+  const idx = allTabIds.findIndex((t) => t.id === currentId)
+  const next = allTabIds[(idx + direction + allTabIds.length) % allTabIds.length]
+  if (next.type === 'terminal') {
+    store.setActiveTab(next.id)
+    store.setActiveTabType('terminal')
+  } else if (next.type === 'browser') {
+    store.setActiveBrowserTab(next.id)
+    store.setActiveTabType('browser')
+  } else {
+    store.setActiveFile(next.id)
+    store.setActiveTabType('editor')
+  }
+  return true
 }

--- a/tests/e2e/tabs.spec.ts
+++ b/tests/e2e/tabs.spec.ts
@@ -221,6 +221,70 @@ test.describe('Tabs', () => {
   })
 
   /**
+   * Regression: after a drag-reorder, Cmd/Ctrl+Shift+[ must walk tabs in
+   * the new visible order. The pre-fix bug read a stale legacy order
+   * (`tabBarOrderByWorktree`), so pressing "left" three times cycled
+   * 3 → 1 → 2 instead of 3 → 2 → 1 once tabs had been rearranged.
+   */
+  test('Cmd/Ctrl+Shift+[ walks tabs in drag-reordered order', async ({ orcaPage }) => {
+    const isMac = process.platform === 'darwin'
+    const mod = isMac ? 'Meta' : 'Control'
+    const worktreeId = (await getActiveWorktreeId(orcaPage))!
+
+    // Ensure at least 3 terminal tabs so the order cycle is non-trivial.
+    while ((await getWorktreeTabs(orcaPage, worktreeId)).length < 3) {
+      await createTerminalTab(orcaPage, worktreeId)
+    }
+    await expect
+      .poll(async () => (await getWorktreeTabs(orcaPage, worktreeId)).length, { timeout: 5_000 })
+      .toBeGreaterThanOrEqual(3)
+
+    const initialOrder = await getTabBarOrder(orcaPage, worktreeId)
+    expect(initialOrder.length).toBeGreaterThanOrEqual(3)
+    const [a, b, c] = initialOrder
+
+    // Reorder via the same store call drag/drop uses: move the first tab to
+    // the end so the visible order becomes [b, c, a].
+    await orcaPage.evaluate(
+      ({ targetWorktreeId, newOrderTail }) => {
+        const store = window.__store
+        if (!store) {
+          return
+        }
+        const state = store.getState()
+        const groups = state.groupsByWorktree[targetWorktreeId] ?? []
+        const activeGroupId = state.activeGroupIdByWorktree[targetWorktreeId]
+        const activeGroup = activeGroupId
+          ? groups.find((group) => group.id === activeGroupId)
+          : groups[0]
+        if (!activeGroup) {
+          return
+        }
+        const [first, ...rest] = activeGroup.tabOrder
+        state.reorderUnifiedTabs(activeGroup.id, [...rest, first])
+        void newOrderTail
+      },
+      { targetWorktreeId: worktreeId, newOrderTail: [b, c, a] }
+    )
+    await expect
+      .poll(async () => getTabBarOrder(orcaPage, worktreeId), { timeout: 3_000 })
+      .toEqual([b, c, a])
+
+    // Activate the last tab in the new visible order, then walk left twice.
+    // Expected cycle: a → c → b (i.e. walks the *new* order in reverse).
+    await orcaPage.evaluate((tabId) => {
+      window.__store?.getState().setActiveTab(tabId)
+    }, a)
+    await expect.poll(async () => getActiveTabId(orcaPage), { timeout: 3_000 }).toBe(a)
+
+    await orcaPage.keyboard.press(`${mod}+Shift+BracketLeft`)
+    await expect.poll(async () => getActiveTabId(orcaPage), { timeout: 3_000 }).toBe(c)
+
+    await orcaPage.keyboard.press(`${mod}+Shift+BracketLeft`)
+    await expect.poll(async () => getActiveTabId(orcaPage), { timeout: 3_000 }).toBe(b)
+  })
+
+  /**
    * User Prompt:
    * - closing tabs works
    */


### PR DESCRIPTION
## Summary
- `Cmd/Ctrl+Shift+[` and `]` (plus the IPC `onSwitchTab` shortcut) read from the legacy `tabBarOrderByWorktree`, which is only written on tab create/close. Drag-reordering updates the canonical `group.tabOrder` used by `TabBar` but leaves the legacy order stale, so keyboard nav cycled tabs in the old sequence (e.g. `3 → 1 → 2` after dragging tab 1 to the end instead of `3 → 2 → 1`).
- New helper `getActiveTabNavOrder` resolves the active group's visible order the same way `TabBar` does (terminal/browser → `entityId`, editor → unified tab id) and is used by both the renderer keyboard shortcut and the IPC handler. A legacy-reconcile fallback remains for worktrees without a split-group layout yet.
- Unit tests cover the regression + fallback path; a Playwright test exercises the full flow (create 3 tabs → reorder → press `Cmd/Ctrl+Shift+[` twice → assert the new visible sequence).

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm vitest run src/renderer/src/components/tab-bar/ src/renderer/src/hooks/useIpcEvents.test.ts src/renderer/src/store/slices/tabs.test.ts src/renderer/src/components/tab-group/`
- [x] `pnpm test:e2e -g "walks tabs in drag-reordered order"`
- [x] manual test