### PR TITLE
feat(feedback): anonymous opt-in for PR tag + contact

### DIFF
--- a/src/main/ipc/feedback.ts
+++ b/src/main/ipc/feedback.ts
@@ -13,6 +13,13 @@ export type FeedbackSubmitArgs = {
   feedback: string
   githubLogin: string | null
   githubEmail: string | null
+  // Why: when the user submits anonymously they can still volunteer a GitHub
+  // handle (so we can @-mention them on the fix PR) or a contact (email / x
+  // handle for follow-up). These are separate fields rather than reusing
+  // githubLogin/githubEmail so the backend can tell verified gh identity
+  // apart from a self-typed handle.
+  anonymousGithubLogin?: string | null
+  anonymousContact?: string | null
 }
 
 type FeedbackSubmitBody = FeedbackSubmitArgs & {

--- a/src/main/ipc/feedback.ts
+++ b/src/main/ipc/feedback.ts
@@ -14,12 +14,13 @@ export type FeedbackSubmitArgs = {
   githubLogin: string | null
   githubEmail: string | null
   // Why: when the user submits anonymously they can still volunteer a GitHub
-  // handle (so we can @-mention them on the fix PR) or a contact (email / x
-  // handle for follow-up). These are separate fields rather than reusing
+  // handle (so we can @-mention them on the fix PR), an email, or an x.com
+  // handle for follow-up. Three separate fields rather than reusing
   // githubLogin/githubEmail so the backend can tell verified gh identity
   // apart from a self-typed handle.
   anonymousGithubLogin?: string | null
-  anonymousContact?: string | null
+  anonymousEmail?: string | null
+  anonymousX?: string | null
 }
 
 type FeedbackSubmitBody = FeedbackSubmitArgs & {

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -506,6 +506,8 @@ export type PreloadApi = {
       feedback: string
       githubLogin: string | null
       githubEmail: string | null
+      anonymousGithubLogin?: string | null
+      anonymousContact?: string | null
     }) => Promise<{ ok: true } | { ok: false; status: number | null; error: string }>
   }
   export: ExportApi

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -507,7 +507,8 @@ export type PreloadApi = {
       githubLogin: string | null
       githubEmail: string | null
       anonymousGithubLogin?: string | null
-      anonymousContact?: string | null
+      anonymousEmail?: string | null
+      anonymousX?: string | null
     }) => Promise<{ ok: true } | { ok: false; status: number | null; error: string }>
   }
   export: ExportApi

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -520,7 +520,8 @@ const api = {
       githubLogin: string | null
       githubEmail: string | null
       anonymousGithubLogin?: string | null
-      anonymousContact?: string | null
+      anonymousEmail?: string | null
+      anonymousX?: string | null
     }): Promise<{ ok: true } | { ok: false; status: number | null; error: string }> =>
       ipcRenderer.invoke('feedback:submit', args)
   },

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -519,6 +519,8 @@ const api = {
       feedback: string
       githubLogin: string | null
       githubEmail: string | null
+      anonymousGithubLogin?: string | null
+      anonymousContact?: string | null
     }): Promise<{ ok: true } | { ok: false; status: number | null; error: string }> =>
       ipcRenderer.invoke('feedback:submit', args)
   },

