### PR TITLE
fix(release): dispatch Homebrew cask bump from release pipeline

### DIFF
--- a/.github/workflows/homebrew-bump.yml
+++ b/.github/workflows/homebrew-bump.yml
@@ -1,0 +1,155 @@
+name: Homebrew Cask Bump
+
+# Why: keep the stablyai/homebrew-orca tap in sync with GitHub Releases.
+# Triggers:
+#   - release.published with !prerelease → release workflow just finalized a
+#     stable tag (see publish-release step in release.yml)
+#   - workflow_dispatch → manual backfill for a specific tag
+#
+# The job computes the sha256 of orca-macos-arm64.dmg + orca-macos-x64.dmg
+# from the release, templates Casks/orca.rb in this repo with the new
+# version and hashes, then PRs the result into stablyai/homebrew-orca. It
+# does NOT run for -rc.* tags: the stable cask should only track GA.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to sync (e.g. v1.3.25)
+        required: true
+        type: string
+
+jobs:
+  bump-cask:
+    runs-on: ubuntu-latest
+    # Why: skip prereleases and RC tags. The stable cask tracks GA only; a
+    # beta channel would be a separate cask in a separate job.
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.release.prerelease == false &&
+       !contains(github.event.release.tag_name, '-rc.'))
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout orca
+        uses: actions/checkout@v4
+
+      - name: Resolve tag and version
+        id: tag
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+        run: |
+          set -euo pipefail
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            tag="$INPUT_TAG"
+          else
+            tag="$RELEASE_TAG"
+          fi
+          version="${tag#v}"
+          echo "tag=$tag" >>"$GITHUB_OUTPUT"
+          echo "version=$version" >>"$GITHUB_OUTPUT"
+
+      - name: Download DMGs and compute sha256
+        id: hash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          mkdir -p dmgs
+          gh release download "$TAG" \
+            --repo "${{ github.repository }}" \
+            --pattern 'orca-macos-arm64.dmg' \
+            --pattern 'orca-macos-x64.dmg' \
+            --dir dmgs
+          arm=$(sha256sum dmgs/orca-macos-arm64.dmg | awk '{print $1}')
+          intel=$(sha256sum dmgs/orca-macos-x64.dmg  | awk '{print $1}')
+          echo "arm=$arm"     >>"$GITHUB_OUTPUT"
+          echo "intel=$intel" >>"$GITHUB_OUTPUT"
+
+      - name: Render updated cask file
+        env:
+          VERSION: ${{ steps.tag.outputs.version }}
+          ARM_SHA: ${{ steps.hash.outputs.arm }}
+          INTEL_SHA: ${{ steps.hash.outputs.intel }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import os, re, pathlib
+          p = pathlib.Path("Casks/orca.rb")
+          src = p.read_text()
+          src = re.sub(r'version "[^"]+"',
+                       f'version "{os.environ["VERSION"]}"', src, count=1)
+          src = re.sub(r'sha256 arm:\s*"[0-9a-f]+",\s*\n\s*intel:\s*"[0-9a-f]+"',
+                       'sha256 arm:   "{arm}",\n         intel: "{intel}"'.format(
+                           arm=os.environ["ARM_SHA"],
+                           intel=os.environ["INTEL_SHA"]),
+                       src, count=1)
+          p.write_text(src)
+          print(src)
+          PY
+
+      # Why: reuse the existing buf0-bot GitHub App (also used by
+      # track-community-prs.yaml) instead of minting a new PAT. The app is
+      # installed org-wide, so it has access to stablyai/homebrew-orca
+      # automatically. GITHUB_TOKEN cannot push cross-repo; a short-lived
+      # installation token can.
+      - name: Generate buf0-bot token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: 2590194
+          private-key: ${{ secrets.BUFO_BOT_PRIVATE_KEY }}
+          owner: stablyai
+          repositories: homebrew-orca
+
+      - name: Checkout tap
+        uses: actions/checkout@v4
+        with:
+          repository: stablyai/homebrew-orca
+          path: tap
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Copy cask into tap and open PR
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          VERSION: ${{ steps.tag.outputs.version }}
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          mkdir -p tap/Casks
+          cp Casks/orca.rb tap/Casks/orca.rb
+
+          cd tap
+          # Why: commit author must match the buf0-bot app so commits are
+          # attributed to the bot in the tap's history / PR UI.
+          git config user.name  "buf0-bot[bot]"
+          git config user.email "252831055+buf0-bot[bot]@users.noreply.github.com"
+
+          if git diff --quiet; then
+            echo "Cask already up-to-date for $TAG; nothing to do."
+            exit 0
+          fi
+
+          branch="bump/orca-$VERSION"
+          git checkout -b "$branch"
+          git add Casks/orca.rb
+          git commit -m "orca $VERSION"
+          git push -u origin "$branch" --force
+
+          # Why: prefer --fill so the PR body matches the commit; fall back
+          # to a brief body if the PR already exists for this branch.
+          gh pr create \
+            --title "orca $VERSION" \
+            --body "Automated bump from stablyai/orca release $TAG." \
+            --base main \
+            --head "$branch" \
+            || gh pr edit "$branch" --title "orca $VERSION"
+
+          # Why: auto-merge so the tap stays hands-free. Tap repo must have
+          # "Allow auto-merge" enabled in settings for this to take effect.
+          gh pr merge "$branch" --squash --auto --delete-branch || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -245,3 +245,21 @@ jobs:
             --draft=false \
             --prerelease="$prerelease" \
             --repo "$GITHUB_REPOSITORY"
+
+      # Why: dispatch the Homebrew cask bump directly instead of relying on a
+      # `release.published` trigger inside homebrew-bump.yml. GitHub blocks
+      # events raised by GITHUB_TOKEN (like the `gh release edit` above) from
+      # starting other workflows — it's a documented anti-loop safeguard. A
+      # workflow_dispatch from inside an already-running workflow is the
+      # documented escape hatch. Scoped to GA tags only; rc/prerelease tags
+      # should not touch the stable cask.
+      - name: Trigger Homebrew cask bump (stable releases only)
+        if: ${{ !contains(needs.resolve-release.outputs.tag, '-rc.') }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.resolve-release.outputs.tag }}
+        run: |
+          gh workflow run homebrew-bump.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref main \
+            -f tag="$TAG"

