### PR TITLE
Fix workspace linked artifact metadata

### DIFF
--- a/src/main/ipc/worktree-logic.ts
+++ b/src/main/ipc/worktree-logic.ts
@@ -186,6 +186,7 @@ export function mergeWorktree(
     linkedIssue: meta?.linkedIssue ?? null,
     linkedPR: meta?.linkedPR ?? null,
     linkedLinearIssue: meta?.linkedLinearIssue ?? null,
+    linkedArtifactUrl: meta?.linkedArtifactUrl ?? null,
     isArchived: meta?.isArchived ?? false,
     isUnread: meta?.isUnread ?? false,
     isPinned: meta?.isPinned ?? false,

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -90,6 +90,7 @@ export async function createRemoteWorktree(
   const requestedDisplayName = args.displayName
     ? sanitizeWorktreeDisplayName(args.displayName)
     : undefined
+  const initialMeta = args.initialMeta ?? {}
 
   // Get git username from remote
   let username = ''
@@ -211,6 +212,7 @@ export async function createRemoteWorktree(
   const worktreeId = `${repo.id}::${created.path}`
   const now = Date.now()
   const metaUpdates: Partial<WorktreeMeta> = {
+    ...initialMeta,
     lastActivityAt: now,
     // Why: grants the new worktree a short grace window at the top of the
     // Recent sort. During worktree creation (git fetch + add can take several
@@ -253,6 +255,7 @@ export async function createLocalWorktree(
   const requestedDisplayName = args.displayName
     ? sanitizeWorktreeDisplayName(args.displayName)
     : undefined
+  const initialMeta = args.initialMeta ?? {}
 
   // Why (§3.3): determine the base branch (and therefore the remote we need to
   // fetch) FIRST, so the fetch can overlap all pre-create work below. Neither
@@ -470,6 +473,7 @@ export async function createLocalWorktree(
   const worktreeId = `${repo.id}::${created.path}`
   const now = Date.now()
   const metaUpdates: Partial<WorktreeMeta> = {
+    ...initialMeta,
     // Stamp activity so the worktree sorts into its final position
     // immediately — prevents scroll-to-reveal racing with a later
     // bumpWorktreeActivity that would re-sort the list.

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -344,6 +344,42 @@ describe('registerWorktreeHandlers', () => {
     })
   })
 
+  it('persists initial linked artifact metadata during local worktree creation', async () => {
+    listWorktreesMock.mockResolvedValue([
+      {
+        path: '/workspace/improve-dashboard',
+        head: 'abc123',
+        branch: 'improve-dashboard',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+    store.setWorktreeMeta.mockImplementation((_worktreeId, meta) => meta)
+
+    const result = await handlers['worktrees:create'](null, {
+      repoId: 'repo-1',
+      name: 'improve-dashboard',
+      initialMeta: {
+        linkedPR: 1687,
+        linkedArtifactUrl: 'https://github.com/stablyai/orca/pull/1687'
+      }
+    })
+
+    expect(store.setWorktreeMeta).toHaveBeenCalledWith(
+      'repo-1::/workspace/improve-dashboard',
+      expect.objectContaining({
+        linkedPR: 1687,
+        linkedArtifactUrl: 'https://github.com/stablyai/orca/pull/1687'
+      })
+    )
+    expect(result).toEqual({
+      worktree: expect.objectContaining({
+        linkedPR: 1687,
+        linkedArtifactUrl: 'https://github.com/stablyai/orca/pull/1687'
+      })
+    })
+  })
+
   it('does not await a cold fetch when the remote-tracking base exists locally', async () => {
     const remoteBase = {
       remote: 'origin',

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -974,6 +974,7 @@ function getDefaultWorktreeMeta(): WorktreeMeta {
     linkedIssue: null,
     linkedPR: null,
     linkedLinearIssue: null,
+    linkedArtifactUrl: null,
     isArchived: false,
     isUnread: false,
     isPinned: false,

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -1760,7 +1760,8 @@ export default function TaskPage(): React.JSX.Element {
         type: 'issue',
         number: 0,
         title: issue.title,
-        url: issue.url
+        url: issue.url,
+        linearIdentifier: issue.identifier
       }
       openModal('new-workspace-composer', {
         linkedWorkItem,

--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -667,7 +667,7 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
       // composer once the lookup returns.
       closeModal()
       void window.api.gh
-        .workItem({ repoPath: repoForLookup.path, number })
+        .workItem({ repoPath: repoForLookup.path, number, type: ghLink.type })
         .then((item) => {
           const data: Record<string, unknown> = { initialRepoId: repoForLookup.id }
           if (item) {
@@ -680,7 +680,14 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
             data.linkedWorkItem = linkedWorkItem
             data.prefilledName = getLinkedWorkItemSuggestedName({ title: item.title })
           } else {
-            // Fallback: we couldn't resolve the URL, just seed the name.
+            // Why: preserve the pasted artifact as a linked source even if the
+            // network lookup fails, instead of demoting it to a plain note/name.
+            data.linkedWorkItem = {
+              type: ghLink.type,
+              number,
+              title: `${slug.owner}/${slug.repo}#${number}`,
+              url: trimmed
+            } satisfies LinkedWorkItemSummary
             data.prefilledName = `${slug.owner}-${slug.repo}-${number}`
           }
           queueMicrotask(() =>

--- a/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
+++ b/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
@@ -480,7 +480,10 @@ export default function SmartWorkspaceNameField({
     if (/^#\d+$/.test(trimmed) || parseGitHubIssueOrPRLink(trimmed) !== null) {
       return 'github'
     }
-    if (/^[A-Za-z][A-Za-z0-9_]*-\d+$/.test(trimmed)) {
+    if (
+      /^[A-Za-z][A-Za-z0-9_]*-\d+$/.test(trimmed) ||
+      /(?:^|[^A-Za-z0-9_])([A-Za-z][A-Za-z0-9_]*-\d+)(?=$|[^A-Za-z0-9_])/i.test(trimmed)
+    ) {
       return 'linear'
     }
     return null

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -38,7 +38,7 @@ import {
   EMPTY_BROWSER_TABS,
   FilledBellIcon
 } from './WorktreeCardHelpers'
-import { IssueSection, PrSection, CommentSection } from './WorktreeCardMeta'
+import { IssueSection, PrSection, LinearSection, CommentSection } from './WorktreeCardMeta'
 import {
   selectLivePtyIdsForWorktree,
   selectRuntimePaneTitlesForWorktree
@@ -66,7 +66,9 @@ const WorktreeCard = React.memo(function WorktreeCard({
   const updateWorktreeMeta = useAppStore((s) => s.updateWorktreeMeta)
   const fetchPRForBranch = useAppStore((s) => s.fetchPRForBranch)
   const fetchIssue = useAppStore((s) => s.fetchIssue)
+  const fetchLinearIssue = useAppStore((s) => s.fetchLinearIssue)
   const cardProps = useAppStore((s) => s.worktreeCardProperties)
+  const currentArtifactUrl = worktree.linkedArtifactUrl ?? null
   const handleEditIssue = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation()
@@ -74,11 +76,14 @@ const WorktreeCard = React.memo(function WorktreeCard({
         worktreeId: worktree.id,
         currentDisplayName: worktree.displayName,
         currentIssue: worktree.linkedIssue,
+        currentPR: worktree.linkedPR,
+        currentLinearIssue: worktree.linkedLinearIssue,
+        currentArtifactUrl,
         currentComment: worktree.comment,
         focus: 'issue'
       })
     },
-    [worktree, openModal]
+    [worktree, currentArtifactUrl, openModal]
   )
 
   const handleEditComment = useCallback(
@@ -88,11 +93,14 @@ const WorktreeCard = React.memo(function WorktreeCard({
         worktreeId: worktree.id,
         currentDisplayName: worktree.displayName,
         currentIssue: worktree.linkedIssue,
+        currentPR: worktree.linkedPR,
+        currentLinearIssue: worktree.linkedLinearIssue,
+        currentArtifactUrl,
         currentComment: worktree.comment,
         focus: 'comment'
       })
     },
-    [worktree, openModal]
+    [worktree, currentArtifactUrl, openModal]
   )
 
   const deleteState = useAppStore((s) => s.deleteStateByWorktreeId[worktree.id])
@@ -148,10 +156,14 @@ const WorktreeCard = React.memo(function WorktreeCard({
   const isFolder = repo ? isFolderRepo(repo) : false
   const prCacheKey = repo && branch ? `${repo.path}::${branch}` : ''
   const issueCacheKey = repo && worktree.linkedIssue ? `${repo.path}::${worktree.linkedIssue}` : ''
+  const linearCacheKey = worktree.linkedLinearIssue ?? ''
 
   // Subscribe to ONLY the specific cache entry, not entire prCache/issueCache
   const prEntry = useAppStore((s) => (prCacheKey ? s.prCache[prCacheKey] : undefined))
   const issueEntry = useAppStore((s) => (issueCacheKey ? s.issueCache[issueCacheKey] : undefined))
+  const linearEntry = useAppStore((s) =>
+    linearCacheKey ? s.linearIssueCache[linearCacheKey] : undefined
+  )
 
   const pr: PRInfo | null | undefined = prEntry !== undefined ? prEntry.data : undefined
   const issue: IssueInfo | null | undefined = worktree.linkedIssue
@@ -167,7 +179,34 @@ const WorktreeCard = React.memo(function WorktreeCard({
           // Why: linked metadata is persisted immediately, but GitHub details
           // arrive asynchronously. Show the durable link number instead of
           // making the worktree look unlinked while the cache warms.
-          title: issue === null ? 'Issue details unavailable' : 'Loading issue...'
+          title: issue === null ? 'Issue details unavailable' : 'Loading issue...',
+          url: currentArtifactUrl ?? undefined
+        }
+      : null)
+  const prDisplay =
+    pr ??
+    (worktree.linkedPR
+      ? {
+          number: worktree.linkedPR,
+          // Why: PR details can be delayed or unavailable when the branch does
+          // not match the PR head. The persisted PR number/URL should still be
+          // visible on the workspace card.
+          title: pr === null ? 'PR details unavailable' : 'Loading PR...',
+          url: currentArtifactUrl ?? undefined
+        }
+      : null)
+  const linearIssue = worktree.linkedLinearIssue
+    ? linearEntry !== undefined
+      ? linearEntry.data
+      : undefined
+    : null
+  const linearDisplay =
+    linearIssue ??
+    (worktree.linkedLinearIssue
+      ? {
+          identifier: worktree.linkedLinearIssue,
+          title: linearIssue === null ? 'Linear details unavailable' : 'Loading Linear issue...',
+          url: currentArtifactUrl ?? undefined
         }
       : null)
 
@@ -318,6 +357,14 @@ const WorktreeCard = React.memo(function WorktreeCard({
     return () => clearInterval(interval)
   }, [repo, isFolder, worktree.linkedIssue, fetchIssue, issueCacheKey, showIssue])
 
+  useEffect(() => {
+    if (!worktree.linkedLinearIssue || !showIssue) {
+      return
+    }
+
+    fetchLinearIssue(worktree.linkedLinearIssue)
+  }, [worktree.linkedLinearIssue, fetchLinearIssue, showIssue])
+
   // Stable click handler – ignore clicks that are really text selections.
   const handleClick = useCallback(
     (event: React.MouseEvent<HTMLDivElement>) => {
@@ -355,9 +402,21 @@ const WorktreeCard = React.memo(function WorktreeCard({
       worktreeId: worktree.id,
       currentDisplayName: worktree.displayName,
       currentIssue: worktree.linkedIssue,
+      currentPR: worktree.linkedPR,
+      currentLinearIssue: worktree.linkedLinearIssue,
+      currentArtifactUrl,
       currentComment: worktree.comment
     })
-  }, [worktree.id, worktree.displayName, worktree.linkedIssue, worktree.comment, openModal])
+  }, [
+    worktree.id,
+    worktree.displayName,
+    worktree.linkedIssue,
+    worktree.linkedPR,
+    worktree.linkedLinearIssue,
+    currentArtifactUrl,
+    worktree.comment,
+    openModal
+  ])
 
   const handleToggleUnreadQuick = useCallback(
     (event: React.MouseEvent<HTMLButtonElement>) => {
@@ -589,14 +648,19 @@ const WorktreeCard = React.memo(function WorktreeCard({
         {/* Meta section: Issue / PR Links / Comment
              Layout coupling: spacing here is used to derive size estimates in
              WorktreeList's estimateSize. Update that function if changing spacing. */}
-        {((cardProps.includes('issue') && issueDisplay) ||
-          (cardProps.includes('pr') && pr) ||
+        {((cardProps.includes('issue') && (issueDisplay || linearDisplay)) ||
+          (cardProps.includes('pr') && prDisplay) ||
           (cardProps.includes('comment') && worktree.comment)) && (
           <div className="flex flex-col gap-[3px] mt-0.5">
             {cardProps.includes('issue') && issueDisplay && (
               <IssueSection issue={issueDisplay} onClick={handleEditIssue} />
             )}
-            {cardProps.includes('pr') && pr && <PrSection pr={pr} onClick={handleEditIssue} />}
+            {cardProps.includes('pr') && prDisplay && (
+              <PrSection pr={prDisplay} onClick={handleEditIssue} />
+            )}
+            {cardProps.includes('issue') && linearDisplay && (
+              <LinearSection issue={linearDisplay} onClick={handleEditIssue} />
+            )}
             {cardProps.includes('comment') && worktree.comment && (
               <CommentSection comment={worktree.comment} onDoubleClick={handleEditComment} />
             )}

--- a/src/renderer/src/components/sidebar/WorktreeCardMeta.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardMeta.tsx
@@ -11,7 +11,8 @@ import { CircleDot } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import CommentMarkdown from './CommentMarkdown'
 import { PullRequestIcon, prStateLabel, checksLabel } from './WorktreeCardHelpers'
-import type { PRInfo, IssueInfo } from '../../../../shared/types'
+import { LinearIcon } from '@/components/icons/LinearIcon'
+import type { PRInfo, IssueInfo, LinearIssue } from '../../../../shared/types'
 
 // ── Issue section ────────────────────────────────────────────────────
 
@@ -82,59 +83,169 @@ export function IssueSection({ issue, onClick }: IssueSectionProps): React.JSX.E
 // ── PR section ───────────────────────────────────────────────────────
 
 type PrSectionProps = {
-  pr: PRInfo
+  pr:
+    | PRInfo
+    | {
+        number: number
+        title: string
+        url?: string
+        state?: PRInfo['state']
+        checksStatus?: PRInfo['checksStatus']
+      }
   onClick: (e: React.MouseEvent) => void
 }
 
-export function PrSection({ pr, onClick: _onClick }: PrSectionProps): React.JSX.Element {
+export function PrSection({ pr, onClick }: PrSectionProps): React.JSX.Element {
+  const content = (
+    <>
+      <PullRequestIcon
+        className={cn(
+          'size-3 shrink-0',
+          pr.state === 'merged' && 'text-purple-600/70 dark:text-purple-400/70',
+          pr.state === 'open' && 'text-emerald-500/80',
+          pr.state === 'closed' && 'text-muted-foreground/60',
+          pr.state === 'draft' && 'text-muted-foreground/50',
+          (!pr.state || !['merged', 'open', 'closed', 'draft'].includes(pr.state)) &&
+            'text-muted-foreground opacity-60'
+        )}
+      />
+      <div className="flex-1 min-w-0 flex items-center gap-1.5 text-[11.5px] leading-none">
+        <span className="text-foreground opacity-80 shrink-0 group-hover/meta:underline">
+          PR #{pr.number}
+        </span>
+        <span className="text-muted-foreground truncate group-hover/meta:text-foreground transition-colors">
+          {pr.title}
+        </span>
+      </div>
+    </>
+  )
+
   return (
     <HoverCard openDelay={300}>
       <HoverCardTrigger asChild>
-        <a
-          href={pr.url}
-          target="_blank"
-          rel="noreferrer"
-          className="flex items-center gap-1.5 min-w-0 cursor-pointer group/meta -mx-1.5 px-1.5 py-0.5 rounded transition-colors hover:bg-background/40"
-          onClick={(e) => e.stopPropagation()}
-        >
-          <PullRequestIcon
-            className={cn(
-              'size-3 shrink-0',
-              pr.state === 'merged' && 'text-purple-600/70 dark:text-purple-400/70',
-              pr.state === 'open' && 'text-emerald-500/80',
-              pr.state === 'closed' && 'text-muted-foreground/60',
-              pr.state === 'draft' && 'text-muted-foreground/50',
-              (!pr.state || !['merged', 'open', 'closed', 'draft'].includes(pr.state)) &&
-                'text-muted-foreground opacity-60'
-            )}
-          />
-          <div className="flex-1 min-w-0 flex items-center gap-1.5 text-[11.5px] leading-none">
-            <span className="text-foreground opacity-80 shrink-0 group-hover/meta:underline">
-              PR #{pr.number}
-            </span>
-            <span className="text-muted-foreground truncate group-hover/meta:text-foreground transition-colors">
-              {pr.title}
-            </span>
+        {pr.url ? (
+          <a
+            href={pr.url}
+            target="_blank"
+            rel="noreferrer"
+            className="flex items-center gap-1.5 min-w-0 cursor-pointer group/meta -mx-1.5 px-1.5 py-0.5 rounded transition-colors hover:bg-background/40"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {content}
+          </a>
+        ) : (
+          <div
+            className="flex items-center gap-1.5 min-w-0 cursor-pointer group/meta -mx-1.5 px-1.5 py-0.5 rounded transition-colors hover:bg-background/40"
+            onClick={onClick}
+          >
+            {content}
           </div>
-        </a>
+        )}
       </HoverCardTrigger>
       <HoverCardContent side="right" align="start" className="w-72 p-3 text-xs space-y-1.5">
         <div className="font-semibold text-[13px]">
           #{pr.number} {pr.title}
         </div>
-        <div className="flex items-center gap-2 text-muted-foreground">
-          <span>State: {prStateLabel(pr.state)}</span>
-          {pr.checksStatus !== 'neutral' && <span>Checks: {checksLabel(pr.checksStatus)}</span>}
+        {(pr.state || (pr.checksStatus && pr.checksStatus !== 'neutral')) && (
+          <div className="flex items-center gap-2 text-muted-foreground">
+            {pr.state && <span>State: {prStateLabel(pr.state)}</span>}
+            {pr.checksStatus && pr.checksStatus !== 'neutral' && (
+              <span>Checks: {checksLabel(pr.checksStatus)}</span>
+            )}
+          </div>
+        )}
+        {pr.url && (
+          <a
+            href={pr.url}
+            target="_blank"
+            rel="noreferrer"
+            className="text-muted-foreground underline underline-offset-2 hover:text-foreground"
+            onClick={(e) => e.stopPropagation()}
+          >
+            View on GitHub
+          </a>
+        )}
+      </HoverCardContent>
+    </HoverCard>
+  )
+}
+
+// ── Linear section ──────────────────────────────────────────────────
+
+type LinearSectionProps = {
+  issue:
+    | LinearIssue
+    | {
+        identifier: string
+        title: string
+        url?: string
+        state?: LinearIssue['state']
+        labels?: string[]
+      }
+  onClick: (e: React.MouseEvent) => void
+}
+
+export function LinearSection({ issue, onClick }: LinearSectionProps): React.JSX.Element {
+  const labels = issue.labels ?? []
+  const content = (
+    <>
+      <LinearIcon className="size-3 shrink-0 text-muted-foreground opacity-70" />
+      <div className="flex-1 min-w-0 flex items-center gap-1.5 text-[11.5px] leading-none">
+        <span className="text-foreground opacity-80 font-medium shrink-0">{issue.identifier}</span>
+        <span className="text-muted-foreground truncate group-hover/meta:text-foreground transition-colors">
+          {issue.title}
+        </span>
+      </div>
+    </>
+  )
+
+  return (
+    <HoverCard openDelay={300}>
+      <HoverCardTrigger asChild>
+        {issue.url ? (
+          <a
+            href={issue.url}
+            target="_blank"
+            rel="noreferrer"
+            className="flex items-center gap-1.5 min-w-0 cursor-pointer group/meta -mx-1.5 px-1.5 py-0.5 rounded transition-colors hover:bg-background/40"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {content}
+          </a>
+        ) : (
+          <div
+            className="flex items-center gap-1.5 min-w-0 cursor-pointer group/meta -mx-1.5 px-1.5 py-0.5 rounded transition-colors hover:bg-background/40"
+            onClick={onClick}
+          >
+            {content}
+          </div>
+        )}
+      </HoverCardTrigger>
+      <HoverCardContent side="right" align="start" className="w-72 p-3 text-xs space-y-1.5">
+        <div className="font-semibold text-[13px]">
+          {issue.identifier} {issue.title}
         </div>
-        <a
-          href={pr.url}
-          target="_blank"
-          rel="noreferrer"
-          className="text-muted-foreground underline underline-offset-2 hover:text-foreground"
-          onClick={(e) => e.stopPropagation()}
-        >
-          View on GitHub
-        </a>
+        {issue.state && <div className="text-muted-foreground">State: {issue.state.name}</div>}
+        {labels.length > 0 && (
+          <div className="flex flex-wrap gap-1">
+            {labels.map((label) => (
+              <Badge key={label} variant="outline" className="h-4 px-1.5 text-[9px]">
+                {label}
+              </Badge>
+            ))}
+          </div>
+        )}
+        {issue.url && (
+          <a
+            href={issue.url}
+            target="_blank"
+            rel="noreferrer"
+            className="text-muted-foreground underline underline-offset-2 hover:text-foreground"
+            onClick={(e) => e.stopPropagation()}
+          >
+            View on Linear
+          </a>
+        )}
       </HoverCardContent>
     </HoverCard>
   )

--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
@@ -49,6 +49,7 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
   const [menuPoint, setMenuPoint] = useState({ x: 0, y: 0 })
   const isDeleting = deleteState?.isDeleting ?? false
   const isFolder = repo ? isFolderRepo(repo) : false
+  const currentArtifactUrl = worktree.linkedArtifactUrl ?? null
 
   useEffect(() => {
     const closeMenu = (): void => setMenuOpen(false)
@@ -77,30 +78,66 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
       worktreeId: worktree.id,
       currentDisplayName: worktree.displayName,
       currentIssue: worktree.linkedIssue,
+      currentPR: worktree.linkedPR,
+      currentLinearIssue: worktree.linkedLinearIssue,
+      currentArtifactUrl,
       currentComment: worktree.comment,
       focus: 'displayName'
     })
-  }, [worktree.id, worktree.displayName, worktree.linkedIssue, worktree.comment, openModal])
+  }, [
+    worktree.id,
+    worktree.displayName,
+    worktree.linkedIssue,
+    worktree.linkedPR,
+    worktree.linkedLinearIssue,
+    currentArtifactUrl,
+    worktree.comment,
+    openModal
+  ])
 
   const handleLinkIssue = useCallback(() => {
     openModal('edit-meta', {
       worktreeId: worktree.id,
       currentDisplayName: worktree.displayName,
       currentIssue: worktree.linkedIssue,
+      currentPR: worktree.linkedPR,
+      currentLinearIssue: worktree.linkedLinearIssue,
+      currentArtifactUrl,
       currentComment: worktree.comment,
       focus: 'issue'
     })
-  }, [worktree.id, worktree.displayName, worktree.linkedIssue, worktree.comment, openModal])
+  }, [
+    worktree.id,
+    worktree.displayName,
+    worktree.linkedIssue,
+    worktree.linkedPR,
+    worktree.linkedLinearIssue,
+    currentArtifactUrl,
+    worktree.comment,
+    openModal
+  ])
 
   const handleComment = useCallback(() => {
     openModal('edit-meta', {
       worktreeId: worktree.id,
       currentDisplayName: worktree.displayName,
       currentIssue: worktree.linkedIssue,
+      currentPR: worktree.linkedPR,
+      currentLinearIssue: worktree.linkedLinearIssue,
+      currentArtifactUrl,
       currentComment: worktree.comment,
       focus: 'comment'
     })
-  }, [worktree.id, worktree.displayName, worktree.linkedIssue, worktree.comment, openModal])
+  }, [
+    worktree.id,
+    worktree.displayName,
+    worktree.linkedIssue,
+    worktree.linkedPR,
+    worktree.linkedLinearIssue,
+    currentArtifactUrl,
+    worktree.comment,
+    openModal
+  ])
 
   const handleCloseTerminals = useCallback(async () => {
     await runSleepWorktree(worktree.id)
@@ -175,7 +212,9 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
           </DropdownMenuItem>
           <DropdownMenuItem onSelect={handleLinkIssue} disabled={isDeleting}>
             <Link className="size-3.5" />
-            {worktree.linkedIssue ? 'Edit GH Issue' : 'Link GH Issue'}
+            {worktree.linkedIssue || worktree.linkedPR || worktree.linkedLinearIssue
+              ? 'Edit Linked Artifact'
+              : 'Link Artifact'}
           </DropdownMenuItem>
           <DropdownMenuItem onSelect={handleComment} disabled={isDeleting}>
             <MessageSquare className="size-3.5" />

--- a/src/renderer/src/components/sidebar/WorktreeMetaDialog.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeMetaDialog.tsx
@@ -10,8 +10,115 @@ import {
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
-import { parseGitHubIssueOrPRNumber } from '@/lib/github-links'
+import { Label } from '@/components/ui/label'
+import { CircleDot, Github, GitPullRequest, Link2, X } from 'lucide-react'
+import { parseGitHubIssueOrPRLink, parseGitHubIssueOrPRNumber } from '@/lib/github-links'
+import { cn } from '@/lib/utils'
+import { LinearIcon } from '@/components/icons/LinearIcon'
 import type { WorktreeMeta } from '../../../../shared/types'
+
+type LinkedArtifactInput =
+  | { kind: 'none' }
+  | { kind: 'github-issue'; number: number; url: string | null }
+  | { kind: 'github-pr'; number: number; url: string | null }
+  | { kind: 'linear'; identifier: string; url: string | null }
+
+function parseLinearIssueIdentifier(input: string): string | null {
+  const match = /(?:^|[^A-Za-z0-9_])([A-Za-z][A-Za-z0-9_]*-\d+)(?=$|[^A-Za-z0-9_])/i.exec(input)
+  return match ? match[1].toUpperCase() : null
+}
+
+function parseLinkedArtifactInput(input: string): LinkedArtifactInput | null {
+  const trimmed = input.trim()
+  if (!trimmed) {
+    return { kind: 'none' }
+  }
+
+  const ghLink = parseGitHubIssueOrPRLink(trimmed)
+  if (ghLink) {
+    return ghLink.type === 'pr'
+      ? { kind: 'github-pr', number: ghLink.number, url: trimmed }
+      : { kind: 'github-issue', number: ghLink.number, url: trimmed }
+  }
+
+  const prMatch = /^pr\s*#?(\d+)$/i.exec(trimmed)
+  if (prMatch) {
+    return { kind: 'github-pr', number: Number.parseInt(prMatch[1], 10), url: null }
+  }
+
+  const issueNumber = parseGitHubIssueOrPRNumber(trimmed)
+  if (issueNumber !== null) {
+    return { kind: 'github-issue', number: issueNumber, url: null }
+  }
+
+  const linearIdentifier = parseLinearIssueIdentifier(trimmed)
+  return linearIdentifier
+    ? {
+        kind: 'linear',
+        identifier: linearIdentifier,
+        url: /^https?:\/\//i.test(trimmed) ? trimmed : null
+      }
+    : null
+}
+
+function formatCurrentArtifact(
+  issue: number | null,
+  pr: number | null,
+  linear: string | null,
+  artifactUrl: string | null
+) {
+  if (artifactUrl) {
+    return artifactUrl
+  }
+  if (pr !== null) {
+    return `PR #${pr}`
+  }
+  if (issue !== null) {
+    return `#${issue}`
+  }
+  return linear ?? ''
+}
+
+function getArtifactSummary(parsedArtifact: LinkedArtifactInput | null) {
+  if (!parsedArtifact) {
+    return {
+      tone: 'invalid' as const,
+      label: 'Invalid artifact',
+      detail: 'Use a GitHub issue/PR URL, PR #123, issue #123, or Linear ID.',
+      Icon: Link2
+    }
+  }
+  if (parsedArtifact.kind === 'none') {
+    return {
+      tone: 'empty' as const,
+      label: 'No linked artifact',
+      detail: 'Leave empty to keep this workspace unlinked.',
+      Icon: Link2
+    }
+  }
+  if (parsedArtifact.kind === 'github-pr') {
+    return {
+      tone: 'valid' as const,
+      label: `GitHub PR #${parsedArtifact.number}`,
+      detail: 'PR metadata will show on the workspace card.',
+      Icon: GitPullRequest
+    }
+  }
+  if (parsedArtifact.kind === 'github-issue') {
+    return {
+      tone: 'valid' as const,
+      label: `GitHub issue #${parsedArtifact.number}`,
+      detail: 'Issue metadata will show on the workspace card.',
+      Icon: CircleDot
+    }
+  }
+  return {
+    tone: 'valid' as const,
+    label: `Linear ${parsedArtifact.identifier}`,
+    detail: 'Linear metadata will show on the workspace card.',
+    Icon: LinearIcon
+  }
+}
 
 const WorktreeMetaDialog = React.memo(function WorktreeMetaDialog() {
   const activeModal = useAppStore((s) => s.activeModal)
@@ -25,25 +132,31 @@ const WorktreeMetaDialog = React.memo(function WorktreeMetaDialog() {
   const worktreeId = typeof modalData.worktreeId === 'string' ? modalData.worktreeId : ''
   const currentDisplayName =
     typeof modalData.currentDisplayName === 'string' ? modalData.currentDisplayName : ''
-  const currentIssue =
-    typeof modalData.currentIssue === 'number' ? String(modalData.currentIssue) : ''
+  const currentIssue = typeof modalData.currentIssue === 'number' ? modalData.currentIssue : null
+  const currentPR = typeof modalData.currentPR === 'number' ? modalData.currentPR : null
+  const currentLinearIssue =
+    typeof modalData.currentLinearIssue === 'string' ? modalData.currentLinearIssue : null
+  const currentArtifactUrl =
+    typeof modalData.currentArtifactUrl === 'string' ? modalData.currentArtifactUrl : null
   const currentComment =
     typeof modalData.currentComment === 'string' ? modalData.currentComment : ''
   const focusField = typeof modalData.focus === 'string' ? modalData.focus : 'comment'
 
   const [displayNameInput, setDisplayNameInput] = useState('')
-  const [issueInput, setIssueInput] = useState('')
+  const [artifactInput, setArtifactInput] = useState('')
   const [commentInput, setCommentInput] = useState('')
   const [saving, setSaving] = useState(false)
   const isMac = navigator.userAgent.includes('Mac')
 
-  const issueInputRef = useRef<HTMLInputElement>(null)
+  const artifactInputRef = useRef<HTMLInputElement>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const prevIsOpenRef = useRef(false)
   const displayNameInputRef = useRef<HTMLInputElement>(null)
   if (isOpen && !prevIsOpenRef.current) {
     setDisplayNameInput(currentDisplayName)
-    setIssueInput(currentIssue)
+    setArtifactInput(
+      formatCurrentArtifact(currentIssue, currentPR, currentLinearIssue, currentArtifactUrl)
+    )
     setCommentInput(currentComment)
   }
   prevIsOpenRef.current = isOpen
@@ -67,8 +180,12 @@ const WorktreeMetaDialog = React.memo(function WorktreeMetaDialog() {
     if (!worktreeId) {
       return false
     }
-    return issueInput.trim() === '' || parseGitHubIssueOrPRNumber(issueInput) !== null
-  }, [worktreeId, issueInput])
+    return parseLinkedArtifactInput(artifactInput) !== null
+  }, [worktreeId, artifactInput])
+  const parsedArtifact = useMemo(() => parseLinkedArtifactInput(artifactInput), [artifactInput])
+  const artifactSummary = useMemo(() => getArtifactSummary(parsedArtifact), [parsedArtifact])
+  const ArtifactIcon = artifactSummary.Icon
+  const isArtifactInvalid = parsedArtifact === null
 
   const handleOpenChange = useCallback(
     (open: boolean) => {
@@ -85,10 +202,10 @@ const WorktreeMetaDialog = React.memo(function WorktreeMetaDialog() {
     }
     setSaving(true)
     try {
-      const trimmedIssue = issueInput.trim()
-      const linkedIssueNumber = parseGitHubIssueOrPRNumber(trimmedIssue)
-      const finalLinkedIssue =
-        trimmedIssue === '' ? null : linkedIssueNumber !== null ? linkedIssueNumber : undefined
+      const parsedArtifact = parseLinkedArtifactInput(artifactInput)
+      if (!parsedArtifact) {
+        return
+      }
 
       const trimmedDisplayName = displayNameInput.trim()
       const updates: Partial<WorktreeMeta> = {
@@ -97,8 +214,26 @@ const WorktreeMetaDialog = React.memo(function WorktreeMetaDialog() {
           displayName: trimmedDisplayName || undefined
         })
       }
-      if (finalLinkedIssue !== undefined) {
-        updates.linkedIssue = finalLinkedIssue
+      if (parsedArtifact.kind === 'none') {
+        updates.linkedIssue = null
+        updates.linkedPR = null
+        updates.linkedLinearIssue = null
+        updates.linkedArtifactUrl = null
+      } else if (parsedArtifact.kind === 'github-issue') {
+        updates.linkedIssue = parsedArtifact.number
+        updates.linkedPR = null
+        updates.linkedLinearIssue = null
+        updates.linkedArtifactUrl = parsedArtifact.url
+      } else if (parsedArtifact.kind === 'github-pr') {
+        updates.linkedIssue = null
+        updates.linkedPR = parsedArtifact.number
+        updates.linkedLinearIssue = null
+        updates.linkedArtifactUrl = parsedArtifact.url
+      } else {
+        updates.linkedIssue = null
+        updates.linkedPR = null
+        updates.linkedLinearIssue = parsedArtifact.identifier
+        updates.linkedArtifactUrl = parsedArtifact.url
       }
 
       await updateWorktreeMeta(worktreeId, updates)
@@ -110,7 +245,7 @@ const WorktreeMetaDialog = React.memo(function WorktreeMetaDialog() {
     worktreeId,
     displayNameInput,
     currentDisplayName,
-    issueInput,
+    artifactInput,
     commentInput,
     updateWorktreeMeta,
     closeModal
@@ -127,7 +262,7 @@ const WorktreeMetaDialog = React.memo(function WorktreeMetaDialog() {
     [handleSave]
   )
 
-  const handleIssueKeyDown = useCallback(
+  const handleInputKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
       if (e.key === 'Enter') {
         e.preventDefault()
@@ -140,60 +275,101 @@ const WorktreeMetaDialog = React.memo(function WorktreeMetaDialog() {
   return (
     <Dialog open={isOpen} onOpenChange={handleOpenChange}>
       <DialogContent
-        className="max-w-md"
+        className="max-w-lg"
         onOpenAutoFocus={(e) => {
           e.preventDefault()
           if (focusField === 'displayName') {
             displayNameInputRef.current?.focus()
           } else if (focusField === 'issue') {
-            issueInputRef.current?.focus()
+            artifactInputRef.current?.focus()
           } else {
             textareaRef.current?.focus()
           }
         }}
       >
         <DialogHeader>
-          <DialogTitle className="text-sm">Edit Worktree Details</DialogTitle>
-          <DialogDescription className="text-xs">
-            Edit the GitHub issue link and notes for this worktree.
+          <DialogTitle className="text-base">Workspace Details</DialogTitle>
+          <DialogDescription className="text-xs leading-5">
+            Update the sidebar name, linked artifact, and workspace notes.
           </DialogDescription>
         </DialogHeader>
 
-        <div className="space-y-4">
-          <div className="space-y-1">
-            <label className="text-[11px] font-medium text-muted-foreground">Display Name</label>
+        <div className="space-y-5">
+          <div className="space-y-1.5">
+            <Label htmlFor="worktree-display-name" className="text-[11px] text-muted-foreground">
+              Display Name
+            </Label>
             <Input
+              id="worktree-display-name"
               ref={displayNameInputRef}
               value={displayNameInput}
               onChange={(e) => setDisplayNameInput(e.target.value)}
-              onKeyDown={handleIssueKeyDown}
-              placeholder="Custom display name..."
+              onKeyDown={handleInputKeyDown}
+              placeholder="Use branch or folder name"
               className="h-8 text-xs"
             />
             <p className="text-[10px] text-muted-foreground">
-              Only changes the name shown in the sidebar — the folder on disk stays the same. Leave
-              blank to use the branch or folder name.
+              Only changes the sidebar label. The folder on disk stays the same.
             </p>
           </div>
 
-          <div className="space-y-1">
-            <label className="text-[11px] font-medium text-muted-foreground">GH Issue</label>
-            <Input
-              ref={issueInputRef}
-              value={issueInput}
-              onChange={(e) => setIssueInput(e.target.value)}
-              onKeyDown={handleIssueKeyDown}
-              placeholder="Issue # or GitHub URL"
-              className="h-8 text-xs"
-            />
-            <p className="text-[10px] text-muted-foreground">
-              Paste an issue URL, or enter a number. Leave blank to remove the link.
+          <div className="space-y-2">
+            <Label
+              htmlFor="worktree-linked-artifact"
+              className="gap-1.5 text-[11px] text-muted-foreground"
+            >
+              <span>Linked Artifact</span>
+              <span className="flex items-center gap-1 text-muted-foreground/70">
+                <Github className="size-3" aria-label="GitHub" />
+                <LinearIcon className="size-3" aria-label="Linear" />
+              </span>
+            </Label>
+            <div className="relative">
+              <ArtifactIcon
+                className={cn(
+                  'pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground',
+                  artifactSummary.tone === 'invalid' && 'text-destructive'
+                )}
+              />
+              <Input
+                id="worktree-linked-artifact"
+                ref={artifactInputRef}
+                value={artifactInput}
+                onChange={(e) => setArtifactInput(e.target.value)}
+                onKeyDown={handleInputKeyDown}
+                placeholder="GitHub URL, PR #123, #123, or ENG-123"
+                aria-invalid={isArtifactInvalid}
+                className="h-8 pr-8 pl-8 text-xs"
+              />
+              {artifactInput.trim() ? (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-xs"
+                  onClick={() => setArtifactInput('')}
+                  className="absolute right-1 top-1/2 size-6 -translate-y-1/2 rounded-sm text-muted-foreground hover:text-foreground"
+                  aria-label="Clear linked artifact"
+                >
+                  <X className="size-3.5" />
+                </Button>
+              ) : null}
+            </div>
+            <p
+              className={cn(
+                'text-[10px] leading-4 text-muted-foreground',
+                artifactSummary.tone === 'invalid' && 'text-destructive'
+              )}
+            >
+              {artifactSummary.detail}
             </p>
           </div>
 
-          <div className="space-y-1">
-            <label className="text-[11px] font-medium text-muted-foreground">Comment</label>
+          <div className="space-y-1.5">
+            <Label htmlFor="worktree-comment" className="text-[11px] text-muted-foreground">
+              Comment
+            </Label>
             <textarea
+              id="worktree-comment"
               ref={textareaRef}
               value={commentInput}
               onChange={(e) => setCommentInput(e.target.value)}

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -25,7 +25,8 @@ import type {
   SetupRunPolicy,
   SparsePreset,
   TuiAgent,
-  WorkspaceCreateTelemetrySource
+  WorkspaceCreateTelemetrySource,
+  WorktreeMeta
 } from '../../../shared/types'
 import {
   ADD_ATTACHMENT_SHORTCUT,
@@ -173,6 +174,17 @@ export type UseComposerStateResult = {
 const composerDropStack: symbol[] = []
 const EMPTY_SPARSE_PRESETS: SparsePreset[] = []
 
+function sameRepoSlug(a: { owner: string; repo: string }, b: { owner: string; repo: string }) {
+  return (
+    a.owner.toLowerCase() === b.owner.toLowerCase() && a.repo.toLowerCase() === b.repo.toLowerCase()
+  )
+}
+
+function parseLinearIssueIdentifier(input: string): string | null {
+  const match = /(?:^|[^A-Za-z0-9_])([A-Za-z][A-Za-z0-9_]*-\d+)(?=$|[^A-Za-z0-9_])/i.exec(input)
+  return match ? match[1].toUpperCase() : null
+}
+
 export function useComposerState(options: UseComposerStateOptions): UseComposerStateResult {
   const {
     initialRepoId,
@@ -272,7 +284,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     if (persistDraft && newWorkspaceDraft?.linkedIssue) {
       return newWorkspaceDraft.linkedIssue
     }
-    if (initialLinkedWorkItem?.type === 'issue') {
+    if (initialLinkedWorkItem?.type === 'issue' && initialLinkedWorkItem.number > 0) {
       return String(initialLinkedWorkItem.number)
     }
     return ''
@@ -448,6 +460,28 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     () => (linkedIssue.trim() ? parseGitHubIssueOrPRNumber(linkedIssue) : null),
     [linkedIssue]
   )
+  const parsedGitHubLinkFromName = useMemo(() => parseGitHubIssueOrPRLink(name), [name])
+  const nameGitHubLinkMatchesSelectedRepo =
+    parsedGitHubLinkFromName !== null &&
+    selectedRepoSlug !== null &&
+    sameRepoSlug(parsedGitHubLinkFromName.slug, selectedRepoSlug)
+  const effectiveLinkedIssueNumber = useMemo<number | null>(() => {
+    if (parsedLinkedIssueNumber !== null && parsedLinkedIssueNumber > 0) {
+      return parsedLinkedIssueNumber
+    }
+    if (linkedWorkItem?.type === 'issue' && linkedWorkItem.number > 0) {
+      return linkedWorkItem.number
+    }
+    if (parsedGitHubLinkFromName?.type === 'issue' && nameGitHubLinkMatchesSelectedRepo) {
+      return parsedGitHubLinkFromName.number
+    }
+    return null
+  }, [
+    linkedWorkItem,
+    nameGitHubLinkMatchesSelectedRepo,
+    parsedGitHubLinkFromName,
+    parsedLinkedIssueNumber
+  ])
   // Why: when the user pastes a PR URL straight into the workspace name field
   // (without picking from the source picker), `linkedPR` stays null and the
   // worktree card has no PR strip. Recover the PR number from the name on
@@ -456,36 +490,44 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     if (linkedPR !== null) {
       return linkedPR
     }
-    const fromName = parseGitHubIssueOrPRLink(name)
-    if (fromName && fromName.type === 'pr') {
+    if (parsedGitHubLinkFromName && parsedGitHubLinkFromName.type === 'pr') {
       // Why: only adopt a number when the URL's owner/repo matches the
       // selected repo. Pasting `github.com/other/repo/pull/1234` must not
       // mislink the worktree to an unrelated PR #1234 in the current repo.
       // If the slug hasn't resolved yet, suppress recovery rather than
       // risking a cross-repo mislink.
-      if (
-        selectedRepoSlug &&
-        fromName.slug.owner.toLowerCase() === selectedRepoSlug.owner.toLowerCase() &&
-        fromName.slug.repo.toLowerCase() === selectedRepoSlug.repo.toLowerCase()
-      ) {
-        return fromName.number
+      if (nameGitHubLinkMatchesSelectedRepo) {
+        return parsedGitHubLinkFromName.number
       }
     }
     return null
-  }, [linkedPR, name, selectedRepoSlug])
+  }, [linkedPR, nameGitHubLinkMatchesSelectedRepo, parsedGitHubLinkFromName])
+  const effectiveLinkedLinearIssue = useMemo<string | null>(() => {
+    if (!linkedWorkItem || linkedWorkItem.url.includes('github.com')) {
+      return null
+    }
+    return (
+      linkedWorkItem.linearIdentifier ??
+      parseLinearIssueIdentifier(linkedWorkItem.url) ??
+      parseLinearIssueIdentifier(linkedWorkItem.title)
+    )
+  }, [linkedWorkItem])
+  const effectiveLinkedArtifactUrl =
+    linkedWorkItem?.url ??
+    (parsedGitHubLinkFromName !== null && nameGitHubLinkMatchesSelectedRepo ? name.trim() : null)
   const setupConfig = useMemo(
     () => getSetupConfig(selectedRepo, yamlHooks),
     [selectedRepo, yamlHooks]
   )
   const setupPolicy: SetupRunPolicy = selectedRepo?.hookSettings?.setupRunPolicy ?? 'run-by-default'
   const hasIssueAutomationConfig = issueCommandTemplate.length > 0
-  const canOfferIssueAutomation = parsedLinkedIssueNumber !== null && hasIssueAutomationConfig
+  const canOfferIssueAutomation = effectiveLinkedIssueNumber !== null && hasIssueAutomationConfig
   // Why: the "no prompt + linked item" path below rehydrates the issueCommand
   // template into the main startup prompt. When that happens we suppress the
   // separate split pane that would otherwise run the same command twice.
   const willApplyIssueCommandAsPrompt = !agentPrompt.trim() && Boolean(linkedWorkItem)
   const shouldWaitForIssueAutomationCheck =
-    (parsedLinkedIssueNumber !== null || willApplyIssueCommandAsPrompt) && !hasLoadedIssueCommand
+    (effectiveLinkedIssueNumber !== null || willApplyIssueCommandAsPrompt) && !hasLoadedIssueCommand
   const shouldRunIssueAutomation = canOfferIssueAutomation && !willApplyIssueCommandAsPrompt
   const requiresExplicitSetupChoice = Boolean(setupConfig) && setupPolicy === 'ask'
   const resolvedSetupDecision =
@@ -511,11 +553,11 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       getWorkspaceSeedName({
         explicitName: name,
         prompt: agentPrompt,
-        linkedIssueNumber: parsedLinkedIssueNumber,
+        linkedIssueNumber: effectiveLinkedIssueNumber,
         linkedPR,
         fallbackName: fallbackCreatureName
       }),
-    [agentPrompt, fallbackCreatureName, linkedPR, name, parsedLinkedIssueNumber]
+    [agentPrompt, effectiveLinkedIssueNumber, fallbackCreatureName, linkedPR, name]
   )
   // Why: when the user links an issue/PR but has not typed any prompt text
   // (attachments don't count), swap the generic "Linked work items:" context
@@ -1172,7 +1214,8 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
         // numeric metadata empty and carry the real source through the URL.
         number: 0,
         title: issue.title,
-        url: issue.url
+        url: issue.url,
+        linearIdentifier: issue.identifier
       })
       const suggestedName = issue.title
       if (!name.trim() || name === lastAutoNameRef.current) {
@@ -1239,6 +1282,8 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       meta: {
         linkedIssue?: number
         linkedPR?: number
+        linkedLinearIssue?: string
+        linkedArtifactUrl?: string | null
         comment?: string
       }
     ): Promise<void> => {
@@ -1285,6 +1330,19 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
             : await ensureHooksConfirmed(useAppStore.getState(), repoId, 'issueCommand')
       }
 
+      const initialLinkedMeta: Partial<
+        Pick<WorktreeMeta, 'linkedIssue' | 'linkedPR' | 'linkedLinearIssue' | 'linkedArtifactUrl'>
+      > = {
+        ...(effectiveLinkedIssueNumber !== null ? { linkedIssue: effectiveLinkedIssueNumber } : {}),
+        ...(effectiveLinkedPR !== null ? { linkedPR: effectiveLinkedPR } : {}),
+        ...(effectiveLinkedLinearIssue !== null
+          ? { linkedLinearIssue: effectiveLinkedLinearIssue }
+          : {}),
+        ...(effectiveLinkedArtifactUrl !== null
+          ? { linkedArtifactUrl: effectiveLinkedArtifactUrl }
+          : {})
+      }
+
       const result = await createWorktree(
         repoId,
         workspaceName,
@@ -1297,22 +1355,22 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
             }
           : undefined,
         telemetrySource,
-        linkedWorkItem?.title
+        linkedWorkItem?.title,
+        initialLinkedMeta
       )
       const worktree = result.worktree
 
-      await applyWorktreeMeta(worktree.id, {
-        ...(parsedLinkedIssueNumber !== null ? { linkedIssue: parsedLinkedIssueNumber } : {}),
-        ...(effectiveLinkedPR !== null ? { linkedPR: effectiveLinkedPR } : {}),
-        ...(note.trim() ? { comment: note.trim() } : {})
-      })
+      const trimmedNote = note.trim()
+      if (trimmedNote) {
+        await applyWorktreeMeta(worktree.id, { comment: trimmedNote })
+      }
 
       const issueCommand =
         shouldRunIssueAutomation && issueCommandTrustDecision === 'run'
           ? {
               command: renderIssueCommandTemplate(issueCommandTemplate, {
-                issueNumber: parsedLinkedIssueNumber,
-                artifactUrl: linkedWorkItem?.url ?? null
+                issueNumber: effectiveLinkedIssueNumber,
+                artifactUrl: effectiveLinkedArtifactUrl
               })
             }
           : undefined
@@ -1378,11 +1436,12 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     issueCommandTemplate,
     effectiveLinkedPR,
     linkedWorkItem?.title,
-    linkedWorkItem?.url,
     normalizedSparseDirectories,
     note,
     onCreated,
-    parsedLinkedIssueNumber,
+    effectiveLinkedIssueNumber,
+    effectiveLinkedLinearIssue,
+    effectiveLinkedArtifactUrl,
     persistDraft,
     repoId,
     requiresExplicitSetupChoice,
@@ -1411,7 +1470,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       const workspaceName = getWorkspaceSeedName({
         explicitName: name,
         prompt: '',
-        linkedIssueNumber: parsedLinkedIssueNumber,
+        linkedIssueNumber: effectiveLinkedIssueNumber,
         linkedPR,
         fallbackName: fallbackCreatureName
       })
@@ -1435,6 +1494,21 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
             ? 'skip'
             : ((resolvedSetupDecision ?? 'inherit') as SetupDecision)
 
+        const initialLinkedMeta: Partial<
+          Pick<WorktreeMeta, 'linkedIssue' | 'linkedPR' | 'linkedLinearIssue' | 'linkedArtifactUrl'>
+        > = {
+          ...(effectiveLinkedIssueNumber !== null
+            ? { linkedIssue: effectiveLinkedIssueNumber }
+            : {}),
+          ...(effectiveLinkedPR !== null ? { linkedPR: effectiveLinkedPR } : {}),
+          ...(effectiveLinkedLinearIssue !== null
+            ? { linkedLinearIssue: effectiveLinkedLinearIssue }
+            : {}),
+          ...(effectiveLinkedArtifactUrl !== null
+            ? { linkedArtifactUrl: effectiveLinkedArtifactUrl }
+            : {})
+        }
+
         const result = await createWorktree(
           repoId,
           workspaceName,
@@ -1447,16 +1521,15 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
               }
             : undefined,
           telemetrySource,
-          linkedWorkItem?.title
+          linkedWorkItem?.title,
+          initialLinkedMeta
         )
         const worktree = result.worktree
 
         const trimmedNote = note.trim()
-        await applyWorktreeMeta(worktree.id, {
-          ...(parsedLinkedIssueNumber !== null ? { linkedIssue: parsedLinkedIssueNumber } : {}),
-          ...(effectiveLinkedPR !== null ? { linkedPR: effectiveLinkedPR } : {}),
-          ...(trimmedNote ? { comment: trimmedNote } : {})
-        })
+        if (trimmedNote) {
+          await applyWorktreeMeta(worktree.id, { comment: trimmedNote })
+        }
 
         // Why: when a linked work item is selected in the quick flow, launch
         // the agent with a blank prompt and type the URL into its input as a
@@ -1578,6 +1651,9 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       clearNewWorkspaceDraft,
       createWorktree,
       fallbackCreatureName,
+      effectiveLinkedIssueNumber,
+      effectiveLinkedLinearIssue,
+      effectiveLinkedArtifactUrl,
       effectiveLinkedPR,
       linkedPR,
       linkedWorkItem,
@@ -1585,7 +1661,6 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       normalizedSparseDirectories,
       note,
       onCreated,
-      parsedLinkedIssueNumber,
       persistDraft,
       repoId,
       requiresExplicitSetupChoice,

--- a/src/renderer/src/lib/launch-work-item-direct.ts
+++ b/src/renderer/src/lib/launch-work-item-direct.ts
@@ -212,6 +212,23 @@ export async function launchWorkItemDirect(args: LaunchWorkItemDirectArgs): Prom
   let startupPlan: ReturnType<typeof buildAgentStartupPlan> = null
   let effectiveAgent: TuiAgent | null = null
   let draftLaunchedNatively = false
+  const linkedMeta: {
+    linkedIssue?: number
+    linkedPR?: number
+    linkedLinearIssue?: string
+    linkedArtifactUrl?: string | null
+  } = {
+    linkedArtifactUrl: item.url
+  }
+  if (item.type === 'issue' && item.number) {
+    linkedMeta.linkedIssue = item.number
+  } else if (item.type === 'pr' && item.number) {
+    linkedMeta.linkedPR = item.number
+  }
+  if (item.linearIdentifier) {
+    linkedMeta.linkedLinearIssue = item.linearIdentifier
+  }
+
   try {
     const result = await store.createWorktree(
       repoId,
@@ -220,33 +237,11 @@ export async function launchWorkItemDirect(args: LaunchWorkItemDirectArgs): Prom
       finalSetupDecision,
       undefined,
       telemetrySource,
-      item.title
+      item.title,
+      linkedMeta
     )
     worktreeId = result.worktree.id
     const worktreePath = result.worktree.path
-    const meta: {
-      linkedIssue?: number
-      linkedPR?: number
-      linkedLinearIssue?: string
-    } = {}
-    if (item.type === 'issue' && item.number) {
-      meta.linkedIssue = item.number
-    } else if (item.type === 'pr' && item.number) {
-      meta.linkedPR = item.number
-    }
-    if (item.linearIdentifier) {
-      meta.linkedLinearIssue = item.linearIdentifier
-    }
-    if (Object.keys(meta).length > 0) {
-      // Why: the Project direct-launch path activates the new workspace
-      // immediately. Persist the link first so the first sidebar render can
-      // show the issue/PR association instead of briefly looking unlinked.
-      // Best-effort: the worktree is already created on disk, so a meta
-      // write failure must not abort activation and orphan it.
-      void store.updateWorktreeMeta(worktreeId, meta).catch(() => {
-        // Non-critical: continue into activation without the link metadata.
-      })
-    }
 
     const detectedIds = new Set(await detectedAgentsPromise)
     effectiveAgent = pickAgent(settings?.defaultTuiAgent, detectedIds)

--- a/src/renderer/src/lib/new-workspace.ts
+++ b/src/renderer/src/lib/new-workspace.ts
@@ -42,6 +42,7 @@ export type LinkedWorkItemSummary = {
   number: number
   title: string
   url: string
+  linearIdentifier?: string
 }
 
 // Why: when a repo has no `orca.yaml` issueCommand and no per-user override,

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -187,6 +187,7 @@ export type UISlice = {
       number: number
       title: string
       url: string
+      linearIdentifier?: string
     } | null
     agent: TuiAgent
     linkedIssue: string

--- a/src/renderer/src/store/slices/worktree-helpers.ts
+++ b/src/renderer/src/store/slices/worktree-helpers.ts
@@ -69,7 +69,10 @@ export type WorktreeSlice = {
      *  so existing callers default to `unknown`; specify when the surface
      *  matters for the activation funnel. */
     telemetrySource?: WorkspaceCreateTelemetrySource,
-    displayName?: string
+    displayName?: string,
+    initialMeta?: Partial<
+      Pick<WorktreeMeta, 'linkedIssue' | 'linkedPR' | 'linkedLinearIssue' | 'linkedArtifactUrl'>
+    >
   ) => Promise<CreateWorktreeResult>
   removeWorktree: (
     worktreeId: string,

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -260,6 +260,30 @@ describe('createWorktree base status merge', () => {
       behind: 2
     })
   })
+
+  it('passes linked artifact metadata through create worktree requests', async () => {
+    const store = createTestStore()
+    const wt = makeWorktree({ id: 'repo1::/path/wt1', repoId: 'repo1', path: '/path/wt1' })
+    mockApi.worktrees.create.mockResolvedValue({ worktree: wt })
+
+    await store
+      .getState()
+      .createWorktree('repo1', 'feature', undefined, 'inherit', undefined, 'sidebar', undefined, {
+        linkedPR: 1687,
+        linkedArtifactUrl: 'https://github.com/stablyai/orca/pull/1687'
+      })
+
+    expect(mockApi.worktrees.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repoId: 'repo1',
+        name: 'feature',
+        initialMeta: {
+          linkedPR: 1687,
+          linkedArtifactUrl: 'https://github.com/stablyai/orca/pull/1687'
+        }
+      })
+    )
+  })
 })
 
 describe('removeWorktree state cleanup', () => {

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -1,7 +1,12 @@
 /* eslint-disable max-lines */
 import type { StateCreator } from 'zustand'
 import type { AppState } from '../types'
-import type { Worktree, WorkspaceVisibleTabType, WorktreeMeta } from '../../../../shared/types'
+import type {
+  Worktree,
+  WorkspaceVisibleTabType,
+  WorktreeMeta,
+  CreateWorktreeArgs
+} from '../../../../shared/types'
 import {
   findWorktreeById,
   applyWorktreeUpdates,
@@ -42,6 +47,8 @@ function areWorktreesEqual(current: Worktree[] | undefined, next: Worktree[]): b
       worktree.comment === candidate.comment &&
       worktree.linkedIssue === candidate.linkedIssue &&
       worktree.linkedPR === candidate.linkedPR &&
+      worktree.linkedLinearIssue === candidate.linkedLinearIssue &&
+      worktree.linkedArtifactUrl === candidate.linkedArtifactUrl &&
       worktree.isArchived === candidate.isArchived &&
       worktree.isUnread === candidate.isUnread &&
       worktree.isPinned === candidate.isPinned &&
@@ -224,7 +231,8 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
     setupDecision = 'inherit',
     sparseCheckout,
     telemetrySource,
-    displayName
+    displayName,
+    initialMeta
   ) => {
     const retryableConflictPatterns = [
       /already exists locally/i,
@@ -245,6 +253,9 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
             setupDecision,
             sparseCheckout,
             ...(displayName ? { displayName } : {}),
+            ...(initialMeta
+              ? { initialMeta: initialMeta as CreateWorktreeArgs['initialMeta'] }
+              : {}),
             ...(telemetrySource ? { telemetrySource } : {})
           })
           // Why: a file watcher (worktrees.onChanged) can fire between the

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -111,6 +111,7 @@ export type Worktree = {
   linkedIssue: number | null
   linkedPR: number | null
   linkedLinearIssue: string | null
+  linkedArtifactUrl?: string | null
   isArchived: boolean
   isUnread: boolean
   isPinned: boolean
@@ -138,6 +139,7 @@ export type WorktreeMeta = {
   linkedIssue: number | null
   linkedPR: number | null
   linkedLinearIssue: string | null
+  linkedArtifactUrl?: string | null
   isArchived: boolean
   isUnread: boolean
   isPinned: boolean
@@ -867,6 +869,10 @@ export type CreateWorktreeArgs = {
   baseBranch?: string
   setupDecision?: SetupDecision
   sparseCheckout?: CreateSparseCheckoutRequest
+  /** Link metadata that must exist before the first worktree refresh. */
+  initialMeta?: Partial<
+    Pick<WorktreeMeta, 'linkedIssue' | 'linkedPR' | 'linkedLinearIssue' | 'linkedArtifactUrl'>
+  >
   /** Telemetry-only: which UI surface initiated this create. Threaded from
    *  the renderer entry point so main can emit `workspace_created` with the
    *  correct `source`. `unknown` is a valid wire value — an unrecognized


### PR DESCRIPTION
## Summary
- Persist GitHub issue URLs, GitHub PR URLs, and Linear issues as linked artifact metadata during workspace creation
- Update the workspace details dialog to edit a generic linked artifact instead of only a GitHub issue
- Improve the linked artifact field UX with GitHub/Linear affordances, parsed status, validation, and clear action

## Tests
- pnpm run tc:web
- pnpm exec oxlint src/renderer/src/components/sidebar/WorktreeMetaDialog.tsx src/renderer/src/components/sidebar/WorktreeCard.tsx src/renderer/src/components/sidebar/WorktreeContextMenu.tsx src/renderer/src/hooks/useComposerState.ts src/renderer/src/lib/new-workspace.ts src/renderer/src/store/slices/ui.ts src/renderer/src/components/TaskPage.tsx src/renderer/src/components/WorktreeJumpPalette.tsx src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
- pnpm exec vitest run src/renderer/src/lib/github-links.test.ts

Risk: medium
Historic risk metadata backfill based on the existing `risk:medium` label.