### PR TITLE
fix(cli): record back/forward history for CLI-activated worktrees

### DIFF
--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -1338,3 +1338,205 @@ describe('useIpcEvents shortcut hint clearing', () => {
     expect(activateAndRevealWorktree).toHaveBeenCalledWith('wt-2')
   })
 })
+
+describe('useIpcEvents CLI-created worktree activation', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.unstubAllGlobals()
+  })
+
+  // Why: regression guard. The CLI "create agent" flow emits
+  // `ui:activateWorktree` to switch the user to the new workspace. A prior
+  // implementation hand-rolled the activation (setActiveRepo + setActiveView
+  // + setActiveWorktree + ensureWorktreeHasInitialTerminal +
+  // revealWorktreeInSidebar), which bypassed recordWorktreeVisit and left
+  // the back/forward buttons ignoring the CLI-driven switch. This test pins
+  // the handler to the canonical `activateAndRevealWorktree` helper, which
+  // is the single place that records the visit in history.
+  it('routes CLI-driven activation through activateAndRevealWorktree so back/forward history is recorded', async () => {
+    const activateAndRevealWorktree = vi.fn()
+    const fetchWorktrees = vi.fn().mockResolvedValue(undefined)
+    const activateWorktreeListenerRef: {
+      current:
+        | ((data: {
+            repoId: string
+            worktreeId: string
+            setup?: { runnerScriptPath: string; envVars: Record<string, string> }
+          }) => void)
+        | null
+    } = { current: null }
+
+    vi.doMock('react', async () => {
+      const actual = await vi.importActual<typeof ReactModule>('react')
+      return {
+        ...actual,
+        useEffect: (effect: () => void | (() => void)) => {
+          effect()
+        }
+      }
+    })
+
+    vi.doMock('../store', () => ({
+      useAppStore: {
+        getState: () => ({
+          fetchRepos: vi.fn(),
+          fetchWorktrees,
+          setUpdateStatus: vi.fn(),
+          activeModal: null,
+          closeModal: vi.fn(),
+          openModal: vi.fn(),
+          activeWorktreeId: 'wt-old',
+          activeView: 'terminal',
+          setActiveView: vi.fn(),
+          setActiveRepo: vi.fn(),
+          setActiveWorktree: vi.fn(),
+          revealWorktreeInSidebar: vi.fn(),
+          setIsFullScreen: vi.fn(),
+          updateBrowserPageState: vi.fn(),
+          activeTabType: 'terminal',
+          editorFontZoomLevel: 0,
+          setEditorFontZoomLevel: vi.fn(),
+          setRateLimitsFromPush: vi.fn(),
+          setSshConnectionState: vi.fn(),
+          setSshTargetLabels: vi.fn(),
+          setPortForwards: vi.fn(),
+          clearPortForwards: vi.fn(),
+          setDetectedPorts: vi.fn(),
+          enqueueSshCredentialRequest: vi.fn(),
+          removeSshCredentialRequest: vi.fn(),
+          clearTabPtyId: vi.fn(),
+          settings: { terminalFontSize: 13 }
+        })
+      }
+    }))
+
+    vi.doMock('@/lib/ui-zoom', () => ({
+      applyUIZoom: vi.fn()
+    }))
+    vi.doMock('@/lib/worktree-activation', () => ({
+      activateAndRevealWorktree,
+      ensureWorktreeHasInitialTerminal: vi.fn()
+    }))
+    vi.doMock('@/components/sidebar/visible-worktrees', () => ({
+      getVisibleWorktreeIds: () => []
+    }))
+    vi.doMock('@/lib/editor-font-zoom', () => ({
+      nextEditorFontZoomLevel: vi.fn(() => 0),
+      computeEditorFontSize: vi.fn(() => 13)
+    }))
+    vi.doMock('@/components/settings/SettingsConstants', () => ({
+      zoomLevelToPercent: vi.fn(() => 100),
+      ZOOM_MIN: -3,
+      ZOOM_MAX: 3
+    }))
+    vi.doMock('@/lib/zoom-events', () => ({
+      dispatchZoomLevelChanged: vi.fn()
+    }))
+
+    vi.stubGlobal('window', {
+      api: {
+        repos: { onChanged: () => () => {} },
+        worktrees: { onChanged: () => () => {} },
+        ui: {
+          onOpenSettings: () => () => {},
+          onToggleLeftSidebar: () => () => {},
+          onToggleRightSidebar: () => () => {},
+          onToggleWorktreePalette: () => () => {},
+          onOpenQuickOpen: () => () => {},
+          onOpenNewWorkspace: () => () => {},
+          onJumpToWorktreeIndex: () => () => {},
+          onWorktreeHistoryNavigate: () => () => {},
+          onActivateWorktree: (
+            listener: (data: {
+              repoId: string
+              worktreeId: string
+              setup?: { runnerScriptPath: string; envVars: Record<string, string> }
+            }) => void
+          ) => {
+            activateWorktreeListenerRef.current = listener
+            return () => {}
+          },
+          onCreateTerminal: () => () => {},
+          onRequestTerminalCreate: () => () => {},
+          replyTerminalCreate: () => {},
+          onSplitTerminal: () => () => {},
+          onRenameTerminal: () => () => {},
+          onFocusTerminal: () => () => {},
+          onCloseTerminal: () => () => {},
+          onNewBrowserTab: () => () => {},
+          onRequestTabCreate: () => () => {},
+          replyTabCreate: () => {},
+          onRequestTabClose: () => () => {},
+          replyTabClose: () => {},
+          onNewTerminalTab: () => () => {},
+          onCloseActiveTab: () => () => {},
+          onSwitchTab: () => () => {},
+          onSwitchTerminalTab: () => () => {},
+          onToggleStatusBar: () => () => {},
+          onFullscreenChanged: () => () => {},
+          onTerminalZoom: () => () => {},
+          getZoomLevel: () => 0,
+          set: vi.fn()
+        },
+        updater: {
+          getStatus: () => Promise.resolve({ state: 'idle' }),
+          onStatus: () => () => {},
+          onClearDismissal: () => () => {}
+        },
+        browser: {
+          onGuestLoadFailed: () => () => {},
+          onOpenLinkInOrcaTab: () => () => {},
+          onNavigationUpdate: () => () => {},
+          onActivateView: () => () => {}
+        },
+        rateLimits: {
+          get: () => Promise.resolve({ limits: {}, lastUpdatedAt: Date.now() }),
+          onUpdate: () => () => {}
+        },
+        ssh: {
+          listTargets: () => Promise.resolve([]),
+          listPortForwards: () => Promise.resolve([]),
+          listDetectedPorts: () => Promise.resolve([]),
+          getState: () => Promise.resolve(null),
+          onStateChanged: () => () => {},
+          onCredentialRequest: () => () => {},
+          onPortForwardsChanged: () => () => {},
+          onDetectedPortsChanged: () => () => {},
+          onCredentialResolved: () => () => {}
+        }
+      }
+    })
+
+    const { useIpcEvents } = await import('./useIpcEvents')
+    useIpcEvents()
+    await Promise.resolve()
+
+    if (typeof activateWorktreeListenerRef.current !== 'function') {
+      throw new Error('Expected onActivateWorktree listener to be registered')
+    }
+
+    const setup = { runnerScriptPath: '/tmp/setup.sh', envVars: { FOO: 'bar' } }
+    activateWorktreeListenerRef.current({
+      repoId: 'repo-1',
+      worktreeId: 'wt-new',
+      setup
+    })
+
+    // Wait for the async IPC handler (it awaits fetchWorktrees before activating).
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    // Worktrees must be fetched first so activateAndRevealWorktree can resolve
+    // the CLI-created worktree out of store state.
+    expect(fetchWorktrees).toHaveBeenCalledWith('repo-1')
+
+    // The core regression guard: the handler must delegate to the canonical
+    // activation helper (which records the visit in history) rather than
+    // hand-rolling the activation steps and skipping recordWorktreeVisit.
+    // `setup` must be passed through the `setup` opt — not positionally
+    // mis-aliased into `startup`, which was a latent bug in the original
+    // hand-rolled path.
+    expect(activateAndRevealWorktree).toHaveBeenCalledTimes(1)
+    expect(activateAndRevealWorktree).toHaveBeenCalledWith('wt-new', { setup })
+  })
+})

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -2,10 +2,7 @@
 import { useEffect } from 'react'
 import { useAppStore } from '../store'
 import { applyUIZoom } from '@/lib/ui-zoom'
