### PR TITLE
Fix daemon shell-ready wrapper persistence

### DIFF
--- a/src/main/daemon/client.ts
+++ b/src/main/daemon/client.ts
@@ -11,6 +11,7 @@ const REQUEST_TIMEOUT_MS = 30000
 export type DaemonClientOptions = {
   socketPath: string
   tokenPath: string
+  protocolVersion?: number
 }
 
 type PendingRequest = {
@@ -22,6 +23,7 @@ type PendingRequest = {
 export class DaemonClient {
   private socketPath: string
   private tokenPath: string
+  private protocolVersion: number
   private clientId = randomUUID()
 
   private controlSocket: Socket | null = null
@@ -46,6 +48,7 @@ export class DaemonClient {
   constructor(opts: DaemonClientOptions) {
     this.socketPath = opts.socketPath
     this.tokenPath = opts.tokenPath
+    this.protocolVersion = opts.protocolVersion ?? PROTOCOL_VERSION
   }
 
   isConnected(): boolean {
@@ -196,7 +199,7 @@ export class DaemonClient {
     return new Promise((resolve, reject) => {
       const hello: HelloMessage = {
         type: 'hello',
-        version: PROTOCOL_VERSION,
+        version: this.protocolVersion,
         token,
         clientId: this.clientId,
         role

--- a/src/main/daemon/daemon-health.test.ts
+++ b/src/main/daemon/daemon-health.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { createServer, connect, type Server } from 'net'
+import { DaemonServer } from './daemon-server'
+import { getDaemonPidPath } from './daemon-spawner'
+import { healthCheckDaemon, killStaleDaemon } from './daemon-health'
+import type { SubprocessHandle } from './session'
+
+function createMockSubprocess(): SubprocessHandle {
+  return {
+    pid: 55555,
+    write() {},
+    resize() {},
+    kill() {},
+    forceKill() {},
+    signal() {},
+    onData() {},
+    onExit() {}
+  }
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve) => {
+    if (!server.listening) {
+      resolve()
+      return
+    }
+    server.close(() => resolve())
+  })
+}
+
+function canConnect(socketPath: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = connect({ path: socketPath })
+    const timer = setTimeout(() => {
+      socket.destroy()
+      resolve(false)
+    }, 500)
+    socket.on('connect', () => {
+      clearTimeout(timer)
+      socket.destroy()
+      resolve(true)
+    })
+    socket.on('error', () => {
+      clearTimeout(timer)
+      resolve(false)
+    })
+  })
+}
+
+describe('daemon health', () => {
+  let dir: string
+  let socketPath: string
+  let tokenPath: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'daemon-health-test-'))
+    socketPath = join(dir, 'daemon.sock')
+    tokenPath = join(dir, 'daemon.token')
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('passes when a daemon answers ping', async () => {
+    const server = new DaemonServer({
+      socketPath,
+      tokenPath,
+      spawnSubprocess: () => createMockSubprocess()
+    })
+    await server.start()
+
+    try {
+      await expect(healthCheckDaemon(socketPath, tokenPath)).resolves.toBe(true)
+    } finally {
+      await server.shutdown()
+    }
+  })
+
+  it('fails when the token file is missing', async () => {
+    await expect(healthCheckDaemon(socketPath, tokenPath)).resolves.toBe(false)
+  })
+
+  it('does not unlink a live socket when the pid file does not match this daemon', async () => {
+    if (process.platform === 'win32') {
+      return
+    }
+
+    const server = createServer((socket) => socket.end())
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject)
+      server.listen(socketPath, () => {
+        server.off('error', reject)
+        resolve()
+      })
+    })
+    writeFileSync(getDaemonPidPath(dir), String(process.pid), { mode: 0o600 })
+
+    try {
+      await expect(killStaleDaemon(dir, socketPath, tokenPath)).resolves.toBe(false)
+      await expect(canConnect(socketPath)).resolves.toBe(true)
+    } finally {
+      await closeServer(server)
+    }
+  })
+})

