### PR TITLE
feat(worktree): optimistic create with reconciled base status

### DIFF
--- a/src/main/ipc/worktree-logic.ts
+++ b/src/main/ipc/worktree-logic.ts
@@ -180,6 +180,7 @@ export function mergeWorktree(
           sparsePresetId: meta?.sparsePresetId
         }
       : {}),
+    ...(meta?.baseRef !== undefined ? { baseRef: meta.baseRef } : {}),
     // Why: diff comments are persisted on WorktreeMeta (see `WorktreeMeta` in
     // shared/types) and forwarded verbatim so the renderer store mirrors
     // on-disk state. `undefined` here means the worktree has no comments yet.

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -22,6 +22,7 @@ import { listWorktrees, addWorktree, addSparseWorktree } from '../git/worktree'
 import { getGitUsername, getDefaultBaseRef, getBranchConflictKind } from '../git/repo'
 import { gitExecFileAsync } from '../git/runner'
 import type { OrcaRuntimeService } from '../runtime/orca-runtime'
+import type { RemoteFetchResult, RemoteTrackingBase } from '../runtime/orca-runtime'
 import { isWslPath, parseWslPath, getWslHome } from '../wsl'
 import { createSetupRunnerScript, getEffectiveHooks, shouldRunSetupForCreate } from '../hooks'
 import { getSshGitProvider } from '../providers/ssh-git-dispatch'
