### PR TITLE
feat(composer): default blank workspace name to a unique marine-creature

### DIFF
--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -33,6 +33,7 @@ import {
   renderIssueCommandTemplate,
   type LinkedWorkItemSummary
 } from '@/lib/new-workspace'
+import { getSuggestedCreatureName } from '@/components/sidebar/worktree-name-suggestions'
 
 export type UseComposerStateOptions = {
   initialRepoId?: string
@@ -169,6 +170,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
   const activeRepoId = useAppStore((s) => s.activeRepoId)
   const settings = useAppStore((s) => s.settings)
   const newWorkspaceDraft = useAppStore((s) => s.newWorkspaceDraft)
+  const worktreesByRepo = useAppStore((s) => s.worktreesByRepo)
 
   const eligibleRepos = useMemo(() => repos.filter((repo) => isGitRepoKind(repo)), [repos])
   const draftRepoId = persistDraft ? (newWorkspaceDraft?.repoId ?? null) : null
@@ -320,15 +322,24 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
   const isSetupCheckPending = Boolean(repoId) && checkedHooksRepoId !== repoId
   const shouldWaitForSetupCheck = Boolean(selectedRepo) && isSetupCheckPending
 
+  // Why: when the user leaves the workspace name blank and provides no other
+  // seed source (prompt, linked issue/PR), pick a repo-scoped unique marine
+  // creature name so the workspace gets a distinct, readable identifier
+  // instead of colliding on a literal "workspace" default.
+  const fallbackCreatureName = useMemo(
+    () => getSuggestedCreatureName(repoId, worktreesByRepo, settings?.nestWorkspaces ?? true),
+    [repoId, worktreesByRepo, settings?.nestWorkspaces]
+  )
   const workspaceSeedName = useMemo(
     () =>
       getWorkspaceSeedName({
         explicitName: name,
         prompt: agentPrompt,
         linkedIssueNumber: parsedLinkedIssueNumber,
-        linkedPR
+        linkedPR,
+        fallbackName: fallbackCreatureName
       }),
-    [agentPrompt, linkedPR, name, parsedLinkedIssueNumber]
+    [agentPrompt, fallbackCreatureName, linkedPR, name, parsedLinkedIssueNumber]
   )
   // Why: when the user links an issue/PR but has not typed any prompt text
   // (attachments don't count), swap the generic "Linked work items:" context
@@ -989,7 +1000,8 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
         explicitName: name,
         prompt: '',
         linkedIssueNumber: null,
-        linkedPR: null
+        linkedPR: null,
+        fallbackName: fallbackCreatureName
       })
       if (
         !repoId ||
@@ -1057,6 +1069,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       applyWorktreeMeta,
       clearNewWorkspaceDraft,
       createWorktree,
+      fallbackCreatureName,
       name,
       note,
       onCreated,

--- a/src/renderer/src/lib/new-workspace.test.ts
+++ b/src/renderer/src/lib/new-workspace.test.ts
@@ -88,4 +88,28 @@ describe('getWorkspaceSeedName', () => {
       })
     ).toBe('workspace')
   })
+
+  it('uses the fallback name when no other seed source is available', () => {
+    expect(
+      getWorkspaceSeedName({
+        explicitName: '',
+        prompt: '',
+        linkedIssueNumber: null,
+        linkedPR: null,
+        fallbackName: 'Nautilus'
+      })
+    ).toBe('Nautilus')
+  })
+
+  it('prefers an explicit name over the fallback name', () => {
+    expect(
+      getWorkspaceSeedName({
+        explicitName: 'my-workspace',
+        prompt: '',
+        linkedIssueNumber: null,
+        linkedPR: null,
+        fallbackName: 'Nautilus'
+      })
+    ).toBe('my-workspace')
+  })
 })

--- a/src/renderer/src/lib/new-workspace.ts
+++ b/src/renderer/src/lib/new-workspace.ts
@@ -153,8 +153,13 @@ export function getWorkspaceSeedName(args: {
   prompt: string
   linkedIssueNumber: number | null
   linkedPR: number | null
+  /** Why: when none of the other seed sources produce a name, the composer
+   *  supplies a repo-scoped unique marine-creature name so blank submissions
+   *  still get a distinct, readable workspace rather than a collision-prone
+   *  "workspace" literal that git would append numeric suffixes to. */
+  fallbackName?: string
 }): string {
-  const { explicitName, prompt, linkedIssueNumber, linkedPR } = args
+  const { explicitName, prompt, linkedIssueNumber, linkedPR, fallbackName } = args
   if (explicitName.trim()) {
     return explicitName.trim()
   }
@@ -174,6 +179,9 @@ export function getWorkspaceSeedName(args: {
     if (slug) {
       return slug
     }
+  }
+  if (fallbackName && fallbackName.trim()) {
+    return fallbackName.trim()
   }
   // Why: the prompt is optional in this flow. Fall back to a stable default
   // branch/workspace seed so users can launch an empty draft without first


### PR DESCRIPTION
## Problem
When a user leaves the workspace name field blank in the composer and has no prompt/linked issue/PR to seed from, `getWorkspaceSeedName` defaults to the literal `"workspace"`. Creating multiple blank workspaces causes collisions on the same name, forcing git to append numeric suffixes (`workspace-2`, `workspace-3`, etc.), which is not user-friendly.

## Solution
Wire `useComposerState` to compute a repo-scoped unique marine-creature name via the existing `getSuggestedCreatureName` helper and pass it as `fallbackName` to `getWorkspaceSeedName`. This ensures blank submissions get a distinct, readable identifier (e.g., "nautilus", "dolphin") instead of colliding, while respecting the `nestWorkspaces` setting.

**Test coverage**: Added unit tests for fallback precedence — explicit name still wins over fallback.

## Test plan
- [x] `pnpm typecheck`
- [x] Unit tests for `getWorkspaceSeedName` fallback precedence (2672 tests green)
- [ ] Manual: open Cmd+J composer, leave name blank, create — verify workspace gets a unique creature name