### PR TITLE
fix(dev): skip single-instance lock for pnpm dev

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -120,7 +120,16 @@ function focusExistingWindow(): void {
 // derives the lock identity from the `userData` path, so this placement lets
 // dev (`orca-dev`) and packaged (`orca`) runs lock in separate namespaces
 // instead of serialising against each other.
-const hasSingleInstanceLock = acquireSingleInstanceLock(app, focusExistingWindow)
+//
+// Why skip in dev: engineers routinely run `pnpm dev` in parallel from
+// multiple worktrees while shipping features, and the lock makes the second
+// `pnpm dev` exit silently. In dev we accept that `orca-runtime.json` and
+// `endpoint.env` may race (the bundled `orca-dev` CLI / agent hooks route
+// to whichever instance wrote last). The dev build is not used for real
+// agent work, so that routing ambiguity is acceptable. Packaged Orca keeps
+// the lock to protect against the corruption documented in PR #1326 /
+// issue #1312.
+const hasSingleInstanceLock = is.dev ? true : acquireSingleInstanceLock(app, focusExistingWindow)
 if (!hasSingleInstanceLock) {
   if (is.dev) {
     // Why: packaged runs have no attached console, but dev runs do. Emit a


### PR DESCRIPTION
## Summary

Allow multiple parallel \`pnpm dev\` runs across worktrees by gating the single-instance lock acquisition on \`is.dev\`. Packaged Orca behavior is unchanged — the lock added in #1326 still protects against the \`orca-runtime.json\` / \`endpoint.env\` corruption documented in #1312.

## Motivation

Devs routinely create and tear down dozens of worktrees per day while shipping features in parallel. The single-instance lock added in #1326 makes the second \`pnpm dev\` exit silently with \`[single-instance] Another Orca instance is already running...\`, which blocks parallel feature development. The pre-existing escape hatch (\`ORCA_DEV_USER_DATA_PATH\`) requires devs to know about it, choose unique paths per worktree, and keep the env var in sync with the CLI wrapper — none of which scales to ephemeral worktrees.

## Approach

One-line change in \`src/main/index.ts\`:

\`\`\`ts
const hasSingleInstanceLock = is.dev ? true : acquireSingleInstanceLock(app, focusExistingWindow)
\`\`\`

In dev, \`hasSingleInstanceLock\` is unconditionally \`true\`, so the file-writing init runs as normal and no \`second-instance\` listener is registered (there's nothing to focus when there's no lock). The downstream \`if (hasSingleInstanceLock)\` guard becomes a no-op in dev, which is fine — packaged builds are the only place the guard actually matters now.

## Risks accepted (dev only)

These are explicitly OK because dev Orca is not used for real agent work — devs use packaged Orca for that and run \`pnpm dev\` to test other features:

- **\`orca-runtime.json\` race** — \`orca-dev\` CLI may hit the wrong window when multiple dev instances are running. Rare, recoverable, no data loss.
- **\`endpoint.env\` race** — agent hooks (Cursor / Claude / Codex / Gemini / opencode) may route to whichever instance wrote last. Not a real concern for our usage pattern.
- **SQLite contention on the shared dev DB** — handled by better-sqlite3 + WAL.
- **Hot-reload edge cases** — unchanged from today; the dev-parent watchdog still handles parent-process death.

## Production unchanged

The lock branch in \`src/main/index.ts\` still runs \`acquireSingleInstanceLock\` for packaged Orca, so all the guarantees from #1326 / #1312 remain:

- No \`orca-runtime.json\` clobber on AppImage / .app double-click.
- No \`stale_bootstrap\` after second-instance quit.
- Owned-metadata clear on clean exit still runs.
- Orphan-socket sweep on startup still runs.

## Verification

- [x] \`pnpm run lint\` — clean (oxlint, 0 errors).
- [x] \`pnpm run tc:node\` — clean.
- [x] \`pnpm vitest run src/main/startup/single-instance-lock.test.ts\` — 3 tests pass (helper unit tests are unaffected; we changed the call site, not the helper).
- [ ] Manual: \`pnpm dev\` from two worktrees in parallel → both boot.
- [ ] Manual: packaged build → second launch still focuses existing window.

Made with [Orca](https://github.com/stablyai/orca) 🐋