### PR TITLE
fix: update Cmd+J placeholder to use 'repo/worktree' terminology

### DIFF
--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -714,7 +714,7 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
       }}
     >
       <CommandInput
-        placeholder={'Jump to worktree or browser tab\u2026  try "repo/branch"'}
+        placeholder={'Jump to worktree or browser tab\u2026  try "repo/worktree"'}
         value={query}
         onValueChange={setQuery}
         wrapperClassName="mx-3 mt-3 rounded-lg border border-border/55 bg-muted/28 px-3.5 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]"

--- a/src/renderer/src/lib/worktree-palette-search.test.ts
+++ b/src/renderer/src/lib/worktree-palette-search.test.ts
@@ -134,7 +134,7 @@ describe('worktree-palette-search', () => {
     expect(results[2].worktreeId).toBe('wt-main')
   })
 
-  it('supports "repo/branch" composite queries and highlights both segments', () => {
+  it('supports "repo/worktree" composite queries and highlights both segments', () => {
     const worktrees = [
       makeWorktree({
         id: 'wt-main',

--- a/src/renderer/src/lib/worktree-palette-search.ts
+++ b/src/renderer/src/lib/worktree-palette-search.ts
@@ -86,10 +86,12 @@ export function searchWorktrees(
   const numericQuery = q.startsWith('#') ? q.slice(1) : q
   const results: PaletteSearchResult[] = []
 
-  // Support "repo/branch" composite queries (e.g. "orca/main") so users can
-  // narrow by repo and branch in a single token. We split on the FIRST slash
-  // only — branch names themselves contain slashes (e.g. "feature/foo"), and
-  // we still want the right-hand side to match those in full.
+  // Support "repo/worktree" composite queries (e.g. "orca/main") so users can
+  // narrow by repo and worktree in a single token. Worktrees are identified by
+  // their branch name here, so the right-hand side is matched against the
+  // branch. We split on the FIRST slash only — branch names themselves contain
+  // slashes (e.g. "feature/foo"), and we still want the right-hand side to
+  // match those in full.
   const slashIndex = q.indexOf('/')
   const composite =
     slashIndex > 0 && slashIndex < q.length - 1


### PR DESCRIPTION
## Problem
The Cmd+J palette placeholder said 'repo/branch', which was inaccurate terminology for the Orca UI context where the user-facing concept is 'worktree', not 'branch'.

## Solution
Updated the placeholder text and related code comments to use 'repo/worktree' terminology. Clarified that the right-hand side matches against the worktree's branch name (implementation detail) while keeping user-facing language consistent with the worktree concept.

Made with [Orca](https://github.com/stablyai/orca) 🐋
