### PR TITLE
fix(windows): tab row overlaps window-controls buttons (#1664)

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1019,16 +1019,19 @@ function App(): React.JSX.Element {
                     className="absolute top-0 z-10 flex items-center h-[36px]"
                     style={
                       {
+                        // Why: right: var(--window-controls-width) is the single
+                        // mechanism that keeps the toggle clear of the
+                        // fixed-position window-controls overlay on Windows (138px)
+                        // and sits at the right edge on non-Windows (0px). No
+                        // internal spacer needed — adding one would push the button
+                        // a further 138px to the left and cover the pane-actions
+                        // Ellipsis button with an un-clickable div.
                         right: 'var(--window-controls-width)',
                         WebkitAppRegion: 'no-drag'
                       } as React.CSSProperties
                     }
                   >
                     {rightSidebarToggle}
-                    {/* Why: the fixed-position window-controls overlay (138px,
-                        top-right) sits on top of this floating toggle on Windows.
-                        Reserve its width so the toggle stays clickable. */}
-                    {isWindows && <div className="window-controls-titlebar-spacer" />}
                   </div>
                 )}
                 <div className="flex flex-1 min-w-0 min-h-0 flex-col">

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -487,6 +487,16 @@
   padding-top: var(--window-controls-height, 0px);
 }
 
