### PR TITLE
feat(editor): add toggle to show minimap in file editor

### DIFF
--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -39,6 +39,7 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     theme: 'system',
     editorAutoSave: false,
     editorAutoSaveDelayMs: 1000,
+    editorMinimapEnabled: false,
     terminalFontSize: 14,
     terminalFontFamily: 'JetBrains Mono',
     terminalFontWeight: 500,

--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -33,6 +33,7 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     theme: 'system',
     editorAutoSave: false,
     editorAutoSaveDelayMs: 1000,
+    editorMinimapEnabled: false,
     terminalFontSize: 14,
     terminalFontFamily: 'JetBrains Mono',
     terminalFontWeight: 500,

--- a/src/renderer/src/components/editor/MonacoEditor.tsx
+++ b/src/renderer/src/components/editor/MonacoEditor.tsx
@@ -450,7 +450,11 @@ export default function MonacoEditor({
         onChange={handleChange}
         onMount={handleMount}
         options={{
-          minimap: { enabled: false },
+          // Why: only the file editor honors editorMinimapEnabled. Monaco 0.55's
+          // DiffEditor hard-overrides minimap.enabled = false on its inner editors
+          // (see diffEditorEditors._adjustOptionsForSubEditor), so threading the
+          // setting into DiffViewer/DiffSectionItem would have no effect.
+          minimap: { enabled: settings?.editorMinimapEnabled ?? false },
           scrollBeyondLastLine: false,
           wordWrap: 'on',
           fontSize: editorFontSize,

--- a/src/renderer/src/components/settings/GeneralPane.tsx
+++ b/src/renderer/src/components/settings/GeneralPane.tsx
@@ -368,6 +368,38 @@ export function GeneralPane({ settings, updateSettings }: GeneralPaneProps): Rea
             ))}
           </div>
         </SearchableSetting>
+
+        <SearchableSetting
+          title="Minimap"
+          description="Show the minimap overview when editing a file."
+          keywords={['minimap', 'overview', 'code', 'scroll']}
+          className="flex items-center justify-between gap-4 px-1 py-2"
+        >
+          <div className="space-y-0.5">
+            <Label>Minimap</Label>
+            <p className="text-xs text-muted-foreground">
+              Show the minimap overview when editing a file.
+            </p>
+          </div>
+          <button
+            role="switch"
+            aria-checked={settings.editorMinimapEnabled}
+            onClick={() =>
+              updateSettings({
+                editorMinimapEnabled: !settings.editorMinimapEnabled
+              })
+            }
+            className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent transition-colors ${
+              settings.editorMinimapEnabled ? 'bg-foreground' : 'bg-muted-foreground/30'
+            }`}
+          >
+            <span
+              className={`pointer-events-none block size-3.5 rounded-full bg-background shadow-sm transition-transform ${
+                settings.editorMinimapEnabled ? 'translate-x-4' : 'translate-x-0.5'
+              }`}
+            />
+          </button>
+        </SearchableSetting>
       </section>
     ) : null,
     matchesSettingsSearch(searchQuery, GENERAL_CLI_SEARCH_ENTRIES) ? (

--- a/src/renderer/src/components/settings/general-search.ts
+++ b/src/renderer/src/components/settings/general-search.ts
@@ -33,6 +33,11 @@ export const GENERAL_EDITOR_SEARCH_ENTRIES: SettingsSearchEntry[] = [
     title: 'Default Diff View',
     description: 'Preferred presentation format for showing git diffs by default.',
     keywords: ['diff', 'view', 'inline', 'side-by-side', 'split']
+  },
+  {
+    title: 'Minimap',
+    description: 'Show the minimap overview when editing a file.',
+    keywords: ['minimap', 'overview', 'code', 'scroll']
   }
 ]
 

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -121,6 +121,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     theme: 'system',
     editorAutoSave: false,
     editorAutoSaveDelayMs: DEFAULT_EDITOR_AUTO_SAVE_DELAY_MS,
+    editorMinimapEnabled: false,
     terminalFontSize: 14,
     terminalFontFamily: defaultTerminalFontFamily(),
     terminalFontWeight: DEFAULT_TERMINAL_FONT_WEIGHT,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -950,6 +950,7 @@ export type GlobalSettings = {
   theme: 'system' | 'dark' | 'light'
   editorAutoSave: boolean
   editorAutoSaveDelayMs: number
+  editorMinimapEnabled: boolean
   terminalFontSize: number
   terminalFontFamily: string
   terminalFontWeight: number


### PR DESCRIPTION
## Summary

- Adds a "Minimap" toggle under **Settings → General → Editor** (default: off, preserves existing behavior).
- Wires `editorMinimapEnabled` into the regular file editor (`MonacoEditor.tsx`).
- Diff views intentionally remain without minimap — Monaco 0.55's `DiffEditor` hard-overrides `minimap.enabled = false` on its inner editors (`diffEditorEditors._adjustOptionsForSubEditor`), so threading the setting there would have no effect. A short `// Why:` comment near the call site documents this.

Closes #1345

## Test plan
- [ ] Toggle the new setting under Settings → General → Editor → Minimap
- [ ] Open a file in the editor and verify the minimap appears/disappears as expected
- [ ] Verify the toggle is searchable in the settings search
- [ ] Confirm diff views still hide the minimap regardless of the setting
- [ ] Existing settings persist across app restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)