### PR TITLE
fix(terminal): thin xterm v6 scrollbar to match Ghostty's native width

### DIFF
--- a/src/renderer/src/assets/terminal.css
+++ b/src/renderer/src/assets/terminal.css
@@ -29,6 +29,30 @@
   overflow-y: auto;
 }
 
+/* Thin (5px) terminal scrollbar. Why this needs !important + a specific
+   selector: xterm.js v6 does NOT use the legacy .xterm-viewport for
+   scrolling when the canvas/WebGL renderer is active (which Orca uses
+   unconditionally — see pane-lifecycle.ts ENABLE_WEBGL_RENDERER). Instead
+   it embeds VS Code's scrollable-element library, which creates a custom
+   DOM scrollbar at .xterm-scrollable-element > .scrollbar.vertical.
+   Its width is hardcoded to 10px via the verticalScrollbarSize option
+   (node_modules/@xterm/xterm/src/vs/base/browser/ui/scrollbar/
+   scrollableElement.ts line 704) and xterm.js does not expose this option
+   on the Terminal constructor — only the slider COLORS are theme-configurable.
+   The width is written as an inline style by VerticalScrollbar._renderDomNode
+   (verticalScrollbar.ts:75), so overriding it requires !important. We also
+   zero the slider's left offset because VS Code centers it based on
+   (verticalScrollbarSize - verticalSliderSize) / 2, which is computed from
+   the unmodified defaults. */
+.xterm .xterm-scrollable-element > .scrollbar.vertical {
+  width: 5px !important;
+}
+
+.xterm .xterm-scrollable-element > .scrollbar.vertical > .slider {
+  width: 5px !important;
+  left: 0 !important;
+}
+
 /* xterm.css sets position:absolute;top:0 on .xterm-helpers but omits left,
    leaving left:auto. In Electron's Blink, left:auto can resolve to a non-zero
    value and offset the IME candidate window away from the cursor. Anchoring it


### PR DESCRIPTION
## Summary

The xterm.js v6 default scrollbar is ~10px wide, which in Orca (with the canvas/WebGL renderer always enabled) reads as an oversized OS-native scrollbar — visually heavier than the rest of the chrome. This PR pares it down to a 5px slider that better matches the look of Ghostty and other modern terminals.

## Why this is non-trivial

xterm.js v6 dropped the legacy `.xterm-viewport` scrollbar in favor of VS Code's [`scrollable-element`](https://github.com/microsoft/vscode/tree/main/src/vs/base/browser/ui/scrollbar) library. The new scrollbar lives at `.xterm-scrollable-element > .scrollbar.vertical`, and its width is hardcoded to 10px via the `verticalScrollbarSize` option in `scrollableElement.ts:704`. xterm.js exposes the slider *colors* via theme options but never plumbs through the width, so a CSS override is the only path. The width is rendered as an **inline style** by `VerticalScrollbar._renderDomNode` (`verticalScrollbar.ts:75`), which is why `!important` is required to win specificity against the inline style.

The slider's `left` offset also has to be zeroed because VS Code centers the slider via `(verticalScrollbarSize - verticalSliderSize) / 2`, computed from the unmodified 10px default. Without this the 5px slider drifts ~2.5px off-center.

The full reasoning is captured as a why-comment above the CSS rules so the next reader doesn't have to dig through `node_modules`.

## Test plan

- [ ] Open a terminal pane, scroll past the buffer top, confirm the vertical scrollbar visibly reads ~5px and is centered in its track
- [ ] Verify the scrollbar slider colors still respect the active theme (the override only changes width, not background)
- [ ] Confirm no regression in scroll behavior (mouse-wheel + drag)
- [ ] Check on macOS *and* Linux/Windows (xterm v6 internals are platform-agnostic, but the OS-native scrollbar fallback differs)

## Notes

- One file changed: `src/renderer/src/assets/terminal.css` (+24 lines, all in one block)
- No JS/TS changes, no behavior change beyond visual width
- Tested locally against the current upstream `main`