### PR TITLE
fix(terminal): split panes lose source cwd when shell omits OSC 7

### DIFF
--- a/src/main/providers/process-cwd.ts
+++ b/src/main/providers/process-cwd.ts
@@ -70,7 +70,11 @@ async function doResolve(pid: number): Promise<string> {
   }
 
   try {
-    const { stdout } = await execFile('lsof', ['-p', String(pid), '-d', 'cwd', '-Fn'], {
+    // Why: `-a` ANDs the -p and -d filters. Without it, macOS lsof ORs them
+    // and emits cwd records for every process on the system, so the n-line
+    // scan below picks up the first unrelated process (often pid ~391 with
+    // cwd `/`) and returns `/` regardless of the target pid's real cwd.
+    const { stdout } = await execFile('lsof', ['-a', '-p', String(pid), '-d', 'cwd', '-Fn'], {
       encoding: 'utf-8',
       timeout: LSOF_TIMEOUT_MS
     })

--- a/src/relay/pty-shell-utils.ts
+++ b/src/relay/pty-shell-utils.ts
@@ -42,10 +42,18 @@ export async function resolveProcessCwd(pid: number, fallbackCwd: string): Promi
   // lsof returns ALL open files (sockets, log files, TTYs) and the first `n`-line
   // could be any of them — not the actual working directory.
   try {
-    const { stdout: output } = await execFile('lsof', ['-p', String(pid), '-d', 'cwd', '-Fn'], {
-      encoding: 'utf-8',
-      timeout: 3000
-    })
+    // Why: `-a` ANDs the -p and -d filters. Without it, macOS lsof ORs them
+    // and emits cwd records for every process on the system, so the n-line
+    // scan below picks up the first unrelated process (often pid ~391 with
+    // cwd `/`) and returns `/` regardless of the target pid's real cwd.
+    const { stdout: output } = await execFile(
+      'lsof',
+      ['-a', '-p', String(pid), '-d', 'cwd', '-Fn'],
+      {
+        encoding: 'utf-8',
+        timeout: 3000
+      }
+    )
     const lines = output.split('\n')
     for (const line of lines) {
       if (line.startsWith('n') && line.includes('/')) {


### PR DESCRIPTION
## Summary

- Split panes (Cmd+D / Cmd+Shift+D / context-menu Split) spawn in `/` instead of the source pane's cwd whenever the shell doesn't emit OSC 7 — reproduces on plain-prompt zsh configs, invisible on starship/p10k/omz setups where the renderer's OSC 7 cache short-circuits first.
- Root cause: `lsof -p <pid> -d cwd -Fn` on macOS ORs the `-p` and `-d` selectors by default, so it emits cwd records for every process on the system. The `for (const line of stdout.split('\n'))` loop then returns the **first** `n/...` record — typically a system daemon (pid ~391) with cwd `/` — regardless of the target pid.
- Fix: pass `-a` so lsof ANDs the filters. Applied to both copies of the helper (`src/main/providers/process-cwd.ts` for the Electron main process and `src/relay/pty-shell-utils.ts` for the SSH relay).

## Test plan

- [ ] Manual: in a terminal tab, `cd` into a subdirectory, press Cmd+D → new pane spawns in the subdirectory, not `/`.
- [ ] Manual: same test with a prompt that *does* emit OSC 7 (starship) to confirm the OSC 7 fast-path is unaffected.
- [ ] Manual: Cmd+Shift+D (horizontal split) inherits cwd the same way.
- [ ] Manual: context-menu "Split Right/Down" inherits cwd.
- [ ] Manual: chained rapid Cmd+D (tests `process-cwd`'s per-pid coalescing still works).
- [ ] Manual: SSH-attached terminal splits via the relay also inherit cwd (exercises `src/relay/pty-shell-utils.ts`).

Made with [Orca](https://github.com/stablyai/orca) 🐋
