### PR TITLE
fix(worktree): drop unsupported `-z` from `git worktree list --porcelain`

### DIFF
--- a/src/main/git/remove-worktree.test.ts
+++ b/src/main/git/remove-worktree.test.ts
@@ -87,7 +87,7 @@ describe('removeWorktree', () => {
 
   it('removes the worktree, prunes stale refs, and deletes its local branch', async () => {
     mockGitCommands({
-      'git worktree list --porcelain -z': {
+      'git worktree list --porcelain': {
         stdout: `worktree /repo
 HEAD abc123
 branch refs/heads/main
@@ -97,7 +97,7 @@ HEAD def456
 branch refs/heads/feature/test
 `
       },
-      'git worktree list --porcelain -z#2': {
+      'git worktree list --porcelain#2': {
         stdout: `worktree /repo
 HEAD abc123
 branch refs/heads/main
@@ -121,7 +121,7 @@ branch refs/heads/main
 
   it('skips branch deletion when another worktree still points at the branch', async () => {
     mockGitCommands({
-      'git worktree list --porcelain -z': {
+      'git worktree list --porcelain': {
         stdout: `worktree /repo
 HEAD abc123
 branch refs/heads/main
@@ -135,7 +135,7 @@ HEAD def456
 branch refs/heads/feature/test
 `
       },
-      'git worktree list --porcelain -z#2': {
+      'git worktree list --porcelain#2': {
         stdout: `worktree /repo
 HEAD abc123
 branch refs/heads/main
@@ -154,7 +154,7 @@ branch refs/heads/feature/test
       expect.arrayContaining([
         'git worktree remove /repo-feature',
         'git worktree prune',
-        'git worktree list --porcelain -z'
+        'git worktree list --porcelain'
       ])
     )
     expect(calls).not.toContain('git branch -D feature/test')
@@ -163,7 +163,7 @@ branch refs/heads/feature/test
 
   it('deletes the branch after prune removes stale sibling worktree entries', async () => {
     mockGitCommands({
-      'git worktree list --porcelain -z': {
+      'git worktree list --porcelain': {
         stdout: `worktree /repo
 HEAD abc123
 branch refs/heads/main
@@ -178,7 +178,7 @@ branch refs/heads/feature/test
 prunable gitdir file points to non-existent location
 `
       },
-      'git worktree list --porcelain -z#2': {
+      'git worktree list --porcelain#2': {
         stdout: `worktree /repo
 HEAD abc123
 branch refs/heads/main
@@ -201,7 +201,7 @@ branch refs/heads/main
 
   it('passes --force before the worktree path when forced removal is requested', async () => {
     mockGitCommands({
-      'git worktree list --porcelain -z': {
+      'git worktree list --porcelain': {
         stdout: `worktree /repo
 HEAD abc123
 branch refs/heads/main
@@ -211,7 +211,7 @@ HEAD def456
 branch refs/heads/feature/test
 `
       },
-      'git worktree list --porcelain -z#2': {
+      'git worktree list --porcelain#2': {
         stdout: `worktree /repo
 HEAD abc123
 branch refs/heads/main
@@ -226,7 +226,7 @@ branch refs/heads/main
 
   it('matches Windows worktree paths before deleting the branch', async () => {
     mockGitCommands({
-      'git worktree list --porcelain -z': {
+      'git worktree list --porcelain': {
         stdout: `worktree C:/repo
 HEAD abc123
 branch refs/heads/main
@@ -236,7 +236,7 @@ HEAD def456
 branch refs/heads/feature/test
 `
       },
-      'git worktree list --porcelain -z#2': {
+      'git worktree list --porcelain#2': {
         stdout: `worktree C:/repo
 HEAD abc123
 branch refs/heads/main
@@ -259,7 +259,7 @@ branch refs/heads/main
   it('keeps removal successful when branch cleanup fails', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     mockGitCommands({
-      'git worktree list --porcelain -z': {
+      'git worktree list --porcelain': {
         stdout: `worktree /repo
 HEAD abc123
 branch refs/heads/main
@@ -269,7 +269,7 @@ HEAD def456
 branch refs/heads/feature/test
 `
       },
-      'git worktree list --porcelain -z#2': {
+      'git worktree list --porcelain#2': {
         stdout: `worktree /repo
 HEAD abc123
 branch refs/heads/main
@@ -337,14 +337,14 @@ describe('listWorktrees', () => {
     // Why: the non-sparse main worktree gets an fs probe of its sparse config
     // file; the linked worktree short-circuits on the parsed `sparse` token and
     // does not. Only one git subprocess runs regardless of worktree count.
-    expect(getGitCalls()).toEqual(['git worktree list --porcelain -z'])
+    expect(getGitCalls()).toEqual(['git worktree list --porcelain'])
     expect(statMock).toHaveBeenCalledTimes(1)
     expect(translateWslOutputPathsMock).toHaveBeenCalledTimes(2)
   })
 
   it('detects sparse checkout after translating paths when porcelain omits sparse token', async () => {
     gitExecFileAsyncMock.mockImplementation((args: string[]) => {
-      if (args.join(' ') === 'worktree list --porcelain -z') {
+      if (args.join(' ') === 'worktree list --porcelain') {
         return {
           stdout:
             'worktree /home/me/repo\0HEAD abc123\0branch refs/heads/main\0\0' +
@@ -394,7 +394,7 @@ describe('listWorktrees', () => {
     // Why: the detection path must not spawn a git subprocess per worktree —
     // the perf regression in #1131 came from `git sparse-checkout list` firing
     // on every poll.
-    expect(getGitCalls()).toEqual(['git worktree list --porcelain -z'])
+    expect(getGitCalls()).toEqual(['git worktree list --porcelain'])
   })
 })
 
@@ -428,7 +428,7 @@ describe('addSparseWorktree', () => {
       'git sparse-checkout set -- packages/web': {
         error: new Error('sparse setup failed')
       },
-      'git worktree list --porcelain -z': {
+      'git worktree list --porcelain': {
         stdout: `worktree /repo
 HEAD abc123
 branch refs/heads/main
@@ -438,7 +438,7 @@ HEAD def456
 branch refs/heads/feature/test
 `
       },
-      'git worktree list --porcelain -z#2': {
+      'git worktree list --porcelain#2': {
         stdout: `worktree /repo
 HEAD abc123
 branch refs/heads/main

--- a/src/main/git/remove-worktree.test.ts
+++ b/src/main/git/remove-worktree.test.ts
@@ -306,16 +306,15 @@ describe('listWorktrees', () => {
     resolveGitDirMock.mockImplementation(async (worktreePath: string) => `${worktreePath}/.git`)
   })
 
-  it('translates parsed path fields from NUL-delimited porcelain output', async () => {
+  it('translates parsed path fields from line-block porcelain output', async () => {
     gitExecFileAsyncMock.mockResolvedValueOnce({
       stdout:
-        'worktree /home/me/repo\0HEAD abc123\0branch refs/heads/main\0\0' +
-        'worktree /home/me/repo-feature\0HEAD def456\0branch refs/heads/feature/test\0sparse\0\0'
+        'worktree /home/me/repo\nHEAD abc123\nbranch refs/heads/main\n\n' +
+        'worktree /home/me/repo-feature\nHEAD def456\nbranch refs/heads/feature/test\nsparse\n\n'
     })
-    translateWslOutputPathsMock.mockImplementation((output: string) => {
-      expect(output).not.toContain('\0')
-      return output.replace('/home/me/', '\\\\wsl.localhost\\Ubuntu\\home\\me\\')
-    })
+    translateWslOutputPathsMock.mockImplementation((output: string) =>
+      output.replace('/home/me/', '\\\\wsl.localhost\\Ubuntu\\home\\me\\')
+    )
 
     await expect(listWorktrees('\\\\wsl.localhost\\Ubuntu\\home\\me\\repo')).resolves.toEqual([
       {
@@ -347,17 +346,16 @@ describe('listWorktrees', () => {
       if (args.join(' ') === 'worktree list --porcelain') {
         return {
           stdout:
-            'worktree /home/me/repo\0HEAD abc123\0branch refs/heads/main\0\0' +
-            'worktree /home/me/repo-feature\0HEAD def456\0branch refs/heads/feature/test\0\0',
+            'worktree /home/me/repo\nHEAD abc123\nbranch refs/heads/main\n\n' +
+            'worktree /home/me/repo-feature\nHEAD def456\nbranch refs/heads/feature/test\n\n',
           stderr: ''
         }
       }
       throw new Error(`Unexpected git call: ${args.join(' ')}`)
     })
-    translateWslOutputPathsMock.mockImplementation((output: string) => {
-      expect(output).not.toContain('\0')
-      return output.replace('/home/me/', '\\\\wsl.localhost\\Ubuntu\\home\\me\\')
-    })
+    translateWslOutputPathsMock.mockImplementation((output: string) =>
+      output.replace('/home/me/', '\\\\wsl.localhost\\Ubuntu\\home\\me\\')
+    )
     const featureWorktreePath = '\\\\wsl.localhost\\Ubuntu\\home\\me\\repo-feature'
     resolveGitDirMock.mockImplementation(async (worktreePath: string) =>
       worktreePath === featureWorktreePath

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -88,11 +88,14 @@ export function parseWorktreeList(output: string): GitWorktreeInfo[] {
  */
 export async function listWorktrees(repoPath: string): Promise<GitWorktreeInfo[]> {
   try {
-    const { stdout } = await gitExecFileAsync(['worktree', 'list', '--porcelain', '-z'], {
+    // Why: `-z` on `git worktree list --porcelain` requires Git ≥ 2.36 (April
+    // 2022). On older Git the subprocess errors out, the catch below returns
+    // [], and every create flow throws "Worktree created but not found in
+    // listing" (issue #1453). The parser handles both line-block and
+    // NUL-delimited blocks, so omitting `-z` is safe.
+    const { stdout } = await gitExecFileAsync(['worktree', 'list', '--porcelain'], {
       cwd: repoPath
     })
-    // Why: WSL path translation is line-oriented, but `-z` porcelain output is
-    // NUL-delimited. Parse first so only complete path fields are translated.
     const worktrees = parseWorktreeList(stdout).map((worktree) => {
       const translatedPath = translateWorktreePath(worktree.path, repoPath)
       return translatedPath === worktree.path ? worktree : { ...worktree, path: translatedPath }
@@ -106,7 +109,11 @@ export async function listWorktrees(repoPath: string): Promise<GitWorktreeInfo[]
         return isSparse ? { ...worktree, isSparse } : worktree
       })
     )
-  } catch {
+  } catch (err) {
+    // Why: a silent catch turned issue #1453's underlying
+    // "git: unknown switch -z" into the opaque "not found in listing" toast.
+    // Surface the cause so future regressions show up immediately.
+    console.warn('[git/worktree] listWorktrees failed:', err)
     return []
   }
 }

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -35,12 +35,10 @@ function looksLikeWindowsPath(pathValue: string): boolean {
  */
 export function parseWorktreeList(output: string): GitWorktreeInfo[] {
   const worktrees: GitWorktreeInfo[] = []
-  const blocks = output.includes('\0')
-    ? parseNullDelimitedWorktreeBlocks(output)
-    : output
-        .trim()
-        .split(/\r?\n\r?\n/)
-        .map((block) => block.trim().split(/\r?\n/))
+  const blocks = output
+    .trim()
+    .split(/\r?\n\r?\n/)
+    .map((block) => block.trim().split(/\r?\n/))
 
   for (const lines of blocks) {
     if (lines.length === 0) {
@@ -88,11 +86,9 @@ export function parseWorktreeList(output: string): GitWorktreeInfo[] {
  */
 export async function listWorktrees(repoPath: string): Promise<GitWorktreeInfo[]> {
   try {
-    // Why: `-z` on `git worktree list --porcelain` requires Git ≥ 2.36 (April
-    // 2022). On older Git the subprocess errors out, the catch below returns
-    // [], and every create flow throws "Worktree created but not found in
-    // listing" (issue #1453). The parser handles both line-block and
-    // NUL-delimited blocks, so omitting `-z` is safe.
+    // Why: do not pass `-z` here. `-z` requires Git ≥ 2.36; older Git rejects
+    // it, listWorktrees returns [], and every create flow throws "Worktree
+    // created but not found in listing" (issue #1453).
     const { stdout } = await gitExecFileAsync(['worktree', 'list', '--porcelain'], {
       cwd: repoPath
     })
@@ -278,28 +274,6 @@ export async function removeWorktree(
       error
     )
   }
-}
-
-function parseNullDelimitedWorktreeBlocks(output: string): string[][] {
-  const blocks: string[][] = []
-  let current: string[] = []
-
-  for (const token of output.split('\0')) {
-    if (!token) {
-      if (current.length > 0) {
-        blocks.push(current)
-        current = []
-      }
-      continue
-    }
-    current.push(token)
-  }
-
-  if (current.length > 0) {
-    blocks.push(current)
-  }
-
-  return blocks
 }
 
 function translateWorktreePath(worktreePath: string, repoPath: string): string {


### PR DESCRIPTION
## Summary

Fixes #1453.

`git worktree list --porcelain -z` requires Git ≥ 2.36 (April 2022). On older Git the subprocess fails with `unknown switch \`z'`, `listWorktrees`' bare `catch {}` swallowed the error, and every create flow surfaced the opaque "Worktree created but not found in listing" toast. The sidebar's "No worktrees found" symptom (`#1393`) falls out of the same broken listing — every poll returned `[]`.

PR `#1316` introduced the `-z` flag in 1.3.33; both reports target releases that contain it (1.3.33 Ubuntu / 1.3.34 macOS). `#1316`'s stated goal was a sparse-checkout perf fix; `-z` was added as a side change without an explicit rationale in the PR body — likely defensive against newline-in-path edge cases. Removing it restores the pre-`#1316` behavior on the listing call.

### Changes

- **Drop `-z`** from the `worktree list --porcelain` call in `listWorktrees`.
- **Log the catch** instead of swallowing it so future regressions in this path don't go silent.
- **Delete the now-dead NUL-delimited parser branch** (`parseNullDelimitedWorktreeBlocks` and the `output.includes('\0')` branch in `parseWorktreeList`). With `-z` gone, real git never emits NUL output here. Two test fixtures that fed NUL input were updated to line-block format (what real git emits).

### What still works after this revert

The per-field WSL path translation introduced in `#1316` (`translateWorktreePath`) is unchanged and still runs after parsing. Sparse-checkout detection via `fs.stat` (the actual fix `#1316` shipped) is unchanged. Only the input format on the listing call reverts to line-blocks.

## Test plan

- [x] `pnpm exec vitest run src/main/git/remove-worktree.test.ts src/main/git/worktree.test.ts` — 26/26 pass
- [x] `pnpm typecheck:node` — clean
- [x] **End-to-end Electron repro:** built a git shim that delegates to real git but rejects `worktree list --porcelain -z` with `unknown switch \`z'` (exit 129), launched dev with `PATH=shim:$PATH`, and ran `createWorktree` via IPC.
  - Before fix → exact error: `Error invoking remote method 'worktrees:create': Error: Worktree created but not found in listing`. Worktree was created on disk but listing returned `[]`.
  - After fix → `worktrees.listAll()` returned 136 worktrees and `createWorktree` succeeded.
- [ ] Reviewer sanity-check on Linux/WSL — covered by existing fixtures (`worktree.test.ts`, `remove-worktree.test.ts`), but a manual smoke from someone on WSL confirming worktree paths still translate correctly would be reassuring.