### PR TITLE
fix(sidebar): constrain worktree list within add-repo dialog bounds

### DIFF
--- a/src/renderer/src/components/sidebar/AddRepoDialog.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoDialog.tsx
@@ -354,7 +354,7 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
             </DialogHeader>
 
             {hasWorktrees && (
-              <div className="space-y-2">
+              <div className="space-y-2 min-w-0">
                 <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
                   Existing worktrees
                 </p>

--- a/src/renderer/src/components/sidebar/LinkedWorktreeItem.tsx
+++ b/src/renderer/src/components/sidebar/LinkedWorktreeItem.tsx
@@ -14,7 +14,7 @@ export function LinkedWorktreeItem({
       className="group flex items-center justify-between gap-3 w-full rounded-md border border-border/60 bg-secondary/30 px-3 py-2 text-left transition-colors hover:bg-accent cursor-pointer"
       onClick={onOpen}
     >
-      <div className="min-w-0">
+      <div className="min-w-0 flex-1">
         <p className="text-sm font-medium text-foreground truncate">{worktree.displayName}</p>
         {branchLabel !== worktree.displayName && (
           <p className="text-xs text-muted-foreground truncate mt-0.5">{branchLabel}</p>

--- a/src/renderer/src/components/sidebar/LinkedWorktreeItem.tsx
+++ b/src/renderer/src/components/sidebar/LinkedWorktreeItem.tsx
@@ -14,7 +14,7 @@ export function LinkedWorktreeItem({
       className="group flex items-center justify-between gap-3 w-full rounded-md border border-border/60 bg-secondary/30 px-3 py-2 text-left transition-colors hover:bg-accent cursor-pointer"
       onClick={onOpen}
     >
-      <div className="min-w-0 flex-1">
+      <div className="min-w-0">
         <p className="text-sm font-medium text-foreground truncate">{worktree.displayName}</p>
         {branchLabel !== worktree.displayName && (
           <p className="text-xs text-muted-foreground truncate mt-0.5">{branchLabel}</p>


### PR DESCRIPTION
## Summary
- Long worktree branch names pushed the worktree list rows past the right edge of the "Open or create a worktree" dialog
- `DialogContent` uses CSS `grid`, and grid children default to `min-width: auto` (sized to content) — so the list wrapper couldn't shrink below the widest row
- Added `min-w-0` to the wrapping div so it can shrink; the inner `truncate` on each row then takes effect and names ellipsis cleanly

## Test plan
- [x] Open the add-repo dialog for a repo with a long worktree branch name (e.g. \`Support-upstream-remote-as-base-ref-for-fork-based-workflows\`)
- [x] Verify every row stays within the dialog border and long names truncate with ellipsis
- [x] Verify the "Open" label on the right remains visible for every row
- [x] Verify short names still render normally