### PR TITLE
fix(daemon): defer startup flush past shell raw-mode switch

### DIFF
--- a/src/main/daemon/post-ready-flush-gate.test.ts
+++ b/src/main/daemon/post-ready-flush-gate.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  PostReadyFlushGate,
+  POST_READY_FLUSH_DELAY_MS,
+  POST_READY_FLUSH_FALLBACK_MS
+} from './post-ready-flush-gate'
+
+describe('PostReadyFlushGate', () => {
+  let onFlush: ReturnType<typeof vi.fn<() => void>>
+  let gate: PostReadyFlushGate
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    onFlush = vi.fn<() => void>()
+    gate = new PostReadyFlushGate(onFlush)
+  })
+
+  afterEach(() => {
+    gate.clear()
+    vi.useRealTimers()
+  })
+
+  it('does not flush immediately when armed', () => {
+    gate.arm()
+    expect(onFlush).not.toHaveBeenCalled()
+  })
+
+  it('flushes via short delay after notifyData signals the prompt draw', () => {
+    gate.arm()
+    gate.notifyData()
+    expect(onFlush).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(POST_READY_FLUSH_DELAY_MS)
+    expect(onFlush).toHaveBeenCalledTimes(1)
+  })
+
+  it('flushes via wall-clock fallback when no notifyData arrives', () => {
+    gate.arm()
+
+    vi.advanceTimersByTime(POST_READY_FLUSH_FALLBACK_MS)
+    expect(onFlush).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores notifyData before arm()', () => {
+    gate.notifyData()
+    vi.advanceTimersByTime(1000)
+    expect(onFlush).not.toHaveBeenCalled()
+  })
+
+  it('notifyData after the fallback fired is a no-op', () => {
+    gate.arm()
+    vi.advanceTimersByTime(POST_READY_FLUSH_FALLBACK_MS)
+    expect(onFlush).toHaveBeenCalledTimes(1)
+
+    gate.notifyData()
+    vi.advanceTimersByTime(1000)
+    expect(onFlush).toHaveBeenCalledTimes(1)
+  })
+
+  it('only the first notifyData schedules the short-delay flush', () => {
+    gate.arm()
+    gate.notifyData()
+    gate.notifyData()
+    gate.notifyData()
+
+    vi.advanceTimersByTime(POST_READY_FLUSH_DELAY_MS)
+    expect(onFlush).toHaveBeenCalledTimes(1)
+  })
+
+  it('clear() cancels a pending fallback flush', () => {
+    gate.arm()
+    gate.clear()
+
+    vi.advanceTimersByTime(POST_READY_FLUSH_FALLBACK_MS * 2)
+    expect(onFlush).not.toHaveBeenCalled()
+  })
+
+  it('clear() cancels a pending post-data flush', () => {
+    gate.arm()
+    gate.notifyData()
+    gate.clear()
+
+    vi.advanceTimersByTime(POST_READY_FLUSH_DELAY_MS * 2)
+    expect(onFlush).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/daemon/post-ready-flush-gate.test.ts
+++ b/src/main/daemon/post-ready-flush-gate.test.ts
@@ -83,4 +83,15 @@ describe('PostReadyFlushGate', () => {
     vi.advanceTimersByTime(POST_READY_FLUSH_DELAY_MS * 2)
     expect(onFlush).not.toHaveBeenCalled()
   })
+
+  it('isPending is true throughout the gate window and false once flush fires', () => {
+    expect(gate.isPending).toBe(false)
+    gate.arm()
+    expect(gate.isPending).toBe(true)
+    gate.notifyData()
+    expect(gate.isPending).toBe(true)
+    vi.advanceTimersByTime(POST_READY_FLUSH_DELAY_MS)
+    expect(gate.isPending).toBe(false)
+    expect(onFlush).toHaveBeenCalledTimes(1)
+  })
 })

