### PR TITLE
feat(new-workspace): inline create-branch row, scoped suggestions, name under Advanced, tab/focus polish

### DIFF
--- a/src/renderer/src/components/NewWorkspaceComposerCard.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.tsx
@@ -398,6 +398,25 @@ export default function NewWorkspaceComposerCard({
                   : '-translate-y-1 opacity-0 delay-0'
               )}
             >
+              {smartNameSelection ? (
+                // Why: when a source (PR/issue/Linear/branch) is picked the
+                // smart field shows a pill instead of an editable name, so
+                // surface the auto-derived workspace name here under Advanced
+                // where it can be reviewed/overridden. When the user typed an
+                // explicit name there's no source pill — the smart input is
+                // already the name field, so we don't duplicate it here.
+                <div className="space-y-1">
+                  <label className="text-xs font-medium text-muted-foreground">Name</label>
+                  <input
+                    type="text"
+                    value={name}
+                    onChange={(event) => onNameValueChange(event.target.value)}
+                    placeholder="Workspace name"
+                    className="w-full min-w-0 rounded-md border border-input bg-transparent px-3 py-1.5 text-sm shadow-xs transition-[color,box-shadow] outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
+                  />
+                </div>
+              ) : null}
+
               <div className="space-y-1">
                 <label className="text-xs font-medium text-muted-foreground">Note</label>
                 <textarea

