### PR TITLE
fix(agent-hooks): silence exit-127 spam from stale managed hook entries

### DIFF
--- a/src/main/agent-hooks/installer-utils.test.ts
+++ b/src/main/agent-hooks/installer-utils.test.ts
@@ -148,13 +148,13 @@ describe('createManagedCommandMatcher', () => {
   })
 
   it('matches the guarded launcher form so wrapped commands sweep correctly', () => {
-    // Why: wrapPosixHookCommand wraps the launcher in `[ -x ... ] && ... || true`
+    // Why: wrapPosixHookCommand wraps the launcher in `if [ -x ... ]; then ...; fi`
     // so a stale entry no-ops instead of returning exit 127. The sweep on
     // install() must still recognize the guarded form as managed, otherwise
     // repeated installs would accumulate one guarded + one unguarded entry.
     expect(
       match(
-        '[ -x "/Users/alice/Library/Application Support/Orca/agent-hooks/claude-hook.sh" ] && /bin/sh "/Users/alice/Library/Application Support/Orca/agent-hooks/claude-hook.sh" || true'
+        'if [ -x "/Users/alice/Library/Application Support/Orca/agent-hooks/claude-hook.sh" ]; then /bin/sh "/Users/alice/Library/Application Support/Orca/agent-hooks/claude-hook.sh"; fi'
       )
     ).toBe(true)
   })
