### PR TITLE
Mobile: drop unused NSMicrophoneUsageDescription + bump iOS build to 9

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -16,7 +16,7 @@
     "ios": {
       "supportsTablet": false,
       "bundleIdentifier": "com.stably.orca.mobile",
-      "buildNumber": "8",
+      "buildNumber": "9",
       "infoPlist": {
         "NSLocalNetworkUsageDescription": "Orca connects to the desktop app on your local network.",
         "NSAppTransportSecurity": {
@@ -65,7 +65,9 @@
       [
         "expo-camera",
         {
-          "cameraPermission": "Allow Orca to use the camera for QR code scanning."
+          "cameraPermission": "Allow Orca to use the camera for QR code scanning.",
+          "microphonePermission": false,
+          "recordAudioAndroid": false
         }
       ],
       [


### PR DESCRIPTION
App Store Review Guideline 5.1.1(iii) (data minimization): only request permissions actually used.

`expo-camera`'s config plugin auto-adds `NSMicrophoneUsageDescription` to Info.plist. Orca only uses the camera for QR-code scanning — not audio capture. Passing `microphonePermission: false` strips the key from Info.plist on prebuild.

Also bumps iOS `buildNumber` 8 → 9 since 8 was already uploaded to TestFlight.

Made with [Orca](https://github.com/stablyai/orca) 🐋
