### PR TITLE
feat(editor): register custom Monaco language for .astro files

### DIFF
--- a/src/renderer/src/lib/language-detect.test.ts
+++ b/src/renderer/src/lib/language-detect.test.ts
@@ -10,7 +10,7 @@ describe('detectLanguage', () => {
     expect(detectLanguage('src/components/Widget.svelte')).toBe('svelte')
   })
 
-  it('keeps .astro mapped to html until its grammar ships', () => {
-    expect(detectLanguage('src/routes/index.astro')).toBe('html')
+  it('maps .astro files to the custom astro language id', () => {
+    expect(detectLanguage('src/routes/index.astro')).toBe('astro')
   })
 })

--- a/src/renderer/src/lib/language-detect.ts
+++ b/src/renderer/src/lib/language-detect.ts
@@ -76,7 +76,7 @@ const EXT_TO_LANGUAGE: Record<string, string> = {
   '.clj': 'clojure',
   '.vue': 'vue',
   '.svelte': 'svelte',
-  '.astro': 'html',
+  '.astro': 'astro',
   '.tf': 'hcl',
   '.hcl': 'hcl',
   '.prisma': 'graphql',

--- a/src/renderer/src/lib/monaco-languages/register-astro.test.ts
+++ b/src/renderer/src/lib/monaco-languages/register-astro.test.ts
@@ -1,0 +1,267 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  astroLanguageConfiguration,
+  astroMonarchLanguage,
+  registerAstroLanguage
+} from './register-astro'
+
+type MonarchAction = {
+  next?: string
+  nextEmbedded?: string
+  switchTo?: string
+}
+type MonarchRule = [RegExp, string | MonarchAction, string?] | { include: string }
+
+function normalizeState(nextState: string): string {
+  return nextState.startsWith('@') ? nextState.slice(1) : nextState
+}
+
+function isRuleEntry(rule: MonarchRule): rule is [RegExp, string | MonarchAction, string?] {
+  return Array.isArray(rule)
+}
+
+function getRuleAction(rule: [RegExp, string | MonarchAction, string?]): MonarchAction | undefined {
+  const [, action, nextStateShortcut] = rule
+  return typeof action === 'object'
+    ? action
+    : nextStateShortcut
+      ? { next: nextStateShortcut }
+      : undefined
+}
+
+function findRuleAction(
+  state: string,
+  source: string,
+  { embedPopOnly = false }: { embedPopOnly?: boolean } = {}
+): MonarchAction | undefined {
+  const tokenizer = astroMonarchLanguage.tokenizer as Record<string, MonarchRule[]>
+  const stateRules = tokenizer[state] ?? tokenizer[state.split('.')[0]]
+  const candidateRules = embedPopOnly
+    ? stateRules.filter((rule) => {
+        if (!isRuleEntry(rule)) {
+          return false
+        }
+        return getRuleAction(rule)?.nextEmbedded === '@pop'
+      })
+    : stateRules
+  const matchedRule = candidateRules.find((rule) => {
+    if (!isRuleEntry(rule)) {
+      return false
+    }
+    const [regexp] = rule
+    regexp.lastIndex = 0
+    const match = regexp.exec(source)
+    return match !== null && match.index === 0
+  })
+
+  return matchedRule && isRuleEntry(matchedRule) ? getRuleAction(matchedRule) : undefined
+}
+
+function collectFixtureRuleActions(source: string): string[] {
+  const ruleActions: string[] = []
+  const tokenizer = astroMonarchLanguage.tokenizer as Record<string, MonarchRule[]>
+  const lines = source.split('\n')
+  const checks: { line: number; state: string; pattern: string }[] = [
+    { line: 1, state: 'root', pattern: '---' },
+    { line: 4, state: 'frontmatter', pattern: '---' },
+    // After the frontmatter closes we are back in `markupReenter`; the next
+    // non-structural character switches into `markup` with html active.
+    { line: 6, state: 'markupReenter', pattern: '' },
+    { line: 6, state: 'markup', pattern: '{' },
+    { line: 6, state: 'astroExpression', pattern: '}' },
+    { line: 8, state: 'markup', pattern: '<script' },
+    { line: 8, state: 'scriptOpen.javascript', pattern: '>' },
+    { line: 10, state: 'scriptBody.javascript', pattern: '</script>' },
+    { line: 12, state: 'markup', pattern: '<style' },
+    { line: 12, state: 'styleOpen.css', pattern: '>' },
+    { line: 14, state: 'styleBody.css', pattern: '</style>' }
+  ]
+
+  checks.forEach((check) => {
+    const line = lines.at(check.line - 1) ?? ''
+    const stateRules = tokenizer[check.state] ?? tokenizer[check.state.split('.')[0]]
+    const matchedRule = stateRules.find((rule) => {
+      if (!isRuleEntry(rule)) {
+        return false
+      }
+      const [regexp] = rule
+      regexp.lastIndex = 0
+      const match = regexp.exec(line)
+      return match !== null && match[0] === check.pattern
+    })
+    if (!matchedRule || !isRuleEntry(matchedRule)) {
+      return
+    }
+
+    const actionObject = getRuleAction(matchedRule)
+
+    const nextState = actionObject?.next ? normalizeState(actionObject.next) : '-'
+    const nextEmbedded = actionObject?.nextEmbedded ?? '-'
+    const switchTo = actionObject?.switchTo ? normalizeState(actionObject.switchTo) : '-'
+    ruleActions.push(
+      `${check.line}:${check.state}:${check.pattern || '<html>'} -> next=${nextState}, embedded=${nextEmbedded}, switch=${switchTo}`
+    )
+  })
+
+  return ruleActions
+}
+
+describe('registerAstroLanguage registration', () => {
+  it('registers the astro language, Monarch tokenizer, and configuration once', () => {
+    const languages: { id: string }[] = [{ id: 'typescript' }]
+    const register = vi.fn((entry: { id: string }) => {
+      languages.push({ id: entry.id })
+    })
+    const setMonarchTokensProvider = vi.fn()
+    const setLanguageConfiguration = vi.fn()
+    const getLanguages = vi.fn(() => languages)
+    const monacoMock = {
+      languages: {
+        register,
+        setMonarchTokensProvider,
+        setLanguageConfiguration,
+        getLanguages
+      }
+    }
+
+    registerAstroLanguage(monacoMock as never)
+    registerAstroLanguage(monacoMock as never)
+
+    expect(register).toHaveBeenCalledTimes(1)
+    expect(register).toHaveBeenCalledWith({
+      id: 'astro',
+      extensions: ['.astro'],
+      aliases: ['Astro']
+    })
+    expect(setMonarchTokensProvider).toHaveBeenCalledTimes(1)
+    expect(setMonarchTokensProvider).toHaveBeenCalledWith('astro', astroMonarchLanguage)
+    expect(setLanguageConfiguration).toHaveBeenCalledTimes(1)
+    expect(setLanguageConfiguration).toHaveBeenCalledWith('astro', astroLanguageConfiguration)
+  })
+})
+
+describe('astro tokenizer transitions', () => {
+  it('captures Astro tokenizer transitions for a representative component fixture', () => {
+    const fixture = `---
+import Layout from '../layouts/Layout.astro'
+const title = 'Home'
+---
+
+<h1>{title}</h1>
+
+<script>
+  console.log('hi')
+</script>
+
+<style lang="scss">
+  h1 { color: rebeccapurple; }
+</style>`
+
+    const ruleActions = collectFixtureRuleActions(fixture)
+
+    expect(ruleActions).toMatchInlineSnapshot(`
+      [
+        "1:root:--- -> next=-, embedded=typescript, switch=frontmatter",
+        "4:frontmatter:--- -> next=-, embedded=@pop, switch=markupReenter",
+        "6:markupReenter:<html> -> next=-, embedded=html, switch=markup",
+        "6:markup:{ -> next=-, embedded=@pop, switch=astroExpressionEnter",
+        "6:astroExpression:} -> next=-, embedded=@pop, switch=markupReenter",
+        "8:markup:<script -> next=-, embedded=@pop, switch=scriptOpen.javascript",
+        "8:scriptOpen.javascript:> -> next=-, embedded=$S2, switch=scriptBody.$S2",
+        "10:scriptBody.javascript:</script> -> next=-, embedded=@pop, switch=markupReenter",
+        "12:markup:<style -> next=-, embedded=@pop, switch=styleOpen.css",
+        "12:styleOpen.css:> -> next=-, embedded=$S2, switch=styleBody.$S2",
+        "14:styleBody.css:</style> -> next=-, embedded=@pop, switch=markupReenter",
+      ]
+    `)
+  })
+})
+
+describe('astro tokenizer regressions', () => {
+  // Regression: a file that opens with a markup expression like `{title}` has
+  // no html embed active yet. If `root` itself ever emitted `nextEmbedded:
+  // '@pop'` Monaco would throw "cannot pop embedded language if not inside
+  // one" before any push had occurred. Enforce the invariant directly.
+  it('never pops an embedded language from the root state', () => {
+    const tokenizer = astroMonarchLanguage.tokenizer as Record<string, MonarchRule[]>
+    const popRules = tokenizer.root.filter((rule) => {
+      if (!isRuleEntry(rule)) {
+        return false
+      }
+      return getRuleAction(rule)?.nextEmbedded === '@pop'
+    })
+    expect(popRules).toHaveLength(0)
+  })
+
+  // Regression (verified live in the Electron app): when entry from root went
+  // straight to `@markup` with `nextEmbedded: 'html'`, while the embed-pop
+  // path also went via `@markupReenter`, Monarch's nested tokenizer reported
+  // "cannot pop embedded language if not inside one" on `{expr}` in markup.
+  // Routing every push of the html embed through `markupReenter` keeps the
+  // embed-stack invariant identical for every entry into `markup`.
+  it('routes all entries into markup through markupReenter', () => {
+    expect(findRuleAction('root', '<h1>Hello</h1>')).toMatchObject({
+      switchTo: '@markupReenter'
+    })
+    expect(findRuleAction('root', '{title}')).toMatchObject({
+      switchTo: '@markupReenter'
+    })
+    expect(findRuleAction('markupReenter', '<h1>Hello</h1>')).toMatchObject({
+      switchTo: '@markup',
+      nextEmbedded: 'html'
+    })
+  })
+
+  // Regression: while the html embed is active, only parent rules whose action
+  // pops the embed are consulted before delegating to html. The `markup`
+  // state must wire `nextEmbedded: '@pop'` on the structural rules so a
+  // trailing `<script>` or `<style>` after page markup can switch language.
+  it('pops the html embed when later script/style/comment markers appear', () => {
+    expect(findRuleAction('markup', '<script>', { embedPopOnly: true })).toMatchObject({
+      switchTo: '@scriptOpen.javascript',
+      nextEmbedded: '@pop'
+    })
+    expect(findRuleAction('markup', '<style lang="scss">', { embedPopOnly: true })).toMatchObject({
+      switchTo: '@styleOpen.css',
+      nextEmbedded: '@pop'
+    })
+    expect(findRuleAction('markup', '<!-- comment -->', { embedPopOnly: true })).toMatchObject({
+      switchTo: '@comment',
+      nextEmbedded: '@pop'
+    })
+    expect(findRuleAction('markup', '{title}', { embedPopOnly: true })).toMatchObject({
+      switchTo: '@astroExpressionEnter',
+      nextEmbedded: '@pop'
+    })
+  })
+})
+
+describe('astro embedded language attributes', () => {
+  it('tracks embedded languages from Astro expressions and lang= attributes', () => {
+    expect(findRuleAction('astroExpressionEnter', 'title }')).toMatchObject({
+      nextEmbedded: 'typescript',
+      switchTo: '@astroExpression'
+    })
+    expect(findRuleAction('scriptLangValue.javascript', '"ts"')).toMatchObject({
+      switchTo: '@scriptOpen.typescript'
+    })
+    expect(findRuleAction('scriptLangValue.typescript', '"js"')).toMatchObject({
+      switchTo: '@scriptOpen.javascript'
+    })
+    expect(findRuleAction('scriptLangValue.javascript', 'ts')).toMatchObject({
+      switchTo: '@scriptOpen.typescript'
+    })
+    expect(findRuleAction('styleLangValue.css', '"scss"')).toMatchObject({
+      switchTo: '@styleOpen.scss'
+    })
+    expect(findRuleAction('styleLangValue.css', "'sass'")).toMatchObject({
+      switchTo: '@styleOpen.scss'
+    })
+    expect(findRuleAction('styleLangValue.css', 'less')).toMatchObject({
+      switchTo: '@styleOpen.less'
+    })
+    expect(findRuleAction('styleLangValue.scss', '"css"')).toMatchObject({
+      switchTo: '@styleOpen.css'
+    })
+  })
+})

