### PR TITLE
chore: run internal skills hook before pnpm install

### DIFF
--- a/orca.yaml
+++ b/orca.yaml
@@ -1,7 +1,9 @@
 scripts:
   setup: |
-    pnpm install
     # Internal Stably dev setup: populates .claude/skills and .agents/skills
-    # from a private repo. Silent no-op for public contributors (env unset).
+    # from a private repo. Runs first (cheap, just symlinks) so skills are
+    # available before the long-running pnpm install below. Silent no-op for
+    # public contributors (env unset).
     [ -n "$ORCA_INTERNAL_DEV_SETUP" ] && [ -x "$ORCA_INTERNAL_DEV_SETUP" ] && \
       "$ORCA_INTERNAL_DEV_SETUP" "$ORCA_WORKTREE_PATH" || true
+    pnpm install


### PR DESCRIPTION
## Summary
Reorders \`orca.yaml scripts.setup\` so the internal skills hook runs **before** \`pnpm install\`.

### Why
- Skill install is basically free: symlinks + a few lines in \`.git/info/exclude\` (<1s).
- \`pnpm install\` on a fresh worktree can take minutes when the pnpm store is cold.
- Putting skills first means they're available immediately — devs don't have to wait for deps before AI agents can find skills in the new worktree.

### For public contributors
No behavior change. The \`|| true\` guard still silently no-ops when \`\$ORCA_INTERNAL_DEV_SETUP\` is unset, then \`pnpm install\` runs exactly as before.

## Test plan
- [x] Diff: hook moved above \`pnpm install\`; no other changes.
- [ ] Create new worktree via Orca app → skills appear near-instantly; \`pnpm install\` progresses independently.

Made with [Orca](https://github.com/stablyai/orca) 🐋
