### PR TITLE
revert(sidebar): restore unread bell, keep bold-title treatment

### DIFF
--- a/src/renderer/src/components/sidebar/SidebarHeader.tsx
+++ b/src/renderer/src/components/sidebar/SidebarHeader.tsx
@@ -26,7 +26,7 @@ const GROUP_BY_OPTIONS = [
 
 const PROPERTY_OPTIONS: { id: WorktreeCardProperty; label: string }[] = [
   { id: 'status', label: 'Terminal status' },
-  { id: 'unread', label: 'Bold unread workspaces' },
+  { id: 'unread', label: 'Unread indicator' },
   { id: 'ci', label: 'CI checks' },
   { id: 'issue', label: 'Linked issue' },
   { id: 'pr', label: 'Linked PR' },

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -4,7 +4,7 @@ import { useShallow } from 'zustand/react/shallow'
 import { useAppStore } from '@/store'
 import { Badge } from '@/components/ui/badge'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
-import { GitMerge, LoaderCircle, CircleCheck, CircleX, Server, ServerOff } from 'lucide-react'
+import { Bell, GitMerge, LoaderCircle, CircleCheck, CircleX, Server, ServerOff } from 'lucide-react'
 import StatusIndicator from './StatusIndicator'
 import CacheTimer from './CacheTimer'
 import WorktreeContextMenu from './WorktreeContextMenu'
@@ -26,7 +26,8 @@ import {
   checksLabel,
   CONFLICT_OPERATION_LABELS,
   EMPTY_TABS,
-  EMPTY_BROWSER_TABS
+  EMPTY_BROWSER_TABS,
+  FilledBellIcon
 } from './WorktreeCardHelpers'
 import { IssueSection, PrSection, CommentSection } from './WorktreeCardMeta'
 
@@ -52,6 +53,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
   hintNumber
 }: WorktreeCardProps) {
   const openModal = useAppStore((s) => s.openModal)
+  const updateWorktreeMeta = useAppStore((s) => s.updateWorktreeMeta)
   const fetchPRForBranch = useAppStore((s) => s.fetchPRForBranch)
   const fetchIssue = useAppStore((s) => s.fetchIssue)
   const cardProps = useAppStore((s) => s.worktreeCardProperties)
@@ -315,10 +317,20 @@ const WorktreeCard = React.memo(function WorktreeCard({
     })
   }, [worktree.id, worktree.displayName, worktree.linkedIssue, worktree.comment, openModal])
 
+  const handleToggleUnreadQuick = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      event.preventDefault()
+      event.stopPropagation()
+      updateWorktreeMeta(worktree.id, { isUnread: !worktree.isUnread })
+    },
+    [worktree.id, worktree.isUnread, updateWorktreeMeta]
+  )
+
+  const unreadTooltip = worktree.isUnread ? 'Mark read' : 'Mark unread'
+
   // Why: the 'unread' card property is the user's opt-out. When off, we render
