### PR TITLE
fix(new-workspace): move tabs to modal header row, rename Quick → Form

### DIFF
--- a/src/renderer/src/components/NewWorkspaceComposerModal.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerModal.tsx
@@ -141,15 +141,6 @@ function ComposerModalBody({
           trigger?.focus({ preventScroll: true })
         }}
       >
-        <DialogHeader className="gap-1">
-          <DialogTitle className="text-base font-semibold">Create Workspace</DialogTitle>
-          <DialogDescription className="text-xs text-muted-foreground">
-            {activeTab === 'quick'
-              ? 'Pick a repository and agent to spin up a new workspace.'
-              : 'Start from an existing PR, issue, branch, or Linear ticket.'}
-          </DialogDescription>
-        </DialogHeader>
-
         <Tabs
           value={activeTab}
           onValueChange={(next) => setActiveTab(next as 'quick' | 'create-from')}
@@ -164,12 +155,17 @@ function ComposerModalBody({
               read as "tabs" — the default pill variant fought the sub-tabs
               inside Create-from for visual weight. The bottom border on the
               list gives it clear separation from the content below. */}
+          {/* Why: DialogContent has p-6 (24px top) and the close button sits
+              absolutely at top-4 (16px), so its 16px icon centers around 24px
+              from the top. Pull the h-8 tab list up with -mt-4 so its center
+              (8 + 16 = 24px) lines up with the X on the same row. Reserve
+              right padding so the last trigger doesn't slide under the X. */}
           <TabsList
             variant="line"
-            className="h-8 w-full justify-start gap-6 border-b border-border/60 px-0"
+            className="-mt-4 h-8 w-full justify-start gap-6 border-b border-border/60 px-0 pr-8"
           >
             <TabsTrigger value="quick" className="flex-none gap-2 px-0 text-xs font-medium">
-              Quick
+              Form
               <ShortcutHint>{tabShortcut.quick}</ShortcutHint>
             </TabsTrigger>
             <TabsTrigger value="create-from" className="flex-none gap-2 px-0 text-xs font-medium">
@@ -177,6 +173,15 @@ function ComposerModalBody({
               <ShortcutHint>{tabShortcut['create-from']}</ShortcutHint>
             </TabsTrigger>
           </TabsList>
+
+          <DialogHeader className="gap-1 pt-4">
+            <DialogTitle className="text-base font-semibold">Create Workspace</DialogTitle>
+            <DialogDescription className="text-xs text-muted-foreground">
+              {activeTab === 'quick'
+                ? 'Pick a repository and agent to spin up a new workspace.'
+                : 'Start from an existing PR, issue, branch, or Linear ticket.'}
+            </DialogDescription>
+          </DialogHeader>
 
           <AnimatedTabPanels active={activeTab}>
             {{


### PR DESCRIPTION
## Summary
- Move the Tabs list in the New Workspace composer modal to the top, sharing the same row as the Dialog close (X) button
- Rename the first tab label from "Quick" to "Form" (internal state key `'quick'` kept to avoid ripple through store/fallback plumbing)

## Test plan
- [ ] Open the New Workspace composer (⌘N) — Form and Create from… tabs sit on the same row as the X close button
- [ ] Header title/description render beneath the tabs
- [ ] ⌘N / ⌘⇧N shortcuts still switch tabs
- [ ] The last tab label doesn't collide with the close icon

Made with [Orca](https://github.com/stablyai/orca) 🐋
