### PR TITLE
Fix tab strip overlap when sidebar closes

### DIFF
--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -55,6 +55,7 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     terminalPaneOpacityTransitionMs: 150,
     terminalDividerThicknessPx: 1,
     terminalRightClickToPaste: false,
+    terminalTabAcceptSuggestion: true,
     terminalFocusFollowsMouse: false,
     terminalClipboardOnSelect: false,
     setupScriptLaunchMode: 'split-vertical',

--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -49,6 +49,7 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     terminalPaneOpacityTransitionMs: 150,
     terminalDividerThicknessPx: 1,
     terminalRightClickToPaste: false,
+    terminalTabAcceptSuggestion: true,
     terminalFocusFollowsMouse: false,
     terminalClipboardOnSelect: false,
     setupScriptLaunchMode: 'split-vertical',

--- a/src/main/daemon/shell-ready.ts
+++ b/src/main/daemon/shell-ready.ts
@@ -1,6 +1,7 @@
 import { tmpdir } from 'os'
 import { basename, join } from 'path'
 import { chmodSync, mkdirSync, writeFileSync } from 'fs'
+import { getZshShellReadyRcfileContent } from '../providers/local-pty-shell-ready'
 
 const SHELL_READY_WRAPPER_ROOT = join(tmpdir(), 'orca-shell-ready')
 const SHELL_READY_MARKER = '\\033]777;orca-shell-ready\\007'
@@ -28,12 +29,6 @@ export ZDOTDIR=${quotePosixSingle(zshDir)}
   const zshProfile = `# Orca daemon zsh shell-ready wrapper
 _orca_home="\${ORCA_ORIG_ZDOTDIR:-$HOME}"
 [[ -f "$_orca_home/.zprofile" ]] && source "$_orca_home/.zprofile"
-`
-  const zshRc = `# Orca daemon zsh shell-ready wrapper
-_orca_home="\${ORCA_ORIG_ZDOTDIR:-$HOME}"
-if [[ -o interactive && -f "$_orca_home/.zshrc" ]]; then
-  source "$_orca_home/.zshrc"
-fi
 `
   const zshLogin = `# Orca daemon zsh shell-ready wrapper
 _orca_home="\${ORCA_ORIG_ZDOTDIR:-$HOME}"
@@ -72,7 +67,7 @@ fi
   const files = [
     [join(zshDir, '.zshenv'), zshEnv],
     [join(zshDir, '.zprofile'), zshProfile],
-    [join(zshDir, '.zshrc'), zshRc],
+    [join(zshDir, '.zshrc'), getZshShellReadyRcfileContent()],
     [join(zshDir, '.zlogin'), zshLogin],
     [join(bashDir, 'rcfile'), bashRc]
   ] as const

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -556,9 +556,10 @@ describe('registerPtyHandlers', () => {
     }
   })
 
-  it('binds Tab to the same zsh forward-char path as the right arrow', async () => {
+  it('makes the zsh Tab binding configurable and disabled by env flag', async () => {
     const { getZshShellReadyRcfileContent } = await import('./pty')
     const zshRcContent = getZshShellReadyRcfileContent()
+    expect(zshRcContent).toContain('ORCA_ZSH_TAB_ACCEPTS_SUGGESTION')
     expect(zshRcContent).toContain("bindkey '^I' forward-char")
   })
 

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -556,6 +556,12 @@ describe('registerPtyHandlers', () => {
     }
   })
 
+  it('binds Tab to the same zsh forward-char path as the right arrow', async () => {
+    const { getZshShellReadyRcfileContent } = await import('./pty')
+    const zshRcContent = getZshShellReadyRcfileContent()
+    expect(zshRcContent).toContain("bindkey '^I' forward-char")
+  })
+
   it('does not write the startup command before the shell-ready marker arrives', async () => {
     vi.useFakeTimers()
     const mockProc = createMockProc()

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -4,7 +4,10 @@ foreground-process inspection, and renderer IPC stay behind a single audited
 boundary. Splitting it by line count would scatter tightly coupled terminal
 process behavior across files without a cleaner ownership seam. */
 import { type BrowserWindow, ipcMain } from 'electron'
-export { getBashShellReadyRcfileContent } from '../providers/local-pty-shell-ready'
+export {
+  getBashShellReadyRcfileContent,
+  getZshShellReadyRcfileContent
+} from '../providers/local-pty-shell-ready'
 import type { OrcaRuntimeService } from '../runtime/orca-runtime'
 import type { GlobalSettings } from '../../shared/types'
 import { openCodeHookService } from '../opencode/hook-service'

--- a/src/main/providers/local-pty-shell-ready.ts
+++ b/src/main/providers/local-pty-shell-ready.ts
@@ -18,6 +18,19 @@ function quotePosixSingle(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`
 }
 
