### PR TITLE
feat(daemon): auto-kill orphaned legacy daemons on upgrade

### DIFF
--- a/docs/auto-kill-old-daemons.md
+++ b/docs/auto-kill-old-daemons.md
@@ -339,12 +339,15 @@ if (legacyAdapters.length > 0) {
 
 6. **Probe-to-discovery race on Tier 2 — mandatory post-discovery sweep.** Between `processLegacyVersion` returning a wrapped adapter with `liveCount > 0` and `DaemonPtyRouter.discoverLegacySessions` completing, the legacy daemon's last session could exit. In that window, the router never registers any session on the legacy adapter → `onExit` never fires on it → drain never triggers. Without a sweep, the legacy daemon persists idle and leaking fds for the rest of this app session (potentially days for always-on users); Tier 1 only catches it on the next launch.
 
-**Required (not optional):** after `discoverLegacySessions` completes, iterate `this.legacy`. For each adapter where no entry in `this.sessionAdapters` maps to it (use `hasActiveSessionsOn(adapter)` — it already exists for the drain path), remove the adapter from `this.legacy`, tear down its per-adapter unsubscribers, and invoke the same `onLegacyDrained(adapter)` callback used by the runtime drain path. This closes the race synchronously on startup.
+**Required (not optional):** after `discoverLegacySessions` completes, iterate `this.legacy`. For each adapter where discovery succeeded and no entry in `this.sessionAdapters` maps to it (use `hasActiveSessionsOn(adapter)` — it already exists for the drain path), remove the adapter from `this.legacy`, tear down its per-adapter unsubscribers, and invoke the same `onLegacyDrained(adapter)` callback used by the runtime drain path. This closes the race synchronously on startup.
+
+If `discoverLegacySessions` catches a `listProcesses` error for an adapter, mark that adapter as `discoveryFailed` and exclude it from both the post-discovery sweep and runtime drain. Reason: the startup probe already proved the daemon had live sessions; a transient discovery RPC failure must not be reinterpreted as "no live sessions" and used to kill the daemon. Leaking that one legacy daemon until the next app launch is acceptable; killing live work is not.
 
 ```ts
 // DaemonPtyRouter — call after discoverLegacySessions finishes populating sessionAdapters.
 sweepDrainedLegacyAdapters(): void {
   for (const adapter of [...this.legacy]) {
+    if (this.discoveryFailedAdapters.has(adapter)) continue
     if (this.hasActiveSessionsOn(adapter)) continue
     this.legacy = this.legacy.filter((a) => a !== adapter)
     const subs = this.unsubscribersByAdapter.get(adapter)
@@ -402,6 +405,7 @@ Drain hook behaviors:
 - **Post-drain `listProcesses`** — assert the drained adapter is not queried (removed from `allAdapters()` iteration). Prevents spurious errors from a dead socket.
 - **Re-entrancy guard** — synthesize a double-exit event for the same session id. Assert `onLegacyDrained` fires at most once.
 - **Post-discovery sweep** — have `discoverLegacySessions` find no sessions for a wrapped legacy adapter. Assert `sweepDrainedLegacyAdapters()` removes that adapter and invokes `onLegacyDrained` exactly once.
+- **Discovery failure is conservative** — make `listProcesses` reject for a wrapped legacy adapter. Assert `sweepDrainedLegacyAdapters()` does not drain it, and a later exit event from that adapter also does not invoke `onLegacyDrained`.
 
 ### Unit tests — `daemon-health.test.ts`
 
@@ -441,6 +445,7 @@ Drain hook behaviors:
 | `listSessions` on a v1 daemon behaves differently than v4. | `cleanupDaemonForProtocol` already works across all versions today — that's its entire design (`daemon-init.ts:242`, accepts `protocolVersion` arg). We're reusing that proven path. `listSessions` has been stable since v1 (it's one of the first RPCs defined — see `daemon-server.ts` handlers). |
 | Probe RPC hangs indefinitely on a wedged daemon, blocking startup. | `DaemonClient` enforces `CONNECT_TIMEOUT_MS=5000` and `REQUEST_TIMEOUT_MS=30000` (`client.ts:8-9`). Worst case per version: ~35s for the probe; if the cleanup path also hangs on the same wedged daemon, the combined worst case per version is ~100s. Parallel across versions caps total at that per-version figure. |
 | Startup latency regression from parallel cleanup. | Benchmark before merge: time from `app.on('ready')` to first IPC on a machine with 3 planted legacy daemons. Target: < 2s additional latency vs baseline in the happy path (daemons present and responsive). Document expected worst-case of 35s when all three are wedged. |
+| `discoverLegacySessions` fails after the startup probe saw live sessions. | Mark that adapter as discovery-failed and exclude it from sweep/drain for this app session. Tier 1 can retry on next launch; the zero-regression priority is preserving live work. |
 | Legacy adapter's `DaemonClient` disconnect races with the `shutdown` RPC inside `cleanupDaemonForProtocol`. | `cleanupDaemonForProtocol` creates its own client (`daemon-init.ts:269`). The probe client opened in `processLegacyVersion` is disconnected in `finally` before cleanup runs. No shared connection. |
 | Future protocol bump to v5 accidentally leaves v4 missing from `PREVIOUS_DAEMON_PROTOCOL_VERSIONS`. | Unit test in `types.test.ts` (add if not present): asserts `PREVIOUS_DAEMON_PROTOCOL_VERSIONS` contains every integer from 1 to `PROTOCOL_VERSION - 1`. Forces discipline at version-bump time. |
 | Two Orca processes racing on the same legacy socket during a user-initiated reinstall. | The app already has a single-instance lock (Electron's `requestSingleInstanceLock`). Legacy cleanup inherits that lock's exclusivity — not additive risk. |

--- a/docs/auto-kill-old-daemons.md
+++ b/docs/auto-kill-old-daemons.md
@@ -1,0 +1,493 @@
+# Auto-kill old daemon versions
+
+## Problem
+
+Orca spawns a background daemon process (`daemon-entry.js`) that owns all PTY sessions and survives Electron quit — this is intentional, so that long-running agents and builds are not killed when the user closes the app. The socket name includes the protocol version (`daemon-v${PROTOCOL_VERSION}.sock`), so every breaking protocol change produces a new daemon, and old daemons from previous app versions keep running.
+
+When a user upgrades Orca, the new app:
+
+1. Spawns a fresh `daemon-v4` daemon (current).
+2. Probes `daemon-v1`, `daemon-v2`, `daemon-v3` sockets; if alive, wraps each as a read-only legacy adapter so in-flight sessions keep working.
+3. **Never** shuts down those legacy daemons — not when they drain, not on the next upgrade, not ever.
+
+Result: orphaned daemons accumulate and hoard PTY master file descriptors (`ptmx`). macOS caps `kern.tty.ptmx_max` at 511, so after a few upgrade cycles users hit "cannot allocate any more pty devices" and every new terminal fails — not just in Orca, but system-wide (Ghostty, Terminal.app, anything that opens a PTY).
+
+Real reported case: 3 orphaned Orca daemons (v2 aged 6d 21h, v3 aged 5d 20h, v4 aged 4d 15h) holding 475 of the 491 allocated ptmx fds between them.
+
+### Why stale daemons exist in the first place
+
+The daemon is spawned `detached: true` with `child.unref()` (`daemon-init.ts:94-98, 138`) specifically so it outlives Electron. On app quit, `disconnectDaemon()` (`daemon-init.ts:215-218`) only closes the IPC socket — it does not terminate the daemon process. The daemon only exits on SIGTERM/SIGINT or a fatal non-PTY exception (`daemon-entry.ts:72-73`).
+
+When the app upgrades across a protocol bump, the new Orca calls `cleanupDaemonForProtocol(runtimeDir, PROTOCOL_VERSION)` (`daemon-init.ts:82`) — which only targets the **current** version. Nothing ever sends SIGTERM to the previous-version daemon. It keeps running until reboot, OOM, or manual kill.
+
+The original designer explicitly spared legacy daemons with the comment at `daemon-init.ts:326-330`:
+
+> "old daemon PTYs can be running long-lived agents during an app upgrade. Keep those sessions routed to their original daemon while new terminals use the current protocol, instead of killing background work."
+
+That decision is correct for daemons with in-flight sessions. The bug is that it applies unconditionally — legacy daemons whose every session has already exited are also spared, with no mechanism to ever kill them.
+
+## Goals
+
+- On app startup, reclaim PTY fds from legacy daemons whose every session has already exited.
+- Do not break in-flight legacy sessions (long-running agents in terminals spawned by an older Orca version must keep working through the transition).
+- When a legacy daemon's last in-flight session ends at runtime, shut the daemon down so its fds are reclaimed without requiring an Orca restart.
+- Zero regressions to current-version (`daemon-v4`) lifecycle. The new code path must not run for `PROTOCOL_VERSION`.
+- Zero timer-based lifecycle logic. Every cleanup trigger must be a discrete event (app startup, session exit) — no polling, no wall-clock thresholds, no risk of false positives against live work.
+
+## Non-goals
+
+- Fixing the v4 per-session fd leak (v4 daemon holding 269 fds for 13 terminals — PTY fd leak on terminal dispose). See "Related work" below.
+- Killing daemon-side sessions when a worktree is deleted. See "Related work" below.
+- Adding daemon-side idle self-exit (a recurring timer in the daemon that self-terminates after N hours of no clients/sessions). Rejected because it introduces timer-based logic that can misfire against the live daemon, causing cold-restore instead of warm-reattach. Can be revisited later as a separate effort.
+- Changing the protocol-versioning scheme, socket naming, or moving to capability negotiation.
+- Retroactively migrating legacy sessions onto the current daemon.
+
+## Design decisions
+
+Two explicitly event-driven cleanup tiers. Both are bounded to `PREVIOUS_DAEMON_PROTOCOL_VERSIONS`; neither touches the current daemon.
+
+- **Tier 1 (startup event):** when the new app launches, any legacy daemon whose sessions have all exited is shut down immediately.
+- **Tier 2 (session-exit event):** any legacy daemon that still has live sessions at startup is wrapped as today; when the last of those sessions emits an exit event at runtime, the daemon is shut down then.
+
+### Rejected: time-based max-age cap
+
+An earlier draft included a "Tier 3" that force-killed legacy daemons older than 48h regardless of live session count, to bound wedged-session pathologies. **Rejected.**
+
+Reason: a legacy daemon older than 48h with live sessions by definition contains work the user cares about (overnight agent runs, week-long builds). Silently killing that session with no warning is UX-hostile and contradicts the original "don't kill background work" intent of the legacy adapter path. The wedged-session case is real but rare, and the right response is observability/logging, not an arbitrary clock-based kill.
+
+The removal of Tier 3 also removes a timer concept from the design — the only remaining triggers are the two discrete events above.
+
+### "Idle" is event-derived, not time-derived
+
+Throughout this design, "idle legacy daemon" means `TerminalHost.listSessions()` returns zero sessions where `isAlive === true` — i.e., every shell subprocess the daemon ever tracked has exited (`session.ts:92-94`). It is **not** a measure of keystroke activity, client connections, or elapsed time. A daemon with a shell sitting at an idle prompt for hours is **not** idle under this definition.
+
+## Current code surface
+
+All relevant logic lives in `src/main/daemon/`:
+
+- `types.ts:7-8` — `PROTOCOL_VERSION = 4`, `PREVIOUS_DAEMON_PROTOCOL_VERSIONS = [1, 2, 3]`.
+- `daemon-spawner.ts:62-82` — `getDaemonSocketPath` / `getDaemonTokenPath` / `getDaemonPidPath` all take an optional `protocolVersion`, so per-version addressing already works.
+- `daemon-init.ts:242-314` — `cleanupDaemonForProtocol(runtimeDir, protocolVersion)` does the full graceful-shutdown dance for any version: probe, connect, `listSessions` to count live sessions, `shutdown` RPC, fallback to `killStaleDaemon`, unlink socket and pid file. **Currently only called for `PROTOCOL_VERSION`** (line 82, inside the opt-in relaunch path).
+- `daemon-init.ts:316-345` — `createLegacyDaemonAdapters` iterates `PREVIOUS_DAEMON_PROTOCOL_VERSIONS`, probes each socket, and wraps live ones as `DaemonPtyAdapter`. Never calls cleanup.
+- `daemon-pty-router.ts:23-28` — `sessionAdapters.delete(id)` fires on every `onExit` event. Natural hook for "last session drained from adapter X".
+- `session.ts:92-94` — `isAlive` is derived purely from shell exit events; event-driven, not timer-driven.
+
+## Design
+
+### Tier 1 — legacy daemon with zero live sessions: kill at startup
+
+In `createLegacyDaemonAdapters`, for each version in `PREVIOUS_DAEMON_PROTOCOL_VERSIONS` whose socket is alive:
+
+- Call `cleanupDaemonForProtocol(runtimeDir, protocolVersion)` directly. It internally probes the socket, opens a client, calls `listSessions` to compute `killedCount`, issues the `shutdown` RPC, and falls back to `killStaleDaemon` on RPC failure (`daemon-init.ts:242-314`). Read its `killedCount` return value:
+  - `killedCount === 0` → the daemon had no live sessions; it's been cleanly torn down. No adapter needed. Continue to next version.
+  - `killedCount > 0` → the daemon had live sessions. **We do not want to have killed them.** This is a correctness issue with the naive "always call cleanup" approach.
+
+Because `cleanupDaemonForProtocol` always issues `shutdown` if the daemon is reachable (line 283) and that call kills all sessions (`killSessions: true` at line 283), a straight call here would kill live legacy sessions. We need the "probe first, branch on live count" shape:
+
+```ts
+// Probe: is this daemon idle or does it have live work?
+const probeClient = new DaemonClient({ socketPath, tokenPath, protocolVersion })
+let liveCount: number
+try {
+  await probeClient.ensureConnected()
+  const { sessions } = await probeClient.request<ListSessionsResult>('listSessions', undefined)
+  liveCount = sessions.filter((s) => s.isAlive).length
+} catch {
+  // Probe said socket was alive but RPC failed — daemon is wedged.
+  // Fall through to cleanup, which will PID-kill if the shutdown RPC also fails.
+  liveCount = 0
+} finally {
+  probeClient.disconnect()
+}
+
+if (liveCount === 0) {
+  await cleanupDaemonForProtocol(runtimeDir, protocolVersion)
+  continue // skip to next version, no adapter added
+}
+
+// Tier 2: live sessions — wrap for drain.
+adapters.push(new DaemonPtyAdapter({ ... }))
+```
+
+**Wedged-daemon handling:** if the probe RPC fails (daemon's socket file exists but the daemon process is hung or non-responsive), we treat it as idle and let `cleanupDaemonForProtocol` handle it — its own retry/fallback path (daemon-init.ts:288-292) will PID-kill via `killStaleDaemon` if the shutdown RPC also fails. Wedged daemons hold fds for sessions nobody can reach anyway, so this is correct.
+
+### `killStaleDaemon` must revalidate the pid before SIGKILL
+
+`daemon-health.ts:killStaleDaemon` (lines 180-220 in current code) validates `isDaemonProcess(pid, socketPath, tokenPath)` once at line 188, sends SIGTERM, polls `process.kill(pid, 0)` for ≤3s, then escalates to `SIGKILL` at line 203 **without re-checking** that `pid` still maps to the daemon. In the 3s polling window the daemon can exit and its pid can be recycled to an unrelated user process (Chrome helper, editor, another Orca-spawned subprocess). SIGKILL against a recycled pid terminates that unrelated process with no diagnostic trail.
+
+This is a pre-existing hazard in `killStaleDaemon`, but the auto-kill design amplifies exposure: Tier 1 expands the number of calls into this path (we now call it for every wedged legacy daemon on every app launch, across every version in `PREVIOUS_DAEMON_PROTOCOL_VERSIONS`), making a previously-rare race materially more likely.
+
+**Required change to `killStaleDaemon`** (treat as part of this PR, not a follow-up):
+
+1. Before sending `SIGKILL` at line 203, call `isDaemonProcess(pid, socketPath, tokenPath)` again. If it returns false (pid recycled, socket gone, token mismatch), skip SIGKILL entirely — the daemon is already dead, and whatever process currently owns that pid is not ours. Log `reason=pid_recycled` and treat the kill as successful.
+2. Preferred reinforcement: when the daemon spawns, write `{ pid, startedAtMs }` into the pid file (currently just `pid`). `isDaemonProcess` learns to read `startedAtMs` and compares against `/proc/<pid>/stat`'s `starttime` (Linux) or `ps -o lstart=` (macOS). A pid match without a start-time match means recycle — reject. Files to change: `daemon-spawner.ts` (write format), `daemon-health.ts` (parse + compare in `isDaemonProcess`).
+
+**Pid-file compatibility is required.** `killStaleDaemon` must accept both the new JSON pid file and the legacy bare-integer pid file during mixed-version upgrades:
+
+```ts
+type ParsedDaemonPid = { pid: number; startedAtMs: number | null }
+
+function parseDaemonPidFile(contents: string): ParsedDaemonPid | null {
+  const trimmed = contents.trim()
+  try {
+    const parsed = JSON.parse(trimmed) as { pid?: unknown; startedAtMs?: unknown }
+    if (typeof parsed.pid === 'number' && Number.isFinite(parsed.pid)) {
+      return {
+        pid: parsed.pid,
+        startedAtMs:
+          typeof parsed.startedAtMs === 'number' && Number.isFinite(parsed.startedAtMs)
+            ? parsed.startedAtMs
+            : null
+      }
+    }
+  } catch {
+    // Legacy daemons wrote the pid file as a bare integer.
+  }
+
+  const pid = Number(trimmed)
+  return Number.isFinite(pid) ? { pid, startedAtMs: null } : null
+}
+```
+
+When `startedAtMs` is `null`, skip the start-time comparison and fall back to the existing `isDaemonProcess(pid, socketPath, tokenPath)` command-line validation only. This preserves compatibility with already-running daemons that wrote the old pid format. Invalid JSON that is not a bare integer is treated as "no trustworthy pid" and must not be killed.
+
+Without step 1 at minimum, Tier 1 SIGKILL of a wedged legacy daemon risks silently killing an unrelated user process. Step 2 is strongly preferred because step 1 still has a microsecond race between the liveness poll and the `isDaemonProcess` revalidation — start-time comparison closes that fully.
+
+### Tier 2 — legacy daemon with live sessions: kill on drain
+
+If `liveCount > 0`, wrap the adapter as today (`daemon-init.ts:335-342`). Additionally, register a drain hook:
+
+- Router already invokes `sessionAdapters.delete(id)` on `onExit` events (`daemon-pty-router.ts:23-28`).
+- Extend the router constructor with `onLegacyDrained?: (adapter: DaemonPtyAdapter) => void`. Fired when the last session pointing at a given legacy adapter has exited.
+- `initDaemonPtyProvider` passes a callback that:
+  1. Calls `adapter.dispose()` to flush its disconnect.
+  2. Calls `cleanupDaemonForProtocol(runtimeDir, adapter.protocolVersion)` to terminate the daemon process.
+
+**Routing race safety:** `daemon-pty-router.ts:46-52` shows `spawn()` routes to a legacy adapter *only* when called with an already-registered `sessionId`. New sessions (no `sessionId`, or unknown `sessionId`) go to `this.current`. So once the legacy adapter's final session fires `onExit` and its map entry is cleared, no new work can land on it. The drain signal is a true edge — safe to fire cleanup.
+
+### Pseudocode for `createLegacyDaemonAdapters`
+
+```ts
+async function createLegacyDaemonAdapters(
+  runtimeDir: string
+): Promise<DaemonPtyAdapter[]> {
+  // Run per-version in parallel — see "Concurrency and ordering" for why.
+  const results = await Promise.all(
+    PREVIOUS_DAEMON_PROTOCOL_VERSIONS.map((protocolVersion) =>
+      processLegacyVersion(runtimeDir, protocolVersion)
+    )
+  )
+  return results.filter((a): a is DaemonPtyAdapter => a !== null)
+}
+
+async function processLegacyVersion(
+  runtimeDir: string,
+  protocolVersion: number
+): Promise<DaemonPtyAdapter | null> {
+  const socketPath = getDaemonSocketPath(runtimeDir, protocolVersion)
+  const tokenPath = getDaemonTokenPath(runtimeDir, protocolVersion)
+
+  if (!(await probeSocket(socketPath))) return null
+
+  // Probe: how many live sessions does this legacy daemon hold?
+  let liveCount = 0
+  let wedged = false
+  const probeClient = new DaemonClient({ socketPath, tokenPath, protocolVersion })
+  try {
+    await probeClient.ensureConnected()
+    const { sessions } = await probeClient.request<ListSessionsResult>(
+      'listSessions',
+      undefined
+    )
+    liveCount = sessions.filter((s) => s.isAlive).length
+  } catch {
+    // Probe failed: socket was live but the daemon won't answer RPC.
+    // Treat as wedged/idle — cleanupDaemonForProtocol falls back to PID kill.
+    wedged = true
+  } finally {
+    probeClient.disconnect()
+  }
+
+  if (liveCount === 0) {
+    // Tier 1: idle or wedged. Clean up immediately.
+    const reason = wedged ? 'wedged' : 'idle'
+    const result = await cleanupDaemonForProtocol(runtimeDir, protocolVersion)
+    console.log(
+      `[daemon] legacy v${protocolVersion} cleanup: reason=${reason} ` +
+        `killedSessions=${result.killedCount}`
+    )
+    return null
+  }
+
+  // Tier 2: live sessions — keep for drain.
+  console.log(
+    `[daemon] legacy v${protocolVersion} wrapped for drain: liveSessions=${liveCount}`
+  )
+  return new DaemonPtyAdapter({
+    socketPath,
+    tokenPath,
+    protocolVersion,
+    historyPath: getHistoryDir()
+  })
+}
+```
+
+Drain wiring in the router:
+
+```ts
+// daemon-pty-router.ts
+private onLegacyDrained?: (adapter: DaemonPtyAdapter) => void
+private unsubscribersByAdapter = new Map<DaemonPtyAdapter, (() => void)[]>()
+
+constructor(opts: {
+  current: DaemonPtyAdapter
+  legacy: DaemonPtyAdapter[]
+  onLegacyDrained?: (adapter: DaemonPtyAdapter) => void
+}) {
+  this.current = opts.current
+  this.legacy = opts.legacy
+  this.onLegacyDrained = opts.onLegacyDrained
+
+  for (const adapter of this.allAdapters()) {
+    const unsubscribers = [
+      adapter.onData(/* existing */),
+      adapter.onExit((payload) => {
+        this.sessionAdapters.delete(payload.id)
+        for (const listener of this.exitListeners) listener(payload)
+
+        // Why: fire drain only for legacy adapters, and only when every session
+        // in the router's map is on a non-legacy adapter (or the map is empty).
+        // Removing the adapter from `this.legacy` before invoking the callback
+        // prevents a double-fire if onExit re-enters (e.g. test harness).
+        if (this.legacy.includes(adapter) && !this.hasActiveSessionsOn(adapter)) {
+          this.legacy = this.legacy.filter((a) => a !== adapter)
+          const subs = this.unsubscribersByAdapter.get(adapter)
+          if (subs) {
+            for (const unsub of subs) unsub()
+            this.unsubscribersByAdapter.delete(adapter)
+          }
+          this.onLegacyDrained?.(adapter)
+        }
+      })
+    ]
+    this.unsubscribersByAdapter.set(adapter, unsubscribers)
+  }
+}
+
+private hasActiveSessionsOn(adapter: DaemonPtyAdapter): boolean {
+  for (const a of this.sessionAdapters.values()) {
+    if (a === adapter) return true
+  }
+  return false
+}
+```
+
+**Per-adapter unsubscriber tracking.** Replace the flat `this.unsubscribers: (() => void)[]` with `this.unsubscribersByAdapter: Map<DaemonPtyAdapter, (() => void)[]>`. On drain, call each unsubscribe for the drained adapter and delete the map entry. This is defensive: today, `adapter.dispose()` tears down the client and no events fire through the stale subscriptions, so the leak is inert. But a future change that reuses a disposed adapter or iterates `unsubscribers` would hit live callbacks into freed state. Cost is one Map instead of an array — no behavioral change for the router's other operations.
+
+Init-side callback wiring:
+
+```ts
+// daemon-init.ts — inside initDaemonPtyProvider
+const legacyAdapters =
+  process.env.ORCA_DISABLE_LEGACY_CLEANUP === '1'
+    ? []
+    : await createLegacyDaemonAdapters(runtimeDir)
+
+let routedAdapter: DaemonPtyAdapter | DaemonPtyRouter = newAdapter
+if (legacyAdapters.length > 0) {
+  routedAdapter = new DaemonPtyRouter({
+    current: newAdapter,
+    legacy: legacyAdapters,
+    onLegacyDrained: async (adapter) => {
+      try {
+        adapter.dispose()
+        const result = await cleanupDaemonForProtocol(
+          runtimeDir,
+          adapter.protocolVersion
+        )
+        console.log(
+          `[daemon] legacy v${adapter.protocolVersion} cleanup: reason=drain ` +
+            `killedSessions=${result.killedCount}`
+        )
+      } catch (err) {
+        console.warn(
+          `[daemon] legacy v${adapter.protocolVersion} drain cleanup failed:`,
+          err
+        )
+      }
+    }
+  })
+
+  await routedAdapter.discoverLegacySessions()
+  routedAdapter.sweepDrainedLegacyAdapters()
+}
+```
+
+`DaemonPtyAdapter`'s constructor currently receives `protocolVersion` in its options and passes it into `DaemonClient` / uses it inline for `supportsCheckpoints` (`daemon-pty-adapter.ts:73-83`), but does not retain it as a field. Add `public readonly protocolVersion: number` captured from `opts.protocolVersion` in the constructor so `onLegacyDrained` callers can read `adapter.protocolVersion`.
+
+## Concurrency and ordering
+
+1. **Tier 1 runs in parallel across versions.** The pseudocode uses `Promise.all` over `PREVIOUS_DAEMON_PROTOCOL_VERSIONS`. Each version's paths (socket, pid, token) are disjoint, so parallelism is safe. This is load-bearing for startup latency: worst case 3 versions × (5s `CONNECT_TIMEOUT_MS` + 30s `REQUEST_TIMEOUT_MS` from `client.ts:8-9`) = up to 105s of added startup time if done serially. Parallel execution caps per-version-worst-case at ~35s for the probe alone; if the probe succeeds but the subsequent `cleanupDaemonForProtocol` call also hangs (its internal `listSessions`, `shutdown`, and `killStaleDaemon` wait add up to ~65s additional), worst case per version is ~100s. Parallel across versions caps total at that per-version figure.
+
+2. **Current daemon spawn is not delayed by Tier 1.** `initDaemonPtyProvider` (`daemon-init.ts:166-209`) awaits `newSpawner.ensureRunning()` at line 177 **before** calling `createLegacyDaemonAdapters` at line 194. Tier 1 never gates the current daemon's readiness. Do not rearrange these awaits.
+
+3. **Drain cleanup runs serially after an exit event.** `onLegacyDrained` is invoked synchronously inside the `onExit` handler. It fires `cleanupDaemonForProtocol` as an async `.catch()`-guarded operation; the exit event itself is not blocked. The router's state mutation (`this.legacy.filter(...)`) happens before the callback, so concurrent exits on different legacy adapters cannot observe a stale `this.legacy` list.
+
+4. **Probe client lifetime.** The probe `DaemonClient` in `processLegacyVersion` is disconnected in `finally` before `cleanupDaemonForProtocol` runs. `cleanupDaemonForProtocol` opens its own fresh `DaemonClient` (`daemon-init.ts:269`). No shared connection, no teardown race.
+
+5. **Re-entrancy on drain.** If a legacy adapter's final session fires `onExit` and during `cleanupDaemonForProtocol` a hypothetical late exit event arrives, `this.legacy.includes(adapter)` returns false (we already filtered it out), so `onLegacyDrained` is not re-invoked. Idempotent by construction.
+
+6. **Probe-to-discovery race on Tier 2 — mandatory post-discovery sweep.** Between `processLegacyVersion` returning a wrapped adapter with `liveCount > 0` and `DaemonPtyRouter.discoverLegacySessions` completing, the legacy daemon's last session could exit. In that window, the router never registers any session on the legacy adapter → `onExit` never fires on it → drain never triggers. Without a sweep, the legacy daemon persists idle and leaking fds for the rest of this app session (potentially days for always-on users); Tier 1 only catches it on the next launch.
+
+**Required (not optional):** after `discoverLegacySessions` completes, iterate `this.legacy`. For each adapter where no entry in `this.sessionAdapters` maps to it (use `hasActiveSessionsOn(adapter)` — it already exists for the drain path), remove the adapter from `this.legacy`, tear down its per-adapter unsubscribers, and invoke the same `onLegacyDrained(adapter)` callback used by the runtime drain path. This closes the race synchronously on startup.
+
+```ts
+// DaemonPtyRouter — call after discoverLegacySessions finishes populating sessionAdapters.
+sweepDrainedLegacyAdapters(): void {
+  for (const adapter of [...this.legacy]) {
+    if (this.hasActiveSessionsOn(adapter)) continue
+    this.legacy = this.legacy.filter((a) => a !== adapter)
+    const subs = this.unsubscribersByAdapter.get(adapter)
+    if (subs) {
+      for (const unsub of subs) unsub()
+      this.unsubscribersByAdapter.delete(adapter)
+    }
+    this.onLegacyDrained?.(adapter)
+  }
+}
+```
+
+The earlier framing of this as "optional polish" was wrong — without the sweep, a legitimate ship scenario (user has a v3 daemon with one session that exits in the probe-to-discover window) silently re-creates the exact leak this PR is supposed to fix. The sweep is load-bearing for the zero-regression guarantee.
+
+## Error handling and logging
+
+- All Tier 1 failures are non-fatal. On probe error or cleanup error, log at warn and continue startup. The worst case is one more app launch with an orphan — still an improvement over "forever".
+- Drain cleanup failures are also non-fatal. If `cleanupDaemonForProtocol` fails during drain, the legacy daemon persists but no longer has the router keeping sessions on it. Tier 1 catches it on the next startup.
+- Structured log lines for each cleanup attempt:
+  - `[daemon] legacy v{version} cleanup: reason={idle|wedged|drain} killedSessions={n}`
+  - `[daemon] legacy v{version} wrapped for drain: liveSessions={n}`
+  - `[daemon] legacy v{version} drain cleanup failed: {error}` (warn)
+- Telemetry (if stats/collector is available): emit a single `daemon_legacy_cleanup` event per cleanup with `{ version, reason, killedSessions }`. Makes it possible to verify the fix lands in prod.
+
+## Testing plan
+
+All under `src/main/daemon/`. Existing tests: `daemon-spawner.test.ts`, `daemon-server.test.ts`, `daemon-pty-adapter.test.ts`, `daemon-health.test.ts`.
+
+### Unit tests — `daemon-init.test.ts` (new)
+
+`processLegacyVersion` behaviors:
+
+- **Idle legacy daemon** — `listSessions` returns `[]`. Assert `cleanupDaemonForProtocol` called once, no adapter returned.
+- **Live legacy daemon** — `listSessions` returns 2 alive sessions. Assert adapter returned, `cleanupDaemonForProtocol` not called.
+- **Wedged daemon** — probe socket alive, `ensureConnected` rejects. Assert `cleanupDaemonForProtocol` called (falls back to PID kill path internally).
+- **Wedged daemon** — probe succeeds, `listSessions` rejects. Same as above.
+- **No legacy socket** — `probeSocket` returns false. Assert no client opened, no cleanup, no adapter.
+- **Probe client disconnected even on throw** — use a spy on `DaemonClient.disconnect` in the `finally` branch.
+- **Killswitch** — with `ORCA_DISABLE_LEGACY_CLEANUP=1`, assert startup does not call `createLegacyDaemonAdapters`, does not construct `DaemonPtyRouter`, and uses `newAdapter` directly.
+
+`createLegacyDaemonAdapters` aggregation:
+
+- **Parallel execution** — inject delays on each per-version probe, assert total elapsed < sum of delays + slack. Guards against silent `for...await` regression.
+- **Mixed outcome** — v1 idle, v2 live, v3 missing. Assert exactly one adapter returned (v2) and exactly one cleanup called (v1).
+
+### Unit tests — `daemon-pty-router.test.ts` (new)
+
+Drain hook behaviors:
+
+- **Single legacy, single session** — fire `onExit`. Assert `onLegacyDrained` fires exactly once; adapter removed from `this.legacy`.
+- **Single legacy, multiple sessions** — 3 sessions. Fire exits for 2 of them. Assert `onLegacyDrained` not yet fired. Fire the third. Assert fires exactly once.
+- **Two legacies, drain one** — v1 has 1 session, v2 has 1 session. Fire v1's exit. Assert `onLegacyDrained` fires with v1 adapter only; v2 still in `this.legacy`.
+- **Current adapter exits never fire drain** — fire `onExit` on the current adapter. Assert `onLegacyDrained` never called.
+- **Post-drain routing** — after drain, call `spawn({ sessionId: <from-drained-adapter> })`. Assert routes to `current` (via `adapterFor` fallback at `daemon-pty-router.ts:190-192`), not to the drained adapter.
+- **Post-drain `listProcesses`** — assert the drained adapter is not queried (removed from `allAdapters()` iteration). Prevents spurious errors from a dead socket.
+- **Re-entrancy guard** — synthesize a double-exit event for the same session id. Assert `onLegacyDrained` fires at most once.
+- **Post-discovery sweep** — have `discoverLegacySessions` find no sessions for a wrapped legacy adapter. Assert `sweepDrainedLegacyAdapters()` removes that adapter and invokes `onLegacyDrained` exactly once.
+
+### Unit tests — `daemon-health.test.ts`
+
+- **Pid file backward compatibility** — assert `killStaleDaemon` accepts both `{ "pid": 123, "startedAtMs": 456 }` and legacy `123` pid-file contents. For the legacy form, assert start-time validation is skipped and the existing command-line `isDaemonProcess` validation remains required.
+
+### Regression guards
+
+- `createLegacyDaemonAdapters` never calls `cleanupDaemonForProtocol(runtimeDir, PROTOCOL_VERSION)`. Loop bound is `PREVIOUS_DAEMON_PROTOCOL_VERSIONS` (compile-time). Add a runtime assertion test: spy on `cleanupDaemonForProtocol`, run the full startup path, assert no call was made with the current version.
+- `types.ts` invariant — `PREVIOUS_DAEMON_PROTOCOL_VERSIONS` must not contain `PROTOCOL_VERSION`. Add a trivial test asserting this. Catches the "forgot to remove v4 when shipping v5" mistake.
+- `daemon-spawner.test.ts` unchanged — socket path scheme is untouched.
+- `daemon-server.test.ts` unchanged — wire protocol is untouched.
+- `daemon-entry.ts` unchanged — no new signal handlers, no timer, no idle-exit logic.
+
+### Integration / manual smoke
+
+1. **Fresh install, no legacy** — launch app. Assert startup proceeds normally, no extra log lines, no probe attempts for nonexistent sockets beyond the `probeSocket` short-circuit.
+2. **Orphan idle daemon** — plant a fake v3 daemon using the current `daemon-entry.js` bound to `daemon-v3.sock`, with zero sessions. Launch app. Assert v3 socket gone, v3 pid file gone, fake v3 PID exited. Log line `reason=idle killedSessions=0` emitted.
+3. **Orphan wedged daemon** — plant a fake v3 daemon that accepts connections but never responds to `listSessions`. Launch app. Within `CONNECT_TIMEOUT_MS + REQUEST_TIMEOUT_MS`, assert v3 daemon killed (via SIGKILL fallback). Log line `reason=wedged` emitted.
+4. **Legacy with live session, drain during runtime** — plant fake v3 holding an open `sleep 60`. Launch app. Assert v3 wrapped (log line `wrapped for drain: liveSessions=1`). Wait for `sleep` to exit. Assert `onLegacyDrained` fires, v3 daemon terminates, log line `reason=drain killedSessions=0` emitted (0 because the session was already exiting when shutdown ran).
+5. **Legacy with live session, app quit before drain** — plant fake v3 with `sleep 600`. Launch app. Quit Orca (Cmd+Q). Assert v3 still running (drain did not fire; `disconnectDaemon` doesn't kill legacies — intentional). Relaunch Orca. Assert v3 still wrapped. Kill the `sleep` externally. Assert drain fires on this new app session.
+
+## Rollout
+
+- **Killswitch env var — `ORCA_DISABLE_LEGACY_CLEANUP=1`.** At the top of `initDaemonPtyProvider`, short-circuit `createLegacyDaemonAdapters` to return `[]` when this env var is set. No-op design that skips Tier 1 and Tier 2 entirely. Gives ops a one-variable remediation lever if a weird user environment triggers the swallow-catch path (node-pty ABI drift, fork with non-standard `destroy()` semantics, etc.) without requiring a hotfix build. Document in the README's troubleshooting section.
+- **No feature flag beyond the killswitch.** The code path only runs against sockets already matched to `PREVIOUS_DAEMON_PROTOCOL_VERSIONS`. Blast radius is bounded to legacy versions by construction.
+- **One-time cleanup burst on first launch after release.** Users upgrading from a version without this fix will see their accumulated orphans (v2/v3) cleaned up the first time they launch the new Orca. Expected.
+- **Protocol version bump not required.** No wire protocol changes. Current daemon behavior is unchanged.
+- **Telemetry for verification.** Watch `daemon_legacy_cleanup` events for the week after release. Expected: initial burst of `reason=idle` events as the backlog drains, then a trickle of `reason=drain` events as users upgrade with live sessions and those sessions eventually exit.
+- **Recommended release ordering with [fix-pty-fd-leak.md](./fix-pty-fd-leak.md).** Land the fd-leak fix first. Reasons: (a) it has the broader test-surface change (six mocks need `dispose`); surfacing issues first is easier to isolate. (b) Shipping this orphan-daemon fix first cleans up v1-v3 corpses but leaves live v4 still leaking per-session. Landing fd-leak first means every new v4 session is clean; this PR then sweeps the graveyard. (c) Both PRs are independent at the code level (no file overlap).
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Tier 1 kills a legacy daemon while a session is mid-startup (probe says 0 live but a new session is being spawned concurrently). | Cannot happen: legacy daemons are from a previous Orca app that has already quit. Nothing in the new app spawns sessions on any legacy daemon — `daemon-pty-router.ts:46-52` only routes by already-registered `sessionId`, and no sessions can be registered until after `createLegacyDaemonAdapters` completes. |
+| Tier 2 drain fires while a session exit is still being processed, races with in-flight RPC to that daemon. | `onExit` is emitted by the adapter only after the session is gone. Drain callback calls `adapter.dispose()` before `cleanupDaemonForProtocol`, flushing client state. Legacy adapters have `respawn: undefined` (`daemon-init.ts:335-342`) so no auto-reconnect races with shutdown. |
+| `listSessions` on a v1 daemon behaves differently than v4. | `cleanupDaemonForProtocol` already works across all versions today — that's its entire design (`daemon-init.ts:242`, accepts `protocolVersion` arg). We're reusing that proven path. `listSessions` has been stable since v1 (it's one of the first RPCs defined — see `daemon-server.ts` handlers). |
+| Probe RPC hangs indefinitely on a wedged daemon, blocking startup. | `DaemonClient` enforces `CONNECT_TIMEOUT_MS=5000` and `REQUEST_TIMEOUT_MS=30000` (`client.ts:8-9`). Worst case per version: ~35s for the probe; if the cleanup path also hangs on the same wedged daemon, the combined worst case per version is ~100s. Parallel across versions caps total at that per-version figure. |
+| Startup latency regression from parallel cleanup. | Benchmark before merge: time from `app.on('ready')` to first IPC on a machine with 3 planted legacy daemons. Target: < 2s additional latency vs baseline in the happy path (daemons present and responsive). Document expected worst-case of 35s when all three are wedged. |
+| Legacy adapter's `DaemonClient` disconnect races with the `shutdown` RPC inside `cleanupDaemonForProtocol`. | `cleanupDaemonForProtocol` creates its own client (`daemon-init.ts:269`). The probe client opened in `processLegacyVersion` is disconnected in `finally` before cleanup runs. No shared connection. |
+| Future protocol bump to v5 accidentally leaves v4 missing from `PREVIOUS_DAEMON_PROTOCOL_VERSIONS`. | Unit test in `types.test.ts` (add if not present): asserts `PREVIOUS_DAEMON_PROTOCOL_VERSIONS` contains every integer from 1 to `PROTOCOL_VERSION - 1`. Forces discipline at version-bump time. |
+| Two Orca processes racing on the same legacy socket during a user-initiated reinstall. | The app already has a single-instance lock (Electron's `requestSingleInstanceLock`). Legacy cleanup inherits that lock's exclusivity — not additive risk. |
+| User force-quits Orca mid-drain, leaving a legacy daemon still running. | Acceptable. Tier 1 catches it on next launch. `disconnectDaemon()` on quit intentionally does not kill legacies (see `daemon-init.ts:215-218`). |
+
+## Regression-guard checklist
+
+Before merge, confirm each of the following has not changed behaviorally:
+
+- [ ] `getDaemonSocketPath(runtimeDir, PROTOCOL_VERSION)` returns the same path format.
+- [ ] `initDaemonPtyProvider` spawns current daemon first (via `newSpawner.ensureRunning()` at line 177 before `createLegacyDaemonAdapters` at line 194).
+- [ ] Legacy sessions that survive Tier 1 still support `attach`, `write`, `resize`, `shutdown`, `sendSignal`, and emit `onData`/`onExit`.
+- [ ] No change to `daemon-entry.ts`, `daemon-server.ts`, or any wire-protocol type. Greppable invariant: `daemon-entry.ts` contains no `setInterval`, no `setTimeout` outside existing error paths, no new signal handlers.
+- [ ] `disconnectDaemon()` on app quit behaves identically — legacy adapters still receive `disconnectOnly` and stay alive across restart.
+- [ ] `shutdownDaemon()` (full teardown path) unchanged.
+- [ ] `DaemonPtyRouter.allAdapters()` (current + legacy) is iterated by `listProcesses`, `dispose`, `disconnectOnly`, and any other multi-adapter operation. Drained legacy adapters must be removed from `this.legacy` so these iterations do not hit a disposed adapter.
+- [ ] `sessionAdapters` map cleanup on `onExit` happens **before** the drain check (order matters — `hasActiveSessionsOn` must not include the session that just exited).
+- [ ] Current-daemon `onExit` never triggers `onLegacyDrained`. Router's `this.legacy.includes(adapter)` check gates this.
+
+## Files to change
+
+- `src/main/daemon/daemon-init.ts` — extract `processLegacyVersion`, rewrite `createLegacyDaemonAdapters` to use `Promise.all`, wire `onLegacyDrained` callback into `DaemonPtyRouter` construction.
+- `src/main/daemon/daemon-pty-router.ts` — add `onLegacyDrained` option, `hasActiveSessionsOn` helper, remove-from-legacy-on-drain logic.
+- `src/main/daemon/daemon-pty-adapter.ts` — add `public readonly protocolVersion: number` field in constructor.
+- `src/main/daemon/daemon-health.ts` — parse both JSON and legacy integer pid files, revalidate before SIGKILL, and compare process start time when known.
+- `src/main/daemon/daemon-spawner.ts` — write `{ pid, startedAtMs }` pid-file JSON for newly spawned daemons.
+- `src/main/daemon/daemon-init.test.ts` — new file with `processLegacyVersion` and `createLegacyDaemonAdapters` unit tests.
+- `src/main/daemon/daemon-pty-router.test.ts` — new file with drain-hook tests.
+- `src/main/daemon/daemon-health.test.ts` — add pid-file compatibility and SIGKILL revalidation tests.
+- `src/main/daemon/types.test.ts` — trivial invariant tests on `PROTOCOL_VERSION` / `PREVIOUS_DAEMON_PROTOCOL_VERSIONS`.
+
+Explicitly **not** touched: `daemon-entry.ts`, `daemon-server.ts`, `daemon-main.ts`, `terminal-host.ts`, `session.ts`, `client.ts`, `pty-subprocess.ts`, `history-manager.ts`.
+
+## Related work (out of scope for this PR)
+
+Three adjacent bugs share the symptom "ptmx fd pool depletes over time" but are independent in cause and fix. Each should be its own follow-up:
+
+1. **v4 per-session fd leak on terminal dispose** (reported: 269 fds for 13 terminals). Fix location: `terminal-host.ts` / `session.ts` dispose path. Suspected cause: pty subprocess exits but `Session.dispose()` or the surrounding `TerminalHost` entry drops the pty close. Triage priority: **higher than this PR** for users who don't upgrade frequently, since this leak accumulates per-use rather than per-upgrade. Document existence here so reviewers know it's acknowledged.
+
+2. **Worktree deletion does not kill its sessions.** `worktrees:remove` (`src/main/ipc/worktrees.ts:251-308`) removes the directory, git tracking, and history files but leaves daemon-side pty sessions alive with their cwd pointing at a deleted path. Shells typically don't exit on cwd removal, so those sessions persist indefinitely. Each leaked session holds ptmx fds on the current daemon until the daemon itself dies. A power user who regularly deletes worktrees accumulates fds on v4 this way. Fix: enumerate sessions whose `cwd` is under the removed path and kill them as part of `worktrees:remove`.
+
+3. **No daemon-side idle self-exit.** The daemon never exits on its own under any circumstance (`daemon-entry.ts:72-73` — SIGTERM/SIGINT only). If Orca is uninstalled or the user stops launching it, whatever daemon was last running holds its fds until reboot. Event-driven cleanup (this PR) cannot solve this because the trigger requires a future app launch. A structural fix would add a timer-based idle check in the daemon, but timer logic carries risk of false-positive self-exit against live work (cold-restore instead of warm-reattach on next launch). Deferred explicitly; revisit only with a strong conservative timeout (hours, not minutes) and a combined signal (zero sessions AND zero clients AND reparented to init).
+
+These three are noted here so that the PR reviewer and on-call engineer understand the full picture: shipping this PR closes the orphan-daemon leak class but does not eliminate ptmx accumulation entirely.
+
+## Open questions
+
+1. Should drain cleanup emit a toast ("Old Orca background process exited")? Leaning no — invisible infra cleanup is correct. Log only.
+2. Should the `processLegacyVersion` probe skip `ensureConnected` and call `cleanupDaemonForProtocol` unconditionally (relying on its own `listSessions` at line 275-277 to compute `killedCount`)? That would eliminate the separate probe client and halve the RPC count. Tradeoff: `cleanupDaemonForProtocol` kills sessions via `shutdown: { killSessions: true }` (line 283) unconditionally — so doing that on a daemon with live sessions would kill them. We need the pre-probe for the branch. Keep as designed.
+3. Should telemetry be gated behind the stats collector's consent flag? Yes — use the same path as other `stats/collector.ts` events. Not a new privacy surface.

--- a/docs/auto-kill-old-daemons.md
+++ b/docs/auto-kill-old-daemons.md
@@ -411,7 +411,7 @@ Drain hook behaviors:
 
 - `createLegacyDaemonAdapters` never calls `cleanupDaemonForProtocol(runtimeDir, PROTOCOL_VERSION)`. Loop bound is `PREVIOUS_DAEMON_PROTOCOL_VERSIONS` (compile-time). Add a runtime assertion test: spy on `cleanupDaemonForProtocol`, run the full startup path, assert no call was made with the current version.
 - `types.ts` invariant — `PREVIOUS_DAEMON_PROTOCOL_VERSIONS` must not contain `PROTOCOL_VERSION`. Add a trivial test asserting this. Catches the "forgot to remove v4 when shipping v5" mistake.
-- `daemon-spawner.test.ts` unchanged — socket path scheme is untouched.
+- `daemon-spawner.test.ts` keeps the socket-path regression and adds a pid-file serialization assertion.
 - `daemon-server.test.ts` unchanged — wire protocol is untouched.
 - `daemon-entry.ts` unchanged — no new signal handlers, no timer, no idle-exit logic.
 
@@ -469,7 +469,9 @@ Before merge, confirm each of the following has not changed behaviorally:
 - `src/main/daemon/daemon-spawner.ts` — write `{ pid, startedAtMs }` pid-file JSON for newly spawned daemons.
 - `src/main/daemon/daemon-init.test.ts` — new file with `processLegacyVersion` and `createLegacyDaemonAdapters` unit tests.
 - `src/main/daemon/daemon-pty-router.test.ts` — new file with drain-hook tests.
+- `src/main/daemon/daemon-pty-adapter.test.ts` — add coverage for the exposed `protocolVersion` field.
 - `src/main/daemon/daemon-health.test.ts` — add pid-file compatibility and SIGKILL revalidation tests.
+- `src/main/daemon/daemon-spawner.test.ts` — add pid-file serialization coverage.
 - `src/main/daemon/types.test.ts` — trivial invariant tests on `PROTOCOL_VERSION` / `PREVIOUS_DAEMON_PROTOCOL_VERSIONS`.
 
 Explicitly **not** touched: `daemon-entry.ts`, `daemon-server.ts`, `daemon-main.ts`, `terminal-host.ts`, `session.ts`, `client.ts`, `pty-subprocess.ts`, `history-manager.ts`.

--- a/src/main/daemon/daemon-health.test.ts
+++ b/src/main/daemon/daemon-health.test.ts
@@ -1,11 +1,17 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { spawn, type ChildProcess } from 'child_process'
 import { mkdtempSync, rmSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { createServer, connect, type Server } from 'net'
 import { DaemonServer } from './daemon-server'
-import { getDaemonPidPath } from './daemon-spawner'
-import { healthCheckDaemon, killStaleDaemon } from './daemon-health'
+import { getDaemonPidPath, serializeDaemonPidFile } from './daemon-spawner'
+import {
+  getProcessStartedAtMs,
+  healthCheckDaemon,
+  killStaleDaemon,
+  parseDaemonPidFile
+} from './daemon-health'
 import type { SubprocessHandle } from './session'
 
 function createMockSubprocess(): SubprocessHandle {
@@ -50,6 +56,27 @@ function canConnect(socketPath: string): Promise<boolean> {
   })
 }
 
+function waitForExit(child: ChildProcess, timeoutMs = 5_000): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return Promise.resolve()
+  }
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('child did not exit')), timeoutMs)
+    child.once('exit', () => {
+      clearTimeout(timer)
+      resolve()
+    })
+  })
+}
+
+function spawnDaemonLikeProcess(socketPath: string, tokenPath: string): ChildProcess {
+  return spawn(
+    process.execPath,
+    ['-e', 'setInterval(() => {}, 1000)', 'daemon-entry', socketPath, tokenPath],
+    { stdio: 'ignore' }
+  )
+}
+
 describe('daemon health', () => {
   let dir: string
   let socketPath: string
@@ -63,6 +90,15 @@ describe('daemon health', () => {
 
   afterEach(() => {
     rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('parses JSON and legacy pid files', () => {
+    expect(parseDaemonPidFile('{"pid":123,"startedAtMs":456}')).toEqual({
+      pid: 123,
+      startedAtMs: 456
+    })
+    expect(parseDaemonPidFile('123')).toEqual({ pid: 123, startedAtMs: null })
+    expect(parseDaemonPidFile('not-json')).toBeNull()
   })
 
   it('passes when a daemon answers ping', async () => {
@@ -104,6 +140,41 @@ describe('daemon health', () => {
       await expect(canConnect(socketPath)).resolves.toBe(true)
     } finally {
       await closeServer(server)
+    }
+  })
+
+  it('kills a daemon-like process from a legacy integer pid file', async () => {
+    const child = spawnDaemonLikeProcess(socketPath, tokenPath)
+    expect(child.pid).toBeTypeOf('number')
+    writeFileSync(getDaemonPidPath(dir), String(child.pid), { mode: 0o600 })
+
+    try {
+      await expect(killStaleDaemon(dir, socketPath, tokenPath)).resolves.toBe(true)
+      await expect(waitForExit(child)).resolves.toBeUndefined()
+    } finally {
+      if (!child.killed) {
+        child.kill('SIGKILL')
+      }
+    }
+  })
+
+  it('kills a daemon-like process from a JSON pid file', async () => {
+    const child = spawnDaemonLikeProcess(socketPath, tokenPath)
+    expect(child.pid).toBeTypeOf('number')
+    const pid = child.pid!
+    writeFileSync(
+      getDaemonPidPath(dir),
+      serializeDaemonPidFile({ pid, startedAtMs: getProcessStartedAtMs(pid) }),
+      { mode: 0o600 }
+    )
+
+    try {
+      await expect(killStaleDaemon(dir, socketPath, tokenPath)).resolves.toBe(true)
+      await expect(waitForExit(child)).resolves.toBeUndefined()
+    } finally {
+      if (!child.killed) {
+        child.kill('SIGKILL')
+      }
     }
   })
 })

--- a/src/main/daemon/daemon-health.ts
+++ b/src/main/daemon/daemon-health.ts
@@ -1,3 +1,5 @@
+/* oxlint-disable max-lines -- Why: pid validation shares process-identity
+helpers with kill escalation so the SIGKILL safety checks stay co-located. */
 import { execFileSync } from 'child_process'
 import { existsSync, readFileSync, unlinkSync } from 'fs'
 import { connect, type Socket } from 'net'
@@ -8,6 +10,12 @@ import { PROTOCOL_VERSION, type HelloMessage, type HelloResponse } from './types
 const HEALTH_CHECK_TIMEOUT_MS = 3_000
 const KILL_WAIT_MS = 3_000
 const KILL_POLL_MS = 100
+const START_TIME_TOLERANCE_MS = 1_500
+
+type ParsedDaemonPid = {
+  pid: number
+  startedAtMs: number | null
+}
 
 function canConnectSocket(socketPath: string): Promise<boolean> {
   return new Promise((resolve) => {
@@ -128,7 +136,94 @@ function commandLineMatchesDaemon(
   )
 }
 
-function isDaemonProcess(pid: number, socketPath: string, tokenPath: string): boolean {
+export function parseDaemonPidFile(contents: string): ParsedDaemonPid | null {
+  const trimmed = contents.trim()
+  try {
+    const parsed = JSON.parse(trimmed) as { pid?: unknown; startedAtMs?: unknown }
+    if (typeof parsed.pid === 'number' && Number.isFinite(parsed.pid)) {
+      return {
+        pid: parsed.pid,
+        startedAtMs:
+          typeof parsed.startedAtMs === 'number' && Number.isFinite(parsed.startedAtMs)
+            ? parsed.startedAtMs
+            : null
+      }
+    }
+  } catch {
+    // Legacy daemons wrote the pid file as a bare integer.
+  }
+
+  const pid = Number(trimmed)
+  return Number.isFinite(pid) ? { pid, startedAtMs: null } : null
+}
+
+function getLinuxProcessStartedAtMs(pid: number): number | null {
+  try {
+    const stat = readFileSync(`/proc/${pid}/stat`, 'utf8')
+    const afterCommand = stat.slice(stat.lastIndexOf(')') + 2)
+    const fields = afterCommand.split(' ')
+    const startTicks = Number(fields[19])
+    const bootTimeLine = readFileSync('/proc/stat', 'utf8')
+      .split('\n')
+      .find((line) => line.startsWith('btime '))
+    const bootTimeSeconds = bootTimeLine ? Number(bootTimeLine.split(/\s+/)[1]) : Number.NaN
+    const ticksPerSecond = Number(
+      execFileSync('getconf', ['CLK_TCK'], { encoding: 'utf8', timeout: 1_000 }).trim()
+    )
+    if (
+      !Number.isFinite(startTicks) ||
+      !Number.isFinite(bootTimeSeconds) ||
+      !Number.isFinite(ticksPerSecond) ||
+      ticksPerSecond <= 0
+    ) {
+      return null
+    }
+    return bootTimeSeconds * 1000 + (startTicks / ticksPerSecond) * 1000
+  } catch {
+    return null
+  }
+}
+
+export function getProcessStartedAtMs(pid: number): number | null {
+  if (process.platform === 'linux') {
+    return getLinuxProcessStartedAtMs(pid)
+  }
+
+  if (process.platform === 'win32') {
+    return null
+  }
+
+  try {
+    const output = execFileSync('ps', ['-p', String(pid), '-o', 'lstart='], {
+      encoding: 'utf8',
+      timeout: 2_000
+    }).trim()
+    const startedAtMs = Date.parse(output)
+    return Number.isFinite(startedAtMs) ? startedAtMs : null
+  } catch {
+    return null
+  }
+}
+
+function startTimeMatches(pid: number, expectedStartedAtMs: number | null): boolean {
+  if (expectedStartedAtMs === null) {
+    return true
+  }
+
+  const actualStartedAtMs = getProcessStartedAtMs(pid)
+  if (actualStartedAtMs === null) {
+    return true
+  }
+
+  return Math.abs(actualStartedAtMs - expectedStartedAtMs) <= START_TIME_TOLERANCE_MS
+}
+
+function isDaemonProcess(
+  pid: number,
+  socketPath: string,
+  tokenPath: string,
+  startedAtMs: number | null
+): boolean {
   try {
     process.kill(pid, 0)
   } catch {
@@ -153,7 +248,10 @@ function isDaemonProcess(pid: number, socketPath: string, tokenPath: string): bo
       // Why: image names are too broad after PID reuse. Match the daemon entry
       // plus the exact socket/token args so we only kill the daemon for this
       // userData protocol endpoint.
-      return commandLineMatchesDaemon(output, socketPath, tokenPath)
+      return (
+        commandLineMatchesDaemon(output, socketPath, tokenPath) &&
+        startTimeMatches(pid, startedAtMs)
+      )
     } catch {
       return false
     }
@@ -161,14 +259,19 @@ function isDaemonProcess(pid: number, socketPath: string, tokenPath: string): bo
 
   try {
     const cmdline = readFileSync(`/proc/${pid}/cmdline`, 'utf8')
-    return commandLineMatchesDaemon(cmdline, socketPath, tokenPath)
+    return (
+      commandLineMatchesDaemon(cmdline, socketPath, tokenPath) && startTimeMatches(pid, startedAtMs)
+    )
   } catch {
     try {
       const output = execFileSync('ps', ['-p', String(pid), '-o', 'command='], {
         encoding: 'utf8',
         timeout: 2_000
       })
-      return commandLineMatchesDaemon(output, socketPath, tokenPath)
+      return (
+        commandLineMatchesDaemon(output, socketPath, tokenPath) &&
+        startTimeMatches(pid, startedAtMs)
+      )
     } catch {
       return false
     }
@@ -184,8 +287,9 @@ export async function killStaleDaemon(
   const pidPath = getDaemonPidPath(runtimeDir, protocolVersion)
   let killedDaemon = false
   try {
-    const pid = Number.parseInt(readFileSync(pidPath, 'utf8').trim(), 10)
-    if (Number.isFinite(pid) && isDaemonProcess(pid, socketPath, tokenPath)) {
+    const parsedPid = parseDaemonPidFile(readFileSync(pidPath, 'utf8'))
+    if (parsedPid && isDaemonProcess(parsedPid.pid, socketPath, tokenPath, parsedPid.startedAtMs)) {
+      const { pid, startedAtMs } = parsedPid
       process.kill(pid, 'SIGTERM')
       const deadline = Date.now() + KILL_WAIT_MS
       let exited = false
@@ -199,14 +303,22 @@ export async function killStaleDaemon(
         await new Promise((resolve) => setTimeout(resolve, KILL_POLL_MS))
       }
       if (!exited) {
-        try {
-          process.kill(pid, 'SIGKILL')
+        if (!isDaemonProcess(pid, socketPath, tokenPath, startedAtMs)) {
+          console.warn('[daemon] Skipping SIGKILL for stale daemon: reason=pid_recycled')
           exited = true
-        } catch {
-          // Already dead
+          killedDaemon = true
+        } else {
+          try {
+            process.kill(pid, 'SIGKILL')
+            exited = true
+          } catch {
+            // Already dead
+          }
         }
       }
-      killedDaemon = exited
+      if (!killedDaemon) {
+        killedDaemon = exited
+      }
     }
   } catch {
     // PID file missing or process already dead

--- a/src/main/daemon/daemon-init.test.ts
+++ b/src/main/daemon/daemon-init.test.ts
@@ -1,0 +1,206 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createServer, type Server } from 'net'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { getDaemonSocketPath } from './daemon-spawner'
+import { PREVIOUS_DAEMON_PROTOCOL_VERSIONS } from './types'
+
+type ClientPlan = {
+  ensureReject?: boolean
+  requestReject?: boolean
+  sessions?: { sessionId: string; isAlive: boolean }[]
+  delayMs?: number
+}
+
+const mocks = vi.hoisted(() => ({
+  killStaleDaemon: vi.fn(async () => true),
+  setLocalPtyProvider: vi.fn(),
+  clientPlans: [] as ClientPlan[],
+  clientInstances: [] as MockDaemonClient[]
+}))
+
+class MockDaemonClient {
+  plan: ClientPlan
+  ensureConnected = vi.fn(async () => {
+    if (this.plan.delayMs) {
+      await new Promise((resolve) => setTimeout(resolve, this.plan.delayMs))
+    }
+    if (this.plan.ensureReject) {
+      throw new Error('connect failed')
+    }
+  })
+  request = vi.fn(async (method: string) => {
+    if (this.plan.requestReject) {
+      throw new Error('request failed')
+    }
+    if (method === 'listSessions') {
+      return { sessions: this.plan.sessions ?? [] }
+    }
+    return {}
+  })
+  disconnect = vi.fn()
+
+  constructor() {
+    this.plan = mocks.clientPlans.shift() ?? {}
+    mocks.clientInstances.push(this)
+  }
+}
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn(() => mkdtempSync(join(tmpdir(), 'daemon-init-app-test-'))),
+    getAppPath: vi.fn(() => '/app'),
+    isPackaged: false
+  }
+}))
+
+vi.mock('../ipc/pty', () => ({
+  setLocalPtyProvider: mocks.setLocalPtyProvider
+}))
+
+vi.mock('./client', () => ({
+  DaemonClient: MockDaemonClient
+}))
+
+vi.mock('./daemon-health', () => ({
+  getProcessStartedAtMs: vi.fn(() => 1),
+  healthCheckDaemon: vi.fn(async () => false),
+  killStaleDaemon: mocks.killStaleDaemon
+}))
+
+function listen(socketPath: string): Promise<Server> {
+  const server = createServer((socket) => socket.end())
+  return new Promise((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(socketPath, () => {
+      server.off('error', reject)
+      resolve(server)
+    })
+  })
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve) => server.close(() => resolve()))
+}
+
+describe('daemon init legacy cleanup', () => {
+  let dir: string
+  let servers: Server[]
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'daemon-init-test-'))
+    servers = []
+    mocks.clientPlans.length = 0
+    mocks.clientInstances.length = 0
+    mocks.killStaleDaemon.mockClear()
+    mocks.setLocalPtyProvider.mockClear()
+  })
+
+  afterEach(async () => {
+    await Promise.all(servers.map((server) => closeServer(server).catch(() => {})))
+    rmSync(dir, { recursive: true, force: true })
+    delete process.env.ORCA_DISABLE_LEGACY_CLEANUP
+  })
+
+  async function openLegacySocket(protocolVersion: number): Promise<void> {
+    servers.push(await listen(getDaemonSocketPath(dir, protocolVersion)))
+  }
+
+  it('cleans up an idle legacy daemon and returns no adapter', async () => {
+    const { processLegacyVersion } = await import('./daemon-init')
+    await openLegacySocket(1)
+    mocks.clientPlans.push({ sessions: [] }, { sessions: [] })
+
+    await expect(processLegacyVersion(dir, 1)).resolves.toBeNull()
+
+    expect(mocks.clientInstances).toHaveLength(2)
+    expect(mocks.clientInstances[1].request).toHaveBeenCalledWith('shutdown', {
+      killSessions: true
+    })
+  })
+
+  it('wraps a live legacy daemon without calling cleanup', async () => {
+    const { processLegacyVersion } = await import('./daemon-init')
+    await openLegacySocket(1)
+    mocks.clientPlans.push({ sessions: [{ sessionId: 'legacy-1', isAlive: true }] })
+
+    const adapter = await processLegacyVersion(dir, 1)
+
+    expect(adapter).not.toBeNull()
+    expect(adapter?.protocolVersion).toBe(1)
+    expect(mocks.clientInstances[0].request).toHaveBeenCalledWith('listSessions', undefined)
+    expect(
+      mocks.clientInstances.some((client) => client.request.mock.calls[0]?.[0] === 'shutdown')
+    ).toBe(false)
+  })
+
+  it('falls back to stale pid cleanup for a wedged legacy daemon', async () => {
+    const { processLegacyVersion } = await import('./daemon-init')
+    await openLegacySocket(1)
+    mocks.clientPlans.push({ ensureReject: true }, { ensureReject: true })
+
+    await expect(processLegacyVersion(dir, 1)).resolves.toBeNull()
+
+    expect(mocks.killStaleDaemon).toHaveBeenCalledWith(
+      dir,
+      getDaemonSocketPath(dir, 1),
+      expect.any(String),
+      1
+    )
+    expect(mocks.clientInstances[0].disconnect).toHaveBeenCalled()
+  })
+
+  it('does not open a client when the legacy socket is missing', async () => {
+    const { processLegacyVersion } = await import('./daemon-init')
+
+    await expect(processLegacyVersion(dir, 1)).resolves.toBeNull()
+
+    expect(mocks.clientInstances).toHaveLength(0)
+    expect(mocks.killStaleDaemon).not.toHaveBeenCalled()
+  })
+
+  it('aggregates mixed legacy cleanup outcomes', async () => {
+    const { createLegacyDaemonAdapters } = await import('./daemon-init')
+    await openLegacySocket(1)
+    await openLegacySocket(2)
+    mocks.clientPlans.push(
+      { sessions: [] },
+      { sessions: [{ sessionId: 'legacy-2', isAlive: true }] },
+      { sessions: [] }
+    )
+
+    const adapters = await createLegacyDaemonAdapters(dir)
+
+    expect(adapters).toHaveLength(1)
+    expect(adapters[0].protocolVersion).toBe(2)
+  })
+
+  it('runs per-version probes in parallel', async () => {
+    const { createLegacyDaemonAdapters } = await import('./daemon-init')
+    for (const version of PREVIOUS_DAEMON_PROTOCOL_VERSIONS) {
+      await openLegacySocket(version)
+      mocks.clientPlans.push({
+        sessions: [{ sessionId: `legacy-${version}`, isAlive: true }],
+        delayMs: 80
+      })
+    }
+
+    const start = Date.now()
+    const adapters = await createLegacyDaemonAdapters(dir)
+
+    expect(adapters).toHaveLength(PREVIOUS_DAEMON_PROTOCOL_VERSIONS.length)
+    expect(Date.now() - start).toBeLessThan(180)
+  })
+
+  it('honors the legacy cleanup killswitch', async () => {
+    const { getLegacyAdaptersForStartup } = await import('./daemon-init')
+    process.env.ORCA_DISABLE_LEGACY_CLEANUP = '1'
+    await openLegacySocket(1)
+    mocks.clientPlans.push({ sessions: [{ sessionId: 'legacy-1', isAlive: true }] })
+
+    await expect(getLegacyAdaptersForStartup(dir)).resolves.toEqual([])
+
+    expect(mocks.clientInstances).toHaveLength(0)
+  })
+})

--- a/src/main/daemon/daemon-init.ts
+++ b/src/main/daemon/daemon-init.ts
@@ -1,3 +1,6 @@
+/* oxlint-disable max-lines -- Why: legacy cleanup adds startup-only cleanup
+paths beside existing daemon lifecycle code; splitting would force tests to
+export more lifecycle internals across files. */
 import { join } from 'path'
 import { app } from 'electron'
 import { mkdirSync, existsSync, unlinkSync, writeFileSync } from 'fs'
@@ -8,6 +11,7 @@ import {
   getDaemonPidPath,
   getDaemonSocketPath,
   getDaemonTokenPath,
+  serializeDaemonPidFile,
   type DaemonLauncher
 } from './daemon-spawner'
 import { DaemonPtyAdapter } from './daemon-pty-adapter'
@@ -18,7 +22,7 @@ import {
   PROTOCOL_VERSION,
   type ListSessionsResult
 } from './types'
-import { healthCheckDaemon, killStaleDaemon } from './daemon-health'
+import { getProcessStartedAtMs, healthCheckDaemon, killStaleDaemon } from './daemon-health'
 import { setLocalPtyProvider } from '../ipc/pty'
 
 let spawner: DaemonSpawner | null = null
@@ -130,7 +134,14 @@ function createOutOfProcessLauncher(runtimeDir: string): DaemonLauncher {
         if (msg && typeof msg === 'object' && (msg as { type?: string }).type === 'ready') {
           clearTimeout(timer)
           if (child.pid) {
-            writeFileSync(getDaemonPidPath(runtimeDir), String(child.pid), { mode: 0o600 })
+            writeFileSync(
+              getDaemonPidPath(runtimeDir),
+              serializeDaemonPidFile({
+                pid: child.pid,
+                startedAtMs: getProcessStartedAtMs(child.pid)
+              }),
+              { mode: 0o600 }
+            )
           }
           // Why: disconnect IPC channel and unref so Electron can exit
           // without waiting for the daemon. The daemon keeps running.
@@ -191,16 +202,30 @@ export async function initDaemonPtyProvider(): Promise<void> {
     }
   })
 
-  const legacyAdapters = await createLegacyDaemonAdapters(runtimeDir)
-  const routedAdapter =
-    legacyAdapters.length > 0
-      ? new DaemonPtyRouter({
-          current: newAdapter,
-          legacy: legacyAdapters
-        })
-      : newAdapter
-  if (routedAdapter instanceof DaemonPtyRouter) {
+  const legacyAdapters = await getLegacyAdaptersForStartup(runtimeDir)
+  let routedAdapter: DaemonPtyAdapter | DaemonPtyRouter = newAdapter
+  if (legacyAdapters.length > 0) {
+    routedAdapter = new DaemonPtyRouter({
+      current: newAdapter,
+      legacy: legacyAdapters,
+      onLegacyDrained: async (drainedAdapter) => {
+        try {
+          drainedAdapter.dispose()
+          const result = await cleanupDaemonForProtocol(runtimeDir, drainedAdapter.protocolVersion)
+          console.log(
+            `[daemon] legacy v${drainedAdapter.protocolVersion} cleanup: reason=drain ` +
+              `killedSessions=${result.killedCount}`
+          )
+        } catch (err) {
+          console.warn(
+            `[daemon] legacy v${drainedAdapter.protocolVersion} drain cleanup failed:`,
+            err
+          )
+        }
+      }
+    })
     await routedAdapter.discoverLegacySessions()
+    routedAdapter.sweepDrainedLegacyAdapters()
   }
 
   spawner = newSpawner
@@ -239,7 +264,7 @@ export type OrphanedDaemonCleanupResult = {
   killedCount: number
 }
 
-async function cleanupDaemonForProtocol(
+export async function cleanupDaemonForProtocol(
   runtimeDir: string,
   protocolVersion: number
 ): Promise<OrphanedDaemonCleanupResult> {
@@ -313,33 +338,69 @@ async function cleanupDaemonForProtocol(
   return { cleaned: didRequestShutdown || didKillStaleDaemon, killedCount }
 }
 
-async function createLegacyDaemonAdapters(runtimeDir: string): Promise<DaemonPtyAdapter[]> {
-  const adapters: DaemonPtyAdapter[] = []
-  for (const protocolVersion of PREVIOUS_DAEMON_PROTOCOL_VERSIONS) {
-    const socketPath = getDaemonSocketPath(runtimeDir, protocolVersion)
-    const tokenPath = getDaemonTokenPath(runtimeDir, protocolVersion)
-    if (!(await probeSocket(socketPath))) {
-      continue
-    }
-    // Why: old daemon PTYs can be running long-lived agents during an app
-    // upgrade. Keep those sessions routed to their original daemon while new
-    // terminals use the current protocol, instead of killing background work.
-    // Legacy adapters intentionally do not respawn: respawning an old protocol
-    // daemon from new code would recreate stale env semantics and can be less
-    // predictable than letting the session fail if that old daemon dies.
-    // Why historyPath is still passed: checkpoint writes will fail silently
-    // (pre-v4 daemons don't support getSnapshot), but the HistoryManager is
-    // still needed for cleanup — close/exit events must remove history dirs
-    // and mark meta.json as ended. Without it, a later v4 session reusing
-    // the same ID could false-restore stale scrollback.bin.
-    adapters.push(
-      new DaemonPtyAdapter({
-        socketPath,
-        tokenPath,
-        protocolVersion,
-        historyPath: getHistoryDir()
-      })
-    )
+export async function getLegacyAdaptersForStartup(runtimeDir: string): Promise<DaemonPtyAdapter[]> {
+  if (process.env.ORCA_DISABLE_LEGACY_CLEANUP === '1') {
+    return []
   }
-  return adapters
+  return createLegacyDaemonAdapters(runtimeDir)
+}
+
+export async function createLegacyDaemonAdapters(runtimeDir: string): Promise<DaemonPtyAdapter[]> {
+  const results = await Promise.all(
+    PREVIOUS_DAEMON_PROTOCOL_VERSIONS.map((protocolVersion) =>
+      processLegacyVersion(runtimeDir, protocolVersion)
+    )
+  )
+  return results.filter((adapter): adapter is DaemonPtyAdapter => adapter !== null)
+}
+
+export async function processLegacyVersion(
+  runtimeDir: string,
+  protocolVersion: number
+): Promise<DaemonPtyAdapter | null> {
+  const socketPath = getDaemonSocketPath(runtimeDir, protocolVersion)
+  const tokenPath = getDaemonTokenPath(runtimeDir, protocolVersion)
+  if (!(await probeSocket(socketPath))) {
+    return null
+  }
+
+  let liveCount = 0
+  let wedged = false
+  const probeClient = new DaemonClient({ socketPath, tokenPath, protocolVersion })
+  try {
+    await probeClient.ensureConnected()
+    const { sessions } = await probeClient.request<ListSessionsResult>('listSessions', undefined)
+    liveCount = sessions.filter((session) => session.isAlive).length
+  } catch {
+    // Why: if an old daemon has a live socket but cannot answer RPC, no new
+    // client can safely reattach to its sessions; reclaim the wedged process.
+    wedged = true
+  } finally {
+    probeClient.disconnect()
+  }
+
+  if (liveCount === 0) {
+    const reason = wedged ? 'wedged' : 'idle'
+    try {
+      const result = await cleanupDaemonForProtocol(runtimeDir, protocolVersion)
+      console.log(
+        `[daemon] legacy v${protocolVersion} cleanup: reason=${reason} ` +
+          `killedSessions=${result.killedCount}`
+      )
+    } catch (err) {
+      console.warn(`[daemon] legacy v${protocolVersion} cleanup failed:`, err)
+    }
+    return null
+  }
+
+  // Why: old daemon PTYs can be running long-lived agents during an app
+  // upgrade. Keep those sessions routed to their original daemon while new
+  // terminals use the current protocol, instead of killing background work.
+  console.log(`[daemon] legacy v${protocolVersion} wrapped for drain: liveSessions=${liveCount}`)
+  return new DaemonPtyAdapter({
+    socketPath,
+    tokenPath,
+    protocolVersion,
+    historyPath: getHistoryDir()
+  })
 }

--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -93,6 +93,13 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
   })
 
   describe('spawn', () => {
+    it('exposes the protocol version used by the daemon client', () => {
+      const legacyAdapter = new DaemonPtyAdapter({ socketPath, tokenPath, protocolVersion: 3 })
+
+      expect(legacyAdapter.protocolVersion).toBe(3)
+      legacyAdapter.dispose()
+    })
+
     it('returns a result with an id', async () => {
       const result = await adapter.spawn({ cols: 80, rows: 24 })
       expect(result.id).toBeDefined()

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -39,6 +39,7 @@ export class TerminalKilledError extends Error {
 }
 
 export class DaemonPtyAdapter implements IPtyProvider {
+  public readonly protocolVersion: number
   private client: DaemonClient
   private historyManager: HistoryManager | null
   private historyReader: HistoryReader | null
@@ -71,15 +72,16 @@ export class DaemonPtyAdapter implements IPtyProvider {
   private static CHECKPOINT_INTERVAL_MS = 5_000
 
   constructor(opts: DaemonPtyAdapterOptions) {
+    this.protocolVersion = opts.protocolVersion ?? PROTOCOL_VERSION
     this.client = new DaemonClient({
       socketPath: opts.socketPath,
       tokenPath: opts.tokenPath,
-      protocolVersion: opts.protocolVersion
+      protocolVersion: this.protocolVersion
     })
     this.historyManager = opts.historyPath ? new HistoryManager(opts.historyPath) : null
     this.historyReader = opts.historyPath ? new HistoryReader(opts.historyPath) : null
     this.respawnFn = opts.respawn ?? null
-    this.supportsCheckpoints = (opts.protocolVersion ?? PROTOCOL_VERSION) >= 4
+    this.supportsCheckpoints = this.protocolVersion >= 4
   }
 
   getHistoryManager(): HistoryManager | null {

--- a/src/main/daemon/daemon-pty-router.test.ts
+++ b/src/main/daemon/daemon-pty-router.test.ts
@@ -74,6 +74,7 @@ function createAdapter(
     reconcileOnStartup: vi.fn(async () => reconcileResult ?? { alive: sessions, killed: [] }),
     dispose: vi.fn(),
     disconnectOnly: vi.fn(async () => {}),
+    protocolVersion: label === 'current' ? 4 : 3,
     emitData: (id: string, data: string) => {
       for (const listener of dataListeners) {
         listener({ id, data })
@@ -110,7 +111,8 @@ describe('DaemonPtyRouter', () => {
   it('drops a legacy mapping after the routed session exits', async () => {
     const current = createAdapter('current')
     const legacy = createAdapter('legacy', ['legacy-session'])
-    const router = new DaemonPtyRouter({ current, legacy: [legacy] })
+    const onLegacyDrained = vi.fn()
+    const router = new DaemonPtyRouter({ current, legacy: [legacy], onLegacyDrained })
 
     await router.discoverLegacySessions()
 
@@ -118,6 +120,102 @@ describe('DaemonPtyRouter', () => {
     await router.spawn({ sessionId: 'legacy-session', cols: 80, rows: 24 })
 
     expect(current.spawn).toHaveBeenCalledWith({ sessionId: 'legacy-session', cols: 80, rows: 24 })
+    expect(onLegacyDrained).toHaveBeenCalledWith(legacy)
+  })
+
+  it('fires drain only after every session on a legacy adapter exits', async () => {
+    const current = createAdapter('current')
+    const legacy = createAdapter('legacy', ['one', 'two', 'three'])
+    const onLegacyDrained = vi.fn()
+    const router = new DaemonPtyRouter({ current, legacy: [legacy], onLegacyDrained })
+
+    await router.discoverLegacySessions()
+
+    legacy.emitExit('one', 0)
+    legacy.emitExit('two', 0)
+    expect(onLegacyDrained).not.toHaveBeenCalled()
+
+    legacy.emitExit('three', 0)
+    expect(onLegacyDrained).toHaveBeenCalledTimes(1)
+    expect(onLegacyDrained).toHaveBeenCalledWith(legacy)
+  })
+
+  it('drains one legacy adapter without touching another', async () => {
+    const current = createAdapter('current')
+    const legacy1 = createAdapter('legacy-1', ['one'])
+    const legacy2 = createAdapter('legacy-2', ['two'])
+    const onLegacyDrained = vi.fn()
+    const router = new DaemonPtyRouter({
+      current,
+      legacy: [legacy1, legacy2],
+      onLegacyDrained
+    })
+
+    await router.discoverLegacySessions()
+
+    legacy1.emitExit('one', 0)
+    router.write('two', 'still-live\n')
+
+    expect(onLegacyDrained).toHaveBeenCalledTimes(1)
+    expect(onLegacyDrained).toHaveBeenCalledWith(legacy1)
+    expect(legacy2.write).toHaveBeenCalledWith('two', 'still-live\n')
+  })
+
+  it('does not fire drain for current adapter exits', async () => {
+    const current = createAdapter('current')
+    const legacy = createAdapter('legacy', ['legacy-session'])
+    const onLegacyDrained = vi.fn()
+    const router = new DaemonPtyRouter({ current, legacy: [legacy], onLegacyDrained })
+
+    const currentSession = await router.spawn({ cols: 80, rows: 24 })
+    current.emitExit(currentSession.id, 0)
+
+    expect(onLegacyDrained).not.toHaveBeenCalled()
+  })
+
+  it('does not query drained adapters in listProcesses', async () => {
+    const current = createAdapter('current')
+    const legacy = createAdapter('legacy', ['legacy-session'])
+    const router = new DaemonPtyRouter({
+      current,
+      legacy: [legacy],
+      onLegacyDrained: vi.fn()
+    })
+
+    await router.discoverLegacySessions()
+    legacy.emitExit('legacy-session', 0)
+    vi.mocked(legacy.listProcesses).mockClear()
+
+    await router.listProcesses()
+
+    expect(legacy.listProcesses).not.toHaveBeenCalled()
+  })
+
+  it('guards against double drain events for the same adapter', async () => {
+    const current = createAdapter('current')
+    const legacy = createAdapter('legacy', ['legacy-session'])
+    const onLegacyDrained = vi.fn()
+    const router = new DaemonPtyRouter({ current, legacy: [legacy], onLegacyDrained })
+
+    await router.discoverLegacySessions()
+
+    legacy.emitExit('legacy-session', 0)
+    legacy.emitExit('legacy-session', 0)
+
+    expect(onLegacyDrained).toHaveBeenCalledTimes(1)
+  })
+
+  it('sweeps adapters that drain before discovery registers sessions', async () => {
+    const current = createAdapter('current')
+    const legacy = createAdapter('legacy')
+    const onLegacyDrained = vi.fn()
+    const router = new DaemonPtyRouter({ current, legacy: [legacy], onLegacyDrained })
+
+    await router.discoverLegacySessions()
+    router.sweepDrainedLegacyAdapters()
+
+    expect(onLegacyDrained).toHaveBeenCalledTimes(1)
+    expect(onLegacyDrained).toHaveBeenCalledWith(legacy)
   })
 
   it('merges startup reconciliation and updates route mappings', async () => {

--- a/src/main/daemon/daemon-pty-router.test.ts
+++ b/src/main/daemon/daemon-pty-router.test.ts
@@ -11,7 +11,8 @@ type AdapterMock = DaemonPtyAdapter & {
 function createAdapter(
   label: string,
   sessions: string[] = [],
-  reconcileResult?: { alive: string[]; killed: string[] }
+  reconcileResult?: { alive: string[]; killed: string[] },
+  opts: { listProcessesRejects?: boolean } = {}
 ): AdapterMock {
   const writes: { id: string; data: string }[] = []
   const dataListeners: ((payload: { id: string; data: string }) => void)[] = []
@@ -22,13 +23,16 @@ function createAdapter(
       sessions.push(id)
       return { id }
     }),
-    listProcesses: vi.fn(async () =>
-      sessions.map((id) => ({
+    listProcesses: vi.fn(async () => {
+      if (opts.listProcessesRejects) {
+        throw new Error('discovery failed')
+      }
+      return sessions.map((id) => ({
         id,
         cwd: '',
         title: label
       }))
-    ),
+    }),
     write: vi.fn((id: string, data: string) => {
       writes.push({ id, data })
     }),
@@ -216,6 +220,23 @@ describe('DaemonPtyRouter', () => {
 
     expect(onLegacyDrained).toHaveBeenCalledTimes(1)
     expect(onLegacyDrained).toHaveBeenCalledWith(legacy)
+  })
+
+  it('does not drain an adapter when legacy discovery fails', async () => {
+    const current = createAdapter('current')
+    const legacy = createAdapter('legacy', ['legacy-session'], undefined, {
+      listProcessesRejects: true
+    })
+    const onLegacyDrained = vi.fn()
+    const router = new DaemonPtyRouter({ current, legacy: [legacy], onLegacyDrained })
+
+    await router.discoverLegacySessions()
+    router.sweepDrainedLegacyAdapters()
+    legacy.emitExit('legacy-session', 0)
+
+    expect(onLegacyDrained).not.toHaveBeenCalled()
+    await router.listProcesses()
+    expect(legacy.listProcesses).toHaveBeenCalledTimes(2)
   })
 
   it('merges startup reconciliation and updates route mappings', async () => {

--- a/src/main/daemon/daemon-pty-router.ts
+++ b/src/main/daemon/daemon-pty-router.ts
@@ -6,6 +6,7 @@ export class DaemonPtyRouter implements IPtyProvider {
   private legacy: DaemonPtyAdapter[]
   private sessionAdapters = new Map<string, DaemonPtyAdapter>()
   private unsubscribersByAdapter = new Map<DaemonPtyAdapter, (() => void)[]>()
+  private discoveryFailedAdapters = new Set<DaemonPtyAdapter>()
   private onLegacyDrained?: (adapter: DaemonPtyAdapter) => void
   private dataListeners: ((payload: { id: string; data: string }) => void)[] = []
   private exitListeners: ((payload: { id: string; code: number }) => void)[] = []
@@ -42,10 +43,12 @@ export class DaemonPtyRouter implements IPtyProvider {
     for (const adapter of this.legacy) {
       try {
         const sessions = await adapter.listProcesses()
+        this.discoveryFailedAdapters.delete(adapter)
         for (const session of sessions) {
           this.sessionAdapters.set(session.id, adapter)
         }
       } catch (error) {
+        this.discoveryFailedAdapters.add(adapter)
         console.warn('[daemon] Failed to discover legacy daemon sessions', error)
       }
     }
@@ -204,10 +207,15 @@ export class DaemonPtyRouter implements IPtyProvider {
   private drainLegacyAdapterIfEmpty(adapter: DaemonPtyAdapter): void {
     // Why: only previous-version adapters are cleaned up here. The current
     // daemon lifecycle must remain byte-identical when its sessions exit.
-    if (!this.legacy.includes(adapter) || this.hasActiveSessionsOn(adapter)) {
+    if (
+      !this.legacy.includes(adapter) ||
+      this.discoveryFailedAdapters.has(adapter) ||
+      this.hasActiveSessionsOn(adapter)
+    ) {
       return
     }
     this.legacy = this.legacy.filter((a) => a !== adapter)
+    this.discoveryFailedAdapters.delete(adapter)
     this.unsubscribeAdapter(adapter)
     this.onLegacyDrained?.(adapter)
   }

--- a/src/main/daemon/daemon-pty-router.ts
+++ b/src/main/daemon/daemon-pty-router.ts
@@ -5,16 +5,22 @@ export class DaemonPtyRouter implements IPtyProvider {
   private current: DaemonPtyAdapter
   private legacy: DaemonPtyAdapter[]
   private sessionAdapters = new Map<string, DaemonPtyAdapter>()
-  private unsubscribers: (() => void)[] = []
+  private unsubscribersByAdapter = new Map<DaemonPtyAdapter, (() => void)[]>()
+  private onLegacyDrained?: (adapter: DaemonPtyAdapter) => void
   private dataListeners: ((payload: { id: string; data: string }) => void)[] = []
   private exitListeners: ((payload: { id: string; code: number }) => void)[] = []
 
-  constructor(opts: { current: DaemonPtyAdapter; legacy: DaemonPtyAdapter[] }) {
+  constructor(opts: {
+    current: DaemonPtyAdapter
+    legacy: DaemonPtyAdapter[]
+    onLegacyDrained?: (adapter: DaemonPtyAdapter) => void
+  }) {
     this.current = opts.current
     this.legacy = opts.legacy
+    this.onLegacyDrained = opts.onLegacyDrained
 
     for (const adapter of this.allAdapters()) {
-      this.unsubscribers.push(
+      const unsubscribers = [
         adapter.onData((payload) => {
           for (const listener of this.dataListeners) {
             listener(payload)
@@ -25,8 +31,10 @@ export class DaemonPtyRouter implements IPtyProvider {
           for (const listener of this.exitListeners) {
             listener(payload)
           }
+          this.drainLegacyAdapterIfEmpty(adapter)
         })
-      )
+      ]
+      this.unsubscribersByAdapter.set(adapter, unsubscribers)
     }
   }
 
@@ -40,6 +48,12 @@ export class DaemonPtyRouter implements IPtyProvider {
       } catch (error) {
         console.warn('[daemon] Failed to discover legacy daemon sessions', error)
       }
+    }
+  }
+
+  sweepDrainedLegacyAdapters(): void {
+    for (const adapter of Array.from(this.legacy)) {
+      this.drainLegacyAdapterIfEmpty(adapter)
     }
   }
 
@@ -172,23 +186,56 @@ export class DaemonPtyRouter implements IPtyProvider {
   }
 
   dispose(): void {
-    for (const unsubscribe of this.unsubscribers.splice(0)) {
-      unsubscribe()
-    }
+    this.unsubscribeAllAdapters()
     for (const adapter of this.allAdapters()) {
       adapter.dispose()
     }
   }
 
   async disconnectOnly(): Promise<void> {
-    for (const unsubscribe of this.unsubscribers.splice(0)) {
-      unsubscribe()
-    }
+    this.unsubscribeAllAdapters()
     await Promise.all([...this.allAdapters()].map((adapter) => adapter.disconnectOnly()))
   }
 
   private adapterFor(sessionId: string): DaemonPtyAdapter {
     return this.sessionAdapters.get(sessionId) ?? this.current
+  }
+
+  private drainLegacyAdapterIfEmpty(adapter: DaemonPtyAdapter): void {
+    // Why: only previous-version adapters are cleaned up here. The current
+    // daemon lifecycle must remain byte-identical when its sessions exit.
+    if (!this.legacy.includes(adapter) || this.hasActiveSessionsOn(adapter)) {
+      return
+    }
+    this.legacy = this.legacy.filter((a) => a !== adapter)
+    this.unsubscribeAdapter(adapter)
+    this.onLegacyDrained?.(adapter)
+  }
+
+  private hasActiveSessionsOn(adapter: DaemonPtyAdapter): boolean {
+    for (const mappedAdapter of this.sessionAdapters.values()) {
+      if (mappedAdapter === adapter) {
+        return true
+      }
+    }
+    return false
+  }
+
+  private unsubscribeAdapter(adapter: DaemonPtyAdapter): void {
+    const unsubscribers = this.unsubscribersByAdapter.get(adapter)
+    if (!unsubscribers) {
+      return
+    }
+    for (const unsubscribe of unsubscribers) {
+      unsubscribe()
+    }
+    this.unsubscribersByAdapter.delete(adapter)
+  }
+
+  private unsubscribeAllAdapters(): void {
+    for (const adapter of Array.from(this.unsubscribersByAdapter.keys())) {
+      this.unsubscribeAdapter(adapter)
+    }
   }
 
   private allAdapters(): DaemonPtyAdapter[] {

--- a/src/main/daemon/daemon-spawner.test.ts
+++ b/src/main/daemon/daemon-spawner.test.ts
@@ -6,7 +6,8 @@ import {
   DaemonSpawner,
   getDaemonPidPath,
   getDaemonSocketPath,
-  getDaemonTokenPath
+  getDaemonTokenPath,
+  serializeDaemonPidFile
 } from './daemon-spawner'
 import { startDaemon, type DaemonHandle } from './daemon-main'
 import { DaemonClient } from './client'
@@ -80,6 +81,13 @@ describe('DaemonSpawner', () => {
       }
       expect(tokenPath).toBe(join(dir, `daemon-v${PROTOCOL_VERSION}.token`))
       expect(pidPath).toBe(join(dir, `daemon-v${PROTOCOL_VERSION}.pid`))
+    })
+
+    it('serializes pid files with process start metadata', () => {
+      expect(JSON.parse(serializeDaemonPidFile({ pid: 123, startedAtMs: 456 }))).toEqual({
+        pid: 123,
+        startedAtMs: 456
+      })
     })
 
     it('starts daemon and returns connection info', async () => {

--- a/src/main/daemon/daemon-spawner.ts
+++ b/src/main/daemon/daemon-spawner.ts
@@ -7,6 +7,11 @@ export type DaemonConnectionInfo = {
   tokenPath: string
 }
 
+export type DaemonPidFile = {
+  pid: number
+  startedAtMs: number | null
+}
+
 export type DaemonProcessHandle = {
   shutdown(): Promise<void>
 }
@@ -79,4 +84,8 @@ export function getDaemonTokenPath(runtimeDir: string, protocolVersion = PROTOCO
 
 export function getDaemonPidPath(runtimeDir: string, protocolVersion = PROTOCOL_VERSION): string {
   return join(runtimeDir, `daemon-v${protocolVersion}.pid`)
+}
+
+export function serializeDaemonPidFile(pidFile: DaemonPidFile): string {
+  return JSON.stringify(pidFile)
 }

--- a/src/main/daemon/types.test.ts
+++ b/src/main/daemon/types.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { PREVIOUS_DAEMON_PROTOCOL_VERSIONS, PROTOCOL_VERSION } from './types'
+
+describe('daemon protocol version invariants', () => {
+  it('does not include the current protocol in previous daemon versions', () => {
+    expect(PREVIOUS_DAEMON_PROTOCOL_VERSIONS).not.toContain(PROTOCOL_VERSION)
+  })
+
+  it('lists every previous protocol version', () => {
+    expect(PREVIOUS_DAEMON_PROTOCOL_VERSIONS).toEqual(
+      Array.from({ length: PROTOCOL_VERSION - 1 }, (_, index) => index + 1)
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- Orca daemons survive Electron quit by design, but previous-protocol daemons were never shut down after upgrades.
- Orphaned legacy daemons can hoard PTY master file descriptors until users hit system-wide PTY allocation failures.
- Legacy daemons with live sessions must remain attached so long-running work survives upgrades.

## Design
Implements the two-tier event-driven cleanup from the design doc: startup cleanup probes only `PREVIOUS_DAEMON_PROTOCOL_VERSIONS` and reclaims idle or wedged legacy daemons, while live legacy daemons stay routed through `DaemonPtyRouter` until their final session exits, at which point the drained daemon is shut down. The current daemon lifecycle stays on the existing path, with an `ORCA_DISABLE_LEGACY_CLEANUP=1` killswitch for the legacy cleanup path.

## Test plan
- [x] `pnpm install`
- [x] `pnpm typecheck`
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/daemon-init.test.ts src/main/daemon/daemon-pty-router.test.ts src/main/daemon/daemon-health.test.ts src/main/daemon/daemon-spawner.test.ts src/main/daemon/daemon-pty-adapter.test.ts src/main/daemon/types.test.ts`
- [x] `env -u ORCA_ORIG_ZDOTDIR pnpm test`
- [x] `pnpm lint`

Design doc: `docs/auto-kill-old-daemons.md`

Made with [Orca](https://github.com/stablyai/orca) 🐋
