### PR TITLE
chore(mobile): bump to v0.0.4 (build 5)

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Orca",
     "slug": "orca-mobile",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",
@@ -16,7 +16,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.stably.orca.mobile",
-      "buildNumber": "4",
+      "buildNumber": "5",
       "infoPlist": {
         "NSLocalNetworkUsageDescription": "Orca connects to the desktop app on your local network.",
         "NSAppTransportSecurity": {


### PR DESCRIPTION
Version bump for the v0.0.4 mobile release covering everything that landed in #1481 (shared RpcClient per host, terminal-fit fixes, surfaced failed connection, faster cold-start, etc).

After merging, tag `mobile-v0.0.4` on main to trigger the GitHub APK release workflow. iOS TestFlight upload is independent.

Made with [Orca](https://github.com/stablyai/orca) 🐋
