### PR TITLE
feat(add-repo): auto-fill clone destination with workspace parent dir

### DIFF
--- a/src/main/ipc/repos.ts
+++ b/src/main/ipc/repos.ts
@@ -573,6 +573,10 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
       if (!repoName) {
         throw new Error('Could not determine repository name from URL')
       }
+      // Why: gitSpawn uses args.destination as cwd, so it must exist before
+      // spawn — fresh installs may have a defaulted parent dir that does not
+      // exist yet (e.g. ~/orca). recursive: true is a no-op when present.
+      await mkdir(args.destination, { recursive: true })
       const clonePath = join(args.destination, repoName)
 
       // Why: use spawn instead of execFile so there is no maxBuffer limit.

--- a/src/renderer/src/components/sidebar/AddRepoDialog.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoDialog.tsx
@@ -14,6 +14,7 @@ import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 import { RemoteStep, CloneStep, useRemoteRepo } from './AddRepoSteps'
 import { CreateStep, useCreateRepo } from './AddRepoCreateStep'
 import { SetupStep } from './AddRepoSetupStep'
+import { getDefaultCloneParent } from './clone-defaults'
 import { isGitRepoKind } from '../../../../shared/repo-kind'
 import type { Repo, Worktree } from '../../../../shared/types'
 
@@ -27,6 +28,7 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
   const openModal = useAppStore((s) => s.openModal)
   const openSettingsPage = useAppStore((s) => s.openSettingsPage)
   const openSettingsTarget = useAppStore((s) => s.openSettingsTarget)
+  const settings = useAppStore((s) => s.settings)
 
   const [step, setStep] = useState<'add' | 'clone' | 'remote' | 'create' | 'setup'>('add')
   const [addedRepo, setAddedRepo] = useState<Repo | null>(null)
@@ -41,6 +43,9 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
 
   // Why: monotonic ID so stale clone callbacks can detect they were superseded.
   const cloneGenRef = useRef(0)
+  // Why: track whether we've already auto-filled for this entry into the clone step,
+  // so a late settings hydration still gets a chance to set the default.
+  const cloneStepAutoFilledRef = useRef(false)
 
   const {
     sshTargets,
@@ -76,6 +81,24 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
     }
     return window.api.repos.onCloneProgress(setCloneProgress)
   }, [isCloning])
+
+  useEffect(() => {
+    if (step !== 'clone') {
+      cloneStepAutoFilledRef.current = false
+      return
+    }
+    if (cloneStepAutoFilledRef.current) {
+      return
+    }
+    if (cloneDestination) {
+      return
+    }
+    if (!settings?.workspaceDir) {
+      return
+    }
+    cloneStepAutoFilledRef.current = true
+    setCloneDestination(getDefaultCloneParent(settings.workspaceDir))
+  }, [step, cloneDestination, settings?.workspaceDir])
 
   const isOpen = activeModal === 'add-repo'
   const repoId = addedRepo?.id ?? ''

--- a/src/renderer/src/components/sidebar/AddRepoDialog.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoDialog.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- Why: the add-project dialog centralizes step routing, clone/remote/create state, and reset semantics across five steps so the modal flow stays in one place. */
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { FolderOpen, ArrowLeft, Globe, Monitor } from 'lucide-react'

--- a/src/renderer/src/components/sidebar/clone-defaults.test.ts
+++ b/src/renderer/src/components/sidebar/clone-defaults.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { getDefaultCloneParent } from './clone-defaults'
+
+describe('getDefaultCloneParent', () => {
+  it('strips a POSIX workspaces suffix', () => {
+    expect(getDefaultCloneParent('/Users/mvanhorn/orca/workspaces')).toBe('/Users/mvanhorn/orca')
+  })
+
+  it('strips a POSIX workspaces suffix with a trailing slash', () => {
+    expect(getDefaultCloneParent('/Users/mvanhorn/orca/workspaces/')).toBe('/Users/mvanhorn/orca')
+  })
+
+  it('strips a Windows workspaces suffix', () => {
+    expect(getDefaultCloneParent('C:\\Users\\mvanhorn\\orca\\workspaces')).toBe(
+      'C:\\Users\\mvanhorn\\orca'
+    )
+  })
+
+  it('leaves input without a workspaces suffix unchanged', () => {
+    expect(getDefaultCloneParent('/Users/mvanhorn/projects')).toBe('/Users/mvanhorn/projects')
+  })
+
+  it('returns empty input unchanged', () => {
+    expect(getDefaultCloneParent('')).toBe('')
+  })
+
+  it('returns an empty parent for workspaces alone', () => {
+    expect(getDefaultCloneParent('workspaces')).toBe('')
+  })
+
+  it('returns root for an absolute root workspaces path', () => {
+    expect(getDefaultCloneParent('/workspaces')).toBe('/')
+  })
+
+  it('returns the drive root for a Windows root workspaces path', () => {
+    expect(getDefaultCloneParent('C:\\workspaces')).toBe('C:\\')
+  })
+
+  it('strips repeated trailing separators before matching the suffix', () => {
+    expect(getDefaultCloneParent('D:\\orca\\workspaces\\\\')).toBe('D:\\orca')
+  })
+
+  it('does not strip a similar-looking final segment', () => {
+    expect(getDefaultCloneParent('/Users/mvanhorn/orca/project-workspaces')).toBe(
+      '/Users/mvanhorn/orca/project-workspaces'
+    )
+  })
+})

