### PR TITLE
fix(terminal): submit startup commands on Windows without requiring manual Enter

### DIFF
--- a/src/main/daemon/terminal-host-startup.test.ts
+++ b/src/main/daemon/terminal-host-startup.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { TerminalHost } from './terminal-host'
+import type { SubprocessHandle } from './session'
+
+function mockSubprocess(): SubprocessHandle {
+  return {
+    pid: 1,
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn(),
+    forceKill: vi.fn(),
+    signal: vi.fn(),
+    onData: () => {},
+    onExit: () => {}
+  } as SubprocessHandle
+}
+
+// Why: Windows shells (PowerShell/cmd.exe) submit on CR, not LF. Without CR
+// the startup command sits typed at the prompt but unexecuted — forcing the
+// user to press Enter after "claude" (or a setup script) is injected.
+// POSIX shells (bash/zsh) keep the LF behaviour. A caller-supplied terminator
+// must not be doubled.
+describe('TerminalHost startup command terminator', () => {
+  const origPlatform = process.platform
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: origPlatform })
+  })
+
+  let sub: SubprocessHandle
+  let host: TerminalHost
+  beforeEach(() => {
+    sub = mockSubprocess()
+    host = new TerminalHost({ spawnSubprocess: () => sub })
+  })
+
+  it.each([
+    ['win32', 'claude', 'claude\r'],
+    ['darwin', 'claude', 'claude\n'],
+    ['win32', 'claude\r', 'claude\r'],
+    ['darwin', 'claude\n', 'claude\n']
+  ])('submits startup with correct terminator on %s', async (platform, cmd, sent) => {
+    Object.defineProperty(process, 'platform', { value: platform })
+    await host.createOrAttach({
+      sessionId: `s-${platform}-${cmd.length}`,
+      cols: 80,
+      rows: 24,
+      command: cmd,
+      shellReadySupported: false,
+      streamClient: { onData: vi.fn(), onExit: vi.fn() }
+    })
+    expect(sub.write).toHaveBeenCalledWith(sent)
+  })
+})

--- a/src/main/daemon/terminal-host.ts
+++ b/src/main/daemon/terminal-host.ts
@@ -101,7 +101,13 @@ export class TerminalHost {
       // the daemon keeps for the pane. Session.write() handles the shell-ready
       // barrier for supported shells and falls back to an immediate write for
       // unsupported ones.
-      session.write(opts.command.endsWith('\n') ? opts.command : `${opts.command}\n`)
+      // Why CR on Windows: PowerShell's PSReadLine and cmd.exe submit the line
+      // on CR (`\r`); a bare LF leaves the command typed but unsubmitted, so
+      // the user would need to press Enter after Orca launches the agent or
+      // setup script. POSIX shells accept CR as Enter under ICRNL.
+      const submit = process.platform === 'win32' ? '\r' : '\n'
+      const endsWithSubmit = opts.command.endsWith('\r') || opts.command.endsWith('\n')
+      session.write(endsWithSubmit ? opts.command : `${opts.command}${submit}`)
     }
 
     return {

--- a/src/main/providers/local-pty-shell-ready.test.ts
+++ b/src/main/providers/local-pty-shell-ready.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as pty from 'node-pty'
+import { writeStartupCommandWhenShellReady } from './local-pty-shell-ready'
+
+type DataCb = (data: string) => void
+type ExitCb = (info: { exitCode: number }) => void
+
+function createMockProc(): pty.IPty & {
+  _emitData: (data: string) => void
+  _writes: string[]
+} {
+  let onDataCbs: DataCb[] = []
+  const writes: string[] = []
+  const fake = {
+    pid: 1,
+    cols: 80,
+    rows: 24,
+    process: 'bash',
+    handleFlowControl: false,
+    write: (data: string) => {
+      writes.push(data)
+    },
+    resize: () => {},
+    clear: () => {},
+    kill: () => {},
+    pause: () => {},
+    resume: () => {},
+    onData: (cb: DataCb) => {
+      onDataCbs.push(cb)
+      return {
+        dispose: () => {
+          onDataCbs = onDataCbs.filter((c) => c !== cb)
+        }
+      }
+    },
+    onExit: (_cb: ExitCb) => ({ dispose: () => {} }),
+    _emitData: (data: string) => {
+      for (const cb of onDataCbs.slice()) {
+        cb(data)
+      }
+    },
+    _writes: writes
+  } as unknown as pty.IPty & { _emitData: (data: string) => void; _writes: string[] }
+
+  return fake
+}
+
+describe('writeStartupCommandWhenShellReady', () => {
+  let origPlatform: NodeJS.Platform
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    origPlatform = process.platform
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    Object.defineProperty(process, 'platform', { value: origPlatform })
+  })
+
+  it('appends LF on POSIX so bash/zsh submit the line', async () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' })
+    const proc = createMockProc()
+    const ready = Promise.resolve()
+    writeStartupCommandWhenShellReady(ready, proc, 'claude', () => {})
+
+    await ready
+    // flush path waits for a post-ready data chunk (prompt draw) then 30ms,
+    // or falls back after 50ms if no data arrives.
+    vi.advanceTimersByTime(50)
+    await Promise.resolve()
+
+    expect(proc._writes).toEqual(['claude\n'])
+  })
+
+  it('appends CR on Windows so PowerShell/cmd.exe submit the line', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+    const proc = createMockProc()
+    const ready = Promise.resolve()
+    writeStartupCommandWhenShellReady(ready, proc, 'claude', () => {})
+
+    await ready
+    vi.advanceTimersByTime(50)
+    await Promise.resolve()
+
+    expect(proc._writes).toEqual(['claude\r'])
+  })
+
+  it('does not re-append a submit byte if the command already ends in CR or LF', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+    const proc = createMockProc()
+    const ready = Promise.resolve()
+    writeStartupCommandWhenShellReady(ready, proc, 'claude\n', () => {})
+
+    await ready
+    vi.advanceTimersByTime(50)
+    await Promise.resolve()
+
+    expect(proc._writes).toEqual(['claude\n'])
+  })
+})

