### PR TITLE
Fix Linux deb package name conflict with Ubuntu Orca

### DIFF
--- a/config/electron-builder.config.cjs
+++ b/config/electron-builder.config.cjs
@@ -135,6 +135,9 @@ module.exports = {
     artifactName: 'orca-macos-${arch}.${ext}'
   },
   linux: {
+    // Why: Ubuntu 26 ships GNOME Orca as the `orca` package and /usr/bin/orca.
+    // The Linux installer should not claim those system package/file names.
+    executableName: 'orca-ide',
     extraResources: [
       {
         from: 'resources/linux/bin/orca',
@@ -151,6 +154,10 @@ module.exports = {
   },
   appImage: {
     artifactName: 'orca-linux.${ext}'
+  },
+  deb: {
+    packageName: 'orca-ide',
+    artifactName: 'orca-ide_${version}_${arch}.${ext}'
   },
   // Why: must be true so that electron-builder rebuilds native modules
   // (node-pty) for each target architecture when producing dual-arch macOS


### PR DESCRIPTION
## Summary

- set the Linux executable name to `orca-ide`
- set the Debian package name and artifact name to `orca-ide`
- keep the user-facing product name as `Orca`

## Motivation

Ubuntu 26 ships GNOME Orca as the system `orca` package, with system paths such as `/usr/bin/orca`. The current Linux `.deb` is also packaged as `orca`, which can conflict with the distro package and its files during installation or updates.

Using a slightly more specific Debian/system name such as `orca-ide` avoids colliding with Ubuntu's accessibility package while preserving the app's product name.

## Testing

- `node` assertion that the Electron Builder config keeps `productName: "Orca"` and sets the Linux DEB naming to `orca-ide`
- `git diff --check`
