### PR TITLE
chore(telemetry): silence dev-mode console mirror in track()

### DIFF
--- a/src/main/telemetry/client.test.ts
+++ b/src/main/telemetry/client.test.ts
@@ -361,16 +361,15 @@ describe('setOptIn()', () => {
     expect(order).toEqual(['optIn', 'capture:telemetry_opted_in'])
   })
 
-  it('console-mirrors telemetry_opted_in when no PostHog client is initialized', async () => {
+  it('drops telemetry_opted_in silently in non-official builds', async () => {
     settings.telemetry!.optedIn = false
     _setPostHogClientForTests(null)
     _enableTransportForTests(false)
 
     await setOptIn('settings', true)
 
-    expect(console.debug).toHaveBeenCalledWith('[telemetry]', 'telemetry_opted_in', {
-      via: 'settings'
-    })
+    expect(mock.capture).not.toHaveBeenCalled()
+    expect(console.debug).not.toHaveBeenCalled()
   })
 
   it('fires app_opened once after pending-banner opt-in enables the SDK', async () => {

--- a/src/main/telemetry/client.ts
+++ b/src/main/telemetry/client.ts
@@ -255,8 +255,6 @@ function waitForCaptureEnqueue(client: PostHog, event: EventName, uuid: string):
 // `ORCA_POSTHOG_WRITE_KEY`.
 export function track<N extends EventName>(name: N, props: EventProps<N>): void {
   if (!testTransportEnabled && (!IS_OFFICIAL_BUILD || !TELEMETRY_ENABLED)) {
-    void name
-    void props
     return
   }
 

--- a/src/main/telemetry/client.ts
+++ b/src/main/telemetry/client.ts
@@ -248,20 +248,21 @@ function waitForCaptureEnqueue(client: PostHog, event: EventName, uuid: string):
   })
 }
 
+// In `pnpm dev` and any contributor / non-official build, `track()` is a
+// no-op: it returns immediately without transmitting, logging, or running
+// the burst-cap / consent / validator pipeline. Telemetry only flows in
+// official stable/rc builds where CI injects `ORCA_BUILD_IDENTITY` and
+// `ORCA_POSTHOG_WRITE_KEY`.
 export function track<N extends EventName>(name: N, props: EventProps<N>): void {
-  // Console mirror: always in non-official builds (so the whole team —
-  // contributors included — sees exactly what would transmit) and also in
-  // official builds when `TELEMETRY_ENABLED` is off (PR 2 verification).
-  // These are the only two paths that short-circuit before the pipeline.
   if (!testTransportEnabled && (!IS_OFFICIAL_BUILD || !TELEMETRY_ENABLED)) {
-    console.debug('[telemetry]', name, props)
+    void name
+    void props
     return
   }
 
   // (1) Shutdown gate. Late IPC arrivals should not attempt to enqueue
   // against a client that is actively flushing.
   if (shuttingDown) {
-    console.debug('[telemetry] shutdown-gate drop:', name)
     return
   }
   if (!posthog || !commonProps || !storeRef) {


### PR DESCRIPTION
## Summary

- Drop the `console.debug('[telemetry]', name, props)` mirror at the top of `track()` in `src/main/telemetry/client.ts`. It fired on every emit in `pnpm dev` and any non-official build, spamming DevTools with lines like `[telemetry] agent_started { agent_kind: 'claude-code', launch_source: 'new_workspace_composer', request_kind: 'new' }` for normal app actions.
- Also drop the matching `[telemetry] shutdown-gate drop:` debug log in the shutdown branch.
- Added a comment on `track()` clarifying that in dev / contributor builds it is a no-op (no transmit, no log, no pipeline) — telemetry only flows in official stable/rc builds where CI injects `ORCA_BUILD_IDENTITY` + `ORCA_POSTHOG_WRITE_KEY`.
- Updated the one test that asserted the mirror to assert the new silent-drop behavior instead.

Behavior in official stable/rc builds is unchanged: events still flow through burst-cap → consent → validator → `posthog.capture()`.

## Test plan
- [x] `pnpm exec vitest run src/main/telemetry/client.test.ts` passes (18/18)
- [x] Run `pnpm dev`, trigger a workspace creation + agent launch, confirm no `[telemetry] …` lines appear in DevTools

Made with [Orca](https://github.com/stablyai/orca) 🐋
