### PR TITLE
feat(hooks): surface worktree setup-skip warning to the renderer

### DIFF
--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -415,10 +415,17 @@ export async function createLocalWorktree(
   invalidateAuthorizedRootsCache()
 
   let setup: CreateWorktreeResult['setup']
+  let warning: string | undefined
   const setupScript = getEffectiveHooks(repo, worktreePath)?.scripts.setup
   const setupMatchesPreview = setupScriptsMatch(repo, worktreePath, primarySetupScript)
   let shouldLaunchSetup = false
   if (setupScript && !setupMatchesPreview) {
+    // Why: surface the trust-gate skip to the renderer so users don't silently
+    // assume their orca.yaml setup ran. The primary checkout's script was what
+    // they authorized in SetupCommandPreview; running the target worktree's
+    // divergent script would be unauthorized execution, so we skip and tell them.
+    warning =
+      'Setup skipped: the target branch’s orca.yaml setup script differs from the one shown in the preview. Open the worktree and run setup manually if you trust it.'
     console.warn(
       `[hooks] setup hook skipped for ${worktreePath}: worktree setup script differs from the primary checkout setup script shown to the user`
     )
@@ -453,6 +460,7 @@ export async function createLocalWorktree(
   notifyWorktreesChanged(mainWindow, repo.id)
   return {
     worktree,
-    ...(setup ? { setup } : {})
+    ...(setup ? { setup } : {}),
+    ...(warning ? { warning } : {})
   }
 }

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -481,6 +481,33 @@ describe('registerWorktreeHandlers', () => {
     )
   })
 
+  it('returns a warning and skips setup when the worktree script differs from the preview', async () => {
+    listWorktreesMock.mockResolvedValue(createdWorktreeList)
+    getEffectiveHooksMock.mockReturnValue({
+      scripts: {
+        setup: 'pnpm worktree:setup'
+      }
+    })
+    setupScriptsMatchMock.mockReturnValue(false)
+    shouldRunSetupForCreateMock.mockReturnValue(true)
+
+    const result = await handlers['worktrees:create'](null, {
+      repoId: 'repo-1',
+      name: 'improve-dashboard',
+      setupDecision: 'run'
+    })
+
+    expect(createSetupRunnerScriptMock).not.toHaveBeenCalled()
+    expect(result).toEqual({
+      worktree: expect.objectContaining({
+        path: '/workspace/improve-dashboard'
+      }),
+      warning: expect.stringMatching(/differs.*preview/i)
+    })
+
+    setupScriptsMatchMock.mockReturnValue(true)
+  })
+
   it('creates a sparse worktree and persists its sparse metadata', async () => {
     listWorktreesMock.mockResolvedValue([
       {

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -1141,6 +1141,9 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
         issueCommand,
         ...(startupPlan ? { startup: { command: startupPlan.launchCommand } } : {})
       })
+      if (result.warning) {
+        toast.warning(result.warning)
+      }
       if (startupPlan) {
         void ensureAgentStartupInTerminal({
           worktreeId: worktree.id,
@@ -1258,6 +1261,9 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
           setup: result.setup,
           ...(startupPlan ? { startup: { command: startupPlan.launchCommand } } : {})
         })
+        if (result.warning) {
+          toast.warning(result.warning)
+        }
         if (startupPlan) {
           void ensureAgentStartupInTerminal({
             worktreeId: worktree.id,

--- a/src/renderer/src/lib/launch-work-item-direct.ts
+++ b/src/renderer/src/lib/launch-work-item-direct.ts
@@ -209,6 +209,9 @@ export async function launchWorkItemDirect(args: LaunchWorkItemDirectArgs): Prom
       toast.error('Workspace created but could not be activated.')
       return
     }
+    if (result.warning) {
+      toast.warning(result.warning)
+    }
     primaryTabId = activation.primaryTabId
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Failed to create workspace.'
@@ -330,6 +333,9 @@ export async function launchFromBranch(args: LaunchFromBranchArgs): Promise<void
     if (!activation) {
       toast.error('Workspace created but could not be activated.')
       return
+    }
+    if (result.warning) {
+      toast.warning(result.warning)
     }
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Failed to create workspace.'


### PR DESCRIPTION
## Summary

Follow-up to #1280. When the trust gate in `createLocalWorktree` skips the auto-launched setup because the target worktree's `orca.yaml` setup script differs from the primary checkout's preview, users previously only saw a `console.warn` they'd never see. Surface the reason through `CreateWorktreeResult.warning` and show it as a `toast.warning` in the three renderer create paths so users know their setup did *not* run and can run it manually if they trust the target branch's script.

- `src/main/ipc/worktree-remote.ts` — populate `warning` in the return value when `setupScriptsMatch` rejects the auto-launch.
- `src/renderer/src/hooks/useComposerState.ts` — toast the warning in both composer submit paths (main create + linked work-item create).
- `src/renderer/src/lib/launch-work-item-direct.ts` — toast the warning in the two direct-launch paths (from link + fallback).

The `CreateWorktreeResult.warning` field already existed (CLI `worktree create` and `worktree rm` already use it), so no schema change was needed. Reuses the existing `toast.warning(...)` sonner pattern already used elsewhere.

## Testing

- [x] `pnpm lint` (0 / 0)
- [x] `pnpm typecheck`
- [x] `pnpm test src/main/hooks src/main/ipc/worktrees` — 61 / 61 pass (new regression test asserts `createSetupRunnerScript` is not called and the result carries a `warning` that matches `/differs.*preview/i` when `setupScriptsMatch` returns `false`).

## Risk

Narrow, additive: new optional return field + three UI call sites wrapped in `if (result.warning)`. No behavior change on the happy path (matching scripts) or on the failing-to-create path. The `better-sqlite3` / `orca-runtime.test.ts` pre-existing ABI-mismatch failures reproduce on clean `main` and are unrelated.

Made with [Orca](https://github.com/stablyai/orca) 🐋
