### PR TITLE
Attribution update

### DIFF
--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -344,7 +344,7 @@ export function registerPtyHandlers(
           isPackaged: app.isPackaged,
           userDataPath: app.getPath('userData'),
           selectedCodexHomePath: getSelectedCodexHomePath?.() ?? null,
-          githubAttributionEnabled: getSettings?.()?.enableGitHubAttribution ?? true
+          githubAttributionEnabled: getSettings?.()?.enableGitHubAttribution ?? false
         }),
       onSpawned: (id) => runtime?.onPtySpawned(id),
       onExit: (id, code) => {
@@ -536,7 +536,7 @@ export function registerPtyHandlers(
           isPackaged: app.isPackaged,
           userDataPath: app.getPath('userData'),
           selectedCodexHomePath: getSelectedCodexHomePath?.() ?? null,
-          githubAttributionEnabled: getSettings?.()?.enableGitHubAttribution ?? true
+          githubAttributionEnabled: getSettings?.()?.enableGitHubAttribution ?? false
         })
       }
       const envToDelete = claudeAuth?.stripAuthEnv

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -117,7 +117,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     refreshLocalBaseRefOnWorktreeCreate: false,
     branchPrefix: 'git-username',
     branchPrefixCustom: '',
-    enableGitHubAttribution: true,
+    enableGitHubAttribution: false,
     theme: 'system',
     editorAutoSave: false,
     editorAutoSaveDelayMs: DEFAULT_EDITOR_AUTO_SAVE_DELAY_MS,


### PR DESCRIPTION
Disable GitHub attribution by default. Existing users keep their saved setting.