### PR TITLE
fix(mobile): unstick worktree spinner once agent exits, match desktop StatusIndicator

### DIFF
--- a/mobile/src/components/AgentSpinner.tsx
+++ b/mobile/src/components/AgentSpinner.tsx
@@ -1,15 +1,20 @@
 import { useEffect, useRef } from 'react'
 import { Animated, Easing, StyleSheet, View } from 'react-native'
-import { colors } from '../theme/mobile-theme'
 
 type WorktreeStatus = 'working' | 'active' | 'permission' | 'done' | 'inactive'
 
+// Why: colors and sizing are 1:1 with the desktop StatusIndicator
+// (src/renderer/src/components/sidebar/StatusIndicator.tsx) so the mobile
+// worktree list reads identically to the sidebar — same yellow spinner for
+// 'working', same emerald dot for 'active'/'done', same neutral-500 @ 40%
+// for 'inactive', same red for 'permission'. Diverging palettes here lose
+// the design intent ('moving' vs 'alive' vs 'completed') the desktop encodes.
 const STATUS_COLORS: Record<WorktreeStatus, string> = {
-  working: colors.statusGreen,
-  active: colors.statusGreen,
-  permission: colors.statusRed,
-  done: '#38bdf8',
-  inactive: '#666666'
+  working: '#eab308',
+  active: '#10b981',
+  done: '#10b981',
+  permission: '#ef4444',
+  inactive: 'rgba(115,115,115,0.4)'
 }
 
 export function AgentSpinner({ status }: { status: WorktreeStatus }) {
@@ -39,23 +44,39 @@ export function AgentSpinner({ status }: { status: WorktreeStatus }) {
       outputRange: ['0deg', '360deg']
     })
     return (
-      <Animated.View style={[styles.spinner, { borderColor: color, transform: [{ rotate }] }]} />
+      <View style={styles.wrapper}>
+        <Animated.View style={[styles.spinner, { borderColor: color, transform: [{ rotate }] }]} />
+      </View>
     )
   }
 
-  return <View style={[styles.dot, { backgroundColor: color }]} />
+  return (
+    <View style={styles.wrapper}>
+      <View style={[styles.dot, { backgroundColor: color }]} />
+    </View>
+  )
 }
 
 const styles = StyleSheet.create({
+  // Why: 12x12 wrapper centered around an 8x8 inner glyph mirrors the
+  // desktop's `inline-flex h-3 w-3 ... items-center justify-center` shell
+  // around `size-2` indicator — keeps row height/baseline alignment stable
+  // across status transitions.
+  wrapper: {
+    width: 12,
+    height: 12,
+    alignItems: 'center',
+    justifyContent: 'center'
+  },
   dot: {
     width: 8,
     height: 8,
     borderRadius: 4
   },
   spinner: {
-    width: 10,
-    height: 10,
-    borderRadius: 5,
+    width: 8,
+    height: 8,
+    borderRadius: 4,
     borderWidth: 2,
     borderTopColor: 'transparent'
   }

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -793,6 +793,46 @@ describe('OrcaRuntimeService', () => {
     })
   })
 
