### PR TITLE
feat(memory): add Memory & CPU status-bar popover

### DIFF
--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -109,12 +109,17 @@ export class DaemonPtyAdapter implements IPtyProvider {
       this.initialCwds.set(sessionId, effectiveCwd)
     }
 
+    // Why: the daemon RPC returns the shell pid of the backing subprocess.
+    // Surfacing it through PtySpawnResult lets ipc/pty register with the
+    // memory collector without a provider-specific accessor.
+    const pid = typeof result.pid === 'number' && result.pid > 0 ? result.pid : null
+
     // Why: check sticky cache first — StrictMode double-mounts call spawn
     // twice. The second call finds an existing daemon session (isNew=false)
     // but should still return the cached cold restore data.
     const cachedRestore = this.coldRestoreCache.get(sessionId)
     if (cachedRestore) {
-      return { id: sessionId, coldRestore: cachedRestore }
+      return { id: sessionId, pid, coldRestore: cachedRestore }
     }
 
     // Cold restore: daemon created a new session but disk history shows
@@ -137,7 +142,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
           })
           .catch((err) => console.warn('[history] openSession failed:', sessionId, err))
       }
-      return { id: sessionId, coldRestore }
+      return { id: sessionId, pid, coldRestore }
     }
 
     if (this.historyManager && result.isNew) {
@@ -153,13 +158,14 @@ export class DaemonPtyAdapter implements IPtyProvider {
 
     const isReattach = !result.isNew
     if (!isReattach || !result.snapshot) {
-      return { id: sessionId }
+      return { id: sessionId, pid }
     }
 
     const isAltScreen = result.snapshot.modes.alternateScreen
     const snapshotPayload = result.snapshot.rehydrateSequences + result.snapshot.snapshotAnsi
     return {
       id: sessionId,
+      pid,
       snapshot: snapshotPayload,
       snapshotCols: result.snapshot.cols,
       snapshotRows: result.snapshot.rows,

--- a/src/main/ipc/memory.ts
+++ b/src/main/ipc/memory.ts
@@ -1,0 +1,8 @@
+import { ipcMain } from 'electron'
+import type { MemorySnapshot } from '../../shared/types'
+import type { Store } from '../persistence'
+import { collectMemorySnapshot } from '../memory/collector'
+
+export function registerMemoryHandlers(store: Store): void {
+  ipcMain.handle('memory:getSnapshot', (): Promise<MemorySnapshot> => collectMemorySnapshot(store))
+}

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -767,7 +767,7 @@ describe('registerPtyHandlers', () => {
         cwd: '/tmp'
       })
 
-      expect(result).toEqual({ id: expect.any(String) })
+      expect(result).toEqual({ id: expect.any(String), pid: 12345 })
       expect(spawnMock).toHaveBeenCalledTimes(1)
       expect(spawnMock).toHaveBeenCalledWith(
         '/bin/zsh',

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -21,6 +21,7 @@ import {
   markClaudePtySpawned
 } from '../claude-accounts/live-pty-gate'
 import { applyTerminalAttributionEnv } from '../attribution/terminal-attribution'
+import { registerPty, unregisterPty } from '../memory/pty-registry'
 
 // ─── Provider Registry ──────────────────────────────────────────────
 // Routes PTY operations by connectionId. null = local provider.
@@ -159,6 +160,10 @@ export function clearProviderPtyState(id: string): void {
   // new teardown path forgets to remove one provider's overlay/hook state.
   openCodeHookService.clearPty(id)
   piTitlebarExtensionService.clearPty(id)
+  // Why: drop the memory-collector registration so a dead PTY does not keep
+  // trying to resolve its (now-dead) pid on every snapshot. Safe no-op for
+  // PTYs that were never registered (SSH-owned).
+  unregisterPty(id)
   // Why: the hook server's per-paneKey caches (lastPrompt / lastTool) would
   // otherwise accumulate entries for dead panes over the process lifetime.
   // Use the spawn-time paneKey mapping since the server has no other way to
@@ -486,6 +491,43 @@ export function registerPtyHandlers(
       if (typeof paneKey === 'string' && paneKey.length > 0 && paneKey.length <= 256) {
         ptyPaneKey.set(result.id, paneKey)
         paneKeyPtyId.set(paneKey, result.id)
+      }
+      // Why: register local PTYs (connectionId falsy) with the memory
+      // collector so it can walk each PTY's process subtree and attribute
+      // memory back to its worktree. SSH PTYs execute remotely and their
+      // process tree is not visible to our local `ps`, so we skip them.
+      if (!args.connectionId) {
+        // Why: providers publish the OS pid on the spawn result (both
+        // LocalPtyProvider and DaemonPtyAdapter). Recording it once here keeps
+        // the memory module from reaching back into ipc/pty on a hot path, and
+        // works uniformly whether the PTY is hosted in-process or by the
+        // daemon subprocess.
+        const spawnedPid = result.pid ?? null
+        // Why: args.worktreeId and args.sessionId arrive as untrusted IPC
+        // payload strings — the static type is not enforced at the boundary.
+        // Narrow them to bounded strings here to match the paneKey defense
+        // above so malformed or oversized values cannot pollute registerPty's
+        // maps or downstream memory-attribution lookups.
+        registerPty({
+          ptyId: result.id,
+          worktreeId:
+            typeof args.worktreeId === 'string' &&
+            args.worktreeId.length > 0 &&
+            args.worktreeId.length <= 512
+              ? args.worktreeId
+              : null,
+          sessionId:
+            typeof args.sessionId === 'string' &&
+            args.sessionId.length > 0 &&
+            args.sessionId.length <= 256
+              ? args.sessionId
+              : null,
+          paneKey: typeof paneKey === 'string' ? paneKey : null,
+          pid:
+            typeof spawnedPid === 'number' && Number.isFinite(spawnedPid) && spawnedPid > 0
+              ? spawnedPid
+              : null
+        })
       }
       return result
     }

--- a/src/main/ipc/register-core-handlers.test.ts
+++ b/src/main/ipc/register-core-handlers.test.ts
@@ -8,6 +8,7 @@ const {
   registerGitHubHandlersMock,
   registerFeedbackHandlersMock,
   registerStatsHandlersMock,
+  registerMemoryHandlersMock,
   registerNotificationHandlersMock,
   registerSettingsHandlersMock,
   registerShellHandlersMock,
@@ -36,6 +37,7 @@ const {
   registerGitHubHandlersMock: vi.fn(),
   registerFeedbackHandlersMock: vi.fn(),
   registerStatsHandlersMock: vi.fn(),
+  registerMemoryHandlersMock: vi.fn(),
   registerNotificationHandlersMock: vi.fn(),
   registerSettingsHandlersMock: vi.fn(),
   registerShellHandlersMock: vi.fn(),
@@ -88,6 +90,10 @@ vi.mock('./export', () => ({
 
 vi.mock('./stats', () => ({
   registerStatsHandlers: registerStatsHandlersMock
+}))
+
+vi.mock('./memory', () => ({
+  registerMemoryHandlers: registerMemoryHandlersMock
 }))
 
 vi.mock('./notifications', () => ({
@@ -168,6 +174,7 @@ describe('registerCoreHandlers', () => {
     registerGitHubHandlersMock.mockReset()
     registerFeedbackHandlersMock.mockReset()
     registerStatsHandlersMock.mockReset()
+    registerMemoryHandlersMock.mockReset()
     registerNotificationHandlersMock.mockReset()
     registerSettingsHandlersMock.mockReset()
     registerShellHandlersMock.mockReset()
@@ -221,6 +228,7 @@ describe('registerCoreHandlers', () => {
     expect(registerLinearHandlersMock).toHaveBeenCalled()
     expect(registerFeedbackHandlersMock).toHaveBeenCalled()
     expect(registerStatsHandlersMock).toHaveBeenCalledWith(stats)
+    expect(registerMemoryHandlersMock).toHaveBeenCalledWith(store)
     expect(registerNotificationHandlersMock).toHaveBeenCalledWith(store)
     expect(registerSettingsHandlersMock).toHaveBeenCalledWith(store)
     expect(registerSessionHandlersMock).toHaveBeenCalledWith(store)
@@ -267,5 +275,8 @@ describe('registerCoreHandlers', () => {
     expect(registerCliHandlersMock).not.toHaveBeenCalled()
     expect(registerPreflightHandlersMock).not.toHaveBeenCalled()
     expect(registerBrowserHandlersMock).not.toHaveBeenCalled()
+    // Why: ipcMain.handle throws on duplicate channel registration, so the
+    // memory handler must not be wired up a second time on reactivation.
+    expect(registerMemoryHandlersMock).not.toHaveBeenCalled()
   })
 })

--- a/src/main/ipc/register-core-handlers.ts
+++ b/src/main/ipc/register-core-handlers.ts
@@ -13,6 +13,7 @@ import { registerLinearHandlers } from './linear'
 import { registerFeedbackHandlers } from './feedback'
 import { registerExportHandlers } from './export'
 import { registerStatsHandlers } from './stats'
+import { registerMemoryHandlers } from './memory'
 import { registerRateLimitHandlers } from './rate-limits'
 import { registerRuntimeHandlers } from './runtime'
 import { registerNotificationHandlers } from './notifications'
@@ -75,6 +76,7 @@ export function registerCoreHandlers(
   registerFeedbackHandlers()
   registerExportHandlers()
   registerStatsHandlers(stats)
+  registerMemoryHandlers(store)
   registerNotificationHandlers(store)
   registerSettingsHandlers(store)
   registerBrowserHandlers()

--- a/src/main/memory/collector.test.ts
+++ b/src/main/memory/collector.test.ts
@@ -1,0 +1,303 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Store } from '../persistence'
+
+vi.mock('electron', () => ({
+  app: {
+    getAppMetrics: () => []
+  }
+}))
+
+const { execMock, listRegisteredPtysMock } = vi.hoisted(() => ({
+  execMock: vi.fn(),
+  listRegisteredPtysMock: vi.fn()
+}))
+
+vi.mock('child_process', () => ({
+  exec: (cmd: string, opts: unknown, cb: (err: Error | null, out: { stdout: string }) => void) =>
+    execMock(cmd, opts, cb)
+}))
+
+vi.mock('./pty-registry', () => ({
+  listRegisteredPtys: listRegisteredPtysMock
+}))
+
+async function loadCollector() {
+  vi.resetModules()
+  return await import('./collector')
+}
+
+const emptyStore = {
+  getWorktreeMeta: () => undefined,
+  getRepo: () => undefined
+} as unknown as Store
+
+describe('parsePsOutput', () => {
+  it('parses a well-formed listing into rows', async () => {
+    const { parsePsOutput } = await loadCollector()
+    const stdout = ['  1 0 0.1 1024', '123 1 5.5 2048', '456 123 0.0 512'].join('\n')
+
+    const rows = parsePsOutput(stdout)
+
+    expect(rows).toEqual([
+      { pid: 1, ppid: 0, cpu: 0.1, memory: 1024 * 1024 },
+      { pid: 123, ppid: 1, cpu: 5.5, memory: 2048 * 1024 },
+      { pid: 456, ppid: 123, cpu: 0, memory: 512 * 1024 }
+    ])
+  })
+
+  it('parses dot-decimal cpu values (LC_ALL=C contract)', async () => {
+    const { parsePsOutput } = await loadCollector()
+    // Why: the enumerator forces LC_ALL=C so ps emits dots, not commas.
+    // If that env override is removed, de_DE systems emit "12,5" and
+    // parseFloat silently returns 12. This test pins the parser's
+    // assumption so the regression is caught here, not in the field.
+    const rows = parsePsOutput('10 1 12.5 1024')
+    expect(rows[0].cpu).toBe(12.5)
+  })
+
+  it('skips blank lines and rows with too few fields', async () => {
+    const { parsePsOutput } = await loadCollector()
+    const rows = parsePsOutput('\n  \n10 1 0.0\n20 1 0.0 512\n')
+    expect(rows).toEqual([{ pid: 20, ppid: 1, cpu: 0, memory: 512 * 1024 }])
+  })
+
+  it('skips rows whose pid or ppid fail to parse', async () => {
+    const { parsePsOutput } = await loadCollector()
+    const rows = parsePsOutput(['abc 1 0.0 100', '10 xyz 0.0 100', '20 1 0.0 100'].join('\n'))
+    expect(rows.map((r) => r.pid)).toEqual([20])
+  })
+
+  it('clamps negative or NaN cpu/memory to 0', async () => {
+    const { parsePsOutput } = await loadCollector()
+    const rows = parsePsOutput('10 1 -5 -100')
+    expect(rows[0].cpu).toBe(0)
+    expect(rows[0].memory).toBe(0)
+  })
+})
+
+describe('parseWmicOutput', () => {
+  it('emits one row per blank-line-delimited stanza', async () => {
+    const { parseWmicOutput } = await loadCollector()
+    const stdout = [
+      'ParentProcessId=1',
+      'ProcessId=100',
+      'WorkingSetSize=2048',
+      '',
+      'ParentProcessId=100',
+      'ProcessId=200',
+      'WorkingSetSize=1024',
+      ''
+    ].join('\r\n')
+
+    const rows = parseWmicOutput(stdout)
+
+    expect(rows).toEqual([
+      { pid: 100, ppid: 1, cpu: 0, memory: 2048 },
+      { pid: 200, ppid: 100, cpu: 0, memory: 1024 }
+    ])
+  })
+
+  it('flushes the final stanza even without a trailing blank line', async () => {
+    const { parseWmicOutput } = await loadCollector()
+    const rows = parseWmicOutput('ProcessId=100\nParentProcessId=1\nWorkingSetSize=512')
+    expect(rows).toEqual([{ pid: 100, ppid: 1, cpu: 0, memory: 512 }])
+  })
+
+  it('skips stanzas missing pid or ppid', async () => {
+    const { parseWmicOutput } = await loadCollector()
+    // Why: wmic occasionally emits a stanza with only WorkingSetSize set
+    // (e.g. a process that exited mid-query). Dropping such rows avoids
+    // injecting ghost zero-pid entries into the index.
+    const stdout = ['WorkingSetSize=999', '', 'ProcessId=100', 'ParentProcessId=1'].join('\n')
+    const rows = parseWmicOutput(stdout)
+    expect(rows).toEqual([{ pid: 100, ppid: 1, cpu: 0, memory: 0 }])
+  })
+
+  it('ignores lines without an equals separator', async () => {
+    const { parseWmicOutput } = await loadCollector()
+    const rows = parseWmicOutput(['garbage line', 'ProcessId=5', 'ParentProcessId=1'].join('\n'))
+    expect(rows).toEqual([{ pid: 5, ppid: 1, cpu: 0, memory: 0 }])
+  })
+})
+
+describe('collectSubtree', () => {
+  function makeIndex(rows: { pid: number; ppid: number }[]) {
+    const byPid = new Map<number, { pid: number; ppid: number; cpu: number; memory: number }>()
+    const childrenOf = new Map<number, number[]>()
+    for (const r of rows) {
+      byPid.set(r.pid, { ...r, cpu: 0, memory: 0 })
+      const kids = childrenOf.get(r.ppid)
+      if (kids) {
+        kids.push(r.pid)
+      } else {
+        childrenOf.set(r.ppid, [r.pid])
+      }
+    }
+    return { byPid, childrenOf }
+  }
+
+  it('walks every descendant of the root inclusive', async () => {
+    const { collectSubtree } = await loadCollector()
+    const index = makeIndex([
+      { pid: 1, ppid: 0 },
+      { pid: 2, ppid: 1 },
+      { pid: 3, ppid: 1 },
+      { pid: 4, ppid: 2 },
+      { pid: 99, ppid: 0 } // unrelated branch
+    ])
+
+    const pids = collectSubtree(index, 1).sort((a, b) => a - b)
+
+    expect(pids).toEqual([1, 2, 3, 4])
+  })
+
+  it('does not revisit pids when cycles are present', async () => {
+    const { collectSubtree } = await loadCollector()
+    // Why: the ppid graph is untrusted — a buggy `ps` snapshot (or a
+    // wrapped/reparented process) could present a cycle. collectSubtree
+    // must terminate and not double-count the same pid.
+    const index = makeIndex([
+      { pid: 1, ppid: 2 },
+      { pid: 2, ppid: 1 }
+    ])
+
+    const pids = collectSubtree(index, 1).sort((a, b) => a - b)
+
+    expect(pids).toEqual([1, 2])
+  })
+
+  it('returns only pids that exist in byPid', async () => {
+    const { collectSubtree } = await loadCollector()
+    // Why: childrenOf may reference a pid that no longer has a row (it
+    // exited between sampling its parent and sampling itself). We list
+    // those as "walked" but do not fabricate a row for them.
+    const index = {
+      byPid: new Map([[1, { pid: 1, ppid: 0, cpu: 0, memory: 0 }]]),
+      childrenOf: new Map([[1, [2]]])
+    }
+
+    expect(collectSubtree(index, 1)).toEqual([1])
+  })
+})
+
+describe('collectMemorySnapshot', () => {
+  beforeEach(() => {
+    execMock.mockReset()
+    listRegisteredPtysMock.mockReset()
+    listRegisteredPtysMock.mockReturnValue([])
+  })
+
+  function mockPsResponse(stdout: string) {
+    execMock.mockImplementation((_cmd, _opts, cb) => cb(null, { stdout, stderr: '' }))
+  }
+
+  it('coalesces concurrent callers onto a single in-flight sweep', async () => {
+    // Why: the collector exists in part to prevent a burst of renderer
+    // polls from spawning overlapping `ps` children. If a regression ever
+    // removes the `inflight` guard, this test catches it without needing
+    // to measure real process spawns.
+    mockPsResponse('1 0 0 1024')
+    const { collectMemorySnapshot } = await loadCollector()
+
+    const [a, b, c] = await Promise.all([
+      collectMemorySnapshot(emptyStore),
+      collectMemorySnapshot(emptyStore),
+      collectMemorySnapshot(emptyStore)
+    ])
+
+    expect(execMock).toHaveBeenCalledTimes(1)
+    // All three callers see the same snapshot object (same promise).
+    expect(a).toBe(b)
+    expect(b).toBe(c)
+  })
+
+  it('starts a fresh sweep after the prior one resolves', async () => {
+    mockPsResponse('1 0 0 1024')
+    const { collectMemorySnapshot } = await loadCollector()
+
+    await collectMemorySnapshot(emptyStore)
+    await collectMemorySnapshot(emptyStore)
+
+    expect(execMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('attributes a process shared by two PTYs to the first registrant only', async () => {
+    // Why: when two PTYs share an ancestor (e.g. a supervisor or a shell
+    // that re-execed), a naive per-PTY subtree walk would double-count
+    // the shared process. The `claimed` set in runSnapshot enforces
+    // first-wins attribution in registration order. This test pins that
+    // invariant — if the dedupe is lost, the totals balloon.
+    mockPsResponse(
+      [
+        '100 1 0 1024', // shared ancestor of both PTYs
+        '101 100 0 512', // pty A's only unique child
+        '102 100 0 256' // pty B's only unique child
+      ].join('\n')
+    )
+    listRegisteredPtysMock.mockReturnValue([
+      {
+        ptyId: 'pty-a',
+        worktreeId: 'repo-1::/wt/a',
+        sessionId: 's-a',
+        paneKey: 'p-a',
+        pid: 100 // sees {100, 101, 102}
+      },
+      {
+        ptyId: 'pty-b',
+        worktreeId: 'repo-1::/wt/b',
+        sessionId: 's-b',
+        paneKey: 'p-b',
+        pid: 100 // also rooted at 100, but every pid is already claimed
+      }
+    ])
+
+    const { collectMemorySnapshot } = await loadCollector()
+    const snap = await collectMemorySnapshot(emptyStore)
+
+    const byWt = new Map(snap.worktrees.map((w) => [w.worktreeId, w]))
+    const a = byWt.get('repo-1::/wt/a')
+    const b = byWt.get('repo-1::/wt/b')
+
+    // pty-a claims all three pids (1024 + 512 + 256 KiB).
+    expect(a?.memory).toBe((1024 + 512 + 256) * 1024)
+    // pty-b gets zero because everything it would walk is already claimed.
+    expect(b?.memory).toBe(0)
+    // And the overall session memory equals the unique sum, not the
+    // double-walked sum — this is the actual regression we care about.
+    expect(snap.totalMemory).toBe((1024 + 512 + 256) * 1024)
+  })
+
+  it('routes PTYs with no worktreeId into the orphan bucket', async () => {
+    mockPsResponse('50 1 0 2048')
+    listRegisteredPtysMock.mockReturnValue([
+      {
+        ptyId: 'pty-orphan',
+        worktreeId: null,
+        sessionId: null,
+        paneKey: null,
+        pid: 50
+      }
+    ])
+
+    const { collectMemorySnapshot } = await loadCollector()
+    const snap = await collectMemorySnapshot(emptyStore)
+
+    expect(snap.worktrees).toHaveLength(1)
+    expect(snap.worktrees[0].worktreeId).toBe('__orphan__')
+    expect(snap.worktrees[0].memory).toBe(2048 * 1024)
+  })
+
+  it('returns an empty snapshot when ps fails', async () => {
+    execMock.mockImplementation((_cmd, _opts, cb) => cb(new Error('ps blew up'), { stdout: '' }))
+    listRegisteredPtysMock.mockReturnValue([])
+
+    const { collectMemorySnapshot } = await loadCollector()
+    const snap = await collectMemorySnapshot(emptyStore)
+
+    // ps failure should not surface as a rejected promise or crash the
+    // renderer; the collector swallows and returns zeros so the UI can
+    // render an empty state.
+    expect(snap.worktrees).toEqual([])
+    expect(snap.totalMemory).toBe(0)
+  })
+})

--- a/src/main/memory/collector.ts
+++ b/src/main/memory/collector.ts
@@ -1,0 +1,503 @@
+/* eslint-disable max-lines -- Why: the collector's platform-specific
+   enumeration paths (`ps` on Unix, `wmic` on Windows) plus the history
+   ring buffer plus the Electron bucketing live together to keep one
+   snapshot's worth of code in one place. Splitting them produces extra
+   modules whose only consumer is this file. */
+/**
+ * Memory dashboard collector.
+ *
+ * One snapshot covers two sources:
+ *   - Orca's own Electron processes, via `app.getAppMetrics()`, bucketed
+ *     into main / renderer / other.
+ *   - Each registered PTY's process subtree, enumerated once from a host-
+ *     wide `ps` sweep (`wmic` on Windows).
+ *
+ * Memory samples are held in a per-key ring (one key per worktree, plus
+ * a reserved app-total key) so the UI can draw a trend sparkline.
+ *
+ * Concurrent callers coalesce onto a single in-flight sweep so a burst of
+ * renderer polls never produces overlapping child processes.
+ */
+
+import { basename } from 'node:path'
+import { exec } from 'node:child_process'
+import { promisify } from 'node:util'
+import os from 'node:os'
+import { app } from 'electron'
+import type {
+  AppMemory,
+  MemorySnapshot,
+  HostMemory,
+  SessionMemory,
+  WorktreeMemory
+} from '../../shared/types'
+import type { Store } from '../persistence'
+import { ORPHAN_WORKTREE_ID } from '../../shared/constants'
+import { listRegisteredPtys } from './pty-registry'
+
+// ─── Module state ───────────────────────────────────────────────────
+
+let inflight: Promise<MemorySnapshot> | null = null
+
+// ─── Public API ─────────────────────────────────────────────────────
+
+export async function collectMemorySnapshot(store: Store): Promise<MemorySnapshot> {
+  // Why: coalescing relies on the persistence store being a process-wide
+  // singleton at runtime. Concurrent callers all hand in the same instance,
+  // so it is safe to return the existing in-flight promise (which was
+  // kicked off with that same store) rather than starting a second sweep.
+  if (inflight) {
+    return inflight
+  }
+  inflight = runSnapshot(store)
+    .catch((err) => {
+      console.warn('[memory] snapshot failed; returning empty', err)
+      return emptySnapshot()
+    })
+    .finally(() => {
+      inflight = null
+    })
+  return inflight
+}
+
+// ─── Internals ──────────────────────────────────────────────────────
+
+const execAsync = promisify(exec)
+const PS_EXEC_TIMEOUT_MS = 5_000
+const PS_MAX_BUFFER = 10 * 1024 * 1024
+
+/** One row from the host-wide process listing. */
+type ProcRow = {
+  pid: number
+  ppid: number
+  /** Percent of one core (may exceed 100 on multi-core). 0 on Windows. */
+  cpu: number
+  /** Resident memory in bytes. */
+  memory: number
+}
+
+/** Indexed view of a single `ps`/`wmic` sweep. */
+type ProcIndex = {
+  byPid: Map<number, ProcRow>
+  childrenOf: Map<number, number[]>
+}
+
+function clampNumber(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return 0
+  }
+  return Math.max(0, value)
+}
+
+function hostMetrics(): HostMemory {
+  const total = clampNumber(os.totalmem())
+  const free = clampNumber(os.freemem())
+  const used = Math.max(0, total - free)
+  return {
+    totalMemory: total,
+    freeMemory: free,
+    usedMemory: used,
+    memoryUsagePercent: total > 0 ? (used / total) * 100 : 0,
+    cpuCoreCount: Math.max(1, os.cpus().length),
+    loadAverage1m: clampNumber(os.loadavg()[0])
+  }
+}
+
+function emptySnapshot(): MemorySnapshot {
+  const zero = { cpu: 0, memory: 0 }
+  return {
+    app: { ...zero, main: zero, renderer: zero, other: zero, history: [] },
+    worktrees: [],
+    host: hostMetrics(),
+    totalCpu: 0,
+    totalMemory: 0,
+    collectedAt: Date.now()
+  }
+}
+
+// ─── History ring buffers ───────────────────────────────────────────
+
+const APP_HISTORY_KEY = '__app__'
+const HISTORY_CAPACITY = 60
+const HISTORY_STALE_MS = 10 * 60 * 1000
+
+type HistoryRing = {
+  samples: number[]
+  touchedAt: number
+}
+
+const historyByKey = new Map<string, HistoryRing>()
+
+function pushHistorySample(key: string, memoryBytes: number, now: number): void {
+  let ring = historyByKey.get(key)
+  if (!ring) {
+    ring = { samples: [], touchedAt: now }
+    historyByKey.set(key, ring)
+  }
+  ring.samples.push(memoryBytes)
+  if (ring.samples.length > HISTORY_CAPACITY) {
+    ring.samples.shift()
+  }
+  ring.touchedAt = now
+}
+
+function readHistory(key: string): number[] {
+  const ring = historyByKey.get(key)
+  return ring ? [...ring.samples] : []
+}
+
+function sweepStaleHistory(now: number): void {
+  for (const [key, ring] of historyByKey) {
+    if (now - ring.touchedAt > HISTORY_STALE_MS) {
+      historyByKey.delete(key)
+    }
+  }
+}
+
+// ─── Host process enumeration ───────────────────────────────────────
+
+async function enumerateProcesses(): Promise<ProcIndex> {
+  const rows = os.platform() === 'win32' ? await enumerateWindows() : await enumerateUnix()
+
+  const byPid = new Map<number, ProcRow>()
+  const childrenOf = new Map<number, number[]>()
+
+  for (const row of rows) {
+    byPid.set(row.pid, row)
+    const siblings = childrenOf.get(row.ppid)
+    if (siblings) {
+      siblings.push(row.pid)
+    } else {
+      childrenOf.set(row.ppid, [row.pid])
+    }
+  }
+
+  return { byPid, childrenOf }
+}
+
+async function enumerateUnix(): Promise<ProcRow[]> {
+  // Why: `-o pcpu` formats the percentage with the current locale's decimal
+  // separator (e.g. "12,5" on de_DE). parseFloat is locale-agnostic and
+  // silently drops the fractional part at a comma. Forcing C locale keeps
+  // decimals as dots.
+  try {
+    const { stdout } = await execAsync('ps -eo pid=,ppid=,pcpu=,rss=', {
+      maxBuffer: PS_MAX_BUFFER,
+      timeout: PS_EXEC_TIMEOUT_MS,
+      env: { ...process.env, LC_ALL: 'C', LANG: 'C' }
+    })
+    return parsePsOutput(stdout)
+  } catch (err) {
+    console.warn('[memory] ps enumeration failed', err)
+    return []
+  }
+}
+
+/** Exported for tests: parses `ps -eo pid=,ppid=,pcpu=,rss=` output. */
+export function parsePsOutput(stdout: string): ProcRow[] {
+  const rows: ProcRow[] = []
+  const lines = stdout.split('\n')
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trim()
+    if (line.length === 0) {
+      continue
+    }
+    // Split on runs of whitespace. We requested exactly 4 columns.
+    const fields = line.split(/\s+/, 4)
+    if (fields.length < 4) {
+      continue
+    }
+    const pid = Number.parseInt(fields[0], 10)
+    const ppid = Number.parseInt(fields[1], 10)
+    const cpu = Number.parseFloat(fields[2])
+    const rssKb = Number.parseInt(fields[3], 10)
+    if (Number.isNaN(pid) || Number.isNaN(ppid)) {
+      continue
+    }
+    rows.push({
+      pid,
+      ppid,
+      cpu: Number.isFinite(cpu) && cpu > 0 ? cpu : 0,
+      memory: Number.isFinite(rssKb) && rssKb > 0 ? rssKb * 1024 : 0
+    })
+  }
+  return rows
+}
+
+async function enumerateWindows(): Promise<ProcRow[]> {
+  // Why: `wmic` ships with stock Windows and emits a plain, tab-separated
+  // table without the CSV-quoting edge cases PowerShell's ConvertTo-Csv
+  // introduces. CPU% would require delta sampling between two queries; for
+  // v1 we report 0% on Windows — memory attribution is the primary signal.
+  try {
+    const { stdout } = await execAsync(
+      'wmic process get ProcessId,ParentProcessId,WorkingSetSize /format:value',
+      { maxBuffer: PS_MAX_BUFFER, timeout: PS_EXEC_TIMEOUT_MS }
+    )
+    return parseWmicOutput(stdout)
+  } catch (err) {
+    console.warn('[memory] wmic enumeration failed', err)
+    return []
+  }
+}
+
+/** Exported for tests: parses `wmic /format:value` stanza output. */
+export function parseWmicOutput(stdout: string): ProcRow[] {
+  // wmic /format:value emits stanzas of `Key=Value` lines separated by blank
+  // lines. We accumulate a record until a blank line, then flush.
+  const rows: ProcRow[] = []
+  let pid = Number.NaN
+  let ppid = Number.NaN
+  let ws = Number.NaN
+
+  const flush = (): void => {
+    if (!Number.isNaN(pid) && !Number.isNaN(ppid)) {
+      rows.push({
+        pid,
+        ppid,
+        cpu: 0,
+        memory: Number.isFinite(ws) && ws > 0 ? ws : 0
+      })
+    }
+    pid = Number.NaN
+    ppid = Number.NaN
+    ws = Number.NaN
+  }
+
+  for (const raw of stdout.split(/\r?\n/)) {
+    const line = raw.trim()
+    if (line.length === 0) {
+      flush()
+      continue
+    }
+    const eq = line.indexOf('=')
+    if (eq < 0) {
+      continue
+    }
+    const key = line.slice(0, eq)
+    const value = line.slice(eq + 1)
+    if (key === 'ProcessId') {
+      pid = Number.parseInt(value, 10)
+    } else if (key === 'ParentProcessId') {
+      ppid = Number.parseInt(value, 10)
+    } else if (key === 'WorkingSetSize') {
+      ws = Number.parseInt(value, 10)
+    }
+  }
+  flush()
+  return rows
+}
+
+/** Walk every descendant PID of `root`, inclusive. Exported for tests. */
+export function collectSubtree(index: ProcIndex, root: number): number[] {
+  const result: number[] = []
+  const seen = new Set<number>()
+  const queue = [root]
+  while (queue.length > 0) {
+    const pid = queue.pop()
+    if (pid === undefined) {
+      break
+    }
+    if (seen.has(pid)) {
+      continue
+    }
+    seen.add(pid)
+    if (index.byPid.has(pid)) {
+      result.push(pid)
+    }
+    const kids = index.childrenOf.get(pid)
+    if (kids) {
+      for (const kid of kids) {
+        queue.push(kid)
+      }
+    }
+  }
+  return result
+}
+
+// ─── Electron app process bucketing ─────────────────────────────────
+
+type AppBucketsRaw = Omit<AppMemory, 'history'>
+
+function bucketElectronMetrics(): AppBucketsRaw {
+  const main = { cpu: 0, memory: 0 }
+  const renderer = { cpu: 0, memory: 0 }
+  const other = { cpu: 0, memory: 0 }
+
+  for (const proc of app.getAppMetrics()) {
+    const cpu = clampNumber(proc.cpu?.percentCPUUsage)
+    // Electron reports workingSetSize in KB. Convert up front so every
+    // memory value in the snapshot is in bytes.
+    const memoryBytes = clampNumber(proc.memory?.workingSetSize) * 1024
+
+    // Why: lowercase once so future Electron versions emitting different
+    // casing ('browser' vs 'Browser') still bucket correctly.
+    const type = (typeof proc.type === 'string' ? proc.type : '').toLowerCase()
+    let target = other
+    if (type === 'browser') {
+      target = main
+    } else if (type === 'renderer' || type === 'tab') {
+      target = renderer
+    }
+
+    target.cpu += cpu
+    target.memory += memoryBytes
+  }
+
+  return {
+    main,
+    renderer,
+    other,
+    cpu: main.cpu + renderer.cpu + other.cpu,
+    memory: main.memory + renderer.memory + other.memory
+  }
+}
+
+// ─── Worktree attribution ───────────────────────────────────────────
+
+type WorktreeBucket = {
+  worktreeId: string
+  worktreeName: string
+  repoId: string
+  repoName: string
+  cpu: number
+  memory: number
+  sessions: SessionMemory[]
+}
+
+function resolveWorktreeNames(
+  worktreeId: string,
+  store: Store
+): {
+  worktreeName: string
+  repoId: string
+  repoName: string
+} {
+  // Orca worktree ids look like `${repoId}::${absolutePath}`.
+  const sep = worktreeId.indexOf('::')
+  const repoId = sep > 0 ? worktreeId.slice(0, sep) : worktreeId
+  const worktreePath = sep > 0 ? worktreeId.slice(sep + 2) : ''
+  const fallbackName = worktreePath ? basename(worktreePath) : worktreeId
+
+  const meta = store.getWorktreeMeta(worktreeId)
+  const repo = store.getRepo(repoId)
+
+  return {
+    worktreeName: meta?.displayName?.trim() || fallbackName,
+    repoId,
+    repoName: repo?.displayName?.trim() || repoId || 'Unknown Repo'
+  }
+}
+
+function makeEmptyBucket(
+  worktreeId: string,
+  worktreeName: string,
+  repoId: string,
+  repoName: string
+): WorktreeBucket {
+  return { worktreeId, worktreeName, repoId, repoName, cpu: 0, memory: 0, sessions: [] }
+}
+
+// ─── Main collection path ───────────────────────────────────────────
+
+async function runSnapshot(store: Store): Promise<MemorySnapshot> {
+  const processIndex = await enumerateProcesses()
+  const appBuckets = bucketElectronMetrics()
+  const ptys = listRegisteredPtys()
+
+  // Why: when two PTYs share an ancestor in the process tree (e.g. a
+  // supervisor, or a shell that re-execed), a naive walk would double-count
+  // that ancestor's memory. Track which pids have already been claimed and
+  // attribute to the first PTY (registration order) to see each pid.
+  const claimed = new Set<number>()
+
+  const orphan = makeEmptyBucket(
+    ORPHAN_WORKTREE_ID,
+    'Unattributed terminals',
+    ORPHAN_WORKTREE_ID,
+    'Other'
+  )
+  const worktreeBuckets = new Map<string, WorktreeBucket>()
+
+  for (const pty of ptys) {
+    let sessionCpu = 0
+    let sessionMemory = 0
+
+    if (pty.pid != null) {
+      for (const pid of collectSubtree(processIndex, pty.pid)) {
+        if (claimed.has(pid)) {
+          continue
+        }
+        const row = processIndex.byPid.get(pid)
+        if (!row) {
+          continue
+        }
+        claimed.add(pid)
+        sessionCpu += row.cpu
+        sessionMemory += row.memory
+      }
+    }
+
+    const session: SessionMemory = {
+      sessionId: pty.sessionId ?? pty.ptyId,
+      paneKey: pty.paneKey,
+      pid: pty.pid ?? 0,
+      cpu: clampNumber(sessionCpu),
+      memory: clampNumber(sessionMemory)
+    }
+
+    let bucket: WorktreeBucket
+    if (pty.worktreeId) {
+      const existing = worktreeBuckets.get(pty.worktreeId)
+      if (existing) {
+        bucket = existing
+      } else {
+        const names = resolveWorktreeNames(pty.worktreeId, store)
+        bucket = makeEmptyBucket(pty.worktreeId, names.worktreeName, names.repoId, names.repoName)
+        worktreeBuckets.set(pty.worktreeId, bucket)
+      }
+    } else {
+      bucket = orphan
+    }
+
+    bucket.cpu += session.cpu
+    bucket.memory += session.memory
+    bucket.sessions.push(session)
+  }
+
+  const bucketList: WorktreeBucket[] = [...worktreeBuckets.values()]
+  if (orphan.sessions.length > 0) {
+    bucketList.push(orphan)
+  }
+
+  // Why: record this sweep's samples *before* reading back history, so the
+  // returned arrays end with the freshly-collected value. Each write also
+  // acts as a keep-alive so active worktrees survive the staleness sweep.
+  const now = Date.now()
+  pushHistorySample(APP_HISTORY_KEY, appBuckets.memory, now)
+  for (const bucket of bucketList) {
+    pushHistorySample(bucket.worktreeId, bucket.memory, now)
+  }
+  sweepStaleHistory(now)
+
+  const worktrees: WorktreeMemory[] = bucketList.map((b) => ({
+    ...b,
+    history: readHistory(b.worktreeId)
+  }))
+
+  let sessionCpuTotal = 0
+  let sessionMemoryTotal = 0
+  for (const wt of worktrees) {
+    sessionCpuTotal += wt.cpu
+    sessionMemoryTotal += wt.memory
+  }
+
+  return {
+    app: { ...appBuckets, history: readHistory(APP_HISTORY_KEY) },
+    worktrees,
+    host: hostMetrics(),
+    totalCpu: appBuckets.cpu + sessionCpuTotal,
+    totalMemory: appBuckets.memory + sessionMemoryTotal,
+    collectedAt: now
+  }
+}

--- a/src/main/memory/pty-registry.ts
+++ b/src/main/memory/pty-registry.ts
@@ -1,0 +1,44 @@
+/**
+ * Lightweight side-table that lets the memory collector attribute PTY
+ * processes back to the worktree that spawned them.
+ *
+ * Why a separate module rather than folding it into pty.ts: the PTY
+ * subsystem has no other reason to know about worktree memory. Keeping
+ * the registry here means the collector can evolve (e.g. start tracking
+ * extra per-session metadata) without touching the critical-path spawn
+ * handler. The write-side is just two calls — `register` on spawn,
+ * `unregister` on teardown.
+ *
+ * Scope: local PTYs only. SSH-backed PTYs execute on a remote host, so
+ * their memory does not contribute to Orca's process footprint and
+ * cannot be queried with our local `ps` tree.
+ */
+
+export type PtyRegistration = {
+  ptyId: string
+  worktreeId: string | null
+  sessionId: string | null
+  paneKey: string | null
+  // Why number | null: captured at spawn time so the collector does not have
+  // to reach back into the IPC module on every snapshot to resolve it. It is
+  // nullable because node-pty can return a process whose pid is briefly
+  // unavailable (spawn succeeded but the OS hasn't published the pid yet);
+  // storing null lets the collector render a zero-attribution row for that
+  // PTY instead of throwing and dropping the whole snapshot.
+  pid: number | null
+}
+
+const registry = new Map<string, PtyRegistration>()
+
+export function registerPty(entry: PtyRegistration): void {
+  registry.set(entry.ptyId, entry)
+}
+
+export function unregisterPty(ptyId: string): void {
+  registry.delete(ptyId)
+}
+
+/** Snapshot of currently-registered local PTYs for the collector to walk. */
+export function listRegisteredPtys(): PtyRegistration[] {
+  return [...registry.values()]
+}

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -341,7 +341,12 @@ export class LocalPtyProvider implements IPtyProvider {
       })
     }
 
-    return { id }
+    // Why: publish the OS pid so ipc/pty can register the PTY with the memory
+    // collector without reaching back into the provider. `proc.pid` may be
+    // briefly 0/undefined if node-pty hasn't observed the forked child yet.
+    const rawPid = proc.pid
+    const pid = typeof rawPid === 'number' && Number.isFinite(rawPid) && rawPid > 0 ? rawPid : null
+    return { id, pid }
   }
 
   // Local PTYs are always attached -- no-op. Remote providers use this to resubscribe.

--- a/src/main/providers/types.ts
+++ b/src/main/providers/types.ts
@@ -29,6 +29,12 @@ export type PtySpawnOptions = {
 
 export type PtySpawnResult = {
   id: string
+  /** OS-level pid of the shell process, when available at spawn time.
+   *  Why: the memory collector needs this to walk each PTY's process
+   *  subtree. Daemon-backed providers return it from the RPC result;
+   *  local providers read it from node-pty. Null when the underlying
+   *  provider could not publish a pid (e.g., race during spawn). */
+  pid?: number | null
   /** ANSI snapshot of the terminal screen, present when reattaching to an
    *  existing daemon session. Write this to xterm.js to restore visual state. */
   snapshot?: string

--- a/src/preload/api-types.d.ts
+++ b/src/preload/api-types.d.ts
@@ -44,6 +44,7 @@ import type {
   SearchOptions,
   SearchResult,
   StatsSummary,
+  MemorySnapshot,
   UpdateStatus,
   Worktree,
   WorktreeMeta,
@@ -201,6 +202,10 @@ export type ExportApi = {
 
 export type StatsApi = {
   getSummary: () => Promise<StatsSummary>
+}
+
+export type MemoryApi = {
+  getSnapshot: () => Promise<MemorySnapshot>
 }
 
 export type ClaudeUsageApi = {
@@ -569,6 +574,7 @@ export type PreloadApi = {
     onClearDismissal: (callback: () => void) => () => void
   }
   stats: StatsApi
+  memory: MemoryApi
   claudeUsage: ClaudeUsageApi
   codexUsage: CodexUsageApi
   fs: {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -9,6 +9,7 @@ import type { AgentHookInstallStatus } from '../shared/agent-hook-types'
 import type {
   FsChangedPayload,
   GhosttyImportPreview,
+  MemorySnapshot,
   NotificationDispatchResult
 } from '../shared/types'
 import type { RuntimeStatus, RuntimeSyncWindowGraph } from '../shared/runtime-types'
@@ -1465,6 +1466,10 @@ const api = {
       totalAgentTimeMs: number
       firstEventAt: number | null
     }> => ipcRenderer.invoke('stats:summary')
+  },
+
+  memory: {
+    getSnapshot: (): Promise<MemorySnapshot> => ipcRenderer.invoke('memory:getSnapshot')
   },
 
   claudeUsage: {

--- a/src/renderer/src/components/status-bar/MemoryStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/MemoryStatusSegment.tsx
@@ -1,0 +1,695 @@
+/* eslint-disable max-lines -- Why: the popover, its sub-sections, the
+   sparkline, and the formatters are all small pieces that only exist to
+   serve this one status-bar segment. Keeping them co-located follows the
+   same convention as the other *StatusSegment.tsx files (see StatusBar.tsx). */
+import React, { memo, useEffect, useMemo, useState } from 'react'
+import { ArrowDownWideNarrow, ChevronDown, ChevronRight, MemoryStick } from 'lucide-react'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
+import { activateAndRevealWorktree } from '@/lib/worktree-activation'
+import { useAppStore } from '../../store'
+import type {
+  AppMemory,
+  SessionMemory,
+  TerminalTab,
+  UsageValues,
+  WorktreeMemory
+} from '../../../../shared/types'
+import { ORPHAN_WORKTREE_ID } from '../../../../shared/constants'
+
+// ─── Constants ──────────────────────────────────────────────────────
+
+const POLL_MS = 2_000
+
+type SortOption = 'memory' | 'cpu' | 'name'
+
+const SORT_LABELS: Record<SortOption, string> = {
+  memory: 'Memory',
+  cpu: 'CPU',
+  name: 'Name'
+}
+
+const METRIC_COLUMNS_CLS = 'flex items-center shrink-0 tabular-nums'
+const CPU_COLUMN_CLS = 'w-12 text-right'
+const MEM_COLUMN_CLS = 'w-16 text-right'
+
+// ─── Formatters ─────────────────────────────────────────────────────
+
+function formatMemory(bytes: number): string {
+  if (bytes < 1024 * 1024) {
+    return `${Math.round(bytes / 1024)} KB`
+  }
+  if (bytes < 1024 * 1024 * 1024) {
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+  }
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`
+}
+
+function formatCpu(percent: number): string {
+  return `${percent.toFixed(1)}%`
+}
+
+function formatPercent(value: number): string {
+  return `${value.toFixed(0)}%`
+}
+
+// ─── Session label resolution ───────────────────────────────────────
+
+function parsePaneKey(paneKey: string | null): { tabId: string; paneRuntimeId: number } | null {
+  if (!paneKey) {
+    return null
+  }
+  const sepIdx = paneKey.indexOf(':')
+  if (sepIdx <= 0) {
+    return null
+  }
+  const paneRuntimeId = Number(paneKey.slice(sepIdx + 1))
+  if (!Number.isFinite(paneRuntimeId)) {
+    return null
+  }
+  return { tabId: paneKey.slice(0, sepIdx), paneRuntimeId }
+}
+
+function sessionRowLabel(
+  session: SessionMemory,
+  worktreeId: string,
+  tabsByWorktree: Record<string, TerminalTab[]>,
+  runtimePaneTitlesByTabId: Record<string, Record<number, string>>
+): string {
+  const parsed = parsePaneKey(session.paneKey)
+  if (parsed) {
+    const tabs = tabsByWorktree[worktreeId] ?? []
+    const tabIndex = tabs.findIndex((t) => t.id === parsed.tabId)
+    const tab = tabIndex >= 0 ? tabs[tabIndex] : undefined
+    if (tab) {
+      // Why: mirror the tab bar's label precedence (SortableTab: customTitle
+      // wins over the live OSC-updated title). Fall through to the runtime
+      // pane title so split panes stay identifiable, then the saved tab
+      // title, and finally a stable index-based label.
+      const custom = tab.customTitle?.trim()
+      if (custom) {
+        return custom
+      }
+      const runtime = runtimePaneTitlesByTabId[parsed.tabId]?.[parsed.paneRuntimeId]?.trim()
+      if (runtime) {
+        return runtime
+      }
+      return tab.defaultTitle?.trim() || tab.title?.trim() || `Terminal ${tabIndex + 1}`
+    }
+  }
+  if (session.pid > 0) {
+    return `pid ${session.pid}`
+  }
+  const fallback = session.sessionId?.slice(0, 8)
+  return fallback ? `session ${fallback}` : '(unknown session)'
+}
+
+// ─── Grouping helpers ───────────────────────────────────────────────
+
+type RepoGroup = {
+  repoId: string
+  repoName: string
+  cpu: number
+  memory: number
+  worktrees: WorktreeMemory[]
+}
+
+function bucketByRepo(worktrees: WorktreeMemory[]): RepoGroup[] {
+  const map = new Map<string, RepoGroup>()
+  for (const wt of worktrees) {
+    const key = wt.repoId || 'unknown'
+    let group = map.get(key)
+    if (!group) {
+      group = {
+        repoId: key,
+        repoName: wt.repoName || 'Unknown Repo',
+        cpu: 0,
+        memory: 0,
+        worktrees: []
+      }
+      map.set(key, group)
+    }
+    group.cpu += wt.cpu
+    group.memory += wt.memory
+    group.worktrees.push(wt)
+  }
+  return [...map.values()]
+}
+
+function sortWorktreesBy(list: WorktreeMemory[], sort: SortOption): WorktreeMemory[] {
+  const copy = [...list]
+  if (sort === 'memory') {
+    copy.sort((a, b) => b.memory - a.memory)
+  } else if (sort === 'cpu') {
+    copy.sort((a, b) => b.cpu - a.cpu)
+  } else {
+    copy.sort((a, b) => a.worktreeName.localeCompare(b.worktreeName))
+  }
+  return copy
+}
+
+function sortRepoGroupsBy(groups: RepoGroup[], sort: SortOption): RepoGroup[] {
+  const copy = [...groups]
+  if (sort === 'memory') {
+    copy.sort((a, b) => b.memory - a.memory)
+  } else if (sort === 'cpu') {
+    copy.sort((a, b) => b.cpu - a.cpu)
+  } else {
+    copy.sort((a, b) => a.repoName.localeCompare(b.repoName))
+  }
+  return copy
+}
+
+// ─── Sparkline ──────────────────────────────────────────────────────
+
+type SparklineProps = {
+  samples: number[]
+  width?: number
+  height?: number
+}
+
+function SparklineImpl({ samples, width = 48, height = 14 }: SparklineProps): React.JSX.Element {
+  const points = useMemo(() => {
+    // Why: defensive against IPC payload drift during hot-reload — a missing
+    // or non-array history should render as a flat line, not throw.
+    const safe = Array.isArray(samples) ? samples : []
+    if (safe.length < 2) {
+      const midY = (height / 2).toFixed(1)
+      return `0,${midY} ${width},${midY}`
+    }
+
+    let min = safe[0]
+    let max = safe[0]
+    for (const v of safe) {
+      if (v < min) {
+        min = v
+      }
+      if (v > max) {
+        max = v
+      }
+    }
+    const range = max - min || 1
+    const stepX = width / (safe.length - 1)
+
+    const out: string[] = []
+    for (let i = 0; i < safe.length; i++) {
+      const x = (i * stepX).toFixed(1)
+      // SVG y grows downward, so invert: larger values render higher.
+      const y = (height - ((safe[i] - min) / range) * height).toFixed(1)
+      out.push(`${x},${y}`)
+    }
+    return out.join(' ')
+  }, [samples, width, height])
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      aria-hidden
+      preserveAspectRatio="none"
+    >
+      <polyline
+        points={points}
+        fill="none"
+        strokeWidth={1}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className="stroke-muted-foreground/70"
+      />
+    </svg>
+  )
+}
+
+/** Why memo: popover polls every 2s and shallow-equal samples shouldn't
+ *  trigger a full re-scan of the min/max/polyline points for every row. */
+const Sparkline = memo(SparklineImpl, (a, b) => {
+  if (a.width !== b.width || a.height !== b.height) {
+    return false
+  }
+  const sa = Array.isArray(a.samples) ? a.samples : []
+  const sb = Array.isArray(b.samples) ? b.samples : []
+  if (sa === sb) {
+    return true
+  }
+  if (sa.length !== sb.length) {
+    return false
+  }
+  for (let i = 0; i < sa.length; i++) {
+    if (sa[i] !== sb[i]) {
+      return false
+    }
+  }
+  return true
+})
+
+// ─── Leaf UI: metric chip + row ─────────────────────────────────────
+
+function MetricChip({
+  label,
+  value,
+  tooltip
+}: {
+  label: string
+  value: string
+  tooltip?: string
+}): React.JSX.Element {
+  const body = (
+    <div className="min-w-0 px-1 py-0.5">
+      <span className="block text-[10px] text-muted-foreground uppercase tracking-wide whitespace-nowrap">
+        {label}
+      </span>
+      <span className="block text-base leading-5 font-medium tabular-nums whitespace-nowrap text-foreground">
+        {value}
+      </span>
+    </div>
+  )
+  if (!tooltip) {
+    return body
+  }
+  return (
+    <Tooltip delayDuration={150}>
+      <TooltipTrigger asChild>{body}</TooltipTrigger>
+      {/* Why z-[70]: parent PopoverContent stacks at z-[60]; the default
+          tooltip z-50 would render behind it. */}
+      <TooltipContent side="top" sideOffset={6} className="z-[70] max-w-xs">
+        {tooltip}
+      </TooltipContent>
+    </Tooltip>
+  )
+}
+
+function MetricPair({
+  cpu,
+  memory,
+  size = 'base'
+}: {
+  cpu: number
+  memory: number
+  size?: 'base' | 'small'
+}): React.JSX.Element {
+  const textCls = size === 'small' ? 'text-[11px]' : 'text-xs'
+  return (
+    <div className={cn(METRIC_COLUMNS_CLS, textCls, 'text-muted-foreground')}>
+      <span className={CPU_COLUMN_CLS}>{formatCpu(cpu)}</span>
+      <span className={MEM_COLUMN_CLS}>{formatMemory(memory)}</span>
+    </div>
+  )
+}
+
+// ─── Section: app (main / renderer / other) ─────────────────────────
+
+function AppSection({ app }: { app: AppMemory }): React.JSX.Element {
+  return (
+    <div className="border-b border-border/50">
+      <div className="px-3 py-2 flex items-center justify-between">
+        <span className="text-xs font-medium truncate">Orca App</span>
+        <div className="flex items-center gap-2 shrink-0">
+          <Sparkline samples={app.history} />
+          <MetricPair cpu={app.cpu} memory={app.memory} />
+        </div>
+      </div>
+      <AppSubRow label="Main" values={app.main} />
+      <AppSubRow label="Renderer" values={app.renderer} />
+      {(app.other.cpu > 0 || app.other.memory > 0) && (
+        <AppSubRow label="Other" values={app.other} />
+      )}
+    </div>
+  )
+}
+
+function AppSubRow({ label, values }: { label: string; values: UsageValues }): React.JSX.Element {
+  return (
+    <div className="px-3 py-1.5 pl-6 flex items-center justify-between">
+      <span className="text-[11px] text-muted-foreground truncate">{label}</span>
+      <MetricPair cpu={values.cpu} memory={values.memory} size="small" />
+    </div>
+  )
+}
+
+// ─── Section: worktree tree ─────────────────────────────────────────
+
+function WorktreeSection({
+  worktrees,
+  sortOption,
+  collapsedRepos,
+  toggleRepo,
+  collapsedWorktrees,
+  toggleWorktree,
+  navigateToWorktree
+}: {
+  worktrees: WorktreeMemory[]
+  sortOption: SortOption
+  collapsedRepos: Set<string>
+  toggleRepo: (repoId: string) => void
+  collapsedWorktrees: Set<string>
+  toggleWorktree: (worktreeId: string) => void
+  navigateToWorktree: (worktreeId: string) => void
+}): React.JSX.Element {
+  // Why: these slices mutate frequently (runtimePaneTitlesByTabId updates on
+  // every terminal OSC escape). Subscribing inside WorktreeSection — which
+  // only mounts when the popover is open — prevents those updates from
+  // re-rendering the always-mounted status-bar segment.
+  const tabsByWorktree = useAppStore((s) => s.tabsByWorktree)
+  const runtimePaneTitlesByTabId = useAppStore((s) => s.runtimePaneTitlesByTabId)
+
+  // Memoize grouping: popover polls every 2s, so without this we'd rebuild
+  // the Map + arrays on every render even when nothing changed.
+  const repoGroups = useMemo(
+    () =>
+      sortRepoGroupsBy(bucketByRepo(worktrees), sortOption).map((group) => ({
+        ...group,
+        worktrees: sortWorktreesBy(group.worktrees, sortOption)
+      })),
+    [worktrees, sortOption]
+  )
+
+  return (
+    <>
+      {repoGroups.map((group) => {
+        const repoCollapsed = collapsedRepos.has(group.repoId)
+        return (
+          <div key={group.repoId} className="border-b border-border/50 last:border-b-0">
+            <div className="flex items-center">
+              <button
+                type="button"
+                onClick={() => toggleRepo(group.repoId)}
+                className="pl-2 py-2 pr-0.5 transition-colors hover:bg-muted/50"
+                aria-label={repoCollapsed ? 'Expand repo' : 'Collapse repo'}
+              >
+                {repoCollapsed ? (
+                  <ChevronRight className="h-3 w-3 text-muted-foreground" />
+                ) : (
+                  <ChevronDown className="h-3 w-3 text-muted-foreground" />
+                )}
+              </button>
+              <div className="flex-1 min-w-0 py-2 pr-3 flex items-center justify-between">
+                <span className="text-[11px] font-semibold uppercase tracking-wide truncate text-muted-foreground">
+                  {group.repoName}
+                </span>
+                <MetricPair cpu={group.cpu} memory={group.memory} />
+              </div>
+            </div>
+
+            {!repoCollapsed && (
+              <div className="border-t border-border/30">
+                {group.worktrees.map((wt) => (
+                  <WorktreeRow
+                    key={wt.worktreeId}
+                    worktree={wt}
+                    isCollapsed={collapsedWorktrees.has(wt.worktreeId)}
+                    onToggle={() => toggleWorktree(wt.worktreeId)}
+                    onNavigate={() => navigateToWorktree(wt.worktreeId)}
+                    tabsByWorktree={tabsByWorktree}
+                    runtimePaneTitlesByTabId={runtimePaneTitlesByTabId}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        )
+      })}
+    </>
+  )
+}
+
+function WorktreeRow({
+  worktree,
+  isCollapsed,
+  onToggle,
+  onNavigate,
+  tabsByWorktree,
+  runtimePaneTitlesByTabId
+}: {
+  worktree: WorktreeMemory
+  isCollapsed: boolean
+  onToggle: () => void
+  onNavigate: () => void
+  tabsByWorktree: Record<string, TerminalTab[]>
+  runtimePaneTitlesByTabId: Record<string, Record<number, string>>
+}): React.JSX.Element {
+  const hasSessions = worktree.sessions.length > 0
+
+  return (
+    <div className="border-b border-border/20 last:border-b-0">
+      <div className="flex items-center ml-2">
+        {hasSessions && (
+          <button
+            type="button"
+            onClick={onToggle}
+            className="pl-2 py-2 pr-0.5 transition-colors shrink-0 hover:bg-muted/60"
+            aria-label={isCollapsed ? 'Expand worktree' : 'Collapse worktree'}
+          >
+            {isCollapsed ? (
+              <ChevronRight className="h-3 w-3 text-muted-foreground" />
+            ) : (
+              <ChevronDown className="h-3 w-3 text-muted-foreground" />
+            )}
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={onNavigate}
+          aria-label={`Open worktree ${worktree.worktreeName}`}
+          className={cn(
+            'flex-1 min-w-0 py-2 pr-3 flex items-center justify-between transition-colors hover:bg-muted/60',
+            hasSessions ? 'pl-1' : 'pl-3'
+          )}
+        >
+          <span className="text-xs font-medium truncate min-w-0 mr-2">{worktree.worktreeName}</span>
+          <div className="flex items-center gap-2 shrink-0">
+            <Sparkline samples={worktree.history} />
+            <MetricPair cpu={worktree.cpu} memory={worktree.memory} />
+          </div>
+        </button>
+      </div>
+
+      {!isCollapsed &&
+        worktree.sessions.map((session) => (
+          // Why: sessionId can be null/fall back to ptyId; combine with pid
+          // so two sessions from the same process family don't collide in
+          // React reconciliation.
+          <div
+            key={`${session.sessionId}:${session.pid}`}
+            className="px-3 py-1.5 pl-10 flex items-center justify-between"
+          >
+            <span className="text-[11px] text-muted-foreground truncate min-w-0 mr-2">
+              {sessionRowLabel(
+                session,
+                worktree.worktreeId,
+                tabsByWorktree,
+                runtimePaneTitlesByTabId
+              )}
+            </span>
+            <MetricPair cpu={session.cpu} memory={session.memory} size="small" />
+          </div>
+        ))}
+    </div>
+  )
+}
+
+// ─── Segment (top-level) ────────────────────────────────────────────
+
+export function MemoryStatusSegment({
+  iconOnly
+}: {
+  // Why: `compact` is accepted for uniformity with the other *StatusSegment
+  // components but is not used — the icon/badge layout already fits inside
+  // a compact status bar.
+  compact?: boolean
+  iconOnly: boolean
+}): React.JSX.Element {
+  const snapshot = useAppStore((s) => s.memorySnapshot)
+  const fetchSnapshot = useAppStore((s) => s.fetchMemorySnapshot)
+
+  const [open, setOpen] = useState(false)
+  const [sortOption, setSortOption] = useState<SortOption>('memory')
+  const [collapsedRepos, setCollapsedRepos] = useState<Set<string>>(new Set())
+  const [collapsedWorktrees, setCollapsedWorktrees] = useState<Set<string>>(new Set())
+
+  // Why: only poll while the popover is open. When closed, the badge shows
+  // whatever value was last fetched — good enough for a passive indicator
+  // and keeps us from waking the main process every few seconds.
+  useEffect(() => {
+    if (!open) {
+      return
+    }
+    void fetchSnapshot()
+    const timer = window.setInterval(() => {
+      void fetchSnapshot()
+    }, POLL_MS)
+    return () => window.clearInterval(timer)
+  }, [open, fetchSnapshot])
+
+  // Derived values are grouped into one memo so open/sort/collapse state
+  // changes don't recompute them.
+  const { totalMemory, totalCpu, hostShare, badgeLabel } = useMemo(() => {
+    const memory = snapshot?.totalMemory ?? 0
+    const cpu = snapshot?.totalCpu ?? 0
+    const hostTotal = snapshot?.host.totalMemory ?? 0
+    return {
+      totalMemory: memory,
+      totalCpu: cpu,
+      hostShare: hostTotal > 0 ? (memory / hostTotal) * 100 : 0,
+      badgeLabel: snapshot ? formatMemory(memory) : '—'
+    }
+  }, [snapshot])
+
+  const toggleRepo = (repoId: string): void => {
+    setCollapsedRepos((prev) => {
+      const next = new Set(prev)
+      if (next.has(repoId)) {
+        next.delete(repoId)
+      } else {
+        next.add(repoId)
+      }
+      return next
+    })
+  }
+
+  const toggleWorktree = (worktreeId: string): void => {
+    setCollapsedWorktrees((prev) => {
+      const next = new Set(prev)
+      if (next.has(worktreeId)) {
+        next.delete(worktreeId)
+      } else {
+        next.add(worktreeId)
+      }
+      return next
+    })
+  }
+
+  const navigateToWorktree = (worktreeId: string): void => {
+    // Orphan bucket has a synthetic id with no real worktree to reveal.
+    if (worktreeId === ORPHAN_WORKTREE_ID) {
+      setOpen(false)
+      return
+    }
+    // Why: returns false when the worktree has been deleted between
+    // snapshot capture and this click. Leave the popover open in that
+    // case so a silent no-op doesn't look like a broken button.
+    const result = activateAndRevealWorktree(worktreeId)
+    if (result === false) {
+      return
+    }
+    setOpen(false)
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <Tooltip delayDuration={150}>
+        <TooltipTrigger asChild>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              className="inline-flex items-center gap-1.5 cursor-pointer rounded px-1 py-0.5 hover:bg-accent/70"
+              aria-label="Memory usage"
+            >
+              <MemoryStick className="size-3 text-muted-foreground" />
+              {!iconOnly && (
+                <span className="text-[11px] font-medium tabular-nums text-muted-foreground">
+                  {badgeLabel}
+                </span>
+              )}
+            </button>
+          </PopoverTrigger>
+        </TooltipTrigger>
+        <TooltipContent side="top" sideOffset={6}>
+          Memory — {badgeLabel}
+        </TooltipContent>
+      </Tooltip>
+
+      <PopoverContent side="top" align="end" sideOffset={8} className="w-[26rem] p-0">
+        <div className="p-3 border-b border-border">
+          <div className="flex items-center justify-between">
+            <h4 className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+              Memory &amp; CPU
+            </h4>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button
+                  type="button"
+                  className="flex items-center gap-1 px-1.5 py-0.5 rounded text-[11px] text-muted-foreground hover:bg-muted transition-colors"
+                  aria-label="Sort worktrees"
+                >
+                  <ArrowDownWideNarrow className="h-3.5 w-3.5" />
+                  <span>{SORT_LABELS[sortOption]}</span>
+                </button>
+              </DropdownMenuTrigger>
+              {/* Why z-[70]: PopoverContent is z-[60]; the default dropdown
+                  z-50 would render behind it. */}
+              <DropdownMenuContent align="end" className="w-40 z-[70]">
+                <DropdownMenuRadioGroup
+                  value={sortOption}
+                  onValueChange={(value) => {
+                    if (value === 'memory' || value === 'cpu' || value === 'name') {
+                      setSortOption(value)
+                    }
+                  }}
+                >
+                  <DropdownMenuRadioItem value="memory">Memory</DropdownMenuRadioItem>
+                  <DropdownMenuRadioItem value="cpu">CPU</DropdownMenuRadioItem>
+                  <DropdownMenuRadioItem value="name">Name</DropdownMenuRadioItem>
+                </DropdownMenuRadioGroup>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+
+          {snapshot && (
+            <div className="mt-2 grid grid-cols-3 gap-2">
+              <MetricChip
+                label="CPU"
+                value={formatCpu(totalCpu)}
+                tooltip="Combined CPU load across the Orca app and the shell subtrees Orca launched. Values above 100% mean more than one core is working at once."
+              />
+              <MetricChip
+                label="Memory"
+                value={formatMemory(totalMemory)}
+                tooltip="Resident memory held by the Orca app plus the processes under each worktree's terminals. A number that only climbs usually points at a worktree keeping something alive."
+              />
+              <MetricChip
+                label="% of system RAM"
+                value={formatPercent(hostShare)}
+                tooltip="How much of this machine's physical RAM the Orca-tracked processes are sitting on. A low number here while the system feels slow means the pressure is coming from something else."
+              />
+            </div>
+          )}
+        </div>
+
+        <div className="max-h-[50vh] overflow-y-auto scrollbar-sleek">
+          {snapshot && <AppSection app={snapshot.app} />}
+
+          {snapshot && snapshot.worktrees.length > 0 && (
+            <WorktreeSection
+              worktrees={snapshot.worktrees}
+              sortOption={sortOption}
+              collapsedRepos={collapsedRepos}
+              toggleRepo={toggleRepo}
+              collapsedWorktrees={collapsedWorktrees}
+              toggleWorktree={toggleWorktree}
+              navigateToWorktree={navigateToWorktree}
+            />
+          )}
+
+          {snapshot && snapshot.worktrees.length === 0 && (
+            <div className="px-3 py-4 text-center text-xs text-muted-foreground">
+              Nothing running right now
+            </div>
+          )}
+
+          {!snapshot && (
+            <div className="px-3 py-4 text-center text-xs text-muted-foreground">Loading…</div>
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -1,7 +1,15 @@
 /* eslint-disable max-lines -- Why: the status bar keeps provider rendering,
 interaction menus, and compact-layout behavior together so the hover/click
 states stay consistent across Claude and Codex. */
-import { AlertTriangle, ChevronDown, ChevronRight, RefreshCw, Terminal, Wifi } from 'lucide-react'
+import {
+  AlertTriangle,
+  ChevronDown,
+  ChevronRight,
+  MemoryStick as MemoryStickIcon,
+  RefreshCw,
+  Terminal,
+  Wifi
+} from 'lucide-react'
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import {
@@ -25,6 +33,7 @@ import { markLiveCodexSessionsForRestart } from '@/lib/codex-session-restart'
 import { SshStatusSegment } from './SshStatusSegment'
 import { SessionsStatusSegment } from './SessionsStatusSegment'
 import { UpdateStatusSegment } from './UpdateStatusSegment'
+import { MemoryStatusSegment } from './MemoryStatusSegment'
 
 function getCodexAccountLabel(
   state: CodexRateLimitAccountsState,
@@ -609,6 +618,7 @@ function StatusBarInner(): React.JSX.Element | null {
   const showCodex = codex && statusBarItems.includes('codex')
   const showSsh = statusBarItems.includes('ssh')
   const showSessions = statusBarItems.includes('sessions')
+  const showMemory = statusBarItems.includes('memory')
   const anyVisible = showClaude || showCodex
   const anyFetching = claude?.status === 'fetching' || codex?.status === 'fetching'
 
@@ -662,6 +672,7 @@ function StatusBarInner(): React.JSX.Element | null {
 
       <div className="flex items-center gap-3">
         <UpdateStatusSegment compact={compact} iconOnly={iconOnly} />
+        {showMemory && <MemoryStatusSegment compact={compact} iconOnly={iconOnly} />}
         {showSessions && <SessionsStatusSegment compact={compact} iconOnly={iconOnly} />}
         {showSsh && <SshStatusSegment compact={compact} iconOnly={iconOnly} />}
       </div>
@@ -703,6 +714,13 @@ function StatusBarInner(): React.JSX.Element | null {
           >
             <Terminal className="size-3.5" />
             Terminal Sessions
+          </DropdownMenuCheckboxItem>
+          <DropdownMenuCheckboxItem
+            checked={statusBarItems.includes('memory')}
+            onCheckedChange={() => toggleStatusBarItem('memory')}
+          >
+            <MemoryStickIcon className="size-3.5" />
+            Memory
           </DropdownMenuCheckboxItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/src/renderer/src/store/index.ts
+++ b/src/renderer/src/store/index.ts
@@ -10,6 +10,7 @@ import { createGitHubSlice } from './slices/github'
 import { createLinearSlice } from './slices/linear'
 import { createEditorSlice } from './slices/editor'
 import { createStatsSlice } from './slices/stats'
+import { createMemorySlice } from './slices/memory'
 import { createClaudeUsageSlice } from './slices/claude-usage'
 import { createCodexUsageSlice } from './slices/codex-usage'
 import { createBrowserSlice } from './slices/browser'
@@ -33,6 +34,7 @@ export const useAppStore = create<AppState>()((...a) => ({
   ...createLinearSlice(...a),
   ...createEditorSlice(...a),
   ...createStatsSlice(...a),
+  ...createMemorySlice(...a),
   ...createClaudeUsageSlice(...a),
   ...createCodexUsageSlice(...a),
   ...createBrowserSlice(...a),

--- a/src/renderer/src/store/slices/memory.ts
+++ b/src/renderer/src/store/slices/memory.ts
@@ -1,0 +1,21 @@
+import type { StateCreator } from 'zustand'
+import type { AppState } from '../types'
+import type { MemorySnapshot } from '../../../../shared/types'
+
+export type MemorySlice = {
+  memorySnapshot: MemorySnapshot | null
+  fetchMemorySnapshot: () => Promise<void>
+}
+
+export const createMemorySlice: StateCreator<AppState, [], [], MemorySlice> = (set) => ({
+  memorySnapshot: null,
+
+  fetchMemorySnapshot: async () => {
+    try {
+      const snapshot = await window.api.memory.getSnapshot()
+      set({ memorySnapshot: snapshot })
+    } catch (err) {
+      console.error('Failed to fetch memory snapshot:', err)
+    }
+  }
+})

--- a/src/renderer/src/store/slices/store-session-cascades.test.ts
+++ b/src/renderer/src/store/slices/store-session-cascades.test.ts
@@ -99,6 +99,7 @@ import { createGitHubSlice } from './github'
 import { createLinearSlice } from './linear'
 import { createEditorSlice } from './editor'
 import { createStatsSlice } from './stats'
+import { createMemorySlice } from './memory'
 import { createClaudeUsageSlice } from './claude-usage'
 import { createCodexUsageSlice } from './codex-usage'
 import { createBrowserSlice } from './browser'
@@ -121,6 +122,7 @@ function createTestStore() {
     ...createLinearSlice(...a),
     ...createEditorSlice(...a),
     ...createStatsSlice(...a),
+    ...createMemorySlice(...a),
     ...createClaudeUsageSlice(...a),
     ...createCodexUsageSlice(...a),
     ...createBrowserSlice(...a),

--- a/src/renderer/src/store/slices/store-test-helpers.ts
+++ b/src/renderer/src/store/slices/store-test-helpers.ts
@@ -18,6 +18,7 @@ import { createGitHubSlice } from './github'
 import { createLinearSlice } from './linear'
 import { createEditorSlice } from './editor'
 import { createStatsSlice } from './stats'
+import { createMemorySlice } from './memory'
 import { createClaudeUsageSlice } from './claude-usage'
 import { createCodexUsageSlice } from './codex-usage'
 import { createBrowserSlice } from './browser'
@@ -48,6 +49,7 @@ export function createTestStore() {
     ...createLinearSlice(...a),
     ...createEditorSlice(...a),
     ...createStatsSlice(...a),
+    ...createMemorySlice(...a),
     ...createClaudeUsageSlice(...a),
     ...createCodexUsageSlice(...a),
     ...createBrowserSlice(...a),

--- a/src/renderer/src/store/slices/tabs.test.ts
+++ b/src/renderer/src/store/slices/tabs.test.ts
@@ -94,6 +94,7 @@ import { createGitHubSlice } from './github'
 import { createLinearSlice } from './linear'
 import { createEditorSlice } from './editor'
 import { createStatsSlice } from './stats'
+import { createMemorySlice } from './memory'
 import { createClaudeUsageSlice } from './claude-usage'
 import { createCodexUsageSlice } from './codex-usage'
 import { createBrowserSlice } from './browser'
@@ -118,6 +119,7 @@ function createTestStore() {
     ...createLinearSlice(...a),
     ...createEditorSlice(...a),
     ...createStatsSlice(...a),
+    ...createMemorySlice(...a),
     ...createClaudeUsageSlice(...a),
     ...createCodexUsageSlice(...a),
     ...createBrowserSlice(...a),

--- a/src/renderer/src/store/types.ts
+++ b/src/renderer/src/store/types.ts
@@ -8,6 +8,7 @@ import type { GitHubSlice } from './slices/github'
 import type { LinearSlice } from './slices/linear'
 import type { EditorSlice } from './slices/editor'
 import type { StatsSlice } from './slices/stats'
+import type { MemorySlice } from './slices/memory'
 import type { ClaudeUsageSlice } from './slices/claude-usage'
 import type { CodexUsageSlice } from './slices/codex-usage'
 import type { BrowserSlice } from './slices/browser'
@@ -28,6 +29,7 @@ export type AppState = RepoSlice &
   LinearSlice &
   EditorSlice &
   StatsSlice &
+  MemorySlice &
   ClaudeUsageSlice &
   CodexUsageSlice &
   BrowserSlice &

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -77,7 +77,18 @@ export const DEFAULT_WORKTREE_CARD_PROPERTIES: WorktreeCardProperty[] = [
   'comment'
 ]
 
-export const DEFAULT_STATUS_BAR_ITEMS: StatusBarItem[] = ['claude', 'codex', 'ssh', 'sessions']
+export const DEFAULT_STATUS_BAR_ITEMS: StatusBarItem[] = [
+  'claude',
+  'codex',
+  'ssh',
+  'sessions',
+  'memory'
+]
+
+/** Synthetic worktree id used by the memory collector to bucket PTYs that
+ *  are not associated with any worktree. Shared across main and renderer so
+ *  the collector and the status-bar popover agree on the sentinel. */
+export const ORPHAN_WORKTREE_ID = '__orphan__'
 
 export const REPO_COLORS = [
   '#737373', // neutral

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -964,7 +964,7 @@ export type NotificationDispatchResult = {
 
 export type WorktreeCardProperty = 'status' | 'unread' | 'ci' | 'issue' | 'pr' | 'comment'
 
-export type StatusBarItem = 'claude' | 'codex' | 'ssh' | 'sessions'
+export type StatusBarItem = 'claude' | 'codex' | 'ssh' | 'sessions' | 'memory'
 
 export type PersistedUIState = {
   lastActiveRepoId: string | null
@@ -1192,4 +1192,64 @@ export type StatsSummary = {
   // For display formatting — sourced from aggregates, not the event log,
   // so it survives event trimming.
   firstEventAt: number | null // timestamp of first-ever event, for "tracking since..."
+}
+
+// ─── Memory dashboard ──────────────────────────────────────────────
+// Resource-metrics snapshot shared across main, preload, and renderer so
+// the IPC payload is the same shape everywhere. Memory is in bytes; CPU
+// is a percentage (can exceed 100 on multi-core).
+
+/** cpu is percent of a single core — can exceed 100 on multi-core. memory is in bytes. */
+export type UsageValues = {
+  cpu: number
+  memory: number
+}
+
+/** The top-level cpu/memory are the sum of main + renderer + other. */
+export type AppMemory = UsageValues & {
+  main: UsageValues
+  renderer: UsageValues
+  other: UsageValues
+  /** Oldest-first memory samples (bytes) for the whole Orca app, one per
+   *  successful collection. Used to render the sparkline in the dashboard.
+   *  Empty before the first snapshot is recorded. */
+  history: number[]
+}
+
+export type SessionMemory = UsageValues & {
+  sessionId: string
+  paneKey: string | null
+  pid: number
+}
+
+/** The top-level cpu/memory are the sum of sessions. */
+export type WorktreeMemory = UsageValues & {
+  worktreeId: string
+  worktreeName: string
+  repoId: string
+  repoName: string
+  sessions: SessionMemory[]
+  /** Oldest-first memory samples (bytes) for this worktree's tracked
+   *  subtrees, one per successful collection. */
+  history: number[]
+}
+
+export type HostMemory = {
+  totalMemory: number
+  freeMemory: number
+  usedMemory: number
+  memoryUsagePercent: number
+  cpuCoreCount: number
+  loadAverage1m: number
+}
+
+export type MemorySnapshot = {
+  app: AppMemory
+  worktrees: WorktreeMemory[]
+  host: HostMemory
+  /** Sum of app + all tracked worktree sessions. Percent of a single core, so may exceed 100 on multi-core machines. */
+  totalCpu: number
+  /** Sum of app + all tracked worktree sessions in bytes. NOT the same as host.totalMemory, which is physical RAM. */
+  totalMemory: number
+  collectedAt: number
 }


### PR DESCRIPTION
## Summary

Adds a live Memory & CPU view to the status bar. A background collector samples Electron app metrics and per-PTY process subtrees (`ps` on Unix, `wmic` on Windows), attributes sessions back to their worktrees via a pty-registry side table, and serves snapshots over IPC. The popover renders totals, per-worktree sections, sparklines, and a sort menu.

## Screenshots

<img width="442" height="321" alt="image" src="https://github.com/user-attachments/assets/85fb2c18-80b5-469d-8ed3-ff704ee2daca" />


## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added unit tests covering the collector's parse paths, subtree walk, single-flight coalescing, and shared-ancestor double-count guard


## Security Audit

**IPC surface.** `memory:getSnapshot` takes no args; output is derived entirely from main-process state. `pty:spawn` narrows untrusted IPC fields before recording them in the registry: `ORCA_PANE_KEY` ≤256 chars, `worktreeId` ≤512 chars, `sessionId` ≤256 chars, and `pid` must be a finite positive number (`src/main/ipc/pty.ts:490-529`). SSH PTYs are excluded from the registry — remote pids aren't visible to the local `ps`.

**Shell invocations.** `ps` and `wmic` commands are static string literals — no renderer data is interpolated, so there is no injection surface. Both are bounded by `timeout: 5s` and `maxBuffer: 10 MiB`. Unix forces `LC_ALL=C` for dot-decimal parsing. Failures are swallowed and return an empty snapshot; concurrent callers coalesce onto a single in-flight sweep so a renderer cannot spawn overlapping children.

**PID handling.** PIDs come from the trusted main-process provider at spawn time — never from the renderer. `collectSubtree` carries a `seen` set (cycle-safe) and only emits pids present in `byPid` (no ghost rows). Shared ancestors are attributed to the first PTY only via a `claimed` set, preventing double-counting and cross-worktree inflation. The collector is read-only w.r.t. the OS — pids are only walked, never signaled. Residual pid-reuse TOCTOU between sampling and the registry snapshot is a narrow correctness nit, not a boundary violation.

## Notes

- Cross-platform: Unix uses `ps`, Windows uses `wmic`. Please verify on all three OSes.
- Per-PTY attribution goes through a renderer-agnostic `pty-registry` side table to avoid leaking PTY internals across IPC.