### PR TITLE
Fix mac updater relaunch

### DIFF
--- a/src/main/updater.mac-install.test.ts
+++ b/src/main/updater.mac-install.test.ts
@@ -46,11 +46,13 @@ const {
     autoUpdaterMock.checkForUpdates.mockReset()
     autoUpdaterMock.downloadUpdate.mockReset()
     autoUpdaterMock.quitAndInstall.mockReset()
+    autoUpdaterMock.autoRunAppAfterInstall = false
   }
 
   const autoUpdaterMock = {
     autoDownload: false,
     autoInstallOnAppQuit: false,
+    autoRunAppAfterInstall: false,
     on,
     checkForUpdates: vi.fn(),
     downloadUpdate: vi.fn(),
@@ -66,7 +68,8 @@ const {
       getVersion: vi.fn(() => '1.0.51'),
       on: appOn,
       emit: appEmit,
-      quit: vi.fn()
+      quit: vi.fn(),
+      releaseSingleInstanceLock: vi.fn()
     },
     browserWindowMock: {
       getAllWindows: vi.fn(() => [])
@@ -124,6 +127,7 @@ describe('updater mac install handoff', () => {
     appMock.getVersion.mockReset()
     appMock.getVersion.mockReturnValue('1.0.51')
     appMock.quit.mockReset()
+    appMock.releaseSingleInstanceLock.mockReset()
     appMock.isPackaged = true
     isMock.dev = false
     killAllPtyMock.mockReset()

--- a/src/main/updater.test.ts
+++ b/src/main/updater.test.ts
@@ -49,6 +49,7 @@ const {
     autoUpdaterMock.quitAndInstall.mockReset()
     autoUpdaterMock.setFeedURL.mockClear()
     autoUpdaterMock.allowPrerelease = false
+    autoUpdaterMock.autoRunAppAfterInstall = false
     delete (autoUpdaterMock as Record<string, unknown>).verifyUpdateCodeSignature
   }
 
@@ -56,6 +57,7 @@ const {
     autoDownload: false,
     autoInstallOnAppQuit: false,
     allowPrerelease: false,
+    autoRunAppAfterInstall: false,
     on,
     checkForUpdates: vi.fn(),
     downloadUpdate: vi.fn(),
@@ -71,7 +73,8 @@ const {
       getVersion: vi.fn(() => '1.0.51'),
       on: appOn,
       emit: appEmit,
-      quit: vi.fn()
+      quit: vi.fn(),
+      releaseSingleInstanceLock: vi.fn()
     },
     browserWindowMock: {
       getAllWindows: vi.fn(() => [])
@@ -140,6 +143,7 @@ describe('updater', () => {
     appMock.getVersion.mockReset()
     appMock.getVersion.mockReturnValue('1.0.51')
     appMock.quit.mockReset()
+    appMock.releaseSingleInstanceLock.mockReset()
     appMock.isPackaged = true
     isMock.dev = false
     killAllPtyMock.mockReset()
@@ -279,8 +283,21 @@ describe('updater', () => {
     expect(autoUpdaterMock.quitAndInstall).not.toHaveBeenCalled()
 
     await vi.advanceTimersByTimeAsync(1)
+    expect(appMock.releaseSingleInstanceLock).toHaveBeenCalledTimes(1)
     expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1)
     expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledWith(false, true)
+    expect(appMock.releaseSingleInstanceLock.mock.invocationCallOrder[0]).toBeLessThan(
+      autoUpdaterMock.quitAndInstall.mock.invocationCallOrder[0]
+    )
+  })
+
+  it('pins mac relaunch behavior instead of relying on electron-updater defaults', async () => {
+    const mainWindow = { webContents: { send: vi.fn() } }
+    const { setupAutoUpdater } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
+
+    expect(autoUpdaterMock.autoRunAppAfterInstall).toBe(true)
   })
 
   it('ignores duplicate quitAndInstall requests while the shared delay is pending', async () => {

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -191,6 +191,12 @@ function performQuitAndInstall(): void {
     win.removeAllListeners('close')
   }
 
+  // Why: Squirrel.Mac can launch the replacement app before our async
+  // will-quit cleanup has fully exited. If the old process still owns the
+  // single-instance lock, the replacement exits and the update appears to
+  // shut down without restarting.
+  app.releaseSingleInstanceLock()
+
   autoUpdater.quitAndInstall(false, true)
 }
 
@@ -511,6 +517,10 @@ export function setupAutoUpdater(
 
   autoUpdater.autoDownload = false
   autoUpdater.autoInstallOnAppQuit = true
+  // Why: MacUpdater ignores quitAndInstall's isForceRunAfter argument; this
+  // property is the switch that makes its ready-to-install path call the
+  // native relaunching updater instead of a plain app.quit().
+  autoUpdater.autoRunAppAfterInstall = true
 
   // Why: the only on-machine window we have into electron-updater. Without
   // this, an unexpected `update-not-available` (e.g. RC user not offered


### PR DESCRIPTION
## Summary
- release the single-instance lock before handing off to electron-updater so Squirrel.Mac can relaunch the replacement app
- explicitly keep autoRunAppAfterInstall enabled for mac updater installs
- add regression coverage for the restart handoff path

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/main/updater.test.ts src/main/updater.mac-install.test.ts
- pnpm exec vitest run --config config/vitest.config.ts src/main/updater.test.ts src/main/updater.mac-install.test.ts src/main/updater.check-failure.test.ts src/main/updater.fallback.test.ts src/main/updater-prerelease-feed.test.ts src/main/updater-changelog.test.ts src/main/updater-nudge.test.ts
- pnpm typecheck
- pnpm exec oxlint src/main/updater.ts src/main/updater.test.ts src/main/updater.mac-install.test.ts
- git diff --check

Note: a full-suite attempt also hit unrelated better-sqlite3 ABI failures in runtime/orchestration tests in this checkout.