### PR TITLE
fix(claude-hook): use forward slashes in Windows managed hook command path

### DIFF
--- a/src/main/claude/hook-service.ts
+++ b/src/main/claude/hook-service.ts
@@ -48,7 +48,15 @@ function getManagedScriptPath(): string {
 }
 
 function getManagedCommand(scriptPath: string): string {
-  return process.platform === 'win32' ? scriptPath : `/bin/sh "${scriptPath}"`
+  // Why: on Windows, Claude Code runs hooks through Git Bash (`/usr/bin/bash`).
+  // A path with single backslashes (e.g. `C:\Users\…\claude-hook.cmd`) is
+  // interpreted by bash as a string with escape sequences, so `\U`, `\A`, etc.
+  // collapse and the launcher fails with `command not found`. Emit forward
+  // slashes — Windows accepts them in path arguments and bash leaves them
+  // intact, so the same JSON value works through every shell layer.
+  return process.platform === 'win32'
+    ? scriptPath.replaceAll('\\', '/')
+    : `/bin/sh "${scriptPath}"`
 }
 
 function getManagedScript(): string {


### PR DESCRIPTION
Fixes #1328.

## Problem

On Windows, Orca writes the Claude Code managed hook command into `~/.claude/settings.json` as a raw path with single backslashes:

```
C:\Users\<user>\AppData\Roaming\orca\agent-hooks\claude-hook.cmd
```

Claude Code invokes hooks through Git Bash (`/usr/bin/bash`), which interprets `\U`, `\A`, etc. as escape sequences and collapses the path to:

```
/usr/bin/bash: line 1: C:UsersleyniAppDataRoamingorcaagent-hooksclaude-hook.cmd: command not found
```

Every Claude Code hook (`UserPromptSubmit`, `Stop`, `PreToolUse`, `PostToolUse`, `PostToolUseFailure`, `PermissionRequest`) fails on Windows. Manually editing the JSON works until Orca's next `install()` overwrites it.

## Fix

Single-line change in `src/main/claude/hook-service.ts::getManagedCommand`: emit forward slashes on Windows. They are accepted when invoking a `.cmd` file and bash leaves them intact, so the same JSON value works through every shell layer.

```ts
return process.platform === 'win32'
  ? scriptPath.replaceAll('\\', '/')
  : `/bin/sh "${scriptPath}"`
```

`createManagedCommandMatcher` in `agent-hooks/installer-utils.ts` already normalizes slashes when sweeping stale entries, so existing installs migrate automatically on the next `install()` call.

## Scope

Intentionally minimal:

- Touches only `src/main/claude/hook-service.ts` (one function, one line of logic + a why-comment).
- Does not change Codex / Cursor / Gemini hook services: they share the same `getManagedCommand` shape, but their runtime invocation paths have not been verified to exhibit the same bash-escape behavior. Keeping them out of scope makes this change safe to ship independently and easy to revert.
- OpenCode is unaffected (it uses `OPENCODE_CONFIG_DIR` + JS plugin, no JSON-stored command).

## Relationship to #1308

Issue #1308 ("Managed hook runtime and PTY spawn env handling drift across layers") describes the same symptom but frames it as part of a broader cross-layer refactor covering PTY env shaping and runtime-state isolation.

This PR is intentionally **narrower and more focused** than #1308: a one-line behavioral fix that unblocks Windows users immediately, with no architectural changes. It does not preempt or block #1308's broader redesign — both can land independently.

## Verification

- Local: edited `getManagedCommand` and confirmed the resulting path no longer collapses through `bash -c`. Existing path matching in `createManagedCommandMatcher` handles backslash-or-forward-slash normalization, so previously-installed entries are detected and swept on the next install.
- Cross-platform: branch on `process.platform === 'win32'` is unchanged for non-Windows; behavior on macOS/Linux is identical.

## Related

- Issue: #1328 (this PR)
- See also: #1308 (broader refactor proposal covering the same symptom)
