### PR TITLE
fix(sidebar): preserve scroll position across worktree delete

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -76,6 +76,13 @@ type VirtualizedWorktreeViewportProps = {
   worktrees: Worktree[]
   repoMap: Map<string, Repo>
   prCache: Record<string, unknown> | null
+  // Why: the viewport remounts when the row structure changes (see
+  // viewportResetKey) so the virtualizer's measurementsCache cannot hold
+  // heights tied to shifted indices. A fresh virtualizer would otherwise
+  // start at scrollTop 0, which makes the sidebar snap to the top whenever
+  // a worktree is deleted. The parent persists the last observed scrollTop
+  // in a ref and seeds the new virtualizer via initialOffset.
+  scrollOffsetRef: React.MutableRefObject<number>
 }
 
 const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewport({
@@ -91,7 +98,8 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
   clearPendingRevealWorktreeId,
   worktrees,
   repoMap,
-  prCache
+  prCache,
+  scrollOffsetRef
 }: VirtualizedWorktreeViewportProps) {
   const scrollRef = useRef<HTMLDivElement>(null)
   const activeWorktreeRowIndex = useMemo(
@@ -105,6 +113,12 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
     estimateSize: () => 120,
     overscan: 10,
     gap: 6,
+    // Why: tells the virtualizer to start its internal scrollOffset at the
+    // ref value rather than 0, so the first getVirtualItems() call after
+    // remount picks the correct window of rows. The sibling useLayoutEffect
+    // mirrors this onto the actual scrollElement.scrollTop so the DOM and
+    // virtualizer stay aligned across remounts.
+    initialOffset: () => scrollOffsetRef.current,
     getItemKey: (index) => {
       const row = rows[index]
       if (!row) {
@@ -113,6 +127,51 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
       return row.type === 'header' ? `hdr:${row.key}` : `wt:${row.worktree.id}`
     }
   })
+
+  // Why: the viewport remounts when row structure changes (see
+  // viewportResetKey). The fresh DOM element starts at scrollTop=0, which
+  // snaps the sidebar back to the top every time a worktree is added or
+  // deleted. Restoring the last observed scrollTop from a ref before the
+  // browser paints keeps the user's scroll position stable across remounts.
+  //
+  // The saved offset is only captured via our scroll listener; we
+  // suppress saving during the initial restoration pass so that the
+  // browser's clamp-to-current-scrollHeight (temporarily smaller because
+  // the virtualizer has not yet measured every row) doesn't overwrite the
+  // user's intended offset with a clamped value.
+  useLayoutEffect(() => {
+    const el = scrollRef.current
+    if (!el) {
+      return
+    }
+    const targetOffset = scrollOffsetRef.current
+    let restoring = targetOffset > 0
+    if (restoring) {
+      el.scrollTop = targetOffset
+    }
+    const onScroll = (): void => {
+      if (restoring) {
+        // Virtualizer has not yet produced its final totalSize, so the
+        // browser may clamp our applied scrollTop to a lower value. Keep
+        // re-applying the target offset each tick until the DOM accepts
+        // it, then start recording user-driven scrolls.
+        if (el.scrollTop === targetOffset) {
+          restoring = false
+          return
+        }
+        if (el.scrollHeight - el.clientHeight >= targetOffset) {
+          el.scrollTop = targetOffset
+          if (el.scrollTop === targetOffset) {
+            restoring = false
+          }
+        }
+        return
+      }
+      scrollOffsetRef.current = el.scrollTop
+    }
+    el.addEventListener('scroll', onScroll, { passive: true })
+    return () => el.removeEventListener('scroll', onScroll)
+  }, [scrollOffsetRef])
 
   React.useEffect(() => {
     if (!pendingRevealWorktreeId) {
@@ -431,6 +490,9 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
 })
 
 const WorktreeList = React.memo(function WorktreeList() {
+  // Why: persists the sidebar scroll offset across the VirtualizedWorktreeViewport
+  // remount that row-structure changes trigger. See viewportResetKey.
+  const sidebarScrollOffsetRef = useRef(0)
   // ── Granular selectors (each is a primitive or shallow-stable ref) ──
   const allWorktrees = useAllWorktrees()
   const repoMap = useRepoMap()
@@ -670,6 +732,10 @@ const WorktreeList = React.memo(function WorktreeList() {
   // an item while its header is added — net row count unchanged). Including
   // the header keys ensures the virtualizer remounts when group structure
   // changes, preventing stale height measurements from causing overlap.
+  // We also key on rows.length so add/delete invalidates the virtualizer's
+  // per-index measurementsCache; scroll position is preserved across the
+  // remount via the ref below so deleting an off-screen worktree doesn't
+  // snap the sidebar back to the top.
   const viewportResetKey = useMemo(() => {
     const headers = rows
       .filter((r): r is GroupHeaderRow => r.type === 'header')
@@ -765,6 +831,7 @@ const WorktreeList = React.memo(function WorktreeList() {
       worktrees={worktrees}
       repoMap={repoMap}
       prCache={prCache}
+      scrollOffsetRef={sidebarScrollOffsetRef}
     />
   )
 })


### PR DESCRIPTION
## Summary
- Deleting an unselected, scrolled-past worktree made the sidebar snap back toward the selected item. The virtualizer's viewport key includes `rows.length` so it remounts cleanly on every add/delete (which avoids stale height caches causing card overlap), but the fresh DOM mount started at `scrollTop=0`.
- Persist the scroll offset in a parent-owned ref, seed the new virtualizer via `initialOffset`, and re-apply `scrollTop` in a `useLayoutEffect` with a retry loop that tolerates the transient window while the virtualizer is still measuring rows.

## Test plan
- [x] Scroll sidebar down, delete unselected worktree: scroll position unchanged, no overlap
- [x] Repeat 5x sequentially: starting scrollTop preserved exactly, 0 overlaps
- [x] Fresh reload: sidebar starts at scrollTop=0 as expected

Made with [Orca](https://github.com/stablyai/orca) 🐋
