### PR TITLE
fix: scroll long SSH target list in Add Repo dialog

### DIFF
--- a/src/renderer/src/components/sidebar/AddRepoSteps.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoSteps.tsx
@@ -240,7 +240,7 @@ export function RemoteStep({
               </Button>
             </div>
           ) : (
-            <div className="space-y-1.5">
+            <div className="space-y-1.5 max-h-64 overflow-y-auto pr-1">
               {sshTargets.map((target) => (
                 <SshTargetRow
                   key={target.id}


### PR DESCRIPTION
## Summary
- Cap the SSH target list height (`max-h-64`) with overflow scroll so long lists don't push the dialog off-screen.

## Test plan
- [ ] Open the Add Repo dialog with many SSH targets configured; verify the list scrolls within the dialog.
- [ ] Verify behavior with 0 and 1-2 targets is unchanged.

Made with [Orca](https://github.com/stablyai/orca) 🐋
