### PR TITLE
Fix agent-browser session cleanup on tab close

### DIFF
--- a/src/main/browser/agent-browser-bridge.test.ts
+++ b/src/main/browser/agent-browser-bridge.test.ts
@@ -748,6 +748,21 @@ describe('AgentBrowserBridge', () => {
     expect(bridge.getActiveWebContentsId()).toBeNull()
   })
 
+  it('closes the named agent-browser session when a tab closes', async () => {
+    succeedWith({ snapshot: 'tree' })
+    await bridge.snapshot()
+
+    execFileMock.mockClear()
+    succeedWith(null)
+    await bridge.onTabClosed(100)
+
+    const closeCall = execFileMock.mock.calls.find((call: unknown[]) =>
+      (call[1] as string[]).includes('close')
+    )
+    expect(closeCall).toBeTruthy()
+    expect(closeCall![1]).toEqual(['--session', 'orca-tab-tab-1', 'close'])
+  })
+
   it('repairs per-worktree active routing when the active tab closes', async () => {
     const tabs = new Map([
       ['tab-a', 1],

--- a/src/main/browser/agent-browser-bridge.ts
+++ b/src/main/browser/agent-browser-bridge.ts
@@ -1682,7 +1682,10 @@ export class AgentBrowserBridge {
 
     const destroy = (async (): Promise<void> => {
       try {
-        await this.runAgentBrowserRaw(sessionName, ['close'])
+        // Why: each browser tab uses its own named agent-browser session. Closing
+        // without --session only tears down the default session and leaves the tab
+        // session's daemon process running.
+        await this.runAgentBrowserRaw(sessionName, ['--session', sessionName, 'close'])
       } catch {
         // Session may already be dead
       }


### PR DESCRIPTION
## Summary
- Close named agent-browser sessions during tab teardown.
- Add regression coverage for `onTabClosed()` so tab close calls `agent-browser --session <name> close`.

## Why
Orca browser tabs use named sessions like `orca-tab-<browserPageId>`. The tab close path previously ran `agent-browser close` without `--session`, which closes the default session instead of the tab session. In repeated browser automation this can leave many `agent-browser-*` daemon processes alive after tabs are closed.

## Tests
- `./node_modules/.bin/vitest run --config config/vitest.config.ts src/main/browser/agent-browser-bridge.test.ts`
- `./node_modules/.bin/tsc --noEmit -p config/tsconfig.node.json --composite false`
- `./node_modules/.bin/vitest run --config config/vitest.config.ts`
- `./node_modules/.bin/oxlint src/main/browser/agent-browser-bridge.ts src/main/browser/agent-browser-bridge.test.ts`