### PR TITLE
feat(browser): viewport-size emulation via CDP

### DIFF
--- a/src/main/browser/browser-manager.test.ts
+++ b/src/main/browser/browser-manager.test.ts
@@ -1117,4 +1117,138 @@ describe('browserManager', () => {
       guestOffMock.mock.calls.filter(([eventName]) => eventName === 'before-input-event')
     ).toHaveLength(2)
   })
+
+  describe('setViewportOverride', () => {
+    function makeGuest(id: number): {
+      guest: Record<string, unknown>
+      debuggerSendCommand: ReturnType<typeof vi.fn>
+      debuggerIsAttached: ReturnType<typeof vi.fn>
+      debuggerAttach: ReturnType<typeof vi.fn>
+    } {
+      const debuggerSendCommand = vi.fn().mockResolvedValue(undefined)
+      const debuggerIsAttached = vi.fn(() => true)
+      const debuggerAttach = vi.fn()
+      const guest = {
+        id,
+        isDestroyed: vi.fn(() => false),
+        getType: vi.fn(() => 'webview'),
+        getUserAgent: vi.fn(
+          () =>
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) orca/1.0.0 Chrome/134.0.0.0 Electron/30.0.0 Safari/537.36'
+        ),
+        setBackgroundThrottling: guestSetBackgroundThrottlingMock,
+        setWindowOpenHandler: guestSetWindowOpenHandlerMock,
+        on: guestOnMock,
+        off: guestOffMock,
+        openDevTools: guestOpenDevToolsMock,
+        debugger: {
+          isAttached: debuggerIsAttached,
+          attach: debuggerAttach,
+          sendCommand: debuggerSendCommand
+        }
+      }
+      return { guest, debuggerSendCommand, debuggerIsAttached, debuggerAttach }
+    }
+
+    it('returns false when the tab is not registered', async () => {
+      const result = await browserManager.setViewportOverride('missing', {
+        width: 375,
+        height: 667,
+        deviceScaleFactor: 2,
+        mobile: true
+      })
+      expect(result).toBe(false)
+    })
+
+    it('applies device metrics, touch emulation, and a mobile UA for mobile presets', async () => {
+      const { guest, debuggerSendCommand } = makeGuest(4242)
+      webContentsFromIdMock.mockReturnValue(guest)
+      browserManager.attachGuestPolicies(guest as never)
+      browserManager.registerGuest({
+        browserPageId: 'tab-mobile',
+        webContentsId: guest.id as number,
+        rendererWebContentsId
+      })
+      webContentsFromIdMock.mockReset()
+      webContentsFromIdMock.mockReturnValue(guest)
+
+      const ok = await browserManager.setViewportOverride('tab-mobile', {
+        width: 375,
+        height: 667,
+        deviceScaleFactor: 2,
+        mobile: true
+      })
+      expect(ok).toBe(true)
+
+      expect(debuggerSendCommand).toHaveBeenCalledWith('Emulation.setDeviceMetricsOverride', {
+        width: 375,
+        height: 667,
+        deviceScaleFactor: 2,
+        mobile: true
+      })
+      expect(debuggerSendCommand).toHaveBeenCalledWith('Emulation.setTouchEmulationEnabled', {
+        enabled: true,
+        maxTouchPoints: 5
+      })
+      const uaCall = debuggerSendCommand.mock.calls.find(
+        (call) => call[0] === 'Emulation.setUserAgentOverride'
+      )
+      expect(uaCall).toBeDefined()
+      expect(uaCall?.[1]).toMatchObject({
+        userAgent: expect.stringContaining('iPhone')
+      })
+      // Chrome major from the guest UA should be spliced into the mobile UA.
+      expect(uaCall?.[1]).toMatchObject({
+        userAgent: expect.stringContaining('CriOS/134')
+      })
+    })
+
+    it('clears device metrics and disables touch for override=null', async () => {
+      const { guest, debuggerSendCommand } = makeGuest(4343)
+      webContentsFromIdMock.mockReturnValue(guest)
+      browserManager.attachGuestPolicies(guest as never)
+      browserManager.registerGuest({
+        browserPageId: 'tab-clear',
+        webContentsId: guest.id as number,
+        rendererWebContentsId
+      })
+
+      const ok = await browserManager.setViewportOverride('tab-clear', null)
+      expect(ok).toBe(true)
+
+      expect(debuggerSendCommand).toHaveBeenCalledWith('Emulation.clearDeviceMetricsOverride', {})
+      expect(debuggerSendCommand).toHaveBeenCalledWith('Emulation.setTouchEmulationEnabled', {
+        enabled: false,
+        maxTouchPoints: 0
+      })
+      expect(debuggerSendCommand).toHaveBeenCalledWith('Emulation.setUserAgentOverride', {
+        userAgent: ''
+      })
+    })
+
+    it('attaches the debugger if not already attached and does not detach after', async () => {
+      const { guest, debuggerSendCommand, debuggerAttach } = makeGuest(4444)
+      ;(guest.debugger as { isAttached: ReturnType<typeof vi.fn> }).isAttached = vi.fn(() => false)
+      webContentsFromIdMock.mockReturnValue(guest)
+      browserManager.attachGuestPolicies(guest as never)
+      browserManager.registerGuest({
+        browserPageId: 'tab-attach',
+        webContentsId: guest.id as number,
+        rendererWebContentsId
+      })
+
+      await browserManager.setViewportOverride('tab-attach', {
+        width: 1024,
+        height: 768,
+        deviceScaleFactor: 1,
+        mobile: false
+      })
+
+      expect(debuggerAttach).toHaveBeenCalledWith('1.3')
+      expect(debuggerSendCommand).toHaveBeenCalled()
+      // Why: detaching would clear Page.addScriptToEvaluateOnNewDocument
+      // (anti-detection). Guard regression.
+      expect((guest.debugger as { detach?: unknown }).detach ?? undefined).toBeUndefined()
+    })
+  })
 })

