### PR TITLE
Mobile: App Store v0.0.4 prep + connection-stability fixes

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -16,7 +16,7 @@
     "ios": {
       "supportsTablet": false,
       "bundleIdentifier": "com.stably.orca.mobile",
-      "buildNumber": "5",
+      "buildNumber": "6",
       "infoPlist": {
         "NSLocalNetworkUsageDescription": "Orca connects to the desktop app on your local network.",
         "NSAppTransportSecurity": {

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -14,7 +14,7 @@
       "backgroundColor": "#111111"
     },
     "ios": {
-      "supportsTablet": true,
+      "supportsTablet": false,
       "bundleIdentifier": "com.stably.orca.mobile",
       "buildNumber": "5",
       "infoPlist": {

--- a/mobile/app/about.tsx
+++ b/mobile/app/about.tsx
@@ -1,7 +1,7 @@
 import { View, Text, StyleSheet, Pressable, Linking, Platform } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useRouter } from 'expo-router'
-import { ChevronLeft, Globe, Shield, LifeBuoy } from 'lucide-react-native'
+import { ChevronLeft, Globe } from 'lucide-react-native'
 import Svg, { Path } from 'react-native-svg'
 import Constants from 'expo-constants'
 import { OrcaLogo } from '../src/components/OrcaLogo'
@@ -81,24 +81,6 @@ export default function AboutScreen() {
         </Pressable>
       </View>
 
-      <View style={[styles.section, styles.sectionSpacer]}>
-        <Pressable
-          style={({ pressed }) => [styles.row, pressed && styles.rowPressed]}
-          onPress={() => void Linking.openURL('https://www.onorca.dev/privacy')}
-        >
-          <Shield size={16} color={colors.textSecondary} />
-          <Text style={styles.rowLabel}>Privacy Policy</Text>
-        </Pressable>
-        <View style={styles.separator} />
-        <Pressable
-          style={({ pressed }) => [styles.row, pressed && styles.rowPressed]}
-          onPress={() => void Linking.openURL('https://github.com/stablyai/orca/issues')}
-        >
-          <LifeBuoy size={16} color={colors.textSecondary} />
-          <Text style={styles.rowLabel}>Support</Text>
-        </Pressable>
-      </View>
-
       <Text style={styles.versionText}>{getVersionLabel()}</Text>
     </View>
   )
@@ -148,9 +130,6 @@ const styles = StyleSheet.create({
     backgroundColor: colors.bgPanel,
     borderRadius: 12,
     overflow: 'hidden'
-  },
-  sectionSpacer: {
-    marginTop: spacing.md
   },
   row: {
     flexDirection: 'row',

--- a/mobile/app/about.tsx
+++ b/mobile/app/about.tsx
@@ -1,7 +1,7 @@
 import { View, Text, StyleSheet, Pressable, Linking, Platform } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useRouter } from 'expo-router'
-import { ChevronLeft, Globe } from 'lucide-react-native'
+import { ChevronLeft, Globe, Shield, LifeBuoy } from 'lucide-react-native'
 import Svg, { Path } from 'react-native-svg'
 import Constants from 'expo-constants'
 import { OrcaLogo } from '../src/components/OrcaLogo'
@@ -81,6 +81,24 @@ export default function AboutScreen() {
         </Pressable>
       </View>
 
+      <View style={[styles.section, styles.sectionSpacer]}>
+        <Pressable
+          style={({ pressed }) => [styles.row, pressed && styles.rowPressed]}
+          onPress={() => void Linking.openURL('https://stably.ai/orca/privacy')}
+        >
+          <Shield size={16} color={colors.textSecondary} />
+          <Text style={styles.rowLabel}>Privacy Policy</Text>
+        </Pressable>
+        <View style={styles.separator} />
+        <Pressable
+          style={({ pressed }) => [styles.row, pressed && styles.rowPressed]}
+          onPress={() => void Linking.openURL('https://github.com/stablyai/orca/issues')}
+        >
+          <LifeBuoy size={16} color={colors.textSecondary} />
+          <Text style={styles.rowLabel}>Support</Text>
+        </Pressable>
+      </View>
+
       <Text style={styles.versionText}>{getVersionLabel()}</Text>
     </View>
   )
@@ -130,6 +148,9 @@ const styles = StyleSheet.create({
     backgroundColor: colors.bgPanel,
     borderRadius: 12,
     overflow: 'hidden'
+  },
+  sectionSpacer: {
+    marginTop: spacing.md
   },
   row: {
     flexDirection: 'row',

--- a/mobile/app/about.tsx
+++ b/mobile/app/about.tsx
@@ -84,7 +84,7 @@ export default function AboutScreen() {
       <View style={[styles.section, styles.sectionSpacer]}>
         <Pressable
           style={({ pressed }) => [styles.row, pressed && styles.rowPressed]}
-          onPress={() => void Linking.openURL('https://stably.ai/orca/privacy')}
+          onPress={() => void Linking.openURL('https://www.onorca.dev/privacy')}
         >
           <Shield size={16} color={colors.textSecondary} />
           <Text style={styles.rowLabel}>Privacy Policy</Text>

--- a/mobile/app/notifications.tsx
+++ b/mobile/app/notifications.tsx
@@ -13,7 +13,7 @@ import { ensureNotificationPermissions } from '../src/notifications/mobile-notif
 export default function NotificationsScreen() {
   const router = useRouter()
   const insets = useSafeAreaInsets()
-  const [pushEnabled, setPushEnabled] = useState(true)
+  const [pushEnabled, setPushEnabled] = useState(false)
 
   useFocusEffect(
     useCallback(() => {

--- a/mobile/app/settings.tsx
+++ b/mobile/app/settings.tsx
@@ -1,7 +1,15 @@
-import { View, Text, StyleSheet, Pressable } from 'react-native'
+import { View, Text, StyleSheet, Pressable, Linking } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useRouter } from 'expo-router'
-import { ChevronLeft, ChevronRight, Info, Bell, Wrench } from 'lucide-react-native'
+import {
+  ChevronLeft,
+  ChevronRight,
+  Info,
+  Bell,
+  Wrench,
+  Shield,
+  LifeBuoy
+} from 'lucide-react-native'
 import { colors, spacing, typography } from '../src/theme/mobile-theme'
 
 export default function SettingsScreen() {
@@ -45,6 +53,24 @@ export default function SettingsScreen() {
           <ChevronRight size={16} color={colors.textMuted} />
         </Pressable>
       </View>
+
+      <View style={[styles.section, styles.sectionSpacer]}>
+        <Pressable
+          style={({ pressed }) => [styles.row, pressed && styles.rowPressed]}
+          onPress={() => void Linking.openURL('https://www.onorca.dev/privacy')}
+        >
+          <Shield size={16} color={colors.textSecondary} />
+          <Text style={styles.rowLabel}>Privacy Policy</Text>
+        </Pressable>
+        <View style={styles.separator} />
+        <Pressable
+          style={({ pressed }) => [styles.row, pressed && styles.rowPressed]}
+          onPress={() => void Linking.openURL('https://github.com/stablyai/orca/issues')}
+        >
+          <LifeBuoy size={16} color={colors.textSecondary} />
+          <Text style={styles.rowLabel}>Support</Text>
+        </Pressable>
+      </View>
     </View>
   )
 }
@@ -77,6 +103,9 @@ const styles = StyleSheet.create({
     backgroundColor: colors.bgPanel,
     borderRadius: 12,
     overflow: 'hidden'
+  },
+  sectionSpacer: {
+    marginTop: spacing.md
   },
   row: {
     flexDirection: 'row',

--- a/mobile/src/storage/preferences.ts
+++ b/mobile/src/storage/preferences.ts
@@ -4,13 +4,18 @@ const PINS_PREFIX = 'orca:pins:'
 const PREFS_PREFIX = 'orca:prefs:'
 const NOTIF_KEY = 'orca:pushNotificationsEnabled'
 
+// Why: default-off so the iOS notification permission prompt never
+// fires until the user explicitly opts in via Settings → Notifications.
+// Apple's review guideline 4.5.4 and HIG both prefer user-initiated
+// permission prompts; default-on would fire the prompt the moment the
+// desktop sent its first notification, which can read as unsolicited.
 export async function loadPushNotificationsEnabled(): Promise<boolean> {
   try {
     const raw = await AsyncStorage.getItem(NOTIF_KEY)
-    if (raw === null) return true
+    if (raw === null) return false
     return raw === 'true'
   } catch {
-    return true
+    return false
   }
 }
 

--- a/mobile/src/transport/client-context.tsx
+++ b/mobile/src/transport/client-context.tsx
@@ -278,13 +278,23 @@ export function RpcClientProvider({ children }: { children: ReactNode }) {
     }
   }, [])
 
-  // Close all clients on provider unmount (app shutdown / hot reload).
+  // Close all clients on provider unmount (app shutdown).
+  // Why: deps must be empty so this cleanup ONLY runs on real unmount.
+  // Hot-reload re-evaluates this module, which makes closeEntry a new
+  // function identity. With [closeEntry] as deps, every Fast Refresh
+  // would tear down all open WebSockets, leaving screens holding closed
+  // clients and the user staring at a 'Reconnecting…' card. Reading
+  // storeRef.current and the locally-scoped closeEntry inside the
+  // cleanup is safe — the ref is stable across renders, and the
+  // function captured here will be the one defined in the same
+  // closure as this effect.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     const store = storeRef.current
     return () => {
       for (const [hostId] of store) closeEntry(hostId)
     }
-  }, [closeEntry])
+  }, [])
 
   const value = useMemo<ContextValue>(
     () => ({

--- a/mobile/src/transport/client-context.tsx
+++ b/mobile/src/transport/client-context.tsx
@@ -23,13 +23,10 @@ import { connect, type RpcClient } from './rpc-client'
 import { loadHosts } from './host-store'
 import type { ConnectionState, HostProfile } from './types'
 
-const IDLE_CLOSE_MS = 30_000
-
 type StoreEntry = {
   client: RpcClient
   state: ConnectionState
   refCount: number
-  idleTimer: ReturnType<typeof setTimeout> | null
   unsubState: () => void
 }
 
@@ -83,7 +80,6 @@ export function RpcClientProvider({ children }: { children: ReactNode }) {
   const closeEntry = useCallback((hostId: string) => {
     const entry = storeRef.current.get(hostId)
     if (!entry) return
-    if (entry.idleTimer) clearTimeout(entry.idleTimer)
     entry.unsubState()
     entry.client.close()
     storeRef.current.delete(hostId)
@@ -150,7 +146,6 @@ export function RpcClientProvider({ children }: { children: ReactNode }) {
         client,
         state: client.getState(),
         refCount: 0,
-        idleTimer: null,
         unsubState
       }
       storeRef.current.set(hostId, entry)
@@ -175,10 +170,6 @@ export function RpcClientProvider({ children }: { children: ReactNode }) {
       const existing = storeRef.current.get(hostId)
       if (existing) {
         existing.refCount += 1
-        if (existing.idleTimer) {
-          clearTimeout(existing.idleTimer)
-          existing.idleTimer = null
-        }
         return existing.client
       }
       // Trigger async open. The acquire-side will return null this tick and
@@ -197,36 +188,30 @@ export function RpcClientProvider({ children }: { children: ReactNode }) {
     for (const host of hosts) primedHostsRef.current.set(host.id, host)
   }, [])
 
-  const release = useCallback(
-    (hostId: string) => {
-      const entry = storeRef.current.get(hostId)
-      if (!entry) return
-      entry.refCount = Math.max(0, entry.refCount - 1)
-      if (entry.refCount > 0) return
-      if (entry.idleTimer) clearTimeout(entry.idleTimer)
-      entry.idleTimer = setTimeout(() => {
-        // Why: only close if still idle when the timer fires. A late acquire
-        // would have cleared the timer.
-        const cur = storeRef.current.get(hostId)
-        if (!cur || cur.refCount > 0) return
-        closeEntry(hostId)
-      }, IDLE_CLOSE_MS)
-    },
-    [closeEntry]
-  )
+  // Why: refcount dropping to 0 no longer triggers an idle-close. The
+  // app deliberately keeps live WebSockets open while the app itself is
+  // foregrounded — closing on transient navigation gaps was producing
+  // false 'disconnected' flashes when the user navigated home → host →
+  // back to home faster than React could re-acquire on the home side.
+  // Connections still close on: explicit user Disconnect, host removal,
+  // app backgrounding (OS-level socket suspension), and provider
+  // unmount (app shutdown).
+  const release = useCallback((hostId: string) => {
+    const entry = storeRef.current.get(hostId)
+    if (!entry) return
+    entry.refCount = Math.max(0, entry.refCount - 1)
+  }, [])
 
   const forceReconnect = useCallback(
     async (hostId: string) => {
       const entry = storeRef.current.get(hostId)
-      // Why: if the entry was previously closed (e.g. user tapped
-      // Disconnect), refCount is lost. Fall back to the number of active
-      // state listeners as a proxy for "screens currently watching this
-      // host," so the freshly-opened entry doesn't trip the idle-close
-      // timer immediately.
+      // Why: preserve refcount across the swap. If the user reaches
+      // forceReconnect via the Disconnect → Reconnect path, the entry
+      // was already closed and refCount=0; fall back to active listener
+      // count as a proxy for "screens still watching this host."
       const listenerCount = stateListenersRef.current.get(hostId)?.size ?? 0
       const savedRefCount = entry?.refCount ?? Math.max(1, listenerCount)
       if (entry) {
-        if (entry.idleTimer) clearTimeout(entry.idleTimer)
         entry.unsubState()
         entry.client.close()
         storeRef.current.delete(hostId)

--- a/mobile/src/transport/rpc-client.ts
+++ b/mobile/src/transport/rpc-client.ts
@@ -32,7 +32,14 @@ export type RpcClient = {
   close: () => void
 }
 
-const RECONNECT_DELAYS = [1000, 2000, 4000, 8000, 16000]
+// Why: capped at 4s so the worst-case "stuck reconnecting" window the
+// user perceives is short. Prior 16s ceiling combined with Android's
+// suspended-timer behaviour during background → foreground transitions
+// often felt like the app would just sit on 'Reconnecting…' forever
+// (the timer was queued, the OS had simply not run it yet). Tapping the
+// manual Reconnect button bypassed the timer, which is why it felt
+// "magic". Shorter backoff makes the auto-recovery path feel as fast.
+const RECONNECT_DELAYS = [500, 1000, 2000, 4000]
 const REQUEST_TIMEOUT_MS = 30_000
 const HANDSHAKE_TIMEOUT_MS = 5_000
 


### PR DESCRIPTION
## Summary

Final pass before submitting v0.0.4 (build 6) to TestFlight / App Store. Covers App Store Connect listing prep, several connection-stability bugs that were producing intermittent 'Reconnecting…' / stuck-spinner symptoms, and a default-off flip for push notifications.

## Connection-stability fixes (the headline)

Three independent bugs that were combining to produce flaky behaviour:

1. **\`79a42016\` — Removed the 30s idle-close timer.** When refcount dropped to 0 (e.g. host detail unmount → home re-render gap), a 30s timer was armed; if nothing re-acquired in time, the WebSocket got torn down. Result: hosts randomly flipped to 'Disconnected' ~30s after any navigation that bounced refcount through 0. The timer's stated purpose ('don't leak idle sockets' is already covered by the OS, the desktop reaper, and the explicit Disconnect / host-removal paths. Removing it fixes the symptom and simplifies the lifecycle.
2. **`2cd960d2` — Don't tear down all clients on every Fast Refresh.** The provider's 'close all on unmount' effect listed `[closeEntry]` as its dependency. `closeEntry` is a stable `useCallback` within one module evaluation, but Fast Refresh re-evaluates the module → new ref → React thinks the dep changed → cleanup runs → all WebSockets close. Screens were left holding closed clients (`intentionallyClosed = true` short-circuits everything). Empty deps now, cleanup only on real unmount.
3. **`5ba58109` — Lowered reconnect backoff cap from 16s to 4s.** Worst-case auto-reconnect window was 16 seconds. Combined with Android's suspended-timer behaviour during background → foreground transitions, that's enough to feel like the UI is permanently stuck. New schedule: 500ms, 1s, 2s, 4s, plateau at 4s.

## App Store Connect prep

- **`d9196888` — Drop `supportsTablet`** so we skip iPad screenshot requirements; add v0.0.4 release notes draft (`docs/mobile-app-store/whats-new-v0.0.4.md`); normalize 'Settings → Experimental' → 'Settings → Mobile' in App Review notes; promote the working `docs/mobile-app-store/*` notes from untracked into the repo.
- **`156adfdb` — Default push notifications to off.** App Store guideline 4.5.4 + HIG prefer user-initiated permission prompts. Default-on would fire the iOS prompt the moment the desktop sent its first notification, which reads as unsolicited. Now the prompt only fires when the user flips the toggle in Settings → Notifications. Also fixes a brief 'on' flash on the Notifications screen before the saved preference loads.
- **`86881dcb` — Point at live `onorca.dev/privacy`** instead of the placeholder; add a clear App Review Notes callout explaining that the published policy describes the desktop IDE's anonymized telemetry but the mobile companion has zero telemetry. The mobile-specific privacy doc (`privacy-policy-template.md`) is repurposed from 'draft to host' into an internal reference doc.
- **`cbe1c18e` — Move Privacy Policy + Support links from About to Settings.** App Store reviewers and HIG conventions both expect privacy + support to be discoverable directly from Settings, not nested behind About. About is now lean (brand + version + social), Settings groups the actionable App + Help rows.
- **`cd218e69` — Bump iOS `buildNumber` to 6** for the next TestFlight upload. Apple requires monotonically increasing build numbers; previous TestFlight uploads were at builds 1, 2, 3.

## Test plan

- mobile `pnpm tsc --noEmit`: clean
- mobile `pnpm lint`: 0 warnings, 47 files
- Manual: hot-reload the app several times — host card stays Connected (verified live).
- Manual: navigate home → host detail → back to home, repeat — host card stays Connected past 30s (idle-timer removal verified live).
- Manual: pair new host via QR — completes within ~1s after permission prompts (no force-close from removed connect-timeout).
- Manual: Disconnect → Reconnect from action sheet — works, refcount preserved across the swap.

## Notable carry-over

`docs/mobile-app-store/*` working notes are now committed (privacy nutrition labels answer key, listing strings, App Review notes, release notes drafts, version-mismatch UX plan, privacy policy template). These were previously untracked but referenced from `docs/mobile-app-store-submission.md`; consolidating them in the repo keeps the submission checklist self-contained.

After merging this PR:
- Re-run `expo prebuild --platform ios --no-install && cd ios && pod install` to regenerate `mobile/ios/` with the new build number + privacy manifest
- Archive in Xcode → Distribute → App Store Connect
- TestFlight build will appear as v0.0.4 (6)
EOF
)

Made with [Orca](https://github.com/stablyai/orca) 🐋
