### PR TITLE
fix(source-control): hide commit input when no uncommitted changes

### DIFF
--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -1137,7 +1137,7 @@ function SourceControlInner(): React.JSX.Element {
               />
             )}
 
-          {(scope === 'all' || scope === 'uncommitted') && (
+          {(scope === 'all' || scope === 'uncommitted') && hasUncommittedEntries && (
             <CommitArea
               stagedCount={grouped.staged.length}
               hasUnresolvedConflicts={unresolvedConflicts.length > 0}


### PR DESCRIPTION
## Summary
- Hide the commit message textarea + Commit button when there are no uncommitted changes. Previously, a clean worktree showed the "No changes on this branch" empty state alongside a useless commit input with a permanently-disabled button (`stagedCount === 0`).

## Test plan
- [ ] Open Source Control on a clean worktree → empty state visible, no commit input
- [ ] Make a change → commit input appears
- [ ] Stage + commit → commit input disappears again when nothing left to commit

Made with [Orca](https://github.com/stablyai/orca) 🐋