+export function getZshShellReadyRcfileContent(): string {
+  return `# Orca zsh shell-ready wrapper
+_orca_home="\${ORCA_ORIG_ZDOTDIR:-$HOME}"
+if [[ -o interactive && -f "$_orca_home/.zshrc" ]]; then
+  source "$_orca_home/.zshrc"
+fi
+# Why: match the right-arrow accept path used by zsh-autosuggestions so Tab
+# accepts the inline command suggestion in Orca's shells instead of falling
+# back to completion or focus traversal.
+bindkey '^I' forward-char
+`
+}
+
 const STARTUP_COMMAND_READY_MAX_WAIT_MS = 1500
 const OSC_133_A = '\x1b]133;A'
 
@@ -124,12 +137,6 @@ export ZDOTDIR=${quotePosixSingle(zshDir)}
 _orca_home="\${ORCA_ORIG_ZDOTDIR:-$HOME}"
 [[ -f "$_orca_home/.zprofile" ]] && source "$_orca_home/.zprofile"
 `
-  const zshRc = `# Orca zsh shell-ready wrapper
-_orca_home="\${ORCA_ORIG_ZDOTDIR:-$HOME}"
-if [[ -o interactive && -f "$_orca_home/.zshrc" ]]; then
-  source "$_orca_home/.zshrc"
-fi
-`
   const zshLogin = `# Orca zsh shell-ready wrapper
 _orca_home="\${ORCA_ORIG_ZDOTDIR:-$HOME}"
 if [[ -o interactive && -f "$_orca_home/.zlogin" ]]; then
@@ -147,7 +154,7 @@ precmd_functions=(\${precmd_functions[@]} __orca_prompt_mark)
   const files = [
     [`${zshDir}/.zshenv`, zshEnv],
     [`${zshDir}/.zprofile`, zshProfile],
-    [`${zshDir}/.zshrc`, zshRc],
+    [`${zshDir}/.zshrc`, getZshShellReadyRcfileContent()],
     [`${zshDir}/.zlogin`, zshLogin],
     [`${bashDir}/rcfile`, bashRc]
   ] as const

--- a/src/main/providers/local-pty-shell-ready.ts
+++ b/src/main/providers/local-pty-shell-ready.ts
@@ -24,10 +24,14 @@ _orca_home="\${ORCA_ORIG_ZDOTDIR:-$HOME}"
 if [[ -o interactive && -f "$_orca_home/.zshrc" ]]; then
   source "$_orca_home/.zshrc"
 fi
