### PR TITLE
feat(gh-project): drag to resize project view columns

### DIFF
--- a/src/renderer/src/components/GitHubItemDialog.tsx
+++ b/src/renderer/src/components/GitHubItemDialog.tsx
@@ -1355,19 +1355,6 @@ function ConversationTab({
             onCommentAdded={onCommentAdded}
           />
         )}
-
-        {item.type !== 'pr' ? (
-          <div className="flex justify-start pt-1">
-            <Button
-              onClick={() => onUse(item)}
-              className="gap-2"
-              aria-label="Start workspace from issue"
-            >
-              Start workspace from issue
-              <ArrowRight className="size-4" />
-            </Button>
-          </div>
-        ) : null}
       </div>
 
       {rightPanel}
@@ -1711,7 +1698,8 @@ function GHEditSection({
   localLabels,
   onStateChange,
   onLabelsChange,
-  assignees
+  assignees,
+  onUse
 }: {
   item: GitHubWorkItem
   repoPath: string | null
@@ -1721,6 +1709,7 @@ function GHEditSection({
   onStateChange: (state: GitHubWorkItem['state']) => void
   onLabelsChange: (labels: string[]) => void
   assignees: string[]
+  onUse: (item: GitHubWorkItem) => void
 }): React.JSX.Element | null {
   const [labelPopoverOpen, setLabelPopoverOpen] = useState(false)
   const [assigneePopoverOpen, setAssigneePopoverOpen] = useState(false)
@@ -2111,6 +2100,16 @@ function GHEditSection({
           )}
         </PopoverContent>
       </Popover>
+
+      <Button
+        size="sm"
+        onClick={() => onUse(item)}
+        className="ml-auto gap-2"
+        aria-label="Start workspace from issue"
+      >
+        Start workspace from issue
+        <ArrowRight className="size-4" />
+      </Button>
     </div>
   )
 }
@@ -2180,7 +2179,7 @@ function GHCommentComposer({
   )
 
   return (
-    <div className={cn('flex items-start gap-2', className)}>
+    <div className={cn('flex flex-col items-start gap-2', className)}>
       <MentionTextarea
         textareaRef={textareaRef}
         value={body}
@@ -2192,14 +2191,13 @@ function GHCommentComposer({
         placeholder="Add a comment…"
         rows={4}
         mentionOptions={mentionOptions}
-        wrapperClassName="flex min-h-20 items-stretch"
+        wrapperClassName="flex min-h-20 w-full items-stretch"
         className="scrollbar-sleek block h-20 max-h-[240px] min-h-20 w-full resize-none overflow-y-auto rounded-md border border-input bg-card px-3 py-2 text-[13px] leading-5 placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
       />
       <Button
-        size="icon"
         onClick={handleSubmit}
         disabled={!body.trim() || submitting}
-        className="size-9 shrink-0"
+        className="gap-2"
         aria-label="Send comment"
       >
         {submitting ? (
@@ -2207,6 +2205,7 @@ function GHCommentComposer({
         ) : (
           <Send className="size-3.5" />
         )}
+        Comment
       </Button>
     </div>
   )
@@ -2525,6 +2524,7 @@ export default function GitHubItemDialog({
                 onStateChange={setLocalState}
                 onLabelsChange={setLocalLabels}
                 assignees={details?.assignees ?? []}
+                onUse={onUse}
               />
             )}
 

--- a/src/renderer/src/components/github-project/ColumnResizeHandle.tsx
+++ b/src/renderer/src/components/github-project/ColumnResizeHandle.tsx
@@ -1,0 +1,123 @@
+import React, { useEffect, useRef, useState } from 'react'
+import { MIN_COLUMN_WIDTH } from './column-widths'
+
+type Props = {
+  fieldId: string
+  nextFieldId: string
+  currentWidth: number
+  nextWidth: number
+  onResize: (fieldId: string, width: number, nextFieldId: string, nextWidth: number) => void
+}
+
+// Why: stored widths are `fr` weights, not pixels — that's what keeps the
+// grid fitting its container exactly. Drag math has to happen in pixels (the
+// mouse moves in pixels), so we measure the rendered widths of the two
+// adjacent cells at drag start, compute the new pixel split, then convert
+// back to fr weights with the pair's total weight held constant. Net effect:
+// dragging redistributes width between the pair without changing the grid's
+// total — the table never grows.
+export default function ColumnResizeHandle({
+  fieldId,
+  nextFieldId,
+  currentWidth,
+  nextWidth,
+  onResize
+}: Props): React.JSX.Element {
+  const [dragging, setDragging] = useState(false)
+  const handleRef = useRef<HTMLDivElement | null>(null)
+  const dragRef = useRef<{
+    startX: number
+    startPxA: number
+    startPxB: number
+    totalFr: number
+  } | null>(null)
+
+  useEffect(() => {
+    if (!dragging) {
+      return
+    }
+    const onMove = (e: MouseEvent): void => {
+      const drag = dragRef.current
+      if (!drag) {
+        return
+      }
+      const totalPx = drag.startPxA + drag.startPxB
+      if (totalPx <= 0) {
+        return
+      }
+      const proposedPxA = drag.startPxA + (e.clientX - drag.startX)
+      const newPxA = Math.max(MIN_COLUMN_WIDTH, Math.min(totalPx - MIN_COLUMN_WIDTH, proposedPxA))
+      const newFrA = (drag.totalFr * newPxA) / totalPx
+      const newFrB = drag.totalFr - newFrA
+      onResize(fieldId, newFrA, nextFieldId, newFrB)
+    }
+    const onUp = (): void => {
+      dragRef.current = null
+      setDragging(false)
+    }
+    document.addEventListener('mousemove', onMove)
+    document.addEventListener('mouseup', onUp)
+    const prevCursor = document.body.style.cursor
+    const prevSelect = document.body.style.userSelect
+    document.body.style.cursor = 'col-resize'
+    document.body.style.userSelect = 'none'
+    return () => {
+      document.removeEventListener('mousemove', onMove)
+      document.removeEventListener('mouseup', onUp)
+      document.body.style.cursor = prevCursor
+      document.body.style.userSelect = prevSelect
+    }
+  }, [dragging, fieldId, nextFieldId, onResize])
+
+  return (
+    <div
+      ref={handleRef}
+      role="separator"
+      aria-orientation="vertical"
+      aria-label="Resize column"
+      onMouseDown={(e) => {
+        if (e.button !== 0) {
+          return
+        }
+        const cell = handleRef.current?.parentElement
+        const nextCell = cell?.nextElementSibling as HTMLElement | null
+        if (!cell || !nextCell) {
+          return
+        }
+        e.preventDefault()
+        e.stopPropagation()
+        dragRef.current = {
+          startX: e.clientX,
+          startPxA: cell.offsetWidth,
+          startPxB: nextCell.offsetWidth,
+          totalFr: currentWidth + nextWidth
+        }
+        setDragging(true)
+      }}
+      onClick={(e) => e.stopPropagation()}
+      onDoubleClick={(e) => {
+        e.preventDefault()
+        e.stopPropagation()
+      }}
+      style={{
+        position: 'absolute',
+        right: '-6px',
+        top: 0,
+        height: '100%',
+        width: '12px',
+        cursor: 'col-resize',
+        userSelect: 'none',
+        zIndex: 30,
+        background: dragging ? 'rgba(59,130,246,0.25)' : 'transparent'
+      }}
+      onMouseEnter={(e) => {
+        ;(e.currentTarget as HTMLDivElement).style.background = 'rgba(59,130,246,0.25)'
+      }}
+      onMouseLeave={(e) => {
+        if (!dragging) {
+          ;(e.currentTarget as HTMLDivElement).style.background = 'transparent'
+        }
+      }}
+    />
+  )
+}

--- a/src/renderer/src/components/github-project/ProjectCell.tsx
+++ b/src/renderer/src/components/github-project/ProjectCell.tsx
@@ -216,7 +216,7 @@ function TitleCell({
     <button
       type="button"
       onClick={onOpenDialog}
-      className="min-w-0 cursor-pointer text-left hover:underline"
+      className="block w-full min-w-0 cursor-pointer text-left hover:underline"
     >
       {content}
     </button>

--- a/src/renderer/src/components/github-project/ProjectRow.tsx
+++ b/src/renderer/src/components/github-project/ProjectRow.tsx
@@ -3,6 +3,8 @@ import { ExternalLink, Play } from 'lucide-react'
 import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
+import ColumnResizeHandle from './ColumnResizeHandle'
+import { resolveWidth } from './column-widths'
 import ProjectCell from './ProjectCell'
 import type {
   GitHubIssueType,
@@ -14,6 +16,9 @@ import type {
 type Props = {
   row: GitHubProjectRowType
   fields: GitHubProjectField[]
+  gridTemplate: string
+  widths: Readonly<Record<string, number>>
+  onResizeColumn: (fieldId: string, width: number, nextFieldId: string, nextWidth: number) => void
   editable: boolean
   onOpenDialog?: () => void
   onEditField?: (fieldId: string, value: GitHubProjectFieldMutationValue | null) => void
@@ -27,6 +32,9 @@ type Props = {
 export default function ProjectRow({
   row,
   fields,
+  gridTemplate,
+  widths,
+  onResizeColumn,
   editable,
   onOpenDialog,
   onEditField,
@@ -50,21 +58,36 @@ export default function ProjectRow({
         'group grid items-center gap-3 border-b border-border/30 px-3 py-2 hover:bg-muted/30',
         disabled && 'opacity-60'
       )}
-      style={{ gridTemplateColumns: buildGridTemplate(fields) }}
+      style={{ gridTemplateColumns: gridTemplate }}
     >
-      {fields.map((f) => (
-        <ProjectCell
-          key={f.id}
-          row={row}
-          field={f}
-          editable={editable}
-          onEditField={onEditField}
-          onEditAssignees={onEditAssignees}
-          onEditLabels={onEditLabels}
-          onEditIssueType={onEditIssueType}
-          onOpenDialog={f.dataType === 'TITLE' ? onOpenDialog : undefined}
-        />
-      ))}
+      {fields.map((f, idx) => {
+        const next = fields[idx + 1]
+        return (
+          <div key={f.id} className="relative flex min-w-0 items-center overflow-hidden">
+            <div className="min-w-0 flex-1 overflow-hidden">
+              <ProjectCell
+                row={row}
+                field={f}
+                editable={editable}
+                onEditField={onEditField}
+                onEditAssignees={onEditAssignees}
+                onEditLabels={onEditLabels}
+                onEditIssueType={onEditIssueType}
+                onOpenDialog={f.dataType === 'TITLE' ? onOpenDialog : undefined}
+              />
+            </div>
+            {next ? (
+              <ColumnResizeHandle
+                fieldId={f.id}
+                nextFieldId={next.id}
+                currentWidth={resolveWidth(f, widths)}
+                nextWidth={resolveWidth(next, widths)}
+                onResize={onResizeColumn}
+              />
+            ) : null}
+          </div>
+        )
+      })}
       <div className="flex items-center justify-end gap-1 opacity-0 transition group-hover:opacity-100">
         {row.content.url ? (
           <Tooltip>
@@ -115,14 +138,4 @@ export default function ProjectRow({
     )
   }
   return rowInner
-}
-
-export function buildGridTemplate(fields: GitHubProjectField[]): string {
-  // Why: TITLE gets the most space; other columns share equally. The extra
-  // trailing column is for row-hover action icons.
-  const cols: string[] = fields.map((f) =>
-    f.dataType === 'TITLE' ? 'minmax(0,3fr)' : 'minmax(80px,1fr)'
-  )
-  cols.push('80px')
-  return cols.join(' ')
 }

--- a/src/renderer/src/components/github-project/ProjectViewList.tsx
+++ b/src/renderer/src/components/github-project/ProjectViewList.tsx
@@ -1,11 +1,19 @@
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { ArrowDown, ArrowUp, ArrowUpDown, Columns3 } from 'lucide-react'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { cn } from '@/lib/utils'
+import ColumnResizeHandle from './ColumnResizeHandle'
 import ProjectGroupHeader from './ProjectGroupHeader'
-import ProjectRow, { buildGridTemplate } from './ProjectRow'
+import ProjectRow from './ProjectRow'
 import { groupRows, sortRows } from './group-sort'
 import { getAvailableColumns, loadHiddenColumns, saveHiddenColumns } from './columns'
+import {
+  buildGridTemplate,
+  loadColumnWidths,
+  MIN_COLUMN_WIDTH,
+  resolveWidth,
+  saveColumnWidths
+} from './column-widths'
 import type {
   GitHubIssueType,
   GitHubProjectField,
@@ -63,6 +71,30 @@ export default function ProjectViewList({
     () => availableFields.filter((f) => !hidden.has(f.id)),
     [availableFields, hidden]
   )
+
+  const [widths, setWidths] = useState<Readonly<Record<string, number>>>(() =>
+    loadColumnWidths(scopeKey)
+  )
+  useEffect(() => {
+    setWidths(loadColumnWidths(scopeKey))
+  }, [scopeKey])
+
+  const setColumnPair = useCallback(
+    (fieldId: string, width: number, nextFieldId: string, nextWidth: number): void => {
+      setWidths((prev) => {
+        const updated = {
+          ...prev,
+          [fieldId]: Math.max(MIN_COLUMN_WIDTH, Math.round(width)),
+          [nextFieldId]: Math.max(MIN_COLUMN_WIDTH, Math.round(nextWidth))
+        }
+        saveColumnWidths(scopeKey, updated)
+        return updated
+      })
+    },
+    [scopeKey]
+  )
+
+  const gridTemplate = useMemo(() => buildGridTemplate(fields, widths), [fields, widths])
 
   const toggleColumn = (fieldId: string): void => {
     setHidden((prev) => {
@@ -135,7 +167,7 @@ export default function ProjectViewList({
       : null
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
+    <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-y-auto">
       <ProjectHeaderRow
         fields={fields}
         availableFields={availableFields}
@@ -143,6 +175,9 @@ export default function ProjectViewList({
         onToggleColumn={toggleColumn}
         activeSort={activeSort}
         onSortClick={handleSortClick}
+        widths={widths}
+        gridTemplate={gridTemplate}
+        onResizeColumn={setColumnPair}
       />
       {groups.map((g) => {
         const expanded = !collapsed.has(g.key)
@@ -171,6 +206,9 @@ export default function ProjectViewList({
                     key={row.id}
                     row={row}
                     fields={fields}
+                    gridTemplate={gridTemplate}
+                    widths={widths}
+                    onResizeColumn={setColumnPair}
                     editable
                     onOpenDialog={() => onOpenDialog?.(row)}
                     onEditField={(fieldId, value) => onEditField?.(row, fieldId, value)}
@@ -195,7 +233,10 @@ function ProjectHeaderRow({
   hidden,
   onToggleColumn,
   activeSort,
-  onSortClick
+  onSortClick,
+  widths,
+  gridTemplate,
+  onResizeColumn
 }: {
   fields: GitHubProjectField[]
   availableFields: GitHubProjectField[]
@@ -203,6 +244,9 @@ function ProjectHeaderRow({
   onToggleColumn: (fieldId: string) => void
   activeSort: SortOverride | null
   onSortClick: (fieldId: string) => void
+  widths: Readonly<Record<string, number>>
+  gridTemplate: string
+  onResizeColumn: (fieldId: string, width: number, nextFieldId: string, nextWidth: number) => void
 }): React.JSX.Element {
   // Why: matches GitHub Projects' fixed column header — sticky so it stays
   // pinned while scrolling the rows beneath it. The trailing slot mirrors the
@@ -210,30 +254,46 @@ function ProjectHeaderRow({
   return (
     <div
       className="sticky top-0 z-10 grid items-center gap-3 border-b border-border/60 bg-background/95 px-3 py-2 text-[11px] font-medium uppercase tracking-wide text-muted-foreground backdrop-blur"
-      style={{ gridTemplateColumns: buildGridTemplate(fields) }}
+      style={{ gridTemplateColumns: gridTemplate }}
     >
-      {fields.map((f) => {
+      {fields.map((f, idx) => {
         const isActive = activeSort?.fieldId === f.id
         const Icon = isActive ? (activeSort.direction === 'ASC' ? ArrowUp : ArrowDown) : ArrowUpDown
+        // Why: only render a resize handle when there is a neighbor to
+        // borrow width from. The trailing field has no field neighbor on
+        // its right (the action column is fixed and not part of the
+        // user-resizable pair set), so omit its handle to keep the total
+        // table width invariant.
+        const next = fields[idx + 1]
         return (
-          <button
-            key={f.id}
-            type="button"
-            onClick={() => onSortClick(f.id)}
-            className={cn(
-              'group flex min-w-0 items-center gap-1 truncate text-left uppercase tracking-wide hover:text-foreground',
-              isActive && 'text-foreground'
-            )}
-            aria-label={`Sort by ${f.name}`}
-          >
-            <span className="truncate">{f.name}</span>
-            <Icon
+          <div key={f.id} className="relative flex min-w-0 items-center">
+            <button
+              type="button"
+              onClick={() => onSortClick(f.id)}
               className={cn(
-                'size-3 shrink-0 transition-opacity',
-                isActive ? 'opacity-100' : 'opacity-0 group-hover:opacity-60'
+                'group flex min-w-0 flex-1 items-center gap-1 truncate text-left uppercase tracking-wide hover:text-foreground',
+                isActive && 'text-foreground'
               )}
-            />
-          </button>
+              aria-label={`Sort by ${f.name}`}
+            >
+              <span className="truncate">{f.name}</span>
+              <Icon
+                className={cn(
+                  'size-3 shrink-0 transition-opacity',
+                  isActive ? 'opacity-100' : 'opacity-0 group-hover:opacity-60'
+                )}
+              />
+            </button>
+            {next ? (
+              <ColumnResizeHandle
+                fieldId={f.id}
+                nextFieldId={next.id}
+                currentWidth={resolveWidth(f, widths)}
+                nextWidth={resolveWidth(next, widths)}
+                onResize={onResizeColumn}
+              />
+            ) : null}
+          </div>
         )
       })}
       <div className="flex items-center justify-end">

--- a/src/renderer/src/components/github-project/ProjectViewWrapper.tsx
+++ b/src/renderer/src/components/github-project/ProjectViewWrapper.tsx
@@ -510,7 +510,7 @@ export default function ProjectViewWrapper(_props: Props = {} as Props): React.J
   )
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col">
+    <div className="flex min-h-0 min-w-0 flex-1 flex-col">
       <div className="flex flex-none items-center gap-2 border-b border-border/50 bg-muted/30 px-3 py-2">
         <ProjectPicker
           activeProject={

--- a/src/renderer/src/components/github-project/column-widths.ts
+++ b/src/renderer/src/components/github-project/column-widths.ts
@@ -1,0 +1,86 @@
+// Why: column widths are a renderer-only preference. Persisted in
+// localStorage (not settings) for the same reasons hidden columns are —
+// purely cosmetic per device and a noisy debounced settings write would
+// be wasteful for what is effectively continuous drag feedback.
+//
+// Stored values are interpreted as `fr` weights, not pixels — this lets
+// the grid always fit its container exactly. Resize redistributes
+// weights between a column pair so the total stays constant and the
+// table never grows beyond its container.
+import type { GitHubProjectField } from '../../../../shared/github-project-types'
+
+const STORAGE_KEY = 'orca.githubProject.columnWidths'
+
+// Default fr weights — TITLE gets the most room; others sit at a
+// comfortable label-width. The numeric values are arbitrary ratios.
+export const DEFAULT_TITLE_WIDTH = 360
+export const DEFAULT_FIELD_WIDTH = 140
+export const ACTION_COLUMN_WIDTH = 80
+export const MIN_COLUMN_WIDTH = 60
+
+type WidthMap = Record<string, Record<string, number>>
+
+function readMap(): WidthMap {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY)
+    if (!raw) {
+      return {}
+    }
+    const parsed = JSON.parse(raw)
+    return parsed && typeof parsed === 'object' ? (parsed as WidthMap) : {}
+  } catch {
+    return {}
+  }
+}
+
+function writeMap(map: WidthMap): void {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(map))
+  } catch {
+    // localStorage may be disabled — widths just won't persist this session.
+  }
+}
+
+export function loadColumnWidths(scopeKey: string): Readonly<Record<string, number>> {
+  const map = readMap()
+  return map[scopeKey] ?? {}
+}
+
+export function saveColumnWidths(scopeKey: string, widths: Record<string, number>): void {
+  const map = readMap()
+  if (Object.keys(widths).length === 0) {
+    delete map[scopeKey]
+  } else {
+    map[scopeKey] = widths
+  }
+  writeMap(map)
+}
+
+export function defaultWidthFor(field: GitHubProjectField): number {
+  return field.dataType === 'TITLE' ? DEFAULT_TITLE_WIDTH : DEFAULT_FIELD_WIDTH
+}
+
+export function resolveWidth(
+  field: GitHubProjectField,
+  widths: Readonly<Record<string, number>>
+): number {
+  const stored = widths[field.id]
+  if (typeof stored === 'number' && stored >= MIN_COLUMN_WIDTH) {
+    return stored
+  }
+  return defaultWidthFor(field)
+}
+
+export function buildGridTemplate(
+  fields: GitHubProjectField[],
+  widths: Readonly<Record<string, number>>
+): string {
+  // Why: emit `minmax(<min>px, <weight>fr)` so the grid honors the
+  // user's relative weights AND fits within the container — pixel
+  // widths would let a wide TITLE blow past the parent and push the
+  // surrounding chrome out. The minmax floor is what stops a column
+  // from collapsing to zero when its weight is small.
+  const cols = fields.map((f) => `minmax(${MIN_COLUMN_WIDTH}px, ${resolveWidth(f, widths)}fr)`)
+  cols.push(`${ACTION_COLUMN_WIDTH}px`)
+  return cols.join(' ')
+}


### PR DESCRIPTION
## Summary
- Adds drag-to-resize column handles to the GitHub Project view, with per-scope widths persisted in localStorage as `fr` weights so the grid always fits its container (no horizontal overflow).
- Resize redistributes width between an adjacent column pair only — total grid width stays invariant.
- Side-quest UX cleanup in `GitHubItemDialog`: moves "Start workspace from issue" button into `GHEditSection` (right-aligned), and turns the comment composer's icon-only send button into a labeled "Comment" button stacked under the textarea.

## Test plan
- [ ] Open a GitHub Project tab, drag a column divider — column resizes, neighbor shrinks/grows by the same amount, table doesn't overflow.
- [ ] Refresh the app — widths persist per project scope.
- [ ] Switch projects — widths are scoped per project (don't leak across).
- [ ] Open an issue dialog — "Start workspace from issue" appears in edit section header; clicking it triggers the workspace flow.
- [ ] Open issue/PR comment composer — "Comment" button below the textarea sends the comment.

Made with [Orca](https://github.com/stablyai/orca) 🐋
