### PR TITLE
Add Markdown document templates

### DIFF
--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -94,6 +94,7 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     experimentalAgentDashboard: false,
     terminalWindowsShell: 'powershell.exe',
     enableGitHubAttribution: true,
+    markdownDocumentTemplates: [],
     ...overrides
   }
 }

--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -88,6 +88,7 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     experimentalAgentDashboard: false,
     terminalWindowsShell: 'powershell.exe',
     enableGitHubAttribution: true,
+    markdownDocumentTemplates: [],
     ...overrides
   }
 }

--- a/src/main/daemon/shell-ready.test.ts
+++ b/src/main/daemon/shell-ready.test.ts
@@ -13,12 +13,15 @@ const describePosix = process.platform === 'win32' ? describe.skip : describe
 
 describePosix('daemon shell-ready launch config', () => {
   let previousUserDataPath: string | undefined
+  let previousOrigZdotdir: string | undefined
   let userDataPath: string
 
   beforeEach(() => {
     previousUserDataPath = process.env.ORCA_USER_DATA_PATH
+    previousOrigZdotdir = process.env.ORCA_ORIG_ZDOTDIR
     userDataPath = mkdtempSync(join(tmpdir(), 'daemon-shell-ready-test-'))
     process.env.ORCA_USER_DATA_PATH = userDataPath
+    delete process.env.ORCA_ORIG_ZDOTDIR
   })
 
   afterEach(() => {
@@ -26,6 +29,11 @@ describePosix('daemon shell-ready launch config', () => {
       delete process.env.ORCA_USER_DATA_PATH
     } else {
       process.env.ORCA_USER_DATA_PATH = previousUserDataPath
+    }
+    if (previousOrigZdotdir === undefined) {
+      delete process.env.ORCA_ORIG_ZDOTDIR
+    } else {
+      process.env.ORCA_ORIG_ZDOTDIR = previousOrigZdotdir
     }
     rmSync(userDataPath, { recursive: true, force: true })
     vi.restoreAllMocks()

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -77,6 +77,7 @@ describe('Store', () => {
     expect(settings.terminalFontSize).toBe(14)
     expect(settings.terminalFontWeight).toBe(500)
     expect(settings.rightSidebarOpenByDefault).toBe(true)
+    expect(settings.markdownDocumentTemplates).toEqual([])
     expect(settings.showTasksButton).toBe(true)
   })
 
@@ -145,9 +146,76 @@ describe('Store', () => {
     expect(store.getSettings().editorAutoSaveDelayMs).toBe(1000)
     expect(store.getSettings().refreshLocalBaseRefOnWorktreeCreate).toBe(false)
     expect(store.getSettings().rightSidebarOpenByDefault).toBe(true)
+    expect(store.getSettings().markdownDocumentTemplates).toEqual([])
     expect(store.getSettings().showTasksButton).toBe(true)
     // repos should be loaded
     expect(store.getRepos()).toHaveLength(1)
+  })
+
+  it('preserves existing persisted Markdown document templates', async () => {
+    const template = {
+      id: 'template-1',
+      name: 'Daily',
+      content: '# {{title}}',
+      createdAt: 100,
+      updatedAt: 200
+    }
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [],
+      worktreeMeta: {},
+      settings: { markdownDocumentTemplates: [template] },
+      ui: {},
+      githubCache: { pr: {}, issue: {} },
+      workspaceSession: {}
+    })
+
+    const store = await createStore()
+    expect(store.getSettings().markdownDocumentTemplates).toEqual([template])
+  })
+
+  it('normalizes malformed persisted Markdown document templates', async () => {
+    const validTemplate = {
+      id: 'template-1',
+      name: 'Daily',
+      content: '# {{title}}',
+      createdAt: 100,
+      updatedAt: 200
+    }
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [],
+      worktreeMeta: {},
+      settings: {
+        markdownDocumentTemplates: [
+          validTemplate,
+          { id: 'bad', name: 'Bad', createdAt: 100, updatedAt: 200 },
+          null,
+          'bad'
+        ]
+      },
+      ui: {},
+      githubCache: { pr: {}, issue: {} },
+      workspaceSession: {}
+    })
+
+    const store = await createStore()
+    expect(store.getSettings().markdownDocumentTemplates).toEqual([validTemplate])
+  })
+
+  it('normalizes non-array Markdown document templates to an empty list', async () => {
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [],
+      worktreeMeta: {},
+      settings: { markdownDocumentTemplates: { id: 'bad' } },
+      ui: {},
+      githubCache: { pr: {}, issue: {} },
+      workspaceSession: {}
+    })
+
+    const store = await createStore()
+    expect(store.getSettings().markdownDocumentTemplates).toEqual([])
   })
 
   it('preserves editorAutoSaveDelayMs when set in persisted data', async () => {

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -11,7 +11,8 @@ import type {
   Repo,
   SparsePreset,
   WorktreeMeta,
-  GlobalSettings
+  GlobalSettings,
+  MarkdownDocumentTemplate
 } from '../shared/types'
 import type { SshTarget } from '../shared/ssh-types'
 import { isFolderRepo } from '../shared/repo-kind'
@@ -94,6 +95,44 @@ function normalizeSshTarget(t: SshTarget): SshTarget {
   return { ...t, configHost: t.configHost ?? t.label ?? t.host }
 }
 
+function normalizeMarkdownDocumentTemplates(value: unknown): MarkdownDocumentTemplate[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value
+    .filter((template): template is MarkdownDocumentTemplate => {
+      if (!template || typeof template !== 'object') {
+        return false
+      }
+      return (
+        typeof template.id === 'string' &&
+        typeof template.name === 'string' &&
+        typeof template.content === 'string' &&
+        typeof template.createdAt === 'number' &&
+        Number.isFinite(template.createdAt) &&
+        typeof template.updatedAt === 'number' &&
+        Number.isFinite(template.updatedAt)
+      )
+    })
+    .map((template) => ({
+      id: template.id,
+      name: template.name,
+      content: template.content,
+      createdAt: template.createdAt,
+      updatedAt: template.updatedAt
+    }))
+}
+
+function normalizeSettings(settings: GlobalSettings): GlobalSettings {
+  return {
+    ...settings,
+    markdownDocumentTemplates: normalizeMarkdownDocumentTemplates(
+      settings.markdownDocumentTemplates
+    )
+  }
+}
+
 export class Store {
   private state: PersistedState
   private writeTimer: ReturnType<typeof setTimeout> | null = null
@@ -140,19 +179,20 @@ export class Store {
           : rawOptionAsAlt === undefined || rawOptionAsAlt === 'true'
             ? 'auto'
             : rawOptionAsAlt
+        const settings = normalizeSettings({
+          ...defaults.settings,
+          ...parsed.settings,
+          terminalMacOptionAsAlt: migratedOptionAsAlt,
+          terminalMacOptionAsAltMigrated: true,
+          notifications: {
+            ...getDefaultNotificationSettings(),
+            ...parsed.settings?.notifications
+          }
+        })
         return {
           ...defaults,
           ...parsed,
-          settings: {
-            ...defaults.settings,
-            ...parsed.settings,
-            terminalMacOptionAsAlt: migratedOptionAsAlt,
-            terminalMacOptionAsAltMigrated: true,
-            notifications: {
-              ...getDefaultNotificationSettings(),
-              ...parsed.settings?.notifications
-            }
-          },
+          settings,
           // Why: 'recent' used to mean the weighted smart sort. One-shot
           // migration moves it to 'smart'; the flag prevents re-firing after
           // a user intentionally selects the new last-activity 'recent' sort.
@@ -420,18 +460,19 @@ export class Store {
   // ── Settings ───────────────────────────────────────────────────────
 
   getSettings(): GlobalSettings {
+    this.state.settings = normalizeSettings(this.state.settings)
     return this.state.settings
   }
 
   updateSettings(updates: Partial<GlobalSettings>): GlobalSettings {
-    this.state.settings = {
+    this.state.settings = normalizeSettings({
       ...this.state.settings,
       ...updates,
       notifications: {
         ...this.state.settings.notifications,
         ...updates.notifications
       }
-    }
+    })
     this.scheduleSave()
     return this.state.settings
   }

--- a/src/main/providers/local-pty-shell-ready.test.ts
+++ b/src/main/providers/local-pty-shell-ready.test.ts
@@ -127,14 +127,22 @@ describe('writeStartupCommandWhenShellReady', () => {
 const describePosix = process.platform === 'win32' ? describe.skip : describe
 
 describePosix('local PTY shell-ready launch config', () => {
+  let previousOrigZdotdir: string | undefined
   let userDataPath: string
 
   beforeEach(() => {
+    previousOrigZdotdir = process.env.ORCA_ORIG_ZDOTDIR
     userDataPath = mkdtempSync(join(tmpdir(), 'local-pty-shell-ready-test-'))
     getUserDataPathMock.mockReturnValue(userDataPath)
+    delete process.env.ORCA_ORIG_ZDOTDIR
   })
 
   afterEach(() => {
+    if (previousOrigZdotdir === undefined) {
+      delete process.env.ORCA_ORIG_ZDOTDIR
+    } else {
+      process.env.ORCA_ORIG_ZDOTDIR = previousOrigZdotdir
+    }
     rmSync(userDataPath, { recursive: true, force: true })
     vi.restoreAllMocks()
   })

--- a/src/renderer/src/components/editor/EditorPanel.tsx
+++ b/src/renderer/src/components/editor/EditorPanel.tsx
@@ -17,8 +17,12 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuPortal,
   DropdownMenuSeparator,
   DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
 import { CLOSE_ALL_CONTEXT_MENUS_EVENT } from '../tab-bar/SortableTab'
@@ -46,6 +50,11 @@ import {
   getMarkdownViewModes,
   isMarkdownPreviewShortcut
 } from './markdown-preview-controls'
+import {
+  getMarkdownTemplateVariables,
+  getTitleFromMarkdownPath,
+  renderMarkdownTemplate
+} from '../../../../shared/document-templates'
 
 const isMac = navigator.userAgent.includes('Mac')
 const isLinux = navigator.userAgent.includes('Linux')
@@ -66,6 +75,12 @@ type FileContent = {
 }
 
 type DiffContent = GitDiffResult
+
+function getPathFilename(relativePath: string): string {
+  const normalized = relativePath.replace(/[\\/]+/g, '/')
+  const slashIndex = normalized.lastIndexOf('/')
+  return slashIndex === -1 ? normalized : normalized.slice(slashIndex + 1)
+}
 
 // Why: split-pane layouts mount one EditorPanel per pane, and each panel
 // attaches its own listener to `ORCA_EDITOR_EXTERNAL_FILE_CHANGE_EVENT`.
@@ -873,6 +888,29 @@ function EditorPanelInner({
     mode: activeFile.mode,
     diffSource: activeFile.diffSource
   })
+  const markdownDocumentTemplates = settings?.markdownDocumentTemplates ?? []
+  const currentMarkdownContent =
+    editorDrafts[activeFile.id] ?? fileContents[activeFile.id]?.content ?? ''
+  const canInsertMarkdownTemplate = isMarkdown && activeFile.mode === 'edit'
+
+  const handleInsertMarkdownTemplate = (templateId: string): void => {
+    const template = markdownDocumentTemplates.find((candidate) => candidate.id === templateId)
+    if (!template || !canInsertMarkdownTemplate) {
+      return
+    }
+    const filename = getPathFilename(activeFile.relativePath)
+    const renderedTemplate = renderMarkdownTemplate(
+      template.content,
+      getMarkdownTemplateVariables({
+        title: getTitleFromMarkdownPath(activeFile.relativePath),
+        filename
+      })
+    )
+    const nextContent = currentMarkdownContent.trim()
+      ? `${currentMarkdownContent.trimEnd()}\n\n${renderedTemplate}`
+      : renderedTemplate
+    handleContentChange(nextContent)
+  }
 
   const handleOpenDiffTargetFile = (): void => {
     if (!openFileState.canOpen) {
@@ -1057,6 +1095,32 @@ function EditorPanelInner({
                 </button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" sideOffset={4}>
+                {markdownDocumentTemplates.length > 0 && (
+                  <>
+                    <DropdownMenuSub>
+                      <DropdownMenuSubTrigger>Insert Template</DropdownMenuSubTrigger>
+                      <DropdownMenuPortal>
+                        <DropdownMenuSubContent>
+                          {canInsertMarkdownTemplate ? (
+                            markdownDocumentTemplates.map((template) => (
+                              <DropdownMenuItem
+                                key={template.id}
+                                onSelect={() => handleInsertMarkdownTemplate(template.id)}
+                              >
+                                {template.name}
+                              </DropdownMenuItem>
+                            ))
+                          ) : (
+                            <DropdownMenuItem disabled>
+                              Only available in Markdown edit mode
+                            </DropdownMenuItem>
+                          )}
+                        </DropdownMenuSubContent>
+                      </DropdownMenuPortal>
+                    </DropdownMenuSub>
+                    <DropdownMenuSeparator />
+                  </>
+                )}
                 <DropdownMenuItem
                   // Why: the item is disabled (not hidden) only in source/Monaco
                   // mode, which has no document DOM to export. We intentionally

--- a/src/renderer/src/components/settings/GeneralPane.tsx
+++ b/src/renderer/src/components/settings/GeneralPane.tsx
@@ -21,6 +21,7 @@ import {
   GENERAL_CACHE_TIMER_SEARCH_ENTRIES,
   GENERAL_CLI_SEARCH_ENTRIES,
   GENERAL_EDITOR_SEARCH_ENTRIES,
+  GENERAL_MARKDOWN_TEMPLATE_SEARCH_ENTRIES,
   GENERAL_PANE_SEARCH_ENTRIES,
   GENERAL_SUPPORT_SEARCH_ENTRIES,
   GENERAL_UPDATE_SEARCH_ENTRIES,
@@ -29,6 +30,7 @@ import {
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
 import { SearchableSetting } from './SearchableSetting'
 import { matchesSettingsSearch } from './settings-search'
+import { MarkdownTemplatesSection } from './MarkdownTemplatesSection'
 
 export { GENERAL_PANE_SEARCH_ENTRIES }
 
@@ -267,6 +269,13 @@ export function GeneralPane({ settings, updateSettings }: GeneralPaneProps): Rea
           </SearchableSetting>
         </div>
       </section>
+    ) : null,
+    matchesSettingsSearch(searchQuery, GENERAL_MARKDOWN_TEMPLATE_SEARCH_ENTRIES) ? (
+      <MarkdownTemplatesSection
+        key="markdown-templates"
+        templates={settings.markdownDocumentTemplates}
+        updateSettings={updateSettings}
+      />
     ) : null,
     matchesSettingsSearch(searchQuery, GENERAL_EDITOR_SEARCH_ENTRIES) ? (
       <section key="editor" className="space-y-4">

--- a/src/renderer/src/components/settings/MarkdownTemplatesSection.tsx
+++ b/src/renderer/src/components/settings/MarkdownTemplatesSection.tsx
@@ -1,0 +1,289 @@
+import { useEffect, useRef, useState } from 'react'
+import { FileText, Pencil, Plus, Trash2 } from 'lucide-react'
+import type { GlobalSettings, MarkdownDocumentTemplate } from '../../../../shared/types'
+import { Button } from '../ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '../ui/dialog'
+import { Input } from '../ui/input'
+import { Label } from '../ui/label'
+
+type MarkdownTemplatesSectionProps = {
+  templates: MarkdownDocumentTemplate[]
+  updateSettings: (updates: Partial<GlobalSettings>) => void
+}
+
+type TemplateDraft = {
+  id: string | null
+  name: string
+  content: string
+  createdAt: number | null
+}
+
+function createTemplateId(): string {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID()
+  }
+  return `template-${Date.now()}-${Math.random().toString(16).slice(2)}`
+}
+
+function createEmptyDraft(): TemplateDraft {
+  return {
+    id: null,
+    name: '',
+    content: '',
+    createdAt: null
+  }
+}
+
+function draftFromTemplate(template: MarkdownDocumentTemplate): TemplateDraft {
+  return {
+    id: template.id,
+    name: template.name,
+    content: template.content,
+    createdAt: template.createdAt
+  }
+}
+
+const PLACEHOLDERS = [
+  { token: '{{title}}', label: 'File title' },
+  { token: '{{filename}}', label: 'Filename' },
+  { token: '{{date}}', label: 'Local date' },
+  { token: '{{time}}', label: 'Local time' },
+  { token: '{{datetime}}', label: 'Date and time' }
+] as const
+
+export function MarkdownTemplatesSection({
+  templates,
+  updateSettings
+}: MarkdownTemplatesSectionProps): React.JSX.Element {
+  const [draft, setDraft] = useState<TemplateDraft | null>(null)
+  const [deleteTarget, setDeleteTarget] = useState<MarkdownDocumentTemplate | null>(null)
+  const contentRef = useRef<HTMLTextAreaElement | null>(null)
+
+  useEffect(() => {
+    if (!draft?.id) {
+      return
+    }
+    const latest = templates.find((template) => template.id === draft.id)
+    if (!latest) {
+      setDraft(null)
+    }
+  }, [draft?.id, templates])
+
+  const openAddDialog = (): void => {
+    setDraft(createEmptyDraft())
+  }
+
+  const openEditDialog = (template: MarkdownDocumentTemplate): void => {
+    setDraft(draftFromTemplate(template))
+  }
+
+  const saveDraft = (): void => {
+    if (!draft) {
+      return
+    }
+
+    const now = Date.now()
+    const name = draft.name.trim()
+    if (!name) {
+      return
+    }
+
+    const savedTemplate: MarkdownDocumentTemplate = {
+      id: draft.id ?? createTemplateId(),
+      name,
+      content: draft.content,
+      createdAt: draft.createdAt ?? now,
+      updatedAt: now
+    }
+
+    const nextTemplates = draft.id
+      ? templates.map((template) => (template.id === draft.id ? savedTemplate : template))
+      : [...templates, savedTemplate]
+
+    updateSettings({ markdownDocumentTemplates: nextTemplates })
+    setDraft(null)
+  }
+
+  const confirmDelete = (): void => {
+    if (!deleteTarget) {
+      return
+    }
+    updateSettings({
+      markdownDocumentTemplates: templates.filter((template) => template.id !== deleteTarget.id)
+    })
+    setDeleteTarget(null)
+  }
+
+  const insertPlaceholder = (token: string): void => {
+    if (!draft) {
+      return
+    }
+    const contentInput = contentRef.current
+    const selectionStart = contentInput?.selectionStart ?? draft.content.length
+    const selectionEnd = contentInput?.selectionEnd ?? draft.content.length
+    const nextContent = `${draft.content.slice(0, selectionStart)}${token}${draft.content.slice(selectionEnd)}`
+    setDraft({ ...draft, content: nextContent })
+    window.requestAnimationFrame(() => {
+      contentInput?.focus()
+      const nextCursor = selectionStart + token.length
+      contentInput?.setSelectionRange(nextCursor, nextCursor)
+    })
+  }
+
+  const isSavingDisabled = !draft?.name.trim()
+
+  return (
+    <section className="space-y-4">
+      <div className="flex items-start justify-between gap-4">
+        <div className="space-y-1">
+          <h2 className="text-sm font-semibold">Markdown Templates</h2>
+          <p className="text-xs text-muted-foreground">
+            Global templates available when creating Markdown documents.
+          </p>
+        </div>
+        <Button variant="outline" size="sm" onClick={openAddDialog} className="shrink-0 gap-1.5">
+          <Plus className="size-3.5" />
+          Add
+        </Button>
+      </div>
+
+      {templates.length === 0 ? (
+        <div className="rounded-md border border-dashed border-border/70 px-4 py-5 text-sm text-muted-foreground">
+          No templates saved.
+        </div>
+      ) : (
+        <div className="divide-y divide-border/50 rounded-md border border-border/50">
+          {templates.map((template) => (
+            <div key={template.id} className="flex items-center gap-3 px-3 py-2.5">
+              <FileText className="size-4 shrink-0 text-muted-foreground" />
+              <div className="min-w-0 flex-1">
+                <div className="truncate text-sm font-medium">{template.name}</div>
+                <div className="truncate text-xs text-muted-foreground">
+                  Updated {new Date(template.updatedAt).toLocaleDateString()}
+                </div>
+              </div>
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                onClick={() => openEditDialog(template)}
+                aria-label={`Edit ${template.name}`}
+              >
+                <Pencil className="size-3.5" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                onClick={() => setDeleteTarget(template)}
+                aria-label={`Delete ${template.name}`}
+              >
+                <Trash2 className="size-3.5" />
+              </Button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <Dialog open={!!draft} onOpenChange={(open) => !open && setDraft(null)}>
+        <DialogContent className="sm:max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>{draft?.id ? 'Edit Template' : 'Add Template'}</DialogTitle>
+            <DialogDescription>
+              Save a reusable Markdown body with supported placeholders.
+            </DialogDescription>
+          </DialogHeader>
+
+          {draft && (
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="markdown-template-name">Name</Label>
+                <Input
+                  id="markdown-template-name"
+                  value={draft.name}
+                  onChange={(event) => setDraft({ ...draft, name: event.target.value })}
+                  placeholder="Daily note"
+                  autoFocus
+                />
+              </div>
+
+              <div className="space-y-2">
+                <div className="space-y-1">
+                  <Label htmlFor="markdown-template-content">Template body</Label>
+                  <p className="text-xs text-muted-foreground">
+                    Write Markdown here. Insert placeholders where Orca should fill values for the
+                    current file.
+                  </p>
+                </div>
+                <textarea
+                  id="markdown-template-content"
+                  ref={contentRef}
+                  value={draft.content}
+                  onChange={(event) => setDraft({ ...draft, content: event.target.value })}
+                  className="min-h-60 w-full resize-y rounded-md border border-input bg-transparent px-3 py-2 font-mono text-xs shadow-xs outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
+                  placeholder={`# {{title}}\n\nCreated {{datetime}}\n\n`}
+                  spellCheck={false}
+                />
+                <div className="rounded-md border border-border/60 bg-muted/20 p-3">
+                  <div className="mb-2 text-xs font-medium text-foreground">
+                    Insert placeholders
+                  </div>
+                  <div className="grid gap-2 sm:grid-cols-2">
+                    {PLACEHOLDERS.map((placeholder) => (
+                      <button
+                        key={placeholder.token}
+                        type="button"
+                        className="flex min-w-0 items-center justify-between gap-3 rounded-md border border-border/60 bg-background/70 px-2.5 py-2 text-left text-xs transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                        onClick={() => insertPlaceholder(placeholder.token)}
+                      >
+                        <code className="shrink-0 rounded bg-muted px-1.5 py-0.5 font-mono">
+                          {placeholder.token}
+                        </code>
+                        <span className="min-w-0 truncate text-muted-foreground">
+                          {placeholder.label}
+                        </span>
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            </div>
+          )}
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDraft(null)}>
+              Cancel
+            </Button>
+            <Button onClick={saveDraft} disabled={isSavingDisabled}>
+              Save
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={!!deleteTarget} onOpenChange={(open) => !open && setDeleteTarget(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete Template</DialogTitle>
+            <DialogDescription>
+              Delete {deleteTarget ? `"${deleteTarget.name}"` : 'this template'}?
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDeleteTarget(null)}>
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={confirmDelete}>
+              Delete
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </section>
+  )
+}

--- a/src/renderer/src/components/settings/general-search.ts
+++ b/src/renderer/src/components/settings/general-search.ts
@@ -36,6 +36,14 @@ export const GENERAL_EDITOR_SEARCH_ENTRIES: SettingsSearchEntry[] = [
   }
 ]
 
+export const GENERAL_MARKDOWN_TEMPLATE_SEARCH_ENTRIES: SettingsSearchEntry[] = [
+  {
+    title: 'Markdown Templates',
+    description: 'Reusable templates for new Markdown documents.',
+    keywords: ['markdown', 'template', 'document', 'note', 'md', 'mdx']
+  }
+]
+
 export const GENERAL_CLI_SEARCH_ENTRIES: SettingsSearchEntry[] = [
   {
     title: 'Shell command',
@@ -94,6 +102,7 @@ export const GENERAL_SUPPORT_SEARCH_ENTRIES: SettingsSearchEntry[] = [
 export const GENERAL_PANE_SEARCH_ENTRIES: SettingsSearchEntry[] = [
   ...GENERAL_WORKSPACE_SEARCH_ENTRIES,
   ...GENERAL_EDITOR_SEARCH_ENTRIES,
+  ...GENERAL_MARKDOWN_TEMPLATE_SEARCH_ENTRIES,
   ...GENERAL_CLI_SEARCH_ENTRIES,
   ...GENERAL_CACHE_TIMER_SEARCH_ENTRIES,
   ...GENERAL_UPDATE_SEARCH_ENTRIES,

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -159,6 +159,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     terminalScrollbackBytes: 10_000_000,
     openLinksInApp: true,
     rightSidebarOpenByDefault: true,
+    markdownDocumentTemplates: [],
     showTitlebarAgentActivity: true,
     showTasksButton: true,
     notifications: getDefaultNotificationSettings(),

--- a/src/shared/document-templates.test.ts
+++ b/src/shared/document-templates.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getMarkdownTemplateVariables,
+  getTitleFromMarkdownPath,
+  renderMarkdownTemplate
+} from './document-templates'
+
+describe('document template helpers', () => {
+  it('replaces supported placeholders', () => {
+    const variables = {
+      title: 'Daily Note',
+      filename: 'daily-note.md',
+      date: '2026-04-30',
+      time: '09:05',
+      datetime: '2026-04-30 09:05'
+    }
+
+    expect(
+      renderMarkdownTemplate('# {{title}}\n{{filename}}\n{{date}} {{time}} {{datetime}}', variables)
+    ).toBe('# Daily Note\ndaily-note.md\n2026-04-30 09:05 2026-04-30 09:05')
+  })
+
+  it('supports whitespace inside placeholders', () => {
+    const variables = {
+      title: 'Title',
+      filename: 'file.md',
+      date: '2026-04-30',
+      time: '09:05',
+      datetime: '2026-04-30 09:05'
+    }
+
+    expect(renderMarkdownTemplate('{{ title }} {{ filename }}', variables)).toBe('Title file.md')
+  })
+
+  it('leaves unknown placeholders unchanged', () => {
+    const variables = {
+      title: 'Title',
+      filename: 'file.md',
+      date: '2026-04-30',
+      time: '09:05',
+      datetime: '2026-04-30 09:05'
+    }
+
+    expect(renderMarkdownTemplate('{{unknown}} {{ title }}', variables)).toBe('{{unknown}} Title')
+  })
+
+  it('formats local date and time deterministically with an injected Date', () => {
+    const variables = getMarkdownTemplateVariables({
+      title: 'Title',
+      filename: 'file.md',
+      now: new Date(2026, 3, 30, 9, 5, 30)
+    })
+
+    expect(variables).toEqual({
+      title: 'Title',
+      filename: 'file.md',
+      date: '2026-04-30',
+      time: '09:05',
+      datetime: '2026-04-30 09:05'
+    })
+  })
+
+  it('derives predictable titles from filenames', () => {
+    expect(getTitleFromMarkdownPath('daily-note.md')).toBe('daily-note')
+    expect(getTitleFromMarkdownPath('notes/foo.bar.md')).toBe('foo.bar')
+    expect(getTitleFromMarkdownPath('README.md')).toBe('README')
+  })
+})

--- a/src/shared/document-templates.ts
+++ b/src/shared/document-templates.ts
@@ -1,0 +1,63 @@
+export type MarkdownTemplateVariables = {
+  title: string
+  filename: string
+  date: string
+  time: string
+  datetime: string
+}
+
+function getLastSegment(path: string): string {
+  const slashIndex = path.lastIndexOf('/')
+  return slashIndex === -1 ? path : path.slice(slashIndex + 1)
+}
+
+function getExtension(filename: string): string {
+  const lastDotIndex = filename.lastIndexOf('.')
+  if (lastDotIndex <= 0 || lastDotIndex === filename.length - 1) {
+    return ''
+  }
+  return filename.slice(lastDotIndex).toLowerCase()
+}
+
+function pad(value: number): string {
+  return String(value).padStart(2, '0')
+}
+
+export function getTitleFromMarkdownPath(relativePath: string): string {
+  const filename = getLastSegment(relativePath.replace(/[\\/]+/g, '/'))
+  const extension = getExtension(filename)
+  return extension ? filename.slice(0, -extension.length) : filename
+}
+
+export function getMarkdownTemplateVariables(args: {
+  title: string
+  filename: string
+  now?: Date
+}): MarkdownTemplateVariables {
+  const now = args.now ?? new Date()
+  const date = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`
+  const time = `${pad(now.getHours())}:${pad(now.getMinutes())}`
+
+  return {
+    title: args.title,
+    filename: args.filename,
+    date,
+    time,
+    datetime: `${date} ${time}`
+  }
+}
+
+export function renderMarkdownTemplate(
+  content: string,
+  variables: MarkdownTemplateVariables
+): string {
+  return content.replace(/\{\{\s*([A-Za-z][A-Za-z0-9_]*)\s*\}\}/g, (match, key: string) => {
+    if (key === 'title' || key === 'filename' || key === 'date' || key === 'time') {
+      return variables[key]
+    }
+    if (key === 'datetime') {
+      return variables.datetime
+    }
+    return match
+  })
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -873,6 +873,14 @@ export type TerminalColorOverrides = {
   bold?: string
 }
 
+export type MarkdownDocumentTemplate = {
+  id: string
+  name: string
+  content: string
+  createdAt: number
+  updatedAt: number
+}
+
 export type GlobalSettings = {
   workspaceDir: string
   nestWorkspaces: boolean
@@ -948,6 +956,7 @@ export type GlobalSettings = {
    *  until the user explicitly wants worktree-scoped in-app browsing. */
   openLinksInApp: boolean
   rightSidebarOpenByDefault: boolean
+  markdownDocumentTemplates: MarkdownDocumentTemplate[]
   /** Whether to show the live agent activity count badge in the titlebar. */
   showTitlebarAgentActivity: boolean
   /** Why: some users do not use the Tasks feature and prefer to keep the


### PR DESCRIPTION
## Summary

- Adds global Markdown document templates to General settings with Add/Edit/Delete flows.
- Supports deterministic placeholder expansion for `{{title}}`, `{{filename}}`, `{{date}}`, `{{time}}`, and `{{datetime}}`.
- Adds an editor-scoped `Insert Template` menu for Markdown edit tabs; templates append to existing content instead of replacing it.
- Keeps existing Markdown creation flows unchanged; this PR does not add a new Explorer or file-creation surface.

Closes #1222 

## Screenshots / Recording


https://github.com/user-attachments/assets/d4a7ad28-6399-408d-b2f3-0802c7446aed


## Testing

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`

Note: local build exits 0 but prints the existing `/usr/local/bin/orca-dev` symlink permission warning.

## AI Code Review Summary

I reviewed this change for scope, cross-platform behavior, and security-sensitive paths. The implementation keeps templates in app settings and inserts rendered Markdown through the existing editor draft/save path, so it does not introduce new filesystem write IPC or alternate document-creation behavior.

Cross-platform check: no new keyboard shortcuts were added. Placeholder dates use local `Date` fields instead of `toISOString()`, avoiding timezone shifts. Filename/title extraction normalizes path separators for display/template variables only and does not introduce security-sensitive path handling.

Security audit: template content is user-authored Markdown inserted into the user's current document. Unknown placeholders are preserved rather than evaluated. Persisted template data is normalized on load/update so malformed stored values do not leak into renderer state. No new file overwrite path, absolute path construction path, or traversal-sensitive IPC was added.

## Platform Notes

Tested locally on macOS with Node v22.22.2. Orca targets macOS, Linux, and Windows; this change avoids platform-specific shortcuts and filesystem assumptions.

## Follow-ups Intentionally Out of Scope

- Repo-local templates
- File-backed template discovery
- Template import/export
- Custom user-defined variables
- New Markdown creation surfaces



Risk: medium
Historic risk metadata backfill based on the existing `risk:medium` label.

## ELI5

Global Markdown templates in settings with placeholders (title, date, etc.) and Insert Template in Markdown editors so you can append common document shapes.
