### PR TITLE
Close node-pty macOS slave fd leak

### DIFF
--- a/config/patches/node-pty@1.1.0.patch
+++ b/config/patches/node-pty@1.1.0.patch
@@ -74,7 +74,7 @@ index 1ec12f79..cec8b67a 100644
  var DEFAULT_NAME = 'xterm';
  var DESTROY_SOCKET_TIMEOUT_MS = 200;
 diff --git a/src/unix/pty.cc b/src/unix/pty.cc
-index 7b4b9e1f..0544b86d 100644
+index 7b4b9e1f..9e6c7476 100644
 --- a/src/unix/pty.cc
 +++ b/src/unix/pty.cc
 @@ -23,7 +23,9 @@
@@ -245,7 +245,7 @@ index 7b4b9e1f..0544b86d 100644
        return;
      }
    }
-@@ -751,35 +828,41 @@ pty_posix_spawn(char** argv, char** env,
+@@ -751,35 +828,42 @@ pty_posix_spawn(char** argv, char** env,
 
    posix_spawnattr_t attrs;
    posix_spawnattr_init(&attrs);
@@ -289,6 +289,7 @@ index 7b4b9e1f..0544b86d 100644
  done:
    posix_spawn_file_actions_destroy(&acts);
    posix_spawnattr_destroy(&attrs);
++  close(slave);
 
 -  for (; count > 0; count--) {
 -    close(low_fds[count]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ patchedDependencies:
     hash: df21db050a4d85552cafbe583ece863d7fa19ed634a1219210a0455b986b6634
     path: config/patches/@xterm__addon-ligatures@0.11.0-beta.198.patch
   node-pty@1.1.0:
-    hash: de322b71e83f8e3f26a341144dbd1159a10d79d8a492e06d4bc9d10d7aa84bf4
+    hash: 6f428c4bd2f9a991b1af62f426af92862ba50860a729da63f49eddca08f0c1a3
     path: config/patches/node-pty@1.1.0.patch
 
 importers:
@@ -159,7 +159,7 @@ importers:
         version: 0.55.1
       node-pty:
         specifier: ^1.1.0
-        version: 1.1.0(patch_hash=de322b71e83f8e3f26a341144dbd1159a10d79d8a492e06d4bc9d10d7aa84bf4)
+        version: 1.1.0(patch_hash=6f428c4bd2f9a991b1af62f426af92862ba50860a729da63f49eddca08f0c1a3)
       pdfjs-dist:
         specifier: ^5.7.284
         version: 5.7.284
@@ -11368,7 +11368,7 @@ snapshots:
       undici: 6.25.0
       which: 6.0.1
 
-  node-pty@1.1.0(patch_hash=de322b71e83f8e3f26a341144dbd1159a10d79d8a492e06d4bc9d10d7aa84bf4):
+  node-pty@1.1.0(patch_hash=6f428c4bd2f9a991b1af62f426af92862ba50860a729da63f49eddca08f0c1a3):
     dependencies:
       node-addon-api: 7.1.1
 

--- a/src/main/daemon/node-pty-fd-leak.test.ts
+++ b/src/main/daemon/node-pty-fd-leak.test.ts
@@ -1,0 +1,42 @@
+import { execFileSync } from 'child_process'
+import { setTimeout as delay } from 'timers/promises'
+import * as pty from 'node-pty'
+import { describe, expect, it } from 'vitest'
+
+function currentRevokedFdCount(): number {
+  return execFileSync('lsof', ['-p', String(process.pid)], { encoding: 'utf8' })
+    .split('\n')
+    .filter((line) => line.includes('(revoked)')).length
+}
+
+async function spawnExitingPty(index: number): Promise<void> {
+  const proc = pty.spawn('/bin/sh', ['-c', 'exit 0'], {
+    name: 'xterm-256color',
+    cols: 80,
+    rows: 24,
+    cwd: process.cwd(),
+    env: { ...process.env, ORCA_FD_LEAK_TEST_INDEX: String(index) }
+  })
+
+  await new Promise<void>((resolve) => {
+    proc.onExit(() => resolve())
+  })
+  ;(proc as unknown as { destroy?: () => void }).destroy?.()
+}
+
+const describeOnDarwin = process.platform === 'darwin' ? describe : describe.skip
+
+describeOnDarwin('node-pty macOS spawn fd handling', () => {
+  it('does not leak revoked slave tty fds across exited pty spawns', async () => {
+    const before = currentRevokedFdCount()
+
+    for (let i = 0; i < 50; i++) {
+      await spawnExitingPty(i)
+    }
+
+    await delay(500)
+    const after = currentRevokedFdCount()
+
+    expect(after - before).toBe(0)
+  }, 15000)
+})


### PR DESCRIPTION
## Summary
- Add the follow-up node-pty patch change to close the parent-side macOS `slave` fd in `pty_posix_spawn` after `posix_spawn` setup finishes.
- Add a Darwin regression test that opens 50 short-lived PTYs and asserts the parent process does not accumulate revoked slave tty fds.

## Why
The diagnostic PR makes failures actionable first. This follow-up addresses one root cause: the Darwin spawn path leaves the parent copy of the slave tty open, so exited children can leave `(revoked)` fd entries behind until the daemon reaches the fd limit and future spawns fail.

## Upstream context
- microsoft/node-pty#907 tracks the Darwin spawn path leaking fds across repeated spawn/exit.
- microsoft/node-pty v1.2.0-beta.10 release notes mention #882, a related macOS `/dev/ptmx` leak fix. This local patch is still carried for Orca's pinned `node-pty@1.1.0`.

## Verification
- `pnpm install` (confirmed patched dependency hash updated and native rebuild completed)
- `pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/node-pty-fd-leak.test.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/node-pty-error-hints.test.ts src/main/daemon/client.test.ts src/main/daemon/node-pty-fd-leak.test.ts`
- `pnpm run tc:node`
- `pnpm exec oxlint src/main/daemon/node-pty-fd-leak.test.ts`
