### PR TITLE
Linear: paste only URL as draft on workspace create

### DIFF
--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -1179,20 +1179,11 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
         setName(suggestedName)
         lastAutoNameRef.current = suggestedName
       }
-      const details = [
-        `[${issue.identifier}] ${issue.title}`,
-        `Status: ${issue.state.name} · Team: ${issue.team.name}`,
-        issue.assignee ? `Assignee: ${issue.assignee.displayName}` : null,
-        issue.labels.length > 0 ? `Labels: ${issue.labels.join(', ')}` : null,
-        `URL: ${issue.url}`,
-        issue.description ? `\n${issue.description}` : null
-      ]
-        .filter(Boolean)
-        .join('\n')
-      if (!noteRef.current.trim() || noteRef.current === lastAutoNoteRef.current) {
-        setNote(details)
-        lastAutoNoteRef.current = details
-      }
+      // Why: match the GitHub issue/PR flow — paste only the URL as a draft
+      // into the agent's input (no auto-submit). The launch path already
+      // drafts `linkedWorkItem.url` when the note is empty; auto-filling the
+      // note here would flip Linear into the `isLinearTypedOnly` branch and
+      // auto-submit the full details block.
     },
     [name]
   )


### PR DESCRIPTION
## Problem

Creating a workspace via 'create from' with a GitHub issue/PR pastes just the URL into the agent's input as a draft (no auto-submit). But Linear pastes a full details block (ID, title, status, team, assignee, labels, URL, description) **and auto-submits** it.

## Fix

`handleSmartLinearIssueSelect` (`src/renderer/src/hooks/useComposerState.ts`) was auto-filling the composer's note field with the multi-line details block. At launch, because Linear items use `number === 0`, the composer's `isLinearTypedOnly` branch fired and sent that note to the agent as a prompt — which submits.

Stop auto-filling the note. With an empty note, Linear falls into the same launch branch GitHub uses:

```ts
const quickDraftPrompt = linkedWorkItem && !isLinearTypedOnly ? linkedWorkItem.url : null
```

…which types only the URL into the agent's input as a draft (no Enter). Workspace name still auto-fills with the issue title (separate field, untouched).

## Test plan

- Open new-workspace composer, pick a Linear issue → name field auto-fills with title; agent input gets only the issue URL as a draft (no submit).
- Pick a GitHub issue/PR → unchanged (URL drafted, no submit).
- Manually typing a note before submit still works (and for hand-typed Linear identifiers without a URL, the existing typed-only fallback still sends the note).

Made with [Orca](https://github.com/stablyai/orca) 🐋
