### PR TITLE
feat(language-detect): add Svelte Monarch grammar for .svelte syntax highlighting

### DIFF
--- a/src/renderer/src/lib/language-detect.test.ts
+++ b/src/renderer/src/lib/language-detect.test.ts
@@ -6,8 +6,11 @@ describe('detectLanguage', () => {
     expect(detectLanguage('src/components/App.vue')).toBe('vue')
   })
 
-  it('keeps .astro and .svelte mapped to html until their grammars ship', () => {
+  it('maps .svelte files to the custom svelte language id', () => {
+    expect(detectLanguage('src/components/Widget.svelte')).toBe('svelte')
+  })
+
+  it('keeps .astro mapped to html until its grammar ships', () => {
     expect(detectLanguage('src/routes/index.astro')).toBe('html')
-    expect(detectLanguage('src/components/Widget.svelte')).toBe('html')
   })
 })

--- a/src/renderer/src/lib/language-detect.ts
+++ b/src/renderer/src/lib/language-detect.ts
@@ -75,7 +75,7 @@ const EXT_TO_LANGUAGE: Record<string, string> = {
   '.hs': 'haskell',
   '.clj': 'clojure',
   '.vue': 'vue',
-  '.svelte': 'html',
+  '.svelte': 'svelte',
   '.astro': 'html',
   '.tf': 'hcl',
   '.hcl': 'hcl',

--- a/src/renderer/src/lib/monaco-languages/register-svelte.test.ts
+++ b/src/renderer/src/lib/monaco-languages/register-svelte.test.ts
@@ -53,20 +53,22 @@ function collectFixtureRuleActions(source: string): string[] {
     { line: 1, state: 'root', pattern: '<script' },
     { line: 1, state: 'scriptOpen.typescript', pattern: '>' },
     { line: 4, state: 'scriptBody.typescript', pattern: '</script>' },
+    // After </script> pops back to root and the next non-structural character
+    // switches root -> markup with the html embed active.
     { line: 6, state: 'root', pattern: '' },
-    { line: 7, state: 'root', pattern: '{#if' },
+    { line: 7, state: 'markup', pattern: '{#if' },
     { line: 7, state: 'svelteBlockExpression', pattern: '}' },
-    { line: 8, state: 'root', pattern: '{' },
+    { line: 8, state: 'markup', pattern: '{' },
     { line: 8, state: 'svelteExpression', pattern: '}' },
-    { line: 9, state: 'root', pattern: '{:else' },
+    { line: 9, state: 'markup', pattern: '{:else' },
     { line: 9, state: 'svelteBlockExpressionEnter', pattern: '}' },
-    { line: 11, state: 'root', pattern: '{/if}' },
-    { line: 13, state: 'root', pattern: '{' },
+    { line: 11, state: 'markup', pattern: '{/if}' },
+    { line: 13, state: 'markup', pattern: '{' },
     { line: 13, state: 'svelteExpression', pattern: '{' },
     { line: 13, state: 'svelteExpressionNestedBrace', pattern: '}' },
-    { line: 14, state: 'root', pattern: '{@html' },
+    { line: 14, state: 'markup', pattern: '{@html' },
     { line: 14, state: 'svelteExpression', pattern: '}' },
-    { line: 16, state: 'root', pattern: '<style' },
+    { line: 16, state: 'markup', pattern: '<style' },
     { line: 16, state: 'styleOpen.css', pattern: '>' },
     { line: 18, state: 'styleBody.css', pattern: '</style>' }
   ]
@@ -162,24 +164,64 @@ describe('svelte tokenizer transitions', () => {
         "1:root:<script -> next=scriptOpen.typescript, embedded=-, switch=-",
         "1:scriptOpen.typescript:> -> next=-, embedded=$S2, switch=scriptBody.$S2",
         "4:scriptBody.typescript:</script> -> next=pop, embedded=@pop, switch=-",
-        "6:root:<html> -> next=-, embedded=html, switch=-",
-        "7:root:{#if -> next=svelteBlockExpressionEnter, embedded=@pop, switch=-",
+        "6:root:<html> -> next=-, embedded=html, switch=markup",
+        "7:markup:{#if -> next=svelteBlockExpressionEnter, embedded=@pop, switch=-",
         "7:svelteBlockExpression:} -> next=pop, embedded=@pop, switch=-",
-        "8:root:{ -> next=svelteExpressionEnter, embedded=@pop, switch=-",
+        "8:markup:{ -> next=svelteExpressionEnter, embedded=@pop, switch=-",
         "8:svelteExpression:} -> next=pop, embedded=@pop, switch=-",
-        "9:root:{:else -> next=svelteBlockExpressionEnter, embedded=@pop, switch=-",
+        "9:markup:{:else -> next=svelteBlockExpressionEnter, embedded=@pop, switch=-",
         "9:svelteBlockExpressionEnter:} -> next=pop, embedded=-, switch=-",
-        "11:root:{/if} -> next=-, embedded=-, switch=-",
-        "13:root:{ -> next=svelteExpressionEnter, embedded=@pop, switch=-",
+        "11:markup:{/if} -> next=-, embedded=-, switch=-",
+        "13:markup:{ -> next=svelteExpressionEnter, embedded=@pop, switch=-",
         "13:svelteExpression:{ -> next=svelteExpressionNestedBrace, embedded=-, switch=-",
         "13:svelteExpressionNestedBrace:} -> next=pop, embedded=-, switch=-",
-        "14:root:{@html -> next=svelteExpressionEnter, embedded=@pop, switch=-",
+        "14:markup:{@html -> next=svelteExpressionEnter, embedded=@pop, switch=-",
         "14:svelteExpression:} -> next=pop, embedded=@pop, switch=-",
-        "16:root:<style -> next=styleOpen.css, embedded=-, switch=-",
+        "16:markup:<style -> next=styleOpen.css, embedded=@pop, switch=-",
         "16:styleOpen.css:> -> next=-, embedded=$S2, switch=styleBody.$S2",
         "18:styleBody.css:</style> -> next=pop, embedded=@pop, switch=-",
       ]
     `)
+  })
+})
+
+describe('svelte tokenizer regressions', () => {
+  // Regression: when a Svelte file starts with `{#if}`, `{name}`, or `{@html}`,
+  // no html embed is active yet. Earlier drafts unconditionally emitted
+  // `nextEmbedded: '@pop'` from root, which Monaco rejects with
+  // "cannot pop embedded language if not inside one". The fix splits the
+  // entry-only `root` state from the html-embedded `markup` state.
+  it('does not pop a non-existent embed when a file starts with a Svelte block', () => {
+    const action = findRuleAction('root', '{#if foo}')
+    expect(action).toMatchObject({ next: '@svelteBlockExpressionEnter' })
+    expect(action?.nextEmbedded).toBeUndefined()
+  })
+
+  it('starts the html embed and switches to markup when markup begins', () => {
+    expect(findRuleAction('root', '<h1>Counter</h1>')).toMatchObject({
+      switchTo: '@markup',
+      nextEmbedded: 'html'
+    })
+  })
+
+  // Regression: while the html embed is active, only parent rules whose action
+  // pops the embed are consulted before delegating to html. The first draft
+  // omitted `nextEmbedded: '@pop'` from `<script>` / `<style>` / `<!--` rules,
+  // so a trailing `<style lang="scss">` after markup never reached the
+  // lang-switching code. The `markup` state wires the embed pop in.
+  it('pops the html embed when later script/style/comment markers appear', () => {
+    expect(findRuleAction('markup', '<script lang="ts">')).toMatchObject({
+      next: '@scriptOpen.typescript',
+      nextEmbedded: '@pop'
+    })
+    expect(findRuleAction('markup', '<style lang="scss">')).toMatchObject({
+      next: '@styleOpen.css',
+      nextEmbedded: '@pop'
+    })
+    expect(findRuleAction('markup', '<!-- comment -->')).toMatchObject({
+      next: '@comment',
+      nextEmbedded: '@pop'
+    })
   })
 })
 

--- a/src/renderer/src/lib/monaco-languages/register-svelte.test.ts
+++ b/src/renderer/src/lib/monaco-languages/register-svelte.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  registerSvelteLanguage,
+  svelteLanguageConfiguration,
+  svelteMonarchLanguage
+} from './register-svelte'
+
+type MonarchAction = {
+  next?: string
+  nextEmbedded?: string
+  switchTo?: string
+}
+type MonarchRule = [RegExp, string | MonarchAction, string?] | { include: string }
+
+function normalizeState(nextState: string): string {
+  return nextState.startsWith('@') ? nextState.slice(1) : nextState
+}
+
+function isRuleEntry(rule: MonarchRule): rule is [RegExp, string | MonarchAction, string?] {
+  return Array.isArray(rule)
+}
+
+function getRuleAction(rule: [RegExp, string | MonarchAction, string?]): MonarchAction | undefined {
+  const [, action, nextStateShortcut] = rule
+  return typeof action === 'object'
+    ? action
+    : nextStateShortcut
+      ? { next: nextStateShortcut }
+      : undefined
+}
+
+function findRuleAction(state: string, source: string): MonarchAction | undefined {
+  const tokenizer = svelteMonarchLanguage.tokenizer as Record<string, MonarchRule[]>
+  const stateRules = tokenizer[state] ?? tokenizer[state.split('.')[0]]
+  const matchedRule = stateRules.find((rule) => {
+    if (!isRuleEntry(rule)) {
+      return false
+    }
+    const [regexp] = rule
+    regexp.lastIndex = 0
+    const match = regexp.exec(source)
+    return match !== null && match.index === 0
+  })
+
+  return matchedRule && isRuleEntry(matchedRule) ? getRuleAction(matchedRule) : undefined
+}
+
+function collectFixtureRuleActions(source: string): string[] {
+  const ruleActions: string[] = []
+  const tokenizer = svelteMonarchLanguage.tokenizer as Record<string, MonarchRule[]>
+  const lines = source.split('\n')
+  const checks: { line: number; state: string; pattern: string }[] = [
+    { line: 1, state: 'root', pattern: '<script' },
+    { line: 1, state: 'scriptOpen.typescript', pattern: '>' },
+    { line: 4, state: 'scriptBody.typescript', pattern: '</script>' },
+    { line: 6, state: 'root', pattern: '' },
+    { line: 7, state: 'root', pattern: '{#if' },
+    { line: 7, state: 'svelteBlockExpression', pattern: '}' },
+    { line: 8, state: 'root', pattern: '{' },
+    { line: 8, state: 'svelteExpression', pattern: '}' },
+    { line: 9, state: 'root', pattern: '{:else' },
+    { line: 9, state: 'svelteBlockExpressionEnter', pattern: '}' },
+    { line: 11, state: 'root', pattern: '{/if}' },
+    { line: 13, state: 'root', pattern: '{' },
+    { line: 13, state: 'svelteExpression', pattern: '{' },
+    { line: 13, state: 'svelteExpressionNestedBrace', pattern: '}' },
+    { line: 14, state: 'root', pattern: '{@html' },
+    { line: 14, state: 'svelteExpression', pattern: '}' },
+    { line: 16, state: 'root', pattern: '<style' },
+    { line: 16, state: 'styleOpen.css', pattern: '>' },
+    { line: 18, state: 'styleBody.css', pattern: '</style>' }
+  ]
+
+  checks.forEach((check) => {
+    const line = lines.at(check.line - 1) ?? ''
+    const stateRules = tokenizer[check.state] ?? tokenizer[check.state.split('.')[0]]
+    const matchedRule = stateRules.find((rule) => {
+      if (!isRuleEntry(rule)) {
+        return false
+      }
+      const [regexp] = rule
+      regexp.lastIndex = 0
+      const match = regexp.exec(line)
+      return match !== null && match[0] === check.pattern
+    })
+    if (!matchedRule || !isRuleEntry(matchedRule)) {
+      return
+    }
+
+    const actionObject = getRuleAction(matchedRule)
+
+    const nextState = actionObject?.next ? normalizeState(actionObject.next) : '-'
+    const nextEmbedded = actionObject?.nextEmbedded ?? '-'
+    const switchTo = actionObject?.switchTo ? normalizeState(actionObject.switchTo) : '-'
+    ruleActions.push(
+      `${check.line}:${check.state}:${check.pattern || '<html>'} -> next=${nextState}, embedded=${nextEmbedded}, switch=${switchTo}`
+    )
+  })
+
+  return ruleActions
+}
+
+describe('registerSvelteLanguage registration', () => {
+  it('registers the svelte language, Monarch tokenizer, and configuration once', () => {
+    const languages: { id: string }[] = [{ id: 'typescript' }]
+    const register = vi.fn((entry: { id: string }) => {
+      languages.push({ id: entry.id })
+    })
+    const setMonarchTokensProvider = vi.fn()
+    const setLanguageConfiguration = vi.fn()
+    const getLanguages = vi.fn(() => languages)
+    const monacoMock = {
+      languages: {
+        register,
+        setMonarchTokensProvider,
+        setLanguageConfiguration,
+        getLanguages
+      }
+    }
+
+    registerSvelteLanguage(monacoMock as never)
+    registerSvelteLanguage(monacoMock as never)
+
+    expect(register).toHaveBeenCalledTimes(1)
+    expect(register).toHaveBeenCalledWith({
+      id: 'svelte',
+      extensions: ['.svelte'],
+      aliases: ['Svelte']
+    })
+    expect(setMonarchTokensProvider).toHaveBeenCalledTimes(1)
+    expect(setMonarchTokensProvider).toHaveBeenCalledWith('svelte', svelteMonarchLanguage)
+    expect(setLanguageConfiguration).toHaveBeenCalledTimes(1)
+    expect(setLanguageConfiguration).toHaveBeenCalledWith('svelte', svelteLanguageConfiguration)
+  })
+})
+
+describe('svelte tokenizer transitions', () => {
+  it('captures Svelte tokenizer transitions for a representative SFC fixture', () => {
+    const fixture = `<script lang="ts">
+  let count = 0
+  $: doubled = count * 2
+</script>
+
+<h1>Counter</h1>
+{#if count > 0}
+  <p>{count} clicked</p>
+{:else}
+  <p>not yet</p>
+{/if}
+
+<div class={{ active: count > 0 }}>{count}</div>
+{@html '<em>raw</em>'}
+
+<style>
+  h1 { color: rebeccapurple; }
+</style>`
+
+    const ruleActions = collectFixtureRuleActions(fixture)
+
+    expect(ruleActions).toMatchInlineSnapshot(`
+      [
+        "1:root:<script -> next=scriptOpen.typescript, embedded=-, switch=-",
+        "1:scriptOpen.typescript:> -> next=-, embedded=$S2, switch=scriptBody.$S2",
+        "4:scriptBody.typescript:</script> -> next=pop, embedded=@pop, switch=-",
+        "6:root:<html> -> next=-, embedded=html, switch=-",
+        "7:root:{#if -> next=svelteBlockExpressionEnter, embedded=@pop, switch=-",
+        "7:svelteBlockExpression:} -> next=pop, embedded=@pop, switch=-",
+        "8:root:{ -> next=svelteExpressionEnter, embedded=@pop, switch=-",
+        "8:svelteExpression:} -> next=pop, embedded=@pop, switch=-",
+        "9:root:{:else -> next=svelteBlockExpressionEnter, embedded=@pop, switch=-",
+        "9:svelteBlockExpressionEnter:} -> next=pop, embedded=-, switch=-",
+        "11:root:{/if} -> next=-, embedded=-, switch=-",
+        "13:root:{ -> next=svelteExpressionEnter, embedded=@pop, switch=-",
+        "13:svelteExpression:{ -> next=svelteExpressionNestedBrace, embedded=-, switch=-",
+        "13:svelteExpressionNestedBrace:} -> next=pop, embedded=-, switch=-",
+        "14:root:{@html -> next=svelteExpressionEnter, embedded=@pop, switch=-",
+        "14:svelteExpression:} -> next=pop, embedded=@pop, switch=-",
+        "16:root:<style -> next=styleOpen.css, embedded=-, switch=-",
+        "16:styleOpen.css:> -> next=-, embedded=$S2, switch=styleBody.$S2",
+        "18:styleBody.css:</style> -> next=pop, embedded=@pop, switch=-",
+      ]
+    `)
+  })
+})
+
+describe('svelte embedded language attributes', () => {
+  it('tracks embedded languages from Svelte block attributes and expressions', () => {
+    expect(findRuleAction('svelteExpressionEnter', 'count }')).toMatchObject({
+      nextEmbedded: 'typescript',
+      switchTo: '@svelteExpression'
+    })
+    expect(findRuleAction('svelteBlockExpressionEnter', 'count > 0}')).toMatchObject({
+      nextEmbedded: 'typescript',
+      switchTo: '@svelteBlockExpression'
+    })
+    expect(findRuleAction('svelteExpression', '{ active: true }')).toMatchObject({
+      next: '@svelteExpressionNestedBrace'
+    })
+    expect(findRuleAction('svelteExpressionNestedBrace', '}')).toMatchObject({
+      next: '@pop'
+    })
+    expect(findRuleAction('scriptLangValue.typescript', '"js"')).toMatchObject({
+      switchTo: '@scriptOpen.javascript'
+    })
+    expect(findRuleAction('scriptLangValue.javascript', '"ts"')).toMatchObject({
+      switchTo: '@scriptOpen.typescript'
+    })
+    expect(findRuleAction('scriptLangValue.typescript', 'js')).toMatchObject({
+      switchTo: '@scriptOpen.javascript'
+    })
+    expect(findRuleAction('styleLangValue.css', '"scss"')).toMatchObject({
+      switchTo: '@styleOpen.scss'
+    })
+    expect(findRuleAction('styleLangValue.css', 'less')).toMatchObject({
+      switchTo: '@styleOpen.less'
+    })
+    expect(findRuleAction('styleLangValue.css', "'sass'")).toMatchObject({
+      switchTo: '@styleOpen.scss'
+    })
+    expect(findRuleAction('styleLangValue.scss', '"css"')).toMatchObject({
+      switchTo: '@styleOpen.css'
+    })
+  })
+})

