### PR TITLE
Disable theme transitions during theme swaps

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -38,6 +38,7 @@ import { registerUpdaterBeforeUnloadBypass } from './lib/updater-beforeunload'
 import { buildWorkspaceSessionPayload } from './lib/workspace-session'
 import { countWorkingAgents, getWorkingAgentsPerWorktree } from './lib/agent-status'
 import { activateAndRevealWorktree } from './lib/worktree-activation'
+import { applyDocumentTheme } from './lib/document-theme'
 import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover'
 import { findWorktreeById, getRepoIdFromWorktreeId } from '@/store/slices/worktree-helpers'
 import {
@@ -498,21 +499,17 @@ function App(): React.JSX.Element {
       return
     }
 
-    const applyTheme = (dark: boolean): void => {
-      document.documentElement.classList.toggle('dark', dark)
-    }
-
     if (settings.theme === 'dark') {
-      applyTheme(true)
+      applyDocumentTheme('dark')
       return undefined
     } else if (settings.theme === 'light') {
-      applyTheme(false)
+      applyDocumentTheme('light')
       return undefined
     } else {
       // system
       const mq = window.matchMedia('(prefers-color-scheme: dark)')
-      applyTheme(mq.matches)
-      const handler = (e: MediaQueryListEvent): void => applyTheme(e.matches)
+      applyDocumentTheme('system')
+      const handler = (): void => applyDocumentTheme('system')
       mq.addEventListener('change', handler)
       return () => mq.removeEventListener('change', handler)
     }

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -16,6 +16,14 @@
 
 @custom-variant dark (&:is(.dark *));
 
+.theme-transition-disabled *,
+.theme-transition-disabled *::before,
+.theme-transition-disabled *::after {
+  /* Why: theme swaps flip many CSS variables at once; transitions make parts of
+     the UI fade at different speeds. Animations stay enabled for spinners. */
+  transition: none !important;
+}
+
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);

--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -22,6 +22,7 @@ import { getRepoKindLabel, isFolderRepo } from '../../../../shared/repo-kind'
 import { useAppStore } from '../../store'
 import { useSystemPrefersDark } from '@/components/terminal-pane/use-system-prefers-dark'
 import { isMacUserAgent, isWindowsUserAgent } from '@/components/terminal-pane/pane-helpers'
+import { applyDocumentTheme } from '@/lib/document-theme'
 import { SCROLLBACK_PRESETS_MB, getFallbackTerminalFonts } from './SettingsConstants'
 import { GeneralPane, GENERAL_PANE_SEARCH_ENTRIES } from './GeneralPane'
 import { BrowserPane, BROWSER_PANE_SEARCH_ENTRIES } from './BrowserPane'
@@ -322,19 +323,7 @@ function Settings(): React.JSX.Element {
   }, [repos])
 
   const applyTheme = useCallback((theme: 'system' | 'dark' | 'light') => {
-    const root = document.documentElement
-    if (theme === 'dark') {
-      root.classList.add('dark')
-    } else if (theme === 'light') {
-      root.classList.remove('dark')
-    } else {
-      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
-      if (prefersDark) {
-        root.classList.add('dark')
-      } else {
-        root.classList.remove('dark')
-      }
-    }
+    applyDocumentTheme(theme)
   }, [])
 
   const displayedGitUsername = repos[0]?.gitUsername ?? ''

--- a/src/renderer/src/lib/document-theme.test.ts
+++ b/src/renderer/src/lib/document-theme.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest'
+import {
+  applyDocumentTheme,
+  resolveDocumentTheme,
+  THEME_TRANSITION_DISABLED_CLASS
+} from './document-theme'
+
+class FakeClassList {
+  private readonly tokens = new Set<string>()
+
+  add(...tokens: string[]): void {
+    for (const token of tokens) {
+      this.tokens.add(token)
+    }
+  }
+
+  remove(...tokens: string[]): void {
+    for (const token of tokens) {
+      this.tokens.delete(token)
+    }
+  }
+
+  toggle(token: string, force?: boolean): boolean {
+    if (force === true) {
+      this.tokens.add(token)
+      return true
+    }
+    if (force === false) {
+      this.tokens.delete(token)
+      return false
+    }
+    if (this.tokens.has(token)) {
+      this.tokens.delete(token)
+      return false
+    }
+    this.tokens.add(token)
+    return true
+  }
+
+  contains(token: string): boolean {
+    return this.tokens.has(token)
+  }
+}
+
+function createThemeRoot(): { classList: FakeClassList } {
+  return { classList: new FakeClassList() }
+}
+
+function createFrameQueue(): {
+  requestAnimationFrame: (callback: FrameRequestCallback) => number
+  flushNextFrame: () => void
+} {
+  const callbacks: FrameRequestCallback[] = []
+  return {
+    requestAnimationFrame: (callback) => {
+      callbacks.push(callback)
+      return callbacks.length
+    },
+    flushNextFrame: () => {
+      callbacks.shift()?.(0)
+    }
+  }
+}
+
+describe('document theme', () => {
+  it('resolves explicit theme preferences', () => {
+    expect(resolveDocumentTheme('dark')).toBe(true)
+    expect(resolveDocumentTheme('light')).toBe(false)
+  })
+
+  it('resolves system from matchMedia', () => {
+    expect(resolveDocumentTheme('system', () => ({ matches: true }))).toBe(true)
+    expect(resolveDocumentTheme('system', () => ({ matches: false }))).toBe(false)
+  })
+
+  it('applies dark and light root classes', () => {
+    const root = createThemeRoot()
+
+    applyDocumentTheme('dark', { root, disableTransitions: false })
+    expect(root.classList.contains('dark')).toBe(true)
+
+    applyDocumentTheme('light', { root, disableTransitions: false })
+    expect(root.classList.contains('dark')).toBe(false)
+  })
+
+  it('applies system root class from matchMedia', () => {
+    const root = createThemeRoot()
+
+    applyDocumentTheme('system', {
+      root,
+      matchMedia: () => ({ matches: true }),
+      disableTransitions: false
+    })
+    expect(root.classList.contains('dark')).toBe(true)
+  })
+
+  it('removes the transition suppression class after two animation frames', () => {
+    const root = createThemeRoot()
+    const frames = createFrameQueue()
+
+    applyDocumentTheme('dark', {
+      root,
+      requestAnimationFrame: frames.requestAnimationFrame
+    })
+
+    expect(root.classList.contains(THEME_TRANSITION_DISABLED_CLASS)).toBe(true)
+
+    frames.flushNextFrame()
+    expect(root.classList.contains(THEME_TRANSITION_DISABLED_CLASS)).toBe(true)
+
+    frames.flushNextFrame()
+    expect(root.classList.contains(THEME_TRANSITION_DISABLED_CLASS)).toBe(false)
+  })
+})