-# Why: match the right-arrow accept path used by zsh-autosuggestions so Tab
-# accepts the inline command suggestion in Orca's shells instead of falling
-# back to completion or focus traversal.
-bindkey '^I' forward-char
+# Why: allow users to opt out of the Tab binding if they want stock completion
+# semantics instead of suggestion acceptance.
+if [[ "\${ORCA_ZSH_TAB_ACCEPTS_SUGGESTION:-1}" != '0' ]]; then
+  # Why: match the right-arrow accept path used by zsh-autosuggestions so Tab
+  # accepts the inline command suggestion in Orca's shells instead of falling
+  # back to completion or focus traversal.
+  bindkey '^I' forward-char
+fi
 `
 }
 

--- a/src/main/rate-limits/claude-pty.test.ts
+++ b/src/main/rate-limits/claude-pty.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { resolveClaudeCommandMock, spawnMock } = vi.hoisted(() => ({
+  resolveClaudeCommandMock: vi.fn(),
+  spawnMock: vi.fn()
+}))
+
+vi.mock('../codex-cli/command', () => ({
+  resolveClaudeCommand: resolveClaudeCommandMock
+}))
+
+vi.mock('node-pty', () => ({
+  spawn: spawnMock
+}))
+
+import { fetchViaPty } from './claude-pty'
+
+function makeDisposable() {
+  return { dispose: vi.fn() }
+}
+
+describe('fetchViaPty', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.clearAllMocks()
+    resolveClaudeCommandMock.mockReturnValue('claude')
+  })
+
+  it('disposes node-pty listeners before killing the hidden PTY on timeout', async () => {
+    const onDataDisposable = makeDisposable()
+    const onExitDisposable = makeDisposable()
+
+    spawnMock.mockReturnValue({
+      onData: vi.fn(() => onDataDisposable),
+      onExit: vi.fn(() => onExitDisposable),
+      write: vi.fn(),
+      kill: vi.fn()
+    })
+
+    const resultPromise = fetchViaPty()
+    await vi.advanceTimersByTimeAsync(25_000)
+    await resultPromise
+
+    const term = spawnMock.mock.results[0]?.value as { kill: ReturnType<typeof vi.fn> }
+    expect(onDataDisposable.dispose.mock.invocationCallOrder[0]).toBeLessThan(
+      term.kill.mock.invocationCallOrder[0]
+    )
+    expect(onExitDisposable.dispose.mock.invocationCallOrder[0]).toBeLessThan(
+      term.kill.mock.invocationCallOrder[0]
+    )
+  })
+})

--- a/src/main/rate-limits/claude-pty.ts
+++ b/src/main/rate-limits/claude-pty.ts
@@ -150,10 +150,20 @@ export async function fetchViaPty(): Promise<ProviderRateLimits> {
       rows: 40,
       env: { ...process.env, TERM: 'xterm-256color' }
     })
+    const termDisposables: { dispose: () => void }[] = []
+    const disposeTermListeners = (): void => {
+      for (const disposable of termDisposables.splice(0)) {
+        disposable.dispose()
+      }
+    }
 
     const timeout = setTimeout(() => {
       if (!resolved) {
         resolved = true
+        // Why: node-pty's NAPI callbacks can outlive the Electron JS
+        // environment if we kill the hidden PTY without disposing them first,
+        // which matches Orca's documented SIGABRT failure mode on shutdown.
+        disposeTermListeners()
         term.kill()
         // Even on timeout, try to parse whatever we collected
         // eslint-disable-next-line no-control-regex
@@ -205,6 +215,7 @@ export async function fetchViaPty(): Promise<ProviderRateLimits> {
       if (enterInterval) {
         clearInterval(enterInterval)
       }
+      disposeTermListeners()
       term.kill()
 
       // eslint-disable-next-line no-control-regex
@@ -243,7 +254,7 @@ export async function fetchViaPty(): Promise<ProviderRateLimits> {
       startEnterPresses()
     }, STARTUP_DELAY_MS)
 
-    term.onData((data) => {
+    const onDataDisposable = term.onData((data) => {
       output += data
 
       // eslint-disable-next-line no-control-regex
@@ -278,8 +289,12 @@ export async function fetchViaPty(): Promise<ProviderRateLimits> {
         }
       }
     })
+    if (onDataDisposable) {
+      termDisposables.push(onDataDisposable)
+    }
 
-    term.onExit(() => {
+    const onExitDisposable = term.onExit(() => {
+      disposeTermListeners()
       if (enterInterval) {
         clearInterval(enterInterval)
       }
@@ -299,5 +314,8 @@ export async function fetchViaPty(): Promise<ProviderRateLimits> {
         })
       }
     })
+    if (onExitDisposable) {
+      termDisposables.push(onExitDisposable)
+    }
   })
 }

--- a/src/main/rate-limits/codex-fetcher.test.ts
+++ b/src/main/rate-limits/codex-fetcher.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { childSpawnMock, resolveCodexCommandMock, ptySpawnMock } = vi.hoisted(() => ({
+  childSpawnMock: vi.fn(),
+  resolveCodexCommandMock: vi.fn(),
+  ptySpawnMock: vi.fn()
+}))
+
+vi.mock('node:child_process', () => ({
+  spawn: childSpawnMock
+}))
+
+vi.mock('../codex-cli/command', () => ({
+  resolveCodexCommand: resolveCodexCommandMock
+}))
+
+vi.mock('node-pty', () => ({
+  spawn: ptySpawnMock
+}))
+
+import { fetchCodexRateLimits } from './codex-fetcher'
+
+function makeDisposable() {
+  return { dispose: vi.fn() }
+}
+
+describe('fetchCodexRateLimits', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.clearAllMocks()
+    resolveCodexCommandMock.mockReturnValue('codex')
+  })
+
+  it('disposes node-pty listeners before killing the PTY fallback on timeout', async () => {
+    const onDataDisposable = makeDisposable()
+    const onExitDisposable = makeDisposable()
+
+    childSpawnMock.mockImplementation(() => {
+      throw new Error('rpc unavailable')
+    })
+    ptySpawnMock.mockReturnValue({
+      onData: vi.fn(() => onDataDisposable),
+      onExit: vi.fn(() => onExitDisposable),
+      write: vi.fn(),
+      kill: vi.fn()
+    })
+
+    const resultPromise = fetchCodexRateLimits()
+    await vi.advanceTimersByTimeAsync(15_000)
+    await resultPromise
+
+    const term = ptySpawnMock.mock.results[0]?.value as { kill: ReturnType<typeof vi.fn> }
+    expect(onDataDisposable.dispose.mock.invocationCallOrder[0]).toBeLessThan(
+      term.kill.mock.invocationCallOrder[0]
+    )
+    expect(onExitDisposable.dispose.mock.invocationCallOrder[0]).toBeLessThan(
+      term.kill.mock.invocationCallOrder[0]
+    )
+  })
+})

--- a/src/main/rate-limits/codex-fetcher.ts
+++ b/src/main/rate-limits/codex-fetcher.ts
@@ -315,10 +315,20 @@ async function fetchViaPty(options?: FetchCodexRateLimitsOptions): Promise<Provi
         ...(options?.codexHomePath ? { CODEX_HOME: options.codexHomePath } : {})
       }
     })
+    const termDisposables: { dispose: () => void }[] = []
+    const disposeTermListeners = (): void => {
+      for (const disposable of termDisposables.splice(0)) {
+        disposable.dispose()
+      }
+    }
 
     const timeout = setTimeout(() => {
       if (!resolved) {
         resolved = true
+        // Why: killing a hidden PTY without disposing node-pty's NAPI listener
+        // handles leaves ThreadSafeFunction callbacks alive into Electron
+        // shutdown, which can abort the app while Node cleans up its env.
+        disposeTermListeners()
         term.kill()
         resolve({
           provider: 'codex',
@@ -331,7 +341,7 @@ async function fetchViaPty(options?: FetchCodexRateLimitsOptions): Promise<Provi
       }
     }, PTY_TIMEOUT_MS)
 
-    term.onData((data) => {
+    const onDataDisposable = term.onData((data) => {
       output += data
 
       // Wait for prompt, then send /status
@@ -349,6 +359,7 @@ async function fetchViaPty(options?: FetchCodexRateLimitsOptions): Promise<Provi
           }
           resolved = true
           clearTimeout(timeout)
+          disposeTermListeners()
           term.kill()
 
           // eslint-disable-next-line no-control-regex
@@ -366,8 +377,12 @@ async function fetchViaPty(options?: FetchCodexRateLimitsOptions): Promise<Provi
         }, 500)
       }
     })
+    if (onDataDisposable) {
+      termDisposables.push(onDataDisposable)
+    }
 
-    term.onExit(() => {
+    const onExitDisposable = term.onExit(() => {
+      disposeTermListeners()
       if (!resolved) {
         resolved = true
         clearTimeout(timeout)
@@ -384,6 +399,9 @@ async function fetchViaPty(options?: FetchCodexRateLimitsOptions): Promise<Provi
         })
       }
     })
+    if (onExitDisposable) {
+      termDisposables.push(onExitDisposable)
+    }
   })
 }
 

--- a/src/renderer/src/components/settings/TerminalPane.tsx
+++ b/src/renderer/src/components/settings/TerminalPane.tsx
@@ -444,6 +444,39 @@ export function TerminalPane({
             />
           </button>
         </SearchableSetting>
+
+        <SearchableSetting
+          title="Tab Accepts Suggestions"
+          description="In shell-ready zsh sessions, Tab accepts the inline suggestion the same way the right arrow does."
+          keywords={['terminal', 'tab', 'suggestion', 'autocomplete', 'zsh', 'shell']}
+          className="flex items-center justify-between gap-4 px-1 py-2"
+        >
+          <div className="space-y-0.5">
+            <Label>Tab Accepts Suggestions</Label>
+            <p className="text-xs text-muted-foreground">
+              In shell-ready zsh sessions, Tab accepts the inline suggestion the same way the
+              right arrow does. Turn this off if you want stock zsh completion on Tab.
+            </p>
+          </div>
+          <button
+            role="switch"
+            aria-checked={settings.terminalTabAcceptSuggestion}
+            onClick={() =>
+              updateSettings({
+                terminalTabAcceptSuggestion: !settings.terminalTabAcceptSuggestion
+              })
+            }
+            className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent transition-colors ${
+              settings.terminalTabAcceptSuggestion ? 'bg-foreground' : 'bg-muted-foreground/30'
+            }`}
+          >
+            <span
+              className={`pointer-events-none block size-3.5 rounded-full bg-background shadow-sm transition-transform ${
+                settings.terminalTabAcceptSuggestion ? 'translate-x-4' : 'translate-x-0.5'
+              }`}
+            />
+          </button>
+        </SearchableSetting>
       </section>
     ) : null,
     matchesSettingsSearch(searchQuery, TERMINAL_DARK_THEME_SEARCH_ENTRIES) ? (

--- a/src/renderer/src/components/settings/terminal-search.ts
+++ b/src/renderer/src/components/settings/terminal-search.ts
@@ -69,6 +69,12 @@ export const TERMINAL_PANE_STYLE_SEARCH_ENTRIES: SettingsSearchEntry[] = [
       'gnome',
       'paste'
     ]
+  },
+  {
+    title: 'Tab Accepts Suggestions',
+    description:
+      'In shell-ready zsh sessions, Tab accepts the inline suggestion the same way the right arrow does.',
+    keywords: ['terminal', 'tab', 'suggestion', 'autocomplete', 'zsh', 'shell']
   }
 ]
 

