### PR TITLE
feat: improve SSH file search with configurable limits and rg fallback

### DIFF
--- a/src/main/ipc/filesystem-list-files.test.ts
+++ b/src/main/ipc/filesystem-list-files.test.ts
@@ -37,6 +37,8 @@ function createMockProcess(): ChildProcess {
   ).setEncoding = vi.fn()
   ;(p as unknown as Record<string, unknown>).stderr = new EventEmitter()
   ;(p as unknown as Record<string, unknown>).kill = vi.fn()
+  ;(p as unknown as Record<string, unknown>).exitCode = null
+  ;(p as unknown as Record<string, unknown>).signalCode = null
 
   return p
 }
@@ -64,23 +66,91 @@ describe('filesystem-list-files', () => {
 
     // Simulate stdout output for normal files
     setTimeout(() => {
-      ;(p1.stdout as unknown as EventEmitter).emit('data', '/mock/root/file1.ts\n')
-      ;(p1.stdout as unknown as EventEmitter).emit('data', '/mock/root/node_modules/bad.js\n')
-      ;(p1.stdout as unknown as EventEmitter).emit('data', '/mock/root/.git/config\n')
-      ;(p1.stdout as unknown as EventEmitter).emit('data', '/mock/root/.github/workflows/ci.yml\n')
-      ;(p1.stdout as unknown as EventEmitter).emit('data', '/mock/root/dir1/') // incomplete line
+      ;(p1.stdout as unknown as EventEmitter).emit('data', 'file1.ts\n')
+      ;(p1.stdout as unknown as EventEmitter).emit('data', 'node_modules/bad.js\n')
+      ;(p1.stdout as unknown as EventEmitter).emit('data', '.git/config\n')
+      ;(p1.stdout as unknown as EventEmitter).emit('data', '.github/workflows/ci.yml\n')
+      ;(p1.stdout as unknown as EventEmitter).emit('data', 'dir1/') // incomplete line
       ;(p1.stdout as unknown as EventEmitter).emit('data', 'file2.js\n')
-      p1.emit('close')
+      p1.emit('close', 0, null)
 
       // Simulate stdout output for env files
-      ;(p2.stdout as unknown as EventEmitter).emit('data', '/mock/root/.env.local\n')
-      ;(p2.stdout as unknown as EventEmitter).emit('data', '/mock/root/file1.ts\n') // Duplicate
-      p2.emit('close')
+      ;(p2.stdout as unknown as EventEmitter).emit('data', '.env.local\n')
+      ;(p2.stdout as unknown as EventEmitter).emit('data', 'file1.ts\n') // Duplicate
+      p2.emit('close', 0, null)
     }, 10)
 
     const result = await promise
 
     expect(result).toEqual(['file1.ts', '.github/workflows/ci.yml', 'dir1/file2.js', '.env.local'])
+  })
+
+  it('rejects rg failures instead of resolving a false-empty list', async () => {
+    const p1 = createMockProcess()
+    const p2 = createMockProcess()
+
+    spawnMock.mockImplementation((_cmd, args: string[]) => {
+      if (args.includes('**/.env*')) {
+        return p2
+      }
+      return p1
+    })
+
+    const storeMock = {} as unknown as Store
+    const promise = listQuickOpenFiles('/mock/root', storeMock)
+
+    setTimeout(() => {
+      p1.emit('close', 2, null)
+      p2.emit('close', 0, null)
+    }, 10)
+
+    await expect(promise).rejects.toThrow('rg exited with code 2')
+  })
+
+  it('kills the sibling rg pass after one pass fails', async () => {
+    const p1 = createMockProcess()
+    const p2 = createMockProcess()
+
+    spawnMock.mockImplementation((_cmd, args: string[]) => {
+      if (args.includes('**/.env*')) {
+        return p2
+      }
+      return p1
+    })
+
+    const storeMock = {} as unknown as Store
+    const promise = listQuickOpenFiles('/mock/root', storeMock)
+
+    setTimeout(() => {
+      ;(p1 as unknown as { exitCode: number | null }).exitCode = 2
+      p1.emit('close', 2, null)
+    }, 10)
+
+    await expect(promise).rejects.toThrow('rg exited with code 2')
+    expect(p2.kill).toHaveBeenCalled()
+  })
+
+  it('accepts rg code 2 when rg emitted parseable paths first', async () => {
+    const p1 = createMockProcess()
+    const p2 = createMockProcess()
+
+    spawnMock.mockImplementation((_cmd, args: string[]) => {
+      if (args.includes('**/.env*')) {
+        return p2
+      }
+      return p1
+    })
+
+    const storeMock = {} as unknown as Store
+    const promise = listQuickOpenFiles('/mock/root', storeMock)
+
+    setTimeout(() => {
+      ;(p1.stdout as unknown as EventEmitter).emit('data', 'src/index.ts\n')
+      p1.emit('close', 2, null)
+      p2.emit('close', 0, null)
+    }, 10)
+
+    await expect(promise).resolves.toEqual(['src/index.ts'])
   })
 
   it('filters out .next, .cache, .stably, .vscode, .idea', async () => {
@@ -98,16 +168,16 @@ describe('filesystem-list-files', () => {
     const promise = listQuickOpenFiles('/mock/root', storeMock)
 
     setTimeout(() => {
-      ;(p1.stdout as unknown as EventEmitter).emit('data', '/mock/root/.next/cache/1.js\n')
-      ;(p1.stdout as unknown as EventEmitter).emit('data', '/mock/root/.cache/data.json\n')
-      ;(p1.stdout as unknown as EventEmitter).emit('data', '/mock/root/.stably/config.json\n')
-      ;(p1.stdout as unknown as EventEmitter).emit('data', '/mock/root/.vscode/settings.json\n')
-      ;(p1.stdout as unknown as EventEmitter).emit('data', '/mock/root/.idea/workspace.xml\n')
-      ;(p1.stdout as unknown as EventEmitter).emit('data', '/mock/root/valid.ts\n')
-      p1.emit('close')
+      ;(p1.stdout as unknown as EventEmitter).emit('data', '.next/cache/1.js\n')
+      ;(p1.stdout as unknown as EventEmitter).emit('data', '.cache/data.json\n')
+      ;(p1.stdout as unknown as EventEmitter).emit('data', '.stably/config.json\n')
+      ;(p1.stdout as unknown as EventEmitter).emit('data', '.vscode/settings.json\n')
+      ;(p1.stdout as unknown as EventEmitter).emit('data', '.idea/workspace.xml\n')
+      ;(p1.stdout as unknown as EventEmitter).emit('data', 'valid.ts\n')
+      p1.emit('close', 0, null)
 
       // Empty env result
-      p2.emit('close')
+      p2.emit('close', 0, null)
     }, 10)
 
     const result = await promise
@@ -138,10 +208,10 @@ describe('filesystem-list-files', () => {
         ;(gitP1.stdout as unknown as EventEmitter).emit('data', 'src/index.ts\n')
         ;(gitP1.stdout as unknown as EventEmitter).emit('data', 'package.json\n')
         ;(gitP1.stdout as unknown as EventEmitter).emit('data', 'node_modules/dep/index.js\n')
-        gitP1.emit('close')
+        gitP1.emit('close', 0, null)
 
         ;(gitP2.stdout as unknown as EventEmitter).emit('data', '.env.local\n')
-        gitP2.emit('close')
+        gitP2.emit('close', 0, null)
       }, 10)
 
       const result = await promise
@@ -185,9 +255,9 @@ describe('filesystem-list-files', () => {
         ;(gitP1.stdout as unknown as EventEmitter).emit('data', '.vscode/settings.json\n')
         ;(gitP1.stdout as unknown as EventEmitter).emit('data', '.github/workflows/ci.yml\n')
         ;(gitP1.stdout as unknown as EventEmitter).emit('data', 'valid.ts\n')
-        gitP1.emit('close')
+        gitP1.emit('close', 0, null)
 
-        gitP2.emit('close')
+        gitP2.emit('close', 0, null)
       }, 10)
 
       const result = await promise
@@ -212,14 +282,16 @@ describe('filesystem-list-files', () => {
       const promise = listQuickOpenFiles('/mock/root', storeMock)
 
       setTimeout(() => {
-        ;(p1.stdout as unknown as EventEmitter).emit('data', '/mock/root/file.ts\n')
-        p1.emit('close')
-        p2.emit('close')
+        ;(p1.stdout as unknown as EventEmitter).emit('data', 'file.ts\n')
+        p1.emit('close', 0, null)
+        p2.emit('close', 0, null)
       }, 10)
 
       const result = await promise
 
       expect(result).toEqual(['file.ts'])
+      const rgCalls = spawnMock.mock.calls.filter((call) => call[0] === 'rg')
+      expect(rgCalls.every((call) => call[1].at(-1) === '.')).toBe(true)
       // git should never have been called
       const gitCalls = spawnMock.mock.calls.filter((call) => call[0] === 'git')
       expect(gitCalls.length).toBe(0)

--- a/src/main/ipc/filesystem-list-files.ts
+++ b/src/main/ipc/filesystem-list-files.ts
@@ -1,4 +1,5 @@
 import { sep } from 'path'
+import type { ChildProcess } from 'child_process'
 import type { Store } from '../persistence'
 import { resolveAuthorizedPath } from './filesystem-auth'
 import { checkRgAvailable } from './rg-availability'
@@ -29,20 +30,24 @@ export async function listQuickOpenFiles(
   // Why: checking rg availability upfront avoids a race condition where
   // spawn('rg') emits 'close' before 'error' on some platforms, causing
   // the handler to resolve with empty results before the git fallback
-  // can run. The result is cached after the first check.
+  // can run.
   const rgAvailable = await checkRgAvailable(authorizedRootPath)
   if (!rgAvailable) {
     return listFilesWithGit(authorizedRootPath, excludePathPrefixes)
   }
 
   const files = new Set<string>()
+  const children: ChildProcess[] = []
   // Why: when rg runs inside WSL, output paths are Linux-native
   // (e.g. /home/user/repo/src/file.ts). Translate them back to Windows
   // UNC paths up-front before the shared line normalizer runs.
   const wslInfo = parseWslPath(authorizedRootPath)
 
   const { primary, envPass } = buildRgArgsForQuickOpen({
-    searchRoot: authorizedRootPath,
+    // Why: rg evaluates root-relative exclude globs against cwd only when the
+    // search target is cwd-relative. With an absolute target, `!packages/app`
+    // filters output after traversal but does not prune the nested worktree.
+    searchRoot: '.',
     excludePathPrefixes,
     // On Windows, rg outputs '\\'-separated paths; force '/'. Also force on
     // macOS/Linux for idempotence — it's a no-op there.
@@ -50,27 +55,31 @@ export async function listQuickOpenFiles(
   })
 
   const runRg = (args: string[]): Promise<void> => {
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
       let buf = ''
       let done = false
-      const finish = (): void => {
+      let parseablePathCount = 0
+      const finish = (err?: Error): void => {
         if (done) {
           return
         }
         done = true
         clearTimeout(timer)
-        resolve()
+        if (err) {
+          reject(err)
+        } else {
+          resolve()
+        }
       }
 
       const processLine = (rawLine: string): void => {
-        const translated = wslInfo ? toWindowsWslPath(rawLine, wslInfo.distro) : rawLine
-        const relPath = normalizeQuickOpenRgLine(translated, {
-          kind: 'absolute',
-          rootPath: authorizedRootPath
-        })
+        const translated =
+          wslInfo && rawLine.startsWith('/') ? toWindowsWslPath(rawLine, wslInfo.distro) : rawLine
+        const relPath = normalizeQuickOpenRgLine(translated, { kind: 'cwd-relative' })
         if (relPath === null) {
           return
         }
+        parseablePathCount++
         if (!shouldIncludeQuickOpenPath(relPath)) {
           return
         }
@@ -84,6 +93,7 @@ export async function listQuickOpenFiles(
         cwd: authorizedRootPath,
         stdio: ['ignore', 'pipe', 'pipe']
       })
+      children.push(child)
       child.stdout!.setEncoding('utf-8')
       child.stdout!.on('data', (chunk: string) => {
         buf += chunk
@@ -103,24 +113,57 @@ export async function listQuickOpenFiles(
         // Why: treat spawn errors like an abnormal exit — discard residual
         // buffer so a truncated final byte sequence cannot leak as a path.
         buf = ''
-        finish()
+        finish(new Error('rg failed to start'))
       })
-      child.once('close', () => {
+      child.once('close', (code, signal) => {
+        if (signal) {
+          // Why: a signal exit means timeout/OOM/external kill. Returning the
+          // already-streamed prefix would recreate the false-empty bug this
+          // path is meant to avoid.
+          buf = ''
+          finish(new Error(`rg killed by ${signal}`))
+          return
+        }
         if (buf) {
           processLine(buf)
         }
-        finish()
+        if (code === 0 || code === 1) {
+          finish()
+        } else if (code === 2 && parseablePathCount > 0) {
+          // rg can return 2 for unreadable subdirectories while still listing
+          // usable files from the rest of the root.
+          finish()
+        } else {
+          finish(new Error(`rg exited with code ${code}`))
+        }
       })
       const timer = setTimeout(() => {
         // Why: on timeout, the buffer is likely truncated mid-path. Discard
         // it so Quick Open never displays a malformed entry.
         buf = ''
         child.kill()
+        finish(new Error('rg list timed out'))
       }, 10000)
     })
   }
 
-  await Promise.all([runRg(primary), runRg(envPass)])
+  const killSurvivors = (): void => {
+    // Why: if one rg pass fails, Promise.all rejects immediately while the
+    // sibling scan can keep walking a huge tree until timeout. Stop it so
+    // repeated Quick Open attempts do not accumulate local rg processes.
+    for (const child of children) {
+      if (child.exitCode === null && child.signalCode === null) {
+        child.kill()
+      }
+    }
+  }
+
+  try {
+    await Promise.all([runRg(primary), runRg(envPass)])
+  } catch (err) {
+    killSurvivors()
+    throw err
+  }
   return Array.from(files)
 }
 

--- a/src/main/ipc/filesystem-list-files.ts
+++ b/src/main/ipc/filesystem-list-files.ts
@@ -1,49 +1,17 @@
-import { relative, sep } from 'path'
+import { sep } from 'path'
 import type { Store } from '../persistence'
 import { resolveAuthorizedPath } from './filesystem-auth'
 import { checkRgAvailable } from './rg-availability'
 import { gitSpawn, wslAwareSpawn } from '../git/runner'
 import { parseWslPath, toWindowsWslPath } from '../wsl'
-
-// Why: We use --hidden to surface dotfiles users commonly edit (e.g. .env,
-// .github workflows, .eslintrc) but must still exclude non-editable hidden
-// directories that would clutter quick-open results. A blocklist is used
-// instead of an allowlist so that novel dotfiles (e.g. .dockerignore) are
-// discoverable by default. Keep this list limited to tool-generated dirs
-// that are never hand-edited.
-const HIDDEN_DIR_BLOCKLIST = new Set([
-  '.git',
-  '.next',
-  '.nuxt',
-  '.cache',
-  '.stably',
-  '.vscode',
-  '.idea',
-  '.yarn',
-  '.pnpm-store',
-  '.terraform',
-  '.docker',
-  '.husky'
-])
-
-// Why: Avoids allocating a segments array per path. Walks the string to
-// extract each '/'-delimited segment and checks it against the blocklist.
-function shouldIncludeQuickOpenPath(path: string): boolean {
-  let start = 0
-  const len = path.length
-  while (start < len) {
-    let end = path.indexOf('/', start)
-    if (end === -1) {
-      end = len
-    }
-    const segment = path.substring(start, end)
-    if (segment === 'node_modules' || HIDDEN_DIR_BLOCKLIST.has(segment)) {
-      return false
-    }
-    start = end + 1
-  }
-  return true
-}
+import {
+  buildExcludePathPrefixes,
+  buildGitLsFilesArgsForQuickOpen,
+  buildRgArgsForQuickOpen,
+  normalizeQuickOpenRgLine,
+  shouldExcludeQuickOpenRelPath,
+  shouldIncludeQuickOpenPath
+} from '../../shared/quick-open-filter'
 
 export async function listQuickOpenFiles(
   rootPath: string,
@@ -54,19 +22,9 @@ export async function listQuickOpenFiles(
 
   // Why: when the main worktree sits at the repo root, linked worktrees are
   // nested subdirectories. Without excluding them, rg/git lists files from
-  // every worktree instead of just the active one.
-  const excludeGlobs: string[] = []
-  if (excludePaths?.length) {
-    const normalizedRoot = `${authorizedRootPath.replace(/[\\/]+$/, '')}/`
-    for (const abs of excludePaths) {
-      const rel = abs.startsWith(normalizedRoot)
-        ? abs.slice(normalizedRoot.length)
-        : relative(authorizedRootPath, abs).replace(/\\/g, '/')
-      if (rel && !rel.startsWith('..') && !rel.startsWith('/')) {
-        excludeGlobs.push(rel)
-      }
-    }
-  }
+  // every worktree instead of just the active one. The shared helper
+  // normalizes, validates, and root-relativizes every input.
+  const excludePathPrefixes = buildExcludePathPrefixes(authorizedRootPath, excludePaths)
 
   // Why: checking rg availability upfront avoids a race condition where
   // spawn('rg') emits 'close' before 'error' on some platforms, causing
@@ -74,17 +32,22 @@ export async function listQuickOpenFiles(
   // can run. The result is cached after the first check.
   const rgAvailable = await checkRgAvailable(authorizedRootPath)
   if (!rgAvailable) {
-    return listFilesWithGit(authorizedRootPath, excludeGlobs)
+    return listFilesWithGit(authorizedRootPath, excludePathPrefixes)
   }
 
-  // Why: We try fast string slicing first (O(1) per file), but fall back to
-  // path.relative() if the rg output doesn't start with the expected prefix.
-  // This handles edge cases where symlinks, bind mounts, Windows junctions,
-  // or custom ripgreprc --path-separator settings cause a mismatch.
-  const normalizedPrefix = `${authorizedRootPath.replace(/[\\/]+/g, '/').replace(/\/$/, '')}/`
-  const prefixLen = normalizedPrefix.length
-
   const files = new Set<string>()
+  // Why: when rg runs inside WSL, output paths are Linux-native
+  // (e.g. /home/user/repo/src/file.ts). Translate them back to Windows
+  // UNC paths up-front before the shared line normalizer runs.
+  const wslInfo = parseWslPath(authorizedRootPath)
+
+  const { primary, envPass } = buildRgArgsForQuickOpen({
+    searchRoot: authorizedRootPath,
+    excludePathPrefixes,
+    // On Windows, rg outputs '\\'-separated paths; force '/'. Also force on
+    // macOS/Linux for idempotence — it's a no-op there.
+    forceSlashSeparator: sep === '\\'
+  })
 
   const runRg = (args: string[]): Promise<void> => {
     return new Promise((resolve) => {
@@ -99,42 +62,22 @@ export async function listQuickOpenFiles(
         resolve()
       }
 
-      // Why: when rg runs inside WSL, output paths are Linux-native
-      // (e.g. /home/user/repo/src/file.ts). Detect this upfront so we
-      // can translate them back to Windows UNC paths for prefix matching.
-      const wslInfo = parseWslPath(authorizedRootPath)
-
-      const processLine = (line: string): void => {
-        if (line.charCodeAt(line.length - 1) === 13 /* \r */) {
-          line = line.substring(0, line.length - 1)
-        }
-        if (!line) {
+      const processLine = (rawLine: string): void => {
+        const translated = wslInfo ? toWindowsWslPath(rawLine, wslInfo.distro) : rawLine
+        const relPath = normalizeQuickOpenRgLine(translated, {
+          kind: 'absolute',
+          rootPath: authorizedRootPath
+        })
+        if (relPath === null) {
           return
         }
-
-        // Translate Linux paths from WSL rg output to Windows UNC paths
-        if (wslInfo) {
-          line = toWindowsWslPath(line, wslInfo.distro)
+        if (!shouldIncludeQuickOpenPath(relPath)) {
+          return
         }
-
-        // Why: Normalize separators to '/' so the prefix check works on all
-        // platforms (Windows rg uses '\', macOS/Linux use '/').
-        const normalized = line.replace(/\\/g, '/')
-        let relPath: string
-        if (normalized.startsWith(normalizedPrefix)) {
-          relPath = normalized.substring(prefixLen)
-        } else {
-          // Fallback: symlink resolution or path-separator mismatch between
-          // Node and rg — use path.relative() which handles all edge cases.
-          relPath = relative(authorizedRootPath, line).replace(/\\/g, '/')
-          if (relPath.startsWith('..') || relPath.startsWith('/')) {
-            // Safety: path escapes the root — skip it entirely
-            return
-          }
+        if (shouldExcludeQuickOpenRelPath(relPath, excludePathPrefixes)) {
+          return
         }
-        if (shouldIncludeQuickOpenPath(relPath)) {
-          files.add(relPath)
-        }
+        files.add(relPath)
       }
 
       const child = wslAwareSpawn('rg', args, {
@@ -151,13 +94,15 @@ export async function listQuickOpenFiles(
           start = newlineIdx + 1
           newlineIdx = buf.indexOf('\n', start)
         }
-        // Keep the incomplete trailing segment for the next chunk
         buf = start < buf.length ? buf.substring(start) : ''
       })
       child.stderr!.on('data', () => {
         /* drain */
       })
       child.once('error', () => {
+        // Why: treat spawn errors like an abnormal exit — discard residual
+        // buffer so a truncated final byte sequence cannot leak as a path.
+        buf = ''
         finish()
       })
       child.once('close', () => {
@@ -166,54 +111,16 @@ export async function listQuickOpenFiles(
         }
         finish()
       })
-      const timer = setTimeout(() => child.kill(), 10000)
+      const timer = setTimeout(() => {
+        // Why: on timeout, the buffer is likely truncated mid-path. Discard
+        // it so Quick Open never displays a malformed entry.
+        buf = ''
+        child.kill()
+      }, 10000)
     })
   }
 
-  // Why: --hidden is needed so users can quick-open dotfiles they commonly
-  // edit (.env, .github/*, .eslintrc, etc.). Without it, rg skips all
-  // dot-prefixed paths. The HIDDEN_DIR_BLOCKLIST in shouldIncludeQuickOpenPath
-  // filters out tool-generated dirs that would clutter results.
-  //
-  // The second rg call adds --no-ignore-vcs to also surface .env* files that
-  // are typically in .gitignore. These are included because users frequently
-  // need to view/edit .env files from quick-open, and excluding them would
-  // force users to navigate manually. The files are read-only in search
-  // results — they are not committed or exposed outside the local editor.
-
-  // Why: On Windows, rg outputs '\'-separated paths. Forcing '/' via
-  // --path-separator avoids per-line backslash replacement in processLine.
-  const rgSepArgs = sep === '\\' ? ['--path-separator', '/'] : []
-  const rgExcludeArgs = excludeGlobs.flatMap((g) => ['--glob', `!${g}/**`])
-
-  await Promise.all([
-    runRg([
-      '--files',
-      '--hidden',
-      ...rgSepArgs,
-      '--glob',
-      '!**/node_modules',
-      '--glob',
-      '!**/.git',
-      ...rgExcludeArgs,
-      authorizedRootPath
-    ]),
-    runRg([
-      '--files',
-      '--hidden',
-      '--no-ignore-vcs',
-      ...rgSepArgs,
-      '--glob',
-      '**/.env*',
-      '--glob',
-      '!**/node_modules',
-      '--glob',
-      '!**/.git',
-      ...rgExcludeArgs,
-      authorizedRootPath
-    ])
-  ])
-
+  await Promise.all([runRg(primary), runRg(envPass)])
   return Array.from(files)
 }
 
@@ -221,13 +128,16 @@ export async function listQuickOpenFiles(
  * Fallback file lister using git ls-files. Used when rg is not available.
  *
  * Why two git ls-files calls: the first lists tracked + untracked-but-not-ignored
- * files (mirrors rg --files --hidden with gitignore respect). The second specifically
- * surfaces .env* files that are typically gitignored but users frequently need in
- * quick-open (mirrors the second rg call with --no-ignore-vcs).
+ * files (mirrors rg --files --hidden with gitignore respect). The second
+ * surfaces .env* files that are typically gitignored but users frequently
+ * need in quick-open (mirrors the second rg call with --no-ignore-vcs).
  */
-function listFilesWithGit(rootPath: string, excludeGlobs: string[] = []): Promise<string[]> {
+function listFilesWithGit(
+  rootPath: string,
+  excludePathPrefixes: readonly string[]
+): Promise<string[]> {
   const files = new Set<string>()
-  const excludePrefixes = excludeGlobs.map((g) => `${g.replace(/\\/g, '/')}/`)
+  const { primary, envPass } = buildGitLsFilesArgsForQuickOpen(excludePathPrefixes)
 
   const runGitLsFiles = (args: string[]): Promise<void> => {
     return new Promise((resolve) => {
@@ -249,7 +159,10 @@ function listFilesWithGit(rootPath: string, excludeGlobs: string[] = []): Promis
         if (!line) {
           return
         }
-        if (excludePrefixes.some((p) => line.startsWith(p))) {
+        // Why: git exclude pathspecs prune most hits, but post-filter is
+        // still required because pathspec semantics differ subtly from the
+        // rg globs and exist as a correctness backstop.
+        if (shouldExcludeQuickOpenRelPath(line, excludePathPrefixes)) {
           return
         }
         if (shouldIncludeQuickOpenPath(line)) {
@@ -279,6 +192,7 @@ function listFilesWithGit(rootPath: string, excludeGlobs: string[] = []): Promis
         /* drain */
       })
       child.once('error', () => {
+        buf = ''
         finish()
       })
       child.once('close', () => {
@@ -287,18 +201,12 @@ function listFilesWithGit(rootPath: string, excludeGlobs: string[] = []): Promis
         }
         finish()
       })
-      const timer = setTimeout(() => child.kill(), 10000)
+      const timer = setTimeout(() => {
+        buf = ''
+        child.kill()
+      }, 10000)
     })
   }
 
-  return Promise.all([
-    // Why: --cached lists tracked files, --others lists untracked files,
-    // --exclude-standard respects .gitignore. Together this mirrors
-    // rg --files --hidden (which respects gitignore by default).
-    runGitLsFiles(['--cached', '--others', '--exclude-standard']),
-    // Why: surfaces .env* files that are typically gitignored. --others
-    // without --exclude-standard lists all untracked files; the pathspec
-    // restricts output to .env* only. Mirrors the rg --no-ignore-vcs call.
-    runGitLsFiles(['--others', '--', '**/.env*'])
-  ]).then(() => Array.from(files))
+  return Promise.all([runGitLsFiles(primary), runGitLsFiles(envPass)]).then(() => Array.from(files))
 }

--- a/src/main/ipc/filesystem.test.ts
+++ b/src/main/ipc/filesystem.test.ts
@@ -21,7 +21,8 @@ const {
   unstageFileMock,
   bulkUnstageFilesMock,
   discardChangesMock,
-  listWorktreesMock
+  listWorktreesMock,
+  getSshFilesystemProviderMock
 } = vi.hoisted(() => ({
   handleMock: vi.fn(),
   trashItemMock: vi.fn(),
@@ -40,7 +41,8 @@ const {
   unstageFileMock: vi.fn(),
   bulkUnstageFilesMock: vi.fn(),
   discardChangesMock: vi.fn(),
-  listWorktreesMock: vi.fn()
+  listWorktreesMock: vi.fn(),
+  getSshFilesystemProviderMock: vi.fn()
 }))
 
 vi.mock('electron', () => ({
@@ -75,6 +77,14 @@ vi.mock('../git/status', () => ({
 
 vi.mock('../git/worktree', () => ({
   listWorktrees: listWorktreesMock
+}))
+
+vi.mock('../providers/ssh-filesystem-dispatch', () => ({
+  getSshFilesystemProvider: getSshFilesystemProviderMock
+}))
+
+vi.mock('../providers/ssh-git-dispatch', () => ({
+  getSshGitProvider: vi.fn().mockReturnValue(null)
 }))
 
 import { registerFilesystemHandlers } from './filesystem'
@@ -122,7 +132,8 @@ describe('registerFilesystemHandlers', () => {
       unstageFileMock,
       bulkUnstageFilesMock,
       discardChangesMock,
-      listWorktreesMock
+      listWorktreesMock,
+      getSshFilesystemProviderMock
     ]) {
       mock.mockReset()
     }
@@ -467,6 +478,28 @@ describe('registerFilesystemHandlers', () => {
       mergeBase: 'merge-base-oid',
       filePath: path.join('src', 'file.ts'),
       oldPath: path.join('src', 'old-file.ts')
+    })
+  })
+
+  // Why: the original SSH Quick Open bug had two halves — relay-side policy
+  // drift AND the main dispatcher silently dropping excludePaths before the
+  // provider saw them. This test guards the second half: regardless of
+  // relay behavior, a new linked worktree under the root must be forwarded
+  // so the remote scan can prune it. See docs/design/share-quick-open-file-listing.md.
+  it('fs:listFiles forwards excludePaths to the SSH filesystem provider', async () => {
+    const listFilesMock = vi.fn().mockResolvedValue([])
+    getSshFilesystemProviderMock.mockReturnValue({ listFiles: listFilesMock })
+
+    registerFilesystemHandlers(store as never)
+
+    await handlers.get('fs:listFiles')!(null, {
+      rootPath: '/home/user/repo',
+      connectionId: 'conn-1',
+      excludePaths: ['/home/user/repo/worktrees/feature']
+    })
+
+    expect(listFilesMock).toHaveBeenCalledWith('/home/user/repo', {
+      excludePaths: ['/home/user/repo/worktrees/feature']
     })
   })
 })

--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -456,7 +456,10 @@ export function registerFilesystemHandlers(store: Store): void {
         if (!provider) {
           return []
         }
-        return provider.listFiles(args.rootPath)
+        // Why: forward excludePaths through to the remote provider.
+        // Dropping it here would silently double-scan nested linked worktrees
+        // over SSH and contribute to timeout-induced partial results.
+        return provider.listFiles(args.rootPath, { excludePaths: args.excludePaths })
       }
       return listQuickOpenFiles(args.rootPath, store, args.excludePaths)
     }

--- a/src/main/ipc/rg-availability.ts
+++ b/src/main/ipc/rg-availability.ts
@@ -1,32 +1,20 @@
 import { wslAwareSpawn } from '../git/runner'
-import { parseWslPath } from '../wsl'
 
-// Why: when rg is not installed, spawn('rg', ...) emits both 'error' and
-// 'close' events but their ordering is non-deterministic across Node versions
-// and platforms. If 'close' fires first the handler resolves with empty
-// results before the 'error' handler can trigger the git-grep fallback.
-// Checking rg availability once upfront (cached) avoids the race entirely.
-
-// Why: separate caches for native Windows and each WSL distro — rg may be
-// installed in one environment but not the other, and different distros
-// may have different packages installed.
-let rgNativeCache: boolean | null = null
-const rgWslCache = new Map<string, boolean>()
+// Why the `settled` flag: when rg is not installed, spawn emits both 'error'
+// and 'close' with non-deterministic ordering across Node versions/platforms.
+// Without guarding, a late 'error' after 'close' would double-resolve (or a
+// late 'close' after 'error' would resolve true after we already resolved
+// false). `settled` makes whichever fires first authoritative.
+//
+// Why no cache: `rg --version` is a sub-10ms spawn, so the cost of checking
+// per call is negligible. Caching had a footgun in both directions — a
+// negative cache persisted across rg installs (forcing an app restart),
+// while a positive cache could mask an rg that was uninstalled or broken
+// mid-session.
 
 export function checkRgAvailable(searchPath?: string): Promise<boolean> {
-  const wslInfo = searchPath ? parseWslPath(searchPath) : null
-  const distro = wslInfo?.distro
-
-  if (distro) {
-    const cached = rgWslCache.get(distro)
-    if (cached !== undefined) {
-      return Promise.resolve(cached)
-    }
-  } else if (rgNativeCache !== null) {
-    return Promise.resolve(rgNativeCache)
-  }
-
   return new Promise((resolve) => {
+    let settled = false
     // Why: pass cwd so wslAwareSpawn routes through wsl.exe when the search
     // path is inside a WSL filesystem. This checks whether rg is available
     // inside the WSL distro rather than on the Windows PATH.
@@ -35,26 +23,18 @@ export function checkRgAvailable(searchPath?: string): Promise<boolean> {
       stdio: 'ignore'
     })
     child.once('error', () => {
-      if (distro) {
-        rgWslCache.set(distro, false)
-      } else {
-        rgNativeCache = false
+      if (settled) {
+        return
       }
+      settled = true
       resolve(false)
     })
     child.once('close', (code) => {
-      const alreadyCached = distro ? rgWslCache.has(distro) : rgNativeCache !== null
-      if (alreadyCached) {
-        // error handler already resolved
+      if (settled) {
         return
       }
-      const available = code === 0
-      if (distro) {
-        rgWslCache.set(distro, available)
-      } else {
-        rgNativeCache = available
-      }
-      resolve(available)
+      settled = true
+      resolve(code === 0)
     })
   })
 }

--- a/src/main/providers/ssh-filesystem-provider.test.ts
+++ b/src/main/providers/ssh-filesystem-provider.test.ts
@@ -136,6 +136,23 @@ describe('SshFilesystemProvider', () => {
     expect(result).toEqual(['src/index.ts', 'package.json'])
   })
 
+  it('listFiles forwards excludePaths when provided', async () => {
+    mux.request.mockResolvedValue([])
+    await provider.listFiles('/home/user/project', {
+      excludePaths: ['/home/user/project/worktrees/b']
+    })
+    expect(mux.request).toHaveBeenCalledWith('fs.listFiles', {
+      rootPath: '/home/user/project',
+      excludePaths: ['/home/user/project/worktrees/b']
+    })
+  })
+
+  it('listFiles omits excludePaths when empty', async () => {
+    mux.request.mockResolvedValue([])
+    await provider.listFiles('/home/user/project', { excludePaths: [] })
+    expect(mux.request).toHaveBeenCalledWith('fs.listFiles', { rootPath: '/home/user/project' })
+  })
+
   describe('watch', () => {
     it('sends fs.watch request and returns unsubscribe', async () => {
       const callback = vi.fn()

--- a/src/main/providers/ssh-filesystem-provider.ts
+++ b/src/main/providers/ssh-filesystem-provider.ts
@@ -87,8 +87,15 @@ export class SshFilesystemProvider implements IFilesystemProvider {
     return (await this.mux.request('fs.search', opts)) as SearchResult
   }
 
-  async listFiles(rootPath: string): Promise<string[]> {
-    return (await this.mux.request('fs.listFiles', { rootPath })) as string[]
+  async listFiles(rootPath: string, options?: { excludePaths?: string[] }): Promise<string[]> {
+    // Why: older relays ignore unknown fields, so sending excludePaths to a
+    // pre-refactor relay is a non-regression. The relay validates the shape
+    // and treats malformed input as "no exclusions" rather than failing.
+    const params: Record<string, unknown> = { rootPath }
+    if (options?.excludePaths && options.excludePaths.length > 0) {
+      params.excludePaths = options.excludePaths
+    }
+    return (await this.mux.request('fs.listFiles', params)) as string[]
   }
 
   async watch(rootPath: string, callback: (events: FsChangeEvent[]) => void): Promise<() => void> {

--- a/src/main/providers/types.ts
+++ b/src/main/providers/types.ts
@@ -107,7 +107,7 @@ export type IFilesystemProvider = {
   copy(source: string, destination: string): Promise<void>
   realpath(filePath: string): Promise<string>
   search(opts: SearchOptions): Promise<SearchResult>
-  listFiles(rootPath: string): Promise<string[]>
+  listFiles(rootPath: string, options?: { excludePaths?: string[] }): Promise<string[]>
   watch(rootPath: string, callback: (events: FsChangeEvent[]) => void): Promise<() => void>
 }
 

--- a/src/relay/fs-handler-git-fallback.ts
+++ b/src/relay/fs-handler-git-fallback.ts
@@ -9,40 +9,11 @@
 import { join } from 'path'
 import { spawn } from 'child_process'
 import { SEARCH_TIMEOUT_MS, type SearchOptions, type SearchResult } from './fs-handler-utils'
-
-// Why: mirrors the local HIDDEN_DIR_BLOCKLIST — tool-generated dirs that
-// clutter quick-open results but should never appear in file listings.
-const HIDDEN_DIR_BLOCKLIST = new Set([
-  '.git',
-  '.next',
-  '.nuxt',
-  '.cache',
-  '.stably',
-  '.vscode',
-  '.idea',
-  '.yarn',
-  '.pnpm-store',
-  '.terraform',
-  '.docker',
-  '.husky'
-])
-
-function shouldIncludePath(path: string): boolean {
-  let start = 0
-  const len = path.length
-  while (start < len) {
-    let end = path.indexOf('/', start)
-    if (end === -1) {
-      end = len
-    }
-    const segment = path.substring(start, end)
-    if (segment === 'node_modules' || HIDDEN_DIR_BLOCKLIST.has(segment)) {
-      return false
-    }
-    start = end + 1
-  }
-  return true
-}
+import {
+  buildGitLsFilesArgsForQuickOpen,
+  shouldExcludeQuickOpenRelPath,
+  shouldIncludeQuickOpenPath
+} from '../shared/quick-open-filter'
 
 const REGEX_SPECIAL = '.*+?^${}()|[]\\'
 function escapeRegexSource(str: string): string {
@@ -61,22 +32,24 @@ function toGitGlobPathspec(glob: string, exclude?: boolean): string {
 
 /**
  * List files using `git ls-files`. Fallback when rg is not installed.
+ *
+ * Why both passes: primary surfaces tracked + untracked-non-ignored;
+ * envPass surfaces gitignored .env* files that users frequently Quick Open.
+ * Exclude pathspecs are prepended by the shared builder so nested linked
+ * worktrees are pruned by git directly; post-filtering remains as a
+ * correctness backstop.
  */
-export function listFilesWithGit(rootPath: string): Promise<string[]> {
+export function listFilesWithGit(
+  rootPath: string,
+  excludePathPrefixes: readonly string[] = []
+): Promise<string[]> {
   const files = new Set<string>()
+  const { primary, envPass } = buildGitLsFilesArgsForQuickOpen(excludePathPrefixes)
 
   const runGitLsFiles = (args: string[]): Promise<void> => {
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
       let buf = ''
       let done = false
-      const finish = (): void => {
-        if (done) {
-          return
-        }
-        done = true
-        clearTimeout(timer)
-        resolve()
-      }
 
       const processLine = (line: string): void => {
         if (line.charCodeAt(line.length - 1) === 13) {
@@ -85,7 +58,10 @@ export function listFilesWithGit(rootPath: string): Promise<string[]> {
         if (!line) {
           return
         }
-        if (shouldIncludePath(line)) {
+        if (shouldExcludeQuickOpenRelPath(line, excludePathPrefixes)) {
+          return
+        }
+        if (shouldIncludeQuickOpenPath(line)) {
           files.add(line)
         }
       }
@@ -109,21 +85,42 @@ export function listFilesWithGit(rootPath: string): Promise<string[]> {
       child.stderr!.on('data', () => {
         /* drain */
       })
-      child.once('error', () => finish())
-      child.once('close', () => {
+      child.once('error', (err) => {
+        if (done) {
+          return
+        }
+        done = true
+        clearTimeout(timer)
+        buf = ''
+        reject(err)
+      })
+      child.once('close', (_code, signal) => {
+        if (done) {
+          return
+        }
+        done = true
+        clearTimeout(timer)
+        if (signal) {
+          // Why: a signal exit means the child was killed (timeout or
+          // external). Treat that as a load failure rather than silently
+          // resolving with whatever git had managed to print.
+          buf = ''
+          reject(new Error(`git ls-files killed by ${signal}`))
+          return
+        }
         if (buf) {
           processLine(buf)
         }
-        finish()
+        resolve()
       })
-      const timer = setTimeout(() => child.kill(), 10_000)
+      const timer = setTimeout(() => {
+        buf = ''
+        child.kill()
+      }, 10_000)
     })
   }
 
-  return Promise.all([
-    runGitLsFiles(['--cached', '--others', '--exclude-standard']),
-    runGitLsFiles(['--others', '--', '**/.env*'])
-  ]).then(() => Array.from(files))
+  return Promise.all([runGitLsFiles(primary), runGitLsFiles(envPass)]).then(() => Array.from(files))
 }
 
 type FileResult = {

--- a/src/relay/fs-handler-install-rg.ts
+++ b/src/relay/fs-handler-install-rg.ts
@@ -1,0 +1,42 @@
+import { readFile } from 'fs/promises'
+
+export async function detectInstallCommand(): Promise<string> {
+  if (process.platform === 'darwin') {
+    return 'brew install ripgrep'
+  }
+  if (process.platform === 'linux') {
+    try {
+      const osRelease = await readFile('/etc/os-release', 'utf-8')
+      const idMatch = osRelease.match(/^ID=(?:"?)([^"\n]+)(?:"?)$/m)
+      const idLikeMatch = osRelease.match(/^ID_LIKE=(?:"?)([^"\n]+)(?:"?)$/m)
+      const ids = [idMatch?.[1], ...(idLikeMatch?.[1]?.split(/\s+/) ?? [])].filter(Boolean)
+      for (const id of ids) {
+        if (id === 'debian' || id === 'ubuntu') {
+          return 'sudo apt install ripgrep'
+        }
+        if (id === 'fedora' || id === 'rhel' || id === 'centos') {
+          return 'sudo dnf install ripgrep'
+        }
+        if (id === 'arch') {
+          return 'sudo pacman -S ripgrep'
+        }
+        if (id === 'alpine') {
+          return 'sudo apk add ripgrep'
+        }
+      }
+    } catch {
+      /* fall through to generic guidance */
+    }
+    return 'install ripgrep via your package manager (e.g. apt/dnf/pacman)'
+  }
+  return 'install ripgrep (https://github.com/BurntSushi/ripgrep#installation)'
+}
+
+export async function buildInstallRgMessage(cause: unknown): Promise<string> {
+  const reason = cause instanceof Error ? cause.message : String(cause)
+  const cmd = await detectInstallCommand()
+  return (
+    `Quick Open scan too large (${reason}). ` +
+    `Install ripgrep on the remote to enable fast, gitignore-aware listing: ${cmd}`
+  )
+}

--- a/src/relay/fs-handler-list-files.ts
+++ b/src/relay/fs-handler-list-files.ts
@@ -1,0 +1,98 @@
+/**
+ * Ripgrep-based file listing for Quick Open.
+ * Extracted from fs-handler-utils.ts to keep it under 300 lines (oxlint max-lines).
+ */
+import { spawn } from 'child_process'
+import { buildRgArgsForQuickOpen, normalizeQuickOpenRgLine } from '../shared/quick-open-filter'
+
+export const LIST_FILES_TIMEOUT_MS = 25_000
+
+export function listFilesWithRg(
+  rootPath: string,
+  excludePathPrefixes: readonly string[] = []
+): Promise<string[]> {
+  return new Promise((resolve, reject) => {
+    const files = new Set<string>()
+    let done = false
+
+    const { primary, envPass } = buildRgArgsForQuickOpen({
+      searchRoot: rootPath,
+      excludePathPrefixes,
+      forceSlashSeparator: true
+    })
+
+    const runPass = (args: string[], name: string) =>
+      new Promise<void>((passResolve, passReject) => {
+        const child = spawn('rg', args, {
+          cwd: rootPath,
+          stdio: ['ignore', 'pipe', 'pipe']
+        })
+
+        let passBuf = ''
+        const processLine = (line: string) => {
+          const normalized = normalizeQuickOpenRgLine(line, {
+            type: 'absolute',
+            rootPath
+          })
+          if (normalized) {
+            files.add(normalized)
+          }
+        }
+
+        child.stdout.on('data', (chunk: Buffer) => {
+          passBuf += chunk.toString('utf-8')
+          const lines = passBuf.split('\n')
+          passBuf = lines.pop() || ''
+          for (const line of lines) {
+            processLine(line)
+          }
+        })
+
+        const timer = setTimeout(() => {
+          child.kill('SIGTERM')
+          passReject(new Error(`${name} pass timed out after ${LIST_FILES_TIMEOUT_MS}ms`))
+        }, LIST_FILES_TIMEOUT_MS)
+
+        child.on('error', (err) => {
+          clearTimeout(timer)
+          passReject(err)
+        })
+
+        child.once('close', (code, signal) => {
+          clearTimeout(timer)
+          if (done) {
+            return
+          }
+          if (signal) {
+            passBuf = ''
+            passReject(new Error(`rg killed by ${signal}`))
+            return
+          }
+          if (passBuf) {
+            processLine(passBuf)
+          }
+          if (code === 0 || code === 1 || code === 2) {
+            passResolve()
+          } else {
+            passReject(new Error(`rg exited with code ${code}`))
+          }
+        })
+      })
+
+    Promise.all([runPass(primary, 'primary'), runPass(envPass, 'envPass')])
+      .then(() => {
+        if (done) {
+          return
+        }
+        done = true
+        resolve(Array.from(files))
+      })
+      .catch((err) => {
+        if (done) {
+          return
+        }
+        done = true
+        reject(err instanceof Error ? err : new Error(String(err)))
+      })
+  })
+}

--- a/src/relay/fs-handler-list-files.ts
+++ b/src/relay/fs-handler-list-files.ts
@@ -1,9 +1,27 @@
 /**
  * Ripgrep-based file listing for Quick Open.
  * Extracted from fs-handler-utils.ts to keep it under 300 lines (oxlint max-lines).
+ *
+ * Why a full rewrite vs. the older execFile+maxBuffer version: on a home-dir
+ * worktree over SSH, rg descended into every dotfile cache, hit the timeout,
+ * and silently resolved with a partial list — Quick Open then showed "No
+ * matching files" even though the file existed on disk. This implementation:
+ *   - streams via spawn (no maxBuffer failure mode)
+ *   - prunes traversal at rg level using the shared blocklist globs
+ *   - runs a second --no-ignore-vcs pass for .env* files
+ *   - honors excludePathPrefixes for nested linked worktrees
+ *   - rejects (not resolves) on timeout / spawn error / signal exit so
+ *     the UI shows a load error instead of a false-empty list
+ *   - treats rg exit code 2 with parseable stdout as success (permission
+ *     denied on a single subdir is expected on home-dir roots)
  */
-import { spawn } from 'child_process'
-import { buildRgArgsForQuickOpen, normalizeQuickOpenRgLine } from '../shared/quick-open-filter'
+import { spawn, type ChildProcess } from 'child_process'
+import {
+  buildRgArgsForQuickOpen,
+  normalizeQuickOpenRgLine,
+  shouldExcludeQuickOpenRelPath,
+  shouldIncludeQuickOpenPath
+} from '../shared/quick-open-filter'
 
 export const LIST_FILES_TIMEOUT_MS = 25_000
 
@@ -14,64 +32,117 @@ export function listFilesWithRg(
   return new Promise((resolve, reject) => {
     const files = new Set<string>()
     let done = false
+    const children: ChildProcess[] = []
 
     const { primary, envPass } = buildRgArgsForQuickOpen({
-      searchRoot: rootPath,
+      // Why: rg only applies root-relative exclude globs as traversal pruning
+      // when the search target is relative to cwd. Absolute targets still
+      // emit root-relative-looking paths for filters, but they do not prune.
+      searchRoot: '.',
       excludePathPrefixes,
       forceSlashSeparator: true
     })
 
-    const runPass = (args: string[], name: string) =>
-      new Promise<void>((passResolve, passReject) => {
-        const child = spawn('rg', args, {
+    const processLine = (rawLine: string): boolean => {
+      const relPath = normalizeQuickOpenRgLine(rawLine, { kind: 'cwd-relative' })
+      if (relPath === null) {
+        return false
+      }
+      // Why: correctness backstop. The rg globs prune most blocklisted dirs,
+      // but a glob edge case could still surface e.g. a .git/ or .npm/ hit.
+      if (!shouldIncludeQuickOpenPath(relPath)) {
+        return true
+      }
+      if (shouldExcludeQuickOpenRelPath(relPath, excludePathPrefixes)) {
+        return true
+      }
+      files.add(relPath)
+      return true
+    }
+
+    const runPass = (args: string[]): Promise<void> =>
+      new Promise((passResolve, passReject) => {
+        let passBuf = ''
+        let passDone = false
+        let passFileCount = 0
+        // --no-messages: permission-denied noise on the remote (e.g. .ssh,
+        // root-owned mounts) would otherwise flood stderr.
+        // cwd: rootPath — root-relative exclude globs like `!packages/app/**`
+        // are evaluated against rg's working directory, not the absolute
+        // search target. Without cwd, nested-worktree exclusions silently
+        // stop working.
+        const child = spawn('rg', ['--no-messages', ...args], {
           cwd: rootPath,
           stdio: ['ignore', 'pipe', 'pipe']
         })
-
-        let passBuf = ''
-        const processLine = (line: string) => {
-          const normalized = normalizeQuickOpenRgLine(line, {
-            type: 'absolute',
-            rootPath
-          })
-          if (normalized) {
-            files.add(normalized)
-          }
-        }
-
-        child.stdout.on('data', (chunk: Buffer) => {
-          passBuf += chunk.toString('utf-8')
-          const lines = passBuf.split('\n')
-          passBuf = lines.pop() || ''
-          for (const line of lines) {
-            processLine(line)
-          }
-        })
+        children.push(child)
 
         const timer = setTimeout(() => {
-          child.kill('SIGTERM')
-          passReject(new Error(`${name} pass timed out after ${LIST_FILES_TIMEOUT_MS}ms`))
-        }, LIST_FILES_TIMEOUT_MS)
-
-        child.on('error', (err) => {
-          clearTimeout(timer)
-          passReject(err)
-        })
-
-        child.once('close', (code, signal) => {
-          clearTimeout(timer)
-          if (done) {
+          if (passDone) {
             return
           }
+          passDone = true
+          // Discard residual buffer on abnormal exit — a truncated byte
+          // sequence could look like a valid path.
+          passBuf = ''
+          child.kill()
+          passReject(new Error('rg list timed out'))
+        }, LIST_FILES_TIMEOUT_MS)
+
+        child.stdout!.setEncoding('utf-8')
+        child.stdout!.on('data', (chunk: string) => {
+          passBuf += chunk
+          let start = 0
+          let idx = passBuf.indexOf('\n', start)
+          while (idx !== -1) {
+            if (processLine(passBuf.substring(start, idx))) {
+              passFileCount++
+            }
+            start = idx + 1
+            idx = passBuf.indexOf('\n', start)
+          }
+          passBuf = start < passBuf.length ? passBuf.substring(start) : ''
+        })
+        child.stderr!.on('data', () => {
+          /* drain to prevent backpressure stalls */
+        })
+        child.once('error', (err) => {
+          if (passDone) {
+            return
+          }
+          passDone = true
+          clearTimeout(timer)
+          passBuf = ''
+          passReject(err)
+        })
+        child.once('close', (code, signal) => {
+          if (passDone) {
+            return
+          }
+          passDone = true
+          clearTimeout(timer)
+          // Why signal != null is a failure: the only way spawn gets a signal
+          // is if the process was killed (timeout, OOM, external SIGKILL).
+          // Trusting its stdout could surface a truncated list as a success.
           if (signal) {
             passBuf = ''
             passReject(new Error(`rg killed by ${signal}`))
             return
           }
+          // Flush residual line only on clean exit.
           if (passBuf) {
-            processLine(passBuf)
+            if (processLine(passBuf)) {
+              passFileCount++
+            }
           }
-          if (code === 0 || code === 1 || code === 2) {
+          // exit 0 = matches found, 1 = no files (still success for --files).
+          // exit 2 is documented as "a subdirectory could not be searched"
+          // (e.g. EACCES on .ssh), but rg also returns 2 for fatal errors
+          // (bad flag, invalid glob). Only trust exit 2 when rg emitted at
+          // least one parseable path — otherwise treat it as a real failure.
+          if (code === 0 || code === 1) {
+            passResolve()
+          } else if (code === 2 && passFileCount > 0) {
             passResolve()
           } else {
             passReject(new Error(`rg exited with code ${code}`))
@@ -79,7 +150,19 @@ export function listFilesWithRg(
         })
       })
 
-    Promise.all([runPass(primary, 'primary'), runPass(envPass, 'envPass')])
+    const killSurvivors = (): void => {
+      // Why: when one pass rejects, Promise.all surfaces the error immediately
+      // but the sibling rg keeps running up to LIST_FILES_TIMEOUT_MS. Kill it
+      // so repeated Quick Open opens don't pile up orphan rg processes on the
+      // remote.
+      for (const child of children) {
+        if (child.exitCode === null && child.signalCode === null) {
+          child.kill()
+        }
+      }
+    }
+
+    Promise.all([runPass(primary), runPass(envPass)])
       .then(() => {
         if (done) {
           return
@@ -92,6 +175,7 @@ export function listFilesWithRg(
           return
         }
         done = true
+        killSurvivors()
         reject(err instanceof Error ? err : new Error(String(err)))
       })
   })

--- a/src/relay/fs-handler-readdir-fallback.ts
+++ b/src/relay/fs-handler-readdir-fallback.ts
@@ -3,32 +3,20 @@
  *
  * Why: when neither ripgrep nor git is available (e.g. a non-git folder on a
  * remote machine without rg), we still need to list files for quick-open.
- * This walks the directory tree using Node's fs.readdir, respecting the same
- * blocklist and timeout constraints as the git-based fallback.
+ * This walks the directory tree using Node's fs.readdir, applying the shared
+ * Quick Open filter policy (blocklist + nested-worktree excludes).
+ *
+ * Partial results: the cap and deadline remain as containment, but a capped
+ * or timed-out traversal now rejects instead of returning a partial list —
+ * otherwise Quick Open would display "No matching files" for what was
+ * actually an incomplete scan.
  */
 import { readdir } from 'fs/promises'
 import { join, relative } from 'path'
+import { HIDDEN_DIR_BLOCKLIST, shouldExcludeQuickOpenRelPath } from '../shared/quick-open-filter'
 
 const MAX_FILES = 10_000
 const TIMEOUT_MS = 10_000
-
-// Why: mirrors the HIDDEN_DIR_BLOCKLIST in fs-handler-git-fallback.ts —
-// tool-generated dirs that clutter quick-open. User-authored dotdirs like
-// .github/ and .devcontainer/ are intentionally kept discoverable.
-const HIDDEN_DIR_BLOCKLIST = new Set([
-  '.git',
-  '.next',
-  '.nuxt',
-  '.cache',
-  '.stably',
-  '.vscode',
-  '.idea',
-  '.yarn',
-  '.pnpm-store',
-  '.terraform',
-  '.docker',
-  '.husky'
-])
 
 function shouldDescend(name: string): boolean {
   if (name === 'node_modules' || HIDDEN_DIR_BLOCKLIST.has(name)) {
@@ -39,14 +27,23 @@ function shouldDescend(name: string): boolean {
 
 /**
  * Recursively list files under `rootPath` using fs.readdir.
- * Returns relative POSIX paths, capped at MAX_FILES with a timeout.
+ * Returns relative POSIX paths. Rejects on cap/deadline so the UI cannot
+ * mistake a partial list for a complete empty result.
  */
-export async function listFilesWithReaddir(rootPath: string): Promise<string[]> {
+export async function listFilesWithReaddir(
+  rootPath: string,
+  excludePathPrefixes: readonly string[] = []
+): Promise<string[]> {
   const files: string[] = []
   const deadline = Date.now() + TIMEOUT_MS
+  let hitLimit = false
 
   async function walk(dir: string): Promise<void> {
+    if (hitLimit) {
+      return
+    }
     if (files.length >= MAX_FILES || Date.now() > deadline) {
+      hitLimit = true
       return
     }
 
@@ -54,29 +51,43 @@ export async function listFilesWithReaddir(rootPath: string): Promise<string[]> 
     try {
       entries = await readdir(dir, { withFileTypes: true })
     } catch {
-      // Permission denied, symlink loop, etc. — skip silently.
+      // Why: permission denied / symlink loop on an individual subtree is
+      // expected on home-dir roots (e.g. root-owned mounts). Skip the
+      // subtree silently — this does NOT promote to a full-listing failure.
       return
     }
 
     for (const entry of entries) {
       if (files.length >= MAX_FILES || Date.now() > deadline) {
+        hitLimit = true
         return
       }
 
       const name = entry.name
+      const absPath = join(dir, name)
+      // Why: path.relative returns backslashes on Windows. Quick-open UI
+      // assumes POSIX separators for display and fuzzy matching.
+      const relPath = relative(rootPath, absPath).replace(/\\/g, '/')
+      if (shouldExcludeQuickOpenRelPath(relPath, excludePathPrefixes)) {
+        continue
+      }
       if (entry.isDirectory()) {
         if (shouldDescend(name)) {
-          await walk(join(dir, name))
+          await walk(absPath)
         }
       } else if (entry.isFile()) {
-        // Why: path.relative() returns backslashes on Windows. The quick-open
-        // UI assumes POSIX separators for display and fuzzy matching.
-        const relPath = relative(rootPath, join(dir, name)).replace(/\\/g, '/')
         files.push(relPath)
       }
     }
   }
 
   await walk(rootPath)
+  if (hitLimit) {
+    throw new Error(
+      files.length >= MAX_FILES
+        ? `File listing exceeded ${MAX_FILES} files`
+        : 'File listing timed out'
+    )
+  }
   return files
 }

--- a/src/relay/fs-handler-utils.ts
+++ b/src/relay/fs-handler-utils.ts
@@ -232,24 +232,29 @@ export function searchWithRg(
 
 // ─── rg availability check ──────────────────────────────────────────
 
-let rgAvailableCache: boolean | null = null
-
+// Why no cache: `rg --version` is a sub-10ms local spawn, and caching the
+// result caused a footgun — a negative cache persisted across rg installs
+// (forcing a relay restart), while a positive cache could mask an rg that
+// was uninstalled or broken mid-session. The `settled` flag below closes
+// the original race between 'error' and 'close' that the cache was added
+// to paper over, so re-checking per call is both simpler and safer.
 export function checkRgAvailable(): Promise<boolean> {
-  if (rgAvailableCache !== null) {
-    return Promise.resolve(rgAvailableCache)
-  }
   return new Promise((resolve) => {
+    let settled = false
     const child = execFile('rg', ['--version'])
     child.once('error', () => {
-      rgAvailableCache = false
+      if (settled) {
+        return
+      }
+      settled = true
       resolve(false)
     })
     child.once('close', (code) => {
-      if (rgAvailableCache !== null) {
+      if (settled) {
         return
       }
-      rgAvailableCache = code === 0
-      resolve(rgAvailableCache)
+      settled = true
+      resolve(code === 0)
     })
   })
 }

--- a/src/relay/fs-handler-utils.ts
+++ b/src/relay/fs-handler-utils.ts
@@ -11,19 +11,7 @@ import { execFile, type ChildProcess } from 'child_process'
 // ─── Constants ───────────────────────────────────────────────────────
 
 export const MAX_FILE_SIZE = 5 * 1024 * 1024
-// Why: previewable binaries (PDFs, images) are rendered by the viewer as
-// base64 blobs, not parsed as text — 5MB is tight for real-world PDFs, and
-// raising this cap only affects binary preview, not text/search paths.
-// Why 10MB (not 50MB like the local main-process cap): the SSH relay ships
-// every JSON-RPC response in a single framed message capped at
-// MAX_MESSAGE_SIZE = 16MB (see src/relay/protocol.ts and
-// src/main/ssh/relay-protocol.ts). A file here is sent as base64 inside JSON,
-// so 10MB on disk → ~13.3MB base64 → ~13.4MB framed payload, leaving headroom
-// under the 16MB frame cap. Raising this cap without first landing streaming
-// reads would cause the encoder to throw "Message too large" and the decoder
-// to discard oversized frames for borderline files. The proper path to a
-// higher remote cap is streaming fs.readFile over the relay, not bumping
-// MAX_MESSAGE_SIZE (which would introduce head-of-line blocking on the mux).
+// 10MB for relayed binaries (base64 → ~13.3MB frame payload at 16MB relay cap)
 export const MAX_PREVIEWABLE_BINARY_SIZE = 10 * 1024 * 1024
 export const SEARCH_TIMEOUT_MS = 15_000
 export const MAX_MATCHES_PER_FILE = 100
@@ -266,61 +254,5 @@ export function checkRgAvailable(): Promise<boolean> {
   })
 }
 
-// ─── rg-based file listing ───────────────────────────────────────────
-
-/**
- * List all non-ignored files under `rootPath` using ripgrep's `--files` mode.
- * Returns relative POSIX paths.
- */
-export function listFilesWithRg(rootPath: string): Promise<string[]> {
-  return new Promise((resolve) => {
-    const files: string[] = []
-    let buffer = ''
-    let done = false
-
-    const finish = () => {
-      if (done) {
-        return
-      }
-      done = true
-      clearTimeout(timer)
-      resolve(files)
-    }
-
-    const child = execFile(
-      'rg',
-      ['--files', '--hidden', '--glob', '!**/node_modules', '--glob', '!**/.git', rootPath],
-      { maxBuffer: 50 * 1024 * 1024 }
-    )
-
-    child.stdout!.setEncoding('utf-8')
-    child.stdout!.on('data', (chunk: string) => {
-      buffer += chunk
-      const lines = buffer.split('\n')
-      buffer = lines.pop() ?? ''
-      for (const line of lines) {
-        if (!line) {
-          continue
-        }
-        const relPath = relative(rootPath, line).replace(/\\/g, '/')
-        if (!relPath.startsWith('..')) {
-          files.push(relPath)
-        }
-      }
-    })
-    child.stderr!.on('data', () => {
-      /* drain */
-    })
-    child.once('error', () => finish())
-    child.once('close', () => {
-      if (buffer) {
-        const relPath = relative(rootPath, buffer.trim()).replace(/\\/g, '/')
-        if (relPath && !relPath.startsWith('..')) {
-          files.push(relPath)
-        }
-      }
-      finish()
-    })
-    const timer = setTimeout(() => child.kill(), 10_000)
-  })
-}
+// Moved to fs-handler-list-files.ts to keep this file under 300 lines (oxlint)
+export { listFilesWithRg, LIST_FILES_TIMEOUT_MS } from './fs-handler-list-files'

--- a/src/relay/fs-handler.ts
+++ b/src/relay/fs-handler.ts
@@ -27,6 +27,8 @@ import {
 } from './fs-handler-utils'
 import { listFilesWithGit, searchWithGitGrep } from './fs-handler-git-fallback'
 import { listFilesWithReaddir } from './fs-handler-readdir-fallback'
+import { buildExcludePathPrefixes } from '../shared/quick-open-filter'
+import { buildInstallRgMessage } from './fs-handler-install-rg'
 
 type WatchState = {
   rootPath: string
@@ -233,9 +235,14 @@ export class FsHandler {
   private async listFiles(params: Record<string, unknown>): Promise<string[]> {
     const rootPath = expandTilde(params.rootPath as string)
     await this.context.validatePathResolved(rootPath)
+    // Why: the main-to-relay RPC adds excludePaths so nested linked worktrees
+    // don't get double-scanned. The shared helper validates the shape and
+    // normalizes into root-relative prefixes; malformed input yields [] so
+    // the request still succeeds (older apps omit the field entirely).
+    const excludePathPrefixes = buildExcludePathPrefixes(rootPath, params.excludePaths)
     const rgAvailable = await checkRgAvailable()
     if (rgAvailable) {
-      return listFilesWithRg(rootPath)
+      return listFilesWithRg(rootPath, excludePathPrefixes)
     }
     // Why: git ls-files only works inside git repos. Use rev-parse to detect
     // git ancestry — unlike checking for a local .git entry, this works from
@@ -248,9 +255,18 @@ export class FsHandler {
       )
     })
     if (isGitRepo) {
-      return listFilesWithGit(rootPath)
+      return listFilesWithGit(rootPath, excludePathPrefixes)
     }
-    return listFilesWithReaddir(rootPath)
+    // Why: the readdir walker rejects on cap/deadline instead of returning a
+    // partial list (design doc: silent truncation is worse than an explicit
+    // error). On a home-root without rg that's almost always an install-rg
+    // problem, so translate the opaque cap error into actionable guidance
+    // the user can act on directly from the error toast.
+    try {
+      return await listFilesWithReaddir(rootPath, excludePathPrefixes)
+    } catch (err) {
+      throw new Error(await buildInstallRgMessage(err))
+    }
   }
 
   private async watch(params: Record<string, unknown>, context?: RequestContext) {

--- a/src/renderer/src/components/QuickOpen.tsx
+++ b/src/renderer/src/components/QuickOpen.tsx
@@ -66,7 +66,7 @@ function fuzzyMatch(query: string, target: string): number {
  */
 function parseInstallRgGuidance(
   message: string
-): { reason: string; command: string | null } | null {
+): { reason: string; command: string | null; guidance: string | null } | null {
   const match = message.match(
     /^Quick Open scan too large \(([^)]+)\)\. Install ripgrep on the remote to enable fast, gitignore-aware listing: (.+)$/
   )
@@ -79,7 +79,23 @@ function parseInstallRgGuidance(
   // your package manager (e.g. apt/dnf/pacman)" — there's no single command
   // to copy, so surface it as plain guidance without the code block.
   const looksLikeCommand = /^(sudo\s+)?(brew|apt|dnf|pacman|apk)\s/.test(tail)
-  return { reason, command: looksLikeCommand ? tail : null }
+  return {
+    reason,
+    command: looksLikeCommand ? tail : null,
+    guidance: looksLikeCommand ? null : tail
+  }
+}
+
+function isNestedPath(parentPath: string, childPath: string): boolean {
+  const windowsPath = /^[a-zA-Z]:[\\/]/.test(parentPath) || parentPath.startsWith('\\\\')
+  const parent = parentPath.replace(/[\\/]+$/, '').replace(/\\/g, '/')
+  const child = childPath.replace(/\\/g, '/')
+  // Why: Windows paths are case-insensitive and can arrive with mixed slash
+  // styles from git/Electron. Normalize before deciding whether to exclude a
+  // nested linked worktree from Quick Open scans.
+  const comparableParent = windowsPath ? parent.toLowerCase() : parent
+  const comparableChild = windowsPath ? child.toLowerCase() : child
+  return comparableChild.startsWith(`${comparableParent}/`)
 }
 
 function FooterKey({ children }: { children: React.ReactNode }): React.JSX.Element {
@@ -92,10 +108,12 @@ function FooterKey({ children }: { children: React.ReactNode }): React.JSX.Eleme
 
 function InstallRgGuidance({
   reason,
-  command
+  command,
+  guidance
 }: {
   reason: string
   command: string | null
+  guidance?: string | null
 }): React.JSX.Element {
   const [copied, setCopied] = useState(false)
   const handleCopy = useCallback(() => {
@@ -144,6 +162,8 @@ function InstallRgGuidance({
             {copied ? 'Copied' : 'Copy'}
           </button>
         </div>
+      ) : guidance ? (
+        <p className="text-[13px] leading-5 text-foreground">{guidance}</p>
       ) : null}
     </div>
   )
@@ -175,8 +195,7 @@ export default function QuickOpen(): React.JSX.Element | null {
     // sibling worktrees in the same repo avoids rescanning the entire store.
     return repoWorktrees
       .filter(
-        (worktree) =>
-          worktree.id !== activeWorktreeId && worktree.path.startsWith(`${worktreePath}/`)
+        (worktree) => worktree.id !== activeWorktreeId && isNestedPath(worktreePath, worktree.path)
       )
       .map((worktree) => worktree.path)
       .sort()
@@ -338,7 +357,11 @@ export default function QuickOpen(): React.JSX.Element | null {
           (() => {
             const guidance = parseInstallRgGuidance(loadError)
             return guidance ? (
-              <InstallRgGuidance reason={guidance.reason} command={guidance.command} />
+              <InstallRgGuidance
+                reason={guidance.reason}
+                command={guidance.command}
+                guidance={guidance.guidance}
+              />
             ) : (
               <div className="py-6 px-4 text-center text-sm text-muted-foreground whitespace-pre-wrap">
                 {loadError}

--- a/src/renderer/src/components/QuickOpen.tsx
+++ b/src/renderer/src/components/QuickOpen.tsx
@@ -1,6 +1,6 @@
 /* oxlint-disable max-lines */
 import React, { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react'
-import { File } from 'lucide-react'
+import { AlertTriangle, Check, Copy, File } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { useActiveWorktree, useWorktreesForRepo } from '@/store/selectors'
 import { detectLanguage } from '@/lib/language-detect'
@@ -52,6 +52,101 @@ function fuzzyMatch(query: string, target: string): number {
   }
 
   return score
+}
+
+/**
+ * Parses the install-ripgrep guidance message produced by the relay's
+ * buildInstallRgMessage(). Returns the parts needed to render as formatted
+ * guidance (reason + install command) when matched, or null otherwise so
+ * callers can fall back to plain-text display.
+ *
+ * Why: the message is plain text on the wire (thrown as an Error), but the
+ * renderer is the only place with enough UI vocabulary to present ripgrep
+ * as an inline code span and the install command as a copyable code block.
+ */
+function parseInstallRgGuidance(
+  message: string
+): { reason: string; command: string | null } | null {
+  const match = message.match(
+    /^Quick Open scan too large \(([^)]+)\)\. Install ripgrep on the remote to enable fast, gitignore-aware listing: (.+)$/
+  )
+  if (!match) {
+    return null
+  }
+  const reason = match[1]
+  const tail = match[2].trim()
+  // Why: on unknown distros the relay emits prose like "install ripgrep via
+  // your package manager (e.g. apt/dnf/pacman)" — there's no single command
+  // to copy, so surface it as plain guidance without the code block.
+  const looksLikeCommand = /^(sudo\s+)?(brew|apt|dnf|pacman|apk)\s/.test(tail)
+  return { reason, command: looksLikeCommand ? tail : null }
+}
+
+function FooterKey({ children }: { children: React.ReactNode }): React.JSX.Element {
+  return (
+    <span className="rounded-full border border-border/60 bg-muted/35 px-2 py-0.5 text-[10px] font-medium text-foreground/85">
+      {children}
+    </span>
+  )
+}
+
+function InstallRgGuidance({
+  reason,
+  command
+}: {
+  reason: string
+  command: string | null
+}): React.JSX.Element {
+  const [copied, setCopied] = useState(false)
+  const handleCopy = useCallback(() => {
+    if (!command) {
+      return
+    }
+    // Why: use Electron's clipboard IPC instead of navigator.clipboard — the
+    // latter often fails silently in the renderer due to focus/permission
+    // quirks inside Radix dialogs. All other copy buttons in the app go
+    // through window.api.ui.writeClipboardText for consistency.
+    void window.api.ui
+      .writeClipboardText(command)
+      .then(() => {
+        setCopied(true)
+        setTimeout(() => setCopied(false), 1500)
+      })
+      .catch(() => {
+        /* best-effort */
+      })
+  }, [command])
+
+  return (
+    <div className="px-4 py-5 text-sm text-muted-foreground space-y-3">
+      <div
+        role="alert"
+        className="flex items-start gap-2.5 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2.5 text-amber-700 dark:text-amber-300"
+      >
+        <AlertTriangle size={16} className="mt-0.5 shrink-0" aria-hidden="true" />
+        <p className="text-[13px] leading-5">Quick Open scan too large ({reason}).</p>
+      </div>
+      <p>
+        Install{' '}
+        <code className="rounded bg-muted px-1 py-0.5 font-mono text-foreground">ripgrep</code> on
+        the remote to enable fast, gitignore-aware listing:
+      </p>
+      {command ? (
+        <div className="flex items-center gap-2 rounded border border-border bg-muted/50 px-3 py-2 font-mono text-xs text-foreground">
+          <span className="flex-1 truncate">{command}</span>
+          <button
+            type="button"
+            onClick={handleCopy}
+            className="flex items-center gap-1 rounded px-2 py-1 text-xs text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+            aria-label="Copy install command"
+          >
+            {copied ? <Check size={12} /> : <Copy size={12} />}
+            {copied ? 'Copied' : 'Copy'}
+          </button>
+        </div>
+      ) : null}
+    </div>
+  )
 }
 
 export default function QuickOpen(): React.JSX.Element | null {
@@ -159,7 +254,11 @@ export default function QuickOpen(): React.JSX.Element | null {
           setFiles([])
           // Why: treating list-files failures as "no matches" hides the real
           // cause when the active worktree path is unauthorized or stale.
-          setLoadError(error instanceof Error ? error.message : String(error))
+          // Strip Electron's "Error invoking remote method 'fs:listFiles':
+          // Error:" wrapper so the user sees only the actionable message.
+          const raw = error instanceof Error ? error.message : String(error)
+          const cleaned = raw.replace(/^Error invoking remote method '[^']+':\s*Error:\s*/, '')
+          setLoadError(cleaned)
         }
       })
       .finally(() => {
@@ -236,7 +335,16 @@ export default function QuickOpen(): React.JSX.Element | null {
         {loading ? (
           <div className="py-6 text-center text-sm text-muted-foreground">Loading files...</div>
         ) : loadError ? (
-          <div className="py-6 text-center text-sm text-red-500">{loadError}</div>
+          (() => {
+            const guidance = parseInstallRgGuidance(loadError)
+            return guidance ? (
+              <InstallRgGuidance reason={guidance.reason} command={guidance.command} />
+            ) : (
+              <div className="py-6 px-4 text-center text-sm text-muted-foreground whitespace-pre-wrap">
+                {loadError}
+              </div>
+            )
+          })()
         ) : filtered.length === 0 ? (
           <CommandEmpty>No matching files.</CommandEmpty>
         ) : (
@@ -260,6 +368,16 @@ export default function QuickOpen(): React.JSX.Element | null {
           })
         )}
       </CommandList>
+      <div className="flex items-center justify-end border-t border-border/60 px-3.5 py-2.5 text-[11px] text-muted-foreground/82">
+        <div className="flex items-center gap-2">
+          <FooterKey>Enter</FooterKey>
+          <span>Open</span>
+          <FooterKey>Esc</FooterKey>
+          <span>Close</span>
+          <FooterKey>↑↓</FooterKey>
+          <span>Move</span>
+        </div>
+      </div>
       {/* Accessibility: announce result count changes */}
       <div aria-live="polite" className="sr-only">
         {deferredQuery.trim() ? `${filtered.length} files found` : ''}

--- a/src/shared/quick-open-filter.test.ts
+++ b/src/shared/quick-open-filter.test.ts
@@ -157,6 +157,24 @@ describe('normalizeQuickOpenRgLine', () => {
     ).toBe('src/a.ts')
   })
 
+  it('strips Windows drive absolute root prefixes', () => {
+    expect(
+      normalizeQuickOpenRgLine('C:\\repo\\src\\a.ts', {
+        kind: 'absolute',
+        rootPath: 'C:\\repo'
+      })
+    ).toBe('src/a.ts')
+  })
+
+  it('preserves Windows UNC roots while stripping absolute root prefixes', () => {
+    expect(
+      normalizeQuickOpenRgLine('\\\\server\\share\\repo\\src\\a.ts', {
+        kind: 'absolute',
+        rootPath: '\\\\server\\share\\repo'
+      })
+    ).toBe('src/a.ts')
+  })
+
   it('strips ./ prefix in cwd-relative mode', () => {
     expect(normalizeQuickOpenRgLine('./src/a.ts', { kind: 'cwd-relative' })).toBe('src/a.ts')
   })
@@ -189,7 +207,7 @@ describe('buildGitLsFilesArgsForQuickOpen', () => {
     const { envPass } = buildGitLsFilesArgsForQuickOpen()
     expect(envPass).toContain('--others')
     expect(envPass).toContain('.env*')
-    expect(envPass).toContain('**/.env*')
+    expect(envPass).toContain(':(glob)**/.env*')
     expect(envPass).not.toContain('--exclude-standard')
   })
 

--- a/src/shared/quick-open-filter.test.ts
+++ b/src/shared/quick-open-filter.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildExcludePathPrefixes,
+  buildGitLsFilesArgsForQuickOpen,
+  buildHiddenDirExcludeGlobs,
+  buildRgArgsForQuickOpen,
+  HIDDEN_DIR_BLOCKLIST,
+  normalizeQuickOpenRgLine,
+  shouldExcludeQuickOpenRelPath,
+  shouldIncludeQuickOpenPath
+} from './quick-open-filter'
+
+describe('shouldIncludeQuickOpenPath', () => {
+  it('includes normal source paths', () => {
+    expect(shouldIncludeQuickOpenPath('src/index.ts')).toBe(true)
+    expect(shouldIncludeQuickOpenPath('.github/workflows/ci.yml')).toBe(true)
+    expect(shouldIncludeQuickOpenPath('.env')).toBe(true)
+  })
+
+  it('excludes node_modules and blocklisted dirs at any depth', () => {
+    expect(shouldIncludeQuickOpenPath('node_modules/a/b.js')).toBe(false)
+    expect(shouldIncludeQuickOpenPath('packages/x/node_modules/a.js')).toBe(false)
+    expect(shouldIncludeQuickOpenPath('.git/config')).toBe(false)
+    expect(shouldIncludeQuickOpenPath('foo/.cache/bar')).toBe(false)
+  })
+
+  // Why hidden: home-dir cache/state dirs that caused the original SSH bug.
+  // Test name explains why each is filtered.
+  it('hides generated npm cache dir from Quick Open', () => {
+    expect(shouldIncludeQuickOpenPath('.npm/pkg/index.js')).toBe(false)
+  })
+  it('hides npm-global install state dir from Quick Open', () => {
+    expect(shouldIncludeQuickOpenPath('.npm-global/bin/foo')).toBe(false)
+  })
+  it('hides GNOME virtual FS runtime mount from Quick Open', () => {
+    expect(shouldIncludeQuickOpenPath('.gvfs/mount/file')).toBe(false)
+  })
+
+  it('does NOT blocklist user-authored dirs like .config, .ssh, .github', () => {
+    expect(HIDDEN_DIR_BLOCKLIST.has('.config')).toBe(false)
+    expect(HIDDEN_DIR_BLOCKLIST.has('.ssh')).toBe(false)
+    expect(HIDDEN_DIR_BLOCKLIST.has('.github')).toBe(false)
+    expect(HIDDEN_DIR_BLOCKLIST.has('.devcontainer')).toBe(false)
+    expect(HIDDEN_DIR_BLOCKLIST.has('.local')).toBe(false)
+  })
+})
+
+describe('buildExcludePathPrefixes', () => {
+  it('returns root-relative POSIX prefixes', () => {
+    expect(
+      buildExcludePathPrefixes('/home/u/repo', [
+        '/home/u/repo/packages/app',
+        '/home/u/repo/worktrees/b'
+      ])
+    ).toEqual(['packages/app', 'worktrees/b'])
+  })
+
+  it('ignores malformed input', () => {
+    expect(buildExcludePathPrefixes('/home/u/repo', undefined)).toEqual([])
+    expect(buildExcludePathPrefixes('/home/u/repo', 'not-array' as unknown)).toEqual([])
+    expect(buildExcludePathPrefixes('/home/u/repo', [null, 42, '', '/outside'])).toEqual([])
+  })
+
+  it('ignores root-equal and outside-root values', () => {
+    expect(buildExcludePathPrefixes('/home/u/repo', ['/home/u/repo'])).toEqual([])
+    expect(buildExcludePathPrefixes('/home/u/repo', ['/home/u/other'])).toEqual([])
+  })
+
+  it('handles Windows-style roots and paths', () => {
+    expect(buildExcludePathPrefixes('C:\\repo', ['C:\\repo\\packages\\app'])).toEqual([
+      'packages/app'
+    ])
+  })
+
+  it('strips trailing slashes', () => {
+    expect(buildExcludePathPrefixes('/r', ['/r/a/', '/r/b///'])).toEqual(['a', 'b'])
+  })
+})
+
+describe('shouldExcludeQuickOpenRelPath', () => {
+  it('matches exact and boundary paths only', () => {
+    expect(shouldExcludeQuickOpenRelPath('packages/app', ['packages/app'])).toBe(true)
+    expect(shouldExcludeQuickOpenRelPath('packages/app/x.ts', ['packages/app'])).toBe(true)
+  })
+
+  it('does not match sibling paths with a shared prefix', () => {
+    expect(shouldExcludeQuickOpenRelPath('packages/app2/x.ts', ['packages/app'])).toBe(false)
+    expect(shouldExcludeQuickOpenRelPath('packages/application', ['packages/app'])).toBe(false)
+  })
+})
+
+describe('buildHiddenDirExcludeGlobs', () => {
+  it('includes node_modules plus blocklist as directory-match globs', () => {
+    const globs = buildHiddenDirExcludeGlobs()
+    expect(globs).toContain('!**/node_modules')
+    expect(globs).toContain('!**/.git')
+    expect(globs).toContain('!**/.cache')
+    // Directory-match form (not contents form) — contents form lets rg still
+    // descend into the directory.
+    expect(globs).not.toContain('!**/node_modules/**')
+  })
+})
+
+describe('buildRgArgsForQuickOpen', () => {
+  it('primary pass includes --files, --hidden, hidden-dir excludes, no --follow', () => {
+    const { primary } = buildRgArgsForQuickOpen({
+      searchRoot: '/root',
+      excludePathPrefixes: [],
+      forceSlashSeparator: false
+    })
+    expect(primary).toContain('--files')
+    expect(primary).toContain('--hidden')
+    expect(primary).toContain('!**/node_modules')
+    expect(primary).not.toContain('--follow')
+  })
+
+  it('.env* pass includes --no-ignore-vcs and both root + nested globs, no --follow', () => {
+    const { envPass } = buildRgArgsForQuickOpen({
+      searchRoot: '/root',
+      excludePathPrefixes: [],
+      forceSlashSeparator: false
+    })
+    expect(envPass).toContain('--no-ignore-vcs')
+    expect(envPass).toContain('.env*')
+    expect(envPass).toContain('**/.env*')
+    expect(envPass).not.toContain('--follow')
+  })
+
+  it('forceSlashSeparator emits --path-separator /', () => {
+    const { primary } = buildRgArgsForQuickOpen({
+      searchRoot: '/r',
+      excludePathPrefixes: [],
+      forceSlashSeparator: true
+    })
+    const idx = primary.indexOf('--path-separator')
+    expect(idx).toBeGreaterThanOrEqual(0)
+    expect(primary[idx + 1]).toBe('/')
+  })
+
+  it('excludePathPrefixes are escaped as directory-match globs', () => {
+    const { primary } = buildRgArgsForQuickOpen({
+      searchRoot: '/r',
+      excludePathPrefixes: ['packages/app', 'feature[1]'],
+      forceSlashSeparator: false
+    })
+    expect(primary).toContain('!packages/app')
+    expect(primary).toContain('!packages/app/**')
+    // Glob metacharacters in a literal name must be escaped.
+    expect(primary).toContain('!feature\\[1\\]')
+  })
+})
+
+describe('normalizeQuickOpenRgLine', () => {
+  it('strips absolute root prefix', () => {
+    expect(
+      normalizeQuickOpenRgLine('/root/src/a.ts', { kind: 'absolute', rootPath: '/root' })
+    ).toBe('src/a.ts')
+  })
+
+  it('strips ./ prefix in cwd-relative mode', () => {
+    expect(normalizeQuickOpenRgLine('./src/a.ts', { kind: 'cwd-relative' })).toBe('src/a.ts')
+  })
+
+  it('strips CRLF', () => {
+    expect(normalizeQuickOpenRgLine('/root/a.ts\r', { kind: 'absolute', rootPath: '/root' })).toBe(
+      'a.ts'
+    )
+  })
+
+  it('returns null for paths outside the absolute root', () => {
+    expect(
+      normalizeQuickOpenRgLine('/other/a.ts', { kind: 'absolute', rootPath: '/root' })
+    ).toBeNull()
+  })
+
+  it('returns null for empty or root-equal lines', () => {
+    expect(normalizeQuickOpenRgLine('', { kind: 'cwd-relative' })).toBeNull()
+    expect(normalizeQuickOpenRgLine('.', { kind: 'cwd-relative' })).toBeNull()
+  })
+})
+
+describe('buildGitLsFilesArgsForQuickOpen', () => {
+  it('primary pass is --cached --others --exclude-standard', () => {
+    const { primary } = buildGitLsFilesArgsForQuickOpen()
+    expect(primary).toEqual(['--cached', '--others', '--exclude-standard'])
+  })
+
+  it('env pass surfaces gitignored .env at root and nested, without --exclude-standard', () => {
+    const { envPass } = buildGitLsFilesArgsForQuickOpen()
+    expect(envPass).toContain('--others')
+    expect(envPass).toContain('.env*')
+    expect(envPass).toContain('**/.env*')
+    expect(envPass).not.toContain('--exclude-standard')
+  })
+
+  it('exclude prefixes prepend positive "." pathspec', () => {
+    const { primary } = buildGitLsFilesArgsForQuickOpen(['packages/app'])
+    const dashDashIdx = primary.indexOf('--')
+    expect(dashDashIdx).toBeGreaterThanOrEqual(0)
+    // Positive pathspec must appear before any exclude pathspec.
+    expect(primary[dashDashIdx + 1]).toBe('.')
+    expect(primary).toContain(':(exclude,glob)packages/app')
+    expect(primary).toContain(':(exclude,glob)packages/app/**')
+  })
+})

--- a/src/shared/quick-open-filter.ts
+++ b/src/shared/quick-open-filter.ts
@@ -1,0 +1,364 @@
+/**
+ * Shared, pure Quick Open (Cmd/Ctrl+P) file-listing filter policy used by both
+ * the local main process and the SSH relay. No IO, no Electron, no WSL, no
+ * auth — callers own process execution and transport-specific path translation.
+ *
+ * Why this module exists (design doc: docs/design/share-quick-open-file-listing.md):
+ * Before extraction, the local and relay listFiles implementations had diverged
+ * on blocklist, .env* handling, nested-worktree exclusions, timeout strategy,
+ * and buffering. A home-dir worktree over SSH would descend into $HOME dotfile
+ * caches, hit a 10s timeout, and silently resolve with a partial result —
+ * Quick Open showed "No matching files" even though the scan was incomplete.
+ * Centralizing the policy prevents future drift.
+ */
+import { posix, win32 } from 'path'
+
+// ─── Hidden-dir blocklist ────────────────────────────────────────────
+
+// Why: with rg --hidden we surface dotfiles users commonly edit (.env,
+// .github/*, .eslintrc). A blocklist (not an allowlist) keeps novel dotfiles
+// discoverable by default; the entries here are tool-generated caches / state
+// that are never hand-edited. Do NOT add broad user-authored dotdirs like
+// .config, .ssh, .gnupg, .github, .devcontainer — users open files in them.
+//
+// .npm, .npm-global, .local/share, .gvfs added for the home-root failure
+// (design doc): these are generated package cache, install state, desktop
+// runtime state — not normal project source.
+export const HIDDEN_DIR_BLOCKLIST: ReadonlySet<string> = new Set([
+  '.git',
+  '.next',
+  '.nuxt',
+  '.cache',
+  '.stably',
+  '.vscode',
+  '.idea',
+  '.yarn',
+  '.pnpm-store',
+  '.terraform',
+  '.docker',
+  '.husky',
+  // Home-dir cache/install/runtime state that caused the original bug when
+  // a worktree rooted at $HOME let rg descend for 10s before timing out.
+  '.npm',
+  '.npm-global',
+  '.gvfs'
+])
+
+// Kept separate from HIDDEN_DIR_BLOCKLIST because node_modules is not a
+// dotfile dir, but it must still be pruned from every traversal.
+const NON_DOTTED_PRUNE = 'node_modules'
+
+/**
+ * Returns true if `relPath` (a `/`-separated, root-relative path) does not
+ * traverse through any blocklisted directory segment. Used as a correctness
+ * backstop after the rg/git traversal-pruning globs — if a blocklisted dir
+ * slips through (e.g., via a glob edge case), this filter still drops it.
+ *
+ * Why: walks the string segment-by-segment without allocating a split array,
+ * since this is called once per listed file and large repos produce ~100k
+ * files.
+ */
+export function shouldIncludeQuickOpenPath(path: string): boolean {
+  let start = 0
+  const len = path.length
+  while (start < len) {
+    let end = path.indexOf('/', start)
+    if (end === -1) {
+      end = len
+    }
+    const segment = path.substring(start, end)
+    if (segment === NON_DOTTED_PRUNE || HIDDEN_DIR_BLOCKLIST.has(segment)) {
+      return false
+    }
+    start = end + 1
+  }
+  return true
+}
+
+// ─── Path flavor detection ───────────────────────────────────────────
+
+// Why: buildExcludePathPrefixes must run correctly even when the main process
+// OS differs from the remote relay OS (macOS app talking to a Linux relay, or
+// Windows app talking to a Linux relay). path.relative from the local OS is
+// wrong for remote roots — pick win32 vs posix based on the root's shape.
+function pathFlavor(rootPath: string): typeof posix | typeof win32 {
+  // Drive letter like C:\ or C:/
+  if (/^[a-zA-Z]:[\\/]/.test(rootPath)) {
+    return win32
+  }
+  // UNC \\server\share
+  if (rootPath.startsWith('\\\\')) {
+    return win32
+  }
+  return posix
+}
+
+// ─── Exclude-path normalization ──────────────────────────────────────
+
+/**
+ * Normalize `excludePaths` (absolute paths sent by the renderer for nested
+ * worktrees) into `/`-separated, root-relative prefixes. Returns empty array
+ * on any malformed input — the request must not fail if the renderer sends a
+ * stale or typo'd exclude path.
+ *
+ * Design doc notes:
+ * - Missing, non-array, non-string, empty, outside-root, and root-equal
+ *   values are silently ignored.
+ * - Always returns `/`-separated strings because rg globs and the shared
+ *   Quick Open policy compare `/`-separated paths.
+ */
+export function buildExcludePathPrefixes(rootPath: string, excludePaths?: unknown): string[] {
+  if (!Array.isArray(excludePaths)) {
+    return []
+  }
+  const flavor = pathFlavor(rootPath)
+  // Trim trailing separators so comparison is stable.
+  const trimmedRoot = rootPath.replace(/[\\/]+$/, '')
+  const normalizedRoot = `${trimmedRoot.replace(/\\/g, '/')}/`
+  const out: string[] = []
+  for (const raw of excludePaths) {
+    if (typeof raw !== 'string' || raw.length === 0) {
+      continue
+    }
+    // Fast path: input already under the root with the same separator shape.
+    const rawFwd = raw.replace(/\\/g, '/')
+    let rel: string
+    if (rawFwd === normalizedRoot.slice(0, -1)) {
+      // Root-equal — refuse to exclude the whole tree.
+      continue
+    }
+    rel = rawFwd.startsWith(normalizedRoot)
+      ? rawFwd.slice(normalizedRoot.length)
+      : // Fall back to path-flavor relative so we do not accidentally use the
+        // local OS's semantics on remote paths.
+        flavor.relative(trimmedRoot, raw).replace(/\\/g, '/')
+    if (!rel || rel.startsWith('..') || rel.startsWith('/')) {
+      continue
+    }
+    // Strip any trailing slash so boundary checks are unambiguous.
+    rel = rel.replace(/\/+$/, '')
+    if (rel.length === 0) {
+      continue
+    }
+    out.push(rel)
+  }
+  return out
+}
+
+/**
+ * Segment-boundary exclude check. `relPath` is `/`-separated, root-relative.
+ * Returns true iff `relPath === prefix` or `relPath` starts with `prefix + '/'`.
+ *
+ * Why: a raw `startsWith` would match `packages/app2` against an exclusion
+ * for `packages/app`. This guard is required wherever exclude prefixes are
+ * used as a post-filter (git and readdir paths).
+ */
+export function shouldExcludeQuickOpenRelPath(
+  relPath: string,
+  excludePathPrefixes: readonly string[]
+): boolean {
+  for (const prefix of excludePathPrefixes) {
+    if (relPath === prefix) {
+      return true
+    }
+    if (relPath.length > prefix.length && relPath.startsWith(`${prefix}/`)) {
+      return true
+    }
+  }
+  return false
+}
+
+// ─── Glob escaping ───────────────────────────────────────────────────
+
+// rg/git glob metacharacters. Escape them when a user-supplied or directory
+// name is embedded into a glob, so a directory literally named `feature[1]`
+// does not silently exclude `feature1`.
+const GLOB_META = new Set<string>(['*', '?', '[', ']', '{', '}', '\\'])
+
+function escapeGlob(segment: string): string {
+  let out = ''
+  for (let i = 0; i < segment.length; i++) {
+    const ch = segment[i]
+    out += GLOB_META.has(ch) ? `\\${ch}` : ch
+  }
+  return out
+}
+
+function escapeGlobPath(relPath: string): string {
+  // Split on '/' so the separators are not themselves escaped.
+  return relPath.split('/').map(escapeGlob).join('/')
+}
+
+// ─── rg traversal-pruning globs ──────────────────────────────────────
+
+/**
+ * Build the hidden-dir traversal-pruning glob args for rg (includes
+ * `node_modules`). Uses the directory-match form `!**\/name` instead of the
+ * contents form `!**\/name/**` because rg still descends into a directory
+ * matched only by the contents form to enumerate entries — the directory
+ * form is what actually prunes traversal of huge caches under $HOME.
+ */
+export function buildHiddenDirExcludeGlobs(): string[] {
+  const names = [NON_DOTTED_PRUNE, ...HIDDEN_DIR_BLOCKLIST]
+  const out: string[] = []
+  for (const name of names) {
+    out.push('--glob', `!**/${escapeGlob(name)}`)
+  }
+  return out
+}
+
+// ─── rg arg builder ──────────────────────────────────────────────────
+
+export type RgArgsOptions = {
+  /** What to pass to rg as the positional search target — pass the absolute
+   *  root path when you plan to strip that prefix from output, or `.` when
+   *  you prefer cwd-relative output (both require cwd: rootPath). */
+  searchRoot: string
+  /** Root-relative, `/`-separated prefixes (from buildExcludePathPrefixes). */
+  excludePathPrefixes: readonly string[]
+  /** On Windows rg emits `\\`-separated paths; pass true to force `/` output. */
+  forceSlashSeparator: boolean
+}
+
+export type RgArgs = {
+  /** Main pass: all non-ignored files, hidden dotfiles included. */
+  primary: string[]
+  /** Second pass: gitignored .env* files. */
+  envPass: string[]
+}
+
+/**
+ * Build the two rg arg arrays for Quick Open. The caller is responsible for
+ * spawning rg with `cwd: rootPath`; root-relative globs like `!packages/app`
+ * are evaluated against rg's working directory, so omitting `cwd` silently
+ * breaks nested-worktree exclusions.
+ *
+ * The builder deliberately does not emit `--follow`: rg --files does not
+ * follow symlinks by default, and enabling it on a home-dir root risks
+ * escaping the authorized root (symlinks into /mnt, /tmp, other users' homes)
+ * and hitting traversal loops.
+ */
+export function buildRgArgsForQuickOpen(opts: RgArgsOptions): RgArgs {
+  const sepArgs = opts.forceSlashSeparator ? ['--path-separator', '/'] : []
+  const hiddenDirGlobs = buildHiddenDirExcludeGlobs()
+  const excludeGlobs: string[] = []
+  for (const prefix of opts.excludePathPrefixes) {
+    // Use directory-match form so rg prunes traversal of the nested worktree
+    // entirely, not just drops already-listed files from it.
+    excludeGlobs.push('--glob', `!${escapeGlobPath(prefix)}`)
+    excludeGlobs.push('--glob', `!${escapeGlobPath(prefix)}/**`)
+  }
+
+  const primary = [
+    '--files',
+    '--hidden',
+    ...sepArgs,
+    ...hiddenDirGlobs,
+    ...excludeGlobs,
+    opts.searchRoot
+  ]
+
+  // .env* pass: must include --no-ignore-vcs so rg surfaces gitignored .env
+  // files, which is the whole reason the second pass exists. Two positive
+  // globs (root-level and nested) because rg treats any positive --glob as a
+  // whitelist; no preceding negative pattern is needed.
+  const envPass = [
+    '--files',
+    '--hidden',
+    '--no-ignore-vcs',
+    ...sepArgs,
+    '--glob',
+    '.env*',
+    '--glob',
+    '**/.env*',
+    ...hiddenDirGlobs,
+    ...excludeGlobs,
+    opts.searchRoot
+  ]
+
+  return { primary, envPass }
+}
+
+// ─── rg stdout line normalization ────────────────────────────────────
+
+export type RgOutputMode =
+  /** rg was invoked with an absolute search target; output paths are absolute. */
+  | { kind: 'absolute'; rootPath: string }
+  /** rg was invoked with cwd: rootPath and searchRoot '.'; output is cwd-relative
+   *  and typically prefixed with `./`. */
+  | { kind: 'cwd-relative' }
+
+/**
+ * Convert one rg --files stdout line into a root-relative, `/`-separated path.
+ * Returns `null` for lines that escape the root (symlink resolution edge cases)
+ * or cannot be normalized. The main-process caller is responsible for any WSL
+ * translation before calling this — keeping WSL out of the shared module.
+ */
+export function normalizeQuickOpenRgLine(rawLine: string, outputMode: RgOutputMode): string | null {
+  let line = rawLine
+  // Strip CR so CRLF from rg on Windows doesn't leak into results.
+  if (line.length > 0 && line.charCodeAt(line.length - 1) === 13) {
+    line = line.substring(0, line.length - 1)
+  }
+  if (!line) {
+    return null
+  }
+  const normalized = line.replace(/\\/g, '/')
+  if (outputMode.kind === 'cwd-relative') {
+    let rel = normalized
+    if (rel.startsWith('./')) {
+      rel = rel.slice(2)
+    } else if (rel === '.') {
+      return null
+    }
+    if (!rel || rel.startsWith('/') || rel.startsWith('..')) {
+      return null
+    }
+    return rel
+  }
+  // Absolute mode: strip the root prefix.
+  const normalizedRoot = `${outputMode.rootPath.replace(/[\\/]+/g, '/').replace(/\/$/, '')}/`
+  if (normalized.startsWith(normalizedRoot)) {
+    return normalized.substring(normalizedRoot.length)
+  }
+  return null
+}
+
+// ─── git ls-files arg builder ────────────────────────────────────────
+
+export type GitLsFilesArgs = {
+  primary: string[]
+  envPass: string[]
+}
+
+/**
+ * Build the two `git ls-files` arg arrays for Quick Open. Exclude prefixes
+ * are encoded as `:(exclude,glob)` pathspecs; a positive `.` pathspec is
+ * prepended so exclude-only pathspecs do not depend on git's edge-case
+ * defaults.
+ *
+ * The `.env*` pass uses BOTH `.env*` (root-level) and `**\/.env*` (nested)
+ * because the `**\/` prefix alone does not match a root-level `.env` file —
+ * this was the silent bug in the prior local implementation.
+ */
+export function buildGitLsFilesArgsForQuickOpen(
+  excludePathPrefixes: readonly string[] = []
+): GitLsFilesArgs {
+  const excludeSpecs: string[] = []
+  for (const prefix of excludePathPrefixes) {
+    excludeSpecs.push(`:(exclude,glob)${escapeGlobPath(prefix)}`)
+    excludeSpecs.push(`:(exclude,glob)${escapeGlobPath(prefix)}/**`)
+  }
+  const trailingPathspecs = excludeSpecs.length > 0 ? ['--', '.', ...excludeSpecs] : []
+
+  const primary = ['--cached', '--others', '--exclude-standard', ...trailingPathspecs]
+  // Second pass: untracked AND ignored .env* files. Do not pass
+  // --exclude-standard — that would re-hide gitignored .env files, which is
+  // the whole reason this pass exists.
+  const envPassPathspecs =
+    excludeSpecs.length > 0
+      ? ['--', '.env*', '**/.env*', ...excludeSpecs]
+      : ['--', '.env*', '**/.env*']
+  const envPass = ['--others', ...envPassPathspecs]
+  return { primary, envPass }
+}

--- a/src/shared/quick-open-filter.ts
+++ b/src/shared/quick-open-filter.ts
@@ -317,7 +317,10 @@ export function normalizeQuickOpenRgLine(rawLine: string, outputMode: RgOutputMo
     return rel
   }
   // Absolute mode: strip the root prefix.
-  const normalizedRoot = `${outputMode.rootPath.replace(/[\\/]+/g, '/').replace(/\/$/, '')}/`
+  // Why: replace only backslashes here. Collapsing repeated slashes breaks
+  // Windows UNC roots (`\\server\share` -> `//server/share`) by turning them
+  // into single-slash POSIX-looking paths that no rg output can match.
+  const normalizedRoot = `${outputMode.rootPath.replace(/\\/g, '/').replace(/\/+$/, '')}/`
   if (normalized.startsWith(normalizedRoot)) {
     return normalized.substring(normalizedRoot.length)
   }
@@ -355,10 +358,14 @@ export function buildGitLsFilesArgsForQuickOpen(
   // Second pass: untracked AND ignored .env* files. Do not pass
   // --exclude-standard — that would re-hide gitignored .env files, which is
   // the whole reason this pass exists.
+  // Why :(glob): default git pathspec uses fnmatch, where `*` crossing `/` is
+  // implementation-dependent. `:(glob)` pins the semantics explicitly so
+  // `**/.env*` reliably surfaces nested `.env` files across git versions.
+  const nestedEnvSpec = ':(glob)**/.env*'
   const envPassPathspecs =
     excludeSpecs.length > 0
-      ? ['--', '.env*', '**/.env*', ...excludeSpecs]
-      : ['--', '.env*', '**/.env*']
+      ? ['--', '.env*', nestedEnvSpec, ...excludeSpecs]
+      : ['--', '.env*', nestedEnvSpec]
   const envPass = ['--others', ...envPassPathspecs]
   return { primary, envPass }
 }


### PR DESCRIPTION
## Problem

Quick Open over SSH relied on git ls-files for listing files, which:
- Fails on non-repo home directories
- Has inconsistent gitignore handling across distros
- Caps scalability on large repos without a clear error

## Solution

- Replace git fallback with ripgrep (rg) for faster, more reliable file listing with automatic gitignore respect
- Add configurable max file limits with clear install guidance when ripgrep is unavailable
- Implement shared Quick Open filter module for consistent path normalization across relay passes
- Support nested worktree exclusions and .env* visibility preferences
- Surface actionable install commands (apt/dnf/pacman/apk) for remote systems without rg

Made with [Orca](https://github.com/stablyai/orca) 🐋
