### PR TITLE
feat(terminal): add programming-ligatures support

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@tiptap/react": "^3.22.4",
     "@tiptap/starter-kit": "^3.22.4",
     "@xterm/addon-fit": "0.12.0-beta.198",
+    "@xterm/addon-ligatures": "0.11.0-beta.198",
     "@xterm/addon-search": "0.17.0-beta.198",
     "@xterm/addon-serialize": "0.15.0-beta.198",
     "@xterm/addon-unicode11": "0.10.0-beta.198",
@@ -153,7 +154,8 @@
       "node-pty"
     ],
     "patchedDependencies": {
-      "node-pty@1.1.0": "patches/node-pty@1.1.0.patch"
+      "node-pty@1.1.0": "patches/node-pty@1.1.0.patch",
+      "@xterm/addon-ligatures@0.11.0-beta.198": "patches/@xterm__addon-ligatures@0.11.0-beta.198.patch"
     }
   }
 }

--- a/patches/@xterm__addon-ligatures@0.11.0-beta.198.patch
+++ b/patches/@xterm__addon-ligatures@0.11.0-beta.198.patch
@@ -1,0 +1,22 @@
+diff --git a/package.json b/package.json
+index c697677b35e736e23702c1abb357b3445c57d949..deb0387e66a8abb301006372ec9775bb54131d5a 100644
+--- a/package.json
++++ b/package.json
+@@ -6,9 +6,16 @@
+     "name": "The xterm.js authors",
+     "url": "https://xtermjs.org/"
+   },
+-  "main": "lib/addon-ligatures.js",
++  "main": "lib/addon-ligatures.mjs",
+   "module": "lib/addon-ligatures.mjs",
+   "types": "typings/addon-ligatures.d.ts",
++  "exports": {
++    ".": {
++      "types": "./typings/addon-ligatures.d.ts",
++      "import": "./lib/addon-ligatures.mjs",
++      "default": "./lib/addon-ligatures.mjs"
++    }
++  },
+   "repository": "https://github.com/xtermjs/xterm.js/tree/master/addons/addon-ligatures",
+   "engines": {
+     "node": ">8.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
+  '@xterm/addon-ligatures@0.11.0-beta.198':
+    hash: df21db050a4d85552cafbe583ece863d7fa19ed634a1219210a0455b986b6634
+    path: patches/@xterm__addon-ligatures@0.11.0-beta.198.patch
   node-pty@1.1.0:
     hash: 02e16954edbb8e511963557e3b2c80f8a6fb230cd0c6a75ade936022f3347322
     path: patches/node-pty@1.1.0.patch
@@ -85,6 +88,9 @@ importers:
       '@xterm/addon-fit':
         specifier: 0.12.0-beta.198
         version: 0.12.0-beta.198(@xterm/xterm@6.1.0-beta.198)
+      '@xterm/addon-ligatures':
+        specifier: 0.11.0-beta.198
+        version: 0.11.0-beta.198(patch_hash=df21db050a4d85552cafbe583ece863d7fa19ed634a1219210a0455b986b6634)(@xterm/xterm@6.1.0-beta.198)
       '@xterm/addon-search':
         specifier: 0.17.0-beta.198
         version: 0.17.0-beta.198(@xterm/xterm@6.1.0-beta.198)
@@ -2949,6 +2955,12 @@ packages:
     peerDependencies:
       '@xterm/xterm': ^6.1.0-beta.198
 
+  '@xterm/addon-ligatures@0.11.0-beta.198':
+    resolution: {integrity: sha512-LpF9KYiixxybSdyWpBtaPg5S1NNosQU0vcYg9P71xZFVRPT5vjaFvxYd80hV0oeKdnT25EMgNxwxbqHasmHQvg==}
+    engines: {node: '>8.0.0'}
+    peerDependencies:
+      '@xterm/xterm': ^6.1.0-beta.198
+
   '@xterm/addon-search@0.17.0-beta.198':
     resolution: {integrity: sha512-loNSX0cB4P+9Sg13sgB/cQPPBgdOi1hxRyZ75Jj90+4iKe227mRmgzdqU3wxr10nyFWJWCpysCjVT+47tdC8mQ==}
     peerDependencies:
@@ -5065,6 +5077,10 @@ packages:
     resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==}
     engines: {node: '>=20'}
 