--- a/src/main/providers/local-pty-shell-ready.ts
+++ b/src/main/providers/local-pty-shell-ready.ts
@@ -278,7 +278,15 @@ export function writeStartupCommandWhenShellReady(
     // open for the pane. Spawning `shell -c <command>; exec shell -l` would
     // avoid the race, but it would also replace the session after the agent
     // exits and break "stay in this terminal" workflows.
-    const payload = startupCommand.endsWith('\n') ? startupCommand : `${startupCommand}\n`
+    // Why CR on Windows: PowerShell's PSReadLine and cmd.exe submit the line
+    // on CR (`\r`) — a bare LF leaves the command typed at the prompt but
+    // unsubmitted, forcing the user to press Enter after Orca launches the
+    // agent or setup script. POSIX shells (bash/zsh) treat either CR or LF as
+    // Enter under ICRNL, so CR works there too, but this code path is reached
+    // on Windows as well as POSIX via writeStartupCommandWhenShellReady.
+    const submit = process.platform === 'win32' ? '\r' : '\n'
+    const endsWithSubmit = startupCommand.endsWith('\r') || startupCommand.endsWith('\n')
+    const payload = endsWithSubmit ? startupCommand : `${startupCommand}${submit}`
     // Why: startup commands are usually long, quoted agent launches. Writing
     // them in one PTY call after the shell-ready barrier avoids the incremental
     // paste behavior that still dropped characters in practice.


### PR DESCRIPTION
## Summary
- On Windows, Orca injected startup commands (agent launch like `claude`, worktree setup script) terminated with `\n`. PowerShell's PSReadLine and cmd.exe submit on CR, so a bare LF left the command typed at the prompt but unexecuted — the user had to press Enter themselves.
- Switched the startup-command terminator to CR on Windows in both the main-process local PTY path (`local-pty-shell-ready.ts`) and the daemon path (`terminal-host.ts`). POSIX shells keep LF; a caller-supplied CR/LF terminator is preserved rather than doubled.

## Test plan
- [x] `pnpm vitest run src/main/daemon/ src/main/providers/local-pty-shell-ready.test.ts` — all green (parameterised cases cover `win32` vs `darwin`, with and without an existing terminator).
- [ ] Manual: on Windows (PowerShell + cmd.exe), open a new worktree and confirm `claude` and the setup script each launch without needing a second Enter.
- [ ] Manual: on macOS, confirm agent launch and setup script still run unchanged (LF path).

Made with [Orca](https://github.com/stablyai/orca) 🐋
