### PR TITLE
fix(daemon): checkpoint-based history persistence to reduce memory

### DIFF
--- a/src/main/daemon/daemon-init.ts
+++ b/src/main/daemon/daemon-init.ts
@@ -327,16 +327,17 @@ async function createLegacyDaemonAdapters(runtimeDir: string): Promise<DaemonPty
     // Legacy adapters intentionally do not respawn: respawning an old protocol
     // daemon from new code would recreate stale env semantics and can be less
     // predictable than letting the session fail if that old daemon dies.
-    // Why no historyPath: checkpoint-based persistence requires the getSnapshot
-    // RPC (protocol v4+). Pre-v4 daemons reject that call, so the checkpoint
-    // timer would silently discard every write. Omitting historyPath avoids
-    // wasted RPC round-trips. Pre-upgrade scrollback.bin files remain on disk
-    // and the history reader's fallback path can still cold-restore from them.
+    // Why historyPath is still passed: checkpoint writes will fail silently
+    // (pre-v4 daemons don't support getSnapshot), but the HistoryManager is
+    // still needed for cleanup — close/exit events must remove history dirs
+    // and mark meta.json as ended. Without it, a later v4 session reusing
+    // the same ID could false-restore stale scrollback.bin.
     adapters.push(
       new DaemonPtyAdapter({
         socketPath,
         tokenPath,
-        protocolVersion
+        protocolVersion,
+        historyPath: getHistoryDir()
       })
     )
   }

--- a/src/main/daemon/daemon-init.ts
+++ b/src/main/daemon/daemon-init.ts
@@ -327,12 +327,16 @@ async function createLegacyDaemonAdapters(runtimeDir: string): Promise<DaemonPty
     // Legacy adapters intentionally do not respawn: respawning an old protocol
     // daemon from new code would recreate stale env semantics and can be less
     // predictable than letting the session fail if that old daemon dies.
+    // Why no historyPath: checkpoint-based persistence requires the getSnapshot
+    // RPC (protocol v4+). Pre-v4 daemons reject that call, so the checkpoint
+    // timer would silently discard every write. Omitting historyPath avoids
+    // wasted RPC round-trips. Pre-upgrade scrollback.bin files remain on disk
+    // and the history reader's fallback path can still cold-restore from them.
     adapters.push(
       new DaemonPtyAdapter({
         socketPath,
         tokenPath,
-        protocolVersion,
-        historyPath: getHistoryDir()
+        protocolVersion
       })
     )
   }

--- a/src/main/daemon/daemon-init.ts
+++ b/src/main/daemon/daemon-init.ts
@@ -212,8 +212,8 @@ export async function initDaemonPtyProvider(): Promise<void> {
 // separate process and survives app quit — sessions stay alive for warm
 // reattach on next launch. Leave history sessions marked "unclean" here so a
 // later daemon crash while Orca is closed is still recoverable on next launch.
-export function disconnectDaemon(): void {
-  adapter?.disconnectOnly()
+export async function disconnectDaemon(): Promise<void> {
+  await adapter?.disconnectOnly()
   adapter = null
 }
 

--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -434,7 +434,7 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       historyAdapter?.dispose()
     })
 
