### PR TITLE
feat(status-bar): show inline usage for inactive accounts in switcher

### DIFF
--- a/src/main/claude-accounts/service.ts
+++ b/src/main/claude-accounts/service.ts
@@ -110,12 +110,13 @@ export class ClaudeAccountService {
         lastAuthenticatedAt: now
       }
 
+      const outgoingAccountId = previousSettings.activeClaudeManagedAccountId
       this.store.updateSettings({
         claudeManagedAccounts: [...previousSettings.claudeManagedAccounts, account],
         activeClaudeManagedAccountId: account.id
       })
       await this.syncRuntimeAuthWithLivePtyGate()
-      await this.rateLimits.refreshForClaudeAccountChange()
+      await this.rateLimits.refreshForClaudeAccountChange(outgoingAccountId)
       return this.getSnapshot()
     } catch (error) {
       this.restoreClaudeSettings(previousSettings)
@@ -178,7 +179,12 @@ export class ClaudeAccountService {
     try {
       await this.syncRuntimeAuthWithLivePtyGate()
       await this.safeRemoveManagedAuth(accountId, account.managedAuthPath)
-      await this.rateLimits.refreshForClaudeAccountChange()
+      this.rateLimits.evictInactiveClaudeCache(accountId)
+      await this.rateLimits.refreshForClaudeAccountChange(
+        settings.activeClaudeManagedAccountId === accountId
+          ? settings.activeClaudeManagedAccountId
+          : undefined
+      )
       return this.getSnapshot()
     } catch (error) {
       this.restoreClaudeSettings(settings)
@@ -192,10 +198,11 @@ export class ClaudeAccountService {
       this.requireAccount(accountId)
     }
     const previousSettings = this.store.getSettings()
+    const outgoingAccountId = previousSettings.activeClaudeManagedAccountId
     this.store.updateSettings({ activeClaudeManagedAccountId: accountId })
     try {
       await this.syncRuntimeAuthWithLivePtyGate()
-      await this.rateLimits.refreshForClaudeAccountChange()
+      await this.rateLimits.refreshForClaudeAccountChange(outgoingAccountId)
       return this.getSnapshot()
     } catch (error) {
       this.restoreClaudeSettings(previousSettings)

--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -112,7 +112,8 @@ function createStore(settings: GlobalSettings) {
 
 function createRateLimits() {
   return {
-    refreshForCodexAccountChange: vi.fn().mockResolvedValue(undefined)
+    refreshForCodexAccountChange: vi.fn().mockResolvedValue(undefined),
+    evictInactiveCodexCache: vi.fn()
   }
 }
 
@@ -555,7 +556,8 @@ describe('CodexAccountService config sync', () => {
     const rateLimits = {
       refreshForCodexAccountChange: vi.fn(async () => {
         callOrder.push('refresh')
-      })
+      }),
+      evictInactiveCodexCache: vi.fn()
     }
     const runtimeHome = createRuntimeHome()
 

--- a/src/main/codex-accounts/service.ts
+++ b/src/main/codex-accounts/service.ts
@@ -108,7 +108,10 @@ export class CodexAccountService {
       this.safeSyncCanonicalConfigToManagedHomes()
       this.runtimeHome.syncForCurrentSelection()
 
-      await this.rateLimits.refreshForCodexAccountChange()
+      // Why: the new account becomes active, so the previous active account is
+      // now inactive and its last-known usage should be cached for the switcher.
+      const outgoingAccountId = settings.activeCodexManagedAccountId
+      await this.rateLimits.refreshForCodexAccountChange(outgoingAccountId)
       return this.getSnapshot()
     } catch (error) {
       this.safeRemoveManagedHome(managedHomePath)
@@ -171,7 +174,14 @@ export class CodexAccountService {
     this.runtimeHome.syncForCurrentSelection()
 
     this.safeRemoveManagedHome(account.managedHomePath)
-    await this.rateLimits.refreshForCodexAccountChange()
+    // Why: a removed account can no longer appear in the switcher dropdown,
+    // so purge its cached usage to avoid stale entries.
+    this.rateLimits.evictInactiveCodexCache(accountId)
+    await this.rateLimits.refreshForCodexAccountChange(
+      settings.activeCodexManagedAccountId === accountId
+        ? settings.activeCodexManagedAccountId
+        : undefined
+    )
     return this.getSnapshot()
   }
 
@@ -180,13 +190,16 @@ export class CodexAccountService {
       this.requireAccount(accountId)
     }
 
+    const previousSettings = this.store.getSettings()
+    const outgoingAccountId = previousSettings.activeCodexManagedAccountId
+
     this.store.updateSettings({
       activeCodexManagedAccountId: accountId
     })
     this.safeSyncCanonicalConfigToManagedHomes()
     this.runtimeHome.syncForCurrentSelection()
 
-    await this.rateLimits.refreshForCodexAccountChange()
+    await this.rateLimits.refreshForCodexAccountChange(outgoingAccountId)
     return this.getSnapshot()
   }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -333,6 +333,18 @@ app.whenReady().then(async () => {
   rateLimits.setCodexHomePathResolver(() => codexRuntimeHome!.prepareForRateLimitFetch())
   rateLimits.setClaudeAuthPreparationResolver(() => claudeRuntimeAuth!.prepareForRateLimitFetch())
   rateLimits.setSettingsResolver(() => store!.getSettings())
+  rateLimits.setInactiveClaudeAccountsResolver(() => {
+    const settings = store!.getSettings()
+    return settings.claudeManagedAccounts
+      .filter((account) => account.id !== settings.activeClaudeManagedAccountId)
+      .map((account) => ({ id: account.id, managedAuthPath: account.managedAuthPath }))
+  })
+  rateLimits.setInactiveCodexAccountsResolver(() => {
+    const settings = store!.getSettings()
+    return settings.codexManagedAccounts
+      .filter((account) => account.id !== settings.activeCodexManagedAccountId)
+      .map((account) => ({ id: account.id, managedHomePath: account.managedHomePath }))
+  })
   runtime = new OrcaRuntimeService(store, stats)
   starNag = new StarNagService(store, stats)
   starNag.start()

--- a/src/main/ipc/rate-limits.ts
+++ b/src/main/ipc/rate-limits.ts
@@ -7,4 +7,10 @@ export function registerRateLimitHandlers(rateLimits: RateLimitService): void {
   ipcMain.handle('rateLimits:setPollingInterval', (_event, ms: number) =>
     rateLimits.setPollingInterval(ms)
   )
+  ipcMain.handle('rateLimits:fetchInactiveClaudeAccounts', () =>
+    rateLimits.fetchInactiveClaudeAccountsOnOpen()
+  )
+  ipcMain.handle('rateLimits:fetchInactiveCodexAccounts', () =>
+    rateLimits.fetchInactiveCodexAccountsOnOpen()
+  )
 }

--- a/src/main/rate-limits/claude-fetcher.ts
+++ b/src/main/rate-limits/claude-fetcher.ts
@@ -6,6 +6,7 @@ import { net, session } from 'electron'
 import type { ProviderRateLimits, RateLimitWindow } from '../../shared/rate-limit-types'
 import { fetchViaPty } from './claude-pty'
 import type { ClaudeRuntimeAuthPreparation } from '../claude-accounts/runtime-auth-service'
+import { readManagedClaudeKeychainCredentials } from '../claude-accounts/keychain'
 
 const OAUTH_USAGE_URL = 'https://api.anthropic.com/api/oauth/usage'
 const OAUTH_BETA_HEADER = 'oauth-2025-04-20'
@@ -75,6 +76,25 @@ type KeychainCredentials = {
   }
 }
 
+// Why: factored out so both the active-account Keychain reader and the
+// managed-account reader share the same JSON parsing + expiry check.
+function parseOAuthTokenFromCredentialsJson(raw: string): string | null {
+  try {
+    const parsed = JSON.parse(raw) as KeychainCredentials
+    const token = parsed?.claudeAiOauth?.accessToken
+    if (!token || typeof token !== 'string') {
+      return null
+    }
+    const expiresAt = parsed.claudeAiOauth?.expiresAt
+    if (typeof expiresAt === 'number' && expiresAt < Date.now()) {
+      return null
+    }
+    return token
+  } catch {
+    return null
+  }
+}
+
 /**
  * Read OAuth token from macOS Keychain.
  * Why: Claude Code v2.x+ stores OAuth credentials in the macOS Keychain
@@ -103,24 +123,7 @@ async function readFromKeychain(): Promise<string | null> {
           resolve(null)
           return
         }
-        try {
-          const parsed = JSON.parse(stdout.trim()) as KeychainCredentials
-          const token = parsed?.claudeAiOauth?.accessToken
-          if (!token || typeof token !== 'string') {
-            resolve(null)
-            return
-          }
-
-          const expiresAt = parsed.claudeAiOauth?.expiresAt
-          if (typeof expiresAt === 'number' && expiresAt < Date.now()) {
-            resolve(null)
-            return
-          }
-
-          resolve(token)
-        } catch {
-          resolve(null)
-        }
+        resolve(parseOAuthTokenFromCredentialsJson(stdout.trim()))
       }
     )
   })
@@ -313,4 +316,51 @@ export async function fetchClaudeRateLimits(options?: {
     error: 'No subscription plan — API key billing',
     status: 'unavailable'
   }
+}
+
+// ---------------------------------------------------------------------------
+// Managed account usage (inactive accounts — fetch-on-open)
+// ---------------------------------------------------------------------------
+
+export type InactiveClaudeAccountInfo = {
+  id: string
+  managedAuthPath: string
+}
+
+// Why: reads an inactive account's OAuth token directly from its managed
+// storage without materializing credentials into the shared runtime location.
+// Using ClaudeRuntimeAuthService would overwrite the active account's auth.
+async function readManagedOAuthToken(account: InactiveClaudeAccountInfo): Promise<string | null> {
+  try {
+    if (process.platform === 'darwin') {
+      const raw = await readManagedClaudeKeychainCredentials(account.id)
+      if (raw) {
+        return parseOAuthTokenFromCredentialsJson(raw)
+      }
+      return null
+    }
+    return await readFromCredentialsFile(account.managedAuthPath)
+  } catch {
+    return null
+  }
+}
+
+export async function fetchManagedAccountUsage(
+  account: InactiveClaudeAccountInfo
+): Promise<ProviderRateLimits> {
+  const token = await readManagedOAuthToken(account)
+  if (!token) {
+    return {
+      provider: 'claude',
+      session: null,
+      weekly: null,
+      updatedAt: Date.now(),
+      error: 'No credentials',
+      status: 'error'
+    }
+  }
+  // Why: PTY fallback is intentionally omitted for inactive accounts. The PTY
+  // path materializes credentials via ClaudeRuntimeAuthService, which would
+  // interfere with the active account's auth state.
+  return fetchViaOAuth(token)
 }

--- a/src/main/rate-limits/service.ts
+++ b/src/main/rate-limits/service.ts
@@ -2,12 +2,22 @@
 handling, account-switch fetch semantics, and renderer push coordination so the
 fetch ordering rules stay in one place. */
 import type { BrowserWindow } from 'electron'
-import type { RateLimitState, ProviderRateLimits } from '../../shared/rate-limit-types'
-import { fetchClaudeRateLimits } from './claude-fetcher'
+import type {
+  RateLimitState,
+  ProviderRateLimits,
+  InactiveAccountUsage
+} from '../../shared/rate-limit-types'
+import { fetchClaudeRateLimits, fetchManagedAccountUsage } from './claude-fetcher'
+import type { InactiveClaudeAccountInfo } from './claude-fetcher'
 import { fetchCodexRateLimits } from './codex-fetcher'
 import type { ClaudeRuntimeAuthPreparation } from '../claude-accounts/runtime-auth-service'
 import { fetchGeminiRateLimits } from './gemini-usage-fetcher'
 import { fetchOpenCodeGoRateLimits } from './opencode-go-usage-fetcher'
+
+export type InactiveCodexAccountInfo = {
+  id: string
+  managedHomePath: string
+}
 
 // Why: quota state does not need near-real-time polling, and a less aggressive
 // default reduces avoidable Claude /usage pressure. We intentionally use a
@@ -15,9 +25,19 @@ import { fetchOpenCodeGoRateLimits } from './opencode-go-usage-fetcher'
 const DEFAULT_POLL_MS = 5 * 60 * 1000 // 5 minutes
 const MIN_REFETCH_MS = 30 * 1000 // 30 seconds — debounce rapid refresh requests
 const STALE_THRESHOLD_MS = 10 * 60 * 1000 // 10 minutes — after this, stale data is dropped
+const INACTIVE_FETCH_DEBOUNCE_MS = 60 * 1000 // 60 seconds — debounce fetch-on-open
+
+// Why: the internal state only tracks claude and codex. The inactiveClaudeAccounts
+// array is derived from the cache on demand in getState() and pushToRenderer().
+type InternalRateLimitState = {
+  claude: ProviderRateLimits | null
+  codex: ProviderRateLimits | null
+  gemini: ProviderRateLimits | null
+  opencodeGo: ProviderRateLimits | null
+}
 
 export class RateLimitService {
-  private state: RateLimitState = { claude: null, codex: null, gemini: null, opencodeGo: null }
+  private state: InternalRateLimitState = { claude: null, codex: null, gemini: null, opencodeGo: null }
   private pollInterval: number = DEFAULT_POLL_MS
   private timer: ReturnType<typeof setInterval> | null = null
   private lastFetchAt = 0
@@ -41,6 +61,14 @@ export class RateLimitService {
         geminiCliOAuthEnabled?: boolean
       })
     | null = null
+  private inactiveClaudeAccountsResolver: (() => InactiveClaudeAccountInfo[]) | null = null
+  private inactiveCodexAccountsResolver: (() => InactiveCodexAccountInfo[]) | null = null
+  private inactiveClaudeCache = new Map<string, ProviderRateLimits>()
+  private inactiveCodexCache = new Map<string, ProviderRateLimits>()
+  private inactiveClaudeFetching = new Set<string>()
+  private inactiveCodexFetching = new Set<string>()
+  private lastInactiveClaudeFetchAt = 0
+  private lastInactiveCodexFetchAt = 0
 
   constructor() {}
 
@@ -61,6 +89,15 @@ export class RateLimitService {
   ): void {
     this.settingsResolver = resolver
   }
+
+  setInactiveClaudeAccountsResolver(resolver: () => InactiveClaudeAccountInfo[]): void {
+    this.inactiveClaudeAccountsResolver = resolver
+  }
+
+  setInactiveCodexAccountsResolver(resolver: () => InactiveCodexAccountInfo[]): void {
+    this.inactiveCodexAccountsResolver = resolver
+  }
+
   attach(mainWindow: BrowserWindow): void {
     this.detachWindowListeners?.()
     this.mainWindow = mainWindow
@@ -98,7 +135,17 @@ export class RateLimitService {
   }
 
   getState(): RateLimitState {
-    return this.state
+    return {
+      ...this.state,
+      inactiveClaudeAccounts: this.buildInactiveArray(
+        this.inactiveClaudeCache,
+        this.inactiveClaudeFetching
+      ),
+      inactiveCodexAccounts: this.buildInactiveArray(
+        this.inactiveCodexCache,
+        this.inactiveCodexFetching
+      )
+    }
   }
 
   async refresh(): Promise<RateLimitState> {
@@ -107,11 +154,15 @@ export class RateLimitService {
     // broken after wake/focus transitions because the click can no-op even
     // though the user is asking for a fresh read right now.
     await this.fetchAll({ force: true })
-    return this.state
+    return this.getState()
   }
 
-  async refreshForCodexAccountChange(): Promise<RateLimitState> {
+  async refreshForCodexAccountChange(outgoingAccountId?: string | null): Promise<RateLimitState> {
+    if (outgoingAccountId && this.state.codex?.session) {
+      this.inactiveCodexCache.set(outgoingAccountId, this.state.codex)
+    }
     this.codexFetchGeneration += 1
+    this.lastInactiveCodexFetchAt = 0
     // Why: switching the selected Codex account must immediately clear the old
     // Codex quota view. Keeping stale values visible would show the previous
     // account's limits under the newly selected identity until the next poll.
@@ -120,17 +171,97 @@ export class RateLimitService {
       codex: this.withFetchingStatus(null, 'codex')
     })
     await this.fetchCodexOnly({ force: true })
-    return this.state
+    return this.getState()
   }
 
-  async refreshForClaudeAccountChange(): Promise<RateLimitState> {
+  async refreshForClaudeAccountChange(outgoingAccountId?: string | null): Promise<RateLimitState> {
+    // Why: snapshot the outgoing account's usage before clearing it so the
+    // inline usage bars in the switcher can show last-known data immediately.
+    if (outgoingAccountId && this.state.claude?.session) {
+      this.inactiveClaudeCache.set(outgoingAccountId, this.state.claude)
+    }
     this.claudeFetchGeneration += 1
+    this.lastInactiveClaudeFetchAt = 0
     this.updateState({
       ...this.state,
       claude: this.withFetchingStatus(null, 'claude')
     })
     await this.fetchClaudeOnly({ force: true })
-    return this.state
+    return this.getState()
+  }
+
+  async fetchInactiveClaudeAccountsOnOpen(): Promise<void> {
+    if (Date.now() - this.lastInactiveClaudeFetchAt < INACTIVE_FETCH_DEBOUNCE_MS) {
+      return
+    }
+    const accounts = this.inactiveClaudeAccountsResolver?.() ?? []
+    if (accounts.length === 0) {
+      return
+    }
+
+    for (const account of accounts) {
+      this.inactiveClaudeFetching.add(account.id)
+    }
+    this.pushToRenderer()
+
+    for (const account of accounts) {
+      try {
+        const fresh = await fetchManagedAccountUsage(account)
+        const cached = this.inactiveClaudeCache.get(account.id) ?? null
+        this.inactiveClaudeCache.set(account.id, this.applyStalePolicy(fresh, cached))
+      } catch {
+        // Why: per-account try/catch prevents one Keychain rejection or
+        // network error from aborting the remaining accounts in the batch.
+      }
+      this.inactiveClaudeFetching.delete(account.id)
+      this.pushToRenderer()
+    }
+
+    this.lastInactiveClaudeFetchAt = Date.now()
+  }
+
+  async fetchInactiveCodexAccountsOnOpen(): Promise<void> {
+    if (Date.now() - this.lastInactiveCodexFetchAt < INACTIVE_FETCH_DEBOUNCE_MS) {
+      return
+    }
+    const accounts = this.inactiveCodexAccountsResolver?.() ?? []
+    if (accounts.length === 0) {
+      return
+    }
+
+    for (const account of accounts) {
+      this.inactiveCodexFetching.add(account.id)
+    }
+    this.pushToRenderer()
+
+    for (const account of accounts) {
+      try {
+        // Why: fetchCodexRateLimits already accepts codexHomePath, so we can
+        // point it at the managed account's home directory directly without
+        // materializing credentials into the shared runtime location.
+        const fresh = await fetchCodexRateLimits({ codexHomePath: account.managedHomePath })
+        const cached = this.inactiveCodexCache.get(account.id) ?? null
+        this.inactiveCodexCache.set(account.id, this.applyStalePolicy(fresh, cached))
+      } catch {
+        // Why: per-account try/catch prevents one failure from aborting the batch.
+      }
+      this.inactiveCodexFetching.delete(account.id)
+      this.pushToRenderer()
+    }
+
+    this.lastInactiveCodexFetchAt = Date.now()
+  }
+
+  evictInactiveClaudeCache(accountId: string): void {
+    this.inactiveClaudeCache.delete(accountId)
+    this.inactiveClaudeFetching.delete(accountId)
+    this.pushToRenderer()
+  }
+
+  evictInactiveCodexCache(accountId: string): void {
+    this.inactiveCodexCache.delete(accountId)
+    this.inactiveCodexFetching.delete(accountId)
+    this.pushToRenderer()
   }
 
   setPollingInterval(ms: number): void {
@@ -587,7 +718,35 @@ export class RateLimitService {
     }
   }
 
-  private updateState(next: RateLimitState): void {
+  private buildInactiveArray(
+    cache: Map<string, ProviderRateLimits>,
+    fetching: Set<string>
+  ): InactiveAccountUsage[] {
+    const result: InactiveAccountUsage[] = []
+    for (const [accountId, limits] of cache) {
+      result.push({
+        accountId,
+        claude: limits,
+        updatedAt: limits.updatedAt,
+        isFetching: fetching.has(accountId)
+      })
+    }
+    // Why: include accounts that are fetching but have no cache yet so the
+    // renderer can show a loading indicator for newly added accounts.
+    for (const accountId of fetching) {
+      if (!cache.has(accountId)) {
+        result.push({
+          accountId,
+          claude: null,
+          updatedAt: 0,
+          isFetching: true
+        })
+      }
+    }
+    return result
+  }
+
+  private updateState(next: InternalRateLimitState): void {
     this.state = next
     this.pushToRenderer()
   }
@@ -596,6 +755,6 @@ export class RateLimitService {
     if (!this.mainWindow || this.mainWindow.isDestroyed()) {
       return
     }
-    this.mainWindow.webContents.send('rateLimits:update', this.state)
+    this.mainWindow.webContents.send('rateLimits:update', this.getState())
   }
 }

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -829,6 +829,8 @@ export type PreloadApi = {
     get: () => Promise<RateLimitState>
     refresh: () => Promise<RateLimitState>
     setPollingInterval: (ms: number) => Promise<void>
+    fetchInactiveClaudeAccounts: () => Promise<void>
+    fetchInactiveCodexAccounts: () => Promise<void>
     onUpdate: (callback: (state: RateLimitState) => void) => () => void
   }
   ssh: {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1579,6 +1579,10 @@ const api = {
     refresh: (): Promise<RateLimitState> => ipcRenderer.invoke('rateLimits:refresh'),
     setPollingInterval: (ms: number): Promise<void> =>
       ipcRenderer.invoke('rateLimits:setPollingInterval', ms),
+    fetchInactiveClaudeAccounts: (): Promise<void> =>
+      ipcRenderer.invoke('rateLimits:fetchInactiveClaudeAccounts'),
+    fetchInactiveCodexAccounts: (): Promise<void> =>
+      ipcRenderer.invoke('rateLimits:fetchInactiveCodexAccounts'),
     onUpdate: (callback: (state: RateLimitState) => void): (() => void) => {
       const listener = (_event: Electron.IpcRendererEvent, state: RateLimitState) => callback(state)
       ipcRenderer.on('rateLimits:update', listener)

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -27,7 +27,7 @@ import type {
   CodexRateLimitAccountsState
 } from '../../../../shared/types'
 import type { ProviderRateLimits, RateLimitWindow } from '../../../../shared/rate-limit-types'
-import { ProviderIcon, ProviderPanel } from './tooltip'
+import { ProviderIcon, ProviderPanel, barColor } from './tooltip'
 import { ClaudeIcon, GeminiIcon, OpenAIIcon, OpenCodeGoIcon } from './icons'
 import { formatWindowLabel } from '@/lib/window-label-formatter'
 import { markLiveCodexSessionsForRestart } from '@/lib/codex-session-restart'
@@ -65,6 +65,8 @@ function ClaudeSwitcherMenu({
   const openSettingsPage = useAppStore((s) => s.openSettingsPage)
   const openSettingsTarget = useAppStore((s) => s.openSettingsTarget)
   const fetchSettings = useAppStore((s) => s.fetchSettings)
+  const fetchInactiveClaudeAccountUsage = useAppStore((s) => s.fetchInactiveClaudeAccountUsage)
+  const inactiveClaudeAccounts = useAppStore((s) => s.rateLimits.inactiveClaudeAccounts)
   const claudeAccountSyncKey = useAppStore((s) => {
     const settings = s.settings
     if (!settings) {
@@ -89,6 +91,12 @@ function ClaudeSwitcherMenu({
       setAccountsExpanded(false)
     }
   }, [open])
+
+  useEffect(() => {
+    if (accountsExpanded) {
+      void fetchInactiveClaudeAccountUsage()
+    }
+  }, [accountsExpanded, fetchInactiveClaudeAccountUsage])
 
   const handleSelectAccount = async (accountId: string | null): Promise<void> => {
     if (isSwitching) {
@@ -155,18 +163,36 @@ function ClaudeSwitcherMenu({
             {availableSwitchTargets.length === 0 ? (
               <div className="px-2 py-1.5 text-[11px] text-muted-foreground">No other accounts</div>
             ) : null}
-            {availableSwitchTargets.map((target) => (
-              <DropdownMenuItem
-                key={target.id ?? 'system'}
-                disabled={isSwitching}
-                onSelect={(event) => {
-                  event.preventDefault()
-                  void handleSelectAccount(target.id)
-                }}
-              >
-                <span className="max-w-[220px] truncate">{target.label}</span>
-              </DropdownMenuItem>
-            ))}
+            {availableSwitchTargets.map((target) => {
+              const inactiveUsage = target.id
+                ? inactiveClaudeAccounts.find((a) => a.accountId === target.id)
+                : null
+
+              return (
+                <DropdownMenuItem
+                  key={target.id ?? 'system'}
+                  disabled={isSwitching}
+                  onSelect={(event) => {
+                    event.preventDefault()
+                    void handleSelectAccount(target.id)
+                  }}
+                >
+                  <div className="flex w-full flex-col gap-0.5">
+                    <span className="max-w-[220px] truncate">{target.label}</span>
+                    {inactiveUsage?.isFetching && !inactiveUsage.claude ? (
+                      <span className="text-[10px] text-muted-foreground animate-pulse">
+                        Loading…
+                      </span>
+                    ) : inactiveUsage?.claude ? (
+                      <InlineUsageBars
+                        limits={inactiveUsage.claude}
+                        isFetching={inactiveUsage.isFetching}
+                      />
+                    ) : null}
+                  </div>
+                </DropdownMenuItem>
+              )
+            })}
           </div>
           <div className="px-2 py-1.5 text-[10px] leading-4 text-muted-foreground">
             Restart live Claude terminals before continuing old conversations after switching.
@@ -201,6 +227,57 @@ function MiniBar({ leftPct }: { leftPct: number }): React.JSX.Element {
         className="h-full rounded-full transition-all duration-300 bg-muted-foreground/40"
         style={{ width: `${Math.min(100, Math.max(0, leftPct))}%` }}
       />
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Inline usage bars (compact bars for inactive accounts in the switcher)
+// ---------------------------------------------------------------------------
+
+function InlineUsageBars({
+  limits,
+  isFetching
+}: {
+  limits: ProviderRateLimits
+  isFetching: boolean
+}): React.JSX.Element {
+  const sessionLeft = limits.session
+    ? Math.max(0, Math.round(100 - limits.session.usedPercent))
+    : null
+  const weeklyLeft = limits.weekly ? Math.max(0, Math.round(100 - limits.weekly.usedPercent)) : null
+
+  return (
+    <div className={`flex w-full items-center gap-2 ${isFetching ? 'animate-pulse' : ''}`}>
+      {sessionLeft !== null && (
+        <div className="flex flex-1 items-center gap-1">
+          <div className="h-[4px] flex-1 overflow-hidden rounded-full bg-muted">
+            <div
+              className={`h-full rounded-full ${barColor(sessionLeft)}`}
+              style={{ width: `${sessionLeft}%` }}
+            />
+          </div>
+          <span className="text-[10px] tabular-nums text-muted-foreground shrink-0">
+            {sessionLeft}% 5h
+          </span>
+        </div>
+      )}
+      {weeklyLeft !== null && (
+        <div className="flex flex-1 items-center gap-1">
+          <div className="h-[4px] flex-1 overflow-hidden rounded-full bg-muted">
+            <div
+              className={`h-full rounded-full ${barColor(weeklyLeft)}`}
+              style={{ width: `${weeklyLeft}%` }}
+            />
+          </div>
+          <span className="text-[10px] tabular-nums text-muted-foreground shrink-0">
+            {weeklyLeft}% wk
+          </span>
+        </div>
+      )}
+      {limits.status === 'error' && !limits.session && !limits.weekly && (
+        <span className="text-[10px] text-muted-foreground">Sign in to see usage</span>
+      )}
     </div>
   )
 }
@@ -336,6 +413,8 @@ function CodexSwitcherMenu({
   const openSettingsPage = useAppStore((s) => s.openSettingsPage)
   const openSettingsTarget = useAppStore((s) => s.openSettingsTarget)
   const fetchSettings = useAppStore((s) => s.fetchSettings)
+  const fetchInactiveCodexAccountUsage = useAppStore((s) => s.fetchInactiveCodexAccountUsage)
+  const inactiveCodexAccounts = useAppStore((s) => s.rateLimits.inactiveCodexAccounts)
   const tabsByWorktree = useAppStore((s) => s.tabsByWorktree)
   const ptyIdsByTabId = useAppStore((s) => s.ptyIdsByTabId)
   const codexRestartNoticeByPtyId = useAppStore((s) => s.codexRestartNoticeByPtyId)
@@ -396,6 +475,12 @@ function CodexSwitcherMenu({
       setAccountsExpanded(false)
     }
   }, [open])
+
+  useEffect(() => {
+    if (accountsExpanded) {
+      void fetchInactiveCodexAccountUsage()
+    }
+  }, [accountsExpanded, fetchInactiveCodexAccountUsage])
 
   const activeAccountLabel =
     accounts.activeAccountId === null
@@ -461,22 +546,40 @@ function CodexSwitcherMenu({
             {availableSwitchTargets.length === 0 ? (
               <div className="px-2 py-1.5 text-[11px] text-muted-foreground">No other accounts</div>
             ) : null}
-            {availableSwitchTargets.map((target) => (
-              <DropdownMenuItem
-                key={target.id ?? 'system'}
-                onSelect={(event) => {
-                  // Why: account switching may need an immediate follow-up
-                  // restart action for live Codex tabs. Prevent the menu from
-                  // auto-closing so that prompt can stay within the same
-                  // account-switcher interaction instead of jumping elsewhere.
-                  event.preventDefault()
-                  void handleSelectAccount(target.id)
-                }}
-                disabled={isSwitching}
-              >
-                <span className="truncate">{target.label}</span>
-              </DropdownMenuItem>
-            ))}
+            {availableSwitchTargets.map((target) => {
+              const inactiveUsage = target.id
+                ? inactiveCodexAccounts.find((a) => a.accountId === target.id)
+                : null
+
+              return (
+                <DropdownMenuItem
+                  key={target.id ?? 'system'}
+                  onSelect={(event) => {
+                    // Why: account switching may need an immediate follow-up
+                    // restart action for live Codex tabs. Prevent the menu from
+                    // auto-closing so that prompt can stay within the same
+                    // account-switcher interaction instead of jumping elsewhere.
+                    event.preventDefault()
+                    void handleSelectAccount(target.id)
+                  }}
+                  disabled={isSwitching}
+                >
+                  <div className="flex w-full flex-col gap-0.5">
+                    <span className="truncate">{target.label}</span>
+                    {inactiveUsage?.isFetching && !inactiveUsage.claude ? (
+                      <span className="text-[10px] text-muted-foreground animate-pulse">
+                        Loading…
+                      </span>
+                    ) : inactiveUsage?.claude ? (
+                      <InlineUsageBars
+                        limits={inactiveUsage.claude}
+                        isFetching={inactiveUsage.isFetching}
+                      />
+                    ) : null}
+                  </div>
+                </DropdownMenuItem>
+              )
+            })}
           </div>
         </div>
       ) : null}

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -180,9 +180,7 @@ function ClaudeSwitcherMenu({
                   <div className="flex w-full flex-col gap-0.5">
                     <span className="max-w-[220px] truncate">{target.label}</span>
                     {inactiveUsage?.isFetching && !inactiveUsage.claude ? (
-                      <span className="text-[10px] text-muted-foreground animate-pulse">
-                        Loading…
-                      </span>
+                      <InlineUsageSkeleton />
                     ) : inactiveUsage?.claude ? (
                       <InlineUsageBars
                         limits={inactiveUsage.claude}
@@ -278,6 +276,15 @@ function InlineUsageBars({
       {limits.status === 'error' && !limits.session && !limits.weekly && (
         <span className="text-[10px] text-muted-foreground">Sign in to see usage</span>
       )}
+    </div>
+  )
+}
+
+function InlineUsageSkeleton(): React.JSX.Element {
+  return (
+    <div className="flex w-full animate-pulse items-center gap-2">
+      <div className="h-[4px] flex-1 rounded-full bg-muted" />
+      <div className="h-[4px] flex-1 rounded-full bg-muted" />
     </div>
   )
 }
@@ -567,9 +574,7 @@ function CodexSwitcherMenu({
                   <div className="flex w-full flex-col gap-0.5">
                     <span className="truncate">{target.label}</span>
                     {inactiveUsage?.isFetching && !inactiveUsage.claude ? (
-                      <span className="text-[10px] text-muted-foreground animate-pulse">
-                        Loading…
-                      </span>
+                      <InlineUsageSkeleton />
                     ) : inactiveUsage?.claude ? (
                       <InlineUsageBars
                         limits={inactiveUsage.claude}

--- a/src/renderer/src/components/status-bar/tooltip.tsx
+++ b/src/renderer/src/components/status-bar/tooltip.tsx
@@ -108,7 +108,7 @@ export function getWindowSections(
 
 // Why: color-coded by remaining capacity so users can quickly gauge urgency.
 // Green = comfortable (>40% left), yellow = caution (20-40%), red = critical (<20%).
-function barColor(leftPct: number): string {
+export function barColor(leftPct: number): string {
   if (leftPct > 40) {
     return 'bg-green-500'
   }

--- a/src/renderer/src/store/slices/rate-limits.ts
+++ b/src/renderer/src/store/slices/rate-limits.ts
@@ -6,11 +6,13 @@ export type RateLimitSlice = {
   rateLimits: RateLimitState
   fetchRateLimits: () => Promise<void>
   refreshRateLimits: () => Promise<void>
+  fetchInactiveClaudeAccountUsage: () => Promise<void>
+  fetchInactiveCodexAccountUsage: () => Promise<void>
   setRateLimitsFromPush: (state: RateLimitState) => void
 }
 
 export const createRateLimitSlice: StateCreator<AppState, [], [], RateLimitSlice> = (set) => ({
-  rateLimits: { claude: null, codex: null, gemini: null, opencodeGo: null },
+  rateLimits: { claude: null, codex: null, gemini: null, opencodeGo: null, inactiveClaudeAccounts: [], inactiveCodexAccounts: [] },
 
   fetchRateLimits: async () => {
     try {
@@ -27,6 +29,22 @@ export const createRateLimitSlice: StateCreator<AppState, [], [], RateLimitSlice
       set({ rateLimits: state })
     } catch (error) {
       console.error('Failed to refresh rate limits:', error)
+    }
+  },
+
+  fetchInactiveClaudeAccountUsage: async () => {
+    try {
+      await window.api.rateLimits.fetchInactiveClaudeAccounts()
+    } catch (error) {
+      console.error('Failed to fetch inactive Claude account usage:', error)
+    }
+  },
+
+  fetchInactiveCodexAccountUsage: async () => {
+    try {
+      await window.api.rateLimits.fetchInactiveCodexAccounts()
+    } catch (error) {
+      console.error('Failed to fetch inactive Codex account usage:', error)
     }
   },
 

--- a/src/shared/rate-limit-types.ts
+++ b/src/shared/rate-limit-types.ts
@@ -32,9 +32,18 @@ export type ProviderRateLimits = {
   status: ProviderRateLimitStatus
 }
 
+export type InactiveAccountUsage = {
+  accountId: string
+  claude: ProviderRateLimits | null
+  updatedAt: number
+  isFetching: boolean
+}
+
 export type RateLimitState = {
   claude: ProviderRateLimits | null
   codex: ProviderRateLimits | null
   gemini: ProviderRateLimits | null
   opencodeGo: ProviderRateLimits | null
+  inactiveClaudeAccounts: InactiveAccountUsage[]
+  inactiveCodexAccounts: InactiveAccountUsage[]
 }


### PR DESCRIPTION
## Summary
- Adds inline session and weekly usage progress bars next to each inactive account in the Claude and Codex account switcher dropdowns, so users can see remaining capacity before switching
- Fetches usage on expand ("Switch to" section) with a 60-second debounce; caches the active account's usage on switch-away so it's available instantly as an inactive entry
- Supports both Claude (reads OAuth credentials from Keychain/file) and Codex (reads from managed home path) inactive accounts

Closes #1248

## Test plan
- [ ] Open the Codex account switcher dropdown and expand "Switch to"
- [ ] Verify usage bars appear next to each inactive account (session % and weekly %)
- [ ] Verify bars animate with pulse while fetching, then settle
- [ ] Verify bars span the full width of the dropdown item
- [ ] Switch accounts and verify the previously-active account now shows cached usage
- [ ] Collapse and re-expand "Switch to" within 60s — should show cached data without re-fetching
- [ ] Wait >60s and re-expand — should trigger a fresh fetch
- [ ] Remove an account and verify its cached usage is evicted
- [ ] Verify no TypeScript errors (`pnpm run typecheck`)

Made with [Orca](https://github.com/stablyai/orca) 🐋
