### PR TITLE
Focus address bar for new browser tabs

### DIFF
--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -393,7 +393,10 @@ function Terminal(): React.JSX.Element | null {
       return
     }
     const defaultUrl = useAppStore.getState().browserDefaultUrl ?? 'about:blank'
-    createBrowserTab(activeWorktreeId, defaultUrl, { title: 'New Browser Tab' })
+    createBrowserTab(activeWorktreeId, defaultUrl, {
+      title: 'New Browser Tab',
+      focusAddressBar: true
+    })
   }, [activeWorktreeId, createBrowserTab])
 
   const handleDuplicateBrowserTab = useCallback(

--- a/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.ts
+++ b/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.ts
@@ -399,7 +399,10 @@ export function useTabGroupWorkspaceModel({
       createSplitGroup,
       newBrowserTab: () => {
         const defaultUrl = useAppStore.getState().browserDefaultUrl ?? 'about:blank'
-        createBrowserTab(worktreeId, defaultUrl, { title: 'New Browser Tab' })
+        createBrowserTab(worktreeId, defaultUrl, {
+          title: 'New Browser Tab',
+          focusAddressBar: true
+        })
       },
       duplicateBrowserTab: (browserTabId: string) => {
         const state = useAppStore.getState()

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -337,7 +337,8 @@ export function useIpcEvents(): void {
         const worktreeId = store.activeWorktreeId
         if (worktreeId) {
           store.createBrowserTab(worktreeId, store.browserDefaultUrl ?? 'about:blank', {
-            title: 'New Browser Tab'
+            title: 'New Browser Tab',
+            focusAddressBar: true
           })
         }
       })

--- a/src/renderer/src/store/slices/browser.test.ts
+++ b/src/renderer/src/store/slices/browser.test.ts
@@ -173,4 +173,58 @@ describe('browser slice', () => {
       'https://example.com/b'
     )
   })
+
+  it('sets pending address-bar focus when focusAddressBar is true even for non-blank URLs', () => {
+    const store = createTestStore()
+    const worktreeId = 'repo1::/tmp/wt-1'
+    seedStore(store, {
+      activeRepoId: 'repo1',
+      activeWorktreeId: worktreeId,
+      activeTabType: 'terminal',
+      worktreesByRepo: {
+        repo1: [makeWorktree({ id: worktreeId, repoId: 'repo1', path: '/tmp/wt-1' })]
+      },
+      groupsByWorktree: {
+        [worktreeId]: [makeTabGroup({ id: 'group-1', worktreeId, activeTabId: null, tabOrder: [] })]
+      },
+      activeGroupIdByWorktree: { [worktreeId]: 'group-1' },
+      browserTabsByWorktree: {},
+      unifiedTabsByWorktree: {}
+    })
+
+    const created = store.getState().createBrowserTab(worktreeId, 'https://example.com/home', {
+      title: 'Home',
+      focusAddressBar: true
+    })
+
+    const pageId = store.getState().browserPagesByWorkspace[created.id]?.[0]?.id
+    expect(pageId).toBeDefined()
+    expect(store.getState().pendingAddressBarFocusByTabId[created.id]).toBe(true)
+    expect(store.getState().pendingAddressBarFocusByPageId[pageId!]).toBe(true)
+  })
+
+  it('does not set pending address-bar focus for non-blank URLs when focusAddressBar is not set', () => {
+    const store = createTestStore()
+    const worktreeId = 'repo1::/tmp/wt-1'
+    seedStore(store, {
+      activeRepoId: 'repo1',
+      activeWorktreeId: worktreeId,
+      activeTabType: 'terminal',
+      worktreesByRepo: {
+        repo1: [makeWorktree({ id: worktreeId, repoId: 'repo1', path: '/tmp/wt-1' })]
+      },
+      groupsByWorktree: {
+        [worktreeId]: [makeTabGroup({ id: 'group-1', worktreeId, activeTabId: null, tabOrder: [] })]
+      },
+      activeGroupIdByWorktree: { [worktreeId]: 'group-1' },
+      browserTabsByWorktree: {},
+      unifiedTabsByWorktree: {}
+    })
+
+    const created = store.getState().createBrowserTab(worktreeId, 'https://example.com/home', {
+      title: 'Home'
+    })
+
+    expect(store.getState().pendingAddressBarFocusByTabId[created.id]).toBeUndefined()
+  })
 })

