### PR TITLE
fix(editor): remove underline beneath markdown h1/h2 headings

### DIFF
--- a/src/renderer/src/assets/markdown-preview.css
+++ b/src/renderer/src/assets/markdown-preview.css
@@ -116,8 +116,6 @@
 
 .markdown-body h2 {
   font-size: 1.4em;
-  border-bottom: 1px solid var(--border);
-  padding-bottom: 0.3em;
 }
 
 .markdown-body h3 {

--- a/src/renderer/src/assets/rich-markdown-editor.css
+++ b/src/renderer/src/assets/rich-markdown-editor.css
@@ -163,8 +163,6 @@
 
 .rich-markdown-editor h2 {
   font-size: 1.4em;
-  padding-bottom: 0.3em;
-  border-bottom: 1px solid var(--border);
 }
 
 .rich-markdown-editor h3 {

--- a/src/renderer/src/components/editor/export-css.ts
+++ b/src/renderer/src/components/editor/export-css.ts
@@ -34,8 +34,8 @@ html, body {
   margin-bottom: 0.5em;
 }
 
-.orca-export-root h1 { font-size: 1.9em; border-bottom: 1px solid #d0d7de; padding-bottom: 0.3em; }
-.orca-export-root h2 { font-size: 1.5em; border-bottom: 1px solid #d0d7de; padding-bottom: 0.3em; }
+.orca-export-root h1 { font-size: 1.9em; }
+.orca-export-root h2 { font-size: 1.5em; }
 .orca-export-root h3 { font-size: 1.25em; }
 .orca-export-root h4 { font-size: 1em; }
 


### PR DESCRIPTION
## Summary

- H2 headings in markdown preview and rich editor rendered with a thin `border-bottom` rule beneath them
- Exported H1 and H2 headings had the same underline treatment via hardcoded styles in `export-css.ts`
- Removes `border-bottom` and `padding-bottom` from all three locations so headings sit flush with following content

## Test plan

- [ ] Open a markdown note with H1 and H2 headings — confirm no underline appears in preview
- [ ] Open a note in rich editor mode — confirm H2 headings have no bottom border
- [ ] Export a note to HTML/PDF — confirm exported H1/H2 headings have no underline

Made with [Orca](https://github.com/stablyai/orca) 🐋
