### PR TITLE
fix: prevent pinned worktrees from expanding collapsed groups

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -24,6 +24,7 @@ import {
 import {
   type GroupHeaderRow,
   type Row,
+  PINNED_GROUP_KEY,
   buildRows,
   getGroupKeyForWorktree
 } from './worktree-list-groups'
@@ -118,9 +119,17 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
       return
     }
 
-    if (groupBy !== 'none') {
+    {
       const targetWorktree = worktrees.find((w) => w.id === pendingRevealWorktreeId)
-      if (targetWorktree) {
+      if (targetWorktree?.isPinned) {
+        // Why: pinned worktrees live in the dedicated "Pinned" section regardless
+        // of their PR-status / repo group. Only uncollapse the Pinned header
+        // itself — expanding the underlying status group would be surprising since
+        // the user intentionally collapsed it.
+        if (collapsedGroups.has(PINNED_GROUP_KEY)) {
+          toggleGroup(PINNED_GROUP_KEY)
+        }
+      } else if (targetWorktree && groupBy !== 'none') {
         const groupKey = getGroupKeyForWorktree(groupBy, targetWorktree, repoMap, prCache)
         if (groupKey && collapsedGroups.has(groupKey)) {
           toggleGroup(groupKey)


### PR DESCRIPTION
## Problem
Clicking a pinned worktree card in the sidebar was unexpectedly expanding collapsed PR status groups (e.g., opening the collapsed "Done" section even though the pinned card was already visible in the "Pinned" section).

## Solution
Modified the worktree reveal effect in `VirtualizedWorktreeViewport` to distinguish between pinned and non-pinned worktrees:
- **For pinned worktrees**: Only uncollapse the "Pinned" section header if it's collapsed (the card is already visible, no need to expand underlying groups)
- **For non-pinned worktrees**: Continue expanding the relevant group (PR status or repo) as before

This prevents surprising behavior where clicking a pinned card unintentionally expands sections the user intentionally collapsed.