### PR TITLE
chore(mobile): bump to v0.0.2 and update Settings release link

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Orca",
     "slug": "orca-mobile",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",
@@ -16,7 +16,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.stably.orca.mobile",
-      "buildNumber": "2",
+      "buildNumber": "3",
       "infoPlist": {
         "NSLocalNetworkUsageDescription": "Orca connects to the desktop app on your local network.",
         "NSAppTransportSecurity": {

--- a/src/renderer/src/components/settings/ExperimentalPane.tsx
+++ b/src/renderer/src/components/settings/ExperimentalPane.tsx
@@ -231,7 +231,7 @@ export function ExperimentalPane({
                   // when cutting a new mobile-v* tag.
                   onClick={() =>
                     void window.api.shell.openUrl(
-                      'https://github.com/stablyai/orca/releases/tag/mobile-v0.0.1'
+                      'https://github.com/stablyai/orca/releases/tag/mobile-v0.0.2'
                     )
                   }
                   className="cursor-pointer underline underline-offset-2 hover:text-foreground"


### PR DESCRIPTION
Bumps the mobile app to **0.0.2** (matching the freshly-tagged `mobile-v0.0.2` release) and points the desktop Settings → Experimental download link at the new release tag.

## Changes

- `mobile/app.json` — `version` 0.0.1 → 0.0.2, iOS `buildNumber` 2 → 3 (every TestFlight upload needs a unique `CFBundleVersion`).
- `src/renderer/src/components/settings/ExperimentalPane.tsx` — release-tag URL updated so the in-app "Download mobile app" button lands on the v0.0.2 release page instead of v0.0.1.

## Why a separate PR

The mobile-v0.0.2 git tag was pushed off the merge commit for #1423 to trigger the Android Release workflow. These bumps are follow-up housekeeping needed for the iOS TestFlight build and the desktop in-app link, but they don't have to be in the tagged commit (the Android APK build doesn't read `version`/`buildNumber`).

Made with [Orca](https://github.com/stablyai/orca) 🐋
