### PR TITLE
Fix SSH host loss crashing Orca

### DIFF
--- a/src/main/ssh/ssh-channel-multiplexer.test.ts
+++ b/src/main/ssh/ssh-channel-multiplexer.test.ts
@@ -179,6 +179,16 @@ describe('SshChannelMultiplexer', () => {
       const lastFrame = transport.written.at(-1)!
       expect(lastFrame[0]).toBe(MessageType.KeepAlive)
     })
+
+    it('turns transport write failures into connection loss instead of throwing from the timer', () => {
+      const writeError = new Error('write EPIPE')
+      transport.write = vi.fn(() => {
+        throw writeError
+      })
+
+      expect(() => vi.advanceTimersByTime(5_000)).not.toThrow()
+      expect(mux.isDisposed()).toBe(true)
+    })
   })
 
   describe('dispose', () => {

--- a/src/main/ssh/ssh-channel-multiplexer.ts
+++ b/src/main/ssh/ssh-channel-multiplexer.ts
@@ -201,7 +201,14 @@ export class SshChannelMultiplexer {
     const seq = this.nextOutgoingSeq++
     const frame = encodeJsonRpcFrame(msg, seq, this.highestReceivedSeq)
     this.unackedTimestamps.set(seq, Date.now())
-    this.transport.write(frame)
+    try {
+      this.transport.write(frame)
+    } catch (err) {
+      // Why: a remote reboot can make the SSH channel's stdin throw EPIPE
+      // from a timer/request path. Scope it to this mux instead of letting
+      // the Electron main process treat it as an uncaught exception.
+      this.handleProtocolError(err)
+    }
   }
 
   private sendKeepAlive(): void {
@@ -211,7 +218,13 @@ export class SshChannelMultiplexer {
     const seq = this.nextOutgoingSeq++
     const frame = encodeKeepAliveFrame(seq, this.highestReceivedSeq)
     this.unackedTimestamps.set(seq, Date.now())
-    this.transport.write(frame)
+    try {
+      this.transport.write(frame)
+    } catch (err) {
+      // Why: keepalive runs on an interval; without catching transport
+      // write failures here, a dead SSH host can terminate the whole app.
+      this.handleProtocolError(err)
+    }
   }
 
   private handleFrame(frame: DecodedFrame): void {

--- a/src/main/ssh/ssh-port-forward.ts
+++ b/src/main/ssh/ssh-port-forward.ts
@@ -69,6 +69,7 @@ export class SshPortForwardManager {
         }
         socket.pipe(channel).pipe(socket)
         channel.on('close', () => socket.destroy())
+        channel.on('error', () => socket.destroy())
         socket.on('close', () => channel.close())
       })
     })

--- a/src/main/ssh/ssh-relay-deploy-helpers.test.ts
+++ b/src/main/ssh/ssh-relay-deploy-helpers.test.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'events'
 import { describe, expect, it, vi } from 'vitest'
 import type { ClientChannel } from 'ssh2'