--- a/src/main/daemon/post-ready-flush-gate.ts
+++ b/src/main/daemon/post-ready-flush-gate.ts
@@ -1,0 +1,75 @@
+/**
+ * Defers a flush callback until after the shell has drawn its prompt and
+ * switched the PTY into raw mode.
+ *
+ * Why: the OSC 777 shell-ready marker fires from zsh's precmd_functions /
+ * bash's PROMPT_COMMAND — before the shell draws its prompt and before
+ * zle/readline flips the PTY into raw mode. Flushing queued input then lets
+ * the kernel (ECHO still on) echo the command once, and the line editor
+ * redraws it under the prompt — producing a visible duplicate (e.g. "claude"
+ * appears twice on agent launch).
+ *
+ * Strategy: after arm() is called, wait for the next PTY data chunk (the
+ * prompt draw) plus a short delay for the tcsetattr() that enables raw mode.
+ * A wall-clock fallback covers the case where the prompt arrives in the same
+ * chunk as the marker, so no follow-up notifyData() ever fires.
+ *
+ * Mirrors the gate in local-pty-shell-ready.ts::writeStartupCommandWhenShellReady,
+ * which solves the same race on the non-daemon path.
+ */
+
+export const POST_READY_FLUSH_DELAY_MS = 30
+export const POST_READY_FLUSH_FALLBACK_MS = 50
+
+export class PostReadyFlushGate {
+  private awaitingPromptDraw = false
+  private postDataTimer: ReturnType<typeof setTimeout> | null = null
+  private fallbackTimer: ReturnType<typeof setTimeout> | null = null
+
+  constructor(private readonly onFlush: () => void) {}
+
+  /** Arm the gate after observing the shell-ready marker. Starts the
+   *  wall-clock fallback; the flush fires when the fallback elapses or when
+   *  notifyData() observes a subsequent PTY data chunk. */
+  arm(): void {
+    this.awaitingPromptDraw = true
+    this.fallbackTimer = setTimeout(() => {
+      this.fallbackTimer = null
+      this.awaitingPromptDraw = false
+      this.onFlush()
+    }, POST_READY_FLUSH_FALLBACK_MS)
+  }
+
+  /** Report a PTY data chunk observed after arm(). The first such call swaps
+   *  the wall-clock fallback for the short post-data delay so readline has
+   *  time to enable raw mode before the flush fires. */
+  notifyData(): void {
+    if (!this.awaitingPromptDraw) {
+      return
+    }
+    this.awaitingPromptDraw = false
+    if (this.fallbackTimer) {
+      clearTimeout(this.fallbackTimer)
+      this.fallbackTimer = null
+    }
+    if (this.postDataTimer === null) {
+      this.postDataTimer = setTimeout(() => {
+        this.postDataTimer = null
+        this.onFlush()
+      }, POST_READY_FLUSH_DELAY_MS)
+    }
+  }
+
+  /** Cancel any pending flush. Call on session teardown. */
+  clear(): void {
+    this.awaitingPromptDraw = false
+    if (this.postDataTimer) {
+      clearTimeout(this.postDataTimer)
+      this.postDataTimer = null
+    }
+    if (this.fallbackTimer) {
+      clearTimeout(this.fallbackTimer)
+      this.fallbackTimer = null
+    }
+  }
+}

