### PR TITLE
fix(ssh): support new markdown file creation on SSH worktrees

### DIFF
--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -8,6 +8,7 @@ import { useAppStore } from '../store'
 import { useAllWorktrees } from '../store/selectors'
 import { findWorktreeById } from '../store/slices/worktree-helpers'
 import { createUntitledMarkdownFile } from '../lib/create-untitled-markdown'
+import { getConnectionId } from '../lib/connection-context'
 import { extractIpcErrorMessage } from '../lib/ipc-error'
 import {
   Dialog,
@@ -447,7 +448,12 @@ function Terminal(): React.JSX.Element | null {
       // current focused group explicitly. Otherwise split layouts fall back to
       // the ambient/default group and open the file in the wrong pane.
       const targetGroupId = useAppStore.getState().activeGroupIdByWorktree[activeWorktreeId]
-      const fileInfo = await createUntitledMarkdownFile(worktree.path, activeWorktreeId)
+      const connectionId = getConnectionId(activeWorktreeId) ?? undefined
+      const fileInfo = await createUntitledMarkdownFile(
+        worktree.path,
+        activeWorktreeId,
+        connectionId
+      )
       openFile(fileInfo, { preview: false, targetGroupId })
     } catch (err) {
       toast.error(extractIpcErrorMessage(err, 'Failed to create untitled markdown file.'))

--- a/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.ts
+++ b/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.ts
@@ -14,6 +14,7 @@ import type {
 import { useAppStore } from '../../store'
 import { useAllWorktrees } from '../../store/selectors'
 import { createUntitledMarkdownFile } from '../../lib/create-untitled-markdown'
+import { getConnectionId } from '../../lib/connection-context'
 import { extractIpcErrorMessage } from '../../lib/ipc-error'
 import { destroyPersistentWebview } from '../browser-pane/BrowserPane'
 
@@ -426,7 +427,8 @@ export function useTabGroupWorkspaceModel({
           return
         }
         try {
-          const fileInfo = await createUntitledMarkdownFile(path, worktreeId)
+          const connectionId = getConnectionId(worktreeId) ?? undefined
+          const fileInfo = await createUntitledMarkdownFile(path, worktreeId, connectionId)
           openFile(fileInfo, { preview: false, targetGroupId: groupId })
         } catch (err) {
           toast.error(extractIpcErrorMessage(err, 'Failed to create untitled markdown file.'))

--- a/src/renderer/src/lib/create-untitled-markdown.test.ts
+++ b/src/renderer/src/lib/create-untitled-markdown.test.ts
@@ -50,4 +50,29 @@ describe('createUntitledMarkdownFile', () => {
 
     expect(createFile).not.toHaveBeenCalled()
   })
+
+  it('passes connectionId to createFile and skips the local pathExists probe for SSH worktrees', async () => {
+    const pathExists = vi.fn(async () => false)
+    const createFile = vi.fn().mockResolvedValueOnce(undefined)
+
+    vi.stubGlobal('window', {
+      api: {
+        shell: { pathExists },
+        fs: { createFile }
+      }
+    })
+
+    await expect(createUntitledMarkdownFile('/repo', 'wt-1', 'conn-1')).resolves.toMatchObject({
+      filePath: '/repo/untitled.md'
+    })
+
+    // Why: shell.pathExists is main-process local-only; probing it on SSH
+    // worktrees always reports "not found" or succeeds against the wrong
+    // filesystem, so the probe must be skipped when a connectionId is set.
+    expect(pathExists).not.toHaveBeenCalled()
+    expect(createFile).toHaveBeenCalledWith({
+      filePath: '/repo/untitled.md',
+      connectionId: 'conn-1'
+    })
+  })
 })

--- a/src/renderer/src/lib/create-untitled-markdown.ts
+++ b/src/renderer/src/lib/create-untitled-markdown.ts
@@ -10,7 +10,8 @@ import { joinPath } from './path'
  */
 export async function createUntitledMarkdownFile(
   worktreePath: string,
-  worktreeId: string
+  worktreeId: string,
+  connectionId?: string
 ): Promise<{
   filePath: string
   relativePath: string
@@ -28,16 +29,22 @@ export async function createUntitledMarkdownFile(
   // user fires the shortcut repeatedly or two split groups create files at
   // nearly the same time. Retrying EEXIST keeps "New Markdown" advancing to
   // the next untitled-N name instead of surfacing a spurious error toast.
+  //
+  // Why (SSH): window.api.shell.pathExists is a local-only main-process probe
+  // and cannot see files on a remote host. For SSH worktrees we skip the probe
+  // and rely solely on the EEXIST retry loop; otherwise every attempt reports
+  // "not found" locally, then fails in the main process when createFile tries
+  // to authorize the remote path against local allowed roots.
   for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
     const fileName = attempt === 1 ? `${baseName}${ext}` : `${baseName}-${attempt}${ext}`
     const filePath = joinPath(worktreePath, fileName)
 
-    if (await window.api.shell.pathExists(filePath)) {
+    if (!connectionId && (await window.api.shell.pathExists(filePath))) {
       continue
     }
 
     try {
-      await window.api.fs.createFile({ filePath })
+      await window.api.fs.createFile({ filePath, connectionId })
 
       return {
         filePath,


### PR DESCRIPTION
## Problem

Creating a new markdown file via 'New Markdown File' failed on SSH worktrees because the code attempted to check if a path existed using the local shell's pathExists probe, which cannot reach a remote host.

## Solution

- Resolve the worktree's `connectionId` (null for local repos, SSH target ID for remote)
- Skip the local pathExists probe when `connectionId` is present — rely solely on the EEXIST retry loop
- Forward `connectionId` through to the fs.createFile API so the main process can route the file creation to the correct target (local or remote via SSH relay)

Made with [Orca](https://github.com/stablyai/orca) 🐋
