### PR TITLE
feat(source-control): add Stage Files primary button

### DIFF
--- a/src/renderer/src/components/right-sidebar/CommitArea.primary-icons.test.tsx
+++ b/src/renderer/src/components/right-sidebar/CommitArea.primary-icons.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { ArrowDownUp, ArrowUp, CloudUpload } from 'lucide-react'
+import { ArrowDownUp, ArrowUp, CloudUpload, Plus } from 'lucide-react'
 import { CommitArea } from './SourceControl'
 import { Button } from '@/components/ui/button'
 import { resolvePrimaryAction, type PrimaryActionInputs } from './source-control-primary-action'
@@ -127,5 +127,18 @@ describe('CommitArea primary action icons', () => {
     })
     const element = CommitArea(props)
     expect(primaryHasIcon(element, CloudUpload)).toBe(true)
+  })
+
+  // Why: a dirty tree with nothing staged surfaces 'Stage Files' as the
+  // primary, anchored by a Plus icon to read as an additive bulk action.
+  it('renders a plus icon on a Stage Files primary', () => {
+    const props = baseProps({
+      stagedCount: 0,
+      hasUnstagedChanges: true,
+      hasMessage: false,
+      upstreamStatus: { hasUpstream: true, ahead: 0, behind: 0 }
+    })
+    const element = CommitArea(props)
+    expect(primaryHasIcon(element, Plus)).toBe(true)
   })
 })

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -126,6 +126,7 @@ const PRIMARY_ICONS: Partial<
   >
 > = {
   commit: Check,
+  stage: Plus,
   push: ArrowUp,
   sync: ArrowDownUp,
   publish: CloudUpload
@@ -725,27 +726,6 @@ function SourceControlInner(): React.JSX.Element {
     [handleCommit, runCompoundCommitAction, runRemoteAction]
   )
 
-  // Why: PrimaryActionKind is narrowed to the single-action kinds the
-  // primary can emit ('commit' | 'push' | 'pull' | 'sync' | 'publish') —
-  // compound commit_* kinds are dropdown-only. An exhaustive switch keeps
-  // the mapping honest: if a new PrimaryActionKind is added, TypeScript
-  // lights up the missing case instead of silently falling through.
-  const handlePrimaryClick = useCallback((): void => {
-    switch (primaryAction.kind) {
-      case 'commit':
-      case 'push':
-      case 'pull':
-      case 'sync':
-      case 'publish':
-        handleActionInvoke(primaryAction.kind)
-        return
-      default: {
-        const _exhaustive: never = primaryAction.kind
-        void _exhaustive
-      }
-    }
-  }, [handleActionInvoke, primaryAction.kind])
-
   const handleOpenDiff = useCallback(
     (entry: GitStatusEntry) => {
       if (!activeWorktreeId || !worktreePath) {
@@ -894,6 +874,57 @@ function SourceControlInner(): React.JSX.Element {
     },
     [worktreePath, grouped, activeWorktreeId, isExecutingBulk, clearSelection]
   )
+
+  // Why: 'stage' primary stages every unstaged + untracked path in one
+  // bulkStage call. It bypasses handleActionInvoke because that handler is
+  // typed to DropdownActionKind and 'stage' is intentionally not in the
+  // dropdown union — the dropdown surface is unchanged.
+  const handleStageAllPrimary = useCallback(async (): Promise<void> => {
+    if (!worktreePath || isExecutingBulk) {
+      return
+    }
+    const filePaths = [
+      ...getStageAllPaths(grouped.unstaged, 'unstaged'),
+      ...getStageAllPaths(grouped.untracked, 'untracked')
+    ]
+    if (filePaths.length === 0) {
+      return
+    }
+    setIsExecutingBulk(true)
+    try {
+      const connectionId = getConnectionId(activeWorktreeId ?? null) ?? undefined
+      await window.api.git.bulkStage({ worktreePath, filePaths, connectionId })
+      clearSelection()
+    } finally {
+      setIsExecutingBulk(false)
+    }
+  }, [worktreePath, isExecutingBulk, grouped, activeWorktreeId, clearSelection])
+
+  // Why: PrimaryActionKind is narrowed to the single-action kinds the
+  // primary can emit ('commit' | 'stage' | 'push' | 'pull' | 'sync' |
+  // 'publish') — compound commit_* kinds are dropdown-only. An exhaustive
+  // switch keeps the mapping honest: if a new PrimaryActionKind is added,
+  // TypeScript lights up the missing case instead of silently falling
+  // through. 'stage' routes to a dedicated primary-only handler because
+  // handleActionInvoke is typed to DropdownActionKind.
+  const handlePrimaryClick = useCallback((): void => {
+    switch (primaryAction.kind) {
+      case 'stage':
+        void handleStageAllPrimary()
+        return
+      case 'commit':
+      case 'push':
+      case 'pull':
+      case 'sync':
+      case 'publish':
+        handleActionInvoke(primaryAction.kind)
+        return
+      default: {
+        const _exhaustive: never = primaryAction.kind
+        void _exhaustive
+      }
+    }
+  }, [handleActionInvoke, handleStageAllPrimary, primaryAction.kind])
 
   const handleUnstageAll = useCallback(async () => {
     if (!worktreePath || isExecutingBulk) {

--- a/src/renderer/src/components/right-sidebar/source-control-primary-action.test.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-primary-action.test.ts
@@ -232,15 +232,87 @@ describe('resolvePrimaryAction', () => {
     })
   })
 
-  it('asks the user to stage files when unstaged changes exist on an in-sync branch', () => {
+  // Why: dirty trees (no staged, has unstaged/untracked) must surface a
+  // 'Stage Files' primary regardless of upstream state. Pulling/syncing on
+  // a dirty tree fails ("Please commit or stash them"), and pushing skips
+  // the immediate user need (prepare a commit), so the staging rung
+  // intercepts before any remote rung fires.
+  it('returns Stage Files on a dirty tree that is behind upstream', () => {
+    const result = resolvePrimaryAction(
+      inputs({
+        hasUnstagedChanges: true,
+        upstreamStatus: { hasUpstream: true, ahead: 0, behind: 3 }
+      })
+    )
+    expect(result).toEqual({
+      kind: 'stage',
+      label: 'Stage Files',
+      title: 'Stage all changes',
+      disabled: false
+    })
+  })
+
+  it('returns Stage Files on a dirty tree that is ahead of upstream', () => {
+    const result = resolvePrimaryAction(
+      inputs({
+        hasUnstagedChanges: true,
+        upstreamStatus: { hasUpstream: true, ahead: 2, behind: 0 }
+      })
+    )
+    expect(result.kind).toBe('stage')
+    expect(result.label).toBe('Stage Files')
+    expect(result.disabled).toBe(false)
+  })
+
+  it('returns Stage Files on a dirty tree with no upstream branch', () => {
+    const result = resolvePrimaryAction(
+      inputs({
+        hasUnstagedChanges: true,
+        upstreamStatus: { hasUpstream: false, ahead: 0, behind: 0 }
+      })
+    )
+    expect(result.kind).toBe('stage')
+  })
+
+  it('returns Stage Files on a dirty tree while upstream status is still loading', () => {
+    const result = resolvePrimaryAction(
+      inputs({ hasUnstagedChanges: true, upstreamStatus: undefined })
+    )
+    expect(result.kind).toBe('stage')
+    expect(result.disabled).toBe(false)
+  })
+
+  it('still resolves to Commit when both staged and unstaged exist (staged wins)', () => {
+    const result = resolvePrimaryAction(
+      inputs({
+        stagedCount: 1,
+        hasUnstagedChanges: true,
+        hasMessage: true,
+        upstreamStatus: { hasUpstream: true, ahead: 0, behind: 0 }
+      })
+    )
+    expect(result.kind).toBe('commit')
+    expect(result.disabled).toBe(false)
+  })
+
+  it('still disables Commit (needs message) when staged+dirty without a message', () => {
+    const result = resolvePrimaryAction(
+      inputs({ stagedCount: 1, hasUnstagedChanges: true, hasMessage: false })
+    )
+    expect(result.kind).toBe('commit')
+    expect(result.disabled).toBe(true)
+    expect(result.title).toBe('Enter a commit message to commit')
+  })
+
+  it('returns Stage Files when unstaged changes exist on an in-sync branch', () => {
     const result = resolvePrimaryAction(
       inputs({ hasUnstagedChanges: true, upstreamStatus: upstreamInSync })
     )
     expect(result).toEqual({
-      kind: 'commit',
-      label: 'Commit',
-      title: 'Stage at least one file to commit',
-      disabled: true
+      kind: 'stage',
+      label: 'Stage Files',
+      title: 'Stage all changes',
+      disabled: false
     })
   })
 

--- a/src/renderer/src/components/right-sidebar/source-control-primary-action.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-primary-action.ts
@@ -14,7 +14,7 @@ import type { GitUpstreamStatus } from '../../../../shared/types'
 // `handlePrimaryClick` switch exhaustively over only the kinds the
 // primary can actually emit, and it kills the compound-commit branch in
 // the isRemoteOperationActive tooltip below at compile time.
-export type PrimaryActionKind = 'commit' | 'push' | 'pull' | 'sync' | 'publish'
+export type PrimaryActionKind = 'commit' | 'stage' | 'push' | 'pull' | 'sync' | 'publish'
 
 // Why: the in-flight remote op tracker stores which action the user actually
 // triggered, so the primary button can mirror that label/spinner instead of
@@ -47,6 +47,7 @@ export type PrimaryActionInputs = {
 }
 
 const PRIMARY_LABEL_BY_KIND: Record<Exclude<PrimaryActionKind, 'commit'>, string> = {
+  stage: 'Stage Files',
   push: 'Push',
   pull: 'Pull',
   sync: 'Sync',
@@ -185,6 +186,20 @@ export function resolvePrimaryAction(inputs: PrimaryActionInputs): PrimaryAction
       label: 'Commit',
       title: 'Enter a commit message to commit',
       disabled: true
+    }
+  }
+
+  // 5b. Nothing staged but local changes exist — surface staging as the
+  //     primary so dirty trees don't invite a remote op (pull/sync would fail
+  //     with uncommitted changes; push/publish skips the actual user need).
+  //     Sits before the upstream-status checks so it works regardless of
+  //     whether upstream has resolved yet.
+  if (!hasStaged && hasUnstagedChanges) {
+    return {
+      kind: 'stage',
+      label: 'Stage Files',
+      title: 'Stage all changes',
+      disabled: false
     }
   }
 


### PR DESCRIPTION
## Summary

- Adds a new `stage` primary action kind to Source Control: when there are unstaged/untracked changes but nothing is staged yet, the primary button shows **Stage Files** instead of Commit/Push/Sync
- Clicking it bulk-stages all unstaged + untracked paths in one `bulkStage` call, so the user lands directly in commit-ready state
- Dropdown surface is unchanged; `stage` is intentionally excluded from `DropdownActionKind` to keep existing dropdown behavior pristine
- Design doc at `docs/source-control-stage-files-primary.md`

## Test plan

- [ ] Cold path (nothing staged, nothing committed): primary shows "Stage Files"; clicking it stages everything
- [ ] After-click: primary transitions to "Commit" immediately after staging
- [ ] Untracked-only: untracked files are staged correctly
- [ ] Mixed (tracked + untracked): all files staged together
- [ ] Clean repo: "Stage Files" does not appear; normal primary action (Push/Sync/Publish) shown
- [ ] Conflicts: primary shows correct conflict action, not "Stage Files"
- [ ] Dropdown/per-row regression: existing dropdown and per-row stage buttons unaffected

All 7 Electron scenarios validated green.

Made with [Orca](https://github.com/stablyai/orca) 🐋
