### PR TITLE
feat(mobile): pairing paste flow + Keychain-backed device tokens

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Orca",
     "slug": "orca-mobile",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",
@@ -16,7 +16,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.stably.orca.mobile",
-      "buildNumber": "3",
+      "buildNumber": "4",
       "infoPlist": {
         "NSLocalNetworkUsageDescription": "Orca connects to the desktop app on your local network.",
         "NSAppTransportSecurity": {

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -1,9 +1,10 @@
-import { useCallback } from 'react'
+import { useCallback, useEffect } from 'react'
 import { View, StyleSheet } from 'react-native'
-import { Stack } from 'expo-router'
+import { Stack, useRouter } from 'expo-router'
 import { StatusBar } from 'expo-status-bar'
 import * as SplashScreen from 'expo-splash-screen'
 import * as Notifications from 'expo-notifications'
+import * as Linking from 'expo-linking'
 import { colors } from '../src/theme/mobile-theme'
 import { OrcaLogo } from '../src/components/OrcaLogo'
 
@@ -26,7 +27,49 @@ Notifications.setNotificationHandler({
   })
 })
 
+// Why: extract the path+payload that follows the orca://pair anchor so we
+// can route it to the confirm screen. Accept either a hash payload
+// (`orca://pair#<base64>`, the QR / shared form) or a query param
+// (`orca://pair?code=<...>`, future-proof for share sheets that strip
+// fragments).
+function extractPairCode(url: string): string | null {
+  if (!url.startsWith('orca://pair')) return null
+  const hashIndex = url.indexOf('#')
+  if (hashIndex !== -1) {
+    return url.slice(hashIndex + 1) || null
+  }
+  const queryIndex = url.indexOf('?')
+  if (queryIndex !== -1) {
+    const params = new URLSearchParams(url.slice(queryIndex + 1))
+    return params.get('code')
+  }
+  return null
+}
+
 export default function RootLayout() {
+  const router = useRouter()
+
+  // Why: route `orca://pair#<code>` deep links to the confirm screen so
+  // the same pairing flow runs whether the link arrived via QR scan,
+  // paste, AirDrop, Messages, or `xcrun simctl openurl`. getInitialURL
+  // covers cold-start (link tapped while app was closed); the listener
+  // covers warm-start (link tapped while app is in memory).
+  useEffect(() => {
+    function handleUrl(url: string) {
+      const code = extractPairCode(url)
+      if (code) {
+        router.push({ pathname: '/pair-confirm', params: { code } })
+      }
+    }
+
+    void Linking.getInitialURL().then((url) => {
+      if (url) handleUrl(url)
+    })
+
+    const sub = Linking.addEventListener('url', ({ url }) => handleUrl(url))
+    return () => sub.remove()
+  }, [router])
+
   // Why: hide the native splash only once the navigation Stack has been laid
   // out — this is the earliest moment the user will see actual app content.
   // Previously the splash hid when a placeholder View rendered, leaving a
@@ -55,6 +98,7 @@ export default function RootLayout() {
           }}
         />
         <Stack.Screen name="pair-scan" options={{ headerShown: false }} />
+        <Stack.Screen name="pair-confirm" options={{ headerShown: false }} />
         <Stack.Screen name="settings" options={{ headerShown: false }} />
         <Stack.Screen name="notifications" options={{ headerShown: false }} />
         <Stack.Screen name="troubleshoot" options={{ headerShown: false }} />

