### PR TITLE
fix(pi): surface Pi working spinner on worktree card

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-dispatcher-pi-routing.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-dispatcher-pi-routing.test.ts
@@ -1,0 +1,154 @@
+// Why: reproduce the renderer-level Pi spinner pipeline from the
+// `pty:data` IPC event all the way down to onTitleChange. The electron
+// verification showed spinner frames arrive via IPC but the store never sees
+// "⠋ Pi" — this file pins the integration between the singleton dispatcher
+// and the transport's per-pty handler.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const ESC = '\x1b'
+const BEL = '\x07'
+const workingFrame = (frame: string): string => `${ESC}]0;${frame} π - cwd${BEL}`
+const idleTitle = (): string => `${ESC}]0;π - cwd${BEL}`
+
+describe('dispatcher → transport → onTitleChange for Pi spinner', () => {
+  const originalWindow = (globalThis as { window?: typeof window }).window
+
+  // The singleton dispatcher subscribes a SINGLE global `window.api.pty.onData`
+  // callback on first `ensurePtyDispatcher()`. We simulate the main process
+  // delivering IPC events by invoking that captured callback directly.
+  let dispatcherCallback: ((payload: { id: string; data: string }) => void) | null = null
+
+  beforeEach(() => {
+    vi.resetModules()
+    dispatcherCallback = null
+    ;(globalThis as { window: typeof window }).window = {
+      ...originalWindow,
+      api: {
+        ...originalWindow?.api,
+        pty: {
+          ...originalWindow?.api?.pty,
+          spawn: vi.fn().mockResolvedValue({ id: 'pty-pi' }),
+          write: vi.fn(),
+          resize: vi.fn(),
+          kill: vi.fn(),
+          onData: vi.fn((cb: (payload: { id: string; data: string }) => void) => {
+            // Only the first subscriber wins in production — the dispatcher
+            // calls onData exactly once (ensurePtyDispatcher guards with the
+            // `ptyDispatcherAttached` flag). Subsequent transport calls go
+            // through the same cached subscription, so we capture the first
+            // one and ignore the rest.
+            if (!dispatcherCallback) {
+              dispatcherCallback = cb
+            }
+            return () => {}
+          }),
+          onExit: vi.fn(() => () => {})
+        }
+      }
+    } as unknown as typeof window
+  })
+
+  afterEach(() => {
+    if (originalWindow) {
+      ;(globalThis as { window: typeof window }).window = originalWindow
+    } else {
+      delete (globalThis as { window?: typeof window }).window
+    }
+  })
+
+  it('routes Pi OSC title frames from pty:data → onTitleChange via the dispatcher', async () => {
+    const { createIpcPtyTransport } = await import('./pty-transport')
+    const onTitleChange = vi.fn()
+
+    const transport = createIpcPtyTransport({ onTitleChange })
+    await transport.connect({ url: '', callbacks: {} })
+
+    expect(dispatcherCallback).not.toBeNull()
+
+    // Simulate the main process firing `pty:data` IPC for pty-pi. The
+    // dispatcher looks up `ptyDataHandlers.get('pty-pi')` and calls it with
+    // the data — the same path exercised by a real Pi session.
+    dispatcherCallback?.({ id: 'pty-pi', data: idleTitle() })
+    dispatcherCallback?.({ id: 'pty-pi', data: workingFrame('⠋') })
+    dispatcherCallback?.({ id: 'pty-pi', data: workingFrame('⠙') })
+    dispatcherCallback?.({ id: 'pty-pi', data: idleTitle() })
+
+    const seenTitles = onTitleChange.mock.calls.map((c) => c[0])
+    expect(seenTitles).toContain('⠋ Pi')
+
+    transport.disconnect()
+  })
+
+  it('pipeline survives a chunk carrying shell output interleaved with spinner frames', async () => {
+    // Why: node-pty batches at 8ms on the main side, so the renderer often
+    // sees multiple OSC sequences and body bytes in one chunk. The transport
+    // handler extracts the LAST OSC title in each chunk — working frames that
+    // land as the last title in any chunk must surface through onTitleChange.
+    const { createIpcPtyTransport } = await import('./pty-transport')
+    const onTitleChange = vi.fn()
+
+    const transport = createIpcPtyTransport({ onTitleChange })
+    await transport.connect({ url: '', callbacks: {} })
+
+    dispatcherCallback?.({
+      id: 'pty-pi',
+      data: `assistant output line 1\r\n${workingFrame('⠋')}more body text`
+    })
+
+    const seenTitles = onTitleChange.mock.calls.map((c) => c[0])
+    expect(seenTitles).toContain('⠋ Pi')
+
+    transport.disconnect()
+  })
+
+  it('attach()-flow pipeline delivers working frames to onTitleChange', async () => {
+    // Why: the reattach code path (daemon-backed or intra-session remount)
+    // calls transport.attach() instead of transport.connect(). If the handler
+    // registration drifted between the two paths, Pi sessions restored after
+    // a tab remount would stop emitting spinner signals — consistent with
+    // the electron-level observation where poll-sampled runtimePaneTitlesByTabId
+    // never flipped to "⠋ Pi" during a live working window.
+    const { createIpcPtyTransport } = await import('./pty-transport')
+    const onTitleChange = vi.fn()
+
+    const transport = createIpcPtyTransport({ onTitleChange })
+    transport.attach({ existingPtyId: 'pty-pi', callbacks: {} })
+
+    // Eager-buffer replay in attach() can flush initial titles through the
+    // same handler; only assert about frames we push AFTER attach resolves.
+    onTitleChange.mockClear()
+
+    dispatcherCallback?.({ id: 'pty-pi', data: workingFrame('⠋') })
+
+    const seenTitles = onTitleChange.mock.calls.map((c) => c[0])
+    expect(seenTitles).toContain('⠋ Pi')
+
+    transport.disconnect()
+  })
+
+  it('reproduces "Pi is idle" state: after working→idle, onTitleChange ends on Pi', async () => {
+    // Why: the user-visible bug is that the store shows "Pi" (idle) even
+    // during working — meaning intermediate "⠋ Pi" updates never landed OR
+    // they landed and were then overwritten and dedupe-filtered. Assert that
+    // BOTH labels reach onTitleChange during a working→idle cycle, in order.
+    const { createIpcPtyTransport } = await import('./pty-transport')
+    const onTitleChange = vi.fn()
+
+    const transport = createIpcPtyTransport({ onTitleChange })
+    await transport.connect({ url: '', callbacks: {} })
+
+    dispatcherCallback?.({ id: 'pty-pi', data: idleTitle() })
+    dispatcherCallback?.({ id: 'pty-pi', data: workingFrame('⠋') })
+    dispatcherCallback?.({ id: 'pty-pi', data: workingFrame('⠙') })
+    dispatcherCallback?.({ id: 'pty-pi', data: idleTitle() })
+
+    const seenTitles = onTitleChange.mock.calls.map((c) => c[0])
+    const workingIdx = seenTitles.findIndex((t) => t === '⠋ Pi')
+    const finalIdleIdx = seenTitles.lastIndexOf('Pi')
+    expect(workingIdx).toBeGreaterThanOrEqual(0)
+    expect(finalIdleIdx).toBeGreaterThan(workingIdx)
+
+    transport.disconnect()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/pty-transport-pi-coalesce.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport-pi-coalesce.test.ts
@@ -1,0 +1,101 @@
+// Why: regression guard for the Pi spinner loss. node-pty and the
+// main-process 8ms batch window commonly coalesce multiple OSC title updates
+// into a single IPC payload. Before the fix, the transport's handler used
+// `extractLastOscTitle` and surfaced only the last title — dropping the
+// intermediate working frames when Pi's agent_end flushed a trailing idle
+// title in the same chunk. The worktree card then never observed the
+// working state. Each OSC title in a chunk must reach onTitleChange in
+// order so the agent tracker and the store see the working→idle transition.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const ESC = '\x1b'
+const BEL = '\x07'
+const workingFrame = (frame: string): string => `${ESC}]0;${frame} π - cwd${BEL}`
+const idleTitle = (): string => `${ESC}]0;π - cwd${BEL}`
+
+describe('pty-transport — coalesced OSC titles from Pi', () => {
+  const originalWindow = (globalThis as { window?: typeof window }).window
+  let onData: ((payload: { id: string; data: string }) => void) | null = null
+
+  beforeEach(() => {
+    vi.resetModules()
+    onData = null
+    ;(globalThis as { window: typeof window }).window = {
+      ...originalWindow,
+      api: {
+        ...originalWindow?.api,
+        pty: {
+          ...originalWindow?.api?.pty,
+          spawn: vi.fn().mockResolvedValue({ id: 'pty-pi' }),
+          write: vi.fn(),
+          resize: vi.fn(),
+          kill: vi.fn(),
+          onData: vi.fn((cb: (payload: { id: string; data: string }) => void) => {
+            onData = cb
+            return () => {}
+          }),
+          onExit: vi.fn(() => () => {})
+        }
+      }
+    } as unknown as typeof window
+  })
+
+  afterEach(() => {
+    if (originalWindow) {
+      ;(globalThis as { window: typeof window }).window = originalWindow
+    } else {
+      delete (globalThis as { window?: typeof window }).window
+    }
+  })
+
+  it('surfaces working frames even when the chunk ends with a trailing idle title', async () => {
+    // Why: Pi's extension emits working frames on `agent_start` and a final
+    // idle title on `agent_end`. When the PTY batches those into one IPC
+    // payload, a last-title-only reader would see only the idle title and
+    // the store would never observe the working state. This is the exact
+    // failure mode users hit on fast agents — the spinner never appears.
+    const { createIpcPtyTransport } = await import('./pty-transport')
+    const onTitleChange = vi.fn()
+    const transport = createIpcPtyTransport({ onTitleChange })
+    await transport.connect({ url: '', callbacks: {} })
+
+    // One realistic chunk: working frames from setInterval(80ms) followed by
+    // agent_end's stopAnimation idle title. All buffered by the node-pty
+    // read batch on the main side.
+    // agent_end fires stopAnimation -> trailing idle title after working frames
+    const chunk = `${workingFrame('⠋')}some response text\r\n${workingFrame('⠙')}more response text\r\n${idleTitle()}`
+    onData?.({ id: 'pty-pi', data: chunk })
+
+    const seen = onTitleChange.mock.calls.map((c) => c[0])
+    // Users expect the working state to register SOMEWHERE in the sequence,
+    // even if extractLastOscTitle only took the last frame. The worktree card
+    // renders 'working' as long as detectAgentStatusFromTitle sees a working
+    // title — if the intermediate frames are dropped, users never see the
+    // spinner on fast-agent prompts.
+    expect(seen).toContain('⠋ Pi')
+    // Idle must land last so the spinner disappears on agent_end.
+    expect(seen.at(-1)).toBe('Pi')
+
+    transport.disconnect()
+  })
+
+  it('surfaces working frames when many spinner frames arrive in one chunk', async () => {
+    // Why: a slow renderer/DOM event loop can delay main-process flushes,
+    // batching 10+ 80ms spinner frames into one IPC event. Every frame must
+    // still feed the observer in order.
+    const { createIpcPtyTransport } = await import('./pty-transport')
+    const onTitleChange = vi.fn()
+    const transport = createIpcPtyTransport({ onTitleChange })
+    await transport.connect({ url: '', callbacks: {} })
+
+    const framesChars = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏']
+    const chunk = framesChars.map(workingFrame).join('body\r\n')
+    onData?.({ id: 'pty-pi', data: chunk })
+
+    const seen = onTitleChange.mock.calls.map((c) => c[0])
+    expect(seen).toContain('⠋ Pi')
+
+    transport.disconnect()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/pty-transport-pi-spinner.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport-pi-spinner.test.ts
@@ -1,0 +1,123 @@
+// Why: reproduce the issue (pi spinner not reaching the worktree card on macOS)
+// entirely in unit-test harness. Pi's titlebar extension emits OSC 0 titles of
+// the form `\x1b]0;⠋ π - cwd\x07` (working frames) and `\x1b]0;π - cwd\x07`
+// (idle). The electron-level verification showed these chunks reach `pty:data`
+// but the store's runtimePaneTitlesByTabId never flips to "⠋ Pi". This file
+// pins the transport-level contract: `onTitleChange` must fire for working
+// frames, in the normalized form the store consumes.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const ESC = '\x1b'
+const BEL = '\x07'
+const workingFrame = (frame: string): string => `${ESC}]0;${frame} π - cwd${BEL}`
+const idleTitle = (): string => `${ESC}]0;π - cwd${BEL}`
+
+describe('createIpcPtyTransport — Pi titlebar spinner signal', () => {
+  const originalWindow = (globalThis as { window?: typeof window }).window
+  let onData: ((payload: { id: string; data: string }) => void) | null = null
+
+  beforeEach(() => {
+    vi.resetModules()
+    onData = null
+    ;(globalThis as { window: typeof window }).window = {
+      ...originalWindow,
+      api: {
+        ...originalWindow?.api,
+        pty: {
+          ...originalWindow?.api?.pty,
+          spawn: vi.fn().mockResolvedValue({ id: 'pty-pi' }),
+          write: vi.fn(),
+          resize: vi.fn(),
+          kill: vi.fn(),
+          onData: vi.fn((cb: (payload: { id: string; data: string }) => void) => {
+            onData = cb
+            return () => {}
+          }),
+          onExit: vi.fn(() => () => {})
+        }
+      }
+    } as unknown as typeof window
+  })
+
+  afterEach(() => {
+    if (originalWindow) {
+      ;(globalThis as { window: typeof window }).window = originalWindow
+    } else {
+      delete (globalThis as { window?: typeof window }).window
+    }
+  })
+
+  it('fires onTitleChange with the normalized working label on each spinner frame', async () => {
+    const { createIpcPtyTransport } = await import('./pty-transport')
+    const onTitleChange = vi.fn()
+
+    const transport = createIpcPtyTransport({ onTitleChange })
+    await transport.connect({ url: '', callbacks: {} })
+
+    // Pi boots idle, then agent_start fires and emits working frames, then
+    // agent_end flips back to idle. Each frame is its own `pty:data` chunk —
+    // matches the node-pty batching behavior I captured from a live session.
+    onData?.({ id: 'pty-pi', data: idleTitle() })
+    onData?.({ id: 'pty-pi', data: workingFrame('⠋') }) // ⠋
+    onData?.({ id: 'pty-pi', data: workingFrame('⠙') }) // ⠙
+    onData?.({ id: 'pty-pi', data: workingFrame('⠹') }) // ⠹
+    onData?.({ id: 'pty-pi', data: idleTitle() })
+
+    const normalized = onTitleChange.mock.calls.map((c) => c[0])
+    // The store only stores the normalized label, which is what the worktree
+    // card feeds back into detectAgentStatusFromTitle. The working→idle cycle
+    // must surface at least one "⠋ Pi" so the card can classify the pane as
+    // 'working' (detectAgentStatusFromTitle('⠋ Pi') === 'working').
+    expect(normalized).toContain('⠋ Pi')
+    expect(normalized).toContain('Pi')
+
+    transport.disconnect()
+  })
+
+  it('fires onTitleChange for working frames via attach() (reattach path)', async () => {
+    const { createIpcPtyTransport } = await import('./pty-transport')
+    const onTitleChange = vi.fn()
+
+    const transport = createIpcPtyTransport({ onTitleChange })
+    // Why: reattach is the path taken when a worktree is restored or when
+    // tab re-mounting happens mid-session. The transport must still wire up
+    // the title observer on this path — otherwise Pi emits spinner frames
+    // that never propagate to the store.
+    transport.attach({ existingPtyId: 'pty-pi', callbacks: {} })
+
+    onTitleChange.mockClear()
+
+    onData?.({ id: 'pty-pi', data: workingFrame('⠋') })
+    onData?.({ id: 'pty-pi', data: workingFrame('⠙') })
+
+    const calls = onTitleChange.mock.calls.map((c) => c[0])
+    expect(calls).toContain('⠋ Pi')
+
+    transport.disconnect()
+  })
+
+  it('surfaces working even when a single chunk contains multiple spinner frames', async () => {
+    // Why: node-pty may coalesce multiple 80ms spinner frames into one
+    // `pty:data` event on macOS when the renderer is briefly throttled.
+    // extractLastOscTitle returns only the LAST OSC title in the chunk — if
+    // a chunk happens to end with the idle title (agent_end fires after the
+    // last working frame), the working frames in between must not be the only
+    // signal the transport ever saw. The important guarantee is that during
+    // an actual working period (before agent_end) at least one chunk's last
+    // title is a working frame, and that produces a "⠋ Pi" onTitleChange.
+    const { createIpcPtyTransport } = await import('./pty-transport')
+    const onTitleChange = vi.fn()
+
+    const transport = createIpcPtyTransport({ onTitleChange })
+    await transport.connect({ url: '', callbacks: {} })
+
+    const coalescedWorking = `${workingFrame('⠋')}output\r\n${workingFrame('⠙')}`
+    onData?.({ id: 'pty-pi', data: coalescedWorking })
+
+    const calls = onTitleChange.mock.calls.map((c) => c[0])
+    expect(calls).toContain('⠋ Pi')
+
+    transport.disconnect()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.ts
@@ -7,7 +7,7 @@ import {
   clearWorkingIndicators,
   createAgentStatusTracker,
   normalizeTerminalTitle,
-  extractLastOscTitle
+  extractAllOscTitles
 } from '../../../../shared/agent-detection'
 import {
   ptyDataHandlers,
@@ -232,13 +232,23 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
         storedCallbacks.onData?.(data)
       }
       if (onTitleChange) {
-        const title = extractLastOscTitle(data)
-        if (title !== null) {
+        // Why: feed EVERY OSC title in the chunk through the observer, not just
+        // the last one. node-pty + the main-process 8ms batch window commonly
+        // coalesce multiple title updates into a single IPC payload — for Pi's
+        // 80ms spinner + agent_end idle cycle, the last title in the chunk is
+        // the idle one and the intermediate working frames were silently
+        // dropped, so the worktree card never observed the working state.
+        // Processing titles in order preserves the working→idle transition
+        // that detectAgentStatusFromTitle and agentTracker both key off.
+        const titles = extractAllOscTitles(data)
+        if (titles.length > 0) {
           if (staleTitleTimer) {
             clearTimeout(staleTitleTimer)
             staleTitleTimer = null
           }
-          applyObservedTerminalTitle(title)
+          for (const title of titles) {
+            applyObservedTerminalTitle(title)
+          }
         } else if (lastEmittedTitle && detectAgentStatusFromTitle(lastEmittedTitle) === 'working') {
           if (staleTitleTimer) {
             clearTimeout(staleTitleTimer)

--- a/src/shared/agent-detection.ts
+++ b/src/shared/agent-detection.ts
@@ -94,6 +94,24 @@ export function extractLastOscTitle(data: string): string | null {
   return last
 }
 
+/**
+ * Extract ALL OSC title-set sequences from raw PTY data, in order of appearance.
+ * Why separate from extractLastOscTitle: node-pty and the main-process batch
+ * window (PTY_BATCH_INTERVAL_MS) often coalesce multiple title changes into
+ * one IPC payload. For fast agents (Pi's 80ms spinner + agent_end idle in the
+ * same batch), returning only the last title silently drops the working
+ * transition. Callers that care about driving UI state transitions
+ * (working/idle spinner) need every title in the chunk. See issue #1083's
+ * spinner-miss follow-up.
+ */
+export function extractAllOscTitles(data: string): string[] {
+  const titles: string[] = []
+  for (const m of data.matchAll(OSC_TITLE_RE)) {
+    titles.push(m[2])
+  }
+  return titles
+}
+
 export function isGeminiTerminalTitle(title: string): boolean {
   return (
     title.includes(GEMINI_PERMISSION) ||


### PR DESCRIPTION
## Summary

- Pi's titlebar extension emits OSC 0 title updates every 80ms during
  work (`⠋ π - cwd`, `⠙ π - cwd`, …) and a trailing idle title on
  `agent_end` (`π - cwd`). node-pty + the main-process 8ms batch window
  commonly coalesce multiple updates into one `pty:data` IPC chunk.
- The pty-transport's data handler used `extractLastOscTitle`, which
  returns **only the final title** in the chunk. For fast agents (Pi with
  a small local model, ~200ms round-trip), the whole working→idle cycle
  landed in one payload — intermediate working frames were dropped, and
  the worktree card's `detectAgentStatusFromTitle` only ever saw the
  idle title.
- Fix: add `extractAllOscTitles` and feed every title in the chunk
  through `applyObservedTerminalTitle` in order, preserving the
  working→idle transition for the store, agent tracker, and spinner UI.

## Evidence

Before: on macOS, polling `runtimePaneTitlesByTabId` 20×/0.25s during a
multi-second Pi working window showed the stored title stuck at `"Pi"`
throughout, while a raw `ipcRenderer.on('pty:data')` listener captured
the working frames flowing through IPC correctly. The worktree card
rendered a solid green "active" dot instead of the green working
spinner.

After: the same polling captures `"⠋ Pi"` alongside `"Pi"` during the
working period, so the card flips to `'working'` and the spinner
animates.

The bug is also pinned at unit-test level in
`pty-transport-pi-coalesce.test.ts:52-85`: with the old behavior, a
single chunk of `workingFrame + body + workingFrame + body + idleTitle`
only surfaced `"Pi"` via `onTitleChange`. With the fix, `"⠋ Pi"` lands
in sequence before the final idle.

## Test plan

- [x] `pnpm vitest run src/renderer/src/components/terminal-pane src/shared/agent-detection src/main/pi`
  — 153 passing
- [x] `pnpm typecheck` — clean on node/cli/web projects
- [x] Live verify in dev Electron: fresh Pi session, prompt →
  `runtimePaneTitlesByTabId` value transitions to `"⠋ Pi"` during the
  working window and back to `"Pi"` after `agent_end`
- [x] Existing title-handling tests (Claude `. `/`* `, Gemini symbols,
  bell detection, eager-buffer replay, stale-title timer) still pass