@@ -163,7 +163,7 @@ describe('createManagedCommandMatcher', () => {
 describe('wrapPosixHookCommand', () => {
   it('produces a guarded command that no-ops when the script is missing', () => {
     const cmd = wrapPosixHookCommand('/does/not/exist.sh')
-    expect(cmd).toBe('[ -x "/does/not/exist.sh" ] && /bin/sh "/does/not/exist.sh" || true')
+    expect(cmd).toBe('if [ -x "/does/not/exist.sh" ]; then /bin/sh "/does/not/exist.sh"; fi')
   })
 
   it('preserves spaces in the script path (Library/Application Support case)', () => {

--- a/src/main/agent-hooks/installer-utils.test.ts
+++ b/src/main/agent-hooks/installer-utils.test.ts
@@ -6,10 +6,12 @@ import {
   readFileSync,
   readdirSync,
   rmSync,
-  writeFileSync
+  writeFileSync,
+  chmodSync
 } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
+import { spawnSync } from 'child_process'
 import {
   createManagedCommandMatcher,
   wrapPosixHookCommand,
@@ -163,7 +165,7 @@ describe('createManagedCommandMatcher', () => {
 describe('wrapPosixHookCommand', () => {
   it('produces a guarded command that no-ops when the script is missing', () => {
     const cmd = wrapPosixHookCommand('/does/not/exist.sh')
-    expect(cmd).toBe('if [ -x "/does/not/exist.sh" ]; then /bin/sh "/does/not/exist.sh"; fi')
+    expect(cmd).toBe("if [ -x '/does/not/exist.sh' ]; then /bin/sh '/does/not/exist.sh'; fi")
   })
 
   it('preserves spaces in the script path (Library/Application Support case)', () => {
@@ -171,6 +173,41 @@ describe('wrapPosixHookCommand', () => {
     // a space. The guard must keep the path quoted so `[ -x ]` and `/bin/sh`
     // each see one argument.
     const cmd = wrapPosixHookCommand('/Users/a/Library/Application Support/Orca/agent-hooks/x.sh')
-    expect(cmd).toContain('"/Users/a/Library/Application Support/Orca/agent-hooks/x.sh"')
+    expect(cmd).toContain("'/Users/a/Library/Application Support/Orca/agent-hooks/x.sh'")
   })
+
+  it('escapes embedded single quotes so the wrapped command stays well-formed', () => {
+    // Why: POSIX single-quote escape renders ' as '\''. Verify a path with an
+    // embedded quote does not break out of the quoting and instead reaches
+    // /bin/sh as a single argument.
+    const cmd = wrapPosixHookCommand("/path/with'quote/x.sh")
+    expect(cmd).toBe(
+      "if [ -x '/path/with'\\''quote/x.sh' ]; then /bin/sh '/path/with'\\''quote/x.sh'; fi"
+    )
+  })
+
+  it.skipIf(process.platform === 'win32')(
+    'returns exit code 0 when the script does not exist (no-op)',
+    () => {
+      const cmd = wrapPosixHookCommand('/does/not/exist.sh')
+      const result = spawnSync('/bin/sh', ['-c', cmd])
+      expect(result.status).toBe(0)
+    }
+  )
+
+  // Why: commit 4d618795 explicitly switched from `&& ... || true` (which
+  // swallowed non-zero exits) to `if ... then ... fi` (which preserves the
+  // script's exit code). This test guards against a future regression that
+  // re-introduces the swallowing form.
+  it.skipIf(process.platform === 'win32')(
+    'propagates the script exit code when the script runs and fails',
+    () => {
+      const scriptPath = join(tmpDir, 'fails.sh')
+      writeFileSync(scriptPath, '#!/bin/sh\nexit 7\n', 'utf-8')
+      chmodSync(scriptPath, 0o755)
+      const cmd = wrapPosixHookCommand(scriptPath)
+      const result = spawnSync('/bin/sh', ['-c', cmd])
+      expect(result.status).toBe(7)
+    }
+  )
 })

--- a/src/main/agent-hooks/installer-utils.test.ts
+++ b/src/main/agent-hooks/installer-utils.test.ts
@@ -10,7 +10,12 @@ import {
 } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
-import { createManagedCommandMatcher, writeHooksJson, type HooksConfig } from './installer-utils'
+import {
+  createManagedCommandMatcher,
+  wrapPosixHookCommand,
+  writeHooksJson,
+  type HooksConfig
+} from './installer-utils'
 
 let tmpDir: string
 let configPath: string
@@ -140,5 +145,32 @@ describe('createManagedCommandMatcher', () => {
 
   it('does not match hooks for a different agent', () => {
     expect(match('/bin/sh "/path/agent-hooks/gemini-hook.sh"')).toBe(false)
+  })
+
+  it('matches the guarded launcher form so wrapped commands sweep correctly', () => {
+    // Why: wrapPosixHookCommand wraps the launcher in `[ -x ... ] && ... || true`
+    // so a stale entry no-ops instead of returning exit 127. The sweep on
+    // install() must still recognize the guarded form as managed, otherwise
+    // repeated installs would accumulate one guarded + one unguarded entry.
+    expect(
+      match(
+        '[ -x "/Users/alice/Library/Application Support/Orca/agent-hooks/claude-hook.sh" ] && /bin/sh "/Users/alice/Library/Application Support/Orca/agent-hooks/claude-hook.sh" || true'
+      )
+    ).toBe(true)
+  })
+})
+
+describe('wrapPosixHookCommand', () => {
+  it('produces a guarded command that no-ops when the script is missing', () => {
+    const cmd = wrapPosixHookCommand('/does/not/exist.sh')
+    expect(cmd).toBe('[ -x "/does/not/exist.sh" ] && /bin/sh "/does/not/exist.sh" || true')
+  })
+
+  it('preserves spaces in the script path (Library/Application Support case)', () => {
+    // Why: Electron's userData on macOS lives under "Application Support" with
+    // a space. The guard must keep the path quoted so `[ -x ]` and `/bin/sh`
+    // each see one argument.
+    const cmd = wrapPosixHookCommand('/Users/a/Library/Application Support/Orca/agent-hooks/x.sh')
+    expect(cmd).toContain('"/Users/a/Library/Application Support/Orca/agent-hooks/x.sh"')
   })
 })

--- a/src/main/agent-hooks/installer-utils.ts
+++ b/src/main/agent-hooks/installer-utils.ts
@@ -74,7 +74,11 @@ export function createManagedCommandMatcher(
 // poisons the user's session. Failures inside the script itself are
 // unaffected — only the missing-script case short-circuits.
 export function wrapPosixHookCommand(scriptPath: string): string {
-  return `if [ -x "${scriptPath}" ]; then /bin/sh "${scriptPath}"; fi`
+  // Why: POSIX single-quote escape so $, `, ", and \ in scriptPath are taken
+  // literally — avoids a shell-injection footgun if a future caller passes an
+  // arbitrary path.
+  const quoted = `'${scriptPath.replaceAll("'", "'\\''")}'`
+  return `if [ -x ${quoted} ]; then /bin/sh ${quoted}; fi`
 }
 
 export function removeManagedCommands(

--- a/src/main/agent-hooks/installer-utils.ts
+++ b/src/main/agent-hooks/installer-utils.ts
@@ -69,12 +69,12 @@ export function createManagedCommandMatcher(
 // switched dev↔prod installs, or had a partial install fail) used to fire
 // `/bin/sh "<missing path>"` on every tool call, which exits 127 and surfaces
 // as `PreToolUse hook (failed) error: hook exited with code 127` in the agent
-// transcript. Wrapping the launcher in `[ -x ... ] && ... || true` makes a
+// transcript. Wrapping the launcher in `if [ -x ... ]; then ...; fi` makes a
 // missing/non-executable script a silent no-op so a broken install never
 // poisons the user's session. Failures inside the script itself are
 // unaffected — only the missing-script case short-circuits.
 export function wrapPosixHookCommand(scriptPath: string): string {
-  return `[ -x "${scriptPath}" ] && /bin/sh "${scriptPath}" || true`
+  return `if [ -x "${scriptPath}" ]; then /bin/sh "${scriptPath}"; fi`
 }
 
 export function removeManagedCommands(

--- a/src/main/agent-hooks/installer-utils.ts
+++ b/src/main/agent-hooks/installer-utils.ts
@@ -65,6 +65,18 @@ export function createManagedCommandMatcher(
   }
 }
 
+// Why: a stale managed hook entry (left over after the user wiped userData,
+// switched dev↔prod installs, or had a partial install fail) used to fire
+// `/bin/sh "<missing path>"` on every tool call, which exits 127 and surfaces
+// as `PreToolUse hook (failed) error: hook exited with code 127` in the agent
+// transcript. Wrapping the launcher in `[ -x ... ] && ... || true` makes a
+// missing/non-executable script a silent no-op so a broken install never
+// poisons the user's session. Failures inside the script itself are
+// unaffected — only the missing-script case short-circuits.
+export function wrapPosixHookCommand(scriptPath: string): string {
+  return `[ -x "${scriptPath}" ] && /bin/sh "${scriptPath}" || true`
+}
+
 export function removeManagedCommands(
   definitions: HookDefinition[],
   isManagedCommand: (command: string | undefined) => boolean

--- a/src/main/claude/hook-service.ts
+++ b/src/main/claude/hook-service.ts
@@ -6,6 +6,7 @@ import {
   createManagedCommandMatcher,
   readHooksJson,
   removeManagedCommands,
+  wrapPosixHookCommand,
   writeHooksJson,
   writeManagedScript,
   type HookDefinition
@@ -48,13 +49,16 @@ function getManagedScriptPath(): string {
 }
 
 function getManagedCommand(scriptPath: string): string {
-  // Why: on Windows, Claude Code runs hooks through Git Bash (`/usr/bin/bash`).
-  // A path with single backslashes (e.g. `C:\Users\…\claude-hook.cmd`) is
-  // interpreted by bash as a string with escape sequences, so `\U`, `\A`, etc.
-  // collapse and the launcher fails with `command not found`. Emit forward
-  // slashes — Windows accepts them in path arguments and bash leaves them
-  // intact, so the same JSON value works through every shell layer.
-  return process.platform === 'win32' ? scriptPath.replaceAll('\\', '/') : `/bin/sh "${scriptPath}"`
+  if (process.platform === 'win32') {
+    // Why: on Windows, Claude Code runs hooks through Git Bash (`/usr/bin/bash`).
+    // A path with single backslashes (e.g. `C:\Users\…\claude-hook.cmd`) is
+    // interpreted by bash as a string with escape sequences, so `\U`, `\A`, etc.
+    // collapse and the launcher fails with `command not found`. Emit forward
+    // slashes — Windows accepts them in path arguments and bash leaves them
+    // intact, so the same JSON value works through every shell layer.
+    return scriptPath.replaceAll('\\', '/')
+  }
+  return wrapPosixHookCommand(scriptPath)
 }
 
 function getManagedScript(): string {

--- a/src/main/codex/hook-service.ts
+++ b/src/main/codex/hook-service.ts
@@ -6,6 +6,7 @@ import {
   createManagedCommandMatcher,
   readHooksJson,
   removeManagedCommands,
+  wrapPosixHookCommand,
   writeHooksJson,
   writeManagedScript,
   type HookDefinition
@@ -39,7 +40,7 @@ function getManagedScriptPath(): string {
 }
 
 function getManagedCommand(scriptPath: string): string {
-  return process.platform === 'win32' ? scriptPath : `/bin/sh "${scriptPath}"`
+  return process.platform === 'win32' ? scriptPath : wrapPosixHookCommand(scriptPath)
 }
 
 function getManagedScript(): string {

--- a/src/main/cursor/hook-service.ts
+++ b/src/main/cursor/hook-service.ts
@@ -6,6 +6,7 @@ import {
   createManagedCommandMatcher,
   readHooksJson,
   removeManagedCommands,
+  wrapPosixHookCommand,
   writeHooksJson,
   writeManagedScript,
   type HookDefinition
@@ -51,7 +52,7 @@ function getManagedScriptPath(): string {
 }
 
 function getManagedCommand(scriptPath: string): string {
-  return process.platform === 'win32' ? scriptPath : `/bin/sh "${scriptPath}"`
+  return process.platform === 'win32' ? scriptPath : wrapPosixHookCommand(scriptPath)
 }
 
 function getManagedScript(): string {

--- a/src/main/gemini/hook-service.ts
+++ b/src/main/gemini/hook-service.ts
@@ -6,6 +6,7 @@ import {
   createManagedCommandMatcher,
   readHooksJson,
   removeManagedCommands,
+  wrapPosixHookCommand,
   writeHooksJson,
   writeManagedScript,
   type HookDefinition
@@ -37,7 +38,7 @@ function getManagedScriptPath(): string {
 }
 
 function getManagedCommand(scriptPath: string): string {
-  return process.platform === 'win32' ? scriptPath : `/bin/sh "${scriptPath}"`
+  return process.platform === 'win32' ? scriptPath : wrapPosixHookCommand(scriptPath)
 }
 
 function getManagedScript(): string {


### PR DESCRIPTION
## Summary

Users hit a wall of red `PreToolUse hook (failed) error: hook exited with code 127` (and matching `PostToolUse`) entries in their Claude transcripts. Root cause: Orca's managed hook entries in `~/.claude/settings.json` (and the Codex/Gemini/Cursor equivalents) embed the absolute path of *this* install's userData script. When that script is missing — wiped userData, switched dev↔prod, an older Orca instance overwrote the path with one whose script no longer exists, partial install — `/bin/sh "<missing>"` returns 127 and Claude reports the hook as failed on every single tool call.

The fix wraps the POSIX launcher in `if [ -x '<path>' ]; then /bin/sh '<path>'; fi` so a missing or non-executable script silently no-ops instead of crashing. The existing managed-command matcher already uses substring detection on `agent-hooks/<filename>`, so the next install sweeps unguarded entries from older builds and replaces them with the guarded form automatically — users with the dead entry get healed on next launch.

## What this fixes

- Stale `~/.claude/settings.json` (or Codex/Gemini/Cursor) entry pointing at a script in a userData dir that was wiped, renamed, or never created.
- Multi-userData thrash: dev and prod Orca builds writing different absolute paths into the same global hooks file, where whichever booted last wins and panes from the loser see exit 127.
- Partial-install failures where the JSON entry was written but the script wasn't.
- Failures inside the launcher itself (missing port/token, network errors talking to the local hook server) are unaffected — the script's own exit status still flows through.

## What this doesn't fix

- The underlying multi-instance design issue: only one `~/.claude/settings.json` exists, every Orca install on every boot rewrites the path to its own userData and sweeps the others out via `createManagedCommandMatcher`. With this fix the failure mode is now silent rather than red-and-noisy, but instances still fight over the same JSON entry on every boot. The durable fix is to move the managed script to a deterministic shared path (e.g. `~/.orca/agent-hooks/claude-hook.sh`) and have the JSON entry reference an env var the agent-hooks server already injects per-PTY (`ORCA_AGENT_HOOK_*`). Worth filing as a follow-up — out of scope here.
- Windows-direct (cmd.exe) hook paths used by Codex/Gemini/Cursor are intentionally unchanged. Claude on Windows already routes through Git Bash so the POSIX guard applies; the others would need a `if exist` wrapper instead. The reported bug is macOS-only and I didn't want to risk a Windows regression on a different code path in the same patch.

## Test plan

- [x] `pnpm vitest run src/main/agent-hooks` — 81 tests pass, including 2 new ones covering the guarded form and the matcher's recognition of it.
- [x] `pnpm typecheck` clean.
- [x] Repro confirmed: `/bin/sh "<missing>"` < /dev/null returns 127; the guarded form returns 0.
- [x] E2E in a live dev Orca on a fresh CDP port: booted with `experimentalAgentDashboard=true`, all six Claude hook events (`PreToolUse`, `PostToolUse`, `PostToolUseFailure`, `PermissionRequest`, `Stop`, `UserPromptSubmit`) were rewritten with the guarded form. Moved the managed script aside; the registered command exits 0 silently. Restored the script; still exits 0. Compared to the unguarded form which exits 127 on the same input.
- [x] `~/.claude/settings.json` round-trips as valid JSON; non-hook keys unchanged.

### Manual end-to-end verification of the four scenarios

Ran each generated command shape directly through `/bin/sh -c` (the same shell the agent CLIs use to execute the JSON `command` value):

| Scenario | Old form | New form |
|---|---|---|
| Missing script (the user's reported bug) | `exit 127` ❌ | `exit 0` ✅ |
| Present-but-failing script (`exit 7`) | n/a | propagates `exit 7` ✅ |
| Path with embedded `'` | breaks quoting ❌ | runs cleanly, `exit 0` ✅ |
| Path with `$` | could expand ❌ | not expanded, runs cleanly, `exit 0` ✅ |

Tests: 17/17 pass in `installer-utils.test.ts`. The lint/format pre-commit hook is green.