### PR TITLE
fix(release): grant actions:write + drop broken auto-merge on tap

### DIFF
--- a/.github/workflows/homebrew-bump.yml
+++ b/.github/workflows/homebrew-bump.yml
@@ -150,6 +150,8 @@ jobs:
             --head "$branch" \
             || gh pr edit "$branch" --title "orca $VERSION"
 
-          # Why: auto-merge so the tap stays hands-free. Tap repo must have
-          # "Allow auto-merge" enabled in settings for this to take effect.
-          gh pr merge "$branch" --squash --auto --delete-branch || true
+          # Why: squash-merge immediately rather than --auto. The tap has no
+          # required checks or branch protection, and `gh pr merge --auto`
+          # only activates when there's something to wait on — on a repo
+          # with no gates it silently no-ops, leaving the PR open forever.
+          gh pr merge "$branch" --squash --delete-branch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -222,6 +222,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      # Why: actions:write is required for `gh workflow run homebrew-bump.yml`
+      # (below). Without it GITHUB_TOKEN gets HTTP 403 "Resource not accessible
+      # by integration" on POST /actions/workflows/:id/dispatches. The default
+      # scoped-down token grants only what the `permissions:` block lists.
+      actions: write
     steps:
       - name: Publish release
         # Why: derive `--prerelease` from the tag shape (not from whatever


### PR DESCRIPTION
## Summary
Two bugs surfaced on the v1.3.26 release — both caught before users were affected thanks to manual dispatch + manual PR merge:

### 1. `Trigger Homebrew cask bump` step failed with HTTP 403
\`\`\`
could not create workflow dispatch event: HTTP 403:
Resource not accessible by integration
\`\`\`
The \`publish-release\` job's permissions block only listed \`contents: write\`, but \`POST /actions/workflows/:id/dispatches\` requires \`actions: write\` on the scoped-down \`GITHUB_TOKEN\`. Added the permission.

Ref: [failing job on v1.3.26](https://github.com/stablyai/orca/actions/runs/25242122032/job/74020602906).

### 2. Tap bump PRs were left open even when the bump did run
Even when \`homebrew-bump.yml\` ran successfully (via manual dispatch for v1.3.25 and v1.3.26), the final \`gh pr merge --auto\` was silently no-op'ing. \`--auto\` only activates when there is a required check or branch-protection rule to wait on; the tap intentionally has neither, so the PR stayed OPEN forever.

Switched to a direct \`gh pr merge --squash --delete-branch\` so the tap stays hands-free as originally intended. Both prior bump PRs (stablyai/homebrew-orca#1 and #2) have been merged manually, so the tap now serves v1.3.26.

## State right now
- Tap: `orca 1.3.26` with matching sha256s (verified via GitHub API).
- `brew update && brew install --cask stablyai/orca/orca` gets users the latest.

## Test plan
- [x] `homebrew-bump.yml` dispatched manually for v1.3.26 — completed in 16s, PR opened in tap, merged.
- [ ] On the next GA release: the \`Trigger Homebrew cask bump\` step should now succeed (no 403), the bump workflow should fire automatically, and the bump PR should auto-merge without human touch.
- [ ] On the next rc release: \`Trigger Homebrew cask bump\` step should skip via the existing \`if: !contains(tag, '-rc.')\` gate.

Made with [Orca](https://github.com/stablyai/orca) 🐋
