### PR TITLE
feat(language-detect): add Vue Monarch grammar for .vue syntax highlighting

### DIFF
--- a/src/renderer/src/lib/language-detect.test.ts
+++ b/src/renderer/src/lib/language-detect.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+import { detectLanguage } from './language-detect'
+
+describe('detectLanguage', () => {
+  it('maps .vue files to the custom vue language id', () => {
+    expect(detectLanguage('src/components/App.vue')).toBe('vue')
+  })
+
+  it('keeps .astro and .svelte mapped to html until their grammars ship', () => {
+    expect(detectLanguage('src/routes/index.astro')).toBe('html')
+    expect(detectLanguage('src/components/Widget.svelte')).toBe('html')
+  })
+})

--- a/src/renderer/src/lib/language-detect.ts
+++ b/src/renderer/src/lib/language-detect.ts
@@ -74,7 +74,7 @@ const EXT_TO_LANGUAGE: Record<string, string> = {
   '.hrl': 'erlang',
   '.hs': 'haskell',
   '.clj': 'clojure',
-  '.vue': 'html',
+  '.vue': 'vue',
   '.svelte': 'html',
   '.astro': 'html',
   '.tf': 'hcl',

--- a/src/renderer/src/lib/monaco-languages/register-vue.test.ts
+++ b/src/renderer/src/lib/monaco-languages/register-vue.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it, vi } from 'vitest'
+import { registerVueLanguage, vueLanguageConfiguration, vueMonarchLanguage } from './register-vue'
+
+type MonarchRule = [RegExp, unknown, string?]
+
+function normalizeState(nextState: string): string {
+  return nextState.startsWith('@') ? nextState.slice(1) : nextState
+}
+
+function collectFixtureRuleActions(source: string): {
+  line: number
+  state: string
+  matched: string
+  nextState?: string
+  nextEmbedded?: string
+}[] {
+  const ruleActions: {
+    line: number
+    state: string
+    matched: string
+    nextState?: string
+    nextEmbedded?: string
+  }[] = []
+  const tokenizer = vueMonarchLanguage.tokenizer as Record<string, MonarchRule[]>
+  const lines = source.split('\n')
+  const checks: { line: number; state: string; pattern: string }[] = [
+    { line: 1, state: 'root', pattern: '<template' },
+    { line: 1, state: 'templateOpen', pattern: '>' },
+    { line: 2, state: 'templateBody', pattern: '{{' },
+    { line: 2, state: 'templateExpression', pattern: '}}' },
+    { line: 3, state: 'templateBody', pattern: '</template>' },
+    { line: 5, state: 'root', pattern: '<script' },
+    { line: 5, state: 'scriptOpen', pattern: '>' },
+    { line: 7, state: 'scriptBody', pattern: '</script>' },
+    { line: 9, state: 'root', pattern: '<style' },
+    { line: 9, state: 'styleOpen', pattern: '>' },
+    { line: 11, state: 'styleBody', pattern: '</style>' }
+  ]
+
+  checks.forEach((check) => {
+    const line = lines.at(check.line - 1) ?? ''
+    const stateRules = tokenizer[check.state]
+    const matchedRule = stateRules.find(([regexp]) => {
+      regexp.lastIndex = 0
+      const match = regexp.exec(line)
+      return match !== null && match[0] === check.pattern
+    })
+    if (!matchedRule) {
+      return
+    }
+
+    const [, action, nextStateShortcut] = matchedRule
+    const actionObject =
+      typeof action === 'object'
+        ? (action as { next?: string; nextEmbedded?: string })
+        : nextStateShortcut
+          ? { next: nextStateShortcut }
+          : undefined
+
+    ruleActions.push({
+      line: check.line,
+      state: check.state,
+      matched: check.pattern,
+      nextState: actionObject?.next ? normalizeState(actionObject.next) : undefined,
+      nextEmbedded: actionObject?.nextEmbedded
+    })
+  })
+
+  return ruleActions
+}
+
+describe('registerVueLanguage', () => {
+  it('registers the vue language, Monarch tokenizer, and configuration once', () => {
+    const languages: { id: string }[] = [{ id: 'typescript' }]
+    const register = vi.fn((entry: { id: string }) => {
+      languages.push({ id: entry.id })
+    })
+    const setMonarchTokensProvider = vi.fn()
+    const setLanguageConfiguration = vi.fn()
+    const getLanguages = vi.fn(() => languages)
+    const monacoMock = {
+      languages: {
+        register,
+        setMonarchTokensProvider,
+        setLanguageConfiguration,
+        getLanguages
+      }
+    }
+
+    registerVueLanguage(monacoMock as never)
+    registerVueLanguage(monacoMock as never)
+
+    expect(register).toHaveBeenCalledTimes(1)
+    expect(register).toHaveBeenCalledWith({
+      id: 'vue',
+      extensions: ['.vue'],
+      aliases: ['Vue']
+    })
+    expect(setMonarchTokensProvider).toHaveBeenCalledTimes(1)
+    expect(setMonarchTokensProvider).toHaveBeenCalledWith('vue', vueMonarchLanguage)
+    expect(setLanguageConfiguration).toHaveBeenCalledTimes(1)
+    expect(setLanguageConfiguration).toHaveBeenCalledWith('vue', vueLanguageConfiguration)
+  })
+
+  it('captures Vue tokenizer transitions for a representative SFC fixture', () => {
+    const fixture = `<template>
+  <p>{{ message.toUpperCase() }}</p>
+</template>
+
+<script setup lang="ts">
+const message = 'hello'
+</script>
+
+<style scoped>
+p { color: rebeccapurple; }
+</style>`
+
+    const ruleActions = collectFixtureRuleActions(fixture)
+
+    expect(ruleActions).toMatchInlineSnapshot(`
+      [
+        {
+          "line": 1,
+          "matched": "<template",
+          "nextEmbedded": undefined,
+          "nextState": "templateOpen",
+          "state": "root",
+        },
+        {
+          "line": 1,
+          "matched": ">",
+          "nextEmbedded": "html",
+          "nextState": "templateBody",
+          "state": "templateOpen",
+        },
+        {
+          "line": 2,
+          "matched": "{{",
+          "nextEmbedded": "@pop",
+          "nextState": "templateExpression",
+          "state": "templateBody",
+        },
+        {
+          "line": 2,
+          "matched": "}}",
+          "nextEmbedded": "html",
+          "nextState": "pop",
+          "state": "templateExpression",
+        },
+        {
+          "line": 3,
+          "matched": "</template>",
+          "nextEmbedded": "@pop",
+          "nextState": "pop",
+          "state": "templateBody",
+        },
+        {
+          "line": 5,
+          "matched": "<script",
+          "nextEmbedded": undefined,
+          "nextState": "scriptOpen",
+          "state": "root",
+        },
+        {
+          "line": 5,
+          "matched": ">",
+          "nextEmbedded": "typescript",
+          "nextState": "scriptBody",
+          "state": "scriptOpen",
+        },
+        {
+          "line": 7,
+          "matched": "</script>",
+          "nextEmbedded": "@pop",
+          "nextState": "pop",
+          "state": "scriptBody",
+        },
+        {
+          "line": 9,
+          "matched": "<style",
+          "nextEmbedded": undefined,
+          "nextState": "styleOpen",
+          "state": "root",
+        },
+        {
+          "line": 9,
+          "matched": ">",
+          "nextEmbedded": "css",
+          "nextState": "styleBody",
+          "state": "styleOpen",
+        },
+        {
+          "line": 11,
+          "matched": "</style>",
+          "nextEmbedded": "@pop",
+          "nextState": "pop",
+          "state": "styleBody",
+        },
+      ]
+    `)
+  })
+})