--- a/src/main/browser/browser-manager.test.ts
+++ b/src/main/browser/browser-manager.test.ts
@@ -1250,5 +1250,34 @@ describe('browserManager', () => {
       // (anti-detection). Guard regression.
       expect((guest.debugger as { detach?: unknown }).detach ?? undefined).toBeUndefined()
     })
+
+    it('returns false when debugger.attach throws (e.g. DevTools already open)', async () => {
+      const { guest, debuggerSendCommand, debuggerAttach } = makeGuest(4545)
+      ;(guest.debugger as { isAttached: ReturnType<typeof vi.fn> }).isAttached = vi.fn(() => false)
+      // Why: Electron throws from debugger.attach if another client (e.g. the
+      // user's open DevTools window) is already attached. setViewportOverride
+      // must surface this as a clean `false` rather than an unhandled rejection.
+      debuggerAttach.mockImplementation(() => {
+        throw new Error('Another debugger is already attached')
+      })
+      webContentsFromIdMock.mockReturnValue(guest)
+      browserManager.attachGuestPolicies(guest as never)
+      browserManager.registerGuest({
+        browserPageId: 'tab-attach-throws',
+        webContentsId: guest.id as number,
+        rendererWebContentsId
+      })
+
+      const ok = await browserManager.setViewportOverride('tab-attach-throws', {
+        width: 1024,
+        height: 768,
+        deviceScaleFactor: 1,
+        mobile: false
+      })
+
+      expect(ok).toBe(false)
+      expect(debuggerAttach).toHaveBeenCalledWith('1.3')
+      expect(debuggerSendCommand).not.toHaveBeenCalled()
+    })
   })
 })

--- a/src/main/browser/browser-manager.ts
+++ b/src/main/browser/browser-manager.ts
@@ -34,6 +34,21 @@ import {
   setupGuestShortcutForwarding
 } from './browser-guest-ui'
 import { ANTI_DETECTION_SCRIPT } from './anti-detection'
+import { cleanElectronUserAgent } from './browser-session-ua'
+import type { BrowserViewportOverride } from '../../shared/types'
+
+// Why: mobile presets need a touch-capable UA or responsive sites serve the
+// desktop variant based on UA sniffing. This is the Chrome DevTools default
+// iPhone UA template; we splice in the guest session's real Chrome major so
+// sec-ch-ua headers (see setupClientHintsOverride) stay consistent.
+function buildMobileUserAgent(chromeMajor: string): string {
+  return `Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/${chromeMajor}.0.0.0 Mobile/15E148 Safari/604.1`
+}
+
+function extractChromeMajor(ua: string): string {
+  const match = ua.match(/Chrome\/(\d+)/)
+  return match ? match[1] : '134'
+}
 
 export type BrowserGuestRegistration = {
   browserPageId?: string
@@ -873,6 +888,76 @@ export class BrowserManager {
     }
     guest.openDevTools({ mode: 'detach' })
     return true
+  }
+
+  // Why: Electron <webview> guests do not expose Chrome DevTools' device
+  // toolbar (Cmd+Shift+M) to the embedding app, so viewport emulation must be
+  // driven through CDP directly. We reuse the debugger attachment that
+  // injectAntiDetection already established and never detach it here — doing
+  // so would clear Page.addScriptToEvaluateOnNewDocument and other per-guest
+  // overrides. Passing override=null clears emulation.
+  async setViewportOverride(
+    browserTabId: string,
+    override: BrowserViewportOverride | null
+  ): Promise<boolean> {
+    const webContentsId = this.webContentsIdByTabId.get(browserTabId)
+    if (!webContentsId) {
+      return false
+    }
+    const guest = webContents.fromId(webContentsId)
+    if (!guest || guest.isDestroyed()) {
+      this.webContentsIdByTabId.delete(browserTabId)
+      this.tabIdByWebContentsId.delete(webContentsId)
+      return false
+    }
+
+    try {
+      if (!guest.debugger.isAttached()) {
+        guest.debugger.attach('1.3')
+      }
+    } catch {
+      return false
+    }
+
+    const dbg = guest.debugger
+    try {
+      if (override) {
+        await dbg.sendCommand('Emulation.setDeviceMetricsOverride', {
+          width: override.width,
+          height: override.height,
+          deviceScaleFactor: override.deviceScaleFactor,
+          mobile: override.mobile
+        })
+        await dbg.sendCommand('Emulation.setTouchEmulationEnabled', {
+          enabled: override.mobile,
+          maxTouchPoints: override.mobile ? 5 : 0
+        })
+        if (override.mobile) {
+          const chromeMajor = extractChromeMajor(cleanElectronUserAgent(guest.getUserAgent()))
+          await dbg.sendCommand('Emulation.setUserAgentOverride', {
+            userAgent: buildMobileUserAgent(chromeMajor)
+          })
+        } else {
+          // Why: desktop presets still need the clean (non-Electron) UA so
+          // Cloudflare/Turnstile don't flag the session. Passing the cleaned
+          // real UA keeps sec-ch-ua consistent with the override.
+          await dbg.sendCommand('Emulation.setUserAgentOverride', {
+            userAgent: cleanElectronUserAgent(guest.getUserAgent())
+          })
+        }
+      } else {
+        await dbg.sendCommand('Emulation.clearDeviceMetricsOverride', {})
+        await dbg.sendCommand('Emulation.setTouchEmulationEnabled', {
+          enabled: false,
+          maxTouchPoints: 0
+        })
+        // Why: passing an empty string restores the session default UA.
+        await dbg.sendCommand('Emulation.setUserAgentOverride', { userAgent: '' })
+      }
+      return true
+    } catch {
+      return false
+    }
   }
 
   // ---------------------------------------------------------------------------

