### PR TITLE
Scope pending PTY spawns to terminal panes

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -168,6 +168,14 @@ function createDeps(overrides: Record<string, unknown> = {}) {
   }
 }
 
+function createDeferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolveDeferred!: (value: T) => void
+  const promise = new Promise<T>((resolve) => {
+    resolveDeferred = resolve
+  })
+  return { promise, resolve: resolveDeferred }
+}
+
 describe('connectPanePty', () => {
   const originalRequestAnimationFrame = globalThis.requestAnimationFrame
   const originalCancelAnimationFrame = globalThis.cancelAnimationFrame
@@ -271,6 +279,56 @@ describe('connectPanePty', () => {
     expect(transport.sendInput).not.toHaveBeenCalledWith(
       expect.stringContaining("claude 'say test'")
     )
+  })
+
+  it('does not reuse a sibling split pane pending spawn after remount', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+
+    const mainSpawn = createDeferred<string>()
+    const setupSpawn = createDeferred<string>()
+
+    const mainTransport = createMockTransport()
+    mainTransport.connect.mockImplementation(async () => mainSpawn.promise)
+    const setupTransport = createMockTransport()
+    setupTransport.connect.mockImplementation(async () => setupSpawn.promise)
+    const remountTransport = createMockTransport()
+    transportFactoryQueue.push(mainTransport, setupTransport, remountTransport)
+
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: null }] },
+      repos: [{ id: 'repo1', connectionId: null }]
+    }
+
+    const sharedTransportsRef = { current: new Map() }
+    connectPanePty(
+      createPane(1) as never,
+      createManager(2) as never,
+      createDeps({ paneTransportsRef: sharedTransportsRef }) as never
+    )
+    connectPanePty(
+      createPane(2) as never,
+      createManager(2) as never,
+      createDeps({
+        startup: { command: 'bash setup-runner.sh' },
+        paneTransportsRef: sharedTransportsRef
+      }) as never
+    )
+
+    const remountDeps = createDeps()
+    connectPanePty(createPane(1) as never, createManager(2) as never, remountDeps as never)
+
+    setupSpawn.resolve('pty-setup')
+    mainSpawn.resolve('pty-main')
+    for (let i = 0; i < 20; i++) {
+      await Promise.resolve()
+    }
+
+    expect(remountTransport.attach).toHaveBeenCalledWith(
+      expect.objectContaining({ existingPtyId: 'pty-main' })
+    )
+    expect(remountDeps.syncPanePtyLayoutBinding).toHaveBeenCalledWith(1, 'pty-main')
+    expect(remountDeps.updateTabPtyId).toHaveBeenCalledWith('tab-1', 'pty-main')
   })
 
   it('drops xterm onData while pane is replaying restored bytes', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -18,7 +18,7 @@ import {
 } from './layout-serialization'
 import { warnTerminalLifecycleAnomaly } from './terminal-lifecycle-diagnostics'
 
-const pendingSpawnByTabId = new Map<string, Promise<string | null>>()
+const pendingSpawnByPaneKey = new Map<string, Promise<string | null>>()
 
 // Why: when multiple panes/tabs need the same deferred SSH connection,
 // the first one calls ssh.connect() and subsequent ones must wait for it
@@ -105,6 +105,7 @@ export function connectPanePty(
   // Why: cache timer state is keyed per-pane (not per-tab) so split-pane tabs
   // can track each Claude session independently without overwriting each other.
   const cacheKey = `${deps.tabId}:${pane.id}`
+  const pendingSpawnKey = `${deps.tabId}:${paneLeafId(pane.id)}`
 
   const onExit = (ptyId: string): void => {
     deps.syncPanePtyLayoutBinding(pane.id, null)
@@ -397,11 +398,13 @@ export function connectPanePty(
         )
         .catch(() => null)
         .finally(() => {
-          if (pendingSpawnByTabId.get(deps.tabId) === spawnPromise) {
-            pendingSpawnByTabId.delete(deps.tabId)
+          if (pendingSpawnByPaneKey.get(pendingSpawnKey) === spawnPromise) {
+            pendingSpawnByPaneKey.delete(pendingSpawnKey)
           }
         })
-      pendingSpawnByTabId.set(deps.tabId, spawnPromise)
+      // Why: split panes in the same tab can spawn concurrently. Key by pane
+      // as well as tab so a remount cannot attach to a sibling setup pane's PTY.
+      pendingSpawnByPaneKey.set(pendingSpawnKey, spawnPromise)
     }
 
     // Why: replay bytes (eager-buffer flush, attach-time screen clear) must
@@ -755,7 +758,7 @@ export function connectPanePty(
       allowInitialIdleCacheSeed = false
       const pendingSpawn = hasExistingPaneTransport
         ? undefined
-        : pendingSpawnByTabId.get(deps.tabId)
+        : pendingSpawnByPaneKey.get(pendingSpawnKey)
       if (pendingSpawn) {
         void pendingSpawn
           .then((spawnedPtyId) => {


### PR DESCRIPTION
## Summary
- key pending PTY spawn promises by terminal pane instead of only by tab
- prevent a remounted pane from attaching to a sibling split pane's in-flight setup/automation PTY
- add a regression test for main + setup split concurrent spawns followed by a remount

## Investigation notes
For the `new-tab-dismiss` repro, the daemon was healthy and listed live sessions for the saved pane PTYs (`b43f4f1a`, `b1e81803`, `e3b54e70`). The persisted terminal history also showed setup output, so this was not primarily a daemon-missing-session case.

The stronger signal was that the same worktree had an extra live setup-like PTY (`86a951d6`) with the same start timestamp as the saved setup pane, but that PTY was orphaned from the saved layout. That points at a renderer-side split/remount race where concurrent pane spawns in one tab can overwrite shared pending state.

## Why
`pendingSpawnByTabId` assumed only one pending spawn per terminal tab. Split terminal tabs violate that: the main pane, setup pane, and issue/automation pane can all spawn concurrently. If a pane remounts while multiple sibling spawns are in flight, it can pick up the wrong sibling's pending spawn. Keying by `tabId + leafId` keeps each pane attached to its own spawn.

## Test plan
- pnpm exec oxlint src/renderer/src/components/terminal-pane/pty-connection.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts --format github
- pnpm test src/renderer/src/components/terminal-pane/pty-connection.test.ts
- git diff --check