### PR TITLE
Make orca.yaml trust dialog clearer when re-prompting

### DIFF
--- a/src/renderer/src/components/sidebar/OrcaYamlTrustDialog.tsx
+++ b/src/renderer/src/components/sidebar/OrcaYamlTrustDialog.tsx
@@ -45,6 +45,7 @@ const OrcaYamlTrustDialog = React.memo(function OrcaYamlTrustDialog() {
         : 'setup'
   const scriptContent = typeof modalData.scriptContent === 'string' ? modalData.scriptContent : ''
   const contentHash = typeof modalData.contentHash === 'string' ? modalData.contentHash : ''
+  const previouslyApproved = modalData.previouslyApproved === true
   const onResolve =
     typeof modalData.onResolve === 'function'
       ? (modalData.onResolve as (decision: 'run' | 'skip') => void)
@@ -94,19 +95,29 @@ const OrcaYamlTrustDialog = React.memo(function OrcaYamlTrustDialog() {
       <DialogContent className="max-w-md sm:max-w-md" showCloseButton={false}>
         <DialogHeader>
           <DialogTitle className="text-sm">
-            Run {SCRIPT_KIND_LABEL[scriptKind]} from {repoName}?
+            {previouslyApproved
+              ? `${repoName}'s ${SCRIPT_KIND_LABEL[scriptKind]} changed — run the new version?`
+              : `Run ${SCRIPT_KIND_LABEL[scriptKind]} from ${repoName}?`}
           </DialogTitle>
           <DialogDescription className="text-xs">
-            This repository&apos;s <code>orca.yaml</code> defines a {SCRIPT_KIND_LABEL[scriptKind]}{' '}
-            that will execute on your machine {SCRIPT_KIND_TRIGGER[scriptKind]}. Only run it if you
-            trust the contents of this repository.
+            {previouslyApproved ? (
+              <>
+                <code>orca.yaml</code> changed since you last approved. Re-review before it runs{' '}
+                {SCRIPT_KIND_TRIGGER[scriptKind]}.
+              </>
+            ) : (
+              <>
+                This repository&apos;s <code>orca.yaml</code> runs on your machine{' '}
+                {SCRIPT_KIND_TRIGGER[scriptKind]}. Only run if you trust {repoName}.
+              </>
+            )}
           </DialogDescription>
         </DialogHeader>
 
         {scriptContent && (
           <div className="rounded-md border border-border/70 bg-muted/35 px-3 py-2">
             <div className="mb-1 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
-              {scriptKind} script
+              {previouslyApproved ? `New ${scriptKind} script` : `${scriptKind} script`}
             </div>
             <pre className="max-h-48 overflow-auto whitespace-pre-wrap break-all font-mono text-xs text-foreground">
               {scriptContent}
@@ -114,15 +125,21 @@ const OrcaYamlTrustDialog = React.memo(function OrcaYamlTrustDialog() {
           </div>
         )}
 
-        <label className="flex items-start gap-2 text-xs text-foreground">
+        <label
+          className={`flex cursor-pointer items-center gap-2.5 rounded-md border px-3 py-2 transition-colors ${
+            alwaysTrust
+              ? 'border-primary/60 bg-primary/5'
+              : 'border-border/70 bg-muted/25 hover:border-border hover:bg-muted/40'
+          }`}
+        >
           <input
             type="checkbox"
-            className="mt-0.5 h-3.5 w-3.5"
+            className="h-4 w-4 accent-primary"
             checked={alwaysTrust}
             onChange={(event) => setAlwaysTrust(event.target.checked)}
           />
-          <span>
-            Always trust this repository&apos;s <code>orca.yaml</code> hooks.
+          <span className="text-xs font-medium text-foreground">
+            Always trust <code>orca.yaml</code> in {repoName}
           </span>
         </label>
 

--- a/src/renderer/src/lib/ensure-hooks-confirmed.test.ts
+++ b/src/renderer/src/lib/ensure-hooks-confirmed.test.ts
@@ -90,6 +90,9 @@ describe('ensureHooksConfirmed', () => {
 
     expect(pending).toHaveLength(1)
     expect(pending[0].data.scriptContent).toBe('new script')
+    // The dialog uses this flag to tell the user we're re-prompting *because*
+    // orca.yaml changed, not because they've never approved this hook.
+    expect(pending[0].data.previouslyApproved).toBe(true)
 
     pending[0].resolve('run')
     await expect(promise).resolves.toBe('run')
@@ -156,7 +159,8 @@ describe('ensureHooksConfirmed', () => {
       repoName: 'Repo One',
       scriptKind: 'setup',
       scriptContent: 'pnpm install',
-      contentHash: await hashOrcaHookScript('pnpm install')
+      contentHash: await hashOrcaHookScript('pnpm install'),
+      previouslyApproved: false
     })
 
     pending[0].resolve('run')

--- a/src/renderer/src/lib/ensure-hooks-confirmed.ts
+++ b/src/renderer/src/lib/ensure-hooks-confirmed.ts
@@ -58,6 +58,9 @@ export async function ensureHooksConfirmed(
 
     const repo = state.repos.find((r) => r.id === repoId)
     const repoName = repo?.displayName ?? 'this repository'
+    // A non-empty existingHash that didn't match means the user approved a previous
+    // version of this script; the prompt is reappearing because orca.yaml changed.
+    const previouslyApproved = Boolean(existingHash)
 
     return new Promise<'run' | 'skip'>((resolve) => {
       state.openModal('confirm-orca-yaml-hooks', {
@@ -66,6 +69,7 @@ export async function ensureHooksConfirmed(
         scriptKind,
         scriptContent,
         contentHash,
+        previouslyApproved,
         onResolve: (decision: 'run' | 'skip') => resolve(decision)
       })
     })


### PR DESCRIPTION
## Summary
- Threads a `previouslyApproved` flag from `ensureHooksConfirmed` into the trust dialog so the UI can tell first-time approvals apart from re-prompts caused by an `orca.yaml` change.
- Re-prompts now lead with \"<repo>'s setup script changed — run the new version?\" and a re-review hint, instead of the same generic prompt every time.
- Restyles the \"always trust\" checkbox as a toggleable card so its current state is more obvious.

## Test plan
- [x] `pnpm typecheck` passes
- [x] `vitest run src/renderer/src/lib/ensure-hooks-confirmed.test.ts` — 8/8 pass (new assertion covers `previouslyApproved` propagation)
- [ ] Manual: trigger a setup hook with no prior approval → first-time copy mentions `orca.yaml` and shows \"setup script\" header
- [ ] Manual: change the setup script after approving → re-prompt copy leads with the changed-script message and shows \"New setup script\" header

Made with [Orca](https://github.com/stablyai/orca) 🐋
