### PR TITLE
fix(sidebar): top-align worktree status dot with title

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -367,11 +367,17 @@ const WorktreeCard = React.memo(function WorktreeCard({
                     {/* Why: make the hover trigger keyboard-focusable so
                         keyboard-only users can open the hover panel (Radix
                         HoverCardTrigger asChild does not promote a
-                        non-interactive child to focusable). */}
+                        non-interactive child to focusable).
+                        Why inline-flex: a default `display: inline` span
+                        contains the inline-flex StatusIndicator on the text
+                        baseline, pushing the dot ~2px down inside the card's
+                        flex-column container. `inline-flex` removes the line
+                        box so the dot stays top-aligned with the title. */}
                     <span
                       tabIndex={0}
                       role="button"
                       aria-label={`Worktree status: ${status}. Show running agents.`}
+                      className="inline-flex"
                     >
                       <StatusIndicator status={status} />
                     </span>


### PR DESCRIPTION
## Summary
- The keyboard-focusable hover-trigger span added in #1147 defaults to `display: inline`, which puts the inline-flex `StatusIndicator` on the text baseline and pushes the dot ~2px below the worktree title.
- Add `inline-flex` to the wrapper so it has no line box, restoring the pre-dashboard top alignment of the dot.

## Test plan
- [x] Reload the app and verify the worktree status dot aligns with the top of the card title (matching the pre-regression look).
- [x] Confirm hover and keyboard focus on the status dot still open the `AgentStatusHover` panel.
- [x] Spot-check `active`, `working`, `permission`, `done`, and idle states — all should sit at the same top y-position.

Made with [Orca](https://github.com/stablyai/orca) 🐋
