### PR TITLE
Link issue metadata before workspace launch

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -147,6 +147,17 @@ const WorktreeCard = React.memo(function WorktreeCard({
       ? issueEntry.data
       : undefined
     : null
+  const issueDisplay =
+    issue ??
+    (worktree.linkedIssue
+      ? {
+          number: worktree.linkedIssue,
+          // Why: linked metadata is persisted immediately, but GitHub details
+          // arrive asynchronously. Show the durable link number instead of
+          // making the worktree look unlinked while the cache warms.
+          title: issue === null ? 'Issue details unavailable' : 'Loading issue...'
+        }
+      : null)
 
   const isDeleting = deleteState?.isDeleting ?? false
 
@@ -554,12 +565,12 @@ const WorktreeCard = React.memo(function WorktreeCard({
         {/* Meta section: Issue / PR Links / Comment
              Layout coupling: spacing here is used to derive size estimates in
              WorktreeList's estimateSize. Update that function if changing spacing. */}
-        {((cardProps.includes('issue') && issue) ||
+        {((cardProps.includes('issue') && issueDisplay) ||
           (cardProps.includes('pr') && pr) ||
           (cardProps.includes('comment') && worktree.comment)) && (
           <div className="flex flex-col gap-[3px] mt-0.5">
-            {cardProps.includes('issue') && issue && (
-              <IssueSection issue={issue} onClick={handleEditIssue} />
+            {cardProps.includes('issue') && issueDisplay && (
+              <IssueSection issue={issueDisplay} onClick={handleEditIssue} />
             )}
             {cardProps.includes('pr') && pr && <PrSection pr={pr} onClick={handleEditIssue} />}
             {cardProps.includes('comment') && worktree.comment && (

--- a/src/renderer/src/components/sidebar/WorktreeCardMeta.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardMeta.tsx
@@ -16,11 +16,20 @@ import type { PRInfo, IssueInfo } from '../../../../shared/types'
 // ── Issue section ────────────────────────────────────────────────────
 
 type IssueSectionProps = {
-  issue: IssueInfo
+  issue:
+    | IssueInfo
+    | {
+        number: number
+        title: string
+        state?: IssueInfo['state']
+        url?: string
+        labels?: string[]
+      }
   onClick: (e: React.MouseEvent) => void
 }
 
 export function IssueSection({ issue, onClick }: IssueSectionProps): React.JSX.Element {
+  const labels = issue.labels ?? []
   return (
     <HoverCard openDelay={300}>
       <HoverCardTrigger asChild>
@@ -41,26 +50,30 @@ export function IssueSection({ issue, onClick }: IssueSectionProps): React.JSX.E
         <div className="font-semibold text-[13px]">
           #{issue.number} {issue.title}
         </div>
-        <div className="text-muted-foreground">
-          State: {issue.state === 'open' ? 'Open' : 'Closed'}
-        </div>
-        {issue.labels.length > 0 && (
+        {issue.state && (
+          <div className="text-muted-foreground">
+            State: {issue.state === 'open' ? 'Open' : 'Closed'}
+          </div>
+        )}
+        {labels.length > 0 && (
           <div className="flex flex-wrap gap-1">
-            {issue.labels.map((l) => (
+            {labels.map((l) => (
               <Badge key={l} variant="outline" className="h-4 px-1.5 text-[9px]">
                 {l}
               </Badge>
             ))}
           </div>
         )}
-        <a
-          href={issue.url}
-          target="_blank"
-          rel="noreferrer"
-          className="text-muted-foreground underline underline-offset-2 hover:text-foreground"
-        >
-          View on GitHub
-        </a>
+        {issue.url && (
+          <a
+            href={issue.url}
+            target="_blank"
+            rel="noreferrer"
+            className="text-muted-foreground underline underline-offset-2 hover:text-foreground"
+          >
+            View on GitHub
+          </a>
+        )}
       </HoverCardContent>
     </HoverCard>
   )

--- a/src/renderer/src/lib/launch-work-item-direct.ts
+++ b/src/renderer/src/lib/launch-work-item-direct.ts
@@ -223,6 +223,25 @@ export async function launchWorkItemDirect(args: LaunchWorkItemDirectArgs): Prom
     )
     worktreeId = result.worktree.id
     const worktreePath = result.worktree.path
+    const meta: {
+      linkedIssue?: number
+      linkedPR?: number
+      linkedLinearIssue?: string
+    } = {}
+    if (item.type === 'issue' && item.number) {
+      meta.linkedIssue = item.number
+    } else if (item.type === 'pr' && item.number) {
+      meta.linkedPR = item.number
+    }
+    if (item.linearIdentifier) {
+      meta.linkedLinearIssue = item.linearIdentifier
+    }
+    if (Object.keys(meta).length > 0) {
+      // Why: the Project direct-launch path activates the new workspace
+      // immediately. Persist the link first so the first sidebar render can
+      // show the issue/PR association instead of briefly looking unlinked.
+      await store.updateWorktreeMeta(worktreeId, meta)
+    }
 
     const detectedIds = new Set(await detectedAgentsPromise)
     effectiveAgent = pickAgent(settings?.defaultTuiAgent, detectedIds)
@@ -299,25 +318,6 @@ export async function launchWorkItemDirect(args: LaunchWorkItemDirectArgs): Prom
     const message = error instanceof Error ? error.message : 'Failed to create workspace.'
     toast.error(message)
     return
-  }
-
-  const meta: {
-    linkedIssue?: number
-    linkedPR?: number
-    linkedLinearIssue?: string
-  } = {}
-  if (item.type === 'issue' && item.number) {
-    meta.linkedIssue = item.number
-  } else if (item.type === 'pr' && item.number) {
-    meta.linkedPR = item.number
-  }
-  if (item.linearIdentifier) {
-    meta.linkedLinearIssue = item.linearIdentifier
-  }
-  if (Object.keys(meta).length > 0) {
-    void store.updateWorktreeMeta(worktreeId, meta).catch(() => {
-      // Meta update is non-critical for the draft flow — continue.
-    })
   }
 
   store.setSidebarOpen(true)


### PR DESCRIPTION
## Summary
- persist issue, PR, and Linear metadata immediately after direct workspace creation
- show persisted linked issue numbers while GitHub issue details are still loading or unavailable
- allow issue hover metadata to render gracefully without full GitHub details

## Tests
- pnpm typecheck