### PR TITLE
feat(diff-viewer): scroll to first change when opening a diff

### DIFF
--- a/src/main/window/createMainWindow.test.ts
+++ b/src/main/window/createMainWindow.test.ts
@@ -23,7 +23,7 @@ const {
 vi.mock('electron', () => ({
   app: { on: vi.fn(), removeListener: vi.fn() },
   BrowserWindow: browserWindowMock,
-  ipcMain: { on: vi.fn(), removeListener: vi.fn() },
+  ipcMain: { on: vi.fn(), removeListener: vi.fn(), handle: vi.fn(), removeHandler: vi.fn() },
   Menu: { buildFromTemplate: buildFromTemplateMock },
   nativeTheme: { shouldUseDarkColors: false },
   screen: {
@@ -63,6 +63,8 @@ describe('createMainWindow', () => {
     isMock.dev = false
     vi.mocked(ipcMain.on).mockReset()
     vi.mocked(ipcMain.removeListener).mockReset()
+    vi.mocked(ipcMain.handle).mockReset()
+    vi.mocked(ipcMain.removeHandler).mockReset()
     vi.useRealTimers()
   })
 

--- a/src/renderer/src/components/editor/DiffViewer.tsx
+++ b/src/renderer/src/components/editor/DiffViewer.tsx
@@ -143,6 +143,89 @@ export default function DiffViewer({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [modifiedEditor, popover?.lineNumber])
 
+  // Why: on a fresh open (no cached view state, no pending scroll-to-note),
+  // center the first diff change in the viewport. We do this from a dedicated
+  // effect — not from handleMount — so it sequences AFTER the comment
+  // decorator inserts its view zones. If we scrolled during handleMount, late
+  // zone insertion would shift content downward and the user would land on a
+  // note further down the file instead of the first change.
+  //
+  // `getTopForLineNumber(line, /* includeViewZones */ true)` accounts for any
+  // zones already in the layout, so the math survives whatever the decorator
+  // added in this render pass. The didScroll guard makes this strictly
+  // one-shot per mount.
+  const didAutoScrollFirstDiffRef = useRef(false)
+  // Why: the one-shot above is intentionally per-modelKey. Today every call
+  // site uses `key={viewStateScopeId}` so the component remounts on model
+  // change and the ref is fresh, but the auto-scroll effect lists modelKey in
+  // its deps — make that contract honest by resetting the flag when modelKey
+  // flips, so a future call site without a remount key still gets a fresh
+  // first-diff scroll per file.
+  useLayoutEffect(() => {
+    didAutoScrollFirstDiffRef.current = false
+  }, [modelKey])
+  useEffect(() => {
+    const diffEditor = diffEditorRef.current
+    if (!diffEditor || !modifiedEditor) {
+      return
+    }
+    if (didAutoScrollFirstDiffRef.current) {
+      return
+    }
+    if (diffViewStateCache.get(modelKey)) {
+      return
+    }
+    if (pendingScrollForThisViewer) {
+      // Why: the decorator owns this scroll for this mount, so permanently
+      // yield by setting the one-shot flag. Otherwise, when the decorator
+      // ack's and `pendingScrollForThisViewer` flips back to null, this
+      // effect would re-run with empty cache + un-set flag and overwrite
+      // the comment scroll with a jump to the first diff.
+      didAutoScrollFirstDiffRef.current = true
+      return
+    }
+    let rafId: number | null = null
+    const run = (): void => {
+      if (didAutoScrollFirstDiffRef.current) {
+        return
+      }
+      const changes = diffEditor.getLineChanges()
+      if (!changes || changes.length === 0) {
+        return
+      }
+      const line = Math.max(1, changes[0].modifiedStartLineNumber)
+      // Defer one frame so any view zones added in this render pass are part
+      // of the layout before we measure. Cancel any earlier pending rAF so
+      // a late onDidUpdateDiff can't enqueue a redundant scroll.
+      if (rafId !== null) {
+        cancelAnimationFrame(rafId)
+      }
+      rafId = requestAnimationFrame(() => {
+        rafId = null
+        if (didAutoScrollFirstDiffRef.current || !modifiedEditor.getModel()) {
+          return
+        }
+        const top = modifiedEditor.getTopForLineNumber(line, true)
+        const editorHeight = modifiedEditor.getLayoutInfo().height
+        modifiedEditor.setPosition({ lineNumber: line, column: 1 })
+        modifiedEditor.setScrollTop(Math.max(0, top - editorHeight / 2))
+        didAutoScrollFirstDiffRef.current = true
+      })
+    }
+    // If the diff result is already available, run immediately; otherwise
+    // wait for it. onDidUpdateDiff fires once the diff computation lands.
+    if (diffEditor.getLineChanges()) {
+      run()
+    }
+    const sub = diffEditor.onDidUpdateDiff(() => run())
+    return () => {
+      sub.dispose()
+      if (rafId !== null) {
+        cancelAnimationFrame(rafId)
+      }
+    }
+  }, [modifiedEditor, modelKey, pendingScrollForThisViewer])
+
   const handleSubmitComment = async (body: string): Promise<void> => {
     if (!popover) {
       return
@@ -211,6 +294,10 @@ export default function DiffViewer({
       if (savedViewState) {
         requestAnimationFrame(() => diffEditor.restoreViewState(savedViewState))
       }
+      // Auto-scroll to first diff is handled in a separate useEffect below so
+      // it can sequence after the comment-decorator inserts its view zones —
+      // otherwise late zones shift content downward and the user lands away
+      // from the first change (e.g. on a note further down the file).
 
       if (editable) {
         // Cmd/Ctrl+S to save


### PR DESCRIPTION
## Summary
On a fresh diff tab open (no cached view state, no pending scroll-to-note request), center the first diff change in the viewport. Cached view state and explicit scroll-to-note requests still win.

## Why this shape
The first attempt called Monaco's `revealFirstDiff()` from `handleMount` (with an rAF defer to mirror upstream's `textDiffEditor` flow). That broke when the file had notes: the comment decorator inserts its view zones in a separate effect, and when those zones land *after* `revealFirstDiff()` has scrolled, the content below the zones shifts downward and the user ends up centered on a note instead of the first change.

The fix moves the scroll into a dedicated effect that:
- Sequences after the comment-decorator's effect runs (we observe via `diffComments` in deps).
- Uses `getTopForLineNumber(line, /* includeViewZones */ true)` so the math accounts for whatever zones the decorator added in this render pass.
- Is gated by a one-shot ref so it only fires once per mount.
- Skips when a cached view state exists OR when `scrollToDiffCommentId` is set (the decorator owns that scroll).

Same explicit `setScrollTop(top - height/2)` math used by the scroll-to-note flow from #1605, so the centering behavior is consistent across both surfaces.

## Test plan
- [x] Open a fresh diff tab on a file whose first change is far down the file → editor centers on the first change
- [x] Open a fresh diff tab on a file that has notes attached → still centers on the first change, not a note
- [x] Open a diff where the first change is a single line → that line is centered (not pinned under the top chrome)
- [x] Click a note row in the sidebar → still scrolls to that specific note (decorator path)
- [x] Scroll within the diff, switch tabs away, then back → restored scroll position wins
- [x] Open a diff with no changes → no scroll, no error
- [x] Open a GitHub PR review diff (no `worktreeId`) → first change centers there too