### PR TITLE
fix(sidebar): let heuristic 'working' beat retained 'done' in worktree dot

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -154,10 +154,16 @@ const WorktreeCard = React.memo(function WorktreeCard({
   // consulted too so the sky dot keeps glowing after the agent process exits,
   // matching the dashboard's retention behavior.
   //
-  // Priority (highest first): permission (blocked/waiting) > done > heuristic.
-  // permission wins over done because a newer blocked agent in the same
+  // Priority (highest first): permission (blocked/waiting) > heuristic
+  // 'working' > done > other heuristic ('active'/'inactive').
+  // permission wins over everything because a newer blocked agent in the same
   // worktree means the user needs to act now, not admire a previous
   // completion.
+  // heuristic 'working' wins over done because a spinner means the user has
+  // already re-prompted the agent after it reported done — the newer "work
+  // in progress" signal is more informative than a retained completion dot.
+  // Only the 'working' heuristic earns this precedence; 'active'/'inactive'
+  // mean "quiet terminal", which shouldn't drown out a recent done.
   // Why: collapse live hook entries to booleans inside the selector so the
   // snapshot is a stable scalar (useShallow compares element identity — an
   // array of freshly-constructed {state,updatedAt} objects would never hit
@@ -217,10 +223,16 @@ const WorktreeCard = React.memo(function WorktreeCard({
     if (hasPermission) {
       return 'permission'
     }
+    // Compute the heuristic once so we can let 'working' beat done without
+    // letting quieter heuristic states ('active'/'inactive') erase a done.
+    const heuristic = getWorktreeStatus(tabs, browserTabs, runtimePaneTitlesForWorktree)
+    if (heuristic === 'working') {
+      return 'working'
+    }
     if (hasLiveDone || hasRetainedDone) {
       return 'done'
     }
-    return getWorktreeStatus(tabs, browserTabs, runtimePaneTitlesForWorktree)
+    return heuristic
   }, [tabs, browserTabs, runtimePaneTitlesForWorktree, hasPermission, hasLiveDone, hasRetainedDone])
 
   const showPR = cardProps.includes('pr')


### PR DESCRIPTION
## Summary
- The sidebar worktree dot previously showed `done` over a live heuristic `working` spinner, so re-prompting an agent after it reported done left the sky-blue dot sticky even once the terminal title flipped to `working`.
- New priority at the sidebar dot: **permission > heuristic `working` > done > other heuristic (`active`/`inactive`)**. Only `working` earns this promotion — `active`/`inactive` still lose to done, so a quiet terminal doesn't drown out a recent completion.
- `WorktreeCard.tsx` now computes the heuristic once and branches on its value; the priority comment above the selector is updated to match.

## Test plan
- [x] `pnpm vitest run src/renderer/src/components/sidebar/WorktreeCard.test.ts src/renderer/src/components/sidebar/smart-sort.test.ts` — 22 passed.
- [x] `pnpm exec tsc --noEmit -p config/tsconfig.web.json --composite false` — clean.
- [x] Manual: opened two Claude Code sessions in the same worktree. Started a long-running task in session A (heuristic `working`), then ran `say hi` in session B. When B finished and reported `done`, the worktree dot stayed on the green `working` spinner instead of flipping to sky-blue — confirming heuristic `working` beats `done`.
- [x] Manual: verified a permission ask (blocked/waiting) overrides all other states, including a co-occurring `working` spinner.
- [x] Manual: started a long process in worktree A, then switched to worktree B and ran a fast task. B moved to `done` while A stayed on `working` — confirming no cross-worktree leakage (per-worktree filtering in the selector holds).

Made with [Orca](https://github.com/stablyai/orca) 🐋