### PR TITLE
fix(diff): collapse redundant line-number gutters in inline diff view

### DIFF
--- a/src/renderer/src/components/editor/DiffSectionItem.tsx
+++ b/src/renderer/src/components/editor/DiffSectionItem.tsx
@@ -133,6 +133,7 @@ export function DiffSectionItem({
 
   const [modifiedEditor, setModifiedEditor] = useState<monacoEditor.ICodeEditor | null>(null)
   const diffEditorRef = useRef<monacoEditor.IStandaloneDiffEditor | null>(null)
+  const lineNumberOptionsSubRef = useRef<{ dispose: () => void } | null>(null)
   const [popover, setPopover] = useState<{ lineNumber: number; top: number } | null>(null)
 
   useDiffCommentDecorator({
@@ -166,10 +167,16 @@ export function DiffSectionItem({
   }, [modifiedEditor, popover?.lineNumber])
 
   useEffect(() => {
-    if (!diffEditorRef.current) {
+    const diffEditor = diffEditorRef.current
+    if (!diffEditor) {
       return
     }
-    applyDiffEditorLineNumberOptions(diffEditorRef.current, sideBySide)
+    lineNumberOptionsSubRef.current?.dispose()
+    lineNumberOptionsSubRef.current = applyDiffEditorLineNumberOptions(diffEditor, sideBySide)
+    return () => {
+      lineNumberOptionsSubRef.current?.dispose()
+      lineNumberOptionsSubRef.current = null
+    }
   }, [sideBySide])
 
   const handleSubmitComment = async (body: string): Promise<void> => {
@@ -216,7 +223,8 @@ export function DiffSectionItem({
 
   const handleMount: DiffOnMount = (editor, monaco) => {
     diffEditorRef.current = editor
-    applyDiffEditorLineNumberOptions(editor, sideBySide)
+    lineNumberOptionsSubRef.current?.dispose()
+    lineNumberOptionsSubRef.current = applyDiffEditorLineNumberOptions(editor, sideBySide)
     const modified = editor.getModifiedEditor()
 
     const updateHeight = (): void => {
@@ -238,6 +246,8 @@ export function DiffSectionItem({
     // methods on a disposed editor instance, and avoids `popover` pointing
     // at a line in an editor that no longer exists.
     modified.onDidDispose(() => {
+      lineNumberOptionsSubRef.current?.dispose()
+      lineNumberOptionsSubRef.current = null
       diffEditorRef.current = null
       setModifiedEditor(null)
       setPopover(null)

--- a/src/renderer/src/components/editor/DiffSectionItem.tsx
+++ b/src/renderer/src/components/editor/DiffSectionItem.tsx
@@ -1,4 +1,4 @@
-import React, { lazy, useEffect, useMemo, useState, type MutableRefObject } from 'react'
+import React, { lazy, useEffect, useMemo, useRef, useState, type MutableRefObject } from 'react'
 import { LazySection } from './LazySection'
 import { ChevronDown, ChevronRight, ExternalLink } from 'lucide-react'
 import { DiffEditor, type DiffOnMount } from '@monaco-editor/react'
@@ -10,6 +10,7 @@ import { computeEditorFontSize } from '@/lib/editor-font-zoom'
 import { findWorktreeById } from '@/store/slices/worktree-helpers'
 import { useDiffCommentDecorator } from '../diff-comments/useDiffCommentDecorator'
 import { DiffCommentPopover } from '../diff-comments/DiffCommentPopover'
+import { applyDiffEditorLineNumberOptions } from './diff-editor-line-number-options'
 import type { DiffComment, GitDiffResult } from '../../../../shared/types'
 
 const ImageDiffViewer = lazy(() => import('./ImageDiffViewer'))
@@ -131,6 +132,7 @@ export function DiffSectionItem({
   )
 
   const [modifiedEditor, setModifiedEditor] = useState<monacoEditor.ICodeEditor | null>(null)
+  const diffEditorRef = useRef<monacoEditor.IStandaloneDiffEditor | null>(null)
   const [popover, setPopover] = useState<{ lineNumber: number; top: number } | null>(null)
 
   useDiffCommentDecorator({
@@ -162,6 +164,13 @@ export function DiffSectionItem({
     // on `popover` above handles the popover-closed case.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [modifiedEditor, popover?.lineNumber])
+
+  useEffect(() => {
+    if (!diffEditorRef.current) {
+      return
+    }
+    applyDiffEditorLineNumberOptions(diffEditorRef.current, sideBySide)
+  }, [sideBySide])
 
   const handleSubmitComment = async (body: string): Promise<void> => {
     if (!popover) {
@@ -206,6 +215,8 @@ export function DiffSectionItem({
   }
 
   const handleMount: DiffOnMount = (editor, monaco) => {
+    diffEditorRef.current = editor
+    applyDiffEditorLineNumberOptions(editor, sideBySide)
     const modified = editor.getModifiedEditor()
 
     const updateHeight = (): void => {
@@ -227,6 +238,7 @@ export function DiffSectionItem({
     // methods on a disposed editor instance, and avoids `popover` pointing
     // at a line in an editor that no longer exists.
     modified.onDidDispose(() => {
+      diffEditorRef.current = null
       setModifiedEditor(null)
       setPopover(null)
     })

--- a/src/renderer/src/components/editor/DiffViewer.tsx
+++ b/src/renderer/src/components/editor/DiffViewer.tsx
@@ -65,6 +65,7 @@ export default function DiffViewer({
     (settings?.theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)
 
   const diffEditorRef = useRef<editor.IStandaloneDiffEditor | null>(null)
+  const lineNumberOptionsSubRef = useRef<{ dispose: () => void } | null>(null)
   const [modifiedEditor, setModifiedEditor] = useState<editor.ICodeEditor | null>(null)
   const [popover, setPopover] = useState<{ lineNumber: number; top: number } | null>(null)
 
@@ -140,7 +141,8 @@ export default function DiffViewer({
   const handleMount: DiffOnMount = useCallback(
     (diffEditor, monaco) => {
       diffEditorRef.current = diffEditor
-      applyDiffEditorLineNumberOptions(diffEditor, sideBySide)
+      lineNumberOptionsSubRef.current?.dispose()
+      lineNumberOptionsSubRef.current = applyDiffEditorLineNumberOptions(diffEditor, sideBySide)
 
       const originalEditor = diffEditor.getOriginalEditor()
       const modifiedEditor = diffEditor.getModifiedEditor()
@@ -172,6 +174,11 @@ export default function DiffViewer({
       } else {
         diffEditor.focus()
       }
+
+      diffEditor.onDidDispose(() => {
+        lineNumberOptionsSubRef.current?.dispose()
+        lineNumberOptionsSubRef.current = null
+      })
     },
     [editable, setupCopy, modelKey, filePath, sideBySide]
   )
@@ -192,10 +199,16 @@ export default function DiffViewer({
   }, [modelKey])
 
   useEffect(() => {
-    if (!diffEditorRef.current) {
+    const diffEditor = diffEditorRef.current
+    if (!diffEditor) {
       return
     }
-    applyDiffEditorLineNumberOptions(diffEditorRef.current, sideBySide)
+    lineNumberOptionsSubRef.current?.dispose()
+    lineNumberOptionsSubRef.current = applyDiffEditorLineNumberOptions(diffEditor, sideBySide)
+    return () => {
+      lineNumberOptionsSubRef.current?.dispose()
+      lineNumberOptionsSubRef.current = null
+    }
   }, [sideBySide])
 
   return (

--- a/src/renderer/src/components/editor/DiffViewer.tsx
+++ b/src/renderer/src/components/editor/DiffViewer.tsx
@@ -9,6 +9,7 @@ import { useContextualCopySetup } from './useContextualCopySetup'
 import { findWorktreeById } from '@/store/slices/worktree-helpers'
 import { useDiffCommentDecorator } from '../diff-comments/useDiffCommentDecorator'
 import { DiffCommentPopover } from '../diff-comments/DiffCommentPopover'
+import { applyDiffEditorLineNumberOptions } from './diff-editor-line-number-options'
 import type { DiffComment } from '../../../../shared/types'
 
 type DiffViewerProps = {
@@ -139,6 +140,7 @@ export default function DiffViewer({
   const handleMount: DiffOnMount = useCallback(
     (diffEditor, monaco) => {
       diffEditorRef.current = diffEditor
+      applyDiffEditorLineNumberOptions(diffEditor, sideBySide)
 
       const originalEditor = diffEditor.getOriginalEditor()
       const modifiedEditor = diffEditor.getModifiedEditor()
@@ -171,7 +173,7 @@ export default function DiffViewer({
         diffEditor.focus()
       }
     },
-    [editable, setupCopy, modelKey, filePath]
+    [editable, setupCopy, modelKey, filePath, sideBySide]
   )
 
   // Why: VS Code snapshots diff view state on deactivation, not on scroll events.
@@ -188,6 +190,13 @@ export default function DiffViewer({
       }
     }
   }, [modelKey])
+
+  useEffect(() => {
+    if (!diffEditorRef.current) {
+      return
+    }
+    applyDiffEditorLineNumberOptions(diffEditorRef.current, sideBySide)
+  }, [sideBySide])
 
   return (
     <div className="flex flex-col flex-1 min-h-0">

--- a/src/renderer/src/components/editor/diff-editor-line-number-options.test.ts
+++ b/src/renderer/src/components/editor/diff-editor-line-number-options.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { buildDiffEditorLineNumberOptions } from './diff-editor-line-number-options'
+import {
+  applyDiffEditorLineNumberOptions,
+  buildDiffEditorLineNumberOptions
+} from './diff-editor-line-number-options'
+import type { editor } from 'monaco-editor'
 
 describe('buildDiffEditorLineNumberOptions', () => {
   it('hides original line numbers in inline mode', () => {
@@ -14,5 +18,64 @@ describe('buildDiffEditorLineNumberOptions', () => {
       original: 'on',
       modified: 'on'
     })
+  })
+})
+
+function createMockCodeEditor(initialLineNumbers: editor.LineNumbersType = 'on'): {
+  editor: editor.ICodeEditor
+  emitDidChangeOptions: () => void
+  getLineNumbers: () => editor.LineNumbersType
+} {
+  let lineNumbers: editor.LineNumbersType = initialLineNumbers
+  const listeners = new Set<() => void>()
+
+  const mockEditor = {
+    getRawOptions: () => ({ lineNumbers }),
+    updateOptions: ({ lineNumbers: nextLineNumbers }: { lineNumbers?: editor.LineNumbersType }) => {
+      if (nextLineNumbers) {
+        lineNumbers = nextLineNumbers
+      }
+    },
+    onDidChangeOptions: (listener: () => void) => {
+      listeners.add(listener)
+      return {
+        dispose: () => {
+          listeners.delete(listener)
+        }
+      }
+    }
+  } as unknown as editor.ICodeEditor
+
+  return {
+    editor: mockEditor,
+    emitDidChangeOptions: () => {
+      listeners.forEach((listener) => listener())
+    },
+    getLineNumbers: () => lineNumbers
+  }
+}
+
+describe('applyDiffEditorLineNumberOptions', () => {
+  it('reapplies desired line number options after parent option updates and stops after dispose', () => {
+    const original = createMockCodeEditor('on')
+    const modified = createMockCodeEditor('on')
+    const diffEditor = {
+      getOriginalEditor: () => original.editor,
+      getModifiedEditor: () => modified.editor
+    } as unknown as editor.IStandaloneDiffEditor
+
+    const disposable = applyDiffEditorLineNumberOptions(diffEditor, false)
+
+    expect(original.getLineNumbers()).toBe('off')
+    expect(modified.getLineNumbers()).toBe('on')
+
+    original.editor.updateOptions({ lineNumbers: 'on' })
+    original.emitDidChangeOptions()
+    expect(original.getLineNumbers()).toBe('off')
+
+    disposable.dispose()
+    original.editor.updateOptions({ lineNumbers: 'on' })
+    original.emitDidChangeOptions()
+    expect(original.getLineNumbers()).toBe('on')
   })
 })

--- a/src/renderer/src/components/editor/diff-editor-line-number-options.test.ts
+++ b/src/renderer/src/components/editor/diff-editor-line-number-options.test.ts
@@ -23,7 +23,7 @@ describe('buildDiffEditorLineNumberOptions', () => {
 
 function createMockCodeEditor(initialLineNumbers: editor.LineNumbersType = 'on'): {
   editor: editor.ICodeEditor
-  emitDidChangeOptions: () => void
+  emitDidChangeConfiguration: () => void
   getLineNumbers: () => editor.LineNumbersType
 } {
   let lineNumbers: editor.LineNumbersType = initialLineNumbers
@@ -36,7 +36,7 @@ function createMockCodeEditor(initialLineNumbers: editor.LineNumbersType = 'on')
         lineNumbers = nextLineNumbers
       }
     },
-    onDidChangeOptions: (listener: () => void) => {
+    onDidChangeConfiguration: (listener: () => void) => {
       listeners.add(listener)
       return {
         dispose: () => {
@@ -48,7 +48,7 @@ function createMockCodeEditor(initialLineNumbers: editor.LineNumbersType = 'on')
 
   return {
     editor: mockEditor,
-    emitDidChangeOptions: () => {
+    emitDidChangeConfiguration: () => {
       listeners.forEach((listener) => listener())
     },
     getLineNumbers: () => lineNumbers
@@ -70,12 +70,12 @@ describe('applyDiffEditorLineNumberOptions', () => {
     expect(modified.getLineNumbers()).toBe('on')
 
     original.editor.updateOptions({ lineNumbers: 'on' })
-    original.emitDidChangeOptions()
+    original.emitDidChangeConfiguration()
     expect(original.getLineNumbers()).toBe('off')
 
     disposable.dispose()
     original.editor.updateOptions({ lineNumbers: 'on' })
-    original.emitDidChangeOptions()
+    original.emitDidChangeConfiguration()
     expect(original.getLineNumbers()).toBe('on')
   })
 })

--- a/src/renderer/src/components/editor/diff-editor-line-number-options.test.ts
+++ b/src/renderer/src/components/editor/diff-editor-line-number-options.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { buildDiffEditorLineNumberOptions } from './diff-editor-line-number-options'
+
+describe('buildDiffEditorLineNumberOptions', () => {
+  it('hides original line numbers in inline mode', () => {
+    expect(buildDiffEditorLineNumberOptions(false)).toEqual({
+      original: 'off',
+      modified: 'on'
+    })
+  })
+
+  it('shows both gutters in side-by-side mode', () => {
+    expect(buildDiffEditorLineNumberOptions(true)).toEqual({
+      original: 'on',
+      modified: 'on'
+    })
+  })
+})

--- a/src/renderer/src/components/editor/diff-editor-line-number-options.ts
+++ b/src/renderer/src/components/editor/diff-editor-line-number-options.ts
@@ -37,8 +37,13 @@ export function applyDiffEditorLineNumberOptions(
   // update the inner editors directly to collapse the duplicate gutter inline.
   reapplyIfNeeded()
 
-  const originalOptionsSub = originalEditor.onDidChangeOptions(reapplyIfNeeded)
-  const modifiedOptionsSub = modifiedEditor.onDidChangeOptions(reapplyIfNeeded)
+  // Why: @monaco-editor/react re-applies the parent options object on every
+  // component re-render, which clobbers our per-pane lineNumbers override
+  // (the parent options carry lineNumbers: 'on'). Subscribe to each inner
+  // editor's onDidChangeConfiguration so we can re-assert the policy on
+  // every option update without racing against Monaco's internal handling.
+  const originalOptionsSub = originalEditor.onDidChangeConfiguration(reapplyIfNeeded)
+  const modifiedOptionsSub = modifiedEditor.onDidChangeConfiguration(reapplyIfNeeded)
 
   return {
     dispose: () => {

--- a/src/renderer/src/components/editor/diff-editor-line-number-options.ts
+++ b/src/renderer/src/components/editor/diff-editor-line-number-options.ts
@@ -1,0 +1,24 @@
+import type { editor } from 'monaco-editor'
+
+type DiffEditorLineNumberOptions = {
+  original: editor.LineNumbersType
+  modified: editor.LineNumbersType
+}
+
+export function buildDiffEditorLineNumberOptions(sideBySide: boolean): DiffEditorLineNumberOptions {
+  return {
+    original: sideBySide ? 'on' : 'off',
+    modified: 'on'
+  }
+}
+
+export function applyDiffEditorLineNumberOptions(
+  diffEditor: editor.IStandaloneDiffEditor,
+  sideBySide: boolean
+): void {
+  const lineNumberOptions = buildDiffEditorLineNumberOptions(sideBySide)
+  // Why: Monaco 0.55 exposes only shared diff options for line numbers, so we
+  // update the inner editors directly to collapse the duplicate gutter inline.
+  diffEditor.getOriginalEditor().updateOptions({ lineNumbers: lineNumberOptions.original })
+  diffEditor.getModifiedEditor().updateOptions({ lineNumbers: lineNumberOptions.modified })
+}

--- a/src/renderer/src/components/editor/diff-editor-line-number-options.ts
+++ b/src/renderer/src/components/editor/diff-editor-line-number-options.ts
@@ -5,6 +5,10 @@ type DiffEditorLineNumberOptions = {
   modified: editor.LineNumbersType
 }
 
+type Disposable = {
+  dispose: () => void
+}
+
 export function buildDiffEditorLineNumberOptions(sideBySide: boolean): DiffEditorLineNumberOptions {
   return {
     original: sideBySide ? 'on' : 'off',
@@ -15,10 +19,31 @@ export function buildDiffEditorLineNumberOptions(sideBySide: boolean): DiffEdito
 export function applyDiffEditorLineNumberOptions(
   diffEditor: editor.IStandaloneDiffEditor,
   sideBySide: boolean
-): void {
+): Disposable {
   const lineNumberOptions = buildDiffEditorLineNumberOptions(sideBySide)
+  const originalEditor = diffEditor.getOriginalEditor()
+  const modifiedEditor = diffEditor.getModifiedEditor()
+
+  const reapplyIfNeeded = (): void => {
+    if (originalEditor.getRawOptions().lineNumbers !== lineNumberOptions.original) {
+      originalEditor.updateOptions({ lineNumbers: lineNumberOptions.original })
+    }
+    if (modifiedEditor.getRawOptions().lineNumbers !== lineNumberOptions.modified) {
+      modifiedEditor.updateOptions({ lineNumbers: lineNumberOptions.modified })
+    }
+  }
+
   // Why: Monaco 0.55 exposes only shared diff options for line numbers, so we
   // update the inner editors directly to collapse the duplicate gutter inline.
-  diffEditor.getOriginalEditor().updateOptions({ lineNumbers: lineNumberOptions.original })
-  diffEditor.getModifiedEditor().updateOptions({ lineNumbers: lineNumberOptions.modified })
+  reapplyIfNeeded()
+
+  const originalOptionsSub = originalEditor.onDidChangeOptions(reapplyIfNeeded)
+  const modifiedOptionsSub = modifiedEditor.onDidChangeOptions(reapplyIfNeeded)
+
+  return {
+    dispose: () => {
+      originalOptionsSub.dispose()
+      modifiedOptionsSub.dispose()
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Closes #1086.

In Monaco's inline diff mode (`renderSideBySide: false`), the default `lineNumbers: 'on'` setting renders two line-number gutters: one for the original line, one for the modified line. The unified inline view already merges both versions into a single scrolled column, so the second gutter is redundant.

Add a small helper that hides the original-side gutter when `sideBySide` is `false`. Side-by-side mode is unchanged (each pane keeps its single gutter). The helper subscribes to `onDidChangeConfiguration` on each inner editor so the override survives `@monaco-editor/react` re-applying the parent `options` object on every component re-render.

## Screenshots

Code change (the `lineNumbers` policy moves from a static `'on'` in the parent `options` to a per-pane override applied + persisted by the new helper):

![Code change](https://files.catbox.moe/sqqw1t.gif)

The visible UI change is one fewer line-number column in the inline diff view. Verified by checking out the branch and toggling `sideBySide` in the diff toolbar.

## Testing

- [x] `pnpm lint` (2 pre-existing warnings in `useDiffCommentDecorator.tsx`, 0 errors from this change)
- [x] `pnpm typecheck` (all three configs pass)
- [x] `pnpm test` (240 files, 2715 tests pass)
- [x] `pnpm build` (success)
- [x] Added `diff-editor-line-number-options.test.ts` with three cases: inline returns `original: 'off'`, side-by-side returns `original: 'on'`, listener re-applies the override after a simulated parent option update and stops re-applying after `dispose()`.

## AI Review Report

Implementation by Codex (gpt-5.3-codex, medium reasoning). Two review rounds via `codex review`:

1. Round 1 caught that the first attempt only applied the override on mount and on `sideBySide` change, but `@monaco-editor/react` re-runs `diffEditor.updateOptions(options)` on every component re-render, which silently re-enabled the original gutter. Fixed by subscribing to per-pane configuration-change events and re-asserting the policy on drift.
2. Round 2 caught that the first listener attempt used `onDidChangeOptions`, which exists on `ITextModel` but not on `IStandaloneCodeEditor` in the version of monaco-editor this repo pins. Fixed by switching to `onDidChangeConfiguration` (the correct editor-level event in this Monaco version) and verified by re-running `pnpm typecheck` clean.

Self-review then proceeded to verify: no regression on side-by-side mode, listener disposal cleans up both subs, and the helper carries a `Why:` comment per `CLAUDE.md` for the next maintainer touching it.

This contribution was developed with AI assistance.
