### PR TITLE
fix(browser-pane): ensure tooltip reliably triggers on container hover

### DIFF
--- a/src/renderer/src/components/browser-pane/BrowserPane.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPane.tsx
@@ -25,6 +25,7 @@ import {
   DropdownMenuShortcut,
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useAppStore } from '@/store'
 import { ORCA_BROWSER_BLANK_URL, ORCA_BROWSER_PARTITION } from '../../../../shared/constants'
 import type {
@@ -1785,16 +1786,28 @@ function BrowserPagePane({
           inputRef={addressBarInputRef}
         />
 
-        <Button
-          size="icon"
-          variant={grab.state !== 'idle' ? 'default' : 'ghost'}
-          className={`h-8 w-8 ${grab.state !== 'idle' ? 'bg-foreground/80 text-background hover:bg-foreground/90' : ''}`}
-          onClick={grab.toggle}
-          title={`Grab page element (${navigator.userAgent.includes('Mac') ? '⌘C' : 'Ctrl+C'})`}
-          disabled={isBlankTab}
-        >
-          <Crosshair className="size-4" />
-        </Button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            {/* Why: wrap the disabled button in a span so pointer events still
+                reach the tooltip trigger — Radix (and the DOM) drop hover
+                events on disabled <button>, which is why the previous native
+                `title` attribute fired inconsistently. */}
+            <span className="inline-flex">
+              <Button
+                size="icon"
+                variant={grab.state !== 'idle' ? 'default' : 'ghost'}
+                className={`h-8 w-8 ${grab.state !== 'idle' ? 'bg-foreground/80 text-background hover:bg-foreground/90' : ''}`}
+                onClick={grab.toggle}
+                disabled={isBlankTab}
+              >
+                <Crosshair className="size-4" />
+              </Button>
+            </span>
+          </TooltipTrigger>
+          <TooltipContent side="bottom" sideOffset={4}>
+            {`Grab page element (${navigator.userAgent.includes('Mac') ? '⌘C' : 'Ctrl+C'})`}
+          </TooltipContent>
+        </Tooltip>
 
         <Button
           size="icon"


### PR DESCRIPTION
## Problem
The native HTML `title` attribute on the Grab button fired inconsistently when disabled. Disabled buttons drop hover events in the DOM, preventing the tooltip from showing reliably.

## Solution
Replaced the native `title` attribute with a Radix `Tooltip` component. Wrapped the disabled button in a `<span>` with `inline-flex` to capture pointer events and reliably trigger the tooltip even when the button is disabled.

Made with [Orca](https://github.com/stablyai/orca) 🐋
