### PR TITLE
feat(ssh): add port forwarding for remote workspaces

### DIFF
--- a/src/main/ipc/ssh.ts
+++ b/src/main/ipc/ssh.ts
@@ -1,3 +1,5 @@
+/* oxlint-disable max-lines -- Why: co-locates SSH IPC handlers, port-forward
+broadcasting, and session lifecycle in one file to keep the data flow obvious. */
 import { ipcMain, type BrowserWindow } from 'electron'
 import type { Store } from '../persistence'
 import { SshConnectionStore } from '../ssh/ssh-connection-store'
@@ -5,7 +7,13 @@ import { SshConnectionManager, type SshConnectionCallbacks } from '../ssh/ssh-co
 import type { SshChannelMultiplexer } from '../ssh/ssh-channel-multiplexer'
 import { SshRelaySession } from '../ssh/ssh-relay-session'
 import { SshPortForwardManager } from '../ssh/ssh-port-forward'
-import type { SshTarget, SshConnectionState, SshConnectionStatus } from '../../shared/ssh-types'
+import type {
+  SshTarget,
+  SshConnectionState,
+  SshConnectionStatus,
+  DetectedPort,
+  SavedPortForward
+} from '../../shared/ssh-types'
 import { isAuthError } from '../ssh/ssh-connection-utils'
 import { registerSshBrowseHandler } from './ssh-browse'
 import { requestCredential, registerCredentialHandler } from './ssh-passphrase'
@@ -32,6 +40,110 @@ const connectInFlight = new Map<string, Promise<SshConnectionState>>()
 // avoids that visual glitch.
 const testingTargets = new Set<string>()
 
+function broadcastPortForwards(getMainWindow: () => BrowserWindow | null, targetId: string): void {
+  const win = getMainWindow()
+  if (!win || win.isDestroyed()) {
+    return
+  }
+  const forwards = portForwardManager!.listForwards(targetId)
+  win.webContents.send('ssh:port-forwards-changed', { targetId, forwards })
+}
+
+function broadcastDetectedPorts(
+  getMainWindow: () => BrowserWindow | null,
+  targetId: string,
+  ports: DetectedPort[]
+): void {
+  const win = getMainWindow()
+  if (!win || win.isDestroyed()) {
+    return
+  }
+  win.webContents.send('ssh:detected-ports-changed', { targetId, ports })
+}
+
+// Why: after user-initiated add/remove/update the runtime manager is the
+// single source of truth — write exactly its entries and nothing else.
+// A separate helper (persistPortForwardsWithUnrestored) preserves entries
+// that failed to restore so they retry on next reconnect.
+function persistPortForwards(targetId: string): void {
+  const active = portForwardManager!.listForwards(targetId)
+  const saved: SavedPortForward[] = active.map((f) => ({
+    localPort: f.localPort,
+    remoteHost: f.remoteHost,
+    remotePort: f.remotePort,
+    label: f.label
+  }))
+  sshStore!.updateTarget(targetId, { portForwards: saved.length > 0 ? saved : undefined })
+}
+
+// Why: called after restorePortForwards so that forwards which failed to
+// restore (e.g. port temporarily busy) are kept in the persisted list and
+// retried on next reconnect, rather than being silently dropped.
+function persistPortForwardsWithUnrestored(targetId: string): void {
+  const active = portForwardManager!.listForwards(targetId)
+  const activeKeys = new Set(active.map((f) => `${f.localPort}:${f.remoteHost}:${f.remotePort}`))
+
+  const existing = sshStore!.getTarget(targetId)?.portForwards ?? []
+  const unrestored = existing.filter(
+    (pf) => !activeKeys.has(`${pf.localPort}:${pf.remoteHost}:${pf.remotePort}`)
+  )
+
+  const saved: SavedPortForward[] = [
+    ...active.map((f) => ({
+      localPort: f.localPort,
+      remoteHost: f.remoteHost,
+      remotePort: f.remotePort,
+      label: f.label
+    })),
+    ...unrestored
+  ]
+  sshStore!.updateTarget(targetId, { portForwards: saved.length > 0 ? saved : undefined })
+}
+
+async function restorePortForwards(
+  targetId: string,
+  getMainWindow: () => BrowserWindow | null
+): Promise<void> {
+  const target = sshStore!.getTarget(targetId)
+  if (!target?.portForwards?.length) {
+    return
+  }
+  const conn = connectionManager!.getConnection(targetId)
+  if (!conn) {
+    return
+  }
+
+  // Why: don't prune failed restores from persisted state. A failure may
+  // be transient (e.g. port temporarily busy at startup) and the forward
+  // should be retried on the next reconnect rather than silently deleted.
+  for (const saved of target.portForwards) {
+    // Why: if the session disconnects/reconnects while this loop is running,
+    // a new connection object is created. Checking identity avoids adding
+    // forwards against a stale connection, which would leak local listeners
+    // that the next reconnect's removeAllForwards() doesn't know about.
+    if (connectionManager!.getConnection(targetId) !== conn) {
+      return
+    }
+    try {
+      await portForwardManager!.addForward(
+        targetId,
+        conn,
+        saved.localPort,
+        saved.remoteHost,
+        saved.remotePort,
+        saved.label
+      )
+    } catch (err) {
+      console.warn(
+        `[ssh] Failed to restore forward :${saved.localPort} → ${saved.remoteHost}:${saved.remotePort}: ${err instanceof Error ? err.message : String(err)}`
+      )
+    }
+  }
+
+  persistPortForwardsWithUnrestored(targetId)
+  broadcastPortForwards(getMainWindow, targetId)
+}
+
 export function registerSshHandlers(
   store: Store,
   getMainWindow: () => BrowserWindow | null
@@ -50,8 +162,10 @@ export function registerSshHandlers(
     'ssh:getState',
     'ssh:testConnection',
     'ssh:addPortForward',
+    'ssh:updatePortForward',
     'ssh:removePortForward',
-    'ssh:listPortForwards'
+    'ssh:listPortForwards',
+    'ssh:listDetectedPorts'
   ]) {
     ipcMain.removeHandler(ch)
   }
@@ -168,13 +282,25 @@ export function registerSshHandlers(
     // while already connected) and reconnect-after-error.
     const existingSession = activeSessions.get(targetId)
     if (existingSession) {
+      // Why: await port teardown before disposing so the OS fully releases
+      // local ports. Without this, restorePortForwards in the new session
+      // can hit EADDRINUSE on the same ports the old session was using.
+      await portForwardManager!.removeAllForwards(targetId)
       existingSession.dispose()
       activeSessions.delete(targetId)
     }
 
     // Why: create the session early so onStateChange sees it in 'deploying'
     // state and knows not to trigger reconnect logic.
-    const session = new SshRelaySession(targetId, getMainWindow, store, portForwardManager!)
+    const session = new SshRelaySession(
+      targetId,
+      getMainWindow,
+      store,
+      portForwardManager!,
+      (tid, ports, _platform) => {
+        broadcastDetectedPorts(getMainWindow, tid, ports)
+      }
+    )
     activeSessions.set(targetId, session)
 
     try {
@@ -235,6 +361,13 @@ export function registerSshHandlers(
         }
       })
 
+      // Why: fires after both establish() and reconnect() reach 'ready'.
+      // Re-creates persisted port forwards so they survive app restarts
+      // and network blips without manual re-configuration.
+      session.setOnReady((tid) => {
+        void restorePortForwards(tid, getMainWindow)
+      })
+
       await session.establish(conn, target.relayGracePeriodSeconds)
 
       // Why: we manually pushed `deploying-relay` above, so the renderer's
