### PR TITLE
Fix skill frontmatter YAML

### DIFF
--- a/skills/orca-cli/SKILL.md
+++ b/skills/orca-cli/SKILL.md
@@ -1,6 +1,18 @@
 ---
 name: orca-cli
-description: Use the `orca` CLI to drive a running Orca editor — manage Orca worktrees; create, read, and run shell commands in Orca-managed terminals; and automate Orca's built-in browser (snapshot/click/fill/screenshot/tabs). Use this instead of raw `git worktree`, ad hoc shell PTYs, or Playwright whenever the task touches Orca state. Coding agents inside an Orca worktree should also use it to keep the worktree comment fresh at meaningful checkpoints. Boundary with `orchestration`: if the recipient of a terminal write is another AI agent (Claude Code, Gemini, Codex, a worker), use `orchestration` — it is the only correct way to send messages, nudges, replies, or task hand-offs to agents. orca-cli writes are for non-agent terminals (shells, build/test commands); reading or `wait`ing on any terminal — including agent terminals — stays in orca-cli.
+description: >-
+  Use the `orca` CLI to drive a running Orca editor — manage Orca worktrees;
+  create, read, and run shell commands in Orca-managed terminals; and automate
+  Orca's built-in browser (snapshot/click/fill/screenshot/tabs). Use this
+  instead of raw `git worktree`, ad hoc shell PTYs, or Playwright whenever the
+  task touches Orca state. Coding agents inside an Orca worktree should also use
+  it to keep the worktree comment fresh at meaningful checkpoints. Boundary with
+  `orchestration`: if the recipient of a terminal write is another AI agent
+  (Claude Code, Gemini, Codex, a worker), use `orchestration` — it is the only
+  correct way to send messages, nudges, replies, or task hand-offs to agents.
+  orca-cli writes are for non-agent terminals (shells, build/test commands);
+  reading or `wait`ing on any terminal — including agent terminals — stays in
+  orca-cli.
 ---
 
 # Orca CLI

--- a/skills/orchestration/SKILL.md
+++ b/skills/orchestration/SKILL.md
@@ -1,6 +1,20 @@
 ---
 name: orchestration
-description: Use `orca orchestration` when coordinating multiple AI agents through Orca: pass context, instructions, questions, findings, reviews, handoffs, or structured results between agents; delegate subtasks; dispatch work; track task DAGs; wait for worker_done/escalation; or run coordinator loops and decision gates. This is the right skill for semantic agent-to-agent communication. Boundary with `orca-cli`: do not use orchestration for ordinary terminal control, shell commands, browser automation, worktree management, or reading/waiting on terminals; use `orca-cli` for those. Triggers include "tell the other agent", "ask <agent>", "hand off to", "pass this to <agent>", "delegate to <agent>", "have <agent> do X", "let <agent> know", "share with the other AI", "coordinate agents", "what did <agent> find", "check orchestration inbox", "reply to <agent>", "dispatch task", "orchestrate agents", "multi-agent", "task DAG", "worker_done", "escalation", "decision gate", and "coordinator loop".
+description: >-
+  Use `orca orchestration` when coordinating multiple AI agents through Orca:
+  pass context, instructions, questions, findings, reviews, handoffs, or
+  structured results between agents; delegate subtasks; dispatch work; track task
+  DAGs; wait for worker_done/escalation; or run coordinator loops and decision
+  gates. This is the right skill for semantic agent-to-agent communication.
+  Boundary with `orca-cli`: do not use orchestration for ordinary terminal
+  control, shell commands, browser automation, worktree management, or
+  reading/waiting on terminals; use `orca-cli` for those. Triggers include "tell
+  the other agent", "ask <agent>", "hand off to", "pass this to <agent>",
+  "delegate to <agent>", "have <agent> do X", "let <agent> know", "share with the
+  other AI", "coordinate agents", "what did <agent> find", "check orchestration
+  inbox", "reply to <agent>", "dispatch task", "orchestrate agents",
+  "multi-agent", "task DAG", "worker_done", "escalation", "decision gate", and
+  "coordinator loop".
 ---
 
 # Orca Inter-Agent Orchestration


### PR DESCRIPTION
## Summary
- Convert long skill descriptions to folded YAML scalars so frontmatter parses correctly
- Preserve the intended description text for orca-cli and orchestration skills

## Verification
- Parsed both edited SKILL.md frontmatter blocks with the yaml package
- Ran git diff --check
- Ran npx skills add /Users/jinjingliang/Documents/projects/orca/fix-skill-frontmatter --skill orca-cli orchestration --agent codex --copy -y --full-depth from an isolated temp project and confirmed both skills installed