### PR TITLE
fix: resolve letter window shortcuts by layout-aware key (Dvorak/Colemak/AZERTY)

### DIFF
--- a/src/shared/window-shortcut-policy.test.ts
+++ b/src/shared/window-shortcut-policy.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   isWindowShortcutModifierChord,
   resolveWindowShortcutAction,
+  type WindowShortcutAction,
   type WindowShortcutInput
 } from './window-shortcut-policy'
 
@@ -263,6 +264,67 @@ describe('resolveWindowShortcutAction', () => {
         'darwin'
       )
     ).toBeNull()
+  })
+
+  it('resolves letter shortcuts by layout-aware key, with code as fallback', () => {
+    // Why: non-QWERTY layouts (Dvorak, Colemak, AZERTY, …) move letters to
+    // other physical keys. Matching only on `input.code` (always QWERTY)
+    // breaks the shortcut for those users. Prefer `input.key` when it is a
+    // letter; fall back to `input.code` only when `key` is empty or a
+    // non-letter marker (dead keys, IME edge cases).
+
+    // Dvorak layout: the letters the user presses sit on different codes
+    // ('b'→KeyN, 'l'→KeyP, 'p'→KeyR, 'n'→KeyL, 'j'→KeyC). All must resolve
+    // to the layout-matched shortcut.
+    const dvorak: [WindowShortcutInput, WindowShortcutAction][] = [
+      [
+        { code: 'KeyN', key: 'b', meta: true, alt: false, shift: false },
+        { type: 'toggleLeftSidebar' }
+      ],
+      [
+        { code: 'KeyP', key: 'l', meta: true, alt: false, shift: false },
+        { type: 'toggleRightSidebar' }
+      ],
+      [{ code: 'KeyR', key: 'p', meta: true, alt: false, shift: false }, { type: 'openQuickOpen' }],
+      [
+        { code: 'KeyL', key: 'n', meta: true, alt: false, shift: false },
+        { type: 'openNewWorkspace' }
+      ],
+      [
+        { code: 'KeyC', key: 'j', meta: true, alt: false, shift: false },
+        { type: 'toggleWorktreePalette' }
+      ]
+    ]
+    for (const [input, expected] of dvorak) {
+      expect(resolveWindowShortcutAction(input, 'darwin')).toEqual(expected)
+    }
+
+    // Inverse guard: physical QWERTY-B on Dvorak types 'x' — that is the
+    // platform Cut shortcut, not the sidebar. The layout-aware match must
+    // reject it.
+    expect(
+      resolveWindowShortcutAction(
+        { code: 'KeyB', key: 'x', meta: true, alt: false, shift: false },
+        'darwin'
+      )
+    ).toBeNull()
+
+    // Fallback: drivers/IME states that leave `key` empty or non-letter
+    // (dead keys, modifier names) must still reach the shortcut on QWERTY.
+    const fallbacks: [WindowShortcutInput, WindowShortcutAction][] = [
+      [
+        { code: 'KeyB', key: '', meta: true, alt: false, shift: false },
+        { type: 'toggleLeftSidebar' }
+      ],
+      [
+        { code: 'KeyN', key: 'Dead', meta: true, alt: false, shift: false },
+        { type: 'openNewWorkspace' }
+      ],
+      [{ code: 'KeyP', meta: true, alt: false, shift: false }, { type: 'openQuickOpen' }]
+    ]
+    for (const [input, expected] of fallbacks) {
+      expect(resolveWindowShortcutAction(input, 'darwin')).toEqual(expected)
+    }
   })
 
   it('exposes the shared platform modifier gate used by browser guests', () => {

--- a/src/shared/window-shortcut-policy.ts
+++ b/src/shared/window-shortcut-policy.ts
@@ -89,6 +89,27 @@ function isZoomOutShortcut(input: WindowShortcutInput): boolean {
   )
 }
 
+// Why: letter shortcuts must follow the user's active keyboard layout. Matching
+// solely on `input.code` uses the physical QWERTY position of the key, which
+// breaks on Dvorak, Colemak, AZERTY, and other non-QWERTY layouts — e.g. on
+// Dvorak the key that types 'b' sits at physical position 'KeyN', so
+// `input.code === 'KeyB'` never fires when the user presses what is, to them,
+// "Cmd+B". `input.key` carries the layout-aware character, so we prefer it
+// when it looks like a letter. We fall back to the QWERTY code when `key` is
+// empty or non-letter (dead keys, some IME states, rare Electron edge cases)
+// so shortcuts still reach users whose driver does not surface `key`.
+function matchesLetterShortcut(
+  input: WindowShortcutInput,
+  letter: string,
+  codeFallback: string
+): boolean {
+  const key = (input.key ?? '').toLowerCase()
+  if (key.length === 1 && key >= 'a' && key <= 'z') {
+    return key === letter
+  }
+  return input.code === codeFallback
+}
+
 export function resolveWindowShortcutAction(
   input: WindowShortcutInput,
   platform: NodeJS.Platform
@@ -120,7 +141,7 @@ export function resolveWindowShortcutAction(
   }
 
   if (
-    input.code === 'KeyJ' &&
+    matchesLetterShortcut(input, 'j', 'KeyJ') &&
     ((platform === 'darwin' && !input.shift) || (platform !== 'darwin' && input.shift))
   ) {
     return { type: 'toggleWorktreePalette' }
@@ -130,15 +151,15 @@ export function resolveWindowShortcutAction(
   // Without main-process interception, xterm.js processes the keydown before
   // the renderer's window-capture handler can preventDefault, causing ^B / ^L
   // to appear in the terminal alongside the sidebar toggle.
-  if (input.code === 'KeyB' && !input.shift) {
+  if (matchesLetterShortcut(input, 'b', 'KeyB') && !input.shift) {
     return { type: 'toggleLeftSidebar' }
   }
 
-  if (input.code === 'KeyL' && !input.shift) {
+  if (matchesLetterShortcut(input, 'l', 'KeyL') && !input.shift) {
     return { type: 'toggleRightSidebar' }
   }
 
-  if (input.code === 'KeyP' && !input.shift) {
+  if (matchesLetterShortcut(input, 'p', 'KeyP') && !input.shift) {
     return { type: 'openQuickOpen' }
   }
 
@@ -146,7 +167,7 @@ export function resolveWindowShortcutAction(
   // main process so it reaches the renderer even when focus lives inside
   // a contentEditable surface (markdown rich editor) or a browser guest
   // webContents, both of which bypass the renderer's window-level keydown.
-  if (input.code === 'KeyN' && !input.shift) {
+  if (matchesLetterShortcut(input, 'n', 'KeyN') && !input.shift) {
     return { type: 'openNewWorkspace' }
   }
 


### PR DESCRIPTION
## What this fixes

Window shortcuts that bind to letters (`Cmd/Ctrl+B`, `+L`, `+P`, `+N`, `+J`) matched only on `input.code`, which always reflects the **QWERTY physical position** of the key. On non-QWERTY layouts (Dvorak, Colemak, AZERTY, etc.) those physical positions hold different letters, so the shortcuts never fired for the user's *actual* `b / l / p / n / j` keys.

**Concrete repro (Dvorak user on macOS):**

- Press `Cmd+B` expecting to toggle the left sidebar → nothing happens, because "b" on Dvorak lives at physical `KeyN`, and the resolver was asking for physical `KeyB`.
- Press the physical `KeyB` instead (which on Dvorak types `x`) → sidebar toggles, but that was the user's Cut shortcut.

Same pattern for `toggleRightSidebar`, `openQuickOpen`, `openNewWorkspace`, `toggleWorktreePalette`.

## The fix

Prefer `input.key` (layout-aware character) when it looks like a letter; fall back to `input.code` only when `key` is empty or a non-letter marker (dead keys, IME states, rare driver edge cases). This mirrors the existing pattern already used by `isZoomOutShortcut` in the same file.

New helper `matchesLetterShortcut(input, letter, codeFallback)` centralizes the rule. The five letter-based branches in `resolveWindowShortcutAction` were switched to it. Non-letter chords (arrows, numpad, digit jumps) are unchanged.

## Tests

Added one consolidated test that covers:

- A full Dvorak layout sweep for all five affected shortcuts (codes `KeyN/KeyP/KeyR/KeyL/KeyC` resolving to the right actions based on `key`).
- The inverse guard: physical `KeyB` typing `x` (Dvorak Cut) must **not** fire the left-sidebar toggle.
- Three fallback cases: empty `key`, `key: 'Dead'`, and missing `key` entirely — resolver still reaches the shortcut via `code` on QWERTY.

All 12 tests in `src/shared/window-shortcut-policy.test.ts` pass locally.

## Cross-platform compatibility review

- Applies equally to `darwin`, `linux`, `win32` — the resolver only branches on `platform` for modifier choice, not for the letter-matching logic.
- `isHistoryNavigateChord` was untouched (it targets `ArrowLeft/ArrowRight`, which are identical across layouts).
- The digit jump (`input.key >= '1' && input.key <= '9'`) was already `key`-based and handles layouts correctly.
- Fallback to `code` ensures users on drivers that don't surface `key` with modifiers (some older Electron builds, certain Linux X11 configs) keep the existing QWERTY behavior.

## Security audit summary

- No new IPC surface, no new permissions, no external dependencies.
- The helper treats `input.key` as opaque string and only compares the first character against `'a'..'z'`; no injection, no user data logged.
- Functionally the change **widens** what the resolver considers a match for letter shortcuts (layout-aware), so it cannot steal any chord that the resolver previously let through — existing null cases (Ctrl+R, Ctrl+U, Ctrl+E, Ctrl+Alt combos) remain null because the modifier gates (`isWindowShortcutModifierChord`, alt/shift checks) are unchanged.

## Testing notes

- Verified locally on macOS 26.3.1 with Orca 1.3.12 (the bug) and against this branch (fix).
- Reproduced on Dvorak by inspecting `/Applications/Orca.app/Contents/Resources/app.asar.unpacked/out/shared/window-shortcut-policy.js` and confirming the shipped code uses `code` only.
- Happy to provide a screen recording if useful — there is no visual change beyond the shortcuts now firing on Dvorak.
