### PR TITLE
Add basic syntax highlighting for .astro files

### DIFF
--- a/src/renderer/src/lib/language-detect.ts
+++ b/src/renderer/src/lib/language-detect.ts
@@ -76,6 +76,7 @@ const EXT_TO_LANGUAGE: Record<string, string> = {
   '.clj': 'clojure',
   '.vue': 'html',
   '.svelte': 'html',
+  '.astro': 'html',
   '.tf': 'hcl',
   '.hcl': 'hcl',
   '.prisma': 'graphql'


### PR DESCRIPTION
## Summary
- Maps `.astro` to Monaco's `html` language id in `language-detect.ts`, matching how `.vue` and `.svelte` are already handled.
- Astro files now get HTML-level coloring (tags, attributes, strings) instead of rendering as plain text.

## Context
A user asked about improving IDE support for Vue/Astro (formatting, linting, highlighting). Proper SFC-aware highlighting — frontmatter TypeScript, template expressions, `<script lang=\"ts\">` sections — needs a Monarch grammar or LSP. That's tracked in a separate issue; this PR is the cheap one-line win.

## Test plan
- [ ] Open an `.astro` file in the editor and confirm HTML-style coloring appears
- [ ] Confirm `.vue` / `.svelte` behavior is unchanged