### PR TITLE
fix(browser): default webview background to white

### DIFF
--- a/src/renderer/src/components/browser-pane/BrowserPane.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPane.tsx
@@ -933,7 +933,11 @@ function BrowserPagePane({
       webview.style.width = '100%'
       webview.style.height = '100%'
       webview.style.border = 'none'
-      webview.style.background = 'transparent'
+      // Why: default to white so sites that don't set an html/body background
+      // (e.g. httpbin.org/html) don't show through to Orca's dark chrome. Real
+      // browsers paint the viewport white by default; sites that specify their
+      // own background (including dark ones) still override this.
+      webview.style.background = '#ffffff'
       webviewRegistry.set(browserTab.id, webview)
       container.appendChild(webview)
       needsInitialNavigation = true


### PR DESCRIPTION
## Problem

Sites that don't set an html/body background (e.g. [httpbin.org/html](https://httpbin.org/html)) appear with a black background in Orca's built-in browser when the IDE is in dark mode. That's because the `<webview>` host element was styled with `background: transparent`, so Orca's dark chrome bled through whenever the guest page didn't paint its own background.

## Fix

Default the webview host background to `#ffffff`. This matches how real browsers (Chrome/Safari/Firefox) paint the viewport white by default. Sites that specify their own background — light or dark — still override it, so nothing changes for pages that correctly declare a background.

```tsx
webview.style.background = '#ffffff'
```

## Verification

- `pnpm run lint` passes
- `pnpm run tc:web` passes
- Manually: httpbin.org/html and similar minimal-HTML sites now render with a white viewport in dark mode

Made with [Orca](https://github.com/stablyai/orca) 🐋
