### PR TITLE
fix(codex-usage): correct Codex model pricing table

### DIFF
--- a/src/main/codex-usage/store.test.ts
+++ b/src/main/codex-usage/store.test.ts
@@ -164,6 +164,112 @@ describe('CodexUsageStore', () => {
     expect(summary.reasoningOutputTokens).toBe(100)
   })
 
+  it('prices current Codex models with current model rates', async () => {
+    const store = createStoreWithState({
+      dailyAggregates: [
+        {
+          day: '2026-04-09',
+          model: 'gpt-5.2-codex',
+          projectKey: 'worktree:repo-1::/workspace/repo',
+          projectLabel: 'Repo',
+          repoId: 'repo-1',
+          worktreeId: 'repo-1::/workspace/repo',
+          eventCount: 1,
+          inputTokens: 2_000_000,
+          cachedInputTokens: 1_000_000,
+          outputTokens: 1_000_000,
+          reasoningOutputTokens: 100_000,
+          totalTokens: 3_000_000,
+          hasInferredPricing: false
+        },
+        {
+          day: '2026-04-09',
+          model: 'gpt-5.3-codex',
+          projectKey: 'worktree:repo-1::/workspace/repo',
+          projectLabel: 'Repo',
+          repoId: 'repo-1',
+          worktreeId: 'repo-1::/workspace/repo',
+          eventCount: 1,
+          inputTokens: 2_000_000,
+          cachedInputTokens: 1_000_000,
+          outputTokens: 1_000_000,
+          reasoningOutputTokens: 100_000,
+          totalTokens: 3_000_000,
+          hasInferredPricing: false
+        },
+        {
+          day: '2026-04-09',
+          model: 'gpt-5.4',
+          projectKey: 'worktree:repo-1::/workspace/repo',
+          projectLabel: 'Repo',
+          repoId: 'repo-1',
+          worktreeId: 'repo-1::/workspace/repo',
+          eventCount: 1,
+          inputTokens: 2_000_000,
+          cachedInputTokens: 1_000_000,
+          outputTokens: 1_000_000,
+          reasoningOutputTokens: 100_000,
+          totalTokens: 3_000_000,
+          hasInferredPricing: false
+        },
+        {
+          day: '2026-04-09',
+          model: 'gpt-5.5',
+          projectKey: 'worktree:repo-1::/workspace/repo',
+          projectLabel: 'Repo',
+          repoId: 'repo-1',
+          worktreeId: 'repo-1::/workspace/repo',
+          eventCount: 1,
+          inputTokens: 2_000_000,
+          cachedInputTokens: 1_000_000,
+          outputTokens: 1_000_000,
+          reasoningOutputTokens: 100_000,
+          totalTokens: 3_000_000,
+          hasInferredPricing: false
+        }
+      ]
+    })
+
+    const summary = await store.getSummary('orca', '30d')
+    const breakdown = await store.getBreakdown('orca', '30d', 'model')
+
+    expect(summary.estimatedCostUsd).toBeCloseTo(85.1)
+    expect(breakdown.find((row) => row.key === 'gpt-5.2-codex')?.estimatedCostUsd).toBeCloseTo(
+      15.925
+    )
+    expect(breakdown.find((row) => row.key === 'gpt-5.3-codex')?.estimatedCostUsd).toBeCloseTo(
+      15.925
+    )
+    expect(breakdown.find((row) => row.key === 'gpt-5.4')?.estimatedCostUsd).toBeCloseTo(17.75)
+    expect(breakdown.find((row) => row.key === 'gpt-5.5')?.estimatedCostUsd).toBeCloseTo(35.5)
+  })
+
+  it('keeps cached input out of the full-price input bucket for GPT-5.5 totals', async () => {
+    const store = createStoreWithState({
+      dailyAggregates: [
+        {
+          day: '2026-04-09',
+          model: 'gpt-5.5',
+          projectKey: 'worktree:repo-1::/workspace/repo',
+          projectLabel: 'Repo',
+          repoId: 'repo-1',
+          worktreeId: 'repo-1::/workspace/repo',
+          eventCount: 1,
+          inputTokens: 491_053_514,
+          cachedInputTokens: 459_283_584,
+          outputTokens: 1_944_952,
+          reasoningOutputTokens: 551_764,
+          totalTokens: 492_998_466,
+          hasInferredPricing: false
+        }
+      ]
+    })
+
+    const summary = await store.getSummary('orca', '30d')
+
+    expect(summary.estimatedCostUsd).toBeCloseTo(446.840002)
+  })
+
   it('counts mixed-model sessions once for each real model row in the breakdown', async () => {
     const store = createStoreWithState({
       sessions: [

--- a/src/main/codex-usage/store.ts
+++ b/src/main/codex-usage/store.ts
@@ -24,8 +24,11 @@ let _codexUsageFile: string | null = null
 
 const MODEL_PRICING: Record<string, { input: number; cachedInput: number; output: number }> = {
   'gpt-5': { input: 1.25, cachedInput: 0.125, output: 10 },
-  'gpt-5.2-codex': { input: 1.75, cachedInput: 0.175, output: 14 },
-  'gpt-5.3-codex': { input: 1.9, cachedInput: 0.19, output: 15 }
+  'gpt-5.1': { input: 1.25, cachedInput: 0.125, output: 10 },
+  'gpt-5.2': { input: 1.75, cachedInput: 0.175, output: 14 },
+  'gpt-5.3-codex': { input: 1.75, cachedInput: 0.175, output: 14 },
+  'gpt-5.4': { input: 2.5, cachedInput: 0.25, output: 15 },
+  'gpt-5.5': { input: 5, cachedInput: 0.5, output: 30 }
 }
 
 function getDefaultState(): CodexUsagePersistedState {
@@ -78,14 +81,23 @@ function normalizeModelForPricing(model: string | null): string | null {
   }
 
   const lower = model.toLowerCase()
-  if (lower === 'gpt-5' || lower === 'gpt-5-codex' || lower.startsWith('gpt-5.4')) {
+  if (lower === 'gpt-5' || lower === 'gpt-5-codex') {
     return 'gpt-5'
   }
-  if (lower.startsWith('gpt-5.2-codex')) {
-    return 'gpt-5.2-codex'
+  if (lower.startsWith('gpt-5.1')) {
+    return 'gpt-5.1'
+  }
+  if (lower.startsWith('gpt-5.2')) {
+    return 'gpt-5.2'
   }
   if (lower.startsWith('gpt-5.3-codex')) {
     return 'gpt-5.3-codex'
+  }
+  if (lower.startsWith('gpt-5.4')) {
+    return 'gpt-5.4'
+  }
+  if (lower.startsWith('gpt-5.5')) {
+    return 'gpt-5.5'
   }
   return null
 }


### PR DESCRIPTION
## Summary
- Update `MODEL_PRICING` in `src/main/codex-usage/store.ts` to current Codex rates: add `gpt-5.1`, `gpt-5.4`, `gpt-5.5`; rename `gpt-5.2-codex` → `gpt-5.2` with corrected rates; align `gpt-5.3-codex` rates.
- Stop aliasing `gpt-5.4` to `gpt-5` in `normalizeModelForPricing` so it gets its own pricing.
- Add tests covering current Codex models and the cached-vs-uncached input split for high-cache `gpt-5.5` traffic.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm vitest run src/main/codex-usage/store.test.ts`

Made with [Orca](https://github.com/stablyai/orca) 🐋
