### PR TITLE
fix(sidebar): restore agent identity icon in inline worktree rows

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.tsx
@@ -154,11 +154,10 @@ const WorktreeCardAgentsBody = React.memo(function WorktreeCardAgentsBody({
                 // agent identity icon right next to it. 'sm' keeps the two
                 // distinguishable at a glance.
                 stateDotSize="sm"
-                // Why: in the per-card inline list the user already knows
-                // which worktree they're in, and clicking the row jumps
-                // directly to the agent — an expand chevron and a repeated
-                // identity glyph (Claude/Gemini/…) are redundant noise here.
-                hideIdentityIcon
+                // Why: in the per-card inline list clicking the row jumps
+                // directly to the agent, so the expand chevron is redundant.
+                // Keep the identity glyph (Claude/Gemini/…) so users can tell
+                // agents apart at a glance within a worktree.
                 hideExpand
               />
             </div>


### PR DESCRIPTION
## Summary
- Partially reverts #1359 — restore the per-agent identity glyph (Claude/Gemini/…) in the inline agent list on each worktree card. A worktree can host agents of different types, and the icon is the fastest way to tell them apart.
- Keeps `hideExpand` on the inline row — clicking the row jumps straight to the agent, so the chevron is still redundant.

## Test plan
- [x] Typecheck
- [ ] Visual: inline agent row now shows state dot + identity icon + prompt; no expand chevron

Made with [Orca](https://github.com/stablyai/orca) 🐋