### PR TITLE
fix(mac): request media permissions dynamically

### DIFF
--- a/config/electron-builder.config.cjs
+++ b/config/electron-builder.config.cjs
@@ -81,8 +81,21 @@ module.exports = {
     entitlements: 'resources/build/entitlements.mac.plist',
     entitlementsInherit: 'resources/build/entitlements.mac.plist',
     extendInfo: {
+      NSAppleEventsUsageDescription:
+        'Orca allows terminal-launched developer tools to automate local apps when you request it.',
+      NSBluetoothAlwaysUsageDescription:
+        'Orca allows terminal-launched developer tools to access Bluetooth devices when you request it.',
+      NSBluetoothPeripheralUsageDescription:
+        'Orca allows terminal-launched developer tools to access Bluetooth devices when you request it.',
       NSCameraUsageDescription: "Application requests access to the device's camera.",
+      NSLocationUsageDescription:
+        'Orca allows terminal-launched developer tools to access location when you request it.',
+      NSLocalNetworkUsageDescription:
+        'Orca allows terminal-launched developer tools to discover and connect to local development servers when you request it.',
       NSMicrophoneUsageDescription: "Application requests access to the device's microphone.",
+      NSAudioCaptureUsageDescription:
+        'Orca allows terminal-launched developer tools to capture desktop audio when you request it.',
+      NSBonjourServices: ['_http._tcp', '_https._tcp'],
       NSDocumentsFolderUsageDescription:
         "Application requests access to the user's Documents folder.",
       NSDownloadsFolderUsageDescription:

--- a/resources/build/entitlements.mac.plist
+++ b/resources/build/entitlements.mac.plist
@@ -2,6 +2,18 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.security.automation.apple-events</key>
+	<true/>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
+	<key>com.apple.security.device.bluetooth</key>
+	<true/>
+	<key>com.apple.security.device.camera</key>
+	<true/>
+	<key>com.apple.security.device.usb</key>
+	<true/>
+	<key>com.apple.security.personal-information.location</key>
+	<true/>
 	<key>com.apple.security.cs.allow-dyld-environment-variables</key>
 	<true/>
 	<key>com.apple.security.cs.allow-jit</key>

--- a/src/main/ipc/developer-permissions.ts
+++ b/src/main/ipc/developer-permissions.ts
@@ -1,0 +1,200 @@
+import { execFile } from 'node:child_process'
+import dgram from 'node:dgram'
+import { access } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import path from 'node:path'
+import { ipcMain, shell, systemPreferences } from 'electron'
+import type {
+  DeveloperPermissionId,
+  DeveloperPermissionRequestResult,
+  DeveloperPermissionState,
+  DeveloperPermissionStatus
+} from '../../shared/developer-permissions-types'
+
+const PRIVACY_PANE_URLS: Partial<Record<DeveloperPermissionId, string>> = {
+  camera: 'x-apple.systempreferences:com.apple.preference.security?Privacy_Camera',
+  microphone: 'x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone',
+  screen: 'x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture',
+  accessibility: 'x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility',
+  'full-disk-access': 'x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles',
+  automation: 'x-apple.systempreferences:com.apple.preference.security?Privacy_Automation',
+  bluetooth: 'x-apple.systempreferences:com.apple.preference.security?Privacy_Bluetooth'
+}
+
+const DEVELOPER_PERMISSION_IDS: DeveloperPermissionId[] = [
+  'microphone',
+  'camera',
+  'screen',
+  'accessibility',
+  'full-disk-access',
+  'automation',
+  'local-network',
+  'usb',
+  'bluetooth'
+]
+
+function unsupportedOffMac(): DeveloperPermissionStatus | null {
+  return process.platform === 'darwin' ? null : 'unsupported'
+}
+
+function getMediaStatus(mediaType: 'microphone' | 'camera' | 'screen'): DeveloperPermissionStatus {
+  const unsupported = unsupportedOffMac()
+  if (unsupported) {
+    return unsupported
+  }
+  try {
+    return systemPreferences.getMediaAccessStatus(mediaType)
+  } catch {
+    return 'unknown'
+  }
+}
+
+async function getFullDiskAccessStatus(): Promise<DeveloperPermissionStatus> {
+  const unsupported = unsupportedOffMac()
+  if (unsupported) {
+    return unsupported
+  }
+  try {
+    // Why: Safari bookmarks are TCC-protected, so read access is a practical
+    // Full Disk Access signal without touching user project contents.
+    await access(path.join(homedir(), 'Library', 'Safari', 'Bookmarks.plist'))
+    return 'granted'
+  } catch {
+    return 'unknown'
+  }
+}
+
+function getAccessibilityStatus(): DeveloperPermissionStatus {
+  const unsupported = unsupportedOffMac()
+  if (unsupported) {
+    return unsupported
+  }
+  return systemPreferences.isTrustedAccessibilityClient(false) ? 'granted' : 'unknown'
+}
+
+async function openPrivacyPane(id: DeveloperPermissionId): Promise<boolean> {
+  const url = PRIVACY_PANE_URLS[id]
+  if (!url) {
+    await shell.openExternal(
+      'x-apple.systempreferences:com.apple.settings.PrivacySecurity.extension'
+    )
+    return true
+  }
+  await shell.openExternal(url)
+  return true
+}
+
+function triggerAppleEventsPrompt(): Promise<void> {
+  return new Promise((resolve) => {
+    execFile(
+      'osascript',
+      ['-e', 'tell application "System Events" to return 1'],
+      { timeout: 3000 },
+      () => resolve()
+    )
+  })
+}
+
+function triggerLocalNetworkPrompt(): Promise<void> {
+  return new Promise((resolve) => {
+    const socket = dgram.createSocket({ type: 'udp4', reuseAddr: true })
+    let settled = false
+    const finish = (): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      try {
+        socket.close()
+      } catch {
+        // Already closed or never fully bound.
+      }
+      resolve()
+    }
+    socket.on('error', finish)
+    socket.bind(() => {
+      const message = Buffer.from([0])
+      socket.send(message, 0, message.length, 5353, '224.0.0.251', finish)
+    })
+    setTimeout(finish, 1000)
+  })
+}
+
+async function getPermissionState(id: DeveloperPermissionId): Promise<DeveloperPermissionState> {
+  switch (id) {
+    case 'microphone':
+    case 'camera':
+    case 'screen':
+      return { id, status: getMediaStatus(id) }
+    case 'accessibility':
+      return { id, status: getAccessibilityStatus() }
+    case 'full-disk-access':
+      return { id, status: await getFullDiskAccessStatus() }
+    case 'automation':
+    case 'local-network':
+      return { id, status: unsupportedOffMac() ?? 'unknown' }
+    case 'usb':
+    case 'bluetooth':
+      return { id, status: unsupportedOffMac() ?? 'ready' }
+  }
+}
+
+async function requestPermission(
+  id: DeveloperPermissionId
+): Promise<DeveloperPermissionRequestResult> {
+  if (process.platform !== 'darwin') {
+    return { id, status: 'unsupported', openedSystemSettings: false }
+  }
+
+  if (id === 'microphone' || id === 'camera') {
+    const granted = await systemPreferences.askForMediaAccess(id)
+    return { id, status: granted ? 'granted' : getMediaStatus(id), openedSystemSettings: false }
+  }
+
+  if (id === 'accessibility') {
+    systemPreferences.isTrustedAccessibilityClient(true)
+    return { id, status: getAccessibilityStatus(), openedSystemSettings: false }
+  }
+
+  if (id === 'automation') {
+    await triggerAppleEventsPrompt()
+    return { id, status: 'unknown', openedSystemSettings: false }
+  }
+
+  if (id === 'local-network') {
+    await triggerLocalNetworkPrompt()
+    return { id, status: 'unknown', openedSystemSettings: false }
+  }
+
+  await openPrivacyPane(id)
+  return { id, status: (await getPermissionState(id)).status, openedSystemSettings: true }
+}
+
+export function registerDeveloperPermissionHandlers(): void {
+  ipcMain.handle(
+    'developerPermissions:getStatus',
+    async (): Promise<DeveloperPermissionState[]> => {
+      return Promise.all(DEVELOPER_PERMISSION_IDS.map(getPermissionState))
+    }
+  )
+
+  ipcMain.handle(
+    'developerPermissions:request',
+    async (
+      _event,
+      args: { id: DeveloperPermissionId }
+    ): Promise<DeveloperPermissionRequestResult> => {
+      if (!DEVELOPER_PERMISSION_IDS.includes(args.id)) {
+        return { id: args.id, status: 'unsupported', openedSystemSettings: false }
+      }
+      return requestPermission(args.id)
+    }
+  )
+
+  ipcMain.handle(
+    'developerPermissions:openSettings',
+    async (_event, args: { id: DeveloperPermissionId }): Promise<void> => {
+      await openPrivacyPane(args.id)
+    }
+  )
+}

--- a/src/main/ipc/register-core-handlers.test.ts
+++ b/src/main/ipc/register-core-handlers.test.ts
@@ -10,6 +10,7 @@ const {
   registerStatsHandlersMock,
   registerMemoryHandlersMock,
   registerNotificationHandlersMock,
+  registerDeveloperPermissionHandlersMock,
   registerSettingsHandlersMock,
   registerShellHandlersMock,
   registerSessionHandlersMock,
@@ -39,6 +40,7 @@ const {
   registerStatsHandlersMock: vi.fn(),
   registerMemoryHandlersMock: vi.fn(),
   registerNotificationHandlersMock: vi.fn(),
+  registerDeveloperPermissionHandlersMock: vi.fn(),
   registerSettingsHandlersMock: vi.fn(),
   registerShellHandlersMock: vi.fn(),
   registerSessionHandlersMock: vi.fn(),
@@ -98,6 +100,10 @@ vi.mock('./memory', () => ({
 
 vi.mock('./notifications', () => ({
   registerNotificationHandlers: registerNotificationHandlersMock
+}))
+
+vi.mock('./developer-permissions', () => ({
+  registerDeveloperPermissionHandlers: registerDeveloperPermissionHandlersMock
 }))
 
 vi.mock('./settings', () => ({
@@ -176,6 +182,7 @@ describe('registerCoreHandlers', () => {
     registerStatsHandlersMock.mockReset()
     registerMemoryHandlersMock.mockReset()
     registerNotificationHandlersMock.mockReset()
+    registerDeveloperPermissionHandlersMock.mockReset()
     registerSettingsHandlersMock.mockReset()
     registerShellHandlersMock.mockReset()
     registerSessionHandlersMock.mockReset()
@@ -230,6 +237,7 @@ describe('registerCoreHandlers', () => {
     expect(registerStatsHandlersMock).toHaveBeenCalledWith(stats)
     expect(registerMemoryHandlersMock).toHaveBeenCalledWith(store)
     expect(registerNotificationHandlersMock).toHaveBeenCalledWith(store)
+    expect(registerDeveloperPermissionHandlersMock).toHaveBeenCalled()
     expect(registerSettingsHandlersMock).toHaveBeenCalledWith(store)
     expect(registerSessionHandlersMock).toHaveBeenCalledWith(store)
     expect(registerUIHandlersMock).toHaveBeenCalledWith(store)

--- a/src/main/ipc/register-core-handlers.ts
+++ b/src/main/ipc/register-core-handlers.ts
@@ -17,6 +17,7 @@ import { registerMemoryHandlers } from './memory'
 import { registerRateLimitHandlers } from './rate-limits'
 import { registerRuntimeHandlers } from './runtime'
 import { registerNotificationHandlers } from './notifications'
+import { registerDeveloperPermissionHandlers } from './developer-permissions'
 import { setTrustedBrowserRendererWebContentsId, setAgentBrowserBridgeRef } from './browser'
 import { registerSessionHandlers } from './session'
 import { registerSettingsHandlers } from './settings'
@@ -78,6 +79,7 @@ export function registerCoreHandlers(
   registerStatsHandlers(stats)
   registerMemoryHandlers(store)
   registerNotificationHandlers(store)
+  registerDeveloperPermissionHandlers()
   registerSettingsHandlers(store)
   registerBrowserHandlers()
   // Why: applyPendingCookieImport MUST run before restorePersistedUserAgent

--- a/src/main/window/attach-main-window-services.test.ts
+++ b/src/main/window/attach-main-window-services.test.ts
@@ -6,6 +6,8 @@ const {
   setPermissionRequestHandlerMock,
   setPermissionCheckHandlerMock,
   setDisplayMediaRequestHandlerMock,
+  systemPreferencesAskForMediaAccessMock,
+  systemPreferencesGetMediaAccessStatusMock,
   registerRepoHandlersMock,
   registerWorktreeHandlersMock,
   registerPtyHandlersMock,
@@ -20,6 +22,8 @@ const {
   setPermissionRequestHandlerMock: vi.fn(),
   setPermissionCheckHandlerMock: vi.fn(),
   setDisplayMediaRequestHandlerMock: vi.fn(),
+  systemPreferencesAskForMediaAccessMock: vi.fn(),
+  systemPreferencesGetMediaAccessStatusMock: vi.fn(),
   registerRepoHandlersMock: vi.fn(),
   registerWorktreeHandlersMock: vi.fn(),
   registerPtyHandlersMock: vi.fn(),
@@ -35,6 +39,10 @@ vi.mock('electron', () => ({
   clipboard: {},
   session: {
     fromPartition: sessionFromPartitionMock
+  },
+  systemPreferences: {
+    askForMediaAccess: systemPreferencesAskForMediaAccessMock,
+    getMediaAccessStatus: systemPreferencesGetMediaAccessStatusMock
   },
   ipcMain: {
     on: onMock,
@@ -74,6 +82,55 @@ vi.mock('../updater', () => ({
 
 import { attachMainWindowServices } from './attach-main-window-services'
 
+type MockFn = ReturnType<typeof vi.fn>
+
+type MainWindowStub = {
+  isDestroyed?: MockFn
+  on: MockFn
+  webContents: {
+    on: MockFn
+    send?: MockFn
+    session: {
+      setPermissionRequestHandler: MockFn
+      setPermissionCheckHandler: MockFn
+    }
+  }
+}
+
+type RuntimeStub = {
+  attachWindow: MockFn
+  setNotifier: MockFn
+  markRendererReloading: MockFn
+  markGraphUnavailable: MockFn
+}
+
+function createMainWindow(extraWebContents: { on?: MockFn; send?: MockFn } = {}): MainWindowStub {
+  return {
+    on: vi.fn(),
+    webContents: {
+      on: vi.fn(),
+      session: {
+        setPermissionRequestHandler: setPermissionRequestHandlerMock,
+        setPermissionCheckHandler: setPermissionCheckHandlerMock
+      },
+      ...extraWebContents
+    }
+  }
+}
+
+function createStore(): never {
+  return { flush: vi.fn() } as never
+}
+
+function createRuntime(): RuntimeStub {
+  return {
+    attachWindow: vi.fn(),
+    setNotifier: vi.fn(),
+    markRendererReloading: vi.fn(),
+    markGraphUnavailable: vi.fn()
+  }
+}
+
 describe('attachMainWindowServices', () => {
   beforeEach(() => {
     onMock.mockReset()
@@ -81,6 +138,8 @@ describe('attachMainWindowServices', () => {
     setPermissionRequestHandlerMock.mockReset()
     setPermissionCheckHandlerMock.mockReset()
     setDisplayMediaRequestHandlerMock.mockReset()
+    systemPreferencesAskForMediaAccessMock.mockReset()
+    systemPreferencesGetMediaAccessStatusMock.mockReset()
     registerRepoHandlersMock.mockReset()
     registerWorktreeHandlersMock.mockReset()
     registerPtyHandlersMock.mockReset()
@@ -95,38 +154,46 @@ describe('attachMainWindowServices', () => {
       setDisplayMediaRequestHandler: setDisplayMediaRequestHandlerMock,
       on: vi.fn()
     })
+    systemPreferencesAskForMediaAccessMock.mockResolvedValue(true)
+    systemPreferencesGetMediaAccessStatusMock.mockReturnValue('granted')
   })
 
-  it('only allows the explicit permission allowlist', () => {
-    const mainWindow = {
-      on: vi.fn(),
-      webContents: {
-        on: vi.fn(),
-        session: {
-          setPermissionRequestHandler: setPermissionRequestHandlerMock
-        }
-      }
-    }
-    const store = { flush: vi.fn() }
-    const runtime = {
-      attachWindow: vi.fn(),
-      setNotifier: vi.fn(),
-      markRendererReloading: vi.fn(),
-      markGraphUnavailable: vi.fn()
-    }
-
-    attachMainWindowServices(mainWindow as never, store as never, runtime as never)
+  it('only allows the explicit permission allowlist', async () => {
+    attachMainWindowServices(createMainWindow() as never, createStore(), createRuntime() as never)
 
     expect(setPermissionRequestHandlerMock).toHaveBeenCalledTimes(2)
     const permissionHandler = setPermissionRequestHandlerMock.mock.calls[0][0]
     const callback = vi.fn()
 
-    permissionHandler(null, 'media', callback)
+    permissionHandler(null, 'media', callback, { mediaTypes: ['audio'] })
+    await vi.waitFor(() => expect(callback).toHaveBeenCalledWith(true))
     permissionHandler(null, 'fullscreen', callback)
     permissionHandler(null, 'pointerLock', callback)
     permissionHandler(null, 'clipboard-read', callback)
 
     expect(callback.mock.calls).toEqual([[true], [true], [true], [false]])
+  })
+
+  it('requests macOS media access only when the renderer asks for media', async () => {
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { value: 'darwin' })
+    try {
+      attachMainWindowServices(createMainWindow() as never, createStore(), createRuntime() as never)
+
+      expect(systemPreferencesAskForMediaAccessMock).not.toHaveBeenCalled()
+
+      const permissionHandler = setPermissionRequestHandlerMock.mock.calls[0][0]
+      const callback = vi.fn()
+      permissionHandler(null, 'media', callback, { mediaTypes: ['audio', 'video'] })
+
+      await vi.waitFor(() => expect(callback).toHaveBeenCalledWith(true))
+      expect(systemPreferencesAskForMediaAccessMock.mock.calls).toEqual([
+        ['microphone'],
+        ['camera']
+      ])
+    } finally {
+      Object.defineProperty(process, 'platform', platform ?? { value: process.platform })
+    }
   })
 
   it('denies browser-session permissions, display capture, and downloads by default', () => {
@@ -139,24 +206,10 @@ describe('attachMainWindowServices', () => {
     })
 
     const mainWindowOnMock = vi.fn()
-    const mainWindow = {
-      on: mainWindowOnMock,
-      webContents: {
-        on: vi.fn(),
-        session: {
-          setPermissionRequestHandler: setPermissionRequestHandlerMock
-        }
-      }
-    }
-    const store = { flush: vi.fn() }
-    const runtime = {
-      attachWindow: vi.fn(),
-      setNotifier: vi.fn(),
-      markRendererReloading: vi.fn(),
-      markGraphUnavailable: vi.fn()
-    }
+    const mainWindow = createMainWindow()
+    mainWindow.on = mainWindowOnMock
 
-    attachMainWindowServices(mainWindow as never, store as never, runtime as never)
+    attachMainWindowServices(mainWindow as never, createStore(), createRuntime() as never)
 
     const browserPermissionHandler = setPermissionRequestHandlerMock.mock.calls[1][0] as (
       wc: unknown,
@@ -176,7 +229,7 @@ describe('attachMainWindowServices', () => {
       rawUrl: 'https://example.com/account'
     })
 
-    const browserPermissionCheckHandler = setPermissionCheckHandlerMock.mock.calls[0][0] as (
+    const browserPermissionCheckHandler = setPermissionCheckHandlerMock.mock.calls[1][0] as (
       wc: unknown,
       permission: string
     ) => boolean
@@ -215,24 +268,10 @@ describe('attachMainWindowServices', () => {
       on: vi.fn()
     })
     const mainWindowOnMock = vi.fn()
-    const mainWindow = {
-      on: mainWindowOnMock,
-      webContents: {
-        on: vi.fn(),
-        session: {
-          setPermissionRequestHandler: setPermissionRequestHandlerMock
-        }
-      }
-    }
-    const store = { flush: vi.fn() }
-    const runtime = {
-      attachWindow: vi.fn(),
-      setNotifier: vi.fn(),
-      markRendererReloading: vi.fn(),
-      markGraphUnavailable: vi.fn()
-    }
+    const mainWindow = createMainWindow()
+    mainWindow.on = mainWindowOnMock
 
-    attachMainWindowServices(mainWindow as never, store as never, runtime as never)
+    attachMainWindowServices(mainWindow as never, createStore(), createRuntime() as never)
 
     const closedHandler = mainWindowOnMock.mock.calls
       .filter(([event]) => event === 'closed')
@@ -246,26 +285,12 @@ describe('attachMainWindowServices', () => {
     const sendMock = vi.fn()
     const webContentsOnMock = vi.fn()
     const mainWindowOnMock = vi.fn()
-    const mainWindow = {
-      isDestroyed: vi.fn(() => false),
-      on: mainWindowOnMock,
-      webContents: {
-        on: webContentsOnMock,
-        send: sendMock,
-        session: {
-          setPermissionRequestHandler: setPermissionRequestHandlerMock
-        }
-      }
-    }
-    const store = { flush: vi.fn() }
-    const runtime = {
-      attachWindow: vi.fn(),
-      setNotifier: vi.fn(),
-      markRendererReloading: vi.fn(),
-      markGraphUnavailable: vi.fn()
-    }
+    const mainWindow = createMainWindow({ on: webContentsOnMock, send: sendMock })
+    mainWindow.isDestroyed = vi.fn(() => false)
+    mainWindow.on = mainWindowOnMock
+    const runtime = createRuntime()
 
-    attachMainWindowServices(mainWindow as never, store as never, runtime as never)
+    attachMainWindowServices(mainWindow as never, createStore(), runtime as never)
 
     expect(runtime.setNotifier).toHaveBeenCalledTimes(1)
     const notifier = runtime.setNotifier.mock.calls[0][0] as {

--- a/src/main/window/attach-main-window-services.ts
+++ b/src/main/window/attach-main-window-services.ts
@@ -1,8 +1,8 @@
 import fs from 'node:fs/promises'
 import path from 'node:path'
 
-import { app, clipboard, ipcMain, nativeImage, session } from 'electron'
-import type { BrowserWindow } from 'electron'
+import { app, clipboard, ipcMain, nativeImage, session, systemPreferences } from 'electron'
+import type { BrowserWindow, MediaAccessPermissionRequest } from 'electron'
 import type { Store } from '../persistence'
 import type { CreateWorktreeResult } from '../../shared/types'
 import { ORCA_BROWSER_PARTITION } from '../../shared/constants'
@@ -85,8 +85,23 @@ export function attachMainWindowServices(
 
   const allowedPermissions = new Set(['media', 'fullscreen', 'pointerLock'])
   mainWindow.webContents.session.setPermissionRequestHandler(
-    (_webContents, permission, callback) => {
+    (_webContents, permission, callback, details) => {
+      if (permission === 'media') {
+        void requestSystemMediaAccess(details).then(callback, (error: unknown) => {
+          console.error('[permissions] Failed to request media access:', error)
+          callback(false)
+        })
+        return
+      }
       callback(allowedPermissions.has(permission))
+    }
+  )
+  mainWindow.webContents.session.setPermissionCheckHandler(
+    (_webContents, permission, _origin, details) => {
+      if (permission !== 'media') {
+        return allowedPermissions.has(permission)
+      }
+      return hasSystemMediaAccess(details?.mediaType)
     }
   )
 
@@ -130,6 +145,54 @@ export function attachMainWindowServices(
     // or hot-reload cycles.
     browserManager.unregisterAll()
   })
+}
+
+function requestedMediaTypes(
+  details: MediaAccessPermissionRequest | undefined
+): Set<'audio' | 'video'> {
+  return new Set(details?.mediaTypes ?? [])
+}
+
+function hasSystemMediaAccess(mediaType: string | undefined): boolean {
+  if (process.platform !== 'darwin') {
+    return true
+  }
+  if (mediaType === 'audio') {
+    return systemPreferences.getMediaAccessStatus('microphone') === 'granted'
+  }
+  if (mediaType === 'video') {
+    return systemPreferences.getMediaAccessStatus('camera') === 'granted'
+  }
+  return false
+}
+
+async function requestSystemMediaAccess(
+  details: MediaAccessPermissionRequest | undefined
+): Promise<boolean> {
+  if (process.platform !== 'darwin') {
+    return true
+  }
+
+  const mediaTypes = requestedMediaTypes(details)
+  if (mediaTypes.size === 0) {
+    return false
+  }
+
+  if (mediaTypes.has('audio')) {
+    // Why: macOS only shows the TCC prompt from the app process, so Chromium's
+    // media grant is paired with the OS-level request at the actual media ask.
+    const granted = await systemPreferences.askForMediaAccess('microphone')
+    if (!granted) {
+      return false
+    }
+  }
+  if (mediaTypes.has('video')) {
+    const granted = await systemPreferences.askForMediaAccess('camera')
+    if (!granted) {
+      return false
+    }
+  }
+  return true
 }
 
 function registerRuntimeWindowLifecycle(

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -81,6 +81,11 @@ import type { AgentHookInstallStatus } from '../shared/agent-hook-types'
 import type { AgentStatusState } from '../shared/agent-status-types'
 import type { RuntimeStatus, RuntimeSyncWindowGraph } from '../shared/runtime-types'
 import type {
+  DeveloperPermissionId,
+  DeveloperPermissionRequestResult,
+  DeveloperPermissionState
+} from '../shared/developer-permissions-types'
+import type {
   ClaudeUsageBreakdownKind,
   ClaudeUsageBreakdownRow,
   ClaudeUsageDailyPoint,
@@ -555,6 +560,11 @@ export type PreloadApi = {
   notifications: {
     dispatch: (args: NotificationDispatchRequest) => Promise<NotificationDispatchResult>
     openSystemSettings: () => Promise<void>
+  }
+  developerPermissions: {
+    getStatus: () => Promise<DeveloperPermissionState[]>
+    request: (args: { id: DeveloperPermissionId }) => Promise<DeveloperPermissionRequestResult>
+    openSettings: (args: { id: DeveloperPermissionId }) => Promise<void>
   }
   shell: {
     openPath: (path: string) => Promise<void>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -647,6 +647,14 @@ const api = {
     openSystemSettings: (): Promise<void> => ipcRenderer.invoke('notifications:openSystemSettings')
   },
 
+  developerPermissions: {
+    getStatus: (): Promise<unknown> => ipcRenderer.invoke('developerPermissions:getStatus'),
+    request: (args: { id: string }): Promise<unknown> =>
+      ipcRenderer.invoke('developerPermissions:request', args),
+    openSettings: (args: { id: string }): Promise<void> =>
+      ipcRenderer.invoke('developerPermissions:openSettings', args)
+  },
+
   shell: {
     openPath: (path: string): Promise<void> => ipcRenderer.invoke('shell:openPath', path),
 

--- a/src/renderer/src/components/settings/DeveloperPermissionsPane.tsx
+++ b/src/renderer/src/components/settings/DeveloperPermissionsPane.tsx
@@ -1,0 +1,259 @@
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react'
+import {
+  Accessibility,
+  Bluetooth,
+  Camera,
+  ExternalLink,
+  HardDrive,
+  Mic,
+  MonitorUp,
+  Network,
+  RefreshCw,
+  ShieldCheck,
+  Usb,
+  Workflow
+} from 'lucide-react'
+import { toast } from 'sonner'
+import type {
+  DeveloperPermissionId,
+  DeveloperPermissionState,
+  DeveloperPermissionStatus
+} from '../../../../shared/developer-permissions-types'
+import { Button } from '../ui/button'
+import type { SettingsSearchEntry } from './settings-search'
+
+export const DEVELOPER_PERMISSIONS_PANE_SEARCH_ENTRIES: SettingsSearchEntry[] = [
+  {
+    title: 'Developer Permissions',
+    description: 'macOS permissions for terminal-launched developer tools.',
+    keywords: ['permissions', 'privacy', 'tcc', 'macos', 'developer tools']
+  },
+  {
+    title: 'Microphone and Camera',
+    description: 'Allow voice, transcription, webcam, and media capture tools.',
+    keywords: ['microphone', 'camera', 'voice', 'audio', 'video', 'sox', 'ffmpeg', 'whisper']
+  },
+  {
+    title: 'Screen Recording and Accessibility',
+    description: 'Allow screenshots, screen inspection, keystrokes, and window automation.',
+    keywords: ['screen recording', 'accessibility', 'screenshot', 'automation', 'window']
+  },
+  {
+    title: 'Full Disk Access',
+    description: 'Open the macOS privacy pane for broad terminal file access.',
+    keywords: ['full disk access', 'documents', 'downloads', 'desktop', 'icloud']
+  },
+  {
+    title: 'Local Network, USB, and Bluetooth',
+    description: 'Allow device and local-network tools used from terminal sessions.',
+    keywords: ['local network', 'usb', 'bluetooth', 'bonjour', 'mdns', 'device']
+  }
+]
+
+type PermissionDefinition = {
+  id: DeveloperPermissionId
+  label: string
+  description: string
+  actionLabel: string
+  icon: ReactNode
+}
+
+const PERMISSIONS: PermissionDefinition[] = [
+  {
+    id: 'microphone',
+    label: 'Microphone',
+    description: 'Voice input, transcription, audio recording, sox, ffmpeg, and Whisper CLIs.',
+    actionLabel: 'Request',
+    icon: <Mic className="size-4" />
+  },
+  {
+    id: 'camera',
+    label: 'Camera',
+    description: 'Webcam capture and camera-driven local test apps.',
+    actionLabel: 'Request',
+    icon: <Camera className="size-4" />
+  },
+  {
+    id: 'screen',
+    label: 'Screen Recording',
+    description: 'Screenshot, visual automation, and UI inspection tools.',
+    actionLabel: 'Open Settings',
+    icon: <MonitorUp className="size-4" />
+  },
+  {
+    id: 'accessibility',
+    label: 'Accessibility',
+    description: 'Keystroke injection, window control, and UI automation tools.',
+    actionLabel: 'Request',
+    icon: <Accessibility className="size-4" />
+  },
+  {
+    id: 'full-disk-access',
+    label: 'Full Disk Access',
+    description: 'Persistent access to protected folders from terminal sessions.',
+    actionLabel: 'Open Settings',
+    icon: <HardDrive className="size-4" />
+  },
+  {
+    id: 'automation',
+    label: 'Automation',
+    description: 'Apple Events for scripts that control other local apps.',
+    actionLabel: 'Trigger Prompt',
+    icon: <Workflow className="size-4" />
+  },
+  {
+    id: 'local-network',
+    label: 'Local Network',
+    description: 'Discovery and access for development servers on your network.',
+    actionLabel: 'Trigger Prompt',
+    icon: <Network className="size-4" />
+  },
+  {
+    id: 'usb',
+    label: 'USB Devices',
+    description: 'Hardware debugging and device tools that talk to USB devices.',
+    actionLabel: 'Open Settings',
+    icon: <Usb className="size-4" />
+  },
+  {
+    id: 'bluetooth',
+    label: 'Bluetooth',
+    description: 'Bluetooth device tools and local hardware experiments.',
+    actionLabel: 'Open Settings',
+    icon: <Bluetooth className="size-4" />
+  }
+]
+
+function statusLabel(status: DeveloperPermissionStatus | undefined): string {
+  switch (status) {
+    case 'granted':
+      return 'Granted'
+    case 'denied':
+      return 'Denied'
+    case 'not-determined':
+      return 'Not requested'
+    case 'restricted':
+      return 'Restricted'
+    case 'unsupported':
+      return 'macOS only'
+    case 'ready':
+      return 'Entitled'
+    case 'unknown':
+    default:
+      return 'Check manually'
+  }
+}
+
+function statusClass(status: DeveloperPermissionStatus | undefined): string {
+  if (status === 'granted' || status === 'ready') {
+    return 'border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300'
+  }
+  if (status === 'denied' || status === 'restricted') {
+    return 'border-destructive/30 bg-destructive/10 text-destructive'
+  }
+  return 'border-border bg-muted text-muted-foreground'
+}
+
+export function DeveloperPermissionsPane(): React.JSX.Element {
+  const [states, setStates] = useState<DeveloperPermissionState[]>([])
+  const [loading, setLoading] = useState(true)
+  const [pendingId, setPendingId] = useState<DeveloperPermissionId | null>(null)
+
+  const stateById = useMemo(
+    () => new Map(states.map((state) => [state.id, state.status] as const)),
+    [states]
+  )
+
+  const refresh = useCallback(async (): Promise<void> => {
+    setLoading(true)
+    try {
+      setStates(await window.api.developerPermissions.getStatus())
+    } catch {
+      toast.error('Could not load developer permissions')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void refresh()
+  }, [refresh])
+
+  const request = async (id: DeveloperPermissionId): Promise<void> => {
+    setPendingId(id)
+    try {
+      const result = await window.api.developerPermissions.request({ id })
+      await refresh()
+      if (result.status === 'granted') {
+        toast.success('Permission granted')
+      } else if (result.openedSystemSettings) {
+        toast.message('Opened macOS Privacy & Security')
+      } else {
+        toast.message('Permission request sent')
+      }
+    } catch {
+      toast.error('Could not request permission')
+    } finally {
+      setPendingId(null)
+    }
+  }
+
+  return (
+    <div className="space-y-5">
+      <div className="flex items-start justify-between gap-4 rounded-lg border border-border/60 bg-muted/25 px-4 py-3">
+        <div className="space-y-1">
+          <div className="flex items-center gap-2 text-sm font-medium">
+            <ShieldCheck className="size-4" />
+            Terminal tools inherit Orca&apos;s macOS privacy envelope.
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Use these controls when a CLI, local app, or automation tool needs macOS privacy access.
+            Orca does not ask at startup.
+          </p>
+        </div>
+        <Button variant="outline" size="sm" className="gap-1.5" onClick={() => void refresh()}>
+          <RefreshCw className={`size-3.5 ${loading ? 'animate-spin' : ''}`} />
+          Refresh
+        </Button>
+      </div>
+
+      <div className="divide-y divide-border/60 rounded-lg border border-border/60">
+        {PERMISSIONS.map((permission) => {
+          const status = stateById.get(permission.id)
+          const pending = pendingId === permission.id
+
+          return (
+            <div key={permission.id} className="flex items-center justify-between gap-4 px-4 py-3">
+              <div className="flex min-w-0 items-start gap-3">
+                <div className="mt-0.5 text-muted-foreground">{permission.icon}</div>
+                <div className="min-w-0 space-y-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="text-sm font-medium">{permission.label}</span>
+                    <span
+                      className={`rounded-full border px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider ${statusClass(
+                        status
+                      )}`}
+                    >
+                      {statusLabel(status)}
+                    </span>
+                  </div>
+                  <p className="text-xs text-muted-foreground">{permission.description}</p>
+                </div>
+              </div>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={pending || status === 'unsupported'}
+                onClick={() => void request(permission.id)}
+                className="shrink-0 gap-1.5"
+              >
+                <ExternalLink className="size-3.5" />
+                {pending ? 'Working...' : permission.actionLabel}
+              </Button>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -8,6 +8,7 @@ import {
   GitBranch,
   Globe,
   Keyboard,
+  ShieldCheck,
   Palette,
   Server,
   SlidersHorizontal,
@@ -37,6 +38,10 @@ import { ExperimentalPane, EXPERIMENTAL_PANE_SEARCH_ENTRIES } from './Experiment
 import { AgentsPane, AGENTS_PANE_SEARCH_ENTRIES } from './AgentsPane'
 import { StatsPane, STATS_PANE_SEARCH_ENTRIES } from '../stats/StatsPane'
 import { IntegrationsPane, INTEGRATIONS_PANE_SEARCH_ENTRIES } from './IntegrationsPane'
+import {
+  DeveloperPermissionsPane,
+  DEVELOPER_PERMISSIONS_PANE_SEARCH_ENTRIES
+} from './DeveloperPermissionsPane'
 import { SettingsSidebar } from './SettingsSidebar'
 import { SettingsSection } from './SettingsSection'
 import { matchesSettingsSearch, type SettingsSearchEntry } from './settings-search'
@@ -49,6 +54,7 @@ type SettingsNavTarget =
   | 'appearance'
   | 'terminal'
   | 'notifications'
+  | 'developer-permissions'
   | 'shortcuts'
   | 'stats'
   | 'ssh'
@@ -337,6 +343,17 @@ function Settings(): React.JSX.Element {
         icon: Bell,
         searchEntries: NOTIFICATIONS_PANE_SEARCH_ENTRIES
       },
+      ...(isMac
+        ? [
+            {
+              id: 'developer-permissions' as const,
+              title: 'Permissions',
+              description: 'macOS privacy access for terminal-launched developer tools.',
+              icon: ShieldCheck,
+              searchEntries: DEVELOPER_PERMISSIONS_PANE_SEARCH_ENTRIES
+            }
+          ]
+        : []),
       {
         id: 'shortcuts',
         title: 'Shortcuts',
@@ -381,7 +398,7 @@ function Settings(): React.JSX.Element {
         searchEntries: getRepositoryPaneSearchEntries(repo)
       }))
     ],
-    [repos, terminalPaneSearchEntries]
+    [isMac, repos, terminalPaneSearchEntries]
   )
 
   const visibleNavSections = useMemo(
@@ -647,6 +664,17 @@ function Settings(): React.JSX.Element {
                 >
                   <NotificationsPane settings={settings} updateSettings={updateSettings} />
                 </SettingsSection>
+
+                {isMac ? (
+                  <SettingsSection
+                    id="developer-permissions"
+                    title="Permissions"
+                    description="macOS privacy access for terminal-launched developer tools."
+                    searchEntries={DEVELOPER_PERMISSIONS_PANE_SEARCH_ENTRIES}
+                  >
+                    <DeveloperPermissionsPane />
+                  </SettingsSection>
+                ) : null}
 
                 <SettingsSection
                   id="shortcuts"

--- a/src/renderer/src/components/terminal-pane/developer-permission-hints.test.ts
+++ b/src/renderer/src/components/terminal-pane/developer-permission-hints.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { detectDeveloperPermissionHint } from './developer-permission-hints'
+
+describe('detectDeveloperPermissionHint', () => {
+  it('detects microphone failures from terminal output', () => {
+    expect(
+      detectDeveloperPermissionHint('sox WARN coreaudio: default input device permission denied')
+        ?.permissionId
+    ).toBe('microphone')
+  })
+
+  it('detects screen recording failures from terminal output', () => {
+    expect(
+      detectDeveloperPermissionHint('screencapture failed: screen recording not authorized')
+        ?.permissionId
+    ).toBe('screen')
+  })
+
+  it('ignores unrelated permission text', () => {
+    expect(detectDeveloperPermissionHint('git: permission denied (publickey)')).toBeNull()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/developer-permission-hints.ts
+++ b/src/renderer/src/components/terminal-pane/developer-permission-hints.ts
@@ -1,0 +1,64 @@
+import type { DeveloperPermissionId } from '../../../../shared/developer-permissions-types'
+
+const ESC = String.fromCharCode(27)
+const BEL = String.fromCharCode(7)
+const ANSI_PATTERN = new RegExp(
+  `${ESC}(?:[@-Z\\\\-_]|\\[[0-?]*[ -/]*[@-~]|\\][^${BEL}]*(?:${BEL}|${ESC}\\\\))`,
+  'g'
+)
+
+type DeveloperPermissionHint = {
+  permissionId: DeveloperPermissionId
+  title: string
+  description: string
+}
+
+export function detectDeveloperPermissionHint(data: string): DeveloperPermissionHint | null {
+  const normalized = data.slice(-4000).replace(ANSI_PATTERN, '').toLowerCase()
+
+  if (
+    /\b(microphone|audio input|input device|default input device)\b/.test(normalized) &&
+    /\b(permission|denied|not authorized|unauthorized|no audio|not permitted)\b/.test(normalized)
+  ) {
+    return {
+      permissionId: 'microphone',
+      title: 'This command may need microphone access',
+      description: 'Open Developer Permissions to enable audio capture for terminal tools.'
+    }
+  }
+
+  if (
+    /\b(camera|webcam|video capture)\b/.test(normalized) &&
+    /\b(permission|denied|not authorized|unauthorized|not permitted)\b/.test(normalized)
+  ) {
+    return {
+      permissionId: 'camera',
+      title: 'This command may need camera access',
+      description: 'Open Developer Permissions to enable camera capture for terminal tools.'
+    }
+  }
+
+  if (
+    /\b(screen recording|screen capture|screencapture|desktop capture)\b/.test(normalized) &&
+    /\b(permission|denied|not authorized|unauthorized|not permitted)\b/.test(normalized)
+  ) {
+    return {
+      permissionId: 'screen',
+      title: 'This command may need screen recording access',
+      description: 'Open Developer Permissions to enable screenshots and screen capture.'
+    }
+  }
+
+  if (
+    /\b(apple events|osascript|system events|automation)\b/.test(normalized) &&
+    /\b(not authorized|not allowed|permission|denied|not permitted)\b/.test(normalized)
+  ) {
+    return {
+      permissionId: 'automation',
+      title: 'This command may need automation access',
+      description: 'Open Developer Permissions to allow Apple Events for terminal scripts.'
+    }
+  }
+
+  return null
+}

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -16,8 +16,10 @@ import {
   POST_REPLAY_FOCUS_REPORTING_RESET
 } from './layout-serialization'
 import { warnTerminalLifecycleAnomaly } from './terminal-lifecycle-diagnostics'
+import { detectDeveloperPermissionHint } from './developer-permission-hints'
 
 const pendingSpawnByPaneKey = new Map<string, Promise<string | null>>()
+const developerPermissionHintKeys = new Set<string>()
 
 // Why: when multiple panes/tabs need the same deferred SSH connection,
 // the first one calls ssh.connect() and subsequent ones must wait for it
@@ -82,6 +84,38 @@ function isSessionOwnedByWorktree(sessionId: string, worktreeId: string): boolea
     return true
   }
   return sessionId.slice(0, separatorIdx) === worktreeId
+}
+
+function maybeShowDeveloperPermissionHint(worktreeId: string, data: string): void {
+  if (!navigator.userAgent.includes('Mac')) {
+    return
+  }
+
+  const hint = detectDeveloperPermissionHint(data)
+  if (!hint) {
+    return
+  }
+  const key = `${worktreeId}:${hint.permissionId}`
+  if (developerPermissionHintKeys.has(key)) {
+    return
+  }
+  developerPermissionHintKeys.add(key)
+
+  toast.message(hint.title, {
+    description: hint.description,
+    duration: 12000,
+    action: {
+      label: 'Open Permissions',
+      onClick: () => {
+        useAppStore.getState().openSettingsTarget({
+          pane: 'developer-permissions',
+          repoId: null,
+          sectionId: 'developer-permissions'
+        })
+        useAppStore.getState().openSettingsPage()
+      }
+    }
+  })
 }
 
 export function connectPanePty(
@@ -449,6 +483,8 @@ export function connectPanePty(
     }
 
     const dataCallback = (data: string): void => {
+      maybeShowDeveloperPermissionHint(deps.worktreeId, data)
+
       if (deps.isVisibleRef.current) {
         pane.terminal.write(data)
       } else {

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -99,6 +99,7 @@ export type UISlice = {
       | 'browser'
       | 'appearance'
       | 'terminal'
+      | 'developer-permissions'
       | 'shortcuts'
       | 'repo'
       | 'agents'

--- a/src/shared/developer-permissions-types.ts
+++ b/src/shared/developer-permissions-types.ts
@@ -1,0 +1,30 @@
+export type DeveloperPermissionId =
+  | 'microphone'
+  | 'camera'
+  | 'screen'
+  | 'accessibility'
+  | 'full-disk-access'
+  | 'automation'
+  | 'local-network'
+  | 'usb'
+  | 'bluetooth'
+
+export type DeveloperPermissionStatus =
+  | 'granted'
+  | 'denied'
+  | 'not-determined'
+  | 'restricted'
+  | 'unknown'
+  | 'unsupported'
+  | 'ready'
+
+export type DeveloperPermissionState = {
+  id: DeveloperPermissionId
+  status: DeveloperPermissionStatus
+}
+
+export type DeveloperPermissionRequestResult = {
+  id: DeveloperPermissionId
+  status: DeveloperPermissionStatus
+  openedSystemSettings: boolean
+}


### PR DESCRIPTION
## Problem

Orca's signed macOS app bundle declares camera and microphone usage strings, but it did not carry the hardened-runtime entitlements needed for terminal-launched tools to reach macOS TCC prompts. As a result, developer tools run inside the embedded terminal could be silently blocked from microphone/camera access and never appear in System Settings, as reported in #1009.

The previous fix requested microphone permission at startup, which made Orca ask for mic access even when the user had not started a voice or media workflow.

## Solution

- Add macOS runtime entitlements for developer-tool permissions that terminal processes may reasonably need: microphone/audio input, camera, Bluetooth, USB, location, and Apple Events automation.
- Add matching macOS purpose strings for Bluetooth, location, Apple Events, local network, and desktop audio capture.
- Keep media permission requests dynamic for Orca-owned Electron web contents: when Chromium asks for `media`, Orca requests the matching macOS camera/microphone permission at that moment, not during app startup.
- Add a Settings → Permissions pane for explicit, contextual developer permission setup:
  - Request microphone/camera/accessibility from the app process.
  - Trigger Apple Events and Local Network prompts only when the user clicks.
  - Open the right macOS Privacy & Security panes for Full Disk Access, Screen Recording, USB, and Bluetooth.
- Add terminal-output hints for common macOS privacy failures. If a CLI prints a likely mic/camera/screen/automation denial, Orca shows a one-time toast that deep-links to the Permissions pane.
- Preserve the existing deny-by-default policy for arbitrary browser sessions.

## Testing

- `pnpm exec oxlint src/main/ipc/developer-permissions.ts src/main/ipc/register-core-handlers.ts src/main/ipc/register-core-handlers.test.ts src/preload/index.ts src/preload/api-types.ts src/shared/developer-permissions-types.ts src/renderer/src/components/settings/DeveloperPermissionsPane.tsx src/renderer/src/components/settings/Settings.tsx src/renderer/src/store/slices/ui.ts src/renderer/src/components/terminal-pane/developer-permission-hints.ts src/renderer/src/components/terminal-pane/developer-permission-hints.test.ts src/renderer/src/components/terminal-pane/pty-connection.ts config/electron-builder.config.cjs`
- `pnpm run typecheck:node`
- `pnpm run typecheck:web`
- `pnpm exec vitest run --config config/vitest.config.ts src/main/window/attach-main-window-services.test.ts src/main/browser/browser-session-registry.test.ts src/main/ipc/register-core-handlers.test.ts src/renderer/src/components/terminal-pane/developer-permission-hints.test.ts`
- `plutil -lint resources/build/entitlements.mac.plist`