### PR TITLE
ci: cache electron + electron-builder tool downloads on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,12 +86,21 @@ jobs:
           - os: macos-15
             platform: mac
             release_command: ORCA_MAC_RELEASE=1 pnpm exec electron-builder --config config/electron-builder.config.cjs --mac --publish always
+            eb_cache_path: |
+              ~/Library/Caches/electron
+              ~/Library/Caches/electron-builder
           - os: windows-latest
             platform: win
             release_command: pnpm exec electron-builder --config config/electron-builder.config.cjs --win --publish always
+            eb_cache_path: |
+              ~\AppData\Local\electron\Cache
+              ~\AppData\Local\electron-builder\Cache
           - os: ubuntu-latest
             platform: linux
             release_command: pnpm exec electron-builder --config config/electron-builder.config.cjs --linux --publish always
+            eb_cache_path: |
+              ~/.cache/electron
+              ~/.cache/electron-builder
 
     runs-on: ${{ matrix.os }}
 
@@ -115,6 +124,16 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: pnpm
+
+      # Cache the Electron binary + electron-builder tool downloads (notarytool,
+      # winCodeSign, nsis, squirrel, AppImage). Saves ~30-90s per job, incl. mac.
+      - name: Cache electron-builder downloads
+        uses: actions/cache@v4
+        with:
+          path: ${{ matrix.eb_cache_path }}
+          key: electron-builder-${{ matrix.platform }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            electron-builder-${{ matrix.platform }}-
 
       # Why: pnpm install triggers electron's postinstall, which downloads the
       # Electron binary from GitHub release assets. GitHub's download CDN


### PR DESCRIPTION
## Summary
- Add `actions/cache@v4` for per-platform Electron + electron-builder tool caches in `release.yml`.
- Paths: `~/Library/Caches/{electron,electron-builder}` on mac, `~/.cache/{electron,electron-builder}` on Linux, `~\AppData\Local\{electron,electron-builder}\Cache` on Windows.
- Key includes `pnpm-lock.yaml` so an electron/electron-builder bump invalidates stale binaries; `restore-keys` fall back to the latest per-platform cache between lockfile changes.

Why: electron-builder re-downloads the Electron binary and signing/packaging tools (notarytool, winCodeSign, nsis, squirrel, AppImage) every run. Caching them saves ~30–90s per job, including on the macOS long leg.

Follow-on to #1106 (pnpm store cache). Combined, these trim roughly 1–2 min off the mac release wall-clock on cache hit. Real sub-10-min wall-clock still needs paid runners.

## Test plan
- [ ] PR checks pass
- [ ] After merge, cut an RC; first run populates cache (no savings), second run shows "Cache restored" and a shorter `Publish release artifacts` step

Made with [Orca](https://github.com/stablyai/orca) 🐋
