### PR TITLE
feat(tasks): improve editability affordances

### DIFF
--- a/src/renderer/src/components/GitHubItemDrawer.tsx
+++ b/src/renderer/src/components/GitHubItemDrawer.tsx
@@ -632,11 +632,12 @@ function GHEditSection({
           <button
             type="button"
             className={cn(
-              'rounded-full border px-2 py-0.5 text-[11px] font-medium transition hover:opacity-80',
+              'group/status inline-flex items-center gap-0.5 rounded-full border px-2 py-0.5 text-[11px] font-medium transition hover:brightness-125 hover:ring-1 hover:ring-white/10',
               getStateTone({ ...item, state: localState })
             )}
           >
             {getStateLabel({ ...item, state: localState })}
+            <ChevronDown className="size-2.5 opacity-50" />
           </button>
         </PopoverTrigger>
         <PopoverContent className="w-36 p-1" align="start">
@@ -671,22 +672,21 @@ function GHEditSection({
           <button
             type="button"
             disabled={isPending('labels') || repoLabels.loading}
-            className="flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[11px] transition hover:bg-muted/40 disabled:opacity-50"
+            className="group/labels inline-flex items-center gap-1 rounded-full border border-border/30 bg-muted/20 px-2 py-0.5 text-[11px] transition hover:brightness-125 hover:ring-1 hover:ring-white/10 disabled:opacity-50"
           >
             {localLabels.length === 0 ? (
               <span className="text-muted-foreground">+ Label</span>
             ) : (
               localLabels.map((name) => (
-                <span
-                  key={name}
-                  className="rounded-full border border-border/50 bg-background/60 px-1.5 py-0.5 text-[10px] text-muted-foreground"
-                >
+                <span key={name} className="text-[10px] text-muted-foreground">
                   {name}
                 </span>
               ))
             )}
-            {isPending('labels') && (
+            {isPending('labels') ? (
               <LoaderCircle className="size-3 animate-spin text-muted-foreground" />
+            ) : (
+              <ChevronDown className="size-2.5 opacity-50" />
             )}
           </button>
         </PopoverTrigger>
@@ -728,22 +728,21 @@ function GHEditSection({
           <button
             type="button"
             disabled={isPending('assignees') || repoAssignees.loading}
-            className="flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[11px] transition hover:bg-muted/40 disabled:opacity-50"
+            className="group/assignees inline-flex items-center gap-1 rounded-full border border-border/30 bg-muted/20 px-2 py-0.5 text-[11px] transition hover:brightness-125 hover:ring-1 hover:ring-white/10 disabled:opacity-50"
           >
             {localAssignees.length === 0 ? (
               <span className="text-muted-foreground">+ Assignee</span>
             ) : (
               localAssignees.map((login) => (
-                <span
-                  key={login}
-                  className="rounded-full border border-border/50 bg-background/60 px-1.5 py-0.5 text-[10px] text-muted-foreground"
-                >
+                <span key={login} className="text-[10px] text-muted-foreground">
                   {login}
                 </span>
               ))
             )}
-            {isPending('assignees') && (
+            {isPending('assignees') ? (
               <LoaderCircle className="size-3 animate-spin text-muted-foreground" />
+            ) : (
+              <ChevronDown className="size-2.5 opacity-50" />
             )}
           </button>
         </PopoverTrigger>

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -5,6 +5,7 @@ place while this surface is still evolving. */
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   ArrowRight,
+  ChevronDown,
   CircleDot,
   EllipsisVertical,
   ExternalLink,
@@ -229,7 +230,7 @@ function GHStatusCell({
     return (
       <span
         className={cn(
-          'rounded-full border px-2 py-0.5 text-[10px] font-medium',
+          'rounded-full border px-2 py-0.5 text-[10px] font-medium opacity-70',
           getTaskStatusTone(item)
         )}
       >
@@ -245,13 +246,14 @@ function GHStatusCell({
           type="button"
           onClick={(e) => e.stopPropagation()}
           className={cn(
-            'rounded-full border px-2 py-0.5 text-[10px] font-medium transition hover:opacity-80',
+            'group/status inline-flex items-center gap-0.5 rounded-full border px-2 py-0.5 text-[10px] font-medium transition hover:brightness-125 hover:ring-1 hover:ring-white/10',
             localState === 'closed'
               ? 'border-rose-500/30 bg-rose-500/10 text-rose-600 dark:text-rose-300'
               : 'border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-300'
           )}
         >
           {localState === 'closed' ? 'Closed' : 'Open'}
+          <ChevronDown className="size-2.5 opacity-50" />
         </button>
       </PopoverTrigger>
       <PopoverContent className="w-36 p-1" align="start" onClick={(e) => e.stopPropagation()}>
@@ -354,13 +356,14 @@ function LinearStatusCell({ issue }: { issue: LinearIssue }): React.JSX.Element 
           type="button"
           onClick={(e) => e.stopPropagation()}
           disabled={states.loading}
-          className="flex items-center gap-1.5 rounded-sm px-1 py-0.5 transition hover:bg-muted/60 disabled:opacity-50"
+          className="group/status flex items-center gap-1.5 rounded-sm px-1 py-0.5 transition hover:bg-muted/60 disabled:opacity-50"
         >
           <span
             className="inline-block size-2 shrink-0 rounded-full"
             style={{ backgroundColor: localState.color }}
           />
           <span className="truncate text-xs text-muted-foreground">{localState.name}</span>
+          <ChevronDown className="size-2.5 shrink-0 text-muted-foreground opacity-50" />
         </button>
       </PopoverTrigger>
       <PopoverContent
@@ -458,10 +461,14 @@ function LinearPriorityCell({ issue }: { issue: LinearIssue }): React.JSX.Elemen
           type="button"
           onClick={(e) => e.stopPropagation()}
           disabled={pending}
-          className="rounded-sm px-1 py-0.5 text-xs text-muted-foreground transition hover:bg-muted/60 disabled:opacity-50"
+          className="group/priority inline-flex items-center gap-0.5 rounded-sm px-1 py-0.5 text-xs text-muted-foreground transition hover:bg-muted/60 disabled:opacity-50"
         >
           {LINEAR_PRIORITY_LABELS[localPriority] ?? `P${localPriority}`}
-          {pending && <LoaderCircle className="ml-1 inline size-3 animate-spin" />}
+          {pending ? (
+            <LoaderCircle className="ml-1 inline size-3 animate-spin" />
+          ) : (
+            <ChevronDown className="size-2.5 shrink-0 opacity-50" />
+          )}
         </button>
       </PopoverTrigger>
       <PopoverContent className="w-36 p-1" align="start" onClick={(e) => e.stopPropagation()}>


### PR DESCRIPTION
## Summary
- Editable elements (status, labels, assignees, priority) now show a chevron dropdown indicator so users can tell they're clickable
- Editable status pills get a brightness + ring hover effect; non-editable PR status badges are muted (`opacity-70`) to visually distinguish them
- Drawer label/assignee buttons restyled as consistent pills with the same hover treatment

## Test plan
- [ ] Open the tasks page on the GitHub tab — verify editable issue status pills show a chevron and non-editable PR statuses look slightly muted
- [ ] Hover over editable status pills — confirm brightness + ring effect
- [ ] Switch to Linear tab — verify status and priority cells show chevrons
- [ ] Open an issue drawer — verify status, label, and assignee pills all show chevrons and have consistent hover effects
- [ ] Click each editable element to confirm popovers still work correctly