### PR TITLE
fix(release): grant actions:write on callers of release.yml

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -39,6 +39,13 @@ on:
 
 permissions:
   contents: write
+  # Why: this workflow calls release.yml, whose publish-release job needs
+  # actions: write to dispatch homebrew-bump.yml. Reusable workflows are
+  # capped by the caller's permissions, so the caller must list every
+  # scope the callee needs. Omitting this produced a startup_failure on
+  # run 25244518794 immediately after actions:write was added to
+  # release.yml in f6cc2aee.
+  actions: write
 
 concurrency:
   group: release-cut

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -17,6 +17,11 @@ on:
 
 permissions:
   contents: write
+  # Why: this workflow calls release.yml, whose publish-release job needs
+  # actions: write to dispatch homebrew-bump.yml. Reusable workflows are
+  # capped by the caller's permissions, so the caller must list every
+  # scope the callee needs. Mirrors the fix in release-cut.yml.
+  actions: write
 
 concurrency:
   group: release-rc


### PR DESCRIPTION
## Summary
- `release.yml`'s `publish-release` job got `actions: write` in f6cc2aee so it can dispatch `homebrew-bump.yml`, but reusable-workflow permissions are capped by the caller. `release-cut.yml` and `release-rc.yml` only listed `contents: write`, so the first cut after that change died with `startup_failure` (run [25244518794](https://github.com/stablyai/orca/actions/runs/25244518794)) before any job ran.
- Grant `actions: write` on both callers so the dispatch permission actually reaches `release.yml`.

## Test plan
- [ ] Merge, then re-dispatch Cut Release (kind: rc) from main and confirm the run starts (no `startup_failure`) and `publish-release` successfully kicks `homebrew-bump.yml` once the stable cut runs.

Made with [Orca](https://github.com/stablyai/orca) 🐋