--- a/src/renderer/src/lib/monaco-languages/register-svelte.test.ts
+++ b/src/renderer/src/lib/monaco-languages/register-svelte.test.ts
@@ -29,10 +29,27 @@ function getRuleAction(rule: [RegExp, string | MonarchAction, string?]): Monarch
       : undefined
 }
 
-function findRuleAction(state: string, source: string): MonarchAction | undefined {
+function findRuleAction(
+  state: string,
+  source: string,
+  { embedPopOnly = false }: { embedPopOnly?: boolean } = {}
+): MonarchAction | undefined {
   const tokenizer = svelteMonarchLanguage.tokenizer as Record<string, MonarchRule[]>
   const stateRules = tokenizer[state] ?? tokenizer[state.split('.')[0]]
-  const matchedRule = stateRules.find((rule) => {
+  // When the html embed is active inside `markup`, Monaco's
+  // `_findLeavingNestedLanguageOffset` only consults rules whose action has
+  // `nextEmbedded: '@pop'` — the zero-width `@rematch` catch-all is
+  // skipped. Mirror that when callers want to verify the "structural rule
+  // pops the embed" path.
+  const candidateRules = embedPopOnly
+    ? stateRules.filter((rule) => {
+        if (!isRuleEntry(rule)) {
+          return false
+        }
+        return getRuleAction(rule)?.nextEmbedded === '@pop'
+      })
+    : stateRules
+  const matchedRule = candidateRules.find((rule) => {
     if (!isRuleEntry(rule)) {
       return false
     }
@@ -160,24 +177,24 @@ describe('svelte tokenizer transitions', () => {
 
     expect(ruleActions).toMatchInlineSnapshot(`
       [
-        "1:root:<script -> next=scriptOpen.typescript, embedded=-, switch=-",
+        "1:root:<script -> next=-, embedded=-, switch=scriptOpen.typescript",
         "1:scriptOpen.typescript:> -> next=-, embedded=$S2, switch=scriptBody.$S2",
-        "4:scriptBody.typescript:</script> -> next=pop, embedded=@pop, switch=-",
+        "4:scriptBody.typescript:</script> -> next=-, embedded=@pop, switch=markupReenter",
         "6:root:<html> -> next=-, embedded=html, switch=markup",
-        "7:markup:{#if -> next=svelteBlockExpressionEnter, embedded=@pop, switch=-",
-        "7:svelteBlockExpression:} -> next=pop, embedded=@pop, switch=-",
-        "8:markup:{ -> next=svelteExpressionEnter, embedded=@pop, switch=-",
-        "8:svelteExpression:} -> next=pop, embedded=@pop, switch=-",
-        "9:markup:{:else -> next=svelteBlockExpressionEnter, embedded=@pop, switch=-",
-        "9:svelteBlockExpressionEnter:} -> next=pop, embedded=-, switch=-",
+        "7:markup:{#if -> next=-, embedded=@pop, switch=svelteBlockExpressionEnter",
+        "7:svelteBlockExpression:} -> next=-, embedded=@pop, switch=markupReenter",
+        "8:markup:{ -> next=-, embedded=@pop, switch=svelteExpressionEnter",
+        "8:svelteExpression:} -> next=-, embedded=@pop, switch=markupReenter",
+        "9:markup:{:else -> next=-, embedded=@pop, switch=svelteBlockExpressionEnter",
+        "9:svelteBlockExpressionEnter:} -> next=-, embedded=-, switch=markupReenter",
         "11:markup:{/if} -> next=-, embedded=-, switch=-",
-        "13:markup:{ -> next=svelteExpressionEnter, embedded=@pop, switch=-",
-        "13:svelteExpression:} -> next=pop, embedded=@pop, switch=-",
-        "14:markup:{@html -> next=svelteExpressionEnter, embedded=@pop, switch=-",
-        "14:svelteExpression:} -> next=pop, embedded=@pop, switch=-",
-        "16:markup:<style -> next=styleOpen.css, embedded=@pop, switch=-",
+        "13:markup:{ -> next=-, embedded=@pop, switch=svelteExpressionEnter",
+        "13:svelteExpression:} -> next=-, embedded=@pop, switch=markupReenter",
+        "14:markup:{@html -> next=-, embedded=@pop, switch=svelteExpressionEnter",
+        "14:svelteExpression:} -> next=-, embedded=@pop, switch=markupReenter",
+        "16:markup:<style -> next=-, embedded=@pop, switch=styleOpen.css",
         "16:styleOpen.css:> -> next=-, embedded=$S2, switch=styleBody.$S2",
-        "18:styleBody.css:</style> -> next=pop, embedded=@pop, switch=-",
+        "18:styleBody.css:</style> -> next=-, embedded=@pop, switch=markupReenter",
       ]
     `)
   })
@@ -191,7 +208,7 @@ describe('svelte tokenizer regressions', () => {
   // entry-only `root` state from the html-embedded `markup` state.
   it('does not pop a non-existent embed when a file starts with a Svelte block', () => {
     const action = findRuleAction('root', '{#if foo}')
-    expect(action).toMatchObject({ next: '@svelteBlockExpressionEnter' })
+    expect(action).toMatchObject({ switchTo: '@svelteBlockExpressionEnter' })
     expect(action?.nextEmbedded).toBeUndefined()
   })
 
@@ -208,16 +225,16 @@ describe('svelte tokenizer regressions', () => {
   // so a trailing `<style lang="scss">` after markup never reached the
   // lang-switching code. The `markup` state wires the embed pop in.
   it('pops the html embed when later script/style/comment markers appear', () => {
-    expect(findRuleAction('markup', '<script lang="ts">')).toMatchObject({
-      next: '@scriptOpen.typescript',
+    expect(findRuleAction('markup', '<script lang="ts">', { embedPopOnly: true })).toMatchObject({
+      switchTo: '@scriptOpen.typescript',
       nextEmbedded: '@pop'
     })
-    expect(findRuleAction('markup', '<style lang="scss">')).toMatchObject({
-      next: '@styleOpen.css',
+    expect(findRuleAction('markup', '<style lang="scss">', { embedPopOnly: true })).toMatchObject({
+      switchTo: '@styleOpen.css',
       nextEmbedded: '@pop'
     })
-    expect(findRuleAction('markup', '<!-- comment -->')).toMatchObject({
-      next: '@comment',
+    expect(findRuleAction('markup', '<!-- comment -->', { embedPopOnly: true })).toMatchObject({
+      switchTo: '@comment',
       nextEmbedded: '@pop'
     })
   })

--- a/src/renderer/src/lib/monaco-languages/register-svelte.test.ts
+++ b/src/renderer/src/lib/monaco-languages/register-svelte.test.ts
@@ -64,8 +64,7 @@ function collectFixtureRuleActions(source: string): string[] {
     { line: 9, state: 'svelteBlockExpressionEnter', pattern: '}' },
     { line: 11, state: 'markup', pattern: '{/if}' },
     { line: 13, state: 'markup', pattern: '{' },
-    { line: 13, state: 'svelteExpression', pattern: '{' },
-    { line: 13, state: 'svelteExpressionNestedBrace', pattern: '}' },
+    { line: 13, state: 'svelteExpression', pattern: '}' },
     { line: 14, state: 'markup', pattern: '{@html' },
     { line: 14, state: 'svelteExpression', pattern: '}' },
     { line: 16, state: 'markup', pattern: '<style' },
@@ -150,7 +149,7 @@ describe('svelte tokenizer transitions', () => {
   <p>not yet</p>
 {/if}
 
-<div class={{ active: count > 0 }}>{count}</div>
+<button on:click={increment}>{count}</button>
 {@html '<em>raw</em>'}
 
 <style>
@@ -173,8 +172,7 @@ describe('svelte tokenizer transitions', () => {
         "9:svelteBlockExpressionEnter:} -> next=pop, embedded=-, switch=-",
         "11:markup:{/if} -> next=-, embedded=-, switch=-",
         "13:markup:{ -> next=svelteExpressionEnter, embedded=@pop, switch=-",
-        "13:svelteExpression:{ -> next=svelteExpressionNestedBrace, embedded=-, switch=-",
-        "13:svelteExpressionNestedBrace:} -> next=pop, embedded=-, switch=-",
+        "13:svelteExpression:} -> next=pop, embedded=@pop, switch=-",
         "14:markup:{@html -> next=svelteExpressionEnter, embedded=@pop, switch=-",
         "14:svelteExpression:} -> next=pop, embedded=@pop, switch=-",
         "16:markup:<style -> next=styleOpen.css, embedded=@pop, switch=-",
@@ -234,12 +232,6 @@ describe('svelte embedded language attributes', () => {
     expect(findRuleAction('svelteBlockExpressionEnter', 'count > 0}')).toMatchObject({
       nextEmbedded: 'typescript',
       switchTo: '@svelteBlockExpression'
-    })
-    expect(findRuleAction('svelteExpression', '{ active: true }')).toMatchObject({
-      next: '@svelteExpressionNestedBrace'
-    })
-    expect(findRuleAction('svelteExpressionNestedBrace', '}')).toMatchObject({
-      next: '@pop'
     })
     expect(findRuleAction('scriptLangValue.typescript', '"js"')).toMatchObject({
       switchTo: '@scriptOpen.javascript'

--- a/src/renderer/src/lib/monaco-languages/register-svelte.ts
+++ b/src/renderer/src/lib/monaco-languages/register-svelte.ts
@@ -1,0 +1,181 @@
+import type * as Monaco from 'monaco-editor'
+
+type MonacoModule = typeof Monaco
+
+export const svelteMonarchLanguage: Monaco.languages.IMonarchLanguage = {
+  defaultToken: '',
+  tokenPostfix: '.svelte',
+  ignoreCase: true,
+  brackets: [
+    { open: '{', close: '}', token: 'delimiter.curly' },
+    { open: '[', close: ']', token: 'delimiter.square' },
+    { open: '(', close: ')', token: 'delimiter.parenthesis' },
+    { open: '<', close: '>', token: 'delimiter.angle' }
+  ],
+  tokenizer: {
+    root: [
+      [/<script(?=\s|>)/, 'tag', '@scriptOpen.typescript'],
+      [/<style(?=\s|>)/, 'tag', '@styleOpen.css'],
+      [/<!--/, 'comment', '@comment'],
+      [/\{\s*\/(if|each|await|key|snippet)\s*\}/, 'keyword.control'],
+      [
+        /\{\s*#(if|each|await|key|snippet)\b/,
+        { token: 'keyword.control', next: '@svelteBlockExpressionEnter', nextEmbedded: '@pop' }
+      ],
+      [
+        /\{\s*:(else|then|catch)\b/,
+        { token: 'keyword.control', next: '@svelteBlockExpressionEnter', nextEmbedded: '@pop' }
+      ],
+      [
+        /\{\s*@(html|debug|const|render)\b/,
+        { token: 'keyword.control', next: '@svelteExpressionEnter', nextEmbedded: '@pop' }
+      ],
+      [
+        /\{(?=[^#:/@])/,
+        { token: 'delimiter.curly', next: '@svelteExpressionEnter', nextEmbedded: '@pop' }
+      ],
+      // Svelte has top-level markup instead of a <template> wrapper. Re-enter
+      // html after Svelte-specific states pop their embedded tokenizers.
+      [/(?=.)/, { token: '', nextEmbedded: 'html' }]
+    ],
+    comment: [
+      [/-->/, 'comment', '@pop'],
+      [/[^-]+/, 'comment'],
+      [/./, 'comment']
+    ],
+    svelteExpressionEnter: [
+      [/\}/, { token: 'delimiter.curly', next: '@pop' }],
+      [/(?=.)/, { token: '', switchTo: '@svelteExpression', nextEmbedded: 'typescript' }]
+    ],
+    svelteExpression: [
+      // Nested braces keep object literals inside {expr} from closing the
+      // Svelte expression at the first inner `}`.
+      [/\{/, 'delimiter.curly', '@svelteExpressionNestedBrace'],
+      [/\}/, { token: 'delimiter.curly', next: '@pop', nextEmbedded: '@pop' }]
+    ],
+    svelteExpressionNestedBrace: [
+      [/\{/, 'delimiter.curly', '@push'],
+      [/\}/, 'delimiter.curly', '@pop']
+    ],
+    svelteBlockExpressionEnter: [
+      [/\}/, { token: 'keyword.control', next: '@pop' }],
+      [/(?=.)/, { token: '', switchTo: '@svelteBlockExpression', nextEmbedded: 'typescript' }]
+    ],
+    svelteBlockExpression: [
+      [/\{/, 'delimiter.curly', '@svelteExpressionNestedBrace'],
+      [/\}/, { token: 'keyword.control', next: '@pop', nextEmbedded: '@pop' }]
+    ],
+    scriptOpen: [
+      [/\/>/, 'tag', '@pop'],
+      [/>/, { token: 'tag', switchTo: '@scriptBody.$S2', nextEmbedded: '$S2' }],
+      [/lang(?=\s*=)/, { token: 'attribute.name', switchTo: '@scriptLangBeforeEquals.$S2' }],
+      { include: '@tagAttributes' }
+    ],
+    scriptLangBeforeEquals: [
+      [/=/, { token: 'delimiter', switchTo: '@scriptLangValue.$S2' }],
+      [/\s+/, 'white'],
+      [/(?=.)/, { token: '', switchTo: '@scriptOpen.$S2' }]
+    ],
+    scriptLangValue: [
+      [/"(?:js|javascript)"/, { token: 'attribute.value', switchTo: '@scriptOpen.javascript' }],
+      [/'(?:js|javascript)'/, { token: 'attribute.value', switchTo: '@scriptOpen.javascript' }],
+      [
+        /(?:js|javascript)(?=\s|\/|>|$)/,
+        { token: 'attribute.value', switchTo: '@scriptOpen.javascript' }
+      ],
+      [/"(?:ts|typescript)"/, { token: 'attribute.value', switchTo: '@scriptOpen.typescript' }],
+      [/'(?:ts|typescript)'/, { token: 'attribute.value', switchTo: '@scriptOpen.typescript' }],
+      [
+        /(?:ts|typescript)(?=\s|\/|>|$)/,
+        { token: 'attribute.value', switchTo: '@scriptOpen.typescript' }
+      ],
+      [/[^\s/>]+/, { token: 'attribute.value', switchTo: '@scriptOpen.$S2' }],
+      [/"[^"]*"/, { token: 'attribute.value', switchTo: '@scriptOpen.$S2' }],
+      [/'[^']*'/, { token: 'attribute.value', switchTo: '@scriptOpen.$S2' }],
+      [/\s+/, 'white']
+    ],
+    scriptBody: [[/<\/script\s*>/, { token: 'tag', next: '@pop', nextEmbedded: '@pop' }]],
+    styleOpen: [
+      [/\/>/, 'tag', '@pop'],
+      [/>/, { token: 'tag', switchTo: '@styleBody.$S2', nextEmbedded: '$S2' }],
+      [/lang(?=\s*=)/, { token: 'attribute.name', switchTo: '@styleLangBeforeEquals.$S2' }],
+      { include: '@tagAttributes' }
+    ],
+    styleLangBeforeEquals: [
+      [/=/, { token: 'delimiter', switchTo: '@styleLangValue.$S2' }],
+      [/\s+/, 'white'],
+      [/(?=.)/, { token: '', switchTo: '@styleOpen.$S2' }]
+    ],
+    styleLangValue: [
+      [/"scss"/, { token: 'attribute.value', switchTo: '@styleOpen.scss' }],
+      [/'scss'/, { token: 'attribute.value', switchTo: '@styleOpen.scss' }],
+      [/scss(?=\s|\/|>|$)/, { token: 'attribute.value', switchTo: '@styleOpen.scss' }],
+      [/"sass"/, { token: 'attribute.value', switchTo: '@styleOpen.scss' }],
+      [/'sass'/, { token: 'attribute.value', switchTo: '@styleOpen.scss' }],
+      [/sass(?=\s|\/|>|$)/, { token: 'attribute.value', switchTo: '@styleOpen.scss' }],
+      [/"less"/, { token: 'attribute.value', switchTo: '@styleOpen.less' }],
+      [/'less'/, { token: 'attribute.value', switchTo: '@styleOpen.less' }],
+      [/less(?=\s|\/|>|$)/, { token: 'attribute.value', switchTo: '@styleOpen.less' }],
+      [/"css"/, { token: 'attribute.value', switchTo: '@styleOpen.css' }],
+      [/'css'/, { token: 'attribute.value', switchTo: '@styleOpen.css' }],
+      [/css(?=\s|\/|>|$)/, { token: 'attribute.value', switchTo: '@styleOpen.css' }],
+      [/[^\s/>]+/, { token: 'attribute.value', switchTo: '@styleOpen.$S2' }],
+      [/"[^"]*"/, { token: 'attribute.value', switchTo: '@styleOpen.$S2' }],
+      [/'[^']*'/, { token: 'attribute.value', switchTo: '@styleOpen.$S2' }],
+      [/\s+/, 'white']
+    ],
+    styleBody: [[/<\/style\s*>/, { token: 'tag', next: '@pop', nextEmbedded: '@pop' }]],
+    tagAttributes: [
+      [/[^\s/>=]+/, 'attribute.name'],
+      [/=/, 'delimiter'],
+      [/"[^"]*"/, 'attribute.value'],
+      [/'[^']*'/, 'attribute.value'],
+      [/\s+/, 'white']
+    ]
+  }
+}
+
+export const svelteLanguageConfiguration: Monaco.languages.LanguageConfiguration = {
+  comments: { blockComment: ['<!--', '-->'] },
+  brackets: [
+    ['{', '}'],
+    ['[', ']'],
+    ['(', ')'],
+    ['<', '>']
+  ],
+  autoClosingPairs: [
+    { open: '{', close: '}' },
+    { open: '[', close: ']' },
+    { open: '(', close: ')' },
+    { open: '"', close: '"' },
+    { open: "'", close: "'" },
+    { open: '`', close: '`' },
+    { open: '<', close: '>' }
+  ],
+  surroundingPairs: [
+    { open: '{', close: '}' },
+    { open: '[', close: ']' },
+    { open: '(', close: ')' },
+    { open: '"', close: '"' },
+    { open: "'", close: "'" },
+    { open: '`', close: '`' },
+    { open: '<', close: '>' }
+  ]
+}
+
+export function registerSvelteLanguage(monaco: MonacoModule): void {
+  const svelteAlreadyRegistered = monaco.languages
+    .getLanguages()
+    .some((language) => language.id === 'svelte')
+  if (svelteAlreadyRegistered) {
+    return
+  }
+
+  monaco.languages.register({
+    id: 'svelte',
+    extensions: ['.svelte'],
+    aliases: ['Svelte']
+  })
+  monaco.languages.setMonarchTokensProvider('svelte', svelteMonarchLanguage)
+  monaco.languages.setLanguageConfiguration('svelte', svelteLanguageConfiguration)
+}

--- a/src/renderer/src/lib/monaco-languages/register-svelte.ts
+++ b/src/renderer/src/lib/monaco-languages/register-svelte.ts
@@ -70,26 +70,23 @@ export const svelteMonarchLanguage: Monaco.languages.IMonarchLanguage = {
       [/[^-]+/, 'comment'],
       [/./, 'comment']
     ],
+    // Once the typescript embed is active inside an expression, Monaco only
+    // consults parent rules whose action ends the embed. That means a brace
+    // counter cannot run from inside the embed, so expressions containing
+    // nested braces (e.g. `class={{ active: foo }}` or `{foo({ bar: 1 })}`)
+    // close at the first inner `}` and the trailing `}` falls into markup.
+    // Matches the RFC's note that regex-based grammars have edge cases;
+    // the common single-brace case `{count}` works correctly.
     svelteExpressionEnter: [
       [/\}/, { token: 'delimiter.curly', next: '@pop' }],
       [/(?=.)/, { token: '', switchTo: '@svelteExpression', nextEmbedded: 'typescript' }]
     ],
-    svelteExpression: [
-      // Nested braces keep object literals inside {expr} from closing the
-      // Svelte expression at the first inner `}`.
-      [/\{/, 'delimiter.curly', '@svelteExpressionNestedBrace'],
-      [/\}/, { token: 'delimiter.curly', next: '@pop', nextEmbedded: '@pop' }]
-    ],
-    svelteExpressionNestedBrace: [
-      [/\{/, 'delimiter.curly', '@push'],
-      [/\}/, 'delimiter.curly', '@pop']
-    ],
+    svelteExpression: [[/\}/, { token: 'delimiter.curly', next: '@pop', nextEmbedded: '@pop' }]],
     svelteBlockExpressionEnter: [
       [/\}/, { token: 'keyword.control', next: '@pop' }],
       [/(?=.)/, { token: '', switchTo: '@svelteBlockExpression', nextEmbedded: 'typescript' }]
     ],
     svelteBlockExpression: [
-      [/\{/, 'delimiter.curly', '@svelteExpressionNestedBrace'],
       [/\}/, { token: 'keyword.control', next: '@pop', nextEmbedded: '@pop' }]
     ],
     scriptOpen: [

--- a/src/renderer/src/lib/monaco-languages/register-svelte.ts
+++ b/src/renderer/src/lib/monaco-languages/register-svelte.ts
@@ -13,10 +13,39 @@ export const svelteMonarchLanguage: Monaco.languages.IMonarchLanguage = {
     { open: '<', close: '>', token: 'delimiter.angle' }
   ],
   tokenizer: {
+    // Entry state. No embed is active yet, so structural rules must NOT pop
+    // an embedded tokenizer (Monaco throws on `nextEmbedded: '@pop'` when no
+    // embed is on the stack). The first piece of template markup transitions
+    // into `markup`, where the html embed is active and structural rules pop
+    // it cleanly.
     root: [
       [/<script(?=\s|>)/, 'tag', '@scriptOpen.typescript'],
       [/<style(?=\s|>)/, 'tag', '@styleOpen.css'],
       [/<!--/, 'comment', '@comment'],
+      [/\{\s*\/(if|each|await|key|snippet)\s*\}/, 'keyword.control'],
+      [
+        /\{\s*#(if|each|await|key|snippet)\b/,
+        { token: 'keyword.control', next: '@svelteBlockExpressionEnter' }
+      ],
+      [
+        /\{\s*:(else|then|catch)\b/,
+        { token: 'keyword.control', next: '@svelteBlockExpressionEnter' }
+      ],
+      [
+        /\{\s*@(html|debug|const|render)\b/,
+        { token: 'keyword.control', next: '@svelteExpressionEnter' }
+      ],
+      [/\{(?=[^#:/@])/, { token: 'delimiter.curly', next: '@svelteExpressionEnter' }],
+      // First markup character: switch into `markup` and start the html embed.
+      [/(?=.)/, { token: '', switchTo: '@markup', nextEmbedded: 'html' }]
+    ],
+    // html-embedded markup state. Structural rules end the embed before
+    // pushing into script/style/comment/svelte states; the catch-all
+    // re-enters html when those states pop back.
+    markup: [
+      [/<script(?=\s|>)/, { token: 'tag', next: '@scriptOpen.typescript', nextEmbedded: '@pop' }],
+      [/<style(?=\s|>)/, { token: 'tag', next: '@styleOpen.css', nextEmbedded: '@pop' }],
+      [/<!--/, { token: 'comment', next: '@comment', nextEmbedded: '@pop' }],
       [/\{\s*\/(if|each|await|key|snippet)\s*\}/, 'keyword.control'],
       [
         /\{\s*#(if|each|await|key|snippet)\b/,
@@ -34,8 +63,6 @@ export const svelteMonarchLanguage: Monaco.languages.IMonarchLanguage = {
         /\{(?=[^#:/@])/,
         { token: 'delimiter.curly', next: '@svelteExpressionEnter', nextEmbedded: '@pop' }
       ],
-      // Svelte has top-level markup instead of a <template> wrapper. Re-enter
-      // html after Svelte-specific states pop their embedded tokenizers.
       [/(?=.)/, { token: '', nextEmbedded: 'html' }]
     ],
     comment: [

--- a/src/renderer/src/lib/monaco-languages/register-svelte.ts
+++ b/src/renderer/src/lib/monaco-languages/register-svelte.ts
@@ -13,60 +13,84 @@ export const svelteMonarchLanguage: Monaco.languages.IMonarchLanguage = {
     { open: '<', close: '>', token: 'delimiter.angle' }
   ],
   tokenizer: {
-    // Entry state. No embed is active yet, so structural rules must NOT pop
-    // an embedded tokenizer (Monaco throws on `nextEmbedded: '@pop'` when no
-    // embed is on the stack). The first piece of template markup transitions
-    // into `markup`, where the html embed is active and structural rules pop
-    // it cleanly.
+    // Entry state: the `start` state runs on the very first token and has no
+    // embed on the stack. Structural rules MUST NOT emit `nextEmbedded:
+    // '@pop'` from here (Monarch throws "cannot pop embedded language if not
+    // inside one"). The first non-structural character transitions into
+    // `markup`, activating the html embed — from then on every path that
+    // returns to `markup` routes through `markupReenter` so the invariant
+    // "markup has html embed active" always holds.
     root: [
-      [/<script(?=\s|>)/, 'tag', '@scriptOpen.typescript'],
-      [/<style(?=\s|>)/, 'tag', '@styleOpen.css'],
-      [/<!--/, 'comment', '@comment'],
+      [/<script(?=\s|>)/, { token: 'tag', switchTo: '@scriptOpen.typescript' }],
+      [/<style(?=\s|>)/, { token: 'tag', switchTo: '@styleOpen.css' }],
+      [/<!--/, { token: 'comment', switchTo: '@comment' }],
       [/\{\s*\/(if|each|await|key|snippet)\s*\}/, 'keyword.control'],
       [
         /\{\s*#(if|each|await|key|snippet)\b/,
-        { token: 'keyword.control', next: '@svelteBlockExpressionEnter' }
+        { token: 'keyword.control', switchTo: '@svelteBlockExpressionEnter' }
       ],
       [
         /\{\s*:(else|then|catch)\b/,
-        { token: 'keyword.control', next: '@svelteBlockExpressionEnter' }
+        { token: 'keyword.control', switchTo: '@svelteBlockExpressionEnter' }
       ],
       [
         /\{\s*@(html|debug|const|render)\b/,
-        { token: 'keyword.control', next: '@svelteExpressionEnter' }
+        { token: 'keyword.control', switchTo: '@svelteExpressionEnter' }
       ],
-      [/\{(?=[^#:/@])/, { token: 'delimiter.curly', next: '@svelteExpressionEnter' }],
-      // First markup character: switch into `markup` and start the html embed.
+      [/\{(?=[^#:/@])/, { token: 'delimiter.curly', switchTo: '@svelteExpressionEnter' }],
       [/(?=.)/, { token: '', switchTo: '@markup', nextEmbedded: 'html' }]
     ],
-    // html-embedded markup state. Structural rules end the embed before
-    // pushing into script/style/comment/svelte states; the catch-all
-    // re-enters html when those states pop back.
+    // html-embedded markup state. INVARIANT: whenever we are in `markup`, the
+    // html embed is active. Every state that pops back to markup routes
+    // through `markupReenter` to re-enter html first. This means `_myTokenize`
+    // never sees `markup` with embed=null — which is what would trigger
+    // "cannot pop embedded language if not inside one" when a structural rule
+    // with `nextEmbedded: '@pop'` fires.
+    //
+    // Two tokenization paths use this state:
+    //   (1) `_nestedTokenize`: scans rules whose action pops the embed; the
+    //       structural rules below are those pop rules.
+    //   (2) `_myTokenize`: called on the substring starting at the popOffset;
+    //       the pop rule at position 0 is the first (and only) rule to match
+    //       before state transitions out of `markup`.
+    // All transitions use `switchTo` rather than `next` so the Monarch stack
+    // stays flat — otherwise re-entering markup via `markupReenter` would add
+    // a frame on every svelte expression close and eventually hit
+    // `maxStack` (100).
     markup: [
-      [/<script(?=\s|>)/, { token: 'tag', next: '@scriptOpen.typescript', nextEmbedded: '@pop' }],
-      [/<style(?=\s|>)/, { token: 'tag', next: '@styleOpen.css', nextEmbedded: '@pop' }],
-      [/<!--/, { token: 'comment', next: '@comment', nextEmbedded: '@pop' }],
+      [
+        /<script(?=\s|>)/,
+        { token: 'tag', switchTo: '@scriptOpen.typescript', nextEmbedded: '@pop' }
+      ],
+      [/<style(?=\s|>)/, { token: 'tag', switchTo: '@styleOpen.css', nextEmbedded: '@pop' }],
+      [/<!--/, { token: 'comment', switchTo: '@comment', nextEmbedded: '@pop' }],
       [/\{\s*\/(if|each|await|key|snippet)\s*\}/, 'keyword.control'],
       [
         /\{\s*#(if|each|await|key|snippet)\b/,
-        { token: 'keyword.control', next: '@svelteBlockExpressionEnter', nextEmbedded: '@pop' }
+        { token: 'keyword.control', switchTo: '@svelteBlockExpressionEnter', nextEmbedded: '@pop' }
       ],
       [
         /\{\s*:(else|then|catch)\b/,
-        { token: 'keyword.control', next: '@svelteBlockExpressionEnter', nextEmbedded: '@pop' }
+        { token: 'keyword.control', switchTo: '@svelteBlockExpressionEnter', nextEmbedded: '@pop' }
       ],
       [
         /\{\s*@(html|debug|const|render)\b/,
-        { token: 'keyword.control', next: '@svelteExpressionEnter', nextEmbedded: '@pop' }
+        { token: 'keyword.control', switchTo: '@svelteExpressionEnter', nextEmbedded: '@pop' }
       ],
       [
         /\{(?=[^#:/@])/,
-        { token: 'delimiter.curly', next: '@svelteExpressionEnter', nextEmbedded: '@pop' }
-      ],
-      [/(?=.)/, { token: '', nextEmbedded: 'html' }]
+        { token: 'delimiter.curly', switchTo: '@svelteExpressionEnter', nextEmbedded: '@pop' }
+      ]
     ],
+    // Re-entry shim: every state that finishes and returns to markup context
+    // switches to this state (with `nextEmbedded: '@pop'` if it had an embed
+    // to pop). A zero-width `@rematch` then re-enters the html embed and
+    // switches to `markup`. `@rematch` short-circuits Monarch's progress
+    // check — a zero-width match that stays in the same state and stack
+    // depth otherwise throws "no progress in tokenizer".
+    markupReenter: [[/(?=.)/, { token: '@rematch', switchTo: '@markup', nextEmbedded: 'html' }]],
     comment: [
-      [/-->/, 'comment', '@pop'],
+      [/-->/, { token: 'comment', switchTo: '@markupReenter' }],
       [/[^-]+/, 'comment'],
       [/./, 'comment']
     ],
@@ -78,19 +102,25 @@ export const svelteMonarchLanguage: Monaco.languages.IMonarchLanguage = {
     // Matches the RFC's note that regex-based grammars have edge cases;
     // the common single-brace case `{count}` works correctly.
     svelteExpressionEnter: [
-      [/\}/, { token: 'delimiter.curly', next: '@pop' }],
+      // Empty expression `{}`: entry popped the html embed, but we never
+      // entered the typescript embed, so only the state needs to unwind.
+      [/\}/, { token: 'delimiter.curly', switchTo: '@markupReenter' }],
       [/(?=.)/, { token: '', switchTo: '@svelteExpression', nextEmbedded: 'typescript' }]
     ],
-    svelteExpression: [[/\}/, { token: 'delimiter.curly', next: '@pop', nextEmbedded: '@pop' }]],
+    svelteExpression: [
+      [/\}/, { token: 'delimiter.curly', switchTo: '@markupReenter', nextEmbedded: '@pop' }]
+    ],
     svelteBlockExpressionEnter: [
-      [/\}/, { token: 'keyword.control', next: '@pop' }],
+      [/\}/, { token: 'keyword.control', switchTo: '@markupReenter' }],
       [/(?=.)/, { token: '', switchTo: '@svelteBlockExpression', nextEmbedded: 'typescript' }]
     ],
     svelteBlockExpression: [
-      [/\}/, { token: 'keyword.control', next: '@pop', nextEmbedded: '@pop' }]
+      [/\}/, { token: 'keyword.control', switchTo: '@markupReenter', nextEmbedded: '@pop' }]
     ],
     scriptOpen: [
-      [/\/>/, 'tag', '@pop'],
+      // Self-closing `<script/>` didn't enter an embed, but it might have been
+      // entered from markup (which popped html on entry). Re-enter uniformly.
+      [/\/>/, { token: 'tag', switchTo: '@markupReenter' }],
       [/>/, { token: 'tag', switchTo: '@scriptBody.$S2', nextEmbedded: '$S2' }],
       [/lang(?=\s*=)/, { token: 'attribute.name', switchTo: '@scriptLangBeforeEquals.$S2' }],
       { include: '@tagAttributes' }
@@ -118,9 +148,11 @@ export const svelteMonarchLanguage: Monaco.languages.IMonarchLanguage = {
       [/'[^']*'/, { token: 'attribute.value', switchTo: '@scriptOpen.$S2' }],
       [/\s+/, 'white']
     ],
-    scriptBody: [[/<\/script\s*>/, { token: 'tag', next: '@pop', nextEmbedded: '@pop' }]],
+    scriptBody: [
+      [/<\/script\s*>/, { token: 'tag', switchTo: '@markupReenter', nextEmbedded: '@pop' }]
+    ],
     styleOpen: [
-      [/\/>/, 'tag', '@pop'],
+      [/\/>/, { token: 'tag', switchTo: '@markupReenter' }],
       [/>/, { token: 'tag', switchTo: '@styleBody.$S2', nextEmbedded: '$S2' }],
       [/lang(?=\s*=)/, { token: 'attribute.name', switchTo: '@styleLangBeforeEquals.$S2' }],
       { include: '@tagAttributes' }
@@ -148,7 +180,9 @@ export const svelteMonarchLanguage: Monaco.languages.IMonarchLanguage = {
       [/'[^']*'/, { token: 'attribute.value', switchTo: '@styleOpen.$S2' }],
       [/\s+/, 'white']
     ],
-    styleBody: [[/<\/style\s*>/, { token: 'tag', next: '@pop', nextEmbedded: '@pop' }]],
+    styleBody: [
+      [/<\/style\s*>/, { token: 'tag', switchTo: '@markupReenter', nextEmbedded: '@pop' }]
+    ],
     tagAttributes: [
       [/[^\s/>=]+/, 'attribute.name'],
       [/=/, 'delimiter'],

--- a/src/renderer/src/lib/monaco-setup.ts
+++ b/src/renderer/src/lib/monaco-setup.ts
@@ -7,6 +7,7 @@ import jsonWorker from 'monaco-editor/esm/vs/language/json/json.worker?worker'
 import cssWorker from 'monaco-editor/esm/vs/language/css/css.worker?worker'
 import htmlWorker from 'monaco-editor/esm/vs/language/html/html.worker?worker'
 import tsWorker from 'monaco-editor/esm/vs/language/typescript/ts.worker?worker'
+import { registerSvelteLanguage } from './monaco-languages/register-svelte'
 import { registerVueLanguage } from './monaco-languages/register-vue'
 
 globalThis.MonacoEnvironment = {
@@ -76,6 +77,7 @@ monacoTS.javascriptDefaults.setCompilerOptions({
 })
 
 registerVueLanguage(monaco)
+registerSvelteLanguage(monaco)
 
 // Configure Monaco to use the locally bundled editor instead of CDN
 loader.config({ monaco })


### PR DESCRIPTION
## Summary

Refs #1085 (Svelte half).

Today `.svelte` is aliased to `html` in `language-detect.ts`, which gives Svelte components HTML-level coloring only and leaves TypeScript inside `<script lang="ts">`, single-brace expressions like `{count}`, and template control flow like `{#if}` / `{/if}` un-tokenized.

This PR is the Svelte counterpart to #1093 (Vue): a Monaco Monarch grammar that embeds the existing `typescript` tokenizer inside `<script>` / `<script lang="ts">`, the `html` tokenizer for top-level markup, and the `css` tokenizer inside `<style>` (with the same `lang=` switching for `js` / `ts` / `scss` / `sass` / `less` / `css` Vue uses). Adds Svelte template syntax recognition: `{expr}`, block control flow `{#if}` / `{:else if}` / `{:else}` / `{/if}` / `{#each ... as ...}` / `{#await}` / `{:then}` / `{:catch}` / `{/await}` / `{#key}` / `{#snippet}`, and special tags `{@html}` / `{@debug}` / `{@const}` / `{@render}`.

The interim `.astro` -> `html` alias from #1084 is preserved; Astro will follow as a separate PR per #1085.

## Screenshots

No visual change in this PR diff itself. The user-visible change is editor-side: opening any `.svelte` file in Orca now tokenizes top-level markup (html), `<script>` / `<script lang="ts">` (typescript / javascript), `<style lang="scss">` (scss / less / sass / css), Svelte block control flow, and `{expression}` interpolation, instead of one whole-file HTML pass.

## Testing

- [x] `pnpm lint` (2 pre-existing warnings in `useDiffCommentDecorator.tsx`, 0 errors from this change)
- [x] `pnpm typecheck` (all three configs pass)
- [x] `pnpm test` (269 files, 3048 tests pass, 7 skipped)
- [x] `pnpm build` (success)
- [x] Added `language-detect.test.ts` cases covering `.svelte` -> `'svelte'` and confirming `.astro` still returns `'html'`
- [x] Added `monaco-languages/register-svelte.test.ts` with: idempotent registration, a tokenizer-transition fixture walk over a representative Svelte SFC (script lang="ts" / top-level markup / `{#if}` / `{:else}` / `{/if}` / `{expression}` / `{@html}` / style), embedded-language tracking for `lang=` attributes (js / ts / scss / sass / less / css), and three regression tests for the root vs markup split

## AI Review Report

Implementation by Codex (gpt-5.5 high). Two review passes via `codex review --base upstream/main`.

The first review caught two functional issues that would have shipped broken: the original `root` state set `nextEmbedded: '@pop'` on Svelte-expression rules, which Monaco rejects with "cannot pop embedded language if not inside one" when a file starts with `{#if}` or `{count}`; and `<script>` / `<style>` rules without `nextEmbedded: '@pop'` were ignored once the html embed activated, so a trailing `<style lang="scss">` after markup never reached the lang-switching code. Fix: split the entry-only `root` state from an html-embedded `markup` state where structural rules pop the embed before pushing into script/style/comment/svelte states.

Cross-platform: pure tokenizer logic, no platform-specific code paths, no path handling, no shortcut bindings. Idempotent registration matches `register-vue.ts` (guards against double-registration on Monaco hot-reload). All Monarch states are reachable and each has a path to `@pop`. No Monaco version assumptions added beyond what register-vue.ts already relies on.

## Security Audit

No new dependencies. No `eval`, no untrusted input handling, no IPC, no path or filesystem access, no auth or secrets. The grammar is data passed to `monaco.languages.setMonarchTokensProvider` and `setLanguageConfiguration`. Nothing outside the renderer.

## Notes

X handle: [@mvanhorn](https://x.com/mvanhorn)

This contribution was developed with AI assistance.
