### PR TITLE
refactor(shortcuts): remove dead Cmd+Shift+D dashboard shortcut

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -710,37 +710,6 @@ function App(): React.JSX.Element {
         return
       }
 
-      // Cmd/Ctrl+Shift+D — open right sidebar (agent dashboard is now
-      // docked at the sidebar bottom, so only toggle visibility).
-      // Why: skip when a terminal is focused — that combo is the terminal
-      // split-pane shortcut (see terminal-shortcut-policy.ts). Both listeners
-      // share the window capture phase and registration order can vary with
-      // React effect re-runs, so a DOM check is the reliable coordination
-      // mechanism (same pattern as Cmd+Shift+G above). xterm-helper-textarea
-      // is the focus target the terminal handler itself uses to detect
-      // terminal focus (see keyboard-handlers.ts isEditableTarget).
-      if (e.shiftKey && !e.altKey && e.key.toLowerCase() === 'd') {
-        // Why: read the experimental toggle at keypress time via getState() so
-        // flipping the setting takes effect immediately without re-binding the
-        // window-level listener (which would require adding `settings` to the
-        // effect deps and tearing down/rebinding on every unrelated settings
-        // change, like theme or font adjustments). Gated behind the key/modifier
-        // check so getState() isn't invoked on every unrelated keystroke.
-        const dashboardExperimentEnabled =
-          useAppStore.getState().settings?.experimentalAgentDashboard === true
-        if (!dashboardExperimentEnabled) {
-          return
-        }
-        const active = document.activeElement as HTMLElement | null
-        if (active?.classList.contains('xterm-helper-textarea')) {
-          return
-        }
-        dispatchClearModifierHints()
-        e.preventDefault()
-        actions.setRightSidebarOpen(true)
-        return
-      }
-
       // Cmd+Shift+I — toggle right sidebar / ports tab (macOS only).
       // Why: Ctrl+Shift+I is the built-in DevTools accelerator on Windows/Linux;
       // intercepting it would break an essential developer tool.


### PR DESCRIPTION
## Summary
- Removes a renderer-level `Cmd/Ctrl+Shift+D` handler in `App.tsx` that force-opened the right sidebar so the old bottom-docked agent dashboard would be visible.
- The handler bails whenever focus is inside a terminal (`xterm-helper-textarea`) to avoid colliding with the terminal split-pane shortcut — in practice a terminal is essentially always focused, so the shortcut almost never fired.
- The dashboard no longer lives in the right sidebar, so there's nothing for the shortcut to open. Delete rather than repurpose for now.

## Non-changes
- `Cmd+D` / `Cmd+Shift+D` for terminal pane splits (in `terminal-pane/keyboard-handlers.ts`) is untouched.
- `Cmd+L` still toggles the right sidebar.

## Test plan
- [x] Build renderer, launch app, focus a terminal, press `Cmd+Shift+D` — the active pane splits (terminal handler still wins). Unchanged behavior.
- [x] With the right sidebar closed and no terminal focused (e.g. focus inside Settings), press `Cmd+Shift+D` — nothing happens. Previously would have opened the right sidebar (only when the experimental dashboard flag was on).
- [x] `Cmd+L` still toggles the right sidebar.
- [x] `Cmd+Shift+E/F/G/I` still open their respective right-sidebar tabs.

Verified end-to-end against the dev build with `experimentalAgentDashboard: true` (the code path this PR removes): xterm count goes 2→3 in scenario 1, stays flat in scenario 2, `Cmd+L` toggles `rightSidebarOpen` both directions, and `Cmd+Shift+G` sets `rightSidebarTab = "source-control"`.

Made with [Orca](https://github.com/stablyai/orca) 🐋