### PR TITLE
fix(runtime): pin dev WebSocket port to 6769 for deterministic pairing

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -531,11 +531,19 @@ app.whenReady().then(async () => {
   // assign a random available port per instance while still exercising the
   // full WebSocket startup path.
   const isE2E = Boolean(process.env.ORCA_E2E_USER_DATA_DIR)
+  // Why: a developer running `pnpm dev` while the packaged Orca is also open
+  // would otherwise race the packaged app for 6768 and silently fall back to
+  // a random OS-assigned port — breaking deterministic mobile pairing/repro
+  // scripts against the dev instance. Pin the first dev instance to 6769 so
+  // ws://127.0.0.1:6769 is stable; a second dev instance still falls back via
+  // ws-transport's EADDRINUSE handler.
+  const devWsPort = is.dev && !isE2E ? 6769 : undefined
   runtimeRpc = new OrcaRuntimeRpcServer({
     runtime,
     userDataPath: app.getPath('userData'),
     enableWebSocket: true,
-    ...(isE2E ? { wsPort: 0 } : {})
+    ...(isE2E ? { wsPort: 0 } : {}),
+    ...(devWsPort !== undefined ? { wsPort: devWsPort } : {})
   })
   registerMobileHandlers(runtimeRpc)
 


### PR DESCRIPTION
## Problem

Running \`pnpm dev\` while the packaged Orca app is open consistently logs:

\`\`\`
[ws-transport] Port 6768 is in use, falling back to OS-assigned port
\`\`\`

Packaged Orca already owns 6768, so the dev instance always loses the race and ends up on a random OS-assigned port. That breaks deterministic mobile pairing and any repro script that targets \`ws://127.0.0.1:<port>\` against the dev instance.

## Fix

Pin the first dev instance to **6769** (one above the packaged port) in \`src/main/index.ts\`. The existing \`EADDRINUSE\` fallback in \`ws-transport.ts\` still handles a second concurrent dev instance.

| Mode | WS port |
| --- | --- |
| Packaged Orca | 6768 (unchanged) |
| First \`pnpm dev\` | **6769** (new — was random) |
| Second concurrent \`pnpm dev\` | OS-assigned (unchanged fallback) |
| E2E (\`ORCA_E2E_USER_DATA_DIR\`) | 0 (unchanged) |

## Verification

- \`pnpm typecheck:node\` passes
- Lint-staged (oxlint, oxfmt) passes on commit

Made with [Orca](https://github.com/stablyai/orca) 🐋
