### PR TITLE
feat(terminal): view diff on unsaved file close

### DIFF
--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -22,8 +22,10 @@ import { Button } from '@/components/ui/button'
 import TabBar from './tab-bar/TabBar'
 import TerminalPane from './terminal-pane/TerminalPane'
 import {
+  ORCA_EDITOR_REQUEST_FILE_CLOSE_EVENT,
   ORCA_EDITOR_SAVE_AND_CLOSE_EVENT,
   ORCA_EDITOR_REQUEST_CMD_SAVE_EVENT,
+  type EditorRequestFileCloseDetail,
   requestEditorSaveQuiesce
 } from './editor/editor-autosave'
 import { isUpdaterQuitAndInstallInProgress } from '@/lib/updater-beforeunload'
@@ -38,9 +40,11 @@ import {
   getEffectiveLayoutForWorktree as getEffectiveLayout,
   anyMountedWorktreeHasLayout as computeAnyMountedWorktreeHasLayout
 } from './terminal/split-group-mount'
+import { appendUniqueOpenFileIds, buildUnsavedDiffModelKey } from './terminal/unsaved-close-queue'
 import CodexRestartChip from './CodexRestartChip'
 
 const EditorPanel = lazy(() => import('./editor/EditorPanel'))
+const DiffViewer = lazy(() => import('./editor/DiffViewer'))
 
 function Terminal(): React.JSX.Element | null {
   const allWorktrees = useAllWorktrees()
@@ -65,7 +69,6 @@ function Terminal(): React.JSX.Element | null {
   const setActiveFile = useAppStore((s) => s.setActiveFile)
   const openFile = useAppStore((s) => s.openFile)
   const closeFile = useAppStore((s) => s.closeFile)
-  const closeAllFiles = useAppStore((s) => s.closeAllFiles)
   const pinFile = useAppStore((s) => s.pinFile)
   const browserTabsByWorktree = useAppStore((s) => s.browserTabsByWorktree)
   const createBrowserTab = useAppStore((s) => s.createBrowserTab)
@@ -135,6 +138,18 @@ function Terminal(): React.JSX.Element | null {
   // Save confirmation dialog state
   const [saveDialogFileId, setSaveDialogFileId] = useState<string | null>(null)
   const saveDialogFile = saveDialogFileId ? openFiles.find((f) => f.id === saveDialogFileId) : null
+  const [unsavedDiffDialogOpen, setUnsavedDiffDialogOpen] = useState(false)
+  const [unsavedDiffLoading, setUnsavedDiffLoading] = useState(false)
+  const [unsavedDiffError, setUnsavedDiffError] = useState<string | null>(null)
+  const [unsavedDiffModelKey, setUnsavedDiffModelKey] = useState<string | null>(null)
+  const [unsavedDiffModel, setUnsavedDiffModel] = useState<{
+    fileLabel: string
+    language: string
+    originalContent: string
+    modifiedContent: string
+  } | null>(null)
+  const unsavedDiffRequestIdRef = useRef(0)
+  const pendingEditorCloseQueueRef = useRef<string[]>([])
 
   // Window close confirmation dialog — shown when the user tries to close the
   // window (X button, Cmd+Q) while terminals with running processes exist.
@@ -173,16 +188,88 @@ function Terminal(): React.JSX.Element | null {
     )
   }, [])
 
+  const waitForFileClosed = useCallback((fileId: string, timeoutMs: number): Promise<boolean> => {
+    if (!useAppStore.getState().openFiles.some((f) => f.id === fileId)) {
+      return Promise.resolve(true)
+    }
+    return new Promise((resolve) => {
+      let unsub: (() => void) | null = null
+      const timeoutId = window.setTimeout(() => {
+        unsub?.()
+        resolve(false)
+      }, timeoutMs)
+      unsub = useAppStore.subscribe((state) => {
+        if (!state.openFiles.some((f) => f.id === fileId)) {
+          window.clearTimeout(timeoutId)
+          unsub?.()
+          resolve(true)
+        }
+      })
+    })
+  }, [])
+
+  const getNextQueuedEditorClose = useCallback((): string | null => {
+    // Why: bulk close actions can enqueue files that become clean or disappear
+    // before they reach the front. Drain those entries eagerly so the dialog
+    // only blocks on tabs that still require an explicit close decision.
+    while (pendingEditorCloseQueueRef.current.length > 0) {
+      const fileId = pendingEditorCloseQueueRef.current[0]
+      const file = useAppStore.getState().openFiles.find((candidate) => candidate.id === fileId)
+      if (!file) {
+        pendingEditorCloseQueueRef.current.shift()
+        continue
+      }
+      if (!file.isDirty) {
+        closeFile(fileId)
+        pendingEditorCloseQueueRef.current.shift()
+        continue
+      }
+      return fileId
+    }
+    return null
+  }, [closeFile])
+
+  const advanceEditorCloseQueue = useCallback(() => {
+    const nextFileId = getNextQueuedEditorClose()
+    if (nextFileId) {
+      setActiveFile(nextFileId)
+      setActiveTabType('editor')
+      setSaveDialogFileId(nextFileId)
+      return
+    }
+    setSaveDialogFileId(null)
+    const pendingWindowClose = windowCloseAfterDirtyRef.current
+    if (pendingWindowClose) {
+      windowCloseAfterDirtyRef.current = null
+      proceedToNativeWindowClose(pendingWindowClose.isQuitting)
+    }
+  }, [getNextQueuedEditorClose, proceedToNativeWindowClose, setActiveFile, setActiveTabType])
+
+  const queueEditorCloseRequests = useCallback(
+    (fileIds: string[], pendingWindowClose?: { isQuitting: boolean }) => {
+      if (pendingWindowClose) {
+        windowCloseAfterDirtyRef.current = pendingWindowClose
+      }
+      pendingEditorCloseQueueRef.current = appendUniqueOpenFileIds(
+        pendingEditorCloseQueueRef.current,
+        fileIds,
+        new Set(useAppStore.getState().openFiles.map((file) => file.id))
+      )
+      advanceEditorCloseQueue()
+    },
+    [advanceEditorCloseQueue]
+  )
+
   const handleCloseFile = useCallback(
     (fileId: string) => {
       const file = useAppStore.getState().openFiles.find((f) => f.id === fileId)
       if (file?.isDirty) {
-        setSaveDialogFileId(fileId)
+        queueEditorCloseRequests([fileId])
         return
       }
       closeFile(fileId)
     },
-    [closeFile]
+    [closeFile, queueEditorCloseRequests]
   )
 
   const handleSaveDialogSave = useCallback(async () => {
@@ -190,59 +277,12 @@ function Terminal(): React.JSX.Element | null {
       return
     }
     const fileId = saveDialogFileId
-    const pendingWindowClose = windowCloseAfterDirtyRef.current
     const file = useAppStore.getState().openFiles.find((f) => f.id === fileId)
     if (!file) {
-      setSaveDialogFileId(null)
-      windowCloseAfterDirtyRef.current = null
-      return
-    }
-
-    if (pendingWindowClose) {
-      setSaveDialogFileId(null)
-      // Why: save-and-close must flush the latest draft even when the visible
-      // editor panel has already unmounted. The headless autosave controller
-      // owns that write path now, so the dialog signals it through a custom
-      // event instead of poking at editor component refs.
-      window.dispatchEvent(
-        new CustomEvent(ORCA_EDITOR_SAVE_AND_CLOSE_EVENT, { detail: { fileId } })
+      pendingEditorCloseQueueRef.current = pendingEditorCloseQueueRef.current.filter(
+        (id) => id !== fileId
       )
-
-      const waitForFileClosed = (timeoutMs: number): Promise<boolean> => {
-        if (!useAppStore.getState().openFiles.some((f) => f.id === fileId)) {
-          return Promise.resolve(true)
-        }
-        return new Promise((resolve) => {
-          let unsub: (() => void) | null = null
-          const timeoutId = window.setTimeout(() => {
-            unsub?.()
-            resolve(false)
-          }, timeoutMs)
-          unsub = useAppStore.subscribe((state) => {
-            if (!state.openFiles.some((f) => f.id === fileId)) {
-              window.clearTimeout(timeoutId)
-              unsub?.()
-              resolve(true)
-            }
-          })
-        })
-      }
-
-      const closed = await waitForFileClosed(10_000)
-      if (!closed) {
-        toast.error('Save timed out or failed. Fix errors before closing.')
-        setSaveDialogFileId(fileId)
-        return
-      }
-
-      const nextDirty = useAppStore.getState().openFiles.filter((f) => f.isDirty)
-      if (nextDirty.length > 0) {
-        setSaveDialogFileId(nextDirty[0].id)
-      } else {
-        const { isQuitting } = pendingWindowClose
-        windowCloseAfterDirtyRef.current = null
-        proceedToNativeWindowClose(isQuitting)
-      }
+      advanceEditorCloseQueue()
       return
     }
 
@@ -250,54 +290,134 @@ function Terminal(): React.JSX.Element | null {
     // editor panel has already unmounted. The headless autosave controller
     // owns that write path now, so the dialog signals it through a custom
     // event instead of poking at editor component refs.
-    window.dispatchEvent(new CustomEvent(ORCA_EDITOR_SAVE_AND_CLOSE_EVENT, { detail: { fileId } }))
     setSaveDialogFileId(null)
-  }, [saveDialogFileId, proceedToNativeWindowClose])
+    setUnsavedDiffDialogOpen(false)
+    window.dispatchEvent(new CustomEvent(ORCA_EDITOR_SAVE_AND_CLOSE_EVENT, { detail: { fileId } }))
+    const closed = await waitForFileClosed(fileId, 10_000)
+    if (!closed) {
+      toast.error('Save timed out or failed. Fix errors before closing.')
+      setSaveDialogFileId(fileId)
+      return
+    }
+    pendingEditorCloseQueueRef.current = pendingEditorCloseQueueRef.current.filter(
+      (id) => id !== fileId
+    )
+    advanceEditorCloseQueue()
+  }, [advanceEditorCloseQueue, saveDialogFileId, waitForFileClosed])
 
   const handleSaveDialogDiscard = useCallback(async () => {
     if (!saveDialogFileId) {
       return
     }
     const fileId = saveDialogFileId
-    const pendingWindowClose = windowCloseAfterDirtyRef.current
-
-    if (pendingWindowClose) {
-      // Why: autosave runs on a background timer. Wait for any pending/in-flight
-      // write to settle before honoring "Don't Save", otherwise the file can be
-      // written after the user explicitly chose to discard their edits.
-      try {
-        await requestEditorSaveQuiesce({ fileId })
-      } catch {
-        // Quiesce failed — proceed with discard anyway so the user isn't stuck.
-      }
-      setSaveDialogFileId(null)
-      markFileDirty(fileId, false)
-      closeFile(fileId)
-
-      const nextDirty = useAppStore.getState().openFiles.filter((f) => f.isDirty)
-      if (nextDirty.length > 0) {
-        setSaveDialogFileId(nextDirty[0].id)
-      } else {
-        const { isQuitting } = pendingWindowClose
-        windowCloseAfterDirtyRef.current = null
-        proceedToNativeWindowClose(isQuitting)
-      }
-      return
-    }
 
     // Why: autosave runs on a background timer. Wait for any pending/in-flight
     // write to settle before honoring "Don't Save", otherwise the file can be
     // written after the user explicitly chose to discard their edits.
-    await requestEditorSaveQuiesce({ fileId })
+    try {
+      await requestEditorSaveQuiesce({ fileId })
+    } catch {
+      // Quiesce failure must not trap the user in a close dialog loop.
+    }
     markFileDirty(fileId, false)
     closeFile(fileId)
-    setSaveDialogFileId(null)
-  }, [saveDialogFileId, closeFile, markFileDirty, proceedToNativeWindowClose])
+    setUnsavedDiffDialogOpen(false)
+    pendingEditorCloseQueueRef.current = pendingEditorCloseQueueRef.current.filter(
+      (id) => id !== fileId
+    )
+    advanceEditorCloseQueue()
+  }, [advanceEditorCloseQueue, closeFile, markFileDirty, saveDialogFileId])
 
   const handleSaveDialogCancel = useCallback(() => {
+    pendingEditorCloseQueueRef.current = []
     windowCloseAfterDirtyRef.current = null
+    setUnsavedDiffDialogOpen(false)
+    setUnsavedDiffError(null)
+    setUnsavedDiffModelKey(null)
+    setUnsavedDiffModel(null)
+    setUnsavedDiffLoading(false)
     setSaveDialogFileId(null)
   }, [])