--- a/src/renderer/src/components/sidebar/SidebarToolbar.tsx
+++ b/src/renderer/src/components/sidebar/SidebarToolbar.tsx
@@ -63,7 +63,8 @@ function FeedbackDialog({
   const [isViewerLoading, setIsViewerLoading] = useState(false)
   const [submitAnonymously, setSubmitAnonymously] = useState(false)
   const [anonGithubLogin, setAnonGithubLogin] = useState('')
-  const [anonContact, setAnonContact] = useState('')
+  const [anonEmail, setAnonEmail] = useState('')
+  const [anonX, setAnonX] = useState('')
 
   React.useEffect(() => {
     if (!open) {
@@ -119,7 +120,8 @@ function FeedbackDialog({
         // anonymous. Otherwise the regular gh identity already covers tagging
         // and contact, and we don't want to surprise non-anonymous submitters.
         anonymousGithubLogin: submitAnonymously ? normalizeOptional(anonGithubLogin) : null,
-        anonymousContact: submitAnonymously ? normalizeOptional(anonContact) : null
+        anonymousEmail: submitAnonymously ? normalizeOptional(anonEmail) : null,
+        anonymousX: submitAnonymously ? normalizeOptional(anonX) : null
       })
 
       if (!result.ok) {
@@ -130,7 +132,8 @@ function FeedbackDialog({
       setFeedback('')
       setSubmitAnonymously(false)
       setAnonGithubLogin('')
-      setAnonContact('')
+      setAnonEmail('')
+      setAnonX('')
       onOpenChange(false)
     } catch (err) {
       toast.error('Failed to submit feedback. Please try again.')
@@ -246,34 +249,32 @@ function FeedbackDialog({
           <div className="overflow-hidden">
             <div className="space-y-2 rounded-md border border-border/70 bg-muted/30 p-3">
               <div className="text-xs text-foreground">
-                If we fix the issue, we can&apos;t let you know 🥲
+                If we fix the issue, we can&apos;t let you know 🥲 (all optional)
               </div>
-              <label className="block space-y-1">
-                <span className="text-[11px] text-muted-foreground">
-                  If you leave your GitHub username, we&apos;ll tag you on the PR.
-                </span>
-                <input
-                  type="text"
-                  value={anonGithubLogin}
-                  onChange={(event) => setAnonGithubLogin(event.target.value)}
-                  placeholder="github-username (optional)"
-                  tabIndex={submitAnonymously ? 0 : -1}
-                  className="h-8 w-full rounded-md border border-border bg-background px-2 text-xs outline-none placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring"
-                />
-              </label>
-              <label className="block space-y-1">
-                <span className="text-[11px] text-muted-foreground">
-                  Optional: email or x.com handle. We&apos;ll reach out when it&apos;s fixed.
-                </span>
-                <input
-                  type="text"
-                  value={anonContact}
-                  onChange={(event) => setAnonContact(event.target.value)}
-                  placeholder="you@example.com or @handle (optional)"
-                  tabIndex={submitAnonymously ? 0 : -1}
-                  className="h-8 w-full rounded-md border border-border bg-background px-2 text-xs outline-none placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring"
-                />
-              </label>
+              <input
+                type="text"
+                value={anonGithubLogin}
+                onChange={(event) => setAnonGithubLogin(event.target.value)}
+                placeholder="GitHub username — we'll tag you on the PR"
+                tabIndex={submitAnonymously ? 0 : -1}
+                className="h-8 w-full rounded-md border border-border bg-background px-2 text-xs outline-none placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring"
+              />
+              <input
+                type="email"
+                value={anonEmail}
+                onChange={(event) => setAnonEmail(event.target.value)}
+                placeholder="Email — we'll reach out when fixed"
+                tabIndex={submitAnonymously ? 0 : -1}
+                className="h-8 w-full rounded-md border border-border bg-background px-2 text-xs outline-none placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring"
+              />
+              <input
+                type="text"
+                value={anonX}
+                onChange={(event) => setAnonX(event.target.value)}
+                placeholder="x.com handle — we'll reach out when fixed"
+                tabIndex={submitAnonymously ? 0 : -1}
+                className="h-8 w-full rounded-md border border-border bg-background px-2 text-xs outline-none placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring"
+              />
             </div>
           </div>
         </div>

--- a/src/renderer/src/components/sidebar/SidebarToolbar.tsx
+++ b/src/renderer/src/components/sidebar/SidebarToolbar.tsx
@@ -42,6 +42,14 @@ function getSubmitIdentity(viewer: GitHubViewer | null, anonymous: boolean): Sub
   }
 }
 
+// Why: when a user goes anonymous they lose the auto-attached gh identity, so
+// the only way we can tag them on the fix PR or reach out when it lands is if
+// they volunteer one of these. Strip the leading @ users tend to type.
+function normalizeOptional(value: string): string | null {
+  const trimmed = value.trim().replace(/^@+/, '')
+  return trimmed.length > 0 ? trimmed : null
+}
+
 function FeedbackDialog({
   open,
   onOpenChange
@@ -54,6 +62,8 @@ function FeedbackDialog({
   const [viewer, setViewer] = useState<GitHubViewer | null>(null)
   const [isViewerLoading, setIsViewerLoading] = useState(false)
   const [submitAnonymously, setSubmitAnonymously] = useState(false)
+  const [anonGithubLogin, setAnonGithubLogin] = useState('')
+  const [anonContact, setAnonContact] = useState('')
 
   React.useEffect(() => {
     if (!open) {
@@ -104,7 +114,12 @@ function FeedbackDialog({
       const result = await window.api.feedback.submit({
         feedback: trimmed,
         githubLogin: identity.githubLogin,
-        githubEmail: identity.githubEmail
+        githubEmail: identity.githubEmail,
+        // Why: only forward the opt-in fields when the user explicitly went
+        // anonymous. Otherwise the regular gh identity already covers tagging
+        // and contact, and we don't want to surprise non-anonymous submitters.
+        anonymousGithubLogin: submitAnonymously ? normalizeOptional(anonGithubLogin) : null,
+        anonymousContact: submitAnonymously ? normalizeOptional(anonContact) : null
       })
 
       if (!result.ok) {
@@ -114,6 +129,8 @@ function FeedbackDialog({
       toast.success('Thanks for the feedback.')
       setFeedback('')
       setSubmitAnonymously(false)
+      setAnonGithubLogin('')
+      setAnonContact('')
       onOpenChange(false)
     } catch (err) {
       toast.error('Failed to submit feedback. Please try again.')
@@ -215,6 +232,50 @@ function FeedbackDialog({
               Submit with your typed feedback only, or connect `gh` to include GitHub identity.
             </div>
           )}
+        </div>
+        {/* Why: grid-rows 0fr→1fr gives a smooth height animation without
+            measuring the DOM. Only shown when the user opts into anonymous so
+            the dialog stays compact in the common case. */}
+        <div
+          className={cn(
+            'grid transition-all duration-300 ease-out',
+            submitAnonymously ? 'mt-2 grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0'
+          )}
+          aria-hidden={!submitAnonymously}
+        >
+          <div className="overflow-hidden">
+            <div className="space-y-2 rounded-md border border-border/70 bg-muted/30 p-3">
+              <div className="text-xs text-foreground">
+                If we fix the issue, we can&apos;t let you know 🥲
+              </div>
+              <label className="block space-y-1">
+                <span className="text-[11px] text-muted-foreground">
+                  If you leave your GitHub username, we&apos;ll tag you on the PR.
+                </span>
+                <input
+                  type="text"
+                  value={anonGithubLogin}
+                  onChange={(event) => setAnonGithubLogin(event.target.value)}
+                  placeholder="github-username (optional)"
+                  tabIndex={submitAnonymously ? 0 : -1}
+                  className="h-8 w-full rounded-md border border-border bg-background px-2 text-xs outline-none placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring"
+                />
+              </label>
+              <label className="block space-y-1">
+                <span className="text-[11px] text-muted-foreground">
+                  Optional: email or x.com handle. We&apos;ll reach out when it&apos;s fixed.
+                </span>
+                <input
+                  type="text"
+                  value={anonContact}
+                  onChange={(event) => setAnonContact(event.target.value)}
+                  placeholder="you@example.com or @handle (optional)"
+                  tabIndex={submitAnonymously ? 0 : -1}
+                  className="h-8 w-full rounded-md border border-border bg-background px-2 text-xs outline-none placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring"
+                />
+              </label>
+            </div>
+          </div>
         </div>
 
         <DialogFooter>


### PR DESCRIPTION
When the user checks **Submit anonymously** in the feedback dialog, the dialog now smoothly expands to reveal two optional fields:

- **GitHub username** \u2014 if provided, we'll @-mention them on the fix PR.
- **Email or x.com handle** \u2014 if provided, we'll reach out when the issue is fixed.

The animation uses a grid-rows `0fr \u2192 1fr` transition so it expands naturally without measuring DOM. The two values are forwarded through the existing main-process IPC proxy as new optional fields `anonymousGithubLogin` / `anonymousContact` so the backend can tell a self-typed handle apart from a verified `gh` identity.

### Backend
Backwards-compatible changes ship in [orca-marketing-website#nwparker/anon-feedback-fields](https://github.com/stablyai/orca-marketing-website/pull/new/nwparker/anon-feedback-fields) \u2014 the API accepts the new fields and surfaces them in the Slack notification as a separate `Anonymous opt-in contact` field block. Older clients keep working unchanged.

### Verification
- `pnpm tc` (node, cli, web tsgo) \u2014 clean
- `pnpm lint` \u2014 only pre-existing warnings

Made with [Orca](https://github.com/stablyai/orca) 🐋