--- a/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
+++ b/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
@@ -7,6 +7,7 @@ import {
   CircleDot,
   ExternalLink,
   GitBranch,
+  GitBranchPlus,
   GitPullRequest,
   Github,
   LoaderCircle,
@@ -86,8 +87,17 @@ const MODES: {
   { id: 'text', label: 'Name', Icon: CaseSensitive }
 ]
 
+const emptyHintByMode: Record<SmartNameMode, string> = {
+  smart: 'Start typing to create a name or find a source.',
+  github: 'Start typing to search GitHub PRs and issues.',
+  branches: 'Start typing to find a branch or create a new one.',
+  linear: 'Start typing to search Linear issues.',
+  text: ''
+}
+
 type RowEntry =
   | { kind: 'use-name'; value: string; name: string }
+  | { kind: 'create-branch'; value: string; name: string }
   | { kind: 'github'; value: string; item: GitHubWorkItem }
   | { kind: 'branch'; value: string; refName: string }
   | { kind: 'linear'; value: string; issue: LinearIssue }
@@ -108,17 +118,21 @@ export default function SmartWorkspaceNameField({
 }: SmartWorkspaceNameFieldProps): React.JSX.Element {
   const {
     addRepo,
+    checkLinearConnection,
     fetchWorkItems,
     getCachedWorkItems,
     linearStatus,
+    linearStatusChecked,
     listLinearIssues,
     searchLinearIssues
   } = useAppStore(
     useShallow((s) => ({
       addRepo: s.addRepo,
+      checkLinearConnection: s.checkLinearConnection,
       fetchWorkItems: s.fetchWorkItems,
       getCachedWorkItems: s.getCachedWorkItems,
       linearStatus: s.linearStatus,
+      linearStatusChecked: s.linearStatusChecked,
       listLinearIssues: s.listLinearIssues,
       searchLinearIssues: s.searchLinearIssues
     }))
@@ -156,6 +170,16 @@ export default function SmartWorkspaceNameField({
     },
     [inputRef]
   )
+
+  useEffect(() => {
+    // Why: the composer can be opened before any other Linear-aware surface
+    // (TaskPage, IntegrationsPane) has had a chance to refresh status, leaving
+    // `linearStatus.connected=false` even when the user is actually connected.
+    // Trigger a check on mount if it hasn't run this session.
+    if (!linearStatusChecked) {
+      void checkLinearConnection()
+    }
+  }, [checkLinearConnection, linearStatusChecked])
 
   useEffect(() => {
     const timer = window.setTimeout(() => setDebouncedQuery(value), SEARCH_DEBOUNCE_MS)
@@ -371,9 +395,28 @@ export default function SmartWorkspaceNameField({
 
   const rows = useMemo<RowEntry[]>(() => {
     const trimmed = value.trim()
-    const nextRows: RowEntry[] = trimmed
-      ? [{ kind: 'use-name', value: `use-name-${trimmed}`, name: trimmed }]
-      : []
+    // Why: on the Branches tab the generic "Use … as workspace name" row
+    // reads as off-topic — the user is picking/creating a branch. Swap it
+    // for a branch-creation row that's pinned above existing-branch results
+    // (suppressed when an existing branch matches exactly so we don't offer
+    // to "create" something that already exists).
+    const branchExactMatch = mode === 'branches' && trimmed.length > 0 && branches.includes(trimmed)
+    // Why: the "Use … as workspace name" row only makes sense in Smart
+    // mode, where the user might be typing a free-form name. On dedicated
+    // source tabs (GitHub/Linear/Branches) it's off-topic — the user is
+    // there to pick (or, on Branches, create) a source.
+    const useNameRow: RowEntry | null =
+      trimmed && mode === 'smart'
+        ? { kind: 'use-name', value: `use-name-${trimmed}`, name: trimmed }
+        : null
+    const createBranchRow: RowEntry | null =
+      trimmed && mode === 'branches' && !branchExactMatch
+        ? { kind: 'create-branch', value: `create-branch-${trimmed}`, name: trimmed }
+        : null
+    const nextRows: RowEntry[] = []
+    if (useNameRow) {
+      nextRows.push(useNameRow)
+    }
     if (mode === 'text') {
       return nextRows
     }
@@ -387,6 +430,9 @@ export default function SmartWorkspaceNameField({
       )
     }
     if (mode === 'smart' || mode === 'branches') {
+      if (createBranchRow) {
+        nextRows.push(createBranchRow)
+      }
       nextRows.push(
         ...branches.map((refName) => ({
           kind: 'branch' as const,
@@ -420,7 +466,10 @@ export default function SmartWorkspaceNameField({
 
   const handleSelect = useCallback(
     (row: RowEntry) => {
-      if (row.kind === 'use-name') {
+      if (row.kind === 'use-name' || row.kind === 'create-branch') {
+        // Why: "create new branch" has no existing ref to base from, so
+        // it follows the same path as a typed name — the workspace's branch
+        // is derived from `name` and `baseBranch` stays unset (default base).
         onValueChange(row.name)
       } else if (row.kind === 'github') {
         onGitHubItemSelect(row.item)
@@ -517,6 +566,31 @@ export default function SmartWorkspaceNameField({
           ref={tabsListRef}
           variant="line"
           className="h-7 w-full justify-start gap-4 border-b border-border/40 px-0"
+          onFocusCapture={(event) => {
+            // Why: Radix Tabs uses roving focus and re-applies tabindex=0 to
+            // the active trigger on every render, so we can't keep it out of
+            // the natural Tab order via props or a MutationObserver (race
+            // with React commits). Instead, intercept focus *on entry* into
+            // the tabs list:
+            //   - Forward Tab from outside (e.g., Repo combobox) → bounce to
+            //     the search input so the segmented control is skipped.
+            //   - Shift-Tab from the input → relatedTarget is the input, so
+            //     allow focus to land on the active trigger (segmented
+            //     control remains reachable in reverse).
+            //   - Intra-list focus moves (arrow keys) → relatedTarget is
+            //     inside the list; allow.
+            const previous = event.relatedTarget as HTMLElement | null
+            const list = tabsListRef.current
+            const input = localInputRef.current
+            if (!list || !input) {
+              return
+            }
+            if (!previous || previous === input || list.contains(previous)) {
+              return
+            }
+            event.stopPropagation()
+            input.focus({ preventScroll: true })
+          }}
         >
           {MODES.map(({ id, label, Icon }) => (
             <TabsTrigger
@@ -687,9 +761,9 @@ export default function SmartWorkspaceNameField({
                 </div>
               ) : rows.length === 0 ? (
                 <div className="px-3 py-6 text-center text-xs text-muted-foreground">
-                  {mode === 'linear' && !linearStatus.connected
+                  {mode === 'linear' && linearStatusChecked && !linearStatus.connected
                     ? 'Connect Linear in Settings to search issues.'
-                    : 'Start typing to create a name or find a source.'}
+                    : emptyHintByMode[mode]}
                 </div>
               ) : (
                 <CommandGroup className="p-1">
@@ -747,6 +821,9 @@ function RowIcon({ row }: { row: RowEntry }): React.JSX.Element {
   if (row.kind === 'use-name') {
     return <CaseSensitive className="size-3.5 shrink-0 text-muted-foreground" />
   }
+  if (row.kind === 'create-branch') {
+    return <GitBranchPlus className="size-3.5 shrink-0 text-muted-foreground" />
+  }
   if (row.kind === 'github') {
     return row.item.type === 'pr' ? (
       <GitPullRequest className="size-3.5 shrink-0 text-muted-foreground" />
@@ -787,6 +864,14 @@ function RowLabel({ row }: { row: RowEntry }): React.JSX.Element {
       <span className="min-w-0 truncate">
         Use <span className="font-medium text-foreground">&ldquo;{row.name}&rdquo;</span> as
         workspace name
+      </span>
+    )
+  }
+  if (row.kind === 'create-branch') {
+    return (
+      <span className="min-w-0 truncate">
+        Create new branch{' '}
+        <span className="font-mono text-[11px] font-medium text-foreground">{row.name}</span>
       </span>
     )
   }

--- a/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
+++ b/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
@@ -465,6 +465,26 @@ export default function SmartWorkspaceNameField({
   //     entirely; the input's Enter handler falls through to onPlainEnter.
   const isQueryStale = value.trim().length > 0 && debouncedQuery.trim() !== value.trim()
 
+  // Why: when the typed value is unambiguously a source reference — a
+  // GitHub issue/PR shorthand ("#1234"), a github.com issue/pull URL, or a
+  // Linear identifier ("STA-123") — the user is clearly looking up that
+  // specific source rather than naming a workspace. Once a matching row
+  // appears in the results, snap the highlight onto it so Enter picks it
+  // instead of the typed-text fallback.
+  const sourceIntent = useMemo<'github' | 'linear' | null>(() => {
+    const trimmed = value.trim()
+    if (!trimmed) {
+      return null
+    }
+    if (/^#\d+$/.test(trimmed) || parseGitHubIssueOrPRLink(trimmed) !== null) {
+      return 'github'
+    }
+    if (/^[A-Za-z][A-Za-z0-9_]*-\d+$/.test(trimmed)) {
+      return 'linear'
+    }
+    return null
+  }, [value])
+
   useEffect(() => {
     if (rows.length === 0) {
       return
@@ -478,10 +498,23 @@ export default function SmartWorkspaceNameField({
       setCommandValue(typedTextRow ? typedTextRow.value : '')
       return
     }
+    if (sourceIntent === 'github') {
+      const githubRow = rows.find((row) => row.kind === 'github')
+      if (githubRow) {
+        setCommandValue(githubRow.value)
+        return
+      }
+    } else if (sourceIntent === 'linear') {
+      const linearRow = rows.find((row) => row.kind === 'linear')
+      if (linearRow) {
+        setCommandValue(linearRow.value)
+        return
+      }
+    }
     setCommandValue((current) =>
       rows.some((row) => row.value === current) ? current : rows[0].value
     )
-  }, [isQueryStale, rows])
+  }, [isQueryStale, rows, sourceIntent])
 
   const loading = githubLoading || branchesLoading || linearLoading
   const ActiveInputIcon = mode === 'text' ? CaseSensitive : loading ? LoaderCircle : Search

--- a/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
+++ b/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
@@ -702,6 +702,26 @@ export default function SmartWorkspaceNameField({
                         !event.ctrlKey &&
                         !event.shiftKey
                       ) {
+                        // Why: when the user types faster than the search
+                        // debounce, `rows`/`commandValue` still reflect the
+                        // previous query — pressing Enter would silently pick
+                        // a stale source row (e.g., a PR from the prior
+                        // letters). Treat results as stale while the search
+                        // is loading or the debounced query hasn't caught up
+                        // to the input value, and commit the typed text
+                        // instead. In Smart/Branches that lines up with the
+                        // use-name / create-branch row the user would have
+                        // wanted; in GitHub/Linear it preserves what they
+                        // typed rather than firing a wrong-source pick.
+                        const trimmed = value.trim()
+                        const stale =
+                          trimmed.length > 0 && (loading || debouncedQuery.trim() !== trimmed)
+                        if (stale) {
+                          event.preventDefault()
+                          onValueChange(trimmed)
+                          setOpen(false)
+                          return
+                        }
                         if (open && rows.length > 0) {
                           const row = rows.find((entry) => entry.value === commandValue)
                           if (row) {

--- a/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
+++ b/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
@@ -395,21 +395,12 @@ export default function SmartWorkspaceNameField({
 
   const rows = useMemo<RowEntry[]>(() => {
     const trimmed = value.trim()
-    // Why: source results (githubItems / branches / linearIssues) are driven
-    // by debouncedQuery, so they're stale until the user pauses typing for
-    // SEARCH_DEBOUNCE_MS. If we leave stale rows in the list, cmdk's built-in
-    // Enter handler picks the highlighted (wrong) source row when the user
-    // types fast and hits Enter. Suppress source rows while stale, so the
-    // popover shows only the typed-text row (use-name in Smart, create-branch
-    // in Branches), and Enter naturally commits the typed text.
-    const stale = trimmed.length > 0 && debouncedQuery.trim() !== trimmed
     // Why: on the Branches tab the generic "Use … as workspace name" row
     // reads as off-topic — the user is picking/creating a branch. Swap it
     // for a branch-creation row that's pinned above existing-branch results
     // (suppressed when an existing branch matches exactly so we don't offer
     // to "create" something that already exists).
-    const branchExactMatch =
-      !stale && mode === 'branches' && trimmed.length > 0 && branches.includes(trimmed)
+    const branchExactMatch = mode === 'branches' && trimmed.length > 0 && branches.includes(trimmed)
     // Why: the "Use … as workspace name" row only makes sense in Smart
     // mode, where the user might be typing a free-form name. On dedicated
     // source tabs (GitHub/Linear/Branches) it's off-topic — the user is
@@ -429,7 +420,7 @@ export default function SmartWorkspaceNameField({
     if (mode === 'text') {
       return nextRows
     }
-    if (!stale && (mode === 'smart' || mode === 'github')) {
+    if (mode === 'smart' || mode === 'github') {
       nextRows.push(
         ...githubItems.map((item) => ({
           kind: 'github' as const,
@@ -442,17 +433,15 @@ export default function SmartWorkspaceNameField({
       if (createBranchRow) {
         nextRows.push(createBranchRow)
       }
-      if (!stale) {
-        nextRows.push(
-          ...branches.map((refName) => ({
-            kind: 'branch' as const,
-            value: `branch-${refName}`,
-            refName
-          }))
-        )
-      }
+      nextRows.push(
+        ...branches.map((refName) => ({
+          kind: 'branch' as const,
+          value: `branch-${refName}`,
+          refName
+        }))
+      )
     }
-    if (!stale && (mode === 'smart' || mode === 'linear')) {
+    if (mode === 'smart' || mode === 'linear') {
       nextRows.push(
         ...linearIssues.map((issue) => ({
           kind: 'linear' as const,
@@ -462,15 +451,37 @@ export default function SmartWorkspaceNameField({
       )
     }
     return nextRows.slice(0, RESULT_LIMIT + 1)
-  }, [branches, debouncedQuery, githubItems, linearIssues, mode, value])
+  }, [branches, githubItems, linearIssues, mode, value])
+
+  // Why: source rows (GitHub/branches/Linear) are driven by debouncedQuery,
+  // so they're stale until the user pauses typing for SEARCH_DEBOUNCE_MS.
+  // We don't want to filter them out (causes flicker as results appear and
+  // disappear with each keystroke), but we do need to prevent cmdk's Enter
+  // handler from auto-selecting a stale source row. Two cases:
+  //   - Smart/Branches: a typed-text row (use-name / create-branch) exists
+  //     and is pinned at the top — force the highlight onto it so Enter
+  //     commits the typed text instead of a stale issue/PR/branch.
+  //   - GitHub/Linear: no typed-text fallback row, so clear the highlight
+  //     entirely; the input's Enter handler falls through to onPlainEnter.
+  const isQueryStale = value.trim().length > 0 && debouncedQuery.trim() !== value.trim()
 
   useEffect(() => {
-    if (rows.length > 0) {
-      setCommandValue((current) =>
-        rows.some((row) => row.value === current) ? current : rows[0].value
-      )
+    if (rows.length === 0) {
+      return
     }
-  }, [rows])
+    if (isQueryStale) {
+      const typedTextRow = rows.find(
+        (row) => row.kind === 'use-name' || row.kind === 'create-branch'
+      )
+      // No typed-text fallback in this mode (GitHub/Linear): clear the
+      // highlight so cmdk doesn't auto-select a stale source on Enter.
+      setCommandValue(typedTextRow ? typedTextRow.value : '')
+      return
+    }
+    setCommandValue((current) =>
+      rows.some((row) => row.value === current) ? current : rows[0].value
+    )
+  }, [isQueryStale, rows])
 
   const loading = githubLoading || branchesLoading || linearLoading
   const ActiveInputIcon = mode === 'text' ? CaseSensitive : loading ? LoaderCircle : Search
@@ -718,8 +729,13 @@ export default function SmartWorkspaceNameField({
                           if (row) {
                             event.preventDefault()
                             handleSelect(row)
+                            return
                           }
-                          return
+                          // No highlighted row (e.g., stale results in
+                          // GitHub/Linear modes where the highlight was
+                          // cleared to avoid auto-selecting a stale source).
+                          // Fall through to onPlainEnter so the keypress
+                          // doesn't feel inert.
                         }
                         onPlainEnter?.()
                       }

--- a/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
+++ b/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
@@ -395,12 +395,21 @@ export default function SmartWorkspaceNameField({
 
   const rows = useMemo<RowEntry[]>(() => {
     const trimmed = value.trim()
+    // Why: source results (githubItems / branches / linearIssues) are driven
+    // by debouncedQuery, so they're stale until the user pauses typing for
+    // SEARCH_DEBOUNCE_MS. If we leave stale rows in the list, cmdk's built-in
+    // Enter handler picks the highlighted (wrong) source row when the user
+    // types fast and hits Enter. Suppress source rows while stale, so the
+    // popover shows only the typed-text row (use-name in Smart, create-branch
+    // in Branches), and Enter naturally commits the typed text.
+    const stale = trimmed.length > 0 && debouncedQuery.trim() !== trimmed
     // Why: on the Branches tab the generic "Use … as workspace name" row
     // reads as off-topic — the user is picking/creating a branch. Swap it
     // for a branch-creation row that's pinned above existing-branch results
     // (suppressed when an existing branch matches exactly so we don't offer
     // to "create" something that already exists).
-    const branchExactMatch = mode === 'branches' && trimmed.length > 0 && branches.includes(trimmed)
+    const branchExactMatch =
+      !stale && mode === 'branches' && trimmed.length > 0 && branches.includes(trimmed)
     // Why: the "Use … as workspace name" row only makes sense in Smart
     // mode, where the user might be typing a free-form name. On dedicated
     // source tabs (GitHub/Linear/Branches) it's off-topic — the user is
@@ -420,7 +429,7 @@ export default function SmartWorkspaceNameField({
     if (mode === 'text') {
       return nextRows
     }
-    if (mode === 'smart' || mode === 'github') {
+    if (!stale && (mode === 'smart' || mode === 'github')) {
       nextRows.push(
         ...githubItems.map((item) => ({
           kind: 'github' as const,
@@ -433,15 +442,17 @@ export default function SmartWorkspaceNameField({
       if (createBranchRow) {
         nextRows.push(createBranchRow)
       }
-      nextRows.push(
-        ...branches.map((refName) => ({
-          kind: 'branch' as const,
-          value: `branch-${refName}`,
-          refName
-        }))
-      )
+      if (!stale) {
+        nextRows.push(
+          ...branches.map((refName) => ({
+            kind: 'branch' as const,
+            value: `branch-${refName}`,
+            refName
+          }))
+        )
+      }
     }
-    if (mode === 'smart' || mode === 'linear') {
+    if (!stale && (mode === 'smart' || mode === 'linear')) {
       nextRows.push(
         ...linearIssues.map((issue) => ({
           kind: 'linear' as const,
@@ -451,7 +462,7 @@ export default function SmartWorkspaceNameField({
       )
     }
     return nextRows.slice(0, RESULT_LIMIT + 1)
-  }, [branches, githubItems, linearIssues, mode, value])
+  }, [branches, debouncedQuery, githubItems, linearIssues, mode, value])
 
   useEffect(() => {
     if (rows.length > 0) {
@@ -702,26 +713,6 @@ export default function SmartWorkspaceNameField({
                         !event.ctrlKey &&
                         !event.shiftKey
                       ) {
-                        // Why: when the user types faster than the search
-                        // debounce, `rows`/`commandValue` still reflect the
-                        // previous query — pressing Enter would silently pick
-                        // a stale source row (e.g., a PR from the prior
-                        // letters). Treat results as stale while the search
-                        // is loading or the debounced query hasn't caught up
-                        // to the input value, and commit the typed text
-                        // instead. In Smart/Branches that lines up with the
-                        // use-name / create-branch row the user would have
-                        // wanted; in GitHub/Linear it preserves what they
-                        // typed rather than firing a wrong-source pick.
-                        const trimmed = value.trim()
-                        const stale =
-                          trimmed.length > 0 && (loading || debouncedQuery.trim() !== trimmed)
-                        if (stale) {
-                          event.preventDefault()
-                          onValueChange(trimmed)
-                          setOpen(false)
-                          return
-                        }
                         if (open && rows.length > 0) {
                           const row = rows.find((entry) => entry.value === commandValue)
                           if (row) {


### PR DESCRIPTION
## Summary

Polish pass on the unified Create Workspace composer. Throws away the `+`-button-plus-dialog approach from #1408 in favor of an inline "Create new branch …" row inside the existing autocomplete, and tightens up several other UX rough edges in the Smart name field.

### Changes

**Branch tab — create-new-branch row (replaces #1408 UX)**
- When on the Branch tab, the autocomplete now shows a **"Create new branch *name*"** row at the top whenever the query is non-empty.
- Suppressed when the query exactly matches an existing branch (no point offering to "create" something already there).
- Selection routes through the same path as a typed name — `baseBranch` stays unset so the new branch starts from the repo's default base.
- No more `+` button, no more "New branch" dialog. The `explicitName` plumbing on `launchFromBranch` from #1408 isn't needed because the unified composer already routes user-typed names through `name` / `baseBranch` correctly.

**Scoped autocomplete suggestions**
- The generic "Use *X* as workspace name" row only appears on the **Smart** tab. On GitHub / Linear / Branch tabs it was off-topic noise — those tabs are about picking (or, on Branches, creating) a specific source.
- Empty-state hints are now per-mode:
  - Smart: "Start typing to create a name or find a source."
  - GitHub: "Start typing to search GitHub PRs and issues."
  - Branch: "Start typing to find a branch or create a new one."
  - Linear: "Start typing to search Linear issues."

**Auto-derived name moves under Advanced**
- When a source (PR/issue/Linear/branch) is selected, the smart input shows a pill — there's no inline name to review.
- Surface the derived workspace name as a **Name** input inside the **Advanced** drawer, where it can be reviewed or overridden.
- When the user typed an explicit name (no source picked), the smart input *is* the name field — Advanced does not duplicate it.

**Tab navigation polish**
- Forward `Tab` from the Repo combobox now skips the Smart/GitHub/Branch/Linear/Name segmented control and lands directly in the search input.
- `Shift+Tab` from the input still focuses the active tab trigger, so the segmented control is reachable in reverse for keyboard users who want to switch modes.
- Implemented as an `onFocusCapture` interceptor on `TabsList` that distinguishes outside-entry (relatedTarget = Repo trigger → bounce to input) from the shift-tab case (relatedTarget = input → allow) and intra-list arrow-key moves (relatedTarget inside list → allow). This avoids fighting Radix's roving tabindex, which re-applies `tabindex=0` on every render.

**Linear status race fix**
- The composer can be the first Linear-aware surface to render in a session, before TaskPage/IntegrationsPane have called `checkLinearConnection`, leaving `linearStatus.connected = false` even when actually connected.
- Now triggers `checkLinearConnection()` on mount when `linearStatusChecked` is false, and gates the "Connect Linear in Settings…" hint on `linearStatusChecked` so the in-flight check doesn't briefly mislabel a connected user as disconnected.

### Testing

- `pnpm typecheck` ✓
- `pnpm lint` ✓ (6 pre-existing warnings unrelated to these files)
- Manual: tabbed through Repo → Input, shift-tabbed back to segmented control; verified create-branch row appears/disappears around exact-match query; verified Advanced shows Name only when a source is picked; verified Linear empty state.

Made with [Orca](https://github.com/stablyai/orca) 🐋
