### PR TITLE
feat: default sidebar sort to 'recent' instead of alphabetical

### DIFF
--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -433,6 +433,24 @@ describe('Store', () => {
     expect(store.getUI().sortBy).toBe('recent')
   })
 
+  it('uses recent as the default sort for a fresh install (no persisted sortBy)', async () => {
+    // Why: the legacy-recent→smart migration must gate on the *raw* persisted
+    // value, not the normalized default. Otherwise, changing the default sort
+    // to 'recent' would cause every fresh install to be mis-migrated to 'smart'.
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [],
+      worktreeMeta: {},
+      settings: {},
+      ui: {},
+      githubCache: { pr: {}, issue: {} },
+      workspaceSession: {}
+    })
+
+    const store = await createStore()
+    expect(store.getUI().sortBy).toBe('recent')
+  })
+
   // ── terminalMacOptionAsAlt migration (issue #903) ───────────────────
 
   it('migrates legacy "true" terminalMacOptionAsAlt to "auto" on first load', async () => {

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -156,9 +156,13 @@ export class Store {
           // Why: 'recent' used to mean the weighted smart sort. One-shot
           // migration moves it to 'smart'; the flag prevents re-firing after
           // a user intentionally selects the new last-activity 'recent' sort.
+          // Gate on the *raw* persisted value, not the normalized one: the
+          // default sortBy is now 'recent', so a fresh install with no
+          // persisted sortBy would otherwise be mis-migrated to 'smart'.
           ui: (() => {
-            const sort = normalizeSortBy(parsed.ui?.sortBy)
-            const migrate = !parsed.ui?._sortBySmartMigrated && sort === 'recent'
+            const rawSort = parsed.ui?.sortBy
+            const sort = normalizeSortBy(rawSort)
+            const migrate = !parsed.ui?._sortBySmartMigrated && rawSort === 'recent'
             return {
               ...defaults.ui,
               ...parsed.ui,

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -325,7 +325,7 @@ function App(): React.JSX.Element {
             sidebarWidth: 280,
             rightSidebarWidth: 350,
             groupBy: 'none',
-            sortBy: 'name',
+            sortBy: 'recent',
             showActiveOnly: false,
             filterRepoIds: [],
             collapsedGroups: [],

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -429,7 +429,7 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
     set({ groupBy: g, collapsedGroups: new Set<string>() })
   },
 
-  sortBy: 'name',
+  sortBy: 'recent',
   setSortBy: (s) => set({ sortBy: s }),
 
   showActiveOnly: false,

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -227,7 +227,7 @@ export function getDefaultUIState(): PersistedUIState {
     sidebarWidth: 280,
     rightSidebarWidth: 350,
     groupBy: 'none',
-    sortBy: 'name',
+    sortBy: 'recent',
     showActiveOnly: false,
     filterRepoIds: [],
     collapsedGroups: [],


### PR DESCRIPTION
## Summary
- Flip the default `sortBy` from `'name'` to `'recent'` in the three places it's seeded (shared constants, Zustand store initial value, App.tsx hydration-failure fallback).
- Gate the legacy `'recent' → 'smart'` one-shot migration in `persistence.ts` on the **raw** persisted `sortBy`, not the normalized default. Otherwise, flipping the default sweeps every fresh install (no persisted `sortBy`) into the migration and permanently locks them onto `'smart'` via the sticky `_sortBySmartMigrated` flag.
- Add a persistence test covering the fresh-install case (no persisted `ui.sortBy` → lands on `'recent'`, not `'smart'`).

## Test plan
- [x] `pnpm vitest run src/main/persistence.test.ts` — all 38 tests pass, including existing legacy-recent migration tests and the new fresh-install test
- [x] `pnpm typecheck` passes
- [x] Manual: fresh profile launches with Recent sort selected
- [x] Manual: existing user with `sortBy: 'name'` keeps `'name'` across restart
- [ ] Manual: existing user with `sortBy: 'smart'` keeps `'smart'` across restart
- [ ] Manual: legacy v1 user with `sortBy: 'recent'` and no `_sortBySmartMigrated` flag still migrates to `'smart'` on first load

Made with [Orca](https://github.com/stablyai/orca) 🐋
