### PR TITLE
fix(terminal): bypass xterm for handled app shortcuts

### DIFF
--- a/src/renderer/src/components/terminal-pane/xterm-bypass-policy.test.ts
+++ b/src/renderer/src/components/terminal-pane/xterm-bypass-policy.test.ts
@@ -5,6 +5,7 @@ function event(overrides: Partial<XtermBypassEvent>): XtermBypassEvent {
   return {
     key: '',
     code: '',
+    defaultPrevented: false,
     metaKey: false,
     ctrlKey: false,
     altKey: false,
@@ -50,6 +51,30 @@ describe('shouldBypassXtermKeydown — macOS', () => {
     }
   })
 
+  it('bubbles already-handled Cmd app shortcuts so kitty does not also write to shell', () => {
+    // Why: some window-level shortcuts call preventDefault without stopping
+    // propagation. VS Code returns false for resolved Meta keybindings for the
+    // same kitty reason: app shortcuts must not also become terminal input.
+    expect(
+      shouldBypassXtermKeydown(
+        event({ key: 'b', code: 'KeyB', defaultPrevented: true, metaKey: true }),
+        opts
+      )
+    ).toBe(true)
+    expect(
+      shouldBypassXtermKeydown(
+        event({
+          key: 'ArrowLeft',
+          code: 'ArrowLeft',
+          defaultPrevented: true,
+          metaKey: true,
+          altKey: true
+        }),
+        opts
+      )
+    ).toBe(true)
+  })
+
   it('does not bubble Cmd+Shift+C — already intercepted in keyboard-handlers.ts', () => {
     expect(
       shouldBypassXtermKeydown(
@@ -73,6 +98,15 @@ describe('shouldBypassXtermKeydown — macOS', () => {
     expect(
       shouldBypassXtermKeydown(
         event({ key: 'c', code: 'KeyC', metaKey: true, ctrlKey: true }),
+        opts
+      )
+    ).toBe(false)
+  })
+
+  it('does not bubble already-handled Ctrl chords on macOS', () => {
+    expect(
+      shouldBypassXtermKeydown(
+        event({ key: 'c', code: 'KeyC', defaultPrevented: true, ctrlKey: true }),
         opts
       )
     ).toBe(false)
@@ -135,6 +169,27 @@ describe('shouldBypassXtermKeydown — Windows/Linux', () => {
         )
       ).toBe(false)
     }
+  })
+
+  it('bubbles already-handled Ctrl app shortcuts so kitty does not also write to shell', () => {
+    expect(
+      shouldBypassXtermKeydown(
+        event({ key: 'b', code: 'KeyB', defaultPrevented: true, ctrlKey: true }),
+        noSel
+      )
+    ).toBe(true)
+    expect(
+      shouldBypassXtermKeydown(
+        event({
+          key: 'ArrowLeft',
+          code: 'ArrowLeft',
+          defaultPrevented: true,
+          ctrlKey: true,
+          altKey: true
+        }),
+        noSel
+      )
+    ).toBe(true)
   })
 
   it('does not bubble plain letters', () => {

--- a/src/renderer/src/components/terminal-pane/xterm-bypass-policy.ts
+++ b/src/renderer/src/components/terminal-pane/xterm-bypass-policy.ts
@@ -20,6 +20,7 @@
 export type XtermBypassEvent = {
   key: string
   code?: string
+  defaultPrevented?: boolean
   metaKey: boolean
   ctrlKey: boolean
   altKey: boolean
@@ -44,6 +45,16 @@ export function shouldBypassXtermKeydown(
   options: XtermBypassOptions
 ): boolean {
   const { isMac, hasSelection } = options
+  const platformModifierHeld = isMac
+    ? event.metaKey && !event.ctrlKey
+    : event.ctrlKey && !event.metaKey
+
+  if (event.defaultPrevented && platformModifierHeld) {
+    // Why: window-level Orca shortcuts may have already handled the chord but
+    // not stopped propagation. Match VS Code by preventing xterm's kitty
+    // encoder from also sending that app shortcut to the shell.
+    return true
+  }
 
   if (isMac) {
     // Narrow Ghostty rule to Cmd+C only: Ghostty bubbles every Cmd chord on


### PR DESCRIPTION
## Summary
- Match VS Code's terminal key handling more closely by bypassing xterm when an Orca platform-modifier shortcut has already called `preventDefault()`.
- Prevent kitty CSI-u from also writing handled app shortcuts, such as Cmd+B/Ctrl+B or Cmd/Ctrl+Alt+Arrow, into the shell.
- Add focused coverage for macOS and Windows/Linux handled-shortcut cases.

## Review Finding
VS Code's `attachCustomKeyEventHandler` returns `false` for resolved workbench keybindings using Meta because xterm's kitty keyboard path otherwise encodes the chord and consumes it. Orca had fixed native clipboard chords, but app-level handlers that only called `preventDefault()` could still let xterm receive the event and send a CSI-u sequence to the PTY.

## Validation
- `npm run lint`
- `npm test -- src/renderer/src/components/terminal-pane/xterm-bypass-policy.test.ts`