### PR TITLE
fix(term): stop cold-restore from leaking CSI 997 to fresh shell

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-appearance.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-appearance.test.ts
@@ -245,11 +245,24 @@ describe('installMode2031Handlers', () => {
     // on subscribe, never on unsubscribe.
     const h = setup()
     try {
+      // Non-replay path: subscribe then unsubscribe clears state.
       await writeSync(h.term, '\x1b[?2031h')
       h.paneLastThemeMode.set(1, 'dark')
       expect(h.paneMode2031.get(1)).toBe(true)
 
       await writeSync(h.term, '\x1b[?2031l')
+      expect(h.paneMode2031.has(1)).toBe(false)
+      expect(h.paneLastThemeMode.has(1)).toBe(false)
+
+      // Replay path: resubscribe, then receive `?2031l` during a replay
+      // window. The `l` handler must still clear — this is the invariant
+      // promised by the test name.
+      await writeSync(h.term, '\x1b[?2031h')
+      h.paneLastThemeMode.set(1, 'dark')
+      expect(h.paneMode2031.get(1)).toBe(true)
+
+      replayIntoTerminal(h.pane, h.replayingPanesRef, '\x1b[?2031l')
+      await new Promise<void>((resolve) => h.term.write('', resolve))
       expect(h.paneMode2031.has(1)).toBe(false)
       expect(h.paneLastThemeMode.has(1)).toBe(false)
     } finally {

--- a/src/renderer/src/components/terminal-pane/terminal-appearance.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-appearance.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it, vi } from 'vitest'
-import { maybePushMode2031Flip, mode2031SequenceFor } from './terminal-appearance'
+import { Terminal } from '@xterm/headless'
+import type { ManagedPane } from '@/lib/pane-manager/pane-manager'
+import {
+  installMode2031Handlers,
+  maybePushMode2031Flip,
+  mode2031SequenceFor
+} from './terminal-appearance'
+import { replayIntoTerminal, type ReplayingPanesRef } from './replay-guard'
 
 function fakeTransport(overrides?: { connected?: boolean; sendOk?: boolean }): {
   isConnected: () => boolean
@@ -121,5 +128,198 @@ describe('maybePushMode2031Flip', () => {
     expect(transportB.sendInput).toHaveBeenCalledTimes(2)
     expect(last.get(1)).toBe('dark')
     expect(last.get(2)).toBe('dark')
+  })
+})
+
+describe('installMode2031Handlers', () => {
+  // Regression coverage for the "random characters on restart" bug: a restored
+  // xterm buffer may contain `CSI ?2031h` emitted by the previous session's
+  // TUI (e.g. Claude Code). Before the fix, replaying that buffer fired our
+  // CSI handler and pushed `CSI ?997;1n` into the fresh shell via
+  // transport.sendInput — zsh then echoed the literal `^[[?997;1n` onto the
+  // prompt. These tests drive a real headless xterm parser so they cover the
+  // actual parser path, not a mock.
+
+  function writeSync(term: Terminal, data: string): Promise<void> {
+    return new Promise((resolve) => term.write(data, resolve))
+  }
+
+  function makeReplayingRef(): ReplayingPanesRef {
+    return { current: new Map() } as ReplayingPanesRef
+  }
+
+  function setup(paneId = 1): {
+    term: Terminal
+    pane: ManagedPane
+    replayingPanesRef: ReplayingPanesRef
+    onSubscribe: ReturnType<typeof vi.fn>
+    paneMode2031: Map<number, boolean>
+    paneLastThemeMode: Map<number, 'dark' | 'light'>
+    dispose: () => void
+  } {
+    const term = new Terminal({ cols: 80, rows: 24, allowProposedApi: true })
+    const pane = { id: paneId, terminal: term } as unknown as ManagedPane
+    const replayingPanesRef = makeReplayingRef()
+    const paneMode2031 = new Map<number, boolean>()
+    const paneLastThemeMode = new Map<number, 'dark' | 'light'>()
+    const onSubscribe = vi.fn()
+    const disposables = installMode2031Handlers({
+      paneId,
+      parser: term.parser,
+      onSubscribe,
+      isReplaying: () => (replayingPanesRef.current.get(paneId) ?? 0) > 0,
+      paneMode2031,
+      paneLastThemeMode
+    })
+    return {
+      term,
+      pane,
+      replayingPanesRef,
+      onSubscribe,
+      paneMode2031,
+      paneLastThemeMode,
+      dispose: () => {
+        for (const d of disposables) {
+          d.dispose()
+        }
+        term.dispose()
+      }
+    }
+  }
+
+  it('records subscribe and fires onSubscribe on a live `CSI ?2031h`', async () => {
+    const h = setup()
+    try {
+      await writeSync(h.term, '\x1b[?2031h')
+      expect(h.paneMode2031.get(1)).toBe(true)
+      expect(h.onSubscribe).toHaveBeenCalledTimes(1)
+    } finally {
+      h.dispose()
+    }
+  })
+
+  it('does NOT fire onSubscribe or record state when the sequence arrives during replay', async () => {
+    // This is the regression: on cold restore the serialized xterm buffer is
+    // replayed through replayIntoTerminal, which sets the replay guard before
+    // xterm parses the bytes. The handler must skip both the push (so no
+    // CSI 997 leaks to the fresh shell) AND the bookkeeping (so a later theme
+    // flip doesn't push either).
+    const h = setup()
+    try {
+      replayIntoTerminal(h.pane, h.replayingPanesRef, '\x1b[?2031h')
+      // write() is async-ish: the guard stays engaged until the
+      // write-completion callback fires. Await parser completion.
+      await new Promise<void>((resolve) => h.term.write('', resolve))
+
+      expect(h.onSubscribe).not.toHaveBeenCalled()
+      expect(h.paneMode2031.has(1)).toBe(false)
+      expect(h.paneLastThemeMode.has(1)).toBe(false)
+      // Once the replay window closes, the pane is not marked replaying.
+      expect(h.replayingPanesRef.current.get(1) ?? 0).toBe(0)
+    } finally {
+      h.dispose()
+    }
+  })
+
+  it('still honors a real `CSI ?2031h` received after a replay window closes', async () => {
+    // If the user relaunches Claude Code after a cold restore, the real TUI
+    // emits `?2031h` itself — that must take effect normally.
+    const h = setup()
+    try {
+      replayIntoTerminal(h.pane, h.replayingPanesRef, '\x1b[?2031h')
+      await new Promise<void>((resolve) => h.term.write('', resolve))
+      expect(h.onSubscribe).not.toHaveBeenCalled()
+
+      await writeSync(h.term, '\x1b[?2031h')
+      expect(h.paneMode2031.get(1)).toBe(true)
+      expect(h.onSubscribe).toHaveBeenCalledTimes(1)
+    } finally {
+      h.dispose()
+    }
+  })
+
+  it('clears subscribe state on `CSI ?2031l` regardless of replay state', async () => {
+    // The `l` (unsubscribe) branch is intentionally not replay-guarded: a
+    // serialized buffer ending in `?2031l` means the TUI unsubscribed before
+    // shutdown, and clearing our stale bookkeeping is harmless — we only send
+    // on subscribe, never on unsubscribe.
+    const h = setup()
+    try {
+      await writeSync(h.term, '\x1b[?2031h')
+      h.paneLastThemeMode.set(1, 'dark')
+      expect(h.paneMode2031.get(1)).toBe(true)
+
+      await writeSync(h.term, '\x1b[?2031l')
+      expect(h.paneMode2031.has(1)).toBe(false)
+      expect(h.paneLastThemeMode.has(1)).toBe(false)
+    } finally {
+      h.dispose()
+    }
+  })
+
+  it('leaves unrelated DEC private modes (e.g. `?25h` cursor show) to xterm', async () => {
+    // Why: we return `false` from both handlers so compound sequences and
+    // unrelated modes still go through xterm's built-in handler. If a future
+    // refactor accidentally returned `true`, cursor visibility would desync.
+    const h = setup()
+    try {
+      await writeSync(h.term, '\x1b[?25l') // hide cursor
+      expect(h.term.options.cursorBlink).toBeDefined() // sanity: xterm responsive
+      expect(h.onSubscribe).not.toHaveBeenCalled()
+      expect(h.paneMode2031.has(1)).toBe(false)
+    } finally {
+      h.dispose()
+    }
+  })
+
+  it('keeps per-pane state isolated when two panes share the parser API', async () => {
+    // Each pane registers its own handlers on its own xterm parser, but the
+    // subscribe bookkeeping map is shared across panes. A replay on pane 1
+    // must not leak into pane 2's live subscribe.
+    const shared2031 = new Map<number, boolean>()
+    const sharedLast = new Map<number, 'dark' | 'light'>()
+    const replayingPanesRef = makeReplayingRef()
+
+    const term1 = new Terminal({ cols: 80, rows: 24, allowProposedApi: true })
+    const term2 = new Terminal({ cols: 80, rows: 24, allowProposedApi: true })
+    const pane1 = { id: 1, terminal: term1 } as unknown as ManagedPane
+    const onSub1 = vi.fn()
+    const onSub2 = vi.fn()
+
+    const d1 = installMode2031Handlers({
+      paneId: 1,
+      parser: term1.parser,
+      onSubscribe: onSub1,
+      isReplaying: () => (replayingPanesRef.current.get(1) ?? 0) > 0,
+      paneMode2031: shared2031,
+      paneLastThemeMode: sharedLast
+    })
+    const d2 = installMode2031Handlers({
+      paneId: 2,
+      parser: term2.parser,
+      onSubscribe: onSub2,
+      isReplaying: () => (replayingPanesRef.current.get(2) ?? 0) > 0,
+      paneMode2031: shared2031,
+      paneLastThemeMode: sharedLast
+    })
+
+    try {
+      // Replay on pane 1 must not subscribe.
+      replayIntoTerminal(pane1, replayingPanesRef, '\x1b[?2031h')
+      await new Promise<void>((resolve) => term1.write('', resolve))
+      expect(onSub1).not.toHaveBeenCalled()
+      expect(shared2031.has(1)).toBe(false)
+
+      // Live on pane 2 must subscribe normally.
+      await writeSync(term2, '\x1b[?2031h')
+      expect(onSub2).toHaveBeenCalledTimes(1)
+      expect(shared2031.get(2)).toBe(true)
+    } finally {
+      for (const d of [...d1, ...d2]) {
+        d.dispose()
+      }
+      term1.dispose()
+      term2.dispose()
+    }
   })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-appearance.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-appearance.test.ts
@@ -257,18 +257,54 @@ describe('installMode2031Handlers', () => {
     }
   })
 
-  it('leaves unrelated DEC private modes (e.g. `?25h` cursor show) to xterm', async () => {
-    // Why: we return `false` from both handlers so compound sequences and
-    // unrelated modes still go through xterm's built-in handler. If a future
-    // refactor accidentally returned `true`, cursor visibility would desync.
-    const h = setup()
+  it('returns `false` so compound DEC private modes still reach xterm', async () => {
+    // Why: we return `false` from both handlers so compound sequences like
+    // `CSI ?25;2031h` still go through xterm's built-in DEC private mode
+    // handler. If a future refactor accidentally returned `true`, cursor
+    // visibility (and any other unrelated mode sharing the sequence) would
+    // desync. xterm's public API does not expose cursor visibility, so assert
+    // the handler's return value directly via a spy wrapping the real parser.
+    const term = new Terminal({ cols: 80, rows: 24, allowProposedApi: true })
+    const paneMode2031 = new Map<number, boolean>()
+    const paneLastThemeMode = new Map<number, 'dark' | 'light'>()
+    const onSubscribe = vi.fn()
+    const returnValues: boolean[] = []
+    // Why the cast: the headless parser's registerCsiHandler callback
+    // returns just `boolean`, but our `Mode2031Parser` type reflects xterm's
+    // canonical `boolean | Promise<boolean>` signature. The spy wraps the
+    // real parser and synchronously records whatever the wrapped handler
+    // returned; in this codebase all mode-2031 handlers are synchronous.
+    const spyParser: Parameters<typeof installMode2031Handlers>[0]['parser'] = {
+      registerCsiHandler: (id, cb) =>
+        term.parser.registerCsiHandler(id, (params) => {
+          const r = cb(params) as boolean
+          returnValues.push(r)
+          return r
+        })
+    }
+    const disposables = installMode2031Handlers({
+      paneId: 1,
+      parser: spyParser,
+      onSubscribe,
+      isReplaying: () => false,
+      paneMode2031,
+      paneLastThemeMode
+    })
     try {
-      await writeSync(h.term, '\x1b[?25l') // hide cursor
-      expect(h.term.options.cursorBlink).toBeDefined() // sanity: xterm responsive
-      expect(h.onSubscribe).not.toHaveBeenCalled()
-      expect(h.paneMode2031.has(1)).toBe(false)
+      // Compound: ?25 (cursor show) + ?2031 (color-scheme subscribe).
+      await writeSync(term, '\x1b[?25;2031h')
+      // Our 2031 recording fired:
+      expect(paneMode2031.get(1)).toBe(true)
+      expect(onSubscribe).toHaveBeenCalledTimes(1)
+      // And every invocation of our handler returned `false`, so xterm's
+      // built-in DEC private mode handler still processes the sequence.
+      expect(returnValues.length).toBeGreaterThan(0)
+      expect(returnValues.every((v) => v === false)).toBe(true)
     } finally {
-      h.dispose()
+      for (const d of disposables) {
+        d.dispose()
+      }
+      term.dispose()
     }
   })
 

--- a/src/renderer/src/components/terminal-pane/terminal-appearance.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-appearance.ts
@@ -1,4 +1,4 @@
-import type { IDisposable, ITheme } from '@xterm/xterm'
+import type { IDisposable, IParser, ITheme } from '@xterm/xterm'
 import type { PaneManager } from '@/lib/pane-manager/pane-manager'
 import type { GlobalSettings } from '../../../../shared/types'
 import { resolveTerminalFontWeights } from '../../../../shared/terminal-fonts'
@@ -21,12 +21,11 @@ export function mode2031SequenceFor(mode: 'dark' | 'light'): string {
   return mode === 'dark' ? '\x1b[?997;1n' : '\x1b[?997;2n'
 }
 
-type Mode2031Parser = {
-  registerCsiHandler(
-    id: { prefix?: string; final: string },
-    callback: (params: (number | number[])[]) => boolean | Promise<boolean>
-  ): IDisposable
-}
+// Why Pick<IParser, ...> over a hand-rolled structural type: keeps the helper
+// tied to xterm's canonical signature so any upstream tightening (added
+// fields on IFunctionIdentifier, narrower param type) surfaces here instead
+// of silently accepting a stale shape.
+type Mode2031Parser = Pick<IParser, 'registerCsiHandler'>
 
 type Mode2031HandlerDeps = {
   paneId: number
@@ -67,6 +66,18 @@ export function installMode2031Handlers(deps: Mode2031HandlerDeps): IDisposable[
         // the fresh shell is not actually subscribed, so a later theme flip
         // must not push either. A real TUI that starts up after restore will
         // re-emit `?2031h` itself and register normally.
+        //
+        // Why this broad guard is safe across all replay sources: the only
+        // replay path that can carry raw `?2031h` is cold-restore scrollback
+        // (pty-connection.ts), which is disk-replayed PTY output against a
+        // fresh shell — the case this guard targets. Daemon snapshot payloads
+        // (`rehydrateSequences + SerializeAddon.serialize()`) and persisted
+        // scrollback (`SerializeAddon.serialize()`) never contain `?2031`:
+        // SerializeAddon's _serializeModes whitelists only ?1h/?66h/?2004h/
+        // [4h/?6h/?45h/?1004h/?7l/mouse modes/?25l, and buildRehydrateSequences
+        // emits only ?2004h/?1h/?1049h. If xterm ever adds ?2031 to that
+        // whitelist, this guard would start suppressing legitimate
+        // subscribes during snapshot reattach — revisit then.
         if (deps.isReplaying()) {
           return false
         }

--- a/src/renderer/src/components/terminal-pane/terminal-appearance.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-appearance.ts
@@ -86,6 +86,10 @@ export function installMode2031Handlers(deps: Mode2031HandlerDeps): IDisposable[
       }
       return false
     }),
+    // Why no replay guard on the unsubscribe branch: clearing stale bookkeeping
+    // is harmless. We only push CSI 997 on subscribe, never on unsubscribe, so
+    // even if a cold-restore replay carries `?2031l`, this handler just deletes
+    // map entries that a later real `?2031h` will re-populate normally.
     deps.parser.registerCsiHandler({ prefix: '?', final: 'l' }, (params) => {
       if (hasMode2031(params)) {
         deps.paneMode2031.delete(deps.paneId)

--- a/src/renderer/src/components/terminal-pane/terminal-appearance.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-appearance.ts
@@ -1,4 +1,4 @@
-import type { ITheme } from '@xterm/xterm'
+import type { IDisposable, ITheme } from '@xterm/xterm'
 import type { PaneManager } from '@/lib/pane-manager/pane-manager'
 import type { GlobalSettings } from '../../../../shared/types'
 import { resolveTerminalFontWeights } from '../../../../shared/terminal-fonts'
@@ -19,6 +19,70 @@ import type { EffectiveMacOptionAsAlt } from '@/lib/keyboard-layout/detect-optio
 // lifecycle hook cannot drift.
 export function mode2031SequenceFor(mode: 'dark' | 'light'): string {
   return mode === 'dark' ? '\x1b[?997;1n' : '\x1b[?997;2n'
+}
+
+type Mode2031Parser = {
+  registerCsiHandler(
+    id: { prefix?: string; final: string },
+    callback: (params: (number | number[])[]) => boolean | Promise<boolean>
+  ): IDisposable
+}
+
+type Mode2031HandlerDeps = {
+  paneId: number
+  parser: Mode2031Parser
+  /** Called when a real (non-replayed) `CSI ?2031h` arrives, after the
+   *  subscribe flag has been set. Kept as a callback so the lifecycle hook
+   *  can keep its transport-aware `pushMode2031ForPane` closure intact. */
+  onSubscribe: () => void
+  isReplaying: () => boolean
+  paneMode2031: Map<number, boolean>
+  paneLastThemeMode: Map<number, 'dark' | 'light'>
+}
+
+// Why split out from the lifecycle hook: the CSI handlers are the defense
+// against a restored xterm buffer pushing `\x1b[?997;1n` into the fresh zsh
+// on cold restore (the "random characters on restart" bug). Keeping them in
+// a pure function lets the tests drive a real xterm parser end-to-end so we
+// catch regressions in the parser-path guard, not just a mock.
+export function installMode2031Handlers(deps: Mode2031HandlerDeps): IDisposable[] {
+  const hasMode2031 = (params: (number | number[])[]): boolean =>
+    params.some((p) => (Array.isArray(p) ? p.includes(2031) : p === 2031))
+
+  // Why return false from both handlers: we only observe mode 2031.
+  // Returning false lets xterm's built-in DEC private mode handler
+  // continue processing the same sequence, so compound sequences like
+  // `CSI ?25;2031h` still update cursor visibility correctly.
+  return [
+    deps.parser.registerCsiHandler({ prefix: '?', final: 'h' }, (params) => {
+      if (hasMode2031(params)) {
+        // Why: a restored xterm buffer may contain `CSI ?2031h` emitted by
+        // the previous session's TUI (e.g. Claude Code). Replaying that
+        // buffer runs this handler, and without the guard we'd push
+        // `CSI ?997;1n` via transport.sendInput into a fresh shell that has
+        // no TUI consuming it — zsh then echoes the literal escape sequence
+        // onto the prompt. The replay guard in pty-connection.ts only covers
+        // xterm's own onData auto-replies, not handler-triggered sends, so
+        // gate explicitly here. We also skip recording the subscribe bit:
+        // the fresh shell is not actually subscribed, so a later theme flip
+        // must not push either. A real TUI that starts up after restore will
+        // re-emit `?2031h` itself and register normally.
+        if (deps.isReplaying()) {
+          return false
+        }
+        deps.paneMode2031.set(deps.paneId, true)
+        deps.onSubscribe()
+      }
+      return false
+    }),
+    deps.parser.registerCsiHandler({ prefix: '?', final: 'l' }, (params) => {
+      if (hasMode2031(params)) {
+        deps.paneMode2031.delete(deps.paneId)
+        deps.paneLastThemeMode.delete(deps.paneId)
+      }
+      return false
+    })
+  ]
 }
 
 // Gate on actual mode flip so font/size/opacity tweaks — which also re-run

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -23,13 +23,17 @@ import {
   restoreScrollbackBuffers
 } from './layout-serialization'
 import { applyExpandedLayoutTo, restoreExpandedLayoutFrom } from './expand-collapse'
-import { applyTerminalAppearance, mode2031SequenceFor } from './terminal-appearance'
+import {
+  applyTerminalAppearance,
+  installMode2031Handlers,
+  mode2031SequenceFor
+} from './terminal-appearance'
 import { parseOsc52 } from './osc52-clipboard'
 import type { EffectiveMacOptionAsAlt } from '@/lib/keyboard-layout/detect-option-as-alt'
 import { resolveEffectiveTerminalAppearance } from '@/lib/terminal-theme'
 import { connectPanePty } from './pty-connection'
 import type { PtyTransport } from './pty-transport'
-import type { ReplayingPanesRef } from './replay-guard'
+import { isPaneReplaying, type ReplayingPanesRef } from './replay-guard'
 import { fitAndFocusPanes, fitPanes } from './pane-helpers'
 import { registerRuntimeTerminalTab, scheduleRuntimeGraphSync } from '@/runtime/sync-runtime-graph'
 import { e2eConfig } from '@/lib/e2e-config'
@@ -336,29 +340,14 @@ export function useTerminalPaneLifecycle({
       onPaneCreated: (pane) => {
         // Install mode 2031 parser handlers before PTY attach so the child's
         // initial CSI ?2031h (sent at startup) is captured.
-        const parser = pane.terminal.parser
-        const hasMode2031 = (params: (number | number[])[]): boolean =>
-          params.some((p) => (Array.isArray(p) ? p.includes(2031) : p === 2031))
-        // Why return false from both handlers: we only observe mode 2031.
-        // Returning false lets xterm's built-in DEC private mode handler
-        // continue processing the same sequence, so compound sequences like
-        // `CSI ?25;2031h` still update cursor visibility correctly.
-        const mode2031Disposables: IDisposable[] = [
-          parser.registerCsiHandler({ prefix: '?', final: 'h' }, (params) => {
-            if (hasMode2031(params)) {
-              paneMode2031Ref.current.set(pane.id, true)
-              pushMode2031ForPane(pane.id)
-            }
-            return false
-          }),
-          parser.registerCsiHandler({ prefix: '?', final: 'l' }, (params) => {
-            if (hasMode2031(params)) {
-              paneMode2031Ref.current.delete(pane.id)
-              paneLastThemeModeRef.current.delete(pane.id)
-            }
-            return false
-          })
-        ]
+        const mode2031Disposables = installMode2031Handlers({
+          paneId: pane.id,
+          parser: pane.terminal.parser,
+          onSubscribe: () => pushMode2031ForPane(pane.id),
+          isReplaying: () => isPaneReplaying(replayingPanesRef, pane.id),
+          paneMode2031: paneMode2031Ref.current,
+          paneLastThemeMode: paneLastThemeModeRef.current
+        })
         mode2031DisposablesRef.current.set(pane.id, mode2031Disposables)
 
         // OSC 52 — TUI-initiated clipboard writes (tmux/nvim/fzf/ssh).


### PR DESCRIPTION
## Summary

- On cold restore, the replayed xterm buffer can contain `CSI ?2031h` left by the previous session's TUI (e.g. Claude Code). Our mode-2031 CSI handler fired during replay and pushed `CSI ?997;1n` via `transport.sendInput` into the freshly spawned zsh, which echoed the literal escape sequence onto the prompt — surfacing as `^[[?997;1n%` on the restored shell. Symptom from the user's perspective: the `--- session restored ---` banner appeared but the prompt was dirtied with garbage characters, making it look like the session hadn't actually restored even though the scrollback write at `pty-connection.ts:463` had already run.
- The existing replay guard only covers xterm's `onData` auto-replies, not handler-triggered sends. Gate the push explicitly in the handler and skip recording the subscribe bit during replay; a real TUI starting up after restore re-emits `?2031h` itself and registers normally.
- Refactored the handler installation out of `onPaneCreated` into a pure `installMode2031Handlers` helper so the parser-path behavior is directly unit-testable.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm vitest run src/renderer/src/components/terminal-pane` — 135/135 pass
- [x] New regression tests in `terminal-appearance.test.ts` drive a real `@xterm/headless` parser through `replayIntoTerminal` and assert no push fires; verified they fail when the `isReplaying()` guard is removed (mutation-validated).
- [x] Manual repro on cold restore: launched Claude Code in a pane with the terminal daemon enabled, force-quit Orca via Activity Monitor (to keep `meta.endedAt = null`), relaunched — `--- session restored ---` banner appears with the restored scrollback above it and a clean zsh prompt with no `^[[?997;1n` garbage.