### PR TITLE
fix(tabs):   close-others/close-to-right on editor & browser tabs

### DIFF
--- a/src/renderer/src/components/tab-bar/TabBar.context-menu.test.ts
+++ b/src/renderer/src/components/tab-bar/TabBar.context-menu.test.ts
@@ -1,0 +1,255 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const useAppStoreMock = vi.fn(
+  (
+    selector: (state: {
+      gitStatusByWorktree: Record<string, never[]>
+      settings: {
+        terminalWindowsShell: 'powershell.exe' | 'cmd.exe' | 'wsl.exe'
+        terminalWindowsPowerShellImplementation: 'auto' | 'powershell.exe' | 'pwsh.exe'
+      }
+    }) => unknown
+  ) =>
+    selector({
+      gitStatusByWorktree: {},
+      settings: {
+        terminalWindowsShell: 'powershell.exe',
+        terminalWindowsPowerShellImplementation: 'auto'
+      }
+    })
+)
+
+vi.mock('react', async () => {
+  const actual = await vi.importActual<typeof import('react')>('react') // eslint-disable-line @typescript-eslint/consistent-type-imports -- vi.importActual requires inline import()
+  return {
+    ...actual,
+    memo: <T>(component: T) => component,
+    useEffect: () => {},
+    useLayoutEffect: () => {},
+    useMemo: <T>(factory: () => T) => factory(),
+    useRef: <T>(current: T) => ({ current }),
+    useState: <T>(initial: T) => [initial, vi.fn()] as const
+  }
+})
+
+vi.mock('lucide-react', () => ({
+  FilePlus: function FilePlus() {
+    return null
+  },
+  Globe: function Globe() {
+    return null
+  },
+  Plus: function Plus() {
+    return null
+  },
+  TerminalSquare: function TerminalSquare() {
+    return null
+  }
+}))
+
+vi.mock('@dnd-kit/sortable', () => ({
+  SortableContext: function SortableContext(props: { children?: unknown }) {
+    return props.children
+  }
+}))
+
+vi.mock('../../store', () => ({
+  useAppStore: (selector: Parameters<typeof useAppStoreMock>[0]) => useAppStoreMock(selector)
+}))
+
+vi.mock('../right-sidebar/status-display', () => ({
+  buildStatusMap: () => new Map()
+}))
+
+vi.mock('../tab-group/tab-insertion', () => ({
+  resolveTabIndicatorEdges: () => []
+}))
+
+vi.mock('@/components/editor/editor-labels', () => ({
+  getEditorDisplayLabel: () => ''
+}))
+
+vi.mock('./SortableTab', () => ({
+  default: function SortableTab(props: Record<string, unknown>) {
+    return { type: 'SortableTab', props }
+  }
+}))
+
+vi.mock('./EditorFileTab', () => ({
+  default: function EditorFileTab(props: Record<string, unknown>) {
+    return { type: 'EditorFileTab', props }
+  }
+}))
+
+vi.mock('./BrowserTab', () => ({
+  default: function BrowserTab(props: Record<string, unknown>) {
+    return { type: 'BrowserTab', props }
+  },
+  getBrowserTabLabel: () => ''
+}))
+
+vi.mock('./QuickLaunchButton', () => ({
+  QuickLaunchAgentMenuItems: function QuickLaunchAgentMenuItems() {
+    return null
+  }
+}))
+
+vi.mock('./shell-icons', () => ({
+  ShellIcon: function ShellIcon() {
+    return null
+  }
+}))
+
+vi.mock('@/lib/focus-terminal-tab-surface', () => ({
+  focusTerminalTabSurface: vi.fn()
+}))
+
+vi.mock('@/components/ui/dropdown-menu', () => ({
+  DropdownMenu: function DropdownMenu(props: { children?: unknown }) {
+    return { type: 'DropdownMenu', props }
+  },
+  DropdownMenuContent: function DropdownMenuContent(props: { children?: unknown }) {
+    return { type: 'DropdownMenuContent', props }
+  },
+  DropdownMenuItem: function DropdownMenuItem(props: {
+    children?: unknown
+    onSelect?: () => void
+  }) {
+    return { type: 'DropdownMenuItem', props }
+  },
+  DropdownMenuSeparator: function DropdownMenuSeparator() {
+    return { type: 'DropdownMenuSeparator', props: {} }
+  },
+  DropdownMenuShortcut: function DropdownMenuShortcut(props: { children?: unknown }) {
+    return { type: 'DropdownMenuShortcut', props }
+  },
+  DropdownMenuTrigger: function DropdownMenuTrigger(props: { children?: unknown }) {
+    return { type: 'DropdownMenuTrigger', props }
+  }
+}))
+
+type ReactElementLike = {
+  type: unknown
+  props: Record<string, unknown>
+}
+
+function findChildrenByType(node: unknown, typeName: string): ReactElementLike[] {
+  const results: ReactElementLike[] = []
+  const visit = (current: unknown): void => {
+    if (current == null) {
+      return
+    }
+    if (Array.isArray(current)) {
+      for (const child of current) {
+        visit(child)
+      }
+      return
+    }
+    if (typeof current === 'string' || typeof current === 'number') {
+      return
+    }
+    const el = current as ReactElementLike
+    const type = el.type as { name?: string } | string | undefined
+    const matchedName = typeof type === 'string' ? type : type?.name
+    if (matchedName === typeName) {
+      results.push(el)
+    }
+    if (el.props && 'children' in el.props) {
+      visit(el.props.children)
+    }
+  }
+  visit(node)
+  return results
+}
+
+async function renderTabBar(props: Record<string, unknown>): Promise<unknown> {
+  const tabBarModule = await import('./TabBar')
+  const candidate = tabBarModule.default as unknown as
+    | ((props: Record<string, unknown>) => unknown)
+    | { type: (props: Record<string, unknown>) => unknown }
+  const TabBar = typeof candidate === 'function' ? candidate : candidate.type
+  return TabBar({
+    activeTabId: null,
+    worktreeId: 'wt-1',
+    expandedPaneByTabId: {},
+    onActivate: () => {},
+    onClose: () => {},
+    onCloseOthers: () => {},
+    onCloseToRight: () => {},
+    onNewTerminalTab: () => {},
+    onNewBrowserTab: () => {},
+    onSetCustomTitle: () => {},
+    onSetTabColor: () => {},
+    onTogglePaneExpand: () => {},
+    wslAvailable: false,
+    ...props
+  })
+}
+
+const TERMINAL_TAB = {
+  id: 'term-1',
+  unifiedTabId: 'unified-term-1',
+  ptyId: null,
+  worktreeId: 'wt-1',
+  title: 'Terminal',
+  customTitle: null,
+  color: null,
+  sortOrder: 0,
+  createdAt: 0
+}
+
+const EDITOR_FILE = {
+  id: 'file-1',
+  tabId: 'unified-editor-1',
+  worktreeId: 'wt-1',
+  relativePath: 'foo.ts',
+  isDirty: false
+}
+
+describe('TabBar context menu wiring', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+    vi.stubGlobal('navigator', { userAgent: 'Mac' })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('counts every tab kind for SortableTab.tabCount', async () => {
+    // Why: Close Others used to pass tabCount=tabs.length, where tabs is just the
+    // terminal list. With one terminal + any number of editor/browser tabs, the
+    // menu item rendered as disabled even though closeOthers can close the
+    // non-terminal siblings.
+    const element = await renderTabBar({
+      tabs: [TERMINAL_TAB],
+      editorFiles: [EDITOR_FILE],
+      browserTabs: [],
+      tabBarOrder: ['term-1', 'unified-editor-1']
+    })
+    const sortable = findChildrenByType(element, 'SortableTab')
+    expect(sortable).toHaveLength(1)
+    expect(sortable[0].props.tabCount).toBe(2)
+  })
+
+  it('passes the editor unifiedTabId when EditorFileTab triggers onCloseToRight', async () => {
+    // Why: TabBar wires the editor tab as () => onCloseToRight(item.id). The
+    // emitted id is the editor's unifiedTabId (item.id for editors), not the
+    // file entityId. TabGroupPanel must accept this id shape to close right-side
+    // tabs from an editor tab — see the matching id|entityId resolver there.
+    const onCloseToRight = vi.fn()
+    const element = await renderTabBar({
+      tabs: [TERMINAL_TAB],
+      editorFiles: [EDITOR_FILE],
+      browserTabs: [],
+      tabBarOrder: ['term-1', 'unified-editor-1'],
+      onCloseToRight
+    })
+    const editorTabs = findChildrenByType(element, 'EditorFileTab')
+    expect(editorTabs).toHaveLength(1)
+    const onClose = editorTabs[0].props.onCloseToRight as () => void
+    onClose()
+    expect(onCloseToRight).toHaveBeenCalledWith('unified-editor-1')
+  })
+})

