### PR TITLE
fix(sidebar): smoothly animate off-screen worktree reveal on click

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -153,8 +153,10 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
         // Why: `align: 'auto'` is a no-op when the card is already visible and
         // otherwise scrolls the minimum amount to bring it into view. Using
         // 'center' here made every worktree click re-center the sidebar, which
-        // is visually jumpy even when nothing needed to move.
-        virtualizer.scrollToIndex(targetIndex, { align: 'auto' })
+        // is visually jumpy even when nothing needed to move. `behavior: 'smooth'`
+        // animates that minimum scroll so off-screen reveals slide into view
+        // instead of snapping — matching the native scroll-into-view feel.
+        virtualizer.scrollToIndex(targetIndex, { align: 'auto', behavior: 'smooth' })
       }
       clearPendingRevealWorktreeId()
     })


### PR DESCRIPTION
## Summary
- When clicking a worktree whose card was outside the viewport, the sidebar jumped instantly to the new position. Adds `behavior: 'smooth'` to the `virtualizer.scrollToIndex` call so the minimum scroll animates into view instead of snapping.
- Still uses `align: 'auto'` so already-visible cards remain a no-op (no re-centering jumpiness).

## Test plan
- [ ] Click an off-screen worktree in the sidebar → card slides smoothly into view.
- [ ] Click a currently-visible worktree → sidebar does not scroll/re-center.
- [ ] Rapid clicks across the list remain responsive (no queued animations feeling laggy).

Made with [Orca](https://github.com/stablyai/orca) 🐋
