### PR TITLE
feat(settings): gate Agent Dashboard behind experimental setting

### DIFF
--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -91,6 +91,7 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     terminalMacOptionAsAltMigrated: true,
     experimentalTerminalDaemon: false,
     experimentalTerminalDaemonNoticeShown: false,
+    experimentalAgentDashboard: false,
     terminalWindowsShell: 'powershell.exe',
     enableGitHubAttribution: true,
     ...overrides

--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -85,6 +85,7 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     terminalMacOptionAsAltMigrated: true,
     experimentalTerminalDaemon: false,
     experimentalTerminalDaemonNoticeShown: false,
+    experimentalAgentDashboard: false,
     terminalWindowsShell: 'powershell.exe',
     enableGitHubAttribution: true,
     ...overrides

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -47,7 +47,6 @@ import { codexHookService } from './codex/hook-service'
 import { geminiHookService } from './gemini/hook-service'
 import { cursorHookService } from './cursor/hook-service'
 import { getPtyIdForPaneKey, registerPaneKeyTeardownListener } from './ipc/pty'
-import { AGENT_DASHBOARD_ENABLED } from '../shared/constants'
 import { AgentBrowserBridge } from './browser/agent-browser-bridge'
 import { browserManager } from './browser/browser-manager'
 
@@ -204,7 +203,11 @@ function openMainWindow(): BrowserWindow {
     if (mainWindow?.isDestroyed()) {
       return
     }
-    if (AGENT_DASHBOARD_ENABLED) {
+    // Why: only forward status events to the renderer when the user has
+    // opted into the experimental dashboard. Reading the current setting
+    // here (rather than a module-level snapshot) lets the gate flip live
+    // for the renderer-side surfaces — the hook server itself always runs.
+    if (store?.getSettings().experimentalAgentDashboard === true) {
       mainWindow?.webContents.send('agentStatus:set', {
         paneKey,
         tabId,
@@ -219,7 +222,7 @@ function openMainWindow(): BrowserWindow {
     // sidebar spinner, unread badge, and Claude prompt-cache timer for every
     // other agent) lights up for cursor panes too. Braille prefix ⠋ → working
     // keyword path; "action required" keyword → permission; bare label → idle.
-    // This runs regardless of AGENT_DASHBOARD_ENABLED because cursor has no
+    // This runs regardless of the dashboard setting because cursor has no
     // pre-dashboard title heuristic to fall back to.
     if (payload.agentType === 'cursor') {
       driveCursorPaneFromHook(paneKey, payload.state)
@@ -341,14 +344,16 @@ app.whenReady().then(async () => {
   nativeTheme.themeSource = store.getSettings().theme ?? 'system'
   // Why: managed hook installation mutates user-global agent config.
   // Startup must fail open so a malformed local config never bricks Orca.
-  // Claude/Codex/Gemini installs are gated behind AGENT_DASHBOARD_ENABLED
-  // because the surface they feed (the in-progress agent dashboard) isn't
-  // shippable yet. Cursor installs unconditionally because cursor-agent
-  // emits no title-based working/idle signal at all (its terminal title
-  // stays literally "Cursor Agent" across a turn), so the hook channel is
-  // the only way to drive the sidebar spinner + unread path for it — there
-  // is no "pre-dashboard" fallback to degrade to the way Claude/Codex have.
-  if (AGENT_DASHBOARD_ENABLED) {
+  // Claude/Codex/Gemini installs are gated behind the experimental
+  // Agent Dashboard setting because the surface they feed (the in-progress
+  // agent dashboard) isn't shippable yet. Cursor installs unconditionally
+  // because cursor-agent emits no title-based working/idle signal at all
+  // (its terminal title stays literally "Cursor Agent" across a turn), so
+  // the hook channel is the only way to drive the sidebar spinner + unread
+  // path for it — there is no "pre-dashboard" fallback to degrade to the
+  // way Claude/Codex have. Toggling the setting takes effect on next launch
+  // because the hook scripts are installed once per boot.
+  if (store.getSettings().experimentalAgentDashboard === true) {
     for (const installManagedHooks of [
       () => claudeHookService.install(),
       () => codexHookService.install(),
@@ -425,11 +430,11 @@ app.whenReady().then(async () => {
   setAppRuntimeFlags({ daemonEnabledAtStartup: daemonStarted })
 
   // Why: the hook server runs unconditionally so cursor-agent panes can reach
-  // it. Claude/Codex/Gemini hook scripts stay uninstalled while
-  // AGENT_DASHBOARD_ENABLED is false, so only cursor events flow in. PTY
-  // spawn env reads ORCA_AGENT_HOOK_* from the live server state, so the
-  // server must start before the window opens — otherwise restored terminals
-  // race ahead without the env on first launch.
+  // it. Claude/Codex/Gemini hook scripts stay uninstalled while the
+  // experimentalAgentDashboard setting is off, so only cursor events flow
+  // in by default. PTY spawn env reads ORCA_AGENT_HOOK_* from the live
+  // server state, so the server must start before the window opens —
+  // otherwise restored terminals race ahead without the env on first launch.
   try {
     await agentHookServer.start({
       env: app.isPackaged ? 'production' : 'development',

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -353,7 +353,8 @@ app.whenReady().then(async () => {
   // path for it — there is no "pre-dashboard" fallback to degrade to the
   // way Claude/Codex have. Toggling the setting takes effect on next launch
   // because the hook scripts are installed once per boot.
-  if (store.getSettings().experimentalAgentDashboard === true) {
+  const agentDashboardEnabled = store.getSettings().experimentalAgentDashboard === true
+  if (agentDashboardEnabled) {
     for (const installManagedHooks of [
       () => claudeHookService.install(),
       () => codexHookService.install(),
@@ -427,7 +428,10 @@ app.whenReady().then(async () => {
       console.error('[daemon] Failed to clean up orphaned daemon:', error)
     }
   }
-  setAppRuntimeFlags({ daemonEnabledAtStartup: daemonStarted })
+  setAppRuntimeFlags({
+    daemonEnabledAtStartup: daemonStarted,
+    agentDashboardEnabledAtStartup: agentDashboardEnabled
+  })
 
   // Why: the hook server runs unconditionally so cursor-agent panes can reach
   // it. Claude/Codex/Gemini hook scripts stay uninstalled while the

--- a/src/main/ipc/app.ts
+++ b/src/main/ipc/app.ts
@@ -10,9 +10,11 @@ export type AppRuntimeFlags = {
    *  The renderer compares this against the current setting to decide whether
    *  a "restart required" banner needs to be shown on the Experimental pane. */
   daemonEnabledAtStartup: boolean
-  /** Whether the experimental agent dashboard was enabled at startup — i.e.
-   *  whether Claude/Codex/Gemini managed hooks were installed for this
-   *  session. Toggling the setting only flips hook installation on the next
+  /** Whether the experimental agent dashboard setting was enabled when this
+   *  session booted. When true, Claude/Codex/Gemini managed hook installation
+   *  was attempted at startup (individual install failures are logged but do
+   *  not flip this flag — the dashboard UI itself treats missing hooks as
+   *  no-ops). Toggling the setting only affects hook installation on the next
    *  launch, so the renderer compares this against the current setting to
    *  decide whether a "restart required" banner needs to be shown. */
   agentDashboardEnabledAtStartup: boolean

--- a/src/main/ipc/app.ts
+++ b/src/main/ipc/app.ts
@@ -10,6 +10,12 @@ export type AppRuntimeFlags = {
    *  The renderer compares this against the current setting to decide whether
    *  a "restart required" banner needs to be shown on the Experimental pane. */
   daemonEnabledAtStartup: boolean
+  /** Whether the experimental agent dashboard was enabled at startup — i.e.
+   *  whether Claude/Codex/Gemini managed hooks were installed for this
+   *  session. Toggling the setting only flips hook installation on the next
+   *  launch, so the renderer compares this against the current setting to
+   *  decide whether a "restart required" banner needs to be shown. */
+  agentDashboardEnabledAtStartup: boolean
 }
 
 export type DaemonTransitionNotice = {
@@ -20,7 +26,10 @@ export type DaemonTransitionNotice = {
   killedCount: number
 }
 
-let runtimeFlags: AppRuntimeFlags = { daemonEnabledAtStartup: false }
+let runtimeFlags: AppRuntimeFlags = {
+  daemonEnabledAtStartup: false,
+  agentDashboardEnabledAtStartup: false
+}
 let pendingDaemonTransitionNotice: DaemonTransitionNotice | null = null
 
 export function setAppRuntimeFlags(flags: AppRuntimeFlags): void {

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -268,6 +268,7 @@ export type CodexUsageApi = {
 
 export type AppRuntimeFlags = {
   daemonEnabledAtStartup: boolean
+  agentDashboardEnabledAtStartup: boolean
 }
 
 export type DaemonTransitionNotice = {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -4,6 +4,7 @@ review and type drift checks easier than scattering these bindings across module
 import { contextBridge, ipcRenderer, webFrame, webUtils } from 'electron'
 import { electronAPI } from '@electron-toolkit/preload'
 import { preloadE2EConfig } from './e2e-config'
+import type { AppRuntimeFlags, DaemonTransitionNotice } from './api-types'
 import type { CliInstallStatus } from '../shared/cli-install-types'
 import type { AgentHookInstallStatus } from '../shared/agent-hook-types'
 import type {
@@ -174,11 +175,8 @@ document.addEventListener(
 // Custom APIs for renderer
 const api = {
   app: {
-    getRuntimeFlags: (): Promise<{
-      daemonEnabledAtStartup: boolean
-      agentDashboardEnabledAtStartup: boolean
-    }> => ipcRenderer.invoke('app:getRuntimeFlags'),
-    consumeDaemonTransitionNotice: (): Promise<{ killedCount: number } | null> =>
+    getRuntimeFlags: (): Promise<AppRuntimeFlags> => ipcRenderer.invoke('app:getRuntimeFlags'),
+    consumeDaemonTransitionNotice: (): Promise<DaemonTransitionNotice | null> =>
       ipcRenderer.invoke('app:consumeDaemonTransitionNotice'),
     relaunch: (): Promise<void> => ipcRenderer.invoke('app:relaunch'),
     // Why: on macOS this returns AppleCurrentKeyboardLayoutInputSourceID so

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -174,8 +174,10 @@ document.addEventListener(
 // Custom APIs for renderer
 const api = {
   app: {
-    getRuntimeFlags: (): Promise<{ daemonEnabledAtStartup: boolean }> =>
-      ipcRenderer.invoke('app:getRuntimeFlags'),
+    getRuntimeFlags: (): Promise<{
+      daemonEnabledAtStartup: boolean
+      agentDashboardEnabledAtStartup: boolean
+    }> => ipcRenderer.invoke('app:getRuntimeFlags'),
     consumeDaemonTransitionNotice: (): Promise<{ killedCount: number } | null> =>
       ipcRenderer.invoke('app:consumeDaemonTransitionNotice'),
     relaunch: (): Promise<void> => ipcRenderer.invoke('app:relaunch'),

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,10 +1,6 @@
 /* eslint-disable max-lines */
 import { lazy, Suspense, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
-import {
-  AGENT_DASHBOARD_ENABLED,
-  DEFAULT_STATUS_BAR_ITEMS,
-  DEFAULT_WORKTREE_CARD_PROPERTIES
-} from '../../shared/constants'
+import { DEFAULT_STATUS_BAR_ITEMS, DEFAULT_WORKTREE_CARD_PROPERTIES } from '../../shared/constants'
 
 import { ArrowLeft, ArrowRight, Minimize2, PanelLeft, PanelRight } from 'lucide-react'
 import {
@@ -162,9 +158,10 @@ function App(): React.JSX.Element {
   // event frequency), re-rendering the entire app tree on every agent status
   // update. Hosting the subscriptions in a leaf isolates that churn.
   //
-  // The AGENT_DASHBOARD_ENABLED gate still lives inside the hooks themselves
-  // (useDashboardData early-returns [] from its memo; useRetainedAgentsSync
-  // early-returns from its effect), so the gate component is cheap when off.
+  // The experimentalAgentDashboard gate still lives inside the hooks
+  // themselves (useDashboardData early-returns [] from its memo;
+  // useRetainedAgentsSync early-returns from its effect), so the gate
+  // component is cheap when the setting is off.
   // Why: git conflict-operation state also drives the worktree cards. Polling
   // cannot live under RightSidebar because App unmounts that subtree when the
   // sidebar is closed, which leaves stale "Rebasing"/"Merging" badges behind
@@ -722,7 +719,14 @@ function App(): React.JSX.Element {
       // mechanism (same pattern as Cmd+Shift+G above). xterm-helper-textarea
       // is the focus target the terminal handler itself uses to detect
       // terminal focus (see keyboard-handlers.ts isEditableTarget).
-      if (AGENT_DASHBOARD_ENABLED && e.shiftKey && !e.altKey && e.key.toLowerCase() === 'd') {
+      // Why: read the experimental toggle at keypress time via getState() so
+      // flipping the setting takes effect immediately without re-binding the
+      // window-level listener (which would require adding `settings` to the
+      // effect deps and tearing down/rebinding on every unrelated settings
+      // change, like theme or font adjustments).
+      const dashboardExperimentEnabled =
+        useAppStore.getState().settings?.experimentalAgentDashboard === true
+      if (dashboardExperimentEnabled && e.shiftKey && !e.altKey && e.key.toLowerCase() === 'd') {
         const active = document.activeElement as HTMLElement | null
         if (active?.classList.contains('xterm-helper-textarea')) {
           return

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -719,14 +719,18 @@ function App(): React.JSX.Element {
       // mechanism (same pattern as Cmd+Shift+G above). xterm-helper-textarea
       // is the focus target the terminal handler itself uses to detect
       // terminal focus (see keyboard-handlers.ts isEditableTarget).
-      // Why: read the experimental toggle at keypress time via getState() so
-      // flipping the setting takes effect immediately without re-binding the
-      // window-level listener (which would require adding `settings` to the
-      // effect deps and tearing down/rebinding on every unrelated settings
-      // change, like theme or font adjustments).
-      const dashboardExperimentEnabled =
-        useAppStore.getState().settings?.experimentalAgentDashboard === true
-      if (dashboardExperimentEnabled && e.shiftKey && !e.altKey && e.key.toLowerCase() === 'd') {
+      if (e.shiftKey && !e.altKey && e.key.toLowerCase() === 'd') {
+        // Why: read the experimental toggle at keypress time via getState() so
+        // flipping the setting takes effect immediately without re-binding the
+        // window-level listener (which would require adding `settings` to the
+        // effect deps and tearing down/rebinding on every unrelated settings
+        // change, like theme or font adjustments). Gated behind the key/modifier
+        // check so getState() isn't invoked on every unrelated keystroke.
+        const dashboardExperimentEnabled =
+          useAppStore.getState().settings?.experimentalAgentDashboard === true
+        if (!dashboardExperimentEnabled) {
+          return
+        }
         const active = document.activeElement as HTMLElement | null
         if (active?.classList.contains('xterm-helper-textarea')) {
           return

--- a/src/renderer/src/components/dashboard/RetainedAgentsSyncGate.tsx
+++ b/src/renderer/src/components/dashboard/RetainedAgentsSyncGate.tsx
@@ -8,8 +8,8 @@ import { useRetainedAgentsSync } from './useRetainedAgents'
 // level — if it only ran when the dashboard is mounted, "done" agents would
 // vanish from the sidebar hovercard whenever the panel is collapsed.
 //
-// The hooks inside still early-return when AGENT_DASHBOARD_ENABLED is false,
-// so this gate is cheap when the feature is off.
+// The hooks inside still early-return when the experimentalAgentDashboard
+// setting is off, so this gate is cheap when the feature is disabled.
 export default function RetainedAgentsSyncGate(): null {
   const dashboardLiveGroups = useDashboardData()
   useRetainedAgentsSync(dashboardLiveGroups)

--- a/src/renderer/src/components/dashboard/useDashboardData.ts
+++ b/src/renderer/src/components/dashboard/useDashboardData.ts
@@ -7,7 +7,6 @@ import {
   type AgentStatusState,
   type AgentType
 } from '../../../../shared/agent-status-types'
-import { AGENT_DASHBOARD_ENABLED } from '../../../../shared/constants'
 import type { Repo, Worktree, TerminalTab } from '../../../../shared/types'
 
 // ─── Dashboard data types ─────────────────────────────────────────────────────
@@ -194,6 +193,7 @@ export function useDashboardData(): DashboardRepoGroup[] {
   // computation itself) so the memo recomputes when freshness boundaries expire,
   // even if no new PTY data arrives.
   const agentStatusEpoch = useAppStore((s) => s.agentStatusEpoch)
+  const dashboardEnabled = useAppStore((s) => s.settings?.experimentalAgentDashboard === true)
 
   return useMemo(
     // Why: Date.now() is read inside the memo (not as a dep) so stale-decay
@@ -201,11 +201,12 @@ export function useDashboardData(): DashboardRepoGroup[] {
     // freshness boundary crosses, driving re-evaluation without coupling to
     // wall-clock time directly.
     () => {
-      // Why: feature flag gate inside the memo avoids the O(repos × worktrees ×
-      // agents) rebuild on every store update when the dashboard is disabled.
-      // Store selectors still subscribe to keep rules-of-hooks satisfied even
-      // if the flag becomes runtime-dynamic.
-      if (!AGENT_DASHBOARD_ENABLED) {
+      // Why: experimental-setting gate inside the memo avoids the
+      // O(repos × worktrees × agents) rebuild on every store update when the
+      // dashboard is disabled. Store selectors still subscribe to keep
+      // rules-of-hooks satisfied and so flipping the setting re-renders
+      // consumers.
+      if (!dashboardEnabled) {
         return []
       }
       return buildDashboardData(
@@ -217,6 +218,13 @@ export function useDashboardData(): DashboardRepoGroup[] {
       )
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [repos, worktreesByRepo, tabsByWorktree, agentStatusByPaneKey, agentStatusEpoch]
+    [
+      repos,
+      worktreesByRepo,
+      tabsByWorktree,
+      agentStatusByPaneKey,
+      agentStatusEpoch,
+      dashboardEnabled
+    ]
   )
 }

--- a/src/renderer/src/components/dashboard/useRetainedAgents.ts
+++ b/src/renderer/src/components/dashboard/useRetainedAgents.ts
@@ -33,6 +33,15 @@ export function useRetainedAgentsSync(liveGroups: DashboardRepoGroup[]): void {
     // App.tsx) makes the hook self-contained and safe to call unconditionally
     // from any site.
     if (!dashboardEnabled) {
+      // Why: reset the previous-agents snapshot while the flag is off so a
+      // later off->on toggle (same session, no restart) does not resurrect
+      // pre-disable state. Without this, the first post-re-enable run would
+      // diff current liveGroups against a stale map captured before the flag
+      // flipped off, and collectRetainedAgentsOnDisappear could retroactively
+      // retain agents that finished / had their paneKeys reused during the
+      // off window — an "agent disappeared while the dashboard was hidden"
+      // case must NOT produce a retained row on re-enable.
+      prevAgentsRef.current = new Map()
       return
     }
     const current = new Map<string, { row: DashboardAgentRow; worktreeId: string }>()

--- a/src/renderer/src/components/dashboard/useRetainedAgents.ts
+++ b/src/renderer/src/components/dashboard/useRetainedAgents.ts
@@ -7,7 +7,6 @@ import {
   type DashboardWorktreeCard
 } from './useDashboardData'
 import type { RetainedAgentEntry } from '@/store/slices/agent-status'
-import { AGENT_DASHBOARD_ENABLED } from '../../../../shared/constants'
 
 // Why: when an agent finishes or its terminal closes, the store cleans up the
 // explicit status entry and the agent vanishes from useDashboardData. Retaining
@@ -20,18 +19,20 @@ export function useRetainedAgentsSync(liveGroups: DashboardRepoGroup[]): void {
   const retainAgents = useAppStore((s) => s.retainAgents)
   const pruneRetainedAgents = useAppStore((s) => s.pruneRetainedAgents)
   const clearRetentionSuppressedPaneKeys = useAppStore((s) => s.clearRetentionSuppressedPaneKeys)
+  const dashboardEnabled = useAppStore((s) => s.settings?.experimentalAgentDashboard === true)
   const prevAgentsRef = useRef<Map<string, { row: DashboardAgentRow; worktreeId: string }>>(
     new Map()
   )
 
   useEffect(() => {
-    // Why: the feature-flag gate lives inside the effect (not around the hook
-    // declarations above) so rules-of-hooks stays satisfied — the store
-    // selectors and useRef must always run. When the dashboard is disabled,
-    // skip all retention work to avoid touching the store for a feature the
-    // user cannot see. Keeping this check here (rather than in App.tsx) makes
-    // the hook self-contained and safe to call unconditionally from any site.
-    if (!AGENT_DASHBOARD_ENABLED) {
+    // Why: the experimental-setting gate lives inside the effect (not around
+    // the hook declarations above) so rules-of-hooks stays satisfied — the
+    // store selectors and useRef must always run. When the dashboard is
+    // disabled, skip all retention work to avoid touching the store for a
+    // feature the user cannot see. Keeping this check here (rather than in
+    // App.tsx) makes the hook self-contained and safe to call unconditionally
+    // from any site.
+    if (!dashboardEnabled) {
       return
     }
     const current = new Map<string, { row: DashboardAgentRow; worktreeId: string }>()
@@ -73,7 +74,13 @@ export function useRetainedAgentsSync(liveGroups: DashboardRepoGroup[]): void {
     if (consumedSuppressedPaneKeys.length > 0) {
       clearRetentionSuppressedPaneKeys(consumedSuppressedPaneKeys)
     }
-  }, [liveGroups, retainAgents, pruneRetainedAgents, clearRetentionSuppressedPaneKeys])
+  }, [
+    liveGroups,
+    retainAgents,
+    pruneRetainedAgents,
+    clearRetentionSuppressedPaneKeys,
+    dashboardEnabled
+  ])
 }
 
 export function useRetainedAgents(liveGroups: DashboardRepoGroup[]): {

--- a/src/renderer/src/components/right-sidebar/index.tsx
+++ b/src/renderer/src/components/right-sidebar/index.tsx
@@ -6,7 +6,6 @@ import { cn } from '@/lib/utils'
 import { useSidebarResize } from '@/hooks/useSidebarResize'
 import type { RightSidebarTab, ActivityBarPosition } from '@/store/slices/editor'
 import type { CheckStatus } from '../../../../shared/types'
-import { AGENT_DASHBOARD_ENABLED } from '../../../../shared/constants'
 import { isFolderRepo } from '../../../../shared/repo-kind'
 import { findWorktreeById } from '@/store/slices/worktree-helpers'
 import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from '@/components/ui/tooltip'
@@ -125,12 +124,15 @@ function RightSidebarInner(): React.JSX.Element {
   const checksStatus = useAppStore(getActiveChecksStatus)
   const activityBarPosition = useAppStore((s) => s.activityBarPosition)
   const setActivityBarPosition = useAppStore((s) => s.setActivityBarPosition)
-  // Why: the bottom-docked agent dashboard is opt-out via Settings → Agents.
-  // Users who prefer a quieter sidebar can hide the panel without losing any
-  // in-terminal agent status — the per-tab status indicators remain. While
-  // settings are still loading, render the panel so it doesn't flash in once
-  // settings arrive.
+  // Why: the bottom-docked agent dashboard is opt-out via Settings → Agents,
+  // AND gated behind the experimental opt-in setting. Users who prefer a
+  // quieter sidebar can hide the panel without losing any in-terminal agent
+  // status — the per-tab status indicators remain. While settings are still
+  // loading, render the panel so it doesn't flash in once settings arrive.
   const showAgentDashboard = useAppStore((s) => s.settings?.showAgentDashboard !== false)
+  const dashboardExperimentEnabled = useAppStore(
+    (s) => s.settings?.experimentalAgentDashboard === true
+  )
 
   // Why: source control and checks are meaningless for non-git folders.
   // Hide those tabs so the activity bar only shows relevant actions.
@@ -254,7 +256,7 @@ function RightSidebarInner(): React.JSX.Element {
         {effectiveTab === 'checks' && <ChecksPanel />}
         {effectiveTab === 'ports' && <PortsPanel />}
       </div>
-      {AGENT_DASHBOARD_ENABLED && showAgentDashboard && <DashboardBottomPanel />}
+      {dashboardExperimentEnabled && showAgentDashboard && <DashboardBottomPanel />}
     </div>
   )
 

--- a/src/renderer/src/components/settings/AgentsPane.tsx
+++ b/src/renderer/src/components/settings/AgentsPane.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import { Check, ChevronDown, ExternalLink, RefreshCw, Terminal } from 'lucide-react'
 import type { GlobalSettings, TuiAgent } from '../../../../shared/types'
-import { AGENT_DASHBOARD_ENABLED } from '../../../../shared/constants'
 import { AGENT_CATALOG, AgentIcon } from '@/lib/agent-catalog'
 import { useDetectedAgents } from '@/hooks/useDetectedAgents'
 import { Button } from '../ui/button'
@@ -256,7 +255,7 @@ export function AgentsPane({ settings, updateSettings }: AgentsPaneProps): React
   return (
     <div className="space-y-8">
       {/* Dashboard visibility */}
-      {AGENT_DASHBOARD_ENABLED && (
+      {settings.experimentalAgentDashboard === true && (
         <section>
           <div className="flex items-center justify-between gap-4 px-1 py-2">
             <div className="space-y-0.5">

--- a/src/renderer/src/components/settings/ExperimentalPane.tsx
+++ b/src/renderer/src/components/settings/ExperimentalPane.tsx
@@ -205,8 +205,8 @@ export function ExperimentalPane({
                 </p>
                 <p className="text-xs text-muted-foreground">
                   {settings.experimentalAgentDashboard
-                    ? 'Restart Orca to install Claude/Codex/Gemini hooks and enable the dashboard.'
-                    : 'Restart Orca to stop receiving Claude/Codex/Gemini hook events. The dashboard will be hidden.'}
+                    ? 'Restart Orca to finish enabling the agent dashboard.'
+                    : 'Restart Orca to finish disabling the agent dashboard.'}
                 </p>
               </div>
               <Button

--- a/src/renderer/src/components/settings/ExperimentalPane.tsx
+++ b/src/renderer/src/components/settings/ExperimentalPane.tsx
@@ -234,8 +234,11 @@ export function ExperimentalPane({
               <Label>Agent dashboard</Label>
               <p className="text-xs text-muted-foreground">
                 Adds a cross-worktree dashboard and hover cards showing each agent&apos;s live
-                status. Requires an app restart, and tracks agents started in new terminals opened
-                after the restart.
+                status. Requires an app restart
+                {settings.experimentalTerminalDaemon
+                  ? ', and tracks agents started in new terminals opened after the restart'
+                  : ''}
+                .
               </p>
               <SupportedAgentsDisclaimer />
             </div>

--- a/src/renderer/src/components/settings/ExperimentalPane.tsx
+++ b/src/renderer/src/components/settings/ExperimentalPane.tsx
@@ -1,12 +1,25 @@
 import { useEffect, useState } from 'react'
 import { RotateCw } from 'lucide-react'
-import type { GlobalSettings } from '../../../../shared/types'
+import type { GlobalSettings, TuiAgent } from '../../../../shared/types'
 import { Button } from '../ui/button'
 import { Label } from '../ui/label'
 import { useAppStore } from '../../store'
 import { SearchableSetting } from './SearchableSetting'
 import { matchesSettingsSearch } from './settings-search'
 import { EXPERIMENTAL_PANE_SEARCH_ENTRIES } from './experimental-search'
+import { AGENT_CATALOG, AgentIcon } from '@/lib/agent-catalog'
+
+// Why: agents with a per-agent hook-service module under src/main that posts
+// status to the shared agent-hooks server. Keep this list in sync with the
+// hook-service.ts files — any agent without one will not light up the
+// dashboard even when the experimental setting is on.
+const AGENT_DASHBOARD_SUPPORTED_AGENTS: readonly TuiAgent[] = [
+  'claude',
+  'codex',
+  'gemini',
+  'cursor',
+  'opencode'
+] as const
 
 export { EXPERIMENTAL_PANE_SEARCH_ENTRIES }
 
@@ -169,13 +182,14 @@ export function ExperimentalPane({
           className="space-y-3 px-1 py-2"
         >
           <div className="flex items-start justify-between gap-4">
-            <div className="min-w-0 shrink space-y-0.5">
+            <div className="min-w-0 shrink space-y-1.5">
               <Label>Agent dashboard</Label>
               <p className="text-xs text-muted-foreground">
                 Adds a cross-worktree dashboard and hover cards showing each agent&apos;s live
                 status. Requires an app restart, and tracks agents started in new terminals opened
                 after the restart.
               </p>
+              <SupportedAgentsDisclaimer />
             </div>
             <button
               type="button"
@@ -226,6 +240,31 @@ export function ExperimentalPane({
       ) : null}
 
       {hiddenExperimentalUnlocked ? <HiddenExperimentalGroup /> : null}
+    </div>
+  )
+}
+
+function SupportedAgentsDisclaimer(): React.JSX.Element {
+  const supported = AGENT_DASHBOARD_SUPPORTED_AGENTS.map((id) => {
+    const entry = AGENT_CATALOG.find((a) => a.id === id)
+    return { id, label: entry?.label ?? id }
+  })
+  return (
+    <div className="space-y-1 pt-0.5 text-xs text-muted-foreground">
+      <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1">
+        <span>Supported agents:</span>
+        {supported.map(({ id, label }) => (
+          <span
+            key={id}
+            className="inline-flex items-center gap-1 rounded-md border border-border/50 bg-muted/40 px-1.5 py-0.5"
+            title={label}
+          >
+            <AgentIcon agent={id} size={12} />
+            <span className="text-[11px] leading-none text-foreground/80">{label}</span>
+          </span>
+        ))}
+      </div>
+      <p className="text-[11px] italic">Currently working on support for more agent CLIs.</p>
     </div>
   )
 }

--- a/src/renderer/src/components/settings/ExperimentalPane.tsx
+++ b/src/renderer/src/components/settings/ExperimentalPane.tsx
@@ -173,7 +173,8 @@ export function ExperimentalPane({
               <Label>Agent dashboard</Label>
               <p className="text-xs text-muted-foreground">
                 Adds a cross-worktree dashboard and hover cards showing each agent&apos;s live
-                status. Requires an app restart to take effect.
+                status. Requires an app restart, and tracks agents started in new terminals opened
+                after the restart.
               </p>
             </div>
             <button

--- a/src/renderer/src/components/settings/ExperimentalPane.tsx
+++ b/src/renderer/src/components/settings/ExperimentalPane.tsx
@@ -49,6 +49,9 @@ export function ExperimentalPane({
   }, [])
 
   const showDaemon = matchesSettingsSearch(searchQuery, [EXPERIMENTAL_PANE_SEARCH_ENTRIES[0]])
+  const showAgentDashboard = matchesSettingsSearch(searchQuery, [
+    EXPERIMENTAL_PANE_SEARCH_ENTRIES[1]
+  ])
   const pendingRestart =
     daemonEnabledAtStartup !== null &&
     settings.experimentalTerminalDaemon !== daemonEnabledAtStartup
@@ -136,6 +139,56 @@ export function ExperimentalPane({
               </Button>
             </div>
           ) : null}
+        </SearchableSetting>
+      ) : null}
+
+      {showAgentDashboard ? (
+        <SearchableSetting
+          title="Agent dashboard"
+          description="Live cross-worktree view of agent activity, plus retention of finished runs in the sidebar hover."
+          keywords={[
+            'experimental',
+            'agent',
+            'dashboard',
+            'status',
+            'activity',
+            'worktree',
+            'hook',
+            'claude',
+            'codex',
+            'gemini',
+            'sidebar'
+          ]}
+          className="space-y-3 px-1 py-2"
+        >
+          <div className="flex items-start justify-between gap-4">
+            <div className="min-w-0 shrink space-y-0.5">
+              <Label>Agent dashboard</Label>
+              <p className="text-xs text-muted-foreground">
+                Adds a cross-worktree dashboard and hover cards showing each agent&apos;s live
+                status. Requires an app restart to take effect.
+              </p>
+            </div>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={settings.experimentalAgentDashboard}
+              onClick={() =>
+                updateSettings({
+                  experimentalAgentDashboard: !settings.experimentalAgentDashboard
+                })
+              }
+              className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent transition-colors ${
+                settings.experimentalAgentDashboard ? 'bg-foreground' : 'bg-muted-foreground/30'
+              }`}
+            >
+              <span
+                className={`inline-block h-3.5 w-3.5 transform rounded-full bg-background shadow-sm transition-transform ${
+                  settings.experimentalAgentDashboard ? 'translate-x-4' : 'translate-x-0.5'
+                }`}
+              />
+            </button>
+          </div>
         </SearchableSetting>
       ) : null}
 

--- a/src/renderer/src/components/settings/ExperimentalPane.tsx
+++ b/src/renderer/src/components/settings/ExperimentalPane.tsx
@@ -23,6 +23,18 @@ const AGENT_DASHBOARD_SUPPORTED_AGENTS: readonly TuiAgent[] = [
   'opencode'
 ] as const
 
+// Why: both AGENT_DASHBOARD_SUPPORTED_AGENTS and AGENT_CATALOG are static
+// module-level constants, so the resolved {id, label} pairs never change at
+// runtime. Computing this inside SupportedAgentsDisclaimer was O(N×M) work on
+// every parent re-render — notably on every keystroke in the settings search —
+// for a list that can only change at build time. Hoisting it makes the cost
+// a one-time module-load expense.
+const SUPPORTED_AGENT_ENTRIES: readonly { id: TuiAgent; label: string }[] =
+  AGENT_DASHBOARD_SUPPORTED_AGENTS.map((id) => {
+    const entry = AGENT_CATALOG.find((a) => a.id === id)
+    return { id, label: entry?.label ?? id }
+  })
+
 export { EXPERIMENTAL_PANE_SEARCH_ENTRIES }
 
 const ORCHESTRATION_SKILL_INSTALL_COMMAND =
@@ -362,15 +374,11 @@ export function ExperimentalPane({
 }
 
 function SupportedAgentsDisclaimer(): React.JSX.Element {
-  const supported = AGENT_DASHBOARD_SUPPORTED_AGENTS.map((id) => {
-    const entry = AGENT_CATALOG.find((a) => a.id === id)
-    return { id, label: entry?.label ?? id }
-  })
   return (
     <div className="space-y-1 pt-0.5 text-xs text-muted-foreground">
       <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1">
         <span>Supported agents:</span>
-        {supported.map(({ id, label }) => (
+        {SUPPORTED_AGENT_ENTRIES.map(({ id, label }) => (
           <span
             key={id}
             className="inline-flex items-center gap-1 rounded-md border border-border/50 bg-muted/40 px-1.5 py-0.5"

--- a/src/renderer/src/components/settings/ExperimentalPane.tsx
+++ b/src/renderer/src/components/settings/ExperimentalPane.tsx
@@ -381,7 +381,9 @@ function SupportedAgentsDisclaimer(): React.JSX.Element {
           </span>
         ))}
       </div>
-      <p className="text-[11px] italic">Currently working on support for more agent CLIs.</p>
+      <p className="text-[11px] italic">
+        We&apos;re currently working on support for more agent CLIs.
+      </p>
     </div>
   )
 }

--- a/src/renderer/src/components/settings/ExperimentalPane.tsx
+++ b/src/renderer/src/components/settings/ExperimentalPane.tsx
@@ -24,11 +24,14 @@ export function ExperimentalPane({
   hiddenExperimentalUnlocked = false
 }: ExperimentalPaneProps): React.JSX.Element {
   const searchQuery = useAppStore((s) => s.settingsSearchQuery)
-  // Why: "daemon enabled at startup" is the effective runtime state, read
-  // directly from main once on mount. The banner compares the user's current
+  // Why: the "enabled at startup" flags are the effective runtime state, read
+  // directly from main once on mount. Each banner compares the user's current
   // setting against this snapshot to tell them a restart is still required.
   // null = not yet fetched (banner stays hidden to avoid a flash).
   const [daemonEnabledAtStartup, setDaemonEnabledAtStartup] = useState<boolean | null>(null)
+  const [agentDashboardEnabledAtStartup, setAgentDashboardEnabledAtStartup] = useState<
+    boolean | null
+  >(null)
   const [relaunching, setRelaunching] = useState(false)
 
   useEffect(() => {
@@ -38,6 +41,7 @@ export function ExperimentalPane({
       .then((flags) => {
         if (!cancelled) {
           setDaemonEnabledAtStartup(flags.daemonEnabledAtStartup)
+          setAgentDashboardEnabledAtStartup(flags.agentDashboardEnabledAtStartup)
         }
       })
       .catch(() => {
@@ -52,9 +56,12 @@ export function ExperimentalPane({
   const showAgentDashboard = matchesSettingsSearch(searchQuery, [
     EXPERIMENTAL_PANE_SEARCH_ENTRIES[1]
   ])
-  const pendingRestart =
+  const pendingDaemonRestart =
     daemonEnabledAtStartup !== null &&
     settings.experimentalTerminalDaemon !== daemonEnabledAtStartup
+  const pendingAgentDashboardRestart =
+    agentDashboardEnabledAtStartup !== null &&
+    settings.experimentalAgentDashboard !== agentDashboardEnabledAtStartup
 
   const handleRelaunch = async (): Promise<void> => {
     if (relaunching) {
@@ -115,7 +122,7 @@ export function ExperimentalPane({
             </button>
           </div>
 
-          {pendingRestart ? (
+          {pendingDaemonRestart ? (
             <div className="flex items-center justify-between gap-3 rounded-md border border-yellow-500/50 bg-yellow-500/10 px-3 py-2.5">
               <div className="min-w-0 flex-1 space-y-0.5">
                 <p className="text-sm font-medium text-yellow-700 dark:text-yellow-300">
@@ -189,6 +196,31 @@ export function ExperimentalPane({
               />
             </button>
           </div>
+
+          {pendingAgentDashboardRestart ? (
+            <div className="flex items-center justify-between gap-3 rounded-md border border-yellow-500/50 bg-yellow-500/10 px-3 py-2.5">
+              <div className="min-w-0 flex-1 space-y-0.5">
+                <p className="text-sm font-medium text-yellow-700 dark:text-yellow-300">
+                  Restart required
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  {settings.experimentalAgentDashboard
+                    ? 'Restart Orca to install Claude/Codex/Gemini hooks and enable the dashboard.'
+                    : 'Restart Orca to stop receiving Claude/Codex/Gemini hook events. The dashboard will be hidden.'}
+                </p>
+              </div>
+              <Button
+                size="sm"
+                variant="default"
+                className="shrink-0 gap-1.5"
+                disabled={relaunching}
+                onClick={handleRelaunch}
+              >
+                <RotateCw className={`size-3 ${relaunching ? 'animate-spin' : ''}`} />
+                {relaunching ? 'Restarting…' : 'Restart now'}
+              </Button>
+            </div>
+          ) : null}
         </SearchableSetting>
       ) : null}
 

--- a/src/renderer/src/components/settings/experimental-search.ts
+++ b/src/renderer/src/components/settings/experimental-search.ts
@@ -16,5 +16,23 @@ export const EXPERIMENTAL_PANE_SEARCH_ENTRIES: SettingsSearchEntry[] = [
       'scrollback',
       'reattach'
     ]
+  },
+  {
+    title: 'Agent dashboard',
+    description:
+      'Live cross-worktree view of agent activity, plus retention of finished runs in the sidebar hover. Experimental — managed hook installs require an app restart.',
+    keywords: [
+      'experimental',
+      'agent',
+      'dashboard',
+      'status',
+      'activity',
+      'worktree',
+      'hook',
+      'claude',
+      'codex',
+      'gemini',
+      'sidebar'
+    ]
   }
 ]

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -14,7 +14,6 @@ import { cn } from '@/lib/utils'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 import { getWorktreeStatus, type WorktreeStatus } from '@/lib/worktree-status'
 import { isExplicitAgentStatusFresh } from '@/lib/agent-status'
-import { AGENT_DASHBOARD_ENABLED } from '../../../../shared/constants'
 import { AGENT_STATUS_STALE_AFTER_MS } from '../../../../shared/agent-status-types'
 import { getRepoKindLabel, isFolderRepo } from '../../../../shared/repo-kind'
 import type { Worktree, Repo, PRInfo, IssueInfo } from '../../../../shared/types'
@@ -49,6 +48,9 @@ const WorktreeCard = React.memo(function WorktreeCard({
   const fetchPRForBranch = useAppStore((s) => s.fetchPRForBranch)
   const fetchIssue = useAppStore((s) => s.fetchIssue)
   const cardProps = useAppStore((s) => s.worktreeCardProperties)
+  const dashboardExperimentEnabled = useAppStore(
+    (s) => s.settings?.experimentalAgentDashboard === true
+  )
   const handleEditIssue = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation()
@@ -350,7 +352,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
           {(cardProps.includes('status') || cardProps.includes('unread')) && (
             <div className="flex flex-col items-center justify-start pt-[2px] gap-2 shrink-0">
               {cardProps.includes('status') &&
-                (AGENT_DASHBOARD_ENABLED ? (
+                (dashboardExperimentEnabled ? (
                   <AgentStatusHover worktreeId={worktree.id}>
                     {/* Why: make the hover trigger keyboard-focusable so
                         keyboard-only users can open the hover panel (Radix

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -15,7 +15,6 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { cn } from '@/lib/utils'
 import type { Worktree, Repo } from '../../../../shared/types'
 import { isGitRepoKind } from '../../../../shared/repo-kind'
-import { AGENT_DASHBOARD_ENABLED } from '../../../../shared/constants'
 import {
   buildExplicitEntriesByTabId,
   buildWorktreeComparator,
@@ -566,7 +565,13 @@ const WorktreeList = React.memo(function WorktreeList() {
     // Combined: O(E) index + O(N×T) scoring + O(N log N) sort, instead of
     // O(N × E × T) per sortEpoch bump. Only smart mode uses the score map;
     // other modes ignore it.
-    const agentStatusForSort = AGENT_DASHBOARD_ENABLED ? state.agentStatusByPaneKey : undefined
+    // Why: smart-sort only weighs live agent status when the experimental
+    // Agent Dashboard is opted in — that's the surface that populates
+    // agentStatusByPaneKey via hooks. With the setting off, pass undefined
+    // so the comparator falls back to the persisted-sortOrder + title
+    // heuristics instead of scoring against an empty map.
+    const agentStatusForSort =
+      state.settings?.experimentalAgentDashboard === true ? state.agentStatusByPaneKey : undefined
     const explicitByTabId =
       sortBy === 'smart' ? buildExplicitEntriesByTabId(agentStatusForSort) : undefined
     const precomputedScores =

--- a/src/renderer/src/components/sidebar/visible-worktrees.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.ts
@@ -1,6 +1,5 @@
 import type { Worktree, Repo, TerminalTab } from '../../../../shared/types'
 import type { AppState } from '@/store/types'
-import { AGENT_DASHBOARD_ENABLED } from '../../../../shared/constants'
 import { matchesSearch } from './worktree-list-groups'
 import { buildWorktreeComparator, sortWorktreesSmart } from './smart-sort'
 import { useAppStore } from '@/store'
@@ -120,7 +119,11 @@ export function getVisibleWorktreeIds(): string[] {
 
   let sortedIds: string[]
 
-  const agentStatusForSort = AGENT_DASHBOARD_ENABLED ? state.agentStatusByPaneKey : undefined
+  // Why: matches WorktreeList's gate — when the experimental Agent Dashboard
+  // is off, the agent-status map is not populated, so fall back to the
+  // non-status sort heuristics instead of scoring against an empty map.
+  const agentStatusForSort =
+    state.settings?.experimentalAgentDashboard === true ? state.agentStatusByPaneKey : undefined
   if (state.sortBy === 'smart') {
     sortedIds = sortWorktreesSmart(
       allWorktrees,

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -313,12 +313,12 @@ export function connectPanePty(
       // snapshot also gates on the experimental dashboard setting — without
       // the opt-in, OSC 9999 status payloads are dropped before they reach
       // the store.
-      const state = useAppStore.getState()
-      if (state.settings?.experimentalAgentDashboard !== true) {
+      const currentState = useAppStore.getState()
+      if (currentState.settings?.experimentalAgentDashboard !== true) {
         return
       }
-      const title = state.runtimePaneTitlesByTabId?.[deps.tabId]?.[pane.id]
-      state.setAgentStatus(cacheKey, payload, title)
+      const title = currentState.runtimePaneTitlesByTabId?.[deps.tabId]?.[pane.id]
+      currentState.setAgentStatus(cacheKey, payload, title)
     }
   })
   const hasExistingPaneTransport = deps.paneTransportsRef.current.size > 0

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -5,7 +5,6 @@ import { isGeminiTerminalTitle, isClaudeAgent } from '@/lib/agent-status'
 import { scheduleRuntimeGraphSync } from '@/runtime/sync-runtime-graph'
 import { useAppStore } from '@/store'
 import { toast } from 'sonner'
-import { AGENT_DASHBOARD_ENABLED } from '../../../../shared/constants'
 import type { PtyConnectResult } from './pty-transport'
 import { createIpcPtyTransport } from './pty-transport'
 import { shouldSeedCacheTimerOnInitialTitle } from './cache-timer-seeding'
@@ -306,15 +305,18 @@ export function connectPanePty(
     // Without this, the OSC parser in pty-transport strips sequences from xterm
     // output but the status never reaches the store or dashboard/hover UI.
     onAgentStatus: (payload) => {
-      if (!AGENT_DASHBOARD_ENABLED) {
-        return
-      }
       // Why: capture the store snapshot once so the title lookup and the
       // setAgentStatus call observe the same state. Re-reading getState()
       // between the two lines opens a brief window where the title could
       // shift (OSC title update landing in between) and the status would be
-      // stored against a title that was never paired with it.
+      // stored against a title that was never paired with it. The same
+      // snapshot also gates on the experimental dashboard setting — without
+      // the opt-in, OSC 9999 status payloads are dropped before they reach
+      // the store.
       const state = useAppStore.getState()
+      if (state.settings?.experimentalAgentDashboard !== true) {
+        return
+      }
       const title = state.runtimePaneTitlesByTabId?.[deps.tabId]?.[pane.id]
       state.setAgentStatus(cacheKey, payload, title)
     }

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -209,7 +209,8 @@ describe('useIpcEvents updater integration', () => {
             credentialResolvedListenerRef.current = listener
             return () => {}
           }
-        }
+        },
+        agentStatus: { onSet: () => () => {} }
       }
     })
 
@@ -392,7 +393,8 @@ describe('useIpcEvents updater integration', () => {
           onCredentialResolved: () => () => {},
           onPortForwardsChanged: () => () => {},
           onDetectedPortsChanged: () => () => {}
-        }
+        },
+        agentStatus: { onSet: () => () => {} }
       }
     })
 
@@ -573,7 +575,8 @@ describe('useIpcEvents updater integration', () => {
           onPortForwardsChanged: () => () => {},
           onDetectedPortsChanged: () => () => {},
           onCredentialResolved: () => () => {}
-        }
+        },
+        agentStatus: { onSet: () => () => {} }
       }
     })
 
@@ -769,7 +772,8 @@ describe('useIpcEvents browser tab close routing', () => {
           onPortForwardsChanged: () => () => {},
           onDetectedPortsChanged: () => () => {},
           onCredentialResolved: () => () => {}
-        }
+        },
+        agentStatus: { onSet: () => () => {} }
       }
     })
 
@@ -950,7 +954,8 @@ describe('useIpcEvents browser tab close routing', () => {
           onPortForwardsChanged: () => () => {},
           onDetectedPortsChanged: () => () => {},
           onCredentialResolved: () => () => {}
-        }
+        },
+        agentStatus: { onSet: () => () => {} }
       }
     })
 
@@ -1126,7 +1131,8 @@ describe('useIpcEvents browser tab close routing', () => {
           onPortForwardsChanged: () => () => {},
           onDetectedPortsChanged: () => () => {},
           onCredentialResolved: () => () => {}
-        }
+        },
+        agentStatus: { onSet: () => () => {} }
       }
     })
 
@@ -1311,7 +1317,8 @@ describe('useIpcEvents shortcut hint clearing', () => {
           onPortForwardsChanged: () => () => {},
           onDetectedPortsChanged: () => () => {},
           onCredentialResolved: () => () => {}
-        }
+        },
+        agentStatus: { onSet: () => () => {} }
       }
     })
 
@@ -1503,7 +1510,8 @@ describe('useIpcEvents CLI-created worktree activation', () => {
           onPortForwardsChanged: () => () => {},
           onDetectedPortsChanged: () => () => {},
           onCredentialResolved: () => () => {}
-        }
+        },
+        agentStatus: { onSet: () => () => {} }
       }
     })
 

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -16,7 +16,6 @@ import { resolveZoomTarget } from './resolve-zoom-target'
 import { handleSwitchTab, handleSwitchTerminalTab } from './ipc-tab-switch'
 import { dispatchClearModifierHints } from './useModifierHint'
 import { normalizeAgentStatusPayload } from '../../../shared/agent-status-types'
-import { AGENT_DASHBOARD_ENABLED } from '../../../shared/constants'
 import { isGitRepoKind } from '../../../shared/repo-kind'
 
 export { resolveZoomTarget } from './resolve-zoom-target'
@@ -706,43 +705,47 @@ export function useIpcEvents(): void {
     // Why: agent status arrives from native hook receivers in the main process.
     // Re-parse it here so the renderer enforces the same normalization rules
     // (state enum, field truncation) regardless of whether the source was a
-    // hook callback or an OSC fallback path.
-    if (AGENT_DASHBOARD_ENABLED) {
-      unsubs.push(
-        window.api.agentStatus.onSet((data) => {
-          // Why: the IPC payload is already a structured object — pass it
-          // straight to the object-input normalizer instead of round-tripping
-          // through JSON.stringify/JSON.parse. Hook events can fire many times
-          // per second during a tool-use run, so this avoids the per-event
-          // serialization cost.
-          const payload = normalizeAgentStatusPayload({
-            state: data.state,
-            prompt: data.prompt,
-            agentType: data.agentType,
-            toolName: data.toolName,
-            toolInput: data.toolInput,
-            lastAssistantMessage: data.lastAssistantMessage,
-            interrupted: data.interrupted
-          })
-          if (!payload) {
-            return
-          }
-          const store = useAppStore.getState()
-          // Why: resolve tab existence and terminal title in a single pass.
-          // Previously the code walked store.tabsByWorktree twice — once to
-          // look up the tab-level title (when the pane-level title was
-          // missing) and again for the explicit tabExists check. A paneKey
-          // that no longer resolves to a live tab belongs to a pane that has
-          // already been torn down; dropping here prevents orphan entries
-          // from accumulating in agentStatusByPaneKey.
-          const { exists, title } = resolvePaneKey(store, data.paneKey)
-          if (!exists) {
-            return
-          }
-          store.setAgentStatus(data.paneKey, payload, title)
+    // hook callback or an OSC fallback path. The subscription itself is
+    // unconditional so flipping the experimental dashboard setting takes
+    // effect without re-running this App-mount effect; the per-event guard
+    // inside the handler drops payloads when the setting is off.
+    unsubs.push(
+      window.api.agentStatus.onSet((data) => {
+        const store = useAppStore.getState()
+        if (store.settings?.experimentalAgentDashboard !== true) {
+          return
+        }
+        // Why: the IPC payload is already a structured object — pass it
+        // straight to the object-input normalizer instead of round-tripping
+        // through JSON.stringify/JSON.parse. Hook events can fire many times
+        // per second during a tool-use run, so this avoids the per-event
+        // serialization cost.
+        const payload = normalizeAgentStatusPayload({
+          state: data.state,
+          prompt: data.prompt,
+          agentType: data.agentType,
+          toolName: data.toolName,
+          toolInput: data.toolInput,
+          lastAssistantMessage: data.lastAssistantMessage,
+          interrupted: data.interrupted
         })
-      )
-    }
+        if (!payload) {
+          return
+        }
+        // Why: resolve tab existence and terminal title in a single pass.
+        // Previously the code walked store.tabsByWorktree twice — once to
+        // look up the tab-level title (when the pane-level title was
+        // missing) and again for the explicit tabExists check. A paneKey
+        // that no longer resolves to a live tab belongs to a pane that has
+        // already been torn down; dropping here prevents orphan entries
+        // from accumulating in agentStatusByPaneKey.
+        const { exists, title } = resolvePaneKey(store, data.paneKey)
+        if (!exists) {
+          return
+        }
+        store.setAgentStatus(data.paneKey, payload, title)
+      })
+    )
 
     return () => unsubs.forEach((fn) => fn())
   }, [])

--- a/src/shared/agent-hook-types.ts
+++ b/src/shared/agent-hook-types.ts
@@ -22,7 +22,8 @@ export type AgentHookInstallStatus = {
 // silently producing partial payloads. Still at v1 because the endpoint-file
 // rollout is additive — pre-endpoint-file scripts still post the same JSON
 // body shape, and no caller was ever shipped on v2 (the Claude/Codex/Gemini
-// install path has been gated behind AGENT_DASHBOARD_ENABLED=false, and the
-// Cursor/OpenCode scripts reroll on every Orca launch so no in-wild fleet
-// exists to distinguish from). Reserve the next bump for a real wire change.
+// install path is gated behind the experimentalAgentDashboard setting and is
+// off by default, and the Cursor/OpenCode scripts reroll on every Orca launch
+// so no in-wild fleet exists to distinguish from). Reserve the next bump for
+// a real wire change.
 export const ORCA_HOOK_PROTOCOL_VERSION = '1' as const

--- a/src/shared/agent-hook-types.ts
+++ b/src/shared/agent-hook-types.ts
@@ -21,9 +21,10 @@ export type AgentHookInstallStatus = {
 // stale script installed by an older app build is diagnosable instead of
 // silently producing partial payloads. Still at v1 because the endpoint-file
 // rollout is additive — pre-endpoint-file scripts still post the same JSON
-// body shape, and no caller was ever shipped on v2 (the Claude/Codex/Gemini
-// install path is gated behind the experimentalAgentDashboard setting and is
-// off by default, and the Cursor/OpenCode scripts reroll on every Orca launch
-// so no in-wild fleet exists to distinguish from). Reserve the next bump for
-// a real wire change.
+// body shape, and no in-wild v1 script exists that a future v2 receiver would
+// need to distinguish from: Claude/Codex/Gemini install is gated behind the
+// experimentalAgentDashboard setting (off by default, so no shipped fleet),
+// and Cursor's managed script is rewritten on every install() call so there
+// is no durable on-disk v1 script to inherit. Reserve the next bump for a
+// real wire change.
 export const ORCA_HOOK_PROTOCOL_VERSION = '1' as const

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -181,6 +181,9 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     terminalMacOptionAsAltMigrated: false,
     experimentalTerminalDaemon: false,
     experimentalTerminalDaemonNoticeShown: false,
+    // Why: opt-in preview — default off so managed-hook installation
+    // (Claude/Codex/Gemini) stays dormant for existing users and upgraders
+    // (persistence.ts merges defaults first, so upgraders inherit this).
     experimentalAgentDashboard: false
   }
 }

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -12,13 +12,6 @@ import { DEFAULT_TERMINAL_FONT_WEIGHT } from './terminal-fonts'
 
 export const SCHEMA_VERSION = 1
 
-// Why: temporary compile-time gate for the agent status dashboard feature.
-// Flip to `true` only when every dashboard PR has landed; the follow-up cleanup
-// PR will delete this constant and every `if (!AGENT_DASHBOARD_ENABLED)` branch
-// entirely, making the feature permanent. Not user-facing — do not read from
-// settings, env, or IPC.
-export const AGENT_DASHBOARD_ENABLED = false
-
 export const ORCA_BROWSER_PARTITION = 'persist:orca-browser'
 // Why: blank browser tabs must start from an inert guest URL that does not
 // navigate the privileged main window to about:blank. Renderer and main both
@@ -187,7 +180,8 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     terminalMacOptionAsAlt: 'auto',
     terminalMacOptionAsAltMigrated: false,
     experimentalTerminalDaemon: false,
-    experimentalTerminalDaemonNoticeShown: false
+    experimentalTerminalDaemonNoticeShown: false,
+    experimentalAgentDashboard: false
   }
 }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1016,6 +1016,15 @@ export type GlobalSettings = {
    *  toast shown to users upgrading from v1.3.0 (where the daemon was on by
    *  default). Set to true the first time the toast fires so it never repeats. */
   experimentalTerminalDaemonNoticeShown: boolean
+  /** Experimental: live Agent Dashboard — a bottom-docked right-sidebar panel
+   *  that aggregates working/blocked/done agents across all worktrees, plus
+   *  the sidebar AgentStatusHover surface, retention of "done" rows, and the
+   *  hook-driven status slice that feeds them. Opt-in because the surface is
+   *  still in preview: managed hook installation (Claude/Codex/Gemini) only
+   *  runs when this is true, so toggling it on takes effect on the next app
+   *  launch. The in-pane status indicators and the cursor-agent hook path are
+   *  unaffected by this toggle. */
+  experimentalAgentDashboard: boolean
 }
 
 export type GhosttyImportPreview = {


### PR DESCRIPTION
## Summary

Replaces the compile-time `AGENT_DASHBOARD_ENABLED` constant with a runtime `experimentalAgentDashboard` field on `GlobalSettings`, exposed via a new toggle in the Experimental pane. Default is off so managed Claude/Codex/Gemini hook installation stays dormant for existing users and new installs until they opt in.

- **Runtime gate** — every prior `AGENT_DASHBOARD_ENABLED` branch now reads from settings instead: main-process hook install, IPC forwarding, renderer dashboard panel, sidebar `AgentStatusHover`, worktree smart-sort, and the `useIpcEvents` subscription. Per-event guards inside handlers drop payloads when the setting is off, so toggling takes effect without re-running App-mount effects.
- **Hook install requires a restart** — Claude/Codex/Gemini managed hook installation still runs once at app boot. To surface this honestly, `AppRuntimeFlags` now carries `agentDashboardEnabledAtStartup` (captured at main-process boot and exposed via `app:getRuntimeFlags`). When the current setting diverges from the startup snapshot, the Experimental pane renders a "Restart required" banner with a "Restart now" button, mirroring the existing terminal-daemon toggle.
- **Default off, including for upgraders** — `persistence.ts` merges defaults first so existing users inherit `experimentalAgentDashboard: false` on upgrade.

Not affected by the toggle: in-pane status indicators and the cursor-agent hook path.

## Test plan

- [x] Toggle off (default) — no dashboard panel, no sidebar hover, no Claude/Codex/Gemini managed hooks installed on launch
- [x] Toggle on → banner appears → Restart now → after relaunch, dashboard panel and hover are live, managed hooks are installed
- [x] Toggle on → off (without restarting) → hook events stop reaching the renderer slice mid-session; restart banner surfaces
- [x] Upgrading user with existing settings file lands on `experimentalAgentDashboard: false`
- [x] Settings search matches the new toggle via keywords (dashboard, agent, hook, claude, codex, gemini, sidebar)

Made with [Orca](https://github.com/stablyai/orca) 🐋

<img width="951" height="134" alt="image" src="https://github.com/user-attachments/assets/5974e1a4-d21a-4416-9bd3-3a556687af00" />
