### PR TITLE
fix(status-bar): hide usage bars for agents not on PATH

### DIFF
--- a/src/renderer/src/components/settings/AppearancePane.tsx
+++ b/src/renderer/src/components/settings/AppearancePane.tsx
@@ -7,6 +7,7 @@ import { matchesSettingsSearch, type SettingsSearchEntry } from './settings-sear
 import { useAppStore } from '../../store'
 import { FontAutocomplete } from './SettingsFormControls'
 import { DEFAULT_APP_FONT_FAMILY } from '../../../../shared/constants'
+import { useAvailableStatusBarToggles } from '../status-bar/use-available-status-bar-toggles'
 
 type AppearancePaneProps = {
   settings: GlobalSettings
@@ -154,6 +155,7 @@ export function AppearancePane({
   const zoomOutLabel = isMac ? '⌘-' : 'Ctrl -'
   const statusBarItems = useAppStore((state) => state.statusBarItems)
   const toggleStatusBarItem = useAppStore((state) => state.toggleStatusBarItem)
+  const visibleStatusBarToggles = useAvailableStatusBarToggles(STATUS_BAR_TOGGLES)
 
   const visibleSections = [
     matchesSettingsSearch(searchQuery, THEME_ENTRIES) ? (
@@ -329,7 +331,7 @@ export function AppearancePane({
           </p>
         </div>
 
-        {STATUS_BAR_TOGGLES.map((toggle) => {
+        {visibleStatusBarToggles.map((toggle) => {
           const enabled = statusBarItems.includes(toggle.id)
           return (
             <SearchableSetting

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -751,17 +751,20 @@ function StatusBarInner(): React.JSX.Element | null {
     }
   }, [])
 
+  const refreshDetectedAgents = useAppStore((s) => s.refreshDetectedAgents)
   const handleRefresh = useCallback(async () => {
     if (isRefreshing) {
       return
     }
     setIsRefreshing(true)
     try {
-      await refreshRateLimits()
+      // Why: also re-run PATH detection so a freshly-installed CLI's bar
+      // appears (and a removed CLI's bar hides) without restarting Orca.
+      await Promise.all([refreshRateLimits(), refreshDetectedAgents()])
     } finally {
       setIsRefreshing(false)
     }
-  }, [isRefreshing, refreshRateLimits])
+  }, [isRefreshing, refreshRateLimits, refreshDetectedAgents])
 
   if (!statusBarVisible) {
     return null

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -26,6 +26,7 @@ import { markLiveCodexSessionsForRestart } from '@/lib/codex-session-restart'
 import { SshStatusSegment } from './SshStatusSegment'
 import { UpdateStatusSegment } from './UpdateStatusSegment'
 import { ResourceUsageStatusSegment } from './ResourceUsageStatusSegment'
+import { isStatusBarItemAvailable } from './status-bar-agent-gating'
 import { PetStatusSegment } from './PetStatusSegment'
 
 function getCodexAccountLabel(
@@ -697,6 +698,13 @@ function StatusBarInner(): React.JSX.Element | null {
   const refreshRateLimits = useAppStore((s) => s.refreshRateLimits)
   const statusBarVisible = useAppStore((s) => s.statusBarVisible)
   const statusBarItems = useAppStore((s) => s.statusBarItems)
+  // Why: usage bars exist to surface CLI rate limits — showing one for an
+  // agent that isn't on the user's PATH is just noise (e.g. a fresh Ubuntu
+  // install showing "Gemini Usage" with no Gemini CLI installed). We gate
+  // the per-CLI bars on detection so the surface stays self-pruning, and
+  // re-show automatically once the agent appears on PATH.
+  const detectedAgentIds = useAppStore((s) => s.detectedAgentIds)
+  const ensureDetectedAgents = useAppStore((s) => s.ensureDetectedAgents)
   // Why: pet segment intentionally does NOT participate in statusBarItems
   // (see design doc — gating with both the experimental flag and a
   // statusBarItems checkbox would double-toggle the surface). It is driven
@@ -716,6 +724,14 @@ function StatusBarInner(): React.JSX.Element | null {
     window.addEventListener(CLOSE_ALL_CONTEXT_MENUS_EVENT, closeMenu)
     return () => window.removeEventListener(CLOSE_ALL_CONTEXT_MENUS_EVENT, closeMenu)
   }, [])
+
+  // Why: trigger PATH-based agent detection on mount so the per-CLI usage
+  // bars (Claude/Codex/Gemini) can hide themselves when the user doesn't
+  // have those CLIs installed. The slice deduplicates concurrent callers,
+  // so this is safe even if other surfaces also call it.
+  useEffect(() => {
+    void ensureDetectedAgents()
+  }, [ensureDetectedAgents])
 
   const containerRefCallback = useCallback((node: HTMLDivElement | null) => {
     if (resizeObserverRef.current) {
@@ -756,13 +772,27 @@ function StatusBarInner(): React.JSX.Element | null {
   // Why: hiding `unavailable` providers makes the status bar appear to lose a
   // provider at random after refreshes or wake/resume. Keeping the slot visible
   // preserves layout stability and makes it obvious that the provider is still
-  // configured but currently unavailable.
-  const showClaude = claude && statusBarItems.includes('claude')
-  const showCodex = codex && statusBarItems.includes('codex')
+  // configured but currently unavailable. Detection-gating (see
+  // status-bar-agent-gating) hides the per-CLI bars when the agent isn't
+  // installed on PATH — this is what stops a fresh install from showing
+  // "Gemini Usage" when Gemini isn't installed.
+  const showClaude =
+    !!claude &&
+    statusBarItems.includes('claude') &&
+    isStatusBarItemAvailable('claude', detectedAgentIds)
+  const showCodex =
+    !!codex &&
+    statusBarItems.includes('codex') &&
+    isStatusBarItemAvailable('codex', detectedAgentIds)
   // Why: hide only when the state hasn't loaded yet (null), not when unavailable.
   // Gemini shows if credentials exist; OpenCode Go shows always so users can see
   // the provider and know to configure the cookie in Settings.
-  const showGemini = gemini !== null && statusBarItems.includes('gemini')
+  const showGemini =
+    gemini !== null &&
+    statusBarItems.includes('gemini') &&
+    isStatusBarItemAvailable('gemini', detectedAgentIds)
+  // Why: OpenCode Go is a web/cookie-auth provider, not a CLI on PATH, so
+  // detection-gating doesn't apply.
   const showOpencodeGo = opencodeGo !== null && statusBarItems.includes('opencode-go')
   const showSsh = statusBarItems.includes('ssh')
   const showResourceUsage = statusBarItems.includes('resource-usage')
@@ -854,27 +884,33 @@ function StatusBarInner(): React.JSX.Element | null {
           />
         </DropdownMenuTrigger>
         <DropdownMenuContent className="min-w-0 w-fit" sideOffset={0} align="start">
-          <DropdownMenuCheckboxItem
-            checked={statusBarItems.includes('claude')}
-            onCheckedChange={() => toggleStatusBarItem('claude')}
-          >
-            <ClaudeIcon size={14} />
-            Claude Usage
-          </DropdownMenuCheckboxItem>
-          <DropdownMenuCheckboxItem
-            checked={statusBarItems.includes('codex')}
-            onCheckedChange={() => toggleStatusBarItem('codex')}
-          >
-            <OpenAIIcon size={14} />
-            Codex Usage
-          </DropdownMenuCheckboxItem>
-          <DropdownMenuCheckboxItem
-            checked={statusBarItems.includes('gemini')}
-            onCheckedChange={() => toggleStatusBarItem('gemini')}
-          >
-            <GeminiIcon size={14} />
-            Gemini Usage
-          </DropdownMenuCheckboxItem>
+          {isStatusBarItemAvailable('claude', detectedAgentIds) && (
+            <DropdownMenuCheckboxItem
+              checked={statusBarItems.includes('claude')}
+              onCheckedChange={() => toggleStatusBarItem('claude')}
+            >
+              <ClaudeIcon size={14} />
+              Claude Usage
+            </DropdownMenuCheckboxItem>
+          )}
+          {isStatusBarItemAvailable('codex', detectedAgentIds) && (
+            <DropdownMenuCheckboxItem
+              checked={statusBarItems.includes('codex')}
+              onCheckedChange={() => toggleStatusBarItem('codex')}
+            >
+              <OpenAIIcon size={14} />
+              Codex Usage
+            </DropdownMenuCheckboxItem>
+          )}
+          {isStatusBarItemAvailable('gemini', detectedAgentIds) && (
+            <DropdownMenuCheckboxItem
+              checked={statusBarItems.includes('gemini')}
+              onCheckedChange={() => toggleStatusBarItem('gemini')}
+            >
+              <GeminiIcon size={14} />
+              Gemini Usage
+            </DropdownMenuCheckboxItem>
+          )}
           <DropdownMenuCheckboxItem
             checked={statusBarItems.includes('opencode-go')}
             onCheckedChange={() => toggleStatusBarItem('opencode-go')}

--- a/src/renderer/src/components/status-bar/status-bar-agent-gating.test.ts
+++ b/src/renderer/src/components/status-bar/status-bar-agent-gating.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { isStatusBarItemAvailable } from './status-bar-agent-gating'
+
+describe('isStatusBarItemAvailable', () => {
+  it('shows non-CLI items regardless of detection', () => {
+    // Why: ssh, resource-usage, and opencode-go aren't CLIs on PATH, so
+    // detection results don't apply.
+    expect(isStatusBarItemAvailable('ssh', null)).toBe(true)
+    expect(isStatusBarItemAvailable('ssh', [])).toBe(true)
+    expect(isStatusBarItemAvailable('resource-usage', [])).toBe(true)
+    expect(isStatusBarItemAvailable('opencode-go', [])).toBe(true)
+  })
+
+  it('keeps CLI items visible while detection is in flight', () => {
+    // Why: pre-detection (null) we don't yet know what the user has, so we
+    // don't want a flash of empty status bar on cold start.
+    expect(isStatusBarItemAvailable('claude', null)).toBe(true)
+    expect(isStatusBarItemAvailable('codex', null)).toBe(true)
+    expect(isStatusBarItemAvailable('gemini', null)).toBe(true)
+  })
+
+  it('hides CLI items not detected on PATH', () => {
+    expect(isStatusBarItemAvailable('claude', [])).toBe(false)
+    expect(isStatusBarItemAvailable('codex', ['claude'])).toBe(false)
+    expect(isStatusBarItemAvailable('gemini', ['claude', 'codex'])).toBe(false)
+  })
+
+  it('shows CLI items detected on PATH', () => {
+    expect(isStatusBarItemAvailable('claude', ['claude'])).toBe(true)
+    expect(isStatusBarItemAvailable('codex', ['codex', 'claude'])).toBe(true)
+    expect(isStatusBarItemAvailable('gemini', ['gemini'])).toBe(true)
+  })
+})

--- a/src/renderer/src/components/status-bar/status-bar-agent-gating.ts
+++ b/src/renderer/src/components/status-bar/status-bar-agent-gating.ts
@@ -1,0 +1,22 @@
+import type { StatusBarItem, TuiAgent } from '../../../../shared/types'
+
+// Why: Claude/Codex/Gemini usage bars are surface noise when the underlying
+// CLI isn't installed (e.g. a fresh Ubuntu install showing "Gemini Usage"
+// when no Gemini CLI is on PATH). We hide both the bar and its toggle when
+// PATH detection reports the agent as missing. Pre-detection (null) keeps
+// the legacy behavior so the bar/toggle don't flicker on cold start, and
+// re-show automatically once the agent appears on PATH.
+const CLI_GATED_ITEMS: ReadonlySet<StatusBarItem> = new Set(['claude', 'codex', 'gemini'])
+
+export function isStatusBarItemAvailable(
+  id: StatusBarItem,
+  detectedAgentIds: TuiAgent[] | null
+): boolean {
+  if (!CLI_GATED_ITEMS.has(id)) {
+    return true
+  }
+  if (detectedAgentIds === null) {
+    return true
+  }
+  return detectedAgentIds.includes(id as TuiAgent)
+}

--- a/src/renderer/src/components/status-bar/use-available-status-bar-toggles.ts
+++ b/src/renderer/src/components/status-bar/use-available-status-bar-toggles.ts
@@ -1,0 +1,12 @@
+import { useAppStore } from '../../store'
+import type { StatusBarItem } from '../../../../shared/types'
+import { isStatusBarItemAvailable } from './status-bar-agent-gating'
+
+/** Subscribes to detected-agent state and returns the toggles filtered to
+ *  those whose underlying CLI is installed (or pre-detection). */
+export function useAvailableStatusBarToggles<T extends { id: StatusBarItem }>(
+  toggles: readonly T[]
+): T[] {
+  const detectedAgentIds = useAppStore((s) => s.detectedAgentIds)
+  return toggles.filter((t) => isStatusBarItemAvailable(t.id, detectedAgentIds))
+}


### PR DESCRIPTION
## Why

Fresh installs (e.g. on Ubuntu) showed usage bars like "Gemini Usage" in the status bar even when the user didn't have that agent's CLI installed. Same for the right-click status-bar context menu and the Settings → Appearance → Status Bar toggles.

## What

Gate the Claude / Codex / Gemini usage bars + their toggles on the existing `preflight.detectAgents` result (which runs `which <cmd>` in a login shell). When the agent isn't on PATH:

- The usage bar is hidden in the status bar.
- The corresponding checkbox is hidden from the status-bar right-click menu.
- The corresponding toggle is hidden in Settings → Appearance → Status Bar.

If the user later installs the agent, the bar/toggle reappear (detection re-runs on app start and via the existing `refreshAgents` paths).

### Out of scope on purpose

- **OpenCode Go** is exempt — it's a web/cookie-auth provider, not a CLI on PATH, so the historical "always show so the user knows to configure it in Settings" behavior stays.
- **SSH** and **Resource Usage** are not gated either.
- Pre-detection (`detectedAgentIds === null`) preserves the legacy "show" behavior so nothing flickers on cold start.

## Files

- `src/renderer/src/components/status-bar/status-bar-agent-gating.ts` — pure helper `isStatusBarItemAvailable(id, detectedAgentIds)`.
- `src/renderer/src/components/status-bar/use-available-status-bar-toggles.ts` — hook variant for components that have a toggle list (kept separate from the pure helper so the helper can be unit-tested without booting the whole store).
- `src/renderer/src/components/status-bar/StatusBar.tsx` — gates `showClaude`/`showCodex`/`showGemini` and their menu checkboxes; triggers `ensureDetectedAgents()` on mount.
- `src/renderer/src/components/settings/AppearancePane.tsx` — filters the `STATUS_BAR_TOGGLES` list with the hook before rendering.
- `src/renderer/src/components/status-bar/status-bar-agent-gating.test.ts` — unit tests for the gating helper (4 cases).

## Verification

- `pnpm typecheck` ✅
- `pnpm lint` ✅ (errors-free, only the same pre-existing react-hooks warnings)
- `pnpm exec vitest run status-bar-agent-gating.test` ✅ 4/4

Pre-existing test failures elsewhere (e2e tests + alias-resolution failures in unrelated suites) are not introduced by this change.

Made with [Orca](https://github.com/stablyai/orca) 🐋
