### PR TITLE
feat: add PowerShell 7+ support for Windows terminals

### DIFF
--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -94,6 +94,7 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     experimentalAgentDashboard: false,
     experimentalPet: false,
     terminalWindowsShell: 'powershell.exe',
+    terminalWindowsPowerShellImplementation: 'powershell.exe',
     enableGitHubAttribution: true,
     ...overrides
   }

--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -88,6 +88,7 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     experimentalAgentDashboard: false,
     experimentalPet: false,
     terminalWindowsShell: 'powershell.exe',
+    terminalWindowsPowerShellImplementation: 'powershell.exe',
     enableGitHubAttribution: true,
     ...overrides
   }

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -120,6 +120,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
       // the override makes the daemon path behave the same as the in-process
       // LocalPtyProvider.
       shellOverride: opts.shellOverride,
+      terminalWindowsPowerShellImplementation: opts.terminalWindowsPowerShellImplementation,
       shellReadySupported: opts.command ? supportsPtyStartupBarrier(opts.env ?? {}) : false
     })
 

--- a/src/main/daemon/daemon-server.ts
+++ b/src/main/daemon/daemon-server.ts
@@ -201,6 +201,7 @@ export class DaemonServer {
           env: p.env,
           command: p.command,
           shellOverride: p.shellOverride,
+          terminalWindowsPowerShellImplementation: p.terminalWindowsPowerShellImplementation,
           shellReadySupported: p.shellReadySupported,
           streamClient: {
             onData: (data) => {

--- a/src/main/daemon/pty-subprocess.test.ts
+++ b/src/main/daemon/pty-subprocess.test.ts
@@ -373,6 +373,39 @@ describe('createPtySubprocess', () => {
     )
   })
 
+  it('falls back to powershell.exe when shellOverride requests pwsh.exe but pwsh is unavailable on Windows', () => {
+    const proc = mockPtyProcess()
+    spawnMock.mockReturnValue(proc)
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')
+
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+    isPwshAvailableMock.mockReturnValue(false)
+
+    try {
+      createPtySubprocess({
+        sessionId: 'test',
+        cols: 80,
+        rows: 24,
+        shellOverride: 'pwsh.exe',
+        terminalWindowsPowerShellImplementation: 'pwsh.exe'
+      })
+    } finally {
+      if (platform) {
+        Object.defineProperty(process, 'platform', platform)
+      }
+    }
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      'powershell.exe',
+      [
+        '-NoExit',
+        '-Command',
+        'try { . $PROFILE } catch {}; [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; [Console]::InputEncoding = [System.Text.Encoding]::UTF8'
+      ],
+      expect.any(Object)
+    )
+  })
+
   it('ignores the PowerShell implementation setting for cmd.exe on Windows', () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)

--- a/src/main/daemon/pty-subprocess.test.ts
+++ b/src/main/daemon/pty-subprocess.test.ts
@@ -1,11 +1,17 @@
-import { describe, expect, it, vi } from 'vitest'
+/* oxlint-disable max-lines -- Why: exercises full PTY subprocess surface (spawn setup, signal routing, data events, platform-specific shell configs, and Windows PowerShell implementations) with co-located test scenarios to prevent fixture drift. */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { spawnMock } = vi.hoisted(() => ({
-  spawnMock: vi.fn()
+const { spawnMock, isPwshAvailableMock } = vi.hoisted(() => ({
+  spawnMock: vi.fn(),
+  isPwshAvailableMock: vi.fn()
 }))
 
 vi.mock('node-pty', () => ({
   spawn: spawnMock
+}))
+
+vi.mock('../pwsh', () => ({
+  isPwshAvailable: isPwshAvailableMock
 }))
 
 import { createPtySubprocess } from './pty-subprocess'
@@ -33,6 +39,11 @@ function mockPtyProcess(pid = 12345) {
 }
 
 describe('createPtySubprocess', () => {
+  beforeEach(() => {
+    spawnMock.mockReset()
+    isPwshAvailableMock.mockReset()
+    isPwshAvailableMock.mockReturnValue(false)
+  })
   it('spawns node-pty with correct options', () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
@@ -260,6 +271,134 @@ describe('createPtySubprocess', () => {
       expect.any(String),
       expect.any(Array),
       expect.objectContaining({ cwd: 'D:\\Users\\orca' })
+    )
+  })
+
+  it('keeps powershell.exe when the inbox PowerShell implementation is selected on Windows', () => {
+    const proc = mockPtyProcess()
+    spawnMock.mockReturnValue(proc)
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')
+
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+    isPwshAvailableMock.mockReturnValue(true)
+
+    try {
+      createPtySubprocess({
+        sessionId: 'test',
+        cols: 80,
+        rows: 24,
+        env: { COMSPEC: 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe' },
+        terminalWindowsPowerShellImplementation: 'powershell.exe'
+      })
+    } finally {
+      if (platform) {
+        Object.defineProperty(process, 'platform', platform)
+      }
+    }
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      'powershell.exe',
+      [
+        '-NoExit',
+        '-Command',
+        'try { . $PROFILE } catch {}; [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; [Console]::InputEncoding = [System.Text.Encoding]::UTF8'
+      ],
+      expect.any(Object)
+    )
+  })
+
+  it('spawns pwsh.exe when PowerShell 7 is selected and available on Windows', () => {
+    const proc = mockPtyProcess()
+    spawnMock.mockReturnValue(proc)
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')
+
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+    isPwshAvailableMock.mockReturnValue(true)
+
+    try {
+      createPtySubprocess({
+        sessionId: 'test',
+        cols: 80,
+        rows: 24,
+        env: { COMSPEC: 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe' },
+        terminalWindowsPowerShellImplementation: 'pwsh.exe'
+      })
+    } finally {
+      if (platform) {
+        Object.defineProperty(process, 'platform', platform)
+      }
+    }
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      'pwsh.exe',
+      [
+        '-NoExit',
+        '-Command',
+        'try { . $PROFILE } catch {}; [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; [Console]::InputEncoding = [System.Text.Encoding]::UTF8'
+      ],
+      expect.any(Object)
+    )
+  })
+
+  it('falls back to powershell.exe when PowerShell 7 is selected but unavailable on Windows', () => {
+    const proc = mockPtyProcess()
+    spawnMock.mockReturnValue(proc)
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')
+
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+    isPwshAvailableMock.mockReturnValue(false)
+
+    try {
+      createPtySubprocess({
+        sessionId: 'test',
+        cols: 80,
+        rows: 24,
+        env: { COMSPEC: 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe' },
+        terminalWindowsPowerShellImplementation: 'pwsh.exe'
+      })
+    } finally {
+      if (platform) {
+        Object.defineProperty(process, 'platform', platform)
+      }
+    }
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      'powershell.exe',
+      [
+        '-NoExit',
+        '-Command',
+        'try { . $PROFILE } catch {}; [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; [Console]::InputEncoding = [System.Text.Encoding]::UTF8'
+      ],
+      expect.any(Object)
+    )
+  })
+
+  it('ignores the PowerShell implementation setting for cmd.exe on Windows', () => {
+    const proc = mockPtyProcess()
+    spawnMock.mockReturnValue(proc)
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')
+
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+    isPwshAvailableMock.mockReturnValue(true)
+
+    try {
+      createPtySubprocess({
+        sessionId: 'test',
+        cols: 80,
+        rows: 24,
+        shellOverride: 'cmd.exe',
+        terminalWindowsPowerShellImplementation: 'pwsh.exe'
+      })
+    } finally {
+      if (platform) {
+        Object.defineProperty(process, 'platform', platform)
+      }
+    }
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      'cmd.exe',
+      ['/K', 'chcp 65001 > nul'],
+      expect.any(Object)
     )
   })
 })

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -23,7 +23,7 @@ export type PtySubprocessOptions = {
    *  Overrides env.COMSPEC / env.SHELL resolution inside the daemon so a user
    *  who picks "New WSL terminal" from the "+" menu actually gets WSL. */
   shellOverride?: string
-  terminalWindowsPowerShellImplementation?: 'powershell.exe' | 'pwsh.exe'
+  terminalWindowsPowerShellImplementation?: 'auto' | 'powershell.exe' | 'pwsh.exe'
 }
 
 function getDefaultCwd(): string {
@@ -82,17 +82,21 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
     // one-off override. Normalize both forms back to the PowerShell family so
     // the shared resolver can still fall back to inbox powershell.exe when
     // pwsh.exe was requested but is unavailable.
-    shellPath =
-      resolveEffectiveWindowsPowerShell({
-        shellFamily:
-          normalizedShellFamily === 'powershell.exe' || normalizedShellFamily === 'pwsh.exe'
-            ? 'powershell.exe'
-            : normalizedShellFamily === 'cmd.exe' || normalizedShellFamily === 'wsl.exe'
-              ? normalizedShellFamily
-              : undefined,
-        implementation: opts.terminalWindowsPowerShellImplementation,
-        pwshAvailable: isPwshAvailable()
-      }) ?? shellPath
+    const shouldResolvePowerShellFamily =
+      opts.terminalWindowsPowerShellImplementation !== undefined ||
+      pathWin32.basename(shellPath) === shellPath
+    shellPath = shouldResolvePowerShellFamily
+      ? (resolveEffectiveWindowsPowerShell({
+          shellFamily:
+            normalizedShellFamily === 'powershell.exe' || normalizedShellFamily === 'pwsh.exe'
+              ? 'powershell.exe'
+              : normalizedShellFamily === 'cmd.exe' || normalizedShellFamily === 'wsl.exe'
+                ? normalizedShellFamily
+                : undefined,
+          implementation: opts.terminalWindowsPowerShellImplementation,
+          pwshAvailable: isPwshAvailable()
+        }) ?? shellPath)
+      : shellPath
     // Why: matches LocalPtyProvider — CMD needs chcp 65001, PowerShell needs
     // $PROFILE dot-sourcing, WSL needs a --bash entry with a translated cwd.
     // Reuse the same shared launch-args helper after resolving the effective

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -78,17 +78,18 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
   if (process.platform === 'win32') {
     const normalizedShellFamily = pathWin32.basename(shellPath).toLowerCase()
     // Why: daemon spawn requests can carry either a canonical shell family
-    // (`powershell.exe`) or a full executable path inherited from COMSPEC /
-    // one-off overrides. Normalize before resolving so the PowerShell 7+
-    // preference applies consistently in both cases, just like the local PTY.
+    // (`powershell.exe`) or a concrete PowerShell executable path from a
+    // one-off override. Normalize both forms back to the PowerShell family so
+    // the shared resolver can still fall back to inbox powershell.exe when
+    // pwsh.exe was requested but is unavailable.
     shellPath =
       resolveEffectiveWindowsPowerShell({
         shellFamily:
-          normalizedShellFamily === 'powershell.exe' ||
-          normalizedShellFamily === 'cmd.exe' ||
-          normalizedShellFamily === 'wsl.exe'
-            ? normalizedShellFamily
-            : undefined,
+          normalizedShellFamily === 'powershell.exe' || normalizedShellFamily === 'pwsh.exe'
+            ? 'powershell.exe'
+            : normalizedShellFamily === 'cmd.exe' || normalizedShellFamily === 'wsl.exe'
+              ? normalizedShellFamily
+              : undefined,
         implementation: opts.terminalWindowsPowerShellImplementation,
         pwshAvailable: isPwshAvailable()
       }) ?? shellPath

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -1,4 +1,5 @@
 import * as pty from 'node-pty'
+import { win32 as pathWin32 } from 'path'
 import type { SubprocessHandle } from './session'
 import {
   getAttributionShellLaunchConfig,
@@ -8,6 +9,8 @@ import {
 import { isValidPtySize, normalizePtySize } from './daemon-pty-size'
 import { ensureNodePtySpawnHelperExecutable } from '../providers/local-pty-utils'
 import { resolveWindowsShellLaunchArgs } from '../providers/windows-shell-args'
+import { resolveEffectiveWindowsPowerShell } from '../providers/windows-powershell'
+import { isPwshAvailable } from '../pwsh'
 
 export type PtySubprocessOptions = {
   sessionId: string
@@ -20,6 +23,7 @@ export type PtySubprocessOptions = {
    *  Overrides env.COMSPEC / env.SHELL resolution inside the daemon so a user
    *  who picks "New WSL terminal" from the "+" menu actually gets WSL. */
   shellOverride?: string
+  terminalWindowsPowerShellImplementation?: 'powershell.exe' | 'pwsh.exe'
 }
 
 function getDefaultCwd(): string {
@@ -67,16 +71,32 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
   // setting, relayed by main) takes priority over env.COMSPEC — otherwise
   // Windows always resolves to cmd.exe (COMSPEC) or PowerShell by fallback,
   // no matter which shell the user actually picked.
-  const shellPath = opts.shellOverride || resolvePtyShellPath(env)
+  let shellPath = opts.shellOverride || resolvePtyShellPath(env)
   let shellArgs: string[]
   let spawnCwd = opts.cwd || getDefaultCwd()
 
   if (process.platform === 'win32') {
+    const normalizedShellFamily = pathWin32.basename(shellPath).toLowerCase()
+    // Why: daemon spawn requests can carry either a canonical shell family
+    // (`powershell.exe`) or a full executable path inherited from COMSPEC /
+    // one-off overrides. Normalize before resolving so the PowerShell 7+
+    // preference applies consistently in both cases, just like the local PTY.
+    shellPath =
+      resolveEffectiveWindowsPowerShell({
+        shellFamily:
+          normalizedShellFamily === 'powershell.exe' ||
+          normalizedShellFamily === 'cmd.exe' ||
+          normalizedShellFamily === 'wsl.exe'
+            ? normalizedShellFamily
+            : undefined,
+        implementation: opts.terminalWindowsPowerShellImplementation,
+        pwshAvailable: isPwshAvailable()
+      }) ?? shellPath
     // Why: matches LocalPtyProvider — CMD needs chcp 65001, PowerShell needs
     // $PROFILE dot-sourcing, WSL needs a --bash entry with a translated cwd.
-    // Previously the daemon passed `[]` here which made every shell launch as
-    // a bare interactive process; that silently degraded PowerShell (no
-    // profile) and never worked at all for WSL (which needs explicit args).
+    // Reuse the same shared launch-args helper after resolving the effective
+    // PowerShell executable so daemon-backed terminals preserve parity with the
+    // in-process PTY path.
     const resolved = resolveWindowsShellLaunchArgs(shellPath, spawnCwd, getDefaultCwd())
     shellArgs = resolved.shellArgs
     spawnCwd = resolved.effectiveCwd

--- a/src/main/daemon/terminal-host.ts
+++ b/src/main/daemon/terminal-host.ts
@@ -18,7 +18,7 @@ export type CreateOrAttachOptions = {
    *  daemon path honors per-tab shell selection the same way LocalPtyProvider
    *  does. */
   shellOverride?: string
-  terminalWindowsPowerShellImplementation?: 'powershell.exe' | 'pwsh.exe'
+  terminalWindowsPowerShellImplementation?: 'auto' | 'powershell.exe' | 'pwsh.exe'
   shellReadySupported?: boolean
   streamClient: { onData: (data: string) => void; onExit: (code: number) => void }
 }
@@ -40,7 +40,7 @@ export type TerminalHostOptions = {
     env?: Record<string, string>
     command?: string
     shellOverride?: string
-    terminalWindowsPowerShellImplementation?: 'powershell.exe' | 'pwsh.exe'
+    terminalWindowsPowerShellImplementation?: 'auto' | 'powershell.exe' | 'pwsh.exe'
   }) => SubprocessHandle
   // Why: on graceful shutdown, the host writes final checkpoints for all live
   // sessions before killing them. This bypasses the RPC round-trip — the daemon

--- a/src/main/daemon/terminal-host.ts
+++ b/src/main/daemon/terminal-host.ts
@@ -18,6 +18,7 @@ export type CreateOrAttachOptions = {
    *  daemon path honors per-tab shell selection the same way LocalPtyProvider
    *  does. */
   shellOverride?: string
+  terminalWindowsPowerShellImplementation?: 'powershell.exe' | 'pwsh.exe'
   shellReadySupported?: boolean
   streamClient: { onData: (data: string) => void; onExit: (code: number) => void }
 }
@@ -39,6 +40,7 @@ export type TerminalHostOptions = {
     env?: Record<string, string>
     command?: string
     shellOverride?: string
+    terminalWindowsPowerShellImplementation?: 'powershell.exe' | 'pwsh.exe'
   }) => SubprocessHandle
   // Why: on graceful shutdown, the host writes final checkpoints for all live
   // sessions before killing them. This bypasses the RPC round-trip — the daemon
@@ -95,7 +97,8 @@ export class TerminalHost {
       cwd: opts.cwd,
       env: opts.env,
       command: opts.command,
-      shellOverride: opts.shellOverride
+      shellOverride: opts.shellOverride,
+      terminalWindowsPowerShellImplementation: opts.terminalWindowsPowerShellImplementation
     })
 
     const session = new Session({

--- a/src/main/daemon/types.ts
+++ b/src/main/daemon/types.ts
@@ -68,6 +68,11 @@ export type CreateOrAttachRequest = {
      *  instead of defaulting to COMSPEC (which is always cmd.exe on Windows)
      *  or the hard-coded powershell.exe fallback. */
     shellOverride?: string
+    /** Why: the UI keeps PowerShell as one shell family, but the runtime may
+     *  need to substitute pwsh.exe for powershell.exe when the user selected
+     *  PowerShell 7+. Forward the persisted implementation choice so the daemon
+     *  PTY path resolves the same effective executable as LocalPtyProvider. */
+    terminalWindowsPowerShellImplementation?: 'powershell.exe' | 'pwsh.exe'
     shellReadySupported?: boolean
   }
 }

--- a/src/main/daemon/types.ts
+++ b/src/main/daemon/types.ts
@@ -72,7 +72,7 @@ export type CreateOrAttachRequest = {
      *  need to substitute pwsh.exe for powershell.exe when the user selected
      *  PowerShell 7+. Forward the persisted implementation choice so the daemon
      *  PTY path resolves the same effective executable as LocalPtyProvider. */
-    terminalWindowsPowerShellImplementation?: 'powershell.exe' | 'pwsh.exe'
+    terminalWindowsPowerShellImplementation?: 'auto' | 'powershell.exe' | 'pwsh.exe'
     shellReadySupported?: boolean
   }
 }

--- a/src/main/ipc/app.ts
+++ b/src/main/ipc/app.ts
@@ -1,6 +1,7 @@
 import { execFile } from 'node:child_process'
 import { promisify } from 'node:util'
 import { app, ipcMain } from 'electron'
+import { isPwshAvailable } from '../pwsh'
 import { isWslAvailable } from '../wsl'
 
 const execFileAsync = promisify(execFile)
@@ -28,6 +29,7 @@ export function registerAppHandlers(): void {
   ipcMain.handle('app:getRuntimeFlags', (): AppRuntimeFlags => runtimeFlags)
 
   ipcMain.handle('wsl:isAvailable', (): boolean => isWslAvailable())
+  ipcMain.handle('pwsh:isAvailable', (): boolean => isPwshAvailable())
 
   // Why: ABC, Polish Pro, US Extended, ABC Extended, and every CJK Roman
   // IME all report a US-QWERTY base layer to navigator.keyboard.getLayoutMap()

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -20,7 +20,8 @@ const {
   openCodeClearPtyMock,
   buildAgentHookEnvMock,
   piBuildPtyEnvMock,
-  piClearPtyMock
+  piClearPtyMock,
+  isPwshAvailableMock
 } = vi.hoisted(() => ({
   handleMock: vi.fn(),
   onMock: vi.fn(),
@@ -35,6 +36,7 @@ const {
   getPathMock: vi.fn(),
   spawnMock: vi.fn(),
   openCodeBuildPtyEnvMock: vi.fn(),
+  isPwshAvailableMock: vi.fn(),
   openCodeClearPtyMock: vi.fn(),
   buildAgentHookEnvMock: vi.fn(),
   piBuildPtyEnvMock: vi.fn(),
@@ -89,6 +91,10 @@ vi.mock('../pi/titlebar-extension-service', () => ({
     clearPty: piClearPtyMock
   }
 }))
+
+vi.mock('../pwsh', () => ({
+  isPwshAvailable: isPwshAvailableMock
+}))
 import { LocalPtyProvider } from '../providers/local-pty-provider'
 import {
   registerPtyHandlers,
@@ -135,6 +141,7 @@ describe('registerPtyHandlers', () => {
     buildAgentHookEnvMock.mockReset()
     piBuildPtyEnvMock.mockReset()
     piClearPtyMock.mockReset()
+    isPwshAvailableMock.mockReset()
     mainWindow.webContents.on.mockReset()
     mainWindow.webContents.send.mockReset()
 
@@ -159,6 +166,7 @@ describe('registerPtyHandlers', () => {
         ? '/tmp/orca-pi-agent-overlay'
         : '/tmp/orca-pi-agent-overlay'
     }))
+    isPwshAvailableMock.mockReturnValue(false)
     spawnMock.mockReturnValue({
       onData: vi.fn(() => makeDisposable()),
       onExit: vi.fn(() => makeDisposable()),
@@ -993,6 +1001,151 @@ describe('registerPtyHandlers', () => {
         ],
         expect.any(Object)
       )
+    })
+
+    it('spawns powershell.exe when PowerShell family keeps the inbox implementation', () => {
+      process.env.COMSPEC = 'C:\\Windows\\system32\\cmd.exe'
+
+      registerPtyHandlers(
+        mainWindow as never,
+        undefined,
+        undefined,
+        () =>
+          ({
+            terminalWindowsShell: 'powershell.exe',
+            terminalWindowsPowerShellImplementation: 'powershell.exe'
+          }) as never
+      )
+      handlers.get('pty:spawn')!(null, { cols: 80, rows: 24 })
+
+      expect(spawnMock).toHaveBeenCalledWith(
+        'powershell.exe',
+        [
+          '-NoExit',
+          '-Command',
+          'try { . $PROFILE } catch {}; [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; [Console]::InputEncoding = [System.Text.Encoding]::UTF8'
+        ],
+        expect.any(Object)
+      )
+    })
+
+    it('spawns pwsh.exe when PowerShell 7 is selected and available', () => {
+      process.env.COMSPEC = 'C:\\Windows\\system32\\cmd.exe'
+      isPwshAvailableMock.mockReturnValue(true)
+
+      registerPtyHandlers(
+        mainWindow as never,
+        undefined,
+        undefined,
+        () =>
+          ({
+            terminalWindowsShell: 'powershell.exe',
+            terminalWindowsPowerShellImplementation: 'pwsh.exe'
+          }) as never
+      )
+      handlers.get('pty:spawn')!(null, { cols: 80, rows: 24 })
+
+      expect(spawnMock).toHaveBeenCalledWith(
+        'pwsh.exe',
+        [
+          '-NoExit',
+          '-Command',
+          'try { . $PROFILE } catch {}; [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; [Console]::InputEncoding = [System.Text.Encoding]::UTF8'
+        ],
+        expect.any(Object)
+      )
+    })
+
+    it('falls back to powershell.exe when PowerShell 7 is selected but unavailable', () => {
+      process.env.COMSPEC = 'C:\\Windows\\system32\\cmd.exe'
+      isPwshAvailableMock.mockReturnValue(false)
+
+      registerPtyHandlers(
+        mainWindow as never,
+        undefined,
+        undefined,
+        () =>
+          ({
+            terminalWindowsShell: 'powershell.exe',
+            terminalWindowsPowerShellImplementation: 'pwsh.exe'
+          }) as never
+      )
+      handlers.get('pty:spawn')!(null, { cols: 80, rows: 24 })
+
+      expect(spawnMock).toHaveBeenCalledWith(
+        'powershell.exe',
+        [
+          '-NoExit',
+          '-Command',
+          'try { . $PROFILE } catch {}; [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; [Console]::InputEncoding = [System.Text.Encoding]::UTF8'
+        ],
+        expect.any(Object)
+      )
+    })
+
+    it('ignores the PowerShell implementation setting for cmd.exe', () => {
+      process.env.COMSPEC = 'C:\\Windows\\system32\\powershell.exe'
+      isPwshAvailableMock.mockReturnValue(true)
+
+      registerPtyHandlers(
+        mainWindow as never,
+        undefined,
+        undefined,
+        () =>
+          ({
+            terminalWindowsShell: 'cmd.exe',
+            terminalWindowsPowerShellImplementation: 'pwsh.exe'
+          }) as never
+      )
+      handlers.get('pty:spawn')!(null, { cols: 80, rows: 24 })
+
+      expect(spawnMock).toHaveBeenCalledWith(
+        'cmd.exe',
+        ['/K', 'chcp 65001 > nul'],
+        expect.any(Object)
+      )
+    })
+
+    it('ignores the PowerShell implementation setting for wsl.exe', () => {
+      process.env.COMSPEC = 'C:\\Windows\\system32\\powershell.exe'
+      isPwshAvailableMock.mockReturnValue(true)
+
+      registerPtyHandlers(
+        mainWindow as never,
+        undefined,
+        undefined,
+        () =>
+          ({
+            terminalWindowsShell: 'wsl.exe',
+            terminalWindowsPowerShellImplementation: 'pwsh.exe'
+          }) as never
+      )
+      handlers.get('pty:spawn')!(null, { cols: 80, rows: 24 })
+
+      expect(spawnMock).toHaveBeenCalledWith('wsl.exe', expect.any(Array), expect.any(Object))
+    })
+
+    it('keeps shellOverride priority for one-off tabs', () => {
+      process.env.COMSPEC = 'C:\\Windows\\system32\\cmd.exe'
+      isPwshAvailableMock.mockReturnValue(false)
+
+      registerPtyHandlers(
+        mainWindow as never,
+        undefined,
+        undefined,
+        () =>
+          ({
+            terminalWindowsShell: 'powershell.exe',
+            terminalWindowsPowerShellImplementation: 'pwsh.exe'
+          }) as never
+      )
+      handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        shellOverride: 'wsl.exe'
+      })
+
+      expect(spawnMock).toHaveBeenCalledWith('wsl.exe', expect.any(Array), expect.any(Object))
     })
   })
 

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -1083,6 +1083,33 @@ describe('registerPtyHandlers', () => {
       )
     })
 
+    it('falls back to powershell.exe when shellOverride requests pwsh.exe but pwsh is unavailable', () => {
+      process.env.COMSPEC = 'C:\\Windows\\system32\\cmd.exe'
+      isPwshAvailableMock.mockReturnValue(false)
+
+      registerPtyHandlers(
+        mainWindow as never,
+        undefined,
+        undefined,
+        () =>
+          ({
+            terminalWindowsShell: 'powershell.exe',
+            terminalWindowsPowerShellImplementation: 'pwsh.exe'
+          }) as never
+      )
+      handlers.get('pty:spawn')!(null, { cols: 80, rows: 24, shellOverride: 'pwsh.exe' })
+
+      expect(spawnMock).toHaveBeenCalledWith(
+        'powershell.exe',
+        [
+          '-NoExit',
+          '-Command',
+          'try { . $PROFILE } catch {}; [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; [Console]::InputEncoding = [System.Text.Encoding]::UTF8'
+        ],
+        expect.any(Object)
+      )
+    })
+
     it('ignores the PowerShell implementation setting for cmd.exe', () => {
       process.env.COMSPEC = 'C:\\Windows\\system32\\powershell.exe'
       isPwshAvailableMock.mockReturnValue(true)

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -11,6 +11,7 @@ import type { GlobalSettings } from '../../shared/types'
 import { openCodeHookService } from '../opencode/hook-service'
 import { agentHookServer } from '../agent-hooks/server'
 import { piTitlebarExtensionService } from '../pi/titlebar-extension-service'
+import { isPwshAvailable } from '../pwsh'
 import { LocalPtyProvider } from '../providers/local-pty-provider'
 import type { IPtyProvider, PtySpawnOptions, PtySpawnResult } from '../providers/types'
 import { mintPtySessionId, isSafePtySessionId } from '../daemon/pty-session-id'
@@ -347,6 +348,9 @@ export function registerPtyHandlers(
     localProvider.configure({
       isHistoryEnabled: () => getSettings?.()?.terminalScopeHistoryByWorktree ?? true,
       getWindowsShell: () => getSettings?.()?.terminalWindowsShell,
+      getWindowsPowerShellImplementation: () =>
+        getSettings?.()?.terminalWindowsPowerShellImplementation ?? 'powershell.exe',
+      pwshAvailable: () => isPwshAvailable(),
       buildSpawnEnv: (id, baseEnv) => {
         const env = buildPtyHostEnv(id, baseEnv, {
           isPackaged: app.isPackaged,
@@ -649,6 +653,14 @@ export function registerPtyHandlers(
           : undefined)
       if (effectiveShellOverride !== undefined) {
         spawnOptions.shellOverride = effectiveShellOverride
+      }
+      if (process.platform === 'win32' && !args.connectionId) {
+        // Why: the renderer only models PowerShell as one shell family. Thread
+        // the persisted implementation choice through spawnOptions so both the
+        // in-process and daemon-backed PTY paths can resolve the same effective
+        // executable without inventing a fourth top-level shell.
+        spawnOptions.terminalWindowsPowerShellImplementation =
+          getSettings?.()?.terminalWindowsPowerShellImplementation ?? 'powershell.exe'
       }
       let result: PtySpawnResult
       try {

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -349,7 +349,9 @@ export function registerPtyHandlers(
       isHistoryEnabled: () => getSettings?.()?.terminalScopeHistoryByWorktree ?? true,
       getWindowsShell: () => getSettings?.()?.terminalWindowsShell,
       getWindowsPowerShellImplementation: () =>
-        getSettings?.()?.terminalWindowsPowerShellImplementation ?? 'powershell.exe',
+        getSettings
+          ? (getSettings()?.terminalWindowsPowerShellImplementation ?? 'auto')
+          : undefined,
       pwshAvailable: () => isPwshAvailable(),
       buildSpawnEnv: (id, baseEnv) => {
         const env = buildPtyHostEnv(id, baseEnv, {
@@ -659,8 +661,9 @@ export function registerPtyHandlers(
         // the persisted implementation choice through spawnOptions so both the
         // in-process and daemon-backed PTY paths can resolve the same effective
         // executable without inventing a fourth top-level shell.
-        spawnOptions.terminalWindowsPowerShellImplementation =
-          getSettings?.()?.terminalWindowsPowerShellImplementation ?? 'powershell.exe'
+        spawnOptions.terminalWindowsPowerShellImplementation = getSettings
+          ? (getSettings()?.terminalWindowsPowerShellImplementation ?? 'auto')
+          : undefined
       }
       let result: PtySpawnResult
       try {

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -3,7 +3,9 @@
 tightly coupled PTY lifecycle logic (scan → ready → write → exit cleanup) across
 files without a cleaner ownership seam. */
 import { basename } from 'path'
+import { win32 as pathWin32 } from 'path'
 import { resolveWindowsShellLaunchArgs } from './windows-shell-args'
+import { resolveEffectiveWindowsPowerShell } from './windows-powershell'
 import { resolveProcessCwd } from './process-cwd'
 import { existsSync } from 'fs'
 import * as pty from 'node-pty'
@@ -100,6 +102,8 @@ export type LocalPtyProviderOptions = {
    *  IPC layer inject the persisted setting without coupling the provider to the
    *  settings store. Returns undefined when no preference is set. */
   getWindowsShell?: () => string | undefined
+  getWindowsPowerShellImplementation?: () => 'powershell.exe' | 'pwsh.exe'
+  pwshAvailable?: () => boolean
   onSpawned?: (id: string) => void
   onExit?: (id: string, code: number) => void
   onData?: (id: string, data: string, timestamp: number) => void
@@ -139,11 +143,30 @@ export class LocalPtyProvider implements IPtyProvider {
       // Why: shellOverride lets a single tab open in a different shell than the
       // persisted default (e.g. "New WSL terminal" from the "+" submenu) without
       // changing the user's setting. It takes priority over the setting.
-      shellPath =
+      const shellFamily =
         args.shellOverride ||
         this.opts.getWindowsShell?.() ||
         process.env.COMSPEC ||
         'powershell.exe'
+      const normalizedShellFamily = pathWin32.basename(shellFamily).toLowerCase()
+      // Why: shell selection can arrive either as a canonical setting value
+      // ('powershell.exe') or as a full executable path from COMSPEC / one-off
+      // overrides. Normalize before resolving so both forms honor the same
+      // PowerShell implementation preference.
+      shellPath =
+        resolveEffectiveWindowsPowerShell({
+          shellFamily:
+            normalizedShellFamily === 'powershell.exe' ||
+            normalizedShellFamily === 'cmd.exe' ||
+            normalizedShellFamily === 'wsl.exe'
+              ? normalizedShellFamily
+              : undefined,
+          implementation: this.opts.getWindowsPowerShellImplementation?.(),
+          pwshAvailable: this.opts.pwshAvailable?.() ?? false
+        }) ?? shellFamily
+      // Why: one-off overrides and persisted shell-family selection keep the
+      // same priority, while the shared resolver chooses which PowerShell
+      // executable is safe to run right now if that family is selected.
       // Why: both this path and the daemon-subprocess path must derive the
       // same shellArgs for the same (shell, cwd) pair. The helper keeps CJK
       // UTF-8 setup (chcp 65001), PowerShell $PROFILE dot-sourcing, and the

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -150,17 +150,18 @@ export class LocalPtyProvider implements IPtyProvider {
         'powershell.exe'
       const normalizedShellFamily = pathWin32.basename(shellFamily).toLowerCase()
       // Why: shell selection can arrive either as a canonical setting value
-      // ('powershell.exe') or as a full executable path from COMSPEC / one-off
-      // overrides. Normalize before resolving so both forms honor the same
-      // PowerShell implementation preference.
+      // ('powershell.exe') or as a concrete PowerShell executable path from a
+      // one-off override. Normalize both forms back to the PowerShell family so
+      // the shared resolver can still fall back to inbox powershell.exe when
+      // pwsh.exe was requested but is unavailable.
       shellPath =
         resolveEffectiveWindowsPowerShell({
           shellFamily:
-            normalizedShellFamily === 'powershell.exe' ||
-            normalizedShellFamily === 'cmd.exe' ||
-            normalizedShellFamily === 'wsl.exe'
-              ? normalizedShellFamily
-              : undefined,
+            normalizedShellFamily === 'powershell.exe' || normalizedShellFamily === 'pwsh.exe'
+              ? 'powershell.exe'
+              : normalizedShellFamily === 'cmd.exe' || normalizedShellFamily === 'wsl.exe'
+                ? normalizedShellFamily
+                : undefined,
           implementation: this.opts.getWindowsPowerShellImplementation?.(),
           pwshAvailable: this.opts.pwshAvailable?.() ?? false
         }) ?? shellFamily

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -102,7 +102,7 @@ export type LocalPtyProviderOptions = {
    *  IPC layer inject the persisted setting without coupling the provider to the
    *  settings store. Returns undefined when no preference is set. */
   getWindowsShell?: () => string | undefined
-  getWindowsPowerShellImplementation?: () => 'powershell.exe' | 'pwsh.exe'
+  getWindowsPowerShellImplementation?: () => 'auto' | 'powershell.exe' | 'pwsh.exe' | undefined
   pwshAvailable?: () => boolean
   onSpawned?: (id: string) => void
   onExit?: (id: string, code: number) => void
@@ -154,17 +154,21 @@ export class LocalPtyProvider implements IPtyProvider {
       // one-off override. Normalize both forms back to the PowerShell family so
       // the shared resolver can still fall back to inbox powershell.exe when
       // pwsh.exe was requested but is unavailable.
-      shellPath =
-        resolveEffectiveWindowsPowerShell({
-          shellFamily:
-            normalizedShellFamily === 'powershell.exe' || normalizedShellFamily === 'pwsh.exe'
-              ? 'powershell.exe'
-              : normalizedShellFamily === 'cmd.exe' || normalizedShellFamily === 'wsl.exe'
-                ? normalizedShellFamily
-                : undefined,
-          implementation: this.opts.getWindowsPowerShellImplementation?.(),
-          pwshAvailable: this.opts.pwshAvailable?.() ?? false
-        }) ?? shellFamily
+      const powerShellImplementation = this.opts.getWindowsPowerShellImplementation?.()
+      const shouldResolvePowerShellFamily =
+        powerShellImplementation !== undefined || pathWin32.basename(shellFamily) === shellFamily
+      shellPath = shouldResolvePowerShellFamily
+        ? (resolveEffectiveWindowsPowerShell({
+            shellFamily:
+              normalizedShellFamily === 'powershell.exe' || normalizedShellFamily === 'pwsh.exe'
+                ? 'powershell.exe'
+                : normalizedShellFamily === 'cmd.exe' || normalizedShellFamily === 'wsl.exe'
+                  ? normalizedShellFamily
+                  : undefined,
+            implementation: powerShellImplementation,
+            pwshAvailable: this.opts.pwshAvailable?.() ?? false
+          }) ?? shellFamily)
+        : shellFamily
       // Why: one-off overrides and persisted shell-family selection keep the
       // same priority, while the shared resolver chooses which PowerShell
       // executable is safe to run right now if that family is selected.

--- a/src/main/providers/types.ts
+++ b/src/main/providers/types.ts
@@ -30,6 +30,12 @@ export type PtySpawnOptions = {
    *  changing the user's persistent default shell setting. Only consulted on
    *  Windows; ignored on macOS/Linux where shell selection is not exposed. */
   shellOverride?: string
+  /** Why: PowerShell is the top-level shell family in product terms, but on
+   *  Windows we may need to choose between inbox Windows PowerShell 5.1 and
+   *  pwsh.exe at spawn time. Threading the persisted implementation choice
+   *  through spawn options keeps local PTY and daemon PTY semantics aligned
+   *  without promoting pwsh into a separate shell family. */
+  terminalWindowsPowerShellImplementation?: 'powershell.exe' | 'pwsh.exe'
 }
 
 export type PtySpawnResult = {

--- a/src/main/providers/types.ts
+++ b/src/main/providers/types.ts
@@ -35,7 +35,7 @@ export type PtySpawnOptions = {
    *  pwsh.exe at spawn time. Threading the persisted implementation choice
    *  through spawn options keeps local PTY and daemon PTY semantics aligned
    *  without promoting pwsh into a separate shell family. */
-  terminalWindowsPowerShellImplementation?: 'powershell.exe' | 'pwsh.exe'
+  terminalWindowsPowerShellImplementation?: 'auto' | 'powershell.exe' | 'pwsh.exe'
 }
 
 export type PtySpawnResult = {

--- a/src/main/providers/windows-powershell.test.ts
+++ b/src/main/providers/windows-powershell.test.ts
@@ -58,13 +58,33 @@ describe('resolveEffectiveWindowsPowerShell', () => {
     ).toBe('powershell.exe')
   })
 
-  it('defaults to powershell.exe when no implementation is persisted', () => {
+  it('uses pwsh.exe for Auto when pwsh is available', () => {
+    expect(
+      resolveEffectiveWindowsPowerShell({
+        shellFamily: 'powershell.exe',
+        implementation: 'auto',
+        pwshAvailable: true
+      })
+    ).toBe('pwsh.exe')
+  })
+
+  it('uses powershell.exe for Auto when pwsh is unavailable', () => {
+    expect(
+      resolveEffectiveWindowsPowerShell({
+        shellFamily: 'powershell.exe',
+        implementation: 'auto',
+        pwshAvailable: false
+      })
+    ).toBe('powershell.exe')
+  })
+
+  it('defaults to Auto when no implementation is persisted', () => {
     expect(
       resolveEffectiveWindowsPowerShell({
         shellFamily: 'powershell.exe',
         implementation: undefined,
         pwshAvailable: true
       })
-    ).toBe('powershell.exe')
+    ).toBe('pwsh.exe')
   })
 })

--- a/src/main/providers/windows-powershell.test.ts
+++ b/src/main/providers/windows-powershell.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import { resolveEffectiveWindowsPowerShell } from './windows-powershell'
+
+describe('resolveEffectiveWindowsPowerShell', () => {
+  it('returns null for non-PowerShell shell families', () => {
+    expect(
+      resolveEffectiveWindowsPowerShell({
+        shellFamily: 'cmd.exe',
+        implementation: 'pwsh.exe',
+        pwshAvailable: true
+      })
+    ).toBeNull()
+
+    expect(
+      resolveEffectiveWindowsPowerShell({
+        shellFamily: 'wsl.exe',
+        implementation: 'powershell.exe',
+        pwshAvailable: true
+      })
+    ).toBeNull()
+
+    expect(
+      resolveEffectiveWindowsPowerShell({
+        shellFamily: undefined,
+        implementation: 'pwsh.exe',
+        pwshAvailable: true
+      })
+    ).toBeNull()
+  })
+
+  it('returns powershell.exe when the saved implementation is powershell.exe', () => {
+    expect(
+      resolveEffectiveWindowsPowerShell({
+        shellFamily: 'powershell.exe',
+        implementation: 'powershell.exe',
+        pwshAvailable: true
+      })
+    ).toBe('powershell.exe')
+  })
+
+  it('returns pwsh.exe when the saved implementation is pwsh.exe and pwsh is available', () => {
+    expect(
+      resolveEffectiveWindowsPowerShell({
+        shellFamily: 'powershell.exe',
+        implementation: 'pwsh.exe',
+        pwshAvailable: true
+      })
+    ).toBe('pwsh.exe')
+  })
+
+  it('falls back to powershell.exe when pwsh is preferred but unavailable', () => {
+    expect(
+      resolveEffectiveWindowsPowerShell({
+        shellFamily: 'powershell.exe',
+        implementation: 'pwsh.exe',
+        pwshAvailable: false
+      })
+    ).toBe('powershell.exe')
+  })
+
+  it('defaults to powershell.exe when no implementation is persisted', () => {
+    expect(
+      resolveEffectiveWindowsPowerShell({
+        shellFamily: 'powershell.exe',
+        implementation: undefined,
+        pwshAvailable: true
+      })
+    ).toBe('powershell.exe')
+  })
+})

--- a/src/main/providers/windows-powershell.ts
+++ b/src/main/providers/windows-powershell.ts
@@ -1,4 +1,4 @@
-export type WindowsPowerShellImplementation = 'powershell.exe' | 'pwsh.exe'
+export type WindowsPowerShellImplementation = 'auto' | 'powershell.exe' | 'pwsh.exe'
 
 /** Resolve which PowerShell executable to spawn right now on Windows.
  *
@@ -14,7 +14,12 @@ export function resolveEffectiveWindowsPowerShell(args: {
     return null
   }
 
-  if (args.implementation === 'pwsh.exe' && args.pwshAvailable) {
+  if (
+    (args.implementation === undefined ||
+      args.implementation === 'auto' ||
+      args.implementation === 'pwsh.exe') &&
+    args.pwshAvailable
+  ) {
     return 'pwsh.exe'
   }
 

--- a/src/main/providers/windows-powershell.ts
+++ b/src/main/providers/windows-powershell.ts
@@ -1,0 +1,22 @@
+export type WindowsPowerShellImplementation = 'powershell.exe' | 'pwsh.exe'
+
+/** Resolve which PowerShell executable to spawn right now on Windows.
+ *
+ * Why: keep the saved pwsh preference intact even when pwsh is temporarily
+ * unavailable, so runtime falls back safely without mutating user settings.
+ */
+export function resolveEffectiveWindowsPowerShell(args: {
+  shellFamily: 'powershell.exe' | 'cmd.exe' | 'wsl.exe' | undefined
+  implementation: WindowsPowerShellImplementation | undefined
+  pwshAvailable: boolean
+}): 'powershell.exe' | 'pwsh.exe' | null {
+  if (args.shellFamily !== 'powershell.exe') {
+    return null
+  }
+
+  if (args.implementation === 'pwsh.exe' && args.pwshAvailable) {
+    return 'pwsh.exe'
+  }
+
+  return 'powershell.exe'
+}

--- a/src/main/pwsh.test.ts
+++ b/src/main/pwsh.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { execFileSyncMock } = vi.hoisted(() => ({
+  execFileSyncMock: vi.fn()
+}))
+
+vi.mock('child_process', () => ({
+  execFileSync: execFileSyncMock
+}))
+
+function setPlatform(platform: NodeJS.Platform): () => void {
+  const originalPlatform = process.platform
+  Object.defineProperty(process, 'platform', {
+    configurable: true,
+    value: platform
+  })
+
+  return () => {
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: originalPlatform
+    })
+  }
+}
+
+describe('isPwshAvailable', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    execFileSyncMock.mockReset()
+  })
+
+  it('returns false on non-Windows platforms', async () => {
+    const restorePlatform = setPlatform('linux')
+
+    try {
+      const { isPwshAvailable } = await import('./pwsh')
+      expect(isPwshAvailable()).toBe(false)
+      expect(execFileSyncMock).not.toHaveBeenCalled()
+    } finally {
+      restorePlatform()
+    }
+  })
+
+  it('returns true when pwsh.exe is available on Windows', async () => {
+    const restorePlatform = setPlatform('win32')
+    execFileSyncMock.mockReturnValue('PowerShell 7.5.0')
+
+    try {
+      const { isPwshAvailable } = await import('./pwsh')
+      expect(isPwshAvailable()).toBe(true)
+      expect(execFileSyncMock).toHaveBeenCalledWith('pwsh.exe', ['-Version'], {
+        stdio: ['pipe', 'pipe', 'pipe'],
+        timeout: 5000
+      })
+    } finally {
+      restorePlatform()
+    }
+  })
+
+  it('returns false when pwsh.exe probe throws on Windows', async () => {
+    const restorePlatform = setPlatform('win32')
+    execFileSyncMock.mockImplementation(() => {
+      throw new Error('missing pwsh')
+    })
+
+    try {
+      const { isPwshAvailable } = await import('./pwsh')
+      expect(isPwshAvailable()).toBe(false)
+    } finally {
+      restorePlatform()
+    }
+  })
+
+  it('reuses the cached result across repeated calls', async () => {
+    const restorePlatform = setPlatform('win32')
+    execFileSyncMock.mockReturnValue('PowerShell 7.5.0')
+
+    try {
+      const { isPwshAvailable } = await import('./pwsh')
+      expect(isPwshAvailable()).toBe(true)
+      expect(isPwshAvailable()).toBe(true)
+      expect(execFileSyncMock).toHaveBeenCalledTimes(1)
+    } finally {
+      restorePlatform()
+    }
+  })
+})

--- a/src/main/pwsh.ts
+++ b/src/main/pwsh.ts
@@ -1,0 +1,31 @@
+import { execFileSync } from 'child_process'
+
+// Cached pwsh availability check — evaluated once per process lifetime
+let pwshAvailableCache: boolean | null = null
+
+/**
+ * Check whether pwsh.exe is available on this Windows machine.
+ * Result is cached for the process lifetime.
+ */
+export function isPwshAvailable(): boolean {
+  if (pwshAvailableCache !== null) {
+    return pwshAvailableCache
+  }
+
+  if (process.platform !== 'win32') {
+    pwshAvailableCache = false
+    return false
+  }
+
+  try {
+    execFileSync('pwsh.exe', ['-Version'], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 5000
+    })
+    pwshAvailableCache = true
+  } catch {
+    pwshAvailableCache = false
+  }
+
+  return pwshAvailableCache
+}

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -933,6 +933,9 @@ export type PreloadApi = {
   wsl: {
     isAvailable: () => Promise<boolean>
   }
+  pwsh: {
+    isAvailable: () => Promise<boolean>
+  }
   agentStatus: {
     /** Listen for agent status updates forwarded from native hook receivers. */
     onSet: (

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -194,6 +194,10 @@ const api = {
     isAvailable: (): Promise<boolean> => ipcRenderer.invoke('wsl:isAvailable')
   },
 
+  pwsh: {
+    isAvailable: (): Promise<boolean> => ipcRenderer.invoke('pwsh:isAvailable')
+  },
+
   repos: {
     list: (): Promise<unknown[]> => ipcRenderer.invoke('repos:list'),
 

--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -153,9 +153,17 @@ function Settings(): React.JSX.Element {
   // TerminalPane, driven by this shared state.
   const ghostty = useGhosttyImport(updateSettings, settings)
   const [wslAvailable, setWslAvailable] = useState(false)
+  const [pwshAvailable, setPwshAvailable] = useState(false)
   useEffect(() => {
+    if (!isWindows) {
+      setWslAvailable(false)
+      setPwshAvailable(false)
+      return
+    }
+
     void window.api.wsl.isAvailable().then(setWslAvailable)
-  }, [])
+    void window.api.pwsh.isAvailable().then(setPwshAvailable)
+  }, [isWindows])
   const [terminalFontSuggestions, setTerminalFontSuggestions] = useState<string[]>(
     getFallbackTerminalFonts()
   )
@@ -662,6 +670,7 @@ function Settings(): React.JSX.Element {
                     setScrollbackMode={setScrollbackMode}
                     ghostty={ghostty}
                     wslAvailable={wslAvailable}
+                    pwshAvailable={pwshAvailable}
                   />
                 </SettingsSection>
 

--- a/src/renderer/src/components/settings/TerminalPane.pwsh.test.ts
+++ b/src/renderer/src/components/settings/TerminalPane.pwsh.test.ts
@@ -43,7 +43,7 @@ vi.mock('@/lib/keyboard-layout/detect-option-as-alt', () => ({
 
 vi.mock('@/components/terminal-pane/pane-helpers', () => ({
   isMacUserAgent: () => false,
-  isWindowsUserAgent: () => false
+  isWindowsUserAgent: () => true
 }))
 
 vi.mock('../ui/button', () => ({
@@ -123,15 +123,10 @@ vi.mock('@/lib/terminal-theme', () => ({
 }))
 
 const ghosttyMock = {
-  open: true,
-  preview: {
-    found: true,
-    configPath: '/path',
-    diff: { terminalFontSize: 14 },
-    unsupportedKeys: []
-  },
+  open: false,
+  preview: null,
   loading: false,
-  applied: true,
+  applied: false,
   applyError: null,
   handleClick: vi.fn(),
   handleApply: vi.fn(),
@@ -145,7 +140,7 @@ type ReactElementLike = {
   props: Record<string, unknown>
 }
 
-function extractText(node: unknown): string {
+function collectText(node: unknown): string {
   if (node == null) {
     return ''
   }
@@ -156,112 +151,64 @@ function extractText(node: unknown): string {
     return String(node)
   }
   if (Array.isArray(node)) {
-    return node.map(extractText).join('')
+    return node.map(collectText).join('')
   }
   const el = node as ReactElementLike
-  if (el.props?.children) {
-    return extractText(el.props.children)
-  }
-  return ''
+  return collectText(el.props?.children)
 }
 
-function findButtons(node: unknown): { text: string; onClick: (() => void) | undefined }[] {
-  const buttons: { text: string; onClick: (() => void) | undefined }[] = []
-
-  function traverse(n: unknown): void {
-    if (n == null) {
-      return
-    }
-    if (typeof n === 'string' || typeof n === 'number') {
-      return
-    }
-    if (Array.isArray(n)) {
-      n.forEach(traverse)
-      return
-    }
-    const el = n as ReactElementLike
-    const typeName = typeof el.type === 'function' ? el.type.name : String(el.type)
-    if (typeName === 'Button') {
-      const text = extractText(el.props.children)
-      buttons.push({ text, onClick: el.props.onClick as (() => void) | undefined })
-    }
-    if (el.props?.children) {
-      traverse(el.props.children)
-    }
-  }
-
-  traverse(node)
-  return buttons
-}
-
-function findGhosttyImportModal(node: unknown): ReactElementLike | null {
+function findAnchorByText(node: unknown, text: string): ReactElementLike | null {
   if (node == null) {
     return null
   }
   if (Array.isArray(node)) {
     for (const child of node) {
-      const found = findGhosttyImportModal(child)
+      const found = findAnchorByText(child, text)
       if (found) {
         return found
       }
     }
     return null
   }
+  if (typeof node === 'string' || typeof node === 'number') {
+    return null
+  }
   const el = node as ReactElementLike
   const typeName = typeof el.type === 'function' ? el.type.name : String(el.type)
-  if (typeName === 'GhosttyImportModal') {
+  if (typeName === 'a' && collectText(el.props.children).includes(text)) {
     return el
   }
-  if (el.props?.children) {
-    return findGhosttyImportModal(el.props.children)
-  }
-  return null
+  return findAnchorByText(el.props?.children, text)
 }
 
-describe('TerminalPane ghostty import wiring', () => {
+describe('TerminalPane PowerShell version setting', () => {
   beforeEach(() => {
     mockStateValues.length = 0
     resetMockState()
     vi.clearAllMocks()
   })
 
-  // Why: the Ghostty import trigger button lives on the section header in
-  // Settings.tsx (headerAction) — not inside TerminalPane. Keep this test
-  // around so a regression that moves the button back into the pane fails.
-  it('does not render an Import from Ghostty button inside the pane', () => {
+  it('shows the PowerShell 7+ download link when pwsh is unavailable', () => {
     const element = TerminalPane({
-      settings: {} as never,
+      settings: {
+        terminalScrollbackBytes: 10_000_000,
+        terminalWindowsShell: 'powershell.exe',
+        terminalWindowsPowerShellImplementation: 'powershell.exe',
+        terminalWordSeparator: ''
+      } as never,
       updateSettings: () => {},
       systemPrefersDark: true,
       terminalFontSuggestions: [],
       scrollbackMode: 'preset',
       setScrollbackMode: () => {},
-      ghostty: ghosttyMock
+      ghostty: ghosttyMock,
+      wslAvailable: false,
+      pwshAvailable: false
     })
 
-    const buttons = findButtons(element)
-    const importButton = buttons.find((b) => b.text === 'Import from Ghostty')
-    expect(importButton).toBeUndefined()
-  })
-
-  it('passes hook state to GhosttyImportModal', () => {
-    const element = TerminalPane({
-      settings: {} as never,
-      updateSettings: () => {},
-      systemPrefersDark: true,
-      terminalFontSuggestions: [],
-      scrollbackMode: 'preset',
-      setScrollbackMode: () => {},
-      ghostty: ghosttyMock
-    })
-
-    const modal = findGhosttyImportModal(element)
-    expect(modal).not.toBeNull()
-    expect(modal?.props.open).toBe(ghosttyMock.open)
-    expect(modal?.props.preview).toEqual(ghosttyMock.preview)
-    expect(modal?.props.loading).toBe(ghosttyMock.loading)
-    expect(modal?.props.applied).toBe(ghosttyMock.applied)
-    expect(modal?.props.onApply).toBe(ghosttyMock.handleApply)
-    expect(modal?.props.onOpenChange).toBe(ghosttyMock.handleOpenChange)
+    expect(collectText(element)).toContain('PowerShell 7+ offers a newer PowerShell experience')
+    const link = findAnchorByText(element, 'Download PowerShell 7+')
+    expect(link).not.toBeNull()
+    expect(link?.props.href).toBe('https://github.com/PowerShell/PowerShell/releases/latest')
   })
 })

--- a/src/renderer/src/components/settings/TerminalPane.pwsh.test.ts
+++ b/src/renderer/src/components/settings/TerminalPane.pwsh.test.ts
@@ -206,7 +206,7 @@ describe('TerminalPane PowerShell version setting', () => {
       pwshAvailable: false
     })
 
-    expect(collectText(element)).toContain('PowerShell 7+ offers a newer PowerShell experience')
+    expect(collectText(element)).toContain('Auto uses Windows PowerShell now')
     const link = findAnchorByText(element, 'Download PowerShell 7+')
     expect(link).not.toBeNull()
     expect(link?.props.href).toBe('https://github.com/PowerShell/PowerShell/releases/latest')

--- a/src/renderer/src/components/settings/TerminalPane.tsx
+++ b/src/renderer/src/components/settings/TerminalPane.tsx
@@ -42,6 +42,7 @@ import {
   TERMINAL_SETUP_SCRIPT_SEARCH_ENTRIES,
   TERMINAL_TYPOGRAPHY_SEARCH_ENTRIES,
   TERMINAL_WINDOW_SEARCH_ENTRIES,
+  TERMINAL_WINDOWS_POWERSHELL_IMPLEMENTATION_SEARCH_ENTRY,
   TERMINAL_WINDOWS_SHELL_SEARCH_ENTRY
 } from './terminal-search'
 import { useDetectedOptionAsAlt } from '@/lib/keyboard-layout/use-effective-mac-option-as-alt'
@@ -64,6 +65,8 @@ type TerminalPaneProps = {
   ghostty: UseGhosttyImportReturn
   /** Whether WSL is installed on this Windows machine. */
   wslAvailable?: boolean
+  /** Whether PowerShell 7+ (pwsh.exe) is installed on this Windows machine. */
+  pwshAvailable?: boolean
 }
 
 export function TerminalPane({
@@ -74,7 +77,8 @@ export function TerminalPane({
   scrollbackMode,
   setScrollbackMode,
   ghostty,
-  wslAvailable
+  wslAvailable,
+  pwshAvailable
 }: TerminalPaneProps): React.JSX.Element {
   const searchQuery = useAppStore((state) => state.settingsSearchQuery)
   const isWindows = isWindowsUserAgent()
@@ -105,6 +109,10 @@ export function TerminalPane({
   )
   const scrollbackToggleValue =
     scrollbackMode === 'custom' ? 'custom' : isPreset ? `${scrollbackMb}` : 'custom'
+  const windowsShell = settings.terminalWindowsShell ?? 'powershell.exe'
+  const powerShellImplementation =
+    settings.terminalWindowsPowerShellImplementation ?? 'powershell.exe'
+  const showWindowsPowerShellImplementation = isWindows && windowsShell === 'powershell.exe'
 
   const visibleSections = [
     isWindows && matchesSettingsSearch(searchQuery, TERMINAL_WINDOWS_SHELL_SEARCH_ENTRY) ? (
@@ -134,7 +142,7 @@ export function TerminalPane({
                 key={value}
                 onClick={() => updateSettings({ terminalWindowsShell: value })}
                 className={`rounded-sm px-3 py-1 text-sm transition-colors ${
-                  (settings.terminalWindowsShell ?? 'powershell.exe') === value
+                  windowsShell === value
                     ? 'bg-accent font-medium text-accent-foreground'
                     : 'text-muted-foreground hover:text-foreground'
                 }`}
@@ -728,6 +736,11 @@ export function TerminalPane({
       </section>
     ) : null,
     matchesSettingsSearch(searchQuery, TERMINAL_ADVANCED_SEARCH_ENTRIES) ||
+    (showWindowsPowerShellImplementation &&
+      matchesSettingsSearch(
+        searchQuery,
+        TERMINAL_WINDOWS_POWERSHELL_IMPLEMENTATION_SEARCH_ENTRY
+      )) ||
     (isMac && matchesSettingsSearch(searchQuery, TERMINAL_MAC_OPTION_SEARCH_ENTRIES)) ? (
       <section key="advanced" className="space-y-4">
         <div className="space-y-1">
@@ -819,6 +832,74 @@ export function TerminalPane({
             Characters treated as word boundaries for double-click selection.
           </p>
         </SearchableSetting>
+        {showWindowsPowerShellImplementation &&
+        matchesSettingsSearch(
+          searchQuery,
+          TERMINAL_WINDOWS_POWERSHELL_IMPLEMENTATION_SEARCH_ENTRY
+        ) ? (
+          <SearchableSetting
+            title="PowerShell Version"
+            description="Choose whether the PowerShell shell option launches Windows PowerShell or PowerShell 7+ for new terminal panes."
+            keywords={[
+              'terminal',
+              'windows',
+              'powershell',
+              'pwsh',
+              'powershell 7',
+              'windows powershell',
+              'version',
+              'advanced'
+            ]}
+            className="space-y-2"
+          >
+            <Label>PowerShell Version</Label>
+            <div className="flex w-fit gap-1 rounded-md border border-border/50 p-1">
+              {[
+                { label: 'Windows PowerShell', value: 'powershell.exe' },
+                { label: 'PowerShell 7+', value: 'pwsh.exe', disabled: !pwshAvailable }
+              ].map(({ label, value, disabled }) => (
+                <button
+                  key={value}
+                  onClick={() => {
+                    if (disabled) {
+                      return
+                    }
+                    updateSettings({
+                      terminalWindowsPowerShellImplementation: value as
+                        | 'powershell.exe'
+                        | 'pwsh.exe'
+                    })
+                  }}
+                  aria-disabled={disabled ? 'true' : undefined}
+                  className={`rounded-sm px-3 py-1 text-sm transition-colors ${
+                    powerShellImplementation === value
+                      ? 'bg-accent font-medium text-accent-foreground'
+                      : disabled
+                        ? 'cursor-not-allowed text-muted-foreground/50'
+                        : 'text-muted-foreground hover:text-foreground'
+                  }`}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+            {!pwshAvailable ? (
+              <p className="text-xs text-muted-foreground">
+                PowerShell 7+ offers a newer PowerShell experience and requires a separate
+                installation.{' '}
+                <a
+                  href="https://github.com/PowerShell/PowerShell/releases/latest"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline hover:text-foreground"
+                >
+                  Download PowerShell 7+
+                </a>
+                .
+              </p>
+            ) : null}
+          </SearchableSetting>
+        ) : null}
         {isMac ? (
           <SearchableSetting
             title="Option as Alt"

--- a/src/renderer/src/components/settings/TerminalPane.tsx
+++ b/src/renderer/src/components/settings/TerminalPane.tsx
@@ -110,8 +110,7 @@ export function TerminalPane({
   const scrollbackToggleValue =
     scrollbackMode === 'custom' ? 'custom' : isPreset ? `${scrollbackMb}` : 'custom'
   const windowsShell = settings.terminalWindowsShell ?? 'powershell.exe'
-  const powerShellImplementation =
-    settings.terminalWindowsPowerShellImplementation ?? 'powershell.exe'
+  const powerShellImplementation = settings.terminalWindowsPowerShellImplementation ?? 'auto'
   const showWindowsPowerShellImplementation = isWindows && windowsShell === 'powershell.exe'
 
   const visibleSections = [
@@ -855,6 +854,7 @@ export function TerminalPane({
             <Label>PowerShell Version</Label>
             <div className="flex w-fit gap-1 rounded-md border border-border/50 p-1">
               {[
+                { label: 'Auto', value: 'auto' },
                 { label: 'Windows PowerShell', value: 'powershell.exe' },
                 { label: 'PowerShell 7+', value: 'pwsh.exe', disabled: !pwshAvailable }
               ].map(({ label, value, disabled }) => (
@@ -866,6 +866,7 @@ export function TerminalPane({
                     }
                     updateSettings({
                       terminalWindowsPowerShellImplementation: value as
+                        | 'auto'
                         | 'powershell.exe'
                         | 'pwsh.exe'
                     })
@@ -885,8 +886,7 @@ export function TerminalPane({
             </div>
             {!pwshAvailable ? (
               <p className="text-xs text-muted-foreground">
-                PowerShell 7+ offers a newer PowerShell experience and requires a separate
-                installation.{' '}
+                Auto uses Windows PowerShell now and switches to PowerShell 7+ when installed.{' '}
                 <a
                   href="https://github.com/PowerShell/PowerShell/releases/latest"
                   target="_blank"

--- a/src/renderer/src/components/settings/terminal-search.test.ts
+++ b/src/renderer/src/components/settings/terminal-search.test.ts
@@ -7,9 +7,19 @@ describe('getTerminalPaneSearchEntries', () => {
     expect(entries.some((entry) => entry.title === 'Right-click to paste')).toBe(true)
   })
 
+  it('includes the PowerShell version setting on Windows', () => {
+    const entries = getTerminalPaneSearchEntries({ isWindows: true, isMac: false })
+    expect(entries.some((entry) => entry.title === 'PowerShell Version')).toBe(true)
+  })
+
   it('omits the Windows right-click setting elsewhere', () => {
     const entries = getTerminalPaneSearchEntries({ isWindows: false, isMac: false })
     expect(entries.some((entry) => entry.title === 'Right-click to paste')).toBe(false)
+  })
+
+  it('omits the PowerShell version setting elsewhere', () => {
+    const entries = getTerminalPaneSearchEntries({ isWindows: false, isMac: false })
+    expect(entries.some((entry) => entry.title === 'PowerShell Version')).toBe(false)
   })
 
   it('includes the Option as Alt setting on macOS', () => {

--- a/src/renderer/src/components/settings/terminal-search.ts
+++ b/src/renderer/src/components/settings/terminal-search.ts
@@ -242,8 +242,27 @@ export const TERMINAL_WINDOWS_SHELL_SEARCH_ENTRY: SettingsSearchEntry[] = [
   }
 ]
 
+export const TERMINAL_WINDOWS_POWERSHELL_IMPLEMENTATION_SEARCH_ENTRY: SettingsSearchEntry[] = [
+  {
+    title: 'PowerShell Version',
+    description:
+      'Choose whether the PowerShell shell option launches Windows PowerShell or PowerShell 7+ for new terminal panes.',
+    keywords: [
+      'terminal',
+      'windows',
+      'powershell',
+      'windows powershell',
+      'powershell 7',
+      'pwsh',
+      'version',
+      'advanced'
+    ]
+  }
+]
+
 export const TERMINAL_WINDOWS_SEARCH_ENTRIES: SettingsSearchEntry[] = [
   ...TERMINAL_WINDOWS_SHELL_SEARCH_ENTRY,
+  ...TERMINAL_WINDOWS_POWERSHELL_IMPLEMENTATION_SEARCH_ENTRY,
   {
     title: 'Right-click to paste',
     description:

--- a/src/renderer/src/components/tab-bar/TabBar.tsx
+++ b/src/renderer/src/components/tab-bar/TabBar.tsx
@@ -24,6 +24,7 @@ import type { HoveredTabInsertion, TabDragItemData } from '../tab-group/useTabDr
 import { resolveTabIndicatorEdges } from '../tab-group/tab-insertion'
 import { getEditorDisplayLabel } from '@/components/editor/editor-labels'
 import { ShellIcon } from './shell-icons'
+import { resolveWindowsShellLaunchTarget } from './windows-shell-launch'
 import { focusTerminalTabSurface } from '@/lib/focus-terminal-tab-surface'
 import {
   DropdownMenu,
@@ -142,6 +143,9 @@ function TabBarInner({
   const gitStatusByWorktree = useAppStore((s) => s.gitStatusByWorktree)
   const defaultWindowsShell = useAppStore(
     (s) => s.settings?.terminalWindowsShell ?? 'powershell.exe'
+  )
+  const defaultWindowsPowerShellImplementation = useAppStore(
+    (s) => s.settings?.terminalWindowsPowerShellImplementation ?? 'powershell.exe'
   )
   const resolvedGroupId = groupId ?? worktreeId
   const statusByRelativePath = useMemo(
@@ -487,7 +491,17 @@ function TabBarInner({
                   <DropdownMenuItem
                     key={entry.shell}
                     onSelect={() => {
-                      onNewTerminalWithShell(entry.shell)
+                      // Why: the top-level Windows shell menu models shell
+                      // categories, not concrete executables. When the user
+                      // picked PowerShell 7+ in advanced settings, launching the
+                      // "PowerShell" menu item must preserve that implementation
+                      // instead of forcing inbox powershell.exe.
+                      onNewTerminalWithShell(
+                        resolveWindowsShellLaunchTarget(
+                          entry.shell,
+                          defaultWindowsPowerShellImplementation
+                        )
+                      )
                     }}
                     className="gap-2 rounded-[7px] px-2 py-1.5 text-[12px] leading-5 font-medium"
                   >

--- a/src/renderer/src/components/tab-bar/TabBar.tsx
+++ b/src/renderer/src/components/tab-bar/TabBar.tsx
@@ -145,8 +145,17 @@ function TabBarInner({
     (s) => s.settings?.terminalWindowsShell ?? 'powershell.exe'
   )
   const defaultWindowsPowerShellImplementation = useAppStore(
-    (s) => s.settings?.terminalWindowsPowerShellImplementation ?? 'powershell.exe'
+    (s) => s.settings?.terminalWindowsPowerShellImplementation ?? 'auto'
   )
+  const [pwshAvailable, setPwshAvailable] = useState(false)
+  useEffect(() => {
+    if (!isWindows) {
+      setPwshAvailable(false)
+      return
+    }
+
+    void window.api.pwsh.isAvailable().then(setPwshAvailable)
+  }, [])
   const resolvedGroupId = groupId ?? worktreeId
   const statusByRelativePath = useMemo(
     () => buildStatusMap(gitStatusByWorktree[worktreeId] ?? []),
@@ -474,10 +483,13 @@ function TabBarInner({
             // each row narrow enough that the shortcut hint fits without
             // wrapping.
             (() => {
-              const allShells = [
+              const allShells: {
+                label: string
+                shell: 'powershell.exe' | 'cmd.exe' | 'wsl.exe'
+              }[] = [
                 { label: 'PowerShell', shell: 'powershell.exe' },
                 { label: 'CMD Prompt', shell: 'cmd.exe' },
-                ...(wslAvailable ? [{ label: 'WSL', shell: 'wsl.exe' }] : [])
+                ...(wslAvailable ? ([{ label: 'WSL', shell: 'wsl.exe' }] as const) : [])
               ]
               const defaultEntry =
                 allShells.find((s) => s.shell === defaultWindowsShell) ?? allShells[0]
@@ -499,7 +511,8 @@ function TabBarInner({
                       onNewTerminalWithShell(
                         resolveWindowsShellLaunchTarget(
                           entry.shell,
-                          defaultWindowsPowerShellImplementation
+                          defaultWindowsPowerShellImplementation,
+                          pwshAvailable
                         )
                       )
                     }}

--- a/src/renderer/src/components/tab-bar/TabBar.windows-shell-launch.test.ts
+++ b/src/renderer/src/components/tab-bar/TabBar.windows-shell-launch.test.ts
@@ -1,0 +1,241 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const useAppStoreMock = vi.fn(
+  (
+    selector: (state: {
+      gitStatusByWorktree: Record<string, never[]>
+      settings: {
+        terminalWindowsShell: 'powershell.exe' | 'cmd.exe' | 'wsl.exe'
+        terminalWindowsPowerShellImplementation: 'powershell.exe' | 'pwsh.exe'
+      }
+    }) => unknown
+  ) =>
+    selector({
+      gitStatusByWorktree: {},
+      settings: {
+        terminalWindowsShell: 'powershell.exe',
+        terminalWindowsPowerShellImplementation: 'pwsh.exe'
+      }
+    })
+)
+
+vi.mock('react', async () => {
+  const actual = await vi.importActual<typeof import('react')>('react') // eslint-disable-line @typescript-eslint/consistent-type-imports -- vi.importActual requires inline import()
+  return {
+    ...actual,
+    memo: <T>(component: T) => component,
+    useEffect: () => {},
+    useLayoutEffect: () => {},
+    useMemo: <T>(factory: () => T) => factory(),
+    useRef: <T>(current: T) => ({ current }),
+    useState: <T>(initial: T) => [initial, vi.fn()] as const
+  }
+})
+
+vi.mock('lucide-react', () => ({
+  FilePlus: function FilePlus() {
+    return null
+  },
+  Globe: function Globe() {
+    return null
+  },
+  Plus: function Plus() {
+    return null
+  },
+  TerminalSquare: function TerminalSquare() {
+    return null
+  }
+}))
+
+vi.mock('@dnd-kit/sortable', () => ({
+  SortableContext: function SortableContext(props: { children?: unknown }) {
+    return props.children
+  }
+}))
+
+vi.mock('../../store', () => ({
+  useAppStore: (selector: Parameters<typeof useAppStoreMock>[0]) => useAppStoreMock(selector)
+}))
+
+vi.mock('../right-sidebar/status-display', () => ({
+  buildStatusMap: () => new Map()
+}))
+
+vi.mock('../tab-group/tab-insertion', () => ({
+  resolveTabIndicatorEdges: () => []
+}))
+
+vi.mock('@/components/editor/editor-labels', () => ({
+  getEditorDisplayLabel: () => ''
+}))
+
+vi.mock('./SortableTab', () => ({
+  default: function SortableTab() {
+    return null
+  }
+}))
+
+vi.mock('./EditorFileTab', () => ({
+  default: function EditorFileTab() {
+    return null
+  }
+}))
+
+vi.mock('./BrowserTab', () => ({
+  default: function BrowserTab() {
+    return null
+  },
+  getBrowserTabLabel: () => ''
+}))
+
+vi.mock('./QuickLaunchButton', () => ({
+  QuickLaunchAgentMenuItems: function QuickLaunchAgentMenuItems() {
+    return null
+  }
+}))
+
+vi.mock('./shell-icons', () => ({
+  ShellIcon: function ShellIcon() {
+    return null
+  }
+}))
+
+vi.mock('@/lib/focus-terminal-tab-surface', () => ({
+  focusTerminalTabSurface: vi.fn()
+}))
+
+vi.mock('@/components/ui/dropdown-menu', () => ({
+  DropdownMenu: function DropdownMenu(props: { children?: unknown }) {
+    return { type: 'DropdownMenu', props }
+  },
+  DropdownMenuContent: function DropdownMenuContent(props: { children?: unknown }) {
+    return { type: 'DropdownMenuContent', props }
+  },
+  DropdownMenuItem: function DropdownMenuItem(props: {
+    children?: unknown
+    onSelect?: () => void
+  }) {
+    return { type: 'DropdownMenuItem', props }
+  },
+  DropdownMenuShortcut: function DropdownMenuShortcut(props: { children?: unknown }) {
+    return { type: 'DropdownMenuShortcut', props }
+  },
+  DropdownMenuTrigger: function DropdownMenuTrigger(props: { children?: unknown }) {
+    return { type: 'DropdownMenuTrigger', props }
+  }
+}))
+
+type ReactElementLike = {
+  type: unknown
+  props: Record<string, unknown>
+}
+
+function collectText(node: unknown): string {
+  if (node == null) {
+    return ''
+  }
+  if (typeof node === 'string') {
+    return node
+  }
+  if (typeof node === 'number') {
+    return String(node)
+  }
+  if (Array.isArray(node)) {
+    return node.map(collectText).join('')
+  }
+  const el = node as ReactElementLike
+  return collectText(el.props?.children)
+}
+
+function expandNode(node: unknown): unknown {
+  if (node == null || typeof node === 'string' || typeof node === 'number') {
+    return node
+  }
+  if (Array.isArray(node)) {
+    return node.map(expandNode)
+  }
+  const el = node as ReactElementLike
+  if (typeof el.type === 'function') {
+    return expandNode(el.type(el.props))
+  }
+  return {
+    ...el,
+    props: {
+      ...el.props,
+      children: expandNode(el.props?.children)
+    }
+  }
+}
+
+function findDropdownMenuItemByText(node: unknown, text: string): ReactElementLike | null {
+  if (node == null) {
+    return null
+  }
+  if (Array.isArray(node)) {
+    for (const child of node) {
+      const found = findDropdownMenuItemByText(child, text)
+      if (found) {
+        return found
+      }
+    }
+    return null
+  }
+  if (typeof node === 'string' || typeof node === 'number') {
+    return null
+  }
+  const el = node as ReactElementLike
+  if (el.type === 'DropdownMenuItem' && collectText(el.props.children).includes(text)) {
+    return el
+  }
+  return findDropdownMenuItemByText(el.props?.children, text)
+}
+
+describe('TabBar PowerShell launch wiring', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+    vi.stubGlobal('navigator', { userAgent: 'Windows' })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('passes pwsh.exe when the PowerShell menu item uses the PowerShell 7+ implementation', async () => {
+    const tabBarModule = await import('./TabBar')
+    const candidate = tabBarModule.default ?? tabBarModule
+    const TabBar =
+      typeof candidate === 'function'
+        ? candidate
+        : typeof (candidate as { type?: unknown }).type === 'function'
+          ? (candidate as { type: (props: Record<string, unknown>) => unknown }).type
+          : null
+    expect(TabBar).not.toBeNull()
+
+    const onNewTerminalWithShell = vi.fn()
+    const element = TabBar!({
+      tabs: [],
+      activeTabId: null,
+      worktreeId: 'wt-1',
+      expandedPaneByTabId: {},
+      onActivate: () => {},
+      onClose: () => {},
+      onCloseOthers: () => {},
+      onCloseToRight: () => {},
+      onNewTerminalTab: () => {},
+      onNewTerminalWithShell,
+      onNewBrowserTab: () => {},
+      onSetCustomTitle: () => {},
+      onSetTabColor: () => {},
+      onTogglePaneExpand: () => {},
+      wslAvailable: false
+    })
+
+    const item = findDropdownMenuItemByText(expandNode(element), 'New Terminal: PowerShell')
+    expect(item).not.toBeNull()
+
+    item?.props.onSelect?.()
+
+    expect(onNewTerminalWithShell).toHaveBeenCalledWith('pwsh.exe')
+  })
+})

--- a/src/renderer/src/components/tab-bar/TabBar.windows-shell-launch.test.ts
+++ b/src/renderer/src/components/tab-bar/TabBar.windows-shell-launch.test.ts
@@ -6,7 +6,7 @@ const useAppStoreMock = vi.fn(
       gitStatusByWorktree: Record<string, never[]>
       settings: {
         terminalWindowsShell: 'powershell.exe' | 'cmd.exe' | 'wsl.exe'
-        terminalWindowsPowerShellImplementation: 'powershell.exe' | 'pwsh.exe'
+        terminalWindowsPowerShellImplementation: 'auto' | 'powershell.exe' | 'pwsh.exe'
       }
     }) => unknown
   ) =>
@@ -234,7 +234,8 @@ describe('TabBar PowerShell launch wiring', () => {
     const item = findDropdownMenuItemByText(expandNode(element), 'New Terminal: PowerShell')
     expect(item).not.toBeNull()
 
-    item?.props.onSelect?.()
+    const onSelect = item?.props.onSelect as (() => void) | undefined
+    onSelect?.()
 
     expect(onNewTerminalWithShell).toHaveBeenCalledWith('pwsh.exe')
   })

--- a/src/renderer/src/components/tab-bar/windows-shell-launch.test.ts
+++ b/src/renderer/src/components/tab-bar/windows-shell-launch.test.ts
@@ -2,18 +2,26 @@ import { describe, expect, it } from 'vitest'
 import { resolveWindowsShellLaunchTarget } from './windows-shell-launch'
 
 describe('resolveWindowsShellLaunchTarget', () => {
+  it('uses PowerShell 7+ for Auto when pwsh is available', () => {
+    expect(resolveWindowsShellLaunchTarget('powershell.exe', 'auto', true)).toBe('pwsh.exe')
+  })
+
+  it('uses Windows PowerShell for Auto when pwsh is unavailable', () => {
+    expect(resolveWindowsShellLaunchTarget('powershell.exe', 'auto', false)).toBe('powershell.exe')
+  })
+
   it('uses the configured PowerShell implementation for the PowerShell menu item', () => {
-    expect(resolveWindowsShellLaunchTarget('powershell.exe', 'pwsh.exe')).toBe('pwsh.exe')
+    expect(resolveWindowsShellLaunchTarget('powershell.exe', 'pwsh.exe', false)).toBe('pwsh.exe')
   })
 
   it('keeps Windows PowerShell when that implementation remains selected', () => {
-    expect(resolveWindowsShellLaunchTarget('powershell.exe', 'powershell.exe')).toBe(
+    expect(resolveWindowsShellLaunchTarget('powershell.exe', 'powershell.exe', true)).toBe(
       'powershell.exe'
     )
   })
 
   it('passes through non-PowerShell shells unchanged', () => {
-    expect(resolveWindowsShellLaunchTarget('cmd.exe', 'pwsh.exe')).toBe('cmd.exe')
-    expect(resolveWindowsShellLaunchTarget('wsl.exe', 'pwsh.exe')).toBe('wsl.exe')
+    expect(resolveWindowsShellLaunchTarget('cmd.exe', 'auto', true)).toBe('cmd.exe')
+    expect(resolveWindowsShellLaunchTarget('wsl.exe', 'auto', true)).toBe('wsl.exe')
   })
 })

--- a/src/renderer/src/components/tab-bar/windows-shell-launch.test.ts
+++ b/src/renderer/src/components/tab-bar/windows-shell-launch.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { resolveWindowsShellLaunchTarget } from './windows-shell-launch'
+
+describe('resolveWindowsShellLaunchTarget', () => {
+  it('uses the configured PowerShell implementation for the PowerShell menu item', () => {
+    expect(resolveWindowsShellLaunchTarget('powershell.exe', 'pwsh.exe')).toBe('pwsh.exe')
+  })
+
+  it('keeps Windows PowerShell when that implementation remains selected', () => {
+    expect(resolveWindowsShellLaunchTarget('powershell.exe', 'powershell.exe')).toBe(
+      'powershell.exe'
+    )
+  })
+
+  it('passes through non-PowerShell shells unchanged', () => {
+    expect(resolveWindowsShellLaunchTarget('cmd.exe', 'pwsh.exe')).toBe('cmd.exe')
+    expect(resolveWindowsShellLaunchTarget('wsl.exe', 'pwsh.exe')).toBe('wsl.exe')
+  })
+})

--- a/src/renderer/src/components/tab-bar/windows-shell-launch.ts
+++ b/src/renderer/src/components/tab-bar/windows-shell-launch.ts
@@ -1,0 +1,10 @@
+export function resolveWindowsShellLaunchTarget(
+  shell: 'powershell.exe' | 'cmd.exe' | 'wsl.exe',
+  powerShellImplementation: 'powershell.exe' | 'pwsh.exe'
+): string {
+  if (shell !== 'powershell.exe') {
+    return shell
+  }
+
+  return powerShellImplementation
+}

--- a/src/renderer/src/components/tab-bar/windows-shell-launch.ts
+++ b/src/renderer/src/components/tab-bar/windows-shell-launch.ts
@@ -1,9 +1,14 @@
 export function resolveWindowsShellLaunchTarget(
   shell: 'powershell.exe' | 'cmd.exe' | 'wsl.exe',
-  powerShellImplementation: 'powershell.exe' | 'pwsh.exe'
+  powerShellImplementation: 'auto' | 'powershell.exe' | 'pwsh.exe',
+  pwshAvailable: boolean
 ): string {
   if (shell !== 'powershell.exe') {
     return shell
+  }
+
+  if (powerShellImplementation === 'auto') {
+    return pwshAvailable ? 'pwsh.exe' : 'powershell.exe'
   }
 
   return powerShellImplementation

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -146,9 +146,9 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     // and Ctrl+right-click still opens the context menu when paste is enabled.
     terminalRightClickToPaste: true,
     terminalWindowsShell: 'powershell.exe',
-    // Why: PowerShell 7 is optional on Windows, so the inbox shell stays the
-    // default unless the user explicitly opts into the newer implementation.
-    terminalWindowsPowerShellImplementation: 'powershell.exe',
+    // Why: Windows users expect "PowerShell" to mean modern PowerShell when it
+    // is installed, with a safe fallback to the inbox Windows PowerShell.
+    terminalWindowsPowerShellImplementation: 'auto',
     terminalMouseHideWhileTyping: false,
     // Default false: opt-in only (matches Ghostty's default). Existing users
     // on upgrade inherit this default via persistence.ts's

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -146,6 +146,9 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     // and Ctrl+right-click still opens the context menu when paste is enabled.
     terminalRightClickToPaste: true,
     terminalWindowsShell: 'powershell.exe',
+    // Why: PowerShell 7 is optional on Windows, so the inbox shell stays the
+    // default unless the user explicitly opts into the newer implementation.
+    terminalWindowsPowerShellImplementation: 'powershell.exe',
     terminalMouseHideWhileTyping: false,
     // Default false: opt-in only (matches Ghostty's default). Existing users
     // on upgrade inherit this default via persistence.ts's

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -955,6 +955,9 @@ export type GlobalSettings = {
    *  user's preferred shell. Defaults to 'powershell.exe' which is the
    *  modern choice for an IDE context. Only consulted on Windows. */
   terminalWindowsShell: string
+  /** Why: PowerShell 7 is optional on Windows, so the inbox shell stays the
+   *  default unless the user explicitly opts into the newer implementation. */
+  terminalWindowsPowerShellImplementation: 'powershell.exe' | 'pwsh.exe'
   terminalFocusFollowsMouse: boolean
   /** Why: mirrors X11 / gnome-terminal "copy on select" UX — making a terminal
    *  selection copies it to the system clipboard automatically, so users can

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -955,9 +955,9 @@ export type GlobalSettings = {
    *  user's preferred shell. Defaults to 'powershell.exe' which is the
    *  modern choice for an IDE context. Only consulted on Windows. */
   terminalWindowsShell: string
-  /** Why: PowerShell 7 is optional on Windows, so the inbox shell stays the
-   *  default unless the user explicitly opts into the newer implementation. */
-  terminalWindowsPowerShellImplementation: 'powershell.exe' | 'pwsh.exe'
+  /** Why: "PowerShell" is the product-facing shell family. Auto resolves to
+   *  PowerShell 7+ when present and falls back to inbox Windows PowerShell. */
+  terminalWindowsPowerShellImplementation: 'auto' | 'powershell.exe' | 'pwsh.exe'
   terminalFocusFollowsMouse: boolean
   /** Why: mirrors X11 / gnome-terminal "copy on select" UX — making a terminal
    *  selection copies it to the system clipboard automatically, so users can


### PR DESCRIPTION
## Summary

This PR adds support for using **PowerShell 7+** for Windows terminals in Orca.

It adds:
- a setting to switch between **Windows PowerShell** and **PowerShell 7+**
- detection for whether `pwsh.exe` is available
- guidance in settings when PowerShell 7+ is not installed, with a link to https://github.com/PowerShell/PowerShell/releases/latest
- consistent terminal launching so all major entry points respect the selected PowerShell implementation
- also includes a follow-up consistency fix for the tab bar launch path

## Screenshots

- Screenshot 1: guidance shown when PowerShell 7+ is not installed
<img width="1459" height="851" alt="Snipaste_2026-05-02_09-10-17" src="https://github.com/user-attachments/assets/60b52667-3e99-4c64-bb97-d981abf8a73b" />


- Screenshot 2: PowerShell implementation switch under **Appearance**
<img width="1459" height="851" alt="Snipaste_2026-05-02_11-18-34" src="https://github.com/user-attachments/assets/c6f3b242-74c5-44be-8404-cc684b351216" />


## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not      
needed

Verified working from:
- the default terminal opened from a Workspace
- the new tab flow
- `Ctrl+T`

## AI Review Report

Reviewed the Windows shell-selection flow end to end, including settings, renderer launch paths, IPC, and    
daemon/local PTY spawning.

The main issue identified was that the tab bar new-terminal path could bypass the configured PowerShell      
implementation and still launch `powershell.exe`. That path was updated so all tested terminal entry points  
now behave consistently.

Cross-platform compatibility was also reviewed:
- Windows-specific PowerShell behavior was validated directly
- macOS/Linux behavior remains unchanged because the new logic only applies to the Windows PowerShell path   
- Electron preload and IPC threading were checked for platform-specific regressions

## Security Audit

Reviewed settings input handling, shell/executable selection, and IPC threading for terminal launch.

No new arbitrary command execution path was introduced. The change only switches between known PowerShell    
implementations and keeps fallback behavior constrained to expected Windows shell executables.

## Notes

This is a Windows-focused feature PR that also includes a follow-up consistency fix for the tab bar terminal 
launch path.
