### PR TITLE
refactor(terminal): remove FORCE_HYPERLINK feature and setting

### DIFF
--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -87,7 +87,6 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     terminalMacOptionAsAltMigrated: true,
     experimentalTerminalDaemon: false,
     experimentalTerminalDaemonNoticeShown: false,
-    terminalForceHyperlink: true,
     terminalWindowsShell: 'powershell.exe',
     enableGitHubAttribution: true,
     ...overrides

--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -81,7 +81,6 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     terminalMacOptionAsAltMigrated: true,
     experimentalTerminalDaemon: false,
     experimentalTerminalDaemonNoticeShown: false,
-    terminalForceHyperlink: true,
     terminalWindowsShell: 'powershell.exe',
     enableGitHubAttribution: true,
     ...overrides

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -186,7 +186,6 @@ export function registerPtyHandlers(
   if (localProvider instanceof LocalPtyProvider) {
     localProvider.configure({
       isHistoryEnabled: () => getSettings?.()?.terminalScopeHistoryByWorktree ?? true,
-      isForceHyperlinkEnabled: () => getSettings?.()?.terminalForceHyperlink ?? true,
       getWindowsShell: () => getSettings?.()?.terminalWindowsShell,
       buildSpawnEnv: (id, baseEnv) => {
         const selectedCodexHomePath = getSelectedCodexHomePath?.() ?? null

--- a/src/main/providers/local-pty-provider.test.ts
+++ b/src/main/providers/local-pty-provider.test.ts
@@ -120,22 +120,6 @@ describe('LocalPtyProvider', () => {
       expect(spawnCall[2].env.CUSTOM_VAR).toBe('custom-value')
     })
 
-    it('sets FORCE_HYPERLINK=1 by default to preserve legacy behavior', async () => {
-      await provider.spawn({ cols: 80, rows: 24 })
-      const spawnCall = spawnMock.mock.calls.at(-1)!
-      expect(spawnCall[2].env.FORCE_HYPERLINK).toBe('1')
-    })
-
-    it('omits FORCE_HYPERLINK when isForceHyperlinkEnabled returns false', async () => {
-      // Why: users with heavy shell init (oh-my-zsh + p10k + nvm + pyenv) can
-      // disable FORCE_HYPERLINK from Settings. Verify the opt-out reaches the
-      // spawn env so OSC-8-reading tools stop emitting the extra escapes.
-      provider.configure({ isForceHyperlinkEnabled: () => false })
-      await provider.spawn({ cols: 80, rows: 24 })
-      const spawnCall = spawnMock.mock.calls.at(-1)!
-      expect(spawnCall[2].env.FORCE_HYPERLINK).toBeUndefined()
-    })
-
     it('combines HOMEDRIVE and HOMEPATH for Windows default cwd', async () => {
       const platform = Object.getOwnPropertyDescriptor(process, 'platform')
       const originalUserProfile = process.env.USERPROFILE

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -92,12 +92,6 @@ export type LocalPtyProviderOptions = {
   /** Whether worktree-scoped shell history is enabled. When true (or absent)
    *  and a worktreeId is provided, HISTFILE is scoped per-worktree. */
   isHistoryEnabled?: () => boolean
-  /** Whether to set FORCE_HYPERLINK=1 in spawned PTYs. Historically always on;
-   *  now user-togglable because the extra OSC-8 emission branches in oh-my-zsh,
-   *  coreutils, and the Rust supports-hyperlinks crate can compound to a
-   *  significant shell-startup slowdown with heavy rc files. When absent,
-   *  defaults to the prior behavior (on). */
-  isForceHyperlinkEnabled?: () => boolean
   /** Why: COMSPEC is always cmd.exe on a stock Windows machine, so reading it
    *  directly would ignore the user's shell preference. This callback lets the
    *  IPC layer inject the persisted setting without coupling the provider to the
@@ -192,21 +186,6 @@ export class LocalPtyProvider implements IPtyProvider {
     } as Record<string, string>
     for (const key of args.envToDelete ?? []) {
       delete spawnEnv[key]
-    }
-
-    // Why: FORCE_HYPERLINK=1 is read by oh-my-zsh's supports_hyperlinks(), the
-    // Rust supports-hyperlinks crate, GNU coreutils, and other tooling.
-    // Forcing it on makes every subprocess invoked during shell init take
-    // extra branches and emit OSC-8 escapes, which compounded with a heavy
-    // zshrc (oh-my-zsh + p10k + nvm + pyenv + conda) can 3×+ the startup time
-    // — reported by users as a multi-minute-to-hour "terminal hang."
-    // We keep the historical default (on) so existing users don't lose link
-    // emission silently, but expose it as a toggle so users with heavy rc
-    // files can opt out. Orca's xterm still renders OSC-8 hyperlinks when
-    // tools emit them on their own detection, so link support is preserved
-    // for the typical modern CLI even when this toggle is off.
-    if (this.opts.isForceHyperlinkEnabled?.() ?? true) {
-      spawnEnv.FORCE_HYPERLINK = '1'
     }
 
     spawnEnv.LANG ??= 'en_US.UTF-8'

--- a/src/renderer/src/components/settings/TerminalPane.tsx
+++ b/src/renderer/src/components/settings/TerminalPane.tsx
@@ -701,58 +701,6 @@ export function TerminalPane({
           ) : null}
         </SearchableSetting>
 
-        <SearchableSetting
-          title="Force Hyperlink Escapes"
-          description="Set FORCE_HYPERLINK=1 in every terminal so tools emit OSC-8 clickable links. Turn off if your shell startup is slow."
-          keywords={[
-            'terminal',
-            'hyperlink',
-            'link',
-            'osc',
-            'osc8',
-            'osc-8',
-            'force_hyperlink',
-            'slow',
-            'startup',
-            'zsh',
-            'zshrc',
-            'oh-my-zsh',
-            'p10k',
-            'powerlevel10k'
-          ]}
-          className="flex items-center justify-between gap-4 px-1 py-2"
-        >
-          <div className="space-y-0.5">
-            <Label>Force Hyperlink Escapes</Label>
-            <p className="text-xs text-muted-foreground">
-              Sets{' '}
-              <code className="rounded bg-muted px-1 py-0.5 text-[11px]">FORCE_HYPERLINK=1</code> in
-              every spawned terminal so tools like <code>ls</code>, <code>git</code>, and{' '}
-              <code>eza</code> emit OSC-8 clickable links. Disable if your shell startup feels slow
-              — heavy setups (oh-my-zsh, powerlevel10k, nvm, pyenv, conda) can take measurably
-              longer with this on. Only affects newly spawned terminals.
-            </p>
-          </div>
-          <button
-            role="switch"
-            aria-checked={settings.terminalForceHyperlink}
-            onClick={() =>
-              updateSettings({
-                terminalForceHyperlink: !settings.terminalForceHyperlink
-              })
-            }
-            className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent transition-colors ${
-              settings.terminalForceHyperlink ? 'bg-foreground' : 'bg-muted-foreground/30'
-            }`}
-          >
-            <span
-              className={`pointer-events-none block size-3.5 rounded-full bg-background shadow-sm transition-transform ${
-                settings.terminalForceHyperlink ? 'translate-x-4' : 'translate-x-0.5'
-              }`}
-            />
-          </button>
-        </SearchableSetting>
-
         {isMac ? (
           <SearchableSetting
             title="Option as Alt"

--- a/src/renderer/src/components/settings/terminal-search.ts
+++ b/src/renderer/src/components/settings/terminal-search.ts
@@ -108,27 +108,6 @@ export const TERMINAL_ADVANCED_SEARCH_ENTRIES: SettingsSearchEntry[] = [
     title: 'Scrollback Size',
     description: 'Maximum terminal scrollback buffer size.',
     keywords: ['terminal', 'scrollback', 'buffer', 'memory']
-  },
-  {
-    title: 'Force Hyperlink Escapes',
-    description:
-      'Set FORCE_HYPERLINK=1 in every terminal so tools emit OSC-8 clickable links. Turn off if your shell startup is slow.',
-    keywords: [
-      'terminal',
-      'hyperlink',
-      'link',
-      'osc',
-      'osc8',
-      'osc-8',
-      'force_hyperlink',
-      'slow',
-      'startup',
-      'zsh',
-      'zshrc',
-      'oh-my-zsh',
-      'p10k',
-      'powerlevel10k'
-    ]
   }
 ]
 

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -169,12 +169,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     terminalMacOptionAsAlt: 'auto',
     terminalMacOptionAsAltMigrated: false,
     experimentalTerminalDaemon: false,
-    experimentalTerminalDaemonNoticeShown: false,
-    // Why: keep the historical default (on) so no existing user's terminal
-    // loses clickable-link emission on upgrade. Users with heavy zshrc setups
-    // can disable it from Settings → Terminal → Advanced to reclaim startup
-    // time.
-    terminalForceHyperlink: true
+    experimentalTerminalDaemonNoticeShown: false
   }
 }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -859,15 +859,6 @@ export type GlobalSettings = {
    *  toast shown to users upgrading from v1.3.0 (where the daemon was on by
    *  default). Set to true the first time the toast fires so it never repeats. */
   experimentalTerminalDaemonNoticeShown: boolean
-  /** When true, Orca sets FORCE_HYPERLINK=1 in every spawned PTY's env. That
-   *  makes modern CLIs (oh-my-zsh's supports_hyperlinks(), coreutils, the Rust
-   *  supports-hyperlinks crate, etc.) emit OSC-8 hyperlink escapes even when
-   *  they would otherwise skip them. Defaults to true to preserve prior
-   *  behavior, but users with heavy shell init (large oh-my-zsh / p10k / nvm /
-   *  pyenv / conda setups) can measurably speed up terminal start by turning
-   *  this off — the extra branching and escape emission across the many
-   *  subshells fired during rc init can multiply startup time. */
-  terminalForceHyperlink: boolean
 }
 
 export type NotificationEventSource = 'agent-task-complete' | 'terminal-bell' | 'test'


### PR DESCRIPTION
## Summary
- Removes the `FORCE_HYPERLINK=1` PTY env injection, the `terminalForceHyperlink` setting, and the Settings → Terminal → Advanced toggle.
- xterm's [`WebLinksAddon`](https://github.com/xtermjs/xterm.js/tree/master/addons/addon-web-links) (already wired up in `pane-lifecycle.ts`) handles plain-text URL detection, and modern CLIs that self-detect terminal hyperlink support still emit OSC-8 on their own — so the global force-on wasn't earning its keep and was the source of the shell-startup slowdowns the toggle was introduced to work around.
- No migration needed: removed fields in persisted settings are simply dropped when merged against defaults.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm vitest run src/main src/renderer src/shared` (all passing)
- [ ] Spawn a fresh terminal, run `ls --hyperlink=auto` / `eza --hyperlink` — links should still render via tool self-detection
- [ ] Verify Settings → Terminal → Advanced no longer shows the "Force Hyperlink Escapes" row