### PR TITLE
fix(sidebar): keep worktree spinner working while any split pane is active

### DIFF
--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -138,6 +138,11 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
   const allWorktrees = useAllWorktrees()
   const repos = useAppStore((s) => s.repos)
   const tabsByWorktree = useAppStore((s) => s.tabsByWorktree)
+  // Why: getWorktreeStatus needs per-pane titles so split-pane tabs with a
+  // working agent in a non-focused pane still surface as 'working' in the
+  // jump palette. Without this, clicking between panes would desync the
+  // palette's spinner from the sidebar's spinner.
+  const runtimePaneTitlesByTabId = useAppStore((s) => s.runtimePaneTitlesByTabId)
   const prCache = useAppStore((s) => s.prCache)
   const issueCache = useAppStore((s) => s.issueCache)
   const activeWorktreeId = useAppStore((s) => s.activeWorktreeId)
@@ -701,7 +706,8 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
                 const branch = branchName(worktree.branch)
                 const status = getWorktreeStatus(
                   tabsByWorktree[worktree.id] ?? [],
-                  browserTabsByWorktree[worktree.id] ?? []
+                  browserTabsByWorktree[worktree.id] ?? [],
+                  runtimePaneTitlesByTabId
                 )
                 const statusLabel = getWorktreeStatusLabel(status)
                 const isCurrentWorktree = activeWorktreeId === worktree.id

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useCallback, useState } from 'react'
+import { useShallow } from 'zustand/react/shallow'
 import { useAppStore } from '@/store'
 import { Badge } from '@/components/ui/badge'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
