### PR TITLE
fix(terminal): refresh WebGL canvas after split reparenting

### DIFF
--- a/src/renderer/src/lib/pane-manager/pane-split-scroll.ts
+++ b/src/renderer/src/lib/pane-manager/pane-split-scroll.ts
@@ -1,6 +1,21 @@
 import type { ManagedPaneInternal, ScrollState } from './pane-manager-types'
 import { restoreScrollState } from './pane-scroll'
 
+// Why: wrapInSplit reparents the existing pane's container, which briefly
+// detaches the WebGL canvas from the DOM. The WebGL renderer's internal
+// render state can become stale after the re-attachment, leaving the canvas
+// blank even though the terminal buffer has data. This mirrors the explicit
+// refresh in resumeRendering() (pane-manager.ts) and the onContextLoss
+// handler (pane-lifecycle.ts) which address the same "frozen terminal"
+// symptom for analogous WebGL state transitions.
+function refreshAfterReparent(pane: ManagedPaneInternal): void {
+  try {
+    pane.terminal.refresh(0, pane.terminal.rows - 1)
+  } catch {
+    /* ignore — pane may have been disposed */
+  }
+}
+
 // Why: reparenting a terminal container during split resets the viewport
 // scroll position (browser clears scrollTop on DOM move). This schedules a
 // two-phase restore: an early double-rAF (~32ms) to minimise the visible
@@ -19,6 +34,7 @@ export function scheduleSplitScrollRestore(
       const live = getPaneById(paneId)
       if (live?.pendingSplitScrollState) {
         restoreScrollState(live.terminal, scrollState)
+        refreshAfterReparent(live)
       }
     })
   })
@@ -33,5 +49,6 @@ export function scheduleSplitScrollRestore(
     }
     live.pendingSplitScrollState = null
     restoreScrollState(live.terminal, scrollState)
+    refreshAfterReparent(live)
   }, 200)
 }

--- a/src/renderer/src/lib/pane-manager/pane-tree-ops.ts
+++ b/src/renderer/src/lib/pane-manager/pane-tree-ops.ts
@@ -40,6 +40,20 @@ export function safeFit(pane: ManagedPaneInternal): void {
       // Why: divider drags fire refits every frame, but most frames do not
       // cross a cell boundary. Skipping those avoids FitAddon.clear()+refresh()
       // churn, which was causing visible terminal blinking while resizing.
+      //
+      // Why: diagnostic for intermittent dead-terminal-after-split. If a
+      // just-reparented pane's proposed dimensions match its current
+      // dimensions (the default 80×24 at certain screen widths), this
+      // early-return skips fitAddon.fit() and no terminal.resize() fires
+      // — leaving the WebGL canvas at stale dimensions.
+      if (pane.pendingSplitScrollState) {
+        console.warn(
+          '[terminal] safeFit early-return during pending split for pane',
+          pane.id,
+          `— dims ${dims.cols}×${dims.rows} match current, webgl:`,
+          !!pane.webglAddon
+        )
+      }
       return
     }
     pane.fitAddon.fit()

--- a/src/renderer/src/lib/pane-manager/pane-tree-ops.ts
+++ b/src/renderer/src/lib/pane-manager/pane-tree-ops.ts
@@ -174,10 +174,23 @@ export function insertPaneNextTo(
     split.appendChild(source.container)
   }
 
-  // Refit both
+  // Refit both and refresh rendering surfaces — both panes were reparented
+  // into the new split wrapper, which can leave the WebGL canvas in a stale
+  // state (same mechanism as wrapInSplit; see refreshAfterReparent in
+  // pane-split-scroll.ts).
   requestAnimationFrame(() => {
     callbacks.safeFit(source)
     callbacks.safeFit(target)
+    try {
+      source.terminal.refresh(0, source.terminal.rows - 1)
+    } catch {
+      /* ignore */
+    }
+    try {
+      target.terminal.refresh(0, target.terminal.rows - 1)
+    } catch {
+      /* ignore */
+    }
   })
 }
 


### PR DESCRIPTION
## Summary
- Fixes blank/dead terminal pane when creating a new worktree with a setup split (and daemon enabled)
- The root cause: `wrapInSplit` reparents the existing pane's container, briefly detaching the WebGL canvas from the DOM. The WebGL renderer's internal state becomes stale, leaving the canvas blank even though the terminal buffer has data (PTY works, input accepted, Cmd+R restores content from daemon snapshot)
- The codebase already handles this exact symptom in `resumeRendering()` and the `onContextLoss` handler with explicit `terminal.refresh(0, rows - 1)` calls — the split reparenting path was missing that same refresh

## Changes
- **`pane-split-scroll.ts`**: Added `refreshAfterReparent()` to both the early double-rAF (~32ms) and authoritative (200ms) phases of `scheduleSplitScrollRestore`
- **`pane-tree-ops.ts`**: Added `terminal.refresh()` in `insertPaneNextTo()` (drag-reorder reparenting) which has the same DOM-move mechanism

## Test plan
- [ ] Create a new worktree with a setup script configured — verify both left (main) and right (setup) panes render correctly
- [ ] Split an existing terminal pane (Cmd+D) — verify both panes render
- [ ] Drag-reorder panes in a multi-split layout — verify no blank panes after drop
- [ ] Switch between worktrees and back — verify terminals still render (existing `resumeRendering` path unaffected)
- [ ] Existing pane-manager unit tests pass (verified locally: 29/29 pass)

Made with [Orca](https://github.com/stablyai/orca) 🐋
