### PR TITLE
Mobile: bump iOS buildNumber to 8 to ship updated app icon

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -16,7 +16,7 @@
     "ios": {
       "supportsTablet": false,
       "bundleIdentifier": "com.stably.orca.mobile",
-      "buildNumber": "7",
+      "buildNumber": "8",
       "infoPlist": {
         "NSLocalNetworkUsageDescription": "Orca connects to the desktop app on your local network.",
         "NSAppTransportSecurity": {


### PR DESCRIPTION
Bumps iOS `buildNumber` 7 → 8 to ship the icon update from #1490 to TestFlight. Apple requires monotonically increasing build numbers — 7 was already uploaded.

Made with [Orca](https://github.com/stablyai/orca) 🐋
