### PR TITLE
fix: keep right sidebar toggle icon vertically centered when toggling open/close

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1028,12 +1028,13 @@ function App(): React.JSX.Element {
           <div className="relative flex flex-1 min-w-0 min-h-0 overflow-hidden">
             {/* Why: right sidebar toggle floats at the top-right of the center
                 column so it's always accessible whether the right sidebar is
-                open or closed. Offset by the 8px drag strip so it aligns with
-                the tab row's 34px band instead of overlapping the draggable
-                window surface above. */}
+                open or closed. Match the RightSidebar header's 42px height and
+                top-0 anchor so the icon's vertical center is identical between
+                open and closed states — otherwise toggling makes the icon jump
+                a few pixels, which reads as layout jitter. */}
             {workspaceActive && !rightSidebarOpen && (
               <div
-                className="absolute top-2 right-0 z-10 flex items-center h-[34px]"
+                className="absolute top-0 right-0 z-10 flex items-center h-[42px]"
                 style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
               >
                 {rightSidebarToggle}


### PR DESCRIPTION
## Problem

The right sidebar toggle icon jumps up and down by ~4px when opening or closing the sidebar, which reads as layout jitter. This happens because the closed state uses different positioning (`top-2`, `h-[34px]`) than the open state (`h-[42px]` items-center at the sidebar header).

## Solution

Both states now use the same `top-0`, `h-[42px]`, `items-center` layout so the icon's vertical center is stable in both open and closed states. The closed-state container now matches the RightSidebar header's positioning exactly.