### PR TITLE
fix(opencode): accept daemon-shaped sessionIds, hash to safe dir name

### DIFF
--- a/src/main/opencode/hook-service.test.ts
+++ b/src/main/opencode/hook-service.test.ts
@@ -34,9 +34,21 @@ describe('OpenCode id safety guard', () => {
     expect(isUsableId(daemonSessionId)).toBe(true)
   })
 
+  it('accepts ids at the inclusive upper length bound', () => {
+    expect(isUsableId('x'.repeat(1024))).toBe(true)
+  })
+
   it('rejects empty or oversized ids', () => {
     expect(isUsableId('')).toBe(false)
     expect(isUsableId('x'.repeat(1025))).toBe(false)
+  })
+
+  it('rejects non-string runtime values even though the type says string', () => {
+    // Why: the typeof guard is defense-in-depth for any-typed callers;
+    // without a test, a future refactor could delete the guard silently.
+    expect(isUsableId(undefined as unknown as string)).toBe(false)
+    expect(isUsableId(null as unknown as string)).toBe(false)
+    expect(isUsableId(42 as unknown as string)).toBe(false)
   })
 
   it('derives a filesystem-safe directory name independent of the raw id', () => {

--- a/src/main/opencode/hook-service.test.ts
+++ b/src/main/opencode/hook-service.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import { _internals } from './hook-service'
 
+const { isUsableId, toSafeDirName } = _internals
+
 describe('OpenCode hook plugin source', () => {
   it('filters child sessions via parentID lookup before forwarding events', () => {
     const source = _internals.getOpenCodePluginSource()
@@ -17,5 +19,38 @@ describe('OpenCode hook plugin source', () => {
 
     expect(source).toContain('export const OrcaOpenCodeStatusPlugin = async (_ctx) => {')
     expect(source).toContain('const client = _ctx?.client;')
+  })
+})
+
+describe('OpenCode id safety guard', () => {
+  it('accepts the daemon-path sessionId shape (worktreeId@@uuid with ::/...)', () => {
+    // Why: after the daemon-parity refactor (#1148) pty.ts mints sessionIds
+    // like `<worktreeId>@@<uuid>` where worktreeId contains "::" and a
+    // filesystem path. The previous strict regex rejected every real id and
+    // silently dropped OPENCODE_CONFIG_DIR. Lock in that such ids are now
+    // accepted so the plugin dir is actually written.
+    const daemonSessionId =
+      '50c010a2-bc8e-4eb1-8847-5812133ad6df::/Users/thebr/ghostx/workspaces/noqa/autoheal@@a1b2c3d4'
+    expect(isUsableId(daemonSessionId)).toBe(true)
+  })
+
+  it('rejects empty or oversized ids', () => {
+    expect(isUsableId('')).toBe(false)
+    expect(isUsableId('x'.repeat(1025))).toBe(false)
+  })
+
+  it('derives a filesystem-safe directory name independent of the raw id', () => {
+    const name = toSafeDirName('50c010::/Users/thebr/x/y@@uuid')
+    // Pure hex, bounded length — no slashes, colons, or caller content.
+    expect(name).toMatch(/^[0-9a-f]{32}$/)
+  })
+
+  it('is stable across calls for the same id', () => {
+    const id = 'some-session-id'
+    expect(toSafeDirName(id)).toBe(toSafeDirName(id))
+  })
+
+  it('produces different names for different ids', () => {
+    expect(toSafeDirName('a')).not.toBe(toSafeDirName('b'))
   })
 })

--- a/src/main/opencode/hook-service.ts
+++ b/src/main/opencode/hook-service.ts
@@ -19,6 +19,10 @@ const ORCA_OPENCODE_PLUGIN_FILE = 'orca-opencode-status.js'
 // filesystem-safe name. Hashing also eliminates path-traversal risk at the
 // source: the directory name is always 32 hex chars, never a prefix/suffix
 // of the caller's input.
+// Why: 1024 is a generous sanity cap — daemon-shaped ids embed a worktree
+// filesystem path plus "@@<uuid>", and this bound prevents pathological inputs
+// from burning CPU in the SHA-256 step. Since the id is hashed anyway, 1024
+// is decoupled from PATH_MAX.
 function isUsableId(id: string): boolean {
   return typeof id === 'string' && id.length > 0 && id.length <= 1024
 }
@@ -227,10 +231,9 @@ export class OpenCodeHookService {
       return
     }
     // Why: writePluginConfig creates a directory per PTY under userData.
-    // Without cleanup these accumulate across sessions. Remove the hashed
-    // directory when the PTY is torn down — same hash-derived path
-    // writePluginConfig created.
-    const configDir = join(app.getPath('userData'), 'opencode-hooks', toSafeDirName(ptyId))
+    // Without cleanup these accumulate across sessions. Using getConfigDir
+    // keeps cleanup aligned with the path writePluginConfig created.
+    const configDir = this.getConfigDir(ptyId)
     try {
       rmSync(configDir, { recursive: true, force: true })
     } catch {
@@ -256,11 +259,15 @@ export class OpenCodeHookService {
     return { OPENCODE_CONFIG_DIR: configDir }
   }
 
+  private getConfigDir(ptyId: string): string {
+    return join(app.getPath('userData'), 'opencode-hooks', toSafeDirName(ptyId))
+  }
+
   private writePluginConfig(ptyId: string): string | null {
     if (!isUsableId(ptyId)) {
       return null
     }
-    const configDir = join(app.getPath('userData'), 'opencode-hooks', toSafeDirName(ptyId))
+    const configDir = this.getConfigDir(ptyId)
     const pluginsDir = join(configDir, 'plugins')
     try {
       mkdirSync(pluginsDir, { recursive: true })

--- a/src/main/opencode/hook-service.ts
+++ b/src/main/opencode/hook-service.ts
@@ -1,21 +1,34 @@
 import { app } from 'electron'
 import { join } from 'path'
 import { mkdirSync, writeFileSync, rmSync } from 'fs'
+import { createHash } from 'crypto'
 
 const ORCA_OPENCODE_PLUGIN_FILE = 'orca-opencode-status.js'
 
-// Why: ptyId today is allocated by Orca (safe UUID-shape), but both entry
-// points construct a filesystem path with it and one of them calls
-// rmSync(..., recursive) on the result. Reject obviously unsafe IDs as a
-// belt-and-braces guard so a future caller (or a bug that forwards an
-// external ID) cannot escape userData/opencode-hooks/.
-function isSafePtyId(ptyId: string): boolean {
-  if (!ptyId || ptyId.length === 0 || ptyId.length > 128) {
-    return false
-  }
-  // Allow alphanumeric, dash, underscore, period (but not leading period or
-  // any slashes/backslashes).
-  return /^[A-Za-z0-9_-][A-Za-z0-9_.-]*$/.test(ptyId) && !ptyId.includes('..')
+// Why: the id passed in by pty.ts's daemon path is a sessionId shaped like
+// "<worktreeId>@@<uuid>" where worktreeId itself contains "::" and a
+// filesystem path (slashes, colons). Earlier the id was a simple numeric
+// counter, so rejecting anything with "/" or ":" was a safe guard against
+// path traversal. After the daemon-parity refactor (#1148) the sessionId
+// shape changed, and the old regex silently rejected every legitimate id,
+// leaving OPENCODE_CONFIG_DIR unset and the plugin never loading.
+//
+// Keep an input-bounds guard (non-empty, bounded length) for defense in
+// depth, and derive the on-disk directory name via hash so any caller's id —
+// including ones containing path separators — produces a short, stable,
+// filesystem-safe name. Hashing also eliminates path-traversal risk at the
+// source: the directory name is always 32 hex chars, never a prefix/suffix
+// of the caller's input.
+function isUsableId(id: string): boolean {
+  return typeof id === 'string' && id.length > 0 && id.length <= 1024
+}
+
+function toSafeDirName(id: string): string {
+  // Why: SHA-256 truncated to 32 hex chars (128 bits) is ample for a
+  // per-session directory name — collisions require ~2^64 concurrent sessions
+  // to become likely, far beyond any real workload. Hex keeps the name
+  // portable across all filesystems (no base64 padding, no `/`).
+  return createHash('sha256').update(id).digest('hex').slice(0, 32)
 }
 
 function getOpenCodePluginSource(): string {
@@ -210,13 +223,14 @@ function getOpenCodePluginSource(): string {
 // pipeline as Claude/Codex/Gemini.
 export class OpenCodeHookService {
   clearPty(ptyId: string): void {
-    if (!isSafePtyId(ptyId)) {
+    if (!isUsableId(ptyId)) {
       return
     }
-    // Why: writePluginConfig creates a directory per PTY under userData. Without
-    // cleanup these accumulate across sessions since ptyId is a monotonically
-    // increasing counter. Remove the directory when the PTY is torn down.
-    const configDir = join(app.getPath('userData'), 'opencode-hooks', ptyId)
+    // Why: writePluginConfig creates a directory per PTY under userData.
+    // Without cleanup these accumulate across sessions. Remove the hashed
+    // directory when the PTY is torn down — same hash-derived path
+    // writePluginConfig created.
+    const configDir = join(app.getPath('userData'), 'opencode-hooks', toSafeDirName(ptyId))
     try {
       rmSync(configDir, { recursive: true, force: true })
     } catch {
@@ -243,10 +257,10 @@ export class OpenCodeHookService {
   }
 
   private writePluginConfig(ptyId: string): string | null {
-    if (!isSafePtyId(ptyId)) {
+    if (!isUsableId(ptyId)) {
       return null
     }
-    const configDir = join(app.getPath('userData'), 'opencode-hooks', ptyId)
+    const configDir = join(app.getPath('userData'), 'opencode-hooks', toSafeDirName(ptyId))
     const pluginsDir = join(configDir, 'plugins')
     try {
       mkdirSync(pluginsDir, { recursive: true })
@@ -264,5 +278,6 @@ export class OpenCodeHookService {
 export const openCodeHookService = new OpenCodeHookService()
 export const _internals = {
   getOpenCodePluginSource,
-  isSafePtyId
+  isUsableId,
+  toSafeDirName
 }


### PR DESCRIPTION
## Summary

- After #1148 changed pty.ts's daemon path to mint sessionIds shaped like `<worktreeId>@@<uuid>` (where `worktreeId` embeds `::` and a filesystem path), the old `isSafePtyId` regex silently rejected every real id — leaving `OPENCODE_CONFIG_DIR` unset and the plugin never loading.
- Replace the strict regex with an input-bounds guard (`isUsableId`: non-empty, length ≤ 1024) and derive the on-disk directory name via SHA-256 (`toSafeDirName`), so any id — including ones with `/` or `::` — produces a short, stable, filesystem-safe name. Hashing also removes path-traversal risk at the source: the dir name is always 32 hex chars, never a prefix/suffix of the caller's input.
- Add unit tests covering both the helpers and the `OpenCodeHookService` public surface — `buildPtyEnv` returns a real `OPENCODE_CONFIG_DIR` for daemon-shaped ids, the plugin file is written, and `clearPty` removes the same directory. These are the regression guards the primitive-only tests were missing.

## Test plan

- [x] `pnpm test src/main/opencode/hook-service.test.ts` — 13/13 pass (primitives + `buildPtyEnv`/`clearPty` round-trip)
- [x] Launched dev Orca (`node config/scripts/run-electron-vite-dev.mjs --remote-debugging-port=9333`), attached via CDP, and inspected the Zustand store. Active ptyId was daemon-shaped: `50c010a2-...::/Users/thebr/ghostx/workspaces/noqa/autoheal-changing-run-ui@@5bb4d1eb`. Expected hash `da0d708c7599494d792b8acb0e5e617c` existed on disk at `~/Library/Application Support/orca-dev/opencode-hooks/da0d708c7599494d792b8acb0e5e617c/plugins/orca-opencode-status.js` with correct plugin source. Pre-fix this directory would never have been created.
- [x] Teardown path covered by the `clearPty removes the same directory buildPtyEnv created` unit test (end-to-end teardown via CDP skipped — the direct `closeTab` store action has a nuanced signature and the unit test is deterministic).