### PR TITLE
fix(linear): stop keychain prompt from appearing during app launch

### DIFF
--- a/src/main/ipc/preflight.test.ts
+++ b/src/main/ipc/preflight.test.ts
@@ -30,10 +30,6 @@ vi.mock('../startup/hydrate-shell-path', () => ({
   mergePathSegments: mergePathSegmentsMock
 }))
 
-vi.mock('../linear/client', () => ({
-  loadToken: vi.fn().mockReturnValue(null)
-}))
-
 import {
   _resetPreflightCache,
   detectInstalledAgents,
@@ -72,8 +68,7 @@ describe('preflight', () => {
 
     expect(status).toEqual({
       git: { installed: true },
-      gh: { installed: true, authenticated: true },
-      linear: { connected: false }
+      gh: { installed: true, authenticated: true }
     })
     expect(execFileAsyncMock).toHaveBeenNthCalledWith(3, 'gh', ['auth', 'status'], {
       encoding: 'utf-8'
@@ -131,8 +126,7 @@ describe('preflight', () => {
 
     expect(status).toEqual({
       git: { installed: true },
-      gh: { installed: true, authenticated: true },
-      linear: { connected: false }
+      gh: { installed: true, authenticated: true }
     })
   })
 
@@ -152,13 +146,11 @@ describe('preflight', () => {
 
     expect(firstStatus).toEqual({
       git: { installed: true },
-      gh: { installed: true, authenticated: false },
-      linear: { connected: false }
+      gh: { installed: true, authenticated: false }
     })
     expect(refreshedStatus).toEqual({
       git: { installed: true },
-      gh: { installed: true, authenticated: true },
-      linear: { connected: false }
+      gh: { installed: true, authenticated: true }
     })
   })
 

--- a/src/main/ipc/preflight.ts
+++ b/src/main/ipc/preflight.ts
@@ -4,7 +4,6 @@ import { promisify } from 'util'
 import path from 'path'
 import { TUI_AGENT_CONFIG } from '../../shared/tui-agent-config'
 import { hydrateShellPath, mergePathSegments } from '../startup/hydrate-shell-path'
-import { loadToken } from '../linear/client'
 import { getActiveMultiplexer } from './ssh'
 
 const execFileAsync = promisify(execFile)
@@ -12,7 +11,6 @@ const execFileAsync = promisify(execFile)
 export type PreflightStatus = {
   git: { installed: boolean }
   gh: { installed: boolean; authenticated: boolean }
-  linear: { connected: boolean }
 }
 
 // Why: cache the result so repeated Landing mounts don't re-spawn processes.
@@ -121,16 +119,9 @@ export async function runPreflightCheck(force = false): Promise<PreflightStatus>
 
   const ghAuthenticated = ghInstalled ? await isGhAuthenticated() : false
 
-  // Why: the Linear preflight check reads the encrypted token file rather
-  // than calling the Linear API. Actual API validation happens lazily on
-  // first use or on linear:connect — this avoids a network round-trip on
-  // every preflight check.
-  const linearConnected = loadToken() !== null
-
   cached = {
     git: { installed: gitInstalled },
-    gh: { installed: ghInstalled, authenticated: ghAuthenticated },
-    linear: { connected: linearConnected }
+    gh: { installed: ghInstalled, authenticated: ghAuthenticated }
   }
 
   return cached

--- a/src/preload/api-types.d.ts
+++ b/src/preload/api-types.d.ts
@@ -173,7 +173,6 @@ export type DetectedBrowserInfo = {
 export type PreflightStatus = {
   git: { installed: boolean }
   gh: { installed: boolean; authenticated: boolean }
-  linear: { connected: boolean }
 }
 
 export type RefreshAgentsResult = {


### PR DESCRIPTION
## Summary
- Removed eager `loadToken()` call from the preflight check, which triggered `safeStorage.decryptString()` and caused macOS to prompt for keychain access on app launch
- The `linear.connected` field in `PreflightStatus` was unused — `getPreflightIssues()` only checks `git` and `gh`
- Linear connection status is already checked lazily via `checkLinearConnection()` when the user opens Settings > Integrations or the Tasks page

## Test plan
- [x] `preflight.test.ts` passes (10/10)
- [x] TypeScript compiles cleanly
- [ ] Launch app with a stored Linear API key — no keychain prompt should appear
- [ ] Open Settings > Integrations — Linear connection status should still display correctly
- [ ] Open Tasks page — Linear issues should still load when connected