--- a/src/renderer/src/components/sidebar/clone-defaults.ts
+++ b/src/renderer/src/components/sidebar/clone-defaults.ts
@@ -1,0 +1,27 @@
+export function getDefaultCloneParent(workspaceDir: string): string {
+  if (!workspaceDir) {
+    return ''
+  }
+
+  const trimmed = workspaceDir.replace(/[\\/]+$/, '')
+  if (!trimmed) {
+    return workspaceDir
+  }
+
+  const separatorIndex = Math.max(trimmed.lastIndexOf('/'), trimmed.lastIndexOf('\\'))
+  const lastSegment = separatorIndex === -1 ? trimmed : trimmed.slice(separatorIndex + 1)
+
+  if (lastSegment !== 'workspaces') {
+    return workspaceDir
+  }
+
+  // Why: default Orca worktrees live under "workspaces"; clones should sit beside that tree.
+  const parent = separatorIndex === -1 ? '' : trimmed.slice(0, separatorIndex)
+  if (parent === '' && trimmed.startsWith('/')) {
+    return '/'
+  }
+  if (/^[A-Za-z]:$/.test(parent)) {
+    return `${parent}${trimmed[separatorIndex]}`
+  }
+  return parent
+}


### PR DESCRIPTION
## Summary

Pre-fills the Clone location field in the Clone from URL dialog with the parent of `settings.workspaceDir`, so a user who pastes a Git URL can click Clone immediately. Today the field is required and empty, so the Clone button stays disabled until the user picks or types a folder, even when they have no preference about where the clone lands.

The default for users with the shipped `workspaceDir` (`~/orca/workspaces`) is `~/orca`, which keeps source clones beside the worktrees rather than inside them. Users who set a custom `workspaceDir` get the parent of that path; users with `workspaceDir` not ending in `workspaces` get their `workspaceDir` value unchanged. The field stays editable, so anyone with a different convention can override it before clicking Clone.

Closes #1592

## Screenshots

Simulated demo of the change: BEFORE shows the dialog with an empty Clone Location placeholder and a dim Clone button; AFTER shows `/Users/mvanhorn/orca` typed into the field and the Clone button activated.

![Simulated Demo](https://files.catbox.moe/bjrh6v.gif)

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added unit tests for the new `getDefaultCloneParent` helper covering POSIX/Windows separators, trailing-separator normalization, root cases, empty input, and similar-looking suffixes (`project-workspaces` is not stripped). Existing `src/main/ipc/repos.ts` tests still pass.

## AI Review Report

The change was reviewed by an AI agent against this checklist: cross-platform path correctness (POSIX `/` and Windows `\`), React effect re-fire and boot-race patterns, dead code and unused imports, and IPC scope creep.

The first review pass surfaced a startup race in `AddRepoDialog.tsx`: an earlier `previousStepRef` pattern recorded the clone-step entry before settings hydrated, so a late settings load never got a chance to fill the destination. The fix replaces it with a `cloneStepAutoFilledRef` that is reset whenever the step leaves `'clone'`, so re-entry (or late settings hydration) re-derives the default.

A second pass surfaced a regression on fresh installs: the auto-filled parent (`~/orca`) does not exist until Orca creates a worktree, and `repos:clone` uses `args.destination` as the spawn cwd, which would ENOENT before git could run. Fixed in `src/main/ipc/repos.ts` with `await mkdir(args.destination, { recursive: true })` before spawn. This also makes a typed-but-not-yet-existing destination work via the picker flow.

## Security Audit

No new IPC surface, no new input handling, no new path resolution beyond reading an existing setting. The auto-filled value is purely a UI default; the existing main-process clone handler is unchanged in how it validates and uses the path. The new `mkdir(args.destination, { recursive: true })` accepts the same `args.destination` value the previous code already used as the spawn cwd, so the trust boundary is unchanged. No secrets, no user-input shell interpolation.

## Notes

- Default-derivation works on macOS, Linux, and Windows: `getDefaultCloneParent` checks both `/workspaces` and `\workspaces` suffixes and trims trailing separators. Tested in vitest.
- Resetting on dialog close is unchanged. Reopening re-derives the default, so user edits do not stick across dialog sessions.
- Field stays editable. The folder picker is untouched.
