### PR TITLE
fix(worktree): allow Unicode letters/numbers in workspace names

### DIFF
--- a/src/main/ipc/worktree-logic.test.ts
+++ b/src/main/ipc/worktree-logic.test.ts
@@ -51,6 +51,20 @@ describe('sanitizeWorktreeName', () => {
     expect(sanitizeWorktreeName('a..b...c')).toBe('a.b.c')
   })
 
+  it('preserves non-ASCII letters and numbers', () => {
+    // Why: users name workspaces in their own language (CJK, accented Latin,
+    // Cyrillic, etc.). Stripping these to ASCII left the name empty and threw
+    // "Invalid worktree name" on every non-Latin keyboard input.
+    expect(sanitizeWorktreeName('中文')).toBe('中文')
+    expect(sanitizeWorktreeName('日本語 テスト')).toBe('日本語-テスト')
+    expect(sanitizeWorktreeName('café-déjà')).toBe('café-déjà')
+    expect(sanitizeWorktreeName('Привет мир')).toBe('Привет-мир')
+  })
+
+  it('still strips git-unsafe punctuation around Unicode names', () => {
+    expect(sanitizeWorktreeName('feat: 中文 (v2)')).toBe('feat-中文-v2')
+  })
+
   it('throws for empty name', () => {
     expect(() => sanitizeWorktreeName('')).toThrow('Invalid worktree name')
   })

--- a/src/main/ipc/worktree-logic.ts
+++ b/src/main/ipc/worktree-logic.ts
@@ -7,11 +7,13 @@ import { getWslHome, parseWslPath } from '../wsl'
  * Strips unsafe characters and collapses runs of special chars to a single hyphen.
  */
 export function sanitizeWorktreeName(input: string): string {
+  // Why: keep Unicode letters/numbers (CJK, accented Latin, etc.) so users can
+  // name workspaces in their own language. Git ref-format permits non-ASCII
+  // bytes, and modern filesystems handle UTF-8 paths. Only strip characters
+  // git or the filesystem actually rejects.
   const sanitized = input
     .trim()
-    .replace(/[\\/]+/g, '-')
-    .replace(/\s+/g, '-')
-    .replace(/[^A-Za-z0-9._-]+/g, '-')
+    .replace(/[^\p{L}\p{N}._-]+/gu, '-')
     .replace(/-+/g, '-')
     // Why: git check-ref-format rejects any ref containing `..`, so a prompt
     // like "../../foo" that survives slugification as `..-..-foo` would


### PR DESCRIPTION
## Summary
- Typing a CJK / non-ASCII workspace name (e.g. `中文`) into the Create Workspace dialog threw "Invalid worktree name". The sanitizer's allowlist `[^A-Za-z0-9._-]+` stripped every non-ASCII char, leaving an empty string after the trailing-hyphen trim.
- Switch to a Unicode-aware allowlist (`[^\p{L}\p{N}._-]+/u`). Git ref-format and modern filesystems accept UTF-8, so there's no reason to forbid these.
- Bug introduced in #102 (`4c0eee23`) when the sanitizer was first extracted.

## Test plan
- [x] `pnpm exec vitest run src/main/ipc/worktree-logic.test.ts` (43/43 passing)
- [x] New cases cover `中文`, `日本語 テスト`, `café-déjà`, `Привет мир`, and mixed punctuation
- [ ] Manual: cmd+N → Name tab → type `中文` → workspace creates successfully

Made with [Orca](https://github.com/stablyai/orca) 🐋
