### PR TITLE
fix(agents): use Kilocode brand logo instead of illegible favicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Orca supports any CLI agent (_not just this list_).
   <a href="https://cursor.com/cli"><kbd><img src="https://www.google.com/s2/favicons?domain=cursor.com&sz=64" width="16" valign="middle" /> Cursor</kbd></a> &nbsp;
   <a href="https://docs.factory.ai/cli/getting-started/quickstart"><kbd><img src="https://www.google.com/s2/favicons?domain=factory.ai&sz=64" width="16" valign="middle" /> Droid</kbd></a> &nbsp;
   <a href="https://docs.github.com/en/copilot/how-tos/set-up/install-copilot-cli"><kbd><img src="https://www.google.com/s2/favicons?domain=github.com&sz=64" width="16" valign="middle" /> GitHub Copilot</kbd></a> &nbsp;
-  <a href="https://kilo.ai/docs/cli"><kbd><img src="https://www.google.com/s2/favicons?domain=kilo.ai&sz=64" width="16" valign="middle" /> Kilocode</kbd></a> &nbsp;
+  <a href="https://kilo.ai/docs/cli"><kbd><img src="https://raw.githubusercontent.com/Kilo-Org/kilocode/main/packages/kilo-vscode/assets/icons/kilo-light.png" width="16" valign="middle" /> Kilocode</kbd></a> &nbsp;
   <a href="https://www.kimi.com/code/docs/en/kimi-cli/guides/getting-started.html"><kbd><img src="https://www.google.com/s2/favicons?domain=moonshot.cn&sz=64" width="16" valign="middle" /> Kimi</kbd></a> &nbsp;
   <a href="https://kiro.dev/docs/cli/"><kbd><img src="https://www.google.com/s2/favicons?domain=kiro.dev&sz=64" width="16" valign="middle" /> Kiro</kbd></a> &nbsp;
   <a href="https://github.com/mistralai/mistral-vibe"><kbd><img src="https://www.google.com/s2/favicons?domain=mistral.ai&sz=64" width="16" valign="middle" /> Mistral Vibe</kbd></a> &nbsp;

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -49,7 +49,7 @@ Orca es compatible con cualquier agente CLI (_no solo los de esta lista_).
   <a href="https://cursor.com/cli"><kbd><img src="https://www.google.com/s2/favicons?domain=cursor.com&sz=64" width="16" valign="middle" /> Cursor</kbd></a> &nbsp;
   <a href="https://docs.factory.ai/cli/getting-started/quickstart"><kbd><img src="https://www.google.com/s2/favicons?domain=factory.ai&sz=64" width="16" valign="middle" /> Droid</kbd></a> &nbsp;
   <a href="https://docs.github.com/en/copilot/how-tos/set-up/install-copilot-cli"><kbd><img src="https://www.google.com/s2/favicons?domain=github.com&sz=64" width="16" valign="middle" /> GitHub Copilot</kbd></a> &nbsp;
-  <a href="https://kilo.ai/docs/cli"><kbd><img src="https://www.google.com/s2/favicons?domain=kilo.ai&sz=64" width="16" valign="middle" /> Kilocode</kbd></a> &nbsp;
+  <a href="https://kilo.ai/docs/cli"><kbd><img src="https://raw.githubusercontent.com/Kilo-Org/kilocode/main/packages/kilo-vscode/assets/icons/kilo-light.png" width="16" valign="middle" /> Kilocode</kbd></a> &nbsp;
   <a href="https://www.kimi.com/code/docs/en/kimi-cli/guides/getting-started.html"><kbd><img src="https://www.google.com/s2/favicons?domain=moonshot.cn&sz=64" width="16" valign="middle" /> Kimi</kbd></a> &nbsp;
   <a href="https://kiro.dev/docs/cli/"><kbd><img src="https://www.google.com/s2/favicons?domain=kiro.dev&sz=64" width="16" valign="middle" /> Kiro</kbd></a> &nbsp;
   <a href="https://github.com/mistralai/mistral-vibe"><kbd><img src="https://www.google.com/s2/favicons?domain=mistral.ai&sz=64" width="16" valign="middle" /> Mistral Vibe</kbd></a> &nbsp;

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -50,7 +50,7 @@ Orca は任意の CLI Agent に対応しています（_このリストに限定
   <a href="https://cursor.com/cli"><kbd><img src="https://www.google.com/s2/favicons?domain=cursor.com&sz=64" width="16" valign="middle" /> Cursor</kbd></a> &nbsp;
   <a href="https://docs.factory.ai/cli/getting-started/quickstart"><kbd><img src="https://www.google.com/s2/favicons?domain=factory.ai&sz=64" width="16" valign="middle" /> Droid</kbd></a> &nbsp;
   <a href="https://docs.github.com/en/copilot/how-tos/set-up/install-copilot-cli"><kbd><img src="https://www.google.com/s2/favicons?domain=github.com&sz=64" width="16" valign="middle" /> GitHub Copilot</kbd></a> &nbsp;
