### PR TITLE
fix(cmd-j): rank empty-query worktrees by focus recency

### DIFF
--- a/docs/cmd-j-empty-query-ordering.md
+++ b/docs/cmd-j-empty-query-ordering.md
@@ -1,0 +1,222 @@
+# Cmd+J empty-query ordering: use visit recency, not activity recency
+
+## Problem
+
+When Cmd+J opens with no query, the `sortedWorktrees` memo in
+`WorktreeJumpPalette.tsx` orders the Worktrees section by
+`Worktree.lastActivityAt` before the empty-query cap is applied. The cap is
+conditional: with browser tabs present, Worktrees is capped at 5 so browser
+rows stay visible above the fold (see the `__hint_worktree_cap__` branch in
+the same file); with no browser tabs, the list is uncapped.
+
+For worktrees with low background signal — notably SSH-backed worktrees —
+`lastActivityAt` can remain old even when the user was just working there.
+Those worktrees get pushed below the visible empty-query rows by local
+worktrees that emitted incidental PTY/activity events. The user then has to
+type a substring to surface the worktree they just visited, which defeats
+the purpose of the empty-query switcher.
+
+Reported symptom: an SSH worktree the user was working in minutes ago does
+not appear in the visible Cmd+J empty-query list; typing any substring
+surfaces it.
+
+## Product model
+
+Cmd+J with an empty query is a fast switcher. It should answer: "where am I
+likely to jump next?"
+
+That is different from both existing recency signals:
+
+- `lastActivityAt` answers "where did work happen?" Right for activity-aware
+  surfaces, wrong for SSH or quiet worktrees where user focus is not
+  accompanied by local PTY/activity signals.
+- `worktreeNavHistory` (see `recordWorktreeVisit` in the
+  `worktree-nav-history` slice) answers "what is the Back/Forward stack?"
+  That stack has index, forward-history, duplicate, and `'tasks'` semantics
+  that are useful for sequential navigation but unrelated to switcher
+  ranking.
+
+The switcher needs its own persisted focus-recency signal. This doc uses
+"focus recency" throughout.
+
+## Proposal
+
+Persist a per-worktree focus-recency timestamp and use it as the primary
+ordering signal for Cmd+J's empty-query Worktrees section.
+
+Store shape, added to `src/renderer/src/store/slices/worktrees.ts` (the
+slice that already owns `activeWorktreeId` and is the natural home for
+per-worktree UI recency):
+
+```ts
+lastVisitedAtByWorktreeId: Record<string, number>
+markWorktreeVisited: (worktreeId: string, visitedAt?: number) => void
+```
+
+`markWorktreeVisited` must be monotonic: if the supplied (or current)
+timestamp is not strictly greater than the stored value, it is a no-op. This
+matters because CLI-driven and IPC-driven activations can race, and we do
+not want an older timestamp to regress recency.
+
+### Stamp site
+
+Stamp from `activateAndRevealWorktree` (`src/renderer/src/lib/worktree-activation.ts`),
+**immediately after the `state.setActiveWorktree(worktreeId)` call at
+line 91**, synchronously, before any of the later view/terminal/reveal
+steps. This guarantees the stamp lands even if a subsequent async step
+fails, since the user already perceives the switch as successful once
+`activeWorktreeId` flips.
+
+Do this *in addition to*, not gated on, the existing
+`state.recordWorktreeVisit(worktreeId)` call; the nav-history slice has
+different semantics (see "Why not use `worktreeNavHistory`").
+
+Do **not** stamp from `setActiveWorktree` directly. That raw setter is
+invoked by hydration, session restore, and test setup — stamping there
+would reset focus recency for the restored workspace on every app launch.
+
+### Activation-path audit
+
+Every user-initiated worktree switch must route through
+`activateAndRevealWorktree`. Before landing, audit direct callers of
+`setActiveWorktree` and classify each:
+
+- **User switches** (sidebar clicks, Cmd+J selections, CLI activations,
+  status-bar/session jumps, deep links) — must go through activation.
+- **Non-user transitions** (store hydration, session restore, tests) — must
+  NOT stamp.
+
+The audit output belongs in the PR description. Do not stamp
+`Worktree.lastActivityAt`.
+
+### Ordering rule (empty query only)
+
+1. Start from visible worktrees: skip `isArchived`, and keep honoring
+   `hideDefaultBranchWorkspace` via `isDefaultBranchWorkspace`.
+2. Build a separate `switchableWorktrees` list that excludes the currently
+   active worktree. Keep the full visible list for loading/empty-state/count
+   logic so the palette never claims there are no worktrees just because the
+   only visible worktree is current.
+3. Sort `switchableWorktrees` by:
+   - `lastVisitedAtByWorktreeId[id]` descending, when present.
+   - `lastActivityAt` descending as the fallback for never-visited or
+     pre-migration worktrees.
+   - `displayName.localeCompare` as the final stable tie-breaker.
+4. Preserve the conditional cap: cap Worktrees at 5 only when browser rows
+   exist (the existing `__hint_worktree_cap__` logic); otherwise leave the
+   Worktrees section uncapped.
+5. Preserve the existing "Type to see all N worktrees" hint, but compute `N`
+   from switchable rows. Empty-state copy is based on the full visible list.
+
+Typing any non-empty query still routes through `sortWorktreesSmart`. No
+change to the sidebar, `sortEpoch`, or `lastActivityAt` semantics.
+
+### Current worktree handling
+
+Cmd+J is a switch surface. Exclude the current worktree from empty-query
+rows in v1. Keep two separate lists so empty-state logic is not affected:
+
+- `visibleWorktreesForState`: includes the current worktree and drives
+  "loading", "has any worktrees", and empty-state decisions.
+- `switchableWorktreesForRows`: excludes the current worktree and drives the
+  actual empty-query Worktrees rows.
+
+A "Current" row variant is out of scope.
+
+## Why not use `worktreeNavHistory`
+
+`worktreeNavHistory` records activations but is the wrong abstraction for
+Cmd+J ordering.
+
+- Back/Forward history is an indexed stack. Cmd+J is an unordered switcher
+  ranked by likely target.
+- History contains `'tasks'` entries; Cmd+J rows should not need to
+  understand task-page sentinels.
+- Back/Forward navigation can leave forward entries in the stack. A raw
+  newest-to-oldest walk either incorrectly includes future entries or needs
+  custom interpretation of `worktreeNavHistoryIndex`.
+- History dedupe rules are stack-oriented. A per-worktree timestamp is
+  simpler and directly models the switcher need.
+
+Keep `worktreeNavHistory` for Back/Forward.
+
+## Migration and persistence
+
+Persist `lastVisitedAtByWorktreeId` via the same zustand persist path that
+survives app restart.
+
+- **Downgrade:** older builds will drop the unknown key on rehydrate
+  (zustand `partialize` strips anything the slice doesn't declare). No
+  custom migration needed; record this explicitly in the PR so nobody
+  invents one.
+- **Pruning:** drop entries whose worktree IDs are no longer present —
+  **after worktree hydration completes**, not on raw rehydrate. Repos load
+  async; pruning too early would nuke timestamps for worktrees whose repo
+  hasn't yet hydrated.
+- **Seeding active on restore:** if, after hydration, the active worktree
+  has no stored timestamp, seed it with the current time from the
+  hydration-complete handler — not by calling `markWorktreeVisited` from
+  `setActiveWorktree`. The two paths have intentionally different
+  semantics (seeding is a migration fixup; stamping is focus recency).
+- Never-visited worktrees stay without timestamps and fall back to
+  `lastActivityAt`.
+
+The map is bounded by live worktree IDs, so no history cap is needed.
+
+## Non-goals
+
+- Changing sidebar sort order.
+- Changing `lastActivityAt` semantics or when it is stamped.
+- Changing the typed-query path; smart-sort remains authoritative.
+- Making Cmd+J mirror Back/Forward history.
+- Persisting Cmd+J UI state such as query, scroll position, or selection.
+- Adding a "Current" row variant.
+
+## Implementation sketch
+
+- Add `lastVisitedAtByWorktreeId` and `markWorktreeVisited` to the
+  `worktrees` slice; persist via the existing persist config.
+- In `activateAndRevealWorktree`, call `markWorktreeVisited(worktreeId)`
+  immediately after `state.setActiveWorktree(worktreeId)` (line 91),
+  synchronously. Focus recency, not work activity.
+- Update the `sortedWorktrees` memo in `WorktreeJumpPalette.tsx` so the
+  empty-query branch uses subscribed store inputs:
+  `lastVisitedAtByWorktreeId`, `activeWorktreeId`, visible worktrees, and
+  existing palette filters. Avoid reading `useAppStore.getState()` inside a
+  memo as the only source of ordering data; that can produce stale UI.
+- Keep the typed-query branch on `sortWorktreesSmart`.
+- Keep browser-tab search ordering unchanged unless a separate browser
+  visit-recency issue is discovered.
+- Extract a pure function `orderEmptyQueryWorktrees` so ordering,
+  current-worktree exclusion, and fallback behavior are testable without
+  mounting the whole palette.
+
+## Tests
+
+Add focused tests for the ordering helper:
+
+- Recently visited SSH/quiet worktree ranks above a locally active worktree
+  with newer `lastActivityAt`.
+- Never-visited worktrees fall back to `lastActivityAt`.
+- Current worktree is excluded from empty-query rows but still counted for
+  empty-state logic.
+- Worktrees cap remains conditional on browser rows.
+- `hideDefaultBranchWorkspace` and `isArchived` still filter rows.
+- Non-empty query still uses `sortWorktreesSmart` order.
+- Hydration seeds the active worktree's timestamp when missing.
+- `markWorktreeVisited` is monotonic: an older timestamp does not regress
+  the stored value.
+
+Do not put these tests in `worktree-palette-search.test.ts` unless the pure
+search function itself changes. That file verifies matching behavior and
+input order preservation, not empty-query ranking.
+
+## Risks
+
+- **Activation paths that bypass `activateAndRevealWorktree`.** Any
+  user-visible switch that calls `setActiveWorktree` directly will skip the
+  stamp. Mitigation: the activation-path audit above.
+- **False empty states after current-worktree exclusion.** Mitigation:
+  separate `visibleWorktreesForState` and `switchableWorktreesForRows`.
+- **Pruning before hydration.** Mitigation: prune in the
+  hydration-complete handler, not on raw rehydrate.

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -105,7 +105,9 @@ function App(): React.JSX.Element {
       toggleRightSidebar: s.toggleRightSidebar,
       setRightSidebarOpen: s.setRightSidebarOpen,
       setRightSidebarTab: s.setRightSidebarTab,
-      updateSettings: s.updateSettings
+      updateSettings: s.updateSettings,
+      pruneLastVisitedTimestamps: s.pruneLastVisitedTimestamps,
+      seedActiveWorktreeLastVisitedIfMissing: s.seedActiveWorktreeLastVisitedIfMissing
     }))
   )
 