--- a/src/renderer/src/lib/monaco-languages/register-astro.ts
+++ b/src/renderer/src/lib/monaco-languages/register-astro.ts
@@ -1,0 +1,189 @@
+import type * as Monaco from 'monaco-editor'
+
+type MonacoModule = typeof Monaco
+
+export const astroMonarchLanguage: Monaco.languages.IMonarchLanguage = {
+  defaultToken: '',
+  tokenPostfix: '.astro',
+  ignoreCase: true,
+  brackets: [
+    { open: '{', close: '}', token: 'delimiter.curly' },
+    { open: '[', close: ']', token: 'delimiter.square' },
+    { open: '(', close: ')', token: 'delimiter.parenthesis' },
+    { open: '<', close: '>', token: 'delimiter.angle' }
+  ],
+  tokenizer: {
+    // Entry state: fires once at file start with no embed on the stack.
+    // Modeled after the Svelte tokenizer — structural rules MUST NOT emit
+    // `nextEmbedded: '@pop'` from here. Only the frontmatter fence is
+    // recognised at file start; everything else (markup, `{expr}`,
+    // `<script>`/`<style>`) is handled after we've routed through
+    // `markupReenter` so the invariant "markup has html embed active" is
+    // satisfied by a single code path. Without this, an interpolation in
+    // the very first markup line popped the html embed before any push had
+    // occurred via this entry — Monaco rejects that with "cannot pop
+    // embedded language if not inside one".
+    root: [
+      // Astro frontmatter: `---` at file start opens a TypeScript fence
+      // closed by another `---` line. The opening line itself enters the
+      // typescript embed.
+      [/---\s*$/, { token: 'keyword', switchTo: '@frontmatter', nextEmbedded: 'typescript' }],
+      [/(?=.)/, { token: '@rematch', switchTo: '@markupReenter' }]
+    ],
+    // Inside the frontmatter fence the typescript embed is active; only a
+    // closing `---` on its own line pops it. Astro requires the closing
+    // fence at column 0.
+    frontmatter: [
+      [/^---\s*$/, { token: 'keyword', switchTo: '@markupReenter', nextEmbedded: '@pop' }]
+    ],
+    // html-embedded markup state. Mirrors Svelte's invariant: whenever we
+    // are in `markup`, the html embed is active. Every state that pops back
+    // to markup routes through `markupReenter` to push html again. Astro
+    // expressions are plain JS (no `{#if}`-style block syntax), so a single
+    // `{` rule handles all interpolations.
+    markup: [
+      [
+        /<script(?=\s|>)/,
+        { token: 'tag', switchTo: '@scriptOpen.javascript', nextEmbedded: '@pop' }
+      ],
+      [/<style(?=\s|>)/, { token: 'tag', switchTo: '@styleOpen.css', nextEmbedded: '@pop' }],
+      [/<!--/, { token: 'comment', switchTo: '@comment', nextEmbedded: '@pop' }],
+      [/\{/, { token: 'delimiter.curly', switchTo: '@astroExpressionEnter', nextEmbedded: '@pop' }]
+    ],
+    markupReenter: [[/(?=.)/, { token: '@rematch', switchTo: '@markup', nextEmbedded: 'html' }]],
+    comment: [
+      [/-->/, { token: 'comment', switchTo: '@markupReenter' }],
+      [/[^-]+/, 'comment'],
+      [/./, 'comment']
+    ],
+    // Once the typescript embed is active inside an expression, Monaco only
+    // consults parent rules whose action ends the embed. A brace counter
+    // therefore cannot run from inside the embed, so expressions with
+    // nested braces (e.g. `{items.map((x) => ({y: x}))}`) close at the
+    // first inner `}`. The common single-brace case `{title}` works.
+    astroExpressionEnter: [
+      // Empty `{}`: entry popped html, but typescript was never entered.
+      [/\}/, { token: 'delimiter.curly', switchTo: '@markupReenter' }],
+      [/(?=.)/, { token: '', switchTo: '@astroExpression', nextEmbedded: 'typescript' }]
+    ],
+    astroExpression: [
+      [/\}/, { token: 'delimiter.curly', switchTo: '@markupReenter', nextEmbedded: '@pop' }]
+    ],
+    scriptOpen: [
+      [/\/>/, { token: 'tag', switchTo: '@markupReenter' }],
+      [/>/, { token: 'tag', switchTo: '@scriptBody.$S2', nextEmbedded: '$S2' }],
+      [/lang(?=\s*=)/, { token: 'attribute.name', switchTo: '@scriptLangBeforeEquals.$S2' }],
+      { include: '@tagAttributes' }
+    ],
+    scriptLangBeforeEquals: [
+      [/=/, { token: 'delimiter', switchTo: '@scriptLangValue.$S2' }],
+      [/\s+/, 'white'],
+      [/(?=.)/, { token: '', switchTo: '@scriptOpen.$S2' }]
+    ],
+    scriptLangValue: [
+      [/"(?:js|javascript)"/, { token: 'attribute.value', switchTo: '@scriptOpen.javascript' }],
+      [/'(?:js|javascript)'/, { token: 'attribute.value', switchTo: '@scriptOpen.javascript' }],
+      [
+        /(?:js|javascript)(?=\s|\/|>|$)/,
+        { token: 'attribute.value', switchTo: '@scriptOpen.javascript' }
+      ],
+      [/"(?:ts|typescript)"/, { token: 'attribute.value', switchTo: '@scriptOpen.typescript' }],
+      [/'(?:ts|typescript)'/, { token: 'attribute.value', switchTo: '@scriptOpen.typescript' }],
+      [
+        /(?:ts|typescript)(?=\s|\/|>|$)/,
+        { token: 'attribute.value', switchTo: '@scriptOpen.typescript' }
+      ],
+      [/[^\s/>]+/, { token: 'attribute.value', switchTo: '@scriptOpen.$S2' }],
+      [/"[^"]*"/, { token: 'attribute.value', switchTo: '@scriptOpen.$S2' }],
+      [/'[^']*'/, { token: 'attribute.value', switchTo: '@scriptOpen.$S2' }],
+      [/\s+/, 'white']
+    ],
+    scriptBody: [
+      [/<\/script\s*>/, { token: 'tag', switchTo: '@markupReenter', nextEmbedded: '@pop' }]
+    ],
+    styleOpen: [
+      [/\/>/, { token: 'tag', switchTo: '@markupReenter' }],
+      [/>/, { token: 'tag', switchTo: '@styleBody.$S2', nextEmbedded: '$S2' }],
+      [/lang(?=\s*=)/, { token: 'attribute.name', switchTo: '@styleLangBeforeEquals.$S2' }],
+      { include: '@tagAttributes' }
+    ],
+    styleLangBeforeEquals: [
+      [/=/, { token: 'delimiter', switchTo: '@styleLangValue.$S2' }],
+      [/\s+/, 'white'],
+      [/(?=.)/, { token: '', switchTo: '@styleOpen.$S2' }]
+    ],
+    styleLangValue: [
+      [/"scss"/, { token: 'attribute.value', switchTo: '@styleOpen.scss' }],
+      [/'scss'/, { token: 'attribute.value', switchTo: '@styleOpen.scss' }],
+      [/scss(?=\s|\/|>|$)/, { token: 'attribute.value', switchTo: '@styleOpen.scss' }],
+      [/"sass"/, { token: 'attribute.value', switchTo: '@styleOpen.scss' }],
+      [/'sass'/, { token: 'attribute.value', switchTo: '@styleOpen.scss' }],
+      [/sass(?=\s|\/|>|$)/, { token: 'attribute.value', switchTo: '@styleOpen.scss' }],
+      [/"less"/, { token: 'attribute.value', switchTo: '@styleOpen.less' }],
+      [/'less'/, { token: 'attribute.value', switchTo: '@styleOpen.less' }],
+      [/less(?=\s|\/|>|$)/, { token: 'attribute.value', switchTo: '@styleOpen.less' }],
+      [/"css"/, { token: 'attribute.value', switchTo: '@styleOpen.css' }],
+      [/'css'/, { token: 'attribute.value', switchTo: '@styleOpen.css' }],
+      [/css(?=\s|\/|>|$)/, { token: 'attribute.value', switchTo: '@styleOpen.css' }],
+      [/[^\s/>]+/, { token: 'attribute.value', switchTo: '@styleOpen.$S2' }],
+      [/"[^"]*"/, { token: 'attribute.value', switchTo: '@styleOpen.$S2' }],
+      [/'[^']*'/, { token: 'attribute.value', switchTo: '@styleOpen.$S2' }],
+      [/\s+/, 'white']
+    ],
+    styleBody: [
+      [/<\/style\s*>/, { token: 'tag', switchTo: '@markupReenter', nextEmbedded: '@pop' }]
+    ],
+    tagAttributes: [
+      [/[^\s/>=]+/, 'attribute.name'],
+      [/=/, 'delimiter'],
+      [/"[^"]*"/, 'attribute.value'],
+      [/'[^']*'/, 'attribute.value'],
+      [/\s+/, 'white']
+    ]
+  }
+}
+
+export const astroLanguageConfiguration: Monaco.languages.LanguageConfiguration = {
+  comments: { blockComment: ['<!--', '-->'] },
+  brackets: [
+    ['{', '}'],
+    ['[', ']'],
+    ['(', ')'],
+    ['<', '>']
+  ],
+  autoClosingPairs: [
+    { open: '{', close: '}' },
+    { open: '[', close: ']' },
+    { open: '(', close: ')' },
+    { open: '"', close: '"' },
+    { open: "'", close: "'" },
+    { open: '`', close: '`' },
+    { open: '<', close: '>' }
+  ],
+  surroundingPairs: [
+    { open: '{', close: '}' },
+    { open: '[', close: ']' },
+    { open: '(', close: ')' },
+    { open: '"', close: '"' },
+    { open: "'", close: "'" },
+    { open: '`', close: '`' },
+    { open: '<', close: '>' }
+  ]
+}
+
+export function registerAstroLanguage(monaco: MonacoModule): void {
+  const astroAlreadyRegistered = monaco.languages
+    .getLanguages()
+    .some((language) => language.id === 'astro')
+  if (astroAlreadyRegistered) {
+    return
+  }
+
+  monaco.languages.register({
+    id: 'astro',
+    extensions: ['.astro'],
+    aliases: ['Astro']
+  })
+  monaco.languages.setMonarchTokensProvider('astro', astroMonarchLanguage)
+  monaco.languages.setLanguageConfiguration('astro', astroLanguageConfiguration)
+}

