### PR TITLE
fix: add update recheck action

### DIFF
--- a/src/renderer/src/components/UpdateCard.tsx
+++ b/src/renderer/src/components/UpdateCard.tsx
@@ -324,12 +324,20 @@ export function UpdateCard() {
             : 'Could not check for updates.',
           message: status.message,
           releaseUrl: releaseUrlForVersion(cachedVersion),
+          // Why: check-time failures are often transient (offline, GitHub
+          // hiccup), so offer a Re-check next to "Download Manually" instead
+          // of forcing the user into the manual fallback.
           primaryAction: cachedVersion
             ? {
                 label: 'Retry Download',
                 onClick: handleUpdate
               }
-            : undefined
+            : {
+                label: 'Re-check',
+                onClick: () => {
+                  void window.api.updater.check({ includePrerelease: false })
+                }
+              }
         }
       : installError
         ? {


### PR DESCRIPTION
## Summary
- add a Re-check action for user-initiated update check failures when no update version is cached
- keep Retry Download behavior for failures tied to a known update version

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/UpdateCard.test.ts
- pnpm lint (passes with existing warnings outside this change)
- pnpm typecheck
- git diff --check 9f5306c96dcc7c8837bc0e8ba2f08f1aad4f5158

## Review
- independent review worker found no regressions and made no changes