### PR TITLE
fix(telemetry): refresh settings_changed whitelist; agent_kind runtime guard

### DIFF
--- a/src/shared/agent-kind.test.ts
+++ b/src/shared/agent-kind.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+
+import { tuiAgentToAgentKind } from './agent-kind'
+import { AGENT_KIND_VALUES, agentKindSchema } from './telemetry-events'
+import { TUI_AGENT_CONFIG } from './tui-agent-config'
+import type { TuiAgent } from './types'
+
+describe('tuiAgentToAgentKind', () => {
+  it('maps every shipped TuiAgent to a concrete telemetry kind', () => {
+    const agents = Object.keys(TUI_AGENT_CONFIG) as TuiAgent[]
+
+    for (const agent of agents) {
+      const kind = tuiAgentToAgentKind(agent)
+
+      expect(kind).not.toBe('other')
+      expect(agentKindSchema.safeParse(kind).success).toBe(true)
+    }
+  })
+
+  it('keeps concrete telemetry kinds in exact sync with shipped TuiAgents', () => {
+    const agents = Object.keys(TUI_AGENT_CONFIG) as TuiAgent[]
+    const mappedKinds = agents.map((agent) => tuiAgentToAgentKind(agent)).sort()
+    const concreteSchemaKinds = AGENT_KIND_VALUES.filter((kind) => kind !== 'other').sort()
+
+    expect(mappedKinds).toEqual(concreteSchemaKinds)
+  })
+
+  it('uses the product id for Claude and the TuiAgent id for Pi', () => {
+    expect(tuiAgentToAgentKind('claude')).toBe('claude-code')
+    expect(tuiAgentToAgentKind('pi')).toBe('pi')
+  })
+})

--- a/src/shared/agent-kind.ts
+++ b/src/shared/agent-kind.ts
@@ -40,6 +40,10 @@ const TUI_AGENT_KIND_BY_AGENT = {
   copilot: 'copilot'
 } satisfies Record<TuiAgent, ConcreteAgentKind>
 
+// Why: `satisfies Record<TuiAgent, …>` makes the lookup exhaustive at compile
+// time, but stale persisted settings or unsafe IPC casts can carry a string
+// outside the union at runtime — fall back to `'other'` so the event still
+// emits instead of failing validation and dropping silently.
 export function tuiAgentToAgentKind(agent: TuiAgent): AgentKind {
-  return TUI_AGENT_KIND_BY_AGENT[agent]
+  return TUI_AGENT_KIND_BY_AGENT[agent] ?? 'other'
 }

--- a/src/shared/agent-kind.ts
+++ b/src/shared/agent-kind.ts
@@ -1,8 +1,7 @@
 // Mapping from the renderer's `TuiAgent` union (every agent Orca knows how
-// to launch) to the closed `agentKindSchema` enum on telemetry events. The
-// telemetry enum is a deliberately smaller set — anything not enumerated
-// maps to `'other'` so dashboards can spot interest in an agent before its
-// slot is added rather than dropping the event.
+// to launch) to the closed `agentKindSchema` enum on telemetry events. Every
+// shipped agent maps to a concrete telemetry value so dashboards can
+// distinguish launch interest instead of collapsing the long tail to `other`.
 //
 // Lives in `src/shared/` (not the renderer) because main-side telemetry
 // emission (`agent_started` from the `pty:spawn` IPC handler) needs the
@@ -12,23 +11,35 @@
 import type { AgentKind } from './telemetry-events'
 import type { TuiAgent } from './types'
 
