### PR TITLE
Restore worktree sidebar scrollbar

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -226,6 +226,36 @@
   scrollbar-color: color-mix(in srgb, var(--muted-foreground, #737373) 48%, transparent) transparent;
 }
 
+/* Keep the sidebar gutter reserved; only the thumb fades in on hover. */
+.worktree-sidebar-scrollbar {
+  scrollbar-color: transparent transparent;
+}
+
+.worktree-sidebar-scrollbar::-webkit-scrollbar-thumb {
+  background-color: transparent;
+  border-width: 3px 3px 3px 0;
+}
+
+.scrollbar-sleek-parent:hover .worktree-sidebar-scrollbar,
+.worktree-sidebar-scrollbar:hover {
+  scrollbar-color: color-mix(in srgb, var(--muted-foreground, #737373) 48%, transparent) transparent;
+}
+
+.scrollbar-sleek-parent:hover .worktree-sidebar-scrollbar::-webkit-scrollbar-thumb,
+.worktree-sidebar-scrollbar:hover::-webkit-scrollbar-thumb {
+  background-color: color-mix(in srgb, var(--muted-foreground, #737373) 28%, transparent);
+}
+
+.scrollbar-sleek-parent:hover .worktree-sidebar-scrollbar::-webkit-scrollbar-thumb:hover,
+.worktree-sidebar-scrollbar:hover::-webkit-scrollbar-thumb:hover {
+  background-color: color-mix(in srgb, var(--muted-foreground, #737373) 48%, transparent);
+}
+
+.scrollbar-sleek-parent:hover .worktree-sidebar-scrollbar::-webkit-scrollbar-thumb:active,
+.worktree-sidebar-scrollbar:hover::-webkit-scrollbar-thumb:active {
+  background-color: color-mix(in srgb, var(--foreground, #171717) 36%, transparent);
+}
+
 [data-slot='popover-content'] {
   max-height: var(--radix-popover-content-available-height);
 }

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -299,7 +299,9 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
       aria-orientation="vertical"
       aria-activedescendant={activeDescendantId}
       onKeyDown={handleContainerKeyDown}
-      className="flex-1 overflow-auto pl-1 pr-2 outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-inset pt-px [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+      className="worktree-sidebar-scrollbar flex-1 overflow-auto pl-1 pr-px scrollbar-sleek outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-inset pt-px"
+      // Why: reserve scrollbar space so non-overlay scrollbars do not nudge worktree cards.
+      style={{ scrollbarGutter: 'stable' }}
     >
       <div
         role="presentation"


### PR DESCRIPTION
## Summary
- restore the native worktree sidebar scrollbar
- keep the scrollbar gutter reserved so cards do not shift
- show the scrollbar thumb only while hovering the workspace sidebar and keep a 1px card gap

## Verification
- pnpm exec oxlint src/renderer/src/components/sidebar/WorktreeList.tsx
- pnpm run tc:web
- pnpm exec oxfmt --check src/renderer/src/assets/main.css src/renderer/src/components/sidebar/WorktreeList.tsx