### PR TITLE
fix(updater): add diagnostic logging for prerelease feed resolution

### DIFF
--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -284,17 +284,20 @@ async function pinPrereleaseFeed(): Promise<void> {
   // back to the default /releases/latest/download/ URL. In the "no newer"
   // case that feed will report the latest stable and compareVersions in the
   // 'update-available' handler will correctly mark it as not-available.
-  const newerTag = await fetchNewerReleaseTag(app.getVersion())
+  const currentVersion = app.getVersion()
+  const newerTag = await fetchNewerReleaseTag(currentVersion)
+  // Why: console.info goes to stdout and is captured by Console.app on macOS
+  // and by --enable-logging elsewhere. This is the only window we have into
+  // the updater on a user's machine when something goes wrong (issue: RC user
+  // not offered newer stable). Cheap to keep, invaluable when triaging.
   if (newerTag) {
-    autoUpdater.setFeedURL({
-      provider: 'generic',
-      url: getReleaseDownloadUrl(newerTag)
-    })
+    const url = getReleaseDownloadUrl(newerTag)
+    console.info(`[updater] prerelease feed pinned: current=${currentVersion} → ${url}`)
+    autoUpdater.setFeedURL({ provider: 'generic', url })
   } else {
-    autoUpdater.setFeedURL({
-      provider: 'generic',
-      url: 'https://github.com/stablyai/orca/releases/latest/download'
-    })
+    const url = 'https://github.com/stablyai/orca/releases/latest/download'
+    console.info(`[updater] prerelease feed fallback: current=${currentVersion} → ${url}`)
+    autoUpdater.setFeedURL({ provider: 'generic', url })
   }
 }
 
@@ -508,6 +511,19 @@ export function setupAutoUpdater(
 
   autoUpdater.autoDownload = false
   autoUpdater.autoInstallOnAppQuit = true
+
+  // Why: the only on-machine window we have into electron-updater. Without
+  // this, an unexpected `update-not-available` (e.g. RC user not offered
+  // newer stable) is invisible — we can't tell whether the manifest fetch
+  // got the wrong version, the request failed, or a stale in-flight check
+  // was deduped. Logs go to main-process stdout, captured on macOS by
+  // Console.app under the app bundle, and on Win/Linux by --enable-logging.
+  autoUpdater.logger = {
+    info: (m: unknown) => console.info('[autoUpdater]', m),
+    warn: (m: unknown) => console.warn('[autoUpdater]', m),
+    error: (m: unknown) => console.error('[autoUpdater]', m),
+    debug: (m: unknown) => console.debug('[autoUpdater]', m)
+  } as never
 
   // Why: no Windows Authenticode certificate exists for this project.
   // electron-builder embeds the code-signing publisherName into the app's


### PR DESCRIPTION
## Why

A user on `v1.3.35-rc.7` reported that "Check for Updates" says **"You're on the latest version"** even though stable `v1.3.35` is published.

Static analysis says this should work:
- The fix from #1104 (`fetchNewerReleaseTag` / `pinPrereleaseFeed`) is in rc.7.
- Running the atom-feed resolver against the live feed correctly returns `v1.3.35` for current `1.3.35-rc.7`.
- The unit tests pass; `latest-mac.yml` at `/releases/download/v1.3.35/` is well-formed.
- semver: `gt('1.3.35', '1.3.35-rc.7') === true`, so `update-available` should fire.

But the user is hitting it. We have **zero on-machine visibility** into the updater — `autoUpdater.logger` is never wired up, and `pinPrereleaseFeed` doesn't log the tag it picked or the URL it pinned. We can't tell whether the atom-feed resolver returned the wrong tag, the manifest fetch got something unexpected, or a stale in-flight check was deduped.

## What

No behavior change. Just visibility:

1. **Wire `autoUpdater.logger` to console** so electron-updater's per-step output (channel file URL, fetched version, dedup decisions) lands in main-process stdout — captured by Console.app on macOS and `--enable-logging` elsewhere.
2. **Log resolved tag + pinned URL in `pinPrereleaseFeed`** in one line, so the next failure shows immediately whether the resolver picked the expected release, fell back to `/releases/latest/download`, or wasn't called at all.

## Why no speculative fix

I spent significant time tracing the code and couldn't find the bug from static analysis. Adding a "defensive retry" or behavior change without knowing the actual failure mode risks masking a real bug. With logs, the next occurrence is diagnosable in seconds — then we fix the actual root cause.

## Test plan

- `pnpm vitest run src/main/updater` → 74 tests pass, log lines visible in test output.
- `pnpm typecheck` → clean.
- New log lines visible in test output:
  ```
  [updater] prerelease feed pinned: current=1.3.19-rc.6 → https://github.com/stablyai/orca/releases/download/v1.3.19
  [updater] prerelease feed fallback: current=1.3.19-rc.6 → https://github.com/stablyai/orca/releases/latest/download
  ```

Made with [Orca](https://github.com/stablyai/orca) 🐋
