### PR TITLE
fix(sidebar): restore green dot for 'active' worktree status

### DIFF
--- a/src/renderer/src/components/sidebar/StatusIndicator.tsx
+++ b/src/renderer/src/components/sidebar/StatusIndicator.tsx
@@ -19,11 +19,12 @@ const StatusIndicator = React.memo(function StatusIndicator({
   ...rest
 }: StatusIndicatorProps) {
   // Why: surface the status label as a native tooltip so hovering the dot
-  // reveals the state — matters especially for 'active' vs 'inactive', which
-  // share the same grey dot (see color-branch comment below). Callers pass
-  // aria-hidden="true" alongside an sr-only label, so the `title` attribute
-  // is ignored by AT and only serves sighted users on hover. Callers can
-  // override by passing their own `title`.
+  // reveals the state — matters especially for 'active' vs 'done', which
+  // share the same emerald dot until TODO(#1265) lands (see color-branch
+  // comment below). Callers pass aria-hidden="true" alongside an sr-only
+  // label, so the `title` attribute is ignored by AT and only serves
+  // sighted users on hover. Callers can override by passing their own
+  // `title`.
   const resolvedTitle = title ?? getWorktreeStatusLabel(status)
 
   if (status === 'working') {

--- a/src/renderer/src/components/sidebar/StatusIndicator.tsx
+++ b/src/renderer/src/components/sidebar/StatusIndicator.tsx
@@ -49,12 +49,18 @@ const StatusIndicator = React.memo(function StatusIndicator({
           'block size-2 rounded-full',
           status === 'permission'
             ? 'bg-red-500'
-            : status === 'done'
-              ? // Green dot for done; working uses a yellow spinner so the
-                // two states differ by both hue and motion. 'active' (terminal
-                // open, quiet) collapses to the same grey as 'inactive' — the
-                // tooltip carries the distinction for sighted users and the
-                // sr-only sibling in callers carries it for AT.
+            : status === 'done' || status === 'active'
+              ? // Green dot for both hook-reported 'done' and the heuristic
+                // 'active' (terminal open, quiet). Without the 'active'
+                // branch users without the experimental agent-tracking
+                // setting never reach 'done' and lose the green dot
+                // entirely. Working uses a yellow spinner so working vs
+                // done differ by both hue and motion; 'inactive' stays grey.
+                // TODO(#1265): differentiate 'active' (quiet terminal)
+                // from 'done' (agent-reported completion) visually — today
+                // both share emerald, so with the experimental tracking
+                // toggle on a newly-opened quiet terminal reads the same
+                // as a completed agent.
                 'bg-emerald-500'
               : 'bg-neutral-500/40'
         )}


### PR DESCRIPTION
## Summary

- Restore the emerald branch for `'active'` in `StatusIndicator` so terminal-open workspaces stay green again.
- #1246 recolored the sidebar status dot for hook-reported `'done'` from sky blue to emerald but accidentally removed the pre-existing `'active'` → emerald branch. Users without the experimental agent-tracking toggle never reach `'done'` (OSC 9999 ingestion is gated in `pty-connection.ts:351-353`), so every open terminal lost its green dot and collapsed to grey.
- `'active'` and `'done'` now share emerald. That ambiguity is only visible to users with the experimental toggle on and is tracked as a follow-up in `#1265`.

## Test plan

- [x] With experimental agent tracking **off**, open a terminal in a worktree and confirm the sidebar dot is green (was grey before this fix).
- [x] With a Claude Code CLI session finishing a turn (tracking off), confirm the dot stays green instead of turning grey/idle.
- [x] With experimental agent tracking **on**, confirm `done` still renders emerald and `working` still renders the yellow spinner.
- [x] `permission` (blocked/waiting) still renders red; `inactive` (no live terminal) still renders grey.

Made with [Orca](https://github.com/stablyai/orca) 🐋
