### PR TITLE
feat(ssh): surface SSH status in worktree UI and streamline add-repo flow

### DIFF
--- a/src/renderer/src/components/NewWorkspaceComposerCard.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.tsx
@@ -19,7 +19,6 @@ import { AGENT_CATALOG } from '@/lib/agent-catalog'
 import { useAppStore } from '@/store'
 import { cn } from '@/lib/utils'
 import type { TuiAgent } from '../../../shared/types'
-import { isGitRepoKind } from '../../../shared/repo-kind'
 
 const isMac = typeof navigator !== 'undefined' && navigator.userAgent.includes('Mac')
 
@@ -190,11 +189,9 @@ export default function NewWorkspaceComposerCard({
   createError
 }: NewWorkspaceComposerCardProps): React.JSX.Element {
   const { isFileDragOver, dragHandlers } = useComposerFileDragOver()
-  const addRepo = useAppStore((s) => s.addRepo)
-  const fetchWorktrees = useAppStore((s) => s.fetchWorktrees)
+  const openModal = useAppStore((s) => s.openModal)
   const defaultTuiAgent = useAppStore((s) => s.settings?.defaultTuiAgent ?? null)
   const updateSettings = useAppStore((s) => s.updateSettings)
-  const [isAddingRepo, setIsAddingRepo] = React.useState(false)
 
   const handleSetDefaultAgent = React.useCallback(
     (next: TuiAgent | 'blank' | null) => {
@@ -218,25 +215,9 @@ export default function NewWorkspaceComposerCard({
     [detectedAgentIds]
   )
 
-  const handleAddRepo = React.useCallback(async (): Promise<void> => {
-    if (isAddingRepo) {
-      return
-    }
-    setIsAddingRepo(true)
-    try {
-      const repo = await addRepo()
-      if (!repo) {
-        return
-      }
-      if (isGitRepoKind(repo)) {
-        await fetchWorktrees(repo.id)
-      }
-      onRepoChange(repo.id)
-      focusNameInput()
-    } finally {
-      setIsAddingRepo(false)
-    }
-  }, [addRepo, fetchWorktrees, focusNameInput, isAddingRepo, onRepoChange])
+  const handleAddRepo = React.useCallback((): void => {
+    openModal('add-repo')
+  }, [openModal])
 
   return (
     <div
@@ -265,12 +246,9 @@ export default function NewWorkspaceComposerCard({
                   type="button"
                   variant="ghost"
                   size="icon-xs"
-                  disabled={isAddingRepo}
-                  onClick={() => void handleAddRepo()}
+                  onClick={handleAddRepo}
                   className="size-5 shrink-0 rounded-sm text-muted-foreground hover:text-foreground"
-                  aria-label={
-                    isAddingRepo ? 'Adding folder or repository' : 'Add folder or repository'
-                  }
+                  aria-label="Add folder or repository"
                 >
                   <FolderPlus className="size-3" />
                 </Button>

--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -1,7 +1,7 @@
 /* oxlint-disable max-lines */
 import React, { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
-import { Globe, Plus } from 'lucide-react'
+import { Globe, Plus, WifiOff } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { getRepoMapFromState, useAllWorktrees } from '@/store/selectors'
 import {
@@ -145,6 +145,7 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
   const activeBrowserTabId = useAppStore((s) => s.activeBrowserTabId)
   const browserTabsByWorktree = useAppStore((s) => s.browserTabsByWorktree)
   const browserPagesByWorkspace = useAppStore((s) => s.browserPagesByWorkspace)
+  const sshConnectionStates = useAppStore((s) => s.sshConnectionStates)
 
   const [query, setQuery] = useState('')
   const deferredQuery = useDeferredValue(query)
@@ -705,6 +706,11 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
                 )
                 const statusLabel = getWorktreeStatusLabel(status)
                 const isCurrentWorktree = activeWorktreeId === worktree.id
+                const sshConnectionId = repo?.connectionId ?? null
+                const sshStatus = sshConnectionId
+                  ? (sshConnectionStates.get(sshConnectionId)?.status ?? 'disconnected')
+                  : null
+                const isSshDisconnected = sshStatus != null && sshStatus !== 'connected'
 
                 return (
                   <CommandItem
@@ -725,6 +731,21 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
                       <div className="flex items-center justify-between gap-2.5">
                         <div className="min-w-0 flex-1">
                           <div className="flex min-w-0 items-center gap-2">
+                            {sshConnectionId && (
+                              <span
+                                aria-label={isSshDisconnected ? 'SSH disconnected' : 'SSH remote'}
+                                className="shrink-0 inline-flex items-center"
+                              >
+                                {isSshDisconnected ? (
+                                  <WifiOff className="size-3.5 text-red-400" aria-hidden="true" />
+                                ) : (
+                                  <Globe
+                                    className="size-3.5 text-muted-foreground"
+                                    aria-hidden="true"
+                                  />
+                                )}
+                              </span>
+                            )}
                             <span className="truncate text-[14px] font-semibold tracking-[-0.01em] text-foreground">
                               {entry.match.displayNameRange ? (
                                 <HighlightedText

--- a/src/renderer/src/components/sidebar/AddRepoDialog.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoDialog.tsx
@@ -316,6 +316,11 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
               setRemoteError(null)
             }}
             onAdd={handleAddRemoteRepo}
+            onOpenSshSettings={() => {
+              closeModal()
+              openSettingsTarget({ pane: 'ssh', repoId: null, sectionId: 'ssh' })
+              openSettingsPage()
+            }}
           />
         ) : step === 'clone' ? (
           <CloneStep

--- a/src/renderer/src/components/sidebar/AddRepoSteps.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoSteps.tsx
@@ -7,7 +7,7 @@
  */
 import React, { useCallback, useRef, useState } from 'react'
 import { toast } from 'sonner'
-import { Folder, FolderOpen } from 'lucide-react'
+import { Folder, FolderOpen, Settings } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
@@ -148,6 +148,7 @@ type RemoteStepProps = {
   onSelectTarget: (id: string) => void
   onRemotePathChange: (value: string) => void
   onAdd: () => void
+  onOpenSshSettings: () => void
 }
 
 export function RemoteStep({
@@ -158,7 +159,8 @@ export function RemoteStep({
   isAddingRemote,
   onSelectTarget,
   onRemotePathChange,
-  onAdd
+  onAdd,
+  onOpenSshSettings
 }: RemoteStepProps): React.JSX.Element {
   const [browsing, setBrowsing] = useState(false)
 
@@ -197,9 +199,18 @@ export function RemoteStep({
         <div className="space-y-1">
           <label className="text-[11px] font-medium text-muted-foreground">SSH target</label>
           {sshTargets.length === 0 ? (
-            <p className="text-xs text-muted-foreground py-2">
-              No SSH targets configured. Add one in Settings first.
-            </p>
+            <div className="space-y-1.5 py-1">
+              <p className="text-xs text-muted-foreground">No SSH targets configured.</p>
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-7 text-xs"
+                onClick={onOpenSshSettings}
+              >
+                <Settings className="size-3.5" />
+                Add in Settings
+              </Button>
+            </div>
           ) : (
             <div className="space-y-1.5">
               {sshTargets.map((target) => {
@@ -252,7 +263,7 @@ export function RemoteStep({
               }}
               placeholder="/home/user/project"
               className="h-8 text-xs flex-1"
-              disabled={isAddingRemote}
+              disabled={isAddingRemote || !selectedTargetId}
             />
             <Button
               variant="outline"

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -288,6 +288,23 @@ const WorktreeCard = React.memo(function WorktreeCard({
             {/* Header row: Title and Checks */}
             <div className="flex items-center justify-between min-w-0 gap-2">
               <div className="flex items-center gap-1.5 min-w-0">
+                {repo?.connectionId && (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span className="shrink-0 inline-flex items-center">
+                        {isSshDisconnected ? (
+                          <WifiOff className="size-3 text-red-400" />
+                        ) : (
+                          <Globe className="size-3 text-muted-foreground" />
+                        )}
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent side="right" sideOffset={8}>
+                      {isSshDisconnected ? 'SSH disconnected' : 'Remote repository via SSH'}
+                    </TooltipContent>
+                  </Tooltip>
+                )}
+
                 <div className="text-[12px] font-semibold text-foreground truncate leading-tight">
                   {worktree.displayName}
                 </div>
@@ -350,23 +367,6 @@ const WorktreeCard = React.memo(function WorktreeCard({
                     {repo.displayName}
                   </span>
                 </div>
-              )}
-
-              {repo?.connectionId && (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span className="shrink-0 inline-flex items-center gap-0.5">
-                      {isSshDisconnected ? (
-                        <WifiOff className="size-3 text-red-400" />
-                      ) : (
-                        <Globe className="size-3 text-muted-foreground" />
-                      )}
-                    </span>
-                  </TooltipTrigger>
-                  <TooltipContent side="right" sideOffset={8}>
-                    {isSshDisconnected ? 'SSH disconnected' : 'Remote repository via SSH'}
-                  </TooltipContent>
-                </Tooltip>
               )}
 
               {isFolder ? (

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -93,6 +93,7 @@ export type UISlice = {
       | 'repo'
       | 'agents'
       | 'experimental'
+      | 'ssh'
     repoId: string | null
     sectionId?: string
   } | null


### PR DESCRIPTION
## Problem

Users working with SSH-based remote repositories lack visibility into SSH connection state directly in the worktree list. Additionally, the add-repo flow from the workspace composer was duplicative and didn't flow naturally to SSH configuration when needed.

## Solution

- **Surface SSH status in UI**: Show SSH icon (Globe/WifiOff) beside worktree titles in the jump palette and WorktreeCard so remote connection state is immediately visible
- **Streamline add-repo**: Replace the inline add-repo flow in NewWorkspaceComposerCard with the existing add-repo modal for a single entry point
- **Improve SSH onboarding**: When no SSH targets are configured in the add-repo dialog, provide a direct link to SSH settings, and disable the remote path input until a target is selected
- **Fix type exports**: Add missing 'ssh' pane type to support the new SSH settings navigation

Improves discoverability of SSH status and reduces friction when adding remote repositories.