--- a/src/renderer/src/lib/document-theme.ts
+++ b/src/renderer/src/lib/document-theme.ts
@@ -1,0 +1,75 @@
+import type { GlobalSettings } from '../../../shared/types'
+
+export type DocumentThemePreference = GlobalSettings['theme']
+
+export const THEME_TRANSITION_DISABLED_CLASS = 'theme-transition-disabled'
+
+const DARK_MODE_QUERY = '(prefers-color-scheme: dark)'
+
+type ThemeClassList = {
+  add: (...tokens: string[]) => void
+  remove: (...tokens: string[]) => void
+  toggle: (token: string, force?: boolean) => boolean
+}
+
+type ThemeRoot = {
+  classList: ThemeClassList
+}
+
+type ThemeMediaMatcher = (query: string) => Pick<MediaQueryList, 'matches'>
+type ThemeAnimationFrame = (callback: FrameRequestCallback) => number
+
+type ApplyDocumentThemeOptions = {
+  root?: ThemeRoot
+  matchMedia?: ThemeMediaMatcher
+  requestAnimationFrame?: ThemeAnimationFrame
+  disableTransitions?: boolean
+}
+
+function systemPrefersDark(
+  matchMedia: ThemeMediaMatcher = window.matchMedia.bind(window)
+): boolean {
+  return matchMedia(DARK_MODE_QUERY).matches
+}
+
+export function resolveDocumentTheme(
+  theme: DocumentThemePreference,
+  matchMedia?: ThemeMediaMatcher
+): boolean {
+  if (theme === 'dark') {
+    return true
+  }
+  if (theme === 'light') {
+    return false
+  }
+  return systemPrefersDark(matchMedia)
+}
+
+export function applyDocumentTheme(
+  theme: DocumentThemePreference,
+  options: ApplyDocumentThemeOptions = {}
+): void {
+  const root = options.root ?? document.documentElement
+  const disableTransitions = options.disableTransitions ?? true
+  const shouldUseDarkTheme = resolveDocumentTheme(theme, options.matchMedia)
+
+  if (disableTransitions) {
+    root.classList.add(THEME_TRANSITION_DISABLED_CLASS)
+  }
+
+  root.classList.toggle('dark', shouldUseDarkTheme)
+
+  if (!disableTransitions) {
+    return
+  }
+
+  const requestFrame = options.requestAnimationFrame ?? window.requestAnimationFrame.bind(window)
+
+  // Why: two frames lets the root theme class recalculate before restoring
+  // normal hover/collapse transitions, preventing staggered color fades.
+  requestFrame(() => {
+    requestFrame(() => {
+      root.classList.remove(THEME_TRANSITION_DISABLED_CLASS)
+    })
+  })
+}

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -3,20 +3,14 @@ import './assets/main.css'
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App'
+import { applyDocumentTheme } from './lib/document-theme'
 
 if (import.meta.env.DEV) {
   import('react-grab').then(({ init }) => init())
   import('react-grab/styles.css')
 }
 
-// Respect system dark mode preference
-function applySystemTheme(): void {
-  const isDark = window.matchMedia('(prefers-color-scheme: dark)').matches
-  document.documentElement.classList.toggle('dark', isDark)
-}
-
-applySystemTheme()
-window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', applySystemTheme)
+applyDocumentTheme('system', { disableTransitions: false })
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>


### PR DESCRIPTION
## Summary

Disable CSS transitions only while Orca flips the document theme class so light/dark swaps happen instantly instead of fading different UI elements at different speeds.

## Changes

- Added a shared renderer document theme helper that resolves `system`, `dark`, and `light` preferences.
- Temporarily applies a root transition-suppression class during theme swaps and removes it after two animation frames.
- Wired startup, settings, and system theme change handling through the shared helper.
- Added focused unit coverage for theme resolution, root class toggling, and transition suppression cleanup.

## Validation

- `pnpm test src/renderer/src/lib/document-theme.test.ts`
- `pnpm run tc:web`
- `pnpm exec oxlint src/renderer/src/lib/document-theme.ts src/renderer/src/lib/document-theme.test.ts src/renderer/src/main.tsx src/renderer/src/App.tsx src/renderer/src/components/settings/Settings.tsx`
- `git diff --check`
