### PR TITLE
fix(agents): detect Kiro under its real binary name `kiro-cli`

### DIFF
--- a/src/renderer/src/lib/agent-catalog.tsx
+++ b/src/renderer/src/lib/agent-catalog.tsx
@@ -85,7 +85,11 @@ export const AGENT_CATALOG: AgentCatalogEntry[] = [
   {
     id: 'kiro',
     label: 'Kiro',
-    cmd: 'kiro',
+    // Why: the Kiro installer (https://cli.kiro.dev/install) ships a binary
+    // named `kiro-cli`, not `kiro`. Match TUI_AGENT_CONFIG.kiro.detectCmd so
+    // the settings pane's "default command" hint aligns with what Orca
+    // actually looks for on PATH.
+    cmd: 'kiro-cli',
     faviconDomain: 'kiro.dev',
     homepageUrl: 'https://kiro.dev/docs/cli/'
   },

--- a/src/shared/tui-agent-config.ts
+++ b/src/shared/tui-agent-config.ts
@@ -76,9 +76,13 @@ export const TUI_AGENT_CONFIG: Record<TuiAgent, TuiAgentConfig> = {
     promptInjectionMode: 'stdin-after-start'
   },
   kiro: {
-    detectCmd: 'kiro',
-    launchCmd: 'kiro',
-    expectedProcess: 'kiro',
+    // Why: the official Kiro installer (https://cli.kiro.dev/install) places a
+    // binary named `kiro-cli` on PATH — there is no `kiro` binary. Keep the
+    // TuiAgent id as 'kiro' for stored preferences, but detect/launch/identify
+    // the real binary name so the agent is recognized as active.
+    detectCmd: 'kiro-cli',
+    launchCmd: 'kiro-cli',
+    expectedProcess: 'kiro-cli',
     promptInjectionMode: 'stdin-after-start'
   },
   crush: {


### PR DESCRIPTION
## Summary
- Kiro wasn't being recognized as an installed/active agent. The official installer (https://cli.kiro.dev/install) ships a binary named `kiro-cli`, not `kiro`, so PATH detection, foreground-process readiness matching, and the Agents settings pane all missed it.
- Point `TUI_AGENT_CONFIG.kiro`'s `detectCmd`/`launchCmd`/`expectedProcess` and `AGENT_CATALOG` entry's `cmd` at `kiro-cli`, mirroring the existing `aug`/`auggie` pattern. The `TuiAgent` id stays `kiro` so stored preferences are unaffected.

## Test plan
- [x] `pnpm typecheck` passes
- [x] Unit tests for `tui-agent-startup` and related renderer/shared modules pass
- [x] Verified in a local Electron dev build: after installing `kiro-cli` (v2.1.1) via the official installer, `detectedAgentIds` includes `kiro` and the Agents settings pane lists Kiro under **Detected** with command hint `kiro-cli`

Made with [Orca](https://github.com/stablyai/orca) 🐋

Fixes https://github.com/stablyai/orca/issues/1214
