### PR TITLE
test(e2e): assert on rendered DOM in 5 specs previously store-tautologies

### DIFF
--- a/src/renderer/src/components/tab-bar/SortableTab.tsx
+++ b/src/renderer/src/components/tab-bar/SortableTab.tsx
@@ -171,6 +171,12 @@ export default function SortableTab({
           data-testid="sortable-tab"
           data-tab-id={tab.id}
           data-tab-title={tab.customTitle ?? tab.title}
+          // Why: expose the active/inactive flag as a DOM attribute so E2E specs
+          // can assert on user-observable selection state without reading the
+          // Zustand store. A store-only "is this tab active?" round-trip would
+          // pass even if the tab-bar render path had silently broken (the same
+          // tautology that let PR #1186's render crash ship past E2E in #1193).
+          data-active={isActive ? 'true' : 'false'}
           {...attributes}
           {...dragListeners}
           // Why: on unread activity, tint the whole tab with a subtle amber
@@ -329,6 +335,12 @@ export default function SortableTab({
                   ? 'text-muted-foreground hover:text-foreground hover:bg-muted'
                   : 'text-transparent group-hover:text-muted-foreground hover:!text-foreground hover:!bg-muted'
               }`}
+              // Why: per-tab close affordance needs a stable accessible name so
+              // E2E specs can drive the same path a user takes (hover → click X)
+              // instead of bypassing the render layer by calling closeTab() on
+              // the store — a store-only assertion would pass even if this
+              // button had been accidentally unmounted.
+              aria-label={`Close tab ${tab.customTitle ?? tab.title}`}
               onPointerDown={(e) => e.stopPropagation()}
               onClick={(e) => {
                 e.stopPropagation()

--- a/src/renderer/src/components/tab-bar/TabBar.tsx
+++ b/src/renderer/src/components/tab-bar/TabBar.tsx
@@ -456,6 +456,11 @@ function TabBarInner({
             className="ml-2 my-auto flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent/50 hover:text-foreground"
             style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
             title="New tab"
+            // Why: aria-label matches the tooltip so E2E can locate the "+"
+            // affordance via getByRole('button', { name: 'New tab' }). The
+            // store-only createTab() round-trip that preceded this was a
+            // tautology — it would pass even if the + button had been deleted.
+            aria-label="New tab"
           >
             <Plus className="w-3.5 h-3.5" />
           </button>

--- a/tests/e2e/file-open.spec.ts
+++ b/tests/e2e/file-open.spec.ts
@@ -68,18 +68,12 @@ test.describe('File Open & Markdown Preview', () => {
   test('opening the right sidebar shows file explorer', async ({ orcaPage }) => {
     await openFileExplorer(orcaPage)
 
-    // Verify the right sidebar is open and on the explorer tab
-    await expect
-      .poll(async () => orcaPage.evaluate(() => window.__store?.getState().rightSidebarOpen), {
-        timeout: 3_000
-      })
-      .toBe(true)
-
-    await expect
-      .poll(async () => orcaPage.evaluate(() => window.__store?.getState().rightSidebarTab), {
-        timeout: 3_000
-      })
-      .toBe('explorer')
+    // Why: the load-bearing check is that `FileExplorer` actually mounted.
+    // `data-orca-explorer-shell` is the stable marker the component renders
+    // on its root shell div — a store-only `rightSidebarTab === 'explorer'`
+    // check would pass even if the explorer crashed on mount and the panel
+    // painted empty.
+    await expect(orcaPage.locator('[data-orca-explorer-shell]')).toBeVisible({ timeout: 5_000 })
   })
 
   /**
@@ -108,6 +102,20 @@ test.describe('File Open & Markdown Preview', () => {
     await expect
       .poll(async () => (await getOpenFiles(orcaPage, worktreeId)).length, { timeout: 5_000 })
       .toBeGreaterThan(filesBefore.length)
+
+    // Why: the load-bearing check is that the editor panel actually rendered
+    // the opened file. `.editor-header-path` is emitted by EditorPanel's
+    // header row and contains the file's full absolute path (which ends in
+    // the clicked file's name); a store-only `activeTabType === 'editor'`
+    // check would pass even if EditorPanel crashed on mount and the surface
+    // is blank. Timeout is generous (20s) because EditorPanel is lazy-loaded
+    // the first time the editor opens in a session — headless Electron runs
+    // routinely take 10s+ to hydrate that chunk plus the inner Monaco/Rich
+    // Markdown chunks, during which the outer Suspense shows "Loading
+    // editor…" and `.editor-header-path` is not yet in the DOM.
+    await expect(orcaPage.locator('.editor-header-path').first()).toContainText(clickedFile!, {
+      timeout: 20_000
+    })
   })
 
   /**
@@ -132,8 +140,15 @@ test.describe('File Open & Markdown Preview', () => {
     const expectedHeading = clickedFile?.endsWith('README.md')
       ? /Orca E2E Test Repo/i
       : /CLAUDE\.md/i
+    // Why 25s: first-time markdown open in a headless Electron session waits
+    // on two lazy chunks (EditorPanel → RichMarkdownEditor) plus ProseMirror
+    // boot + file read. Real-run traces show the heading reliably paints
+    // within ~10-15s but with enough variance that a 15s bound flakes. The
+    // user-facing guarantee is just "the rich markdown surface eventually
+    // paints the file's first heading" — giving it 25s keeps the assertion
+    // meaningful without turning every run into a flake risk.
     await expect(orcaPage.getByRole('heading', { name: expectedHeading, level: 1 })).toBeVisible({
-      timeout: 15_000
+      timeout: 25_000
     })
   })
 

--- a/tests/e2e/file-open.spec.ts
+++ b/tests/e2e/file-open.spec.ts
@@ -122,31 +122,19 @@ test.describe('File Open & Markdown Preview', () => {
     // Wait for the editor tab to become active
     await expect.poll(async () => getActiveTabType(orcaPage), { timeout: 5_000 }).toBe('editor')
 
-    await expect
-      .poll(
-        async () =>
-          orcaPage.evaluate(() => {
-            const store = window.__store
-            if (!store) {
-              return false
-            }
-
-            const state = store.getState()
-            const activeFile = state.openFiles.find((file) => file.id === state.activeFileId)
-            if (!activeFile || !activeFile.relativePath.endsWith('.md')) {
-              return false
-            }
-
-            // Why: markdown files default to the rendered "rich" mode in
-            // EditorPanel. Hidden Electron windows do not make the rendered DOM
-            // surface a reliable assertion target, so confirm the editor state
-            // chose the markdown view mode instead of falling back to a plain
-            // non-markdown tab.
-            return (state.markdownViewMode[activeFile.id] ?? 'rich') === 'rich'
-          }),
-        { timeout: 15_000, message: 'Markdown file did not enter rich markdown mode' }
-      )
-      .toBe(true)
+    // The seeded README.md starts with `# Orca E2E Test Repo`, so the rich
+    // markdown editor should render a real <h1> with that text. Asserting on
+    // the rendered heading (not `markdownViewMode` in the store) is the whole
+    // point of this spec — a store-only check passes even if
+    // RichMarkdownEditor failed to mount and the editor surface is blank.
+    // Fall back to CLAUDE.md's first heading when that file was opened
+    // instead: the seeded `CLAUDE.md` starts with `# CLAUDE.md`.
+    const expectedHeading = clickedFile?.endsWith('README.md')
+      ? /Orca E2E Test Repo/i
+      : /CLAUDE\.md/i
+    await expect(orcaPage.getByRole('heading', { name: expectedHeading, level: 1 })).toBeVisible({
+      timeout: 15_000
+    })
   })
 
   /**

--- a/tests/e2e/tab-rename.spec.ts
+++ b/tests/e2e/tab-rename.spec.ts
@@ -124,6 +124,12 @@ test.describe('Tab Rename (Inline)', () => {
     await renameInput.press('Escape')
 
     await expect(renameInput).toBeHidden()
+    // Why: the final assertion must be on user-observable DOM, not the store's
+    // customTitle field. A render-layer bug where the tab silently paints the
+    // in-progress "Should Be Discarded" text would leave customTitle null
+    // (Escape cleared it) yet flash the discarded label to the user — the
+    // original title must still be the one rendered on the tab.
+    await expect(tabLocatorByTitle(orcaPage, originalTitle)).toBeVisible()
     await expect
       .poll(async () => getActiveCustomTitle(orcaPage, worktreeId), { timeout: 3_000 })
       .toBe(null)
@@ -131,6 +137,13 @@ test.describe('Tab Rename (Inline)', () => {
 
   test('renaming to an empty string resets the tab to its default title', async ({ orcaPage }) => {
     const worktreeId = (await getActiveWorktreeId(orcaPage))!
+
+    // Snapshot the default (non-custom) title first so the DOM assertion later
+    // can verify the tab reverts to *this exact* rendered text — a store-only
+    // `customTitle === null` check would pass even if the rendered label was
+    // stuck on "Seeded Custom".
+    const defaultTitle = await getActiveTabTitle(orcaPage, worktreeId)
+    expect(defaultTitle.length).toBeGreaterThan(0)
 
     // Why: seed a custom title directly via the store so this test asserts the
     // "empty string → reset" behavior independently from the double-click flow.
@@ -163,6 +176,9 @@ test.describe('Tab Rename (Inline)', () => {
     await renameInput.fill('')
     await renameInput.press('Enter')
 
+    // User-observable DOM assertion: the tab element must re-render with the
+    // original default title, not the "Seeded Custom" override.
+    await expect(tabLocatorByTitle(orcaPage, defaultTitle)).toBeVisible()
     await expect
       .poll(async () => getActiveCustomTitle(orcaPage, worktreeId), { timeout: 3_000 })
       .toBe(null)

--- a/tests/e2e/tab-rename.spec.ts
+++ b/tests/e2e/tab-rename.spec.ts
@@ -50,7 +50,7 @@ test.describe('Tab Rename (Inline)', () => {
     expect(tab).toBeDefined()
     // Why: mirror what the UI renders (customTitle ?? title) so locators that
     // key off the tab's visible text match what's actually on screen.
-    return tab!.title ?? ''
+    return tab!.customTitle ?? tab!.title ?? ''
   }
 
   function tabLocatorByTitle(

--- a/tests/e2e/tabs.spec.ts
+++ b/tests/e2e/tabs.spec.ts
@@ -6,9 +6,20 @@
  * - dragging tabs around to reorder them
  * - closing tabs works
  * - double-click a tab to rename it inline
+ *
+ * Why these specs assert on the DOM: a prior version of this file drove every
+ * flow through `window.__store` and read the same fields back — a tautology
+ * that would have passed even if the tab bar had stopped rendering (the same
+ * pattern that let PR #1186's `StartFromField` render crash ship past the
+ * E2E suite in #1193). The rule in tests/e2e/AGENTS.md is that the final
+ * `expect()` must target user-observable DOM. Store calls are only used here
+ * for *setup* (e.g. to guarantee >= N tabs exist) or when the real user-facing
+ * action genuinely can't be driven via DOM in hidden-window Electron runs
+ * (dnd-kit reorder); in those cases a DOM assertion still follows.
  */
 
 import { test, expect } from './helpers/orca-app'
+import type { Page } from '@stablyai/playwright-test'
 import {
   waitForSessionReady,
   waitForActiveWorktree,
@@ -20,57 +31,28 @@ import {
   ensureTerminalVisible
 } from './helpers/store'
 
-async function createTerminalTab(
-  page: Parameters<typeof getActiveWorktreeId>[0],
-  worktreeId: string
-): Promise<void> {
-  await page.evaluate((targetWorktreeId) => {
-    const store = window.__store
-    if (!store) {
-      return
-    }
+const SORTABLE_TAB = '[data-testid="sortable-tab"]'
 
-    const state = store.getState()
-    const newTab = state.createTab(targetWorktreeId)
-    state.setActiveTabType('terminal')
-    const tabs = state.tabsByWorktree[targetWorktreeId] ?? []
-    state.setTabBarOrder(
-      targetWorktreeId,
-      tabs
-        .map((tab) => (tab.id === newTab.id ? null : tab.id))
-        .filter(Boolean)
-        .concat(newTab.id)
-    )
-  }, worktreeId)
+function tabLocator(page: Page, tabId: string) {
+  return page.locator(`${SORTABLE_TAB}[data-tab-id="${tabId}"]`).first()
 }
 
-async function closeActiveTerminalTab(
-  page: Parameters<typeof getActiveWorktreeId>[0],
-  worktreeId: string
-): Promise<void> {
-  await page.evaluate((targetWorktreeId) => {
-    const store = window.__store
-    if (!store) {
-      return
-    }
+/** Count rendered tabs in the tab bar (user-visible, not store-level). */
+async function countRenderedTabs(page: Page): Promise<number> {
+  return page.locator(SORTABLE_TAB).count()
+}
 
-    const state = store.getState()
-    const currentTabs = state.tabsByWorktree[targetWorktreeId] ?? []
-    const activeTabId = state.activeTabIdByWorktree[targetWorktreeId] ?? state.activeTabId
-    if (!activeTabId) {
-      return
-    }
-
-    if (currentTabs.length > 1) {
-      const currentIndex = currentTabs.findIndex((tab) => tab.id === activeTabId)
-      const nextTab = currentTabs[currentIndex + 1] ?? currentTabs[currentIndex - 1]
-      if (nextTab) {
-        state.setActiveTab(nextTab.id)
-      }
-    }
-
-    state.closeTab(activeTabId)
-  }, worktreeId)
+/**
+ * Read the DOM's active-tab id from the `data-active` attribute exposed by
+ * SortableTab. We assert on DOM rather than `activeTabId` in the store so a
+ * render-layer regression (e.g. the active indicator failing to paint on the
+ * correct tab) cannot silently pass.
+ */
+async function getDomActiveTabId(page: Page): Promise<string | null> {
+  return page.evaluate((selector) => {
+    const match = document.querySelector(`${selector}[data-active="true"]`)
+    return match?.getAttribute('data-tab-id') ?? null
+  }, SORTABLE_TAB)
 }
 
 test.describe('Tabs', () => {
@@ -83,17 +65,31 @@ test.describe('Tabs', () => {
   /**
    * User Prompt:
    * - New tab works
+   *
+   * Why: asserting on a new `[data-testid="sortable-tab"]` in the DOM (not
+   * `tabsByWorktree.length` in the store) is the guard that would have caught
+   * a tab-bar render regression. Clicking the real "+" button and then "New
+   * Terminal" drives the same code path a user takes.
    */
   test('clicking "+" then "New Terminal" creates a new terminal tab', async ({ orcaPage }) => {
-    const worktreeId = (await getActiveWorktreeId(orcaPage))!
-    const tabsBefore = await getWorktreeTabs(orcaPage, worktreeId)
+    const tabsBefore = await countRenderedTabs(orcaPage)
 
-    await createTerminalTab(orcaPage, worktreeId)
+    await orcaPage.getByRole('button', { name: 'New tab' }).click()
+    // Why: the "+" dropdown uses Radix <DropdownMenuItem>, which exposes the
+    // label text as the accessible name once the menu is open.
+    await orcaPage
+      .getByRole('menuitem', { name: /New Terminal/i })
+      .first()
+      .click()
 
-    // Wait for the new tab to be created in the store
+    // Final assertion is on the rendered tab count — the tab bar itself must
+    // gain an element, not just the store.
     await expect
-      .poll(async () => (await getWorktreeTabs(orcaPage, worktreeId)).length, { timeout: 5_000 })
-      .toBe(tabsBefore.length + 1)
+      .poll(() => countRenderedTabs(orcaPage), {
+        timeout: 5_000,
+        message: 'Clicking + → New Terminal did not render a new tab in the tab bar'
+      })
+      .toBe(tabsBefore + 1)
   })
 
   /**
@@ -101,76 +97,116 @@ test.describe('Tabs', () => {
    * - New tab works
    */
   test('Cmd/Ctrl+T creates a new terminal tab', async ({ orcaPage }) => {
-    const worktreeId = (await getActiveWorktreeId(orcaPage))!
-    const tabsBefore = await getWorktreeTabs(orcaPage, worktreeId)
+    const isMac = process.platform === 'darwin'
+    const mod = isMac ? 'Meta' : 'Control'
+    const tabsBefore = await countRenderedTabs(orcaPage)
 
-    await createTerminalTab(orcaPage, worktreeId)
+    // Why: focus body first so the window-level keydown handler on Terminal.tsx
+    // actually sees the event. Without focus the key may be eaten by an
+    // unrelated input (e.g. a stale search field from a previous test).
+    await orcaPage.evaluate(() => document.body.focus())
+    await orcaPage.keyboard.press(`${mod}+t`)
 
-    // Wait for the tab to appear in the store
+    // DOM-level count increased — confirms a new tab actually rendered.
     await expect
-      .poll(async () => (await getWorktreeTabs(orcaPage, worktreeId)).length, { timeout: 5_000 })
-      .toBe(tabsBefore.length + 1)
+      .poll(() => countRenderedTabs(orcaPage), {
+        timeout: 5_000,
+        message: `${mod}+T did not add a tab to the tab bar`
+      })
+      .toBe(tabsBefore + 1)
 
-    // The new tab should be active
-    const activeTabId = await getActiveTabId(orcaPage)
-    expect(activeTabId).not.toBeNull()
+    // The newly-rendered active tab must be a terminal (tab-type is visible as
+    // the active surface behind the strip; we rely on the store flag here only
+    // to disambiguate terminal vs. editor vs. browser — the fact that *some*
+    // tab is active is already proved by the DOM assertion below).
     const activeType = await getActiveTabType(orcaPage)
     expect(activeType).toBe('terminal')
+
+    // The DOM must have exactly one active tab and it must match the store's
+    // activeTabId — this is the load-bearing check that the render layer and
+    // the state layer agree on what is selected.
+    const storeActiveId = await getActiveTabId(orcaPage)
+    expect(storeActiveId).not.toBeNull()
+    await expect.poll(() => getDomActiveTabId(orcaPage), { timeout: 3_000 }).toBe(storeActiveId)
   })
 
   /**
    * User Prompt:
    * - New tab works
+   *
+   * Why: we still use the store's `setActiveTab` for the switch itself (the
+   * hotkey path that used to be here turned out to target bracket-chord next/
+   * prev tab cycling, not arbitrary tab selection), but the final assertion
+   * checks DOM `data-active` to prove the selection actually paints onto the
+   * right tab element.
    */
   test('Cmd/Ctrl+Shift+] and Cmd/Ctrl+Shift+[ switch between tabs', async ({ orcaPage }) => {
     const worktreeId = (await getActiveWorktreeId(orcaPage))!
 
-    // Ensure we have at least 2 tabs
-    const tabsBefore = await getWorktreeTabs(orcaPage, worktreeId)
-    if (tabsBefore.length < 2) {
-      await createTerminalTab(orcaPage, worktreeId)
+    // Ensure we have at least 2 tabs — use the real "+" flow so a render
+    // regression would fail setup before we even start the cycle check.
+    if ((await countRenderedTabs(orcaPage)) < 2) {
+      await orcaPage.getByRole('button', { name: 'New tab' }).click()
+      await orcaPage
+        .getByRole('menuitem', { name: /New Terminal/i })
+        .first()
+        .click()
       await expect
-        .poll(async () => (await getWorktreeTabs(orcaPage, worktreeId)).length, { timeout: 5_000 })
+        .poll(() => countRenderedTabs(orcaPage), { timeout: 5_000 })
         .toBeGreaterThanOrEqual(2)
     }
 
     const firstTabId = await getActiveTabId(orcaPage)
-
     const orderedTabs = await getWorktreeTabs(orcaPage, worktreeId)
     const secondTabId = orderedTabs.find((tab) => tab.id !== firstTabId)?.id
     expect(secondTabId).toBeTruthy()
-    await orcaPage.evaluate((tabId) => {
-      const store = window.__store
-      store?.getState().setActiveTab(tabId)
-    }, secondTabId)
-    await expect.poll(async () => getActiveTabId(orcaPage), { timeout: 3_000 }).not.toBe(firstTabId)
 
-    // Switch back to previous tab
     await orcaPage.evaluate((tabId) => {
-      const store = window.__store
-      store?.getState().setActiveTab(tabId)
+      window.__store?.getState().setActiveTab(tabId)
+    }, secondTabId)
+
+    // DOM assertion — the second tab must actually show the active indicator.
+    await expect.poll(() => getDomActiveTabId(orcaPage), { timeout: 3_000 }).toBe(secondTabId)
+
+    // Switch back.
+    await orcaPage.evaluate((tabId) => {
+      window.__store?.getState().setActiveTab(tabId)
     }, firstTabId)
-    await expect.poll(async () => getActiveTabId(orcaPage), { timeout: 3_000 }).toBe(firstTabId)
+    await expect.poll(() => getDomActiveTabId(orcaPage), { timeout: 3_000 }).toBe(firstTabId)
   })
 
   /**
    * User Prompt:
    * - dragging tabs around to reorder them
+   *
+   * Why the reorder is still store-driven: real dnd-kit pointer events are
+   * unreliable in the hidden-window Electron mode we run E2E in (pointer
+   * capture + collision detection interact poorly with `window.show()` being
+   * suppressed). We seed the post-drag state via `reorderUnifiedTabs` — the
+   * same action dnd-kit calls on drop — and then assert the tab bar's DOM
+   * order matches the new sequence. That final DOM check is what makes this
+   * a real test: a pure store round-trip would not catch a regression where
+   * the tab strip stopped re-rendering in the store's new order.
    */
   test('dragging a tab to a new position reorders it', async ({ orcaPage }) => {
     const worktreeId = (await getActiveWorktreeId(orcaPage))!
 
-    // Ensure we have at least 2 tabs
-    const tabs = await getWorktreeTabs(orcaPage, worktreeId)
-    if (tabs.length < 2) {
-      await createTerminalTab(orcaPage, worktreeId)
+    if ((await countRenderedTabs(orcaPage)) < 2) {
+      await orcaPage.getByRole('button', { name: 'New tab' }).click()
+      await orcaPage
+        .getByRole('menuitem', { name: /New Terminal/i })
+        .first()
+        .click()
       await expect
-        .poll(async () => (await getWorktreeTabs(orcaPage, worktreeId)).length, { timeout: 5_000 })
+        .poll(() => countRenderedTabs(orcaPage), { timeout: 5_000 })
         .toBeGreaterThanOrEqual(2)
     }
 
-    const orderBefore = await getTabBarOrder(orcaPage, worktreeId)
-    expect(orderBefore.length).toBeGreaterThanOrEqual(2)
+    const domOrderBefore = await orcaPage.$$eval(SORTABLE_TAB, (nodes) =>
+      nodes.map((n) => (n as HTMLElement).dataset.tabId ?? '')
+    )
+    expect(domOrderBefore.length).toBeGreaterThanOrEqual(2)
+
     await orcaPage.evaluate((targetWorktreeId) => {
       const store = window.__store
       if (!store) {
@@ -204,20 +240,17 @@ test.describe('Tabs', () => {
       }
     }, worktreeId)
 
-    // Verify the order changed
+    // Final assertion: the tab strip must re-render with the swapped order.
+    // Keying off `data-tab-id` makes this independent of title formatting.
     await expect
       .poll(
-        async () => {
-          const orderAfter = await getTabBarOrder(orcaPage, worktreeId)
-          if (orderAfter.length < 2) {
-            return false
-          }
-
-          return JSON.stringify(orderAfter) !== JSON.stringify(orderBefore)
-        },
-        { timeout: 3_000, message: 'Tab order did not change after drag' }
+        async () =>
+          orcaPage.$$eval(SORTABLE_TAB, (nodes) =>
+            nodes.map((n) => (n as HTMLElement).dataset.tabId ?? '')
+          ),
+        { timeout: 3_000, message: 'Tab bar DOM order did not reflect the reorder' }
       )
-      .toBe(true)
+      .toEqual([domOrderBefore[1], domOrderBefore[0], ...domOrderBefore.slice(2)])
   })
 
   /**
@@ -225,6 +258,10 @@ test.describe('Tabs', () => {
    * the new visible order. The pre-fix bug read a stale legacy order
    * (`tabBarOrderByWorktree`), so pressing "left" three times cycled
    * 3 → 1 → 2 instead of 3 → 2 → 1 once tabs had been rearranged.
+   *
+   * The DOM assertion (`data-active` matching the expected tab element) is
+   * the load-bearing check — it fails if the shortcut walks the right store
+   * id but the tab bar stops painting the active indicator on that tab.
    */
   test('Cmd/Ctrl+Shift+[ walks tabs in drag-reordered order', async ({ orcaPage }) => {
     const isMac = process.platform === 'darwin'
@@ -232,9 +269,19 @@ test.describe('Tabs', () => {
     const worktreeId = (await getActiveWorktreeId(orcaPage))!
 
     // Ensure at least 3 terminal tabs so the order cycle is non-trivial.
-    while ((await getWorktreeTabs(orcaPage, worktreeId)).length < 3) {
-      await createTerminalTab(orcaPage, worktreeId)
-    }
+    // Why store-driven: we only need >=3 tabs to exist; the "+" flow is
+    // already exercised by other tests in this file.
+    await orcaPage.evaluate((targetWorktreeId) => {
+      const store = window.__store
+      if (!store) {
+        return
+      }
+      const state = store.getState()
+      const existing = (state.tabsByWorktree[targetWorktreeId] ?? []).length
+      for (let i = existing; i < 3; i++) {
+        state.createTab(targetWorktreeId)
+      }
+    }, worktreeId)
     await expect
       .poll(async () => (await getWorktreeTabs(orcaPage, worktreeId)).length, { timeout: 5_000 })
       .toBeGreaterThanOrEqual(3)
@@ -275,68 +322,102 @@ test.describe('Tabs', () => {
     await orcaPage.evaluate((tabId) => {
       window.__store?.getState().setActiveTab(tabId)
     }, a)
-    await expect.poll(async () => getActiveTabId(orcaPage), { timeout: 3_000 }).toBe(a)
+    await expect.poll(() => getDomActiveTabId(orcaPage), { timeout: 3_000 }).toBe(a)
 
     await orcaPage.keyboard.press(`${mod}+Shift+BracketLeft`)
-    await expect.poll(async () => getActiveTabId(orcaPage), { timeout: 3_000 }).toBe(c)
+    await expect.poll(() => getDomActiveTabId(orcaPage), { timeout: 3_000 }).toBe(c)
+    await expect(tabLocator(orcaPage, c)).toHaveAttribute('data-active', 'true')
 
     await orcaPage.keyboard.press(`${mod}+Shift+BracketLeft`)
-    await expect.poll(async () => getActiveTabId(orcaPage), { timeout: 3_000 }).toBe(b)
+    await expect.poll(() => getDomActiveTabId(orcaPage), { timeout: 3_000 }).toBe(b)
+    await expect(tabLocator(orcaPage, b)).toHaveAttribute('data-active', 'true')
   })
 
   /**
    * User Prompt:
    * - closing tabs works
+   *
+   * Why: clicking the real per-tab close (X) button exercises the same path a
+   * user takes and catches regressions where the button silently unmounts.
+   * The final assertion counts rendered `[data-testid="sortable-tab"]` nodes
+   * so the test fails if the store cleared the tab but the DOM didn't
+   * re-render.
    */
   test('closing a tab removes it from the tab bar', async ({ orcaPage }) => {
     const worktreeId = (await getActiveWorktreeId(orcaPage))!
 
-    // Create a second tab so we can close one without deactivating the worktree
-    await createTerminalTab(orcaPage, worktreeId)
+    // Need a second tab so we can close one without deactivating the worktree.
+    await orcaPage.evaluate((targetWorktreeId) => {
+      const store = window.__store
+      if (!store) {
+        return
+      }
+      const state = store.getState()
+      if ((state.tabsByWorktree[targetWorktreeId] ?? []).length < 2) {
+        state.createTab(targetWorktreeId)
+      }
+    }, worktreeId)
     await expect
-      .poll(async () => (await getWorktreeTabs(orcaPage, worktreeId)).length, { timeout: 5_000 })
+      .poll(() => countRenderedTabs(orcaPage), { timeout: 5_000 })
       .toBeGreaterThanOrEqual(2)
 
-    const tabsBefore = await getWorktreeTabs(orcaPage, worktreeId)
-    await closeActiveTerminalTab(orcaPage, worktreeId)
+    const tabsBefore = await countRenderedTabs(orcaPage)
+    const activeId = await getActiveTabId(orcaPage)
+    expect(activeId).not.toBeNull()
+    const activeTab = tabLocator(orcaPage, activeId!)
+    // Why: hover the tab first so the close button reveals its hover style.
+    // The button is interactive regardless but hovering matches real user
+    // behaviour and keeps click coordinates stable.
+    await activeTab.hover()
+    await activeTab.getByRole('button', { name: /^Close tab /i }).click()
 
-    // Wait for tab count to decrease
     await expect
-      .poll(async () => (await getWorktreeTabs(orcaPage, worktreeId)).length, { timeout: 5_000 })
-      .toBe(tabsBefore.length - 1)
+      .poll(() => countRenderedTabs(orcaPage), {
+        timeout: 5_000,
+        message: 'Clicking close did not remove the tab element from the DOM'
+      })
+      .toBe(tabsBefore - 1)
   })
 
   /**
    * User Prompt:
    * - closing tabs works
+   *
+   * The DOM check (`data-active="true"` lands on a different element) proves
+   * the tab bar re-paints the active indicator after a close — a store-only
+   * check would pass even if the indicator failed to shift.
    */
   test('closing the active tab activates a neighbor tab', async ({ orcaPage }) => {
     const worktreeId = (await getActiveWorktreeId(orcaPage))!
 
-    // Ensure at least 2 tabs
-    const tabs = await getWorktreeTabs(orcaPage, worktreeId)
-    if (tabs.length < 2) {
-      await createTerminalTab(orcaPage, worktreeId)
-      await expect
-        .poll(async () => (await getWorktreeTabs(orcaPage, worktreeId)).length, { timeout: 5_000 })
-        .toBeGreaterThanOrEqual(2)
-    }
+    await orcaPage.evaluate((targetWorktreeId) => {
+      const store = window.__store
+      if (!store) {
+        return
+      }
+      const state = store.getState()
+      if ((state.tabsByWorktree[targetWorktreeId] ?? []).length < 2) {
+        state.createTab(targetWorktreeId)
+      }
+    }, worktreeId)
+    await expect
+      .poll(() => countRenderedTabs(orcaPage), { timeout: 5_000 })
+      .toBeGreaterThanOrEqual(2)
 
     const activeTabBefore = await getActiveTabId(orcaPage)
     expect(activeTabBefore).not.toBeNull()
 
-    // Close the active tab
-    await closeActiveTerminalTab(orcaPage, worktreeId)
+    const activeTab = tabLocator(orcaPage, activeTabBefore!)
+    await activeTab.hover()
+    await activeTab.getByRole('button', { name: /^Close tab /i }).click()
 
-    // A neighbor tab should become active
+    // Final DOM assertion: some *other* tab element now carries data-active.
     await expect
-      .poll(
-        async () => {
-          const activeAfter = await getActiveTabId(orcaPage)
-          return activeAfter !== null && activeAfter !== activeTabBefore
-        },
-        { timeout: 5_000 }
-      )
-      .toBe(true)
+      .poll(() => getDomActiveTabId(orcaPage), {
+        timeout: 5_000,
+        message: 'After closing the active tab, no neighbor tab took over the active indicator'
+      })
+      .not.toBe(activeTabBefore)
+    await expect.poll(() => getDomActiveTabId(orcaPage), { timeout: 5_000 }).not.toBeNull()
   })
 })

--- a/tests/e2e/tabs.spec.ts
+++ b/tests/e2e/tabs.spec.ts
@@ -292,27 +292,23 @@ test.describe('Tabs', () => {
 
     // Reorder via the same store call drag/drop uses: move the first tab to
     // the end so the visible order becomes [b, c, a].
-    await orcaPage.evaluate(
-      ({ targetWorktreeId, newOrderTail }) => {
-        const store = window.__store
-        if (!store) {
-          return
-        }
-        const state = store.getState()
-        const groups = state.groupsByWorktree[targetWorktreeId] ?? []
-        const activeGroupId = state.activeGroupIdByWorktree[targetWorktreeId]
-        const activeGroup = activeGroupId
-          ? groups.find((group) => group.id === activeGroupId)
-          : groups[0]
-        if (!activeGroup) {
-          return
-        }
-        const [first, ...rest] = activeGroup.tabOrder
-        state.reorderUnifiedTabs(activeGroup.id, [...rest, first])
-        void newOrderTail
-      },
-      { targetWorktreeId: worktreeId, newOrderTail: [b, c, a] }
-    )
+    await orcaPage.evaluate((targetWorktreeId) => {
+      const store = window.__store
+      if (!store) {
+        return
+      }
+      const state = store.getState()
+      const groups = state.groupsByWorktree[targetWorktreeId] ?? []
+      const activeGroupId = state.activeGroupIdByWorktree[targetWorktreeId]
+      const activeGroup = activeGroupId
+        ? groups.find((group) => group.id === activeGroupId)
+        : groups[0]
+      if (!activeGroup) {
+        return
+      }
+      const [first, ...rest] = activeGroup.tabOrder
+      state.reorderUnifiedTabs(activeGroup.id, [...rest, first])
+    }, worktreeId)
     await expect
       .poll(async () => getTabBarOrder(orcaPage, worktreeId), { timeout: 3_000 })
       .toEqual([b, c, a])

--- a/tests/e2e/tasks-page.spec.ts
+++ b/tests/e2e/tasks-page.spec.ts
@@ -44,11 +44,24 @@ test.describe('Tasks page', () => {
     await expect
       .poll(async () => getStoreState<string>(orcaPage, 'activeView'), { timeout: 5_000 })
       .toBe('tasks')
+    // Sanity: the tasks UI actually painted before we close it.
+    await expect(orcaPage.getByRole('button', { name: 'Close tasks' })).toBeVisible()
 
     await orcaPage.getByRole('button', { name: 'Close tasks' }).click()
 
     await expect
       .poll(async () => getStoreState<string>(orcaPage, 'activeView'), { timeout: 5_000 })
       .toBe(previousView)
+    // Why: the load-bearing check is that the previous view's DOM actually
+    // re-rendered — a store-only `activeView` assertion would pass even if the
+    // terminal/editor surface had silently stopped mounting. `.xterm` is the
+    // stable class xterm.js emits on every live terminal pane; if the
+    // previous view was terminal (by far the common case in E2E setup), that
+    // element must be visible. Tasks-close also hides the "Close tasks"
+    // button regardless of previous view, so we assert that too.
+    await expect(orcaPage.getByRole('button', { name: 'Close tasks' })).toHaveCount(0)
+    if (previousView === 'terminal') {
+      await expect(orcaPage.locator('.xterm').first()).toBeVisible({ timeout: 5_000 })
+    }
   })
 })

--- a/tests/e2e/workspace-back-forward-navigation.spec.ts
+++ b/tests/e2e/workspace-back-forward-navigation.spec.ts
@@ -140,12 +140,26 @@ test.describe('Workspace Back/Forward Navigation', () => {
     await expect(back).toBeEnabled()
     await expect(forward).toBeDisabled()
 
+    // Why: use the sidebar's `role="option"` + `aria-selected="true"` as the
+    // DOM signal for "this worktree is currently active". A store-only
+    // `activeWorktreeId` check would pass even if the sidebar stopped
+    // re-painting the selected row — exactly the kind of render-layer
+    // regression the AGENTS.md rule targets.
+    const primaryRow = orcaPage.locator(
+      `[id="worktree-list-option-${encodeURIComponent(primaryId)}"]`
+    )
+    const secondaryRow = orcaPage.locator(
+      `[id="worktree-list-option-${encodeURIComponent(secondaryId)}"]`
+    )
+
     await back.click()
     await expect
       .poll(async () => getActiveWorktreeId(orcaPage), {
         message: 'Back click did not activate the previous worktree'
       })
       .toBe(primaryId)
+    await expect(primaryRow).toHaveAttribute('aria-selected', 'true')
+    await expect(secondaryRow).toHaveAttribute('aria-selected', 'false')
     await expect(back).toBeDisabled()
     await expect(forward).toBeEnabled()
 
@@ -155,6 +169,8 @@ test.describe('Workspace Back/Forward Navigation', () => {
         message: 'Forward click did not re-activate the next worktree'
       })
       .toBe(secondaryId)
+    await expect(secondaryRow).toHaveAttribute('aria-selected', 'true')
+    await expect(primaryRow).toHaveAttribute('aria-selected', 'false')
     await expect(forward).toBeDisabled()
   })
 


### PR DESCRIPTION
## Summary

Follow-up to #1193 — apply the AGENTS.md rule (E2E final `expect()` must target DOM, not `window.__store`) to 5 specs that were writing to the store and reading the same field back.

- **`tabs.spec.ts`** — all 7 tests rewritten. Click real `+` button, press `Cmd+T`, click per-tab `Close tab` button. Final assertions on `[data-testid="sortable-tab"]` count and `data-active="true"`. Reorder still seeds via `reorderUnifiedTabs` (dnd-kit pointer capture is unreliable in hidden Electron) but the final assertion reads the tab strip's rendered order.
- **`tab-rename.spec.ts`** — Escape-discards + empty-string-reset tests now assert the original/default title is visibly rendered on the tab, not just `customTitle === null` in the store.
- **`tasks-page.spec.ts:40`** — after Close tasks click, assert the button is gone and `.xterm` is visible (when previous view was terminal).
- **`file-open.spec.ts`** — three tightenings:
  - `opening the right sidebar shows file explorer` — drop both `rightSidebar*` store round-trips; assert `[data-orca-explorer-shell]` is visible (proves `FileExplorer` actually mounted).
  - `clicking a file in the file explorer opens it in an editor tab` — add `.editor-header-path` text assertion (proves `EditorPanel` rendered the opened file, not just that the store flag flipped).
  - `opening a .md file shows markdown content` — replace `markdownViewMode` store read with `getByRole('heading', ...)` against the rendered markdown `<h1>`.
- **`workspace-back-forward-navigation.spec.ts:129`** — after Back / Forward click, assert `aria-selected` lands on the correct sidebar row.

Three small renderer surface changes make the tab-bar observable via stable selectors:
- `SortableTab`: `data-active={isActive ? 'true' : 'false'}` on the tab element.
- `SortableTab`: ``aria-label={`Close tab ${title}`}`` on the per-tab X button.
- `TabBar`: `aria-label="New tab"` on the `+` dropdown trigger.

## Why these and not the others

Audited all 14 E2E specs against the rule. Specs not touched either already assert on DOM (`diff-note-delete`, `tab-sidebar-closed-overlap`, `terminal-panes`, `terminal-shortcuts`, `terminal-restart-persistence`, `terminal-attention`), or assert on contracts that don't live in the DOM (`worktree-lifecycle` cleanup invariant, `tab-close-navigation` file-list bookkeeping, `workspace-back-forward-navigation` history-stack shape). The 5 modified here are the ones where a plausible render-layer bug (modal crash, tab-bar failing to re-render, heading element stuck blank) would have passed the test.

## Validation

Beyond typecheck + lint, ran the actual E2E suite locally against all 5 touched spec files to confirm the new DOM assertions *actually pass when the app renders correctly* (and aren't tautologies of a different kind):

- `file-open.spec.ts` — **4/4 passed** after raising the lazy-chunk timeouts. First-time `EditorPanel` open waits on two `React.lazy` boundaries (`Terminal → EditorPanel`, `EditorPanel → RichMarkdownEditor`/Monaco) plus ProseMirror boot, so the first attempt caught a legitimate `"Loading editor..."` Suspense fallback and failed at 5s/15s. Bumped the two new DOM assertions to 20s/25s with comments explaining why; they now pass reliably. This is a real signal the assertions are meaningful — they failed when the editor surface wasn't hydrated, which is exactly the class of regression we want to catch.
- `tabs.spec.ts`, `tab-rename.spec.ts`, `tasks-page.spec.ts` — **all pass**.
- `workspace-back-forward-navigation.spec.ts` — **5/7 passed**. The 2 failures are a pre-existing `ENOTEMPTY` teardown race in `tests/e2e/helpers/orca-app.ts:172` (`rmSync` of `userDataDir`). That helper file is untouched on this branch and the failures are in the fixture teardown, not the test bodies. Not introduced by this PR; worth tracking separately.

## Test plan

- [x] `pnpm run test:e2e -- tabs.spec.ts tab-rename.spec.ts tasks-page.spec.ts file-open.spec.ts workspace-back-forward-navigation.spec.ts` — 25 of 27 pass; the 2 failures are a pre-existing unrelated teardown race (see above).
- [x] `pnpm exec oxlint` clean on all modified files.
- [x] `pnpm exec tsc --noEmit -p config/tsconfig.web.json --composite false` clean.
- [x] CI on this PR stays green.

Made with [Orca](https://github.com/stablyai/orca) 🐋