### PR TITLE
fix(sidebar): remove confusing base-drift banner

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -7,7 +7,6 @@ import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip
 import {
   AlertTriangle,
   Bell,
-  Copy,
   GitMerge,
   LoaderCircle,
   CircleCheck,
@@ -94,7 +93,6 @@ const WorktreeCard = React.memo(function WorktreeCard({
 
   const deleteState = useAppStore((s) => s.deleteStateByWorktreeId[worktree.id])
   const conflictOperation = useAppStore((s) => s.gitConflictOperationByWorktree[worktree.id])
-  const baseStatus = useAppStore((s) => s.baseStatusByWorktreeId[worktree.id])
   const remoteBranchConflict = useAppStore((s) => s.remoteBranchConflictByWorktreeId[worktree.id])
 
   // SSH disconnected state
@@ -357,24 +355,6 @@ const WorktreeCard = React.memo(function WorktreeCard({
   )
 
   const unreadTooltip = worktree.isUnread ? 'Mark read' : 'Mark unread'
-  const handleCopyRebaseCommand = useCallback(
-    async (event: React.MouseEvent<HTMLButtonElement>) => {
-      event.preventDefault()
-      event.stopPropagation()
-      if (!baseStatus || baseStatus.status === 'base_changed') {
-        return
-      }
-      // Why: design §3.2 forbids splitting blindly on the first slash —
-      // remote names may contain slashes (e.g. `foo/bar`). Trust the remote
-      // parsed by the main process and fall back only when the event predates
-      // that field.
-      const remote =
-        baseStatus.remote ??
-        (baseStatus.base.includes('/') ? baseStatus.base.split('/')[0] : 'origin')
-      await window.api.ui.writeClipboardText(`git fetch ${remote} && git rebase ${baseStatus.base}`)
-    },
-    [baseStatus]
-  )
 
   // Why: the 'unread' card property is the user's opt-out. When off, we render
   // as if the workspace is read so bold emphasis never appears. The persisted
@@ -605,59 +585,6 @@ const WorktreeCard = React.memo(function WorktreeCard({
             {cardProps.includes('pr') && pr && <PrSection pr={pr} onClick={handleEditIssue} />}
             {cardProps.includes('comment') && worktree.comment && (
               <CommentSection comment={worktree.comment} onDoubleClick={handleEditComment} />
-            )}
-          </div>
-        )}
-
-        {baseStatus && baseStatus.status !== 'current' && (
-          <div
-            className={cn(
-              'mt-0.5 flex items-start gap-1.5 rounded border px-1.5 py-1 text-[10.5px] leading-snug',
-              baseStatus.status === 'drift' || baseStatus.status === 'base_changed'
-                ? 'border-amber-500/25 bg-amber-500/5 text-amber-700 dark:text-amber-300'
-                : 'border-border bg-muted/35 text-muted-foreground'
-            )}
-          >
-            {baseStatus.status === 'checking' ? (
-              <LoaderCircle className="mt-[1px] size-3 shrink-0 animate-spin" />
-            ) : (
-              <AlertTriangle className="mt-[1px] size-3 shrink-0" />
-            )}
-            <div className="min-w-0 flex-1">
-              {baseStatus.status === 'checking' && <span>Checking base…</span>}
-              {baseStatus.status === 'unknown' && <span>Base could not be checked.</span>}
-              {baseStatus.status === 'base_changed' && (
-                <span>Base changed upstream. Review before rebasing.</span>
-              )}
-              {baseStatus.status === 'drift' && (
-                <>
-                  <span>
-                    Base updated: {baseStatus.base} advanced by {baseStatus.behind ?? 0} commits.
-                  </span>
-                  {baseStatus.recentSubjects?.[0] && (
-                    <span className="block truncate opacity-80">
-                      Most recent: {baseStatus.recentSubjects[0]}
-                    </span>
-                  )}
-                </>
-              )}
-            </div>
-            {baseStatus.status === 'drift' && (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    type="button"
-                    onClick={handleCopyRebaseCommand}
-                    className="mt-[-1px] inline-flex size-5 shrink-0 items-center justify-center rounded hover:bg-amber-500/10"
-                    aria-label="Copy rebase command"
-                  >
-                    <Copy className="size-3" />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent side="right" sideOffset={8}>
-                  Copy rebase command
-                </TooltipContent>
-              </Tooltip>
             )}
           </div>
         )}


### PR DESCRIPTION
## Summary
- Removes the amber "Base updated: origin/main advanced by N commits" banner from the worktree card, along with the copy-rebase button and recent-subject preview.
- Main moves constantly, so a persistent warning trains users to ignore it. Rebasing only matters situationally (right before merging, or when a needed fix lands), not as a per-card alert.

## Test plan
- [ ] Sidebar renders without the amber base-drift block on drifted worktrees
- [ ] Other worktree-card warnings (remote branch conflict, conflict operation) still render

Made with [Orca](https://github.com/stablyai/orca) 🐋
