### PR TITLE
refactor(sidebar): tidy worktree list group header layout

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -384,7 +384,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                   role="button"
                   tabIndex={0}
                   className={cn(
-                    'group flex h-7 w-full items-center gap-1.5 px-1.5 text-left transition-all cursor-pointer',
+                    'group flex h-7 w-full items-center gap-1.5 pl-3 pr-1.5 text-left transition-all cursor-pointer',
                     // First header sits directly under SidebarHeader, which already
                     // supplies its own spacing — only offset secondary group headers.
                     vItem.index !== firstHeaderIndex && 'mt-2',
@@ -402,11 +402,10 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                     <div
                       className={cn(
                         'flex size-4 shrink-0 items-center justify-center rounded-[4px]',
-                        row.repo ? 'text-foreground' : ''
+                        row.repo && 'text-muted-foreground'
                       )}
-                      style={row.repo ? { color: row.repo.badgeColor } : undefined}
                     >
-                      <row.icon className="size-3" />
+                      <row.icon className="size-3.5" />
                     </div>
                   ) : null}
 
@@ -421,6 +420,15 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                     </div>
                   </div>
 
+                  <div className="flex size-4 shrink-0 items-center justify-center text-muted-foreground/60 opacity-0 group-hover:opacity-100 transition-opacity">
+                    <ChevronDown
+                      className={cn(
+                        'size-3.5 transition-transform',
+                        collapsedGroups.has(row.key) && '-rotate-90'
+                      )}
+                    />
+                  </div>
+
                   {row.repo ? (
                     <Tooltip>
                       <TooltipTrigger asChild>
@@ -428,7 +436,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                           type="button"
                           variant="ghost"
                           size="icon-xs"
-                          className="mr-0.5 size-5 shrink-0 rounded-md text-muted-foreground hover:bg-accent/70 hover:text-foreground opacity-0 group-hover:opacity-100 transition-opacity"
+                          className="mr-0.5 size-5 shrink-0 rounded-md text-muted-foreground hover:bg-accent/70 hover:text-foreground transition-opacity"
                           aria-label={`Create worktree for ${row.label}`}
                           onClick={(event) => {
                             event.preventDefault()
@@ -449,15 +457,6 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                       </TooltipContent>
                     </Tooltip>
                   ) : null}
-
-                  <div className="flex size-4 shrink-0 items-center justify-center text-muted-foreground/60 opacity-0 group-hover:opacity-100 transition-opacity">
-                    <ChevronDown
-                      className={cn(
-                        'size-3.5 transition-transform',
-                        collapsedGroups.has(row.key) && '-rotate-90'
-                      )}
-                    />
-                  </div>
                 </div>
               </div>
             )

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -384,7 +384,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                   role="button"
                   tabIndex={0}
                   className={cn(
-                    'group flex h-7 w-full items-center gap-1.5 pl-3 pr-1.5 text-left transition-all cursor-pointer',
+                    'group flex h-7 w-full items-center gap-1.5 pl-3 pr-1 text-left transition-all cursor-pointer',
                     // First header sits directly under SidebarHeader, which already
                     // supplies its own spacing — only offset secondary group headers.
                     vItem.index !== firstHeaderIndex && 'mt-2',
@@ -436,7 +436,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                           type="button"
                           variant="ghost"
                           size="icon-xs"
-                          className="mr-0.5 size-5 shrink-0 rounded-md text-muted-foreground hover:bg-accent/70 hover:text-foreground transition-opacity"
+                          className="size-5 shrink-0 rounded-md text-muted-foreground hover:bg-accent/70 hover:text-foreground transition-opacity"
                           aria-label={`Create worktree for ${row.label}`}
                           onClick={(event) => {
                             event.preventDefault()

--- a/src/renderer/src/components/sidebar/worktree-list-groups.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.ts
@@ -2,7 +2,7 @@ import {
   CircleCheckBig,
   CircleDot,
   CircleX,
-  FolderGit2,
+  Folder,
   GitPullRequest,
   LayoutList,
   Pin
@@ -62,7 +62,7 @@ export const PR_GROUP_META: Record<
 
 export const REPO_GROUP_META = {
   tone: 'text-foreground',
-  icon: FolderGit2
+  icon: Folder
 } as const
 
 export const PINNED_GROUP_KEY = 'pinned'


### PR DESCRIPTION
## Summary
- Move the collapse chevron next to the group label in the worktree sidebar group header
- Swap the repo group icon from `FolderGit2` (colored) to a neutral muted `Folder`
- Adjust group header padding (`pl-3 pr-1.5`) for better alignment with row contents

## Test plan
- [ ] Sidebar group headers render with chevron on the left of the create button
- [ ] Repo group icon is muted-foreground, not the per-repo badge color
- [ ] Collapse/expand still works on group headers

Made with [Orca](https://github.com/stablyai/orca) 🐋
