### PR TITLE
feat(cli): add tab profile automation primitives

### DIFF
--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -64,7 +64,14 @@ export function supportsBrowserPageFlag(commandPath: string[]): boolean {
   if (['repo', 'worktree', 'terminal'].includes(commandPath[0])) {
     return false
   }
-  return !['tab list', 'tab create'].includes(joined)
+  return ![
+    'tab list',
+    'tab create',
+    'tab current',
+    'tab profile list',
+    'tab profile create',
+    'tab profile delete'
+  ].includes(joined)
 }
 
 export function isCommandGroup(commandPath: string[]): boolean {

--- a/src/cli/browser.test.ts
+++ b/src/cli/browser.test.ts
@@ -209,6 +209,54 @@ describe('orca cli browser page targeting', () => {
         '  [1] page-2  Mail — https://mail.example.com  [Work]'
     )
   })
+
+  it('shows a single tab by page id', async () => {
+    queueFixtures(
+      callMock,
+      okFixture('req_tab_show', {
+        tab: {
+          browserPageId: 'page-1',
+          index: 0,
+          url: 'https://example.com',
+          title: 'Example',
+          active: true,
+          worktreeId: 'repo::/tmp/repo/feature',
+          profileId: 'work',
+          profileLabel: 'Work'
+        }
+      })
+    )
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(['tab', 'show', '--page', 'page-1', '--json'], '/tmp/not-an-orca-worktree')
+
+    expect(callMock).toHaveBeenCalledTimes(1)
+    expect(callMock).toHaveBeenCalledWith('browser.tabShow', { page: 'page-1' })
+  })
+
+  it('resolves the current tab in a worktree', async () => {
+    queueFixtures(
+      callMock,
+      okFixture('req_tab_current', {
+        tab: {
+          browserPageId: 'page-2',
+          index: 1,
+          url: 'https://mail.example.com',
+          title: 'Mail',
+          active: true,
+          worktreeId: 'repo::/tmp/repo/feature',
+          profileId: 'default',
+          profileLabel: 'Default'
+        }
+      })
+    )
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(['tab', 'current', '--worktree', 'all', '--json'], '/tmp/not-an-orca-worktree')
+
+    expect(callMock).toHaveBeenCalledTimes(1)
+    expect(callMock).toHaveBeenCalledWith('browser.tabCurrent', { worktree: undefined })
+  })
 })
 
 describe('orca cli browser tab profiles', () => {
@@ -275,6 +323,74 @@ describe('orca cli browser tab profiles', () => {
 
     expect(callMock).toHaveBeenCalledTimes(1)
     expect(callMock).toHaveBeenCalledWith('browser.profileDelete', { profileId: 'work' })
+  })
+
+  it('shows the profile bound to a tab', async () => {
+    queueFixtures(
+      callMock,
+      okFixture('req_profile_show', {
+        browserPageId: 'page-2',
+        worktreeId: 'repo::/tmp/repo/feature',
+        profileId: 'work',
+        profileLabel: 'Work'
+      })
+    )
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(
+      ['tab', 'profile', 'show', '--page', 'page-2', '--json'],
+      '/tmp/not-an-orca-worktree'
+    )
+
+    expect(callMock).toHaveBeenCalledTimes(1)
+    expect(callMock).toHaveBeenCalledWith('browser.tabProfileShow', { page: 'page-2' })
+  })
+
+  it('switches a tab back to the default profile', async () => {
+    queueFixtures(
+      callMock,
+      okFixture('req_profile_default', {
+        browserPageId: 'page-2',
+        profileId: 'default',
+        profileLabel: 'Default'
+      })
+    )
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(
+      ['tab', 'profile', 'use-default', '--page', 'page-2', '--json'],
+      '/tmp/not-an-orca-worktree'
+    )
+
+    expect(callMock).toHaveBeenCalledTimes(1)
+    expect(callMock).toHaveBeenCalledWith('browser.tabSetProfile', {
+      page: 'page-2',
+      profileId: 'default'
+    })
+  })
+
+  it('clones a tab into a different profile', async () => {
+    queueFixtures(
+      callMock,
+      okFixture('req_profile_clone', {
+        browserPageId: 'page-9',
+        sourceBrowserPageId: 'page-2',
+        profileId: 'work',
+        profileLabel: 'Work'
+      })
+    )
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(
+      ['tab', 'profile', 'clone', '--page', 'page-2', '--profile', 'work', '--json'],
+      '/tmp/not-an-orca-worktree'
+    )
+
+    expect(callMock).toHaveBeenCalledTimes(1)
+    expect(callMock).toHaveBeenCalledWith('browser.tabProfileClone', {
+      page: 'page-2',
+      profileId: 'work'
+    })
   })
 })
 

--- a/src/cli/browser.test.ts
+++ b/src/cli/browser.test.ts
@@ -126,6 +126,156 @@ describe('orca cli browser page targeting', () => {
       worktree: `path:${path.resolve('/tmp/repo/feature')}`
     })
   })
