### PR TITLE
fix(terminal): stabilize DOM renderer scrollbar

### DIFF
--- a/src/renderer/src/assets/terminal.css
+++ b/src/renderer/src/assets/terminal.css
@@ -26,7 +26,9 @@
 }
 
 .pane-manager-root .xterm-viewport {
-  overflow-y: auto;
+  /* Why: xterm/VS Code keep the scrollbar gutter stable. `auto` lets Linux
+     DOM scrollbars appear/disappear, which can feed resize/reflow jitter. */
+  overflow-y: scroll;
 }
 
 /* xterm.css sets position:absolute;top:0 on .xterm-helpers but omits left,

--- a/src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts
@@ -95,6 +95,8 @@ describe('attachWebgl', () => {
 
     expect(pane.webglAddon).toBeNull()
     expect(pane.webglDisabledAfterContextLoss).toBe(true)
+    expect(pane.fitAddon.fit).toHaveBeenCalledTimes(1)
+    expect(pane.terminal.refresh).toHaveBeenCalledWith(0, 23)
 
     attachWebgl(pane)
 

--- a/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
+++ b/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
@@ -282,14 +282,31 @@ export function setLigaturesEnabled(pane: ManagedPaneInternal, enabled: boolean)
   }
 }
 
-export function disposeWebgl(pane: ManagedPaneInternal): void {
-  if (pane.webglAddon) {
-    try {
-      pane.webglAddon.dispose()
-    } catch {
-      /* ignore */
-    }
-    pane.webglAddon = null
+export function disposeWebgl(
+  pane: ManagedPaneInternal,
+  options?: { refreshDimensions?: boolean }
+): void {
+  if (!pane.webglAddon) {
+    return
+  }
+  try {
+    pane.webglAddon.dispose()
+  } catch {
+    /* ignore */
+  }
+  pane.webglAddon = null
+  if (options?.refreshDimensions) {
+    // Why: VS Code refreshes terminal dimensions after WebGL teardown because
+    // DOM and WebGL renderer cell metrics differ. Without this, Linux DOM
+    // scrollbars can desync and trigger visible reflow jitter.
+    requestAnimationFrame(() => {
+      try {
+        pane.fitAddon.fit()
+        pane.terminal.refresh(0, pane.terminal.rows - 1)
+      } catch {
+        /* ignore — pane may have been disposed in the meantime */
+      }
+    })
   }
 }
 
@@ -316,26 +333,7 @@ export function attachWebgl(pane: ManagedPaneInternal): void {
       // Recreating WebGL for this pane can loop context loss and leave xterm
       // visually blank, so keep the pane on the DOM renderer until remount.
       pane.webglDisabledAfterContextLoss = true
-      webglAddon.dispose()
-      pane.webglAddon = null
-      // Why: when the WebGL context is lost the GPU-rendered canvas goes
-      // blank instantly. After disposing the addon, xterm.js falls back to
-      // the DOM renderer but may not redraw the viewport unprompted —
-      // without a refresh + refit, the scrollback area renders as blank
-      // space above the most recent output. Deferring to the next frame
-      // gives the DOM renderer time to initialise before repainting. Scroll
-      // position is preserved by xterm's native viewportY handling across
-      // resize (see scroll-reflow.test.ts "reference: undisturbed"); if a
-      // splitPane was in flight, its scheduleSplitScrollRestore timer owns
-      // the authoritative restore.
-      requestAnimationFrame(() => {
-        try {
-          pane.fitAddon.fit()
-          pane.terminal.refresh(0, pane.terminal.rows - 1)
-        } catch {
-          /* ignore — pane may have been disposed in the meantime */
-        }
-      })
+      disposeWebgl(pane, { refreshDimensions: true })
     })
     pane.terminal.loadAddon(webglAddon)
     pane.webglAddon = webglAddon

