### PR TITLE
fix(search): keep include/exclude visible and prevent buried matches

### DIFF
--- a/src/renderer/src/components/right-sidebar/Search.tsx
+++ b/src/renderer/src/components/right-sidebar/Search.tsx
@@ -24,7 +24,6 @@ export default function Search(): React.JSX.Element {
     activeWorktreeId ? s.fileSearchStateByWorktree[activeWorktreeId] : null
   )
   const fileSearchQuery = searchState?.query ?? ''
-  const fileSearchQueryDetailsExpanded = searchState?.queryDetailsExpanded ?? false
   const fileSearchCaseSensitive = searchState?.caseSensitive ?? false
   const fileSearchWholeWord = searchState?.wholeWord ?? false
   const fileSearchUseRegex = searchState?.useRegex ?? false
@@ -262,29 +261,6 @@ export default function Search(): React.JSX.Element {
     [activeWorktreeId, openFile, setPendingEditorReveal]
   )
 
-  const hasFilePatternFilters =
-    fileSearchIncludePattern.trim().length > 0 || fileSearchExcludePattern.trim().length > 0
-  const searchDetailsVisible = fileSearchQueryDetailsExpanded || hasFilePatternFilters
-
-  const handleToggleSearchDetails = useCallback(() => {
-    const nextExpanded = !searchDetailsVisible
-    updateActiveSearchState({ queryDetailsExpanded: nextExpanded })
-
-    // Why: VS Code shifts focus into the newly revealed include field so the
-    // details toggle acts as an entry point for scope filters instead of only
-    // changing layout. Collapsing returns focus to the main query input.
-    window.setTimeout(() => {
-      if (nextExpanded) {
-        includeInputRef.current?.focus()
-        includeInputRef.current?.select()
-        return
-      }
-
-      inputRef.current?.focus()
-      inputRef.current?.select()
-    }, 0)
-  }, [searchDetailsVisible, updateActiveSearchState])
-
   if (!activeWorktreeId) {
     return (
       <div className="flex items-center justify-center h-full text-muted-foreground text-xs">
@@ -301,7 +277,6 @@ export default function Search(): React.JSX.Element {
         excludeInputRef={excludeInputRef}
         query={fileSearchQuery}
         loading={fileSearchLoading}
-        detailsVisible={searchDetailsVisible}
         caseSensitive={fileSearchCaseSensitive}
         wholeWord={fileSearchWholeWord}
         useRegex={fileSearchUseRegex}
@@ -310,7 +285,6 @@ export default function Search(): React.JSX.Element {
         onQueryChange={handleQueryChange}
         onKeyDown={handleKeyDown}
         onClearSearch={handleClearSearch}
-        onToggleSearchDetails={handleToggleSearchDetails}
         onToggleCaseSensitive={() => {
           updateActiveSearchState({ caseSensitive: !fileSearchCaseSensitive })
           rerunSearch()
@@ -324,19 +298,11 @@ export default function Search(): React.JSX.Element {
           rerunSearch()
         }}
         onIncludeChange={(value) => {
-          updateActiveSearchState({
-            includePattern: value,
-            queryDetailsExpanded:
-              value.trim().length > 0 || fileSearchExcludePattern.trim().length > 0
-          })
+          updateActiveSearchState({ includePattern: value })
           rerunSearch()
         }}
         onExcludeChange={(value) => {
-          updateActiveSearchState({
-            excludePattern: value,
-            queryDetailsExpanded:
-              fileSearchIncludePattern.trim().length > 0 || value.trim().length > 0
-          })
+          updateActiveSearchState({ excludePattern: value })
           rerunSearch()
         }}
       />

--- a/src/renderer/src/components/right-sidebar/SearchHeader.tsx
+++ b/src/renderer/src/components/right-sidebar/SearchHeader.tsx
@@ -1,13 +1,5 @@
 import React from 'react'
-import {
-  Search as SearchIcon,
-  CaseSensitive,
-  WholeWord,
-  Regex,
-  X,
-  Loader2,
-  Ellipsis
-} from 'lucide-react'
+import { Search as SearchIcon, CaseSensitive, WholeWord, Regex, X, Loader2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { SearchFilters } from './SearchFilters'
 import { ToggleButton } from './SearchResultItems'
@@ -18,7 +10,6 @@ type SearchHeaderProps = {
   excludeInputRef: React.RefObject<HTMLInputElement | null>
   query: string
   loading: boolean
-  detailsVisible: boolean
   caseSensitive: boolean
   wholeWord: boolean
   useRegex: boolean
@@ -27,7 +18,6 @@ type SearchHeaderProps = {
   onQueryChange: (e: React.ChangeEvent<HTMLInputElement>) => void
   onKeyDown: (e: React.KeyboardEvent) => void
   onClearSearch: () => void
-  onToggleSearchDetails: () => void
   onToggleCaseSensitive: () => void
   onToggleWholeWord: () => void
   onToggleRegex: () => void
@@ -41,7 +31,6 @@ export function SearchHeader({
   excludeInputRef,
   query,
   loading,
-  detailsVisible,
   caseSensitive,
   wholeWord,
   useRegex,
@@ -50,7 +39,6 @@ export function SearchHeader({
   onQueryChange,
   onKeyDown,
   onClearSearch,
-  onToggleSearchDetails,
   onToggleCaseSensitive,
   onToggleWholeWord,
   onToggleRegex,
@@ -85,14 +73,6 @@ export function SearchHeader({
             <X size={12} />
           </Button>
         )}
-        <ToggleButton
-          active={detailsVisible}
-          onClick={onToggleSearchDetails}
-          title="Toggle Search Details"
-          ariaExpanded={detailsVisible}
-        >
-          <Ellipsis size={14} />
-        </ToggleButton>
         <ToggleButton active={caseSensitive} onClick={onToggleCaseSensitive} title="Match Case">
           <CaseSensitive size={14} />
         </ToggleButton>
@@ -104,19 +84,17 @@ export function SearchHeader({
         </ToggleButton>
       </div>
 
-      {detailsVisible && (
-        // Why: VS Code keeps include/exclude scope controls tucked behind a
-        // dedicated details toggle so the default search UI stays compact
-        // until the user asks for extra filtering options.
-        <SearchFilters
-          includePattern={includePattern}
-          excludePattern={excludePattern}
-          includeInputRef={includeInputRef}
-          excludeInputRef={excludeInputRef}
-          onIncludeChange={onIncludeChange}
-          onExcludeChange={onExcludeChange}
-        />
-      )}
+      {/* Why: the Search tab is a secondary destination — users switch to it
+         when they want powerful, scoped search, so include/exclude fields
+         stay visible instead of hidden behind a toggle. */}
+      <SearchFilters
+        includePattern={includePattern}
+        excludePattern={excludePattern}
+        includeInputRef={includeInputRef}
+        excludeInputRef={excludeInputRef}
+        onIncludeChange={onIncludeChange}
+        onExcludeChange={onExcludeChange}
+      />
     </div>
   )
 }

--- a/src/renderer/src/components/right-sidebar/SearchResultItems.tsx
+++ b/src/renderer/src/components/right-sidebar/SearchResultItems.tsx
@@ -134,8 +134,18 @@ export function MatchResultRow({
     const len = match.matchLength
 
     if (col >= 0 && col + len <= content.length) {
+      // Why: left-truncate the pre-match text so the highlight stays visible at
+      // narrow sidebar widths. Without this, a long `before` pushes the match
+      // off the right edge even with overflow ellipsis. Mirrors VS Code's
+      // search view (see searchTreeModel/match.ts#preview → lcut).
+      const BEFORE_MAX = 26
+      const rawBefore = content.slice(0, col).trimStart()
+      const before =
+        rawBefore.length > BEFORE_MAX
+          ? `…${rawBefore.slice(rawBefore.length - BEFORE_MAX)}`
+          : rawBefore
       return {
-        before: content.slice(0, col),
+        before,
         match: content.slice(col, col + len),
         after: content.slice(col + len)
       }
@@ -165,12 +175,14 @@ export function MatchResultRow({
           <span className="text-[10px] text-muted-foreground flex-shrink-0 tabular-nums mt-px">
             {match.line}
           </span>
-          <span className="text-xs truncate">
-            <span className="text-muted-foreground">{parts.before.trimStart()}</span>
+          <span className="text-xs flex min-w-0 items-baseline whitespace-pre">
+            <span className="text-muted-foreground flex-shrink-0">{parts.before}</span>
             {parts.match && (
-              <span className="bg-amber-500/30 text-foreground rounded-sm">{parts.match}</span>
+              <span className="bg-amber-500/30 text-foreground rounded-sm flex-shrink-0">
+                {parts.match}
+              </span>
             )}
-            <span className="text-muted-foreground">{parts.after}</span>
+            <span className="text-muted-foreground min-w-0 truncate">{parts.after}</span>
           </span>
         </Button>
       </ContextMenuTrigger>

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -267,7 +267,6 @@ export type EditorSlice = {
     string,
     {
       query: string
-      queryDetailsExpanded: boolean
       caseSensitive: boolean
       wholeWord: boolean
       useRegex: boolean
@@ -1727,7 +1726,6 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
     set((s) => {
       const current = s.fileSearchStateByWorktree[worktreeId] || {
         query: '',
-        queryDetailsExpanded: false,
         caseSensitive: false,
         wholeWord: false,
         useRegex: false,

--- a/src/renderer/src/store/slices/store-cascades.test.ts
+++ b/src/renderer/src/store/slices/store-cascades.test.ts
@@ -97,7 +97,6 @@ describe('removeWorktree cascade', () => {
       fileSearchStateByWorktree: {
         [worktreeId]: {
           query: 'needle',
-          queryDetailsExpanded: true,
           caseSensitive: true,
           wholeWord: false,
           useRegex: false,
@@ -223,7 +222,6 @@ describe('removeWorktree cascade', () => {
       fileSearchStateByWorktree: {
         [wt1]: {
           query: 'old',
-          queryDetailsExpanded: false,
           caseSensitive: false,
           wholeWord: false,
           useRegex: false,
@@ -235,7 +233,6 @@ describe('removeWorktree cascade', () => {
         },
         [wt2]: {
           query: 'keep',
-          queryDetailsExpanded: true,
           caseSensitive: true,
           wholeWord: true,
           useRegex: false,


### PR DESCRIPTION
## Problem
When performing scoped file searches with include/exclude filters, the filter fields were hidden behind an 'Ellipsis' toggle button, forcing users to repeatedly toggle visibility. Additionally, match highlights in narrow sidebars were often pushed off the right edge by long pre-match text, making search results visually inaccessible.

## Solution
- Remove the queryDetailsExpanded toggle and always show include/exclude scope filters in the Search tab since it's explicitly a secondary destination for scoped search, not a primary sidebar.
- Left-truncate pre-match text in search result previews (with ellipsis) so match highlights stay visible at narrow sidebar widths, mirroring VS Code's behavior.

Made with [Orca](https://github.com/stablyai/orca) 🐋
