### PR TITLE
fix(release): derive prerelease state from tag shape, not release flag

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -92,16 +92,28 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Latest published stable release (excludes drafts + prereleases).
+          # Latest stable release tag, picked by *tag shape* (no `-rc.`)
+          # rather than the GitHub `isPrerelease` flag. electron-builder's
+          # publish step has flipped that flag back to `false` on RC
+          # releases in the past (issue surfaced 2026-04-27 when
+          # v1.3.22-rc.2 became "latest" on GitHub and poisoned the
+          # compute-next-version math here). Filtering by tag format is
+          # the authoritative signal — an `-rc.N` tag is never stable,
+          # regardless of what the release metadata says.
           latest_stable="$(gh release list \
               --repo "$GITHUB_REPOSITORY" \
               --exclude-drafts \
-              --exclude-pre-releases \
-              --limit 1 \
+              --limit 50 \
               --json tagName \
-              --jq '.[0].tagName // ""')"
+              --jq '[.[] | .tagName | select(test("-rc\\.") | not)] | .[0] // ""')"
           latest_stable="${latest_stable#v}"
           echo "Latest stable: ${latest_stable:-<none>}"
+
+          # Strip any prerelease suffix before numeric math. Without this,
+          # `Number("1-rc")` returns NaN and `(NaN||0)+1` silently collapses
+          # to 1 — exactly the path that produced v1.3.1-rc.4 on 2026-04-27
+          # when latest_stable was misread as a prerelease tag.
+          strip_pre() { echo "${1%%-*}"; }
 
           semver_gt() {
             # returns 0 if $1 > $2 by semver rules (ignoring prerelease)
@@ -113,7 +125,7 @@ jobs:
                 if ((a[i]||0) < (b[i]||0)) process.exit(1);
               }
               process.exit(1);
-            ' "$1" "$2"
+            ' "$(strip_pre "$1")" "$(strip_pre "$2")"
           }
 
           bump() {
@@ -124,7 +136,7 @@ jobs:
               if (level === "major") console.log(`${(v[0]||0)+1}.0.0`);
               else if (level === "minor") console.log(`${v[0]||0}.${(v[1]||0)+1}.0`);
               else console.log(`${v[0]||0}.${v[1]||0}.${(v[2]||0)+1}`);
-            ' "$1" "$2"
+            ' "$(strip_pre "$1")" "$2"
           }
 
           next_rc_in_series() {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -209,6 +209,24 @@ jobs:
       contents: write
     steps:
       - name: Publish release
-        run: gh release edit "${{ needs.resolve-release.outputs.tag }}" --draft=false --repo "${{ github.repository }}"
+        # Why: derive `--prerelease` from the tag shape (not from whatever
+        # electron-builder left the release flagged as). On 2026-04-27,
+        # electron-builder's publish step flipped `prerelease` back to
+        # `false` on -rc.N releases, which caused an RC to be marked as
+        # GitHub's "latest" release and broke release-cut.yml's math.
+        # Re-asserting here means the final release state is determined
+        # by the tag — a ground truth electron-builder can't rewrite.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.resolve-release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          if [[ "$TAG" == *"-rc."* ]]; then
+            prerelease=true
+          else
+            prerelease=false
+          fi
+          gh release edit "$TAG" \
+            --draft=false \
+            --prerelease="$prerelease" \
+            --repo "$GITHUB_REPOSITORY"


### PR DESCRIPTION
## Summary

Two interacting bugs produced `v1.3.1-rc.4` as a \"latest\" release today. Full breakdown in the commit message; the gist:

- **release-cut.yml** trusted the GitHub `isPrerelease` flag to find latest stable. That flag had been flipped to `false` on RC releases, so the query returned an RC tag, and `bump()` then mis-parsed the suffix via `Number(\"1-rc\") = NaN`, collapsing the result to `1.3.1`.
- **release.yml's publish step** only ran `--draft=false`, so whatever state the `prerelease` flag was left in by electron-builder became final — which is how RCs were getting marked as stable in the first place.

## Changes

- `release-cut.yml`: filter latest stable by tag shape (no `-rc.`) via jq. Strip prerelease suffix in `bump()` and `semver_gt()` so the math is robust to dirty inputs.
- `release.yml`: re-assert `--prerelease=<derived from tag>` in the publish step so the final release state is a function of the tag name, not of intermediate publisher behavior.

## Test plan

- [ ] After merge, cut a fresh `rc` — should produce `v1.3.22-rc.3` (given `latest_stable=1.3.21` and existing `v1.3.22-rc.0..2` tags).
- [ ] Confirm the release is marked as `prerelease: true` and does NOT become `isLatest: true`.
- [ ] Cut a `patch` and confirm it is marked `prerelease: false` and gets `isLatest: true` once published.

## Cleanup (separate, manual)

The following releases were mislabeled as stable and need to be flipped back to prerelease so `isLatest` lands on `v1.3.21` until a new stable ships: `v1.3.1-rc.3`, `v1.3.1-rc.4`, `v1.3.22-rc.2`. I'll do this right after merging.

Made with [Orca](https://github.com/stablyai/orca) 🐋
