### PR TITLE
feat(hooks): restore always-trust repo option

### DIFF
--- a/src/cli/handlers/worktree.ts
+++ b/src/cli/handlers/worktree.ts
@@ -14,6 +14,16 @@ import {
 } from '../flags'
 import { getRequiredWorktreeSelector, resolveCurrentWorktreeSelector } from '../selectors'
 
+type HookWarningResult = {
+  warning?: string
+}
+
+function printHookWarning(result: HookWarningResult, json: boolean): void {
+  if (!json && result.warning) {
+    console.error(`warning: ${result.warning}`)
+  }
+}
+
 export const WORKTREE_HANDLERS: Record<string, CommandHandler> = {
   'worktree ps': async ({ flags, client, json }) => {
     const result = await client.call<RuntimeWorktreePsResult>('worktree.ps', {
@@ -41,14 +51,18 @@ export const WORKTREE_HANDLERS: Record<string, CommandHandler> = {
     printResult(result, json, formatWorktreeShow)
   },
   'worktree create': async ({ flags, client, json }) => {
-    const result = await client.call<{ worktree: RuntimeWorktreeRecord }>('worktree.create', {
-      repo: getRequiredStringFlag(flags, 'repo'),
-      name: getRequiredStringFlag(flags, 'name'),
-      baseBranch: getOptionalStringFlag(flags, 'base-branch'),
-      linkedIssue: getOptionalNumberFlag(flags, 'issue'),
-      comment: getOptionalStringFlag(flags, 'comment'),
-      runHooks: flags.get('run-hooks') === true
-    })
+    const result = await client.call<{ worktree: RuntimeWorktreeRecord; warning?: string }>(
+      'worktree.create',
+      {
+        repo: getRequiredStringFlag(flags, 'repo'),
+        name: getRequiredStringFlag(flags, 'name'),
+        baseBranch: getOptionalStringFlag(flags, 'base-branch'),
+        linkedIssue: getOptionalNumberFlag(flags, 'issue'),
+        comment: getOptionalStringFlag(flags, 'comment'),
+        runHooks: flags.get('run-hooks') === true
+      }
+    )
+    printHookWarning(result.result, json)
     printResult(result, json, formatWorktreeShow)
   },
   'worktree set': async ({ flags, client, cwd, json }) => {
@@ -61,11 +75,12 @@ export const WORKTREE_HANDLERS: Record<string, CommandHandler> = {
     printResult(result, json, formatWorktreeShow)
   },
   'worktree rm': async ({ flags, client, cwd, json }) => {
-    const result = await client.call<{ removed: boolean }>('worktree.rm', {
+    const result = await client.call<{ removed: boolean; warning?: string }>('worktree.rm', {
       worktree: await getRequiredWorktreeSelector(flags, 'worktree', cwd, client),
       force: flags.get('force') === true,
       runHooks: flags.get('run-hooks') === true
     })
+    printHookWarning(result.result, json)
     printResult(result, json, (value) => `removed: ${value.removed}`)
   }
 }

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -1022,7 +1022,9 @@ describe('OrcaRuntimeService', () => {
         repoId: 'repo-1',
         path: '/tmp/workspaces/runtime-hook-skip',
         branch: 'runtime-hook-skip'
-      })
+      }),
+      warning:
+        'orca.yaml setup hook skipped for /tmp/workspaces/runtime-hook-skip; pass --run-hooks to run it.'
     })
     expect(activateWorktree).toHaveBeenCalledWith('repo-1', expect.any(String), undefined)
   })
@@ -1036,10 +1038,13 @@ describe('OrcaRuntimeService', () => {
     })
     vi.mocked(removeWorktree).mockResolvedValue(undefined)
 
-    await runtime.removeManagedWorktree(TEST_WORKTREE_ID)
+    const result = await runtime.removeManagedWorktree(TEST_WORKTREE_ID)
 
     expect(runHook).not.toHaveBeenCalled()
     expect(removeWorktree).toHaveBeenCalledWith(TEST_REPO_PATH, TEST_WORKTREE_PATH, false)