-import {
-  activateAndRevealWorktree,
-  ensureWorktreeHasInitialTerminal
-} from '@/lib/worktree-activation'
+import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 import { SPLIT_TERMINAL_PANE_EVENT, CLOSE_TERMINAL_PANE_EVENT } from '@/constants/terminal'
 import type { SplitTerminalPaneDetail, CloseTerminalPaneDetail } from '@/constants/terminal'
 import { getVisibleWorktreeIds } from '@/components/sidebar/visible-worktrees'
@@ -141,18 +138,16 @@ export function useIpcEvents(): void {
     unsubs.push(
       window.api.ui.onActivateWorktree(({ repoId, worktreeId, setup }) => {
         void (async () => {
-          const store = useAppStore.getState()
-          await store.fetchWorktrees(repoId)
-          // Why: CLI-created worktrees should feel identical to UI-created
-          // worktrees. The renderer owns the "active worktree -> first tab"
-          // behavior today, so we explicitly replay that activation sequence
-          // after the runtime creates a worktree outside the renderer.
-          store.setActiveRepo(repoId)
-          store.setActiveView('terminal')
-          store.setActiveWorktree(worktreeId)
-          ensureWorktreeHasInitialTerminal(store, worktreeId, setup)
-
-          store.revealWorktreeInSidebar(worktreeId)
+          // Why: fetch worktrees first so the activation helper can resolve
+          // the CLI-created worktree via findWorktreeById — it arrived from
+          // the main process and is not yet in the renderer state.
+          await useAppStore.getState().fetchWorktrees(repoId)
+          // Why: route through activateAndRevealWorktree so CLI-created
+          // worktrees share the canonical activation path with UI-created
+          // ones. This records the visit in the back/forward history stack
+          // (recordWorktreeVisit), without which the nav buttons would
+          // ignore the CLI-driven workspace switch.
+          activateAndRevealWorktree(worktreeId, { setup })
         })().catch((error) => {
           console.error('Failed to activate CLI-created worktree:', error)
         })


### PR DESCRIPTION
## Summary
- The `ui:activateWorktree` IPC handler — fired when `orca-cli` creates an agent and auto-switches the user to the new workspace — hand-rolled its activation sequence and skipped `recordWorktreeVisit`. As a result, the titlebar Back/Forward buttons silently ignored CLI-driven workspace switches: the new workspace never entered the nav-history stack, so clicking Back after a CLI-created agent appeared to do nothing useful.
- Route the handler through `activateAndRevealWorktree` (the canonical activation helper already used by sidebar clicks, the jump palette, and keyboard shortcuts). It records the visit, clears sidebar filters, and reveals the target, so CLI-created workspaces now behave identically to UI-created ones.
- Incidentally fixes a latent argument-aliasing bug: the old path passed `setup` into `ensureWorktreeHasInitialTerminal`'s `startup` parameter slot, so CLI-provided setup scripts were being queued as shell startup commands rather than handled by the setup-launch path.
- Adds a regression test pinning the IPC handler to the canonical helper. Verified the test fails against the prior hand-rolled implementation before re-applying the fix.

## Test plan
- [x] `pnpm run typecheck` passes
- [x] `pnpm exec vitest run src/renderer/src/hooks/useIpcEvents.test.ts` — all 12 tests pass (was 11)
- [x] New test fails against the buggy hand-rolled implementation (confirmed locally by reverting, seeing the failure, then restoring the fix)
- [x] **End-to-end verification in a live Electron dev build against `demo-project` via playwright-cli over CDP:**
  1. Launched the dev build with `--remote-debugging-port=9333` and attached playwright-cli.
  2. Seeded nav history to a known state: reset `worktreeNavHistory` to `[]`, activated an existing `demo-project` worktree (`ribbon-taxicab`) via `setActiveWorktree` + `recordWorktreeVisit` → `navHistory = [ribbon-taxicab]`, `navIndex = 0`.
  3. Ran `orca worktree create --repo id:<demo-project> --name cli-back-forward-test-…` (pointed at the dev runtime via `ORCA_USER_DATA_PATH`). The app auto-switched to the new worktree as expected.
  4. **Fix confirmed:** immediately after the CLI switch, `navHistory = [ribbon-taxicab, cli-back-forward-test-…]`, `navIndex = 1` — the CLI-created worktree was recorded. Back button was enabled, Forward disabled (correct for tip of a 2-entry stack).
  5. Clicked the titlebar Back button → `activeWorktreeId` became `ribbon-taxicab`, `navIndex = 0`.
  6. Clicked Forward → `activeWorktreeId` returned to the CLI-created worktree, `navIndex = 1`.
  7. Under the prior (buggy) implementation the CLI-created worktree would never have been recorded, so step 4 would have shown `navHistory = [ribbon-taxicab]` with Back disabled — matching the originally reported symptom.
  8. Cleaned up the test worktree via `orca worktree rm`.