+/* Why: in side activity-bar mode the panel header does NOT extend to the window
+   edge — the 40px icon strip sits to its right. But the window-controls overlay
+   is 138px wide, so it still overlaps the panel by (138 - 40) = 98px. Apply
+   exactly that remainder as padding-right so the close button clears the
+   minimize button. max(0px, ...) keeps this a no-op on non-Windows where the
+   var is 0px and the subtraction would otherwise go negative. */
+.right-sidebar-header-side-inset {
+  padding-right: max(0px, calc(var(--window-controls-width, 0px) - 40px));
+}
+
 .sidebar-toggle {
   -webkit-app-region: no-drag;
   background: none;

--- a/src/renderer/src/components/right-sidebar/index.tsx
+++ b/src/renderer/src/components/right-sidebar/index.tsx
@@ -72,7 +72,6 @@ type ActivityBarItem = {
 }
 
 const isMac = navigator.userAgent.includes('Mac')
-const isWindows = !isMac && navigator.userAgent.includes('Windows')
 const mod = isMac ? '\u2318' : 'Ctrl+'
 
 const ACTIVITY_ITEMS: ActivityBarItem[] = [

--- a/src/renderer/src/components/right-sidebar/index.tsx
+++ b/src/renderer/src/components/right-sidebar/index.tsx
@@ -319,12 +319,12 @@ function RightSidebarInner(): React.JSX.Element {
           </ContextMenu>
         ) : (
           /* ── Side layout: static title header ── */
-          /* Why: no right-sidebar-header-inset here — in side mode the 40px
-             activity bar strip sits to the right of the panel content, so the
-             header never reaches the window-controls zone. Adding the 138px
-             inset would push the close button 178px from the window edge,
-             creating a 40px gap between it and the minimize button. */
-          <div className="flex items-center justify-between h-[36px] min-h-[36px] px-3 border-b border-border">
+          /* Why: the 40px side activity bar absorbs the rightmost 40px of the
+             138px window-controls overlay, but the remaining 98px still overlaps
+             the panel header. right-sidebar-header-side-inset applies exactly
+             that remainder (138-40=98px) as padding-right so the close button
+             clears the minimize button without the full 138px gap. */
+          <div className="flex items-center justify-between h-[36px] min-h-[36px] px-3 border-b border-border right-sidebar-header-side-inset">
             <span className="text-[11px] font-semibold uppercase tracking-wider text-foreground">
               {visibleItems.find((item) => item.id === effectiveTab)?.title ?? ''}
             </span>

--- a/src/renderer/src/components/right-sidebar/index.tsx
+++ b/src/renderer/src/components/right-sidebar/index.tsx
@@ -319,7 +319,12 @@ function RightSidebarInner(): React.JSX.Element {
           </ContextMenu>
         ) : (
           /* ── Side layout: static title header ── */
-          <div className="flex items-center justify-between h-[36px] min-h-[36px] px-3 border-b border-border right-sidebar-header-inset">
+          /* Why: no right-sidebar-header-inset here — in side mode the 40px
+             activity bar strip sits to the right of the panel content, so the
+             header never reaches the window-controls zone. Adding the 138px
+             inset would push the close button 178px from the window edge,
+             creating a 40px gap between it and the minimize button. */
+          <div className="flex items-center justify-between h-[36px] min-h-[36px] px-3 border-b border-border">
             <span className="text-[11px] font-semibold uppercase tracking-wider text-foreground">
               {visibleItems.find((item) => item.id === effectiveTab)?.title ?? ''}
             </span>

--- a/src/renderer/src/components/right-sidebar/index.tsx
+++ b/src/renderer/src/components/right-sidebar/index.tsx
@@ -308,7 +308,6 @@ function RightSidebarInner(): React.JSX.Element {
                   <div className="flex items-center">{activityBarIcons}</div>
                   <div className="flex items-center">
                     {closeButton}
-                    {isWindows && <div className="window-controls-titlebar-spacer" />}
                   </div>
                 </TooltipProvider>
               </div>
@@ -327,7 +326,6 @@ function RightSidebarInner(): React.JSX.Element {
             <TooltipProvider delayDuration={400}>
               <div className="flex items-center">
                 {closeButton}
-                {isWindows && <div className="window-controls-titlebar-spacer" />}
               </div>
             </TooltipProvider>
           </div>

--- a/src/renderer/src/components/tab-group/TabGroupPanel.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.tsx
@@ -323,14 +323,21 @@ export default function TabGroupPanel({
           </div>
           {/* Why: Electron's native drag hit-test ignores z-index — a no-drag
               element only overrides drag when it's a DOM descendant, not a
-              sibling in another branch. The floating right-sidebar toggle in
-              App.tsx sits in a separate DOM tree, so we need an explicit
-              no-drag child here to punch a hole in the drag surface beneath it
-              and let clicks through to the toggle. */}
+              sibling in another branch. The floating right-sidebar toggle and
+              the fixed-position window-controls overlay on Windows both sit in
+              separate DOM trees, so we need an explicit no-drag child here to
+              punch holes in the drag surface beneath them. The sidebar toggle
+              is 40px (w-10); window controls add --window-controls-width
+              (138px on Windows, 0px elsewhere) on top. */}
           {reserveClosedExplorerToggleSpace && !rightSidebarOpen ? (
             <div
-              className="shrink-0 w-10"
-              style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+              className="shrink-0"
+              style={
+                {
+                  width: 'calc(40px + var(--window-controls-width, 0px))',
+                  WebkitAppRegion: 'no-drag'
+                } as React.CSSProperties
+              }
             />
           ) : null}
         </div>


### PR DESCRIPTION
Fixes #1664

## Root cause

The top-right tab group (`touchesTopEdge && touchesRightEdge`) renders a no-drag spacer at the far right of the tab row to leave room for the floating sidebar toggle (40px). On Windows, the custom `WindowControls` overlay (min/max/close buttons) is `position: fixed; right: 0; width: 138px` — it sits on top of the same corner, but the tab row's drag surface still extended under it, making the buttons hard to click and visually overlapping with tab content.

## Fix

Widen the existing no-drag spacer from a hardcoded `w-10` (40px) to `calc(40px + var(--window-controls-width, 0px))`. The `--window-controls-width` CSS variable is already set to `138px` on Windows and `0px` everywhere else (set in `App.tsx`), so this is a zero-cost no-op on macOS/Linux.

## Test plan
- [ ] On Windows with right sidebar **closed**: hover/click minimize, maximize, close — no tab content or drag region underneath; buttons are fully accessible
- [ ] On Windows with right sidebar **open**: unchanged — the sidebar's own header has `right-sidebar-header-inset` padding
- [ ] On macOS/Linux: tab row layout unchanged (spacer stays 40px)
- [ ] With split tab groups: the fix only applies to the panel that `touchesTopEdge && touchesRightEdge`, other panels unaffected