### PR TITLE
fix(ssh): remove relay FS path allowlist to support symlinks outside workspace (#1661)

### DIFF
--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -149,25 +149,17 @@ export async function createRemoteWorktree(
     /* best-effort */
   }
 
-  // Why: the relay's git.addWorktree validates targetDir against registered
-  // roots. The worktree sibling path (repo/../name) is outside the repo root
-  // and must be registered first. Using request (not notify) makes the
-  // ordering guarantee explicit rather than relying on FIFO frame processing,
-  // and closes failure windows during relay reconnect or fresh-host scenarios
-  // where roots may not yet be registered at all. See issue #911.
   const mux = getActiveMultiplexer(repo.connectionId!)
   if (!mux) {
     throw new Error('SSH connection is not available. Please reconnect and try again.')
   }
-  // Why: git.addWorktree validates both repoPath and targetDir against
-  // registered roots. In a fresh-host or reconnect scenario, registerRelayRoots
-  // may not have finished yet, so neither path may be registered. Register both
-  // synchronously here to close that window.
-  //
-  // Why (fallback): when Orca reconnects via --connect to a relay still in its
-  // grace period, the old relay binary may not have the request handler yet.
-  // Fall back to notify so worktree creation still works against pre-upgrade
-  // relays.
+  // Why: kept for back-compat with old relay binaries during the upgrade
+  // window — those still gate git.addWorktree on registered roots, so we
+  // must prime them synchronously to close fresh-host / reconnect windows.
+  // New relays no-op these calls. Notify-fallback handles older relays that
+  // pre-date the request-form session.registerRoot handler. Tracked for
+  // removal once the relay-version floor moves past the cutover (see
+  // docs/relay-fs-allowlist-removal.md).
   try {
     await Promise.all([
       mux.request('session.registerRoot', { rootPath: repo.path }),
@@ -194,13 +186,14 @@ export async function createRemoteWorktree(
       (err.message.includes('No workspace roots registered yet') ||
         err.message.includes('Path outside authorized workspace'))
     ) {
-      // Why: validatePath throws two distinct errors — "No workspace roots
-      // registered yet" (relay has no roots at all, e.g., reconnect before
-      // registerRelayRoots completes) and "Path outside authorized workspace"
-      // (roots exist but the sibling worktree path isn't among them). Both are
-      // implementation details that mean nothing to the user.
+      // Why: only an OLD relay binary (pre-allowlist-removal) can produce
+      // these errors. New relays no-op session.registerRoot. Translate the
+      // raw error into an actionable upgrade-window message while still
+      // preserving the original string for bug reports. Tracked for removal
+      // once the relay-version floor moves past the cutover (see
+      // docs/relay-fs-allowlist-removal.md).
       throw new Error(
-        'The SSH relay has not registered the worktree path yet. Please wait a moment and try again, or disconnect and reconnect the SSH session.'
+        `Older relay reported an authorization error; please reconnect to deploy the latest relay. (${err.message})`
       )
     }
     throw err

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -390,9 +390,10 @@ export class SshRelaySession {
     unregisterSshGitProvider(this.targetId)
   }
 
-  // Why: the relay's RelayContext starts with rootsRegistered=false and rejects
-  // all FS operations until at least one root is registered. This must run
-  // after every relay deploy because each deploy creates a fresh RelayContext.
+  // Why: kept for back-compat with old relay binaries during the upgrade
+  // window — those still gate FS ops on registered roots. New relays no-op
+  // these notifications. Tracked for removal once the relay-version floor
+  // moves past the cutover (see docs/relay-fs-allowlist-removal.md).
   private async registerRelayRoots(mux: SshChannelMultiplexer): Promise<void> {
     const remoteRepos = this.store.getRepos().filter((r) => r.connectionId === this.targetId)
 

--- a/src/relay/context.ts
+++ b/src/relay/context.ts
@@ -1,7 +1,5 @@
-import { resolve, relative, isAbsolute } from 'path'
+import { resolve } from 'path'
 import { homedir } from 'os'
-import { realpathSync } from 'fs'
-import { realpath } from 'fs/promises'
 
 // Why: Node's fs APIs don't understand shell tilde expansion. Old repos may
 // have been stored with `~` or `~/…` paths before the client-side fix, so the
@@ -16,69 +14,18 @@ export function expandTilde(p: string): string {
   return p
 }
 
-// Why: mutating FS operations on the remote must be scoped to workspace roots
-// registered by the main process. Without this, a compromised or buggy client
-// could delete arbitrary files on the remote host.
+// Why: the relay runs as the SSH user and trusts the renderer process. A
+// compromised renderer can already weaponize pty.spawn and git.exec to reach
+// any path the SSH user can reach, so the FS-side allowlist provided friction
+// without meaningfully narrowing the blast radius. See
+// docs/relay-fs-allowlist-removal.md.
+//
+// registerRoot is retained as a no-op so existing session.registerRoot RPC
+// calls (notification + request) remain valid during the relay-deploy upgrade
+// window where an old main may still call into a new relay (and vice versa).
+// Tracked for deletion once the relay-version floor moves past the cutover.
 export class RelayContext {
-  readonly authorizedRoots = new Set<string>()
-
-  // Why: before any root is registered there is a race window where
-  // authorizedRoots is empty. If we allowed all paths during that window a
-  // compromised client could read or mutate arbitrary files before the first
-  // workspace root is registered. We track registration explicitly and reject
-  // every validatePath call until at least one root has been added.
-  private rootsRegistered = false
-
-  registerRoot(rootPath: string): void {
-    const resolved = resolve(expandTilde(rootPath))
-    this.authorizedRoots.add(resolved)
-    // Why: on macOS, /tmp is a symlink to /private/tmp. If a root is registered
-    // as /tmp/workspace, validatePathResolved would resolve it to /private/tmp/
-    // workspace, which fails the textual root check. Register both forms so the
-    // resolved path also passes validation.
-    try {
-      const real = realpathSync(resolved)
-      if (real !== resolved) {
-        this.authorizedRoots.add(real)
-      }
-    } catch {
-      // Root doesn't exist yet — textual form is sufficient
-    }
-    this.rootsRegistered = true
-  }
-
-  validatePath(targetPath: string): void {
-    if (!this.rootsRegistered) {
-      throw new Error('No workspace roots registered yet — path validation denied')
-    }
-
-    const resolved = resolve(expandTilde(targetPath))
-    for (const root of this.authorizedRoots) {
-      const rel = relative(root, resolved)
-      if (!rel.startsWith('..') && !isAbsolute(rel)) {
-        return
-      }
-    }
-    throw new Error(`Path outside authorized workspace: ${targetPath}`)
-  }
-
-  // Why: validatePath only normalizes `..` textually. A symlink inside the
-  // workspace pointing outside it (e.g., workspace/evil -> /etc/) would pass
-  // textual validation. This async variant resolves symlinks via realpath
-  // before checking the path, closing the symlink traversal vector.
-  async validatePathResolved(targetPath: string): Promise<void> {
-    this.validatePath(targetPath)
-    try {
-      const real = await realpath(targetPath)
-      this.validatePath(real)
-    } catch (err) {
-      // Why: ENOENT/ENOTDIR means the path doesn't exist yet (e.g., createFile)
-      // so the textual check above is sufficient. Other errors (EACCES, EIO)
-      // indicate real problems that should propagate.
-      const code = (err as NodeJS.ErrnoException).code
-      if (code !== 'ENOENT' && code !== 'ENOTDIR') {
-        throw err
-      }
-    }
+  registerRoot(_rootPath: string): void {
+    // intentionally empty
   }
 }

--- a/src/relay/fs-handler.test.ts
+++ b/src/relay/fs-handler.test.ts
@@ -76,7 +76,6 @@ describe('FsHandler', () => {
     tmpDir = mkdtempSync(path.join(tmpdir(), 'relay-fs-'))
     dispatcher = createMockDispatcher()
     const ctx = new RelayContext()
-    ctx.registerRoot(tmpDir)
     handler = new FsHandler(dispatcher as unknown as RelayDispatcher, ctx)
   })
 

--- a/src/relay/fs-handler.ts
+++ b/src/relay/fs-handler.ts
@@ -2,6 +2,8 @@ import { readdir, writeFile, stat, lstat, mkdir, rename, cp, rm, realpath } from
 import { execFile } from 'child_process'
 import type { RelayDispatcher, RequestContext } from './dispatcher'
 import type { RelayContext } from './context'
+// Why: RelayContext is accepted in the constructor for protocol back-compat
+// (see docs/relay-fs-allowlist-removal.md), but no longer consulted on FS ops.
 import { expandTilde } from './context'
 import {
   DEFAULT_MAX_RESULTS,
@@ -24,12 +26,10 @@ type WatchState = {
 
 export class FsHandler {
   private dispatcher: RelayDispatcher
-  private context: RelayContext
   private watches = new Map<string, WatchState>()
 
-  constructor(dispatcher: RelayDispatcher, context: RelayContext) {
+  constructor(dispatcher: RelayDispatcher, _context: RelayContext) {
     this.dispatcher = dispatcher
-    this.context = context
     this.registerHandlers()
   }
 
@@ -52,7 +52,6 @@ export class FsHandler {
 
   private async readDir(params: Record<string, unknown>) {
     const dirPath = expandTilde(params.dirPath as string)
-    await this.context.validatePathResolved(dirPath)
     const entries = await readdir(dirPath, { withFileTypes: true })
     return entries
       .map((entry) => ({
@@ -70,13 +69,11 @@ export class FsHandler {
 
   private async readFile(params: Record<string, unknown>) {
     const filePath = expandTilde(params.filePath as string)
-    await this.context.validatePathResolved(filePath)
     return readRelayFileContent(filePath)
   }
 
   private async writeFile(params: Record<string, unknown>) {
     const filePath = expandTilde(params.filePath as string)
-    await this.context.validatePathResolved(filePath)
     const content = params.content as string
     try {
       const fileStats = await lstat(filePath)
@@ -93,7 +90,6 @@ export class FsHandler {
 
   private async stat(params: Record<string, unknown>) {
     const filePath = expandTilde(params.filePath as string)
-    await this.context.validatePathResolved(filePath)
     // Why: lstat is used instead of stat so that symlinks are reported as
     // symlinks rather than being silently followed. stat() follows symlinks,
     // meaning isSymbolicLink() would always return false.
@@ -109,7 +105,6 @@ export class FsHandler {
 
   private async deletePath(params: Record<string, unknown>) {
     const targetPath = expandTilde(params.targetPath as string)
-    await this.context.validatePathResolved(targetPath)
     const recursive = params.recursive as boolean | undefined
     const stats = await stat(targetPath)
     if (stats.isDirectory() && !recursive) {
@@ -120,9 +115,6 @@ export class FsHandler {
 
   private async createFile(params: Record<string, unknown>) {
     const filePath = expandTilde(params.filePath as string)
-    // Why: symlinks in parent directories can redirect creation outside the
-    // workspace. validatePathResolved follows symlinks before checking roots.
-    await this.context.validatePathResolved(filePath)
     const { dirname } = await import('path')
     await mkdir(dirname(filePath), { recursive: true })
     await writeFile(filePath, '', { encoding: 'utf-8', flag: 'wx' })
@@ -130,45 +122,29 @@ export class FsHandler {
 
   private async createDir(params: Record<string, unknown>) {
     const dirPath = expandTilde(params.dirPath as string)
-    await this.context.validatePathResolved(dirPath)
     await mkdir(dirPath, { recursive: true })
   }
 
   private async rename(params: Record<string, unknown>) {
     const oldPath = expandTilde(params.oldPath as string)
     const newPath = expandTilde(params.newPath as string)
-    await this.context.validatePathResolved(oldPath)
-    await this.context.validatePathResolved(newPath)
     await rename(oldPath, newPath)
   }
 
   private async copy(params: Record<string, unknown>) {
     const source = expandTilde(params.source as string)
     const destination = expandTilde(params.destination as string)
-    // Why: cp follows symlinks — a symlink inside the workspace pointing to
-    // /etc would copy sensitive files into the workspace where readFile can
-    // exfiltrate them.
-    await this.context.validatePathResolved(source)
-    await this.context.validatePathResolved(destination)
     await cp(source, destination, { recursive: true })
   }
 
   private async realpath(params: Record<string, unknown>) {
     const filePath = expandTilde(params.filePath as string)
-    this.context.validatePath(filePath)
-    const resolved = await realpath(filePath)
-    // Why: a symlink inside the workspace may resolve to a path outside it.
-    // Returning the resolved path without validation leaks the external target.
-    this.context.validatePath(resolved)
-    return resolved
+    return await realpath(filePath)
   }
 
   private async search(params: Record<string, unknown>) {
     const query = params.query as string
     const rootPath = expandTilde(params.rootPath as string)
-    // Why: a symlink inside the workspace pointing to a directory outside it
-    // would let rg search (and return content from) files beyond the workspace.
-    await this.context.validatePathResolved(rootPath)
     const caseSensitive = params.caseSensitive as boolean | undefined
     const wholeWord = params.wholeWord as boolean | undefined
     const useRegex = params.useRegex as boolean | undefined
@@ -203,7 +179,6 @@ export class FsHandler {
 
   private async listFiles(params: Record<string, unknown>): Promise<string[]> {
     const rootPath = expandTilde(params.rootPath as string)
-    await this.context.validatePathResolved(rootPath)
     // Why: the main-to-relay RPC adds excludePaths so nested linked worktrees
     // don't get double-scanned. The shared helper validates the shape and
     // normalizes into root-relative prefixes; malformed input yields [] so
@@ -240,7 +215,6 @@ export class FsHandler {
 
   private async watch(params: Record<string, unknown>, context?: RequestContext) {
     const rootPath = expandTilde(params.rootPath as string)
-    this.context.validatePath(rootPath)
 
     if (this.watches.size >= 20) {
       throw new Error('Maximum number of file watchers reached')

--- a/src/relay/git-handler-staging.test.ts
+++ b/src/relay/git-handler-staging.test.ts
@@ -27,7 +27,6 @@ describe('GitHandler — commit & staging', () => {
     tmpDir = mkdtempSync(path.join(tmpdir(), 'relay-git-staging-'))
     dispatcher = createMockDispatcher()
     const ctx = new RelayContext()
-    ctx.registerRoot(tmpDir)
     // eslint-disable-next-line no-new
     new GitHandler(dispatcher as unknown as RelayDispatcher, ctx)
   })

--- a/src/relay/git-handler-status-ops.ts
+++ b/src/relay/git-handler-status-ops.ts
@@ -47,7 +47,6 @@ export async function detectConflictOperation(worktreePath: string): Promise<str
 
 export async function getStatusOp(
   git: GitExec,
-  validatePath: (p: string) => void,
   params: Record<string, unknown>
 ): Promise<{
   entries: Record<string, unknown>[]
@@ -56,7 +55,6 @@ export async function getStatusOp(
   branch?: string
 }> {
   const worktreePath = params.worktreePath as string
-  validatePath(worktreePath)
   const conflictOperation = await detectConflictOperation(worktreePath)
   const entries: Record<string, unknown>[] = []
   let head: string | undefined

--- a/src/relay/git-handler-worktree-ops.ts
+++ b/src/relay/git-handler-worktree-ops.ts
@@ -9,16 +9,10 @@ import type { GitExec } from './git-handler-ops'
 
 // ─── Worktree management ─────────────────────────────────────────────
 
-export async function addWorktreeOp(
-  git: GitExec,
-  validatePath: (p: string) => void,
-  params: Record<string, unknown>
-): Promise<void> {
+export async function addWorktreeOp(git: GitExec, params: Record<string, unknown>): Promise<void> {
   const repoPath = params.repoPath as string
-  validatePath(repoPath)
   const branchName = params.branchName as string
   const targetDir = params.targetDir as string
-  validatePath(targetDir)
   const base = params.base as string | undefined
   const track = params.track as boolean | undefined
 
@@ -42,11 +36,9 @@ export async function addWorktreeOp(
 
 export async function removeWorktreeOp(
   git: GitExec,
-  validatePath: (p: string) => void,
   params: Record<string, unknown>
 ): Promise<void> {
   const worktreePath = params.worktreePath as string
-  validatePath(worktreePath)
   const force = params.force as boolean | undefined
 
   let repoPath = worktreePath

--- a/src/relay/git-handler.test.ts
+++ b/src/relay/git-handler.test.ts
@@ -23,7 +23,6 @@ describe('GitHandler', () => {
     tmpDir = mkdtempSync(path.join(tmpdir(), 'relay-git-'))
     dispatcher = createMockDispatcher()
     const ctx = new RelayContext()
-    ctx.registerRoot(tmpDir)
     // eslint-disable-next-line no-new
     new GitHandler(dispatcher as unknown as RelayDispatcher, ctx)
   })

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -22,11 +22,11 @@ const BULK_CHUNK_SIZE = 100
 
 export class GitHandler {
   private dispatcher: RelayDispatcher
-  private context: RelayContext
 
-  constructor(dispatcher: RelayDispatcher, context: RelayContext) {
+  // Why: RelayContext is accepted for protocol back-compat (see
+  // docs/relay-fs-allowlist-removal.md) but no longer consulted on git ops.
+  constructor(dispatcher: RelayDispatcher, _context: RelayContext) {
     this.dispatcher = dispatcher
-    this.context = context
     this.registerHandlers()
   }
 
@@ -75,12 +75,11 @@ export class GitHandler {
   }
 
   private async getStatus(params: Record<string, unknown>) {
-    return getStatusOp(this.git.bind(this), this.context.validatePath.bind(this.context), params)
+    return getStatusOp(this.git.bind(this), params)
   }
 
   private async getDiff(params: Record<string, unknown>) {
     const worktreePath = params.worktreePath as string
-    this.context.validatePath(worktreePath)
     const filePath = params.filePath as string
     // Why: filePath is relative to worktreePath and used in readWorkingFile via
     // path.join. Without validation, ../../etc/passwd traverses outside the worktree.
@@ -100,7 +99,6 @@ export class GitHandler {
 
   private async stage(params: Record<string, unknown>) {
     const worktreePath = params.worktreePath as string
-    this.context.validatePath(worktreePath)
     const filePath = params.filePath as string
     await this.git(['add', '--', filePath], worktreePath)
   }
@@ -109,21 +107,18 @@ export class GitHandler {
     params: Record<string, unknown>
   ): Promise<{ success: boolean; error?: string }> {
     const worktreePath = params.worktreePath as string
-    this.context.validatePath(worktreePath)
     const message = params.message as string
     return commitChangesRelay(this.git.bind(this), worktreePath, message)
   }
 
   private async unstage(params: Record<string, unknown>) {
     const worktreePath = params.worktreePath as string
-    this.context.validatePath(worktreePath)
     const filePath = params.filePath as string
     await this.git(['restore', '--staged', '--', filePath], worktreePath)
   }
 
   private async bulkStage(params: Record<string, unknown>) {
     const worktreePath = params.worktreePath as string
-    this.context.validatePath(worktreePath)
     const filePaths = params.filePaths as string[]
     for (let i = 0; i < filePaths.length; i += BULK_CHUNK_SIZE) {
       const chunk = filePaths.slice(i, i + BULK_CHUNK_SIZE)
@@ -133,7 +128,6 @@ export class GitHandler {
 
   private async bulkUnstage(params: Record<string, unknown>) {
     const worktreePath = params.worktreePath as string
-    this.context.validatePath(worktreePath)
     const filePaths = params.filePaths as string[]
     for (let i = 0; i < filePaths.length; i += BULK_CHUNK_SIZE) {
       const chunk = filePaths.slice(i, i + BULK_CHUNK_SIZE)
@@ -143,7 +137,6 @@ export class GitHandler {
 
   private async discard(params: Record<string, unknown>) {
     const worktreePath = params.worktreePath as string
-    this.context.validatePath(worktreePath)
     const filePath = params.filePath as string
 
     const resolved = path.resolve(worktreePath, filePath)
@@ -162,26 +155,18 @@ export class GitHandler {
       // untracked
     }
 
-    if (tracked) {
-      await this.git(['restore', '--worktree', '--source=HEAD', '--', filePath], worktreePath)
-    } else {
-      // Why: textual path checks pass for symlinks inside the worktree, but
-      // rm follows symlinks — so a symlink pointing outside the workspace
-      // would delete the target. validatePathResolved catches this.
-      await this.context.validatePathResolved(resolved)
-      await rm(resolved, { force: true, recursive: true })
-    }
+    await (tracked
+      ? this.git(['restore', '--worktree', '--source=HEAD', '--', filePath], worktreePath)
+      : rm(resolved, { force: true, recursive: true }))
   }
 
   private async conflictOperation(params: Record<string, unknown>) {
     const worktreePath = params.worktreePath as string
-    this.context.validatePath(worktreePath)
     return detectConflictOperation(worktreePath)
   }
 
   private async branchCompare(params: Record<string, unknown>) {
     const worktreePath = params.worktreePath as string
-    this.context.validatePath(worktreePath)
     const baseRef = params.baseRef as string
     // Why: a baseRef starting with '-' would be interpreted as a flag to
     // git rev-parse, potentially leaking environment variables or config.
@@ -202,7 +187,6 @@ export class GitHandler {
 
   private async upstreamStatus(params: Record<string, unknown>) {
     const worktreePath = params.worktreePath as string
-    this.context.validatePath(worktreePath)
 
     try {
       const { stdout: upstreamStdout } = await this.git(
@@ -250,7 +234,6 @@ export class GitHandler {
 
   private async fetch(params: Record<string, unknown>) {
     const worktreePath = params.worktreePath as string
-    this.context.validatePath(worktreePath)
     try {
       await this.git(['fetch', '--prune'], worktreePath)
     } catch (error) {
@@ -263,7 +246,6 @@ export class GitHandler {
 
   private async push(params: Record<string, unknown>) {
     const worktreePath = params.worktreePath as string
-    this.context.validatePath(worktreePath)
     // Why: always pass --set-upstream (mirrors src/main/git/remote.ts).
     // Orca's worktrees initially track the BASE ref (origin/main) because
     // they're created via `git worktree add --track -b <name> <dir>
@@ -286,7 +268,6 @@ export class GitHandler {
 
   private async pull(params: Record<string, unknown>) {
     const worktreePath = params.worktreePath as string
-    this.context.validatePath(worktreePath)
     // Why: plain `git pull` uses the user's configured pull strategy (merge by
     // default) so diverged branches reconcile instead of erroring out.
     try {
@@ -300,7 +281,6 @@ export class GitHandler {
 
   private async branchDiff(params: Record<string, unknown>) {
     const worktreePath = params.worktreePath as string
-    this.context.validatePath(worktreePath)
     const baseRef = params.baseRef as string
     if (baseRef.startsWith('-')) {
       throw new Error('Base ref must not start with "-"')
@@ -321,16 +301,12 @@ export class GitHandler {
   private async exec(params: Record<string, unknown>) {
     const args = params.args as string[]
     const cwd = params.cwd as string
-    this.context.validatePath(cwd)
 
     validateGitExecArgs(args)
     const { stdout, stderr } = await this.git(args, cwd)
     return { stdout, stderr }
   }
 
-  // Why: isGitRepo is called during the add-repo flow before any workspace
-  // roots are registered with the relay. Skipping validatePath is safe because
-  // this is a read-only git rev-parse check — no files are mutated.
   private async isGitRepo(params: Record<string, unknown>) {
     const dirPath = params.dirPath as string
     try {
@@ -343,7 +319,6 @@ export class GitHandler {
 
   private async listWorktrees(params: Record<string, unknown>) {
     const repoPath = params.repoPath as string
-    this.context.validatePath(repoPath)
     try {
       const { stdout } = await this.git(['worktree', 'list', '--porcelain'], repoPath)
       return parseWorktreeList(stdout)
@@ -353,14 +328,10 @@ export class GitHandler {
   }
 
   private async addWorktree(params: Record<string, unknown>) {
-    return addWorktreeOp(this.git.bind(this), this.context.validatePath.bind(this.context), params)
+    return addWorktreeOp(this.git.bind(this), params)
   }
 
   private async removeWorktree(params: Record<string, unknown>) {
-    return removeWorktreeOp(
-      this.git.bind(this),
-      this.context.validatePath.bind(this.context),
-      params
-    )
+    return removeWorktreeOp(this.git.bind(this), params)
   }
 }

--- a/src/relay/integration.test.ts
+++ b/src/relay/integration.test.ts
@@ -75,7 +75,6 @@ describe('Integration: Client Mux ↔ Relay Dispatcher', () => {
 
     // Register handlers on the relay
     const context = new RelayContext()
-    context.registerRoot(tmpDir)
     fsHandler = new FsHandler(dispatcher, context)
     new GitHandler(dispatcher, context)
 

--- a/src/relay/relay.ts
+++ b/src/relay/relay.ts
@@ -152,6 +152,13 @@ function main(): void {
 
   const context = new RelayContext()
 
+  // Why: session.registerRoot is now a protocol-level no-op (the relay no
+  // longer enforces a workspace allowlist; see docs/relay-fs-allowlist-removal.md).
+  // Both notification and request handlers are retained so a new main
+  // connecting to a new relay during the upgrade window — and an old main
+  // connecting to a new relay — both keep working without "Method not found"
+  // errors. Tracked for removal once the relay-version floor moves past the
+  // cutover.
   dispatcher.onNotification('session.registerRoot', (params) => {
     const rootPath = params.rootPath as string
     if (rootPath) {
@@ -159,12 +166,6 @@ function main(): void {
     }
   })
 
-  // Why: worktree creation needs to await root registration before sending
-  // addWorktree, which validates the target directory. While FIFO frame
-  // processing means a notification won't be reordered in steady state,
-  // the request variant makes the ordering guarantee explicit and closes
-  // failure windows during relay reconnect or fresh-host scenarios where
-  // roots may not yet be registered at all. See issue #911.
   dispatcher.onRequest('session.registerRoot', async (params) => {
     const rootPath = params.rootPath as string
     if (rootPath) {

--- a/src/relay/subprocess.test.ts
+++ b/src/relay/subprocess.test.ts
@@ -62,7 +62,6 @@ describe('Subprocess: Relay entry point', () => {
 
     relay = spawn()
     await relay.sentinelReceived
-    relay.sendNotification('session.registerRoot', { rootPath: tmpDir })
 
     const id = relay.send('fs.stat', { filePath: path.join(tmpDir, 'test.txt') })
     const resp = await relay.waitForResponse(id)
@@ -80,7 +79,6 @@ describe('Subprocess: Relay entry point', () => {
 
     relay = spawn()
     await relay.sentinelReceived
-    relay.sendNotification('session.registerRoot', { rootPath: tmpDir })
 
     const id = relay.send('fs.readDir', { dirPath: tmpDir })
     const resp = await relay.waitForResponse(id)
@@ -95,7 +93,6 @@ describe('Subprocess: Relay entry point', () => {
 
     relay = spawn()
     await relay.sentinelReceived
-    relay.sendNotification('session.registerRoot', { rootPath: tmpDir })
 
     const filePath = path.join(tmpDir, 'output.txt')
     const wId = relay.send('fs.writeFile', { filePath, content: 'via subprocess' })
@@ -121,7 +118,6 @@ describe('Subprocess: Relay entry point', () => {
 
     relay = spawn()
     await relay.sentinelReceived
-    relay.sendNotification('session.registerRoot', { rootPath: tmpDir })
 
     const id = relay.send('git.status', { worktreePath: tmpDir })
     const resp = await relay.waitForResponse(id)
@@ -148,7 +144,6 @@ describe('Subprocess: Relay entry point', () => {
     tmpDir = mkdtempSync(path.join(tmpdir(), 'relay-sub-'))
     relay = spawn()
     await relay.sentinelReceived
-    relay.sendNotification('session.registerRoot', { rootPath: tmpDir })
 
     const id = relay.send('fs.readFile', { filePath: path.join(tmpDir, 'nonexistent.txt') })
     const resp = await relay.waitForResponse(id)
@@ -164,7 +159,6 @@ describe('Subprocess: Relay entry point', () => {
 
     relay = spawn()
     await relay.sentinelReceived
-    relay.sendNotification('session.registerRoot', { rootPath: tmpDir })
 
     const id1 = relay.send('fs.stat', { filePath: path.join(tmpDir, 'one.txt') })
     const id2 = relay.send('fs.stat', { filePath: path.join(tmpDir, 'two.txt') })
@@ -202,53 +196,60 @@ describe('Subprocess: Relay entry point', () => {
     expect(relay.proc.exitCode).toBe(0)
   }, 10_000)
 
-  it('registers root via request and returns acknowledgment', async () => {
-    tmpDir = mkdtempSync(path.join(tmpdir(), 'relay-sub-'))
-    writeFileSync(path.join(tmpDir, 'test.txt'), 'hello')
-
+  it('session.registerRoot request returns ok acknowledgment', async () => {
+    // Why: session.registerRoot is a protocol-level no-op since the FS
+    // allowlist removal, but the request form still must reply { ok: true }
+    // for back-compat with mains during the upgrade window. See
+    // docs/relay-fs-allowlist-removal.md.
     relay = spawn()
     await relay.sentinelReceived
 
-    const id = relay.send('session.registerRoot', { rootPath: tmpDir })
+    const id = relay.send('session.registerRoot', { rootPath: '/tmp/anything' })
     const resp = await relay.waitForResponse(id)
 
     expect(resp.error).toBeUndefined()
     expect(resp.result).toEqual({ ok: true })
-
-    const statId = relay.send('fs.stat', { filePath: path.join(tmpDir, 'test.txt') })
-    const statResp = await relay.waitForResponse(statId)
-    expect(statResp.error).toBeUndefined()
-    expect((statResp.result as { type: string }).type).toBe('file')
   }, 10_000)
 
-  it('rejects fs operations when no roots are registered', async () => {
-    tmpDir = mkdtempSync(path.join(tmpdir(), 'relay-sub-'))
-    writeFileSync(path.join(tmpDir, 'test.txt'), 'hello')
-
-    relay = spawn()
-    await relay.sentinelReceived
-
-    const id = relay.send('fs.stat', { filePath: path.join(tmpDir, 'test.txt') })
-    const resp = await relay.waitForResponse(id)
-
-    expect(resp.error).toBeDefined()
-    expect(resp.error!.message).toContain('No workspace roots registered yet')
-  }, 10_000)
-
-  it('rejects paths outside registered roots', async () => {
+  it('reads files outside any registered root', async () => {
+    // Regression test for the architecture change in docs/relay-fs-allowlist-removal.md:
+    // the relay no longer enforces a workspace allowlist.
     tmpDir = mkdtempSync(path.join(tmpdir(), 'relay-sub-'))
     const outsideDir = mkdtempSync(path.join(tmpdir(), 'relay-outside-'))
-    writeFileSync(path.join(outsideDir, 'secret.txt'), 'secret')
+    writeFileSync(path.join(outsideDir, 'secret.txt'), 'visible')
 
     relay = spawn()
     await relay.sentinelReceived
-    relay.sendNotification('session.registerRoot', { rootPath: tmpDir })
 
-    const id = relay.send('fs.stat', { filePath: path.join(outsideDir, 'secret.txt') })
+    const id = relay.send('fs.readFile', { filePath: path.join(outsideDir, 'secret.txt') })
     const resp = await relay.waitForResponse(id)
 
-    expect(resp.error).toBeDefined()
-    expect(resp.error!.message).toContain('Path outside authorized workspace')
+    expect(resp.error).toBeUndefined()
+    expect((resp.result as { content: string }).content).toBe('visible')
+
+    await rm(outsideDir, { recursive: true, force: true }).catch(() => {})
+  }, 10_000)
+
+  it('reads files via symlinks resolving outside the workspace', async () => {
+    // Regression test for issue #1661: a symlink under the workspace pointing
+    // to a directory outside it must resolve transparently. The pre-removal
+    // relay rejected this with "Path outside authorized workspace".
+    tmpDir = mkdtempSync(path.join(tmpdir(), 'relay-sub-'))
+    const outsideDir = mkdtempSync(path.join(tmpdir(), 'relay-outside-'))
+    writeFileSync(path.join(outsideDir, 'data.txt'), 'symlinked-target')
+    const { symlinkSync } = require('fs')
+    symlinkSync(outsideDir, path.join(tmpDir, 'link'))
+
+    relay = spawn()
+    await relay.sentinelReceived
+
+    const id = relay.send('fs.readFile', {
+      filePath: path.join(tmpDir, 'link', 'data.txt')
+    })
+    const resp = await relay.waitForResponse(id)
+
+    expect(resp.error).toBeUndefined()
+    expect((resp.result as { content: string }).content).toBe('symlinked-target')
 
     await rm(outsideDir, { recursive: true, force: true }).catch(() => {})
   }, 10_000)


### PR DESCRIPTION
## Summary

#1661.

When a remote SSH workspace contains a symlink whose target lies outside the registered repo/worktree roots, file reads currently fail with:

```
Error invoking remote method 'fs:readFile': Error: Path outside authorized workspace: /external-storage/project
```

This silently breaks common workflows: HPC dataset/model mounts (the issue reporter's case), multi-checkout repos, cross-mount symlinks, and any external-target symlink under a workspace.

This PR removes the SSH relay's FS path allowlist so the relay accepts any path the renderer asks for and follows symlinks transparently.

## What changed

**Relay (`src/relay/`):**
- Stripped `RelayContext.authorizedRoots`, `validatePath`, and `validatePathResolved` along with all ~33 call sites in `fs-handler.ts` and `git-handler.ts`.
- Dropped the `validatePath` callback parameter from `addWorktreeOp`, `removeWorktreeOp`, and `getStatusOp`.
- `RelayContext` is reduced to a near-empty class with a no-op `registerRoot` (kept for protocol back-compat).
- `session.registerRoot` notification + request handlers in `relay.ts` are retained as no-ops with a back-compat comment.

**Main (`src/main/`):**
- Narrowed (not deleted) the error-translation block in `worktree-remote.ts` to a single message that handles old relays still surfacing the legacy error string.
- Updated stale `Why:` comments in `ssh-relay-session.ts` and `worktree-remote.ts` that referred to the removed allowlist behavior.

**Tests (`src/relay/*.test.ts`):**
- Removed two negative-allowlist tests in `subprocess.test.ts` (`'rejects fs operations when no roots are registered'`, `'rejects paths outside registered roots'`).
- Added a positive control: `'reads files outside any registered root'`.
- Added a direct regression test for #1661: `'reads files via symlinks resolving outside the workspace'`.
- Cleaned up dead `ctx.registerRoot(tmpDir)` setup lines across the relay test files.

**Doc:**
- New `docs/relay-fs-allowlist-removal.md` with the full rationale, back-compat matrix, alternatives considered, and follow-up cleanup plan.

## Why this is safe

The threat model the original allowlist was framed against — "a compromised renderer should not be able to ask the relay to read/write arbitrary paths" — is already conceded by every other RPC the relay exposes:

- `pty.spawn` lets the renderer spawn arbitrary shells running as the SSH user. `cat /etc/passwd` is one keystroke from a shell.
- `git.exec` runs git commands in arbitrary directories. `git -C /etc cat-file` is reachable.

The FS allowlist was therefore not closing a hole — it was adding friction to one of several equivalent paths. The renderer is, and has to be, in our trust boundary.

**Intra-worktree path checks** in `git.discard` and `git.diff` (the rules that prevent `discard('.')` from wiping the worktree or `getDiff('../etc/passwd')` from escaping) are intentionally preserved — those are footgun guards, not a workspace boundary.

## Backwards compatibility

Protocol unchanged. `session.registerRoot` continues to exist; both notification and request forms are accepted; both are no-ops on a new relay; both still gate correctly on an old relay. Behavior matrix:

| Main | Relay | Behavior |
| --- | --- | --- |
| New | New | `session.registerRoot` is a no-op. FS works for any path. |
| New | Old (upgrade window) | Main still notifies registerRoot. Old relay still gates correctly. Unchanged from today. |
| Old | New (rare reconnect race) | Main notifies registerRoot. New relay no-ops. FS works for any path. No regression. |

`RELAY_VERSION` is bumped on every relay code change as part of the normal deploy flow, so a new main redeploys a new relay on first connect.

## Verification

- `pnpm tc:node` — 0 errors
- `pnpm lint` — 0 errors (7 pre-existing warnings, unrelated)
- `pnpm test src/relay src/main/ssh src/main/ipc/worktrees.test.ts src/main/ipc/filesystem.test.ts src/main/ipc/repos-create.test.ts` — **469 / 469 passed**, including the new symlink regression test.
- Manual repro plan in the design doc.

## Rollback

Revert this PR. Test surface is small, revert is mechanical.

## Follow-ups (tracked separately, not in this PR)

Once the relay-version floor moves past the no-op cutover (one or two releases out), delete:

- The `RelayContext` class
- The `mux.request('session.registerRoot', …)` synchronous block + `'Method not found'` notify-fallback in `worktree-remote.ts`
- The narrowed error-translation block in `worktree-remote.ts`

See `docs/relay-fs-allowlist-removal.md` § Follow-ups.

Made with [Orca](https://github.com/stablyai/orca) 🐋
