### PR TITLE
fix(release-cut): anchor RC base to latest_stable + patch

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -103,15 +103,6 @@ jobs:
           latest_stable="${latest_stable#v}"
           echo "Latest stable: ${latest_stable:-<none>}"
 
-          # Latest tag of any kind on the repo (including RCs). Used only
-          # when kind=rc to figure out the current RC series base.
-          latest_tag="$(git tag --sort=-v:refname | head -n 1 || true)"
-          latest_tag="${latest_tag#v}"
-          echo "Latest tag:    ${latest_tag:-<none>}"
-
-          # Strip any existing -rc.N suffix for base-version math.
-          base_of() { echo "${1%%-rc.*}"; }
-
           semver_gt() {
             # returns 0 if $1 > $2 by semver rules (ignoring prerelease)
             node -e '
@@ -159,14 +150,15 @@ jobs:
 
           case "$KIND" in
             rc)
-              # Why: an RC continues the current series if there is one,
-              # otherwise starts a new series on the next patch version.
-              # This keeps the "I just want another RC" case one click.
-              if [[ -n "$latest_tag" && "$latest_tag" == *"-rc."* ]]; then
-                base="$(base_of "$latest_tag")"
-              else
-                base="$(bump "$latest_stable" patch)"
-              fi
+              # Why: RCs always stabilize the *next* patch after whatever
+              # is currently published as stable. Earlier logic tried to
+              # "continue the current series" by reading the highest git
+              # tag, which silently reopened a series that had already
+              # shipped (e.g. cutting v1.3.21-rc.7 after v1.3.21 stable
+              # was out). Anchoring to latest_stable + patch eliminates
+              # that class of bug; minor/major RCs are cut by running
+              # that stable kind first.
+              base="$(bump "$latest_stable" patch)"
               new="$(next_rc_in_series "$base")"
               ;;
             patch|minor|major)


### PR DESCRIPTION
## Summary

- The `rc` branch in `release-cut.yml` derived its base version from the highest git tag (`git tag --sort=-v:refname | head -n 1`), which silently reopened a series that had already shipped as stable. After `v1.3.21` was published, cutting a new RC still produced `v1.3.21-rc.N` instead of starting `v1.3.22-rc.0`.
- Anchor RCs to `latest_stable + patch`. The `latest_tag` / `base_of` helpers are no longer needed and have been removed.
- Minor/major RCs: cut the stable kind first, then `rc`. This is clearer than the old "continue whatever was most recent" heuristic and removes an easy foot-gun.

## Test plan

- [ ] Dispatch `Cut Release` with `kind=rc` against `main` on a branch fork and confirm the computed version is `v1.3.22-rc.0` given current state (`latest_stable=1.3.21`, existing `v1.3.21-rc.*` tags).
- [ ] Cut a subsequent RC and confirm it increments to `v1.3.22-rc.1`.
- [ ] Cut a `patch` release and confirm the updater-safety gate still refuses if the computed version is not `> latest_stable`.

Made with [Orca](https://github.com/stablyai/orca) 🐋