@@ -39,6 +40,13 @@ import {
 import { invalidateAuthorizedRootsCache } from './filesystem-auth'
 import { createWorktreeSymlinks } from './worktree-symlinks'
 import { normalizeSparseDirectories } from './sparse-checkout-directories'
+
+async function readCommitSha(repoPath: string, ref: string): Promise<string> {
+  const { stdout } = await gitExecFileAsync(['rev-parse', '--verify', `${ref}^{commit}`], {
+    cwd: repoPath
+  })
+  return stdout.trim()
+}
 
 export function notifyWorktreesChanged(mainWindow: BrowserWindow, repoId: string): void {
   if (!mainWindow.isDestroyed()) {
@@ -260,30 +268,35 @@ export async function createLocalWorktree(
     )
   }
 
-  // Why (§3.3 Lifecycle): fire fetch via the shared 30s-window cache on the
-  // runtime so repeat creates on the same repo reuse the in-flight promise
-  // and dispatch probes benefit from the freshness window. Kicked off BEFORE
-  // the suffix loop / PR probe / path resolution so those operations overlap
-  // the network round-trip — the `await` right before `addWorktree` is the
-  // only point that actually requires fetch completion.
-  //
-  // Why `runtime` is optional: a handful of legacy IPC test harnesses still
-  // call createLocalWorktree without the runtime. In that case we fall back
-  // to the old fire-and-forget behavior (which those tests already expect).
-  // Production `worktrees.ts` always passes runtime, so the happy path
-  // always gets the cache.
-  const remote = baseBranch.includes('/') ? baseBranch.split('/')[0] : 'origin'
-  const fetchPromise: Promise<void> = runtime
-    ? runtime.fetchRemoteWithCache(repo.path, remote)
-    : gitExecFileAsync(['fetch', remote], { cwd: repo.path })
-        .then(() => undefined)
-        .catch(() => undefined)
+  let optimisticBase: RemoteTrackingBase | null = null
+  let optimisticFetchPromise: Promise<RemoteFetchResult> | null = null
+  let initialBaseStatus: CreateWorktreeResult['initialBaseStatus']
+  let legacyFetchPromise: Promise<void> | null = null
 
-  // Why: emit a progress event so the renderer dialog can switch its spinner
-  // label to "Checking for updates..." while the fetch is in flight, then
-  // "Creating worktree..." after we await it. Renderer falls back to the
-  // static "Creating worktree..." label if no event arrives.
-  emitCreateWorktreeProgress(mainWindow, 'fetching')
+  if (runtime) {
+    optimisticBase = await runtime.resolveRemoteTrackingBase(repo.path, baseBranch)
+    if (optimisticBase) {
+      const hasLocalBaseRef = await runtime.hasRemoteTrackingRef(repo.path, optimisticBase)
+      if (hasLocalBaseRef) {
+        const isFresh = await runtime.isRemoteFetchFresh(repo.path, optimisticBase.remote)
+        if (!isFresh) {
+          optimisticFetchPromise = runtime.getOrStartRemoteFetch(repo.path, optimisticBase.remote)
+        }
+      } else {
+        emitCreateWorktreeProgress(mainWindow, 'fetching')
+        await runtime.fetchRemoteWithCache(repo.path, optimisticBase.remote)
+        if (!(await runtime.hasRemoteTrackingRef(repo.path, optimisticBase))) {
+          throw new Error(`Base ref "${baseBranch}" was not found after fetching.`)
+        }
+      }
+    }
+  } else {
+    const remote = baseBranch.includes('/') ? baseBranch.split('/')[0] : 'origin'
+    legacyFetchPromise = gitExecFileAsync(['fetch', remote], { cwd: repo.path })
+      .then(() => undefined)
+      .catch(() => undefined)
+    emitCreateWorktreeProgress(mainWindow, 'fetching')
+  }
   // Why: WSL worktrees live under ~/orca/workspaces inside the WSL
   // filesystem. Validate against that root, not the Windows workspace dir.
   // If WSL home lookup fails, keep using the configured workspace root so
@@ -406,15 +419,9 @@ export async function createLocalWorktree(
     }
   }
 
-  // Why (§3.3): gate on the fetch we fired at the top of this function.
-  // Pre-create probes (branch-conflict, PR probe, path resolution, sparse
-  // prep) already ran concurrently with the fetch; in the warm case this
-  // await is a no-op. In the cold case the spinner has already shown
-  // "Checking for updates..." so the user sees the wait is legible.
-  //
-  // `fetchRemoteWithCache` never rejects (log-and-proceed on offline
-  // failure), so the bare `await` does not need a try/catch here.
-  await fetchPromise
+  if (legacyFetchPromise) {
+    await legacyFetchPromise
+  }
   emitCreateWorktreeProgress(mainWindow, 'creating')
 
   await (sparseDirectories.length > 0
@@ -451,6 +458,7 @@ export async function createLocalWorktree(
     // See createRemoteWorktree above: createdAt protects the newly-created
     // worktree from ambient PTY bumps in other worktrees for CREATE_GRACE_MS.
     createdAt: now,
+    baseRef: baseBranch,
     ...(shouldSetDisplayName(effectiveRequestedName, branchName, effectiveSanitizedName)
       ? { displayName: effectiveRequestedName }
       : {}),
@@ -520,9 +528,48 @@ export async function createLocalWorktree(
     }
   }
 
+  if (runtime && optimisticBase && optimisticFetchPromise) {
+    initialBaseStatus = {
+      repoId: repo.id,
+      worktreeId,
+      status: 'checking',
+      base: optimisticBase.base,
+      remote: optimisticBase.remote
+    }
+    runtime.emitWorktreeBaseStatus(initialBaseStatus)
+    try {
+      const createdBaseSha = await readCommitSha(created.path, 'HEAD')
+      const token = runtime.recordOptimisticReconcileToken(worktreeId)
+      void runtime
+        .reconcileWorktreeBaseStatus({
+          repoId: repo.id,
+          repoPath: repo.path,
+          worktreeId,
+          base: optimisticBase,
+          branchName,
+          createdBaseSha,
+          token,
+          fetchPromise: optimisticFetchPromise
+        })
+        .catch((error) => {
+          console.warn(`[worktree-base-status] reconcile failed for ${worktreeId}:`, error)
+        })
+    } catch (error) {
+      console.warn(`[worktree-base-status] failed to read created base for ${worktreeId}:`, error)
+      runtime.emitWorktreeBaseStatus({
+        repoId: repo.id,
+        worktreeId,
+        status: 'unknown',
+        base: optimisticBase.base,
+        remote: optimisticBase.remote
+      })
+    }
+  }
+
   notifyWorktreesChanged(mainWindow, repo.id)
   return {
     worktree,
-    ...(setup ? { setup } : {})
+    ...(setup ? { setup } : {}),
+    ...(initialBaseStatus ? { initialBaseStatus } : {})
   }
 }

--- a/src/main/ipc/worktrees-windows.test.ts
+++ b/src/main/ipc/worktrees-windows.test.ts
@@ -184,9 +184,15 @@ describe('registerWorktreeHandlers – Windows path handling', () => {
     // Why: createLocalWorktree routes `git fetch` through
     // `runtime.fetchRemoteWithCache` (§3.3 Lifecycle). Stub it for path tests.
     const runtimeStub = {
-      fetchRemoteWithCache: async () => {
-        /* noop */
-      }
+      resolveRemoteTrackingBase: vi.fn().mockResolvedValue(null),
+      hasRemoteTrackingRef: vi.fn().mockResolvedValue(false),
+      isRemoteFetchFresh: vi.fn().mockResolvedValue(false),
+      getOrStartRemoteFetch: vi.fn().mockResolvedValue({ ok: true }),
+      fetchRemoteWithCache: vi.fn().mockResolvedValue(undefined),
+      emitWorktreeBaseStatus: vi.fn(),
+      recordOptimisticReconcileToken: vi.fn().mockReturnValue('token-1'),
+      reconcileWorktreeBaseStatus: vi.fn(),
+      clearOptimisticReconcileToken: vi.fn()
     }
     registerWorktreeHandlers(mainWindow as never, store as never, runtimeStub as never)
   })

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -135,6 +135,17 @@ describe('registerWorktreeHandlers', () => {
     setWorktreeMeta: vi.fn(),
     removeWorktreeMeta: vi.fn()
   }
+  let runtimeStub: {
+    resolveRemoteTrackingBase: ReturnType<typeof vi.fn>
+    hasRemoteTrackingRef: ReturnType<typeof vi.fn>
+    isRemoteFetchFresh: ReturnType<typeof vi.fn>
+    getOrStartRemoteFetch: ReturnType<typeof vi.fn>
+    fetchRemoteWithCache: ReturnType<typeof vi.fn>
+    emitWorktreeBaseStatus: ReturnType<typeof vi.fn>
+    recordOptimisticReconcileToken: ReturnType<typeof vi.fn>
+    reconcileWorktreeBaseStatus: ReturnType<typeof vi.fn>
+    clearOptimisticReconcileToken: ReturnType<typeof vi.fn>
+  }
 
   beforeEach(() => {
     for (const m of [
@@ -208,9 +219,9 @@ describe('registerWorktreeHandlers', () => {
     getDefaultBaseRefMock.mockReturnValue('origin/main')
     getBranchConflictKindMock.mockResolvedValue(null)
     getPRForBranchMock.mockResolvedValue(null)
-    // Why: createLocalWorktree now fires `git fetch` in the background via
-    // gitExecFileAsync. The default mock must return a resolved promise so
-    // the fire-and-forget `.catch()` chain doesn't trip on undefined.
+    // Why: createLocalWorktree can still hit legacy git fetch fallback in
+    // narrow unit harnesses. Return a resolved promise so catch/then chains
+    // don't trip on undefined.
     gitExecFileAsyncMock.mockResolvedValue({ stdout: '', stderr: '' })
     getEffectiveHooksMock.mockReturnValue(null)
     shouldRunSetupForCreateMock.mockReturnValue(false)
@@ -252,10 +263,16 @@ describe('registerWorktreeHandlers', () => {
     // `runtime.fetchRemoteWithCache` (§3.3 Lifecycle). A minimal stub
     // keeps these tests focused on create-flow semantics; the full
     // cache behavior is covered by fetch-remote-cache.test.ts.
-    const runtimeStub = {
-      fetchRemoteWithCache: async () => {
-        /* noop — fetch mocked at gitExecFileAsync level via gitExecFileAsyncMock */
-      }
+    runtimeStub = {
+      resolveRemoteTrackingBase: vi.fn().mockResolvedValue(null),
+      hasRemoteTrackingRef: vi.fn().mockResolvedValue(false),
+      isRemoteFetchFresh: vi.fn().mockResolvedValue(false),
+      getOrStartRemoteFetch: vi.fn().mockResolvedValue({ ok: true }),
+      fetchRemoteWithCache: vi.fn().mockResolvedValue(undefined),
+      emitWorktreeBaseStatus: vi.fn(),
+      recordOptimisticReconcileToken: vi.fn().mockReturnValue('token-1'),
+      reconcileWorktreeBaseStatus: vi.fn(),
+      clearOptimisticReconcileToken: vi.fn()
     }
     registerWorktreeHandlers(mainWindow as never, store as never, runtimeStub as never)
   })
@@ -294,6 +311,65 @@ describe('registerWorktreeHandlers', () => {
         branch: 'improve-dashboard-2'
       })
     })
+  })
+
+  it('does not await a cold fetch when the remote-tracking base exists locally', async () => {
+    const remoteBase = {
+      remote: 'origin',
+      branch: 'main',
+      ref: 'refs/remotes/origin/main',
+      base: 'origin/main'
+    }
+    let resolveFetch!: () => void
+    const pendingFetch = new Promise<{ ok: true }>((resolve) => {
+      resolveFetch = () => resolve({ ok: true })
+    })
+    runtimeStub.resolveRemoteTrackingBase.mockResolvedValue(remoteBase)
+    runtimeStub.hasRemoteTrackingRef.mockResolvedValue(true)
+    runtimeStub.getOrStartRemoteFetch.mockReturnValue(pendingFetch)
+    listWorktreesMock.mockResolvedValue([
+      {
+        path: '/workspace/improve-dashboard',
+        head: 'created-sha',
+        branch: 'improve-dashboard',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+    gitExecFileAsyncMock.mockResolvedValue({ stdout: 'created-sha\n', stderr: '' })
+
+    const createPromise = handlers['worktrees:create'](null, {
+      repoId: 'repo-1',
+      name: 'improve-dashboard'
+    }) as Promise<unknown>
+
+    const result = await Promise.race([
+      createPromise,
+      new Promise((resolve) => setTimeout(() => resolve('timed-out'), 0))
+    ])
+    expect(result).not.toBe('timed-out')
+
+    expect(runtimeStub.getOrStartRemoteFetch).toHaveBeenCalledWith('/workspace/repo', 'origin')
+    expect(runtimeStub.fetchRemoteWithCache).not.toHaveBeenCalled()
+    expect(runtimeStub.emitWorktreeBaseStatus).toHaveBeenCalledWith({
+      repoId: 'repo-1',
+      worktreeId: 'repo-1::/workspace/improve-dashboard',
+      status: 'checking',
+      base: 'origin/main',
+      remote: 'origin'
+    })
+    expect(runtimeStub.reconcileWorktreeBaseStatus).toHaveBeenCalledWith(
+      expect.objectContaining({
+        createdBaseSha: 'created-sha',
+        fetchPromise: pendingFetch
+      })
+    )
+    expect(result).toEqual(
+      expect.objectContaining({
+        initialBaseStatus: expect.objectContaining({ status: 'checking', base: 'origin/main' })
+      })
+    )
+    resolveFetch()
   })
 
   it('throws a clear error when no default base ref can be resolved', async () => {

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -418,6 +418,7 @@ export function registerWorktreeHandlers(
           throw new Error(`No git provider for connection "${repo.connectionId}"`)
         }
         await provider.removeWorktree(worktreePath, args.force)
+        runtime.clearOptimisticReconcileToken(args.worktreeId)
         store.removeWorktreeMeta(args.worktreeId)
         deleteWorktreeHistoryDir(args.worktreeId)
         notifyWorktreesChanged(mainWindow, repoId)
@@ -454,6 +455,7 @@ export function registerWorktreeHandlers(
           // list` continues to show the stale entry and the branch it had checked out
           // remains locked — other worktrees cannot check it out.
           await gitExecFileAsync(['worktree', 'prune'], { cwd: repo.path }).catch(() => {})
+          runtime.clearOptimisticReconcileToken(args.worktreeId)
           store.removeWorktreeMeta(args.worktreeId)
           deleteWorktreeHistoryDir(args.worktreeId)
           invalidateAuthorizedRootsCache()
@@ -462,6 +464,7 @@ export function registerWorktreeHandlers(
         }
         throw new Error(formatWorktreeRemovalError(error, worktreePath, args.force ?? false))
       }
+      runtime.clearOptimisticReconcileToken(args.worktreeId)
       store.removeWorktreeMeta(args.worktreeId)
       deleteWorktreeHistoryDir(args.worktreeId)
       invalidateAuthorizedRootsCache()

--- a/src/main/runtime/fetch-remote-cache.test.ts
+++ b/src/main/runtime/fetch-remote-cache.test.ts
@@ -22,6 +22,23 @@ vi.mock('../git/runner', async (importOriginal) => {
 // normally — none of them trigger IO until a runtime method is called.
 import { OrcaRuntimeService } from './orca-runtime'
 
+function fetchCallCount(): number {
+  return gitExecFileAsyncMock.mock.calls.filter(
+    ([argv]) => Array.isArray(argv) && argv[0] === 'fetch'
+  ).length
+}
+
+function mockFetchResults(results: (Promise<unknown> | unknown)[]): void {
+  let fetchIndex = 0
+  gitExecFileAsyncMock.mockImplementation((argv: string[]) => {
+    if (argv[0] === 'rev-parse') {
+      return Promise.reject(new Error('not a repo in cache-key test'))
+    }
+    const result = results[fetchIndex++]
+    return result instanceof Promise ? result : Promise.resolve(result)
+  })
+}
+
 describe('OrcaRuntimeService.fetchRemoteWithCache', () => {
   beforeEach(() => {
     gitExecFileAsyncMock.mockReset()
@@ -36,25 +53,21 @@ describe('OrcaRuntimeService.fetchRemoteWithCache', () => {
     // `.finally()` eviction, the second caller would await the rejected
     // promise forever (or throw the same error) — the regression pattern
     // described in §3.3.
-    gitExecFileAsyncMock
-      .mockRejectedValueOnce(new Error('network down'))
-      .mockResolvedValueOnce({ stdout: '', stderr: '' })
+    mockFetchResults([Promise.reject(new Error('network down')), { stdout: '', stderr: '' }])
 
     const runtime = new OrcaRuntimeService(null)
 
     await runtime.fetchRemoteWithCache('/repo/a', 'origin')
     await runtime.fetchRemoteWithCache('/repo/a', 'origin')
 
-    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(2)
+    expect(fetchCallCount()).toBe(2)
   })
 
   it('does not advance the freshness timestamp when the fetch rejects', async () => {
     // A rejected fetch that wrote the timestamp would make the 30s freshness
     // cache "lie" — the next caller would skip the fetch on a repo whose
     // last real sync is unknown. §3.3 mandates success-only writes.
-    gitExecFileAsyncMock
-      .mockRejectedValueOnce(new Error('boom'))
-      .mockResolvedValueOnce({ stdout: '', stderr: '' })
+    mockFetchResults([Promise.reject(new Error('boom')), { stdout: '', stderr: '' }])
 
     const runtime = new OrcaRuntimeService(null)
 
@@ -63,7 +76,7 @@ describe('OrcaRuntimeService.fetchRemoteWithCache', () => {
     // short-circuit and skip the fetch. It must still dispatch a real fetch.
     await runtime.fetchRemoteWithCache('/repo/b', 'origin')
 
-    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(2)
+    expect(fetchCallCount()).toBe(2)
   })
 
   it('serializes two concurrent callers onto a single git fetch', async () => {
@@ -75,7 +88,7 @@ describe('OrcaRuntimeService.fetchRemoteWithCache', () => {
     const pending = new Promise<{ stdout: string; stderr: string }>((resolve) => {
       resolveFetch = () => resolve({ stdout: '', stderr: '' })
     })
-    gitExecFileAsyncMock.mockReturnValueOnce(pending)
+    mockFetchResults([pending])
 
     const runtime = new OrcaRuntimeService(null)
 
@@ -84,16 +97,17 @@ describe('OrcaRuntimeService.fetchRemoteWithCache', () => {
 
     // Allow both callers to register before we resolve.
     await Promise.resolve()
-    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(1)
+    await Promise.resolve()
+    expect(fetchCallCount()).toBe(1)
 
     resolveFetch()
     await Promise.all([first, second])
 
-    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(1)
+    expect(fetchCallCount()).toBe(1)
   })
 
   it('skips the fetch inside the 30s freshness window after a successful fetch', async () => {
-    gitExecFileAsyncMock.mockResolvedValue({ stdout: '', stderr: '' })
+    mockFetchResults([{ stdout: '', stderr: '' }])
 
     const runtime = new OrcaRuntimeService(null)
 
@@ -101,6 +115,18 @@ describe('OrcaRuntimeService.fetchRemoteWithCache', () => {
     await runtime.fetchRemoteWithCache('/repo/d', 'origin')
 
     // Second call must short-circuit on the freshness window (no new exec).
-    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(1)
+    expect(fetchCallCount()).toBe(1)
+  })
+
+  it('resolves remote-tracking bases with longest configured remote matching', async () => {
+    gitExecFileAsyncMock.mockResolvedValue({ stdout: 'foo\nfoo/bar\norigin\n', stderr: '' })
+    const runtime = new OrcaRuntimeService(null)
+
+    await expect(runtime.resolveRemoteTrackingBase('/repo/e', 'foo/bar/main')).resolves.toEqual({
+      remote: 'foo/bar',
+      branch: 'main',
+      ref: 'refs/remotes/foo/bar/main',
+      base: 'foo/bar/main'
+    })
   })
 })

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -1200,6 +1200,46 @@ describe('OrcaRuntimeService', () => {
     expect(removeWorktree).toHaveBeenCalledWith(TEST_REPO_PATH, TEST_WORKTREE_PATH, false)
   })
 
+  it('clears optimistic reconcile tokens when a CLI worktree removal succeeds', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    const worktreeBaseStatus = vi.fn()
+    runtime.setNotifier({
+      worktreesChanged: vi.fn(),
+      worktreeBaseStatus,
+      reposChanged: vi.fn(),
+      activateWorktree: vi.fn(),
+      createTerminal: vi.fn(),
+      splitTerminal: vi.fn(),
+      renameTerminal: vi.fn(),
+      focusTerminal: vi.fn(),
+      closeTerminal: vi.fn(),
+      sleepWorktree: vi.fn(),
+      terminalFitOverrideChanged: vi.fn(),
+      terminalDriverChanged: vi.fn()
+    })
+    vi.mocked(removeWorktree).mockResolvedValue(undefined)
+
+    const token = runtime.recordOptimisticReconcileToken(TEST_WORKTREE_ID)
+    await runtime.removeManagedWorktree(TEST_WORKTREE_ID)
+    await runtime.reconcileWorktreeBaseStatus({
+      repoId: TEST_REPO_ID,
+      repoPath: TEST_REPO_PATH,
+      worktreeId: TEST_WORKTREE_ID,
+      base: {
+        remote: 'origin',
+        branch: 'main',
+        ref: 'refs/remotes/origin/main',
+        base: 'origin/main'
+      },
+      branchName: 'feature',
+      createdBaseSha: 'created-sha',
+      token,
+      fetchPromise: Promise.resolve({ ok: true })
+    })
+
+    expect(worktreeBaseStatus).not.toHaveBeenCalled()
+  })
+
   it('invalidates the filesystem-auth cache after CLI worktree creation', async () => {
     // Reproduces: CLI-created worktrees fail with "Access denied: unknown
     // repository or worktree path" because the filesystem-auth cache was
@@ -1402,9 +1442,10 @@ describe('OrcaRuntimeService', () => {
 
       runtime.setAgentBrowserBridge({ tabSwitch: tabSwitchMock } as never)
 
-      await expect(
-        runtime.browserTabSwitch({ page: 'page-1', focus: true })
-      ).resolves.toEqual({ switched: 0, browserPageId: 'page-1' })
+      await expect(runtime.browserTabSwitch({ page: 'page-1', focus: true })).resolves.toEqual({
+        switched: 0,
+        browserPageId: 'page-1'
+      })
       // Bridge is unchanged — focus is delivered to the renderer via IPC
       // (notifyRendererBrowserPaneFocus), not threaded through bridge state.
       expect(tabSwitchMock).toHaveBeenCalledWith(undefined, undefined, 'page-1')

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -19,6 +19,8 @@ import type {
   GlobalSettings,
   Repo,
   StatsSummary,
+  WorktreeBaseStatusEvent,
+  WorktreeRemoteBranchConflictEvent,
   WorktreeStartupLaunch
 } from '../../shared/types'
 import { isFolderRepo } from '../../shared/repo-kind'
@@ -151,6 +153,15 @@ type RuntimeAccountServices = {
   rateLimits: RateLimitService
 }
 
+export type RemoteFetchResult = { ok: true } | { ok: false; errorKind: 'git_error' }
+
+export type RemoteTrackingBase = {
+  remote: string
+  branch: string
+  ref: string
+  base: string
+}
+
 export type AccountsSnapshot = {
   claude: ClaudeRateLimitAccountsState
   codex: CodexRateLimitAccountsState
@@ -238,6 +249,8 @@ type RuntimePtyController = {
 
 type RuntimeNotifier = {
   worktreesChanged(repoId: string): void
+  worktreeBaseStatus?(event: WorktreeBaseStatusEvent): void
+  worktreeRemoteBranchConflict?(event: WorktreeRemoteBranchConflictEvent): void
   reposChanged(): void
   activateWorktree(
     repoId: string,
@@ -612,8 +625,9 @@ export class OrcaRuntimeService {
   // A literal "insert before await / read-back after await" without these
   // three rules wedges all future creates on the same repo after a single
   // DNS hiccup until process restart (see §3.3 Lifecycle).
-  private fetchInflight = new Map<string, Promise<void>>()
+  private fetchInflight = new Map<string, Promise<RemoteFetchResult>>()
   private fetchLastCompletedAt = new Map<string, number>()
+  private optimisticReconcileTokens = new Map<string, string>()
   private readonly getLocalProviderFn: (() => IPtyProvider) | null
   private accountServices: RuntimeAccountServices | null = null
 
@@ -3464,6 +3478,7 @@ export class OrcaRuntimeService {
       ...(shouldSetDisplayName(requestedName, branchName, sanitizedName)
         ? { displayName: requestedName }
         : {}),
+      baseRef: baseBranch,
       ...(args.linkedIssue !== undefined ? { linkedIssue: args.linkedIssue } : {}),
       ...(args.comment !== undefined ? { comment: args.comment } : {})
     })
@@ -3544,14 +3559,37 @@ export class OrcaRuntimeService {
    * primary telemetry target; splitting the cache by call-site would double
    * the fetch load on warm repos.
    */
-  async fetchRemoteWithCache(repoPath: string, remote: string): Promise<void> {
-    const key = `${repoPath}::${remote}`
+  async getCanonicalFetchKey(repoPath: string, remote: string): Promise<string> {
+    try {
+      const { stdout } = await gitExecFileAsync(
+        ['rev-parse', '--path-format=absolute', '--git-common-dir'],
+        { cwd: repoPath }
+      )
+      const commonDir = stdout.trim()
+      if (commonDir) {
+        return `${commonDir}::${remote}`
+      }
+    } catch {
+      // Fall through to the caller-provided path. The fetch still runs from
+      // repoPath; this key only controls cache sharing.
+    }
+    return `${repoPath}::${remote}`
+  }
+
+  async isRemoteFetchFresh(repoPath: string, remote: string): Promise<boolean> {
+    const key = await this.getCanonicalFetchKey(repoPath, remote)
+    const lastAt = this.fetchLastCompletedAt.get(key)
+    return lastAt !== undefined && Date.now() - lastAt < FETCH_FRESHNESS_MS
+  }
+
+  async getOrStartRemoteFetch(repoPath: string, remote: string): Promise<RemoteFetchResult> {
+    const key = await this.getCanonicalFetchKey(repoPath, remote)
     const lastAt = this.fetchLastCompletedAt.get(key)
     if (lastAt !== undefined && Date.now() - lastAt < FETCH_FRESHNESS_MS) {
       // Why: freshness window hit — skip the fetch entirely. Do NOT reuse any
       // in-flight promise here; the timestamp is only written on success, so
       // hitting this branch means a previous fetch did succeed recently.
-      return
+      return { ok: true }
     }
 
     const existing = this.fetchInflight.get(key)
@@ -3562,16 +3600,18 @@ export class OrcaRuntimeService {
     }
 
     const promise = gitExecFileAsync(['fetch', remote], { cwd: repoPath })
-      .then(() => {
+      .then((): RemoteFetchResult => {
         // Why (§3.3 Lifecycle): timestamp on success ONLY. Writing on rejection
         // would make the freshness cache lie about the last known remote state.
         this.fetchLastCompletedAt.set(key, Date.now())
+        return { ok: true }
       })
-      .catch((err) => {
+      .catch((err): RemoteFetchResult => {
         // Why: swallow here so awaiters don't throw at the await site. Outer
         // create/dispatch paths are already tolerant of offline fetch failure;
         // this is the behavioral contract of this helper.
         console.warn(`[fetchRemoteWithCache] ${remote} fetch failed for ${repoPath}:`, err)
+        return { ok: false, errorKind: 'git_error' }
       })
       .finally(() => {
         // Why (§3.3 Lifecycle): evict on BOTH success and rejection. A
@@ -3582,6 +3622,173 @@ export class OrcaRuntimeService {
 
     this.fetchInflight.set(key, promise)
     return promise
+  }
+
+  async fetchRemoteWithCache(repoPath: string, remote: string): Promise<void> {
+    await this.getOrStartRemoteFetch(repoPath, remote)
+  }
+
+  async resolveRemoteTrackingBase(
+    repoPath: string,
+    baseBranch: string
+  ): Promise<RemoteTrackingBase | null> {
+    let remotes: string[]
+    try {
+      const { stdout } = await gitExecFileAsync(['remote'], { cwd: repoPath })
+      remotes = stdout
+        .split('\n')
+        .map((line) => line.trim())
+        .filter(Boolean)
+    } catch {
+      return null
+    }
+
+    const remote = remotes
+      .filter((candidate) => baseBranch.startsWith(`${candidate}/`))
+      .sort((a, b) => b.length - a.length)[0]
+    if (!remote) {
+      return null
+    }
+    const branch = baseBranch.slice(remote.length + 1)
+    if (!branch) {
+      return null
+    }
+    return {
+      remote,
+      branch,
+      ref: `refs/remotes/${remote}/${branch}`,
+      base: baseBranch
+    }
+  }
+
+  async hasRemoteTrackingRef(repoPath: string, base: RemoteTrackingBase): Promise<boolean> {
+    try {
+      await gitExecFileAsync(['rev-parse', '--verify', `${base.ref}^{commit}`], { cwd: repoPath })
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  recordOptimisticReconcileToken(worktreeId: string): string {
+    const token = randomUUID()
+    this.optimisticReconcileTokens.set(worktreeId, token)
+    return token
+  }
+
+  clearOptimisticReconcileToken(worktreeId: string): void {
+    this.optimisticReconcileTokens.delete(worktreeId)
+  }
+
+  emitWorktreeBaseStatus(event: WorktreeBaseStatusEvent): void {
+    this.notifier?.worktreeBaseStatus?.(event)
+  }
+
+  async reconcileWorktreeBaseStatus(args: {
+    repoId: string
+    repoPath: string
+    worktreeId: string
+    base: RemoteTrackingBase
+    branchName: string
+    createdBaseSha: string
+    token: string
+    fetchPromise: Promise<RemoteFetchResult>
+  }): Promise<void> {
+    const stillCurrent = (): boolean =>
+      this.optimisticReconcileTokens.get(args.worktreeId) === args.token
+    const emit = (event: Omit<WorktreeBaseStatusEvent, 'repoId' | 'worktreeId' | 'base'>): void => {
+      if (!stillCurrent()) {
+        return
+      }
+      this.notifier?.worktreeBaseStatus?.({
+        repoId: args.repoId,
+        worktreeId: args.worktreeId,
+        base: args.base.base,
+        remote: args.base.remote,
+        ...event
+      })
+    }
+    const checkPublishRemoteConflict = async (): Promise<void> => {
+      const publishRemote = 'origin'
+      try {
+        if (publishRemote !== args.base.remote) {
+          const result = await this.getOrStartRemoteFetch(args.repoPath, publishRemote)
+          if (!result.ok) {
+            return
+          }
+        }
+        await gitExecFileAsync(
+          ['rev-parse', '--verify', `refs/remotes/${publishRemote}/${args.branchName}^{commit}`],
+          { cwd: args.repoPath }
+        )
+        if (stillCurrent()) {
+          this.notifier?.worktreeRemoteBranchConflict?.({
+            repoId: args.repoId,
+            worktreeId: args.worktreeId,
+            remote: publishRemote,
+            branchName: args.branchName
+          })
+        }
+      } catch {
+        // No publish-remote conflict is the common case; stay quiet.
+      }
+    }
+
+    const fetchResult = await args.fetchPromise
+    if (!stillCurrent()) {
+      return
+    }
+    if (!fetchResult.ok) {
+      emit({ status: 'unknown' })
+      return
+    }
+
+    try {
+      const { stdout } = await gitExecFileAsync(
+        ['rev-parse', '--verify', `${args.base.ref}^{commit}`],
+        { cwd: args.repoPath }
+      )
+      const postFetchSha = stdout.trim()
+      if (postFetchSha === args.createdBaseSha) {
+        emit({ status: 'current' })
+        await checkPublishRemoteConflict()
+        return
+      }
+
+      try {
+        await gitExecFileAsync(['merge-base', '--is-ancestor', args.createdBaseSha, postFetchSha], {
+          cwd: args.repoPath
+        })
+      } catch {
+        emit({ status: 'base_changed' })
+        await checkPublishRemoteConflict()
+        return
+      }
+
+      const { stdout: countStdout } = await gitExecFileAsync(
+        ['rev-list', '--count', `${args.createdBaseSha}..${postFetchSha}`],
+        { cwd: args.repoPath }
+      )
+      const behind = Number(countStdout.trim())
+      if (!Number.isFinite(behind) || behind <= 0) {
+        emit({ status: 'current' })
+        await checkPublishRemoteConflict()
+        return
+      }
+      const { stdout: logStdout } = await gitExecFileAsync(
+        ['log', '--format=%s', '-n', '5', `${args.createdBaseSha}..${postFetchSha}`],
+        { cwd: args.repoPath }
+      )
+      emit({
+        status: 'drift',
+        behind,
+        recentSubjects: logStdout.split('\n').filter((line) => line.trim().length > 0)
+      })
+      await checkPublishRemoteConflict()
+    } catch (err) {
+      console.warn(`[worktree-base-status] reconcile failed for ${args.worktreeId}:`, err)
+      emit({ status: 'unknown' })
+    }
   }
 
   /**
@@ -3603,17 +3810,23 @@ export class OrcaRuntimeService {
     if (!repo) {
       return null
     }
-    const base = getDefaultBaseRef(repo.path)
+    const meta = this.store.getWorktreeMeta(wt.id)
+    const base =
+      meta?.baseRef || meta?.sparseBaseRef || repo.worktreeBaseRef || getDefaultBaseRef(repo.path)
     if (!base) {
       // Why: brand-new repo with no remote primary — nothing to compare
       // against, so there's no meaningful drift to report. Dispatch should
       // not block on a probe that cannot form an opinion.
       return null
     }
-    const remote = base.includes('/') ? base.split('/')[0] : 'origin'
+    const remoteTrackingBase = await this.resolveRemoteTrackingBase(repo.path, base)
+    if (!remoteTrackingBase) {
+      return null
+    }
+    const remote = remoteTrackingBase.remote
     // Why: fetch failures are non-fatal; we proceed with whatever the
     // last-known remote ref points at. `fetchRemoteWithCache` never throws.
-    await this.fetchRemoteWithCache(wt.path, remote)
+    await this.fetchRemoteWithCache(repo.path, remote)
     const drift = getRemoteDrift(wt.path, 'HEAD', base)
     if (!drift) {
       return null
@@ -3719,6 +3932,7 @@ export class OrcaRuntimeService {
         // list` continues to show the stale entry and the branch it had checked out
         // remains locked — other worktrees cannot check it out.
         await gitExecFileAsync(['worktree', 'prune'], { cwd: repo.path }).catch(() => {})
+        this.clearOptimisticReconcileToken(worktree.id)
         this.store.removeWorktreeMeta(worktree.id)
         this.invalidateResolvedWorktreeCache()
         invalidateAuthorizedRootsCache()
@@ -3730,6 +3944,7 @@ export class OrcaRuntimeService {
       throw new Error(formatWorktreeRemovalError(error, worktree.path, force))
     }
 
+    this.clearOptimisticReconcileToken(worktree.id)
     this.store.removeWorktreeMeta(worktree.id)
     this.invalidateResolvedWorktreeCache()
     invalidateAuthorizedRootsCache()

--- a/src/main/window/attach-main-window-services.ts
+++ b/src/main/window/attach-main-window-services.ts
@@ -198,6 +198,8 @@ function registerRuntimeWindowLifecycle(
   }
   runtime.setNotifier({
     worktreesChanged: (repoId) => send('worktrees:changed', { repoId }),
+    worktreeBaseStatus: (event) => send('worktree:baseStatus', event),
+    worktreeRemoteBranchConflict: (event) => send('worktree:remoteBranchConflict', event),
     reposChanged: () => send('repos:changed'),
     activateWorktree: (
       repoId,

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -61,7 +61,9 @@ import type {
   MemorySnapshot,
   UpdateStatus,
   Worktree,
+  WorktreeBaseStatusEvent,
   WorktreeMeta,
+  WorktreeRemoteBranchConflictEvent,
   WorktreeSetupLaunch,
   WorktreeStartupLaunch,
   WorkspaceSessionState
@@ -435,6 +437,10 @@ export type PreloadApi = {
     updateMeta: (args: { worktreeId: string; updates: Partial<WorktreeMeta> }) => Promise<Worktree>
     persistSortOrder: (args: { orderedIds: string[] }) => Promise<void>
     onChanged: (callback: (data: { repoId: string }) => void) => () => void
+    onBaseStatus: (callback: (data: WorktreeBaseStatusEvent) => void) => () => void
+    onRemoteBranchConflict: (
+      callback: (data: WorktreeRemoteBranchConflictEvent) => void
+    ) => () => void
   }
   pty: {
     spawn: (opts: {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -26,7 +26,9 @@ import type {
   NotificationSoundPathResult,
   NotificationSoundResult,
   OnboardingState,
-  SearchResult
+  SearchResult,
+  WorktreeBaseStatusEvent,
+  WorktreeRemoteBranchConflictEvent
 } from '../shared/types'
 import type { RuntimeStatus, RuntimeSyncWindowGraph } from '../shared/runtime-types'
 import type { RateLimitState } from '../shared/rate-limit-types'
@@ -372,6 +374,24 @@ const api = {
         callback(data)
       ipcRenderer.on('worktrees:changed', listener)
       return () => ipcRenderer.removeListener('worktrees:changed', listener)
+    },
+
+    onBaseStatus: (callback: (data: WorktreeBaseStatusEvent) => void): (() => void) => {
+      const listener = (_event: Electron.IpcRendererEvent, data: WorktreeBaseStatusEvent) =>
+        callback(data)
+      ipcRenderer.on('worktree:baseStatus', listener)
+      return () => ipcRenderer.removeListener('worktree:baseStatus', listener)
+    },
+
+    onRemoteBranchConflict: (
+      callback: (data: WorktreeRemoteBranchConflictEvent) => void
+    ): (() => void) => {
+      const listener = (
+        _event: Electron.IpcRendererEvent,
+        data: WorktreeRemoteBranchConflictEvent
+      ) => callback(data)
+      ipcRenderer.on('worktree:remoteBranchConflict', listener)
+      return () => ipcRenderer.removeListener('worktree:remoteBranchConflict', listener)
     }
   },
 

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -4,7 +4,17 @@ import { useShallow } from 'zustand/react/shallow'
 import { useAppStore } from '@/store'
 import { Badge } from '@/components/ui/badge'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
-import { Bell, GitMerge, LoaderCircle, CircleCheck, CircleX, Server, ServerOff } from 'lucide-react'
+import {
+  AlertTriangle,
+  Bell,
+  Copy,
+  GitMerge,
+  LoaderCircle,
+  CircleCheck,
+  CircleX,
+  Server,
+  ServerOff
+} from 'lucide-react'
 import StatusIndicator from './StatusIndicator'
 import CacheTimer from './CacheTimer'
 import WorktreeContextMenu from './WorktreeContextMenu'
@@ -84,6 +94,8 @@ const WorktreeCard = React.memo(function WorktreeCard({
 
   const deleteState = useAppStore((s) => s.deleteStateByWorktreeId[worktree.id])
   const conflictOperation = useAppStore((s) => s.gitConflictOperationByWorktree[worktree.id])
+  const baseStatus = useAppStore((s) => s.baseStatusByWorktreeId[worktree.id])
+  const remoteBranchConflict = useAppStore((s) => s.remoteBranchConflictByWorktreeId[worktree.id])
 
   // SSH disconnected state
   const sshStatus = useAppStore((s) => {
@@ -334,6 +346,24 @@ const WorktreeCard = React.memo(function WorktreeCard({
   )
 
   const unreadTooltip = worktree.isUnread ? 'Mark read' : 'Mark unread'
+  const handleCopyRebaseCommand = useCallback(
+    async (event: React.MouseEvent<HTMLButtonElement>) => {
+      event.preventDefault()
+      event.stopPropagation()
+      if (!baseStatus || baseStatus.status === 'base_changed') {
+        return
+      }
+      // Why: design §3.2 forbids splitting blindly on the first slash —
+      // remote names may contain slashes (e.g. `foo/bar`). Trust the remote
+      // parsed by the main process and fall back only when the event predates
+      // that field.
+      const remote =
+        baseStatus.remote ??
+        (baseStatus.base.includes('/') ? baseStatus.base.split('/')[0] : 'origin')
+      await window.api.ui.writeClipboardText(`git fetch ${remote} && git rebase ${baseStatus.base}`)
+    },
+    [baseStatus]
+  )
 
   // Why: the 'unread' card property is the user's opt-out. When off, we render
   // as if the workspace is read so bold emphasis never appears. The persisted
@@ -565,6 +595,68 @@ const WorktreeCard = React.memo(function WorktreeCard({
             {cardProps.includes('comment') && worktree.comment && (
               <CommentSection comment={worktree.comment} onDoubleClick={handleEditComment} />
             )}
+          </div>
+        )}
+
+        {baseStatus && baseStatus.status !== 'current' && (
+          <div
+            className={cn(
+              'mt-0.5 flex items-start gap-1.5 rounded border px-1.5 py-1 text-[10.5px] leading-snug',
+              baseStatus.status === 'drift' || baseStatus.status === 'base_changed'
+                ? 'border-amber-500/25 bg-amber-500/5 text-amber-700 dark:text-amber-300'
+                : 'border-border bg-muted/35 text-muted-foreground'
+            )}
+          >
+            {baseStatus.status === 'checking' ? (
+              <LoaderCircle className="mt-[1px] size-3 shrink-0 animate-spin" />
+            ) : (
+              <AlertTriangle className="mt-[1px] size-3 shrink-0" />
+            )}
+            <div className="min-w-0 flex-1">
+              {baseStatus.status === 'checking' && <span>Checking base…</span>}
+              {baseStatus.status === 'unknown' && <span>Base could not be checked.</span>}
+              {baseStatus.status === 'base_changed' && (
+                <span>Base changed upstream. Review before rebasing.</span>
+              )}
+              {baseStatus.status === 'drift' && (
+                <>
+                  <span>
+                    Base updated: {baseStatus.base} advanced by {baseStatus.behind ?? 0} commits.
+                  </span>
+                  {baseStatus.recentSubjects?.[0] && (
+                    <span className="block truncate opacity-80">
+                      Most recent: {baseStatus.recentSubjects[0]}
+                    </span>
+                  )}
+                </>
+              )}
+            </div>
+            {baseStatus.status === 'drift' && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    onClick={handleCopyRebaseCommand}
+                    className="mt-[-1px] inline-flex size-5 shrink-0 items-center justify-center rounded hover:bg-amber-500/10"
+                    aria-label="Copy rebase command"
+                  >
+                    <Copy className="size-3" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="right" sideOffset={8}>
+                  Copy rebase command
+                </TooltipContent>
+              </Tooltip>
+            )}
+          </div>
+        )}
+
+        {remoteBranchConflict && (
+          <div className="mt-0.5 flex items-start gap-1.5 rounded border border-amber-500/25 bg-amber-500/5 px-1.5 py-1 text-[10.5px] leading-snug text-amber-700 dark:text-amber-300">
+            <AlertTriangle className="mt-[1px] size-3 shrink-0" />
+            <span className="min-w-0 flex-1">
+              {remoteBranchConflict.remote}/{remoteBranchConflict.branchName} already exists.
+            </span>
           </div>
         )}
 

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -145,7 +145,11 @@ describe('useIpcEvents updater integration', () => {
     vi.stubGlobal('window', {
       api: {
         repos: { onChanged: () => () => {} },
-        worktrees: { onChanged: () => () => {} },
+        worktrees: {
+          onChanged: () => () => {},
+          onBaseStatus: () => () => {},
+          onRemoteBranchConflict: () => () => {}
+        },
         ui: {
           onOpenSettings: () => () => {},
           onToggleLeftSidebar: () => () => {},
@@ -345,7 +349,11 @@ describe('useIpcEvents updater integration', () => {
     vi.stubGlobal('window', {
       api: {
         repos: { onChanged: () => () => {} },
-        worktrees: { onChanged: () => () => {} },
+        worktrees: {
+          onChanged: () => () => {},
+          onBaseStatus: () => () => {},
+          onRemoteBranchConflict: () => () => {}
+        },
         ui: {
           onOpenSettings: () => () => {},
           onToggleLeftSidebar: () => () => {},
@@ -539,7 +547,11 @@ describe('useIpcEvents updater integration', () => {
     vi.stubGlobal('window', {
       api: {
         repos: { onChanged: () => () => {} },
-        worktrees: { onChanged: () => () => {} },
+        worktrees: {
+          onChanged: () => () => {},
+          onBaseStatus: () => () => {},
+          onRemoteBranchConflict: () => () => {}
+        },
         ui: {
           onOpenSettings: () => () => {},
           onToggleLeftSidebar: () => () => {},
@@ -745,7 +757,11 @@ describe('useIpcEvents browser tab close routing', () => {
       dispatchEvent: vi.fn(),
       api: {
         repos: { onChanged: () => () => {} },
-        worktrees: { onChanged: () => () => {} },
+        worktrees: {
+          onChanged: () => () => {},
+          onBaseStatus: () => () => {},
+          onRemoteBranchConflict: () => () => {}
+        },
         ui: {
           onOpenSettings: () => () => {},
           onToggleLeftSidebar: () => () => {},
@@ -940,7 +956,11 @@ describe('useIpcEvents browser tab close routing', () => {
       dispatchEvent: vi.fn(),
       api: {
         repos: { onChanged: () => () => {} },
-        worktrees: { onChanged: () => () => {} },
+        worktrees: {
+          onChanged: () => () => {},
+          onBaseStatus: () => () => {},
+          onRemoteBranchConflict: () => () => {}
+        },
         ui: {
           onOpenSettings: () => () => {},
           onToggleLeftSidebar: () => () => {},
@@ -1130,7 +1150,11 @@ describe('useIpcEvents browser tab close routing', () => {
       dispatchEvent: vi.fn(),
       api: {
         repos: { onChanged: () => () => {} },
-        worktrees: { onChanged: () => () => {} },
+        worktrees: {
+          onChanged: () => () => {},
+          onBaseStatus: () => () => {},
+          onRemoteBranchConflict: () => () => {}
+        },
         ui: {
           onOpenSettings: () => () => {},
           onToggleLeftSidebar: () => () => {},
@@ -1329,7 +1353,11 @@ describe('useIpcEvents CLI-created worktree activation', () => {
     vi.stubGlobal('window', {
       api: {
         repos: { onChanged: () => () => {} },
-        worktrees: { onChanged: () => () => {} },
+        worktrees: {
+          onChanged: () => () => {},
+          onBaseStatus: () => () => {},
+          onRemoteBranchConflict: () => () => {}
+        },
         ui: {
           onOpenSettings: () => () => {},
           onToggleLeftSidebar: () => () => {},

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -70,6 +70,18 @@ export function useIpcEvents(): void {
     )
 
     unsubs.push(
+      window.api.worktrees.onBaseStatus((event) => {
+        useAppStore.getState().updateWorktreeBaseStatus(event)
+      })
+    )
+
+    unsubs.push(
+      window.api.worktrees.onRemoteBranchConflict((event) => {
+        useAppStore.getState().updateWorktreeRemoteBranchConflict(event)
+      })
+    )
+
+    unsubs.push(
       window.api.ui.onOpenSettings(() => {
         useAppStore.getState().openSettingsPage()
       })

--- a/src/renderer/src/store/slices/worktree-helpers.ts
+++ b/src/renderer/src/store/slices/worktree-helpers.ts
@@ -4,6 +4,8 @@ import type {
   SetupDecision,
   WorkspaceCreateTelemetrySource,
   Worktree,
+  WorktreeBaseStatusEvent,
+  WorktreeRemoteBranchConflictEvent,
   WorktreeMeta
 } from '../../../../shared/types'
 
@@ -17,6 +19,8 @@ export type WorktreeSlice = {
   worktreesByRepo: Record<string, Worktree[]>
   activeWorktreeId: string | null
   deleteStateByWorktreeId: Record<string, WorktreeDeleteState>
+  baseStatusByWorktreeId: Record<string, WorktreeBaseStatusEvent>
+  remoteBranchConflictByWorktreeId: Record<string, WorktreeRemoteBranchConflictEvent>
   /**
    * Monotonically increasing counter that signals when the sidebar sort order
    * should be recomputed.  Only bumped by events that represent meaningful
@@ -112,6 +116,8 @@ export type WorktreeSlice = {
     worktreeId: string,
     identity: { head?: string; branch?: string }
   ) => void
+  updateWorktreeBaseStatus: (event: WorktreeBaseStatusEvent) => void
+  updateWorktreeRemoteBranchConflict: (event: WorktreeRemoteBranchConflictEvent) => void
 }
 
 export function findWorktreeById(

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -9,6 +9,7 @@ import type { Worktree } from '../../../../shared/types'
 
 const mockApi = {
   worktrees: {
+    create: vi.fn(),
     list: vi.fn().mockResolvedValue([]),
     remove: vi.fn().mockResolvedValue(undefined),
     updateMeta: vi.fn().mockResolvedValue(undefined)
@@ -141,6 +142,30 @@ describe('fetchWorktrees', () => {
     expect(store.getState().sortEpoch).toBe(8)
   })
 
+  it('updates the repo entry when only the persisted base ref changes', async () => {
+    const store = createTestStore()
+    const existing = makeWorktree({
+      id: 'repo1::/path/wt1',
+      repoId: 'repo1',
+      path: '/path/wt1',
+      baseRef: 'origin/main'
+    })
+    const refreshed = makeWorktree({
+      id: 'repo1::/path/wt1',
+      repoId: 'repo1',
+      path: '/path/wt1',
+      baseRef: 'upstream/release'
+    })
+
+    mockApi.worktrees.list.mockResolvedValue([refreshed])
+    store.setState({ worktreesByRepo: { repo1: [existing] }, sortEpoch: 7 } as Partial<AppState>)
+
+    await store.getState().fetchWorktrees('repo1')
+
+    expect(store.getState().worktreesByRepo.repo1).toEqual([refreshed])
+    expect(store.getState().sortEpoch).toBe(8)
+  })
+
   it('keeps the last known worktree list when a refresh transiently returns empty', async () => {
     const store = createTestStore()
     const existing = makeWorktree({ id: 'repo1::/path/wt1', repoId: 'repo1', path: '/path/wt1' })
@@ -195,6 +220,45 @@ describe('updateWorktreeGitIdentity', () => {
     })
     expect(store.getState().sortEpoch).toBe(4)
     expect(mockApi.worktrees.list).not.toHaveBeenCalled()
+  })
+})
+
+describe('createWorktree base status merge', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('does not overwrite a newer reconcile status with the initial checking status', async () => {
+    const store = createTestStore()
+    const wt = makeWorktree({ id: 'repo1::/path/wt1', repoId: 'repo1', path: '/path/wt1' })
+    mockApi.worktrees.create.mockImplementation(async () => {
+      store.getState().updateWorktreeBaseStatus({
+        repoId: 'repo1',
+        worktreeId: wt.id,
+        status: 'drift',
+        base: 'origin/main',
+        remote: 'origin',
+        behind: 2,
+        recentSubjects: ['new base commit']
+      })
+      return {
+        worktree: wt,
+        initialBaseStatus: {
+          repoId: 'repo1',
+          worktreeId: wt.id,
+          status: 'checking',
+          base: 'origin/main',
+          remote: 'origin'
+        }
+      }
+    })
+
+    await store.getState().createWorktree('repo1', 'feature')
+
+    expect(store.getState().baseStatusByWorktreeId[wt.id]).toMatchObject({
+      status: 'drift',
+      behind: 2
+    })
   })
 })
 

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -46,6 +46,7 @@ function areWorktreesEqual(current: Worktree[] | undefined, next: Worktree[]): b
       worktree.isPinned === candidate.isPinned &&
       worktree.sortOrder === candidate.sortOrder &&
       worktree.lastActivityAt === candidate.lastActivityAt &&
+      worktree.baseRef === candidate.baseRef &&
       worktree.sparseBaseRef === candidate.sparseBaseRef &&
       arraysShallowEqual(worktree.sparseDirectories, candidate.sparseDirectories)
     )
@@ -60,6 +61,8 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
   worktreesByRepo: {},
   activeWorktreeId: null,
   deleteStateByWorktreeId: {},
+  baseStatusByWorktreeId: {},
+  remoteBranchConflictByWorktreeId: {},
   sortEpoch: 0,
   everActivatedWorktreeIds: new Set<string>(),
   lastVisitedAtByWorktreeId: {},
@@ -195,6 +198,24 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
     })
   },
 
+  updateWorktreeBaseStatus: (event) => {
+    set((s) => ({
+      baseStatusByWorktreeId: {
+        ...s.baseStatusByWorktreeId,
+        [event.worktreeId]: event
+      }
+    }))
+  },
+
+  updateWorktreeRemoteBranchConflict: (event) => {
+    set((s) => ({
+      remoteBranchConflictByWorktreeId: {
+        ...s.remoteBranchConflictByWorktreeId,
+        [event.worktreeId]: event
+      }
+    }))
+  },
+
   createWorktree: async (
     repoId,
     name,
@@ -236,6 +257,15 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
                 ...s.worktreesByRepo,
                 [repoId]: alreadyPresent ? current : [...current, result.worktree]
               },
+              ...(result.initialBaseStatus
+                ? {
+                    baseStatusByWorktreeId: {
+                      ...s.baseStatusByWorktreeId,
+                      [result.worktree.id]:
+                        s.baseStatusByWorktreeId[result.worktree.id] ?? result.initialBaseStatus
+                    }
+                  }
+                : {}),
               sortEpoch: s.sortEpoch + 1
             }
           })
@@ -410,6 +440,16 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
           runtimePaneTitlesByTabId: nextRuntimePaneTitlesByTabId,
           terminalLayoutsByTabId: nextLayouts,
           deleteStateByWorktreeId: nextDeleteState,
+          baseStatusByWorktreeId: (() => {
+            const nextStatus = { ...s.baseStatusByWorktreeId }
+            delete nextStatus[worktreeId]
+            return nextStatus
+          })(),
+          remoteBranchConflictByWorktreeId: (() => {
+            const nextConflict = { ...s.remoteBranchConflictByWorktreeId }
+            delete nextConflict[worktreeId]
+            return nextConflict
+          })(),
           fileSearchStateByWorktree: (() => {
             const nextSearch = { ...s.fileSearchStateByWorktree }
             // Why: file search UI state is worktree-scoped. Removing the worktree
@@ -985,6 +1025,8 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
         runtimePaneTitlesByTabId: omitByTabId(s.runtimePaneTitlesByTabId),
         // Delete state
         deleteStateByWorktreeId: omitByWorktree(s.deleteStateByWorktreeId),
+        baseStatusByWorktreeId: omitByWorktree(s.baseStatusByWorktreeId),
+        remoteBranchConflictByWorktreeId: omitByWorktree(s.remoteBranchConflictByWorktreeId),
         // File search
         fileSearchStateByWorktree: omitByWorktree(s.fileSearchStateByWorktree),
         // Browser state

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -111,6 +111,8 @@ export type Worktree = {
   /** ID of the saved preset this worktree was created from, if any. Cleared
    *  when the worktree is no longer sparse on refresh. */
   sparsePresetId?: string
+  /** Intended create base for stale-base probes. Persisted metadata, not UI drift state. */
+  baseRef?: string
   diffComments?: DiffComment[]
 } & GitWorktreeInfo
 
@@ -131,6 +133,8 @@ export type WorktreeMeta = {
   sparseDirectories?: string[]
   sparseBaseRef?: string
   sparsePresetId?: string
+  /** Intended create base for stale-base probes. Persisted metadata, not UI drift state. */
+  baseRef?: string
   diffComments?: DiffComment[]
 }
 
@@ -859,6 +863,28 @@ export type CreateWorktreeResult = {
   worktree: Worktree
   setup?: WorktreeSetupLaunch
   warning?: string
+  initialBaseStatus?: WorktreeBaseStatusEvent
+}
+
+export type WorktreeBaseStatusKind = 'checking' | 'current' | 'drift' | 'base_changed' | 'unknown'
+
+export type WorktreeBaseStatusEvent = {
+  repoId: string
+  worktreeId: string
+  status: WorktreeBaseStatusKind
+  base: string
+  /** Configured remote name parsed from `base` (longest-prefix match). Absent
+   *  when classification skipped optimistic reconcile (e.g. legacy fallback). */
+  remote?: string
+  behind?: number
+  recentSubjects?: string[]
+}
+
+export type WorktreeRemoteBranchConflictEvent = {
+  repoId: string
+  worktreeId: string
+  remote: string
+  branchName: string
 }
 
 // ─── Updater ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Surface worktree creation immediately; reconcile base state asynchronously
- Emit drift / publish-remote-conflict events once fetches complete
- Token-based gating ensures stale events are dropped after deletion

## Test plan
- [x] Existing worktree tests pass
- [ ] Manually verify cold-base create flow
- [ ] Manually verify offline create surfaces unknown base status

Made with [Orca](https://github.com/stablyai/orca) 🐋
