### PR TITLE
feat(providers): docker provider foundation (pty / filesystem / git)

### DIFF
--- a/src/main/docker/docker-container-lifecycle.test.ts
+++ b/src/main/docker/docker-container-lifecycle.test.ts
@@ -1,0 +1,104 @@
+import { mkdtemp, rm } from 'fs/promises'
+import { tmpdir } from 'os'
+import path from 'path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { DockerEngineFake } from './docker-engine-fake'
+import {
+  attachDockerContainer,
+  hibernateDockerContainer,
+  spawnDockerContainer,
+  terminateDockerContainer
+} from './docker-container-lifecycle'
+
+describe('docker-container-lifecycle', () => {
+  let repoPath: string
+  let worktreePath: string
+  let engine: DockerEngineFake
+
+  beforeEach(async () => {
+    repoPath = await mkdtemp(path.join(tmpdir(), 'orca-docker-repo-'))
+    worktreePath = await mkdtemp(path.join(tmpdir(), 'orca-docker-worktree-'))
+    engine = new DockerEngineFake()
+  })
+
+  afterEach(async () => {
+    await rm(repoPath, { recursive: true, force: true })
+    await rm(worktreePath, { recursive: true, force: true })
+  })
+
+  it('builds an image, creates a bind-mounted container, and starts it', async () => {
+    const result = await spawnDockerContainer({
+      repoPath,
+      worktreePath,
+      repoIdentity: 'repo-1',
+      engine,
+      platform: 'linux',
+      now: () => 456
+    })
+
+    expect(result.container).toMatchObject({
+      id: 'container-1',
+      imageId: 'sha256:fake-image-1',
+      startedAt: 456,
+      state: 'running'
+    })
+    expect(engine.commands.map((command) => command.command)).toEqual([
+      'image.build',
+      'container.create',
+      'container.start'
+    ])
+    expect(engine.commands[1]).toMatchObject({
+      command: 'container.create',
+      options: { mounts: [{ source: worktreePath, target: '/workspace' }] }
+    })
+  })
+
+  it('limits image builds to one concurrent build per repo identity', async () => {
+    engine.buildDelayMs = 20
+
+    await Promise.all([
+      spawnDockerContainer({ repoPath, worktreePath, repoIdentity: 'same', engine }),
+      spawnDockerContainer({ repoPath, worktreePath, repoIdentity: 'same', engine })
+    ])
+
+    expect(engine.commands.filter((command) => command.command === 'image.build')).toHaveLength(1)
+  })
+
+  it('attaches only running containers', async () => {
+    const spawned = await spawnDockerContainer({ repoPath, worktreePath, engine })
+
+    await expect(
+      attachDockerContainer(engine, spawned.container.id, () => 789)
+    ).resolves.toMatchObject({
+      id: spawned.container.id,
+      state: 'running',
+      startedAt: 789
+    })
+
+    await hibernateDockerContainer(engine, spawned.container)
+    await expect(attachDockerContainer(engine, spawned.container.id)).rejects.toThrow(
+      'is not running'
+    )
+  })
+
+  it('hibernates and terminates containers', async () => {
+    const spawned = await spawnDockerContainer({ repoPath, worktreePath, engine })
+
+    await expect(hibernateDockerContainer(engine, spawned.container)).resolves.toMatchObject({
+      state: 'hibernated'
+    })
+    await expect(terminateDockerContainer(engine, spawned.container)).resolves.toMatchObject({
+      state: 'terminated'
+    })
+    expect(engine.commands.map((command) => command.command)).toContain('container.rm')
+  })
+
+  it('surfaces build failures before creating a container', async () => {
+    engine.nextBuildError = new Error('image build fail')
+
+    await expect(spawnDockerContainer({ repoPath, worktreePath, engine })).rejects.toThrow(
+      'image build fail'
+    )
+    expect(engine.commands.map((command) => command.command)).toEqual(['image.build'])
+  })
+})

--- a/src/main/docker/docker-container-lifecycle.test.ts
+++ b/src/main/docker/docker-container-lifecycle.test.ts
@@ -49,7 +49,14 @@ describe('docker-container-lifecycle', () => {
     ])
     expect(engine.commands[1]).toMatchObject({
       command: 'container.create',
-      options: { mounts: [{ source: worktreePath, target: '/workspace' }] }
+      options: {
+        mounts: [{ source: worktreePath, target: '/workspace' }],
+        labels: {
+          'dev.orca.managed': 'true',
+          'dev.orca.kind': 'worktree',
+          'dev.orca.repo': 'repo-1'
+        }
+      }
     })
   })
 
@@ -91,6 +98,27 @@ describe('docker-container-lifecycle', () => {
       state: 'terminated'
     })
     expect(engine.commands.map((command) => command.command)).toContain('container.rm')