--- a/src/renderer/src/lib/pane-manager/pane-manager.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager.ts
@@ -230,7 +230,7 @@ export class PaneManager {
     }
     pane.gpuRenderingEnabled = enabled
     if (!enabled) {
-      disposeWebgl(pane)
+      disposeWebgl(pane, { refreshDimensions: true })
       return
     }
     if (pane.webglAttachmentDeferred || pane.webglDisabledAfterContextLoss) {

--- a/src/renderer/src/lib/pane-manager/pane-terminal-gpu-acceleration.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-gpu-acceleration.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ManagedPaneInternal, PaneManagerOptions } from './pane-manager-types'
+import { applyTerminalGpuAcceleration } from './pane-terminal-gpu-acceleration'
+
+function createPane(): ManagedPaneInternal {
+  return {
+    id: 1,
+    terminal: {
+      cols: 80,
+      rows: 24
+    } as never,
+    container: {} as never,
+    xtermContainer: {} as never,
+    linkTooltip: {} as never,
+    terminalGpuAcceleration: 'auto',
+    gpuRenderingEnabled: true,
+    webglAttachmentDeferred: false,
+    webglDisabledAfterContextLoss: false,
+    webglAddon: {
+      dispose: vi.fn()
+    } as never,
+    ligaturesAddon: null,
+    fitResizeObserver: null,
+    pendingObservedFitRafId: null,
+    fitAddon: {
+      proposeDimensions: vi.fn(() => ({ cols: 80, rows: 23 })),
+      fit: vi.fn()
+    } as never,
+    searchAddon: {} as never,
+    serializeAddon: {} as never,
+    unicode11Addon: {} as never,
+    webLinksAddon: {} as never,
+    compositionHandler: null,
+    pendingSplitScrollState: null,
+    debugLabel: null
+  }
+}
+
+describe('applyTerminalGpuAcceleration', () => {
+  beforeEach(() => {
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(16)
+      return 1
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('refits after disabling WebGL so DOM renderer dimensions settle', () => {
+    const pane = createPane()
+    const options: PaneManagerOptions = { terminalGpuAcceleration: 'auto' }
+
+    applyTerminalGpuAcceleration([pane], options, 'off')
+
+    expect(pane.webglAddon).toBeNull()
+    expect(pane.fitAddon.fit).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/lib/pane-manager/pane-terminal-gpu-acceleration.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-gpu-acceleration.ts
@@ -16,7 +16,7 @@ export function applyTerminalGpuAcceleration(
   for (const pane of panes) {
     pane.terminalGpuAcceleration = nextMode
     if (nextMode === 'off') {
-      disposeWebgl(pane)
+      disposeWebgl(pane, { refreshDimensions: true })
       continue
     }
     if (


### PR DESCRIPTION
"## Summary\n- Keep xterm's viewport scrollbar gutter stable, matching upstream xterm/VS Code instead of overriding it to `overflow-y: auto`.\n- Refresh terminal dimensions after real WebGL teardown paths, matching VS Code's `_disposeOfWebglRenderer()` behavior.\n- Add coverage for the GPU-off WebGL-to-DOM transition so future changes don't regress this path.\n\n## Why this should address #1292\nThe user reported two symptoms after upgrading:\n\n1. Terminal block artifacts still appear.\n2. When terminal GPU acceleration is disabled, the right-side xterm scrollbar/slider appears and jumps repeatedly.\n\nComparing Orca against VS Code found two high-confidence mismatches that can explain those symptoms:\n\n- VS Code/xterm keep the terminal viewport scrollbar gutter stable. Orca overrode `.xterm-viewport` to `overflow-y: auto`, which lets Linux DOM scrollbars appear/disappear as wrapping changes. On non-overlay scrollbar systems this can feed a resize -> wrap -> scrollbar -> resize loop, matching the reported jumping slider.\n- VS Code refreshes terminal dimensions after WebGL renderer teardown because DOM and WebGL renderer metrics differ. Orca only did this recovery on WebGL context loss, not on user-driven GPU-off transitions. That can leave stale geometry/rendered content until an unrelated resize occurs.\n\nThis PR does not close #1292 yet. We should ship it, ask the user to retest on the next release, and keep the issue open until confirmed.\n\n## VS Code references\n- WebGL teardown requests dimensions refresh: `/Users/nwparker/projects/orca-ref-oss/vscode/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts:960-975`\n- WebGL attach requests dimensions refresh: `/Users/nwparker/projects/orca-ref-oss/vscode/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts:867-876`\n- Terminal GPU acceleration setting shape: `/Users/nwparker/projects/orca-ref-oss/vscode/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts`\n\n## Validation\n- `pnpm vitest run src/renderer/src/lib/pane-manager/pane-terminal-gpu-acceleration.test.ts src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts src/renderer/src/lib/pane-manager/pane-fit-resize-observer.test.ts src/renderer/src/lib/pane-manager/pane-tree-ops.test.ts`\n- `pnpm exec tsc --noEmit -p config/tsconfig.node.json`\n- `pnpm exec tsc --noEmit -p config/tsconfig.web.json` still fails on existing unrelated TS6307 project include issues for `src/main/wsl.ts` and `src/main/ipc/worktree-logic.ts`.\n"