### PR TITLE
fix(tabs): repair mixed tab shortcut switching

### DIFF
--- a/config/tsconfig.tc.web.json
+++ b/config/tsconfig.tc.web.json
@@ -1,5 +1,14 @@
 {
   "extends": "./tsconfig.web.json",
+  "include": [
+    "../src/renderer/src/env.d.ts",
+    "../src/renderer/src/**/*",
+    "../src/renderer/src/**/*.tsx",
+    "../src/preload/*.d.ts",
+    "../src/shared/**/*",
+    "../src/main/ipc/worktree-logic.ts",
+    "../src/main/wsl.ts"
+  ],
   "compilerOptions": {
     "baseUrl": null,
     "paths": {

--- a/src/renderer/src/components/tab-bar/group-tab-order.test.ts
+++ b/src/renderer/src/components/tab-bar/group-tab-order.test.ts
@@ -49,7 +49,7 @@ function browserTab(id: string, groupId: string, entityId: string, sortOrder: nu
 }
 
 describe('getGroupVisibleTabOrder', () => {
-  it('returns terminal/browser tabs keyed by entityId and editor tabs keyed by unified id', () => {
+  it('returns active-group refs with backing ids plus unified tab ids', () => {
     const group: TabGroup = {
       id: 'g1',
       worktreeId: 'wt',
@@ -70,9 +70,9 @@ describe('getGroupVisibleTabOrder', () => {
         new Set()
       )
     ).toEqual([
-      { type: 'terminal', id: 'term-1' },
-      { type: 'editor', id: 'tab-e1' },
-      { type: 'terminal', id: 'term-2' }
+      { type: 'terminal', id: 'term-1', tabId: 'tab-t1' },
+      { type: 'editor', id: '/repo/file.md', tabId: 'tab-e1' },
+      { type: 'terminal', id: 'term-2', tabId: 'tab-t2' }
     ])
   })
 
@@ -115,7 +115,7 @@ describe('getGroupVisibleTabOrder', () => {
       terminalTab('tab-t2', 'g1', 'term-zombie', 1)
     ]
     expect(getGroupVisibleTabOrder(group, tabs, new Set(['term-1']), new Set(), new Set())).toEqual(
-      [{ type: 'terminal', id: 'term-1' }]
+      [{ type: 'terminal', id: 'term-1', tabId: 'tab-t1' }]
     )
   })
 
@@ -140,9 +140,9 @@ describe('getGroupVisibleTabOrder', () => {
         new Set(['browser-1'])
       )
     ).toEqual([
-      { type: 'terminal', id: 'term-1' },
-      { type: 'browser', id: 'browser-1' },
-      { type: 'editor', id: 'tab-e1' }
+      { type: 'terminal', id: 'term-1', tabId: 'tab-t1' },
+      { type: 'browser', id: 'browser-1', tabId: 'tab-b1' },
+      { type: 'editor', id: '/repo/file.md', tabId: 'tab-e1' }
     ])
   })
 })
@@ -200,6 +200,45 @@ describe('getActiveTabNavOrder', () => {
       'term-2',
       'term-3',
       'term-1'
+    ])
+  })
+
+  it('keeps the active group editor ref isolated when the same file is open in another group', () => {
+    const activeGroup: TabGroup = {
+      id: 'g1',
+      worktreeId: 'wt',
+      activeTabId: 'tab-e1',
+      tabOrder: ['tab-e1', 'tab-t1']
+    }
+    const otherGroup: TabGroup = {
+      id: 'g2',
+      worktreeId: 'wt',
+      activeTabId: 'tab-e2',
+      tabOrder: ['tab-e2', 'tab-t2']
+    }
+    const tabs: Tab[] = [
+      editorTab('tab-e1', 'g1', '/repo/file.md', 0),
+      terminalTab('tab-t1', 'g1', 'term-1', 1),
+      editorTab('tab-e2', 'g2', '/repo/file.md', 2),
+      terminalTab('tab-t2', 'g2', 'term-2', 3)
+    ]
+    const state = makeState({
+      activeGroupIdByWorktree: { wt: 'g1' },
+      groupsByWorktree: { wt: [activeGroup, otherGroup] },
+      unifiedTabsByWorktree: { wt: tabs },
+      tabsByWorktree: {
+        // @ts-expect-error — minimal shape for terminal presence only
+        wt: [{ id: 'term-1' }, { id: 'term-2' }]
+      },
+      openFiles: [
+        // @ts-expect-error — minimal OpenFile shape; nav helper only reads `id` and `worktreeId`
+        { id: '/repo/file.md', worktreeId: 'wt' }
+      ]
+    })
+
+    expect(getActiveTabNavOrder(state, 'wt')).toEqual([
+      { type: 'editor', id: '/repo/file.md', tabId: 'tab-e1' },
+      { type: 'terminal', id: 'term-1', tabId: 'tab-t1' }
     ])
   })
 

--- a/src/renderer/src/components/tab-bar/group-tab-order.ts
+++ b/src/renderer/src/components/tab-bar/group-tab-order.ts
@@ -5,6 +5,7 @@ import { reconcileTabOrder } from './reconcile-order'
 export type VisibleTabRef = {
   type: 'terminal' | 'editor' | 'browser'
   id: string
+  tabId?: string
 }
 
 /**
@@ -18,9 +19,11 @@ export type VisibleTabRef = {
  * only written when tabs are created/closed — drag-reordering updates
  * `group.tabOrder` but not the legacy flat order, which surfaces as
  * keyboard nav cycling tabs in a stale sequence (e.g. 3 → 1 → 2 instead of
- * 3 → 2 → 1). This helper returns the exact ids TabBar uses, keyed the same
- * way (terminal→entityId, browser→entityId, editor→unified tab id), so both
- * code paths share a single source of truth.
+ * 3 → 2 → 1). This helper returns the exact ids TabBar uses, with a dual-id
+ * contract for active-group entries: `id` always carries the backing
+ * entity/file id used by legacy activation APIs, while `tabId` preserves the
+ * unified tab id for exact split-group selection. That keeps both code paths
+ * on the same order without collapsing the identifier domains.
  *
  * Note: TabBar's reconciler appends entities present in state but missing
  * from `group.tabOrder` (an invariant-repair fallback). This helper
@@ -63,19 +66,19 @@ export function getGroupVisibleTabOrder(
         continue
       }
       seenTerminals.add(tab.entityId)
-      result.push({ type: 'terminal', id: tab.entityId })
+      result.push({ type: 'terminal', id: tab.entityId, tabId: tab.id })
     } else if (tab.contentType === 'browser') {
       if (!browserEntityIds.has(tab.entityId) || seenBrowsers.has(tab.entityId)) {
         continue
       }
       seenBrowsers.add(tab.entityId)
-      result.push({ type: 'browser', id: tab.entityId })
+      result.push({ type: 'browser', id: tab.entityId, tabId: tab.id })
     } else {
       if (!editorEntityIds.has(tab.entityId) || seenEditors.has(tab.id)) {
         continue
       }
       seenEditors.add(tab.id)
-      result.push({ type: 'editor', id: tab.id })
+      result.push({ type: 'editor', id: tab.entityId, tabId: tab.id })
     }
   }
   return result

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -686,12 +686,13 @@ export function useTerminalPaneLifecycle({
     // is a per-user prompt/template rather than repo bootstrap, so Orca should
     // not guess at ordering requirements that vary by user workflow.
     if (issueCommandSplit) {
-      const targetPane =
-        (issueAutomationAnchorPaneId !== null
-          ? (manager.getPanes().find((pane) => pane.id === issueAutomationAnchorPaneId) ?? null)
-          : null) ??
-        manager.getActivePane() ??
-        manager.getPanes()[0]
+      let targetPane = manager.getActivePane() ?? manager.getPanes()[0] ?? null
+      if (issueAutomationAnchorPaneId !== null) {
+        // Why: keep the same anchor-first fallback order without the ternary +
+        // nullish chain that `tsgo` currently misreads as always-nullish.
+        targetPane =
+          manager.getPanes().find((pane) => pane.id === issueAutomationAnchorPaneId) ?? targetPane
+      }
       if (targetPane) {
         splitPaneWithOneShotStartup(
           ptyDeps,

--- a/src/renderer/src/hooks/ipc-tab-switch.test.ts
+++ b/src/renderer/src/hooks/ipc-tab-switch.test.ts
@@ -15,19 +15,45 @@ vi.mock('@/components/tab-bar/group-tab-order', () => ({
   getActiveTabNavOrder: getActiveTabNavOrderMock
 }))
 
-import { handleSwitchTerminalTab } from './ipc-tab-switch'
+import { handleSwitchTab, handleSwitchTerminalTab } from './ipc-tab-switch'
 
 type ActiveTabType = 'terminal' | 'editor' | 'browser'
 
-function makeStore(activeTabType: ActiveTabType) {
+type MockGroup = {
+  id: string
+  activeTabId: string | null
+}
+
+type MockStore = {
+  activeWorktreeId: string
+  activeTabType: ActiveTabType
+  activeTabId: string
+  activeFileId: string
+  activeBrowserTabId: string
+  activeGroupIdByWorktree: Record<string, string>
+  groupsByWorktree: Record<string, MockGroup[]>
+  setActiveTab: ReturnType<typeof vi.fn>
+  setActiveFile: ReturnType<typeof vi.fn>
+  setActiveBrowserTab: ReturnType<typeof vi.fn>
+  activateTab: ReturnType<typeof vi.fn>
+  setActiveTabType: ReturnType<typeof vi.fn>
+}
+
+function makeStore(activeTabType: ActiveTabType, overrides: Partial<MockStore> = {}): MockStore {
   return {
     activeWorktreeId: 'wt-1',
     activeTabType,
     activeTabId: 'term-1',
     activeFileId: 'editor-1',
     activeBrowserTabId: 'browser-1',
+    activeGroupIdByWorktree: { 'wt-1': 'group-1' },
+    groupsByWorktree: { 'wt-1': [{ id: 'group-1', activeTabId: 'tab-1' }] },
     setActiveTab: vi.fn(),
-    setActiveTabType: vi.fn()
+    setActiveFile: vi.fn(),
+    setActiveBrowserTab: vi.fn(),
+    activateTab: vi.fn(),
+    setActiveTabType: vi.fn(),
+    ...overrides
   }
 }
 
@@ -137,5 +163,111 @@ describe('handleSwitchTerminalTab', () => {
     expect(handleSwitchTerminalTab(1)).toBe(false)
     expect(store.setActiveTab).not.toHaveBeenCalled()
     expect(store.setActiveTabType).not.toHaveBeenCalled()
+  })
+})
+
+describe('handleSwitchTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('switches terminal to editor using the backing file id and unified tab id', () => {
+    const store = makeStore('terminal')
+    store.activeTabId = 'term-1'
+    getStateMock.mockReturnValue(store)
+    getActiveTabNavOrderMock.mockReturnValue([
+      { type: 'terminal', id: 'term-1' },
+      { type: 'editor', id: 'file-1', tabId: 'tab-editor-1' },
+      { type: 'browser', id: 'browser-1', tabId: 'tab-browser-1' }
+    ])
+
+    expect(handleSwitchTab(1)).toBe(true)
+    expect(store.setActiveFile).toHaveBeenCalledWith('file-1')
+    expect(store.activateTab).toHaveBeenCalledWith('tab-editor-1')
+    expect(store.setActiveTabType).toHaveBeenCalledWith('editor')
+  })
+
+  it('uses the active group tab id to find the current editor index', () => {
+    const store = makeStore('editor')
+    store.activeFileId = 'file-1'
+    store.activeGroupIdByWorktree = { 'wt-1': 'group-1' }
+    store.groupsByWorktree = { 'wt-1': [{ id: 'group-1', activeTabId: 'tab-editor-b' }] }
+    getStateMock.mockReturnValue(store)
+    getActiveTabNavOrderMock.mockReturnValue([
+      { type: 'editor', id: 'file-1', tabId: 'tab-editor-a' },
+      { type: 'terminal', id: 'term-1' },
+      { type: 'editor', id: 'file-1', tabId: 'tab-editor-b' },
+      { type: 'terminal', id: 'term-2' }
+    ])
+
+    expect(handleSwitchTab(1)).toBe(true)
+    expect(store.setActiveTab).toHaveBeenCalledWith('term-2')
+    expect(store.setActiveTabType).toHaveBeenCalledWith('terminal')
+  })
+
+  it('switches from one editor to another using the active group tab id and nav tab ids', () => {
+    const store = makeStore('editor')
+    store.activeFileId = 'file-a'
+    store.activeGroupIdByWorktree = { 'wt-1': 'group-1' }
+    store.groupsByWorktree = { 'wt-1': [{ id: 'group-1', activeTabId: 'tab-b' }] }
+    getStateMock.mockReturnValue(store)
+    getActiveTabNavOrderMock.mockReturnValue([
+      { type: 'editor', id: 'file-a', tabId: 'tab-a' },
+      { type: 'editor', id: 'file-a', tabId: 'tab-b' },
+      { type: 'editor', id: 'file-c', tabId: 'tab-c' }
+    ])
+
+    expect(handleSwitchTab(1)).toBe(true)
+    expect(store.setActiveFile).toHaveBeenCalledWith('file-c')
+    expect(store.activateTab).toHaveBeenCalledWith('tab-c')
+    expect(store.setActiveTabType).toHaveBeenCalledWith('editor')
+  })
+
+  it('ignores editor refs with tab ids when switching terminal tabs only', () => {
+    const store = makeStore('terminal')
+    store.activeTabId = 'term-2'
+    getStateMock.mockReturnValue(store)
+    getActiveTabNavOrderMock.mockReturnValue([
+      { type: 'terminal', id: 'term-1' },
+      { type: 'editor', id: 'editor-1', tabId: 'tab-editor-1' },
+      { type: 'terminal', id: 'term-2' },
+      { type: 'editor', id: 'editor-2', tabId: 'tab-editor-2' },
+      { type: 'terminal', id: 'term-3' }
+    ])
+
+    expect(handleSwitchTerminalTab(1)).toBe(true)
+    expect(store.setActiveTab).toHaveBeenCalledWith('term-3')
+    expect(store.setActiveTabType).toHaveBeenCalledWith('terminal')
+  })
+
+  it('switches editor to terminal without touching editor activation', () => {
+    const store = makeStore('editor')
+    store.activeFileId = 'file-1'
+    getStateMock.mockReturnValue(store)
+    getActiveTabNavOrderMock.mockReturnValue([
+      { type: 'editor', id: 'file-1', tabId: 'tab-editor-1' },
+      { type: 'terminal', id: 'term-1' },
+      { type: 'browser', id: 'browser-1', tabId: 'tab-browser-1' }
+    ])
+
+    expect(handleSwitchTab(1)).toBe(true)
+    expect(store.setActiveTab).toHaveBeenCalledWith('term-1')
+    expect(store.setActiveFile).not.toHaveBeenCalled()
+    expect(store.setActiveTabType).toHaveBeenCalledWith('terminal')
+  })
+
+  it('falls back when an editor entry has no unified tab id', () => {
+    const store = makeStore('terminal')
+    store.activeTabId = 'term-1'
+    getStateMock.mockReturnValue(store)
+    getActiveTabNavOrderMock.mockReturnValue([
+      { type: 'terminal', id: 'term-1' },
+      { type: 'editor', id: 'file-1' }
+    ])
+
+    expect(() => handleSwitchTab(1)).not.toThrow()
+    expect(store.setActiveFile).toHaveBeenCalledWith('file-1')
+    expect(store.activateTab).not.toHaveBeenCalled()
+    expect(store.setActiveTabType).toHaveBeenCalledWith('editor')
   })
 })

--- a/src/renderer/src/hooks/ipc-tab-switch.ts
+++ b/src/renderer/src/hooks/ipc-tab-switch.ts
@@ -23,15 +23,28 @@ export function handleSwitchTab(direction: number): boolean {
   const group = activeGroupId
     ? (store.groupsByWorktree[worktreeId] ?? []).find((candidate) => candidate.id === activeGroupId)
     : undefined
-  const currentId =
+  // Why: prefer the active group's unified tab id so split layouts disambiguate
+  // which copy of a same-entity tab is focused. Match strictly against `tabId`
+  // in that path; only fall back to backing-id matching when the group path
+  // doesn't apply (no group, or its activeTabId isn't in the visible nav —
+  // e.g. hydration races). Keeping the two domains in separate branches
+  // prevents a backing id from colliding with an unrelated tab's `tabId`.
+  const groupTabIdInNav =
     group?.activeTabId && allTabIds.some((entry) => entry.tabId === group.activeTabId)
       ? group.activeTabId
-      : store.activeTabType === 'editor'
+      : null
+  let idx: number
+  if (groupTabIdInNav) {
+    idx = allTabIds.findIndex((t) => t.tabId === groupTabIdInNav)
+  } else {
+    const fallbackId =
+      store.activeTabType === 'editor'
         ? store.activeFileId
         : store.activeTabType === 'browser'
           ? store.activeBrowserTabId
           : store.activeTabId
-  const idx = allTabIds.findIndex((t) => t.tabId === currentId || t.id === currentId)
+    idx = allTabIds.findIndex((t) => t.id === fallbackId)
+  }
   const next = allTabIds[(idx + direction + allTabIds.length) % allTabIds.length]
   if (next.type === 'terminal') {
     store.setActiveTab(next.id)
@@ -40,8 +53,9 @@ export function handleSwitchTab(direction: number): boolean {
     store.setActiveBrowserTab(next.id)
     store.setActiveTabType('browser')
   } else {
-    // Why: backing ids must drive file activation, while unified tab ids only
-    // participate when the active-group ref actually carries one.
+    // Why: `setActiveFile` targets the file entity (its implicit activateTab
+    // picks the first matching tab in the active group); `activateTab(tabId)`
+    // then disambiguates which split copy when the same file is open twice.
     store.setActiveFile(next.id)
     if (next.tabId) {
       store.activateTab?.(next.tabId)

--- a/src/renderer/src/hooks/ipc-tab-switch.ts
+++ b/src/renderer/src/hooks/ipc-tab-switch.ts
@@ -19,13 +19,19 @@ export function handleSwitchTab(direction: number): boolean {
   if (allTabIds.length <= 1) {
     return false
   }
+  const activeGroupId = store.activeGroupIdByWorktree[worktreeId]
+  const group = activeGroupId
+    ? (store.groupsByWorktree[worktreeId] ?? []).find((candidate) => candidate.id === activeGroupId)
+    : undefined
   const currentId =
-    store.activeTabType === 'editor'
-      ? store.activeFileId
-      : store.activeTabType === 'browser'
-        ? store.activeBrowserTabId
-        : store.activeTabId
-  const idx = allTabIds.findIndex((t) => t.id === currentId)
+    group?.activeTabId && allTabIds.some((entry) => entry.tabId === group.activeTabId)
+      ? group.activeTabId
+      : store.activeTabType === 'editor'
+        ? store.activeFileId
+        : store.activeTabType === 'browser'
+          ? store.activeBrowserTabId
+          : store.activeTabId
+  const idx = allTabIds.findIndex((t) => t.tabId === currentId || t.id === currentId)
   const next = allTabIds[(idx + direction + allTabIds.length) % allTabIds.length]
   if (next.type === 'terminal') {
     store.setActiveTab(next.id)
@@ -34,7 +40,12 @@ export function handleSwitchTab(direction: number): boolean {
     store.setActiveBrowserTab(next.id)
     store.setActiveTabType('browser')
   } else {
+    // Why: backing ids must drive file activation, while unified tab ids only
+    // participate when the active-group ref actually carries one.
     store.setActiveFile(next.id)
+    if (next.tabId) {
+      store.activateTab?.(next.tabId)
+    }
     store.setActiveTabType('editor')
   }
   return true


### PR DESCRIPTION
Closes #1123

## Summary
- repair mixed tab shortcut switching so Cmd/Ctrl+Shift+[ and Cmd/Ctrl+Shift+] advance through mixed terminal/editor/browser tab bars without dead key presses
- keep editor navigation on the correct identifier domains by using backing file ids for file activation and unified tab ids for exact active-group selection
- unblock `tc:web` by tightening the web typecheck file set and removing the always-nullish terminal pane expression

## Validation
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/tab-bar/group-tab-order.test.ts src/renderer/src/hooks/ipc-tab-switch.test.ts`
- verified the shortcut flow in a running Electron build: `terminal -> src/a.ts -> src/b.ts`, with both `activeFileId` and active-group `activeTabId` updating as expected

## AI Code Review Summary
- Cross-platform compatibility: the fix stays within the existing Cmd/Ctrl shared shortcut path and does not introduce platform-specific key, path, or menu assumptions; the existing macOS/Linux/Windows behavior split remains intact.
- Security audit summary: no new auth, network, filesystem write, shell execution, or secret-handling paths were introduced by the tab-switching changes; the typecheck unblock is limited to TS config coverage and a nullish-expression cleanup.

## Platform Notes
- validated in this branch on macOS
- the shortcut logic remains shared for macOS, Linux, and Windows through the existing renderer path

## Visual Change
- No visual change.

## Contributor
- X (Twitter): @paakjong