### PR TITLE
improve active worktree card visibility in light mode

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -337,7 +337,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
       className={cn(
         'group relative flex items-start gap-2.5 px-2 py-2 rounded-lg cursor-pointer transition-all duration-200 outline-none select-none ml-1',
         isActive
-          ? 'bg-black/[0.10] shadow-[0_1px_2px_rgba(0,0,0,0.06)] border border-black/15 dark:bg-white/[0.10] dark:border-border/40 dark:shadow-[0_1px_2px_rgba(0,0,0,0.03)]'
+          ? 'bg-black/[0.08] shadow-[0_1px_2px_rgba(0,0,0,0.04)] border border-black/[0.015] dark:bg-white/[0.10] dark:border-border/40 dark:shadow-[0_1px_2px_rgba(0,0,0,0.03)]'
           : 'border border-transparent hover:bg-accent/40',
         isDeleting && 'opacity-50 grayscale cursor-not-allowed',
         isSshDisconnected && !isDeleting && 'opacity-60'
@@ -450,7 +450,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
                 <TooltipTrigger asChild>
                   <Badge
                     variant="outline"
-                    className="h-[16px] px-1.5 text-[10px] font-medium rounded shrink-0 leading-none text-muted-foreground border-muted-foreground/30 bg-muted-foreground/5"
+                    className="h-[16px] px-1.5 text-[10px] font-medium rounded shrink-0 leading-none text-foreground/70 border-foreground/20 bg-foreground/[0.06]"
                   >
                     primary
                   </Badge>

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -337,7 +337,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
       className={cn(
         'group relative flex items-start gap-2.5 px-2 py-2 rounded-lg cursor-pointer transition-all duration-200 outline-none select-none ml-1',
         isActive
-          ? 'bg-black/[0.06] shadow-[0_1px_2px_rgba(0,0,0,0.03)] border border-border/60 dark:bg-white/[0.10] dark:border-border/40'
+          ? 'bg-black/[0.10] shadow-[0_1px_2px_rgba(0,0,0,0.06)] border border-black/15 dark:bg-white/[0.10] dark:border-border/40 dark:shadow-[0_1px_2px_rgba(0,0,0,0.03)]'
           : 'border border-transparent hover:bg-accent/40',
         isDeleting && 'opacity-50 grayscale cursor-not-allowed',
         isSshDisconnected && !isDeleting && 'opacity-60'


### PR DESCRIPTION
## Problem
The active worktree card background in the sidebar was too subtle in light mode — users couldn't quickly tell which worktree was selected. The `primary` badge next to the worktree title also blended in with surrounding muted text.

## Solution
- Boost active-card contrast in light mode: `bg-black/[0.06]` → `bg-black/[0.08]`, add a faint `border-black/[0.015]` and slightly stronger shadow. Dark mode unchanged.
- Restyle the `primary` badge with `foreground/70` text, `foreground/20` border, `foreground/[0.06]` bg so it stands out without introducing a color hue.

Made with [Orca](https://github.com/stablyai/orca) 🐋