+  opentype.js@0.8.0:
+    resolution: {integrity: sha512-FQHR4oGP+a0m/f6yHoRpBOIbn/5ZWxKd4D/djHVJu8+KpBTYrJda0b7mLcgDEMWXE9xBCJm+qb0yv6FcvPjukg==}
+    hasBin: true
+
   ora@5.4.1:
     resolution: {integrity: sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==}
     engines: {node: '>=10'}
@@ -5820,6 +5836,9 @@ packages:
 
   tiny-async-pool@1.3.0:
     resolution: {integrity: sha512-01EAw5EDrcVrdgyCLgoSPvqznC0sVxDSVeiOz09FUpjh71G79VCqneOr+xvt7T1r76CF6ZZfPjHorN2+d+3mqA==}
+
+  tiny-inflate@1.0.3:
+    resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
 
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
@@ -8790,6 +8809,12 @@ snapshots:
     dependencies:
       '@xterm/xterm': 6.1.0-beta.198
 
+  '@xterm/addon-ligatures@0.11.0-beta.198(patch_hash=df21db050a4d85552cafbe583ece863d7fa19ed634a1219210a0455b986b6634)(@xterm/xterm@6.1.0-beta.198)':
+    dependencies:
+      '@xterm/xterm': 6.1.0-beta.198
+      lru-cache: 6.0.0
+      opentype.js: 0.8.0
+
   '@xterm/addon-search@0.17.0-beta.198(@xterm/xterm@6.1.0-beta.198)':
     dependencies:
       '@xterm/xterm': 6.1.0-beta.198
@@ -11344,6 +11369,10 @@ snapshots:
       powershell-utils: 0.1.0
       wsl-utils: 0.3.1
 
+  opentype.js@0.8.0:
+    dependencies:
+      tiny-inflate: 1.0.3
+
   ora@5.4.1:
     dependencies:
       bl: 4.1.0
@@ -12370,6 +12399,8 @@ snapshots:
   tiny-async-pool@1.3.0:
     dependencies:
       semver: 5.7.2
+
+  tiny-inflate@1.0.3: {}
 
   tiny-invariant@1.3.3: {}
 

--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -43,6 +43,7 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     terminalFontFamily: 'JetBrains Mono',
     terminalFontWeight: 500,
     terminalLineHeight: 1,
+    terminalLigatures: 'auto',
     terminalCursorStyle: 'block',
     terminalCursorBlink: false,
     terminalThemeDark: 'orca-dark',

--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -37,6 +37,7 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     terminalFontFamily: 'JetBrains Mono',
     terminalFontWeight: 500,
     terminalLineHeight: 1,
+    terminalLigatures: 'auto',
     terminalCursorStyle: 'block',
     terminalCursorBlink: false,
     terminalThemeDark: 'orca-dark',

--- a/src/renderer/src/components/settings/TerminalPane.tsx
+++ b/src/renderer/src/components/settings/TerminalPane.tsx
@@ -10,6 +10,10 @@ import {
   TERMINAL_FONT_WEIGHT_STEP,
   normalizeTerminalFontWeight
 } from '../../../../shared/terminal-fonts'
+import {
+  fontFamilyHasKnownLigatures,
+  resolveTerminalLigaturesEnabled
+} from '../../../../shared/terminal-ligatures'
 import { Button } from '../ui/button'
 import { Input } from '../ui/input'
 import { Label } from '../ui/label'
@@ -246,6 +250,64 @@ export function TerminalPane({
               })
             }
           />
