### PR TITLE
fix: pr-bug-scan findings from #1396 (reapply)

### DIFF
--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -5355,7 +5355,10 @@ export class OrcaRuntimeService {
     if (!browserPageId) {
       throw new BrowserError('browser_no_tab', 'No browser tab open in this worktree')
     }
-    const profile = browserSessionRegistry.getProfile(params.profileId)
+    // Why: 'default' is a synthetic id; fall back to the registry's default profile when not registered.
+    const profile =
+      browserSessionRegistry.getProfile(params.profileId) ??
+      (params.profileId === 'default' ? browserSessionRegistry.getDefaultProfile() : null)
     if (!profile) {
       throw new BrowserError(
         'invalid_argument',

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -468,7 +468,16 @@ export function useIpcEvents(): void {
             })
             return
           }
-          destroyPersistentWebview(data.browserPageId)
+          // Why: a workspace can host multiple browser pages; profile switch must
+          // tear down every sibling webview, not just the one referenced by the IPC.
+          const workspacePages = store.browserPagesByWorkspace[owningWorkspace.id] ?? []
+          if (workspacePages.length > 0) {
+            for (const page of workspacePages) {
+              destroyPersistentWebview(page.id)
+            }
+          } else {
+            destroyPersistentWebview(data.browserPageId)
+          }
           store.switchBrowserTabProfile(owningWorkspace.id, data.profileId)
           window.api.ui.replyTabSetProfile({ requestId: data.requestId })
         } catch (err) {


### PR DESCRIPTION
Reapplies the two fixes from #1460 on top of fresh origin/main.

#1460 was branched off the merge commit of #1396 and silently reverted ~280 files of intervening work (status-bar split, github-project view, source-control refactor, mobile rewrites, etc.) — including removing 'tab profile list' from the tab-list strings, the known regression class for #1396.

**Fixes:**
- `src/main/runtime/orca-runtime.ts` — `browserTabSetProfile` falls back to `getDefaultProfile()` when `profileId === 'default'` and isn't registered.
- `src/renderer/src/hooks/useIpcEvents.ts` — workspace profile switch destroys all sibling webviews via `browserPagesByWorkspace`, not just the IPC's referenced page.

Verified locally: `pnpm typecheck:web`, `pnpm typecheck:node`, `pnpm lint` all pass.