### PR TITLE
feat: reduce drag grab area height from 8px to 6px

### DIFF
--- a/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
@@ -217,7 +217,7 @@ export default function TabGroupSplitLayout({
       // so disabling it is the simplest fix.
       autoScroll={false}
     >
-      {/* Why: the 8px drag strip sits ABOVE the split layout — lifted out of
+      {/* Why: the 6px drag strip sits ABOVE the split layout — lifted out of
           each pane — so vertical split resize handles don't extend into the
           window-drag region at the top. Only the split layout's own panes
           own the resize handles, while this strip keeps the whole top of the
@@ -229,7 +229,7 @@ export default function TabGroupSplitLayout({
           overlapping 1px lines read as one clean seam. */}
       <div className="flex flex-col flex-1 min-w-0 min-h-0 overflow-hidden border-l border-border">
         <div
-          className="h-2 shrink-0 bg-card"
+          className="h-[6px] shrink-0 bg-card"
           style={{ WebkitAppRegion: 'drag' } as React.CSSProperties}
         />
         <div className="flex flex-1 min-w-0 min-h-0 overflow-hidden">


### PR DESCRIPTION
## Problem
The clickable drag area above the tabs was 8px tall (h-2), making it too easy to accidentally grab the window when trying to interact with the tab area.

## Solution
Reduced the drag grab area from 8px to 6px (h-[6px]) to provide a more compact clickable region while still maintaining a comfortable grab target for window dragging.

This preserves window movability while giving more screen real estate to the tab interface.

Made with [Orca](https://github.com/stablyai/orca) 🐋