--- a/src/renderer/src/components/tab-bar/TabBar.tsx
+++ b/src/renderer/src/components/tab-bar/TabBar.tsx
@@ -384,7 +384,7 @@ function TabBarInner({
                 <SortableTab
                   key={item.id}
                   tab={item.data}
-                  tabCount={tabs.length}
+                  tabCount={orderedItems.length}
                   hasTabsToRight={index < orderedItems.length - 1}
                   isActive={activeTabType === 'terminal' && item.id === activeTabId}
                   isExpanded={expandedPaneByTabId[item.id] === true}

--- a/src/renderer/src/components/tab-group/TabGroupPanel.context-menu.test.ts
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.context-menu.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import type { Tab, TabContentType } from '../../../../shared/types'
+import { resolveGroupTabFromVisibleId } from './tab-group-visible-id'
+
+function tab(id: string, entityId: string, contentType: TabContentType, sortOrder: number): Tab {
+  return {
+    id,
+    entityId,
+    contentType,
+    groupId: 'group-1',
+    worktreeId: 'worktree-1',
+    label: id,
+    customLabel: null,
+    color: null,
+    sortOrder,
+    createdAt: sortOrder
+  }
+}
+
+describe('TabGroupPanel context menu id resolution', () => {
+  const groupTabs = [
+    tab('unified-terminal-1', 'terminal-entity-1', 'terminal', 0),
+    tab('unified-editor-1', 'editor-entity-1', 'editor', 1),
+    tab('unified-browser-1', 'browser-entity-1', 'browser', 2)
+  ]
+
+  it('resolves terminal and browser entity ids to their unified tab ids', () => {
+    // Why: terminal/browser context menu callbacks emit backing entity ids, but
+    // closeOthers/closeToRight must receive the unified tab id.
+    expect(resolveGroupTabFromVisibleId(groupTabs, 'terminal-entity-1')?.id).toBe(
+      'unified-terminal-1'
+    )
+    expect(resolveGroupTabFromVisibleId(groupTabs, 'browser-entity-1')?.id).toBe(
+      'unified-browser-1'
+    )
+  })
+
+  it('resolves editor unified tab ids without falling back to the file entity id only', () => {
+    // Why: editor tabs can have multiple visible tabs for one file. The menu
+    // emits the visible unified id so split groups close the selected copy.
+    expect(resolveGroupTabFromVisibleId(groupTabs, 'unified-editor-1')?.id).toBe('unified-editor-1')
+  })
+
+  it('returns null for ids that are not visible in the group', () => {
+    expect(resolveGroupTabFromVisibleId(groupTabs, 'missing-id')).toBeNull()
+  })
+})

--- a/src/renderer/src/components/tab-group/TabGroupPanel.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.tsx
@@ -14,6 +14,7 @@ import TerminalPane from '../terminal-pane/TerminalPane'
 import { browserSlotAnchorName } from '../browser-pane/browser-pane-slots'
 import { useTabGroupWorkspaceModel } from './useTabGroupWorkspaceModel'
 import TabGroupDropOverlay from './TabGroupDropOverlay'
+import { resolveGroupTabFromVisibleId } from './tab-group-visible-id'
 import {
   getTabPaneBodyDroppableId,
   type HoveredTabInsertion,
@@ -113,17 +114,13 @@ export default function TabGroupPanel({
         // Why: TabBar emits this with the entityId for terminals/browsers and
         // the unifiedTabId for editors (see TabBar's per-type wiring). Match
         // both so the menu works on every tab kind, not just terminals.
-        const item = model.groupTabs.find(
-          (candidate) => candidate.id === visibleId || candidate.entityId === visibleId
-        )
+        const item = resolveGroupTabFromVisibleId(model.groupTabs, visibleId)
         if (item) {
           commands.closeOthers(item.id)
         }
       }}
       onCloseToRight={(visibleId) => {
-        const item = model.groupTabs.find(
-          (candidate) => candidate.id === visibleId || candidate.entityId === visibleId
-        )
+        const item = resolveGroupTabFromVisibleId(model.groupTabs, visibleId)
         if (item) {
           commands.closeToRight(item.id)
         }

--- a/src/renderer/src/components/tab-group/TabGroupPanel.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.tsx
@@ -109,17 +109,20 @@ export default function TabGroupPanel({
           commands.closeItem(item.id)
         }
       }}
-      onCloseOthers={(terminalId) => {
+      onCloseOthers={(visibleId) => {
+        // Why: TabBar emits this with the entityId for terminals/browsers and
+        // the unifiedTabId for editors (see TabBar's per-type wiring). Match
+        // both so the menu works on every tab kind, not just terminals.
         const item = model.groupTabs.find(
-          (candidate) => candidate.entityId === terminalId && candidate.contentType === 'terminal'
+          (candidate) => candidate.id === visibleId || candidate.entityId === visibleId
         )
         if (item) {
           commands.closeOthers(item.id)
         }
       }}
-      onCloseToRight={(terminalId) => {
+      onCloseToRight={(visibleId) => {
         const item = model.groupTabs.find(
-          (candidate) => candidate.entityId === terminalId && candidate.contentType === 'terminal'
+          (candidate) => candidate.id === visibleId || candidate.entityId === visibleId
         )
         if (item) {
           commands.closeToRight(item.id)

--- a/src/renderer/src/components/tab-group/tab-group-visible-id.ts
+++ b/src/renderer/src/components/tab-group/tab-group-visible-id.ts
@@ -1,0 +1,11 @@
+import type { Tab } from '../../../../shared/types'
+
+export function resolveGroupTabFromVisibleId(
+  groupTabs: readonly Tab[],
+  visibleId: string
+): Tab | null {
+  return (
+    groupTabs.find((candidate) => candidate.id === visibleId || candidate.entityId === visibleId) ??
+    null
+  )
+}


### PR DESCRIPTION
## Summary

Fixes two regressions in the tab context menu when a tab group contains non-terminal tabs:

- **"Close Tabs To The Right" silently no-op'd on editor and browser tabs.** The handler in `TabGroupPanel` filtered `groupTabs` to `contentType === 'terminal'` and matched only on `entityId`, but `TabBar` emits the `unifiedTabId` for editor tabs and the `entityId` for browser tabs (see `TabBar.tsx` per-tab wiring). Matching by `id` OR `entityId` resolves the tab regardless of kind.
- **"Close Others" rendered as disabled with mixed tab kinds.** `SortableTab.tabCount` was wired to `tabs.length`, where `tabs` is the terminal-only list. With one terminal + any number of editor/browser tabs, the menu disabled itself even though `closeOthers` can close the non-terminal siblings. Use `orderedItems.length` (the full visible tab strip) instead.

## Testing

- [x] `pnpm lint` (passes with the same 6 pre-existing warnings in `github-project/*` unrelated to this PR)
- [x] `pnpm typecheck`
- [x] `pnpm test` — added 2 new tests in `TabBar.context-menu.test.ts`. The 2 failing tests in `node-pty-fd-leak.test.ts` reproduce on `main` without my changes (macOS posix_spawn error message format mismatch), so they are pre-existing and unrelated.
- [x] `pnpm build`
- [x] Added high-quality regression tests covering the SortableTab `tabCount` propagation with mixed tab kinds, and that `EditorFileTab.onCloseToRight` emits the editor's `unifiedTabId` (which `TabGroupPanel` must accept).

No visual change. Manually verified the menu items now work on editor, browser, and terminal tabs in a single tab group.

## AI Review Report

Reviewed for correctness, cross-platform compatibility, and regression risk. The change is purely a renderer-side fix in `TabGroupPanel.tsx` and `TabBar.tsx`; no platform-specific code, IPC, paths, or shortcuts are touched, so macOS, Linux, and Windows behavior is identical.

The new id-resolver in `TabGroupPanel` accepts both `unifiedTabId` and `entityId`; collisions between those id spaces are not a concern in practice (both are UUID-like and live in disjoint maps), but the function still calls back into `commands.closeOthers`/`closeToRight` with the resolved `unifiedTabId`, which is the canonical id used by the workspace model and store. The `tabCount` change preserves the existing `<= 1` threshold semantics, just applied to the correct denominator.

## Security Audit

No new IPC handlers, no command execution, no path handling, no auth or secret handling, no dependency changes, no renderer access to arbitrary file paths. The change only adjusts in-renderer wiring between the context menu and the existing close commands.

## Notes

X/Twitter handle: https://x.com/Crilofer
