### PR TITLE
fix(terminal): preserve copy with kitty keyboard

### DIFF
--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -30,6 +30,7 @@ import {
 } from './terminal-appearance'
 import { parseOsc52 } from './osc52-clipboard'
 import { parseOsc7 } from './parse-osc7'
+import { shouldBypassXtermKeydown } from './xterm-bypass-policy'
 import type { PaneCwdMap } from './resolve-split-cwd'
 import { installMouseHideWhileTyping } from './mouse-hide-while-typing'
 import type { EffectiveMacOptionAsAlt } from '@/lib/keyboard-layout/detect-option-as-alt'
@@ -423,6 +424,25 @@ export function useTerminalPaneLifecycle({
           return true
         })
         osc7DisposablesRef.current.set(pane.id, osc7Disposable)
+
+        // Why: let clipboard chords bypass xterm's kitty CSI-u encoder.
+        // With vtExtensions.kittyKeyboard on, a CLI that activates progressive
+        // enhancement (Codex does, Claude Code does not) makes xterm encode
+        // Cmd+C as a CSI-u sequence with cancel=true, which preventDefaults
+        // the keydown and suppresses Chromium's native copy event — so the
+        // selection never reaches the clipboard. Returning false here short-
+        // circuits xterm's _keyDown before the encoder runs, letting the
+        // browser copy pipeline and Electron menu accelerators fire normally.
+        // See xterm-bypass-policy.ts for the rule derivation (Ghostty/VS Code).
+        pane.terminal.attachCustomKeyEventHandler((e) => {
+          if (e.type !== 'keydown') {
+            return true
+          }
+          return !shouldBypassXtermKeydown(e, {
+            isMac: navigator.userAgent.includes('Mac'),
+            hasSelection: pane.terminal.hasSelection()
+          })
+        })
 
         const linkProviderDisposable = pane.terminal.registerLinkProvider(
           createFilePathLinkProvider(pane.id, linkDeps, pane.linkTooltip, fileOpenLinkHint)

--- a/src/renderer/src/components/terminal-pane/xterm-bypass-policy.test.ts
+++ b/src/renderer/src/components/terminal-pane/xterm-bypass-policy.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest'
+import { shouldBypassXtermKeydown, type XtermBypassEvent } from './xterm-bypass-policy'
+
+function event(overrides: Partial<XtermBypassEvent>): XtermBypassEvent {
+  return {
+    key: '',
+    code: '',
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    ...overrides
+  }
+}
+
+describe('shouldBypassXtermKeydown — macOS', () => {
+  const opts = { isMac: true, hasSelection: true }
+  const noSel = { isMac: true, hasSelection: false }
+
+  it('bubbles Cmd+C so Chromium copy fires and xterm populates clipboard', () => {
+    // Why: this is the whole point of the policy. When kitty progressive
+    // enhancement is on, the default xterm path CSI-u encodes Cmd+C and
+    // preventDefaults the keydown, suppressing the browser copy event.
+    expect(shouldBypassXtermKeydown(event({ key: 'c', code: 'KeyC', metaKey: true }), opts)).toBe(
+      true
+    )
+  })
+
+  it('bubbles Cmd+C even with no selection (no-op copy is harmless on macOS)', () => {
+    expect(shouldBypassXtermKeydown(event({ key: 'c', code: 'KeyC', metaKey: true }), noSel)).toBe(
+      true
+    )
+  })
+
+  it('does NOT bubble other Cmd chords — Orca window handlers intercept them before xterm', () => {
+    // Why: this policy is narrowly scoped to Cmd+C, the one clipboard chord
+    // Orca does not intercept at the window level. Cmd+V, Cmd+F, Cmd+D, Cmd+K,
+    // Cmd+W, Cmd+Arrow, Cmd+Backspace are all handled in keyboard-handlers.ts
+    // with stopImmediatePropagation before xterm's textarea listener fires,
+    // so they never reach this handler. Cmd+A flows through xterm's legacy
+    // evaluator which correctly produces type=1 (selectAll), so we must not
+    // swallow it here.
+    const cases = [
+      event({ key: 'v', code: 'KeyV', metaKey: true }),
+      event({ key: 'a', code: 'KeyA', metaKey: true }),
+      event({ key: 't', code: 'KeyT', metaKey: true })
+    ]
+    for (const e of cases) {
+      expect(shouldBypassXtermKeydown(e, opts)).toBe(false)
+    }
+  })
+
+  it('does not bubble Cmd+Shift+C — already intercepted in keyboard-handlers.ts', () => {
+    expect(
+      shouldBypassXtermKeydown(
+        event({ key: 'C', code: 'KeyC', metaKey: true, shiftKey: true }),
+        opts
+      )
+    ).toBe(false)
+  })
+
+  it('does not bubble Ctrl chords — those must reach the shell', () => {
+    // Ctrl+C is SIGINT, Ctrl+D is EOF, etc. — xterm must see them.
+    expect(shouldBypassXtermKeydown(event({ key: 'c', code: 'KeyC', ctrlKey: true }), opts)).toBe(
+      false
+    )
+    expect(shouldBypassXtermKeydown(event({ key: 'd', code: 'KeyD', ctrlKey: true }), opts)).toBe(
+      false
+    )
+  })
+
+  it('does not bubble Cmd+Ctrl combos (unusual; defer to xterm)', () => {
+    expect(
+      shouldBypassXtermKeydown(
+        event({ key: 'c', code: 'KeyC', metaKey: true, ctrlKey: true }),
+        opts
+      )
+    ).toBe(false)
+  })
+
+  it('does not bubble plain letters — those are normal input', () => {
+    expect(shouldBypassXtermKeydown(event({ key: 'c', code: 'KeyC' }), opts)).toBe(false)
+  })
+})
+
+describe('shouldBypassXtermKeydown — Windows/Linux', () => {
+  const withSel = { isMac: false, hasSelection: true }
+  const noSel = { isMac: false, hasSelection: false }
+
+  it('bubbles Ctrl+Shift+C (standard terminal copy on Linux/Windows)', () => {
+    expect(
+      shouldBypassXtermKeydown(
+        event({ key: 'C', code: 'KeyC', ctrlKey: true, shiftKey: true }),
+        noSel
+      )
+    ).toBe(true)
+  })
+
+  it('bubbles Ctrl+C only when there is a selection (otherwise SIGINT)', () => {
+    // Why: bare Ctrl+C without a selection must reach the shell as SIGINT.
+    // With a selection, terminals like Windows Terminal copy instead.
+    expect(
+      shouldBypassXtermKeydown(event({ key: 'c', code: 'KeyC', ctrlKey: true }), withSel)
+    ).toBe(true)
+    expect(shouldBypassXtermKeydown(event({ key: 'c', code: 'KeyC', ctrlKey: true }), noSel)).toBe(
+      false
+    )
+  })
+
+  it('bubbles Ctrl+V and Ctrl+Shift+V for paste', () => {
+    expect(shouldBypassXtermKeydown(event({ key: 'v', code: 'KeyV', ctrlKey: true }), noSel)).toBe(
+      true
+    )
+    expect(
+      shouldBypassXtermKeydown(
+        event({ key: 'V', code: 'KeyV', ctrlKey: true, shiftKey: true }),
+        noSel
+      )
+    ).toBe(true)
+  })
+
+  it('bubbles Shift+Insert (X11/Linux paste convention)', () => {
+    expect(
+      shouldBypassXtermKeydown(event({ key: 'Insert', code: 'Insert', shiftKey: true }), noSel)
+    ).toBe(true)
+  })
+
+  it('does not bubble plain Ctrl letter chords — shell shortcuts must reach PTY', () => {
+    // Ctrl+A, Ctrl+E, Ctrl+U, Ctrl+R, Ctrl+L — all readline-critical.
+    for (const keyCode of ['a', 'e', 'u', 'r', 'l']) {
+      expect(
+        shouldBypassXtermKeydown(
+          event({ key: keyCode, code: `Key${keyCode.toUpperCase()}`, ctrlKey: true }),
+          noSel
+        )
+      ).toBe(false)
+    }
+  })
+
+  it('does not bubble plain letters', () => {
+    expect(shouldBypassXtermKeydown(event({ key: 'c', code: 'KeyC' }), noSel)).toBe(false)
+  })
+
+  it('does not bubble Cmd chords on non-Mac (Super+C has no clipboard meaning there)', () => {
+    expect(shouldBypassXtermKeydown(event({ key: 'c', code: 'KeyC', metaKey: true }), noSel)).toBe(
+      false
+    )
+  })
+})

--- a/src/renderer/src/components/terminal-pane/xterm-bypass-policy.ts
+++ b/src/renderer/src/components/terminal-pane/xterm-bypass-policy.ts
@@ -1,0 +1,82 @@
+// Why: when a CLI activates kitty progressive enhancement (CSI > N u), xterm's
+// KittyKeyboard encoder turns every modifier chord — including plain Cmd+C —
+// into a CSI-u sequence with `cancel: true`, which calls preventDefault() on
+// the keydown. That preventDefault suppresses Chromium's native `copy` event,
+// so xterm's own `copy` listener on its container never fires and the
+// selection is never written to the clipboard.
+//
+// Fix: intercept in `attachCustomKeyEventHandler` and return `false` for chords
+// that should bubble to the browser / host (clipboard, native menu). Returning
+// `false` makes xterm bail *before* the kitty encoder runs, so the browser's
+// copy pipeline and the OS-level keybinding both fire normally.
+//
+// Rule source — Ghostty (src/input/key_encode.zig:543-545):
+//   "on macOS, command+keys do not encode text ... They don't in native text
+//    inputs (TextEdit) and they also don't in other native terminals
+//    (Terminal.app, iTerm2)."
+// VS Code (terminalInstance.ts:1115-1171) and Superset's terminal (which hit
+// this exact bug) both converge on the same pattern.
+
+export type XtermBypassEvent = {
+  key: string
+  code?: string
+  metaKey: boolean
+  ctrlKey: boolean
+  altKey: boolean
+  shiftKey: boolean
+}
+
+export type XtermBypassOptions = {
+  isMac: boolean
+  /** True when the terminal has a current text selection — Ctrl+C on
+   *  Windows/Linux should only bubble to clipboard when something is selected,
+   *  otherwise it must reach the shell as SIGINT. */
+  hasSelection: boolean
+}
+
+/**
+ * Decide whether a chord should bypass xterm's keydown handler so the native
+ * browser pipeline (Chromium `copy` event, Electron menu accelerators) can
+ * handle it instead of the kitty CSI-u encoder swallowing it.
+ */
+export function shouldBypassXtermKeydown(
+  event: XtermBypassEvent,
+  options: XtermBypassOptions
+): boolean {
+  const { isMac, hasSelection } = options
+
+  if (isMac) {
+    // Narrow Ghostty rule to Cmd+C only: Ghostty bubbles every Cmd chord on
+    // macOS, but Orca's window-level handlers (keyboard-handlers.ts,
+    // TerminalPane.tsx Cmd+V interception) already swallow every Cmd chord
+    // that does something meaningful before xterm sees it. Cmd+C is the one
+    // chord that was never intercepted, so it's the only real-world breakage.
+    // Limiting the bypass to Cmd+C avoids accidentally regressing xterm's
+    // native Cmd+A select-all path, which goes through a different evaluator
+    // branch than the kitty encoder.
+    return (
+      event.code === 'KeyC' && event.metaKey && !event.ctrlKey && !event.altKey && !event.shiftKey
+    )
+  }
+
+  // Windows/Linux: standard clipboard bindings bubble; Ctrl+C only bubbles
+  // with a selection (otherwise it's SIGINT and must reach the shell).
+  const onlyCtrl = event.ctrlKey && !event.metaKey && !event.altKey && !event.shiftKey
+  const ctrlShiftOnly = event.ctrlKey && event.shiftKey && !event.metaKey && !event.altKey
+  const onlyShift = event.shiftKey && !event.ctrlKey && !event.metaKey && !event.altKey
+
+  if (event.code === 'KeyC' && ctrlShiftOnly) {
+    return true
+  }
+  if (event.code === 'KeyC' && onlyCtrl && hasSelection) {
+    return true
+  }
+  if (event.code === 'KeyV' && (onlyCtrl || ctrlShiftOnly)) {
+    return true
+  }
+  if (event.code === 'Insert' && onlyShift) {
+    return true
+  }
+
+  return false
+}


### PR DESCRIPTION
## Summary
- Fix Cmd+C copy in terminal panes when kitty keyboard progressive enhancement is active.
- Add a focused xterm bypass policy for native clipboard chords and wire it through `attachCustomKeyEventHandler`.
- Cover macOS and Windows/Linux clipboard behavior with unit tests.

## Diagnosis
`vtExtensions.kittyKeyboard` allows CLIs to enable progressive keyboard enhancement. When active, xterm can encode Meta chords such as plain Cmd+C as CSI-u with `cancel: true`, which prevents the keydown default. That suppresses Chromium's native copy event, so selected terminal text never reaches the clipboard.

## Fix
Return `false` from xterm's custom key handler for native clipboard chords that should be handled by the browser or host instead of the kitty encoder. On macOS this is scoped to bare Cmd+C; on Windows/Linux it covers Ctrl+Shift+C, Ctrl+C with selection, Ctrl+V, Ctrl+Shift+V, and Shift+Insert.

## Validation
- `npm run lint`
- `npm test -- src/renderer/src/components/terminal-pane/xterm-bypass-policy.test.ts`
- Electron manual validation with kitty progressive enhancement active: Cmd+C updates clipboard, Cmd+X still reaches xterm, Cmd+Shift+C still works through Orca's explicit copy handler.