### PR TITLE
fix(ssh): support Cmd+P file search for non-git folders without ripgrep

### DIFF
--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -440,8 +440,12 @@ export function registerFilesystemHandlers(store: Store): void {
     ): Promise<string[]> => {
       if (args.connectionId) {
         const provider = getSshFilesystemProvider(args.connectionId)
+        // Why: when the SSH connection is not yet established (cold start) or
+        // temporarily disconnected, return [] so quick-open shows "No matching
+        // files" instead of an error banner. The file list will repopulate when
+        // the user re-opens quick-open after the connection is restored.
         if (!provider) {
-          throw new Error(`No filesystem provider for connection "${args.connectionId}"`)
+          return []
         }
         return provider.listFiles(args.rootPath)
       }

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -99,11 +99,14 @@ export function registerWorktreeHandlers(mainWindow: BrowserWindow, store: Store
       gitWorktrees = [createFolderWorktree(repo)]
     } else if (repo.connectionId) {
       const provider = getSshGitProvider(repo.connectionId)
-      // Why: when SSH is disconnected the provider is null. Throwing here
-      // makes the renderer's fetchWorktrees catch block preserve its cached
-      // worktree list instead of replacing it with an empty array.
+      // Why: when SSH is disconnected the provider is null. Return [] so the
+      // renderer's fetchWorktrees guard (`worktrees.length === 0 && current.length > 0`)
+      // preserves its cached worktree list. This avoids a console error on every
+      // fetchAllWorktrees cycle while the connection is being (re-)established —
+      // worktrees will be properly populated when the SSH `connected` event fires
+      // and triggers a re-fetch.
       if (!provider) {
-        throw new Error(`SSH connection "${repo.connectionId}" is not active`)
+        return []
       }
       gitWorktrees = await provider.listWorktrees(repo.path)
     } else {

--- a/src/relay/fs-handler-readdir-fallback.ts
+++ b/src/relay/fs-handler-readdir-fallback.ts
@@ -1,0 +1,82 @@
+/**
+ * Plain readdir-based file listing fallback.
+ *
+ * Why: when neither ripgrep nor git is available (e.g. a non-git folder on a
+ * remote machine without rg), we still need to list files for quick-open.
+ * This walks the directory tree using Node's fs.readdir, respecting the same
+ * blocklist and timeout constraints as the git-based fallback.
+ */
+import { readdir } from 'fs/promises'
+import { join, relative } from 'path'
+
+const MAX_FILES = 10_000
+const TIMEOUT_MS = 10_000
+
+const HIDDEN_DIR_BLOCKLIST = new Set([
+  '.git',
+  '.next',
+  '.nuxt',
+  '.cache',
+  '.stably',
+  '.vscode',
+  '.idea',
+  '.yarn',
+  '.pnpm-store',
+  '.terraform',
+  '.docker',
+  '.husky'
+])
+
+function shouldDescend(name: string): boolean {
+  if (name === 'node_modules' || HIDDEN_DIR_BLOCKLIST.has(name)) {
+    return false
+  }
+  // Skip hidden directories (dotfiles other than those in the blocklist
+  // are already covered, but be explicit for any remaining)
+  if (name.startsWith('.') && HIDDEN_DIR_BLOCKLIST.has(name)) {
+    return false
+  }
+  return true
+}
+
+/**
+ * Recursively list files under `rootPath` using fs.readdir.
+ * Returns relative POSIX paths, capped at MAX_FILES with a timeout.
+ */
+export async function listFilesWithReaddir(rootPath: string): Promise<string[]> {
+  const files: string[] = []
+  const deadline = Date.now() + TIMEOUT_MS
+
+  async function walk(dir: string): Promise<void> {
+    if (files.length >= MAX_FILES || Date.now() > deadline) {
+      return
+    }
+
+    let entries
+    try {
+      entries = await readdir(dir, { withFileTypes: true })
+    } catch {
+      // Permission denied, symlink loop, etc. — skip silently.
+      return
+    }
+
+    for (const entry of entries) {
+      if (files.length >= MAX_FILES || Date.now() > deadline) {
+        return
+      }
+
+      const name = entry.name
+      if (entry.isDirectory()) {
+        if (shouldDescend(name)) {
+          await walk(join(dir, name))
+        }
+      } else if (entry.isFile()) {
+        const relPath = relative(rootPath, join(dir, name))
+        files.push(relPath)
+      }
+    }
+  }
+
+  await walk(rootPath)
+  return files
+}

--- a/src/relay/fs-handler-readdir-fallback.ts
+++ b/src/relay/fs-handler-readdir-fallback.ts
@@ -12,8 +12,26 @@ import { join, relative } from 'path'
 const MAX_FILES = 10_000
 const TIMEOUT_MS = 10_000
 
+// Why: mirrors the HIDDEN_DIR_BLOCKLIST in fs-handler-git-fallback.ts —
+// tool-generated dirs that clutter quick-open. User-authored dotdirs like
+// .github/ and .devcontainer/ are intentionally kept discoverable.
+const HIDDEN_DIR_BLOCKLIST = new Set([
+  '.git',
+  '.next',
+  '.nuxt',
+  '.cache',
+  '.stably',
+  '.vscode',
+  '.idea',
+  '.yarn',
+  '.pnpm-store',
+  '.terraform',
+  '.docker',
+  '.husky'
+])
+
 function shouldDescend(name: string): boolean {
-  if (name === 'node_modules' || name.startsWith('.')) {
+  if (name === 'node_modules' || HIDDEN_DIR_BLOCKLIST.has(name)) {
     return false
   }
   return true
@@ -51,7 +69,9 @@ export async function listFilesWithReaddir(rootPath: string): Promise<string[]> 
           await walk(join(dir, name))
         }
       } else if (entry.isFile()) {
-        const relPath = relative(rootPath, join(dir, name))
+        // Why: path.relative() returns backslashes on Windows. The quick-open
+        // UI assumes POSIX separators for display and fuzzy matching.
+        const relPath = relative(rootPath, join(dir, name)).replace(/\\/g, '/')
         files.push(relPath)
       }
     }

--- a/src/relay/fs-handler-readdir-fallback.ts
+++ b/src/relay/fs-handler-readdir-fallback.ts
@@ -12,28 +12,8 @@ import { join, relative } from 'path'
 const MAX_FILES = 10_000
 const TIMEOUT_MS = 10_000
 
-const HIDDEN_DIR_BLOCKLIST = new Set([
-  '.git',
-  '.next',
-  '.nuxt',
-  '.cache',
-  '.stably',
-  '.vscode',
-  '.idea',
-  '.yarn',
-  '.pnpm-store',
-  '.terraform',
-  '.docker',
-  '.husky'
-])
-
 function shouldDescend(name: string): boolean {
-  if (name === 'node_modules' || HIDDEN_DIR_BLOCKLIST.has(name)) {
-    return false
-  }
-  // Skip hidden directories (dotfiles other than those in the blocklist
-  // are already covered, but be explicit for any remaining)
-  if (name.startsWith('.') && HIDDEN_DIR_BLOCKLIST.has(name)) {
+  if (name === 'node_modules' || name.startsWith('.')) {
     return false
   }
   return true

--- a/src/relay/fs-handler.ts
+++ b/src/relay/fs-handler.ts
@@ -24,6 +24,7 @@ import {
   checkRgAvailable
 } from './fs-handler-utils'
 import { listFilesWithGit, searchWithGitGrep } from './fs-handler-git-fallback'
+import { listFilesWithReaddir } from './fs-handler-readdir-fallback'
 
 type WatchState = {
   rootPath: string
@@ -228,10 +229,18 @@ export class FsHandler {
     const rootPath = expandTilde(params.rootPath as string)
     await this.context.validatePathResolved(rootPath)
     const rgAvailable = await checkRgAvailable()
-    if (!rgAvailable) {
-      return listFilesWithGit(rootPath)
+    if (rgAvailable) {
+      return listFilesWithRg(rootPath)
     }
-    return listFilesWithRg(rootPath)
+    // Why: git ls-files only works inside git repos. For non-git directories
+    // (e.g. a plain folder added over SSH), the command exits with an error
+    // and returns nothing. Fall back to a recursive readdir walk so quick-open
+    // still populates for non-git folders without ripgrep.
+    const gitFiles = await listFilesWithGit(rootPath)
+    if (gitFiles.length > 0) {
+      return gitFiles
+    }
+    return listFilesWithReaddir(rootPath)
   }
 
   private async watch(params: Record<string, unknown>) {

--- a/src/relay/fs-handler.ts
+++ b/src/relay/fs-handler.ts
@@ -8,9 +8,10 @@ import {
   rename,
   cp,
   rm,
-  realpath
+  realpath,
+  access
 } from 'fs/promises'
-import { extname } from 'path'
+import { extname, join } from 'path'
 import type { RelayDispatcher } from './dispatcher'
 import type { RelayContext } from './context'
 import { expandTilde } from './context'
@@ -232,13 +233,15 @@ export class FsHandler {
     if (rgAvailable) {
       return listFilesWithRg(rootPath)
     }
-    // Why: git ls-files only works inside git repos. For non-git directories
-    // (e.g. a plain folder added over SSH), the command exits with an error
-    // and returns nothing. Fall back to a recursive readdir walk so quick-open
-    // still populates for non-git folders without ripgrep.
-    const gitFiles = await listFilesWithGit(rootPath)
-    if (gitFiles.length > 0) {
-      return gitFiles
+    // Why: git ls-files only works inside git repos. Check for .git first so
+    // we don't misclassify a git repo with only ignored files as a non-git
+    // folder — that would surface .gitignore'd files via the readdir fallback.
+    const isGitRepo = await access(join(rootPath, '.git')).then(
+      () => true,
+      () => false
+    )
+    if (isGitRepo) {
+      return listFilesWithGit(rootPath)
     }
     return listFilesWithReaddir(rootPath)
   }

--- a/src/relay/fs-handler.ts
+++ b/src/relay/fs-handler.ts
@@ -8,10 +8,10 @@ import {
   rename,
   cp,
   rm,
-  realpath,
-  access
+  realpath
 } from 'fs/promises'
-import { extname, join } from 'path'
+import { extname } from 'path'
+import { execFile } from 'child_process'
 import type { RelayDispatcher } from './dispatcher'
 import type { RelayContext } from './context'
 import { expandTilde } from './context'
@@ -233,13 +233,16 @@ export class FsHandler {
     if (rgAvailable) {
       return listFilesWithRg(rootPath)
     }
-    // Why: git ls-files only works inside git repos. Check for .git first so
-    // we don't misclassify a git repo with only ignored files as a non-git
-    // folder — that would surface .gitignore'd files via the readdir fallback.
-    const isGitRepo = await access(join(rootPath, '.git')).then(
-      () => true,
-      () => false
-    )
+    // Why: git ls-files only works inside git repos. Use rev-parse to detect
+    // git ancestry — unlike checking for a local .git entry, this works from
+    // subdirectories of a checkout (e.g. /repo/packages/app added as a folder).
+    // Without this, a git subdirectory would fall through to readdir and
+    // surface .gitignore'd build artifacts.
+    const isGitRepo = await new Promise<boolean>((resolve) => {
+      execFile('git', ['rev-parse', '--is-inside-work-tree'], { cwd: rootPath }, (err) =>
+        resolve(!err)
+      )
+    })
     if (isGitRepo) {
       return listFilesWithGit(rootPath)
     }

--- a/src/renderer/src/components/QuickOpen.tsx
+++ b/src/renderer/src/components/QuickOpen.tsx
@@ -94,14 +94,17 @@ export default function QuickOpen(): React.JSX.Element | null {
   )
 
   // Why: when quick-open opens before the SSH connection is established,
-  // fs:listFiles returns [] (no provider yet). Watching sshConnectedGeneration
-  // lets the file-load effect re-fire automatically once the connection comes
-  // up, so the user doesn't have to close and reopen the dialog.
-  const sshConnectedGeneration = useAppStore((s) => s.sshConnectedGeneration)
+  // fs:listFiles returns [] (no provider yet). Watching the active target's
+  // connection status lets the file-load effect re-fire automatically once
+  // that specific connection comes up, without being affected by unrelated
+  // SSH targets reconnecting.
+  const activeTargetStatus = useAppStore((s) =>
+    connectionId ? s.sshConnectionStates.get(connectionId)?.status : undefined
+  )
   const filesRequestKey = useMemo(
     () =>
-      `${worktreePath ?? ''}\n${connectionId ?? ''}\n${excludePathsKey}\n${connectionId ? sshConnectedGeneration : 0}`,
-    [connectionId, excludePathsKey, worktreePath, sshConnectedGeneration]
+      `${worktreePath ?? ''}\n${connectionId ?? ''}\n${excludePathsKey}\n${activeTargetStatus ?? ''}`,
+    [connectionId, excludePathsKey, worktreePath, activeTargetStatus]
   )
 
   // Why: reset input only on open. Keeping this out of the file-load effect

--- a/src/renderer/src/components/QuickOpen.tsx
+++ b/src/renderer/src/components/QuickOpen.tsx
@@ -92,9 +92,16 @@ export default function QuickOpen(): React.JSX.Element | null {
     () => getConnectionId(activeWorktreeId ?? null) ?? undefined,
     [activeWorktreeId]
   )
+
+  // Why: when quick-open opens before the SSH connection is established,
+  // fs:listFiles returns [] (no provider yet). Watching sshConnectedGeneration
+  // lets the file-load effect re-fire automatically once the connection comes
+  // up, so the user doesn't have to close and reopen the dialog.
+  const sshConnectedGeneration = useAppStore((s) => s.sshConnectedGeneration)
   const filesRequestKey = useMemo(
-    () => `${worktreePath ?? ''}\n${connectionId ?? ''}\n${excludePathsKey}`,
-    [connectionId, excludePathsKey, worktreePath]
+    () =>
+      `${worktreePath ?? ''}\n${connectionId ?? ''}\n${excludePathsKey}\n${connectionId ? sshConnectedGeneration : 0}`,
+    [connectionId, excludePathsKey, worktreePath, sshConnectedGeneration]
   )
 
   // Why: reset input only on open. Keeping this out of the file-load effect


### PR DESCRIPTION
## Summary
- **Add readdir-based file listing fallback** in the relay (`fs-handler-readdir-fallback.ts`) for non-git directories on remotes without ripgrep. When `rg` is unavailable and `git ls-files` returns nothing (not a git repo), falls back to a recursive `readdir` walk with the same blocklist, 10k file cap, and 10s timeout.
- **Return `[]` instead of throwing** in `worktrees:list` when the SSH git provider is unavailable. This matches the existing `worktrees:listAll` behavior (line 67) and avoids a console error on every `fetchAllWorktrees` cycle while the connection is being (re-)established. The renderer's empty-array guard (`worktrees.length === 0 && current.length > 0`) preserves cached worktree data identically.
- **Return `[]` from `fs:listFiles`** when the SSH filesystem provider is missing, so quick-open shows "No matching files" instead of an error banner during SSH cold start or reconnection.

## Test plan
- [ ] SSH into a remote machine **without ripgrep** installed
- [ ] Add a **non-git folder** as a project (should trigger "Open as Folder" dialog)
- [ ] Press Cmd+P — verify quick-open populates with files from the directory
- [ ] Verify Cmd+P still works for git repos over SSH (with and without rg)
- [ ] Verify Cmd+P still works for local repos (no regression)
- [ ] Disconnect SSH, press Cmd+P — verify no error banner, just "No matching files"
- [ ] Reconnect SSH, press Cmd+P — verify files repopulate
- [ ] Check console — verify no `Failed to fetch worktrees` errors during SSH reconnection