### PR TITLE
fix(new-workspace): keep Cmd/Ctrl+Enter submit working after source selection

### DIFF
--- a/src/renderer/src/components/NewWorkspaceComposerModal.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerModal.tsx
@@ -6,8 +6,13 @@ import AgentSettingsDialog from '@/components/agent/AgentSettingsDialog'
 import { useComposerState } from '@/hooks/useComposerState'
 import { AGENT_CATALOG } from '@/lib/agent-catalog'
 import type { LinkedWorkItemSummary } from '@/lib/new-workspace'
-import { shouldSuppressEnterSubmit } from '@/lib/new-workspace-enter-guard'
+import {
+  shouldAllowComposerEnterSubmitTarget,
+  shouldSuppressEnterSubmit
+} from '@/lib/new-workspace-enter-guard'
 import type { TuiAgent, WorkspaceCreateTelemetrySource } from '../../../shared/types'
+
+const isMac = typeof navigator !== 'undefined' && navigator.userAgent.includes('Mac')
 
 type ComposerModalData = {
   prefilledName?: string
@@ -181,11 +186,11 @@ function QuickTabBody({
       // plain Enter inside fields (notes, repo search) doesn't accidentally
       // submit — users can type or confirm selections without triggering
       // workspace creation.
-      const hasModifier = event.metaKey || event.ctrlKey
+      const hasModifier = isMac ? event.metaKey && !event.ctrlKey : event.ctrlKey && !event.metaKey
       if (!hasModifier) {
         return
       }
-      if (!composerRef.current?.contains(target)) {
+      if (!shouldAllowComposerEnterSubmitTarget(target, composerRef.current)) {
         return
       }
       if (createDisabled) {

--- a/src/renderer/src/lib/new-workspace-enter-guard.test.ts
+++ b/src/renderer/src/lib/new-workspace-enter-guard.test.ts
@@ -1,5 +1,8 @@
-import { describe, it, expect } from 'vitest'
-import { shouldSuppressEnterSubmit } from './new-workspace-enter-guard'
+import { afterEach, beforeEach, describe, it, expect } from 'vitest'
+import {
+  shouldAllowComposerEnterSubmitTarget,
+  shouldSuppressEnterSubmit
+} from './new-workspace-enter-guard'
 
 function makeEvent(overrides: Partial<{ isComposing: boolean; shiftKey: boolean }>): {
   isComposing: boolean
@@ -7,6 +10,21 @@ function makeEvent(overrides: Partial<{ isComposing: boolean; shiftKey: boolean 
 } {
   return { isComposing: false, shiftKey: false, ...overrides }
 }
+
+class FakeHTMLElement extends EventTarget {
+  private readonly children = new Set<FakeHTMLElement>()
+
+  append(child: FakeHTMLElement): void {
+    this.children.add(child)
+  }
+
+  contains(target: EventTarget): boolean {
+    return target === this || this.children.has(target as FakeHTMLElement)
+  }
+}
+
+let previousHTMLElement: typeof globalThis.HTMLElement | undefined
+let previousDocument: typeof globalThis.document | undefined
 
 describe('shouldSuppressEnterSubmit', () => {
   it('returns false for a plain Enter with no composition', () => {
@@ -28,6 +46,67 @@ describe('shouldSuppressEnterSubmit', () => {
   it('returns true when both isComposing and shiftKey are true (textarea)', () => {
     expect(shouldSuppressEnterSubmit(makeEvent({ isComposing: true, shiftKey: true }), true)).toBe(
       true
+    )
+  })
+})
+
+describe('shouldAllowComposerEnterSubmitTarget', () => {
+  beforeEach(() => {
+    previousHTMLElement = globalThis.HTMLElement
+    previousDocument = globalThis.document
+    const body = new FakeHTMLElement()
+    const documentElement = new FakeHTMLElement()
+    Object.defineProperty(globalThis, 'HTMLElement', {
+      configurable: true,
+      value: FakeHTMLElement
+    })
+    Object.defineProperty(globalThis, 'document', {
+      configurable: true,
+      value: { body, documentElement }
+    })
+  })
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, 'HTMLElement', {
+      configurable: true,
+      value: previousHTMLElement
+    })
+    Object.defineProperty(globalThis, 'document', {
+      configurable: true,
+      value: previousDocument
+    })
+  })
+
+  it('allows targets inside the composer', () => {
+    const composer = new FakeHTMLElement()
+    const input = new FakeHTMLElement()
+    composer.append(input)
+
+    expect(shouldAllowComposerEnterSubmitTarget(input, composer as unknown as HTMLElement)).toBe(
+      true
+    )
+  })
+
+  it('allows body/document targets after a source selection drops focus', () => {
+    const composer = new FakeHTMLElement()
+
+    expect(
+      shouldAllowComposerEnterSubmitTarget(document.body, composer as unknown as HTMLElement)
+    ).toBe(true)
+    expect(
+      shouldAllowComposerEnterSubmitTarget(
+        document.documentElement,
+        composer as unknown as HTMLElement
+      )
+    ).toBe(true)
+  })
+
+  it('rejects targets outside the composer', () => {
+    const composer = new FakeHTMLElement()
+    const outside = new FakeHTMLElement()
+
+    expect(shouldAllowComposerEnterSubmitTarget(outside, composer as unknown as HTMLElement)).toBe(
+      false
     )
   })
 })

--- a/src/renderer/src/lib/new-workspace-enter-guard.ts
+++ b/src/renderer/src/lib/new-workspace-enter-guard.ts
@@ -17,3 +17,19 @@ export function shouldSuppressEnterSubmit(
   }
   return false
 }
+
+export function shouldAllowComposerEnterSubmitTarget(
+  target: EventTarget | null,
+  composer: HTMLElement | null
+): boolean {
+  if (!(target instanceof HTMLElement)) {
+    return false
+  }
+  if (composer?.contains(target)) {
+    return true
+  }
+  // Why: selecting a PR/issue/Linear row replaces the focused input with a
+  // source pill, and Chromium can retarget the next global keydown to body.
+  // Keep the modal shortcut alive for that post-selection focus fallback.
+  return target === document.body || target === document.documentElement
+}


### PR DESCRIPTION
## Summary
- After selecting a PR/issue/Linear row, focus moves off the input and Chromium retargets the next keydown to `document.body`, breaking the Cmd/Ctrl+Enter submit shortcut. Allow `body`/`documentElement` as valid submit targets so the modal shortcut survives the post-selection focus drop.
- Tighten the modifier check to be platform-exclusive — Cmd-only on Mac, Ctrl-only on Linux/Windows — so users don't accidentally submit while holding both modifiers.
- Adds unit tests covering composer-contained, body/documentElement, and outside targets.

## Test plan
- [x] `npx vitest run src/renderer/src/lib/new-workspace-enter-guard.test.ts` (8/8 pass)
- [x] `npx tsc --noEmit -p config/tsconfig.web.json` (no new errors)
- [ ] Manual: Cmd+Enter still submits after picking a GitHub PR/issue/Linear row in the New Workspace modal
- [ ] Manual: Cmd+Enter inside composer fields still submits
- [ ] Manual on Linux/Windows: Ctrl+Enter behaves the same; Cmd+Ctrl+Enter does not submit

Made with [Orca](https://github.com/stablyai/orca) 🐋