--- a/src/renderer/src/lib/monaco-languages/register-vue.test.ts
+++ b/src/renderer/src/lib/monaco-languages/register-vue.test.ts
@@ -1,10 +1,44 @@
 import { describe, expect, it, vi } from 'vitest'
 import { registerVueLanguage, vueLanguageConfiguration, vueMonarchLanguage } from './register-vue'
 
-type MonarchRule = [RegExp, unknown, string?]
+type MonarchAction = {
+  next?: string
+  nextEmbedded?: string
+  switchTo?: string
+}
+type MonarchRule = [RegExp, string | MonarchAction, string?] | { include: string }
 
 function normalizeState(nextState: string): string {
   return nextState.startsWith('@') ? nextState.slice(1) : nextState
+}
+
+function isRuleEntry(rule: MonarchRule): rule is [RegExp, string | MonarchAction, string?] {
+  return Array.isArray(rule)
+}
+
+function getRuleAction(rule: [RegExp, string | MonarchAction, string?]): MonarchAction | undefined {
+  const [, action, nextStateShortcut] = rule
+  return typeof action === 'object'
+    ? action
+    : nextStateShortcut
+      ? { next: nextStateShortcut }
+      : undefined
+}
+
+function findRuleAction(state: string, source: string): MonarchAction | undefined {
+  const tokenizer = vueMonarchLanguage.tokenizer as Record<string, MonarchRule[]>
+  const stateRules = tokenizer[state] ?? tokenizer[state.split('.')[0]]
+  const matchedRule = stateRules.find((rule) => {
+    if (!isRuleEntry(rule)) {
+      return false
+    }
+    const [regexp] = rule
+    regexp.lastIndex = 0
+    const match = regexp.exec(source)
+    return match !== null && match.index === 0
+  })
+
+  return matchedRule && isRuleEntry(matchedRule) ? getRuleAction(matchedRule) : undefined
 }
 
 function collectFixtureRuleActions(source: string): {
@@ -13,6 +47,7 @@ function collectFixtureRuleActions(source: string): {
   matched: string
   nextState?: string
   nextEmbedded?: string
+  switchTo?: string
 }[] {
   const ruleActions: {
     line: number
@@ -20,6 +55,7 @@ function collectFixtureRuleActions(source: string): {
     matched: string
     nextState?: string
     nextEmbedded?: string
+    switchTo?: string
   }[] = []
   const tokenizer = vueMonarchLanguage.tokenizer as Record<string, MonarchRule[]>
   const lines = source.split('\n')
@@ -30,39 +66,38 @@ function collectFixtureRuleActions(source: string): {
     { line: 2, state: 'templateExpression', pattern: '}}' },
     { line: 3, state: 'templateBody', pattern: '</template>' },
     { line: 5, state: 'root', pattern: '<script' },
-    { line: 5, state: 'scriptOpen', pattern: '>' },
-    { line: 7, state: 'scriptBody', pattern: '</script>' },
+    { line: 5, state: 'scriptOpen.typescript', pattern: '>' },
+    { line: 7, state: 'scriptBody.typescript', pattern: '</script>' },
     { line: 9, state: 'root', pattern: '<style' },
-    { line: 9, state: 'styleOpen', pattern: '>' },
-    { line: 11, state: 'styleBody', pattern: '</style>' }
+    { line: 9, state: 'styleOpen.css', pattern: '>' },
+    { line: 11, state: 'styleBody.css', pattern: '</style>' }
   ]
 
   checks.forEach((check) => {
     const line = lines.at(check.line - 1) ?? ''
-    const stateRules = tokenizer[check.state]
-    const matchedRule = stateRules.find(([regexp]) => {
+    const stateRules = tokenizer[check.state] ?? tokenizer[check.state.split('.')[0]]
+    const matchedRule = stateRules.find((rule) => {
+      if (!isRuleEntry(rule)) {
+        return false
+      }
+      const [regexp] = rule
       regexp.lastIndex = 0
       const match = regexp.exec(line)
       return match !== null && match[0] === check.pattern
     })
-    if (!matchedRule) {
+    if (!matchedRule || !isRuleEntry(matchedRule)) {
       return
     }
 
-    const [, action, nextStateShortcut] = matchedRule
-    const actionObject =
-      typeof action === 'object'
-        ? (action as { next?: string; nextEmbedded?: string })
-        : nextStateShortcut
-          ? { next: nextStateShortcut }
-          : undefined
+    const actionObject = getRuleAction(matchedRule)
 
     ruleActions.push({
       line: check.line,
       state: check.state,
       matched: check.pattern,
       nextState: actionObject?.next ? normalizeState(actionObject.next) : undefined,
-      nextEmbedded: actionObject?.nextEmbedded
+      nextEmbedded: actionObject?.nextEmbedded,
+      switchTo: actionObject?.switchTo ? normalizeState(actionObject.switchTo) : undefined
     })
   })
 
@@ -125,27 +160,31 @@ p { color: rebeccapurple; }
           "nextEmbedded": undefined,
           "nextState": "templateOpen",
           "state": "root",
+          "switchTo": undefined,
         },
         {
           "line": 1,
           "matched": ">",
           "nextEmbedded": "html",
-          "nextState": "templateBody",
+          "nextState": undefined,
           "state": "templateOpen",
+          "switchTo": "templateBody",
         },
         {
           "line": 2,
           "matched": "{{",
           "nextEmbedded": "@pop",
-          "nextState": "templateExpression",
+          "nextState": "templateExpressionEnter",
           "state": "templateBody",
+          "switchTo": undefined,
         },
         {
           "line": 2,
           "matched": "}}",
-          "nextEmbedded": "html",
+          "nextEmbedded": "@pop",
           "nextState": "pop",
           "state": "templateExpression",
+          "switchTo": undefined,
         },
         {
           "line": 3,
@@ -153,50 +192,79 @@ p { color: rebeccapurple; }
           "nextEmbedded": "@pop",
           "nextState": "pop",
           "state": "templateBody",
+          "switchTo": undefined,
         },
         {
           "line": 5,
           "matched": "<script",
           "nextEmbedded": undefined,
-          "nextState": "scriptOpen",
+          "nextState": "scriptOpen.typescript",
           "state": "root",
+          "switchTo": undefined,
         },
         {
           "line": 5,
           "matched": ">",
-          "nextEmbedded": "typescript",
-          "nextState": "scriptBody",
-          "state": "scriptOpen",
+          "nextEmbedded": "$S2",
+          "nextState": undefined,
+          "state": "scriptOpen.typescript",
+          "switchTo": "scriptBody.$S2",
         },
         {
           "line": 7,
           "matched": "</script>",
           "nextEmbedded": "@pop",
           "nextState": "pop",
-          "state": "scriptBody",
+          "state": "scriptBody.typescript",
+          "switchTo": undefined,
         },
         {
           "line": 9,
           "matched": "<style",
           "nextEmbedded": undefined,
-          "nextState": "styleOpen",
+          "nextState": "styleOpen.css",
           "state": "root",
+          "switchTo": undefined,
         },
         {
           "line": 9,
           "matched": ">",
-          "nextEmbedded": "css",
-          "nextState": "styleBody",
-          "state": "styleOpen",
+          "nextEmbedded": "$S2",
+          "nextState": undefined,
+          "state": "styleOpen.css",
+          "switchTo": "styleBody.$S2",
         },
         {
           "line": 11,
           "matched": "</style>",
           "nextEmbedded": "@pop",
           "nextState": "pop",
-          "state": "styleBody",
+          "state": "styleBody.css",
+          "switchTo": undefined,
         },
       ]
     `)
+  })
+
+  it('tracks embedded languages from Vue block attributes', () => {
+    expect(findRuleAction('templateExpressionEnter', 'message }}')).toMatchObject({
+      nextEmbedded: 'typescript',
+      switchTo: '@templateExpression'
+    })
+    expect(findRuleAction('scriptLangValue.typescript', '"js"')).toMatchObject({
+      switchTo: '@scriptOpen.javascript'
+    })
+    expect(findRuleAction('scriptLangValue.javascript', '"ts"')).toMatchObject({
+      switchTo: '@scriptOpen.typescript'
+    })
+    expect(findRuleAction('scriptLangValue.typescript', 'js')).toMatchObject({
+      switchTo: '@scriptOpen.javascript'
+    })
+    expect(findRuleAction('styleLangValue.css', '"scss"')).toMatchObject({
+      switchTo: '@styleOpen.scss'
+    })
+    expect(findRuleAction('styleLangValue.css', 'less')).toMatchObject({
+      switchTo: '@styleOpen.less'
+    })
   })
 })

--- a/src/renderer/src/lib/monaco-languages/register-vue.ts
+++ b/src/renderer/src/lib/monaco-languages/register-vue.ts
@@ -1,0 +1,113 @@
+import type * as Monaco from 'monaco-editor'
+
+type MonacoModule = typeof Monaco
+
+export const vueMonarchLanguage: Monaco.languages.IMonarchLanguage = {
+  defaultToken: '',
+  tokenPostfix: '.vue',
+  ignoreCase: true,
+  brackets: [
+    { open: '{', close: '}', token: 'delimiter.curly' },
+    { open: '[', close: ']', token: 'delimiter.square' },
+    { open: '(', close: ')', token: 'delimiter.parenthesis' },
+    { open: '<', close: '>', token: 'delimiter.angle' }
+  ],
+  tokenizer: {
+    root: [
+      [/<template(?=\s|>)/, 'tag', '@templateOpen'],
+      [/<script(?=\s|>)/, 'tag', '@scriptOpen'],
+      [/<style(?=\s|>)/, 'tag', '@styleOpen'],
+      [/<!--/, 'comment', '@comment'],
+      [/<\/?[A-Za-z][^>]*>/, 'tag'],
+      [/[^<]+/, '']
+    ],
+    comment: [
+      [/-->/, 'comment', '@pop'],
+      [/[^-]+/, 'comment'],
+      [/./, 'comment']
+    ],
+    templateOpen: [
+      [/\/>/, 'tag', '@pop'],
+      [/>/, { token: 'tag', next: '@templateBody', nextEmbedded: 'html' }],
+      [/[^\s/>=]+/, 'attribute.name'],
+      [/=/, 'delimiter'],
+      [/"[^"]*"/, 'attribute.value'],
+      [/'[^']*'/, 'attribute.value'],
+      [/\s+/, 'white']
+    ],
+    templateBody: [
+      [/\{\{/, { token: 'delimiter.curly', next: '@templateExpression', nextEmbedded: '@pop' }],
+      [/<\/template\s*>/, { token: 'tag', next: '@pop', nextEmbedded: '@pop' }]
+    ],
+    templateExpression: [
+      [/\}\}/, { token: 'delimiter.curly', next: '@pop', nextEmbedded: 'html' }],
+      [/[^}]+/, 'metatag'],
+      [/./, 'metatag']
+    ],
+    scriptOpen: [
+      [/\/>/, 'tag', '@pop'],
+      [/>/, { token: 'tag', next: '@scriptBody', nextEmbedded: 'typescript' }],
+      [/[^\s/>=]+/, 'attribute.name'],
+      [/=/, 'delimiter'],
+      [/"[^"]*"/, 'attribute.value'],
+      [/'[^']*'/, 'attribute.value'],
+      [/\s+/, 'white']
+    ],
+    scriptBody: [[/<\/script\s*>/, { token: 'tag', next: '@pop', nextEmbedded: '@pop' }]],
+    styleOpen: [
+      [/\/>/, 'tag', '@pop'],
+      [/>/, { token: 'tag', next: '@styleBody', nextEmbedded: 'css' }],
+      [/[^\s/>=]+/, 'attribute.name'],
+      [/=/, 'delimiter'],
+      [/"[^"]*"/, 'attribute.value'],
+      [/'[^']*'/, 'attribute.value'],
+      [/\s+/, 'white']
+    ],
+    styleBody: [[/<\/style\s*>/, { token: 'tag', next: '@pop', nextEmbedded: '@pop' }]]
+  }
+}
+
+export const vueLanguageConfiguration: Monaco.languages.LanguageConfiguration = {
+  comments: { blockComment: ['<!--', '-->'] },
+  brackets: [
+    ['{', '}'],
+    ['[', ']'],
+    ['(', ')'],
+    ['<', '>']
+  ],
+  autoClosingPairs: [
+    { open: '{', close: '}' },
+    { open: '[', close: ']' },
+    { open: '(', close: ')' },
+    { open: '"', close: '"' },
+    { open: "'", close: "'" },
+    { open: '`', close: '`' },
+    { open: '<', close: '>' }
+  ],
+  surroundingPairs: [
+    { open: '{', close: '}' },
+    { open: '[', close: ']' },
+    { open: '(', close: ')' },
+    { open: '"', close: '"' },
+    { open: "'", close: "'" },
+    { open: '`', close: '`' },
+    { open: '<', close: '>' }
+  ]
+}
+
+export function registerVueLanguage(monaco: MonacoModule): void {
+  const vueAlreadyRegistered = monaco.languages
+    .getLanguages()
+    .some((language) => language.id === 'vue')
+  if (vueAlreadyRegistered) {
+    return
+  }
+
+  monaco.languages.register({
+    id: 'vue',
+    extensions: ['.vue'],
+    aliases: ['Vue']
+  })
+  monaco.languages.setMonarchTokensProvider('vue', vueMonarchLanguage)
+  monaco.languages.setLanguageConfiguration('vue', vueLanguageConfiguration)
+}

--- a/src/renderer/src/lib/monaco-languages/register-vue.ts
+++ b/src/renderer/src/lib/monaco-languages/register-vue.ts
@@ -37,6 +37,10 @@ export const vueMonarchLanguage: Monaco.languages.IMonarchLanguage = {
         { token: 'delimiter.curly', next: '@templateExpressionEnter', nextEmbedded: '@pop' }
       ],
       [/<\/template\s*>/, { token: 'tag', next: '@pop', nextEmbedded: '@pop' }],
+      // After a `{{ ... }}` interpolation returns here, the html embed
+      // has been popped alongside the typescript expression embed. Re-enter
+      // html so the remaining template markup is tokenized by Monaco's html
+      // tokenizer instead of falling back to the empty default token.
       [/(?=.)/, { token: '', nextEmbedded: 'html' }]
     ],
     templateExpressionEnter: [

--- a/src/renderer/src/lib/monaco-languages/register-vue.ts
+++ b/src/renderer/src/lib/monaco-languages/register-vue.ts
@@ -15,8 +15,8 @@ export const vueMonarchLanguage: Monaco.languages.IMonarchLanguage = {
   tokenizer: {
     root: [
       [/<template(?=\s|>)/, 'tag', '@templateOpen'],
-      [/<script(?=\s|>)/, 'tag', '@scriptOpen'],
-      [/<style(?=\s|>)/, 'tag', '@styleOpen'],
+      [/<script(?=\s|>)/, 'tag', '@scriptOpen.typescript'],
+      [/<style(?=\s|>)/, 'tag', '@styleOpen.css'],
       [/<!--/, 'comment', '@comment'],
       [/<\/?[A-Za-z][^>]*>/, 'tag'],
       [/[^<]+/, '']
@@ -28,42 +28,91 @@ export const vueMonarchLanguage: Monaco.languages.IMonarchLanguage = {
     ],
     templateOpen: [
       [/\/>/, 'tag', '@pop'],
-      [/>/, { token: 'tag', next: '@templateBody', nextEmbedded: 'html' }],
-      [/[^\s/>=]+/, 'attribute.name'],
-      [/=/, 'delimiter'],
-      [/"[^"]*"/, 'attribute.value'],
-      [/'[^']*'/, 'attribute.value'],
-      [/\s+/, 'white']
+      [/>/, { token: 'tag', switchTo: '@templateBody', nextEmbedded: 'html' }],
+      { include: '@tagAttributes' }
     ],
     templateBody: [
-      [/\{\{/, { token: 'delimiter.curly', next: '@templateExpression', nextEmbedded: '@pop' }],
-      [/<\/template\s*>/, { token: 'tag', next: '@pop', nextEmbedded: '@pop' }]
+      [
+        /\{\{/,
+        { token: 'delimiter.curly', next: '@templateExpressionEnter', nextEmbedded: '@pop' }
+      ],
+      [/<\/template\s*>/, { token: 'tag', next: '@pop', nextEmbedded: '@pop' }],
+      [/(?=.)/, { token: '', nextEmbedded: 'html' }]
+    ],
+    templateExpressionEnter: [
+      [/\}\}/, { token: 'delimiter.curly', next: '@pop' }],
+      [/(?=.)/, { token: '', switchTo: '@templateExpression', nextEmbedded: 'typescript' }]
     ],
     templateExpression: [
-      [/\}\}/, { token: 'delimiter.curly', next: '@pop', nextEmbedded: 'html' }],
-      [/[^}]+/, 'metatag'],
-      [/./, 'metatag']
+      [/\}\}/, { token: 'delimiter.curly', next: '@pop', nextEmbedded: '@pop' }]
     ],
     scriptOpen: [
       [/\/>/, 'tag', '@pop'],
-      [/>/, { token: 'tag', next: '@scriptBody', nextEmbedded: 'typescript' }],
-      [/[^\s/>=]+/, 'attribute.name'],
-      [/=/, 'delimiter'],
-      [/"[^"]*"/, 'attribute.value'],
-      [/'[^']*'/, 'attribute.value'],
+      [/>/, { token: 'tag', switchTo: '@scriptBody.$S2', nextEmbedded: '$S2' }],
+      [/lang(?=\s*=)/, { token: 'attribute.name', switchTo: '@scriptLangBeforeEquals.$S2' }],
+      { include: '@tagAttributes' }
+    ],
+    scriptLangBeforeEquals: [
+      [/=/, { token: 'delimiter', switchTo: '@scriptLangValue.$S2' }],
+      [/\s+/, 'white'],
+      [/(?=.)/, { token: '', switchTo: '@scriptOpen.$S2' }]
+    ],
+    scriptLangValue: [
+      [/"(?:js|javascript)"/, { token: 'attribute.value', switchTo: '@scriptOpen.javascript' }],
+      [/'(?:js|javascript)'/, { token: 'attribute.value', switchTo: '@scriptOpen.javascript' }],
+      [
+        /(?:js|javascript)(?=\s|\/|>|$)/,
+        { token: 'attribute.value', switchTo: '@scriptOpen.javascript' }
+      ],
+      [/"(?:ts|typescript)"/, { token: 'attribute.value', switchTo: '@scriptOpen.typescript' }],
+      [/'(?:ts|typescript)'/, { token: 'attribute.value', switchTo: '@scriptOpen.typescript' }],
+      [
+        /(?:ts|typescript)(?=\s|\/|>|$)/,
+        { token: 'attribute.value', switchTo: '@scriptOpen.typescript' }
+      ],
+      [/[^\s/>]+/, { token: 'attribute.value', switchTo: '@scriptOpen.$S2' }],
+      [/"[^"]*"/, { token: 'attribute.value', switchTo: '@scriptOpen.$S2' }],
+      [/'[^']*'/, { token: 'attribute.value', switchTo: '@scriptOpen.$S2' }],
       [/\s+/, 'white']
     ],
     scriptBody: [[/<\/script\s*>/, { token: 'tag', next: '@pop', nextEmbedded: '@pop' }]],
     styleOpen: [
       [/\/>/, 'tag', '@pop'],
-      [/>/, { token: 'tag', next: '@styleBody', nextEmbedded: 'css' }],
+      [/>/, { token: 'tag', switchTo: '@styleBody.$S2', nextEmbedded: '$S2' }],
+      [/lang(?=\s*=)/, { token: 'attribute.name', switchTo: '@styleLangBeforeEquals.$S2' }],
+      { include: '@tagAttributes' }
+    ],
+    styleLangBeforeEquals: [
+      [/=/, { token: 'delimiter', switchTo: '@styleLangValue.$S2' }],
+      [/\s+/, 'white'],
+      [/(?=.)/, { token: '', switchTo: '@styleOpen.$S2' }]
+    ],
+    styleLangValue: [
+      [/"scss"/, { token: 'attribute.value', switchTo: '@styleOpen.scss' }],
+      [/'scss'/, { token: 'attribute.value', switchTo: '@styleOpen.scss' }],
+      [/scss(?=\s|\/|>|$)/, { token: 'attribute.value', switchTo: '@styleOpen.scss' }],
+      [/"sass"/, { token: 'attribute.value', switchTo: '@styleOpen.scss' }],
+      [/'sass'/, { token: 'attribute.value', switchTo: '@styleOpen.scss' }],
+      [/sass(?=\s|\/|>|$)/, { token: 'attribute.value', switchTo: '@styleOpen.scss' }],
+      [/"less"/, { token: 'attribute.value', switchTo: '@styleOpen.less' }],
+      [/'less'/, { token: 'attribute.value', switchTo: '@styleOpen.less' }],
+      [/less(?=\s|\/|>|$)/, { token: 'attribute.value', switchTo: '@styleOpen.less' }],
+      [/"css"/, { token: 'attribute.value', switchTo: '@styleOpen.css' }],
+      [/'css'/, { token: 'attribute.value', switchTo: '@styleOpen.css' }],
+      [/css(?=\s|\/|>|$)/, { token: 'attribute.value', switchTo: '@styleOpen.css' }],
+      [/[^\s/>]+/, { token: 'attribute.value', switchTo: '@styleOpen.$S2' }],
+      [/"[^"]*"/, { token: 'attribute.value', switchTo: '@styleOpen.$S2' }],
+      [/'[^']*'/, { token: 'attribute.value', switchTo: '@styleOpen.$S2' }],
+      [/\s+/, 'white']
+    ],
+    styleBody: [[/<\/style\s*>/, { token: 'tag', next: '@pop', nextEmbedded: '@pop' }]],
+    tagAttributes: [
       [/[^\s/>=]+/, 'attribute.name'],
       [/=/, 'delimiter'],
       [/"[^"]*"/, 'attribute.value'],
       [/'[^']*'/, 'attribute.value'],
       [/\s+/, 'white']
-    ],
-    styleBody: [[/<\/style\s*>/, { token: 'tag', next: '@pop', nextEmbedded: '@pop' }]]
+    ]
   }
 }
 

--- a/src/renderer/src/lib/monaco-setup.ts
+++ b/src/renderer/src/lib/monaco-setup.ts
@@ -7,6 +7,7 @@ import jsonWorker from 'monaco-editor/esm/vs/language/json/json.worker?worker'
 import cssWorker from 'monaco-editor/esm/vs/language/css/css.worker?worker'
 import htmlWorker from 'monaco-editor/esm/vs/language/html/html.worker?worker'
 import tsWorker from 'monaco-editor/esm/vs/language/typescript/ts.worker?worker'
+import { registerVueLanguage } from './monaco-languages/register-vue'
 
 globalThis.MonacoEnvironment = {
   getWorker(_workerId, label) {
@@ -73,6 +74,8 @@ monacoTS.javascriptDefaults.setCompilerOptions({
   ...monacoTS.javascriptDefaults.getCompilerOptions(),
   jsx: monacoTS.JsxEmit.Preserve
 })
+
+registerVueLanguage(monaco)
 
 // Configure Monaco to use the locally bundled editor instead of CDN
 loader.config({ monaco })


### PR DESCRIPTION
## Summary

Refs #1085 (Vue half).

Today `.vue`, `.svelte`, and `.astro` are all aliased to `html` in `language-detect.ts`, which gives Vue SFCs HTML-level coloring only and leaves TypeScript inside `<script setup lang="ts">` and template expressions like `{{ foo }}` un-tokenized.

This PR ships Option A from the RFC for Vue specifically: a Monaco Monarch grammar that embeds the existing `typescript` tokenizer inside `<script>` / `<script setup>`, the `html` tokenizer inside `<template>`, and the `css` tokenizer inside `<style>`. Per the RFC's "start with Vue since more users ask," Astro and Svelte are intentionally deferred to follow-up PRs - the interim `.astro` -> `html` alias from #1084 is preserved.

## Screenshots

Code change (the `.vue` mapping moves from `'html'` to a registered `'vue'` language; new helper at `src/renderer/src/lib/monaco-languages/register-vue.ts` registers the language + Monarch tokenizer once during Monaco bootstrap):

![Code change](https://files.catbox.moe/nhfotb.gif)

Visible result: open any `.vue` file in the editor. Template, script, and style sections are now tokenized by the embedded HTML / TypeScript / CSS tokenizers respectively, instead of one whole-file HTML pass.

## Testing

- [x] `pnpm lint` (2 pre-existing warnings in `useDiffCommentDecorator.tsx`, 0 errors from this change)
- [x] `pnpm typecheck` (all three configs pass)
- [x] `pnpm test` (241 files, 2716 tests pass)
- [x] `pnpm build` (success)
- [x] Added `language-detect.test.ts` covering `.vue` -> `'vue'` and confirming `.svelte`/`.astro` still return `'html'`
- [x] Added `monaco-languages/register-vue.test.ts` with a tokenizer-transition test that walks a representative Vue SFC fixture (template / script setup lang="ts" / style scoped) and asserts the expected `nextEmbedded` languages at each open/close boundary

## AI Review Report

Implementation by Codex (gpt-5.3-codex, medium reasoning). One review pass via `codex review --base upstream/main`:

> "The changes add Vue language detection and a Monaco Monarch tokenizer without introducing evident correctness regressions. Targeted tests and web typechecking pass."

The review pass focused on: tokenizer state machine correctness (no infinite loops, all states reachable, all states have a way to pop), idempotent registration (the helper guards against double-registration when Monaco hot-reloads), no regression on `.svelte`/`.astro` (still HTML), no Monaco version assumptions that break in future upgrades.

This contribution was developed with AI assistance.