--- a/src/renderer/src/store/slices/browser.ts
+++ b/src/renderer/src/store/slices/browser.ts
@@ -22,6 +22,12 @@ type CreateBrowserTabOptions = {
   // tab in a specific (sibling or newly-split) group rather than the ambient
   // active group. Defaults to the worktree's current active group.
   targetGroupId?: string
+  // Why: the explicit "New Tab" action (keyboard shortcut, + button) should
+  // land the user in the address bar even when their configured home page is a
+  // real URL, so they can type a destination immediately. Link-opened tabs
+  // (context menu, window.open, http link routing) leave this unset so focus
+  // stays on the webview. When omitted, we fall back to the blank-URL check.
+  focusAddressBar?: boolean
 }
 
 type CreateBrowserPageOptions = {
@@ -350,7 +356,8 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
       const shouldUpdateGlobalActiveSurface = shouldActivate && s.activeWorktreeId === worktreeId
       const shouldFocusAddressBar =
         shouldUpdateGlobalActiveSurface &&
-        (page.url === 'about:blank' || page.url === ORCA_BROWSER_BLANK_URL)
+        (options?.focusAddressBar ??
+          (page.url === 'about:blank' || page.url === ORCA_BROWSER_BLANK_URL))
 
       return {
         browserTabsByWorktree: {


### PR DESCRIPTION
## Summary
- focus the address bar for explicit New Browser Tab actions, even when the default browser URL is a real homepage
- keep link-opened, duplicated, preview, and CLI-created browser tabs on the existing implicit focus behavior
- add browser slice coverage for explicit address-bar focus on non-blank URLs

## Verification
- pnpm exec oxlint src/renderer/src/components/Terminal.tsx src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.ts src/renderer/src/hooks/useIpcEvents.ts src/renderer/src/store/slices/browser.ts src/renderer/src/store/slices/browser.test.ts
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/store/slices/browser.test.ts src/renderer/src/store/slices/store-cascades.test.ts
- pnpm typecheck
- git diff --check origin/main...HEAD

Note: full \
> orca@1.3.19-rc.8 test /Users/jinjingliang/Documents/projects/orca/auto-focus-on-address-bar-opening-new-browser-tab
> vitest run --config config/vitest.config.ts -- src/renderer/src/store/slices/browser.test.ts 'src/renderer/src/store/slices/store-cascades.test.ts\'


 RUN  v4.1.1 /Users/jinjingliang/Documents/projects/orca/auto-focus-on-address-bar-opening-new-browser-tab

 ❯ src/main/providers/local-pty-provider.test.ts (23 tests | 16 failed) 72ms
       × returns a unique PTY id 15ms
       × calls node-pty spawn with correct args 2ms
       × invokes onSpawned callback 2ms
       × invokes buildSpawnEnv callback to customize environment 1ms
       × writes data to the PTY process 1ms
       × resizes the PTY process 6ms
       × kills the PTY process 4ms
       × invokes onExit callback via the node-pty exit handler 3ms
       × returns false when foreground process matches shell 2ms
       × returns true when foreground process differs from shell 3ms
       × returns the process name 3ms
       × notifies data listeners when PTY produces output 1ms
       × notifies exit listeners when PTY exits 1ms
       × allows unsubscribing from events 2ms
       × returns spawned PTYs 2ms
       × kills all PTY processes 2ms
 ❯ src/main/ipc/pty.test.ts (35 tests | 1 failed) 140ms
       × skips git/gh attribution shims when attribution is disabled 6ms

 Test Files  2 failed | 252 passed (254)
      Tests  17 failed | 2802 passed | 7 skipped (2826)
   Start at  22:23:25
   Duration  24.66s (transform 23.37s, setup 0ms, import 55.79s, tests 56.32s, environment 57ms)

 ELIFECYCLE  Test failed. See above for more details. unexpectedly ran the full suite and failed in unrelated main PTY tests (electron app.getPath mock/env attribution), while the focused renderer tests above passed.