### PR TITLE
fix: stop file explorer edge auto-scroll on drag leave

### DIFF
--- a/src/renderer/src/components/right-sidebar/useFileExplorerDragDrop.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerDragDrop.ts
@@ -288,19 +288,30 @@ export function useFileExplorerDragDrop({
         setIsNativeDragOver(true)
       }
     }, []),
-    onDragLeave: useCallback((_e: React.DragEvent) => {
-      // Decrement both counters since we cannot inspect types on dragleave
-      rootDragCounterRef.current -= 1
-      if (rootDragCounterRef.current <= 0) {
-        rootDragCounterRef.current = 0
-        setIsRootDragOver(false)
-      }
-      nativeRootDragCounterRef.current -= 1
-      if (nativeRootDragCounterRef.current <= 0) {
-        nativeRootDragCounterRef.current = 0
-        setIsNativeDragOver(false)
-      }
-    }, []),
+    onDragLeave: useCallback(
+      (_e: React.DragEvent) => {
+        // Decrement both counters since we cannot inspect types on dragleave
+        rootDragCounterRef.current -= 1
+        if (rootDragCounterRef.current <= 0) {
+          rootDragCounterRef.current = 0
+          setIsRootDragOver(false)
+        }
+        nativeRootDragCounterRef.current -= 1
+        if (nativeRootDragCounterRef.current <= 0) {
+          nativeRootDragCounterRef.current = 0
+          setIsNativeDragOver(false)
+        }
+        // Why: the edge auto-scroll rAF loop re-schedules itself as long as the
+        // last recorded cursor Y sits in an edge zone. If the drag leaves the
+        // explorer (dragged out of window, ESC-cancelled, or dropped elsewhere)
+        // neither onDrop nor onDragEnd fires here, so without this stop the
+        // loop keeps scrolling the viewport down and fights manual scroll-up.
+        if (rootDragCounterRef.current === 0 && nativeRootDragCounterRef.current === 0) {
+          stopDragEdgeScroll()
+        }
+      },
+      [stopDragEdgeScroll]
+    ),
     onDrop: useCallback(
       (e: React.DragEvent) => {
         e.preventDefault()


### PR DESCRIPTION
## Problem

File explorer uncontrollably scrolls down when:
- User expands a folder to make tree scrollable
- User starts a file drag (internal or native Files drop) near the bottom edge, triggering the edge auto-scroll rAF loop
- Drag leaves the explorer window, is ESC-cancelled, or drops outside
- The edge auto-scroll loop never stops because it only halts on onDrop/onDragEnd, which don't fire on drag-leave

Result: rAF loop re-schedules indefinitely with stale cursor Y, continuously scrolling the viewport down and defeating manual scroll-up attempts.

## Solution

Add stopDragEdgeScroll() call in onDragLeave handler when both internal and native drag counters reach 0, symmetrically halting the edge-scroll loop when the drag fully exits the explorer. The loop continues normally while hovering (as intended) and stops cleanly on departure.

Tested via /electron: manual scroll is stable, hover-near-bottom still triggers auto-scroll, dragleave cleanly halts it.

Made with [Orca](https://github.com/stablyai/orca) 🐋
