### PR TITLE
fix(worktree): silence spawn-git-ENOENT spam from stale repo paths

### DIFF
--- a/src/main/git/remove-worktree.test.ts
+++ b/src/main/git/remove-worktree.test.ts
@@ -7,12 +7,14 @@ const {
   gitExecFileAsyncMock,
   gitExecFileSyncMock,
   translateWslOutputPathsMock,
+  accessMock,
   statMock,
   resolveGitDirMock
 } = vi.hoisted(() => ({
   gitExecFileAsyncMock: vi.fn(),
   gitExecFileSyncMock: vi.fn(),
   translateWslOutputPathsMock: vi.fn((output: string) => output),
+  accessMock: vi.fn(),
   statMock: vi.fn(),
   resolveGitDirMock: vi.fn()
 }))
@@ -29,7 +31,7 @@ vi.mock('./status', () => ({
 
 vi.mock('fs/promises', async () => {
   const actual = await vi.importActual<typeof FsPromises>('fs/promises')
-  return { ...actual, stat: statMock }
+  return { ...actual, access: accessMock, stat: statMock }
 })
 
 import { addSparseWorktree, listWorktrees, removeWorktree } from './worktree'
@@ -77,6 +79,10 @@ describe('removeWorktree', () => {
     gitExecFileSyncMock.mockReset()
     translateWslOutputPathsMock.mockReset()
     translateWslOutputPathsMock.mockImplementation((output: string) => output)
+    accessMock.mockReset()
+    // Default: every repo path under test exists on disk. Tests that exercise
+    // the missing-cwd precheck override this.
+    accessMock.mockResolvedValue(undefined)
     statMock.mockReset()
     // Default: no worktree has a sparse-checkout config file. Tests that need
     // sparse detection override this.
@@ -298,6 +304,10 @@ describe('listWorktrees', () => {
     gitExecFileSyncMock.mockReset()
     translateWslOutputPathsMock.mockReset()
     translateWslOutputPathsMock.mockImplementation((output: string) => output)
+    accessMock.mockReset()
+    // Default: every repo path under test exists on disk. Tests that exercise
+    // the missing-cwd precheck override this.
+    accessMock.mockResolvedValue(undefined)
     statMock.mockReset()
     // Default: no worktree has a sparse-checkout config file. Tests that need
     // sparse detection override this.
@@ -394,6 +404,36 @@ describe('listWorktrees', () => {
     // on every poll.
     expect(getGitCalls()).toEqual(['git worktree list --porcelain'])
   })
+
+  it('returns [] without spawning git when the repo path is missing on disk', async () => {
+    accessMock.mockRejectedValue(Object.assign(new Error('not found'), { code: 'ENOENT' }))
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    expect(await listWorktrees('/gone')).toEqual([])
+    expect(getGitCalls()).toEqual([])
+    expect(warnSpy).not.toHaveBeenCalled()
+    warnSpy.mockRestore()
+  })
+
+  it('returns [] silently when git fails with ENOENT (race after access)', async () => {
+    gitExecFileAsyncMock.mockRejectedValueOnce(
+      Object.assign(new Error('spawn git ENOENT'), { code: 'ENOENT' })
+    )
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    expect(await listWorktrees('/repo')).toEqual([])
+    expect(warnSpy).not.toHaveBeenCalled()
+    warnSpy.mockRestore()
+  })
+
+  it('warns on non-ENOENT git failures so issue #1453-style regressions surface', async () => {
+    gitExecFileAsyncMock.mockRejectedValueOnce(new Error('git: unknown switch -z'))
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    expect(await listWorktrees('/repo')).toEqual([])
+    expect(warnSpy).toHaveBeenCalledWith('[git/worktree] listWorktrees failed:', expect.any(Error))
+    warnSpy.mockRestore()
+  })
 })
 
 describe('addSparseWorktree', () => {
@@ -402,6 +442,10 @@ describe('addSparseWorktree', () => {
     gitExecFileSyncMock.mockReset()
     translateWslOutputPathsMock.mockReset()
     translateWslOutputPathsMock.mockImplementation((output: string) => output)
+    accessMock.mockReset()
+    // Default: every repo path under test exists on disk. Tests that exercise
+    // the missing-cwd precheck override this.
+    accessMock.mockResolvedValue(undefined)
     statMock.mockReset()
     // Default: no worktree has a sparse-checkout config file. Tests that need
     // sparse detection override this.

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -1,4 +1,4 @@
-import { stat } from 'fs/promises'
+import { access, stat } from 'fs/promises'
 import { join, posix, win32 } from 'path'
 import type { GitWorktreeInfo } from '../../shared/types'
 import { gitExecFileAsync, translateWslOutputPaths } from './runner'
@@ -85,6 +85,22 @@ export function parseWorktreeList(output: string): GitWorktreeInfo[] {
  * List all worktrees for a git repo at the given path.
  */
 export async function listWorktrees(repoPath: string): Promise<GitWorktreeInfo[]> {
+  // Why: when the user moves or deletes a repo folder out from under Orca, the
+  // persisted Repo entry still references the now-missing path. Spawning git
+  // with a non-existent cwd fails with the misleading `spawn git ENOENT` (Node
+  // reports the *executable* in the error even when it's the cwd that's gone),
+  // and the polled worktree-list call would flood the console once per repo
+  // per 3-second poll. Pre-check the path with `access` so missing repos return [] silently
+  // and the "spawn failed" branch below stays scoped to real git errors.
+  try {
+    await access(repoPath)
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return []
+    }
+    // Other access errors (EACCES, EBUSY) are worth surfacing — fall through.
+  }
+
   try {
     // Why: do not pass `-z` here. `-z` requires Git ≥ 2.36; older Git rejects
     // it, listWorktrees returns [], and every create flow throws "Worktree
@@ -106,6 +122,13 @@ export async function listWorktrees(repoPath: string): Promise<GitWorktreeInfo[]
       })
     )
   } catch (err) {
+    // Why: ENOENT from spawn here means the cwd was removed between the access check
+    // above and the git invocation (or, on Windows, that git itself isn't on
+    // PATH — covered by the startup PATH hydration). Either way, no signal
+    // worth a stack trace per poll.
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return []
+    }
     // Why: a silent catch turned issue #1453's underlying
     // "git: unknown switch -z" into the opaque "not found in listing" toast.
     // Surface the cause so future regressions show up immediately.


### PR DESCRIPTION
## Summary

- `listWorktrees` now `fs.access`-checks the repo path before spawning git, so persisted repos whose folders were deleted return `[]` silently instead of warning a full stack on every 3-sec poll.
- The catch path now suppresses ENOENT (race after the access check) but still logs the original `[git/worktree] listWorktrees failed:` warn for genuine failures, so the issue #1453 `-z` regression still surfaces.
- Mirrors Superset's `existsOnDisk` precheck pattern.

## Why

Console looked like this every 3 seconds:

```
[git/worktree] listWorktrees failed: Error: spawn git ENOENT
    at ChildProcess._handle.onexit ...
  errno: -2, code: 'ENOENT', syscall: 'spawn git', path: 'git',
  spawnargs: [ 'worktree', 'list', '--porcelain' ], ...
```

Node's `child_process.spawn` reports `path: 'git'` whether the binary OR the cwd is missing — so the message was misleading even before it became spam. Once a user has a stale persisted repo (deleted fixture, moved checkout), the polled `listWorktrees` warns once per repo per poll cycle.

## Test plan

- [x] `pnpm vitest run src/main/git/` — 84/84 pass (3 new tests for the precheck branches).
- [x] `pnpm typecheck` clean.
- [x] Validated end-to-end via a fresh dev instance attached over CDP, seeded with the user's `orca-data.json` containing 3 missing repo paths. After ~25s of background polling plus 3 explicit `fetchAllWorktrees()` calls, the main-process console showed **0** occurrences of `listWorktrees failed` or `spawn git ENOENT`.

Made with [Orca](https://github.com/stablyai/orca) 🐋
