### PR TITLE
feat(agent-cockpit): bold-until-viewed weight on dashboard rows

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -27,6 +27,7 @@ import { ZoomOverlay } from './components/ZoomOverlay'
 import { SshPassphraseDialog } from './components/settings/SshPassphraseDialog'
 import { useGitStatusPolling } from './components/right-sidebar/useGitStatusPolling'
 import { useEditorExternalWatch } from './hooks/useEditorExternalWatch'
+import { useAutoAckViewedAgent } from './hooks/useAutoAckViewedAgent'
 import {
   setRuntimeGraphStoreStateGetter,
   setRuntimeGraphSyncEnabled
@@ -175,6 +176,7 @@ function App(): React.JSX.Element {
   // of tying reloads to the Explorer UI lifecycle.
   useEditorExternalWatch()
   useGlobalFileDrop()
+  useAutoAckViewedAgent()
 
   // Why: sidebar open/close flips width instantaneously. useLayoutEffect
   // runs synchronously after React commits the DOM but before paint, so

--- a/src/renderer/src/components/dashboard/DashboardAgentRow.tsx
+++ b/src/renderer/src/components/dashboard/DashboardAgentRow.tsx
@@ -63,8 +63,10 @@ function lastEnteredDoneAt(agent: DashboardAgentRowData): number | null {
 type Props = {
   agent: DashboardAgentRowData
   onDismiss: (paneKey: string) => void
-  /** Navigate directly to the tab this agent lives in. */
-  onActivate: (tabId: string) => void
+  /** Navigate directly to the tab this agent lives in. paneKey is passed
+   *  through so the caller can acknowledge (mark-visited) the specific row
+   *  that was clicked, without having to re-derive it from the tab id. */
+  onActivate: (tabId: string, paneKey: string) => void
   /**
    * Why: the relative-time labels ("Xm ago") need a periodic re-render to stay
    * honest. We accept `now` from a parent container so a single 30s tick owned
@@ -73,13 +75,25 @@ type Props = {
    * tick (AgentDashboard for the dashboard, AgentStatusHover for hovercards).
    */
   now: number
+  /**
+   * Why: bold weight for the prompt rides on the enclosing worktree's
+   * isUnread (unvisited) signal, not on the per-agent state. Passed in from
+   * DashboardWorktreeCard so the workspace name and its agent rows share
+   * the same "you haven't looked at this yet" rule — visiting the worktree
+   * clears isUnread, and the next render mutes both in lockstep.
+   *
+   * Optional so other callers can opt out and default to muted when their
+   * surface carries the unread signal elsewhere.
+   */
+  isUnvisited?: boolean
 }
 
 const DashboardAgentRow = React.memo(function DashboardAgentRow({
   agent,
   onDismiss,
   onActivate,
-  now
+  now,
+  isUnvisited = false
 }: Props) {
   const [expanded, setExpanded] = useState(false)
   // Why: stop propagation so clicking the X doesn't also fire the worktree
@@ -120,9 +134,9 @@ const DashboardAgentRow = React.memo(function DashboardAgentRow({
   const handleActivate = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation()
-      onActivate(agent.tab.id)
+      onActivate(agent.tab.id, agent.paneKey)
     },
-    [onActivate, agent.tab.id]
+    [onActivate, agent.tab.id, agent.paneKey]
   )
   const startedAt = agent.startedAt > 0 ? agent.startedAt : null
   const doneAt = lastEnteredDoneAt(agent)
@@ -223,12 +237,11 @@ const DashboardAgentRow = React.memo(function DashboardAgentRow({
             overflow-hidden so the truncate→wrap class flip stays clipped
             during the interpolation.
 
-            Done and waiting rows get "unread" weight (semibold + full
-            foreground) so the user can tell at a glance which rows need
-            their attention. Working/idle stay at the quieter baseline
-            since the state dot (spinner or neutral) is already doing the
-            work. Mirrors the convention in Slack/Gmail/Linear where the
-            row text thickens to signal "you haven't dealt with this yet."
+            Weight tracks the workspace's unvisited signal (isUnvisited):
+            bold + full foreground for agents inside a workspace the user
+            hasn't looked at yet, normal + muted once they've visited. This
+            keeps the prompt row's weight in lockstep with the workspace
+            name above it — one attention axis, not two.
 
             Rendered unconditionally with a state-label fallback so rows
             without a prompt (fresh/unknown) still have a human-readable
@@ -238,9 +251,7 @@ const DashboardAgentRow = React.memo(function DashboardAgentRow({
             'block min-w-0 flex-1 overflow-hidden text-[11px] leading-snug',
             'transition-[height] duration-200 ease-out [interpolate-size:allow-keywords]',
             expanded ? 'h-auto whitespace-pre-wrap break-words' : 'h-[1lh] truncate',
-            agent.state === 'done' || agent.state === 'waiting' || agent.state === 'blocked'
-              ? 'font-semibold text-foreground'
-              : 'font-medium text-foreground/90'
+            isUnvisited ? 'font-semibold text-foreground' : 'font-normal text-muted-foreground'
           )}
           // Why: tooltip should only reveal truncated prompt text — not echo state-word fallbacks
           // (e.g. "Working"/"Done") that already fit on one line and never overflow.

--- a/src/renderer/src/components/dashboard/DashboardWorktreeCard.tsx
+++ b/src/renderer/src/components/dashboard/DashboardWorktreeCard.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react'
+import React, { useCallback, useMemo } from 'react'
 import { cn } from '@/lib/utils'
 import { useAppStore } from '@/store'
 import DashboardAgentRow from './DashboardAgentRow'
@@ -39,26 +39,62 @@ const DashboardWorktreeCard = React.memo(function DashboardWorktreeCard({
 }: Props) {
   const setActiveWorktree = useAppStore((s) => s.setActiveWorktree)
   const setActiveView = useAppStore((s) => s.setActiveView)
+  const acknowledgeAgents = useAppStore((s) => s.acknowledgeAgents)
 
-  // Why: clicking a worktree row only navigates. It does NOT dismiss retained
-  // done agents — the user may have multiple agents done (e.g. Claude + Codex)
-  // and silently dropping any of them on row click erases a signal they were
-  // about to click through to investigate. Dismissal happens only through the
-  // explicit X button on each agent row.
+  const paneKeys = useMemo(() => card.agents.map((a) => a.paneKey), [card.agents])
+  // Why: subscribe to the ack map's single reference (cheap Object.is check
+  // via Zustand's default equality) and derive the per-card slice locally.
+  // A useShallow selector here would allocate a fresh object on every
+  // store change — including unrelated ones like terminal output —
+  // multiplied across every card on screen. Reading the reference and
+  // memoizing the per-card slice collapses that to one allocation per
+  // card per genuine ack change. acknowledgeAgents in ui.ts preserves the
+  // map reference when no ack is actually moving forward, so unrelated
+  // clicks do not invalidate this memo either.
+  const acknowledgedAgentsByPaneKey = useAppStore((s) => s.acknowledgedAgentsByPaneKey)
+  const ackByPaneKey = useMemo(() => {
+    const out: Record<string, number> = {}
+    for (const paneKey of paneKeys) {
+      out[paneKey] = acknowledgedAgentsByPaneKey[paneKey] ?? 0
+    }
+    return out
+  }, [paneKeys, acknowledgedAgentsByPaneKey])
+
+  // Why: an agent counts as "unvisited" when it has no ack OR the agent's
+  // current state began after the last ack (a new turn/state transition is
+  // a fresh signal the user hasn't seen). Using stateStartedAt (not
+  // updatedAt) means within-state tool/prompt pings don't re-trigger the
+  // unread highlight; only genuine state changes do.
+  const isAgentUnvisited = useCallback(
+    (paneKey: string, stateStartedAt: number) => {
+      const ackAt = ackByPaneKey[paneKey] ?? 0
+      return ackAt < stateStartedAt
+    },
+    [ackByPaneKey]
+  )
+
+  // Why: clicking a worktree row navigates AND acknowledges every agent
+  // currently shown under it. The user looking at the card counts as
+  // "seeing" all its rows, even ones they don't click individually —
+  // otherwise a workspace with five done agents would stay bold forever
+  // after the user scrolled past it. Dismissal of done rows still requires
+  // the explicit X; ack only changes the visual weight.
   const handleClick = useCallback(() => {
     setActiveWorktree(card.worktree.id)
     setActiveView('terminal')
-  }, [card.worktree.id, setActiveWorktree, setActiveView])
+    acknowledgeAgents(paneKeys)
+  }, [card.worktree.id, paneKeys, setActiveWorktree, setActiveView, acknowledgeAgents])
 
-  // Why: clicking an agent row only navigates to that agent's tab. It must not
-  // call onCheck() — that would mark the worktree as checked AND dismiss all
-  // retained done rows in it, which erases the signal the user was clicking
-  // through to investigate. Only the X button on a done row should dismiss it.
+  // Why: clicking an agent row navigates to that agent's tab AND acks the
+  // row so it fades to the visited weight. Scoped to a single paneKey so
+  // sibling rows (other agents on the same workspace) remain bold until the
+  // user looks at them. Dismissal still requires the explicit X.
   const handleActivateAgent = useCallback(
-    (tabId: string) => {
+    (tabId: string, paneKey: string) => {
       onActivateAgentTab(card.worktree.id, tabId)
+      acknowledgeAgents([paneKey])
     },
-    [card.worktree.id, onActivateAgentTab]
+    [card.worktree.id, onActivateAgentTab, acknowledgeAgents]
   )
 
   // Why: React's onFocus handler receives a SyntheticEvent, but the parent
@@ -69,6 +105,17 @@ const DashboardWorktreeCard = React.memo(function DashboardWorktreeCard({
   }, [onFocus, card.worktree.id])
 
   const branchName = card.worktree.branch?.replace(/^refs\/heads\//, '') ?? ''
+
+  // Why: workspace-level bold/muted weight tracks whether ANY of this card's
+  // agents are unvisited — so the workspace header stays bold while even one
+  // row inside it needs the user's attention, and fades once the user has
+  // clicked through every agent. Per-agent granularity lives on the rows
+  // themselves (DashboardAgentRow isUnvisited prop). If a workspace has no
+  // agents (edge case during spin-up), default to muted so the row doesn't
+  // read louder than it has value to.
+  const anyAgentUnvisited = card.agents.some((a) =>
+    isAgentUnvisited(a.paneKey, a.entry.stateStartedAt)
+  )
 
   // Why: the card is a clickable *surface* but NOT a `role="button"` — its
   // children (DashboardAgentRow) render real <button>s (dismiss X, chevron),
@@ -107,9 +154,18 @@ const DashboardWorktreeCard = React.memo(function DashboardWorktreeCard({
     >
       {/* Worktree header row. Why: workspace name + branch share one line
           to save vertical space — the branch is a secondary qualifier that
-          reads fine as a muted suffix rather than its own line. */}
+          reads fine as a muted suffix rather than its own line. Weight is
+          driven by anyAgentUnvisited so unvisited workspaces read boldly,
+          while already-visited ones fade into the background. */}
       <div className="flex items-baseline gap-1.5 min-w-0">
-        <span className="text-[11px] font-semibold text-foreground truncate leading-tight shrink-0 max-w-[60%]">
+        <span
+          className={cn(
+            'text-[11px] truncate leading-tight shrink-0 max-w-[60%]',
+            anyAgentUnvisited
+              ? 'font-semibold text-foreground'
+              : 'font-normal text-muted-foreground'
+          )}
+        >
           {card.worktree.displayName}
         </span>
         {branchName && (
@@ -129,6 +185,7 @@ const DashboardWorktreeCard = React.memo(function DashboardWorktreeCard({
                 onDismiss={onDismissAgent}
                 onActivate={handleActivateAgent}
                 now={now}
+                isUnvisited={isAgentUnvisited(agent.paneKey, agent.entry.stateStartedAt)}
               />
             </div>
           ))}

--- a/src/renderer/src/components/sidebar/AgentStatusHover.tsx
+++ b/src/renderer/src/components/sidebar/AgentStatusHover.tsx
@@ -94,6 +94,7 @@ const AgentStatusHover = React.memo(function AgentStatusHover({
   const setActiveWorktree = useAppStore((s) => s.setActiveWorktree)
   const setActiveTab = useAppStore((s) => s.setActiveTab)
   const setActiveView = useAppStore((s) => s.setActiveView)
+  const acknowledgeAgents = useAppStore((s) => s.acknowledgeAgents)
 
   const agents = useMemo<DashboardAgentRowType[]>(() => {
     const rows: DashboardAgentRowType[] = []
@@ -203,16 +204,22 @@ const AgentStatusHover = React.memo(function AgentStatusHover({
   // Why: clicking a row activates the specific tab the agent runs in. Retained
   // rows can outlive their tab, so fall back to worktree-only activation when
   // the tab is no longer present.
+  // Why: symmetric with the dashboard's handleActivateAgent — clicking a row
+  // through the sidebar hovercard should fade it to the visited weight
+  // immediately, instead of waiting for useAutoAckViewedAgent to catch up once
+  // the tab becomes active. Scoped to the single clicked paneKey so sibling
+  // rows remain bold.
   const handleActivateAgentTab = useCallback(
-    (tabId: string) => {
+    (tabId: string, paneKey: string) => {
       setActiveWorktree(worktreeId)
       setActiveView('terminal')
       const tabs = useAppStore.getState().tabsByWorktree[worktreeId] ?? []
       if (tabs.some((t) => t.id === tabId)) {
         setActiveTab(tabId)
       }
+      acknowledgeAgents([paneKey])
     },
-    [worktreeId, setActiveWorktree, setActiveTab, setActiveView]
+    [worktreeId, setActiveWorktree, setActiveTab, setActiveView, acknowledgeAgents]
   )
 
   return (
@@ -249,7 +256,7 @@ const AgentStatusHover = React.memo(function AgentStatusHover({
 type AgentStatusHoverContentProps = {
   agents: DashboardAgentRowType[]
   onDismiss: (paneKey: string) => void
-  onActivate: (tabId: string) => void
+  onActivate: (tabId: string, paneKey: string) => void
 }
 
 // Why: split out so `useNow(30_000)` only runs while the hovercard body is
@@ -275,6 +282,28 @@ const AgentStatusHoverContent = React.memo(function AgentStatusHoverContent({
   // this to the inner content (which only mounts while the card is open)
   // keeps the overhead bounded to the card the user is actually looking at.
   const now = useNow(30_000)
+
+  // Why: mirrors DashboardWorktreeCard's isAgentUnvisited rule so the
+  // hovercard's weight signal stays consistent with the dashboard. Without
+  // this, previously-bold attention-needed states (done/waiting/blocked)
+  // render muted because DashboardAgentRow's weight is now driven exclusively
+  // by isUnvisited.
+  const acknowledgedAgentsByPaneKey = useAppStore((s) => s.acknowledgedAgentsByPaneKey)
+  const paneKeys = useMemo(() => agents.map((a) => a.paneKey), [agents])
+  const ackByPaneKey = useMemo(() => {
+    const out: Record<string, number> = {}
+    for (const paneKey of paneKeys) {
+      out[paneKey] = acknowledgedAgentsByPaneKey[paneKey] ?? 0
+    }
+    return out
+  }, [paneKeys, acknowledgedAgentsByPaneKey])
+  const isAgentUnvisited = useCallback(
+    (paneKey: string, stateStartedAt: number) => {
+      const ackAt = ackByPaneKey[paneKey] ?? 0
+      return ackAt < stateStartedAt
+    },
+    [ackByPaneKey]
+  )
 
   if (agents.length === 0) {
     return <div className="py-1 text-center text-muted-foreground">No agent activity</div>
@@ -304,6 +333,7 @@ const AgentStatusHoverContent = React.memo(function AgentStatusHoverContent({
               onDismiss={onDismiss}
               onActivate={onActivate}
               now={now}
+              isUnvisited={isAgentUnvisited(agent.paneKey, agent.entry.stateStartedAt)}
             />
           </div>
         ))}

--- a/src/renderer/src/hooks/useAutoAckViewedAgent.ts
+++ b/src/renderer/src/hooks/useAutoAckViewedAgent.ts
@@ -1,0 +1,114 @@
+import { useEffect } from 'react'
+import { useAppStore } from '@/store'
+
+// Why: an agent row counts as "already seen" when the user is actually looking
+// at the tab it lives on. Without this effect, ack only fires via an explicit
+// click in the dashboard — which misses the common case where the user is
+// already on the terminal tab when the agent finishes or blocks. That leaves
+// the dashboard bolded for an event the user literally just watched happen.
+//
+// The effect subscribes directly to the store (not via React selectors) so it
+// sees every state change with no re-render amplification up the component
+// tree. A reference-equality guard inside the callback bails out immediately
+// when none of the five slices we care about (activeView, activeTabId,
+// agentStatusByPaneKey, acknowledgedAgentsByPaneKey, settings) have changed —
+// so the Object.entries walk only runs for updates that could legitimately
+// affect the ack decision.
+//
+// It acks whenever:
+//   - activeView is 'terminal' (the user isn't on Settings/Tasks), AND
+//   - activeTabId identifies a live tab, AND
+//   - at least one agentStatusByPaneKey entry has paneKey prefixed by
+//     `${activeTabId}:` AND its ackAt < stateStartedAt.
+//
+// We ack ALL matching panes in one call (a tab can host split panes, each
+// with its own paneKey) so acknowledgeAgents' identity-preserving guard
+// collapses the no-op path.
+export function useAutoAckViewedAgent(): void {
+  useEffect(() => {
+    // Why: the root zustand store is created with plain `create()` (no
+    // subscribeWithSelector middleware), so subscribe has no selector form.
+    // Track the slice references we actually depend on and early-return on
+    // unrelated updates — terminal output, tab state, settings, etc. would
+    // otherwise invoke the scan on every store change. Initialize to
+    // `undefined` so the first call always runs at least once.
+    let lastActiveView: unknown = undefined
+    let lastActiveTabId: unknown = undefined
+    let lastAgentStatus: unknown = undefined
+    let lastAcknowledged: unknown = undefined
+    // Why: settings is tracked so flipping `experimentalAgentDashboard`
+    // alone re-evaluates the feature gate below — without this, a pure
+    // settings change would be swallowed by the fast-path until some other
+    // tracked slice changed. Tracking the whole settings reference (rather
+    // than the one specific boolean) is acceptable because settings changes
+    // are rare compared to agent-status updates, and it matches the existing
+    // pattern of tracking whole slice references.
+    let lastSettings: unknown = undefined
+
+    const maybeAck = (): void => {
+      const s = useAppStore.getState()
+      if (
+        s.activeView === lastActiveView &&
+        s.activeTabId === lastActiveTabId &&
+        s.agentStatusByPaneKey === lastAgentStatus &&
+        s.acknowledgedAgentsByPaneKey === lastAcknowledged &&
+        s.settings === lastSettings
+      ) {
+        return
+      }
+      lastActiveView = s.activeView
+      lastActiveTabId = s.activeTabId
+      lastAgentStatus = s.agentStatusByPaneKey
+      lastAcknowledged = s.acknowledgedAgentsByPaneKey
+      lastSettings = s.settings
+
+      // Why: mirror the dashboard's visibility gate — if the experimental
+      // agent dashboard is off, nothing in the UI reads the ack map, so
+      // accumulating entries for unseen agents is wasted memory and the
+      // Object.entries scan below is pure overhead. The subscribe callback
+      // fires on any store change, so flipping the setting naturally
+      // re-evaluates this guard without a separate subscription.
+      if (s.settings?.experimentalAgentDashboard !== true) {
+        return
+      }
+
+      if (s.activeView !== 'terminal') {
+        return
+      }
+      const activeTabId = s.activeTabId
+      if (!activeTabId) {
+        return
+      }
+      const prefix = `${activeTabId}:`
+      const toAck: string[] = []
+      for (const [paneKey, entry] of Object.entries(s.agentStatusByPaneKey)) {
+        if (!paneKey.startsWith(prefix)) {
+          continue
+        }
+        const ackAt = s.acknowledgedAgentsByPaneKey[paneKey] ?? 0
+        // Why: use stateStartedAt (not updatedAt) so tool/prompt pings
+        // within the same state don't re-trigger ack work on every event —
+        // acknowledgeAgents short-circuits anyway when the value is
+        // unchanged, but keeping the comparison in sync with the
+        // "is-unvisited" rule in DashboardWorktreeCard avoids a stutter
+        // where we ack on an updatedAt-bump that didn't cross a state
+        // transition.
+        if (ackAt < entry.stateStartedAt) {
+          toAck.push(paneKey)
+        }
+      }
+      if (toAck.length > 0) {
+        s.acknowledgeAgents(toAck)
+      }
+    }
+    // Why: run once on mount to catch the case where the app restores to a
+    // session whose current state already has agents on the visible tab.
+    maybeAck()
+    // Why: store.subscribe fires on every state change. The reference-
+    // equality guard above bails out immediately for the common case
+    // (terminal output, timers, etc.) so the Object.entries walk only runs
+    // when one of the five slices we read has actually changed.
+    const unsubscribe = useAppStore.subscribe(maybeAck)
+    return unsubscribe
+  }, [])
+}

--- a/src/renderer/src/hooks/useAutoAckViewedAgent.ts
+++ b/src/renderer/src/hooks/useAutoAckViewedAgent.ts
@@ -21,6 +21,14 @@ import { useAppStore } from '@/store'
 //   - at least one agentStatusByPaneKey entry has paneKey prefixed by
 //     `${activeTabId}:` AND its ackAt < stateStartedAt.
 //
+// The ack ALSO requires the OS window to be visible and focused
+// (document.visibilityState === 'visible' && document.hasFocus()) —
+// otherwise a transition that arrives while the user is away would silently
+// clear the bold-until-viewed signal for an event they never saw. A
+// visibilitychange / focus listener re-runs the scan when the user returns
+// so any transitions that failed the gate while away get acked the moment
+// focus actually comes back.
+//
 // We ack ALL matching panes in one call (a tab can host split panes, each
 // with its own paneKey) so acknowledgeAgents' identity-preserving guard
 // collapses the no-op path.
@@ -56,11 +64,6 @@ export function useAutoAckViewedAgent(): void {
       ) {
         return
       }
-      lastActiveView = s.activeView
-      lastActiveTabId = s.activeTabId
-      lastAgentStatus = s.agentStatusByPaneKey
-      lastAcknowledged = s.acknowledgedAgentsByPaneKey
-      lastSettings = s.settings
 
       // Why: mirror the dashboard's visibility gate — if the experimental
       // agent dashboard is off, nothing in the UI reads the ack map, so
@@ -75,10 +78,36 @@ export function useAutoAckViewedAgent(): void {
       if (s.activeView !== 'terminal') {
         return
       }
+      // Why: the auto-ack represents "the user saw this row" — but tab-active is
+      // only a proxy. If the OS window is hidden, minimized, or another app has
+      // focus, the user is demonstrably not looking at the dashboard even with the
+      // terminal tab set. Without this gate, an agent finishing while the user is
+      // away silently clears the bold-until-viewed signal and the user returns to
+      // a dashboard with no indication anything transitioned.
+      if (typeof document !== 'undefined') {
+        if (document.visibilityState !== 'visible') {
+          return
+        }
+        if (!document.hasFocus()) {
+          return
+        }
+      }
       const activeTabId = s.activeTabId
       if (!activeTabId) {
         return
       }
+      // Why: advance the refs ONLY after all gates have passed — if the visibility
+      // or feature gate caused an early return, we must leave the refs stale so
+      // the next call (e.g. triggered by the focus listener on return) sees a
+      // diff and actually runs the scan. Updating refs before the gates would
+      // consume the diff silently and leave the user returning to a dashboard
+      // whose bold-until-viewed rows stay bold until some unrelated store change
+      // happens to bump the refs again.
+      lastActiveView = s.activeView
+      lastActiveTabId = s.activeTabId
+      lastAgentStatus = s.agentStatusByPaneKey
+      lastAcknowledged = s.acknowledgedAgentsByPaneKey
+      lastSettings = s.settings
       const prefix = `${activeTabId}:`
       const toAck: string[] = []
       for (const [paneKey, entry] of Object.entries(s.agentStatusByPaneKey)) {
@@ -109,6 +138,18 @@ export function useAutoAckViewedAgent(): void {
     // (terminal output, timers, etc.) so the Object.entries walk only runs
     // when one of the five slices we read has actually changed.
     const unsubscribe = useAppStore.subscribe(maybeAck)
-    return unsubscribe
+    // Why: focus/visibility don't flow through the zustand store, so a
+    // late-arriving transition that failed the gate above never re-evaluates
+    // when focus returns. Subscribe to the two DOM events so the ack scan
+    // reruns the moment the user is actually back on the window.
+    const onVisibility = (): void => maybeAck()
+    const onFocus = (): void => maybeAck()
+    document.addEventListener('visibilitychange', onVisibility)
+    window.addEventListener('focus', onFocus)
+    return () => {
+      unsubscribe()
+      document.removeEventListener('visibilitychange', onVisibility)
+      window.removeEventListener('focus', onFocus)
+    }
   }, [])
 }

--- a/src/renderer/src/store/slices/agent-status-ack-cleanup.test.ts
+++ b/src/renderer/src/store/slices/agent-status-ack-cleanup.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createTestStore } from './store-test-helpers'
+
+// Why: paneKeys are generated from `${tabId}:${paneId}`, and both ids are
+// freshly minted on creation, so a reused paneKey is extremely unlikely to
+// surface through ordinary UI flow. These tests exercise the cleanup path
+// directly by simulating the "close and re-create the same paneKey" case —
+// this is the only guarantee that closed panes can't leak stale acks that
+// silently suppress the "unvisited" signal on future paneKey collisions.
+
+describe('acknowledgedAgentsByPaneKey cleanup on teardown', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('removeAgentStatus drops the ack entry for the closed pane', () => {
+    vi.useFakeTimers()
+    const store = createTestStore()
+    store
+      .getState()
+      .setAgentStatus('tab-1:0', { state: 'working', prompt: 'p', agentType: 'claude' })
+    store.getState().acknowledgeAgents(['tab-1:0'])
+    expect(store.getState().acknowledgedAgentsByPaneKey['tab-1:0']).toBeGreaterThan(0)
+
+    store.getState().removeAgentStatus('tab-1:0')
+
+    expect(store.getState().acknowledgedAgentsByPaneKey['tab-1:0']).toBeUndefined()
+  })
+
+  it('removeAgentStatusByTabPrefix drops every ack entry whose paneKey starts with the tab prefix', () => {
+    vi.useFakeTimers()
+    const store = createTestStore()
+    store
+      .getState()
+      .setAgentStatus('tab-1:0', { state: 'working', prompt: 'p', agentType: 'claude' })
+    store
+      .getState()
+      .setAgentStatus('tab-1:1', { state: 'working', prompt: 'p', agentType: 'claude' })
+    store
+      .getState()
+      .setAgentStatus('tab-10:0', { state: 'working', prompt: 'p', agentType: 'claude' })
+    store.getState().acknowledgeAgents(['tab-1:0', 'tab-1:1', 'tab-10:0'])
+
+    store.getState().removeAgentStatusByTabPrefix('tab-1')
+
+    const ack = store.getState().acknowledgedAgentsByPaneKey
+    expect(ack['tab-1:0']).toBeUndefined()
+    expect(ack['tab-1:1']).toBeUndefined()
+    // Why: the ":" delimiter on the prefix guards against false-prefix matches
+    // across tab ids that share a leading substring (tab-1 vs tab-10).
+    expect(ack['tab-10:0']).toBeGreaterThan(0)
+  })
+
+  it('dropAgentStatus drops the ack entry even when the pane had no live entry', () => {
+    vi.useFakeTimers()
+    const store = createTestStore()
+    // Why: simulate a dismissed/retained-only row — no live entry but an ack
+    // was planted earlier in the session. Without cleanup on this path, the
+    // ack would outlive every lifecycle and silently suppress a future
+    // paneKey collision's unvisited signal.
+    store.getState().acknowledgeAgents(['tab-2:0'])
+    expect(store.getState().acknowledgedAgentsByPaneKey['tab-2:0']).toBeGreaterThan(0)
+
+    store.getState().dropAgentStatus('tab-2:0')
+
+    expect(store.getState().acknowledgedAgentsByPaneKey['tab-2:0']).toBeUndefined()
+  })
+
+  it('dropAgentStatusByTabPrefix drops ack entries even when no live or retained entries matched', () => {
+    vi.useFakeTimers()
+    const store = createTestStore()
+    store.getState().acknowledgeAgents(['tab-3:0', 'tab-3:1'])
+    expect(Object.keys(store.getState().acknowledgedAgentsByPaneKey)).toEqual(
+      expect.arrayContaining(['tab-3:0', 'tab-3:1'])
+    )
+
+    store.getState().dropAgentStatusByTabPrefix('tab-3')
+
+    const ack = store.getState().acknowledgedAgentsByPaneKey
+    expect(ack['tab-3:0']).toBeUndefined()
+    expect(ack['tab-3:1']).toBeUndefined()
+  })
+
+  it('a paneKey reused after teardown reads as unvisited (no leaked ack suppresses the signal)', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-29T12:00:00.000Z'))
+    const store = createTestStore()
+
+    // Session 1: agent runs on tab-1:0, user acks it, tab closes.
+    store
+      .getState()
+      .setAgentStatus('tab-1:0', { state: 'working', prompt: 'first', agentType: 'claude' })
+    store.getState().acknowledgeAgents(['tab-1:0'])
+    const firstAck = store.getState().acknowledgedAgentsByPaneKey['tab-1:0']
+    expect(firstAck).toBeGreaterThan(0)
+
+    store.getState().dropAgentStatusByTabPrefix('tab-1')
+    expect(store.getState().acknowledgedAgentsByPaneKey['tab-1:0']).toBeUndefined()
+
+    // Session 2: a brand-new tab+pane happens to collide on the same paneKey,
+    // some time later. The ack from session 1 must NOT suppress the
+    // unvisited signal for this new agent.
+    vi.setSystemTime(new Date('2026-04-29T12:05:00.000Z'))
+    store
+      .getState()
+      .setAgentStatus('tab-1:0', { state: 'working', prompt: 'second', agentType: 'codex' })
+    const newEntry = store.getState().agentStatusByPaneKey['tab-1:0']
+    const ackAt = store.getState().acknowledgedAgentsByPaneKey['tab-1:0'] ?? 0
+
+    // Why: the unvisited rule (DashboardWorktreeCard's isAgentUnvisited) is
+    // `ackAt < stateStartedAt`. A leaked session-1 ack would still be
+    // greater than the second paneKey's fresh stateStartedAt only by
+    // accident of wall-clock ordering, but more robustly: after cleanup,
+    // ackAt is 0, which is strictly less than any stateStartedAt.
+    expect(ackAt).toBe(0)
+    expect(ackAt < newEntry.stateStartedAt).toBe(true)
+  })
+})

--- a/src/renderer/src/store/slices/agent-status.ts
+++ b/src/renderer/src/store/slices/agent-status.ts
@@ -251,11 +251,24 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
       set((s) => {
         const next = { ...s.agentStatusByPaneKey }
         delete next[paneKey]
+        // Why: acknowledgedAgentsByPaneKey is written per user-ack but owned
+        // lifecycle-wise by the pane — drop the ack entry in lockstep with the
+        // live-map entry so closed panes don't leave stale ack timestamps that
+        // could silently suppress "unvisited" signals on future paneKey
+        // collisions.
+        let nextAck = s.acknowledgedAgentsByPaneKey
+        if (paneKey in nextAck) {
+          nextAck = { ...nextAck }
+          delete nextAck[paneKey]
+        }
         // Why: bump sortEpoch in lockstep with agentStatusEpoch — removing an
         // agent can legitimately change worktree sort order, same rationale
         // as setAgentStatus.
         return {
           agentStatusByPaneKey: next,
+          ...(nextAck !== s.acknowledgedAgentsByPaneKey
+            ? { acknowledgedAgentsByPaneKey: nextAck }
+            : {}),
           agentStatusEpoch: s.agentStatusEpoch + 1,
           sortEpoch: s.sortEpoch + 1
         }
@@ -275,12 +288,24 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
         for (const key of toRemove) {
           delete next[key]
         }
+        // See removeAgentStatus for rationale on ack cleanup.
+        let nextAck = s.acknowledgedAgentsByPaneKey
+        const ackKeys = Object.keys(nextAck).filter((k) => k.startsWith(prefix))
+        if (ackKeys.length > 0) {
+          nextAck = { ...nextAck }
+          for (const k of ackKeys) {
+            delete nextAck[k]
+          }
+        }
         // Why: bump sortEpoch in lockstep with agentStatusEpoch — removing
         // agents can legitimately change worktree sort order, same rationale
         // as setAgentStatus. The pre-check guards against spurious bumps when
         // no keys matched the prefix.
         return {
           agentStatusByPaneKey: next,
+          ...(nextAck !== s.acknowledgedAgentsByPaneKey
+            ? { acknowledgedAgentsByPaneKey: nextAck }
+            : {}),
           agentStatusEpoch: s.agentStatusEpoch + 1,
           sortEpoch: s.sortEpoch + 1
         }
@@ -298,13 +323,25 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
         const hasLive = paneKey in s.agentStatusByPaneKey
         liveExisted = hasLive
         const hasRetained = paneKey in s.retainedAgentsByPaneKey
+        // See removeAgentStatus for rationale on ack cleanup. Apply this
+        // regardless of live/retained presence — the ack entry is owned by
+        // the pane lifecycle independently of live/retained state.
+        let nextAck = s.acknowledgedAgentsByPaneKey
+        if (paneKey in nextAck) {
+          nextAck = { ...nextAck }
+          delete nextAck[paneKey]
+        }
         // Why: bail when there is genuinely nothing to do. The old guard
         // `!hasLive && !hasRetained && alreadySuppressed` leaked a phantom
         // suppressor write in the `!hasLive && !hasRetained && !alreadySuppressed`
         // case. With the hasLive-gated suppressor below, a no-op drop on a
         // paneKey with no live and no retained entry truly has nothing to
-        // change, so short-circuit here.
+        // change, so short-circuit here — but still flush a pending ack
+        // cleanup if one is present.
         if (!hasLive && !hasRetained) {
+          if (nextAck !== s.acknowledgedAgentsByPaneKey) {
+            return { acknowledgedAgentsByPaneKey: nextAck }
+          }
           return s
         }
 
@@ -353,6 +390,9 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
         return {
           agentStatusByPaneKey: nextLive,
           retainedAgentsByPaneKey: nextRetained,
+          ...(nextAck !== s.acknowledgedAgentsByPaneKey
+            ? { acknowledgedAgentsByPaneKey: nextAck }
+            : {}),
           ...(needsSuppressorWrite
             ? {
                 retentionSuppressedPaneKeys: {
@@ -388,7 +428,21 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
         const retainedKeys = Object.keys(s.retainedAgentsByPaneKey).filter((k) =>
           k.startsWith(prefix)
         )
+        // See removeAgentStatus for rationale on ack cleanup. Apply this
+        // regardless of live/retained presence — ack entries are owned by
+        // the pane lifecycle independently of live/retained state.
+        let nextAck = s.acknowledgedAgentsByPaneKey
+        const ackKeys = Object.keys(nextAck).filter((k) => k.startsWith(prefix))
+        if (ackKeys.length > 0) {
+          nextAck = { ...nextAck }
+          for (const k of ackKeys) {
+            delete nextAck[k]
+          }
+        }
         if (liveKeys.length === 0 && retainedKeys.length === 0) {
+          if (nextAck !== s.acknowledgedAgentsByPaneKey) {
+            return { acknowledgedAgentsByPaneKey: nextAck }
+          }
           return s
         }
         hadLive = liveKeys.length > 0
@@ -425,6 +479,9 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
           agentStatusByPaneKey: nextLive,
           retainedAgentsByPaneKey: nextRetained,
           retentionSuppressedPaneKeys: nextRetentionSuppressedPaneKeys,
+          ...(nextAck !== s.acknowledgedAgentsByPaneKey
+            ? { acknowledgedAgentsByPaneKey: nextAck }
+            : {}),
           // Why: mirrors removeAgentStatusByTabPrefix — only bump the live-map
           // epoch / sortEpoch when the live map actually changed. Retained-only
           // sweeps do not participate in smart-sort or freshness calculations.

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -59,6 +59,15 @@ export type UISlice = {
   toggleSidebar: () => void
   setSidebarOpen: (open: boolean) => void
   setSidebarWidth: (width: number) => void
+  /** Per-agent "I've looked at this" timestamps, keyed by paneKey. Set when
+   *  the user clicks an agent row or its parent workspace card from the
+   *  dashboard. A row is considered unvisited when no ack exists OR the
+   *  agent's current stateStartedAt is newer than the last ack (i.e. the
+   *  agent has transitioned state since the user last saw it). Session-only
+   *  — restart resets everyone to unvisited, which is harmless since the
+   *  first visit after launch is a legitimate "need to see" moment. */
+  acknowledgedAgentsByPaneKey: Record<string, number>
+  acknowledgeAgents: (paneKeys: string[]) => void
   activeView: 'terminal' | 'settings' | 'tasks'
   previousViewBeforeTasks: 'terminal' | 'settings'
   previousViewBeforeSettings: 'terminal' | 'tasks'
@@ -192,6 +201,33 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
   toggleSidebar: () => set((s) => ({ sidebarOpen: !s.sidebarOpen })),
   setSidebarOpen: (open) => set({ sidebarOpen: open }),
   setSidebarWidth: (width) => set({ sidebarWidth: width }),
+
+  acknowledgedAgentsByPaneKey: {},
+  acknowledgeAgents: (paneKeys) =>
+    set((s) => {
+      if (paneKeys.length === 0) {
+        return s
+      }
+      const now = Date.now()
+      // Why: only allocate a new map (and emit a store update) if at least
+      // one ack is actually moving forward. Comparing `prev < now` instead
+      // of `prev !== now` matters because stored values are historical
+      // timestamps and `Date.now()` advances every millisecond — a strict-
+      // inequality guard would fire on every call and rewrite the map on
+      // every dashboard click or auto-ack tick, forcing every subscriber
+      // (all agent rows, the SidebarHeader count, etc.) to re-render.
+      let next: Record<string, number> | null = null
+      for (const key of paneKeys) {
+        const prev = s.acknowledgedAgentsByPaneKey[key] ?? 0
+        if (prev < now) {
+          if (next === null) {
+            next = { ...s.acknowledgedAgentsByPaneKey }
+          }
+          next[key] = now
+        }
+      }
+      return next ? { acknowledgedAgentsByPaneKey: next } : s
+    }),
 
   activeView: 'terminal',
   previousViewBeforeTasks: 'terminal',


### PR DESCRIPTION
## Summary
Replace the dashboard's "bold = done/waiting/blocked" rule with "bold = you haven't looked at this yet." An agent row renders bold until the user either clicks through it in the dashboard/hovercard or has its terminal tab focused (in a visible, focused window) when the agent transitions state.

- New session-only store slice: `acknowledgedAgentsByPaneKey` (paneKey → last-ack timestamp) plus `acknowledgeAgents`.
- `DashboardAgentRow` takes an `isUnvisited` prop (defaults to `false`) that drives the prompt's weight.
- `DashboardWorktreeCard` passes `isUnvisited` per row and uses OR-across-rows for its workspace-header weight. Clicking the card acks every agent under it; clicking a single row acks just that paneKey.
- `AgentStatusHover` (sidebar hovercard) mirrors the same rule — computes `isUnvisited` per row from the shared ack map and acks the clicked paneKey on activation, so attention-needed states (done/waiting/blocked) stay bold in the hovercard and fade to muted when visited.
- `useAutoAckViewedAgent` subscribes to the store directly (no useShallow) and bails fast on unrelated updates. It acks all panes on the currently-focused tab whose `stateStartedAt` is newer than their last ack — but only when `document.visibilityState === 'visible'` AND `document.hasFocus()`, so transitions that arrive while the user is away (minimized window, different app, locked screen) aren't silently consumed. `visibilitychange` / `focus` listeners re-run the scan when the user returns, and the ref-equality fast-path advances its cache only after all gates pass so those re-runs actually see a diff.
- Ack entries are dropped in lockstep with pane/tab teardown in `removeAgentStatus`, `removeAgentStatusByTabPrefix`, `dropAgentStatus`, and `dropAgentStatusByTabPrefix`, so closed panes don't leave stale acks that could silently suppress the "unvisited" signal on future paneKey reuse.
- `onActivate(tabId)` → `onActivate(tabId, paneKey)` on `DashboardAgentRow` — lets the dashboard and sidebar hovercard ack the specific row clicked without re-deriving paneKey from tabId.

## Non-goals
- No UI placement changes. The dashboard still lives in the right-sidebar bottom panel. The agent-cockpit placement move is tracked separately.

## Test plan
- [x] Automated: `agent-status-ack-cleanup.test.ts` covers all four teardown paths and the paneKey-reuse case.
- [x] With the dashboard experiment on, launch a working agent — its row is bold until the user either clicks the row/workspace or has the agent's tab focused when it transitions.
- [x] Multi-agent workspace (Claude + Codex both running): clicking the workspace card acks both rows at once; the header mutes when all rows have been visited.
- [x] Clicking a single agent row acks only that paneKey — sibling rows in the same workspace stay bold.
- [x] Sidebar hovercard: done/waiting/blocked rows render bold until visited; clicking a row through the hovercard fades that row to muted without affecting siblings.
- [x] Have a terminal tab focused AND window visible/focused when its agent transitions to done/blocked: row renders muted immediately (no explicit click needed).
- [x] Window minimized / another app focused when an agent transitions: row STAYS bold. Returning to Orca (Cmd+Tab back, un-minimize, etc.) acks the row on focus return.
- [x] Dismiss X still removes retained done rows without navigating.
- [x] With `experimentalAgentDashboard` off, `useAutoAckViewedAgent` does not write any entries to `acknowledgedAgentsByPaneKey` even when agent transitions arrive — confirmed via CDP: setting the flag off, firing `setAgentStatus` for an agent on the active tab, and observing the ack map stays `{}`. (The PTY-boundary drop at `pty-connection.ts:351` is a separate guard that only affects live OSC 9999 traffic; the slice-level `setAgentStatus` action is ungated by design.)
- [x] Quit + relaunch: the ack map, live `agentStatusByPaneKey`, and retained-done rows are all in-memory only — none are in `PersistedUIState` (`src/shared/types.ts:1059`). Any agent that was running pre-quit reappears only when the agent itself re-emits OSC 9999, and starts unvisited.
- [x] Unrelated store churn does not allocate a new `acknowledgedAgentsByPaneKey` map — confirmed via CDP: 100 synchronous `acknowledgeAgents` calls on the same paneKey produced exactly 1 unique map reference. Unrelated UI-slice writes (sidebar toggle, search query, view flip) also preserve the ref. New references only appear when at least one ack timestamp actually moves forward.

Made with [Orca](https://github.com/stablyai/orca) 🐋