### PR TITLE
fix(sidebar): avoid re-centering on worktree selection unless out of view

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -150,7 +150,11 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
         (row) => row.type === 'item' && row.worktree.id === pendingRevealWorktreeId
       )
       if (targetIndex !== -1) {
-        virtualizer.scrollToIndex(targetIndex, { align: 'center' })
+        // Why: `align: 'auto'` is a no-op when the card is already visible and
+        // otherwise scrolls the minimum amount to bring it into view. Using
+        // 'center' here made every worktree click re-center the sidebar, which
+        // is visually jumpy even when nothing needed to move.
+        virtualizer.scrollToIndex(targetIndex, { align: 'auto' })
       }
       clearPendingRevealWorktreeId()
     })


### PR DESCRIPTION
## Summary
- Switch the sidebar reveal scroll from `align: 'center'` to `align: 'auto'` so clicking a worktree only scrolls when its card is not already visible.
- Eliminates the jumpy re-centering that happened on every selection even when the target card was fully in view.

## Test plan
- [ ] Click several visible worktree cards in a tall sidebar — list should not move.
- [ ] Click a worktree scrolled above/below the viewport — sidebar scrolls just enough to bring it into view.
- [ ] Cmd+Shift+Up/Down keyboard nav still scrolls when cycling past the edge.

Made with [Orca](https://github.com/stablyai/orca) 🐋
