### PR TITLE
feat(terminal): auto-focus newly created terminal tab

### DIFF
--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -34,6 +34,7 @@ import BrowserPaneOverlayLayer from './browser-pane/BrowserPaneOverlayLayer'
 import { handleSwitchTab, handleSwitchTerminalTab } from '../hooks/ipc-tab-switch'
 import TabGroupSplitLayout from './tab-group/TabGroupSplitLayout'
 import { shouldAutoCreateInitialTerminal } from './terminal/initial-terminal'
+import { focusTerminalTabSurface } from '@/lib/focus-terminal-tab-surface'
 import {
   getEffectiveLayoutForWorktree as getEffectiveLayout,
   anyMountedWorktreeHasLayout as computeAnyMountedWorktreeHasLayout
@@ -400,6 +401,12 @@ function Terminal(): React.JSX.Element | null {
       const order = base.filter((id) => id !== newTab.id)
       order.push(newTab.id)
       setTabBarOrder(activeWorktreeId, order)
+      // Why: keyboard (Cmd/Ctrl+T) creation should leave the user ready to type
+      // in the new shell. Without an explicit focus call, the window-level
+      // keydown handler keeps focus on whatever surface dispatched the shortcut
+      // (often <body>), so the first keystroke is dropped instead of reaching
+      // the new xterm. Matches the "+" menu path in TabBar.tsx.
+      focusTerminalTabSurface(newTab.id)
     },
     [activeWorktreeId, createTab, setActiveTabType, setTabBarOrder]
   )

--- a/src/renderer/src/components/tab-bar/TabBar.tsx
+++ b/src/renderer/src/components/tab-bar/TabBar.tsx
@@ -3,7 +3,7 @@
  * to a file that was already ~398 code lines on main. The per-type render
  * branches share little beyond drag data, so consolidating them would cost
  * more clarity than the ~5 lines of bloat is worth. */
-import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { SortableContext } from '@dnd-kit/sortable'
 import { FilePlus, Globe, Plus, TerminalSquare } from 'lucide-react'
 import type {
@@ -24,6 +24,7 @@ import type { HoveredTabInsertion, TabDragItemData } from '../tab-group/useTabDr
 import { resolveTabIndicatorEdges } from '../tab-group/tab-insertion'
 import { getEditorDisplayLabel } from '@/components/editor/editor-labels'
 import { ShellIcon } from './shell-icons'
+import { focusTerminalTabSurface } from '@/lib/focus-terminal-tab-surface'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -224,27 +225,6 @@ function TabBarInner({
     }
     return indicators
   }, [activeIndicator, orderedItems])
-
-  const focusTerminalTabSurface = useCallback((tabId: string) => {
-    // Why: creating a terminal from the "+" menu is a two-step focus race:
-    // React must first mount the new TerminalPane/xterm, then Radix closes the
-    // menu. Even after suppressing trigger focus restore, the terminal's hidden
-    // textarea may not exist until the next paint. Double-rAF waits for that
-    // commit so the new tab, not the "+" button, ends up owning keyboard focus.
-    requestAnimationFrame(() => {
-      requestAnimationFrame(() => {
-        const scoped = document.querySelector(
-          `[data-terminal-tab-id="${tabId}"] .xterm-helper-textarea`
-        ) as HTMLElement | null
-        if (scoped) {
-          scoped.focus()
-          return
-        }
-        const fallback = document.querySelector('.xterm-helper-textarea') as HTMLElement | null
-        fallback?.focus()
-      })
-    })
-  }, [])
 
   // Horizontal wheel scrolling for the tab strip
   const tabStripRef = useRef<HTMLDivElement>(null)