+
+  const handleSaveDialogViewDiff = useCallback(async () => {
+    if (!saveDialogFileId) {
+      return
+    }
+    const file = useAppStore
+      .getState()
+      .openFiles.find((candidate) => candidate.id === saveDialogFileId)
+    if (!file) {
+      return
+    }
+
+    const requestId = ++unsavedDiffRequestIdRef.current
+    setUnsavedDiffModelKey(buildUnsavedDiffModelKey(file.id, requestId))
+    setUnsavedDiffDialogOpen(true)
+    setUnsavedDiffLoading(true)
+    setUnsavedDiffError(null)
+
+    let originalContent = ''
+    if (!file.isUntitled) {
+      try {
+        const connectionId = getConnectionId(file.worktreeId) ?? undefined
+        const saved = await window.api.fs.readFile({ filePath: file.filePath, connectionId })
+        if (saved.isBinary) {
+          if (requestId !== unsavedDiffRequestIdRef.current) {
+            return
+          }
+          setUnsavedDiffModel(null)
+          setUnsavedDiffModelKey(null)
+          setUnsavedDiffLoading(false)
+          setUnsavedDiffError('Diff is unavailable for binary files.')
+          return
+        }
+        originalContent = saved.content
+      } catch (error) {
+        if (requestId !== unsavedDiffRequestIdRef.current) {
+          return
+        }
+        setUnsavedDiffModel(null)
+        setUnsavedDiffModelKey(null)
+        setUnsavedDiffLoading(false)
+        setUnsavedDiffError(
+          `Failed to load saved file: ${extractIpcErrorMessage(error, 'Unable to read file')}`
+        )
+        return
+      }
+    }
+
+    const modifiedContent = useAppStore.getState().editorDrafts[file.id] ?? originalContent
+    if (requestId !== unsavedDiffRequestIdRef.current) {
+      return
+    }
+    setUnsavedDiffModel({
+      fileLabel: file.relativePath.split('/').pop() ?? file.relativePath,
+      language: file.language,
+      originalContent,
+      modifiedContent
+    })
+    setUnsavedDiffLoading(false)
+  }, [saveDialogFileId])
+
+  useEffect(() => {
+    const onRequestEditorClose = (event: Event): void => {
+      const customEvent = event as CustomEvent<EditorRequestFileCloseDetail>
+      const fileId = customEvent.detail?.fileId
+      if (!fileId) {
+        return
+      }
+      queueEditorCloseRequests([fileId])
+    }
+    window.addEventListener(
+      ORCA_EDITOR_REQUEST_FILE_CLOSE_EVENT,
+      onRequestEditorClose as EventListener
+    )
+    return () =>
+      window.removeEventListener(
+        ORCA_EDITOR_REQUEST_FILE_CLOSE_EVENT,
+        onRequestEditorClose as EventListener
+      )
+  }, [queueEditorCloseRequests])
 
   useEffect(() => {
     if (tabs.length === 0) {
@@ -584,6 +704,7 @@ function Terminal(): React.JSX.Element | null {
       }
       const state = useAppStore.getState()
       const order = state.tabBarOrderByWorktree[activeWorktreeId] ?? []
+      const dirtyFileIds: string[] = []
       for (const id of order) {
         if (id === tabId) {
           continue
@@ -593,10 +714,9 @@ function Terminal(): React.JSX.Element | null {
         } else if (
           state.openFiles.some((file) => file.worktreeId === activeWorktreeId && file.id === id)
         ) {
-          if (
-            state.activeFileId === id &&
-            state.openFiles.find((file) => file.id === id)?.isDirty
-          ) {
+          const file = state.openFiles.find((candidate) => candidate.id === id)
+          if (file?.isDirty) {
+            dirtyFileIds.push(id)
             continue
           }
           closeFile(id)
@@ -607,8 +727,11 @@ function Terminal(): React.JSX.Element | null {
           closeBrowserTab(id)
         }
       }
+      if (dirtyFileIds.length > 0) {
+        queueEditorCloseRequests(dirtyFileIds)
+      }
     },
-    [activeWorktreeId, closeBrowserTab, closeFile, closeTab]
+    [activeWorktreeId, closeBrowserTab, closeFile, closeTab, queueEditorCloseRequests]
   )
 
   const handleCloseTabsToRight = useCallback(
@@ -623,12 +746,18 @@ function Terminal(): React.JSX.Element | null {
         return
       }
       const rightIds = currentOrder.slice(index + 1)
+      const dirtyFileIds: string[] = []
       for (const id of rightIds) {
         if ((state.tabsByWorktree[activeWorktreeId] ?? []).some((tab) => tab.id === id)) {
           closeTab(id)
         } else if (
           state.openFiles.some((file) => file.worktreeId === activeWorktreeId && file.id === id)
         ) {
+          const file = state.openFiles.find((candidate) => candidate.id === id)
+          if (file?.isDirty) {
+            dirtyFileIds.push(id)
+            continue
+          }
           closeFile(id)
         } else if (
           (state.browserTabsByWorktree[activeWorktreeId] ?? []).some((tab) => tab.id === id)
@@ -637,9 +766,29 @@ function Terminal(): React.JSX.Element | null {
           closeBrowserTab(id)
         }
       }
+      if (dirtyFileIds.length > 0) {
+        queueEditorCloseRequests(dirtyFileIds)
+      }
     },
-    [activeWorktreeId, closeBrowserTab, closeFile, closeTab]
+    [activeWorktreeId, closeBrowserTab, closeFile, closeTab, queueEditorCloseRequests]
   )
+
+  const handleCloseAllFiles = useCallback(() => {
+    if (!activeWorktreeId) {
+      return
+    }
+    const state = useAppStore.getState()
+    const filesInWorktree = state.openFiles.filter((file) => file.worktreeId === activeWorktreeId)
+    const dirtyFileIds = filesInWorktree.filter((file) => file.isDirty).map((file) => file.id)
+    for (const file of filesInWorktree) {
+      if (!file.isDirty) {
+        closeFile(file.id)
+      }
+    }
+    if (dirtyFileIds.length > 0) {
+      queueEditorCloseRequests(dirtyFileIds)
+    }
+  }, [activeWorktreeId, closeFile, queueEditorCloseRequests])
 
   const handleActivateTab = useCallback(
     (tabId: string) => {
@@ -861,8 +1010,10 @@ function Terminal(): React.JSX.Element | null {
 
       const dirtyFiles = useAppStore.getState().openFiles.filter((f) => f.isDirty)
       if (dirtyFiles.length > 0) {
-        windowCloseAfterDirtyRef.current = { isQuitting }
-        setSaveDialogFileId(dirtyFiles[0].id)
+        queueEditorCloseRequests(
+          dirtyFiles.map((file) => file.id),
+          { isQuitting }
+        )
         return
       }
 
@@ -895,7 +1046,7 @@ function Terminal(): React.JSX.Element | null {
         }
       )
     })
-  }, [])
+  }, [queueEditorCloseRequests])
 
   // Why: removeWorktree cleans up browser tab state in the store but cannot
   // call destroyPersistentWebview (renderer-only DOM code). This subscriber
