### PR TITLE
feat(agent-status): shared types + renderer store slice foundation

### DIFF
--- a/src/renderer/src/lib/agent-status.test.ts
+++ b/src/renderer/src/lib/agent-status.test.ts
@@ -9,7 +9,11 @@ import {
   createAgentStatusTracker,
   getAgentLabel,
   isGeminiTerminalTitle,
-  normalizeTerminalTitle
+  normalizeTerminalTitle,
+  isExplicitAgentStatusFresh,
+  mapAgentStatusStateToVisualStatus,
+  formatAgentTypeLabel,
+  agentTypeToIconAgent
 } from './agent-status'
 import { extractLastOscTitle } from '../components/terminal-pane/pty-transport'
 
@@ -426,5 +430,112 @@ describe('createAgentStatusTracker', () => {
     }
 
     expect(onBecameIdle).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('isExplicitAgentStatusFresh', () => {
+  it('treats the boundary (now - updatedAt == staleAfterMs) as fresh', () => {
+    // Why: the function uses `<=`, so equality at the boundary must remain
+    // fresh. Protecting this invariant keeps entries from flipping to stale
+    // one tick earlier than the configured TTL implies.
+    const staleAfterMs = 60_000
+    const now = 1_000_000
+    const entry = { updatedAt: now - staleAfterMs }
+    expect(isExplicitAgentStatusFresh(entry, now, staleAfterMs)).toBe(true)
+  })
+
+  it('treats one millisecond past the boundary as stale', () => {
+    const staleAfterMs = 60_000
+    const now = 1_000_000
+    const entry = { updatedAt: now - staleAfterMs - 1 }
+    expect(isExplicitAgentStatusFresh(entry, now, staleAfterMs)).toBe(false)
+  })
+
+  it('treats a just-updated entry (now - updatedAt == 0) as fresh', () => {
+    const staleAfterMs = 60_000
+    const now = 1_000_000
+    const entry = { updatedAt: now }
+    expect(isExplicitAgentStatusFresh(entry, now, staleAfterMs)).toBe(true)
+  })
+})
+
+describe('mapAgentStatusStateToVisualStatus', () => {
+  it("maps 'working' to 'working'", () => {
+    expect(mapAgentStatusStateToVisualStatus('working')).toBe('working')
+  })
+
+  it("maps 'blocked' to 'permission'", () => {
+    expect(mapAgentStatusStateToVisualStatus('blocked')).toBe('permission')
+  })
+
+  it("maps 'waiting' to 'permission'", () => {
+    expect(mapAgentStatusStateToVisualStatus('waiting')).toBe('permission')
+  })
+
+  it("maps 'done' to 'active'", () => {
+    expect(mapAgentStatusStateToVisualStatus('done')).toBe('active')
+  })
+
+  it('returns a non-empty string for every valid state', () => {
+    for (const state of ['working', 'blocked', 'waiting', 'done'] as const) {
+      const visual = mapAgentStatusStateToVisualStatus(state)
+      expect(typeof visual).toBe('string')
+      expect(visual.length).toBeGreaterThan(0)
+    }
+  })
+})
+
+describe('formatAgentTypeLabel', () => {
+  it("returns 'Agent' for null", () => {
+    expect(formatAgentTypeLabel(null)).toBe('Agent')
+  })
+
+  it("returns 'Agent' for undefined", () => {
+    expect(formatAgentTypeLabel(undefined)).toBe('Agent')
+  })
+
+  it("returns 'Agent' for 'unknown'", () => {
+    expect(formatAgentTypeLabel('unknown')).toBe('Agent')
+  })
+
+  it("maps 'claude' to 'Claude'", () => {
+    expect(formatAgentTypeLabel('claude')).toBe('Claude')
+  })
+
+  it("maps 'codex' to 'Codex'", () => {
+    expect(formatAgentTypeLabel('codex')).toBe('Codex')
+  })
+
+  it("maps 'gemini' to 'Gemini'", () => {
+    expect(formatAgentTypeLabel('gemini')).toBe('Gemini')
+  })
+
+  it("passes through unknown-but-nonsentinel strings as-is (e.g. 'cursor')", () => {
+    expect(formatAgentTypeLabel('cursor')).toBe('cursor')
+  })
+})
+
+describe('agentTypeToIconAgent', () => {
+  it('returns null for null', () => {
+    expect(agentTypeToIconAgent(null)).toBeNull()
+  })
+
+  it('returns null for undefined', () => {
+    expect(agentTypeToIconAgent(undefined)).toBeNull()
+  })
+
+  it("returns null for 'unknown'", () => {
+    expect(agentTypeToIconAgent('unknown')).toBeNull()
+  })
+
+  it("round-trips iconable agent types like 'claude'", () => {
+    expect(agentTypeToIconAgent('claude')).toBe('claude')
+  })
+
+  it('returns null for arbitrary non-iconable strings', () => {
+    // Why: guards against hook payloads reporting agentTypes that AgentIcon
+    // cannot render (e.g. "totally-fake-agent"); returning null lets the
+    // caller fall back to a neutral glyph instead of a broken icon.
+    expect(agentTypeToIconAgent('totally-fake-agent')).toBeNull()
   })
 })

--- a/src/renderer/src/lib/agent-status.ts
+++ b/src/renderer/src/lib/agent-status.ts
@@ -1,4 +1,10 @@
-import type { TerminalTab, Worktree } from '../../../shared/types'
+import type { TerminalTab, TuiAgent, Worktree } from '../../../shared/types'
+import type {
+  AgentStatusEntry,
+  AgentStatusState,
+  AgentType
+} from '../../../shared/agent-status-types'
+import type { Status } from '../components/sidebar/StatusIndicator'
 
 // Re-export from shared module so existing renderer imports continue to work.
 // Why: the main process now needs the same agent detection logic for stat
@@ -84,6 +90,104 @@ export function getWorkingAgentsPerWorktree({
   }
 
   return result
+}
+
+const WELL_KNOWN_LABELS: Record<string, string> = {
+  claude: 'Claude',
+  codex: 'Codex',
+  gemini: 'Gemini',
+  opencode: 'OpenCode',
+  aider: 'Aider'
+}
+
+export function formatAgentTypeLabel(agentType: AgentType | null | undefined): string {
+  if (!agentType || agentType === 'unknown') {
+    return 'Agent'
+  }
+  // Capitalize well-known names nicely; pass through custom names as-is
+  return WELL_KNOWN_LABELS[agentType] ?? agentType
+}
+
+// Why: AgentIcon expects a TuiAgent, but AgentType is a broader union
+// (WellKnownAgentType | (string & {})) that includes 'unknown' and arbitrary
+// strings reported by hook payloads. Return null for the unknown case so
+// AgentIcon renders a neutral "?" glyph — using 'claude' as a fallback
+// caused Codex panes to briefly show the Claude icon before the hook fired.
+// Why: we also guard against arbitrary strings (e.g. a hook reporting
+// agentType: "weirdo") by checking membership in an explicit record. A
+// blind `as TuiAgent` cast would pass values through that AgentIcon can't
+// render, producing a broken icon or falling back to an unrelated glyph.
+// Why: modeled as `Record<TuiAgent, true>` rather than a Set so the TypeScript
+// compiler fails to build when a TuiAgent member is added to shared/types.ts
+// without being added here — a Set<TuiAgent> is structurally permissive and
+// would silently accept a subset of the union.
+const ICONABLE_AGENT_TYPES: Record<TuiAgent, true> = {
+  claude: true,
+  codex: true,
+  opencode: true,
+  pi: true,
+  gemini: true,
+  aider: true,
+  goose: true,
+  amp: true,
+  kilo: true,
+  kiro: true,
+  crush: true,
+  aug: true,
+  cline: true,
+  codebuff: true,
+  continue: true,
+  cursor: true,
+  droid: true,
+  kimi: true,
+  'mistral-vibe': true,
+  'qwen-code': true,
+  rovo: true,
+  hermes: true,
+  copilot: true
+}
+
+export function agentTypeToIconAgent(agentType: AgentType | null | undefined): TuiAgent | null {
+  if (!agentType || agentType === 'unknown') {
+    return null
+  }
+  return Object.prototype.hasOwnProperty.call(ICONABLE_AGENT_TYPES, agentType)
+    ? (agentType as TuiAgent)
+    : null
+}
+
+// Why: explicit agent status entries (from hook-based reports) can go stale if
+// the agent process exits without sending a final update. This helper lets
+// callers decide whether to trust the entry based on a configurable TTL.
+export function isExplicitAgentStatusFresh(
+  entry: Pick<AgentStatusEntry, 'updatedAt'>,
+  now: number,
+  staleAfterMs: number
+): boolean {
+  return now - entry.updatedAt <= staleAfterMs
+}
+
+/**
+ * Map an explicit AgentStatusState to the visual Status used by
+ * StatusIndicator and WorktreeCard.
+ *
+ * | Explicit State | Visual Status | Meaning                        |
+ * |----------------|---------------|--------------------------------|
+ * | working        | working       | agent actively executing       |
+ * | blocked        | permission    | agent needs user attention     |
+ * | waiting        | permission    | agent needs user attention     |
+ * | done           | active        | task complete but pane live    |
+ */
+export function mapAgentStatusStateToVisualStatus(state: AgentStatusState): Status {
+  switch (state) {
+    case 'working':
+      return 'working'
+    case 'blocked':
+    case 'waiting':
+      return 'permission'
+    case 'done':
+      return 'active'
+  }
 }
 
 export function countWorkingAgents({

--- a/src/renderer/src/lib/agent-status.ts
+++ b/src/renderer/src/lib/agent-status.ts
@@ -4,7 +4,7 @@ import type {
   AgentStatusState,
   AgentType
 } from '../../../shared/agent-status-types'
-import type { Status } from '../components/sidebar/StatusIndicator'
+import type { WorktreeStatus } from './worktree-status'
 
 // Re-export from shared module so existing renderer imports continue to work.
 // Why: the main process now needs the same agent detection logic for stat
@@ -178,7 +178,7 @@ export function isExplicitAgentStatusFresh(
  * | waiting        | permission    | agent needs user attention     |
  * | done           | active        | task complete but pane live    |
  */
-export function mapAgentStatusStateToVisualStatus(state: AgentStatusState): Status {
+export function mapAgentStatusStateToVisualStatus(state: AgentStatusState): WorktreeStatus {
   switch (state) {
     case 'working':
       return 'working'

--- a/src/renderer/src/store/index.ts
+++ b/src/renderer/src/store/index.ts
@@ -15,6 +15,7 @@ import { createCodexUsageSlice } from './slices/codex-usage'
 import { createBrowserSlice } from './slices/browser'
 import { createRateLimitSlice } from './slices/rate-limits'
 import { createSshSlice } from './slices/ssh'
+import { createAgentStatusSlice } from './slices/agent-status'
 import { createDiffCommentsSlice } from './slices/diffComments'
 import { createDetectedAgentsSlice } from './slices/detected-agents'
 import { createWorktreeNavHistorySlice } from './slices/worktree-nav-history'
@@ -37,6 +38,7 @@ export const useAppStore = create<AppState>()((...a) => ({
   ...createBrowserSlice(...a),
   ...createRateLimitSlice(...a),
   ...createSshSlice(...a),
+  ...createAgentStatusSlice(...a),
   ...createDiffCommentsSlice(...a),
   ...createDetectedAgentsSlice(...a),
   ...createWorktreeNavHistorySlice(...a)

--- a/src/renderer/src/store/slices/agent-status.test.ts
+++ b/src/renderer/src/store/slices/agent-status.test.ts
@@ -1,0 +1,310 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  AGENT_STATUS_STALE_AFTER_MS,
+  type AgentStatusEntry
+} from '../../../../shared/agent-status-types'
+import type { TerminalTab } from '../../../../shared/types'
+import type { RetainedAgentEntry } from './agent-status'
+import { createTestStore } from './store-test-helpers'
+
+// Why: queueMicrotask is used by the agent-status slice to schedule the
+// freshness timer after state updates. In tests we need to flush microtasks
+// before advancing fake timers so the setTimeout gets registered.
+function flushMicrotasks(): Promise<void> {
+  return new Promise((resolve) => queueMicrotask(resolve))
+}
+
+describe('agent status freshness expiry', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('advances agentStatusEpoch when a fresh entry crosses the stale threshold', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-09T12:00:00.000Z'))
+
+    const store = createTestStore()
+    store.getState().setAgentStatus('tab-1:1', { state: 'working', prompt: 'Fix tests' }, 'codex')
+
+    // setAgentStatus bumps epoch once synchronously
+    expect(store.getState().agentStatusEpoch).toBe(1)
+
+    // Flush the queueMicrotask that schedules the freshness timer
+    await flushMicrotasks()
+
+    vi.advanceTimersByTime(AGENT_STATUS_STALE_AFTER_MS + 1)
+
+    // Timer bump adds another increment
+    expect(store.getState().agentStatusEpoch).toBe(2)
+  })
+
+  it('cancels the scheduled freshness tick when the entry is removed first', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-09T12:00:00.000Z'))
+
+    const store = createTestStore()
+    store.getState().setAgentStatus('tab-1:1', { state: 'working', prompt: 'Fix tests' }, 'codex')
+    // set bumps to 1, remove bumps to 2
+    store.getState().removeAgentStatus('tab-1:1')
+    expect(store.getState().agentStatusEpoch).toBe(2)
+
+    // Flush microtask and advance past stale threshold
+    await flushMicrotasks()
+    vi.advanceTimersByTime(AGENT_STATUS_STALE_AFTER_MS + 1)
+
+    // No additional bump since the entry was removed before the timer fires
+    expect(store.getState().agentStatusEpoch).toBe(2)
+  })
+})
+
+describe('agent status tool + assistant fields', () => {
+  // Why: setAgentStatus schedules a real 30-minute freshness setTimeout via
+  // queueMicrotask. Without fake timers those handles leak into the test
+  // process and keep vitest alive past the run.
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('writes toolName, toolInput, and lastAssistantMessage straight onto the entry', () => {
+    vi.useFakeTimers()
+    const store = createTestStore()
+    store.getState().setAgentStatus(
+      'tab-1:1',
+      {
+        state: 'working',
+        prompt: 'Edit the config',
+        toolName: 'Edit',
+        toolInput: '/src/config.ts',
+        lastAssistantMessage: 'Edited config.ts'
+      },
+      'claude'
+    )
+    const entry = store.getState().agentStatusByPaneKey['tab-1:1']
+    expect(entry.toolName).toBe('Edit')
+    expect(entry.toolInput).toBe('/src/config.ts')
+    expect(entry.lastAssistantMessage).toBe('Edited config.ts')
+  })
+
+  it('clears fields to undefined when a later payload omits them', () => {
+    vi.useFakeTimers()
+    const store = createTestStore()
+    store.getState().setAgentStatus(
+      'tab-1:1',
+      {
+        state: 'working',
+        prompt: 'Edit the config',
+        toolName: 'Edit',
+        toolInput: '/src/config.ts',
+        lastAssistantMessage: 'Edited config.ts'
+      },
+      'claude'
+    )
+    // Why: the main-process cache is the source of truth for tool/assistant
+    // fields — a fresh-turn reset surfaces as undefined on the payload, and
+    // the store must not fall back to the prior entry's values.
+    store.getState().setAgentStatus('tab-1:1', { state: 'working', prompt: 'Next step' }, 'claude')
+    const entry = store.getState().agentStatusByPaneKey['tab-1:1']
+    expect(entry.toolName).toBeUndefined()
+    expect(entry.toolInput).toBeUndefined()
+    expect(entry.lastAssistantMessage).toBeUndefined()
+  })
+
+  it('preserves prior agentType when payload omits it', () => {
+    vi.useFakeTimers()
+    const store = createTestStore()
+    store
+      .getState()
+      .setAgentStatus('tab-1:1', { state: 'working', prompt: 'p1', agentType: 'claude' })
+    store.getState().setAgentStatus('tab-1:1', { state: 'working', prompt: 'p2' })
+    expect(store.getState().agentStatusByPaneKey['tab-1:1'].agentType).toBe('claude')
+  })
+
+  it('preserves prior agentType when payload sends the "unknown" sentinel', () => {
+    // Why: 'unknown' is the sentinel for "agent didn't identify itself". A
+    // later ping that loses the identity must not stomp a well-known prior
+    // identity (e.g. 'claude' learned from an earlier hook ping), or the UI
+    // label/icon would flicker from "Claude" to the neutral "Agent".
+    vi.useFakeTimers()
+    const store = createTestStore()
+    store
+      .getState()
+      .setAgentStatus('tab-1:1', { state: 'working', prompt: 'p1', agentType: 'claude' })
+    store
+      .getState()
+      .setAgentStatus('tab-1:1', { state: 'working', prompt: 'p2', agentType: 'unknown' })
+    expect(store.getState().agentStatusByPaneKey['tab-1:1'].agentType).toBe('claude')
+  })
+
+  it('overwrites prior agentType when payload sends a different known value', () => {
+    vi.useFakeTimers()
+    const store = createTestStore()
+    store
+      .getState()
+      .setAgentStatus('tab-1:1', { state: 'working', prompt: 'p1', agentType: 'claude' })
+    store
+      .getState()
+      .setAgentStatus('tab-1:1', { state: 'working', prompt: 'p2', agentType: 'cursor' })
+    expect(store.getState().agentStatusByPaneKey['tab-1:1'].agentType).toBe('cursor')
+  })
+})
+
+describe('agent status stateStartedAt', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('carries stateStartedAt forward across same-state pings', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-09T12:00:00.000Z'))
+
+    const store = createTestStore()
+    store.getState().setAgentStatus('tab-1:1', { state: 'working', prompt: 'p1' }, 'claude')
+    const firstStart = store.getState().agentStatusByPaneKey['tab-1:1'].stateStartedAt
+
+    // Advance 5s and re-ping with same state but different prompt/tool fields
+    vi.setSystemTime(new Date('2026-04-09T12:00:05.000Z'))
+    store
+      .getState()
+      .setAgentStatus('tab-1:1', { state: 'working', prompt: 'p1', toolName: 'Edit' }, 'claude')
+
+    const entry = store.getState().agentStatusByPaneKey['tab-1:1']
+    // Why: stateStartedAt is the invariant we are protecting — it must survive
+    // tool/prompt pings within the same state, while updatedAt advances.
+    expect(entry.stateStartedAt).toBe(firstStart)
+    expect(entry.updatedAt).toBe(new Date('2026-04-09T12:00:05.000Z').getTime())
+  })
+
+  it('resets stateStartedAt when the state changes', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-09T12:00:00.000Z'))
+
+    const store = createTestStore()
+    store.getState().setAgentStatus('tab-1:1', { state: 'working', prompt: 'p1' }, 'claude')
+    const workingStart = store.getState().agentStatusByPaneKey['tab-1:1'].stateStartedAt
+
+    vi.setSystemTime(new Date('2026-04-09T12:00:10.000Z'))
+    store.getState().setAgentStatus('tab-1:1', { state: 'done', prompt: 'p1' }, 'claude')
+
+    const entry = store.getState().agentStatusByPaneKey['tab-1:1']
+    expect(entry.stateStartedAt).toBe(new Date('2026-04-09T12:00:10.000Z').getTime())
+    expect(entry.stateStartedAt).not.toBe(workingStart)
+    // history should capture the working state's true start
+    expect(entry.stateHistory).toHaveLength(1)
+    expect(entry.stateHistory[0].state).toBe('working')
+    expect(entry.stateHistory[0].startedAt).toBe(workingStart)
+  })
+})
+
+describe('agent status retention + prefix sweep', () => {
+  // Why: setAgentStatus schedules a real 30-minute freshness setTimeout via
+  // queueMicrotask. Use fake timers so the handle does not leak into the
+  // test process.
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('removeAgentStatusByTabPrefix scopes by the ":" delimiter so tab-1 does not sweep tab-10', () => {
+    vi.useFakeTimers()
+    const store = createTestStore()
+    store.getState().setAgentStatus('tab-1:0', { state: 'working', prompt: 'p' }, 'claude')
+    store.getState().setAgentStatus('tab-1:1', { state: 'working', prompt: 'p' }, 'claude')
+    store.getState().setAgentStatus('tab-10:0', { state: 'working', prompt: 'p' }, 'claude')
+
+    store.getState().removeAgentStatusByTabPrefix('tab-1')
+
+    const map = store.getState().agentStatusByPaneKey
+    expect(map['tab-1:0']).toBeUndefined()
+    expect(map['tab-1:1']).toBeUndefined()
+    // Why: the ":" delimiter on the prefix guards against false-prefix matches
+    // across tab ids that share a leading substring (tab-1 vs tab-10).
+    expect(map['tab-10:0']).toBeDefined()
+  })
+
+  it('dismissRetainedAgentsByWorktree removes only entries for the given worktreeId', () => {
+    const store = createTestStore()
+    const now = Date.now()
+    const entryA: AgentStatusEntry = {
+      state: 'done',
+      prompt: '',
+      updatedAt: now,
+      stateStartedAt: now,
+      paneKey: 'tab-a:0',
+      stateHistory: []
+    }
+    const entryB: AgentStatusEntry = {
+      state: 'done',
+      prompt: '',
+      updatedAt: now,
+      stateStartedAt: now,
+      paneKey: 'tab-b:0',
+      stateHistory: []
+    }
+    const retainedA: RetainedAgentEntry = {
+      entry: entryA,
+      worktreeId: 'wt-a',
+      tab: { id: 'tab-a', title: 'claude' } as unknown as TerminalTab,
+      agentType: 'claude',
+      startedAt: now
+    }
+    const retainedB: RetainedAgentEntry = {
+      entry: entryB,
+      worktreeId: 'wt-b',
+      tab: { id: 'tab-b', title: 'claude' } as unknown as TerminalTab,
+      agentType: 'claude',
+      startedAt: now
+    }
+
+    store.getState().retainAgent(retainedA)
+    store.getState().retainAgent(retainedB)
+    store.getState().dismissRetainedAgentsByWorktree('wt-a')
+
+    const retained = store.getState().retainedAgentsByPaneKey
+    expect(retained['tab-a:0']).toBeUndefined()
+    expect(retained['tab-b:0']).toBeDefined()
+    expect(retained['tab-b:0'].worktreeId).toBe('wt-b')
+  })
+
+  it('pruneRetainedAgents keeps only entries whose worktreeId is in the valid set', () => {
+    const store = createTestStore()
+    const now = Date.now()
+    const entryA: AgentStatusEntry = {
+      state: 'done',
+      prompt: '',
+      updatedAt: now,
+      stateStartedAt: now,
+      paneKey: 'tab-a:0',
+      stateHistory: []
+    }
+    const entryB: AgentStatusEntry = {
+      state: 'done',
+      prompt: '',
+      updatedAt: now,
+      stateStartedAt: now,
+      paneKey: 'tab-b:0',
+      stateHistory: []
+    }
+    const retainedA: RetainedAgentEntry = {
+      entry: entryA,
+      worktreeId: 'wt-a',
+      tab: { id: 'tab-a', title: 'claude' } as unknown as TerminalTab,
+      agentType: 'claude',
+      startedAt: now
+    }
+    const retainedB: RetainedAgentEntry = {
+      entry: entryB,
+      worktreeId: 'wt-b',
+      tab: { id: 'tab-b', title: 'claude' } as unknown as TerminalTab,
+      agentType: 'claude',
+      startedAt: now
+    }
+
+    store.getState().retainAgent(retainedA)
+    store.getState().retainAgent(retainedB)
+    store.getState().pruneRetainedAgents(new Set(['wt-a']))
+
+    const retained = store.getState().retainedAgentsByPaneKey
+    expect(retained['tab-a:0']).toBeDefined()
+    expect(retained['tab-a:0'].worktreeId).toBe('wt-a')
+    expect(retained['tab-b:0']).toBeUndefined()
+  })
+})

--- a/src/renderer/src/store/slices/agent-status.ts
+++ b/src/renderer/src/store/slices/agent-status.ts
@@ -1,0 +1,325 @@
+import type { StateCreator } from 'zustand'
+import type { AppState } from '../types'
+import {
+  AGENT_STATUS_STALE_AFTER_MS,
+  AGENT_STATE_HISTORY_MAX,
+  type AgentStateHistoryEntry,
+  type AgentStatusEntry,
+  type AgentType,
+  type ParsedAgentStatusPayload
+} from '../../../../shared/agent-status-types'
+import type { TerminalTab } from '../../../../shared/types'
+
+/** Snapshot of a finished (or vanished) agent status entry, kept around so
+ *  the dashboard + sidebar hover can continue showing the completion until the
+ *  user acknowledges it by clicking the worktree. The `worktreeId` is stamped
+ *  at retention time so we know where the row belongs even after the tab/pty
+ *  it came from has gone away. */
+export type RetainedAgentEntry = {
+  entry: AgentStatusEntry
+  worktreeId: string
+  /** Snapshot of the tab the agent lived in at retention time. We keep the
+   *  full record (not just an id) because the tab may be gone from
+   *  `tabsByWorktree` by the time the retained row is rendered. */
+  tab: TerminalTab
+  agentType: AgentType
+  startedAt: number
+}
+
+export type AgentStatusSlice = {
+  /** Explicit agent status entries keyed by `${tabId}:${paneId}` composite.
+   *  Real-time only — lives in renderer memory, not persisted to disk. */
+  agentStatusByPaneKey: Record<string, AgentStatusEntry>
+  /** Monotonic tick that advances when agent-status freshness boundaries pass. */
+  agentStatusEpoch: number
+
+  /** Retained "done" entries — snapshots of agents that have disappeared from
+   *  `agentStatusByPaneKey`. Keyed by paneKey so re-appearance of the same pane
+   *  overwrites the snapshot. Shared between the dashboard and the sidebar
+   *  agent-status hover so the two surfaces display identical rows. */
+  retainedAgentsByPaneKey: Record<string, RetainedAgentEntry>
+
+  /** Update or insert an agent status entry from a status payload. */
+  setAgentStatus: (
+    paneKey: string,
+    payload: ParsedAgentStatusPayload,
+    terminalTitle?: string
+  ) => void
+
+  /** Remove a single entry (e.g., when a pane's terminal exits). */
+  removeAgentStatus: (paneKey: string) => void
+
+  /** Remove all entries whose paneKey starts with the given prefix.
+   *  Used when a tab is closed — same prefix-sweep as cacheTimerByKey cleanup. */
+  removeAgentStatusByTabPrefix: (tabIdPrefix: string) => void
+
+  /** Retain an agent snapshot (called by the top-level retention sync effect). */
+  retainAgent: (retained: RetainedAgentEntry) => void
+
+  /** Dismiss a retained entry by its paneKey. */
+  dismissRetainedAgent: (paneKey: string) => void
+
+  /** Dismiss all retained entries belonging to a worktree. */
+  dismissRetainedAgentsByWorktree: (worktreeId: string) => void
+
+  /** Prune retained entries whose worktreeId is not in the given set. */
+  pruneRetainedAgents: (validWorktreeIds: Set<string>) => void
+}
+
+export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusSlice> = (
+  set,
+  get
+) => {
+  // Why: tests that call setAgentStatus must use vi.useFakeTimers() or remove the entry before teardown — otherwise a real 30-minute setTimeout leaks into the test process.
+  let staleExpiryTimer: ReturnType<typeof setTimeout> | null = null
+
+  const clearStaleExpiryTimer = (): void => {
+    if (staleExpiryTimer !== null) {
+      clearTimeout(staleExpiryTimer)
+      staleExpiryTimer = null
+    }
+  }
+
+  const scheduleNextFreshnessExpiry = (): void => {
+    clearStaleExpiryTimer()
+
+    const entries = Object.values(get().agentStatusByPaneKey)
+    if (entries.length === 0) {
+      return
+    }
+
+    const now = Date.now()
+    let nextExpiryAt = Number.POSITIVE_INFINITY
+    // Why: skip entries already past the stale boundary — they each contribute
+    // exactly one epoch bump at crossing, and rescheduling on them would spin
+    // the timer forever because the bump doesn't clear them from the map
+    // (retention is intentional so freshness-aware selectors can decay).
+    for (const entry of entries) {
+      const expiryAt = entry.updatedAt + AGENT_STATUS_STALE_AFTER_MS
+      if (expiryAt > now) {
+        nextExpiryAt = Math.min(nextExpiryAt, expiryAt)
+      }
+    }
+    if (!Number.isFinite(nextExpiryAt)) {
+      return
+    }
+
+    // Why: +1 ms ensures the timer fires strictly after the stale boundary,
+    // so isExplicitAgentStatusFresh (which uses `<=`) flips to stale when the
+    // timer runs. Without the +1, float/rounding could leave the entry "just
+    // fresh enough" at the tick, delaying the epoch bump by one tick.
+    const delayMs = nextExpiryAt - now + 1
+    staleExpiryTimer = setTimeout(() => {
+      staleExpiryTimer = null
+      // Why: freshness is time-based, not event-based. Advancing these epochs
+      // at the exact stale boundary forces all freshness-aware selectors to
+      // recompute — and re-sorts WorktreeList — even when no new PTY output
+      // arrives. sortEpoch must bump in lockstep with agentStatusEpoch because
+      // a stale transition can legitimately change worktree ordering.
+      set((s) => ({
+        agentStatusEpoch: s.agentStatusEpoch + 1,
+        sortEpoch: s.sortEpoch + 1
+      }))
+      scheduleNextFreshnessExpiry()
+    }, delayMs)
+  }
+
+  return {
+    agentStatusByPaneKey: {},
+    agentStatusEpoch: 0,
+    retainedAgentsByPaneKey: {},
+
+    setAgentStatus: (paneKey, payload, terminalTitle) => {
+      set((s) => {
+        const existing = s.agentStatusByPaneKey[paneKey]
+        // Why: terminalTitle is identity-like — it labels the pane itself, not
+        // the current turn's activity. Preserve the prior value when a ping
+        // omits it so the pane label does not flicker out between hook events.
+        // Unlike the tool/prompt/assistant fields below (which legitimately
+        // clear on a fresh turn), a missing title means "no update", not "the
+        // pane has no title any more".
+        const effectiveTitle = terminalTitle ?? existing?.terminalTitle
+
+        // Why: build up a rolling log of state transitions so the dashboard can
+        // render activity blocks showing what the agent has been doing. Only push
+        // when the state actually changes to avoid duplicate entries from prompt-
+        // only updates within the same state.
+        let history: AgentStateHistoryEntry[] = existing?.stateHistory ?? []
+        if (existing && existing.state !== payload.state) {
+          history = [
+            ...history,
+            {
+              state: existing.state,
+              prompt: existing.prompt,
+              // Why: use stateStartedAt (not updatedAt) so the history row
+              // reflects when the state was first reported, not the most
+              // recent within-state ping (tool/prompt updates refresh
+              // updatedAt but not stateStartedAt).
+              startedAt: existing.stateStartedAt,
+              // Why: preserve the interrupt flag on the historical `done` entry
+              // so activity-block views can render past cancellations as such.
+              interrupted: existing.interrupted
+            }
+          ]
+          if (history.length > AGENT_STATE_HISTORY_MAX) {
+            history = history.slice(history.length - AGENT_STATE_HISTORY_MAX)
+          }
+        }
+
+        const now = Date.now()
+        // Why: stateStartedAt anchors to the first time this state was
+        // reported. Carry forward the prior value on tool/prompt pings within
+        // the same state so stateHistory[].startedAt reflects true state-onset
+        // (see AgentStatusEntry.stateStartedAt docs).
+        const stateStartedAt =
+          existing && existing.state === payload.state ? existing.stateStartedAt : now
+
+        // Why: tool/assistant fields come pre-merged from the main-process
+        // cache (see `resolveToolState` in server.ts), so the payload always
+        // carries the authoritative current snapshot — including clears on a
+        // fresh turn. Writing through directly (no existing fallback) is what
+        // lets a `UserPromptSubmit` reset clear stale tool lines in the UI.
+        const entry: AgentStatusEntry = {
+          state: payload.state,
+          prompt: payload.prompt,
+          updatedAt: now,
+          stateStartedAt,
+          // Why: unlike tool/prompt/assistant fields (which legitimately clear on a
+          // fresh turn), agentType is the agent's identity for the pane — it does
+          // not change between updates. Preserve the prior value when a payload
+          // omits it so the icon/label does not flicker out between hook pings.
+          // 'unknown' is the sentinel for "agent didn't identify itself" in
+          // WellKnownAgentType. Treat it like absence so a well-known prior
+          // identity (e.g. 'claude' learned from an earlier hook ping) isn't
+          // stomped by a later ping that lost the identity (e.g. legacy/partial
+          // integrations).
+          agentType:
+            payload.agentType && payload.agentType !== 'unknown'
+              ? payload.agentType
+              : existing?.agentType,
+          paneKey,
+          terminalTitle: effectiveTitle,
+          stateHistory: history,
+          toolName: payload.toolName,
+          toolInput: payload.toolInput,
+          lastAssistantMessage: payload.lastAssistantMessage,
+          // Why: interrupted lives on `done` only. parseAgentStatusPayload
+          // already clamps it to `undefined` for non-done states, so writing
+          // the field through directly preserves truth for done and resets
+          // it when a new turn starts (working → Stop reprices it).
+          interrupted: payload.interrupted
+        }
+        return {
+          agentStatusByPaneKey: { ...s.agentStatusByPaneKey, [paneKey]: entry },
+          // Why: bump both epochs so WorktreeCard re-derives its visual status
+          // and WorktreeList re-sorts immediately when an agent reports status.
+          // The freshness-expiry timer and the remove* paths bump both epochs
+          // for the same reason — agent transitions (new, stale, removed) can
+          // all legitimately change worktree sort order.
+          agentStatusEpoch: s.agentStatusEpoch + 1,
+          sortEpoch: s.sortEpoch + 1
+        }
+      })
+      // Why: schedule after set completes so the timer reads the updated map.
+      // queueMicrotask avoids re-entry into the zustand store during set.
+      queueMicrotask(() => scheduleNextFreshnessExpiry())
+    },
+
+    removeAgentStatus: (paneKey) => {
+      if (!(paneKey in get().agentStatusByPaneKey)) {
+        return
+      }
+      set((s) => {
+        const next = { ...s.agentStatusByPaneKey }
+        delete next[paneKey]
+        // Why: bump sortEpoch in lockstep with agentStatusEpoch — removing an
+        // agent can legitimately change worktree sort order, same rationale
+        // as setAgentStatus.
+        return {
+          agentStatusByPaneKey: next,
+          agentStatusEpoch: s.agentStatusEpoch + 1,
+          sortEpoch: s.sortEpoch + 1
+        }
+      })
+      queueMicrotask(() => scheduleNextFreshnessExpiry())
+    },
+
+    removeAgentStatusByTabPrefix: (tabIdPrefix) => {
+      const prefix = `${tabIdPrefix}:`
+      const currentKeys = Object.keys(get().agentStatusByPaneKey)
+      const toRemove = currentKeys.filter((k) => k.startsWith(prefix))
+      if (toRemove.length === 0) {
+        return
+      }
+      set((s) => {
+        const next = { ...s.agentStatusByPaneKey }
+        for (const key of toRemove) {
+          delete next[key]
+        }
+        // Why: bump sortEpoch in lockstep with agentStatusEpoch — removing
+        // agents can legitimately change worktree sort order, same rationale
+        // as setAgentStatus. The pre-check guards against spurious bumps when
+        // no keys matched the prefix.
+        return {
+          agentStatusByPaneKey: next,
+          agentStatusEpoch: s.agentStatusEpoch + 1,
+          sortEpoch: s.sortEpoch + 1
+        }
+      })
+      queueMicrotask(() => scheduleNextFreshnessExpiry())
+    },
+
+    retainAgent: (retained) => {
+      // Why: retained entries are a pure read-overlay — consumers read
+      // retainedAgentsByPaneKey directly each render, so no sort/status epoch
+      // bump is needed. Retention does not participate in sort ordering.
+      set((s) => ({
+        retainedAgentsByPaneKey: {
+          ...s.retainedAgentsByPaneKey,
+          [retained.entry.paneKey]: retained
+        }
+      }))
+    },
+
+    dismissRetainedAgent: (paneKey) => {
+      set((s) => {
+        if (!(paneKey in s.retainedAgentsByPaneKey)) {
+          return s
+        }
+        const next = { ...s.retainedAgentsByPaneKey }
+        delete next[paneKey]
+        return { retainedAgentsByPaneKey: next }
+      })
+    },
+
+    dismissRetainedAgentsByWorktree: (worktreeId) => {
+      set((s) => {
+        let changed = false
+        const next: Record<string, RetainedAgentEntry> = {}
+        for (const [key, ra] of Object.entries(s.retainedAgentsByPaneKey)) {
+          if (ra.worktreeId === worktreeId) {
+            changed = true
+            continue
+          }
+          next[key] = ra
+        }
+        return changed ? { retainedAgentsByPaneKey: next } : s
+      })
+    },
+
+    pruneRetainedAgents: (validWorktreeIds) => {
+      set((s) => {
+        let changed = false
+        const next: Record<string, RetainedAgentEntry> = {}
+        for (const [key, ra] of Object.entries(s.retainedAgentsByPaneKey)) {
+          if (!validWorktreeIds.has(ra.worktreeId)) {
+            changed = true
+            continue
+          }
+          next[key] = ra
+        }
+        return changed ? { retainedAgentsByPaneKey: next } : s
+      })
+    }
+  }
+}

--- a/src/renderer/src/store/slices/store-session-cascades.test.ts
+++ b/src/renderer/src/store/slices/store-session-cascades.test.ts
@@ -99,6 +99,7 @@ import { createCodexUsageSlice } from './codex-usage'
 import { createBrowserSlice } from './browser'
 import { createRateLimitSlice } from './rate-limits'
 import { createSshSlice } from './ssh'
+import { createAgentStatusSlice } from './agent-status'
 import { createDiffCommentsSlice } from './diffComments'
 import { createDetectedAgentsSlice } from './detected-agents'
 import { createWorktreeNavHistorySlice } from './worktree-nav-history'
@@ -120,6 +121,7 @@ function createTestStore() {
     ...createBrowserSlice(...a),
     ...createRateLimitSlice(...a),
     ...createSshSlice(...a),
+    ...createAgentStatusSlice(...a),
     ...createDiffCommentsSlice(...a),
     ...createDetectedAgentsSlice(...a),
     ...createWorktreeNavHistorySlice(...a)

--- a/src/renderer/src/store/slices/store-test-helpers.ts
+++ b/src/renderer/src/store/slices/store-test-helpers.ts
@@ -23,6 +23,7 @@ import { createCodexUsageSlice } from './codex-usage'
 import { createBrowserSlice } from './browser'
 import { createRateLimitSlice } from './rate-limits'
 import { createSshSlice } from './ssh'
+import { createAgentStatusSlice } from './agent-status'
 import { createDiffCommentsSlice } from './diffComments'
 import { createDetectedAgentsSlice } from './detected-agents'
 import { createWorktreeNavHistorySlice } from './worktree-nav-history'
@@ -52,6 +53,7 @@ export function createTestStore() {
     ...createBrowserSlice(...a),
     ...createRateLimitSlice(...a),
     ...createSshSlice(...a),
+    ...createAgentStatusSlice(...a),
     ...createDiffCommentsSlice(...a),
     ...createDetectedAgentsSlice(...a),
     ...createWorktreeNavHistorySlice(...a)

--- a/src/renderer/src/store/slices/tabs.test.ts
+++ b/src/renderer/src/store/slices/tabs.test.ts
@@ -94,6 +94,7 @@ import { createCodexUsageSlice } from './codex-usage'
 import { createBrowserSlice } from './browser'
 import { createRateLimitSlice } from './rate-limits'
 import { createSshSlice } from './ssh'
+import { createAgentStatusSlice } from './agent-status'
 import { createDiffCommentsSlice } from './diffComments'
 import { createDetectedAgentsSlice } from './detected-agents'
 import { createWorktreeNavHistorySlice } from './worktree-nav-history'
@@ -117,6 +118,7 @@ function createTestStore() {
     ...createBrowserSlice(...a),
     ...createRateLimitSlice(...a),
     ...createSshSlice(...a),
+    ...createAgentStatusSlice(...a),
     ...createDiffCommentsSlice(...a),
     ...createDetectedAgentsSlice(...a),
     ...createWorktreeNavHistorySlice(...a)

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -394,6 +394,10 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         pendingColdRestoreByPtyId: nextColdRestores
       }
     })
+    // Why: delegate agent-status cleanup to its own slice so the epoch and
+    // stale-freshness timer bookkeeping stay consistent with other agent-status
+    // mutations.
+    get().removeAgentStatusByTabPrefix(tabId)
     for (const tabs of Object.values(get().unifiedTabsByWorktree)) {
       const workspaceItem = tabs.find(
         (entry) => entry.contentType === 'terminal' && entry.entityId === tabId

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -394,9 +394,16 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         pendingColdRestoreByPtyId: nextColdRestores
       }
     })
-    // Why: delegate agent-status cleanup to its own slice so the epoch and
-    // stale-freshness timer bookkeeping stay consistent with other agent-status
-    // mutations.
+    // Why: sweep live agent-status entries for this tab — the pane/tab state is
+    // gone, so any remaining status would be stale. Delegate to the agent-status
+    // slice so the epoch and stale-freshness timer bookkeeping stay consistent
+    // with other agent-status mutations.
+    //
+    // Retained agent entries (retainedAgentsByPaneKey) are INTENTIONALLY NOT
+    // swept here: they are worktree-scoped so a completed agent card survives
+    // tab close, and are pruned separately by pruneRetainedAgents when the
+    // worktree list refreshes, or by dismissRetainedAgentsByWorktree when the
+    // worktree itself is deleted.
     get().removeAgentStatusByTabPrefix(tabId)
     for (const tabs of Object.values(get().unifiedTabsByWorktree)) {
       const workspaceItem = tabs.find(

--- a/src/renderer/src/store/types.ts
+++ b/src/renderer/src/store/types.ts
@@ -13,6 +13,7 @@ import type { CodexUsageSlice } from './slices/codex-usage'
 import type { BrowserSlice } from './slices/browser'
 import type { RateLimitSlice } from './slices/rate-limits'
 import type { SshSlice } from './slices/ssh'
+import type { AgentStatusSlice } from './slices/agent-status'
 import type { DiffCommentsSlice } from './slices/diffComments'
 import type { DetectedAgentsSlice } from './slices/detected-agents'
 import type { WorktreeNavHistorySlice } from './slices/worktree-nav-history'
@@ -32,6 +33,7 @@ export type AppState = RepoSlice &
   BrowserSlice &
   RateLimitSlice &
   SshSlice &
+  AgentStatusSlice &
   DiffCommentsSlice &
   DetectedAgentsSlice &
   WorktreeNavHistorySlice

--- a/src/shared/agent-hook-types.ts
+++ b/src/shared/agent-hook-types.ts
@@ -1,0 +1,23 @@
+// Why: these IPC payload shapes live here but have no renderer/main consumer
+// in this PR. They are pulled in by the main-process hook server (Claude /
+// Codex / Gemini native hook integrations) that lands in the follow-up PR.
+// Keeping the types shared up-front avoids a churn PR that renames or splits
+// them once the hook server imports them.
+
+export type AgentHookTarget = 'claude' | 'codex' | 'gemini'
+
+export type AgentHookInstallState = 'installed' | 'not_installed' | 'partial' | 'error'
+
+export type AgentHookInstallStatus = {
+  agent: AgentHookTarget
+  state: AgentHookInstallState
+  configPath: string
+  managedHooksPresent: boolean
+  detail: string | null
+}
+
+// Why: bumped whenever the managed script's request shape changes. The
+// receiver logs a warning when it sees a request from a different version so a
+// stale script installed by an older app build is diagnosable instead of
+// silently producing partial payloads.
+export const ORCA_HOOK_PROTOCOL_VERSION = '1' as const

--- a/src/shared/agent-status-types.test.ts
+++ b/src/shared/agent-status-types.test.ts
@@ -1,0 +1,312 @@
+import { describe, it, expect } from 'vitest'
+import {
+  parseAgentStatusPayload,
+  AGENT_STATUS_MAX_FIELD_LENGTH,
+  AGENT_STATUS_TOOL_NAME_MAX_LENGTH,
+  AGENT_STATUS_TOOL_INPUT_MAX_LENGTH,
+  AGENT_STATUS_ASSISTANT_MESSAGE_MAX_LENGTH,
+  AGENT_STATUS_STATES,
+  AGENT_TYPE_MAX_LENGTH
+} from './agent-status-types'
+
+describe('parseAgentStatusPayload', () => {
+  it('parses a valid working payload', () => {
+    const result = parseAgentStatusPayload(
+      '{"state":"working","prompt":"Fix the flaky assertion","agentType":"codex"}'
+    )
+    expect(result).toEqual({
+      state: 'working',
+      prompt: 'Fix the flaky assertion',
+      agentType: 'codex'
+    })
+  })
+
+  it('parses all AGENT_STATUS_STATES', () => {
+    for (const state of AGENT_STATUS_STATES) {
+      const result = parseAgentStatusPayload(`{"state":"${state}"}`)
+      expect(result).not.toBeNull()
+      expect(result!.state).toBe(state)
+    }
+  })
+
+  it('returns null for invalid state', () => {
+    expect(parseAgentStatusPayload('{"state":"running"}')).toBeNull()
+    expect(parseAgentStatusPayload('{"state":"idle"}')).toBeNull()
+    expect(parseAgentStatusPayload('{"state":""}')).toBeNull()
+  })
+
+  it('returns null when state is a non-string type', () => {
+    expect(parseAgentStatusPayload('{"state":123}')).toBeNull()
+    expect(parseAgentStatusPayload('{"state":true}')).toBeNull()
+    expect(parseAgentStatusPayload('{"state":null}')).toBeNull()
+  })
+
+  it('returns null for invalid JSON', () => {
+    expect(parseAgentStatusPayload('not json')).toBeNull()
+    expect(parseAgentStatusPayload('{broken')).toBeNull()
+    expect(parseAgentStatusPayload('')).toBeNull()
+  })
+
+  it('returns null for non-object JSON', () => {
+    expect(parseAgentStatusPayload('"just a string"')).toBeNull()
+    expect(parseAgentStatusPayload('42')).toBeNull()
+    expect(parseAgentStatusPayload('null')).toBeNull()
+    expect(parseAgentStatusPayload('[]')).toBeNull()
+  })
+
+  it('normalizes multiline prompt to single line', () => {
+    const result = parseAgentStatusPayload(
+      '{"state":"working","prompt":"line one\\nline two\\nline three"}'
+    )
+    expect(result!.prompt).toBe('line one line two line three')
+  })
+
+  it('normalizes Windows-style line endings (\\r\\n) to single line', () => {
+    const result = parseAgentStatusPayload(
+      '{"state":"working","prompt":"line one\\r\\nline two\\r\\nline three"}'
+    )
+    expect(result!.prompt).toBe('line one line two line three')
+  })
+
+  it('trims whitespace from the prompt field', () => {
+    const result = parseAgentStatusPayload('{"state":"working","prompt":"  padded  "}')
+    expect(result!.prompt).toBe('padded')
+  })
+
+  it('truncates the prompt beyond max length', () => {
+    const longString = 'x'.repeat(300)
+    const result = parseAgentStatusPayload(`{"state":"working","prompt":"${longString}"}`)
+    expect(result!.prompt).toHaveLength(AGENT_STATUS_MAX_FIELD_LENGTH)
+  })
+
+  it('defaults missing prompt to empty string', () => {
+    const result = parseAgentStatusPayload('{"state":"done"}')
+    expect(result!.prompt).toBe('')
+  })
+
+  it('handles non-string prompt gracefully', () => {
+    const result = parseAgentStatusPayload('{"state":"working","prompt":42}')
+    expect(result!.prompt).toBe('')
+  })
+
+  it('accepts custom non-empty agentType values', () => {
+    const result = parseAgentStatusPayload('{"state":"working","agentType":"cursor"}')
+    expect(result).toEqual({
+      state: 'working',
+      prompt: '',
+      agentType: 'cursor'
+    })
+  })
+
+  it('truncates agentType beyond AGENT_TYPE_MAX_LENGTH', () => {
+    const longAgentType = 'a'.repeat(AGENT_TYPE_MAX_LENGTH + 20)
+    const result = parseAgentStatusPayload(
+      JSON.stringify({ state: 'working', agentType: longAgentType })
+    )
+    expect(result!.agentType).toHaveLength(AGENT_TYPE_MAX_LENGTH)
+  })
+
+  it('treats whitespace-only agentType as undefined', () => {
+    const result = parseAgentStatusPayload('{"state":"working","agentType":"   "}')
+    expect(result!.agentType).toBeUndefined()
+  })
+
+  it('collapses newlines in agentType (single-line field)', () => {
+    // Why: pins the regression the parser comment on agent-status-types.ts calls
+    // out — a payload with agentType: "claude\nrogue" must not leak the newline
+    // into UI rendering or equality checks.
+    const result = parseAgentStatusPayload('{"state":"working","agentType":"claude\\nrogue"}')
+    expect(result!.agentType).toBe('claude rogue')
+  })
+
+  it('parses toolName, toolInput, and lastAssistantMessage', () => {
+    const result = parseAgentStatusPayload(
+      JSON.stringify({
+        state: 'working',
+        toolName: 'Edit',
+        toolInput: '/path/to/file.ts',
+        lastAssistantMessage: 'Here is the edit I made.'
+      })
+    )
+    expect(result).toEqual({
+      state: 'working',
+      prompt: '',
+      agentType: undefined,
+      toolName: 'Edit',
+      toolInput: '/path/to/file.ts',
+      lastAssistantMessage: 'Here is the edit I made.'
+    })
+  })
+
+  it('truncates each optional field to its own cap', () => {
+    const longName = 'n'.repeat(AGENT_STATUS_TOOL_NAME_MAX_LENGTH + 50)
+    const longInput = 'i'.repeat(AGENT_STATUS_TOOL_INPUT_MAX_LENGTH + 50)
+    const longMessage = 'm'.repeat(AGENT_STATUS_ASSISTANT_MESSAGE_MAX_LENGTH + 500)
+    const result = parseAgentStatusPayload(
+      JSON.stringify({
+        state: 'working',
+        toolName: longName,
+        toolInput: longInput,
+        lastAssistantMessage: longMessage
+      })
+    )
+    expect(result!.toolName).toHaveLength(AGENT_STATUS_TOOL_NAME_MAX_LENGTH)
+    expect(result!.toolInput).toHaveLength(AGENT_STATUS_TOOL_INPUT_MAX_LENGTH)
+    expect(result!.lastAssistantMessage).toHaveLength(AGENT_STATUS_ASSISTANT_MESSAGE_MAX_LENGTH)
+  })
+
+  it('leaves omitted optional fields undefined (not empty string)', () => {
+    const result = parseAgentStatusPayload('{"state":"working"}')
+    expect(result!.toolName).toBeUndefined()
+    expect(result!.toolInput).toBeUndefined()
+    expect(result!.lastAssistantMessage).toBeUndefined()
+  })
+
+  it('treats non-string optional fields as undefined', () => {
+    const result = parseAgentStatusPayload(
+      '{"state":"working","toolName":42,"toolInput":null,"lastAssistantMessage":[]}'
+    )
+    expect(result!.toolName).toBeUndefined()
+    expect(result!.toolInput).toBeUndefined()
+    expect(result!.lastAssistantMessage).toBeUndefined()
+  })
+
+  it('treats empty-string optional fields as undefined', () => {
+    const result = parseAgentStatusPayload(
+      '{"state":"working","toolName":"   ","toolInput":"","lastAssistantMessage":"   "}'
+    )
+    expect(result!.toolName).toBeUndefined()
+    expect(result!.toolInput).toBeUndefined()
+    expect(result!.lastAssistantMessage).toBeUndefined()
+  })
+
+  it('collapses newlines in toolInput (single-line preview field)', () => {
+    const result = parseAgentStatusPayload('{"state":"working","toolInput":"line one\\nline two"}')
+    expect(result!.toolInput).toBe('line one line two')
+  })
+
+  it('preserves paragraph breaks in lastAssistantMessage', () => {
+    // Why: the assistant message is rendered with `whitespace-pre-wrap` in the
+    // dashboard row so the user sees the same paragraph structure the agent
+    // produced. Collapsing newlines would destroy that structure.
+    const result = parseAgentStatusPayload(
+      '{"state":"done","lastAssistantMessage":"Summary line.\\n\\nDetails paragraph."}'
+    )
+    expect(result!.lastAssistantMessage).toBe('Summary line.\n\nDetails paragraph.')
+  })
+
+  it('normalizes \\r\\n to \\n and caps blank-line runs at one in lastAssistantMessage', () => {
+    const result = parseAgentStatusPayload(
+      '{"state":"done","lastAssistantMessage":"a\\r\\nb\\n\\n\\n\\nc"}'
+    )
+    expect(result!.lastAssistantMessage).toBe('a\nb\n\nc')
+  })
+
+  it('folds Unicode line/paragraph separators into \\n and caps blank-line runs in lastAssistantMessage', () => {
+    // Why: U+2028 and U+2029 render as real line breaks under
+    // `whitespace-pre-wrap`. Without folding them to `\n`, a payload with
+    // many separators would bypass the `\n{3,}` → `\n\n` safeguard and let
+    // an agent emit arbitrarily many paragraph breaks. Pin that the
+    // multiline normalizer treats these code points the same way the
+    // single-line normalizer does (strip/convert), so the blank-line cap
+    // applies.
+    const resultLineSep = parseAgentStatusPayload(
+      '{"state":"done","lastAssistantMessage":"a\u2028\u2028\u2028\u2028b"}'
+    )
+    expect(resultLineSep!.lastAssistantMessage).toBe('a\n\nb')
+
+    const resultParaSep = parseAgentStatusPayload(
+      '{"state":"done","lastAssistantMessage":"a\u2029\u2029\u2029\u2029b"}'
+    )
+    expect(resultParaSep!.lastAssistantMessage).toBe('a\n\nb')
+
+    const resultMixed = parseAgentStatusPayload(
+      '{"state":"done","lastAssistantMessage":"a\u2028\u2029\\n\u2028\u2029b"}'
+    )
+    expect(resultMixed!.lastAssistantMessage).toBe('a\n\nb')
+  })
+
+  it('still respects the base prompt cap independent of the new fields', () => {
+    const prompt = 'p'.repeat(300)
+    const result = parseAgentStatusPayload(
+      JSON.stringify({ state: 'working', prompt, toolInput: 'x'.repeat(5) })
+    )
+    expect(result!.prompt).toHaveLength(AGENT_STATUS_MAX_FIELD_LENGTH)
+    expect(result!.toolInput).toBe('xxxxx')
+  })
+
+  it('preserves interrupted=true when state is done', () => {
+    const result = parseAgentStatusPayload('{"state":"done","interrupted":true}')
+    expect(result!.interrupted).toBe(true)
+  })
+
+  it('clears interrupted on non-done states (stale-signal suppression)', () => {
+    for (const state of ['working', 'blocked', 'waiting'] as const) {
+      const result = parseAgentStatusPayload(`{"state":"${state}","interrupted":true}`)
+      expect(result!.interrupted).toBeUndefined()
+    }
+  })
+
+  it('requires strict boolean true for interrupted (rejects truthy non-boolean)', () => {
+    // Why: the parser uses `=== true` to guard against agents that surface a
+    // string or numeric truthy sentinel; only an explicit boolean counts.
+    expect(
+      parseAgentStatusPayload('{"state":"done","interrupted":"true"}')!.interrupted
+    ).toBeUndefined()
+    expect(parseAgentStatusPayload('{"state":"done","interrupted":1}')!.interrupted).toBeUndefined()
+    expect(
+      parseAgentStatusPayload('{"state":"done","interrupted":"yes"}')!.interrupted
+    ).toBeUndefined()
+  })
+
+  it('never leaves a lone high surrogate when truncating mid surrogate-pair', () => {
+    // Why: prepend a single-code-unit character so truncation at the (even)
+    // AGENT_STATUS_MAX_FIELD_LENGTH cap lands ON a high surrogate rather than
+    // between complete pairs. Without this prefix the test would pass even if
+    // the surrogate guard were removed, because the last code unit would
+    // always be a low surrogate.
+    const prompt = `x${'😀'.repeat(AGENT_STATUS_MAX_FIELD_LENGTH)}`
+    const result = parseAgentStatusPayload(JSON.stringify({ state: 'working', prompt }))
+    expect(result!.prompt.length).toBeLessThanOrEqual(AGENT_STATUS_MAX_FIELD_LENGTH)
+    const len = result!.prompt.length
+    const last = result!.prompt.charCodeAt(len - 1)
+    const secondLast = len >= 2 ? result!.prompt.charCodeAt(len - 2) : 0
+    const isLoneHighSurrogate = last >= 0xd800 && last <= 0xdbff
+    expect(isLoneHighSurrogate).toBe(false)
+    // Why: if the last char is a low surrogate, its preceding char must be a
+    // high surrogate — otherwise we'd have a dangling low surrogate, which is
+    // also malformed UTF-16. Pin both directions so the guard is actually load-bearing.
+    if (last >= 0xdc00 && last <= 0xdfff) {
+      expect(secondLast >= 0xd800 && secondLast <= 0xdbff).toBe(true)
+    }
+  })
+
+  it('never leaves a lone high surrogate in lastAssistantMessage truncation', () => {
+    // Why: the multiline normalizer has the same surrogate-pair guard as the
+    // single-line path; cover both so a refactor can't drop the protection
+    // on one side. Emoji count chosen to land truncation inside a pair.
+    const surrogatePairs = Math.floor(AGENT_STATUS_ASSISTANT_MESSAGE_MAX_LENGTH / 2) + 1
+    // Why: prepend a single-code-unit character so truncation at the (even)
+    // cap lands ON a high surrogate rather than between complete pairs. Without
+    // this prefix the test would pass even if the surrogate guard were removed,
+    // because the last code unit would always be a low surrogate.
+    const message = `x${'😀'.repeat(surrogatePairs)}`
+    const result = parseAgentStatusPayload(
+      JSON.stringify({ state: 'done', lastAssistantMessage: message })
+    )
+    expect(result!.lastAssistantMessage!.length).toBeLessThanOrEqual(
+      AGENT_STATUS_ASSISTANT_MESSAGE_MAX_LENGTH
+    )
+    const len = result!.lastAssistantMessage!.length
+    const last = result!.lastAssistantMessage!.charCodeAt(len - 1)
+    const secondLast = len >= 2 ? result!.lastAssistantMessage!.charCodeAt(len - 2) : 0
+    const isLoneHighSurrogate = last >= 0xd800 && last <= 0xdbff
+    expect(isLoneHighSurrogate).toBe(false)
+    // Why: if the last char is a low surrogate, its preceding char must be a
+    // high surrogate — otherwise we'd have a dangling low surrogate, which is
+    // also malformed UTF-16. Pin both directions so the guard is actually load-bearing.
+    if (last >= 0xdc00 && last <= 0xdfff) {
+      expect(secondLast >= 0xd800 && secondLast <= 0xdbff).toBe(true)
+    }
+  })
+})

--- a/src/shared/agent-status-types.test.ts
+++ b/src/shared/agent-status-types.test.ts
@@ -268,6 +268,12 @@ describe('parseAgentStatusPayload', () => {
     const prompt = `x${'😀'.repeat(AGENT_STATUS_MAX_FIELD_LENGTH)}`
     const result = parseAgentStatusPayload(JSON.stringify({ state: 'working', prompt }))
     expect(result!.prompt.length).toBeLessThanOrEqual(AGENT_STATUS_MAX_FIELD_LENGTH)
+    // Why: pins the guard as load-bearing — a future change that over-trims
+    // (e.g., drops more than one trailing code unit by accident) would leave
+    // the non-malformed assertions happy but silently shrink the output.
+    // The surrogate-pair guard may drop at most ONE trailing high surrogate,
+    // so the result must still reach `max - 1`.
+    expect(result!.prompt.length).toBeGreaterThanOrEqual(AGENT_STATUS_MAX_FIELD_LENGTH - 1)
     const len = result!.prompt.length
     const last = result!.prompt.charCodeAt(len - 1)
     const secondLast = len >= 2 ? result!.prompt.charCodeAt(len - 2) : 0
@@ -296,6 +302,14 @@ describe('parseAgentStatusPayload', () => {
     )
     expect(result!.lastAssistantMessage!.length).toBeLessThanOrEqual(
       AGENT_STATUS_ASSISTANT_MESSAGE_MAX_LENGTH
+    )
+    // Why: pins the guard as load-bearing — a future change that over-trims
+    // (e.g., drops more than one trailing code unit by accident) would leave
+    // the non-malformed assertions happy but silently shrink the output.
+    // The surrogate-pair guard may drop at most ONE trailing high surrogate,
+    // so the result must still reach `max - 1`.
+    expect(result!.lastAssistantMessage!.length).toBeGreaterThanOrEqual(
+      AGENT_STATUS_ASSISTANT_MESSAGE_MAX_LENGTH - 1
     )
     const len = result!.lastAssistantMessage!.length
     const last = result!.lastAssistantMessage!.charCodeAt(len - 1)

--- a/src/shared/agent-status-types.ts
+++ b/src/shared/agent-status-types.ts
@@ -12,7 +12,16 @@ export type AgentStatusState = (typeof AGENT_STATUS_STATES)[number]
 export type WellKnownAgentType = 'claude' | 'codex' | 'gemini' | 'opencode' | 'aider' | 'unknown'
 export type AgentType = WellKnownAgentType | (string & {})
 
-/** A snapshot of a previous agent state, used to render activity blocks. */
+/** A snapshot of a previous agent state, used to render activity blocks.
+ *  Why: intentionally narrower than AgentStatusEntry — omits toolName,
+ *  toolInput, and lastAssistantMessage. History rows record what STATE the
+ *  agent was in and what PROMPT was being handled; tool context is
+ *  per-event/per-turn and doesn't meaningfully apply to a historical state
+ *  snapshot. Carrying tool/assistant payloads on every transition would also
+ *  bloat memory on long sessions (capped at AGENT_STATE_HISTORY_MAX entries
+ *  per agent). The current state's tool/assistant fields live on
+ *  AgentStatusEntry only, and activity-block rendering intentionally shows
+ *  state + prompt + duration summaries rather than tool traces. */
 export type AgentStateHistoryEntry = {
   state: AgentStatusState
   prompt: string

--- a/src/shared/agent-status-types.ts
+++ b/src/shared/agent-status-types.ts
@@ -1,0 +1,238 @@
+// ─── Explicit agent status (reported via native agent hooks → IPC) ──────────
+// These types define the normalized status that Orca receives from Claude,
+// Codex, and other explicit integrations. Agent state is hook-reported only —
+// we do not infer status from terminal titles anywhere in the data flow.
+
+export const AGENT_STATUS_STATES = ['working', 'blocked', 'waiting', 'done'] as const
+export type AgentStatusState = (typeof AGENT_STATUS_STATES)[number]
+// Why: agent types are not restricted to a fixed set — new agents appear
+// regularly and users may run custom agents. Any non-empty string is accepted;
+// well-known names are kept as a convenience union for internal code that
+// wants to pattern-match on common agents.
+export type WellKnownAgentType = 'claude' | 'codex' | 'gemini' | 'opencode' | 'aider' | 'unknown'
+export type AgentType = WellKnownAgentType | (string & {})
+
+/** A snapshot of a previous agent state, used to render activity blocks. */
+export type AgentStateHistoryEntry = {
+  state: AgentStatusState
+  prompt: string
+  /** When this state was first reported. */
+  startedAt: number
+  /** True when this `done` was a cancellation (user hit ESC/Ctrl+C). Reported
+   *  by the agent itself — Claude Code sets `is_interrupt: true` on its `Stop`
+   *  hook when the turn ended via interrupt. Always falsy for non-`done`
+   *  states, so retention logic can preserve this signal. */
+  interrupted?: boolean
+}
+
+/** Maximum number of history entries kept per agent to bound memory. */
+export const AGENT_STATE_HISTORY_MAX = 20
+
+export type AgentStatusEntry = {
+  state: AgentStatusState
+  /** The user's most recent prompt, when the hook payload carried one.
+   *  Cached across the turn — subsequent tool-use events in the same turn do
+   *  not include the prompt, so the renderer receives the last known value
+   *  until a new prompt arrives or the pane resets. Empty when unknown. */
+  prompt: string
+  /** Timestamp (ms) of the last status update. */
+  updatedAt: number
+  /** Timestamp (ms) when the current `state` was first reported.
+   *  Why: separate from updatedAt so stateHistory[].startedAt reflects when
+   *  the state was first reported, not the most recent within-state update
+   *  (tool/prompt pings reset updatedAt but not stateStartedAt). */
+  stateStartedAt: number
+  agentType?: AgentType
+  /** Composite key: `${tabId}:${paneId}` — matches the cacheTimerByKey convention. */
+  paneKey: string
+  terminalTitle?: string
+  /** Rolling log of previous states. Each entry records a state the agent was in
+   *  before transitioning to the current one. Capped at AGENT_STATE_HISTORY_MAX. */
+  stateHistory: AgentStateHistoryEntry[]
+  /** Name of the tool the agent is currently using (e.g. "Edit", "Bash"). */
+  toolName?: string
+  /** Short preview of the tool input (e.g. file path, command). */
+  toolInput?: string
+  /** Most recent assistant message preview, when the hook carried one. */
+  lastAssistantMessage?: string
+  /** True when the current `done` state was reached via an interrupt rather
+   *  than a normal turn completion (Claude Code's `is_interrupt: true`).
+   *  Orthogonal to `state`: the agent still finished the turn, but the user
+   *  cancelled it. Undefined while the agent is working or for non-Claude
+   *  agents that don't surface this signal. */
+  interrupted?: boolean
+}
+
+// ─── Agent status payload shape (what hook receivers send via IPC) ──────────
+// Hook integrations only need to provide normalized state fields. The
+// remaining AgentStatusEntry fields (updatedAt, paneKey, etc.) are populated
+// by the renderer when it receives the IPC event.
+
+export type AgentStatusPayload = {
+  state: AgentStatusState
+  prompt?: string
+  agentType?: AgentType
+  toolName?: string
+  toolInput?: string
+  lastAssistantMessage?: string
+  interrupted?: boolean
+}
+
+/**
+ * The result of `parseAgentStatusPayload`: prompt is always normalized to a
+ * string (empty string when the raw payload omits it), so consumers do not
+ * need nullish-coalescing on the field. Tool/assistant fields stay optional so
+ * absence ("no new info") is distinguishable from an explicit empty string.
+ */
+export type ParsedAgentStatusPayload = Omit<AgentStatusPayload, 'prompt'> & { prompt: string }
+
+/** Maximum character length for the prompt field. Truncated on parse. */
+export const AGENT_STATUS_MAX_FIELD_LENGTH = 200
+/** Maximum character length for the toolName field. */
+export const AGENT_STATUS_TOOL_NAME_MAX_LENGTH = 60
+/** Maximum character length for the toolInput preview. */
+export const AGENT_STATUS_TOOL_INPUT_MAX_LENGTH = 160
+/** Maximum character length for the lastAssistantMessage preview.
+ *  Why: assistant messages are the user-facing "what did the agent say" body,
+ *  expanded inline in the dashboard row. 8 KB comfortably fits a multi-
+ *  paragraph summary while still providing a hard upper bound — the hook
+ *  HTTP endpoint already caps bodies at 1 MB, but per-field truncation is a
+ *  second line of defense against a buggy/malicious agent spamming huge
+ *  strings into the cache (which lives per pane with bounded history). */
+export const AGENT_STATUS_ASSISTANT_MESSAGE_MAX_LENGTH = 8000
+/**
+ * Freshness threshold for explicit agent status. Retained past this point so
+ * WorktreeCard's sidebar dot can decay "working" back to "active" when the
+ * hook stream goes silent. Smart-sort + WorktreeCard still read this; the
+ * dashboard + hover only display hook-reported data as-is.
+ */
+export const AGENT_STATUS_STALE_AFTER_MS = 30 * 60 * 1000
+
+// Why: typed as ReadonlySet<string> so .has() accepts any string without
+// requiring `state as AgentStatusState` at the check site. The narrowing
+// cast stays on the return line, where it's actually proven safe.
+const VALID_STATES: ReadonlySet<string> = new Set<string>(AGENT_STATUS_STATES)
+/** Maximum character length for the agentType label. Truncated on parse. */
+export const AGENT_TYPE_MAX_LENGTH = 40
+
+// Why: when truncation lands mid surrogate-pair (emoji / astral chars), the
+// high surrogate would be left dangling and render as the Unicode replacement
+// glyph. Drop the lone high surrogate so the result is always a valid UTF-16
+// sequence. Shared by the single-line and multiline normalizers so the
+// protection can't drift between them.
+function truncatePreservingSurrogates(value: string, maxLength: number): string {
+  if (value.length <= maxLength) {
+    return value
+  }
+  let truncated = value.slice(0, maxLength)
+  const lastCode = truncated.charCodeAt(truncated.length - 1)
+  if (lastCode >= 0xd800 && lastCode <= 0xdbff) {
+    truncated = truncated.slice(0, -1)
+  }
+  return truncated
+}
+
+/** Normalize a status field: trim, collapse to single line, truncate. */
+function normalizeField(value: unknown, maxLength: number = AGENT_STATUS_MAX_FIELD_LENGTH): string {
+  if (typeof value !== 'string') {
+    return ''
+  }
+  // Why: include Unicode line separators (U+2028, U+2029) in the collapse
+  // set. A hook payload like "claude rogue" would otherwise bypass the
+  // single-line invariant that downstream UI and equality checks rely on —
+  // the data comes from an untrusted agent process.
+  const singleLine = value.trim().replace(/[\r\n\u2028\u2029]+/g, ' ')
+  return truncatePreservingSurrogates(singleLine, maxLength)
+}
+
+// Why: assistant messages are a multi-paragraph "what did the agent say"
+// body that the dashboard renders with `whitespace-pre-wrap`. Collapsing
+// newlines here would erase structure the UI is designed to show. Still
+// normalize `\r\n` → `\n` and cap paragraph gaps at one blank line to keep
+// the bound meaningful, but otherwise preserve line breaks.
+function normalizeMultilineField(value: unknown, maxLength: number): string {
+  if (typeof value !== 'string') {
+    return ''
+  }
+  // Why: fold Unicode line/paragraph separators (U+2028, U+2029) into ordinary
+  // `\n` before the blank-line-run cap. These code points render as real line
+  // breaks under `whitespace-pre-wrap`, so leaving them untouched would let a
+  // buggy/malicious agent bypass the `\n{3,}` → `\n\n` safeguard by spamming
+  // arbitrarily many U+2029 paragraph breaks. Matches the single-line
+  // normalizer's treatment of the same code points, keeping the two paths in
+  // sync. Step order preserved: `\r\n` → `\n`, bare `\r` → `\n`,
+  // U+2028/U+2029 → `\n`, then collapse blank-line runs.
+  const normalized = value
+    .trim()
+    .replace(/\r\n/g, '\n')
+    .replace(/\r/g, '\n')
+    .replace(/[\u2028\u2029]/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+  return truncatePreservingSurrogates(normalized, maxLength)
+}
+
+// Why: tool/assistant fields are optional on the entry (absence = "no update
+// for this field"). We only surface them when the caller actually provided a
+// string value so a missing field doesn't overwrite the prior cached state.
+function normalizeOptionalField(value: unknown, maxLength: number): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined
+  }
+  const normalized = normalizeField(value, maxLength)
+  return normalized.length > 0 ? normalized : undefined
+}
+
+function normalizeOptionalMultilineField(value: unknown, maxLength: number): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined
+  }
+  const normalized = normalizeMultilineField(value, maxLength)
+  return normalized.length > 0 ? normalized : undefined
+}
+
+/**
+ * Parse and validate an agent status JSON payload received from explicit
+ * hook integrations or OSC 9999. Returns null if the payload is malformed or
+ * has an invalid state.
+ */
+export function parseAgentStatusPayload(json: string): ParsedAgentStatusPayload | null {
+  try {
+    const parsed = JSON.parse(json)
+    if (typeof parsed !== 'object' || parsed === null) {
+      return null
+    }
+    const obj = parsed as Record<string, unknown>
+    // Why: explicit typeof guard ensures non-string values (e.g. numbers)
+    // are rejected rather than relying on Set.has returning false for
+    // mismatched types.
+    if (typeof obj.state !== 'string') {
+      return null
+    }
+    const state = obj.state
+    if (!VALID_STATES.has(state)) {
+      return null
+    }
+    return {
+      state: state as AgentStatusState,
+      prompt: normalizeField(obj.prompt),
+      // Why: route through normalizeOptionalField so agentType gets the same
+      // trim / collapse-newlines / truncate / empty→undefined treatment as the
+      // other single-line string fields (toolName, toolInput, prompt). Inline
+      // trim+slice left embedded newlines intact, which broke single-line UI
+      // rendering and equality checks when a payload contained e.g.
+      // `agentType: "claude\nrogue"`.
+      agentType: normalizeOptionalField(obj.agentType, AGENT_TYPE_MAX_LENGTH),
+      toolName: normalizeOptionalField(obj.toolName, AGENT_STATUS_TOOL_NAME_MAX_LENGTH),
+      toolInput: normalizeOptionalField(obj.toolInput, AGENT_STATUS_TOOL_INPUT_MAX_LENGTH),
+      lastAssistantMessage: normalizeOptionalMultilineField(
+        obj.lastAssistantMessage,
+        AGENT_STATUS_ASSISTANT_MESSAGE_MAX_LENGTH
+      ),
+      // Why: only meaningful on `done`. Coerce to undefined on other states so
+      // the field doesn't leak stale truth through state transitions.
+      interrupted: obj.interrupted === true && state === 'done' ? true : undefined
+    }
+  } catch {
+    return null
+  }
+}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -11,6 +11,14 @@ import type {
 import { DEFAULT_TERMINAL_FONT_WEIGHT } from './terminal-fonts'
 
 export const SCHEMA_VERSION = 1
+
+// Why: temporary compile-time gate for the agent status dashboard feature.
+// Flip to `true` only when every dashboard PR has landed; the follow-up cleanup
+// PR will delete this constant and every `if (!AGENT_DASHBOARD_ENABLED)` branch
+// entirely, making the feature permanent. Not user-facing — do not read from
+// settings, env, or IPC.
+export const AGENT_DASHBOARD_ENABLED = false
+
 export const ORCA_BROWSER_PARTITION = 'persist:orca-browser'
 // Why: blank browser tabs must start from an inert guest URL that does not
 // navigate the privileged main window to about:blank. Renderer and main both


### PR DESCRIPTION
## Summary

First PR in the agent-status dashboard series. Adds the foundation — no runtime behavior yet:

- **Shared protocol types** (`src/shared/agent-status-types.ts`) — `AgentStatusState`, `AgentStatusEntry`, `AgentStateHistoryEntry`, `ParsedAgentStatusPayload`, and the `parseAgentStatusPayload` parser with length caps and surrogate-pair-safe truncation.
- **Renderer Zustand slice** (`src/renderer/src/store/slices/agent-status.ts`) — keyed by `${tabId}:${paneId}`, tracks `stateStartedAt` separately from `updatedAt`, maintains per-agent history (capped), and bumps a freshness epoch so sort order re-derives at the stale boundary.
- **Feature flag** — everything in this series is gated behind `AGENT_DASHBOARD_ENABLED = false` in `src/shared/constants.ts`. Nothing produces or consumes these entries yet; the main-process hook server and UI wiring land in follow-up PRs.

No UI surface is exposed to users at this stage.

## Test plan

- [x] `pnpm vitest run src/shared/agent-status-types.test.ts` passes (31 tests covering parser, truncation, surrogate-pair guards, line-separator folding)
- [x] `pnpm vitest run src/renderer/src/store/slices/agent-status.test.ts` passes (slice mutations, epoch bookkeeping, prefix-scoped removal)
- [x] `pnpm vitest run src/renderer/src/lib/agent-status.test.ts` passes (existing agent-status helpers incl. `mapAgentStatusStateToVisualStatus`)
- [x] `pnpm run typecheck` passes across all projects
- [x] Confirm `AGENT_DASHBOARD_ENABLED` is still `false` before merging