### PR TITLE
feat(settings): replace task-icon toggle with Tasks-button toggle, expose in View menu

### DIFF
--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -64,7 +64,7 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     openLinksInApp: false,
     rightSidebarOpenByDefault: true,
     showTitlebarAgentActivity: true,
-    showTaskProviderIcons: true,
+    showTasksButton: true,
     diffDefaultView: 'inline',
     notifications: {
       enabled: true,

--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -58,7 +58,7 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     openLinksInApp: false,
     rightSidebarOpenByDefault: true,
     showTitlebarAgentActivity: true,
-    showTaskProviderIcons: true,
+    showTasksButton: true,
     diffDefaultView: 'inline',
     notifications: {
       enabled: true,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -18,7 +18,7 @@ import { registerCoreHandlers } from './ipc/register-core-handlers'
 import { triggerStartupNotificationRegistration } from './ipc/notifications'
 import { OrcaRuntimeService } from './runtime/orca-runtime'
 import { OrcaRuntimeRpcServer } from './runtime/runtime-rpc'
-import { registerAppMenu } from './menu/register-app-menu'
+import { registerAppMenu, rebuildAppMenu } from './menu/register-app-menu'
 import { checkForUpdatesFromMenu, isQuittingForUpdate } from './updater'
 import {
   configureDevUserDataPath,
@@ -396,8 +396,40 @@ app.whenReady().then(async () => {
     onZoomReset: () => {
       mainWindow?.webContents.send('terminal:zoom', 'reset')
     },
-    onToggleStatusBar: () => {
-      mainWindow?.webContents.send('ui:toggleStatusBar')
+    onToggleLeftSidebar: () => {
+      mainWindow?.webContents.send('ui:toggleLeftSidebar')
+    },
+    onToggleRightSidebar: () => {
+      mainWindow?.webContents.send('ui:toggleRightSidebar')
+    },
+    onToggleAppearance: (key) => {
+      if (!store) {
+        return
+      }
+      if (key === 'statusBarVisible') {
+        // Why: status bar visibility lives under the persisted UI state
+        // (ui:set/ui:get), not settings. The renderer owns the authoritative
+        // toggle logic (it knows the current value and persists it back), so
+        // we forward the event and let it flip + store.
+        mainWindow?.webContents.send('ui:toggleStatusBar')
+        return
+      }
+      const current = store.getSettings()
+      store.updateSettings({ [key]: !current[key] })
+      // Why: settings:get returns the current snapshot; renderer tracks
+      // settings through window.api.settings.get(). Push the new value so
+      // the sidebar/titlebar re-render without waiting for a round-trip.
+      mainWindow?.webContents.send('settings:changed', { [key]: !current[key] })
+      rebuildAppMenu()
+    },
+    getAppearanceState: () => {
+      const settings = store?.getSettings()
+      const ui = store?.getUI()
+      return {
+        showTasksButton: settings?.showTasksButton !== false,
+        showTitlebarAgentActivity: settings?.showTitlebarAgentActivity !== false,
+        statusBarVisible: ui?.statusBarVisible !== false
+      }
     }
   })
   runtimeRpc = new OrcaRuntimeRpcServer({

--- a/src/main/ipc/settings.ts
+++ b/src/main/ipc/settings.ts
@@ -3,6 +3,16 @@ import type { Store } from '../persistence'
 import type { GlobalSettings, PersistedState } from '../../shared/types'
 import { listSystemFontFamilies } from '../system-fonts'
 import { previewGhosttyImport } from '../ghostty/index'
+import { rebuildAppMenu } from '../menu/register-app-menu'
+
+// Why: fields that appear in the View > Appearance submenu need the menu
+// rebuilt after any update so the checkbox `checked` state stays in sync
+// with the persisted value. Electron doesn't reactively re-render menu
+// items when the backing state changes.
+const APPEARANCE_MENU_KEYS: readonly (keyof GlobalSettings)[] = [
+  'showTasksButton',
+  'showTitlebarAgentActivity'
+]
 
 export function registerSettingsHandlers(store: Store): void {
   ipcMain.handle('settings:get', () => {
@@ -13,7 +23,11 @@ export function registerSettingsHandlers(store: Store): void {
     if (args.theme) {
       nativeTheme.themeSource = args.theme
     }
-    return store.updateSettings(args)
+    const result = store.updateSettings(args)
+    if (APPEARANCE_MENU_KEYS.some((key) => key in args)) {
+      rebuildAppMenu()
+    }
+    return result
   })
 
   ipcMain.handle('settings:listFonts', () => {

--- a/src/main/menu/register-app-menu.test.ts
+++ b/src/main/menu/register-app-menu.test.ts
@@ -30,7 +30,14 @@ function buildMenuOptions() {
     onZoomIn: vi.fn(),
     onZoomOut: vi.fn(),
     onZoomReset: vi.fn(),
-    onToggleStatusBar: vi.fn()
+    onToggleLeftSidebar: vi.fn(),
+    onToggleRightSidebar: vi.fn(),
+    onToggleAppearance: vi.fn(),
+    getAppearanceState: vi.fn(() => ({
+      showTasksButton: true,
+      showTitlebarAgentActivity: true,
+      statusBarVisible: true
+    }))
   }
 }
 
@@ -181,5 +188,75 @@ describe('registerAppMenu', () => {
     expect(fileLabels).not.toContain('Exit')
     // No Help menu on macOS — About/Check for Updates live in the app menu.
     expect(template.find((item) => item.label === 'Help')).toBeUndefined()
+  })
+
+  it('exposes an Appearance submenu under View with checkbox items reflecting state', () => {
+    const options = buildMenuOptions()
+    options.getAppearanceState.mockReturnValue({
+      showTasksButton: false,
+      showTitlebarAgentActivity: true,
+      statusBarVisible: true
+    })
+    registerAppMenu(options)
+
+    const viewSubmenu = getSubmenu(getTemplate(), 'View')
+    const appearanceEntry = viewSubmenu.find((item) => item.label === 'Appearance')
+    expect(appearanceEntry).toBeDefined()
+
+    const appearanceSubmenu = (appearanceEntry?.submenu ??
+      []) as Electron.MenuItemConstructorOptions[]
+    const tasksItem = appearanceSubmenu.find((item) => item.label === 'Show Tasks Button')
+    expect(tasksItem?.type).toBe('checkbox')
+    expect(tasksItem?.checked).toBe(false)
+
+    const titlebarItem = appearanceSubmenu.find(
+      (item) => item.label === 'Show Titlebar Agent Activity'
+    )
+    expect(titlebarItem?.checked).toBe(true)
+
+    const statusBarItem = appearanceSubmenu.find((item) => item.label === 'Show Status Bar')
+    expect(statusBarItem?.checked).toBe(true)
+  })
+
+  it('routes Appearance checkbox clicks through onToggleAppearance', () => {
+    const options = buildMenuOptions()
+    registerAppMenu(options)
+
+    const viewSubmenu = getSubmenu(getTemplate(), 'View')
+    const appearanceSubmenu = (viewSubmenu.find((item) => item.label === 'Appearance')?.submenu ??
+      []) as Electron.MenuItemConstructorOptions[]
+
+    appearanceSubmenu
+      .find((item) => item.label === 'Show Tasks Button')
+      ?.click?.({} as never, {} as never, {} as never)
+
+    expect(options.onToggleAppearance).toHaveBeenCalledWith('showTasksButton')
+  })
+
+  it('routes sidebar toggle items through their callbacks', () => {
+    const options = buildMenuOptions()
+    registerAppMenu(options)
+
+    const viewSubmenu = getSubmenu(getTemplate(), 'View')
+    const appearanceSubmenu = (viewSubmenu.find((item) => item.label === 'Appearance')?.submenu ??
+      []) as Electron.MenuItemConstructorOptions[]
+
+    const leftLabel = `Toggle Left Sidebar\t${isMac ? 'Cmd+B' : 'Ctrl+B'}`
+    const rightLabel = `Toggle Right Sidebar\t${isMac ? 'Alt+Cmd+B' : 'Ctrl+Alt+B'}`
+
+    appearanceSubmenu
+      .find((item) => item.label === leftLabel)
+      ?.click?.({} as never, {} as never, {} as never)
+    appearanceSubmenu
+      .find((item) => item.label === rightLabel)
+      ?.click?.({} as never, {} as never, {} as never)
+
+    expect(options.onToggleLeftSidebar).toHaveBeenCalledTimes(1)
+    expect(options.onToggleRightSidebar).toHaveBeenCalledTimes(1)
+    // Why: these entries must not bind Cmd/Ctrl+B as real accelerators
+    // because before-input-event carries a TipTap-bold carve-out that the
+    // menu accelerator would bypass.
+    expect(appearanceSubmenu.find((item) => item.label === leftLabel)?.accelerator).toBeUndefined()
+    expect(appearanceSubmenu.find((item) => item.label === rightLabel)?.accelerator).toBeUndefined()
   })
 })

--- a/src/main/menu/register-app-menu.ts
+++ b/src/main/menu/register-app-menu.ts
@@ -1,23 +1,40 @@
 import { BrowserWindow, Menu, app } from 'electron'
 
+export type AppearanceMenuState = {
+  showTasksButton: boolean
+  showTitlebarAgentActivity: boolean
+  statusBarVisible: boolean
+}
+
+export type AppearanceMenuKey = keyof AppearanceMenuState
+
 type RegisterAppMenuOptions = {
   onOpenSettings: () => void
   onCheckForUpdates: (options: { includePrerelease: boolean }) => void
   onZoomIn: () => void
   onZoomOut: () => void
   onZoomReset: () => void
-  onToggleStatusBar: () => void
+  onToggleLeftSidebar: () => void
+  onToggleRightSidebar: () => void
+  onToggleAppearance: (key: AppearanceMenuKey) => void
+  getAppearanceState: () => AppearanceMenuState
 }
 
-export function registerAppMenu({
-  onOpenSettings,
-  onCheckForUpdates,
-  onZoomIn,
-  onZoomOut,
-  onZoomReset,
-  onToggleStatusBar
-}: RegisterAppMenuOptions): void {
+function buildAndApplyMenu(options: RegisterAppMenuOptions): void {
+  const {
+    onOpenSettings,
+    onCheckForUpdates,
+    onZoomIn,
+    onZoomOut,
+    onZoomReset,
+    onToggleLeftSidebar,
+    onToggleRightSidebar,
+    onToggleAppearance,
+    getAppearanceState
+  } = options
+
   const isMac = process.platform === 'darwin'
+  const appearance = getAppearanceState()
 
   const reloadFocusedWindow = (ignoreCache: boolean): void => {
     const webContents = BrowserWindow.getFocusedWindow()?.webContents
@@ -125,6 +142,53 @@ export function registerAppMenu({
     ]
   }
 
+  // Why: mirror VS Code's View > Appearance submenu so users can toggle
+  // sidebar/status-bar/tasks-button/titlebar-activity from the menu bar as
+  // well as from the settings pane. Electron doesn't reactively update
+  // menu items when the backing state changes, so rebuildAppMenu() must be
+  // called after every settings update — each build reads current
+  // appearance state through getAppearanceState() and produces a fresh
+  // template with accurate `checked` values.
+  const appearanceSubmenu: Electron.MenuItemConstructorOptions = {
+    label: 'Appearance',
+    submenu: [
+      {
+        // Why: display-only shortcut hint — not a real accelerator. Cmd/Ctrl+B
+        // is intercepted in createMainWindow.ts's before-input-event handler
+        // with a TipTap-bold carve-out for markdown editors. Binding the
+        // accelerator here would steal the chord before that carve-out can
+        // fire. Sidebar open/closed lives in the renderer store (non-persisted),
+        // so we forward a toggle request rather than mirroring state in main.
+        label: `Toggle Left Sidebar\t${isMac ? 'Cmd+B' : 'Ctrl+B'}`,
+        click: () => onToggleLeftSidebar()
+      },
+      {
+        // Why: display-only shortcut hint for the same reason as above.
+        label: `Toggle Right Sidebar\t${isMac ? 'Alt+Cmd+B' : 'Ctrl+Alt+B'}`,
+        click: () => onToggleRightSidebar()
+      },
+      {
+        label: 'Show Status Bar',
+        type: 'checkbox',
+        checked: appearance.statusBarVisible,
+        click: () => onToggleAppearance('statusBarVisible')
+      },
+      { type: 'separator' },
+      {
+        label: 'Show Tasks Button',
+        type: 'checkbox',
+        checked: appearance.showTasksButton,
+        click: () => onToggleAppearance('showTasksButton')
+      },
+      {
+        label: 'Show Titlebar Agent Activity',
+        type: 'checkbox',
+        checked: appearance.showTitlebarAgentActivity,
+        click: () => onToggleAppearance('showTitlebarAgentActivity')
+      }
+    ]
+  }
+
   const viewMenu: Electron.MenuItemConstructorOptions = {
     label: 'View',
     submenu: [
@@ -178,10 +242,7 @@ export function registerAppMenu({
       { type: 'separator' },
       { role: 'togglefullscreen' },
       { type: 'separator' },
-      {
-        label: 'Toggle Status Bar',
-        click: () => onToggleStatusBar()
-      }
+      appearanceSubmenu
     ]
   }
 
@@ -209,4 +270,21 @@ export function registerAppMenu({
   ]
 
   Menu.setApplicationMenu(Menu.buildFromTemplate(template))
+}
+
+let lastRegisterOptions: RegisterAppMenuOptions | null = null
+
+export function registerAppMenu(options: RegisterAppMenuOptions): void {
+  lastRegisterOptions = options
+  buildAndApplyMenu(options)
+}
+
+/** Rebuild the application menu using the options from the most recent
+ *  registerAppMenu call. Used to refresh checkbox `checked` state when
+ *  settings that feed the Appearance submenu change, since Electron's
+ *  menu items do not reactively re-render when the backing state updates. */
+export function rebuildAppMenu(): void {
+  if (lastRegisterOptions) {
+    buildAndApplyMenu(lastRegisterOptions)
+  }
 }

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -77,7 +77,7 @@ describe('Store', () => {
     expect(settings.terminalFontSize).toBe(14)
     expect(settings.terminalFontWeight).toBe(500)
     expect(settings.rightSidebarOpenByDefault).toBe(true)
-    expect(settings.showTaskProviderIcons).toBe(true)
+    expect(settings.showTasksButton).toBe(true)
   })
 
   it('returns default UI state when no data file exists', async () => {
@@ -145,7 +145,7 @@ describe('Store', () => {
     expect(store.getSettings().editorAutoSaveDelayMs).toBe(1000)
     expect(store.getSettings().refreshLocalBaseRefOnWorktreeCreate).toBe(false)
     expect(store.getSettings().rightSidebarOpenByDefault).toBe(true)
-    expect(store.getSettings().showTaskProviderIcons).toBe(true)
+    expect(store.getSettings().showTasksButton).toBe(true)
     // repos should be loaded
     expect(store.getRepos()).toHaveLength(1)
   })

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -522,6 +522,10 @@ export type PreloadApi = {
     set: (args: Partial<GlobalSettings>) => Promise<GlobalSettings>
     listFonts: () => Promise<string[]>
     previewGhosttyImport: () => Promise<GhosttyImportPreview>
+    /** Subscribe to out-of-band settings updates (e.g. the View > Appearance
+     *  menu toggles) so the renderer can stay in sync with main's persisted
+     *  state without round-tripping through settings:get. */
+    onChanged: (callback: (updates: Partial<GlobalSettings>) => void) => () => void
   }
   codexAccounts: {
     list: () => Promise<CodexRateLimitAccountsState>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -589,7 +589,16 @@ const api = {
     listFonts: (): Promise<string[]> => ipcRenderer.invoke('settings:listFonts'),
 
     previewGhosttyImport: (): Promise<GhosttyImportPreview> =>
-      ipcRenderer.invoke('settings:previewGhosttyImport')
+      ipcRenderer.invoke('settings:previewGhosttyImport'),
+
+    onChanged: (callback: (updates: Record<string, unknown>) => void): (() => void) => {
+      const listener = (
+        _event: Electron.IpcRendererEvent,
+        updates: Record<string, unknown>
+      ): void => callback(updates)
+      ipcRenderer.on('settings:changed', listener)
+      return () => ipcRenderer.removeListener('settings:changed', listener)
+    }
   },
 
   codexAccounts: {

--- a/src/renderer/src/components/settings/AppearancePane.tsx
+++ b/src/renderer/src/components/settings/AppearancePane.tsx
@@ -34,9 +34,9 @@ export const APPEARANCE_PANE_SEARCH_ENTRIES: SettingsSearchEntry[] = [
     keywords: ['titlebar', 'agent', 'badge', 'active', 'count', 'status']
   },
   {
-    title: 'Task Provider Icons',
-    description: 'Show GitHub and Linear icons in the Tasks sidebar button.',
-    keywords: ['tasks', 'sidebar', 'github', 'linear', 'icons', 'badges']
+    title: 'Show Tasks Button',
+    description: 'Show the Tasks button at the top of the left sidebar.',
+    keywords: ['tasks', 'sidebar', 'button', 'hide', 'show', 'github', 'linear']
   }
 ]
 
@@ -198,36 +198,35 @@ export function AppearancePane({
       <section key="sidebar" className="space-y-4">
         <div className="space-y-1">
           <h3 className="text-sm font-semibold">Sidebar</h3>
-          <p className="text-xs text-muted-foreground">Tune the left sidebar chrome.</p>
         </div>
 
         <SearchableSetting
-          title="Task Provider Icons"
-          description="Show GitHub and Linear icons in the Tasks sidebar button."
-          keywords={['tasks', 'sidebar', 'github', 'linear', 'icons', 'badges']}
+          title="Show Tasks Button"
+          description="Show the Tasks button at the top of the left sidebar."
+          keywords={['tasks', 'sidebar', 'button', 'hide', 'show', 'github', 'linear']}
           className="flex items-center justify-between gap-4 px-1 py-2"
         >
           <div className="space-y-0.5">
-            <Label>Task Provider Icons</Label>
+            <Label>Show Tasks Button</Label>
             <p className="text-xs text-muted-foreground">
-              Show GitHub and Linear icons next to the Tasks button.
+              Show the Tasks button at the top of the left sidebar.
             </p>
           </div>
           <button
             role="switch"
-            aria-checked={settings.showTaskProviderIcons}
+            aria-checked={settings.showTasksButton}
             onClick={() =>
               updateSettings({
-                showTaskProviderIcons: !settings.showTaskProviderIcons
+                showTasksButton: !settings.showTasksButton
               })
             }
             className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent transition-colors ${
-              settings.showTaskProviderIcons ? 'bg-foreground' : 'bg-muted-foreground/30'
+              settings.showTasksButton ? 'bg-foreground' : 'bg-muted-foreground/30'
             }`}
           >
             <span
               className={`pointer-events-none block size-3.5 rounded-full bg-background shadow-sm transition-transform ${
-                settings.showTaskProviderIcons ? 'translate-x-4' : 'translate-x-0.5'
+                settings.showTasksButton ? 'translate-x-4' : 'translate-x-0.5'
               }`}
             />
           </button>

--- a/src/renderer/src/components/sidebar/SidebarNav.tsx
+++ b/src/renderer/src/components/sidebar/SidebarNav.tsx
@@ -1,18 +1,10 @@
 import React from 'react'
-import { Github, List } from 'lucide-react'
+import { List } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { useRepoMap } from '@/store/selectors'
 import { cn } from '@/lib/utils'
 import { isGitRepoKind } from '../../../../shared/repo-kind'
 import { getTaskPresetQuery, PER_REPO_FETCH_LIMIT } from '@/lib/new-workspace'
-
-function LinearIcon({ className }: { className?: string }): React.JSX.Element {
-  return (
-    <svg viewBox="0 0 24 24" aria-hidden className={className} fill="currentColor">
-      <path d="M2.886 4.18A11.982 11.982 0 0 1 11.99 0C18.624 0 24 5.376 24 12.009c0 3.64-1.62 6.903-4.18 9.105L2.887 4.18ZM1.817 5.626l16.556 16.556c-.524.33-1.075.62-1.65.866L.951 7.277c.247-.575.537-1.126.866-1.65ZM.322 9.163l14.515 14.515c-.71.172-1.443.282-2.195.322L0 11.358a12 12 0 0 1 .322-2.195Zm-.17 4.862 9.823 9.824a12.02 12.02 0 0 1-9.824-9.824Z" />
-    </svg>
-  )
-}
 
 const SidebarNav = React.memo(function SidebarNav() {
   const openTaskPage = useAppStore((s) => s.openTaskPage)
@@ -20,7 +12,9 @@ const SidebarNav = React.memo(function SidebarNav() {
   const repos = useAppStore((s) => s.repos)
   const repoMap = useRepoMap()
   const canBrowseTasks = repos.some((repo) => isGitRepoKind(repo))
-  const showTaskProviderIcons = useAppStore((s) => s.settings?.showTaskProviderIcons !== false)
+  // Why: the setting is opt-out (default true). `!== false` keeps the button
+  // visible for users whose persisted settings predate this field.
+  const showTasksButton = useAppStore((s) => s.settings?.showTasksButton !== false)
 
   // Why: warm the GitHub work-item cache on hover/focus so by the time the
   // user's click finishes the round-trip has either completed or is already
@@ -51,6 +45,10 @@ const SidebarNav = React.memo(function SidebarNav() {
 
   const tasksActive = activeView === 'tasks'
 
+  if (!showTasksButton) {
+    return null
+  }
+
   return (
     <div className="flex flex-col gap-0.5 px-2 pt-2 pb-1">
       <button
@@ -75,38 +73,6 @@ const SidebarNav = React.memo(function SidebarNav() {
       >
         <List className="size-4 shrink-0" strokeWidth={2.25} />
         <span className="flex-1">Tasks</span>
-        {showTaskProviderIcons ? (
-          <span className="flex items-center gap-1">
-            <span
-              role="button"
-              tabIndex={-1}
-              onClick={(e) => {
-                e.stopPropagation()
-                if (!canBrowseTasks) {
-                  return
-                }
-                openTaskPage({ taskSource: 'github' })
-              }}
-              className="rounded p-0.5 text-muted-foreground/70 transition-colors hover:text-foreground"
-            >
-              <Github className="size-3.5" aria-hidden />
-            </span>
-            <span
-              role="button"
-              tabIndex={-1}
-              onClick={(e) => {
-                e.stopPropagation()
-                if (!canBrowseTasks) {
-                  return
-                }
-                openTaskPage({ taskSource: 'linear' })
-              }}
-              className="rounded p-0.5 text-muted-foreground/70 transition-colors hover:text-foreground"
-            >
-              <LinearIcon className="size-3.5" />
-            </span>
-          </span>
-        ) : null}
       </button>
     </div>
   )

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -178,6 +178,9 @@ describe('useIpcEvents updater integration', () => {
           getZoomLevel: () => 0,
           set: vi.fn()
         },
+        settings: {
+          onChanged: () => () => {}
+        },
         updater: {
           getStatus: () => Promise.resolve({ state: 'idle' }),
           onStatus: (listener: (status: unknown) => void) => {
@@ -365,6 +368,9 @@ describe('useIpcEvents updater integration', () => {
           getZoomLevel: () => 0,
           set: vi.fn()
         },
+        settings: {
+          onChanged: () => () => {}
+        },
         updater: {
           getStatus: () => Promise.resolve({ state: 'idle' }),
           onStatus: () => () => {},
@@ -549,6 +555,9 @@ describe('useIpcEvents updater integration', () => {
           onTerminalZoom: () => () => {},
           getZoomLevel: () => 0,
           set: vi.fn()
+        },
+        settings: {
+          onChanged: () => () => {}
         },
         updater: {
           getStatus: () => Promise.resolve({ state: 'idle' }),
@@ -747,6 +756,9 @@ describe('useIpcEvents browser tab close routing', () => {
           getZoomLevel: () => 0,
           set: vi.fn()
         },
+        settings: {
+          onChanged: () => () => {}
+        },
         updater: {
           getStatus: () => Promise.resolve({ state: 'idle' }),
           onStatus: () => () => {},
@@ -929,6 +941,9 @@ describe('useIpcEvents browser tab close routing', () => {
           getZoomLevel: () => 0,
           set: vi.fn()
         },
+        settings: {
+          onChanged: () => () => {}
+        },
         updater: {
           getStatus: () => Promise.resolve({ state: 'idle' }),
           onStatus: () => () => {},
@@ -1105,6 +1120,9 @@ describe('useIpcEvents browser tab close routing', () => {
           onTerminalZoom: () => () => {},
           getZoomLevel: () => 0,
           set: vi.fn()
+        },
+        settings: {
+          onChanged: () => () => {}
         },
         updater: {
           getStatus: () => Promise.resolve({ state: 'idle' }),
@@ -1291,6 +1309,9 @@ describe('useIpcEvents shortcut hint clearing', () => {
           onTerminalZoom: () => () => {},
           getZoomLevel: () => 0,
           set: vi.fn()
+        },
+        settings: {
+          onChanged: () => () => {}
         },
         updater: {
           getStatus: () => Promise.resolve({ state: 'idle' }),
@@ -1484,6 +1505,9 @@ describe('useIpcEvents CLI-created worktree activation', () => {
           onTerminalZoom: () => () => {},
           getZoomLevel: () => 0,
           set: vi.fn()
+        },
+        settings: {
+          onChanged: () => () => {}
         },
         updater: {
           getStatus: () => Promise.resolve({ state: 'idle' }),

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -45,6 +45,30 @@ export function useIpcEvents(): void {
       })
     )
 
+    // Why: the View > Appearance menu toggles settings directly in main (so
+    // checkbox state reflects the persisted value without a round-trip) and
+    // broadcasts the change. Merge it into the store so the sidebar and
+    // titlebar re-render immediately instead of waiting for the next
+    // fetchSettings() call.
+    unsubs.push(
+      window.api.settings.onChanged((updates) => {
+        const store = useAppStore.getState()
+        if (!store.settings) {
+          return
+        }
+        useAppStore.setState({
+          settings: {
+            ...store.settings,
+            ...updates,
+            notifications: {
+              ...store.settings.notifications,
+              ...updates.notifications
+            }
+          }
+        })
+      })
+    )
+
     unsubs.push(
       window.api.ui.onToggleLeftSidebar(() => {
         dispatchClearModifierHints()

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -160,7 +160,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     openLinksInApp: true,
     rightSidebarOpenByDefault: true,
     showTitlebarAgentActivity: true,
-    showTaskProviderIcons: true,
+    showTasksButton: true,
     notifications: getDefaultNotificationSettings(),
     diffDefaultView: 'inline',
     promptCacheTimerEnabled: false,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -919,9 +919,10 @@ export type GlobalSettings = {
   rightSidebarOpenByDefault: boolean
   /** Whether to show the live agent activity count badge in the titlebar. */
   showTitlebarAgentActivity: boolean
-  /** Why: the Tasks sidebar label can be kept cleaner for users who do not
-   *  actively use the GitHub/Linear integrations behind it. */
-  showTaskProviderIcons: boolean
+  /** Why: some users do not use the Tasks feature and prefer to keep the
+   *  left sidebar free of its button entirely. Hiding the button here also
+   *  removes it from keyboard navigation. */
+  showTasksButton: boolean
   diffDefaultView: 'inline' | 'side-by-side'
   notifications: NotificationSettings
   /** When true, a countdown timer is shown after a Claude agent becomes idle,


### PR DESCRIPTION
## Summary
- Replaced the "Task Provider Icons" toggle (which only hid the GitHub/Linear badges on the sidebar Tasks button) with "Show Tasks Button", which hides the entire Tasks row in the left sidebar
- Dropped the confusing "Tune the left sidebar chrome" subtitle from Settings → Appearance → Sidebar
- Added a VS Code-inspired View → Appearance submenu with Toggle Left/Right Sidebar, Show Status Bar, Show Tasks Button, and Show Titlebar Agent Activity — with live checkbox state kept in sync via a menu rebuild on setting change

## Test plan
- [x] `pnpm typecheck` passes
- [x] `vitest` passes for affected files (menu, settings IPC, persistence, useIpcEvents, codex-accounts)
- [x] In dev Orca: Settings → Appearance → Sidebar shows "Show Tasks Button" (no "Tune" text). Toggling it off removes the Tasks button from the sidebar; toggling on restores it.
- [ ] View → Appearance menu shows the 5 items with accurate checkbox state; clicking Show Tasks Button and Show Titlebar Agent Activity updates the UI and persists

Made with [Orca](https://github.com/stablyai/orca) 🐋
