### PR TITLE
feat(linear): add create-issue button for feature parity with GitHub

### DIFF
--- a/src/main/ipc/linear.ts
+++ b/src/main/ipc/linear.ts
@@ -5,14 +5,12 @@ import {
   getIssue,
   searchIssues,
   listIssues,
+  createIssue,
   updateIssue,
   addIssueComment,
-  getIssueComments,
-  getTeamStates,
-  getTeamLabels,
-  getTeamMembers
+  getIssueComments
 } from '../linear/issues'
-import { listTeams } from '../linear/teams'
+import { listTeams, getTeamStates, getTeamLabels, getTeamMembers } from '../linear/teams'
 import type { LinearListFilter } from '../linear/issues'
 import type { LinearIssueUpdate } from '../../shared/types'
 
@@ -59,6 +57,23 @@ export function registerLinearHandlers(): void {
         : undefined
       const limit = Math.min(Math.max(1, args?.limit ?? 20), 50)
       return listIssues(filter, limit)
+    }
+  )
+
+  ipcMain.handle(
+    'linear:createIssue',
+    async (_event, args: { teamId: string; title: string; description?: string }) => {
+      if (typeof args?.teamId !== 'string' || !args.teamId.trim()) {
+        return { ok: false, error: 'Team ID is required' }
+      }
+      if (typeof args?.title !== 'string' || !args.title.trim()) {
+        return { ok: false, error: 'Title is required' }
+      }
+      return createIssue(
+        args.teamId.trim(),
+        args.title.trim(),
+        args.description?.trim() || undefined
+      )
     }
   )
 

--- a/src/main/linear/issues.ts
+++ b/src/main/linear/issues.ts
@@ -1,11 +1,4 @@
-import type {
-  LinearIssue,
-  LinearIssueUpdate,
-  LinearComment,
-  LinearWorkflowState,
-  LinearLabel,
-  LinearMember
-} from '../../shared/types'
+import type { LinearIssue, LinearIssueUpdate, LinearComment } from '../../shared/types'
 import { acquire, release, getClient, isAuthError, clearToken } from './client'
 import { mapLinearIssue } from './mappers'
 
@@ -120,6 +113,45 @@ export async function listIssues(
   }
 }
 
+export async function createIssue(
+  teamId: string,
+  title: string,
+  description?: string
+): Promise<
+  { ok: true; id: string; identifier: string; url: string } | { ok: false; error: string }
+> {
+  const client = getClient()
+  if (!client) {
+    return { ok: false, error: 'Not connected to Linear' }
+  }
+
+  await acquire()
+  try {
+    const result = await client.createIssue({
+      teamId,
+      title,
+      ...(description ? { description } : {})
+    })
+    if (!result.success) {
+      return { ok: false, error: 'Linear create failed' }
+    }
+    const issue = await result.issue
+    if (!issue) {
+      return { ok: false, error: 'Issue was created but could not be retrieved' }
+    }
+    return { ok: true, id: issue.id, identifier: issue.identifier, url: issue.url }
+  } catch (error) {
+    if (isAuthError(error)) {
+      clearToken()
+      throw error
+    }
+    const message = error instanceof Error ? error.message : String(error)
+    return { ok: false, error: message }
+  } finally {
+    release()
+  }
+}
+
 export async function updateIssue(
   id: string,
   updates: LinearIssueUpdate
@@ -229,87 +261,6 @@ export async function getIssueComments(issueId: string): Promise<LinearComment[]
       throw error
     }
     console.warn('[linear] getIssueComments failed:', error)
