### PR TITLE
fix(new-workspace): use Linear logo instead of "L" placeholder

### DIFF
--- a/src/renderer/src/components/icons/LinearIcon.tsx
+++ b/src/renderer/src/components/icons/LinearIcon.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+
+// Why: the Linear brand logo is referenced from multiple surfaces (sidebar
+// nav, workspace creation combobox). Keeping a single source avoids drift
+// in the path data and lets every caller pick its own size/color via
+// `currentColor`.
+export function LinearIcon({ className }: { className?: string }): React.JSX.Element {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden className={className} fill="currentColor">
+      <path d="M2.886 4.18A11.982 11.982 0 0 1 11.99 0C18.624 0 24 5.376 24 12.009c0 3.64-1.62 6.903-4.18 9.105L2.887 4.18ZM1.817 5.626l16.556 16.556c-.524.33-1.075.62-1.65.866L.951 7.277c.247-.575.537-1.126.866-1.65ZM.322 9.163l14.515 14.515c-.71.172-1.443.282-2.195.322L0 11.358a12 12 0 0 1 .322-2.195Zm-.17 4.862 9.823 9.824a12.02 12.02 0 0 1-9.824-9.824Z" />
+    </svg>
+  )
+}

--- a/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
+++ b/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
@@ -37,6 +37,7 @@ import {
   type RepoSlug
 } from '@/lib/github-links'
 import { cn } from '@/lib/utils'
+import { LinearIcon } from '@/components/icons/LinearIcon'
 import type { GitHubWorkItem, LinearIssue } from '../../../../shared/types'
 
 type SmartNameMode = 'smart' | 'github' | 'branches' | 'linear' | 'text'
@@ -894,11 +895,7 @@ function RowIcon({ row }: { row: RowEntry }): React.JSX.Element {
   if (row.kind === 'branch') {
     return <GitBranch className="size-3.5 shrink-0 text-muted-foreground" />
   }
-  return (
-    <span className="size-3.5 shrink-0 rounded-sm bg-muted text-[8px] font-semibold leading-3.5 text-muted-foreground">
-      L
-    </span>
-  )
+  return <LinearIcon className="size-3.5 shrink-0 text-muted-foreground" />
 }
 
 function SelectionIcon({ kind }: { kind: SmartWorkspaceNameSelection['kind'] }): React.JSX.Element {
@@ -911,11 +908,7 @@ function SelectionIcon({ kind }: { kind: SmartWorkspaceNameSelection['kind'] }):
   if (kind === 'branch') {
     return <GitBranch className="size-3.5 shrink-0 text-muted-foreground" />
   }
-  return (
-    <span className="size-3.5 shrink-0 rounded-sm bg-muted text-center text-[8px] font-semibold leading-3.5 text-muted-foreground">
-      L
-    </span>
-  )
+  return <LinearIcon className="size-3.5 shrink-0 text-muted-foreground" />
 }
 
 function RowLabel({ row }: { row: RowEntry }): React.JSX.Element {

--- a/src/renderer/src/components/sidebar/SidebarNav.tsx
+++ b/src/renderer/src/components/sidebar/SidebarNav.tsx
@@ -5,16 +5,9 @@ import { useRepoMap } from '@/store/selectors'
 import { cn } from '@/lib/utils'
 import { isGitRepoKind } from '../../../../shared/repo-kind'
 import { getTaskPresetQuery, PER_REPO_FETCH_LIMIT } from '@/lib/new-workspace'
+import { LinearIcon } from '@/components/icons/LinearIcon'
 
 const isMac = typeof navigator !== 'undefined' && navigator.userAgent.includes('Mac')
-
-function LinearIcon({ className }: { className?: string }): React.JSX.Element {
-  return (
-    <svg viewBox="0 0 24 24" aria-hidden className={className} fill="currentColor">
-      <path d="M2.886 4.18A11.982 11.982 0 0 1 11.99 0C18.624 0 24 5.376 24 12.009c0 3.64-1.62 6.903-4.18 9.105L2.887 4.18ZM1.817 5.626l16.556 16.556c-.524.33-1.075.62-1.65.866L.951 7.277c.247-.575.537-1.126.866-1.65ZM.322 9.163l14.515 14.515c-.71.172-1.443.282-2.195.322L0 11.358a12 12 0 0 1 .322-2.195Zm-.17 4.862 9.823 9.824a12.02 12.02 0 0 1-9.824-9.824Z" />
-    </svg>
-  )
-}
 
 const SidebarNav = React.memo(function SidebarNav() {
   const openTaskPage = useAppStore((s) => s.openTaskPage)


### PR DESCRIPTION
The Linear rows in the workspace-create combobox were rendering a plain **"L"** inside a muted square (both in `RowIcon` and `SelectionIcon`). Replace with the actual Linear logo so the combobox matches the Linear entry point in the sidebar.

### Changes
- **New** `src/renderer/src/components/icons/LinearIcon.tsx` — single source for the Linear brand SVG so callers can pick size/color via `currentColor`.
- `SidebarNav.tsx` — drop the inline copy, import the shared icon (no behavior change).
- `SmartWorkspaceNameField.tsx` — replace both `<span>L</span>` placeholders with `<LinearIcon className="size-3.5 shrink-0 text-muted-foreground" />`.

### Notes
The original report also asked about using Linear's per-issue *status* icon (backlog/todo/in-progress/done glyph). I went with the brand logo here because it's the same icon already used in the sidebar's Linear entry point, and the per-issue status would need to be pulled from each `LinearIssue`'s state — happy to do that as a follow-up if preferred.

Made with [Orca](https://github.com/stablyai/orca) 🐋
