### PR TITLE
fix(pty): tolerate trailing slash in ZDOTDIR self-loop guard

### DIFF
--- a/src/main/daemon/shell-ready.test.ts
+++ b/src/main/daemon/shell-ready.test.ts
@@ -135,6 +135,33 @@ describePosix('daemon shell-ready launch config', () => {
     }
   })
 
+  it('falls back to HOME when ZDOTDIR is only slashes (e.g. "/")', async () => {
+    // Why: a bare `/` (or `////`) normalizes to empty and is never a user's
+    // real zsh config root; sourcing `/.zshenv` would silently no-op. Falling
+    // back to HOME matches what the wrapper already assumes when ZDOTDIR is
+    // unset.
+    const previousZdotdir = process.env.ZDOTDIR
+    const previousHome = process.env.HOME
+    process.env.ZDOTDIR = '/'
+    process.env.HOME = '/Users/alice'
+    try {
+      const { getShellReadyLaunchConfig } = await importFreshShellReady()
+      const config = getShellReadyLaunchConfig('/bin/zsh')
+      expect(config.env.ORCA_ORIG_ZDOTDIR).toBe('/Users/alice')
+    } finally {
+      if (previousZdotdir === undefined) {
+        delete process.env.ZDOTDIR
+      } else {
+        process.env.ZDOTDIR = previousZdotdir
+      }
+      if (previousHome === undefined) {
+        delete process.env.HOME
+      } else {
+        process.env.HOME = previousHome
+      }
+    }
+  })
+
   it('preserves ZDOTDIR that contains /shell-ready/zsh as a substring but does not end with it', async () => {
     // Why: the guard must match the suffix, not a substring — a user directory
     // like `/Users/alice/shell-ready/zsh-custom` should round-trip unchanged.

--- a/src/main/daemon/shell-ready.test.ts
+++ b/src/main/daemon/shell-ready.test.ts
@@ -62,4 +62,95 @@ describePosix('daemon shell-ready launch config', () => {
     expect(config.env.ZDOTDIR).toBe(join(userDataPath, 'shell-ready', 'zsh'))
     expect(existsSync(join(userDataPath, 'shell-ready', 'zsh', '.zshenv'))).toBe(true)
   })
+
+  it('falls back to HOME for ORCA_ORIG_ZDOTDIR when inherited ZDOTDIR points at a wrapper dir', async () => {
+    // Why: guards against the zsh recursion loop that happens when the daemon
+    // was forked from a shell which was itself an Orca PTY. Such a shell has
+    // ZDOTDIR=<some>/shell-ready/zsh; propagating that unchanged would make
+    // the wrapper `source "$ORCA_ORIG_ZDOTDIR/.zshenv"` source itself.
+    const previousZdotdir = process.env.ZDOTDIR
+    const previousHome = process.env.HOME
+    process.env.ZDOTDIR = '/some/other/orca/shell-ready/zsh'
+    process.env.HOME = '/Users/alice'
+    try {
+      const { getShellReadyLaunchConfig } = await importFreshShellReady()
+      const config = getShellReadyLaunchConfig('/bin/zsh')
+      expect(config.env.ORCA_ORIG_ZDOTDIR).toBe('/Users/alice')
+    } finally {
+      if (previousZdotdir === undefined) {
+        delete process.env.ZDOTDIR
+      } else {
+        process.env.ZDOTDIR = previousZdotdir
+      }
+      if (previousHome === undefined) {
+        delete process.env.HOME
+      } else {
+        process.env.HOME = previousHome
+      }
+    }
+  })
+
+  it('preserves a real inherited ZDOTDIR as ORCA_ORIG_ZDOTDIR', async () => {
+    // Why: users who run a custom zsh dotfiles directory legitimately set
+    // ZDOTDIR before launching Orca. We only want to reject the self-loop
+    // case — any real user ZDOTDIR must round-trip so their configs load.
+    const previousZdotdir = process.env.ZDOTDIR
+    process.env.ZDOTDIR = '/Users/alice/.config/zsh'
+    try {
+      const { getShellReadyLaunchConfig } = await importFreshShellReady()
+      const config = getShellReadyLaunchConfig('/bin/zsh')
+      expect(config.env.ORCA_ORIG_ZDOTDIR).toBe('/Users/alice/.config/zsh')
+    } finally {
+      if (previousZdotdir === undefined) {
+        delete process.env.ZDOTDIR
+      } else {
+        process.env.ZDOTDIR = previousZdotdir
+      }
+    }
+  })
+
+  it('rejects inherited ZDOTDIR ending in /shell-ready/zsh even with a trailing slash', async () => {
+    // Why: `endsWith('/shell-ready/zsh')` without normalization is bypassed by
+    // a trailing slash, which some shell startup scripts add. Pinning this case
+    // guards against a regression that would reintroduce the recursion loop.
+    const previousZdotdir = process.env.ZDOTDIR
+    const previousHome = process.env.HOME
+    process.env.ZDOTDIR = '/some/other/orca/shell-ready/zsh/'
+    process.env.HOME = '/Users/alice'
+    try {
+      const { getShellReadyLaunchConfig } = await importFreshShellReady()
+      const config = getShellReadyLaunchConfig('/bin/zsh')
+      expect(config.env.ORCA_ORIG_ZDOTDIR).toBe('/Users/alice')
+    } finally {
+      if (previousZdotdir === undefined) {
+        delete process.env.ZDOTDIR
+      } else {
+        process.env.ZDOTDIR = previousZdotdir
+      }
+      if (previousHome === undefined) {
+        delete process.env.HOME
+      } else {
+        process.env.HOME = previousHome
+      }
+    }
+  })
+
+  it('preserves ZDOTDIR that contains /shell-ready/zsh as a substring but does not end with it', async () => {
+    // Why: the guard must match the suffix, not a substring — a user directory
+    // like `/Users/alice/shell-ready/zsh-custom` should round-trip unchanged.
+    // Pinning this case prevents an over-eager `includes` swap in the future.
+    const previousZdotdir = process.env.ZDOTDIR
+    process.env.ZDOTDIR = '/Users/alice/shell-ready/zsh-custom'
+    try {
+      const { getShellReadyLaunchConfig } = await importFreshShellReady()
+      const config = getShellReadyLaunchConfig('/bin/zsh')
+      expect(config.env.ORCA_ORIG_ZDOTDIR).toBe('/Users/alice/shell-ready/zsh-custom')
+    } finally {
+      if (previousZdotdir === undefined) {
+        delete process.env.ZDOTDIR
+      } else {
+        process.env.ZDOTDIR = previousZdotdir
+      }
+    }
+  })
 })