--- a/src/renderer/src/lib/monaco-setup.ts
+++ b/src/renderer/src/lib/monaco-setup.ts
@@ -7,6 +7,7 @@ import jsonWorker from 'monaco-editor/esm/vs/language/json/json.worker?worker'
 import cssWorker from 'monaco-editor/esm/vs/language/css/css.worker?worker'
 import htmlWorker from 'monaco-editor/esm/vs/language/html/html.worker?worker'
 import tsWorker from 'monaco-editor/esm/vs/language/typescript/ts.worker?worker'
+import { registerAstroLanguage } from './monaco-languages/register-astro'
 import { registerSvelteLanguage } from './monaco-languages/register-svelte'
 import { registerVueLanguage } from './monaco-languages/register-vue'
 
@@ -69,6 +70,7 @@ monacoTS.javascriptDefaults.setCompilerOptions({
 
 registerVueLanguage(monaco)
 registerSvelteLanguage(monaco)
+registerAstroLanguage(monaco)
 
 // Configure Monaco to use the locally bundled editor instead of CDN
 loader.config({ monaco })


### PR DESCRIPTION
## Summary
- Register a dedicated `astro` language id in Monaco with frontmatter, embedded `<script>`/`<style>`, and `{expr}` interpolation handling
- Map `.astro` files to the new language id (previously fell back to `html`)
- Add unit tests for the registration helper and the language-detect mapping

## Test plan
- [x] `pn typecheck`
- [x] Unit tests pass (`register-astro.test.ts`, `language-detect.test.ts`)
- [ ] Manually open a `.astro` file in the editor and confirm syntax highlighting for frontmatter, markup, and embedded script/style

Made with [Orca](https://github.com/stablyai/orca) 🐋
