### PR TITLE
fix(persistence): unlink tmp file when write/rename fails

### DIFF
--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -2,7 +2,7 @@
 load/save, and flush logic in one file so the full storage contract is reviewable
 as a unit instead of being scattered across modules. */
 import { app } from 'electron'
-import { readFileSync, writeFileSync, mkdirSync, existsSync, renameSync } from 'fs'
+import { readFileSync, writeFileSync, mkdirSync, existsSync, renameSync, unlinkSync } from 'fs'
 import { writeFile, rename, mkdir, rm } from 'fs/promises'
 import { join, dirname } from 'path'
 import { homedir } from 'os'
@@ -185,15 +185,25 @@ export class Store {
     const dir = dirname(dataFile)
     await mkdir(dir, { recursive: true }).catch(() => {})
     const tmpFile = `${dataFile}.${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}.tmp`
-    await writeFile(tmpFile, JSON.stringify(this.state, null, 2), 'utf-8')
-    // Why: if flush() ran while this async write was in-flight, it bumped
-    // writeGeneration and already wrote the latest state synchronously.
-    // Renaming this stale tmp file would overwrite the fresh data.
-    if (this.writeGeneration !== gen) {
-      await rm(tmpFile).catch(() => {})
-      return
+    // Why: wrap write+rename in try/finally-on-error so any failure (ENOSPC,
+    // ENFILE, EIO, permission) removes the tmp file rather than leaving a
+    // multi-megabyte orphan behind. Successful rename consumes the tmp file.
+    let renamed = false
+    try {
+      await writeFile(tmpFile, JSON.stringify(this.state, null, 2), 'utf-8')
+      // Why: if flush() ran while this async write was in-flight, it bumped
+      // writeGeneration and already wrote the latest state synchronously.
+      // Renaming this stale tmp file would overwrite the fresh data.
+      if (this.writeGeneration !== gen) {
+        return
+      }
+      await rename(tmpFile, dataFile)
+      renamed = true
+    } finally {
+      if (!renamed) {
+        await rm(tmpFile).catch(() => {})
+      }
     }
-    await rename(tmpFile, dataFile)
   }
 
   // Why: synchronous variant kept only for flush() at shutdown, where the
@@ -205,8 +215,23 @@ export class Store {
       mkdirSync(dir, { recursive: true })
     }
     const tmpFile = `${dataFile}.${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}.tmp`
-    writeFileSync(tmpFile, JSON.stringify(this.state, null, 2), 'utf-8')
-    renameSync(tmpFile, dataFile)
+    // Why: mirror the async path — on any failure between writeFileSync and
+    // renameSync, remove the tmp file so crashes during shutdown don't leak
+    // orphans into userData.
+    let renamed = false
+    try {
+      writeFileSync(tmpFile, JSON.stringify(this.state, null, 2), 'utf-8')
+      renameSync(tmpFile, dataFile)
+      renamed = true
+    } finally {
+      if (!renamed) {
+        try {
+          unlinkSync(tmpFile)
+        } catch {
+          // Best-effort cleanup; the write already failed, swallow secondary error.
+        }
+      }
+    }
   }
 
   // ── Repos ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `Store.writeToDiskAsync` / `writeToDiskSync` write to `orca-data.json.<pid>.<ts>.<rand>.tmp` and then rename. If `writeFile` or `rename` throws (ENOSPC, ENFILE, EIO, permission), the tmp file was leaked.
- Wrap both write paths in `try { … } finally { if (!renamed) unlink(tmp) }` so any failure cleans up after itself. The success path is unchanged — the rename consumes the tmp file.

## Context

Surfaced by a real `ENFILE: file table overflow` freeze on macOS: the OS-wide fd table was saturated by another process, which killed Orca's writes mid-rename and left multiple ~15 MB `orca-data.json.*.tmp` orphans in `~/Library/Application Support/orca/`. Those orphans accumulate forever — macOS does not sweep `Application Support`.

Not covering the crash/SIGKILL case (process dies *between* write and rename) on purpose — a startup sweep was considered and rejected. If a future crash leaves an orphan, it's easier to notice and investigate than to silently delete on next launch.

## Test plan

- [x] `pnpm exec vitest run src/main/persistence.test.ts` — 37/37 pass
- [x] `pnpm exec tsgo --noEmit -p config/tsconfig.node.json` — clean
- [ ] Spot-check on a dev instance: `chmod -w` the userData dir mid-save, confirm no `*.tmp` is left behind after the failed write