### PR TITLE
fix(browser-pane): keep focus in Orca when destroying focused webview

### DIFF
--- a/src/renderer/src/components/browser-pane/BrowserPane.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPane.tsx
@@ -148,6 +148,14 @@ export function destroyPersistentWebview(browserTabId: string): void {
     return
   }
   void window.api.browser.unregisterGuest({ browserPageId: browserTabId })
+  // Why: if this webview currently owns focus, removing it lets macOS hand
+  // activation back to the previously-active app (Slack, etc.) because the
+  // focused webContents is gone with no replacement. Move focus back into the
+  // main renderer first so Electron keeps focus inside the Orca window.
+  if (webview === document.activeElement || webview.contains(document.activeElement)) {
+    ;(document.activeElement as HTMLElement | null)?.blur?.()
+    window.focus()
+  }
   webview.remove()
   webviewRegistry.delete(browserTabId)
   registeredWebContentsIds.delete(browserTabId)


### PR DESCRIPTION
## Summary
- Before `webview.remove()` in `destroyPersistentWebview`, if the webview currently owns focus, blur the active element and call `window.focus()` so activation stays inside Orca.
- Without this, macOS hands activation to the previously-active app (e.g. Slack) because the focused webContents disappears with no replacement, pulling the user out of Orca on worktree delete.

## Test plan
- [ ] Focus a browser-pane webview, delete the worktree (or tab), and verify Orca remains frontmost instead of surrendering focus to the previously-active app.
- [ ] Non-focused destroys (tab group cleanup, HMR, workspace teardown) behave unchanged.

Made with [Orca](https://github.com/stablyai/orca) 🐋