-import { waitForSentinel } from './ssh-relay-deploy-helpers'
+import { execCommand, waitForSentinel } from './ssh-relay-deploy-helpers'
 import { RELAY_SENTINEL } from './relay-protocol'
 
 function createMockChannel(): ClientChannel {
@@ -38,5 +38,40 @@ describe('waitForSentinel', () => {
     transport.onData((chunk) => chunks.push(chunk.toString('utf-8')))
 
     expect(chunks).toEqual(['same-chunk-frame'])
+  })
+
+  it('rejects on relay channel errors before the sentinel instead of emitting uncaught errors', async () => {
+    const channel = createMockChannel()
+    const transportPromise = waitForSentinel(channel)
+
+    expect(() => channel.emit('error', new Error('remote host rebooted'))).not.toThrow()
+    await expect(transportPromise).rejects.toThrow('remote host rebooted')
+  })
+
+  it('notifies transport close subscribers on relay channel errors after the sentinel', async () => {
+    const channel = createMockChannel()
+    const transportPromise = waitForSentinel(channel)
+
+    channel.emit('data', Buffer.from(RELAY_SENTINEL))
+    const transport = await transportPromise
+    const onClose = vi.fn()
+    transport.onClose(onClose)
+
+    expect(() => channel.emit('error', new Error('remote host rebooted'))).not.toThrow()
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('execCommand', () => {
+  it('rejects on command channel errors instead of emitting uncaught errors', async () => {
+    const channel = createMockChannel()
+    const conn = {
+      exec: vi.fn().mockResolvedValue(channel)
+    }
+    const commandPromise = execCommand(conn as never, 'uname -sm')
+
+    await Promise.resolve()
+    expect(() => channel.emit('error', new Error('remote host rebooted'))).not.toThrow()
+    await expect(commandPromise).rejects.toThrow('remote host rebooted')
   })
 })

--- a/src/main/ssh/ssh-relay-deploy-helpers.ts
+++ b/src/main/ssh/ssh-relay-deploy-helpers.ts
@@ -10,12 +10,14 @@ export { uploadFile, uploadDirectory, mkdirSftp } from './sftp-upload'
 export function waitForSentinel(channel: ClientChannel): Promise<MultiplexerTransport> {
   return new Promise<MultiplexerTransport>((resolve, reject) => {
     let sentinelReceived = false
+    let settled = false
     let stderrOutput = ''
     let bufferedStdout = Buffer.alloc(0)
     let closedAfterSentinel = false
 
     const timeout = setTimeout(() => {
-      if (!sentinelReceived) {
+      if (!settled) {
+        settled = true
         channel.close()
         reject(
           new Error(
@@ -36,20 +38,48 @@ export function waitForSentinel(channel: ClientChannel): Promise<MultiplexerTran
     const dataCallbacks: ((data: Buffer) => void)[] = []
     const closeCallbacks: (() => void)[] = []
 
-    channel.on('close', () => {
-      if (!sentinelReceived) {
-        clearTimeout(timeout)
-        reject(
-          new Error(
-            `Relay process exited before ready.${stderrOutput ? ` stderr: ${stderrOutput.trim()}` : ''}`
-          )
-        )
+    const notifyClosed = (): void => {
+      if (closedAfterSentinel) {
         return
       }
       closedAfterSentinel = true
       for (const cb of closeCallbacks) {
         cb()
       }
+    }
+
+    const failOrClose = (err: Error): void => {
+      clearTimeout(timeout)
+      if (!sentinelReceived) {
+        if (!settled) {
+          settled = true
+          reject(err)
+        }
+        return
+      }
+      notifyClosed()
+    }
+
+    // Why: SSH channel streams emit `error` when the remote host disappears.
+    // Unhandled EventEmitter errors are process-fatal, so convert them into
+    // startup rejection before the sentinel and transport close after it.
+    channel.on('error', (err: Error) => failOrClose(err))
+    channel.stderr.on('error', (err: Error) => failOrClose(err))
+
+    channel.on('close', () => {
+      if (!sentinelReceived) {
+        clearTimeout(timeout)
+        if (!settled) {
+          settled = true
+          reject(
+            new Error(
+              `Relay process exited before ready.${stderrOutput ? ` stderr: ${stderrOutput.trim()}` : ''}`
+            )
+          )
+        }
+        return
+      }
+      notifyClosed()
     })
 
     // Why: data arriving in the same TCP chunk as the sentinel is buffered
@@ -88,6 +118,7 @@ export function waitForSentinel(channel: ClientChannel): Promise<MultiplexerTran
         if (afterSentinel.length > 0) {
           pendingAfterSentinel = afterSentinel
         }
+        settled = true
 
         const transport: MultiplexerTransport = {
           write: (buf: Buffer) => channel.stdin.write(buf),
@@ -139,6 +170,19 @@ export async function execCommand(conn: SshConnection, command: string): Promise
       }
     }, EXEC_TIMEOUT_MS)
 
+    const fail = (err: Error): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      clearTimeout(timeout)
+      reject(err)
+    }
+
+    // Why: remote reboot tears down exec channels with stream errors. Without
+    // scoped listeners, Node treats those as uncaught exceptions.
+    channel.on('error', fail)
+    channel.stderr.on('error', fail)
     channel.on('data', (data: Buffer) => {
       stdout += data.toString('utf-8')
     })

--- a/src/main/ssh/ssh-relay-deploy.ts
+++ b/src/main/ssh/ssh-relay-deploy.ts
@@ -345,7 +345,9 @@ async function launchRelay(
   const launchCmd = `cd ${escapedDir} && nohup ${escapedNode} relay.js --detached --grace-time ${graceTime} --sock-path ${shellEscape(sockFile)} > ${shellEscape(logFile)} 2>&1 </dev/null &`
   const launchChannel = await conn.exec(launchCmd)
   launchChannel.on('data', () => {})
+  launchChannel.on('error', () => {})
   launchChannel.stderr.on('data', () => {})
+  launchChannel.stderr.on('error', () => {})
   // Why: the shell exits quickly (nohup ... &), but the SSH channel stays
   // open until all child fds close. Explicitly closing it after the poll
   // loop prevents channel accumulation across relay restarts, which would


### PR DESCRIPTION
## Summary
- handle SSH relay transport write failures as scoped connection loss instead of uncaught exceptions
- add channel error handlers for relay startup/exec paths and port-forward channels
- add regression coverage for remote-host-loss style channel errors

Fixes #1640

## Test Plan
- pnpm vitest run --config config/vitest.config.ts src/main/ssh/ssh-channel-multiplexer.test.ts src/main/ssh/ssh-relay-deploy-helpers.test.ts src/main/ssh/ssh-port-forward.test.ts
- pnpm vitest run --config config/vitest.config.ts src/main/ssh src/main/ipc/ssh.test.ts src/main/ipc/ssh-browse.ts src/main/ipc/filesystem-import-ssh.test.ts
- pnpm run tc:node
- pnpm oxlint src/main/ssh/ssh-channel-multiplexer.ts src/main/ssh/ssh-relay-deploy-helpers.ts src/main/ssh/ssh-relay-deploy.ts src/main/ssh/ssh-port-forward.ts src/main/ssh/ssh-channel-multiplexer.test.ts src/main/ssh/ssh-relay-deploy-helpers.test.ts