### PR TITLE
chore(mobile): bump version to 0.0.6 build 1

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Orca",
     "slug": "orca-mobile",
-    "version": "0.0.5",
+    "version": "0.0.6",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",


### PR DESCRIPTION
Bumps mobile/app.json to version 0.0.6 (iOS buildNumber 1, Android versionCode 1) for the next TestFlight upload.

Follows the established convention of landing the version bump on main before generating native iOS project files.

Made with [Orca](https://github.com/stablyai/orca) 🐋