-    return []
-  } finally {
-    release()
-  }
-}
-
-export async function getTeamStates(teamId: string): Promise<LinearWorkflowState[]> {
-  const client = getClient()
-  if (!client) {
-    return []
-  }
-
-  await acquire()
-  try {
-    const team = await client.team(teamId)
-    const states = await team.states()
-    return states.nodes
-      .map((s) => ({
-        id: s.id,
-        name: s.name,
-        type: s.type,
-        color: s.color,
-        position: s.position
-      }))
-      .sort((a, b) => a.position - b.position)
-  } catch (error) {
-    if (isAuthError(error)) {
-      clearToken()
-      throw error
-    }
-    console.warn('[linear] getTeamStates failed:', error)
-    return []
-  } finally {
-    release()
-  }
-}
-
-export async function getTeamLabels(teamId: string): Promise<LinearLabel[]> {
-  const client = getClient()
-  if (!client) {
-    return []
-  }
-
-  await acquire()
-  try {
-    const team = await client.team(teamId)
-    const labels = await team.labels()
-    return labels.nodes.map((l) => ({ id: l.id, name: l.name, color: l.color }))
-  } catch (error) {
-    if (isAuthError(error)) {
-      clearToken()
-      throw error
-    }
-    console.warn('[linear] getTeamLabels failed:', error)
-    return []
-  } finally {
-    release()
-  }
-}
-
-export async function getTeamMembers(teamId: string): Promise<LinearMember[]> {
-  const client = getClient()
-  if (!client) {
-    return []
-  }
-
-  await acquire()
-  try {
-    const team = await client.team(teamId)
-    const members = await team.members()
-    return members.nodes.map((m) => ({
-      id: m.id,
-      displayName: m.displayName,
-      avatarUrl: m.avatarUrl ?? undefined
-    }))
-  } catch (error) {
-    if (isAuthError(error)) {
-      clearToken()
-      throw error
-    }
-    console.warn('[linear] getTeamMembers failed:', error)
     return []
   } finally {
     release()

--- a/src/main/linear/teams.ts
+++ b/src/main/linear/teams.ts
@@ -1,4 +1,4 @@
-import type { LinearTeam } from '../../shared/types'
+import type { LinearTeam, LinearWorkflowState, LinearLabel, LinearMember } from '../../shared/types'
 import { acquire, release, getClient, isAuthError, clearToken } from './client'
 
 export async function listTeams(): Promise<LinearTeam[]> {
@@ -19,6 +19,87 @@ export async function listTeams(): Promise<LinearTeam[]> {
       throw error
     }
     console.warn('[linear] listTeams failed:', error)
+    return []
+  } finally {
+    release()
+  }
+}
+
+export async function getTeamStates(teamId: string): Promise<LinearWorkflowState[]> {
+  const client = getClient()
+  if (!client) {
+    return []
+  }
+
+  await acquire()
+  try {
+    const team = await client.team(teamId)
+    const states = await team.states()
+    return states.nodes
+      .map((s) => ({
+        id: s.id,
+        name: s.name,
+        type: s.type,
+        color: s.color,
+        position: s.position
+      }))
+      .sort((a, b) => a.position - b.position)
+  } catch (error) {
+    if (isAuthError(error)) {
+      clearToken()
+      throw error
+    }
+    console.warn('[linear] getTeamStates failed:', error)
+    return []
+  } finally {
+    release()
+  }
+}
+
+export async function getTeamLabels(teamId: string): Promise<LinearLabel[]> {
+  const client = getClient()
+  if (!client) {
+    return []
+  }
+
+  await acquire()
+  try {
+    const team = await client.team(teamId)
+    const labels = await team.labels()
+    return labels.nodes.map((l) => ({ id: l.id, name: l.name, color: l.color }))
+  } catch (error) {
+    if (isAuthError(error)) {
+      clearToken()
+      throw error
+    }
+    console.warn('[linear] getTeamLabels failed:', error)
+    return []
+  } finally {
+    release()
+  }
+}
+
+export async function getTeamMembers(teamId: string): Promise<LinearMember[]> {
+  const client = getClient()
+  if (!client) {
+    return []
+  }
+
+  await acquire()
+  try {
+    const team = await client.team(teamId)
+    const members = await team.members()
+    return members.nodes.map((m) => ({
+      id: m.id,
+      displayName: m.displayName,
+      avatarUrl: m.avatarUrl ?? undefined
+    }))
+  } catch (error) {
+    if (isAuthError(error)) {
+      clearToken()
+      throw error
+    }
+    console.warn('[linear] getTeamMembers failed:', error)
     return []
   } finally {
     release()

--- a/src/preload/api-types.d.ts
+++ b/src/preload/api-types.d.ts
@@ -466,6 +466,13 @@ export type PreloadApi = {
       filter?: 'assigned' | 'created' | 'all' | 'completed'
       limit?: number
     }) => Promise<LinearIssue[]>
+    createIssue: (args: {
+      teamId: string
+      title: string
+      description?: string
+    }) => Promise<
+      { ok: true; id: string; identifier: string; url: string } | { ok: false; error: string }
+    >
     getIssue: (args: { id: string }) => Promise<LinearIssue | null>
     updateIssue: (args: {
       id: string

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -494,6 +494,14 @@ const api = {
       limit?: number
     }): Promise<unknown[]> => ipcRenderer.invoke('linear:listIssues', args),
 
+    createIssue: (args: {
+      teamId: string
+      title: string
+      description?: string
+    }): Promise<
+      { ok: true; id: string; identifier: string; url: string } | { ok: false; error: string }
+    > => ipcRenderer.invoke('linear:createIssue', args),
+
     getIssue: (args: { id: string }): Promise<unknown> =>
       ipcRenderer.invoke('linear:getIssue', args),
 

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -904,6 +904,18 @@ export default function TaskPage(): React.JSX.Element {
     () => linearIssues.filter((issue) => linearTeamSelection.has(issue.team.id)),
     [linearIssues, linearTeamSelection]
   )
+  // New Linear issue dialog state
+  const [newLinearIssueOpen, setNewLinearIssueOpen] = useState(false)
+  const [newLinearIssueTitle, setNewLinearIssueTitle] = useState('')
+  const [newLinearIssueBody, setNewLinearIssueBody] = useState('')
+  const [newLinearIssueTeamId, setNewLinearIssueTeamId] = useState<string | null>(null)
+  const [newLinearIssueSubmitting, setNewLinearIssueSubmitting] = useState(false)
+
+  const newLinearIssueTargetTeam = useMemo(
+    () => availableTeams.find((t) => t.id === newLinearIssueTeamId) ?? availableTeams[0] ?? null,
+    [availableTeams, newLinearIssueTeamId]
+  )
+
   const [linearConnectOpen, setLinearConnectOpen] = useState(false)
   const [linearApiKeyDraft, setLinearApiKeyDraft] = useState('')
   const [linearConnectState, setLinearConnectState] = useState<'idle' | 'connecting' | 'error'>(
@@ -1256,9 +1268,68 @@ export default function TaskPage(): React.JSX.Element {
     }
   }, [newIssueBody, newIssueSubmitting, newIssueTargetRepo, newIssueTitle, setDrawerWorkItem])
 
+  const handleCreateNewLinearIssue = useCallback(async (): Promise<void> => {
+    if (!newLinearIssueTargetTeam) {
+      return
+    }
+    const title = newLinearIssueTitle.trim()
+    if (!title || newLinearIssueSubmitting) {
+      return
+    }
+    setNewLinearIssueSubmitting(true)
+    try {
+      const result = await window.api.linear.createIssue({
+        teamId: newLinearIssueTargetTeam.id,
+        title,
+        description: newLinearIssueBody || undefined
+      })
+      if (!result.ok) {
+        toast.error(result.error || 'Failed to create issue.')
+        return
+      }
+      toast.success(`Created ${result.identifier}`, {
+        action: result.url
+          ? {
+              label: 'View',
+              onClick: () => window.open(result.url, '_blank')
+            }
+          : undefined
+      })
+      setNewLinearIssueOpen(false)
+      setNewLinearIssueTitle('')
+      setNewLinearIssueBody('')
+      setLinearRefreshNonce((n) => n + 1)
+
+      // Why: auto-open the new issue in the side drawer so the user sees
+      // exactly what was filed, mirroring the GitHub create-issue flow.
+      void window.api.linear
+        .getIssue({ id: result.id })
+        .then((full) => {
+          if (full) {
+            setDrawerLinearIssue(full)
+          }
+        })
+        .catch(() => {})
+    } finally {
+      setNewLinearIssueSubmitting(false)
+    }
+  }, [
+    newLinearIssueBody,
+    newLinearIssueSubmitting,
+    newLinearIssueTargetTeam,
+    newLinearIssueTitle,
+    setDrawerLinearIssue
+  ])
+
   useEffect(() => {
     // Why: when a modal is open, let it own Esc dismissal.
-    if (drawerWorkItem || drawerLinearIssue || newIssueOpen || activeModal !== 'none') {
+    if (
+      drawerWorkItem ||
+      drawerLinearIssue ||
+      newIssueOpen ||
+      newLinearIssueOpen ||
+      activeModal !== 'none'
+    ) {
       return
     }
 
@@ -1292,7 +1363,14 @@ export default function TaskPage(): React.JSX.Element {
 
     window.addEventListener('keydown', onKeyDown, { capture: true })
     return () => window.removeEventListener('keydown', onKeyDown, { capture: true })
-  }, [activeModal, closeTaskPage, drawerLinearIssue, drawerWorkItem, newIssueOpen])
+  }, [
+    activeModal,
+    closeTaskPage,
+    drawerLinearIssue,
+    drawerWorkItem,
+    newIssueOpen,
+    newLinearIssueOpen
+  ])
 
   // Why: check Linear connection status on mount so the UI can show the
   // correct connected/disconnected state without requiring a settings visit.
@@ -1727,27 +1805,51 @@ export default function TaskPage(): React.JSX.Element {
                           )
                         })}
                       </div>
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <Button
-                            variant="outline"
-                            size="icon"
-                            onClick={() => setLinearRefreshNonce((n) => n + 1)}
-                            disabled={linearLoading}
-                            aria-label="Refresh Linear issues"
-                            className="border-border/50 bg-transparent hover:bg-muted/50 backdrop-blur-md supports-[backdrop-filter]:bg-transparent"
-                          >
-                            {linearLoading ? (
-                              <LoaderCircle className="size-4 animate-spin" />
-                            ) : (
-                              <RefreshCw className="size-4" />
-                            )}
-                          </Button>
-                        </TooltipTrigger>
-                        <TooltipContent side="bottom" sideOffset={6}>
-                          Refresh Linear issues
-                        </TooltipContent>
-                      </Tooltip>
+                      <div className="flex shrink-0 items-center gap-2">
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Button
+                              variant="outline"
+                              size="icon"
+                              onClick={() => {
+                                setNewLinearIssueTitle('')
+                                setNewLinearIssueBody('')
+                                setNewLinearIssueTeamId(availableTeams[0]?.id ?? null)
+                                setNewLinearIssueOpen(true)
+                              }}
+                              disabled={availableTeams.length === 0}
+                              aria-label="New Linear issue"
+                              className="border-border/50 bg-transparent hover:bg-muted/50 backdrop-blur-md supports-[backdrop-filter]:bg-transparent"
+                            >
+                              <Plus className="size-4" />
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent side="bottom" sideOffset={6}>
+                            New Linear issue
+                          </TooltipContent>
+                        </Tooltip>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Button
+                              variant="outline"
+                              size="icon"
+                              onClick={() => setLinearRefreshNonce((n) => n + 1)}
+                              disabled={linearLoading}
+                              aria-label="Refresh Linear issues"
+                              className="border-border/50 bg-transparent hover:bg-muted/50 backdrop-blur-md supports-[backdrop-filter]:bg-transparent"
+                            >
+                              {linearLoading ? (
+                                <LoaderCircle className="size-4 animate-spin" />
+                              ) : (
+                                <RefreshCw className="size-4" />
+                              )}
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent side="bottom" sideOffset={6}>
+                            Refresh Linear issues
+                          </TooltipContent>
+                        </Tooltip>
+                      </div>
                     </div>
                     <div className="mt-3 flex items-center gap-3">
                       <div className="relative min-w-[320px] flex-1">