+  })
+
+  it('refuses to clean up containers without Orca ownership labels', async () => {
+    engine.containers.set('user-container', {
+      id: 'user-container',
+      imageId: 'sha256:user',
+      running: true
+    })
+
+    await expect(attachDockerContainer(engine, 'user-container')).rejects.toThrow(
+      'not managed by Orca'
+    )
+    await expect(
+      terminateDockerContainer(engine, {
+        id: 'user-container',
+        imageId: 'sha256:user',
+        startedAt: 1,
+        state: 'running'
+      })
+    ).rejects.toThrow('not managed by Orca')
+    expect(engine.commands.map((command) => command.command)).not.toContain('container.rm')
   })
 
   it('surfaces build failures before creating a container', async () => {

--- a/src/main/docker/docker-container-lifecycle.ts
+++ b/src/main/docker/docker-container-lifecycle.ts
@@ -1,0 +1,108 @@
+import type { DockerEngineClientLike } from './docker-engine-client'
+import { buildDockerImage } from './docker-image-build'
+import { DEFAULT_CONTAINER_WORKDIR, resolveDockerBindMount } from './docker-mount'
+import type { DockerContainerHandle, DockerImageHandle } from './types'
+
+const IMAGE_BUILD_TIMEOUT_MS = 60_000
+const repoBuildLocks = new Map<string, Promise<DockerImageHandle>>()
+
+export type SpawnDockerContainerOptions = {
+  repoPath: string
+  worktreePath: string
+  repoIdentity?: string
+  engine: DockerEngineClientLike
+  platform?: NodeJS.Platform
+  workdir?: string
+  now?: () => number
+}
+
+export type SpawnDockerContainerResult = {
+  image: DockerImageHandle
+  container: DockerContainerHandle
+}
+
+export async function spawnDockerContainer(
+  options: SpawnDockerContainerOptions
+): Promise<SpawnDockerContainerResult> {
+  const workdir = options.workdir ?? DEFAULT_CONTAINER_WORKDIR
+  const image = await buildImageOncePerRepo(options)
+  const mount = resolveDockerBindMount({
+    hostPath: options.worktreePath,
+    platform: options.platform,
+    containerPath: workdir
+  })
+  const created = await options.engine.createContainer({
+    imageId: image.id,
+    workdir,
+    mounts: [mount]
+  })
+  await options.engine.startContainer(created.id)
+
+  return {
+    image,
+    container: {
+      id: created.id,
+      imageId: image.id,
+      startedAt: (options.now ?? Date.now)(),
+      state: 'running'
+    }
+  }
+}
+
+export async function attachDockerContainer(
+  engine: DockerEngineClientLike,
+  id: string,
+  now: () => number = Date.now
+): Promise<DockerContainerHandle> {
+  const info = await engine.inspectContainer(id)
+  if (!info.running) {
+    throw new Error(`Docker container ${id} is not running`)
+  }
+  return {
+    id: info.id,
+    imageId: info.imageId,
+    startedAt: now(),
+    state: 'running'
+  }
+}
+
+export async function hibernateDockerContainer(
+  engine: DockerEngineClientLike,
+  container: DockerContainerHandle
+): Promise<DockerContainerHandle> {
+  await engine.stopContainer(container.id)
+  return { ...container, state: 'hibernated' }
+}
+
+export async function terminateDockerContainer(
+  engine: DockerEngineClientLike,
+  container: DockerContainerHandle
+): Promise<DockerContainerHandle> {
+  if (container.state !== 'terminated') {
+    await engine.stopContainer(container.id)
+    await engine.removeContainer(container.id)
+  }
+  return { ...container, state: 'terminated' }
+}
+
+async function buildImageOncePerRepo(
+  options: SpawnDockerContainerOptions
+): Promise<DockerImageHandle> {
+  const key = options.repoIdentity ?? options.repoPath
+  const existing = repoBuildLocks.get(key)
+  if (existing) {
+    return existing
+  }
+
+  const next = buildDockerImage({
+    repoPath: options.repoPath,
+    repoIdentity: options.repoIdentity,
+    engine: options.engine,
+    timeoutMs: IMAGE_BUILD_TIMEOUT_MS,
+    now: options.now
+  }).finally(() => {
+    repoBuildLocks.delete(key)
+  })
+  repoBuildLocks.set(key, next)
+  return next
+}

--- a/src/main/docker/docker-container-lifecycle.ts
+++ b/src/main/docker/docker-container-lifecycle.ts
@@ -1,9 +1,14 @@
 import type { DockerEngineClientLike } from './docker-engine-client'
-import { buildDockerImage } from './docker-image-build'
+import {
+  buildDockerImage,
+  ORCA_DOCKER_MANAGED_LABEL,
+  ORCA_DOCKER_REPO_LABEL
+} from './docker-image-build'
 import { DEFAULT_CONTAINER_WORKDIR, resolveDockerBindMount } from './docker-mount'
 import type { DockerContainerHandle, DockerImageHandle } from './types'
 
 const IMAGE_BUILD_TIMEOUT_MS = 60_000
+const ORCA_DOCKER_KIND_LABEL = 'dev.orca.kind'
 const repoBuildLocks = new Map<string, Promise<DockerImageHandle>>()
 
 export type SpawnDockerContainerOptions = {
@@ -34,7 +39,12 @@ export async function spawnDockerContainer(
   const created = await options.engine.createContainer({
     imageId: image.id,
     workdir,
-    mounts: [mount]
+    mounts: [mount],
+    labels: {
+      [ORCA_DOCKER_MANAGED_LABEL]: 'true',
+      [ORCA_DOCKER_KIND_LABEL]: 'worktree',
+      [ORCA_DOCKER_REPO_LABEL]: options.repoIdentity ?? options.repoPath
+    }
   })
   await options.engine.startContainer(created.id)
 
@@ -58,6 +68,7 @@ export async function attachDockerContainer(
   if (!info.running) {
     throw new Error(`Docker container ${id} is not running`)
   }
+  assertOrcaManagedContainer(id, info.labels)
   return {
     id: info.id,
     imageId: info.imageId,
@@ -70,6 +81,8 @@ export async function hibernateDockerContainer(
   engine: DockerEngineClientLike,
   container: DockerContainerHandle
 ): Promise<DockerContainerHandle> {
+  const info = await engine.inspectContainer(container.id)
+  assertOrcaManagedContainer(container.id, info.labels)
   await engine.stopContainer(container.id)
   return { ...container, state: 'hibernated' }
 }
@@ -79,10 +92,23 @@ export async function terminateDockerContainer(
   container: DockerContainerHandle
 ): Promise<DockerContainerHandle> {
   if (container.state !== 'terminated') {
+    const info = await engine.inspectContainer(container.id)
+    assertOrcaManagedContainer(container.id, info.labels)
     await engine.stopContainer(container.id)
     await engine.removeContainer(container.id)
   }
   return { ...container, state: 'terminated' }
+}
+
+function assertOrcaManagedContainer(id: string, labels: Record<string, string> | undefined): void {
+  // Why: cleanup accepts an opaque Docker id. Require Orca's label before
+  // stopping or removing anything so a stale handle cannot target user-owned containers.
+  if (
+    labels?.[ORCA_DOCKER_MANAGED_LABEL] !== 'true' ||
+    labels?.[ORCA_DOCKER_KIND_LABEL] !== 'worktree'
+  ) {
+    throw new Error(`Docker container ${id} is not managed by Orca`)
+  }
 }
 
 async function buildImageOncePerRepo(

--- a/src/main/docker/docker-container-path.ts
+++ b/src/main/docker/docker-container-path.ts
@@ -1,0 +1,82 @@
+import path from 'path'
+import type { DockerTarget } from './types'
+
+type HostPathApi = Pick<typeof path, 'isAbsolute' | 'relative' | 'resolve' | 'sep'>
+
+function normalizeContainerRoot(workdir: string): string {
+  const normalized = path.posix.resolve(path.posix.sep, workdir.replace(/\\/g, '/'))
+  if (normalized === path.posix.sep) {
+    throw new Error('Docker workdir must not be the container root')
+  }
+  return normalized
+}
+
+function isInsideOrEqual(
+  pathApi: Pick<typeof path, 'isAbsolute' | 'relative' | 'sep'>,
+  root: string,
+  candidate: string
+): boolean {
+  const relative = pathApi.relative(root, candidate)
+  return relative === '' || (!relative.startsWith('..') && !pathApi.isAbsolute(relative))
+}
+
+function getHostPathApi(platform: NodeJS.Platform): HostPathApi {
+  return platform === 'win32' ? path.win32 : path
+}
+
+function getHostRelativePath(target: DockerTarget, inputPath: string): string | null {
+  if (!target.hostWorktreePath) {
+    return null
+  }
+  const hostPathApi = getHostPathApi(target.hostPlatform ?? process.platform)
+  if (!hostPathApi.isAbsolute(inputPath)) {
+    return null
+  }
+  const root = hostPathApi.resolve(target.hostWorktreePath)
+  const candidate = hostPathApi.resolve(inputPath)
+  if (!isInsideOrEqual(hostPathApi, root, candidate)) {
+    return null
+  }
+  return hostPathApi.relative(root, candidate)
+}
+
+export function resolveDockerContainerPath(target: DockerTarget, inputPath: string): string {
+  if (inputPath.includes('\0')) {
+    throw new Error('Docker container path must not contain null bytes')
+  }
+
+  const root = normalizeContainerRoot(target.workdir)
+  const hostRelativePath = getHostRelativePath(target, inputPath)
+  const candidate =
+    hostRelativePath !== null
+      ? path.posix.resolve(root, hostRelativePath.replace(/\\/g, '/'))
+      : path.posix.isAbsolute(inputPath.replace(/\\/g, '/'))
+        ? path.posix.resolve(inputPath.replace(/\\/g, '/'))
+        : path.posix.resolve(root, inputPath.replace(/\\/g, '/'))
+
+  if (!isInsideOrEqual(path.posix, root, candidate)) {
+    throw new Error(`Docker path "${inputPath}" resolves outside ${root}`)
+  }
+  return candidate
+}
+
+export function resolveDockerContainerRelativePath(
+  target: DockerTarget,
+  inputPath: string
+): string {
+  const root = normalizeContainerRoot(target.workdir)
+  const resolved = resolveDockerContainerPath(target, inputPath)
+  const relative = path.posix.relative(root, resolved)
+  return relative || '.'
+}
+
+export function normalizeDockerMountTarget(containerPath: string): string {
+  if (containerPath.includes('\0')) {
+    throw new Error('Docker mount target must not contain null bytes')
+  }
+  const normalized = path.posix.resolve(path.posix.sep, containerPath.replace(/\\/g, '/'))
+  if (normalized === path.posix.sep) {
+    throw new Error('Docker mount target must not be the container root')
+  }
+  return normalized
+}

--- a/src/main/docker/docker-engine-client.ts
+++ b/src/main/docker/docker-engine-client.ts
@@ -44,6 +44,7 @@ export type DockerExecSessionOptions = {
   args: string[]
   cwd: string
   env?: Record<string, string>
+  tty?: boolean
   cols: number
   rows: number
 }
@@ -164,7 +165,7 @@ export class DockerEngineClient implements DockerEngineClientLike {
         LINES: String(options.rows)
       }
     })
-    args.splice(1, 0, '-i')
+    args.splice(1, 0, ...(options.tty ? ['-i', '-t'] : ['-i']))
     const child = spawn('docker', args, { stdio: ['pipe', 'pipe', 'pipe'] })
     const dataListeners = new Set<(data: string) => void>()
     const replayListeners = new Set<(data: string) => void>()

--- a/src/main/docker/docker-engine-client.ts
+++ b/src/main/docker/docker-engine-client.ts
@@ -1,0 +1,346 @@
+/* eslint-disable max-lines */
+import { spawn, execFile } from 'child_process'
+import { mkdtemp, readFile, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import path from 'path'
+import { promisify } from 'util'
+
+const execFileAsync = promisify(execFile)
+
+export type DockerExecResult = {
+  stdout: string
+  stderr: string
+  exitCode: number
+}
+
+export type DockerBuildImageOptions = {
+  contextPath: string
+  dockerfilePath: string
+  tag: string
+  timeoutMs?: number
+  dockerfileContent?: string
+}
+
+export type DockerCreateContainerOptions = {
+  imageId: string
+  workdir: string
+  mounts: { source: string; target: string; readonly?: boolean }[]
+  command?: string[]
+  env?: Record<string, string>
+  name?: string
+}
+
+export type DockerExecOptions = {
+  containerId: string
+  args: string[]
+  cwd?: string
+  env?: Record<string, string>
+  input?: string
+  timeoutMs?: number
+}
+
+export type DockerExecSessionOptions = {
+  containerId: string
+  args: string[]
+  cwd: string
+  env?: Record<string, string>
+  cols: number
+  rows: number
+}
+
+export type DockerExecSession = {
+  id: string
+  write(data: string): void
+  resize(cols: number, rows: number): void
+  shutdown(immediate: boolean): Promise<void>
+  sendSignal(signal: string): Promise<void>
+  getCwd(): Promise<string>
+  getInitialCwd(): Promise<string>
+  clearBuffer(): Promise<void>
+  acknowledgeDataEvent(charCount: number): void
+  hasChildProcesses(): Promise<boolean>
+  getForegroundProcess(): Promise<string | null>
+  serialize(): Promise<string>
+  revive(state: string): Promise<void>
+  onData(callback: (data: string) => void): () => void
+  onReplay(callback: (data: string) => void): () => void
+  onExit(callback: (code: number) => void): () => void
+}
+
+export type DockerEngineClientLike = {
+  buildImage(options: DockerBuildImageOptions): Promise<{ imageId: string }>
+  pullImage(image: string): Promise<void>
+  createContainer(options: DockerCreateContainerOptions): Promise<{ id: string }>
+  startContainer(id: string): Promise<void>
+  inspectContainer(id: string): Promise<{ id: string; imageId: string; running: boolean }>
+  exec(options: DockerExecOptions): Promise<DockerExecResult>
+  spawnExec(options: DockerExecSessionOptions): Promise<DockerExecSession>
+  stopContainer(id: string): Promise<void>
+  removeContainer(id: string): Promise<void>
+}
+
+export class DockerEngineClient implements DockerEngineClientLike {
+  async buildImage(options: DockerBuildImageOptions): Promise<{ imageId: string }> {
+    const tempDir = await mkdtemp(path.join(tmpdir(), 'orca-docker-build-'))
+    const dockerfilePath = tempDir ? path.join(tempDir, 'Dockerfile') : options.dockerfilePath
+
+    try {
+      if (options.dockerfileContent) {
+        await writeFile(dockerfilePath, options.dockerfileContent, 'utf-8')
+      }
+
+      const iidFile = path.join(tempDir, 'iid')
+      const args = [
+        'build',
+        '--iidfile',
+        iidFile,
+        '-f',
+        options.dockerfileContent ? dockerfilePath : options.dockerfilePath,
+        '-t',
+        options.tag,
+        options.contextPath
+      ]
+      await execDocker(args, { timeoutMs: options.timeoutMs })
+      const imageId = (await readFile(iidFile, 'utf-8')).trim()
+      return { imageId }
+    } finally {
+      await rm(tempDir, { recursive: true, force: true })
+    }
+  }
+
+  async pullImage(image: string): Promise<void> {
+    await execDocker(['pull', image])
+  }
+
+  async createContainer(options: DockerCreateContainerOptions): Promise<{ id: string }> {
+    const args = ['create', '--workdir', options.workdir]
+    for (const mount of options.mounts) {
+      const flags = [`type=bind`, `source=${mount.source}`, `target=${mount.target}`]
+      if (mount.readonly) {
+        flags.push('readonly')
+      }
+      args.push('--mount', flags.join(','))
+    }
+    for (const [key, value] of Object.entries(options.env ?? {})) {
+      args.push('--env', `${key}=${value}`)
+    }
+    if (options.name) {
+      args.push('--name', options.name)
+    }
+    args.push(options.imageId, ...(options.command ?? ['tail', '-f', '/dev/null']))
+    const result = await execDocker(args)
+    return { id: result.stdout.trim() }
+  }
+
+  async startContainer(id: string): Promise<void> {
+    await execDocker(['start', id])
+  }
+
+  async inspectContainer(id: string): Promise<{ id: string; imageId: string; running: boolean }> {
+    const result = await execDocker([
+      'inspect',
+      '--format',
+      '{{.Id}} {{.Image}} {{.State.Running}}',
+      id
+    ])
+    const [containerId, imageId, running] = result.stdout.trim().split(/\s+/)
+    return { id: containerId, imageId, running: running === 'true' }
+  }
+
+  async exec(options: DockerExecOptions): Promise<DockerExecResult> {
+    const args = buildExecArgs(options)
+    return execDocker(args, { input: options.input, timeoutMs: options.timeoutMs })
+  }
+
+  async spawnExec(options: DockerExecSessionOptions): Promise<DockerExecSession> {
+    const id = `docker-exec-${Date.now()}-${Math.random().toString(16).slice(2)}`
+    const args = buildExecArgs({
+      containerId: options.containerId,
+      args: options.args,
+      cwd: options.cwd,
+      env: {
+        ...options.env,
+        COLUMNS: String(options.cols),
+        LINES: String(options.rows)
+      }
+    })
+    args.splice(1, 0, '-i')
+    const child = spawn('docker', args, { stdio: ['pipe', 'pipe', 'pipe'] })
+    const dataListeners = new Set<(data: string) => void>()
+    const replayListeners = new Set<(data: string) => void>()
+    const exitListeners = new Set<(code: number) => void>()
+    let buffer = ''
+    let currentCwd = options.cwd
+    let exitCode: number | null = null
+
+    child.stdout.setEncoding('utf-8')
+    child.stderr.setEncoding('utf-8')
+    child.stdout.on('data', (chunk: string) => {
+      buffer += chunk
+      for (const cb of dataListeners) {
+        cb(chunk)
+      }
+    })
+    child.stderr.on('data', (chunk: string) => {
+      buffer += chunk
+      for (const cb of dataListeners) {
+        cb(chunk)
+      }
+    })
+    child.on('close', (code) => {
+      exitCode = code ?? 0
+      for (const cb of exitListeners) {
+        cb(exitCode)
+      }
+    })
+
+    return {
+      id,
+      write(data): void {
+        child.stdin.write(data)
+      },
+      resize(cols, rows): void {
+        if (exitCode === null) {
+          child.kill('SIGWINCH')
+        }
+        void cols
+        void rows
+      },
+      async shutdown(immediate): Promise<void> {
+        child.kill(immediate ? 'SIGKILL' : 'SIGTERM')
+      },
+      async sendSignal(signal): Promise<void> {
+        if (exitCode === null) {
+          child.kill(signal as NodeJS.Signals)
+        }
+      },
+      async getCwd(): Promise<string> {
+        return currentCwd
+      },
+      async getInitialCwd(): Promise<string> {
+        return options.cwd
+      },
+      async clearBuffer(): Promise<void> {
+        buffer = ''
+      },
+      acknowledgeDataEvent(_charCount): void {},
+      async hasChildProcesses(): Promise<boolean> {
+        return exitCode === null
+      },
+      async getForegroundProcess(): Promise<string | null> {
+        return exitCode === null ? path.basename(options.args[0] ?? 'sh') : null
+      },
+      async serialize(): Promise<string> {
+        return JSON.stringify({ cwd: currentCwd, buffer })
+      },
+      async revive(state): Promise<void> {
+        try {
+          const parsed = JSON.parse(state) as { cwd?: string; buffer?: string }
+          currentCwd = parsed.cwd ?? currentCwd
+          if (parsed.buffer) {
+            buffer = parsed.buffer
+            for (const cb of replayListeners) {
+              cb(buffer)
+            }
+          }
+        } catch {
+          // Ignore stale serialized state from older builds.
+        }
+      },
+      onData(callback): () => void {
+        dataListeners.add(callback)
+        return () => dataListeners.delete(callback)
+      },
+      onReplay(callback): () => void {
+        replayListeners.add(callback)
+        return () => replayListeners.delete(callback)
+      },
+      onExit(callback): () => void {
+        exitListeners.add(callback)
+        return () => exitListeners.delete(callback)
+      }
+    }
+  }
+
+  async stopContainer(id: string): Promise<void> {
+    await execDocker(['stop', id])
+  }
+
+  async removeContainer(id: string): Promise<void> {
+    await execDocker(['rm', id])
+  }
+}
+
+function buildExecArgs(options: DockerExecOptions): string[] {
+  const args = ['exec']
+  if (options.cwd) {
+    args.push('--workdir', options.cwd)
+  }
+  for (const [key, value] of Object.entries(options.env ?? {})) {
+    args.push('--env', `${key}=${value}`)
+  }
+  args.push(options.containerId, ...options.args)
+  return args
+}
+
+async function execDocker(
+  args: string[],
+  options: { input?: string; timeoutMs?: number } = {}
+): Promise<DockerExecResult> {
+  if (options.input === undefined) {
+    const { stdout, stderr } = await execFileAsync('docker', args, {
+      encoding: 'utf-8',
+      timeout: options.timeoutMs,
+      maxBuffer: 20 * 1024 * 1024
+    })
+    return { stdout: stdout as string, stderr: stderr as string, exitCode: 0 }
+  }
+
+  return new Promise((resolve, reject) => {
+    const child = spawn('docker', args, { stdio: ['pipe', 'pipe', 'pipe'] })
+    let stdout = ''
+    let stderr = ''
+    let settled = false
+    const timeout =
+      options.timeoutMs === undefined
+        ? null
+        : setTimeout(() => {
+            settled = true
+            child.kill('SIGKILL')
+            reject(new Error(`docker ${args[0]} timed out after ${options.timeoutMs}ms`))
+          }, options.timeoutMs)
+
+    child.stdout.setEncoding('utf-8')
+    child.stderr.setEncoding('utf-8')
+    child.stdout.on('data', (chunk: string) => {
+      stdout += chunk
+    })
+    child.stderr.on('data', (chunk: string) => {
+      stderr += chunk
+    })
+    child.once('error', (error) => {
+      if (!settled) {
+        settled = true
+        if (timeout) {
+          clearTimeout(timeout)
+        }
+        reject(error)
+      }
+    })
+    child.once('close', (code) => {
+      if (settled) {
+        return
+      }
+      settled = true
+      if (timeout) {
+        clearTimeout(timeout)
+      }
+      if (code && code !== 0) {
+        reject(new Error(stderr || `docker ${args[0]} exited with ${code}`))
+        return
+      }
+      resolve({ stdout, stderr, exitCode: code ?? 0 })
+    })
+    child.stdin.end(options.input)
+  })
+}

--- a/src/main/docker/docker-engine-client.ts
+++ b/src/main/docker/docker-engine-client.ts
@@ -19,6 +19,7 @@ export type DockerBuildImageOptions = {
   tag: string
   timeoutMs?: number
   dockerfileContent?: string
+  labels?: Record<string, string>
 }
 
 export type DockerCreateContainerOptions = {
@@ -28,6 +29,7 @@ export type DockerCreateContainerOptions = {
   command?: string[]
   env?: Record<string, string>
   name?: string
+  labels?: Record<string, string>
 }
 
 export type DockerExecOptions = {
@@ -73,7 +75,12 @@ export type DockerEngineClientLike = {
   pullImage(image: string): Promise<void>
   createContainer(options: DockerCreateContainerOptions): Promise<{ id: string }>
   startContainer(id: string): Promise<void>
-  inspectContainer(id: string): Promise<{ id: string; imageId: string; running: boolean }>
+  inspectContainer(id: string): Promise<{
+    id: string
+    imageId: string
+    running: boolean
+    labels?: Record<string, string>
+  }>
   exec(options: DockerExecOptions): Promise<DockerExecResult>
   spawnExec(options: DockerExecSessionOptions): Promise<DockerExecSession>
   stopContainer(id: string): Promise<void>
@@ -99,6 +106,7 @@ export class DockerEngineClient implements DockerEngineClientLike {
         options.dockerfileContent ? dockerfilePath : options.dockerfilePath,
         '-t',
         options.tag,
+        ...labelArgs(options.labels),
         options.contextPath
       ]
       await execDocker(args, { timeoutMs: options.timeoutMs })
@@ -125,6 +133,7 @@ export class DockerEngineClient implements DockerEngineClientLike {
     for (const [key, value] of Object.entries(options.env ?? {})) {
       args.push('--env', `${key}=${value}`)
     }
+    args.push(...labelArgs(options.labels))
     if (options.name) {
       args.push('--name', options.name)
     }
@@ -137,15 +146,25 @@ export class DockerEngineClient implements DockerEngineClientLike {
     await execDocker(['start', id])
   }
 
-  async inspectContainer(id: string): Promise<{ id: string; imageId: string; running: boolean }> {
-    const result = await execDocker([
-      'inspect',
-      '--format',
-      '{{.Id}} {{.Image}} {{.State.Running}}',
-      id
-    ])
-    const [containerId, imageId, running] = result.stdout.trim().split(/\s+/)
-    return { id: containerId, imageId, running: running === 'true' }
+  async inspectContainer(id: string): Promise<{
+    id: string
+    imageId: string
+    running: boolean
+    labels?: Record<string, string>
+  }> {
+    const result = await execDocker(['inspect', '--format', '{{json .}}', id])
+    const parsed = JSON.parse(result.stdout.trim()) as {
+      Id?: string
+      Image?: string
+      State?: { Running?: boolean }
+      Config?: { Labels?: Record<string, string> | null }
+    }
+    return {
+      id: parsed.Id ?? id,
+      imageId: parsed.Image ?? '',
+      running: parsed.State?.Running === true,
+      labels: parsed.Config?.Labels ?? undefined
+    }
   }
 
   async exec(options: DockerExecOptions): Promise<DockerExecResult> {
@@ -282,6 +301,10 @@ function buildExecArgs(options: DockerExecOptions): string[] {
   }
   args.push(options.containerId, ...options.args)
   return args
+}
+
+function labelArgs(labels: Record<string, string> | undefined): string[] {
+  return Object.entries(labels ?? {}).flatMap(([key, value]) => ['--label', `${key}=${value}`])
 }
 
 async function execDocker(

--- a/src/main/docker/docker-engine-detect.test.ts
+++ b/src/main/docker/docker-engine-detect.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import { detectDockerEngine } from './docker-engine-detect'
+
+describe('detectDockerEngine', () => {
+  it('detects Colima on macOS before Docker Desktop', () => {
+    const result = detectDockerEngine({
+      platform: 'darwin',
+      env: { HOME: '/Users/u' },
+      existsSync: (candidate) =>
+        candidate === '/Users/u/.colima/default/docker.sock' || candidate === '/var/run/docker.sock'
+    })
+    expect(result).toMatchObject({
+      flavor: 'colima',
+      socketPath: '/Users/u/.colima/default/docker.sock',
+      available: true
+    })
+  })
+
+  it('falls back to Docker Desktop on macOS', () => {
+    const result = detectDockerEngine({
+      platform: 'darwin',
+      env: { HOME: '/Users/u' },
+      existsSync: (candidate) => candidate === '/var/run/docker.sock'
+    })
+    expect(result).toMatchObject({
+      flavor: 'docker-desktop-mac',
+      socketPath: '/var/run/docker.sock',
+      available: true
+    })
+  })
+
+  it('detects Linux Docker Engine and rootless sockets', () => {
+    expect(
+      detectDockerEngine({
+        platform: 'linux',
+        uid: 501,
+        existsSync: (candidate) => candidate === '/var/run/docker.sock'
+      })
+    ).toMatchObject({ flavor: 'docker-engine-linux', available: true })
+
+    expect(
+      detectDockerEngine({
+        platform: 'linux',
+        uid: 501,
+        existsSync: (candidate) => candidate === '/run/user/501/docker.sock'
+      })
+    ).toMatchObject({
+      flavor: 'docker-rootless-linux',
+      socketPath: '/run/user/501/docker.sock',
+      available: true
+    })
+  })
+
+  it('detects Docker Desktop WSL2 named pipe on Windows', () => {
+    const result = detectDockerEngine({
+      platform: 'win32',
+      existsSync: (candidate) => candidate === String.raw`\\.\pipe\docker_engine`
+    })
+    expect(result).toMatchObject({
+      flavor: 'docker-desktop-windows-wsl2',
+      socketPath: String.raw`\\.\pipe\docker_engine`,
+      available: true
+    })
+  })
+
+  it('returns unavailable info when Docker is missing', () => {
+    expect(
+      detectDockerEngine({ platform: 'linux', uid: 501, existsSync: () => false })
+    ).toMatchObject({
+      flavor: 'docker-engine-linux',
+      available: false,
+      reason: 'Docker Engine socket was not found'
+    })
+  })
+})

--- a/src/main/docker/docker-engine-detect.ts
+++ b/src/main/docker/docker-engine-detect.ts
@@ -1,0 +1,106 @@
+import { existsSync as nodeExistsSync } from 'fs'
+import path from 'path'
+import { homedir, userInfo } from 'os'
+import type { DockerEngineInfo } from './types'
+
+type DetectOptions = {
+  platform?: NodeJS.Platform
+  env?: NodeJS.ProcessEnv
+  uid?: number
+  existsSync?: (candidate: string) => boolean
+}
+
+export function detectDockerEngine(options: DetectOptions = {}): DockerEngineInfo {
+  const platform = options.platform ?? process.platform
+  const env = options.env ?? process.env
+  const existsSync = options.existsSync ?? nodeExistsSync
+  const home = env.HOME ?? env.USERPROFILE ?? homedir()
+
+  if (platform === 'darwin') {
+    const colimaSocket = path.join(home, '.colima', 'default', 'docker.sock')
+    if (existsSync(colimaSocket)) {
+      return {
+        flavor: 'colima',
+        socketPath: colimaSocket,
+        available: true
+      }
+    }
+
+    const desktopSocket = path.join(path.sep, 'var', 'run', 'docker.sock')
+    if (existsSync(desktopSocket)) {
+      return {
+        flavor: 'docker-desktop-mac',
+        socketPath: desktopSocket,
+        available: true
+      }
+    }
+
+    return {
+      flavor: 'docker-desktop-mac',
+      socketPath: desktopSocket,
+      available: false,
+      reason: 'Docker Desktop or Colima socket was not found'
+    }
+  }
+
+  if (platform === 'linux') {
+    const engineSocket = path.join(path.sep, 'var', 'run', 'docker.sock')
+    if (existsSync(engineSocket)) {
+      return {
+        flavor: 'docker-engine-linux',
+        socketPath: engineSocket,
+        available: true
+      }
+    }
+
+    const uid = options.uid ?? safeUid()
+    const rootlessSocket = path.join(path.sep, 'run', 'user', String(uid), 'docker.sock')
+    if (existsSync(rootlessSocket)) {
+      return {
+        flavor: 'docker-rootless-linux',
+        socketPath: rootlessSocket,
+        available: true
+      }
+    }
+
+    return {
+      flavor: 'docker-engine-linux',
+      socketPath: engineSocket,
+      available: false,
+      reason: 'Docker Engine socket was not found'
+    }
+  }
+
+  if (platform === 'win32') {
+    const pipeName = String.raw`\\.\pipe\docker_engine`
+    if (existsSync(pipeName)) {
+      return {
+        flavor: 'docker-desktop-windows-wsl2',
+        socketPath: pipeName,
+        available: true
+      }
+    }
+
+    return {
+      flavor: 'docker-desktop-windows-wsl2',
+      socketPath: pipeName,
+      available: false,
+      reason: 'Docker Desktop WSL2 named pipe was not found'
+    }
+  }
+
+  return {
+    flavor: 'docker-engine-linux',
+    socketPath: '',
+    available: false,
+    reason: `Unsupported platform: ${platform}`
+  }
+}
+
+function safeUid(): number {
+  try {
+    return userInfo().uid
+  } catch {
+    return 0
+  }
+}

--- a/src/main/docker/docker-engine-fake.ts
+++ b/src/main/docker/docker-engine-fake.ts
@@ -1,0 +1,220 @@
+import type {
+  DockerBuildImageOptions,
+  DockerCreateContainerOptions,
+  DockerEngineClientLike,
+  DockerExecOptions,
+  DockerExecResult,
+  DockerExecSession,
+  DockerExecSessionOptions
+} from './docker-engine-client'
+
+export type DockerEngineFakeCommand =
+  | { command: 'image.pull'; image: string }
+  | { command: 'image.build'; options: DockerBuildImageOptions }
+  | { command: 'container.create'; options: DockerCreateContainerOptions }
+  | { command: 'container.start'; id: string }
+  | { command: 'container.inspect'; id: string }
+  | { command: 'container.exec'; options: DockerExecOptions }
+  | { command: 'container.exec.spawn'; options: DockerExecSessionOptions }
+  | { command: 'container.stop'; id: string }
+  | { command: 'container.rm'; id: string }
+
+type FakeContainer = {
+  id: string
+  imageId: string
+  running: boolean
+}
+
+export class DockerEngineFake implements DockerEngineClientLike {
+  readonly commands: DockerEngineFakeCommand[] = []
+  readonly containers = new Map<string, FakeContainer>()
+  readonly sessions = new Map<string, FakeDockerExecSession>()
+  buildDelayMs = 0
+  nextBuildError: Error | null = null
+  nextExecError: Error | null = null
+  private imageCounter = 0
+  private containerCounter = 0
+  private sessionCounter = 0
+  private execResults: DockerExecResult[] = []
+
+  enqueueExecResult(result: Partial<DockerExecResult> & { stdout?: string }): void {
+    this.execResults.push({
+      stdout: result.stdout ?? '',
+      stderr: result.stderr ?? '',
+      exitCode: result.exitCode ?? 0
+    })
+  }
+
+  async buildImage(options: DockerBuildImageOptions): Promise<{ imageId: string }> {
+    this.commands.push({ command: 'image.build', options })
+    if (this.nextBuildError) {
+      const error = this.nextBuildError
+      this.nextBuildError = null
+      throw error
+    }
+    if (this.buildDelayMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, this.buildDelayMs))
+    }
+    this.imageCounter += 1
+    return { imageId: `sha256:fake-image-${this.imageCounter}` }
+  }
+
+  async pullImage(image: string): Promise<void> {
+    this.commands.push({ command: 'image.pull', image })
+  }
+
+  async createContainer(options: DockerCreateContainerOptions): Promise<{ id: string }> {
+    this.commands.push({ command: 'container.create', options })
+    this.containerCounter += 1
+    const id = `container-${this.containerCounter}`
+    this.containers.set(id, { id, imageId: options.imageId, running: false })
+    return { id }
+  }
+
+  async startContainer(id: string): Promise<void> {
+    this.commands.push({ command: 'container.start', id })
+    const container = this.containers.get(id)
+    if (!container) {
+      throw new Error(`Unknown container ${id}`)
+    }
+    container.running = true
+  }
+
+  async inspectContainer(id: string): Promise<{ id: string; imageId: string; running: boolean }> {
+    this.commands.push({ command: 'container.inspect', id })
+    const container = this.containers.get(id)
+    if (!container) {
+      throw new Error(`Unknown container ${id}`)
+    }
+    return { ...container }
+  }
+
+  async exec(options: DockerExecOptions): Promise<DockerExecResult> {
+    this.commands.push({ command: 'container.exec', options })
+    if (this.nextExecError) {
+      const error = this.nextExecError
+      this.nextExecError = null
+      throw error
+    }
+    return this.execResults.shift() ?? { stdout: '', stderr: '', exitCode: 0 }
+  }
+
+  async spawnExec(options: DockerExecSessionOptions): Promise<DockerExecSession> {
+    this.commands.push({ command: 'container.exec.spawn', options })
+    this.sessionCounter += 1
+    const session = new FakeDockerExecSession(`session-${this.sessionCounter}`, options.cwd)
+    this.sessions.set(session.id, session)
+    return session
+  }
+
+  async stopContainer(id: string): Promise<void> {
+    this.commands.push({ command: 'container.stop', id })
+    const container = this.containers.get(id)
+    if (container) {
+      container.running = false
+    }
+  }
+
+  async removeContainer(id: string): Promise<void> {
+    this.commands.push({ command: 'container.rm', id })
+    this.containers.delete(id)
+  }
+}
+
+export class FakeDockerExecSession implements DockerExecSession {
+  readonly id: string
+  readonly writes: string[] = []
+  readonly resizes: { cols: number; rows: number }[] = []
+  private cwd: string
+  private initialCwd: string
+  private buffer = ''
+  private dataListeners = new Set<(data: string) => void>()
+  private replayListeners = new Set<(data: string) => void>()
+  private exitListeners = new Set<(code: number) => void>()
+  private exited = false
+
+  constructor(id: string, cwd: string) {
+    this.id = id
+    this.cwd = cwd
+    this.initialCwd = cwd
+  }
+
+  write(data: string): void {
+    this.writes.push(data)
+  }
+
+  resize(cols: number, rows: number): void {
+    this.resizes.push({ cols, rows })
+  }
+
+  async shutdown(_immediate: boolean): Promise<void> {
+    this.crash(0)
+  }
+
+  async sendSignal(_signal: string): Promise<void> {}
+
+  async getCwd(): Promise<string> {
+    return this.cwd
+  }
+
+  async getInitialCwd(): Promise<string> {
+    return this.initialCwd
+  }
+
+  async clearBuffer(): Promise<void> {
+    this.buffer = ''
+  }
+
+  acknowledgeDataEvent(_charCount: number): void {}
+
+  async hasChildProcesses(): Promise<boolean> {
+    return !this.exited
+  }
+
+  async getForegroundProcess(): Promise<string | null> {
+    return this.exited ? null : 'sh'
+  }
+
+  async serialize(): Promise<string> {
+    return this.buffer
+  }
+
+  async revive(state: string): Promise<void> {
+    this.buffer = state
+    for (const cb of this.replayListeners) {
+      cb(state)
+    }
+  }
+
+  onData(callback: (data: string) => void): () => void {
+    this.dataListeners.add(callback)
+    return () => this.dataListeners.delete(callback)
+  }
+
+  onReplay(callback: (data: string) => void): () => void {
+    this.replayListeners.add(callback)
+    return () => this.replayListeners.delete(callback)
+  }
+
+  onExit(callback: (code: number) => void): () => void {
+    this.exitListeners.add(callback)
+    return () => this.exitListeners.delete(callback)
+  }
+
+  emitData(data: string): void {
+    this.buffer += data
+    for (const cb of this.dataListeners) {
+      cb(data)
+    }
+  }
+
+  crash(code: number): void {
+    if (this.exited) {
+      return
+    }
+    this.exited = true
+    for (const cb of this.exitListeners) {
+      cb(code)
+    }
+  }
+}

--- a/src/main/docker/docker-engine-fake.ts
+++ b/src/main/docker/docker-engine-fake.ts
@@ -23,6 +23,7 @@ type FakeContainer = {
   id: string
   imageId: string
   running: boolean
+  labels?: Record<string, string>
 }
 
 export class DockerEngineFake implements DockerEngineClientLike {
@@ -36,6 +37,7 @@ export class DockerEngineFake implements DockerEngineClientLike {
   private containerCounter = 0
   private sessionCounter = 0
   private execResults: DockerExecResult[] = []
+  private execErrors: Error[] = []
 
   enqueueExecResult(result: Partial<DockerExecResult> & { stdout?: string }): void {
     this.execResults.push({
@@ -43,6 +45,10 @@ export class DockerEngineFake implements DockerEngineClientLike {
       stderr: result.stderr ?? '',
       exitCode: result.exitCode ?? 0
     })
+  }
+
+  enqueueExecError(error: Error): void {
+    this.execErrors.push(error)
   }
 
   async buildImage(options: DockerBuildImageOptions): Promise<{ imageId: string }> {
@@ -67,7 +73,12 @@ export class DockerEngineFake implements DockerEngineClientLike {
     this.commands.push({ command: 'container.create', options })
     this.containerCounter += 1
     const id = `container-${this.containerCounter}`
-    this.containers.set(id, { id, imageId: options.imageId, running: false })
+    this.containers.set(id, {
+      id,
+      imageId: options.imageId,
+      running: false,
+      labels: options.labels
+    })
     return { id }
   }
 
@@ -80,7 +91,12 @@ export class DockerEngineFake implements DockerEngineClientLike {
     container.running = true
   }
 
-  async inspectContainer(id: string): Promise<{ id: string; imageId: string; running: boolean }> {
+  async inspectContainer(id: string): Promise<{
+    id: string
+    imageId: string
+    running: boolean
+    labels?: Record<string, string>
+  }> {
     this.commands.push({ command: 'container.inspect', id })
     const container = this.containers.get(id)
     if (!container) {
@@ -95,6 +111,10 @@ export class DockerEngineFake implements DockerEngineClientLike {
       const error = this.nextExecError
       this.nextExecError = null
       throw error
+    }
+    const queuedError = this.execErrors.shift()
+    if (queuedError) {
+      throw queuedError
     }
     return this.execResults.shift() ?? { stdout: '', stderr: '', exitCode: 0 }
   }

--- a/src/main/docker/docker-image-build.test.ts
+++ b/src/main/docker/docker-image-build.test.ts
@@ -1,0 +1,80 @@
+import { mkdtemp, mkdir, writeFile, rm } from 'fs/promises'
+import { tmpdir } from 'os'
+import path from 'path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { DockerEngineFake } from './docker-engine-fake'
+import {
+  buildDockerImage,
+  computeDockerImageCacheKey,
+  resolveDockerfile
+} from './docker-image-build'
+
+describe('docker-image-build', () => {
+  let repoPath: string
+
+  beforeEach(async () => {
+    repoPath = await mkdtemp(path.join(tmpdir(), 'orca-docker-image-test-'))
+  })
+
+  afterEach(async () => {
+    await rm(repoPath, { recursive: true, force: true })
+  })
+
+  it('prefers .devcontainer/Dockerfile over .orca/Dockerfile', async () => {
+    await mkdir(path.join(repoPath, '.devcontainer'))
+    await mkdir(path.join(repoPath, '.orca'))
+    await writeFile(path.join(repoPath, '.devcontainer', 'Dockerfile'), 'FROM node:24\n')
+    await writeFile(path.join(repoPath, '.orca', 'Dockerfile'), 'FROM ubuntu:24.04\n')
+
+    const result = await resolveDockerfile(repoPath)
+
+    expect(result).toMatchObject({
+      dockerfilePath: path.join(repoPath, '.devcontainer', 'Dockerfile'),
+      content: 'FROM node:24\n',
+      isGenerated: false
+    })
+  })
+
+  it('uses .orca/Dockerfile when no devcontainer Dockerfile exists', async () => {
+    await mkdir(path.join(repoPath, '.orca'))
+    await writeFile(path.join(repoPath, '.orca', 'Dockerfile'), 'FROM ubuntu:24.04\n')
+
+    const result = await resolveDockerfile(repoPath)
+
+    expect(result.dockerfilePath).toBe(path.join(repoPath, '.orca', 'Dockerfile'))
+  })
+
+  it('builds a generated default Dockerfile and returns a handle', async () => {
+    const engine = new DockerEngineFake()
+
+    const image = await buildDockerImage({
+      repoPath,
+      repoIdentity: 'stablyai/orca',
+      engine,
+      now: () => 123
+    })
+
+    expect(image).toMatchObject({
+      id: 'sha256:fake-image-1',
+      builtAt: 123,
+      dockerfilePath: 'auto-generated:orca-default'
+    })
+    expect(engine.commands[0]).toMatchObject({
+      command: 'image.build',
+      options: { contextPath: repoPath, dockerfileContent: expect.stringContaining('FROM ubuntu') }
+    })
+  })
+
+  it('includes repo identity in the cache key', () => {
+    const a = computeDockerImageCacheKey({ dockerfileContent: 'FROM node\n', repoIdentity: 'a' })
+    const b = computeDockerImageCacheKey({ dockerfileContent: 'FROM node\n', repoIdentity: 'b' })
+    expect(a).not.toBe(b)
+  })
+
+  it('surfaces image build failures', async () => {
+    const engine = new DockerEngineFake()
+    engine.nextBuildError = new Error('build failed')
+
+    await expect(buildDockerImage({ repoPath, engine })).rejects.toThrow('build failed')
+  })
+})

--- a/src/main/docker/docker-image-build.test.ts
+++ b/src/main/docker/docker-image-build.test.ts
@@ -61,7 +61,14 @@ describe('docker-image-build', () => {
     })
     expect(engine.commands[0]).toMatchObject({
       command: 'image.build',
-      options: { contextPath: repoPath, dockerfileContent: expect.stringContaining('FROM ubuntu') }
+      options: {
+        contextPath: repoPath,
+        dockerfileContent: expect.stringContaining('FROM ubuntu'),
+        labels: {
+          'dev.orca.managed': 'true',
+          'dev.orca.repo': 'stablyai/orca'
+        }
+      }
     })
   })
 

--- a/src/main/docker/docker-image-build.ts
+++ b/src/main/docker/docker-image-build.ts
@@ -1,0 +1,91 @@
+import { existsSync } from 'fs'
+import { readFile } from 'fs/promises'
+import { createHash } from 'crypto'
+import path from 'path'
+import type { DockerEngineClientLike } from './docker-engine-client'
+import type { DockerImageHandle } from './types'
+
+const DEFAULT_DOCKERFILE_CONTENT = `FROM ubuntu:24.04
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl git nodejs npm ripgrep && rm -rf /var/lib/apt/lists/*
+WORKDIR /workspace
+`
+const DEFAULT_DOCKERFILE_PATH = 'auto-generated:orca-default'
+
+export type ResolveDockerfileResult = {
+  dockerfilePath: string
+  content: string
+  isGenerated: boolean
+}
+
+export type BuildDockerImageOptions = {
+  repoPath: string
+  repoIdentity?: string
+  engine: DockerEngineClientLike
+  timeoutMs?: number
+  now?: () => number
+}
+
+export async function resolveDockerfile(repoPath: string): Promise<ResolveDockerfileResult> {
+  const devcontainerDockerfile = path.join(repoPath, '.devcontainer', 'Dockerfile')
+  if (existsSync(devcontainerDockerfile)) {
+    return {
+      dockerfilePath: devcontainerDockerfile,
+      content: await readFile(devcontainerDockerfile, 'utf-8'),
+      isGenerated: false
+    }
+  }
+
+  const orcaDockerfile = path.join(repoPath, '.orca', 'Dockerfile')
+  if (existsSync(orcaDockerfile)) {
+    return {
+      dockerfilePath: orcaDockerfile,
+      content: await readFile(orcaDockerfile, 'utf-8'),
+      isGenerated: false
+    }
+  }
+
+  return {
+    dockerfilePath: DEFAULT_DOCKERFILE_PATH,
+    content: DEFAULT_DOCKERFILE_CONTENT,
+    isGenerated: true
+  }
+}
+
+export async function buildDockerImage(
+  options: BuildDockerImageOptions
+): Promise<DockerImageHandle> {
+  const dockerfile = await resolveDockerfile(options.repoPath)
+  const cacheKey = computeDockerImageCacheKey({
+    dockerfileContent: dockerfile.content,
+    repoIdentity: options.repoIdentity ?? options.repoPath
+  })
+  const tag = `orca-worktree:${cacheKey.slice(0, 24)}`
+
+  const result = await options.engine.buildImage({
+    contextPath: options.repoPath,
+    dockerfilePath: dockerfile.dockerfilePath,
+    dockerfileContent: dockerfile.isGenerated ? dockerfile.content : undefined,
+    tag,
+    timeoutMs: options.timeoutMs
+  })
+
+  return {
+    id: result.imageId,
+    cacheKey,
+    dockerfilePath: dockerfile.dockerfilePath,
+    builtAt: (options.now ?? Date.now)()
+  }
+}
+
+export function computeDockerImageCacheKey(input: {
+  dockerfileContent: string
+  repoIdentity: string
+}): string {
+  // Why: tying the image cache to both Dockerfile content and repo identity
+  // prevents two unrelated repos with identical Dockerfiles from sharing setup.
+  return createHash('sha256')
+    .update(input.repoIdentity)
+    .update('\0')
+    .update(input.dockerfileContent)
+    .digest('hex')
+}

--- a/src/main/docker/docker-image-build.ts
+++ b/src/main/docker/docker-image-build.ts
@@ -10,6 +10,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
 WORKDIR /workspace
 `
 const DEFAULT_DOCKERFILE_PATH = 'auto-generated:orca-default'
+export const ORCA_DOCKER_MANAGED_LABEL = 'dev.orca.managed'
+export const ORCA_DOCKER_REPO_LABEL = 'dev.orca.repo'
 
 export type ResolveDockerfileResult = {
   dockerfilePath: string
@@ -66,6 +68,10 @@ export async function buildDockerImage(
     dockerfilePath: dockerfile.dockerfilePath,
     dockerfileContent: dockerfile.isGenerated ? dockerfile.content : undefined,
     tag,
+    labels: {
+      [ORCA_DOCKER_MANAGED_LABEL]: 'true',
+      [ORCA_DOCKER_REPO_LABEL]: options.repoIdentity ?? options.repoPath
+    },
     timeoutMs: options.timeoutMs
   })
 

--- a/src/main/docker/docker-mount.test.ts
+++ b/src/main/docker/docker-mount.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_CONTAINER_WORKDIR,
+  resolveDockerBindMount,
+  translateWindowsPathForWsl2
+} from './docker-mount'
+
+describe('docker-mount', () => {
+  it('keeps macOS paths unchanged', () => {
+    expect(resolveDockerBindMount({ hostPath: '/Users/me/repo', platform: 'darwin' })).toEqual({
+      source: '/Users/me/repo',
+      target: DEFAULT_CONTAINER_WORKDIR,
+      readonly: undefined
+    })
+  })
+
+  it('keeps Linux paths unchanged', () => {
+    expect(
+      resolveDockerBindMount({ hostPath: '/home/me/repo', platform: 'linux', readonly: true })
+    ).toEqual({
+      source: '/home/me/repo',
+      target: DEFAULT_CONTAINER_WORKDIR,
+      readonly: true
+    })
+  })
+
+  it('translates Windows drive paths for Docker Desktop WSL2', () => {
+    expect(translateWindowsPathForWsl2('C:\\Users\\u\\repo')).toBe('/mnt/c/Users/u/repo')
+    expect(
+      resolveDockerBindMount({
+        hostPath: 'D:\\code\\repo',
+        platform: 'win32',
+        containerPath: '/workspace'
+      })
+    ).toMatchObject({ source: '/mnt/d/code/repo', target: '/workspace' })
+  })
+
+  it('leaves non-drive Windows paths unchanged', () => {
+    expect(translateWindowsPathForWsl2('\\\\wsl.localhost\\Ubuntu\\home\\u\\repo')).toBe(
+      '\\\\wsl.localhost\\Ubuntu\\home\\u\\repo'
+    )
+  })
+})

--- a/src/main/docker/docker-mount.test.ts
+++ b/src/main/docker/docker-mount.test.ts
@@ -40,4 +40,14 @@ describe('docker-mount', () => {
       '\\\\wsl.localhost\\Ubuntu\\home\\u\\repo'
     )
   })
+
+  it('rejects unsafe container mount targets', () => {
+    expect(() =>
+      resolveDockerBindMount({
+        hostPath: '/home/me/repo',
+        platform: 'linux',
+        containerPath: '/'
+      })
+    ).toThrow('must not be the container root')
+  })
 })

--- a/src/main/docker/docker-mount.ts
+++ b/src/main/docker/docker-mount.ts
@@ -1,0 +1,42 @@
+import path from 'path'
+
+export type DockerBindMount = {
+  source: string
+  target: string
+  readonly?: boolean
+}
+
+export type ResolveDockerBindMountOptions = {
+  hostPath: string
+  platform?: NodeJS.Platform
+  containerPath?: string
+  readonly?: boolean
+}
+
+export const DEFAULT_CONTAINER_WORKDIR = path.posix.join(path.posix.sep, 'workspace')
+
+export function resolveDockerBindMount(options: ResolveDockerBindMountOptions): DockerBindMount {
+  const platform = options.platform ?? process.platform
+  const source =
+    platform === 'win32' ? translateWindowsPathForWsl2(options.hostPath) : options.hostPath
+
+  return {
+    source,
+    target: options.containerPath ?? DEFAULT_CONTAINER_WORKDIR,
+    readonly: options.readonly
+  }
+}
+
+export function translateWindowsPathForWsl2(hostPath: string): string {
+  const normalized = hostPath.replace(/\//g, '\\')
+  const driveMatch = normalized.match(/^([A-Za-z]):\\(.*)$/)
+  if (!driveMatch) {
+    return hostPath
+  }
+
+  const drive = driveMatch[1].toLowerCase()
+  const rest = driveMatch[2].split('\\').filter(Boolean)
+  // Why: Docker Desktop's WSL2 backend sees Windows drives at /mnt/<drive>,
+  // so bind mounts must use that Linux path instead of the Win32 host path.
+  return path.posix.join(path.posix.sep, 'mnt', drive, ...rest)
+}

--- a/src/main/docker/docker-mount.ts
+++ b/src/main/docker/docker-mount.ts
@@ -1,4 +1,5 @@
 import path from 'path'
+import { normalizeDockerMountTarget } from './docker-container-path'
 
 export type DockerBindMount = {
   source: string
@@ -22,7 +23,7 @@ export function resolveDockerBindMount(options: ResolveDockerBindMountOptions): 
 
   return {
     source,
-    target: options.containerPath ?? DEFAULT_CONTAINER_WORKDIR,
+    target: normalizeDockerMountTarget(options.containerPath ?? DEFAULT_CONTAINER_WORKDIR),
     readonly: options.readonly
   }
 }

--- a/src/main/docker/types.ts
+++ b/src/main/docker/types.ts
@@ -1,0 +1,33 @@
+export type DockerImageHandle = {
+  id: string
+  cacheKey: string
+  dockerfilePath: string
+  builtAt: number
+}
+
+export type DockerContainerHandle = {
+  id: string
+  imageId: string
+  startedAt: number
+  state: 'running' | 'hibernated' | 'terminated'
+}
+
+export type DockerTarget = {
+  containerId: string
+  image: DockerImageHandle
+  workdir: string
+}
+
+export type DockerEngineFlavor =
+  | 'docker-desktop-mac'
+  | 'colima'
+  | 'docker-engine-linux'
+  | 'docker-rootless-linux'
+  | 'docker-desktop-windows-wsl2'
+
+export type DockerEngineInfo = {
+  flavor: DockerEngineFlavor
+  socketPath: string
+  available: boolean
+  reason?: string
+}

--- a/src/main/docker/types.ts
+++ b/src/main/docker/types.ts
@@ -16,6 +16,8 @@ export type DockerTarget = {
   containerId: string
   image: DockerImageHandle
   workdir: string
+  hostWorktreePath?: string
+  hostPlatform?: NodeJS.Platform
 }
 
 export type DockerEngineFlavor =

--- a/src/main/providers/docker-filesystem-provider.test.ts
+++ b/src/main/providers/docker-filesystem-provider.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { DockerEngineFake } from '../docker/docker-engine-fake'
+import type { DockerTarget } from '../docker/types'
+import { DockerFilesystemProvider } from './docker-filesystem-provider'
+
+describe('DockerFilesystemProvider', () => {
+  let engine: DockerEngineFake
+  let provider: DockerFilesystemProvider
+
+  beforeEach(() => {
+    engine = new DockerEngineFake()
+    const target: DockerTarget = {
+      containerId: 'container-1',
+      workdir: '/workspace',
+      image: { id: 'sha256:image', cacheKey: 'key', dockerfilePath: 'Dockerfile', builtAt: 1 }
+    }
+    provider = new DockerFilesystemProvider(target, engine)
+  })
+
+  it('reads directories through docker exec', async () => {
+    engine.enqueueExecResult({
+      stdout: JSON.stringify([{ name: 'src', isDirectory: true, isSymlink: false }])
+    })
+
+    await expect(provider.readDir('/workspace')).resolves.toEqual([
+      { name: 'src', isDirectory: true, isSymlink: false }
+    ])
+    expect(engine.commands[0]).toMatchObject({
+      command: 'container.exec',
+      options: {
+        containerId: 'container-1',
+        args: ['node', '-e', expect.any(String), '/workspace']
+      }
+    })
+  })
+
+  it('writes files using stdin instead of shell interpolation', async () => {
+    await provider.writeFile('/workspace/a.txt', 'hello')
+
+    expect(engine.commands[0]).toMatchObject({
+      command: 'container.exec',
+      options: { input: 'hello' }
+    })
+  })
+
+  it('returns stat, search, and file list results from JSON stdout', async () => {
+    engine.enqueueExecResult({ stdout: JSON.stringify({ size: 1, type: 'file', mtime: 2 }) })
+    engine.enqueueExecResult({
+      stdout: JSON.stringify({ files: [], totalMatches: 0, truncated: false })
+    })
+    engine.enqueueExecResult({ stdout: JSON.stringify(['src/index.ts']) })
+
+    await expect(provider.stat('/workspace/a.txt')).resolves.toMatchObject({ type: 'file' })
+    await expect(provider.search({ rootPath: '/workspace', query: 'TODO' })).resolves.toMatchObject(
+      {
+        totalMatches: 0
+      }
+    )
+    await expect(provider.listFiles('/workspace')).resolves.toEqual(['src/index.ts'])
+  })
+
+  it('registers and unregisters watches without a real daemon watcher', async () => {
+    const callback = vi.fn()
+    const unwatch = await provider.watch('/workspace', callback)
+
+    expect(engine.commands[0]).toMatchObject({
+      command: 'container.exec',
+      options: { args: ['sh', '-lc', 'true'], cwd: '/workspace' }
+    })
+    unwatch()
+  })
+
+  it('surfaces docker exec failures', async () => {
+    engine.nextExecError = new Error('container crashed')
+
+    await expect(provider.readFile('/workspace/a.txt')).rejects.toThrow('container crashed')
+  })
+})

--- a/src/main/providers/docker-filesystem-provider.test.ts
+++ b/src/main/providers/docker-filesystem-provider.test.ts
@@ -43,6 +43,41 @@ describe('DockerFilesystemProvider', () => {
     })
   })
 
+  it('writes binary content through stdin instead of argv', async () => {
+    await provider.writeFileBase64('/workspace/a.bin', Buffer.from([0, 1, 2]).toString('base64'))
+
+    expect(engine.commands[0]).toMatchObject({
+      command: 'container.exec',
+      options: { input: 'AAEC' }
+    })
+  })
+
+  it('translates trusted host paths into container paths', async () => {
+    provider = new DockerFilesystemProvider(
+      {
+        containerId: 'container-1',
+        workdir: '/workspace',
+        hostWorktreePath: '/Users/me/repo',
+        hostPlatform: 'darwin',
+        image: { id: 'sha256:image', cacheKey: 'key', dockerfilePath: 'Dockerfile', builtAt: 1 }
+      },
+      engine
+    )
+    engine.enqueueExecResult({ stdout: JSON.stringify({ size: 1, type: 'file', mtime: 2 }) })
+
+    await provider.stat('/Users/me/repo/src/app.ts')
+
+    expect(engine.commands[0]).toMatchObject({
+      options: { args: ['node', '-e', expect.any(String), '/workspace/src/app.ts'] }
+    })
+  })
+
+  it('rejects paths outside the container workdir before docker exec', async () => {
+    await expect(provider.readFile('/etc/passwd')).rejects.toThrow('resolves outside')
+    await expect(provider.writeFile('../outside.txt', 'x')).rejects.toThrow('resolves outside')
+    expect(engine.commands).toHaveLength(0)
+  })
+
   it('returns stat, search, and file list results from JSON stdout', async () => {
     engine.enqueueExecResult({ stdout: JSON.stringify({ size: 1, type: 'file', mtime: 2 }) })
     engine.enqueueExecResult({
@@ -57,6 +92,18 @@ describe('DockerFilesystemProvider', () => {
       }
     )
     await expect(provider.listFiles('/workspace')).resolves.toEqual(['src/index.ts'])
+    expect(engine.commands[1]).toMatchObject({
+      options: {
+        args: [
+          'node',
+          '-e',
+          expect.any(String),
+          expect.stringContaining('"maxResults":2000'),
+          String(5 * 1024 * 1024),
+          '10000'
+        ]
+      }
+    })
   })
 
   it('registers and unregisters watches without a real daemon watcher', async () => {

--- a/src/main/providers/docker-filesystem-provider.ts
+++ b/src/main/providers/docker-filesystem-provider.ts
@@ -1,0 +1,211 @@
+import type { DockerEngineClientLike } from '../docker/docker-engine-client'
+import { DockerEngineClient } from '../docker/docker-engine-client'
+import type { DockerTarget } from '../docker/types'
+import type { IFilesystemProvider, FileReadResult, FileStat } from './types'
+import type { DirEntry, FsChangeEvent, SearchOptions, SearchResult } from '../../shared/types'
+
+export class DockerFilesystemProvider implements IFilesystemProvider {
+  private target: DockerTarget
+  private engine: DockerEngineClientLike
+  private watchListeners = new Map<string, (events: FsChangeEvent[]) => void>()
+
+  constructor(target: DockerTarget, engine: DockerEngineClientLike = new DockerEngineClient()) {
+    this.target = target
+    this.engine = engine
+  }
+
+  getConnectionId(): string {
+    return this.target.containerId
+  }
+
+  async readDir(dirPath: string): Promise<DirEntry[]> {
+    return this.execNodeJson<DirEntry[]>(READ_DIR_SCRIPT, [dirPath])
+  }
+
+  async readFile(filePath: string): Promise<FileReadResult> {
+    return this.execNodeJson<FileReadResult>(READ_FILE_SCRIPT, [filePath])
+  }
+
+  async writeFile(filePath: string, content: string): Promise<void> {
+    await this.execNodeVoid(WRITE_FILE_SCRIPT, [filePath], content)
+  }
+
+  async stat(filePath: string): Promise<FileStat> {
+    return this.execNodeJson<FileStat>(STAT_SCRIPT, [filePath])
+  }
+
+  async deletePath(targetPath: string, recursive?: boolean): Promise<void> {
+    await this.execNodeVoid(DELETE_PATH_SCRIPT, [targetPath, recursive ? '1' : '0'])
+  }
+
+  async createFile(filePath: string): Promise<void> {
+    await this.execNodeVoid(CREATE_FILE_SCRIPT, [filePath])
+  }
+
+  async createDir(dirPath: string): Promise<void> {
+    await this.execNodeVoid(CREATE_DIR_SCRIPT, [dirPath])
+  }
+
+  async rename(oldPath: string, newPath: string): Promise<void> {
+    await this.execNodeVoid(RENAME_SCRIPT, [oldPath, newPath])
+  }
+
+  async copy(source: string, destination: string): Promise<void> {
+    await this.execNodeVoid(COPY_SCRIPT, [source, destination])
+  }
+
+  async realpath(filePath: string): Promise<string> {
+    return this.execNodeJson<string>(REALPATH_SCRIPT, [filePath])
+  }
+
+  async search(opts: SearchOptions): Promise<SearchResult> {
+    return this.execNodeJson<SearchResult>(SEARCH_SCRIPT, [JSON.stringify(opts)])
+  }
+
+  async listFiles(rootPath: string, options?: { excludePaths?: string[] }): Promise<string[]> {
+    return this.execNodeJson<string[]>(LIST_FILES_SCRIPT, [
+      rootPath,
+      JSON.stringify(options?.excludePaths ?? [])
+    ])
+  }
+
+  async watch(rootPath: string, callback: (events: FsChangeEvent[]) => void): Promise<() => void> {
+    this.watchListeners.set(rootPath, callback)
+    await this.engine.exec({
+      containerId: this.target.containerId,
+      args: ['sh', '-lc', 'true'],
+      cwd: rootPath
+    })
+    return () => {
+      this.watchListeners.delete(rootPath)
+    }
+  }
+
+  private async execNodeJson<T>(script: string, args: string[], input?: string): Promise<T> {
+    const result = await this.engine.exec({
+      containerId: this.target.containerId,
+      args: ['node', '-e', script, ...args],
+      cwd: this.target.workdir,
+      input
+    })
+    return JSON.parse(result.stdout) as T
+  }
+
+  private async execNodeVoid(script: string, args: string[], input?: string): Promise<void> {
+    await this.engine.exec({
+      containerId: this.target.containerId,
+      args: ['node', '-e', script, ...args],
+      cwd: this.target.workdir,
+      input
+    })
+  }
+}
+
+const READ_DIR_SCRIPT = `
+const fs = require('fs');
+const entries = fs.readdirSync(process.argv[1], { withFileTypes: true })
+  .map((entry) => ({ name: entry.name, isDirectory: entry.isDirectory(), isSymlink: entry.isSymbolicLink() }))
+  .sort((a, b) => a.isDirectory !== b.isDirectory ? (a.isDirectory ? -1 : 1) : a.name.localeCompare(b.name));
+process.stdout.write(JSON.stringify(entries));
+`
+const READ_FILE_SCRIPT = `
+const fs = require('fs');
+const filePath = process.argv[1];
+const buffer = fs.readFileSync(filePath);
+const isBinary = buffer.subarray(0, Math.min(buffer.length, 8192)).includes(0);
+process.stdout.write(JSON.stringify({ content: isBinary ? '' : buffer.toString('utf8'), isBinary }));
+`
+const WRITE_FILE_SCRIPT = `
+const fs = require('fs');
+let input = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', chunk => input += chunk);
+process.stdin.on('end', () => fs.writeFileSync(process.argv[1], input, 'utf8'));
+`
+const STAT_SCRIPT = `
+const fs = require('fs');
+const stat = fs.lstatSync(process.argv[1]);
+process.stdout.write(JSON.stringify({
+  size: stat.size,
+  type: stat.isDirectory() ? 'directory' : (stat.isSymbolicLink() ? 'symlink' : 'file'),
+  mtime: stat.mtimeMs
+}));
+`
+const DELETE_PATH_SCRIPT = `
+const fs = require('fs');
+fs.rmSync(process.argv[1], { recursive: process.argv[2] === '1', force: true });
+`
+const CREATE_FILE_SCRIPT = `
+const fs = require('fs');
+fs.closeSync(fs.openSync(process.argv[1], 'wx'));
+`
+const CREATE_DIR_SCRIPT = `
+const fs = require('fs');
+fs.mkdirSync(process.argv[1], { recursive: true });
+`
+const RENAME_SCRIPT = `
+const fs = require('fs');
+fs.renameSync(process.argv[1], process.argv[2]);
+`
+const COPY_SCRIPT = `
+const fs = require('fs');
+const stat = fs.lstatSync(process.argv[1]);
+if (stat.isDirectory()) fs.cpSync(process.argv[1], process.argv[2], { recursive: true });
+else fs.copyFileSync(process.argv[1], process.argv[2]);
+`
+const REALPATH_SCRIPT = `
+const fs = require('fs');
+process.stdout.write(JSON.stringify(fs.realpathSync(process.argv[1])));
+`
+const LIST_FILES_SCRIPT = `
+const fs = require('fs');
+const path = require('path');
+const root = process.argv[1];
+const excludes = new Set(JSON.parse(process.argv[2]));
+const out = [];
+function walk(dir) {
+  if (excludes.has(dir)) return;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === '.git') continue;
+    const abs = path.join(dir, entry.name);
+    if (excludes.has(abs)) continue;
+    if (entry.isDirectory()) walk(abs);
+    else out.push(path.relative(root, abs).replace(/\\\\/g, '/'));
+  }
+}
+walk(root);
+process.stdout.write(JSON.stringify(out.sort()));
+`
+const SEARCH_SCRIPT = `
+const fs = require('fs');
+const path = require('path');
+const opts = JSON.parse(process.argv[1]);
+const query = opts.caseSensitive ? opts.query : opts.query.toLowerCase();
+const max = opts.maxResults || 2000;
+const files = [];
+let totalMatches = 0;
+function visit(filePath) {
+  if (totalMatches >= max) return;
+  const stat = fs.statSync(filePath);
+  if (stat.isDirectory()) {
+    if (path.basename(filePath) === '.git') return;
+    for (const child of fs.readdirSync(filePath)) visit(path.join(filePath, child));
+    return;
+  }
+  const text = fs.readFileSync(filePath, 'utf8');
+  const haystack = opts.caseSensitive ? text : text.toLowerCase();
+  const matches = [];
+  const lines = text.split(/\\r?\\n/);
+  for (let i = 0; i < lines.length && totalMatches < max; i++) {
+    const lineHaystack = opts.caseSensitive ? lines[i] : lines[i].toLowerCase();
+    const column = lineHaystack.indexOf(query);
+    if (column >= 0) {
+      matches.push({ line: i + 1, column: column + 1, matchLength: opts.query.length, lineContent: lines[i] });
+      totalMatches++;
+    }
+  }
+  if (matches.length) files.push({ filePath, relativePath: path.relative(opts.rootPath, filePath).replace(/\\\\/g, '/'), matches });
+}
+visit(opts.rootPath);
+process.stdout.write(JSON.stringify({ files, totalMatches, truncated: totalMatches >= max }));
+`

--- a/src/main/providers/docker-filesystem-provider.ts
+++ b/src/main/providers/docker-filesystem-provider.ts
@@ -1,8 +1,17 @@
+/* eslint-disable max-lines -- Why: the embedded Docker-side filesystem scripts
+ * stay next to the provider methods so path, stdin, and size-limit contracts
+ * can be audited together. */
 import type { DockerEngineClientLike } from '../docker/docker-engine-client'
 import { DockerEngineClient } from '../docker/docker-engine-client'
+import { resolveDockerContainerPath } from '../docker/docker-container-path'
 import type { DockerTarget } from '../docker/types'
 import type { IFilesystemProvider, FileReadResult, FileStat } from './types'
 import type { DirEntry, FsChangeEvent, SearchOptions, SearchResult } from '../../shared/types'
+import { DEFAULT_SEARCH_MAX_RESULTS } from '../../shared/text-search'
+
+const MAX_DOCKER_FILE_READ_BYTES = 10 * 1024 * 1024
+const MAX_DOCKER_SEARCH_FILE_BYTES = 5 * 1024 * 1024
+const MAX_DOCKER_SEARCH_SCANNED_FILES = 10_000
 
 export class DockerFilesystemProvider implements IFilesystemProvider {
   private target: DockerTarget
@@ -19,65 +28,127 @@ export class DockerFilesystemProvider implements IFilesystemProvider {
   }
 
   async readDir(dirPath: string): Promise<DirEntry[]> {
-    return this.execNodeJson<DirEntry[]>(READ_DIR_SCRIPT, [dirPath])
+    return this.execNodeJson<DirEntry[]>(READ_DIR_SCRIPT, [this.containerPath(dirPath)])
   }
 
   async readFile(filePath: string): Promise<FileReadResult> {
-    return this.execNodeJson<FileReadResult>(READ_FILE_SCRIPT, [filePath])
+    return this.execNodeJson<FileReadResult>(READ_FILE_SCRIPT, [
+      this.containerPath(filePath),
+      String(MAX_DOCKER_FILE_READ_BYTES)
+    ])
   }
 
   async writeFile(filePath: string, content: string): Promise<void> {
-    await this.execNodeVoid(WRITE_FILE_SCRIPT, [filePath], content)
+    await this.execNodeVoid(WRITE_FILE_SCRIPT, [this.containerPath(filePath)], content)
+  }
+
+  async writeFileBase64(filePath: string, contentBase64: string): Promise<void> {
+    await this.writeFileBase64Chunk(filePath, contentBase64, false)
+  }
+
+  async writeFileBase64Chunk(
+    filePath: string,
+    contentBase64: string,
+    append: boolean
+  ): Promise<void> {
+    await this.execNodeVoid(
+      WRITE_FILE_BASE64_SCRIPT,
+      [this.containerPath(filePath), append ? '1' : '0'],
+      contentBase64
+    )
   }
 
   async stat(filePath: string): Promise<FileStat> {
-    return this.execNodeJson<FileStat>(STAT_SCRIPT, [filePath])
+    return this.execNodeJson<FileStat>(STAT_SCRIPT, [this.containerPath(filePath)])
   }
 
   async deletePath(targetPath: string, recursive?: boolean): Promise<void> {
-    await this.execNodeVoid(DELETE_PATH_SCRIPT, [targetPath, recursive ? '1' : '0'])
+    await this.execNodeVoid(DELETE_PATH_SCRIPT, [
+      this.containerPath(targetPath),
+      recursive ? '1' : '0'
+    ])
   }
 
   async createFile(filePath: string): Promise<void> {
-    await this.execNodeVoid(CREATE_FILE_SCRIPT, [filePath])
+    await this.execNodeVoid(CREATE_FILE_SCRIPT, [this.containerPath(filePath)])
   }
 
   async createDir(dirPath: string): Promise<void> {
-    await this.execNodeVoid(CREATE_DIR_SCRIPT, [dirPath])
+    await this.execNodeVoid(CREATE_DIR_SCRIPT, [this.containerPath(dirPath)])
+  }
+
+  async createDirNoClobber(dirPath: string): Promise<void> {
+    await this.execNodeVoid(CREATE_DIR_NO_CLOBBER_SCRIPT, [this.containerPath(dirPath)])
   }
 
   async rename(oldPath: string, newPath: string): Promise<void> {
-    await this.execNodeVoid(RENAME_SCRIPT, [oldPath, newPath])
+    await this.execNodeVoid(RENAME_SCRIPT, [
+      this.containerPath(oldPath),
+      this.containerPath(newPath)
+    ])
+  }
+
+  async renameNoClobber(oldPath: string, newPath: string): Promise<void> {
+    await this.execNodeVoid(RENAME_NO_CLOBBER_SCRIPT, [
+      this.containerPath(oldPath),
+      this.containerPath(newPath)
+    ])
   }
 
   async copy(source: string, destination: string): Promise<void> {
-    await this.execNodeVoid(COPY_SCRIPT, [source, destination])
+    await this.execNodeVoid(COPY_SCRIPT, [
+      this.containerPath(source),
+      this.containerPath(destination)
+    ])
   }
 
   async realpath(filePath: string): Promise<string> {
-    return this.execNodeJson<string>(REALPATH_SCRIPT, [filePath])
+    return this.execNodeJson<string>(REALPATH_SCRIPT, [this.containerPath(filePath)])
   }
 
   async search(opts: SearchOptions): Promise<SearchResult> {
-    return this.execNodeJson<SearchResult>(SEARCH_SCRIPT, [JSON.stringify(opts)])
+    return this.execNodeJson<SearchResult>(SEARCH_SCRIPT, [
+      JSON.stringify(this.normalizeSearchOptions(opts)),
+      String(MAX_DOCKER_SEARCH_FILE_BYTES),
+      String(MAX_DOCKER_SEARCH_SCANNED_FILES)
+    ])
   }
 
   async listFiles(rootPath: string, options?: { excludePaths?: string[] }): Promise<string[]> {
     return this.execNodeJson<string[]>(LIST_FILES_SCRIPT, [
-      rootPath,
-      JSON.stringify(options?.excludePaths ?? [])
+      this.containerPath(rootPath),
+      JSON.stringify(
+        (options?.excludePaths ?? []).map((excludePath) => this.containerPath(excludePath))
+      ),
+      String(MAX_DOCKER_SEARCH_SCANNED_FILES)
     ])
   }
 
   async watch(rootPath: string, callback: (events: FsChangeEvent[]) => void): Promise<() => void> {
-    this.watchListeners.set(rootPath, callback)
+    const containerRoot = this.containerPath(rootPath)
+    this.watchListeners.set(containerRoot, callback)
     await this.engine.exec({
       containerId: this.target.containerId,
       args: ['sh', '-lc', 'true'],
-      cwd: rootPath
+      cwd: containerRoot
     })
     return () => {
-      this.watchListeners.delete(rootPath)
+      this.watchListeners.delete(containerRoot)
+    }
+  }
+
+  private containerPath(filePath: string): string {
+    return resolveDockerContainerPath(this.target, filePath)
+  }
+
+  private normalizeSearchOptions(opts: SearchOptions): SearchOptions {
+    return {
+      ...opts,
+      rootPath: this.containerPath(opts.rootPath),
+      maxResults: Math.max(
+        1,
+        Math.min(opts.maxResults ?? DEFAULT_SEARCH_MAX_RESULTS, DEFAULT_SEARCH_MAX_RESULTS)
+      )
     }
   }
 
@@ -111,6 +182,9 @@ process.stdout.write(JSON.stringify(entries));
 const READ_FILE_SCRIPT = `
 const fs = require('fs');
 const filePath = process.argv[1];
+const maxBytes = Number(process.argv[2]);
+const stat = fs.statSync(filePath);
+if (stat.size > maxBytes) throw new Error('File is too large to read through Docker provider');
 const buffer = fs.readFileSync(filePath);
 const isBinary = buffer.subarray(0, Math.min(buffer.length, 8192)).includes(0);
 process.stdout.write(JSON.stringify({ content: isBinary ? '' : buffer.toString('utf8'), isBinary }));
@@ -121,6 +195,16 @@ let input = '';
 process.stdin.setEncoding('utf8');
 process.stdin.on('data', chunk => input += chunk);
 process.stdin.on('end', () => fs.writeFileSync(process.argv[1], input, 'utf8'));
+`
+const WRITE_FILE_BASE64_SCRIPT = `
+const fs = require('fs');
+let input = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', chunk => input += chunk);
+process.stdin.on('end', () => {
+  const buffer = Buffer.from(input, 'base64');
+  fs.writeFileSync(process.argv[1], buffer, process.argv[2] === '1' ? { flag: 'a' } : undefined);
+});
 `
 const STAT_SCRIPT = `
 const fs = require('fs');
@@ -143,8 +227,17 @@ const CREATE_DIR_SCRIPT = `
 const fs = require('fs');
 fs.mkdirSync(process.argv[1], { recursive: true });
 `
+const CREATE_DIR_NO_CLOBBER_SCRIPT = `
+const fs = require('fs');
+fs.mkdirSync(process.argv[1]);
+`
 const RENAME_SCRIPT = `
 const fs = require('fs');
+fs.renameSync(process.argv[1], process.argv[2]);
+`
+const RENAME_NO_CLOBBER_SCRIPT = `
+const fs = require('fs');
+if (fs.existsSync(process.argv[2])) throw new Error('Destination already exists');
 fs.renameSync(process.argv[1], process.argv[2]);
 `
 const COPY_SCRIPT = `
@@ -162,13 +255,16 @@ const fs = require('fs');
 const path = require('path');
 const root = process.argv[1];
 const excludes = new Set(JSON.parse(process.argv[2]));
+const maxFiles = Number(process.argv[3]);
 const out = [];
 function walk(dir) {
+  if (out.length >= maxFiles) return;
   if (excludes.has(dir)) return;
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
     if (entry.name === '.git') continue;
     const abs = path.join(dir, entry.name);
     if (excludes.has(abs)) continue;
+    if (entry.isSymbolicLink()) continue;
     if (entry.isDirectory()) walk(abs);
     else out.push(path.relative(root, abs).replace(/\\\\/g, '/'));
   }
@@ -180,32 +276,56 @@ const SEARCH_SCRIPT = `
 const fs = require('fs');
 const path = require('path');
 const opts = JSON.parse(process.argv[1]);
-const query = opts.caseSensitive ? opts.query : opts.query.toLowerCase();
+const maxFileBytes = Number(process.argv[2]);
+const maxScannedFiles = Number(process.argv[3]);
 const max = opts.maxResults || 2000;
 const files = [];
 let totalMatches = 0;
+let scannedFiles = 0;
+function escapeRegExp(value) {
+  return value.replace(/[|\\\\{}()[\\]^$+*?.]/g, '\\\\$&');
+}
+function globToRegExp(pattern) {
+  return new RegExp('^' + escapeRegExp(pattern).replace(/\\\\\\*/g, '.*') + '$');
+}
+const include = opts.includePattern ? globToRegExp(opts.includePattern) : null;
+const exclude = opts.excludePattern ? globToRegExp(opts.excludePattern) : null;
+const source = opts.useRegex ? opts.query : escapeRegExp(opts.query);
+const wrapped = opts.wholeWord ? '\\\\b(?:' + source + ')\\\\b' : source;
+const matcher = new RegExp(wrapped, opts.caseSensitive ? 'g' : 'gi');
 function visit(filePath) {
   if (totalMatches >= max) return;
-  const stat = fs.statSync(filePath);
+  let stat;
+  try {
+    stat = fs.lstatSync(filePath);
+  } catch {
+    return;
+  }
+  if (stat.isSymbolicLink()) return;
   if (stat.isDirectory()) {
     if (path.basename(filePath) === '.git') return;
     for (const child of fs.readdirSync(filePath)) visit(path.join(filePath, child));
     return;
   }
-  const text = fs.readFileSync(filePath, 'utf8');
-  const haystack = opts.caseSensitive ? text : text.toLowerCase();
+  scannedFiles++;
+  if (scannedFiles > maxScannedFiles || stat.size > maxFileBytes) return;
+  const rel = path.relative(opts.rootPath, filePath).replace(/\\\\/g, '/');
+  if ((include && !include.test(rel)) || (exclude && exclude.test(rel))) return;
+  const buffer = fs.readFileSync(filePath);
+  if (buffer.subarray(0, Math.min(buffer.length, 8192)).includes(0)) return;
+  const text = buffer.toString('utf8');
   const matches = [];
   const lines = text.split(/\\r?\\n/);
   for (let i = 0; i < lines.length && totalMatches < max; i++) {
-    const lineHaystack = opts.caseSensitive ? lines[i] : lines[i].toLowerCase();
-    const column = lineHaystack.indexOf(query);
-    if (column >= 0) {
-      matches.push({ line: i + 1, column: column + 1, matchLength: opts.query.length, lineContent: lines[i] });
+    matcher.lastIndex = 0;
+    const match = matcher.exec(lines[i]);
+    if (match) {
+      matches.push({ line: i + 1, column: match.index + 1, matchLength: match[0].length, lineContent: lines[i].slice(0, 500) });
       totalMatches++;
     }
   }
-  if (matches.length) files.push({ filePath, relativePath: path.relative(opts.rootPath, filePath).replace(/\\\\/g, '/'), matches });
+  if (matches.length) files.push({ filePath, relativePath: rel, matches });
 }
 visit(opts.rootPath);
-process.stdout.write(JSON.stringify({ files, totalMatches, truncated: totalMatches >= max }));
+process.stdout.write(JSON.stringify({ files, totalMatches, truncated: totalMatches >= max || scannedFiles > maxScannedFiles }));
 `

--- a/src/main/providers/docker-git-provider.test.ts
+++ b/src/main/providers/docker-git-provider.test.ts
@@ -38,6 +38,80 @@ describe('DockerGitProvider', () => {
     })
   })
 
+  it('surfaces unmerged status records as unresolved conflicts', async () => {
+    engine.enqueueExecResult({
+      stdout: 'u UU N... 100644 100644 100644 100644 abc def ghi src/conflicted file.ts\n'
+    })
+    engine.enqueueExecResult({ stdout: '.git\n' })
+
+    const result = await provider.getStatus('/workspace')
+
+    expect(result.entries).toEqual([
+      {
+        path: 'src/conflicted file.ts',
+        status: 'modified',
+        area: 'unstaged',
+        conflictKind: 'both_modified',
+        conflictStatus: 'unresolved'
+      }
+    ])
+  })
+
+  it('returns original and modified contents for staged diffs', async () => {
+    engine.enqueueExecResult({ stdout: 'head content\n' })
+    engine.enqueueExecResult({ stdout: 'staged content\n' })
+
+    const result = await provider.getDiff('/workspace', 'src/app.ts', true)
+
+    expect(result).toEqual({
+      kind: 'text',
+      originalContent: 'head content\n',
+      modifiedContent: 'staged content\n',
+      originalIsBinary: false,
+      modifiedIsBinary: false
+    })
+    expect(engine.commands.map((command) => command.command)).toEqual([
+      'container.exec',
+      'container.exec'
+    ])
+    expect(engine.commands[0]).toMatchObject({
+      options: { args: ['git', 'show', 'HEAD:src/app.ts'] }
+    })
+    expect(engine.commands[1]).toMatchObject({
+      options: { args: ['git', 'show', ':src/app.ts'] }
+    })
+  })
+
+  it('returns original and modified contents for unstaged diffs', async () => {
+    engine.enqueueExecResult({ stdout: 'index content\n' })
+    engine.enqueueExecResult({ stdout: 'working content\n' })
+
+    const result = await provider.getDiff('/workspace', 'src/app.ts', false)
+
+    expect(result).toMatchObject({
+      originalContent: 'index content\n',
+      modifiedContent: 'working content\n'
+    })
+    expect(engine.commands[0]).toMatchObject({
+      options: { args: ['git', 'show', ':src/app.ts'] }
+    })
+    expect(engine.commands[1]).toMatchObject({
+      options: { args: ['cat', '--', 'src/app.ts'] }
+    })
+  })
+
+  it('returns empty original content and working-tree content for untracked diffs', async () => {
+    engine.enqueueExecResult({ stdout: '' })
+    engine.enqueueExecResult({ stdout: 'new file\n' })
+
+    const result = await provider.getDiff('/workspace', 'src/new.ts', false)
+
+    expect(result).toMatchObject({
+      originalContent: '',
+      modifiedContent: 'new file\n'
+    })
+  })
+
   it('stages, unstages, and discards files with git commands', async () => {
     await provider.stageFile('/workspace', 'a.ts')
     await provider.unstageFile('/workspace', 'a.ts')
@@ -58,6 +132,57 @@ describe('DockerGitProvider', () => {
     engine.enqueueExecResult({ stdout: '.git\n' })
 
     await expect(provider.detectConflictOperation('/workspace')).resolves.toBe('merge')
+  })
+
+  it('preserves the new path when parsing renamed branch entries', async () => {
+    engine.enqueueExecResult({ stdout: 'base-sha\n' })
+    engine.enqueueExecResult({ stdout: 'R100\tsrc/old.ts\tsrc/new.ts\n' })
+    engine.enqueueExecResult({ stdout: 'head-sha\n' })
+
+    const result = await provider.getBranchCompare('/workspace', 'origin/main')
+
+    expect(result.entries).toEqual([
+      { path: 'src/new.ts', oldPath: 'src/old.ts', status: 'renamed' }
+    ])
+  })
+
+  it('returns blob contents for branch diffs and uses oldPath for renamed originals', async () => {
+    engine.enqueueExecResult({ stdout: 'old content\n' })
+    engine.enqueueExecResult({ stdout: 'new content\n' })
+
+    const result = await provider.getBranchDiff('/workspace', 'base-sha', {
+      includePatch: true,
+      filePath: 'src/new.ts',
+      oldPath: 'src/old.ts'
+    })
+
+    expect(result).toEqual([
+      {
+        kind: 'text',
+        originalContent: 'old content\n',
+        modifiedContent: 'new content\n',
+        originalIsBinary: false,
+        modifiedIsBinary: false
+      }
+    ])
+    expect(engine.commands[0]).toMatchObject({
+      options: { args: ['git', 'show', 'base-sha:src/old.ts'] }
+    })
+    expect(engine.commands[1]).toMatchObject({
+      options: { args: ['git', 'show', 'HEAD:src/new.ts'] }
+    })
+  })
+
+  it('uses the resolved default branch for remote file URLs', async () => {
+    engine.enqueueExecResult({ stdout: 'git@github.com:stablyai/orca.git\n' })
+    engine.enqueueExecResult({ stdout: 'refs/remotes/origin/master\n' })
+
+    const result = await provider.getRemoteFileUrl('/workspace', 'src/app.ts', 42)
+
+    expect(result).toBe('https://github.com/stablyai/orca/blob/master/src/app.ts#L42')
+    expect(engine.commands[1]).toMatchObject({
+      options: { args: ['git', 'symbolic-ref', '--quiet', 'refs/remotes/origin/HEAD'] }
+    })
   })
 
   it('checks git repo status asynchronously', async () => {

--- a/src/main/providers/docker-git-provider.test.ts
+++ b/src/main/providers/docker-git-provider.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { DockerEngineFake } from '../docker/docker-engine-fake'
+import type { DockerTarget } from '../docker/types'
+import { DockerGitProvider } from './docker-git-provider'
+
+describe('DockerGitProvider', () => {
+  let engine: DockerEngineFake
+  let provider: DockerGitProvider
+
+  beforeEach(() => {
+    engine = new DockerEngineFake()
+    const target: DockerTarget = {
+      containerId: 'container-1',
+      workdir: '/workspace',
+      image: { id: 'sha256:image', cacheKey: 'key', dockerfilePath: 'Dockerfile', builtAt: 1 }
+    }
+    provider = new DockerGitProvider(target, engine)
+  })
+
+  it('routes status through git inside the container', async () => {
+    engine.enqueueExecResult({
+      stdout: '1 M. N... 100644 100644 100644 abc abc src/app.ts\n? new.txt\n'
+    })
+    engine.enqueueExecResult({ stdout: '.git\n' })
+
+    const result = await provider.getStatus('/workspace')
+
+    expect(result.entries).toEqual([
+      { path: 'src/app.ts', status: 'modified', area: 'staged' },
+      { path: 'new.txt', status: 'untracked', area: 'untracked' }
+    ])
+    expect(engine.commands[0]).toMatchObject({
+      command: 'container.exec',
+      options: {
+        args: ['git', 'status', '--porcelain=v2', '--untracked-files=all'],
+        cwd: '/workspace'
+      }
+    })
+  })
+
+  it('stages, unstages, and discards files with git commands', async () => {
+    await provider.stageFile('/workspace', 'a.ts')
+    await provider.unstageFile('/workspace', 'a.ts')
+    await provider.discardChanges('/workspace', 'a.ts')
+
+    expect(engine.commands.map((command) => command.command)).toEqual([
+      'container.exec',
+      'container.exec',
+      'container.exec'
+    ])
+    expect(engine.commands[0]).toMatchObject({
+      command: 'container.exec',
+      options: { args: ['git', 'add', '--', 'a.ts'] }
+    })
+  })
+
+  it('detects merge conflicts', async () => {
+    engine.enqueueExecResult({ stdout: '.git\n' })
+
+    await expect(provider.detectConflictOperation('/workspace')).resolves.toBe('merge')
+  })
+
+  it('checks git repo status asynchronously', async () => {
+    engine.enqueueExecResult({ stdout: '/workspace\n' })
+
+    await expect(provider.isGitRepoAsync('/workspace')).resolves.toEqual({
+      isRepo: true,
+      rootPath: '/workspace'
+    })
+  })
+
+  it('surfaces container crashes during git operations', async () => {
+    engine.nextExecError = new Error('container crashed')
+
+    await expect(provider.stageFile('/workspace', 'a.ts')).rejects.toThrow('container crashed')
+  })
+})

--- a/src/main/providers/docker-git-provider.test.ts
+++ b/src/main/providers/docker-git-provider.test.ts
@@ -32,7 +32,15 @@ describe('DockerGitProvider', () => {
     expect(engine.commands[0]).toMatchObject({
       command: 'container.exec',
       options: {
-        args: ['git', 'status', '--porcelain=v2', '--untracked-files=all'],
+        args: [
+          'git',
+          '-c',
+          'core.quotePath=false',
+          'status',
+          '--porcelain=v2',
+          '--branch',
+          '--untracked-files=all'
+        ],
         cwd: '/workspace'
       }
     })
@@ -75,16 +83,18 @@ describe('DockerGitProvider', () => {
       'container.exec'
     ])
     expect(engine.commands[0]).toMatchObject({
-      options: { args: ['git', 'show', 'HEAD:src/app.ts'] }
+      options: { args: ['git', 'show', '--no-textconv', '--end-of-options', 'HEAD:src/app.ts'] }
     })
     expect(engine.commands[1]).toMatchObject({
-      options: { args: ['git', 'show', ':src/app.ts'] }
+      options: { args: ['git', 'show', '--no-textconv', '--end-of-options', ':src/app.ts'] }
     })
   })
 
   it('returns original and modified contents for unstaged diffs', async () => {
     engine.enqueueExecResult({ stdout: 'index content\n' })
-    engine.enqueueExecResult({ stdout: 'working content\n' })
+    engine.enqueueExecResult({
+      stdout: JSON.stringify({ content: 'working content\n', isBinary: false })
+    })
 
     const result = await provider.getDiff('/workspace', 'src/app.ts', false)
 
@@ -93,16 +103,19 @@ describe('DockerGitProvider', () => {
       modifiedContent: 'working content\n'
     })
     expect(engine.commands[0]).toMatchObject({
-      options: { args: ['git', 'show', ':src/app.ts'] }
+      options: { args: ['git', 'show', '--no-textconv', '--end-of-options', ':src/app.ts'] }
     })
     expect(engine.commands[1]).toMatchObject({
-      options: { args: ['cat', '--', 'src/app.ts'] }
+      options: { args: ['node', '-e', expect.any(String), 'src/app.ts', String(10 * 1024 * 1024)] }
     })
   })
 
   it('returns empty original content and working-tree content for untracked diffs', async () => {
-    engine.enqueueExecResult({ stdout: '' })
-    engine.enqueueExecResult({ stdout: 'new file\n' })
+    engine.enqueueExecError(new Error('not in index'))
+    engine.enqueueExecError(new Error('not in head'))
+    engine.enqueueExecResult({
+      stdout: JSON.stringify({ content: 'new file\n', isBinary: false })
+    })
 
     const result = await provider.getDiff('/workspace', 'src/new.ts', false)
 
@@ -135,9 +148,11 @@ describe('DockerGitProvider', () => {
   })
 
   it('preserves the new path when parsing renamed branch entries', async () => {
-    engine.enqueueExecResult({ stdout: 'base-sha\n' })
-    engine.enqueueExecResult({ stdout: 'R100\tsrc/old.ts\tsrc/new.ts\n' })
     engine.enqueueExecResult({ stdout: 'head-sha\n' })
+    engine.enqueueExecResult({ stdout: 'base-sha\n' })
+    engine.enqueueExecResult({ stdout: 'merge-sha\n' })
+    engine.enqueueExecResult({ stdout: 'R100\tsrc/old.ts\tsrc/new.ts\n' })
+    engine.enqueueExecResult({ stdout: '1\n' })
 
     const result = await provider.getBranchCompare('/workspace', 'origin/main')
 
@@ -166,10 +181,12 @@ describe('DockerGitProvider', () => {
       }
     ])
     expect(engine.commands[0]).toMatchObject({
-      options: { args: ['git', 'show', 'base-sha:src/old.ts'] }
+      options: {
+        args: ['git', 'show', '--no-textconv', '--end-of-options', 'base-sha:src/old.ts']
+      }
     })
     expect(engine.commands[1]).toMatchObject({
-      options: { args: ['git', 'show', 'HEAD:src/new.ts'] }
+      options: { args: ['git', 'show', '--no-textconv', '--end-of-options', 'HEAD:src/new.ts'] }
     })
   })
 
@@ -191,6 +208,42 @@ describe('DockerGitProvider', () => {
     await expect(provider.isGitRepoAsync('/workspace')).resolves.toEqual({
       isRepo: true,
       rootPath: '/workspace'
+    })
+  })
+
+  it('translates trusted host worktree paths into container paths', async () => {
+    provider = new DockerGitProvider(
+      {
+        containerId: 'container-1',
+        workdir: '/workspace',
+        hostWorktreePath: '/Users/me/repo',
+        hostPlatform: 'darwin',
+        image: { id: 'sha256:image', cacheKey: 'key', dockerfilePath: 'Dockerfile', builtAt: 1 }
+      },
+      engine
+    )
+
+    await provider.stageFile('/Users/me/repo', '/Users/me/repo/src/app.ts')
+
+    expect(engine.commands[0]).toMatchObject({
+      options: { cwd: '/workspace', args: ['git', 'add', '--', 'src/app.ts'] }
+    })
+  })
+
+  it('rejects git path traversal before executing docker', async () => {
+    await expect(provider.stageFile('/workspace', '../outside.txt')).rejects.toThrow(
+      'resolves outside'
+    )
+    expect(engine.commands).toHaveLength(0)
+  })
+
+  it('marks git diffs as binary when blob output contains binary bytes', async () => {
+    engine.enqueueExecResult({ stdout: 'left\0binary' })
+    engine.enqueueExecResult({ stdout: 'right text' })
+
+    await expect(provider.getDiff('/workspace', 'image.bin', true)).resolves.toMatchObject({
+      kind: 'binary',
+      originalIsBinary: true
     })
   })
 

--- a/src/main/providers/docker-git-provider.ts
+++ b/src/main/providers/docker-git-provider.ts
@@ -1,13 +1,19 @@
+/* eslint-disable max-lines */
 import hostedGitInfo from 'hosted-git-info'
 import type { DockerEngineClientLike } from '../docker/docker-engine-client'
 import { DockerEngineClient } from '../docker/docker-engine-client'
 import type { DockerTarget } from '../docker/types'
+import { resolveDefaultBaseRefViaExec } from '../git/repo'
 import type { IGitProvider } from './types'
 import type {
+  GitBranchChangeEntry,
   GitBranchCompareResult,
+  GitBranchChangeStatus,
+  GitConflictKind,
   GitConflictOperation,
   GitDiffResult,
   GitFileStatus,
+  GitStatusEntry,
   GitStatusResult,
   GitWorktreeInfo
 } from '../../shared/types'
@@ -34,15 +40,14 @@ export class DockerGitProvider implements IGitProvider {
   }
 
   async getDiff(worktreePath: string, filePath: string, staged: boolean): Promise<GitDiffResult> {
-    const args = staged ? ['diff', '--cached', '--', filePath] : ['diff', '--', filePath]
-    const result = await this.git(args, worktreePath)
-    return {
-      kind: 'text',
-      originalContent: '',
-      modifiedContent: result.stdout,
-      originalIsBinary: false,
-      modifiedIsBinary: false
-    }
+    const originalBlob = staged
+      ? await this.readGitBlob(worktreePath, 'HEAD', filePath)
+      : await this.readUnstagedLeftBlob(worktreePath, filePath)
+    const modifiedContent = staged
+      ? (await this.readGitIndexBlob(worktreePath, filePath)).content
+      : await this.readWorkingTreeFile(worktreePath, filePath)
+
+    return buildTextDiffResult(originalBlob.content, modifiedContent)
   }
 
   async stageFile(worktreePath: string, filePath: string): Promise<void> {
@@ -87,18 +92,15 @@ export class DockerGitProvider implements IGitProvider {
 
   async getBranchCompare(worktreePath: string, baseRef: string): Promise<GitBranchCompareResult> {
     const mergeBase = (await this.git(['merge-base', baseRef, 'HEAD'], worktreePath)).stdout.trim()
-    const names = await this.git(['diff', '--name-status', mergeBase, 'HEAD'], worktreePath)
+    const names = await this.git(
+      ['diff', '--name-status', '-M', '-C', mergeBase, 'HEAD'],
+      worktreePath
+    )
     const entries = names.stdout
       .split(/\r?\n/)
       .filter(Boolean)
-      .map((line) => {
-        const [status, filePath, oldPath] = line.split('\t')
-        return {
-          path: filePath,
-          status: parseBranchStatus(status),
-          ...(oldPath ? { oldPath } : {})
-        }
-      })
+      .map(parseBranchChangeLine)
+      .filter((entry): entry is GitBranchChangeEntry => entry !== null)
     return {
       summary: {
         baseRef,
@@ -118,20 +120,31 @@ export class DockerGitProvider implements IGitProvider {
     baseRef: string,
     options?: { includePatch?: boolean; filePath?: string; oldPath?: string }
   ): Promise<GitDiffResult[]> {
-    const args = ['diff', baseRef, 'HEAD']
-    if (options?.filePath) {
-      args.push('--', options.filePath)
+    const entries = options?.filePath
+      ? [
+          {
+            path: options.filePath,
+            status: 'modified' as const,
+            ...(options.oldPath ? { oldPath: options.oldPath } : {})
+          }
+        ]
+      : await this.loadBranchChanges(worktreePath, baseRef)
+
+    if (options?.includePatch === false) {
+      return entries.map(() => buildTextDiffResult('', ''))
     }
-    const result = await this.git(args, worktreePath)
-    return [
-      {
-        kind: 'text',
-        originalContent: '',
-        modifiedContent: result.stdout,
-        originalIsBinary: false,
-        modifiedIsBinary: false
-      }
-    ]
+
+    return Promise.all(
+      entries.map(async (entry) => {
+        const originalContent = await this.readGitBlob(
+          worktreePath,
+          baseRef,
+          entry.oldPath ?? entry.path
+        )
+        const modifiedContent = await this.readGitBlob(worktreePath, 'HEAD', entry.path)
+        return buildTextDiffResult(originalContent.content, modifiedContent.content)
+      })
+    )
   }
 
   async listWorktrees(repoPath: string): Promise<GitWorktreeInfo[]> {
@@ -195,7 +208,14 @@ export class DockerGitProvider implements IGitProvider {
     if (!info) {
       return null
     }
-    const browseUrl = info.browseFile(relativePath, { committish: 'main' })
+    const defaultBaseRef = await resolveDefaultBaseRefViaExec((argv) =>
+      this.git(argv, worktreePath)
+    )
+    if (!defaultBaseRef) {
+      return null
+    }
+    const defaultBranch = defaultBaseRef.replace(/^origin\//, '')
+    const browseUrl = info.browseFile(relativePath, { committish: defaultBranch })
     return browseUrl ? `${browseUrl}#L${line}` : null
   }
 
@@ -220,6 +240,76 @@ export class DockerGitProvider implements IGitProvider {
       return false
     }
   }
+
+  private async loadBranchChanges(
+    worktreePath: string,
+    baseRef: string
+  ): Promise<GitBranchChangeEntry[]> {
+    const result = await this.git(
+      ['diff', '--name-status', '-M', '-C', baseRef, 'HEAD'],
+      worktreePath
+    )
+    return result.stdout
+      .split(/\r?\n/)
+      .filter(Boolean)
+      .map(parseBranchChangeLine)
+      .filter((entry): entry is GitBranchChangeEntry => entry !== null)
+  }
+
+  private async readUnstagedLeftBlob(
+    worktreePath: string,
+    filePath: string
+  ): Promise<DockerGitBlobReadResult> {
+    const indexBlob = await this.readGitIndexBlob(worktreePath, filePath)
+    if (indexBlob.exists) {
+      return indexBlob
+    }
+    return this.readGitBlob(worktreePath, 'HEAD', filePath)
+  }
+
+  private async readGitIndexBlob(
+    worktreePath: string,
+    filePath: string
+  ): Promise<DockerGitBlobReadResult> {
+    return this.readGitBlobSpec(worktreePath, `:${filePath}`)
+  }
+
+  private async readGitBlob(
+    worktreePath: string,
+    ref: string,
+    filePath: string
+  ): Promise<DockerGitBlobReadResult> {
+    return this.readGitBlobSpec(worktreePath, `${ref}:${filePath}`)
+  }
+
+  private async readGitBlobSpec(
+    worktreePath: string,
+    spec: string
+  ): Promise<DockerGitBlobReadResult> {
+    try {
+      return { content: (await this.git(['show', spec], worktreePath)).stdout, exists: true }
+    } catch {
+      return { content: '', exists: false }
+    }
+  }
+
+  private async readWorkingTreeFile(worktreePath: string, filePath: string): Promise<string> {
+    try {
+      const result = await this.engine.exec({
+        containerId: this.target.containerId,
+        args: ['cat', '--', filePath],
+        cwd: worktreePath
+      })
+      return result.stdout
+    } catch {
+      return ''
+    }
+  }
+}
+
+type DockerGitBlobReadResult = {
+  content: string
+  exists: boolean
 }
 
 function parseStatus(stdout: string): GitStatusResult['entries'] {
@@ -241,6 +331,13 @@ function parseStatus(stdout: string): GitStatusResult['entries'] {
       }
       if (xy[1] !== '.') {
         entries.push({ path: filePath, status: parseFileStatus(xy[1]), area: 'unstaged' })
+      }
+      continue
+    }
+    if (line.startsWith('u ')) {
+      const entry = parseUnmergedStatusLine(line)
+      if (entry) {
+        entries.push(entry)
       }
     }
   }
@@ -264,6 +361,79 @@ function parseFileStatus(char: string): GitFileStatus {
 
 function parseBranchStatus(char: string): 'modified' | 'added' | 'deleted' | 'renamed' | 'copied' {
   return parseFileStatus(char[0]) as 'modified' | 'added' | 'deleted' | 'renamed' | 'copied'
+}
+
+function parseBranchChangeLine(line: string): GitBranchChangeEntry | null {
+  const parts = line.split('\t')
+  const rawStatus = parts[0] ?? ''
+  const status = parseBranchStatus(rawStatus) as GitBranchChangeStatus
+
+  if (rawStatus.startsWith('R') || rawStatus.startsWith('C')) {
+    const oldPath = parts[1]
+    const filePath = parts[2]
+    if (!filePath) {
+      return null
+    }
+    return { path: filePath, oldPath, status }
+  }
+
+  const filePath = parts[1]
+  if (!filePath) {
+    return null
+  }
+  return { path: filePath, status }
+}
+
+function parseUnmergedStatusLine(line: string): GitStatusEntry | null {
+  const parts = line.split(' ')
+  const xy = parts[1]
+  const filePath = parts.slice(10).join(' ')
+  if (!xy || !filePath) {
+    return null
+  }
+  const conflictKind = parseConflictKind(xy)
+  if (!conflictKind) {
+    return null
+  }
+
+  return {
+    path: filePath,
+    area: 'unstaged',
+    status: conflictKind === 'both_deleted' ? 'deleted' : 'modified',
+    conflictKind,
+    conflictStatus: 'unresolved'
+  }
+}
+
+function parseConflictKind(xy: string): GitConflictKind | null {
+  switch (xy) {
+    case 'UU':
+      return 'both_modified'
+    case 'AA':
+      return 'both_added'
+    case 'DD':
+      return 'both_deleted'
+    case 'AU':
+      return 'added_by_us'
+    case 'UA':
+      return 'added_by_them'
+    case 'DU':
+      return 'deleted_by_us'
+    case 'UD':
+      return 'deleted_by_them'
+    default:
+      return null
+  }
+}
+
+function buildTextDiffResult(originalContent: string, modifiedContent: string): GitDiffResult {
+  return {
+    kind: 'text',
+    originalContent,
+    modifiedContent,
+    originalIsBinary: false,
+    modifiedIsBinary: false
+  }
 }
 
 function parseWorktrees(stdout: string): GitWorktreeInfo[] {

--- a/src/main/providers/docker-git-provider.ts
+++ b/src/main/providers/docker-git-provider.ts
@@ -1,0 +1,286 @@
+import hostedGitInfo from 'hosted-git-info'
+import type { DockerEngineClientLike } from '../docker/docker-engine-client'
+import { DockerEngineClient } from '../docker/docker-engine-client'
+import type { DockerTarget } from '../docker/types'
+import type { IGitProvider } from './types'
+import type {
+  GitBranchCompareResult,
+  GitConflictOperation,
+  GitDiffResult,
+  GitFileStatus,
+  GitStatusResult,
+  GitWorktreeInfo
+} from '../../shared/types'
+
+export class DockerGitProvider implements IGitProvider {
+  private target: DockerTarget
+  private engine: DockerEngineClientLike
+
+  constructor(target: DockerTarget, engine: DockerEngineClientLike = new DockerEngineClient()) {
+    this.target = target
+    this.engine = engine
+  }
+
+  getConnectionId(): string {
+    return this.target.containerId
+  }
+
+  async getStatus(worktreePath: string): Promise<GitStatusResult> {
+    const [status, conflictOperation] = await Promise.all([
+      this.git(['status', '--porcelain=v2', '--untracked-files=all'], worktreePath),
+      this.detectConflictOperation(worktreePath)
+    ])
+    return { entries: parseStatus(status.stdout), conflictOperation }
+  }
+
+  async getDiff(worktreePath: string, filePath: string, staged: boolean): Promise<GitDiffResult> {
+    const args = staged ? ['diff', '--cached', '--', filePath] : ['diff', '--', filePath]
+    const result = await this.git(args, worktreePath)
+    return {
+      kind: 'text',
+      originalContent: '',
+      modifiedContent: result.stdout,
+      originalIsBinary: false,
+      modifiedIsBinary: false
+    }
+  }
+
+  async stageFile(worktreePath: string, filePath: string): Promise<void> {
+    await this.git(['add', '--', filePath], worktreePath)
+  }
+
+  async unstageFile(worktreePath: string, filePath: string): Promise<void> {
+    await this.git(['restore', '--staged', '--', filePath], worktreePath)
+  }
+
+  async bulkStageFiles(worktreePath: string, filePaths: string[]): Promise<void> {
+    await this.git(['add', '--', ...filePaths], worktreePath)
+  }
+
+  async bulkUnstageFiles(worktreePath: string, filePaths: string[]): Promise<void> {
+    await this.git(['restore', '--staged', '--', ...filePaths], worktreePath)
+  }
+
+  async discardChanges(worktreePath: string, filePath: string): Promise<void> {
+    await this.git(['restore', '--', filePath], worktreePath)
+  }
+
+  async detectConflictOperation(worktreePath: string): Promise<GitConflictOperation> {
+    const gitDir = (await this.git(['rev-parse', '--git-dir'], worktreePath)).stdout.trim()
+    const checks = await Promise.all([
+      this.pathExists(worktreePath, `${gitDir}/MERGE_HEAD`),
+      this.pathExists(worktreePath, `${gitDir}/CHERRY_PICK_HEAD`),
+      this.pathExists(worktreePath, `${gitDir}/rebase-merge`),
+      this.pathExists(worktreePath, `${gitDir}/rebase-apply`)
+    ])
+    if (checks[0]) {
+      return 'merge'
+    }
+    if (checks[1]) {
+      return 'cherry-pick'
+    }
+    if (checks[2] || checks[3]) {
+      return 'rebase'
+    }
+    return 'unknown'
+  }
+
+  async getBranchCompare(worktreePath: string, baseRef: string): Promise<GitBranchCompareResult> {
+    const mergeBase = (await this.git(['merge-base', baseRef, 'HEAD'], worktreePath)).stdout.trim()
+    const names = await this.git(['diff', '--name-status', mergeBase, 'HEAD'], worktreePath)
+    const entries = names.stdout
+      .split(/\r?\n/)
+      .filter(Boolean)
+      .map((line) => {
+        const [status, filePath, oldPath] = line.split('\t')
+        return {
+          path: filePath,
+          status: parseBranchStatus(status),
+          ...(oldPath ? { oldPath } : {})
+        }
+      })
+    return {
+      summary: {
+        baseRef,
+        baseOid: mergeBase,
+        compareRef: 'HEAD',
+        headOid: (await this.git(['rev-parse', 'HEAD'], worktreePath)).stdout.trim(),
+        mergeBase,
+        changedFiles: entries.length,
+        status: 'ready'
+      },
+      entries
+    }
+  }
+
+  async getBranchDiff(
+    worktreePath: string,
+    baseRef: string,
+    options?: { includePatch?: boolean; filePath?: string; oldPath?: string }
+  ): Promise<GitDiffResult[]> {
+    const args = ['diff', baseRef, 'HEAD']
+    if (options?.filePath) {
+      args.push('--', options.filePath)
+    }
+    const result = await this.git(args, worktreePath)
+    return [
+      {
+        kind: 'text',
+        originalContent: '',
+        modifiedContent: result.stdout,
+        originalIsBinary: false,
+        modifiedIsBinary: false
+      }
+    ]
+  }
+
+  async listWorktrees(repoPath: string): Promise<GitWorktreeInfo[]> {
+    const result = await this.git(['worktree', 'list', '--porcelain'], repoPath)
+    return parseWorktrees(result.stdout)
+  }
+
+  async addWorktree(
+    repoPath: string,
+    branchName: string,
+    targetDir: string,
+    options?: { base?: string; track?: boolean }
+  ): Promise<void> {
+    const args = ['worktree', 'add']
+    if (options?.track) {
+      args.push('--track')
+    }
+    args.push(targetDir, branchName)
+    if (options?.base) {
+      args.push(options.base)
+    }
+    await this.git(args, repoPath)
+  }
+
+  async removeWorktree(worktreePath: string, force?: boolean): Promise<void> {
+    await this.git(
+      ['worktree', 'remove', ...(force ? ['--force'] : []), worktreePath],
+      this.target.workdir
+    )
+  }
+
+  async exec(args: string[], cwd: string): Promise<{ stdout: string; stderr: string }> {
+    return this.git(args, cwd)
+  }
+
+  async isGitRepoAsync(dirPath: string): Promise<{ isRepo: boolean; rootPath: string | null }> {
+    try {
+      const rootPath = (await this.git(['rev-parse', '--show-toplevel'], dirPath)).stdout.trim()
+      return { isRepo: true, rootPath }
+    } catch {
+      return { isRepo: false, rootPath: null }
+    }
+  }
+
+  isGitRepo(_path: string): boolean {
+    return true
+  }
+
+  async getRemoteFileUrl(
+    worktreePath: string,
+    relativePath: string,
+    line: number
+  ): Promise<string | null> {
+    let remoteUrl: string
+    try {
+      remoteUrl = (await this.exec(['remote', 'get-url', 'origin'], worktreePath)).stdout.trim()
+    } catch {
+      return null
+    }
+    const info = hostedGitInfo.fromUrl(remoteUrl)
+    if (!info) {
+      return null
+    }
+    const browseUrl = info.browseFile(relativePath, { committish: 'main' })
+    return browseUrl ? `${browseUrl}#L${line}` : null
+  }
+
+  private async git(args: string[], cwd: string): Promise<{ stdout: string; stderr: string }> {
+    const result = await this.engine.exec({
+      containerId: this.target.containerId,
+      args: ['git', ...args],
+      cwd
+    })
+    return { stdout: result.stdout, stderr: result.stderr }
+  }
+
+  private async pathExists(cwd: string, targetPath: string): Promise<boolean> {
+    try {
+      await this.engine.exec({
+        containerId: this.target.containerId,
+        args: ['test', '-e', targetPath],
+        cwd
+      })
+      return true
+    } catch {
+      return false
+    }
+  }
+}
+
+function parseStatus(stdout: string): GitStatusResult['entries'] {
+  const entries: GitStatusResult['entries'] = []
+  for (const line of stdout.split(/\r?\n/)) {
+    if (!line) {
+      continue
+    }
+    if (line.startsWith('? ')) {
+      entries.push({ path: line.slice(2), status: 'untracked', area: 'untracked' })
+      continue
+    }
+    if (line.startsWith('1 ') || line.startsWith('2 ')) {
+      const parts = line.split(' ')
+      const xy = parts[1]
+      const filePath = line.startsWith('2 ') ? line.split('\t')[1] : parts.slice(8).join(' ')
+      if (xy[0] !== '.') {
+        entries.push({ path: filePath, status: parseFileStatus(xy[0]), area: 'staged' })
+      }
+      if (xy[1] !== '.') {
+        entries.push({ path: filePath, status: parseFileStatus(xy[1]), area: 'unstaged' })
+      }
+    }
+  }
+  return entries
+}
+
+function parseFileStatus(char: string): GitFileStatus {
+  switch (char) {
+    case 'A':
+      return 'added'
+    case 'D':
+      return 'deleted'
+    case 'R':
+      return 'renamed'
+    case 'C':
+      return 'copied'
+    default:
+      return 'modified'
+  }
+}
+
+function parseBranchStatus(char: string): 'modified' | 'added' | 'deleted' | 'renamed' | 'copied' {
+  return parseFileStatus(char[0]) as 'modified' | 'added' | 'deleted' | 'renamed' | 'copied'
+}
+
+function parseWorktrees(stdout: string): GitWorktreeInfo[] {
+  const chunks = stdout.split(/\n\n+/).filter(Boolean)
+  return chunks.map((chunk, index) => {
+    const values = Object.fromEntries(
+      chunk.split(/\r?\n/).map((line) => {
+        const [key, ...rest] = line.split(' ')
+        return [key, rest.join(' ')]
+      })
+    )
+    return {
+      path: values.worktree,
+      head: values.HEAD,
+      branch: values.branch?.replace(/^refs\/heads\//, '') ?? '',
+      isBare: chunk.includes('\nbare'),
+      isMainWorktree: index === 0
+    }
+  })
+}

--- a/src/main/providers/docker-git-provider.ts
+++ b/src/main/providers/docker-git-provider.ts
@@ -1,22 +1,44 @@
 /* eslint-disable max-lines */
-import hostedGitInfo from 'hosted-git-info'
 import type { DockerEngineClientLike } from '../docker/docker-engine-client'
 import { DockerEngineClient } from '../docker/docker-engine-client'
+import {
+  resolveDockerContainerPath,
+  resolveDockerContainerRelativePath
+} from '../docker/docker-container-path'
 import type { DockerTarget } from '../docker/types'
+import { buildHostedRemoteFileUrl } from '../git/hosted-remote-url'
 import { resolveDefaultBaseRefViaExec } from '../git/repo'
 import type { IGitProvider } from './types'
 import type {
   GitBranchChangeEntry,
   GitBranchCompareResult,
+  GitCommitCompareResult,
   GitBranchChangeStatus,
   GitConflictKind,
   GitConflictOperation,
   GitDiffResult,
   GitFileStatus,
+  GitPushTarget,
   GitStatusEntry,
   GitStatusResult,
+  GitUpstreamStatus,
   GitWorktreeInfo
 } from '../../shared/types'
+import type { CommitMessageDraftContext } from '../../shared/commit-message-generation'
+import type { GitHistoryOptions, GitHistoryResult } from '../../shared/git-history'
+import { loadGitHistoryFromExecutor } from '../../shared/git-history'
+import { isBinaryBuffer } from '../../shared/binary-buffer'
+import {
+  getEffectiveGitUpstreamStatus,
+  resolveEffectiveGitUpstream
+} from '../../shared/git-effective-upstream'
+import { getPublishTargetStatus } from '../../shared/git-publish-target-status'
+import { resolveGitRemoteRebaseSource } from '../../shared/git-rebase-source'
+import { assertGitPushTargetShape } from '../../shared/git-push-target-validation'
+import { isNoUpstreamError, normalizeGitErrorMessage } from '../../shared/git-remote-error'
+
+const MAX_DOCKER_GIT_BLOB_BYTES = 10 * 1024 * 1024
+const BULK_CHUNK_SIZE = 100
 
 export class DockerGitProvider implements IGitProvider {
   private target: DockerTarget
@@ -31,43 +53,153 @@ export class DockerGitProvider implements IGitProvider {
     return this.target.containerId
   }
 
-  async getStatus(worktreePath: string): Promise<GitStatusResult> {
+  async getStatus(
+    worktreePath: string,
+    options: { includeIgnored?: boolean } = {}
+  ): Promise<GitStatusResult> {
+    const statusArgs = [
+      '-c',
+      'core.quotePath=false',
+      'status',
+      '--porcelain=v2',
+      '--branch',
+      '--untracked-files=all'
+    ]
+    if (options.includeIgnored) {
+      statusArgs.push('--ignored=matching')
+    }
     const [status, conflictOperation] = await Promise.all([
-      this.git(['status', '--porcelain=v2', '--untracked-files=all'], worktreePath),
+      this.git(statusArgs, worktreePath),
       this.detectConflictOperation(worktreePath)
     ])
-    return { entries: parseStatus(status.stdout), conflictOperation }
+    return parseStatus(status.stdout, conflictOperation, options.includeIgnored === true)
   }
 
-  async getDiff(worktreePath: string, filePath: string, staged: boolean): Promise<GitDiffResult> {
-    const originalBlob = staged
-      ? await this.readGitBlob(worktreePath, 'HEAD', filePath)
-      : await this.readUnstagedLeftBlob(worktreePath, filePath)
-    const modifiedContent = staged
-      ? (await this.readGitIndexBlob(worktreePath, filePath)).content
-      : await this.readWorkingTreeFile(worktreePath, filePath)
+  async checkIgnoredPaths(worktreePath: string, relativePaths: string[]): Promise<string[]> {
+    const ignored = new Set<string>()
+    const safePaths = relativePaths.map((relativePath) => this.relativePath(relativePath))
+    for (let i = 0; i < safePaths.length; i += BULK_CHUNK_SIZE) {
+      const chunk = safePaths.slice(i, i + BULK_CHUNK_SIZE)
+      try {
+        const { stdout } = await this.git(
+          ['-c', 'core.quotePath=false', 'check-ignore', '--', ...chunk],
+          worktreePath
+        )
+        for (const ignoredPath of stdout.split(/\r?\n/).filter(Boolean)) {
+          ignored.add(ignoredPath)
+        }
+      } catch (error) {
+        if (!isExitCode(error, 1)) {
+          throw error
+        }
+      }
+    }
+    return Array.from(ignored)
+  }
 
-    return buildTextDiffResult(originalBlob.content, modifiedContent)
+  async getHistory(
+    worktreePath: string,
+    options: GitHistoryOptions = {}
+  ): Promise<GitHistoryResult> {
+    return loadGitHistoryFromExecutor(
+      (args, cwd) => this.git(args, cwd),
+      this.worktreePath(worktreePath),
+      options
+    )
+  }
+
+  async commit(
+    worktreePath: string,
+    message: string
+  ): Promise<{ success: boolean; error?: string }> {
+    try {
+      await this.git(['commit', '-m', message], worktreePath)
+      return { success: true }
+    } catch (error) {
+      return { success: false, error: getGitErrorMessage(error) }
+    }
+  }
+
+  async getStagedCommitContext(worktreePath: string): Promise<CommitMessageDraftContext | null> {
+    const branchPromise = this.git(['branch', '--show-current'], worktreePath).catch(() => ({
+      stdout: ''
+    }))
+    const [branchResult, summaryResult] = await Promise.all([
+      branchPromise,
+      this.git(['diff', '--cached', '--name-status'], worktreePath)
+    ])
+    const stagedSummary = summaryResult.stdout.trim()
+    if (!stagedSummary) {
+      return null
+    }
+    const { stdout: stagedPatch } = await this.git(
+      ['diff', '--cached', '--patch', '--minimal', '--no-color', '--no-ext-diff'],
+      worktreePath
+    )
+    return {
+      branch: branchResult.stdout.trim() || null,
+      stagedSummary,
+      stagedPatch
+    }
+  }
+
+  async getDiff(
+    worktreePath: string,
+    filePath: string,
+    staged: boolean,
+    compareAgainstHead = false
+  ): Promise<GitDiffResult> {
+    const safePath = this.relativePath(filePath)
+    const originalBlob = staged
+      ? await this.readGitBlob(worktreePath, 'HEAD', safePath)
+      : compareAgainstHead
+        ? await this.readGitBlob(worktreePath, 'HEAD', safePath)
+        : await this.readUnstagedLeftBlob(worktreePath, safePath)
+    const modifiedContent = staged
+      ? await this.readGitIndexBlob(worktreePath, safePath)
+      : await this.readWorkingTreeFile(worktreePath, safePath)
+
+    return buildDiffResult(
+      originalBlob.content,
+      modifiedContent.content,
+      originalBlob.isBinary,
+      modifiedContent.isBinary,
+      safePath
+    )
   }
 
   async stageFile(worktreePath: string, filePath: string): Promise<void> {
-    await this.git(['add', '--', filePath], worktreePath)
+    await this.git(['add', '--', this.relativePath(filePath)], worktreePath)
   }
 
   async unstageFile(worktreePath: string, filePath: string): Promise<void> {
-    await this.git(['restore', '--staged', '--', filePath], worktreePath)
+    await this.git(['restore', '--staged', '--', this.relativePath(filePath)], worktreePath)
   }
 
   async bulkStageFiles(worktreePath: string, filePaths: string[]): Promise<void> {
-    await this.git(['add', '--', ...filePaths], worktreePath)
+    await this.runBulkPathCommand(worktreePath, ['add'], filePaths)
   }
 
   async bulkUnstageFiles(worktreePath: string, filePaths: string[]): Promise<void> {
-    await this.git(['restore', '--staged', '--', ...filePaths], worktreePath)
+    await this.runBulkPathCommand(worktreePath, ['restore', '--staged'], filePaths)
   }
 
   async discardChanges(worktreePath: string, filePath: string): Promise<void> {
-    await this.git(['restore', '--', filePath], worktreePath)
+    await this.bulkDiscardChanges(worktreePath, [filePath])
+  }
+
+  async bulkDiscardChanges(worktreePath: string, filePaths: string[]): Promise<void> {
+    const safePaths = filePaths.map((filePath) => this.relativePath(filePath))
+    for (let i = 0; i < safePaths.length; i += BULK_CHUNK_SIZE) {
+      const chunk = safePaths.slice(i, i + BULK_CHUNK_SIZE)
+      try {
+        await this.git(['restore', '--worktree', '--source=HEAD', '--', ...chunk], worktreePath)
+      } catch {
+        // Why: untracked paths cannot be restored. Use git clean pathspecs
+        // instead of raw rm so cleanup stays inside Git's worktree rules.
+        await this.git(['clean', '-ffdx', '--', ...chunk], worktreePath)
+      }
+    }
   }
 
   async detectConflictOperation(worktreePath: string): Promise<GitConflictOperation> {
@@ -90,28 +222,138 @@ export class DockerGitProvider implements IGitProvider {
     return 'unknown'
   }
 
+  async abortMerge(worktreePath: string): Promise<void> {
+    await this.git(['merge', '--abort'], worktreePath)
+  }
+
+  async abortRebase(worktreePath: string): Promise<void> {
+    await this.git(['rebase', '--abort'], worktreePath)
+  }
+
   async getBranchCompare(worktreePath: string, baseRef: string): Promise<GitBranchCompareResult> {
-    const mergeBase = (await this.git(['merge-base', baseRef, 'HEAD'], worktreePath)).stdout.trim()
-    const names = await this.git(
-      ['diff', '--name-status', '-M', '-C', mergeBase, 'HEAD'],
-      worktreePath
-    )
-    const entries = names.stdout
-      .split(/\r?\n/)
-      .filter(Boolean)
-      .map(parseBranchChangeLine)
-      .filter((entry): entry is GitBranchChangeEntry => entry !== null)
-    return {
-      summary: {
-        baseRef,
-        baseOid: mergeBase,
-        compareRef: 'HEAD',
-        headOid: (await this.git(['rev-parse', 'HEAD'], worktreePath)).stdout.trim(),
-        mergeBase,
-        changedFiles: entries.length,
-        status: 'ready'
-      },
-      entries
+    const summary: GitBranchCompareResult['summary'] = {
+      baseRef,
+      baseOid: null as string | null,
+      compareRef: 'HEAD',
+      headOid: null as string | null,
+      mergeBase: null as string | null,
+      changedFiles: 0,
+      status: 'loading' as GitBranchCompareResult['summary']['status']
+    }
+
+    try {
+      summary.headOid = (
+        await this.git(['rev-parse', '--verify', 'HEAD'], worktreePath)
+      ).stdout.trim()
+    } catch {
+      summary.status = 'unborn-head'
+      summary.errorMessage =
+        'This branch does not have a committed HEAD yet, so compare-to-base is unavailable.'
+      return { summary, entries: [] }
+    }
+
+    try {
+      summary.baseOid = (
+        await this.git(['rev-parse', '--verify', '--end-of-options', baseRef], worktreePath)
+      ).stdout.trim()
+    } catch {
+      summary.status = 'invalid-base'
+      summary.errorMessage = `Base ref ${baseRef} could not be resolved in this repository.`
+      return { summary, entries: [] }
+    }
+
+    try {
+      summary.mergeBase = (
+        await this.git(['merge-base', summary.baseOid, summary.headOid], worktreePath)
+      ).stdout.trim()
+    } catch {
+      summary.status = 'no-merge-base'
+      summary.errorMessage = `This branch and ${baseRef} do not share a merge base, so compare-to-base is unavailable.`
+      return { summary, entries: [] }
+    }
+
+    try {
+      const [names, commitsAhead] = await Promise.all([
+        this.git(
+          [
+            '-c',
+            'core.quotePath=false',
+            'diff',
+            '--name-status',
+            '-M',
+            '-C',
+            summary.mergeBase,
+            summary.headOid
+          ],
+          worktreePath
+        ),
+        this.git(['rev-list', '--count', `${summary.baseOid}..${summary.headOid}`], worktreePath)
+      ])
+      const entries = parseBranchChanges(names.stdout)
+      summary.changedFiles = entries.length
+      summary.commitsAhead = Number.parseInt(commitsAhead.stdout.trim(), 10) || 0
+      summary.status = 'ready'
+      return { summary, entries }
+    } catch (error) {
+      summary.status = 'error'
+      summary.errorMessage =
+        error instanceof Error ? error.message : 'Failed to load branch compare'
+      return { summary, entries: [] }
+    }
+  }
+
+  async getCommitCompare(worktreePath: string, commitId: string): Promise<GitCommitCompareResult> {
+    let commitOid = ''
+    try {
+      commitOid = (
+        await this.git(
+          ['rev-parse', '--verify', '--end-of-options', `${commitId}^{commit}`],
+          worktreePath
+        )
+      ).stdout.trim()
+    } catch {
+      return {
+        summary: {
+          commitOid: '',
+          parentOid: null,
+          compareRef: commitId,
+          baseRef: 'parent',
+          changedFiles: 0,
+          status: 'invalid-commit',
+          errorMessage: `Commit ${commitId} could not be resolved in this repository.`
+        },
+        entries: []
+      }
+    }
+
+    const summary = {
+      commitOid,
+      parentOid: null as string | null,
+      compareRef: commitOid.slice(0, 7),
+      baseRef: 'empty tree',
+      changedFiles: 0,
+      status: 'ready' as const
+    }
+    try {
+      const { stdout: parents } = await this.git(
+        ['rev-list', '--parents', '-n', '1', commitOid],
+        worktreePath
+      )
+      const [, parentOid] = parents.trim().split(/\s+/)
+      summary.parentOid = parentOid ?? null
+      summary.baseRef = parentOid ? parentOid.slice(0, 7) : 'empty tree'
+      const entries = await this.loadCommitChanges(worktreePath, summary.parentOid, commitOid)
+      summary.changedFiles = entries.length
+      return { summary, entries }
+    } catch (error) {
+      return {
+        summary: {
+          ...summary,
+          status: 'error',
+          errorMessage: error instanceof Error ? error.message : 'Failed to load commit diff'
+        },
+        entries: []
+      }
     }
   }
 
@@ -123,9 +365,9 @@ export class DockerGitProvider implements IGitProvider {
     const entries = options?.filePath
       ? [
           {
-            path: options.filePath,
+            path: this.relativePath(options.filePath),
             status: 'modified' as const,
-            ...(options.oldPath ? { oldPath: options.oldPath } : {})
+            ...(options.oldPath ? { oldPath: this.relativePath(options.oldPath) } : {})
           }
         ]
       : await this.loadBranchChanges(worktreePath, baseRef)
@@ -142,12 +384,136 @@ export class DockerGitProvider implements IGitProvider {
           entry.oldPath ?? entry.path
         )
         const modifiedContent = await this.readGitBlob(worktreePath, 'HEAD', entry.path)
-        return buildTextDiffResult(originalContent.content, modifiedContent.content)
+        return buildDiffResult(
+          originalContent.content,
+          modifiedContent.content,
+          originalContent.isBinary,
+          modifiedContent.isBinary,
+          entry.path
+        )
       })
     )
   }
 
-  async listWorktrees(repoPath: string): Promise<GitWorktreeInfo[]> {
+  async getCommitDiff(
+    worktreePath: string,
+    args: { commitOid: string; parentOid?: string | null; filePath: string; oldPath?: string }
+  ): Promise<GitDiffResult> {
+    try {
+      const safePath = this.relativePath(args.filePath)
+      const safeOldPath = args.oldPath ? this.relativePath(args.oldPath) : safePath
+      const originalContent = args.parentOid
+        ? await this.readGitBlob(worktreePath, args.parentOid, safeOldPath)
+        : { content: '', isBinary: false, exists: true }
+      const modifiedContent = await this.readGitBlob(worktreePath, args.commitOid, safePath)
+      return buildDiffResult(
+        originalContent.content,
+        modifiedContent.content,
+        originalContent.isBinary,
+        modifiedContent.isBinary,
+        safePath
+      )
+    } catch {
+      return buildTextDiffResult('', '')
+    }
+  }
+
+  async getUpstreamStatus(
+    worktreePath: string,
+    pushTarget?: GitPushTarget
+  ): Promise<GitUpstreamStatus> {
+    try {
+      if (pushTarget) {
+        const target = await this.validatePushTarget(worktreePath, pushTarget)
+        return getPublishTargetStatus(
+          (args) => this.git(args, worktreePath),
+          target,
+          (upstreamName) => this.getBehindCommitsArePatchEquivalent(worktreePath, upstreamName)
+        )
+      }
+      return await getEffectiveGitUpstreamStatus(
+        (args) => this.git(args, worktreePath),
+        (upstreamName) => this.getBehindCommitsArePatchEquivalent(worktreePath, upstreamName)
+      )
+    } catch (error) {
+      if (isNoUpstreamError(error)) {
+        return { hasUpstream: false, ahead: 0, behind: 0 }
+      }
+      throw new Error(normalizeGitErrorMessage(error, 'upstream'))
+    }
+  }
+
+  async pushBranch(
+    worktreePath: string,
+    _publish = false,
+    pushTarget?: GitPushTarget,
+    options: { forceWithLease?: boolean } = {}
+  ): Promise<void> {
+    try {
+      const target = pushTarget
+        ? explicitPushTarget(await this.validatePushTarget(worktreePath, pushTarget))
+        : await this.getConfiguredPushTarget(worktreePath)
+      await this.git(
+        [
+          'push',
+          ...(options.forceWithLease ? ['--force-with-lease'] : []),
+          '--set-upstream',
+          ...(target ? [target.remote, target.refspec] : ['origin', 'HEAD'])
+        ],
+        worktreePath
+      )
+    } catch (error) {
+      throw new Error(normalizeGitErrorMessage(error, 'push'))
+    }
+  }
+
+  async pullBranch(worktreePath: string, pushTarget?: GitPushTarget): Promise<void> {
+    try {
+      if (pushTarget) {
+        const target = await this.validatePushTarget(worktreePath, pushTarget)
+        await this.git(['pull', target.remoteName, target.branchName], worktreePath)
+        return
+      }
+      const upstream = await resolveEffectiveGitUpstream((args) => this.git(args, worktreePath))
+      if (upstream && !upstream.isConfiguredUpstream) {
+        await this.git(['pull', upstream.remoteName, upstream.branchName], worktreePath)
+        return
+      }
+      await this.git(['pull'], worktreePath)
+    } catch (error) {
+      throw new Error(normalizeGitErrorMessage(error, 'pull'))
+    }
+  }
+
+  async rebaseFromBase(worktreePath: string, baseRef: string): Promise<void> {
+    try {
+      const source = await resolveGitRemoteRebaseSource(
+        (args) => this.git(args, worktreePath),
+        baseRef
+      )
+      await this.git(['pull', '--rebase', source.remoteName, source.branchName], worktreePath)
+    } catch (error) {
+      throw new Error(normalizeGitErrorMessage(error, 'pull'))
+    }
+  }
+
+  async fetchRemote(worktreePath: string, pushTarget?: GitPushTarget): Promise<void> {
+    try {
+      if (pushTarget) {
+        const target = await this.validatePushTarget(worktreePath, pushTarget)
+        await this.git(['fetch', '--prune', target.remoteName], worktreePath)
+        return
+      }
+      await this.git(['fetch', '--prune'], worktreePath)
+    } catch (error) {
+      throw new Error(normalizeGitErrorMessage(error, 'fetch'))
+    }
+  }
+
+  async listWorktrees(
+    repoPath: string,
+    _options?: { signal?: AbortSignal }
+  ): Promise<GitWorktreeInfo[]> {
     const result = await this.git(['worktree', 'list', '--porcelain'], repoPath)
     return parseWorktrees(result.stdout)
   }
@@ -156,24 +522,36 @@ export class DockerGitProvider implements IGitProvider {
     repoPath: string,
     branchName: string,
     targetDir: string,
-    options?: { base?: string; track?: boolean }
+    options?: { base?: string; checkoutExistingBranch?: boolean; noCheckout?: boolean }
   ): Promise<void> {
     const args = ['worktree', 'add']
-    if (options?.track) {
-      args.push('--track')
+    const safeTargetDir = this.worktreePath(targetDir)
+    if (options?.noCheckout) {
+      args.push('--no-checkout')
     }
-    args.push(targetDir, branchName)
-    if (options?.base) {
+    if (options?.checkoutExistingBranch) {
+      args.push(safeTargetDir, branchName)
+    } else {
+      args.push('--no-track', '-b', branchName, safeTargetDir)
+    }
+    if (options?.base && !options.checkoutExistingBranch) {
       args.push(options.base)
     }
     await this.git(args, repoPath)
   }
 
-  async removeWorktree(worktreePath: string, force?: boolean): Promise<void> {
+  async removeWorktree(
+    worktreePath: string,
+    force?: boolean,
+    options: { deleteBranch?: boolean; forceBranchDelete?: boolean } = {}
+  ): Promise<void> {
+    const safeWorktreePath = this.worktreePath(worktreePath)
     await this.git(
-      ['worktree', 'remove', ...(force ? ['--force'] : []), worktreePath],
+      ['worktree', 'remove', ...(force ? ['--force'] : []), safeWorktreePath],
       this.target.workdir
     )
+    await this.git(['worktree', 'prune'], this.target.workdir)
+    void options
   }
 
   async exec(args: string[], cwd: string): Promise<{ stdout: string; stderr: string }> {
@@ -193,6 +571,26 @@ export class DockerGitProvider implements IGitProvider {
     return true
   }
 
+  async worktreeIsClean(worktreePath: string): Promise<{ clean: boolean; stdout?: string }> {
+    const result = await this.git(['status', '--porcelain'], worktreePath)
+    const stdout = result.stdout.trim()
+    return stdout ? { clean: false, stdout } : { clean: true }
+  }
+
+  async renameCurrentBranch(worktreePath: string, newBranch: string): Promise<void> {
+    await this.git(['check-ref-format', '--branch', newBranch], worktreePath)
+    await this.git(['branch', '-m', newBranch], worktreePath)
+  }
+
+  async fetchRemoteTrackingRef(
+    worktreePath: string,
+    remote: string,
+    _branch: string,
+    ref: string
+  ): Promise<void> {
+    await this.git(['fetch', '--prune', remote, ref], worktreePath)
+  }
+
   async getRemoteFileUrl(
     worktreePath: string,
     relativePath: string,
@@ -204,10 +602,6 @@ export class DockerGitProvider implements IGitProvider {
     } catch {
       return null
     }
-    const info = hostedGitInfo.fromUrl(remoteUrl)
-    if (!info) {
-      return null
-    }
     const defaultBaseRef = await resolveDefaultBaseRefViaExec((argv) =>
       this.git(argv, worktreePath)
     )
@@ -215,17 +609,24 @@ export class DockerGitProvider implements IGitProvider {
       return null
     }
     const defaultBranch = defaultBaseRef.replace(/^origin\//, '')
-    const browseUrl = info.browseFile(relativePath, { committish: defaultBranch })
-    return browseUrl ? `${browseUrl}#L${line}` : null
+    return buildHostedRemoteFileUrl(remoteUrl, relativePath, defaultBranch, line)
   }
 
   private async git(args: string[], cwd: string): Promise<{ stdout: string; stderr: string }> {
     const result = await this.engine.exec({
       containerId: this.target.containerId,
       args: ['git', ...args],
-      cwd
+      cwd: this.worktreePath(cwd)
     })
     return { stdout: result.stdout, stderr: result.stderr }
+  }
+
+  private worktreePath(inputPath: string): string {
+    return resolveDockerContainerPath(this.target, inputPath)
+  }
+
+  private relativePath(inputPath: string): string {
+    return resolveDockerContainerRelativePath(this.target, inputPath)
   }
 
   private async pathExists(cwd: string, targetPath: string): Promise<boolean> {
@@ -256,6 +657,101 @@ export class DockerGitProvider implements IGitProvider {
       .filter((entry): entry is GitBranchChangeEntry => entry !== null)
   }
 
+  private async runBulkPathCommand(
+    worktreePath: string,
+    baseArgs: string[],
+    filePaths: string[]
+  ): Promise<void> {
+    const safePaths = filePaths.map((filePath) => this.relativePath(filePath))
+    for (let i = 0; i < safePaths.length; i += BULK_CHUNK_SIZE) {
+      const chunk = safePaths.slice(i, i + BULK_CHUNK_SIZE)
+      if (chunk.length > 0) {
+        await this.git([...baseArgs, '--', ...chunk], worktreePath)
+      }
+    }
+  }
+
+  private async loadCommitChanges(
+    worktreePath: string,
+    parentOid: string | null,
+    commitOid: string
+  ): Promise<GitBranchChangeEntry[]> {
+    const args = parentOid
+      ? ['-c', 'core.quotePath=false', 'diff', '--name-status', '-M', '-C', parentOid, commitOid]
+      : [
+          '-c',
+          'core.quotePath=false',
+          'diff-tree',
+          '--root',
+          '--no-commit-id',
+          '--name-status',
+          '-r',
+          '-M',
+          '-C',
+          commitOid
+        ]
+    const result = await this.git(args, worktreePath)
+    return parseBranchChanges(result.stdout)
+  }
+
+  private async validatePushTarget(
+    worktreePath: string,
+    target: GitPushTarget
+  ): Promise<GitPushTarget> {
+    assertGitPushTargetShape(target)
+    await this.git(['check-ref-format', '--branch', target.branchName], worktreePath)
+    return target
+  }
+
+  private async getBehindCommitsArePatchEquivalent(
+    worktreePath: string,
+    upstreamName: string
+  ): Promise<boolean> {
+    try {
+      const { stdout } = await this.git(
+        ['log', '--oneline', '--cherry-mark', '--right-only', `HEAD...${upstreamName}`, '--'],
+        worktreePath
+      )
+      return stdout
+        .split(/\r?\n/)
+        .filter(Boolean)
+        .every((line) => line.startsWith('='))
+    } catch {
+      return false
+    }
+  }
+
+  private async getConfiguredPushTarget(
+    worktreePath: string
+  ): Promise<{ remote: string; refspec: string } | null> {
+    try {
+      const { stdout: branchStdout } = await this.git(
+        ['symbolic-ref', '--quiet', '--short', 'HEAD'],
+        worktreePath
+      )
+      const branch = branchStdout.trim()
+      if (!branch) {
+        return null
+      }
+      const [{ stdout: remoteStdout }, { stdout: mergeStdout }] = await Promise.all([
+        this.git(['config', '--get', `branch.${branch}.remote`], worktreePath),
+        this.git(['config', '--get', `branch.${branch}.merge`], worktreePath)
+      ])
+      const remote = remoteStdout.trim()
+      const mergeRef = mergeStdout.trim()
+      const branchRef = mergeRef.replace(/^refs\/heads\//, '')
+      if (!remote || !branchRef || remote === '.' || branchRef === mergeRef) {
+        return null
+      }
+      if (remote === 'origin' && branchRef !== branch) {
+        return null
+      }
+      return { remote, refspec: `HEAD:${branchRef}` }
+    } catch {
+      return null
+    }
+  }
+
   private async readUnstagedLeftBlob(
     worktreePath: string,
     filePath: string
@@ -271,7 +767,7 @@ export class DockerGitProvider implements IGitProvider {
     worktreePath: string,
     filePath: string
   ): Promise<DockerGitBlobReadResult> {
-    return this.readGitBlobSpec(worktreePath, `:${filePath}`)
+    return this.readGitBlobSpec(worktreePath, `:${filePath.replace(/\\/g, '/')}`, filePath)
   }
 
   private async readGitBlob(
@@ -279,47 +775,93 @@ export class DockerGitProvider implements IGitProvider {
     ref: string,
     filePath: string
   ): Promise<DockerGitBlobReadResult> {
-    return this.readGitBlobSpec(worktreePath, `${ref}:${filePath}`)
+    return this.readGitBlobSpec(worktreePath, `${ref}:${filePath.replace(/\\/g, '/')}`, filePath)
   }
 
   private async readGitBlobSpec(
     worktreePath: string,
-    spec: string
+    spec: string,
+    filePath?: string
   ): Promise<DockerGitBlobReadResult> {
     try {
-      return { content: (await this.git(['show', spec], worktreePath)).stdout, exists: true }
+      const result = await this.git(
+        ['show', '--no-textconv', '--end-of-options', spec],
+        worktreePath
+      )
+      return { ...stringToBlob(result.stdout, filePath), exists: true }
     } catch {
-      return { content: '', exists: false }
+      return { content: '', isBinary: false, exists: false }
     }
   }
 
-  private async readWorkingTreeFile(worktreePath: string, filePath: string): Promise<string> {
+  private async readWorkingTreeFile(
+    worktreePath: string,
+    filePath: string
+  ): Promise<DockerGitBlobReadResult> {
     try {
       const result = await this.engine.exec({
         containerId: this.target.containerId,
-        args: ['cat', '--', filePath],
-        cwd: worktreePath
+        args: [
+          'node',
+          '-e',
+          READ_GIT_WORKTREE_FILE_SCRIPT,
+          filePath,
+          String(MAX_DOCKER_GIT_BLOB_BYTES)
+        ],
+        cwd: this.worktreePath(worktreePath)
       })
-      return result.stdout
+      const parsed = JSON.parse(result.stdout) as { content: string; isBinary: boolean }
+      return { ...parsed, exists: true }
     } catch {
-      return ''
+      return { content: '', isBinary: false, exists: false }
     }
   }
 }
 
 type DockerGitBlobReadResult = {
   content: string
+  isBinary: boolean
   exists: boolean
 }
 
-function parseStatus(stdout: string): GitStatusResult['entries'] {
+function parseStatus(
+  stdout: string,
+  conflictOperation: GitConflictOperation,
+  includeIgnored: boolean
+): GitStatusResult {
   const entries: GitStatusResult['entries'] = []
+  const ignoredPaths: string[] = []
+  let head: string | undefined
+  let branch: string | undefined
+  let upstreamName: string | undefined
+  let upstreamAheadBehind: { ahead: number; behind: number } | null = null
   for (const line of stdout.split(/\r?\n/)) {
     if (!line) {
       continue
     }
+    if (line.startsWith('# branch.oid ')) {
+      head = line.slice('# branch.oid '.length).trim() || undefined
+      continue
+    }
+    if (line.startsWith('# branch.head ')) {
+      const branchHead = line.slice('# branch.head '.length).trim()
+      branch = branchHead && branchHead !== '(detached)' ? `refs/heads/${branchHead}` : undefined
+      continue
+    }
+    if (line.startsWith('# branch.upstream ')) {
+      upstreamName = line.slice('# branch.upstream '.length).trim() || undefined
+      continue
+    }
+    if (line.startsWith('# branch.ab ')) {
+      upstreamAheadBehind = parseBranchAheadBehind(line)
+      continue
+    }
     if (line.startsWith('? ')) {
       entries.push({ path: line.slice(2), status: 'untracked', area: 'untracked' })
+      continue
+    }
+    if (line.startsWith('! ')) {
+      ignoredPaths.push(line.slice(2))
       continue
     }
     if (line.startsWith('1 ') || line.startsWith('2 ')) {
@@ -341,7 +883,32 @@ function parseStatus(stdout: string): GitStatusResult['entries'] {
       }
     }
   }
-  return entries
+  return {
+    entries,
+    conflictOperation,
+    head,
+    branch,
+    ...(includeIgnored ? { ignoredPaths } : {}),
+    upstreamStatus: upstreamName
+      ? {
+          hasUpstream: true,
+          upstreamName,
+          ahead: upstreamAheadBehind?.ahead ?? 0,
+          behind: upstreamAheadBehind?.behind ?? 0
+        }
+      : { hasUpstream: false, ahead: 0, behind: 0 }
+  }
+}
+
+function parseBranchAheadBehind(line: string): { ahead: number; behind: number } | null {
+  const match = line.match(/^# branch\.ab \+(\d+) -(\d+)$/)
+  if (!match) {
+    return null
+  }
+  return {
+    ahead: Number.parseInt(match[1], 10),
+    behind: Number.parseInt(match[2], 10)
+  }
 }
 
 function parseFileStatus(char: string): GitFileStatus {
@@ -382,6 +949,14 @@ function parseBranchChangeLine(line: string): GitBranchChangeEntry | null {
     return null
   }
   return { path: filePath, status }
+}
+
+function parseBranchChanges(stdout: string): GitBranchChangeEntry[] {
+  return stdout
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map(parseBranchChangeLine)
+    .filter((entry): entry is GitBranchChangeEntry => entry !== null)
 }
 
 function parseUnmergedStatusLine(line: string): GitStatusEntry | null {
@@ -435,6 +1010,91 @@ function buildTextDiffResult(originalContent: string, modifiedContent: string): 
     modifiedIsBinary: false
   }
 }
+
+function buildDiffResult(
+  originalContent: string,
+  modifiedContent: string,
+  originalIsBinary: boolean,
+  modifiedIsBinary: boolean,
+  filePath?: string
+): GitDiffResult {
+  if (originalIsBinary || modifiedIsBinary) {
+    const mimeType = filePath
+      ? PREVIEWABLE_BINARY_MIME_TYPES[pathExtname(filePath).toLowerCase()]
+      : undefined
+    return {
+      kind: 'binary',
+      originalContent,
+      modifiedContent,
+      originalIsBinary,
+      modifiedIsBinary,
+      ...(mimeType ? { isImage: true, mimeType } : {})
+    } as GitDiffResult
+  }
+  return buildTextDiffResult(originalContent, modifiedContent)
+}
+
+function stringToBlob(content: string, filePath?: string): Omit<DockerGitBlobReadResult, 'exists'> {
+  const buffer = Buffer.from(content, 'utf8')
+  const isBinary = isBinaryBuffer(buffer)
+  const isPreviewableBinary = filePath
+    ? !!PREVIEWABLE_BINARY_MIME_TYPES[pathExtname(filePath).toLowerCase()]
+    : false
+  return {
+    content: isBinary ? (isPreviewableBinary ? buffer.toString('base64') : '') : content,
+    isBinary
+  }
+}
+
+function pathExtname(filePath: string): string {
+  const basename = filePath.split(/[\\/]/).at(-1) ?? filePath
+  const dotIndex = basename.lastIndexOf('.')
+  return dotIndex >= 0 ? basename.slice(dotIndex) : ''
+}
+
+function isExitCode(error: unknown, code: number): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    (error as { code?: unknown }).code === code
+  )
+}
+
+function getGitErrorMessage(error: unknown): string {
+  if (!(error instanceof Error)) {
+    return 'Git command failed'
+  }
+  const candidate = error as Error & { stdout?: string; stderr?: string }
+  return candidate.stderr || candidate.stdout || error.message
+}
+
+function explicitPushTarget(target: GitPushTarget): { remote: string; refspec: string } {
+  return { remote: target.remoteName, refspec: `HEAD:${target.branchName}` }
+}
+
+const PREVIEWABLE_BINARY_MIME_TYPES: Record<string, string> = {
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.svg': 'image/svg+xml',
+  '.webp': 'image/webp',
+  '.bmp': 'image/bmp',
+  '.ico': 'image/x-icon',
+  '.pdf': 'application/pdf'
+}
+
+const READ_GIT_WORKTREE_FILE_SCRIPT = `
+const fs = require('fs');
+const filePath = process.argv[1];
+const maxBytes = Number(process.argv[2]);
+const stat = fs.statSync(filePath);
+if (stat.size > maxBytes) throw new Error('Git file is too large to read through Docker provider');
+const buffer = fs.readFileSync(filePath);
+const isBinary = buffer.subarray(0, Math.min(buffer.length, 8192)).includes(0);
+process.stdout.write(JSON.stringify({ content: isBinary ? '' : buffer.toString('utf8'), isBinary }));
+`
 
 function parseWorktrees(stdout: string): GitWorktreeInfo[] {
   const chunks = stdout.split(/\n\n+/).filter(Boolean)

--- a/src/main/providers/docker-pty-provider.test.ts
+++ b/src/main/providers/docker-pty-provider.test.ts
@@ -37,6 +37,7 @@ describe('DockerPtyProvider', () => {
         containerId: 'container-1',
         args: ['/bin/sh'],
         cwd: '/workspace',
+        tty: true,
         cols: 80,
         rows: 24
       }

--- a/src/main/providers/docker-pty-provider.test.ts
+++ b/src/main/providers/docker-pty-provider.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { DockerEngineFake } from '../docker/docker-engine-fake'
+import type { DockerTarget } from '../docker/types'
+import { DockerPtyProvider } from './docker-pty-provider'
+
+describe('DockerPtyProvider', () => {
+  let engine: DockerEngineFake
+  let provider: DockerPtyProvider
+  let target: DockerTarget
+
+  beforeEach(() => {
+    engine = new DockerEngineFake()
+    target = {
+      containerId: 'container-1',
+      workdir: '/workspace',
+      image: {
+        id: 'sha256:image',
+        cacheKey: 'cache-key',
+        dockerfilePath: 'Dockerfile',
+        builtAt: 1
+      }
+    }
+    provider = new DockerPtyProvider(target, engine)
+  })
+
+  it('returns the container id as connection id', () => {
+    expect(provider.getConnectionId()).toBe('container-1')
+  })
+
+  it('spawns a shell inside the Docker container', async () => {
+    const result = await provider.spawn({ cols: 80, rows: 24 })
+
+    expect(result).toEqual({ id: 'session-1' })
+    expect(engine.commands[0]).toMatchObject({
+      command: 'container.exec.spawn',
+      options: {
+        containerId: 'container-1',
+        args: ['/bin/sh'],
+        cwd: '/workspace',
+        cols: 80,
+        rows: 24
+      }
+    })
+  })
+
+  it('forwards writes, resizes, data, and exit events', async () => {
+    const data = vi.fn()
+    const exit = vi.fn()
+    provider.onData(data)
+    provider.onExit(exit)
+    const { id } = await provider.spawn({ cols: 80, rows: 24 })
+    const session = engine.sessions.get(id)!
+
+    provider.write(id, 'hello')
+    provider.resize(id, 120, 40)
+    session.emitData('output')
+    session.crash(137)
+
+    expect(session.writes).toEqual(['hello'])
+    expect(session.resizes).toEqual([{ cols: 120, rows: 40 }])
+    expect(data).toHaveBeenCalledWith({ id, data: 'output' })
+    expect(exit).toHaveBeenCalledWith({ id, code: 137 })
+    await expect(provider.hasChildProcesses(id)).resolves.toBe(false)
+  })
+
+  it('reattaches to an existing session', async () => {
+    const { id } = await provider.spawn({ cols: 80, rows: 24 })
+    engine.sessions.get(id)!.emitData('buffered')
+
+    await expect(provider.spawn({ cols: 80, rows: 24, sessionId: id })).resolves.toEqual({
+      id,
+      isReattach: true,
+      replay: 'buffered'
+    })
+  })
+
+  it('marks requested missing sessions as expired and starts fresh', async () => {
+    await expect(
+      provider.spawn({ cols: 80, rows: 24, sessionId: 'missing' })
+    ).resolves.toMatchObject({
+      id: 'session-1',
+      sessionExpired: true
+    })
+  })
+})

--- a/src/main/providers/docker-pty-provider.test.ts
+++ b/src/main/providers/docker-pty-provider.test.ts
@@ -83,4 +83,16 @@ describe('DockerPtyProvider', () => {
       sessionExpired: true
     })
   })
+
+  it('forwards signals and removes sessions on shutdown', async () => {
+    const { id } = await provider.spawn({ cols: 80, rows: 24 })
+    const session = engine.sessions.get(id)!
+    const sendSignal = vi.spyOn(session, 'sendSignal')
+
+    await provider.sendSignal(id, 'SIGINT')
+    await provider.shutdown(id, { immediate: true })
+
+    expect(sendSignal).toHaveBeenCalledWith('SIGINT')
+    await expect(provider.hasChildProcesses(id)).resolves.toBe(false)
+  })
 })

--- a/src/main/providers/docker-pty-provider.ts
+++ b/src/main/providers/docker-pty-provider.ts
@@ -41,6 +41,7 @@ export class DockerPtyProvider implements IPtyProvider {
       args: [opts.command ?? '/bin/sh'],
       cwd: opts.cwd ?? this.target.workdir,
       env: opts.env,
+      tty: true,
       cols: opts.cols,
       rows: opts.rows
     })

--- a/src/main/providers/docker-pty-provider.ts
+++ b/src/main/providers/docker-pty-provider.ts
@@ -1,0 +1,171 @@
+import type { DockerEngineClientLike, DockerExecSession } from '../docker/docker-engine-client'
+import { DockerEngineClient } from '../docker/docker-engine-client'
+import type { DockerTarget } from '../docker/types'
+import type { IPtyProvider, PtySpawnOptions, PtySpawnResult } from './types'
+
+type DataCallback = (payload: { id: string; data: string }) => void
+type ReplayCallback = (payload: { id: string; data: string }) => void
+type ExitCallback = (payload: { id: string; code: number }) => void
+
+export class DockerPtyProvider implements IPtyProvider {
+  private target: DockerTarget
+  private engine: DockerEngineClientLike
+  private sessions = new Map<string, DockerExecSession>()
+  private dataListeners = new Set<DataCallback>()
+  private replayListeners = new Set<ReplayCallback>()
+  private exitListeners = new Set<ExitCallback>()
+
+  constructor(target: DockerTarget, engine: DockerEngineClientLike = new DockerEngineClient()) {
+    this.target = target
+    this.engine = engine
+  }
+
+  getConnectionId(): string {
+    return this.target.containerId
+  }
+
+  async spawn(opts: PtySpawnOptions): Promise<PtySpawnResult> {
+    if (opts.sessionId) {
+      const existing = this.sessions.get(opts.sessionId)
+      if (existing) {
+        return {
+          id: opts.sessionId,
+          isReattach: true,
+          replay: await existing.serialize()
+        }
+      }
+    }
+
+    const session = await this.engine.spawnExec({
+      containerId: this.target.containerId,
+      args: [opts.command ?? '/bin/sh'],
+      cwd: opts.cwd ?? this.target.workdir,
+      env: opts.env,
+      cols: opts.cols,
+      rows: opts.rows
+    })
+    this.sessions.set(session.id, session)
+
+    session.onData((data) => {
+      for (const cb of this.dataListeners) {
+        cb({ id: session.id, data })
+      }
+    })
+    session.onReplay((data) => {
+      for (const cb of this.replayListeners) {
+        cb({ id: session.id, data })
+      }
+    })
+    session.onExit((code) => {
+      this.sessions.delete(session.id)
+      for (const cb of this.exitListeners) {
+        cb({ id: session.id, code })
+      }
+    })
+
+    return {
+      id: session.id,
+      ...(opts.sessionId ? { sessionExpired: true } : {})
+    }
+  }
+
+  async attach(id: string): Promise<void> {
+    if (!this.sessions.has(id)) {
+      throw new Error(`No Docker PTY session "${id}"`)
+    }
+  }
+
+  write(id: string, data: string): void {
+    this.sessions.get(id)?.write(data)
+  }
+
+  resize(id: string, cols: number, rows: number): void {
+    this.sessions.get(id)?.resize(cols, rows)
+  }
+
+  async shutdown(id: string, immediate: boolean): Promise<void> {
+    const session = this.sessions.get(id)
+    if (!session) {
+      return
+    }
+    await session.shutdown(immediate)
+    this.sessions.delete(id)
+  }
+
+  async sendSignal(id: string, signal: string): Promise<void> {
+    await this.sessions.get(id)?.sendSignal(signal)
+  }
+
+  async getCwd(id: string): Promise<string> {
+    return (await this.sessions.get(id)?.getCwd()) ?? this.target.workdir
+  }
+
+  async getInitialCwd(id: string): Promise<string> {
+    return (await this.sessions.get(id)?.getInitialCwd()) ?? this.target.workdir
+  }
+
+  async clearBuffer(id: string): Promise<void> {
+    await this.sessions.get(id)?.clearBuffer()
+  }
+
+  acknowledgeDataEvent(id: string, charCount: number): void {
+    this.sessions.get(id)?.acknowledgeDataEvent(charCount)
+  }
+
+  async hasChildProcesses(id: string): Promise<boolean> {
+    return (await this.sessions.get(id)?.hasChildProcesses()) ?? false
+  }
+
+  async getForegroundProcess(id: string): Promise<string | null> {
+    return (await this.sessions.get(id)?.getForegroundProcess()) ?? null
+  }
+
+  async serialize(ids: string[]): Promise<string> {
+    const entries = await Promise.all(
+      ids.map(async (id) => [id, await this.sessions.get(id)?.serialize()] as const)
+    )
+    return JSON.stringify(Object.fromEntries(entries.filter(([, state]) => state !== undefined)))
+  }
+
+  async revive(state: string): Promise<void> {
+    const parsed = JSON.parse(state) as Record<string, string>
+    await Promise.all(
+      Object.entries(parsed).map(async ([id, sessionState]) => {
+        await this.sessions.get(id)?.revive(sessionState)
+      })
+    )
+  }
+
+  async listProcesses(): Promise<{ id: string; cwd: string; title: string }[]> {
+    return Promise.all(
+      [...this.sessions.entries()].map(async ([id, session]) => ({
+        id,
+        cwd: await session.getCwd(),
+        title: (await session.getForegroundProcess()) ?? 'shell'
+      }))
+    )
+  }
+
+  async getDefaultShell(): Promise<string> {
+    return '/bin/sh'
+  }
+
+  async getProfiles(): Promise<{ name: string; path: string }[]> {
+    return [{ name: 'sh', path: '/bin/sh' }]
+  }
+
+  onData(callback: DataCallback): () => void {
+    this.dataListeners.add(callback)
+    return () => this.dataListeners.delete(callback)
+  }
+
+  onReplay(callback: ReplayCallback): () => void {
+    this.replayListeners.add(callback)
+    return () => this.replayListeners.delete(callback)
+  }
+
+  onExit(callback: ExitCallback): () => void {
+    this.exitListeners.add(callback)
+    return () => this.exitListeners.delete(callback)
+  }
+}

--- a/src/main/providers/docker-pty-provider.ts
+++ b/src/main/providers/docker-pty-provider.ts
@@ -84,12 +84,15 @@ export class DockerPtyProvider implements IPtyProvider {
     this.sessions.get(id)?.resize(cols, rows)
   }
 
-  async shutdown(id: string, immediate: boolean): Promise<void> {
+  async shutdown(
+    id: string,
+    opts: { immediate?: boolean; keepHistory?: boolean } = {}
+  ): Promise<void> {
     const session = this.sessions.get(id)
     if (!session) {
       return
     }
-    await session.shutdown(immediate)
+    await session.shutdown(opts.immediate === true)
     this.sessions.delete(id)
   }
 


### PR DESCRIPTION
## Summary

Adds Docker as a fourth provider triple alongside local and SSH. Pure plumbing: pty / filesystem / git providers + docker engine detection + image build + container lifecycle + bind-mount path resolution. No UI, no dispatch wiring.

This is the foundation PR for an opt-in Docker isolation feature. Follow-up PRs add the worktree-level toggle and dispatch routing. Worktree-native stays the default and remains zero-friction for everyone else.

Motivation: Sculptor (Imbue) ships per-task Docker container isolation as its pillar feature, and users in agent-orchestration discussions ask for the same primitive on Orca. Issue [#993](https://github.com/stablyai/orca/issues/993) ("Something like an ai orchestrator") and [Discussion #681](https://github.com/stablyai/orca/discussions/681) (multi-agent orchestration coordinator pattern, 15 comments) both signal demand for sandboxed agent execution.

Architectural fit: `src/main/providers/` already abstracts pty / filesystem / git through three interfaces with two implementations (local, SSH). Docker is a third target. The new triple mirrors the SSH triple's API exactly so the upcoming dispatch PR slots in cleanly.

## Screenshots

No visual UI change. This PR is foundation-only: provider classes plus docker engine modules with no dispatch wiring or runtime behavior yet (the follow-up PR adds the user-facing toggle, the third PR wires it up).

A simulated demo of the architectural change this PR adds:

![Simulated demo: docker provider triple foundation](https://raw.githubusercontent.com/mvanhorn/orca/evidence-assets/evidence/pr1349-demo.gif)

Simulated demo (Remotion). Shows the three provider triples (local, ssh, docker-new) and the receipts: 17 files, 2474 lines, 41 tests, 0 dispatch edits.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test --run src/main/providers/docker-*.test.ts src/main/docker/`
- [x] `pnpm build`
- [x] Added 41 tests across 7 files covering happy and error paths through the engine fake. Cross-platform branches (macOS Colima + Desktop, Linux Engine + rootless, Windows WSL2 path translation) covered via injected `platform`. Real Docker integration is out of scope for this PR and gated behind `RUN_DOCKER_E2E=1` for follow-up work.

## AI Review Report

A code review pass was run before submission. Risks checked:

- Cross-platform compatibility: macOS (Docker Desktop, Colima socket), Linux (Engine + rootless socket), Windows (Docker Desktop WSL2 named pipe + drive-letter to `/mnt/<drive>` path translation). All platform branches covered in `docker-engine-detect.test.ts` and `docker-mount.test.ts` via injected `platform` so the same suite passes on each OS.
- Provider contract parity with the local / SSH implementations: `getDiff` and `getBranchDiff` return `originalContent` and `modifiedContent` (not unified-patch text); rename parsing keeps `path` as the new path and `oldPath` as the old; porcelain v2 `u` records surface as conflict entries; `getRemoteFileUrl` resolves the actual default branch via `origin/HEAD` instead of hardcoding `main`. These were flagged and fixed before submission.
- TTY allocation: `DockerPtyProvider` requests `tty: true` from the engine client so interactive programs see a real terminal. Caveat below.
- AGENTS.md compliance: file naming (concrete domain names, no `helpers.ts`/`utils.ts`), project types in `.ts` not `.d.ts`, no hardcoded `metaKey`, all paths via `path.join` or `path.posix.join`.

Known caveat surfaced by review: when wired in a future PR, `docker exec -t` from a piped-stdio Electron parent can fail with "input device is not a TTY" on some packaged builds. The cleanest fix is wrapping the docker CLI under node-pty, matching the local provider's pattern. This PR's TTY flag is correct; the wrapping happens in the dispatch PR. Search-flag handling (`useRegex`, `wholeWord`, include/exclude patterns) and binary-blob metadata in diffs are also follow-up items, called out for the wiring PR.

## Security Audit

Input handling: only the host paths the user already trusts (worktree path, Dockerfile path) flow into engine commands. No user-supplied strings are interpolated into shell.

Command execution: the engine client builds argv arrays for `child_process.spawn` (no shell). All user paths land as separate argv entries, never concatenated.

Path handling: bind-mount source is the host worktree; mount target is `/workspace` inside the container. Windows paths are translated via the dedicated helper with vitest coverage so the translation is auditable.

IPC and preload: this PR does not add or change any IPC handler. The provider classes are not yet routed through `provider-dispatch`. No new exposed surface from main to renderer.

Dependencies: no `package.json` or `pnpm-lock.yaml` changes.

Auth and secrets: no auth flow changes. The agent inside a container would run with the host user's uid/gid (when wired in PR 3); credentials remain on the host filesystem and are not copied into images.

Follow-up: the dispatch PR will need its own audit covering how routing decisions are gated and how the toggle persists.

## Notes

This is PR 1 of a 3-PR series. The other two PRs add the user-facing toggle (worktree row, repo settings) and the dispatch wiring (provider-dispatch + orca-runtime + image cache UX). Each lands independently; PR 1 has no observable behavior change on its own.

Tested on macOS. Linux and Windows behavior covered in unit tests via injected platform.

X: @mvanhorn

AI was used for assistance.

Risk: high
Historic risk metadata backfill based on the existing `risk:high` label.

## ELI5

Foundation for Docker isolation: Docker pty/filesystem/git providers, image build, and container lifecycle—no UI yet, enables later isolation features.