--- a/src/renderer/src/components/tab-group/TabGroupPanel.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense } from 'react'
+import { lazy, Suspense, type CSSProperties } from 'react'
 import { useDroppable } from '@dnd-kit/core'
 import { Columns2, Ellipsis, Rows2, X } from 'lucide-react'
 import { useAppStore } from '../../store'
@@ -174,30 +174,37 @@ export default function TabGroupPanel({
           className={`flex h-full items-stretch pr-1.5${
             reserveClosedExplorerToggleSpace && !rightSidebarOpen ? ' pr-10' : ''
           }`}
-          style={{
-            paddingLeft:
-              reserveCollapsedSidebarHeaderSpace && !sidebarOpen
-                ? 'var(--collapsed-sidebar-header-width)'
-                : undefined
-          }}
         >
+          {reserveCollapsedSidebarHeaderSpace && !sidebarOpen ? (
+            // Why: the collapsed sidebar still occupies the left titlebar
+            // chrome, so the top-left tab row needs a real spacer rather than
+            // just padding. That keeps the first tab from sitting underneath
+            // the floating controls when the sidebar is closed.
+            <div
+              aria-hidden
+              className="h-full shrink-0 pointer-events-none"
+              style={
+                {
+                  width: 'var(--collapsed-sidebar-header-width)',
+                  WebkitAppRegion: 'no-drag'
+                } as CSSProperties
+              }
+            />
+          ) : null}
           {/* Why: when the right sidebar is closed, App.tsx renders a floating
-              explorer toggle in the top-right corner of the workspace. Only the
-              top-right tab group can sit underneath that button, so reserve
-              space in just that one header instead of pushing every group in. */}
-          {/* Why: collapsing the left worktree sidebar should let the terminal
-              reclaim the full left edge, but the top-left tab row should still
-              stop where the remaining titlebar controls end. Use the measured
-              width of that controls cluster instead of the old full sidebar
-              width so tabs cap at the agent badge, not at the old divider. */}
+              explorer toggle in the top-right corner of the workspace. Only
+              the top-right tab group can sit underneath that button, so
+              reserve space in just that one header instead of pushing every
+              group in. */}
           <div className="min-w-0 flex-1 h-full">{tabBar}</div>
-          {/* Why: pane-scoped layout actions belong with the active pane instead
-              of the global tab-bar `+`, which should keep opening tabs exactly
-              as before. The local overflow menu holds split directions and
-              close-group without changing the existing tab-creation affordance. */}
+          {/* Why: pane-scoped layout actions belong with the active pane
+              instead of the global tab-bar `+`, which should keep opening tabs
+              exactly as before. The local overflow menu holds split directions
+              and close-group without changing the existing tab-creation
+              affordance. */}
           <div
             className={actionChromeClassName}
-            style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+            style={{ WebkitAppRegion: 'no-drag' } as CSSProperties}
           >
             {isFocused ? (
               <DropdownMenu modal={false}>

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -156,6 +156,7 @@ export function connectPanePty(
   // Why: remote repos route PTY spawn through the SSH provider. Resolve the
   // repo's connectionId from the store so the transport passes it to pty:spawn.
   const state = useAppStore.getState()
+  const tabAcceptSuggestion = state.settings?.terminalTabAcceptSuggestion ?? true
   const allWorktrees = Object.values(state.worktreesByRepo ?? {}).flat()
   const worktree = allWorktrees.find((w) => w.id === deps.worktreeId)
   const repo = worktree ? state.repos?.find((r) => r.id === worktree.repoId) : null
@@ -163,7 +164,10 @@ export function connectPanePty(
 
   const transport = createIpcPtyTransport({
     cwd: deps.cwd,
-    env: paneStartup?.env,
+    env: {
+      ...paneStartup?.env,
+      ORCA_ZSH_TAB_ACCEPTS_SUGGESTION: tabAcceptSuggestion ? '1' : '0'
+    },
     command: paneStartup?.command,
     connectionId,
     worktreeId: deps.worktreeId,

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -120,6 +120,10 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     // box. Other platforms ignore this field because the UI never exposes it,
     // and Ctrl+right-click still opens the context menu when paste is enabled.
     terminalRightClickToPaste: true,
+    // Default true so zsh shells accept inline suggestions with Tab the same
+    // way they do with the right arrow. Users can disable this if they prefer
+    // the stock completion path on Tab.
+    terminalTabAcceptSuggestion: true,
     // Default false: opt-in only (matches Ghostty's default). Existing users
     // on upgrade inherit this default via persistence.ts's
     // { ...defaults.settings, ...parsed.settings } merge, so enabling

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -609,6 +609,10 @@ export type GlobalSettings = {
    *  The setting stays Windows-only so macOS/Linux keep their existing context
    *  menu behavior and users can still reach the menu with Ctrl+right-click. */
   terminalRightClickToPaste: boolean
+  /** When true, Orca's shell-ready zsh wrapper binds Tab to the same accept
+   *  behavior as the right arrow for zsh-autosuggestions. Users who prefer
+   *  conventional completion on Tab can turn this off. */
+  terminalTabAcceptSuggestion: boolean
   terminalFocusFollowsMouse: boolean
   /** Why: mirrors X11 / gnome-terminal "copy on select" UX — making a terminal
    *  selection copies it to the system clipboard automatically, so users can


### PR DESCRIPTION
Reserve collapsed sidebar chrome with an explicit spacer so the first tab no longer sits under the floating left controls when the sidebar is closed.

Tests:
- pnpm exec vitest run src/main/persistence.test.ts src/main/codex-accounts/runtime-home-service.test.ts src/renderer/src/components/tab-group/TabGroupSplitLayout.test.ts
- pnpm run typecheck:node
- pnpm run typecheck:web