### PR TITLE
fix(notifications): restore agent-task-complete dispatch broken by #944

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-types.ts
@@ -25,11 +25,14 @@ export type PtyConnectionDeps = {
   markTerminalTabUnread: (tabId: string) => void
   clearWorktreeUnread: (worktreeId: string) => void
   clearTerminalTabUnread: (tabId: string) => void
-  // Why: the renderer-side dispatcher only handles BEL-sourced notifications
-  // now. shared/types.ts keeps a wider NotificationEventSource union because
-  // main-process callers can still emit others (e.g. `'test'` for the
-  // settings-pane button).
-  dispatchNotification: (event: { source: 'terminal-bell' }) => void
+  // Why: the renderer dispatches two notification sources — BEL from the PTY
+  // byte stream and agent-task-complete on the working→idle title transition.
+  // shared/types.ts keeps a wider NotificationEventSource union because the
+  // main process can also emit `'test'` from the settings-pane button.
+  dispatchNotification: (event: {
+    source: 'terminal-bell' | 'agent-task-complete'
+    terminalTitle?: string
+  }) => void
   setCacheTimerStartedAt: (key: string, ts: number | null) => void
   syncPanePtyLayoutBinding: (paneId: number, ptyId: string | null) => void
 }

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -978,13 +978,12 @@ describe('connectPanePty', () => {
     })
   })
 
