### PR TITLE
fix(linear): defer keychain decrypt, cache viewer, add Test connection

### DIFF
--- a/src/main/ipc/linear.ts
+++ b/src/main/ipc/linear.ts
@@ -1,5 +1,5 @@
 import { ipcMain } from 'electron'
-import { connect, disconnect, getStatus } from '../linear/client'
+import { connect, disconnect, getStatus, testConnection } from '../linear/client'
 import { _resetPreflightCache } from './preflight'
 import {
   getIssue,
@@ -37,6 +37,10 @@ export function registerLinearHandlers(): void {
 
   ipcMain.handle('linear:status', async () => {
     return getStatus()
+  })
+
+  ipcMain.handle('linear:testConnection', async () => {
+    return testConnection()
   })
 
   ipcMain.handle('linear:searchIssues', async (_event, args: { query: string; limit?: number }) => {

--- a/src/main/linear/client.ts
+++ b/src/main/linear/client.ts
@@ -31,13 +31,62 @@ export function release(): void {
   }
 }
 
-// ── Token storage ────────────────────────────────────────────────────
+// ── Token + viewer storage ───────────────────────────────────────────
+// Why: the token is encrypted via safeStorage (OS keychain). The viewer
+// metadata is kept in a separate *plaintext* file so settings/status
+// checks can answer "are you connected, and as whom?" without ever
+// decrypting the token. Decrypting triggers a macOS Keychain permission
+// dialog after every app signature change (e.g. every update), so we only
+// touch the encrypted token when the user actually makes a Linear API
+// call or explicitly tests the connection.
 function getTokenPath(): string {
   return join(homedir(), '.orca', 'linear-token.enc')
 }
 
+function getViewerPath(): string {
+  return join(homedir(), '.orca', 'linear-viewer.json')
+}
+
 let cachedToken: string | null = null
 let cachedViewer: LinearViewer | null = null
+let viewerLoadedFromDisk = false
+
+function readViewerFromDisk(): LinearViewer | null {
+  const path = getViewerPath()
+  if (!existsSync(path)) {
+    return null
+  }
+  try {
+    const raw = readFileSync(path, { encoding: 'utf-8' })
+    const parsed = JSON.parse(raw) as Partial<LinearViewer>
+    if (typeof parsed?.displayName !== 'string' || typeof parsed?.organizationName !== 'string') {
+      return null
+    }
+    return {
+      displayName: parsed.displayName,
+      email: typeof parsed.email === 'string' ? parsed.email : null,
+      organizationName: parsed.organizationName
+    }
+  } catch {
+    return null
+  }
+}
+
+function writeViewerToDisk(viewer: LinearViewer): void {
+  const dir = join(homedir(), '.orca')
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true })
+  }
+  writeFileSync(getViewerPath(), JSON.stringify(viewer), { encoding: 'utf-8', mode: 0o600 })
+}
+
+function clearViewerOnDisk(): void {
+  try {
+    unlinkSync(getViewerPath())
+  } catch {
+    // File may not exist — safe to ignore.
+  }
+}
 
 export function saveToken(apiKey: string): void {
   const dir = join(homedir(), '.orca')
@@ -59,9 +108,16 @@ export function saveToken(apiKey: string): void {
   cachedToken = apiKey
 }
 
-export function loadToken(): string | null {
+// Why: force=true is used when the caller wants a token and accepts the
+// keychain prompt (explicit "Test connection" or an actual API call). The
+// default call path is fine with returning null if we haven't decrypted yet
+// this session, so status checks don't trigger Keychain.
+export function loadToken(options: { force?: boolean } = {}): string | null {
   if (cachedToken !== null) {
     return cachedToken
+  }
+  if (!options.force) {
+    return null
   }
   const tokenPath = getTokenPath()
   if (!existsSync(tokenPath)) {
@@ -78,20 +134,32 @@ export function loadToken(): string | null {
   }
 }
 
+export function hasStoredToken(): boolean {
+  if (cachedToken !== null) {
+    return true
+  }
+  return existsSync(getTokenPath())
+}
+
 export function clearToken(): void {
   cachedToken = null
   cachedViewer = null
+  viewerLoadedFromDisk = false
   const tokenPath = getTokenPath()
   try {
     unlinkSync(tokenPath)
   } catch {
     // File may not exist — safe to ignore.
   }
+  clearViewerOnDisk()
 }
 
 // ── Client factory ───────────────────────────────────────────────────
+// Why: this is called by the issues/teams modules when the user actually
+// performs a Linear action — at that point decrypting the token (and
+// surfacing a Keychain prompt if needed) is expected.
 export function getClient(): LinearClient | null {
-  const token = loadToken()
+  const token = loadToken({ force: true })
   if (!token) {
     return null
   }
@@ -122,7 +190,9 @@ export async function connect(
     }
 
     saveToken(apiKey)
+    writeViewerToDisk(viewer)
     cachedViewer = viewer
+    viewerLoadedFromDisk = true
     return { ok: true, viewer }
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Failed to validate API key'
@@ -134,36 +204,63 @@ export function disconnect(): void {
   clearToken()
 }
 
-export async function getStatus(): Promise<LinearConnectionStatus> {
-  const token = loadToken()
-  if (!token) {
+// Why: getStatus must NEVER decrypt the token. It returns the cached
+// viewer (written at connect time) so the settings/landing UIs can show
+// "Connected as X" without triggering a Keychain permission dialog after
+// every app update. The encrypted token is only touched lazily on real
+// Linear API calls or when the user clicks "Test connection".
+export function getStatus(): LinearConnectionStatus {
+  if (!hasStoredToken()) {
     return { connected: false, viewer: null }
   }
 
-  if (cachedViewer) {
-    return { connected: true, viewer: cachedViewer }
+  if (!cachedViewer && !viewerLoadedFromDisk) {
+    cachedViewer = readViewerFromDisk()
+    viewerLoadedFromDisk = true
   }
 
-  // Lazily fetch viewer info on first status check after app restart.
+  return { connected: true, viewer: cachedViewer }
+}
+
+// Why: explicit user-initiated check. Decrypts the token, pings the
+// Linear API to re-validate, and refreshes the cached viewer file. If the
+// token is rejected (401) it clears state just like a live API error.
+export async function testConnection(): Promise<
+  { ok: true; viewer: LinearViewer } | { ok: false; error: string }
+> {
+  const token = loadToken({ force: true })
+  if (!token) {
+    return { ok: false, error: 'No API key stored.' }
+  }
   try {
     const client = new LinearClient({ apiKey: token })
     const me = await client.viewer
     const org = await me.organization
-
-    cachedViewer = {
+    const viewer: LinearViewer = {
       displayName: me.displayName,
       email: me.email ?? null,
       organizationName: org.name
     }
-    return { connected: true, viewer: cachedViewer }
+    writeViewerToDisk(viewer)
+    cachedViewer = viewer
+    viewerLoadedFromDisk = true
+    return { ok: true, viewer }
   } catch (error) {
     if (isAuthError(error)) {
       clearToken()
     }
-    return { connected: false, viewer: null }
+    const message = error instanceof Error ? error.message : 'Test failed'
+    return { ok: false, error: message }
   }
 }
 
+// Why: called at main-process startup. This used to eagerly decrypt the
+// token (which triggered a Keychain prompt on every launch after an app
+// update). We now only warm the plaintext viewer cache — the token stays
+// encrypted on disk until actually needed.
 export function initLinearToken(): void {
-  loadToken()
+  if (!viewerLoadedFromDisk) {
+    cachedViewer = readViewerFromDisk()
+    viewerLoadedFromDisk = true
+  }
 }

--- a/src/preload/api-types.d.ts
+++ b/src/preload/api-types.d.ts
@@ -455,6 +455,7 @@ export type PreloadApi = {
     }) => Promise<{ ok: true; viewer: LinearViewer } | { ok: false; error: string }>
     disconnect: () => Promise<void>
     status: () => Promise<LinearConnectionStatus>
+    testConnection: () => Promise<{ ok: true; viewer: LinearViewer } | { ok: false; error: string }>
     searchIssues: (args: { query: string; limit?: number }) => Promise<LinearIssue[]>
     listIssues: (args?: {
       filter?: 'assigned' | 'created' | 'all' | 'completed'

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -476,6 +476,9 @@ const api = {
 
     status: (): Promise<unknown> => ipcRenderer.invoke('linear:status'),
 
+    testConnection: (): Promise<{ ok: true; viewer: unknown } | { ok: false; error: string }> =>
+      ipcRenderer.invoke('linear:testConnection'),
+
     searchIssues: (args: { query: string; limit?: number }): Promise<unknown[]> =>
       ipcRenderer.invoke('linear:searchIssues', args),
 

--- a/src/renderer/src/components/settings/IntegrationsPane.tsx
+++ b/src/renderer/src/components/settings/IntegrationsPane.tsx
@@ -1,5 +1,14 @@
 import { useEffect, useState } from 'react'
-import { Github, ExternalLink, LoaderCircle, Lock, Terminal, Unlink } from 'lucide-react'
+import {
+  Github,
+  ExternalLink,
+  LoaderCircle,
+  Lock,
+  Terminal,
+  Unlink,
+  CheckCircle2,
+  AlertCircle
+} from 'lucide-react'
 import { useAppStore } from '../../store'
 import { Button } from '../ui/button'
 import { Input } from '../ui/input'
@@ -41,6 +50,7 @@ export function IntegrationsPane(): React.JSX.Element {
   const connectLinear = useAppStore((s) => s.connectLinear)
   const disconnectLinear = useAppStore((s) => s.disconnectLinear)
   const checkLinearConnection = useAppStore((s) => s.checkLinearConnection)
+  const testLinearConnection = useAppStore((s) => s.testLinearConnection)
 
   const [ghStatus, setGhStatus] = useState<GhStatus>('checking')
   const [linearDialogOpen, setLinearDialogOpen] = useState(false)
@@ -49,6 +59,10 @@ export function IntegrationsPane(): React.JSX.Element {
     'idle'
   )
   const [linearConnectError, setLinearConnectError] = useState<string | null>(null)
+  const [linearTestState, setLinearTestState] = useState<'idle' | 'testing' | 'ok' | 'error'>(
+    'idle'
+  )
+  const [linearTestError, setLinearTestError] = useState<string | null>(null)
 
   useEffect(() => {
     void checkLinearConnection()
@@ -90,6 +104,24 @@ export function IntegrationsPane(): React.JSX.Element {
     await disconnectLinear()
     setLinearConnectState('idle')
     setLinearConnectError(null)
+    setLinearTestState('idle')
+    setLinearTestError(null)
+  }
+
+  // Why: explicit user-triggered verification. This is the *only* path in
+  // settings that decrypts the stored API key, so the macOS Keychain prompt
+  // (if the app signature has changed since the item was stored) only
+  // appears when the user clicks Test — not just for opening Settings.
+  const handleLinearTest = async (): Promise<void> => {
+    setLinearTestState('testing')
+    setLinearTestError(null)
+    const result = await testLinearConnection()
+    if (result.ok) {
+      setLinearTestState('ok')
+    } else {
+      setLinearTestState('error')
+      setLinearTestError(result.error)
+    }
   }
 
   const handleRefreshGh = (): void => {
@@ -190,7 +222,9 @@ export function IntegrationsPane(): React.JSX.Element {
             <p className="text-sm font-medium">Linear</p>
             <p className="text-xs text-muted-foreground">
               {linearStatus.connected
-                ? `${linearStatus.viewer?.organizationName ?? ''} · ${linearStatus.viewer?.displayName ?? ''}${linearStatus.viewer?.email ? ` · ${linearStatus.viewer.email}` : ''}`
+                ? linearStatus.viewer
+                  ? `${linearStatus.viewer.organizationName} · ${linearStatus.viewer.displayName}${linearStatus.viewer.email ? ` · ${linearStatus.viewer.email}` : ''}`
+                  : 'API key saved. Test to verify.'
                 : 'Browse and link issues to workspaces.'}
             </p>
           </div>
@@ -216,6 +250,43 @@ export function IntegrationsPane(): React.JSX.Element {
             </button>
           )}
         </div>
+
+        {linearStatus.connected && (
+          <div className="mt-2.5 flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => void handleLinearTest()}
+              disabled={linearTestState === 'testing'}
+            >
+              {linearTestState === 'testing' ? (
+                <>
+                  <LoaderCircle className="size-3.5 mr-1.5 animate-spin" />
+                  Testing…
+                </>
+              ) : (
+                'Test connection'
+              )}
+            </Button>
+            {linearTestState === 'ok' && (
+              <span className="flex items-center gap-1 text-xs text-emerald-600 dark:text-emerald-400">
+                <CheckCircle2 className="size-3.5" />
+                Verified
+              </span>
+            )}
+            {linearTestState === 'error' && linearTestError && (
+              <span className="flex items-center gap-1 text-xs text-destructive">
+                <AlertCircle className="size-3.5" />
+                {linearTestError}
+              </span>
+            )}
+            {linearTestState === 'idle' && (
+              <span className="text-[11px] text-muted-foreground/70">
+                Verifies your API key against Linear.
+              </span>
+            )}
+          </div>
+        )}
       </div>
 
       {/* Linear Connect Dialog */}

--- a/src/renderer/src/store/slices/linear.ts
+++ b/src/renderer/src/store/slices/linear.ts
@@ -46,6 +46,9 @@ export type LinearSlice = {
   connectLinear: (
     apiKey: string
   ) => Promise<{ ok: true; viewer: LinearViewer } | { ok: false; error: string }>
+  testLinearConnection: () => Promise<
+    { ok: true; viewer: LinearViewer } | { ok: false; error: string }
+  >
   disconnectLinear: () => Promise<void>
   fetchLinearIssue: (id: string) => Promise<LinearIssue | null>
   searchLinearIssues: (query: string, limit?: number) => Promise<LinearIssue[]>
@@ -77,6 +80,31 @@ export const createLinearSlice: StateCreator<AppState, [], [], LinearSlice> = (s
       } else if (!get().linearStatusChecked) {
         set({ linearStatusChecked: true })
       }
+    }
+  },
+
+  testLinearConnection: async () => {
+    try {
+      const result = (await window.api.linear.testConnection()) as
+        | { ok: true; viewer: LinearViewer }
+        | { ok: false; error: string }
+      if (result.ok) {
+        set({
+          linearStatus: { connected: true, viewer: result.viewer },
+          linearStatusChecked: true
+        })
+      } else {
+        // Why: testConnection clears the token on auth errors; reflect that
+        // locally so the UI drops back to the Connect state.
+        set({
+          linearStatus: { connected: false, viewer: null },
+          linearStatusChecked: true
+        })
+      }
+      return result
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Test failed'
+      return { ok: false as const, error: message }
     }
   },
 


### PR DESCRIPTION
## Summary

macOS Keychain prompts the user to re-authorize access to `orca Safe Storage` every time the app's code signature changes — i.e. after every update. Previously `linear:status` called `safeStorage.decryptString` eagerly on every Settings mount and on app startup, so users saw the *"Electron wants to use your confidential information stored in 'orca Safe Storage' in your keychain"* dialog just for opening Settings after an update.

This change **defers keychain access until the user actually needs the token**.

### What changed

- **Split persisted state into two files**:
  - `~/.orca/linear-token.enc` — encrypted token (unchanged format). Only decrypted when the user makes a real Linear API call or clicks "Test connection".
  - `~/.orca/linear-viewer.json` — plaintext viewer metadata (org name, display name, email). Written at connect time. Used for the "Connected as …" row in Settings. Never touches the keychain.
- **`getStatus()` no longer decrypts.** It returns `connected: true` when the token file exists, with viewer metadata from the plaintext cache.
- **`initLinearToken()` no longer decrypts at startup.** Just warms the plaintext viewer cache.
- **Added "Test connection" button** in Settings → Integrations → Linear. Explicit user action is the only path (besides a live API call) that decrypts the token.
- `getClient()` (used by all Linear API calls) passes `{ force: true }` to `loadToken` — the keychain prompt is expected when the user is actively using Linear.

### Why this design

Settings should never prompt for a keychain password. "Connected" is a UI affordance — it does not need a live token to render. The token only needs to exist *at the moment an API call happens* (or when the user explicitly asks us to verify it).

### UX

- Open Settings after an update → no Keychain dialog.
- Settings shows the cached org/user from the last successful connect.
- Click **Test connection** → Keychain dialog (click Always Allow once) → green "Verified" check.
- Browse issues on the Linear tab → Keychain dialog if not yet allowed this session → issues load.

## Test plan

- [ ] Open Settings → Integrations on a freshly-signed dev build that hasn't been authorized for the keychain item. Verify **no dialog** appears.
- [ ] Click **Test connection**. Verify the Keychain dialog appears, then "Verified" shows after approval.
- [ ] Click **Disconnect**, then re-**Connect** with a valid key — verify the viewer file is rewritten and the UI updates.
- [ ] Connect, relaunch the app, open Settings — should show "Connected" with cached org/user and no dialog.
- [ ] Manually break the token (e.g. `echo garbage > ~/.orca/linear-token.enc`) and click Test — verify error state, then the row falls back to "Connect".
- [ ] Browse issues on the Linear tab — keychain prompt happens once, issues load.
- [ ] Linux/Windows: connect + status + test flow still works (safeStorage fallback path unaffected).

Made with [Orca](https://github.com/stablyai/orca) 🐋
