### PR TITLE
test(notifications): guard agent-task-complete producer at IPC boundary

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -1,6 +1,8 @@
 /* oxlint-disable max-lines */
+import type * as React from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { POST_REPLAY_FOCUS_REPORTING_RESET, POST_REPLAY_MODE_RESET } from './layout-serialization'
+import type * as UseNotificationDispatchModule from './use-notification-dispatch'
 
 const toastInfo = vi.fn()
 
@@ -80,6 +82,17 @@ vi.mock('sonner', () => ({
     info: toastInfo
   }
 }))
+
+// Why: the working→idle test imports the real useNotificationDispatch to
+// verify producer → IPC end-to-end. useCallback is pure memoization for
+// that hook, so pass-through here lets it be invoked outside React.
+vi.mock('react', async (importOriginal) => {
+  const actual = await importOriginal<typeof React>()
+  return {
+    ...actual,
+    useCallback: <T extends (...args: unknown[]) => unknown>(fn: T): T => fn
+  }
+})
 
 vi.mock('./pty-transport', () => ({
   createIpcPtyTransport: vi.fn((options: Record<string, unknown>) => {
@@ -217,6 +230,9 @@ describe('connectPanePty', () => {
         pty: {
           signal: vi.fn(),
           ackColdRestore: vi.fn()
+        },
+        notifications: {
+          dispatch: vi.fn()
         }
       }
     }
@@ -983,14 +999,30 @@ describe('connectPanePty', () => {
   // unread — those stay BEL-only so non-agent long-running tasks remain
   // first-class attention sources. Double-firing with a concurrent BEL is
   // collapsed by the per-worktree dedupe in main/ipc/notifications.ts.
+  //
+  // This test deliberately wires the real useNotificationDispatch hook into
+  // connectPanePty instead of a vi.fn() stub. A stub would let the producer
+  // be silently deleted and the test still pass by asserting "not called";
+  // routing through the real hook to window.api.notifications.dispatch means
+  // removing the producer breaks the IPC assertion, which is the user-facing
+  // contract.
   it('dispatches agent-task-complete on working→idle but does not raise tab/worktree unread', async () => {
     const { connectPanePty } = await import('./pty-connection')
+    const { useNotificationDispatch } = await vi.importActual<typeof UseNotificationDispatchModule>(
+      './use-notification-dispatch'
+    )
     const transport = createMockTransport()
     transportFactoryQueue.push(transport)
 
+    // Why: useNotificationDispatch uses useCallback internally; bypass the
+    // React machinery by invoking its body directly through a module call.
+    // Safe here because useCallback is pure memoization — the returned
+    // function has the same behavior as the callback passed in.
+    const dispatchNotification = useNotificationDispatch('wt-1')
+
     const pane = createPane(1)
     const manager = createManager(1)
-    const deps = createDeps()
+    const deps = createDeps({ dispatchNotification })
 
     connectPanePty(pane as never, manager as never, deps as never)
 
@@ -1005,10 +1037,13 @@ describe('connectPanePty', () => {
 
     expect(deps.markWorktreeUnread).not.toHaveBeenCalled()
     expect(deps.markTerminalTabUnread).not.toHaveBeenCalled()
-    expect(deps.dispatchNotification).toHaveBeenCalledWith({
-      source: 'agent-task-complete',
-      terminalTitle: '* Claude done'
-    })
+    expect(window.api.notifications.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'agent-task-complete',
+        worktreeId: 'wt-1',
+        terminalTitle: '* Claude done'
+      })
+    )
   })
 
   // Why: onAgentExited must clear any running prompt-cache countdown so the

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -86,6 +86,13 @@ vi.mock('sonner', () => ({
 // Why: the working→idle test imports the real useNotificationDispatch to
 // verify producer → IPC end-to-end. useCallback is pure memoization for
 // that hook, so pass-through here lets it be invoked outside React.
+//
+// Scope note: this mock applies to every test in this file, not just the
+// working→idle test. It is safe today because no other test in this file
+// depends on useCallback identity stability — the suite does not render
+// React components. If that ever changes, either narrow this with
+// vi.doMock inside the it() block or extract the hook body into a plain
+// non-hook function so the test does not need to bypass React at all.
 vi.mock('react', async (importOriginal) => {
   const actual = await importOriginal<typeof React>()
   return {
@@ -1018,6 +1025,9 @@ describe('connectPanePty', () => {
     // React machinery by invoking its body directly through a module call.
     // Safe here because useCallback is pure memoization — the returned
     // function has the same behavior as the callback passed in.
+    // Depends on the file-level vi.mock('react', ...) near the top of this
+    // file that replaces useCallback with a pass-through. Removing that
+    // mock breaks this test with a rules-of-hooks error.
     const dispatchNotification = useNotificationDispatch('wt-1')
 
     const pane = createPane(1)


### PR DESCRIPTION
## Summary

- Rewrites the `connectPanePty` working→idle test to route through the real `useNotificationDispatch` hook and assert on `window.api.notifications.dispatch` — the user-facing IPC contract — instead of on a stubbed `deps.dispatchNotification` callback.
- Motivated by #944 / #1200: PR #944 silently deleted the sole renderer-side producer of `{ source: 'agent-task-complete', ... }`, and the existing test passed because it asserted against a stub that was also no longer called. Post-this-change, the same deletion fails the test with `expected window.api.notifications.dispatch to be called, was called 0 times`.

## Why this framing

Stub-based assertions on the producer's direct dep (`deps.dispatchNotification.toHaveBeenCalled`) are trivially satisfied by deleting the caller. Routing through the real hook means the only way to satisfy the assertion is to actually issue the IPC request, so silent producer removal can no longer hide behind a passing test.

`useCallback` is pass-through-mocked at the file level so the hook can be invoked outside a React render tree; it's pure memoization for this hook, so the pass-through is semantically equivalent.

## Test plan

- [x] `pnpm exec vitest run src/renderer/src/components/terminal-pane/` — 18 files / 160 tests pass
- [x] Simulated the #944 regression by deleting the `dispatchNotification({ source: 'agent-task-complete', ... })` call in `pty-connection.ts` — the rewritten test fails at the IPC assertion; restoring the call returns the suite to green
- [x] Typecheck clean (`pnpm run typecheck`)
- [x] Lint clean (`pnpm exec oxlint`)

Made with [Orca](https://github.com/stablyai/orca) 🐋