-  // Why: the working→idle transition is kept solely to drive Claude's
-  // prompt-cache timer. It MUST NOT raise attention — doing so would
-  // double-fire with the BEL path above (since Claude's "done" state is
-  // accompanied by a BEL), plus it would mean agents silently fire alerts
-  // that non-agent programs cannot. Attention is BEL-only; this is just
-  // the cache timer hook.
-  it('does not raise attention on agent working→idle (BEL is the sole attention signal)', async () => {
+  // Why: the working→idle transition fires an 'agent-task-complete' OS
+  // notification (user-toggleable in Settings) but MUST NOT raise tab/worktree
+  // unread — those stay BEL-only so non-agent long-running tasks remain
+  // first-class attention sources. Double-firing with a concurrent BEL is
+  // collapsed by the per-worktree dedupe in main/ipc/notifications.ts.
+  it('dispatches agent-task-complete on working→idle but does not raise tab/worktree unread', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport()
     transportFactoryQueue.push(transport)
@@ -1006,7 +1005,10 @@ describe('connectPanePty', () => {
 
     expect(deps.markWorktreeUnread).not.toHaveBeenCalled()
     expect(deps.markTerminalTabUnread).not.toHaveBeenCalled()
-    expect(deps.dispatchNotification).not.toHaveBeenCalled()
+    expect(deps.dispatchNotification).toHaveBeenCalledWith({
+      source: 'agent-task-complete',
+      terminalTitle: '* Claude done'
+    })
   })
 
   // Why: onAgentExited must clear any running prompt-cache countdown so the

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -208,14 +208,20 @@ export function connectPanePty(
     deps.dispatchNotification({ source: 'terminal-bell' })
   }
 
-  // ─── Prompt-cache timer: driven by agent lifecycle, not attention ─────
+  // ─── Agent task-complete: OS notification, not tab attention ──────────
   //
-  // The working→idle title transition is kept purely to drive Claude's
-  // prompt-cache countdown in the sidebar. It intentionally does NOT raise
-  // attention — that would double-fire with the BEL above, and OSC title
-  // transitions are too narrow a signal to be the sole attention source
-  // (only agent TUIs emit them; non-agent long-running tasks would never
-  // get surfaced).
+  // The working→idle title transition drives two independent concerns:
+  //   1. The Claude prompt-cache countdown in the sidebar.
+  //   2. The "Agent Task Complete" OS notification users toggle in Settings.
+  //
+  // We intentionally do NOT raise tab/worktree unread from here — that
+  // remains BEL-only so non-agent long-running tasks stay first-class and
+  // so unread state only reflects what the terminal byte stream actually
+  // signals. OS notifications are a separate channel: not every agent CLI
+  // reliably emits BEL on completion (Gemini, some Codex flows), and
+  // without this dispatch the Settings toggle would have zero producers.
+  // Double-firing with a concurrent BEL is handled by the 5 s per-worktree
+  // dedupe in main/ipc/notifications.ts.
   const onAgentBecameIdle = (title: string): void => {
     // Why: only start the prompt-cache countdown for Claude agents — other
     // agents have different (or no) prompt-caching semantics and showing a
@@ -231,6 +237,12 @@ export function connectPanePty(
     if (isClaudeAgent(title) && (settings === null || settings.promptCacheTimerEnabled)) {
       deps.setCacheTimerStartedAt(cacheKey, Date.now())
     }
+    // Why: this is the sole producer of 'agent-task-complete' in the renderer;
+    // removing it (as #944 did) leaves the user-facing Settings toggle with no
+    // events to fire. Dispatch is gated per-source in main; the main-process
+    // dedupe also collapses concurrent BEL + task-complete for the same
+    // worktree into a single notification.
+    deps.dispatchNotification({ source: 'agent-task-complete', terminalTitle: title })
   }
   const onAgentBecameWorking = (): void => {
     // Why: a new API call refreshes the prompt-cache TTL, so clear any running

--- a/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
+++ b/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
@@ -11,9 +11,9 @@ import { getRepoMapFromState, getWorktreeMapFromState } from '@/store/selectors'
  */
 export function useNotificationDispatch(
   worktreeId: string
-): (event: { source: 'terminal-bell' }) => void {
+): (event: { source: 'terminal-bell' | 'agent-task-complete'; terminalTitle?: string }) => void {
   return useCallback(
-    (event: { source: 'terminal-bell' }) => {
+    (event: { source: 'terminal-bell' | 'agent-task-complete'; terminalTitle?: string }) => {
       const state = useAppStore.getState()
 
       // Why: shutdownWorktreeTerminals clears ptyIdsByTabId synchronously
@@ -42,6 +42,7 @@ export function useNotificationDispatch(
         worktreeId,
         repoLabel: repo?.displayName,
         worktreeLabel: worktree?.displayName || worktree?.branch || worktreeId,
+        terminalTitle: event.terminalTitle,
         isActiveWorktree: state.activeWorktreeId === worktreeId
       })
     },

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -97,7 +97,10 @@ type UseTerminalPaneLifecycleDeps = {
   markTerminalTabUnread: (tabId: string) => void
   clearWorktreeUnread: (worktreeId: string) => void
   clearTerminalTabUnread: (tabId: string) => void
-  dispatchNotification: (event: { source: 'terminal-bell' }) => void
+  dispatchNotification: (event: {
+    source: 'terminal-bell' | 'agent-task-complete'
+    terminalTitle?: string
+  }) => void
   setCacheTimerStartedAt: (key: string, ts: number | null) => void
   syncPanePtyLayoutBinding: (paneId: number, ptyId: string | null) => void
   setTabPaneExpanded: (tabId: string, expanded: boolean) => void


### PR DESCRIPTION
## Summary

- PR #944 (per-tab activity indicators) removed the only renderer-side producer of `agent-task-complete` notifications inside `onAgentBecameIdle`, on the theory that BEL would cover the same ground.
- In practice, the "Agent Task Complete" toggle in Settings has had zero event producers since #944 merged — notifications users explicitly opted into silently stopped firing. Not every agent CLI reliably emits BEL on completion (Gemini, some Codex flows), so BEL is not a complete substitute.
- This restores the dispatch from `onAgentBecameIdle` in `pty-connection.ts`, keeping tab/worktree unread state BEL-only (so non-agent long-running tasks remain first-class attention sources). Double-firing with a concurrent BEL is already collapsed by the existing 5 s per-worktree dedupe in `main/ipc/notifications.ts`.
- Types plumb `{ source: 'agent-task-complete' | 'terminal-bell', terminalTitle? }` through `pty-connection-types.ts`, `use-terminal-pane-lifecycle.ts`, and `use-notification-dispatch.ts`. The existing unit test that asserted idle-does-nothing is updated to reflect the intended behavior.

Fixes the report that notifications stopped working after installing today's build.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint` (2 unrelated pre-existing warnings)
- [x] `pnpm vitest run src/renderer/src/components/terminal-pane/pty-connection.test.ts` — 20 passed
- [x] `pnpm vitest run src/main/ipc/notifications.test.ts` — 10 passed
- [ ] Manually: launch a Claude agent, let it finish, confirm OS notification fires with "Agent Task Complete" enabled in Settings
- [ ] Manually: ring BEL + finish agent within 5 s → single notification (main-process dedupe)
- [ ] Manually: disable "Agent Task Complete" toggle → no notification on agent idle, BEL still fires

Made with [Orca](https://github.com/stablyai/orca) 🐋