--- a/src/main/daemon/daemon-health.ts
+++ b/src/main/daemon/daemon-health.ts
@@ -1,0 +1,230 @@
+import { execFileSync } from 'child_process'
+import { existsSync, readFileSync, unlinkSync } from 'fs'
+import { connect, type Socket } from 'net'
+import { encodeNdjson } from './ndjson'
+import { getDaemonPidPath } from './daemon-spawner'
+import { PROTOCOL_VERSION, type HelloMessage, type HelloResponse } from './types'
+
+const HEALTH_CHECK_TIMEOUT_MS = 3_000
+const KILL_WAIT_MS = 3_000
+const KILL_POLL_MS = 100
+
+function canConnectSocket(socketPath: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    if (process.platform !== 'win32' && !existsSync(socketPath)) {
+      resolve(false)
+      return
+    }
+    const sock = connect({ path: socketPath })
+    const timer = setTimeout(() => {
+      sock.destroy()
+      resolve(false)
+    }, 500)
+    sock.on('connect', () => {
+      clearTimeout(timer)
+      sock.destroy()
+      resolve(true)
+    })
+    sock.on('error', () => {
+      clearTimeout(timer)
+      resolve(false)
+    })
+  })
+}
+
+export function healthCheckDaemon(socketPath: string, tokenPath: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    if (process.platform !== 'win32' && !existsSync(socketPath)) {
+      resolve(false)
+      return
+    }
+
+    let token: string
+    try {
+      token = readFileSync(tokenPath, 'utf8').trim()
+    } catch {
+      resolve(false)
+      return
+    }
+
+    let settled = false
+    let sock: Socket | null = null
+    const settle = (result: boolean): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      clearTimeout(timer)
+      sock?.destroy()
+      resolve(result)
+    }
+    const timer = setTimeout(() => settle(false), HEALTH_CHECK_TIMEOUT_MS)
+
+    sock = connect({ path: socketPath })
+    sock.on('error', () => settle(false))
+    sock.on('connect', () => {
+      const hello: HelloMessage = {
+        type: 'hello',
+        version: PROTOCOL_VERSION,
+        token,
+        clientId: 'health-check',
+        role: 'control'
+      }
+      sock?.write(encodeNdjson(hello))
+    })
+
+    let buffer = ''
+    sock.on('data', (chunk: Buffer) => {
+      if (settled) {
+        return
+      }
+      buffer += chunk.toString()
+      for (;;) {
+        const newlineIdx = buffer.indexOf('\n')
+        if (newlineIdx === -1) {
+          break
+        }
+        const line = buffer.slice(0, newlineIdx)
+        buffer = buffer.slice(newlineIdx + 1)
+        if (!line) {
+          continue
+        }
+
+        let message: Record<string, unknown>
+        try {
+          message = JSON.parse(line) as Record<string, unknown>
+        } catch {
+          settle(false)
+          return
+        }
+
+        if (message.type === 'hello') {
+          if (!(message as HelloResponse).ok) {
+            settle(false)
+            return
+          }
+          sock?.write(encodeNdjson({ id: 'health-1', type: 'ping' }))
+          continue
+        }
+
+        if (message.id === 'health-1') {
+          settle(Boolean(message.ok))
+          return
+        }
+      }
+    })
+  })
+}
+
+function commandLineMatchesDaemon(
+  commandLine: string,
+  socketPath: string,
+  tokenPath: string
+): boolean {
+  return (
+    commandLine.includes('daemon-entry') &&
+    commandLine.includes(socketPath) &&
+    commandLine.includes(tokenPath)
+  )
+}
+
+function isDaemonProcess(pid: number, socketPath: string, tokenPath: string): boolean {
+  try {
+    process.kill(pid, 0)
+  } catch {
+    return false
+  }
+
+  if (process.platform === 'win32') {
+    try {
+      const output = execFileSync(
+        'powershell.exe',
+        [
+          '-NoProfile',
+          '-NonInteractive',
+          '-Command',
+          `(Get-CimInstance Win32_Process -Filter "ProcessId = ${pid}").CommandLine`
+        ],
+        {
+          encoding: 'utf8',
+          timeout: 3_000
+        }
+      )
+      // Why: image names are too broad after PID reuse. Match the daemon entry
+      // plus the exact socket/token args so we only kill the daemon for this
+      // userData protocol endpoint.
+      return commandLineMatchesDaemon(output, socketPath, tokenPath)
+    } catch {
+      return false
+    }
+  }
+
+  try {
+    const cmdline = readFileSync(`/proc/${pid}/cmdline`, 'utf8')
+    return commandLineMatchesDaemon(cmdline, socketPath, tokenPath)
+  } catch {
+    try {
+      const output = execFileSync('ps', ['-p', String(pid), '-o', 'command='], {
+        encoding: 'utf8',
+        timeout: 2_000
+      })
+      return commandLineMatchesDaemon(output, socketPath, tokenPath)
+    } catch {
+      return false
+    }
+  }
+}
+
+export async function killStaleDaemon(
+  runtimeDir: string,
+  socketPath: string,
+  tokenPath: string,
+  protocolVersion = PROTOCOL_VERSION
+): Promise<boolean> {
+  const pidPath = getDaemonPidPath(runtimeDir, protocolVersion)
+  let killedDaemon = false
+  try {
+    const pid = Number.parseInt(readFileSync(pidPath, 'utf8').trim(), 10)
+    if (Number.isFinite(pid) && isDaemonProcess(pid, socketPath, tokenPath)) {
+      process.kill(pid, 'SIGTERM')
+      const deadline = Date.now() + KILL_WAIT_MS
+      let exited = false
+      while (Date.now() < deadline) {
+        try {
+          process.kill(pid, 0)
+        } catch {
+          exited = true
+          break
+        }
+        await new Promise((resolve) => setTimeout(resolve, KILL_POLL_MS))
+      }
+      if (!exited) {
+        try {
+          process.kill(pid, 'SIGKILL')
+          exited = true
+        } catch {
+          // Already dead
+        }
+      }
+      killedDaemon = exited
+    }
+  } catch {
+    // PID file missing or process already dead
+  }
+
+  try {
+    unlinkSync(pidPath)
+  } catch {
+    // Best-effort
+  }
+
+  const socketIsLive = await canConnectSocket(socketPath)
+  if (process.platform !== 'win32' && existsSync(socketPath) && (killedDaemon || !socketIsLive)) {
+    try {
+      unlinkSync(socketPath)
+    } catch {
+      // Best-effort
+    }
+  }
+  return killedDaemon
+}

--- a/src/main/daemon/daemon-init.test.ts
+++ b/src/main/daemon/daemon-init.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { tmpdir } from 'os'
 import { join } from 'path'
-import { mkdtempSync, rmSync, existsSync } from 'fs'
+import { existsSync, mkdirSync, mkdtempSync, rmSync, unlinkSync, writeFileSync } from 'fs'
+import { createServer, type Server, type Socket } from 'net'
 import type { SubprocessHandle } from './session'
 import type * as DaemonInitModule from './daemon-init'
 
@@ -41,6 +42,91 @@ async function importFreshDaemonInit(): Promise<typeof DaemonInitModule> {
   return import('./daemon-init')
 }
 
