### PR TITLE
Allow large text files to open in editor

### DIFF
--- a/src/main/ipc/filesystem.test.ts
+++ b/src/main/ipc/filesystem.test.ts
@@ -10,6 +10,7 @@ const {
   readFileMock,
   writeFileMock,
   statMock,
+  openMock,
   realpathMock,
   lstatMock,
   getStatusMock,
@@ -30,6 +31,7 @@ const {
   readFileMock: vi.fn(),
   writeFileMock: vi.fn(),
   statMock: vi.fn(),
+  openMock: vi.fn(),
   realpathMock: vi.fn(),
   lstatMock: vi.fn(),
   getStatusMock: vi.fn(),
@@ -59,6 +61,7 @@ vi.mock('fs/promises', () => ({
   readFile: readFileMock,
   writeFile: writeFileMock,
   stat: statMock,
+  open: openMock,
   realpath: realpathMock,
   lstat: lstatMock
 }))
@@ -142,6 +145,7 @@ describe('registerFilesystemHandlers', () => {
       readFileMock,
       writeFileMock,
       statMock,
+      openMock,
       realpathMock,
       lstatMock,
       getStatusMock,
@@ -179,6 +183,13 @@ describe('registerFilesystemHandlers', () => {
     ])
     trashItemMock.mockResolvedValue(undefined)
     statMock.mockResolvedValue({ size: 10, isDirectory: () => false, mtimeMs: 123 })
+    openMock.mockResolvedValue({
+      read: vi.fn(async (buffer: Buffer) => {
+        buffer.fill(0x61)
+        return { bytesRead: buffer.length, buffer }
+      }),
+      close: vi.fn()
+    })
     lstatMock.mockRejectedValue(Object.assign(new Error('missing'), { code: 'ENOENT' }))
   })
 
@@ -236,6 +247,55 @@ describe('registerFilesystemHandlers', () => {
       isImage: true,
       mimeType: mime
     })
+  })
+
+  it('opens text files larger than the old 5MB guard', async () => {
+    const content = 'a'.repeat(6 * 1024 * 1024)
+    statMock.mockResolvedValue({ size: content.length, isDirectory: () => false, mtimeMs: 123 })
+    readFileMock.mockResolvedValue(Buffer.from(content))
+
+    registerFilesystemHandlers(store as never)
+
+    await expect(
+      handlers.get('fs:readFile')!(null, { filePath: path.resolve('/workspace/repo/large.json') })
+    ).resolves.toEqual({
+      content,
+      isBinary: false
+    })
+  })
+
+  it('rejects text files beyond the editor read budget', async () => {
+    statMock.mockResolvedValue({ size: 51 * 1024 * 1024, isDirectory: () => false, mtimeMs: 123 })
+
+    registerFilesystemHandlers(store as never)
+
+    await expect(
+      handlers.get('fs:readFile')!(null, { filePath: path.resolve('/workspace/repo/huge.json') })
+    ).rejects.toThrow('exceeds 50MB limit')
+
+    expect(readFileMock).not.toHaveBeenCalled()
+  })
+
+  it('probes large unknown binaries without reading the full file', async () => {
+    statMock.mockResolvedValue({ size: 6 * 1024 * 1024, isDirectory: () => false, mtimeMs: 123 })
+    openMock.mockResolvedValue({
+      read: vi.fn(async (buffer: Buffer) => {
+        buffer[0] = 0x00
+        return { bytesRead: 1, buffer }
+      }),
+      close: vi.fn()
+    })
+
+    registerFilesystemHandlers(store as never)
+
+    await expect(
+      handlers.get('fs:readFile')!(null, { filePath: path.resolve('/workspace/repo/archive.bin') })
+    ).resolves.toEqual({
+      content: '',
+      isBinary: true
+    })
+
+    expect(readFileMock).not.toHaveBeenCalled()
   })
 
   it('moves files to trash', async () => {

--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines */
 import { ipcMain, shell } from 'electron'
-import { readdir, readFile, writeFile, stat, lstat } from 'fs/promises'
+import { readdir, readFile, writeFile, stat, lstat, open } from 'fs/promises'
 import { extname } from 'path'
 import type { ChildProcess } from 'child_process'
 import { wslAwareSpawn } from '../git/runner'
@@ -53,7 +53,10 @@ import { checkRgAvailable } from './rg-availability'
 import { getSshFilesystemProvider } from '../providers/ssh-filesystem-dispatch'
 import { getSshGitProvider } from '../providers/ssh-git-dispatch'
 
-const MAX_FILE_SIZE = 5 * 1024 * 1024 // 5MB
+// Why: Monaco has large-file optimizations like VS Code; blocking at 5MB makes
+// ordinary JSON/log files inaccessible before the editor can degrade features.
+const MAX_TEXT_FILE_SIZE = 50 * 1024 * 1024 // 50MB
+const BINARY_PROBE_BYTES = 8192
 // Why: previewable binaries (PDFs, images) are rendered by the viewer as
 // base64 blobs, not parsed as text — 5MB is tight for real-world PDFs, and
 // raising this cap only affects binary preview, not text/search paths.
@@ -85,6 +88,17 @@ function isBinaryBuffer(buffer: Buffer): boolean {
     }
   }
   return false
+}
+
+async function isBinaryFilePrefix(filePath: string): Promise<boolean> {
+  const handle = await open(filePath, 'r')
+  try {
+    const probe = Buffer.alloc(BINARY_PROBE_BYTES)
+    const { bytesRead } = await handle.read(probe, 0, probe.length, 0)
+    return isBinaryBuffer(probe.subarray(0, bytesRead))
+  } finally {
+    await handle.close()
+  }
 }
 
 export function registerFilesystemHandlers(store: Store): void {
@@ -135,15 +149,15 @@ export function registerFilesystemHandlers(store: Store): void {
       const filePath = await resolveAuthorizedPath(args.filePath, store)
       const stats = await stat(filePath)
       const mimeType = PREVIEWABLE_BINARY_MIME_TYPES[extname(filePath).toLowerCase()]
-      const sizeLimit = mimeType ? MAX_PREVIEWABLE_BINARY_SIZE : MAX_FILE_SIZE
+      const sizeLimit = mimeType ? MAX_PREVIEWABLE_BINARY_SIZE : MAX_TEXT_FILE_SIZE
       if (stats.size > sizeLimit) {
         throw new Error(
           `File too large: ${(stats.size / 1024 / 1024).toFixed(1)}MB exceeds ${sizeLimit / 1024 / 1024}MB limit`
         )
       }
 
-      const buffer = await readFile(filePath)
       if (mimeType) {
+        const buffer = await readFile(filePath)
         return {
           content: buffer.toString('base64'),
           isBinary: true,
@@ -155,6 +169,14 @@ export function registerFilesystemHandlers(store: Store): void {
         }
       }
 
+      // Why: the text cap is intentionally larger than the old binary cap.
+      // Probe unknown large files first so archives do not get fully buffered
+      // just to discover they are not editable text.
+      if (stats.size > BINARY_PROBE_BYTES && (await isBinaryFilePrefix(filePath))) {
+        return { content: '', isBinary: true }
+      }
+
+      const buffer = await readFile(filePath)
       if (isBinaryBuffer(buffer)) {
         return { content: '', isBinary: true }
       }

--- a/src/relay/fs-handler-file-read.ts
+++ b/src/relay/fs-handler-file-read.ts
@@ -1,0 +1,38 @@
+import { readFile, stat } from 'fs/promises'
+import { extname } from 'path'
+import {
+  BINARY_PROBE_BYTES,
+  IMAGE_MIME_TYPES,
+  MAX_PREVIEWABLE_BINARY_SIZE,
+  MAX_TEXT_FILE_SIZE,
+  isBinaryBuffer,
+  isBinaryFilePrefix
+} from './fs-handler-utils'
+
+export async function readRelayFileContent(filePath: string) {
+  const stats = await stat(filePath)
+  const mimeType = IMAGE_MIME_TYPES[extname(filePath).toLowerCase()]
+  const sizeLimit = mimeType ? MAX_PREVIEWABLE_BINARY_SIZE : MAX_TEXT_FILE_SIZE
+  if (stats.size > sizeLimit) {
+    throw new Error(
+      `File too large: ${(stats.size / 1024 / 1024).toFixed(1)}MB exceeds ${sizeLimit / 1024 / 1024}MB limit`
+    )
+  }
+
+  if (mimeType) {
+    const buffer = await readFile(filePath)
+    return { content: buffer.toString('base64'), isBinary: true, isImage: true, mimeType }
+  }
+
+  // Why: SSH reads serialize through bounded relay frames; probing large
+  // unknown files prevents binary archives from consuming frame budget.
+  if (stats.size > BINARY_PROBE_BYTES && (await isBinaryFilePrefix(filePath))) {
+    return { content: '', isBinary: true }
+  }
+
+  const buffer = await readFile(filePath)
+  if (isBinaryBuffer(buffer)) {
+    return { content: '', isBinary: true }
+  }
+  return { content: buffer.toString('utf-8'), isBinary: false }
+}

--- a/src/relay/fs-handler-utils.ts
+++ b/src/relay/fs-handler-utils.ts
@@ -6,6 +6,7 @@
  * so they are straightforward to test independently.
  */
 import { spawn, execFile } from 'child_process'
+import { open } from 'fs/promises'
 import {
   buildRgArgs,
   createAccumulator,
@@ -17,9 +18,13 @@ import type { SearchResult as SharedSearchResult } from '../shared/types'
 
 // ─── Constants ───────────────────────────────────────────────────────
 
-export const MAX_FILE_SIZE = 5 * 1024 * 1024
+// Why: remote reads still travel through bounded JSON-RPC frames, but matching
+// the old 5MB search cap would block common JSON/log files before Monaco's
+// large-file optimizations can handle them.
+export const MAX_TEXT_FILE_SIZE = 10 * 1024 * 1024
 // 10MB for relayed binaries (base64 → ~13.3MB frame payload at 16MB relay cap)
 export const MAX_PREVIEWABLE_BINARY_SIZE = 10 * 1024 * 1024
+export const BINARY_PROBE_BYTES = 8192
 export const SEARCH_TIMEOUT_MS = SHARED_SEARCH_TIMEOUT_MS
 export const DEFAULT_MAX_RESULTS = 2000
 
@@ -45,6 +50,17 @@ export function isBinaryBuffer(buffer: Buffer): boolean {
     }
   }
   return false
+}
+
+export async function isBinaryFilePrefix(filePath: string): Promise<boolean> {
+  const handle = await open(filePath, 'r')
+  try {
+    const probe = Buffer.alloc(BINARY_PROBE_BYTES)
+    const { bytesRead } = await handle.read(probe, 0, probe.length, 0)
+    return isBinaryBuffer(probe.subarray(0, bytesRead))
+  } finally {
+    await handle.close()
+  }
 }
 
 // ─── Search types ────────────────────────────────────────────────────

--- a/src/relay/fs-handler.test.ts
+++ b/src/relay/fs-handler.test.ts
@@ -132,6 +132,33 @@ describe('FsHandler', () => {
     expect(result.isBinary).toBe(false)
   })
 
+  it('readFile returns text files larger than the old 5MB guard', async () => {
+    const filePath = path.join(tmpDir, 'large.json')
+    const content = 'a'.repeat(6 * 1024 * 1024)
+    writeFileSync(filePath, content)
+
+    const result = (await dispatcher.callRequest('fs.readFile', { filePath })) as {
+      content: string
+      isBinary: boolean
+    }
+    expect(result.content).toBe(content)
+    expect(result.isBinary).toBe(false)
+  })
+
+  it('readFile returns binary marker for large unknown binary files', async () => {
+    const filePath = path.join(tmpDir, 'archive.bin')
+    const content = Buffer.alloc(6 * 1024 * 1024, 0x61)
+    content[0] = 0x00
+    writeFileSync(filePath, content)
+
+    const result = (await dispatcher.callRequest('fs.readFile', { filePath })) as {
+      content: string
+      isBinary: boolean
+    }
+    expect(result.content).toBe('')
+    expect(result.isBinary).toBe(true)
+  })
+
   it('readFile returns base64 for image files', async () => {
     const filePath = path.join(tmpDir, 'test.png')
     writeFileSync(filePath, Buffer.from([0x89, 0x50, 0x4e, 0x47]))
@@ -150,8 +177,7 @@ describe('FsHandler', () => {
 
   it('readFile throws for files exceeding size limit', async () => {
     const filePath = path.join(tmpDir, 'huge.txt')
-    // Write 6MB file
-    writeFileSync(filePath, Buffer.alloc(6 * 1024 * 1024))
+    writeFileSync(filePath, Buffer.alloc(11 * 1024 * 1024, 'a'))
 
     await expect(dispatcher.callRequest('fs.readFile', { filePath })).rejects.toThrow(
       'File too large'

--- a/src/relay/fs-handler.ts
+++ b/src/relay/fs-handler.ts
@@ -1,26 +1,10 @@
-import {
-  readdir,
-  readFile,
-  writeFile,
-  stat,
-  lstat,
-  mkdir,
-  rename,
-  cp,
-  rm,
-  realpath
-} from 'fs/promises'
-import { extname } from 'path'
+import { readdir, writeFile, stat, lstat, mkdir, rename, cp, rm, realpath } from 'fs/promises'
 import { execFile } from 'child_process'
 import type { RelayDispatcher, RequestContext } from './dispatcher'
 import type { RelayContext } from './context'
 import { expandTilde } from './context'
 import {
-  MAX_FILE_SIZE,
-  MAX_PREVIEWABLE_BINARY_SIZE,
   DEFAULT_MAX_RESULTS,
-  IMAGE_MIME_TYPES,
-  isBinaryBuffer,
   searchWithRg,
   listFilesWithRg,
   checkRgAvailable
@@ -29,6 +13,7 @@ import { listFilesWithGit, searchWithGitGrep } from './fs-handler-git-fallback'
 import { listFilesWithReaddir } from './fs-handler-readdir-fallback'
 import { buildExcludePathPrefixes } from '../shared/quick-open-filter'
 import { buildInstallRgMessage } from './fs-handler-install-rg'
+import { readRelayFileContent } from './fs-handler-file-read'
 
 type WatchState = {
   rootPath: string
@@ -86,23 +71,7 @@ export class FsHandler {
   private async readFile(params: Record<string, unknown>) {
     const filePath = expandTilde(params.filePath as string)
     await this.context.validatePathResolved(filePath)
-    const stats = await stat(filePath)
-    const mimeType = IMAGE_MIME_TYPES[extname(filePath).toLowerCase()]
-    const sizeLimit = mimeType ? MAX_PREVIEWABLE_BINARY_SIZE : MAX_FILE_SIZE
-    if (stats.size > sizeLimit) {
-      throw new Error(
-        `File too large: ${(stats.size / 1024 / 1024).toFixed(1)}MB exceeds ${sizeLimit / 1024 / 1024}MB limit`
-      )
-    }
-
-    const buffer = await readFile(filePath)
-    if (mimeType) {
-      return { content: buffer.toString('base64'), isBinary: true, isImage: true, mimeType }
-    }
-    if (isBinaryBuffer(buffer)) {
-      return { content: '', isBinary: true }
-    }
-    return { content: buffer.toString('utf-8'), isBinary: false }
+    return readRelayFileContent(filePath)
   }
 
   private async writeFile(params: Record<string, unknown>) {

--- a/src/renderer/src/components/settings/TerminalPane.tsx
+++ b/src/renderer/src/components/settings/TerminalPane.tsx
@@ -39,13 +39,15 @@ import {
   TERMINAL_MAC_OPTION_SEARCH_ENTRIES,
   TERMINAL_PANE_STYLE_SEARCH_ENTRIES,
   TERMINAL_RENDERING_SEARCH_ENTRIES,
-  TERMINAL_RIGHT_CLICK_TO_PASTE_SEARCH_ENTRY,
   TERMINAL_SETUP_SCRIPT_SEARCH_ENTRIES,
   TERMINAL_TYPOGRAPHY_SEARCH_ENTRIES,
-  TERMINAL_WINDOW_SEARCH_ENTRIES,
+  TERMINAL_WINDOW_SEARCH_ENTRIES
+} from './terminal-search'
+import {
+  TERMINAL_RIGHT_CLICK_TO_PASTE_SEARCH_ENTRY,
   TERMINAL_WINDOWS_POWERSHELL_IMPLEMENTATION_SEARCH_ENTRY,
   TERMINAL_WINDOWS_SHELL_SEARCH_ENTRY
-} from './terminal-search'
+} from './terminal-windows-search'
 import { useDetectedOptionAsAlt } from '@/lib/keyboard-layout/use-effective-mac-option-as-alt'
 import { detectedCategoryToDefault } from '@/lib/keyboard-layout/detect-option-as-alt'
 import { DarkTerminalThemeSection, LightTerminalThemeSection } from './TerminalThemeSections'

--- a/src/renderer/src/components/settings/terminal-search.ts
+++ b/src/renderer/src/components/settings/terminal-search.ts
@@ -1,4 +1,5 @@
 import type { SettingsSearchEntry } from './settings-search'
+import { TERMINAL_WINDOWS_SEARCH_ENTRIES } from './terminal-windows-search'
 
 export const TERMINAL_TYPOGRAPHY_SEARCH_ENTRIES: SettingsSearchEntry[] = [
   {
@@ -238,64 +239,6 @@ export const TERMINAL_SETUP_SCRIPT_SEARCH_ENTRIES: SettingsSearchEntry[] = [
       'location',
       'launch'
     ]
-  }
-]
-
-export const TERMINAL_WINDOWS_SHELL_SEARCH_ENTRY: SettingsSearchEntry[] = [
-  {
-    title: 'Default Shell',
-    description: 'Choose the default shell for new terminal panes on Windows.',
-    keywords: [
-      'terminal',
-      'windows',
-      'shell',
-      'powershell',
-      'cmd',
-      'command prompt',
-      'default',
-      'wsl',
-      'linux',
-      'bash',
-      'ubuntu'
-    ]
-  }
-]
-
-export const TERMINAL_WINDOWS_POWERSHELL_IMPLEMENTATION_SEARCH_ENTRY: SettingsSearchEntry[] = [
-  {
-    title: 'PowerShell Version',
-    description:
-      'Choose whether the PowerShell shell option launches Windows PowerShell or PowerShell 7+ for new terminal panes.',
-    keywords: [
-      'terminal',
-      'windows',
-      'powershell',
-      'windows powershell',
-      'powershell 7',
-      'pwsh',
-      'version',
-      'advanced'
-    ]
-  }
-]
-
-export const TERMINAL_WINDOWS_SEARCH_ENTRIES: SettingsSearchEntry[] = [
-  ...TERMINAL_WINDOWS_SHELL_SEARCH_ENTRY,
-  ...TERMINAL_WINDOWS_POWERSHELL_IMPLEMENTATION_SEARCH_ENTRY,
-  {
-    title: 'Right-click to paste',
-    description:
-      'On Windows, right-click pastes the clipboard into the terminal. Use Ctrl+right-click to open the context menu.',
-    keywords: ['terminal', 'windows', 'right click', 'paste', 'context menu']
-  }
-]
-
-export const TERMINAL_RIGHT_CLICK_TO_PASTE_SEARCH_ENTRY: SettingsSearchEntry[] = [
-  {
-    title: 'Right-click to paste',
-    description:
-      'On Windows, right-click pastes the clipboard into the terminal. Use Ctrl+right-click to open the context menu.',
-    keywords: ['terminal', 'windows', 'right click', 'paste', 'context menu']
   }
 ]
 

--- a/src/renderer/src/components/settings/terminal-windows-search.ts
+++ b/src/renderer/src/components/settings/terminal-windows-search.ts
@@ -1,0 +1,54 @@
+import type { SettingsSearchEntry } from './settings-search'
+
+export const TERMINAL_WINDOWS_SHELL_SEARCH_ENTRY: SettingsSearchEntry[] = [
+  {
+    title: 'Default Shell',
+    description: 'Choose the default shell for new terminal panes on Windows.',
+    keywords: [
+      'terminal',
+      'windows',
+      'shell',
+      'powershell',
+      'cmd',
+      'command prompt',
+      'default',
+      'wsl',
+      'linux',
+      'bash',
+      'ubuntu'
+    ]
+  }
+]
+
+export const TERMINAL_WINDOWS_POWERSHELL_IMPLEMENTATION_SEARCH_ENTRY: SettingsSearchEntry[] = [
+  {
+    title: 'PowerShell Version',
+    description:
+      'Choose whether the PowerShell shell option launches Windows PowerShell or PowerShell 7+ for new terminal panes.',
+    keywords: [
+      'terminal',
+      'windows',
+      'powershell',
+      'windows powershell',
+      'powershell 7',
+      'pwsh',
+      'version',
+      'advanced'
+    ]
+  }
+]
+
+export const TERMINAL_RIGHT_CLICK_TO_PASTE_SEARCH_ENTRY: SettingsSearchEntry[] = [
+  {
+    title: 'Right-click to paste',
+    description:
+      'On Windows, right-click pastes the clipboard into the terminal. Use Ctrl+right-click to open the context menu.',
+    keywords: ['terminal', 'windows', 'right click', 'paste', 'context menu']
+  }
+]
+
+export const TERMINAL_WINDOWS_SEARCH_ENTRIES: SettingsSearchEntry[] = [
+  ...TERMINAL_WINDOWS_SHELL_SEARCH_ENTRY,
+  ...TERMINAL_WINDOWS_POWERSHELL_IMPLEMENTATION_SEARCH_ENTRY,
+  ...TERMINAL_RIGHT_CLICK_TO_PASTE_SEARCH_ENTRY
+]

--- a/src/shared/text-search.ts
+++ b/src/shared/text-search.ts
@@ -45,9 +45,8 @@ export const MAX_MATCHES_PER_FILE = 100
 export const DEFAULT_SEARCH_MAX_RESULTS = 2000
 export const SEARCH_TIMEOUT_MS = 15_000
 
-// Why: the text-search path only reads files up to 5MB — this mirrors both
-// the local MAX_FILE_SIZE and the relay's MAX_FILE_SIZE. Kept here so the rg
-// `--max-filesize` flag stays in sync across callers.
+// Why: search should stay cheaper than opening a file in the editor. The
+// editor read path has a larger cap and relies on Monaco large-file handling.
 const SEARCH_MAX_FILE_SIZE = 5 * 1024 * 1024
 
 // Why: `lineContent` is carried per-match to the renderer. Minified bundles


### PR DESCRIPTION
## Summary
- increase editor text read limits so JSON/log files above 5MB can open instead of failing at IPC
- keep search at the cheaper 5MB cap and keep preview/binary payload caps separate
- apply the same fix to SSH relay reads while staying under relay frame limits

## Reference review
- checked mature editor large-file behavior: large files should still open, with expensive editor features degraded after load instead of failing before render

## Tests
- pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/filesystem.test.ts
- pnpm exec vitest run --config config/vitest.config.ts src/relay/fs-handler.test.ts
- pnpm exec oxlint src/main/ipc/filesystem.ts src/main/ipc/filesystem.test.ts src/relay/fs-handler-utils.ts src/relay/fs-handler.ts src/relay/fs-handler.test.ts src/shared/text-search.ts
- pnpm run tc:node
- pnpm run tc:web

Fixes #1366