### PR TITLE
Refresh first-launch telemetry banner copy

### DIFF
--- a/src/renderer/src/components/FirstLaunchBanner.tsx
+++ b/src/renderer/src/components/FirstLaunchBanner.tsx
@@ -103,7 +103,7 @@ export function FirstLaunchBanner({
     // `relative` is load-bearing: the absolutely-positioned ✕ anchors to
     // this container.
     <div
-      className="fixed left-1/2 top-2 z-40 flex w-[min(46.5rem,calc(100vw-2rem))] -translate-x-1/2 items-start gap-4 rounded-lg border border-border bg-card/95 py-3 pl-4 pr-3 shadow-lg backdrop-blur"
+      className="fixed left-1/2 top-2 z-40 flex w-[min(44.625rem,calc(100vw-2rem))] -translate-x-1/2 items-start gap-4 rounded-lg border border-border bg-card/95 py-3 pl-4 pr-3 shadow-lg backdrop-blur"
       role="region"
       aria-label="Telemetry notice"
       aria-live="polite"
@@ -111,11 +111,11 @@ export function FirstLaunchBanner({
       {/* Text column — title + body stack on the left, takes remaining
           width so the action column never pushes copy into a wrap. */}
       <div className="flex-1 space-y-0.5 pr-1 text-sm">
-        <p className="font-medium leading-snug">Help us figure out what to build next</p>
+        <p className="font-medium leading-snug">Help us decide what to build next</p>
         <p className="text-xs leading-snug text-muted-foreground">
-          We&apos;d like to start sending anonymous counts of which features you use and where
-          things break — no file contents, prompts, terminal output, or anything that identifies
-          you. Change this anytime in Settings &rarr; Privacy &amp; Telemetry.{' '}
+          Anonymous counts of which features you use help us prioritize what to build. No file
+          contents, prompts, terminal output, or anything that identifies you. Change anytime in
+          Settings &rarr; Privacy &amp; Telemetry.{' '}
           <button
             type="button"
             className="underline underline-offset-2 hover:text-foreground"
@@ -133,8 +133,14 @@ export function FirstLaunchBanner({
           choice. ✕ stays in the corner as a familiar escape and to
           satisfy keyboard/notification-style dismiss expectations. */}
       <div className="flex shrink-0 items-center gap-2 self-center pr-6">
-        <Button variant="outline" size="sm" onClick={handleTurnOff} disabled={inFlight}>
-          Turn off
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={handleTurnOff}
+          disabled={inFlight}
+          className="border-border/60 text-muted-foreground"
+        >
+          Opt out
         </Button>
         <Button size="sm" onClick={handleAcknowledge} disabled={inFlight}>
           Got it


### PR DESCRIPTION
## Summary
- Reframe the body so anonymous usage counts → product priorities leads, and the privacy guarantee reads as a list of concrete exclusions (file contents, prompts, terminal output) rather than a hedged disclaimer.
- Rename the secondary action "Turn off" → "Opt out" and lower its border/label contrast so "Got it" stays the visual default.
- Update the title to "Help us decide what to build next" and trim banner width slightly to match the shorter copy.

## Test plan
- [x] Launch as a pre-telemetry-cohort user (`existedBeforeTelemetryRelease=true`, `optedIn=null`), confirm the banner renders the new title/body and "Opt out" button styling
- [x] Click "Opt out" and verify `telemetry_opted_out { via: 'first_launch_banner' }` still fires before the SDK is disabled
- [x] Click "Got it" and the corner ✕ and confirm both silently persist `optedIn: true` and dismiss the notice

Made with [Orca](https://github.com/stablyai/orca) 🐋