@@ -274,6 +407,10 @@ export function registerSshHandlers(
   ipcMain.handle('ssh:disconnect', async (_event, args: { targetId: string }) => {
     const session = activeSessions.get(args.targetId)
     if (session) {
+      // Why: await port teardown so local listeners are fully released
+      // before the disconnect completes. Without this, an immediate
+      // reconnect can hit EADDRINUSE on the same ports.
+      await portForwardManager!.removeAllForwards(args.targetId)
       session.dispose()
       activeSessions.delete(args.targetId)
     }
@@ -361,7 +498,7 @@ export function registerSshHandlers(
       if (!conn) {
         throw new Error(`SSH connection "${args.targetId}" not found`)
       }
-      return portForwardManager!.addForward(
+      const entry = await portForwardManager!.addForward(
         args.targetId,
         conn,
         args.localPort,
@@ -369,15 +506,68 @@ export function registerSshHandlers(
         args.remotePort,
         args.label
       )
+      persistPortForwards(args.targetId)
+      broadcastPortForwards(getMainWindow, args.targetId)
+      return entry
+    }
+  )
+
+  ipcMain.handle(
+    'ssh:updatePortForward',
+    async (
+      _event,
+      args: {
+        id: string
+        targetId: string
+        localPort: number
+        remoteHost: string
+        remotePort: number
+        label?: string
+      }
+    ) => {
+      const conn = connectionManager!.getConnection(args.targetId)
+      if (!conn) {
+        throw new Error(`SSH connection "${args.targetId}" not found`)
+      }
+      try {
+        const entry = await portForwardManager!.updateForward(
+          args.id,
+          conn,
+          args.localPort,
+          args.remoteHost,
+          args.remotePort,
+          args.label
+        )
+        persistPortForwards(entry.connectionId)
+        broadcastPortForwards(getMainWindow, entry.connectionId)
+        return entry
+      } catch (err) {
+        // Why: if the edit failed (and rollback may also have failed),
+        // sync the renderer with the actual runtime state so it doesn't
+        // show a forward that no longer exists.
+        persistPortForwards(args.targetId)
+        broadcastPortForwards(getMainWindow, args.targetId)
+        throw err
+      }
     }
   )
 
   ipcMain.handle('ssh:removePortForward', (_event, args: { id: string }) => {
-    return portForwardManager!.removeForward(args.id)
+    const removed = portForwardManager!.removeForward(args.id)
+    if (removed) {
+      persistPortForwards(removed.connectionId)
+      broadcastPortForwards(getMainWindow, removed.connectionId)
+    }
+    return removed
   })
 
   ipcMain.handle('ssh:listPortForwards', (_event, args?: { targetId?: string }) => {
     return portForwardManager!.listForwards(args?.targetId)
+  })
+
+  ipcMain.handle('ssh:listDetectedPorts', (_event, args: { targetId: string }) => {
+    const session = activeSessions.get(args.targetId)
+    return session?.getPortScanner()?.getDetectedPorts(args.targetId) ?? []
   })
 
   return { connectionManager, sshStore }

--- a/src/main/ssh/ssh-port-forward.test.ts
+++ b/src/main/ssh/ssh-port-forward.test.ts
@@ -85,12 +85,13 @@ describe('SshPortForwardManager', () => {
     const conn = createMockConn()
     const entry = await manager.addForward('conn-1', conn as never, 3000, 'localhost', 8080)
 
-    expect(manager.removeForward(entry.id)).toBe(true)
+    const removed = manager.removeForward(entry.id)
+    expect(removed).toMatchObject({ id: entry.id, localPort: 3000 })
     expect(manager.listForwards()).toHaveLength(0)
   })
 
-  it('returns false when removing nonexistent forward', () => {
-    expect(manager.removeForward('nonexistent')).toBe(false)
+  it('returns null when removing nonexistent forward', () => {
+    expect(manager.removeForward('nonexistent')).toBeNull()
   })
 
   it('removes all forwards for a connection', async () => {

--- a/src/main/ssh/ssh-port-forward.ts
+++ b/src/main/ssh/ssh-port-forward.ts
@@ -1,14 +1,8 @@
 import { createServer, type Server, type Socket } from 'net'
 import type { SshConnection } from './ssh-connection'
+import type { PortForwardEntry } from '../../shared/ssh-types'
 
-export type PortForwardEntry = {
-  id: string
-  connectionId: string
-  localPort: number
-  remoteHost: string
-  remotePort: number
-  label?: string
-}
+export type { PortForwardEntry }
 
 type ActiveForward = {
   entry: PortForwardEntry
@@ -28,7 +22,26 @@ export class SshPortForwardManager {
     remotePort: number,
     label?: string
   ): Promise<PortForwardEntry> {
-    const id = `pf-${this.nextId++}`
+    return this.addForwardWithId(
+      `pf-${this.nextId++}`,
+      connectionId,
+      conn,
+      localPort,
+      remoteHost,
+      remotePort,
+      label
+    )
+  }
+
+  private async addForwardWithId(
+    id: string,
+    connectionId: string,
+    conn: SshConnection,
+    localPort: number,
+    remoteHost: string,
+    remotePort: number,
+    label?: string
+  ): Promise<PortForwardEntry> {
     const entry: PortForwardEntry = {
       id,
       connectionId,
@@ -72,18 +85,86 @@ export class SshPortForwardManager {
     return entry
   }
 
-  removeForward(id: string): boolean {
+  async updateForward(
+    id: string,
+    conn: SshConnection,
+    localPort: number,
+    remoteHost: string,
+    remotePort: number,
+    label?: string
+  ): Promise<PortForwardEntry> {
+    const existing = this.forwards.get(id)
+    if (!existing) {
+      throw new Error(`Port forward "${id}" not found`)
+    }
+    const oldEntry = { ...existing.entry }
+
+    // Why: use the async variant so the OS fully releases the port before
+    // we try to rebind. Without this, same-port edits (e.g. label change)
+    // fail with EADDRINUSE because server.close() is async.
+    await this.removeForwardAsync(id)
+
+    try {
+      return await this.addForward(
+        oldEntry.connectionId,
+        conn,
+        localPort,
+        remoteHost,
+        remotePort,
+        label
+      )
+    } catch (err) {
+      // Why: use addForwardWithId to preserve the original ID so the
+      // renderer's references remain valid after a failed edit.
+      try {
+        await this.addForwardWithId(
+          oldEntry.id,
+          oldEntry.connectionId,
+          conn,
+          oldEntry.localPort,
+          oldEntry.remoteHost,
+          oldEntry.remotePort,
+          oldEntry.label
+        )
+      } catch {
+        // best-effort rollback
+      }
+      throw err
+    }
+  }
+
+  removeForward(id: string): PortForwardEntry | null {
     const forward = this.forwards.get(id)
     if (!forward) {
-      return false
+      return null
     }
+    this.teardownForward(forward)
+    this.forwards.delete(id)
+    return forward.entry
+  }
 
+  // Why: server.close() is async — the OS may not release the port until the
+  // callback fires. callers that need to rebind the same port (updateForward)
+  // must await this variant.
+  private removeForwardAsync(id: string): Promise<PortForwardEntry | null> {
+    const forward = this.forwards.get(id)
+    if (!forward) {
+      return Promise.resolve(null)
+    }
+    for (const socket of forward.activeSockets) {
+      socket.destroy()
+    }
+    this.forwards.delete(id)
+    return new Promise((resolve) => {
+      forward.server.close(() => resolve(forward.entry))
+    })
+  }
+
+  private teardownForward(forward: ActiveForward): void {
     for (const socket of forward.activeSockets) {
       socket.destroy()
     }
     forward.server.close()
-    this.forwards.delete(id)
-    return true
   }
 
   listForwards(connectionId?: string): PortForwardEntry[] {
@@ -96,16 +177,13 @@ export class SshPortForwardManager {
     return entries
   }
 
-  removeAllForwards(connectionId: string): void {
-    // Why: removeForward deletes from this.forwards. Collecting IDs first
-    // avoids mutating the map during iteration, which is fragile if
-    // removeForward ever gains cascading cleanup.
+  async removeAllForwards(connectionId: string): Promise<void> {
     const toRemove = [...this.forwards.entries()]
       .filter(([, { entry }]) => entry.connectionId === connectionId)
       .map(([id]) => id)
-    for (const id of toRemove) {
-      this.removeForward(id)
-    }
+    // Why: await each removal so the OS fully releases ports before callers
+    // (like restorePortForwards) try to rebind on the same local ports.
+    await Promise.all(toRemove.map((id) => this.removeForwardAsync(id)))
   }
 
   dispose(): void {

--- a/src/main/ssh/ssh-port-scanner.ts
+++ b/src/main/ssh/ssh-port-scanner.ts
@@ -1,0 +1,116 @@
+import type { SshChannelMultiplexer } from './ssh-channel-multiplexer'
+import type { DetectedPort } from '../../shared/ssh-types'
+
+const POLL_INTERVAL_MS = 3_000
+
+type ScanHandle = {
+  timer: ReturnType<typeof setInterval>
+  // Why: keyed by "host:port" (not just port) so that host-distinct listeners
+  // on the same port (e.g. 127.0.0.1:3000 + 0.0.0.0:3000) are tracked separately.
+  previousPorts: Map<string, DetectedPort>
+  // Why: ports detected on the first scan are pre-existing services (sshd, system
+  // daemons) that the user didn't just start. VS Code calls these "initialCandidates"
+  // and excludes them from auto-forward suggestions (Phase 3).
+  initialPorts: Set<string> | null
+}
+
+export class PortScanner {
+  private handles = new Map<string, ScanHandle>()
+
+  startScanning(
+    targetId: string,
+    mux: SshChannelMultiplexer,
+    onChanged: (targetId: string, ports: DetectedPort[], platform: string) => void
+  ): void {
+    this.stopScanning(targetId)
+
+    const handle: ScanHandle = {
+      timer: null!,
+      previousPorts: new Map(),
+      initialPorts: null
+    }
+
+    // Why: guard against overlapping scans. On slow remotes, /proc/*/fd walks
+    // can take longer than POLL_INTERVAL_MS. Without this guard, setInterval
+    // would stack up concurrent requests on the shared SSH multiplexer.
+    let polling = false
+    const poll = async (): Promise<void> => {
+      if (polling) {
+        return
+      }
+      polling = true
+      try {
+        const result = (await mux.request('ports.detect')) as {
+          ports: DetectedPort[]
+          platform: string
+        }
+
+        if (!this.handles.has(targetId)) {
+          return
+        }
+
+        const currentPorts = new Map<string, DetectedPort>()
+        for (const p of result.ports) {
+          currentPorts.set(`${p.host}:${p.port}`, p)
+        }
+
+        if (handle.initialPorts === null) {
+          handle.initialPorts = new Set(currentPorts.keys())
+        }
+
+        if (!portsEqual(handle.previousPorts, currentPorts)) {
+          handle.previousPorts = currentPorts
+          onChanged(targetId, result.ports, result.platform)
+        }
+      } catch {
+        // Relay disconnected or request timed out — retry on next interval
+      } finally {
+        polling = false
+      }
+    }
+
+    handle.timer = setInterval(() => void poll(), POLL_INTERVAL_MS)
+    this.handles.set(targetId, handle)
+
+    void poll()
+  }
+
+  getDetectedPorts(targetId: string): DetectedPort[] {
+    const handle = this.handles.get(targetId)
+    if (!handle) {
+      return []
+    }
+    return Array.from(handle.previousPorts.values())
+  }
+
+  stopScanning(targetId: string): void {
+    const handle = this.handles.get(targetId)
+    if (!handle) {
+      return
+    }
+    clearInterval(handle.timer)
+    this.handles.delete(targetId)
+  }
+
+  dispose(): void {
+    for (const [targetId] of this.handles) {
+      this.stopScanning(targetId)
+    }
+  }
+}
+
+function portsEqual(a: Map<string, DetectedPort>, b: Map<string, DetectedPort>): boolean {
+  if (a.size !== b.size) {
+    return false
+  }
+  for (const [key, entryA] of a) {
+    const entryB = b.get(key)
+    if (!entryB) {
+      return false
+    }
+    if (entryA.pid !== entryB.pid || entryA.processName !== entryB.processName) {
+      return false
+    }
+  }
+  return true
+}

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -1,3 +1,4 @@
+/* oxlint-disable max-lines */
 // Why: consolidates all relay lifecycle state (multiplexer, providers, abort
 // controller, initialization flag) into a single class per SSH target.
 // Previously this state was scattered across 5 module-level Maps/Sets in
@@ -28,8 +29,10 @@ import {
   getSshFilesystemProvider
 } from '../providers/ssh-filesystem-dispatch'
 import { registerSshGitProvider, unregisterSshGitProvider } from '../providers/ssh-git-dispatch'
+import { PortScanner } from './ssh-port-scanner'
 import type { SshPortForwardManager } from './ssh-port-forward'
 import type { SshConnection } from './ssh-connection'
+import type { DetectedPort } from '../../shared/ssh-types'
 import type { Store } from '../persistence'
 
 export type RelaySessionState = 'idle' | 'deploying' | 'ready' | 'reconnecting' | 'disposed'
@@ -43,16 +46,27 @@ export class SshRelaySession {
   // up, the onStateChange reconnect path never fires. This callback lets
   // ssh.ts wire up relay-level reconnect from outside the session.
   private _onRelayLost: ((targetId: string) => void) | null = null
+  private _onReady: ((targetId: string) => void) | null = null
+  private portScanner: PortScanner | null = null
 
   constructor(
     readonly targetId: string,
     private getMainWindow: () => BrowserWindow | null,
     private store: Store,
-    private portForwardManager: SshPortForwardManager
+    private portForwardManager: SshPortForwardManager,
+    private onDetectedPortsChanged?: (
+      targetId: string,
+      ports: DetectedPort[],
+      platform: string
+    ) => void
   ) {}
 
   setOnRelayLost(cb: (targetId: string) => void): void {
     this._onRelayLost = cb
+  }
+
+  setOnReady(cb: (targetId: string) => void): void {
+    this._onReady = cb
   }
 
   getState(): RelaySessionState {
@@ -70,6 +84,10 @@ export class SshRelaySession {
 
   getMux(): SshChannelMultiplexer | null {
     return this.mux
+  }
+
+  getPortScanner(): PortScanner | null {
+    return this.portScanner
   }
 
   // Why: single entry point for relay setup — used by both initial connect
@@ -128,6 +146,8 @@ export class SshRelaySession {
 
       this.watchMuxForRelayLoss(mux)
       this._state = 'ready'
+      this.startPortScanning()
+      this._onReady?.(this.targetId)
     } catch (err) {
       // Why: if deployAndLaunchRelay succeeded but registerProviders threw
       // partway through, the mux is live and some providers may be partially
@@ -160,7 +180,11 @@ export class SshRelaySession {
 
     this._state = 'reconnecting'
 
-    this.portForwardManager.removeAllForwards(this.targetId)
+    // Why: stop scanning before teardownProviders so the polling timer doesn't
+    // fire against a disposed multiplexer.
+    this.stopPortScanning()
+    await this.portForwardManager.removeAllForwards(this.targetId)
+    this.broadcastEmptyLists()
     this.teardownProviders('connection_lost')
 
     try {
@@ -259,6 +283,8 @@ export class SshRelaySession {
 
       this.watchMuxForRelayLoss(mux)
       this._state = 'ready'
+      this.startPortScanning()
+      this._onReady?.(this.targetId)
     } catch (err) {
       // Why: clean up the mux if it was created but registration failed
       // partway through. Without this, the mux's keepalive/timeout timers
@@ -284,7 +310,11 @@ export class SshRelaySession {
       return
     }
     this.abortController?.abort()
-    this.portForwardManager.removeAllForwards(this.targetId)
+    this.stopPortScanning()
+    // Why: fire-and-forget — nothing rebinds after dispose, so we don't
+    // need to wait for the OS to release ports.
+    void this.portForwardManager.removeAllForwards(this.targetId)
+    this.broadcastEmptyLists()
     this.teardownProviders('shutdown')
     this._state = 'disposed'
   }
@@ -390,6 +420,45 @@ export class SshRelaySession {
   // Why: extracted so establish() and reconnect() share exactly the same
   // event wiring. Previously forgetting to wire onReplay on one path
   // caused silent terminal blanking after reconnect.
+  private broadcastEmptyLists(): void {
+    const win = this.getMainWindow()
+    if (!win || win.isDestroyed()) {
+      return
+    }
+    win.webContents.send('ssh:port-forwards-changed', {
+      targetId: this.targetId,
+      forwards: []
+    })
+    win.webContents.send('ssh:detected-ports-changed', {
+      targetId: this.targetId,
+      ports: []
+    })
+  }
+
+  private startPortScanning(): void {
+    if (!this.mux || this.isDisposed()) {
+      return
+    }
+    const scanner = new PortScanner()
+    this.portScanner = scanner
+    // Why: capture the scanner instance so that a late ports.detect callback
+    // from a previous relay session (before reconnect replaced it) is silently
+    // discarded instead of publishing stale results into the new session.
+    scanner.startScanning(this.targetId, this.mux, (targetId, ports, platform) => {
+      if (this.portScanner !== scanner) {
+        return
+      }
+      this.onDetectedPortsChanged?.(targetId, ports, platform)
+    })
+  }
+
+  private stopPortScanning(): void {
+    if (this.portScanner) {
+      this.portScanner.stopScanning(this.targetId)
+      this.portScanner = null
+    }
+  }
+
   private wireUpPtyEvents(ptyProvider: SshPtyProvider): void {
     const getWin = this.getMainWindow
     ptyProvider.onData((payload) => {

--- a/src/preload/api-types.d.ts
+++ b/src/preload/api-types.d.ts
@@ -85,7 +85,12 @@ import type {
   ClaudeUsageSummary
 } from '../../shared/claude-usage-types'
 import type { RateLimitState } from '../../shared/rate-limit-types'
-import type { SshConnectionState, SshTarget } from '../../shared/ssh-types'
+import type {
+  SshConnectionState,
+  SshTarget,
+  PortForwardEntry,
+  DetectedPort
+} from '../../shared/ssh-types'
 import type {
   CodexUsageBreakdownKind,
   CodexUsageBreakdownRow,
@@ -807,9 +812,24 @@ export type PreloadApi = {
       remoteHost: string
       remotePort: number
       label?: string
-    }) => Promise<unknown>
-    removePortForward: (args: { id: string }) => Promise<boolean>
-    listPortForwards: (args?: { targetId?: string }) => Promise<unknown[]>
+    }) => Promise<PortForwardEntry>
+    updatePortForward: (args: {
+      id: string
+      targetId: string
+      localPort: number
+      remoteHost: string
+      remotePort: number
+      label?: string
+    }) => Promise<PortForwardEntry>
+    removePortForward: (args: { id: string }) => Promise<PortForwardEntry | null>
+    listPortForwards: (args?: { targetId?: string }) => Promise<PortForwardEntry[]>
+    listDetectedPorts: (args: { targetId: string }) => Promise<DetectedPort[]>
+    onPortForwardsChanged: (
+      callback: (data: { targetId: string; forwards: PortForwardEntry[] }) => void
+    ) => () => void
+    onDetectedPortsChanged: (
+      callback: (data: { targetId: string; ports: DetectedPort[] }) => void
+    ) => () => void
     browseDir: (args: { targetId: string; dirPath: string }) => Promise<{
       entries: { name: string; isDirectory: boolean }[]
       resolvedPath: string

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -13,7 +13,12 @@ import type {
 } from '../shared/types'
 import type { RuntimeStatus, RuntimeSyncWindowGraph } from '../shared/runtime-types'
 import type { RateLimitState } from '../shared/rate-limit-types'
-import type { SshConnectionState, SshTarget } from '../shared/ssh-types'
+import type {
+  SshConnectionState,
+  SshTarget,
+  PortForwardEntry,
+  DetectedPort
+} from '../shared/ssh-types'
 import type { AgentStatusState } from '../shared/agent-status-types'
 import {
   ORCA_EDITOR_SAVE_DIRTY_FILES_EVENT,
@@ -1564,13 +1569,47 @@ const api = {
       remoteHost: string
       remotePort: number
       label?: string
-    }): Promise<unknown> => ipcRenderer.invoke('ssh:addPortForward', args),
+    }): Promise<PortForwardEntry> => ipcRenderer.invoke('ssh:addPortForward', args),
 
-    removePortForward: (args: { id: string }): Promise<boolean> =>
+    updatePortForward: (args: {
+      id: string
+      targetId: string
+      localPort: number
+      remoteHost: string
+      remotePort: number
+      label?: string
+    }): Promise<PortForwardEntry> => ipcRenderer.invoke('ssh:updatePortForward', args),
+
+    removePortForward: (args: { id: string }): Promise<PortForwardEntry | null> =>
       ipcRenderer.invoke('ssh:removePortForward', args),
 
-    listPortForwards: (args?: { targetId?: string }): Promise<unknown[]> =>
+    listPortForwards: (args?: { targetId?: string }): Promise<PortForwardEntry[]> =>
       ipcRenderer.invoke('ssh:listPortForwards', args),
+
+    listDetectedPorts: (args: { targetId: string }): Promise<DetectedPort[]> =>
+      ipcRenderer.invoke('ssh:listDetectedPorts', args),
+
+    onPortForwardsChanged: (
+      callback: (data: { targetId: string; forwards: PortForwardEntry[] }) => void
+    ): (() => void) => {
+      const handler = (
+        _event: Electron.IpcRendererEvent,
+        data: { targetId: string; forwards: PortForwardEntry[] }
+      ) => callback(data)
+      ipcRenderer.on('ssh:port-forwards-changed', handler)
+      return () => ipcRenderer.removeListener('ssh:port-forwards-changed', handler)
+    },
+
+    onDetectedPortsChanged: (
+      callback: (data: { targetId: string; ports: DetectedPort[] }) => void
+    ): (() => void) => {
+      const handler = (
+        _event: Electron.IpcRendererEvent,
+        data: { targetId: string; ports: DetectedPort[] }
+      ) => callback(data)
+      ipcRenderer.on('ssh:detected-ports-changed', handler)
+      return () => ipcRenderer.removeListener('ssh:detected-ports-changed', handler)
+    },
 
     browseDir: (args: {
       targetId: string

--- a/src/relay/port-scan-handler.test.ts
+++ b/src/relay/port-scan-handler.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import { parseHexAddress } from './port-scan-handler'
+
+describe('parseHexAddress', () => {
+  it('parses IPv4 localhost (127.0.0.1)', () => {
+    // 127.0.0.1 in little-endian hex: 0100007F
+    const result = parseHexAddress('0100007F:0BB8')
+    expect(result).toEqual({ host: '127.0.0.1', port: 3000 })
+  })
+
+  it('parses IPv4 all-interfaces (0.0.0.0)', () => {
+    const result = parseHexAddress('00000000:1F90')
+    expect(result).toEqual({ host: '0.0.0.0', port: 8080 })
+  })
+
+  it('parses port 22 correctly', () => {
+    const result = parseHexAddress('00000000:0016')
+    expect(result).toEqual({ host: '0.0.0.0', port: 22 })
+  })
+
+  it('parses port 443 correctly', () => {
+    const result = parseHexAddress('0100007F:01BB')
+    expect(result).toEqual({ host: '127.0.0.1', port: 443 })
+  })
+
+  it('parses a non-localhost IPv4 address', () => {
+    // 192.168.1.100 in little-endian: 6401A8C0
+    const result = parseHexAddress('6401A8C0:1388')
+    expect(result).toEqual({ host: '192.168.1.100', port: 5000 })
+  })
+
+  it('parses IPv6 all-zeros (::)', () => {
+    const result = parseHexAddress('00000000000000000000000000000000:1F90')
+    expect(result).toEqual({ host: '::', port: 8080 })
+  })
+
+  it('parses IPv6 loopback (::1)', () => {
+    const result = parseHexAddress('00000000000000000000000001000000:0BB8')
+    expect(result).toEqual({ host: '::1', port: 3000 })
+  })
+
+  it('returns null for port 0', () => {
+    const result = parseHexAddress('0100007F:0000')
+    expect(result).toBeNull()
+  })
+
+  it('returns null for malformed input', () => {
+    expect(parseHexAddress('invalid')).toBeNull()
+    expect(parseHexAddress('')).toBeNull()
+    expect(parseHexAddress('::::')).toBeNull()
+  })
+
+  it('parses high ports correctly', () => {
+    // Port 65535 = FFFF
+    const result = parseHexAddress('0100007F:FFFF')
+    expect(result).toEqual({ host: '127.0.0.1', port: 65535 })
+  })
+
+  it('parses port 5432 (postgres)', () => {
+    const result = parseHexAddress('0100007F:1538')
+    expect(result).toEqual({ host: '127.0.0.1', port: 5432 })
+  })
+
+  it('parses port 3306 (mysql)', () => {
+    const result = parseHexAddress('00000000:0CEA')
+    expect(result).toEqual({ host: '0.0.0.0', port: 3306 })
+  })
+})

--- a/src/relay/port-scan-handler.ts
+++ b/src/relay/port-scan-handler.ts
@@ -1,0 +1,240 @@
+import { readFile, readdir, readlink } from 'fs/promises'
+import type { RelayDispatcher } from './dispatcher'
+
+// Keep in sync with src/shared/ssh-types.ts — DetectedPort
+export type DetectedPort = {
+  port: number
+  host: string
+  pid?: number
+  processName?: string
+}
+
+const SYSTEM_PORTS_TO_EXCLUDE = new Set([22])
+
+const MAX_DETECTED_PORTS = 50
+
+export class PortScanHandler {
+  constructor(dispatcher: RelayDispatcher) {
+    dispatcher.onRequest('ports.detect', async () => {
+      if (process.platform !== 'linux') {
+        return { ports: [], platform: process.platform }
+      }
+      return {
+        ports: await this.scanListeningPorts(),
+        platform: process.platform
+      }
+    })
+  }
+
+  private async scanListeningPorts(): Promise<DetectedPort[]> {
+    const [tcp4, tcp6] = await Promise.all([
+      this.readProcNet('/proc/net/tcp'),
+      this.readProcNet('/proc/net/tcp6')
+    ])
+
+    const listeningSockets = [...tcp4, ...tcp6]
+    if (listeningSockets.length === 0) {
+      return []
+    }
+
+    const inodeSet = new Set(listeningSockets.map((s) => s.inode))
+    const inodeToPid = await this.mapInodesToPids(inodeSet)
+
+    const seen = new Set<string>()
+    const results: DetectedPort[] = []
+    const relayPid = process.pid
+    const relayParentPid = process.ppid
+
+    for (const socket of listeningSockets) {
+      const key = `${socket.host}:${socket.port}`
+      if (seen.has(key)) {
+        continue
+      }
+      seen.add(key)
+
+      if (SYSTEM_PORTS_TO_EXCLUDE.has(socket.port)) {
+        continue
+      }
+
+      const pid = inodeToPid.get(socket.inode)
+      if (pid === relayPid || pid === relayParentPid) {
+        continue
+      }
+
+      const processName = pid != null ? await this.getProcessName(pid) : undefined
+
+      if (processName === 'sshd') {
+        continue
+      }
+
+      results.push({
+        port: socket.port,
+        host: socket.host,
+        pid: pid ?? undefined,
+        processName
+      })
+    }
+
+    // Why: sort before capping so the visible set is deterministic (lowest
+    // port numbers first) regardless of /proc enumeration order.
+    results.sort((a, b) => a.port - b.port)
+    return results.slice(0, MAX_DETECTED_PORTS)
+  }
+
+  private async readProcNet(
+    path: string
+  ): Promise<{ port: number; host: string; inode: number }[]> {
+    let content: string
+    try {
+      content = await readFile(path, 'utf-8')
+    } catch {
+      return []
+    }
+
+    const lines = content.split('\n')
+    const results: { port: number; host: string; inode: number }[] = []
+
+    for (let i = 1; i < lines.length; i++) {
+      const fields = lines[i].trim().split(/\s+/)
+      if (fields.length < 10) {
+        continue
+      }
+
+      // State field (index 3): 0A = TCP_LISTEN
+      if (fields[3] !== '0A') {
+        continue
+      }
+
+      const localAddress = fields[1]
+      const parsed = parseHexAddress(localAddress)
+      if (!parsed) {
+        continue
+      }
+
+      const inode = parseInt(fields[9], 10)
+      if (isNaN(inode) || inode === 0) {
+        continue
+      }
+
+      results.push({ port: parsed.port, host: parsed.host, inode })
+    }
+
+    return results
+  }
+
+  private async mapInodesToPids(inodes: Set<number>): Promise<Map<number, number>> {
+    const result = new Map<number, number>()
+    if (inodes.size === 0) {
+      return result
+    }
+
+    let pids: string[]
+    try {
+      pids = (await readdir('/proc')).filter((name) => /^\d+$/.test(name))
+    } catch {
+      return result
+    }
+
+    for (const pidStr of pids) {
+      const fdDir = `/proc/${pidStr}/fd`
+      let fds: string[]
+      try {
+        fds = await readdir(fdDir)
+      } catch {
+        continue
+      }
+
+      const pid = parseInt(pidStr, 10)
+
+      for (const fd of fds) {
+        let link: string
+        try {
+          link = await readlink(`${fdDir}/${fd}`)
+        } catch {
+          continue
+        }
+
+        const match = link.match(/^socket:\[(\d+)\]$/)
+        if (!match) {
+          continue
+        }
+
+        const inode = parseInt(match[1], 10)
+        if (inodes.has(inode)) {
+          result.set(inode, pid)
+        }
+      }
+    }
+
+    return result
+  }
+
+  private async getProcessName(pid: number): Promise<string | undefined> {
+    try {
+      const cmdline = await readFile(`/proc/${pid}/cmdline`, 'utf-8')
+      if (!cmdline) {
+        return undefined
+      }
+
+      const exe = cmdline.split('\0')[0]
+      if (!exe) {
+        return undefined
+      }
+
+      const parts = exe.split('/')
+      return parts.at(-1)
+    } catch {
+      return undefined
+    }
+  }
+}
+
+// Why: /proc/net/tcp encodes addresses as hex pairs in host-byte-order.
+// IPv4: 8 hex chars for address + ':' + 4 hex chars for port.
+// IPv6: 32 hex chars for address + ':' + 4 hex chars for port.
+export function parseHexAddress(hexAddr: string): { host: string; port: number } | null {
+  const parts = hexAddr.split(':')
+  if (parts.length !== 2) {
+    return null
+  }
+
+  const port = parseInt(parts[1], 16)
+  if (isNaN(port) || port === 0) {
+    return null
+  }
+
+  const addrHex = parts[0]
+
+  if (addrHex.length === 8) {
+    const b1 = parseInt(addrHex.substring(6, 8), 16)
+    const b2 = parseInt(addrHex.substring(4, 6), 16)
+    const b3 = parseInt(addrHex.substring(2, 4), 16)
+    const b4 = parseInt(addrHex.substring(0, 2), 16)
+    const host = `${b1}.${b2}.${b3}.${b4}`
+    return { host, port }
+  }
+
+  if (addrHex.length === 32) {
+    if (addrHex === '00000000000000000000000000000000') {
+      return { host: '::', port }
+    }
+    if (addrHex === '00000000000000000000000001000000') {
+      return { host: '::1', port }
+    }
+    return { host: formatIPv6(addrHex), port }
+  }
+
+  return null
+}
+
+function formatIPv6(hex: string): string {
+  const groups: string[] = []
+  for (let i = 0; i < 32; i += 8) {
+    const chunk = hex.substring(i, i + 8)
+    const reversed =
+      chunk.substring(6, 8) + chunk.substring(4, 6) + chunk.substring(2, 4) + chunk.substring(0, 2)
+    groups.push(reversed.substring(0, 4))
+    groups.push(reversed.substring(4, 8))
+  }
+  return groups.map((g) => g.replace(/^0+/, '') || '0').join(':')
+}

--- a/src/relay/relay.ts
+++ b/src/relay/relay.ts
@@ -21,6 +21,7 @@ import { PtyHandler } from './pty-handler'
 import { FsHandler } from './fs-handler'
 import { GitHandler } from './git-handler'
 import { PreflightHandler } from './preflight-handler'
+import { PortScanHandler } from './port-scan-handler'
 
 const DEFAULT_GRACE_MS = 5 * 60 * 1000
 const SOCK_NAME = 'relay.sock'
@@ -196,6 +197,9 @@ function main(): void {
 
   const _preflightHandler = new PreflightHandler(dispatcher)
   void _preflightHandler
+
+  const _portScanHandler = new PortScanHandler(dispatcher)
+  void _portScanHandler
 
   // ── Socket server for reconnection ──────────────────────────────────
   // Why: the relay's original stdin/stdout is tied to the SSH exec channel.

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -675,6 +675,17 @@ function App(): React.JSX.Element {
         e.preventDefault()
         actions.setRightSidebarTab('source-control')
         actions.setRightSidebarOpen(true)
+        return
+      }
+
+      // Cmd+Shift+I — toggle right sidebar / ports tab (macOS only).
+      // Why: Ctrl+Shift+I is the built-in DevTools accelerator on Windows/Linux;
+      // intercepting it would break an essential developer tool.
+      if (isMac && e.shiftKey && !e.altKey && e.key.toLowerCase() === 'i') {
+        dispatchClearModifierHints()
+        e.preventDefault()
+        actions.setRightSidebarTab('ports')
+        actions.setRightSidebarOpen(true)
       }
     }
 

--- a/src/renderer/src/components/right-sidebar/PortsPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/PortsPanel.tsx
@@ -1,0 +1,609 @@
+/* oxlint-disable max-lines -- Why: co-locates forwarded list, detected list, modal form, and
+per-entry actions in one file to keep the data flow straightforward. */
+import React, { useCallback, useMemo, useState } from 'react'
+import { ExternalLink, Copy, Trash2, Plus, Unplug, ChevronRight, Pencil } from 'lucide-react'
+import { useAppStore } from '@/store'
+import { useActiveWorktree, useRepoById } from '@/store/selectors'
+import { cn } from '@/lib/utils'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import type { PortForwardEntry, DetectedPort } from '../../../../shared/ssh-types'
+
+// Why: ports < 1024 require root to bind on the local machine. Remap them
+// to a high port so the default "Forward" action doesn't fail with EACCES.
+function safeLocalPort(remotePort: number): number {
+  if (remotePort < 1024) {
+    return remotePort + 10000
+  }
+  return remotePort
+}
+
+const HTTP_PORTS = new Set([80, 443, 3000, 3001, 4200, 5000, 5173, 5174, 8000, 8080, 8443, 8888])
+const HTTPS_PORTS = new Set([443, 8443])
+
+// Why: the scanner reports numeric addresses (127.0.0.1, 0.0.0.0, ::1, ::)
+// while forwards typically use "localhost". Normalize all loopback/wildcard
+// variants to "localhost" so dedup matching works regardless of representation.
+const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '::1', '0.0.0.0', '::'])
+function normalizeHost(host: string | undefined): string {
+  if (!host || LOOPBACK_HOSTS.has(host)) {
+    return 'localhost'
+  }
+  return host
+}
+
+type PortForwardDialogState =
+  | { mode: 'closed' }
+  | {
+      mode: 'add'
+      defaults: { remotePort?: number; remoteHost?: string; label?: string; targetId?: string }
+    }
+  | { mode: 'edit'; entry: PortForwardEntry }
+
+export default function PortsPanel(): React.JSX.Element {
+  const portForwardsByConnection = useAppStore((s) => s.portForwardsByConnection)
+  const detectedPortsByConnection = useAppStore((s) => s.detectedPortsByConnection)
+  const sshConnectionStates = useAppStore((s) => s.sshConnectionStates)
+  // Why: scope the panel to the active worktree's SSH connection so
+  // actions target the correct machine and the disconnected state
+  // reflects the active worktree, not some other SSH session.
+  const activeWorktree = useActiveWorktree()
+  const activeRepo = useRepoById(activeWorktree?.repoId ?? null)
+  const activeConnectionId = activeRepo?.connectionId ?? null
+
+  const isDisconnected = activeConnectionId
+    ? sshConnectionStates.get(activeConnectionId)?.status !== 'connected'
+    : true
+
+  const allForwards = useMemo(() => {
+    if (!activeConnectionId) {
+      return []
+    }
+    return portForwardsByConnection[activeConnectionId] ?? []
+  }, [portForwardsByConnection, activeConnectionId])
+
+  const forwardedKeys = useMemo(() => {
+    const set = new Set<string>()
+    for (const f of allForwards) {
+      set.add(`${normalizeHost(f.remoteHost)}:${f.remotePort}`)
+    }
+    return set
+  }, [allForwards])
+
+  const allDetected = useMemo(() => {
+    if (!activeConnectionId) {
+      return []
+    }
+    const ports = detectedPortsByConnection[activeConnectionId] ?? []
+    return ports
+      .filter((p) => !forwardedKeys.has(`${normalizeHost(p.host)}:${p.port}`))
+      .map((p) => ({ ...p, targetId: activeConnectionId }))
+      .sort((a, b) => a.port - b.port)
+  }, [detectedPortsByConnection, activeConnectionId, forwardedKeys])
+
+  const [forwardedCollapsed, setForwardedCollapsed] = useState(false)
+  const [detectedCollapsed, setDetectedCollapsed] = useState(false)
+  const [dialogState, setDialogState] = useState<PortForwardDialogState>({ mode: 'closed' })
+
+  const handleForwardDetected = useCallback((port: DetectedPort & { targetId: string }) => {
+    setDialogState({
+      mode: 'add',
+      defaults: {
+        remotePort: port.port,
+        remoteHost: normalizeHost(port.host),
+        label: port.processName,
+        targetId: port.targetId
+      }
+    })
+  }, [])
+
+  const handleEdit = useCallback((entry: PortForwardEntry) => {
+    setDialogState({ mode: 'edit', entry })
+  }, [])
+
+  const handleDialogClose = useCallback(() => {
+    setDialogState({ mode: 'closed' })
+  }, [])
+
+  if (isDisconnected) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full px-4 text-center text-muted-foreground">
+        <Unplug size={32} className="mb-3 opacity-50" />
+        <p className="text-sm font-medium">SSH connection lost</p>
+        <p className="text-xs mt-1">Reconnecting...</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col h-full overflow-y-auto scrollbar-sleek">
+      {/* Header */}
+      <div className="flex items-center justify-between px-3 py-2 border-b border-border">
+        <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+          Ports
+        </span>
+        <button
+          type="button"
+          className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+          onClick={() =>
+            setDialogState({ mode: 'add', defaults: { targetId: activeConnectionId ?? undefined } })
+          }
+        >
+          <Plus size={14} />
+          Add
+        </button>
+      </div>
+
+      {/* Forwarded ports */}
+      {allForwards.length > 0 && (
+        <div className="px-3 py-2">
+          <button
+            type="button"
+            className="flex items-center gap-1 w-full text-left mb-1.5"
+            onClick={() => setForwardedCollapsed((v) => !v)}
+          >
+            <ChevronRight
+              size={12}
+              className={cn(
+                'text-muted-foreground transition-transform',
+                !forwardedCollapsed && 'rotate-90'
+              )}
+            />
+            <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+              Forwarded
+            </span>
+            <span className="text-[10px] text-muted-foreground/60 ml-1">{allForwards.length}</span>
+          </button>
+          {!forwardedCollapsed &&
+            allForwards.map((entry) => (
+              <ForwardedPortRow key={entry.id} entry={entry} onEdit={() => handleEdit(entry)} />
+            ))}
+        </div>
+      )}
+
+      {/* Detected ports */}
+      {allDetected.length > 0 && (
+        <div className="px-3 py-2">
+          <button
+            type="button"
+            className="flex items-center gap-1 w-full text-left mb-1.5"
+            onClick={() => setDetectedCollapsed((v) => !v)}
+          >
+            <ChevronRight
+              size={12}
+              className={cn(
+                'text-muted-foreground transition-transform',
+                !detectedCollapsed && 'rotate-90'
+              )}
+            />
+            <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+              Detected
+            </span>
+            <span className="text-[10px] text-muted-foreground/60 ml-1">{allDetected.length}</span>
+          </button>
+          {!detectedCollapsed &&
+            allDetected.map((port) => (
+              <DetectedPortRow
+                key={`${port.targetId}-${port.host}-${port.port}`}
+                port={port}
+                onForward={() => handleForwardDetected(port)}
+              />
+            ))}
+        </div>
+      )}
+
+      {/* Empty state */}
+      {allForwards.length === 0 && allDetected.length === 0 && (
+        <div className="flex flex-col items-center justify-center flex-1 px-4 text-center text-muted-foreground">
+          <p className="text-sm">No forwarded ports</p>
+          <p className="text-xs mt-1 mb-3">
+            Forward a port to access remote services on your local machine.
+          </p>
+          <button
+            type="button"
+            className="text-xs px-3 py-1.5 rounded bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
+            onClick={() =>
+              setDialogState({
+                mode: 'add',
+                defaults: { targetId: activeConnectionId ?? undefined }
+              })
+            }
+          >
+            Forward a Port
+          </button>
+        </div>
+      )}
+
+      <PortForwardDialog
+        state={dialogState}
+        activeConnectionId={activeConnectionId}
+        onClose={handleDialogClose}
+      />
+    </div>
+  )
+}
+
+function ForwardedPortRow({
+  entry,
+  onEdit
+}: {
+  entry: PortForwardEntry
+  onEdit: () => void
+}): React.JSX.Element {
+  const [removing, setRemoving] = useState(false)
+
+  const handleRemove = useCallback(async () => {
+    setRemoving(true)
+    try {
+      await window.api.ssh.removePortForward({ id: entry.id })
+    } catch {
+      // broadcast will update state
+    }
+    setRemoving(false)
+  }, [entry.id])
+
+  const handleCopy = useCallback(() => {
+    // Why: use 127.0.0.1 instead of localhost because the local TCP listener
+    // binds to 127.0.0.1 specifically. On systems that resolve localhost to
+    // ::1 first, "localhost:<port>" would fail even though the forward is up.
+    void window.api.ui.writeClipboardText(`127.0.0.1:${entry.localPort}`)
+  }, [entry.localPort])
+
+  const handleOpenBrowser = useCallback(() => {
+    // Why: the protocol hint comes from the remote port (the actual service),
+    // not the local port which may be an arbitrary remap.
+    const protocol = HTTPS_PORTS.has(entry.remotePort) ? 'https' : 'http'
+    void window.api.shell.openUrl(`${protocol}://127.0.0.1:${entry.localPort}`)
+  }, [entry.localPort, entry.remotePort])
+
+  const isHttpPort = HTTP_PORTS.has(entry.remotePort)
+
+  return (
+    <div className="group flex items-center gap-2 py-1 px-1 -mx-1 rounded hover:bg-accent/50 transition-colors">
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-1.5">
+          {entry.label && (
+            <span className="text-xs font-medium text-foreground truncate">{entry.label}</span>
+          )}
+          <span
+            className={cn(
+              'text-xs text-muted-foreground truncate',
+              !entry.label && 'text-foreground'
+            )}
+          >
+            :{entry.localPort} → :{entry.remotePort}
+          </span>
+        </div>
+      </div>
+      <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
+        {isHttpPort && (
+          <button
+            type="button"
+            className="p-1 rounded hover:bg-accent transition-colors text-muted-foreground hover:text-foreground"
+            onClick={handleOpenBrowser}
+            title="Open in Browser"
+          >
+            <ExternalLink size={13} />
+          </button>
+        )}
+        <button
+          type="button"
+          className="p-1 rounded hover:bg-accent transition-colors text-muted-foreground hover:text-foreground"
+          onClick={handleCopy}
+          title="Copy Address"
+        >
+          <Copy size={13} />
+        </button>
+        <button
+          type="button"
+          className="p-1 rounded hover:bg-accent transition-colors text-muted-foreground hover:text-foreground"
+          onClick={onEdit}
+          title="Edit"
+        >
+          <Pencil size={13} />
+        </button>
+        <button
+          type="button"
+          className={cn(
+            'p-1 rounded hover:bg-accent transition-colors text-muted-foreground hover:text-foreground',
+            removing && 'opacity-50'
+          )}
+          onClick={handleRemove}
+          disabled={removing}
+          title="Remove"
+        >
+          <Trash2 size={13} />
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function DetectedPortRow({
+  port,
+  onForward
+}: {
+  port: DetectedPort & { targetId: string }
+  onForward: () => void
+}): React.JSX.Element {
+  return (
+    <div className="group flex items-center gap-2 py-1 px-1 -mx-1 rounded hover:bg-accent/50 transition-colors">
+      <div className="flex-1 min-w-0">
+        <span className="text-xs text-foreground">:{port.port}</span>
+        {port.processName && (
+          <span className="text-xs text-muted-foreground ml-1.5">{port.processName}</span>
+        )}
+      </div>
+      <button
+        type="button"
+        className="text-[11px] px-2 py-0.5 rounded opacity-0 group-hover:opacity-100 transition-opacity bg-accent hover:bg-accent/80 text-foreground"
+        onClick={onForward}
+      >
+        Forward
+      </button>
+    </div>
+  )
+}
+
+function digitsOnly(value: string): string {
+  return value.replace(/\D/g, '')
+}
+
+const INPUT_CLASS =
+  'block w-full mt-0.5 px-2 py-1.5 text-xs rounded border border-border bg-background text-foreground focus:outline-none focus:ring-1 focus:ring-ring'
+
+function PortForwardDialog({
+  state,
+  activeConnectionId,
+  onClose
+}: {
+  state: PortForwardDialogState
+  activeConnectionId: string | null
+  onClose: () => void
+}): React.JSX.Element {
+  const isOpen = state.mode !== 'closed'
+  const isEdit = state.mode === 'edit'
+
+  const initialRemotePort =
+    state.mode === 'edit'
+      ? state.entry.remotePort.toString()
+      : state.mode === 'add'
+        ? (state.defaults.remotePort?.toString() ?? '')
+        : ''
+
+  const initialLocalPort =
+    state.mode === 'edit'
+      ? state.entry.localPort.toString()
+      : state.mode === 'add' && state.defaults.remotePort != null
+        ? safeLocalPort(state.defaults.remotePort).toString()
+        : ''
+
+  const initialRemoteHost =
+    state.mode === 'edit'
+      ? state.entry.remoteHost
+      : state.mode === 'add'
+        ? (state.defaults.remoteHost ?? 'localhost')
+        : 'localhost'
+
+  const initialLabel =
+    state.mode === 'edit'
+      ? (state.entry.label ?? '')
+      : state.mode === 'add'
+        ? (state.defaults.label ?? '')
+        : ''
+
+  // Why: capture the target at dialog-open time via defaults.targetId so
+  // switching worktrees while the dialog is open doesn't redirect the
+  // forward to the wrong SSH connection.
+  const targetId =
+    state.mode === 'edit'
+      ? state.entry.connectionId
+      : state.mode === 'add'
+        ? (state.defaults.targetId ?? activeConnectionId ?? '')
+        : (activeConnectionId ?? '')
+
+  return (
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) {
+          onClose()
+        }
+      }}
+    >
+      <DialogContent showCloseButton={false} className="max-w-[340px]">
+        <DialogHeader>
+          <DialogTitle className="text-sm">
+            {isEdit ? 'Edit Port Forward' : 'Forward a Port'}
+          </DialogTitle>
+          <DialogDescription className="text-xs">
+            {isEdit
+              ? 'Update the port forwarding configuration.'
+              : 'Forward a remote port to your local machine.'}
+          </DialogDescription>
+        </DialogHeader>
+        {isOpen && (
+          <PortForwardForm
+            key={
+              state.mode === 'edit'
+                ? `edit-${state.entry.id}`
+                : `add-${targetId}-${initialRemotePort}-${initialRemoteHost}`
+            }
+            mode={state.mode}
+            editId={state.mode === 'edit' ? state.entry.id : undefined}
+            initialRemotePort={initialRemotePort}
+            initialLocalPort={initialLocalPort}
+            initialRemoteHost={initialRemoteHost}
+            initialLabel={initialLabel}
+            targetId={targetId}
+            onClose={onClose}
+          />
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function PortForwardForm({
+  mode,
+  editId,
+  initialRemotePort,
+  initialLocalPort,
+  initialRemoteHost,
+  initialLabel,
+  targetId,
+  onClose
+}: {
+  mode: 'add' | 'edit'
+  editId?: string
+  initialRemotePort: string
+  initialLocalPort: string
+  initialRemoteHost: string
+  initialLabel: string
+  targetId: string
+  onClose: () => void
+}): React.JSX.Element {
+  const [remotePort, setRemotePort] = useState(initialRemotePort)
+  const [localPort, setLocalPort] = useState(initialLocalPort)
+  const [remoteHost, setRemoteHost] = useState(initialRemoteHost)
+  const [label, setLabel] = useState(initialLabel)
+  const [error, setError] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault()
+      setError(null)
+
+      const rPort = parseInt(remotePort, 10)
+      const lPort = parseInt(localPort || remotePort, 10)
+
+      if (isNaN(rPort) || rPort < 1 || rPort > 65535) {
+        setError('Remote port must be 1\u201365535')
+        return
+      }
+      if (isNaN(lPort) || lPort < 1 || lPort > 65535) {
+        setError('Local port must be 1\u201365535')
+        return
+      }
+
+      setSubmitting(true)
+      try {
+        await (mode === 'edit' && editId
+          ? window.api.ssh.updatePortForward({
+              id: editId,
+              targetId,
+              localPort: lPort,
+              remoteHost: remoteHost || 'localhost',
+              remotePort: rPort,
+              label: label || undefined
+            })
+          : window.api.ssh.addPortForward({
+              targetId,
+              localPort: lPort,
+              remoteHost: remoteHost || 'localhost',
+              remotePort: rPort,
+              label: label || undefined
+            }))
+        onClose()
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err)
+        if (msg.includes('EADDRINUSE') || msg.includes('already in use')) {
+          setError(`Port ${lPort} is already in use. Choose a different local port.`)
+        } else if (msg.includes('EACCES') || msg.includes('permission denied')) {
+          setError(`Port ${lPort} requires elevated privileges. Use a local port \u2265 1024.`)
+        } else {
+          setError(msg)
+        }
+      }
+      setSubmitting(false)
+    },
+    [mode, editId, remotePort, localPort, remoteHost, label, targetId, onClose]
+  )
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-3">
+      <div className="space-y-2">
+        <label className="block">
+          <span className="text-[11px] text-muted-foreground">Remote Port</span>
+          <input
+            type="text"
+            inputMode="numeric"
+            value={remotePort}
+            onChange={(e) => {
+              const val = digitsOnly(e.target.value)
+              setRemotePort(val)
+              const prev = parseInt(remotePort, 10)
+              const cur = parseInt(localPort, 10)
+              if (!localPort || cur === prev || cur === safeLocalPort(prev)) {
+                const parsed = parseInt(val, 10)
+                setLocalPort(isNaN(parsed) ? '' : safeLocalPort(parsed).toString())
+              }
+            }}
+            className={INPUT_CLASS}
+            placeholder="3000"
+            autoFocus
+            required
+          />
+        </label>
+
+        <label className="block">
+          <span className="text-[11px] text-muted-foreground">Local Port</span>
+          <input
+            type="text"
+            inputMode="numeric"
+            value={localPort}
+            onChange={(e) => setLocalPort(digitsOnly(e.target.value))}
+            className={INPUT_CLASS}
+            placeholder="Same as remote"
+          />
+        </label>
+
+        <label className="block">
+          <span className="text-[11px] text-muted-foreground">Remote Host</span>
+          <input
+            type="text"
+            value={remoteHost}
+            onChange={(e) => setRemoteHost(e.target.value)}
+            className={INPUT_CLASS}
+            placeholder="localhost"
+          />
+        </label>
+
+        <label className="block">
+          <span className="text-[11px] text-muted-foreground">Label (optional)</span>
+          <input
+            type="text"
+            value={label}
+            onChange={(e) => setLabel(e.target.value)}
+            className={INPUT_CLASS}
+            placeholder="dev-server"
+          />
+        </label>
+      </div>
+
+      {error && <div className="text-[11px] text-destructive">{error}</div>}
+
+      <div className="flex justify-end gap-2">
+        <Button type="button" variant="outline" size="sm" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button type="submit" size="sm" disabled={submitting || !remotePort}>
+          {submitting
+            ? mode === 'edit'
+              ? 'Saving...'
+              : 'Forwarding...'
+            : mode === 'edit'
+              ? 'Save'
+              : 'Forward'}
+        </Button>
+      </div>
+    </form>
+  )
+}

--- a/src/renderer/src/components/right-sidebar/PortsPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/PortsPanel.tsx
@@ -142,10 +142,10 @@ export default function PortsPanel(): React.JSX.Element {
 
       {/* Forwarded ports */}
       {allForwards.length > 0 && (
-        <div className="px-3 py-2">
+        <div className="px-3 pt-2">
           <button
             type="button"
-            className="flex items-center gap-1 w-full text-left mb-1.5"
+            className="flex items-center gap-1 w-full text-left mb-1"
             onClick={() => setForwardedCollapsed((v) => !v)}
           >
             <ChevronRight
@@ -169,10 +169,10 @@ export default function PortsPanel(): React.JSX.Element {
 
       {/* Detected ports */}
       {allDetected.length > 0 && (
-        <div className="px-3 py-2">
+        <div className="px-3 pt-2">
           <button
             type="button"
-            className="flex items-center gap-1 w-full text-left mb-1.5"
+            className="flex items-center gap-1 w-full text-left mb-1"
             onClick={() => setDetectedCollapsed((v) => !v)}
           >
             <ChevronRight

--- a/src/renderer/src/components/right-sidebar/index.tsx
+++ b/src/renderer/src/components/right-sidebar/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react'
-import { Files, Search, GitBranch, ListChecks, PanelRight } from 'lucide-react'
+import { Files, Search, GitBranch, ListChecks, Cable, PanelRight } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { getRepoMapFromState, useActiveWorktree, useRepoById } from '@/store/selectors'
 import { cn } from '@/lib/utils'
@@ -21,6 +21,7 @@ import FileExplorer from './FileExplorer'
 import SourceControl from './SourceControl'
 import SearchPanel from './Search'
 import ChecksPanel from './ChecksPanel'
+import PortsPanel from './PortsPanel'
 
 const MIN_WIDTH = 220
 // Why: long file names (e.g. construction drawing sheets, multi-part document
@@ -66,6 +67,8 @@ type ActivityBarItem = {
   shortcut: string
   /** When true, hidden for non-git (folder-mode) repos. */
   gitOnly?: boolean
+  /** When true, only shown when at least one SSH connection is active. */
+  sshOnly?: boolean
 }
 
 const isMac = navigator.userAgent.includes('Mac')
@@ -97,6 +100,15 @@ const ACTIVITY_ITEMS: ActivityBarItem[] = [
     title: 'Checks',
     shortcut: `${isMac ? '\u21E7' : 'Shift+'}${mod}K`,
     gitOnly: true
+  },
+  {
+    id: 'ports',
+    icon: Cable,
+    title: 'Ports',
+    // Why: Ctrl+Shift+I is the DevTools accelerator on Windows/Linux, so this
+    // shortcut is macOS-only. On other platforms the tooltip omits it.
+    shortcut: isMac ? `\u21E7${mod}I` : '',
+    sshOnly: true
   }
 ]
 
@@ -116,9 +128,85 @@ function RightSidebarInner(): React.JSX.Element {
   // Hide those tabs so the activity bar only shows relevant actions.
   const activeRepo = useRepoById(activeWorktree?.repoId ?? null)
   const isFolder = activeRepo ? isFolderRepo(activeRepo) : false
+
+  // Why: show the Ports tab only when the active worktree belongs to a
+  // remote (SSH) repo, not for any global SSH connection. Switching to a
+  // local worktree should hide the tab even if SSH sessions are alive.
+  const isRemoteWorktree = !!activeRepo?.connectionId
+  const hasActiveSshConnection = useAppStore((s) => {
+    if (!activeRepo?.connectionId) {
+      return false
+    }
+    const state = s.sshConnectionStates.get(activeRepo.connectionId)
+    return state?.status === 'connected'
+  })
+
+  // Why: when the SSH connection drops while the user is viewing the Ports
+  // panel, hiding the tab immediately would be jarring. Keep it visible
+  // during a 30-second grace period, then hide it.
+  const isPortsPanelActive = rightSidebarTab === 'ports'
+  // Why: graceActiveRef is set synchronously during render (not via useEffect)
+  // so that the very first render after disconnect already sees the grace flag,
+  // preventing a one-frame flicker to the Explorer tab.
+  const graceActiveRef = React.useRef(false)
+  const graceTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+  const [, forceUpdate] = useState(0)
+
+  if (!hasActiveSshConnection && isPortsPanelActive && !graceActiveRef.current) {
+    graceActiveRef.current = true
+  } else if (graceActiveRef.current && (hasActiveSshConnection || !isPortsPanelActive)) {
+    // Why: clear grace when either (a) the SSH session reconnects, or (b) the
+    // user navigates away from the Ports tab — no reason to keep it visible
+    // once they've moved on.
+    graceActiveRef.current = false
+    if (graceTimerRef.current) {
+      clearTimeout(graceTimerRef.current)
+      graceTimerRef.current = null
+    }
+  }
+
+  const disconnectGraceActive = graceActiveRef.current
+
+  useEffect(() => {
+    if (disconnectGraceActive) {
+      graceTimerRef.current = setTimeout(() => {
+        graceActiveRef.current = false
+        graceTimerRef.current = null
+        // Why: only reset the tab if the user is still on Ports. If they
+        // already navigated to Search/Checks/etc during the grace period,
+        // forcing them back to Explorer would be disruptive.
+        if (useAppStore.getState().rightSidebarTab === 'ports') {
+          setRightSidebarTab('explorer')
+        }
+        forceUpdate((n) => n + 1)
+      }, 30_000)
+      return () => {
+        if (graceTimerRef.current) {
+          clearTimeout(graceTimerRef.current)
+          graceTimerRef.current = null
+        }
+      }
+    }
+    return undefined
+  }, [disconnectGraceActive, setRightSidebarTab])
+
   const visibleItems = useMemo(
-    () => (isFolder ? ACTIVITY_ITEMS.filter((item) => !item.gitOnly) : ACTIVITY_ITEMS),
-    [isFolder]
+    () =>
+      ACTIVITY_ITEMS.filter((item) => {
+        if (item.gitOnly && isFolder) {
+          return false
+        }
+        if (item.sshOnly) {
+          if (!isRemoteWorktree) {
+            return false
+          }
+          if (!hasActiveSshConnection && !disconnectGraceActive) {
+            return false
+          }
+        }
+        return true
+      }),
+    [isFolder, isRemoteWorktree, hasActiveSshConnection, disconnectGraceActive]
   )
 
   // If the active tab is hidden (e.g. switched from a git repo to a folder),
@@ -151,6 +239,7 @@ function RightSidebarInner(): React.JSX.Element {
       {effectiveTab === 'search' && <SearchPanel />}
       {effectiveTab === 'source-control' && <SourceControl />}
       {effectiveTab === 'checks' && <ChecksPanel />}
+      {effectiveTab === 'ports' && <PortsPanel />}
     </div>
   )
 
@@ -318,7 +407,7 @@ function ActivityBarButton({
             active ? 'text-foreground' : 'text-muted-foreground/60 hover:text-muted-foreground'
           )}
           onClick={onClick}
-          aria-label={`${item.title} (${item.shortcut})`}
+          aria-label={item.shortcut ? `${item.title} (${item.shortcut})` : item.title}
         >
           <Icon size={isTop ? 16 : 18} />
 
@@ -343,7 +432,7 @@ function ActivityBarButton({
         </button>
       </TooltipTrigger>
       <TooltipContent side={isTop ? 'bottom' : 'left'} sideOffset={6}>
-        {item.title} ({item.shortcut})
+        {item.shortcut ? `${item.title} (${item.shortcut})` : item.title}
       </TooltipContent>
     </Tooltip>
   )

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -109,6 +109,9 @@ describe('useIpcEvents updater integration', () => {
           setRateLimitsFromPush: vi.fn(),
           setSshConnectionState: vi.fn(),
           setSshTargetLabels: vi.fn(),
+          setPortForwards: vi.fn(),
+          clearPortForwards: vi.fn(),
+          setDetectedPorts: vi.fn(),
           enqueueSshCredentialRequest: vi.fn(),
           removeSshCredentialRequest,
           settings: { terminalFontSize: 13 }
@@ -195,9 +198,13 @@ describe('useIpcEvents updater integration', () => {
         },
         ssh: {
           listTargets: () => Promise.resolve([]),
+          listPortForwards: () => Promise.resolve([]),
+          listDetectedPorts: () => Promise.resolve([]),
           getState: () => Promise.resolve(null),
           onStateChanged: () => () => {},
           onCredentialRequest: () => () => {},
+          onPortForwardsChanged: () => () => {},
+          onDetectedPortsChanged: () => () => {},
           onCredentialResolved: (listener: (data: { requestId: string }) => void) => {
             credentialResolvedListenerRef.current = listener
             return () => {}
@@ -258,6 +265,9 @@ describe('useIpcEvents updater integration', () => {
       setRateLimitsFromPush: vi.fn(),
       setSshConnectionState,
       setSshTargetLabels: vi.fn(),
+      setPortForwards: vi.fn(),
+      clearPortForwards: vi.fn(),
+      setDetectedPorts: vi.fn(),
       enqueueSshCredentialRequest: vi.fn(),
       removeSshCredentialRequest: vi.fn(),
       clearRemoteDetectedAgents: vi.fn(),
@@ -371,13 +381,17 @@ describe('useIpcEvents updater integration', () => {
         },
         ssh: {
           listTargets: () => Promise.resolve([]),
+          listPortForwards: () => Promise.resolve([]),
+          listDetectedPorts: () => Promise.resolve([]),
           getState: () => Promise.resolve(null),
           onStateChanged: (listener: (data: { targetId: string; state: unknown }) => void) => {
             sshStateListenerRef.current = listener
             return () => {}
           },
           onCredentialRequest: () => () => {},
-          onCredentialResolved: () => () => {}
+          onCredentialResolved: () => () => {},
+          onPortForwardsChanged: () => () => {},
+          onDetectedPortsChanged: () => () => {}
         }
       }
     })
@@ -459,6 +473,9 @@ describe('useIpcEvents updater integration', () => {
           setRateLimitsFromPush: vi.fn(),
           setSshConnectionState: vi.fn(),
           setSshTargetLabels: vi.fn(),
+          setPortForwards: vi.fn(),
+          clearPortForwards: vi.fn(),
+          setDetectedPorts: vi.fn(),
           enqueueSshCredentialRequest: vi.fn(),
           removeSshCredentialRequest: vi.fn(),
           clearTabPtyId: vi.fn(),
@@ -548,9 +565,13 @@ describe('useIpcEvents updater integration', () => {
         },
         ssh: {
           listTargets: () => Promise.resolve([]),
+          listPortForwards: () => Promise.resolve([]),
+          listDetectedPorts: () => Promise.resolve([]),
           getState: () => Promise.resolve(null),
           onStateChanged: () => () => {},
           onCredentialRequest: () => () => {},
+          onPortForwardsChanged: () => () => {},
+          onDetectedPortsChanged: () => () => {},
           onCredentialResolved: () => () => {}
         }
       }
@@ -632,6 +653,9 @@ describe('useIpcEvents browser tab close routing', () => {
           setRateLimitsFromPush: vi.fn(),
           setSshConnectionState: vi.fn(),
           setSshTargetLabels: vi.fn(),
+          setPortForwards: vi.fn(),
+          clearPortForwards: vi.fn(),
+          setDetectedPorts: vi.fn(),
           enqueueSshCredentialRequest: vi.fn(),
           removeSshCredentialRequest: vi.fn(),
           settings: { terminalFontSize: 13 },
@@ -737,9 +761,13 @@ describe('useIpcEvents browser tab close routing', () => {
         },
         ssh: {
           listTargets: () => Promise.resolve([]),
+          listPortForwards: () => Promise.resolve([]),
+          listDetectedPorts: () => Promise.resolve([]),
           getState: () => Promise.resolve(null),
           onStateChanged: () => () => {},
           onCredentialRequest: () => () => {},
+          onPortForwardsChanged: () => () => {},
+          onDetectedPortsChanged: () => () => {},
           onCredentialResolved: () => () => {}
         }
       }
@@ -805,6 +833,9 @@ describe('useIpcEvents browser tab close routing', () => {
           setRateLimitsFromPush: vi.fn(),
           setSshConnectionState: vi.fn(),
           setSshTargetLabels: vi.fn(),
+          setPortForwards: vi.fn(),
+          clearPortForwards: vi.fn(),
+          setDetectedPorts: vi.fn(),
           enqueueSshCredentialRequest: vi.fn(),
           removeSshCredentialRequest: vi.fn(),
           settings: { terminalFontSize: 13 },
@@ -911,9 +942,13 @@ describe('useIpcEvents browser tab close routing', () => {
         },
         ssh: {
           listTargets: () => Promise.resolve([]),
+          listPortForwards: () => Promise.resolve([]),
+          listDetectedPorts: () => Promise.resolve([]),
           getState: () => Promise.resolve(null),
           onStateChanged: () => () => {},
           onCredentialRequest: () => () => {},
+          onPortForwardsChanged: () => () => {},
+          onDetectedPortsChanged: () => () => {},
           onCredentialResolved: () => () => {}
         }
       }
@@ -977,6 +1012,9 @@ describe('useIpcEvents browser tab close routing', () => {
           setRateLimitsFromPush: vi.fn(),
           setSshConnectionState: vi.fn(),
           setSshTargetLabels: vi.fn(),
+          setPortForwards: vi.fn(),
+          clearPortForwards: vi.fn(),
+          setDetectedPorts: vi.fn(),
           enqueueSshCredentialRequest: vi.fn(),
           removeSshCredentialRequest: vi.fn(),
           settings: { terminalFontSize: 13 },
@@ -1080,9 +1118,13 @@ describe('useIpcEvents browser tab close routing', () => {
         },
         ssh: {
           listTargets: () => Promise.resolve([]),
+          listPortForwards: () => Promise.resolve([]),
+          listDetectedPorts: () => Promise.resolve([]),
           getState: () => Promise.resolve(null),
           onStateChanged: () => () => {},
           onCredentialRequest: () => () => {},
+          onPortForwardsChanged: () => () => {},
+          onDetectedPortsChanged: () => () => {},
           onCredentialResolved: () => () => {}
         }
       }
@@ -1166,6 +1208,9 @@ describe('useIpcEvents shortcut hint clearing', () => {
           setRateLimitsFromPush: vi.fn(),
           setSshConnectionState: vi.fn(),
           setSshTargetLabels: vi.fn(),
+          setPortForwards: vi.fn(),
+          clearPortForwards: vi.fn(),
+          setDetectedPorts: vi.fn(),
           enqueueSshCredentialRequest: vi.fn(),
           removeSshCredentialRequest: vi.fn(),
           clearTabPtyId: vi.fn(),
@@ -1258,9 +1303,13 @@ describe('useIpcEvents shortcut hint clearing', () => {
         },
         ssh: {
           listTargets: () => Promise.resolve([]),
+          listPortForwards: () => Promise.resolve([]),
+          listDetectedPorts: () => Promise.resolve([]),
           getState: () => Promise.resolve(null),
           onStateChanged: () => () => {},
           onCredentialRequest: () => () => {},
+          onPortForwardsChanged: () => () => {},
+          onDetectedPortsChanged: () => () => {},
           onCredentialResolved: () => () => {}
         }
       }

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -518,6 +518,24 @@ export function useIpcEvents(): void {
           const state = await window.api.ssh.getState({ targetId: target.id })
           if (state) {
             useAppStore.getState().setSshConnectionState(target.id, state as SshConnectionState)
+            // Why: if the renderer reattaches while an SSH session is alive
+            // (e.g. window re-creation or reload), forwarded and detected ports
+            // are only populated via push events. Fetch current snapshots so the
+            // Ports panel doesn't show empty for an active session.
+            if ((state as SshConnectionState).status === 'connected') {
+              const [forwards, detected] = await Promise.all([
+                window.api.ssh.listPortForwards({ targetId: target.id }),
+                window.api.ssh.listDetectedPorts({ targetId: target.id })
+              ])
+              // Why: if the session disconnected while we were awaiting the
+              // snapshot, the disconnect handler already cleared port state.
+              // Applying stale data here would resurrect a dead session's ports.
+              const currentState = useAppStore.getState().sshConnectionStates.get(target.id)
+              if (currentState?.status === 'connected') {
+                useAppStore.getState().setPortForwards(target.id, forwards)
+                useAppStore.getState().setDetectedPorts(target.id, detected)
+              }
+            }
           }
         }
         useAppStore.getState().setSshTargetLabels(labels)
@@ -535,6 +553,18 @@ export function useIpcEvents(): void {
     unsubs.push(
       window.api.ssh.onCredentialResolved(({ requestId }) => {
         useAppStore.getState().removeSshCredentialRequest(requestId)
+      })
+    )
+
+    unsubs.push(
+      window.api.ssh.onPortForwardsChanged(({ targetId, forwards }) => {
+        useAppStore.getState().setPortForwards(targetId, forwards)
+      })
+    )
+
+    unsubs.push(
+      window.api.ssh.onDetectedPortsChanged(({ targetId, ports }) => {
+        useAppStore.getState().setDetectedPorts(targetId, ports)
       })
     )
 
@@ -568,6 +598,11 @@ export function useIpcEvents(): void {
           // promise. When the user reconnects and opens the quick-launch menu,
           // ensureRemoteDetectedAgents will re-detect against the new relay.
           store.clearRemoteDetectedAgents(data.targetId)
+
+          // Why: defensive — clear port forward and detected port state in case
+          // the broadcast from removeAllForwards races with the state change.
+          store.clearPortForwards(data.targetId)
+          store.setDetectedPorts(data.targetId, [])
 
           // Why: an explicit disconnect or terminal failure tears down the SSH
           // PTY provider without emitting per-PTY exit events. Clear the stale

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -119,7 +119,7 @@ export type OpenFile = {
   mode: 'edit' | 'diff' | 'conflict-review' | 'markdown-preview'
 }
 
-export type RightSidebarTab = 'explorer' | 'search' | 'source-control' | 'checks'
+export type RightSidebarTab = 'explorer' | 'search' | 'source-control' | 'checks' | 'ports'
 export type ActivityBarPosition = 'top' | 'side'
 
 export type MarkdownViewMode = 'source' | 'rich' | 'preview'
@@ -827,7 +827,12 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
       // after close. Adding them to the reopen stack would let Cmd+Shift+T
       // try to reopen a path that no longer exists. Preview tabs are also
       // excluded — they are ephemeral views, not user-opened files.
-      if (closedFile && wtRecent && !shouldDeleteFromDisk && closedFile.mode !== 'markdown-preview') {
+      if (
+        closedFile &&
+        wtRecent &&
+        !shouldDeleteFromDisk &&
+        closedFile.mode !== 'markdown-preview'
+      ) {
         const { id: _id, isDirty: _dirty, ...snap } = closedFile
         const stack = s.recentlyClosedEditorTabsByWorktree[wtRecent] ?? []
         nextRecentlyClosed = {

--- a/src/renderer/src/store/slices/ssh.ts
+++ b/src/renderer/src/store/slices/ssh.ts
@@ -1,6 +1,10 @@
 import type { StateCreator } from 'zustand'
 import type { AppState } from '../types'
-import type { SshConnectionState } from '../../../../shared/ssh-types'
+import type {
+  SshConnectionState,
+  PortForwardEntry,
+  DetectedPort
+} from '../../../../shared/ssh-types'
 
 export type SshCredentialRequest = {
   requestId: string
@@ -19,11 +23,22 @@ export type SshSlice = {
    * components like the file explorer to re-trigger data loads that failed
    * before the connection was established. */
   sshConnectedGeneration: number
+  /** Port forwards keyed by connection ID. Updated via push events from main.
+   *  Why Record instead of Map: Zustand selectors use shallow-equality on plain
+   *  objects. Spreading a Record produces a new reference that Zustand can diff
+   *  by identity, whereas Map mutations are easy to get wrong. */
+  portForwardsByConnection: Record<string, PortForwardEntry[]>
+  /** Detected listening ports on the remote, keyed by connection ID.
+   *  Updated by polling the relay's ports.detect RPC. */
+  detectedPortsByConnection: Record<string, DetectedPort[]>
   setSshConnectionState: (targetId: string, state: SshConnectionState) => void
   setSshTargetLabels: (labels: Map<string, string>) => void
   enqueueSshCredentialRequest: (req: SshCredentialRequest) => void
   removeSshCredentialRequest: (requestId: string) => void
   bumpSshConnectedGeneration: () => void
+  setPortForwards: (targetId: string, forwards: PortForwardEntry[]) => void
+  clearPortForwards: (targetId: string) => void
+  setDetectedPorts: (targetId: string, ports: DetectedPort[]) => void
 }
 
 export const createSshSlice: StateCreator<AppState, [], [], SshSlice> = (set) => ({
@@ -31,6 +46,8 @@ export const createSshSlice: StateCreator<AppState, [], [], SshSlice> = (set) =>
   sshTargetLabels: new Map(),
   sshCredentialQueue: [],
   sshConnectedGeneration: 0,
+  portForwardsByConnection: {},
+  detectedPortsByConnection: {},
 
   setSshConnectionState: (targetId, state) =>
     set((s) => {
@@ -47,5 +64,33 @@ export const createSshSlice: StateCreator<AppState, [], [], SshSlice> = (set) =>
       sshCredentialQueue: s.sshCredentialQueue.filter((req) => req.requestId !== requestId)
     })),
   bumpSshConnectedGeneration: () =>
-    set((s) => ({ sshConnectedGeneration: s.sshConnectedGeneration + 1 }))
+    set((s) => ({ sshConnectedGeneration: s.sshConnectedGeneration + 1 })),
+
+  setPortForwards: (targetId, forwards) =>
+    set((s) => {
+      const next = { ...s.portForwardsByConnection }
+      if (forwards.length > 0) {
+        next[targetId] = forwards
+      } else {
+        delete next[targetId]
+      }
+      return { portForwardsByConnection: next }
+    }),
+
+  clearPortForwards: (targetId) =>
+    set((s) => {
+      const { [targetId]: _, ...rest } = s.portForwardsByConnection
+      return { portForwardsByConnection: rest }
+    }),
+
+  setDetectedPorts: (targetId, ports) =>
+    set((s) => {
+      const next = { ...s.detectedPortsByConnection }
+      if (ports.length > 0) {
+        next[targetId] = ports
+      } else {
+        delete next[targetId]
+      }
+      return { detectedPortsByConnection: next }
+    })
 })

--- a/src/shared/ssh-types.ts
+++ b/src/shared/ssh-types.ts
@@ -22,6 +22,16 @@ export type SshTarget = {
    *  partition targets into eager (no passphrase) vs deferred (passphrase)
    *  without attempting a connection first. */
   lastRequiredPassphrase?: boolean
+  /** Port forwards to auto-restore on connect/reconnect. Persisted so
+   *  forwards survive app restarts. */
+  portForwards?: SavedPortForward[]
+}
+
+export type SavedPortForward = {
+  localPort: number
+  remoteHost: string
+  remotePort: number
+  label?: string
 }
 
 export type SshConnectionStatus =
@@ -40,4 +50,25 @@ export type SshConnectionState = {
   error: string | null
   /** Number of reconnection attempts since last disconnect. */
   reconnectAttempt: number
+}
+
+// ─── Port Forwarding Types ─────────────────────────────────────────
+
+export type PortForwardEntry = {
+  id: string
+  connectionId: string
+  localPort: number
+  remoteHost: string
+  remotePort: number
+  label?: string
+}
+
+/** A listening port detected on the remote host via /proc/net/tcp scanning.
+ *  Keep in sync with src/relay/port-scan-handler.ts — DetectedPort.
+ *  The relay is deployed as a standalone bundle and cannot import from shared. */
+export type DetectedPort = {
+  port: number
+  host: string
+  pid?: number
+  processName?: string
 }


### PR DESCRIPTION
## Summary
- Adds SSH port forwarding support with a **Ports** panel in the right sidebar, enabling users to forward remote ports to their local machine
- Auto-detects listening ports on remote Linux hosts via `/proc/net/tcp` scanning
- Persists port forwards across app restarts and SSH reconnects
- Scopes the Ports tab to the active SSH worktree only (hidden for local worktrees)
- Adds keyboard shortcut (Cmd+Shift+I) to toggle the Ports panel

### Key implementation details
- Modal dialog for add/edit port forwards with input validation (port range, EADDRINUSE, EACCES)
- Async `server.close()` handling to prevent EADDRINUSE on same-port edits and reconnects
- Connection liveness checks during restore to prevent stale forward leaks on disconnect/reconnect races
- Split persistence helpers: `persistPortForwards` (user actions) vs `persistPortForwardsWithUnrestored` (restore path) to prevent removed forwards from reappearing

Closes #1028

## Test plan
- [ ] Connect to a remote SSH worktree → Ports tab appears in right sidebar
- [ ] Switch to a local worktree → Ports tab disappears
- [ ] Click "Add" → modal opens, fill in remote port → forward created, local port accessible
- [ ] Click pencil icon on a forward → edit modal opens pre-filled, change port → updated
- [ ] Click trash icon → forward removed
- [ ] Start a service on remote (e.g. `python -m http.server 8000`) → detected in "Detected" section
- [ ] Click "Forward" on detected port → opens pre-filled modal
- [ ] Restart app → previously forwarded ports are restored automatically
- [ ] Disconnect and reconnect SSH → forwards are restored after reconnect
- [ ] Forward a privileged port (e.g. 80) → local port auto-remaps to 10080
- [ ] Try to forward a port already in use → clear error message shown
- [ ] Cmd+Shift+I → toggles Ports panel open/closed

Made with [Orca](https://github.com/stablyai/orca) 🐋
