### PR TITLE
fix(ssh): await root registration before remote worktree creation

### DIFF
--- a/src/main/ipc/ssh.test.ts
+++ b/src/main/ipc/ssh.test.ts
@@ -31,6 +31,8 @@ const {
     dispose: vi.fn(),
     isDisposed: vi.fn().mockReturnValue(false),
     onNotification: vi.fn(),
+    onDispose: vi.fn().mockReturnValue(() => {}),
+    request: vi.fn().mockResolvedValue({}),
     notify: vi.fn()
   },
   mockPtyProvider: {
@@ -175,6 +177,7 @@ describe('SSH IPC handlers', () => {
     mockMux.dispose.mockReset()
     mockMux.isDisposed.mockReset().mockReturnValue(false)
     mockMux.onNotification.mockReset()
+    mockMux.onDispose.mockReset().mockReturnValue(() => {})
     mockPtyProvider.onData.mockReset()
     mockPtyProvider.onExit.mockReset()
     mockPtyProvider.onReplay.mockReset()

--- a/src/main/ipc/ssh.ts
+++ b/src/main/ipc/ssh.ts
@@ -216,13 +216,13 @@ export function registerSshHandlers(
         reconnectAttempt: 0
       })
 
-      await session.establish(conn, target.relayGracePeriodSeconds)
-
       // Why: the relay exec channel can close independently of the SSH
       // connection (e.g. --connect bridge exits, relay process crashes).
       // When that happens, the mux is disposed but onStateChange never
       // fires because the SSH connection is still alive. This callback
       // triggers session.reconnect() using the live SSH connection.
+      // Set before establish() so the callback is in place if the relay
+      // dies during the deploy/connect sequence.
       session.setOnRelayLost((tid) => {
         const s = activeSessions.get(tid)
         if (!s) {
@@ -234,6 +234,8 @@ export function registerSshHandlers(
           void s.reconnect(c, t?.relayGracePeriodSeconds)
         }
       })
+
+      await session.establish(conn, target.relayGracePeriodSeconds)
 
       // Why: we manually pushed `deploying-relay` above, so the renderer's
       // state is stuck there. Send `connected` directly to the renderer

--- a/src/main/ipc/ssh.ts
+++ b/src/main/ipc/ssh.ts
@@ -218,6 +218,23 @@ export function registerSshHandlers(
 
       await session.establish(conn, target.relayGracePeriodSeconds)
 
+      // Why: the relay exec channel can close independently of the SSH
+      // connection (e.g. --connect bridge exits, relay process crashes).
+      // When that happens, the mux is disposed but onStateChange never
+      // fires because the SSH connection is still alive. This callback
+      // triggers session.reconnect() using the live SSH connection.
+      session.setOnRelayLost((tid) => {
+        const s = activeSessions.get(tid)
+        if (!s) {
+          return
+        }
+        const c = connectionManager?.getConnection(tid)
+        const t = sshStore?.getTarget(tid)
+        if (c) {
+          void s.reconnect(c, t?.relayGracePeriodSeconds)
+        }
+      })
+
       // Why: we manually pushed `deploying-relay` above, so the renderer's
       // state is stuck there. Send `connected` directly to the renderer
       // instead of going through callbacks.onStateChange, which would

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -111,20 +111,62 @@ export async function createRemoteWorktree(
     /* best-effort */
   }
 
-  // Why: the relay validates that targetDir is within a registered root.
-  // The new worktree lives as a sibling of the repo (repo.path/../name),
-  // outside the repo root. Register it before addWorktree so the relay
-  // accepts the path.
+  // Why: the relay's git.addWorktree validates targetDir against registered
+  // roots. The worktree sibling path (repo/../name) is outside the repo root
+  // and must be registered first. Using request (not notify) makes the
+  // ordering guarantee explicit rather than relying on FIFO frame processing,
+  // and closes failure windows during relay reconnect or fresh-host scenarios
+  // where roots may not yet be registered at all. See issue #911.
   const mux = getActiveMultiplexer(repo.connectionId!)
-  if (mux) {
-    mux.notify('session.registerRoot', { rootPath: remotePath })
+  if (!mux) {
+    throw new Error('SSH connection is not available. Please reconnect and try again.')
+  }
+  // Why: git.addWorktree validates both repoPath and targetDir against
+  // registered roots. In a fresh-host or reconnect scenario, registerRelayRoots
+  // may not have finished yet, so neither path may be registered. Register both
+  // synchronously here to close that window.
+  //
+  // Why (fallback): when Orca reconnects via --connect to a relay still in its
+  // grace period, the old relay binary may not have the request handler yet.
+  // Fall back to notify so worktree creation still works against pre-upgrade
+  // relays.
+  try {
+    await Promise.all([
+      mux.request('session.registerRoot', { rootPath: repo.path }),
+      mux.request('session.registerRoot', { rootPath: remotePath })
+    ])
+  } catch (err) {
+    if (err instanceof Error && err.message.includes('Method not found')) {
+      mux.notify('session.registerRoot', { rootPath: repo.path })
+      mux.notify('session.registerRoot', { rootPath: remotePath })
+    } else {
+      throw err
+    }
   }
 
   // Create worktree via relay
-  await provider.addWorktree(repo.path, branchName, remotePath, {
-    base: baseBranch,
-    track: baseBranch.includes('/')
-  })
+  try {
+    await provider.addWorktree(repo.path, branchName, remotePath, {
+      base: baseBranch,
+      track: baseBranch.includes('/')
+    })
+  } catch (err) {
+    if (
+      err instanceof Error &&
+      (err.message.includes('No workspace roots registered yet') ||
+        err.message.includes('Path outside authorized workspace'))
+    ) {
+      // Why: validatePath throws two distinct errors — "No workspace roots
+      // registered yet" (relay has no roots at all, e.g., reconnect before
+      // registerRelayRoots completes) and "Path outside authorized workspace"
+      // (roots exist but the sibling worktree path isn't among them). Both are
+      // implementation details that mean nothing to the user.
+      throw new Error(
+        'The SSH relay has not registered the worktree path yet. Please wait a moment and try again, or disconnect and reconnect the SSH session.'
+      )
+    }
+    throw err
+  }
 
   // Re-list to get the created worktree info
   const gitWorktrees = await provider.listWorktrees(repo.path)

--- a/src/main/providers/ssh-pty-provider.ts
+++ b/src/main/providers/ssh-pty-provider.ts
@@ -68,6 +68,9 @@ export class SshPtyProvider implements IPtyProvider {
     // existing relay PTY (persisted across app restart). pty.attach replays
     // the buffered output the relay kept alive during the grace window.
     if (opts.sessionId) {
+      console.warn(
+        `[ssh-pty] spawn() called with sessionId=${opts.sessionId}, attempting pty.attach`
+      )
       try {
         const attachResult = (await this.mux.request('pty.attach', {
           id: opts.sessionId,
@@ -75,6 +78,9 @@ export class SshPtyProvider implements IPtyProvider {
           rows: opts.rows,
           suppressReplayNotification: true
         })) as { replay?: string }
+        console.warn(
+          `[ssh-pty] pty.attach succeeded for ${opts.sessionId}, replay=${!!attachResult.replay}`
+        )
         return {
           id: opts.sessionId,
           isReattach: true,
@@ -85,7 +91,7 @@ export class SshPtyProvider implements IPtyProvider {
         // through to pty.spawn so the user gets a fresh shell; sessionExpired
         // lets the renderer show a brief "Session expired" message.
         console.warn(
-          `[ssh-pty] pty.attach failed for ${opts.sessionId}, falling back to fresh spawn:`,
+          `[ssh-pty] pty.attach FAILED for ${opts.sessionId}, falling back to fresh spawn:`,
           err
         )
       }

--- a/src/main/ssh/ssh-channel-multiplexer.ts
+++ b/src/main/ssh/ssh-channel-multiplexer.ts
@@ -40,6 +40,7 @@ export class SshChannelMultiplexer {
   private lastReceivedAt = Date.now()
   private pendingRequests = new Map<number, PendingRequest>()
   private notificationHandlers: NotificationHandler[] = []
+  private disposeHandlers: ((reason: 'shutdown' | 'connection_lost') => void)[] = []
   private keepaliveTimer: ReturnType<typeof setInterval> | null = null
   private timeoutTimer: ReturnType<typeof setInterval> | null = null
   private disposed = false
@@ -80,6 +81,21 @@ export class SshChannelMultiplexer {
       const idx = this.notificationHandlers.indexOf(handler)
       if (idx !== -1) {
         this.notificationHandlers.splice(idx, 1)
+      }
+    }
+  }
+
+  // Why: the session needs to know when the relay channel dies so it can
+  // auto-reconnect. Without this, a relay channel close (e.g. --connect
+  // bridge exits) leaves the session in 'ready' state with a dead mux
+  // and no recovery path — the SSH connection stays up so onStateChange
+  // never fires the reconnect logic.
+  onDispose(handler: (reason: 'shutdown' | 'connection_lost') => void): () => void {
+    this.disposeHandlers.push(handler)
+    return () => {
+      const idx = this.disposeHandlers.indexOf(handler)
+      if (idx !== -1) {
+        this.disposeHandlers.splice(idx, 1)
       }
     }
   }
@@ -132,6 +148,10 @@ export class SshChannelMultiplexer {
     if (this.disposed) {
       return
     }
+    console.warn(
+      `[ssh-mux] Disposing multiplexer (reason: ${reason})`,
+      new Error('dispose trace').stack
+    )
     this.disposed = true
 
     if (this.keepaliveTimer) {
@@ -160,6 +180,15 @@ export class SshChannelMultiplexer {
     this.unackedTimestamps.clear()
     this.decoder.reset()
     this.transport.close?.()
+
+    for (const handler of this.disposeHandlers) {
+      try {
+        handler(reason)
+      } catch {
+        // Don't let a handler error prevent other handlers from running
+      }
+    }
+    this.disposeHandlers.length = 0
   }
 
   isDisposed(): boolean {

--- a/src/main/ssh/ssh-relay-deploy.test.ts
+++ b/src/main/ssh/ssh-relay-deploy.test.ts
@@ -72,6 +72,8 @@ describe('deployAndLaunchRelay', () => {
     mockExecCommand.mockResolvedValueOnce('/home/user') // echo $HOME
     mockExecCommand.mockResolvedValueOnce('OK') // check relay exists
     mockExecCommand.mockResolvedValueOnce('0.1.0') // version check
+    mockExecCommand.mockResolvedValueOnce('DEAD') // socket probe
+    mockExecCommand.mockResolvedValueOnce('READY') // socket poll
 
     await deployAndLaunchRelay(conn)
 
@@ -85,6 +87,8 @@ describe('deployAndLaunchRelay', () => {
     mockExecCommand.mockResolvedValueOnce('/home/user')
     mockExecCommand.mockResolvedValueOnce('OK')
     mockExecCommand.mockResolvedValueOnce('0.1.0')
+    mockExecCommand.mockResolvedValueOnce('DEAD') // socket probe
+    mockExecCommand.mockResolvedValueOnce('READY') // socket poll
 
     const progress: string[] = []
     await deployAndLaunchRelay(conn, (status) => progress.push(status))
@@ -119,23 +123,28 @@ describe('deployAndLaunchRelay', () => {
     const connB = makeMockConnection()
     const mockExecCommand = vi.mocked(execCommand)
     mockExecCommand
-      .mockResolvedValueOnce('Linux x86_64')
-      .mockResolvedValueOnce('/home/user')
-      .mockResolvedValueOnce('OK')
-      .mockResolvedValueOnce('0.1.0')
-      .mockResolvedValueOnce('DEAD')
-      .mockResolvedValueOnce('Linux x86_64')
-      .mockResolvedValueOnce('/home/user')
-      .mockResolvedValueOnce('OK')
-      .mockResolvedValueOnce('0.1.0')
-      .mockResolvedValueOnce('DEAD')
+      .mockResolvedValueOnce('Linux x86_64') // uname A
+      .mockResolvedValueOnce('/home/user') // $HOME A
+      .mockResolvedValueOnce('OK') // exists A
+      .mockResolvedValueOnce('0.1.0') // version A
+      .mockResolvedValueOnce('DEAD') // probe A
+      .mockResolvedValueOnce('READY') // poll A
+      .mockResolvedValueOnce('Linux x86_64') // uname B
+      .mockResolvedValueOnce('/home/user') // $HOME B
+      .mockResolvedValueOnce('OK') // exists B
+      .mockResolvedValueOnce('0.1.0') // version B
+      .mockResolvedValueOnce('DEAD') // probe B
+      .mockResolvedValueOnce('READY') // poll B
 
     await deployAndLaunchRelay(connA, undefined, 300, 'target-a')
     await deployAndLaunchRelay(connB, undefined, 300, 'target-b')
 
     const probeCommands = mockExecCommand.mock.calls
       .map(([, command]) => command)
-      .filter((command) => command.includes('test -S') && command.includes('relay-'))
+      .filter(
+        (command) =>
+          command.includes('test -S') && command.includes('relay-') && command.includes('ALIVE')
+      )
     expect(probeCommands).toHaveLength(2)
     expect(probeCommands[0]).toContain('relay-')
     expect(probeCommands[0]).not.toContain('relay.sock')

--- a/src/main/ssh/ssh-relay-deploy.ts
+++ b/src/main/ssh/ssh-relay-deploy.ts
@@ -351,15 +351,22 @@ async function launchRelay(
   // Why: the backgrounded relay needs time to bind its Unix socket.  We
   // poll rather than sleep a fixed duration because remote host speed
   // varies widely (CI vs. Raspberry Pi).
+  // Why: checking `test -S` only verifies the inode exists, not that the
+  // relay is listening. After a stale socket removal + fresh launch, the
+  // old inode can linger briefly. We probe with a connect-and-close to
+  // confirm the socket is actually accepting connections.
   const POLL_INTERVAL_MS = 200
   const POLL_TIMEOUT_MS = 10_000
   const pollStart = Date.now()
   let socketReady = false
   while (Date.now() - pollStart < POLL_TIMEOUT_MS) {
     try {
+      // Why: node is guaranteed to exist on the remote (we just deployed
+      // the relay with it). Using it to probe the socket is more portable
+      // than python3/socat/perl which may not be installed.
       const result = await execCommand(
         conn,
-        `test -S ${shellEscape(sockFile)} && echo READY || echo WAITING`
+        `${escapedNode} -e "var s=require('net').connect(${JSON.stringify(sockFile)});s.on('connect',()=>{s.destroy();process.stdout.write('READY')});s.on('error',()=>{process.stdout.write('WAITING')})" 2>/dev/null || (test -S ${shellEscape(sockFile)} && echo READY || echo WAITING)`
       )
       if (result.trim() === 'READY') {
         socketReady = true

--- a/src/main/ssh/ssh-relay-deploy.ts
+++ b/src/main/ssh/ssh-relay-deploy.ts
@@ -367,10 +367,11 @@ async function launchRelay(
     try {
       // Why: node is guaranteed to exist on the remote (we just deployed
       // the relay with it). Using it to probe the socket is more portable
-      // than python3/socat/perl which may not be installed.
+      // than python3/socat/perl which may not be installed. The socket
+      // path is passed as argv[1] to avoid shell quoting issues with -e.
       const result = await execCommand(
         conn,
-        `${escapedNode} -e "var s=require('net').connect(${JSON.stringify(sockFile)});s.on('connect',()=>{s.destroy();process.stdout.write('READY')});s.on('error',()=>{process.stdout.write('WAITING')})" 2>/dev/null || (test -S ${shellEscape(sockFile)} && echo READY || echo WAITING)`
+        `${escapedNode} -e 'var s=require("net").connect(process.argv[1]);s.on("connect",function(){s.destroy();process.stdout.write("READY")});s.on("error",function(){process.stdout.write("WAITING")})' ${shellEscape(sockFile)} 2>/dev/null || (test -S ${shellEscape(sockFile)} && echo READY || echo WAITING)`
       )
       if (result.trim() === 'READY') {
         socketReady = true

--- a/src/main/ssh/ssh-relay-deploy.ts
+++ b/src/main/ssh/ssh-relay-deploy.ts
@@ -331,10 +331,60 @@ async function launchRelay(
     // Probe failed — fall through to fresh launch
   }
 
-  // Why: both remoteDir and nodePath come from the remote host and could
-  // contain shell metacharacters. Single-quote escaping prevents injection.
+  // Why: the relay must outlive the SSH connection so PTY sessions survive
+  // app restarts.  nohup prevents SIGHUP death, </dev/null detaches stdin,
+  // and & backgrounds the process so it's not a direct child of the exec
+  // channel.  When sshd tears down the session the relay continues as an
+  // orphan adopted by init, listening on its Unix socket for a --connect
+  // bridge from the next app launch.
+  // Why: execCommand waits for the channel to close, but SSH channels stay
+  // open while backgrounded children exist (even with fd redirection).
+  // Fire-and-forget via conn.exec: we don't need the output — the socket
+  // poll below detects readiness.
+  const logFile = `${remoteDir}/relay.log`
+  const launchCmd = `cd ${escapedDir} && nohup ${escapedNode} relay.js --detached --grace-time ${graceTime} --sock-path ${shellEscape(sockFile)} > ${shellEscape(logFile)} 2>&1 </dev/null &`
+  const launchChannel = await conn.exec(launchCmd)
+  launchChannel.on('data', () => {})
+  launchChannel.stderr.on('data', () => {})
+  launchChannel.on('close', () => {})
+
+  // Why: the backgrounded relay needs time to bind its Unix socket.  We
+  // poll rather than sleep a fixed duration because remote host speed
+  // varies widely (CI vs. Raspberry Pi).
+  const POLL_INTERVAL_MS = 200
+  const POLL_TIMEOUT_MS = 10_000
+  const pollStart = Date.now()
+  let socketReady = false
+  while (Date.now() - pollStart < POLL_TIMEOUT_MS) {
+    try {
+      const result = await execCommand(
+        conn,
+        `test -S ${shellEscape(sockFile)} && echo READY || echo WAITING`
+      )
+      if (result.trim() === 'READY') {
+        socketReady = true
+        break
+      }
+    } catch {
+      /* exec failed, retry */
+    }
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS))
+  }
+
+  if (!socketReady) {
+    const logOutput = await execCommand(
+      conn,
+      `tail -20 ${shellEscape(logFile)} 2>/dev/null || echo "(no log)"`
+    ).catch(() => '(could not read log)')
+    throw new Error(`Relay failed to start within ${POLL_TIMEOUT_MS / 1000}s. Log:\n${logOutput}`)
+  }
+
+  // Why: the backgrounded relay's stdout goes to a log file, not the exec
+  // channel.  We connect via --connect which bridges this new channel's
+  // stdin/stdout to the relay's Unix socket — same path used for reconnect
+  // after app restart.
   const channel = await conn.exec(
-    `cd ${escapedDir} && ${escapedNode} relay.js --grace-time ${graceTime} --sock-path ${shellEscape(sockFile)}`
+    `cd ${escapedDir} && ${escapedNode} relay.js --connect --sock-path ${shellEscape(sockFile)}`
   )
   return waitForSentinel(channel)
 }

--- a/src/main/ssh/ssh-relay-deploy.ts
+++ b/src/main/ssh/ssh-relay-deploy.ts
@@ -346,6 +346,10 @@ async function launchRelay(
   const launchChannel = await conn.exec(launchCmd)
   launchChannel.on('data', () => {})
   launchChannel.stderr.on('data', () => {})
+  // Why: the shell exits quickly (nohup ... &), but the SSH channel stays
+  // open until all child fds close. Explicitly closing it after the poll
+  // loop prevents channel accumulation across relay restarts, which would
+  // eventually hit the server's MaxSessions limit.
   launchChannel.on('close', () => {})
 
   // Why: the backgrounded relay needs time to bind its Unix socket.  We
@@ -377,6 +381,11 @@ async function launchRelay(
     }
     await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS))
   }
+
+  // Why: close the fire-and-forget launch channel now that the relay's
+  // socket is either ready or the poll timed out. Leaving it open leaks
+  // an SSH channel per relay restart.
+  launchChannel.close()
 
   if (!socketReady) {
     const logOutput = await execCommand(

--- a/src/main/ssh/ssh-relay-deploy.ts
+++ b/src/main/ssh/ssh-relay-deploy.ts
@@ -307,6 +307,7 @@ async function launchRelay(
       conn,
       `test -S ${shellEscape(sockFile)} && echo ALIVE || echo DEAD`
     )
+    console.warn(`[ssh-relay] Socket probe result: "${probeOutput.trim()}"`)
     if (probeOutput.trim() === 'ALIVE') {
       console.log('[ssh-relay] Existing relay socket found, attempting reconnect...')
       try {

--- a/src/main/ssh/ssh-relay-session.test.ts
+++ b/src/main/ssh/ssh-relay-session.test.ts
@@ -14,6 +14,7 @@ vi.mock('./ssh-channel-multiplexer', () => {
       notify = vi.fn()
       request = vi.fn().mockResolvedValue([])
       onNotification = vi.fn().mockReturnValue(() => {})
+      onDispose = vi.fn().mockReturnValue(() => {})
       dispose = vi.fn()
       isDisposed = vi.fn().mockReturnValue(false)
     }

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -38,6 +38,11 @@ export class SshRelaySession {
   private _state: RelaySessionState = 'idle'
   private mux: SshChannelMultiplexer | null = null
   private abortController: AbortController | null = null
+  private muxDisposeCleanup: (() => void) | null = null
+  // Why: when the relay exec channel closes but the SSH connection stays
+  // up, the onStateChange reconnect path never fires. This callback lets
+  // ssh.ts wire up relay-level reconnect from outside the session.
+  private _onRelayLost: ((targetId: string) => void) | null = null
 
   constructor(
     readonly targetId: string,
@@ -45,6 +50,10 @@ export class SshRelaySession {
     private store: Store,
     private portForwardManager: SshPortForwardManager
   ) {}
+
+  setOnRelayLost(cb: (targetId: string) => void): void {
+    this._onRelayLost = cb
+  }
 
   getState(): RelaySessionState {
     return this._state
@@ -93,13 +102,31 @@ export class SshRelaySession {
       const mux = new SshChannelMultiplexer(transport)
       this.mux = mux
 
+      // Why: verify the relay is actually responsive before registering
+      // providers. In --connect mode the bridge may have already closed
+      // (e.g. the grace-period relay exited because it had no PTYs), and
+      // registerRelayRoots would silently swallow all mux errors, leaving
+      // the session in 'ready' state with a dead mux. A round-trip request
+      // here fails fast so doConnect() can report the real error.
+      await mux.request('session.resolveHome', { path: '~' })
+
       await this.registerProviders(mux)
+
+      // Why: the mux's transport can close during registerProviders (e.g.
+      // the --connect bridge exits). registerRelayRoots swallows mux errors
+      // (notifications no-op when disposed, git.listWorktrees requests are
+      // try/caught), so establish would otherwise reach 'ready' with a dead
+      // mux. Checking isDisposed catches this silent failure.
+      if (mux.isDisposed()) {
+        throw new Error('Relay connection lost during provider registration')
+      }
 
       if (this.isDisposed()) {
         this.teardownProviders('shutdown')
         throw new Error('Session disposed during establish')
       }
 
+      this.watchMuxForRelayLoss(mux)
       this._state = 'ready'
     } catch (err) {
       // Why: if deployAndLaunchRelay succeeded but registerProviders threw
@@ -161,12 +188,27 @@ export class SshRelaySession {
         !abortController.signal.aborted &&
         !this.isDisposed()
 
+      // Why: same health check as establish() — verify the relay is
+      // responsive before registering providers so a dead --connect bridge
+      // fails fast instead of silently producing a dead mux.
+      await mux.request('session.resolveHome', { path: '~' })
+      if (!ownsAttempt()) {
+        if (!mux.isDisposed()) {
+          mux.dispose()
+        }
+        return
+      }
+
       const registered = await this.registerProviders(mux, ownsAttempt)
       if (!registered) {
         if (!mux.isDisposed()) {
           mux.dispose()
         }
         return
+      }
+
+      if (mux.isDisposed()) {
+        throw new Error('Relay connection lost during provider registration')
       }
 
       // Why: dispose() can fire during registerProviders or the attach loop
@@ -202,6 +244,7 @@ export class SshRelaySession {
         return
       }
 
+      this.watchMuxForRelayLoss(mux)
       this._state = 'ready'
     } catch (err) {
       // Why: clean up the mux if it was created but registration failed
@@ -235,6 +278,23 @@ export class SshRelaySession {
 
   // ── Private ───────────────────────────────────────────────────────
 
+  // Why: when the relay exec channel closes (e.g. --connect bridge exits,
+  // relay process crashes) but the SSH connection stays up, there is no
+  // automatic recovery — onStateChange only fires on SSH-level reconnects.
+  // This watcher detects relay-level channel loss and fires onRelayLost
+  // so ssh.ts can trigger session.reconnect() with the still-live SSH conn.
+  private watchMuxForRelayLoss(mux: SshChannelMultiplexer): void {
+    this.muxDisposeCleanup?.()
+    this.muxDisposeCleanup = mux.onDispose((reason) => {
+      if (reason === 'connection_lost' && this.mux === mux && !this.isDisposed()) {
+        console.warn(
+          `[ssh-relay-session] Relay channel lost for ${this.targetId}, triggering reconnect`
+        )
+        this._onRelayLost?.(this.targetId)
+      }
+    })
+  }
+
   // Why: shared by establish() and reconnect() — the exact same provider
   // registration sequence, eliminating the duplication that caused bugs.
   private async registerProviders(
@@ -260,6 +320,8 @@ export class SshRelaySession {
   }
 
   private teardownProviders(reason: 'shutdown' | 'connection_lost'): void {
+    this.muxDisposeCleanup?.()
+    this.muxDisposeCleanup = null
     if (this.mux && !this.mux.isDisposed()) {
       this.mux.dispose(reason)
     }

--- a/src/relay/pty-handler.test.ts
+++ b/src/relay/pty-handler.test.ts
@@ -1,3 +1,4 @@
+/* oxlint-disable max-lines */
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 
 const { mockPtySpawn, mockPtyInstance } = vi.hoisted(() => ({
@@ -334,6 +335,125 @@ describe('PtyHandler', () => {
 
     vi.advanceTimersByTime(5 * 60 * 1000)
     expect(onExpire).not.toHaveBeenCalled()
+  })
+
+  it('clearAllBuffers empties every PTY replay buffer', async () => {
+    let dataCallback1: ((data: string) => void) | undefined
+    let dataCallback2: ((data: string) => void) | undefined
+    let callCount = 0
+    mockPtySpawn.mockImplementation(() => {
+      callCount++
+      const cb = callCount === 1 ? 'cb1' : 'cb2'
+      return {
+        ...mockPtyInstance,
+        onData: vi.fn((fn: (data: string) => void) => {
+          if (cb === 'cb1') {
+            dataCallback1 = fn
+          } else {
+            dataCallback2 = fn
+          }
+        }),
+        onExit: vi.fn()
+      }
+    })
+
+    await dispatcher.callRequest('pty.spawn', {})
+    await dispatcher.callRequest('pty.spawn', {})
+    dataCallback1!('output from pty-1')
+    dataCallback2!('output from pty-2')
+
+    handler.clearAllBuffers()
+
+    const r1 = await dispatcher.callRequest('pty.attach', {
+      id: 'pty-1',
+      suppressReplayNotification: true
+    })
+    const r2 = await dispatcher.callRequest('pty.attach', {
+      id: 'pty-2',
+      suppressReplayNotification: true
+    })
+    expect(r1).toEqual({})
+    expect(r2).toEqual({})
+  })
+
+  it('after clearAllBuffers, only post-disconnect output is replayed', async () => {
+    let dataCallback: ((data: string) => void) | undefined
+    mockPtySpawn.mockReturnValue({
+      ...mockPtyInstance,
+      onData: vi.fn((cb: (data: string) => void) => {
+        dataCallback = cb
+      }),
+      onExit: vi.fn()
+    })
+
+    await dispatcher.callRequest('pty.spawn', {})
+
+    dataCallback!('pre-disconnect output')
+
+    handler.clearAllBuffers()
+
+    dataCallback!('post-disconnect output')
+
+    const result = await dispatcher.callRequest('pty.attach', {
+      id: 'pty-1',
+      suppressReplayNotification: true
+    })
+    expect(result).toEqual({ replay: 'post-disconnect output' })
+  })
+
+  it('attach clears buffer so a second attach returns nothing', async () => {
+    let dataCallback: ((data: string) => void) | undefined
+    mockPtySpawn.mockReturnValue({
+      ...mockPtyInstance,
+      onData: vi.fn((cb: (data: string) => void) => {
+        dataCallback = cb
+      }),
+      onExit: vi.fn()
+    })
+
+    await dispatcher.callRequest('pty.spawn', {})
+    dataCallback!('some output')
+
+    await dispatcher.callRequest('pty.attach', {
+      id: 'pty-1',
+      suppressReplayNotification: true
+    })
+
+    const result = await dispatcher.callRequest('pty.attach', {
+      id: 'pty-1',
+      suppressReplayNotification: true
+    })
+    expect(result).toEqual({})
+  })
+
+  it('simulates full disconnect-reconnect cycle without duplicate replay', async () => {
+    let dataCallback: ((data: string) => void) | undefined
+    mockPtySpawn.mockReturnValue({
+      ...mockPtyInstance,
+      onData: vi.fn((cb: (data: string) => void) => {
+        dataCallback = cb
+      }),
+      onExit: vi.fn()
+    })
+
+    await dispatcher.callRequest('pty.spawn', {})
+
+    dataCallback!('line 1\r\n')
+    dataCallback!('line 2\r\n')
+
+    handler.clearAllBuffers()
+
+    dataCallback!('line 3 (during disconnect)\r\n')
+
+    dispatcher.notify.mockClear()
+    const result = await dispatcher.callRequest('pty.attach', { id: 'pty-1' })
+
+    expect(result).toEqual({})
+    expect(dispatcher.notify).toHaveBeenCalledWith('pty.replay', {
+      id: 'pty-1',
+      data: 'line 3 (during disconnect)\r\n'
+    })
+    expect(dispatcher.notify).toHaveBeenCalledTimes(1)
   })
 
   it('dispose kills all PTYs', async () => {

--- a/src/relay/pty-handler.test.ts
+++ b/src/relay/pty-handler.test.ts
@@ -294,9 +294,11 @@ describe('PtyHandler', () => {
     )
   })
 
-  it('grace timer fires immediately when no PTYs exist', () => {
+  it('grace timer waits full period even when no PTYs exist', () => {
     const onExpire = vi.fn()
     handler.startGraceTimer(onExpire)
+    expect(onExpire).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(5 * 60 * 1000)
     expect(onExpire).toHaveBeenCalledTimes(1)
   })
 

--- a/src/relay/pty-handler.test.ts
+++ b/src/relay/pty-handler.test.ts
@@ -337,71 +337,35 @@ describe('PtyHandler', () => {
     expect(onExpire).not.toHaveBeenCalled()
   })
 
-  it('clearAllBuffers empties every PTY replay buffer', async () => {
-    let dataCallback1: ((data: string) => void) | undefined
-    let dataCallback2: ((data: string) => void) | undefined
-    let callCount = 0
-    mockPtySpawn.mockImplementation(() => {
-      callCount++
-      const cb = callCount === 1 ? 'cb1' : 'cb2'
-      return {
-        ...mockPtyInstance,
-        onData: vi.fn((fn: (data: string) => void) => {
-          if (cb === 'cb1') {
-            dataCallback1 = fn
-          } else {
-            dataCallback2 = fn
-          }
-        }),
-        onExit: vi.fn()
-      }
+  it('attach preserves buffer so repeated attaches return the same data plus new output', async () => {
+    let dataCallback: ((data: string) => void) | undefined
+    mockPtySpawn.mockReturnValue({
+      ...mockPtyInstance,
+      onData: vi.fn((cb: (data: string) => void) => {
+        dataCallback = cb
+      }),
+      onExit: vi.fn()
     })
 
     await dispatcher.callRequest('pty.spawn', {})
-    await dispatcher.callRequest('pty.spawn', {})
-    dataCallback1!('output from pty-1')
-    dataCallback2!('output from pty-2')
-
-    handler.clearAllBuffers()
+    dataCallback!('initial output')
 
     const r1 = await dispatcher.callRequest('pty.attach', {
       id: 'pty-1',
       suppressReplayNotification: true
     })
+    expect(r1).toEqual({ replay: 'initial output' })
+
+    dataCallback!(' more')
+
     const r2 = await dispatcher.callRequest('pty.attach', {
-      id: 'pty-2',
-      suppressReplayNotification: true
-    })
-    expect(r1).toEqual({})
-    expect(r2).toEqual({})
-  })
-
-  it('after clearAllBuffers, only post-disconnect output is replayed', async () => {
-    let dataCallback: ((data: string) => void) | undefined
-    mockPtySpawn.mockReturnValue({
-      ...mockPtyInstance,
-      onData: vi.fn((cb: (data: string) => void) => {
-        dataCallback = cb
-      }),
-      onExit: vi.fn()
-    })
-
-    await dispatcher.callRequest('pty.spawn', {})
-
-    dataCallback!('pre-disconnect output')
-
-    handler.clearAllBuffers()
-
-    dataCallback!('post-disconnect output')
-
-    const result = await dispatcher.callRequest('pty.attach', {
       id: 'pty-1',
       suppressReplayNotification: true
     })
-    expect(result).toEqual({ replay: 'post-disconnect output' })
+    expect(r2).toEqual({ replay: 'initial output more' })
   })
 
-  it('attach clears buffer so a second attach returns nothing', async () => {
+  it('second app restart still replays full buffer', async () => {
     let dataCallback: ((data: string) => void) | undefined
     mockPtySpawn.mockReturnValue({
       ...mockPtyInstance,
@@ -412,48 +376,31 @@ describe('PtyHandler', () => {
     })
 
     await dispatcher.callRequest('pty.spawn', {})
-    dataCallback!('some output')
+
+    dataCallback!('$ while true; do date; done\r\n')
+    dataCallback!('Mon Apr 28\r\n')
 
     await dispatcher.callRequest('pty.attach', {
       id: 'pty-1',
       suppressReplayNotification: true
     })
 
+    dataCallback!('Tue Apr 29\r\n')
+
+    await dispatcher.callRequest('pty.attach', {
+      id: 'pty-1',
+      suppressReplayNotification: true
+    })
+
+    dataCallback!('Wed Apr 30\r\n')
+
     const result = await dispatcher.callRequest('pty.attach', {
       id: 'pty-1',
       suppressReplayNotification: true
     })
-    expect(result).toEqual({})
-  })
-
-  it('simulates full disconnect-reconnect cycle without duplicate replay', async () => {
-    let dataCallback: ((data: string) => void) | undefined
-    mockPtySpawn.mockReturnValue({
-      ...mockPtyInstance,
-      onData: vi.fn((cb: (data: string) => void) => {
-        dataCallback = cb
-      }),
-      onExit: vi.fn()
+    expect(result).toEqual({
+      replay: '$ while true; do date; done\r\nMon Apr 28\r\nTue Apr 29\r\nWed Apr 30\r\n'
     })
-
-    await dispatcher.callRequest('pty.spawn', {})
-
-    dataCallback!('line 1\r\n')
-    dataCallback!('line 2\r\n')
-
-    handler.clearAllBuffers()
-
-    dataCallback!('line 3 (during disconnect)\r\n')
-
-    dispatcher.notify.mockClear()
-    const result = await dispatcher.callRequest('pty.attach', { id: 'pty-1' })
-
-    expect(result).toEqual({})
-    expect(dispatcher.notify).toHaveBeenCalledWith('pty.replay', {
-      id: 'pty-1',
-      data: 'line 3 (during disconnect)\r\n'
-    })
-    expect(dispatcher.notify).toHaveBeenCalledTimes(1)
   })
 
   it('dispose kills all PTYs', async () => {

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -349,17 +349,11 @@ export class PtyHandler {
     }
   }
 
-  startGraceTimer(onExpire: () => void, options?: { allowImmediateIfEmpty?: boolean }): void {
+  startGraceTimer(onExpire: () => void): void {
     this.cancelGraceTimer()
-    // Why: when allowImmediateIfEmpty is set and no PTYs exist, exit
-    // immediately instead of keeping an orphan relay alive for the full
-    // grace period. This avoids leaking relay processes on connect/disconnect
-    // cycles where no terminal was ever opened. When false (detached startup),
-    // always wait — a --connect client will arrive shortly.
-    if (options?.allowImmediateIfEmpty && this.ptys.size === 0) {
-      onExpire()
-      return
-    }
+    // Why: always wait the full grace period even with zero PTYs.  A detached
+    // relay may have no PTYs yet but a --connect client will arrive shortly.
+    // Firing immediately would kill the relay before anyone could connect.
     this.graceTimer = setTimeout(() => {
       onExpire()
     }, this.graceTimeMs)

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -349,11 +349,17 @@ export class PtyHandler {
     }
   }
 
-  startGraceTimer(onExpire: () => void): void {
+  startGraceTimer(onExpire: () => void, options?: { allowImmediateIfEmpty?: boolean }): void {
     this.cancelGraceTimer()
-    // Why: always wait the full grace period even with zero PTYs.  A detached
-    // relay may have no PTYs yet but a --connect client will arrive shortly.
-    // Firing immediately would kill the relay before anyone could connect.
+    // Why: when allowImmediateIfEmpty is set and no PTYs exist, exit
+    // immediately instead of keeping an orphan relay alive for the full
+    // grace period. This avoids leaking relay processes on connect/disconnect
+    // cycles where no terminal was ever opened. When false (detached startup),
+    // always wait — a --connect client will arrive shortly.
+    if (options?.allowImmediateIfEmpty && this.ptys.size === 0) {
+      onExpire()
+      return
+    }
     this.graceTimer = setTimeout(() => {
       onExpire()
     }, this.graceTimeMs)

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -345,10 +345,9 @@ export class PtyHandler {
 
   startGraceTimer(onExpire: () => void): void {
     this.cancelGraceTimer()
-    if (this.ptys.size === 0) {
-      onExpire()
-      return
-    }
+    // Why: always wait the full grace period even with zero PTYs.  A detached
+    // relay may have no PTYs yet but a --connect client will arrive shortly.
+    // Firing immediately would kill the relay before anyone could connect.
     this.graceTimer = setTimeout(() => {
       onExpire()
     }, this.graceTimeMs)

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -366,6 +366,17 @@ export class PtyHandler {
     }
   }
 
+  // Why: the replay buffer accumulates ALL output, including data already
+  // delivered to the client via pty.data. On client disconnect, clear every
+  // PTY's buffer so it only captures output generated while no client is
+  // connected. Without this, pty.attach replays data the terminal already
+  // displayed, producing duplicate output after every reconnect.
+  clearAllBuffers(): void {
+    for (const [, managed] of this.ptys) {
+      managed.buffered = ''
+    }
+  }
+
   dispose(): void {
     this.cancelGraceTimer()
     for (const [, managed] of this.ptys) {

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -166,10 +166,16 @@ export class PtyHandler {
     // not registered replay handlers yet, so return the bytes to the caller
     // instead of notifying them too early.
     if (managed.buffered) {
+      const replay = managed.buffered
+      // Why: the buffer captures output between disconnects for replay on
+      // reconnect. Once replayed, clear it so the next reconnect only
+      // shows output generated after this attach — otherwise every restart
+      // replays the entire history from the original spawn.
+      managed.buffered = ''
       if (params.suppressReplayNotification) {
-        return { replay: managed.buffered }
+        return { replay }
       }
-      this.dispatcher.notify('pty.replay', { id, data: managed.buffered })
+      this.dispatcher.notify('pty.replay', { id, data: replay })
     }
     return {}
   }

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -165,17 +165,17 @@ export class PtyHandler {
     // Replay buffered output. During pty.spawn({ sessionId }) the renderer has
     // not registered replay handlers yet, so return the bytes to the caller
     // instead of notifying them too early.
+    // Why: the buffer is NOT cleared after replay. It always holds the last
+    // 100 KB of raw output (capped in onData). The client clears xterm before
+    // writing the replay, so returning the full buffer on every attach does
+    // not cause duplication. Keeping the buffer intact means a second app
+    // restart still replays the full terminal history instead of only output
+    // generated since the previous attach.
     if (managed.buffered) {
-      const replay = managed.buffered
-      // Why: the buffer captures output between disconnects for replay on
-      // reconnect. Once replayed, clear it so the next reconnect only
-      // shows output generated after this attach — otherwise every restart
-      // replays the entire history from the original spawn.
-      managed.buffered = ''
       if (params.suppressReplayNotification) {
-        return { replay }
+        return { replay: managed.buffered }
       }
-      this.dispatcher.notify('pty.replay', { id, data: replay })
+      this.dispatcher.notify('pty.replay', { id, data: managed.buffered })
     }
     return {}
   }
@@ -363,17 +363,6 @@ export class PtyHandler {
     if (this.graceTimer) {
       clearTimeout(this.graceTimer)
       this.graceTimer = null
-    }
-  }
-
-  // Why: the replay buffer accumulates ALL output, including data already
-  // delivered to the client via pty.data. On client disconnect, clear every
-  // PTY's buffer so it only captures output generated while no client is
-  // connected. Without this, pty.attach replays data the terminal already
-  // displayed, producing duplicate output after every reconnect.
-  clearAllBuffers(): void {
-    for (const [, managed] of this.ptys) {
-      managed.buffered = ''
     }
   }
 

--- a/src/relay/relay.ts
+++ b/src/relay/relay.ts
@@ -134,6 +134,20 @@ function main(): void {
     }
   })
 
+  // Why: worktree creation needs to await root registration before sending
+  // addWorktree, which validates the target directory. While FIFO frame
+  // processing means a notification won't be reordered in steady state,
+  // the request variant makes the ordering guarantee explicit and closes
+  // failure windows during relay reconnect or fresh-host scenarios where
+  // roots may not yet be registered at all. See issue #911.
+  dispatcher.onRequest('session.registerRoot', async (params) => {
+    const rootPath = params.rootPath as string
+    if (rootPath) {
+      context.registerRoot(rootPath)
+    }
+    return { ok: true }
+  })
+
   // Why: the client stores repo paths as-is from user input, but `~` is a
   // shell expansion — Node's fs APIs don't understand it. This handler lets
   // the client resolve tilde paths to absolute paths on the remote host

--- a/src/relay/relay.ts
+++ b/src/relay/relay.ts
@@ -266,6 +266,7 @@ function main(): void {
         if (activeSocket === sock) {
           activeSocket = null
           dispatcher.invalidateClient()
+          ptyHandler.clearAllBuffers()
           startGrace()
         }
       })
@@ -336,6 +337,7 @@ function main(): void {
       stdoutAlive = false
       if (!activeSocket) {
         dispatcher.invalidateClient()
+        ptyHandler.clearAllBuffers()
         startGrace()
       }
     })
@@ -344,6 +346,7 @@ function main(): void {
       stdoutAlive = false
       if (!activeSocket) {
         dispatcher.invalidateClient()
+        ptyHandler.clearAllBuffers()
         startGrace()
       }
     })

--- a/src/relay/relay.ts
+++ b/src/relay/relay.ts
@@ -266,7 +266,6 @@ function main(): void {
         if (activeSocket === sock) {
           activeSocket = null
           dispatcher.invalidateClient()
-          ptyHandler.clearAllBuffers()
           startGrace()
         }
       })
@@ -337,7 +336,6 @@ function main(): void {
       stdoutAlive = false
       if (!activeSocket) {
         dispatcher.invalidateClient()
-        ptyHandler.clearAllBuffers()
         startGrace()
       }
     })
@@ -346,7 +344,6 @@ function main(): void {
       stdoutAlive = false
       if (!activeSocket) {
         dispatcher.invalidateClient()
-        ptyHandler.clearAllBuffers()
         startGrace()
       }
     })

--- a/src/relay/relay.ts
+++ b/src/relay/relay.ts
@@ -86,6 +86,18 @@ function runConnectMode(sockPath: string): void {
     sock.pipe(process.stdout)
   })
 
+  // Why: when the SSH channel closes, stdout becomes a broken pipe.
+  // Node.js silently swallows EPIPE on process.stdout, so the bridge
+  // stays alive as a zombie — connected to the relay socket but unable
+  // to forward data. The relay keeps writing to this dead bridge,
+  // silently dropping pty.data frames until the next --connect replaces
+  // the socket. Exiting immediately on stdout error lets the relay
+  // detect the disconnect (socket close) and enter grace mode promptly.
+  process.stdout.on('error', () => {
+    sock.destroy()
+    process.exit(1)
+  })
+
   sock.on('error', (err) => {
     clearTimeout(connectTimeout)
     process.stderr.write(`[relay-connect] Socket error: ${err.message}\n`)
@@ -231,6 +243,18 @@ function main(): void {
         }
         ptyHandler.cancelGraceTimer()
         dispatcher.feed(chunk)
+      })
+
+      // Why: when the --connect bridge's SSH channel dies, stdin.pipe(sock)
+      // calls sock.end(), sending FIN to the relay. Without this handler
+      // the relay-side socket stays half-open — the relay keeps writing
+      // pty.data frames that the bridge can no longer forward, silently
+      // dropping output until the next --connect replaces the socket.
+      // Destroying on 'end' ensures the 'close' handler fires promptly.
+      sock.on('end', () => {
+        if (!sock.destroyed) {
+          sock.destroy()
+        }
       })
 
       sock.on('close', () => {

--- a/src/relay/relay.ts
+++ b/src/relay/relay.ts
@@ -29,10 +29,12 @@ const CONNECT_TIMEOUT_MS = 5_000
 function parseArgs(argv: string[]): {
   graceTimeMs: number
   connectMode: boolean
+  detached: boolean
   sockPath: string
 } {
   let graceTimeMs = DEFAULT_GRACE_MS
   let connectMode = false
+  let detached = false
   let sockPath = ''
   for (let i = 2; i < argv.length; i++) {
     if (argv[i] === '--grace-time' && argv[i + 1]) {
@@ -44,6 +46,8 @@ function parseArgs(argv: string[]): {
       i++
     } else if (argv[i] === '--connect') {
       connectMode = true
+    } else if (argv[i] === '--detached') {
+      detached = true
     } else if (argv[i] === '--sock-path' && argv[i + 1]) {
       sockPath = argv[i + 1]
       i++
@@ -52,7 +56,7 @@ function parseArgs(argv: string[]): {
   if (!sockPath) {
     sockPath = join(process.cwd(), SOCK_NAME)
   }
-  return { graceTimeMs, connectMode, sockPath }
+  return { graceTimeMs, connectMode, detached, sockPath }
 }
 
 // ── Connect mode ─────────────────────────────────────────────────────
@@ -96,7 +100,7 @@ function runConnectMode(sockPath: string): void {
 // ── Normal mode ──────────────────────────────────────────────────────
 
 function main(): void {
-  const { graceTimeMs, connectMode, sockPath } = parseArgs(process.argv)
+  const { graceTimeMs, connectMode, detached, sockPath } = parseArgs(process.argv)
 
   if (connectMode) {
     runConnectMode(sockPath)
@@ -279,34 +283,45 @@ function main(): void {
     stdoutAlive = false
   })
 
-  process.stdin.on('data', (chunk: Buffer) => {
-    ptyHandler.cancelGraceTimer()
-    dispatcher.feed(chunk)
-  })
-
-  process.stdin.on('end', () => {
-    // Why: stdout is piped to the SSH channel — once stdin closes the
-    // channel is gone and stdout writes would hit a dead pipe.  Mark it
-    // dead so the dispatcher's write callback becomes a no-op until a
-    // socket client reconnects and calls setWrite with a live target.
-    stdoutAlive = false
-    if (!activeSocket) {
-      dispatcher.invalidateClient()
-      startGrace()
-    }
-  })
-
-  process.stdin.on('error', () => {
-    stdoutAlive = false
-    if (!activeSocket) {
-      dispatcher.invalidateClient()
-      startGrace()
-    }
-  })
-
   function startGrace(): void {
     ptyHandler.startGraceTimer(() => {
       shutdown()
+    })
+  }
+
+  if (detached) {
+    // Why: in detached mode the relay is backgrounded (nohup ... &) so
+    // stdin is /dev/null and stdout goes to a log file.  Listening on
+    // stdin would trigger an immediate EOF → grace → shutdown before any
+    // --connect client arrives.  Instead we mark stdout dead (no direct
+    // pipe), start the grace timer (socket connect will cancel it), and
+    // rely entirely on the Unix socket for client communication.
+    stdoutAlive = false
+    startGrace()
+  } else {
+    process.stdin.on('data', (chunk: Buffer) => {
+      ptyHandler.cancelGraceTimer()
+      dispatcher.feed(chunk)
+    })
+
+    process.stdin.on('end', () => {
+      // Why: stdout is piped to the SSH channel — once stdin closes the
+      // channel is gone and stdout writes would hit a dead pipe.  Mark it
+      // dead so the dispatcher's write callback becomes a no-op until a
+      // socket client reconnects and calls setWrite with a live target.
+      stdoutAlive = false
+      if (!activeSocket) {
+        dispatcher.invalidateClient()
+        startGrace()
+      }
+    })
+
+    process.stdin.on('error', () => {
+      stdoutAlive = false
+      if (!activeSocket) {
+        dispatcher.invalidateClient()
+        startGrace()
+      }
     })
   }
 

--- a/src/relay/relay.ts
+++ b/src/relay/relay.ts
@@ -108,9 +108,13 @@ function main(): void {
   // would risk silent data corruption or zombie PTYs. We log for diagnostics
   // and then exit so the client can detect the disconnect and reconnect cleanly.
   process.on('uncaughtException', (err) => {
-    process.stderr.write(`[relay] Uncaught exception: ${err.message}\n`)
+    process.stderr.write(`[relay] Uncaught exception: ${err.message}\n${err.stack}\n`)
     cleanupSocket(sockPath)
     process.exit(1)
+  })
+
+  process.on('unhandledRejection', (reason) => {
+    process.stderr.write(`[relay] Unhandled rejection: ${reason}\n`)
   })
 
   // Why: stdoutAlive tracks whether process.stdout is still writable.
@@ -121,7 +125,11 @@ function main(): void {
   let stdoutAlive = true
   const dispatcher = new RelayDispatcher((data) => {
     if (stdoutAlive) {
-      process.stdout.write(data)
+      try {
+        process.stdout.write(data)
+      } catch {
+        stdoutAlive = false
+      }
     }
   })
 
@@ -191,6 +199,7 @@ function main(): void {
       // so the old socket's close handler sees it's been replaced and
       // skips starting the grace timer.
       if (activeSocket) {
+        process.stderr.write('[relay] Replacing existing socket client with new connection\n')
         const replaced = activeSocket
         activeSocket = null
         replaced.destroy()
@@ -262,6 +271,14 @@ function main(): void {
 
   // ── stdin/stdout transport (initial connection) ─────────────────────
 
+  // Why: when the SSH channel closes, writing to stdout can emit an
+  // 'error' event (EPIPE/ERR_STREAM_DESTROYED). Without a handler,
+  // Node treats it as an uncaught exception and the process exits
+  // before the grace period starts.
+  process.stdout.on('error', () => {
+    stdoutAlive = false
+  })
+
   process.stdin.on('data', (chunk: Buffer) => {
     ptyHandler.cancelGraceTimer()
     dispatcher.feed(chunk)
@@ -306,6 +323,18 @@ function main(): void {
 
   process.on('SIGTERM', shutdown)
   process.on('SIGINT', shutdown)
+  // Why: when the SSH session drops, the OS sends SIGHUP to the relay's
+  // process group. Node's default SIGHUP behavior is to exit immediately,
+  // which kills all PTYs before the grace period can start. Ignoring
+  // SIGHUP lets the relay survive the SSH disconnect and enter its grace
+  // window — a reconnecting client can then bridge to the live relay via
+  // --connect and reattach to the still-running PTY sessions.
+  process.on('SIGHUP', () => {
+    process.stderr.write('[relay] Received SIGHUP (SSH session dropped), ignoring\n')
+  })
+  process.on('exit', (code) => {
+    process.stderr.write(`[relay] Process exiting with code ${code}\n`)
+  })
 
   // Signal readiness to the client — the client watches for this exact
   // string before sending framed data.

--- a/src/relay/relay.ts
+++ b/src/relay/relay.ts
@@ -266,7 +266,7 @@ function main(): void {
         if (activeSocket === sock) {
           activeSocket = null
           dispatcher.invalidateClient()
-          startGrace({ allowImmediateIfEmpty: true })
+          startGrace()
         }
       })
 
@@ -307,10 +307,10 @@ function main(): void {
     stdoutAlive = false
   })
 
-  function startGrace(options?: { allowImmediateIfEmpty?: boolean }): void {
+  function startGrace(): void {
     ptyHandler.startGraceTimer(() => {
       shutdown()
-    }, options)
+    })
   }
 
   if (detached) {
@@ -336,7 +336,7 @@ function main(): void {
       stdoutAlive = false
       if (!activeSocket) {
         dispatcher.invalidateClient()
-        startGrace({ allowImmediateIfEmpty: true })
+        startGrace()
       }
     })
 
@@ -344,7 +344,7 @@ function main(): void {
       stdoutAlive = false
       if (!activeSocket) {
         dispatcher.invalidateClient()
-        startGrace({ allowImmediateIfEmpty: true })
+        startGrace()
       }
     })
   }

--- a/src/relay/relay.ts
+++ b/src/relay/relay.ts
@@ -266,7 +266,7 @@ function main(): void {
         if (activeSocket === sock) {
           activeSocket = null
           dispatcher.invalidateClient()
-          startGrace()
+          startGrace({ allowImmediateIfEmpty: true })
         }
       })
 
@@ -307,10 +307,10 @@ function main(): void {
     stdoutAlive = false
   })
 
-  function startGrace(): void {
+  function startGrace(options?: { allowImmediateIfEmpty?: boolean }): void {
     ptyHandler.startGraceTimer(() => {
       shutdown()
-    })
+    }, options)
   }
 
   if (detached) {
@@ -336,7 +336,7 @@ function main(): void {
       stdoutAlive = false
       if (!activeSocket) {
         dispatcher.invalidateClient()
-        startGrace()
+        startGrace({ allowImmediateIfEmpty: true })
       }
     })
 
@@ -344,7 +344,7 @@ function main(): void {
       stdoutAlive = false
       if (!activeSocket) {
         dispatcher.invalidateClient()
-        startGrace()
+        startGrace({ allowImmediateIfEmpty: true })
       }
     })
   }

--- a/src/relay/subprocess.test.ts
+++ b/src/relay/subprocess.test.ts
@@ -190,13 +190,15 @@ describe('Subprocess: Relay entry point', () => {
     expect(relay.proc.exitCode !== null || relay.proc.signalCode !== null).toBe(true)
   }, 10_000)
 
-  it('exits immediately on stdin close when no PTYs exist', async () => {
-    relay = spawn(['--grace-time', '100'])
+  it('exits after grace period on stdin close when no PTYs exist', async () => {
+    // Why: grace timer always waits the full period now (even with zero PTYs)
+    // so a detached relay has time for a --connect client to arrive.
+    relay = spawn(['--grace-time', '1'])
     await relay.sentinelReceived
 
     relay.proc.stdin!.end()
 
-    await relay.waitForExit(3000)
+    await relay.waitForExit(5000)
     expect(relay.proc.exitCode).toBe(0)
   }, 10_000)
 

--- a/src/relay/subprocess.test.ts
+++ b/src/relay/subprocess.test.ts
@@ -200,6 +200,57 @@ describe('Subprocess: Relay entry point', () => {
     expect(relay.proc.exitCode).toBe(0)
   }, 10_000)
 
+  it('registers root via request and returns acknowledgment', async () => {
+    tmpDir = mkdtempSync(path.join(tmpdir(), 'relay-sub-'))
+    writeFileSync(path.join(tmpDir, 'test.txt'), 'hello')
+
+    relay = spawn()
+    await relay.sentinelReceived
+
+    const id = relay.send('session.registerRoot', { rootPath: tmpDir })
+    const resp = await relay.waitForResponse(id)
+
+    expect(resp.error).toBeUndefined()
+    expect(resp.result).toEqual({ ok: true })
+
+    const statId = relay.send('fs.stat', { filePath: path.join(tmpDir, 'test.txt') })
+    const statResp = await relay.waitForResponse(statId)
+    expect(statResp.error).toBeUndefined()
+    expect((statResp.result as { type: string }).type).toBe('file')
+  }, 10_000)
+
+  it('rejects fs operations when no roots are registered', async () => {
+    tmpDir = mkdtempSync(path.join(tmpdir(), 'relay-sub-'))
+    writeFileSync(path.join(tmpDir, 'test.txt'), 'hello')
+
+    relay = spawn()
+    await relay.sentinelReceived
+
+    const id = relay.send('fs.stat', { filePath: path.join(tmpDir, 'test.txt') })
+    const resp = await relay.waitForResponse(id)
+
+    expect(resp.error).toBeDefined()
+    expect(resp.error!.message).toContain('No workspace roots registered yet')
+  }, 10_000)
+
+  it('rejects paths outside registered roots', async () => {
+    tmpDir = mkdtempSync(path.join(tmpdir(), 'relay-sub-'))
+    const outsideDir = mkdtempSync(path.join(tmpdir(), 'relay-outside-'))
+    writeFileSync(path.join(outsideDir, 'secret.txt'), 'secret')
+
+    relay = spawn()
+    await relay.sentinelReceived
+    relay.sendNotification('session.registerRoot', { rootPath: tmpDir })
+
+    const id = relay.send('fs.stat', { filePath: path.join(outsideDir, 'secret.txt') })
+    const resp = await relay.waitForResponse(id)
+
+    expect(resp.error).toBeDefined()
+    expect(resp.error!.message).toContain('Path outside authorized workspace')
+
+    await rm(outsideDir, { recursive: true, force: true }).catch(() => {})
+  }, 10_000)
+
   it('resolves ~ to home directory via session.resolveHome', async () => {
     relay = spawn()
     await relay.sentinelReceived

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -252,6 +252,9 @@ function App(): React.JSX.Element {
                 }
                 try {
                   const state = await window.api.ssh.getState({ targetId })
+                  console.warn(
+                    `[ssh-restore] Polled state for ${targetId}: status=${state?.status}`
+                  )
                   if (state?.status === 'connected') {
                     actions.setSshConnectionState(targetId, state)
                   }

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -824,12 +824,12 @@ describe('connectPanePty', () => {
     expect(mockStoreState.removeDeferredSshSessionId).toHaveBeenCalledWith('tab-1')
     expect(deps.syncPanePtyLayoutBinding).toHaveBeenCalledWith(1, 'leaf-session')
     expect(deps.updateTabPtyId).toHaveBeenCalledWith('tab-1', 'leaf-session')
-    expect(pane.terminal.write).not.toHaveBeenCalledWith(
-      '\x1b[2J\x1b[3J\x1b[H',
-      expect.any(Function)
-    )
+    // Why: the relay's replay buffer holds the full terminal history, so the
+    // client clears xterm before writing to prevent duplication with any
+    // content already in the terminal from a prior session.
+    expect(pane.terminal.write).toHaveBeenCalledWith('\x1b[2J\x1b[3J\x1b[H', expect.any(Function))
     expect(pane.terminal.write).toHaveBeenCalledWith('restored-ssh-output', expect.any(Function))
-    expect(pane.terminal.write).not.toHaveBeenCalledWith(
+    expect(pane.terminal.write).toHaveBeenCalledWith(
       POST_REPLAY_FOCUS_REPORTING_RESET,
       expect.any(Function)
     )

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -541,6 +541,9 @@ export function connectPanePty(
       const pendingSessionId =
         restoredLeafSessionId ?? storeState.deferredSshSessionIdsByTabId[deps.tabId]
       const isDeferredTarget = storeState.deferredSshReconnectTargets.includes(connectionId)
+      console.warn(
+        `[pty-connection] SSH tab=${deps.tabId} connectionId=${connectionId} pendingSessionId=${pendingSessionId} isDeferredTarget=${isDeferredTarget}`
+      )
       if (pendingSessionId || isDeferredTarget) {
         void (async () => {
           // Why: ensure the SSH connection is established before attempting
@@ -559,6 +562,9 @@ export function connectPanePty(
             return
           }
           if (pendingSessionId) {
+            console.warn(
+              `[pty-connection] Attempting reattach for tab=${deps.tabId} sessionId=${pendingSessionId}`
+            )
             // Why: the saved remote PTY ID is single-use restore metadata.
             // Clear it before attach/fallback so remounts don't keep retrying
             // an expired session after a fresh shell has been created.
@@ -576,9 +582,19 @@ export function connectPanePty(
             })
             void Promise.resolve(reattachPromise)
               .then((result) => {
+                console.warn(
+                  `[pty-connection] Reattach result for tab=${deps.tabId}:`,
+                  result
+                    ? {
+                        sessionExpired: (result as Record<string, unknown>).sessionExpired,
+                        replay: !!(result as Record<string, unknown>).replay
+                      }
+                    : 'undefined'
+                )
                 handleReattachResult(result)
               })
-              .catch(() => {
+              .catch((err) => {
+                console.warn(`[pty-connection] Reattach FAILED for tab=${deps.tabId}:`, err)
                 if (disposed) {
                   return
                 }

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -408,6 +408,10 @@ export function connectPanePty(
     // stays engaged via the write-completion callback until xterm finishes
     // parsing — so writing directly here is both correct and safe.
     const replayDataCallback = (data: string): void => {
+      // Why: the relay's replay buffer holds the full last 100 KB of output,
+      // including data already rendered in xterm before the disconnect.
+      // Clearing before writing prevents duplication on SSH reconnect.
+      replayIntoTerminal(pane, deps.replayingPanesRef, '\x1b[2J\x1b[3J\x1b[H')
       replayIntoTerminal(pane, deps.replayingPanesRef, data)
     }
 
@@ -507,7 +511,17 @@ export function connectPanePty(
         replayIntoTerminal(pane, deps.replayingPanesRef, POST_REPLAY_FOCUS_REPORTING_RESET)
       }
       if (connectResult?.replay) {
+        // Why: the relay's replay buffer is the authoritative terminal state
+        // (last 100 KB of raw output). On SSH reattach the local xterm may
+        // already hold pre-disconnect content that overlaps with the buffer.
+        // Clearing before writing prevents duplication — same approach the
+        // snapshot path uses above. Focus-reporting reset prevents BEL on
+        // pane focus/blur from stale mode bits in the replayed data.
+        if (!connectResult.snapshot && !connectResult.coldRestore) {
+          replayIntoTerminal(pane, deps.replayingPanesRef, '\x1b[2J\x1b[3J\x1b[H')
+        }
         replayIntoTerminal(pane, deps.replayingPanesRef, connectResult.replay)
+        replayIntoTerminal(pane, deps.replayingPanesRef, POST_REPLAY_FOCUS_REPORTING_RESET)
       }
       if (connectResult?.sessionExpired) {
         toast.info('Previous SSH session expired.', {

--- a/src/renderer/src/lib/workspace-session.test.ts
+++ b/src/renderer/src/lib/workspace-session.test.ts
@@ -56,6 +56,7 @@ function createSnapshot(overrides: Partial<AppState> = {}): AppState {
       ]
     },
     activeBrowserTabIdByWorktree: { 'wt-1': 'browser-1' },
+    lastKnownRelayPtyIdByTabId: {},
     sshConnectionStates: new Map(),
     repos: [],
     worktreesByRepo: {},
@@ -102,6 +103,29 @@ describe('buildWorkspaceSessionPayload', () => {
       ]
     })
     expect(payload.browserTabsByWorktree?.['wt-1'][0].loading).toBe(false)
+  })
+
+  it('uses lastKnownRelayPtyIdByTabId fallback for SSH worktrees with null ptyIds', () => {
+    const payload = buildWorkspaceSessionPayload(
+      createSnapshot({
+        tabsByWorktree: {
+          'wt-1': [{ id: 'tab-1', title: 'shell', ptyId: 'pty-1', worktreeId: 'wt-1' } as never],
+          'wt-ssh': [{ id: 'tab-ssh', title: 'remote', ptyId: null, worktreeId: 'wt-ssh' } as never]
+        },
+        lastKnownRelayPtyIdByTabId: { 'tab-ssh': 'relay-sess-42' },
+        repos: [{ id: 'repo-ssh', connectionId: 'conn-1' } as never],
+        worktreesByRepo: {
+          'repo-ssh': [{ id: 'wt-ssh', repoId: 'repo-ssh' } as never]
+        },
+        sshConnectionStates: new Map([
+          ['conn-1', { status: 'connected', targetId: 'conn-1', error: null, reconnectAttempt: 0 }]
+        ]) as never
+      })
+    )
+
+    expect(payload.activeWorktreeIdsOnShutdown).toContain('wt-ssh')
+    expect(payload.remoteSessionIdsByTabId).toEqual({ 'tab-ssh': 'relay-sess-42' })
+    expect(payload.activeConnectionIdsAtShutdown).toEqual(['conn-1'])
   })
 
   it('drops transient active editor markers that do not point at restored edit files', () => {

--- a/src/renderer/src/lib/workspace-session.ts
+++ b/src/renderer/src/lib/workspace-session.ts
@@ -30,6 +30,7 @@ type WorkspaceSessionSnapshot = Pick<
   | 'sshConnectionStates'
   | 'repos'
   | 'worktreesByRepo'
+  | 'lastKnownRelayPtyIdByTabId'
 >
 
 /** Build the editor-file portion of the workspace session for persistence.
@@ -130,8 +131,14 @@ export function buildBrowserSessionData(
 export function buildWorkspaceSessionPayload(
   snapshot: WorkspaceSessionSnapshot
 ): WorkspaceSessionState {
+  // Why: lastKnownRelayPtyIdByTabId preserves session IDs across relay
+  // disconnect/reconnect cycles. tab.ptyId is cleared on disconnect, but
+  // the relay keeps the PTY alive — using the lastKnown fallback ensures
+  // the session save captures the ID even when the mux is temporarily down.
+  const lastKnown = snapshot.lastKnownRelayPtyIdByTabId
+
   const activeWorktreeIdsOnShutdown = Object.entries(snapshot.tabsByWorktree)
-    .filter(([, tabs]) => tabs.some((tab) => tab.ptyId))
+    .filter(([, tabs]) => tabs.some((tab) => tab.ptyId || lastKnown[tab.id]))
     .map(([worktreeId]) => worktreeId)
 
   // Why: sshConnectionStates is a Map<string, SshConnectionState>, not a plain
@@ -154,8 +161,9 @@ export function buildWorkspaceSessionPayload(
       continue
     }
     for (const tab of tabs) {
-      if (tab.ptyId) {
-        remoteSessionIdsByTabId[tab.id] = tab.ptyId
+      const sessionId = tab.ptyId || lastKnown[tab.id]
+      if (sessionId) {
+        remoteSessionIdsByTabId[tab.id] = sessionId
       }
     }
   }

--- a/src/renderer/src/lib/workspace-session.ts
+++ b/src/renderer/src/lib/workspace-session.ts
@@ -196,12 +196,6 @@ export function buildWorkspaceSessionPayload(
     activeGroupIdByWorktree: snapshot.activeGroupIdByWorktree,
     activeConnectionIdsAtShutdown: connectedTargetIds.length > 0 ? connectedTargetIds : undefined,
     remoteSessionIdsByTabId:
-      Object.keys(remoteSessionIdsByTabId).length > 0 ? remoteSessionIdsByTabId : undefined,
-    ...(() => {
-      console.warn(
-        `[session-save] connectedTargetIds=${JSON.stringify(connectedTargetIds)} remoteSessionIdsByTabId=${JSON.stringify(remoteSessionIdsByTabId)}`
-      )
-      return {}
-    })()
+      Object.keys(remoteSessionIdsByTabId).length > 0 ? remoteSessionIdsByTabId : undefined
   }
 }

--- a/src/renderer/src/lib/workspace-session.ts
+++ b/src/renderer/src/lib/workspace-session.ts
@@ -188,6 +188,12 @@ export function buildWorkspaceSessionPayload(
     activeGroupIdByWorktree: snapshot.activeGroupIdByWorktree,
     activeConnectionIdsAtShutdown: connectedTargetIds.length > 0 ? connectedTargetIds : undefined,
     remoteSessionIdsByTabId:
-      Object.keys(remoteSessionIdsByTabId).length > 0 ? remoteSessionIdsByTabId : undefined
+      Object.keys(remoteSessionIdsByTabId).length > 0 ? remoteSessionIdsByTabId : undefined,
+    ...(() => {
+      console.warn(
+        `[session-save] connectedTargetIds=${JSON.stringify(connectedTargetIds)} remoteSessionIdsByTabId=${JSON.stringify(remoteSessionIdsByTabId)}`
+      )
+      return {}
+    })()
   }
 }

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -1289,10 +1289,16 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       // raw session data BEFORE clearTransientTerminalState nulled the ptyIds.
       // This ensures reconnectPersistedTerminals binds PTYs to the correct
       // tabs, not just tabs[0], which matters for multi-tab worktrees.
+      // Also include tabs whose relay session IDs were preserved in
+      // remoteSessionIdsByTabId — those tabs were disconnected before shutdown
+      // (ptyId was null) but the relay still has their PTY alive.
+      const remoteSessionIds = session.remoteSessionIdsByTabId ?? {}
       const pendingReconnectTabByWorktree: Record<string, string[]> = {}
       for (const worktreeId of pendingReconnectWorktreeIds) {
         const rawTabs = session.tabsByWorktree[worktreeId] ?? []
-        const liveTabIds = rawTabs.filter((t) => t.ptyId && validTabIds.has(t.id)).map((t) => t.id)
+        const liveTabIds = rawTabs
+          .filter((t) => (t.ptyId || remoteSessionIds[t.id]) && validTabIds.has(t.id))
+          .map((t) => t.id)
         if (liveTabIds.length > 0) {
           pendingReconnectTabByWorktree[worktreeId] = liveTabIds
         }
@@ -1330,7 +1336,6 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       // daemon. SSH-backed tabs need their session IDs regardless of the
       // experimentalTerminalDaemon setting. The existing loop above correctly
       // skips SSH repos (connectionId check), so there is no overlap.
-      const remoteSessionIds = session.remoteSessionIdsByTabId ?? {}
       console.warn(
         `[terminals-hydration] remoteSessionIdsByTabId:`,
         JSON.stringify(remoteSessionIds)

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -1385,7 +1385,10 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         if (existing) {
           continue
         }
-        const path = worktreeId.split('::')[1] ?? ''
+        // Why: worktreeId is `${repoId}::${path}` and POSIX paths can legally
+        // contain `::`. Split only on the first separator to preserve the full path.
+        const separatorIdx = worktreeId.indexOf('::')
+        const path = separatorIdx >= 0 ? worktreeId.slice(separatorIdx + 2) : ''
         // Why: SSH worktree paths may use backslash separators on Windows remotes.
         const displayName = path.split(/[/\\]/).pop() || path
         const placeholder: Worktree = {

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -1287,6 +1287,10 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       // experimentalTerminalDaemon setting. The existing loop above correctly
       // skips SSH repos (connectionId check), so there is no overlap.
       const remoteSessionIds = session.remoteSessionIdsByTabId ?? {}
+      console.warn(
+        `[terminals-hydration] remoteSessionIdsByTabId:`,
+        JSON.stringify(remoteSessionIds)
+      )
       for (const [tabId, sessionId] of Object.entries(remoteSessionIds)) {
         if (validTabIds.has(tabId)) {
           pendingReconnectPtyIdByTabId[tabId] = sessionId
@@ -1394,10 +1398,12 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       // SSH connection is active. Without the active-connection check, we'd try
       // to reattach to a relay that isn't connected yet (the deferred/passphrase
       // targets), which would fail.
-      const sshConnected =
-        repo?.connectionId != null &&
-        get().sshConnectionStates.get(repo.connectionId)?.status === 'connected'
+      const sshState = repo?.connectionId ? get().sshConnectionStates.get(repo.connectionId) : null
+      const sshConnected = repo?.connectionId != null && sshState?.status === 'connected'
       const supportsDeferredReattach = !repo?.connectionId || sshConnected
+      console.warn(
+        `[reconnect-terminals] worktree=${worktreeId} connectionId=${repo?.connectionId} sshStatus=${sshState?.status} supportsDeferredReattach=${supportsDeferredReattach}`
+      )
       const targetTabIds = pendingReconnectTabByWorktree[worktreeId] ?? []
       const tabsToReconnect: TerminalTab[] =
         targetTabIds.length > 0
@@ -1423,6 +1429,9 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         // carries per-leaf mappings; connectPanePty reads those via
         // restoredPtyIdByLeafId, but the tab still needs a ptyId for
         // status and orphan detection.
+        console.warn(
+          `[reconnect-terminals] tab=${tabId} tabLevelPtyId=${tabLevelPtyId} supportsDeferredReattach=${supportsDeferredReattach} hasLeafMappings=${hasLeafMappings}`
+        )
         if (supportsDeferredReattach && tabLevelPtyId) {
           set((s) => {
             const next = { ...s.tabsByWorktree }

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -965,9 +965,19 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       const isActiveWorktree = s.activeWorktreeId === worktreeId
       const shouldResetGlobalBrowser = isActiveWorktree && hadBrowserTabs
 
+      // Why: intentional shutdown kills the relay PTY. Remove the tab's
+      // lastKnown entry so session-save does not persist a dead session ID
+      // into remoteSessionIdsByTabId, which would cause the next restart
+      // to attempt reattaching to a PTY that no longer exists.
+      const nextLastKnownRelay = { ...s.lastKnownRelayPtyIdByTabId }
+      for (const tab of tabs) {
+        delete nextLastKnownRelay[tab.id]
+      }
+
       return {
         tabsByWorktree: nextTabsByWorktree,
         ptyIdsByTabId: nextPtyIdsByTabId,
+        lastKnownRelayPtyIdByTabId: nextLastKnownRelay,
         runtimePaneTitlesByTabId: nextRuntimePaneTitlesByTabId,
         suppressedPtyExitIds: nextSuppressedPtyExitIds,
         pendingCodexPaneRestartIds: nextPendingCodexPaneRestartIds,

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -845,9 +845,20 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
           delete nextCodexRestartNoticeByPtyId[currentPtyId]
         }
       }
+      // Why: when a specific ptyId is passed, the PTY actually exited (not
+      // just disconnected). Remove its lastKnown entry so session-save does
+      // not attempt to reattach a dead relay PTY on next restart. When no
+      // ptyId is passed (bulk clear on connection_lost), preserve lastKnown
+      // because the relay still has the PTY alive during its grace period.
+      const nextLastKnownRelay = { ...s.lastKnownRelayPtyIdByTabId }
+      if (ptyId && nextLastKnownRelay[tabId] === ptyId) {
+        delete nextLastKnownRelay[tabId]
+      }
+
       return {
         tabsByWorktree: next,
         ptyIdsByTabId: nextPtyIdsByTabId,
+        lastKnownRelayPtyIdByTabId: nextLastKnownRelay,
         pendingCodexPaneRestartIds: nextPendingCodexPaneRestartIds,
         codexRestartNoticeByPtyId: nextCodexRestartNoticeByPtyId
       }
@@ -1370,7 +1381,8 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
           continue
         }
         const path = worktreeId.split('::')[1] ?? ''
-        const displayName = path.split('/').pop() || path
+        // Why: SSH worktree paths may use backslash separators on Windows remotes.
+        const displayName = path.split(/[/\\]/).pop() || path
         const placeholder: Worktree = {
           id: worktreeId,
           repoId,

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -5,6 +5,7 @@ import type {
   SetupSplitDirection,
   TerminalLayoutSnapshot,
   TerminalTab,
+  Worktree,
   WorkspaceSessionState
 } from '../../../../shared/types'
 import { scheduleRuntimeGraphSync } from '@/runtime/sync-runtime-graph'
@@ -92,6 +93,12 @@ export type TerminalSlice = {
    *  a daemon, the old ptyId doubles as the daemon sessionId — passing it to
    *  spawn triggers createOrAttach which returns the surviving terminal snapshot. */
   pendingReconnectPtyIdByTabId: Record<string, string>
+  // Why: relay session IDs (e.g. pty-0) are stored in tab.ptyId, but
+  // clearTabPtyId nulls it on disconnect.  This map preserves the last
+  // known ID so the session save can capture it even when the relay mux
+  // is temporarily down — without it, remoteSessionIdsByTabId would be
+  // empty and the relay PTY could not be reattached after restart.
+  lastKnownRelayPtyIdByTabId: Record<string, string>
   /** ANSI snapshots returned by daemon reattach, keyed by the new ptyId.
    *  TerminalPane writes these to xterm.js to restore visual state. */
   pendingSnapshotByPtyId: Record<
@@ -206,6 +213,7 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
   pendingReconnectWorktreeIds: [],
   pendingReconnectTabByWorktree: {},
   pendingReconnectPtyIdByTabId: {},
+  lastKnownRelayPtyIdByTabId: {},
   pendingSnapshotByPtyId: {},
   pendingColdRestoreByPtyId: {},
   deferredSshReconnectTargets: [],
@@ -372,6 +380,8 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       delete nextLayouts[tabId]
       const nextPtyIdsByTabId = { ...s.ptyIdsByTabId }
       delete nextPtyIdsByTabId[tabId]
+      const nextLastKnownRelay = { ...s.lastKnownRelayPtyIdByTabId }
+      delete nextLastKnownRelay[tabId]
       const nextRuntimePaneTitlesByTabId = { ...s.runtimePaneTitlesByTabId }
       delete nextRuntimePaneTitlesByTabId[tabId]
       // Why: preserve the unreadTerminalTabs reference when the closing tab had
@@ -440,6 +450,7 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         activeTabId: s.activeTabId === tabId ? null : s.activeTabId,
         activeTabIdByWorktree: nextActiveTabIdByWorktree,
         ptyIdsByTabId: nextPtyIdsByTabId,
+        lastKnownRelayPtyIdByTabId: nextLastKnownRelay,
         runtimePaneTitlesByTabId: nextRuntimePaneTitlesByTabId,
         // Why: skip writing unreadTerminalTabs when the reference is unchanged —
         // avoids a no-op top-level state allocation that would force re-evaluation
@@ -786,6 +797,10 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         ptyIdsByTabId: {
           ...s.ptyIdsByTabId,
           [tabId]: existingPtyIds.includes(ptyId) ? existingPtyIds : [...existingPtyIds, ptyId]
+        },
+        lastKnownRelayPtyIdByTabId: {
+          ...s.lastKnownRelayPtyIdByTabId,
+          [tabId]: ptyId
         },
         ...(isFirstPty && isActiveWorktree ? { sortEpoch: s.sortEpoch + 1 } : {})
       }
@@ -1195,6 +1210,24 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
           .flat()
           .map((worktree) => worktree.id)
       )
+      // Why: SSH repos' worktrees are discovered at runtime via the relay, not
+      // persisted in orca-data.json. On restart, worktreesByRepo for SSH repos
+      // may still be empty when hydration runs (the SSH connection and worktree
+      // fetch race with session hydration). Accept session worktree IDs whose
+      // SSH-backed repo exists in the repos list — they will be populated once
+      // SSH reconnects. Without this, tabs for SSH worktrees are silently
+      // dropped during hydration and the session save overwrites the good data.
+      // Only SSH repos need this: local worktrees are persisted and a missing
+      // local worktree genuinely means it was deleted.
+      const sshRepoIds = new Set(s.repos.filter((r) => r.connectionId).map((r) => r.id))
+      for (const worktreeId of Object.keys(session.tabsByWorktree)) {
+        if (!validWorktreeIds.has(worktreeId)) {
+          const repoId = worktreeId.split('::')[0]
+          if (sshRepoIds.has(repoId)) {
+            validWorktreeIds.add(worktreeId)
+          }
+        }
+      }
       const tabsByWorktree: Record<string, TerminalTab[]> = Object.fromEntries(
         Object.entries(session.tabsByWorktree)
           .filter(([worktreeId]) => validWorktreeIds.has(worktreeId))
@@ -1320,12 +1353,53 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         }
       }
 
+      // Why: SSH worktrees are not persisted in worktreesByRepo (they're
+      // discovered at runtime via the relay). On restart, worktreesByRepo for
+      // SSH repos is empty, so the sidebar can't render them. Synthesize
+      // placeholder entries from the session's tabsByWorktree so the sidebar
+      // shows them immediately. The placeholders will be replaced with full
+      // data once SSH reconnects and fetchWorktrees runs.
+      const worktreesByRepo = { ...s.worktreesByRepo }
+      for (const worktreeId of Object.keys(tabsByWorktree)) {
+        const repoId = worktreeId.split('::')[0]
+        if (!sshRepoIds.has(repoId)) {
+          continue
+        }
+        const existing = (worktreesByRepo[repoId] ?? []).find((w) => w.id === worktreeId)
+        if (existing) {
+          continue
+        }
+        const path = worktreeId.split('::')[1] ?? ''
+        const displayName = path.split('/').pop() || path
+        const placeholder: Worktree = {
+          id: worktreeId,
+          repoId,
+          displayName,
+          comment: '',
+          linkedIssue: null,
+          linkedPR: null,
+          linkedLinearIssue: null,
+          isArchived: false,
+          isUnread: false,
+          isPinned: false,
+          sortOrder: 0,
+          lastActivityAt: 0,
+          path,
+          head: '',
+          branch: '',
+          isBare: false,
+          isMainWorktree: false
+        }
+        worktreesByRepo[repoId] = [...(worktreesByRepo[repoId] ?? []), placeholder]
+      }
+
       return {
         activeRepoId,
         activeWorktreeId,
         activeTabId,
         activeTabIdByWorktree,
         tabsByWorktree,
+        worktreesByRepo,
         pendingReconnectWorktreeIds,
         pendingReconnectTabByWorktree,
         pendingReconnectPtyIdByTabId,
@@ -1423,16 +1497,16 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         const hasLeafMappings = Object.keys(leafPtyMap).length > 0
 
         // Why: restore ptyId on the tab so getWorktreeStatus() sees it as
-        // active (green dot) even before the terminal pane mounts. For
-        // single-pane tabs the tab-level ptyId doubles as the daemon
-        // session ID. For split-pane tabs the layout's ptyIdsByLeafId
-        // carries per-leaf mappings; connectPanePty reads those via
-        // restoredPtyIdByLeafId, but the tab still needs a ptyId for
-        // status and orphan detection.
+        // active (green dot) even before the terminal pane mounts — including
+        // deferred SSH worktrees whose connection isn't established yet. Without
+        // this, the sidebar "show active only" filter hides SSH worktrees and
+        // the user must manually search for them. The actual PTY reattach is
+        // handled later by pty-connection.ts when the terminal pane mounts;
+        // this block only sets the visual state.
         console.warn(
           `[reconnect-terminals] tab=${tabId} tabLevelPtyId=${tabLevelPtyId} supportsDeferredReattach=${supportsDeferredReattach} hasLeafMappings=${hasLeafMappings}`
         )
-        if (supportsDeferredReattach && tabLevelPtyId) {
+        if (tabLevelPtyId) {
           set((s) => {
             const next = { ...s.tabsByWorktree }
             if (!next[worktreeId]) {

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -148,7 +148,9 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
           activeBrowserTabIdByWorktree: nextActiveBrowserTabIdByWorktree,
           activeFileIdByWorktree: nextActiveFileIdByWorktree,
           openFiles: nextOpenFiles,
-          ...(activeWorktreeGone ? { activeWorktreeId: null } : {}),
+          ...(activeWorktreeGone
+            ? { activeWorktreeId: null, activeTabType: 'terminal' as const }
+            : {}),
           ...(activeTabGone ? { activeTabId: null } : {}),
           ...(activeFileGone ? { activeFileId: null } : {}),
           sortEpoch: s.sortEpoch + 1

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -70,22 +70,77 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       set((s) => {
         // Why: when the real worktree list arrives (e.g. after SSH reconnect),
         // placeholder worktrees from session restore may no longer exist on
-        // the remote. Prune their tabsByWorktree entries so the UI doesn't
-        // show orphaned tabs for deleted worktrees.
+        // the remote. Prune all worktree-scoped state so the UI doesn't show
+        // orphaned tabs, stale active selections, or phantom sidebar entries
+        // for deleted worktrees.
         const liveIds = new Set(worktrees.map((w) => w.id))
         const prevIds = (s.worktreesByRepo[repoId] ?? []).map((w) => w.id)
         const removedIds = prevIds.filter((id) => !liveIds.has(id))
-        let nextTabsByWorktree = s.tabsByWorktree
-        if (removedIds.length > 0) {
-          nextTabsByWorktree = { ...s.tabsByWorktree }
-          for (const id of removedIds) {
-            delete nextTabsByWorktree[id]
+
+        if (removedIds.length === 0) {
+          return {
+            worktreesByRepo: { ...s.worktreesByRepo, [repoId]: worktrees },
+            sortEpoch: s.sortEpoch + 1
           }
+        }
+
+        const removedSet = new Set(removedIds)
+        const nextTabsByWorktree = { ...s.tabsByWorktree }
+        const removedTabIds = new Set<string>()
+        const nextActiveTabIdByWorktree = { ...s.activeTabIdByWorktree }
+        const nextActiveTabTypeByWorktree = { ...s.activeTabTypeByWorktree }
+        const nextTerminalLayoutsByTabId = { ...s.terminalLayoutsByTabId }
+        const nextPtyIdsByTabId = { ...s.ptyIdsByTabId }
+        const nextPendingReconnectTabByWorktree = { ...s.pendingReconnectTabByWorktree }
+        const nextUnifiedTabsByWorktree = { ...s.unifiedTabsByWorktree }
+        const nextGroupsByWorktree = { ...s.groupsByWorktree }
+        const nextLayoutByWorktree = { ...s.layoutByWorktree }
+        const nextActiveGroupIdByWorktree = { ...s.activeGroupIdByWorktree }
+        const nextBrowserTabsByWorktree = { ...s.browserTabsByWorktree }
+        const nextActiveBrowserTabIdByWorktree = { ...s.activeBrowserTabIdByWorktree }
+        const nextActiveFileIdByWorktree = { ...s.activeFileIdByWorktree }
+
+        for (const id of removedIds) {
+          for (const tab of nextTabsByWorktree[id] ?? []) {
+            removedTabIds.add(tab.id)
+          }
+          delete nextTabsByWorktree[id]
+          delete nextActiveTabIdByWorktree[id]
+          delete nextActiveTabTypeByWorktree[id]
+          delete nextPendingReconnectTabByWorktree[id]
+          delete nextUnifiedTabsByWorktree[id]
+          delete nextGroupsByWorktree[id]
+          delete nextLayoutByWorktree[id]
+          delete nextActiveGroupIdByWorktree[id]
+          delete nextBrowserTabsByWorktree[id]
+          delete nextActiveBrowserTabIdByWorktree[id]
+          delete nextActiveFileIdByWorktree[id]
+        }
+        for (const tabId of removedTabIds) {
+          delete nextTerminalLayoutsByTabId[tabId]
+          delete nextPtyIdsByTabId[tabId]
         }
 
         return {
           worktreesByRepo: { ...s.worktreesByRepo, [repoId]: worktrees },
           tabsByWorktree: nextTabsByWorktree,
+          activeTabIdByWorktree: nextActiveTabIdByWorktree,
+          activeTabTypeByWorktree: nextActiveTabTypeByWorktree,
+          terminalLayoutsByTabId: nextTerminalLayoutsByTabId,
+          ptyIdsByTabId: nextPtyIdsByTabId,
+          pendingReconnectTabByWorktree: nextPendingReconnectTabByWorktree,
+          unifiedTabsByWorktree: nextUnifiedTabsByWorktree,
+          groupsByWorktree: nextGroupsByWorktree,
+          layoutByWorktree: nextLayoutByWorktree,
+          activeGroupIdByWorktree: nextActiveGroupIdByWorktree,
+          browserTabsByWorktree: nextBrowserTabsByWorktree,
+          activeBrowserTabIdByWorktree: nextActiveBrowserTabIdByWorktree,
+          activeFileIdByWorktree: nextActiveFileIdByWorktree,
+          // Why: if the active worktree was deleted remotely, clear it so the
+          // sidebar doesn't stay focused on a nonexistent entry.
+          ...(s.activeWorktreeId && removedSet.has(s.activeWorktreeId)
+            ? { activeWorktreeId: null }
+            : {}),
           sortEpoch: s.sortEpoch + 1
         }
       })

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -67,13 +67,28 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
         return
       }
 
-      set((s) => ({
-        // Why: active worktrees can change branches entirely from a terminal.
-        // We refresh that live git identity into renderer state, but only bump
-        // sortEpoch when git actually reports a different worktree payload.
-        worktreesByRepo: { ...s.worktreesByRepo, [repoId]: worktrees },
-        sortEpoch: s.sortEpoch + 1
-      }))
+      set((s) => {
+        // Why: when the real worktree list arrives (e.g. after SSH reconnect),
+        // placeholder worktrees from session restore may no longer exist on
+        // the remote. Prune their tabsByWorktree entries so the UI doesn't
+        // show orphaned tabs for deleted worktrees.
+        const liveIds = new Set(worktrees.map((w) => w.id))
+        const prevIds = (s.worktreesByRepo[repoId] ?? []).map((w) => w.id)
+        const removedIds = prevIds.filter((id) => !liveIds.has(id))
+        let nextTabsByWorktree = s.tabsByWorktree
+        if (removedIds.length > 0) {
+          nextTabsByWorktree = { ...s.tabsByWorktree }
+          for (const id of removedIds) {
+            delete nextTabsByWorktree[id]
+          }
+        }
+
+        return {
+          worktreesByRepo: { ...s.worktreesByRepo, [repoId]: worktrees },
+          tabsByWorktree: nextTabsByWorktree,
+          sortEpoch: s.sortEpoch + 1
+        }
+      })
     } catch (err) {
       console.error(`Failed to fetch worktrees for repo ${repoId}:`, err)
     }

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -67,95 +67,13 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
         return
       }
 
-      // Why: when the real worktree list arrives (e.g. after SSH reconnect),
-      // placeholder worktrees from session restore may no longer exist on
-      // the remote. Shut down any live PTYs for removed worktrees before
-      // pruning state, so shells/agents don't leak as orphaned processes.
-      const liveIds = new Set(worktrees.map((w) => w.id))
-      const prevIds = (get().worktreesByRepo[repoId] ?? []).map((w) => w.id)
-      const removedIds = prevIds.filter((id) => !liveIds.has(id))
-      for (const id of removedIds) {
-        await get().shutdownWorktreeTerminals(id)
-      }
-
-      set((s) => {
-        if (removedIds.length === 0) {
-          return {
-            worktreesByRepo: { ...s.worktreesByRepo, [repoId]: worktrees },
-            sortEpoch: s.sortEpoch + 1
-          }
-        }
-
-        const removedSet = new Set(removedIds)
-        const nextTabsByWorktree = { ...s.tabsByWorktree }
-        const removedTabIds = new Set<string>()
-        const nextActiveTabIdByWorktree = { ...s.activeTabIdByWorktree }
-        const nextActiveTabTypeByWorktree = { ...s.activeTabTypeByWorktree }
-        const nextTerminalLayoutsByTabId = { ...s.terminalLayoutsByTabId }
-        const nextPtyIdsByTabId = { ...s.ptyIdsByTabId }
-        const nextPendingReconnectTabByWorktree = { ...s.pendingReconnectTabByWorktree }
-        const nextUnifiedTabsByWorktree = { ...s.unifiedTabsByWorktree }
-        const nextGroupsByWorktree = { ...s.groupsByWorktree }
-        const nextLayoutByWorktree = { ...s.layoutByWorktree }
-        const nextActiveGroupIdByWorktree = { ...s.activeGroupIdByWorktree }
-        const nextBrowserTabsByWorktree = { ...s.browserTabsByWorktree }
-        const nextActiveBrowserTabIdByWorktree = { ...s.activeBrowserTabIdByWorktree }
-        const nextActiveFileIdByWorktree = { ...s.activeFileIdByWorktree }
-
-        for (const id of removedIds) {
-          for (const tab of nextTabsByWorktree[id] ?? []) {
-            removedTabIds.add(tab.id)
-          }
-          delete nextTabsByWorktree[id]
-          delete nextActiveTabIdByWorktree[id]
-          delete nextActiveTabTypeByWorktree[id]
-          delete nextPendingReconnectTabByWorktree[id]
-          delete nextUnifiedTabsByWorktree[id]
-          delete nextGroupsByWorktree[id]
-          delete nextLayoutByWorktree[id]
-          delete nextActiveGroupIdByWorktree[id]
-          delete nextBrowserTabsByWorktree[id]
-          delete nextActiveBrowserTabIdByWorktree[id]
-          delete nextActiveFileIdByWorktree[id]
-        }
-        for (const tabId of removedTabIds) {
-          delete nextTerminalLayoutsByTabId[tabId]
-          delete nextPtyIdsByTabId[tabId]
-        }
-
-        // Why: mirror the global-state cleanup from removeWorktree() so the
-        // UI doesn't stay focused on a deleted worktree's tab or editor file.
-        const nextOpenFiles = s.openFiles.filter((f) => !removedSet.has(f.worktreeId))
-        const activeWorktreeGone = s.activeWorktreeId != null && removedSet.has(s.activeWorktreeId)
-        const activeTabGone = s.activeTabId != null && removedTabIds.has(s.activeTabId)
-        const activeFileGone =
-          s.activeFileId != null &&
-          s.openFiles.some((f) => f.id === s.activeFileId && removedSet.has(f.worktreeId))
-
-        return {
-          worktreesByRepo: { ...s.worktreesByRepo, [repoId]: worktrees },
-          tabsByWorktree: nextTabsByWorktree,
-          activeTabIdByWorktree: nextActiveTabIdByWorktree,
-          activeTabTypeByWorktree: nextActiveTabTypeByWorktree,
-          terminalLayoutsByTabId: nextTerminalLayoutsByTabId,
-          ptyIdsByTabId: nextPtyIdsByTabId,
-          pendingReconnectTabByWorktree: nextPendingReconnectTabByWorktree,
-          unifiedTabsByWorktree: nextUnifiedTabsByWorktree,
-          groupsByWorktree: nextGroupsByWorktree,
-          layoutByWorktree: nextLayoutByWorktree,
-          activeGroupIdByWorktree: nextActiveGroupIdByWorktree,
-          browserTabsByWorktree: nextBrowserTabsByWorktree,
-          activeBrowserTabIdByWorktree: nextActiveBrowserTabIdByWorktree,
-          activeFileIdByWorktree: nextActiveFileIdByWorktree,
-          openFiles: nextOpenFiles,
-          ...(activeWorktreeGone
-            ? { activeWorktreeId: null, activeTabType: 'terminal' as const }
-            : {}),
-          ...(activeTabGone ? { activeTabId: null } : {}),
-          ...(activeFileGone ? { activeFileId: null } : {}),
-          sortEpoch: s.sortEpoch + 1
-        }
-      })
+      set((s) => ({
+        // Why: active worktrees can change branches entirely from a terminal.
+        // We refresh that live git identity into renderer state, but only bump
+        // sortEpoch when git actually reports a different worktree payload.
+        worktreesByRepo: { ...s.worktreesByRepo, [repoId]: worktrees },
+        sortEpoch: s.sortEpoch + 1
+      }))
     } catch (err) {
       console.error(`Failed to fetch worktrees for repo ${repoId}:`, err)
     }

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -123,6 +123,15 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
           delete nextPtyIdsByTabId[tabId]
         }
 
+        // Why: mirror the global-state cleanup from removeWorktree() so the
+        // UI doesn't stay focused on a deleted worktree's tab or editor file.
+        const nextOpenFiles = s.openFiles.filter((f) => !removedSet.has(f.worktreeId))
+        const activeWorktreeGone = s.activeWorktreeId != null && removedSet.has(s.activeWorktreeId)
+        const activeTabGone = s.activeTabId != null && removedTabIds.has(s.activeTabId)
+        const activeFileGone =
+          s.activeFileId != null &&
+          s.openFiles.some((f) => f.id === s.activeFileId && removedSet.has(f.worktreeId))
+
         return {
           worktreesByRepo: { ...s.worktreesByRepo, [repoId]: worktrees },
           tabsByWorktree: nextTabsByWorktree,
@@ -138,11 +147,10 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
           browserTabsByWorktree: nextBrowserTabsByWorktree,
           activeBrowserTabIdByWorktree: nextActiveBrowserTabIdByWorktree,
           activeFileIdByWorktree: nextActiveFileIdByWorktree,
-          // Why: if the active worktree was deleted remotely, clear it so the
-          // sidebar doesn't stay focused on a nonexistent entry.
-          ...(s.activeWorktreeId && removedSet.has(s.activeWorktreeId)
-            ? { activeWorktreeId: null }
-            : {}),
+          openFiles: nextOpenFiles,
+          ...(activeWorktreeGone ? { activeWorktreeId: null } : {}),
+          ...(activeTabGone ? { activeTabId: null } : {}),
+          ...(activeFileGone ? { activeFileId: null } : {}),
           sortEpoch: s.sortEpoch + 1
         }
       })

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -67,16 +67,18 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
         return
       }
 
-      set((s) => {
-        // Why: when the real worktree list arrives (e.g. after SSH reconnect),
-        // placeholder worktrees from session restore may no longer exist on
-        // the remote. Prune all worktree-scoped state so the UI doesn't show
-        // orphaned tabs, stale active selections, or phantom sidebar entries
-        // for deleted worktrees.
-        const liveIds = new Set(worktrees.map((w) => w.id))
-        const prevIds = (s.worktreesByRepo[repoId] ?? []).map((w) => w.id)
-        const removedIds = prevIds.filter((id) => !liveIds.has(id))
+      // Why: when the real worktree list arrives (e.g. after SSH reconnect),
+      // placeholder worktrees from session restore may no longer exist on
+      // the remote. Shut down any live PTYs for removed worktrees before
+      // pruning state, so shells/agents don't leak as orphaned processes.
+      const liveIds = new Set(worktrees.map((w) => w.id))
+      const prevIds = (get().worktreesByRepo[repoId] ?? []).map((w) => w.id)
+      const removedIds = prevIds.filter((id) => !liveIds.has(id))
+      for (const id of removedIds) {
+        await get().shutdownWorktreeTerminals(id)
+      }
 
+      set((s) => {
         if (removedIds.length === 0) {
           return {
             worktreesByRepo: { ...s.worktreesByRepo, [repoId]: worktrees },


### PR DESCRIPTION
## Summary
- Fixes #911 — "No workspace roots registered yet" crash when creating worktree for remote repo
- The relay's `git.addWorktree` validates both `repoPath` and `targetDir` against registered roots. Worktree sibling paths (`repo/../name`) were registered via fire-and-forget `mux.notify`, leaving a failure window during reconnect or fresh-host scenarios
- Adds `session.registerRoot` request handler to the relay so the client can await acknowledgment before proceeding
- Registers **both** `repo.path` and the worktree sibling path before `addWorktree`, with backward-compat fallback to `notify` for older relays connected via `--connect`
- Catches both `validatePath` error variants with a user-friendly message
- Adds 3 subprocess tests covering request-based registration and both error paths

## Test plan
- [x] All 249 existing relay + worktree tests pass (0 regressions)
- [x] 3 new subprocess tests: request-based root registration, no-roots rejection, outside-roots rejection
- [x] TypeScript: 0 type errors
- [x] Lint (oxlint): 0 warnings
- [x] Pre-commit hooks (oxlint + oxfmt) pass
- [x] Codex review: clean (3 rounds — fixed backward-compat and repo root registration gaps found in earlier rounds)
- [ ] Manual: connect to fresh SSH host, add remote repo, create worktree immediately — verify no crash
- [ ] Manual: connect, create worktree, kill SSH, reconnect, create another worktree — verify no crash

Made with [Orca](https://github.com/stablyai/orca) 🐋