-  // as if the workspace is read so bold emphasis never appears — matching the
-  // old "hide the bell" behavior exactly. The persisted `worktree.isUnread`
-  // flag is unchanged; only the rendering changes.
+  // as if the workspace is read so bold emphasis never appears. The persisted
+  // `worktree.isUnread` flag is unchanged; only the rendering changes.
   const showUnreadEmphasis = cardProps.includes('unread') && worktree.isUnread
 
   const cardBody = (
@@ -360,14 +372,41 @@ const WorktreeCard = React.memo(function WorktreeCard({
         </div>
       )}
 
-      {/* Status indicator on the left.
-           Why: bold-for-unread carries the attention signal in the title row
-           now, so the rail only needs to render when the status dot is
-           enabled — the 'unread' property is intentionally excluded here. */}
-      {cardProps.includes('status') && (
-        <div className="flex items-center justify-start pt-[2px] shrink-0">
-          <StatusIndicator status={status} aria-hidden="true" />
-          <span className="sr-only">{getWorktreeStatusLabel(status)}</span>
+      {/* Status indicator on the left */}
+      {(cardProps.includes('status') || cardProps.includes('unread')) && (
+        <div className="flex flex-col items-center justify-start pt-[2px] gap-2 shrink-0">
+          {cardProps.includes('status') && (
+            <>
+              <StatusIndicator status={status} aria-hidden="true" />
+              <span className="sr-only">{getWorktreeStatusLabel(status)}</span>
+            </>
+          )}
+
+          {cardProps.includes('unread') && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={handleToggleUnreadQuick}
+                  className={cn(
+                    'group/unread flex size-4 cursor-pointer items-center justify-center rounded transition-all',
+                    'hover:bg-accent/80 active:scale-95',
+                    'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring'
+                  )}
+                  aria-label={worktree.isUnread ? 'Mark as read' : 'Mark as unread'}
+                >
+                  {worktree.isUnread ? (
+                    <FilledBellIcon className="size-[13px] text-amber-500 drop-shadow-sm" />
+                  ) : (
+                    <Bell className="size-3 text-muted-foreground/40 opacity-0 group-hover:opacity-100 group-hover/unread:opacity-100 transition-opacity" />
+                  )}
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="right" sideOffset={8}>
+                <span>{unreadTooltip}</span>
+              </TooltipContent>
+            </Tooltip>
+          )}
         </div>
       )}
 
@@ -485,17 +524,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
           {repo && !hideRepoBadge && (
             <div className="flex items-center gap-1.5 shrink-0 px-1.5 py-0.5 rounded-[4px] bg-accent border border-border dark:bg-accent/50 dark:border-border/60">
               <div className="size-1.5 rounded-full" style={{ backgroundColor: repo.badgeColor }} />
-              {/* Why: repo label tracks the title's weight. Keeps
-                   text-foreground on the read state (not muted) because this
-                   label sits on a tinted bg-accent chip — muting it would leave
-                   it nearly invisible; the weight change alone restores
-                   hierarchy against the title. */}
-              <span
-                className={cn(
-                  'text-[10px] truncate max-w-[6rem] leading-none lowercase text-foreground',
-                  showUnreadEmphasis ? 'font-semibold' : 'font-normal'
-                )}
-              >
+              <span className="text-[10px] font-semibold text-foreground truncate max-w-[6rem] leading-none lowercase">
                 {repo.displayName}
               </span>
             </div>

--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
@@ -10,6 +10,8 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import {
   FolderOpen,
   Copy,
+  Bell,
+  BellOff,
   Link,
   MessageSquare,
   Moon,
@@ -61,6 +63,10 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
   const handleCopyPath = useCallback(() => {
     window.api.ui.writeClipboardText(worktree.path)
   }, [worktree.path])
+
+  const handleToggleRead = useCallback(() => {
+    updateWorktreeMeta(worktree.id, { isUnread: !worktree.isUnread })
+  }, [worktree.id, worktree.isUnread, updateWorktreeMeta])
 
   const handleTogglePin = useCallback(() => {
     updateWorktreeMeta(worktree.id, { isPinned: !worktree.isPinned })
@@ -162,6 +168,10 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
           <DropdownMenuItem onSelect={handleRename} disabled={isDeleting}>
             <Pencil className="size-3.5" />
             Rename
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={handleToggleRead} disabled={isDeleting}>
+            {worktree.isUnread ? <BellOff className="size-3.5" /> : <Bell className="size-3.5" />}
+            {worktree.isUnread ? 'Mark Read' : 'Mark Unread'}
           </DropdownMenuItem>
           <DropdownMenuItem onSelect={handleLinkIssue} disabled={isDeleting}>
             <Link className="size-3.5" />

--- a/src/renderer/src/components/tab-bar/SortableTab.tsx
+++ b/src/renderer/src/components/tab-bar/SortableTab.tsx
@@ -259,10 +259,9 @@ export default function SortableTab({
           )}
           {showActivityAffordance ? (
             // Why: the activity marker sits to the LEFT of the tab title using
-            // Orca's filled bell glyph (amber-500 with a subtle drop shadow).
-            // The sidebar WorktreeCard used to render the same bell; it now
-            // uses a bold-title treatment. The tab bar keeps the bell for
-            // now — aligning the two surfaces is a deliberate follow-up.
+            // Orca's filled bell glyph (amber-500 with a subtle drop shadow)
+            // so it matches the worktree-level bell in the sidebar — keeping
+            // every "needs your attention" surface in Orca consistent.
             <span data-testid="tab-activity-bell" className="inline-flex shrink-0">
               <FilledBellIcon className="w-3 h-3 mr-1 text-amber-500 drop-shadow-sm" />
             </span>


### PR DESCRIPTION
## Summary
- Reverts #1330, bringing back the clickable bell affordance in the sidebar left rail and the Mark Read / Mark Unread context-menu entry.
- Keeps the bold-on-unread title weight from #1330 so unread workspaces still read with extra emphasis.
- Keeps the drop of \`font-medium\` on the \`PR #NNN\` link so it continues to match the read-state title weight.
- Restores the \"Unread indicator\" label in the sidebar property picker and the original SortableTab bell-consistency comment.

## Test plan
- [ ] With the \"Unread indicator\" setting on, bell appears in the left rail and toggles isUnread on click.
- [ ] Unread workspace titles still render with bold weight; read titles render at normal weight.
- [ ] Context menu shows Mark Read / Mark Unread again.
- [ ] \`PR #NNN\` label stays at normal weight.

Made with [Orca](https://github.com/stablyai/orca) 🐋
