### PR TITLE
fix(new-workspace): unwrap getBaseRefDefault envelope in StartFromField

### DIFF
--- a/src/renderer/src/components/new-workspace/StartFromField.tsx
+++ b/src/renderer/src/components/new-workspace/StartFromField.tsx
@@ -42,9 +42,11 @@ export default function StartFromField({
     setDefaultBaseRef(null)
     void window.api.repos
       .getBaseRefDefault({ repoId })
-      .then((ref) => {
+      .then((result) => {
         if (!stale) {
-          setDefaultBaseRef(ref)
+          // Why: IPC returns a `{ defaultBaseRef, remoteCount }` envelope;
+          // this component only needs `defaultBaseRef` for the trigger label.
+          setDefaultBaseRef(result.defaultBaseRef)
         }
       })
       .catch(() => {


### PR DESCRIPTION
## Summary
- Clicking **Create Worktree** crashed the dialog with `Uncaught Error: Minified React error #31` (`object with keys {defaultBaseRef, remoteCount}`).
- #1186 changed `repos:getBaseRefDefault` to return `{ defaultBaseRef, remoteCount }` and updated `SourceControl.tsx` / `BaseRefPicker.tsx`, but missed `StartFromField.tsx` (added in #1078). The component still stored the whole envelope into `useState<string | null>` and rendered it as a JSX child.
- Extract `result.defaultBaseRef` like the other two call sites already do.

## Test plan
- [ ] Open a repo and click **Create Worktree** — dialog opens without a React crash.
- [ ] The "Start from" trigger shows the concrete default branch name (e.g. `origin/main`) with the `(default)` suffix.
- [ ] Switching repos updates the displayed default ref.