--- a/mobile/app/pair-confirm.tsx
+++ b/mobile/app/pair-confirm.tsx
@@ -1,0 +1,217 @@
+import { useEffect, useState } from 'react'
+import { View, Text, StyleSheet, Pressable, ActivityIndicator } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { useLocalSearchParams, useRouter } from 'expo-router'
+import { ChevronLeft } from 'lucide-react-native'
+import { parsePairingCode } from '../src/transport/pairing'
+import { connect } from '../src/transport/rpc-client'
+import { saveHost, getNextHostName } from '../src/transport/host-store'
+import type { PairingOffer } from '../src/transport/types'
+import { colors, spacing, radii, typography } from '../src/theme/mobile-theme'
+
+type Status = 'awaiting-confirm' | 'connecting' | 'error'
+
+export default function PairConfirmScreen() {
+  const router = useRouter()
+  const insets = useSafeAreaInsets()
+  const params = useLocalSearchParams<{ code?: string }>()
+  const [offer, setOffer] = useState<PairingOffer | null>(null)
+  const [status, setStatus] = useState<Status>('awaiting-confirm')
+  const [errorMessage, setErrorMessage] = useState('')
+
+  useEffect(() => {
+    if (!params.code) {
+      setStatus('error')
+      setErrorMessage('Missing pairing code')
+      return
+    }
+    const parsed = parsePairingCode(params.code)
+    if (!parsed) {
+      setStatus('error')
+      setErrorMessage('Not a valid pairing code')
+      return
+    }
+    setOffer(parsed)
+  }, [params.code])
+
+  async function confirm() {
+    if (!offer) return
+    setStatus('connecting')
+    let client: ReturnType<typeof connect> | null = null
+    try {
+      client = connect(offer.endpoint, offer.deviceToken, offer.publicKeyB64)
+      const response = await client.sendRequest('status.get')
+      client.close()
+      client = null
+
+      if (!response.ok) {
+        setStatus('error')
+        setErrorMessage(
+          response.error.code === 'unauthorized'
+            ? 'Authentication failed — token may be expired'
+            : `Server error: ${response.error.message}`
+        )
+        return
+      }
+
+      const hostId = `host-${Date.now()}`
+      const hostName = await getNextHostName()
+      await saveHost({
+        id: hostId,
+        name: hostName,
+        endpoint: offer.endpoint,
+        deviceToken: offer.deviceToken,
+        publicKeyB64: offer.publicKeyB64,
+        lastConnected: Date.now()
+      })
+      router.replace(`/h/${hostId}`)
+    } catch {
+      setStatus('error')
+      setErrorMessage('Cannot connect — check that your computer is on the same network')
+    } finally {
+      client?.close()
+    }
+  }
+
+  function cancel() {
+    router.replace('/')
+  }
+
+  const containerPadding = { paddingTop: insets.top + spacing.sm }
+
+  return (
+    <View style={[styles.container, containerPadding]}>
+      <Pressable style={styles.backButton} onPress={cancel}>
+        <ChevronLeft size={22} color={colors.textSecondary} />
+      </Pressable>
+
+      <View style={styles.content}>
+        <Text style={styles.title}>Pair with this desktop?</Text>
+
+        {offer && status === 'awaiting-confirm' && (
+          <>
+            <Text style={styles.subtitle}>
+              You opened a pairing link from your desktop. Confirm to add it to your hosts.
+            </Text>
+            <View style={styles.detailsCard}>
+              <Text style={styles.detailsLabel}>Endpoint</Text>
+              <Text style={styles.detailsValue}>{offer.endpoint}</Text>
+            </View>
+            <Pressable style={styles.primaryButton} onPress={() => void confirm()}>
+              <Text style={styles.primaryButtonText}>Pair</Text>
+            </Pressable>
+            <Pressable style={styles.secondaryButton} onPress={cancel}>
+              <Text style={styles.secondaryButtonText}>Cancel</Text>
+            </Pressable>
+          </>
+        )}
+
+        {status === 'connecting' && (
+          <View style={styles.centered}>
+            <ActivityIndicator size="large" color={colors.textSecondary} />
+            <Text style={styles.connectingText}>Connecting…</Text>
+          </View>
+        )}
+
+        {status === 'error' && (
+          <View style={styles.centered}>
+            <Text style={styles.errorText}>{errorMessage}</Text>
+            <Pressable style={styles.primaryButton} onPress={cancel}>
+              <Text style={styles.primaryButtonText}>Back to home</Text>
+            </Pressable>
+          </View>
+        )}
+      </View>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.bgBase,
+    padding: spacing.lg
+  },
+  backButton: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: spacing.sm
+  },
+  content: {
+    flex: 1,
+    paddingHorizontal: spacing.sm
+  },
+  title: {
+    fontSize: typography.titleSize,
+    fontWeight: '600',
+    color: colors.textPrimary,
+    marginBottom: spacing.sm
+  },
+  subtitle: {
+    fontSize: typography.bodySize,
+    color: colors.textSecondary,
+    lineHeight: 20,
+    marginBottom: spacing.lg
+  },
+  detailsCard: {
+    backgroundColor: colors.bgPanel,
+    borderRadius: radii.input,
+    padding: spacing.md,
+    marginBottom: spacing.lg
+  },
+  detailsLabel: {
+    fontSize: 12,
+    color: colors.textMuted,
+    marginBottom: 4
+  },
+  detailsValue: {
+    fontSize: typography.bodySize,
+    color: colors.textPrimary,
+    fontFamily: 'Menlo',
+    fontWeight: '500'
+  },
+  primaryButton: {
+    backgroundColor: colors.textPrimary,
+    paddingHorizontal: spacing.xl,
+    paddingVertical: spacing.sm + 2,
+    borderRadius: radii.button,
+    alignItems: 'center',
+    marginBottom: spacing.sm
+  },
+  primaryButtonText: {
+    color: colors.bgBase,
+    fontSize: typography.bodySize,
+    fontWeight: '600'
+  },
+  secondaryButton: {
+    paddingHorizontal: spacing.xl,
+    paddingVertical: spacing.sm + 2,
+    borderRadius: radii.button,
+    alignItems: 'center'
+  },
+  secondaryButtonText: {
+    color: colors.textSecondary,
+    fontSize: typography.bodySize,
+    fontWeight: '500'
+  },
+  centered: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center'
+  },
+  connectingText: {
+    color: colors.textSecondary,
+    fontSize: typography.bodySize,
+    marginTop: spacing.lg
+  },
+  errorText: {
+    color: colors.statusRed,
+    fontSize: typography.bodySize,
+    textAlign: 'center',
+    marginBottom: spacing.xl,
+    lineHeight: 20
+  }
+})