@@ -102,6 +103,24 @@ const WorktreeCard = React.memo(function WorktreeCard({
   // ── GRANULAR selectors: only subscribe to THIS worktree's data ──
   const tabs = useAppStore((s) => s.tabsByWorktree[worktree.id] ?? EMPTY_TABS)
   const browserTabs = useAppStore((s) => s.browserTabsByWorktree[worktree.id] ?? EMPTY_BROWSER_TABS)
+  // Why: split-pane tabs expose per-pane titles that the aggregate
+  // `tab.title` does not preserve (onActivePaneChange overwrites it with the
+  // focused pane's title). getWorktreeStatus needs those pane titles to keep
+  // the sidebar spinner reflecting *any* working pane, not just the focused
+  // one. Narrow the subscription to this worktree's tabs via useShallow so
+  // unrelated pane-title updates do not re-render every sidebar card.
+  const runtimePaneTitlesForWorktree = useAppStore(
+    useShallow((s) => {
+      const out: Record<string, Record<number, string>> = {}
+      for (const tab of s.tabsByWorktree[worktree.id] ?? []) {
+        const paneTitles = s.runtimePaneTitlesByTabId[tab.id]
+        if (paneTitles) {
+          out[tab.id] = paneTitles
+        }
+      }
+      return out
+    })
+  )
 
   const branch = branchDisplayName(worktree.branch)
   const isFolder = repo ? isFolderRepo(repo) : false
@@ -123,8 +142,8 @@ const WorktreeCard = React.memo(function WorktreeCard({
 
   // Derive status
   const status: WorktreeStatus = useMemo(
-    () => getWorktreeStatus(tabs, browserTabs),
-    [tabs, browserTabs]
+    () => getWorktreeStatus(tabs, browserTabs, runtimePaneTitlesForWorktree),
+    [tabs, browserTabs, runtimePaneTitlesForWorktree]
   )
 
   const showPR = cardProps.includes('pr')

--- a/src/renderer/src/lib/worktree-status.test.ts
+++ b/src/renderer/src/lib/worktree-status.test.ts
@@ -5,8 +5,8 @@ describe('worktree-status', () => {
   it('prioritizes permission over other live activity states', () => {
     const status = getWorktreeStatus(
       [
-        { ptyId: 'pty-working', title: 'claude [working]' },
-        { ptyId: 'pty-permission', title: 'claude [permission]' }
+        { id: 'tab-1', ptyId: 'pty-working', title: 'claude [working]' },
+        { id: 'tab-2', ptyId: 'pty-permission', title: 'claude [permission]' }
       ],
       [{ id: 'browser-1' }]
     )
@@ -23,5 +23,29 @@ describe('worktree-status', () => {
 
   it('returns inactive when neither tabs nor browser state are live', () => {
     expect(getWorktreeStatus([], [])).toBe('inactive')
+  })
+
+  it('reports working when any pane in a split-pane tab is working even if tab.title is idle', () => {
+    // Regression: clicking between split panes rewrites tab.title to the
+    // focused pane's title (see onActivePaneChange in
+    // use-terminal-pane-lifecycle.ts). If the focused pane is idle while
+    // another pane is still working, the sidebar spinner must stay spinning.
+    const status = getWorktreeStatus(
+      [{ id: 'tab-1', ptyId: 'pty-1', title: 'claude [done]' }],
+      [],
+      { 'tab-1': { 0: 'codex [working]', 1: 'claude [done]' } }
+    )
+
+    expect(status).toBe('working')
+  })
+
+  it('prefers pane-level permission status over tab.title', () => {
+    const status = getWorktreeStatus(
+      [{ id: 'tab-1', ptyId: 'pty-1', title: 'claude [done]' }],
+      [],
+      { 'tab-1': { 0: 'claude [permission]', 1: 'claude [done]' } }
+    )
+
+    expect(status).toBe('permission')
   })
 })

--- a/src/renderer/src/lib/worktree-status.ts
+++ b/src/renderer/src/lib/worktree-status.ts
@@ -11,14 +11,27 @@ const STATUS_LABELS: Record<WorktreeStatus, string> = {
 }
 
 export function getWorktreeStatus(
-  tabs: Pick<TerminalTab, 'ptyId' | 'title'>[],
-  browserTabs: { id: string }[]
+  tabs: Pick<TerminalTab, 'id' | 'ptyId' | 'title'>[],
+  browserTabs: { id: string }[],
+  runtimePaneTitlesByTabId: Record<string, Record<number, string>> = {}
 ): WorktreeStatus {
   const liveTabs = tabs.filter((tab) => tab.ptyId)
-  if (liveTabs.some((tab) => detectAgentStatusFromTitle(tab.title) === 'permission')) {
+
+  // Why: a split-pane tab can host multiple concurrent agents, but `tab.title`
+  // only reflects the most-recently-focused pane (see onActivePaneChange in
+  // use-terminal-pane-lifecycle.ts). Reading just `tab.title` causes the
+  // sidebar spinner to follow the focused pane instead of the aggregate tab
+  // state — e.g. clicking an idle Claude pane while Codex is still working in
+  // another pane would collapse the spinner to solid green. Consult per-pane
+  // titles first (same pattern as countWorkingAgentsForTab) and only fall back
+  // to `tab.title` for tabs that have no mounted panes yet.
+  const hasStatus = (status: 'permission' | 'working'): boolean =>
+    liveTabs.some((tab) => tabHasStatus(tab, runtimePaneTitlesByTabId, status))
+
+  if (hasStatus('permission')) {
     return 'permission'
   }
-  if (liveTabs.some((tab) => detectAgentStatusFromTitle(tab.title) === 'working')) {
+  if (hasStatus('working')) {
     return 'working'
   }
   if (liveTabs.length > 0 || browserTabs.length > 0) {
@@ -29,6 +42,23 @@ export function getWorktreeStatus(
     return 'active'
   }
   return 'inactive'
+}
+
+function tabHasStatus(
+  tab: Pick<TerminalTab, 'id' | 'title'>,
+  runtimePaneTitlesByTabId: Record<string, Record<number, string>>,
+  status: 'permission' | 'working'
+): boolean {
+  const paneTitles = runtimePaneTitlesByTabId[tab.id]
+  if (paneTitles && Object.keys(paneTitles).length > 0) {
+    for (const title of Object.values(paneTitles)) {
+      if (detectAgentStatusFromTitle(title) === status) {
+        return true
+      }
+    }
+    return false
+  }
+  return detectAgentStatusFromTitle(tab.title) === status
 }
 
 export function getWorktreeStatusLabel(status: WorktreeStatus): string {


### PR DESCRIPTION
## Summary
- `getWorktreeStatus()` derived the sidebar/jump-palette dot solely from `tab.title`, but `onActivePaneChange` in `use-terminal-pane-lifecycle.ts` rewrites `tab.title` to the focused pane's title. With Codex working in one split pane and an idle Claude in another, clicking the Claude pane overwrote `tab.title` and collapsed the spinner to solid green even though Codex was still running.
- Threaded per-pane titles (already maintained in `runtimePaneTitlesByTabId` and used by `countWorkingAgentsForTab`) through `getWorktreeStatus`. The sidebar `WorktreeCard` subscribes via a shallow selector scoped to this worktree's tabs; `WorktreeJumpPalette` passes the map in too.
- Pane-level statuses now take precedence over `tab.title` for both `working` and `permission`, falling back to `tab.title` only for tabs whose panes aren't mounted yet.

## Test plan
- [x] `pnpm exec vitest run src/renderer/src/lib/worktree-status.test.ts src/renderer/src/components/sidebar/WorktreeCard.test.ts` (7 tests pass, incl. two new regression cases)
- [x] `pnpm exec tsc --noEmit -p config/tsconfig.web.json --composite false`
- [x] `pnpm exec oxlint` on changed files (0 warnings)
- [ ] Manual repro in Electron: split a terminal, start Codex in pane A, let Claude finish in pane B; click pane B and confirm the sidebar spinner keeps spinning until Codex also finishes