### PR TITLE
docs(agents): note SSH use case in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,10 @@ Orca targets macOS, Linux, and Windows. Keep all platform-dependent behavior beh
 - **Shortcut labels in UI**: Display `⌘` / `⇧` on Mac and `Ctrl+` / `Shift+` on other platforms.
 - **File paths**: Use `path.join` or Electron/Node path utilities — never assume `/` or `\`.
 
+## SSH Use Case
+
+All changes must consider the SSH use case. Don't assume local-only execution.
+
 ## GitHub CLI Usage
 
 Be mindful of the user's `gh` CLI API rate limit — batch requests where possible and avoid unnecessary calls. All code, commands, and scripts must be compatible with macOS, Linux, and Windows.


### PR DESCRIPTION
## Summary
- Add a short SSH use case note to AGENTS.md so future changes don't assume local-only execution.

## Test plan
- [x] Docs-only change; no code affected.

Made with [Orca](https://github.com/stablyai/orca) 🐋
