### PR TITLE
fix(tab-bar): dismiss tab context menu on window blur for webview clicks

### DIFF
--- a/src/renderer/src/components/tab-bar/BrowserTab.tsx
+++ b/src/renderer/src/components/tab-bar/BrowserTab.tsx
@@ -97,6 +97,20 @@ export default function BrowserTab({
     return () => window.removeEventListener(CLOSE_ALL_CONTEXT_MENUS_EVENT, closeMenu)
   }, [])
 
+  // Why: Electron <webview> elements run in a separate process, so clicking
+  // inside one never dispatches a pointerdown on the renderer document. Radix
+  // DropdownMenu relies on document pointerdown for outside-click detection,
+  // so it misses webview clicks. Listening for window blur catches the moment
+  // focus leaves the renderer (including into a webview).
+  useEffect(() => {
+    if (!menuOpen) {
+      return
+    }
+    const dismiss = (): void => setMenuOpen(false)
+    window.addEventListener('blur', dismiss)
+    return () => window.removeEventListener('blur', dismiss)
+  }, [menuOpen])
+
   return (
     <>
       <div

--- a/src/renderer/src/components/tab-bar/EditorFileTab.tsx
+++ b/src/renderer/src/components/tab-bar/EditorFileTab.tsx
@@ -178,6 +178,20 @@ export default function EditorFileTab({
     return () => window.removeEventListener(CLOSE_ALL_CONTEXT_MENUS_EVENT, closeMenu)
   }, [])
 
+  // Why: Electron <webview> elements run in a separate process, so clicking
+  // inside one never dispatches a pointerdown on the renderer document. Radix
+  // DropdownMenu relies on document pointerdown for outside-click detection,
+  // so it misses webview clicks. Listening for window blur catches the moment
+  // focus leaves the renderer (including into a webview).
+  useEffect(() => {
+    if (!menuOpen) {
+      return
+    }
+    const dismiss = (): void => setMenuOpen(false)
+    window.addEventListener('blur', dismiss)
+    return () => window.removeEventListener('blur', dismiss)
+  }, [menuOpen])
+
   return (
     <>
       <div

--- a/src/renderer/src/components/tab-bar/SortableTab.tsx
+++ b/src/renderer/src/components/tab-bar/SortableTab.tsx
@@ -149,6 +149,20 @@ export default function SortableTab({
     return () => window.removeEventListener(CLOSE_ALL_CONTEXT_MENUS_EVENT, closeMenu)
   }, [])
 
+  // Why: Electron <webview> elements run in a separate process, so clicking
+  // inside one never dispatches a pointerdown on the renderer document. Radix
+  // DropdownMenu relies on document pointerdown for outside-click detection,
+  // so it misses webview clicks. Listening for window blur catches the moment
+  // focus leaves the renderer (including into a webview).
+  useEffect(() => {
+    if (!menuOpen) {
+      return
+    }
+    const dismiss = (): void => setMenuOpen(false)
+    window.addEventListener('blur', dismiss)
+    return () => window.removeEventListener('blur', dismiss)
+  }, [menuOpen])
+
   // Why: while editing, suppress dnd-kit drag listeners and tab-activation/double-click
   // handlers so typing/clicking inside the inline input doesn't start a drag, re-open the
   // editor, or steal focus away from the input. We still spread `attributes` unconditionally


### PR DESCRIPTION
## Problem
Tab context menus remain stuck open when a user clicks inside an Electron `<webview>` element. This is because `<webview>` runs in a separate process, so clicks inside it don't dispatch `pointerdown` on the renderer document. Radix DropdownMenu relies on document `pointerdown` for outside-click detection, and therefore misses webview clicks entirely.

## Solution
Added a `useEffect` hook to each tab component (BrowserTab, EditorFileTab, SortableTab) that listens for `window.blur` events. When focus leaves the renderer (including into a webview), the event handler closes the context menu by setting `menuOpen` to false. This ensures the menu state stays clean when users interact with embedded webviews.

Made with [Orca](https://github.com/stablyai/orca) 🐋
