### PR TITLE
feat(sidebar): add Search button to nav, restore task-provider icons

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -2,7 +2,7 @@
 import { lazy, Suspense, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { DEFAULT_STATUS_BAR_ITEMS, DEFAULT_WORKTREE_CARD_PROPERTIES } from '../../shared/constants'
 
-import { ArrowLeft, ArrowRight, Minimize2, PanelLeft, PanelRight, Search } from 'lucide-react'
+import { ArrowLeft, ArrowRight, Minimize2, PanelLeft, PanelRight } from 'lucide-react'
 import {
   FOCUS_TERMINAL_PANE_EVENT,
   SYNC_FIT_PANES_EVENT,
@@ -869,27 +869,6 @@ function App(): React.JSX.Element {
             </PopoverContent>
           </Popover>
         ) : null}
-        {/* Why: always rendered (not gated on showSidebar) because the
-            worktree palette is global — it mirrors the ⌘J/Ctrl+Shift+J
-            shortcut which is live from every view including Settings and
-            Landing. The `sidebar-toggle` class is the shared titlebar
-            icon-button style used by back/forward/sidebar-toggle/right-
-            sidebar neighbors; the name is historical and applies to any
-            titlebar icon button, not only sidebar toggles. */}
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              className="sidebar-toggle"
-              onClick={() => actions.openModal('worktree-palette')}
-              aria-label="Search worktrees and browser tabs"
-            >
-              <Search size={14} />
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="bottom" sideOffset={6}>
-            {`Search (${isMac ? '⌘J' : 'Ctrl+Shift+J'})`}
-          </TooltipContent>
-        </Tooltip>
       </div>
       {/* Why: Back/Forward traverse mixed worktree + Tasks history, so the
           cluster is shown wherever the history shortcut is live (terminal or

--- a/src/renderer/src/components/sidebar/SidebarNav.tsx
+++ b/src/renderer/src/components/sidebar/SidebarNav.tsx
@@ -1,13 +1,24 @@
 import React from 'react'
-import { List } from 'lucide-react'
+import { Github, List, Search } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { useRepoMap } from '@/store/selectors'
 import { cn } from '@/lib/utils'
 import { isGitRepoKind } from '../../../../shared/repo-kind'
 import { getTaskPresetQuery, PER_REPO_FETCH_LIMIT } from '@/lib/new-workspace'
 
+const isMac = typeof navigator !== 'undefined' && navigator.userAgent.includes('Mac')
+
+function LinearIcon({ className }: { className?: string }): React.JSX.Element {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden className={className} fill="currentColor">
+      <path d="M2.886 4.18A11.982 11.982 0 0 1 11.99 0C18.624 0 24 5.376 24 12.009c0 3.64-1.62 6.903-4.18 9.105L2.887 4.18ZM1.817 5.626l16.556 16.556c-.524.33-1.075.62-1.65.866L.951 7.277c.247-.575.537-1.126.866-1.65ZM.322 9.163l14.515 14.515c-.71.172-1.443.282-2.195.322L0 11.358a12 12 0 0 1 .322-2.195Zm-.17 4.862 9.823 9.824a12.02 12.02 0 0 1-9.824-9.824Z" />
+    </svg>
+  )
+}
+
 const SidebarNav = React.memo(function SidebarNav() {
   const openTaskPage = useAppStore((s) => s.openTaskPage)
+  const openModal = useAppStore((s) => s.openModal)
   const activeView = useAppStore((s) => s.activeView)
   const repos = useAppStore((s) => s.repos)
   const repoMap = useRepoMap()
@@ -45,34 +56,74 @@ const SidebarNav = React.memo(function SidebarNav() {
 
   const tasksActive = activeView === 'tasks'
 
-  if (!showTasksButton) {
-    return null
-  }
-
   return (
     <div className="flex flex-col gap-0.5 px-2 pt-2 pb-1">
+      {showTasksButton ? (
+        <button
+          type="button"
+          onClick={() => {
+            if (!canBrowseTasks) {
+              return
+            }
+            openTaskPage()
+          }}
+          onPointerEnter={handlePrefetch}
+          onFocus={handlePrefetch}
+          disabled={!canBrowseTasks}
+          aria-current={tasksActive ? 'page' : undefined}
+          className={cn(
+            'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] font-medium tracking-tight transition-colors',
+            tasksActive
+              ? 'bg-sidebar-accent text-sidebar-accent-foreground'
+              : 'text-sidebar-foreground hover:bg-sidebar-accent/60 hover:text-sidebar-accent-foreground',
+            !canBrowseTasks && 'cursor-not-allowed opacity-50 hover:bg-transparent'
+          )}
+        >
+          <List className="size-4 shrink-0" strokeWidth={2.25} />
+          <span className="flex-1">Tasks</span>
+          <span className="flex items-center gap-1">
+            <span
+              role="button"
+              tabIndex={-1}
+              onClick={(e) => {
+                e.stopPropagation()
+                if (!canBrowseTasks) {
+                  return
+                }
+                openTaskPage({ taskSource: 'github' })
+              }}
+              className="rounded p-0.5 text-muted-foreground/70 transition-colors hover:text-foreground"
+            >
+              <Github className="size-3.5" aria-hidden />
+            </span>
+            <span
+              role="button"
+              tabIndex={-1}
+              onClick={(e) => {
+                e.stopPropagation()
+                if (!canBrowseTasks) {
+                  return
+                }
+                openTaskPage({ taskSource: 'linear' })
+              }}
+              className="rounded p-0.5 text-muted-foreground/70 transition-colors hover:text-foreground"
+            >
+              <LinearIcon className="size-3.5" />
+            </span>
+          </span>
+        </button>
+      ) : null}
       <button
         type="button"
-        onClick={() => {
-          if (!canBrowseTasks) {
-            return
-          }
-          openTaskPage()
-        }}
-        onPointerEnter={handlePrefetch}
-        onFocus={handlePrefetch}
-        disabled={!canBrowseTasks}
-        aria-current={tasksActive ? 'page' : undefined}
-        className={cn(
-          'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] font-medium tracking-tight transition-colors',
-          tasksActive
-            ? 'bg-sidebar-accent text-sidebar-accent-foreground'
-            : 'text-sidebar-foreground hover:bg-sidebar-accent/60 hover:text-sidebar-accent-foreground',
-          !canBrowseTasks && 'cursor-not-allowed opacity-50 hover:bg-transparent'
-        )}
+        onClick={() => openModal('worktree-palette')}
+        aria-label="Search worktrees and browser tabs"
+        className="group flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] font-medium tracking-tight text-sidebar-foreground transition-colors hover:bg-sidebar-accent/60 hover:text-sidebar-accent-foreground"
       >
-        <List className="size-4 shrink-0" strokeWidth={2.25} />
-        <span className="flex-1">Tasks</span>
+        <Search className="size-4 shrink-0" strokeWidth={2.25} />
+        <span className="flex-1">Search</span>
+        <kbd className="hidden rounded border border-border/60 bg-background/40 px-1.5 py-px font-mono text-[10px] font-medium text-muted-foreground group-hover:inline-flex items-center">
+          {isMac ? '⌘J' : 'Ctrl+Shift+J'}
+        </kbd>
       </button>
     </div>
   )


### PR DESCRIPTION
## Summary
- Move the worktree/browser-tab search entry out of the titlebar into a full-width **Search** button in the sidebar nav below Tasks — magnifying glass on the left, `⌘J` / `Ctrl+Shift+J` kbd chip shown on hover on the right.
- Restore the GitHub + Linear quick-launch icons on the **Tasks** button (removed in #1271) so users can jump straight into a provider-scoped task list.

## Test plan
- [ ] Sidebar nav shows Tasks with GitHub + Linear icons, and Search directly below
- [ ] Hovering Search swaps the magnifying glass for the shortcut chip (`⌘J` on macOS, `Ctrl+Shift+J` elsewhere)
- [ ] Clicking Search opens the worktree palette; shortcut still works globally
- [ ] Clicking GitHub / Linear icons on the Tasks button opens the Tasks page scoped to that provider without also triggering the parent Tasks click
- [ ] Titlebar no longer has a standalone Search icon button

Made with [Orca](https://github.com/stablyai/orca) 🐋
