### PR TITLE
fix(feedback): enforce anonymous submissions

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -7,7 +7,6 @@
   "rules": {
     "react/jsx-no-duplicate-props": "error",
     "react/jsx-no-undef": "error",
-    "react/jsx-uses-vars": "error",
     "react/no-children-prop": "error",
     "react/no-danger-with-children": "error",
     "react/no-direct-mutation-state": "error",

--- a/src/main/ipc/feedback.test.ts
+++ b/src/main/ipc/feedback.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const fetchMock = vi.fn()
+
+vi.mock('electron', () => ({
+  app: { getVersion: () => '1.2.3-test' },
+  ipcMain: { handle: vi.fn(), removeHandler: vi.fn() },
+  net: { fetch: (...args: unknown[]) => fetchMock(...args) }
+}))
+
+import { submitFeedback } from './feedback'
+
+function okResponse(): Response {
+  return { ok: true, status: 200 } as unknown as Response
+}
+
+function postedBody(): Record<string, unknown> {
+  const init = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined
+  return JSON.parse(String(init?.body)) as Record<string, unknown>
+}
+
+describe('submitFeedback', () => {
+  beforeEach(() => {
+    fetchMock.mockReset()
+    fetchMock.mockResolvedValue(okResponse())
+  })
+
+  it('strips GitHub identity and anonymous contact fields when submitted anonymously', async () => {
+    const anonymousArgs = {
+      feedback: 'private bug report',
+      submitAnonymously: true,
+      githubLogin: 'trusted-user',
+      githubEmail: 'trusted@example.com',
+      anonymousGithubLogin: 'trusted-user',
+      anonymousEmail: 'trusted@example.com',
+      anonymousX: 'trusted'
+    }
+    await submitFeedback(anonymousArgs)
+
+    const body = postedBody()
+    expect(body).toMatchObject({
+      feedback: 'private bug report',
+      githubLogin: null,
+      githubEmail: null,
+      appVersion: '1.2.3-test'
+    })
+    expect(body).not.toHaveProperty('anonymousGithubLogin')
+    expect(body).not.toHaveProperty('anonymousEmail')
+    expect(body).not.toHaveProperty('anonymousX')
+  })
+
+  it('preserves verified GitHub identity when not submitted anonymously', async () => {
+    await submitFeedback({
+      feedback: 'public bug report',
+      submitAnonymously: false,
+      githubLogin: 'trusted-user',
+      githubEmail: 'trusted@example.com'
+    })
+
+    const body = postedBody()
+    expect(body).toMatchObject({
+      feedback: 'public bug report',
+      githubLogin: 'trusted-user',
+      githubEmail: 'trusted@example.com',
+      appVersion: '1.2.3-test'
+    })
+  })
+})

--- a/src/main/ipc/feedback.ts
+++ b/src/main/ipc/feedback.ts
@@ -11,19 +11,15 @@ const FEEDBACK_API_FALLBACK_URL = 'https://www.onorca.dev/v1/feedback'
 
 export type FeedbackSubmitArgs = {
   feedback: string
+  submitAnonymously?: boolean
   githubLogin: string | null
   githubEmail: string | null
-  // Why: when the user submits anonymously they can still volunteer a GitHub
-  // handle (so we can @-mention them on the fix PR), an email, or an x.com
-  // handle for follow-up. Three separate fields rather than reusing
-  // githubLogin/githubEmail so the backend can tell verified gh identity
-  // apart from a self-typed handle.
-  anonymousGithubLogin?: string | null
-  anonymousEmail?: string | null
-  anonymousX?: string | null
 }
 
-type FeedbackSubmitBody = FeedbackSubmitArgs & {
+type FeedbackSubmitBody = {
+  feedback: string
+  githubLogin: string | null
+  githubEmail: string | null
   appVersion: string
   platform: NodeJS.Platform
   osRelease: string
@@ -40,8 +36,15 @@ export type FeedbackSubmitResult =
 // node os module), so we enrich the payload here rather than trusting the
 // renderer.
 function buildSubmitBody(args: FeedbackSubmitArgs): FeedbackSubmitBody {
+  const identity = args.submitAnonymously
+    ? { githubLogin: null, githubEmail: null }
+    : { githubLogin: args.githubLogin, githubEmail: args.githubEmail }
+
+  // Why: anonymity is an IPC-only privacy decision. Allow-list fields here so
+  // stale renderer state or future identity-shaped fields cannot leak upstream.
   return {
-    ...args,
+    feedback: args.feedback,
+    ...identity,
     appVersion: app.getVersion(),
     platform: process.platform,
     osRelease: os.release(),

--- a/src/main/runtime/rpc/methods/browser-schemas.ts
+++ b/src/main/runtime/rpc/methods/browser-schemas.ts
@@ -46,6 +46,7 @@ export const Scroll = BrowserTarget.extend({
     .unknown()
     .transform((v) => (typeof v === 'number' && v > 0 ? v : undefined))
     .pipe(z.number().optional())
+    .optional()
 })
 
 export const Screenshot = BrowserTarget.extend({
@@ -53,6 +54,7 @@ export const Screenshot = BrowserTarget.extend({
     .unknown()
     .transform((v) => (v === 'png' || v === 'jpeg' ? v : undefined))
     .pipe(z.enum(['png', 'jpeg']).optional())
+    .optional()
 })
 
 export const FullScreenshot = BrowserTarget.extend({
@@ -78,6 +80,7 @@ export const TabSwitch = BrowserTarget.extend({
     .unknown()
     .transform((v) => (typeof v === 'number' ? v : undefined))
     .pipe(z.number().optional())
+    .optional()
 }).refine(
   (val) => {
     if (val.page !== undefined) {
@@ -107,7 +110,8 @@ export const TabClose = z.object({
   index: z
     .unknown()
     .transform((v) => (typeof v === 'number' ? v : undefined))
-    .pipe(z.number().optional()),
+    .pipe(z.number().optional())
+    .optional(),
   page: OptionalString,
   worktree: OptionalString
 })
@@ -149,7 +153,8 @@ export const Wait = BrowserTarget.extend({
   timeout: z
     .unknown()
     .transform((v) => (typeof v === 'number' && v > 0 ? v : undefined))
-    .pipe(z.number().optional()),
+    .pipe(z.number().optional())
+    .optional(),
   text: OptionalPlainString,
   url: OptionalPlainString,
   load: OptionalPlainString,
@@ -262,6 +267,7 @@ export const InterceptEnable = BrowserTarget.extend({
     .unknown()
     .transform((v) => (Array.isArray(v) ? (v as string[]) : undefined))
     .pipe(z.array(z.string()).optional())
+    .optional()
 })
 
 export const MouseXY = BrowserTarget.extend({

--- a/src/main/runtime/rpc/methods/terminal.ts
+++ b/src/main/runtime/rpc/methods/terminal.ts
@@ -44,6 +44,7 @@ const TerminalRead = TerminalHandle.extend({
           message: 'Cursor must be a non-negative integer'
         })
     )
+    .optional()
 })
 
 // Why: the legacy handler allowed `title: string | null` and rejected every
@@ -89,7 +90,8 @@ const TerminalSplit = TerminalHandle.extend({
   direction: z
     .unknown()
     .transform((v) => (v === 'vertical' || v === 'horizontal' ? v : undefined))
-    .pipe(z.enum(['vertical', 'horizontal']).optional()),
+    .pipe(z.enum(['vertical', 'horizontal']).optional())
+    .optional(),
   command: OptionalString
 })
 

--- a/src/main/runtime/rpc/methods/worktree.ts
+++ b/src/main/runtime/rpc/methods/worktree.ts
@@ -38,7 +38,8 @@ const WorktreeCreate = z.object({
     .transform((v) =>
       typeof v === 'string' && (v === 'run' || v === 'skip' || v === 'inherit') ? v : undefined
     )
-    .pipe(z.enum(['run', 'skip', 'inherit']).optional()),
+    .pipe(z.enum(['run', 'skip', 'inherit']).optional())
+    .optional(),
   // Why: mobile clients pass a startup command (e.g. 'claude') so the first
   // terminal pane launches the selected agent instead of an idle shell.
   startupCommand: OptionalString

--- a/src/main/runtime/rpc/schemas.ts
+++ b/src/main/runtime/rpc/schemas.ts
@@ -8,10 +8,13 @@ import { z } from 'zod'
 // Why: the original handlers treated non-numeric/NaN limit values as "no
 // limit" rather than as errors. Preserve that forgiving behavior so CLI
 // callers passing stringified numbers or Infinity still reach the runtime.
+// The outer optional() is required for omitted keys in Zod v4; an optional
+// schema hidden behind pipe() still makes z.object require the property.
 export const OptionalFiniteNumber = z
   .unknown()
   .transform((value) => (typeof value === 'number' && Number.isFinite(value) ? value : undefined))
   .pipe(z.number().optional())
+  .optional()
 
 export const OptionalPositiveInt = z
   .unknown()
@@ -19,21 +22,25 @@ export const OptionalPositiveInt = z
     typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : undefined
   )
   .pipe(z.number().optional())
+  .optional()
 
 export const OptionalString = z
   .unknown()
   .transform((value) => (typeof value === 'string' && value.length > 0 ? value : undefined))
   .pipe(z.string().optional())
+  .optional()
 
 export const OptionalPlainString = z
   .unknown()
   .transform((value) => (typeof value === 'string' ? value : undefined))
   .pipe(z.string().optional())
+  .optional()
 
 export const OptionalBoolean = z
   .unknown()
   .transform((value) => (typeof value === 'boolean' ? value : undefined))
   .pipe(z.boolean().optional())
+  .optional()
 
 // Why: runtime handlers accept `linkedIssue: number | null | undefined` with
 // distinct meanings — undefined means "no update", null means "clear", number
@@ -50,6 +57,7 @@ export const TriStateLinkedIssue = z
     return undefined
   })
   .pipe(z.union([z.number(), z.null(), z.undefined()]))
+  .optional()
 
 // Why: the legacy extractBrowserTarget treated worktree as a plain-string
 // passthrough (empty string preserved) but `page` as non-empty-string. The

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -504,11 +504,9 @@ export type PreloadApi = {
   feedback: {
     submit: (args: {
       feedback: string
+      submitAnonymously?: boolean
       githubLogin: string | null
       githubEmail: string | null
-      anonymousGithubLogin?: string | null
-      anonymousEmail?: string | null
-      anonymousX?: string | null
     }) => Promise<{ ok: true } | { ok: false; status: number | null; error: string }>
   }
   export: ExportApi

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -517,11 +517,9 @@ const api = {
   feedback: {
     submit: (args: {
       feedback: string
+      submitAnonymously?: boolean
       githubLogin: string | null
       githubEmail: string | null
-      anonymousGithubLogin?: string | null
-      anonymousEmail?: string | null
-      anonymousX?: string | null
     }): Promise<{ ok: true } | { ok: false; status: number | null; error: string }> =>
       ipcRenderer.invoke('feedback:submit', args)
   },

--- a/src/renderer/src/components/editor/RichMarkdownErrorBoundary.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownErrorBoundary.tsx
@@ -7,6 +7,7 @@ type Props = {
 
 type State = {
   error: Error | null
+  fileId: string
 }
 
 // Why: a thrown exception inside the TipTap/ProseMirror render or in the
@@ -19,20 +20,22 @@ type State = {
 // switches tabs so a transient failure doesn't permanently disable the
 // rich editor for that pane.
 export class RichMarkdownErrorBoundary extends React.Component<Props, State> {
-  state: State = { error: null }
+  state: State = { error: null, fileId: this.props.fileId }
 
-  static getDerivedStateFromError(error: Error): State {
+  static getDerivedStateFromProps(props: Props, state: State): Partial<State> | null {
+    if (props.fileId !== state.fileId) {
+      return { error: null, fileId: props.fileId }
+    }
+
+    return null
+  }
+
+  static getDerivedStateFromError(error: Error): Partial<State> {
     return { error }
   }
 
   componentDidCatch(error: Error, info: React.ErrorInfo): void {
     console.error('[RichMarkdownEditor] render crash contained by boundary', error, info)
-  }
-
-  componentDidUpdate(prevProps: Props): void {
-    if (prevProps.fileId !== this.props.fileId && this.state.error) {
-      this.setState({ error: null })
-    }
   }
 
   handleReset = (): void => {

--- a/src/renderer/src/components/sidebar/SidebarToolbar.tsx
+++ b/src/renderer/src/components/sidebar/SidebarToolbar.tsx
@@ -42,14 +42,6 @@ function getSubmitIdentity(viewer: GitHubViewer | null, anonymous: boolean): Sub
   }
 }
 
-// Why: when a user goes anonymous they lose the auto-attached gh identity, so
-// the only way we can tag them on the fix PR or reach out when it lands is if
-// they volunteer one of these. Strip the leading @ users tend to type.
-function normalizeOptional(value: string): string | null {
-  const trimmed = value.trim().replace(/^@+/, '')
-  return trimmed.length > 0 ? trimmed : null
-}
-
 function FeedbackDialog({
   open,
   onOpenChange
@@ -62,9 +54,6 @@ function FeedbackDialog({
   const [viewer, setViewer] = useState<GitHubViewer | null>(null)
   const [isViewerLoading, setIsViewerLoading] = useState(false)
   const [submitAnonymously, setSubmitAnonymously] = useState(false)
-  const [anonGithubLogin, setAnonGithubLogin] = useState('')
-  const [anonEmail, setAnonEmail] = useState('')
-  const [anonX, setAnonX] = useState('')
 
   React.useEffect(() => {
     if (!open) {
@@ -114,14 +103,9 @@ function FeedbackDialog({
       // and prod.
       const result = await window.api.feedback.submit({
         feedback: trimmed,
+        submitAnonymously,
         githubLogin: identity.githubLogin,
-        githubEmail: identity.githubEmail,
-        // Why: only forward the opt-in fields when the user explicitly went
-        // anonymous. Otherwise the regular gh identity already covers tagging
-        // and contact, and we don't want to surprise non-anonymous submitters.
-        anonymousGithubLogin: submitAnonymously ? normalizeOptional(anonGithubLogin) : null,
-        anonymousEmail: submitAnonymously ? normalizeOptional(anonEmail) : null,
-        anonymousX: submitAnonymously ? normalizeOptional(anonX) : null
+        githubEmail: identity.githubEmail
       })
 
       if (!result.ok) {
@@ -131,9 +115,6 @@ function FeedbackDialog({
       toast.success('Thanks for the feedback.')
       setFeedback('')
       setSubmitAnonymously(false)
-      setAnonGithubLogin('')
-      setAnonEmail('')
-      setAnonX('')
       onOpenChange(false)
     } catch (err) {
       toast.error('Failed to submit feedback. Please try again.')
@@ -236,49 +217,6 @@ function FeedbackDialog({
             </div>
           )}
         </div>
-        {/* Why: grid-rows 0fr→1fr gives a smooth height animation without
-            measuring the DOM. Only shown when the user opts into anonymous so
-            the dialog stays compact in the common case. */}
-        <div
-          className={cn(
-            'grid transition-all duration-300 ease-out',
-            submitAnonymously ? 'mt-2 grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0'
-          )}
-          aria-hidden={!submitAnonymously}
-        >
-          <div className="overflow-hidden">
-            <div className="space-y-2 rounded-md border border-border/70 bg-muted/30 p-3">
-              <div className="text-xs text-foreground">
-                If we fix the issue, we can&apos;t let you know 🥲 (all optional)
-              </div>
-              <input
-                type="text"
-                value={anonGithubLogin}
-                onChange={(event) => setAnonGithubLogin(event.target.value)}
-                placeholder="GitHub username — we'll tag you on the PR"
-                tabIndex={submitAnonymously ? 0 : -1}
-                className="h-8 w-full rounded-md border border-border bg-background px-2 text-xs outline-none placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring"
-              />
-              <input
-                type="email"
-                value={anonEmail}
-                onChange={(event) => setAnonEmail(event.target.value)}
-                placeholder="Email — we'll reach out when fixed"
-                tabIndex={submitAnonymously ? 0 : -1}
-                className="h-8 w-full rounded-md border border-border bg-background px-2 text-xs outline-none placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring"
-              />
-              <input
-                type="text"
-                value={anonX}
-                onChange={(event) => setAnonX(event.target.value)}
-                placeholder="x.com handle — we'll reach out when fixed"
-                tabIndex={submitAnonymously ? 0 : -1}
-                className="h-8 w-full rounded-md border border-border bg-background px-2 text-xs outline-none placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring"
-              />
-            </div>
-          </div>
-        </div>
-
         <DialogFooter>
           <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isSubmitting}>
             Cancel


### PR DESCRIPTION
## Summary
- make feedback anonymity an explicit IPC flag and allow-list the backend POST body
- remove anonymous contact fields so checked anonymous never sends identity/contact data upstream
- add regression coverage for stale identity/contact fields in anonymous feedback payloads
- unblock current oxlint config parsing and replace the rich markdown boundary reset with derived state so full lint can run

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/feedback.test.ts
- pnpm run tc:node
- pnpm run tc:web
- pnpm lint
- pnpm exec oxfmt --check .oxlintrc.json src/main/ipc/feedback.ts src/main/ipc/feedback.test.ts src/preload/index.ts src/preload/api-types.ts src/renderer/src/components/sidebar/SidebarToolbar.tsx src/renderer/src/components/editor/RichMarkdownErrorBoundary.tsx