--- a/src/main/browser/browser-manager.ts
+++ b/src/main/browser/browser-manager.ts
@@ -98,6 +98,11 @@ export class BrowserManager {
   // has to bridge that mismatch to activate the right tab before capture.
   private readonly workspaceIdByPageId = new Map<string, string>()
   private readonly rendererWebContentsIdByTabId = new Map<string, number>()
+  // Why: chain setViewportOverride calls per tab so rapid toggles don't
+  // interleave CDP commands. Without serialization, two concurrent calls can
+  // race (e.g. clearDeviceMetricsOverride landing after a later mobile
+  // setDeviceMetricsOverride), leaving emulation in an unexpected state.
+  private readonly viewportOpsByTabId = new Map<string, Promise<unknown>>()
   private readonly contextMenuCleanupByTabId = new Map<string, () => void>()
   private readonly grabShortcutCleanupByTabId = new Map<string, () => void>()
   private readonly shortcutForwardingCleanupByTabId = new Map<string, () => void>()
@@ -651,6 +656,9 @@ export class BrowserManager {
     this.rendererWebContentsIdByTabId.delete(browserTabId)
     this.workspaceIdByPageId.delete(browserTabId)
     this.worktreeIdByTabId.delete(browserTabId)
+    // Why: drop any pending viewport-op chain for this tab so the Map doesn't
+    // retain a resolved promise keyed to a destroyed guest.
+    this.viewportOpsByTabId.delete(browserTabId)
   }
 
   unregisterAll(): void {
@@ -900,6 +908,31 @@ export class BrowserManager {
     browserTabId: string,
     override: BrowserViewportOverride | null
   ): Promise<boolean> {
+    // Why: chain per-tab so rapid toggles (e.g. user clicking presets quickly)
+    // don't interleave CDP commands. Each call waits for the previous one to
+    // settle, guaranteeing the last-requested override wins rather than whichever
+    // sendCommand sequence happens to finish last.
+    const prev = this.viewportOpsByTabId.get(browserTabId) ?? Promise.resolve()
+    const next = prev
+      .catch(() => {})
+      .then(() => this.doSetViewportOverrideImpl(browserTabId, override))
+    this.viewportOpsByTabId.set(browserTabId, next)
+    try {
+      return await next
+    } finally {
+      // Why: only clear if this call's promise is still the tail. A concurrent
+      // later call may have already replaced the entry; deleting would drop the
+      // chain and break serialization for the next invocation.
+      if (this.viewportOpsByTabId.get(browserTabId) === next) {
+        this.viewportOpsByTabId.delete(browserTabId)
+      }
+    }
+  }
+
+  private async doSetViewportOverrideImpl(
+    browserTabId: string,
+    override: BrowserViewportOverride | null
+  ): Promise<boolean> {
     const webContentsId = this.webContentsIdByTabId.get(browserTabId)
     if (!webContentsId) {
       return false
@@ -915,7 +948,16 @@ export class BrowserManager {
       if (!guest.debugger.isAttached()) {
         guest.debugger.attach('1.3')
       }
-    } catch {
+    } catch (err) {
+      // Why: DevTools being open on the guest causes attach to throw with
+      // "Another debugger is already attached". Silently returning false made
+      // this failure mode undiagnosable — surface it via the logger with enough
+      // context (tab + webContents ids) to correlate with user reports.
+      console.warn('[browser-manager] setViewportOverride: failed to attach debugger', {
+        browserTabId,
+        webContentsId,
+        error: err instanceof Error ? err.message : String(err)
+      })
       return false
     }
 
@@ -934,8 +976,30 @@ export class BrowserManager {
         })
         if (override.mobile) {
           const chromeMajor = extractChromeMajor(cleanElectronUserAgent(guest.getUserAgent()))
+          // Why: pass userAgentMetadata alongside the mobile UA string so
+          // sec-ch-ua-mobile / sec-ch-ua-platform client hints match. Without
+          // it, session-level desktop client-hints leak through and create a
+          // UA/CH mismatch that bot-detection (Cloudflare, Turnstile) flags.
           await dbg.sendCommand('Emulation.setUserAgentOverride', {
-            userAgent: buildMobileUserAgent(chromeMajor)
+            userAgent: buildMobileUserAgent(chromeMajor),
+            userAgentMetadata: {
+              brands: [
+                { brand: 'Google Chrome', version: chromeMajor },
+                { brand: 'Chromium', version: chromeMajor },
+                { brand: 'Not/A)Brand', version: '24' }
+              ],
+              fullVersionList: [
+                { brand: 'Google Chrome', version: `${chromeMajor}.0.0.0` },
+                { brand: 'Chromium', version: `${chromeMajor}.0.0.0` },
+                { brand: 'Not/A)Brand', version: '24.0.0.0' }
+              ],
+              fullVersion: `${chromeMajor}.0.0.0`,
+              platform: 'iOS',
+              platformVersion: '17.0',
+              architecture: '',
+              model: 'iPhone',
+              mobile: true
+            }
           })
         } else {
           // Why: desktop presets still need the clean (non-Electron) UA so

--- a/src/main/ipc/browser.ts
+++ b/src/main/ipc/browser.ts
@@ -25,7 +25,8 @@ import type {
 import type {
   BrowserCookieImportResult,
   BrowserSessionProfile,
-  BrowserSessionProfileScope
+  BrowserSessionProfileScope,
+  BrowserViewportOverride
 } from '../../shared/types'
 
 let trustedBrowserRendererWebContentsId: number | null = null
@@ -179,16 +180,36 @@ export function registerBrowserHandlers(): void {
       event,
       args: {
         browserPageId: string
-        override: {
-          width: number
-          height: number
-          deviceScaleFactor: number
-          mobile: boolean
-        } | null
+        override: BrowserViewportOverride | null
       }
     ) => {
       if (!isTrustedBrowserRenderer(event.sender)) {
         return false
+      }
+      // Why: CDP misbehaves on non-finite/negative metrics (NaN/Infinity can
+      // wedge Emulation.setDeviceMetricsOverride and leave the page in a
+      // broken state). Validate at the main-process trust boundary so a buggy
+      // or compromised renderer cannot corrupt CDP state.
+      if (args.override !== null) {
+        const { width, height, deviceScaleFactor, mobile } = args.override
+        const isFinitePositive = (n: unknown): n is number =>
+          typeof n === 'number' && Number.isFinite(n) && n > 0
+        if (!isFinitePositive(width) || width < 1 || width > 10000) {
+          return false
+        }
+        if (!isFinitePositive(height) || height < 1 || height > 10000) {
+          return false
+        }
+        if (
+          !isFinitePositive(deviceScaleFactor) ||
+          deviceScaleFactor < 0.1 ||
+          deviceScaleFactor > 5
+        ) {
+          return false
+        }
+        if (typeof mobile !== 'boolean') {
+          return false
+        }
       }
       return browserManager.setViewportOverride(args.browserPageId, args.override)
     }

--- a/src/main/ipc/browser.ts
+++ b/src/main/ipc/browser.ts
@@ -84,6 +84,7 @@ export function registerBrowserHandlers(): void {
   ipcMain.removeHandler('browser:registerGuest')
   ipcMain.removeHandler('browser:unregisterGuest')
   ipcMain.removeHandler('browser:openDevTools')
+  ipcMain.removeHandler('browser:setViewportOverride')
   ipcMain.removeHandler('browser:acceptDownload')
   ipcMain.removeHandler('browser:cancelDownload')
   ipcMain.removeHandler('browser:setGrabMode')
@@ -171,6 +172,27 @@ export function registerBrowserHandlers(): void {
     }
     return browserManager.openDevTools(args.browserPageId)
   })
+
+  ipcMain.handle(
+    'browser:setViewportOverride',
+    (
+      event,
+      args: {
+        browserPageId: string
+        override: {
+          width: number
+          height: number
+          deviceScaleFactor: number
+          mobile: boolean
+        } | null
+      }
+    ) => {
+      if (!isTrustedBrowserRenderer(event.sender)) {
+        return false
+      }
+      return browserManager.setViewportOverride(args.browserPageId, args.override)
+    }
+  )
 
   ipcMain.handle('browser:acceptDownload', async (event, args: { downloadId: string }) => {
     if (!isTrustedBrowserRenderer(event.sender)) {

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -127,6 +127,15 @@ export type BrowserApi = {
   }) => Promise<void>
   unregisterGuest: (args: { browserPageId: string }) => Promise<void>
   openDevTools: (args: { browserPageId: string }) => Promise<boolean>
+  setViewportOverride: (args: {
+    browserPageId: string
+    override: {
+      width: number
+      height: number
+      deviceScaleFactor: number
+      mobile: boolean
+    } | null
+  }) => Promise<boolean>
   onGuestLoadFailed: (
     callback: (args: { browserPageId: string; loadError: BrowserLoadError }) => void
   ) => () => void

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -6,6 +6,7 @@ import type {
   BrowserSessionProfile,
   BrowserSessionProfileScope,
   BrowserSessionProfileSource,
+  BrowserViewportOverride,
   ClaudeRateLimitAccountsState,
   CodexRateLimitAccountsState,
   CreateWorktreeArgs,
@@ -129,12 +130,7 @@ export type BrowserApi = {
   openDevTools: (args: { browserPageId: string }) => Promise<boolean>
   setViewportOverride: (args: {
     browserPageId: string
-    override: {
-      width: number
-      height: number
-      deviceScaleFactor: number
-      mobile: boolean
-    } | null
+    override: BrowserViewportOverride | null
   }) => Promise<boolean>
   onGuestLoadFailed: (
     callback: (args: { browserPageId: string; loadError: BrowserLoadError }) => void

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -9,6 +9,7 @@ import type { CliInstallStatus } from '../shared/cli-install-types'
 import type { AgentHookInstallStatus } from '../shared/agent-hook-types'
 import type {
   BaseRefDefaultResult,
+  BrowserViewportOverride,
   CreateWorktreeArgs,
   CustomSidekick,
   FsChangedPayload,
@@ -741,12 +742,7 @@ const api = {
 
     setViewportOverride: (args: {
       browserPageId: string
-      override: {
-        width: number
-        height: number
-        deviceScaleFactor: number
-        mobile: boolean
-      } | null
+      override: BrowserViewportOverride | null
     }): Promise<boolean> => ipcRenderer.invoke('browser:setViewportOverride', args),
 
     onGuestLoadFailed: (

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -739,6 +739,16 @@ const api = {
     openDevTools: (args: { browserPageId: string }): Promise<boolean> =>
       ipcRenderer.invoke('browser:openDevTools', args),
 
+    setViewportOverride: (args: {
+      browserPageId: string
+      override: {
+        width: number
+        height: number
+        deviceScaleFactor: number
+        mobile: boolean
+      } | null
+    }): Promise<boolean> => ipcRenderer.invoke('browser:setViewportOverride', args),
+
     onGuestLoadFailed: (
       callback: (args: {
         browserPageId: string

--- a/src/renderer/src/components/browser-pane/BrowserPane.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPane.tsx
@@ -963,12 +963,14 @@ function BrowserPagePane({
       // reloads, SPA navigations, and persisted-session restoration.
       const presetId = viewportPresetIdRef.current
       const preset = getBrowserViewportPreset(presetId)
-      if (preset) {
-        void window.api.browser.setViewportOverride({
-          browserPageId: browserTab.id,
-          override: browserViewportPresetToOverride(preset)
-        })
-      }
+      // Why: always reapply on dom-ready (including null) because
+      // Emulation.setDeviceMetricsOverride can persist across same-origin navigations
+      // within the same renderer. Sending null ensures CDP matches the store state
+      // instead of showing a stale emulated viewport after the user picks "Default".
+      void window.api.browser.setViewportOverride({
+        browserPageId: browserTab.id,
+        override: preset ? browserViewportPresetToOverride(preset) : null
+      })
     }
 
     const handleDidStartLoading = (): void => {

--- a/src/renderer/src/components/browser-pane/BrowserPane.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPane.tsx
@@ -38,6 +38,10 @@ import {
   normalizeExternalBrowserUrl
 } from '../../../../shared/browser-url'
 import {
+  browserViewportPresetToOverride,
+  getBrowserViewportPreset
+} from '../../../../shared/browser-viewport-presets'
+import {
   consumeEvictedBrowserTab,
   markEvictedBrowserTab,
   rememberLiveBrowserUrl
@@ -298,6 +302,12 @@ function BrowserPagePane({
   const initialBrowserUrlRef = useRef(browserTab.url)
   const browserTabUrlRef = useRef(browserTab.url)
   const activeLoadFailureRef = useRef<BrowserLoadError | null>(browserTab.loadError)
+  // Why: CDP viewport emulation does not survive all renderer process swaps
+  // (cross-origin navigations, crashes). We reapply on every dom-ready from
+  // this ref so the persisted preset survives reloads without re-running the
+  // webview lifecycle effect whenever the preset changes.
+  const viewportPresetIdRef = useRef(browserTab.viewportPresetId ?? null)
+  viewportPresetIdRef.current = browserTab.viewportPresetId ?? null
   const trackNextLoadingEventRef = useRef(false)
   // Why: tracks the most recent URL the webview has navigated to or been
   // observed at, from any source (navigation events, address bar, initial
@@ -945,6 +955,19 @@ function BrowserPagePane({
       syncNavigationState(webview)
       if (keepAddressBarFocusRef.current) {
         focusAddressBarNow()
+      }
+      // Why: CDP Emulation.setDeviceMetricsOverride and related overrides are
+      // scoped to the guest's debugger session and do not survive all
+      // cross-origin navigations (renderer swaps). Reapplying on dom-ready is
+      // idempotent, so users who picked a viewport preset keep it after
+      // reloads, SPA navigations, and persisted-session restoration.
+      const presetId = viewportPresetIdRef.current
+      const preset = getBrowserViewportPreset(presetId)
+      if (preset) {
+        void window.api.browser.setViewportOverride({
+          browserPageId: browserTab.id,
+          override: browserViewportPresetToOverride(preset)
+        })
       }
     }
 
@@ -1776,6 +1799,8 @@ function BrowserPagePane({
         <BrowserToolbarMenu
           currentProfileId={sessionProfileId}
           workspaceId={workspaceId}
+          browserPageId={browserTab.id}
+          viewportPresetId={browserTab.viewportPresetId ?? null}
           onDestroyWebview={() => destroyPersistentWebview(browserTab.id)}
         />
       </div>

--- a/src/renderer/src/components/browser-pane/BrowserToolbarMenu.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserToolbarMenu.tsx
@@ -247,7 +247,7 @@ export function BrowserToolbarMenu({
                       viewportPresetId === null ? 'opacity-100' : 'opacity-0'
                     }`}
                   />
-                  Responsive
+                  Default
                 </DropdownMenuItem>
                 <DropdownMenuSeparator />
                 {BROWSER_VIEWPORT_PRESETS.map((preset) => {

--- a/src/renderer/src/components/browser-pane/BrowserToolbarMenu.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserToolbarMenu.tsx
@@ -16,6 +16,8 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuPortal,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuSeparator,
   DropdownMenuSub,
   DropdownMenuSubContent,
@@ -241,31 +243,25 @@ export function BrowserToolbarMenu({
             </DropdownMenuSubTrigger>
             <DropdownMenuPortal>
               <DropdownMenuSubContent>
-                <DropdownMenuItem onSelect={() => applyViewportPreset(null)}>
-                  <Check
-                    className={`mr-2 size-3.5 shrink-0 ${
-                      viewportPresetId === null ? 'opacity-100' : 'opacity-0'
-                    }`}
-                  />
-                  Default
-                </DropdownMenuItem>
-                <DropdownMenuSeparator />
-                {BROWSER_VIEWPORT_PRESETS.map((preset) => {
-                  const isActive = preset.id === viewportPresetId
-                  return (
-                    <DropdownMenuItem
-                      key={preset.id}
-                      onSelect={() => applyViewportPreset(preset.id)}
-                    >
-                      <Check
-                        className={`mr-2 size-3.5 shrink-0 ${
-                          isActive ? 'opacity-100' : 'opacity-0'
-                        }`}
-                      />
+                {/* Why: Viewport is a "pick one of N" control, so use a radio group
+                    for proper a11y semantics (role="menuitemradio", aria-checked).
+                    The "Default" option represents a null preset (no override),
+                    encoded as the sentinel string 'default' because
+                    DropdownMenuRadioGroup values must be strings. */}
+                <DropdownMenuRadioGroup
+                  value={viewportPresetId ?? 'default'}
+                  onValueChange={(v) =>
+                    applyViewportPreset(v === 'default' ? null : (v as BrowserViewportPresetId))
+                  }
+                >
+                  <DropdownMenuRadioItem value="default">Default</DropdownMenuRadioItem>
+                  <DropdownMenuSeparator />
+                  {BROWSER_VIEWPORT_PRESETS.map((preset) => (
+                    <DropdownMenuRadioItem key={preset.id} value={preset.id}>
                       <span className="truncate">{preset.label}</span>
-                    </DropdownMenuItem>
-                  )
-                })}
+                    </DropdownMenuRadioItem>
+                  ))}
+                </DropdownMenuRadioGroup>
               </DropdownMenuSubContent>
             </DropdownMenuPortal>
           </DropdownMenuSub>

--- a/src/renderer/src/components/browser-pane/BrowserToolbarMenu.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserToolbarMenu.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Check, Ellipsis, Import, Plus, Settings } from 'lucide-react'
+import { Check, Ellipsis, Import, Monitor, Plus, Settings } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -24,16 +24,26 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { useAppStore } from '@/store'
 import { BROWSER_FAMILY_LABELS } from '../../../../shared/constants'
+import type { BrowserViewportPresetId } from '../../../../shared/types'
+import {
+  BROWSER_VIEWPORT_PRESETS,
+  browserViewportPresetToOverride,
+  getBrowserViewportPreset
+} from '../../../../shared/browser-viewport-presets'
 
 type BrowserToolbarMenuProps = {
   currentProfileId: string | null
   workspaceId: string
+  browserPageId: string
+  viewportPresetId: BrowserViewportPresetId | null
   onDestroyWebview: () => void
 }
 
 export function BrowserToolbarMenu({
   currentProfileId,
   workspaceId,
+  browserPageId,
+  viewportPresetId,
   onDestroyWebview
 }: BrowserToolbarMenuProps): React.JSX.Element {
   const browserSessionProfiles = useAppStore((s) => s.browserSessionProfiles)
@@ -43,6 +53,14 @@ export function BrowserToolbarMenu({
   const importCookiesFromBrowser = useAppStore((s) => s.importCookiesFromBrowser)
   const importCookiesToProfile = useAppStore((s) => s.importCookiesToProfile)
   const browserSessionImportState = useAppStore((s) => s.browserSessionImportState)
+  const setBrowserPageViewportPreset = useAppStore((s) => s.setBrowserPageViewportPreset)
+
+  const applyViewportPreset = (nextId: BrowserViewportPresetId | null): void => {
+    setBrowserPageViewportPreset(browserPageId, nextId)
+    const preset = getBrowserViewportPreset(nextId)
+    const override = preset ? browserViewportPresetToOverride(preset) : null
+    void window.api.browser.setViewportOverride({ browserPageId, override })
+  }
 
   const [newProfileDialogOpen, setNewProfileDialogOpen] = useState(false)
   const [newProfileName, setNewProfileName] = useState('')
@@ -210,6 +228,44 @@ export function BrowserToolbarMenu({
                 <DropdownMenuItem onSelect={() => void handleImportFromFile()}>
                   From File…
                 </DropdownMenuItem>
+              </DropdownMenuSubContent>
+            </DropdownMenuPortal>
+          </DropdownMenuSub>
+
+          <DropdownMenuSeparator />
+
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger>
+              <Monitor className="mr-2 size-3.5" />
+              Viewport Size
+            </DropdownMenuSubTrigger>
+            <DropdownMenuPortal>
+              <DropdownMenuSubContent>
+                <DropdownMenuItem onSelect={() => applyViewportPreset(null)}>
+                  <Check
+                    className={`mr-2 size-3.5 shrink-0 ${
+                      viewportPresetId === null ? 'opacity-100' : 'opacity-0'
+                    }`}
+                  />
+                  Responsive
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                {BROWSER_VIEWPORT_PRESETS.map((preset) => {
+                  const isActive = preset.id === viewportPresetId
+                  return (
+                    <DropdownMenuItem
+                      key={preset.id}
+                      onSelect={() => applyViewportPreset(preset.id)}
+                    >
+                      <Check
+                        className={`mr-2 size-3.5 shrink-0 ${
+                          isActive ? 'opacity-100' : 'opacity-0'
+                        }`}
+                      />
+                      <span className="truncate">{preset.label}</span>
+                    </DropdownMenuItem>
+                  )
+                })}
               </DropdownMenuSubContent>
             </DropdownMenuPortal>
           </DropdownMenuSub>

--- a/src/renderer/src/store/slices/browser.ts
+++ b/src/renderer/src/store/slices/browser.ts
@@ -992,6 +992,10 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
       }
     }),
 
+  // viewportPresetId is a per-page setting on BrowserPage and is intentionally not
+  // mirrored onto BrowserWorkspace: the outer tab strip doesn't surface the preset,
+  // so there's no UI consumer at the workspace layer. Keeping it page-local avoids
+  // cross-layer plumbing; do NOT add mirrorWorkspaceFromActivePage here.
   setBrowserPageViewportPreset: (pageId, viewportPresetId) =>
     set((s) => {
       const page = findPage(s.browserPagesByWorkspace, pageId)

--- a/src/renderer/src/store/slices/browser.ts
+++ b/src/renderer/src/store/slices/browser.ts
@@ -8,6 +8,7 @@ import type {
   BrowserLoadError,
   BrowserPage,
   BrowserSessionProfile,
+  BrowserViewportPresetId,
   BrowserWorkspace,
   WorkspaceSessionState
 } from '../../../../shared/types'
@@ -81,6 +82,10 @@ export type BrowserSlice = {
   updateBrowserPageState: (pageId: string, updates: BrowserTabPageState) => void
   setBrowserTabUrl: (pageId: string, url: string) => void
   setBrowserPageUrl: (pageId: string, url: string) => void
+  setBrowserPageViewportPreset: (
+    pageId: string,
+    viewportPresetId: BrowserViewportPresetId | null
+  ) => void
   hydrateBrowserSession: (session: WorkspaceSessionState) => void
   switchBrowserTabProfile: (workspaceId: string, profileId: string | null) => void
   browserSessionProfiles: BrowserSessionProfile[]
@@ -983,6 +988,27 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
           [workspace.worktreeId]: (s.browserTabsByWorktree[workspace.worktreeId] ?? []).map((tab) =>
             tab.id === workspace.id ? nextWorkspace : tab
           )
+        }
+      }
+    }),
+
+  setBrowserPageViewportPreset: (pageId, viewportPresetId) =>
+    set((s) => {
+      const page = findPage(s.browserPagesByWorkspace, pageId)
+      if (!page) {
+        return s
+      }
+      const workspace = findWorkspace(s.browserTabsByWorktree, page.workspaceId)
+      if (!workspace) {
+        return s
+      }
+      const nextPages = (s.browserPagesByWorkspace[workspace.id] ?? []).map((entry) =>
+        entry.id === pageId ? { ...entry, viewportPresetId } : entry
+      )
+      return {
+        browserPagesByWorkspace: {
+          ...s.browserPagesByWorkspace,
+          [workspace.id]: nextPages
         }
       }
     }),

--- a/src/shared/browser-viewport-presets.ts
+++ b/src/shared/browser-viewport-presets.ts
@@ -12,7 +12,7 @@ export type BrowserViewportPreset = {
 // Why: deviceScaleFactor=2 on mobile/tablet mirrors Chrome's device toolbar so
 // retina-aware sites pick the correct asset tier; mobile=true enables touch
 // emulation + small-viewport CSS. Dimensions match Chrome DevTools presets.
-export const BROWSER_VIEWPORT_PRESETS: readonly BrowserViewportPreset[] = [
+export const BROWSER_VIEWPORT_PRESETS = [
   {
     id: 'mobile-s',
     label: 'Mobile S — 320 × 568',
@@ -69,7 +69,7 @@ export const BROWSER_VIEWPORT_PRESETS: readonly BrowserViewportPreset[] = [
     deviceScaleFactor: 1,
     mobile: false
   }
-]
+] as const satisfies readonly BrowserViewportPreset[]
 
 export function getBrowserViewportPreset(
   id: BrowserViewportPresetId | null | undefined

--- a/src/shared/browser-viewport-presets.ts
+++ b/src/shared/browser-viewport-presets.ts
@@ -1,0 +1,92 @@
+import type { BrowserViewportOverride, BrowserViewportPresetId } from './types'
+
+export type BrowserViewportPreset = {
+  id: BrowserViewportPresetId
+  label: string
+  width: number
+  height: number
+  deviceScaleFactor: number
+  mobile: boolean
+}
+
+// Why: deviceScaleFactor=2 on mobile/tablet mirrors Chrome's device toolbar so
+// retina-aware sites pick the correct asset tier; mobile=true enables touch
+// emulation + small-viewport CSS. Dimensions match Chrome DevTools presets.
+export const BROWSER_VIEWPORT_PRESETS: readonly BrowserViewportPreset[] = [
+  {
+    id: 'mobile-s',
+    label: 'Mobile S — 320 × 568',
+    width: 320,
+    height: 568,
+    deviceScaleFactor: 2,
+    mobile: true
+  },
+  {
+    id: 'mobile-m',
+    label: 'Mobile M — 375 × 667',
+    width: 375,
+    height: 667,
+    deviceScaleFactor: 2,
+    mobile: true
+  },
+  {
+    id: 'mobile-l',
+    label: 'Mobile L — 425 × 812',
+    width: 425,
+    height: 812,
+    deviceScaleFactor: 2,
+    mobile: true
+  },
+  {
+    id: 'tablet',
+    label: 'Tablet — 768 × 1024',
+    width: 768,
+    height: 1024,
+    deviceScaleFactor: 2,
+    mobile: true
+  },
+  {
+    id: 'laptop',
+    label: 'Laptop — 1024 × 768',
+    width: 1024,
+    height: 768,
+    deviceScaleFactor: 1,
+    mobile: false
+  },
+  {
+    id: 'laptop-l',
+    label: 'Laptop L — 1440 × 900',
+    width: 1440,
+    height: 900,
+    deviceScaleFactor: 1,
+    mobile: false
+  },
+  {
+    id: 'desktop',
+    label: 'Desktop — 1920 × 1080',
+    width: 1920,
+    height: 1080,
+    deviceScaleFactor: 1,
+    mobile: false
+  }
+]
+
+export function getBrowserViewportPreset(
+  id: BrowserViewportPresetId | null | undefined
+): BrowserViewportPreset | null {
+  if (!id) {
+    return null
+  }
+  return BROWSER_VIEWPORT_PRESETS.find((p) => p.id === id) ?? null
+}
+
+export function browserViewportPresetToOverride(
+  preset: BrowserViewportPreset
+): BrowserViewportOverride {
+  return {
+    width: preset.width,
+    height: preset.height,
+    deviceScaleFactor: preset.deviceScaleFactor,
+    mobile: preset.mobile
+  }
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -256,7 +256,7 @@ export type BrowserPage = {
   canGoForward: boolean
   loadError: BrowserLoadError | null
   createdAt: number
-  /** Active CDP viewport emulation preset. null = responsive (fill pane). */
+  /** Active CDP viewport emulation preset. null = default (fill pane, no CDP override) */
   viewportPresetId?: BrowserViewportPresetId | null
 }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -226,6 +226,24 @@ export type BrowserLoadError = {
   validatedUrl: string
 }
 
+// Why: BrowserPage persists the active viewport preset so CDP emulation can be
+// reapplied on reload/navigation without the user re-picking from the toolbar.
+export type BrowserViewportPresetId =
+  | 'mobile-s'
+  | 'mobile-m'
+  | 'mobile-l'
+  | 'tablet'
+  | 'laptop'
+  | 'laptop-l'
+  | 'desktop'
+
+export type BrowserViewportOverride = {
+  width: number
+  height: number
+  deviceScaleFactor: number
+  mobile: boolean
+}
+
 export type BrowserPage = {
   id: string
   workspaceId: string
@@ -238,6 +256,8 @@ export type BrowserPage = {
   canGoForward: boolean
   loadError: BrowserLoadError | null
   createdAt: number
+  /** Active CDP viewport emulation preset. null = responsive (fill pane). */
+  viewportPresetId?: BrowserViewportPresetId | null
 }
 
 export type BrowserWorkspace = {

--- a/src/shared/workspace-session-schema.ts
+++ b/src/shared/workspace-session-schema.ts
@@ -127,6 +127,16 @@ const browserLoadErrorSchema = z.object({
   validatedUrl: z.string()
 })
 
+const browserViewportPresetIdSchema = z.enum([
+  'mobile-s',
+  'mobile-m',
+  'mobile-l',
+  'tablet',
+  'laptop',
+  'laptop-l',
+  'desktop'
+])
+
 // Why: cast to WorkspaceSessionState's embedded BrowserWorkspace so future
 // additive fields in the type flow through without requiring a schema edit.
 const browserWorkspaceSchema: z.ZodType<BrowserWorkspace> = z.object({
@@ -157,7 +167,11 @@ const browserPageSchema = z.object({
   canGoBack: z.boolean(),
   canGoForward: z.boolean(),
   loadError: browserLoadErrorSchema.nullable(),
-  createdAt: z.number()
+  createdAt: z.number(),
+  // Why: optional+nullable so sessions persisted before viewport presets were
+  // added still validate; without this, zod would strip the field during
+  // restore and reset the user's chosen preset on every app restart.
+  viewportPresetId: browserViewportPresetIdSchema.nullable().optional()
 })
 
 const browserHistoryEntrySchema = z.object({


### PR DESCRIPTION
## Summary
- Adds a **Viewport Size** submenu to the browser toolbar "…" menu with Mobile S/M/L, Tablet, Laptop, Laptop L, and Desktop presets plus a **Responsive** option.
- Implements device emulation in main via `guest.debugger` + `Emulation.setDeviceMetricsOverride` / `setTouchEmulationEnabled` / `setUserAgentOverride`; mobile presets swap in an iPhone CriOS UA, Responsive clears all overrides. Coexists with existing anti-detection CDP usage — debugger is never detached.
- Wires a new `browser:setViewportOverride` IPC handler + preload binding, persists the selected preset per browser tab in the store, and re-applies it on `dom-ready` so it survives navigations and tab switches.

## Test plan
Open a browser tab and pick a preset (e.g. Mobile M): the page should re-layout to a mobile width, touch-capable sites (e.g. `developer.mozilla.org`, `https://www.w3schools.com/html/html5_event_attributes.asp`) should fire touch events, and `navigator.userAgent` should report an iPhone CriOS string. Switch to Responsive and confirm the viewport resets to the natural window size and UA clears. Open DevTools (Cmd+Shift+I) and verify the device toolbar reflects the active override. Navigate away and back, then switch tabs away and back — the selected preset should persist and re-apply on each dom-ready.

Made with [Orca](https://github.com/stablyai/orca) 🐋
