### PR TITLE
feat: implement hierarchical tree view for PR diff file list fixes #1109 

### DIFF
--- a/src/renderer/src/components/GitHubItemDialog.tsx
+++ b/src/renderer/src/components/GitHubItemDialog.tsx
@@ -365,13 +365,12 @@ function PRDiffTreeNode({
 
   // Directory node
   return (
-    <div>
+    <div role="treeitem" aria-expanded={open}>
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
         className="flex w-full items-center gap-1.5 px-3 py-1.5 text-left transition hover:bg-muted/40"
         style={{ paddingLeft: `${12 + depth * 16}px` }}
-        aria-expanded={open}
         aria-label={`${open ? 'Collapse' : 'Expand'} folder ${node.name}`}
       >
         {open ? (
@@ -390,7 +389,7 @@ function PRDiffTreeNode({
         </span>
       </button>
       {open && (
-        <div>
+        <div role="group">
           {node.children.map((child) => (
             <PRDiffTreeNode
               key={child.kind === 'file' ? child.file.path : child.path}
@@ -428,7 +427,7 @@ function PRDiffTreeView({
 }: PRDiffTreeViewProps): React.JSX.Element {
   const tree = useMemo(() => buildDiffTree(files), [files])
   return (
-    <div>
+    <div role="tree" aria-label="Changed files">
       {tree.map((node) => (
         <PRDiffTreeNode
           key={node.kind === 'file' ? node.file.path : node.path}
@@ -605,7 +604,7 @@ function PRFileRow({
   )
 
   return (
-    <div className="border-b border-border/50">
+    <div className="border-b border-border/50" {...(label != null ? { role: 'treeitem' } : {})}>
       <button
         type="button"
         onClick={handleToggle}
@@ -627,12 +626,43 @@ function PRFileRow({
           {fileStatusLabel(file.status)}
         </span>
         <span className="min-w-0 flex-1 truncate font-mono text-[12px] text-foreground">
-          {file.oldPath && file.oldPath !== file.path && !label ? (
-            <>
-              <span className="text-muted-foreground">{file.oldPath}</span>
-              <span className="mx-1 text-muted-foreground">→</span>
-              {file.path}
-            </>
+          {file.oldPath && file.oldPath !== file.path ? (
+            label ? (
+              // Why: in tree view we only have room for basenames, but still need to
+              // communicate the rename so the user doesn't have to expand or switch
+              // to flat view to discover what was renamed. When basenames match (i.e.
+              // only the directory changed), we include the parent directory so the
+              // display isn't a meaningless "foo.ts → foo.ts".
+              (() => {
+                const oldBase = file.oldPath!.split('/').pop() ?? file.oldPath!
+                if (oldBase === label) {
+                  const oldParts = file.oldPath!.split('/')
+                  const newParts = file.path.split('/')
+                  const oldShort = oldParts.slice(-2).join('/')
+                  const newShort = newParts.slice(-2).join('/')
+                  return (
+                    <>
+                      <span className="text-muted-foreground">{oldShort}</span>
+                      <span className="mx-1 text-muted-foreground">→</span>
+                      {newShort}
+                    </>
+                  )
+                }
+                return (
+                  <>
+                    <span className="text-muted-foreground">{oldBase}</span>
+                    <span className="mx-1 text-muted-foreground">→</span>
+                    {label}
+                  </>
+                )
+              })()
+            ) : (
+              <>
+                <span className="text-muted-foreground">{file.oldPath}</span>
+                <span className="mx-1 text-muted-foreground">→</span>
+                {file.path}
+              </>
+            )
           ) : (
             (label ?? file.path)
           )}

--- a/src/renderer/src/components/GitHubItemDialog.tsx
+++ b/src/renderer/src/components/GitHubItemDialog.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable max-lines -- Why: the GH item dialog keeps its header, conversation, files, and checks tabs co-located so the read-only PR/Issue surface stays in one place while this view evolves. */
 import React, { Suspense, lazy, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
+  AlignJustify,
   ArrowDown,
   ArrowRight,
   ArrowUp,
@@ -11,7 +12,10 @@ import {
   CircleDot,
   ExternalLink,
   FileText,
+  Folder,
+  FolderOpen,
   GitPullRequest,
+  LayoutList,
   LoaderCircle,
   MessageSquare,
   MessageSquarePlus,
@@ -36,6 +40,7 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover
 import CommentMarkdown from '@/components/sidebar/CommentMarkdown'
 import { detectLanguage } from '@/lib/language-detect'
 import { cn } from '@/lib/utils'
+import { buildDiffTree, type DiffTreeNode } from '@/components/pr-diff-tree'
 import { CHECK_COLOR, CHECK_ICON } from '@/components/right-sidebar/checks-helpers'
 import {
   filterPRCommentsByAudience,
@@ -315,6 +320,131 @@ type FileRowProps = {
   baseSha: string | undefined
 }
 
+type DiffViewMode = 'flat' | 'tree'
+
+// ─── Tree view components ────────────────────────────────────────────
+
+type DiffTreeNodeProps = {
+  node: DiffTreeNode
+  depth: number
+  repoPath: string
+  prNumber: number
+  headSha: string | undefined
+  baseSha: string | undefined
+  onCommentAdded: (comment: PRComment) => void
+}
+
+function PRDiffTreeNode({
+  node,
+  depth,
+  repoPath,
+  prNumber,
+  headSha,
+  baseSha,
+  onCommentAdded
+}: DiffTreeNodeProps): React.JSX.Element {
+  const [open, setOpen] = useState(true)
+
+  if (node.kind === 'file') {
+    return (
+      <PRFileRow
+        file={node.file}
+        repoPath={repoPath}
+        prNumber={prNumber}
+        headSha={headSha}
+        baseSha={baseSha}
+        onCommentAdded={onCommentAdded}
+        // Why: tree-view file rows are indented by a CSS left-padding proportional
+        // to depth so the expand chevron of PRFileRow stays at position 0 while
+        // the folder hierarchy is communicated purely through indentation.
+        indentDepth={depth}
+        label={node.name}
+      />
+    )
+  }
+
+  // Directory node
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex w-full items-center gap-1.5 px-3 py-1.5 text-left transition hover:bg-muted/40"
+        style={{ paddingLeft: `${12 + depth * 16}px` }}
+        aria-expanded={open}
+        aria-label={`${open ? 'Collapse' : 'Expand'} folder ${node.name}`}
+      >
+        {open ? (
+          <>
+            <ChevronDown className="size-3 shrink-0 text-muted-foreground" />
+            <FolderOpen className="size-3.5 shrink-0 text-amber-400" />
+          </>
+        ) : (
+          <>
+            <ChevronRight className="size-3 shrink-0 text-muted-foreground" />
+            <Folder className="size-3.5 shrink-0 text-amber-400" />
+          </>
+        )}
+        <span className="min-w-0 flex-1 truncate font-mono text-[11px] text-muted-foreground">
+          {node.name}
+        </span>
+      </button>
+      {open && (
+        <div>
+          {node.children.map((child) => (
+            <PRDiffTreeNode
+              key={child.kind === 'file' ? child.file.path : child.path}
+              node={child}
+              depth={depth + 1}
+              repoPath={repoPath}
+              prNumber={prNumber}
+              headSha={headSha}
+              baseSha={baseSha}
+              onCommentAdded={onCommentAdded}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+type PRDiffTreeViewProps = {
+  files: GitHubPRFile[]
+  repoPath: string
+  prNumber: number
+  headSha: string | undefined
+  baseSha: string | undefined
+  onCommentAdded: (comment: PRComment) => void
+}
+
+function PRDiffTreeView({
+  files,
+  repoPath,
+  prNumber,
+  headSha,
+  baseSha,
+  onCommentAdded
+}: PRDiffTreeViewProps): React.JSX.Element {
+  const tree = useMemo(() => buildDiffTree(files), [files])
+  return (
+    <div>
+      {tree.map((node) => (
+        <PRDiffTreeNode
+          key={node.kind === 'file' ? node.file.path : node.path}
+          node={node}
+          depth={0}
+          repoPath={repoPath}
+          prNumber={prNumber}
+          headSha={headSha}
+          baseSha={baseSha}
+          onCommentAdded={onCommentAdded}
+        />
+      ))}
+    </div>
+  )
+}
+
 // Why: bounded LRU — opening many PRs with many files during a session
 // would otherwise grow this module-level map without bound until reload.
 const PR_FILE_CONTENT_CACHE_MAX = 64
@@ -396,8 +526,14 @@ function PRFileRow({
   prNumber,
   headSha,
   baseSha,
-  onCommentAdded
-}: FileRowProps & { onCommentAdded: (comment: PRComment) => void }): React.JSX.Element {
+  onCommentAdded,
+  indentDepth = 0,
+  label
+}: FileRowProps & {
+  onCommentAdded: (comment: PRComment) => void
+  indentDepth?: number
+  label?: string
+}): React.JSX.Element {
   const [expanded, setExpanded] = useState(false)
   const [contents, setContents] = useState<GitHubPRFileContents | null>(null)
   const [loading, setLoading] = useState(false)
@@ -473,7 +609,8 @@ function PRFileRow({
       <button
         type="button"
         onClick={handleToggle}
-        className="flex w-full items-center gap-2 px-3 py-2 text-left transition hover:bg-muted/40"
+        className="flex w-full items-center gap-2 py-2 pr-3 text-left transition hover:bg-muted/40"
+        style={{ paddingLeft: `${12 + indentDepth * 16}px` }}
       >
         {expanded ? (
           <ChevronDown className="size-3.5 shrink-0 text-muted-foreground" />
@@ -490,14 +627,14 @@ function PRFileRow({
           {fileStatusLabel(file.status)}
         </span>
         <span className="min-w-0 flex-1 truncate font-mono text-[12px] text-foreground">
-          {file.oldPath && file.oldPath !== file.path ? (
+          {file.oldPath && file.oldPath !== file.path && !label ? (
             <>
               <span className="text-muted-foreground">{file.oldPath}</span>
               <span className="mx-1 text-muted-foreground">→</span>
               {file.path}
             </>
           ) : (
-            file.path
+            (label ?? file.path)
           )}
         </span>
         <span className="shrink-0 font-mono text-[11px] text-muted-foreground">
@@ -1906,6 +2043,7 @@ export default function GitHubItemDialog({
   const [error, setError] = useState<string | null>(null)
   const [localState, setLocalState] = useState<GitHubWorkItem['state']>(workItem?.state ?? 'open')
   const [localLabels, setLocalLabels] = useState<string[]>(workItem?.labels ?? [])
+  const [diffViewMode, setDiffViewMode] = useState<DiffViewMode>('flat')
   const workItemId = workItem?.id
   const workItemState = workItem?.state
   const workItemLabels = workItem?.labels
@@ -2202,17 +2340,75 @@ export default function GitHubItemDialog({
                           </div>
                         ) : (
                           <div>
-                            {files.map((file) => (
-                              <PRFileRow
-                                key={file.path}
-                                file={file}
+                            {/* Files-tab toolbar: view-mode toggle */}
+                            <div className="flex items-center justify-end gap-1 border-b border-border/40 px-3 py-1.5">
+                              <Tooltip>
+                                <TooltipTrigger asChild>
+                                  <button
+                                    id="pr-files-flat-view"
+                                    type="button"
+                                    onClick={() => setDiffViewMode('flat')}
+                                    aria-label="Flat view"
+                                    aria-pressed={diffViewMode === 'flat'}
+                                    className={cn(
+                                      'flex size-6 items-center justify-center rounded transition hover:bg-muted',
+                                      diffViewMode === 'flat'
+                                        ? 'bg-muted text-foreground'
+                                        : 'text-muted-foreground'
+                                    )}
+                                  >
+                                    <AlignJustify className="size-3.5" />
+                                  </button>
+                                </TooltipTrigger>
+                                <TooltipContent side="bottom" sideOffset={4}>
+                                  Flat view
+                                </TooltipContent>
+                              </Tooltip>
+                              <Tooltip>
+                                <TooltipTrigger asChild>
+                                  <button
+                                    id="pr-files-tree-view"
+                                    type="button"
+                                    onClick={() => setDiffViewMode('tree')}
+                                    aria-label="Tree view"
+                                    aria-pressed={diffViewMode === 'tree'}
+                                    className={cn(
+                                      'flex size-6 items-center justify-center rounded transition hover:bg-muted',
+                                      diffViewMode === 'tree'
+                                        ? 'bg-muted text-foreground'
+                                        : 'text-muted-foreground'
+                                    )}
+                                  >
+                                    <LayoutList className="size-3.5" />
+                                  </button>
+                                </TooltipTrigger>
+                                <TooltipContent side="bottom" sideOffset={4}>
+                                  Tree view
+                                </TooltipContent>
+                              </Tooltip>
+                            </div>
+                            {diffViewMode === 'flat' ? (
+                              files.map((file) => (
+                                <PRFileRow
+                                  key={file.path}
+                                  file={file}
+                                  repoPath={repoPath ?? ''}
+                                  prNumber={workItem.number}
+                                  headSha={details?.headSha}
+                                  baseSha={details?.baseSha}
+                                  onCommentAdded={appendOptimisticComment}
+                                />
+                              ))
+                            ) : (
+                              <PRDiffTreeView
+                                files={files}
                                 repoPath={repoPath ?? ''}
                                 prNumber={workItem.number}
                                 headSha={details?.headSha}
                                 baseSha={details?.baseSha}
                                 onCommentAdded={appendOptimisticComment}
                               />
-                            ))}
+                            )}
                           </div>
                         )}
                       </TabsContent>

--- a/src/renderer/src/components/pr-diff-tree.test.ts
+++ b/src/renderer/src/components/pr-diff-tree.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest'
+import { buildDiffTree } from './pr-diff-tree'
+import type { GitHubPRFile } from '../../../shared/types'
+
+describe('buildDiffTree', () => {
+  it('builds a hierarchical tree from flat paths', () => {
+    const files: GitHubPRFile[] = [
+      { path: 'src/app.ts', status: 'modified', additions: 1, deletions: 1, isBinary: false },
+      {
+        path: 'src/components/button.tsx',
+        status: 'added',
+        additions: 10,
+        deletions: 0,
+        isBinary: false
+      },
+      {
+        path: 'src/components/input.tsx',
+        status: 'added',
+        additions: 5,
+        deletions: 0,
+        isBinary: false
+      },
+      { path: 'README.md', status: 'modified', additions: 2, deletions: 0, isBinary: false }
+    ]
+
+    const tree = buildDiffTree(files)
+
+    // src/ (dir) and README.md (file) should be at root due to sort (dirs first)
+    expect(tree).toHaveLength(2)
+    expect(tree[0].name).toBe('src')
+    expect(tree[1].name).toBe('README.md')
+
+    const src = tree[0]
+    if (src.kind !== 'dir') {
+      throw new Error('src should be a directory')
+    }
+
+    // components/ (dir) and app.ts (file) should be inside src
+    expect(src.children).toHaveLength(2)
+    expect(src.children[0].name).toBe('components')
+    expect(src.children[1].name).toBe('app.ts')
+
+    const components = src.children[0]
+    if (components.kind !== 'dir') {
+      throw new Error('components should be a directory')
+    }
+    expect(components.children).toHaveLength(2)
+    expect(components.children[0].name).toBe('button.tsx')
+    expect(components.children[1].name).toBe('input.tsx')
+  })
+
+  it('compacts single-child directory chains', () => {
+    const files: GitHubPRFile[] = [
+      { path: 'a/b/c/d.ts', status: 'added', additions: 1, deletions: 0, isBinary: false }
+    ]
+
+    const tree = buildDiffTree(files)
+    expect(tree).toHaveLength(1)
+    expect(tree[0].name).toBe('a/b/c')
+
+    const abc = tree[0]
+    if (abc.kind !== 'dir') {
+      throw new Error('a/b/c should be a directory')
+    }
+    expect(abc.children).toHaveLength(1)
+    expect(abc.children[0].name).toBe('d.ts')
+  })
+
+  it('does not compact when there are multiple children', () => {
+    const files: GitHubPRFile[] = [
+      { path: 'a/b/c.ts', status: 'added', additions: 1, deletions: 0, isBinary: false },
+      { path: 'a/d/e.ts', status: 'added', additions: 1, deletions: 0, isBinary: false }
+    ]
+
+    const tree = buildDiffTree(files)
+    expect(tree).toHaveLength(1)
+    expect(tree[0].name).toBe('a')
+
+    const a = tree[0]
+    if (a.kind !== 'dir') {
+      throw new Error('a should be a directory')
+    }
+    expect(a.children).toHaveLength(2)
+    expect(a.children[0].name).toBe('b')
+    expect(a.children[1].name).toBe('d')
+  })
+})

--- a/src/renderer/src/components/pr-diff-tree.test.ts
+++ b/src/renderer/src/components/pr-diff-tree.test.ts
@@ -84,4 +84,67 @@ describe('buildDiffTree', () => {
     expect(a.children[0].name).toBe('b')
     expect(a.children[1].name).toBe('d')
   })
+
+  it('returns an empty array for an empty file list', () => {
+    expect(buildDiffTree([])).toEqual([])
+  })
+
+  it('handles root-level-only files with no directories', () => {
+    const files: GitHubPRFile[] = [
+      { path: 'README.md', status: 'modified', additions: 1, deletions: 0, isBinary: false },
+      { path: 'package.json', status: 'modified', additions: 2, deletions: 1, isBinary: false }
+    ]
+
+    const tree = buildDiffTree(files)
+    expect(tree).toHaveLength(2)
+    expect(tree.every((n) => n.kind === 'file')).toBe(true)
+    expect(tree[0].name).toBe('package.json')
+    expect(tree[1].name).toBe('README.md')
+  })
+
+  it('preserves renamed file metadata in leaf nodes', () => {
+    const files: GitHubPRFile[] = [
+      {
+        path: 'src/utils/new-name.ts',
+        oldPath: 'src/helpers/old-name.ts',
+        status: 'renamed',
+        additions: 0,
+        deletions: 0,
+        isBinary: false
+      }
+    ]
+
+    const tree = buildDiffTree(files)
+    expect(tree).toHaveLength(1)
+
+    const src = tree[0]
+    if (src.kind !== 'dir') {
+      throw new Error('expected dir')
+    }
+    expect(src.name).toBe('src/utils')
+
+    const leaf = src.children[0]
+    if (leaf.kind !== 'file') {
+      throw new Error('expected file')
+    }
+    expect(leaf.name).toBe('new-name.ts')
+    expect(leaf.file.oldPath).toBe('src/helpers/old-name.ts')
+  })
+
+  it('handles backslash-separated paths', () => {
+    const files: GitHubPRFile[] = [
+      { path: 'src\\lib\\index.ts', status: 'added', additions: 5, deletions: 0, isBinary: false }
+    ]
+
+    const tree = buildDiffTree(files)
+    expect(tree).toHaveLength(1)
+    expect(tree[0].name).toBe('src/lib')
+
+    const dir = tree[0]
+    if (dir.kind !== 'dir') {
+      throw new Error('expected dir')
+    }
+    expect(dir.children).toHaveLength(1)
+    expect(dir.children[0].name).toBe('index.ts')
+  })
 })

--- a/src/renderer/src/components/pr-diff-tree.ts
+++ b/src/renderer/src/components/pr-diff-tree.ts
@@ -1,0 +1,98 @@
+import type { GitHubPRFile } from '../../../shared/types'
+
+export type DiffTreeLeaf = {
+  kind: 'file'
+  file: GitHubPRFile
+  /** Basename shown in the tree row. */
+  name: string
+}
+
+export type DiffTreeDir = {
+  kind: 'dir'
+  /** Display label — may be a compacted "a/b/c" segment for single-child chains. */
+  name: string
+  /** Original path segments (joined) that this node covers. */
+  path: string
+  children: DiffTreeNode[]
+}
+
+export type DiffTreeNode = DiffTreeLeaf | DiffTreeDir
+
+/** Intermediate mutable structure used during tree construction. */
+type MutableDir = {
+  dirs: Map<string, MutableDir>
+  files: GitHubPRFile[]
+}
+
+function insertFile(root: MutableDir, segments: string[], file: GitHubPRFile): void {
+  if (segments.length === 1) {
+    root.files.push(file)
+    return
+  }
+  const [head, ...rest] = segments
+  // head is always defined because segments.length >= 2 here
+  const segment = head!
+  if (!root.dirs.has(segment)) {
+    root.dirs.set(segment, { dirs: new Map(), files: [] })
+  }
+  insertFile(root.dirs.get(segment)!, rest, file)
+}
+
+/**
+ * Compact "elevator" nodes: a directory with exactly one child directory and
+ * no files is merged with its sole child (similar to VS Code's compact folders).
+ */
+function compact(node: MutableDir, prefix: string): DiffTreeNode[] {
+  const children: DiffTreeNode[] = []
+
+  for (const file of node.files) {
+    const segments = file.path.split(/[\\/]+/).filter(Boolean)
+    children.push({ kind: 'file', file, name: segments.at(-1) ?? file.path })
+  }
+
+  for (const [name, child] of node.dirs) {
+    const dirPath = prefix ? `${prefix}/${name}` : name
+    children.push(buildDirNode(name, dirPath, child))
+  }
+
+  // Sort: dirs first, then files, each group alpha-sorted
+  children.sort((a, b) => {
+    if (a.kind !== b.kind) {
+      return a.kind === 'dir' ? -1 : 1
+    }
+    return a.name.localeCompare(b.name)
+  })
+
+  return children
+}
+
+function buildDirNode(name: string, path: string, node: MutableDir): DiffTreeDir {
+  // Compact: merge single-child-dir chains into one label
+  let label = name
+  let current = node
+  let currentPath = path
+
+  while (current.files.length === 0 && current.dirs.size === 1) {
+    const [[childName, childNode]] = current.dirs
+    label = `${label}/${childName}`
+    currentPath = `${currentPath}/${childName}`
+    current = childNode
+  }
+
+  return {
+    kind: 'dir',
+    name: label,
+    path: currentPath,
+    children: compact(current, currentPath)
+  }
+}
+
+/** Builds a sorted, compacted directory tree from a flat list of PR files. */
+export function buildDiffTree(files: GitHubPRFile[]): DiffTreeNode[] {
+  const root: MutableDir = { dirs: new Map(), files: [] }
+  for (const file of files) {
+    const segments = file.path.split(/[\\/]+/).filter(Boolean)
+    insertFile(root, segments, file)
+  }
+  return compact(root, '')
+}


### PR DESCRIPTION
## Summary

Describe the user-visible change.

feat: implement hierarchical tree view for PR diff file list
- Added `pr-diff-tree.ts` for grouping flat file paths into a directory tree.
- Implemented folder compaction (e.g. src/main/java) to reduce vertical noise.
- Added Flat/Tree view toggle buttons to the GitHub PR dialog's Files tab.
- Updated `PRFileRow` to support nested indentation and basename-only display in tree mode.
- Added unit tests for tree construction and compaction logic.

## Screenshots
<img width="1917" height="1080" alt="image" src="https://github.com/user-attachments/assets/ea9a7999-2604-4f2c-acae-44d2974ce3e3" />
- Add screenshots or a screen recording for any new or changed UI behavior.


## Testing

- [x ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

## AI Review Report

Summarize the code review you ran with your AI coding agent. Include the main risks it checked, what it flagged, and what you changed or verified as a result.
Confirm that the review explicitly checked cross-platform compatibility for macOS, Linux, and Windows, including shortcuts, labels, paths, shell behavior, and any Electron-specific platform differences touched by this PR.

## Security Audit

Provide a basic security audit summary from your AI coding agent. Call out any input handling, command execution, path handling, auth, secrets, dependency, or IPC risks that were reviewed, plus any follow-up needed.

## Notes

this pr added the features represented in 

https://github.com/stablyai/orca/issues/1109