### PR TITLE
fix(sidebar): smoothly animate off-screen worktree reveal on click

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -153,8 +153,10 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
         // Why: `align: 'auto'` is a no-op when the card is already visible and
         // otherwise scrolls the minimum amount to bring it into view. Using
         // 'center' here made every worktree click re-center the sidebar, which
-        // is visually jumpy even when nothing needed to move.
-        virtualizer.scrollToIndex(targetIndex, { align: 'auto' })
+        // is visually jumpy even when nothing needed to move. `behavior: 'smooth'`
+        // animates that minimum scroll so off-screen reveals slide into view
+        // instead of snapping — matching the native scroll-into-view feel.
+        virtualizer.scrollToIndex(targetIndex, { align: 'auto', behavior: 'smooth' })
       }
       clearPendingRevealWorktreeId()
     })


### PR DESCRIPTION
## Summary
- Clicking a worktree card whose row is outside the sidebar viewport used to snap it into view with an instant jump.
- Pass `behavior: 'smooth'` to `virtualizer.scrollToIndex` so the minimum-distance scroll animates instead of jumping. `align: 'auto'` is kept, so visible cards still no-op (no re-centering, keeping the fix from #1295 intact).

## Test plan
- [x] Click a worktree that is currently visible in the sidebar — nothing should scroll.
- [x] Click a worktree above the current viewport — sidebar should smoothly slide up to reveal it.
- [x] Click a worktree below the current viewport — sidebar should smoothly slide down to reveal it.
- [x] Cmd+Shift+Up/Down keyboard cycling still works (uses the same `align: 'auto'` scroll path separately).

Made with [Orca](https://github.com/stablyai/orca) 🐋
