### PR TITLE
fix(menu): auto-hide menu bar on Windows and Linux

### DIFF
--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -85,11 +85,12 @@ export function createMainWindow(
     minHeight: 400,
     show: false,
     // Why: on macOS the menu lives in the system menu bar, so the in-window
-    // menu bar is irrelevant and stays hidden. On Windows/Linux the menu bar
-    // *is* the only surface for File/Edit/View/Window, so keep it always
-    // visible — otherwise users never see the menu items at all (they'd have
-    // to press Alt to toggle it).
-    autoHideMenuBar: process.platform === 'darwin',
+    // menu bar is irrelevant. On Windows/Linux we auto-hide so the menu bar
+    // doesn't consume a dedicated row of vertical space on every launch —
+    // users can still reveal the (properly restructured) File/Edit/View/
+    // Window/Help menus by pressing Alt, matching native Windows/Linux
+    // conventions (File Explorer, Firefox, etc.).
+    autoHideMenuBar: true,
     backgroundColor: nativeTheme.shouldUseDarkColors ? '#0a0a0a' : '#ffffff',
     titleBarStyle: process.platform === 'darwin' ? 'hiddenInset' : undefined,
     // Why: initial position for 1x zoom; syncTrafficLightPosition() adjusts


### PR DESCRIPTION
## Summary
- Follow-up to #1111. Keeping the menu bar always visible on Win/Linux added a dedicated row of vertical space users didn't want.
- Revert to `autoHideMenuBar: true` everywhere — matches native Win/Linux convention (File Explorer, Firefox): menu bar is hidden by default, Alt reveals it.
- The template restructure from #1111 (File → Settings/Exit, Help → About/Check for Updates, no redundant "Orca" entry) still applies when the menu is shown.

## Test plan
- [x] `pnpm vitest run src/main/window src/main/menu`
- [ ] Manual on Windows: launch → no extra menu row; press Alt → File/Edit/View/Window/Help appear with correct items
- [ ] Manual on Linux: launch → no extra menu row; Alt reveals same menus
- [ ] Manual on macOS: unchanged

Made with [Orca](https://github.com/stablyai/orca) 🐋
