### PR TITLE
fix(ssh): trigger reconnect on Enter in disconnected dialog

### DIFF
--- a/src/renderer/src/components/sidebar/SshDisconnectedDialog.tsx
+++ b/src/renderer/src/components/sidebar/SshDisconnectedDialog.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { toast } from 'sonner'
 import { Loader2, Server, ServerOff } from 'lucide-react'
 import {
@@ -63,6 +63,30 @@ export function SshDisconnectedDialog({
     ? 'Reconnecting to the remote host...'
     : (STATUS_MESSAGES[status] ?? 'This remote repository is not connected.')
   const showReconnect = isReconnectable(status)
+
+  useEffect(() => {
+    // Window-level Enter handler. The dialog typically appears while focus
+    // is inside an embedded terminal (xterm) or editor (monaco) that
+    // aggressively reclaims focus, so dialog-scoped key handlers never
+    // fire. Listening on window (capture phase) catches Enter regardless
+    // of where focus actually lives while the dialog is open.
+    if (!open || !showReconnect || isConnecting) {
+      return undefined
+    }
+    const onKeyDown = (event: KeyboardEvent): void => {
+      if (event.key !== 'Enter' || event.defaultPrevented) {
+        return
+      }
+      if (event.isComposing) {
+        return
+      }
+      event.preventDefault()
+      event.stopPropagation()
+      void handleReconnect()
+    }
+    window.addEventListener('keydown', onKeyDown, true)
+    return () => window.removeEventListener('keydown', onKeyDown, true)
+  }, [open, showReconnect, isConnecting, handleReconnect])
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>


### PR DESCRIPTION
## Summary
- The SSH disconnected dialog now treats Enter as the primary action (Reconnect), regardless of which element holds focus.
- Uses a window-level `keydown` capture listener that is only active while `open && showReconnect && !isConnecting`.

## Why
Dialog-scoped `onKeyDown` / `onOpenAutoFocus` handlers didn't fire because the dialog typically appears while focus is inside xterm/monaco, which aggressively reclaim focus. A window-level listener is the only reliable way to catch Enter in that scenario.

## Test plan
- [ ] Trigger SSH disconnect, press Enter → should reconnect (not dismiss).
- [ ] Verify Dismiss button still works via click.
- [ ] Verify no regressions in other dialogs or terminals (listener only mounts while this dialog is open).

Made with [Orca](https://github.com/stablyai/orca) 🐋
