### PR TITLE
fix(cli): exclude tab profile list/create/delete from --page flag (pr-bug-scan #1397)

### DIFF
--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -64,7 +64,14 @@ export function supportsBrowserPageFlag(commandPath: string[]): boolean {
   if (['repo', 'worktree', 'terminal'].includes(commandPath[0])) {
     return false
   }
-  return !['tab list', 'tab create', 'tab current'].includes(joined)
+  return ![
+    'tab list',
+    'tab create',
+    'tab current',
+    'tab profile list',
+    'tab profile create',
+    'tab profile delete'
+  ].includes(joined)
 }
 
 export function isCommandGroup(commandPath: string[]): boolean {


### PR DESCRIPTION
Re-applies the surviving finding from #1458 against current main.

Background: #1458 was branched off stale main pre-#1396 and pre-#1497. Its diff against current main would have (a) duplicated the ProfileCreate.scope strict-enum fix already shipped in #1497 and (b) silently reverted 'tab current' out of the supportsBrowserPageFlag exclusion list (added in #1396). Closing #1458 in favor of this clean re-application.

### Findings addressed
- ✅ **[low]** `src/cli/args.ts:54-62` — `--page` flag silently accepted on `tab profile list/create/delete`

### Verification
- `pnpm typecheck:cli` ✅
- `pnpm lint` ✅ (no new warnings)
- ProfileCreate.scope finding already addressed by #1497 — no action needed

Supersedes #1458.