### PR TITLE
fix(mobile): remove dead-row gap above keyboard accessory bar

### DIFF
--- a/mobile/src/terminal/TerminalWebView.tsx
+++ b/mobile/src/terminal/TerminalWebView.tsx
@@ -350,12 +350,15 @@ const XTERM_HTML = `<!DOCTYPE html>
       ? containerHeightPx
       : window.innerHeight;
     var cols = Math.floor(vpWidth / cellWidth);
-    // Why: subtract 2 rows after dividing. The WebView's reported height
-    // can slightly overstate the usable area (layout timing, subpixel
-    // rounding, safe-area insets). Subtracting 2 guarantees the last
-    // visible row plus the shell prompt (which often wraps on narrow
-    // screens) stays fully above the accessory bar.
-    var rows = Math.max(8, Math.floor(vpHeight / cellHeight) - 2);
+    // Why: the rows we report become the PTY's actual row count after the
+    // server fits to viewport, and xterm renders exactly that many lines
+    // anchored top-left of the WebView. Subtracting rows here would leave
+    // dead xterm-background space at the bottom of the container and make
+    // the last PTY rows visually appear above an "invisible line." Any
+    // safety margin between the prompt and the accessory bar must come
+    // from RN layout (terminalFrame's flex bounds), not from undersizing
+    // the PTY.
+    var rows = Math.max(8, Math.floor(vpHeight / cellHeight));
     notify({ type: 'measure-result', cols: cols, rows: rows });
   }
 


### PR DESCRIPTION
## Problem

In the mobile companion app, when a terminal is bottomed out, the last prompt line sits ~2-3 lines above the accessory shortcut bar instead of flush against it. Scrollback content also visually "disappears" into that strip, because xterm only renders `rows` lines while the WebView container is taller than that.

## Root cause

`measureFitDimensions` in `mobile/src/terminal/TerminalWebView.tsx` was subtracting 2 from the reported row count:

```js
var rows = Math.max(8, Math.floor(vpHeight / cellHeight) - 2);
```

The reported `{cols, rows}` is sent to the server in `terminal.subscribe` / `terminal.updateViewport`, and the server resizes the PTY to those exact dimensions. xterm is then opened at `rows` and its surface (`transform-origin: top left`) renders `rows × cellHeight` pixels — leaving roughly `2 × cellHeight` of empty `#terminal-container` background at the bottom.

The original comment claimed this was a safety margin against "layout timing / subpixel rounding / safe-area insets," but the visible result is a permanent dead strip and an invisible boundary that hides the last PTY rows from view.

## Fix

Stop subtracting from the row count. The `terminalFrame` View (`flex: 1`) is already correctly bounded by the accessory/input bar, and `Math.floor` already absorbs sub-pixel rounding. If we ever need a true safety gap between the prompt and the keyboard bar, that belongs in RN layout (padding on `terminalFrame`), not in PTY sizing.

## Verification

- `oxlint` clean.
- Manual testing on physical Android device should show: the bottom prompt row sits flush against the accessory bar; scrollback no longer hides behind a phantom bottom strip.

Follow-up to #1423.

Made with [Orca](https://github.com/stablyai/orca) 🐋