+function writeNdjson(socket: Socket, message: unknown): void {
+  socket.write(`${JSON.stringify(message)}\n`)
+}
+
+async function startLegacyDaemonStub(
+  socketPath: string,
+  tokenPath: string
+): Promise<{ shutdown: () => Promise<void>; shutdownRequested: () => boolean }> {
+  mkdirSync(join(tokenPath, '..'), { recursive: true })
+  writeFileSync(tokenPath, 'legacy-token', { mode: 0o600 })
+  let shutdownRequested = false
+
+  const server = createServer((socket) => {
+    let buffer = ''
+    let greeted = false
+    socket.on('data', (chunk) => {
+      buffer += chunk.toString()
+      for (;;) {
+        const newlineIdx = buffer.indexOf('\n')
+        if (newlineIdx === -1) {
+          break
+        }
+        const line = buffer.slice(0, newlineIdx)
+        buffer = buffer.slice(newlineIdx + 1)
+        const message = JSON.parse(line)
+        if (!greeted) {
+          greeted = true
+          expect(message).toMatchObject({
+            type: 'hello',
+            version: 1,
+            token: 'legacy-token'
+          })
+          writeNdjson(socket, { type: 'hello', ok: true })
+          continue
+        }
+        if (message.type === 'listSessions') {
+          writeNdjson(socket, {
+            id: message.id,
+            ok: true,
+            payload: { sessions: [{ sessionId: 'legacy', isAlive: true }] }
+          })
+        } else if (message.type === 'shutdown') {
+          shutdownRequested = true
+          writeNdjson(socket, { id: message.id, ok: true, payload: {} })
+          setTimeout(() => {
+            socket.destroy()
+            server.close(() => {
+              if (process.platform !== 'win32') {
+                try {
+                  unlinkSync(socketPath)
+                } catch {
+                  // Best-effort
+                }
+              }
+            })
+          }, 0)
+        }
+      }
+    })
+  })
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(socketPath, () => {
+      server.off('error', reject)
+      resolve()
+    })
+  })
+
+  return {
+    shutdown: () => closeServer(server),
+    shutdownRequested: () => shutdownRequested
+  }
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve) => {
+    if (!server.listening) {
+      resolve()
+      return
+    }
+    server.close(() => resolve())
+  })
+}
+
 describe('cleanupOrphanedDaemon', () => {
   let userDataDir: string
 
@@ -60,6 +146,21 @@ describe('cleanupOrphanedDaemon', () => {
     const result = await cleanupOrphanedDaemon()
     expect(result.cleaned).toBe(false)
     expect(result.killedCount).toBe(0)
+  })
+
+  it('removes stale pid files when no daemon socket exists', async () => {
+    const { cleanupOrphanedDaemon } = await importFreshDaemonInit()
+    const { getDaemonPidPath } = await import('./daemon-spawner')
+
+    const runtimeDir = join(userDataDir, 'daemon')
+    mkdirSync(runtimeDir, { recursive: true })
+    const pidPath = getDaemonPidPath(runtimeDir)
+    writeFileSync(pidPath, '999999', { mode: 0o600 })
+
+    const result = await cleanupOrphanedDaemon()
+
+    expect(result.cleaned).toBe(false)
+    expect(existsSync(pidPath)).toBe(false)
   })
 
   it('kills live sessions and shuts down a running daemon', async () => {
@@ -111,6 +212,66 @@ describe('cleanupOrphanedDaemon', () => {
     // Best-effort teardown of any surviving handles from the spawner side.
     for (const handle of daemonHandles) {
       await handle.shutdown().catch(() => {})
+    }
+  })
+
+  it('cleans up previous protocol daemons after a protocol bump', async () => {
+    const { cleanupOrphanedDaemon } = await importFreshDaemonInit()
+    const { getDaemonPidPath, getDaemonSocketPath, getDaemonTokenPath } =
+      await import('./daemon-spawner')
+
+    const runtimeDir = join(userDataDir, 'daemon')
+    mkdirSync(runtimeDir, { recursive: true })
+    const legacySocketPath = getDaemonSocketPath(runtimeDir, 1)
+    const legacyTokenPath = getDaemonTokenPath(runtimeDir, 1)
+    const legacyPidPath = getDaemonPidPath(runtimeDir, 1)
+    writeFileSync(legacyPidPath, String(process.pid), { mode: 0o600 })
+    const legacyDaemon = await startLegacyDaemonStub(legacySocketPath, legacyTokenPath)
+
+    try {
+      const result = await cleanupOrphanedDaemon()
+
+      expect(result).toEqual({ cleaned: true, killedCount: 1 })
+      expect(legacyDaemon.shutdownRequested()).toBe(true)
+      expect(existsSync(legacyPidPath)).toBe(false)
+    } finally {
+      await legacyDaemon.shutdown()
+    }
+  })
+
+  it('does not report cleaned when fallback cleanup preserves an unowned live socket', async () => {
+    if (process.platform === 'win32') {
+      return
+    }
+
+    const { cleanupOrphanedDaemon } = await importFreshDaemonInit()
+    const { getDaemonPidPath, getDaemonSocketPath, getDaemonTokenPath } =
+      await import('./daemon-spawner')
+
+    const runtimeDir = join(userDataDir, 'daemon')
+    mkdirSync(runtimeDir, { recursive: true })
+    const socketPath = getDaemonSocketPath(runtimeDir)
+    const tokenPath = getDaemonTokenPath(runtimeDir)
+    const server = createServer((socket) => {
+      socket.once('data', () => socket.end('not daemon protocol\n'))
+    })
+    writeFileSync(tokenPath, 'bad-token', { mode: 0o600 })
+    writeFileSync(getDaemonPidPath(runtimeDir), String(process.pid), { mode: 0o600 })
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject)
+      server.listen(socketPath, () => {
+        server.off('error', reject)
+        resolve()
+      })
+    })
+
+    try {
+      const result = await cleanupOrphanedDaemon()
+
+      expect(result).toEqual({ cleaned: false, killedCount: 0 })
+      expect(existsSync(socketPath)).toBe(true)
+    } finally {
+      await closeServer(server)
     }
   })
 })

--- a/src/main/daemon/daemon-init.ts
+++ b/src/main/daemon/daemon-init.ts
@@ -1,17 +1,23 @@
 import { join } from 'path'
 import { app } from 'electron'
-import { mkdirSync, existsSync, unlinkSync } from 'fs'
+import { mkdirSync, existsSync, unlinkSync, writeFileSync } from 'fs'
 import { fork } from 'child_process'
 import { connect } from 'net'
 import {
   DaemonSpawner,
+  getDaemonPidPath,
   getDaemonSocketPath,
   getDaemonTokenPath,
   type DaemonLauncher
 } from './daemon-spawner'
 import { DaemonPtyAdapter } from './daemon-pty-adapter'
 import { DaemonClient } from './client'
-import type { ListSessionsResult } from './types'
+import {
+  PREVIOUS_DAEMON_PROTOCOL_VERSIONS,
+  PROTOCOL_VERSION,
+  type ListSessionsResult
+} from './types'
+import { healthCheckDaemon, killStaleDaemon } from './daemon-health'
 import { setLocalPtyProvider } from '../ipc/pty'
 
 let spawner: DaemonSpawner | null = null
@@ -64,22 +70,25 @@ function probeSocket(socketPath: string): Promise<boolean> {
   })
 }
 
