### PR TITLE
fix(sidebar): clear agent status when sleeping a worktree

### DIFF
--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -1079,6 +1079,15 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       }
     })
 
+    // Why: sleep keeps the tab records (so wake restores them) but kills the
+    // PTYs, and there is no implicit "PTY death drops agent-status rows" path
+    // — closeTab and pane-close drop their own rows explicitly. Without the
+    // same explicit sweep here, a worktree slept in the 'done' state leaves
+    // live/retained entries behind and WorktreeCard's dot stays blue.
+    for (const tab of tabs) {
+      get().dropAgentStatusByTabPrefix(tab.id)
+    }
+
     if (ptyIds.length === 0) {
       return
     }


### PR DESCRIPTION
## Summary
- Sleeping a worktree that was in the `done` (blue) state left the sidebar dot blue. Sleep keeps tab records (to restore them on wake) and kills PTYs, but nothing in that path sweeps agent-status rows — `closeTab` and pane-close drop their own rows explicitly, so `shutdownWorktreeTerminals` has to do the same or `WorktreeCard`'s `hasLiveDone` / `hasRetainedDone` selectors keep reporting true.
- Fix: per-tab `dropAgentStatusByTabPrefix` sweep at the end of `shutdownWorktreeTerminals`, reusing the helper `closeTab` already calls (so retention suppressors are planted correctly for the same-frame live→gone race).

## Test plan
- [x] Open a workspace, let an agent reach `done` (blue dot in sidebar), then sleep the workspace. Dot should transition out of blue.
- [x] Regression: sleep a workspace with an actively `working` agent — dot should still clear.
- [x] Regression: close a single tab / pane while its agent is `done` — dashboard and sidebar should still clear as before.
- [x] Wake the slept workspace and confirm tabs restore (sleep must not start closing tabs).

Made with [Orca](https://github.com/stablyai/orca) 🐋
