### PR TITLE
fix(titlebar): make empty tab bar space draggable on macOS

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -931,7 +931,10 @@ function App(): React.JSX.Element {
                 open or closed. Its height matches the 42px workspace strip
                 used by the sidebar and tab rows. */}
             {workspaceActive && !rightSidebarOpen && (
-              <div className="absolute top-0 right-0 z-10 flex items-center h-[42px]">
+              <div
+                className="absolute top-0 right-0 z-10 flex items-center h-[42px]"
+                style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+              >
                 {rightSidebarToggle}
               </div>
             )}

--- a/src/renderer/src/components/tab-group/TabGroupPanel.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.tsx
@@ -198,20 +198,24 @@ export default function TabGroupPanel({
         className="h-[42px] shrink-0 border-b border-border bg-card"
         style={{ WebkitAppRegion: 'drag' } as React.CSSProperties}
       >
-        <div
-          className="flex h-full items-stretch pr-1.5"
-          style={{
-            paddingLeft:
-              reserveCollapsedSidebarHeaderSpace && !sidebarOpen
-                ? 'var(--collapsed-sidebar-header-width)'
-                : undefined
-          }}
-        >
-          {/* Why: collapsing the left worktree sidebar should let the terminal
-              reclaim the full left edge, but the top-left tab row should still
-              stop where the remaining titlebar controls end. Use the measured
-              width of that controls cluster instead of the old full sidebar
-              width so tabs cap at the agent badge, not at the old divider. */}
+        <div className="flex h-full items-stretch pr-1.5">
+          {/* Why: Electron's native drag hit-test only respects no-drag on DOM
+              descendants, not z-index siblings. When the left sidebar is
+              collapsed, its header floats absolutely (z-10) over this tab row
+              from a separate DOM branch. An explicit no-drag spacer here
+              punches a hole in the drag surface so the floating sidebar toggle
+              and other titlebar controls remain clickable. */}
+          {reserveCollapsedSidebarHeaderSpace && !sidebarOpen ? (
+            <div
+              className="shrink-0"
+              style={
+                {
+                  width: 'var(--collapsed-sidebar-header-width)',
+                  WebkitAppRegion: 'no-drag'
+                } as React.CSSProperties
+              }
+            />
+          ) : null}
           <div className="min-w-0 flex-1 h-full">{tabBar}</div>
           {/* Why: pane-scoped layout actions belong with the active pane instead
               of the global tab-bar `+`, which should keep opening tabs exactly

--- a/src/renderer/src/components/tab-group/TabGroupPanel.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.tsx
@@ -190,11 +190,16 @@ export default function TabGroupPanel({
           can show multiple groups at once, while the window titlebar only has
           one shared center slot. Rendering true tab chrome here preserves
           per-group titles without making groups fight over one portal target. */}
-      <div className="h-[42px] shrink-0 border-b border-border bg-card">
+      {/* Why: the macOS window uses hiddenInset titleBarStyle, so the only
+          way to drag-move the window is via -webkit-app-region: drag. Without
+          this, the empty space after tabs in the center column is dead — the
+          user can only drag from the tiny left-sidebar header strip. */}
+      <div
+        className="h-[42px] shrink-0 border-b border-border bg-card"
+        style={{ WebkitAppRegion: 'drag' } as React.CSSProperties}
+      >
         <div
-          className={`flex h-full items-stretch pr-1.5${
-            reserveClosedExplorerToggleSpace && !rightSidebarOpen ? ' pr-10' : ''
-          }`}
+          className="flex h-full items-stretch pr-1.5"
           style={{
             paddingLeft:
               reserveCollapsedSidebarHeaderSpace && !sidebarOpen
@@ -202,10 +207,6 @@ export default function TabGroupPanel({
                 : undefined
           }}
         >
-          {/* Why: when the right sidebar is closed, App.tsx renders a floating
-              explorer toggle in the top-right corner of the workspace. Only the
-              top-right tab group can sit underneath that button, so reserve
-              space in just that one header instead of pushing every group in. */}
           {/* Why: collapsing the left worktree sidebar should let the terminal
               reclaim the full left edge, but the top-left tab row should still
               stop where the remaining titlebar controls end. Use the measured
@@ -286,6 +287,18 @@ export default function TabGroupPanel({
               </DropdownMenu>
             ) : null}
           </div>
+          {/* Why: Electron's native drag hit-test ignores z-index — a no-drag
+              element only overrides drag when it's a DOM descendant, not a
+              sibling in another branch. The floating right-sidebar toggle in
+              App.tsx sits in a separate DOM tree, so we need an explicit
+              no-drag child here to punch a hole in the drag surface beneath it
+              and let clicks through to the toggle. */}
+          {reserveClosedExplorerToggleSpace && !rightSidebarOpen ? (
+            <div
+              className="shrink-0 w-10"
+              style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+            />
+          ) : null}
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- Add `-webkit-app-region: drag` to the 42px tab row container in `TabGroupPanel` so empty space after tabs becomes a window drag handle on macOS (addresses user feedback that the title bar area isn't draggable)
- Replace `pr-10` padding reserve with an explicit `no-drag` spacer element to keep the floating right-sidebar toggle clickable — Electron's native drag hit-test only respects `no-drag` on DOM descendants, not z-index siblings
- Add `no-drag` to the floating toggle wrapper in `App.tsx` as belt-and-suspenders

## Test plan
- [ ] macOS: verify empty space in the tab row (after last tab and "+" button) allows dragging the window
- [ ] macOS fullscreen: verify the right-sidebar toggle button (top-right, visible when sidebar is closed) is clickable
- [ ] macOS: verify tabs, "+" button, and pane actions menu remain fully interactive (not swallowed by drag)
- [ ] macOS: verify split groups each have draggable empty space in their tab rows
- [ ] Windows/Linux: verify no regression (no `titleBarStyle` set, so drag regions are inert)