-function createOutOfProcessLauncher(): DaemonLauncher {
+function createOutOfProcessLauncher(runtimeDir: string): DaemonLauncher {
   return async (socketPath, tokenPath) => {
-    const alive = await probeSocket(socketPath)
-    if (alive) {
-      // Why: daemon is already running from a previous app session.
-      // No new process to manage — return a no-op shutdown handle.
-      return { shutdown: async () => {} }
+    const healthy = await healthCheckDaemon(socketPath, tokenPath)
+    if (healthy) {
+      // Why: daemon is already running from a previous app session and
+      // responded to a protocol-level ping. Safe to reuse.
+      return {
+        shutdown: async () => {
+          await cleanupDaemonForProtocol(runtimeDir, PROTOCOL_VERSION)
+        }
+      }
     }
 
-    // Why: stale socket file from a crashed daemon blocks the new server
-    // from binding. Remove it before spawning.
-    if (process.platform !== 'win32' && existsSync(socketPath)) {
-      unlinkSync(socketPath)
-    }
+    // Why: a raw socket can outlive a broken or wedged daemon. Kill by PID
+    // before respawn so the new daemon does not race the stale process.
+    await killStaleDaemon(runtimeDir, socketPath, tokenPath)
 
     const entryPath = getDaemonEntryPath()
+    const userDataPath = app.getPath('userData')
     const child = fork(entryPath, ['--socket', socketPath, '--token', tokenPath], {
       // Why: detached + unref lets the daemon outlive the Electron process.
       // stdio 'ignore' prevents the child from holding the parent's stdout
@@ -90,7 +99,13 @@ function createOutOfProcessLauncher(): DaemonLauncher {
       // Node.js process instead of an Electron renderer/main process. Without
       // it, Electron's GPU/display initialization can interfere with native
       // module operations like node-pty's posix_spawn of the spawn-helper.
-      env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' }
+      env: {
+        ...process.env,
+        ELECTRON_RUN_AS_NODE: '1',
+        // Why: the detached daemon is plain Node and cannot call Electron's
+        // app.getPath(), but shell-ready rcfiles must live outside swept tmp.
+        ORCA_USER_DATA_PATH: userDataPath
+      }
     })
 
     // Wait for the daemon to signal readiness via IPC
@@ -113,6 +128,9 @@ function createOutOfProcessLauncher(): DaemonLauncher {
       child.on('message', (msg: unknown) => {
         if (msg && typeof msg === 'object' && (msg as { type?: string }).type === 'ready') {
           clearTimeout(timer)
+          if (child.pid) {
+            writeFileSync(getDaemonPidPath(runtimeDir), String(child.pid), { mode: 0o600 })
+          }
           // Why: disconnect IPC channel and unref so Electron can exit
           // without waiting for the daemon. The daemon keeps running.
           child.disconnect()
@@ -146,10 +164,11 @@ function createOutOfProcessLauncher(): DaemonLauncher {
 
 export async function initDaemonPtyProvider(): Promise<void> {
   const runtimeDir = getRuntimeDir()
+  await cleanupPreviousProtocolDaemons(runtimeDir)
 
   const newSpawner = new DaemonSpawner({
     runtimeDir,
-    launcher: createOutOfProcessLauncher()
+    launcher: createOutOfProcessLauncher(runtimeDir)
   })
 
   // Why: assign spawner/adapter only after both succeed. If ensureRunning()
@@ -192,6 +211,11 @@ export async function shutdownDaemon(): Promise<void> {
   adapter = null
   await spawner?.shutdown()
   spawner = null
+  try {
+    unlinkSync(getDaemonPidPath(getRuntimeDir()))
+  } catch {
+    // Best-effort
+  }
 }
 
 export type OrphanedDaemonCleanupResult = {
@@ -201,6 +225,88 @@ export type OrphanedDaemonCleanupResult = {
   /** Number of live PTY sessions killed during cleanup. The caller surfaces this
    *  to the user so they know what background work was stopped. */
   killedCount: number
+}
+
+async function cleanupDaemonForProtocol(
+  runtimeDir: string,
+  protocolVersion: number
+): Promise<OrphanedDaemonCleanupResult> {
+  const socketPath = getDaemonSocketPath(runtimeDir, protocolVersion)
+  const tokenPath = getDaemonTokenPath(runtimeDir, protocolVersion)
+  const pidPath = getDaemonPidPath(runtimeDir, protocolVersion)
+
+  const alive = await probeSocket(socketPath)
+  if (!alive) {
+    // Why: still best-effort remove a stale socket file so a future opt-in
+    // launch doesn't hit EADDRINUSE when the daemon tries to bind.
+    if (process.platform !== 'win32' && existsSync(socketPath)) {
+      try {
+        unlinkSync(socketPath)
+      } catch {
+        // Best-effort
+      }
+    }
+    try {
+      unlinkSync(pidPath)
+    } catch {
+      // Best-effort
+    }
+    return { cleaned: false, killedCount: 0 }
+  }
+
+  const client = new DaemonClient({ socketPath, tokenPath, protocolVersion })
+  let killedCount = 0
+  let didRequestShutdown = false
+  let didKillStaleDaemon = false
+  try {
+    await client.ensureConnected()
+    const sessions = await client
+      .request<ListSessionsResult>('listSessions', undefined)
+      .catch(() => ({ sessions: [] }))
+    killedCount = sessions.sessions.filter((s) => s.isAlive).length
+
+    // Why: the daemon exposes a single-shot `shutdown` RPC (daemon-server.ts)
+    // that kills every session and then terminates its own process. Using it
+    // avoids the race between per-session `kill` calls and the daemon exiting.
+    await client.request('shutdown', { killSessions: true }).catch(() => {
+      // Daemon exits immediately after handling the RPC — the socket may close
+      // before the reply round-trips. Treat that as success.
+    })
+    didRequestShutdown = true
+  } catch {
+    // Why: previous-protocol daemons may be wedged or too old to complete the
+    // RPC cleanup path. Fall back to PID cleanup, but daemon-health only
+    // unlinks a live socket after proving it killed the matching process.
+    didKillStaleDaemon = await killStaleDaemon(runtimeDir, socketPath, tokenPath, protocolVersion)
+  } finally {
+    client.disconnect()
+  }
+
+  // Why: after `shutdown`, the daemon unlinks its socket itself — but on some
+  // crash paths the file lingers. Clean up defensively so a later opt-in
+  // relaunch can bind cleanly.
+  if (didRequestShutdown && process.platform !== 'win32' && existsSync(socketPath)) {
+    try {
+      unlinkSync(socketPath)
+    } catch {
+      // Best-effort
+    }
+  }
+  try {
+    unlinkSync(pidPath)
+  } catch {
+    // Best-effort
+  }
+
+  return { cleaned: didRequestShutdown || didKillStaleDaemon, killedCount }
+}
+
+async function cleanupPreviousProtocolDaemons(runtimeDir: string): Promise<void> {
+  for (const protocolVersion of PREVIOUS_DAEMON_PROTOCOL_VERSIONS) {
+    await cleanupDaemonForProtocol(runtimeDir, protocolVersion).catch((error) => {
+      console.warn(`[daemon] Failed to clean up v${protocolVersion} daemon`, error)
+    })
+  }
 }
 
 /** Detect and tear down an orphaned daemon left behind by a previous app
@@ -215,53 +321,14 @@ export type OrphanedDaemonCleanupResult = {
  *  the daemon to shut itself down (which terminates all PTYs). */
 export async function cleanupOrphanedDaemon(): Promise<OrphanedDaemonCleanupResult> {
   const runtimeDir = getRuntimeDir()
-  const socketPath = getDaemonSocketPath(runtimeDir)
-  const tokenPath = getDaemonTokenPath(runtimeDir)
-
-  const alive = await probeSocket(socketPath)
-  if (!alive) {
-    // Why: still best-effort remove a stale socket file so a future opt-in
-    // launch doesn't hit EADDRINUSE when the daemon tries to bind.
-    if (process.platform !== 'win32' && existsSync(socketPath)) {
-      try {
-        unlinkSync(socketPath)
-      } catch {
-        // Best-effort
-      }
-    }
-    return { cleaned: false, killedCount: 0 }
-  }
-
-  const client = new DaemonClient({ socketPath, tokenPath })
+  let cleaned = false
   let killedCount = 0
-  try {
-    await client.ensureConnected()
-    const sessions = await client
-      .request<ListSessionsResult>('listSessions', undefined)
-      .catch(() => ({ sessions: [] }))
-    killedCount = sessions.sessions.filter((s) => s.isAlive).length
 
-    // Why: the daemon exposes a single-shot `shutdown` RPC (daemon-server.ts:263)
-    // that kills every session and then terminates its own process. Using it
-    // avoids the race between per-session `kill` calls and the daemon exiting.
-    await client.request('shutdown', { killSessions: true }).catch(() => {
-      // Daemon exits immediately after handling the RPC — the socket may close
-      // before the reply round-trips. Treat that as success.
-    })
-  } finally {
-    client.disconnect()
+  for (const protocolVersion of [PROTOCOL_VERSION, ...PREVIOUS_DAEMON_PROTOCOL_VERSIONS]) {
+    const result = await cleanupDaemonForProtocol(runtimeDir, protocolVersion)
+    cleaned ||= result.cleaned
+    killedCount += result.killedCount
   }
 
-  // Why: after `shutdown`, the daemon unlinks its socket itself — but on some
-  // crash paths the file lingers. Clean up defensively so a later opt-in
-  // relaunch can bind cleanly.
-  if (process.platform !== 'win32' && existsSync(socketPath)) {
-    try {
-      unlinkSync(socketPath)
-    } catch {
-      // Best-effort
-    }
-  }
-
-  return { cleaned: true, killedCount }
+  return { cleaned, killedCount }
 }

--- a/src/main/daemon/daemon-pty-size.ts
+++ b/src/main/daemon/daemon-pty-size.ts
@@ -1,0 +1,13 @@
+const DEFAULT_COLS = 80
+const DEFAULT_ROWS = 24
+
+export function isValidPtySize(cols: number, rows: number): boolean {
+  return Number.isFinite(cols) && Number.isFinite(rows) && cols >= 1 && rows >= 1
+}
+
+export function normalizePtySize(cols: number, rows: number): { cols: number; rows: number } {
+  if (isValidPtySize(cols, rows)) {
+    return { cols, rows }
+  }
+  return { cols: DEFAULT_COLS, rows: DEFAULT_ROWS }
+}

--- a/src/main/daemon/daemon-server.test.ts
+++ b/src/main/daemon/daemon-server.test.ts
@@ -112,6 +112,15 @@ describe('DaemonServer', () => {
       expect(result.sessions).toHaveLength(1)
     })
 
+    it('handles ping health checks', async () => {
+      await startServer()
+      const c = await connectClient()
+
+      const result = await c.request<{ pong: boolean }>('ping', undefined)
+
+      expect(result).toEqual({ pong: true })
+    })
+
     it('handles write (fire-and-forget)', async () => {
       await startServer()
       const c = await connectClient()

--- a/src/main/daemon/daemon-server.ts
+++ b/src/main/daemon/daemon-server.ts
@@ -260,6 +260,9 @@ export class DaemonServer {
       case 'listSessions':
         return { sessions: this.host.listSessions() }
 
+      case 'ping':
+        return { pong: true }
+
       case 'shutdown':
         if (request.payload.killSessions) {
           this.host.dispose()

--- a/src/main/daemon/daemon-spawner.test.ts
+++ b/src/main/daemon/daemon-spawner.test.ts
@@ -2,7 +2,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { mkdtempSync, rmSync } from 'fs'
-import { DaemonSpawner, getDaemonSocketPath, getDaemonTokenPath } from './daemon-spawner'
+import {
+  DaemonSpawner,
+  getDaemonPidPath,
+  getDaemonSocketPath,
+  getDaemonTokenPath
+} from './daemon-spawner'
 import { startDaemon, type DaemonHandle } from './daemon-main'
 import { DaemonClient } from './client'
 import type { SubprocessHandle } from './session'
@@ -66,6 +71,7 @@ describe('DaemonSpawner', () => {
     it('uses protocol-scoped socket and token paths', () => {
       const socketPath = getDaemonSocketPath(dir)
       const tokenPath = getDaemonTokenPath(dir)
+      const pidPath = getDaemonPidPath(dir)
 
       if (process.platform === 'win32') {
         expect(socketPath).toContain(`orca-terminal-host-v${PROTOCOL_VERSION}`)
@@ -73,6 +79,7 @@ describe('DaemonSpawner', () => {
         expect(socketPath).toBe(join(dir, `daemon-v${PROTOCOL_VERSION}.sock`))
       }
       expect(tokenPath).toBe(join(dir, `daemon-v${PROTOCOL_VERSION}.token`))
+      expect(pidPath).toBe(join(dir, `daemon-v${PROTOCOL_VERSION}.pid`))
     })
 
     it('starts daemon and returns connection info', async () => {

--- a/src/main/daemon/daemon-spawner.ts
+++ b/src/main/daemon/daemon-spawner.ts
@@ -59,17 +59,24 @@ export class DaemonSpawner {
   }
 }
 
-export function getDaemonSocketPath(runtimeDir: string): string {
+export function getDaemonSocketPath(
+  runtimeDir: string,
+  protocolVersion = PROTOCOL_VERSION
+): string {
   // Why: Windows IPC servers use named pipes rather than filesystem socket
   // files. Include the protocol version in the endpoint name so a daemon from
   // an older build is never reused after a breaking protocol change.
   if (process.platform === 'win32') {
     const suffix = createHash('sha256').update(runtimeDir).digest('hex').slice(0, 12)
-    return `\\\\?\\pipe\\orca-terminal-host-v${PROTOCOL_VERSION}-${suffix}`
+    return `\\\\?\\pipe\\orca-terminal-host-v${protocolVersion}-${suffix}`
   }
-  return join(runtimeDir, `daemon-v${PROTOCOL_VERSION}.sock`)
+  return join(runtimeDir, `daemon-v${protocolVersion}.sock`)
 }
 
-export function getDaemonTokenPath(runtimeDir: string): string {
-  return join(runtimeDir, `daemon-v${PROTOCOL_VERSION}.token`)
+export function getDaemonTokenPath(runtimeDir: string, protocolVersion = PROTOCOL_VERSION): string {
+  return join(runtimeDir, `daemon-v${protocolVersion}.token`)
+}
+
+export function getDaemonPidPath(runtimeDir: string, protocolVersion = PROTOCOL_VERSION): string {
+  return join(runtimeDir, `daemon-v${protocolVersion}.pid`)
 }

--- a/src/main/daemon/pty-subprocess.test.ts
+++ b/src/main/daemon/pty-subprocess.test.ts
@@ -90,6 +90,31 @@ describe('createPtySubprocess', () => {
     expect(proc.resize).toHaveBeenCalledWith(120, 40)
   })
 
+  it('normalizes invalid initial spawn dimensions', () => {
+    const proc = mockPtyProcess()
+    spawnMock.mockReturnValue(proc)
+
+    createPtySubprocess({ sessionId: 'test', cols: 0, rows: -1 })
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(Array),
+      expect.objectContaining({ cols: 80, rows: 24 })
+    )
+  })
+
+  it('ignores transient zero-size resize calls', () => {
+    const proc = mockPtyProcess()
+    spawnMock.mockReturnValue(proc)
+
+    const handle = createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
+    handle.resize(0, 0)
+    handle.write('still alive\n')
+
+    expect(proc.resize).not.toHaveBeenCalled()
+    expect(proc.write).toHaveBeenCalledWith('still alive\n')
+  })
+
   it('forwards kill calls', () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -1,6 +1,7 @@
 import * as pty from 'node-pty'
 import type { SubprocessHandle } from './session'
 import { getShellReadyLaunchConfig, resolvePtyShellPath } from './shell-ready'
+import { isValidPtySize, normalizePtySize } from './daemon-pty-size'
 import { ensureNodePtySpawnHelperExecutable } from '../providers/local-pty-utils'
 
 export type PtySubprocessOptions = {
@@ -30,6 +31,7 @@ function getDefaultCwd(): string {
 }
 
 export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandle {
+  const size = normalizePtySize(opts.cols, opts.rows)
   const env: Record<string, string> = {
     ...process.env,
     ...opts.env,
@@ -64,8 +66,8 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
 
   const proc = pty.spawn(shellPath, shellArgs, {
     name: 'xterm-256color',
-    cols: opts.cols,
-    rows: opts.rows,
+    cols: size.cols,
+    rows: size.rows,
     cwd: opts.cwd || getDefaultCwd(),
     env
   })
@@ -100,6 +102,9 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
     },
     resize: (cols, rows) => {
       if (dead) {
+        return
+      }
+      if (!isValidPtySize(cols, rows)) {
         return
       }
       try {

--- a/src/main/daemon/session.ts
+++ b/src/main/daemon/session.ts
@@ -1,4 +1,5 @@
 import { HeadlessEmulator } from './headless-emulator'
+import { isValidPtySize, normalizePtySize } from './daemon-pty-size'
 import type { SessionState, ShellReadyState, TerminalSnapshot } from './types'
 
 const SHELL_READY_TIMEOUT_MS = 15_000
@@ -49,9 +50,10 @@ export class Session {
   constructor(opts: SessionOptions) {
     this.sessionId = opts.sessionId
     this.subprocess = opts.subprocess
+    const size = normalizePtySize(opts.cols, opts.rows)
     this.emulator = new HeadlessEmulator({
-      cols: opts.cols,
-      rows: opts.rows,
+      cols: size.cols,
+      rows: size.rows,
       scrollback: opts.scrollback,
       // Why: xterm.js generates query responses (DA1, DSR) asynchronously.
       // If the subprocess has already exited, writing to it would hit a dead
@@ -116,6 +118,9 @@ export class Session {
 
   resize(cols: number, rows: number): void {
     if (this._state === 'exited' || this._disposed) {
+      return
+    }
+    if (!isValidPtySize(cols, rows)) {
       return
     }
     this.emulator.resize(cols, rows)

--- a/src/main/daemon/shell-ready.test.ts
+++ b/src/main/daemon/shell-ready.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { existsSync, mkdtempSync, rmSync } from 'fs'
+import type * as ShellReadyModule from './shell-ready'
+
+async function importFreshShellReady(): Promise<typeof ShellReadyModule> {
+  vi.resetModules()
+  return import('./shell-ready')
+}
+
+const describePosix = process.platform === 'win32' ? describe.skip : describe
+
+describePosix('daemon shell-ready launch config', () => {
+  let previousUserDataPath: string | undefined
+  let userDataPath: string
+
+  beforeEach(() => {
+    previousUserDataPath = process.env.ORCA_USER_DATA_PATH
+    userDataPath = mkdtempSync(join(tmpdir(), 'daemon-shell-ready-test-'))
+    process.env.ORCA_USER_DATA_PATH = userDataPath
+  })
+
+  afterEach(() => {
+    if (previousUserDataPath === undefined) {
+      delete process.env.ORCA_USER_DATA_PATH
+    } else {
+      process.env.ORCA_USER_DATA_PATH = previousUserDataPath
+    }
+    rmSync(userDataPath, { recursive: true, force: true })
+    vi.restoreAllMocks()
+  })
+
+  it('stores wrapper rcfiles under durable userData instead of tmp', async () => {
+    const { getShellReadyLaunchConfig } = await importFreshShellReady()
+
+    const config = getShellReadyLaunchConfig('/bin/bash')
+    const rcfile = join(userDataPath, 'shell-ready', 'bash', 'rcfile')
+
+    expect(config.args).toEqual(['--rcfile', rcfile])
+    expect(existsSync(rcfile)).toBe(true)
+  })
+
+  it('rewrites wrappers when a long-lived daemon finds a missing rcfile', async () => {
+    const { getShellReadyLaunchConfig } = await importFreshShellReady()
+    const rcfile = join(userDataPath, 'shell-ready', 'bash', 'rcfile')
+
+    getShellReadyLaunchConfig('/bin/bash')
+    rmSync(rcfile)
+
+    expect(existsSync(rcfile)).toBe(false)
+    getShellReadyLaunchConfig('/bin/bash')
+    expect(existsSync(rcfile)).toBe(true)
+  })
+
+  it('points zsh launch config at durable wrapper files', async () => {
+    const { getShellReadyLaunchConfig } = await importFreshShellReady()
+
+    const config = getShellReadyLaunchConfig('/bin/zsh')
+
+    expect(config.args).toEqual(['-l'])
+    expect(config.env.ZDOTDIR).toBe(join(userDataPath, 'shell-ready', 'zsh'))
+    expect(existsSync(join(userDataPath, 'shell-ready', 'zsh', '.zshenv'))).toBe(true)
+  })
+})

--- a/src/main/daemon/shell-ready.ts
+++ b/src/main/daemon/shell-ready.ts
@@ -1,8 +1,8 @@
 import { tmpdir } from 'os'
-import { basename, join } from 'path'
-import { chmodSync, mkdirSync, writeFileSync } from 'fs'
+import { basename, dirname, join } from 'path'
+import { chmodSync, existsSync, mkdirSync, writeFileSync } from 'fs'
 
-const SHELL_READY_WRAPPER_ROOT = join(tmpdir(), 'orca-shell-ready')
+const ORCA_USER_DATA_PATH_ENV = 'ORCA_USER_DATA_PATH'
 const SHELL_READY_MARKER = '\\033]777;orca-shell-ready\\007'
 
 let didEnsureShellReadyWrappers = false
@@ -11,14 +11,39 @@ function quotePosixSingle(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`
 }
 
+function getShellReadyWrapperRoot(): string {
+  const userDataPath = process.env[ORCA_USER_DATA_PATH_ENV]
+  // Why: older/test launchers may not seed ORCA_USER_DATA_PATH. Keep a
+  // fallback so daemon startup does not fail before the parent can be fixed.
+  return join(userDataPath || tmpdir(), userDataPath ? 'shell-ready' : 'orca-shell-ready')
+}
+
+function getRequiredShellReadyWrapperPaths(root = getShellReadyWrapperRoot()): string[] {
+  return [
+    join(root, 'zsh', '.zshenv'),
+    join(root, 'zsh', '.zprofile'),
+    join(root, 'zsh', '.zshrc'),
+    join(root, 'zsh', '.zlogin'),
+    join(root, 'bash', 'rcfile')
+  ]
+}
+
+function shellReadyWrappersExist(): boolean {
+  return getRequiredShellReadyWrapperPaths().every((path) => existsSync(path))
+}
+
 function ensureShellReadyWrappers(): void {
-  if (didEnsureShellReadyWrappers || process.platform === 'win32') {
+  if (process.platform === 'win32') {
+    return
+  }
+  if (didEnsureShellReadyWrappers && shellReadyWrappersExist()) {
     return
   }
   didEnsureShellReadyWrappers = true
 
-  const zshDir = join(SHELL_READY_WRAPPER_ROOT, 'zsh')
-  const bashDir = join(SHELL_READY_WRAPPER_ROOT, 'bash')
+  const root = getShellReadyWrapperRoot()
+  const zshDir = join(root, 'zsh')
+  const bashDir = join(root, 'bash')
 
   const zshEnv = `# Orca daemon zsh shell-ready wrapper
 export ORCA_ORIG_ZDOTDIR="\${ORCA_ORIG_ZDOTDIR:-$HOME}"
@@ -78,7 +103,7 @@ fi
   ] as const
 
   for (const [path, content] of files) {
-    mkdirSync(path.slice(0, path.lastIndexOf('/')), { recursive: true })
+    mkdirSync(dirname(path), { recursive: true })
     writeFileSync(path, content, 'utf8')
     chmodSync(path, 0o644)
   }
@@ -108,11 +133,12 @@ export function getShellReadyLaunchConfig(shellPath: string): {
 
   if (shellName === 'zsh') {
     ensureShellReadyWrappers()
+    const root = getShellReadyWrapperRoot()
     return {
       args: ['-l'],
       env: {
         ORCA_ORIG_ZDOTDIR: process.env.ZDOTDIR || process.env.HOME || '',
-        ZDOTDIR: join(SHELL_READY_WRAPPER_ROOT, 'zsh')
+        ZDOTDIR: join(root, 'zsh')
       },
       supportsReadyMarker: true
     }
@@ -120,8 +146,9 @@ export function getShellReadyLaunchConfig(shellPath: string): {
 
   if (shellName === 'bash') {
     ensureShellReadyWrappers()
+    const root = getShellReadyWrapperRoot()
     return {
-      args: ['--rcfile', join(SHELL_READY_WRAPPER_ROOT, 'bash', 'rcfile')],
+      args: ['--rcfile', join(root, 'bash', 'rcfile')],
       env: {},
       supportsReadyMarker: true
     }

--- a/src/main/daemon/terminal-host.test.ts
+++ b/src/main/daemon/terminal-host.test.ts
@@ -171,6 +171,18 @@ describe('TerminalHost', () => {
   })
 
   describe('resize', () => {
+    it('normalizes invalid initial dimensions before spawning a session', async () => {
+      await host.createOrAttach({
+        sessionId: 'session-1',
+        cols: 0,
+        rows: -1,
+        streamClient: { onData: vi.fn(), onExit: vi.fn() }
+      })
+
+      expect(spawnFn).toHaveBeenCalledWith(expect.objectContaining({ cols: 80, rows: 24 }))
+      expect(host.listSessions()[0]).toMatchObject({ cols: 80, rows: 24 })
+    })
+
     it('forwards resize to the session', async () => {
       await host.createOrAttach({
         sessionId: 'session-1',
@@ -181,6 +193,20 @@ describe('TerminalHost', () => {
 
       host.resize('session-1', 120, 40)
       expect(lastSubprocess.resize).toHaveBeenCalledWith(120, 40)
+    })
+
+    it('ignores transient zero-size resize events', async () => {
+      await host.createOrAttach({
+        sessionId: 'session-1',
+        cols: 80,
+        rows: 24,
+        streamClient: { onData: vi.fn(), onExit: vi.fn() }
+      })
+
+      host.resize('session-1', 0, 0)
+
+      expect(lastSubprocess.resize).not.toHaveBeenCalled()
+      expect(host.listSessions()[0]).toMatchObject({ cols: 80, rows: 24 })
     })
   })
 

--- a/src/main/daemon/terminal-host.ts
+++ b/src/main/daemon/terminal-host.ts
@@ -1,4 +1,5 @@
 import { Session, type SubprocessHandle } from './session'
+import { normalizePtySize } from './daemon-pty-size'
 import type { SessionInfo, TerminalSnapshot, ShellReadyState } from './types'
 import { SessionNotFoundError } from './types'
 
@@ -72,11 +73,12 @@ export class TerminalHost {
 
     // Clear tombstone if re-creating a killed session
     this.killedTombstones.delete(opts.sessionId)
+    const size = normalizePtySize(opts.cols, opts.rows)
 
     const subprocess = this.spawnSubprocess({
       sessionId: opts.sessionId,
-      cols: opts.cols,
-      rows: opts.rows,
+      cols: size.cols,
+      rows: size.rows,
       cwd: opts.cwd,
       env: opts.env,
       command: opts.command
@@ -84,8 +86,8 @@ export class TerminalHost {
 
     const session = new Session({
       sessionId: opts.sessionId,
-      cols: opts.cols,
-      rows: opts.rows,
+      cols: size.cols,
+      rows: size.rows,
       subprocess,
       shellReadySupported: opts.shellReadySupported ?? false
     })

--- a/src/main/daemon/types.ts
+++ b/src/main/daemon/types.ts
@@ -1,5 +1,8 @@
 // ─── Protocol Version ────────────────────────────────────────────────
-export const PROTOCOL_VERSION = 1
+// Why: v1 daemons can survive app updates and keep using tmp-backed
+// shell-ready rcfiles. v2 forces a fresh daemon with durable wrapper paths.
+export const PROTOCOL_VERSION = 2
+export const PREVIOUS_DAEMON_PROTOCOL_VERSIONS = [1] as const
 
 // ─── Session State Machine ──────────────────────────────────────────
 export type SessionState = 'created' | 'spawning' | 'running' | 'exiting' | 'exited'
@@ -141,6 +144,11 @@ export type ShutdownRequest = {
   }
 }
 
+export type PingRequest = {
+  id: string
+  type: 'ping'
+}
+
 export type DaemonRequest =
   | CreateOrAttachRequest
   | CancelCreateOrAttachRequest
@@ -153,6 +161,7 @@ export type DaemonRequest =
   | GetCwdRequest
   | ClearScrollbackRequest
   | ShutdownRequest
+  | PingRequest
 
 // ─── RPC Responses (Daemon → Client, on control socket) ────────────
 


### PR DESCRIPTION
## Problem
Persistent terminal daemon shell-ready wrappers were written under temp storage and only generated once per daemon lifetime. On macOS, temp cleanup could delete those rcfiles while a detached daemon survived app restarts, so new startup-command PTYs launched with missing bash/zsh wrapper files. That skipped user shell init, prevented the shell-ready marker from firing, and caused startup-command terminals to wait for timeout with a bare prompt.

A related resize path could also produce zombie daemon terminals. During pane split/drag/resize, the renderer can transiently compute an invalid PTY size such as 0 rows or columns. That resize was forwarded into the daemon and node-pty; if node-pty rejected it, the subprocess wrapper could mark the PTY dead while the daemon session still looked alive.

Daemon reuse also relied on a raw socket probe. A stale or wedged daemon could accept a TCP connection but fail protocol requests, causing Orca to reuse a broken background daemon.

Bumping the daemon protocol to force a fresh daemon also needed migration handling; otherwise older v1 daemons could be left running invisibly after the app moved to v2 endpoints.

## Solution
Store daemon shell-ready wrappers under durable app userData via ORCA_USER_DATA_PATH, and verify the wrapper files exist every time shell-ready launch config is requested so long-lived daemons regenerate missing files.

Pass the Electron userData path into the detached daemon, bump the daemon protocol to v2, and explicitly clean up previous-protocol daemons so old v1 sessions are not orphaned.

Guard daemon resize handling against non-finite or non-positive PTY dimensions before they reach the headless emulator or node-pty, so transient resize measurements do not kill or zombie a session.

Fold in the still-valid part of PR 767: add a daemon ping RPC, PID path, and current-version protocol-level health check before daemon reuse. If the health check fails, Orca kills the stale daemon by PID and respawns instead of trusting the socket probe.

## Verification
- pnpm test src/main/daemon
- pnpm run tc:node