### PR TITLE
feat(diff-comments): edit notes inline from diff card and sidebar

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -1096,6 +1096,12 @@
    percentages would not give equal contrast. Override lives in `.dark`. */
 .orca-diff-comment-card {
   position: relative;
+  /* Why: Monaco's view-lines overlay (data-mprt=8) is positioned absolutely on
+     top of view-zone DOM. Without an explicit z-index here, clicks on
+     interior controls (Cancel/Save in edit mode, the textarea, etc.) hit the
+     overlay first and never reach our buttons. Lifting the whole card creates
+     a stacking context that keeps every nested control clickable. */
+  z-index: 1;
   border: 1px solid color-mix(in srgb, var(--foreground) 22%, transparent);
   border-left: 3px solid color-mix(in srgb, var(--foreground) 55%, transparent);
   border-radius: 6px;
@@ -1266,6 +1272,36 @@
 
 .orca-diff-comment-popover-footer {
   display: flex;
+  align-items: center;
   justify-content: flex-end;
   gap: 6px;
+}
+
+/* Why: surface the keyboard shortcuts next to Cancel/Save so users know Enter
+   submits and Escape cancels without trial and error. mr:auto pushes the hint
+   to the left so the action buttons stay right-aligned. */
+.orca-diff-comment-shortcut-hint {
+  margin-right: auto;
+  font-size: 10.5px;
+  color: var(--muted-foreground);
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  user-select: none;
+}
+
+.orca-diff-comment-shortcut-hint kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  border: 1px solid color-mix(in srgb, var(--foreground) 22%, transparent);
+  border-radius: 3px;
+  background: color-mix(in srgb, var(--foreground) 6%, transparent);
+  font-family: inherit;
+  font-size: 10px;
+  line-height: 1;
+  color: var(--muted-foreground);
 }

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -1278,23 +1278,18 @@
 }
 
 /* Why: trailing kbd pill inside Save/Cancel so the keyboard shortcut sits on
-   the action it triggers — same pattern as the Search row in SidebarNav. The
-   pill uses a translucent background so it adapts to both the primary
-   (filled) Save button and the ghost Cancel button. */
+   the action it triggers — same pattern as the AppearancePane shortcut hints.
+   No min-width or fixed height so the glyph (Esc, ↵) sets the pill's natural
+   width instead of being centered in a forced square. */
 .orca-diff-comment-kbd {
   display: inline-flex;
   align-items: center;
-  justify-content: center;
-  min-width: 14px;
-  height: 14px;
-  padding: 0 3px;
   margin-left: 2px;
+  padding: 1px 4px;
   border: 1px solid color-mix(in srgb, currentColor 30%, transparent);
   border-radius: 3px;
-  background: color-mix(in srgb, currentColor 10%, transparent);
   font-family: inherit;
-  font-size: 9.5px;
+  font-size: 10px;
   line-height: 1;
-  font-weight: 500;
   opacity: 0.75;
 }

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -1277,31 +1277,24 @@
   gap: 6px;
 }
 
-/* Why: surface the keyboard shortcuts next to Cancel/Save so users know Enter
-   submits and Escape cancels without trial and error. mr:auto pushes the hint
-   to the left so the action buttons stay right-aligned. */
-.orca-diff-comment-shortcut-hint {
-  margin-right: auto;
-  font-size: 10.5px;
-  color: var(--muted-foreground);
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  user-select: none;
-}
-
-.orca-diff-comment-shortcut-hint kbd {
+/* Why: trailing kbd pill inside Save/Cancel so the keyboard shortcut sits on
+   the action it triggers — same pattern as the Search row in SidebarNav. The
+   pill uses a translucent background so it adapts to both the primary
+   (filled) Save button and the ghost Cancel button. */
+.orca-diff-comment-kbd {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 16px;
-  height: 16px;
-  padding: 0 4px;
-  border: 1px solid color-mix(in srgb, var(--foreground) 22%, transparent);
+  min-width: 14px;
+  height: 14px;
+  padding: 0 3px;
+  margin-left: 2px;
+  border: 1px solid color-mix(in srgb, currentColor 30%, transparent);
   border-radius: 3px;
-  background: color-mix(in srgb, var(--foreground) 6%, transparent);
+  background: color-mix(in srgb, currentColor 10%, transparent);
   font-family: inherit;
-  font-size: 10px;
+  font-size: 9.5px;
   line-height: 1;
-  color: var(--muted-foreground);
+  font-weight: 500;
+  opacity: 0.75;
 }

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -1276,20 +1276,3 @@
   justify-content: flex-end;
   gap: 6px;
 }
-
-/* Why: trailing kbd pill inside Save/Cancel so the keyboard shortcut sits on
-   the action it triggers — same pattern as the AppearancePane shortcut hints.
-   No min-width or fixed height so the glyph (Esc, ↵) sets the pill's natural
-   width instead of being centered in a forced square. */
-.orca-diff-comment-kbd {
-  display: inline-flex;
-  align-items: center;
-  margin-left: 2px;
-  padding: 1px 4px;
-  border: 1px solid color-mix(in srgb, currentColor 30%, transparent);
-  border-radius: 3px;
-  font-family: inherit;
-  font-size: 10px;
-  line-height: 1;
-  opacity: 0.75;
-}

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -1125,6 +1125,36 @@
   letter-spacing: 0.03em;
 }
 