@@ -508,10 +488,6 @@ function TabBarInner({
                     key={entry.shell}
                     onSelect={() => {
                       onNewTerminalWithShell(entry.shell)
-                      const newActiveTabId = useAppStore.getState().activeTabId
-                      if (newActiveTabId) {
-                        focusTerminalTabSurface(newActiveTabId)
-                      }
                     }}
                     className="gap-2 rounded-[7px] px-2 py-1.5 text-[12px] leading-5 font-medium"
                   >
@@ -528,10 +504,6 @@ function TabBarInner({
             <DropdownMenuItem
               onSelect={() => {
                 onNewTerminalTab()
-                const newActiveTabId = useAppStore.getState().activeTabId
-                if (newActiveTabId) {
-                  focusTerminalTabSurface(newActiveTabId)
-                }
               }}
               className="gap-2 rounded-[7px] px-2 py-1.5 text-[12px] leading-5 font-medium"
             >

--- a/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.ts
+++ b/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.ts
@@ -17,6 +17,7 @@ import { createUntitledMarkdownFile } from '../../lib/create-untitled-markdown'
 import { getConnectionId } from '../../lib/connection-context'
 import { extractIpcErrorMessage } from '../../lib/ipc-error'
 import { destroyPersistentWebview } from '../browser-pane/BrowserPane'
+import { focusTerminalTabSurface } from '../../lib/focus-terminal-tab-surface'
 
 export type GroupEditorItem = OpenFile & { tabId: string }
 export type GroupBrowserItem = BrowserTabState & { tabId: string }
@@ -438,11 +439,13 @@ export function useTabGroupWorkspaceModel({
         const terminal = createTab(worktreeId, groupId)
         setActiveTab(terminal.id)
         setActiveTabType('terminal')
+        focusTerminalTabSurface(terminal.id)
       },
       newTerminalWithShell: (shellOverride: string) => {
         const terminal = createTab(worktreeId, groupId, shellOverride)
         setActiveTab(terminal.id)
         setActiveTabType('terminal')
+        focusTerminalTabSurface(terminal.id)
       },
       pinFile,
       setTabColor,

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -17,6 +17,7 @@ import { handleSwitchTab, handleSwitchTerminalTab } from './ipc-tab-switch'
 import { dispatchClearModifierHints } from './useModifierHint'
 import { normalizeAgentStatusPayload } from '../../../shared/agent-status-types'
 import { isGitRepoKind } from '../../../shared/repo-kind'
+import { focusTerminalTabSurface } from '@/lib/focus-terminal-tab-surface'
 
 export { resolveZoomTarget } from './resolve-zoom-target'
 
@@ -476,6 +477,7 @@ export function useIpcEvents(): void {
         const order = base.filter((id) => id !== newTab.id)
         order.push(newTab.id)
         store.setTabBarOrder(worktreeId, order)
+        focusTerminalTabSurface(newTab.id)
       })
     )
 

--- a/src/renderer/src/lib/focus-terminal-tab-surface.ts
+++ b/src/renderer/src/lib/focus-terminal-tab-surface.ts
@@ -1,0 +1,22 @@
+/**
+ * Move keyboard focus into the xterm instance for a freshly-mounted terminal
+ * tab. Handles the two-step race where React must first mount the new
+ * TerminalPane/xterm before the hidden .xterm-helper-textarea exists —
+ * double-rAF waits for that commit so focus lands on the new tab instead of
+ * whatever surface (menu trigger, body, previous tab) just relinquished it.
+ */
+export function focusTerminalTabSurface(tabId: string): void {
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      const scoped = document.querySelector(
+        `[data-terminal-tab-id="${tabId}"] .xterm-helper-textarea`
+      ) as HTMLElement | null
+      if (scoped) {
+        scoped.focus()
+        return
+      }
+      const fallback = document.querySelector('.xterm-helper-textarea') as HTMLElement | null
+      fallback?.focus()
+    })
+  })
+}


### PR DESCRIPTION
## Summary
- Extract double-rAF xterm focus helper into `src/renderer/src/lib/focus-terminal-tab-surface.ts`
- Call it from every new-terminal entry point: Cmd/Ctrl+T (`Terminal.tsx`), IPC-triggered creation (`useIpcEvents.ts`), and per-group `newTerminalTab`/`newTerminalWithShell` (`useTabGroupWorkspaceModel.ts`)
- Previously only the "+" menu in `TabBar.tsx` focused the new tab, so keyboard/IPC-created terminals dropped the first keystroke

## Test plan
- [ ] Cmd/Ctrl+T → type immediately, keystrokes land in the new terminal
- [ ] "+" menu → New Terminal (incl. Windows per-shell variants) still focuses correctly
- [ ] IPC-triggered new terminal focuses the new tab
- [ ] Creating a terminal from the per-group command surface focuses it

Made with [Orca](https://github.com/stablyai/orca) 🐋
