### PR TITLE
feat(terminal): WSL shell support for Windows users

### DIFF
--- a/src/main/ipc/app.ts
+++ b/src/main/ipc/app.ts
@@ -1,4 +1,5 @@
 import { app, ipcMain } from 'electron'
+import { isWslAvailable } from '../wsl'
 
 export type AppRuntimeFlags = {
   /** Whether the persistent terminal daemon was actually started this session.
@@ -38,6 +39,8 @@ export function registerAppHandlers(): void {
     pendingDaemonTransitionNotice = null
     return notice
   })
+
+  ipcMain.handle('wsl:isAvailable', (): boolean => isWslAvailable())
 
   ipcMain.handle('app:relaunch', () => {
     // Why: small delay lets the renderer finish painting any "Restarting…"

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -418,6 +418,7 @@ export function registerPtyHandlers(
         connectionId?: string | null
         worktreeId?: string
         sessionId?: string
+        shellOverride?: string
       }
     ) => {
       const provider = getProvider(args.connectionId)
@@ -473,6 +474,9 @@ export function registerPtyHandlers(
       }
       if (args.sessionId !== undefined) {
         spawnOptions.sessionId = args.sessionId
+      }
+      if (args.shellOverride !== undefined) {
+        spawnOptions.shellOverride = args.shellOverride
       }
       const result = await provider.spawn(spawnOptions)
       ptyOwnership.set(result.id, args.connectionId ?? null)

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -149,6 +149,8 @@ export class LocalPtyProvider implements IPtyProvider {
       // byte sequences are misinterpreted as UTF-8.
       if (shellBasename === 'cmd.exe') {
         shellArgs = ['/K', 'chcp 65001 > nul']
+        effectiveCwd = cwd
+        validationCwd = cwd
       } else if (shellBasename === 'powershell.exe' || shellBasename === 'pwsh.exe') {
         // Why: `-NoExit -Command` alone skips the user's $PROFILE, breaking
         // custom prompts (oh-my-posh, starship), aliases, and PSReadLine
@@ -159,6 +161,8 @@ export class LocalPtyProvider implements IPtyProvider {
           '-Command',
           'try { . $PROFILE } catch {}; [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; [Console]::InputEncoding = [System.Text.Encoding]::UTF8'
         ]
+        effectiveCwd = cwd
+        validationCwd = cwd
       } else if (shellBasename === 'wsl.exe') {
         // Why: this branch handles the "user chose WSL as their shell" case,
         // distinct from the wslInfo branch above which is for repos whose cwd
@@ -175,8 +179,6 @@ export class LocalPtyProvider implements IPtyProvider {
         validationCwd = cwd
       } else {
         shellArgs = []
-      }
-      if (shellBasename !== 'wsl.exe') {
         effectiveCwd = cwd
         validationCwd = cwd
       }

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -5,7 +5,7 @@ files without a cleaner ownership seam. */
 import { basename, win32 as pathWin32 } from 'path'
 import { existsSync } from 'fs'
 import * as pty from 'node-pty'
-import { parseWslPath } from '../wsl'
+import { parseWslPath, isWslAvailable } from '../wsl'
 import {
   injectHistoryEnv,
   updateHistFileForFallback,
@@ -134,7 +134,10 @@ export class LocalPtyProvider implements IPtyProvider {
       effectiveCwd = getDefaultCwd()
       validationCwd = cwd
     } else if (process.platform === 'win32') {
-      shellPath = this.opts.getWindowsShell?.() || process.env.COMSPEC || 'powershell.exe'
+      // Why: shellOverride lets a single tab open in a different shell than the
+      // persisted default (e.g. "New WSL terminal" from the "+" submenu) without
+      // changing the user's setting. It takes priority over the setting.
+      shellPath = args.shellOverride || this.opts.getWindowsShell?.() || process.env.COMSPEC || 'powershell.exe'
       // Why: use path.win32.basename so backslash-separated Windows paths
       // are parsed correctly even when tests mock process.platform on Linux CI.
       const shellBasename = pathWin32.basename(shellPath).toLowerCase()
@@ -156,11 +159,27 @@ export class LocalPtyProvider implements IPtyProvider {
           '-Command',
           'try { . $PROFILE } catch {}; [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; [Console]::InputEncoding = [System.Text.Encoding]::UTF8'
         ]
+      } else if (shellBasename === 'wsl.exe') {
+        // Why: this branch handles the "user chose WSL as their shell" case,
+        // distinct from the wslInfo branch above which is for repos whose cwd
+        // lives on a WSL filesystem. Here the cwd is a normal Windows path, so
+        // we translate it to a Linux /mnt/<drive>/... path and open a login
+        // bash in the user's default distro (no -d flag = default distro).
+        const driveMatch = cwd.replace(/\\/g, '/').match(/^([A-Za-z]):\/?(.*)$/)
+        const linuxCwd = driveMatch
+          ? `/mnt/${driveMatch[1].toLowerCase()}/${driveMatch[2]}`
+          : '/mnt/c'
+        const escapedLinuxCwd = linuxCwd.replace(/'/g, "'\\''")
+        shellArgs = ['--', 'bash', '-c', `cd '${escapedLinuxCwd}' && exec bash -l`]
+        effectiveCwd = getDefaultCwd()
+        validationCwd = cwd
       } else {
         shellArgs = []
       }
-      effectiveCwd = cwd
-      validationCwd = cwd
+      if (shellBasename !== 'wsl.exe') {
+        effectiveCwd = cwd
+        validationCwd = cwd
+      }
     } else {
       shellPath = args.env?.SHELL || process.env.SHELL || '/bin/zsh'
       shellArgs = ['-l']
@@ -465,10 +484,14 @@ export class LocalPtyProvider implements IPtyProvider {
 
   async getProfiles(): Promise<{ name: string; path: string }[]> {
     if (process.platform === 'win32') {
-      return [
+      const profiles: { name: string; path: string }[] = [
         { name: 'PowerShell', path: 'powershell.exe' },
         { name: 'Command Prompt', path: 'cmd.exe' }
       ]
+      if (isWslAvailable()) {
+        profiles.push({ name: 'WSL', path: 'wsl.exe' })
+      }
+      return profiles
     }
     const shells = ['/bin/zsh', '/bin/bash', '/bin/sh']
     return shells.filter((s) => existsSync(s)).map((s) => ({ name: basename(s), path: s }))

--- a/src/main/providers/types.ts
+++ b/src/main/providers/types.ts
@@ -25,6 +25,11 @@ export type PtySpawnOptions = {
   /** Daemon session ID for reattach. When provided, the daemon reconnects
    *  to an existing session instead of creating a new one. */
   sessionId?: string
+  /** Why: allows the renderer to request a specific shell for a single new
+   *  terminal tab (e.g. "open this tab in WSL" from the "+" submenu) without
+   *  changing the user's persistent default shell setting. Only consulted on
+   *  Windows; ignored on macOS/Linux where shell selection is not exposed. */
+  shellOverride?: string
 }
 
 export type PtySpawnResult = {

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -53,6 +53,10 @@ type WorktreesApi = {
   onChanged: (callback: (data: { repoId: string }) => void) => () => void
 }
 
+type WslApi = {
+  isAvailable: () => Promise<boolean>
+}
+
 type PtyApi = {
   spawn: (opts: {
     cols: number
@@ -63,6 +67,7 @@ type PtyApi = {
     connectionId?: string | null
     worktreeId?: string
     sessionId?: string
+    shellOverride?: string
   }) => Promise<{
     id: string
     snapshot?: string
@@ -228,6 +233,7 @@ type Api = PreloadApi & {
   notifications: NotificationsApi
   shell: ShellApi
   agentStatus: AgentStatusApi
+  wsl: WslApi
 }
 
 declare global {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -177,6 +177,10 @@ const api = {
     relaunch: (): Promise<void> => ipcRenderer.invoke('app:relaunch')
   },
 
+  wsl: {
+    isAvailable: (): Promise<boolean> => ipcRenderer.invoke('wsl:isAvailable')
+  },
+
   repos: {
     list: (): Promise<unknown[]> => ipcRenderer.invoke('repos:list'),
 
@@ -281,6 +285,7 @@ const api = {
       connectionId?: string | null
       worktreeId?: string
       sessionId?: string
+      shellOverride?: string
     }): Promise<{
       id: string
       snapshot?: string

--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -123,6 +123,14 @@ function Terminal(): React.JSX.Element | null {
     ? (browserTabsByWorktree[activeWorktreeId] ?? []).map((tab) => tab.id).join(',')
     : ''
 
+  const [wslAvailable, setWslAvailable] = useState(false)
+  useEffect(() => {
+    // Why: wsl:isAvailable is synchronous on the main-process side but we
+    // call it asynchronously so the renderer doesn't block on startup. The
+    // result only gates UI options, so a brief false→true transition is fine.
+    void window.api.wsl.isAvailable().then(setWslAvailable)
+  }, [])
+
   // Save confirmation dialog state
   const [saveDialogFileId, setSaveDialogFileId] = useState<string | null>(null)
   const saveDialogFile = saveDialogFileId ? openFiles.find((f) => f.id === saveDialogFileId) : null
@@ -355,38 +363,41 @@ function Terminal(): React.JSX.Element | null {
     createTab(activeWorktreeId)
   }, [workspaceSessionReady, activeWorktreeId, createTab, reconcileWorktreeTabModel])
 
-  const handleNewTab = useCallback(() => {
-    if (!activeWorktreeId) {
-      return
-    }
-    const newTab = createTab(activeWorktreeId)
-    setActiveTabType('terminal')
-    // Why: persist the tab bar order with the new terminal at the end of the
-    // current visual order. Without this, reconcileOrder falls back to
-    // terminals-first when tabBarOrderByWorktree is unset, causing a new
-    // terminal to jump to index 0 instead of appending after editor tabs.
-    const state = useAppStore.getState()
-    const currentTerminals = state.tabsByWorktree[activeWorktreeId] ?? []
-    const currentEditors = state.openFiles.filter((f) => f.worktreeId === activeWorktreeId)
-    const currentBrowsers = state.browserTabsByWorktree[activeWorktreeId] ?? []
-    const stored = state.tabBarOrderByWorktree[activeWorktreeId]
-    const termIds = currentTerminals.map((t) => t.id)
-    const editorIds = currentEditors.map((f) => f.id)
-    const browserIds = currentBrowsers.map((tab) => tab.id)
-    const validIds = new Set([...termIds, ...editorIds, ...browserIds])
-    const base = (stored ?? []).filter((id) => validIds.has(id))
-    const inBase = new Set(base)
-    for (const id of [...termIds, ...editorIds, ...browserIds]) {
-      if (!inBase.has(id)) {
-        base.push(id)
-        inBase.add(id)
+  const handleNewTab = useCallback(
+    (shellOverride?: string) => {
+      if (!activeWorktreeId) {
+        return
       }
-    }
-    // The new tab is already in base via termIds; move it to the end
-    const order = base.filter((id) => id !== newTab.id)
-    order.push(newTab.id)
-    setTabBarOrder(activeWorktreeId, order)
-  }, [activeWorktreeId, createTab, setActiveTabType, setTabBarOrder])
+      const newTab = createTab(activeWorktreeId, undefined, shellOverride)
+      setActiveTabType('terminal')
+      // Why: persist the tab bar order with the new terminal at the end of the
+      // current visual order. Without this, reconcileOrder falls back to
+      // terminals-first when tabBarOrderByWorktree is unset, causing a new
+      // terminal to jump to index 0 instead of appending after editor tabs.
+      const state = useAppStore.getState()
+      const currentTerminals = state.tabsByWorktree[activeWorktreeId] ?? []
+      const currentEditors = state.openFiles.filter((f) => f.worktreeId === activeWorktreeId)
+      const currentBrowsers = state.browserTabsByWorktree[activeWorktreeId] ?? []
+      const stored = state.tabBarOrderByWorktree[activeWorktreeId]
+      const termIds = currentTerminals.map((t) => t.id)
+      const editorIds = currentEditors.map((f) => f.id)
+      const browserIds = currentBrowsers.map((tab) => tab.id)
+      const validIds = new Set([...termIds, ...editorIds, ...browserIds])
+      const base = (stored ?? []).filter((id) => validIds.has(id))
+      const inBase = new Set(base)
+      for (const id of [...termIds, ...editorIds, ...browserIds]) {
+        if (!inBase.has(id)) {
+          base.push(id)
+          inBase.add(id)
+        }
+      }
+      // The new tab is already in base via termIds; move it to the end
+      const order = base.filter((id) => id !== newTab.id)
+      order.push(newTab.id)
+      setTabBarOrder(activeWorktreeId, order)
+    },
+    [activeWorktreeId, createTab, setActiveTabType, setTabBarOrder]
+  )
 
   const handleNewBrowserTab = useCallback(() => {
     if (!activeWorktreeId) {
@@ -955,9 +966,11 @@ function Terminal(): React.JSX.Element | null {
             onClose={handleCloseTab}
             onCloseOthers={handleCloseOthers}
             onCloseToRight={handleCloseTabsToRight}
-            onNewTerminalTab={handleNewTab}
+            onNewTerminalTab={() => handleNewTab()}
+            onNewTerminalWithShell={handleNewTab}
             onNewBrowserTab={handleNewBrowserTab}
             onNewFileTab={handleNewFile}
+            wslAvailable={wslAvailable}
             onSetCustomTitle={setTabCustomTitle}
             onSetTabColor={setTabColor}
             expandedPaneByTabId={expandedPaneByTabId}

--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -143,6 +143,10 @@ function Settings(): React.JSX.Element {
   // the import trigger as a headerAction. The modal itself still lives inside
   // TerminalPane, driven by this shared state.
   const ghostty = useGhosttyImport(updateSettings, settings)
+  const [wslAvailable, setWslAvailable] = useState(false)
+  useEffect(() => {
+    void window.api.wsl.isAvailable().then(setWslAvailable)
+  }, [])
   const [terminalFontSuggestions, setTerminalFontSuggestions] = useState<string[]>(
     getFallbackTerminalFonts()
   )
@@ -622,6 +626,7 @@ function Settings(): React.JSX.Element {
                     scrollbackMode={scrollbackMode}
                     setScrollbackMode={setScrollbackMode}
                     ghostty={ghostty}
+                    wslAvailable={wslAvailable}
                   />
                 </SettingsSection>
 

--- a/src/renderer/src/components/settings/TerminalPane.tsx
+++ b/src/renderer/src/components/settings/TerminalPane.tsx
@@ -62,6 +62,8 @@ type TerminalPaneProps = {
    *  the section header can render the trigger button as a headerAction
    *  instead of taking its own row inside the settings list. */
   ghostty: UseGhosttyImportReturn
+  /** Whether WSL is installed on this Windows machine. */
+  wslAvailable?: boolean
 }
 
 export function TerminalPane({
@@ -71,7 +73,8 @@ export function TerminalPane({
   terminalFontSuggestions,
   scrollbackMode,
   setScrollbackMode,
-  ghostty
+  ghostty,
+  wslAvailable
 }: TerminalPaneProps): React.JSX.Element {
   const searchQuery = useAppStore((state) => state.settingsSearchQuery)
   const isWindows = isWindowsUserAgent()
@@ -122,12 +125,11 @@ export function TerminalPane({
         >
           <Label>Default Shell</Label>
           <div className="flex w-fit gap-1 rounded-md border border-border/50 p-1">
-            {(
-              [
-                { label: 'PowerShell', value: 'powershell.exe' },
-                { label: 'Command Prompt', value: 'cmd.exe' }
-              ] as const
-            ).map(({ label, value }) => (
+            {[
+              { label: 'PowerShell', value: 'powershell.exe' },
+              { label: 'Command Prompt', value: 'cmd.exe' },
+              ...(wslAvailable ? [{ label: 'WSL', value: 'wsl.exe' }] : [])
+            ].map(({ label, value }) => (
               <button
                 key={value}
                 onClick={() => updateSettings({ terminalWindowsShell: value })}

--- a/src/renderer/src/components/settings/terminal-search.ts
+++ b/src/renderer/src/components/settings/terminal-search.ts
@@ -226,7 +226,19 @@ export const TERMINAL_WINDOWS_SHELL_SEARCH_ENTRY: SettingsSearchEntry[] = [
   {
     title: 'Default Shell',
     description: 'Choose the default shell for new terminal panes on Windows.',
-    keywords: ['terminal', 'windows', 'shell', 'powershell', 'cmd', 'command prompt', 'default']
+    keywords: [
+      'terminal',
+      'windows',
+      'shell',
+      'powershell',
+      'cmd',
+      'command prompt',
+      'default',
+      'wsl',
+      'linux',
+      'bash',
+      'ubuntu'
+    ]
   }
 ]
 

--- a/src/renderer/src/components/tab-bar/TabBar.tsx
+++ b/src/renderer/src/components/tab-bar/TabBar.tsx
@@ -28,10 +28,14 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
 
 const isMac = navigator.userAgent.includes('Mac')
+const isWindows = navigator.userAgent.includes('Windows')
 const NEW_TERMINAL_SHORTCUT = isMac ? '⌘T' : 'Ctrl+T'
 const NEW_BROWSER_SHORTCUT = isMac ? '⌘⇧B' : 'Ctrl+Shift+B'
 const NEW_FILE_SHORTCUT = isMac ? '⌘⇧M' : 'Ctrl+Shift+M'
@@ -47,8 +51,13 @@ type TabBarProps = {
   onCloseOthers: (tabId: string) => void
   onCloseToRight: (tabId: string) => void
   onNewTerminalTab: () => void
+  /** On Windows, opens a new terminal with a specific shell instead of the default. */
+  onNewTerminalWithShell?: (shell: string) => void
   onNewBrowserTab: () => void
   onNewFileTab?: () => void
+  /** Whether WSL is installed on this Windows machine. When true, the "+"
+   *  dropdown shows a WSL option under the terminal submenu. */
+  wslAvailable?: boolean
   onSetCustomTitle: (tabId: string, title: string | null) => void
   onSetTabColor: (tabId: string, color: string | null) => void
   onTogglePaneExpand: (tabId: string) => void
@@ -108,6 +117,7 @@ function TabBarInner({
   onCloseOthers,
   onCloseToRight,
   onNewTerminalTab,
+  onNewTerminalWithShell,
   onNewBrowserTab,
   onNewFileTab,
   onSetCustomTitle,
@@ -127,7 +137,8 @@ function TabBarInner({
   onPinFile,
   tabBarOrder,
   onCreateSplitGroup,
-  hoveredTabInsertion
+  hoveredTabInsertion,
+  wslAvailable
 }: TabBarProps): React.JSX.Element {
   const gitStatusByWorktree = useAppStore((s) => s.gitStatusByWorktree)
   const resolvedGroupId = groupId ?? worktreeId
@@ -445,20 +456,55 @@ function TabBarInner({
             e.preventDefault()
           }}
         >
-          <DropdownMenuItem
-            onSelect={() => {
-              onNewTerminalTab()
-              const newActiveTabId = useAppStore.getState().activeTabId
-              if (newActiveTabId) {
-                focusTerminalTabSurface(newActiveTabId)
-              }
-            }}
-            className="gap-2 rounded-[7px] px-2 py-1.5 text-[12px] leading-5 font-medium"
-          >
-            <TerminalSquare className="size-4 text-muted-foreground" />
-            New Terminal
-            <DropdownMenuShortcut>{NEW_TERMINAL_SHORTCUT}</DropdownMenuShortcut>
-          </DropdownMenuItem>
+          {isWindows && onNewTerminalWithShell ? (
+            // Why: on Windows there are multiple shell choices (PowerShell, CMD,
+            // WSL). A submenu mirrors Windows Terminal and VS Code's UX where
+            // the "+" arrow expands to show all available profiles.
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger className="gap-2 rounded-[7px] px-2 py-1.5 text-[12px] leading-5 font-medium">
+                <TerminalSquare className="size-4 text-muted-foreground" />
+                New Terminal
+                <DropdownMenuShortcut>{NEW_TERMINAL_SHORTCUT}</DropdownMenuShortcut>
+              </DropdownMenuSubTrigger>
+              <DropdownMenuSubContent className="min-w-[10rem] rounded-[11px] border-border/80 p-1 shadow-[0_16px_36px_rgba(0,0,0,0.24)]">
+                {[
+                  { label: 'PowerShell', shell: 'powershell.exe' },
+                  { label: 'Command Prompt', shell: 'cmd.exe' },
+                  ...(wslAvailable ? [{ label: 'WSL', shell: 'wsl.exe' }] : [])
+                ].map(({ label, shell }) => (
+                  <DropdownMenuItem
+                    key={shell}
+                    onSelect={() => {
+                      onNewTerminalWithShell(shell)
+                      const newActiveTabId = useAppStore.getState().activeTabId
+                      if (newActiveTabId) {
+                        focusTerminalTabSurface(newActiveTabId)
+                      }
+                    }}
+                    className="gap-2 rounded-[7px] px-2 py-1.5 text-[12px] leading-5 font-medium"
+                  >
+                    <TerminalSquare className="size-4 text-muted-foreground" />
+                    {label}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
+          ) : (
+            <DropdownMenuItem
+              onSelect={() => {
+                onNewTerminalTab()
+                const newActiveTabId = useAppStore.getState().activeTabId
+                if (newActiveTabId) {
+                  focusTerminalTabSurface(newActiveTabId)
+                }
+              }}
+              className="gap-2 rounded-[7px] px-2 py-1.5 text-[12px] leading-5 font-medium"
+            >
+              <TerminalSquare className="size-4 text-muted-foreground" />
+              New Terminal
+              <DropdownMenuShortcut>{NEW_TERMINAL_SHORTCUT}</DropdownMenuShortcut>
+            </DropdownMenuItem>
+          )}
           <DropdownMenuItem
             onSelect={onNewBrowserTab}
             className="gap-2 rounded-[7px] px-2 py-1.5 text-[12px] leading-5 font-medium"

--- a/src/renderer/src/components/tab-group/TabGroupPanel.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useMemo } from 'react'
+import { lazy, Suspense, useEffect, useMemo, useState } from 'react'
 import { useDroppable } from '@dnd-kit/core'
 import { Columns2, Ellipsis, Rows2, X } from 'lucide-react'
 import { useAppStore } from '../../store'
@@ -49,6 +49,11 @@ export default function TabGroupPanel({
 }): React.JSX.Element {
   const rightSidebarOpen = useAppStore((state) => state.rightSidebarOpen)
   const sidebarOpen = useAppStore((state) => state.sidebarOpen)
+
+  const [wslAvailable, setWslAvailable] = useState(false)
+  useEffect(() => {
+    void window.api.wsl.isAvailable().then(setWslAvailable)
+  }, [])
 
   const model = useTabGroupWorkspaceModel({ groupId, worktreeId })
   const {
@@ -119,6 +124,8 @@ export default function TabGroupPanel({
         }
       }}
       onNewTerminalTab={commands.newTerminalTab}
+      onNewTerminalWithShell={commands.newTerminalWithShell}
+      wslAvailable={wslAvailable}
       onNewBrowserTab={commands.newBrowserTab}
       onNewFileTab={commands.newFileTab}
       onSetCustomTitle={commands.setTabCustomTitle}

--- a/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.ts
+++ b/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.ts
@@ -437,6 +437,11 @@ export function useTabGroupWorkspaceModel({
         setActiveTab(terminal.id)
         setActiveTabType('terminal')
       },
+      newTerminalWithShell: (shellOverride: string) => {
+        const terminal = createTab(worktreeId, groupId, shellOverride)
+        setActiveTab(terminal.id)
+        setActiveTabType('terminal')
+      },
       pinFile,
       setTabColor,
       setTabCustomTitle

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -264,6 +264,8 @@ export function connectPanePty(
   const worktree = allWorktrees.find((w) => w.id === deps.worktreeId)
   const repo = worktree ? state.repos?.find((r) => r.id === worktree.repoId) : null
   const connectionId = repo?.connectionId ?? null
+  const tab = (state.tabsByWorktree[deps.worktreeId] ?? []).find((t) => t.id === deps.tabId)
+  const shellOverride = tab?.shellOverride
 
   const transport = createIpcPtyTransport({
     cwd: deps.cwd,
@@ -271,6 +273,7 @@ export function connectPanePty(
     command: paneStartup?.command,
     connectionId,
     worktreeId: deps.worktreeId,
+    ...(shellOverride ? { shellOverride } : {}),
     onPtyExit: onExit,
     onTitleChange,
     onPtySpawn,

--- a/src/renderer/src/components/terminal-pane/pty-dispatcher.ts
+++ b/src/renderer/src/components/terminal-pane/pty-dispatcher.ts
@@ -211,6 +211,8 @@ export type IpcPtyTransportOptions = {
   connectionId?: string | null
   /** Orca worktree identity for scoped shell history. */
   worktreeId?: string
+  /** Why: mirrors PtySpawnOptions.shellOverride — see types.ts for rationale. */
+  shellOverride?: string
   onPtyExit?: (ptyId: string) => void
   onTitleChange?: (title: string, rawTitle: string) => void
   onPtySpawn?: (ptyId: string) => void

--- a/src/renderer/src/components/terminal-pane/pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.ts
@@ -149,6 +149,7 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
     command,
     connectionId,
     worktreeId,
+    shellOverride,
     onPtyExit,
     onTitleChange,
     onPtySpawn,
@@ -351,7 +352,8 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
           command,
           ...(connectionId ? { connectionId } : {}),
           ...(options.sessionId ? { sessionId: options.sessionId } : {}),
-          worktreeId
+          worktreeId,
+          ...(shellOverride ? { shellOverride } : {})
         })
         const spawnResult = result as PtyConnectResult & { isReattach?: boolean }
 

--- a/src/renderer/src/components/terminal/TerminalShell.tsx
+++ b/src/renderer/src/components/terminal/TerminalShell.tsx
@@ -29,8 +29,10 @@ type TerminalShellProps = {
   onCloseOthers: (tabId: string) => void
   onCloseTabsToRight: (tabId: string) => void
   onNewTerminalTab: () => void
+  onNewTerminalWithShell?: (shell: string) => void
   onNewBrowserTab: () => void
   onNewFileTab?: () => void
+  wslAvailable?: boolean
   onSetCustomTitle: (tabId: string, title: string | null) => void
   onSetTabColor: (tabId: string, color: string | null) => void
   onTogglePaneExpand: (tabId: string) => void
@@ -65,8 +67,10 @@ export function TerminalShell({
   onCloseOthers,
   onCloseTabsToRight,
   onNewTerminalTab,
+  onNewTerminalWithShell,
   onNewBrowserTab,
   onNewFileTab,
+  wslAvailable,
   onSetCustomTitle,
   onSetTabColor,
   onTogglePaneExpand,
@@ -103,8 +107,10 @@ export function TerminalShell({
               onCloseOthers={onCloseOthers}
               onCloseToRight={onCloseTabsToRight}
               onNewTerminalTab={onNewTerminalTab}
+              onNewTerminalWithShell={onNewTerminalWithShell}
               onNewBrowserTab={onNewBrowserTab}
               onNewFileTab={onNewFileTab}
+              wslAvailable={wslAvailable}
               onSetCustomTitle={onSetCustomTitle}
               onSetTabColor={onSetTabColor}
               expandedPaneByTabId={expandedPaneByTabId}

--- a/src/renderer/src/components/terminal/terminal-tab-actions.ts
+++ b/src/renderer/src/components/terminal/terminal-tab-actions.ts
@@ -2,12 +2,15 @@ import { useAppStore } from '@/store'
 import { TOGGLE_TERMINAL_PANE_EXPAND_EVENT } from '@/constants/terminal'
 import { reconcileTabOrder } from '../tab-bar/reconcile-order'
 
-export function createNewTerminalTab(activeWorktreeId: string | null): void {
+export function createNewTerminalTab(
+  activeWorktreeId: string | null,
+  shellOverride?: string
+): void {
   if (!activeWorktreeId) {
     return
   }
   const state = useAppStore.getState()
-  const newTab = state.createTab(activeWorktreeId)
+  const newTab = state.createTab(activeWorktreeId, undefined, shellOverride)
   state.setActiveTabType('terminal')
   // Why: persist the tab bar order with the new terminal at the end of the
   // current visual order. Without this, reconcileTabOrder falls back to

--- a/src/renderer/src/components/terminal/useTerminalTabs.ts
+++ b/src/renderer/src/components/terminal/useTerminalTabs.ts
@@ -156,6 +156,10 @@ export function useTerminalTabs() {
   ])
 
   const handleNewTab = useCallback(() => createNewTerminalTab(activeWorktreeId), [activeWorktreeId])
+  const handleNewTabWithShell = useCallback(
+    (shell: string) => createNewTerminalTab(activeWorktreeId, shell),
+    [activeWorktreeId]
+  )
 
   const handlePtyExit = useCallback(
     (tabId: string, ptyId: string) => {
@@ -196,6 +200,7 @@ export function useTerminalTabs() {
     setTabColor,
     closeAllFiles,
     handleNewTab,
+    handleNewTabWithShell,
     handleCloseTab: closeTerminalTab,
     handlePtyExit,
     handleCloseOthers,

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -121,7 +121,7 @@ export type TerminalSlice = {
    *  fresh shell prompt. */
   pendingColdRestoreByPtyId: Record<string, { scrollback: string; cwd: string }>
   consumePendingColdRestore: (ptyId: string) => { scrollback: string; cwd: string } | null
-  createTab: (worktreeId: string, targetGroupId?: string) => TerminalTab
+  createTab: (worktreeId: string, targetGroupId?: string, shellOverride?: string) => TerminalTab
   closeTab: (tabId: string) => void
   reorderTabs: (worktreeId: string, tabIds: string[]) => void
   setTabBarOrder: (worktreeId: string, order: string[]) => void
@@ -296,7 +296,7 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       return { deferredSshSessionIdsByTabId: next }
     }),
 
-  createTab: (worktreeId, targetGroupId) => {
+  createTab: (worktreeId, targetGroupId, shellOverride) => {
     const id = globalThis.crypto.randomUUID()
     let tab!: TerminalTab
     set((s) => {
@@ -319,7 +319,8 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         customTitle: null,
         color: null,
         sortOrder: existing.length,
-        createdAt: Date.now()
+        createdAt: Date.now(),
+        ...(shellOverride !== undefined ? { shellOverride } : {})
       }
       const validTargetGroupId =
         targetGroupId && s.groupsByWorktree[worktreeId]?.some((group) => group.id === targetGroupId)

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -144,6 +144,11 @@ export type TerminalTab = {
   createdAt: number
   /** Bumped on shutdown so TerminalPane remounts with a fresh PTY. */
   generation?: number
+  /** Why: records the shell this tab was explicitly opened with (e.g. 'wsl.exe'
+   *  from the "+" submenu) so the PTY can re-use the same shell on reconnect
+   *  without needing the user to interact with the tab again. Undefined means
+   *  "use the default shell setting". */
+  shellOverride?: string
 }
 
 export type BrowserHistoryEntry = {


### PR DESCRIPTION
## Summary

- **Settings > Terminal — Default Shell toggle now includes WSL** (shown only when WSL is installed). Selecting WSL sets `terminalWindowsShell: 'wsl.exe'` and persists like PowerShell/CMD.
- **"+" dropdown on Windows shows a per-profile submenu** (PowerShell / Command Prompt / WSL), mirroring the Windows Terminal / VS Code UX. On Mac/Linux the existing single-item button is unchanged.
- **`shellOverride` wired end-to-end**: `TerminalTab` → store → `pty-connection` → `pty-transport` → IPC → `local-pty-provider`. A tab opened via the submenu always reopens in the same shell without changing the user's default.
- **WSL/CMD/PowerShell profiles in `getProfiles()`** — `local-pty-provider.getProfiles()` now returns WSL when available, laying groundwork for future profile pickers.

### WSL launch behavior
- For repos on a WSL filesystem (`\wsl.localhost\...`): unchanged — still routes through `wsl.exe -d <distro>`.
- For Windows-path repos with WSL as the chosen shell: translates the cwd to `/mnt/<drive>/...` and opens the user's default distro login bash (`wsl.exe -- bash -c "cd '...' && exec bash -l"`).

### WSL detection
- `wsl:isAvailable` IPC handler calls `wsl.exe --status` once per process lifetime (cached in `wsl.ts`).
- Renderer fetches it with a single `useEffect` in `Terminal.tsx`, `TabGroupPanel.tsx`, and `Settings.tsx` — no polling.

## Test plan

- [ ] On Windows with WSL installed: Settings > Terminal shows "WSL" button; selecting it persists and new terminals open bash
- [ ] On Windows without WSL: WSL button absent from Settings and "+" submenu
- [ ] On Mac/Linux: "+" button shows single "New Terminal" item (no submenu)
- [ ] PowerShell and CMD still work as before
- [ ] Ctrl+T / Cmd+T opens default shell (no submenu for keyboard shortcut)
- [ ] Repo on WSL filesystem still opens correctly (existing behavior unchanged)
- [ ] Switching default shell in Settings, then opening tab, uses new default
- [ ] Opening WSL tab via submenu does not change default shell setting

Made with [Orca](https://github.com/stablyai/orca) 🐋

Fixes #408, #723
