### PR TITLE
fix(terminal): restore Polish / US-Extended Option+letter composition (#1205)

### DIFF
--- a/src/main/ipc/app.ts
+++ b/src/main/ipc/app.ts
@@ -1,4 +1,5 @@
-import { app, ipcMain, systemPreferences } from 'electron'
+import { execFileSync } from 'node:child_process'
+import { app, ipcMain } from 'electron'
 import { isWslAvailable } from '../wsl'
 
 export type AppRuntimeFlags = {
@@ -42,32 +43,43 @@ export function registerAppHandlers(): void {
 
   ipcMain.handle('wsl:isAvailable', (): boolean => isWslAvailable())
 
-  // Why: Polish Pro, US Extended, ABC Extended, and the Japanese/Chinese/Korean
-  // Roman IMEs all report a US-QWERTY base layer to navigator.keyboard
-  // .getLayoutMap() — the layout-fingerprint probe in the renderer therefore
-  // classifies them as 'us' and flips macOptionIsMeta=true, which swallows
-  // Option+letter compositions (issue #1205: Polish diacritics fail to type).
-  // macOS's AppleCurrentKeyboardLayoutInputSourceID distinguishes these from
-  // plain com.apple.keylayout.US, so we surface it to the renderer as an
-  // authoritative override. Non-Darwin platforms have no equivalent and
-  // return null so the fingerprint stays the only signal.
+  // Why: ABC, Polish Pro, US Extended, ABC Extended, and every CJK Roman
+  // IME all report a US-QWERTY base layer to navigator.keyboard.getLayoutMap()
+  // — the layout-fingerprint probe in the renderer therefore classifies
+  // them as 'us' and flips macOptionIsMeta=true, silently swallowing every
+  // Option+letter composition (#1205: Option+A → å / ą is dropped). The
+  // macOS-shipped `com.apple.HIToolbox` preference
+  // `AppleCurrentKeyboardLayoutInputSourceID` names the actual layout
+  // (e.g. `com.apple.keylayout.ABC` vs `com.apple.keylayout.US`), which
+  // the renderer uses as an authoritative override. Non-Darwin platforms
+  // have no equivalent and return null so the fingerprint stays the only
+  // signal.
+  //
+  // Why `defaults read` (via execFileSync) and not systemPreferences
+  // .getUserDefault: getUserDefault only reads from NSGlobalDomain and the
+  // current app's own domain. The keyboard layout ID lives in the
+  // `com.apple.HIToolbox` domain, which getUserDefault cannot reach —
+  // observed to return null even when the preference is set. The `defaults`
+  // CLI reads any domain and is the same mechanism Apple documents for
+  // this value.
   ipcMain.handle('app:getKeyboardInputSourceId', (): string | null => {
     if (process.platform !== 'darwin') {
       return null
     }
     try {
-      const value = systemPreferences.getUserDefault(
-        'AppleCurrentKeyboardLayoutInputSourceID',
-        'string'
-      )
-      if (typeof value !== 'string' || value.length === 0) {
-        return null
-      }
-      return value
+      const stdout = execFileSync(
+        '/usr/bin/defaults',
+        ['read', 'com.apple.HIToolbox', 'AppleCurrentKeyboardLayoutInputSourceID'],
+        // Why: short timeout so a wedged defaults binary (corporate-managed
+        // config, sandbox policy, …) never stalls the renderer's probe.
+        // Fall through to the fingerprint on timeout.
+        { encoding: 'utf8', timeout: 500, stdio: ['ignore', 'pipe', 'ignore'] }
+      ).trim()
+      return stdout.length > 0 ? stdout : null
     } catch {
-      // Why: defaults may be unreadable in sandboxed or corporate-managed
-      // environments; treat that as "no signal" rather than crashing the
-      // renderer. The layout fingerprint still runs as a fallback.
+      // Why: defaults exits non-zero when the key is absent (first boot
+      // before any input-source interaction), or when sandboxed. Treat
+      // that as "no signal" — the fingerprint still runs as fallback.
       return null
     }
   })

--- a/src/main/ipc/app.ts
+++ b/src/main/ipc/app.ts
@@ -1,6 +1,9 @@
-import { execFileSync } from 'node:child_process'
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
 import { app, ipcMain } from 'electron'
 import { isWslAvailable } from '../wsl'
+
+const execFileAsync = promisify(execFile)
 
 export type AppRuntimeFlags = {
   /** Whether the persistent terminal daemon was actually started this session.
@@ -62,20 +65,25 @@ export function registerAppHandlers(): void {
   // observed to return null even when the preference is set. The `defaults`
   // CLI reads any domain and is the same mechanism Apple documents for
   // this value.
-  ipcMain.handle('app:getKeyboardInputSourceId', (): string | null => {
+  ipcMain.handle('app:getKeyboardInputSourceId', async (): Promise<string | null> => {
     if (process.platform !== 'darwin') {
       return null
     }
     try {
-      const stdout = execFileSync(
+      // Why: async so the probe never blocks the main-process event loop.
+      // The probe re-runs on every window focus-in (see option-as-alt-probe.ts),
+      // and a blocking execFileSync would briefly stall unrelated IPC each
+      // time the user Alt-Tabbed back into the app.
+      const { stdout } = await execFileAsync(
         '/usr/bin/defaults',
         ['read', 'com.apple.HIToolbox', 'AppleCurrentKeyboardLayoutInputSourceID'],
         // Why: short timeout so a wedged defaults binary (corporate-managed
-        // config, sandbox policy, …) never stalls the renderer's probe.
+        // config, sandbox policy, …) never holds the handle indefinitely.
         // Fall through to the fingerprint on timeout.
-        { encoding: 'utf8', timeout: 500, stdio: ['ignore', 'pipe', 'ignore'] }
-      ).trim()
-      return stdout.length > 0 ? stdout : null
+        { encoding: 'utf8', timeout: 500 }
+      )
+      const trimmed = stdout.trim()
+      return trimmed.length > 0 ? trimmed : null
     } catch {
       // Why: defaults exits non-zero when the key is absent (first boot
       // before any input-source interaction), or when sandboxed. Treat

--- a/src/main/ipc/app.ts
+++ b/src/main/ipc/app.ts
@@ -1,4 +1,4 @@
-import { app, ipcMain } from 'electron'
+import { app, ipcMain, systemPreferences } from 'electron'
 import { isWslAvailable } from '../wsl'
 
 export type AppRuntimeFlags = {
@@ -41,6 +41,36 @@ export function registerAppHandlers(): void {
   })
 
   ipcMain.handle('wsl:isAvailable', (): boolean => isWslAvailable())
+
+  // Why: Polish Pro, US Extended, ABC Extended, and the Japanese/Chinese/Korean
+  // Roman IMEs all report a US-QWERTY base layer to navigator.keyboard
+  // .getLayoutMap() — the layout-fingerprint probe in the renderer therefore
+  // classifies them as 'us' and flips macOptionIsMeta=true, which swallows
+  // Option+letter compositions (issue #1205: Polish diacritics fail to type).
+  // macOS's AppleCurrentKeyboardLayoutInputSourceID distinguishes these from
+  // plain com.apple.keylayout.US, so we surface it to the renderer as an
+  // authoritative override. Non-Darwin platforms have no equivalent and
+  // return null so the fingerprint stays the only signal.
+  ipcMain.handle('app:getKeyboardInputSourceId', (): string | null => {
+    if (process.platform !== 'darwin') {
+      return null
+    }
+    try {
+      const value = systemPreferences.getUserDefault(
+        'AppleCurrentKeyboardLayoutInputSourceID',
+        'string'
+      )
+      if (typeof value !== 'string' || value.length === 0) {
+        return null
+      }
+      return value
+    } catch {
+      // Why: defaults may be unreadable in sandboxed or corporate-managed
+      // environments; treat that as "no signal" rather than crashing the
+      // renderer. The layout fingerprint still runs as a fallback.
+      return null
+    }
+  })
 
   ipcMain.handle('app:relaunch', () => {
     // Why: small delay lets the renderer finish painting any "Restarting…"

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -285,6 +285,12 @@ export type AppApi = {
   /** Relaunches the app via Electron's app.relaunch() + app.exit(0). Used
    *  by the "Restart now" button on the Experimental settings pane. */
   relaunch: () => Promise<void>
+  /** Returns the macOS `AppleCurrentKeyboardLayoutInputSourceID` when
+   *  available (e.g. `com.apple.keylayout.PolishPro`). Used by the
+   *  keyboard-layout probe to distinguish layouts whose base layer matches
+   *  US QWERTY but whose Option layer composes characters (issue #1205).
+   *  Returns null on non-Darwin platforms or when the defaults read fails. */
+  getKeyboardInputSourceId: () => Promise<string | null>
 }
 
 export type PreloadApi = {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -176,7 +176,14 @@ const api = {
       ipcRenderer.invoke('app:getRuntimeFlags'),
     consumeDaemonTransitionNotice: (): Promise<{ killedCount: number } | null> =>
       ipcRenderer.invoke('app:consumeDaemonTransitionNotice'),
-    relaunch: (): Promise<void> => ipcRenderer.invoke('app:relaunch')
+    relaunch: (): Promise<void> => ipcRenderer.invoke('app:relaunch'),
+    // Why: on macOS this returns AppleCurrentKeyboardLayoutInputSourceID so
+    // the renderer's keyboard-layout probe can distinguish Polish Pro / US
+    // Extended / ABC Extended / IME Roman modes from plain US QWERTY (see
+    // src/renderer/src/lib/keyboard-layout/input-source-id.ts, issue #1205).
+    // Returns null on non-Darwin or when the defaults read fails.
+    getKeyboardInputSourceId: (): Promise<string | null> =>
+      ipcRenderer.invoke('app:getKeyboardInputSourceId')
   },
 
   wsl: {

--- a/src/renderer/src/lib/keyboard-layout/input-source-id.test.ts
+++ b/src/renderer/src/lib/keyboard-layout/input-source-id.test.ts
@@ -2,52 +2,59 @@ import { describe, it, expect } from 'vitest'
 import { classifyInputSourceId } from './input-source-id'
 
 describe('classifyInputSourceId', () => {
-  it('returns "none" for nullish input (no signal available)', () => {
-    expect(classifyInputSourceId(null)).toBe('none')
-    expect(classifyInputSourceId(undefined)).toBe('none')
-    expect(classifyInputSourceId('')).toBe('none')
+  it('returns "unknown" for nullish input so the caller falls back to the fingerprint', () => {
+    expect(classifyInputSourceId(null)).toBe('unknown')
+    expect(classifyInputSourceId(undefined)).toBe('unknown')
+    expect(classifyInputSourceId('')).toBe('unknown')
   })
 
-  it('returns "none" for plain US QWERTY (fingerprint is authoritative)', () => {
-    expect(classifyInputSourceId('com.apple.keylayout.US')).toBe('none')
-    expect(classifyInputSourceId('com.apple.keylayout.ABC')).toBe('none')
-    expect(classifyInputSourceId('com.apple.keylayout.Dvorak')).toBe('none')
+  it('allowlists plain US Standard as meta', () => {
+    expect(classifyInputSourceId('com.apple.keylayout.US')).toBe('meta')
   })
 
-  it('flags Polish Pro as composing (the #1205 repro)', () => {
+  it('allowlists US International PC as meta', () => {
+    expect(classifyInputSourceId('com.apple.keylayout.USInternational-PC')).toBe('meta')
+  })
+
+  it('is case-insensitive on the allowlist (defaults differ between macOS versions)', () => {
+    expect(classifyInputSourceId('COM.APPLE.KEYLAYOUT.US')).toBe('meta')
+    expect(classifyInputSourceId('com.apple.keylayout.us')).toBe('meta')
+  })
+
+  it('classifies ABC as compose (the user-reported Option+A → å repro)', () => {
+    // ABC looks US on the base layer but composes Option+A → å. Pre-fix,
+    // the fingerprint alone drove the decision and flipped
+    // macOptionIsMeta=true, silently swallowing the composition.
+    expect(classifyInputSourceId('com.apple.keylayout.ABC')).toBe('compose')
+  })
+
+  it('classifies Polish Pro as compose (#1205)', () => {
     expect(classifyInputSourceId('com.apple.keylayout.PolishPro')).toBe('compose')
   })
 
-  it('flags US Extended as composing', () => {
+  it('classifies US Extended and ABC Extended as compose', () => {
     expect(classifyInputSourceId('com.apple.keylayout.USExtended')).toBe('compose')
-  })
-
-  it('flags ABC Extended as composing', () => {
     expect(classifyInputSourceId('com.apple.keylayout.ABCExtended')).toBe('compose')
   })
 
-  it('is case-insensitive (defaults can differ between major macOS versions)', () => {
-    expect(classifyInputSourceId('COM.APPLE.KEYLAYOUT.POLISHPRO')).toBe('compose')
-    expect(classifyInputSourceId('com.apple.keylayout.polishpro')).toBe('compose')
-  })
-
-  it('matches prefix + dot-suffix variants so future Apple-shipped subtypes still flag', () => {
-    expect(classifyInputSourceId('com.apple.keylayout.PolishPro.variant')).toBe('compose')
-    expect(classifyInputSourceId('com.apple.keylayout.USExtended.v2')).toBe('compose')
-  })
-
-  it('does not flag unrelated IDs that happen to start with "com.apple.keylayout.US"', () => {
-    // "US" is a prefix of "USExtended"/"USInternational" but on its own it
-    // is plain US QWERTY — the denylist uses full-identifier matching plus
-    // a `.`-bounded prefix form so "US" never bleeds into variants.
-    expect(classifyInputSourceId('com.apple.keylayout.US')).toBe('none')
-    expect(classifyInputSourceId('com.apple.keylayout.USInternational-PC')).toBe('none')
-  })
-
-  it('flags Japanese/Chinese/Korean Roman IMEs (Option routes through the IME)', () => {
+  it('classifies every other Apple-shipped layout as compose (default-deny)', () => {
+    // Matches Ghostty: only US and USInternational-PC are allowlisted;
+    // everything else (Dvorak, Colemak, German, French, Turkish, Spanish,
+    // Swedish, every CJK Roman IME) falls back to compose.
+    expect(classifyInputSourceId('com.apple.keylayout.Dvorak')).toBe('compose')
+    expect(classifyInputSourceId('com.apple.keylayout.Colemak')).toBe('compose')
+    expect(classifyInputSourceId('com.apple.keylayout.German')).toBe('compose')
+    expect(classifyInputSourceId('com.apple.keylayout.French')).toBe('compose')
+    expect(classifyInputSourceId('com.apple.keylayout.Turkish-QWERTY')).toBe('compose')
     expect(classifyInputSourceId('com.apple.inputmethod.Kotoeri.Roman')).toBe('compose')
     expect(classifyInputSourceId('com.apple.inputmethod.TCIM.Pinyin')).toBe('compose')
-    expect(classifyInputSourceId('com.apple.inputmethod.SCIM.ITABC')).toBe('compose')
     expect(classifyInputSourceId('com.apple.inputmethod.Korean.2SetKorean')).toBe('compose')
+  })
+
+  it('does not prefix-leak the US allowlist into extended variants', () => {
+    // `com.apple.keylayout.US` must not silently allowlist `USExtended`.
+    // The matcher is full-ID equality (case-insensitive), not prefix.
+    expect(classifyInputSourceId('com.apple.keylayout.USExtended')).toBe('compose')
+    expect(classifyInputSourceId('com.apple.keylayout.US.variant')).toBe('compose')
   })
 })

--- a/src/renderer/src/lib/keyboard-layout/input-source-id.test.ts
+++ b/src/renderer/src/lib/keyboard-layout/input-source-id.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { classifyInputSourceId } from './input-source-id'
+
+describe('classifyInputSourceId', () => {
+  it('returns "none" for nullish input (no signal available)', () => {
+    expect(classifyInputSourceId(null)).toBe('none')
+    expect(classifyInputSourceId(undefined)).toBe('none')
+    expect(classifyInputSourceId('')).toBe('none')
+  })
+
+  it('returns "none" for plain US QWERTY (fingerprint is authoritative)', () => {
+    expect(classifyInputSourceId('com.apple.keylayout.US')).toBe('none')
+    expect(classifyInputSourceId('com.apple.keylayout.ABC')).toBe('none')
+    expect(classifyInputSourceId('com.apple.keylayout.Dvorak')).toBe('none')
+  })
+
+  it('flags Polish Pro as composing (the #1205 repro)', () => {
+    expect(classifyInputSourceId('com.apple.keylayout.PolishPro')).toBe('compose')
+  })
+
+  it('flags US Extended as composing', () => {
+    expect(classifyInputSourceId('com.apple.keylayout.USExtended')).toBe('compose')
+  })
+
+  it('flags ABC Extended as composing', () => {
+    expect(classifyInputSourceId('com.apple.keylayout.ABCExtended')).toBe('compose')
+  })
+
+  it('is case-insensitive (defaults can differ between major macOS versions)', () => {
+    expect(classifyInputSourceId('COM.APPLE.KEYLAYOUT.POLISHPRO')).toBe('compose')
+    expect(classifyInputSourceId('com.apple.keylayout.polishpro')).toBe('compose')
+  })
+
+  it('matches prefix + dot-suffix variants so future Apple-shipped subtypes still flag', () => {
+    expect(classifyInputSourceId('com.apple.keylayout.PolishPro.variant')).toBe('compose')
+    expect(classifyInputSourceId('com.apple.keylayout.USExtended.v2')).toBe('compose')
+  })
+
+  it('does not flag unrelated IDs that happen to start with "com.apple.keylayout.US"', () => {
+    // "US" is a prefix of "USExtended"/"USInternational" but on its own it
+    // is plain US QWERTY — the denylist uses full-identifier matching plus
+    // a `.`-bounded prefix form so "US" never bleeds into variants.
+    expect(classifyInputSourceId('com.apple.keylayout.US')).toBe('none')
+    expect(classifyInputSourceId('com.apple.keylayout.USInternational-PC')).toBe('none')
+  })
+
+  it('flags Japanese/Chinese/Korean Roman IMEs (Option routes through the IME)', () => {
+    expect(classifyInputSourceId('com.apple.inputmethod.Kotoeri.Roman')).toBe('compose')
+    expect(classifyInputSourceId('com.apple.inputmethod.TCIM.Pinyin')).toBe('compose')
+    expect(classifyInputSourceId('com.apple.inputmethod.SCIM.ITABC')).toBe('compose')
+    expect(classifyInputSourceId('com.apple.inputmethod.Korean.2SetKorean')).toBe('compose')
+  })
+})

--- a/src/renderer/src/lib/keyboard-layout/input-source-id.ts
+++ b/src/renderer/src/lib/keyboard-layout/input-source-id.ts
@@ -1,0 +1,88 @@
+/**
+ * Classifier for macOS's `AppleCurrentKeyboardLayoutInputSourceID`.
+ *
+ * Why this exists alongside detect-option-as-alt: the layout-fingerprint
+ * probe (`detectOptionAsAltFromLayoutMap`) inspects `navigator.keyboard
+ * .getLayoutMap()`, which only surfaces the base (unshifted) layer. Some
+ * Apple-shipped layouts — most notably "Polish Pro" and the Japanese/Chinese
+ * Roman modes — keep the base layer identical to US QWERTY but repurpose
+ * the Option layer for character composition (Option+A = ą, Option+C = ć,
+ * …). The fingerprint classifies these as `'us'`, the effective setting
+ * resolves to `'true'`, xterm's `macOptionIsMeta` turns on, and every
+ * Option+letter keystroke is silently translated to an Esc+letter
+ * readline chord — so typing Polish diacritics, etc., fails with no
+ * visible feedback (issue #1205).
+ *
+ * macOS exposes the active input source via the defaults value
+ * `AppleCurrentKeyboardLayoutInputSourceID` (e.g. `com.apple.keylayout.US`,
+ * `com.apple.keylayout.PolishPro`, `com.apple.inputmethod.Kotoeri.…`). This
+ * module keeps an explicit denylist of IDs whose Option layer composes
+ * characters even though the base layer looks US-like; anything on that
+ * denylist overrides the fingerprint's `'us'` verdict.
+ *
+ * Reference:
+ *   ~/projects/ghostty/macos/Sources/Helpers/KeyboardLayout.swift
+ *   (Ghostty reads TISCopyCurrentKeyboardInputSource; same underlying
+ *   identifier string as AppleCurrentKeyboardLayoutInputSourceID.)
+ */
+
+/**
+ * Input source IDs whose Option layer composes layout characters even
+ * though the unshifted layer matches US QWERTY on `getLayoutMap()`. On
+ * these layouts the effective `macOptionAsAlt` must stay `'false'` so
+ * Option+letter reaches xterm as a composed dead-key character instead of
+ * being translated to an Esc+letter readline chord.
+ *
+ * Matching is case-insensitive on the full ID so future Apple-shipped
+ * variants under the same product family (e.g. `PolishProUnicode`,
+ * `Polish.…`) are still caught. Prefix matching is intentional —
+ * Apple occasionally ships `.US` vs `.USExtended` pairs where the
+ * extended variant also composes via Option.
+ */
+const COMPOSING_INPUT_SOURCE_PREFIXES: readonly string[] = [
+  // Polish Pro: base layer is US QWERTY, Option+A/C/E/L/N/O/S/X/Z compose
+  // the nine Polish diacritics (ą, ć, ę, ł, ń, ó, ś, ź, ż). Reported in #1205.
+  'com.apple.keylayout.polishpro',
+  // US Extended (formerly "US Extended" / "USExtended"): ships with macOS
+  // and uses Option as a dead-key modifier for accents on A/E/I/O/U — same
+  // shape as the Polish Pro trap. Matches Ghostty's classification.
+  'com.apple.keylayout.usextended',
+  // ABC Extended: Apple's newer replacement for US Extended. Base layer
+  // matches US; Option composes accents and typographic punctuation.
+  'com.apple.keylayout.abcextended',
+  // Japanese/Chinese/Korean Roman modes route Option through the IME for
+  // kana/pinyin input. The fingerprint sees a US-looking base layer
+  // because the Roman mode reports ASCII, so we treat these as composing.
+  'com.apple.inputmethod.kotoeri',
+  'com.apple.inputmethod.tcim',
+  'com.apple.inputmethod.scim',
+  'com.apple.inputmethod.korean'
+]
+
+export type InputSourceOverride =
+  /** Input source is known to compose layout characters via Option. The
+   *  effective setting must be `'false'` regardless of what the layout
+   *  fingerprint said. */
+  | 'compose'
+  /** Input source is recognized but does not compose via Option (e.g.
+   *  plain `com.apple.keylayout.US`, `com.apple.keylayout.Dvorak`). Let
+   *  the fingerprint decide. */
+  | 'none'
+
+export function classifyInputSourceId(id: string | null | undefined): InputSourceOverride {
+  if (!id) {
+    return 'none'
+  }
+  const normalized = id.toLowerCase()
+  for (const prefix of COMPOSING_INPUT_SOURCE_PREFIXES) {
+    if (normalized === prefix || normalized.startsWith(`${prefix}.`)) {
+      return 'compose'
+    }
+  }
+  return 'none'
+}
+
+/** Test-only: exported so tests can assert the denylist membership
+ *  directly without reimporting the private constant. */
+export const __composingInputSourcePrefixesForTests: readonly string[] =
+  COMPOSING_INPUT_SOURCE_PREFIXES

--- a/src/renderer/src/lib/keyboard-layout/input-source-id.ts
+++ b/src/renderer/src/lib/keyboard-layout/input-source-id.ts
@@ -3,86 +3,78 @@
  *
  * Why this exists alongside detect-option-as-alt: the layout-fingerprint
  * probe (`detectOptionAsAltFromLayoutMap`) inspects `navigator.keyboard
- * .getLayoutMap()`, which only surfaces the base (unshifted) layer. Some
- * Apple-shipped layouts — most notably "Polish Pro" and the Japanese/Chinese
- * Roman modes — keep the base layer identical to US QWERTY but repurpose
- * the Option layer for character composition (Option+A = ą, Option+C = ć,
- * …). The fingerprint classifies these as `'us'`, the effective setting
- * resolves to `'true'`, xterm's `macOptionIsMeta` turns on, and every
- * Option+letter keystroke is silently translated to an Esc+letter
- * readline chord — so typing Polish diacritics, etc., fails with no
+ * .getLayoutMap()`, which only surfaces the base (unshifted) layer. Many
+ * macOS layouts keep a US-identical base layer but repurpose the Option
+ * layer for dead-key composition — ABC (Option+A = å), Polish Pro
+ * (Option+A = ą), US Extended, ABC Extended, and the CJK Roman IMEs all
+ * share this trap. The fingerprint classifies them as `'us'`, the
+ * effective setting resolves to `'true'`, xterm's `macOptionIsMeta`
+ * turns on, and every Option+letter keystroke is silently translated to
+ * an Esc+letter readline chord — so typing å, ą, ï, etc., fails with no
  * visible feedback (issue #1205).
  *
- * macOS exposes the active input source via the defaults value
- * `AppleCurrentKeyboardLayoutInputSourceID` (e.g. `com.apple.keylayout.US`,
- * `com.apple.keylayout.PolishPro`, `com.apple.inputmethod.Kotoeri.…`). This
- * module keeps an explicit denylist of IDs whose Option layer composes
- * characters even though the base layer looks US-like; anything on that
- * denylist overrides the fingerprint's `'us'` verdict.
+ * The only layouts where Option-as-Meta is the right default are plain
+ * US Standard and US-International-PC — matching Ghostty's
+ * `detectOptionAsAlt` (~/projects/ghostty/src/input/keyboard.zig:25-57
+ * + ~/projects/ghostty/macos/Sources/Helpers/KeyboardLayout.swift,
+ * which whitelists only `com.apple.keylayout.US` and
+ * `com.apple.keylayout.USInternational-PC`).
  *
- * Reference:
- *   ~/projects/ghostty/macos/Sources/Helpers/KeyboardLayout.swift
- *   (Ghostty reads TISCopyCurrentKeyboardInputSource; same underlying
- *   identifier string as AppleCurrentKeyboardLayoutInputSourceID.)
+ * When the main-process IPC returns a non-null ID, this classifier is
+ * authoritative: `'meta'` → Option-as-Meta is safe; `'compose'` →
+ * Option must compose. The fingerprint probe is only consulted when no
+ * ID is available (non-Darwin, sandboxed defaults, IPC failure).
  */
 
 /**
- * Input source IDs whose Option layer composes layout characters even
- * though the unshifted layer matches US QWERTY on `getLayoutMap()`. On
- * these layouts the effective `macOptionAsAlt` must stay `'false'` so
- * Option+letter reaches xterm as a composed dead-key character instead of
- * being translated to an Esc+letter readline chord.
+ * Input source IDs where Option-as-Meta is the correct default. The
+ * shipped US Standard and US-International-PC layouts are the only
+ * Apple layouts that don't use Option for composition. Everything else
+ * — including ABC, Polish Pro, US Extended, ABC Extended, every
+ * international layout, every CJK Roman IME — composes via Option and
+ * must stay `'false'`.
  *
- * Matching is case-insensitive on the full ID so future Apple-shipped
- * variants under the same product family (e.g. `PolishProUnicode`,
- * `Polish.…`) are still caught. Prefix matching is intentional —
- * Apple occasionally ships `.US` vs `.USExtended` pairs where the
- * extended variant also composes via Option.
+ * Matching is case-insensitive full-ID. We deliberately do NOT prefix-
+ * match here: `com.apple.keylayout.US` must not silently allowlist
+ * `com.apple.keylayout.USExtended`.
  */
-const COMPOSING_INPUT_SOURCE_PREFIXES: readonly string[] = [
-  // Polish Pro: base layer is US QWERTY, Option+A/C/E/L/N/O/S/X/Z compose
-  // the nine Polish diacritics (ą, ć, ę, ł, ń, ó, ś, ź, ż). Reported in #1205.
-  'com.apple.keylayout.polishpro',
-  // US Extended (formerly "US Extended" / "USExtended"): ships with macOS
-  // and uses Option as a dead-key modifier for accents on A/E/I/O/U — same
-  // shape as the Polish Pro trap. Matches Ghostty's classification.
-  'com.apple.keylayout.usextended',
-  // ABC Extended: Apple's newer replacement for US Extended. Base layer
-  // matches US; Option composes accents and typographic punctuation.
-  'com.apple.keylayout.abcextended',
-  // Japanese/Chinese/Korean Roman modes route Option through the IME for
-  // kana/pinyin input. The fingerprint sees a US-looking base layer
-  // because the Roman mode reports ASCII, so we treat these as composing.
-  'com.apple.inputmethod.kotoeri',
-  'com.apple.inputmethod.tcim',
-  'com.apple.inputmethod.scim',
-  'com.apple.inputmethod.korean'
+const META_INPUT_SOURCE_IDS: readonly string[] = [
+  'com.apple.keylayout.us',
+  'com.apple.keylayout.usinternational-pc'
 ]
 
 export type InputSourceOverride =
-  /** Input source is known to compose layout characters via Option. The
-   *  effective setting must be `'false'` regardless of what the layout
-   *  fingerprint said. */
+  /** Option-as-Meta is safe on this input source. Resolves to `'us'`
+   *  for `effectiveMacOptionAsAlt`. */
+  | 'meta'
+  /** Option composes layout characters on this input source. Resolves
+   *  to `'non-us'` so `macOptionIsMeta` stays off and compositions like
+   *  Option+A → å / ą reach the shell. */
   | 'compose'
-  /** Input source is recognized but does not compose via Option (e.g.
-   *  plain `com.apple.keylayout.US`, `com.apple.keylayout.Dvorak`). Let
-   *  the fingerprint decide. */
-  | 'none'
+  /** No macOS input source ID available (non-Darwin, IPC failure,
+   *  sandboxed defaults). The caller should fall back to the layout
+   *  fingerprint. */
+  | 'unknown'
 
 export function classifyInputSourceId(id: string | null | undefined): InputSourceOverride {
   if (!id) {
-    return 'none'
+    return 'unknown'
   }
   const normalized = id.toLowerCase()
-  for (const prefix of COMPOSING_INPUT_SOURCE_PREFIXES) {
-    if (normalized === prefix || normalized.startsWith(`${prefix}.`)) {
-      return 'compose'
+  for (const allowed of META_INPUT_SOURCE_IDS) {
+    if (normalized === allowed) {
+      return 'meta'
     }
   }
-  return 'none'
+  // Why: any other macOS input source ID composes via Option. This
+  // includes ABC (not to be confused with US), Polish Pro, US Extended,
+  // ABC Extended, every international layout, Dvorak, Colemak, and
+  // every CJK Roman IME. Forcing `'compose'` matches Ghostty's
+  // allowlist-only behavior and prevents the #1205-style silent-swallow
+  // bug from recurring for any future Apple-shipped layout.
+  return 'compose'
 }
 
-/** Test-only: exported so tests can assert the denylist membership
- *  directly without reimporting the private constant. */
-export const __composingInputSourcePrefixesForTests: readonly string[] =
-  COMPOSING_INPUT_SOURCE_PREFIXES
+/** Test-only: exported so tests can assert the allowlist without
+ *  reimporting the private constant. */
+export const __metaInputSourceIdsForTests: readonly string[] = META_INPUT_SOURCE_IDS

--- a/src/renderer/src/lib/keyboard-layout/option-as-alt-probe.test.ts
+++ b/src/renderer/src/lib/keyboard-layout/option-as-alt-probe.test.ts
@@ -170,4 +170,71 @@ describe('createOptionAsAltProbe', () => {
     // No further calls after dispose.
     expect(listener).not.toHaveBeenCalled()
   })
+
+  it('forces non-us when the macOS input source ID is on the compose denylist (#1205)', async () => {
+    // Polish Pro reports a US-identical base layer to getLayoutMap(); without
+    // the input-source override it would classify as 'us' → macOptionIsMeta=true
+    // and swallow every Option+letter composition (ą, ć, ę, …).
+    const win = makeMockWindow(US_MAP)
+    const probe = createOptionAsAltProbe(win as unknown as Window, {
+      readInputSourceId: async () => 'com.apple.keylayout.PolishPro'
+    })
+    await probe.refresh()
+    expect(probe.getCurrent()).toBe('non-us')
+    probe.dispose()
+  })
+
+  it('lets the fingerprint decide when the input source ID is plain US', async () => {
+    const win = makeMockWindow(US_MAP)
+    const probe = createOptionAsAltProbe(win as unknown as Window, {
+      readInputSourceId: async () => 'com.apple.keylayout.US'
+    })
+    await probe.refresh()
+    expect(probe.getCurrent()).toBe('us')
+    probe.dispose()
+  })
+
+  it('falls back to the fingerprint when the input-source reader returns null (non-Darwin)', async () => {
+    const win = makeMockWindow(US_MAP)
+    const probe = createOptionAsAltProbe(win as unknown as Window, {
+      readInputSourceId: async () => null
+    })
+    await probe.refresh()
+    expect(probe.getCurrent()).toBe('us')
+    probe.dispose()
+  })
+
+  it('falls back to the fingerprint when the input-source reader throws', async () => {
+    const win = makeMockWindow(TURKISH_MAP)
+    const probe = createOptionAsAltProbe(win as unknown as Window, {
+      readInputSourceId: async () => {
+        throw new Error('ipc unavailable')
+      }
+    })
+    await probe.refresh()
+    expect(probe.getCurrent()).toBe('non-us')
+    probe.dispose()
+  })
+
+  it('re-probes the input source ID on focus-in so mid-session layout switches are picked up', async () => {
+    // Simulate: user boots on US, flips to Polish Pro via the Input Source
+    // menu, Orca regains focus. Fingerprint stays US the whole time; the
+    // input-source override is what notices the switch.
+    let activeInputSourceId: string | null = 'com.apple.keylayout.US'
+    const win = makeMockWindow(US_MAP)
+    const probe = createOptionAsAltProbe(win as unknown as Window, {
+      readInputSourceId: async () => activeInputSourceId
+    })
+    await probe.refresh()
+    expect(probe.getCurrent()).toBe('us')
+
+    activeInputSourceId = 'com.apple.keylayout.PolishPro'
+    win.fireFocus()
+    // Let the focus-triggered probe resolve.
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(probe.getCurrent()).toBe('non-us')
+    probe.dispose()
+  })
 })

--- a/src/renderer/src/lib/keyboard-layout/option-as-alt-probe.test.ts
+++ b/src/renderer/src/lib/keyboard-layout/option-as-alt-probe.test.ts
@@ -171,26 +171,43 @@ describe('createOptionAsAltProbe', () => {
     expect(listener).not.toHaveBeenCalled()
   })
 
-  it('forces non-us when the macOS input source ID is on the compose denylist (#1205)', async () => {
-    // Polish Pro reports a US-identical base layer to getLayoutMap(); without
-    // the input-source override it would classify as 'us' → macOptionIsMeta=true
-    // and swallow every Option+letter composition (ą, ć, ę, …).
-    const win = makeMockWindow(US_MAP)
-    const probe = createOptionAsAltProbe(win as unknown as Window, {
-      readInputSourceId: async () => 'com.apple.keylayout.PolishPro'
-    })
-    await probe.refresh()
-    expect(probe.getCurrent()).toBe('non-us')
-    probe.dispose()
+  it('forces non-us when the input source ID is not on the Option-as-Meta allowlist (#1205)', async () => {
+    // ABC and Polish Pro both report a US-identical base layer to
+    // getLayoutMap(); without the input-source override they would classify
+    // as 'us' → macOptionIsMeta=true and swallow every Option+letter
+    // composition (Option+A → å on ABC, ą on Polish Pro).
+    for (const id of ['com.apple.keylayout.ABC', 'com.apple.keylayout.PolishPro']) {
+      const win = makeMockWindow(US_MAP)
+      const probe = createOptionAsAltProbe(win as unknown as Window, {
+        readInputSourceId: async () => id
+      })
+      await probe.refresh()
+      expect(probe.getCurrent()).toBe('non-us')
+      probe.dispose()
+    }
   })
 
-  it('lets the fingerprint decide when the input source ID is plain US', async () => {
+  it('resolves to us when the input source ID is plain US (allowlist match)', async () => {
     const win = makeMockWindow(US_MAP)
     const probe = createOptionAsAltProbe(win as unknown as Window, {
       readInputSourceId: async () => 'com.apple.keylayout.US'
     })
     await probe.refresh()
     expect(probe.getCurrent()).toBe('us')
+    probe.dispose()
+  })
+
+  it('trusts the input source ID over the fingerprint even when the fingerprint says us', async () => {
+    // Pre-fix: the fingerprint's 'us' verdict was authoritative and the
+    // macOS ID was ignored, so Turkish-F (which reports US-identical on
+    // several keys) plus any US-like fingerprint flipped
+    // macOptionIsMeta=true. Now the ID overrides.
+    const win = makeMockWindow(US_MAP)
+    const probe = createOptionAsAltProbe(win as unknown as Window, {
+      readInputSourceId: async () => 'com.apple.keylayout.German'
+    })
+    await probe.refresh()
+    expect(probe.getCurrent()).toBe('non-us')
     probe.dispose()
   })
 
@@ -217,8 +234,8 @@ describe('createOptionAsAltProbe', () => {
   })
 
   it('re-probes the input source ID on focus-in so mid-session layout switches are picked up', async () => {
-    // Simulate: user boots on US, flips to Polish Pro via the Input Source
-    // menu, Orca regains focus. Fingerprint stays US the whole time; the
+    // Simulate: user boots on US, flips to ABC via the Input Source menu,
+    // Orca regains focus. Fingerprint stays US the whole time; the
     // input-source override is what notices the switch.
     let activeInputSourceId: string | null = 'com.apple.keylayout.US'
     const win = makeMockWindow(US_MAP)
@@ -228,7 +245,7 @@ describe('createOptionAsAltProbe', () => {
     await probe.refresh()
     expect(probe.getCurrent()).toBe('us')
 
-    activeInputSourceId = 'com.apple.keylayout.PolishPro'
+    activeInputSourceId = 'com.apple.keylayout.ABC'
     win.fireFocus()
     // Let the focus-triggered probe resolve.
     await Promise.resolve()

--- a/src/renderer/src/lib/keyboard-layout/option-as-alt-probe.ts
+++ b/src/renderer/src/lib/keyboard-layout/option-as-alt-probe.ts
@@ -13,12 +13,21 @@
  * reliable proxy. The only missed case is a layout change triggered by a
  * key pressed while Orca is focused (e.g. a Karabiner rule), which is
  * exceedingly rare and self-heals on the next blur/focus cycle.
+ *
+ * Why two signals (fingerprint + input source ID): the fingerprint can only
+ * see the base (unshifted) layer, which is identical to US QWERTY on
+ * Polish Pro, US Extended, ABC Extended, and the CJK Roman IMEs — all of
+ * which use Option as a dead-key / compose modifier. Without the input
+ * source ID override, those users get macOptionIsMeta=true and lose every
+ * Option+letter composition (issue #1205). See
+ * ./input-source-id.ts for the denylist.
  */
 import {
   detectOptionAsAltFromLayoutMap,
   type DetectedLayoutCategory,
   type LayoutMapLike
 } from './detect-option-as-alt'
+import { classifyInputSourceId } from './input-source-id'
 
 type NavigatorWithKeyboard = Navigator & {
   keyboard?: {
@@ -27,6 +36,8 @@ type NavigatorWithKeyboard = Navigator & {
 }
 
 type Listener = (category: DetectedLayoutCategory) => void
+
+type InputSourceIdReader = () => Promise<string | null>
 
 export type OptionAsAltProbe = {
   /** Current detected category. Starts `'unknown'` until the first probe
@@ -40,10 +51,43 @@ export type OptionAsAltProbe = {
   dispose: () => void
 }
 
-export function createOptionAsAltProbe(win: Window = window): OptionAsAltProbe {
+type CreateProbeOptions = {
+  /** Injectable reader for the macOS input source ID. Defaults to the
+   *  preload `window.api.app.getKeyboardInputSourceId` when available.
+   *  Tests pass a stub to exercise the compose override deterministically. */
+  readInputSourceId?: InputSourceIdReader
+}
+
+function defaultInputSourceIdReader(): InputSourceIdReader {
+  return async () => {
+    const api = (
+      globalThis as {
+        window?: { api?: { app?: { getKeyboardInputSourceId?: () => Promise<string | null> } } }
+      }
+    ).window?.api
+    const reader = api?.app?.getKeyboardInputSourceId
+    if (!reader) {
+      return null
+    }
+    try {
+      return await reader()
+    } catch {
+      // Why: the IPC can transiently reject during main-process teardown
+      // (e.g. app quitting mid-probe). Treat as no signal so the
+      // fingerprint remains the sole input.
+      return null
+    }
+  }
+}
+
+export function createOptionAsAltProbe(
+  win: Window = window,
+  options: CreateProbeOptions = {}
+): OptionAsAltProbe {
   let current: DetectedLayoutCategory = 'unknown'
   const listeners = new Set<Listener>()
   let disposed = false
+  const readInputSourceId = options.readInputSourceId ?? defaultInputSourceIdReader()
 
   const notify = (next: DetectedLayoutCategory): void => {
     if (next === current) {
@@ -65,6 +109,34 @@ export function createOptionAsAltProbe(win: Window = window): OptionAsAltProbe {
     }
     const nav = win.navigator as NavigatorWithKeyboard
     const keyboard = nav?.keyboard
+
+    // Why: read the input-source ID first — if it's on the compose
+    // denylist, we skip the layout-map fetch entirely. The ID is a macOS
+    // -only string; non-Darwin resolves to null and leaves the
+    // fingerprint as the only signal.
+    let inputSourceId: string | null = null
+    try {
+      inputSourceId = await readInputSourceId()
+    } catch {
+      // Treat errors as no signal — the fingerprint still runs below.
+      inputSourceId = null
+    }
+
+    if (disposed) {
+      return
+    }
+
+    // Why: input-source override wins over the fingerprint whenever the ID
+    // is on the compose denylist (Polish Pro, US Extended, CJK Roman IMEs,
+    // …). These layouts keep a US-looking base layer so the fingerprint
+    // would otherwise classify them as 'us' → macOptionIsMeta=true, which
+    // silently swallows every Option+letter dead-key (#1205). Forcing
+    // 'non-us' here makes the effective setting resolve to 'false'.
+    if (classifyInputSourceId(inputSourceId) === 'compose') {
+      notify('non-us')
+      return
+    }
+
     if (!keyboard?.getLayoutMap) {
       // Non-Chromium or Electron stripped of the Keyboard API. Stay at
       // 'unknown' → terminal defaults to 'false' (safe for non-US).

--- a/src/renderer/src/lib/keyboard-layout/option-as-alt-probe.ts
+++ b/src/renderer/src/lib/keyboard-layout/option-as-alt-probe.ts
@@ -14,13 +14,16 @@
  * key pressed while Orca is focused (e.g. a Karabiner rule), which is
  * exceedingly rare and self-heals on the next blur/focus cycle.
  *
- * Why two signals (fingerprint + input source ID): the fingerprint can only
- * see the base (unshifted) layer, which is identical to US QWERTY on
- * Polish Pro, US Extended, ABC Extended, and the CJK Roman IMEs — all of
- * which use Option as a dead-key / compose modifier. Without the input
- * source ID override, those users get macOptionIsMeta=true and lose every
- * Option+letter composition (issue #1205). See
- * ./input-source-id.ts for the denylist.
+ * Why two signals (input source ID + fingerprint): the fingerprint can
+ * only see the base (unshifted) layer, which is identical to US QWERTY
+ * on a large set of Apple-shipped layouts — ABC, Polish Pro, US
+ * Extended, ABC Extended, and every CJK Roman IME all trap on it. They
+ * repurpose Option for dead-key composition (Option+A → å / ą), so
+ * trusting the fingerprint alone makes macOptionIsMeta=true and
+ * silently swallows those characters (issue #1205). On macOS we treat
+ * the input source ID as authoritative and only fall back to the
+ * fingerprint when the ID is unavailable (non-Darwin, sandboxed
+ * defaults, IPC failure). See ./input-source-id.ts for the allowlist.
  */
 import {
   detectOptionAsAltFromLayoutMap,
@@ -110,10 +113,9 @@ export function createOptionAsAltProbe(
     const nav = win.navigator as NavigatorWithKeyboard
     const keyboard = nav?.keyboard
 
-    // Why: read the input-source ID first — if it's on the compose
-    // denylist, we skip the layout-map fetch entirely. The ID is a macOS
-    // -only string; non-Darwin resolves to null and leaves the
-    // fingerprint as the only signal.
+    // Why: read the input-source ID first. On macOS this resolves to a
+    // concrete ID (e.g. com.apple.keylayout.ABC); on every other platform
+    // it resolves to null and we fall through to the fingerprint.
     let inputSourceId: string | null = null
     try {
       inputSourceId = await readInputSourceId()
@@ -126,13 +128,20 @@ export function createOptionAsAltProbe(
       return
     }
 
-    // Why: input-source override wins over the fingerprint whenever the ID
-    // is on the compose denylist (Polish Pro, US Extended, CJK Roman IMEs,
-    // …). These layouts keep a US-looking base layer so the fingerprint
-    // would otherwise classify them as 'us' → macOptionIsMeta=true, which
-    // silently swallows every Option+letter dead-key (#1205). Forcing
-    // 'non-us' here makes the effective setting resolve to 'false'.
-    if (classifyInputSourceId(inputSourceId) === 'compose') {
+    // Why: when macOS returns a concrete input source ID, it's authoritative.
+    // The fingerprint can only see the base (unshifted) layer, which is
+    // US-identical on ABC, Polish Pro, US Extended, ABC Extended, and every
+    // CJK Roman IME — so trusting it flips macOptionIsMeta=true on all of
+    // them and silently swallows Option+letter compositions (#1205). The
+    // allowlist matches Ghostty: only com.apple.keylayout.US and
+    // com.apple.keylayout.USInternational-PC get Option-as-Meta; everything
+    // else composes via Option.
+    const override = classifyInputSourceId(inputSourceId)
+    if (override === 'meta') {
+      notify('us')
+      return
+    }
+    if (override === 'compose') {
       notify('non-us')
       return
     }


### PR DESCRIPTION
## Summary

Fixes [#1205](https://github.com/stablyai/orca/issues/1205): on macOS with Polish Pro (and US Extended / ABC Extended / CJK Roman IMEs), Option+letter chords were silently swallowed so diacritic characters (ą, ć, ę, ł, ń, ó, ś, ź, ż, …) could not be typed in the terminal.

### Root cause

The Option-as-Alt probe (`detectOptionAsAltFromLayoutMap`) fingerprints the keyboard layout by reading `navigator.keyboard.getLayoutMap()`, which only exposes the **base (unshifted) layer**. Polish Pro's base layer is **identical to US QWERTY** — Polish characters sit entirely on the Option layer as dead-key compositions. The fingerprint therefore classified it as `'us'`, the effective setting resolved to `'true'`, xterm's `macOptionIsMeta` turned on, and every Option+letter keystroke was translated to an Esc+letter readline chord before composition could produce the diacritic. Same shape for `USExtended`, `ABCExtended`, and the Japanese/Chinese/Korean Roman IMEs, which are all US-QWERTY base + Option compose.

The Find dialog worked because it's a plain `<input>` — xterm.js is the only surface where `macOptionIsMeta` applies.

### Fix

Adds a second signal: macOS's `AppleCurrentKeyboardLayoutInputSourceID` (the same identifier Ghostty reads via `TISCopyCurrentKeyboardInputSource`). When the active input source is on an explicit compose-denylist (`com.apple.keylayout.PolishPro`, `com.apple.keylayout.USExtended`, `com.apple.keylayout.ABCExtended`, `com.apple.inputmethod.Kotoeri`, `...TCIM`, `...SCIM`, `...Korean`), the probe forces `'non-us'`, `effectiveMacOptionAsAlt` resolves to `'false'`, and Option+letter reaches the shell as the composed character.

- `src/main/ipc/app.ts` — new `app:getKeyboardInputSourceId` IPC reads the macOS defaults value via `systemPreferences.getUserDefault`. Returns `null` on non-Darwin and on read failures so the fingerprint stays authoritative in those paths.
- `src/preload/index.ts` + `src/preload/api-types.ts` — expose `window.api.app.getKeyboardInputSourceId`.
- `src/renderer/src/lib/keyboard-layout/input-source-id.ts` — pure classifier over the denylist. Case-insensitive, prefix-bounded (`com.apple.keylayout.US` ≠ `com.apple.keylayout.USExtended`).
- `src/renderer/src/lib/keyboard-layout/option-as-alt-probe.ts` — reads the input source ID as part of every probe cycle (initial + each focus-in) and short-circuits to `'non-us'` when it's on the denylist; otherwise falls through to the existing fingerprint. Reader is DI'd so tests can drive the override deterministically.

Re-probing on focus-in means mid-session layout switches via the Input Source menu are picked up the next time Orca regains focus, matching the existing fingerprint behavior.

### Scope

- No setting default change: `terminalMacOptionAsAlt: 'auto'` still ships as default. Users who explicitly set `'true'`, `'false'`, `'left'`, or `'right'` are unaffected; the override only kicks in when the resolver is in `'auto'` mode.
- No shortcut policy changes; `terminal-shortcut-policy.ts` already compensates the three critical readline chords (Option+B/F/D) when `macOptionAsAlt === 'false'`, so US-layout users who happen to be on a compose-denylist layout (rare) don't lose word-nav.

## Test plan

- [x] `pnpm vitest run src/renderer/src/lib/keyboard-layout/` — 46 tests pass (14 new).
- [x] `pnpm vitest run src/renderer` — all 1179 renderer tests pass.
- [x] `pnpm run typecheck` — clean across node/cli/web configs.
- [ ] Manual verification on macOS with Polish Pro active (Input Menu → Polish → Polish – Pro), type `Option+A` in a terminal pane — should insert `ą`. Pre-fix this was silently dropped.
- [ ] Manual verification on US Standard — Option+B still produces readline backward-word (`\eb`); no regression.
- [ ] Manual verification of layout switch: boot on US, switch to Polish Pro via macOS Input Source menu, click back into Orca, confirm diacritic composition now works without restart.

Made with [Orca](https://github.com/stablyai/orca) 🐋
