### PR TITLE
Pin zod to ~4.3.6 (revert 4.4.x bump from #1526)

### DIFF
--- a/mobile/package.json
+++ b/mobile/package.json
@@ -38,7 +38,7 @@
     "react-native-worklets": "^0.7.4",
     "tweetnacl": "^1.0.3",
     "ws": "^8.20.0",
-    "zod": "^4.4.3",
+    "zod": "~4.3.6",
     "zustand": "^5.0.13"
   },
   "devDependencies": {

--- a/mobile/pnpm-lock.yaml
+++ b/mobile/pnpm-lock.yaml
@@ -87,8 +87,8 @@ importers:
         specifier: ^8.20.0
         version: 8.20.0
       zod:
-        specifier: ^4.4.3
-        version: 4.4.3
+        specifier: ~4.3.6
+        version: 4.3.6
       zustand:
         specifier: ^5.0.13
         version: 5.0.13(@types/react@19.2.14)(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6))
@@ -5637,8 +5637,8 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
-  zod@4.4.3:
-    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
   zustand@5.0.13:
     resolution: {integrity: sha512-efI2tVaVQPqtOh114loML/Z80Y4NP3yc+Ff0fYiZJPauNeWZeIp/bRFD7I9bfmCOYBh/PHxlglQ9+wvlwnPikQ==}
@@ -12492,7 +12492,7 @@ snapshots:
 
   zod@3.25.76: {}
 
-  zod@4.4.3: {}
+  zod@4.3.6: {}
 
   zustand@5.0.13(@types/react@19.2.14)(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6)):
     optionalDependencies:

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "tw-animate-css": "^1.4.0",
     "tweetnacl": "^1.0.3",
     "ws": "^8.20.0",
-    "zod": "^4.4.3",
+    "zod": "~4.3.6",
     "zustand": "^5.0.13"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,8 +227,8 @@ importers:
         specifier: ^8.20.0
         version: 8.20.0
       zod:
-        specifier: ^4.4.3
-        version: 4.4.3
+        specifier: ~4.3.6
+        version: 4.3.6
       zustand:
         specifier: ^5.0.13
         version: 5.0.13(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5))
@@ -244,7 +244,7 @@ importers:
         version: 1.59.1
       '@stablyai/playwright-test':
         specifier: ^2.1.14
-        version: 2.1.14(@playwright/test@1.59.1)(zod@4.4.3)
+        version: 2.1.14(@playwright/test@1.59.1)(zod@4.3.6)
       '@tailwindcss/vite':
         specifier: ^4.2.4
         version: 4.2.4(vite@7.3.2(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4))
@@ -6376,8 +6376,8 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
-  zod@4.4.3:
-    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
   zustand@5.0.13:
     resolution: {integrity: sha512-efI2tVaVQPqtOh114loML/Z80Y4NP3yc+Ff0fYiZJPauNeWZeIp/bRFD7I9bfmCOYBh/PHxlglQ9+wvlwnPikQ==}
@@ -8224,27 +8224,27 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
-  '@stablyai/playwright-base@2.1.14(@playwright/test@1.59.1)(zod@4.4.3)':
+  '@stablyai/playwright-base@2.1.14(@playwright/test@1.59.1)(zod@4.3.6)':
     dependencies:
       '@playwright/test': 1.59.1
       jpeg-js: 0.4.4
       p-retry: 4.6.2
       pngjs: 7.0.0
     optionalDependencies:
-      zod: 4.4.3
+      zod: 4.3.6
 
-  '@stablyai/playwright-test@2.1.14(@playwright/test@1.59.1)(zod@4.4.3)':
+  '@stablyai/playwright-test@2.1.14(@playwright/test@1.59.1)(zod@4.3.6)':
     dependencies:
       '@playwright/test': 1.59.1
-      '@stablyai/playwright': 2.1.14(@playwright/test@1.59.1)(zod@4.4.3)
-      '@stablyai/playwright-base': 2.1.14(@playwright/test@1.59.1)(zod@4.4.3)
+      '@stablyai/playwright': 2.1.14(@playwright/test@1.59.1)(zod@4.3.6)
+      '@stablyai/playwright-base': 2.1.14(@playwright/test@1.59.1)(zod@4.3.6)
     transitivePeerDependencies:
       - zod
 
-  '@stablyai/playwright@2.1.14(@playwright/test@1.59.1)(zod@4.4.3)':
+  '@stablyai/playwright@2.1.14(@playwright/test@1.59.1)(zod@4.3.6)':
     dependencies:
       '@playwright/test': 1.59.1