@@ -232,6 +234,16 @@ function App(): React.JSX.Element {
           actions.hydrateTabsSession(session)
           actions.hydrateEditorSession(session)
           actions.hydrateBrowserSession(session)
+          // Why: prune lastVisitedAtByWorktreeId entries whose worktrees
+          // no longer exist. Must run AFTER hydration — before this point,
+          // async repo loads may not have populated worktreesByRepo yet and
+          // pruning would delete timestamps for worktrees that are about to
+          // appear. Seed the restored active worktree's timestamp if missing
+          // so users upgrading from a pre-feature build don't see the active
+          // worktree sink in the empty-query list.
+          // See docs/cmd-j-empty-query-ordering.md.
+          actions.pruneLastVisitedTimestamps()
+          actions.seedActiveWorktreeLastVisitedIfMissing()
           await actions.fetchBrowserSessionProfiles()
 
           // Why: SSH connections must be re-established BEFORE terminal

--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -17,6 +17,7 @@ import { getLinkedWorkItemSuggestedName } from '@/lib/new-workspace'
 import type { LinkedWorkItemSummary } from '@/lib/new-workspace'
 import { sortWorktreesSmart } from '@/components/sidebar/smart-sort'
 import { isDefaultBranchWorkspace } from '@/components/sidebar/visible-worktrees'
+import { orderEmptyQueryWorktrees } from '@/lib/order-empty-query-worktrees'
 import StatusIndicator from '@/components/sidebar/StatusIndicator'
 import { cn } from '@/lib/utils'
 import { getWorktreeStatus, getWorktreeStatusLabel } from '@/lib/worktree-status'
@@ -159,6 +160,7 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
   const browserPagesByWorkspace = useAppStore((s) => s.browserPagesByWorkspace)
   const sshConnectionStates = useAppStore((s) => s.sshConnectionStates)
   const hideDefaultBranchWorkspace = useAppStore((s) => s.hideDefaultBranchWorkspace)
+  const lastVisitedAtByWorktreeId = useAppStore((s) => s.lastVisitedAtByWorktreeId)
 
   const [query, setQuery] = useState('')
   const deferredQuery = useDeferredValue(query)
@@ -177,37 +179,55 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
 
   const hasQuery = deferredQuery.trim().length > 0
 
-  const sortedWorktrees = useMemo(() => {
-    const visibleWorktrees = allWorktrees.filter((worktree) => {
-      if (worktree.isArchived) {
-        return false
-      }
-      // Why: keep the jump palette aligned with the sidebar. If the user
-      // opted to hide the default-branch workspace, surfacing it here via
-      // Cmd+J would reintroduce the entry they asked to remove.
-      // Drift warning: this check must stay in lockstep with the sidebar's
-      // filter in computeVisibleWorktreeIds (visible-worktrees.ts). Both
-      // surfaces share isDefaultBranchWorkspace so the predicate can't drift,
-      // but adding a new filter axis (e.g. a second toggle) here would need
-      // the matching change in the sidebar pipeline — otherwise Cmd+J and
-      // the sidebar will show different lists.
-      if (hideDefaultBranchWorkspace && isDefaultBranchWorkspace(worktree)) {
-        return false
-      }
-      return true
-    })
-    // Why: on empty query, show pure recency (matches sidebar's 'recent' sort
-    // rationale in smart-sort.ts) so Cmd+J is a predictable "jump back to what
-    // I was just on" surface. Typing swaps in smart-sort to rank matches.
-    // Deps over-include on the empty-query branch; acceptable since they
-    // change infrequently and branching the memo isn't worth it.
-    return hasQuery
-      ? sortWorktreesSmart(visibleWorktrees, tabsByWorktree, repoMap, prCache)
-      : [...visibleWorktrees].sort(
-          (a, b) =>
-            b.lastActivityAt - a.lastActivityAt || a.displayName.localeCompare(b.displayName)
-        )
-  }, [allWorktrees, tabsByWorktree, repoMap, prCache, hasQuery, hideDefaultBranchWorkspace])
+  // Why: keep the jump palette aligned with the sidebar. If the user
+  // opted to hide the default-branch workspace, surfacing it here via
+  // Cmd+J would reintroduce the entry they asked to remove.
+  // Drift warning: this check must stay in lockstep with the sidebar's
+  // filter in computeVisibleWorktreeIds (visible-worktrees.ts). Both
+  // surfaces share isDefaultBranchWorkspace so the predicate can't drift,
+  // but adding a new filter axis (e.g. a second toggle) here would need
+  // the matching change in the sidebar pipeline — otherwise Cmd+J and
+  // the sidebar will show different lists.
+  const visibleWorktrees = useMemo(
+    () =>
+      allWorktrees.filter((worktree) => {
+        if (worktree.isArchived) {
+          return false
+        }
+        if (hideDefaultBranchWorkspace && isDefaultBranchWorkspace(worktree)) {
+          return false
+        }
+        return true
+      }),
+    [allWorktrees, hideDefaultBranchWorkspace]
+  )
+
+  // Why: empty-query rows use focus-recency (lastVisitedAtByWorktreeId) with
+  // lastActivityAt fallback so SSH / quiet worktrees don't get pushed below
+  // the fold by noisy local worktrees. Current worktree is excluded from the
+  // empty-query rows per product model (Cmd+J is a switch surface, not a
+  // "show me everything" surface), but kept in visibleWorktreesForState so
+  // empty-state/loading logic remains unaffected.
+  // See docs/cmd-j-empty-query-ordering.md.
+  const { visibleWorktreesForState, switchableWorktreesForRows } = useMemo(
+    () =>
+      orderEmptyQueryWorktrees({
+        visibleWorktrees,
+        activeWorktreeId,
+        lastVisitedAtByWorktreeId
+      }),
+    [visibleWorktrees, activeWorktreeId, lastVisitedAtByWorktreeId]
+  )
+
+  // Why: typed queries still route through sortWorktreesSmart — switcher
+  // ranking only diverges from smart-sort on the empty-query branch.
+  const sortedWorktrees = useMemo(
+    () =>
+      hasQuery
+        ? sortWorktreesSmart(visibleWorktrees, tabsByWorktree, repoMap, prCache)
+        : switchableWorktreesForRows,
+    [hasQuery, visibleWorktrees, switchableWorktreesForRows, tabsByWorktree, repoMap, prCache]
+  )
 
   const browserSortedWorktrees = useMemo(() => {
     // Why: browser-tab search is explicitly cross-worktree, so it must keep
@@ -387,7 +407,11 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
     canCreateWorktree && createWorktreeName.length > 0 && worktreeItems.length === 0
 
   const isLoading = repos.length > 0 && Object.keys(worktreesByRepo).length === 0
-  const hasAnyWorktrees = sortedWorktrees.length > 0
+  // Why: empty-state / "has any worktrees?" uses the full visible list
+  // (including current) so the palette never claims to be empty just
+  // because the only visible worktree is the currently active one.
+  // See docs/cmd-j-empty-query-ordering.md.
+  const hasAnyWorktrees = visibleWorktreesForState.length > 0
   const hasAnyBrowserPages = browserPageEntries.length > 0
 
   useEffect(() => {
@@ -710,6 +734,16 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
       return {
         title: 'No results match your search',
         subtitle: 'Try a name, branch, repo, comment, PR, page title, or URL.'
+      }
+    }
+    // Why: empty-query rows exclude the current worktree, so a single-worktree
+    // setup has hasAnyWorktrees=true but zero switchable rows. Without this
+    // branch the palette would claim "No active worktrees" while one is open
+    // — misleading. See docs/cmd-j-empty-query-ordering.md.
+    if (!hasQuery && hasAnyWorktrees && !hasAnyBrowserPages) {
+      return {
+        title: 'No other worktrees to switch to',
+        subtitle: 'Type to search or create a new worktree.'
       }
     }
     return {

--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.tsx
@@ -54,6 +54,7 @@ const WorktreeCardAgentsBody = React.memo(function WorktreeCardAgentsBody({
   const setActiveTab = useAppStore((s) => s.setActiveTab)
   const setActiveView = useAppStore((s) => s.setActiveView)
   const acknowledgeAgents = useAppStore((s) => s.acknowledgeAgents)
+  const markWorktreeVisited = useAppStore((s) => s.markWorktreeVisited)
 
   // Why: per-worktree collapse is session-only UI state. Single-primitive
   // subscription so the card only re-renders when THIS worktree's collapsed
@@ -89,13 +90,23 @@ const WorktreeCardAgentsBody = React.memo(function WorktreeCardAgentsBody({
     (tabId: string, paneKey: string) => {
       acknowledgeAgents([paneKey])
       setActiveWorktree(worktreeId)
+      // Why: sidebar agent-tab click is a user-initiated switch; stamp focus
+      // recency for Cmd+J. See docs/cmd-j-empty-query-ordering.md.
+      markWorktreeVisited(worktreeId)
       setActiveView('terminal')
       const tabs = useAppStore.getState().tabsByWorktree[worktreeId] ?? []
       if (tabs.some((t) => t.id === tabId)) {
         setActiveTab(tabId)
       }
     },
-    [worktreeId, setActiveWorktree, setActiveTab, setActiveView, acknowledgeAgents]
+    [
+      worktreeId,
+      setActiveWorktree,
+      setActiveTab,
+      setActiveView,
+      acknowledgeAgents,
+      markWorktreeVisited
+    ]
   )
 
   const handleToggleCollapsed = useCallback(

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -460,6 +460,7 @@ describe('useIpcEvents updater integration', () => {
           createTab,
           setActiveView,
           setActiveWorktree,
+          markWorktreeVisited: vi.fn(),
           setActiveTabType,
           setActiveTab,
           revealWorktreeInSidebar,

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -214,6 +214,11 @@ export function useIpcEvents(): void {
         const store = useAppStore.getState()
         store.setActiveView('terminal')
         store.setActiveWorktree(worktreeId)
+        // Why: CLI-driven terminal creation is a user-initiated worktree switch
+        // and must stamp focus recency for Cmd+J. Doesn't route through
+        // activateAndRevealWorktree because it has custom terminal-creation
+        // logic; see docs/cmd-j-empty-query-ordering.md.
+        store.markWorktreeVisited(worktreeId)
         const tab = store.createTab(worktreeId)
         store.setActiveTabType('terminal')
         store.setActiveTab(tab.id)
@@ -244,6 +249,9 @@ export function useIpcEvents(): void {
           }
           store.setActiveView('terminal')
           store.setActiveWorktree(worktreeId)
+          // Why: CLI-driven terminal-create request is user-initiated; stamp
+          // focus recency for Cmd+J. See docs/cmd-j-empty-query-ordering.md.
+          store.markWorktreeVisited(worktreeId)
           const tab = store.createTab(worktreeId)
           store.setActiveTabType('terminal')
           store.setActiveTab(tab.id)
@@ -285,6 +293,9 @@ export function useIpcEvents(): void {
       window.api.ui.onFocusTerminal(({ tabId, worktreeId }) => {
         const store = useAppStore.getState()
         store.setActiveWorktree(worktreeId)
+        // Why: CLI-driven focus is a user-initiated switch; stamp focus
+        // recency for Cmd+J. See docs/cmd-j-empty-query-ordering.md.
+        store.markWorktreeVisited(worktreeId)
         store.setActiveView('terminal')
         store.setActiveTab(tabId)
         store.revealWorktreeInSidebar(worktreeId)

--- a/src/renderer/src/lib/order-empty-query-worktrees.test.ts
+++ b/src/renderer/src/lib/order-empty-query-worktrees.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest'
+import type { Worktree } from '../../../shared/types'
+import { orderEmptyQueryWorktrees } from './order-empty-query-worktrees'
+
+function wt(overrides: Partial<Worktree> & { id: string; displayName: string }): Worktree {
+  return {
+    repoId: 'repo-1',
+    path: `/tmp/${overrides.id}`,
+    head: 'abc',
+    branch: `refs/heads/${overrides.id}`,
+    isBare: false,
+    isMainWorktree: false,
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0,
+    ...overrides
+  }
+}
+
+describe('orderEmptyQueryWorktrees', () => {
+  it('ranks a recently visited (quiet) worktree above a noisy never-visited one', () => {
+    // Why: the core bug — an SSH worktree the user just visited must outrank
+    // a locally noisy worktree even when the latter has a newer lastActivityAt.
+    const ssh = wt({ id: 'ssh', displayName: 'ssh', lastActivityAt: 1_000 })
+    const local = wt({ id: 'local', displayName: 'local', lastActivityAt: 9_999 })
+    const result = orderEmptyQueryWorktrees({
+      visibleWorktrees: [local, ssh],
+      activeWorktreeId: null,
+      lastVisitedAtByWorktreeId: { ssh: 500 }
+    })
+    expect(result.switchableWorktreesForRows.map((w) => w.id)).toEqual(['ssh', 'local'])
+  })
+
+  it('sorts visited worktrees by lastVisitedAt descending', () => {
+    const a = wt({ id: 'a', displayName: 'a' })
+    const b = wt({ id: 'b', displayName: 'b' })
+    const result = orderEmptyQueryWorktrees({
+      visibleWorktrees: [a, b],
+      activeWorktreeId: null,
+      lastVisitedAtByWorktreeId: { a: 100, b: 200 }
+    })
+    expect(result.switchableWorktreesForRows.map((w) => w.id)).toEqual(['b', 'a'])
+  })
+
+  it('falls back to lastActivityAt for never-visited worktrees', () => {
+    const a = wt({ id: 'a', displayName: 'a', lastActivityAt: 100 })
+    const b = wt({ id: 'b', displayName: 'b', lastActivityAt: 200 })
+    const result = orderEmptyQueryWorktrees({
+      visibleWorktrees: [a, b],
+      activeWorktreeId: null,
+      lastVisitedAtByWorktreeId: {}
+    })
+    expect(result.switchableWorktreesForRows.map((w) => w.id)).toEqual(['b', 'a'])
+  })
+
+  it('uses displayName as final tie-breaker', () => {
+    const a = wt({ id: 'a', displayName: 'apple', lastActivityAt: 100 })
+    const b = wt({ id: 'b', displayName: 'banana', lastActivityAt: 100 })
+    const result = orderEmptyQueryWorktrees({
+      visibleWorktrees: [b, a],
+      activeWorktreeId: null,
+      lastVisitedAtByWorktreeId: {}
+    })
+    expect(result.switchableWorktreesForRows.map((w) => w.id)).toEqual(['a', 'b'])
+  })
+
+  it('excludes current worktree from rows but includes it in state list', () => {
+    const cur = wt({ id: 'cur', displayName: 'cur' })
+    const other = wt({ id: 'other', displayName: 'other' })
+    const result = orderEmptyQueryWorktrees({
+      visibleWorktrees: [cur, other],
+      activeWorktreeId: 'cur',
+      lastVisitedAtByWorktreeId: {}
+    })
+    expect(result.switchableWorktreesForRows.map((w) => w.id)).toEqual(['other'])
+    expect(result.visibleWorktreesForState.map((w) => w.id)).toEqual(['cur', 'other'])
+  })
+
+  it('returns empty rows but non-empty state when only the current worktree is visible', () => {
+    const cur = wt({ id: 'cur', displayName: 'cur' })
+    const result = orderEmptyQueryWorktrees({
+      visibleWorktrees: [cur],
+      activeWorktreeId: 'cur',
+      lastVisitedAtByWorktreeId: {}
+    })
+    expect(result.switchableWorktreesForRows).toEqual([])
+    expect(result.visibleWorktreesForState).toHaveLength(1)
+  })
+})

--- a/src/renderer/src/lib/order-empty-query-worktrees.ts
+++ b/src/renderer/src/lib/order-empty-query-worktrees.ts
@@ -1,0 +1,59 @@
+import type { Worktree } from '../../../shared/types'
+
+export type OrderEmptyQueryInputs = {
+  visibleWorktrees: readonly Worktree[]
+  activeWorktreeId: string | null
+  lastVisitedAtByWorktreeId: Record<string, number>
+}
+
+export type OrderEmptyQueryResult = {
+  /** Full visible list (including current). Drives "has any worktrees"
+   *  / loading / empty-state decisions so the palette never claims to be
+   *  empty just because the only visible worktree is the current one. */
+  visibleWorktreesForState: readonly Worktree[]
+  /** Switchable rows for the Worktrees section — current worktree excluded,
+   *  sorted by focus-recency with lastActivityAt fallback and displayName
+   *  tie-breaker. v1 has no "Current" row variant. */
+  switchableWorktreesForRows: Worktree[]
+}
+
+/**
+ * Pure ordering helper for Cmd+J's empty-query Worktrees section.
+ * See docs/cmd-j-empty-query-ordering.md — this function encodes the
+ * ordering-rule block:
+ *   1. primary: lastVisitedAtByWorktreeId[id] (focus recency)
+ *   2. fallback: Worktree.lastActivityAt (for never-visited / pre-migration)
+ *   3. stable tie-breaker: displayName.localeCompare
+ * The current worktree is intentionally excluded from rows but kept in
+ * visibleWorktreesForState so empty-state logic isn't affected.
+ */
+export function orderEmptyQueryWorktrees(inputs: OrderEmptyQueryInputs): OrderEmptyQueryResult {
+  const { visibleWorktrees, activeWorktreeId, lastVisitedAtByWorktreeId } = inputs
+  const switchable = visibleWorktrees.filter((w) => w.id !== activeWorktreeId)
+  // Why: a visited worktree must always outrank a never-visited one,
+  // even when the never-visited worktree has a newer lastActivityAt.
+  // Mixing the two signals into a single numeric score would let
+  // incidental background activity on a local worktree push a just-
+  // visited SSH worktree below the fold — the exact bug the feature
+  // fixes. Compare presence first, then value within each tier.
+  const sorted = [...switchable].sort((a, b) => {
+    const aVisited = lastVisitedAtByWorktreeId[a.id]
+    const bVisited = lastVisitedAtByWorktreeId[b.id]
+    if (aVisited != null && bVisited != null) {
+      if (bVisited !== aVisited) {
+        return bVisited - aVisited
+      }
+    } else if (aVisited != null) {
+      return -1
+    } else if (bVisited != null) {
+      return 1
+    } else if (b.lastActivityAt !== a.lastActivityAt) {
+      return b.lastActivityAt - a.lastActivityAt
+    }
+    return a.displayName.localeCompare(b.displayName)
+  })
+  return {
+    visibleWorktreesForState: visibleWorktrees,
+    switchableWorktreesForRows: sorted
+  }
+}

--- a/src/renderer/src/lib/workspace-session.ts
+++ b/src/renderer/src/lib/workspace-session.ts
@@ -223,6 +223,7 @@ export function buildWorkspaceSessionPayload(
     // anything don't bloat the payload. See
     // docs/cmd-j-empty-query-ordering.md.
     lastVisitedAtByWorktreeId:
+      snapshot.lastVisitedAtByWorktreeId &&
       Object.keys(snapshot.lastVisitedAtByWorktreeId).length > 0
         ? snapshot.lastVisitedAtByWorktreeId
         : undefined

--- a/src/renderer/src/lib/workspace-session.ts
+++ b/src/renderer/src/lib/workspace-session.ts
@@ -31,6 +31,7 @@ type WorkspaceSessionSnapshot = Pick<
   | 'repos'
   | 'worktreesByRepo'
   | 'lastKnownRelayPtyIdByTabId'
+  | 'lastVisitedAtByWorktreeId'
 >
 
 /** Build the editor-file portion of the workspace session for persistence.
@@ -216,6 +217,14 @@ export function buildWorkspaceSessionPayload(
     activeGroupIdByWorktree: snapshot.activeGroupIdByWorktree,
     activeConnectionIdsAtShutdown: connectedTargetIds.length > 0 ? connectedTargetIds : undefined,
     remoteSessionIdsByTabId:
-      Object.keys(remoteSessionIdsByTabId).length > 0 ? remoteSessionIdsByTabId : undefined
+      Object.keys(remoteSessionIdsByTabId).length > 0 ? remoteSessionIdsByTabId : undefined,
+    // Why: per-worktree focus-recency for Cmd+J's empty-query ordering.
+    // Omit when empty so sessions written by builds that never stamped
+    // anything don't bloat the payload. See
+    // docs/cmd-j-empty-query-ordering.md.
+    lastVisitedAtByWorktreeId:
+      Object.keys(snapshot.lastVisitedAtByWorktreeId).length > 0
+        ? snapshot.lastVisitedAtByWorktreeId
+        : undefined
   }
 }

--- a/src/renderer/src/lib/worktree-activation.ts
+++ b/src/renderer/src/lib/worktree-activation.ts
@@ -90,6 +90,14 @@ export function activateAndRevealWorktree(
   // clears unread, bumps dead PTY generations, triggers GitHub refresh
   state.setActiveWorktree(worktreeId)
 
+  // Why: record focus recency for Cmd+J's empty-query ordering BEFORE any
+  // later async step (initial terminal / reveal) could throw — the user
+  // already perceives the switch as successful the instant activeWorktreeId
+  // flips, so the recency stamp must land with the same guarantee. Separate
+  // from recordWorktreeVisit (nav-history) and from worktree.lastActivityAt
+  // (background signal) on purpose — see docs/cmd-j-empty-query-ordering.md.
+  state.markWorktreeVisited(worktreeId)
+
   // Why: activateAndRevealWorktree always ends in 'terminal' view (step 2),
   // and Settings/Tasks transitions do not pass through this function, so no
   // view-guard is needed here. The guard skips re-recording when the caller

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -1510,6 +1510,11 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         activeTabIdByWorktree,
         tabsByWorktree,
         worktreesByRepo,
+        // Why: restore the per-worktree focus-recency map. Pruning of stale
+        // entries happens later (App.tsx calls pruneLastVisitedTimestamps
+        // after hydration) — not here — because SSH worktrees may still be
+        // appearing in worktreesByRepo at this moment.
+        lastVisitedAtByWorktreeId: session.lastVisitedAtByWorktreeId ?? {},
         pendingReconnectWorktreeIds,
         pendingReconnectTabByWorktree,
         pendingReconnectPtyIdByTabId,

--- a/src/renderer/src/store/slices/worktree-helpers.ts
+++ b/src/renderer/src/store/slices/worktree-helpers.ts
@@ -36,6 +36,14 @@ export type WorktreeSlice = {
    */
   everActivatedWorktreeIds: Set<string>
   /**
+   * Persisted focus-recency timestamp per worktree, used as the primary
+   * ordering signal for Cmd+J's empty-query Worktrees section. Stamped by
+   * `markWorktreeVisited` from user-initiated activations
+   * (activateAndRevealWorktree), NOT from background activity events or raw
+   * `setActiveWorktree` calls. See docs/cmd-j-empty-query-ordering.md.
+   */
+  lastVisitedAtByWorktreeId: Record<string, number>
+  /**
    * Guards the one-shot hydration-time purge in `fetchAllWorktrees`. Set to
    * `true` only after the first launch where every repo's `worktrees.list` IPC
    * call succeeded AND at least one repo returned a non-empty result — at that
@@ -65,6 +73,28 @@ export type WorktreeSlice = {
    *  ghostty's "show until interact" model. Persists isUnread=false. */
   clearWorktreeUnread: (worktreeId: string) => void
   bumpWorktreeActivity: (worktreeId: string) => void
+  /**
+   * Monotonic stamp of the focus-recency timestamp for a worktree. No-op if
+   * the supplied (or current) timestamp is not strictly greater than the
+   * stored value. Called from user-initiated activations only. See
+   * docs/cmd-j-empty-query-ordering.md.
+   */
+  markWorktreeVisited: (worktreeId: string, visitedAt?: number) => void
+  /**
+   * Drop `lastVisitedAtByWorktreeId` entries whose worktree IDs no longer
+   * exist. Must be called AFTER worktree hydration completes — repos load
+   * async, so pruning on raw rehydrate would nuke timestamps for worktrees
+   * whose repo hasn't yet hydrated.
+   */
+  pruneLastVisitedTimestamps: () => void
+  /**
+   * One-shot migration fixup: if the active worktree has no stored
+   * focus-recency timestamp after session hydration, seed it with the
+   * current time. Different semantics from `markWorktreeVisited` — this
+   * only fills in a missing entry on first load, it does not record a
+   * fresh visit.
+   */
+  seedActiveWorktreeLastVisitedIfMissing: () => void
   setActiveWorktree: (worktreeId: string | null) => void
   allWorktrees: () => Worktree[]
   /**

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -748,3 +748,45 @@ describe('purgeWorktreeTerminalState direct (design §4.4)', () => {
     expect(store.getState().tabsByWorktree).toBe(before)
   })
 })
+
+describe('markWorktreeVisited', () => {
+  it('is monotonic: an older timestamp does not regress the stored value', () => {
+    const store = createTestStore()
+    store.getState().markWorktreeVisited('wt-1', 1000)
+    expect(store.getState().lastVisitedAtByWorktreeId['wt-1']).toBe(1000)
+
+    store.getState().markWorktreeVisited('wt-1', 500)
+    expect(store.getState().lastVisitedAtByWorktreeId['wt-1']).toBe(1000)
+
+    store.getState().markWorktreeVisited('wt-1', 1000)
+    expect(store.getState().lastVisitedAtByWorktreeId['wt-1']).toBe(1000)
+
+    store.getState().markWorktreeVisited('wt-1', 2000)
+    expect(store.getState().lastVisitedAtByWorktreeId['wt-1']).toBe(2000)
+  })
+
+  it('seedActiveWorktreeLastVisitedIfMissing seeds only when missing', () => {
+    const store = createTestStore()
+    store.setState({
+      activeWorktreeId: 'wt-1',
+      lastVisitedAtByWorktreeId: {}
+    } as Partial<AppState>)
+    store.getState().seedActiveWorktreeLastVisitedIfMissing()
+    expect(store.getState().lastVisitedAtByWorktreeId['wt-1']).toBeTypeOf('number')
+
+    const existing = store.getState().lastVisitedAtByWorktreeId['wt-1']
+    store.getState().seedActiveWorktreeLastVisitedIfMissing()
+    expect(store.getState().lastVisitedAtByWorktreeId['wt-1']).toBe(existing)
+  })
+
+  it('pruneLastVisitedTimestamps drops entries for unknown worktree IDs', () => {
+    const store = createTestStore()
+    const wt = makeWorktree({ id: 'repo1::/a', repoId: 'repo1', path: '/a' })
+    store.setState({
+      worktreesByRepo: { repo1: [wt] },
+      lastVisitedAtByWorktreeId: { 'repo1::/a': 100, 'stale-id': 200 }
+    } as Partial<AppState>)
+    store.getState().pruneLastVisitedTimestamps()
+    expect(store.getState().lastVisitedAtByWorktreeId).toEqual({ 'repo1::/a': 100 })
+  })
+})

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -62,6 +62,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
   deleteStateByWorktreeId: {},
   sortEpoch: 0,
   everActivatedWorktreeIds: new Set<string>(),
+  lastVisitedAtByWorktreeId: {},
   hasHydratedWorktreePurge: false,
 
   fetchWorktrees: async (repoId) => {
@@ -353,6 +354,14 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
         const nextEverActivatedWorktreeIds = s.everActivatedWorktreeIds.has(worktreeId)
           ? new Set([...s.everActivatedWorktreeIds].filter((id) => id !== worktreeId))
           : s.everActivatedWorktreeIds
+        const nextLastVisitedAtByWorktreeId =
+          worktreeId in s.lastVisitedAtByWorktreeId
+            ? (() => {
+                const next = { ...s.lastVisitedAtByWorktreeId }
+                delete next[worktreeId]
+                return next
+              })()
+            : s.lastVisitedAtByWorktreeId
         return {
           worktreesByRepo: next,
           tabsByWorktree: nextTabs,
@@ -397,6 +406,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
           activeBrowserTabId: removedActiveWorktree ? null : s.activeBrowserTabId,
           activeTabType: removedActiveWorktree || activeFileCleared ? 'terminal' : s.activeTabType,
           everActivatedWorktreeIds: nextEverActivatedWorktreeIds,
+          lastVisitedAtByWorktreeId: nextLastVisitedAtByWorktreeId,
           sortEpoch: s.sortEpoch + 1
         }
       })
@@ -549,6 +559,66 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
         console.error('Failed to persist worktree activity timestamp:', err)
         void get().fetchWorktrees(getRepoIdFromWorktreeId(worktreeId))
       })
+  },
+
+  markWorktreeVisited: (worktreeId, visitedAt) => {
+    // Why: Cmd+J's empty-query ordering needs a focus-recency signal that is
+    // distinct from worktree.lastActivityAt (which is driven by background
+    // PTY/activity events). Monotonic: CLI- and IPC-driven activations can
+    // race, so older timestamps must not regress the stored value. See
+    // docs/cmd-j-empty-query-ordering.md.
+    set((s) => {
+      const now = visitedAt ?? Date.now()
+      const prev = s.lastVisitedAtByWorktreeId[worktreeId] ?? 0
+      if (!(now > prev)) {
+        return {}
+      }
+      return {
+        lastVisitedAtByWorktreeId: {
+          ...s.lastVisitedAtByWorktreeId,
+          [worktreeId]: now
+        }
+      }
+    })
+  },
+
+  pruneLastVisitedTimestamps: () => {
+    set((s) => {
+      const validIds = new Set<string>()
+      for (const list of Object.values(s.worktreesByRepo)) {
+        for (const w of list) {
+          validIds.add(w.id)
+        }
+      }
+      let changed = false
+      const next: Record<string, number> = {}
+      for (const [id, ts] of Object.entries(s.lastVisitedAtByWorktreeId)) {
+        if (validIds.has(id)) {
+          next[id] = ts
+        } else {
+          changed = true
+        }
+      }
+      return changed ? { lastVisitedAtByWorktreeId: next } : {}
+    })
+  },
+
+  seedActiveWorktreeLastVisitedIfMissing: () => {
+    set((s) => {
+      const id = s.activeWorktreeId
+      if (!id) {
+        return {}
+      }
+      if (s.lastVisitedAtByWorktreeId[id] != null) {
+        return {}
+      }
+      return {
+        lastVisitedAtByWorktreeId: {
+          ...s.lastVisitedAtByWorktreeId,
+          [id]: Date.now()
+        }
+      }
+    })
   },
 
   setActiveWorktree: (worktreeId) => {
@@ -887,6 +957,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
         // Top-level actives
         openFiles: nextOpenFiles,
         everActivatedWorktreeIds: nextEverActivatedWorktreeIds,
+        lastVisitedAtByWorktreeId: omitByWorktree(s.lastVisitedAtByWorktreeId),
         activeWorktreeId: removedActive ? null : s.activeWorktreeId,
         activeFileId: activeFileCleared ? null : s.activeFileId,
         activeBrowserTabId: removedActive ? null : s.activeBrowserTabId,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -403,6 +403,13 @@ export type WorkspaceSessionState = {
    *  shutdown from renderer state so remote PTYs can be reattached via
    *  the relay's pty.attach RPC on startup. */
   remoteSessionIdsByTabId?: Record<string, string>
+  /** Per-worktree focus-recency timestamps used by the Cmd+J empty-query
+   *  ordering. Separate from worktree.lastActivityAt (background signal)
+   *  and worktreeNavHistory (Back/Forward stack). See
+   *  docs/cmd-j-empty-query-ordering.md. Absent in sessions written by
+   *  older builds — hydration tolerates missing/partial maps and the
+   *  active worktree is seeded on first restore. */
+  lastVisitedAtByWorktreeId?: Record<string, number>
 }
 
 // ─── GitHub ──────────────────────────────────────────────────────────

--- a/src/shared/workspace-session-schema.ts
+++ b/src/shared/workspace-session-schema.ts
@@ -204,7 +204,12 @@ export const workspaceSessionStateSchema: z.ZodType<WorkspaceSessionState> = z.o
   tabGroupLayouts: z.record(z.string(), tabGroupLayoutNodeSchema).optional(),
   activeGroupIdByWorktree: z.record(z.string(), z.string()).optional(),
   activeConnectionIdsAtShutdown: z.array(z.string()).optional(),
-  remoteSessionIdsByTabId: z.record(z.string(), z.string()).optional()
+  remoteSessionIdsByTabId: z.record(z.string(), z.string()).optional(),
+  // Why: the sort comparator in order-empty-query-worktrees.ts would produce
+  // NaN (undefined sort order) if a corrupted session file carried NaN or
+  // Infinity here. Constrain to finite non-negative numbers so a bad on-disk
+  // value is rejected at parse time rather than silently breaking Cmd+J.
+  lastVisitedAtByWorktreeId: z.record(z.string(), z.number().finite().nonnegative()).optional()
 })
 
 export type ParsedWorkspaceSession =


### PR DESCRIPTION
## Summary
- Persist a per-worktree focus-recency timestamp (`lastVisitedAtByWorktreeId`) and stamp it from `activateAndRevealWorktree`, so Cmd+J's empty-query Worktrees section ranks by user focus rather than background activity.
- Extract `orderEmptyQueryWorktrees` as a pure helper; exclude the active worktree from switchable rows while keeping full-visible list for empty-state/loading logic. Preserves conditional cap and typed-query smart-sort unchanged.
- Seed active worktree timestamp on hydration-complete; prune stale map entries after hydration. Zustand downgrade drops unknown key — no migration.

See `docs/cmd-j-empty-query-ordering.md` for full design.

Fixes the SSH-worktree-not-showing-up-in-Cmd+J symptom.

## Test plan
- [ ] Open Cmd+J with empty query after working in an SSH worktree — it ranks above locally active ones.
- [ ] Never-visited worktrees fall back to `lastActivityAt` ordering.
- [ ] Current worktree excluded from empty-query rows; empty-state copy unaffected.
- [ ] Typed query still uses smart sort.
- [ ] App restart seeds active worktree's focus-recency when missing.

Made with [Orca](https://github.com/stablyai/orca) 🐋
