### PR TITLE
Make projects the default workspace grouping

### DIFF
--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -86,7 +86,7 @@ describe('Store', () => {
     const store = await createStore()
     const ui = store.getUI()
     expect(ui.sidebarWidth).toBe(280)
-    expect(ui.groupBy).toBe('none')
+    expect(ui.groupBy).toBe('repo')
     expect(ui.lastActiveRepoId).toBeNull()
     expect(ui.dismissedUpdateVersion).toBeNull()
     expect(ui.lastUpdateCheckAt).toBeNull()
@@ -433,7 +433,7 @@ describe('Store', () => {
     store.updateUI({ sidebarWidth: 400 })
     const ui = store.getUI()
     expect(ui.sidebarWidth).toBe(400)
-    expect(ui.groupBy).toBe('none') // default preserved
+    expect(ui.groupBy).toBe('repo') // default preserved
     expect(ui.dismissedUpdateVersion).toBeNull()
   })
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines */
 import { lazy, Suspense, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
-import { DEFAULT_STATUS_BAR_ITEMS, DEFAULT_WORKTREE_CARD_PROPERTIES } from '../../shared/constants'
+import { getDefaultUIState } from '../../shared/constants'
 
 import { ArrowLeft, ArrowRight, Minimize2, PanelLeft, PanelRight } from 'lucide-react'
 import { SYNC_FIT_PANES_EVENT, TOGGLE_TERMINAL_PANE_EXPAND_EVENT } from '@/constants/terminal'
@@ -335,25 +335,7 @@ function App(): React.JSX.Element {
       } catch (error) {
         console.error('Failed to hydrate workspace session:', error)
         if (!cancelled) {
-          actions.hydratePersistedUI({
-            lastActiveRepoId: null,
-            lastActiveWorktreeId: null,
-            sidebarWidth: 280,
-            rightSidebarWidth: 350,
-            groupBy: 'none',
-            sortBy: 'recent',
-            showActiveOnly: false,
-            hideDefaultBranchWorkspace: false,
-            filterRepoIds: [],
-            collapsedGroups: [],
-            uiZoomLevel: 0,
-            editorFontZoomLevel: 0,
-            worktreeCardProperties: [...DEFAULT_WORKTREE_CARD_PROPERTIES],
-            statusBarItems: [...DEFAULT_STATUS_BAR_ITEMS],
-            statusBarVisible: true,
-            dismissedUpdateVersion: null,
-            lastUpdateCheckAt: null
-          })
+          actions.hydratePersistedUI(getDefaultUIState())
           actions.hydrateWorkspaceSession({
             activeRepoId: null,
             activeWorktreeId: null,

--- a/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
@@ -100,6 +100,41 @@ describe('buildRows with pinned worktrees', () => {
 
     expect(rows[0]).toMatchObject({ type: 'header', label: 'c15t' })
   })
+
+  it('groups folder-mode workspaces under their folder name', () => {
+    const folderRepo: Repo = {
+      ...repo,
+      id: 'folder-1',
+      path: '/tmp/design-assets',
+      displayName: 'design-assets',
+      kind: 'folder'
+    }
+    const folderWorktree: Worktree = {
+      ...worktree,
+      id: 'folder-1::/tmp/design-assets',
+      repoId: folderRepo.id,
+      path: folderRepo.path,
+      branch: '',
+      displayName: folderRepo.displayName,
+      isMainWorktree: true
+    }
+    const rows = buildRows(
+      'repo',
+      [folderWorktree],
+      new Map([[folderRepo.id, folderRepo]]),
+      null,
+      new Set()
+    )
+
+    expect(rows[0]).toMatchObject({
+      type: 'header',
+      key: 'repo:folder-1',
+      label: 'design-assets',
+      count: 1,
+      repo: folderRepo
+    })
+    expect(rows[1]).toMatchObject({ type: 'item', worktree: { id: folderWorktree.id } })
+  })
 })
 
 describe('WorktreeList header styles', () => {

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -522,7 +522,7 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
       return { trustedOrcaHooks: next }
     }),
 
-  groupBy: 'none',
+  groupBy: 'repo',
   // Why: group keys are mode-specific (e.g. repo id vs PR status), so
   // collapsed state from one mode is meaningless in another. Clearing
   // also prevents unbounded accumulation of stale keys across mode switches.

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -250,7 +250,7 @@ export function getDefaultUIState(): PersistedUIState {
     lastActiveWorktreeId: null,
     sidebarWidth: 280,
     rightSidebarWidth: 350,
-    groupBy: 'none',
+    groupBy: 'repo',
     sortBy: 'recent',
     showActiveOnly: false,
     hideDefaultBranchWorkspace: false,


### PR DESCRIPTION
## Summary
- Default new UI state to group workspaces by project/repo
- Align renderer pre-hydration and hydration-error fallback defaults with the shared UI default
- Add regression coverage for folder-mode workspaces under project grouping

## Verification
- pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/worktree-list-groups.test.ts src/main/persistence.test.ts src/renderer/src/store/slices/ui.test.ts
- pnpm tsgo --noEmit -p config/tsconfig.tc.web.json
- pnpm oxlint src/renderer/src/components/sidebar/worktree-list-groups.test.ts src/shared/constants.ts src/main/persistence.test.ts src/renderer/src/App.tsx src/renderer/src/store/slices/ui.ts
- git diff --check