-      '@stablyai/playwright-base': 2.1.14(@playwright/test@1.59.1)(zod@4.4.3)
+      '@stablyai/playwright-base': 2.1.14(@playwright/test@1.59.1)(zod@4.3.6)
     transitivePeerDependencies:
       - zod
 
@@ -12882,7 +12882,7 @@ snapshots:
 
   zod@3.25.76: {}
 
-  zod@4.4.3: {}
+  zod@4.3.6: {}
 
   zustand@5.0.13(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5)):
     optionalDependencies:


### PR DESCRIPTION
## Summary

zod 4.4 changed how `.transform(...).pipe(z.X().optional())` interacts with `z.object` field validation. When such a field's key is **omitted** from the parsed object, zod 4.4 reports:

> Invalid input: expected nonoptional, received undefined

…instead of treating the missing key as the inner schema's `.optional()` case. This silently broke every RPC method whose params object uses `OptionalFiniteNumber` / `OptionalString` / `OptionalBoolean` / `OptionalPlainString` / `OptionalPositiveInt` (defined in `src/main/runtime/rpc/schemas.ts`) or local copies of the same idiom — the dispatcher rejects the call with `invalid_argument` before the handler runs.

## Real-user impact on `main`

- **mobile `worktree.ps` with default limit** returns `invalid_argument` → phone home page shows '0 worktrees' for every host that actually has worktrees, and tapping a host card never loads worktrees on the detail screen.
- `worktree.list` / `worktree.set` / `worktree.create` likewise reject callers that omit any optional field (`setupDecision`, `displayName`, `comment`, etc.).
- `terminal.split` (omit `direction`), `terminal.create` (omit `title`/`command`/`worktree`).
- `browser screenshot` / `browser scroll` / `browser wait` / `browser tab switch` / `browser tab close` / `browser intercept enable` whenever any optional field is left off.

## Diagnosis trail

The phone connects and authenticates fine (E2EE handshake completes; account-switcher RPCs work). But every `worktree.ps` invocation hits this in the dispatcher:

```
[rpc.dispatchStreaming] parseParams ERROR {
  method: 'worktree.ps',
  rawParams: undefined,
  error: { code: 'invalid_argument', message: 'Invalid input: expected nonoptional, received undefined' }
}
```

Reduced repro:

```ts
import { z } from 'zod' // 4.4.3
const OptionalFiniteNumber = z.unknown()
  .transform((v) => (typeof v === 'number' && Number.isFinite(v) ? v : undefined))
  .pipe(z.number().optional())

z.object({ limit: OptionalFiniteNumber }).safeParse({})
// 4.3.6: { success: true, data: {} }
// 4.4.3: { success: false, error: 'expected nonoptional, received undefined' }
```

## Why pin instead of fix-forward

There are 13 sites across `src/main/runtime/rpc/` that use this pattern. Each would need to switch from `.pipe(z.X().optional())` to `.pipe(z.union([z.X(), z.undefined()])).optional()` (the field-level `.optional()` is what 4.4 actually honors). That churn is large, easy to miss in CI (these schemas are validated against payload shapes that aren't exercised by the runtime test suite — this bug shipped to `main` without a single test catching it), and would have to be re-audited on the next zod minor bump.

zod 4.3.6 has no Dependabot alerts and was bumped opportunistically as part of #1526's `pnpm update` sweep, **not** for a CVE. Reverting unblocks mobile + CLI without changing any application code, and uses tilde range (`~4.3.6`) so we don't drift back into 4.4 on the next install.

## Verification

- `pnpm install` resolves `zod` to `4.3.6` in both root and mobile lockfiles.
- `pnpm tc:node` and `pnpm tc:web` clean.
- `pnpm vitest run src/main/runtime/rpc` — all RPC tests pass except the pre-existing `orchestration.test.ts` failure (better-sqlite3 native-module mismatch on Node 25, unrelated to zod).
- Reduced repro for `OptionalFiniteNumber` against the now-installed `zod` produces `{ success: true, data: {} }` for empty-object input, restoring main-prior behavior.

## Files changed

- `package.json`, `pnpm-lock.yaml` — root pin
- `mobile/package.json`, `mobile/pnpm-lock.yaml` — mobile pin
- No application code changes

Made with [Orca](https://github.com/stablyai/orca) 🐋
