### PR TITLE
fix(ui): shrink titlebar to 36px and align traffic lights

### DIFF
--- a/src/main/window/createMainWindow.test.ts
+++ b/src/main/window/createMainWindow.test.ts
@@ -494,7 +494,7 @@ describe('createMainWindow', () => {
     syncListener?.({} as never, 1.2)
 
     if (process.platform === 'darwin') {
-      expect(browserWindowInstance.setWindowButtonPosition).toHaveBeenCalledWith({ x: 16, y: 18 })
+      expect(browserWindowInstance.setWindowButtonPosition).toHaveBeenCalledWith({ x: 16, y: 16 })
       return
     }
 

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -31,11 +31,11 @@ function forceRepaint(window: BrowserWindow): void {
   }, 32)
 }
 
-// Why: the titlebar is 42px (border-box, 1px border-bottom).  The visual
-// center of the CSS-centered content sits at ~20 CSS px from the top.
-// At zoom factor z that becomes 20·z window px.  Traffic lights are
+// Why: the titlebar is 36px (border-box, 1px border-bottom).  The visual
+// center of the CSS-centered content sits at ~18 CSS px from the top.
+// At zoom factor z that becomes 18·z window px.  Traffic lights are
 // ~12px tall, so we position their top edge at (center − 6).
-const TITLEBAR_CSS_CENTER = 20
+const TITLEBAR_CSS_CENTER = 18
 const TRAFFIC_LIGHT_RADIUS = 6
 const TRAFFIC_LIGHT_X = 16
 const MIN_WIDTH = 600

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1048,7 +1048,7 @@ function App(): React.JSX.Element {
                 a few pixels, which reads as layout jitter. */}
             {workspaceActive && !rightSidebarOpen && (
               <div
-                className="absolute top-0 right-0 z-10 flex items-center h-[42px]"
+                className="absolute top-0 right-0 z-10 flex items-center h-[36px]"
                 style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
               >
                 {rightSidebarToggle}

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -361,17 +361,26 @@
 /* Why: workspace view still needs a full titlebar-height strip above the
    sidebar so the native macOS traffic lights and sidebar chrome sit in the
    same vertical band they use in settings/landing. The center and right
-   workspace columns are offset separately to align with this 42px baseline. */
+   workspace columns are offset separately to align with this 36px baseline
+   (4px drag strip + 32px tab row). */
 .titlebar-left {
-  height: 42px;
-  min-height: 42px;
+  height: 36px;
+  min-height: 36px;
   display: flex;
   flex-direction: row;
   align-items: center;
   overflow: hidden;
   flex-shrink: 0;
   background: var(--bg-titlebar, var(--card));
-  border-bottom: 1px solid var(--border);
+  /* Why: draw the divider via inset shadow instead of border-bottom so the
+     flex content area spans the full 36px. With border-bottom + border-box,
+     the content area shrinks to 35px and flex-centered controls land at
+     y=17.5, a half-pixel below the native traffic-light center at y=18
+     (set via setWindowButtonPosition in createMainWindow.ts). The shadow
+     paints the same 1px seam without stealing layout space, so the sidebar
+     toggle, agent badge, and back/forward arrows align pixel-perfectly
+     with the traffic lights. */
+  box-shadow: inset 0 -1px 0 var(--border);
   -webkit-app-region: drag;
   user-select: none;
 }
@@ -405,6 +414,11 @@
    .sidebar-toggle spacing stays unchanged for other titlebar icons. */
 .sidebar-toggle-compact {
   padding: 4px 5px;
+  color: var(--foreground);
+}
+
+.sidebar-toggle-compact:disabled {
+  color: var(--muted-foreground);
 }
 
 .sidebar-toggle:disabled {

--- a/src/renderer/src/components/right-sidebar/index.tsx
+++ b/src/renderer/src/components/right-sidebar/index.tsx
@@ -302,7 +302,7 @@ function RightSidebarInner(): React.JSX.Element {
           /* ── Top activity bar: horizontal icon row ── */
           <ContextMenu>
             <ContextMenuTrigger asChild>
-              <div className="flex items-center justify-between border-b border-border h-[42px] min-h-[42px] pl-2 pr-1">
+              <div className="flex items-center justify-between border-b border-border h-[36px] min-h-[36px] pl-2 pr-1">
                 <TooltipProvider delayDuration={400}>
                   <div className="flex items-center">{activityBarIcons}</div>
                   {closeButton}
@@ -316,7 +316,7 @@ function RightSidebarInner(): React.JSX.Element {
           </ContextMenu>
         ) : (
           /* ── Side layout: static title header ── */
-          <div className="flex items-center justify-between h-[42px] min-h-[42px] px-3 border-b border-border">
+          <div className="flex items-center justify-between h-[36px] min-h-[36px] px-3 border-b border-border">
             <span className="text-[11px] font-semibold uppercase tracking-wider text-foreground">
               {visibleItems.find((item) => item.id === effectiveTab)?.title ?? ''}
             </span>
@@ -409,7 +409,7 @@ function ActivityBarButton({
         <button
           className={cn(
             'relative flex items-center justify-center transition-colors',
-            isTop ? 'h-[42px] w-9' : 'w-10 h-10',
+            isTop ? 'h-[36px] w-9' : 'w-10 h-10',
             active ? 'text-foreground' : 'text-muted-foreground/60 hover:text-muted-foreground'
           )}
           onClick={onClick}

--- a/src/renderer/src/components/sidebar/SidebarNav.tsx
+++ b/src/renderer/src/components/sidebar/SidebarNav.tsx
@@ -75,11 +75,14 @@ const SidebarNav = React.memo(function SidebarNav() {
             'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] font-medium tracking-tight transition-colors',
             tasksActive
               ? 'bg-sidebar-accent text-sidebar-accent-foreground'
-              : 'text-sidebar-foreground hover:bg-sidebar-accent/60 hover:text-sidebar-accent-foreground',
+              : 'text-sidebar-foreground/60 hover:bg-sidebar-foreground/8',
             !canBrowseTasks && 'cursor-not-allowed opacity-50 hover:bg-transparent'
           )}
         >
-          <List className="size-4 shrink-0" strokeWidth={2.25} />
+          <List
+            className={cn('size-4 shrink-0', !tasksActive && 'text-sidebar-foreground/30')}
+            strokeWidth={tasksActive ? 2.25 : 1.75}
+          />
           <span className="flex-1">Tasks</span>
           <span className="flex items-center gap-1">
             <span
@@ -117,9 +120,9 @@ const SidebarNav = React.memo(function SidebarNav() {
         type="button"
         onClick={() => openModal('worktree-palette')}
         aria-label="Search worktrees and browser tabs"
-        className="group flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] font-medium tracking-tight text-sidebar-foreground transition-colors hover:bg-sidebar-accent/60 hover:text-sidebar-accent-foreground"
+        className="group flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] font-medium tracking-tight text-sidebar-foreground/60 transition-colors hover:bg-sidebar-foreground/8"
       >
-        <Search className="size-4 shrink-0" strokeWidth={2.25} />
+        <Search className="size-4 shrink-0 text-sidebar-foreground/30" strokeWidth={1.75} />
         <span className="flex-1">Search</span>
         <kbd className="hidden rounded border border-border/60 bg-background/40 px-1.5 py-px font-mono text-[10px] font-medium text-muted-foreground group-hover:inline-flex items-center">
           {isMac ? '⌘J' : 'Ctrl+Shift+J'}

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -336,7 +336,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
   const cardBody = (
     <div
       className={cn(
-        'group relative flex items-start gap-2.5 px-2 py-2 rounded-lg cursor-pointer transition-all duration-200 outline-none select-none ml-1',
+        'group relative flex items-start gap-1.5 px-2 py-2 rounded-lg cursor-pointer transition-all duration-200 outline-none select-none ml-1',
         isActive
           ? 'bg-black/[0.08] shadow-[0_1px_2px_rgba(0,0,0,0.04)] border border-black/[0.015] dark:bg-white/[0.10] dark:border-border/40 dark:shadow-[0_1px_2px_rgba(0,0,0,0.03)]'
           : 'border border-transparent hover:bg-accent/40',

--- a/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
@@ -223,9 +223,11 @@ export default function TabGroupSplitLayout({
           window-drag region at the top. Only the split layout's own panes
           own the resize handles, while this strip keeps the whole top of the
           center column draggable regardless of how the splits are arranged.
-          Why 10px specifically: pairs with the 32px tab row below so the
-          total top-band is 42px, matching the sibling `titlebar-left` above
-          the sidebar. Without this, the tab row's bottom border falls short
+          Why 4px specifically: pairs with the 32px tab row below so the
+          total top-band is 36px, matching the sibling `titlebar-left` above
+          the sidebar. Keep this small — it's just enough drag surface above
+          the tabs without opening a visible gap between the window top and
+          the tab chrome. Without this, the tab row's bottom border falls short
           of the sidebar header's and the seam between columns reads as off.
           Why `border-l` on the wrapper: paint the single full-height divider
           between the left sidebar and the terminal area, regardless of split
@@ -234,7 +236,7 @@ export default function TabGroupSplitLayout({
           both painted and stacked into a 2px bar below the drag strip. */}
       <div className="flex flex-col flex-1 min-w-0 min-h-0 overflow-hidden border-l border-border">
         <div
-          className="h-[10px] shrink-0 bg-card"
+          className="h-[4px] shrink-0 bg-card"
           style={{ WebkitAppRegion: 'drag' } as React.CSSProperties}
         />
         <div className="flex flex-1 min-w-0 min-h-0 overflow-hidden">


### PR DESCRIPTION
## Summary
- Shrinks the titlebar strip from 42px to 36px (4px drag + 32px tab row) and aligns native macOS traffic lights to the new visual center (y=18).
- Replaces `border-bottom` on `.titlebar-left` with an inset box-shadow so the flex content spans the full 36px and sidebar toggle / agent badge / back-forward arrows align pixel-perfectly with the traffic lights.
- Softens sidebar nav (Tasks / Search) idle contrast, adds explicit color for `.sidebar-toggle-compact` enabled/disabled, and tightens `WorktreeCard` gap.

## Test plan
- [ ] Launch on macOS; confirm traffic lights vertically centered in titlebar at 1x, 1.25x, 1.5x zoom.
- [ ] Verify no 1px seam or jitter between titlebar-left and tab row.
- [ ] Right sidebar collapsed/expanded header still reads correctly at 36px.
- [ ] Sidebar Tasks/Search have correct idle, hover, and active states.

Made with [Orca](https://github.com/stablyai/orca) 🐋