+        </SearchableSetting>
+
+        <SearchableSetting
+          title="Font Ligatures"
+          description='Render programming ligatures (e.g. =>, !=, ===) for fonts that ship them. "Auto" enables ligatures only for known ligature fonts (Fira Code, JetBrains Mono, Cascadia Code, Iosevka, etc.).'
+          keywords={[
+            'terminal',
+            'typography',
+            'ligatures',
+            'ligature',
+            'fira code',
+            'jetbrains mono',
+            'cascadia code',
+            'iosevka',
+            'calt',
+            'font features'
+          ]}
+          className="space-y-2"
+        >
+          <Label>Font Ligatures</Label>
+          <div className="flex w-fit gap-1 rounded-md border border-border/50 p-1">
+            {(['auto', 'on', 'off'] as const).map((option) => (
+              <button
+                key={option}
+                onClick={() => updateSettings({ terminalLigatures: option })}
+                className={`rounded-sm px-3 py-1 text-sm capitalize transition-colors ${
+                  (settings.terminalLigatures ?? 'auto') === option
+                    ? 'bg-accent font-medium text-accent-foreground'
+                    : 'text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                {option === 'auto' ? 'Auto' : option === 'on' ? 'On' : 'Off'}
+              </button>
+            ))}
+          </div>
+          <p className="text-xs text-muted-foreground">
+            {settings.terminalLigatures === 'on'
+              ? 'Ligatures are always on. Fonts without ligatures simply render as-is.'
+              : settings.terminalLigatures === 'off'
+                ? 'Ligatures are always off, even for fonts that ship them.'
+                : fontFamilyHasKnownLigatures(settings.terminalFontFamily)
+                  ? `Auto — enabled because "${settings.terminalFontFamily}" is a known ligature font. Switch to "Off" to disable.`
+                  : `Auto — disabled because "${
+                      settings.terminalFontFamily || 'the current font'
+                    }" is not a known ligature font. Switch to "On" to enable anyway.`}
+          </p>
+          {/* Why: surface the resolved state explicitly so the "Auto" label
+              isn't ambiguous when a user is staring at it. */}
+          <p className="sr-only" aria-live="polite">
+            Ligatures are currently{' '}
+            {resolveTerminalLigaturesEnabled(
+              settings.terminalLigatures,
+              settings.terminalFontFamily
+            )
+              ? 'enabled'
+              : 'disabled'}
+            .
+          </p>
         </SearchableSetting>
       </section>
     ) : null,

--- a/src/renderer/src/components/settings/terminal-search.ts
+++ b/src/renderer/src/components/settings/terminal-search.ts
@@ -20,6 +20,23 @@ export const TERMINAL_TYPOGRAPHY_SEARCH_ENTRIES: SettingsSearchEntry[] = [
     title: 'Line Height',
     description: 'Controls the terminal line height multiplier.',
     keywords: ['terminal', 'typography', 'line height', 'spacing']
+  },
+  {
+    title: 'Font Ligatures',
+    description:
+      'Render programming ligatures (e.g. => → ≠ ≥) for fonts that ship them. "Auto" enables ligatures only for known ligature fonts (Fira Code, JetBrains Mono, Cascadia Code, Iosevka, etc.).',
+    keywords: [
+      'terminal',
+      'typography',
+      'ligatures',
+      'ligature',
+      'fira code',
+      'jetbrains mono',
+      'cascadia code',
+      'iosevka',
+      'calt',
+      'font features'
+    ]
   }
 ]
 

--- a/src/renderer/src/components/terminal-pane/terminal-appearance.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-appearance.ts
@@ -2,6 +2,7 @@ import type { IDisposable, IParser, ITheme } from '@xterm/xterm'
 import type { PaneManager } from '@/lib/pane-manager/pane-manager'
 import type { GlobalSettings } from '../../../../shared/types'
 import { resolveTerminalFontWeights } from '../../../../shared/terminal-fonts'
+import { resolveTerminalLigaturesEnabled } from '../../../../shared/terminal-ligatures'
 import {
   getBuiltinTheme,
   resolvePaneStyleOptions,
@@ -142,6 +143,10 @@ export function applyTerminalAppearance(
   const theme: ITheme | null = appearance.theme ?? getBuiltinTheme(appearance.themeName)
   const paneBackground = theme?.background ?? '#000000'
   const terminalFontWeights = resolveTerminalFontWeights(settings.terminalFontWeight)
+  const ligaturesEnabled = resolveTerminalLigaturesEnabled(
+    settings.terminalLigatures,
+    settings.terminalFontFamily
+  )
 
   for (const pane of manager.getPanes()) {
     if (theme) {
@@ -162,6 +167,12 @@ export function applyTerminalAppearance(
     // `effectiveMacOptionAsAlt` carries.
     pane.terminal.options.macOptionIsMeta = effectiveMacOptionAsAlt === 'true'
     pane.terminal.options.lineHeight = settings.terminalLineHeight
+    // Why call unconditionally: the per-pane helper is a no-op when the
+    // current addon state already matches, so passing the resolved value on
+    // every appearance apply keeps newly-created panes in sync without a
+    // separate hook and lets live toggles (settings change, font swap)
+    // land immediately.
+    manager.setPaneLigaturesEnabled(pane.id, ligaturesEnabled)
     try {
       const state = captureScrollState(pane.terminal)
       pane.fitAddon.fit()

--- a/src/renderer/src/lib/pane-manager/pane-fit-resize-observer.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-fit-resize-observer.test.ts
@@ -54,6 +54,7 @@ function createPane(): ManagedPaneInternal {
     unicode11Addon: {} as never,
     webLinksAddon: {} as never,
     webglAddon: null,
+    ligaturesAddon: null,
     compositionHandler: null,
     pendingSplitScrollState: {
       wasAtBottom: true,

--- a/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
+++ b/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
@@ -1,6 +1,11 @@
 import { Terminal } from '@xterm/xterm'
 import type { ITerminalOptions } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
+// Upstream packaging bug: @xterm/addon-ligatures declares `"main":
+// "lib/addon-ligatures.js"` but ships only the `.mjs` entry, so Vite fails to
+// resolve the bare import. Fixed locally via patches/@xterm__addon-ligatures*.
+// Tracking upstream: https://github.com/xtermjs/xterm.js/issues/5822 — drop
+// the patch once that lands.
 import { LigaturesAddon } from '@xterm/addon-ligatures'
 import { SearchAddon } from '@xterm/addon-search'
 import { Unicode11Addon } from '@xterm/addon-unicode11'

--- a/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
+++ b/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
@@ -1,6 +1,7 @@
 import { Terminal } from '@xterm/xterm'
 import type { ITerminalOptions } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
+import { LigaturesAddon } from '@xterm/addon-ligatures'
 import { SearchAddon } from '@xterm/addon-search'
 import { Unicode11Addon } from '@xterm/addon-unicode11'
 import { WebLinksAddon } from '@xterm/addon-web-links'
@@ -139,6 +140,7 @@ export function createPaneDOM(
     unicode11Addon,
     webLinksAddon,
     webglAddon: null,
+    ligaturesAddon: null,
     compositionHandler: null,
     pendingSplitScrollState: null,
     pendingDragScrollState: null
@@ -237,6 +239,57 @@ export function openTerminal(pane: ManagedPaneInternal): void {
   })
 }
 
+export function disposeLigatures(pane: ManagedPaneInternal): void {
+  if (pane.ligaturesAddon) {
+    try {
+      pane.ligaturesAddon.dispose()
+    } catch {
+      /* ignore */
+    }
+    pane.ligaturesAddon = null
+  }
+}
+
+export function attachLigatures(pane: ManagedPaneInternal): void {
+  if (pane.ligaturesAddon) {
+    return
+  }
+  try {
+    const ligaturesAddon = new LigaturesAddon()
+    pane.terminal.loadAddon(ligaturesAddon)
+    pane.ligaturesAddon = ligaturesAddon
+    // Why: the WebGL renderer builds its glyph texture atlas at activation
+    // time, so `font-feature-settings` applied after WebGL loaded won't
+    // reach the GPU-rendered cells until the atlas is rebuilt. The upstream
+    // docs call this out explicitly — reactivating WebGL after ligatures
+    // forces a fresh atlas that includes the ligated glyphs.
+    if (pane.webglAddon) {
+      disposeWebgl(pane)
+      attachWebgl(pane)
+    }
+  } catch (err) {
+    console.warn('[terminal] ligatures addon failed to attach for pane', pane.id, err)
+    pane.ligaturesAddon = null
+  }
+}
+
+/** Enable or disable ligatures in-place, reusing the running terminal so the
+ *  setting can be toggled without dropping scrollback or the PTY binding. */
+export function setLigaturesEnabled(pane: ManagedPaneInternal, enabled: boolean): void {
+  if (enabled) {
+    attachLigatures(pane)
+  } else if (pane.ligaturesAddon) {
+    disposeLigatures(pane)
+    // Why: ligatures lived inside the WebGL atlas, so after disposing the
+    // addon the atlas still holds the ligated glyphs. Rebuild it so text
+    // renders as the non-ligated fallback immediately.
+    if (pane.webglAddon) {
+      disposeWebgl(pane)
+      attachWebgl(pane)
+    }
+  }
+}
+
 export function disposeWebgl(pane: ManagedPaneInternal): void {
   if (pane.webglAddon) {
     try {
@@ -313,6 +366,11 @@ export function disposePane(
   if (pane.compositionHandler) {
     pane.terminal.element?.removeEventListener('compositionstart', pane.compositionHandler, true)
     pane.compositionHandler = null
+  }
+  try {
+    pane.ligaturesAddon?.dispose()
+  } catch {
+    /* ignore */
   }
   try {
     pane.webglAddon?.dispose()

--- a/src/renderer/src/lib/pane-manager/pane-manager-types.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager-types.ts
@@ -1,6 +1,7 @@
 import type { Terminal } from '@xterm/xterm'
 import type { ITerminalOptions } from '@xterm/xterm'
 import type { FitAddon } from '@xterm/addon-fit'
+import type { LigaturesAddon } from '@xterm/addon-ligatures'
 import type { SearchAddon } from '@xterm/addon-search'
 import type { Unicode11Addon } from '@xterm/addon-unicode11'
 import type { WebLinksAddon } from '@xterm/addon-web-links'
@@ -60,6 +61,10 @@ export type ManagedPaneInternal = {
   linkTooltip: HTMLElement
   gpuRenderingEnabled: boolean
   webglAddon: WebglAddon | null
+  // Why nullable: ligatures are opt-in per font and toggleable at runtime,
+  // so the addon instance only exists while the feature is active. A null
+  // value means "currently disabled".
+  ligaturesAddon: LigaturesAddon | null
   fitResizeObserver: ResizeObserver | null
   pendingObservedFitRafId: number | null
   serializeAddon: SerializeAddon

--- a/src/renderer/src/lib/pane-manager/pane-manager.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager.ts
@@ -22,6 +22,7 @@ import {
   openTerminal,
   attachWebgl,
   disposeWebgl,
+  setLigaturesEnabled,
   disposePane
 } from './pane-lifecycle'
 import { shouldFollowMouseFocus } from './focus-follows-mouse'
@@ -217,6 +218,18 @@ export class PaneManager {
     applyPaneOpacity(this.panes.values(), this.activePaneId, this.styleOptions)
     this.applyDividerStylesWrapped()
     applyRootBackground(this.root, this.styleOptions)
+  }
+
+  /** Enable or disable programming-ligatures rendering on a single pane.
+   *  Called by applyTerminalAppearance whenever the resolved ligatures state
+   *  changes, so toggling the setting or switching fonts takes effect on
+   *  live panes without restarting. */
+  setPaneLigaturesEnabled(paneId: number, enabled: boolean): void {
+    const pane = this.panes.get(paneId)
+    if (!pane) {
+      return
+    }
+    setLigaturesEnabled(pane, enabled)
   }
 
   setPaneGpuRendering(paneId: number, enabled: boolean): void {

--- a/src/renderer/src/lib/pane-manager/pane-tree-ops.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-tree-ops.test.ts
@@ -48,6 +48,7 @@ function createPane({
     unicode11Addon: {} as never,
     webLinksAddon: {} as never,
     webglAddon: null,
+    ligaturesAddon: null,
     compositionHandler: null,
     pendingSplitScrollState: null,
     pendingDragScrollState: null

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -114,6 +114,11 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     terminalFontFamily: defaultTerminalFontFamily(),
     terminalFontWeight: DEFAULT_TERMINAL_FONT_WEIGHT,
     terminalLineHeight: 1,
+    // Why 'auto': when the user has picked a known ligature font we want the
+    // feature enabled by default, but we never force it if they pick a font
+    // that lacks ligatures or if they've explicitly opted out. The resolver
+    // is in shared/terminal-ligatures.ts.
+    terminalLigatures: 'auto',
     terminalCursorStyle: 'bar',
     terminalCursorBlink: true,
     terminalThemeDark: 'Ghostty Default Style Dark',

--- a/src/shared/terminal-ligatures.ts
+++ b/src/shared/terminal-ligatures.ts
@@ -1,0 +1,61 @@
+// Font families that ship with programming-ligatures out of the box. Used by
+// the `'auto'` mode of `terminalLigatures` so users who pick a ligature font
+// get the feature for free without touching settings. Matching is
+// case-insensitive and substring-based so variants like "JetBrainsMono NF"
+// still resolve.
+const LIGATURE_FONT_TOKENS = [
+  'fira code',
+  'fira mono',
+  'jetbrains mono',
+  'jetbrainsmono',
+  'cascadia code',
+  'cascadia mono',
+  'iosevka',
+  'victor mono',
+  'hasklig',
+  'monoid',
+  'operator mono',
+  'dank mono',
+  'mononoki',
+  'pragmatapro',
+  'recursive',
+  'monolisa',
+  'commit mono',
+  'geist mono',
+  'maple mono',
+  'departure mono'
+] as const
+
+/** Whether a user-facing font-family string looks like one of the well-known
+ *  ligature-capable programming fonts. Matches the first declared family in
+ *  the string (the user's choice) rather than any fallback. */
+export function fontFamilyHasKnownLigatures(fontFamily: string | null | undefined): boolean {
+  if (!fontFamily) {
+    return false
+  }
+  // `terminalFontFamily` is a single family name in settings, but
+  // defensively split on commas so the helper also works when fed a full
+  // `font-family` stack (e.g. via `buildFontFamily`).
+  const primary = fontFamily.split(',')[0]?.replace(/"/g, '').trim().toLowerCase() ?? ''
+  if (!primary) {
+    return false
+  }
+  return LIGATURE_FONT_TOKENS.some((token) => primary.includes(token))
+}
+
+/** Resolve the effective ligature-enabled state from the user setting and
+ *  the current font. `'auto'` defers to font detection; explicit `'on'` /
+ *  `'off'` always wins so a user who disables ligatures keeps them disabled
+ *  even after switching to Fira Code. */
+export function resolveTerminalLigaturesEnabled(
+  mode: 'auto' | 'on' | 'off' | null | undefined,
+  fontFamily: string | null | undefined
+): boolean {
+  if (mode === 'on') {
+    return true
+  }
+  if (mode === 'off') {
+    return false
+  }
+  return fontFamilyHasKnownLigatures(fontFamily)
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -750,6 +750,15 @@ export type GlobalSettings = {
   terminalFontFamily: string
   terminalFontWeight: number
   terminalLineHeight: number
+  /** Whether to enable programming-ligatures rendering via
+   *  `@xterm/addon-ligatures`.
+   *  - `'auto'` (default): enabled only when the configured font is known to
+   *    ship ligatures (Fira Code, JetBrains Mono, Cascadia Code, etc.). This
+   *    keeps the out-of-the-box experience right for users who install a
+   *    ligature font without touching settings.
+   *  - `'on'` / `'off'`: explicit override. Never changes when the user
+   *    switches fonts, so "off" always stays off. */
+  terminalLigatures: 'auto' | 'on' | 'off'
   terminalCursorStyle: 'bar' | 'block' | 'underline'
   terminalCursorBlink: boolean
   terminalThemeDark: string


### PR DESCRIPTION
## Summary
- Add `@xterm/addon-ligatures` with a pnpm patch that fixes the package's broken `main` entry (only ships `.mjs`, but declares a `.js` path) so Vite/Electron can resolve it.
- New `terminalLigatures` setting (`'auto' | 'on' | 'off'`) exposed in **Terminal → Typography → Font Ligatures**.
  - **Auto** (default): enable ligatures when the font is a known ligature font — Fira Code, JetBrains Mono, Cascadia Code, Iosevka, Victor Mono, Hasklig, Monoid, MonoLisa, Commit Mono, Geist Mono, Maple Mono, Departure Mono, etc.
  - **On / Off**: explicit overrides, so a user who turns ligatures off keeps them off even after switching fonts.
- `LigaturesAddon` attach/dispose wired into the `PaneManager` and driven by `applyTerminalAppearance` so the setting takes effect live on all panes without restarting. WebGL is reactivated when the state flips so the texture atlas rebuilds with (or without) the ligated glyphs.

## Test plan
- [x] `pnpm run typecheck` passes (node + cli + web).
- [x] `pnpm run lint` clean for changed files.
- [x] `pnpm test` — no new failures introduced relative to `main` (same 3 pre-existing test-file failures).
- [ ] Launch the app with Fira Code / JetBrains Mono → ligatures render in "Auto".
- [ ] Switch to a non-ligature font (e.g. SF Mono) → ligatures disappear in "Auto".
- [ ] Flip the toggle to "Off" on a ligature font → ligatures disappear immediately, no restart needed.
- [ ] Flip to "On" on a non-ligature font → still harmless; fallback ligatures from the addon's default `calt` set render if available.

Made with [Orca](https://github.com/stablyai/orca) 🐋
