### PR TITLE
feat(new-workspace): default Start-from picker to Pull requests tab

### DIFF
--- a/src/renderer/src/components/new-workspace/StartFromPicker.tsx
+++ b/src/renderer/src/components/new-workspace/StartFromPicker.tsx
@@ -48,7 +48,7 @@ export default function StartFromPicker({
     }))
   )
 
-  const [tab, setTab] = useState<PickerTab>('branches')
+  const [tab, setTab] = useState<PickerTab>(isRemoteRepo ? 'branches' : 'prs')
   const [query, setQuery] = useState('')
   const [debouncedQuery, setDebouncedQuery] = useState('')
   const [repoSlug, setRepoSlug] = useState<RepoSlug | null>(null)
@@ -298,10 +298,6 @@ export default function StartFromPicker({
       <Tabs value={tab} onValueChange={(v) => setTab(v as PickerTab)} className="gap-0">
         <div className="flex items-center justify-between gap-2 border-b border-border/50 px-3 py-2">
           <TabsList className="h-8">
-            <TabsTrigger value="branches" className="gap-1.5 text-xs">
-              <GitBranch className="size-3.5" />
-              Branches
-            </TabsTrigger>
             <TabsTrigger
               value="prs"
               disabled={isRemoteRepo}
@@ -312,6 +308,10 @@ export default function StartFromPicker({
             >
               <GitPullRequest className="size-3.5" />
               Pull requests
+            </TabsTrigger>
+            <TabsTrigger value="branches" className="gap-1.5 text-xs">
+              <GitBranch className="size-3.5" />
+              Branches
             </TabsTrigger>
           </TabsList>
           {currentBaseBranch !== undefined ? (

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -306,6 +306,15 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
   const lastAutoNameRef = useRef<string>(
     persistDraft ? (newWorkspaceDraft?.name ?? initialName) : initialName
   )
+  // Why: tracks the note value we auto-prefilled from a Start-from PR pick, so
+  // a subsequent PR change can replace it without clobbering user-typed text.
+  const lastAutoNoteRef = useRef<string>('')
+  // Why: read the latest note inside handleBaseBranchPrSelect without adding
+  // `note` to its deps (which would rebuild the callback on every keystroke).
+  const noteRef = useRef<string>(note)
+  useEffect(() => {
+    noteRef.current = note
+  }, [note])
   const composerRef = useRef<HTMLDivElement | null>(null)
   const promptTextareaRef = useRef<HTMLTextAreaElement | null>(null)
   const nameInputRef = useRef<HTMLInputElement | null>(null)
@@ -934,6 +943,18 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       // linkedWorkItem assignment. Reuse applyLinkedWorkItem so auto-name and
       // linkedPR state stay in a single code path.
       applyLinkedWorkItem(item)
+      // Why: starting a worktree from a PR is a strong hint for what the
+      // worktree's comment should surface (`orca worktree current`, sidebar).
+      // Prefill the note if it's empty or still equal to a prior auto-fill, so
+      // we don't overwrite anything the user has typed.
+      if (item.type === 'pr') {
+        const suggestedNote = `PR #${item.number} — ${item.title}`
+        const currentNote = noteRef.current
+        if (!currentNote.trim() || currentNote === lastAutoNoteRef.current) {
+          setNote(suggestedNote)
+          lastAutoNoteRef.current = suggestedNote
+        }
+      }
     },
     [applyLinkedWorkItem]
   )


### PR DESCRIPTION
## Summary
- Reorders Start-from picker tabs so **Pull requests** is first and becomes the default (falls back to **Branches** for remote SSH repos where PRs are disabled).
- Auto-prefills the worktree note with `PR #<n> — <title>` when a PR is picked, guarded via `lastAutoNoteRef` so user-typed notes are never clobbered.
- Uses a `noteRef` to keep `handleBaseBranchPrSelect` stable across note keystrokes.

## Test plan
- [ ] Open New Workspace → Start-from picker lands on Pull requests tab by default
- [ ] For a remote SSH repo, picker lands on Branches (Pull requests disabled)
- [ ] Picking a PR prefills the note as `PR #<n> — <title>` when the note is empty
- [ ] Picking a different PR replaces the prior auto-fill
- [ ] Typing a custom note, then picking a PR, does not overwrite the custom note

Made with [Orca](https://github.com/stablyai/orca) 🐋
