### PR TITLE
Settings: rephrase phone-fit-hold copy to drop third-party brand name

### DIFF
--- a/mobile/app/terminal-settings.tsx
+++ b/mobile/app/terminal-settings.tsx
@@ -146,7 +146,7 @@ export default function TerminalSettingsScreen() {
         <Text style={styles.groupDescription}>
           While you&apos;re using a terminal on your phone, Orca shrinks it to fit your
           screen. When you close the app or switch away, this controls whether it stays at
-          phone size (so apps like Claude Code don&apos;t reflow) or resizes back to your
+          phone size (so interactive CLI tools don&apos;t reflow) or resizes back to your
           desktop. You can always tap Restore on the terminal banner to resize it manually.
         </Text>
 

--- a/src/renderer/src/components/settings/MobilePane.tsx
+++ b/src/renderer/src/components/settings/MobilePane.tsx
@@ -310,7 +310,7 @@ export function MobilePane(): React.JSX.Element {
         <p className="text-muted-foreground mb-3 text-xs">
           While you&apos;re using a terminal on your phone, Orca shrinks it to fit your phone
           screen. When you close the app or switch away, this controls whether it stays at
-          phone size (so apps like Claude Code don&apos;t reflow) or resizes back to your
+          phone size (so interactive CLI tools don&apos;t reflow) or resizes back to your
           desktop. You can always click Restore on the terminal banner to resize it manually.
         </p>
         <Select


### PR DESCRIPTION
## Summary

Drop the explicit "Claude Code" reference in the auto-restore-fit setting description. Same one-line copy fix applied to both the mobile app's Terminal settings page and the desktop's Mobile preferences pane (kept in sync).

Before:
> phone size (so apps like Claude Code don't reflow)

After:
> phone size (so interactive CLI tools don't reflow)

## Why

The previous copy named a specific third-party CLI as the canonical example. "Interactive CLI tools" describes the actual category the setting protects — TUIs that don't reflow gracefully on resize — and ages better as the agent-CLI landscape shifts.

## Risk

Cosmetic copy change, no behavior change. typecheck (mobile + web) and oxlint pass clean.

Made with [Orca](https://github.com/stablyai/orca) 🐋
