### PR TITLE
refactor(pty): extract sessionId helper and harden daemon spawn cleanup

### DIFF
--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -3,10 +3,10 @@ safety wiring spread across spawn/event-routing; splitting would scatter tightly
 adapter ↔ history lifecycle logic. */
 import { basename } from 'path'
 import { existsSync } from 'fs'
-import { randomUUID } from 'crypto'
 import { DaemonClient } from './client'
 import { HistoryManager } from './history-manager'
 import { HistoryReader } from './history-reader'
+import { mintPtySessionId } from './pty-session-id'
 import { supportsPtyStartupBarrier } from './shell-ready'
 import {
   PROTOCOL_VERSION,
@@ -93,9 +93,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
   private async doSpawn(opts: PtySpawnOptions): Promise<PtySpawnResult> {
     await this.ensureConnected()
 
-    const sessionId =
-      opts.sessionId ??
-      (opts.worktreeId ? `${opts.worktreeId}@@${randomUUID().slice(0, 8)}` : randomUUID())
+    const sessionId = opts.sessionId ?? mintPtySessionId(opts.worktreeId)
 
     if (this.killedSessionTombstones.has(sessionId)) {
       throw new TerminalKilledError(sessionId)

--- a/src/main/daemon/pty-session-id.test.ts
+++ b/src/main/daemon/pty-session-id.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+import { isSafePtySessionId, mintPtySessionId } from './pty-session-id'
+
+const USER_DATA = '/tmp/orca-userdata'
+
+describe('mintPtySessionId', () => {
+  it('returns a UUID when no worktreeId is provided', () => {
+    const id = mintPtySessionId()
+    expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/)
+  })
+
+  it('prefixes the worktreeId and suffixes an 8-char hex tag', () => {
+    const id = mintPtySessionId('wt-alpha')
+    expect(id).toMatch(/^wt-alpha@@[0-9a-f]{8}$/)
+  })
+
+  it('preserves path-shaped worktreeIds verbatim in the prefix', () => {
+    // Why: real worktreeIds are `${repo.id}::${absolutePath}` and contain
+    // slashes. The mint must not rewrite or sanitize them — reconcileOnStartup
+    // splits on `@@` to recover the worktreeId.
+    const id = mintPtySessionId('repo-123::/Users/me/work/wt-1')
+    expect(id).toMatch(/^repo-123::\/Users\/me\/work\/wt-1@@[0-9a-f]{8}$/)
+  })
+})
+
+describe('isSafePtySessionId', () => {
+  it('accepts minted UUIDs', () => {
+    expect(isSafePtySessionId(mintPtySessionId(), USER_DATA)).toBe(true)
+  })
+
+  it('accepts minted worktree-scoped ids (happy path, hyphen-only)', () => {
+    expect(isSafePtySessionId(mintPtySessionId('wt-alpha'), USER_DATA)).toBe(true)
+  })
+
+  it('accepts minted ids with path-shaped worktreeIds containing slashes', () => {
+    // Why: real worktreeIds are `${repo.id}::${absolutePath}`, so the minted
+    // sessionId contains `/` in its prefix. A char-denylist validator that
+    // rejected `/` would break every real daemon spawn.
+    const id = mintPtySessionId('repo-abc123::/Users/thebr/work/wt-1')
+    expect(isSafePtySessionId(id, USER_DATA)).toBe(true)
+  })
+
+  it('accepts caller-supplied path-shaped ids that stay inside userData', () => {
+    expect(isSafePtySessionId('some-repo::/Users/me/wt/abc@@deadbeef', USER_DATA)).toBe(true)
+  })
+
+  it('rejects empty string', () => {
+    expect(isSafePtySessionId('', USER_DATA)).toBe(false)
+  })
+
+  it('rejects ids longer than 512 characters', () => {
+    expect(isSafePtySessionId('a'.repeat(513), USER_DATA)).toBe(false)
+  })
+
+  it('rejects ids containing a NUL byte', () => {
+    expect(isSafePtySessionId('safe\0evil', USER_DATA)).toBe(false)
+  })
+
+  it('rejects ids that traverse out of userData via ..', () => {
+    expect(isSafePtySessionId('../etc/passwd', USER_DATA)).toBe(false)
+  })
+
+  it('rejects ids that traverse out of userData via deep ..', () => {
+    expect(isSafePtySessionId('sub/../../etc/passwd', USER_DATA)).toBe(false)
+  })
+
+  it('rejects ids that resolve to the userData root itself', () => {
+    // Why: if id resolves to `.` (the root), callers could overwrite userData
+    // meta files. Guard ensures the target is a strict subpath.
+    expect(isSafePtySessionId('.', USER_DATA)).toBe(false)
+  })
+
+  it('accepts ids with nested valid path segments inside userData', () => {
+    // Why: minted ids can contain `/` (from worktreeId::absolute-path) so the
+    // validator must allow that as long as the result stays inside userData.
+    expect(isSafePtySessionId('sub/path/ok@@12345678', USER_DATA)).toBe(true)
+  })
+})

--- a/src/main/daemon/pty-session-id.ts
+++ b/src/main/daemon/pty-session-id.ts
@@ -1,0 +1,59 @@
+import { randomUUID } from 'crypto'
+import { isAbsolute, join, relative, resolve, sep } from 'path'
+
+/**
+ * Session IDs use the format `${worktreeId}@@${shortUuid}` so that
+ * DaemonPtyAdapter.reconcileOnStartup (see daemon-pty-adapter.ts) can
+ * derive the owning worktree by splitting on the @@ separator.
+ *
+ * Both pty.ts (host-daemon spawn path) and DaemonPtyAdapter.doSpawn
+ * (fallback when opts.sessionId is absent) must use this helper — a
+ * drifted format would break cold-restore mapping and Pi overlay
+ * keying.
+ */
+export function mintPtySessionId(worktreeId?: string): string {
+  return worktreeId ? `${worktreeId}@@${randomUUID().slice(0, 8)}` : randomUUID()
+}
+
+/**
+ * Why: `effectiveSessionId` is used as a filesystem key (Pi overlay
+ * directory under app.getPath('userData')). The security property we
+ * want is containment: the derived overlay path must be strictly
+ * inside the userData root so a crafted IPC payload (args.sessionId
+ * or args.worktreeId forwarded from the renderer) cannot make us
+ * write overlay files outside userData.
+ *
+ * Callers pass `app.getPath('userData')` as `userDataPath`. Any
+ * subpath inside userData is acceptable as a filesystem key since
+ * the Pi overlay path lives deeper inside userData — enforcing
+ * "id cannot escape userData" is a superset of "id cannot escape Pi
+ * overlay root".
+ *
+ * Note: real worktreeIds are `${repo.id}::${absolutePath}` so minted
+ * session ids contain `/` on POSIX and `\` on Windows. Rejecting
+ * those chars outright would break every real daemon spawn with a
+ * worktree. We instead compute `join(userDataPath, id)` and assert
+ * the normalized result is a strict subpath — this rejects `..`
+ * sequences, absolute-path injection, and NUL truncation attacks
+ * without false positives on legitimate path-shaped ids.
+ */
+export function isSafePtySessionId(id: string, userDataPath: string): boolean {
+  if (id.length === 0 || id.length > 512) {
+    return false
+  }
+  if (id.includes('\0')) {
+    return false
+  }
+  const resolvedRoot = resolve(userDataPath)
+  const resolvedTarget = resolve(join(userDataPath, id))
+  const rel = relative(resolvedRoot, resolvedTarget)
+  // Why: `path.relative` can return an absolute path when the target lives
+  // on a different drive or under a UNC share on Windows (e.g. relative
+  // from C:\userdata to D:\evil yields "D:\evil", which does NOT start with
+  // ".."). Reject any absolute result — a legitimate subpath under
+  // userData always produces a relative result on every platform.
+  if (rel === '' || isAbsolute(rel) || rel.startsWith('..') || rel.includes(`..${sep}`)) {
+    return false
+  }
+  return true
+}

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -626,6 +626,85 @@ describe('registerPtyHandlers', () => {
         expect(spawnEnv).not.toBe(argsEnv)
       })
 
+      it('rejects a caller-supplied sessionId that escapes userData via ..', async () => {
+        // Why: effectiveSessionId is used as a Pi overlay directory key under
+        // userData. A crafted IPC payload with a traversal sequence must be
+        // refused before any filesystem side-effects run.
+        const daemonSpawn = setupDaemonAdapter()
+        handlers.clear()
+        registerPtyHandlers(mainWindow as never)
+        await expect(
+          handlers.get('pty:spawn')!(null, {
+            cols: 80,
+            rows: 24,
+            env: {},
+            sessionId: '../etc/passwd'
+          })
+        ).rejects.toThrow(/Invalid PTY session id/)
+        expect(daemonSpawn).not.toHaveBeenCalled()
+        expect(piBuildPtyEnvMock).not.toHaveBeenCalled()
+      })
+
+      it('sweeps per-PTY state when provider.spawn fails for a MINTED sessionId', async () => {
+        // Why: buildPtyHostEnv has filesystem side-effects (Pi overlay
+        // materialization). If provider.spawn later fails, the overlay would
+        // leak. The handler should clear per-PTY state for the minted id so
+        // it isn't orphaned.
+        const daemonSpawn = vi.fn(async () => {
+          throw new Error('spawn boom')
+        })
+        setLocalPtyProvider({
+          spawn: daemonSpawn,
+          write: vi.fn(),
+          resize: vi.fn(),
+          kill: vi.fn(),
+          shutdown: vi.fn(),
+          onData: vi.fn(() => vi.fn()),
+          onExit: vi.fn(() => vi.fn()),
+          listProcesses: vi.fn(async () => []),
+          getForegroundProcess: vi.fn(async () => null)
+        } as never)
+        handlers.clear()
+        registerPtyHandlers(mainWindow as never)
+        await expect(
+          handlers.get('pty:spawn')!(null, { cols: 80, rows: 24, env: {} })
+        ).rejects.toThrow(/spawn boom/)
+        expect(openCodeClearPtyMock).toHaveBeenCalled()
+        expect(piClearPtyMock).toHaveBeenCalled()
+      })
+
+      it('does NOT sweep per-PTY state on provider.spawn failure for CALLER-supplied sessionId', async () => {
+        // Why: a caller-supplied sessionId may refer to an existing PTY whose
+        // state (OpenCode hooks, Pi overlay, agent-hook pane caches) must not
+        // be clobbered on a retry/attach failure. Only minted ids get swept.
+        const daemonSpawn = vi.fn(async () => {
+          throw new Error('spawn boom')
+        })
+        setLocalPtyProvider({
+          spawn: daemonSpawn,
+          write: vi.fn(),
+          resize: vi.fn(),
+          kill: vi.fn(),
+          shutdown: vi.fn(),
+          onData: vi.fn(() => vi.fn()),
+          onExit: vi.fn(() => vi.fn()),
+          listProcesses: vi.fn(async () => []),
+          getForegroundProcess: vi.fn(async () => null)
+        } as never)
+        handlers.clear()
+        registerPtyHandlers(mainWindow as never)
+        await expect(
+          handlers.get('pty:spawn')!(null, {
+            cols: 80,
+            rows: 24,
+            env: {},
+            sessionId: 'caller-owned-session'
+          })
+        ).rejects.toThrow(/spawn boom/)
+        expect(openCodeClearPtyMock).not.toHaveBeenCalled()
+        expect(piClearPtyMock).not.toHaveBeenCalled()
+      })
+
       it('does NOT inject host-local env on SSH spawns (connectionId set)', async () => {
         const sshSpawn = vi.fn(async (_opts: { env: Record<string, string> }) => ({
           id: 'ssh-pty'

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -4,7 +4,6 @@ foreground-process inspection, and renderer IPC stay behind a single audited
 boundary. Splitting it by line count would scatter tightly coupled terminal
 process behavior across files without a cleaner ownership seam. */
 import { join, delimiter } from 'path'
-import { randomUUID } from 'crypto'
 import { type BrowserWindow, ipcMain, app } from 'electron'
 export { getBashShellReadyRcfileContent } from '../providers/local-pty-shell-ready'
 import type { OrcaRuntimeService } from '../runtime/orca-runtime'
@@ -13,7 +12,8 @@ import { openCodeHookService } from '../opencode/hook-service'
 import { agentHookServer } from '../agent-hooks/server'
 import { piTitlebarExtensionService } from '../pi/titlebar-extension-service'
 import { LocalPtyProvider } from '../providers/local-pty-provider'
-import type { IPtyProvider, PtySpawnOptions } from '../providers/types'
+import type { IPtyProvider, PtySpawnOptions, PtySpawnResult } from '../providers/types'
+import { mintPtySessionId, isSafePtySessionId } from '../daemon/pty-session-id'
 import type { ClaudeRuntimeAuthPreparation } from '../claude-accounts/runtime-auth-service'
 import { CLAUDE_AUTH_ENV_VARS, hasClaudeAuthEnvConflict } from '../claude-accounts/environment'
 import {
@@ -519,25 +519,55 @@ export function registerPtyHandlers(
       // the user's Pi state (auth, sessions, skills) survives daemon cold
       // restore too. Do NOT "simplify" id allocation back to a fresh UUID
       // per spawn; that would discard Pi state on every reconnect.
+      // Why: only state for ids we minted in THIS request should be cleared on
+      // spawn failure. If the caller supplied args.sessionId it may refer to
+      // an existing PTY whose state (OpenCode hooks, Pi overlay, agent-hook
+      // pane caches) we must not clobber on a retry/attach failure.
+      const isMintedSessionId = args.sessionId === undefined && isDaemonHostSpawn
       const effectiveSessionId =
-        args.sessionId ??
-        (isDaemonHostSpawn
-          ? args.worktreeId
-            ? `${args.worktreeId}@@${randomUUID().slice(0, 8)}`
-            : randomUUID()
-          : undefined)
+        args.sessionId ?? (isDaemonHostSpawn ? mintPtySessionId(args.worktreeId) : undefined)
       const baseEnv = claudeAuth ? { ...args.env, ...claudeAuth.envPatch } : args.env
       let env: Record<string, string> | undefined = baseEnv
       if (isDaemonHostSpawn) {
+        if (effectiveSessionId === undefined) {
+          // Should be unreachable: the expression above returns a string when
+          // isDaemonHostSpawn is true. Defense-in-depth in case future edits
+          // break this invariant.
+          throw new Error('Invariant violation: daemon spawn without sessionId')
+        }
+        const sessionIdForEnv = effectiveSessionId
+        // Why: Pi overlay paths are derived from the session id; reject
+        // traversal sequences / path separators so a crafted IPC payload
+        // cannot escape the overlay root. If the renderer ever forwards a
+        // malicious sessionId or worktreeId the spawn is refused before any
+        // filesystem side-effects run.
+        if (!isSafePtySessionId(sessionIdForEnv, app.getPath('userData'))) {
+          throw new Error('Invalid PTY session id')
+        }
         // Why: clone before mutating so we don't leak injections back into
         // args.env (which the renderer may reuse for other IPC calls).
         env = { ...baseEnv }
-        buildPtyHostEnv(effectiveSessionId as string, env, {
-          isPackaged: app.isPackaged,
-          userDataPath: app.getPath('userData'),
-          selectedCodexHomePath: getSelectedCodexHomePath?.() ?? null,
-          githubAttributionEnabled: getSettings?.()?.enableGitHubAttribution ?? false
-        })
+        try {
+          buildPtyHostEnv(sessionIdForEnv, env, {
+            isPackaged: app.isPackaged,
+            userDataPath: app.getPath('userData'),
+            selectedCodexHomePath: getSelectedCodexHomePath?.() ?? null,
+            githubAttributionEnabled: getSettings?.()?.enableGitHubAttribution ?? false
+          })
+        } catch (err) {
+          // Why: buildPtyHostEnv has filesystem side-effects (Pi overlay
+          // materialization). If it throws before we reach provider.spawn,
+          // clear per-PTY state so the next attempt starts clean.
+          //
+          // Only sweep state for ids we MINTED in this request — caller-
+          // supplied ids may refer to existing PTYs whose overlay/hook state
+          // must not be clobbered by a transient overlay-mkdir failure on a
+          // retry/attach path.
+          if (isMintedSessionId) {
+            clearProviderPtyState(sessionIdForEnv)
+          }
+          throw err
+        }
       }
       const envToDelete = claudeAuth?.stripAuthEnv
         ? [...CLAUDE_AUTH_ENV_VARS, 'ANTHROPIC_CUSTOM_HEADERS']
@@ -575,7 +605,25 @@ export function registerPtyHandlers(
       if (effectiveShellOverride !== undefined) {
         spawnOptions.shellOverride = effectiveShellOverride
       }
-      const result = await provider.spawn(spawnOptions)
+      let result: PtySpawnResult
+      try {
+        result = await provider.spawn(spawnOptions)
+      } catch (err) {
+        // Why: when buildPtyHostEnv materialized a Pi overlay for this id
+        // but provider.spawn failed, the overlay would leak. Sweep per-PTY
+        // state for the minted id so it isn't orphaned. Safe to call even
+        // when no overlay was created (clearProviderPtyState is a no-op in
+        // that case).
+        //
+        // Only clean up when we MINTED the id in this request. Caller-supplied
+        // ids may correspond to existing PTYs whose state (OpenCode hooks, Pi
+        // overlay, agent-hook pane caches) we MUST NOT clear on a retry/attach
+        // failure.
+        if (isMintedSessionId && effectiveSessionId !== undefined) {
+          clearProviderPtyState(effectiveSessionId)
+        }
+        throw err
+      }
       ptyOwnership.set(result.id, args.connectionId ?? null)
       if (isClaudeLaunch) {
         markClaudePtySpawned(result.id)


### PR DESCRIPTION
## Summary

Follow-up to #1148 (daemon-parity env refactor). That PR landed with duplicated session-id minting logic in two modules and no cleanup for a partially-materialized Pi overlay when `provider.spawn` fails.

- **Dedup the sessionId format.** Extract the `${worktreeId}@@${shortUuid}` mint into a shared `mintPtySessionId` helper so `src/main/ipc/pty.ts` (host daemon spawn path) and `DaemonPtyAdapter.doSpawn` (fallback when `opts.sessionId` is absent) can't drift. Drift here would break daemon cold-restore mapping and Pi overlay keying silently.
- **Path-containment guard.** Add `isSafePtySessionId(id, userDataPath)` that verifies the id resolves to a strict subpath of userData — rejects `..` traversal, absolute-path injection, NUL truncation, and cross-drive escapes (where `path.relative` can return an absolute result on Windows). Applied in `pty.ts` before `buildPtyHostEnv` runs, because the session id becomes a Pi overlay directory name. A char denylist would've rejected legitimate worktree-shaped ids (`${repo.id}::${absolutePath}`), so the check is structural instead.
- **Spawn-failure cleanup.** Wrap `buildPtyHostEnv` and `provider.spawn` in try/catch in `pty.ts`. If either throws after overlay materialization, call `clearProviderPtyState` so Pi overlay / OpenCode hooks / agent-hook pane caches don't orphan for that id.
- **Only sweep ids we minted.** Caller-supplied `args.sessionId` may refer to an existing PTY whose state (OpenCode hooks, Pi overlay, agent-hook pane caches) must not be clobbered on a retry/attach failure. The cleanup only fires when the id was minted in this request (`args.sessionId === undefined && isDaemonHostSpawn`).

## Test plan

### Automated

- [x] `pnpm vitest run src/main/ipc/pty.test.ts src/main/daemon/pty-session-id.test.ts src/main/daemon/daemon-pty-adapter.test.ts` — **111/111 pass** (14 new unit tests for `mintPtySessionId` / `isSafePtySessionId`, plus 3 new tests in `pty.test.ts` covering the invalid-id rejection path and the minted-vs-caller-supplied spawn-failure cleanup contract)
- [x] `pnpm tsc --noEmit` — clean
- [x] Pre-commit oxlint/oxfmt — passed

### Live verification (dev Orca, `experimentalTerminalDaemon: true`, CDP attach via playwright-cli)

Spawned PTYs through `window.api.pty.spawn` and inspected the resulting Pi overlay directories under `~/Library/Application Support/orca-dev/pi-agent-overlays/`.

| Test | Expected | Observed |
|---|---|---|
| Mint format with `worktreeId: 'test-wt-alpha'` | `test-wt-alpha@@<8-hex>` | `test-wt-alpha@@4e80b685` ✓ |
| Mint format with real path-shaped worktreeId (`${repo}::${absPath}`) | Accepted, contains `/` and `::` in prefix | `50c010a2-…::/Users/thebr/…/test2143@@2631a143` ✓ |
| `sessionId: '../etc/passwd'` | Rejected pre-spawn | `Invalid PTY session id` ✓ |
| `sessionId: 'sub/../../etc/passwd'` | Rejected pre-spawn | `Invalid PTY session id` ✓ |
| `sessionId: '.'` (userData root) | Rejected pre-spawn | `Invalid PTY session id` ✓ |
| `sessionId: 'safe\0evil'` (NUL byte) | Rejected pre-spawn | `Invalid PTY session id` ✓ |
| `sessionId: ''` (empty) | Rejected pre-spawn | `Invalid PTY session id` ✓ |
| No orphaned dirs created from rejected spawns | `find $userData/pi-agent-overlays $userData/opencode-hooks` for `..`/`passwd`/`etc`/`evil` returns empty | ✓ (none) |
| Valid mint materializes overlay under userData | `pi-agent-overlays/<mintedId>` exists on disk | `pi-agent-overlays/env-check@@36235157` ✓ |

Confirms the structural containment check:
- Fires **before** `buildPtyHostEnv` — rejected attempts leave zero filesystem side-effects
- Does **not** false-positive on real worktree-shaped ids that contain `:` and `/`
- Sessionid threads all the way through to `piTitlebarExtensionService.buildPtyEnv` and becomes the overlay directory name, confirming the mint path is live under daemon spawn.

### Notes

- A parallel fix for `src/main/opencode/hook-service.ts` (replacing its regex-based id check with a path-containment guard) was prepared but **not included** — main already solved the same underlying issue via a SHA-256 hash-based directory name (`toSafeDirName`) in a separate commit, which is a strictly better containment strategy.

Made with [Orca](https://github.com/stablyai/orca) 🐋