### PR TITLE
Mobile: declare mass-market encryption exemption + bump iOS build to 7

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -16,12 +16,13 @@
     "ios": {
       "supportsTablet": false,
       "bundleIdentifier": "com.stably.orca.mobile",
-      "buildNumber": "6",
+      "buildNumber": "7",
       "infoPlist": {
         "NSLocalNetworkUsageDescription": "Orca connects to the desktop app on your local network.",
         "NSAppTransportSecurity": {
           "NSAllowsLocalNetworking": true
-        }
+        },
+        "ITSAppUsesNonExemptEncryption": false
       },
       "privacyManifests": {
         "NSPrivacyTracking": false,


### PR DESCRIPTION
## Summary

Sets `ITSAppUsesNonExemptEncryption=false` in `Info.plist` (via `app.json`) so App Store Connect does not ask the export-compliance question on every TestFlight / App Store upload. Bumps iOS `buildNumber` 6 → 7 for the next archive.

## Why

The previous upload (build 6) triggered the "App Encryption Documentation" wizard in App Store Connect. Picking the wrong option there leads down the heavy CCATS-letter path which is only relevant for apps where encryption is the core product feature.

The mobile app uses Curve25519 (TweetNaCl) + XSalsa20-Poly1305 for the QR pairing handshake. This is standard, publicly-known cryptography used **solely for transport security between the user's own devices**, not as the product's primary feature. That falls under the U.S. mass-market exemption: `5D992.c`, Note 3 to Category 5 Part 2 of the EAR.

Declaring `ITSAppUsesNonExemptEncryption=false` is the standard answer for this case and is what virtually every Expo / React Native consumer app does when their crypto usage is incidental to transport.

## Test plan

- `Info.plist` regenerated via `expo prebuild` contains:
  - `CFBundleVersion = 7`
  - `ITSAppUsesNonExemptEncryption = <false/>`
- Next archive uploaded to App Store Connect should skip the App Encryption Documentation wizard entirely.

Made with [Orca](https://github.com/stablyai/orca) 🐋