-    it('writes scrollback to disk on data events', async () => {
+    it('does not write to disk on individual data events (checkpoint-based)', async () => {
       historyAdapter = new DaemonPtyAdapter({ socketPath, tokenPath, historyPath: historyDir })
 
       const { id } = await historyAdapter.spawn({
@@ -447,11 +447,11 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       lastSubprocess._simulateData('hello from pty\r\n')
       await new Promise((r) => setTimeout(r, 50))
 
-      const scrollback = readFileSync(
-        join(historyDir, getHistorySessionDirName(id), 'scrollback.bin'),
-        'utf-8'
+      // Why: checkpoint-based persistence does not write on every data event.
+      // No scrollback.bin should exist — checkpoints write checkpoint.json on a timer.
+      expect(existsSync(join(historyDir, getHistorySessionDirName(id), 'scrollback.bin'))).toBe(
+        false
       )
-      expect(scrollback).toContain('hello from pty')
     })
 
     it('writes meta.json with endedAt on exit', async () => {
@@ -559,7 +559,7 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       expect(third.coldRestore).toBeUndefined()
     })
 
-    it('records post-cold-restore data to disk for future restores', async () => {
+    it('opens session for checkpointing after cold restore', async () => {
       const sessionId = 'post-restore-data'
       const sessionDir = join(historyDir, getHistorySessionDirName(sessionId))
       mkdirSync(sessionDir, { recursive: true })
@@ -581,24 +581,17 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       const result = await historyAdapter.spawn({ cols: 80, rows: 24, sessionId })
       expect(result.coldRestore).toBeDefined()
 
-      // Restored scrollback is seeded into the new history file immediately
-      const seeded = readFileSync(
-        join(historyDir, getHistorySessionDirName(sessionId), 'scrollback.bin'),
-        'utf-8'
-      )
-      expect(seeded).toContain('old output')
-
-      // Simulate new data arriving after cold restore
-      lastSubprocess._simulateData('new post-restore output\r\n')
       await new Promise((r) => setTimeout(r, 50))
 
-      // History should now contain both the seeded and new data
-      const scrollback = readFileSync(
-        join(historyDir, getHistorySessionDirName(sessionId), 'scrollback.bin'),
-        'utf-8'
+      // Why: checkpoint-based persistence opens the session for future
+      // checkpointing but does not seed scrollback.bin. New data is persisted
+      // via periodic checkpoint timer, not per-chunk appendData.
+      const meta = JSON.parse(
+        readFileSync(join(historyDir, getHistorySessionDirName(sessionId), 'meta.json'), 'utf-8')
       )
-      expect(scrollback).toContain('old output')
-      expect(scrollback).toContain('new post-restore output')
+      expect(meta.cwd).toBe('/tmp')
+      expect(meta.cols).toBe(80)
+      expect(meta.rows).toBe(24)
     })
 
     it('does not cold-restore for clean shutdown (endedAt set)', async () => {

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -157,11 +157,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
       return { id: sessionId, pid, coldRestore }
     }
 
-    // Why: openSession must run for both new sessions and warm reattaches.
-    // On reattach after app relaunch, the HistoryManager is a fresh instance
-    // with no in-memory writers. Without openSession, checkpoint() silently
-    // no-ops and the session has no crash-recovery data if the daemon dies.
-    if (this.historyManager) {
+    if (this.historyManager && result.isNew) {
       void this.historyManager
         .openSession(sessionId, {
           cwd: effectiveCwd ?? '',
@@ -169,6 +165,12 @@ export class DaemonPtyAdapter implements IPtyProvider {
           rows: effectiveRows
         })
         .catch((err) => console.warn('[history] openSession failed:', sessionId, err))
+    } else if (this.historyManager) {
+      // Why: on warm reattach after app relaunch, the HistoryManager is a
+      // fresh instance with no writers. registerWriter adds the writer
+      // without overwriting meta.json or deleting the existing checkpoint
+      // (which is the only valid recovery data until the next tick).
+      this.historyManager.registerWriter(sessionId)
     }
 
     const isReattach = !result.isNew
@@ -450,6 +452,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
             if (result.snapshot && this.historyManager) {
               return this.historyManager.checkpoint(sessionId, result.snapshot)
             }
+            return undefined
           })
           .catch((err) => console.warn('[history] checkpoint failed:', sessionId, err))
       )

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -142,19 +142,26 @@ export class DaemonPtyAdapter implements IPtyProvider {
       // scrollbackAnsi (rows above the viewport only) which excludes the alt
       // buffer. For normal sessions, use the full snapshot with rehydrate
       // sequences to restore terminal modes (colors, cursor position, etc).
+      // Why: scrollbackAnsi may be empty if the emulator hadn't accumulated
+      // scrollback before the alt-screen app launched. In that case, skip
+      // cold restore entirely rather than showing a blank terminal — no
+      // content is better than confusing the user with an empty restore.
       const isAltScreen = restoreInfo.modes.alternateScreen
       const scrollback = isAltScreen
-        ? restoreInfo.scrollbackAnsi
+        ? restoreInfo.scrollbackAnsi || null
         : restoreInfo.rehydrateSequences + restoreInfo.snapshotAnsi
-      const coldRestore = { scrollback, cwd: restoreInfo.cwd }
-      this.coldRestoreCache.set(sessionId, coldRestore)
       // Why: use registerWriter (not openSession) to avoid deleting the
       // existing checkpoint.json. If the revived daemon crashes again before
       // the next 5s tick, the checkpoint is the only recovery data available.
       if (this.historyManager) {
         this.historyManager.registerWriter(sessionId)
       }
-      return { id: sessionId, pid, coldRestore }
+      if (scrollback) {
+        const coldRestore = { scrollback, cwd: restoreInfo.cwd }
+        this.coldRestoreCache.set(sessionId, coldRestore)
+        return { id: sessionId, pid, coldRestore }
+      }
+      return { id: sessionId, pid }
     }
 
     if (this.historyManager && result.isNew) {
@@ -320,6 +327,12 @@ export class DaemonPtyAdapter implements IPtyProvider {
         killed.push(session.sessionId)
       } else {
         alive.push(session.sessionId)
+        // Why: background sessions discovered here may produce output before
+        // the user reattaches their pane. Without adding them to the checkpoint
+        // set, disconnectOnly()'s final checkpoint would skip them, leaving
+        // stale recovery data if the daemon later crashes.
+        this.activeSessionIds.add(session.sessionId)
+        this.historyManager?.registerWriter(session.sessionId)
       }
     }
 

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -63,6 +63,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
   private coldRestoreCache = new Map<string, { scrollback: string; cwd: string }>()
   private activeSessionIds = new Set<string>()
   private checkpointInterval: ReturnType<typeof setInterval> | null = null
+  private checkpointInFlight: Promise<void> | null = null
   private static CHECKPOINT_INTERVAL_MS = 5_000
 
   constructor(opts: DaemonPtyAdapterOptions) {
@@ -422,6 +423,12 @@ export class DaemonPtyAdapter implements IPtyProvider {
       clearInterval(this.checkpointInterval)
       this.checkpointInterval = null
     }
+    // Why: wait for any in-flight timer pass to finish before starting
+    // the final checkpoint. Otherwise both passes race on the shared tmp
+    // file, risking ENOENT on rename and disabling future writes.
+    if (this.checkpointInFlight) {
+      await this.checkpointInFlight
+    }
     // Why: without a final checkpoint, sessions opened after the last timer
     // tick have no checkpoint.json on disk. If the detached daemon later
     // dies, detectColdRestore finds nothing to restore from. Must await
@@ -444,7 +451,16 @@ export class DaemonPtyAdapter implements IPtyProvider {
       return
     }
     this.checkpointInterval = setInterval(() => {
-      void this.checkpointAllSessions()
+      // Why: if the previous pass is still in-flight (slow RPC or disk),
+      // skip this tick. Overlapping passes race on the shared tmp file
+      // in checkpoint(), and a lost rename triggers handleWriteError which
+      // permanently disables the session's history writes.
+      if (this.checkpointInFlight) {
+        return
+      }
+      this.checkpointInFlight = this.checkpointAllSessions().finally(() => {
+        this.checkpointInFlight = null
+      })
     }, DaemonPtyAdapter.CHECKPOINT_INTERVAL_MS)
   }
 

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -8,7 +8,12 @@ import { DaemonClient } from './client'
 import { HistoryManager } from './history-manager'
 import { HistoryReader } from './history-reader'
 import { supportsPtyStartupBarrier } from './shell-ready'
-import type { CreateOrAttachResult, DaemonEvent, ListSessionsResult } from './types'
+import type {
+  CreateOrAttachResult,
+  DaemonEvent,
+  GetSnapshotResult,
+  ListSessionsResult
+} from './types'
 import type { IPtyProvider, PtySpawnOptions, PtySpawnResult } from '../providers/types'
 
 export type DaemonPtyAdapterOptions = {
@@ -56,6 +61,9 @@ export class DaemonPtyAdapter implements IPtyProvider {
   // mount → ??? The sticky cache returns the same cold restore data on the
   // second mount until the renderer explicitly acknowledges it.
   private coldRestoreCache = new Map<string, { scrollback: string; cwd: string }>()
+  private activeSessionIds = new Set<string>()
+  private checkpointInterval: ReturnType<typeof setInterval> | null = null
+  private static CHECKPOINT_INTERVAL_MS = 5_000
 
   constructor(opts: DaemonPtyAdapterOptions) {
     this.client = new DaemonClient({
@@ -122,23 +130,21 @@ export class DaemonPtyAdapter implements IPtyProvider {
       return { id: sessionId, pid, coldRestore: cachedRestore }
     }
 
+    this.activeSessionIds.add(sessionId)
+
     // Cold restore: daemon created a new session but disk history shows
     // an unclean shutdown → return saved scrollback so the renderer can
-    // display the previous terminal content. Must run BEFORE openSession
-    // which would overwrite the saved history files.
+    // display the previous terminal content.
     if (result.isNew && restoreInfo) {
-      const coldRestore = { scrollback: restoreInfo.scrollback, cwd: restoreInfo.cwd }
+      const scrollback = restoreInfo.rehydrateSequences + restoreInfo.snapshotAnsi
+      const coldRestore = { scrollback, cwd: restoreInfo.cwd }
       this.coldRestoreCache.set(sessionId, coldRestore)
-      // Why: seed the reopened history with the recovered metadata, not the
-      // renderer's transient mount-time size, so a second crash restores the
-      // same terminal context the daemon just revived.
       if (this.historyManager) {
         void this.historyManager
           .openSession(sessionId, {
             cwd: restoreInfo.cwd,
             cols: restoreInfo.cols,
-            rows: restoreInfo.rows,
-            initialScrollback: restoreInfo.scrollback
+            rows: restoreInfo.rows
           })
           .catch((err) => console.warn('[history] openSession failed:', sessionId, err))
       }
@@ -150,8 +156,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
         .openSession(sessionId, {
           cwd: effectiveCwd ?? '',
           cols: effectiveCols,
-          rows: effectiveRows,
-          initialScrollback: result.snapshot?.snapshotAnsi
+          rows: effectiveRows
         })
         .catch((err) => console.warn('[history] openSession failed:', sessionId, err))
     }
@@ -194,6 +199,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
 
   async shutdown(id: string, _immediate: boolean): Promise<void> {
     await this.client.request('kill', { sessionId: id })
+    this.activeSessionIds.delete(id)
     this.initialCwds.delete(id)
     // Why: user explicitly closed this terminal — clean up disk history
     // so it doesn't trigger a false cold restore on next launch.
@@ -363,8 +369,15 @@ export class DaemonPtyAdapter implements IPtyProvider {
   }
 
   dispose(): void {
+    if (this.checkpointInterval) {
+      clearInterval(this.checkpointInterval)
+      this.checkpointInterval = null
+    }
     this.removeEventListener?.()
     this.removeEventListener = null
+    // Why: final checkpoints are written daemon-side in TerminalHost.dispose()
+    // which has direct access to sessions. The adapter only marks sessions as
+    // cleanly ended here so they don't trigger false cold restores.
     if (this.historyManager) {
       void this.historyManager
         .dispose()
@@ -378,6 +391,10 @@ export class DaemonPtyAdapter implements IPtyProvider {
   // restore. disconnectOnly() leaves history files in unclean state so
   // the next launch detects them as crash-recoverable.
   disconnectOnly(): void {
+    if (this.checkpointInterval) {
+      clearInterval(this.checkpointInterval)
+      this.checkpointInterval = null
+    }
     this.removeEventListener?.()
     this.removeEventListener = null
     this.client.disconnect()
@@ -386,6 +403,35 @@ export class DaemonPtyAdapter implements IPtyProvider {
   private async ensureConnected(): Promise<void> {
     await this.client.ensureConnected()
     this.setupEventRouting()
+    this.startCheckpointTimer()
+  }
+
+  private startCheckpointTimer(): void {
+    if (this.checkpointInterval || !this.historyManager) {
+      return
+    }
+    this.checkpointInterval = setInterval(() => {
+      this.checkpointAllSessions()
+    }, DaemonPtyAdapter.CHECKPOINT_INTERVAL_MS)
+  }
+
+  // Why: the adapter runs in the Electron main process and does not have direct
+  // access to daemon Session objects. It calls the getSnapshot RPC over the
+  // daemon socket per session.
+  private checkpointAllSessions(): void {
+    if (!this.historyManager) {
+      return
+    }
+    for (const sessionId of this.activeSessionIds) {
+      void this.client
+        .request<GetSnapshotResult>('getSnapshot', { sessionId })
+        .then((result) => {
+          if (result.snapshot && this.historyManager) {
+            return this.historyManager.checkpoint(sessionId, result.snapshot)
+          }
+        })
+        .catch((err) => console.warn('[history] checkpoint failed:', sessionId, err))
+    }
   }
 
   // Why: when the daemon process dies, operations fail with ENOENT (socket
@@ -431,16 +477,12 @@ export class DaemonPtyAdapter implements IPtyProvider {
       }
 
       if (event.event === 'data') {
-        if (this.historyManager) {
-          void this.historyManager
-            .appendData(event.sessionId, event.payload.data)
-            .catch((err) => console.warn('[history] appendData failed:', event.sessionId, err))
-        }
         // oxlint-disable-next-line unicorn/no-useless-spread -- copy-safe: listeners may unsubscribe during iteration
         for (const listener of [...this.dataListeners]) {
           listener({ id: event.sessionId, data: event.payload.data })
         }
       } else if (event.event === 'exit') {
+        this.activeSessionIds.delete(event.sessionId)
         if (this.historyManager) {
           void this.historyManager
             .closeSession(event.sessionId, event.payload.code)

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -8,11 +8,12 @@ import { DaemonClient } from './client'
 import { HistoryManager } from './history-manager'
 import { HistoryReader } from './history-reader'
 import { supportsPtyStartupBarrier } from './shell-ready'
-import type {
-  CreateOrAttachResult,
-  DaemonEvent,
-  GetSnapshotResult,
-  ListSessionsResult
+import {
+  PROTOCOL_VERSION,
+  type CreateOrAttachResult,
+  type DaemonEvent,
+  type GetSnapshotResult,
+  type ListSessionsResult
 } from './types'
 import type { IPtyProvider, PtySpawnOptions, PtySpawnResult } from '../providers/types'
 
@@ -64,6 +65,9 @@ export class DaemonPtyAdapter implements IPtyProvider {
   private activeSessionIds = new Set<string>()
   private checkpointInterval: ReturnType<typeof setInterval> | null = null
   private checkpointInFlight: Promise<void> | null = null
+  // Why: checkpoint-based persistence requires the getSnapshot RPC (v4+).
+  // Legacy daemons reject it, causing noisy log spam every 5 seconds.
+  private supportsCheckpoints: boolean
   private static CHECKPOINT_INTERVAL_MS = 5_000
 
   constructor(opts: DaemonPtyAdapterOptions) {
@@ -75,6 +79,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
     this.historyManager = opts.historyPath ? new HistoryManager(opts.historyPath) : null
     this.historyReader = opts.historyPath ? new HistoryReader(opts.historyPath) : null
     this.respawnFn = opts.respawn ?? null
+    this.supportsCheckpoints = (opts.protocolVersion ?? PROTOCOL_VERSION) >= 4
   }
 
   getHistoryManager(): HistoryManager | null {
@@ -447,7 +452,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
   }
 
   private startCheckpointTimer(): void {
-    if (this.checkpointInterval || !this.historyManager) {
+    if (this.checkpointInterval || !this.historyManager || !this.supportsCheckpoints) {
       return
     }
     this.checkpointInterval = setInterval(() => {

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -157,7 +157,11 @@ export class DaemonPtyAdapter implements IPtyProvider {
       return { id: sessionId, pid, coldRestore }
     }
 
-    if (this.historyManager && result.isNew) {
+    // Why: openSession must run for both new sessions and warm reattaches.
+    // On reattach after app relaunch, the HistoryManager is a fresh instance
+    // with no in-memory writers. Without openSession, checkpoint() silently
+    // no-ops and the session has no crash-recovery data if the daemon dies.
+    if (this.historyManager) {
       void this.historyManager
         .openSession(sessionId, {
           cwd: effectiveCwd ?? '',

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -137,22 +137,22 @@ export class DaemonPtyAdapter implements IPtyProvider {
     // display the previous terminal content.
     if (result.isNew && restoreInfo) {
       // Why: if the checkpoint was captured while an alternate-screen app
-      // (vim, less, htop) was active, rehydrateSequences contains \x1b[?1049h
-      // which would reopen the alternate buffer in a fresh shell. The old
-      // scrollback fallback explicitly truncated alt-screen content; replaying
-      // it here would leave the terminal stuck behind stale TUI content.
-      const prefix = restoreInfo.modes.alternateScreen ? '' : restoreInfo.rehydrateSequences
-      const scrollback = prefix + restoreInfo.snapshotAnsi
+      // (vim, less, htop) was active, snapshotAnsi is the alt buffer content.
+      // Replaying that into a fresh shell would show stale TUI content. Use
+      // scrollbackAnsi (rows above the viewport only) which excludes the alt
+      // buffer. For normal sessions, use the full snapshot with rehydrate
+      // sequences to restore terminal modes (colors, cursor position, etc).
+      const isAltScreen = restoreInfo.modes.alternateScreen
+      const scrollback = isAltScreen
+        ? restoreInfo.scrollbackAnsi
+        : restoreInfo.rehydrateSequences + restoreInfo.snapshotAnsi
       const coldRestore = { scrollback, cwd: restoreInfo.cwd }
       this.coldRestoreCache.set(sessionId, coldRestore)
+      // Why: use registerWriter (not openSession) to avoid deleting the
+      // existing checkpoint.json. If the revived daemon crashes again before
+      // the next 5s tick, the checkpoint is the only recovery data available.
       if (this.historyManager) {
-        void this.historyManager
-          .openSession(sessionId, {
-            cwd: restoreInfo.cwd,
-            cols: restoreInfo.cols,
-            rows: restoreInfo.rows
-          })
-          .catch((err) => console.warn('[history] openSession failed:', sessionId, err))
+        this.historyManager.registerWriter(sessionId)
       }
       return { id: sessionId, pid, coldRestore }
     }

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -390,11 +390,17 @@ export class DaemonPtyAdapter implements IPtyProvider {
   // dispose() writes endedAt for all sessions, which would prevent cold
   // restore. disconnectOnly() leaves history files in unclean state so
   // the next launch detects them as crash-recoverable.
+  // We write a final checkpoint before disconnecting so that if the daemon
+  // later crashes while Orca is closed, checkpoint.json has recovery data.
   disconnectOnly(): void {
     if (this.checkpointInterval) {
       clearInterval(this.checkpointInterval)
       this.checkpointInterval = null
     }
+    // Why: without a final checkpoint, sessions opened after the last timer
+    // tick have no checkpoint.json on disk. If the detached daemon later
+    // dies, detectColdRestore finds nothing to restore from.
+    this.checkpointAllSessions()
     this.removeEventListener?.()
     this.removeEventListener = null
     this.client.disconnect()

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -136,7 +136,13 @@ export class DaemonPtyAdapter implements IPtyProvider {
     // an unclean shutdown → return saved scrollback so the renderer can
     // display the previous terminal content.
     if (result.isNew && restoreInfo) {
-      const scrollback = restoreInfo.rehydrateSequences + restoreInfo.snapshotAnsi
+      // Why: if the checkpoint was captured while an alternate-screen app
+      // (vim, less, htop) was active, rehydrateSequences contains \x1b[?1049h
+      // which would reopen the alternate buffer in a fresh shell. The old
+      // scrollback fallback explicitly truncated alt-screen content; replaying
+      // it here would leave the terminal stuck behind stale TUI content.
+      const prefix = restoreInfo.modes.alternateScreen ? '' : restoreInfo.rehydrateSequences
+      const scrollback = prefix + restoreInfo.snapshotAnsi
       const coldRestore = { scrollback, cwd: restoreInfo.cwd }
       this.coldRestoreCache.set(sessionId, coldRestore)
       if (this.historyManager) {
@@ -392,15 +398,17 @@ export class DaemonPtyAdapter implements IPtyProvider {
   // the next launch detects them as crash-recoverable.
   // We write a final checkpoint before disconnecting so that if the daemon
   // later crashes while Orca is closed, checkpoint.json has recovery data.
-  disconnectOnly(): void {
+  async disconnectOnly(): Promise<void> {
     if (this.checkpointInterval) {
       clearInterval(this.checkpointInterval)
       this.checkpointInterval = null
     }
     // Why: without a final checkpoint, sessions opened after the last timer
     // tick have no checkpoint.json on disk. If the detached daemon later
-    // dies, detectColdRestore finds nothing to restore from.
-    this.checkpointAllSessions()
+    // dies, detectColdRestore finds nothing to restore from. Must await
+    // before disconnecting — fire-and-forget would race with client.disconnect()
+    // and the pending getSnapshot RPCs would be rejected.
+    await this.checkpointAllSessions()
     this.removeEventListener?.()
     this.removeEventListener = null
     this.client.disconnect()
@@ -417,27 +425,32 @@ export class DaemonPtyAdapter implements IPtyProvider {
       return
     }
     this.checkpointInterval = setInterval(() => {
-      this.checkpointAllSessions()
+      void this.checkpointAllSessions()
     }, DaemonPtyAdapter.CHECKPOINT_INTERVAL_MS)
   }
 
   // Why: the adapter runs in the Electron main process and does not have direct
   // access to daemon Session objects. It calls the getSnapshot RPC over the
-  // daemon socket per session.
-  private checkpointAllSessions(): void {
+  // daemon socket per session. Returns a promise that resolves when all
+  // checkpoint writes complete (callers that don't need to wait can void it).
+  private async checkpointAllSessions(): Promise<void> {
     if (!this.historyManager) {
       return
     }
+    const promises: Promise<void>[] = []
     for (const sessionId of this.activeSessionIds) {
-      void this.client
-        .request<GetSnapshotResult>('getSnapshot', { sessionId })
-        .then((result) => {
-          if (result.snapshot && this.historyManager) {
-            return this.historyManager.checkpoint(sessionId, result.snapshot)
-          }
-        })
-        .catch((err) => console.warn('[history] checkpoint failed:', sessionId, err))
+      promises.push(
+        this.client
+          .request<GetSnapshotResult>('getSnapshot', { sessionId })
+          .then((result) => {
+            if (result.snapshot && this.historyManager) {
+              return this.historyManager.checkpoint(sessionId, result.snapshot)
+            }
+          })
+          .catch((err) => console.warn('[history] checkpoint failed:', sessionId, err))
+      )
     }
+    await Promise.all(promises)
   }
 
   // Why: when the daemon process dies, operations fail with ENOENT (socket

--- a/src/main/daemon/daemon-pty-router.test.ts
+++ b/src/main/daemon/daemon-pty-router.test.ts
@@ -73,7 +73,7 @@ function createAdapter(
     clearTombstone: vi.fn(),
     reconcileOnStartup: vi.fn(async () => reconcileResult ?? { alive: sessions, killed: [] }),
     dispose: vi.fn(),
-    disconnectOnly: vi.fn(),
+    disconnectOnly: vi.fn(async () => {}),
     emitData: (id: string, data: string) => {
       for (const listener of dataListeners) {
         listener({ id, data })

--- a/src/main/daemon/daemon-pty-router.ts
+++ b/src/main/daemon/daemon-pty-router.ts
@@ -180,13 +180,11 @@ export class DaemonPtyRouter implements IPtyProvider {
     }
   }
 
-  disconnectOnly(): void {
+  async disconnectOnly(): Promise<void> {
     for (const unsubscribe of this.unsubscribers.splice(0)) {
       unsubscribe()
     }
-    for (const adapter of this.allAdapters()) {
-      adapter.disconnectOnly()
-    }
+    await Promise.all([...this.allAdapters()].map((adapter) => adapter.disconnectOnly()))
   }
 
   private adapterFor(sessionId: string): DaemonPtyAdapter {

--- a/src/main/daemon/daemon-server.ts
+++ b/src/main/daemon/daemon-server.ts
@@ -280,6 +280,9 @@ export class DaemonServer {
       case 'listSessions':
         return { sessions: this.host.listSessions() }
 
+      case 'getSnapshot':
+        return { snapshot: this.host.getSnapshot(request.payload.sessionId) }
+
       case 'ping':
         return { pong: true }
 

--- a/src/main/daemon/history-manager.test.ts
+++ b/src/main/daemon/history-manager.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'os'
 import { join } from 'path'
 import { mkdtempSync, rmSync, readFileSync, existsSync, chmodSync } from 'fs'
 import { HistoryManager } from './history-manager'
+import type { TerminalSnapshot, TerminalModes } from './types'
 import { getHistorySessionDirName } from './history-paths'
 
 function createTestDir(): string {
@@ -11,6 +12,27 @@ function createTestDir(): string {
 
 function sessionPath(baseDir: string, sessionId: string, file: string): string {
   return join(baseDir, getHistorySessionDirName(sessionId), file)
+}
+
+const defaultModes: TerminalModes = {
+  bracketedPaste: false,
+  mouseTracking: false,
+  applicationCursor: false,
+  alternateScreen: false
+}
+
+function makeSnapshot(overrides: Partial<TerminalSnapshot> = {}): TerminalSnapshot {
+  return {
+    snapshotAnsi: 'hello world\r\n',
+    scrollbackAnsi: '',
+    rehydrateSequences: '',
+    cwd: '/tmp',
+    modes: defaultModes,
+    cols: 80,
+    rows: 24,
+    scrollbackLines: 0,
+    ...overrides
+  }
 }
 
 describe('HistoryManager', () => {
@@ -43,66 +65,89 @@ describe('HistoryManager', () => {
       expect(meta.exitCode).toBeNull()
     })
 
-    it('creates scrollback.bin file', async () => {
+    it('creates session directory', async () => {
       await mgr.openSession('sess-1', { cwd: '/tmp', cols: 120, rows: 40 })
 
-      const scrollbackPath = sessionPath(dir, 'sess-1', 'scrollback.bin')
-      expect(existsSync(scrollbackPath)).toBe(true)
-    })
-
-    it('seeds scrollback with initial snapshot', async () => {
-      await mgr.openSession('sess-1', {
-        cwd: '/tmp',
-        cols: 80,
-        rows: 24,
-        initialScrollback: 'previous output\r\n'
-      })
-
-      const data = readFileSync(sessionPath(dir, 'sess-1', 'scrollback.bin'), 'utf-8')
-      expect(data).toBe('previous output\r\n')
+      const sessionDir = join(dir, getHistorySessionDirName('sess-1'))
+      expect(existsSync(sessionDir)).toBe(true)
     })
   })
 
-  describe('appendData', () => {
-    it('appends PTY output to scrollback.bin', async () => {
+  describe('checkpoint', () => {
+    it('writes checkpoint.json with snapshot data', async () => {
       await mgr.openSession('sess-1', { cwd: '/tmp', cols: 80, rows: 24 })
 
-      await mgr.appendData('sess-1', 'hello ')
-      await mgr.appendData('sess-1', 'world\r\n')
+      const snapshot = makeSnapshot({ snapshotAnsi: 'terminal content\r\n' })
+      await mgr.checkpoint('sess-1', snapshot)
 
-      const data = readFileSync(sessionPath(dir, 'sess-1', 'scrollback.bin'), 'utf-8')
-      expect(data).toBe('hello world\r\n')
+      const cpPath = sessionPath(dir, 'sess-1', 'checkpoint.json')
+      expect(existsSync(cpPath)).toBe(true)
+
+      const data = JSON.parse(readFileSync(cpPath, 'utf-8'))
+      expect(data.snapshotAnsi).toBe('terminal content\r\n')
+      expect(data.cols).toBe(80)
+      expect(data.rows).toBe(24)
+      expect(data.checkpointedAt).toBeDefined()
     })
 
-    it('ignores data for unknown sessions', async () => {
-      // Should not throw
-      await mgr.appendData('nonexistent', 'data')
+    it('overwrites previous checkpoint atomically', async () => {
+      await mgr.openSession('sess-1', { cwd: '/tmp', cols: 80, rows: 24 })
+
+      await mgr.checkpoint('sess-1', makeSnapshot({ snapshotAnsi: 'first' }))
+      await mgr.checkpoint('sess-1', makeSnapshot({ snapshotAnsi: 'second' }))
+
+      const data = JSON.parse(readFileSync(sessionPath(dir, 'sess-1', 'checkpoint.json'), 'utf-8'))
+      expect(data.snapshotAnsi).toBe('second')
     })
 
-    it('persists the latest cwd from OSC-7 updates', async () => {
-      await mgr.openSession('sess-1', { cwd: '/tmp/original', cols: 80, rows: 24 })
+    it('preserves terminal modes in checkpoint', async () => {
+      await mgr.openSession('sess-1', { cwd: '/tmp', cols: 80, rows: 24 })
 
-      await mgr.appendData('sess-1', '\x1b]7;file:///tmp/updated%20cwd\x07prompt$ ')
-
-      const meta = mgr.readMeta('sess-1')
-      expect(meta?.cwd).toBe('/tmp/updated cwd')
-    })
-
-    it('persists Windows UNC cwd updates from OSC-7', async () => {
-      const platform = Object.getOwnPropertyDescriptor(process, 'platform')
-      Object.defineProperty(process, 'platform', { value: 'win32' })
-
-      try {
-        await mgr.openSession('sess-1', { cwd: 'C:\\start', cols: 80, rows: 24 })
-        await mgr.appendData('sess-1', '\x1b]7;file://server/share/project\x07')
-      } finally {
-        if (platform) {
-          Object.defineProperty(process, 'platform', platform)
-        }
+      const modes: TerminalModes = {
+        bracketedPaste: true,
+        mouseTracking: false,
+        applicationCursor: true,
+        alternateScreen: false
       }
+      await mgr.checkpoint('sess-1', makeSnapshot({ modes }))
 
-      const meta = mgr.readMeta('sess-1')
-      expect(meta?.cwd).toBe('\\\\server\\share\\project')
+      const data = JSON.parse(readFileSync(sessionPath(dir, 'sess-1', 'checkpoint.json'), 'utf-8'))
+      expect(data.modes.bracketedPaste).toBe(true)
+      expect(data.modes.applicationCursor).toBe(true)
+    })
+
+    it('preserves rehydrateSequences in checkpoint', async () => {
+      await mgr.openSession('sess-1', { cwd: '/tmp', cols: 80, rows: 24 })
+
+      await mgr.checkpoint('sess-1', makeSnapshot({ rehydrateSequences: '\x1b[?2004h\x1b[?1h' }))
+
+      const data = JSON.parse(readFileSync(sessionPath(dir, 'sess-1', 'checkpoint.json'), 'utf-8'))
+      expect(data.rehydrateSequences).toBe('\x1b[?2004h\x1b[?1h')
+    })
+
+    it('ignores checkpoint for unknown sessions', async () => {
+      await mgr.checkpoint('nonexistent', makeSnapshot())
+    })
+
+    it('ignores checkpoint for disabled sessions', async () => {
+      await mgr.openSession('sess-1', { cwd: '/tmp', cols: 80, rows: 24 })
+
+      const cpPath = sessionPath(dir, 'sess-1', 'checkpoint.json')
+      chmodSync(join(dir, getHistorySessionDirName('sess-1')), 0o555)
+
+      await mgr.checkpoint('sess-1', makeSnapshot())
+
+      chmodSync(join(dir, getHistorySessionDirName('sess-1')), 0o755)
+
+      await mgr.checkpoint('sess-1', makeSnapshot({ snapshotAnsi: 'after-error' }))
+      expect(existsSync(cpPath)).toBe(false)
+    })
+
+    it('does not write scrollback.bin', async () => {
+      await mgr.openSession('sess-1', { cwd: '/tmp', cols: 80, rows: 24 })
+      await mgr.checkpoint('sess-1', makeSnapshot())
+
+      expect(existsSync(sessionPath(dir, 'sess-1', 'scrollback.bin'))).toBe(false)
     })
   })
 
@@ -116,112 +161,8 @@ describe('HistoryManager', () => {
       expect(meta.exitCode).toBe(0)
     })
 
-    it('flushes pending data before closing', async () => {
-      await mgr.openSession('sess-1', { cwd: '/tmp', cols: 80, rows: 24 })
-      await mgr.appendData('sess-1', 'final output')
-      await mgr.closeSession('sess-1', 1)
-
-      const data = readFileSync(sessionPath(dir, 'sess-1', 'scrollback.bin'), 'utf-8')
-      expect(data).toBe('final output')
-    })
-
-    it('flushes buffered partial escape on close', async () => {
-      await mgr.openSession('sess-1', { cwd: '/tmp', cols: 80, rows: 24 })
-      // Send data ending with a partial CSI 3J prefix — gets held in buffer
-      await mgr.appendData('sess-1', 'prompt$ \x1b[')
-      await mgr.closeSession('sess-1', 0)
-
-      const data = readFileSync(sessionPath(dir, 'sess-1', 'scrollback.bin'), 'utf-8')
-      expect(data).toBe('prompt$ \x1b[')
-    })
-
     it('ignores close for unknown sessions', async () => {
-      // Should not throw
       await mgr.closeSession('nonexistent', 0)
-    })
-  })
-
-  describe('clear-scrollback detection (CSI 3J)', () => {
-    it('resets scrollback.bin when CSI 3J is detected', async () => {
-      await mgr.openSession('sess-1', { cwd: '/tmp', cols: 80, rows: 24 })
-
-      await mgr.appendData('sess-1', 'old output\r\n')
-      // CSI 3J = \x1b[3J (erase scrollback)
-      await mgr.appendData('sess-1', '\x1b[3J')
-      await mgr.appendData('sess-1', 'new output\r\n')
-
-      const data = readFileSync(sessionPath(dir, 'sess-1', 'scrollback.bin'), 'utf-8')
-      expect(data).not.toContain('old output')
-      expect(data).toContain('new output')
-    })
-
-    it('handles multiple CSI 3J in one chunk — resets to content after the last', async () => {
-      await mgr.openSession('sess-1', { cwd: '/tmp', cols: 80, rows: 24 })
-
-      await mgr.appendData('sess-1', 'old\x1b[3Jmiddle\x1b[3Jfresh\r\n')
-
-      const data = readFileSync(sessionPath(dir, 'sess-1', 'scrollback.bin'), 'utf-8')
-      expect(data).not.toContain('old')
-      expect(data).not.toContain('middle')
-      expect(data).toBe('fresh\r\n')
-    })
-
-    it('handles CSI 3J split across chunks', async () => {
-      await mgr.openSession('sess-1', { cwd: '/tmp', cols: 80, rows: 24 })
-
-      await mgr.appendData('sess-1', 'old stuff\r\n')
-      await mgr.appendData('sess-1', '\x1b[3')
-      await mgr.appendData('sess-1', 'J')
-      await mgr.appendData('sess-1', 'fresh\r\n')
-
-      const data = readFileSync(sessionPath(dir, 'sess-1', 'scrollback.bin'), 'utf-8')
-      expect(data).not.toContain('old stuff')
-      expect(data).toContain('fresh')
-    })
-
-    it('buffers trailing partial CSI 3J in afterClear content', async () => {
-      await mgr.openSession('sess-1', { cwd: '/tmp', cols: 80, rows: 24 })
-
-      // CSI 3J followed by content that ends with a partial CSI 3J prefix
-      await mgr.appendData('sess-1', 'old\x1b[3Jnew-data\x1b[')
-      // Complete the sequence — should trigger a second reset
-      await mgr.appendData('sess-1', '3Jfinal')
-
-      const data = readFileSync(sessionPath(dir, 'sess-1', 'scrollback.bin'), 'utf-8')
-      expect(data).not.toContain('old')
-      expect(data).not.toContain('new-data')
-      expect(data).toBe('final')
-    })
-
-    it('resets scrollback on CSI 3J even after 5MB cap is hit', async () => {
-      await mgr.openSession('sess-1', { cwd: '/tmp', cols: 80, rows: 24 })
-
-      const fiveMB = 'x'.repeat(5 * 1024 * 1024)
-      await mgr.appendData('sess-1', fiveMB)
-      // Cap is hit — normal writes are blocked
-      await mgr.appendData('sess-1', 'blocked')
-      let data = readFileSync(sessionPath(dir, 'sess-1', 'scrollback.bin'), 'utf-8')
-      expect(data).not.toContain('blocked')
-
-      // CSI 3J should still reset, allowing new writes
-      await mgr.appendData('sess-1', '\x1b[3Jafter-clear')
-      data = readFileSync(sessionPath(dir, 'sess-1', 'scrollback.bin'), 'utf-8')
-      expect(data).toBe('after-clear')
-    })
-  })
-
-  describe('5MB size cap', () => {
-    it('stops appending after 5MB', async () => {
-      await mgr.openSession('sess-1', { cwd: '/tmp', cols: 80, rows: 24 })
-
-      // Write 5MB + some extra
-      const chunk = 'x'.repeat(1024 * 1024) // 1MB
-      for (let i = 0; i < 6; i++) {
-        await mgr.appendData('sess-1', chunk)
-      }
-
-      const stats = readFileSync(sessionPath(dir, 'sess-1', 'scrollback.bin'))
-      expect(stats.length).toBeLessThanOrEqual(5 * 1024 * 1024 + 1024) // some tolerance
     })
   })
 
@@ -230,46 +171,33 @@ describe('HistoryManager', () => {
       await mgr.openSession('a', { cwd: '/a', cols: 80, rows: 24 })
       await mgr.openSession('b', { cwd: '/b', cols: 120, rows: 40 })
 
-      await mgr.appendData('a', 'session-a')
-      await mgr.appendData('b', 'session-b')
+      await mgr.checkpoint('a', makeSnapshot({ snapshotAnsi: 'session-a' }))
+      await mgr.checkpoint('b', makeSnapshot({ snapshotAnsi: 'session-b' }))
 
-      const dataA = readFileSync(sessionPath(dir, 'a', 'scrollback.bin'), 'utf-8')
-      const dataB = readFileSync(sessionPath(dir, 'b', 'scrollback.bin'), 'utf-8')
+      const dataA = JSON.parse(readFileSync(sessionPath(dir, 'a', 'checkpoint.json'), 'utf-8'))
+      const dataB = JSON.parse(readFileSync(sessionPath(dir, 'b', 'checkpoint.json'), 'utf-8'))
 
-      expect(dataA).toBe('session-a')
-      expect(dataB).toBe('session-b')
+      expect(dataA.snapshotAnsi).toBe('session-a')
+      expect(dataB.snapshotAnsi).toBe('session-b')
     })
   })
 
   describe('dispose', () => {
     it('writes endedAt for open sessions to prevent false cold-restore', async () => {
       await mgr.openSession('sess-1', { cwd: '/tmp', cols: 80, rows: 24 })
-      await mgr.appendData('sess-1', 'data')
+      await mgr.checkpoint('sess-1', makeSnapshot())
       await mgr.dispose()
-
-      const data = readFileSync(sessionPath(dir, 'sess-1', 'scrollback.bin'), 'utf-8')
-      expect(data).toBe('data')
 
       const meta = JSON.parse(readFileSync(sessionPath(dir, 'sess-1', 'meta.json'), 'utf-8'))
       expect(meta.endedAt).not.toBeNull()
       expect(meta.exitCode).toBeNull()
-    })
-
-    it('flushes buffered partial escape sequences', async () => {
-      await mgr.openSession('partial', { cwd: '/tmp', cols: 80, rows: 24 })
-      // Send data ending with a partial CSI 3J prefix
-      await mgr.appendData('partial', 'hello\x1b')
-      await mgr.dispose()
-
-      const data = readFileSync(sessionPath(dir, 'partial', 'scrollback.bin'), 'utf-8')
-      expect(data).toBe('hello\x1b')
     })
   })
 
   describe('removeSession', () => {
     it('deletes session directory from disk', async () => {
       await mgr.openSession('sess-1', { cwd: '/tmp', cols: 80, rows: 24 })
-      await mgr.appendData('sess-1', 'data')
+      await mgr.checkpoint('sess-1', makeSnapshot())
       await mgr.closeSession('sess-1', 0)
 
       await mgr.removeSession('sess-1')
@@ -306,48 +234,37 @@ describe('HistoryManager', () => {
     })
   })
 
-  describe('disk-full handling', () => {
+  describe('error handling', () => {
     it('disables writes after fs error and does not throw', async () => {
       await mgr.openSession('disk-full', { cwd: '/tmp', cols: 80, rows: 24 })
-      await mgr.appendData('disk-full', 'before-error')
 
-      // Make scrollback file read-only to trigger write error
-      const scrollbackPath = sessionPath(dir, 'disk-full', 'scrollback.bin')
-      chmodSync(scrollbackPath, 0o444)
+      const sessionDir = join(dir, getHistorySessionDirName('disk-full'))
+      chmodSync(sessionDir, 0o555)
 
-      // Should not throw — error is caught and session is disabled
-      await mgr.appendData('disk-full', 'failing-write')
+      await mgr.checkpoint('disk-full', makeSnapshot())
 
-      // Restore permissions so we can read and clean up
-      chmodSync(scrollbackPath, 0o644)
+      chmodSync(sessionDir, 0o755)
 
-      // Subsequent writes were skipped because session was disabled
-      const content = readFileSync(scrollbackPath, 'utf-8')
-      expect(content).toBe('before-error')
+      await mgr.checkpoint('disk-full', makeSnapshot({ snapshotAnsi: 'after-error' }))
+      expect(existsSync(sessionPath(dir, 'disk-full', 'checkpoint.json'))).toBe(false)
     })
 
     it('disables writes after fs error on openSession', async () => {
-      // Make base dir read-only so mkdirSync fails
       chmodSync(dir, 0o555)
 
-      // Should not throw
       await mgr.openSession('disk-full-open', { cwd: '/tmp', cols: 80, rows: 24 })
 
-      // Restore permissions for cleanup
       chmodSync(dir, 0o755)
 
-      // Session writer was never registered, so appendData is a no-op
-      await mgr.appendData('disk-full-open', 'data-after-failed-open')
+      await mgr.checkpoint('disk-full-open', makeSnapshot())
     })
 
-    it('does not throw on closeSession disk error (prevents false cold-restore)', async () => {
+    it('does not throw on closeSession disk error', async () => {
       await mgr.openSession('close-err', { cwd: '/tmp', cols: 80, rows: 24 })
 
-      // Make meta.json read-only so updateMeta's writeFileSync fails
       const metaPath = sessionPath(dir, 'close-err', 'meta.json')
       chmodSync(metaPath, 0o444)
 
-      // Should not throw
       await mgr.closeSession('close-err', 0)
 
       chmodSync(metaPath, 0o644)
@@ -360,14 +277,13 @@ describe('HistoryManager', () => {
       })
 
       await mgr.openSession('err-cb', { cwd: '/tmp', cols: 80, rows: 24 })
-      await mgr.appendData('err-cb', 'before')
 
-      const scrollbackPath = sessionPath(dir, 'err-cb', 'scrollback.bin')
-      chmodSync(scrollbackPath, 0o444)
+      const sessionDir = join(dir, getHistorySessionDirName('err-cb'))
+      chmodSync(sessionDir, 0o555)
 
-      await mgr.appendData('err-cb', 'trigger-error')
+      await mgr.checkpoint('err-cb', makeSnapshot())
 
-      chmodSync(scrollbackPath, 0o644)
+      chmodSync(sessionDir, 0o755)
 
       expect(errors).toHaveLength(1)
       expect(errors[0].sessionId).toBe('err-cb')

--- a/src/main/daemon/history-manager.ts
+++ b/src/main/daemon/history-manager.ts
@@ -62,15 +62,20 @@ export class HistoryManager {
       }
       writeFileSync(join(dir, 'meta.json'), JSON.stringify(meta, null, 2))
 
-      // Why: if a session ID is reused after a previous clean exit, the old
-      // checkpoint.json may still be on disk. Without removing it, a crash
+      // Why: if a session ID is reused after a previous clean exit, stale
+      // recovery files may still be on disk. Without removing them, a crash
       // before the first 5s checkpoint tick would cause detectColdRestore to
-      // replay stale terminal content from the previous session.
+      // replay stale terminal content from the previous session. Both
+      // checkpoint.json and scrollback.bin (legacy) must be cleaned up
+      // because the reader falls back to scrollback.bin when no checkpoint
+      // exists.
       const checkpointPath = join(dir, 'checkpoint.json')
-      try {
-        unlinkSync(checkpointPath)
-      } catch {
-        // ENOENT is expected for new sessions
+      for (const staleFile of [checkpointPath, join(dir, 'scrollback.bin')]) {
+        try {
+          unlinkSync(staleFile)
+        } catch {
+          // ENOENT is expected for new sessions
+        }
       }
 
       this.writers.set(sessionId, {

--- a/src/main/daemon/history-manager.ts
+++ b/src/main/daemon/history-manager.ts
@@ -123,6 +123,7 @@ export class HistoryManager {
 
       const data = JSON.stringify({
         snapshotAnsi: snapshot.snapshotAnsi,
+        scrollbackAnsi: snapshot.scrollbackAnsi,
         rehydrateSequences: snapshot.rehydrateSequences,
         cwd: effectiveCwd,
         cols: snapshot.cols,

--- a/src/main/daemon/history-manager.ts
+++ b/src/main/daemon/history-manager.ts
@@ -1,6 +1,7 @@
 import { join } from 'path'
-import { mkdirSync, writeFileSync, appendFileSync, readFileSync, existsSync, rmSync } from 'fs'
+import { mkdirSync, writeFileSync, readFileSync, existsSync, rmSync, renameSync } from 'fs'
 import { getHistorySessionDirName } from './history-paths'
+import type { TerminalSnapshot } from './types'
 
 export type SessionMeta = {
   cwd: string
@@ -15,47 +16,11 @@ export type OpenSessionOptions = {
   cwd: string
   cols: number
   rows: number
-  initialScrollback?: string
-}
-
-const MAX_SCROLLBACK_BYTES = 5 * 1024 * 1024
-
-function parseFileUriPath(uri: string): string | null {
-  try {
-    const url = new URL(uri)
-    if (url.protocol !== 'file:') {
-      return null
-    }
-
-    const decodedPath = decodeURIComponent(url.pathname)
-    if (process.platform !== 'win32') {
-      return decodedPath
-    }
-
-    // Why: daemon-side cwd persistence must preserve the full Windows target
-    // path from OSC-7, including UNC hosts, or cold restore can reopen in a
-    // different directory than the live shell had reached before the crash.
-    if (url.hostname) {
-      return `\\\\${url.hostname}${decodedPath.replace(/\//g, '\\')}`
-    }
-    if (/^\/[A-Za-z]:/.test(decodedPath)) {
-      return decodedPath.slice(1)
-    }
-    return decodedPath.replace(/\//g, '\\')
-  } catch {
-    return null
-  }
 }
 
 type SessionWriter = {
   dir: string
-  scrollbackPath: string
-  bytesWritten: number
-  cwd: string
-  // Why: CSI 3J (erase scrollback) can arrive split across data chunks.
-  // Buffer the trailing bytes that look like a partial CSI 3J prefix
-  // so the next chunk can complete the match.
-  partialEscape: string
+  checkpointPath: string
 }
 
 export type HistoryManagerOptions = {
@@ -89,29 +54,19 @@ export class HistoryManager {
       }
       writeFileSync(join(dir, 'meta.json'), JSON.stringify(meta, null, 2))
 
-      const scrollbackPath = join(dir, 'scrollback.bin')
-      let bytesWritten = 0
-
-      if (opts.initialScrollback) {
-        writeFileSync(scrollbackPath, opts.initialScrollback)
-        bytesWritten = Buffer.byteLength(opts.initialScrollback)
-      } else {
-        writeFileSync(scrollbackPath, '')
-      }
-
       this.writers.set(sessionId, {
         dir,
-        scrollbackPath,
-        bytesWritten,
-        cwd: opts.cwd,
-        partialEscape: ''
+        checkpointPath: join(dir, 'checkpoint.json')
       })
     } catch (err) {
       this.handleWriteError(sessionId, err)
     }
   }
 
-  async appendData(sessionId: string, data: string): Promise<void> {
+  // Why: replaces the old appendData (which wrote every PTY chunk to disk).
+  // Checkpoints happen every ~5 seconds from a timer, not on every data event,
+  // so disk I/O drops from O(PTY throughput) to O(1 write per interval).
+  async checkpoint(sessionId: string, snapshot: TerminalSnapshot): Promise<void> {
     if (this.disabledSessions.has(sessionId)) {
       return
     }
@@ -121,57 +76,22 @@ export class HistoryManager {
     }
 
     try {
-      const combined = writer.partialEscape + data
-      writer.partialEscape = ''
-      const nextCwd = this.extractLatestCwd(combined)
-      if (nextCwd && nextCwd !== writer.cwd) {
-        writer.cwd = nextCwd
-        this.updateMeta(writer.dir, { cwd: nextCwd })
-      }
-
-      // Why: use lastIndexOf so that multiple CSI 3J sequences in one chunk
-      // reset to the content after the *last* clear, not the first.
-      const clearIdx = combined.lastIndexOf('\x1b[3J')
-      if (clearIdx !== -1) {
-        const afterClear = combined.slice(clearIdx + 4)
-        // Why: CSI 3J resets the byte counter — a clear after the 5MB cap
-        // must still take effect, otherwise the on-disk history is stale.
-        this.resetScrollback(writer)
-        // Why: afterClear may itself end with a partial CSI 3J prefix
-        // (e.g., the chunk was `...\x1b[3Jdata\x1b[`). Buffer it the
-        // same way the main path does, otherwise the next chunk's
-        // completion of the sequence won't be detected as a clear.
-        const partial = this.trailingPartialCsi3J(afterClear)
-        if (partial) {
-          writer.partialEscape = partial
-          const safe = afterClear.slice(0, afterClear.length - partial.length)
-          if (safe.length > 0) {
-            this.writeChunk(writer, safe)
-          }
-        } else if (afterClear.length > 0) {
-          this.writeChunk(writer, afterClear)
-        }
-        return
-      }
-
-      // Why: CSI 3J detection (above) must run even when the cap is hit,
-      // because a clear resets the byte counter. All other writes are
-      // blocked once the cap is reached.
-      if (writer.bytesWritten >= MAX_SCROLLBACK_BYTES) {
-        return
-      }
-
-      const partial = this.trailingPartialCsi3J(combined)
-      if (partial) {
-        writer.partialEscape = partial
-        const safe = combined.slice(0, combined.length - partial.length)
-        if (safe.length > 0) {
-          this.writeChunk(writer, safe)
-        }
-        return
-      }
-
-      this.writeChunk(writer, combined)
+      const data = JSON.stringify({
+        snapshotAnsi: snapshot.snapshotAnsi,
+        rehydrateSequences: snapshot.rehydrateSequences,
+        cwd: snapshot.cwd,
+        cols: snapshot.cols,
+        rows: snapshot.rows,
+        modes: snapshot.modes,
+        scrollbackLines: snapshot.scrollbackLines,
+        checkpointedAt: new Date().toISOString()
+      })
+      // Why: atomic write via tmp+rename prevents half-written checkpoints
+      // on crash. Reading a corrupt checkpoint is worse than reading a
+      // slightly stale one.
+      const tmpPath = `${writer.checkpointPath}.tmp`
+      writeFileSync(tmpPath, data)
+      renameSync(tmpPath, writer.checkpointPath)
     } catch (err) {
       this.handleWriteError(sessionId, err)
     }
@@ -184,17 +104,6 @@ export class HistoryManager {
     }
 
     this.writers.delete(sessionId)
-    // Why: partialEscape may hold buffered bytes from a chunk boundary that
-    // looked like a CSI 3J prefix. Flush them before closing so they aren't
-    // silently dropped. (dispose() does the same flush.)
-    if (writer.partialEscape) {
-      try {
-        this.writeChunk(writer, writer.partialEscape)
-      } catch {
-        // Best-effort flush — don't block session close
-      }
-      writer.partialEscape = ''
-    }
     try {
       this.updateMeta(writer.dir, { endedAt: new Date().toISOString(), exitCode })
     } catch (err) {
@@ -232,74 +141,15 @@ export class HistoryManager {
 
   async dispose(): Promise<void> {
     // Why: mark all open sessions as cleanly ended so they don't trigger
-    // false cold-restores on next launch. Flush any buffered partial escape
-    // data before closing.
+    // false cold-restores on next launch.
     for (const [sessionId, writer] of this.writers) {
-      if (writer.partialEscape) {
-        try {
-          this.writeChunk(writer, writer.partialEscape)
-        } catch {
-          // Best-effort flush — don't block shutdown
-        }
-        writer.partialEscape = ''
-      }
       try {
         this.updateMeta(writer.dir, { endedAt: new Date().toISOString(), exitCode: null })
       } catch {
-        // Best-effort — don't block shutdown
         this.disabledSessions.add(sessionId)
       }
     }
     this.writers.clear()
-  }
-
-  private writeChunk(writer: SessionWriter, data: string): void {
-    const buf = Buffer.from(data)
-    const remaining = MAX_SCROLLBACK_BYTES - writer.bytesWritten
-    if (remaining <= 0) {
-      return
-    }
-
-    if (buf.length > remaining) {
-      appendFileSync(writer.scrollbackPath, buf.subarray(0, remaining))
-      writer.bytesWritten = MAX_SCROLLBACK_BYTES
-    } else {
-      appendFileSync(writer.scrollbackPath, buf)
-      writer.bytesWritten += buf.length
-    }
-  }
-
-  private resetScrollback(writer: SessionWriter): void {
-    writeFileSync(writer.scrollbackPath, '')
-    writer.bytesWritten = 0
-  }
-
-  // Why: CSI 3J is 4 bytes (\x1b [ 3 J). If the chunk ends with a prefix
-  // of this sequence, we must buffer it and check the next chunk.
-  private trailingPartialCsi3J(data: string): string | null {
-    const suffixes = ['\x1b[3', '\x1b[', '\x1b']
-    for (const suffix of suffixes) {
-      if (data.endsWith(suffix)) {
-        return suffix
-      }
-    }
-    return null
-  }
-
-  private extractLatestCwd(data: string): string | null {
-    // OSC-7 format: ESC ] 7 ; <uri> BEL  or  ESC ] 7 ; <uri> ST
-    // oxlint-disable-next-line no-control-regex -- terminal escape sequences require control chars
-    const osc7Re = /\x1b\]7;([^\x07\x1b]*?)(?:\x07|\x1b\\)/g
-    let match: RegExpExecArray | null
-    let latest: string | null = null
-    while ((match = osc7Re.exec(data)) !== null) {
-      latest = this.parseOsc7Uri(match[1])
-    }
-    return latest
-  }
-
-  private parseOsc7Uri(uri: string): string | null {
-    return parseFileUriPath(uri)
   }
 
   // Why: history is best-effort — any error should disable the session
@@ -316,7 +166,6 @@ export class HistoryManager {
     try {
       meta = JSON.parse(readFileSync(metaPath, 'utf-8'))
     } catch {
-      // meta.json missing or corrupt — nothing to update
       return
     }
     Object.assign(meta, updates)

--- a/src/main/daemon/history-manager.ts
+++ b/src/main/daemon/history-manager.ts
@@ -82,6 +82,22 @@ export class HistoryManager {
     }
   }
 
+  // Why: on warm reattach after app relaunch, the HistoryManager is a fresh
+  // instance with no in-memory writers. This registers the writer so
+  // checkpoint() calls work, without overwriting meta.json or deleting the
+  // existing checkpoint.json (which is the only valid recovery data until
+  // the next checkpoint tick writes a fresh one).
+  registerWriter(sessionId: string): void {
+    if (this.writers.has(sessionId)) {
+      return
+    }
+    const dir = join(this.basePath, getHistorySessionDirName(sessionId))
+    this.writers.set(sessionId, {
+      dir,
+      checkpointPath: join(dir, 'checkpoint.json')
+    })
+  }
+
   // Why: replaces the old appendData (which wrote every PTY chunk to disk).
   // Checkpoints happen every ~5 seconds from a timer, not on every data event,
   // so disk I/O drops from O(PTY throughput) to O(1 write per interval).

--- a/src/main/daemon/history-manager.ts
+++ b/src/main/daemon/history-manager.ts
@@ -1,5 +1,13 @@
 import { join } from 'path'
-import { mkdirSync, writeFileSync, readFileSync, existsSync, rmSync, renameSync } from 'fs'
+import {
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+  rmSync,
+  renameSync,
+  unlinkSync
+} from 'fs'
 import { getHistorySessionDirName } from './history-paths'
 import type { TerminalSnapshot } from './types'
 
@@ -54,9 +62,20 @@ export class HistoryManager {
       }
       writeFileSync(join(dir, 'meta.json'), JSON.stringify(meta, null, 2))
 
+      // Why: if a session ID is reused after a previous clean exit, the old
+      // checkpoint.json may still be on disk. Without removing it, a crash
+      // before the first 5s checkpoint tick would cause detectColdRestore to
+      // replay stale terminal content from the previous session.
+      const checkpointPath = join(dir, 'checkpoint.json')
+      try {
+        unlinkSync(checkpointPath)
+      } catch {
+        // ENOENT is expected for new sessions
+      }
+
       this.writers.set(sessionId, {
         dir,
-        checkpointPath: join(dir, 'checkpoint.json')
+        checkpointPath
       })
     } catch (err) {
       this.handleWriteError(sessionId, err)

--- a/src/main/daemon/history-manager.ts
+++ b/src/main/daemon/history-manager.ts
@@ -95,10 +95,20 @@ export class HistoryManager {
     }
 
     try {
+      // Why: shells that haven't emitted OSC-7 have snapshot.cwd = null.
+      // Persisting null would overwrite the usable cwd from meta.json,
+      // breaking cold restore cwd recovery. Fall back to the meta cwd
+      // so the revived shell inherits the original working directory.
+      let effectiveCwd = snapshot.cwd
+      if (effectiveCwd === null) {
+        const meta = this.readMetaFromDir(writer.dir)
+        effectiveCwd = meta?.cwd ?? null
+      }
+
       const data = JSON.stringify({
         snapshotAnsi: snapshot.snapshotAnsi,
         rehydrateSequences: snapshot.rehydrateSequences,
-        cwd: snapshot.cwd,
+        cwd: effectiveCwd,
         cols: snapshot.cols,
         rows: snapshot.rows,
         modes: snapshot.modes,
@@ -177,6 +187,15 @@ export class HistoryManager {
   private handleWriteError(sessionId: string, err: unknown): void {
     this.disabledSessions.add(sessionId)
     this.onWriteError?.(sessionId, err as Error)
+  }
+
+  private readMetaFromDir(dir: string): SessionMeta | null {
+    const metaPath = join(dir, 'meta.json')
+    try {
+      return JSON.parse(readFileSync(metaPath, 'utf-8'))
+    } catch {
+      return null
+    }
   }
 
   private updateMeta(dir: string, updates: Partial<SessionMeta>): void {

--- a/src/main/daemon/history-reader.test.ts
+++ b/src/main/daemon/history-reader.test.ts
@@ -10,7 +10,7 @@ function createTestDir(): string {
   return mkdtempSync(join(tmpdir(), 'history-reader-test-'))
 }
 
-function writeSessionFiles(
+function writeSessionWithScrollback(
   basePath: string,
   sessionId: string,
   meta: SessionMeta,
@@ -22,6 +22,18 @@ function writeSessionFiles(
   writeFileSync(join(dir, 'scrollback.bin'), scrollback)
 }
 
+function writeSessionWithCheckpoint(
+  basePath: string,
+  sessionId: string,
+  meta: SessionMeta,
+  checkpoint: Record<string, unknown>
+): void {
+  const dir = join(basePath, getHistorySessionDirName(sessionId))
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(join(dir, 'meta.json'), JSON.stringify(meta))
+  writeFileSync(join(dir, 'checkpoint.json'), JSON.stringify(checkpoint))
+}
+
 function makeMeta(overrides: Partial<SessionMeta> = {}): SessionMeta {
   return {
     cwd: '/home/user/project',
@@ -30,6 +42,25 @@ function makeMeta(overrides: Partial<SessionMeta> = {}): SessionMeta {
     startedAt: '2026-04-15T10:00:00Z',
     endedAt: null,
     exitCode: null,
+    ...overrides
+  }
+}
+
+function makeCheckpoint(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    snapshotAnsi: 'hello world\r\n$ ls\r\n',
+    rehydrateSequences: '',
+    cwd: '/home/user/project',
+    cols: 80,
+    rows: 24,
+    modes: {
+      bracketedPaste: false,
+      mouseTracking: false,
+      applicationCursor: false,
+      alternateScreen: false
+    },
+    scrollbackLines: 0,
+    checkpointedAt: '2026-04-15T11:00:00Z',
     ...overrides
   }
 }
@@ -47,24 +78,51 @@ describe('HistoryReader', () => {
     rmSync(dir, { recursive: true, force: true })
   })
 
-  describe('detectColdRestore', () => {
-    it('returns restore info for unclean shutdown (endedAt is null)', () => {
-      writeSessionFiles(dir, 'sess-1', makeMeta(), 'hello world\r\n$ ls\r\n')
+  describe('detectColdRestore — checkpoint.json', () => {
+    it('returns restore info from checkpoint.json for unclean shutdown', () => {
+      writeSessionWithCheckpoint(dir, 'sess-1', makeMeta(), makeCheckpoint())
 
       const info = reader.detectColdRestore('sess-1')
       expect(info).not.toBeNull()
       expect(info!.cwd).toBe('/home/user/project')
       expect(info!.cols).toBe(80)
       expect(info!.rows).toBe(24)
-      expect(info!.scrollback).toContain('hello world')
+      expect(info!.snapshotAnsi).toContain('hello world')
+      expect(info!.rehydrateSequences).toBe('')
+    })
+
+    it('restores terminal modes from checkpoint', () => {
+      const modes = {
+        bracketedPaste: true,
+        mouseTracking: false,
+        applicationCursor: true,
+        alternateScreen: false
+      }
+      writeSessionWithCheckpoint(dir, 'sess-1', makeMeta(), makeCheckpoint({ modes }))
+
+      const info = reader.detectColdRestore('sess-1')
+      expect(info!.modes.bracketedPaste).toBe(true)
+      expect(info!.modes.applicationCursor).toBe(true)
+    })
+
+    it('restores rehydrateSequences from checkpoint', () => {
+      writeSessionWithCheckpoint(
+        dir,
+        'sess-1',
+        makeMeta(),
+        makeCheckpoint({ rehydrateSequences: '\x1b[?2004h' })
+      )
+
+      const info = reader.detectColdRestore('sess-1')
+      expect(info!.rehydrateSequences).toBe('\x1b[?2004h')
     })
 
     it('returns null for clean shutdown (endedAt is set)', () => {
-      writeSessionFiles(
+      writeSessionWithCheckpoint(
         dir,
         'sess-1',
         makeMeta({ endedAt: '2026-04-15T12:00:00Z', exitCode: 0 }),
-        'old output'
+        makeCheckpoint()
       )
 
       expect(reader.detectColdRestore('sess-1')).toBeNull()
@@ -78,54 +136,73 @@ describe('HistoryReader', () => {
       const sessionDir = join(dir, getHistorySessionDirName('corrupt'))
       mkdirSync(sessionDir, { recursive: true })
       writeFileSync(join(sessionDir, 'meta.json'), 'not json')
-      writeFileSync(join(sessionDir, 'scrollback.bin'), 'data')
+      writeFileSync(join(sessionDir, 'checkpoint.json'), JSON.stringify(makeCheckpoint()))
 
       expect(reader.detectColdRestore('corrupt')).toBeNull()
     })
 
-    it('returns empty scrollback when scrollback.bin is missing', () => {
-      const sessionDir = join(dir, getHistorySessionDirName('no-scrollback'))
+    it('falls back to scrollback.bin when checkpoint.json is corrupt', () => {
+      const sessionDir = join(dir, getHistorySessionDirName('bad-cp'))
       mkdirSync(sessionDir, { recursive: true })
       writeFileSync(join(sessionDir, 'meta.json'), JSON.stringify(makeMeta()))
+      writeFileSync(join(sessionDir, 'checkpoint.json'), 'not json')
+      writeFileSync(join(sessionDir, 'scrollback.bin'), 'fallback data\r\n')
 
-      const info = reader.detectColdRestore('no-scrollback')
+      const info = reader.detectColdRestore('bad-cp')
       expect(info).not.toBeNull()
-      expect(info!.scrollback).toBe('')
+      expect(info!.snapshotAnsi).toBe('fallback data\r\n')
+      expect(info!.rehydrateSequences).toBe('')
     })
   })
 
-  describe('TUI truncation', () => {
-    it('truncates before last unmatched alternate-screen-on', () => {
-      const scrollback = [
-        'normal output\r\n',
-        '\x1b[?1049h', // alt screen on (vim started)
-        'vim content here'
-        // No matching \x1b[?1049l — vim was running when daemon died
-      ].join('')
+  describe('detectColdRestore — scrollback.bin fallback (backward compatibility)', () => {
+    it('restores from scrollback.bin when checkpoint.json is absent', () => {
+      writeSessionWithScrollback(dir, 'old-sess', makeMeta(), 'old format data\r\n')
 
-      writeSessionFiles(dir, 'tui-sess', makeMeta(), scrollback)
+      const info = reader.detectColdRestore('old-sess')
+      expect(info).not.toBeNull()
+      expect(info!.snapshotAnsi).toContain('old format data')
+      expect(info!.rehydrateSequences).toBe('')
+      expect(info!.modes.bracketedPaste).toBe(false)
+      expect(info!.modes.alternateScreen).toBe(false)
+    })
+
+    it('returns null when neither checkpoint.json nor scrollback.bin exist', () => {
+      const sessionDir = join(dir, getHistorySessionDirName('no-data'))
+      mkdirSync(sessionDir, { recursive: true })
+      writeFileSync(join(sessionDir, 'meta.json'), JSON.stringify(makeMeta()))
+
+      expect(reader.detectColdRestore('no-data')).toBeNull()
+    })
+
+    it('truncates alt-screen from scrollback.bin fallback', () => {
+      const scrollback = ['normal output\r\n', '\x1b[?1049h', 'vim content here'].join('')
+
+      writeSessionWithScrollback(dir, 'tui-sess', makeMeta(), scrollback)
 
       const info = reader.detectColdRestore('tui-sess')
       expect(info).not.toBeNull()
-      expect(info!.scrollback).toContain('normal output')
-      expect(info!.scrollback).not.toContain('vim content')
+      expect(info!.snapshotAnsi).toContain('normal output')
+      expect(info!.snapshotAnsi).not.toContain('vim content')
     })
+  })
 
+  describe('TUI truncation (scrollback.bin fallback path)', () => {
     it('preserves content when alt-screen is properly closed', () => {
       const scrollback = [
         'before vim\r\n',
-        '\x1b[?1049h', // alt screen on
+        '\x1b[?1049h',
         'vim stuff',
-        '\x1b[?1049l', // alt screen off
+        '\x1b[?1049l',
         'after vim\r\n'
       ].join('')
 
-      writeSessionFiles(dir, 'closed-tui', makeMeta(), scrollback)
+      writeSessionWithScrollback(dir, 'closed-tui', makeMeta(), scrollback)
 
       const info = reader.detectColdRestore('closed-tui')
       expect(info).not.toBeNull()
-      expect(info!.scrollback).toContain('before vim')
-      expect(info!.scrollback).toContain('after vim')
+      expect(info!.snapshotAnsi).toContain('before vim')
+      expect(info!.snapshotAnsi).toContain('after vim')
     })
 
     it('handles multiple alt-screen cycles with last one unclosed', () => {
@@ -137,49 +214,47 @@ describe('HistoryReader', () => {
         'line2\r\n',
         '\x1b[?1049h',
         'vim2-still-running'
-        // No close — daemon crashed while vim2 was open
       ].join('')
 
-      writeSessionFiles(dir, 'multi-tui', makeMeta(), scrollback)
+      writeSessionWithScrollback(dir, 'multi-tui', makeMeta(), scrollback)
 
       const info = reader.detectColdRestore('multi-tui')
       expect(info).not.toBeNull()
-      expect(info!.scrollback).toContain('line1')
-      expect(info!.scrollback).toContain('line2')
-      expect(info!.scrollback).not.toContain('vim2-still-running')
+      expect(info!.snapshotAnsi).toContain('line1')
+      expect(info!.snapshotAnsi).toContain('line2')
+      expect(info!.snapshotAnsi).not.toContain('vim2-still-running')
     })
 
     it('truncates at outermost unmatched alt-screen-on for nested sessions', () => {
       const scrollback = [
         'normal output\r\n',
-        '\x1b[?1049h', // outer alt screen (e.g., tmux)
+        '\x1b[?1049h',
         'tmux content',
-        '\x1b[?1049h', // inner alt screen (e.g., vim inside tmux)
+        '\x1b[?1049h',
         'vim inside tmux'
-        // Neither closed — daemon crashed
       ].join('')
 
-      writeSessionFiles(dir, 'nested-tui', makeMeta(), scrollback)
+      writeSessionWithScrollback(dir, 'nested-tui', makeMeta(), scrollback)
 
       const info = reader.detectColdRestore('nested-tui')
       expect(info).not.toBeNull()
-      expect(info!.scrollback).toContain('normal output')
-      expect(info!.scrollback).not.toContain('tmux content')
-      expect(info!.scrollback).not.toContain('vim inside tmux')
+      expect(info!.snapshotAnsi).toContain('normal output')
+      expect(info!.snapshotAnsi).not.toContain('tmux content')
+      expect(info!.snapshotAnsi).not.toContain('vim inside tmux')
     })
 
     it('returns full content when no alt-screen sequences', () => {
-      writeSessionFiles(dir, 'plain', makeMeta(), 'just normal shell output\r\n')
+      writeSessionWithScrollback(dir, 'plain', makeMeta(), 'just normal shell output\r\n')
 
       const info = reader.detectColdRestore('plain')
-      expect(info!.scrollback).toBe('just normal shell output\r\n')
+      expect(info!.snapshotAnsi).toBe('just normal shell output\r\n')
     })
   })
 
   describe('listRestorable', () => {
     it('lists sessions with unclean shutdown', () => {
-      writeSessionFiles(dir, 'alive', makeMeta(), 'data')
-      writeSessionFiles(dir, 'dead', makeMeta({ endedAt: '2026-04-15T12:00:00Z' }), 'data')
+      writeSessionWithScrollback(dir, 'alive', makeMeta(), 'data')
+      writeSessionWithScrollback(dir, 'dead', makeMeta({ endedAt: '2026-04-15T12:00:00Z' }), 'data')
 
       const restorable = reader.listRestorable()
       expect(restorable).toEqual(['alive'])
@@ -191,7 +266,7 @@ describe('HistoryReader', () => {
 
     it('returns decoded session ids for encoded on-disk directories', () => {
       const sessionId = 'repo-1::C:/Users/dev/feature'
-      writeSessionFiles(dir, sessionId, makeMeta(), 'data')
+      writeSessionWithScrollback(dir, sessionId, makeMeta(), 'data')
 
       expect(reader.listRestorable()).toEqual([sessionId])
     })

--- a/src/main/daemon/history-reader.test.ts
+++ b/src/main/daemon/history-reader.test.ts
@@ -49,6 +49,7 @@ function makeMeta(overrides: Partial<SessionMeta> = {}): SessionMeta {
 function makeCheckpoint(overrides: Record<string, unknown> = {}): Record<string, unknown> {
   return {
     snapshotAnsi: 'hello world\r\n$ ls\r\n',
+    scrollbackAnsi: 'hello world\r\n',
     rehydrateSequences: '',
     cwd: '/home/user/project',
     cols: 80,

--- a/src/main/daemon/history-reader.ts
+++ b/src/main/daemon/history-reader.ts
@@ -47,9 +47,20 @@ export class HistoryReader {
 
     try {
       const checkpoint = JSON.parse(readFileSync(checkpointPath, 'utf-8'))
+      // Why: HeadlessEmulator.getSnapshot() doesn't populate scrollbackAnsi
+      // (it's always ''). For alt-screen checkpoints, derive usable scrollback
+      // by truncating snapshotAnsi at the alt-screen boundary — same logic the
+      // scrollback.bin fallback uses. This ensures alt-screen cold restores
+      // recover normal shell output that existed before the TUI launched.
+      const rawScrollback = checkpoint.scrollbackAnsi ?? ''
+      const scrollbackAnsi =
+        rawScrollback ||
+        (checkpoint.modes?.alternateScreen
+          ? this.truncateAltScreen(checkpoint.snapshotAnsi ?? '')
+          : (checkpoint.snapshotAnsi ?? ''))
       return {
         snapshotAnsi: checkpoint.snapshotAnsi,
-        scrollbackAnsi: checkpoint.scrollbackAnsi ?? '',
+        scrollbackAnsi,
         rehydrateSequences: checkpoint.rehydrateSequences,
         cwd: checkpoint.cwd,
         cols: checkpoint.cols,

--- a/src/main/daemon/history-reader.ts
+++ b/src/main/daemon/history-reader.ts
@@ -1,13 +1,16 @@
 import { join } from 'path'
 import { readFileSync, existsSync, readdirSync } from 'fs'
 import type { SessionMeta } from './history-manager'
+import type { TerminalModes } from './types'
 import { getHistorySessionDirName } from './history-paths'
 
 export type ColdRestoreInfo = {
-  scrollback: string
+  snapshotAnsi: string
+  rehydrateSequences: string
   cwd: string
   cols: number
   rows: number
+  modes: TerminalModes
 }
 
 const ALT_SCREEN_ON = '\x1b[?1049h'
@@ -29,12 +32,32 @@ export class HistoryReader {
       return null
     }
 
-    const scrollback = this.readScrollback(sessionId)
-    return {
-      scrollback: this.truncateAltScreen(scrollback),
-      cwd: meta.cwd,
-      cols: meta.cols,
-      rows: meta.rows
+    const checkpointPath = join(
+      this.basePath,
+      getHistorySessionDirName(sessionId),
+      'checkpoint.json'
+    )
+    if (!existsSync(checkpointPath)) {
+      // Why: backward compatibility with pre-checkpoint sessions. If the user
+      // upgrades and then the daemon crashes before a checkpoint is written,
+      // the old scrollback.bin is still the best recovery data available.
+      return this.detectColdRestoreFromScrollback(sessionId, meta)
+    }
+
+    try {
+      const checkpoint = JSON.parse(readFileSync(checkpointPath, 'utf-8'))
+      return {
+        snapshotAnsi: checkpoint.snapshotAnsi,
+        rehydrateSequences: checkpoint.rehydrateSequences,
+        cwd: checkpoint.cwd,
+        cols: checkpoint.cols,
+        rows: checkpoint.rows,
+        modes: checkpoint.modes
+      }
+    } catch {
+      // Why: corrupt checkpoint — fall back to scrollback.bin rather than
+      // discarding recoverable data entirely.
+      return this.detectColdRestoreFromScrollback(sessionId, meta)
     }
   }
 
@@ -77,19 +100,37 @@ export class HistoryReader {
     }
   }
 
-  private readScrollback(sessionId: string): string {
+  // Why: handles the upgrade transition where sessions created before the
+  // checkpoint migration still have scrollback.bin but no checkpoint.json.
+  private detectColdRestoreFromScrollback(
+    sessionId: string,
+    meta: SessionMeta
+  ): ColdRestoreInfo | null {
     const scrollbackPath = join(
       this.basePath,
       getHistorySessionDirName(sessionId),
       'scrollback.bin'
     )
     if (!existsSync(scrollbackPath)) {
-      return ''
+      return null
     }
     try {
-      return readFileSync(scrollbackPath, 'utf-8')
+      const scrollback = readFileSync(scrollbackPath, 'utf-8')
+      return {
+        snapshotAnsi: this.truncateAltScreen(scrollback),
+        rehydrateSequences: '',
+        cwd: meta.cwd,
+        cols: meta.cols,
+        rows: meta.rows,
+        modes: {
+          bracketedPaste: false,
+          mouseTracking: false,
+          applicationCursor: false,
+          alternateScreen: false
+        }
+      }
     } catch {
-      return ''
+      return null
     }
   }
 
@@ -111,9 +152,6 @@ export class HistoryReader {
       }
 
       if (onIdx !== -1 && (offIdx === -1 || onIdx < offIdx)) {
-        // Why: track where depth first goes above 0 — that's the outermost
-        // unmatched ON. Nested ONs (depth > 1) are inside the same alt-screen
-        // block, so we truncate at the outermost boundary.
         if (depth === 0) {
           outermostUnmatchedOnIdx = onIdx
         }

--- a/src/main/daemon/history-reader.ts
+++ b/src/main/daemon/history-reader.ts
@@ -6,6 +6,7 @@ import { getHistorySessionDirName } from './history-paths'
 
 export type ColdRestoreInfo = {
   snapshotAnsi: string
+  scrollbackAnsi: string
   rehydrateSequences: string
   cwd: string
   cols: number
@@ -48,6 +49,7 @@ export class HistoryReader {
       const checkpoint = JSON.parse(readFileSync(checkpointPath, 'utf-8'))
       return {
         snapshotAnsi: checkpoint.snapshotAnsi,
+        scrollbackAnsi: checkpoint.scrollbackAnsi ?? '',
         rehydrateSequences: checkpoint.rehydrateSequences,
         cwd: checkpoint.cwd,
         cols: checkpoint.cols,
@@ -116,8 +118,10 @@ export class HistoryReader {
     }
     try {
       const scrollback = readFileSync(scrollbackPath, 'utf-8')
+      const truncated = this.truncateAltScreen(scrollback)
       return {
-        snapshotAnsi: this.truncateAltScreen(scrollback),
+        snapshotAnsi: truncated,
+        scrollbackAnsi: truncated,
         rehydrateSequences: '',
         cwd: meta.cwd,
         cols: meta.cols,

--- a/src/main/daemon/history-reader.ts
+++ b/src/main/daemon/history-reader.ts
@@ -48,16 +48,15 @@ export class HistoryReader {
     try {
       const checkpoint = JSON.parse(readFileSync(checkpointPath, 'utf-8'))
       // Why: HeadlessEmulator.getSnapshot() doesn't populate scrollbackAnsi
-      // (it's always ''). For alt-screen checkpoints, derive usable scrollback
-      // by truncating snapshotAnsi at the alt-screen boundary — same logic the
-      // scrollback.bin fallback uses. This ensures alt-screen cold restores
-      // recover normal shell output that existed before the TUI launched.
-      const rawScrollback = checkpoint.scrollbackAnsi ?? ''
+      // (it's always ''). For non-alt-screen checkpoints, snapshotAnsi IS
+      // the normal buffer content and is safe to use as scrollback. For
+      // alt-screen checkpoints, snapshotAnsi is the serialized TUI buffer
+      // (not raw PTY stream), so truncateAltScreen won't find transition
+      // sequences and would return stale TUI content. Return empty instead
+      // — the adapter skips cold restore when scrollbackAnsi is falsy.
       const scrollbackAnsi =
-        rawScrollback ||
-        (checkpoint.modes?.alternateScreen
-          ? this.truncateAltScreen(checkpoint.snapshotAnsi ?? '')
-          : (checkpoint.snapshotAnsi ?? ''))
+        checkpoint.scrollbackAnsi ||
+        (checkpoint.modes?.alternateScreen ? '' : (checkpoint.snapshotAnsi ?? ''))
       return {
         snapshotAnsi: checkpoint.snapshotAnsi,
         scrollbackAnsi,

--- a/src/main/daemon/terminal-host.ts
+++ b/src/main/daemon/terminal-host.ts
@@ -33,15 +33,21 @@ export type TerminalHostOptions = {
     env?: Record<string, string>
     command?: string
   }) => SubprocessHandle
+  // Why: on graceful shutdown, the host writes final checkpoints for all live
+  // sessions before killing them. This bypasses the RPC round-trip — the daemon
+  // writes checkpoints in-process, guaranteeing completion before teardown.
+  onFinalCheckpoint?: (sessionId: string, snapshot: TerminalSnapshot) => void
 }
 
 export class TerminalHost {
   private sessions = new Map<string, Session>()
   private killedTombstones = new Map<string, number>()
   private spawnSubprocess: TerminalHostOptions['spawnSubprocess']
+  private onFinalCheckpoint: TerminalHostOptions['onFinalCheckpoint']
 
   constructor(opts: TerminalHostOptions) {
     this.spawnSubprocess = opts.spawnSubprocess
+    this.onFinalCheckpoint = opts.onFinalCheckpoint
   }
 
   async createOrAttach(opts: CreateOrAttachOptions): Promise<CreateOrAttachResult> {
@@ -150,6 +156,17 @@ export class TerminalHost {
     this.getAliveSession(sessionId).clearScrollback()
   }
 
+  // Why: unlike getAliveSession (which throws), this returns null for dead/missing
+  // sessions. Checkpoint is best-effort — a session that exited between the timer
+  // firing and the RPC arriving should not throw.
+  getSnapshot(sessionId: string): TerminalSnapshot | null {
+    const session = this.sessions.get(sessionId)
+    if (!session || !session.isAlive) {
+      return null
+    }
+    return session.getSnapshot()
+  }
+
   isKilled(sessionId: string): boolean {
     return this.killedTombstones.has(sessionId)
   }
@@ -177,6 +194,24 @@ export class TerminalHost {
   }
 
   dispose(): void {
+    // Why: write final checkpoints before killing sessions so graceful shutdown
+    // has zero data loss. The checkpoint callback writes synchronously to disk.
+    if (this.onFinalCheckpoint) {
+      for (const [sessionId, session] of this.sessions) {
+        if (!session.isAlive) {
+          continue
+        }
+        const snapshot = session.getSnapshot()
+        if (snapshot) {
+          try {
+            this.onFinalCheckpoint(sessionId, snapshot)
+          } catch {
+            // Best-effort — don't block shutdown
+          }
+        }
+      }
+    }
+
     for (const [, session] of this.sessions) {
       session.detachAllClients()
       session.kill()

--- a/src/main/daemon/types.ts
+++ b/src/main/daemon/types.ts
@@ -1,8 +1,11 @@
 // ─── Protocol Version ────────────────────────────────────────────────
 // Why: daemons can survive app updates with long-lived shell env. Bump when
 // spawn-time env semantics change so stale sessions cannot bypass new behavior.
-export const PROTOCOL_VERSION = 3
-export const PREVIOUS_DAEMON_PROTOCOL_VERSIONS = [1, 2] as const
+// Why: bumped from 3 → 4 for the getSnapshot RPC. A surviving v3 daemon
+// would reject getSnapshot as unknown, silently failing all checkpoint
+// writes. The bump forces a stale daemon to be replaced on reconnect.
+export const PROTOCOL_VERSION = 4
+export const PREVIOUS_DAEMON_PROTOCOL_VERSIONS = [1, 2, 3] as const
 
 // ─── Session State Machine ──────────────────────────────────────────
 export type SessionState = 'created' | 'spawning' | 'running' | 'exiting' | 'exited'
@@ -149,6 +152,14 @@ export type PingRequest = {
   type: 'ping'
 }
 
+export type GetSnapshotRequest = {
+  id: string
+  type: 'getSnapshot'
+  payload: {
+    sessionId: string
+  }
+}
+
 export type DaemonRequest =
   | CreateOrAttachRequest
   | CancelCreateOrAttachRequest
@@ -162,6 +173,7 @@ export type DaemonRequest =
   | ClearScrollbackRequest
   | ShutdownRequest
   | PingRequest
+  | GetSnapshotRequest
 
 // ─── RPC Responses (Daemon → Client, on control socket) ────────────
 
@@ -184,6 +196,10 @@ export type CreateOrAttachResult = {
   snapshot: TerminalSnapshot | null
   pid: number | null
   shellState: ShellReadyState
+}
+
+export type GetSnapshotResult = {
+  snapshot: TerminalSnapshot | null
 }
 
 export type ListSessionsResult = {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -476,7 +476,12 @@ app.on('before-quit', () => {
   rateLimits?.stop()
 })
 
-app.on('will-quit', () => {
+// Why: will-quit fires twice when daemon disconnect needs an async flush.
+// First pass: run all sync cleanup, then preventDefault to await the final
+// checkpoint writes. Second pass (after disconnect resolves): skip the
+// async work and let Electron exit.
+let daemonDisconnectDone = false
+app.on('will-quit', (e) => {
   // Why: stats.flush() must run before killAllPty() so it can read the
   // live agent state and emit synthetic agent_stop events for agents that
   // are still running. killAllPty() does not call runtime.onPtyExit(),
@@ -489,15 +494,6 @@ app.on('will-quit', () => {
   // holding ports and leaving stale session state on disk.
   runtime?.getAgentBrowserBridge()?.destroyAllSessions()
   killAllPty()
-  // Why: in daemon mode, killAllPty is a no-op (daemon sessions survive app
-  // quit) but the client connection must be closed so sockets are released.
-  // disconnectDaemon only tears down the client transport — it does NOT kill
-  // the daemon process or mark its history as cleanly ended, preserving both
-  // warm reattach and crash recovery on next launch.
-  // Why void: will-quit is synchronous in Electron, but the internal await
-  // ensures checkpoints complete before socket disconnect. The promise chain
-  // finishes on the event loop before the process actually exits.
-  void disconnectDaemon()
   void closeAllWatchers()
   if (runtimeRpc) {
     void runtimeRpc.stop().catch((error) => {
@@ -505,6 +501,18 @@ app.on('will-quit', () => {
     })
   }
   store?.flush()
+
+  // Why: disconnectDaemon writes final checkpoints via async getSnapshot RPCs.
+  // Without preventDefault, Electron exits before the RPCs complete and the
+  // checkpoint data is lost. The guard prevents an infinite quit loop —
+  // app.quit() re-fires will-quit, but the second pass skips straight through.
+  if (!daemonDisconnectDone) {
+    e.preventDefault()
+    disconnectDaemon().finally(() => {
+      daemonDisconnectDone = true
+      app.quit()
+    })
+  }
 })
 
 app.on('window-all-closed', () => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -494,7 +494,10 @@ app.on('will-quit', () => {
   // disconnectDaemon only tears down the client transport — it does NOT kill
   // the daemon process or mark its history as cleanly ended, preserving both
   // warm reattach and crash recovery on next launch.
-  disconnectDaemon()
+  // Why void: will-quit is synchronous in Electron, but the internal await
+  // ensures checkpoints complete before socket disconnect. The promise chain
+  // finishes on the event loop before the process actually exits.
+  void disconnectDaemon()
   void closeAllWatchers()
   if (runtimeRpc) {
     void runtimeRpc.stop().catch((error) => {


### PR DESCRIPTION
## Summary
- Replace per-chunk `appendFileSync` disk writes with periodic checkpoint-based persistence (serialize HeadlessEmulator state every 5 seconds)
- Eliminates unbounded disk I/O that macOS cached as "App Memory" (reported as 140 GB RAM usage by users running TUI-heavy workflows)
- Removes ~150 lines of CSI 3J detection, partial escape buffering, and byte counting logic

## Problem
The daemon history manager wrote every PTY data chunk to disk synchronously for crash recovery. TUIs (vim, lazygit, claude-code) emit CSI 3J on every redraw, resetting the 5 MB byte counter and making total writes unbounded. macOS caches these writes in the unified buffer cache, reporting them as application memory.

## Solution
The HeadlessEmulator already maintains a fully-parsed, deduplicated terminal state. Instead of streaming every byte to disk, we now:
1. Serialize emulator state every 5 seconds via a new `getSnapshot` RPC
2. Write checkpoints atomically (tmp+rename) to `checkpoint.json`
3. Write final checkpoints daemon-side in `TerminalHost.dispose()` for zero data loss on graceful shutdown
4. Fall back to `scrollback.bin` for backward compatibility during the upgrade transition

Key changes:
- `types.ts`: Add `GetSnapshotRequest`/`GetSnapshotResult`, bump `PROTOCOL_VERSION` 3→4
- `terminal-host.ts`: Add `getSnapshot()` method, `onFinalCheckpoint` callback in dispose
- `daemon-server.ts`: Add `getSnapshot` RPC routing
- `history-manager.ts`: Rewrite — `checkpoint()` replaces `appendData()`
- `history-reader.ts`: Read `checkpoint.json` first, fall back to `scrollback.bin`
- `daemon-pty-adapter.ts`: Remove per-chunk writes, add 5s checkpoint timer + `activeSessionIds`

## Test plan
- [ ] All 285 daemon tests pass (24 test files)
- [ ] Verify checkpoint.json is written every 5 seconds with correct snapshot data
- [ ] Verify graceful shutdown writes final checkpoint (zero data loss)
- [ ] Verify cold restore from checkpoint.json works correctly
- [ ] Verify cold restore falls back to scrollback.bin for pre-upgrade sessions
- [ ] Verify no disk I/O on individual PTY data events
- [ ] Verify protocol version bump forces stale daemon replacement
- [ ] Test with TUI-heavy workflows (vim, lazygit, build logs) to confirm memory stays bounded

Made with [Orca](https://github.com/stablyai/orca) 🐋
