### PR TITLE
feat(tabs): slimmer tabs with window-drag strip on top

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -961,26 +961,7 @@ function App(): React.JSX.Element {
               filesystem watchers + cached directory trees survive across
               open/close toggles. Unmount on the tasks view since that
               surface is intentionally distraction-free. */}
-          {showRightSidebarControls ? (
-            workspaceActive ? (
-              /* Why: in workspace view the right sidebar must start at the
-                 tab row, not the window edge, so the 8px drag strip that
-                 runs across the top of the center column continues uninterrupted
-                 over the right sidebar. Wrapping adds a matching 8px drag
-                 surface above and shrinks the sidebar to fill the remainder. */
-              <div className="flex min-h-0 flex-col shrink-0">
-                <div
-                  className="h-2 shrink-0 bg-card"
-                  style={{ WebkitAppRegion: 'drag' } as React.CSSProperties}
-                />
-                <div className="flex min-h-0 flex-1">
-                  <RightSidebar />
-                </div>
-              </div>
-            ) : (
-              <RightSidebar />
-            )
-          ) : null}
+          {showRightSidebarControls ? <RightSidebar /> : null}
         </div>
         <StatusBar />
         {/* Why: NewWorkspaceComposerCard renders Radix <Tooltip>s that crash

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -928,11 +928,12 @@ function App(): React.JSX.Element {
           <div className="relative flex flex-1 min-w-0 min-h-0 overflow-hidden">
             {/* Why: right sidebar toggle floats at the top-right of the center
                 column so it's always accessible whether the right sidebar is
-                open or closed. Its height matches the 42px workspace strip
-                used by the sidebar and tab rows. */}
+                open or closed. Offset by the 8px drag strip so it aligns with
+                the tab row's 34px band instead of overlapping the draggable
+                window surface above. */}
             {workspaceActive && !rightSidebarOpen && (
               <div
-                className="absolute top-0 right-0 z-10 flex items-center h-[42px]"
+                className="absolute top-2 right-0 z-10 flex items-center h-[34px]"
                 style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
               >
                 {rightSidebarToggle}
@@ -960,7 +961,26 @@ function App(): React.JSX.Element {
               filesystem watchers + cached directory trees survive across
               open/close toggles. Unmount on the tasks view since that
               surface is intentionally distraction-free. */}
-          {showRightSidebarControls ? <RightSidebar /> : null}
+          {showRightSidebarControls ? (
+            workspaceActive ? (
+              /* Why: in workspace view the right sidebar must start at the
+                 tab row, not the window edge, so the 8px drag strip that
+                 runs across the top of the center column continues uninterrupted
+                 over the right sidebar. Wrapping adds a matching 8px drag
+                 surface above and shrinks the sidebar to fill the remainder. */
+              <div className="flex min-h-0 flex-col shrink-0">
+                <div
+                  className="h-2 shrink-0 bg-card"
+                  style={{ WebkitAppRegion: 'drag' } as React.CSSProperties}
+                />
+                <div className="flex min-h-0 flex-1">
+                  <RightSidebar />
+                </div>
+              </div>
+            ) : (
+              <RightSidebar />
+            )
+          ) : null}
         </div>
         <StatusBar />
         {/* Why: NewWorkspaceComposerCard renders Radix <Tooltip>s that crash

--- a/src/renderer/src/components/right-sidebar/index.tsx
+++ b/src/renderer/src/components/right-sidebar/index.tsx
@@ -197,7 +197,12 @@ function RightSidebarInner(): React.JSX.Element {
       )}
     >
       {/* Panel content area */}
-      <div className="flex flex-col flex-1 min-w-0 bg-sidebar overflow-hidden">
+      <div
+        className="flex flex-col flex-1 min-w-0 bg-sidebar overflow-hidden"
+        style={{
+          borderLeft: rightSidebarOpen ? '1px solid var(--sidebar-border)' : 'none'
+        }}
+      >
         {activityBarPosition === 'top' ? (
           /* ── Top activity bar: horizontal icon row ── */
           <ContextMenu>

--- a/src/renderer/src/components/right-sidebar/index.tsx
+++ b/src/renderer/src/components/right-sidebar/index.tsx
@@ -197,12 +197,7 @@ function RightSidebarInner(): React.JSX.Element {
       )}
     >
       {/* Panel content area */}
-      <div
-        className="flex flex-col flex-1 min-w-0 bg-sidebar overflow-hidden"
-        style={{
-          borderLeft: rightSidebarOpen ? '1px solid var(--sidebar-border)' : 'none'
-        }}
-      >
+      <div className="flex flex-col flex-1 min-w-0 bg-sidebar overflow-hidden">
         {activityBarPosition === 'top' ? (
           /* ── Top activity bar: horizontal icon row ── */
           <ContextMenu>

--- a/src/renderer/src/components/tab-bar/BrowserTab.tsx
+++ b/src/renderer/src/components/tab-bar/BrowserTab.tsx
@@ -111,10 +111,8 @@ export default function BrowserTab({
           ref={setNodeRef}
           {...attributes}
           {...listeners}
-          className={`group relative flex items-center h-full px-3 text-sm cursor-pointer select-none shrink-0 border-r border-border ${getDropIndicatorClasses(dropIndicator ?? null)} ${
-            isActive
-              ? 'bg-accent text-foreground border-b-transparent'
-              : 'bg-card text-muted-foreground hover:text-foreground hover:bg-accent/50'
+          className={`group relative flex items-center h-full px-1.5 text-xs cursor-pointer select-none shrink-0 border-t ${hasTabsToRight ? 'border-r' : ''} border-border bg-card ${getDropIndicatorClasses(dropIndicator ?? null)} ${
+            isActive ? 'text-foreground' : 'text-muted-foreground hover:text-foreground'
           }`}
           onPointerDown={(e) => {
             if (e.button !== 0) {
@@ -138,11 +136,11 @@ export default function BrowserTab({
         >
           {isActive && <span className={ACTIVE_TAB_INDICATOR_CLASSES} aria-hidden />}
           <Globe
-            className={`w-3.5 h-3.5 mr-1.5 shrink-0 ${isActive ? 'text-foreground' : 'text-muted-foreground'}`}
+            className={`w-3 h-3 mr-1 shrink-0 ${isActive ? 'text-foreground' : 'text-muted-foreground'}`}
           />
-          <span className="truncate max-w-[180px] mr-1.5">{getBrowserTabLabel(tab)}</span>
+          <span className="truncate max-w-[100px] mr-1">{getBrowserTabLabel(tab)}</span>
           {tab.loading && !tab.loadError && !isBlankBrowserTab(tab) && (
-            <span className="mr-1.5 size-1.5 rounded-full bg-sky-500/80 shrink-0" />
+            <span className="mr-1 size-1.5 rounded-full bg-sky-500/80 shrink-0" />
           )}
           <button
             className={`flex items-center justify-center w-4 h-4 rounded-sm shrink-0 ${

--- a/src/renderer/src/components/tab-bar/BrowserTab.tsx
+++ b/src/renderer/src/components/tab-bar/BrowserTab.tsx
@@ -111,7 +111,7 @@ export default function BrowserTab({
           ref={setNodeRef}
           {...attributes}
           {...listeners}
-          className={`group relative flex items-center h-full px-1.5 text-xs cursor-pointer select-none shrink-0 border-t ${hasTabsToRight ? 'border-r' : ''} border-border bg-card ${getDropIndicatorClasses(dropIndicator ?? null)} ${
+          className={`group relative flex items-center h-full px-1.5 text-xs cursor-pointer select-none shrink-0 outline-none focus:outline-none focus-visible:outline-none border-t ${hasTabsToRight ? 'border-r' : ''} border-border bg-card ${getDropIndicatorClasses(dropIndicator ?? null)} ${
             isActive ? 'text-foreground' : 'text-muted-foreground hover:text-foreground'
           }`}
           onPointerDown={(e) => {

--- a/src/renderer/src/components/tab-bar/EditorFileTab.tsx
+++ b/src/renderer/src/components/tab-bar/EditorFileTab.tsx
@@ -175,10 +175,8 @@ export default function EditorFileTab({
           ref={setNodeRef}
           {...attributes}
           {...listeners}
-          className={`group relative flex items-center h-full px-3 text-sm cursor-pointer select-none shrink-0 border-r border-border ${getDropIndicatorClasses(dropIndicator ?? null)} ${
-            isActive
-              ? 'bg-accent text-foreground border-b-transparent'
-              : 'bg-card text-muted-foreground hover:text-foreground hover:bg-accent/50'
+          className={`group relative flex items-center h-full px-1.5 text-xs cursor-pointer select-none shrink-0 border-t ${hasTabsToRight ? 'border-r' : ''} border-border bg-card ${getDropIndicatorClasses(dropIndicator ?? null)} ${
+            isActive ? 'text-foreground' : 'text-muted-foreground hover:text-foreground'
           }`}
           onPointerDown={(e) => {
             if (e.button !== 0) {
@@ -208,25 +206,25 @@ export default function EditorFileTab({
           {isActive && <span className={ACTIVE_TAB_INDICATOR_CLASSES} aria-hidden />}
           {isConflictReview ? (
             <ShieldAlert
-              className={`w-3.5 h-3.5 mr-1.5 shrink-0 ${isActive ? 'text-orange-400' : 'text-orange-400/70'}`}
+              className={`w-3 h-3 mr-1 shrink-0 ${isActive ? 'text-orange-400' : 'text-orange-400/70'}`}
             />
           ) : isDiff ? (
             <GitCompareArrows
-              className={`w-3.5 h-3.5 mr-1.5 shrink-0 ${isActive ? 'text-foreground' : 'text-muted-foreground'}`}
+              className={`w-3 h-3 mr-1 shrink-0 ${isActive ? 'text-foreground' : 'text-muted-foreground'}`}
             />
           ) : (
             <FileCode
-              className={`w-3.5 h-3.5 mr-1.5 shrink-0 ${isActive ? 'text-foreground' : 'text-muted-foreground'}`}
+              className={`w-3 h-3 mr-1 shrink-0 ${isActive ? 'text-foreground' : 'text-muted-foreground'}`}
             />
           )}
-          <span className="mr-1.5 flex min-w-0 items-baseline gap-1.5">
+          <span className="mr-1 flex min-w-0 items-baseline gap-1">
             {isRenaming ? (
               <input
                 ref={renameInputRef}
                 defaultValue={basename(file.filePath)}
                 // Tiny border to make the edit affordance obvious without
                 // changing overall tab height. Size matches the label span.
-                className="truncate max-w-[130px] bg-transparent text-sm text-foreground outline-none border border-ring rounded-sm px-1 py-0"
+                className="truncate max-w-[80px] bg-transparent text-xs text-foreground outline-none border border-ring rounded-sm px-1 py-0"
                 onPointerDown={(e) => e.stopPropagation()}
                 onMouseDown={(e) => e.stopPropagation()}
                 onClick={(e) => e.stopPropagation()}
@@ -247,7 +245,7 @@ export default function EditorFileTab({
               />
             ) : (
               <span
-                className={`truncate max-w-[130px]${file.isPreview ? ' italic' : ''}${file.externalMutation ? ' line-through' : ''}`}
+                className={`truncate max-w-[80px]${file.isPreview ? ' italic' : ''}${file.externalMutation ? ' line-through' : ''}`}
                 style={tabStatusColor ? { color: tabStatusColor } : undefined}
                 onDoubleClick={(e) => {
                   // Why: the outer tab's onDoubleClick pins preview tabs. Scope

--- a/src/renderer/src/components/tab-bar/EditorFileTab.tsx
+++ b/src/renderer/src/components/tab-bar/EditorFileTab.tsx
@@ -175,7 +175,7 @@ export default function EditorFileTab({
           ref={setNodeRef}
           {...attributes}
           {...listeners}
-          className={`group relative flex items-center h-full px-1.5 text-xs cursor-pointer select-none shrink-0 border-t ${hasTabsToRight ? 'border-r' : ''} border-border bg-card ${getDropIndicatorClasses(dropIndicator ?? null)} ${
+          className={`group relative flex items-center h-full px-1.5 text-xs cursor-pointer select-none shrink-0 outline-none focus:outline-none focus-visible:outline-none border-t ${hasTabsToRight ? 'border-r' : ''} border-border bg-card ${getDropIndicatorClasses(dropIndicator ?? null)} ${
             isActive ? 'text-foreground' : 'text-muted-foreground hover:text-foreground'
           }`}
           onPointerDown={(e) => {

--- a/src/renderer/src/components/tab-bar/SortableTab.tsx
+++ b/src/renderer/src/components/tab-bar/SortableTab.tsx
@@ -179,7 +179,7 @@ export default function SortableTab({
           // tab still reads as "selected + has activity". The wash is
           // rendered as an absolutely-positioned child below so the ::after
           // pseudo-element stays free for the drop indicator.
-          className={`group relative flex items-center h-full px-1.5 text-xs cursor-pointer select-none shrink-0 border-t ${hasTabsToRight ? 'border-r' : ''} border-border bg-card ${getDropIndicatorClasses(dropIndicator ?? null)} ${
+          className={`group relative flex items-center h-full px-1.5 text-xs cursor-pointer select-none shrink-0 outline-none focus:outline-none focus-visible:outline-none border-t ${hasTabsToRight ? 'border-r' : ''} border-border bg-card ${getDropIndicatorClasses(dropIndicator ?? null)} ${
             isActive ? 'text-foreground' : 'text-muted-foreground hover:text-foreground'
           }`}
           onDoubleClick={(e) => {

--- a/src/renderer/src/components/tab-bar/SortableTab.tsx
+++ b/src/renderer/src/components/tab-bar/SortableTab.tsx
@@ -179,10 +179,8 @@ export default function SortableTab({
           // tab still reads as "selected + has activity". The wash is
           // rendered as an absolutely-positioned child below so the ::after
           // pseudo-element stays free for the drop indicator.
-          className={`group relative flex items-center h-full px-3 text-sm cursor-pointer select-none shrink-0 border-r border-border ${getDropIndicatorClasses(dropIndicator ?? null)} ${
-            isActive
-              ? 'bg-accent text-foreground border-b-transparent'
-              : 'bg-card text-muted-foreground hover:text-foreground hover:bg-accent/50'
+          className={`group relative flex items-center h-full px-1.5 text-xs cursor-pointer select-none shrink-0 border-t ${hasTabsToRight ? 'border-r' : ''} border-border bg-card ${getDropIndicatorClasses(dropIndicator ?? null)} ${
+            isActive ? 'text-foreground' : 'text-muted-foreground hover:text-foreground'
           }`}
           onDoubleClick={(e) => {
             if (isEditing) {
@@ -234,11 +232,11 @@ export default function SortableTab({
             // so it matches the worktree-level bell in the sidebar — keeping
             // every "needs your attention" surface in Orca consistent.
             <span data-testid="tab-activity-bell" className="inline-flex shrink-0">
-              <FilledBellIcon className="w-3.5 h-3.5 mr-1.5 text-amber-500 drop-shadow-sm" />
+              <FilledBellIcon className="w-3 h-3 mr-1 text-amber-500 drop-shadow-sm" />
             </span>
           ) : (
             <TerminalIcon
-              className={`w-3.5 h-3.5 mr-1.5 shrink-0 ${isActive ? 'text-foreground' : 'text-muted-foreground'}`}
+              className={`w-3 h-3 mr-1 shrink-0 ${isActive ? 'text-foreground' : 'text-muted-foreground'}`}
             />
           )}
           {isEditing ? (
@@ -278,11 +276,11 @@ export default function SortableTab({
               // shrink it to ~0 when many tabs compete for horizontal space.
               // Force a minimum width that matches the normal title box so the
               // rename input stays usable even when the tab bar is saturated.
-              className="h-5 w-[130px] min-w-[130px] max-w-[130px] mr-1.5 px-1 py-0 text-xs"
+              className="h-5 w-[72px] min-w-[72px] max-w-[72px] mr-1 px-1 py-0 text-xs"
               spellCheck={false}
             />
           ) : (
-            <span className="truncate max-w-[130px] mr-1.5">{tab.customTitle ?? tab.title}</span>
+            <span className="truncate max-w-[72px] mr-1">{tab.customTitle ?? tab.title}</span>
           )}
           {tab.color && !isEditing && (
             <span

--- a/src/renderer/src/components/tab-bar/TabBar.tsx
+++ b/src/renderer/src/components/tab-bar/TabBar.tsx
@@ -337,7 +337,12 @@ function TabBarInner({
             "+" button remains window-draggable. */}
         <div
           ref={tabStripRef}
-          className="terminal-tab-strip flex items-stretch overflow-x-auto overflow-y-hidden"
+          // Why: `border-r` on the strip itself guarantees a visible vertical
+          // separator between the last tab and the "+" button even when the
+          // strip is scrolled. Each tab's own right border is clipped by
+          // overflow-x-auto once tabs overflow, so relying on the per-tab
+          // border alone leaves no boundary on the trailing edge.
+          className="terminal-tab-strip flex items-stretch overflow-x-auto overflow-y-hidden border-r border-border"
           style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
         >
           {orderedItems.map((item, index) => {

--- a/src/renderer/src/components/tab-bar/TabBar.tsx
+++ b/src/renderer/src/components/tab-bar/TabBar.tsx
@@ -337,11 +337,13 @@ function TabBarInner({
             "+" button remains window-draggable. */}
         <div
           ref={tabStripRef}
-          // Why: `border-r` on the strip itself guarantees a visible vertical
-          // separator between the last tab and the "+" button even when the
-          // strip is scrolled. Each tab's own right border is clipped by
-          // overflow-x-auto once tabs overflow, so relying on the per-tab
-          // border alone leaves no boundary on the trailing edge.
+          // Why: only `border-r` on the strip — the trailing edge must stay
+          // visible even when tabs overflow-scroll past the last tab. The
+          // left edge is instead painted by the FIRST tab's own `border-l`
+          // (see per-tab components) so its rendering is identical to every
+          // between-tab separator. A strip-level `border-l` would render at
+          // a different box than the tab's own `border-t`, producing a
+          // heavier-looking L-corner at the leftmost tab when inactive.
           className="terminal-tab-strip flex items-stretch overflow-x-auto overflow-y-hidden border-r border-border"
           style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
         >

--- a/src/renderer/src/components/tab-bar/TabDragPreview.tsx
+++ b/src/renderer/src/components/tab-bar/TabDragPreview.tsx
@@ -11,7 +11,7 @@ export default function TabDragPreview({ drag }: { drag: TabDragItemData }): Rea
   const Icon =
     drag.tabType === 'browser' ? Globe : drag.tabType === 'editor' ? FileCode : TerminalIcon
   return (
-    <div className="pointer-events-none flex h-full w-full items-center gap-1.5 rounded-sm border border-border bg-accent px-3 text-sm text-foreground shadow-md">
+    <div className="pointer-events-none flex h-full w-full items-center gap-1.5 rounded-sm border border-border bg-accent px-2 text-xs text-foreground shadow-md">
       <Icon className="h-3.5 w-3.5 shrink-0" />
       <span className="truncate">{drag.label}</span>
       {drag.color ? (

--- a/src/renderer/src/components/tab-bar/drop-indicator.ts
+++ b/src/renderer/src/components/tab-bar/drop-indicator.ts
@@ -14,11 +14,11 @@ export function getDropIndicatorClasses(dropIndicator: DropIndicator): string {
   return ''
 }
 
-// Why: the bg-accent vs. bg-card contrast alone is too subtle to tell which
-// tab is active at a glance, especially in light mode. VS Code solves this
-// with a 1–2px colored bar across the top of the active tab
-// (tab.activeBorderTop). We mirror that here with an absolutely-positioned
-// child span so it sits above the tab content without shifting layout and
-// without conflicting with drop-indicator pseudo-elements during a drag.
+// Why: the active tab no longer recolors its background, so this 1px top
+// border is the ONLY cue distinguishing the selected tab. Absolutely
+// positioned with z-10 so it overlays the tab chrome without shifting layout
+// and without conflicting with drop-indicator pseudo-elements during a drag.
+// `-top-px` pulls it onto the tab's own 1px top border so the blue bar
+// REPLACES the faint gray line rather than stacking below it.
 export const ACTIVE_TAB_INDICATOR_CLASSES =
-  'pointer-events-none absolute inset-x-0 top-0 h-0.5 bg-[#1e3d9c] z-10'
+  'pointer-events-none absolute inset-x-0 -top-px h-px bg-[#1e3d9c] z-10'

--- a/src/renderer/src/components/tab-bar/drop-indicator.ts
+++ b/src/renderer/src/components/tab-bar/drop-indicator.ts
@@ -19,6 +19,10 @@ export function getDropIndicatorClasses(dropIndicator: DropIndicator): string {
 // positioned with z-10 so it overlays the tab chrome without shifting layout
 // and without conflicting with drop-indicator pseudo-elements during a drag.
 // `-top-px` pulls it onto the tab's own 1px top border so the blue bar
-// REPLACES the faint gray line rather than stacking below it.
+// REPLACES the faint gray line rather than stacking below it. Horizontal
+// inset is 0 (not -1px): negative insets on the last tab bleed into the
+// strip's scrollWidth, so clicking between active tabs flips the strip
+// between "fits exactly" and "overflows by 1px", which jitters every tab by
+// 1px because the browser preserves scrollLeft near the end.
 export const ACTIVE_TAB_INDICATOR_CLASSES =
   'pointer-events-none absolute inset-x-0 -top-px h-px bg-[#1e3d9c] z-10'

--- a/src/renderer/src/components/tab-group/TabGroupPanel.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.tsx
@@ -28,7 +28,6 @@ export default function TabGroupPanel({
   isWorktreeActive,
   isFocused,
   hasSplitGroups,
-  touchesRightEdge,
   reserveClosedExplorerToggleSpace,
   reserveCollapsedSidebarHeaderSpace,
   isTabDragActive = false,
@@ -40,7 +39,6 @@ export default function TabGroupPanel({
   isWorktreeActive: boolean
   isFocused: boolean
   hasSplitGroups: boolean
-  touchesRightEdge: boolean
   reserveClosedExplorerToggleSpace: boolean
   reserveCollapsedSidebarHeaderSpace: boolean
   isTabDragActive?: boolean
@@ -190,14 +188,7 @@ export default function TabGroupPanel({
       // because a lone group has nothing to contrast against.
       className={`group/tab-group flex flex-col flex-1 min-w-0 min-h-0 overflow-hidden${
         hasSplitGroups
-          ? // Why: drop only the RIGHT border on the rightmost group. The right
-            // sidebar paints its own `borderLeft` that already extends full
-            // height, so painting our own border-r in that spot stacks a
-            // second 1px line next to it — reading as a 2px-thick bar below
-            // the 8px drag strip (where the sidebar border continues alone
-            // above). The left edge has no such double-up, so the left
-            // border is always kept.
-            ` border-l ${touchesRightEdge ? '' : 'border-r'} border-border border-b ${isFocused ? 'border-b-accent' : 'opacity-95'}`
+          ? ` border-x border-border border-b ${isFocused ? 'border-b-accent' : 'opacity-95'}`
           : ''
       }`}
       onPointerDown={commands.focusGroup}

--- a/src/renderer/src/components/tab-group/TabGroupPanel.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.tsx
@@ -28,6 +28,7 @@ export default function TabGroupPanel({
   isWorktreeActive,
   isFocused,
   hasSplitGroups,
+  touchesRightEdge,
   reserveClosedExplorerToggleSpace,
   reserveCollapsedSidebarHeaderSpace,
   isTabDragActive = false,
@@ -39,6 +40,7 @@ export default function TabGroupPanel({
   isWorktreeActive: boolean
   isFocused: boolean
   hasSplitGroups: boolean
+  touchesRightEdge: boolean
   reserveClosedExplorerToggleSpace: boolean
   reserveCollapsedSidebarHeaderSpace: boolean
   isTabDragActive?: boolean
@@ -188,7 +190,14 @@ export default function TabGroupPanel({
       // because a lone group has nothing to contrast against.
       className={`group/tab-group flex flex-col flex-1 min-w-0 min-h-0 overflow-hidden${
         hasSplitGroups
-          ? ` border-x border-border border-b ${isFocused ? 'border-b-accent' : 'opacity-95'}`
+          ? // Why: drop only the RIGHT border on the rightmost group. The right
+            // sidebar paints its own `borderLeft` that already extends full
+            // height, so painting our own border-r in that spot stacks a
+            // second 1px line next to it — reading as a 2px-thick bar below
+            // the 8px drag strip (where the sidebar border continues alone
+            // above). The left edge has no such double-up, so the left
+            // border is always kept.
+            ` border-l ${touchesRightEdge ? '' : 'border-r'} border-border border-b ${isFocused ? 'border-b-accent' : 'opacity-95'}`
           : ''
       }`}
       onPointerDown={commands.focusGroup}

--- a/src/renderer/src/components/tab-group/TabGroupPanel.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.tsx
@@ -195,7 +195,7 @@ export default function TabGroupPanel({
           this, the empty space after tabs in the center column is dead — the
           user can only drag from the tiny left-sidebar header strip. */}
       <div
-        className="h-[42px] shrink-0 border-b border-border bg-card"
+        className="h-[34px] shrink-0 border-b border-border bg-card"
         style={{ WebkitAppRegion: 'drag' } as React.CSSProperties}
       >
         <div className="flex h-full items-stretch pr-1.5">

--- a/src/renderer/src/components/tab-group/TabGroupPanel.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.tsx
@@ -28,6 +28,7 @@ export default function TabGroupPanel({
   isWorktreeActive,
   isFocused,
   hasSplitGroups,
+  touchesRightEdge,
   reserveClosedExplorerToggleSpace,
   reserveCollapsedSidebarHeaderSpace,
   isTabDragActive = false,
@@ -39,6 +40,7 @@ export default function TabGroupPanel({
   isWorktreeActive: boolean
   isFocused: boolean
   hasSplitGroups: boolean
+  touchesRightEdge: boolean
   reserveClosedExplorerToggleSpace: boolean
   reserveCollapsedSidebarHeaderSpace: boolean
   isTabDragActive?: boolean
@@ -176,8 +178,27 @@ export default function TabGroupPanel({
 
   return (
     <div
+      // Why: vertical borders are always `border-border` so the focus
+      // highlight doesn't introduce a near-white strip next to the split
+      // resize handle (--accent is ~#f5f5f5 in light mode, which reads as a
+      // visible gap between the dragger and the tab row). Only the bottom
+      // border changes color on focus, which is enough to cue the focused
+      // group without painting a bright line along the vertical edges.
+      // Why: unfocused split groups dim very subtly so the focused group
+      // reads as "selected" without making the unfocused content look
+      // washed out or hard to read. Only applied when `hasSplitGroups`
+      // because a lone group has nothing to contrast against.
       className={`group/tab-group flex flex-col flex-1 min-w-0 min-h-0 overflow-hidden${
-        hasSplitGroups ? ` border-x border-b ${isFocused ? 'border-accent' : 'border-border'}` : ''
+        hasSplitGroups
+          ? // Why: drop only the RIGHT border on the rightmost group. The right
+            // sidebar paints its own `borderLeft` that already extends full
+            // height, so painting our own border-r in that spot stacks a
+            // second 1px line next to it — reading as a 2px-thick bar below
+            // the 8px drag strip (where the sidebar border continues alone
+            // above). The left edge has no such double-up, so the left
+            // border is always kept.
+            ` border-l ${touchesRightEdge ? '' : 'border-r'} border-border border-b ${isFocused ? 'border-b-accent' : 'opacity-95'}`
+          : ''
       }`}
       onPointerDown={commands.focusGroup}
       // Why: keyboard and assistive-tech users can move focus into an unfocused

--- a/src/renderer/src/components/tab-group/TabGroupSplitLayout.test.ts
+++ b/src/renderer/src/components/tab-group/TabGroupSplitLayout.test.ts
@@ -39,10 +39,12 @@ describe('TabGroupSplitLayout', () => {
       isWorktreeActive
     })
 
-    // DndContext has multiple children (layout wrapper + DragOverlay), so
-    // index into the layout wrapper explicitly.
+    // DndContext has multiple children (layout wrapper + DragOverlay). The
+    // layout wrapper holds [drag-strip, split-body]; the split-body holds the
+    // SplitNode element.
     const layoutWrapper = element.props.children[0]
-    const splitNodeElement = layoutWrapper.props.children
+    const splitBody = layoutWrapper.props.children[1]
+    const splitNodeElement = splitBody.props.children
     const tabGroupPanelElement = splitNodeElement.type(splitNodeElement.props)
     return tabGroupPanelElement.props as {
       groupId: string
@@ -98,7 +100,8 @@ describe('TabGroupSplitLayout', () => {
     })
 
     const layoutWrapper = element.props.children[0]
-    const splitNodeElement = layoutWrapper.props.children
+    const splitBody = layoutWrapper.props.children[1]
+    const splitNodeElement = splitBody.props.children
     const rootElement = splitNodeElement.type(splitNodeElement.props)
     const leftChild = rootElement.props.children[0].props.children
     const rightChild = rootElement.props.children[2].props.children

--- a/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
@@ -125,6 +125,7 @@ function SplitNode({
         // "focused", Cmd/Ctrl+W and split shortcuts can hit the wrong worktree.
         isFocused={isWorktreeActive && node.groupId === focusedGroupId}
         hasSplitGroups={hasSplitGroups}
+        touchesRightEdge={touchesRightEdge}
         reserveClosedExplorerToggleSpace={touchesTopEdge && touchesRightEdge}
         reserveCollapsedSidebarHeaderSpace={touchesTopEdge && touchesLeftEdge}
         isTabDragActive={isTabDragActive}
@@ -198,6 +199,7 @@ export default function TabGroupSplitLayout({
   isWorktreeActive: boolean
 }): React.JSX.Element {
   const dragSplit = useTabDragSplit({ worktreeId, enabled: isWorktreeActive })
+  const hasSplits = layout.type === 'split'
 
   return (
     <DndContext
@@ -219,10 +221,16 @@ export default function TabGroupSplitLayout({
           each pane — so vertical split resize handles don't extend into the
           window-drag region at the top. Only the split layout's own panes
           own the resize handles, while this strip keeps the whole top of the
-          center column draggable regardless of how the splits are arranged. */}
+          center column draggable regardless of how the splits are arranged.
+          Why conditional `border-l`: when splits exist, the leftmost pane
+          paints its own `border-l` starting at y=8. Mirroring that border
+          on the drag strip extends the seam up to y=0 so the left-sidebar /
+          center-column line reaches the top of the window, matching the
+          full-height right-sidebar seam. Without splits the pane has no
+          `border-l`, so we skip it here too to avoid a dangling 8px stub. */}
       <div className="flex flex-col flex-1 min-w-0 min-h-0 overflow-hidden">
         <div
-          className="h-2 shrink-0 bg-card"
+          className={`h-2 shrink-0 bg-card${hasSplits ? ' border-l border-border' : ''}`}
           style={{ WebkitAppRegion: 'drag' } as React.CSSProperties}
         />
         <div className="flex flex-1 min-w-0 min-h-0 overflow-hidden">
@@ -232,7 +240,7 @@ export default function TabGroupSplitLayout({
             worktreeId={worktreeId}
             focusedGroupId={focusedGroupId}
             isWorktreeActive={isWorktreeActive}
-            hasSplitGroups={layout.type === 'split'}
+            hasSplitGroups={hasSplits}
             touchesTopEdge={true}
             touchesRightEdge={true}
             touchesLeftEdge={true}

--- a/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
@@ -125,7 +125,6 @@ function SplitNode({
         // "focused", Cmd/Ctrl+W and split shortcuts can hit the wrong worktree.
         isFocused={isWorktreeActive && node.groupId === focusedGroupId}
         hasSplitGroups={hasSplitGroups}
-        touchesRightEdge={touchesRightEdge}
         reserveClosedExplorerToggleSpace={touchesTopEdge && touchesRightEdge}
         reserveCollapsedSidebarHeaderSpace={touchesTopEdge && touchesLeftEdge}
         isTabDragActive={isTabDragActive}
@@ -222,15 +221,16 @@ export default function TabGroupSplitLayout({
           window-drag region at the top. Only the split layout's own panes
           own the resize handles, while this strip keeps the whole top of the
           center column draggable regardless of how the splits are arranged.
-          Why conditional `border-l`: when splits exist, the leftmost pane
-          paints its own `border-l` starting at y=8. Mirroring that border
-          on the drag strip extends the seam up to y=0 so the left-sidebar /
-          center-column line reaches the top of the window, matching the
-          full-height right-sidebar seam. Without splits the pane has no
-          `border-l`, so we skip it here too to avoid a dangling 8px stub. */}
+          Why conditional `border-x`: when splits exist, the outer panes
+          paint their own vertical borders starting at y=8 (see
+          TabGroupPanel). Mirroring those borders on the drag strip extends
+          both seams up to y=0 so the lines between the terminal area and
+          the left/right sidebars reach the top of the window. Without
+          splits the panes have no vertical borders, so we skip them here
+          too to avoid dangling 8px stubs. */}
       <div className="flex flex-col flex-1 min-w-0 min-h-0 overflow-hidden">
         <div
-          className={`h-2 shrink-0 bg-card${hasSplits ? ' border-l border-border' : ''}`}
+          className={`h-2 shrink-0 bg-card${hasSplits ? ' border-x border-border' : ''}`}
           style={{ WebkitAppRegion: 'drag' } as React.CSSProperties}
         />
         <div className="flex flex-1 min-w-0 min-h-0 overflow-hidden">

--- a/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
@@ -215,22 +215,33 @@ export default function TabGroupSplitLayout({
       // so disabling it is the simplest fix.
       autoScroll={false}
     >
-      <div className="flex flex-1 min-w-0 min-h-0 overflow-hidden">
-        <SplitNode
-          node={layout}
-          nodePath=""
-          worktreeId={worktreeId}
-          focusedGroupId={focusedGroupId}
-          isWorktreeActive={isWorktreeActive}
-          hasSplitGroups={layout.type === 'split'}
-          touchesTopEdge={true}
-          touchesRightEdge={true}
-          touchesLeftEdge={true}
-          isTabDragActive={dragSplit.activeDrag !== null}
-          activeDropGroupId={dragSplit.hoveredDropTarget?.groupId ?? null}
-          activeDropZone={dragSplit.hoveredDropTarget?.zone ?? null}
-          hoveredTabInsertion={dragSplit.hoveredTabInsertion}
+      {/* Why: the 8px drag strip sits ABOVE the split layout — lifted out of
+          each pane — so vertical split resize handles don't extend into the
+          window-drag region at the top. Only the split layout's own panes
+          own the resize handles, while this strip keeps the whole top of the
+          center column draggable regardless of how the splits are arranged. */}
+      <div className="flex flex-col flex-1 min-w-0 min-h-0 overflow-hidden">
+        <div
+          className="h-2 shrink-0 bg-card"
+          style={{ WebkitAppRegion: 'drag' } as React.CSSProperties}
         />
+        <div className="flex flex-1 min-w-0 min-h-0 overflow-hidden">
+          <SplitNode
+            node={layout}
+            nodePath=""
+            worktreeId={worktreeId}
+            focusedGroupId={focusedGroupId}
+            isWorktreeActive={isWorktreeActive}
+            hasSplitGroups={layout.type === 'split'}
+            touchesTopEdge={true}
+            touchesRightEdge={true}
+            touchesLeftEdge={true}
+            isTabDragActive={dragSplit.activeDrag !== null}
+            activeDropGroupId={dragSplit.hoveredDropTarget?.groupId ?? null}
+            activeDropZone={dragSplit.hoveredDropTarget?.zone ?? null}
+            hoveredTabInsertion={dragSplit.hoveredTabInsertion}
+          />
+        </div>
       </div>
       {/* Why: the sortable tab is anchored inside its source tab strip (no
           transform while dragging), and that strip uses overflow-hidden so

--- a/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
@@ -222,15 +222,14 @@ export default function TabGroupSplitLayout({
           window-drag region at the top. Only the split layout's own panes
           own the resize handles, while this strip keeps the whole top of the
           center column draggable regardless of how the splits are arranged.
-          Why conditional `border-l`: when splits exist, the leftmost pane
-          paints its own `border-l` starting at y=8. Mirroring that border
-          on the drag strip extends the seam up to y=0 so the left-sidebar /
-          center-column line reaches the top of the window, matching the
-          full-height right-sidebar seam. Without splits the pane has no
-          `border-l`, so we skip it here too to avoid a dangling 8px stub. */}
-      <div className="flex flex-col flex-1 min-w-0 min-h-0 overflow-hidden">
+          Why `border-l` on the wrapper: paint a single full-height divider
+          between the left sidebar and the terminal area, regardless of
+          split state. When splits exist, the leftmost pane also renders its
+          own `border-l` at the same x — both use `border-border` so the
+          overlapping 1px lines read as one clean seam. */}
+      <div className="flex flex-col flex-1 min-w-0 min-h-0 overflow-hidden border-l border-border">
         <div
-          className={`h-2 shrink-0 bg-card${hasSplits ? ' border-l border-border' : ''}`}
+          className="h-2 shrink-0 bg-card"
           style={{ WebkitAppRegion: 'drag' } as React.CSSProperties}
         />
         <div className="flex flex-1 min-w-0 min-h-0 overflow-hidden">

--- a/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
@@ -125,6 +125,7 @@ function SplitNode({
         // "focused", Cmd/Ctrl+W and split shortcuts can hit the wrong worktree.
         isFocused={isWorktreeActive && node.groupId === focusedGroupId}
         hasSplitGroups={hasSplitGroups}
+        touchesRightEdge={touchesRightEdge}
         reserveClosedExplorerToggleSpace={touchesTopEdge && touchesRightEdge}
         reserveCollapsedSidebarHeaderSpace={touchesTopEdge && touchesLeftEdge}
         isTabDragActive={isTabDragActive}
@@ -221,16 +222,15 @@ export default function TabGroupSplitLayout({
           window-drag region at the top. Only the split layout's own panes
           own the resize handles, while this strip keeps the whole top of the
           center column draggable regardless of how the splits are arranged.
-          Why conditional `border-x`: when splits exist, the outer panes
-          paint their own vertical borders starting at y=8 (see
-          TabGroupPanel). Mirroring those borders on the drag strip extends
-          both seams up to y=0 so the lines between the terminal area and
-          the left/right sidebars reach the top of the window. Without
-          splits the panes have no vertical borders, so we skip them here
-          too to avoid dangling 8px stubs. */}
+          Why conditional `border-l`: when splits exist, the leftmost pane
+          paints its own `border-l` starting at y=8. Mirroring that border
+          on the drag strip extends the seam up to y=0 so the left-sidebar /
+          center-column line reaches the top of the window, matching the
+          full-height right-sidebar seam. Without splits the pane has no
+          `border-l`, so we skip it here too to avoid a dangling 8px stub. */}
       <div className="flex flex-col flex-1 min-w-0 min-h-0 overflow-hidden">
         <div
-          className={`h-2 shrink-0 bg-card${hasSplits ? ' border-x border-border' : ''}`}
+          className={`h-2 shrink-0 bg-card${hasSplits ? ' border-l border-border' : ''}`}
           style={{ WebkitAppRegion: 'drag' } as React.CSSProperties}
         />
         <div className="flex flex-1 min-w-0 min-h-0 overflow-hidden">

--- a/tests/e2e/tab-rename.spec.ts
+++ b/tests/e2e/tab-rename.spec.ts
@@ -258,9 +258,11 @@ test.describe('Tab Rename (Inline)', () => {
 
     // Why: create enough terminal tabs that flex space runs out. 15 is well
     // above the threshold at which the pre-fix input collapsed, and it keeps
-    // the test fast. The width fix pins the input to 130px, so even saturated,
-    // it should stay near that size — we assert ≥100px to allow a bit of slack
-    // for fonts/padding/containers differing between environments.
+    // the test fast. The width fix pins the input to 72px (matching the
+    // slimmer tab title box), so even saturated, it should stay near that
+    // size — we assert ≥60px to allow a bit of slack for fonts/padding/
+    // containers differing between environments. The meaningful guarantee is
+    // that the input does not collapse to ~0 when flex space is saturated.
     await orcaPage.evaluate((targetWorktreeId) => {
       const store = window.__store
       if (!store) {
@@ -289,7 +291,7 @@ test.describe('Tab Rename (Inline)', () => {
 
     const box = await renameInput.boundingBox()
     expect(box).not.toBeNull()
-    expect(box!.width).toBeGreaterThanOrEqual(100)
+    expect(box!.width).toBeGreaterThanOrEqual(60)
   })
 
   test('middle-clicking inside the rename input does not close the tab', async ({ orcaPage }) => {


### PR DESCRIPTION
## Summary
- Shrink tabs: tighter padding (`px-3` → `px-1.5`), smaller icons (`w-3.5` → `w-3`), smaller labels (`text-sm` → `text-xs`), lower max label widths.
- Drop the inset / background-accent look on the active tab. Active state is now a 1px top border that sits on the tab's own gray top border (no layout shift, no click-to-recolor).
- Add an 8px window-drag strip above the tab row. Lift it from each `TabGroupPanel` up to the split-layout container so split resize handles don't extend into the draggable region — and so a split-down pane's tab row stays flush without an extra gap above it.
- Wrap the workspace `RightSidebar` with a matching 8px drag strip so its top aligns with the tab row instead of the OS window edge.
- Strip-level right border on the tab container so the rightmost tab always has a visible separator before the `+` button, even when the strip is scrolled and the last tab is suppressing its own right border to avoid a doubled line.

## Test plan
- [x] Tabs look slimmer; active tab shows only a top blue line (no background fill).
- [x] Clicking the active tab does not change its color anymore.
- [x] 8px strip above tabs is draggable (window moves).
- [x] Split right: resize handle does NOT reach the window top; it starts at the tab row.
- [x] Split down: lower pane's tab row has no extra gap above it.
- [x] Right sidebar: top edge aligns with the tab row (8px drag strip above it).
- [x] Right-sidebar toggle (closed state) still clickable and aligned with the tab band.
- [x] Overflowing tab strip: a separator is still visible between the last-visible tab and the `+` button with no doubled-width border.

<img width="1512" height="49" alt="image" src="https://github.com/user-attachments/assets/8b92a66b-b2da-4a88-990f-7d9df4bf68ee" />
