### PR TITLE
fix: pr-bug-scan findings from #1415 (re-applied on current main)

### DIFF
--- a/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.tsx
@@ -697,15 +697,15 @@ export function ResourceUsageStatusSegment({
     }
     void fetchSnapshot()
     void refreshSessions()
+    // Why: sessions already have an always-on poll in the effect below; only
+    // the memory snapshot is gated on the popover being open. Stacking a
+    // second sessions interval here doubled IPC traffic while the popover
+    // was open.
     const memTimer = window.setInterval(() => {
       void fetchSnapshot()
     }, POLL_MS)
-    const sessTimer = window.setInterval(() => {
-      void refreshSessions()
-    }, SESSIONS_POLL_MS)
     return () => {
       window.clearInterval(memTimer)
-      window.clearInterval(sessTimer)
     }
   }, [open, fetchSnapshot, refreshSessions])
 
@@ -791,7 +791,12 @@ export function ResourceUsageStatusSegment({
     }
   }, [snapshot])
 
-  const daemonUnreachable = sessionsError && memorySnapshotError !== null
+  // Why: memorySnapshotError is null both for "last fetch succeeded" and
+  // "never fetched". When the segment is mounted but the popover hasn't
+  // been opened, fetchMemorySnapshot has never run, so a sessions IPC
+  // failure on the always-on poll would otherwise be silent. Treat the
+  // absence of any snapshot plus a sessions error as unreachable too.
+  const daemonUnreachable = sessionsError && (memorySnapshotError !== null || snapshot === null)
   // Why: a partial failure where the sessions IPC fails but the snapshot
   // IPC still works was silently invisible after the merge — the old
   // SessionsTabPanel surfaced it as "Terminal sessions unavailable". Show
@@ -878,10 +883,17 @@ export function ResourceUsageStatusSegment({
       // bulk "Kill orphan terminals" button. Bound sessions still confirm.
       if (!session.bound) {
         setSessions((prev) => prev.filter((s) => s.id !== session.sessionId))
-        void window.api.pty.kill(session.sessionId).catch(() => {
-          /* already dead */
-        })
-        void refreshSessions()
+        // Why: await the kill before refreshing — otherwise the optimistic
+        // removal races a refresh that re-reads the daemon list before the
+        // kill lands and re-adds the row that was just removed.
+        void (async () => {
+          try {
+            await window.api.pty.kill(session.sessionId)
+          } catch {
+            /* already dead */
+          }
+          await refreshSessions()
+        })()
         return
       }
       setKillConfirm(session)
@@ -1235,62 +1247,66 @@ export function ResourceUsageStatusSegment({
             </button>
           </div>
         )}
-
-        <Dialog
-          open={killConfirm !== null}
-          onOpenChange={(next) => {
-            if (next) {
-              return
-            }
+      </PopoverContent>
+      {/* Why: Radix Dialog must not be a descendant of PopoverContent — when
+          the popover unmounts (e.g. clicking outside, focus moving to the
+          confirm dialog), the Dialog unmounts mid-interaction and the kill
+          confirm flow disappears. Hoist it to a sibling so its lifetime is
+          independent of the popover. */}
+      <Dialog
+        open={killConfirm !== null}
+        onOpenChange={(next) => {
+          if (next) {
+            return
+          }
+          if (killing) {
+            return
+          }
+          setKillConfirm(null)
+        }}
+      >
+        <DialogContent
+          className="max-w-md"
+          showCloseButton={!killing}
+          onPointerDownOutside={(e) => {
             if (killing) {
-              return
+              e.preventDefault()
             }
-            setKillConfirm(null)
+          }}
+          onEscapeKeyDown={(e) => {
+            if (killing) {
+              e.preventDefault()
+            }
           }}
         >
-          <DialogContent
-            className="max-w-md"
-            showCloseButton={!killing}
-            onPointerDownOutside={(e) => {
-              if (killing) {
-                e.preventDefault()
-              }
-            }}
-            onEscapeKeyDown={(e) => {
-              if (killing) {
-                e.preventDefault()
-              }
-            }}
-          >
-            <DialogHeader>
-              <DialogTitle className="text-sm">
-                Kill{' '}
-                <span className="font-medium text-foreground">
-                  {killConfirm?.label ?? 'this session'}
-                </span>
-                ?
-              </DialogTitle>
-              <DialogDescription className="text-xs">
-                Force-quits this terminal. Any unsaved work in the pane is lost. This can&apos;t be
-                undone.
-              </DialogDescription>
-            </DialogHeader>
-            <DialogFooter>
-              <Button variant="outline" onClick={() => setKillConfirm(null)} disabled={killing}>
-                Cancel
-              </Button>
-              <Button
-                variant="destructive"
-                onClick={() => void runKillConfirmed()}
-                disabled={killing}
-              >
-                {killing ? <LoaderCircle className="size-4 animate-spin" /> : null}
-                {killing ? 'Killing…' : 'Kill session'}
-              </Button>
-            </DialogFooter>
-          </DialogContent>
-        </Dialog>
-      </PopoverContent>
+          <DialogHeader>
+            <DialogTitle className="text-sm">
+              Kill{' '}
+              <span className="font-medium text-foreground">
+                {killConfirm?.label ?? 'this session'}
+              </span>
+              ?
+            </DialogTitle>
+            <DialogDescription className="text-xs">
+              Force-quits this terminal. Any unsaved work in the pane is lost. This can&apos;t be
+              undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setKillConfirm(null)} disabled={killing}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => void runKillConfirmed()}
+              disabled={killing}
+            >
+              {killing ? <LoaderCircle className="size-4 animate-spin" /> : null}
+              {killing ? 'Killing…' : 'Kill session'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
       <DaemonActionDialog api={daemonActions} />
     </Popover>
   )


### PR DESCRIPTION
Re-applies the four `ResourceUsageStatusSegment` fixes from #1464 on top of current main.

#1464 was branched off the #1415 merge commit and was 62 commits behind by the time it landed for review. Its 233-file diff would have silently reverted #1451 (focus right pane after clicking an agent), which reworks `navigateToTab` to thread `paneKey` through and call `activateTabAndFocusPane`. This PR is built fresh on `origin/main` and only touches `ResourceUsageStatusSegment.tsx`.

### Findings addressed (from #1415 / #1464)
- ✅ **[medium]** Orphan kill race re-adds the killed row — `await` the kill before `refreshSessions`.
- ✅ **[medium]** Duplicate sessions interval inside the open-gated effect — removed; the always-on poll below already covers it.
- ✅ **[medium]** Kill-confirm `Dialog` mounted inside `PopoverContent` — hoisted to a sibling so its lifetime is independent of the popover.
- ✅ **[low]** `daemonUnreachable` required `memorySnapshotError !== null`, so a sessions failure before the popover ever opened was silent — also treat `snapshot === null` + sessions error as unreachable.

### Verification
- `pnpm typecheck:web` — clean.
- `pnpm lint` — clean (7 pre-existing warnings, 0 new).
- `navigateToTab`/`activateTabAndFocusPane` from #1451 preserved.

Closes the intent of #1464; that PR is being closed with an audit-trail comment.