+type ConcreteAgentKind = Exclude<AgentKind, 'other'>
+
+const TUI_AGENT_KIND_BY_AGENT = {
+  claude: 'claude-code',
+  codex: 'codex',
+  autohand: 'autohand',
+  opencode: 'opencode',
+  pi: 'pi',
+  gemini: 'gemini',
+  aider: 'aider',
+  goose: 'goose',
+  amp: 'amp',
+  kilo: 'kilo',
+  kiro: 'kiro',
+  crush: 'crush',
+  aug: 'aug',
+  cline: 'cline',
+  codebuff: 'codebuff',
+  continue: 'continue',
+  cursor: 'cursor',
+  droid: 'droid',
+  kimi: 'kimi',
+  'mistral-vibe': 'mistral-vibe',
+  'qwen-code': 'qwen-code',
+  rovo: 'rovo',
+  hermes: 'hermes',
+  copilot: 'copilot'
+} satisfies Record<TuiAgent, ConcreteAgentKind>
+
 export function tuiAgentToAgentKind(agent: TuiAgent): AgentKind {
-  switch (agent) {
-    case 'claude':
-      return 'claude-code'
-    case 'codex':
-      return 'codex'
-    case 'copilot':
-      return 'copilot'
-    case 'gemini':
-      return 'gemini'
-    case 'cursor':
-      return 'cursor'
-    case 'opencode':
-      return 'opencode'
-    case 'aider':
-      return 'aider'
-    default:
-      return 'other'
-  }
+  return TUI_AGENT_KIND_BY_AGENT[agent]
 }