+  it('clears stale working status after the agent exits and the shell takes over the title', async () => {
+    // Why: regression test for issue #1437 — the mobile worktree-list spinner
+    // kept playing forever because lastAgentStatus was sticky on 'working'
+    // once an agent exited without emitting an idle/agent-shaped final OSC
+    // title. worktree.ps must recompute from the live OSC title each call.
+    const runtime = new OrcaRuntimeService(store)
+
+    runtime.attachWindow(1)
+    runtime.syncWindowGraph(1, {
+      tabs: [
+        {
+          tabId: 'tab-1',
+          worktreeId: 'repo-1::/tmp/worktree-a',
+          title: 'Codex working',
+          activeLeafId: 'pane:1',
+          layout: null
+        }
+      ],
+      leaves: [
+        {
+          tabId: 'tab-1',
+          worktreeId: 'repo-1::/tmp/worktree-a',
+          leafId: 'pane:1',
+          paneRuntimeId: 1,
+          ptyId: 'pty-1'
+        }
+      ]
+    })
+
+    runtime.onPtyData('pty-1', '\x1b]0;Codex working\x07', 100)
+    const working = await runtime.getWorktreePs()
+    expect(working.worktrees[0].status).toBe('working')
+
+    // Agent exits, shell title takes over — desktop's getWorktreeStatus would
+    // immediately flip back to 'active'. Mobile must do the same.
+    runtime.onPtyData('pty-1', '\x1b]0;bash\x07', 200)
+    const afterExit = await runtime.getWorktreePs()
+    expect(afterExit.worktrees[0].status).toBe('active')
+  })
+
   it('fails terminal stop closed while the renderer graph is reloading', async () => {
     const runtime = new OrcaRuntimeService(store)
     let killed = false

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -167,6 +167,12 @@ type RuntimeLeafRecord = RuntimeSyncedLeaf & {
   tailLinesTotal: number
   preview: string
   lastAgentStatus: AgentStatus | null
+  // Why: the most recent OSC title observed on this leaf's PTY data. Used by
+  // worktree.ps so daemon-hosted terminals (no renderer pushing pane titles)
+  // still recompute working/idle from the live title each call instead of
+  // serving a stale `lastAgentStatus` after the agent process exits and the
+  // shell takes over the title — the bug behind issue #1437.
+  lastOscTitle: string | null
 }
 
 type RuntimePtyWorktreeRecord = {
@@ -632,7 +638,8 @@ export class OrcaRuntimeService {
         tailTruncated: existing?.ptyId === ptyId ? existing.tailTruncated : false,
         tailLinesTotal: existing?.ptyId === ptyId ? existing.tailLinesTotal : 0,
         preview: existing?.ptyId === ptyId ? existing.preview : '',
-        lastAgentStatus: existing?.ptyId === ptyId ? existing.lastAgentStatus : null
+        lastAgentStatus: existing?.ptyId === ptyId ? existing.lastAgentStatus : null,
+        lastOscTitle: existing?.ptyId === ptyId ? existing.lastOscTitle : null
       })
 
       if (leaf.ptyId) {
@@ -790,8 +797,21 @@ export class OrcaRuntimeService {
       leaf.tailLinesTotal += nextTail.newCompleteLines
       leaf.preview = buildPreview(leaf.tailBuffer, leaf.tailPartialLine)
 
-      if (agentStatus !== null) {
+      if (oscTitle !== null) {
+        // Why: keep the latest OSC title on the leaf so worktree.ps can
+        // recompute status from the live title each call. Without this,
+        // daemon-hosted terminals (no renderer pushing pane titles) had no
+        // way to clear a stale 'working' status after the agent exited and
+        // the shell took over the title — the stuck-spinner bug in #1437.
+        leaf.lastOscTitle = oscTitle
         const prevStatus = leaf.lastAgentStatus
+        // Why: when a new OSC title doesn't classify as an agent state (e.g.
+        // bare shell title after the agent exits), clear lastAgentStatus so
+        // it is no longer sticky. Tui-idle waiters that needed the previous
+        // 'idle' transition were already resolved at the moment of the
+        // transition below; only fresh waiters registered after the agent
+        // exits would observe the cleared value, and they correctly fall
+        // back to title-based detection / polling.
         leaf.lastAgentStatus = agentStatus
         // Why: resolve tui-idle on any transition TO idle (not just working→idle).
         // Claude Code may skip "working" entirely on fast tasks, going null→idle,
@@ -986,12 +1006,15 @@ export class OrcaRuntimeService {
       return
     }
     const status = detectAgentStatusFromTitle(title)
-    if (status === null) {
-      return
-    }
     for (const leaf of this.leaves.values()) {
       if (leaf.ptyId === ptyId) {
-        leaf.lastAgentStatus = status
+        // Why: seed lastOscTitle even when the seeded title doesn't classify
+        // as an agent state, so worktree.ps recomputes status from the live
+        // title rather than treating the leaf as agentless.
+        leaf.lastOscTitle = title
+        if (status !== null) {
+          leaf.lastAgentStatus = status
+        }
       }
     }
   }
@@ -5695,7 +5718,14 @@ function getLeafWorktreeStatus(
   leaf: RuntimeLeafRecord,
   tabTitle: string | null
 ): RuntimeWorktreeStatus {
-  const detected = leaf.lastAgentStatus ?? detectAgentStatusFromTitle(leaf.title ?? tabTitle ?? '')
+  // Why: recompute from the live title each call so worktree.ps mirrors what
+  // the desktop sidebar's getWorktreeStatus does (no sticky state). Prefer
+  // the runtime-tracked OSC title (covers daemon-hosted terminals) over the
+  // renderer-pushed leaf.title and the tab title. Falling back to
+  // lastAgentStatus only when no title is available preserves a sensible
+  // signal for very fresh leaves before any title has been observed.
+  const liveTitle = leaf.lastOscTitle ?? leaf.title ?? tabTitle ?? ''
+  const detected = liveTitle ? detectAgentStatusFromTitle(liveTitle) : leaf.lastAgentStatus
   if (detected === 'permission') {
     return 'permission'
   }


### PR DESCRIPTION
## Summary

#1437. The mobile worktree-list spinner kept playing forever after an agent finished — visible in the screenshot on the issue. Two divergences from desktop, both fixed here.

## Root cause (logic)

`worktree.ps` on the runtime read the **sticky** `leaf.lastAgentStatus` before falling back to the live title:

```ts
const detected = leaf.lastAgentStatus ?? detectAgentStatusFromTitle(leaf.title ?? tabTitle ?? '')
```

`lastAgentStatus` only updates when a new OSC title classifies as an agent state. The moment a bare-shell title (e.g. `bash`) takes over after an agent exits, `detectAgentStatusFromTitle` returns `null` and the field stays at `'working'` indefinitely. Mobile keeps spinning.

Desktop's `getWorktreeStatus` (`src/renderer/src/lib/worktree-status.ts`) has no such stickiness — it recomputes from current pane titles every render.

## Server fix (`src/main/runtime/orca-runtime.ts`)

- Add `lastOscTitle: string | null` to `RuntimeLeafRecord`.
- In `onPtyData`, store `lastOscTitle` on every observed OSC title, regardless of whether it parses as an agent state.
- Clear `lastAgentStatus` when the new OSC title is not agent-shaped, so it is a single source of truth. Tui-idle waiters resolve at the moment of the working→idle transition, so this does not regress orchestration.
- `getLeafWorktreeStatus` now recomputes from the live title each call (`leaf.lastOscTitle ?? leaf.title ?? tabTitle`), mirroring the desktop sidebar's behavior. Daemon-hosted terminals (no renderer pushing pane titles) are now correctly handled.
- Seed `lastOscTitle` in `applySeededAgentStatus` too.

## Mobile fix (`mobile/src/components/AgentSpinner.tsx`)

Visual parity with `src/renderer/src/components/sidebar/StatusIndicator.tsx`:

| State | Before | After (matches desktop) |
|---|---|---|
| `working` spinner | green `#22c55e` | yellow `#eab308` |
| `active` dot | green `#22c55e` | emerald `#10b981` |
| `done` dot | blue `#38bdf8` | emerald `#10b981` |
| `inactive` dot | solid `#666` | `rgba(115,115,115,0.4)` |
| `permission` | red (unchanged) | red (unchanged) |

Inner glyph is now 8x8 centered in a 12x12 wrapper, mirroring desktop's `size-2` inside `h-3 w-3` so row baselines stay stable across status transitions.

## Tests

- Added a regression test in `src/main/runtime/orca-runtime.test.ts`: simulate `Codex working` OSC title, then `bash`, assert `worktree.ps` reports `active`.
- `pnpm tc:node`, `pnpm tc:web`, `pnpm lint` clean (no new warnings).
- All non-sqlite-infra runtime tests pass, including `tui-idle resolves on agent working→idle OSC title transition` and `tui-idle times out when PTY data has no agent OSC title transitions` — confirming orchestration semantics are preserved.
- Pre-existing better-sqlite3 `NODE_MODULE_VERSION` failures (called out in #1423) are unrelated.

## Out of scope

- Desktop visual parity is unchanged.
- Mobile `getWorktreeStatus` (the client-side fallback) is left as-is — it already preferred `w.status` from the server, so the server fix is sufficient.

Made with [Orca](https://github.com/stablyai/orca) 🐋