+/* Why: keep edit + delete close together but visually distinct from the meta
+   label. Both share the same subtle button styling; only delete recolours on
+   hover (destructive intent). */
+.orca-diff-comment-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.orca-diff-comment-edit {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 3px;
+  border-radius: 4px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--muted-foreground);
+  cursor: pointer;
+  pointer-events: auto;
+  position: relative;
+  z-index: 1;
+}
+
+.orca-diff-comment-edit:hover {
+  color: var(--foreground);
+  border-color: color-mix(in srgb, var(--foreground) 20%, transparent);
+  background: color-mix(in srgb, var(--foreground) 6%, transparent);
+}
+
 /* Why: the trash button is always visible (not hover-only) because the saved
    note is a persistent, action-bearing card — users should be able to see and
    target the delete affordance without guessing that hovering reveals it.

--- a/src/renderer/src/components/diff-comments/DiffCommentCard.tsx
+++ b/src/renderer/src/components/diff-comments/DiffCommentCard.tsx
@@ -15,10 +15,6 @@ import { Button } from '@/components/ui/button'
 type Props = {
   lineNumber: number
   body: string
-  // Why: when the card is rendered without an `onEdit` callback (e.g. a
-  // future read-only diff surface) the pencil button is hidden so consumers
-  // can opt out of inline editing.
-  onEdit?: () => void
   onDelete: () => void
   // Why: Monaco view zones have a fixed `heightInPx` set at insertion time
   // and aren't auto-measured. While the user is in edit mode the textarea
@@ -37,7 +33,6 @@ type Props = {
 export function DiffCommentCard({
   lineNumber,
   body,
-  onEdit,
   onDelete,
   onContentResize,
   pendingEdit,
@@ -118,17 +113,24 @@ export function DiffCommentCard({
     onContentResizeRef.current?.()
   }, [editing])
 
-  // Why: when the editor opens or closes the card's height changes (textarea
-  // + footer vs single body block). Ping the decorator so it re-measures and
-  // resizes the Monaco view zone — otherwise the card clips the next line.
+  const editingPrevRef = useRef(editing)
   useEffect(() => {
+    if (editingPrevRef.current === editing) {
+      return
+    }
+    editingPrevRef.current = editing
+    // Why: when the editor opens or closes the card's height changes (textarea
+    // + footer vs single body block). Ping the decorator so it re-measures and
+    // resizes the Monaco view zone — otherwise the card clips the next line.
+    // Skip the initial mount: the zone's heightInPx estimate is intentionally
+    // close to actual on first paint to avoid a layout pass before the user
+    // interacts; firing here would re-layout every card on creation.
     onContentResizeRef.current?.()
   }, [editing])
 
   const handleStartEdit = (): void => {
     setDraft(body)
     setEditing(true)
-    onEdit?.()
   }
 
   const handleCancel = (): void => {
@@ -136,17 +138,16 @@ export function DiffCommentCard({
     setDraft(body)
   }
 
+  const trimmedDraft = draft.trim()
+  const canSubmit = !submitting && trimmedDraft.length > 0 && trimmedDraft !== body
+
   const handleSubmit = async (): Promise<void> => {
-    if (submitting || !onSubmitEdit) {
-      return
-    }
-    const trimmed = draft.trim()
-    if (!trimmed) {
+    if (!canSubmit || !onSubmitEdit) {
       return
     }
     setSubmitting(true)
     try {
-      const ok = await onSubmitEdit(trimmed)
+      const ok = await onSubmitEdit(trimmedDraft)
       if (ok) {
         setEditing(false)
       }
@@ -222,16 +223,12 @@ export function DiffCommentCard({
               // Why: plain Enter saves to mirror the new-note popover; Shift
               // +Enter keeps the newline. IME composition is excluded so a
               // CJK conversion-confirm keystroke doesn't submit a half-typed
-              // note. Mirror the Save button's disabled guard — if the draft
-              // is empty or unchanged, no-op so Enter doesn't quietly close
-              // the editor (the user must explicitly Cancel/Escape).
+              // note. Share the canSubmit predicate with the Save button so
+              // Enter doesn't quietly close the editor when empty/unchanged
+              // (the user must explicitly Cancel/Escape).
               if (e.key === 'Enter' && !e.nativeEvent.isComposing && !e.shiftKey) {
                 e.preventDefault()
-                if (submitting) {
-                  return
-                }
-                const trimmed = draft.trim()
-                if (!trimmed || trimmed === body) {
+                if (!canSubmit) {
                   return
                 }
                 void handleSubmit()
@@ -246,11 +243,7 @@ export function DiffCommentCard({
             <Button variant="ghost" size="sm" onClick={handleCancel} disabled={submitting}>
               Cancel
             </Button>
-            <Button
-              size="sm"
-              onClick={() => void handleSubmit()}
-              disabled={submitting || draft.trim().length === 0 || draft.trim() === body}
-            >
+            <Button size="sm" onClick={() => void handleSubmit()} disabled={!canSubmit}>
               {submitting ? 'Saving…' : 'Save'}
             </Button>
           </div>

--- a/src/renderer/src/components/diff-comments/DiffCommentCard.tsx
+++ b/src/renderer/src/components/diff-comments/DiffCommentCard.tsx
@@ -243,7 +243,15 @@ export function DiffCommentCard({
             <Button variant="ghost" size="sm" onClick={handleCancel} disabled={submitting}>
               Cancel
             </Button>
-            <Button size="sm" onClick={() => void handleSubmit()} disabled={!canSubmit}>
+            <Button
+              size="sm"
+              onClick={() => void handleSubmit()}
+              disabled={!canSubmit}
+              // Why: pin a min-width sized to fit "Saving…" so the brief
+              // submit-in-flight label swap doesn't shift button width and
+              // produce a visible jitter on fast (local-IPC) saves.
+              className="min-w-[68px]"
+            >
               {submitting ? 'Saving…' : 'Save'}
             </Button>
           </div>

--- a/src/renderer/src/components/diff-comments/DiffCommentCard.tsx
+++ b/src/renderer/src/components/diff-comments/DiffCommentCard.tsx
@@ -237,11 +237,9 @@ export function DiffCommentCard({
             rows={3}
           />
           <div className="orca-diff-comment-popover-footer">
-            <span className="orca-diff-comment-shortcut-hint" aria-hidden="true">
-              <kbd>↵</kbd> to save · <kbd>Esc</kbd> to cancel
-            </span>
             <Button variant="ghost" size="sm" onClick={handleCancel} disabled={submitting}>
               Cancel
+              <kbd className="orca-diff-comment-kbd">Esc</kbd>
             </Button>
             <Button
               size="sm"
@@ -254,6 +252,7 @@ export function DiffCommentCard({
               title={submitting ? 'Saving…' : undefined}
             >
               Save
+              <kbd className="orca-diff-comment-kbd">↵</kbd>
             </Button>
           </div>
         </>

--- a/src/renderer/src/components/diff-comments/DiffCommentCard.tsx
+++ b/src/renderer/src/components/diff-comments/DiffCommentCard.tsx
@@ -240,6 +240,9 @@ export function DiffCommentCard({
             rows={3}
           />
           <div className="orca-diff-comment-popover-footer">
+            <span className="orca-diff-comment-shortcut-hint" aria-hidden="true">
+              <kbd>↵</kbd> to save · <kbd>Esc</kbd> to cancel
+            </span>
             <Button variant="ghost" size="sm" onClick={handleCancel} disabled={submitting}>
               Cancel
             </Button>

--- a/src/renderer/src/components/diff-comments/DiffCommentCard.tsx
+++ b/src/renderer/src/components/diff-comments/DiffCommentCard.tsx
@@ -247,12 +247,13 @@ export function DiffCommentCard({
               size="sm"
               onClick={() => void handleSubmit()}
               disabled={!canSubmit}
-              // Why: pin a min-width sized to fit "Saving…" so the brief
-              // submit-in-flight label swap doesn't shift button width and
-              // produce a visible jitter on fast (local-IPC) saves.
-              className="min-w-[68px]"
+              // Why: keep the label "Save" while submitting so the button
+              // doesn't change width mid-flight; the disabled state alone
+              // signals the in-flight save. The title attribute surfaces the
+              // status for assistive tech.
+              title={submitting ? 'Saving…' : undefined}
             >
-              {submitting ? 'Saving…' : 'Save'}
+              Save
             </Button>
           </div>
         </>

--- a/src/renderer/src/components/diff-comments/DiffCommentCard.tsx
+++ b/src/renderer/src/components/diff-comments/DiffCommentCard.tsx
@@ -1,4 +1,6 @@
-import { Trash } from 'lucide-react'
+import { Pencil, Trash } from 'lucide-react'
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { Button } from '@/components/ui/button'
 
 // Why: the saved-note card lives inside a Monaco view zone's DOM node.
 // useDiffCommentDecorator creates a React root per zone and renders this
@@ -13,30 +15,246 @@ import { Trash } from 'lucide-react'
 type Props = {
   lineNumber: number
   body: string
+  // Why: when the card is rendered without an `onEdit` callback (e.g. a
+  // future read-only diff surface) the pencil button is hidden so consumers
+  // can opt out of inline editing.
+  onEdit?: () => void
   onDelete: () => void
+  // Why: Monaco view zones have a fixed `heightInPx` set at insertion time
+  // and aren't auto-measured. While the user is in edit mode the textarea
+  // grows, so the parent decorator passes a callback we fire on resize and
+  // it re-syncs the zone height. Without this the editor inputs would clip.
+  onContentResize?: () => void
+  // Why: the SourceControl sidebar can request that a specific card open
+  // its editor. The decorator forwards that pending id; when it matches,
+  // we enter edit mode on the next render and acknowledge so the request
+  // doesn't fire repeatedly.
+  pendingEdit?: boolean
+  onPendingEditConsumed?: () => void
+  onSubmitEdit?: (body: string) => Promise<boolean>
 }
 
-export function DiffCommentCard({ lineNumber, body, onDelete }: Props): React.JSX.Element {
+export function DiffCommentCard({
+  lineNumber,
+  body,
+  onEdit,
+  onDelete,
+  onContentResize,
+  pendingEdit,
+  onPendingEditConsumed,
+  onSubmitEdit
+}: Props): React.JSX.Element {
+  const [editing, setEditing] = useState(false)
+  const [draft, setDraft] = useState(body)
+  const [submitting, setSubmitting] = useState(false)
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null)
+
+  // Why: stash the consumed callback in a ref so the effect below doesn't
+  // re-run every parent render (the decorator passes a fresh arrow each time).
+  // Without this, an unrelated re-render with `pendingEdit=true` still in props
+  // would re-fire the effect after `editing` flipped to false from Cancel,
+  // re-entering edit mode against the user's intent.
+  const onPendingEditConsumedRef = useRef(onPendingEditConsumed)
+  onPendingEditConsumedRef.current = onPendingEditConsumed
+  // Why: ack each `pendingEdit` activation exactly once. The effect's
+  // `editing` and `body` deps cause re-entry after `setEditing(true)` lands or
+  // when an external edit lands mid-request; without this guard ack would fire
+  // multiple times per request, producing redundant `setEditingDiffCommentId`
+  // store writes and re-render churn.
+  const ackedPendingEditRef = useRef(false)
+
+  // Why: enter edit mode when the sidebar requests it via the UI slice. The
+  // ack callback clears the pending id so re-clicking after cancel works. Ack
+  // also fires when the card is already editing — otherwise a same-id re-
+  // request from the sidebar would leave the global state stuck.
+  useEffect(() => {
+    if (!pendingEdit) {
+      ackedPendingEditRef.current = false
+      return
+    }
+    if (ackedPendingEditRef.current) {
+      return
+    }
+    ackedPendingEditRef.current = true
+    if (!editing) {
+      setEditing(true)
+      setDraft(body)
+    }
+    onPendingEditConsumedRef.current?.()
+  }, [pendingEdit, editing, body])
+
+  // Why: keep the draft in sync with external body changes when not actively
+  // editing, so a concurrent agent edit (or a delete + recreate) is visible
+  // the next time the user opens the editor.
+  useEffect(() => {
+    if (!editing) {
+      setDraft(body)
+    }
+  }, [body, editing])
+
+  // Why: stash `onContentResize` in a ref so the layout/resize effects only
+  // re-run on `editing` transitions. The decorator passes a fresh arrow every
+  // render; depending on it directly would re-fire the layout effect on every
+  // unrelated parent render and yank the caret to the textarea's end while
+  // the user is mid-edit.
+  const onContentResizeRef = useRef(onContentResize)
+  onContentResizeRef.current = onContentResize
+
+  // Why: focus + auto-grow the textarea on entering edit mode. Layout effect
+  // so the height is set before the browser paints — a measurement pass on
+  // the next animation frame would visibly jump from 0 to N px.
+  useLayoutEffect(() => {
+    if (!editing) {
+      return
+    }
+    const el = textareaRef.current
+    if (!el) {
+      return
+    }
+    el.style.height = 'auto'
+    el.style.height = `${Math.min(el.scrollHeight, 240)}px`
+    el.focus()
+    el.setSelectionRange(el.value.length, el.value.length)
+    onContentResizeRef.current?.()
+  }, [editing])
+
+  // Why: when the editor opens or closes the card's height changes (textarea
+  // + footer vs single body block). Ping the decorator so it re-measures and
+  // resizes the Monaco view zone — otherwise the card clips the next line.
+  useEffect(() => {
+    onContentResizeRef.current?.()
+  }, [editing])
+
+  const handleStartEdit = (): void => {
+    setDraft(body)
+    setEditing(true)
+    onEdit?.()
+  }
+
+  const handleCancel = (): void => {
+    setEditing(false)
+    setDraft(body)
+  }
+
+  const handleSubmit = async (): Promise<void> => {
+    if (submitting || !onSubmitEdit) {
+      return
+    }
+    const trimmed = draft.trim()
+    if (!trimmed) {
+      return
+    }
+    setSubmitting(true)
+    try {
+      const ok = await onSubmitEdit(trimmed)
+      if (ok) {
+        setEditing(false)
+      }
+    } catch (err) {
+      // Why: surface the error in the console but keep the editor open with
+      // the draft intact so the user can retry. Without this, a rejection from
+      // `onSubmitEdit` becomes an unhandled promise rejection at the call sites
+      // (`void handleSubmit()`).
+      console.error('Failed to submit diff comment edit:', err)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
   return (
     <div className="orca-diff-comment-card">
       <div className="orca-diff-comment-header">
         <span className="orca-diff-comment-meta">Note · line {lineNumber}</span>
-        <button
-          type="button"
-          className="orca-diff-comment-delete"
-          title="Delete note"
-          aria-label="Delete note"
-          onMouseDown={(ev) => ev.stopPropagation()}
-          onClick={(ev) => {
-            ev.preventDefault()
-            ev.stopPropagation()
-            onDelete()
-          }}
-        >
-          <Trash className="size-3.5" />
-        </button>
+        <div className="orca-diff-comment-actions">
+          {onSubmitEdit && !editing && (
+            <button
+              type="button"
+              className="orca-diff-comment-edit"
+              title="Edit note"
+              aria-label="Edit note"
+              onMouseDown={(ev) => ev.stopPropagation()}
+              onClick={(ev) => {
+                ev.preventDefault()
+                ev.stopPropagation()
+                handleStartEdit()
+              }}
+            >
+              <Pencil className="size-3.5" />
+            </button>
+          )}
+          {!editing && (
+            <button
+              type="button"
+              className="orca-diff-comment-delete"
+              title="Delete note"
+              aria-label="Delete note"
+              onMouseDown={(ev) => ev.stopPropagation()}
+              onClick={(ev) => {
+                ev.preventDefault()
+                ev.stopPropagation()
+                onDelete()
+              }}
+            >
+              <Trash className="size-3.5" />
+            </button>
+          )}
+        </div>
       </div>
-      <div className="orca-diff-comment-body">{body}</div>
+      {editing ? (
+        <>
+          <textarea
+            ref={textareaRef}
+            className="orca-diff-comment-popover-textarea"
+            value={draft}
+            onChange={(e) => {
+              setDraft(e.target.value)
+              const el = e.currentTarget
+              el.style.height = 'auto'
+              el.style.height = `${Math.min(el.scrollHeight, 240)}px`
+              onContentResizeRef.current?.()
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Escape') {
+                e.preventDefault()
+                handleCancel()
+                return
+              }
+              // Why: plain Enter saves to mirror the new-note popover; Shift
+              // +Enter keeps the newline. IME composition is excluded so a
+              // CJK conversion-confirm keystroke doesn't submit a half-typed
+              // note. Mirror the Save button's disabled guard — if the draft
+              // is empty or unchanged, no-op so Enter doesn't quietly close
+              // the editor (the user must explicitly Cancel/Escape).
+              if (e.key === 'Enter' && !e.nativeEvent.isComposing && !e.shiftKey) {
+                e.preventDefault()
+                if (submitting) {
+                  return
+                }
+                const trimmed = draft.trim()
+                if (!trimmed || trimmed === body) {
+                  return
+                }
+                void handleSubmit()
+              }
+            }}
+            rows={3}
+          />
+          <div className="orca-diff-comment-popover-footer">
+            <Button variant="ghost" size="sm" onClick={handleCancel} disabled={submitting}>
+              Cancel
+            </Button>
+            <Button
+              size="sm"
+              onClick={() => void handleSubmit()}
+              disabled={submitting || draft.trim().length === 0 || draft.trim() === body}
+            >
+              {submitting ? 'Saving…' : 'Save'}
+            </Button>
+          </div>
+        </>
+      ) : (
+        <div className="orca-diff-comment-body">{body}</div>
+      )}
     </div>
   )
 }

--- a/src/renderer/src/components/diff-comments/DiffCommentCard.tsx
+++ b/src/renderer/src/components/diff-comments/DiffCommentCard.tsx
@@ -239,7 +239,6 @@ export function DiffCommentCard({
           <div className="orca-diff-comment-popover-footer">
             <Button variant="ghost" size="sm" onClick={handleCancel} disabled={submitting}>
               Cancel
-              <kbd className="orca-diff-comment-kbd">Esc</kbd>
             </Button>
             <Button
               size="sm"

--- a/src/renderer/src/components/diff-comments/DiffCommentCard.tsx
+++ b/src/renderer/src/components/diff-comments/DiffCommentCard.tsx
@@ -251,7 +251,7 @@ export function DiffCommentCard({
               title={submitting ? 'Saving…' : undefined}
             >
               Save
-              {!submitting && <CornerDownLeft className="ml-1 size-3 opacity-70" />}
+              <CornerDownLeft className="ml-1 size-3 opacity-70" />
             </Button>
           </div>
         </>

--- a/src/renderer/src/components/diff-comments/DiffCommentCard.tsx
+++ b/src/renderer/src/components/diff-comments/DiffCommentCard.tsx
@@ -1,4 +1,4 @@
-import { Pencil, Trash } from 'lucide-react'
+import { CornerDownLeft, Pencil, Trash } from 'lucide-react'
 import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { Button } from '@/components/ui/button'
 
@@ -251,7 +251,7 @@ export function DiffCommentCard({
               title={submitting ? 'Saving…' : undefined}
             >
               Save
-              <kbd className="orca-diff-comment-kbd">↵</kbd>
+              {!submitting && <CornerDownLeft className="ml-1 size-3 opacity-70" />}
             </Button>
           </div>
         </>

--- a/src/renderer/src/components/diff-comments/useDiffCommentDecorator.tsx
+++ b/src/renderer/src/components/diff-comments/useDiffCommentDecorator.tsx
@@ -293,6 +293,59 @@ export function useDiffCommentDecorator({
     // the Monaco batch, then unmount afterwards.
     const rootsToUnmount: Root[] = []
 
+    // Why: re-measure the zone DOM and tell Monaco to grow/shrink the zone
+    // so the inline editor can expand without clipping the next editor line.
+    // Called from the card whenever it toggles edit mode or the textarea
+    // grows. Monaco's `_layoutZone` re-reads `delegate.heightInPx`, so we
+    // mutate the delegate first, then trigger a re-layout. Bails out if the
+    // zone has been removed since enqueuing. Defined outside changeViewZones
+    // so a future caller cannot mistakenly reach into the outer accessor —
+    // resizeZone always opens its own changeViewZones batch.
+    const resizeZone = (commentId: string): void => {
+      const entry = zones.get(commentId)
+      if (!entry) {
+        return
+      }
+      const measured = entry.domNode.scrollHeight
+      if (measured <= 0) {
+        return
+      }
+      if (entry.delegate.heightInPx === measured) {
+        return
+      }
+      entry.delegate.heightInPx = measured
+      editor.changeViewZones((acc) => {
+        acc.layoutZone(entry.zoneId)
+      })
+    }
+
+    // Why: render helper used by BOTH the new-zone branch and the patch-
+    // existing-zone branch so the card's prop wiring stays in lockstep — any
+    // future prop is added once.
+    const renderCard = (root: Root, comment: DiffComment): void => {
+      root.render(
+        <DiffCommentCard
+          lineNumber={comment.lineNumber}
+          body={comment.body}
+          onDelete={() => onDeleteCommentRef.current(comment.id)}
+          onSubmitEdit={
+            onUpdateCommentRef.current
+              ? async (body) => {
+                  const fn = onUpdateCommentRef.current
+                  if (!fn) {
+                    return false
+                  }
+                  return fn(comment.id, body)
+                }
+              : undefined
+          }
+          onContentResize={() => resizeZone(comment.id)}
+          pendingEdit={pendingEditCommentId === comment.id}
+          onPendingEditConsumed={() => onPendingEditConsumedRef.current?.()}
+        />
+      )
+    }
+
     editor.changeViewZones((accessor) => {
       // Why: remove only the zones whose comments are gone. Rebuilding all
       // zones on every change caused flicker and dropped focus/selection in
@@ -303,30 +356,6 @@ export function useDiffCommentDecorator({
           rootsToUnmount.push(entry.root)
           zones.delete(commentId)
         }
-      }
-
-      // Why: re-measure the zone DOM and tell Monaco to grow/shrink the zone
-      // so the inline editor can expand without clipping the next editor line.
-      // Called from the card whenever it toggles edit mode or the textarea
-      // grows. Monaco's `_layoutZone` re-reads `delegate.heightInPx`, so we
-      // mutate the delegate first, then trigger a re-layout. Bails out if the
-      // zone has been removed since enqueuing.
-      const resizeZone = (commentId: string): void => {
-        const entry = zones.get(commentId)
-        if (!entry) {
-          return
-        }
-        const measured = entry.domNode.scrollHeight
-        if (measured <= 0) {
-          return
-        }
-        if (entry.delegate.heightInPx === measured) {
-          return
-        }
-        entry.delegate.heightInPx = measured
-        editor.changeViewZones((acc) => {
-          acc.layoutZone(entry.zoneId)
-        })
       }
 
       // Add zones for newly-added comments.
@@ -343,30 +372,7 @@ export function useDiffCommentDecorator({
         dom.addEventListener('mousedown', (ev) => ev.stopPropagation())
 
         const root = createRoot(dom)
-        const renderCard = (comment: DiffComment): void => {
-          root.render(
-            <DiffCommentCard
-              lineNumber={comment.lineNumber}
-              body={comment.body}
-              onDelete={() => onDeleteCommentRef.current(comment.id)}
-              onSubmitEdit={
-                onUpdateCommentRef.current
-                  ? async (body) => {
-                      const fn = onUpdateCommentRef.current
-                      if (!fn) {
-                        return false
-                      }
-                      return fn(comment.id, body)
-                    }
-                  : undefined
-              }
-              onContentResize={() => resizeZone(comment.id)}
-              pendingEdit={pendingEditCommentId === comment.id}
-              onPendingEditConsumed={() => onPendingEditConsumedRef.current?.()}
-            />
-          )
-        }
-        renderCard(c)
+        renderCard(root, c)
 
         // Why: estimate height from line count so the zone is close to the
         // right size on first paint. Monaco sets heightInPx authoritatively at
@@ -415,27 +421,7 @@ export function useDiffCommentDecorator({
         if (entry.lastBody === c.body && entry.lastPendingEdit === nextPendingEdit) {
           continue
         }
-        entry.root.render(
-          <DiffCommentCard
-            lineNumber={c.lineNumber}
-            body={c.body}
-            onDelete={() => onDeleteCommentRef.current(c.id)}
-            onSubmitEdit={
-              onUpdateCommentRef.current
-                ? async (body) => {
-                    const fn = onUpdateCommentRef.current
-                    if (!fn) {
-                      return false
-                    }
-                    return fn(c.id, body)
-                  }
-                : undefined
-            }
-            onContentResize={() => resizeZone(c.id)}
-            pendingEdit={nextPendingEdit}
-            onPendingEditConsumed={() => onPendingEditConsumedRef.current?.()}
-          />
-        )
+        renderCard(entry.root, c)
         entry.lastBody = c.body
         entry.lastPendingEdit = nextPendingEdit
       }

--- a/src/renderer/src/components/diff-comments/useDiffCommentDecorator.tsx
+++ b/src/renderer/src/components/diff-comments/useDiffCommentDecorator.tsx
@@ -21,14 +21,42 @@ type DecoratorArgs = {
   addButtonLabel?: string
   onAddCommentClick: (args: { lineNumber: number; startLine?: number; top: number }) => void
   onDeleteComment: (commentId: string) => void
+  // Why: present only on surfaces that allow editing the saved note (local
+  // diffs persisted to WorktreeMeta). GitHub PR review surfaces don't pass
+  // this — their notes are remote and can't be edited via this slice.
+  onUpdateComment?: (commentId: string, body: string) => Promise<boolean>
+  // Why: pending-edit request from the SourceControl sidebar. When this id
+  // matches a card the card auto-enters its inline editor on the next render.
+  // The decorator forwards it through; the card calls the ack callback so we
+  // know to stop forcing the editor open on subsequent renders.
+  pendingEditCommentId?: string | null
+  onPendingEditConsumed?: () => void
 }
 
 type ZoneEntry = {
   zoneId: string
   domNode: HTMLElement
+  // Why: hold the IViewZone delegate so `layoutZone` re-reads our updated
+  // heightInPx during inline edits. Monaco's _layoutZone calls
+  // _computeWhitespaceProps(zone.delegate), which reads delegate.heightInPx —
+  // mutating the delegate is the supported way to grow a zone in place.
+  delegate: monacoEditor.IViewZone
   root: Root
   lastBody: string
+  // Why: track the last `pendingEdit` prop we rendered so the patch loop
+  // re-renders whenever it transitions. Without this, after the card acks the
+  // pending request (clearing the global to null), the decorator's next pass
+  // would skip the re-render — the card keeps `pendingEdit=true` in props, and
+  // a later `editing=false` toggle would re-trigger its open-editor effect.
+  lastPendingEdit: boolean
 }
+
+// Why: card chrome (header/meta/border/padding) plus per-line body height. Used
+// in two places — the initial heightInPx estimate and the live resize during
+// inline edit — so keep them in lockstep.
+const ZONE_CHROME_PX = 52
+const ZONE_LINE_PX = 18
+const ZONE_MIN_PX = 72
 
 export function useDiffCommentDecorator({
   editor,
@@ -37,7 +65,10 @@ export function useDiffCommentDecorator({
   comments,
   addButtonLabel = 'Add note for the AI',
   onAddCommentClick,
-  onDeleteComment
+  onDeleteComment,
+  onUpdateComment,
+  pendingEditCommentId,
+  onPendingEditConsumed
 }: DecoratorArgs): void {
   const hoverLineRef = useRef<number | null>(null)
   // Why: one React root per view zone. Body updates re-render into the
@@ -52,8 +83,12 @@ export function useDiffCommentDecorator({
   // the "+" button and all view zones, producing visible flicker.
   const onAddCommentClickRef = useRef(onAddCommentClick)
   const onDeleteCommentRef = useRef(onDeleteComment)
+  const onUpdateCommentRef = useRef(onUpdateComment)
+  const onPendingEditConsumedRef = useRef(onPendingEditConsumed)
   onAddCommentClickRef.current = onAddCommentClick
   onDeleteCommentRef.current = onDeleteComment
+  onUpdateCommentRef.current = onUpdateComment
+  onPendingEditConsumedRef.current = onPendingEditConsumed
 
   useEffect(() => {
     if (!editor) {
@@ -270,6 +305,30 @@ export function useDiffCommentDecorator({
         }
       }
 
+      // Why: re-measure the zone DOM and tell Monaco to grow/shrink the zone
+      // so the inline editor can expand without clipping the next editor line.
+      // Called from the card whenever it toggles edit mode or the textarea
+      // grows. Monaco's `_layoutZone` re-reads `delegate.heightInPx`, so we
+      // mutate the delegate first, then trigger a re-layout. Bails out if the
+      // zone has been removed since enqueuing.
+      const resizeZone = (commentId: string): void => {
+        const entry = zones.get(commentId)
+        if (!entry) {
+          return
+        }
+        const measured = entry.domNode.scrollHeight
+        if (measured <= 0) {
+          return
+        }
+        if (entry.delegate.heightInPx === measured) {
+          return
+        }
+        entry.delegate.heightInPx = measured
+        editor.changeViewZones((acc) => {
+          acc.layoutZone(entry.zoneId)
+        })
+      }
+
       // Add zones for newly-added comments.
       for (const c of relevant) {
         if (zones.has(c.id)) {
@@ -284,13 +343,30 @@ export function useDiffCommentDecorator({
         dom.addEventListener('mousedown', (ev) => ev.stopPropagation())
 
         const root = createRoot(dom)
-        root.render(
-          <DiffCommentCard
-            lineNumber={c.lineNumber}
-            body={c.body}
-            onDelete={() => onDeleteCommentRef.current(c.id)}
-          />
-        )
+        const renderCard = (comment: DiffComment): void => {
+          root.render(
+            <DiffCommentCard
+              lineNumber={comment.lineNumber}
+              body={comment.body}
+              onDelete={() => onDeleteCommentRef.current(comment.id)}
+              onSubmitEdit={
+                onUpdateCommentRef.current
+                  ? async (body) => {
+                      const fn = onUpdateCommentRef.current
+                      if (!fn) {
+                        return false
+                      }
+                      return fn(comment.id, body)
+                    }
+                  : undefined
+              }
+              onContentResize={() => resizeZone(comment.id)}
+              pendingEdit={pendingEditCommentId === comment.id}
+              onPendingEditConsumed={() => onPendingEditConsumedRef.current?.()}
+            />
+          )
+        }
+        renderCard(c)
 
         // Why: estimate height from line count so the zone is close to the
         // right size on first paint. Monaco sets heightInPx authoritatively at
@@ -298,24 +374,30 @@ export function useDiffCommentDecorator({
         // lets the card bleed into the following editor line. The constant
         // covers fixed chrome (inline wrapper padding ~10, card border 2, card
         // padding 12, header+meta ~22, trailing breathing room) and the
-        // per-line factor matches the 12px/1.4 body line-height. If you tweak
-        // the card's padding/header sizing, re-tune these numbers in lockstep
-        // or the zone will clip again.
+        // per-line factor matches the 12px/1.4 body line-height.
         const lineCount = c.body.split('\n').length
-        const heightInPx = Math.max(72, 52 + lineCount * 18)
+        const heightInPx = Math.max(ZONE_MIN_PX, ZONE_CHROME_PX + lineCount * ZONE_LINE_PX)
 
         // Why: suppressMouseDown: false so clicks inside the zone (Delete
         // button) reach our DOM listeners. With true, Monaco intercepts the
         // mousedown and routes it to the editor, so the Delete button never
         // fires. The delete/body mousedown listeners stopPropagation so the
         // editor still doesn't steal focus on interaction.
-        const zoneId = accessor.addZone({
+        const delegate: monacoEditor.IViewZone = {
           afterLineNumber: c.lineNumber,
           heightInPx,
           domNode: dom,
           suppressMouseDown: false
+        }
+        const zoneId = accessor.addZone(delegate)
+        zones.set(c.id, {
+          zoneId,
+          domNode: dom,
+          delegate,
+          root,
+          lastBody: c.body,
+          lastPendingEdit: pendingEditCommentId === c.id
         })
-        zones.set(c.id, { zoneId, domNode: dom, root, lastBody: c.body })
       }
 
       // Patch existing zones whose body text changed in place — re-render the
@@ -325,7 +407,12 @@ export function useDiffCommentDecorator({
         if (!entry) {
           continue
         }
-        if (entry.lastBody === c.body) {
+        const nextPendingEdit = pendingEditCommentId === c.id
+        // Why: re-render when body OR pending-edit state changed. Skipping on
+        // the body alone left a stale `pendingEdit=true` in the card's props
+        // after ack, which then re-triggered the open-editor effect on the
+        // next `editing` toggle (Cancel re-entered edit mode).
+        if (entry.lastBody === c.body && entry.lastPendingEdit === nextPendingEdit) {
           continue
         }
         entry.root.render(
@@ -333,9 +420,24 @@ export function useDiffCommentDecorator({
             lineNumber={c.lineNumber}
             body={c.body}
             onDelete={() => onDeleteCommentRef.current(c.id)}
+            onSubmitEdit={
+              onUpdateCommentRef.current
+                ? async (body) => {
+                    const fn = onUpdateCommentRef.current
+                    if (!fn) {
+                      return false
+                    }
+                    return fn(c.id, body)
+                  }
+                : undefined
+            }
+            onContentResize={() => resizeZone(c.id)}
+            pendingEdit={nextPendingEdit}
+            onPendingEditConsumed={() => onPendingEditConsumedRef.current?.()}
           />
         )
         entry.lastBody = c.body
+        entry.lastPendingEdit = nextPendingEdit
       }
     })
 
@@ -353,5 +455,5 @@ export function useDiffCommentDecorator({
     // forcing a full rebuild — exactly the flicker this diff-based pass is
     // meant to avoid. Zone teardown lives in the editor-scoped effect above,
     // which only fires when the editor itself is replaced/unmounted.
-  }, [editor, filePath, worktreeId, comments])
+  }, [editor, filePath, worktreeId, comments, pendingEditCommentId])
 }

--- a/src/renderer/src/components/editor/DiffSectionItem.tsx
+++ b/src/renderer/src/components/editor/DiffSectionItem.tsx
@@ -77,6 +77,9 @@ export function DiffSectionItem({
   const editorFontZoomLevel = useAppStore((s) => s.editorFontZoomLevel)
   const addDiffComment = useAppStore((s) => s.addDiffComment)
   const deleteDiffComment = useAppStore((s) => s.deleteDiffComment)
+  const updateDiffComment = useAppStore((s) => s.updateDiffComment)
+  const editingDiffCommentId = useAppStore((s) => s.editingDiffCommentId)
+  const setEditingDiffCommentId = useAppStore((s) => s.setEditingDiffCommentId)
   // Why: subscribe to the raw comments array on the worktree (reference-
   // stable across unrelated store updates) and filter by filePath inside a
   // memo. Selecting a fresh `.filter(...)` result would invalidate on every
@@ -125,13 +128,26 @@ export function DiffSectionItem({
 
   useEffect(() => () => disposeDiffModels(), [disposeDiffModels])
 
+  // Why: only forward the pending edit id when it matches a comment in this
+  // section so unrelated sections don't keep re-rendering their decorator
+  // every time the sidebar requests an edit elsewhere.
+  const pendingEditForThisSection = useMemo(() => {
+    if (!editingDiffCommentId) {
+      return null
+    }
+    return diffComments.some((c) => c.id === editingDiffCommentId) ? editingDiffCommentId : null
+  }, [editingDiffCommentId, diffComments])
+
   useDiffCommentDecorator({
     editor: modifiedEditor,
     filePath: section.path,
     worktreeId,
     comments: diffComments,
     onAddCommentClick: ({ lineNumber, top }) => setPopover({ lineNumber, top }),
-    onDeleteComment: (id) => void deleteDiffComment(worktreeId, id)
+    onDeleteComment: (id) => void deleteDiffComment(worktreeId, id),
+    onUpdateComment: (id, body) => updateDiffComment(worktreeId, id, body),
+    pendingEditCommentId: pendingEditForThisSection,
+    onPendingEditConsumed: () => setEditingDiffCommentId(null)
   })
 
   useEffect(() => {

--- a/src/renderer/src/components/editor/DiffViewer.tsx
+++ b/src/renderer/src/components/editor/DiffViewer.tsx
@@ -60,6 +60,9 @@ export default function DiffViewer({
   const editorFontZoomLevel = useAppStore((s) => s.editorFontZoomLevel)
   const addDiffComment = useAppStore((s) => s.addDiffComment)
   const deleteDiffComment = useAppStore((s) => s.deleteDiffComment)
+  const updateDiffComment = useAppStore((s) => s.updateDiffComment)
+  const editingDiffCommentId = useAppStore((s) => s.editingDiffCommentId)
+  const setEditingDiffCommentId = useAppStore((s) => s.setEditingDiffCommentId)
   // Why: subscribe to the raw comments array on the worktree so selector
   // identity only changes when diffComments actually changes on this worktree.
   // Filtering by relativePath happens in a memo below.
@@ -89,8 +92,19 @@ export default function DiffViewer({
 
   const hasLineCommentAction = Boolean(worktreeId || onAddLineComment)
 
+  // Why: only forward the pending edit id when this viewer owns the matching
+  // comment (worktree+path). Otherwise unrelated viewers would also try to
+  // open the editor and ack the request first, racing the intended viewer.
+  const pendingEditForThisViewer = useMemo(() => {
+    if (!worktreeId || !editingDiffCommentId) {
+      return null
+    }
+    return diffComments.some((c) => c.id === editingDiffCommentId) ? editingDiffCommentId : null
+  }, [editingDiffCommentId, diffComments, worktreeId])
+
   // Why: gate the decorator on having a comment target. Local diffs persist
   // notes to worktree metadata; GitHub PR diffs post line comments remotely.
+  // updateDiffComment is only wired for local diffs (worktreeId present).
   useDiffCommentDecorator({
     editor: hasLineCommentAction ? modifiedEditor : null,
     filePath: relativePath,
@@ -103,7 +117,10 @@ export default function DiffViewer({
       if (worktreeId) {
         void deleteDiffComment(worktreeId, id)
       }
-    }
+    },
+    onUpdateComment: worktreeId ? (id, body) => updateDiffComment(worktreeId, id, body) : undefined,
+    pendingEditCommentId: pendingEditForThisViewer,
+    onPendingEditConsumed: () => setEditingDiffCommentId(null)
   })
 
   useEffect(() => {

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -22,6 +22,7 @@ import {
   GitMerge,
   GitPullRequestArrow,
   MessageSquare,
+  Pencil,
   Trash,
   TriangleAlert,
   CircleCheck,
@@ -210,6 +211,7 @@ function SourceControlInner(): React.JSX.Element {
   const openAllDiffs = useAppStore((s) => s.openAllDiffs)
   const openBranchAllDiffs = useAppStore((s) => s.openBranchAllDiffs)
   const deleteDiffComment = useAppStore((s) => s.deleteDiffComment)
+  const setEditingDiffCommentId = useAppStore((s) => s.setEditingDiffCommentId)
   // Why: pass activeWorktreeId directly (even when null/undefined) so the
   // slice's getDiffComments returns its stable EMPTY_COMMENTS sentinel. An
   // inline `[]` fallback would allocate a new array each store update, break
@@ -1294,6 +1296,7 @@ function SourceControlInner(): React.JSX.Element {
               <DiffCommentsInlineList
                 comments={diffCommentsForActive}
                 onDelete={(id) => void deleteDiffComment(activeWorktreeId, id)}
+                onEdit={(id) => setEditingDiffCommentId(id)}
               />
             )}
           </div>
@@ -1982,10 +1985,15 @@ function SectionHeader({
 
 function DiffCommentsInlineList({
   comments,
-  onDelete
+  onDelete,
+  onEdit
 }: {
   comments: DiffComment[]
   onDelete: (commentId: string) => void
+  // Why: clicking edit doesn't open an editor inline in the sidebar — the user
+  // chose "edit in the diff card" so the parent routes the click through the
+  // UI slice, which the diff card consumes to enter its own editor.
+  onEdit: (commentId: string) => void
 }): React.JSX.Element {
   // Why: group by filePath so the inline list mirrors the structure in the
   // Notes tab — a compact section per file with line-number prefixes.
@@ -2060,6 +2068,18 @@ function DiffCommentsInlineList({
                   aria-label={`Copy note on line ${c.lineNumber}`}
                 >
                   {copiedId === c.id ? <Check className="size-3" /> : <Copy className="size-3" />}
+                </button>
+                <button
+                  type="button"
+                  className="shrink-0 rounded p-0.5 text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover:opacity-100"
+                  onClick={(ev) => {
+                    ev.stopPropagation()
+                    onEdit(c.id)
+                  }}
+                  title="Edit note in diff"
+                  aria-label={`Edit note on line ${c.lineNumber}`}
+                >
+                  <Pencil className="size-3" />
                 </button>
                 <button
                   type="button"

--- a/src/renderer/src/store/slices/diffComments.test.ts
+++ b/src/renderer/src/store/slices/diffComments.test.ts
@@ -224,13 +224,13 @@ describe('updateDiffComment', () => {
     expect(updateMeta).not.toHaveBeenCalled()
   })
 
-  it('returns true and is a no-op when the comment id is missing', async () => {
+  it('returns false when the comment id is missing (edit-while-deleted race)', async () => {
     const store = createTestStore()
     seed(store, [])
 
     const ok = await store.getState().updateDiffComment(WT, 'missing', 'anything')
 
-    expect(ok).toBe(true)
+    expect(ok).toBe(false)
     expect(updateMeta).not.toHaveBeenCalled()
   })
 

--- a/src/renderer/src/store/slices/diffComments.test.ts
+++ b/src/renderer/src/store/slices/diffComments.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { create } from 'zustand'
+import type { AppState } from '../types'
+import type { DiffComment, Worktree } from '../../../../shared/types'
+
+// Mock sonner (imported transitively by other slices)
+vi.mock('sonner', () => ({ toast: { info: vi.fn(), success: vi.fn(), error: vi.fn() } }))
+vi.mock('@/lib/agent-status', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return {
+    ...actual,
+    detectAgentStatusFromTitle: vi.fn().mockReturnValue(null)
+  }
+})
+
+const updateMeta = vi.fn().mockResolvedValue({})
+const mockApi = {
+  worktrees: {
+    list: vi.fn().mockResolvedValue([]),
+    create: vi.fn().mockResolvedValue({}),
+    remove: vi.fn().mockResolvedValue(undefined),
+    updateMeta
+  },
+  repos: {
+    list: vi.fn().mockResolvedValue([]),
+    add: vi.fn().mockResolvedValue({}),
+    remove: vi.fn().mockResolvedValue(undefined),
+    update: vi.fn().mockResolvedValue({}),
+    pickFolder: vi.fn().mockResolvedValue(null)
+  },
+  pty: { kill: vi.fn().mockResolvedValue(undefined) },
+  gh: { prForBranch: vi.fn().mockResolvedValue(null), issue: vi.fn().mockResolvedValue(null) },
+  settings: { get: vi.fn().mockResolvedValue({}), set: vi.fn().mockResolvedValue(undefined) },
+  cache: {
+    getGitHub: vi.fn().mockResolvedValue(null),
+    setGitHub: vi.fn().mockResolvedValue(undefined)
+  },
+  claudeUsage: {
+    getScanState: vi.fn().mockResolvedValue({
+      enabled: false,
+      isScanning: false,
+      lastScanStartedAt: null,
+      lastScanCompletedAt: null,
+      lastScanError: null,
+      hasAnyClaudeData: false
+    }),
+    setEnabled: vi.fn().mockResolvedValue({}),
+    refresh: vi.fn().mockResolvedValue({}),
+    getSummary: vi.fn().mockResolvedValue(null),
+    getDaily: vi.fn().mockResolvedValue([]),
+    getBreakdown: vi.fn().mockResolvedValue([]),
+    getRecentSessions: vi.fn().mockResolvedValue([])
+  },
+  codexUsage: {
+    getScanState: vi.fn().mockResolvedValue({
+      enabled: false,
+      isScanning: false,
+      lastScanStartedAt: null,
+      lastScanCompletedAt: null,
+      lastScanError: null,
+      hasAnyCodexData: false
+    }),
+    setEnabled: vi.fn().mockResolvedValue({}),
+    refresh: vi.fn().mockResolvedValue({}),
+    getSummary: vi.fn().mockResolvedValue(null),
+    getDaily: vi.fn().mockResolvedValue([]),
+    getBreakdown: vi.fn().mockResolvedValue([]),
+    getRecentSessions: vi.fn().mockResolvedValue([])
+  }
+}
+
+// @ts-expect-error -- mock
+globalThis.window = { api: mockApi }
+
+import { createRepoSlice } from './repos'
+import { createSparsePresetsSlice } from './sparse-presets'
+import { createWorktreeSlice } from './worktrees'
+import { createTerminalSlice } from './terminals'
+import { createTabsSlice } from './tabs'
+import { createUISlice } from './ui'
+import { createSettingsSlice } from './settings'
+import { createGitHubSlice } from './github'
+import { createLinearSlice } from './linear'
+import { createEditorSlice } from './editor'
+import { createStatsSlice } from './stats'
+import { createMemorySlice } from './memory'
+import { createClaudeUsageSlice } from './claude-usage'
+import { createCodexUsageSlice } from './codex-usage'
+import { createBrowserSlice } from './browser'
+import { createRateLimitSlice } from './rate-limits'
+import { createSshSlice } from './ssh'
+import { createAgentStatusSlice } from './agent-status'
+import { createDiffCommentsSlice } from './diffComments'
+import { createDetectedAgentsSlice } from './detected-agents'
+import { createWorktreeNavHistorySlice } from './worktree-nav-history'
+
+function createTestStore() {
+  return create<AppState>()((...a) => ({
+    ...createRepoSlice(...a),
+    ...createSparsePresetsSlice(...a),
+    ...createWorktreeSlice(...a),
+    ...createTerminalSlice(...a),
+    ...createTabsSlice(...a),
+    ...createUISlice(...a),
+    ...createSettingsSlice(...a),
+    ...createGitHubSlice(...a),
+    ...createLinearSlice(...a),
+    ...createEditorSlice(...a),
+    ...createStatsSlice(...a),
+    ...createMemorySlice(...a),
+    ...createClaudeUsageSlice(...a),
+    ...createCodexUsageSlice(...a),
+    ...createBrowserSlice(...a),
+    ...createRateLimitSlice(...a),
+    ...createSshSlice(...a),
+    ...createAgentStatusSlice(...a),
+    ...createDiffCommentsSlice(...a),
+    ...createDetectedAgentsSlice(...a),
+    ...createWorktreeNavHistorySlice(...a)
+  }))
+}
+
+const REPO = 'repo1'
+const WT = 'repo1::/path/wt'
+
+function makeWorktree(diffComments: DiffComment[]): Worktree {
+  return {
+    id: WT,
+    repoId: REPO,
+    path: '/path/wt',
+    head: 'abc',
+    branch: 'refs/heads/feature',
+    isBare: false,
+    isMainWorktree: false,
+    displayName: 'feature',
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0,
+    diffComments
+  }
+}
+
+function seed(store: ReturnType<typeof createTestStore>, comments: DiffComment[]): void {
+  store.setState({
+    worktreesByRepo: { [REPO]: [makeWorktree(comments)] }
+  })
+}
+
+describe('updateDiffComment', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    updateMeta.mockResolvedValue({})
+  })
+
+  it('updates the body, trims it, and persists', async () => {
+    const store = createTestStore()
+    const original: DiffComment = {
+      id: 'c1',
+      worktreeId: WT,
+      filePath: 'src/foo.ts',
+      lineNumber: 10,
+      body: 'old body',
+      createdAt: 1000,
+      side: 'modified'
+    }
+    seed(store, [original])
+
+    const ok = await store.getState().updateDiffComment(WT, 'c1', '  new body  ')
+
+    expect(ok).toBe(true)
+    const saved = store.getState().getDiffComments(WT)[0]
+    expect(saved.body).toBe('new body')
+    // identity-preserving fields untouched
+    expect(saved.id).toBe('c1')
+    expect(saved.lineNumber).toBe(10)
+    expect(saved.createdAt).toBe(1000)
+    expect(updateMeta).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects an empty body without persisting', async () => {
+    const store = createTestStore()
+    seed(store, [
+      {
+        id: 'c1',
+        worktreeId: WT,
+        filePath: 'src/foo.ts',
+        lineNumber: 10,
+        body: 'old body',
+        createdAt: 1000,
+        side: 'modified'
+      }
+    ])
+
+    const ok = await store.getState().updateDiffComment(WT, 'c1', '   ')
+
+    expect(ok).toBe(false)
+    expect(store.getState().getDiffComments(WT)[0].body).toBe('old body')
+    expect(updateMeta).not.toHaveBeenCalled()
+  })
+
+  it('returns true and is a no-op for an unchanged body', async () => {
+    const store = createTestStore()
+    seed(store, [
+      {
+        id: 'c1',
+        worktreeId: WT,
+        filePath: 'src/foo.ts',
+        lineNumber: 10,
+        body: 'same',
+        createdAt: 1000,
+        side: 'modified'
+      }
+    ])
+
+    const ok = await store.getState().updateDiffComment(WT, 'c1', 'same')
+
+    expect(ok).toBe(true)
+    expect(updateMeta).not.toHaveBeenCalled()
+  })
+
+  it('returns true and is a no-op when the comment id is missing', async () => {
+    const store = createTestStore()
+    seed(store, [])
+
+    const ok = await store.getState().updateDiffComment(WT, 'missing', 'anything')
+
+    expect(ok).toBe(true)
+    expect(updateMeta).not.toHaveBeenCalled()
+  })
+
+  it('rolls back on persist failure', async () => {
+    const store = createTestStore()
+    seed(store, [
+      {
+        id: 'c1',
+        worktreeId: WT,
+        filePath: 'src/foo.ts',
+        lineNumber: 10,
+        body: 'old body',
+        createdAt: 1000,
+        side: 'modified'
+      }
+    ])
+    updateMeta.mockRejectedValueOnce(new Error('disk full'))
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const ok = await store.getState().updateDiffComment(WT, 'c1', 'new body')
+
+    expect(ok).toBe(false)
+    expect(store.getState().getDiffComments(WT)[0].body).toBe('old body')
+    errSpy.mockRestore()
+  })
+})

--- a/src/renderer/src/store/slices/diffComments.ts
+++ b/src/renderer/src/store/slices/diffComments.ts
@@ -215,21 +215,40 @@ export const createDiffCommentsSlice: StateCreator<AppState, [], [], DiffComment
     if (!trimmed) {
       return false
     }
-    const result = mutateComments(set, worktreeId, (existing) => {
-      const idx = existing.findIndex((c) => c.id === commentId)
+
+    // Why: look up the current state OUTSIDE mutateComments so we can
+    // distinguish "comment missing" (return false — likely an edit-while-
+    // deleted race; the card should keep its draft and not silently close)
+    // from "body unchanged" (return true — benign no-op; the card can close
+    // the editor without surfacing an error).
+    const repoId = getRepoIdFromWorktreeId(worktreeId)
+    const repoList = get().worktreesByRepo[repoId]
+    const target = repoList?.find((w) => w.id === worktreeId)
+    const existing = target?.diffComments ?? []
+    const existingIdx = existing.findIndex((c) => c.id === commentId)
+    if (existingIdx === -1) {
+      return false
+    }
+    if (existing[existingIdx].body === trimmed) {
+      return true
+    }
+
+    const result = mutateComments(set, worktreeId, (current) => {
+      const idx = current.findIndex((c) => c.id === commentId)
       if (idx === -1) {
         return null
       }
-      if (existing[idx].body === trimmed) {
+      if (current[idx].body === trimmed) {
         return null
       }
-      const next = existing.slice()
-      next[idx] = { ...existing[idx], body: trimmed }
+      const next = current.slice()
+      next[idx] = { ...current[idx], body: trimmed }
       return next
     })
     if (!result) {
-      // Why: no-op (id missing or body unchanged) — treat as success so the
-      // caller can close its editor without surfacing a spurious error.
+      // Why: between the pre-check and the set updater, the comment vanished
+      // or another mutation already wrote the same body. Treat as success so
+      // the caller closes its editor.
       return true
     }
     try {

--- a/src/renderer/src/store/slices/diffComments.ts
+++ b/src/renderer/src/store/slices/diffComments.ts
@@ -6,6 +6,7 @@ import { findWorktreeById, getRepoIdFromWorktreeId } from './worktree-helpers'
 export type DiffCommentsSlice = {
   getDiffComments: (worktreeId: string | null | undefined) => DiffComment[]
   addDiffComment: (input: Omit<DiffComment, 'id' | 'createdAt'>) => Promise<DiffComment | null>
+  updateDiffComment: (worktreeId: string, commentId: string, body: string) => Promise<boolean>
   deleteDiffComment: (worktreeId: string, commentId: string) => Promise<void>
 }
 
@@ -202,6 +203,42 @@ export const createDiffCommentsSlice: StateCreator<AppState, [], [], DiffComment
       // write is not possible here even though we queued in order.
       rollback(set, input.worktreeId, result.previous, result.next)
       return null
+    }
+  },
+
+  updateDiffComment: async (worktreeId, commentId, body) => {
+    // Why: trim trailing whitespace but reject an entirely-empty edit so we
+    // don't end up with a saved note that renders as a blank card. Callers
+    // should treat `false` as "edit not committed" and keep the editor open
+    // so the user can either type more or cancel explicitly.
+    const trimmed = body.trim()
+    if (!trimmed) {
+      return false
+    }
+    const result = mutateComments(set, worktreeId, (existing) => {
+      const idx = existing.findIndex((c) => c.id === commentId)
+      if (idx === -1) {
+        return null
+      }
+      if (existing[idx].body === trimmed) {
+        return null
+      }
+      const next = existing.slice()
+      next[idx] = { ...existing[idx], body: trimmed }
+      return next
+    })
+    if (!result) {
+      // Why: no-op (id missing or body unchanged) — treat as success so the
+      // caller can close its editor without surfacing a spurious error.
+      return true
+    }
+    try {
+      await enqueuePersist(worktreeId, get)
+      return true
+    } catch (err) {
+      console.error('Failed to persist diff comments:', err)
+      rollback(set, worktreeId, result.previous, result.next)
+      return false
     }
   },
 

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -286,6 +286,12 @@ export type UISlice = {
   pendingRevealWorktreeId: string | null
   revealWorktreeInSidebar: (worktreeId: string) => void
   clearPendingRevealWorktreeId: () => void
+  // Why: lets the SourceControl sidebar request that a specific diff-comment
+  // card open its inline editor. Cleared by the card after it consumes the
+  // request (or when the user cancels), so the same id can be requested again
+  // later without the card seeing a stale value.
+  editingDiffCommentId: string | null
+  setEditingDiffCommentId: (id: string | null) => void
   persistedUIReady: boolean
   uiZoomLevel: number
   setUIZoomLevel: (level: number) => void
@@ -654,6 +660,8 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
   pendingRevealWorktreeId: null,
   revealWorktreeInSidebar: (worktreeId) => set({ pendingRevealWorktreeId: worktreeId }),
   clearPendingRevealWorktreeId: () => set({ pendingRevealWorktreeId: null }),
+  editingDiffCommentId: null,
+  setEditingDiffCommentId: (id) => set({ editingDiffCommentId: id }),
   persistedUIReady: false,
   uiZoomLevel: 0,
   setUIZoomLevel: (level) => set({ uiZoomLevel: level }),


### PR DESCRIPTION
## Summary
- Adds an inline editor to the diff-comment card so a saved note can be edited in place; the SourceControl sidebar pencil routes through a new `editingDiffCommentId` UI-slice slot that the matching card consumes.
- New `updateDiffComment` slice action with optimistic update + rollback, trim/no-op handling, and unit coverage in `diffComments.test.ts`.
- Decorator tracks `lastBody` and `lastPendingEdit` per zone so body and pending-edit transitions re-render in place without rebuilding zones; card stabilizes consumer callbacks via refs and acks each pending request exactly once so Cancel reliably closes the editor.

## Tested
- [x] Pencil click opens the inline editor with the existing note prefilled.
- [x] Entering edit mode triggers Monaco view-zone re-layout (zone grew 106 → 139 → 173 px as the textarea expanded).
- [x] Live textarea resize during typing — no nested view-zone batch errors.
- [x] Externally-changed comment re-renders in place with pencil + delete still wired (patch path keeps `onSubmitEdit`).
- [x] `updateDiffComment` slice contract: missing id → `false`, unchanged body → `true`, real edit → `true` and persists.
- [x] Save button enables on a real change; disables on revert / whitespace-only / all-whitespace. Enter on a valid edit submits.
- [x] `pnpm test src/renderer/src/store/slices/diffComments.test.ts` — 5/5 passing.
- [x] `pnpm typecheck` — clean.

Made with [Orca](https://github.com/stablyai/orca) 🐋