@@ -998,7 +1149,7 @@ function Terminal(): React.JSX.Element | null {
             onActivateBrowserTab={handleActivateBrowserTab}
             onCloseBrowserTab={handleCloseBrowserTab}
             onDuplicateBrowserTab={handleDuplicateBrowserTab}
-            onCloseAllFiles={closeAllFiles}
+            onCloseAllFiles={handleCloseAllFiles}
             onPinFile={pinFile}
             tabBarOrder={tabBarOrder}
           />,
@@ -1170,9 +1321,9 @@ function Terminal(): React.JSX.Element | null {
 
       {/* Save confirmation dialog */}
       <Dialog
-        open={saveDialogFileId !== null}
+        open={saveDialogFileId !== null && !unsavedDiffDialogOpen}
         onOpenChange={(open) => {
-          if (!open) {
+          if (!open && !unsavedDiffDialogOpen) {
             handleSaveDialogCancel()
           }
         }}
@@ -1189,6 +1340,82 @@ function Terminal(): React.JSX.Element | null {
           <DialogFooter className="gap-2">
             <Button type="button" variant="outline" size="sm" onClick={handleSaveDialogCancel}>
               Cancel
+            </Button>
+            <Button type="button" variant="outline" size="sm" onClick={handleSaveDialogViewDiff}>
+              View Diff
+            </Button>
+            <Button type="button" variant="outline" size="sm" onClick={handleSaveDialogDiscard}>
+              Don&apos;t Save
+            </Button>
+            <Button type="button" size="sm" onClick={handleSaveDialogSave}>
+              Save
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={unsavedDiffDialogOpen}
+        onOpenChange={(open) => {
+          setUnsavedDiffDialogOpen(open)
+        }}
+      >
+        <DialogContent className="top-0 right-0 bottom-0 left-0 m-auto translate-x-0 translate-y-0 w-[calc(100vw-1rem)] max-w-[calc(100vw-1rem)] h-[calc(100vh-4rem)] flex flex-col p-4">
+          <DialogHeader>
+            <DialogTitle className="text-sm">
+              Unsaved Diff{unsavedDiffModel ? ` - ${unsavedDiffModel.fileLabel}` : ''}
+            </DialogTitle>
+            <DialogDescription className="text-xs">
+              Compare your current unsaved draft with the saved file on disk.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="min-h-0 flex-1 overflow-hidden rounded-md border border-border/60">
+            {unsavedDiffLoading ? (
+              <div className="h-full flex items-center justify-center text-xs text-muted-foreground">
+                Loading diff...
+              </div>
+            ) : unsavedDiffError ? (
+              <div className="h-full flex items-center justify-center px-4 text-xs text-destructive">
+                {unsavedDiffError}
+              </div>
+            ) : unsavedDiffModel ? (
+              <Suspense
+                fallback={
+                  <div className="h-full flex items-center justify-center text-xs text-muted-foreground">
+                    Loading diff view...
+                  </div>
+                }
+              >
+                <div className="h-full min-h-0 flex flex-col">
+                  <DiffViewer
+                    key={unsavedDiffModelKey ?? `unsaved-close:${unsavedDiffModel.fileLabel}`}
+                    modelKey={unsavedDiffModelKey ?? `unsaved-close:${unsavedDiffModel.fileLabel}`}
+                    originalContent={unsavedDiffModel.originalContent}
+                    modifiedContent={unsavedDiffModel.modifiedContent}
+                    language={unsavedDiffModel.language}
+                    filePath={saveDialogFile?.filePath ?? ''}
+                    relativePath={saveDialogFile?.relativePath ?? unsavedDiffModel.fileLabel}
+                    // Why: the unsaved-close modal is transient and space-constrained.
+                    // Inline diff keeps one wide code column so long lines remain readable.
+                    sideBySide={false}
+                    editable={false}
+                  />
+                </div>
+              </Suspense>
+            ) : (
+              <div className="h-full flex items-center justify-center text-xs text-muted-foreground">
+                No diff available.
+              </div>
+            )}
+          </div>
+          <DialogFooter className="mt-4 gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => setUnsavedDiffDialogOpen(false)}
+            >
+              Back
             </Button>
             <Button type="button" variant="outline" size="sm" onClick={handleSaveDialogDiscard}>
               Don&apos;t Save

--- a/src/renderer/src/components/editor/DiffViewer.tsx
+++ b/src/renderer/src/components/editor/DiffViewer.tsx
@@ -242,7 +242,7 @@ export default function DiffViewer({
   }, [sideBySide])
 
   return (
-    <div className="flex flex-col flex-1 min-h-0">
+    <div className="flex h-full flex-col flex-1 min-h-0">
       <div className="flex-1 min-h-0 relative">
         {popover && hasLineCommentAction && (
           <DiffCommentPopover

--- a/src/renderer/src/components/editor/editor-autosave.test.ts
+++ b/src/renderer/src/components/editor/editor-autosave.test.ts
@@ -4,7 +4,9 @@ import {
   canAutoSaveOpenFile,
   getOpenFilesForExternalFileChange,
   normalizeAutoSaveDelayMs,
+  ORCA_EDITOR_REQUEST_FILE_CLOSE_EVENT,
   ORCA_EDITOR_QUIESCE_FILE_SAVES_EVENT,
+  requestEditorFileClose,
   requestEditorFileSave,
   requestEditorSaveQuiesce
 } from './editor-autosave'
@@ -137,6 +139,21 @@ describe('requestEditorFileSave', () => {
     await expect(requestEditorFileSave({ fileId: 'file-1' })).rejects.toThrow(
       'Editor save controller is unavailable.'
     )
+  })
+})
+
+describe('requestEditorFileClose', () => {
+  it('dispatches a close request event with the file id', () => {
+    const listener = vi.fn()
+    window.addEventListener(ORCA_EDITOR_REQUEST_FILE_CLOSE_EVENT, listener as EventListener)
+    try {
+      requestEditorFileClose('file-1')
+      expect(listener).toHaveBeenCalledTimes(1)
+      const event = listener.mock.calls[0][0] as CustomEvent<{ fileId: string }>
+      expect(event.detail).toEqual({ fileId: 'file-1' })
+    } finally {
+      window.removeEventListener(ORCA_EDITOR_REQUEST_FILE_CLOSE_EVENT, listener as EventListener)
+    }
   })
 })
 

--- a/src/renderer/src/components/editor/editor-autosave.ts
+++ b/src/renderer/src/components/editor/editor-autosave.ts
@@ -13,6 +13,7 @@ export const ORCA_EDITOR_SAVE_FILE_EVENT = 'orca:editor-save-file'
 export const ORCA_EDITOR_SAVE_AND_CLOSE_EVENT = 'orca:save-and-close'
 export const ORCA_EDITOR_FILE_SAVED_EVENT = 'orca:editor-file-saved'
 export const ORCA_EDITOR_REQUEST_CMD_SAVE_EVENT = 'orca:editor-request-cmd-save'
+export const ORCA_EDITOR_REQUEST_FILE_CLOSE_EVENT = 'orca:editor-request-file-close'
 
 export type EditorPathMutationTarget = {
   worktreeId: string
@@ -41,6 +42,10 @@ export type EditorSaveFileDetail = EditorSaveFileTarget & {
 export type EditorFileSavedDetail = {
   fileId: string
   content: string
+}
+
+export type EditorRequestFileCloseDetail = {
+  fileId: string
 }
 
 export function canAutoSaveOpenFile(file: OpenFile): boolean {
@@ -129,6 +134,14 @@ export async function requestEditorFileSave(target: EditorSaveFileTarget): Promi
       reject(new Error('Editor save controller is unavailable.'))
     }
   })
+}
+
+export function requestEditorFileClose(fileId: string): void {
+  window.dispatchEvent(
+    new CustomEvent<EditorRequestFileCloseDetail>(ORCA_EDITOR_REQUEST_FILE_CLOSE_EVENT, {
+      detail: { fileId }
+    })
+  )
 }
 
 export function notifyEditorExternalFileChange(target: EditorPathMutationTarget): void {

--- a/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.ts
+++ b/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.ts
@@ -17,6 +17,7 @@ import { createUntitledMarkdownFile } from '../../lib/create-untitled-markdown'
 import { getConnectionId } from '../../lib/connection-context'
 import { extractIpcErrorMessage } from '../../lib/ipc-error'
 import { destroyPersistentWebview } from '../browser-pane/BrowserPane'
+import { requestEditorFileClose } from '../editor/editor-autosave'
 
 export type GroupEditorItem = OpenFile & { tabId: string }
 export type GroupBrowserItem = BrowserTabState & { tabId: string }
@@ -164,8 +165,17 @@ export function useTabGroupWorkspaceModel({
             item.contentType === 'conflict-review')
       )
       if (!otherReference) {
+        const file = useAppStore.getState().openFiles.find((candidate) => candidate.id === entityId)
+        if (file?.isDirty) {
+          // Why: split-group close actions bypass Terminal.tsx, but the unsaved
+          // confirmation + save/discard ordering must stay centralized there so
+          // tab close, bulk close, and window quit share one queueing flow.
+          requestEditorFileClose(entityId)
+          return false
+        }
         closeFile(entityId)
       }
+      return true
     },
     [closeFile, worktreeId]
   )
@@ -198,7 +208,10 @@ export function useTabGroupWorkspaceModel({
         destroyPersistentWebview(item.entityId)
         closeBrowserTab(item.entityId)
       } else {
-        closeEditorIfUnreferenced(item.entityId, item.id)
+        const canCloseTab = closeEditorIfUnreferenced(item.entityId, item.id)
+        if (!canCloseTab) {
+          return
+        }
         closeUnifiedTab(item.id)
       }
       if (!opts?.skipEmptyCheck) {
@@ -228,11 +241,14 @@ export function useTabGroupWorkspaceModel({
           destroyPersistentWebview(item.entityId)
           closeBrowserTab(item.entityId)
         } else {
-          closeEditorIfUnreferenced(item.entityId, item.id)
+          const canCloseTab = closeEditorIfUnreferenced(item.entityId, item.id)
+          if (canCloseTab) {
+            closeUnifiedTab(item.id)
+          }
         }
       }
     },
-    [closeBrowserTab, closeEditorIfUnreferenced, closeTab, groupTabs]
+    [closeBrowserTab, closeEditorIfUnreferenced, closeTab, closeUnifiedTab, groupTabs]
   )
 
   const activateTerminal = useCallback(

--- a/src/renderer/src/components/terminal/unsaved-close-queue.test.ts
+++ b/src/renderer/src/components/terminal/unsaved-close-queue.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { appendUniqueOpenFileIds, buildUnsavedDiffModelKey } from './unsaved-close-queue'
+
+describe('buildUnsavedDiffModelKey', () => {
+  it('includes file id and request id so each open gets a fresh model identity', () => {
+    expect(buildUnsavedDiffModelKey('/repo/file.ts', 1)).toBe('unsaved-close:/repo/file.ts:1')
+    expect(buildUnsavedDiffModelKey('/repo/file.ts', 2)).toBe('unsaved-close:/repo/file.ts:2')
+  })
+})
+
+describe('appendUniqueOpenFileIds', () => {
+  it('appends only open file ids and skips duplicates', () => {
+    const result = appendUniqueOpenFileIds(
+      ['a'],
+      ['a', 'b', 'missing', 'c', 'b'],
+      new Set(['a', 'b', 'c'])
+    )
+    expect(result).toEqual(['a', 'b', 'c'])
+  })
+
+  it('returns the original queue when no requested ids are provided', () => {
+    const queue = ['a']
+    expect(appendUniqueOpenFileIds(queue, [], new Set(['a']))).toEqual(['a'])
+  })
+})

--- a/src/renderer/src/components/terminal/unsaved-close-queue.ts
+++ b/src/renderer/src/components/terminal/unsaved-close-queue.ts
@@ -1,0 +1,24 @@
+export function buildUnsavedDiffModelKey(fileId: string, requestId: number): string {
+  return `unsaved-close:${fileId}:${requestId}`
+}
+
+export function appendUniqueOpenFileIds(
+  queue: string[],
+  requestedFileIds: string[],
+  openFileIds: ReadonlySet<string>
+): string[] {
+  if (requestedFileIds.length === 0) {
+    return queue
+  }
+  const nextQueue = [...queue]
+  for (const fileId of requestedFileIds) {
+    if (!openFileIds.has(fileId)) {
+      continue
+    }
+    if (nextQueue.includes(fileId)) {
+      continue
+    }
+    nextQueue.push(fileId)
+  }
+  return nextQueue
+}


### PR DESCRIPTION
## Summary

This PR introduces a brand-new "View Diff" feature for the unsaved changes prompt when closing a file. Previously, if users had unsaved changes and tried to close a file, they had to either blindly save, discard, or manually cancel to go look at their code again.

## Screenshots

<img width="516" height="133" alt="image" src="https://github.com/user-attachments/assets/4de7f2d7-40f4-4b6c-bc2e-8dfb68792082" />

<img width="508" height="880" alt="image" src="https://github.com/user-attachments/assets/50661ead-6ebc-463c-ae60-0719282a1c8c" />


## With this feature:
1. **View Diff Button:** Adds a new action to the unsaved close prompt.
2. **Inline Diff Viewer Modal:** When clicked, a full diff viewer opens comparing the current dirty draft against the canonical file on disk, utilizing the Monaco `DiffEditor` component.
3. **Integrated Actions:** The diff view modal itself includes full **Back**, **Don't Save**, and **Save** footer buttons, meaning users can confidently evaluate their changes and save directly from within the diff workflow.
4. **Queue Management (`unsaved-close-queue.ts`):** We now properly track and dequeue files during bulk closes (like quitting the window or closing all tabs) so you get sequentially prompted for each unsaved file exactly once, avoiding duplicate dialog overlaps.

Closes #1237 

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