--- a/Casks/orca.rb
+++ b/Casks/orca.rb
@@ -1,0 +1,41 @@
+cask "orca" do
+  arch arm: "arm64", intel: "x64"
+
+  version "1.3.24"
+  sha256 arm:   "fc707f290ff3b631b7b7947bf339885b61a43d2e89475997c125b61268ed4966",
+         intel: "5f677c13a08f7a5740442e29d388285a86488c8c1f7aa5f10a8721a2c6ede8e4"
+
+  url "https://github.com/stablyai/orca/releases/download/v#{version}/orca-macos-#{arch}.dmg",
+      verified: "github.com/stablyai/orca/"
+  name "Orca"
+  desc "IDE for orchestrating AI coding agents across terminals and worktrees"
+  homepage "https://onorca.dev/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  # Why: electron-updater (src/main/updater.ts) handles in-place updates by
+  # writing a new Orca.app into /Applications. Marking the cask auto_updates
+  # tells Homebrew not to compete with the in-app updater — `brew upgrade`
+  # becomes a no-op unless the user passes --greedy, and brew's version
+  # metadata stays aligned with whatever the app has swapped itself to.
+  auto_updates true
+  depends_on macos: ">= :big_sur"
+
+  app "Orca.app"
+
+  # Why: Orca writes user data under ~/.orca (worktrees, agent state) and
+  # Electron's standard userData directories. Zap removes everything the app
+  # creates during normal use so `brew uninstall --zap` is a clean slate.
+  zap trash: [
+    "~/.orca",
+    "~/Library/Application Support/Orca",
+    "~/Library/Caches/com.stablyai.orca",
+    "~/Library/Caches/com.stablyai.orca.ShipIt",
+    "~/Library/HTTPStorages/com.stablyai.orca",
+    "~/Library/Preferences/com.stablyai.orca.plist",
+    "~/Library/Saved Application State/com.stablyai.orca.savedState",
+  ]
+end

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 </p>
 
 <p align="center">
