### PR TITLE
fix(pi): prefill linked issue URL via env var to bypass paste-readiness race

### DIFF
--- a/src/main/pi/titlebar-extension-service.test.ts
+++ b/src/main/pi/titlebar-extension-service.test.ts
@@ -71,7 +71,7 @@ describe('PiTitlebarExtensionService', () => {
     expect(env.PI_CODING_AGENT_DIR).toBe(join(userDataDir, 'pi-agent-overlays', 'pty-1'))
     // Orca's titlebar extension is added alongside user extensions, not replacing them.
     const overlayExtensions = readdirSync(join(env.PI_CODING_AGENT_DIR!, 'extensions')).sort()
-    expect(overlayExtensions).toEqual(['orca-titlebar-spinner.ts', 'user-ext'])
+    expect(overlayExtensions).toEqual(['orca-prefill.ts', 'orca-titlebar-spinner.ts', 'user-ext'])
     // User's top-level resources are reachable via the overlay.
     expect(existsSync(join(env.PI_CODING_AGENT_DIR!, 'skills', 'my-skill', 'SKILL.md'))).toBe(true)
     expect(existsSync(join(env.PI_CODING_AGENT_DIR!, 'auth.json'))).toBe(true)

--- a/src/main/pi/titlebar-extension-service.ts
+++ b/src/main/pi/titlebar-extension-service.ts
@@ -15,9 +15,43 @@ import { basename, join, relative, resolve, sep } from 'path'
 import { app } from 'electron'
 
 const ORCA_PI_EXTENSION_FILE = 'orca-titlebar-spinner.ts'
+const ORCA_PI_PREFILL_EXTENSION_FILE = 'orca-prefill.ts'
 const PI_AGENT_DIR_NAME = '.pi'
 const PI_AGENT_SUBDIR = 'agent'
 const PI_OVERLAY_DIR_NAME = 'pi-agent-overlays'
+
+// Why: env-var name read by the prefill extension. Mirrors Claude's
+// `--prefill <text>` semantics for pi — the editor mounts with the text
+// already in its input box but unsubmitted, so the user can review/edit
+// before sending. Used by the new-workspace draft-launch flow to drop a
+// linked GitHub/Linear issue URL into pi without racing pi's lengthy
+// startup output (banner + skills + extensions) against the bracketed-
+// paste readiness detector.
+export const ORCA_PI_PREFILL_ENV_VAR = 'ORCA_PI_PREFILL'
+
+// Why: pi exposes `pi.ui.setEditorText(text)` from inside an extension's
+// session_start handler — that's the equivalent of Claude's `--prefill`.
+// We can't use a CLI flag (pi has none) and bracketed-paste-after-ready
+// races against pi's startup output, so we ship a tiny extension that
+// reads ORCA_PI_PREFILL on session_start and types it into the editor.
+// The env var is consumed (deleted from process.env) so /new in the same
+// session doesn't re-prefill.
+function getPiPrefillExtensionSource(): string {
+  return [
+    'export default function (pi) {',
+    "  pi.on('session_start', async (event, ctx) => {",
+    `    const prefill = process.env.${ORCA_PI_PREFILL_ENV_VAR}`,
+    '    if (!prefill) return',
+    `    delete process.env.${ORCA_PI_PREFILL_ENV_VAR}`,
+    "    if (event.reason !== 'startup') return",
+    '    try {',
+    '      ctx.ui.setEditorText(prefill)',
+    '    } catch {}',
+    '  })',
+    '}',
+    ''
+  ].join('\n')
+}
 
 function getPiTitlebarExtensionSource(): string {
   return [
@@ -272,6 +306,10 @@ export class PiTitlebarExtensionService {
       // instead of replacing that directory, otherwise Orca terminals would
       // silently disable the user's Pi customization inside Orca only.
       writeFileSync(join(extensionsDir, ORCA_PI_EXTENSION_FILE), getPiTitlebarExtensionSource())
+      writeFileSync(
+        join(extensionsDir, ORCA_PI_PREFILL_EXTENSION_FILE),
+        getPiPrefillExtensionSource()
+      )
     } catch {
       // Why: overlay creation is best-effort — permission errors (EPERM/EACCES)
       // on Windows can occur when the userData directory is restricted or when

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -383,10 +383,12 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       return
     }
     let cancelled = false
-    void (window.api.gh.repoSlug({ repoPath: selectedRepoPath }) as Promise<{
-      owner: string
-      repo: string
-    } | null>)
+    void (
+      window.api.gh.repoSlug({ repoPath: selectedRepoPath }) as Promise<{
+        owner: string
+        repo: string
+      } | null>
+    )
       .then((result) => {
         if (cancelled) {
           return
@@ -1509,7 +1511,8 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
             agent: draftLaunchPlan.agent,
             launchCommand: draftLaunchPlan.launchCommand,
             expectedProcess: draftLaunchPlan.expectedProcess,
-            followupPrompt: null
+            followupPrompt: null,
+            ...(draftLaunchPlan.env ? { env: draftLaunchPlan.env } : {})
           }
         } else if (agent !== null) {
           startupPlan = buildAgentStartupPlan({
@@ -1542,6 +1545,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
             ? {
                 startup: {
                   command: startupPlan.launchCommand,
+                  ...(startupPlan.env ? { env: startupPlan.env } : {}),
                   ...(quickTelemetry ? { telemetry: quickTelemetry } : {})
                 }
               }

--- a/src/renderer/src/lib/launch-work-item-direct.ts
+++ b/src/renderer/src/lib/launch-work-item-direct.ts
@@ -118,7 +118,9 @@ function buildStartupOpts(
   agent: TuiAgent | null,
   plan: ReturnType<typeof buildAgentStartupPlan>,
   launchSource: LaunchSource
-): { startup?: { command: string; telemetry?: AgentStartedTelemetry } } {
+): {
+  startup?: { command: string; env?: Record<string, string>; telemetry?: AgentStartedTelemetry }
+} {
   if (!plan) {
     return {}
   }
@@ -127,7 +129,11 @@ function buildStartupOpts(
       ? null
       : { agent_kind: tuiAgentToAgentKind(agent), launch_source: launchSource, request_kind: 'new' }
   return {
-    startup: { command: plan.launchCommand, ...(telemetry ? { telemetry } : {}) }
+    startup: {
+      command: plan.launchCommand,
+      ...(plan.env ? { env: plan.env } : {}),
+      ...(telemetry ? { telemetry } : {})
+    }
   }
 }
 
@@ -264,7 +270,8 @@ export async function launchWorkItemDirect(args: LaunchWorkItemDirectArgs): Prom
         agent: draftLaunchPlan.agent,
         launchCommand: draftLaunchPlan.launchCommand,
         expectedProcess: draftLaunchPlan.expectedProcess,
-        followupPrompt: null
+        followupPrompt: null,
+        ...(draftLaunchPlan.env ? { env: draftLaunchPlan.env } : {})
       }
       draftLaunchedNatively = true
     } else if (effectiveAgent !== null) {

--- a/src/renderer/src/lib/tui-agent-startup.test.ts
+++ b/src/renderer/src/lib/tui-agent-startup.test.ts
@@ -173,6 +173,27 @@ describe('buildAgentDraftLaunchPlan', () => {
     ).toBeNull()
   })
 
+  it('uses ORCA_PI_PREFILL env var for pi (no CLI flag exists)', () => {
+    // Why: pi has no `--prefill` flag, and bracketed-paste-after-ready races
+    // against pi's lengthy startup output. The Orca overlay installs an
+    // `orca-prefill` extension that reads ORCA_PI_PREFILL on session_start
+    // and seeds the editor. Plan plumbs the env var without polluting the
+    // shell command (no `FOO='...' pi` prefix typed into the terminal).
+    expect(
+      buildAgentDraftLaunchPlan({
+        agent: 'pi',
+        draft: 'https://github.com/acme/repo/issues/42',
+        cmdOverrides: {},
+        platform: 'darwin'
+      })
+    ).toEqual({
+      agent: 'pi',
+      launchCommand: 'pi',
+      expectedProcess: 'pi',
+      env: { ORCA_PI_PREFILL: 'https://github.com/acme/repo/issues/42' }
+    })
+  })
+
   it('returns null for an empty draft so callers fall back cleanly', () => {
     expect(
       buildAgentDraftLaunchPlan({

--- a/src/renderer/src/lib/tui-agent-startup.ts
+++ b/src/renderer/src/lib/tui-agent-startup.ts
@@ -15,6 +15,12 @@ export type AgentStartupPlan = {
    * `followupPrompt` so the call site can choose: type-and-submit (followup)
    * or type-and-leave-pending (draft). */
   draftPrompt?: string | null
+  /** Why: env vars to apply at PTY spawn time. Currently used to deliver
+   * pi's `ORCA_PI_PREFILL` so the overlay's `orca-prefill` extension
+   * picks it up on session_start. Plumbed into `startup.env` by the
+   * activation site, NOT into the shell command, so the value isn't
+   * visibly prefixed onto the terminal. */
+  env?: Record<string, string>
 }
 
 function quoteStartupArg(value: string, platform: NodeJS.Platform): string {
@@ -103,6 +109,12 @@ export type AgentDraftLaunchPlan = {
   agent: TuiAgent
   launchCommand: string
   expectedProcess: string
+  /** Why: env-var-based prefill (currently pi via the overlay-installed
+   * `orca-prefill` extension) ships the draft text in the PTY-spawn
+   * environment instead of via a CLI flag. Callers MUST plumb this into
+   * the queued `startup.env` so it reaches the shell that launches the
+   * agent. Empty/undefined when the agent uses a CLI flag (Claude). */
+  env?: Record<string, string>
 }
 
 /**
@@ -124,20 +136,31 @@ export function buildAgentDraftLaunchPlan(args: {
 }): AgentDraftLaunchPlan | null {
   const { agent, draft, cmdOverrides, platform } = args
   const config = TUI_AGENT_CONFIG[agent]
-  if (!config.draftPromptFlag) {
-    return null
-  }
   const trimmed = draft.trim()
   if (!trimmed) {
     return null
   }
   const baseCommand = cmdOverrides[agent] ?? config.launchCmd
-  const quoted = quoteStartupArg(trimmed, platform)
-  return {
-    agent,
-    launchCommand: `${baseCommand} ${config.draftPromptFlag} ${quoted}`,
-    expectedProcess: config.expectedProcess
+  if (config.draftPromptFlag) {
+    const quoted = quoteStartupArg(trimmed, platform)
+    return {
+      agent,
+      launchCommand: `${baseCommand} ${config.draftPromptFlag} ${quoted}`,
+      expectedProcess: config.expectedProcess
+    }
   }
+  if (config.draftPromptEnvVar) {
+    // Why: the env var is set on the PTY-spawn env (not embedded in the
+    // shell command) so the value never has to be shell-escaped and the
+    // user doesn't see a `FOO='...'` prefix typed into their terminal.
+    return {
+      agent,
+      launchCommand: baseCommand,
+      expectedProcess: config.expectedProcess,
+      env: { [config.draftPromptEnvVar]: trimmed }
+    }
+  }
+  return null
 }
 
 export { isShellProcess } from '../../../shared/agent-detection'

--- a/src/shared/tui-agent-config.ts
+++ b/src/shared/tui-agent-config.ts
@@ -21,6 +21,16 @@ export type TuiAgentConfig = {
    * Agents without native support fall through to the paste-after-ready
    * code path in agent-paste-draft.ts. */
   draftPromptFlag?: string
+  /** Why: agents that don't expose a `--prefill <text>`-style CLI flag but
+   * CAN read an env var on startup to seed their input box without
+   * submitting. Today only pi uses this (via Orca's overlay-installed
+   * `orca-prefill` extension reading `ORCA_PI_PREFILL`). Equivalent in
+   * effect to `draftPromptFlag`: avoids the bracketed-paste-after-ready
+   * race when the agent's startup output is long (pi prints banner,
+   * skills, and extensions for several seconds, which keeps the
+   * readiness quiet-timer resetting). When set, the draft-launch plan
+   * passes the text via this env var instead of pasting after ready. */
+  draftPromptEnvVar?: string
   /** Why: agents that gate first-launch behind a "Do you trust this
    * folder?" menu (Cursor-Agent, GitHub Copilot CLI) consume the bracketed
    * paste as menu input. Pre-write the same trust artifact the agent writes
@@ -70,7 +80,15 @@ export const TUI_AGENT_CONFIG: Record<TuiAgent, TuiAgentConfig> = {
     detectCmd: 'pi',
     launchCmd: 'pi',
     expectedProcess: 'pi',
-    promptInjectionMode: 'argv'
+    promptInjectionMode: 'argv',
+    // Why: pi has no `--prefill` flag, and bracketed-paste-after-ready
+    // races against its multi-second startup output (banner + skills +
+    // extensions list) so the paste frequently never lands. Orca's
+    // overlay installs an `orca-prefill` pi extension (see
+    // src/main/pi/titlebar-extension-service.ts) that reads this env var
+    // on session_start and calls `pi.ui.setEditorText(text)`. Same
+    // user-visible behavior as `claude --prefill <text>`.
+    draftPromptEnvVar: 'ORCA_PI_PREFILL'
   },
   gemini: {
     detectCmd: 'gemini',


### PR DESCRIPTION
## Problem

In the new-workspace dialog, picking a GH issue in the smart input and selecting **pi** as the agent should land the issue URL in pi's input box as an editable draft (matching Claude/Codex behavior). It didn't — the input came up empty.

## Root cause

Pi has no `--prefill` flag, so the draft flow falls back to bracketed-paste-after-ready (`agent-paste-draft.ts`):

1. Wait for `\x1b[?2004h` (DECSET 2004) on the PTY
2. Wait for `BRACKETED_PASTE_QUIET_MS` (1500ms) of stream silence
3. Send `\x1b[200~<text>\x1b[201~`

Pi emits `?2004h` early but then prints a multi-second startup banner (Skills + Prompts + Extensions + Skill conflicts list — 5+ seconds of continuous output). The quiet-timer keeps resetting until the 8s hard budget expires, and the paste is dropped. Claude sidesteps this with `--prefill`; codex's startup is short enough to hit the quiet window.

## Fix

Mirror Claude's `--prefill` semantics for pi using pi's extension API (`pi.ui.setEditorText`):

- **`src/main/pi/titlebar-extension-service.ts`** — overlay now writes a second tiny pi extension (`orca-prefill.ts`) alongside the existing titlebar spinner. On `session_start` it reads `ORCA_PI_PREFILL` from env, calls `pi.ui.setEditorText(text)`, and deletes the env var so subsequent `/new` sessions don't re-prefill.
- **`src/shared/tui-agent-config.ts`** — new `draftPromptEnvVar` field on `TuiAgentConfig`; pi sets it to `ORCA_PI_PREFILL`.
- **`src/renderer/src/lib/tui-agent-startup.ts`** — `buildAgentDraftLaunchPlan` now returns `{ launchCommand: 'pi', env: { ORCA_PI_PREFILL: <text> } }` for env-var agents. `AgentStartupPlan` carries `env?` through.
- **`useComposerState.submitQuick`** + **`launch-work-item-direct.ts`** — plumb `plan.env` into the queued `startup.env`, which already flows to `pty:spawn` env via `pty-connection.ts`.

The launched shell command stays a clean `pi` (no `FOO='...' pi` prefix typed into the terminal), and the readiness race is sidestepped entirely.

## Test plan

- ✅ `tui-agent-startup.test.ts` — added a case asserting pi returns the env-var-based plan
- ✅ `titlebar-extension-service.test.ts` — overlay now mirrors both `orca-prefill.ts` and `orca-titlebar-spinner.ts`
- ✅ `npm run typecheck` clean
- Manual: workspace create → smart-input pick a GH issue → agent: pi → URL appears in pi's input box, unsubmitted, ready to edit/send

## Cross-platform

Env vars are passed via `pty:spawn` (`args.env`), so this works identically on macOS, Linux, and Windows — no shell-syntax differences.

Made with [Orca](https://github.com/stablyai/orca) 🐋
