### PR TITLE
feat(settings): list supported audio formats for Custom Notification Sound

### DIFF
--- a/src/renderer/src/components/settings/NotificationsPane.tsx
+++ b/src/renderer/src/components/settings/NotificationsPane.tsx
@@ -31,8 +31,9 @@ export const NOTIFICATIONS_PANE_SEARCH_ENTRIES: SettingsSearchEntry[] = [
   },
   {
     title: 'Custom Sound',
-    description: 'Choose one local audio file for all delivered desktop notifications.',
-    keywords: ['notifications', 'sound', 'audio', 'ogg', 'mp3', 'wav']
+    description:
+      'Choose one local audio file (MP3, WAV, OGG, M4A, AAC, or FLAC) for all delivered desktop notifications.',
+    keywords: ['notifications', 'sound', 'audio', 'mp3', 'wav', 'ogg', 'm4a', 'aac', 'flac']
   },
   {
     title: 'Send Test Notification',
@@ -140,6 +141,9 @@ export function NotificationsPane({
           </div>
           <p className="text-xs text-muted-foreground">
             One local audio file for all delivered desktop notifications.
+          </p>
+          <p className="text-[11px] text-muted-foreground/80">
+            Supported formats: MP3, WAV, OGG, M4A, AAC, FLAC.
           </p>
         </div>
         <div className="flex min-w-0 flex-wrap items-center gap-2">


### PR DESCRIPTION
## Summary
- Updates `SettingsSearchEntry` for "Custom Sound" to include all supported formats (MP3, WAV, OGG, M4A, AAC, FLAC) in the description and keywords, improving search discoverability.
- Adds a small caption line under the Custom Sound description in `NotificationsPane` listing the supported formats so users know what file types they can pick.
- Source of truth for the format list: `src/main/ipc/shell.ts` line 129 (the `pickAudio` dialog filter).

## Test plan
- [ ] Open Settings → Notifications, verify a "Supported formats: MP3, WAV, OGG, M4A, AAC, FLAC." caption appears under the Custom Sound description.
- [ ] Search for "aac" or "flac" in settings search, verify the Custom Sound entry appears.
- [ ] No functional/logic changes — no runtime behavior to test.

Made with [Orca](https://github.com/stablyai/orca) 🐋