@@ -2313,6 +2415,111 @@ export default function TaskPage(): React.JSX.Element {
               disabled={!newIssueTargetRepo || !newIssueTitle.trim() || newIssueSubmitting}
             >
               {newIssueSubmitting ? (
+                <>
+                  <LoaderCircle className="size-4 animate-spin" />
+                  Creating…
+                </>
+              ) : (
+                'Create issue'
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={newLinearIssueOpen}
+        onOpenChange={(open) => {
+          if (!newLinearIssueSubmitting) {
+            setNewLinearIssueOpen(open)
+          }
+        }}
+      >
+        <DialogContent
+          className="sm:max-w-lg"
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
+              event.preventDefault()
+              void handleCreateNewLinearIssue()
+            }
+          }}
+        >
+          <DialogHeader>
+            <DialogTitle>New Linear issue</DialogTitle>
+            <DialogDescription>
+              {availableTeams.length > 1
+                ? 'Creates a new issue in the selected team.'
+                : `Creates a new issue in ${newLinearIssueTargetTeam?.name ?? 'your team'}.`}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex flex-col gap-3">
+            {availableTeams.length > 1 ? (
+              <div className="flex flex-col gap-1">
+                <label className="text-[11px] font-medium text-muted-foreground">Team</label>
+                <Select
+                  value={newLinearIssueTeamId ?? undefined}
+                  onValueChange={(v) => setNewLinearIssueTeamId(v)}
+                  disabled={newLinearIssueSubmitting}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {availableTeams.map((t) => (
+                      <SelectItem key={t.id} value={t.id}>
+                        {t.key} — {t.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            ) : null}
+            <div className="flex flex-col gap-1">
+              <label className="text-[11px] font-medium text-muted-foreground">Title</label>
+              <Input
+                autoFocus
+                value={newLinearIssueTitle}
+                onChange={(e) => setNewLinearIssueTitle(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
+                    e.preventDefault()
+                    void handleCreateNewLinearIssue()
+                  }
+                }}
+                placeholder="Short summary"
+                disabled={newLinearIssueSubmitting}
+              />
+            </div>
+            <div className="flex flex-col gap-1">
+              <label className="text-[11px] font-medium text-muted-foreground">
+                Description (optional, markdown)
+              </label>
+              <textarea
+                value={newLinearIssueBody}
+                onChange={(e) => setNewLinearIssueBody(e.target.value)}
+                placeholder="What's going on?"
+                rows={6}
+                disabled={newLinearIssueSubmitting}
+                className="w-full min-w-0 rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs transition-[color,box-shadow] outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 resize-none max-h-60 overflow-y-auto"
+              />
+            </div>
+            <p className="text-[10px] text-muted-foreground">Cmd/Ctrl+Enter to submit.</p>
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setNewLinearIssueOpen(false)}
+              disabled={newLinearIssueSubmitting}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={() => void handleCreateNewLinearIssue()}
+              disabled={
+                !newLinearIssueTargetTeam || !newLinearIssueTitle.trim() || newLinearIssueSubmitting
+              }
+            >
+              {newLinearIssueSubmitting ? (
                 <>
                   <LoaderCircle className="size-4 animate-spin" />
                   Creating…


### PR DESCRIPTION
## Summary
- Adds a "+" button to the Linear issues toolbar, mirroring the existing GitHub create-issue flow
- Opens a dialog with team selector (when multiple teams), title, description fields, and Cmd/Ctrl+Enter shortcut
- On success: shows toast, refreshes the issue list, and auto-opens the new issue in the side drawer
- Moves `getTeamStates`/`getTeamLabels`/`getTeamMembers` from `issues.ts` → `teams.ts` to stay under the max-lines lint threshold

## Changes
- **`src/main/linear/issues.ts`** — New `createIssue(teamId, title, description?)` using the Linear SDK
- **`src/main/linear/teams.ts`** — Receives relocated team-metadata functions
- **`src/main/ipc/linear.ts`** — New `linear:createIssue` IPC handler with input validation
- **`src/preload/index.ts`** + **`api-types.d.ts`** — Preload bridge + types for `createIssue`
- **`src/renderer/src/components/TaskPage.tsx`** — UI: state, "+" button, dialog, submit handler, Esc guard

## Test plan
- [ ] Connect to Linear, verify the "+" button appears in the Linear toolbar
- [ ] Click "+", verify dialog opens with team selector (if multiple teams) or single-team description
- [ ] Create an issue with title only — verify toast, list refresh, and drawer auto-open
- [ ] Create an issue with title + description — verify description appears in Linear
- [ ] Try submitting with empty title — verify button is disabled
- [ ] Verify Cmd/Ctrl+Enter submits from the dialog
- [ ] Verify Esc closes the dialog (and doesn't close the task page)
- [ ] Disconnect from Linear, verify "+" button is not shown
- [ ] Verify GitHub "+" button still works as before

Made with [Orca](https://github.com/stablyai/orca) 🐋