-  <a href="https://kilo.ai/docs/cli"><kbd><img src="https://www.google.com/s2/favicons?domain=kilo.ai&sz=64" width="16" valign="middle" /> Kilocode</kbd></a> &nbsp;
+  <a href="https://kilo.ai/docs/cli"><kbd><img src="https://raw.githubusercontent.com/Kilo-Org/kilocode/main/packages/kilo-vscode/assets/icons/kilo-light.png" width="16" valign="middle" /> Kilocode</kbd></a> &nbsp;
   <a href="https://www.kimi.com/code/docs/en/kimi-cli/guides/getting-started.html"><kbd><img src="https://www.google.com/s2/favicons?domain=moonshot.cn&sz=64" width="16" valign="middle" /> Kimi</kbd></a> &nbsp;
   <a href="https://kiro.dev/docs/cli/"><kbd><img src="https://www.google.com/s2/favicons?domain=kiro.dev&sz=64" width="16" valign="middle" /> Kiro</kbd></a> &nbsp;
   <a href="https://github.com/mistralai/mistral-vibe"><kbd><img src="https://www.google.com/s2/favicons?domain=mistral.ai&sz=64" width="16" valign="middle" /> Mistral Vibe</kbd></a> &nbsp;

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -50,7 +50,7 @@ Orca 支持任何 CLI Agent (_不仅限于以下列表_)。
   <a href="https://cursor.com/cli"><kbd><img src="https://www.google.com/s2/favicons?domain=cursor.com&sz=64" width="16" valign="middle" /> Cursor</kbd></a> &nbsp;
   <a href="https://docs.factory.ai/cli/getting-started/quickstart"><kbd><img src="https://www.google.com/s2/favicons?domain=factory.ai&sz=64" width="16" valign="middle" /> Droid</kbd></a> &nbsp;
   <a href="https://docs.github.com/en/copilot/how-tos/set-up/install-copilot-cli"><kbd><img src="https://www.google.com/s2/favicons?domain=github.com&sz=64" width="16" valign="middle" /> GitHub Copilot</kbd></a> &nbsp;
-  <a href="https://kilo.ai/docs/cli"><kbd><img src="https://www.google.com/s2/favicons?domain=kilo.ai&sz=64" width="16" valign="middle" /> Kilocode</kbd></a> &nbsp;
+  <a href="https://kilo.ai/docs/cli"><kbd><img src="https://raw.githubusercontent.com/Kilo-Org/kilocode/main/packages/kilo-vscode/assets/icons/kilo-light.png" width="16" valign="middle" /> Kilocode</kbd></a> &nbsp;
   <a href="https://www.kimi.com/code/docs/en/kimi-cli/guides/getting-started.html"><kbd><img src="https://www.google.com/s2/favicons?domain=moonshot.cn&sz=64" width="16" valign="middle" /> Kimi</kbd></a> &nbsp;
   <a href="https://kiro.dev/docs/cli/"><kbd><img src="https://www.google.com/s2/favicons?domain=kiro.dev&sz=64" width="16" valign="middle" /> Kiro</kbd></a> &nbsp;
   <a href="https://github.com/mistralai/mistral-vibe"><kbd><img src="https://www.google.com/s2/favicons?domain=mistral.ai&sz=64" width="16" valign="middle" /> Mistral Vibe</kbd></a> &nbsp;