--- a/src/shared/telemetry-events.test.ts
+++ b/src/shared/telemetry-events.test.ts
@@ -5,6 +5,7 @@
 
 import { describe, expect, it } from 'vitest'
 import {
+  AGENT_KIND_VALUES,
   agentKindSchema,
   commonPropsSchema,
   errorClassSchema,
@@ -189,9 +190,9 @@ describe('commonPropsSchema', () => {
 
 describe('exported enum schemas', () => {
   it('agentKindSchema accepts the known product IDs', () => {
-    expect(agentKindSchema.safeParse('claude-code').success).toBe(true)
-    expect(agentKindSchema.safeParse('codex').success).toBe(true)
-    expect(agentKindSchema.safeParse('other').success).toBe(true)
+    for (const kind of AGENT_KIND_VALUES) {
+      expect(agentKindSchema.safeParse(kind).success).toBe(true)
+    }
   })
 
   it('errorClassSchema rejects novel classes', () => {

--- a/src/shared/telemetry-events.ts
+++ b/src/shared/telemetry-events.ts
@@ -14,6 +14,8 @@
 
 import { z } from 'zod'
 
+import type { GlobalSettings } from './types'
+
 // ── Shared property enums ───────────────────────────────────────────────
 
 // Mirrors the shipped `TuiAgent` launch surface, with one deliberate shift:
@@ -122,12 +124,18 @@ export type OptInVia = z.infer<typeof optInViaSchema>
 //
 // Kept as an `as const` tuple so the Zod enum below and any call-site usage
 // share one array — typo-drift is impossible.
+type BooleanGlobalSettingsKey = {
+  [Key in keyof GlobalSettings]-?: GlobalSettings[Key] extends boolean ? Key : never
+}[keyof GlobalSettings]
 export const SETTINGS_CHANGED_WHITELIST = [
   'editorAutoSave',
   'openLinksInApp',
-  'experimentalTerminalDaemon',
-  'experimentalAgentDashboard'
-] as const
+  'experimentalAgentDashboard',
+  'experimentalMobile',
+  'experimentalSidekick',
+  'experimentalWorktreeSymlinks',
+  'geminiCliOAuthEnabled'
+] as const satisfies readonly BooleanGlobalSettingsKey[]
 export const settingsChangedKeySchema = z.enum(SETTINGS_CHANGED_WHITELIST)
 export type SettingsChangedKey = z.infer<typeof settingsChangedKeySchema>
 

--- a/src/shared/telemetry-events.ts
+++ b/src/shared/telemetry-events.ts
@@ -16,23 +16,40 @@ import { z } from 'zod'
 
 // ── Shared property enums ───────────────────────────────────────────────
 
-// Mirrors the detectable agents in `src/shared/agent-detection.ts`
-// (`AGENT_NAMES`), with one deliberate shift: `claude` in AGENT_NAMES ↔
-// `claude-code` here (product, not CLI string) so dashboards read cleanly.
+// Mirrors the shipped `TuiAgent` launch surface, with one deliberate shift:
+// `claude` in settings/launch state ↔ `claude-code` here (product, not CLI
+// string) so dashboards read cleanly.
 //
-// Enum values are limited to agents that have a real emit path today. Adding
-// a new agent is additive-safe — extend this enum when the call site that
-// would emit it lands, not in anticipation.
-export const agentKindSchema = z.enum([
+// `other` remains as a telemetry escape hatch, but project-owned TuiAgents
+// should map to concrete values; see `tuiAgentToAgentKind`.
+export const AGENT_KIND_VALUES = [
   'claude-code',
   'codex',
-  'gemini',
-  'copilot',
-  'cursor',
+  'autohand',
   'opencode',
+  'pi',
+  'gemini',
   'aider',
+  'goose',
+  'amp',
+  'kilo',
+  'kiro',
+  'crush',
+  'aug',
+  'cline',
+  'codebuff',
+  'continue',
+  'cursor',
+  'droid',
+  'kimi',
+  'mistral-vibe',
+  'qwen-code',
+  'rovo',
+  'hermes',
+  'copilot',
   'other'
-])
+] as const
+export const agentKindSchema = z.enum(AGENT_KIND_VALUES)
 export type AgentKind = z.infer<typeof agentKindSchema>
 
 // Trimmed to the two values Orca's PTY-typed-command launch architecture can


### PR DESCRIPTION
## Summary

- Drop dead `experimentalTerminalDaemon` whitelist entry (no longer in `GlobalSettings`).
- Add four shipped bool toggles to `settings_changed` whitelist: `experimentalMobile`, `experimentalSidekick`, `experimentalWorktreeSymlinks`, `geminiCliOAuthEnabled`. All four are user-facing toggles wired through `settings:set`, structurally identical to the existing `experimentalAgentDashboard` entry that has been observed firing in PostHog.
- Tighten the tuple to `satisfies readonly BooleanGlobalSettingsKey[]` so a future typo or removed setting fails typecheck instead of silently dropping events.
- `tuiAgentToAgentKind`: add `?? 'other'` runtime guard. The `satisfies Record<TuiAgent, …>` keeps the lookup compile-time exhaustive, but stale persisted settings or an unsafe IPC cast can carry a string outside the `TuiAgent` union; this preserves emission instead of dropping the event at the validator.

Discovered while verifying rc.4 telemetry against PostHog: settings panel toggles aren't represented in the funnel beyond `editorAutoSave` / `openLinksInApp` / `experimentalAgentDashboard`, even though several other experimental flags ship today.

## Test plan

- [x] `pnpm typecheck` clean.
- [x] `pnpm vitest run src/shared/telemetry-events.test.ts src/shared/agent-kind.test.ts src/main/telemetry/ src/main/ipc/telemetry.test.ts src/main/ipc/settings.test.ts` — 113 passed. The whitelist tests iterate `SETTINGS_CHANGED_WHITELIST` so they auto-cover the new keys.
- [x] **Dev-build verification of `track()` call sites.** Launched a dev Orca with `--remote-debugging-port`, attached playwright-cli, and drove the same IPCs the UI uses (`window.api.settings.set`, `window.api.pty.spawn`). In dev, `track()` short-circuits to `console.debug('[telemetry]', name, props)` (`src/main/telemetry/client.ts:255-258`), so main-process stdout shows exactly what would transmit. This proves the call-site shape; it does NOT prove the wire path.
- [ ] **Production wire-path verification.** After this lands in an rc build: toggle each of the four new settings in the UI and confirm a `settings_changed` event lands in PostHog with the matching `setting_key` and `value_kind: 'bool'`. Spawn Pi (and ideally one or two other previously-collapsed agents) and confirm `agent_started.agent_kind` lands as the concrete kind, not `'other'`.

### Dev-build verification — observed output

`settings_changed`: toggled all six whitelisted keys via `window.api.settings.set`:

```
[telemetry] settings_changed { setting_key: 'experimentalMobile', value_kind: 'bool' }
[telemetry] settings_changed { setting_key: 'experimentalSidekick', value_kind: 'bool' }
[telemetry] settings_changed { setting_key: 'experimentalWorktreeSymlinks', value_kind: 'bool' }
[telemetry] settings_changed { setting_key: 'geminiCliOAuthEnabled', value_kind: 'bool' }
[telemetry] settings_changed { setting_key: 'editorAutoSave', value_kind: 'bool' }
[telemetry] settings_changed { setting_key: 'openLinksInApp', value_kind: 'bool' }
```

Negative cases — toggling `theme`, `rightSidebarOpenByDefault`, and the removed `experimentalTerminalDaemon` produced **zero** telemetry lines, confirming the whitelist boundary holds.

`agent_started`: spawned an inert PTY (`command: 'true'`) for each of the 17 `TuiAgent` values that previously collapsed to `'other'`:

```
[telemetry] agent_started { agent_kind: 'pi',           launch_source: 'sidebar', request_kind: 'new' }
[telemetry] agent_started { agent_kind: 'autohand',     launch_source: 'sidebar', request_kind: 'new' }
[telemetry] agent_started { agent_kind: 'goose',        launch_source: 'sidebar', request_kind: 'new' }
[telemetry] agent_started { agent_kind: 'amp',          launch_source: 'sidebar', request_kind: 'new' }
[telemetry] agent_started { agent_kind: 'kilo',         launch_source: 'sidebar', request_kind: 'new' }
[telemetry] agent_started { agent_kind: 'kiro',         launch_source: 'sidebar', request_kind: 'new' }
[telemetry] agent_started { agent_kind: 'crush',        launch_source: 'sidebar', request_kind: 'new' }
[telemetry] agent_started { agent_kind: 'cline',        launch_source: 'sidebar', request_kind: 'new' }
[telemetry] agent_started { agent_kind: 'codebuff',     launch_source: 'sidebar', request_kind: 'new' }
[telemetry] agent_started { agent_kind: 'continue',     launch_source: 'sidebar', request_kind: 'new' }
[telemetry] agent_started { agent_kind: 'droid',        launch_source: 'sidebar', request_kind: 'new' }
[telemetry] agent_started { agent_kind: 'kimi',         launch_source: 'sidebar', request_kind: 'new' }
[telemetry] agent_started { agent_kind: 'mistral-vibe', launch_source: 'sidebar', request_kind: 'new' }
[telemetry] agent_started { agent_kind: 'qwen-code',    launch_source: 'sidebar', request_kind: 'new' }
[telemetry] agent_started { agent_kind: 'rovo',         launch_source: 'sidebar', request_kind: 'new' }
[telemetry] agent_started { agent_kind: 'hermes',       launch_source: 'sidebar', request_kind: 'new' }
[telemetry] agent_started { agent_kind: 'aug',          launch_source: 'sidebar', request_kind: 'new' }
```

Spawning with an out-of-enum kind (`'made_up_agent'`) emitted **zero** telemetry lines — confirms `agentKindSchema.safeParse` at `src/main/ipc/pty.ts:1049` rejects unknown kinds before `track()` is called.

## Risk

Low. The change only widens what gets recorded, never what executes. The `track()` pipeline early-returns at every gate (shutdown, burst cap, consent, validator) and never throws back into the IPC handler. The handler in `src/main/ipc/settings.ts:51-67` already iterates `Object.keys(args)` filtered by the whitelist set and skips non-boolean values, so no new code path is exercised — only new map keys.