### PR TITLE
fix(terminal): deterministic sessionId + orphan reaper (closes #217)

### DIFF
--- a/src/main/daemon/daemon-init.ts
+++ b/src/main/daemon/daemon-init.ts
@@ -48,7 +48,10 @@ function getRuntimeDir(): string {
   return dir
 }
 
-function getHistoryDir(): string {
+// Why: exported so the orphan-history-reaper (a sibling pass run after daemon
+// init in src/main/index.ts) can enumerate `terminal-history/<encodedId>/`
+// directories without duplicating the path-derivation logic.
+export function getHistoryDir(): string {
   const dir = join(app.getPath('userData'), 'terminal-history')
   mkdirSync(dir, { recursive: true })
   return dir

--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -634,6 +634,65 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
         true
       )
     })
+
+    it('warns when an explicit sessionId produces a new daemon session with no disk history', async () => {
+      // Why (design doc §9 post-release monitoring): the adapter emits a
+      // console.warn when a spawn with an explicit sessionId produces a
+      // brand-new daemon session AND no disk history was found. That pair
+      // is the signal that either (a) the orphan reaper ate a dir the user
+      // still wanted, or (b) the persisted mapping pointed at a session
+      // that never checkpointed. Locking the log line down here means a
+      // refactor can't silently drop the monitoring hook.
+      historyAdapter = new DaemonPtyAdapter({ socketPath, tokenPath, historyPath: historyDir })
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      try {
+        const sessionId = 'wt-x@@deadbeef'
+        await historyAdapter.spawn({ cols: 80, rows: 24, cwd: '/tmp', sessionId })
+        const matched = warnSpy.mock.calls.find(
+          (call) =>
+            typeof call[0] === 'string' &&
+            call[0].includes('cold-restore miss for explicit sessionId')
+        )
+        expect(matched, 'expected cold-restore-miss warn to fire').toBeDefined()
+      } finally {
+        warnSpy.mockRestore()
+      }
+    })
+
+    it('does not warn when an explicit sessionId finds existing disk history', async () => {
+      // Why: the warn must NOT fire on the happy path (persisted id +
+      // history dir present). A false-positive warn in that case would
+      // train operators to ignore the signal.
+      const sessionId = 'wt-y@@cafebabe'
+      const sessionDir = join(historyDir, getHistorySessionDirName(sessionId))
+      mkdirSync(sessionDir, { recursive: true })
+      writeFileSync(
+        join(sessionDir, 'meta.json'),
+        JSON.stringify({
+          cwd: '/tmp',
+          cols: 80,
+          rows: 24,
+          startedAt: '2026-04-15T10:00:00Z',
+          endedAt: null,
+          exitCode: null
+        })
+      )
+      writeFileSync(join(sessionDir, 'scrollback.bin'), 'prior session output')
+
+      historyAdapter = new DaemonPtyAdapter({ socketPath, tokenPath, historyPath: historyDir })
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      try {
+        await historyAdapter.spawn({ cols: 80, rows: 24, sessionId })
+        const matched = warnSpy.mock.calls.find(
+          (call) =>
+            typeof call[0] === 'string' &&
+            call[0].includes('cold-restore miss for explicit sessionId')
+        )
+        expect(matched).toBeUndefined()
+      } finally {
+        warnSpy.mockRestore()
+      }
+    })
   })
 
   describe('respawn on daemon death', () => {

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -186,6 +186,21 @@ export class DaemonPtyAdapter implements IPtyProvider {
     }
 
     if (this.historyManager && result.isNew) {
+      // Why (design doc §9 post-release monitoring): a spawn with an explicit
+      // sessionId that produced a brand-new daemon session AND has no disk
+      // history is the signal that either (a) the reaper ate a dir the user
+      // still wanted, or (b) the persisted mapping pointed at a session that
+      // never wrote a checkpoint. This shouldn't happen under the defensive
+      // keep-set derivation — if it starts showing up in logs, investigate
+      // before the next release.
+      if (opts.sessionId !== undefined && !restoreInfo) {
+        console.warn('[pty] cold-restore miss for explicit sessionId — no disk history found', {
+          sessionId,
+          worktreeId: opts.worktreeId,
+          tabId: opts.tabId,
+          leafId: opts.leafId
+        })
+      }
       void this.historyManager
         .openSession(sessionId, {
           cwd: effectiveCwd ?? '',

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -96,7 +96,14 @@ export class DaemonPtyAdapter implements IPtyProvider {
   private async doSpawn(opts: PtySpawnOptions): Promise<PtySpawnResult> {
     await this.ensureConnected()
 
-    const sessionId = opts.sessionId ?? mintPtySessionId(opts.worktreeId)
+    // Why: the renderer should thread tabId/leafId for every daemon-host
+    // spawn so we get a deterministic sessionId. On the main-process
+    // spawn path, `ipc/pty.ts` has already minted `opts.sessionId` with
+    // the deterministic suffix — we arrive here via opts.sessionId in
+    // the common case. This fallback handles direct callers (tests,
+    // non-IPC code paths) that don't pre-mint; they should still pass
+    // tabId/leafId when possible so the id is stable across restarts.
+    const sessionId = opts.sessionId ?? mintPtySessionId(opts.worktreeId, opts.tabId, opts.leafId)
 
     if (this.killedSessionTombstones.has(sessionId)) {
       throw new TerminalKilledError(sessionId)

--- a/src/main/daemon/orphan-history-reaper.test.ts
+++ b/src/main/daemon/orphan-history-reaper.test.ts
@@ -1,0 +1,412 @@
+/* oxlint-disable max-lines -- Why: these tests cover the full reaper
+decision matrix (keep set, mtime gate, two-launch quarantine, edge
+cases) in one place so a regression anywhere trips a single suite. */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  utimesSync,
+  writeFileSync
+} from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { getHistorySessionDirName } from './history-paths'
+import { mintPtySessionId } from './pty-session-id'
+import {
+  REAP_MTIME_GRACE_MS,
+  REAP_QUARANTINE_LAUNCHES,
+  runOrphanHistoryReaper
+} from './orphan-history-reaper'
+import type { WorkspaceSessionState } from '../../shared/types'
+
+function freshTmp(): { sidecarDir: string; historyBasePath: string; cleanup: () => void } {
+  const sidecarDir = mkdtempSync(join(tmpdir(), 'orca-reaper-'))
+  const historyBasePath = join(sidecarDir, 'terminal-history')
+  mkdirSync(historyBasePath, { recursive: true })
+  return {
+    sidecarDir,
+    historyBasePath,
+    cleanup: () => rmSync(sidecarDir, { recursive: true, force: true })
+  }
+}
+
+// Helper: create a session dir with a synthetic mtime by writing a file and
+// then reaching back in time. Returns the directory path.
+function makeSessionDir(
+  historyBasePath: string,
+  sessionId: string,
+  opts?: { ageMs?: number }
+): string {
+  const dir = join(historyBasePath, getHistorySessionDirName(sessionId))
+  mkdirSync(dir, { recursive: true })
+  // Write something so the dir has distinct mtime semantics on all FSes.
+  writeFileSync(join(dir, 'checkpoint.json'), '{}')
+  if (opts?.ageMs !== undefined) {
+    const ts = Date.now() - opts.ageMs
+    utimesSync(dir, ts / 1000, ts / 1000)
+    utimesSync(join(dir, 'checkpoint.json'), ts / 1000, ts / 1000)
+  }
+  return dir
+}
+
+function emptySession(overrides: Partial<WorkspaceSessionState> = {}): WorkspaceSessionState {
+  return {
+    activeRepoId: null,
+    activeWorktreeId: null,
+    activeTabId: null,
+    tabsByWorktree: {},
+    terminalLayoutsByTabId: {},
+    ...overrides
+  }
+}
+
+describe('runOrphanHistoryReaper — keep set', () => {
+  let tmp: ReturnType<typeof freshTmp>
+
+  beforeEach(() => {
+    tmp = freshTmp()
+  })
+  afterEach(() => {
+    tmp.cleanup()
+  })
+
+  it('never reaps a dir whose sessionId appears in the live daemon set, even if old', async () => {
+    // Why: the daemon is the ground truth for live sessions. A running PTY
+    // whose workspace-session slot failed to persist must still be kept.
+    const sessionId = 'wt-a@@deadbeef'
+    makeSessionDir(tmp.historyBasePath, sessionId, { ageMs: REAP_MTIME_GRACE_MS + 10_000 })
+
+    const stats = await runOrphanHistoryReaper({
+      historyBasePath: tmp.historyBasePath,
+      sidecarDir: tmp.sidecarDir,
+      workspaceSession: emptySession(),
+      liveDaemonSessionIds: [sessionId]
+    })
+
+    expect(stats.reaped).toBe(0)
+    expect(stats.keptByKeepSet).toBe(1)
+    expect(existsSync(join(tmp.historyBasePath, getHistorySessionDirName(sessionId)))).toBe(true)
+  })
+
+  it('keeps a dir whose sessionId is only reachable via deterministic derivation', async () => {
+    // Why: this is the core correctness case — the ptyId field wasn't
+    // persisted (SIGKILL-before-persist), but the layout snapshot has a
+    // pane entry whose (worktreeId, tabId, leafId) still derives to the
+    // right id. Without deterministic keep-set derivation, this dir would
+    // be treated as orphan and eventually reaped.
+    const wt = 'wt-alpha'
+    const tabId = 'tab-xyz'
+    const leafId = 'pane:2'
+    const derivedId = mintPtySessionId(wt, tabId, leafId)
+    makeSessionDir(tmp.historyBasePath, derivedId, { ageMs: REAP_MTIME_GRACE_MS + 10_000 })
+
+    const session = emptySession({
+      tabsByWorktree: {
+        [wt]: [
+          {
+            id: tabId,
+            ptyId: null,
+            worktreeId: wt,
+            title: 'Terminal',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 0
+          }
+        ]
+      },
+      terminalLayoutsByTabId: {
+        [tabId]: {
+          root: { type: 'leaf', leafId },
+          activeLeafId: null,
+          expandedLeafId: null
+        }
+      }
+    })
+
+    const stats = await runOrphanHistoryReaper({
+      historyBasePath: tmp.historyBasePath,
+      sidecarDir: tmp.sidecarDir,
+      workspaceSession: session,
+      liveDaemonSessionIds: []
+    })
+
+    expect(stats.reaped).toBe(0)
+    expect(stats.keptByKeepSet).toBe(1)
+  })
+
+  it('keeps verbatim ptyIds stored in the workspace session', async () => {
+    // Why: legacy panes whose pre-restart ptyId persisted must still
+    // round-trip through the reaper's keep set even after the
+    // deterministic path lands — failure to keep them would surface as
+    // one-time scrollback loss on the upgrade boot.
+    const id = 'wt-legacy@@cafebabe'
+    makeSessionDir(tmp.historyBasePath, id, { ageMs: REAP_MTIME_GRACE_MS + 10_000 })
+
+    const session = emptySession({
+      tabsByWorktree: {
+        'wt-legacy': [
+          {
+            id: 'tab-1',
+            ptyId: id,
+            worktreeId: 'wt-legacy',
+            title: 'Terminal',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 0
+          }
+        ]
+      }
+    })
+
+    const stats = await runOrphanHistoryReaper({
+      historyBasePath: tmp.historyBasePath,
+      sidecarDir: tmp.sidecarDir,
+      workspaceSession: session,
+      liveDaemonSessionIds: []
+    })
+
+    expect(stats.reaped).toBe(0)
+  })
+
+  it('keeps ptyIdsByLeafId entries verbatim', async () => {
+    const id = 'wt-alpha@@abcdef12'
+    makeSessionDir(tmp.historyBasePath, id, { ageMs: REAP_MTIME_GRACE_MS + 10_000 })
+
+    const session = emptySession({
+      terminalLayoutsByTabId: {
+        'tab-1': {
+          root: { type: 'leaf', leafId: 'pane:1' },
+          activeLeafId: null,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { 'pane:1': id }
+        }
+      }
+    })
+
+    const stats = await runOrphanHistoryReaper({
+      historyBasePath: tmp.historyBasePath,
+      sidecarDir: tmp.sidecarDir,
+      workspaceSession: session,
+      liveDaemonSessionIds: []
+    })
+
+    expect(stats.reaped).toBe(0)
+  })
+
+  it('keeps remote SSH session ids (arbitrary format)', async () => {
+    // Why: remote session ids do not follow the `worktreeId@@suffix`
+    // pattern. The reaper must not reap them just because they miss
+    // every other keep-set source.
+    const id = 'ssh::user@host::session-xyz'
+    makeSessionDir(tmp.historyBasePath, id, { ageMs: REAP_MTIME_GRACE_MS + 10_000 })
+
+    const session = emptySession({
+      remoteSessionIdsByTabId: { 'tab-ssh': id }
+    })
+
+    const stats = await runOrphanHistoryReaper({
+      historyBasePath: tmp.historyBasePath,
+      sidecarDir: tmp.sidecarDir,
+      workspaceSession: session,
+      liveDaemonSessionIds: []
+    })
+
+    expect(stats.reaped).toBe(0)
+  })
+})
+
+describe('runOrphanHistoryReaper — mtime gate', () => {
+  let tmp: ReturnType<typeof freshTmp>
+  beforeEach(() => {
+    tmp = freshTmp()
+  })
+  afterEach(() => {
+    tmp.cleanup()
+  })
+
+  it('never reaps a dir whose mtime is within the grace window, even if orphan', async () => {
+    const id = 'wt-a@@aaaaaaaa'
+    makeSessionDir(tmp.historyBasePath, id, { ageMs: REAP_MTIME_GRACE_MS - 60_000 })
+
+    const stats = await runOrphanHistoryReaper({
+      historyBasePath: tmp.historyBasePath,
+      sidecarDir: tmp.sidecarDir,
+      workspaceSession: emptySession(),
+      liveDaemonSessionIds: []
+    })
+
+    expect(stats.reaped).toBe(0)
+    expect(stats.keptByMtimeGrace).toBe(1)
+  })
+})
+
+describe('runOrphanHistoryReaper — two-launch quarantine', () => {
+  let tmp: ReturnType<typeof freshTmp>
+  beforeEach(() => {
+    tmp = freshTmp()
+  })
+  afterEach(() => {
+    tmp.cleanup()
+  })
+
+  it('requires at least REAP_QUARANTINE_LAUNCHES elapsed launches before reaping', async () => {
+    // Why: quarantine is measured in *elapsed* launches after the first
+    // sighting, not sightings. So with REAP_QUARANTINE_LAUNCHES = 2, an
+    // orphan first seen on launch N is reaped no earlier than launch N+2.
+    // That asymmetry is deliberate: a single "dropped" launch (crash after
+    // workspace-session write but before reaper pass) cannot eat a
+    // surviving dir — the user has an extra boot to recover.
+    expect(REAP_QUARANTINE_LAUNCHES).toBe(2)
+    const id = 'wt-a@@bbbbbbbb'
+    const dir = makeSessionDir(tmp.historyBasePath, id, { ageMs: REAP_MTIME_GRACE_MS + 10_000 })
+
+    // Launch 1: firstSeenLaunchN = 1. Quarantined.
+    const s1 = await runOrphanHistoryReaper({
+      historyBasePath: tmp.historyBasePath,
+      sidecarDir: tmp.sidecarDir,
+      workspaceSession: emptySession(),
+      liveDaemonSessionIds: []
+    })
+    expect(s1.reaped).toBe(0)
+    expect(s1.keptByQuarantine).toBe(1)
+    expect(existsSync(dir)).toBe(true)
+
+    // Launch 2: launchesSinceSeen = 1. Still quarantined — the whole
+    // point of the two-launch bound is "one in-flight bad run cannot
+    // reap data the user still wants".
+    const s2 = await runOrphanHistoryReaper({
+      historyBasePath: tmp.historyBasePath,
+      sidecarDir: tmp.sidecarDir,
+      workspaceSession: emptySession(),
+      liveDaemonSessionIds: []
+    })
+    expect(s2.reaped).toBe(0)
+    expect(s2.keptByQuarantine).toBe(1)
+    expect(existsSync(dir)).toBe(true)
+
+    // Launch 3: launchesSinceSeen = 2. Eligible for reap.
+    const s3 = await runOrphanHistoryReaper({
+      historyBasePath: tmp.historyBasePath,
+      sidecarDir: tmp.sidecarDir,
+      workspaceSession: emptySession(),
+      liveDaemonSessionIds: []
+    })
+    expect(s3.reaped).toBe(1)
+    expect(existsSync(dir)).toBe(false)
+  })
+
+  it('resets the quarantine clock when a previously-orphaned id reappears in the keep set', async () => {
+    const id = 'wt-a@@cccccccc'
+    makeSessionDir(tmp.historyBasePath, id, { ageMs: REAP_MTIME_GRACE_MS + 10_000 })
+
+    // Launch 1: orphan — records.
+    await runOrphanHistoryReaper({
+      historyBasePath: tmp.historyBasePath,
+      sidecarDir: tmp.sidecarDir,
+      workspaceSession: emptySession(),
+      liveDaemonSessionIds: []
+    })
+
+    // Launch 2: id reappears in keep set (e.g. the workspace session
+    // persistence that was failing is now healthy). Must NOT reap.
+    const s2 = await runOrphanHistoryReaper({
+      historyBasePath: tmp.historyBasePath,
+      sidecarDir: tmp.sidecarDir,
+      workspaceSession: emptySession(),
+      liveDaemonSessionIds: [id]
+    })
+    expect(s2.reaped).toBe(0)
+    expect(s2.keptByKeepSet).toBe(1)
+
+    // Launch 3: id is orphaned again — the counter must have been reset,
+    // so this launch re-records rather than immediately reaping.
+    const s3 = await runOrphanHistoryReaper({
+      historyBasePath: tmp.historyBasePath,
+      sidecarDir: tmp.sidecarDir,
+      workspaceSession: emptySession(),
+      liveDaemonSessionIds: []
+    })
+    expect(s3.reaped).toBe(0)
+    expect(s3.keptByQuarantine).toBe(1)
+  })
+
+  it('treats a corrupt sidecar as "nothing seen yet" (extra quarantine, never premature reap)', async () => {
+    const id = 'wt-a@@dddddddd'
+    const dir = makeSessionDir(tmp.historyBasePath, id, {
+      ageMs: REAP_MTIME_GRACE_MS + 10_000
+    })
+
+    // Seed a corrupt sidecar that would otherwise appear to have seen
+    // the id on launch 1 with counter at 10 — if we trusted it, the reaper
+    // would fire immediately. We must NOT.
+    writeFileSync(join(tmp.sidecarDir, 'reaper-seen.json'), '{not: "json')
+
+    const stats = await runOrphanHistoryReaper({
+      historyBasePath: tmp.historyBasePath,
+      sidecarDir: tmp.sidecarDir,
+      workspaceSession: emptySession(),
+      liveDaemonSessionIds: []
+    })
+    expect(stats.reaped).toBe(0)
+    expect(stats.keptByQuarantine).toBe(1)
+    expect(existsSync(dir)).toBe(true)
+
+    // Sidecar should have been rewritten with a valid JSON shape.
+    const written = JSON.parse(readFileSync(join(tmp.sidecarDir, 'reaper-seen.json'), 'utf-8'))
+    expect(written.version).toBe(1)
+    expect(written.launchCounter).toBe(1)
+  })
+})
+
+describe('runOrphanHistoryReaper — edge cases', () => {
+  let tmp: ReturnType<typeof freshTmp>
+  beforeEach(() => {
+    tmp = freshTmp()
+  })
+  afterEach(() => {
+    tmp.cleanup()
+  })
+
+  it('no-ops when the history directory does not exist (fresh install)', async () => {
+    rmSync(tmp.historyBasePath, { recursive: true, force: true })
+    const stats = await runOrphanHistoryReaper({
+      historyBasePath: tmp.historyBasePath,
+      sidecarDir: tmp.sidecarDir,
+      workspaceSession: emptySession(),
+      liveDaemonSessionIds: []
+    })
+    expect(stats).toEqual({
+      scanned: 0,
+      keptByKeepSet: 0,
+      keptByMtimeGrace: 0,
+      keptByQuarantine: 0,
+      reaped: 0,
+      errors: 0
+    })
+  })
+
+  it('ignores directory entries whose names do not round-trip through encodeURIComponent', async () => {
+    // A directory named literally `%` cannot be a valid minted session id
+    // because decodeURIComponent('%') throws. The reaper must skip it.
+    mkdirSync(join(tmp.historyBasePath, '%'), { recursive: true })
+    // And a legitimate orphan alongside.
+    const id = 'wt-a@@eeeeeeee'
+    makeSessionDir(tmp.historyBasePath, id, { ageMs: REAP_MTIME_GRACE_MS + 10_000 })
+
+    const stats = await runOrphanHistoryReaper({
+      historyBasePath: tmp.historyBasePath,
+      sidecarDir: tmp.sidecarDir,
+      workspaceSession: emptySession(),
+      liveDaemonSessionIds: []
+    })
+    // Malformed entry: not counted in keep/mtime/quarantine/reaped. Scanned
+    // increments for every readdir entry.
+    expect(stats.scanned).toBe(2)
+    expect(existsSync(join(tmp.historyBasePath, '%'))).toBe(true)
+  })
+})

--- a/src/main/daemon/orphan-history-reaper.ts
+++ b/src/main/daemon/orphan-history-reaper.ts
@@ -1,0 +1,347 @@
+/**
+ * Orphan history reaper.
+ *
+ * Why: with the deterministic-sessionId path in place
+ * (`mintPtySessionId(worktreeId, tabId, leafId)`), cold-restore now maps a
+ * fresh post-restart PTY to the same `terminal-history/<encodedId>/` dir as
+ * before the crash. The tradeoff is that session-id persistence is no longer
+ * the gate for reachability — a deterministic id may point at a history dir
+ * whose owning pane was permanently closed before persistence landed, and
+ * nothing in the lifecycle will ever clean that dir up. Without a reaper,
+ * the `terminal-history/` tree grows unboundedly over time.
+ *
+ * This pass is intentionally conservative — the single most important
+ * invariant is **never delete a history dir whose pane still exists, even if
+ * the workspace-session persistence failed to list it this launch.** Two
+ * guards stack on top of the keep set:
+ *
+ *   1. mtime gate: skip any dir whose on-disk mtime is newer than
+ *      `REAP_MTIME_GRACE_MS` (30 days). A live PTY writes checkpoint.json
+ *      frequently, so anything fresh is in use (or very recently was).
+ *
+ *   2. two-launch quarantine: we record every orphan candidate in a sidecar
+ *      (`reaper-seen.json`) along with the first launch counter that saw it,
+ *      and only delete on the Nth launch where N >= REAP_QUARANTINE_LAUNCHES
+ *      after that. So a transient keep-set miss on one launch (e.g. a
+ *      corrupted workspace-session file, a worker that failed to persist)
+ *      simply defers deletion by a launch; it cannot reap data the user
+ *      still wants on the next boot.
+ *
+ * The sidecar lives *sibling* to `terminal-history/` in userData so that
+ * clearing terminal-history to recover from a bug does not also clear the
+ * reaper's memory (which would put every surviving dir immediately at
+ * launchN and re-start the quarantine clock).
+ *
+ * Corrupt sidecar → we treat it as "nothing seen yet" — extra quarantine,
+ * never premature reap. Filesystem errors anywhere in the walk are logged
+ * and swallowed; the reaper is a best-effort disk-hygiene pass and must
+ * never crash startup.
+ */
+import { join } from 'path'
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync
+} from 'fs'
+import { getHistorySessionDirName } from './history-paths'
+import { mintPtySessionId } from './pty-session-id'
+import type { TerminalPaneLayoutNode, WorkspaceSessionState } from '../../shared/types'
+
+/** 30 days. Any history dir with an mtime newer than this is assumed to
+ *  belong to a pane that was live recently enough that the reaper should
+ *  not touch it, regardless of keep-set membership. */
+export const REAP_MTIME_GRACE_MS = 30 * 24 * 60 * 60 * 1000
+
+/** Two distinct launches must see the same orphan before it becomes
+ *  eligible for deletion. A launch that persists the workspace session
+ *  before crashing would set the counter back to "never seen" for every
+ *  still-referenced dir, so REAP_QUARANTINE_LAUNCHES >= 2 means a single
+ *  bad launch cannot cost us anything the user still wants. */
+export const REAP_QUARANTINE_LAUNCHES = 2
+
+const SIDECAR_FILENAME = 'reaper-seen.json'
+
+type SidecarV1 = {
+  version: 1
+  launchCounter: number
+  /** sessionId → { firstSeenLaunchN: number } */
+  seen: Record<string, { firstSeenLaunchN: number }>
+}
+
+type ReaperInputs = {
+  /** Absolute path to `<userData>/terminal-history`. Passed from
+   *  `getHistoryDir()` rather than recomputed so tests can override. */
+  historyBasePath: string
+  /** Parent of `terminal-history/` — the sidecar lives *here*, not
+   *  inside `terminal-history/`, so wiping history for recovery does
+   *  not also erase the quarantine state. */
+  sidecarDir: string
+  /** Current workspace session (from `store.getWorkspaceSession()`).
+   *  The reaper derives the deterministic keep set from this. */
+  workspaceSession: WorkspaceSessionState
+  /** Session IDs that the daemon currently reports as live. Always kept. */
+  liveDaemonSessionIds: Iterable<string>
+  /** Clock injection for tests. Defaults to `Date.now`. */
+  now?: () => number
+}
+
+export type ReapStats = {
+  scanned: number
+  keptByKeepSet: number
+  keptByMtimeGrace: number
+  keptByQuarantine: number
+  reaped: number
+  errors: number
+}
+
+/**
+ * Run the orphan reaper once. Safe to call unconditionally at startup even
+ * if `historyBasePath` does not exist yet (first launch) — the function
+ * treats a missing directory as "nothing to scan".
+ */
+export async function runOrphanHistoryReaper(inputs: ReaperInputs): Promise<ReapStats> {
+  const now = inputs.now ?? Date.now
+  const stats: ReapStats = {
+    scanned: 0,
+    keptByKeepSet: 0,
+    keptByMtimeGrace: 0,
+    keptByQuarantine: 0,
+    reaped: 0,
+    errors: 0
+  }
+
+  if (!existsSync(inputs.historyBasePath)) {
+    return stats
+  }
+
+  const keep = buildKeepSet(inputs.workspaceSession, inputs.liveDaemonSessionIds)
+
+  const sidecarPath = join(inputs.sidecarDir, SIDECAR_FILENAME)
+  const sidecar = loadSidecar(sidecarPath)
+  sidecar.launchCounter += 1
+
+  let entries: string[]
+  try {
+    entries = readdirSync(inputs.historyBasePath)
+  } catch (err) {
+    console.warn('[history-reaper] failed to read history dir:', err)
+    stats.errors += 1
+    persistSidecar(sidecarPath, sidecar, inputs.sidecarDir)
+    return stats
+  }
+
+  // Why: track which sessionIds we saw this launch so we can prune sidecar
+  // entries that have since been deleted or restored to the keep set —
+  // otherwise `seen` grows without bound across the lifetime of the app.
+  const seenThisLaunch = new Set<string>()
+
+  for (const entry of entries) {
+    stats.scanned += 1
+    const dirPath = join(inputs.historyBasePath, entry)
+    let sessionId: string
+    try {
+      sessionId = decodeURIComponent(entry)
+    } catch {
+      // Malformed dir name (not produced by getHistorySessionDirName). Leave
+      // alone — we only touch dirs whose name round-trips through
+      // encode/decodeURIComponent cleanly.
+      continue
+    }
+    // Defensive: require the round-trip encoding matches exactly. Anything
+    // else could be an unrelated directory that shares the parent path.
+    if (getHistorySessionDirName(sessionId) !== entry) {
+      continue
+    }
+
+    if (keep.has(sessionId)) {
+      stats.keptByKeepSet += 1
+      // Drop any quarantine state — a previously-orphaned id that reappeared
+      // in the keep set should start from zero if it ever orphans again.
+      delete sidecar.seen[sessionId]
+      continue
+    }
+
+    let mtimeMs: number
+    try {
+      mtimeMs = statSync(dirPath).mtimeMs
+    } catch (err) {
+      console.warn('[history-reaper] stat failed for', entry, err)
+      stats.errors += 1
+      continue
+    }
+    if (now() - mtimeMs < REAP_MTIME_GRACE_MS) {
+      stats.keptByMtimeGrace += 1
+      // Still update the quarantine counter so that when the mtime grace
+      // eventually lapses the two-launch timer is already running.
+      recordSeen(sidecar, sessionId, seenThisLaunch)
+      continue
+    }
+
+    const seenEntry = sidecar.seen[sessionId]
+    if (!seenEntry) {
+      recordSeen(sidecar, sessionId, seenThisLaunch)
+      stats.keptByQuarantine += 1
+      continue
+    }
+    seenThisLaunch.add(sessionId)
+    const launchesSinceSeen = sidecar.launchCounter - seenEntry.firstSeenLaunchN
+    if (launchesSinceSeen < REAP_QUARANTINE_LAUNCHES) {
+      stats.keptByQuarantine += 1
+      continue
+    }
+
+    // All three gates (keep set, mtime grace, two-launch quarantine) cleared.
+    try {
+      rmSync(dirPath, { recursive: true, force: true })
+      stats.reaped += 1
+      delete sidecar.seen[sessionId]
+    } catch (err) {
+      console.warn('[history-reaper] rm failed for', entry, err)
+      stats.errors += 1
+    }
+  }
+
+  // Prune sidecar entries for sessions that no longer have an on-disk dir
+  // (deleted outside the reaper) or that turned out to be in the keep set.
+  for (const id of Object.keys(sidecar.seen)) {
+    if (!seenThisLaunch.has(id)) {
+      delete sidecar.seen[id]
+    }
+  }
+
+  persistSidecar(sidecarPath, sidecar, inputs.sidecarDir)
+  return stats
+}
+
+function recordSeen(sidecar: SidecarV1, sessionId: string, seenThisLaunch: Set<string>): void {
+  if (!sidecar.seen[sessionId]) {
+    sidecar.seen[sessionId] = { firstSeenLaunchN: sidecar.launchCounter }
+  }
+  seenThisLaunch.add(sessionId)
+}
+
+/**
+ * Build the union of all sessionIds that should be preserved this launch:
+ *
+ *  - Every ptyId stored on a terminal tab (legacy ptyId field) or inside
+ *    a persisted pane-layout snapshot (ptyIdsByLeafId). These are verbatim
+ *    session ids that survived the previous app run.
+ *
+ *  - remoteSessionIdsByTabId — defensive keep for SSH-hosted sessions
+ *    whose ids don't match the `worktreeId@@suffix` pattern.
+ *
+ *  - Deterministic ids derived from every (worktreeId, tabId, leafId) triple
+ *    reachable through the workspace session. This is the critical entry:
+ *    it protects history dirs whose verbatim ptyId never got persisted
+ *    (the SIGKILL-between-spawn-and-persist window the fix is closing).
+ *
+ *  - Live daemon session ids from the reconciled adapter.
+ */
+function buildKeepSet(
+  session: WorkspaceSessionState,
+  liveDaemonSessionIds: Iterable<string>
+): Set<string> {
+  const keep = new Set<string>()
+
+  for (const id of liveDaemonSessionIds) {
+    keep.add(id)
+  }
+
+  for (const tabs of Object.values(session.tabsByWorktree ?? {})) {
+    for (const tab of tabs) {
+      if (tab.ptyId) {
+        keep.add(tab.ptyId)
+      }
+    }
+  }
+
+  for (const [tabId, layout] of Object.entries(session.terminalLayoutsByTabId ?? {})) {
+    if (!layout) {
+      continue
+    }
+    for (const ptyId of Object.values(layout.ptyIdsByLeafId ?? {})) {
+      keep.add(ptyId)
+    }
+    // Deterministic derivation: for every pane leaf we know how to reach
+    // through the persisted layout tree, compute the id mintPtySessionId
+    // would produce for (worktreeId, tabId, leafId) and keep it. We need
+    // the worktreeId for this — look it up via the tab record so the keep
+    // set survives even if the tab's ptyId slot is empty.
+    const worktreeId = findWorktreeIdForTab(session, tabId)
+    if (!worktreeId) {
+      continue
+    }
+    for (const leafId of collectLeafIdsFromLayoutRoot(layout.root)) {
+      keep.add(mintPtySessionId(worktreeId, tabId, leafId))
+    }
+  }
+
+  for (const remoteId of Object.values(session.remoteSessionIdsByTabId ?? {})) {
+    if (remoteId) {
+      keep.add(remoteId)
+    }
+  }
+
+  return keep
+}
+
+function findWorktreeIdForTab(session: WorkspaceSessionState, tabId: string): string | undefined {
+  for (const [worktreeId, tabs] of Object.entries(session.tabsByWorktree ?? {})) {
+    if (tabs.some((t) => t.id === tabId)) {
+      return worktreeId
+    }
+  }
+  return undefined
+}
+
+function collectLeafIdsFromLayoutRoot(node: TerminalPaneLayoutNode | null): string[] {
+  if (!node) {
+    return []
+  }
+  if (node.type === 'leaf') {
+    return [node.leafId]
+  }
+  return [...collectLeafIdsFromLayoutRoot(node.first), ...collectLeafIdsFromLayoutRoot(node.second)]
+}
+
+function loadSidecar(sidecarPath: string): SidecarV1 {
+  const empty: SidecarV1 = { version: 1, launchCounter: 0, seen: {} }
+  if (!existsSync(sidecarPath)) {
+    return empty
+  }
+  try {
+    const raw = JSON.parse(readFileSync(sidecarPath, 'utf-8')) as Partial<SidecarV1>
+    if (
+      raw &&
+      raw.version === 1 &&
+      typeof raw.launchCounter === 'number' &&
+      raw.seen &&
+      typeof raw.seen === 'object'
+    ) {
+      return {
+        version: 1,
+        launchCounter: raw.launchCounter,
+        seen: { ...raw.seen }
+      }
+    }
+  } catch (err) {
+    console.warn('[history-reaper] sidecar unreadable, resetting:', err)
+  }
+  // Corrupt sidecar → start over. That resets the quarantine clock for
+  // every current orphan, which is the safe direction (one extra launch
+  // of quarantine beats one premature reap).
+  return empty
+}
+
+function persistSidecar(sidecarPath: string, sidecar: SidecarV1, sidecarDir: string): void {
+  try {
+    mkdirSync(sidecarDir, { recursive: true })
+    writeFileSync(sidecarPath, JSON.stringify(sidecar), { mode: 0o600 })
+  } catch (err) {
+    console.warn('[history-reaper] sidecar write failed:', err)
+  }
+}

--- a/src/main/daemon/pty-session-id.test.ts
+++ b/src/main/daemon/pty-session-id.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { isSafePtySessionId, mintPtySessionId } from './pty-session-id'
+import { isSafePtySessionId, mintPtySessionId, mintPtySessionIdWithOrigin } from './pty-session-id'
 
 const USER_DATA = '/tmp/orca-userdata'
 
@@ -20,6 +20,83 @@ describe('mintPtySessionId', () => {
     // splits on `@@` to recover the worktreeId.
     const id = mintPtySessionId('repo-123::/Users/me/work/wt-1')
     expect(id).toMatch(/^repo-123::\/Users\/me\/work\/wt-1@@[0-9a-f]{8}$/)
+  })
+
+  it('derives a deterministic suffix from (worktreeId, tabId, leafId)', () => {
+    // Why: cold-restore after a SIGKILL-between-spawn-and-persist only
+    // works when re-minting the id for the same pane triple produces the
+    // same 8-char suffix — otherwise the post-restart PTY lands on a
+    // fresh history directory and scrollback is lost.
+    const a = mintPtySessionId('wt-alpha', 'tab-xyz', 'pane:3')
+    const b = mintPtySessionId('wt-alpha', 'tab-xyz', 'pane:3')
+    expect(a).toBe(b)
+    expect(a).toMatch(/^wt-alpha@@[0-9a-f]{8}$/)
+  })
+
+  it('does not collide across sibling panes in the same tab', () => {
+    // Why: two live panes in the same tab must map to distinct history
+    // dirs so their scrollback files do not interleave. Collision is a
+    // correctness bug, not a performance concern.
+    const p1 = mintPtySessionId('wt-alpha', 'tab-xyz', 'pane:1')
+    const p2 = mintPtySessionId('wt-alpha', 'tab-xyz', 'pane:2')
+    expect(p1).not.toBe(p2)
+  })
+
+  it('does not collide across sibling tabs in the same worktree', () => {
+    const a = mintPtySessionId('wt-alpha', 'tab-a', 'pane:1')
+    const b = mintPtySessionId('wt-alpha', 'tab-b', 'pane:1')
+    expect(a).not.toBe(b)
+  })
+
+  it('falls back to a random suffix when tabId is absent', () => {
+    // Why: the deterministic path requires BOTH tabId and leafId. A
+    // missing piece must degrade to the legacy random-suffix behavior —
+    // never silently produce a "deterministic-looking" but empty-input
+    // digest that would collide across every tabId-less caller.
+    const a = mintPtySessionId('wt-alpha', undefined, 'pane:1')
+    const b = mintPtySessionId('wt-alpha', undefined, 'pane:1')
+    expect(a).not.toBe(b)
+    expect(a).toMatch(/^wt-alpha@@[0-9a-f]{8}$/)
+  })
+
+  it('falls back to a random suffix when leafId is absent', () => {
+    const a = mintPtySessionId('wt-alpha', 'tab-xyz', undefined)
+    const b = mintPtySessionId('wt-alpha', 'tab-xyz', undefined)
+    expect(a).not.toBe(b)
+  })
+})
+
+describe('mintPtySessionIdWithOrigin', () => {
+  it('reports `explicit` when the caller supplies a session id verbatim', () => {
+    const r = mintPtySessionIdWithOrigin({ explicitSessionId: 'sess-preexisting' })
+    expect(r.sessionId).toBe('sess-preexisting')
+    expect(r.derivedFrom).toBe('explicit')
+  })
+
+  it('reports `deterministic` when (worktreeId, tabId, leafId) are all present', () => {
+    const r = mintPtySessionIdWithOrigin({
+      worktreeId: 'wt-alpha',
+      tabId: 'tab-xyz',
+      leafId: 'pane:3'
+    })
+    expect(r.derivedFrom).toBe('deterministic')
+    expect(r.sessionId).toMatch(/^wt-alpha@@[0-9a-f]{8}$/)
+  })
+
+  it('reports `random-fallback` when worktreeId is present but tabId or leafId is missing', () => {
+    // Why: this is the diagnostic signal the renderer-threading work is
+    // supposed to eliminate for daemon-host spawns. The caller (ipc/pty.ts)
+    // escalates this to a warn log so a plumbing regression surfaces
+    // without silently reintroducing the race.
+    const r = mintPtySessionIdWithOrigin({ worktreeId: 'wt-alpha', leafId: 'pane:1' })
+    expect(r.derivedFrom).toBe('random-fallback')
+    expect(r.sessionId).toMatch(/^wt-alpha@@[0-9a-f]{8}$/)
+  })
+
+  it('reports `random-fallback` when worktreeId is absent', () => {
+    const r = mintPtySessionIdWithOrigin({})
+    expect(r.derivedFrom).toBe('random-fallback')
+    expect(r.sessionId).toMatch(/^[0-9a-f-]{36}$/)
   })
 })
 

--- a/src/main/daemon/pty-session-id.test.ts
+++ b/src/main/daemon/pty-session-id.test.ts
@@ -64,6 +64,44 @@ describe('mintPtySessionId', () => {
     const b = mintPtySessionId('wt-alpha', 'tab-xyz', undefined)
     expect(a).not.toBe(b)
   })
+
+  it('distinguishes (tabId="a\\0b", leafId="c") from (tabId="a", leafId="b\\0c")', () => {
+    // Why: the design doc §7.1 calls this out explicitly. A plain NUL
+    // separator is insufficient because `hash("a\0b" + "\0" + "c")`
+    // equals `hash("a" + "\0" + "b\0c")` — the mint uses length-prefixed
+    // encoding so the boundary between tabId and leafId is recoverable
+    // from the byte stream. Losing this distinction would collapse two
+    // distinct panes onto one history dir.
+    const a = mintPtySessionId('wt-alpha', 'a\x00b', 'c')
+    const b = mintPtySessionId('wt-alpha', 'a', 'b\x00c')
+    expect(a).not.toBe(b)
+  })
+
+  it('distinguishes siblings that concat to the same string via length prefix', () => {
+    // Why: the primary correctness guarantee of length-prefix encoding.
+    // ("ab", "cd") and ("a", "bcd") both produce the byte string "abcd"
+    // if you just concatenate; with length-prefixed hashing they must
+    // still hash differently.
+    const a = mintPtySessionId('wt-alpha', 'ab', 'cd')
+    const b = mintPtySessionId('wt-alpha', 'a', 'bcd')
+    expect(a).not.toBe(b)
+  })
+
+  it('has zero collisions across 1000 sibling (tabId, leafId) pairs', () => {
+    // Why: 8 hex chars = 32 bits ≈ 1 in 4B per pair; with 1000 pairs the
+    // birthday-paradox expected collisions is <<1. A collision here means
+    // our hash implementation is broken (e.g. truncating before hashing),
+    // not just an unlucky draw.
+    const seen = new Set<string>()
+    for (let t = 0; t < 100; t++) {
+      for (let p = 0; p < 10; p++) {
+        const id = mintPtySessionId('wt-alpha', `tab-${t}`, `pane:${p}`)
+        expect(seen.has(id)).toBe(false)
+        seen.add(id)
+      }
+    }
+    expect(seen.size).toBe(1000)
+  })
 })
 
 describe('mintPtySessionIdWithOrigin', () => {

--- a/src/main/daemon/pty-session-id.ts
+++ b/src/main/daemon/pty-session-id.ts
@@ -1,18 +1,104 @@
-import { randomUUID } from 'crypto'
+import { createHash, randomUUID } from 'crypto'
 import { isAbsolute, join, relative, resolve, sep } from 'path'
 
+export type MintedSessionIdOrigin = 'deterministic' | 'explicit' | 'random-fallback'
+
+export type MintSessionIdResult = {
+  sessionId: string
+  /**
+   * How the id was produced:
+   *  - `deterministic`: derived from (worktreeId, tabId, leafId) — the happy
+   *    path that lets cold-restore survive a crash before persistence.
+   *  - `explicit`: caller supplied a pre-computed sessionId (reattach path).
+   *  - `random-fallback`: a daemon-host spawn did not receive tabId/leafId
+   *    and had to fall back to a random UUID. Persistence still matters for
+   *    this branch — it is the old behavior and re-exposes the race this
+   *    design is trying to close. Logged at warn level so regressions in
+   *    the renderer plumbing surface loudly.
+   */
+  derivedFrom: MintedSessionIdOrigin
+}
+
 /**
- * Session IDs use the format `${worktreeId}@@${shortUuid}` so that
+ * Session IDs use the format `${worktreeId}@@${suffix}` so that
  * DaemonPtyAdapter.reconcileOnStartup (see daemon-pty-adapter.ts) can
  * derive the owning worktree by splitting on the @@ separator.
  *
- * Both pty.ts (host-daemon spawn path) and DaemonPtyAdapter.doSpawn
- * (fallback when opts.sessionId is absent) must use this helper — a
- * drifted format would break cold-restore mapping and Pi overlay
+ * Deterministic suffix (preferred): when both `tabId` and `leafId` are
+ * provided, the suffix is the first 32 bits of SHA-256(tabId || "\0" ||
+ * leafId), hex-encoded. This lets a restart reach the same history
+ * directory for the same (worktreeId, tabId, leafId) triple *without*
+ * needing `orca-data.json` to have persisted the sessionId — closing
+ * the SIGKILL-between-spawn-and-persist race that Issue #217 describes.
+ *
+ * Random suffix (fallback): when tabId/leafId are absent (e.g. an older
+ * non-pane caller) the suffix is `randomUUID().slice(0, 8)`. This is the
+ * legacy behavior; the renderer is expected to thread tabId+leafId for
+ * every daemon-host spawn, so falling in here from a daemon-host code
+ * path indicates a plumbing bug and is logged at warn level by callers.
+ *
+ * Both `pty.ts` (host-daemon spawn path) and DaemonPtyAdapter.doSpawn
+ * (fallback when opts.sessionId is absent) delegate to this helper —
+ * a drifted format would break cold-restore mapping and Pi overlay
  * keying.
+ *
+ * Collision bound: with 32 bits of suffix entropy, the birthday bound
+ * for two distinct (tabId, leafId) pairs colliding within one worktree
+ * is ~1 in 2^16 at ~256 pairs. Real worktrees hold O(10) panes. The
+ * bound matches the pre-existing random-UUID path (also 32 bits) — no
+ * regression.
  */
-export function mintPtySessionId(worktreeId?: string): string {
-  return worktreeId ? `${worktreeId}@@${randomUUID().slice(0, 8)}` : randomUUID()
+export function mintPtySessionId(worktreeId?: string, tabId?: string, leafId?: string): string {
+  if (!worktreeId) {
+    return randomUUID()
+  }
+  if (tabId && leafId) {
+    // Why: NUL separator is belt-and-suspenders. `createHash.update()` is
+    // streaming so `update("a") + update("\0") + update("b")` and
+    // `update("a\0b")` produce identical digests; the explicit separator
+    // is cosmetic against today's NUL-free input alphabet (tabIds are
+    // `crypto.randomUUID()`, leafIds are `pane:<number>`). Callers that
+    // might introduce NUL-containing inputs must switch to a
+    // length-prefixed encoding instead.
+    const h = createHash('sha256')
+    h.update(tabId)
+    h.update('\0')
+    h.update(leafId)
+    const suffix = h.digest('hex').slice(0, 8)
+    return `${worktreeId}@@${suffix}`
+  }
+  return `${worktreeId}@@${randomUUID().slice(0, 8)}`
+}
+
+/**
+ * Variant that also reports how the id was produced. Use this at the
+ * single mint call site in `ipc/pty.ts` so the observability log can
+ * split info vs. warn appropriately.
+ */
+export function mintPtySessionIdWithOrigin(args: {
+  worktreeId?: string
+  tabId?: string
+  leafId?: string
+  explicitSessionId?: string
+}): MintSessionIdResult {
+  if (args.explicitSessionId) {
+    return { sessionId: args.explicitSessionId, derivedFrom: 'explicit' }
+  }
+  if (args.worktreeId && args.tabId && args.leafId) {
+    return {
+      sessionId: mintPtySessionId(args.worktreeId, args.tabId, args.leafId),
+      derivedFrom: 'deterministic'
+    }
+  }
+  // Either worktreeId is absent (non-daemon spawn — we return a raw uuid
+  // and the caller is responsible for deciding whether that's expected)
+  // or tabId/leafId weren't threaded through from the renderer. The
+  // second case is the one we want to hear about; callers differentiate
+  // on `!!args.worktreeId` before choosing the log level.
+  return {
+    sessionId: mintPtySessionId(args.worktreeId, args.tabId, args.leafId),
+    derivedFrom: 'random-fallback'
+  }
 }
 
 /**

--- a/src/main/daemon/pty-session-id.ts
+++ b/src/main/daemon/pty-session-id.ts
@@ -53,17 +53,28 @@ export function mintPtySessionId(worktreeId?: string, tabId?: string, leafId?: s
     return randomUUID()
   }
   if (tabId && leafId) {
-    // Why: NUL separator is belt-and-suspenders. `createHash.update()` is
-    // streaming so `update("a") + update("\0") + update("b")` and
-    // `update("a\0b")` produce identical digests; the explicit separator
-    // is cosmetic against today's NUL-free input alphabet (tabIds are
-    // `crypto.randomUUID()`, leafIds are `pane:<number>`). Callers that
-    // might introduce NUL-containing inputs must switch to a
-    // length-prefixed encoding instead.
+    // Why: length-prefix each field before hashing so (tabId, leafId)
+    // pairs that concatenate to the same byte string but differ in where
+    // the boundary falls still produce distinct digests. A plain NUL
+    // separator is NOT sufficient — `hash("a\0b" + "\0" + "c")` equals
+    // `hash("a" + "\0" + "b\0c")` because `createHash.update` is a
+    // streaming append. Today's inputs (tabIds are `crypto.randomUUID()`,
+    // leafIds are `pane:<number>`) never contain NUL, so the practical
+    // risk is zero — but the design doc §7.1 calls out this property
+    // explicitly, and length-prefixing is the cheapest unambiguous
+    // encoding that doesn't rely on an input-alphabet invariant we'd
+    // have to re-verify every time a caller changes.
+    const tabBuf = Buffer.from(tabId, 'utf8')
+    const leafBuf = Buffer.from(leafId, 'utf8')
+    const tabLen = Buffer.alloc(4)
+    tabLen.writeUInt32BE(tabBuf.length, 0)
+    const leafLen = Buffer.alloc(4)
+    leafLen.writeUInt32BE(leafBuf.length, 0)
     const h = createHash('sha256')
-    h.update(tabId)
-    h.update('\0')
-    h.update(leafId)
+    h.update(tabLen)
+    h.update(tabBuf)
+    h.update(leafLen)
+    h.update(leafBuf)
     const suffix = h.digest('hex').slice(0, 8)
     return `${worktreeId}@@${suffix}`
   }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -550,12 +550,18 @@ app.whenReady().then(async () => {
         liveDaemonSessionIds.add(id)
       }
     }
-    await runOrphanHistoryReaper({
+    const reapStats = await runOrphanHistoryReaper({
       historyBasePath: getHistoryDir(),
       sidecarDir: app.getPath('userData'),
       workspaceSession: store.getWorkspaceSession(),
       liveDaemonSessionIds
     })
+    // Why (design doc §9): log counts so post-release we can tell whether
+    // the reaper is firing at all and whether the three gates (keep set,
+    // mtime grace, quarantine) are in their expected ratios. Persistent
+    // non-zero `reaped` without corresponding shrinkage of history dirs in
+    // the wild would indicate a logic bug worth investigating.
+    console.log('[history-reaper] startup pass stats:', reapStats)
   } catch (error) {
     console.warn('[history-reaper] startup pass failed:', error)
   }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -11,7 +11,14 @@ import { StatsCollector, initStatsPath } from './stats/collector'
 import { ClaudeUsageStore, initClaudeUsagePath } from './claude-usage/store'
 import { CodexUsageStore, initCodexUsagePath } from './codex-usage/store'
 import { killAllPty } from './ipc/pty'
-import { initDaemonPtyProvider, disconnectDaemon } from './daemon/daemon-init'
+import {
+  initDaemonPtyProvider,
+  disconnectDaemon,
+  getDaemonProvider,
+  getHistoryDir
+} from './daemon/daemon-init'
+import { runOrphanHistoryReaper } from './daemon/orphan-history-reaper'
+import { DaemonPtyRouter } from './daemon/daemon-pty-router'
 import { setAppRuntimeFlags } from './ipc/app'
 import { closeAllWatchers } from './ipc/filesystem-watcher'
 import { registerCoreHandlers } from './ipc/register-core-handlers'
@@ -519,6 +526,38 @@ app.whenReady().then(async () => {
     await initDaemonPtyProvider()
   } catch (error) {
     console.error('[daemon] Failed to start daemon PTY provider, falling back to local:', error)
+  }
+  // Why: with deterministic session ids the `terminal-history/` tree no
+  // longer self-cleans when the persisted keep set misses an id — a pane
+  // closed permanently before its workspace-session update landed would
+  // leak a dir forever. Run a conservative (30-day mtime grace +
+  // two-launch quarantine) orphan reaper once per boot, sibling to
+  // daemon init. Best-effort: a failure here must never block startup.
+  try {
+    const provider = getDaemonProvider()
+    const liveDaemonSessionIds = new Set<string>()
+    if (provider instanceof DaemonPtyRouter) {
+      for (const id of provider.getCurrentAdapter().getActiveSessionIds()) {
+        liveDaemonSessionIds.add(id)
+      }
+      for (const legacy of provider.getLegacyAdapters()) {
+        for (const id of legacy.getActiveSessionIds()) {
+          liveDaemonSessionIds.add(id)
+        }
+      }
+    } else if (provider) {
+      for (const id of provider.getActiveSessionIds()) {
+        liveDaemonSessionIds.add(id)
+      }
+    }
+    await runOrphanHistoryReaper({
+      historyBasePath: getHistoryDir(),
+      sidecarDir: app.getPath('userData'),
+      workspaceSession: store.getWorkspaceSession(),
+      liveDaemonSessionIds
+    })
+  } catch (error) {
+    console.warn('[history-reaper] startup pass failed:', error)
   }
   setAppRuntimeFlags({
     agentDashboardEnabledAtStartup: agentDashboardEnabled

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -15,7 +15,7 @@ import { piTitlebarExtensionService } from '../pi/titlebar-extension-service'
 import { isPwshAvailable } from '../pwsh'
 import { LocalPtyProvider } from '../providers/local-pty-provider'
 import type { IPtyProvider, PtySpawnOptions, PtySpawnResult } from '../providers/types'
-import { mintPtySessionId, isSafePtySessionId } from '../daemon/pty-session-id'
+import { mintPtySessionIdWithOrigin, isSafePtySessionId } from '../daemon/pty-session-id'
 import type { ClaudeRuntimeAuthPreparation } from '../claude-accounts/runtime-auth-service'
 import { CLAUDE_AUTH_ENV_VARS, hasClaudeAuthEnvConflict } from '../claude-accounts/environment'
 import {
@@ -631,6 +631,13 @@ export function registerPtyHandlers(
         worktreeId?: string
         sessionId?: string
         shellOverride?: string
+        // Why: renderer threads tabId + leafId for every daemon-host spawn so
+        // the main process can mint a deterministic sessionId from
+        // (worktreeId, tabId, leafId). That makes cold-restore survive a
+        // SIGKILL between spawn and the renderer's debounced persistence.
+        // Both fields are optional for back-compat with non-pane callers.
+        tabId?: string
+        leafId?: string
       }
     ) => {
       const provider = getProvider(args.connectionId)
@@ -680,8 +687,40 @@ export function registerPtyHandlers(
       // an existing PTY whose state (OpenCode hooks, Pi overlay, agent-hook
       // pane caches) we must not clobber on a retry/attach failure.
       const isMintedSessionId = args.sessionId === undefined && isDaemonHostSpawn
-      const effectiveSessionId =
-        args.sessionId ?? (isDaemonHostSpawn ? mintPtySessionId(args.worktreeId) : undefined)
+      // Why: mint deterministically from (worktreeId, tabId, leafId) when
+      // the renderer threads those. Explicit sessionIds (reattach) and
+      // random-fallback (tabId/leafId missing) are recorded so we can
+      // spot renderer plumbing regressions in the logs.
+      const mintResult = isDaemonHostSpawn
+        ? mintPtySessionIdWithOrigin({
+            worktreeId: args.worktreeId,
+            tabId: args.tabId,
+            leafId: args.leafId,
+            explicitSessionId: args.sessionId
+          })
+        : args.sessionId
+          ? { sessionId: args.sessionId, derivedFrom: 'explicit' as const }
+          : null
+      const effectiveSessionId = mintResult?.sessionId
+      if (mintResult && isDaemonHostSpawn) {
+        const logPayload = {
+          worktreeId: args.worktreeId,
+          tabId: args.tabId,
+          leafId: args.leafId,
+          sessionId: mintResult.sessionId,
+          derivedFrom: mintResult.derivedFrom
+        }
+        if (mintResult.derivedFrom === 'random-fallback') {
+          // Why: a daemon-host spawn arriving without tabId/leafId means the
+          // renderer plumbing didn't thread them — cold restore will only
+          // survive if the renderer later persists this sessionId before a
+          // crash. That's exactly the race Issue #217 documented, so surface
+          // it as a warning.
+          console.warn('[pty] mintPtySessionId random-fallback', logPayload)
+        } else {
+          console.info('[pty] mintPtySessionId', logPayload)
+        }
+      }
       const baseEnv = claudeAuth ? { ...args.env, ...claudeAuth.envPatch } : args.env
       let env: Record<string, string> | undefined = baseEnv
       const preAllocatedHandle =
@@ -752,6 +791,15 @@ export function registerPtyHandlers(
       }
       if (effectiveSessionId !== undefined) {
         spawnOptions.sessionId = effectiveSessionId
+      }
+      // Why: forward tabId/leafId to the provider so any fallback mint path
+      // inside the adapter (tests, direct callers) can still produce a
+      // deterministic id.
+      if (args.tabId !== undefined) {
+        spawnOptions.tabId = args.tabId
+      }
+      if (args.leafId !== undefined) {
+        spawnOptions.leafId = args.leafId
       }
       // Why: on Windows, fall back to the persisted default-shell setting
       // when the renderer didn't send a per-tab override. Without this, the

--- a/src/main/providers/types.ts
+++ b/src/main/providers/types.ts
@@ -25,6 +25,15 @@ export type PtySpawnOptions = {
   /** Daemon session ID for reattach. When provided, the daemon reconnects
    *  to an existing session instead of creating a new one. */
   sessionId?: string
+  /** Tab identity, forwarded by the renderer for daemon-host spawns so the
+   *  main process can derive a deterministic sessionId from
+   *  (worktreeId, tabId, leafId). Closes the SIGKILL-between-spawn-and-
+   *  persist race that loses scrollback on unclean restart. Optional for
+   *  backwards compatibility with non-pane callers; when absent the daemon
+   *  path falls back to a random-suffix sessionId and logs at warn level. */
+  tabId?: string
+  /** Pane leaf identity (e.g. "pane:1"). See `tabId` for why. */
+  leafId?: string
   /** Why: allows the renderer to request a specific shell for a single new
    *  terminal tab (e.g. "open this tab in WSL" from the "+" submenu) without
    *  changing the user's persistent default shell setting. Only consulted on

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -418,6 +418,12 @@ export type PreloadApi = {
       // Preserved from the deleted index.d.ts PtyApi duplicate during the
       // single-source-of-truth collapse (see docs/preload-typecheck-hole.md §1).
       shellOverride?: string
+      // Why: renderer threads these for daemon-host spawns so the main
+      // process can mint a deterministic sessionId from (worktreeId,
+      // tabId, leafId). Closes the SIGKILL-between-spawn-and-persist race
+      // that lost terminal scrollback on unclean restart (Issue #217).
+      tabId?: string
+      leafId?: string
     }) => Promise<{
       id: string
       snapshot?: string

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -328,6 +328,8 @@ const api = {
       worktreeId?: string
       sessionId?: string
       shellOverride?: string
+      tabId?: string
+      leafId?: string
     }): Promise<{
       id: string
       snapshot?: string

--- a/src/renderer/src/components/terminal-pane/layout-serialization.test.ts
+++ b/src/renderer/src/components/terminal-pane/layout-serialization.test.ts
@@ -1,3 +1,6 @@
+/* oxlint-disable max-lines -- Why: layout-serialization concentrates the
+replay/snapshot/fallback-font logic and its regressions are easiest to
+catch together. */
 import { describe, expect, it, beforeAll } from 'vitest'
 import type { TerminalPaneLayoutNode } from '../../../../shared/types'
 
@@ -39,8 +42,10 @@ import {
   serializeTerminalLayout,
   EMPTY_LAYOUT,
   collectLeafIdsInOrder,
-  collectLeafIdsInReplayCreationOrder
+  collectLeafIdsInReplayCreationOrder,
+  replayTerminalLayout
 } from './layout-serialization'
+import type { PaneManager } from '@/lib/pane-manager/pane-manager'
 
 // ---------------------------------------------------------------------------
 // Helper to create mock elements
@@ -298,5 +303,133 @@ describe('collectLeafIdsInReplayCreationOrder', () => {
     }
 
     expect(collectLeafIdsInReplayCreationOrder(layout)).toEqual(['A', 'B', 'C'])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// replayTerminalLayout — pane-counter advance
+// ---------------------------------------------------------------------------
+/**
+ * Why: a persisted layout stores leafIds as `pane:<N>` verbatim. After replay
+ * the PaneManager's monotonic counter (a per-instance `nextPaneId` that
+ * resets to 1 on each app start) must be advanced past max(N) so the next
+ * user-triggered split does not mint a pane whose `paneLeafId` collides with
+ * an existing persisted leaf. Collision would collapse the determinism of
+ * session ids derived from `(worktreeId, tabId, leafId)` — two distinct panes
+ * sharing one history directory. Covered by tests below.
+ */
+
+function createMockPaneManager(): {
+  manager: PaneManager
+  createdIds: number[]
+  advanceCalls: number[]
+  // How the mock simulates the real counter. On createInitialPane / splitPane
+  // we hand out `nextId++`; advanceNextPaneIdTo bumps the counter forward.
+  nextId: () => number
+} {
+  let counter = 1
+  const created: number[] = []
+  const advances: number[] = []
+
+  const mintPane = (): { id: number } => {
+    const id = counter++
+    created.push(id)
+    return { id }
+  }
+
+  const manager = {
+    createInitialPane: ({ focus }: { focus?: boolean } = {}) => {
+      void focus
+      return mintPane()
+    },
+    splitPane: () => mintPane(),
+    advanceNextPaneIdTo: (minNextId: number) => {
+      advances.push(minNextId)
+      if (minNextId > counter) {
+        counter = minNextId
+      }
+    }
+    // Why: we cast through unknown because the mock only implements the
+    // narrow surface replayTerminalLayout actually calls. Keeps the test
+    // from having to stand up WebGL/DOM dependencies.
+  } as unknown as PaneManager
+
+  return {
+    manager,
+    createdIds: created,
+    advanceCalls: advances,
+    nextId: () => counter
+  }
+}
+
+describe('replayTerminalLayout — pane counter advance', () => {
+  it('bumps the counter past the highest persisted pane:N', () => {
+    // Why: persisted leafIds can encode panes with N higher than what the
+    // replay itself mints (e.g. the user closed pane 2 and then split
+    // pane 5 before shutdown — the snapshot still contains pane:5 but
+    // only 3 panes end up replayed). The counter must reach max(N)+1.
+    const { manager, advanceCalls, nextId } = createMockPaneManager()
+    const snapshot = {
+      root: {
+        type: 'split' as const,
+        direction: 'vertical' as const,
+        first: { type: 'leaf' as const, leafId: 'pane:7' },
+        second: { type: 'leaf' as const, leafId: 'pane:3' }
+      },
+      activeLeafId: null,
+      expandedLeafId: null
+    }
+
+    replayTerminalLayout(manager, snapshot, false)
+
+    // highest persisted N is 7; counter must be advanced to >= 8.
+    expect(advanceCalls).toEqual([8])
+    expect(nextId()).toBeGreaterThanOrEqual(8)
+  })
+
+  it('does not regress the counter when the highest persisted N is small', () => {
+    const { manager, advanceCalls } = createMockPaneManager()
+    const snapshot = {
+      root: { type: 'leaf' as const, leafId: 'pane:1' },
+      activeLeafId: null,
+      expandedLeafId: null
+    }
+
+    replayTerminalLayout(manager, snapshot, false)
+
+    // advanceNextPaneIdTo(2) is called but has no effect if the counter
+    // is already >= 2 — in the mock `createInitialPane` minted id 1 and
+    // left the counter at 2 so this is a no-op move, which the mock
+    // ignores (the real implementation's guard matches).
+    expect(advanceCalls).toEqual([2])
+  })
+
+  it('skips non-matching leaf ids without throwing', () => {
+    // Why: a corrupted or legacy snapshot might contain leafIds that
+    // don't match `pane:<N>`. These must be skipped rather than crash
+    // the restore — the counter fix is a best-effort safety valve.
+    const { manager, advanceCalls } = createMockPaneManager()
+    const snapshot = {
+      root: {
+        type: 'split' as const,
+        direction: 'vertical' as const,
+        first: { type: 'leaf' as const, leafId: 'legacy-shape-123' },
+        second: { type: 'leaf' as const, leafId: 'pane:4' }
+      },
+      activeLeafId: null,
+      expandedLeafId: null
+    }
+
+    replayTerminalLayout(manager, snapshot, false)
+
+    expect(advanceCalls).toEqual([5])
+  })
+
+  it('advances to 1 (a no-op) when the snapshot has no persisted panes', () => {
+    const { manager, advanceCalls } = createMockPaneManager()
+    replayTerminalLayout(manager, { root: null, activeLeafId: null, expandedLeafId: null }, false)
+    // Snapshot has no root → replayTerminalLayout returns early, before
+    // the advance call path. Assert no advance was issued.
+    expect(advanceCalls).toEqual([])
   })
 })

--- a/src/renderer/src/components/terminal-pane/layout-serialization.ts
+++ b/src/renderer/src/components/terminal-pane/layout-serialization.ts
@@ -283,6 +283,43 @@ export function restoreScrollbackBuffers(
   }
 }
 
+/**
+ * Why: the snapshot stores leafIds as `pane:<N>` strings rewritten verbatim
+ * on restore. After replay we must advance PaneManager.nextPaneId past
+ * `max(N)` so the next user-triggered split does not mint a pane whose
+ * `paneLeafId` collides with a persisted leaf — a collision would collapse
+ * the determinism of sessionIds derived from `(worktreeId, tabId, leafId)`.
+ *
+ * Parser: `/^pane:(\d+)$/`. Non-matching entries (e.g. a legacy custom
+ * leafId shape, or a corrupted snapshot) are skipped rather than thrown
+ * on — the counter advance is a best-effort safety; if the highest
+ * numeric leaf is missed we fall back to the per-instance monotonic
+ * default, which at worst surfaces the original collision bug, not a
+ * new crash.
+ */
+function highestPaneNInSnapshot(node: TerminalPaneLayoutNode | null | undefined): number {
+  if (!node) {
+    return 0
+  }
+  let max = 0
+  const visit = (n: TerminalPaneLayoutNode): void => {
+    if (n.type === 'leaf') {
+      const match = /^pane:(\d+)$/.exec(n.leafId)
+      if (match) {
+        const parsed = Number(match[1])
+        if (Number.isFinite(parsed) && parsed > max) {
+          max = parsed
+        }
+      }
+      return
+    }
+    visit(n.first)
+    visit(n.second)
+  }
+  visit(node)
+  return max
+}
+
 export function replayTerminalLayout(
   manager: PaneManager,
   snapshot: TerminalLayoutSnapshot | null | undefined,
@@ -315,5 +352,11 @@ export function replayTerminalLayout(
   }
 
   restoreNode(snapshot.root, initialPane.id)
+
+  // Why: bump PaneManager's counter past the highest persisted `pane:N`
+  // before any user-triggered split runs. See highestPaneNInSnapshot.
+  const maxPersisted = highestPaneNInSnapshot(snapshot.root)
+  manager.advanceNextPaneIdTo(maxPersisted + 1)
+
   return paneByLeafId
 }

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -445,12 +445,25 @@ export function connectPanePty(
     // has no equivalent mechanism, so the renderer must inject it via sendInput.
     let pendingStartupCommand = connectionId ? (paneStartup?.command ?? null) : null
 
+    // Why: this must match the leafId the persistence layer uses for
+    // terminalLayoutsByTabId[tabId].ptyIdsByLeafId so a restart reaches
+    // the same history directory. `restoredLeafId` wins when the pane
+    // was materialized from a persisted snapshot (replayTerminalLayout
+    // preserved it); otherwise the newly-assigned paneId is the leaf.
+    const effectiveLeafId = deps.restoredLeafId ?? paneLeafId(pane.id)
+
     const startFreshSpawn = (): void => {
       const spawnPromise = Promise.resolve(
         transport.connect({
           url: '',
           cols,
           rows,
+          // Why: threading tabId/leafId lets the main process derive a
+          // deterministic sessionId (see src/main/daemon/pty-session-id.ts)
+          // so cold-restore works even if the renderer was SIGKILLed
+          // before its debounced ptyId persistence ran.
+          tabId: deps.tabId,
+          leafId: effectiveLeafId,
           callbacks: {
             onData: dataCallback,
             onReplayData: replayDataCallback,
@@ -797,6 +810,12 @@ export function connectPanePty(
         cols,
         rows,
         sessionId: deferredReattachSessionId,
+        // Why: tabId/leafId are ignored when sessionId is explicit, but
+        // threading them keeps the audit trail intact and makes a future
+        // fallback (e.g. the explicit id was invalid) produce a
+        // deterministic id instead of a random one.
+        tabId: deps.tabId,
+        leafId: effectiveLeafId,
         callbacks: {
           onData: dataCallback,
           onReplayData: replayDataCallback,

--- a/src/renderer/src/components/terminal-pane/pty-dispatcher.ts
+++ b/src/renderer/src/components/terminal-pane/pty-dispatcher.ts
@@ -153,6 +153,13 @@ export type PtyTransport = {
     /** Daemon session ID for reattach. When provided, the daemon reconnects
      *  to an existing session instead of creating a new one. */
     sessionId?: string
+    /** Tab identity, forwarded with every daemon-host spawn so the main
+     *  process can mint a deterministic sessionId from (worktreeId, tabId,
+     *  leafId). Closes the SIGKILL-between-spawn-and-persist race that
+     *  lost terminal scrollback on unclean restart (Issue #217). */
+    tabId?: string
+    /** Pane leaf identity (e.g. "pane:1"). See `tabId` for why. */
+    leafId?: string
     callbacks: {
       onConnect?: () => void
       onDisconnect?: () => void

--- a/src/renderer/src/components/terminal-pane/pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.ts
@@ -353,7 +353,12 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
           ...(connectionId ? { connectionId } : {}),
           ...(options.sessionId ? { sessionId: options.sessionId } : {}),
           worktreeId,
-          ...(shellOverride ? { shellOverride } : {})
+          ...(shellOverride ? { shellOverride } : {}),
+          // Why: thread tabId/leafId so the main process can derive a
+          // deterministic sessionId. Issue #217 regression prevention —
+          // see pty-session-id.ts.
+          ...(options.tabId ? { tabId: options.tabId } : {}),
+          ...(options.leafId ? { leafId: options.leafId } : {})
         })
         const spawnResult = result as PtyConnectResult & { isReattach?: boolean }
 

--- a/src/renderer/src/lib/pane-manager/pane-manager.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager.ts
@@ -1,3 +1,7 @@
+/* eslint-disable max-lines -- Why: PaneManager owns the DOM, WebGL,
+drag-reorder, and counter-advance state for the terminal-pane tree. Splitting
+further would scatter invariants (active pane focus, nextPaneId monotonicity,
+divider styles) across files with no cleaner ownership seam. */
 import type {
   PaneManagerOptions,
   PaneStyleOptions,
@@ -60,6 +64,15 @@ export class PaneManager {
     this.root = root
     this.options = options
     this.renderingSuspended = options.initialRenderingSuspended === true
+  }
+
+  // Why: nextPaneId resets to 1 on restart; persisted pane:N leafIds are
+  // replayed verbatim. Bumping past max(N) prevents the next split from
+  // colliding — otherwise two panes derive the same deterministic history dir.
+  advanceNextPaneIdTo(minNextId: number): void {
+    if (minNextId > this.nextPaneId) {
+      this.nextPaneId = minNextId
+    }
   }
 
   createInitialPane(opts?: { focus?: boolean }): ManagedPane {

--- a/tests/e2e/terminal-restart-persistence.spec.ts
+++ b/tests/e2e/terminal-restart-persistence.spec.ts
@@ -347,9 +347,45 @@ test.describe('Terminal restart persistence', () => {
       // Split vertically — a new pane is created with its own ptyId
       await splitActiveTerminalPane(firstLaunch.page, 'vertical')
       await waitForPaneCount(firstLaunch.page, 2, 15_000)
-      // Why: splitActiveTerminalPane makes the new pane active, so the next
-      // discoverActivePtyId returns the *new* pane's pty.
-      const secondPtyId = await discoverActivePtyId(firstLaunch.page)
+      // Why: don't use discoverActivePtyId here — it works by broadcasting a
+      // marker to every candidate pty in the tab and reading the active
+      // pane's xterm buffer. Right after a split the new pane's PTY may not
+      // be registered in ptyIdsByTabId yet (CI is slower than local), which
+      // makes the probe time out. Instead, poll the store directly for the
+      // tab's ptyId list to grow to 2, then pick the id that isn't firstPtyId.
+      const tabId = await firstLaunch.page.evaluate(() => {
+        const store = window.__store
+        if (!store) {
+          return null
+        }
+        const s = store.getState()
+        const worktreeId = s.activeWorktreeId
+        if (!worktreeId) {
+          return null
+        }
+        return s.activeTabIdByWorktree[worktreeId] ?? null
+      })
+      if (!tabId) {
+        throw new Error('2-pane split test: active tabId unavailable')
+      }
+      await expect
+        .poll(
+          async () =>
+            firstLaunch.page.evaluate((tabId) => {
+              return (window.__store?.getState().ptyIdsByTabId[tabId] ?? []).length
+            }, tabId),
+          { timeout: 15_000, message: 'Split pane never registered its PTY in the store' }
+        )
+        .toBeGreaterThanOrEqual(2)
+      const ptyIds = await firstLaunch.page.evaluate((tabId) => {
+        return window.__store?.getState().ptyIdsByTabId[tabId] ?? []
+      }, tabId)
+      const secondPtyId = ptyIds.find((id: string) => id !== firstPtyId)
+      if (!secondPtyId) {
+        throw new Error(
+          `2-pane split test: could not identify second ptyId from ${JSON.stringify(ptyIds)}`
+        )
+      }
       expect(secondPtyId).not.toBe(firstPtyId)
 
       const markerB = `SPLIT_PANE_B_${Date.now()}`

--- a/tests/e2e/terminal-restart-persistence.spec.ts
+++ b/tests/e2e/terminal-restart-persistence.spec.ts
@@ -1,3 +1,4 @@
+/* oxlint-disable max-lines */
 /**
  * E2E tests for terminal scrollback persistence across clean app restarts.
  *
@@ -35,6 +36,7 @@ import { TEST_REPO_PATH_FILE } from './global-setup'
 import {
   discoverActivePtyId,
   execInTerminal,
+  splitActiveTerminalPane,
   waitForActiveTerminalManager,
   waitForTerminalOutput,
   waitForPaneCount,
@@ -91,7 +93,11 @@ async function bootstrapFirstLaunch(
  * restore, and confirm the previously-active worktree is the active one
  * again so downstream assertions operate against the right worktree.
  */
-async function bootstrapRestoredLaunch(page: Page, expectedWorktreeId: string): Promise<void> {
+async function bootstrapRestoredLaunch(
+  page: Page,
+  expectedWorktreeId: string,
+  expectedPaneCount = 1
+): Promise<void> {
   await waitForSessionReady(page)
   await expect
     .poll(async () => getActiveWorktreeId(page), { timeout: 10_000 })
@@ -101,7 +107,7 @@ async function bootstrapRestoredLaunch(page: Page, expectedWorktreeId: string): 
   // restored terminal surface is what we're about to assert against, so make
   // sure it exists before any content/layout assertion races.
   await waitForActiveTerminalManager(page, 30_000)
-  await waitForPaneCount(page, 1, 30_000)
+  await waitForPaneCount(page, expectedPaneCount, 30_000)
 }
 
 test.describe('Terminal restart persistence', () => {
@@ -304,6 +310,133 @@ test.describe('Terminal restart persistence', () => {
       session.dispose()
     }
   })
+
+  test('2-pane split: both panes restore their scrollback after quit', async (// oxlint-disable-next-line no-empty-pattern -- Playwright's second fixture arg is testInfo; the first must be an object destructure to opt out of the default fixture set.
+  {}, testInfo) => {
+    // Why (design doc §7.2): the multi-pane path is distinct from single-pane
+    // because each pane derives its sessionId from its own leafId via
+    // mintPtySessionId(worktreeId, tabId, leafId). A bug in the leafId arm of
+    // the derivation (e.g. the renderer forgets to thread leafId so every
+    // pane collapses to the tab-level random fallback) would pass the
+    // single-pane test and silently regress the split case. This test
+    // produces a distinct marker in each pane, quits, and requires both
+    // markers to be restored after relaunch.
+    const repoPath = readFileSync(TEST_REPO_PATH_FILE, 'utf-8').trim()
+    if (!repoPath || !existsSync(repoPath)) {
+      test.skip(true, 'Global setup did not produce a seeded test repo')
+      return
+    }
+
+    const session = createRestartSession(testInfo)
+    let firstApp: ElectronApplication | null = null
+    let secondApp: ElectronApplication | null = null
+
+    try {
+      // ── First launch ────────────────────────────────────────────────
+      const firstLaunch = await session.launch()
+      firstApp = firstLaunch.app
+      const { worktreeId, ptyId: firstPtyId } = await bootstrapFirstLaunch(
+        firstLaunch.page,
+        repoPath
+      )
+
+      const markerA = `SPLIT_PANE_A_${Date.now()}`
+      await execInTerminal(firstLaunch.page, firstPtyId, `echo ${markerA}`)
+      await waitForTerminalOutput(firstLaunch.page, markerA)
+
+      // Split vertically — a new pane is created with its own ptyId
+      await splitActiveTerminalPane(firstLaunch.page, 'vertical')
+      await waitForPaneCount(firstLaunch.page, 2, 15_000)
+      // Why: splitActiveTerminalPane makes the new pane active, so the next
+      // discoverActivePtyId returns the *new* pane's pty.
+      const secondPtyId = await discoverActivePtyId(firstLaunch.page)
+      expect(secondPtyId).not.toBe(firstPtyId)
+
+      const markerB = `SPLIT_PANE_B_${Date.now()}`
+      await execInTerminal(firstLaunch.page, secondPtyId, `echo ${markerB}`)
+      await waitForTerminalOutput(firstLaunch.page, markerB)
+
+      await session.close(firstApp)
+      firstApp = null
+
+      // ── Second launch ───────────────────────────────────────────────
+      const secondLaunch = await session.launch()
+      secondApp = secondLaunch.app
+      await bootstrapRestoredLaunch(secondLaunch.page, worktreeId, 2)
+
+      // Both markers must be present in the restored terminal content.
+      // getTerminalContent returns content of the active pane only, so we
+      // check whether the combined content across panes contains both.
+      await expect
+        .poll(
+          async () => {
+            const content = await secondLaunch.page.evaluate(() => {
+              const managers = window.__paneManagers
+              if (!managers) {
+                return ''
+              }
+              const allText: string[] = []
+              for (const manager of managers.values()) {
+                const panes = manager.getPanes?.() ?? []
+                for (const pane of panes) {
+                  // Why: Terminal.buffer.active.getLine(n).translateToString()
+                  // joined across the visible viewport gives us the rendered
+                  // text regardless of which pane is currently focused.
+                  const term = (
+                    pane as {
+                      terminal?: {
+                        buffer?: {
+                          active?: {
+                            length: number
+                            getLine: (
+                              n: number
+                            ) => { translateToString: (trim?: boolean) => string } | undefined
+                          }
+                        }
+                      }
+                    }
+                  ).terminal
+                  const buf = term?.buffer?.active
+                  if (!buf) {
+                    continue
+                  }
+                  for (let i = 0; i < buf.length; i++) {
+                    const line = buf.getLine(i)?.translateToString(true)
+                    if (line) {
+                      allText.push(line)
+                    }
+                  }
+                }
+              }
+              return allText.join('\n')
+            })
+            return content.includes(markerA) && content.includes(markerB)
+          },
+          {
+            timeout: 20_000,
+            message: 'Split-pane restore did not recover both per-pane markers'
+          }
+        )
+        .toBe(true)
+    } finally {
+      if (secondApp) {
+        await session.close(secondApp)
+      }
+      if (firstApp) {
+        await session.close(firstApp)
+      }
+      session.dispose()
+    }
+  })
+
+  // Why: the cold-restore-miss warn signal (design doc §9) is covered by the
+  // unit test in src/main/daemon/daemon-pty-adapter.test.ts (
+  // "warns when an explicit sessionId produces a new daemon session with no
+  // disk history"). That's the right granularity for asserting a log-line
+  // contract — an e2e-scale repro was attempted but Playwright's
+  // _electron.launch reliably captures only a small subset of main-process
+  // console output, which made the assertion flaky despite the production
+  // code path firing correctly.
 
   test('idle session does not spam session.set writes', async (// oxlint-disable-next-line no-empty-pattern -- Playwright's second fixture arg is testInfo; the first must be an object destructure to opt out of the default fixture set.
   {}, testInfo) => {

--- a/tests/e2e/terminal-restart-persistence.spec.ts
+++ b/tests/e2e/terminal-restart-persistence.spec.ts
@@ -27,7 +27,8 @@
  *     removed periodic save represented.
  */
 
-import { readFileSync, existsSync } from 'fs'
+import { readFileSync, writeFileSync, existsSync } from 'fs'
+import { join } from 'path'
 import type { ElectronApplication, Page } from '@stablyai/playwright-test'
 import { test, expect } from './helpers/orca-app'
 import { TEST_REPO_PATH_FILE } from './global-setup'
@@ -216,6 +217,83 @@ test.describe('Terminal restart persistence', () => {
           timeout: 10_000
         })
         .toBe(tabsBefore.length)
+    } finally {
+      if (secondApp) {
+        await session.close(secondApp)
+      }
+      if (firstApp) {
+        await session.close(firstApp)
+      }
+      session.dispose()
+    }
+  })
+
+  test('scrollback survives quit with missing ptyId (Issue #217 regression)', async (// oxlint-disable-next-line no-empty-pattern -- Playwright's second fixture arg is testInfo; the first must be an object destructure to opt out of the default fixture set.
+  {}, testInfo) => {
+    // Why (design doc §7.2): this is the load-bearing test for the
+    // deterministic-sessionId fix. Issue #217 failed specifically when
+    // orca-data.json's `ptyId` field was empty at restore time (the
+    // SIGKILL-between-spawn-and-persist window). Before the fix, the
+    // renderer had no way to reach the on-disk history dir without that
+    // field. After the fix, mintPtySessionId(worktreeId, tabId, leafId)
+    // reproduces the same id, so the cold-restore reader finds the dir
+    // anyway. We simulate the race here by mutating the persisted
+    // orca-data.json between launches — deleting the ptyId field gives
+    // us the exact state the old code couldn't recover from, without
+    // the flakiness of racing a real SIGKILL.
+    const repoPath = readFileSync(TEST_REPO_PATH_FILE, 'utf-8').trim()
+    if (!repoPath || !existsSync(repoPath)) {
+      test.skip(true, 'Global setup did not produce a seeded test repo')
+      return
+    }
+
+    const session = createRestartSession(testInfo)
+    let firstApp: ElectronApplication | null = null
+    let secondApp: ElectronApplication | null = null
+
+    try {
+      // ── First launch: produce scrollback, let clean quit flush state ──
+      const firstLaunch = await session.launch()
+      firstApp = firstLaunch.app
+      const { worktreeId, ptyId } = await bootstrapFirstLaunch(firstLaunch.page, repoPath)
+
+      const marker = `DETERMINISTIC_RESTORE_${Date.now()}`
+      await execInTerminal(firstLaunch.page, ptyId, `echo ${marker}`)
+      await waitForTerminalOutput(firstLaunch.page, marker)
+
+      await session.close(firstApp)
+      firstApp = null
+
+      // Simulate the SIGKILL-before-persist race: strip ptyId from every
+      // tab in the persisted session. The terminal-history/ dir stays on
+      // disk (it was written by the daemon's checkpoint tick, not by
+      // orca-data.json). Pre-fix code would fail to find it; post-fix
+      // code re-derives the id from (worktreeId, tabId, leafId) and
+      // hits the same directory.
+      const dataFile = join(session.userDataDir, 'orca-data.json')
+      const data = JSON.parse(readFileSync(dataFile, 'utf-8')) as {
+        workspaceSession?: {
+          tabsByWorktree?: Record<string, { ptyId: string | null }[]>
+        }
+      }
+      const tabs = data.workspaceSession?.tabsByWorktree?.[worktreeId] ?? []
+      for (const tab of tabs) {
+        tab.ptyId = null
+      }
+      writeFileSync(dataFile, JSON.stringify(data))
+
+      // ── Second launch: deterministic path must recover scrollback ────
+      const secondLaunch = await session.launch()
+      secondApp = secondLaunch.app
+      await bootstrapRestoredLaunch(secondLaunch.page, worktreeId)
+
+      await expect
+        .poll(async () => (await getTerminalContent(secondLaunch.page)).includes(marker), {
+          timeout: 15_000,
+          message:
+            'Deterministic-sessionId restore did not recover scrollback when ptyId was missing'
+        })
+        .toBe(true)
     } finally {
       if (secondApp) {
         await session.close(secondApp)


### PR DESCRIPTION
## Summary

- Fixes: terminal scrollback lost on restart when the persisted `ptyId` didn't make it to disk before shutdown. The renderer now derives the sessionId from `(worktreeId, tabId, leafId)` via SHA-256, so cold-restore reaches the same `terminal-history/<encodedId>/` directory even when `orca-data.json`'s `ptyId` slot is empty. Closes the SIGKILL-between-spawn-and-persist race.
- Adds a startup orphan reaper with three stacked guards — keep set (deterministic re-derivation + verbatim ptyIds + remote session ids + live daemon ids), 30-day mtime grace, two-launch quarantine via `reaper-seen.json` sidecar. Safe by construction: a history dir whose owning pane still exists is never reaped, even after a transient keep-set miss.
- Bumps `PaneManager.nextPaneId` past `max(N)` in persisted `pane:N` leafIds on replay so post-restart splits don't mint a paneId that collides with an existing deterministic-history dir.

## Design

See `DESIGN_DOC_TERMINAL_HISTORY_FIX.md` (worktree-local) — Option B (deterministic sessionId) + separable reaper, approved.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm vitest run src/main/daemon src/renderer/src/components/terminal-pane/layout-serialization.test.ts` — 391 pass, 3 pre-existing `shell-ready.test.ts` failures unrelated to this PR (confirmed by stash test on HEAD before my changes)
- [x] New vitest coverage: `pty-session-id` (collision fixture, length-prefix boundary, fallback origins), `orphan-history-reaper` (keep-set / mtime / quarantine / edge-case matrix), `layout-serialization` (counter-advance via mock PaneManager)
- [x] E2E added: `tests/e2e/terminal-restart-persistence.spec.ts` — "scrollback survives quit with missing ptyId (Issue #217 regression)" — simulates the SIGKILL-before-persist race by mutating orca-data.json between two real Electron launches
- [x] Post-release monitoring: warn log on cold-restore-miss for explicit sessionId; reaper stats logged every startup
- [ ] Manual smoke: quit → relaunch → scrollback present (expected default-path behavior)
- [ ] Manual smoke: split 2 panes → quit → relaunch → both panes show their pre-quit scrollback

Made with [Orca](https://github.com/stablyai/orca) 🐋
