### PR TITLE
fix(mobile): silence no-control-regex on bracketed-paste sanitizer

### DIFF
--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -1013,6 +1013,7 @@ export default function SessionScreen() {
       // malicious copy containing `\x1b[201~` can't terminate paste mode early
       // and have the trailing bytes interpreted as shell commands. Matches
       // xterm.js / iTerm2 behavior.
+      // eslint-disable-next-line no-control-regex -- intentional bracketed-paste marker stripping
       const sanitized = wrap ? text.replace(/\x1b\[20[01]~/g, '') : text
       const payload = wrap ? `\x1b[200~${sanitized}\x1b[201~` : sanitized
       const wrappedBytes = new TextEncoder().encode(payload).byteLength


### PR DESCRIPTION
Follow-up to #1576.

The bracketed-paste sanitizer regex `/\x1b\[20[01]~/g` intentionally matches the `\x1b` control character — that's the whole point (stripping embedded `\x1b[200~` / `\x1b[201~` markers from clipboard text to prevent paste-mode injection). The `no-control-regex` lint warning was flagged on #1576's CI run.

### Change
Adds a single `// eslint-disable-next-line no-control-regex -- intentional bracketed-paste marker stripping` directive immediately above the regex line. Same convention used 25× elsewhere in this repo, including `mobile/scripts/repro-worktree-startup-stream.ts:147,149`.

### Regression analysis
- **Comment-only change** — +1/-0, no runtime semantics affected.
- **Directive scope** — `eslint-disable-next-line` only affects the immediately following line, so future legitimate violations on adjacent lines remain caught.
- **Tooling compatibility** — the repo's lint is `oxlint`, which accepts both `eslint-disable-*` and `oxlint-disable-*` forms; existing files in `mobile/` use this exact form.
- **Pre-commit hooks ran clean** (oxlint + oxfmt).