### PR TITLE
feat(sidebar): inline Connect for disconnected SSH targets in remote project dialog

### DIFF
--- a/src/renderer/src/components/sidebar/AddRepoDialog.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoDialog.tsx
@@ -52,7 +52,8 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
     setRemoteError,
     resetRemoteState,
     handleOpenRemoteStep,
-    handleAddRemoteRepo
+    handleAddRemoteRepo,
+    handleConnectTarget
   } = useRemoteRepo(fetchWorktrees, setStep, setAddedRepo, closeModal)
   useEffect(() => {
     if (!isCloning) {
@@ -321,6 +322,7 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
               openSettingsTarget({ pane: 'ssh', repoId: null, sectionId: 'ssh' })
               openSettingsPage()
             }}
+            onConnectTarget={handleConnectTarget}
           />
         ) : step === 'clone' ? (
           <CloneStep

--- a/src/renderer/src/components/sidebar/AddRepoSteps.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoSteps.tsx
@@ -5,7 +5,7 @@
  * by moving the presentational JSX for each wizard step into separate components
  * while the parent retains all state and handlers.
  */
-import React, { useCallback, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { Folder, FolderOpen, Settings } from 'lucide-react'
 import { useAppStore } from '@/store'
@@ -13,6 +13,7 @@ import { DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/di
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { RemoteFileBrowser } from './RemoteFileBrowser'
+import { SshTargetRow } from './SshTargetRow'
 import type { Repo } from '../../../../shared/types'
 import type { SshTarget, SshConnectionState } from '../../../../shared/ssh-types'
 
@@ -71,6 +72,27 @@ export function useRemoteRepo(
       setSshTargets([])
     }
   }, [setStep])
+
+  // Why: keep the target list's connection state in sync while the dialog is
+  // open, so clicking the inline Connect button below updates the dot/label
+  // live without the user reopening the step.
+  useEffect(() => {
+    const unsubscribe = window.api.ssh.onStateChanged(({ targetId, state }) => {
+      setSshTargets((prev) => prev.map((t) => (t.id === targetId ? { ...t, state } : t)))
+      if (state.status === 'connected') {
+        setSelectedTargetId((curr) => curr ?? targetId)
+      }
+    })
+    return unsubscribe
+  }, [])
+
+  const handleConnectTarget = useCallback(async (targetId: string) => {
+    try {
+      await window.api.ssh.connect({ targetId })
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Connection failed')
+    }
+  }, [])
 
   const handleAddRemoteRepo = useCallback(async () => {
     if (!selectedTargetId || !remotePath.trim()) {
@@ -133,7 +155,8 @@ export function useRemoteRepo(
     setRemoteError,
     resetRemoteState,
     handleOpenRemoteStep,
-    handleAddRemoteRepo
+    handleAddRemoteRepo,
+    handleConnectTarget
   }
 }
 
@@ -149,6 +172,7 @@ type RemoteStepProps = {
   onRemotePathChange: (value: string) => void
   onAdd: () => void
   onOpenSshSettings: () => void
+  onConnectTarget: (id: string) => Promise<void>
 }
 
 export function RemoteStep({
@@ -160,7 +184,8 @@ export function RemoteStep({
   onSelectTarget,
   onRemotePathChange,
   onAdd,
-  onOpenSshSettings
+  onOpenSshSettings,
+  onConnectTarget
 }: RemoteStepProps): React.JSX.Element {
   const [browsing, setBrowsing] = useState(false)
 
@@ -213,36 +238,15 @@ export function RemoteStep({
             </div>
           ) : (
             <div className="space-y-1.5">
-              {sshTargets.map((target) => {
-                const isConnected = target.state?.status === 'connected'
-                const isSelected = selectedTargetId === target.id
-                return (
-                  <button
-                    key={target.id}
-                    className={`w-full flex items-center gap-2 px-3 py-2 rounded-md border text-xs transition-colors cursor-pointer ${
-                      isSelected
-                        ? 'border-foreground/30 bg-accent'
-                        : 'border-border hover:bg-accent/50'
-                    } ${!isConnected ? 'opacity-50' : ''}`}
-                    onClick={() => {
-                      if (isConnected) {
-                        onSelectTarget(target.id)
-                      }
-                    }}
-                    disabled={!isConnected}
-                  >
-                    <span
-                      className={`size-2 rounded-full shrink-0 ${isConnected ? 'bg-green-500' : 'bg-muted-foreground/30'}`}
-                    />
-                    <span className="font-medium truncate">
-                      {target.label || `${target.username}@${target.host}`}
-                    </span>
-                    {!isConnected && (
-                      <span className="text-muted-foreground ml-auto">Not connected</span>
-                    )}
-                  </button>
-                )
-              })}
+              {sshTargets.map((target) => (
+                <SshTargetRow
+                  key={target.id}
+                  target={target}
+                  isSelected={selectedTargetId === target.id}
+                  onSelect={onSelectTarget}
+                  onConnect={onConnectTarget}
+                />
+              ))}
             </div>
           )}
         </div>

--- a/src/renderer/src/components/sidebar/SshTargetRow.tsx
+++ b/src/renderer/src/components/sidebar/SshTargetRow.tsx
@@ -1,0 +1,95 @@
+/**
+ * Row used in the "Open remote project" step to pick an SSH target.
+ *
+ * Why extracted: keeps AddRepoSteps.tsx under the 400-line oxlint limit
+ * while isolating the inline-connect interaction logic.
+ */
+import React, { useState } from 'react'
+import { Loader2 } from 'lucide-react'
+import type { SshTarget, SshConnectionState } from '../../../../shared/ssh-types'
+
+type Props = {
+  target: SshTarget & { state?: SshConnectionState }
+  isSelected: boolean
+  onSelect: (id: string) => void
+  onConnect: (id: string) => Promise<void>
+}
+
+export function SshTargetRow({
+  target,
+  isSelected,
+  onSelect,
+  onConnect
+}: Props): React.JSX.Element {
+  const [connecting, setConnecting] = useState(false)
+  const status = target.state?.status ?? 'disconnected'
+  const isConnected = status === 'connected'
+  const isBusy =
+    connecting ||
+    status === 'connecting' ||
+    status === 'deploying-relay' ||
+    status === 'reconnecting'
+  const dotColor = isConnected
+    ? 'bg-green-500'
+    : isBusy
+      ? 'bg-yellow-500'
+      : 'bg-muted-foreground/30'
+
+  const handleRowClick = (): void => {
+    if (isConnected) {
+      onSelect(target.id)
+    }
+  }
+
+  const handleConnectClick = (e: React.MouseEvent): void => {
+    // Why: prevent the row's onClick from also firing and treating the click
+    // as a selection when the target is disconnected.
+    e.stopPropagation()
+    if (isBusy) {
+      return
+    }
+    setConnecting(true)
+    void onConnect(target.id).finally(() => setConnecting(false))
+  }
+
+  return (
+    <div
+      role={isConnected ? 'button' : undefined}
+      tabIndex={isConnected ? 0 : undefined}
+      className={`w-full flex items-center gap-2 px-3 py-2 rounded-md border text-xs transition-colors ${
+        isSelected ? 'border-foreground/30 bg-accent' : 'border-border hover:bg-accent/50'
+      } ${isConnected ? 'cursor-pointer' : ''}`}
+      onClick={handleRowClick}
+      onKeyDown={(e) => {
+        if (isConnected && (e.key === 'Enter' || e.key === ' ')) {
+          e.preventDefault()
+          onSelect(target.id)
+        }
+      }}
+    >
+      <span className={`size-2 rounded-full shrink-0 ${dotColor}`} />
+      <span className={`font-medium truncate ${!isConnected ? 'text-muted-foreground' : ''}`}>
+        {target.label || `${target.username}@${target.host}`}
+      </span>
+      {!isConnected && (
+        // Why: inline Connect avoids forcing the user out to Settings just to
+        // bring up a configured target.
+        <button
+          type="button"
+          className="ml-auto shrink-0 rounded px-1.5 py-0.5 text-[11px] font-medium text-foreground hover:bg-accent/70 disabled:opacity-50 disabled:cursor-default flex items-center gap-1"
+          onClick={handleConnectClick}
+          disabled={isBusy}
+        >
+          {isBusy ? (
+            <>
+              <Loader2 className="size-3 animate-spin" />
+              Connecting…
+            </>
+          ) : (
+            'Connect'
+          )}
+        </button>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- In the "Open remote project" dialog, disconnected SSH targets now show an inline **Connect** button instead of a disabled row with only a "Not connected" label. Users can bring up a configured target without leaving the dialog for Settings.
- The target list subscribes to `ssh:state-changed` while mounted, so dot color, label color, and the Connect/Connecting… state update live as the handshake progresses. On a successful connect, the target is auto-selected if nothing else is selected yet.
- Extracted the row into `SshTargetRow.tsx` to stay under the 400-line oxlint limit and isolate the inline-connect interaction logic.

## Test plan
- [x] Typecheck: `pnpm typecheck:web`
- [x] Lint: `pnpm exec oxlint` on changed files
- [x] Manual: with `openclaw` disconnected, opened Add repo → Remote project, verified the inline Connect button renders and row remains keyboard-accessible when connected
- [ ] Verify successful connect flips the row to green and auto-selects it, allowing "Add remote project" to proceed

Made with [Orca](https://github.com/stablyai/orca) 🐋
