### PR TITLE
fix(pty): honor Windows shell selection on daemon path + shell-specific icons

### DIFF
--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -116,6 +116,12 @@ export class DaemonPtyAdapter implements IPtyProvider {
       cwd: effectiveCwd,
       env: opts.env,
       command: opts.command,
+      // Why: without this, the daemon always spawns cmd.exe (COMSPEC) or
+      // PowerShell as a fallback — regardless of which shell the renderer
+      // asked for in the "+" menu or persisted as the default. Forwarding
+      // the override makes the daemon path behave the same as the in-process
+      // LocalPtyProvider.
+      shellOverride: opts.shellOverride,
       shellReadySupported: opts.command ? supportsPtyStartupBarrier(opts.env ?? {}) : false
     })
 

--- a/src/main/daemon/daemon-server.ts
+++ b/src/main/daemon/daemon-server.ts
@@ -22,6 +22,7 @@ export type DaemonServerOptions = {
     cwd?: string
     env?: Record<string, string>
     command?: string
+    shellOverride?: string
   }) => SubprocessHandle
 }
 
@@ -199,6 +200,7 @@ export class DaemonServer {
           cwd: p.cwd,
           env: p.env,
           command: p.command,
+          shellOverride: p.shellOverride,
           shellReadySupported: p.shellReadySupported,
           streamClient: {
             onData: (data) => {

--- a/src/main/daemon/daemon-server.ts
+++ b/src/main/daemon/daemon-server.ts
@@ -1,3 +1,8 @@
+/* oxlint-disable max-lines -- Why: daemon-server owns the full RPC route
+ * table for the daemon protocol. Each case in routeRequest is a single
+ * pattern-matched call into TerminalHost, so splitting this file would
+ * require leaking the host reference across modules for no readability win
+ * over keeping all route handlers co-located. */
 import { createServer, type Server, type Socket } from 'net'
 import { randomUUID } from 'crypto'
 import { writeFileSync, chmodSync, unlinkSync } from 'fs'

--- a/src/main/daemon/daemon-server.ts
+++ b/src/main/daemon/daemon-server.ts
@@ -1,8 +1,3 @@
-/* oxlint-disable max-lines -- Why: daemon-server owns the full RPC route
- * table for the daemon protocol. Each case in routeRequest is a single
- * pattern-matched call into TerminalHost, so splitting this file would
- * require leaking the host reference across modules for no readability win
- * over keeping all route handlers co-located. */
 import { createServer, type Server, type Socket } from 'net'
 import { randomUUID } from 'crypto'
 import { writeFileSync, chmodSync, unlinkSync } from 'fs'

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -7,6 +7,7 @@ import {
 } from './shell-ready'
 import { isValidPtySize, normalizePtySize } from './daemon-pty-size'
 import { ensureNodePtySpawnHelperExecutable } from '../providers/local-pty-utils'
+import { resolveWindowsShellLaunchArgs } from '../providers/windows-shell-args'
 
 export type PtySubprocessOptions = {
   sessionId: string
@@ -15,6 +16,10 @@ export type PtySubprocessOptions = {
   cwd?: string
   env?: Record<string, string>
   command?: string
+  /** Explicit shell executable path/basename the renderer asked for.
+   *  Overrides env.COMSPEC / env.SHELL resolution inside the daemon so a user
+   *  who picks "New WSL terminal" from the "+" menu actually gets WSL. */
+  shellOverride?: string
 }
 
 function getDefaultCwd(): string {
@@ -58,11 +63,23 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
 
   env.LANG ??= 'en_US.UTF-8'
 
-  const shellPath = resolvePtyShellPath(env)
+  // Why: the shellOverride from the "+" menu (or persisted default shell
+  // setting, relayed by main) takes priority over env.COMSPEC — otherwise
+  // Windows always resolves to cmd.exe (COMSPEC) or PowerShell by fallback,
+  // no matter which shell the user actually picked.
+  const shellPath = opts.shellOverride || resolvePtyShellPath(env)
   let shellArgs: string[]
+  let spawnCwd = opts.cwd || getDefaultCwd()
 
   if (process.platform === 'win32') {
-    shellArgs = []
+    // Why: matches LocalPtyProvider — CMD needs chcp 65001, PowerShell needs
+    // $PROFILE dot-sourcing, WSL needs a --bash entry with a translated cwd.
+    // Previously the daemon passed `[]` here which made every shell launch as
+    // a bare interactive process; that silently degraded PowerShell (no
+    // profile) and never worked at all for WSL (which needs explicit args).
+    const resolved = resolveWindowsShellLaunchArgs(shellPath, spawnCwd, getDefaultCwd())
+    shellArgs = resolved.shellArgs
+    spawnCwd = resolved.effectiveCwd
   } else {
     const shellLaunch = opts.command
       ? getShellReadyLaunchConfig(shellPath)
@@ -84,7 +101,7 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
     name: 'xterm-256color',
     cols: size.cols,
     rows: size.rows,
-    cwd: opts.cwd || getDefaultCwd(),
+    cwd: spawnCwd,
     env
   })
 

--- a/src/main/daemon/terminal-host.ts
+++ b/src/main/daemon/terminal-host.ts
@@ -12,6 +12,11 @@ export type CreateOrAttachOptions = {
   cwd?: string
   env?: Record<string, string>
   command?: string
+  /** Explicit shell the renderer asked for (e.g. 'wsl.exe' for "New WSL
+   *  terminal" from the "+" menu). Forwarded to the subprocess spawner so the
+   *  daemon path honors per-tab shell selection the same way LocalPtyProvider
+   *  does. */
+  shellOverride?: string
   shellReadySupported?: boolean
   streamClient: { onData: (data: string) => void; onExit: (code: number) => void }
 }
@@ -32,6 +37,7 @@ export type TerminalHostOptions = {
     cwd?: string
     env?: Record<string, string>
     command?: string
+    shellOverride?: string
   }) => SubprocessHandle
   // Why: on graceful shutdown, the host writes final checkpoints for all live
   // sessions before killing them. This bypasses the RPC round-trip — the daemon
@@ -87,7 +93,8 @@ export class TerminalHost {
       rows: size.rows,
       cwd: opts.cwd,
       env: opts.env,
-      command: opts.command
+      command: opts.command,
+      shellOverride: opts.shellOverride
     })
 
     const session = new Session({

--- a/src/main/daemon/types.ts
+++ b/src/main/daemon/types.ts
@@ -62,6 +62,12 @@ export type CreateOrAttachRequest = {
     cwd?: string
     env?: Record<string, string>
     command?: string
+    /** Explicit Windows shell override selected by the user (e.g. 'wsl.exe').
+     *  The daemon forwards this to its subprocess spawner so each tab honors
+     *  the shell picked in the "+" menu or the persisted default-shell setting,
+     *  instead of defaulting to COMSPEC (which is always cmd.exe on Windows)
+     *  or the hard-coded powershell.exe fallback. */
+    shellOverride?: string
     shellReadySupported?: boolean
   }
 }

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -560,8 +560,20 @@ export function registerPtyHandlers(
       if (effectiveSessionId !== undefined) {
         spawnOptions.sessionId = effectiveSessionId
       }
-      if (args.shellOverride !== undefined) {
-        spawnOptions.shellOverride = args.shellOverride
+      // Why: on Windows, fall back to the persisted default-shell setting
+      // when the renderer didn't send a per-tab override. Without this, the
+      // daemon path ignores the user's "Default Shell" preference entirely —
+      // it just calls resolvePtyShellPath(env) which reads COMSPEC (cmd.exe)
+      // or falls back to PowerShell. The LocalPtyProvider already consults
+      // getWindowsShell(); this mirrors that on the daemon path so users who
+      // set WSL as default actually get WSL when pressing Ctrl+T.
+      const effectiveShellOverride =
+        args.shellOverride ??
+        (process.platform === 'win32' && !args.connectionId
+          ? getSettings?.()?.terminalWindowsShell
+          : undefined)
+      if (effectiveShellOverride !== undefined) {
+        spawnOptions.shellOverride = effectiveShellOverride
       }
       const result = await provider.spawn(spawnOptions)
       ptyOwnership.set(result.id, args.connectionId ?? null)

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -2,7 +2,8 @@
 ~70 lines of scanner/promise wiring to spawn(). Splitting the method would scatter
 tightly coupled PTY lifecycle logic (scan → ready → write → exit cleanup) across
 files without a cleaner ownership seam. */
-import { basename, win32 as pathWin32 } from 'path'
+import { basename } from 'path'
+import { resolveWindowsShellLaunchArgs } from './windows-shell-args'
 import { existsSync } from 'fs'
 import * as pty from 'node-pty'
 import { parseWslPath, isWslAvailable } from '../wsl'
@@ -137,51 +138,19 @@ export class LocalPtyProvider implements IPtyProvider {
       // Why: shellOverride lets a single tab open in a different shell than the
       // persisted default (e.g. "New WSL terminal" from the "+" submenu) without
       // changing the user's setting. It takes priority over the setting.
-      shellPath = args.shellOverride || this.opts.getWindowsShell?.() || process.env.COMSPEC || 'powershell.exe'
-      // Why: use path.win32.basename so backslash-separated Windows paths
-      // are parsed correctly even when tests mock process.platform on Linux CI.
-      const shellBasename = pathWin32.basename(shellPath).toLowerCase()
-      // Why: On CJK Windows (Chinese, Japanese, Korean), the console code page
-      // defaults to the system ANSI code page (e.g. 936/GBK for Chinese).
-      // ConPTY encodes its output pipe using this code page, but node-pty
-      // always decodes as UTF-8. Without switching to code page 65001 (UTF-8),
-      // multi-byte CJK characters are garbled because the GBK/Shift-JIS/EUC-KR
-      // byte sequences are misinterpreted as UTF-8.
-      if (shellBasename === 'cmd.exe') {
-        shellArgs = ['/K', 'chcp 65001 > nul']
-        effectiveCwd = cwd
-        validationCwd = cwd
-      } else if (shellBasename === 'powershell.exe' || shellBasename === 'pwsh.exe') {
-        // Why: `-NoExit -Command` alone skips the user's $PROFILE, breaking
-        // custom prompts (oh-my-posh, starship), aliases, and PSReadLine
-        // configuration. Dot-sourcing $PROFILE first restores the normal
-        // startup experience.
-        shellArgs = [
-          '-NoExit',
-          '-Command',
-          'try { . $PROFILE } catch {}; [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; [Console]::InputEncoding = [System.Text.Encoding]::UTF8'
-        ]
-        effectiveCwd = cwd
-        validationCwd = cwd
-      } else if (shellBasename === 'wsl.exe') {
-        // Why: this branch handles the "user chose WSL as their shell" case,
-        // distinct from the wslInfo branch above which is for repos whose cwd
-        // lives on a WSL filesystem. Here the cwd is a normal Windows path, so
-        // we translate it to a Linux /mnt/<drive>/... path and open a login
-        // bash in the user's default distro (no -d flag = default distro).
-        const driveMatch = cwd.replace(/\\/g, '/').match(/^([A-Za-z]):\/?(.*)$/)
-        const linuxCwd = driveMatch
-          ? `/mnt/${driveMatch[1].toLowerCase()}/${driveMatch[2]}`
-          : '/mnt/c'
-        const escapedLinuxCwd = linuxCwd.replace(/'/g, "'\\''")
-        shellArgs = ['--', 'bash', '-c', `cd '${escapedLinuxCwd}' && exec bash -l`]
-        effectiveCwd = getDefaultCwd()
-        validationCwd = cwd
-      } else {
-        shellArgs = []
-        effectiveCwd = cwd
-        validationCwd = cwd
-      }
+      shellPath =
+        args.shellOverride ||
+        this.opts.getWindowsShell?.() ||
+        process.env.COMSPEC ||
+        'powershell.exe'
+      // Why: both this path and the daemon-subprocess path must derive the
+      // same shellArgs for the same (shell, cwd) pair. The helper keeps CJK
+      // UTF-8 setup (chcp 65001), PowerShell $PROFILE dot-sourcing, and the
+      // wsl.exe /mnt/<drive> cwd translation in one place.
+      const resolved = resolveWindowsShellLaunchArgs(shellPath, cwd, defaultCwd)
+      shellArgs = resolved.shellArgs
+      effectiveCwd = resolved.effectiveCwd
+      validationCwd = resolved.validationCwd
     } else {
       shellPath = args.env?.SHELL || process.env.SHELL || '/bin/zsh'
       shellArgs = ['-l']

--- a/src/main/providers/windows-shell-args.test.ts
+++ b/src/main/providers/windows-shell-args.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import { resolveWindowsShellLaunchArgs } from './windows-shell-args'
+
+describe('resolveWindowsShellLaunchArgs', () => {
+  it('returns cmd.exe args with chcp 65001 for UTF-8 output', () => {
+    const result = resolveWindowsShellLaunchArgs('cmd.exe', 'C:\\Users\\alice', 'C:\\Users\\alice')
+    expect(result.shellArgs).toEqual(['/K', 'chcp 65001 > nul'])
+    expect(result.effectiveCwd).toBe('C:\\Users\\alice')
+    expect(result.validationCwd).toBe('C:\\Users\\alice')
+  })
+
+  it('returns PowerShell args that dot-source $PROFILE and force UTF-8 I/O', () => {
+    const result = resolveWindowsShellLaunchArgs(
+      'powershell.exe',
+      'C:\\Users\\alice',
+      'C:\\Users\\alice'
+    )
+    expect(result.shellArgs[0]).toBe('-NoExit')
+    expect(result.shellArgs[1]).toBe('-Command')
+    // The actual command must dot-source $PROFILE before setting encodings,
+    // otherwise oh-my-posh / starship / PSReadLine never load.
+    expect(result.shellArgs[2]).toContain('. $PROFILE')
+    expect(result.shellArgs[2]).toContain('UTF8')
+  })
+
+  it('handles pwsh.exe (PowerShell Core) the same as Windows PowerShell', () => {
+    const result = resolveWindowsShellLaunchArgs('pwsh.exe', 'C:\\', 'C:\\Users\\alice')
+    expect(result.shellArgs[0]).toBe('-NoExit')
+  })
+
+  it('translates Windows cwd to /mnt/<drive>/... for wsl.exe', () => {
+    const result = resolveWindowsShellLaunchArgs(
+      'wsl.exe',
+      'C:\\Users\\alice\\code',
+      'C:\\Users\\alice'
+    )
+    expect(result.shellArgs).toEqual([
+      '--',
+      'bash',
+      '-c',
+      "cd '/mnt/c/Users/alice/code' && exec bash -l"
+    ])
+    // Why: WSL cannot cd into a Windows path, so node-pty must start from the
+    // user's Windows home and we inject the Linux cd into the shellArgs above.
+    expect(result.effectiveCwd).toBe('C:\\Users\\alice')
+    expect(result.validationCwd).toBe('C:\\Users\\alice\\code')
+  })
+
+  it('escapes single quotes when translating a WSL cwd', () => {
+    const result = resolveWindowsShellLaunchArgs('wsl.exe', "C:\\weird'path", 'C:\\Users\\alice')
+    // The injected bash cmd must not break out of the surrounding single
+    // quotes when the path contains a ' character.
+    expect(result.shellArgs[3]).toBe("cd '/mnt/c/weird'\\''path' && exec bash -l")
+  })
+
+  it('falls back to /mnt/c when cwd is not a drive-letter path', () => {
+    const result = resolveWindowsShellLaunchArgs('wsl.exe', '\\\\server\\share', 'C:\\Users\\alice')
+    expect(result.shellArgs[3]).toBe("cd '/mnt/c' && exec bash -l")
+  })
+
+  it('falls back to empty args + same cwd for unknown shells', () => {
+    const result = resolveWindowsShellLaunchArgs(
+      'C:\\tools\\fish.exe',
+      'C:\\Users\\alice',
+      'C:\\Users\\alice'
+    )
+    expect(result.shellArgs).toEqual([])
+    expect(result.effectiveCwd).toBe('C:\\Users\\alice')
+    expect(result.validationCwd).toBe('C:\\Users\\alice')
+  })
+
+  it('is case-insensitive on the shell basename', () => {
+    const result = resolveWindowsShellLaunchArgs('PowerShell.EXE', 'C:\\', 'C:\\')
+    expect(result.shellArgs[0]).toBe('-NoExit')
+  })
+})

--- a/src/main/providers/windows-shell-args.ts
+++ b/src/main/providers/windows-shell-args.ts
@@ -1,0 +1,75 @@
+import { win32 as pathWin32 } from 'path'
+
+/** Result of resolving a Windows shell to its launch args + effective cwd.
+ *
+ *  Why this module exists: both the in-process LocalPtyProvider and the
+ *  daemon-subprocess spawner must produce IDENTICAL launch args for the same
+ *  (shellPath, cwd) pair. A prior drift let the daemon path always spawn
+ *  PowerShell regardless of which shell the user picked — the renderer's
+ *  shellOverride never reached the daemon's shell-args branches. Sharing the
+ *  decision here keeps both paths honest. */
+export type WindowsShellLaunchArgs = {
+  shellArgs: string[]
+  /** The cwd node-pty should be spawned with. WSL cannot cd into a Windows
+   *  path, so the wsl.exe branch returns the user's home as the effective cwd
+   *  and injects `cd '<linux path>'` into shellArgs instead. */
+  effectiveCwd: string
+  /** The path the caller should still validate exists on disk. Equals cwd in
+   *  every branch except wsl.exe (which validates the Windows cwd even though
+   *  the shell itself launches from $HOME). */
+  validationCwd: string
+}
+
+/** Build the argv + effective cwd for a Windows shell launch.
+ *
+ *  - cmd.exe: `/K chcp 65001 > nul` so multi-byte CJK output renders correctly.
+ *  - powershell.exe / pwsh.exe: dot-source $PROFILE and force UTF-8 I/O so
+ *    oh-my-posh / starship / PSReadLine keep working. `-NoExit` alone would
+ *    skip the profile.
+ *  - wsl.exe: translate the Windows cwd to /mnt/<drive>/... and enter a login
+ *    bash inside the default distro.
+ *  - anything else: no args, same cwd. */
+export function resolveWindowsShellLaunchArgs(
+  shellPath: string,
+  cwd: string,
+  defaultCwd: string
+): WindowsShellLaunchArgs {
+  const shellBasename = pathWin32.basename(shellPath).toLowerCase()
+
+  if (shellBasename === 'cmd.exe') {
+    return {
+      shellArgs: ['/K', 'chcp 65001 > nul'],
+      effectiveCwd: cwd,
+      validationCwd: cwd
+    }
+  }
+
+  if (shellBasename === 'powershell.exe' || shellBasename === 'pwsh.exe') {
+    return {
+      shellArgs: [
+        '-NoExit',
+        '-Command',
+        'try { . $PROFILE } catch {}; [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; [Console]::InputEncoding = [System.Text.Encoding]::UTF8'
+      ],
+      effectiveCwd: cwd,
+      validationCwd: cwd
+    }
+  }
+
+  if (shellBasename === 'wsl.exe') {
+    const driveMatch = cwd.replace(/\\/g, '/').match(/^([A-Za-z]):\/?(.*)$/)
+    const linuxCwd = driveMatch ? `/mnt/${driveMatch[1].toLowerCase()}/${driveMatch[2]}` : '/mnt/c'
+    const escapedLinuxCwd = linuxCwd.replace(/'/g, "'\\''")
+    return {
+      shellArgs: ['--', 'bash', '-c', `cd '${escapedLinuxCwd}' && exec bash -l`],
+      effectiveCwd: defaultCwd,
+      validationCwd: cwd
+    }
+  }
+
+  return {
+    shellArgs: [],
+    effectiveCwd: cwd,
+    validationCwd: cwd
+  }
+}

--- a/src/renderer/src/components/tab-bar/SortableTab.tsx
+++ b/src/renderer/src/components/tab-bar/SortableTab.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useSortable } from '@dnd-kit/sortable'
 import { X, Terminal as TerminalIcon, Minimize2, Columns2, Rows2 } from 'lucide-react'
+import { ShellIcon } from './shell-icons'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -233,6 +234,21 @@ export default function SortableTab({
             // every "needs your attention" surface in Orca consistent.
             <span data-testid="tab-activity-bell" className="inline-flex shrink-0">
               <FilledBellIcon className="w-3 h-3 mr-1 text-amber-500 drop-shadow-sm" />
+            </span>
+          ) : tab.shellOverride ? (
+            // Why: when the tab was explicitly opened with a specific Windows
+            // shell (PowerShell / CMD / WSL via the "+" menu), render the
+            // matching brand-style glyph so the strip shows at a glance which
+            // shell this tab is running. Falls back to the generic lucide
+            // TerminalIcon below for mac/linux shells and for Windows tabs
+            // that were spawned before the per-tab shell override landed
+            // (shellOverride absent → same neutral glyph as before, no visual
+            // regression for existing sessions).
+            <span
+              className={`mr-1 inline-flex shrink-0 ${isActive ? 'text-foreground' : 'text-muted-foreground'}`}
+              aria-hidden
+            >
+              <ShellIcon shell={tab.shellOverride} size={12} />
             </span>
           ) : (
             <TerminalIcon

--- a/src/renderer/src/components/tab-bar/TabBar.tsx
+++ b/src/renderer/src/components/tab-bar/TabBar.tsx
@@ -23,6 +23,7 @@ import { reconcileTabOrder } from './reconcile-order'
 import type { HoveredTabInsertion, TabDragItemData } from '../tab-group/useTabDragSplit'
 import { resolveTabIndicatorEdges } from '../tab-group/tab-insertion'
 import { getEditorDisplayLabel } from '@/components/editor/editor-labels'
+import { ShellIcon } from './shell-icons'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -459,17 +460,19 @@ function TabBarInner({
           {isWindows && onNewTerminalWithShell ? (
             // Why: previously the Windows path nested shell choices under a
             // Radix submenu. In practice the submenu frequently failed to open
-            // on hover/click (see "New Terminal Selection Windows" feedback),
-            // and even when it worked the two-step expansion hid the fact that
-            // multiple shells were available. Inlining all shells as flat
-            // items with the configured default pinned to the top — and
-            // carrying the Ctrl+T shortcut label since it opens the default —
-            // matches the user's rec: no popouts, show up to three shells at
-            // once, make the "selected" default obvious at a glance.
+            // on hover/click, and even when it worked the two-step expansion
+            // hid the fact that multiple shells were available. Inlining all
+            // shells as flat items — default pinned to the top with the
+            // Ctrl+T hint — matches the "no popouts, show all options at
+            // once" rec. Each entry uses a shell-specific icon (ShellIcon)
+            // so PowerShell / CMD / WSL are distinguishable at a glance.
+            // Labels use "CMD Prompt" instead of "Command Prompt" to keep
+            // each row narrow enough that the shortcut hint fits without
+            // wrapping.
             (() => {
               const allShells = [
                 { label: 'PowerShell', shell: 'powershell.exe' },
-                { label: 'Command Prompt', shell: 'cmd.exe' },
+                { label: 'CMD Prompt', shell: 'cmd.exe' },
                 ...(wslAvailable ? [{ label: 'WSL', shell: 'wsl.exe' }] : [])
               ]
               const defaultEntry =
@@ -492,15 +495,8 @@ function TabBarInner({
                     }}
                     className="gap-2 rounded-[7px] px-2 py-1.5 text-[12px] leading-5 font-medium"
                   >
-                    <TerminalSquare className="size-4 text-muted-foreground" />
-                    <span className="flex-1">
-                      New Terminal: {entry.label}
-                      {isDefault ? (
-                        <span className="ml-1.5 text-[10px] uppercase tracking-wide text-muted-foreground">
-                          Default
-                        </span>
-                      ) : null}
-                    </span>
+                    <ShellIcon shell={entry.shell} size={14} />
+                    <span className="flex-1">New Terminal: {entry.label}</span>
                     {isDefault ? (
                       <DropdownMenuShortcut>{NEW_TERMINAL_SHORTCUT}</DropdownMenuShortcut>
                     ) : null}

--- a/src/renderer/src/components/tab-bar/shell-icons.tsx
+++ b/src/renderer/src/components/tab-bar/shell-icons.tsx
@@ -1,0 +1,98 @@
+import React from 'react'
+import { Terminal as TerminalIcon } from 'lucide-react'
+
+export type WindowsShell = 'powershell.exe' | 'cmd.exe' | 'wsl.exe'
+
+// Why: the "+" dropdown and per-tab tab strip both need a visual distinction
+// between PowerShell, CMD, and WSL sessions. Stock lucide glyphs don't
+// differentiate — every session rendered as the same generic chevron. These
+// hand-crafted icons (derived from the official brand marks and redrawn as
+// small currentColor-aware paths so they inherit the tab's text color) make
+// each shell identifiable at a glance without shipping a heavier brand-asset
+// package like simple-icons.
+
+function PowerShellIcon({ size = 14 }: { size?: number }): React.JSX.Element {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden
+    >
+      <rect x="1.5" y="3" width="21" height="18" rx="2.5" fill="#2E74B5" />
+      <path
+        d="M6.5 7.3l6.2 4.7-6.2 4.7-1.2-1.2 4.6-3.5-4.6-3.5z"
+        fill="#ffffff"
+        fillRule="nonzero"
+      />
+      <rect x="12.5" y="15.3" width="5" height="1.4" rx="0.4" fill="#ffffff" />
+    </svg>
+  )
+}
+
+function CmdIcon({ size = 14 }: { size?: number }): React.JSX.Element {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden
+    >
+      <rect x="1.5" y="3" width="21" height="18" rx="2.5" fill="#1F1F1F" />
+      <path d="M5.8 8l4 4-4 4-1.1-1.1L7.7 12 4.7 9.1z" fill="#ffffff" />
+      <rect x="10.5" y="15" width="8" height="1.4" rx="0.4" fill="#ffffff" />
+    </svg>
+  )
+}
+
+function WslIcon({ size = 14 }: { size?: number }): React.JSX.Element {
+  // Text-based mark. A full Tux silhouette at 14px is unreadable and a rough
+  // hand-drawn version is worse than a clean "WSL" typographic tile, which
+  // still reads as distinct from PowerShell/CMD at a glance.
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden
+    >
+      <rect x="1.5" y="3" width="21" height="18" rx="2.5" fill="#F4B400" />
+      <text
+        x="12"
+        y="15.2"
+        textAnchor="middle"
+        fontSize="7"
+        fontWeight="800"
+        fill="#1F1F1F"
+        fontFamily="system-ui, -apple-system, sans-serif"
+      >
+        WSL
+      </text>
+    </svg>
+  )
+}
+
+export function ShellIcon({
+  shell,
+  size = 14
+}: {
+  shell: string | null | undefined
+  size?: number
+}): React.JSX.Element {
+  const normalized = (shell ?? '').toLowerCase()
+  if (normalized === 'powershell.exe' || normalized === 'pwsh.exe') {
+    return <PowerShellIcon size={size} />
+  }
+  if (normalized === 'cmd.exe') {
+    return <CmdIcon size={size} />
+  }
+  if (normalized === 'wsl.exe' || normalized.startsWith('wsl')) {
+    return <WslIcon size={size} />
+  }
+  // Fallback: generic terminal glyph for mac/linux shells and anything
+  // unrecognized. Inherits currentColor so it matches the surrounding tab.
+  return <TerminalIcon width={size} height={size} aria-hidden />
+}

--- a/src/renderer/src/store/slices/tabs-hydration.test.ts
+++ b/src/renderer/src/store/slices/tabs-hydration.test.ts
@@ -1,3 +1,7 @@
+/* oxlint-disable max-lines -- Why: exhaustive table-driven tests for the
+ * tabs-hydration reducer — each case is a minimal fixture + assertion, and
+ * splitting the table across files would scatter closely related regression
+ * coverage for the same function. */
 import { describe, it, expect, vi } from 'vitest'
 import type { WorkspaceSessionState } from '../../../../shared/types'
 import { buildHydratedTabState } from './tabs-hydration'

--- a/src/renderer/src/store/slices/tabs-hydration.test.ts
+++ b/src/renderer/src/store/slices/tabs-hydration.test.ts
@@ -1,7 +1,3 @@
-/* oxlint-disable max-lines -- Why: exhaustive table-driven tests for the
- * tabs-hydration reducer — each case is a minimal fixture + assertion, and
- * splitting the table across files would scatter closely related regression
- * coverage for the same function. */
 import { describe, it, expect, vi } from 'vitest'
 import type { WorkspaceSessionState } from '../../../../shared/types'
 import { buildHydratedTabState } from './tabs-hydration'

--- a/src/shared/text-search.ts
+++ b/src/shared/text-search.ts
@@ -1,3 +1,9 @@
+/* oxlint-disable max-lines -- Why: this is the single source of truth for
+ * rg arg construction, rg --json parsing, git-grep submatch parsing, and
+ * relative-path normalization, shared by both the local main process and
+ * the SSH relay. The prior divergence between those two implementations
+ * caused the maxBuffer footgun the design doc calls out; re-splitting the
+ * file would re-introduce that failure mode. */
 /**
  * Shared, pure text-search helpers used by both the local main process and the
  * SSH relay. No Electron, no child_process, no fs — the caller owns process
@@ -14,11 +20,7 @@
  * sites must use this module; see filesystem.ts and relay/fs-handler.ts.
  */
 import { join, relative } from 'path'
-import type {
-  SearchFileResult,
-  SearchOptions,
-  SearchResult
-} from './types'
+import type { SearchFileResult, SearchOptions, SearchResult } from './types'
 
 export type SearchAccumulator = {
   fileMap: Map<string, SearchFileResult>
@@ -116,11 +118,7 @@ export type SearchOptionsLike = Pick<
  * its original shape, and rg's output paths are translated back to Windows
  * UNC via the `transformAbsPath` callback in `ingestRgJsonLine`.
  */
-export function buildRgArgs(
-  query: string,
-  target: string,
-  opts: SearchOptionsLike
-): string[] {
+export function buildRgArgs(query: string, target: string, opts: SearchOptionsLike): string[] {
   const args: string[] = [
     '--json',
     '--hidden',
@@ -141,12 +139,18 @@ export function buildRgArgs(
     args.push('--fixed-strings')
   }
   if (opts.includePattern) {
-    for (const pat of opts.includePattern.split(',').map((s) => s.trim()).filter(Boolean)) {
+    for (const pat of opts.includePattern
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean)) {
       args.push('--glob', pat)
     }
   }
   if (opts.excludePattern) {
-    for (const pat of opts.excludePattern.split(',').map((s) => s.trim()).filter(Boolean)) {
+    for (const pat of opts.excludePattern
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean)) {
       args.push('--glob', `!${pat}`)
     }
   }
@@ -180,7 +184,15 @@ export function ingestRgJsonLine(
   if (!line) {
     return 'continue'
   }
-  let msg: { type?: string; data?: { path?: { text?: string }; submatches?: { start: number; end: number }[]; line_number?: number; lines?: { text?: string } } }
+  let msg: {
+    type?: string
+    data?: {
+      path?: { text?: string }
+      submatches?: { start: number; end: number }[]
+      line_number?: number
+      lines?: { text?: string }
+    }
+  }
   try {
     msg = JSON.parse(line)
   } catch {
@@ -288,13 +300,19 @@ export function buildGitGrepArgs(query: string, opts: SearchOptionsLike): string
 
   let hasPathspecs = false
   if (opts.includePattern) {
-    for (const pat of opts.includePattern.split(',').map((s) => s.trim()).filter(Boolean)) {
+    for (const pat of opts.includePattern
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean)) {
       gitArgs.push(toGitGlobPathspec(pat))
       hasPathspecs = true
     }
   }
   if (opts.excludePattern) {
-    for (const pat of opts.excludePattern.split(',').map((s) => s.trim()).filter(Boolean)) {
+    for (const pat of opts.excludePattern
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean)) {
       gitArgs.push(toGitGlobPathspec(pat, true))
       hasPathspecs = true
     }


### PR DESCRIPTION
## Summary

Two user-reported issues, rolled into one PR:

### 1. Bug — Windows shell selection was silently ignored

> I just tried all 3 options (default set to WSL in settings) and for each terminal I see the same PowerShell message when I start it, regardless of selection.

Root cause: the daemon-backed PTY path (the normal case on Windows) never forwarded \`shellOverride\`. \`pty-subprocess.ts\` called \`resolvePtyShellPath(env)\` which reads \`COMSPEC\` (always cmd.exe on Windows) or falls back to PowerShell — the renderer's choice never got there.

Fix:
- Thread \`shellOverride\` through \`daemon-pty-adapter\` → \`createOrAttach\` RPC → \`terminal-host\` → \`pty-subprocess\`, and actually resolve the correct launch args (CMD \`chcp 65001\`, PowerShell \`-NoExit\` + \`$PROFILE\` dot-source, WSL \`/mnt/<drive>\` cwd translation) on the daemon path.
- Extract the Windows shell-args decision into a shared helper (\`resolveWindowsShellLaunchArgs\`) so \`LocalPtyProvider\` and the daemon subprocess cannot drift again.
- In \`ipc/pty.ts\`, fall back to the persisted \`terminalWindowsShell\` setting when the renderer didn't send an override, so the daemon path honors Settings → Default Shell the same way \`LocalPtyProvider\` already did.

### 2. UI polish on the "+" menu and tab strip

> Use better logos for each shell. Use them in tabs too. Remove the 'DEFAULT' word (takes too much space). Rename 'Command Prompt' → 'CMD Prompt'.

- New \`ShellIcon\` component with per-shell brand-style glyphs (PowerShell, CMD, WSL).
- The "+" dropdown uses \`ShellIcon\` per entry.
- Terminal tabs with a \`shellOverride\` use \`ShellIcon\` in the tab strip too, so a WSL tab is visually distinct from a PowerShell tab at a glance.
- Removed the inline \"Default\" tag — the Ctrl+T shortcut hint already marks the top entry.
- Renamed \"Command Prompt\" → \"CMD Prompt\".

## Test plan

- [ ] On Windows, open the \"+\" menu → verify 3 flat entries, each with a distinct shell icon, default at top with Ctrl+T hint.
- [ ] Open each option from the menu — verify PowerShell / CMD / WSL actually launch (not all PowerShell).
- [ ] Set Default Shell to WSL in Settings, press Ctrl+T — verify a WSL terminal opens.
- [ ] Open a PowerShell tab, then a WSL tab — confirm the tab strip icons are different.
- [ ] On mac/linux, the menu still shows a single \"New Terminal\" item with ⌘T / Ctrl+T shortcut.
- [ ] New unit tests for \`resolveWindowsShellLaunchArgs\` cover cmd / powershell / pwsh / wsl / unknown shells, case-insensitive basename matching, and WSL cwd escaping.

Made with [Orca](https://github.com/stablyai/orca) 🐋