--- a/src/main/daemon/shell-ready.ts
+++ b/src/main/daemon/shell-ready.ts
@@ -18,6 +18,30 @@ function getShellReadyWrapperRoot(): string {
   return join(userDataPath || tmpdir(), userDataPath ? 'shell-ready' : 'orca-shell-ready')
 }
 
+// Why: if our own process inherited ZDOTDIR from a parent shell that was
+// itself an Orca PTY (e.g. the user launched Orca from a terminal inside a
+// running Orca), that ZDOTDIR points at an Orca shell-ready wrapper dir.
+// Propagating it as the new PTY's ORCA_ORIG_ZDOTDIR makes the wrapper's
+// `source "$ORCA_ORIG_ZDOTDIR/.zshenv"` line source itself recursively —
+// zsh gives "job table full or recursion limit exceeded" and the shell
+// never reaches a usable prompt.
+//
+// Any path component ending in `/shell-ready/zsh` is an Orca wrapper dir
+// (regardless of whether it came from this daemon's userData, a packaged
+// Orca, or a different dev build). Treat it as if ZDOTDIR were unset so the
+// caller falls back to HOME for the user's real config root.
+function resolveOriginalZdotdir(): string {
+  const inherited = process.env.ZDOTDIR
+  // Why: tolerate trailing slashes — some shell startup scripts export
+  // `ZDOTDIR="$dir/"`, and without normalization the suffix check would
+  // miss the self-loop path and restore the recursion bug.
+  const normalized = inherited ? inherited.replace(/\/+$/, '') : ''
+  if (normalized && !normalized.endsWith('/shell-ready/zsh')) {
+    return inherited as string
+  }
+  return process.env.HOME || ''
+}
+
 function getRequiredShellReadyWrapperPaths(root = getShellReadyWrapperRoot()): string[] {
   return [
     join(root, 'zsh', '.zshenv'),
@@ -170,7 +194,7 @@ function getWrappedShellLaunchConfig(
     return {
       args: ['-l'],
       env: {
-        ORCA_ORIG_ZDOTDIR: process.env.ZDOTDIR || process.env.HOME || '',
+        ORCA_ORIG_ZDOTDIR: resolveOriginalZdotdir(),
         ZDOTDIR: join(root, 'zsh'),
         ORCA_SHELL_READY_MARKER: options.emitReadyMarker ? '1' : '0'
       },

--- a/src/main/daemon/shell-ready.ts
+++ b/src/main/daemon/shell-ready.ts
@@ -32,14 +32,19 @@ function getShellReadyWrapperRoot(): string {
 // caller falls back to HOME for the user's real config root.
 function resolveOriginalZdotdir(): string {
   const inherited = process.env.ZDOTDIR
+  if (!inherited) {
+    return process.env.HOME || ''
+  }
   // Why: tolerate trailing slashes — some shell startup scripts export
   // `ZDOTDIR="$dir/"`, and without normalization the suffix check would
-  // miss the self-loop path and restore the recursion bug.
-  const normalized = inherited ? inherited.replace(/\/+$/, '') : ''
-  if (normalized && !normalized.endsWith('/shell-ready/zsh')) {
-    return inherited as string
+  // miss the self-loop path and restore the recursion bug. Also collapses
+  // a pathological `ZDOTDIR=/` to empty so we fall back to HOME rather than
+  // sourcing `/.zshenv` (which is never the user's real config).
+  const normalized = inherited.replace(/\/+$/, '')
+  if (!normalized || normalized.endsWith('/shell-ready/zsh')) {
+    return process.env.HOME || ''
   }
-  return process.env.HOME || ''
+  return inherited
 }
 
 function getRequiredShellReadyWrapperPaths(root = getShellReadyWrapperRoot()): string[] {

--- a/src/main/providers/local-pty-shell-ready.test.ts
+++ b/src/main/providers/local-pty-shell-ready.test.ts
@@ -1,6 +1,30 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { mkdtempSync, rmSync } from 'fs'
 import type * as pty from 'node-pty'
+import type * as LocalPtyShellReadyModule from './local-pty-shell-ready'
 import { writeStartupCommandWhenShellReady } from './local-pty-shell-ready'
+
+const { getUserDataPathMock } = vi.hoisted(() => ({
+  getUserDataPathMock: vi.fn<() => string>()
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: (name: string) => {
+      if (name === 'userData') {
+        return getUserDataPathMock()
+      }
+      throw new Error(`unexpected app.getPath(${name})`)
+    }
+  }
+}))
+
+async function importFreshLocalPtyShellReady(): Promise<typeof LocalPtyShellReadyModule> {
+  vi.resetModules()
+  return import('./local-pty-shell-ready')
+}
 
 type DataCb = (data: string) => void
 type ExitCb = (info: { exitCode: number }) => void
@@ -97,5 +121,125 @@ describe('writeStartupCommandWhenShellReady', () => {
     await Promise.resolve()
 
     expect(proc._writes).toEqual(['claude\n'])
+  })
+})
+
+const describePosix = process.platform === 'win32' ? describe.skip : describe
+
+describePosix('local PTY shell-ready launch config', () => {
+  let userDataPath: string
+
+  beforeEach(() => {
+    userDataPath = mkdtempSync(join(tmpdir(), 'local-pty-shell-ready-test-'))
+    getUserDataPathMock.mockReturnValue(userDataPath)
+  })
+
+  afterEach(() => {
+    rmSync(userDataPath, { recursive: true, force: true })
+    vi.restoreAllMocks()
+  })
+
+  it('falls back to HOME for ORCA_ORIG_ZDOTDIR when inherited ZDOTDIR points at a wrapper dir', async () => {
+    // Why: mirrors the daemon path — guards the same zsh recursion loop for
+    // PTYs spawned by the renderer/local provider when Orca is launched from
+    // inside an Orca terminal (e.g. `pn dev`).
+    const previousZdotdir = process.env.ZDOTDIR
+    const previousHome = process.env.HOME
+    process.env.ZDOTDIR = '/some/other/orca/shell-ready/zsh'
+    process.env.HOME = '/Users/alice'
+    try {
+      const { getShellReadyLaunchConfig } = await importFreshLocalPtyShellReady()
+      const config = getShellReadyLaunchConfig('/bin/zsh')
+      expect(config.env.ORCA_ORIG_ZDOTDIR).toBe('/Users/alice')
+    } finally {
+      if (previousZdotdir === undefined) {
+        delete process.env.ZDOTDIR
+      } else {
+        process.env.ZDOTDIR = previousZdotdir
+      }
+      if (previousHome === undefined) {
+        delete process.env.HOME
+      } else {
+        process.env.HOME = previousHome
+      }
+    }
+  })
+
+  it('preserves a real inherited ZDOTDIR as ORCA_ORIG_ZDOTDIR', async () => {
+    const previousZdotdir = process.env.ZDOTDIR
+    process.env.ZDOTDIR = '/Users/alice/.config/zsh'
+    try {
+      const { getShellReadyLaunchConfig } = await importFreshLocalPtyShellReady()
+      const config = getShellReadyLaunchConfig('/bin/zsh')
+      expect(config.env.ORCA_ORIG_ZDOTDIR).toBe('/Users/alice/.config/zsh')
+    } finally {
+      if (previousZdotdir === undefined) {
+        delete process.env.ZDOTDIR
+      } else {
+        process.env.ZDOTDIR = previousZdotdir
+      }
+    }
+  })
+
+  it('rejects inherited ZDOTDIR ending in /shell-ready/zsh even with a trailing slash', async () => {
+    const previousZdotdir = process.env.ZDOTDIR
+    const previousHome = process.env.HOME
+    process.env.ZDOTDIR = '/some/other/orca/shell-ready/zsh/'
+    process.env.HOME = '/Users/alice'
+    try {
+      const { getShellReadyLaunchConfig } = await importFreshLocalPtyShellReady()
+      const config = getShellReadyLaunchConfig('/bin/zsh')
+      expect(config.env.ORCA_ORIG_ZDOTDIR).toBe('/Users/alice')
+    } finally {
+      if (previousZdotdir === undefined) {
+        delete process.env.ZDOTDIR
+      } else {
+        process.env.ZDOTDIR = previousZdotdir
+      }
+      if (previousHome === undefined) {
+        delete process.env.HOME
+      } else {
+        process.env.HOME = previousHome
+      }
+    }
+  })
+
+  it('falls back to HOME when ZDOTDIR is only slashes (e.g. "/")', async () => {
+    const previousZdotdir = process.env.ZDOTDIR
+    const previousHome = process.env.HOME
+    process.env.ZDOTDIR = '/'
+    process.env.HOME = '/Users/alice'
+    try {
+      const { getShellReadyLaunchConfig } = await importFreshLocalPtyShellReady()
+      const config = getShellReadyLaunchConfig('/bin/zsh')
+      expect(config.env.ORCA_ORIG_ZDOTDIR).toBe('/Users/alice')
+    } finally {
+      if (previousZdotdir === undefined) {
+        delete process.env.ZDOTDIR
+      } else {
+        process.env.ZDOTDIR = previousZdotdir
+      }
+      if (previousHome === undefined) {
+        delete process.env.HOME
+      } else {
+        process.env.HOME = previousHome
+      }
+    }
+  })
+
+  it('preserves ZDOTDIR that contains /shell-ready/zsh as a substring but does not end with it', async () => {
+    const previousZdotdir = process.env.ZDOTDIR
+    process.env.ZDOTDIR = '/Users/alice/shell-ready/zsh-custom'
+    try {
+      const { getShellReadyLaunchConfig } = await importFreshLocalPtyShellReady()
+      const config = getShellReadyLaunchConfig('/bin/zsh')
+      expect(config.env.ORCA_ORIG_ZDOTDIR).toBe('/Users/alice/shell-ready/zsh-custom')
+    } finally {
+      if (previousZdotdir === undefined) {
+        delete process.env.ZDOTDIR
+      } else {
+        process.env.ZDOTDIR = previousZdotdir
+      }
+    }
   })
 })

--- a/src/main/providers/local-pty-shell-ready.ts
+++ b/src/main/providers/local-pty-shell-ready.ts
@@ -88,14 +88,19 @@ function getShellReadyWrapperRoot(): string {
 // falls back to HOME for the user's real config root.
 function resolveOriginalZdotdir(): string {
   const inherited = process.env.ZDOTDIR
+  if (!inherited) {
+    return process.env.HOME || ''
+  }
   // Why: tolerate trailing slashes — some shell startup scripts export
   // `ZDOTDIR="$dir/"`, and without normalization the suffix check would
-  // miss the self-loop path and restore the recursion bug.
-  const normalized = inherited ? inherited.replace(/\/+$/, '') : ''
-  if (normalized && !normalized.endsWith('/shell-ready/zsh')) {
-    return inherited as string
+  // miss the self-loop path and restore the recursion bug. Also collapses
+  // a pathological `ZDOTDIR=/` to empty so we fall back to HOME rather than
+  // sourcing `/.zshenv` (which is never the user's real config).
+  const normalized = inherited.replace(/\/+$/, '')
+  if (!normalized || normalized.endsWith('/shell-ready/zsh')) {
+    return process.env.HOME || ''
   }
-  return process.env.HOME || ''
+  return inherited
 }
 
 export function getBashShellReadyRcfileContent(): string {

--- a/src/main/providers/local-pty-shell-ready.ts
+++ b/src/main/providers/local-pty-shell-ready.ts
@@ -74,6 +74,30 @@ function getShellReadyWrapperRoot(): string {
   return `${app.getPath('userData')}/shell-ready`
 }
 
+// Why: if our own process inherited ZDOTDIR from a parent shell that was
+// itself an Orca PTY (e.g. the user launched `pn dev` from a terminal inside
+// a running Orca), that ZDOTDIR points at an Orca shell-ready wrapper dir.
+// Propagating it as the new PTY's ORCA_ORIG_ZDOTDIR makes the wrapper's
+// `source "$ORCA_ORIG_ZDOTDIR/.zshenv"` line source itself recursively —
+// zsh gives "job table full or recursion limit exceeded" and the shell
+// never reaches a usable prompt.
+//
+// Any path component ending in `/shell-ready/zsh` is an Orca wrapper dir
+// (regardless of whether it came from this app's userData, a packaged Orca,
+// or a different dev build). Treat it as if ZDOTDIR were unset so the caller
+// falls back to HOME for the user's real config root.
+function resolveOriginalZdotdir(): string {
+  const inherited = process.env.ZDOTDIR
+  // Why: tolerate trailing slashes — some shell startup scripts export
+  // `ZDOTDIR="$dir/"`, and without normalization the suffix check would
+  // miss the self-loop path and restore the recursion bug.
+  const normalized = inherited ? inherited.replace(/\/+$/, '') : ''
+  if (normalized && !normalized.endsWith('/shell-ready/zsh')) {
+    return inherited as string
+  }
+  return process.env.HOME || ''
+}
+
 export function getBashShellReadyRcfileContent(): string {
   return `# Orca bash shell-ready wrapper
 [[ -f /etc/profile ]] && source /etc/profile
@@ -207,7 +231,7 @@ function getWrappedShellLaunchConfig(
     return {
       args: ['-l'],
       env: {
-        ORCA_ORIG_ZDOTDIR: process.env.ZDOTDIR || process.env.HOME || '',
+        ORCA_ORIG_ZDOTDIR: resolveOriginalZdotdir(),
         ZDOTDIR: `${getShellReadyWrapperRoot()}/zsh`,
         ORCA_SHELL_READY_MARKER: options.emitReadyMarker ? '1' : '0'
       },


### PR DESCRIPTION
## Problem

When Orca or its daemon is launched from inside an existing Orca PTY, the child process inherits `ZDOTDIR=<userData>/shell-ready/zsh` — a wrapper directory owned by the parent Orca. Propagating that unchanged as `ORCA_ORIG_ZDOTDIR` in the new PTY makes the wrapper's `source "$ORCA_ORIG_ZDOTDIR/.zshenv"` source itself. zsh errors out with "job table full or recursion limit exceeded" and the prompt never renders. This bit anyone running `pn dev` (or otherwise launching Orca) from a terminal inside a running Orca.

A first fix detected the wrapper via `endsWith('/shell-ready/zsh')`, but the check was bypassed by a trailing slash (`ZDOTDIR="$dir/"`, which some shell startup scripts do), reintroducing the loop.

## Solution

`resolveOriginalZdotdir()` (applied symmetrically to the daemon and local-pty shell-launch paths):

- Normalizes trailing slashes before the suffix check, so `/shell-ready/zsh` and `/shell-ready/zsh/` both fall back to `HOME`.
- Preserves any other inherited `ZDOTDIR` (e.g. a user's custom dotfiles dir) unchanged.
- Collapses a pathological all-slash `ZDOTDIR` (like `/`) to `HOME` rather than leaving `source "/.zshenv"` as a silent no-op.

## Test plan

- Unit coverage on both paths (daemon `shell-ready.test.ts` and `local-pty-shell-ready.test.ts`) pins the contract: wrapper-suffix rejection, real-user `ZDOTDIR` round-trip, trailing-slash tolerance, substring-vs-suffix, and the `/` edge case. **16/16 tests pass.**
- Verified live in the Electron dev build: after killing a stale daemon spawned from another worktree (which was shadowing the launch code being tested), a fresh terminal pane opened in the `fix-zdotdir-recursion` build renders a clean prompt with `ORCA_ORIG_ZDOTDIR=$HOME` — the nested zsh no longer self-sources and the "recursion limit exceeded" errors are gone.