--- a/src/main/daemon/post-ready-flush-gate.ts
+++ b/src/main/daemon/post-ready-flush-gate.ts
@@ -28,6 +28,12 @@ export class PostReadyFlushGate {
 
   constructor(private readonly onFlush: () => void) {}
 
+  /** True between arm() and the actual flush firing. Callers should treat
+   *  input as still-queued during this window to preserve ordering. */
+  get isPending(): boolean {
+    return this.awaitingPromptDraw || this.postDataTimer !== null || this.fallbackTimer !== null
+  }
+
   /** Arm the gate after observing the shell-ready marker. Starts the
    *  wall-clock fallback; the flush fires when the fallback elapses or when
    *  notifyData() observes a subsequent PTY data chunk. */

--- a/src/main/daemon/session.test.ts
+++ b/src/main/daemon/session.test.ts
@@ -1,3 +1,4 @@
+/* oxlint-disable max-lines */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { Session } from './session'
 import type { SessionState, ShellReadyState } from './types'
@@ -186,16 +187,30 @@ describe('Session', () => {
       expect(subprocess.written).toEqual([])
     })
 
-    it('flushes buffered writes when shell marker is detected', () => {
+    // Why: the shell-ready marker fires from precmd/PROMPT_COMMAND, before
+    // the shell draws its prompt and before readline flips the PTY into raw
+    // mode. Flushing then causes the kernel (ECHO on) to echo the command
+    // once, and readline redraws it under the prompt — producing "claude
+    // claude" on agent launch. The flush must defer until after prompt draw.
+    it('defers flush until after prompt draw + short delay', () => {
       createSession({ shellReadySupported: true })
-
       session.write('pre-ready input')
-      expect(subprocess.written).toEqual([])
-
-      // Simulate the shell marker arriving in PTY output
       subprocess.simulateData('\x1b]777;orca-shell-ready\x07')
       expect(session.shellState).toBe('ready' satisfies ShellReadyState)
+      expect(subprocess.written).toEqual([])
+
+      subprocess.simulateData('\r\nuser@host $ ')
+      vi.advanceTimersByTime(30)
       expect(subprocess.written).toEqual(['pre-ready input'])
+    })
+
+    it('flushes via fallback timer if the prompt arrived in the marker chunk', () => {
+      createSession({ shellReadySupported: true })
+      session.write('claude\n')
+      subprocess.simulateData('\x1b]777;orca-shell-ready\x07user@host $ ')
+      expect(subprocess.written).toEqual([])
+      vi.advanceTimersByTime(50)
+      expect(subprocess.written).toEqual(['claude\n'])
     })
 
     it('transitions to timed_out after 15 seconds', () => {

--- a/src/main/daemon/session.test.ts
+++ b/src/main/daemon/session.test.ts
@@ -1,4 +1,3 @@
-/* oxlint-disable max-lines */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { Session } from './session'
 import type { SessionState, ShellReadyState } from './types'
@@ -187,29 +186,20 @@ describe('Session', () => {
       expect(subprocess.written).toEqual([])
     })
 
-    // Why: the shell-ready marker fires from precmd/PROMPT_COMMAND, before
-    // the shell draws its prompt and before readline flips the PTY into raw
-    // mode. Flushing then causes the kernel (ECHO on) to echo the command
-    // once, and readline redraws it under the prompt — producing "claude
-    // claude" on agent launch. The flush must defer until after prompt draw.
-    it('defers flush until after prompt draw + short delay', () => {
+    // Why: regression guard for "claude claude" double-echo. The marker fires
+    // from precmd before readline switches the PTY into raw mode; flushing
+    // then lets the kernel re-echo the command under the prompt. Detailed
+    // timing behavior is covered by post-ready-flush-gate.test.ts; here we
+    // just verify Session wires the gate in (no write on the raw marker).
+    it('defers flush past the shell-ready marker to avoid kernel ECHO duplication', () => {
       createSession({ shellReadySupported: true })
-      session.write('pre-ready input')
+      session.write('claude\n')
       subprocess.simulateData('\x1b]777;orca-shell-ready\x07')
       expect(session.shellState).toBe('ready' satisfies ShellReadyState)
       expect(subprocess.written).toEqual([])
 
       subprocess.simulateData('\r\nuser@host $ ')
       vi.advanceTimersByTime(30)
-      expect(subprocess.written).toEqual(['pre-ready input'])
-    })
-
-    it('flushes via fallback timer if the prompt arrived in the marker chunk', () => {
-      createSession({ shellReadySupported: true })
-      session.write('claude\n')
-      subprocess.simulateData('\x1b]777;orca-shell-ready\x07user@host $ ')
-      expect(subprocess.written).toEqual([])
-      vi.advanceTimersByTime(50)
       expect(subprocess.written).toEqual(['claude\n'])
     })
 

--- a/src/main/daemon/session.test.ts
+++ b/src/main/daemon/session.test.ts
@@ -178,29 +178,25 @@ describe('Session', () => {
   })
 
   describe('shell readiness gating', () => {
-    it('buffers writes during pending state', () => {
-      createSession({ shellReadySupported: true })
-      expect(session.shellState).toBe('pending')
-
-      session.write('buffered input')
-      expect(subprocess.written).toEqual([])
-    })
-
     // Why: regression guard for "claude claude" double-echo. The marker fires
     // from precmd before readline switches the PTY into raw mode; flushing
     // then lets the kernel re-echo the command under the prompt. Detailed
-    // timing behavior is covered by post-ready-flush-gate.test.ts; here we
-    // just verify Session wires the gate in (no write on the raw marker).
-    it('defers flush past the shell-ready marker to avoid kernel ECHO duplication', () => {
+    // timing behavior is covered by post-ready-flush-gate.test.ts.
+    // Also checks writes that arrive during the gate window keep their order
+    // — the gate continues to queue even though shellState is already 'ready'.
+    it('defers flush past the shell-ready marker and preserves write order', () => {
       createSession({ shellReadySupported: true })
-      session.write('claude\n')
+      expect(session.shellState).toBe('pending')
+
+      session.write('first\n')
       subprocess.simulateData('\x1b]777;orca-shell-ready\x07')
       expect(session.shellState).toBe('ready' satisfies ShellReadyState)
+      session.write('second\n')
       expect(subprocess.written).toEqual([])
 
       subprocess.simulateData('\r\nuser@host $ ')
       vi.advanceTimersByTime(30)
-      expect(subprocess.written).toEqual(['claude\n'])
+      expect(subprocess.written).toEqual(['first\n', 'second\n'])
     })
 
     it('transitions to timed_out after 15 seconds', () => {

--- a/src/main/daemon/session.ts
+++ b/src/main/daemon/session.ts
@@ -1,25 +1,11 @@
-/* eslint-disable max-lines -- Why: post-ready flush gating (see POST_READY_FLUSH_DELAY_MS)
-adds ~25 lines of timer/state wiring across handleSubprocessData, transitionToReady,
-and cleanup paths. Splitting it out of Session would scatter tightly coupled shell
-lifecycle logic across files without a cleaner ownership seam. */
 import { HeadlessEmulator } from './headless-emulator'
 import { isValidPtySize, normalizePtySize } from './daemon-pty-size'
+import { PostReadyFlushGate } from './post-ready-flush-gate'
 import type { SessionState, ShellReadyState, TerminalSnapshot } from './types'
 
 const SHELL_READY_TIMEOUT_MS = 15_000
 const KILL_TIMEOUT_MS = 5_000
 const SHELL_READY_MARKER = '\x1b]777;orca-shell-ready\x07'
-// Why: the OSC 777 marker fires from precmd/PROMPT_COMMAND, before the shell
-// draws its prompt and before zle/readline flips the PTY into raw mode.
-// Flushing the pre-ready queue then lets the kernel (ECHO still on) echo the
-// command once, and the line editor redraws it under the prompt — producing a
-// visible duplicate (e.g. "claude" twice when launching an agent). Wait for
-// the next data chunk (the prompt draw) plus a short delay for the
-// tcsetattr() that enables raw mode, with a wall-clock fallback for cases
-// where the prompt arrived in the same chunk as the marker. Matches the gate
-// in local-pty-shell-ready.ts::writeStartupCommandWhenShellReady.
-const POST_READY_FLUSH_DELAY_MS = 30
-const POST_READY_FLUSH_FALLBACK_MS = 50
 
 export type SubprocessHandle = {
   pid: number
@@ -61,10 +47,7 @@ export class Session {
   private markerBuffer = ''
   private shellReadyTimer: ReturnType<typeof setTimeout> | null = null
   private killTimer: ReturnType<typeof setTimeout> | null = null
-  // See POST_READY_FLUSH_DELAY_MS for why the flush is deferred.
-  private postReadyFlushPending = false
-  private postReadyFlushTimer: ReturnType<typeof setTimeout> | null = null
-  private postReadyFallbackTimer: ReturnType<typeof setTimeout> | null = null
+  private postReadyFlushGate: PostReadyFlushGate
 
   constructor(opts: SessionOptions) {
     this.sessionId = opts.sessionId
@@ -89,6 +72,7 @@ export class Session {
       this._shellState = 'unsupported'
     }
 
+    this.postReadyFlushGate = new PostReadyFlushGate(() => this.flushPreReadyQueue())
     this.subprocess.onData((data) => this.handleSubprocessData(data))
     this.subprocess.onExit((code) => this.handleSubprocessExit(code))
   }
@@ -228,7 +212,7 @@ export class Session {
       clearTimeout(this.killTimer)
       this.killTimer = null
     }
-    this.clearPostReadyTimers()
+    this.postReadyFlushGate.clear()
 
     this.attachedClients = []
     this.preReadyStdinQueue = []
@@ -249,20 +233,8 @@ export class Session {
 
     if (this._shellState === 'pending') {
       this.scanForShellMarker(data)
-    } else if (this.postReadyFlushPending) {
-      // Why: prompt draw arrived. Swap the wall-clock fallback for the short
-      // post-data delay so readline has time to enable raw mode first.
-      this.postReadyFlushPending = false
-      if (this.postReadyFallbackTimer) {
-        clearTimeout(this.postReadyFallbackTimer)
-        this.postReadyFallbackTimer = null
-      }
-      if (this.postReadyFlushTimer === null) {
-        this.postReadyFlushTimer = setTimeout(() => {
-          this.postReadyFlushTimer = null
-          this.flushPreReadyQueue()
-        }, POST_READY_FLUSH_DELAY_MS)
-      }
+    } else {
+      this.postReadyFlushGate.notifyData()
     }
 
     // Broadcast to attached clients
@@ -287,7 +259,7 @@ export class Session {
       clearTimeout(this.shellReadyTimer)
       this.shellReadyTimer = null
     }
-    this.clearPostReadyTimers()
+    this.postReadyFlushGate.clear()
 
     for (const client of this.attachedClients) {
       client.onExit(code)
@@ -320,13 +292,7 @@ export class Session {
     if (this.preReadyStdinQueue.length === 0) {
       return
     }
-    // See POST_READY_FLUSH_DELAY_MS.
-    this.postReadyFlushPending = true
-    this.postReadyFallbackTimer = setTimeout(() => {
-      this.postReadyFallbackTimer = null
-      this.postReadyFlushPending = false
-      this.flushPreReadyQueue()
-    }, POST_READY_FLUSH_FALLBACK_MS)
+    this.postReadyFlushGate.arm()
   }
 
   private onShellReadyTimeout(): void {
@@ -339,23 +305,10 @@ export class Session {
   }
 
   private flushPreReadyQueue(): void {
-    this.postReadyFlushPending = false
     const queued = this.preReadyStdinQueue
     this.preReadyStdinQueue = []
     for (const data of queued) {
       this.subprocess.write(data)
-    }
-  }
-
-  private clearPostReadyTimers(): void {
-    this.postReadyFlushPending = false
-    if (this.postReadyFlushTimer) {
-      clearTimeout(this.postReadyFlushTimer)
-      this.postReadyFlushTimer = null
-    }
-    if (this.postReadyFallbackTimer) {
-      clearTimeout(this.postReadyFallbackTimer)
-      this.postReadyFallbackTimer = null
     }
   }
 
@@ -377,7 +330,7 @@ export class Session {
       clearTimeout(this.killTimer)
       this.killTimer = null
     }
-    this.clearPostReadyTimers()
+    this.postReadyFlushGate.clear()
 
     const clients = this.attachedClients
     this.attachedClients = []

--- a/src/main/daemon/session.ts
+++ b/src/main/daemon/session.ts
@@ -1,3 +1,7 @@
+/* eslint-disable max-lines -- Why: post-ready flush gating (see POST_READY_FLUSH_DELAY_MS)
+adds ~25 lines of timer/state wiring across handleSubprocessData, transitionToReady,
+and cleanup paths. Splitting it out of Session would scatter tightly coupled shell
+lifecycle logic across files without a cleaner ownership seam. */
 import { HeadlessEmulator } from './headless-emulator'
 import { isValidPtySize, normalizePtySize } from './daemon-pty-size'
 import type { SessionState, ShellReadyState, TerminalSnapshot } from './types'
@@ -5,6 +9,17 @@ import type { SessionState, ShellReadyState, TerminalSnapshot } from './types'
 const SHELL_READY_TIMEOUT_MS = 15_000
 const KILL_TIMEOUT_MS = 5_000
 const SHELL_READY_MARKER = '\x1b]777;orca-shell-ready\x07'
+// Why: the OSC 777 marker fires from precmd/PROMPT_COMMAND, before the shell
+// draws its prompt and before zle/readline flips the PTY into raw mode.
+// Flushing the pre-ready queue then lets the kernel (ECHO still on) echo the
+// command once, and the line editor redraws it under the prompt — producing a
+// visible duplicate (e.g. "claude" twice when launching an agent). Wait for
+// the next data chunk (the prompt draw) plus a short delay for the
+// tcsetattr() that enables raw mode, with a wall-clock fallback for cases
+// where the prompt arrived in the same chunk as the marker. Matches the gate
+// in local-pty-shell-ready.ts::writeStartupCommandWhenShellReady.
+const POST_READY_FLUSH_DELAY_MS = 30
+const POST_READY_FLUSH_FALLBACK_MS = 50
 
 export type SubprocessHandle = {
   pid: number
@@ -46,6 +61,10 @@ export class Session {
   private markerBuffer = ''
   private shellReadyTimer: ReturnType<typeof setTimeout> | null = null
   private killTimer: ReturnType<typeof setTimeout> | null = null
+  // See POST_READY_FLUSH_DELAY_MS for why the flush is deferred.
+  private postReadyFlushPending = false
+  private postReadyFlushTimer: ReturnType<typeof setTimeout> | null = null
+  private postReadyFallbackTimer: ReturnType<typeof setTimeout> | null = null
 
   constructor(opts: SessionOptions) {
     this.sessionId = opts.sessionId
@@ -209,6 +228,7 @@ export class Session {
       clearTimeout(this.killTimer)
       this.killTimer = null
     }
+    this.clearPostReadyTimers()
 
     this.attachedClients = []
     this.preReadyStdinQueue = []
@@ -229,6 +249,20 @@ export class Session {
 
     if (this._shellState === 'pending') {
       this.scanForShellMarker(data)
+    } else if (this.postReadyFlushPending) {
+      // Why: prompt draw arrived. Swap the wall-clock fallback for the short
+      // post-data delay so readline has time to enable raw mode first.
+      this.postReadyFlushPending = false
+      if (this.postReadyFallbackTimer) {
+        clearTimeout(this.postReadyFallbackTimer)
+        this.postReadyFallbackTimer = null
+      }
+      if (this.postReadyFlushTimer === null) {
+        this.postReadyFlushTimer = setTimeout(() => {
+          this.postReadyFlushTimer = null
+          this.flushPreReadyQueue()
+        }, POST_READY_FLUSH_DELAY_MS)
+      }
     }
 
     // Broadcast to attached clients
@@ -253,6 +287,7 @@ export class Session {
       clearTimeout(this.shellReadyTimer)
       this.shellReadyTimer = null
     }
+    this.clearPostReadyTimers()
 
     for (const client of this.attachedClients) {
       client.onExit(code)
@@ -282,7 +317,16 @@ export class Session {
       clearTimeout(this.shellReadyTimer)
       this.shellReadyTimer = null
     }
-    this.flushPreReadyQueue()
+    if (this.preReadyStdinQueue.length === 0) {
+      return
+    }
+    // See POST_READY_FLUSH_DELAY_MS.
+    this.postReadyFlushPending = true
+    this.postReadyFallbackTimer = setTimeout(() => {
+      this.postReadyFallbackTimer = null
+      this.postReadyFlushPending = false
+      this.flushPreReadyQueue()
+    }, POST_READY_FLUSH_FALLBACK_MS)
   }
 
   private onShellReadyTimeout(): void {
@@ -295,10 +339,23 @@ export class Session {
   }
 
   private flushPreReadyQueue(): void {
+    this.postReadyFlushPending = false
     const queued = this.preReadyStdinQueue
     this.preReadyStdinQueue = []
     for (const data of queued) {
       this.subprocess.write(data)
+    }
+  }
+
+  private clearPostReadyTimers(): void {
+    this.postReadyFlushPending = false
+    if (this.postReadyFlushTimer) {
+      clearTimeout(this.postReadyFlushTimer)
+      this.postReadyFlushTimer = null
+    }
+    if (this.postReadyFallbackTimer) {
+      clearTimeout(this.postReadyFallbackTimer)
+      this.postReadyFallbackTimer = null
     }
   }
 
@@ -320,6 +377,7 @@ export class Session {
       clearTimeout(this.killTimer)
       this.killTimer = null
     }
+    this.clearPostReadyTimers()
 
     const clients = this.attachedClients
     this.attachedClients = []

--- a/src/main/daemon/session.ts
+++ b/src/main/daemon/session.ts
@@ -106,7 +106,11 @@ export class Session {
       return
     }
 
-    if (this._shellState === 'pending') {
+    // Why: during the post-ready flush gate window (shellState is already
+    // 'ready' but the queue hasn't flushed yet) we must keep queuing. Writing
+    // directly would let fresh input race ahead of the buffered startup
+    // command, changing execution order.
+    if (this._shellState === 'pending' || this.postReadyFlushGate.isPending) {
       this.preReadyStdinQueue.push(data)
       return
     }

--- a/src/main/daemon/terminal-host.test.ts
+++ b/src/main/daemon/terminal-host.test.ts
@@ -147,7 +147,15 @@ describe('TerminalHost', () => {
 
       expect(lastSubprocess.write).not.toHaveBeenCalled()
 
+      // Why: the marker alone no longer flushes — the kernel can still have
+      // ECHO enabled when it arrives. The flush waits for the prompt draw
+      // plus a short delay so readline has switched the PTY into raw mode
+      // first. Otherwise the command would be visibly double-echoed.
       lastSubprocess._onDataCb?.('\x1b]777;orca-shell-ready\x07')
+      expect(lastSubprocess.write).not.toHaveBeenCalled()
+
+      lastSubprocess._onDataCb?.('\r\nuser@host $ ')
+      await new Promise((r) => setTimeout(r, 40))
       expect(lastSubprocess.write).toHaveBeenCalledWith('echo hello\n')
     })
   })


### PR DESCRIPTION
## Summary

- Fixes a recent regression where launching an agent from the quick-launch menu shows the command twice (e.g. \`claude\` appears on two lines) when the daemon is enabled.
- Root cause: the daemon session flushed its pre-ready stdin queue the instant the OSC 777 shell-ready marker arrived, but that marker fires from zsh's \`precmd_functions\` / bash's \`PROMPT_COMMAND\` — *before* the shell draws its prompt and *before* zle/readline flips the PTY into raw mode. Writing while the kernel still has ECHO on produces a visible duplicate: kernel echoes the command once, then readline redraws it under the prompt.
- Fix: mirror the gating already used by the non-daemon path (\`local-pty-shell-ready.ts::writeStartupCommandWhenShellReady\`) — after the marker, wait for the next PTY data chunk (prompt draw) plus a 30ms delay, with a 50ms wall-clock fallback for when the prompt arrives in the same chunk as the marker.
- Why it became visible now: #1025 made shell-ready wrappers persist reliably in userData. Before that, the wrappers were often absent under \`tmpdir()\` and the 15s fallback fired long after the shell was in raw mode, hiding the race.

## Test plan

- [x] \`pnpm vitest run src/main/daemon/\` — all 270 tests pass, including new regression tests:
  - \`defers flush until after prompt draw + short delay\`
  - \`flushes via fallback timer if the prompt arrived in the marker chunk\`
- [x] Updated \`terminal-host.test.ts\` assertion that previously flushed immediately on the marker.
- [x] \`pnpm typecheck\` and \`pnpm exec oxlint src/main/daemon/\` pass.
- [ ] Manual: with daemon enabled, launch \`claude\` via tab-bar quick-launch menu → command appears exactly once.