+
+  it('passes explicit profile ids to tab create', async () => {
+    queueFixtures(callMock, okFixture('req_create', { browserPageId: 'page-3' }))
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(
+      ['tab', 'create', '--url', 'https://example.com', '--profile', 'work', '--worktree', 'all', '--json'],
+      '/tmp/not-an-orca-worktree'
+    )
+
+    expect(callMock).toHaveBeenCalledTimes(1)
+    expect(callMock).toHaveBeenCalledWith(
+      'browser.tabCreate',
+      {
+        url: 'https://example.com',
+        worktree: undefined,
+        profileId: 'work'
+      },
+      { timeoutMs: 60_000 }
+    )
+  })
+
+  it('passes tab profile updates through by page id', async () => {
+    queueFixtures(
+      callMock,
+      okFixture('req_set_profile', {
+        browserPageId: 'page-2',
+        profileId: 'work',
+        profileLabel: 'Work'
+      })
+    )
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(
+      ['tab', 'profile', 'set', '--page', 'page-2', '--profile', 'work', '--json'],
+      '/tmp/repo/feature/src'
+    )
+
+    expect(callMock).toHaveBeenCalledTimes(1)
+    expect(callMock).toHaveBeenCalledWith('browser.tabSetProfile', {
+      page: 'page-2',
+      profileId: 'work'
+    })
+  })
+
+  it('shows tab profile labels in text mode when requested', async () => {
+    queueFixtures(
+      callMock,
+      okFixture('req_list', {
+        tabs: [
+          {
+            browserPageId: 'page-1',
+            index: 0,
+            url: 'https://example.com',
+            title: 'Example',
+            active: true,
+            profileId: 'default',
+            profileLabel: 'Default'
+          },
+          {
+            browserPageId: 'page-2',
+            index: 1,
+            url: 'https://mail.example.com',
+            title: 'Mail',
+            active: false,
+            profileId: 'work',
+            profileLabel: 'Work'
+          }
+        ]
+      })
+    )
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(['tab', 'list', '--show-profile', '--worktree', 'all'], '/tmp/not-an-orca-worktree')
+
+
+    expect(callMock).toHaveBeenCalledTimes(1)
+    expect(callMock).toHaveBeenCalledWith('browser.tabList', { worktree: undefined })
+    expect(logSpy).toHaveBeenCalledWith(
+      '* [0] page-1  Example — https://example.com  [Default]\n' +
+        '  [1] page-2  Mail — https://mail.example.com  [Work]'
+    )
+  })
+})
+
+describe('orca cli browser tab profiles', () => {
+  beforeEach(() => {
+    callMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('lists browser tab profiles', async () => {
+    queueFixtures(
+      callMock,
+      okFixture('req_profiles', {
+        profiles: [
+          { id: 'default', scope: 'default', label: 'Default', partition: 'persist:orca-browser' },
+          { id: 'work', scope: 'isolated', label: 'Work', partition: 'persist:orca-browser-session-work' }
+        ]
+      })
+    )
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(['tab', 'profile', 'list', '--json'], '/tmp/not-an-orca-worktree')
+
+    expect(callMock).toHaveBeenCalledTimes(1)
+    expect(callMock).toHaveBeenCalledWith('browser.profileList')
+  })
+
+  it('creates isolated browser tab profiles by default', async () => {
+    queueFixtures(
+      callMock,
+      okFixture('req_profile_create', {
+        profile: {
+          id: 'work',
+          scope: 'isolated',
+          label: 'Work',
+          partition: 'persist:orca-browser-session-work'
+        }
+      })
+    )
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(
+      ['tab', 'profile', 'create', '--label', 'Work', '--json'],
+      '/tmp/not-an-orca-worktree'
+    )
+
+    expect(callMock).toHaveBeenCalledTimes(1)
+    expect(callMock).toHaveBeenCalledWith('browser.profileCreate', {
+      label: 'Work',
+      scope: 'isolated'
+    })
+  })
+
+  it('deletes browser tab profiles by id', async () => {
+    queueFixtures(callMock, okFixture('req_profile_delete', { deleted: true, profileId: 'work' }))
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(
+      ['tab', 'profile', 'delete', '--profile', 'work', '--json'],
+      '/tmp/not-an-orca-worktree'
+    )
+
+    expect(callMock).toHaveBeenCalledTimes(1)
+    expect(callMock).toHaveBeenCalledWith('browser.profileDelete', { profileId: 'work' })
+  })
 })
 
 describe('orca cli browser waits and viewport flags', () => {

--- a/src/cli/dispatch.ts
+++ b/src/cli/dispatch.ts
@@ -7,6 +7,7 @@ import { TERMINAL_HANDLERS } from './handlers/terminal'
 import { BROWSER_NAV_HANDLERS } from './handlers/browser-nav'
 import { BROWSER_INTERACT_HANDLERS } from './handlers/browser-interact'
 import { BROWSER_TAB_HANDLERS } from './handlers/browser-tab'
+import { BROWSER_PROFILE_HANDLERS } from './handlers/browser-profile'
 import { BROWSER_COOKIE_HANDLERS } from './handlers/browser-cookie'
 import { BROWSER_CAPTURE_HANDLERS } from './handlers/browser-capture'
 import { BROWSER_ENV_HANDLERS } from './handlers/browser-env'
@@ -32,6 +33,7 @@ function buildHandlers(): Map<string, CommandHandler> {
     BROWSER_NAV_HANDLERS,
     BROWSER_INTERACT_HANDLERS,
     BROWSER_TAB_HANDLERS,
+    BROWSER_PROFILE_HANDLERS,
     BROWSER_COOKIE_HANDLERS,
     BROWSER_CAPTURE_HANDLERS,
     BROWSER_ENV_HANDLERS,

--- a/src/cli/format.ts
+++ b/src/cli/format.ts
@@ -1,8 +1,12 @@
 import type {
   BrowserProfileListResult,
+  BrowserTabCurrentResult,
   BrowserScreenshotResult,
   BrowserSnapshotResult,
   BrowserTabListResult,
+  BrowserTabProfileCloneResult,
+  BrowserTabProfileShowResult,
+  BrowserTabShowResult,
   CliStatusResult,
   RuntimeRepoList,
   RuntimeRepoSearchRefs,
@@ -267,4 +271,29 @@ export function formatBrowserProfileList(result: BrowserProfileListResult): stri
       return `${profile.id}  ${profile.label}  ${profile.scope}  source:${source}`
     })
     .join('\n')
+}
+
+export function formatTabShow(result: BrowserTabShowResult | BrowserTabCurrentResult): string {
+  const tab = result.tab
+  return [
+    `page: ${tab.browserPageId}`,
+    `title: ${tab.title}`,
+    `url: ${tab.url}`,
+    `active: ${tab.active}`,
+    `worktree: ${tab.worktreeId ?? 'unknown'}`,
+    `profile: ${tab.profileLabel ?? tab.profileId ?? 'unknown'}`
+  ].join('\n')
+}
+
+export function formatTabProfileShow(result: BrowserTabProfileShowResult): string {
+  return [
+    `page: ${result.browserPageId}`,
+    `worktree: ${result.worktreeId ?? 'unknown'}`,
+    `profileId: ${result.profileId ?? 'default'}`,
+    `profile: ${result.profileLabel ?? result.profileId ?? 'default'}`
+  ].join('\n')
+}
+
+export function formatTabProfileClone(result: BrowserTabProfileCloneResult): string {
+  return `Cloned ${result.sourceBrowserPageId} to ${result.browserPageId} (${result.profileLabel ?? result.profileId ?? 'default'})`
 }

--- a/src/cli/format.ts
+++ b/src/cli/format.ts
@@ -1,4 +1,5 @@
 import type {
+  BrowserProfileListResult,
   BrowserScreenshotResult,
   BrowserSnapshotResult,
   BrowserTabListResult,
@@ -237,13 +238,33 @@ export function formatScreenshot(result: BrowserScreenshotResult): string {
 }
 
 export function formatTabList(result: BrowserTabListResult): string {
+  return formatTabListWithProfiles(result, false)
+}
+
+export function formatTabListWithProfiles(
+  result: BrowserTabListResult,
+  showProfile: boolean
+): string {
   if (result.tabs.length === 0) {
     return 'No browser tabs open.'
   }
   return result.tabs
     .map((t) => {
       const marker = t.active ? '* ' : '  '
-      return `${marker}[${t.index}] ${t.browserPageId}  ${t.title} — ${t.url}`
+      const profile = showProfile ? `  [${t.profileLabel ?? t.profileId ?? 'Unknown'}]` : ''
+      return `${marker}[${t.index}] ${t.browserPageId}  ${t.title} — ${t.url}${profile}`
+    })
+    .join('\n')
+}
+
+export function formatBrowserProfileList(result: BrowserProfileListResult): string {
+  if (result.profiles.length === 0) {
+    return 'No browser profiles found.'
+  }
+  return result.profiles
+    .map((profile) => {
+      const source = profile.source?.browserFamily ?? 'none'
+      return `${profile.id}  ${profile.label}  ${profile.scope}  source:${source}`
     })
     .join('\n')
 }

--- a/src/cli/handlers/browser-profile.ts
+++ b/src/cli/handlers/browser-profile.ts
@@ -1,11 +1,15 @@
 import type {
   BrowserProfileCreateResult,
   BrowserProfileDeleteResult,
-  BrowserProfileListResult
+  BrowserProfileListResult,
+  BrowserTabProfileCloneResult,
+  BrowserTabProfileShowResult,
+  BrowserTabSetProfileResult
 } from '../../shared/runtime-types'
 import type { CommandHandler } from '../dispatch'
 import { getOptionalStringFlag, getRequiredStringFlag } from '../flags'
-import { formatBrowserProfileList, printResult } from '../format'
+import { formatBrowserProfileList, formatTabProfileClone, formatTabProfileShow, printResult } from '../format'
+import { getBrowserCommandTarget } from '../selectors'
 
 export const BROWSER_PROFILE_HANDLERS: Record<string, CommandHandler> = {
   'tab profile list': async ({ client, json }) => {
@@ -31,5 +35,41 @@ export const BROWSER_PROFILE_HANDLERS: Record<string, CommandHandler> = {
       profileId
     })
     printResult(result, json, (value) => (value.deleted ? `Deleted profile ${value.profileId}` : `Profile ${value.profileId} was not deleted`))
+  },
+  'tab profile set': async ({ flags, client, cwd, json }) => {
+    const profileId = getRequiredStringFlag(flags, 'profile')
+    const target = await getBrowserCommandTarget(flags, cwd, client)
+    const result = await client.call<BrowserTabSetProfileResult>('browser.tabSetProfile', {
+      ...target,
+      profileId
+    })
+    printResult(
+      result,
+      json,
+      (value) =>
+        `Switched ${value.browserPageId} to ${value.profileLabel ?? value.profileId ?? 'default'}`
+    )
+  },
+  'tab profile show': async ({ flags, client, cwd, json }) => {
+    const target = await getBrowserCommandTarget(flags, cwd, client)
+    const result = await client.call<BrowserTabProfileShowResult>('browser.tabProfileShow', target)
+    printResult(result, json, formatTabProfileShow)
+  },
+  'tab profile use-default': async ({ flags, client, cwd, json }) => {
+    const target = await getBrowserCommandTarget(flags, cwd, client)
+    const result = await client.call<BrowserTabSetProfileResult>('browser.tabSetProfile', {
+      ...target,
+      profileId: 'default'
+    })
+    printResult(result, json, (value) => `Switched ${value.browserPageId} to Default`)
+  },
+  'tab profile clone': async ({ flags, client, cwd, json }) => {
+    const profileId = getRequiredStringFlag(flags, 'profile')
+    const target = await getBrowserCommandTarget(flags, cwd, client)
+    const result = await client.call<BrowserTabProfileCloneResult>('browser.tabProfileClone', {
+      ...target,
+      profileId
+    })
+    printResult(result, json, formatTabProfileClone)
   }
 }

--- a/src/cli/handlers/browser-profile.ts
+++ b/src/cli/handlers/browser-profile.ts
@@ -1,0 +1,35 @@
+import type {
+  BrowserProfileCreateResult,
+  BrowserProfileDeleteResult,
+  BrowserProfileListResult
+} from '../../shared/runtime-types'
+import type { CommandHandler } from '../dispatch'
+import { getOptionalStringFlag, getRequiredStringFlag } from '../flags'
+import { formatBrowserProfileList, printResult } from '../format'
+
+export const BROWSER_PROFILE_HANDLERS: Record<string, CommandHandler> = {
+  'tab profile list': async ({ client, json }) => {
+    const result = await client.call<BrowserProfileListResult>('browser.profileList')
+    printResult(result, json, formatBrowserProfileList)
+  },
+  'tab profile create': async ({ flags, client, json }) => {
+    const label = getRequiredStringFlag(flags, 'label')
+    const scope = getOptionalStringFlag(flags, 'scope') === 'imported' ? 'imported' : 'isolated'
+    const result = await client.call<BrowserProfileCreateResult>('browser.profileCreate', {
+      label,
+      scope
+    })
+    printResult(
+      result,
+      json,
+      (value) => `Created profile ${value.profile?.id ?? 'unknown'} (${value.profile?.label ?? label})`
+    )
+  },
+  'tab profile delete': async ({ flags, client, json }) => {
+    const profileId = getRequiredStringFlag(flags, 'profile')
+    const result = await client.call<BrowserProfileDeleteResult>('browser.profileDelete', {
+      profileId
+    })
+    printResult(result, json, (value) => (value.deleted ? `Deleted profile ${value.profileId}` : `Profile ${value.profileId} was not deleted`))
+  }
+}

--- a/src/cli/handlers/browser-tab.ts
+++ b/src/cli/handlers/browser-tab.ts
@@ -1,6 +1,10 @@
-import type { BrowserTabListResult, BrowserTabSwitchResult } from '../../shared/runtime-types'
+import type {
+  BrowserTabListResult,
+  BrowserTabSetProfileResult,
+  BrowserTabSwitchResult
+} from '../../shared/runtime-types'
 import type { CommandHandler } from '../dispatch'
-import { formatTabList, printResult } from '../format'
+import { formatTabList, formatTabListWithProfiles, printResult } from '../format'
 import {
   getOptionalNonNegativeIntegerFlag,
   getOptionalStringFlag,
@@ -13,7 +17,10 @@ export const BROWSER_TAB_HANDLERS: Record<string, CommandHandler> = {
   'tab list': async ({ flags, client, cwd, json }) => {
     const worktree = await getBrowserWorktreeSelector(flags, cwd, client)
     const result = await client.call<BrowserTabListResult>('browser.tabList', { worktree })
-    printResult(result, json, formatTabList)
+    const showProfile = flags.has('show-profile')
+    printResult(result, json, (value) =>
+      showProfile ? formatTabListWithProfiles(value, true) : formatTabList(value)
+    )
   },
   'tab switch': async ({ flags, client, cwd, json }) => {
     const index = getOptionalNonNegativeIntegerFlag(flags, 'index')
@@ -34,13 +41,28 @@ export const BROWSER_TAB_HANDLERS: Record<string, CommandHandler> = {
   },
   'tab create': async ({ flags, client, cwd, json }) => {
     const url = getOptionalStringFlag(flags, 'url')
+    const profileId = getOptionalStringFlag(flags, 'profile')
     const worktree = await getBrowserWorktreeSelector(flags, cwd, client)
     const result = await client.call<{ browserPageId: string }>(
       'browser.tabCreate',
-      { url, worktree },
+      { url, worktree, profileId },
       { timeoutMs: 60_000 }
     )
     printResult(result, json, (v) => `Created tab ${v.browserPageId}`)
+  },
+  'tab profile set': async ({ flags, client, cwd, json }) => {
+    const profileId = getRequiredStringFlag(flags, 'profile')
+    const target = await getBrowserCommandTarget(flags, cwd, client)
+    const result = await client.call<BrowserTabSetProfileResult>('browser.tabSetProfile', {
+      ...target,
+      profileId
+    })
+    printResult(
+      result,
+      json,
+      (value) =>
+        `Switched ${value.browserPageId} to ${value.profileLabel ?? value.profileId ?? 'default'}`
+    )
   },
   'tab close': async ({ flags, client, cwd, json }) => {
     const index = getOptionalNonNegativeIntegerFlag(flags, 'index')

--- a/src/cli/handlers/browser-tab.ts
+++ b/src/cli/handlers/browser-tab.ts
@@ -1,15 +1,17 @@
 import type {
+  BrowserTabCurrentResult,
   BrowserTabListResult,
-  BrowserTabSetProfileResult,
+  BrowserTabShowResult,
   BrowserTabSwitchResult
 } from '../../shared/runtime-types'
 import type { CommandHandler } from '../dispatch'
-import { formatTabList, formatTabListWithProfiles, printResult } from '../format'
 import {
-  getOptionalNonNegativeIntegerFlag,
-  getOptionalStringFlag,
-  getRequiredStringFlag
-} from '../flags'
+  formatTabList,
+  formatTabListWithProfiles,
+  formatTabShow,
+  printResult
+} from '../format'
+import { getOptionalNonNegativeIntegerFlag, getOptionalStringFlag, getRequiredStringFlag } from '../flags'
 import { RuntimeClientError } from '../runtime-client'
 import { getBrowserCommandTarget, getBrowserWorktreeSelector } from '../selectors'
 
@@ -21,6 +23,16 @@ export const BROWSER_TAB_HANDLERS: Record<string, CommandHandler> = {
     printResult(result, json, (value) =>
       showProfile ? formatTabListWithProfiles(value, true) : formatTabList(value)
     )
+  },
+  'tab show': async ({ flags, client, cwd, json }) => {
+    const target = await getBrowserCommandTarget(flags, cwd, client)
+    const result = await client.call<BrowserTabShowResult>('browser.tabShow', target)
+    printResult(result, json, formatTabShow)
+  },
+  'tab current': async ({ flags, client, cwd, json }) => {
+    const worktree = await getBrowserWorktreeSelector(flags, cwd, client)
+    const result = await client.call<BrowserTabCurrentResult>('browser.tabCurrent', { worktree })
+    printResult(result, json, formatTabShow)
   },
   'tab switch': async ({ flags, client, cwd, json }) => {
     const index = getOptionalNonNegativeIntegerFlag(flags, 'index')
@@ -49,20 +61,6 @@ export const BROWSER_TAB_HANDLERS: Record<string, CommandHandler> = {
       { timeoutMs: 60_000 }
     )
     printResult(result, json, (v) => `Created tab ${v.browserPageId}`)
-  },
-  'tab profile set': async ({ flags, client, cwd, json }) => {
-    const profileId = getRequiredStringFlag(flags, 'profile')
-    const target = await getBrowserCommandTarget(flags, cwd, client)
-    const result = await client.call<BrowserTabSetProfileResult>('browser.tabSetProfile', {
-      ...target,
-      profileId
-    })
-    printResult(
-      result,
-      json,
-      (value) =>
-        `Switched ${value.browserPageId} to ${value.profileLabel ?? value.profileId ?? 'default'}`
-    )
   },
   'tab close': async ({ flags, client, cwd, json }) => {
     const index = getOptionalNonNegativeIntegerFlag(flags, 'index')

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -59,10 +59,15 @@ Orchestration:
 Browser Automation:
   tab create                Create a new browser tab (navigates to --url)
   tab list                  List open browser tabs
+  tab show                  Show one browser tab by page id
+  tab current               Show the current browser tab
   tab profile list          List browser session profiles
   tab profile create        Create a browser session profile
   tab profile delete        Delete a browser session profile
   tab profile set           Switch a browser tab to a different profile
+  tab profile show          Show the profile bound to a browser tab
+  tab profile use-default   Switch a browser tab back to the default profile
+  tab profile clone         Clone a browser tab into another profile
   tab switch                Switch the active browser tab by --index or --page
   tab close                 Close a browser tab by --index/--page or the current tab
   snapshot                  Accessibility snapshot with element refs (e.g. @e1, @e2)
@@ -187,7 +192,7 @@ Browser Options:
   --amount <pixels>         Scroll distance in pixels (default: viewport height)
   --index <n>               Tab index (from \`tab list\`)
   --page <id>               Stable browser page id (preferred for concurrent workflows)
-  --profile <id>            Browser profile id (see \`orca profile list\`)
+  --profile <id>            Browser profile id (see \`orca tab profile list\`)
   --show-profile            Include the tab's browser profile in text output
   --format <png|jpeg>       Screenshot image format
   --from <ref>              Drag source element ref
@@ -210,7 +215,10 @@ Examples:
   $ orca terminal wait --terminal term_123 --for exit --timeout-ms 60000 --json
   $ orca tab profile list
   $ orca tab profile create --label Work
+  $ orca tab current --json
+  $ orca tab show --page page_123 --json
   $ orca tab create --url https://example.com --profile work
+  $ orca tab profile clone --page page_123 --profile work --json
   $ orca snapshot
   $ orca click --element e3
   $ orca fill --element e5 --value "hello"

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -59,6 +59,10 @@ Orchestration:
 Browser Automation:
   tab create                Create a new browser tab (navigates to --url)
   tab list                  List open browser tabs
+  tab profile list          List browser session profiles
+  tab profile create        Create a browser session profile
+  tab profile delete        Delete a browser session profile
+  tab profile set           Switch a browser tab to a different profile
   tab switch                Switch the active browser tab by --index or --page
   tab close                 Close a browser tab by --index/--page or the current tab
   snapshot                  Accessibility snapshot with element refs (e.g. @e1, @e2)
@@ -183,6 +187,8 @@ Browser Options:
   --amount <pixels>         Scroll distance in pixels (default: viewport height)
   --index <n>               Tab index (from \`tab list\`)
   --page <id>               Stable browser page id (preferred for concurrent workflows)
+  --profile <id>            Browser profile id (see \`orca profile list\`)
+  --show-profile            Include the tab's browser profile in text output
   --format <png|jpeg>       Screenshot image format
   --from <ref>              Drag source element ref
   --to <ref>                Drag target element ref
@@ -202,7 +208,9 @@ Examples:
   $ orca terminal list --worktree path:/Users/me/orca/workspaces/orca/cli-test-1 --json
   $ orca terminal send --terminal term_123 --text "hi" --enter
   $ orca terminal wait --terminal term_123 --for exit --timeout-ms 60000 --json
-  $ orca tab create --url https://example.com
+  $ orca tab profile list
+  $ orca tab profile create --label Work
+  $ orca tab create --url https://example.com --profile work
   $ orca snapshot
   $ orca click --element e3
   $ orca fill --element e5 --value "hello"
@@ -306,6 +314,8 @@ export function formatFlagHelp(flag: string): string {
     amount: '--amount <pixels>      Scroll distance in pixels',
     index: '--index <n>            Tab index to switch to',
     page: '--page <id>            Stable browser page id from `orca tab list --json`',
+    profile: '--profile <id>        Browser profile id',
+    'show-profile': '--show-profile        Include tab profile in text output',
     format: '--format <png|jpeg>    Screenshot image format'
   }
 

--- a/src/cli/specs/browser-basic.ts
+++ b/src/cli/specs/browser-basic.ts
@@ -158,6 +158,18 @@ export const BROWSER_BASIC_COMMAND_SPECS: CommandSpec[] = [
     allowedFlags: [...GLOBAL_FLAGS, 'worktree', 'show-profile']
   },
   {
+    path: ['tab', 'show'],
+    summary: 'Show one browser tab by page id',
+    usage: 'orca tab show --page <id> [--worktree <selector>] [--json]',
+    allowedFlags: [...GLOBAL_FLAGS, 'worktree']
+  },
+  {
+    path: ['tab', 'current'],
+    summary: 'Show the current browser tab',
+    usage: 'orca tab current [--worktree <selector|all>] [--json]',
+    allowedFlags: [...GLOBAL_FLAGS, 'worktree']
+  },
+  {
     path: ['tab', 'switch'],
     summary: 'Switch the active browser tab',
     usage: 'orca tab switch (--index <n> | --page <id>) [--worktree <selector>] [--json]',
@@ -177,6 +189,12 @@ export const BROWSER_BASIC_COMMAND_SPECS: CommandSpec[] = [
     allowedFlags: [...GLOBAL_FLAGS, 'profile', 'worktree']
   },
   {
+    path: ['tab', 'profile', 'show'],
+    summary: 'Show the browser profile bound to a tab',
+    usage: 'orca tab profile show --page <id> [--worktree <selector>] [--json]',
+    allowedFlags: [...GLOBAL_FLAGS, 'worktree']
+  },
+  {
     path: ['tab', 'profile', 'list'],
     summary: 'List browser session profiles available to browser tabs',
     usage: 'orca tab profile list [--json]',
@@ -193,6 +211,19 @@ export const BROWSER_BASIC_COMMAND_SPECS: CommandSpec[] = [
     summary: 'Delete a browser session profile used by browser tabs',
     usage: 'orca tab profile delete --profile <id> [--json]',
     allowedFlags: [...GLOBAL_FLAGS, 'profile']
+  },
+  {
+    path: ['tab', 'profile', 'use-default'],
+    summary: 'Switch a browser tab back to the default browser profile',
+    usage: 'orca tab profile use-default --page <id> [--worktree <selector>] [--json]',
+    allowedFlags: [...GLOBAL_FLAGS, 'worktree']
+  },
+  {
+    path: ['tab', 'profile', 'clone'],
+    summary: 'Clone a browser tab into a different browser profile',
+    usage:
+      'orca tab profile clone --profile <id> [--page <id>] [--worktree <selector>] [--json]',
+    allowedFlags: [...GLOBAL_FLAGS, 'profile', 'worktree']
   },
   {
     path: ['tab', 'close'],

--- a/src/cli/specs/browser-basic.ts
+++ b/src/cli/specs/browser-basic.ts
@@ -154,8 +154,8 @@ export const BROWSER_BASIC_COMMAND_SPECS: CommandSpec[] = [
   {
     path: ['tab', 'list'],
     summary: 'List open browser tabs',
-    usage: 'orca tab list [--worktree <selector|all>] [--json]',
-    allowedFlags: [...GLOBAL_FLAGS, 'worktree']
+    usage: 'orca tab list [--worktree <selector|all>] [--show-profile] [--json]',
+    allowedFlags: [...GLOBAL_FLAGS, 'worktree', 'show-profile']
   },
   {
     path: ['tab', 'switch'],
@@ -166,8 +166,33 @@ export const BROWSER_BASIC_COMMAND_SPECS: CommandSpec[] = [
   {
     path: ['tab', 'create'],
     summary: 'Create a new browser tab in the current worktree',
-    usage: 'orca tab create [--url <url>] [--worktree <selector>] [--json]',
-    allowedFlags: [...GLOBAL_FLAGS, 'url', 'worktree']
+    usage: 'orca tab create [--url <url>] [--worktree <selector>] [--profile <id>] [--json]',
+    allowedFlags: [...GLOBAL_FLAGS, 'url', 'worktree', 'profile']
+  },
+  {
+    path: ['tab', 'profile', 'set'],
+    summary: 'Switch a browser tab to a different browser profile',
+    usage:
+      'orca tab profile set (--page <id> | --worktree <selector>) --profile <id> [--json]',
+    allowedFlags: [...GLOBAL_FLAGS, 'profile', 'worktree']
+  },
+  {
+    path: ['tab', 'profile', 'list'],
+    summary: 'List browser session profiles available to browser tabs',
+    usage: 'orca tab profile list [--json]',
+    allowedFlags: [...GLOBAL_FLAGS]
+  },
+  {
+    path: ['tab', 'profile', 'create'],
+    summary: 'Create a browser session profile for browser tabs',
+    usage: 'orca tab profile create --label <name> [--scope <isolated|imported>] [--json]',
+    allowedFlags: [...GLOBAL_FLAGS, 'label', 'scope']
+  },
+  {
+    path: ['tab', 'profile', 'delete'],
+    summary: 'Delete a browser session profile used by browser tabs',
+    usage: 'orca tab profile delete --profile <id> [--json]',
+    allowedFlags: [...GLOBAL_FLAGS, 'profile']
   },
   {
     path: ['tab', 'close'],

--- a/src/main/browser/browser-manager.test.ts
+++ b/src/main/browser/browser-manager.test.ts
@@ -131,6 +131,32 @@ describe('browserManager', () => {
     })
   })
 
+  it('remembers the registered session profile for a browser page', () => {
+    const guest = {
+      id: 104,
+      isDestroyed: vi.fn(() => false),
+      getType: vi.fn(() => 'webview'),
+      setBackgroundThrottling: guestSetBackgroundThrottlingMock,
+      setWindowOpenHandler: guestSetWindowOpenHandlerMock,
+      on: guestOnMock,
+      off: guestOffMock,
+      openDevTools: guestOpenDevToolsMock
+    }
+    webContentsFromIdMock.mockReturnValue(guest)
+
+    browserManager.attachGuestPolicies(guest as never)
+    browserManager.registerGuest({
+      browserPageId: 'browser-1',
+      workspaceId: 'workspace-1',
+      worktreeId: 'wt-1',
+      webContentsId: guest.id,
+      rendererWebContentsId,
+      sessionProfileId: 'work'
+    })
+
+    expect(browserManager.getSessionProfileIdForTab('browser-1')).toBe('work')
+  })
+
   it('falls back to opening popup URLs externally before a guest is registered', () => {
     const guest = {
       id: 105,

--- a/src/main/browser/browser-manager.ts
+++ b/src/main/browser/browser-manager.ts
@@ -55,6 +55,7 @@ export type BrowserGuestRegistration = {
   browserTabId?: string
   workspaceId?: string
   worktreeId?: string
+  sessionProfileId?: string | null
   webContentsId: number
   rendererWebContentsId: number
 }
@@ -97,6 +98,7 @@ export class BrowserManager {
   // visibility/focus state is keyed by browser workspace id. Screenshot prep
   // has to bridge that mismatch to activate the right tab before capture.
   private readonly workspaceIdByPageId = new Map<string, string>()
+  private readonly sessionProfileIdByPageId = new Map<string, string | null>()
   private readonly rendererWebContentsIdByTabId = new Map<string, number>()
   // Why: chain setViewportOverride calls per tab so rapid toggles don't
   // interleave CDP commands. Without serialization, two concurrent calls can
@@ -543,6 +545,7 @@ export class BrowserManager {
     browserTabId: legacyBrowserTabId,
     workspaceId,
     worktreeId,
+    sessionProfileId,
     webContentsId,
     rendererWebContentsId
   }: BrowserGuestRegistration): void {
@@ -592,6 +595,7 @@ export class BrowserManager {
     if (workspaceId) {
       this.workspaceIdByPageId.set(browserTabId, workspaceId)
     }
+    this.sessionProfileIdByPageId.set(browserTabId, sessionProfileId ?? null)
     this.rendererWebContentsIdByTabId.set(browserTabId, rendererWebContentsId)
     if (worktreeId) {
       this.worktreeIdByTabId.set(browserTabId, worktreeId)
@@ -655,6 +659,7 @@ export class BrowserManager {
     this.webContentsIdByTabId.delete(browserTabId)
     this.rendererWebContentsIdByTabId.delete(browserTabId)
     this.workspaceIdByPageId.delete(browserTabId)
+    this.sessionProfileIdByPageId.delete(browserTabId)
     this.worktreeIdByTabId.delete(browserTabId)
     // Why: drop any pending viewport-op chain for this tab so the Map doesn't
     // retain a resolved promise keyed to a destroyed guest.
@@ -681,6 +686,7 @@ export class BrowserManager {
     this.policyCleanupByGuestId.clear()
     this.tabIdByWebContentsId.clear()
     this.worktreeIdByTabId.clear()
+    this.sessionProfileIdByPageId.clear()
     this.pendingLoadFailuresByGuestId.clear()
     this.pendingPermissionEventsByGuestId.clear()
     this.pendingPopupEventsByGuestId.clear()
@@ -697,6 +703,10 @@ export class BrowserManager {
 
   getWorktreeIdForTab(browserTabId: string): string | undefined {
     return this.worktreeIdByTabId.get(browserTabId)
+  }
+
+  getSessionProfileIdForTab(browserTabId: string): string | null {
+    return this.sessionProfileIdByPageId.get(browserTabId) ?? null
   }
 
   notifyPermissionDenied(args: {

--- a/src/main/ipc/browser.ts
+++ b/src/main/ipc/browser.ts
@@ -103,6 +103,7 @@ export function registerBrowserHandlers(): void {
         browserPageId: string
         workspaceId: string
         worktreeId: string
+        sessionProfileId?: string | null
         webContentsId: number
       }
     ) => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -50,7 +50,11 @@ import type {
   BrowserScreenshotResult,
   BrowserEvalResult,
   BrowserTabListResult,
+  BrowserTabSetProfileResult,
   BrowserTabSwitchResult,
+  BrowserProfileCreateResult,
+  BrowserProfileDeleteResult,
+  BrowserProfileListResult,
   BrowserHoverResult,
   BrowserDragResult,
   BrowserUploadResult,
@@ -75,7 +79,9 @@ import type {
 } from '../../shared/runtime-types'
 import { BrowserWindow, ipcMain } from 'electron'
 import type { AgentBrowserBridge } from '../browser/agent-browser-bridge'
+import { browserManager } from '../browser/browser-manager'
 import { BrowserError } from '../browser/cdp-bridge'
+import { browserSessionRegistry } from '../browser/browser-session-registry'
 import { waitForTabRegistration } from '../ipc/browser'
 import { getPRForBranch } from '../github/client'
 import {
@@ -2303,7 +2309,20 @@ export class OrcaRuntimeService {
 
   async browserTabList(params: { worktree?: string }): Promise<BrowserTabListResult> {
     const worktreeId = await this.resolveBrowserWorktreeId(params.worktree)
-    return this.requireAgentBrowserBridge().tabList(worktreeId)
+    const result = this.requireAgentBrowserBridge().tabList(worktreeId)
+    return {
+      tabs: result.tabs.map((tab) => {
+        const rawProfileId = browserManager.getSessionProfileIdForTab(tab.browserPageId)
+        const profile =
+          browserSessionRegistry.getProfile(rawProfileId ?? 'default') ??
+          browserSessionRegistry.getDefaultProfile()
+        return {
+          ...tab,
+          profileId: profile.id,
+          profileLabel: profile.label
+        }
+      })
+    }
   }
 
   async browserTabSwitch(
@@ -2955,6 +2974,7 @@ export class OrcaRuntimeService {
   async browserTabCreate(params: {
     url?: string
     worktree?: string
+    profileId?: string
   }): Promise<{ browserPageId: string }> {
     const win = this.getAuthoritativeWindow()
     const requestId = randomUUID()
@@ -2998,7 +3018,12 @@ export class OrcaRuntimeService {
         }
       }
       ipcMain.on('browser:tabCreateReply', handler)
-      win.webContents.send('browser:requestTabCreate', { requestId, url, worktreeId })
+      win.webContents.send('browser:requestTabCreate', {
+        requestId,
+        url,
+        worktreeId,
+        sessionProfileId: params.profileId
+      })
     })
 
     // Why: the renderer creates the Zustand tab immediately, but the webview must
@@ -3038,6 +3063,79 @@ export class OrcaRuntimeService {
     }
 
     return { browserPageId }
+  }
+
+  async browserTabSetProfile(
+    params: {
+      profileId: string
+    } & BrowserCommandTargetParams
+  ): Promise<BrowserTabSetProfileResult> {
+    const target = await this.resolveBrowserCommandTarget(params)
+    const browserPageId = target.browserPageId ?? this.requireAgentBrowserBridge().getActivePageId(target.worktreeId)
+    if (!browserPageId) {
+      throw new BrowserError('browser_no_tab', 'No browser tab open in this worktree')
+    }
+    const profile = browserSessionRegistry.getProfile(params.profileId)
+    if (!profile) {
+      throw new BrowserError('invalid_argument', `Browser profile ${params.profileId} was not found`)
+    }
+
+    const win = this.getAuthoritativeWindow()
+    const requestId = randomUUID()
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        ipcMain.removeListener('browser:tabSetProfileReply', handler)
+        reject(new Error('Tab profile update timed out'))
+      }, 10_000)
+
+      const handler = (
+        _event: Electron.IpcMainEvent,
+        reply: { requestId: string; error?: string }
+      ): void => {
+        if (reply.requestId !== requestId) {
+          return
+        }
+        clearTimeout(timer)
+        ipcMain.removeListener('browser:tabSetProfileReply', handler)
+        if (reply.error) {
+          reject(new Error(reply.error))
+        } else {
+          resolve()
+        }
+      }
+      ipcMain.on('browser:tabSetProfileReply', handler)
+      win.webContents.send('browser:requestTabSetProfile', {
+        requestId,
+        browserPageId,
+        profileId: profile.id
+      })
+    })
+
+    return {
+      browserPageId,
+      profileId: profile.id,
+      profileLabel: profile.label
+    }
+  }
+
+  async browserProfileList(): Promise<BrowserProfileListResult> {
+    return { profiles: browserSessionRegistry.listProfiles() }
+  }
+
+  async browserProfileCreate(params: {
+    label: string
+    scope: 'isolated' | 'imported'
+  }): Promise<BrowserProfileCreateResult> {
+    return {
+      profile: browserSessionRegistry.createProfile(params.scope, params.label)
+    }
+  }
+
+  async browserProfileDelete(params: { profileId: string }): Promise<BrowserProfileDeleteResult> {
+    return {
+      deleted: await browserSessionRegistry.deleteProfile(params.profileId),
+      profileId: params.profileId
+    }
   }
 
   async browserTabClose(params: {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -49,8 +49,12 @@ import type {
   BrowserReloadResult,
   BrowserScreenshotResult,
   BrowserEvalResult,
+  BrowserTabCurrentResult,
   BrowserTabListResult,
+  BrowserTabProfileCloneResult,
+  BrowserTabProfileShowResult,
   BrowserTabSetProfileResult,
+  BrowserTabShowResult,
   BrowserTabSwitchResult,
   BrowserProfileCreateResult,
   BrowserProfileDeleteResult,
@@ -2311,18 +2315,25 @@ export class OrcaRuntimeService {
     const worktreeId = await this.resolveBrowserWorktreeId(params.worktree)
     const result = this.requireAgentBrowserBridge().tabList(worktreeId)
     return {
-      tabs: result.tabs.map((tab) => {
-        const rawProfileId = browserManager.getSessionProfileIdForTab(tab.browserPageId)
-        const profile =
-          browserSessionRegistry.getProfile(rawProfileId ?? 'default') ??
-          browserSessionRegistry.getDefaultProfile()
-        return {
-          ...tab,
-          profileId: profile.id,
-          profileLabel: profile.label
-        }
-      })
+      tabs: result.tabs.map((tab) => this.enrichBrowserTabInfo(tab))
     }
+  }
+
+  async browserTabShow(params: {
+    page: string
+    worktree?: string
+  }): Promise<BrowserTabShowResult> {
+    const worktreeId = await this.resolveBrowserWorktreeId(params.worktree)
+    return { tab: this.describeBrowserTab(params.page, worktreeId) }
+  }
+
+  async browserTabCurrent(params: { worktree?: string }): Promise<BrowserTabCurrentResult> {
+    const worktreeId = await this.resolveBrowserWorktreeId(params.worktree)
+    const browserPageId = this.requireAgentBrowserBridge().getActivePageId(worktreeId)
+    if (!browserPageId) {
+      throw new BrowserError('browser_no_tab', 'No browser tab open in this worktree')
+    }
+    return { tab: this.describeBrowserTab(browserPageId, worktreeId) }
   }
 
   async browserTabSwitch(
@@ -2976,55 +2987,11 @@ export class OrcaRuntimeService {
     worktree?: string
     profileId?: string
   }): Promise<{ browserPageId: string }> {
-    const win = this.getAuthoritativeWindow()
-    const requestId = randomUUID()
     const url = params.url ?? 'about:blank'
-
-    // Why: the renderer's Zustand store keys browser tabs by worktreeId in
-    // "repoId::path" format. The CLI sends a selector (e.g. "path:/Users/...").
-    // Resolve it here so the renderer receives the store-compatible ID.
     const worktreeId = params.worktree
       ? (await this.resolveWorktreeSelector(params.worktree)).id
       : undefined
-
-    // Why: browser webviews only mount when their worktree is active in the UI.
-    // Switch to it before creating the tab so the webview attaches immediately.
-    if (worktreeId) {
-      await this.ensureBrowserWorktreeActive(worktreeId)
-    }
-
-    // Why: tab creation is a renderer-side Zustand store operation. The main process
-    // sends a request, the renderer creates the tab and replies with the workspace ID
-    // (which is the browserPageId used by registerGuest and the bridge).
-    const browserPageId = await new Promise<string>((resolve, reject) => {
-      const timer = setTimeout(() => {
-        ipcMain.removeListener('browser:tabCreateReply', handler)
-        reject(new Error('Tab creation timed out'))
-      }, 10_000)
-
-      const handler = (
-        _event: Electron.IpcMainEvent,
-        reply: { requestId: string; browserPageId?: string; error?: string }
-      ): void => {
-        if (reply.requestId !== requestId) {
-          return
-        }
-        clearTimeout(timer)
-        ipcMain.removeListener('browser:tabCreateReply', handler)
-        if (reply.error) {
-          reject(new Error(reply.error))
-        } else {
-          resolve(reply.browserPageId!)
-        }
-      }
-      ipcMain.on('browser:tabCreateReply', handler)
-      win.webContents.send('browser:requestTabCreate', {
-        requestId,
-        url,
-        worktreeId,
-        sessionProfileId: params.profileId
-      })
-    })
+    const { browserPageId } = await this.createBrowserTabInRenderer(url, worktreeId, params.profileId)
 
     // Why: the renderer creates the Zustand tab immediately, but the webview must
     // mount and fire dom-ready before registerGuest runs. Waiting here ensures the
@@ -3113,6 +3080,54 @@ export class OrcaRuntimeService {
 
     return {
       browserPageId,
+      profileId: profile.id,
+      profileLabel: profile.label
+    }
+  }
+
+  async browserTabProfileShow(
+    params: {
+      page: string
+      worktree?: string
+    }
+  ): Promise<BrowserTabProfileShowResult> {
+    const worktreeId = await this.resolveBrowserWorktreeId(params.worktree)
+    const tab = this.describeBrowserTab(params.page, worktreeId)
+    return {
+      browserPageId: tab.browserPageId,
+      worktreeId: tab.worktreeId ?? null,
+      profileId: tab.profileId ?? null,
+      profileLabel: tab.profileLabel ?? null
+    }
+  }
+
+  async browserTabProfileClone(
+    params: {
+      profileId: string
+    } & BrowserCommandTargetParams
+  ): Promise<BrowserTabProfileCloneResult> {
+    const target = await this.resolveBrowserCommandTarget(params)
+    const sourceBrowserPageId =
+      target.browserPageId ?? this.requireAgentBrowserBridge().getActivePageId(target.worktreeId)
+    if (!sourceBrowserPageId) {
+      throw new BrowserError('browser_no_tab', 'No browser tab open in this worktree')
+    }
+    const sourceTab = this.describeBrowserTab(sourceBrowserPageId, target.worktreeId)
+    const profile = browserSessionRegistry.getProfile(params.profileId)
+    if (!profile) {
+      throw new BrowserError(
+        'invalid_argument',
+        `Browser profile ${params.profileId} was not found`
+      )
+    }
+    const created = await this.createBrowserTabInRenderer(
+      sourceTab.url,
+      sourceTab.worktreeId ?? target.worktreeId,
+      profile.id
+    )
+    return {
+      browserPageId: created.browserPageId,
+      sourceBrowserPageId,
       profileId: profile.id,
       profileLabel: profile.label
     }
@@ -3208,6 +3223,84 @@ export class OrcaRuntimeService {
     })
 
     return { closed: true }
+  }
+
+  private enrichBrowserTabInfo(
+    tab: BrowserTabListResult['tabs'][number]
+  ): BrowserTabListResult['tabs'][number] {
+    const rawProfileId = browserManager.getSessionProfileIdForTab(tab.browserPageId)
+    const profile =
+      browserSessionRegistry.getProfile(rawProfileId ?? 'default') ??
+      browserSessionRegistry.getDefaultProfile()
+    return {
+      ...tab,
+      worktreeId: browserManager.getWorktreeIdForTab(tab.browserPageId) ?? null,
+      profileId: profile.id,
+      profileLabel: profile.label
+    }
+  }
+
+  private describeBrowserTab(
+    browserPageId: string,
+    explicitWorktreeId?: string
+  ): BrowserTabListResult['tabs'][number] {
+    const worktreeId = explicitWorktreeId ?? browserManager.getWorktreeIdForTab(browserPageId)
+    const tab = this.requireAgentBrowserBridge()
+      .tabList(worktreeId)
+      .tabs.find((entry) => entry.browserPageId === browserPageId)
+    if (!tab) {
+      const scope = worktreeId ? ' in this worktree' : ''
+      throw new BrowserError(
+        'browser_tab_not_found',
+        `Browser page ${browserPageId} was not found${scope}`
+      )
+    }
+    return this.enrichBrowserTabInfo(tab)
+  }
+
+  private async createBrowserTabInRenderer(
+    url: string,
+    worktreeId?: string,
+    profileId?: string
+  ): Promise<{ browserPageId: string }> {
+    const win = this.getAuthoritativeWindow()
+    const requestId = randomUUID()
+
+    if (worktreeId) {
+      await this.ensureBrowserWorktreeActive(worktreeId)
+    }
+
+    const browserPageId = await new Promise<string>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        ipcMain.removeListener('browser:tabCreateReply', handler)
+        reject(new Error('Tab creation timed out'))
+      }, 10_000)
+
+      const handler = (
+        _event: Electron.IpcMainEvent,
+        reply: { requestId: string; browserPageId?: string; error?: string }
+      ): void => {
+        if (reply.requestId !== requestId) {
+          return
+        }
+        clearTimeout(timer)
+        ipcMain.removeListener('browser:tabCreateReply', handler)
+        if (reply.error) {
+          reject(new Error(reply.error))
+        } else {
+          resolve(reply.browserPageId!)
+        }
+      }
+      ipcMain.on('browser:tabCreateReply', handler)
+      win.webContents.send('browser:requestTabCreate', {
+        requestId,
+        url,
+        worktreeId,
+        sessionProfileId: profileId
+      })
+    })
+
+    return { browserPageId }
   }
 
   private getAuthoritativeWindow(): BrowserWindow {

--- a/src/main/runtime/rpc/methods/browser-core.ts
+++ b/src/main/runtime/rpc/methods/browser-core.ts
@@ -16,10 +16,13 @@ import {
   KeyboardInsert,
   Keypress,
   LimitParam,
+  ProfileCreate,
+  ProfileDelete,
   Screenshot,
   Scroll,
   Select,
   SelectorPath,
+  TabSetProfile,
   TabClose,
   TabCreate,
   TabList,
@@ -101,9 +104,29 @@ export const BROWSER_CORE_METHODS: RpcMethod[] = [
     handler: async (params, { runtime }) => runtime.browserTabCreate(params)
   }),
   defineMethod({
+    name: 'browser.tabSetProfile',
+    params: TabSetProfile,
+    handler: async (params, { runtime }) => runtime.browserTabSetProfile(params)
+  }),
+  defineMethod({
     name: 'browser.tabClose',
     params: TabClose,
     handler: async (params, { runtime }) => runtime.browserTabClose(params)
+  }),
+  defineMethod({
+    name: 'browser.profileList',
+    params: null,
+    handler: async (_params, { runtime }) => runtime.browserProfileList()
+  }),
+  defineMethod({
+    name: 'browser.profileCreate',
+    params: ProfileCreate,
+    handler: async (params, { runtime }) => runtime.browserProfileCreate(params)
+  }),
+  defineMethod({
+    name: 'browser.profileDelete',
+    params: ProfileDelete,
+    handler: async (params, { runtime }) => runtime.browserProfileDelete(params)
   }),
   defineMethod({
     name: 'browser.hover',

--- a/src/main/runtime/rpc/methods/browser-core.ts
+++ b/src/main/runtime/rpc/methods/browser-core.ts
@@ -22,10 +22,13 @@ import {
   Scroll,
   Select,
   SelectorPath,
+  TabCurrent,
   TabSetProfile,
   TabClose,
   TabCreate,
   TabList,
+  TabProfileClone,
+  TabShow,
   TabSwitch,
   Type,
   Upload,
@@ -94,6 +97,16 @@ export const BROWSER_CORE_METHODS: RpcMethod[] = [
     handler: async (params, { runtime }) => runtime.browserTabList(params)
   }),
   defineMethod({
+    name: 'browser.tabShow',
+    params: TabShow,
+    handler: async (params, { runtime }) => runtime.browserTabShow(params)
+  }),
+  defineMethod({
+    name: 'browser.tabCurrent',
+    params: TabCurrent,
+    handler: async (params, { runtime }) => runtime.browserTabCurrent(params)
+  }),
+  defineMethod({
     name: 'browser.tabSwitch',
     params: TabSwitch,
     handler: async (params, { runtime }) => runtime.browserTabSwitch(params)
@@ -107,6 +120,16 @@ export const BROWSER_CORE_METHODS: RpcMethod[] = [
     name: 'browser.tabSetProfile',
     params: TabSetProfile,
     handler: async (params, { runtime }) => runtime.browserTabSetProfile(params)
+  }),
+  defineMethod({
+    name: 'browser.tabProfileShow',
+    params: TabShow,
+    handler: async (params, { runtime }) => runtime.browserTabProfileShow(params)
+  }),
+  defineMethod({
+    name: 'browser.tabProfileClone',
+    params: TabProfileClone,
+    handler: async (params, { runtime }) => runtime.browserTabProfileClone(params)
   }),
   defineMethod({
     name: 'browser.tabClose',

--- a/src/main/runtime/rpc/methods/browser-schemas.ts
+++ b/src/main/runtime/rpc/methods/browser-schemas.ts
@@ -94,6 +94,15 @@ export const TabCreate = z.object({
   profileId: OptionalString
 })
 
+export const TabShow = z.object({
+  page: requiredString('Missing required --page'),
+  worktree: OptionalPlainString
+})
+
+export const TabCurrent = z.object({
+  worktree: OptionalString
+})
+
 export const TabClose = z.object({
   index: z
     .unknown()
@@ -104,6 +113,10 @@ export const TabClose = z.object({
 })
 
 export const TabSetProfile = BrowserTarget.extend({
+  profileId: requiredString('Missing required --profile')
+})
+
+export const TabProfileClone = BrowserTarget.extend({
   profileId: requiredString('Missing required --profile')
 })
 

--- a/src/main/runtime/rpc/methods/browser-schemas.ts
+++ b/src/main/runtime/rpc/methods/browser-schemas.ts
@@ -90,7 +90,8 @@ export const TabSwitch = BrowserTarget.extend({
 
 export const TabCreate = z.object({
   url: OptionalString,
-  worktree: OptionalString
+  worktree: OptionalString,
+  profileId: OptionalString
 })
 
 export const TabClose = z.object({
@@ -100,6 +101,10 @@ export const TabClose = z.object({
     .pipe(z.number().optional()),
   page: OptionalString,
   worktree: OptionalString
+})
+
+export const TabSetProfile = BrowserTarget.extend({
+  profileId: requiredString('Missing required --profile')
 })
 
 export const Drag = BrowserTarget.extend({
@@ -151,6 +156,23 @@ export const Highlight = BrowserTarget.extend({
 
 export const Exec = BrowserTarget.extend({
   command: requiredString('Missing required --command')
+})
+
+export const ProfileCreate = z.object({
+  label: requiredString('Missing required --label'),
+  scope: z
+    .unknown()
+    .transform((value) => {
+      if (value === 'imported') {
+        return 'imported'
+      }
+      return 'isolated'
+    })
+    .pipe(z.enum(['isolated', 'imported']))
+})
+
+export const ProfileDelete = z.object({
+  profileId: requiredString('Missing required --profile')
 })
 
 export const Get = BrowserTarget.extend({

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -124,6 +124,7 @@ export type BrowserApi = {
     browserPageId: string
     workspaceId: string
     worktreeId: string
+    sessionProfileId?: string | null
     webContentsId: number
   }) => Promise<void>
   unregisterGuest: (args: { browserPageId: string }) => Promise<void>
@@ -844,9 +845,18 @@ export type PreloadApi = {
     onWorktreeHistoryNavigate: (callback: (direction: 'back' | 'forward') => void) => () => void
     onNewBrowserTab: (callback: () => void) => () => void
     onRequestTabCreate: (
-      callback: (data: { requestId: string; url: string; worktreeId?: string }) => void
+      callback: (data: {
+        requestId: string
+        url: string
+        worktreeId?: string
+        sessionProfileId?: string
+      }) => void
     ) => () => void
     replyTabCreate: (reply: { requestId: string; browserPageId?: string; error?: string }) => void
+    onRequestTabSetProfile: (
+      callback: (data: { requestId: string; browserPageId: string; profileId: string }) => void
+    ) => () => void
+    replyTabSetProfile: (reply: { requestId: string; error?: string }) => void
     onRequestTabClose: (
       callback: (data: { requestId: string; tabId: string | null; worktreeId?: string }) => void
     ) => () => void

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -758,6 +758,7 @@ const api = {
       browserPageId: string
       workspaceId: string
       worktreeId: string
+      sessionProfileId?: string | null
       webContentsId: number
     }): Promise<void> => ipcRenderer.invoke('browser:registerGuest', args),
 
@@ -1373,11 +1374,16 @@ const api = {
       return () => ipcRenderer.removeListener('ui:newBrowserTab', listener)
     },
     onRequestTabCreate: (
-      callback: (data: { requestId: string; url: string; worktreeId?: string }) => void
+      callback: (data: {
+        requestId: string
+        url: string
+        worktreeId?: string
+        sessionProfileId?: string
+      }) => void
     ): (() => void) => {
       const listener = (
         _event: Electron.IpcRendererEvent,
-        data: { requestId: string; url: string; worktreeId?: string }
+        data: { requestId: string; url: string; worktreeId?: string; sessionProfileId?: string }
       ) => callback(data)
       ipcRenderer.on('browser:requestTabCreate', listener)
       return () => ipcRenderer.removeListener('browser:requestTabCreate', listener)
@@ -1388,6 +1394,19 @@ const api = {
       error?: string
     }): void => {
       ipcRenderer.send('browser:tabCreateReply', reply)
+    },
+    onRequestTabSetProfile: (
+      callback: (data: { requestId: string; browserPageId: string; profileId: string }) => void
+    ): (() => void) => {
+      const listener = (
+        _event: Electron.IpcRendererEvent,
+        data: { requestId: string; browserPageId: string; profileId: string }
+      ) => callback(data)
+      ipcRenderer.on('browser:requestTabSetProfile', listener)
+      return () => ipcRenderer.removeListener('browser:requestTabSetProfile', listener)
+    },
+    replyTabSetProfile: (reply: { requestId: string; error?: string }): void => {
+      ipcRenderer.send('browser:tabSetProfileReply', reply)
     },
     onRequestTabClose: (
       callback: (data: { requestId: string; tabId: string | null; worktreeId?: string }) => void

--- a/src/renderer/src/components/browser-pane/BrowserPane.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPane.tsx
@@ -949,6 +949,7 @@ function BrowserPagePane({
           browserPageId: browserTab.id,
           workspaceId,
           worktreeId,
+          sessionProfileId,
           webContentsId
         })
       }

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -18,6 +18,7 @@ import { dispatchClearModifierHints } from './useModifierHint'
 import { normalizeAgentStatusPayload } from '../../../shared/agent-status-types'
 import { isGitRepoKind } from '../../../shared/repo-kind'
 import { focusTerminalTabSurface } from '@/lib/focus-terminal-tab-surface'
+import { destroyPersistentWebview } from '@/components/browser-pane/webview-registry'
 
 export { resolveZoomTarget } from './resolve-zoom-target'
 
@@ -429,7 +430,8 @@ export function useIpcEvents(): void {
 
           const workspace = store.createBrowserTab(worktreeId, data.url, {
             title: data.url,
-            targetGroupId: activeBrowserUnifiedTab?.groupId
+            targetGroupId: activeBrowserUnifiedTab?.groupId,
+            sessionProfileId: data.sessionProfileId
           })
           // Why: registerGuest fires with the page ID (not workspace ID) as
           // browserPageId. Return the page ID so waitForTabRegistration can
@@ -441,6 +443,38 @@ export function useIpcEvents(): void {
           window.api.ui.replyTabCreate({
             requestId: data.requestId,
             error: err instanceof Error ? err.message : 'Tab creation failed'
+          })
+        }
+      })
+    )
+
+    unsubs.push(
+      window.api.ui.onRequestTabSetProfile((data) => {
+        try {
+          const store = useAppStore.getState()
+          const owningWorkspace = Object.values(store.browserTabsByWorktree)
+            .flat()
+            .find((workspace) => {
+              if (workspace.id === data.browserPageId) {
+                return true
+              }
+              const pages = store.browserPagesByWorkspace[workspace.id] ?? []
+              return pages.some((page) => page.id === data.browserPageId)
+            })
+          if (!owningWorkspace) {
+            window.api.ui.replyTabSetProfile({
+              requestId: data.requestId,
+              error: `Browser tab ${data.browserPageId} not found`
+            })
+            return
+          }
+          destroyPersistentWebview(data.browserPageId)
+          store.switchBrowserTabProfile(owningWorkspace.id, data.profileId)
+          window.api.ui.replyTabSetProfile({ requestId: data.requestId })
+        } catch (err) {
+          window.api.ui.replyTabSetProfile({
+            requestId: data.requestId,
+            error: err instanceof Error ? err.message : 'Tab profile update failed'
           })
         }
       })

--- a/src/shared/runtime-types.ts
+++ b/src/shared/runtime-types.ts
@@ -252,6 +252,7 @@ export type BrowserTabInfo = {
   url: string
   title: string
   active: boolean
+  worktreeId?: string | null
   profileId?: string | null
   profileLabel?: string | null
 }
@@ -267,6 +268,28 @@ export type BrowserTabSwitchResult = {
 
 export type BrowserTabSetProfileResult = {
   browserPageId: string
+  profileId: string | null
+  profileLabel: string | null
+}
+
+export type BrowserTabShowResult = {
+  tab: BrowserTabInfo
+}
+
+export type BrowserTabCurrentResult = {
+  tab: BrowserTabInfo
+}
+
+export type BrowserTabProfileShowResult = {
+  browserPageId: string
+  worktreeId: string | null
+  profileId: string | null
+  profileLabel: string | null
+}
+
+export type BrowserTabProfileCloneResult = {
+  browserPageId: string
+  sourceBrowserPageId: string
   profileId: string | null
   profileLabel: string | null
 }

--- a/src/shared/runtime-types.ts
+++ b/src/shared/runtime-types.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines -- Why: shared type definitions for all runtime RPC methods live in one file for discoverability and import simplicity. */
 import type { TerminalPaneLayoutNode } from './types'
-import type { GitWorktreeInfo, Repo } from './types'
+import type { BrowserSessionProfile, GitWorktreeInfo, Repo } from './types'
 
 export type RuntimeGraphStatus = 'ready' | 'reloading' | 'unavailable'
 
@@ -252,6 +252,8 @@ export type BrowserTabInfo = {
   url: string
   title: string
   active: boolean
+  profileId?: string | null
+  profileLabel?: string | null
 }
 
 export type BrowserTabListResult = {
@@ -261,6 +263,25 @@ export type BrowserTabListResult = {
 export type BrowserTabSwitchResult = {
   switched: number
   browserPageId: string
+}
+
+export type BrowserTabSetProfileResult = {
+  browserPageId: string
+  profileId: string | null
+  profileLabel: string | null
+}
+
+export type BrowserProfileListResult = {
+  profiles: BrowserSessionProfile[]
+}
+
+export type BrowserProfileCreateResult = {
+  profile: BrowserSessionProfile | null
+}
+
+export type BrowserProfileDeleteResult = {
+  deleted: boolean
+  profileId: string
 }
 
 export type BrowserHoverResult = {


### PR DESCRIPTION
## Summary
- add browser tab inspection primitives for automation
- add browser tab profile inspection and clone primitives
- keep the commands under `tab` / `tab profile` so external automation can build its own rotation strategy on top

## Depends on
- #1396

This branch is stacked on top of the tab profile control work in #1396. Review the diff commit-by-commit or after #1396 lands.

## What changed
- added `orca tab show --page <id>`
- added `orca tab current [--worktree <selector|all>]`
- added `orca tab profile show --page <id>`
- added `orca tab profile use-default --page <id>`
- added `orca tab profile clone --profile <id> [--page <id>] [--worktree <selector>]`
- added richer automation-facing tab metadata including worktree/profile fields

## Why
This PR intentionally does not implement round-robin or any policy layer. Instead, it exposes the inspection and cloning primitives that an external program needs in order to safely implement its own profile selection logic.

With these commands, an external automation layer can:
- inspect the current tab and its profile
- read the profile bound to a specific tab
- reset a tab to the default profile
- clone the current page into a different profile without mutating the original tab

## Tests
- `./node_modules/.bin/vitest run src/cli/browser.test.ts src/cli/index.test.ts`
- `./node_modules/.bin/tsc --noEmit -p config/tsconfig.cli.json --composite false`
- `./node_modules/.bin/tsc --noEmit -p config/tsconfig.node.json --composite false`
