### PR TITLE
fix(terminal): restore cursor visibility on daemon snapshot reattach

### DIFF
--- a/src/renderer/src/components/terminal-pane/layout-serialization.ts
+++ b/src/renderer/src/components/terminal-pane/layout-serialization.ts
@@ -36,12 +36,18 @@ export const POST_REPLAY_MODE_RESET =
 
 // Why: daemon snapshot restore reattaches to a live session, so we avoid the
 // full POST_REPLAY_MODE_RESET bundle there — a still-running TUI may still
-// rely on mouse or bracketed-paste modes. Focus reporting is the exception:
-// if xterm preserves `?1004h` across snapshot replay, pane focus/blur emits
-// `\e[I` / `\e[O` into the PTY and shells like zsh ring BEL when no TUI is
-// actively consuming them. Clearing only 1004 preserves the other live-session
-// modes while preventing phantom bells on restored background tabs.
-export const POST_REPLAY_FOCUS_REPORTING_RESET = '\x1b[?1004l'
+// rely on mouse or bracketed-paste modes. Two exceptions are safe to reset:
+//
+//   25   — DECTCEM cursor visibility: SerializeAddon bakes `?25l` into the
+//          snapshot when the cursor was hidden at capture time. Without `?25h`
+//          here the cursor stays invisible after reattach. If a TUI is still
+//          running and wants the cursor hidden, the SIGWINCH sent immediately
+//          after restore triggers a repaint that re-hides it — a brief flash
+//          that is far less harmful than a permanently invisible cursor.
+//   1004 — focus event reporting: preserving `?1004h` makes restored shells
+//          ring BEL on pane focus/blur (shells like zsh treat `\e[I`/`\e[O`
+//          as unbound key input).
+export const POST_REPLAY_FOCUS_REPORTING_RESET = '\x1b[?25h\x1b[?1004l'
 
 export function paneLeafId(paneId: number): string {
   return `pane:${paneId}`


### PR DESCRIPTION
## Summary
- Follow-up to #1192 — the initial fix only covered scrollback-restore and cold-restore paths (`POST_REPLAY_MODE_RESET`)
- The most common restart path is **daemon snapshot reattach** (daemon survives app close), which uses `POST_REPLAY_FOCUS_REPORTING_RESET` — this was still missing `?25h`
- `SerializeAddon` bakes `?25l` into the snapshot when the cursor was hidden at capture time, so reattaching to a stale daemon left the cursor permanently invisible
- Added `?25h` to `POST_REPLAY_FOCUS_REPORTING_RESET` — if a TUI is still running, the SIGWINCH sent after restore triggers a repaint that re-hides the cursor immediately

## Test plan
- [ ] Quit and relaunch the app (daemon stays alive) — cursor should be visible
- [ ] Run a TUI (vim/less) → quit app → relaunch → verify cursor is visible after TUI exits
- [ ] Run a TUI → quit app → relaunch while TUI is still running → verify TUI re-hides cursor after SIGWINCH repaint
- [ ] `pnpm vitest run pty-connection.test.ts` passes (20/20)

Made with [Orca](https://github.com/stablyai/orca) 🐋