--- a/src/renderer/src/lib/agent-catalog.tsx
+++ b/src/renderer/src/lib/agent-catalog.tsx
@@ -79,7 +79,6 @@ export const AGENT_CATALOG: AgentCatalogEntry[] = [
     id: 'kilo',
     label: 'Kilocode',
     cmd: 'kilo',
-    faviconDomain: 'kilo.ai',
     homepageUrl: 'https://kilo.ai/docs/cli'
   },
   {
@@ -198,6 +197,31 @@ function PiIcon({ size = 14 }: { size?: number }): React.JSX.Element {
   )
 }
 
+function KiloIcon({ size = 14 }: { size?: number }): React.JSX.Element {
+  // SVG sourced from Kilo-Org/kilocode:packages/kilo-vscode/assets/icons/kilo-light.svg.
+  // Why: the Google favicon for kilo.ai is black-on-black at small sizes and
+  // is illegible. Inlining the brand mark (yellow on black) keeps it readable
+  // on both light and dark app themes without using currentColor — this logo
+  // is intentionally brand-colored, not theme-colored.
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 512 512"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden
+      style={{ borderRadius: 2 }}
+    >
+      <path d="M512 0H0V512H512V0Z" fill="black" />
+      <path
+        d="M322 377H377V421H307.857L278 391.143V322H322V377ZM421 307.857L391.143 278H322V322L377 322V377H421V307.857ZM234 278H190V322H234V278ZM91 391.143L120.857 421H234V377H135V278H91V391.143ZM371.172 189.999V120.856L341.315 90.9995H278V135H327.172V189.999H278V233.999H421V189.999H371.172ZM135 91H91V233.999H135V184.5H190V233.999H234V184.5L190 140.5H135V91ZM234 91H190V140.5H234V91Z"
+        fill="#FAF74F"
+      />
+    </svg>
+  )
+}
+
 function AiderIcon({ size = 14 }: { size?: number }): React.JSX.Element {
   // SVG sourced from aider.chat/assets/icons/safari-pinned-tab.svg.
   // Why: className="text-current" opts out of shadcn's Select rule that forces
@@ -276,6 +300,9 @@ export function AgentIcon({
   }
   if (agent === 'aider') {
     return <AiderIcon size={size} />
+  }
+  if (agent === 'kilo') {
+    return <KiloIcon size={size} />
   }
   const catalogEntry = AGENT_CATALOG.find((a) => a.id === agent)
   if (catalogEntry?.faviconDomain) {


### PR DESCRIPTION
## Summary
- The Google favicon for `kilo.ai` is black-on-black at small sizes and was invisible in the agent badge lists and the in-app `AgentIcon` surfaces.
- Replaced it with Kilo's official brand mark (yellow `#FAF74F` on black) sourced from [`Kilo-Org/kilocode/packages/kilo-vscode/assets/icons/kilo-light.svg`](https://github.com/Kilo-Org/kilocode/blob/main/packages/kilo-vscode/assets/icons/kilo-light.svg).
- In the app, added a dedicated `KiloIcon` SVG component (mirrors the pattern used for `PiIcon`/`AiderIcon`) so the logo renders at intended brand colors on any theme; dropped the unused `faviconDomain: 'kilo.ai'` entry.
- In the four README variants (EN/ES/JA/ZH), pointed the badge `<img>` at the raw brand PNG.

## Before / After
| | |
| --- | --- |
| Before | Black Kilo logo on the dark agent-icon chip — effectively invisible. |
| After  | Yellow-on-black brand mark, legible against both light and dark surfaces. |

## Test plan
- [ ] Open Orca and confirm Kilocode shows a legible yellow logo in: Agents settings, Quick Launch, Agent combobox, and Dashboard rows.
- [ ] Confirm all four README files render the yellow Kilocode badge on GitHub.

Made with [Orca](https://github.com/stablyai/orca) 🐋
