### PR TITLE
fix(terminal): make Claude Code OSC 8 hyperlinks clickable

### DIFF
--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -45,7 +45,15 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
     // Why: TUIs feature-gate on TERM_PROGRAM_VERSION. The daemon is forked
     // by main (daemon-init.ts:93) with the parent's env, so ORCA_APP_VERSION
     // — set in src/main/index.ts from app.getVersion() — is inherited here.
-    TERM_PROGRAM_VERSION: process.env.ORCA_APP_VERSION ?? '0.0.0-dev'
+    TERM_PROGRAM_VERSION: process.env.ORCA_APP_VERSION ?? '0.0.0-dev',
+    // Why: opt tools (Claude Code, ls --hyperlink, etc.) into emitting OSC 8
+    // hyperlinks. The `supports-hyperlinks` npm package gates on a hard-coded
+    // TERM_PROGRAM allowlist (iTerm.app / WezTerm / vscode) and returns false
+    // for TERM_PROGRAM=Orca, so callers drop OSC 8 output entirely and emit
+    // bare text instead. xterm.js in Orca parses OSC 8 and the pane's
+    // linkHandler routes clicks, so forcing the advertisement is safe and
+    // restores clickable refs like `owner/repo#123` / `PR#123`.
+    FORCE_HYPERLINK: '1'
   } as Record<string, string>
 
   env.LANG ??= 'en_US.UTF-8'

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -288,6 +288,16 @@ describe('registerPtyHandlers', () => {
       expect(env.TERM_PROGRAM).toBe('Orca')
     })
 
+    it('advertises OSC 8 hyperlink support via FORCE_HYPERLINK', async () => {
+      // Why: the supports-hyperlinks npm package hard-codes a TERM_PROGRAM
+      // allowlist (iTerm.app / WezTerm / vscode) and reports false for
+      // TERM_PROGRAM=Orca, so tools like Claude Code emit plain text instead
+      // of ESC]8;; wrappers. Setting FORCE_HYPERLINK=1 forces the detector to
+      // return true; xterm.js + our linkHandler handle the sequences natively.
+      const env = await spawnAndGetEnv()
+      expect(env.FORCE_HYPERLINK).toBe('1')
+    })
+
     it('surfaces ORCA_APP_VERSION as TERM_PROGRAM_VERSION for TUI feature gating', async () => {
       const env = await spawnAndGetEnv(undefined, { ORCA_APP_VERSION: '1.2.3-test' })
       expect(env.TERM_PROGRAM_VERSION).toBe('1.2.3-test')

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -181,7 +181,15 @@ export class LocalPtyProvider implements IPtyProvider {
       // autodetection, bat/delta paging hints). Sourced from ORCA_APP_VERSION
       // which main/index.ts seeds from app.getVersion() at startup; the
       // fallback keeps tests and non-Electron runs working.
-      TERM_PROGRAM_VERSION: process.env.ORCA_APP_VERSION ?? '0.0.0-dev'
+      TERM_PROGRAM_VERSION: process.env.ORCA_APP_VERSION ?? '0.0.0-dev',
+      // Why: opt tools (Claude Code, ls --hyperlink, etc.) into emitting OSC 8
+      // hyperlinks. The `supports-hyperlinks` npm package gates on a hard-coded
+      // TERM_PROGRAM allowlist (iTerm.app / WezTerm / vscode) and returns false
+      // for TERM_PROGRAM=Orca, so callers drop OSC 8 output entirely and emit
+      // bare text instead. xterm.js in Orca parses OSC 8 and the pane's
+      // linkHandler routes clicks, so forcing the advertisement is safe and
+      // restores clickable refs like `owner/repo#123` / `PR#123`.
+      FORCE_HYPERLINK: '1'
     } as Record<string, string>
     for (const key of args.envToDelete ?? []) {
       delete spawnEnv[key]


### PR DESCRIPTION
## Summary
- Claude Code's \`owner/repo#123\` / \`PR#123\` references rendered as plain text inside Orca, even though xterm.js + our pane \`linkHandler\` already parse OSC 8 correctly.
- Root cause: Claude Code gates OSC 8 emission on the \`supports-hyperlinks\` npm package, which hard-codes a \`TERM_PROGRAM\` allowlist (\`iTerm.app\`, \`WezTerm\`, \`vscode\`) and returns \`false\` for \`TERM_PROGRAM=Orca\` — so the \`ESC]8;;URL…\` bytes were never emitted.
- Fix: set \`FORCE_HYPERLINK=1\` in the PTY env at both spawn sites (\`local-pty-provider.ts\`, \`daemon/pty-subprocess.ts\`). \`supports-hyperlinks\` honors it above the allowlist.

## Why not \`TERM_PROGRAM=vscode\`?
- Users commonly put \`[[ \"\$TERM_PROGRAM\" == \"vscode\" ]] && . \"\$(code --locate-shell-integration-path zsh)\"\` in their dotfiles. That would source VS Code's shell integration and start injecting OSC 633 marks into every Orca pane — xterm.js doesn't render OSC 633 so they'd silently clutter prompts.
- Users' profiles often branch on \`TERM_PROGRAM == vscode\` for other setup.
- \`FORCE_HYPERLINK\` is a scoped, dedicated opt-in; nothing else gates on it, and Go/Rust/Python CLIs ignore it entirely (they rely on \`\$TERM\` / \`\$COLORTERM\`).

## Test plan
- [x] New unit test locks in that \`FORCE_HYPERLINK=1\` is advertised (\`src/main/ipc/pty.test.ts\`).
- [ ] Manual: launch Orca, run \`claude\` in a pane, have it reference a GitHub PR or issue (e.g. \`anthropics/claude-code#123\`) and confirm the reference underlines on hover and opens on ⌘+click.
- [ ] Manual: confirm nothing regresses for plain-text URL detection (WebLinksAddon) or our file-path link provider.

Made with [Orca](https://github.com/stablyai/orca) 🐋
