### PR TITLE
Preserve workspace name casing

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -417,7 +417,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
 
                   <div className="min-w-0 flex-1">
                     <div className="flex items-center gap-1.5">
-                      <div className="truncate text-[13px] font-semibold leading-none capitalize">
+                      <div className="truncate text-[13px] font-semibold leading-none">
                         {row.label}
                       </div>
                       <div className="rounded-full bg-black/12 px-1.5 py-0.5 text-[9px] font-medium leading-none text-muted-foreground/90">

--- a/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 import { buildRows, getPRGroupKey } from './worktree-list-groups'
 import type { Repo, Worktree } from '../../../../shared/types'
@@ -90,5 +92,23 @@ describe('buildRows with pinned worktrees', () => {
     const allPinned = { ...unpinned1, isPinned: true }
     const rows = buildRows('none', [pinned, allPinned], repoMap, null, new Set())
     expect(rows.some((r) => r.type === 'header' && r.key === 'all')).toBe(false)
+  })
+
+  it('preserves repo display casing in group labels', () => {
+    const lowercaseRepo = { ...repo, displayName: 'c15t' }
+    const rows = buildRows('repo', [worktree], new Map([[repo.id, lowercaseRepo]]), null, new Set())
+
+    expect(rows[0]).toMatchObject({ type: 'header', label: 'c15t' })
+  })
+})
+
+describe('WorktreeList header styles', () => {
+  it('does not title-case workspace group labels', () => {
+    const source = readFileSync(
+      fileURLToPath(new URL('./WorktreeList.tsx', import.meta.url)),
+      'utf8'
+    )
+
+    expect(source).not.toContain('leading-none capitalize')
   })
 })


### PR DESCRIPTION
## Summary

Preserves user-provided workspace and repo name casing in sidebar group labels.

The sidebar group header was applying Tailwind's `capitalize` class, which changed names at render time. For example, a folder or repo named `c15t` appeared as `C15t`, even though the stored display name was already correct.

## Changes

- Removes the `capitalize` class from workspace group header labels.
- Adds regression coverage for lowercase repo display names such as `c15t`.
- Adds a guard so the title-casing style is not reintroduced on the sidebar header.

## Validation

- `pnpm test src/renderer/src/components/sidebar/worktree-list-groups.test.ts`