--- a/mobile/app/pair-scan.tsx
+++ b/mobile/app/pair-scan.tsx
@@ -3,12 +3,13 @@ import { View, Text, StyleSheet, Pressable, ActivityIndicator } from 'react-nati
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { CameraView, useCameraPermissions } from 'expo-camera'
 import { useRouter } from 'expo-router'
-import { ChevronLeft } from 'lucide-react-native'
-import { decodePairingUrl } from '../src/transport/pairing'
+import { ChevronLeft, Clipboard as ClipboardIcon } from 'lucide-react-native'
+import { decodePairingUrl, parsePairingCode } from '../src/transport/pairing'
 import { connect } from '../src/transport/rpc-client'
 import { saveHost, getNextHostName } from '../src/transport/host-store'
 import type { PairingOffer } from '../src/transport/types'
 import { colors, spacing, radii, typography } from '../src/theme/mobile-theme'
+import { TextInputModal } from '../src/components/TextInputModal'
 
 function Step({ number, text }: { number: number; text: string }) {
   return (
@@ -27,6 +28,7 @@ export default function PairScanScreen() {
   const [permission, requestPermission] = useCameraPermissions()
   const [status, setStatus] = useState<'scanning' | 'connecting' | 'error'>('scanning')
   const [errorMessage, setErrorMessage] = useState('')
+  const [pasteVisible, setPasteVisible] = useState(false)
   const processingRef = useRef(false)
 
   const handleBarCodeScanned = useCallback(
@@ -46,6 +48,22 @@ export default function PairScanScreen() {
     },
     [router]
   )
+
+  const handlePasteSubmit = useCallback((input: string) => {
+    setPasteVisible(false)
+    if (processingRef.current) return
+    processingRef.current = true
+
+    const offer = parsePairingCode(input)
+    if (!offer) {
+      setStatus('error')
+      setErrorMessage('Not a valid pairing code — copy it from your computer and paste again')
+      processingRef.current = false
+      return
+    }
+
+    void testAndSave(offer)
+  }, [])
 
   async function testAndSave(offer: PairingOffer) {
     setStatus('connecting')
@@ -140,20 +158,29 @@ export default function PairScanScreen() {
       </View>
 
       {status === 'scanning' && (
-        <View style={styles.cameraWrap}>
-          <CameraView
-            style={styles.camera}
-            facing="back"
-            barcodeScannerSettings={{ barcodeTypes: ['qr'] }}
-            onBarcodeScanned={handleBarCodeScanned}
-          />
-          <View style={styles.reticle} pointerEvents="none">
-            <View style={[styles.corner, styles.cornerTL]} />
-            <View style={[styles.corner, styles.cornerTR]} />
-            <View style={[styles.corner, styles.cornerBL]} />
-            <View style={[styles.corner, styles.cornerBR]} />
+        <>
+          <View style={styles.cameraWrap}>
+            <CameraView
+              style={styles.camera}
+              facing="back"
+              barcodeScannerSettings={{ barcodeTypes: ['qr'] }}
+              onBarcodeScanned={handleBarCodeScanned}
+            />
+            <View style={styles.reticle} pointerEvents="none">
+              <View style={[styles.corner, styles.cornerTL]} />
+              <View style={[styles.corner, styles.cornerTR]} />
+              <View style={[styles.corner, styles.cornerBL]} />
+              <View style={[styles.corner, styles.cornerBR]} />
+            </View>
           </View>
-        </View>
+          <Pressable
+            style={({ pressed }) => [styles.pasteButton, pressed && styles.pasteButtonPressed]}
+            onPress={() => setPasteVisible(true)}
+          >
+            <ClipboardIcon size={16} color={colors.textSecondary} />
+            <Text style={styles.pasteButtonText}>Or paste pairing code</Text>
+          </Pressable>
+        </>
       )}
 
       {status === 'connecting' && (
@@ -166,11 +193,34 @@ export default function PairScanScreen() {
       {status === 'error' && (
         <View style={styles.centered}>
           <Text style={styles.errorText}>{errorMessage}</Text>
-          <Pressable style={styles.primaryButton} onPress={retry}>
-            <Text style={styles.primaryButtonText}>Try Again</Text>
-          </Pressable>
+          <View style={styles.errorActions}>
+            <Pressable style={styles.primaryButton} onPress={retry}>
+              <Text style={styles.primaryButtonText}>Try Again</Text>
+            </Pressable>
+            <Pressable
+              style={({ pressed }) => [
+                styles.secondaryButton,
+                pressed && styles.pasteButtonPressed
+              ]}
+              onPress={() => {
+                retry()
+                setPasteVisible(true)
+              }}
+            >
+              <Text style={styles.secondaryButtonText}>Paste code instead</Text>
+            </Pressable>
+          </View>
         </View>
       )}
+
+      <TextInputModal
+        visible={pasteVisible}
+        title="Paste pairing code"
+        message="Copy the code shown under the QR on your computer."
+        placeholder="orca://pair#... or paste the code"
+        onSubmit={handlePasteSubmit}
+        onCancel={() => setPasteVisible(false)}
+      />
     </View>
   )
 }
@@ -303,5 +353,36 @@ const styles = StyleSheet.create({
     color: colors.bgBase,
     fontSize: typography.bodySize,
     fontWeight: '600'
+  },
+  pasteButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing.xs,
+    marginTop: spacing.md,
+    paddingVertical: spacing.sm,
+    borderRadius: radii.button
+  },
+  pasteButtonPressed: {
+    opacity: 0.6
+  },
+  pasteButtonText: {
+    color: colors.textSecondary,
+    fontSize: typography.bodySize,
+    fontWeight: '500'
+  },
+  errorActions: {
+    alignItems: 'center',
+    gap: spacing.sm
+  },
+  secondaryButton: {
+    paddingHorizontal: spacing.xl,
+    paddingVertical: spacing.sm,
+    borderRadius: radii.button
+  },
+  secondaryButtonText: {
+    color: colors.textSecondary,
+    fontSize: typography.bodySize,
+    fontWeight: '500'
   }
 })

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -22,6 +22,7 @@
     "expo-linking": "^55.0.14",
     "expo-notifications": "^55.0.21",
     "expo-router": "^55.0.13",
+    "expo-secure-store": "^55.0.13",
     "expo-splash-screen": "^55.0.19",
     "expo-status-bar": "^55.0.5",
     "lucide-react-native": "^1.11.0",

--- a/mobile/pnpm-lock.yaml
+++ b/mobile/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       expo-router:
         specifier: ^55.0.13
         version: 55.0.13(121105c3b042d5e83ab3c1d3b84ed55f)
+      expo-secure-store:
+        specifier: ^55.0.13
+        version: 55.0.13(expo@55.0.17)
       expo-splash-screen:
         specifier: ^55.0.19
         version: 55.0.19(expo@55.0.17)(typescript@5.9.3)
@@ -3233,6 +3236,11 @@ packages:
         optional: true
       react-server-dom-webpack:
         optional: true
+
+  expo-secure-store@55.0.13:
+    resolution: {integrity: sha512-I6r0JNO1Fd4o0Gu7Ixiic7s89lqgdUHq17uBH9y1f/AntoyKn71TdtYJH82RgfsBbu5qNVzrwImmvlANyOlITQ==}
+    peerDependencies:
+      expo: '*'
 
   expo-server@55.0.8:
     resolution: {integrity: sha512-AoV5TKuO4biSzrhe/OVLyInfTT0pV9/OOc/g/oVq5vmCjL8SaSYTkES8PLt+67Tm7VqX+Dn0+kSx1nQcjEKaPw==}
@@ -9564,6 +9572,10 @@ snapshots:
       - '@types/react-dom'
       - expo-font
       - supports-color
+
+  expo-secure-store@55.0.13(expo@55.0.17):
+    dependencies:
+      expo: 55.0.17(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.13)(react-dom@19.2.5(react@19.2.0))(react-native-webview@13.16.1(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
 
   expo-server@55.0.8: {}
 

--- a/mobile/src/transport/host-store.ts
+++ b/mobile/src/transport/host-store.ts
@@ -1,16 +1,73 @@
 import AsyncStorage from '@react-native-async-storage/async-storage'
-import { HostProfileSchema, type HostProfile } from './types'
+import * as SecureStore from 'expo-secure-store'
+import {
+  HostProfileSchema,
+  StoredHostProfileSchema,
+  type HostProfile,
+  type StoredHostProfile
+} from './types'
 
 const STORAGE_KEY = 'orca:hosts'
+const TOKEN_KEY_PREFIX = 'orca:host-token:'
+
+// Why: WHEN_UNLOCKED_THIS_DEVICE_ONLY keeps the pairing token off
+// iCloud Keychain and out of iCloud/iTunes backup restores onto a
+// different physical device. Reads/writes are silent (no biometric
+// prompt) since we don't request access control flags.
+const KEYCHAIN_OPTIONS: SecureStore.SecureStoreOptions = {
+  keychainAccessible: SecureStore.WHEN_UNLOCKED_THIS_DEVICE_ONLY
+}
+
+function tokenKey(hostId: string): string {
+  return `${TOKEN_KEY_PREFIX}${hostId}`
+}
 
 export async function loadHosts(): Promise<HostProfile[]> {
+  const raw = await AsyncStorage.getItem(STORAGE_KEY)
+  if (!raw) return []
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return []
+  }
+  if (!Array.isArray(parsed)) return []
+
+  const out: HostProfile[] = []
+  for (const item of parsed) {
+    // Why: pre-v0.0.3 records carry the deviceToken in AsyncStorage.
+    // Drop them silently — the three pre-launch users will re-pair on
+    // first run rather than carry a migration shim through the auth
+    // path.
+    if (item && typeof item === 'object' && 'deviceToken' in item) {
+      continue
+    }
+    const stored = StoredHostProfileSchema.safeParse(item)
+    if (!stored.success) continue
+
+    const token = await SecureStore.getItemAsync(tokenKey(stored.data.id), KEYCHAIN_OPTIONS)
+    if (!token) {
+      // Why: orphaned metadata with no matching keychain entry — most
+      // likely a stale record from a development install. Skip it
+      // rather than surface a half-broken host.
+      continue
+    }
+    out.push({ ...stored.data, deviceToken: token })
+  }
+  return out
+}
+
+async function loadStoredHosts(): Promise<StoredHostProfile[]> {
   const raw = await AsyncStorage.getItem(STORAGE_KEY)
   if (!raw) return []
   try {
     const parsed = JSON.parse(raw) as unknown
     if (!Array.isArray(parsed)) return []
     return parsed.flatMap((item) => {
-      const result = HostProfileSchema.safeParse(item)
+      // Why: same drop-old-records rule as loadHosts; keeps internal
+      // mutators from re-persisting pre-v0.0.3 entries.
+      if (item && typeof item === 'object' && 'deviceToken' in item) return []
+      const result = StoredHostProfileSchema.safeParse(item)
       return result.success ? [result.data] : []
     })
   } catch {
@@ -18,25 +75,39 @@ export async function loadHosts(): Promise<HostProfile[]> {
   }
 }
 
-export async function saveHost(host: HostProfile): Promise<void> {
-  const hosts = await loadHosts()
-  const index = hosts.findIndex((h) => h.id === host.id)
-  if (index >= 0) {
-    hosts[index] = host
-  } else {
-    hosts.push(host)
+function toStored(host: HostProfile): StoredHostProfile {
+  return {
+    id: host.id,
+    name: host.name,
+    endpoint: host.endpoint,
+    publicKeyB64: host.publicKeyB64,
+    lastConnected: host.lastConnected
   }
+}
+
+export async function saveHost(host: HostProfile): Promise<void> {
+  const validated = HostProfileSchema.parse(host)
+  const hosts = await loadStoredHosts()
+  const stored = toStored(validated)
+  const index = hosts.findIndex((h) => h.id === stored.id)
+  if (index >= 0) {
+    hosts[index] = stored
+  } else {
+    hosts.push(stored)
+  }
+  await SecureStore.setItemAsync(tokenKey(stored.id), validated.deviceToken, KEYCHAIN_OPTIONS)
   await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(hosts))
 }
 
 export async function removeHost(hostId: string): Promise<void> {
-  const hosts = await loadHosts()
+  const hosts = await loadStoredHosts()
   const filtered = hosts.filter((h) => h.id !== hostId)
   await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(filtered))
+  await SecureStore.deleteItemAsync(tokenKey(hostId), KEYCHAIN_OPTIONS)
 }
 
 export async function renameHost(hostId: string, newName: string): Promise<void> {
-  const hosts = await loadHosts()
+  const hosts = await loadStoredHosts()
   const host = hosts.find((h) => h.id === hostId)
   if (host) {
     host.name = newName
@@ -45,7 +116,7 @@ export async function renameHost(hostId: string, newName: string): Promise<void>
 }
 
 export async function getNextHostName(): Promise<string> {
-  const hosts = await loadHosts()
+  const hosts = await loadStoredHosts()
   const existingNumbers = hosts
     .map((h) => {
       const match = h.name.match(/^Host (\d+)$/)
@@ -57,7 +128,7 @@ export async function getNextHostName(): Promise<string> {
 }
 
 export async function updateLastConnected(hostId: string): Promise<void> {
-  const hosts = await loadHosts()
+  const hosts = await loadStoredHosts()
   const host = hosts.find((h) => h.id === hostId)
   if (host) {
     host.lastConnected = Date.now()

--- a/mobile/src/transport/pairing.ts
+++ b/mobile/src/transport/pairing.ts
@@ -1,16 +1,38 @@
 import { PairingOfferSchema, type PairingOffer } from './types'
 
+// Why: this file mirrors src/shared/pairing.ts (which is covered by CI
+// vitest) but uses atob/btoa because Metro/Hermes don't ship Node's
+// Buffer. Keep the parsing semantics in sync — when one changes, update
+// the other.
+
 export function decodePairingUrl(url: string): PairingOffer | null {
   try {
     const hashIndex = url.indexOf('#')
     if (!url.startsWith('orca://pair') || hashIndex === -1) return null
-
-    const base64url = url.slice(hashIndex + 1)
-    const base64 = base64url.replace(/-/g, '+').replace(/_/g, '/')
-    const json = atob(base64)
-    const parsed = JSON.parse(json)
-    return PairingOfferSchema.parse(parsed)
+    return decodePairingBase64(url.slice(hashIndex + 1))
   } catch {
     return null
   }
+}
+
+// Why: accept either an `orca://pair#<base64>` URL or the bare base64
+// string so the paste-pair flow can take whichever the user actually
+// copied from desktop.
+export function parsePairingCode(input: string): PairingOffer | null {
+  const trimmed = input.trim()
+  if (!trimmed) return null
+  try {
+    if (trimmed.startsWith('orca://pair')) {
+      return decodePairingUrl(trimmed)
+    }
+    return decodePairingBase64(trimmed)
+  } catch {
+    return null
+  }
+}
+
+function decodePairingBase64(base64url: string): PairingOffer {
+  const base64 = base64url.replace(/-/g, '+').replace(/_/g, '/')
+  const json = atob(base64)
+  return PairingOfferSchema.parse(JSON.parse(json))
 }

--- a/mobile/src/transport/types.ts
+++ b/mobile/src/transport/types.ts
@@ -60,3 +60,16 @@ export const HostProfileSchema = z.object({
   publicKeyB64: z.string().min(1),
   lastConnected: z.number().finite()
 })
+
+// Why: persisted host record after the v0.0.3 keychain split. The
+// deviceToken is held in iOS Keychain via expo-secure-store and joined
+// in at load time; it must NOT appear in AsyncStorage anymore.
+export const StoredHostProfileSchema = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  endpoint: z.string().min(1),
+  publicKeyB64: z.string().min(1),
+  lastConnected: z.number().finite()
+})
+
+export type StoredHostProfile = z.infer<typeof StoredHostProfileSchema>

--- a/src/main/ipc/mobile.ts
+++ b/src/main/ipc/mobile.ts
@@ -82,6 +82,7 @@ export function registerMobileHandlers(rpcServer: OrcaRuntimeRpcServer): void {
     return {
       available: true as const,
       qrDataUrl,
+      pairingUrl: url,
       endpoint,
       deviceId: device.deviceId
     }

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1167,11 +1167,15 @@ export type PreloadApi = {
     listNetworkInterfaces: () => Promise<{
       interfaces: { name: string; address: string }[]
     }>
-    getPairingQR: (args?: {
-      address?: string
-    }) => Promise<
+    getPairingQR: (args?: { address?: string }) => Promise<
       | { available: false }
-      | { available: true; qrDataUrl: string; endpoint: string; deviceId: string }
+      | {
+          available: true
+          qrDataUrl: string
+          pairingUrl: string
+          endpoint: string
+          deviceId: string
+        }
     >
     listDevices: () => Promise<{
       devices: { deviceId: string; name: string; pairedAt: number; lastSeenAt: number }[]

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2133,7 +2133,13 @@ const api = {
       address?: string
     }): Promise<
       | { available: false }
-      | { available: true; qrDataUrl: string; endpoint: string; deviceId: string }
+      | {
+          available: true
+          qrDataUrl: string
+          pairingUrl: string
+          endpoint: string
+          deviceId: string
+        }
     > => ipcRenderer.invoke('mobile:getPairingQR', args),
 
     listDevices: (): Promise<{

--- a/src/renderer/src/components/settings/MobilePane.tsx
+++ b/src/renderer/src/components/settings/MobilePane.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
 import { toast } from 'sonner'
-import { Maximize2, RefreshCw, Trash2, Wifi } from 'lucide-react'
+import { Check, Copy, Maximize2, RefreshCw, Trash2, Wifi } from 'lucide-react'
 import { Button } from '../ui/button'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '../ui/dialog'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
@@ -38,12 +38,14 @@ type NetworkInterface = {
 
 export function MobilePane(): React.JSX.Element {
   const [qrDataUrl, setQrDataUrl] = useState<string | null>(null)
+  const [pairingUrl, setPairingUrl] = useState<string | null>(null)
   const [endpoint, setEndpoint] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
   const [devices, setDevices] = useState<PairedDevice[]>([])
   const [qrEnlarged, setQrEnlarged] = useState(false)
   const [networkInterfaces, setNetworkInterfaces] = useState<NetworkInterface[]>([])
   const [selectedAddress, setSelectedAddress] = useState<string | undefined>(undefined)
+  const [codeCopied, setCodeCopied] = useState(false)
 
   const loadDevices = useCallback(async () => {
     try {
@@ -74,7 +76,9 @@ export function MobilePane(): React.JSX.Element {
       )
       if (result.available) {
         setQrDataUrl(result.qrDataUrl)
+        setPairingUrl(result.pairingUrl)
         setEndpoint(result.endpoint)
+        setCodeCopied(false)
         void loadDevices()
       } else {
         toast.error('WebSocket transport is not running')
@@ -109,6 +113,19 @@ export function MobilePane(): React.JSX.Element {
     const interval = setInterval(() => void loadDevices(), 3000)
     return () => clearInterval(interval)
   }, [deviceCountAtQr, devices.length, loadDevices])
+
+  async function copyPairingCode() {
+    if (!pairingUrl) {
+      return
+    }
+    try {
+      await navigator.clipboard.writeText(pairingUrl)
+      setCodeCopied(true)
+      setTimeout(() => setCodeCopied(false), 2000)
+    } catch {
+      toast.error('Failed to copy pairing code')
+    }
+  }
 
   async function revokeDevice(deviceId: string) {
     try {
@@ -177,6 +194,26 @@ export function MobilePane(): React.JSX.Element {
           <p className="text-muted-foreground max-w-xs text-center text-xs">
             Scan this code with the Orca mobile app. Each code creates a unique device token.
           </p>
+          {pairingUrl && (
+            <div className="flex w-full max-w-sm flex-col gap-1.5 px-4">
+              <div className="text-muted-foreground text-center text-xs">
+                Or paste this code in the mobile app:
+              </div>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => void copyPairingCode()}
+                className="font-mono text-[10px] leading-tight whitespace-normal break-all h-auto py-2"
+              >
+                <span className="flex-1 text-left">{pairingUrl}</span>
+                {codeCopied ? (
+                  <Check className="ml-2 size-3.5 shrink-0 text-emerald-500" />
+                ) : (
+                  <Copy className="ml-2 size-3.5 shrink-0" />
+                )}
+              </Button>
+            </div>
+          )}
         </div>
       )}
 

--- a/src/shared/pairing.test.ts
+++ b/src/shared/pairing.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { encodePairingOffer, decodePairingOffer, type PairingOffer } from './pairing'
+import {
+  encodePairingOffer,
+  decodePairingOffer,
+  parsePairingCode,
+  type PairingOffer
+} from './pairing'
 
 describe('pairing offer', () => {
   const offer: PairingOffer = {
@@ -47,5 +52,45 @@ describe('pairing offer', () => {
     const wrong = { v: 2, endpoint: 'ws://host:1234', deviceToken: 'tok' }
     const base64 = Buffer.from(JSON.stringify(wrong)).toString('base64')
     expect(() => decodePairingOffer(`orca://pair#${base64}`)).toThrow()
+  })
+})
+
+describe('parsePairingCode', () => {
+  const offer: PairingOffer = {
+    v: 2,
+    endpoint: 'ws://192.168.1.10:6768',
+    deviceToken: 'token-abc',
+    publicKeyB64: 'pubkey-xyz'
+  }
+
+  it('parses a full orca://pair# URL', () => {
+    const url = encodePairingOffer(offer)
+    expect(parsePairingCode(url)).toEqual(offer)
+  })
+
+  it('parses a bare base64url payload (without scheme prefix)', () => {
+    const url = encodePairingOffer(offer)
+    const base64url = url.split('#')[1]!
+    expect(parsePairingCode(base64url)).toEqual(offer)
+  })
+
+  it('tolerates surrounding whitespace from clipboard', () => {
+    const url = encodePairingOffer(offer)
+    expect(parsePairingCode(`  ${url}\n`)).toEqual(offer)
+  })
+
+  it('returns null for empty input', () => {
+    expect(parsePairingCode('')).toBeNull()
+    expect(parsePairingCode('   ')).toBeNull()
+  })
+
+  it('returns null for garbage input', () => {
+    expect(parsePairingCode('not a pairing code')).toBeNull()
+    expect(parsePairingCode('https://example.com')).toBeNull()
+  })
+
+  it('returns null for valid base64 of unrelated JSON', () => {
+    const bogus = Buffer.from(JSON.stringify({ hello: 'world' })).toString('base64')
+    expect(parsePairingCode(bogus)).toBeNull()
   })
 })

--- a/src/shared/pairing.ts
+++ b/src/shared/pairing.ts
@@ -28,7 +28,28 @@ export function decodePairingOffer(url: string): PairingOffer {
   if (!url.startsWith('orca://pair') || hashIndex === -1) {
     throw new Error('Invalid pairing URL: must start with orca://pair#')
   }
-  const base64url = url.slice(hashIndex + 1)
+  return decodePairingBase64(url.slice(hashIndex + 1))
+}
+
+// Why: accept either an `orca://pair#<base64>` URL or the bare base64
+// string so the mobile paste-pair flow can take whichever the user
+// actually copied from desktop.
+export function parsePairingCode(input: string): PairingOffer | null {
+  const trimmed = input.trim()
+  if (!trimmed) {
+    return null
+  }
+  try {
+    if (trimmed.startsWith('orca://pair')) {
+      return decodePairingOffer(trimmed)
+    }
+    return decodePairingBase64(trimmed)
+  } catch {
+    return null
+  }
+}
+
+function decodePairingBase64(base64url: string): PairingOffer {
   const base64 = base64url.replace(/-/g, '+').replace(/_/g, '/')
   const json = Buffer.from(base64, 'base64').toString('utf-8')
   return PairingOfferSchema.parse(JSON.parse(json))


### PR DESCRIPTION
## Summary

Two App Store prep improvements bundled into a single rebuild + TestFlight push.

### 1. Paste-pair fallback

- Desktop **Settings → Mobile** pairing panel now shows the pairing code below the QR with a one-click **Copy pairing code** button.
- Mobile pair-scan adds an **"Or paste pairing code"** button under the camera view → opens a paste sheet → decodes via the shared `parsePairingCode` parser → pairs identically to the QR path.

**Why:** lets us record the App Store demo video in the iOS simulator (which has no real camera) and gives end users an accessibility fallback when the camera path doesn't work.

### 2. Pairing tokens → iOS Keychain

- New `expo-secure-store` dependency.
- `mobile/src/transport/host-store.ts` refactored: device tokens move to **iOS Keychain** with `WHEN_UNLOCKED_THIS_DEVICE_ONLY` accessibility class. Host metadata (name, endpoint, public key, lastConnected) stays in AsyncStorage; only the secret moves.
- `StoredHostProfileSchema` (no `deviceToken` field) added in `mobile/src/transport/types.ts` for the on-disk shape; existing `HostProfile` is the in-memory shape (with token joined in at load time).

**Effects:** token encrypted at rest by the device passcode, never syncs to iCloud Keychain, isn't restored to a different physical device from a backup. **Reads/writes are silent** — no biometric prompt, no permission sheet.

### 3. Migration policy: silent drop

Pre-v0.0.3 host records (which carried `deviceToken` directly in AsyncStorage) are silently filtered out by `loadHosts()` on first launch. Given the tiny pre-public user base (~3 users), asking them to re-pair was simpler than carrying a migration shim through the auth path. The `whats-new-v0.0.3.md` release note flags this for TestFlight users.

## Build / version

- `mobile/app.json`: `version` 0.0.2 → 0.0.3, `ios.buildNumber` 3 → 4
- `expo prebuild --platform ios --no-install` + `pod install` run; ExpoSecureStore (55.0.13) integrated. `mobile/ios/` is gitignored, regenerated locally.

## Files

**Mobile:**
- `mobile/app/pair-scan.tsx` — paste button, modal, error "Paste code instead" recovery action
- `mobile/src/transport/pairing.ts` — adds `parsePairingCode(input)` accepting either `orca://pair#…` URL or bare base64
- `mobile/src/transport/host-store.ts` — split metadata vs Keychain; silent drop of pre-v0.0.3 records
- `mobile/src/transport/types.ts` — adds `StoredHostProfile` / `StoredHostProfileSchema`
- `mobile/app.json`, `mobile/package.json`, `mobile/pnpm-lock.yaml`

**Desktop:**
- `src/main/ipc/mobile.ts` — IPC returns `pairingUrl` alongside `qrDataUrl`
- `src/preload/index.ts`, `src/preload/api-types.ts` — new field in return type
- `src/renderer/src/components/settings/MobilePane.tsx` — Copy button + visible code under QR
- `src/shared/pairing.ts` — adds `parsePairingCode` + extracts `decodePairingBase64` helper
- `src/shared/pairing.test.ts` — 6 new tests for `parsePairingCode` (URL form, bare base64, whitespace tolerance, empty, garbage, valid base64 of unrelated JSON)

## Verification

- `pnpm lint` — 0 errors (6 pre-existing warnings in unrelated `ProjectViewWrapper.tsx`)
- `pnpm tc:node`, `pnpm tc:web` — clean
- `mobile && npx tsc --noEmit` — clean
- `pnpm lint` (mobile) — clean
- `pnpm test src/shared/pairing.test.ts` — 13/13 pass

## Manual validation (after merge)

1. Install v0.0.2 from TestFlight, pair a host, verify it works.
2. Upgrade to v0.0.3 — host list should be empty (silent drop). Re-pair from desktop's QR or paste flow → both should land in Keychain.
3. Delete v0.0.3, reinstall v0.0.3 → previously paired hosts come back (Keychain persistence).
4. iOS Simulator: `xcrun simctl install booted Orca.app` → use paste flow with a code copied from desktop → confirm pairing works.

## Notes

- This PR does **not** include the docs in `docs/mobile-app-store/` (kept untracked locally per request — they belong with the App Store submission queue, not this code change).
- Do **not** merge yet — testing happens in TestFlight first.

Made with [Orca](https://github.com/stablyai/orca) 🐋
