### PR TITLE
ci: auto-label PRs by size

### DIFF
--- a/.github/pull-request-size.yml
+++ b/.github/pull-request-size.yml
@@ -1,0 +1,50 @@
+# Configuration for cbrgm/pr-size-labeler-action
+# See: https://github.com/cbrgm/pr-size-labeler-action
+#
+# A PR gets the smallest label whose `diff` and `files` thresholds both fit.
+# Generated/lock/vendored files are excluded so they don't dominate the size calculation.
+
+exclude_files:
+  - "**/pnpm-lock.yaml"
+  - "**/package-lock.json"
+  - "**/yarn.lock"
+  - "**/*.lock"
+  - "**/*.snap"
+  - "**/dist/**"
+  - "**/build/**"
+  - "**/node_modules/**"
+  - "**/vendor/**"
+  - "**/*.min.js"
+  - "**/*.min.css"
+  - "**/*.map"
+  - "**/*.generated.*"
+  - "**/generated/**"
+
+label_configs:
+  - size: xs
+    diff: 25
+    files: 1
+    labels: ["size/xs"]
+
+  - size: s
+    diff: 150
+    files: 10
+    labels: ["size/s"]
+
+  - size: m
+    diff: 600
+    files: 25
+    labels: ["size/m"]
+
+  - size: l
+    diff: 2500
+    files: 50
+    labels: ["size/l"]
+
+  - size: xl
+    diff: 5000
+    files: 100
+    labels: ["size/xl"]
+
+# Count only added lines (ignore deletions) so large refactors/removals aren't over-penalized.
+added_lines_only: true

--- a/.github/workflows/pr-size-labeler.yml
+++ b/.github/workflows/pr-size-labeler.yml
@@ -1,0 +1,29 @@
+name: PR Size Labeler
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - edited
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  label-pr-size:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Label PR based on size
+        uses: cbrgm/pr-size-labeler-action@v1.3.7
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_repository: ${{ github.repository }}
+          github_pr_number: ${{ github.event.pull_request.number }}
+          config_file_path: .github/pull-request-size.yml


### PR DESCRIPTION
## Summary
- Adds `cbrgm/pr-size-labeler-action@v1.3.7` workflow that applies `size/xs`..`size/xl` labels to PRs based on files changed and lines added.
- Adds `.github/pull-request-size.yml` config with lock/generated/vendored paths excluded and `added_lines_only: true` so big deletions/refactors aren't over-penalized.
- Size labels (xs/s/m/l/xl) created on the repo with a green→red color ramp.

## Test plan
- [x] `size/*` labels exist on repo (verified via `gh label list`)
- [ ] Workflow runs on this PR and applies a `size/*` label
- [ ] Re-runs on subsequent pushes (workflow triggers on `synchronize`)

Made with [Orca](https://github.com/stablyai/orca) 🐋