+    expect(result.warning).toBe(
+      `orca.yaml archive hook skipped for ${TEST_WORKTREE_PATH}; pass --run-hooks to run it.`
+    )
   })
 
   it('runs archive hooks for CLI worktree removal when hooks are explicitly enabled', async () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1035,6 +1035,7 @@ export class OrcaRuntimeService {
     const worktree = mergeWorktree(repo.id, created, meta)
 
     let setup: CreateWorktreeResult['setup']
+    let warning: string | undefined
     const hooks = getEffectiveHooks(repo)
     if (hooks?.scripts.setup && args.runHooks === true) {
       if (this.authoritativeWindowId !== null) {
@@ -1059,7 +1060,8 @@ export class OrcaRuntimeService {
       }
     } else if (hooks?.scripts.setup) {
       // Runtime RPC calls have no renderer trust prompt, so hooks require explicit CLI opt-in.
-      console.info(`[hooks] setup hook skipped for ${worktreePath}; pass --run-hooks to run it`)
+      warning = `orca.yaml setup hook skipped for ${worktreePath}; pass --run-hooks to run it.`
+      console.warn(`[hooks] ${warning}`)
     }
 
     this.notifier?.worktreesChanged(repo.id)
@@ -1077,7 +1079,8 @@ export class OrcaRuntimeService {
     invalidateAuthorizedRootsCache()
     return {
       worktree,
-      ...(setup ? { setup } : {})
+      ...(setup ? { setup } : {}),
+      ...(warning ? { warning } : {})
     }
   }
 
@@ -1109,7 +1112,7 @@ export class OrcaRuntimeService {
     worktreeSelector: string,
     force = false,
     runHooks = false
-  ): Promise<void> {
+  ): Promise<{ warning?: string }> {
     if (!this.store) {
       throw new Error('runtime_unavailable')
     }
@@ -1123,6 +1126,7 @@ export class OrcaRuntimeService {
     }
 
     const hooks = getEffectiveHooks(repo)
+    let warning: string | undefined
     if (hooks?.scripts.archive && runHooks) {
       const result = await runHook('archive', worktree.path, repo)
       if (!result.success) {
@@ -1130,7 +1134,8 @@ export class OrcaRuntimeService {
       }
     } else if (hooks?.scripts.archive) {
       // Runtime RPC calls have no renderer trust prompt, so hooks require explicit CLI opt-in.
-      console.info(`[hooks] archive hook skipped for ${worktree.path}; pass --run-hooks to run it`)
+      warning = `orca.yaml archive hook skipped for ${worktree.path}; pass --run-hooks to run it.`
+      console.warn(`[hooks] ${warning}`)
     }
 
     try {
@@ -1147,7 +1152,9 @@ export class OrcaRuntimeService {
         this.invalidateResolvedWorktreeCache()
         invalidateAuthorizedRootsCache()
         this.notifier?.worktreesChanged(repo.id)
-        return
+        return {
+          ...(warning ? { warning } : {})
+        }
       }
       throw new Error(formatWorktreeRemovalError(error, worktree.path, force))
     }
@@ -1156,6 +1163,9 @@ export class OrcaRuntimeService {
     this.invalidateResolvedWorktreeCache()
     invalidateAuthorizedRootsCache()
     this.notifier?.worktreesChanged(repo.id)
+    return {
+      ...(warning ? { warning } : {})
+    }
   }
 
   async renameTerminal(handle: string, title: string | null): Promise<RuntimeTerminalRename> {

--- a/src/main/runtime/rpc/methods/worktree.ts
+++ b/src/main/runtime/rpc/methods/worktree.ts
@@ -95,12 +95,12 @@ export const WORKTREE_METHODS: RpcMethod[] = [
     name: 'worktree.rm',
     params: WorktreeRemove,
     handler: async (params, { runtime }) => {
-      await runtime.removeManagedWorktree(
+      const result = await runtime.removeManagedWorktree(
         params.worktree,
         params.force === true,
         params.runHooks === true
       )
-      return { removed: true }
+      return { removed: true, ...result }
     }
   })
 ]

--- a/src/renderer/src/components/sidebar/OrcaYamlTrustDialog.tsx
+++ b/src/renderer/src/components/sidebar/OrcaYamlTrustDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import {
   Dialog,
   DialogContent,
@@ -30,6 +30,8 @@ const OrcaYamlTrustDialog = React.memo(function OrcaYamlTrustDialog() {
   const modalData = useAppStore((s) => s.modalData)
   const closeModal = useAppStore((s) => s.closeModal)
   const markOrcaHookScriptConfirmed = useAppStore((s) => s.markOrcaHookScriptConfirmed)
+  const markOrcaHookRepoAlwaysTrusted = useAppStore((s) => s.markOrcaHookRepoAlwaysTrusted)
+  const [alwaysTrust, setAlwaysTrust] = useState(false)
 
   const isOpen = activeModal === 'confirm-orca-yaml-hooks'
 
@@ -48,15 +50,34 @@ const OrcaYamlTrustDialog = React.memo(function OrcaYamlTrustDialog() {
       ? (modalData.onResolve as (decision: 'run' | 'skip') => void)
       : null
 
+  useEffect(() => {
+    if (isOpen) {
+      setAlwaysTrust(false)
+    }
+  }, [isOpen])
+
   const resolveAndClose = useCallback(
     (decision: 'run' | 'skip') => {
-      if (decision === 'run' && repoId && contentHash) {
-        markOrcaHookScriptConfirmed(repoId, scriptKind, contentHash)
+      if (decision === 'run' && repoId) {
+        if (alwaysTrust) {
+          markOrcaHookRepoAlwaysTrusted(repoId)
+        } else if (contentHash) {
+          markOrcaHookScriptConfirmed(repoId, scriptKind, contentHash)
+        }
       }
       onResolve?.(decision)
       closeModal()
     },
-    [closeModal, contentHash, markOrcaHookScriptConfirmed, onResolve, repoId, scriptKind]
+    [
+      alwaysTrust,
+      closeModal,
+      contentHash,
+      markOrcaHookRepoAlwaysTrusted,
+      markOrcaHookScriptConfirmed,
+      onResolve,
+      repoId,
+      scriptKind
+    ]
   )
 
   const handleOpenChange = useCallback(
@@ -92,6 +113,18 @@ const OrcaYamlTrustDialog = React.memo(function OrcaYamlTrustDialog() {
             </pre>
           </div>
         )}
+
+        <label className="flex items-start gap-2 text-xs text-foreground">
+          <input
+            type="checkbox"
+            className="mt-0.5 h-3.5 w-3.5"
+            checked={alwaysTrust}
+            onChange={(event) => setAlwaysTrust(event.target.checked)}
+          />
+          <span>
+            Always trust this repository&apos;s <code>orca.yaml</code> hooks.
+          </span>
+        </label>
 
         <DialogFooter>
           <Button variant="outline" onClick={() => resolveAndClose('skip')}>

--- a/src/renderer/src/lib/ensure-hooks-confirmed.test.ts
+++ b/src/renderer/src/lib/ensure-hooks-confirmed.test.ts
@@ -92,6 +92,20 @@ describe('ensureHooksConfirmed', () => {
     await expect(promise).resolves.toBe('run')
   })
 
+  it('returns run without inspecting hooks when the repo is always trusted', async () => {
+    const { state, pending } = createTestState()
+    state.trustedOrcaHooks['repo-1'] = {
+      all: { approvedAt: 1 }
+    }
+    hooksCheckMock.mockRejectedValue(new Error('boom'))
+
+    const decision = await ensureHooksConfirmed(state, 'repo-1', 'setup')
+
+    expect(decision).toBe('run')
+    expect(hooksCheckMock).not.toHaveBeenCalled()
+    expect(pending).toHaveLength(0)
+  })
+
   it('returns run without prompting when no script of that kind is configured', async () => {
     const { state, pending } = createTestState()
     hooksCheckMock.mockResolvedValue({

--- a/src/renderer/src/lib/ensure-hooks-confirmed.ts
+++ b/src/renderer/src/lib/ensure-hooks-confirmed.ts
@@ -23,6 +23,10 @@ export async function ensureHooksConfirmed(
   scriptKind: HookScriptKind
 ): Promise<'run' | 'skip'> {
   return enqueueTrustPrompt(async () => {
+    if (state.trustedOrcaHooks[repoId]?.all) {
+      return 'run'
+    }
+
     let scriptContent = ''
     try {
       if (scriptKind === 'issueCommand') {

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -172,6 +172,7 @@ export type UISlice = {
     kind: OrcaHookScriptKind,
     contentHash: string
   ) => void
+  markOrcaHookRepoAlwaysTrusted: (repoId: string) => void
   clearOrcaHookTrustForRepo: (repoId: string) => void
   searchQuery: string
   setSearchQuery: (q: string) => void
@@ -386,6 +387,22 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
         [kind]: { contentHash, approvedAt: Date.now() }
       }
       const next = { ...s.trustedOrcaHooks, [repoId]: nextRepo }
+      window.api.ui.set({ trustedOrcaHooks: next }).catch(console.error)
+      return { trustedOrcaHooks: next }
+    }),
+  markOrcaHookRepoAlwaysTrusted: (repoId) =>
+    set((s) => {
+      const existing = s.trustedOrcaHooks[repoId]
+      if (existing?.all) {
+        return s
+      }
+      const next = {
+        ...s.trustedOrcaHooks,
+        [repoId]: {
+          ...existing,
+          all: { approvedAt: Date.now() }
+        }
+      }
       window.api.ui.set({ trustedOrcaHooks: next }).catch(console.error)
       return { trustedOrcaHooks: next }
     }),

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -669,6 +669,7 @@ export type CreateWorktreeArgs = {
 export type CreateWorktreeResult = {
   worktree: Worktree
   setup?: WorktreeSetupLaunch
+  warning?: string
 }
 
 // ─── Updater ─────────────────────────────────────────────────────────
@@ -1128,6 +1129,9 @@ export type PersistedTrustedOrcaHookEntry = {
 }
 
 export type PersistedTrustedOrcaHookRepo = {
+  all?: {
+    approvedAt: number
+  }
   setup?: PersistedTrustedOrcaHookEntry
   archive?: PersistedTrustedOrcaHookEntry
   issueCommand?: PersistedTrustedOrcaHookEntry


### PR DESCRIPTION
## Summary
- restores the explicit "Always trust this repository's orca.yaml hooks" option in the hook trust dialog
- stores repo-level hook trust as trustedOrcaHooks[repoId].all
- bypasses future hook inspections/prompts for repos the user has chosen to always trust
- returns and prints CLI-facing warnings when --run-hooks is omitted and an orca.yaml setup/archive hook is skipped

## CLI behavior
- Non-JSON output prints: warning: orca.yaml <setup|archive> hook skipped ... pass --run-hooks to run it.
- JSON output includes the warning in result.warning.
- Worktree create/remove still succeeds; only hook execution is skipped.

## Test plan
- pnpm vitest run --config config/vitest.config.ts src/renderer/src/lib/ensure-hooks-confirmed.test.ts
- pnpm vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts -t "CLI"
- pnpm exec tsgo --noEmit -p config/tsconfig.tc.web.json
- pnpm exec tsgo --noEmit -p config/tsconfig.node.json
- pnpm exec tsgo --noEmit -p config/tsconfig.tc.cli.json
- pnpm exec oxlint <changed files>
- git diff --check