-  <a href="https://onOrca.dev"><strong>Download at onOrca.dev</strong></a>
+  <a href="#install"><strong>Download 🐋</strong></a>
 </p>
 
 <p align="center">
@@ -73,14 +73,30 @@ Orca supports any CLI agent (_not just this list_).
 
 ## Install
 
-- **[Download from onOrca.dev](https://onOrca.dev)**
-- On macOS, install via Homebrew:
-  ```bash
-  brew tap stablyai/orca
-  brew install --cask orca
-  ```
-  Updates are handled by Orca's built-in updater; see [docs/homebrew-cask.md](docs/homebrew-cask.md).
-- Or download the latest binaries via the **[GitHub Releases page](https://github.com/stablyai/orca/releases)**.
+- **[Download from onOrca.dev](https://onOrca.dev)** — or grab the latest binaries from the **[GitHub Releases page](https://github.com/stablyai/orca/releases/latest)**.
+
+Alternatively, install from a package manager:
+
+### macOS (Homebrew)
+
+```bash
+brew tap stablyai/orca
+brew install --cask orca
+```
+
+Updates are handled by Orca's built-in updater; see [docs/homebrew-cask.md](docs/homebrew-cask.md).
+
+### Arch Linux (AUR)
+
+```bash
+# Precompiled binary
+yay -S stably-orca-bin
+
+# Build from GitHub source
+yay -S stably-orca-git
+```
+
+See [stably-orca-bin](https://aur.archlinux.org/packages/stably-orca-bin) and [stably-orca-git](https://aur.archlinux.org/packages/stably-orca-git) on the AUR.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -83,8 +83,6 @@ Alternatively, install from a package manager:
 brew install --cask stablyai/orca/orca
 ```
 
-Updates are handled by Orca's built-in updater; see [docs/homebrew-cask.md](docs/homebrew-cask.md).
-
 ### Arch Linux (AUR)
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -80,8 +80,7 @@ Alternatively, install from a package manager:
 ### macOS (Homebrew)
 
 ```bash
-brew tap stablyai/orca
-brew install --cask orca
+brew install --cask stablyai/orca/orca
 ```
 
 Updates are handled by Orca's built-in updater; see [docs/homebrew-cask.md](docs/homebrew-cask.md).

--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ Orca supports any CLI agent (_not just this list_).
 ## Install
 
 - **[Download from onOrca.dev](https://onOrca.dev)**
+- On macOS, install via Homebrew:
+  ```bash
+  brew tap stablyai/orca
+  brew install --cask orca
+  ```
+  Updates are handled by Orca's built-in updater; see [docs/homebrew-cask.md](docs/homebrew-cask.md).
 - Or download the latest binaries via the **[GitHub Releases page](https://github.com/stablyai/orca/releases)**.
 
 ---

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -80,8 +80,7 @@ También puedes instalar desde un gestor de paquetes:
 ### macOS (Homebrew)
 
 ```bash
-brew tap stablyai/orca
-brew install --cask orca
+brew install --cask stablyai/orca/orca
 ```
 
 Las actualizaciones las gestiona el actualizador integrado de Orca; consulta [docs/homebrew-cask.md](homebrew-cask.md).

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -83,8 +83,6 @@ También puedes instalar desde un gestor de paquetes:
 brew install --cask stablyai/orca/orca
 ```
 
-Las actualizaciones las gestiona el actualizador integrado de Orca; consulta [docs/homebrew-cask.md](homebrew-cask.md).
-
 ### Arch Linux (AUR)
 
 ```bash

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -21,7 +21,7 @@
 </p>
 
 <p align="center">
-  <a href="https://onOrca.dev"><strong>Descarga en onOrca.dev</strong></a>
+  <a href="#instalación"><strong>Descargar 🐋</strong></a>
 </p>
 
 <p align="center">
@@ -73,8 +73,30 @@ Orca es compatible con cualquier agente CLI (_no solo los de esta lista_).
 
 ## Instalación
 
-- **[Descarga desde onOrca.dev](https://onOrca.dev)**
-- O descarga los binarios más recientes desde la **[página de GitHub Releases](https://github.com/stablyai/orca/releases)**.
+- **[Descarga desde onOrca.dev](https://onOrca.dev)** — o descarga los binarios más recientes desde la **[página de GitHub Releases](https://github.com/stablyai/orca/releases/latest)**.
+
+También puedes instalar desde un gestor de paquetes:
+
+### macOS (Homebrew)
+
+```bash
+brew tap stablyai/orca
+brew install --cask orca
+```
+
+Las actualizaciones las gestiona el actualizador integrado de Orca; consulta [docs/homebrew-cask.md](homebrew-cask.md).
+
+### Arch Linux (AUR)
+
+```bash
+# Binario precompilado
+yay -S stably-orca-bin
+
+# Compilar desde el código de GitHub
+yay -S stably-orca-git
+```
+
+Consulta [stably-orca-bin](https://aur.archlinux.org/packages/stably-orca-bin) y [stably-orca-git](https://aur.archlinux.org/packages/stably-orca-git) en el AUR.
 
 ---
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -81,8 +81,7 @@ Orca は任意の CLI Agent に対応しています（_このリストに限定
 ### macOS (Homebrew)
 
 ```bash
-brew tap stablyai/orca
-brew install --cask orca
+brew install --cask stablyai/orca/orca
 ```
 
 アップデートは Orca 内蔵のアップデータが処理します。詳しくは [docs/homebrew-cask.md](homebrew-cask.md) を参照してください。

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -22,7 +22,7 @@
 </p>
 
 <p align="center">
-  <a href="https://onOrca.dev"><strong>onOrca.dev でダウンロード</strong></a>
+  <a href="#インストール"><strong>ダウンロード 🐋</strong></a>
 </p>
 
 <p align="center">
@@ -74,8 +74,30 @@ Orca は任意の CLI Agent に対応しています（_このリストに限定
 
 ## インストール
 
-- **[onOrca.dev からダウンロード](https://onOrca.dev)**
-- または、**[GitHub Releases ページ](https://github.com/stablyai/orca/releases)**から最新のインストーラーをダウンロードしてください。
+- **[onOrca.dev からダウンロード](https://onOrca.dev)** — または **[GitHub Releases ページ](https://github.com/stablyai/orca/releases/latest)** から最新のインストーラーを取得できます。
+
+パッケージマネージャーからのインストールも可能です:
+
+### macOS (Homebrew)
+
+```bash
+brew tap stablyai/orca
+brew install --cask orca
+```
+
+アップデートは Orca 内蔵のアップデータが処理します。詳しくは [docs/homebrew-cask.md](homebrew-cask.md) を参照してください。
+
+### Arch Linux (AUR)
+
+```bash
+# ビルド済みバイナリ
+yay -S stably-orca-bin
+
+# GitHub ソースからビルド
+yay -S stably-orca-git
+```
+
+AUR の [stably-orca-bin](https://aur.archlinux.org/packages/stably-orca-bin) と [stably-orca-git](https://aur.archlinux.org/packages/stably-orca-git) を参照してください。
 
 ---
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -84,8 +84,6 @@ Orca は任意の CLI Agent に対応しています（_このリストに限定
 brew install --cask stablyai/orca/orca
 ```
 
-アップデートは Orca 内蔵のアップデータが処理します。詳しくは [docs/homebrew-cask.md](homebrew-cask.md) を参照してください。
-
 ### Arch Linux (AUR)
 
 ```bash

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -84,8 +84,6 @@ Orca 支持任何 CLI Agent (_不仅限于以下列表_)。
 brew install --cask stablyai/orca/orca
 ```
 
-更新由 Orca 内置的更新器处理；详见 [docs/homebrew-cask.md](homebrew-cask.md)。
-
 ### Arch Linux (AUR)
 
 ```bash

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -22,7 +22,7 @@
 </p>
 
 <p align="center">
-  <a href="https://onOrca.dev"><strong>在 onOrca.dev 下载</strong></a>
+  <a href="#安装"><strong>下载 🐋</strong></a>
 </p>
 
 <p align="center">
@@ -74,8 +74,30 @@ Orca 支持任何 CLI Agent (_不仅限于以下列表_)。
 
 ## 安装
 
-- **[从 onOrca.dev 下载](https://onOrca.dev)**
-- 或者通过 **[GitHub Releases 页面](https://github.com/stablyai/orca/releases)** 下载最新的安装包。
+- **[从 onOrca.dev 下载](https://onOrca.dev)** — 或通过 **[GitHub Releases 页面](https://github.com/stablyai/orca/releases/latest)** 获取最新安装包。
+
+你也可以通过包管理器安装:
+
+### macOS (Homebrew)
+
+```bash
+brew tap stablyai/orca
+brew install --cask orca
+```
+
+更新由 Orca 内置的更新器处理；详见 [docs/homebrew-cask.md](homebrew-cask.md)。
+
+### Arch Linux (AUR)
+
+```bash
+# 预编译二进制
+yay -S stably-orca-bin
+
+# 从 GitHub 源码构建
+yay -S stably-orca-git
+```
+
+详见 AUR 上的 [stably-orca-bin](https://aur.archlinux.org/packages/stably-orca-bin) 与 [stably-orca-git](https://aur.archlinux.org/packages/stably-orca-git)。
 
 ---
 

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -81,8 +81,7 @@ Orca 支持任何 CLI Agent (_不仅限于以下列表_)。
 ### macOS (Homebrew)
 
 ```bash
-brew tap stablyai/orca
-brew install --cask orca
+brew install --cask stablyai/orca/orca
 ```
 
 更新由 Orca 内置的更新器处理；详见 [docs/homebrew-cask.md](homebrew-cask.md)。

--- a/docs/homebrew-cask.md
+++ b/docs/homebrew-cask.md
@@ -1,0 +1,90 @@
+# Homebrew Cask
+
+Orca is distributed on macOS as a Homebrew Cask. This doc covers how the cask
+is wired up, how it interacts with Orca's in-app updater, and what to do when
+something drifts.
+
+## For users
+
+```bash
+brew tap stablyai/orca
+brew install --cask orca
+```
+
+Or in one command: `brew install --cask stablyai/orca/orca`. Both forms install
+`Orca.app` into `/Applications`. Subsequent updates are handled by Orca's
+in-app updater (electron-updater) — `brew upgrade` is a no-op because the
+cask is marked `auto_updates true`. Users who want brew to force-reinstall
+from the cask version can pass `--greedy`.
+
+## How the pieces fit together
+
+There are three moving parts:
+
+1. **`Casks/orca.rb`** in this repo — source of truth for the cask file.
+   Edited by automation on every stable release; can be edited manually if
+   metadata (zap list, macOS floor, desc) needs to change.
+2. **`stablyai/homebrew-orca`** — the public tap users consume. Mirrors
+   `Casks/orca.rb` from this repo via the bump workflow. Nothing else lives
+   there; do not hand-edit.
+3. **`.github/workflows/homebrew-bump.yml`** — runs on `release.published`
+   for stable tags (skips `-rc.*` and GitHub pre-releases). Downloads the
+   two DMGs, rewrites `version`/`sha256` in `Casks/orca.rb`, pushes a PR to
+   the tap, and auto-merges it.
+
+### Why the cask uses `auto_updates true`
+
+`electron-updater` (`src/main/updater.ts`) downloads each new release and
+swaps `Orca.app` in place. Homebrew-Cask's tracking of installed versions is
+based on the cask's `version:` field plus an install receipt — so when the
+app mutates itself, brew's metadata drifts. `auto_updates true` tells
+Homebrew this is expected: `brew outdated` and `brew upgrade` ignore the
+cask unless `--greedy` is passed. Uninstall still works normally.
+
+The hidden requirement: Squirrel.Mac (what electron-updater uses) needs
+write access to `/Applications/Orca.app`. Cask installs into `/Applications`
+with user ownership by default, so this works out of the box. If a user ever
+`sudo`-installs or the bundle becomes root-owned, the in-app updater will
+fail silently; they'd need `brew reinstall --cask orca` or `brew upgrade
+--cask orca --greedy` to recover.
+
+## One-time setup (already done, documented here for reference)
+
+1. **Tap repo**: `stablyai/homebrew-orca` on GitHub. Must be named
+   `homebrew-<anything>` so `brew tap stablyai/orca` resolves. Public.
+2. **Auto-merge** enabled in tap repo settings.
+3. **Seeded** with a copy of `Casks/orca.rb` for the initial version.
+
+The workflow authenticates as the existing `buf0-bot` GitHub App
+(installed org-wide on stablyai), reusing the `BUFO_BOT_PRIVATE_KEY`
+secret that's already on `stablyai/orca` for `track-community-prs.yaml`.
+No PAT rotation, no new secret.
+
+## Submitting to homebrew-cask (the main tap)
+
+The `stablyai/homebrew-orca` tap ships first. Once Orca has stable user
+demand and has been on a release cadence for ~30+ days without the version
+string breaking conventions (no `-rc`, no date suffixes), we can submit to
+`Homebrew/homebrew-cask` so users can `brew install --cask orca` without a
+tap prefix. That submission is a one-time PR against
+https://github.com/Homebrew/homebrew-cask; subsequent bumps to the main tap
+are handled by their own [autobump infrastructure](https://docs.brew.sh/Autobump)
+as long as the release cadence matches their expectations. T3 Code's
+[cask](https://github.com/Homebrew/homebrew-cask/blob/main/Casks/t/t3-code.rb)
+is a close structural analogue.
+
+## Troubleshooting
+
+- **"electron-updater says no update available, but brew says I'm out of
+  date"** — expected if the user ran `brew upgrade --greedy` or installed
+  the cask before the in-app updater picked up a newer release. The
+  `auto_updates true` flag usually prevents this; if a user reports it,
+  check that their cask file still has the marker.
+- **Bump workflow failed to PR the tap** — verify the `buf0-bot` app is
+  still installed on `stablyai/homebrew-orca` (org-wide install, should
+  auto-cover any new org repo). Re-run via `workflow_dispatch` with the
+  tag name.
+- **Squirrel-mac fails during update** — almost always bundle permissions
+  or a signing-identity mismatch. See the `Why: signing identity stability`
+  comment in `config/electron-builder.config.cjs` and the updater logs in
+  `~/Library/Application Support/Orca/logs/`.


### PR DESCRIPTION
## Summary
The Homebrew bump workflow shipped in #1304 listens on `release.published`, but it never fired for v1.3.25 — brew users stayed stuck on v1.3.24 until I manually dispatched it.

**Root cause:** the `publish-release` job in `release.yml` flips the release from draft to published with `gh release edit` using `GITHUB_TOKEN`. [GitHub explicitly blocks](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow) workflow events raised via `GITHUB_TOKEN` from kicking off other workflows — an anti-loop safeguard. So the `release.published` trigger in `homebrew-bump.yml` is dead on arrival for this repo's release flow.

**Fix:** dispatch `homebrew-bump.yml` directly from `publish-release` via `gh workflow run`. `workflow_dispatch` is a documented exception to the `GITHUB_TOKEN` recursion rule, so this actually fires. Gated to GA tags only (`!contains(tag, '-rc.')`) so prerelease tags don't touch the stable cask.

## State of the tap right now
Already manually recovered: the tap now serves v1.3.25 (`gh api /repos/stablyai/homebrew-orca/contents/Casks/orca.rb` confirms version 1.3.25 with the right sha256s). Users doing `brew update && brew install --cask stablyai/orca/orca` will now get the current release.

## Test plan
- [x] `release.published` trigger left in `homebrew-bump.yml` as a safety net for manually-published (UI-driven) releases — those events use the human's token, not `GITHUB_TOKEN`, so they do propagate.
- [x] `workflow_dispatch` input verified to work end-to-end on v1.3.25 (ran in 23s, PR created and auto-merged into the tap).
- [ ] Verify on the next GA release: the `Trigger Homebrew cask bump` step should show up as green in `release.yml`, and the bump run should appear in the Actions tab within a minute of `publish-release` completing.
- [ ] Confirm it skips on the next rc tag (no bump run created).

Made with [Orca](https://github.com/stablyai/orca) 🐋
