### PR TITLE
fix: enable Codex hook notifications

### DIFF
--- a/src/main/ipc/notifications.test.ts
+++ b/src/main/ipc/notifications.test.ts
@@ -293,6 +293,116 @@ describe('registerNotificationHandlers', () => {
     expect(notificationShowMock).toHaveBeenCalledTimes(1)
   })
 
+  it('allows independent pane notifications in the same worktree', () => {
+    registerNotificationHandlers({
+      getSettings: () => ({
+        notifications: {
+          enabled: true,
+          agentTaskComplete: true,
+          terminalBell: true,
+          suppressWhenFocused: false
+        }
+      })
+    } as never)
+
+    const handler = getDispatchHandler()
+
+    expect(
+      handler({}, { source: 'agent-task-complete', worktreeId: 'repo::wt1', dedupeKey: 'tab-1:1' })
+    ).toEqual({ delivered: true })
+    expect(
+      handler({}, { source: 'agent-task-complete', worktreeId: 'repo::wt1', dedupeKey: 'tab-1:2' })
+    ).toEqual({ delivered: true })
+    expect(notificationShowMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('deduplicates duplicate signals for the same pane', () => {
+    registerNotificationHandlers({
+      getSettings: () => ({
+        notifications: {
+          enabled: true,
+          agentTaskComplete: true,
+          terminalBell: true,
+          suppressWhenFocused: false
+        }
+      })
+    } as never)
+
+    const handler = getDispatchHandler()
+
+    expect(
+      handler({}, { source: 'agent-task-complete', worktreeId: 'repo::wt1', dedupeKey: 'tab-1:1' })
+    ).toEqual({ delivered: true })
+    expect(
+      handler({}, { source: 'terminal-bell', worktreeId: 'repo::wt1', dedupeKey: 'tab-1:1' })
+    ).toEqual({
+      delivered: false,
+      reason: 'cooldown'
+    })
+    expect(notificationShowMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('deduplicates mobile notification fanout for the same worktree', () => {
+    const dispatchMobileNotification = vi.fn()
+    registerNotificationHandlers(
+      {
+        getSettings: () => ({
+          notifications: {
+            enabled: true,
+            agentTaskComplete: true,
+            terminalBell: true,
+            suppressWhenFocused: false
+          }
+        })
+      } as never,
+      { dispatchMobileNotification } as never
+    )
+
+    const handler = getDispatchHandler()
+
+    expect(handler({}, { source: 'agent-task-complete', worktreeId: 'repo::wt1' })).toEqual({
+      delivered: true
+    })
+    expect(handler({}, { source: 'agent-task-complete', worktreeId: 'repo::wt1' })).toEqual({
+      delivered: false,
+      reason: 'cooldown'
+    })
+
+    vi.advanceTimersByTime(5001)
+
+    expect(handler({}, { source: 'agent-task-complete', worktreeId: 'repo::wt1' })).toEqual({
+      delivered: true
+    })
+    expect(dispatchMobileNotification).toHaveBeenCalledTimes(2)
+  })
+
+  it('allows mobile notification fanout for independent panes in the same worktree', () => {
+    const dispatchMobileNotification = vi.fn()
+    registerNotificationHandlers(
+      {
+        getSettings: () => ({
+          notifications: {
+            enabled: true,
+            agentTaskComplete: true,
+            terminalBell: true,
+            suppressWhenFocused: false
+          }
+        })
+      } as never,
+      { dispatchMobileNotification } as never
+    )
+
+    const handler = getDispatchHandler()
+
+    expect(
+      handler({}, { source: 'agent-task-complete', worktreeId: 'repo::wt1', dedupeKey: 'tab-1:1' })
+    ).toEqual({ delivered: true })
+    expect(
+      handler({}, { source: 'agent-task-complete', worktreeId: 'repo::wt1', dedupeKey: 'tab-1:2' })
+    ).toEqual({ delivered: true })
+    expect(dispatchMobileNotification).toHaveBeenCalledTimes(2)
+  })
+
   it('loads allowed custom sound files for preload playback', async () => {
     const soundPath = join(tempDir, 'sound.ogg')
     writeFileSync(soundPath, Buffer.from([1, 2, 3]))

--- a/src/main/ipc/notifications.ts
+++ b/src/main/ipc/notifications.ts
@@ -31,6 +31,7 @@ const activeNotifications = new Set<Notification>()
 
 export function registerNotificationHandlers(store: Store, runtime?: OrcaRuntimeService): void {
   const recentNotifications = new Map<string, number>()
+  const recentMobileNotifications = new Map<string, number>()
 
   ipcMain.removeHandler('notifications:openSystemSettings')
   ipcMain.removeHandler('notifications:getPermissionStatus')
@@ -67,12 +68,15 @@ export function registerNotificationHandlers(store: Store, runtime?: OrcaRuntime
   ipcMain.handle(
     'notifications:dispatch',
     (_event, args: NotificationDispatchRequest): NotificationDispatchResult => {
-      // Why: mobile push is independent of desktop notification guards.
-      // The user's phone should receive the notification even when the desktop
-      // window is focused (suppressWhenFocused), Electron notifications aren't
-      // supported, or the desktop is in cooldown. The mobile client decides
-      // independently whether to show based on its own app state.
-      if (runtime) {
+      // Why: mobile push is independent of desktop notification guards like
+      // focus suppression and Electron support, but it still needs its own
+      // cooldown because hooks and title transitions can report the same
+      // completion through separate renderer paths.
+      const dedupeKey = getNotificationDedupeKey(args)
+      const now = Date.now()
+      const lastMobileSentAt = recentMobileNotifications.get(dedupeKey) ?? 0
+      const shouldDispatchMobile = now - lastMobileSentAt >= NOTIFICATION_COOLDOWN_MS
+      if (runtime && shouldDispatchMobile) {
         const opts = buildNotificationOptions(args)
         runtime.dispatchMobileNotification({
           source: args.source,
@@ -80,6 +84,14 @@ export function registerNotificationHandlers(store: Store, runtime?: OrcaRuntime
           body: opts.body,
           worktreeId: args.worktreeId
         })
+        recentMobileNotifications.set(dedupeKey, now)
+        if (recentMobileNotifications.size > 50) {
+          for (const [key, ts] of recentMobileNotifications) {
+            if (now - ts >= NOTIFICATION_COOLDOWN_MS) {
+              recentMobileNotifications.delete(key)
+            }
+          }
+        }
       }
 
       if (!Notification.isSupported()) {
@@ -109,10 +121,9 @@ export function registerNotificationHandlers(store: Store, runtime?: OrcaRuntime
         return { delivered: false, reason: 'suppressed-focus' }
       }
 
-      // Dedupe by worktree, not by source — an agent finishing and a terminal bell
-      // often fire within the same data chunk so only the first one should surface.
-      const dedupeKey = args.worktreeId ?? args.worktreeLabel ?? 'global'
-      const now = Date.now()
+      // Dedupe by the pane-scoped key when available, not by source — an agent
+      // finishing and a terminal bell often fire within the same data chunk so
+      // only the first one should surface for that pane.
       const lastSentAt = recentNotifications.get(dedupeKey) ?? 0
       if (now - lastSentAt < NOTIFICATION_COOLDOWN_MS) {
         return { delivered: false, reason: 'cooldown' }
@@ -301,6 +312,16 @@ export function triggerStartupNotificationRegistration(store: Store): void {
   setTimeout(cleanup, 10_000)
 
   notification.show()
+}
+
+function getNotificationDedupeKey(args: NotificationDispatchRequest): string {
+  // Why: two panes in the same worktree are separate attention sources and
+  // must not suppress each other. A pane-scoped key still collapses duplicate
+  // hook/title/BEL signals for the same pane.
+  if (args.dedupeKey) {
+    return `pane:${args.dedupeKey}`
+  }
+  return args.worktreeId ?? args.worktreeLabel ?? 'global'
 }
 
 function buildNotificationOptions(args: NotificationDispatchRequest): {

--- a/src/renderer/src/components/terminal-pane/pty-connection-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-types.ts
@@ -37,6 +37,7 @@ export type PtyConnectionDeps = {
   // main process can also emit `'test'` from the settings-pane button.
   dispatchNotification: (event: {
     source: 'terminal-bell' | 'agent-task-complete'
+    dedupeKey?: string
     terminalTitle?: string
   }) => void
   setCacheTimerStartedAt: (key: string, ts: number | null) => void

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -1126,7 +1126,10 @@ describe('connectPanePty', () => {
 
     expect(deps.markWorktreeUnread).toHaveBeenCalledTimes(1)
     expect(deps.markTerminalTabUnread).toHaveBeenCalledWith('tab-1')
-    expect(deps.dispatchNotification).toHaveBeenCalledWith({ source: 'terminal-bell' })
+    expect(deps.dispatchNotification).toHaveBeenCalledWith({
+      source: 'terminal-bell',
+      dedupeKey: `tab-1:${LEAF_1}`
+    })
   })
 
   // Why: show-until-interact — a real keystroke through xterm onData is the
@@ -1378,7 +1381,7 @@ describe('connectPanePty', () => {
   // notification (user-toggleable in Settings) but MUST NOT raise tab/worktree
   // unread — those stay BEL-only so non-agent long-running tasks remain
   // first-class attention sources. Double-firing with a concurrent BEL is
-  // collapsed by the per-worktree dedupe in main/ipc/notifications.ts.
+  // collapsed by pane-scoped dedupe in main/ipc/notifications.ts.
   //
   // This test deliberately wires the real useNotificationDispatch hook into
   // connectPanePty instead of a vi.fn() stub. A stub would let the producer
@@ -1424,6 +1427,7 @@ describe('connectPanePty', () => {
       expect.objectContaining({
         source: 'agent-task-complete',
         worktreeId: 'wt-1',
+        dedupeKey: `tab-1:${LEAF_1}`,
         terminalTitle: '* Claude done'
       })
     )

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -268,7 +268,7 @@ export function connectPanePty(
     // decision higher up, not a transport-layer guess.
     deps.markWorktreeUnread(deps.worktreeId)
     deps.markTerminalTabUnread(deps.tabId)
-    deps.dispatchNotification({ source: 'terminal-bell' })
+    deps.dispatchNotification({ source: 'terminal-bell', dedupeKey: cacheKey })
   }
 
   // ─── Agent task-complete: OS notification, not tab attention ──────────
@@ -283,7 +283,7 @@ export function connectPanePty(
   // signals. OS notifications are a separate channel: not every agent CLI
   // reliably emits BEL on completion (Gemini, some Codex flows), and
   // without this dispatch the Settings toggle would have zero producers.
-  // Double-firing with a concurrent BEL is handled by the 5 s per-worktree
+  // Double-firing with a concurrent BEL is handled by the 5 s pane-scoped
   // dedupe in main/ipc/notifications.ts.
   const onAgentBecameIdle = (title: string): void => {
     // Why: only start the prompt-cache countdown for Claude agents — other
@@ -304,8 +304,12 @@ export function connectPanePty(
     // removing it (as #944 did) leaves the user-facing Settings toggle with no
     // events to fire. Dispatch is gated per-source in main; the main-process
     // dedupe also collapses concurrent BEL + task-complete for the same
-    // worktree into a single notification.
-    deps.dispatchNotification({ source: 'agent-task-complete', terminalTitle: title })
+    // pane into a single notification.
+    deps.dispatchNotification({
+      source: 'agent-task-complete',
+      dedupeKey: cacheKey,
+      terminalTitle: title
+    })
   }
   const onAgentBecameWorking = (): void => {
     // Why: a new API call refreshes the prompt-cache TTL, so clear any running

--- a/src/renderer/src/components/terminal-pane/terminal-notification-dispatch.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-notification-dispatch.ts
@@ -4,6 +4,7 @@ import { playDesktopNotificationSound } from '@/lib/desktop-notification-sound'
 
 export type TerminalNotificationEvent = {
   source: 'terminal-bell' | 'agent-task-complete'
+  dedupeKey?: string
   terminalTitle?: string
 }
 
@@ -38,6 +39,7 @@ export function dispatchTerminalNotification(
     .dispatch({
       source: event.source,
       worktreeId,
+      dedupeKey: event.dedupeKey,
       repoLabel: repo?.displayName,
       worktreeLabel: worktree?.displayName || worktree?.branch || worktreeId,
       terminalTitle: event.terminalTitle,

--- a/src/renderer/src/components/terminal-pane/terminal-notification-dispatch.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-notification-dispatch.ts
@@ -1,0 +1,54 @@
+import { useAppStore } from '@/store'
+import { getRepoMapFromState, getWorktreeMapFromState } from '@/store/selectors'
+import { playDesktopNotificationSound } from '@/lib/desktop-notification-sound'
+
+export type TerminalNotificationEvent = {
+  source: 'terminal-bell' | 'agent-task-complete'
+  terminalTitle?: string
+}
+
+export function dispatchTerminalNotification(
+  worktreeId: string,
+  event: TerminalNotificationEvent
+): void {
+  const state = useAppStore.getState()
+
+  // Why: shutdownWorktreeTerminals clears ptyIdsByTabId synchronously before
+  // killing PTYs asynchronously. Any notification arriving after that point is
+  // stale — e.g. a staleTitleTimer that fires after shutdown, an agent tracker
+  // transition from accumulated closure state, or a hook event for a dead pane.
+  // Checking for live PTYs at dispatch time catches all phantom notification
+  // sources rather than trying to cancel each timer or callback individually.
+  const tabs = state.tabsByWorktree[worktreeId] ?? []
+  const hasLivePtys = tabs.some((tab) => (state.ptyIdsByTabId[tab.id] ?? []).length > 0)
+  if (!hasLivePtys) {
+    return
+  }
+
+  // Why: prefer worktree.repoId over string-parsing the worktreeId. The
+  // `${repoId}::${path}` format is an implementation detail of id construction;
+  // coupling the notification dispatcher to it would silently drop the repo
+  // label if that format ever changes. The worktree object is the source of
+  // truth for its owning repo.
+  const worktree = getWorktreeMapFromState(state).get(worktreeId)
+  const repo = worktree ? getRepoMapFromState(state).get(worktree.repoId) : null
+  const customSoundPath = state.settings?.notifications?.customSoundPath ?? null
+
+  void window.api.notifications
+    .dispatch({
+      source: event.source,
+      worktreeId,
+      repoLabel: repo?.displayName,
+      worktreeLabel: worktree?.displayName || worktree?.branch || worktreeId,
+      terminalTitle: event.terminalTitle,
+      isActiveWorktree: state.activeWorktreeId === worktreeId
+    })
+    .then((result) => {
+      if (result.delivered) {
+        void playDesktopNotificationSound(customSoundPath)
+      }
+    })
+    .catch((err) => {
+      console.warn('Failed to dispatch notification:', err)
+    })
+}

--- a/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
+++ b/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
@@ -1,7 +1,8 @@
 import { useCallback } from 'react'
-import { useAppStore } from '@/store'
-import { getRepoMapFromState, getWorktreeMapFromState } from '@/store/selectors'
-import { playDesktopNotificationSound } from '@/lib/desktop-notification-sound'
+import {
+  dispatchTerminalNotification,
+  type TerminalNotificationEvent
+} from './terminal-notification-dispatch'
 
 /**
  * Returns a stable dispatch function for terminal notifications.
@@ -12,51 +13,9 @@ import { playDesktopNotificationSound } from '@/lib/desktop-notification-sound'
  */
 export function useNotificationDispatch(
   worktreeId: string
-): (event: { source: 'terminal-bell' | 'agent-task-complete'; terminalTitle?: string }) => void {
+): (event: TerminalNotificationEvent) => void {
   return useCallback(
-    (event: { source: 'terminal-bell' | 'agent-task-complete'; terminalTitle?: string }) => {
-      const state = useAppStore.getState()
-
-      // Why: shutdownWorktreeTerminals clears ptyIdsByTabId synchronously
-      // before killing PTYs asynchronously. Any notification arriving after
-      // that point is stale — e.g. a staleTitleTimer that fires 3 s after
-      // shutdown, or an agent tracker transition from accumulated closure
-      // state. Checking for live PTYs at dispatch time catches ALL phantom
-      // notification sources regardless of which timer or callback produced
-      // them, rather than trying to cancel each one individually.
-      const tabs = state.tabsByWorktree[worktreeId] ?? []
-      const hasLivePtys = tabs.some((tab) => (state.ptyIdsByTabId[tab.id] ?? []).length > 0)
-      if (!hasLivePtys) {
-        return
-      }
-
-      // Why: prefer worktree.repoId over string-parsing the worktreeId. The
-      // `${repoId}::${path}` format is an implementation detail of id
-      // construction; coupling the notification dispatcher to it would silently
-      // drop the repo label if that format ever changes. The worktree object
-      // itself is the source of truth for its owning repo.
-      const worktree = getWorktreeMapFromState(state).get(worktreeId)
-      const repo = worktree ? getRepoMapFromState(state).get(worktree.repoId) : null
-      const customSoundPath = state.settings?.notifications?.customSoundPath ?? null
-
-      void window.api.notifications
-        .dispatch({
-          source: event.source,
-          worktreeId,
-          repoLabel: repo?.displayName,
-          worktreeLabel: worktree?.displayName || worktree?.branch || worktreeId,
-          terminalTitle: event.terminalTitle,
-          isActiveWorktree: state.activeWorktreeId === worktreeId
-        })
-        .then((result) => {
-          if (result.delivered) {
-            void playDesktopNotificationSound(customSoundPath)
-          }
-        })
-        .catch((err) => {
-          console.warn('Failed to dispatch notification:', err)
-        })
-    },
+    (event: TerminalNotificationEvent) => dispatchTerminalNotification(worktreeId, event),
     [worktreeId]
   )
 }

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -114,6 +114,7 @@ type UseTerminalPaneLifecycleDeps = {
   clearTerminalTabUnread: (tabId: string) => void
   dispatchNotification: (event: {
     source: 'terminal-bell' | 'agent-task-complete'
+    dedupeKey?: string
     terminalTitle?: string
   }) => void
   setCacheTimerStartedAt: (key: string, ts: number | null) => void

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -2232,6 +2232,66 @@ describe('useIpcEvents agent status snapshot integration', () => {
     expect(setAgentStatus).not.toHaveBeenCalled()
   })
 
+  it('hydrates Codex done snapshots without dispatching completion notifications', async () => {
+    const setAgentStatus = vi.fn()
+    const dispatchTerminalNotification = vi.fn()
+    const getSnapshot = vi.fn(() =>
+      Promise.resolve([
+        {
+          paneKey: TAB_1_PANE_KEY,
+          connectionId: 'conn-1',
+          state: 'done' as const,
+          prompt: 'p',
+          agentType: 'codex',
+          receivedAt: 1_700_000_000_000,
+          stateStartedAt: 1_699_999_999_000
+        }
+      ])
+    )
+    const storeState: StoreLike = buildStoreState({
+      setAgentStatus,
+      workspaceSessionReady: true,
+      repos: [{ id: 'repo-1', connectionId: 'conn-1' }],
+      worktreesByRepo: {
+        'repo-1': [{ id: 'wt-1', repoId: 'repo-1' }]
+      },
+      tabsByWorktree: {
+        'wt-1': [{ id: 'tab-1', ptyId: 'pty-1', worktreeId: 'wt-1', title: 'Codex Tab' }]
+      },
+      terminalLayoutsByTabId: {
+        'tab-1': {
+          root: { type: 'leaf', leafId: TAB_1_LEAF_ID },
+          activeLeafId: TAB_1_LEAF_ID,
+          expandedLeafId: null
+        }
+      }
+    })
+
+    stubReactSyncEffect()
+    vi.doMock('../store', () => ({
+      useAppStore: { subscribe: vi.fn(() => () => {}), getState: () => storeState }
+    }))
+    stubAuxiliaryModules()
+    vi.doMock('@/components/terminal-pane/terminal-notification-dispatch', () => ({
+      dispatchTerminalNotification
+    }))
+    vi.stubGlobal(
+      'window',
+      buildWindowApi({
+        getSnapshot,
+        onSet: () => () => {}
+      })
+    )
+
+    const { useIpcEvents } = await import('./useIpcEvents')
+    useIpcEvents()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(dispatchTerminalNotification).not.toHaveBeenCalled()
+    expect(setAgentStatus).toHaveBeenCalledTimes(1)
+  })
+
   it('forwards events whose connectionId matches the live repo connection', async () => {
     const setAgentStatus = vi.fn()
     const onSetListenerRef: { current: ((data: AgentStatusSetData) => void) | null } = {
@@ -2306,6 +2366,13 @@ describe('useIpcEvents agent status snapshot integration', () => {
       },
       tabsByWorktree: {
         'wt-1': [{ id: 'tab-1', ptyId: 'pty-1', worktreeId: 'wt-1', title: 'Codex Tab' }]
+      },
+      terminalLayoutsByTabId: {
+        'tab-1': {
+          root: { type: 'leaf', leafId: TAB_1_LEAF_ID },
+          activeLeafId: TAB_1_LEAF_ID,
+          expandedLeafId: null
+        }
       }
     })
 
@@ -2332,7 +2399,7 @@ describe('useIpcEvents agent status snapshot integration', () => {
     await Promise.resolve()
 
     onSetListenerRef.current?.({
-      paneKey: 'tab-1:0',
+      paneKey: TAB_1_PANE_KEY,
       connectionId: 'conn-1',
       state: 'done',
       agentType: 'codex',
@@ -2342,9 +2409,138 @@ describe('useIpcEvents agent status snapshot integration', () => {
 
     expect(dispatchTerminalNotification).toHaveBeenCalledWith('wt-1', {
       source: 'agent-task-complete',
+      dedupeKey: TAB_1_PANE_KEY,
       terminalTitle: 'Codex Tab'
     })
     expect(setAgentStatus).toHaveBeenCalledTimes(1)
+  })
+
+  it('routes Codex notifications to the live pane worktree over stale payload worktreeId', async () => {
+    const setAgentStatus = vi.fn()
+    const dispatchTerminalNotification = vi.fn()
+    const onSetListenerRef: { current: ((data: AgentStatusSetData) => void) | null } = {
+      current: null
+    }
+    const storeState: StoreLike = buildStoreState({
+      setAgentStatus,
+      workspaceSessionReady: true,
+      repos: [{ id: 'repo-1', connectionId: 'conn-1' }],
+      worktreesByRepo: {
+        'repo-1': [
+          { id: 'wt-live', repoId: 'repo-1' },
+          { id: 'wt-stale', repoId: 'repo-1' }
+        ]
+      },
+      tabsByWorktree: {
+        'wt-live': [{ id: 'tab-1', ptyId: 'pty-1', worktreeId: 'wt-live', title: 'Codex Tab' }],
+        'wt-stale': [{ id: 'tab-other', ptyId: 'pty-2', worktreeId: 'wt-stale', title: 'Other' }]
+      },
+      terminalLayoutsByTabId: {
+        'tab-1': {
+          root: { type: 'leaf', leafId: TAB_1_LEAF_ID },
+          activeLeafId: TAB_1_LEAF_ID,
+          expandedLeafId: null
+        }
+      }
+    })
+
+    stubReactSyncEffect()
+    vi.doMock('../store', () => ({
+      useAppStore: { subscribe: vi.fn(() => () => {}), getState: () => storeState }
+    }))
+    stubAuxiliaryModules()
+    vi.doMock('@/components/terminal-pane/terminal-notification-dispatch', () => ({
+      dispatchTerminalNotification
+    }))
+    vi.stubGlobal(
+      'window',
+      buildWindowApi({
+        onSet: (cb) => {
+          onSetListenerRef.current = cb
+          return () => {}
+        }
+      })
+    )
+
+    const { useIpcEvents } = await import('./useIpcEvents')
+    useIpcEvents()
+    await Promise.resolve()
+
+    onSetListenerRef.current?.({
+      paneKey: TAB_1_PANE_KEY,
+      worktreeId: 'wt-stale',
+      connectionId: 'conn-1',
+      state: 'done',
+      agentType: 'codex',
+      receivedAt: 1_700_000_000_100,
+      stateStartedAt: 1_699_999_999_100
+    })
+
+    expect(dispatchTerminalNotification).toHaveBeenCalledWith('wt-live', {
+      source: 'agent-task-complete',
+      dedupeKey: TAB_1_PANE_KEY,
+      terminalTitle: 'Codex Tab'
+    })
+  })
+
+  it('does not dispatch Codex notifications for closed split panes', async () => {
+    const setAgentStatus = vi.fn()
+    const dispatchTerminalNotification = vi.fn()
+    const onSetListenerRef: { current: ((data: AgentStatusSetData) => void) | null } = {
+      current: null
+    }
+    const storeState: StoreLike = buildStoreState({
+      setAgentStatus,
+      workspaceSessionReady: true,
+      repos: [{ id: 'repo-1', connectionId: 'conn-1' }],
+      worktreesByRepo: {
+        'repo-1': [{ id: 'wt-1', repoId: 'repo-1' }]
+      },
+      tabsByWorktree: {
+        'wt-1': [{ id: 'tab-1', ptyId: 'pty-1', worktreeId: 'wt-1', title: 'Codex Tab' }]
+      },
+      terminalLayoutsByTabId: {
+        'tab-1': {
+          root: { type: 'leaf', leafId: TAB_1_LEAF_ID },
+          activeLeafId: TAB_1_LEAF_ID,
+          expandedLeafId: null
+        }
+      }
+    })
+
+    stubReactSyncEffect()
+    vi.doMock('../store', () => ({
+      useAppStore: { subscribe: vi.fn(() => () => {}), getState: () => storeState }
+    }))
+    stubAuxiliaryModules()
+    vi.doMock('@/components/terminal-pane/terminal-notification-dispatch', () => ({
+      dispatchTerminalNotification
+    }))
+    vi.stubGlobal(
+      'window',
+      buildWindowApi({
+        onSet: (cb) => {
+          onSetListenerRef.current = cb
+          return () => {}
+        }
+      })
+    )
+
+    const { useIpcEvents } = await import('./useIpcEvents')
+    useIpcEvents()
+    await Promise.resolve()
+
+    onSetListenerRef.current?.({
+      paneKey: makePaneKey('tab-1', STALE_LEAF_ID),
+      connectionId: 'conn-1',
+      state: 'done',
+      agentType: 'codex',
+      receivedAt: 1_700_000_000_100,
+      stateStartedAt: 1_699_999_999_100
+    })
+
+    expect(dispatchTerminalNotification).not.toHaveBeenCalled()
+    expect(setAgentStatus).not.toHaveBeenCalled()
   })
 
   it('does not dispatch Codex notifications for stale remote hook events', async () => {
@@ -2388,7 +2584,7 @@ describe('useIpcEvents agent status snapshot integration', () => {
     await Promise.resolve()
 
     onSetListenerRef.current?.({
-      paneKey: 'tab-1:0',
+      paneKey: TAB_1_PANE_KEY,
       connectionId: 'conn-stale',
       state: 'done',
       agentType: 'codex',

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -2291,6 +2291,115 @@ describe('useIpcEvents agent status snapshot integration', () => {
     )
   })
 
+  it('dispatches Codex done hook events through terminal notifications', async () => {
+    const setAgentStatus = vi.fn()
+    const dispatchTerminalNotification = vi.fn()
+    const onSetListenerRef: { current: ((data: AgentStatusSetData) => void) | null } = {
+      current: null
+    }
+    const storeState: StoreLike = buildStoreState({
+      setAgentStatus,
+      workspaceSessionReady: true,
+      repos: [{ id: 'repo-1', connectionId: 'conn-1' }],
+      worktreesByRepo: {
+        'repo-1': [{ id: 'wt-1', repoId: 'repo-1' }]
+      },
+      tabsByWorktree: {
+        'wt-1': [{ id: 'tab-1', ptyId: 'pty-1', worktreeId: 'wt-1', title: 'Codex Tab' }]
+      }
+    })
+
+    stubReactSyncEffect()
+    vi.doMock('../store', () => ({
+      useAppStore: { subscribe: vi.fn(() => () => {}), getState: () => storeState }
+    }))
+    stubAuxiliaryModules()
+    vi.doMock('@/components/terminal-pane/terminal-notification-dispatch', () => ({
+      dispatchTerminalNotification
+    }))
+    vi.stubGlobal(
+      'window',
+      buildWindowApi({
+        onSet: (cb) => {
+          onSetListenerRef.current = cb
+          return () => {}
+        }
+      })
+    )
+
+    const { useIpcEvents } = await import('./useIpcEvents')
+    useIpcEvents()
+    await Promise.resolve()
+
+    onSetListenerRef.current?.({
+      paneKey: 'tab-1:0',
+      connectionId: 'conn-1',
+      state: 'done',
+      agentType: 'codex',
+      receivedAt: 1_700_000_000_100,
+      stateStartedAt: 1_699_999_999_100
+    })
+
+    expect(dispatchTerminalNotification).toHaveBeenCalledWith('wt-1', {
+      source: 'agent-task-complete',
+      terminalTitle: 'Codex Tab'
+    })
+    expect(setAgentStatus).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not dispatch Codex notifications for stale remote hook events', async () => {
+    const setAgentStatus = vi.fn()
+    const dispatchTerminalNotification = vi.fn()
+    const onSetListenerRef: { current: ((data: AgentStatusSetData) => void) | null } = {
+      current: null
+    }
+    const storeState: StoreLike = buildStoreState({
+      setAgentStatus,
+      workspaceSessionReady: true,
+      repos: [{ id: 'repo-1', connectionId: null }],
+      worktreesByRepo: {
+        'repo-1': [{ id: 'wt-1', repoId: 'repo-1' }]
+      },
+      tabsByWorktree: {
+        'wt-1': [{ id: 'tab-1', ptyId: 'pty-1', worktreeId: 'wt-1', title: 'Codex Tab' }]
+      }
+    })
+
+    stubReactSyncEffect()
+    vi.doMock('../store', () => ({
+      useAppStore: { subscribe: vi.fn(() => () => {}), getState: () => storeState }
+    }))
+    stubAuxiliaryModules()
+    vi.doMock('@/components/terminal-pane/terminal-notification-dispatch', () => ({
+      dispatchTerminalNotification
+    }))
+    vi.stubGlobal(
+      'window',
+      buildWindowApi({
+        onSet: (cb) => {
+          onSetListenerRef.current = cb
+          return () => {}
+        }
+      })
+    )
+
+    const { useIpcEvents } = await import('./useIpcEvents')
+    useIpcEvents()
+    await Promise.resolve()
+
+    onSetListenerRef.current?.({
+      paneKey: 'tab-1:0',
+      connectionId: 'conn-stale',
+      state: 'done',
+      agentType: 'codex',
+      receivedAt: 1_700_000_000_100,
+      stateStartedAt: 1_699_999_999_100
+    })
+
+    expect(dispatchTerminalNotification).not.toHaveBeenCalled()
+    expect(setAgentStatus).not.toHaveBeenCalled()
+  })
+
   it('drops events whose connectionId no longer matches the live local repo', async () => {
     const setAgentStatus = vi.fn()
     const onSetListenerRef: { current: ((data: AgentStatusSetData) => void) | null } = {

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -44,6 +44,7 @@ import { collectLeafIdsInOrder } from '@/components/terminal-pane/layout-seriali
 import { track } from '@/lib/telemetry'
 import { singlePaneLayoutSnapshot } from '@/store/slices/terminal-helpers'
 import { buildWorkspaceSessionPayload } from '@/lib/workspace-session'
+import { dispatchTerminalNotification } from '@/components/terminal-pane/terminal-notification-dispatch'
 
 export { resolveZoomTarget } from './resolve-zoom-target'
 
@@ -1441,7 +1442,7 @@ export function useIpcEvents(): void {
       if (!payload) {
         return
       }
-      const { exists, title, repoConnectionId } = resolvePaneKey(store, data.paneKey)
+      const { exists, title, repoConnectionId, worktreeId } = resolvePaneKey(store, data.paneKey)
       if (!exists) {
         // Why: empty paneKeys are dropped in main before IPC fanout. Reaching
         // this branch means a non-empty paneKey escaped without a matching
@@ -1465,6 +1466,19 @@ export function useIpcEvents(): void {
       // the renderer bundle is newer than the preload bundle.
       if (data.connectionId !== undefined && data.connectionId !== repoConnectionId) {
         return
+      }
+      if (options?.replay !== true && payload.agentType === 'codex' && payload.state === 'done') {
+        // Why: Codex hook state is authoritative even when its terminal title
+        // does not produce Orca's working->idle transition. Reuse the normal
+        // dispatcher so Settings suppression, cooldown, and sound still apply.
+        // Snapshot replay is cached state, not a fresh completion event.
+        if (worktreeId) {
+          dispatchTerminalNotification(worktreeId, {
+            source: 'agent-task-complete',
+            dedupeKey: data.paneKey,
+            terminalTitle: title
+          })
+        }
       }
       store.setAgentStatus(data.paneKey, payload, title, {
         updatedAt: data.receivedAt,
@@ -1665,16 +1679,21 @@ export function useIpcEvents(): void {
 function resolvePaneKey(
   store: ReturnType<typeof useAppStore.getState>,
   paneKey: string
-): { exists: boolean; title: string | undefined; repoConnectionId: string | null } {
+): {
+  exists: boolean
+  title: string | undefined
+  repoConnectionId: string | null
+  worktreeId: string | undefined
+} {
   const parsed = parsePaneKey(paneKey)
   if (!parsed) {
-    return { exists: false, title: undefined, repoConnectionId: null }
+    return { exists: false, title: undefined, repoConnectionId: null, worktreeId: undefined }
   }
   const { tabId, leafId } = parsed
   const layout = store.terminalLayoutsByTabId?.[tabId]
   const leafExists = collectLeafIdsInOrder(layout?.root).includes(leafId)
   if (!leafExists) {
-    return { exists: false, title: undefined, repoConnectionId: null }
+    return { exists: false, title: undefined, repoConnectionId: null, worktreeId: undefined }
   }
   // Why: replay can remint numeric pane ids, so status title recovery must use
   // persisted leaf-keyed titles when crossing from hook state into tab state.
@@ -1712,5 +1731,5 @@ function resolvePaneKey(
       repoConnectionId = repo?.connectionId ?? null
     }
   }
-  return { exists, title: paneTitle ?? tabTitle, repoConnectionId }
+  return { exists, title: paneTitle ?? tabTitle, repoConnectionId, worktreeId: owningWorktreeId }
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1506,6 +1506,7 @@ export type NotificationEventSource = 'agent-task-complete' | 'terminal-bell' | 
 export type NotificationDispatchRequest = {
   source: NotificationEventSource
   worktreeId?: string
+  dedupeKey?: string
   repoLabel?: string
   worktreeLabel?: string
   terminalTitle?: string

--- a/tests/e2e/codex-notifications.spec.ts
+++ b/tests/e2e/codex-notifications.spec.ts
@@ -1,0 +1,150 @@
+import type { ElectronApplication, Page } from '@stablyai/playwright-test'
+import { test, expect } from './helpers/orca-app'
+import {
+  splitActiveTerminalPane,
+  waitForActiveTerminalManager,
+  waitForPaneIdentitySnapshot,
+  waitForPaneCount
+} from './helpers/terminal'
+import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+
+type RecordedNotification = {
+  title?: string
+  body?: string
+  at: number
+}
+
+async function installNotificationShowRecorder(app: ElectronApplication): Promise<void> {
+  await app.evaluate(({ Notification }) => {
+    const g = globalThis as unknown as {
+      __orcaNotificationShows?: RecordedNotification[]
+      __orcaNotificationRecorderInstalled?: boolean
+    }
+
+    g.__orcaNotificationShows = []
+    if (g.__orcaNotificationRecorderInstalled) {
+      return
+    }
+    g.__orcaNotificationRecorderInstalled = true
+
+    try {
+      Object.defineProperty(Notification, 'isSupported', {
+        configurable: true,
+        value: () => true
+      })
+    } catch {
+      Notification.isSupported = () => true
+    }
+
+    Notification.prototype.show = function patchedShow(): void {
+      const notification = this as unknown as {
+        title?: string
+        body?: string
+        emit?: (eventName: string) => boolean
+      }
+      g.__orcaNotificationShows!.push({
+        title: notification.title,
+        body: notification.body,
+        at: Date.now()
+      })
+
+      // Why: the production handler holds Notification instances until close
+      // so macOS click handlers survive GC. The recorder suppresses the native
+      // OS notification, so emit close ourselves to release that reference.
+      setImmediate(() => {
+        notification.emit?.('close')
+      })
+    }
+  })
+}
+
+async function getRecordedNotifications(app: ElectronApplication): Promise<RecordedNotification[]> {
+  return app.evaluate(() => {
+    const g = globalThis as unknown as { __orcaNotificationShows?: RecordedNotification[] }
+    return g.__orcaNotificationShows ?? []
+  })
+}
+
+async function enableAgentCompletionNotifications(page: Page): Promise<void> {
+  await page.evaluate(async () => {
+    const store = window.__store
+    if (!store) {
+      throw new Error('enableAgentCompletionNotifications: window.__store is unavailable')
+    }
+    const state = store.getState()
+    await state.updateSettings({
+      notifications: {
+        ...state.settings.notifications,
+        enabled: true,
+        agentTaskComplete: true,
+        terminalBell: true,
+        suppressWhenFocused: false,
+        customSoundPath: null
+      }
+    })
+  })
+}
+
+async function sendCodexDoneHook(app: ElectronApplication, paneKey: string): Promise<void> {
+  const now = Date.now()
+  await app.evaluate(
+    ({ BrowserWindow }, args) => {
+      const win = BrowserWindow.getAllWindows().find((window) => !window.isDestroyed())
+      if (!win) {
+        throw new Error('sendCodexDoneHook: no BrowserWindow')
+      }
+      win.webContents.send('agentStatus:set', {
+        paneKey: args.paneKey,
+        state: 'done',
+        prompt: `e2e notification ${args.paneKey}`,
+        agentType: 'codex',
+        connectionId: null,
+        receivedAt: args.now,
+        stateStartedAt: args.now
+      })
+    },
+    { paneKey, now }
+  )
+}
+
+test.describe('Codex notifications', () => {
+  test('two Codex panes in one worktree notify independently while duplicates collapse', async ({
+    orcaPage,
+    electronApp
+  }) => {
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+    await ensureTerminalVisible(orcaPage)
+    await waitForActiveTerminalManager(orcaPage, 30_000)
+    await waitForPaneCount(orcaPage, 1, 30_000)
+    await enableAgentCompletionNotifications(orcaPage)
+    await installNotificationShowRecorder(electronApp)
+
+    await splitActiveTerminalPane(orcaPage, 'vertical')
+    const paneSnapshot = await waitForPaneIdentitySnapshot(orcaPage, 2)
+    const [firstPane, secondPane] = paneSnapshot.panes
+    if (!firstPane || !secondPane) {
+      throw new Error('Expected two split panes for Codex notification test')
+    }
+    const firstPaneKey = `${paneSnapshot.tabId}:${firstPane.leafId}`
+    const secondPaneKey = `${paneSnapshot.tabId}:${secondPane.leafId}`
+
+    // Why: this reproduces the regression shape. The first two events are the
+    // same pane and should collapse under cooldown; the third is a sibling pane
+    // in the same worktree and must still surface.
+    await sendCodexDoneHook(electronApp, firstPaneKey)
+    await sendCodexDoneHook(electronApp, firstPaneKey)
+    await sendCodexDoneHook(electronApp, secondPaneKey)
+
+    await expect
+      .poll(async () => getRecordedNotifications(electronApp), {
+        timeout: 10_000,
+        message:
+          'Expected one notification per Codex pane, with duplicate same-pane events collapsed'
+      })
+      .toHaveLength(2)
+
+    await orcaPage.waitForTimeout(750)
+    expect(await getRecordedNotifications(electronApp)).toHaveLength(2)
+  })
+})


### PR DESCRIPTION
Install Codex hooks during startup even when the agent dashboard experiment is disabled, while keeping Claude and Gemini behind the experiment flag.

Route Codex hook completion events through the existing terminal notification dispatcher so notification settings, labels, and sounds stay consistent with title-based completions.

Validation: `pnpm test -- src/main/agent-hooks/startup-hook-installation.test.ts src/renderer/src/hooks/useIpcEvents.test.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts`

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`