### PR TITLE
fix(terminal): restore cursor visibility after scrollback replay

### DIFF
--- a/src/renderer/src/components/terminal-pane/layout-serialization.ts
+++ b/src/renderer/src/components/terminal-pane/layout-serialization.ts
@@ -24,11 +24,15 @@ export const EMPTY_LAYOUT: TerminalLayoutSnapshot = {
 // so replayed mode bits do not leak into the fresh shell. ghostty achieves
 // the same end by not restoring state at all.
 //
+//   25                  — DECTCEM cursor visibility (SerializeAddon captures
+//                         `?25l` when the cursor was hidden at snapshot time;
+//                         without an explicit `?25h` here the cursor stays
+//                         invisible in the restored terminal)
 //   1000/1002/1003/1006 — mouse reporting variants
 //   1004                — focus event reporting (the actual bug source)
 //   2004                — bracketed paste
 export const POST_REPLAY_MODE_RESET =
-  '\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1004l\x1b[?1006l\x1b[?2004l'
+  '\x1b[?25h\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1004l\x1b[?1006l\x1b[?2004l'
 
 // Why: daemon snapshot restore reattaches to a live session, so we avoid the
 // full POST_REPLAY_MODE_RESET bundle there — a still-running TUI may still


### PR DESCRIPTION
## Summary
- xterm's `SerializeAddon` captures `?25l` (DECTCEM cursor hide) when the cursor was hidden at snapshot time (e.g. a TUI like vim, less, or Claude Code was running at shutdown)
- On restore, the serialized buffer replays that escape into xterm, leaving the cursor invisible even though the underlying shell is fresh
- Added `\x1b[?25h` to **both** `POST_REPLAY_MODE_RESET` (scrollback/cold-restore) and `POST_REPLAY_FOCUS_REPORTING_RESET` (daemon snapshot reattach) to cover all restore paths
- For live sessions, if a TUI wants the cursor hidden, the SIGWINCH sent immediately after restore triggers a repaint that re-hides it — a brief flash that is far less harmful than a permanently invisible cursor

## Test plan
- [ ] Open a terminal, run `vim` (which hides the cursor on exit in some configs), then quit the app
- [ ] Relaunch — the restored terminal should have a visible cursor
- [ ] Verify daemon reattach (live session with stale daemon) restores cursor visibility
- [ ] Verify a running TUI (e.g. vim) still hides cursor correctly after reattach
- [ ] Verify existing e2e test `terminal-attention.spec.ts` still passes
- [ ] Verify `pty-connection.test.ts` passes (20/20)