### PR TITLE
fix(mac-perms): fall through to Privacy pane when in-app prompt is a no-op

### DIFF
--- a/src/main/ipc/developer-permissions.ts
+++ b/src/main/ipc/developer-permissions.ts
@@ -147,13 +147,32 @@ async function requestPermission(
   }
 
   if (id === 'microphone' || id === 'camera') {
+    // Why: askForMediaAccess only surfaces the TCC prompt when status is
+    // 'not-determined'. If the user previously denied (or macOS set the status
+    // to 'denied'/'restricted'), it resolves false with no prompt — leaving
+    // the user stuck. Fall through to the Privacy pane so they can toggle it.
     const granted = await systemPreferences.askForMediaAccess(id)
-    return { id, status: granted ? 'granted' : getMediaStatus(id), openedSystemSettings: false }
+    if (granted) {
+      return { id, status: 'granted', openedSystemSettings: false }
+    }
+    const status = getMediaStatus(id)
+    if (status === 'denied' || status === 'restricted' || status === 'unknown') {
+      await openPrivacyPane(id)
+      return { id, status, openedSystemSettings: true }
+    }
+    return { id, status, openedSystemSettings: false }
   }
 
   if (id === 'accessibility') {
-    systemPreferences.isTrustedAccessibilityClient(true)
-    return { id, status: getAccessibilityStatus(), openedSystemSettings: false }
+    // Why: isTrustedAccessibilityClient(true) shows the prompt only the first
+    // time for a given bundle. Once the user has dismissed or denied, calling
+    // it again is a no-op. Fall through to the Privacy pane when not granted.
+    const trusted = systemPreferences.isTrustedAccessibilityClient(true)
+    if (trusted) {
+      return { id, status: 'granted', openedSystemSettings: false }
+    }
+    await openPrivacyPane(id)
+    return { id, status: getAccessibilityStatus(), openedSystemSettings: true }
   }
 
   if (id === 'automation') {

--- a/src/renderer/src/components/settings/DeveloperPermissionsPane.tsx
+++ b/src/renderer/src/components/settings/DeveloperPermissionsPane.tsx
@@ -179,6 +179,18 @@ export function DeveloperPermissionsPane(): React.JSX.Element {
     void refresh()
   }, [refresh])
 
+  // Why: after the user flips a permission in System Settings and switches
+  // back to Orca, the chip should reflect the new status without a manual
+  // Refresh click. Tied to window focus rather than a polling interval so
+  // we don't keep hammering `systemPreferences` while the pane is idle.
+  useEffect(() => {
+    const onFocus = (): void => {
+      void refresh()
+    }
+    window.addEventListener('focus', onFocus)
+    return () => window.removeEventListener('focus', onFocus)
+  }, [refresh])
+
   const request = async (id: DeveloperPermissionId): Promise<void> => {
     setPendingId(id)
     try {


### PR DESCRIPTION
## Problem

After #1233 shipped the Settings → Permissions pane, clicking **Request** on Microphone (or Camera) while macOS had the permission set to Denied did nothing visible except show a toast that read *"Permission request sent"*. No TCC dialog appeared, and the user had no way to actually toggle the permission on from Orca.

Root cause: `systemPreferences.askForMediaAccess(type)` only surfaces the macOS prompt when the current status is `'not-determined'`. If the user has already denied (or the status is otherwise non-pending), the API resolves `false` with no side effect. The IPC handler was returning `openedSystemSettings: false` in that case, which hit the generic fallback toast in the renderer.

`systemPreferences.isTrustedAccessibilityClient(true)` has the same one-shot behavior for Accessibility.

## Fix

When the in-app prompt API cannot grant access, open the matching Privacy & Security deep-link pane so the user can flip the permission themselves:

- **Microphone / Camera**: if `askForMediaAccess` resolves false and the status is `denied`, `restricted`, or `unknown`, open the Privacy → Microphone (or Camera) pane and report `openedSystemSettings: true` — the renderer then shows the correct "Opened macOS Privacy & Security" toast.
- **Accessibility**: if `isTrustedAccessibilityClient(true)` returns false, open Privacy → Accessibility the same way.

No behavioral change when the in-app prompt can actually grant access: `askForMediaAccess` on a `'not-determined'` status still shows the native TCC dialog as before.

## Testing

- `pnpm exec oxlint src/main/ipc/developer-permissions.ts`
- `pnpm run typecheck:node`
- Manual end-to-end via Electron CDP: launched Orca dev, opened Settings → Permissions, confirmed the Microphone row showed **Denied**, clicked **Request**. Observed: macOS Privacy → Microphone pane opened, and the in-app toast correctly read *"Opened macOS Privacy & Security"* (previously it showed the misleading *"Permission request sent"*).

Made with [Orca](https://github.com/stablyai/orca) 🐋
