### PR TITLE
fix(sidebar): Cmd+Shift+Up/Down crosses Pinned/All boundary when collapsed

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -24,6 +24,7 @@ import {
 import {
   type GroupHeaderRow,
   type Row,
+  ALL_GROUP_KEY,
   PINNED_GROUP_KEY,
   buildRows,
   getGroupKeyForWorktree
@@ -134,6 +135,14 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
         if (groupKey && collapsedGroups.has(groupKey)) {
           toggleGroup(groupKey)
         }
+      } else if (targetWorktree && groupBy === 'none') {
+        // Why: when any worktree is pinned, buildRows emits a sibling "All"
+        // header for the unpinned block (see worktree-list-groups.ts). If that
+        // header is collapsed, revealing an unpinned target would otherwise
+        // leave it hidden — uncollapse it so the card is actually visible.
+        if (collapsedGroups.has(ALL_GROUP_KEY)) {
+          toggleGroup(ALL_GROUP_KEY)
+        }
       }
     }
 
@@ -174,9 +183,18 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
 
   const navigateWorktree = useCallback(
     (direction: 'up' | 'down') => {
-      const worktreeRows = rows.filter(
-        (r): r is Extract<Row, { type: 'item' }> => r.type === 'item'
-      )
+      // Why: derive the cycling order from an all-expanded layout, not the
+      // rendered rows. Otherwise Cmd+Shift+Up/Down would skip any worktree
+      // hidden in a collapsed group — in particular it couldn't cross the
+      // Pinned/All boundary when either section is collapsed. Reveal will
+      // uncollapse the target section (see pendingRevealWorktreeId effect).
+      const worktreeRows = buildRows(
+        groupBy,
+        worktrees,
+        repoMap,
+        prCache,
+        new Set<string>()
+      ).filter((r): r is Extract<Row, { type: 'item' }> => r.type === 'item')
       if (worktreeRows.length === 0) {
         return
       }
@@ -208,7 +226,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
         virtualizer.scrollToIndex(rowIndex, { align: 'auto' })
       }
     },
-    [rows, activeWorktreeId, virtualizer]
+    [rows, activeWorktreeId, virtualizer, groupBy, worktrees, repoMap, prCache]
   )
 
   useEffect(() => {


### PR DESCRIPTION
## Problem

When the sidebar grouping is set to 'none' and a user has pinned some worktrees, the Cmd+Shift+Up/Down keyboard shortcuts to cycle through worktrees would:
- Skip worktrees hidden in collapsed groups
- Become unable to cross the Pinned/All boundary when either section is collapsed

## Solution

1. Derive the keyboard cycling order from an all-expanded layout (calling `buildRows` with an empty collapsed set) instead of using the rendered rows. This ensures no worktrees are skipped regardless of collapse state.

2. When revealing a worktree via keyboard navigation (in the `pendingRevealWorktreeId` effect), uncollapse the All header when targeting an unpinned worktree with `groupBy === 'none'`. This ensures the target is actually visible after reveal.

Made with [Orca](https://github.com/stablyai/orca) 🐋
