### PR TITLE
fix(agents): detect Auggie using real `auggie` binary name

### DIFF
--- a/src/renderer/src/lib/agent-catalog.tsx
+++ b/src/renderer/src/lib/agent-catalog.tsx
@@ -99,7 +99,7 @@ export const AGENT_CATALOG: AgentCatalogEntry[] = [
   {
     id: 'aug',
     label: 'Auggie',
-    cmd: 'aug',
+    cmd: 'auggie',
     faviconDomain: 'augmentcode.com',
     homepageUrl: 'https://docs.augmentcode.com/cli/overview'
   },

--- a/src/shared/tui-agent-config.ts
+++ b/src/shared/tui-agent-config.ts
@@ -88,9 +88,12 @@ export const TUI_AGENT_CONFIG: Record<TuiAgent, TuiAgentConfig> = {
     promptInjectionMode: 'stdin-after-start'
   },
   aug: {
-    detectCmd: 'aug',
-    launchCmd: 'aug',
-    expectedProcess: 'aug',
+    // Why: the published @augmentcode/auggie npm package installs a binary
+    // named `auggie` (not `aug`). Keep the TuiAgent id as 'aug' for stored
+    // preferences, but detect/launch/identify the real binary name.
+    detectCmd: 'auggie',
+    launchCmd: 'auggie',
+    expectedProcess: 'auggie',
     promptInjectionMode: 'stdin-after-start'
   },
   cline: {


### PR DESCRIPTION
## Summary

- The `@augmentcode/auggie` npm package installs a binary named `auggie`, not `aug`. Orca was probing PATH for `aug`, so even when the user had Auggie installed it never appeared as a detected agent (despite being listed in the catalog).
- Update `detectCmd` / `launchCmd` / `expectedProcess` in `TUI_AGENT_CONFIG` and `cmd` in `AGENT_CATALOG` to `auggie`. The `TuiAgent` id stays as `'aug'` so any stored user preferences/defaults keep working.

## Verification

1. Installed Auggie locally via `npm install -g @augmentcode/auggie` — `which auggie` resolves, `auggie --version` prints `0.24.0`.
2. Launched Orca dev build with `--remote-debugging-port` and attached via playwright-cli.
3. Called `window.api.preflight.detectAgents()` through the renderer — `"aug"` is now present in the returned array alongside the other installed agents.
4. `pnpm test -- src/main/ipc/preflight.test.ts` passes (full suite: 2672 passed, 6 skipped).

cc @SamoSR

## Test plan

- [ ] Install Auggie (`npm i -g @augmentcode/auggie`) and confirm it appears under "Detected" in the Agents settings pane
- [ ] Create a new workspace with Auggie selected and confirm it launches and accepts the initial prompt