### PR TITLE
fix: avoid updater relaunch crash

### DIFF
--- a/src/main/updater.mac-install.test.ts
+++ b/src/main/updater.mac-install.test.ts
@@ -46,13 +46,11 @@ const {
     autoUpdaterMock.checkForUpdates.mockReset()
     autoUpdaterMock.downloadUpdate.mockReset()
     autoUpdaterMock.quitAndInstall.mockReset()
-    autoUpdaterMock.autoRunAppAfterInstall = false
   }
 
   const autoUpdaterMock = {
     autoDownload: false,
     autoInstallOnAppQuit: false,
-    autoRunAppAfterInstall: false,
     on,
     checkForUpdates: vi.fn(),
     downloadUpdate: vi.fn(),
@@ -68,8 +66,7 @@ const {
       getVersion: vi.fn(() => '1.0.51'),
       on: appOn,
       emit: appEmit,
-      quit: vi.fn(),
-      releaseSingleInstanceLock: vi.fn()
+      quit: vi.fn()
     },
     browserWindowMock: {
       getAllWindows: vi.fn(() => [])
@@ -127,7 +124,6 @@ describe('updater mac install handoff', () => {
     appMock.getVersion.mockReset()
     appMock.getVersion.mockReturnValue('1.0.51')
     appMock.quit.mockReset()
-    appMock.releaseSingleInstanceLock.mockReset()
     appMock.isPackaged = true
     isMock.dev = false
     killAllPtyMock.mockReset()

--- a/src/main/updater.test.ts
+++ b/src/main/updater.test.ts
@@ -49,7 +49,6 @@ const {
     autoUpdaterMock.quitAndInstall.mockReset()
     autoUpdaterMock.setFeedURL.mockClear()
     autoUpdaterMock.allowPrerelease = false
-    autoUpdaterMock.autoRunAppAfterInstall = false
     delete (autoUpdaterMock as Record<string, unknown>).verifyUpdateCodeSignature
   }
 
@@ -57,7 +56,6 @@ const {
     autoDownload: false,
     autoInstallOnAppQuit: false,
     allowPrerelease: false,
-    autoRunAppAfterInstall: false,
     on,
     checkForUpdates: vi.fn(),
     downloadUpdate: vi.fn(),
@@ -73,8 +71,7 @@ const {
       getVersion: vi.fn(() => '1.0.51'),
       on: appOn,
       emit: appEmit,
-      quit: vi.fn(),
-      releaseSingleInstanceLock: vi.fn()
+      quit: vi.fn()
     },
     browserWindowMock: {
       getAllWindows: vi.fn(() => [])
@@ -143,7 +140,6 @@ describe('updater', () => {
     appMock.getVersion.mockReset()
     appMock.getVersion.mockReturnValue('1.0.51')
     appMock.quit.mockReset()
-    appMock.releaseSingleInstanceLock.mockReset()
     appMock.isPackaged = true
     isMock.dev = false
     killAllPtyMock.mockReset()
@@ -283,21 +279,8 @@ describe('updater', () => {
     expect(autoUpdaterMock.quitAndInstall).not.toHaveBeenCalled()
 
     await vi.advanceTimersByTimeAsync(1)
-    expect(appMock.releaseSingleInstanceLock).toHaveBeenCalledTimes(1)
     expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1)
     expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledWith(false, true)
-    expect(appMock.releaseSingleInstanceLock.mock.invocationCallOrder[0]).toBeLessThan(
-      autoUpdaterMock.quitAndInstall.mock.invocationCallOrder[0]
-    )
-  })
-
-  it('pins mac relaunch behavior instead of relying on electron-updater defaults', async () => {
-    const mainWindow = { webContents: { send: vi.fn() } }
-    const { setupAutoUpdater } = await import('./updater')
-
-    setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
-
-    expect(autoUpdaterMock.autoRunAppAfterInstall).toBe(true)
   })
 
   it('ignores duplicate quitAndInstall requests while the shared delay is pending', async () => {

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -191,12 +191,6 @@ function performQuitAndInstall(): void {
     win.removeAllListeners('close')
   }
 
-  // Why: Squirrel.Mac can launch the replacement app before our async
-  // will-quit cleanup has fully exited. If the old process still owns the
-  // single-instance lock, the replacement exits and the update appears to
-  // shut down without restarting.
-  app.releaseSingleInstanceLock()
-
   autoUpdater.quitAndInstall(false, true)
 }
 
@@ -517,10 +511,6 @@ export function setupAutoUpdater(
 
   autoUpdater.autoDownload = false
   autoUpdater.autoInstallOnAppQuit = true
-  // Why: MacUpdater ignores quitAndInstall's isForceRunAfter argument; this
-  // property is the switch that makes its ready-to-install path call the
-  // native relaunching updater instead of a plain app.quit().
-  autoUpdater.autoRunAppAfterInstall = true
 
   // Why: the only on-machine window we have into electron-updater. Without
   // this, an unexpected `update-not-available` (e.g. RC user not offered

--- a/src/main/window/createMainWindow.test.ts
+++ b/src/main/window/createMainWindow.test.ts
@@ -827,6 +827,54 @@ describe('createMainWindow', () => {
     expect(menuPopupMock).toHaveBeenCalledWith({ window: browserWindowInstance, x: 42, y: 84 })
   })
 
+  it('does not read destroyed webContents during closed cleanup', () => {
+    const windowHandlers: Record<string, (...args: any[]) => void> = {}
+    const webContents = {
+      on: vi.fn(),
+      setZoomLevel: vi.fn(),
+      setBackgroundThrottling: vi.fn(),
+      invalidate: vi.fn(),
+      setWindowOpenHandler: vi.fn(),
+      send: vi.fn(),
+      isDevToolsOpened: vi.fn(),
+      openDevTools: vi.fn(),
+      closeDevTools: vi.fn()
+    }
+    let webContentsDestroyed = false
+    const browserWindowInstance = {
+      get webContents() {
+        if (webContentsDestroyed) {
+          throw new Error('Object has been destroyed')
+        }
+        return webContents
+      },
+      on: vi.fn((event, handler) => {
+        windowHandlers[event] = handler
+      }),
+      isDestroyed: vi.fn(() => false),
+      isMaximized: vi.fn(() => true),
+      isFullScreen: vi.fn(() => false),
+      getSize: vi.fn(() => [1200, 800]),
+      setSize: vi.fn(),
+      maximize: vi.fn(),
+      show: vi.fn(),
+      loadFile: vi.fn(),
+      loadURL: vi.fn()
+    }
+    browserWindowMock.mockImplementation(function () {
+      return browserWindowInstance
+    })
+
+    createMainWindow(null)
+
+    webContentsDestroyed = true
+
+    // Why: Electron may destroy webContents before BrowserWindow's `closed`
+    // cleanup runs during updater shutdown. The cleanup must not crash, or
+    // Squirrel.Mac never reaches the relaunch step.
+    expect(() => windowHandlers.closed?.()).not.toThrow()
+  })
+
   it('resets the markdown editor focus flag on renderer crash, navigation, and destroy', () => {
     const windowHandlers: Record<string, (...args: any[]) => void> = {}
     const webContents = {

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -684,7 +684,10 @@ export function createMainWindow(
     ipcMain.removeHandler(isMaximizedChannel)
     ipcMain.removeListener(confirmCloseChannel, onConfirmClose)
     ipcMain.removeListener(markdownFocusChannel, onMarkdownEditorFocused)
-    mainWindow.webContents.removeListener('context-menu', onMainContextMenu)
+    // Why: on updater-triggered shutdown, BrowserWindow can emit `closed`
+    // after its webContents has already been destroyed. The destroyed
+    // webContents owns its listeners, so do not touch `mainWindow.webContents`
+    // here or the quit path can crash before Squirrel.Mac relaunches Orca.
     app.removeListener('before-quit', freezeBoundsOnQuit)
   })
 


### PR DESCRIPTION
## Summary
- fixes the mac updater relaunch regression by avoiding `mainWindow.webContents` access from `BrowserWindow.closed` cleanup after Electron has destroyed the WebContents
- backs out the previous updater-lock/default changes from #1653 because v1.3.43 already relaunches correctly without them
- adds a regression test for the destroyed-WebContents shutdown ordering that crashed v1.3.44 during `quitAndInstall`

## Root Cause
A packaged updater repro from `v1.3.44` successfully downloaded the update, then exited with code 7 during `quitAndInstall` before Squirrel.Mac could relaunch. The app log ended with:

```text
TypeError: Object has been destroyed
    at BrowserWindow.<anonymous> (.../app.asar/out/main/index.js:46626:17)
```

`git blame` points the crashing cleanup line to `b023c5713e Polish rich markdown editor interactions (#1609)`, which landed between `v1.3.43` and `v1.3.44`.
https://github.com/stablyai/orca/pull/1609

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/main/window/createMainWindow.test.ts src/main/updater.test.ts src/main/updater.mac-install.test.ts`
- `pnpm exec oxlint src/main/window/createMainWindow.ts src/main/window/createMainWindow.test.ts src/main/updater.ts src/main/updater.test.ts src/main/updater.mac-install.test.ts`
- `pnpm exec tsgo --noEmit -p config/tsconfig.node.json`
- packaged-app updater harness reproduced the `v1.3.44` shutdown-without-relaunch failure and captured the destroyed-WebContents crash
