### PR TITLE
fix: cmd+t always opens terminal in central pane

### DIFF
--- a/src/main/browser/browser-guest-ui.ts
+++ b/src/main/browser/browser-guest-ui.ts
@@ -284,12 +284,10 @@ export function setupGuestShortcutForwarding(args: {
     if (input.code === 'KeyB' && input.shift) {
       renderer.send('ui:newBrowserTab')
     } else if (input.code === 'KeyT' && !input.shift) {
-      // Why: once focus is inside a browser guest, Cmd/Ctrl+T should extend
-      // the current browser workspace with another internal page instead of
-      // creating a sibling Orca terminal tab. The renderer still decides
-      // whether that means "new page in this workspace" or "new workspace"
-      // based on the current active surface.
-      renderer.send('ui:newBrowserTab')
+      // Why: Cmd/Ctrl+T always opens a new terminal in the central pane,
+      // even when focus is inside a browser guest. Cmd/Ctrl+Shift+B is the
+      // dedicated shortcut for new browser tabs.
+      renderer.send('ui:newTerminalTab')
     } else if (input.code === 'KeyL' && !input.shift) {
       // Why: the address bar lives in the renderer chrome, not the guest
       // page. Forward Cmd/Ctrl+L out of the guest so the active BrowserPane

--- a/src/main/browser/browser-manager.test.ts
+++ b/src/main/browser/browser-manager.test.ts
@@ -1093,7 +1093,7 @@ describe('browserManager', () => {
     }
 
     expect(rendererSendMock).toHaveBeenNthCalledWith(1, 'ui:newBrowserTab')
-    expect(rendererSendMock).toHaveBeenNthCalledWith(2, 'ui:newBrowserTab')
+    expect(rendererSendMock).toHaveBeenNthCalledWith(2, 'ui:newTerminalTab')
     expect(rendererSendMock).toHaveBeenNthCalledWith(3, 'ui:closeActiveTab')
     expect(rendererSendMock).toHaveBeenNthCalledWith(4, 'ui:switchTab', 1)
     expect(rendererSendMock).toHaveBeenNthCalledWith(5, 'ui:switchTerminalTab', 1)

--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -881,18 +881,13 @@ function Terminal(): React.JSX.Element | null {
     const isMac = navigator.userAgent.includes('Mac')
     const onKeyDown = (e: KeyboardEvent): void => {
       const mod = isMac ? e.metaKey : e.ctrlKey
-      // Why: when the browser workspace is the active surface, standard
-      // browser tab creation should stay inside that workspace. Reusing the
-      // same shortcut keeps Orca's embedded browser aligned with user
-      // expectations instead of unexpectedly mutating the outer tab strip.
+      // Why: Cmd/Ctrl+T always opens a new terminal, regardless of which
+      // surface is active. Browser-tab creation has its own shortcut
+      // (Cmd/Ctrl+Shift+B) so users have a predictable way to spawn a
+      // terminal from anywhere in the central pane.
       if (mod && e.key === 't' && !e.shiftKey && !e.repeat) {
         e.preventDefault()
-        const state = useAppStore.getState()
-        if (state.activeTabType === 'browser') {
-          handleNewBrowserTab()
-        } else {
-          handleNewTab()
-        }
+        handleNewTab()
         return
       }
 


### PR DESCRIPTION
## Summary
- Cmd/Ctrl+T now always opens a new terminal in the central pane, even when a browser tab is the active surface or focus is inside a browser guest webview. Previously it would create a new browser tab in those cases.
- Cmd/Ctrl+Shift+B remains the dedicated shortcut for new browser tabs.

## Test plan
- [x] Cmd+T from terminal surface → new terminal tab (regression check)
- [x] Cmd+Shift+B → new browser tab
- [x] Cmd+T with focus inside browser guest webview → new terminal tab (the fix)
- [x] `pnpm vitest run src/main/browser/browser-manager.test.ts` passes

Made with [Orca](https://github.com/stablyai/orca) 🐋
