### PR TITLE
Mobile: indefinite phone-fit hold + configurable auto-restore

### DIFF
--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -102,6 +102,7 @@ export default function RootLayout() {
           <Stack.Screen name="pair-scan" options={{ headerShown: false }} />
           <Stack.Screen name="pair-confirm" options={{ headerShown: false }} />
           <Stack.Screen name="settings" options={{ headerShown: false }} />
+          <Stack.Screen name="terminal-settings" options={{ headerShown: false }} />
           <Stack.Screen name="notifications" options={{ headerShown: false }} />
           <Stack.Screen name="troubleshoot" options={{ headerShown: false }} />
           <Stack.Screen name="about" options={{ headerShown: false }} />

--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -238,13 +238,6 @@ export default function SessionScreen() {
       const seq = (subscribeSeqRef.current.get(handle) ?? 0) + 1
       subscribeSeqRef.current.set(handle, seq)
 
-      console.log('[fit][session] subscribe', {
-        handle: handle.slice(-8),
-        seq,
-        viewport: viewportRef.current,
-        viewportMeasured: viewportMeasuredRef.current
-      })
-
       // Why: server handles auto-fit on subscribe — no terminal.focus call needed.
       // The viewport is embedded in the subscribe params so the server resizes
       // the PTY before serializing scrollback. This eliminates the focus→safeFit
@@ -287,24 +280,8 @@ export default function SessionScreen() {
           } else if (eventSeq != null && data.type === 'scrollback') {
             layoutSeqRef.current.set(handle, eventSeq)
           }
-          if (data.type === 'scrollback' || data.type === 'resized') {
-            console.log('[fit][session] event', {
-              handle: handle.slice(-8),
-              type: data.type,
-              cols: data.cols,
-              rows: data.rows,
-              displayMode: data.displayMode,
-              seq: eventSeq,
-              reason: data.reason
-            })
-          }
           if (data.type === 'scrollback') {
             if (initializedHandlesRef.current.has(handle)) {
-              console.log('[fit][session] scrollback IGNORED (already initialized)', {
-                handle: handle.slice(-8),
-                cols: data.cols,
-                rows: data.rows
-              })
               return
             }
             const cols = (data.cols as number) || 80
@@ -358,10 +335,6 @@ export default function SessionScreen() {
                   scrollbackRows !== viewportRef.current.rows))
             if (needsResubscribe) {
               void (async () => {
-                console.log('[fit][session] post-scrollback measure-start', {
-                  handle: handle.slice(-8),
-                  containerHeight: terminalFrameHeightRef.current
-                })
                 // Why: wait for the WebView's init() rAF chain to fully
                 // run (term.open → renderService population → first
                 // paint) before measuring. Without this, the measure
@@ -381,20 +354,11 @@ export default function SessionScreen() {
                 // raced ahead via a parallel `measureViewportOnce`, the
                 // server still has a null viewport for THIS subscriber
                 // record — we MUST resubscribe so the server stores it.
-                console.log('[fit][session] post-scrollback measure-result', {
-                  handle: handle.slice(-8),
-                  dims,
-                  alreadyMeasured: viewportMeasuredRef.current
-                })
                 if (dims) {
                   viewportRef.current = dims
                   viewportMeasuredRef.current = true
                   unsubscribeTerminal(handle)
                   initializedHandlesRef.current.delete(handle)
-                  console.log('[fit][session] post-scrollback re-subscribe', {
-                    handle: handle.slice(-8),
-                    viewport: dims
-                  })
                   subscribeToTerminal(handle)
                 }
               })()
@@ -465,11 +429,6 @@ export default function SessionScreen() {
       // not a setting. The toggle only ever requests 'auto' or 'desktop'.
       const next: 'auto' | 'desktop' =
         current === 'auto' || current === 'phone' ? 'desktop' : 'auto'
-      console.log('[fit][session] toggleDisplayMode', {
-        handle: handle.slice(-8),
-        current,
-        next
-      })
       toggleInFlightRef.current.add(handle)
       try {
         await client.sendRequest('terminal.setDisplayMode', {

--- a/mobile/app/settings.tsx
+++ b/mobile/app/settings.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useMemo, useState } from 'react'
 import { View, Text, StyleSheet, Pressable, Linking } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useRouter } from 'expo-router'
@@ -10,135 +9,13 @@ import {
   Wrench,
   Shield,
   LifeBuoy,
-  Smartphone
+  Terminal as TerminalIcon
 } from 'lucide-react-native'
 import { colors, spacing, typography } from '../src/theme/mobile-theme'
-import { loadHosts } from '../src/transport/host-store'
-import type { HostProfile } from '../src/transport/types'
-import { useAllHostClients } from '../src/transport/client-context'
-import type { RpcClient } from '../src/transport/rpc-client'
-
-// Why: mirrors the desktop labels but compressed to fit a phone row.
-// The compact-summary form (rowSublabel) shows the *currently chosen*
-// behavior in plain language; the option rows use the same compact
-// phrasing. The server clamps anything outside [5_000, 60min].
-// See docs/mobile-fit-hold.md.
-const AUTO_RESTORE_FIT_OPTIONS: {
-  value: string
-  label: string
-  ms: number | null
-}[] = [
-  { value: 'indefinite', label: 'Keep at phone size (default)', ms: null },
-  { value: '60s', label: 'After 1 minute', ms: 60_000 },
-  { value: '5m', label: 'After 5 minutes', ms: 5 * 60_000 },
-  { value: '30m', label: 'After 30 minutes', ms: 30 * 60_000 }
-]
-
-function autoRestoreSummary(ms: number | null | undefined): string {
-  if (ms === undefined) return '…'
-  if (ms === null) return AUTO_RESTORE_FIT_OPTIONS[0]!.label
-  const exact = AUTO_RESTORE_FIT_OPTIONS.find((o) => o.ms === ms)
-  return exact ? exact.label : `After ${Math.round(ms / 1000)}s`
-}
-
-// Why: a single small inline picker. We avoid pulling in a full picker
-// dependency by toggling visible-rows on press — same pattern as the
-// other lightweight inline pickers in the mobile shell.
-function AutoRestoreFitRow({
-  client,
-  hostName
-}: {
-  client: RpcClient | null
-  hostName: string
-}): React.JSX.Element {
-  const [ms, setMs] = useState<number | null | undefined>(undefined)
-  const [expanded, setExpanded] = useState(false)
-
-  useEffect(() => {
-    if (!client) return
-    let cancelled = false
-    void client
-      .sendRequest('terminal.getAutoRestoreFit')
-      .then((resp) => {
-        if (cancelled) return
-        const value = (resp as { ms?: number | null } | null)?.ms
-        setMs(value === undefined ? null : value)
-      })
-      .catch(() => {
-        if (!cancelled) setMs(null)
-      })
-    return () => {
-      cancelled = true
-    }
-  }, [client])
-
-  async function selectOption(opt: { value: string; label: string; ms: number | null }) {
-    if (!client) return
-    setExpanded(false)
-    setMs(opt.ms)
-    try {
-      const resp = (await client.sendRequest('terminal.setAutoRestoreFit', {
-        ms: opt.ms
-      })) as { ms?: number | null } | null
-      const finalMs = resp?.ms === undefined ? null : resp.ms
-      setMs(finalMs)
-    } catch {
-      // Server-side clamp/persistence failed; refetch to resync.
-      try {
-        const resp = (await client.sendRequest('terminal.getAutoRestoreFit')) as {
-          ms?: number | null
-        } | null
-        setMs(resp?.ms === undefined ? null : resp.ms)
-      } catch {
-        // give up silently — the next mount retries
-      }
-    }
-  }
-
-  return (
-    <View>
-      <Pressable
-        style={({ pressed }) => [styles.row, pressed && styles.rowPressed]}
-        onPress={() => setExpanded((v) => !v)}
-      >
-        <Smartphone size={16} color={colors.textSecondary} />
-        <View style={{ flex: 1 }}>
-          <Text style={styles.rowLabel}>{hostName}</Text>
-          <Text style={styles.rowSublabel}>{autoRestoreSummary(ms)}</Text>
-        </View>
-        <ChevronRight
-          size={16}
-          color={colors.textMuted}
-          style={{ transform: [{ rotate: expanded ? '90deg' : '0deg' }] }}
-        />
-      </Pressable>
-      {expanded &&
-        AUTO_RESTORE_FIT_OPTIONS.map((opt) => (
-          <Pressable
-            key={opt.value}
-            style={({ pressed }) => [
-              styles.optionRow,
-              pressed && styles.rowPressed,
-              opt.ms === (ms ?? null) && styles.optionRowSelected
-            ]}
-            onPress={() => void selectOption(opt)}
-          >
-            <Text style={styles.optionLabel}>{opt.label}</Text>
-          </Pressable>
-        ))}
-    </View>
-  )
-}
 
 export default function SettingsScreen() {
   const router = useRouter()
   const insets = useSafeAreaInsets()
-  const [hosts, setHosts] = useState<HostProfile[]>([])
-  useEffect(() => {
-    void loadHosts().then(setHosts)
-  }, [])
-  const hostIds = useMemo(() => hosts.map((h) => h.id), [hosts])
-  const hostClients = useAllHostClients(hostIds)
 
   return (
     <View style={[styles.container, { paddingTop: insets.top + spacing.sm }]}>
@@ -150,6 +27,15 @@ export default function SettingsScreen() {
       </View>
 
       <View style={styles.section}>
+        <Pressable
+          style={({ pressed }) => [styles.row, pressed && styles.rowPressed]}
+          onPress={() => router.push('/terminal-settings')}
+        >
+          <TerminalIcon size={16} color={colors.textSecondary} />
+          <Text style={styles.rowLabel}>Terminal</Text>
+          <ChevronRight size={16} color={colors.textMuted} />
+        </Pressable>
+        <View style={styles.separator} />
         <Pressable
           style={({ pressed }) => [styles.row, pressed && styles.rowPressed]}
           onPress={() => router.push('/notifications')}
@@ -177,21 +63,6 @@ export default function SettingsScreen() {
           <ChevronRight size={16} color={colors.textMuted} />
         </Pressable>
       </View>
-
-      {hosts.length > 0 && (
-        <View style={[styles.section, styles.sectionSpacer]}>
-          <Text style={styles.sectionHeading}>When you leave the app</Text>
-          {hosts.map((host, idx) => {
-            const entry = hostClients.find((e) => e.hostId === host.id)
-            return (
-              <View key={host.id}>
-                {idx > 0 && <View style={styles.separator} />}
-                <AutoRestoreFitRow client={entry?.client ?? null} hostName={host.name} />
-              </View>
-            )
-          })}
-        </View>
-      )}
 
       <View style={[styles.section, styles.sectionSpacer]}>
         <Pressable
@@ -260,31 +131,6 @@ const styles = StyleSheet.create({
     flex: 1,
     fontSize: typography.bodySize,
     fontWeight: '500',
-    color: colors.textPrimary
-  },
-  rowSublabel: {
-    fontSize: typography.bodySize - 2,
-    color: colors.textSecondary,
-    marginTop: 2
-  },
-  sectionHeading: {
-    fontSize: typography.bodySize - 2,
-    fontWeight: '600',
-    color: colors.textSecondary,
-    paddingHorizontal: spacing.md + 2,
-    paddingTop: spacing.sm + 2,
-    paddingBottom: spacing.xs
-  },
-  optionRow: {
-    paddingVertical: spacing.sm + 2,
-    paddingHorizontal: spacing.md + 2 + 22 + spacing.sm + 2,
-    backgroundColor: colors.bgRaised
-  },
-  optionRowSelected: {
-    backgroundColor: colors.bgPanel
-  },
-  optionLabel: {
-    fontSize: typography.bodySize,
     color: colors.textPrimary
   },
   separator: {

--- a/mobile/app/settings.tsx
+++ b/mobile/app/settings.tsx
@@ -28,7 +28,7 @@ const AUTO_RESTORE_FIT_OPTIONS: {
   label: string
   ms: number | null
 }[] = [
-  { value: 'indefinite', label: 'Keep at phone size', ms: null },
+  { value: 'indefinite', label: 'Keep at phone size (default)', ms: null },
   { value: '60s', label: 'After 1 minute', ms: 60_000 },
   { value: '5m', label: 'After 5 minutes', ms: 5 * 60_000 },
   { value: '30m', label: 'After 30 minutes', ms: 30 * 60_000 }

--- a/mobile/app/settings.tsx
+++ b/mobile/app/settings.tsx
@@ -18,20 +18,50 @@ import type { HostProfile } from '../src/transport/types'
 import { useAllHostClients } from '../src/transport/client-context'
 import type { RpcClient } from '../src/transport/rpc-client'
 
-// Why: must mirror the desktop preset list so the two surfaces stay in
-// sync. The server clamps anything outside [5_000, 60min] (see
-// docs/mobile-fit-hold.md).
-const AUTO_RESTORE_FIT_OPTIONS: { value: string; label: string; ms: number | null }[] = [
-  { value: 'indefinite', label: 'Indefinite', ms: null },
-  { value: '60s', label: '1 minute', ms: 60_000 },
-  { value: '5m', label: '5 minutes', ms: 5 * 60_000 },
-  { value: '30m', label: '30 minutes', ms: 30 * 60_000 }
+// Why: mirrors the desktop labels but compressed to fit a phone row.
+// The compact-summary form (rowSublabel) shows the *currently chosen*
+// behavior in plain language; the option rows use the same compact
+// phrasing. The server clamps anything outside [5_000, 60min].
+// See docs/mobile-fit-hold.md.
+const AUTO_RESTORE_FIT_OPTIONS: {
+  value: string
+  label: string
+  summary: string
+  ms: number | null
+}[] = [
+  {
+    value: 'indefinite',
+    label: 'Keep at phone size',
+    summary: 'Stays at phone size until you tap Restore',
+    ms: null
+  },
+  {
+    value: '60s',
+    label: 'Resize to desktop after 1 min',
+    summary: 'Resizes to desktop 1 minute after you leave',
+    ms: 60_000
+  },
+  {
+    value: '5m',
+    label: 'Resize to desktop after 5 min',
+    summary: 'Resizes to desktop 5 minutes after you leave',
+    ms: 5 * 60_000
+  },
+  {
+    value: '30m',
+    label: 'Resize to desktop after 30 min',
+    summary: 'Resizes to desktop 30 minutes after you leave',
+    ms: 30 * 60_000
+  }
 ]
 
-function autoRestoreLabel(ms: number | null | undefined): string {
-  if (ms == null) return 'Indefinite'
+function autoRestoreSummary(ms: number | null | undefined): string {
+  if (ms === undefined) return '…'
+  if (ms == null) {
+    return AUTO_RESTORE_FIT_OPTIONS[0]!.summary
+  }
   const exact = AUTO_RESTORE_FIT_OPTIONS.find((o) => o.ms === ms)
-  return exact ? exact.label : `${Math.round(ms / 1000)}s`
+  return exact ? exact.summary : `Resizes to desktop ${Math.round(ms / 1000)}s after you leave`
 }
 
 // Why: a single small inline picker. We avoid pulling in a full picker
@@ -97,7 +127,7 @@ function AutoRestoreFitRow({
         <Smartphone size={16} color={colors.textSecondary} />
         <View style={{ flex: 1 }}>
           <Text style={styles.rowLabel}>{hostName}</Text>
-          <Text style={styles.rowSublabel}>Auto-restore: {autoRestoreLabel(ms)}</Text>
+          <Text style={styles.rowSublabel}>{autoRestoreSummary(ms)}</Text>
         </View>
         <ChevronRight
           size={16}
@@ -173,7 +203,7 @@ export default function SettingsScreen() {
 
       {hosts.length > 0 && (
         <View style={[styles.section, styles.sectionSpacer]}>
-          <Text style={styles.sectionHeading}>Terminal width hold</Text>
+          <Text style={styles.sectionHeading}>When you leave the app</Text>
           {hosts.map((host, idx) => {
             const entry = hostClients.find((e) => e.hostId === host.id)
             return (

--- a/mobile/app/settings.tsx
+++ b/mobile/app/settings.tsx
@@ -26,42 +26,18 @@ import type { RpcClient } from '../src/transport/rpc-client'
 const AUTO_RESTORE_FIT_OPTIONS: {
   value: string
   label: string
-  summary: string
   ms: number | null
 }[] = [
-  {
-    value: 'indefinite',
-    label: 'Keep at phone size',
-    summary: 'Stays at phone size until you tap Restore',
-    ms: null
-  },
-  {
-    value: '60s',
-    label: 'Resize to desktop after 1 min',
-    summary: 'Resizes to desktop 1 minute after you leave',
-    ms: 60_000
-  },
-  {
-    value: '5m',
-    label: 'Resize to desktop after 5 min',
-    summary: 'Resizes to desktop 5 minutes after you leave',
-    ms: 5 * 60_000
-  },
-  {
-    value: '30m',
-    label: 'Resize to desktop after 30 min',
-    summary: 'Resizes to desktop 30 minutes after you leave',
-    ms: 30 * 60_000
-  }
+  { value: 'indefinite', label: 'Keep at phone size', ms: null },
+  { value: '60s', label: 'After 1 minute', ms: 60_000 },
+  { value: '5m', label: 'After 5 minutes', ms: 5 * 60_000 },
+  { value: '30m', label: 'After 30 minutes', ms: 30 * 60_000 }
 ]
 
 function autoRestoreSummary(ms: number | null | undefined): string {
   if (ms === undefined) return '…'
-  if (ms == null) {
-    return AUTO_RESTORE_FIT_OPTIONS[0]!.summary
-  }
-  const exact = AUTO_RESTORE_FIT_OPTIONS.find((o) => o.ms === ms)
-  return exact ? exact.summary : `Resizes to desktop ${Math.round(ms / 1000)}s after you leave`
+  const exact = ms == null ? AUTO_RESTORE_FIT_OPTIONS[0]! : AUTO_RESTORE_FIT_OPTIONS.find((o) => o.ms === ms)
+  return exact ? exact.label : `After ${Math.round(ms / 1000)}s`
 }
 
 // Why: a single small inline picker. We avoid pulling in a full picker

--- a/mobile/app/settings.tsx
+++ b/mobile/app/settings.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useMemo, useState } from 'react'
 import { View, Text, StyleSheet, Pressable, Linking } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useRouter } from 'expo-router'
@@ -8,13 +9,129 @@ import {
   Bell,
   Wrench,
   Shield,
-  LifeBuoy
+  LifeBuoy,
+  Smartphone
 } from 'lucide-react-native'
 import { colors, spacing, typography } from '../src/theme/mobile-theme'
+import { loadHosts } from '../src/transport/host-store'
+import type { HostProfile } from '../src/transport/types'
+import { useAllHostClients } from '../src/transport/client-context'
+import type { RpcClient } from '../src/transport/rpc-client'
+
+// Why: must mirror the desktop preset list so the two surfaces stay in
+// sync. The server clamps anything outside [5_000, 60min] (see
+// docs/mobile-fit-hold.md).
+const AUTO_RESTORE_FIT_OPTIONS: { value: string; label: string; ms: number | null }[] = [
+  { value: 'indefinite', label: 'Indefinite', ms: null },
+  { value: '60s', label: '1 minute', ms: 60_000 },
+  { value: '5m', label: '5 minutes', ms: 5 * 60_000 },
+  { value: '30m', label: '30 minutes', ms: 30 * 60_000 }
+]
+
+function autoRestoreLabel(ms: number | null | undefined): string {
+  if (ms == null) return 'Indefinite'
+  const exact = AUTO_RESTORE_FIT_OPTIONS.find((o) => o.ms === ms)
+  return exact ? exact.label : `${Math.round(ms / 1000)}s`
+}
+
+// Why: a single small inline picker. We avoid pulling in a full picker
+// dependency by toggling visible-rows on press — same pattern as the
+// other lightweight inline pickers in the mobile shell.
+function AutoRestoreFitRow({
+  client,
+  hostName
+}: {
+  client: RpcClient | null
+  hostName: string
+}): React.JSX.Element {
+  const [ms, setMs] = useState<number | null | undefined>(undefined)
+  const [expanded, setExpanded] = useState(false)
+
+  useEffect(() => {
+    if (!client) return
+    let cancelled = false
+    void client
+      .sendRequest('terminal.getAutoRestoreFit')
+      .then((resp) => {
+        if (cancelled) return
+        const value = (resp as { ms?: number | null } | null)?.ms
+        setMs(value === undefined ? null : value)
+      })
+      .catch(() => {
+        if (!cancelled) setMs(null)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [client])
+
+  async function selectOption(opt: { value: string; label: string; ms: number | null }) {
+    if (!client) return
+    setExpanded(false)
+    setMs(opt.ms)
+    try {
+      const resp = (await client.sendRequest('terminal.setAutoRestoreFit', {
+        ms: opt.ms
+      })) as { ms?: number | null } | null
+      const finalMs = resp?.ms === undefined ? null : resp.ms
+      setMs(finalMs)
+    } catch {
+      // Server-side clamp/persistence failed; refetch to resync.
+      try {
+        const resp = (await client.sendRequest('terminal.getAutoRestoreFit')) as {
+          ms?: number | null
+        } | null
+        setMs(resp?.ms === undefined ? null : resp.ms)
+      } catch {
+        // give up silently — the next mount retries
+      }
+    }
+  }
+
+  return (
+    <View>
+      <Pressable
+        style={({ pressed }) => [styles.row, pressed && styles.rowPressed]}
+        onPress={() => setExpanded((v) => !v)}
+      >
+        <Smartphone size={16} color={colors.textSecondary} />
+        <View style={{ flex: 1 }}>
+          <Text style={styles.rowLabel}>{hostName}</Text>
+          <Text style={styles.rowSublabel}>Auto-restore: {autoRestoreLabel(ms)}</Text>
+        </View>
+        <ChevronRight
+          size={16}
+          color={colors.textMuted}
+          style={{ transform: [{ rotate: expanded ? '90deg' : '0deg' }] }}
+        />
+      </Pressable>
+      {expanded &&
+        AUTO_RESTORE_FIT_OPTIONS.map((opt) => (
+          <Pressable
+            key={opt.value}
+            style={({ pressed }) => [
+              styles.optionRow,
+              pressed && styles.rowPressed,
+              opt.ms === (ms ?? null) && styles.optionRowSelected
+            ]}
+            onPress={() => void selectOption(opt)}
+          >
+            <Text style={styles.optionLabel}>{opt.label}</Text>
+          </Pressable>
+        ))}
+    </View>
+  )
+}
 
 export default function SettingsScreen() {
   const router = useRouter()
   const insets = useSafeAreaInsets()
+  const [hosts, setHosts] = useState<HostProfile[]>([])
+  useEffect(() => {
+    void loadHosts().then(setHosts)
+  }, [])
+  const hostIds = useMemo(() => hosts.map((h) => h.id), [hosts])
+  const hostClients = useAllHostClients(hostIds)
 
   return (
     <View style={[styles.container, { paddingTop: insets.top + spacing.sm }]}>
@@ -53,6 +170,21 @@ export default function SettingsScreen() {
           <ChevronRight size={16} color={colors.textMuted} />
         </Pressable>
       </View>
+
+      {hosts.length > 0 && (
+        <View style={[styles.section, styles.sectionSpacer]}>
+          <Text style={styles.sectionHeading}>Terminal width hold</Text>
+          {hosts.map((host, idx) => {
+            const entry = hostClients.find((e) => e.hostId === host.id)
+            return (
+              <View key={host.id}>
+                {idx > 0 && <View style={styles.separator} />}
+                <AutoRestoreFitRow client={entry?.client ?? null} hostName={host.name} />
+              </View>
+            )
+          })}
+        </View>
+      )}
 
       <View style={[styles.section, styles.sectionSpacer]}>
         <Pressable
@@ -121,6 +253,31 @@ const styles = StyleSheet.create({
     flex: 1,
     fontSize: typography.bodySize,
     fontWeight: '500',
+    color: colors.textPrimary
+  },
+  rowSublabel: {
+    fontSize: typography.bodySize - 2,
+    color: colors.textSecondary,
+    marginTop: 2
+  },
+  sectionHeading: {
+    fontSize: typography.bodySize - 2,
+    fontWeight: '600',
+    color: colors.textSecondary,
+    paddingHorizontal: spacing.md + 2,
+    paddingTop: spacing.sm + 2,
+    paddingBottom: spacing.xs
+  },
+  optionRow: {
+    paddingVertical: spacing.sm + 2,
+    paddingHorizontal: spacing.md + 2 + 22 + spacing.sm + 2,
+    backgroundColor: colors.bgRaised
+  },
+  optionRowSelected: {
+    backgroundColor: colors.bgPanel
+  },
+  optionLabel: {
+    fontSize: typography.bodySize,
     color: colors.textPrimary
   },
   separator: {

--- a/mobile/app/settings.tsx
+++ b/mobile/app/settings.tsx
@@ -36,7 +36,8 @@ const AUTO_RESTORE_FIT_OPTIONS: {
 
 function autoRestoreSummary(ms: number | null | undefined): string {
   if (ms === undefined) return '…'
-  const exact = ms == null ? AUTO_RESTORE_FIT_OPTIONS[0]! : AUTO_RESTORE_FIT_OPTIONS.find((o) => o.ms === ms)
+  if (ms === null) return AUTO_RESTORE_FIT_OPTIONS[0]!.label
+  const exact = AUTO_RESTORE_FIT_OPTIONS.find((o) => o.ms === ms)
   return exact ? exact.label : `After ${Math.round(ms / 1000)}s`
 }
 

--- a/mobile/app/terminal-settings.tsx
+++ b/mobile/app/terminal-settings.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
-import { View, Text, StyleSheet, Pressable } from 'react-native'
+import { View, Text, StyleSheet, Pressable, ScrollView } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useRouter } from 'expo-router'
 import { ChevronLeft, ChevronRight, Smartphone } from 'lucide-react-native'
@@ -8,17 +8,22 @@ import { loadHosts } from '../src/transport/host-store'
 import type { HostProfile } from '../src/transport/types'
 import { useAllHostClients } from '../src/transport/client-context'
 import type { RpcClient } from '../src/transport/rpc-client'
+import { PickerModal, type PickerOption } from '../src/components/PickerModal'
 
-const AUTO_RESTORE_FIT_OPTIONS: {
-  value: string
-  label: string
-  ms: number | null
-}[] = [
+type RestoreValue = 'indefinite' | '60s' | '5m' | '30m'
+
+const AUTO_RESTORE_FIT_OPTIONS: (PickerOption<RestoreValue> & { ms: number | null })[] = [
   { value: 'indefinite', label: 'Keep at phone size (default)', ms: null },
   { value: '60s', label: 'After 1 minute', ms: 60_000 },
   { value: '5m', label: 'After 5 minutes', ms: 5 * 60_000 },
   { value: '30m', label: 'After 30 minutes', ms: 30 * 60_000 }
 ]
+
+function valueFromMs(ms: number | null | undefined): RestoreValue {
+  if (ms == null) return 'indefinite'
+  const exact = AUTO_RESTORE_FIT_OPTIONS.find((o) => o.ms === ms)
+  return exact ? exact.value : 'indefinite'
+}
 
 function autoRestoreSummary(ms: number | null | undefined): string {
   if (ms === undefined) return '…'
@@ -27,88 +32,30 @@ function autoRestoreSummary(ms: number | null | undefined): string {
   return exact ? exact.label : `After ${Math.round(ms / 1000)}s`
 }
 
-function AutoRestoreFitRow({
+function HostFitRow({
   client,
-  hostName
+  hostName,
+  ms,
+  onPress
 }: {
   client: RpcClient | null
   hostName: string
+  ms: number | null | undefined
+  onPress: () => void
 }): React.JSX.Element {
-  const [ms, setMs] = useState<number | null | undefined>(undefined)
-  const [expanded, setExpanded] = useState(false)
-
-  useEffect(() => {
-    if (!client) return
-    let cancelled = false
-    void client
-      .sendRequest('terminal.getAutoRestoreFit')
-      .then((resp) => {
-        if (cancelled) return
-        const value = (resp as { ms?: number | null } | null)?.ms
-        setMs(value === undefined ? null : value)
-      })
-      .catch(() => {
-        if (!cancelled) setMs(null)
-      })
-    return () => {
-      cancelled = true
-    }
-  }, [client])
-
-  async function selectOption(opt: { value: string; label: string; ms: number | null }) {
-    if (!client) return
-    setExpanded(false)
-    setMs(opt.ms)
-    try {
-      const resp = (await client.sendRequest('terminal.setAutoRestoreFit', {
-        ms: opt.ms
-      })) as { ms?: number | null } | null
-      const finalMs = resp?.ms === undefined ? null : resp.ms
-      setMs(finalMs)
-    } catch {
-      try {
-        const resp = (await client.sendRequest('terminal.getAutoRestoreFit')) as {
-          ms?: number | null
-        } | null
-        setMs(resp?.ms === undefined ? null : resp.ms)
-      } catch {
-        // give up silently — the next mount retries
-      }
-    }
-  }
-
   return (
-    <View>
-      <Pressable
-        style={({ pressed }) => [styles.row, pressed && styles.rowPressed]}
-        onPress={() => setExpanded((v) => !v)}
-      >
-        <Smartphone size={16} color={colors.textSecondary} />
-        <View style={{ flex: 1 }}>
-          <Text style={styles.rowLabel}>{hostName}</Text>
-          <Text style={styles.rowSublabel}>{autoRestoreSummary(ms)}</Text>
-        </View>
-        <ChevronRight
-          size={16}
-          color={colors.textMuted}
-          style={{ transform: [{ rotate: expanded ? '90deg' : '0deg' }] }}
-        />
-      </Pressable>
-      {expanded &&
-        AUTO_RESTORE_FIT_OPTIONS.map((opt) => (
-          <Pressable
-            key={opt.value}
-            style={({ pressed }) => [
-              styles.optionRow,
-              pressed && styles.rowPressed,
-              opt.ms === (ms ?? null) && styles.optionRowSelected
-            ]}
-            onPress={() => void selectOption(opt)}
-          >
-            <Text style={styles.optionLabel}>{opt.label}</Text>
-          </Pressable>
-        ))}
-    </View>
+    <Pressable
+      style={({ pressed }) => [styles.row, pressed && styles.rowPressed]}
+      onPress={onPress}
+      disabled={!client}
+    >
+      <Smartphone size={16} color={colors.textSecondary} />
+      <View style={styles.rowContent}>
+        <Text style={styles.rowLabel}>{hostName}</Text>
+        <Text style={styles.rowSublabel}>{autoRestoreSummary(ms)}</Text>
+      </View>
+      <ChevronRight size={16} color={colors.textMuted} />
+    </Pressable>
   )
 }
 
@@ -122,6 +69,66 @@ export default function TerminalSettingsScreen() {
   const hostIds = useMemo(() => hosts.map((h) => h.id), [hosts])
   const hostClients = useAllHostClients(hostIds)
 
+  // Why: per-host current value, lazily fetched. We keep state at the
+  // screen level rather than per-row so the picker can render at root
+  // level — embedding PickerModal inside a row clipped its BottomDrawer
+  // absoluteFill backdrop to the ScrollView content frame and made the
+  // drawer appear cut-off.
+  const [hostMs, setHostMs] = useState<Record<string, number | null | undefined>>({})
+  const [pickerHostId, setPickerHostId] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    for (const host of hosts) {
+      const entry = hostClients.find((e) => e.hostId === host.id)
+      const client = entry?.client ?? null
+      if (!client) continue
+      void client
+        .sendRequest('terminal.getAutoRestoreFit')
+        .then((resp) => {
+          if (cancelled) return
+          const value = (resp as { ms?: number | null } | null)?.ms
+          setHostMs((prev) => ({ ...prev, [host.id]: value === undefined ? null : value }))
+        })
+        .catch(() => {
+          if (!cancelled) setHostMs((prev) => ({ ...prev, [host.id]: null }))
+        })
+    }
+    return () => {
+      cancelled = true
+    }
+  }, [hosts, hostClients])
+
+  async function selectValue(hostId: string, value: RestoreValue) {
+    const entry = hostClients.find((e) => e.hostId === hostId)
+    const client = entry?.client ?? null
+    if (!client) return
+    const opt = AUTO_RESTORE_FIT_OPTIONS.find((o) => o.value === value)
+    if (!opt) return
+    setHostMs((prev) => ({ ...prev, [hostId]: opt.ms }))
+    try {
+      const resp = (await client.sendRequest('terminal.setAutoRestoreFit', {
+        ms: opt.ms
+      })) as { ms?: number | null } | null
+      const finalMs = resp?.ms === undefined ? null : resp.ms
+      setHostMs((prev) => ({ ...prev, [hostId]: finalMs }))
+    } catch {
+      try {
+        const resp = (await client.sendRequest('terminal.getAutoRestoreFit')) as {
+          ms?: number | null
+        } | null
+        setHostMs((prev) => ({
+          ...prev,
+          [hostId]: resp?.ms === undefined ? null : resp.ms
+        }))
+      } catch {
+        // give up silently — the next mount retries
+      }
+    }
+  }
+
+  const pickerHost = pickerHostId ? hosts.find((h) => h.id === pickerHostId) : null
+
   return (
     <View style={[styles.container, { paddingTop: insets.top + spacing.sm }]}>
       <View style={styles.topRow}>
@@ -131,26 +138,54 @@ export default function TerminalSettingsScreen() {
         <Text style={styles.heading}>Terminal</Text>
       </View>
 
-      {hosts.length === 0 ? (
-        <View style={styles.section}>
-          <Text style={styles.emptyText}>
-            No paired desktops yet. Pair one to control terminal behavior.
-          </Text>
-        </View>
-      ) : (
-        <View style={styles.section}>
-          <Text style={styles.sectionHeading}>When you leave the app</Text>
-          {hosts.map((host, idx) => {
-            const entry = hostClients.find((e) => e.hostId === host.id)
-            return (
-              <View key={host.id}>
-                {idx > 0 && <View style={styles.separator} />}
-                <AutoRestoreFitRow client={entry?.client ?? null} hostName={host.name} />
-              </View>
-            )
-          })}
-        </View>
-      )}
+      <ScrollView
+        contentContainerStyle={styles.scrollContent}
+        showsVerticalScrollIndicator={false}
+      >
+        <Text style={styles.groupHeading}>WHEN YOU LEAVE THE APP</Text>
+        <Text style={styles.groupDescription}>
+          While you&apos;re using a terminal on your phone, Orca shrinks it to fit your
+          screen. When you close the app or switch away, this controls whether it stays at
+          phone size (so apps like Claude Code don&apos;t reflow) or resizes back to your
+          desktop. You can always tap Restore on the terminal banner to resize it manually.
+        </Text>
+
+        {hosts.length === 0 ? (
+          <View style={[styles.section, styles.sectionTopGap]}>
+            <Text style={styles.emptyText}>
+              No paired desktops yet. Pair one to control terminal behavior.
+            </Text>
+          </View>
+        ) : (
+          <View style={[styles.section, styles.sectionTopGap]}>
+            {hosts.map((host, idx) => {
+              const entry = hostClients.find((e) => e.hostId === host.id)
+              return (
+                <View key={host.id}>
+                  {idx > 0 && <View style={styles.separator} />}
+                  <HostFitRow
+                    client={entry?.client ?? null}
+                    hostName={host.name}
+                    ms={hostMs[host.id]}
+                    onPress={() => setPickerHostId(host.id)}
+                  />
+                </View>
+              )
+            })}
+          </View>
+        )}
+      </ScrollView>
+
+      <PickerModal<RestoreValue>
+        visible={pickerHost != null}
+        title={pickerHost ? `Restore ${pickerHost.name}` : ''}
+        options={AUTO_RESTORE_FIT_OPTIONS}
+        selected={valueFromMs(pickerHost ? hostMs[pickerHost.id] : null)}
+        onSelect={(v) => {
+          if (pickerHost) void selectValue(pickerHost.id, v)
+        }}
+        onClose={() => setPickerHostId(null)}
+      />
     </View>
   )
 }
@@ -159,12 +194,14 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: colors.bgBase,
-    padding: spacing.lg
+    paddingHorizontal: spacing.lg,
+    paddingTop: 0
   },
   topRow: {
     flexDirection: 'row',
     alignItems: 'center',
-    marginBottom: spacing.xl
+    marginTop: spacing.sm,
+    marginBottom: spacing.lg
   },
   backButton: {
     width: 36,
@@ -179,10 +216,30 @@ const styles = StyleSheet.create({
     fontWeight: '700',
     color: colors.textPrimary
   },
+  scrollContent: {
+    paddingBottom: spacing.xl
+  },
+  groupHeading: {
+    fontSize: 11,
+    fontWeight: '600',
+    color: colors.textMuted,
+    letterSpacing: 0.5,
+    marginBottom: spacing.xs,
+    paddingHorizontal: spacing.xs
+  },
+  groupDescription: {
+    fontSize: typography.bodySize - 1,
+    color: colors.textSecondary,
+    lineHeight: 20,
+    paddingHorizontal: spacing.xs
+  },
   section: {
     backgroundColor: colors.bgPanel,
     borderRadius: 12,
     overflow: 'hidden'
+  },
+  sectionTopGap: {
+    marginTop: spacing.sm
   },
   emptyText: {
     fontSize: typography.bodySize,
@@ -199,8 +256,10 @@ const styles = StyleSheet.create({
   rowPressed: {
     backgroundColor: colors.bgRaised
   },
+  rowContent: {
+    flex: 1
+  },
   rowLabel: {
-    flex: 1,
     fontSize: typography.bodySize,
     fontWeight: '500',
     color: colors.textPrimary
@@ -209,26 +268,6 @@ const styles = StyleSheet.create({
     fontSize: typography.bodySize - 2,
     color: colors.textSecondary,
     marginTop: 2
-  },
-  sectionHeading: {
-    fontSize: typography.bodySize - 2,
-    fontWeight: '600',
-    color: colors.textSecondary,
-    paddingHorizontal: spacing.md + 2,
-    paddingTop: spacing.sm + 2,
-    paddingBottom: spacing.xs
-  },
-  optionRow: {
-    paddingVertical: spacing.sm + 2,
-    paddingHorizontal: spacing.md + 2 + 22 + spacing.sm + 2,
-    backgroundColor: colors.bgRaised
-  },
-  optionRowSelected: {
-    backgroundColor: colors.bgPanel
-  },
-  optionLabel: {
-    fontSize: typography.bodySize,
-    color: colors.textPrimary
   },
   separator: {
     height: StyleSheet.hairlineWidth,

--- a/mobile/app/terminal-settings.tsx
+++ b/mobile/app/terminal-settings.tsx
@@ -1,0 +1,238 @@
+import { useEffect, useMemo, useState } from 'react'
+import { View, Text, StyleSheet, Pressable } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { useRouter } from 'expo-router'
+import { ChevronLeft, ChevronRight, Smartphone } from 'lucide-react-native'
+import { colors, spacing, typography } from '../src/theme/mobile-theme'
+import { loadHosts } from '../src/transport/host-store'
+import type { HostProfile } from '../src/transport/types'
+import { useAllHostClients } from '../src/transport/client-context'
+import type { RpcClient } from '../src/transport/rpc-client'
+
+const AUTO_RESTORE_FIT_OPTIONS: {
+  value: string
+  label: string
+  ms: number | null
+}[] = [
+  { value: 'indefinite', label: 'Keep at phone size (default)', ms: null },
+  { value: '60s', label: 'After 1 minute', ms: 60_000 },
+  { value: '5m', label: 'After 5 minutes', ms: 5 * 60_000 },
+  { value: '30m', label: 'After 30 minutes', ms: 30 * 60_000 }
+]
+
+function autoRestoreSummary(ms: number | null | undefined): string {
+  if (ms === undefined) return '…'
+  if (ms === null) return AUTO_RESTORE_FIT_OPTIONS[0]!.label
+  const exact = AUTO_RESTORE_FIT_OPTIONS.find((o) => o.ms === ms)
+  return exact ? exact.label : `After ${Math.round(ms / 1000)}s`
+}
+
+function AutoRestoreFitRow({
+  client,
+  hostName
+}: {
+  client: RpcClient | null
+  hostName: string
+}): React.JSX.Element {
+  const [ms, setMs] = useState<number | null | undefined>(undefined)
+  const [expanded, setExpanded] = useState(false)
+
+  useEffect(() => {
+    if (!client) return
+    let cancelled = false
+    void client
+      .sendRequest('terminal.getAutoRestoreFit')
+      .then((resp) => {
+        if (cancelled) return
+        const value = (resp as { ms?: number | null } | null)?.ms
+        setMs(value === undefined ? null : value)
+      })
+      .catch(() => {
+        if (!cancelled) setMs(null)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [client])
+
+  async function selectOption(opt: { value: string; label: string; ms: number | null }) {
+    if (!client) return
+    setExpanded(false)
+    setMs(opt.ms)
+    try {
+      const resp = (await client.sendRequest('terminal.setAutoRestoreFit', {
+        ms: opt.ms
+      })) as { ms?: number | null } | null
+      const finalMs = resp?.ms === undefined ? null : resp.ms
+      setMs(finalMs)
+    } catch {
+      try {
+        const resp = (await client.sendRequest('terminal.getAutoRestoreFit')) as {
+          ms?: number | null
+        } | null
+        setMs(resp?.ms === undefined ? null : resp.ms)
+      } catch {
+        // give up silently — the next mount retries
+      }
+    }
+  }
+
+  return (
+    <View>
+      <Pressable
+        style={({ pressed }) => [styles.row, pressed && styles.rowPressed]}
+        onPress={() => setExpanded((v) => !v)}
+      >
+        <Smartphone size={16} color={colors.textSecondary} />
+        <View style={{ flex: 1 }}>
+          <Text style={styles.rowLabel}>{hostName}</Text>
+          <Text style={styles.rowSublabel}>{autoRestoreSummary(ms)}</Text>
+        </View>
+        <ChevronRight
+          size={16}
+          color={colors.textMuted}
+          style={{ transform: [{ rotate: expanded ? '90deg' : '0deg' }] }}
+        />
+      </Pressable>
+      {expanded &&
+        AUTO_RESTORE_FIT_OPTIONS.map((opt) => (
+          <Pressable
+            key={opt.value}
+            style={({ pressed }) => [
+              styles.optionRow,
+              pressed && styles.rowPressed,
+              opt.ms === (ms ?? null) && styles.optionRowSelected
+            ]}
+            onPress={() => void selectOption(opt)}
+          >
+            <Text style={styles.optionLabel}>{opt.label}</Text>
+          </Pressable>
+        ))}
+    </View>
+  )
+}
+
+export default function TerminalSettingsScreen() {
+  const router = useRouter()
+  const insets = useSafeAreaInsets()
+  const [hosts, setHosts] = useState<HostProfile[]>([])
+  useEffect(() => {
+    void loadHosts().then(setHosts)
+  }, [])
+  const hostIds = useMemo(() => hosts.map((h) => h.id), [hosts])
+  const hostClients = useAllHostClients(hostIds)
+
+  return (
+    <View style={[styles.container, { paddingTop: insets.top + spacing.sm }]}>
+      <View style={styles.topRow}>
+        <Pressable style={styles.backButton} onPress={() => router.back()}>
+          <ChevronLeft size={22} color={colors.textSecondary} />
+        </Pressable>
+        <Text style={styles.heading}>Terminal</Text>
+      </View>
+
+      {hosts.length === 0 ? (
+        <View style={styles.section}>
+          <Text style={styles.emptyText}>
+            No paired desktops yet. Pair one to control terminal behavior.
+          </Text>
+        </View>
+      ) : (
+        <View style={styles.section}>
+          <Text style={styles.sectionHeading}>When you leave the app</Text>
+          {hosts.map((host, idx) => {
+            const entry = hostClients.find((e) => e.hostId === host.id)
+            return (
+              <View key={host.id}>
+                {idx > 0 && <View style={styles.separator} />}
+                <AutoRestoreFitRow client={entry?.client ?? null} hostName={host.name} />
+              </View>
+            )
+          })}
+        </View>
+      )}
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.bgBase,
+    padding: spacing.lg
+  },
+  topRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: spacing.xl
+  },
+  backButton: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginRight: spacing.sm
+  },
+  heading: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: colors.textPrimary
+  },
+  section: {
+    backgroundColor: colors.bgPanel,
+    borderRadius: 12,
+    overflow: 'hidden'
+  },
+  emptyText: {
+    fontSize: typography.bodySize,
+    color: colors.textSecondary,
+    padding: spacing.md
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm + 2,
+    paddingVertical: spacing.md,
+    paddingHorizontal: spacing.md + 2
+  },
+  rowPressed: {
+    backgroundColor: colors.bgRaised
+  },
+  rowLabel: {
+    flex: 1,
+    fontSize: typography.bodySize,
+    fontWeight: '500',
+    color: colors.textPrimary
+  },
+  rowSublabel: {
+    fontSize: typography.bodySize - 2,
+    color: colors.textSecondary,
+    marginTop: 2
+  },
+  sectionHeading: {
+    fontSize: typography.bodySize - 2,
+    fontWeight: '600',
+    color: colors.textSecondary,
+    paddingHorizontal: spacing.md + 2,
+    paddingTop: spacing.sm + 2,
+    paddingBottom: spacing.xs
+  },
+  optionRow: {
+    paddingVertical: spacing.sm + 2,
+    paddingHorizontal: spacing.md + 2 + 22 + spacing.sm + 2,
+    backgroundColor: colors.bgRaised
+  },
+  optionRowSelected: {
+    backgroundColor: colors.bgPanel
+  },
+  optionLabel: {
+    fontSize: typography.bodySize,
+    color: colors.textPrimary
+  },
+  separator: {
+    height: StyleSheet.hairlineWidth,
+    backgroundColor: colors.borderSubtle,
+    marginHorizontal: spacing.md
+  }
+})

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -35,7 +35,7 @@
     "react-native-svg": "^15.15.4",
     "react-native-web": "^0.21.2",
     "react-native-webview": "^13.16.1",
-    "react-native-worklets": "^0.7.4",
+    "react-native-worklets": "^0.8.3",
     "tweetnacl": "^1.0.3",
     "ws": "^8.20.0",
     "zod": "~4.3.6",

--- a/mobile/pnpm-lock.yaml
+++ b/mobile/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
         version: 2.2.0(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))
       expo:
         specifier: ^55.0.23
-        version: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+        version: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       expo-build-properties:
         specifier: ^55.0.13
         version: 55.0.13(expo@55.0.23)
@@ -37,7 +37,7 @@ importers:
         version: 55.0.22(expo@55.0.23)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       expo-router:
         specifier: ^55.0.14
-        version: 55.0.14(5d3cfa74814122d59abca9aec6df68b1)
+        version: 55.0.14(021822249f1df9b3c5f483d3fca100f4)
       expo-secure-store:
         specifier: ^55.0.13
         version: 55.0.13(expo@55.0.23)
@@ -61,7 +61,7 @@ importers:
         version: 2.31.2(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
       react-native-reanimated:
         specifier: ^4.3.0
-        version: 4.3.0(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+        version: 4.3.0(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
       react-native-safe-area-context:
         specifier: ^5.7.0
         version: 5.7.0(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
@@ -78,8 +78,8 @@ importers:
         specifier: ^13.16.1
         version: 13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
       react-native-worklets:
-        specifier: ^0.7.4
-        version: 0.7.4(@babel/core@7.29.0)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+        specifier: ^0.8.3
+        version: 0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
       tweetnacl:
         specifier: ^1.0.3
         version: 1.0.3
@@ -445,12 +445,6 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-class-properties@7.27.1':
-    resolution: {integrity: sha512-D0VcalChDMtuRvJIu3U/fwWjf8ZMykz5iZsg77Nuj821vCKI3zCyRLwRdWbsuJ/uRwZhZ002QtCqIkwC/ZkvbA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/plugin-transform-class-properties@7.28.6':
     resolution: {integrity: sha512-dY2wS3I2G7D697VHndN91TJr8/AAfXQNt5ynCTI/MpxMsSzHp+52uNivYT5wCPax3whc47DR8Ba7cmlQMg24bw==}
     engines: {node: '>=6.9.0'}
@@ -462,12 +456,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.12.0
-
-  '@babel/plugin-transform-classes@7.28.4':
-    resolution: {integrity: sha512-cFOlhIYPBv/iBoc+KS3M6et2XPtbT2HiCRfBXWtfpc9OAyostldxIf9YAYB6ypURBBbx+Qv6nyrLzASfJe+hBA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
 
   '@babel/plugin-transform-classes@7.28.6':
     resolution: {integrity: sha512-EF5KONAqC5zAqT783iMGuM2ZtmEBy+mJMOKl2BCvPZ2lVrwvXnB6o+OBWCS+CoeCCpVRF2sA2RBKUxvT8tQT5Q==}
@@ -607,12 +595,6 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-nullish-coalescing-operator@7.27.1':
-    resolution: {integrity: sha512-aGZh6xMo6q9vq1JGcw58lZ1Z0+i0xB2x0XaauNIUXd6O1xXc3RwoWEBlsTQrY4KQ9Jf0s5rgD6SiNkaUdJegTA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/plugin-transform-nullish-coalescing-operator@7.28.6':
     resolution: {integrity: sha512-3wKbRgmzYbw24mDJXT7N+ADXw8BC/imU9yo9c9X9NKaLF1fW+e5H1U5QjMUBe4Qo4Ox/o++IyUkl1sVCLgevKg==}
     engines: {node: '>=6.9.0'}
@@ -639,12 +621,6 @@ packages:
 
   '@babel/plugin-transform-optional-catch-binding@7.28.6':
     resolution: {integrity: sha512-R8ja/Pyrv0OGAvAXQhSTmWyPJPml+0TMqXlO5w+AsMEiwb2fg3WkOvob7UxFSL3OIttFSGSRFKQsOhJ/X6HQdQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-optional-chaining@7.27.1':
-    resolution: {integrity: sha512-BQmKPPIuc8EkZgNKsv0X4bPmOoayeu4F1YCwx2/CfmDSXDbp7GnzlUH+/ul5VGfRg1AoFPsrIThlEBj2xb4CAg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -812,12 +788,6 @@ packages:
 
   '@babel/preset-react@7.28.5':
     resolution: {integrity: sha512-Z3J8vhRq7CeLjdC58jLv4lnZ5RKFUJWqH5emvxmv9Hv3BD1T9R/Im713R4MTKwvFaV74ejZ3sM01LyEKk4ugNQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/preset-typescript@7.27.1':
-    resolution: {integrity: sha512-l7WfQfX0WK4M0v2RudjuQK4u99BS6yLHYEmdtVPP7lKV013zr9DygFuWNlnbvQ9LR+LS0Egz/XAvGx5U9MX0fQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -4771,12 +4741,13 @@ packages:
       react: '*'
       react-native: '*'
 
-  react-native-worklets@0.7.4:
-    resolution: {integrity: sha512-NYOdM1MwBb3n+AtMqy1tFy3Mn8DliQtd8sbzAVRf9Gc+uvQ0zRfxN7dS8ZzoyX7t6cyQL5THuGhlnX+iFlQTag==}
+  react-native-worklets@0.8.3:
+    resolution: {integrity: sha512-oCBJROyLU7yG/1R8s0INMflygTH71bx+5XcYkH0CM938TlhSoVbiunE1WVW5FZa51vwYqfLie/IXMX2s1Kh3eg==}
     peerDependencies:
       '@babel/core': '*'
+      '@react-native/metro-config': '*'
       react: '*'
-      react-native: '*'
+      react-native: 0.81 - 0.85
 
   react-native@0.83.9:
     resolution: {integrity: sha512-bTQpaSJBbxOizI8SMNiCR/5aIvfO3ZlXAcWYxg6FmdbfJYCZ0zdUCK9mSZ4patureITGHNU94RXhxDAJhqsO7w==}
@@ -4960,11 +4931,6 @@ packages:
 
   semver@7.6.3:
     resolution: {integrity: sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==}
-    engines: {node: '>=10'}
-    hasBin: true
-
-  semver@7.7.3:
-    resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -6047,14 +6013,6 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-class-properties@7.27.1(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.28.6
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/plugin-transform-class-properties@7.28.6(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
@@ -6068,18 +6026,6 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-classes@7.28.4(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-compilation-targets': 7.28.6
-      '@babel/helper-globals': 7.28.0
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.0)
-      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -6237,11 +6183,6 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-nullish-coalescing-operator@7.27.1(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-
   '@babel/plugin-transform-nullish-coalescing-operator@7.28.6(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
@@ -6275,14 +6216,6 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
-
-  '@babel/plugin-transform-optional-chaining@7.27.1(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/plugin-transform-optional-chaining@7.28.6(@babel/core@7.29.0)':
     dependencies:
@@ -6544,17 +6477,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/preset-typescript@7.27.1(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-validator-option': 7.27.1
-      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.0)
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/preset-typescript@7.28.5(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
@@ -6757,7 +6679,7 @@ snapshots:
       connect: 3.7.0
       debug: 4.4.3
       dnssd-advertise: 1.1.4
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       expo-server: 55.0.9
       fetch-nodeshim: 0.4.10
       getenv: 2.0.0
@@ -6784,7 +6706,7 @@ snapshots:
       ws: 8.20.0
       zod: 3.25.76
     optionalDependencies:
-      expo-router: 55.0.14(5d3cfa74814122d59abca9aec6df68b1)
+      expo-router: 55.0.14(021822249f1df9b3c5f483d3fca100f4)
       react-native: 0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6)
     transitivePeerDependencies:
       - '@expo/dom-webview'
@@ -6855,7 +6777,7 @@ snapshots:
 
   '@expo/dom-webview@55.0.5(expo@55.0.23)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)':
     dependencies:
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       react: 19.2.6
       react-native: 0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6)
 
@@ -6913,7 +6835,7 @@ snapshots:
     dependencies:
       '@expo/dom-webview': 55.0.5(expo@55.0.23)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
       anser: 1.4.10
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       react: 19.2.6
       react-native: 0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6)
       stacktrace-parser: 0.1.11
@@ -6922,7 +6844,7 @@ snapshots:
     dependencies:
       '@expo/dom-webview': 55.0.5(expo@55.0.23)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
       anser: 1.4.10
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       react: 19.2.6
       react-native: 0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6)
       stacktrace-parser: 0.1.11
@@ -6949,7 +6871,7 @@ snapshots:
       postcss: 8.4.49
       resolve-from: 5.0.0
     optionalDependencies:
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -6960,7 +6882,7 @@ snapshots:
     dependencies:
       '@expo/log-box': 55.0.11(@expo/dom-webview@55.0.5)(expo@55.0.23)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
       anser: 1.4.10
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       pretty-format: 29.7.0
       react: 19.2.6
       react-native: 0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6)
@@ -7024,7 +6946,7 @@ snapshots:
       '@expo/json-file': 10.0.14
       '@react-native/normalize-colors': 0.83.6
       debug: 4.4.3
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       resolve-from: 5.0.0
       semver: 7.7.4
       xml2js: 0.6.0
@@ -7045,14 +6967,14 @@ snapshots:
   '@expo/router-server@55.0.16(@expo/metro-runtime@55.0.10)(expo-constants@55.0.16)(expo-font@55.0.7)(expo-router@55.0.14)(expo-server@55.0.9)(expo@55.0.23)(react-dom@19.2.5(react@19.2.6))(react@19.2.6)':
     dependencies:
       debug: 4.4.3
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       expo-constants: 55.0.16(expo@55.0.23)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))
       expo-font: 55.0.7(expo@55.0.23)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
       expo-server: 55.0.9
       react: 19.2.6
     optionalDependencies:
       '@expo/metro-runtime': 55.0.10(@expo/dom-webview@55.0.5)(expo@55.0.23)(react-dom@19.2.5(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
-      expo-router: 55.0.14(5d3cfa74814122d59abca9aec6df68b1)
+      expo-router: 55.0.14(021822249f1df9b3c5f483d3fca100f4)
       react-dom: 19.2.5(react@19.2.6)
     transitivePeerDependencies:
       - supports-color
@@ -7640,7 +7562,6 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
-    optional: true
 
   '@react-native/babel-preset@0.83.6(@babel/core@7.29.0)':
     dependencies:
@@ -7729,7 +7650,6 @@ snapshots:
       react-refresh: 0.14.2
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   '@react-native/codegen@0.83.6(@babel/core@7.29.0)':
     dependencies:
@@ -7760,7 +7680,6 @@ snapshots:
       nullthrows: 1.1.1
       tinyglobby: 0.2.16
       yargs: 17.7.2
-    optional: true
 
   '@react-native/community-cli-plugin@0.83.9(@react-native/metro-config@0.85.2(@babel/core@7.29.0))':
     dependencies:
@@ -7834,8 +7753,7 @@ snapshots:
 
   '@react-native/js-polyfills@0.83.9': {}
 
-  '@react-native/js-polyfills@0.85.2':
-    optional: true
+  '@react-native/js-polyfills@0.85.2': {}
 
   '@react-native/metro-babel-transformer@0.85.2(@babel/core@7.29.0)':
     dependencies:
@@ -7845,7 +7763,6 @@ snapshots:
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   '@react-native/metro-config@0.85.2(@babel/core@7.29.0)':
     dependencies:
@@ -7858,7 +7775,6 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
-    optional: true
 
   '@react-native/normalize-colors@0.74.89': {}
 
@@ -8407,7 +8323,6 @@ snapshots:
   babel-plugin-syntax-hermes-parser@0.33.3:
     dependencies:
       hermes-parser: 0.33.3
-    optional: true
 
   babel-plugin-transform-flow-enums@0.0.2(@babel/core@7.29.0):
     dependencies:
@@ -8462,7 +8377,7 @@ snapshots:
       resolve-from: 5.0.0
     optionalDependencies:
       '@babel/runtime': 7.29.2
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -9316,12 +9231,12 @@ snapshots:
 
   expo-application@55.0.14(expo@55.0.23):
     dependencies:
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
 
   expo-asset@55.0.17(expo@55.0.23)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3):
     dependencies:
       '@expo/image-utils': 0.8.14(typescript@5.9.3)
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       expo-constants: 55.0.16(expo@55.0.23)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))
       react: 19.2.6
       react-native: 0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6)
@@ -9332,14 +9247,14 @@ snapshots:
   expo-build-properties@55.0.13(expo@55.0.23):
     dependencies:
       '@expo/schema-utils': 55.0.4
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       resolve-from: 5.0.0
       semver: 7.7.4
 
   expo-camera@55.0.18(@types/emscripten@1.41.5)(expo@55.0.23)(react-native-web@0.21.2(react-dom@19.2.5(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6):
     dependencies:
       barcode-detector: 3.1.3(@types/emscripten@1.41.5)
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       react: 19.2.6
       react-native: 0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6)
     optionalDependencies:
@@ -9350,40 +9265,40 @@ snapshots:
   expo-constants@55.0.16(expo@55.0.23)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6)):
     dependencies:
       '@expo/env': 2.1.2
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       react-native: 0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6)
     transitivePeerDependencies:
       - supports-color
 
   expo-crypto@55.0.14(expo@55.0.23):
     dependencies:
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
 
   expo-file-system@55.0.19(expo@55.0.23)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6)):
     dependencies:
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       react-native: 0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6)
 
   expo-font@55.0.7(expo@55.0.23)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6):
     dependencies:
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       fontfaceobserver: 2.3.0
       react: 19.2.6
       react-native: 0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6)
 
   expo-glass-effect@55.0.11(expo@55.0.23)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6):
     dependencies:
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       react: 19.2.6
       react-native: 0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6)
 
   expo-haptics@55.0.14(expo@55.0.23):
     dependencies:
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
 
   expo-image@55.0.10(expo@55.0.23)(react-native-web@0.21.2(react-dom@19.2.5(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6):
     dependencies:
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       react: 19.2.6
       react-native: 0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6)
       sf-symbols-typescript: 2.2.0
@@ -9392,7 +9307,7 @@ snapshots:
 
   expo-keep-awake@55.0.8(expo@55.0.23)(react@19.2.6):
     dependencies:
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       react: 19.2.6
 
   expo-linking@55.0.15(expo@55.0.23)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6):
@@ -9461,20 +9376,20 @@ snapshots:
       - supports-color
       - typescript
 
-  expo-modules-core@55.0.25(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6):
+  expo-modules-core@55.0.25(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6):
     dependencies:
       invariant: 2.2.4
       react: 19.2.6
       react-native: 0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6)
     optionalDependencies:
-      react-native-worklets: 0.7.4(@babel/core@7.29.0)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+      react-native-worklets: 0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
 
   expo-notifications@55.0.22(expo@55.0.23)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3):
     dependencies:
       '@expo/image-utils': 0.8.14(typescript@5.9.3)
       abort-controller: 3.0.0
       badgin: 1.2.3
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       expo-application: 55.0.14(expo@55.0.23)
       expo-constants: 55.0.16(expo@55.0.23)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))
       react: 19.2.6
@@ -9483,7 +9398,7 @@ snapshots:
       - supports-color
       - typescript
 
-  expo-router@55.0.14(5d3cfa74814122d59abca9aec6df68b1):
+  expo-router@55.0.14(021822249f1df9b3c5f483d3fca100f4):
     dependencies:
       '@expo/log-box': 55.0.12(@expo/dom-webview@55.0.5)(expo@55.0.23)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
       '@expo/metro-runtime': 55.0.10(@expo/dom-webview@55.0.5)(expo@55.0.23)(react-dom@19.2.5(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
@@ -9496,7 +9411,7 @@ snapshots:
       client-only: 0.0.1
       debug: 4.4.3
       escape-string-regexp: 4.0.0
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       expo-constants: 55.0.16(expo@55.0.23)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))
       expo-glass-effect: 55.0.11(expo@55.0.23)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
       expo-image: 55.0.10(expo@55.0.23)(react-native-web@0.21.2(react-dom@19.2.5(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
@@ -9523,7 +9438,7 @@ snapshots:
       '@testing-library/react-native': 13.3.3(jest@29.7.0(@types/node@25.6.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react-test-renderer@19.2.0(react@19.2.6))(react@19.2.6)
       react-dom: 19.2.5(react@19.2.6)
       react-native-gesture-handler: 2.31.2(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
-      react-native-reanimated: 4.3.0(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+      react-native-reanimated: 4.3.0(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
       react-native-web: 0.21.2(react-dom@19.2.5(react@19.2.6))(react@19.2.6)
     transitivePeerDependencies:
       - '@react-native-masked-view/masked-view'
@@ -9534,14 +9449,14 @@ snapshots:
 
   expo-secure-store@55.0.13(expo@55.0.23):
     dependencies:
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
 
   expo-server@55.0.9: {}
 
   expo-splash-screen@55.0.20(expo@55.0.23)(typescript@5.9.3):
     dependencies:
       '@expo/prebuild-config': 55.0.17(expo@55.0.23)(typescript@5.9.3)
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -9555,13 +9470,13 @@ snapshots:
   expo-symbols@55.0.8(expo-font@55.0.7)(expo@55.0.23)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6):
     dependencies:
       '@expo-google-fonts/material-symbols': 0.4.34
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       expo-font: 55.0.7(expo@55.0.23)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       react-native: 0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6)
       sf-symbols-typescript: 2.2.0
 
-  expo@55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3):
+  expo@55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3):
     dependencies:
       '@babel/runtime': 7.29.2
       '@expo/cli': 55.0.29(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-constants@55.0.16)(expo-font@55.0.7)(expo-router@55.0.14)(expo@55.0.23)(react-dom@19.2.5(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
@@ -9582,7 +9497,7 @@ snapshots:
       expo-font: 55.0.7(expo@55.0.23)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
       expo-keep-awake: 55.0.8(expo@55.0.23)(react@19.2.6)
       expo-modules-autolinking: 55.0.21(typescript@5.9.3)
-      expo-modules-core: 55.0.25(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+      expo-modules-core: 55.0.25(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
       pretty-format: 29.7.0
       react: 19.2.6
       react-native: 0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6)
@@ -9830,8 +9745,7 @@ snapshots:
 
   hermes-estree@0.32.1: {}
 
-  hermes-estree@0.33.3:
-    optional: true
+  hermes-estree@0.33.3: {}
 
   hermes-estree@0.35.0: {}
 
@@ -9846,7 +9760,6 @@ snapshots:
   hermes-parser@0.33.3:
     dependencies:
       hermes-estree: 0.33.3
-    optional: true
 
   hermes-parser@0.35.0:
     dependencies:
@@ -10272,7 +10185,7 @@ snapshots:
       '@jest/create-cache-key-function': 29.7.0
       '@jest/globals': 29.7.0
       babel-jest: 29.7.0(@babel/core@7.29.0)
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.5(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       jest-environment-jsdom: 29.7.0
       jest-snapshot: 29.7.0
       jest-watch-select-projects: 2.0.0
@@ -10750,7 +10663,6 @@ snapshots:
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   metro-cache-key@0.83.7:
     dependencies:
@@ -10759,7 +10671,6 @@ snapshots:
   metro-cache-key@0.84.4:
     dependencies:
       flow-enums-runtime: 0.0.6
-    optional: true
 
   metro-cache@0.83.7:
     dependencies:
@@ -10778,7 +10689,6 @@ snapshots:
       metro-core: 0.84.4
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   metro-config@0.83.7:
     dependencies:
@@ -10809,7 +10719,6 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
-    optional: true
 
   metro-core@0.83.7:
     dependencies:
@@ -10822,7 +10731,6 @@ snapshots:
       flow-enums-runtime: 0.0.6
       lodash.throttle: 4.1.1
       metro-resolver: 0.84.4
-    optional: true
 
   metro-file-map@0.83.7:
     dependencies:
@@ -10851,7 +10759,6 @@ snapshots:
       walker: 1.0.8
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   metro-minify-terser@0.83.7:
     dependencies:
@@ -10862,7 +10769,6 @@ snapshots:
     dependencies:
       flow-enums-runtime: 0.0.6
       terser: 5.46.2
-    optional: true
 
   metro-resolver@0.83.7:
     dependencies:
@@ -10871,7 +10777,6 @@ snapshots:
   metro-resolver@0.84.4:
     dependencies:
       flow-enums-runtime: 0.0.6
-    optional: true
 
   metro-runtime@0.83.7:
     dependencies:
@@ -10882,7 +10787,6 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.29.2
       flow-enums-runtime: 0.0.6
-    optional: true
 
   metro-source-map@0.83.7:
     dependencies:
@@ -10911,7 +10815,6 @@ snapshots:
       vlq: 1.0.1
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   metro-symbolicate@0.83.7:
     dependencies:
@@ -10934,7 +10837,6 @@ snapshots:
       vlq: 1.0.1
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   metro-transform-plugins@0.83.7:
     dependencies:
@@ -10957,7 +10859,6 @@ snapshots:
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   metro-transform-worker@0.83.7:
     dependencies:
@@ -10998,7 +10899,6 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
-    optional: true
 
   metro@0.83.7:
     dependencies:
@@ -11091,7 +10991,6 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
-    optional: true
 
   micromatch@4.0.8:
     dependencies:
@@ -11193,7 +11092,6 @@ snapshots:
   ob1@0.84.4:
     dependencies:
       flow-enums-runtime: 0.0.6
-    optional: true
 
   object-assign@4.1.1: {}
 
@@ -11529,12 +11427,12 @@ snapshots:
       react: 19.2.6
       react-native: 0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6)
 
-  react-native-reanimated@4.3.0(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6):
+  react-native-reanimated@4.3.0(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6):
     dependencies:
       react: 19.2.6
       react-native: 0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6)
       react-native-is-edge-to-edge: 1.3.1(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
-      react-native-worklets: 0.7.4(@babel/core@7.29.0)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+      react-native-worklets: 0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
       semver: 7.7.4
 
   react-native-safe-area-context@5.7.0(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6):
@@ -11579,22 +11477,23 @@ snapshots:
       react: 19.2.6
       react-native: 0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6)
 
-  react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6):
+  react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-class-properties': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-classes': 7.28.4(@babel/core@7.29.0)
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-optional-chaining': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-classes': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.29.0)
       '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.29.0)
       '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.29.0)
       '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.29.0)
-      '@babel/preset-typescript': 7.27.1(@babel/core@7.29.0)
+      '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
+      '@react-native/metro-config': 0.85.2(@babel/core@7.29.0)
       convert-source-map: 2.0.0
       react: 19.2.6
       react-native: 0.83.9(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6)
-      semver: 7.7.3
+      semver: 7.7.4
     transitivePeerDependencies:
       - supports-color
 
@@ -11817,8 +11716,6 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.6.3: {}
-
-  semver@7.7.3: {}
 
   semver@7.7.4: {}
 

--- a/mobile/src/terminal/TerminalWebView.tsx
+++ b/mobile/src/terminal/TerminalWebView.tsx
@@ -213,36 +213,21 @@ const XTERM_HTML = `<!DOCTYPE html>
   var FIT_RETRY_MAX_FRAMES = 60;
   var fitRetryToken = 0;
   function applyFitScale(reason) {
-    if (!term || !term.element) {
-      flog('skip-no-term', { reason: reason });
-      return;
-    }
+    if (!term || !term.element) return;
     var token = ++fitRetryToken;
     var attempts = 0;
     var lastScrollWidth = -1;
-    flog('start', {
-      reason: reason,
-      cols: term.cols,
-      rows: term.rows,
-      vpWidth: window.innerWidth,
-      vpHeight: window.innerHeight
-    });
     function attempt() {
-      if (token !== fitRetryToken) {
-        flog('cancel-superseded', { reason: reason, attempts: attempts });
-        return;
-      }
+      if (token !== fitRetryToken) return;
       if (!term || !term.element) return;
       attempts++;
       var cellW = getCellWidth();
       if (cellW > 0 && term.cols > 0) {
-        flog('commit-cellW', { reason: reason, attempts: attempts, cellW: cellW, cols: term.cols });
         commitFitScale(reason, attempts, 'cellW');
         return;
       }
       var w = term.element.scrollWidth;
       if (w > 0 && w === lastScrollWidth) {
-        flog('commit-stableSW', { reason: reason, attempts: attempts, scrollWidth: w });
         commitFitScale(reason, attempts, 'stableSW');
         return;
       }
@@ -283,19 +268,20 @@ const XTERM_HTML = `<!DOCTYPE html>
     var expectedW = cellW * term.cols;
     var suspect =
       currentScale === 1 && term.cols > 0 && expectedW > vpW + 1; // expected wider than viewport but no zoom
-    flog(suspect ? 'commit-SUSPECT' : 'commit', {
-      reason: reason,
-      attempts: attempts,
-      gate: gate,
-      preSnapScale: preSnapScale,
-      finalScale: currentScale,
-      cellW: cellW,
-      cols: term.cols,
-      expectedW: expectedW,
-      scrollWidth: sw,
-      vpWidth: vpW,
-      suspect: suspect
-    });
+    if (suspect) {
+      flog('commit-SUSPECT', {
+        reason: reason,
+        attempts: attempts,
+        gate: gate,
+        preSnapScale: preSnapScale,
+        finalScale: currentScale,
+        cellW: cellW,
+        cols: term.cols,
+        expectedW: expectedW,
+        scrollWidth: sw,
+        vpWidth: vpW
+      });
+    }
   }
 
   function isAltScreenActive(data) {
@@ -347,15 +333,6 @@ const XTERM_HTML = `<!DOCTYPE html>
     afterDrainCallbacks = [];
     initRows = rows || 24;
     firstDataPending = true;
-    flog('init', {
-      cols: cols,
-      rows: rows,
-      hasInitialData: typeof initialData === 'string' && initialData.length > 0,
-      initialDataLen: typeof initialData === 'string' ? initialData.length : 0,
-      vpWidth: window.innerWidth,
-      vpHeight: window.innerHeight,
-      gen: gen
-    });
     var replayData = normalizeInitialData(initialData);
     activeAltScreenSnapshot = isAltScreenActive(replayData);
     if (term) term.dispose();

--- a/mobile/src/transport/connection-health.ts
+++ b/mobile/src/transport/connection-health.ts
@@ -6,16 +6,17 @@ import type { ConnectionState } from './types'
 // - WARNING_ATTEMPTS: 3 → label flips to "Can't connect" (existing
 //   behavior). Calibrated to absorb a normal laptop wake / brief
 //   network blip without alarming the user.
-// - UNREACHABLE_ATTEMPTS: 6 → with the 4s backoff cap that's ≈ 20s of
-//   continuous failure. Combined with the never-connected /
-//   stale-since-last-connect heuristic below, this is the trigger to
-//   surface a "re-pair?" affordance.
+// - UNREACHABLE_ATTEMPTS: 12 → with the tiered 0.5s→60s backoff this
+//   is ≈ 2 minutes of continuous failure. Combined with the
+//   never-connected / stale-since-last-connect heuristic below, this
+//   is the trigger to surface a "re-pair?" affordance. MUST stay
+//   aligned with rpc-client.ts GIVE_UP_AFTER_ATTEMPTS.
 // - STALE_SINCE_LAST_CONNECT_MS: 60s → if we WERE connected this
 //   session but haven't been for ≥ 1 minute despite the retry loop
 //   spinning, treat the same as never-connected. Catches the case
 //   where the desktop's IP changed mid-session.
 export const WARNING_ATTEMPTS = 3
-export const UNREACHABLE_ATTEMPTS = 6
+export const UNREACHABLE_ATTEMPTS = 12
 export const STALE_SINCE_LAST_CONNECT_MS = 60_000
 
 export type ConnectionVerdict =

--- a/mobile/src/transport/rpc-client.ts
+++ b/mobile/src/transport/rpc-client.ts
@@ -42,22 +42,24 @@ export type RpcClient = {
   close: () => void
 }
 
-// Why: capped at 4s so the worst-case "stuck reconnecting" window the
-// user perceives is short. Prior 16s ceiling combined with Android's
-// suspended-timer behaviour during background → foreground transitions
-// often felt like the app would just sit on 'Reconnecting…' forever
-// (the timer was queued, the OS had simply not run it yet). Tapping the
-// manual Reconnect button bypassed the timer, which is why it felt
-// "magic". Shorter backoff makes the auto-recovery path feel as fast.
-const RECONNECT_DELAYS = [500, 1000, 2000, 4000]
-// Why: cap auto-retry once we're clearly unreachable. With the 4s
-// backoff cap that's ≈20s of solid failure before we stop. The UI
-// renders an "unreachable, re-pair?" banner at this point; user taps
-// Retry or Re-pair to resume. MUST stay aligned with
-// connection-health.ts UNREACHABLE_ATTEMPTS so the verdict matches the
-// moment the loop pauses — if these drift the user sees "Reconnecting…"
-// while the loop is silently parked.
-const GIVE_UP_AFTER_ATTEMPTS = 6
+// Why: tiered backoff. The first four entries (500ms→4s) keep
+// auto-recovery snappy for the common case — a brief Wi-Fi blip,
+// laptop wake, or AP-isolation cycle. Beyond that we slow down
+// (8s→60s) so a phone whose desktop is genuinely unreachable doesn't
+// burn a TCP SYN every 4s indefinitely while still healing on its
+// own when the network recovers. Total time across all 12 attempts
+// is ≈ 2m 5s before the give-up cap fires.
+const RECONNECT_DELAYS = [500, 1000, 2000, 4000, 8000, 15_000, 30_000, 60_000]
+// Why: cap auto-retry once we're clearly unreachable for a long time.
+// With the tiered backoff above this is ≈ 2 minutes of continuous
+// failure before we stop and surface the re-pair banner. The longer
+// runway tolerates flaky AP-isolation routers and laptop sleep cycles
+// that briefly drop the LAN path. MUST stay aligned with
+// connection-health.ts UNREACHABLE_ATTEMPTS so the "unreachable"
+// verdict matches the moment the loop actually pauses — if these
+// drift the user sees "Reconnecting…" while the loop is silently
+// parked.
+const GIVE_UP_AFTER_ATTEMPTS = 12
 const REQUEST_TIMEOUT_MS = 30_000
 const CONNECT_TIMEOUT_MS = 12_000
 const HANDSHAKE_TIMEOUT_MS = 5_000

--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -97,6 +97,7 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     terminalMacOptionAsAltMigrated: true,
     experimentalAgentDashboard: false,
     experimentalMobile: false,
+    mobileAutoRestoreFitMs: null,
     experimentalSidekick: false,
     experimentalWorktreeSymlinks: false,
     terminalWindowsShell: 'powershell.exe',

--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -91,6 +91,7 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     terminalMacOptionAsAltMigrated: true,
     experimentalAgentDashboard: false,
     experimentalMobile: false,
+    mobileAutoRestoreFitMs: null,
     experimentalSidekick: false,
     experimentalWorktreeSymlinks: false,
     terminalWindowsShell: 'powershell.exe',

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -1150,6 +1150,26 @@ export function registerPtyHandlers(
     runtime?.onExternalPtyResize(args.id, args.cols, args.rows)
   })
 
+  // Why: pty:reportGeometry is a measurement-only sibling of pty:resize.
+  // pty:resize means "I want the PTY at this size" (a write/intent — gated
+  // by mobile-driver and cascade suppress). pty:reportGeometry means "the
+  // desktop pane I'm rendering currently measures this many cells" (a
+  // read/observation). Mobile-fit hold needs the latter even while the
+  // former is intentionally blocked: when a previously-hidden desktop
+  // tab becomes visible while a phone is driving, the server has no way
+  // to learn the real desktop dims, and resolveDesktopRestoreTarget
+  // returns the stale spawn default (e.g. 80×24) on Take Back. Splitting
+  // the channels keeps each guard simple — pty:resize keeps its mobile-
+  // driver gate; pty:reportGeometry never resizes the PTY, only refreshes
+  // the restore-target cache. See docs/mobile-fit-hold.md.
+  ipcMain.removeAllListeners('pty:reportGeometry')
+  ipcMain.on(
+    'pty:reportGeometry',
+    (_event, args: { id: string; cols: number; rows: number }) => {
+      runtime?.recordRendererGeometry(args.id, args.cols, args.rows)
+    }
+  )
+
   // Why: fire-and-forget — clears the DaemonPtyAdapter's sticky cold restore
   // cache after the renderer has consumed the data. No-op for non-daemon providers.
   ipcMain.on('pty:ackColdRestore', (_event, args: { id: string }) => {

--- a/src/main/ipc/runtime.ts
+++ b/src/main/ipc/runtime.ts
@@ -38,15 +38,21 @@ export function registerRuntimeHandlers(runtime: OrcaRuntimeService): void {
   // a 'resized' event to any active mobile subscriber. This uses the same
   // code path as the mobile toggle button (terminal.setDisplayMode RPC).
   ipcMain.removeHandler('runtime:restoreTerminalFit')
-  ipcMain.handle('runtime:restoreTerminalFit', (_event, args: { ptyId: string }) => {
+  ipcMain.handle('runtime:restoreTerminalFit', async (_event, args: { ptyId: string }) => {
     // Why: this IPC powers the desktop "Take back" button. Beyond restoring
     // PTY dims (the original semantic), it now also reclaims the input
     // floor for the desktop via the driver state machine. The lock banner
     // unmounts and desktop input/resize are unblocked until the next
     // mobile interaction takes the floor again. See
     // docs/mobile-presence-lock.md.
+    //
+    // Why async: reclaimTerminalForDesktop awaits applyMobileDisplayMode's
+    // PTY-resize chain. Returning the unresolved Promise to ipcMain made
+    // Electron try to structured-clone a Promise — "An object could not
+    // be cloned" error — and the renderer's restoreTerminalFit() rejected
+    // with no useful info.
     try {
-      const reclaimed = runtime.reclaimTerminalForDesktop(args.ptyId)
+      const reclaimed = await runtime.reclaimTerminalForDesktop(args.ptyId)
       return { restored: reclaimed }
     } catch {
       return { restored: false }

--- a/src/main/runtime/fit-override-integration.test.ts
+++ b/src/main/runtime/fit-override-integration.test.ts
@@ -239,8 +239,17 @@ describe('fit override integration', () => {
     expect(resizes).toEqual(['pty-1:42x18', 'pty-1:120x35'])
   })
 
-  it('disconnect auto-restore also resizes PTY', async () => {
-    const runtime = new OrcaRuntimeService(store)
+  it('disconnect auto-restore also resizes PTY (when auto-restore is configured)', async () => {
+    // Why: indefinite hold (mobileAutoRestoreFitMs=null) is the default and
+    // intentionally suppresses disconnect-driven auto-restore so the desktop
+    // banner stays mounted after the phone leaves. This test verifies the
+    // legacy auto-restore path still works when the user opts into a finite
+    // window. See docs/mobile-fit-hold.md.
+    const finiteRestoreStore = {
+      ...store,
+      getSettings: () => ({ ...store.getSettings(), mobileAutoRestoreFitMs: 5_000 })
+    }
+    const runtime = new OrcaRuntimeService(finiteRestoreStore)
     let ptySize = { cols: 100, rows: 30 }
 
     runtime.setPtyController({
@@ -276,5 +285,45 @@ describe('fit override integration', () => {
     await new Promise((r) => setTimeout(r, 0))
     expect(ptySize).toEqual({ cols: 100, rows: 30 })
     expect(runtime.getTerminalFitOverride('pty-1')).toBeNull()
+  })
+
+  it('disconnect with indefinite hold (default) keeps PTY at phone dims', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    let ptySize = { cols: 100, rows: 30 }
+
+    runtime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null,
+      resize: (_ptyId, cols, rows) => {
+        ptySize = { cols, rows }
+        return true
+      },
+      getSize: () => ({ ...ptySize })
+    })
+    runtime.setNotifier({
+      worktreesChanged: vi.fn(),
+      reposChanged: vi.fn(),
+      activateWorktree: vi.fn(),
+      createTerminal: vi.fn(),
+      splitTerminal: vi.fn(),
+      renameTerminal: vi.fn(),
+      focusTerminal: vi.fn(),
+      closeTerminal: vi.fn(),
+      sleepWorktree: vi.fn(),
+      terminalFitOverrideChanged: vi.fn(),
+      terminalDriverChanged: vi.fn()
+    })
+
+    // Default mobileAutoRestoreFitMs is null (indefinite hold).
+    await runtime.resizeForClient('pty-1', 'mobile-fit', 'phone-disconnect', 45, 20)
+    expect(ptySize).toEqual({ cols: 45, rows: 20 })
+
+    runtime.onClientDisconnected('phone-disconnect')
+    await new Promise((r) => setTimeout(r, 0))
+
+    // PTY stays at phone dims and override persists — desktop banner remains.
+    expect(ptySize).toEqual({ cols: 45, rows: 20 })
+    expect(runtime.getTerminalFitOverride('pty-1')).not.toBeNull()
   })
 })

--- a/src/main/runtime/mobile-presence-lock.test.ts
+++ b/src/main/runtime/mobile-presence-lock.test.ts
@@ -59,7 +59,12 @@ const store = {
     nestWorkspaces: false,
     refreshLocalBaseRefOnWorktreeCreate: false,
     branchPrefix: 'none',
-    branchPrefixCustom: ''
+    branchPrefixCustom: '',
+    // Why: legacy mobile tests pre-date the fit-hold preference. Default
+    // to MIN (the new clamp floor) so the auto-restore behavior they assert
+    // continues to fire after a finite delay. Real getDefaultSettings()
+    // is null/indefinite. See docs/mobile-fit-hold.md.
+    mobileAutoRestoreFitMs: 5_000
   })
 }
 
@@ -344,7 +349,7 @@ describe('mobile presence lock — multi-mobile semantics', () => {
     // NOT B's (which captured 45x20 when it joined a phone-fitted PTY).
     runtime.handleMobileUnsubscribe('pty-1', 'phone-A')
     runtime.handleMobileUnsubscribe('pty-1', 'phone-B')
-    await vi.advanceTimersByTimeAsync(300)
+    await vi.advanceTimersByTimeAsync(5_000)
 
     expect(ptySizes.get('pty-1')).toEqual({ cols: 150, rows: 40 })
   })

--- a/src/main/runtime/mobile-subscribe-integration.test.ts
+++ b/src/main/runtime/mobile-subscribe-integration.test.ts
@@ -546,6 +546,25 @@ describe('mobile subscribe integration', () => {
       expect(ptySizes.get('pty-1')).toEqual({ cols: 45, rows: 20 })
     })
 
+    it('null (indefinite) keeps PTY at phone dims when WS connection closes (onClientDisconnected)', async () => {
+      // Why: backgrounding the mobile app eventually closes the WebSocket,
+      // which routes through onClientDisconnected (NOT handleMobileUnsubscribe).
+      // The disconnect path predates indefinite-hold; without explicit gates
+      // it would unconditionally restore the PTY to desktop dims and clear
+      // the override, unmounting the desktop banner.
+      settingsState.mobileAutoRestoreFitMs = null
+      const { runtime, ptySizes } = createRuntime()
+      await runtime.handleMobileSubscribe('pty-1', 'client-a', { cols: 45, rows: 20 })
+
+      runtime.onClientDisconnected('client-a')
+      await vi.advanceTimersByTimeAsync(0)
+      // Flush soft-leave grace too — that path also has its own desktop-restore branch.
+      await vi.advanceTimersByTimeAsync(60_000)
+
+      expect(ptySizes.get('pty-1')).toEqual({ cols: 45, rows: 20 })
+      expect(runtime.getTerminalFitOverride('pty-1')).not.toBeNull()
+    })
+
     it('reclaimTerminalForDesktop returns held PTY to desktop dims (no subscriber)', async () => {
       settingsState.mobileAutoRestoreFitMs = null
       const { runtime, ptySizes } = createRuntime()

--- a/src/main/runtime/mobile-subscribe-integration.test.ts
+++ b/src/main/runtime/mobile-subscribe-integration.test.ts
@@ -44,6 +44,16 @@ vi.mock('../git/repo', async (importOriginal) => {
   }
 })
 
+// Why: many tests pre-date the mobileAutoRestoreFitMs preference. Default
+// the mock store to MIN (5_000ms — the new clamp floor) so legacy
+// assertions about "restore fires after the configured delay" keep their
+// shape while new tests can override per-test. Indefinite/null is the
+// real-world default and is exercised by a dedicated test below.
+const LEGACY_RESTORE_MS = 5_000
+const settingsState = {
+  mobileAutoRestoreFitMs: LEGACY_RESTORE_MS as number | null
+}
+
 const store = {
   getRepo: () => ({
     id: 'repo-1',
@@ -65,8 +75,14 @@ const store = {
     nestWorkspaces: false,
     refreshLocalBaseRefOnWorktreeCreate: false,
     branchPrefix: 'none',
-    branchPrefixCustom: ''
-  })
+    branchPrefixCustom: '',
+    mobileAutoRestoreFitMs: settingsState.mobileAutoRestoreFitMs
+  }),
+  updateSettings: (updates: { mobileAutoRestoreFitMs?: number | null }) => {
+    if ('mobileAutoRestoreFitMs' in updates) {
+      settingsState.mobileAutoRestoreFitMs = updates.mobileAutoRestoreFitMs ?? null
+    }
+  }
 }
 
 function createRuntime() {
@@ -112,6 +128,7 @@ function createRuntime() {
 describe('mobile subscribe integration', () => {
   beforeEach(() => {
     vi.useFakeTimers()
+    settingsState.mobileAutoRestoreFitMs = LEGACY_RESTORE_MS
   })
 
   afterEach(() => {
@@ -157,7 +174,7 @@ describe('mobile subscribe integration', () => {
     expect(resizes).toEqual([])
   })
 
-  it('handleMobileUnsubscribe restores PTY after 300ms debounce in auto mode', async () => {
+  it('handleMobileUnsubscribe restores PTY after debounce in auto mode', async () => {
     const { runtime, ptySizes } = createRuntime()
     await runtime.handleMobileSubscribe('pty-1', 'client-a', { cols: 45, rows: 20 })
     expect(ptySizes.get('pty-1')).toEqual({ cols: 45, rows: 20 })
@@ -166,7 +183,7 @@ describe('mobile subscribe integration', () => {
     // Not yet restored
     expect(ptySizes.get('pty-1')).toEqual({ cols: 45, rows: 20 })
 
-    await vi.advanceTimersByTimeAsync(300)
+    await vi.advanceTimersByTimeAsync(LEGACY_RESTORE_MS)
     expect(ptySizes.get('pty-1')).toEqual({ cols: 150, rows: 40 })
   })
 
@@ -180,7 +197,7 @@ describe('mobile subscribe integration', () => {
     expect(ptySizes.get('pty-1')).toEqual({ cols: 45, rows: 20 })
 
     runtime.handleMobileUnsubscribe('pty-1', 'client-a')
-    await vi.advanceTimersByTimeAsync(1000)
+    await vi.advanceTimersByTimeAsync(LEGACY_RESTORE_MS)
     // Restored to desktop dims — no sticky-phone retention.
     expect(ptySizes.get('pty-1')).toEqual({ cols: 150, rows: 40 })
   })
@@ -247,7 +264,7 @@ describe('mobile subscribe integration', () => {
 
     // Unsubscribe and let restore fire
     runtime.handleMobileUnsubscribe('pty-1', 'client-a')
-    await vi.advanceTimersByTimeAsync(300)
+    await vi.advanceTimersByTimeAsync(LEGACY_RESTORE_MS)
 
     // Should restore to original desktop dims, not 45x20
     expect(ptySizes.get('pty-1')).toEqual({ cols: 150, rows: 40 })
@@ -352,7 +369,7 @@ describe('mobile subscribe integration', () => {
       runtime.onClientDisconnected('client-a')
       // Timer should be cancelled, PTY already restored by disconnect handler
 
-      await vi.advanceTimersByTimeAsync(1000)
+      await vi.advanceTimersByTimeAsync(LEGACY_RESTORE_MS)
       expect(ptySizes.get('pty-1')).toEqual({ cols: 150, rows: 40 })
     })
 
@@ -367,7 +384,7 @@ describe('mobile subscribe integration', () => {
       expect(runtime.getMobileDisplayMode('pty-1')).toBe('auto')
 
       // Timer should have been cancelled — no crash from resizing a dead PTY
-      await vi.advanceTimersByTimeAsync(1000)
+      await vi.advanceTimersByTimeAsync(LEGACY_RESTORE_MS)
     })
 
     it('onPtyExit does not cancel timers for other PTYs', async () => {
@@ -378,7 +395,7 @@ describe('mobile subscribe integration', () => {
       // pty-2 exits — should not affect pty-1's pending restore
       runtime.onPtyExit('pty-2', 0)
 
-      await vi.advanceTimersByTimeAsync(300)
+      await vi.advanceTimersByTimeAsync(LEGACY_RESTORE_MS)
       expect(ptySizes.get('pty-1')).toEqual({ cols: 150, rows: 40 })
     })
   })
@@ -484,6 +501,114 @@ describe('mobile subscribe integration', () => {
       const restoreResult = await runtime.resizeForClient('pty-1', 'restore', 'client-old')
       expect(ptySizes.get('pty-1')).toEqual({ cols: 150, rows: 40 })
       expect(restoreResult.mode).toBe('desktop-fit')
+    })
+  })
+
+  // See docs/mobile-fit-hold.md.
+  describe('mobileAutoRestoreFitMs (fit hold)', () => {
+    it('null (indefinite) keeps PTY at phone dims after last unsubscribe', async () => {
+      settingsState.mobileAutoRestoreFitMs = null
+      const { runtime, ptySizes } = createRuntime()
+      await runtime.handleMobileSubscribe('pty-1', 'client-a', { cols: 45, rows: 20 })
+      runtime.handleMobileUnsubscribe('pty-1', 'client-a')
+
+      // Wait long past the legacy 300ms debounce — PTY must remain held.
+      await vi.advanceTimersByTimeAsync(60_000)
+      expect(ptySizes.get('pty-1')).toEqual({ cols: 45, rows: 20 })
+    })
+
+    it('finite ms restores after the configured delay', async () => {
+      settingsState.mobileAutoRestoreFitMs = 60_000
+      const { runtime, ptySizes } = createRuntime()
+      await runtime.handleMobileSubscribe('pty-1', 'client-a', { cols: 45, rows: 20 })
+      runtime.handleMobileUnsubscribe('pty-1', 'client-a')
+
+      await vi.advanceTimersByTimeAsync(30_000)
+      // Not yet — still mid-window.
+      expect(ptySizes.get('pty-1')).toEqual({ cols: 45, rows: 20 })
+
+      await vi.advanceTimersByTimeAsync(30_000)
+      expect(ptySizes.get('pty-1')).toEqual({ cols: 150, rows: 40 })
+    })
+
+    it('re-subscribe before timer fires cancels pending restore', async () => {
+      settingsState.mobileAutoRestoreFitMs = 60_000
+      const { runtime, ptySizes } = createRuntime()
+      await runtime.handleMobileSubscribe('pty-1', 'client-a', { cols: 45, rows: 20 })
+      runtime.handleMobileUnsubscribe('pty-1', 'client-a')
+
+      await vi.advanceTimersByTimeAsync(30_000)
+      await runtime.handleMobileSubscribe('pty-1', 'client-a', { cols: 45, rows: 20 })
+
+      // The pending timer should have been cancelled by the new subscribe.
+      // Wait long past what would've been the restore moment.
+      await vi.advanceTimersByTimeAsync(120_000)
+      expect(ptySizes.get('pty-1')).toEqual({ cols: 45, rows: 20 })
+    })
+
+    it('reclaimTerminalForDesktop returns held PTY to desktop dims (no subscriber)', async () => {
+      settingsState.mobileAutoRestoreFitMs = null
+      const { runtime, ptySizes } = createRuntime()
+      await runtime.handleMobileSubscribe('pty-1', 'client-a', { cols: 45, rows: 20 })
+      runtime.handleMobileUnsubscribe('pty-1', 'client-a')
+
+      // No subscribers, indefinite hold — PTY stays at phone dims.
+      await vi.advanceTimersByTimeAsync(60_000)
+      expect(ptySizes.get('pty-1')).toEqual({ cols: 45, rows: 20 })
+      expect(runtime.isMobileSubscriberActive('pty-1')).toBe(false)
+
+      // Manual reclaim: PTY restored to desktop dims via the held branch.
+      const ok = await runtime.reclaimTerminalForDesktop('pty-1')
+      expect(ok).toBe(true)
+      expect(ptySizes.get('pty-1')).toEqual({ cols: 150, rows: 40 })
+    })
+
+    it('setMobileAutoRestoreFitMs(null) clears all pending timers', async () => {
+      settingsState.mobileAutoRestoreFitMs = 60_000
+      const { runtime, ptySizes } = createRuntime()
+      await runtime.handleMobileSubscribe('pty-1', 'client-a', { cols: 45, rows: 20 })
+      runtime.handleMobileUnsubscribe('pty-1', 'client-a')
+
+      // Pending timer exists. Switch preference → indefinite.
+      runtime.setMobileAutoRestoreFitMs(null)
+      // Now wait far longer than the original 60s window. No restore fires.
+      await vi.advanceTimersByTimeAsync(120_000)
+      expect(ptySizes.get('pty-1')).toEqual({ cols: 45, rows: 20 })
+    })
+
+    it('setMobileAutoRestoreFitMs to a finite value does not retroactively schedule', async () => {
+      settingsState.mobileAutoRestoreFitMs = null
+      const { runtime, ptySizes } = createRuntime()
+      await runtime.handleMobileSubscribe('pty-1', 'client-a', { cols: 45, rows: 20 })
+      runtime.handleMobileUnsubscribe('pty-1', 'client-a')
+
+      // Indefinite hold — no timer scheduled at unsubscribe.
+      // Switch preference → 60s. The already-held PTY is NOT auto-restored;
+      // the new value applies to the *next* unsubscribe.
+      runtime.setMobileAutoRestoreFitMs(60_000)
+      await vi.advanceTimersByTimeAsync(120_000)
+      expect(ptySizes.get('pty-1')).toEqual({ cols: 45, rows: 20 })
+    })
+
+    it('setMobileAutoRestoreFitMs clamps below MIN to MIN', () => {
+      const { runtime } = createRuntime()
+      const result = runtime.setMobileAutoRestoreFitMs(100)
+      expect(result).toBe(5_000)
+    })
+
+    it('setMobileAutoRestoreFitMs clamps above MAX to MAX', () => {
+      const { runtime } = createRuntime()
+      const result = runtime.setMobileAutoRestoreFitMs(99 * 60 * 60 * 1000)
+      expect(result).toBe(60 * 60 * 1000)
+    })
+
+    it('reclaimTerminalForDesktop on already-restored PTY returns false', async () => {
+      const { runtime } = createRuntime()
+      await runtime.handleMobileSubscribe('pty-1', 'client-a', { cols: 45, rows: 20 })
+      runtime.handleMobileUnsubscribe('pty-1', 'client-a')
+      await vi.advanceTimersByTimeAsync(LEGACY_RESTORE_MS)
+      // Now restored to desktop — no subscriber, no override.
+      expect(await runtime.reclaimTerminalForDesktop('pty-1')).toBe(false)
     })
   })
 })

--- a/src/main/runtime/mobile-subscribe-integration.test.ts
+++ b/src/main/runtime/mobile-subscribe-integration.test.ts
@@ -517,6 +517,32 @@ describe('mobile subscribe integration', () => {
       await runtime.applyMobileDisplayMode('pty-1')
       expect(ptySizes.get('pty-1')).toEqual({ cols: 130, rows: 35 })
     })
+
+    it('updates baseline mid-fit when desktop reports dims that differ from the override', async () => {
+      // Why: a previously-hidden desktop tab can become visible while the
+      // phone is still phone-fitting (e.g. user activates the tab on
+      // desktop). The pane's container goes 0×0 → real geometry, fitAddon
+      // measures, and pty:resize fires with REAL dims (not the override's
+      // phone dims). That report is legitimate and must refresh the
+      // restore baseline so take-back lands on the visible desktop
+      // geometry instead of whatever stale baseline the subscriber
+      // captured at first subscribe.
+      const { runtime, ptySizes } = createRuntime()
+      // Pre-populate with an old/stale baseline (e.g. spawn default 80×24)
+      // by first reporting it before subscribe, then subscribing.
+      ptySizes.set('pty-1', { cols: 80, rows: 24 })
+      runtime.onExternalPtyResize('pty-1', 80, 24)
+      await runtime.handleMobileSubscribe('pty-1', 'client-a', { cols: 45, rows: 20 })
+
+      // Desktop tab gets activated mid-fit; renderer reports real dims.
+      // These differ from the override (45×20), so they must pass through.
+      runtime.onExternalPtyResize('pty-1', 200, 60)
+
+      // Take back — should land on 200×60, not 80×24.
+      runtime.setMobileDisplayMode('pty-1', 'desktop')
+      await runtime.applyMobileDisplayMode('pty-1')
+      expect(ptySizes.get('pty-1')).toEqual({ cols: 200, rows: 60 })
+    })
   })
 
   describe('backward compatibility', () => {

--- a/src/main/runtime/mobile-subscribe-integration.test.ts
+++ b/src/main/runtime/mobile-subscribe-integration.test.ts
@@ -545,6 +545,65 @@ describe('mobile subscribe integration', () => {
     })
   })
 
+  describe('recordRendererGeometry (pty:reportGeometry IPC)', () => {
+    it('refreshes subscriber baseline while a mobile-fit override is active', async () => {
+      // Why: backs the partial-restore-width fix. When phone subscribes to
+      // a never-desktop-active terminal, the subscriber baseline is the
+      // PTY spawn default (e.g. 80×24). The renderer's measurement-only
+      // report (sent when the desktop pane finally measures real geometry)
+      // must update the baseline so Take Back restores to real dims.
+      const { runtime, ptySizes } = createRuntime()
+      ptySizes.set('pty-1', { cols: 80, rows: 24 })
+      runtime.onExternalPtyResize('pty-1', 80, 24)
+      await runtime.handleMobileSubscribe('pty-1', 'client-a', { cols: 45, rows: 20 })
+
+      // Override is now in place (phone-fit). Desktop pane becomes visible
+      // and measures real geometry. The renderer reports it via the
+      // measurement-only channel.
+      runtime.recordRendererGeometry('pty-1', 214, 72)
+
+      // Take back — should restore to the reported dims, not 80×24.
+      runtime.setMobileDisplayMode('pty-1', 'desktop')
+      await runtime.applyMobileDisplayMode('pty-1')
+      expect(ptySizes.get('pty-1')).toEqual({ cols: 214, rows: 72 })
+    })
+
+    it('updates lastRendererSizes for a never-subscribed PTY', () => {
+      // Why: handleMobileSubscribe's previousCols fallback chain reads
+      // lastRendererSizes. A geometry report fired before the first
+      // subscribe must populate that cache so the subscriber's baseline
+      // captures real dims, not the spawn default.
+      const { runtime } = createRuntime()
+      runtime.recordRendererGeometry('pty-99', 180, 50)
+
+      const renderer = runtime.getLastRendererSize('pty-99')
+      expect(renderer).toEqual({ cols: 180, rows: 50 })
+    })
+
+    it('ignores non-positive dims', () => {
+      const { runtime } = createRuntime()
+      runtime.recordRendererGeometry('pty-1', 0, 0)
+      runtime.recordRendererGeometry('pty-1', -5, 10)
+      runtime.recordRendererGeometry('pty-1', 10, -5)
+      expect(runtime.getLastRendererSize('pty-1')).toBeNull()
+    })
+
+    it('bypasses the cascade-suppress window (it is measurement-only)', async () => {
+      // Why: pty:resize is gated by a 500ms suppress to absorb the safeFit
+      // cascade after a mode flip. The measurement-only channel must not
+      // be gated — its whole purpose is to deliver a fresh measurement
+      // when the renderer detects the pane container has finally settled
+      // to real geometry, including potentially right after a flip.
+      const { runtime } = createRuntime()
+      // Arm cascade-suppress.
+      runtime.setMobileDisplayMode('pty-1', 'desktop')
+      await runtime.applyMobileDisplayMode('pty-1')
+      // Within the 500ms window:
+      runtime.recordRendererGeometry('pty-1', 130, 40)
+      expect(runtime.getLastRendererSize('pty-1')).toEqual({ cols: 130, rows: 40 })
+    })
+  })
+
   describe('backward compatibility', () => {
     it('old resizeForClient still works alongside new system', async () => {
       const { runtime, ptySizes } = createRuntime()

--- a/src/main/runtime/mobile-subscribe-integration.test.ts
+++ b/src/main/runtime/mobile-subscribe-integration.test.ts
@@ -468,23 +468,54 @@ describe('mobile subscribe integration', () => {
       expect(ptySizes.get('pty-1')).toEqual({ cols: 105, rows: 40 })
     })
 
-    it('refreshes baseline on phone-fitted subscribers when their baseline is non-null', async () => {
-      // Behavior change per docs/mobile-terminal-layout-state-machine.md:
-      // legacy `!wasResizedToPhone` gate is replaced with `previousCols != null`.
-      // A phone-fitted subscriber's baseline IS non-null (captured at subscribe),
-      // so onExternalPtyResize now overwrites it with the renderer's reported geometry.
+    it('ignores reports while a mobile-fit override is in place', async () => {
+      // Why: while a mobile-fit override is in place, the PTY is parked at
+      // phone dims and the desktop renderer's safeFit will report those
+      // phone dims back to us. Treating that as "external" geometry would
+      // overwrite the subscriber's previousCols/Rows baseline with phone
+      // dims; resolveDesktopRestoreTarget would then return phone dims on
+      // the next "Restore" click, leaving xterm stuck at phone dims after
+      // a no-op desktop-restore. See docs/mobile-fit-hold.md.
       const { runtime, ptySizes } = createRuntime()
       await runtime.handleMobileSubscribe('pty-1', 'client-a', { cols: 45, rows: 20 })
 
-      // Renderer reports 45x20 — under the new design, this overwrites baseline
-      // (previously it was skipped because the subscriber was phone-fitted).
+      // Renderer reports phone dims back (echo of override). Must be ignored.
       runtime.onExternalPtyResize('pty-1', 45, 20)
 
-      // Toggle to desktop — restore lands on what the renderer reported (45x20),
-      // not the original 150x40.
+      // Toggle to desktop — restore lands on the original desktop baseline,
+      // not the phone-dim echo.
       runtime.setMobileDisplayMode('pty-1', 'desktop')
       await runtime.applyMobileDisplayMode('pty-1')
+      expect(ptySizes.get('pty-1')).toEqual({ cols: 150, rows: 40 })
+    })
+
+    it('still updates baseline once the override is cleared (real desktop resize)', async () => {
+      // Counterpart to the above: after the user takes back, the renderer's
+      // pty:resize events ARE legitimate geometry reports and must update
+      // the baseline used by the next phone-fit cycle.
+      const { runtime, ptySizes } = createRuntime()
+      await runtime.handleMobileSubscribe('pty-1', 'client-a', { cols: 45, rows: 20 })
+
+      // Take back — clears override and arms the 500ms cascade-suppress.
+      runtime.setMobileDisplayMode('pty-1', 'desktop')
+      await runtime.applyMobileDisplayMode('pty-1')
+      expect(ptySizes.get('pty-1')).toEqual({ cols: 150, rows: 40 })
+
+      // Wait past the renderer-cascade suppress window.
+      await vi.advanceTimersByTimeAsync(500)
+
+      // User resizes the desktop window. Renderer fires pty:resize.
+      runtime.onExternalPtyResize('pty-1', 130, 35)
+
+      // Toggle back to phone, then take back again — should restore to the
+      // updated desktop geometry, not the original 150x40.
+      runtime.setMobileDisplayMode('pty-1', 'auto')
+      await runtime.applyMobileDisplayMode('pty-1')
       expect(ptySizes.get('pty-1')).toEqual({ cols: 45, rows: 20 })
+
+      runtime.setMobileDisplayMode('pty-1', 'desktop')
+      await runtime.applyMobileDisplayMode('pty-1')
+      expect(ptySizes.get('pty-1')).toEqual({ cols: 130, rows: 35 })
     })
   })
 
@@ -567,6 +598,75 @@ describe('mobile subscribe integration', () => {
       // Mobile re-subscribes (e.g. tab switch). Must re-fit to phone dims.
       await runtime.handleMobileSubscribe('pty-1', 'client-a', { cols: 45, rows: 20 })
       expect(ptySizes.get('pty-1')).toEqual({ cols: 45, rows: 20 })
+    })
+
+    it('reclaim with WS disconnect between cycles — held branch restores correctly each time', async () => {
+      // Why: regression for "subsequent take-back stuck on phone dims" with
+      // indefinite hold. The realistic flow is:
+      //   subscribe → desktop reclaim → WS disconnect (background app) →
+      //   phone re-subscribes → WS disconnect → desktop reclaim (held branch)
+      // The held branch must restore to real desktop dims every time, not
+      // get stuck reading current PTY size (= phone dims).
+      settingsState.mobileAutoRestoreFitMs = null
+      const { runtime, ptySizes } = createRuntime()
+
+      for (let i = 0; i < 3; i++) {
+        // Phone subscribes, fits to phone dims.
+        await runtime.handleMobileSubscribe('pty-1', 'client-a', { cols: 45, rows: 20 })
+        expect(ptySizes.get('pty-1'), `iter ${i}: phone-fit`).toEqual({ cols: 45, rows: 20 })
+
+        // Phone WS disconnects (e.g. backgrounding). With indefinite hold,
+        // PTY stays at phone dims and override persists; subscriber is
+        // removed from inner.
+        runtime.onClientDisconnected('client-a')
+        await vi.advanceTimersByTimeAsync(0)
+        await vi.advanceTimersByTimeAsync(60_000)
+        expect(ptySizes.get('pty-1'), `iter ${i}: held after disconnect`).toEqual({
+          cols: 45,
+          rows: 20
+        })
+        expect(runtime.isMobileSubscriberActive('pty-1'), `iter ${i}: no subscribers`).toBe(false)
+        expect(
+          runtime.getTerminalFitOverride('pty-1'),
+          `iter ${i}: override held`
+        ).not.toBeNull()
+
+        // Desktop clicks Restore — held-override branch.
+        const ok = await runtime.reclaimTerminalForDesktop('pty-1')
+        expect(ok, `iter ${i}: reclaim ok`).toBe(true)
+        expect(ptySizes.get('pty-1'), `iter ${i}: PTY restored to desktop`).toEqual({
+          cols: 150,
+          rows: 40
+        })
+        expect(
+          runtime.getTerminalFitOverride('pty-1'),
+          `iter ${i}: override cleared`
+        ).toBeNull()
+      }
+    })
+
+    it('reclaim → re-subscribe → reclaim cycle works repeatedly', async () => {
+      // Why: regression for "subsequent take-back doesn't change dims, stuck
+      // at phone dims". The full ping-pong must work N times, not just once.
+      const { runtime, ptySizes } = createRuntime()
+
+      for (let i = 0; i < 3; i++) {
+        // Phone takes the floor (or first subscribe).
+        await runtime.handleMobileSubscribe('pty-1', 'client-a', { cols: 45, rows: 20 })
+        expect(ptySizes.get('pty-1'), `iter ${i}: phone-fit`).toEqual({ cols: 45, rows: 20 })
+
+        // Desktop reclaims.
+        const ok = await runtime.reclaimTerminalForDesktop('pty-1')
+        expect(ok, `iter ${i}: reclaim ok`).toBe(true)
+        expect(ptySizes.get('pty-1'), `iter ${i}: reclaimed to desktop`).toEqual({
+          cols: 150,
+          rows: 40
+        })
+        expect(
+          runtime.getTerminalFitOverride('pty-1'),
+          `iter ${i}: override cleared`
+        ).toBeNull()
+      }
     })
 
     it('null (indefinite) keeps PTY at phone dims when WS connection closes (onClientDisconnected)', async () => {

--- a/src/main/runtime/mobile-subscribe-integration.test.ts
+++ b/src/main/runtime/mobile-subscribe-integration.test.ts
@@ -270,6 +270,37 @@ describe('mobile subscribe integration', () => {
     expect(ptySizes.get('pty-1')).toEqual({ cols: 150, rows: 40 })
   })
 
+  it('preserves held-override baseline across resubscribe-after-indefinite-hold', async () => {
+    // Why: when the last mobile subscriber leaves under indefinite hold,
+    // the inner-subscribers map is wiped but `terminalFitOverrides` retains
+    // the original desktop dims as previousCols/previousRows. A fresh
+    // resubscribe must inherit those — otherwise rendererSize/currentSize
+    // (both phone dims because the override held them) would replace the
+    // baseline with phone dims, and any subsequent desktop "Restore" would
+    // be a no-op (restore-target == current dims).
+    settingsState.mobileAutoRestoreFitMs = null // indefinite hold
+    const { runtime, ptySizes } = createRuntime()
+
+    // Initial subscribe at desktop 150x40 → fit to 45x20.
+    await runtime.handleMobileSubscribe('pty-1', 'client-a', { cols: 45, rows: 20 })
+    expect(ptySizes.get('pty-1')).toEqual({ cols: 45, rows: 20 })
+
+    // Phone leaves; indefinite hold keeps PTY at phone dims with no
+    // subscribers. Override baseline still carries 150x40.
+    runtime.handleMobileUnsubscribe('pty-1', 'client-a')
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(ptySizes.get('pty-1')).toEqual({ cols: 45, rows: 20 })
+
+    // Phone reopens — fresh resubscribe (inner map is empty).
+    await runtime.handleMobileSubscribe('pty-1', 'client-a', { cols: 45, rows: 20 })
+
+    // Desktop user clicks Restore.
+    await runtime.reclaimTerminalForDesktop('pty-1')
+
+    // Must restore to the original 150x40, not the phone-fit 45x20.
+    expect(ptySizes.get('pty-1')).toEqual({ cols: 150, rows: 40 })
+  })
+
   it('clamps viewport to valid range', async () => {
     const { runtime, ptySizes } = createRuntime()
 

--- a/src/main/runtime/mobile-subscribe-integration.test.ts
+++ b/src/main/runtime/mobile-subscribe-integration.test.ts
@@ -546,6 +546,29 @@ describe('mobile subscribe integration', () => {
       expect(ptySizes.get('pty-1')).toEqual({ cols: 45, rows: 20 })
     })
 
+    it('reclaimTerminalForDesktop with active subscriber resets mode so next subscribe re-fits', async () => {
+      // Why: desktop "Take back" while the phone is actively driving sets
+      // mobileDisplayMode='desktop' to drive the layout transition. Without
+      // resetting it, the next mobile subscribe (e.g. user switches tabs
+      // back on the phone) sees mode='desktop' and enters passive watch,
+      // never re-fitting the PTY to phone dims. The phone then renders the
+      // desktop-dim scrollback echoed back at it. See docs/mobile-fit-hold.md.
+      const { runtime, ptySizes } = createRuntime()
+      await runtime.handleMobileSubscribe('pty-1', 'client-a', { cols: 45, rows: 20 })
+      expect(ptySizes.get('pty-1')).toEqual({ cols: 45, rows: 20 })
+
+      // Desktop reclaim while phone is still subscribed.
+      const ok = await runtime.reclaimTerminalForDesktop('pty-1')
+      expect(ok).toBe(true)
+      expect(ptySizes.get('pty-1')).toEqual({ cols: 150, rows: 40 })
+      // Mode reset so a re-subscribe takes the auto path.
+      expect(runtime.getMobileDisplayMode('pty-1')).toBe('auto')
+
+      // Mobile re-subscribes (e.g. tab switch). Must re-fit to phone dims.
+      await runtime.handleMobileSubscribe('pty-1', 'client-a', { cols: 45, rows: 20 })
+      expect(ptySizes.get('pty-1')).toEqual({ cols: 45, rows: 20 })
+    })
+
     it('null (indefinite) keeps PTY at phone dims when WS connection closes (onClientDisconnected)', async () => {
       // Why: backgrounding the mobile app eventually closes the WebSocket,
       // which routes through onClientDisconnected (NOT handleMobileUnsubscribe).

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1544,7 +1544,11 @@ export class OrcaRuntimeService {
       }
 
       const cur = this.layouts.get(ptyId)
-      if (cur?.kind === 'phone') {
+      // Why: Indefinite hold (mobileAutoRestoreFitMs == null) keeps the PTY
+      // at phone dims after the phone disconnects; the desktop banner's
+      // Restore button is the explicit return path. See
+      // docs/mobile-fit-hold.md.
+      if (cur?.kind === 'phone' && this.getAutoRestoreFitMs() != null) {
         // Use the soft-leaver's snapshot baseline as a hint, falling
         // through to resolveDesktopRestoreTarget for missing values.
         const fallback = this.resolveDesktopRestoreTarget(ptyId)
@@ -1581,7 +1585,8 @@ export class OrcaRuntimeService {
     }
     for (const { ptyId, baseline } of ptysToRestore) {
       const cur = this.layouts.get(ptyId)
-      if (cur?.kind === 'phone') {
+      // Why: Indefinite hold gate — see soft-leaver branch above.
+      if (cur?.kind === 'phone' && this.getAutoRestoreFitMs() != null) {
         const fallback = this.resolveDesktopRestoreTarget(ptyId)
         const cols = baseline?.cols ?? fallback.cols
         const rows = baseline?.rows ?? fallback.rows
@@ -1636,6 +1641,11 @@ export class OrcaRuntimeService {
       }
       const cur = this.layouts.get(ptyId)
       if (cur?.kind !== 'phone') {
+        continue
+      }
+      // Why: Indefinite hold gate — see soft-leaver branch above. Legacy
+      // mobile clients (resizeForClient path) honor the same setting.
+      if (this.getAutoRestoreFitMs() == null) {
         continue
       }
       const fallback = this.resolveDesktopRestoreTarget(ptyId)

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -2668,8 +2668,37 @@ export class OrcaRuntimeService {
     ) {
       return
     }
-    this.lastRendererSizes.set(ptyId, { cols, rows })
+    this.refreshRendererGeometry(ptyId, cols, rows)
+  }
 
+  // Why: pty:reportGeometry IPC sibling. The renderer calls this when a
+  // desktop pane container goes from 0×0 to a real size while a mobile-fit
+  // override is active (e.g. user activates a previously-hidden tab on
+  // desktop after the phone has already taken the floor). We need the
+  // restore-target baseline to track real desktop dims even during the
+  // fit period — otherwise resolveDesktopRestoreTarget falls back to the
+  // PTY's spawn default (typically 80×24) and Take Back leaves the
+  // terminal partially restored. This is a measurement-only channel: it
+  // refreshes lastRendererSizes and non-null subscriber baselines, never
+  // resizes the PTY, and bypasses both isResizeSuppressed and the
+  // override-echo gate by design — the renderer only fires it when it
+  // has just measured fresh real geometry. See docs/mobile-fit-hold.md.
+  recordRendererGeometry(ptyId: string, cols: number, rows: number): void {
+    if (cols <= 0 || rows <= 0) {
+      return
+    }
+    this.refreshRendererGeometry(ptyId, cols, rows)
+  }
+
+  // Why: test seam — exposes lastRendererSizes for assertions about
+  // pty:reportGeometry / onExternalPtyResize side effects without making
+  // the underlying Map writable from the outside.
+  getLastRendererSize(ptyId: string): { cols: number; rows: number } | null {
+    return this.lastRendererSizes.get(ptyId) ?? null
+  }
+
+  private refreshRendererGeometry(ptyId: string, cols: number, rows: number): void {
+    this.lastRendererSizes.set(ptyId, { cols, rows })
     const inner = this.mobileSubscribers.get(ptyId)
     if (!inner) {
       return

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -2244,14 +2244,6 @@ export class OrcaRuntimeService {
   ): void {
     const inner = this.mobileSubscribers.get(ptyId)
     const record = inner?.get(clientId)
-    console.log('[fit][server] updateMobileSubscriberViewport', {
-      ptyId: ptyId.slice(-8),
-      clientId: clientId.slice(-8),
-      viewport,
-      hasInner: !!inner,
-      innerSize: inner?.size ?? 0,
-      hasRecord: !!record
-    })
     if (!record) {
       return
     }
@@ -2277,17 +2269,7 @@ export class OrcaRuntimeService {
     viewport?: { cols: number; rows: number }
   ): Promise<boolean> {
     const mode = this.mobileDisplayModes.get(ptyId) ?? 'auto'
-    const currentSize0 = this.getTerminalSize(ptyId)
-    console.log('[fit][server] handleMobileSubscribe', {
-      ptyId: ptyId.slice(-8),
-      clientId: clientId.slice(-8),
-      viewport,
-      mode,
-      currentSize: currentSize0,
-      hadInner: this.mobileSubscribers.has(ptyId)
-    })
     if (!viewport) {
-      console.log('[fit][server] handleMobileSubscribe NO_VIEWPORT — skipping fit')
       return false
     }
 
@@ -2391,24 +2373,13 @@ export class OrcaRuntimeService {
     // Route the actual resize through the state machine. The fresh-subscribe
     // gate lets enqueueLayout's "no layouts entry" short-circuit pass on
     // the very first transition for this PTY.
-    console.log('[fit][server] handleMobileSubscribe enqueueing phone fit', {
-      ptyId: ptyId.slice(-8),
-      cols: clampedCols,
-      rows: clampedRows,
-      mode
-    })
     this.freshSubscribeGuard.add(ptyId)
     try {
-      const result = await this.enqueueLayout(ptyId, {
+      await this.enqueueLayout(ptyId, {
         kind: 'phone',
         cols: clampedCols,
         rows: clampedRows,
         ownerClientId: clientId
-      })
-      console.log('[fit][server] handleMobileSubscribe enqueue result', {
-        ptyId: ptyId.slice(-8),
-        result,
-        sizeAfter: this.getTerminalSize(ptyId)
       })
     } finally {
       this.freshSubscribeGuard.delete(ptyId)
@@ -2570,16 +2541,6 @@ export class OrcaRuntimeService {
     const inner = this.mobileSubscribers.get(ptyId)
     const subscriber = inner ? this.pickMostRecentActor(inner) : null
     const subscriberRecord = subscriber && inner ? inner.get(subscriber.clientId) : null
-    console.log('[fit][server] applyMobileDisplayMode', {
-      ptyId: ptyId.slice(-8),
-      mode,
-      hasInner: !!inner,
-      innerSize: inner?.size ?? 0,
-      subscriberId: subscriber?.clientId.slice(-8),
-      hasRecord: !!subscriberRecord,
-      recordViewport: subscriberRecord?.viewport,
-      wasResizedToPhone: subscriberRecord?.wasResizedToPhone
-    })
 
     if (mode === 'desktop') {
       // Reset wasResizedToPhone on every fitted subscriber so a future

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -2651,16 +2651,21 @@ export class OrcaRuntimeService {
     if (this.isResizeSuppressed()) {
       return
     }
-    // Why: while a mobile-fit override is in place, the PTY is parked at
-    // phone dims. Any desktop-renderer-reported pty:resize for this ptyId
-    // is reporting the override's phone dims back to us — not the
-    // underlying desktop pane geometry. Treating it as "external" would
-    // overwrite each subscriber's previousCols/Rows baseline with phone
-    // dims, which is the value resolveDesktopRestoreTarget reads when
-    // the user clicks Restore. The result: take-back enqueues
-    // {kind:'desktop', cols:49, rows:40}, which is a no-op resize and
-    // leaves xterm stuck at phone dims.
-    if (this.terminalFitOverrides.has(ptyId)) {
+    // Why: while a mobile-fit override is in place, the desktop renderer's
+    // safeFit echoes pty:resize(override.cols, override.rows). Treating that
+    // echo as legitimate geometry would overwrite each subscriber's
+    // previousCols/Rows baseline with phone dims, so the next take-back
+    // enqueues a no-op {kind:'desktop', cols:49, rows:40} and leaves xterm
+    // stuck. Only filter reports that EXACTLY match the override — a fresh
+    // measurement from a now-visible pane (e.g. user activated a previously
+    // hidden tab on desktop, container went 0×0 → 1782×1195) reports
+    // different dims and is the right baseline to remember.
+    const activeOverride = this.terminalFitOverrides.get(ptyId)
+    if (
+      activeOverride &&
+      activeOverride.cols === cols &&
+      activeOverride.rows === rows
+    ) {
       return
     }
     this.lastRendererSizes.set(ptyId, { cols, rows })

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -2328,15 +2328,24 @@ export class OrcaRuntimeService {
     // Multi-mobile: peer joiner against an already-fitted PTY captures null
     // — the existing baseline-holder's snapshot remains canonical. See
     // docs/mobile-presence-lock.md.
+    //
+    // Resubscribe-after-indefinite-hold: the held override carries the only
+    // authoritative pre-fit dims across the no-subscriber gap. Inherit it
+    // first; otherwise rendererSize/currentSize would be the held phone dims
+    // and applyLayout would clobber the override's previousCols with phone
+    // dims, making any subsequent Restore a no-op.
+    const heldOverride = this.terminalFitOverrides.get(ptyId)
     const existing = inner.get(clientId)
     const someoneAlreadyFitted = [...inner.values()].some((s) => s.wasResizedToPhone)
     const currentSize = this.getTerminalSize(ptyId)
     const rendererSize = this.lastRendererSizes.get(ptyId)
     const previousCols =
       existing?.previousCols ??
+      heldOverride?.previousCols ??
       (someoneAlreadyFitted ? null : (rendererSize?.cols ?? currentSize?.cols ?? null))
     const previousRows =
       existing?.previousRows ??
+      heldOverride?.previousRows ??
       (someoneAlreadyFitted ? null : (rendererSize?.rows ?? currentSize?.rows ?? null))
     const now = Date.now()
     const subscribedAt = existing?.subscribedAt ?? now

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1832,6 +1832,11 @@ export class OrcaRuntimeService {
       this.setMobileDisplayMode(ptyId, 'desktop')
       await this.applyMobileDisplayMode(ptyId)
       this.setDriver(ptyId, { kind: 'desktop' })
+      // Why: a desktop-initiated reclaim is "I'm taking over right now",
+      // not a sticky preference. The next mobile subscribe (e.g. user
+      // switches back to the terminal tab on the phone) must default to
+      // phone-fit again, not stay in passive desktop-watch mode.
+      this.setMobileDisplayMode(ptyId, 'auto')
       return true
     }
     const heldOverride = this.terminalFitOverrides.get(ptyId)
@@ -1851,6 +1856,12 @@ export class OrcaRuntimeService {
       const rows = heldOverride.previousRows ?? fallback.rows
       await this.enqueueLayout(ptyId, { kind: 'desktop', cols, rows })
       this.setDriver(ptyId, { kind: 'desktop' })
+      // Why: a desktop-initiated reclaim is "I'm taking over right now",
+      // not a sticky preference. Reset to auto so the next mobile subscribe
+      // re-enters phone-fit. (Held-PTY branch may not have an entry, but
+      // calling setMobileDisplayMode('auto') is a no-op deletion in that
+      // case — safe and idempotent.)
+      this.setMobileDisplayMode(ptyId, 'auto')
       return true
     }
     return false

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -2651,6 +2651,18 @@ export class OrcaRuntimeService {
     if (this.isResizeSuppressed()) {
       return
     }
+    // Why: while a mobile-fit override is in place, the PTY is parked at
+    // phone dims. Any desktop-renderer-reported pty:resize for this ptyId
+    // is reporting the override's phone dims back to us — not the
+    // underlying desktop pane geometry. Treating it as "external" would
+    // overwrite each subscriber's previousCols/Rows baseline with phone
+    // dims, which is the value resolveDesktopRestoreTarget reads when
+    // the user clicks Restore. The result: take-back enqueues
+    // {kind:'desktop', cols:49, rows:40}, which is a no-op resize and
+    // leaves xterm stuck at phone dims.
+    if (this.terminalFitOverrides.has(ptyId)) {
+      return
+    }
     this.lastRendererSizes.set(ptyId, { cols, rows })
 
     const inner = this.mobileSubscribers.get(ptyId)

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -16,6 +16,7 @@ import { OrchestrationDb } from './orchestration/db'
 import { formatMessagesForInjection } from './orchestration/formatter'
 import type {
   CreateWorktreeResult,
+  GlobalSettings,
   Repo,
   StatsSummary,
   WorktreeStartupLaunch
@@ -173,7 +174,12 @@ type RuntimeStore = {
     refreshLocalBaseRefOnWorktreeCreate: boolean
     branchPrefix: string
     branchPrefixCustom: string
+    mobileAutoRestoreFitMs?: number | null
   }
+  // Why: narrow to `unknown` return so test mocks can return void without
+  // a cast. The runtime never reads the return value — the persisted value
+  // is read back via getSettings() on the next access.
+  updateSettings?: (updates: Partial<GlobalSettings>) => unknown
 }
 
 type RuntimeLeafRecord = RuntimeSyncedLeaf & {
@@ -1801,17 +1807,107 @@ export class OrcaRuntimeService {
   }
 
   // Why: invoked from `runtime:restoreTerminalFit` IPC (the desktop "Take
-  // back" button). Forces the PTY back to desktop dims and flips the driver
-  // to `desktop`, suppressing further mobile-driven dim changes until a
-  // mobile actor takes the floor again.
+  // back" / "Restore" button). Forces the PTY back to desktop dims and
+  // flips the driver to `desktop`, suppressing further mobile-driven dim
+  // changes until a mobile actor takes the floor again. Two cases:
+  //   1. Active mobile subscriber: route through applyMobileDisplayMode so
+  //      the existing 'resized' event reaches the phone.
+  //   2. Held with no mobile subscriber (post-indefinite-hold): no inner
+  //      subscriber to notify; resolve restore target and enqueueLayout
+  //      directly. applyLayout is the SOLE writer of terminalFitOverrides;
+  //      the held branch must not duplicate that mutation. See
+  //      docs/mobile-fit-hold.md.
   async reclaimTerminalForDesktop(ptyId: string): Promise<boolean> {
-    if (!this.isMobileSubscriberActive(ptyId)) {
-      return false
+    if (this.isMobileSubscriberActive(ptyId)) {
+      this.setMobileDisplayMode(ptyId, 'desktop')
+      await this.applyMobileDisplayMode(ptyId)
+      this.setDriver(ptyId, { kind: 'desktop' })
+      return true
     }
-    this.setMobileDisplayMode(ptyId, 'desktop')
-    await this.applyMobileDisplayMode(ptyId)
-    this.setDriver(ptyId, { kind: 'desktop' })
-    return true
+    const heldOverride = this.terminalFitOverrides.get(ptyId)
+    if (heldOverride) {
+      const pending = this.pendingRestoreTimers.get(ptyId)
+      if (pending) {
+        clearTimeout(pending.timer)
+        this.pendingRestoreTimers.delete(ptyId)
+      }
+      // Why: with no subscribers, resolveDesktopRestoreTarget falls through
+      // to current PTY size — which is at phone dims (wrong). Prefer the
+      // baseline captured on the override at first phone-fit; this is the
+      // last desktop geometry the layout machine knew about. Then chain
+      // to the standard resolver for the residual fallbacks.
+      const fallback = this.resolveDesktopRestoreTarget(ptyId)
+      const cols = heldOverride.previousCols ?? fallback.cols
+      const rows = heldOverride.previousRows ?? fallback.rows
+      await this.enqueueLayout(ptyId, { kind: 'desktop', cols, rows })
+      this.setDriver(ptyId, { kind: 'desktop' })
+      return true
+    }
+    return false
+  }
+
+  // Why: read-side clamp for mobileAutoRestoreFitMs. `null` means
+  // indefinite hold (no auto-restore timer). A finite value is clamped
+  // to [MIN, MAX] to defend against bad config — the smallest useful
+  // value is a few seconds, the largest is one hour. See
+  // docs/mobile-fit-hold.md.
+  private getAutoRestoreFitMs(): number | null {
+    const raw = this.store?.getSettings().mobileAutoRestoreFitMs ?? null
+    if (raw == null) {
+      return null
+    }
+    if (typeof raw !== 'number' || !Number.isFinite(raw)) {
+      return null
+    }
+    return Math.min(Math.max(raw, MOBILE_AUTO_RESTORE_FIT_MIN_MS), MOBILE_AUTO_RESTORE_FIT_MAX_MS)
+  }
+
+  // Why: invoked when the user changes mobileAutoRestoreFitMs to `null`
+  // (Indefinite). Clears every pending restore timer so the just-expressed
+  // preference "do not auto-restore" is honored for ALL currently-pending
+  // PTYs, not just one. See docs/mobile-fit-hold.md.
+  cancelAllPendingFitRestoreTimers(): void {
+    for (const [, entry] of this.pendingRestoreTimers) {
+      clearTimeout(entry.timer)
+    }
+    this.pendingRestoreTimers.clear()
+  }
+
+  // Why: read the persisted user preference (clamped) for surfacing to UI
+  // callers (mobile RPC, desktop preferences). Returns null when the
+  // setting is unset or `null` ("Indefinite").
+  getMobileAutoRestoreFitMs(): number | null {
+    return this.getAutoRestoreFitMs()
+  }
+
+  // Why: persisted-preference setter routed through the same `Store` the
+  // desktop preferences UI writes to. Transitions to `null` (Indefinite)
+  // clear every pending restore timer to honor the preference change for
+  // already-held PTYs. Transitions to a finite value do NOT retroactively
+  // schedule timers for PTYs that are currently held — those PTYs were
+  // already-not-restored under the old preference, and silently scheduling
+  // a restore on a settings change would be surprising. The new value
+  // takes effect on the next unsubscribe. See docs/mobile-fit-hold.md.
+  setMobileAutoRestoreFitMs(ms: number | null): number | null {
+    if (!this.store?.updateSettings) {
+      return this.getAutoRestoreFitMs()
+    }
+    let normalized: number | null
+    if (ms == null) {
+      normalized = null
+    } else if (typeof ms !== 'number' || !Number.isFinite(ms)) {
+      normalized = null
+    } else {
+      normalized = Math.min(
+        Math.max(ms, MOBILE_AUTO_RESTORE_FIT_MIN_MS),
+        MOBILE_AUTO_RESTORE_FIT_MAX_MS
+      )
+    }
+    this.store.updateSettings({ mobileAutoRestoreFitMs: normalized })
+    if (normalized == null) {
+      this.cancelAllPendingFitRestoreTimers()
+    }
+    return normalized
   }
 
   // Why: with multiple subscribers, the active phone-fit dims follow the
@@ -2399,31 +2495,44 @@ export class OrcaRuntimeService {
       const existingTimer = this.pendingRestoreTimers.get(ptyId)
       if (existingTimer) {
         clearTimeout(existingTimer.timer)
-      }
-      // Snapshot the disconnecting subscriber's baseline NOW, before the
-      // timer fires. By the time the timer runs (300ms later), the
-      // subscriber map has been deleted; resolveDesktopRestoreTarget would
-      // fall through to lastRendererSizes → current PTY size (which is at
-      // phone dims, wrong). The disconnecting subscriber's baseline is the
-      // correct restore target.
-      const fallback = this.lastRendererSizes.get(ptyId)
-      const restoreCols =
-        subscriber.previousCols ?? fallback?.cols ?? this.getTerminalSize(ptyId)?.cols ?? 80
-      const restoreRows =
-        subscriber.previousRows ?? fallback?.rows ?? this.getTerminalSize(ptyId)?.rows ?? 24
-      const timer = setTimeout(() => {
         this.pendingRestoreTimers.delete(ptyId)
-        if (this.isMobileSubscriberActive(ptyId)) {
-          return
-        }
-        void this.enqueueLayout(ptyId, {
-          kind: 'desktop',
-          cols: restoreCols,
-          rows: restoreRows
-        })
-      }, 300)
+      }
+      // Why: scheduling is conditional on the user's mobileAutoRestoreFitMs
+      // preference. `null` (default, "Indefinite") leaves the PTY at phone
+      // dims until the user clicks Restore on the desktop banner — the
+      // central UX promise of docs/mobile-fit-hold.md. A finite value runs
+      // the restore that long after the last unsubscribe.
+      const autoRestoreMs = this.getAutoRestoreFitMs()
+      if (autoRestoreMs == null) {
+        // Indefinite hold: the fit override persists, the SOFT_LEAVE_GRACE
+        // driver-state grace above still releases the input lock, and the
+        // banner's Restore button is the explicit return path.
+      } else {
+        // Snapshot the disconnecting subscriber's baseline NOW, before the
+        // timer fires. By the time the timer runs, the subscriber map has
+        // been deleted; resolveDesktopRestoreTarget would fall through to
+        // lastRendererSizes → current PTY size (which is at phone dims,
+        // wrong). The disconnecting subscriber's baseline is the correct
+        // restore target.
+        const fallback = this.lastRendererSizes.get(ptyId)
+        const restoreCols =
+          subscriber.previousCols ?? fallback?.cols ?? this.getTerminalSize(ptyId)?.cols ?? 80
+        const restoreRows =
+          subscriber.previousRows ?? fallback?.rows ?? this.getTerminalSize(ptyId)?.rows ?? 24
+        const timer = setTimeout(() => {
+          this.pendingRestoreTimers.delete(ptyId)
+          if (this.isMobileSubscriberActive(ptyId)) {
+            return
+          }
+          void this.enqueueLayout(ptyId, {
+            kind: 'desktop',
+            cols: restoreCols,
+            rows: restoreRows
+          })
+        }, autoRestoreMs)
 
-      this.pendingRestoreTimers.set(ptyId, { timer, clientId })
+        this.pendingRestoreTimers.set(ptyId, { timer, clientId })
+      }
     }
     // 'desktop' mode: was never resized, nothing to restore.
   }
@@ -6159,6 +6268,14 @@ const TUI_IDLE_DEFAULT_TIMEOUT_MS = 5 * 60 * 1000
 const TUI_IDLE_POLL_INTERVAL_MS = 2000
 const TUI_IDLE_QUIESCENCE_MS = 3000
 const MESSAGE_WAIT_DEFAULT_TIMEOUT_MS = 2 * 60 * 1000
+
+// Clamp range for the user-facing mobileAutoRestoreFitMs preference.
+// MIN floor: a couple of seconds is the smallest useful auto-restore
+// (anything tighter is the legacy 300ms debounce).
+// MAX ceiling: one hour — a held PTY beyond that is almost certainly
+// "I forgot" rather than intentional.
+const MOBILE_AUTO_RESTORE_FIT_MIN_MS = 5_000
+const MOBILE_AUTO_RESTORE_FIT_MAX_MS = 60 * 60 * 1000
 
 function buildTerminalWaitResult(
   handle: string,

--- a/src/main/runtime/rpc/methods/terminal.ts
+++ b/src/main/runtime/rpc/methods/terminal.ts
@@ -416,13 +416,6 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
       const ptyId = leaf.ptyId
       const clientId = params.client?.id
 
-      console.log('[fit][server] terminal.subscribe', {
-        ptyId: ptyId.slice(-8),
-        clientId: clientId?.slice(-8),
-        isMobile,
-        viewport: params.viewport
-      })
-
       // Server-side auto-fit: resize PTY to phone dims before serializing scrollback
       if (isMobile && clientId) {
         await runtime.handleMobileSubscribe(ptyId, clientId, params.viewport)

--- a/src/main/runtime/rpc/methods/terminal.ts
+++ b/src/main/runtime/rpc/methods/terminal.ts
@@ -189,6 +189,13 @@ const TerminalUpdateViewport = TerminalHandle.extend({
   })
 })
 
+// Why: phone-fit auto-restore preference (docs/mobile-fit-hold.md). `null`
+// means Indefinite; finite millisecond values are clamped server-side
+// into [5_000, 60min] before persistence.
+const TerminalSetAutoRestoreFit = z.object({
+  ms: z.number().nullable()
+})
+
 export const TERMINAL_METHODS: RpcAnyMethod[] = [
   defineMethod({
     name: 'terminal.list',
@@ -515,5 +522,19 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
       }
       return { unsubscribed: true }
     }
+  }),
+  defineMethod({
+    name: 'terminal.getAutoRestoreFit',
+    params: z.object({}),
+    handler: async (_params, { runtime }) => ({
+      ms: runtime.getMobileAutoRestoreFitMs()
+    })
+  }),
+  defineMethod({
+    name: 'terminal.setAutoRestoreFit',
+    params: TerminalSetAutoRestoreFit,
+    handler: async (params, { runtime }) => ({
+      ms: runtime.setMobileAutoRestoreFitMs(params.ms)
+    })
   })
 ]

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -478,6 +478,7 @@ export type PreloadApi = {
     }>
     write: (id: string, data: string) => void
     resize: (id: string, cols: number, rows: number) => void
+    reportGeometry: (id: string, cols: number, rows: number) => void
     signal: (id: string, signal: string) => void
     kill: (id: string, opts?: { keepHistory?: boolean }) => Promise<void>
     ackColdRestore: (id: string) => void

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -418,6 +418,15 @@ const api = {
       ipcRenderer.send('pty:resize', { id, cols, rows })
     },
 
+    /** Why: measurement-only sibling of resize. Fires when a desktop pane
+     * container measures real geometry (e.g. previously hidden tab becomes
+     * visible) so the runtime's restore-target baseline can stay fresh
+     * even while a mobile-fit override blocks pty:resize. Never resizes
+     * the PTY. See docs/mobile-fit-hold.md. */
+    reportGeometry: (id: string, cols: number, rows: number): void => {
+      ipcRenderer.send('pty:reportGeometry', { id, cols, rows })
+    },
+
     signal: (id: string, signal: string): void => {
       ipcRenderer.send('pty:signal', { id, signal })
     },

--- a/src/renderer/src/components/settings/MobilePane.tsx
+++ b/src/renderer/src/components/settings/MobilePane.tsx
@@ -8,13 +8,16 @@ import type { SettingsSearchEntry } from './settings-search'
 import { useAppStore } from '../../store'
 
 // Why: indefinite hold (`null`) is the default; finite presets give users
-// a wall-clock auto-restore for the rare case where they prefer it. Values
-// are server-clamped into [5_000ms, 60min]. See docs/mobile-fit-hold.md.
+// a wall-clock auto-restore. Each label reads as a complete sentence
+// answering "what happens when I leave the mobile app?" — that framing
+// surfaced in user research as the only way the picker is intelligible
+// without reading the description. Values are server-clamped into
+// [5_000ms, 60min]. See docs/mobile-fit-hold.md.
 const AUTO_RESTORE_FIT_OPTIONS: { value: string; label: string; ms: number | null }[] = [
-  { value: 'indefinite', label: 'Indefinite (default)', ms: null },
-  { value: '60s', label: '1 minute', ms: 60_000 },
-  { value: '5m', label: '5 minutes', ms: 5 * 60_000 },
-  { value: '30m', label: '30 minutes', ms: 30 * 60_000 }
+  { value: 'indefinite', label: 'Keep at phone size until I press Restore', ms: null },
+  { value: '60s', label: 'Resize to desktop after 1 minute', ms: 60_000 },
+  { value: '5m', label: 'Resize to desktop after 5 minutes', ms: 5 * 60_000 },
+  { value: '30m', label: 'Resize to desktop after 30 minutes', ms: 30 * 60_000 }
 ]
 
 function autoRestoreValueFromMs(ms: number | null | undefined): string {
@@ -42,9 +45,9 @@ export const MOBILE_PANE_SEARCH_ENTRIES: SettingsSearchEntry[] = [
     keywords: ['network', 'interface', 'tailscale', 'vpn', 'overlay', 'ip', 'address', 'wifi']
   },
   {
-    title: 'Auto-restore terminal width',
+    title: 'When you leave the mobile app',
     description:
-      'How long to keep a terminal at phone size after the mobile app leaves before restoring desktop dimensions.',
+      'Choose what happens to terminals you were viewing on mobile after you close the app or switch away.',
     keywords: [
       'mobile',
       'terminal',
@@ -54,7 +57,9 @@ export const MOBILE_PANE_SEARCH_ENTRIES: SettingsSearchEntry[] = [
       'width',
       'resize',
       'hold',
-      'indefinite'
+      'leave',
+      'background',
+      'close'
     ]
   }
 ]
@@ -219,16 +224,17 @@ export function MobilePane(): React.JSX.Element {
         </div>
       </div>
 
-      {/* Auto-restore terminal width preference */}
+      {/* When you leave the mobile app — terminal sizing preference */}
       <div className="rounded-lg border border-border/60 p-4">
         <div className="mb-3 flex items-center gap-2">
           <Smartphone className="size-4 text-muted-foreground" />
-          <span className="text-sm font-medium">Auto-restore terminal width</span>
+          <span className="text-sm font-medium">When you leave the mobile app</span>
         </div>
         <p className="text-muted-foreground mb-3 text-xs">
-          When you leave the mobile app, terminals stay at phone size by default so TUI apps
-          like Claude Code don&apos;t reflow. Pick a duration to auto-restore them to desktop
-          width, or use the &quot;Restore&quot; button on the terminal banner at any time.
+          While you&apos;re using a terminal on your phone, Orca shrinks it to fit your phone
+          screen. When you close the app or switch away, this controls whether it stays at
+          phone size (so apps like Claude Code don&apos;t reflow) or resizes back to your
+          desktop. You can always click Restore on the terminal banner to resize it manually.
         </p>
         <Select
           value={autoRestoreValueFromMs(autoRestoreFitMs)}

--- a/src/renderer/src/components/settings/MobilePane.tsx
+++ b/src/renderer/src/components/settings/MobilePane.tsx
@@ -12,7 +12,7 @@ import { useAppStore } from '../../store'
 // duration knob. Indefinite hold (`null`) is the default. Server clamps
 // anything outside [5_000ms, 60min]. See docs/mobile-fit-hold.md.
 const AUTO_RESTORE_FIT_OPTIONS: { value: string; label: string; ms: number | null }[] = [
-  { value: 'indefinite', label: 'Keep at phone size', ms: null },
+  { value: 'indefinite', label: 'Keep at phone size (default)', ms: null },
   { value: '60s', label: 'After 1 minute', ms: 60_000 },
   { value: '5m', label: 'After 5 minutes', ms: 5 * 60_000 },
   { value: '30m', label: 'After 30 minutes', ms: 30 * 60_000 }

--- a/src/renderer/src/components/settings/MobilePane.tsx
+++ b/src/renderer/src/components/settings/MobilePane.tsx
@@ -222,39 +222,6 @@ export function MobilePane(): React.JSX.Element {
         </div>
       </div>
 
-      {/* When you leave the mobile app — terminal sizing preference */}
-      <div className="rounded-lg border border-border/60 p-4">
-        <div className="mb-3 flex items-center gap-2">
-          <Smartphone className="size-4 text-muted-foreground" />
-          <span className="text-sm font-medium">When you leave the mobile app</span>
-        </div>
-        <p className="text-muted-foreground mb-3 text-xs">
-          While you&apos;re using a terminal on your phone, Orca shrinks it to fit your phone
-          screen. When you close the app or switch away, this controls whether it stays at
-          phone size (so apps like Claude Code don&apos;t reflow) or resizes back to your
-          desktop. You can always click Restore on the terminal banner to resize it manually.
-        </p>
-        <Select
-          value={autoRestoreValueFromMs(autoRestoreFitMs)}
-          onValueChange={(v) => {
-            const opt = AUTO_RESTORE_FIT_OPTIONS.find((o) => o.value === v)
-            if (!opt) return
-            void updateSettings({ mobileAutoRestoreFitMs: opt.ms })
-          }}
-        >
-          <SelectTrigger size="sm" className="min-w-[220px]">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            {AUTO_RESTORE_FIT_OPTIONS.map((opt) => (
-              <SelectItem key={opt.value} value={opt.value}>
-                {opt.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </div>
-
       {/* QR code display */}
       {qrDataUrl && (
         <div className="flex flex-col items-center gap-3 rounded-lg border border-border/60 py-6">
@@ -332,6 +299,39 @@ export function MobilePane(): React.JSX.Element {
             Revoking a device disconnects it immediately.
           </p>
         )}
+      </div>
+
+      {/* Mobile behavior — terminal sizing when leaving the app */}
+      <div className="rounded-lg border border-border/60 p-4">
+        <div className="mb-3 flex items-center gap-2">
+          <Smartphone className="size-4 text-muted-foreground" />
+          <span className="text-sm font-medium">When you leave the mobile app</span>
+        </div>
+        <p className="text-muted-foreground mb-3 text-xs">
+          While you&apos;re using a terminal on your phone, Orca shrinks it to fit your phone
+          screen. When you close the app or switch away, this controls whether it stays at
+          phone size (so apps like Claude Code don&apos;t reflow) or resizes back to your
+          desktop. You can always click Restore on the terminal banner to resize it manually.
+        </p>
+        <Select
+          value={autoRestoreValueFromMs(autoRestoreFitMs)}
+          onValueChange={(v) => {
+            const opt = AUTO_RESTORE_FIT_OPTIONS.find((o) => o.value === v)
+            if (!opt) return
+            void updateSettings({ mobileAutoRestoreFitMs: opt.ms })
+          }}
+        >
+          <SelectTrigger size="sm" className="min-w-[220px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {AUTO_RESTORE_FIT_OPTIONS.map((opt) => (
+              <SelectItem key={opt.value} value={opt.value}>
+                {opt.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
       </div>
 
       {/* Enlarged QR dialog */}

--- a/src/renderer/src/components/settings/MobilePane.tsx
+++ b/src/renderer/src/components/settings/MobilePane.tsx
@@ -1,10 +1,29 @@
 import { useCallback, useEffect, useState } from 'react'
 import { toast } from 'sonner'
-import { Check, Copy, Maximize2, RefreshCw, Trash2, Wifi } from 'lucide-react'
+import { Check, Copy, Maximize2, RefreshCw, Smartphone, Trash2, Wifi } from 'lucide-react'
 import { Button } from '../ui/button'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '../ui/dialog'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
 import type { SettingsSearchEntry } from './settings-search'
+import { useAppStore } from '../../store'
+
+// Why: indefinite hold (`null`) is the default; finite presets give users
+// a wall-clock auto-restore for the rare case where they prefer it. Values
+// are server-clamped into [5_000ms, 60min]. See docs/mobile-fit-hold.md.
+const AUTO_RESTORE_FIT_OPTIONS: { value: string; label: string; ms: number | null }[] = [
+  { value: 'indefinite', label: 'Indefinite (default)', ms: null },
+  { value: '60s', label: '1 minute', ms: 60_000 },
+  { value: '5m', label: '5 minutes', ms: 5 * 60_000 },
+  { value: '30m', label: '30 minutes', ms: 30 * 60_000 }
+]
+
+function autoRestoreValueFromMs(ms: number | null | undefined): string {
+  if (ms == null) {
+    return 'indefinite'
+  }
+  const exact = AUTO_RESTORE_FIT_OPTIONS.find((o) => o.ms === ms)
+  return exact ? exact.value : 'indefinite'
+}
 
 export const MOBILE_PANE_SEARCH_ENTRIES: SettingsSearchEntry[] = [
   {
@@ -21,6 +40,22 @@ export const MOBILE_PANE_SEARCH_ENTRIES: SettingsSearchEntry[] = [
     title: 'Network Interface',
     description: 'Choose which network address to use for mobile pairing.',
     keywords: ['network', 'interface', 'tailscale', 'vpn', 'overlay', 'ip', 'address', 'wifi']
+  },
+  {
+    title: 'Auto-restore terminal width',
+    description:
+      'How long to keep a terminal at phone size after the mobile app leaves before restoring desktop dimensions.',
+    keywords: [
+      'mobile',
+      'terminal',
+      'restore',
+      'phone',
+      'fit',
+      'width',
+      'resize',
+      'hold',
+      'indefinite'
+    ]
   }
 ]
 
@@ -37,6 +72,8 @@ type NetworkInterface = {
 }
 
 export function MobilePane(): React.JSX.Element {
+  const autoRestoreFitMs = useAppStore((s) => s.settings?.mobileAutoRestoreFitMs ?? null)
+  const updateSettings = useAppStore((s) => s.updateSettings)
   const [qrDataUrl, setQrDataUrl] = useState<string | null>(null)
   const [pairingUrl, setPairingUrl] = useState<string | null>(null)
   const [endpoint, setEndpoint] = useState<string | null>(null)
@@ -180,6 +217,38 @@ export function MobilePane(): React.JSX.Element {
             {qrDataUrl ? 'Regenerate' : 'Generate QR Code'}
           </Button>
         </div>
+      </div>
+
+      {/* Auto-restore terminal width preference */}
+      <div className="rounded-lg border border-border/60 p-4">
+        <div className="mb-3 flex items-center gap-2">
+          <Smartphone className="size-4 text-muted-foreground" />
+          <span className="text-sm font-medium">Auto-restore terminal width</span>
+        </div>
+        <p className="text-muted-foreground mb-3 text-xs">
+          When you leave the mobile app, terminals stay at phone size by default so TUI apps
+          like Claude Code don&apos;t reflow. Pick a duration to auto-restore them to desktop
+          width, or use the &quot;Restore&quot; button on the terminal banner at any time.
+        </p>
+        <Select
+          value={autoRestoreValueFromMs(autoRestoreFitMs)}
+          onValueChange={(v) => {
+            const opt = AUTO_RESTORE_FIT_OPTIONS.find((o) => o.value === v)
+            if (!opt) return
+            void updateSettings({ mobileAutoRestoreFitMs: opt.ms })
+          }}
+        >
+          <SelectTrigger size="sm" className="min-w-[220px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {AUTO_RESTORE_FIT_OPTIONS.map((opt) => (
+              <SelectItem key={opt.value} value={opt.value}>
+                {opt.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
       </div>
 
       {/* QR code display */}

--- a/src/renderer/src/components/settings/MobilePane.tsx
+++ b/src/renderer/src/components/settings/MobilePane.tsx
@@ -317,7 +317,9 @@ export function MobilePane(): React.JSX.Element {
           value={autoRestoreValueFromMs(autoRestoreFitMs)}
           onValueChange={(v) => {
             const opt = AUTO_RESTORE_FIT_OPTIONS.find((o) => o.value === v)
-            if (!opt) return
+            if (!opt) {
+              return
+            }
             void updateSettings({ mobileAutoRestoreFitMs: opt.ms })
           }}
         >

--- a/src/renderer/src/components/settings/MobilePane.tsx
+++ b/src/renderer/src/components/settings/MobilePane.tsx
@@ -7,17 +7,15 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '.
 import type { SettingsSearchEntry } from './settings-search'
 import { useAppStore } from '../../store'
 
-// Why: indefinite hold (`null`) is the default; finite presets give users
-// a wall-clock auto-restore. Each label reads as a complete sentence
-// answering "what happens when I leave the mobile app?" — that framing
-// surfaced in user research as the only way the picker is intelligible
-// without reading the description. Values are server-clamped into
-// [5_000ms, 60min]. See docs/mobile-fit-hold.md.
+// Why: the section heading "When you leave the mobile app" carries the
+// "what happens" framing so the option labels only need to vary on the
+// duration knob. Indefinite hold (`null`) is the default. Server clamps
+// anything outside [5_000ms, 60min]. See docs/mobile-fit-hold.md.
 const AUTO_RESTORE_FIT_OPTIONS: { value: string; label: string; ms: number | null }[] = [
-  { value: 'indefinite', label: 'Keep at phone size until I press Restore', ms: null },
-  { value: '60s', label: 'Resize to desktop after 1 minute', ms: 60_000 },
-  { value: '5m', label: 'Resize to desktop after 5 minutes', ms: 5 * 60_000 },
-  { value: '30m', label: 'Resize to desktop after 30 minutes', ms: 30 * 60_000 }
+  { value: 'indefinite', label: 'Keep at phone size', ms: null },
+  { value: '60s', label: 'After 1 minute', ms: 60_000 },
+  { value: '5m', label: 'After 5 minutes', ms: 5 * 60_000 },
+  { value: '30m', label: 'After 30 minutes', ms: 30 * 60_000 }
 ]
 
 function autoRestoreValueFromMs(ms: number | null | undefined): string {

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -159,6 +159,17 @@ export default function TerminalPane({
               if (!pane) {
                 continue
               }
+              // Why: skip the fallback for hidden/unmounted panes whose
+              // container is 0×0. Force-resizing xterm to the server's
+              // desktop dims while the DOM has no geometry leaves xterm
+              // with cols/rows that won't match when the tab is later
+              // activated (the activation refit will correct it). The
+              // fallback is for the *visible* pane that legitimately
+              // failed to refit via the rAF safeFit.
+              const rect = pane.container.getBoundingClientRect()
+              if (rect.width === 0 || rect.height === 0) {
+                continue
+              }
               safeFit(pane)
               const stuckAtMobile =
                 event.priorCols != null &&

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -29,7 +29,11 @@ import { useTerminalPaneLifecycle } from './use-terminal-pane-lifecycle'
 import { useTerminalPaneContextMenu } from './use-terminal-pane-context-menu'
 import { useNotificationDispatch } from './use-notification-dispatch'
 import { connectPanePty } from './pty-connection'
-import { getPaneIdsForPty, onOverrideChange } from '@/lib/pane-manager/mobile-fit-overrides'
+import {
+  getFitOverrideForPty,
+  getPaneIdsForPty,
+  onOverrideChange
+} from '@/lib/pane-manager/mobile-fit-overrides'
 import { getDriverForPty, onDriverChange } from '@/lib/pane-manager/mobile-driver-state'
 import { safeFit } from '@/lib/pane-manager/pane-tree-ops'
 
@@ -1167,14 +1171,16 @@ export default function TerminalPane({
         if (!ptyId) {
           return null
         }
-        // Why: presence-lock — banner is gated on driver state, not on
-        // fit-override. The banner now communicates "input is paused"
-        // (the load-bearing fact) instead of dimensional state. The
-        // dimensional override may still be active and is reflected in
-        // the PTY but not in the banner copy. See
-        // docs/mobile-presence-lock.md.
+        // Why: two-state banner. (1) Driver is mobile → presence-lock,
+        // input paused (docs/mobile-presence-lock.md). (2) No mobile
+        // driver but a phone-fit override is still in place → indefinite
+        // hold (docs/mobile-fit-hold.md): the user left mobile, the PTY
+        // is held at phone dims, and the banner is the explicit
+        // return-to-desktop-size escape hatch.
         const driver = getDriverForPty(ptyId)
-        if (driver.kind !== 'mobile') {
+        const isMobileDriving = driver.kind === 'mobile'
+        const isHeldAtPhoneFit = !isMobileDriving && getFitOverrideForPty(ptyId) !== null
+        if (!isMobileDriving && !isHeldAtPhoneFit) {
           return null
         }
         return createPortal(
@@ -1197,7 +1203,9 @@ export default function TerminalPane({
             }}
           >
             <span>
-              Mobile is driving this terminal — your input is paused. Click Take back to resume.
+              {isMobileDriving
+                ? 'Mobile is driving this terminal — your input is paused. Click Take back to resume.'
+                : 'This terminal is held at phone size for the mobile app. Click Restore to return it to desktop size.'}
             </span>
             <button
               style={{
@@ -1212,15 +1220,15 @@ export default function TerminalPane({
               onClick={() => {
                 const ptyId = paneTransportsRef.current.get(pane.id)?.getPtyId()
                 if (ptyId) {
-                  // Why: same IPC route — handler now also reclaims the
-                  // input floor for the desktop via the driver state
-                  // machine, so the banner unmounts and input is unblocked
-                  // until the next mobile interaction.
+                  // Why: same IPC route — handler resolves both the
+                  // active-mobile-subscriber path and the held-no-subscriber
+                  // path (docs/mobile-fit-hold.md), so the banner unmounts
+                  // and the PTY returns to desktop dims in either case.
                   void window.api.runtime.restoreTerminalFit(ptyId)
                 }
               }}
             >
-              Take back
+              {isMobileDriving ? 'Take back' : 'Restore'}
             </button>
           </div>,
           pane.container,

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -434,6 +434,57 @@ export function connectPanePty(
     transport.resize(cols, rows)
   })
 
+  // Why: while a mobile-fit override is active, the onResize listener above
+  // and the matching server-side gate both correctly drop pty:resize so the
+  // PTY stays parked at phone dims. But the server still needs to learn the
+  // real desktop pane geometry — otherwise resolveDesktopRestoreTarget falls
+  // back to the PTY's spawn default (e.g. 80×24 for a hidden tab) and Take
+  // Back leaves the terminal partially restored. This observer measures the
+  // pane container as a side-channel, computes proposed cols/rows the way
+  // safeFit would, and reports it via pty:reportGeometry — a measurement-
+  // only IPC that updates lastRendererSizes and non-null subscriber
+  // baselines without resizing the PTY. We only fire while an override is
+  // active because the normal pty:resize path covers all other cases. See
+  // docs/mobile-fit-hold.md.
+  let pendingGeometryReportRaf: number | null = null
+  const reportPaneGeometry = (): void => {
+    pendingGeometryReportRaf = null
+    const currentPtyId = transport.getPtyId()
+    if (!currentPtyId) {
+      return
+    }
+    if (!getFitOverrideForPty(currentPtyId)) {
+      return
+    }
+    let proposed: { cols: number; rows: number } | undefined
+    try {
+      proposed = pane.fitAddon.proposeDimensions()
+    } catch {
+      proposed = undefined
+    }
+    if (!proposed || proposed.cols <= 0 || proposed.rows <= 0) {
+      return
+    }
+    window.api.pty.reportGeometry(currentPtyId, proposed.cols, proposed.rows)
+  }
+  const geometryReportObserver =
+    typeof ResizeObserver === 'undefined'
+      ? null
+      : new ResizeObserver(() => {
+          if (pendingGeometryReportRaf !== null) {
+            return
+          }
+          pendingGeometryReportRaf = requestAnimationFrame(reportPaneGeometry)
+        })
+  // Why: pane.xtermContainer is created later in pane-lifecycle's
+  // attachWebgl/initial-fit path; pane.container is always present at the
+  // moment connectPanePty runs (it's the .pane element). Both report the
+  // same layout signal — when the outer pane resizes, the inner xterm
+  // container resizes too — so this is the safe element to observe.
+  if (geometryReportObserver && pane.container instanceof Element) {
+    geometryReportObserver.observe(pane.container)
+  }
+
   // Defer PTY spawn/attach to next frame so FitAddon has time to calculate
   // the correct terminal dimensions from the laid-out container.
   deps.pendingWritesRef.current.set(pane.id, '')
@@ -1174,6 +1225,11 @@ export function connectPanePty(
       }
       onDataDisposable.dispose()
       onResizeDisposable.dispose()
+      geometryReportObserver?.disconnect()
+      if (pendingGeometryReportRaf !== null) {
+        cancelAnimationFrame(pendingGeometryReportRaf)
+        pendingGeometryReportRaf = null
+      }
     }
   }
 }

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -202,6 +202,10 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     // (persistence.ts merges defaults first, so upgraders inherit this).
     experimentalAgentDashboard: false,
     experimentalMobile: false,
+    // Why: indefinite hold by default — the desktop "Restore" banner is the
+    // explicit return-to-desktop-size action, no wall-clock guess.
+    // See docs/mobile-fit-hold.md.
+    mobileAutoRestoreFitMs: null,
     // Why: off by default — opt-in cosmetic joke feature. Leaving the default
     // false keeps the overlay unmounted for users who never enable it.
     experimentalSidekick: false,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1216,6 +1216,14 @@ export type GlobalSettings = {
    *  the cursor-agent hook path are unaffected by this toggle. */
   experimentalAgentDashboard: boolean
   experimentalMobile: boolean
+  /** Auto-restore window for a phone-fit PTY after the last mobile
+   *  subscriber leaves. `null` (default) holds the PTY at phone size
+   *  indefinitely; the desktop "Restore" banner remains the explicit
+   *  return-to-desktop-size action. A finite millisecond value schedules
+   *  an automatic restore that long after the last unsubscribe. Clamped
+   *  on read into [5_000ms, 60min] to defend against bad config.
+   *  See docs/mobile-fit-hold.md. */
+  mobileAutoRestoreFitMs: number | null
   /** Experimental: floating animated sidekick (claude.webp) in the bottom-right
    *  corner. Opt-in because it's a cosmetic joke feature; users who leave it
    *  off never mount the overlay. Toggling takes effect immediately in the


### PR DESCRIPTION
## Why

When the mobile app leaves a terminal (tab swap, app background, lock screen), the PTY currently restores to desktop dims ~300ms later. For TUI apps like Claude Code and codex this fires an expensive reflow that disrupts the on-screen UI even though the user is coming right back. Users want the terminal to stay at phone size, with an explicit way back to desktop.

## What

- **Default**: indefinite hold. The phone-fit override and PTY dims stay put after the last mobile subscriber leaves. The 300ms debounced restore is gone.
- **Escape hatch**: the existing desktop banner is widened to also show when a terminal is held with no active mobile driver, with copy/button adapted ("This terminal is held at phone size... Restore"). Click Restore → PTY snaps back to desktop dims.
- **Optional auto-restore**: new `mobileAutoRestoreFitMs` setting on `GlobalSettings` (`number | null`). `null` = Indefinite. Finite values (clamped server-side to [5s, 60min]) schedule a wall-clock restore that long after the last unsubscribe.
- **Settable from both ends**: dropdown in desktop Mobile preferences (Indefinite / 1m / 5m / 30m) and a per-host expandable picker in the mobile Settings screen. Mobile uses two new RPCs on the existing `terminal.*` namespace: `terminal.getAutoRestoreFit` and `terminal.setAutoRestoreFit`.

See `docs/mobile-fit-hold.md` for the full design (3-iteration design review).

## Notable runtime semantics

- `reclaimTerminalForDesktop` widened: handles both the active-subscriber path (existing) and the held-no-subscriber path (resolves restore target via the override's snapshotted baseline; `applyLayout` remains the sole writer of `terminalFitOverrides`).
- Setting transitions: `finite → null` cancels every pending restore timer; `null → finite` does NOT retroactively schedule timers for already-held PTYs (the new value applies to the next unsubscribe).
- Re-subscribe before a finite-window restore fires cancels the pending timer.

## Tests

8 new tests in `mobile-subscribe-integration.test.ts` covering: indefinite hold, finite-delay auto-restore, re-subscribe-cancels, manual reclaim of held PTY, finite→null clears all timers, null→finite no retro-scheduling, and clamp behavior. Updated 2 mock stores (`mobile-subscribe-integration`, `mobile-presence-lock`) and 2 codex-accounts test fixtures for the new field. All 48 mobile-related tests pass; `tc:node` and `tc:web` clean.

Made with [Orca](https://github.com/stablyai/orca) 🐋
