### PR TITLE
fix(claude-usage): correct Anthropic model pricing

### DIFF
--- a/src/main/claude-usage/store.test.ts
+++ b/src/main/claude-usage/store.test.ts
@@ -177,4 +177,58 @@ describe('ClaudeUsageStore', () => {
     expect(summary.turns).toBe(5)
     expect(summary.zeroCacheReadTurns).toBe(2)
   })
+
+  it('prices Claude Opus 4.7 with current Anthropic rates', async () => {
+    const store = createStoreWithState({
+      dailyAggregates: [
+        {
+          day: '2026-04-09',
+          model: 'claude-opus-4-7-20260416',
+          projectKey: 'worktree:repo-1::/workspace/repo-a',
+          projectLabel: 'Repo A',
+          repoId: 'repo-1',
+          worktreeId: 'repo-1::/workspace/repo-a',
+          turnCount: 1,
+          zeroCacheReadTurnCount: 0,
+          inputTokens: 1_000_000,
+          outputTokens: 1_000_000,
+          cacheReadTokens: 1_000_000,
+          cacheWriteTokens: 1_000_000
+        }
+      ]
+    })
+
+    const summary = await store.getSummary('orca', '30d')
+    const breakdown = await store.getBreakdown('orca', '30d', 'model')
+
+    expect(summary.estimatedCostUsd).toBeCloseTo(36.75)
+    expect(
+      breakdown.find((row) => row.key === 'claude-opus-4-7-20260416')?.estimatedCostUsd
+    ).toBeCloseTo(36.75)
+  })
+
+  it('does not collapse older Opus 4.1 usage into current Opus 4.7 pricing', async () => {
+    const store = createStoreWithState({
+      dailyAggregates: [
+        {
+          day: '2026-04-09',
+          model: 'claude-opus-4-1-20250805',
+          projectKey: 'worktree:repo-1::/workspace/repo-a',
+          projectLabel: 'Repo A',
+          repoId: 'repo-1',
+          worktreeId: 'repo-1::/workspace/repo-a',
+          turnCount: 1,
+          zeroCacheReadTurnCount: 0,
+          inputTokens: 1_000_000,
+          outputTokens: 1_000_000,
+          cacheReadTokens: 1_000_000,
+          cacheWriteTokens: 1_000_000
+        }
+      ]
+    })
+
+    const summary = await store.getSummary('orca', '30d')
+
+    expect(summary.estimatedCostUsd).toBeCloseTo(110.25)
+  })
 })

--- a/src/main/claude-usage/store.ts
+++ b/src/main/claude-usage/store.ts
@@ -28,11 +28,18 @@ const MODEL_PRICING: Record<
   string,
   { input: number; output: number; cacheRead: number; cacheWrite: number }
 > = {
-  'claude-opus-4-6': { input: 6.15, output: 30.75, cacheRead: 0.61, cacheWrite: 7.69 },
-  'claude-opus-4-5': { input: 6.15, output: 30.75, cacheRead: 0.61, cacheWrite: 7.69 },
-  'claude-sonnet-4-6': { input: 3.69, output: 18.45, cacheRead: 0.37, cacheWrite: 4.61 },
-  'claude-sonnet-4-5': { input: 3.69, output: 18.45, cacheRead: 0.37, cacheWrite: 4.61 },
-  'claude-haiku-4-5': { input: 1.23, output: 6.15, cacheRead: 0.12, cacheWrite: 1.54 }
+  'claude-opus-4-7': { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+  'claude-opus-4-6': { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+  'claude-opus-4-5': { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+  'claude-opus-4-1': { input: 15, output: 75, cacheRead: 1.5, cacheWrite: 18.75 },
+  'claude-opus-4': { input: 15, output: 75, cacheRead: 1.5, cacheWrite: 18.75 },
+  'claude-sonnet-4-6': { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+  'claude-sonnet-4-5': { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+  'claude-sonnet-4': { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+  'claude-sonnet-3-7': { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+  'claude-haiku-4-5': { input: 1, output: 5, cacheRead: 0.1, cacheWrite: 1.25 },
+  'claude-haiku-3-5': { input: 0.8, output: 4, cacheRead: 0.08, cacheWrite: 1 },
+  'claude-haiku-3': { input: 0.25, output: 1.25, cacheRead: 0.03, cacheWrite: 0.3 }
 }
 
 function getDefaultState(): ClaudeUsagePersistedState {
@@ -66,14 +73,41 @@ function normalizeModelForPricing(model: string | null): string | null {
     return null
   }
   const lower = model.toLowerCase()
-  if (lower.includes('opus')) {
+  if (lower.includes('opus-4-7')) {
+    return 'claude-opus-4-7'
+  }
+  if (lower.includes('opus-4-6')) {
     return 'claude-opus-4-6'
   }
-  if (lower.includes('sonnet')) {
+  if (lower.includes('opus-4-5')) {
+    return 'claude-opus-4-5'
+  }
+  if (lower.includes('opus-4-1')) {
+    return 'claude-opus-4-1'
+  }
+  if (lower.includes('opus-4')) {
+    return 'claude-opus-4'
+  }
+  if (lower.includes('sonnet-4-6')) {
     return 'claude-sonnet-4-6'
   }
-  if (lower.includes('haiku')) {
+  if (lower.includes('sonnet-4-5')) {
+    return 'claude-sonnet-4-5'
+  }
+  if (lower.includes('sonnet-4')) {
+    return 'claude-sonnet-4'
+  }
+  if (lower.includes('sonnet-3-7') || lower.includes('sonnet-3.7')) {
+    return 'claude-sonnet-3-7'
+  }
+  if (lower.includes('haiku-4-5')) {
     return 'claude-haiku-4-5'
+  }
+  if (lower.includes('haiku-3-5') || lower.includes('haiku-3.5')) {
+    return 'claude-haiku-3-5'
+  }
+  if (lower.includes('haiku-3')) {
+    return 'claude-haiku-3'
   }
   return null
 }


### PR DESCRIPTION
## Summary
- update Claude usage pricing for current Opus, Sonnet, and Haiku model families
- add explicit Opus 4.7 handling instead of collapsing every Opus model into a stale Opus 4.6 row
- add regression coverage for Opus 4.7 and older Opus 4.1 pricing

## Tests
- pnpm vitest run --config config/vitest.config.ts src/main/claude-usage/store.test.ts src/main/claude-usage/scanner.test.ts
- pnpm run tc:node
- pnpm lint -- src/main/claude-usage/store.ts src/main/claude-usage/store.test.ts