### PR TITLE
feat(ssh): preserve remote PTY sessions across app close

### DIFF
--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -114,6 +114,8 @@ import { LocalPtyProvider } from '../providers/local-pty-provider'
 import {
   registerPtyHandlers,
   registerSshPtyProvider,
+  deletePtyOwnership,
+  setPtyOwnership,
   setLocalPtyProvider,
   unregisterSshPtyProvider
 } from './pty'
@@ -137,9 +139,10 @@ describe('registerPtyHandlers', () => {
     }
   }
 
-  const savedPiAgentDir = process.env.PI_CODING_AGENT_DIR
+  const savedOpenCodeConfigDir = process.env.OPENCODE_CONFIG_DIR
   const savedOrcaOpenCodeConfigDir = process.env.ORCA_OPENCODE_CONFIG_DIR
   const savedOrcaOpenCodeSourceConfigDir = process.env.ORCA_OPENCODE_SOURCE_CONFIG_DIR
+  const savedPiAgentDir = process.env.PI_CODING_AGENT_DIR
   const savedOrcaPiAgentDir = process.env.ORCA_PI_CODING_AGENT_DIR
   const savedOrcaPiSourceAgentDir = process.env.ORCA_PI_SOURCE_AGENT_DIR
 
@@ -214,25 +217,30 @@ describe('registerPtyHandlers', () => {
   afterEach(() => {
     unregisterSshPtyProvider('ssh-1')
     setLocalPtyProvider(new LocalPtyProvider())
-    if (savedPiAgentDir === undefined) {
-      delete process.env.PI_CODING_AGENT_DIR
+    if (savedOpenCodeConfigDir !== undefined) {
+      process.env.OPENCODE_CONFIG_DIR = savedOpenCodeConfigDir
     } else {
-      process.env.PI_CODING_AGENT_DIR = savedPiAgentDir
+      delete process.env.OPENCODE_CONFIG_DIR
     }
-    if (savedOrcaOpenCodeConfigDir === undefined) {
-      delete process.env.ORCA_OPENCODE_CONFIG_DIR
-    } else {
+    if (savedOrcaOpenCodeConfigDir !== undefined) {
       process.env.ORCA_OPENCODE_CONFIG_DIR = savedOrcaOpenCodeConfigDir
-    }
-    if (savedOrcaOpenCodeSourceConfigDir === undefined) {
-      delete process.env.ORCA_OPENCODE_SOURCE_CONFIG_DIR
     } else {
+      delete process.env.ORCA_OPENCODE_CONFIG_DIR
+    }
+    if (savedOrcaOpenCodeSourceConfigDir !== undefined) {
       process.env.ORCA_OPENCODE_SOURCE_CONFIG_DIR = savedOrcaOpenCodeSourceConfigDir
-    }
-    if (savedOrcaPiAgentDir === undefined) {
-      delete process.env.ORCA_PI_CODING_AGENT_DIR
     } else {
+      delete process.env.ORCA_OPENCODE_SOURCE_CONFIG_DIR
+    }
+    if (savedPiAgentDir !== undefined) {
+      process.env.PI_CODING_AGENT_DIR = savedPiAgentDir
+    } else {
+      delete process.env.PI_CODING_AGENT_DIR
+    }
+    if (savedOrcaPiAgentDir !== undefined) {
       process.env.ORCA_PI_CODING_AGENT_DIR = savedOrcaPiAgentDir
+    } else {
+      delete process.env.ORCA_PI_CODING_AGENT_DIR
     }
     if (savedOrcaPiSourceAgentDir === undefined) {
       delete process.env.ORCA_PI_SOURCE_AGENT_DIR
@@ -882,6 +890,10 @@ describe('registerPtyHandlers', () => {
         const sshSpawn = vi.fn(async (_opts: { env: Record<string, string> }) => ({
           id: 'ssh-pty'
         }))
+        const store = {
+          upsertSshRemotePtyLease: vi.fn(),
+          persistPtyBinding: vi.fn()
+        }
         registerSshPtyProvider('ssh-1', {
           spawn: sshSpawn,
           write: vi.fn(),
@@ -905,12 +917,22 @@ describe('registerPtyHandlers', () => {
           getProfiles: vi.fn()
         } as never)
         handlers.clear()
-        registerPtyHandlers(mainWindow as never)
+        registerPtyHandlers(
+          mainWindow as never,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          store as never
+        )
         await handlers.get('pty:spawn')!(null, {
           cols: 80,
           rows: 24,
           env: { FOO: 'bar' },
-          connectionId: 'ssh-1'
+          connectionId: 'ssh-1',
+          worktreeId: 'wt-1',
+          tabId: 'tab-1',
+          leafId: 'leaf-1'
         })
         const env = sshSpawn.mock.calls.at(-1)![0].env
         // Why: every host-local var must be absent over SSH — the hook
@@ -930,8 +952,309 @@ describe('registerPtyHandlers', () => {
         expect(env.FOO).toBe('bar')
         expect(openCodeBuildPtyEnvMock).not.toHaveBeenCalled()
         expect(piBuildPtyEnvMock).not.toHaveBeenCalled()
+        expect(store.upsertSshRemotePtyLease).toHaveBeenCalledWith(
+          expect.objectContaining({
+            targetId: 'ssh-1',
+            ptyId: 'ssh-pty',
+            worktreeId: 'wt-1',
+            tabId: 'tab-1',
+            leafId: 'leaf-1',
+            state: 'attached'
+          })
+        )
+        expect(store.persistPtyBinding).toHaveBeenCalledWith({
+          worktreeId: 'wt-1',
+          tabId: 'tab-1',
+          leafId: 'leaf-1',
+          ptyId: 'ssh-pty'
+        })
+      })
+
+      it('marks a caller-supplied SSH session expired when remote reattach is gone', async () => {
+        const sshSpawn = vi.fn(async () => {
+          throw new Error('SSH_SESSION_EXPIRED: remote-pty')
+        })
+        const store = {
+          markSshRemotePtyLease: vi.fn()
+        }
+        registerSshPtyProvider('ssh-1', {
+          spawn: sshSpawn,
+          write: vi.fn(),
+          resize: vi.fn(),
+          shutdown: vi.fn(),
+          sendSignal: vi.fn(),
+          getCwd: vi.fn(),
+          getInitialCwd: vi.fn(),
+          clearBuffer: vi.fn(),
+          acknowledgeDataEvent: vi.fn(),
+          hasChildProcesses: vi.fn(),
+          getForegroundProcess: vi.fn(),
+          serialize: vi.fn(),
+          revive: vi.fn(),
+          onData: vi.fn(() => () => {}),
+          onReplay: vi.fn(() => () => {}),
+          onExit: vi.fn(() => () => {}),
+          listProcesses: vi.fn(async () => []),
+          attach: vi.fn(),
+          getDefaultShell: vi.fn(),
+          getProfiles: vi.fn()
+        } as never)
+        handlers.clear()
+        registerPtyHandlers(
+          mainWindow as never,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          store as never
+        )
+
+        await expect(
+          handlers.get('pty:spawn')!(null, {
+            cols: 80,
+            rows: 24,
+            env: {},
+            connectionId: 'ssh-1',
+            sessionId: 'remote-pty'
+          })
+        ).rejects.toThrow('SSH_SESSION_EXPIRED: remote-pty')
+
+        expect(store.markSshRemotePtyLease).toHaveBeenCalledWith('ssh-1', 'remote-pty', 'expired')
+      })
+
+      it('does not tombstone an SSH lease when explicit kill shutdown fails transiently', async () => {
+        const store = {
+          markSshRemotePtyLease: vi.fn()
+        }
+        registerSshPtyProvider('ssh-1', {
+          spawn: vi.fn(),
+          write: vi.fn(),
+          resize: vi.fn(),
+          shutdown: vi.fn().mockRejectedValue(new Error('Multiplexer disposed')),
+          sendSignal: vi.fn(),
+          getCwd: vi.fn(),
+          getInitialCwd: vi.fn(),
+          clearBuffer: vi.fn(),
+          acknowledgeDataEvent: vi.fn(),
+          hasChildProcesses: vi.fn(),
+          getForegroundProcess: vi.fn(),
+          serialize: vi.fn(),
+          revive: vi.fn(),
+          onData: vi.fn(() => () => {}),
+          onReplay: vi.fn(() => () => {}),
+          onExit: vi.fn(() => () => {}),
+          listProcesses: vi.fn(async () => []),
+          attach: vi.fn(),
+          getDefaultShell: vi.fn(),
+          getProfiles: vi.fn()
+        } as never)
+        setPtyOwnership('remote-pty', 'ssh-1')
+        handlers.clear()
+        registerPtyHandlers(
+          mainWindow as never,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          store as never
+        )
+
+        try {
+          await expect(
+            handlers.get('pty:kill')!(null, { id: 'remote-pty', keepHistory: false })
+          ).rejects.toThrow('Multiplexer disposed')
+        } finally {
+          deletePtyOwnership('remote-pty')
+        }
+
+        expect(store.markSshRemotePtyLease).not.toHaveBeenCalledWith(
+          'ssh-1',
+          'remote-pty',
+          'terminated'
+        )
+      })
+
+      it('marks an SSH lease terminated after runtime controller kill succeeds', async () => {
+        const shutdown = vi.fn(async () => undefined)
+        const store = {
+          markSshRemotePtyLease: vi.fn()
+        }
+        const runtime = {
+          setPtyController: vi.fn(),
+          onPtyExit: vi.fn()
+        }
+        registerSshPtyProvider('ssh-1', {
+          spawn: vi.fn(),
+          write: vi.fn(),
+          resize: vi.fn(),
+          shutdown,
+          sendSignal: vi.fn(),
+          getCwd: vi.fn(),
+          getInitialCwd: vi.fn(),
+          clearBuffer: vi.fn(),
+          acknowledgeDataEvent: vi.fn(),
+          hasChildProcesses: vi.fn(),
+          getForegroundProcess: vi.fn(),
+          serialize: vi.fn(),
+          revive: vi.fn(),
+          onData: vi.fn(() => () => {}),
+          onReplay: vi.fn(() => () => {}),
+          onExit: vi.fn(() => () => {}),
+          listProcesses: vi.fn(async () => []),
+          attach: vi.fn(),
+          getDefaultShell: vi.fn(),
+          getProfiles: vi.fn()
+        } as never)
+        setPtyOwnership('remote-pty', 'ssh-1')
+        handlers.clear()
+        registerPtyHandlers(
+          mainWindow as never,
+          runtime as never,
+          undefined,
+          undefined,
+          undefined,
+          store as never
+        )
+        const controller = runtime.setPtyController.mock.calls[0]?.[0] as {
+          kill: (ptyId: string) => boolean
+        }
+
+        expect(controller.kill('remote-pty')).toBe(true)
+        await Promise.resolve()
+
+        expect(shutdown).toHaveBeenCalledWith('remote-pty', { immediate: false })
+        expect(store.markSshRemotePtyLease).toHaveBeenCalledWith(
+          'ssh-1',
+          'remote-pty',
+          'terminated'
+        )
+        expect(runtime.onPtyExit).toHaveBeenCalledWith('remote-pty', -1)
+      })
+
+      it('marks a detached SSH lease terminated when runtime controller kill has no provider', async () => {
+        const store = {
+          markSshRemotePtyLease: vi.fn()
+        }
+        const runtime = {
+          setPtyController: vi.fn(),
+          onPtyExit: vi.fn()
+        }
+        setPtyOwnership('remote-pty', 'ssh-1')
+        handlers.clear()
+        registerPtyHandlers(
+          mainWindow as never,
+          runtime as never,
+          undefined,
+          undefined,
+          undefined,
+          store as never
+        )
+        const controller = runtime.setPtyController.mock.calls[0]?.[0] as {
+          kill: (ptyId: string) => boolean
+        }
+
+        expect(controller.kill('remote-pty')).toBe(true)
+
+        expect(store.markSshRemotePtyLease).toHaveBeenCalledWith(
+          'ssh-1',
+          'remote-pty',
+          'terminated'
+        )
+        expect(runtime.onPtyExit).toHaveBeenCalledWith('remote-pty', -1)
+      })
+
+      it('preserves an SSH lease when runtime controller kill shutdown fails transiently', async () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+        const store = {
+          markSshRemotePtyLease: vi.fn()
+        }
+        const runtime = {
+          setPtyController: vi.fn(),
+          onPtyExit: vi.fn()
+        }
+        registerSshPtyProvider('ssh-1', {
+          spawn: vi.fn(),
+          write: vi.fn(),
+          resize: vi.fn(),
+          shutdown: vi.fn().mockRejectedValue(new Error('Multiplexer disposed')),
+          sendSignal: vi.fn(),
+          getCwd: vi.fn(),
+          getInitialCwd: vi.fn(),
+          clearBuffer: vi.fn(),
+          acknowledgeDataEvent: vi.fn(),
+          hasChildProcesses: vi.fn(),
+          getForegroundProcess: vi.fn(),
+          serialize: vi.fn(),
+          revive: vi.fn(),
+          onData: vi.fn(() => () => {}),
+          onReplay: vi.fn(() => () => {}),
+          onExit: vi.fn(() => () => {}),
+          listProcesses: vi.fn(async () => []),
+          attach: vi.fn(),
+          getDefaultShell: vi.fn(),
+          getProfiles: vi.fn()
+        } as never)
+        setPtyOwnership('remote-pty', 'ssh-1')
+        handlers.clear()
+        registerPtyHandlers(
+          mainWindow as never,
+          runtime as never,
+          undefined,
+          undefined,
+          undefined,
+          store as never
+        )
+        const controller = runtime.setPtyController.mock.calls[0]?.[0] as {
+          kill: (ptyId: string) => boolean
+        }
+
+        try {
+          expect(controller.kill('remote-pty')).toBe(true)
+          await Promise.resolve()
+        } finally {
+          warnSpy.mockRestore()
+          deletePtyOwnership('remote-pty')
+        }
+
+        expect(store.markSshRemotePtyLease).not.toHaveBeenCalledWith(
+          'ssh-1',
+          'remote-pty',
+          'terminated'
+        )
+        expect(runtime.onPtyExit).not.toHaveBeenCalled()
       })
     })
+  })
+
+  it('rethrows non-not-found local provider shutdown failures', async () => {
+    setLocalPtyProvider({
+      spawn: vi.fn(),
+      write: vi.fn(),
+      resize: vi.fn(),
+      shutdown: vi.fn().mockRejectedValue(new Error('daemon unavailable')),
+      sendSignal: vi.fn(),
+      getCwd: vi.fn(),
+      getInitialCwd: vi.fn(),
+      clearBuffer: vi.fn(),
+      acknowledgeDataEvent: vi.fn(),
+      hasChildProcesses: vi.fn(),
+      getForegroundProcess: vi.fn(),
+      serialize: vi.fn(),
+      revive: vi.fn(),
+      onData: vi.fn(() => () => {}),
+      onReplay: vi.fn(() => () => {}),
+      onExit: vi.fn(() => () => {}),
+      listProcesses: vi.fn(async () => []),
+      attach: vi.fn(),
+      getDefaultShell: vi.fn(),
+      getProfiles: vi.fn()
+    } as never)
+    handlers.clear()
+    registerPtyHandlers(mainWindow as never)
+
+    await expect(handlers.get('pty:kill')!(null, { id: 'local-pty' })).rejects.toThrow(
+      'daemon unavailable'
+    )
   })
 
   it('lists sessions from both local and SSH providers', async () => {
@@ -979,6 +1302,70 @@ describe('registerPtyHandlers', () => {
       immediate: true,
       keepHistory: false
     })
+  })
+
+  it('ignores fire-and-forget IPC for detached SSH PTYs without a provider', async () => {
+    const store = {
+      upsertSshRemotePtyLease: vi.fn(),
+      persistPtyBinding: vi.fn(),
+      markSshRemotePtyLease: vi.fn()
+    }
+    const provider = {
+      spawn: vi.fn(async () => ({ id: 'remote-pty' })),
+      write: vi.fn(),
+      resize: vi.fn(),
+      shutdown: vi.fn(),
+      sendSignal: vi.fn(async () => undefined),
+      getCwd: vi.fn(),
+      getInitialCwd: vi.fn(),
+      clearBuffer: vi.fn(),
+      acknowledgeDataEvent: vi.fn(),
+      onData: vi.fn(() => () => {}),
+      onReplay: vi.fn(() => () => {}),
+      onExit: vi.fn(() => () => {}),
+      listProcesses: vi.fn(),
+      hasChildProcesses: vi.fn(),
+      getForegroundProcess: vi.fn(),
+      serialize: vi.fn(),
+      revive: vi.fn(),
+      getDefaultShell: vi.fn(),
+      getProfiles: vi.fn()
+    }
+    registerSshPtyProvider('ssh-1', provider as never)
+    registerPtyHandlers(
+      mainWindow as never,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      store as never
+    )
+    await handlers.get('pty:spawn')!(null, {
+      cols: 80,
+      rows: 24,
+      connectionId: 'ssh-1',
+      env: {}
+    })
+    unregisterSshPtyProvider('ssh-1')
+    const listenerFor = (channel: string): ((event: unknown, args: unknown) => void) => {
+      const call = onMock.mock.calls.find((entry: unknown[]) => entry[0] === channel)
+      if (!call) {
+        throw new Error(`missing ${channel} listener`)
+      }
+      return call[1] as (event: unknown, args: unknown) => void
+    }
+
+    expect(() => listenerFor('pty:write')(null, { id: 'remote-pty', data: 'x' })).not.toThrow()
+    expect(() =>
+      listenerFor('pty:resize')(null, { id: 'remote-pty', cols: 100, rows: 30 })
+    ).not.toThrow()
+    expect(() => listenerFor('pty:ackColdRestore')(null, { id: 'remote-pty' })).not.toThrow()
+    expect(() =>
+      listenerFor('pty:signal')(null, { id: 'remote-pty', signal: 'SIGINT' })
+    ).not.toThrow()
+
+    await expect(handlers.get('pty:kill')!(null, { id: 'remote-pty' })).resolves.toBeUndefined()
+    expect(store.markSshRemotePtyLease).toHaveBeenCalledWith('ssh-1', 'remote-pty', 'terminated')
   })
 
   it('injects ORCA_TERMINAL_HANDLE for non-local PTY providers', async () => {

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -16,6 +16,7 @@ import { piTitlebarExtensionService } from '../pi/titlebar-extension-service'
 import { isPwshAvailable } from '../pwsh'
 import { LocalPtyProvider } from '../providers/local-pty-provider'
 import type { IPtyProvider, PtySpawnOptions, PtySpawnResult } from '../providers/types'
+import { SSH_SESSION_EXPIRED_ERROR, isSshPtyNotFoundError } from '../providers/ssh-pty-provider'
 import { mintPtySessionId, isSafePtySessionId } from '../daemon/pty-session-id'
 import { addNodePtyRecoveryHint } from '../daemon/node-pty-error-hints'
 import type { ClaudeRuntimeAuthPreparation } from '../claude-accounts/runtime-auth-service'
@@ -139,6 +140,14 @@ function getProviderForPty(ptyId: string): IPtyProvider {
   return getProvider(connectionId)
 }
 
+function tryGetProviderForPty(ptyId: string): IPtyProvider | undefined {
+  try {
+    return getProviderForPty(ptyId)
+  } catch {
+    return undefined
+  }
+}
+
 function normalizeNodePtySpawnError(err: unknown): Error {
   const rawMessage = err instanceof Error ? err.message : String(err)
   const hintedMessage = addNodePtyRecoveryHint(rawMessage)
@@ -152,6 +161,24 @@ function normalizeNodePtySpawnError(err: unknown): Error {
     return err
   }
   return new Error(hintedMessage)
+}
+
+function isPtyAlreadyGoneError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err)
+  return isSshPtyNotFoundError(err) || /Session not found/i.test(message)
+}
+
+function finishPtyShutdown(
+  id: string,
+  connectionId: string | null | undefined,
+  store: Store | undefined
+): void {
+  clearProviderPtyState(id)
+  if (connectionId) {
+    store?.markSshRemotePtyLease(connectionId, id, 'terminated')
+  }
+  ptyOwnership.delete(id)
+  markClaudePtyExited(id)
 }
 
 // ─── Host PTY env assembly ──────────────────────────────────────────
@@ -429,6 +456,10 @@ export function clearProviderPtyState(id: string): void {
 
 export function deletePtyOwnership(id: string): void {
   ptyOwnership.delete(id)
+}
+
+export function setPtyOwnership(id: string, connectionId: string | null): void {
+  ptyOwnership.set(id, connectionId)
 }
 
 // Why: localProvider.onData/onExit return unsubscribe functions. Without
@@ -841,14 +872,41 @@ export function registerPtyHandlers(
       }
     },
     kill: (ptyId) => {
-      const provider = getProviderForPty(ptyId)
-      // Why: shutdown() is async but the PtyController interface is sync.
-      // Swallowing the rejection prevents an unhandled promise rejection crash
-      // if the remote SSH session is already gone.
-      void provider.shutdown(ptyId, { immediate: false }).catch(() => {})
-      clearProviderPtyState(ptyId)
-      markClaudePtyExited(ptyId)
-      runtime?.onPtyExit(ptyId, -1)
+      let provider: IPtyProvider
+      let connectionId: string | null | undefined
+      try {
+        connectionId = ptyOwnership.get(ptyId)
+        provider = getProviderForPty(ptyId)
+      } catch {
+        if (connectionId) {
+          // Why: runtime/CLI close can target a detached SSH PTY after its
+          // provider was unregistered. Tombstone the lease so reconnect does
+          // not revive a terminal the user explicitly closed.
+          finishPtyShutdown(ptyId, connectionId, store)
+          runtime?.onPtyExit(ptyId, -1)
+          return true
+        }
+        return false
+      }
+      // Why: shutdown() is async but the PtyController interface is sync. Defer
+      // cleanup until shutdown resolves so transient SSH/daemon failures don't
+      // hide a still-running remote process or local daemon session.
+      void provider
+        .shutdown(ptyId, { immediate: false })
+        .then(() => {
+          finishPtyShutdown(ptyId, connectionId, store)
+          runtime?.onPtyExit(ptyId, -1)
+        })
+        .catch((err) => {
+          if (isPtyAlreadyGoneError(err)) {
+            finishPtyShutdown(ptyId, connectionId, store)
+            runtime?.onPtyExit(ptyId, -1)
+            return
+          }
+          console.warn(
+            `[pty] Failed to stop PTY ${ptyId}: ${err instanceof Error ? err.message : String(err)}`
+          )
+        })
       return true
     },
     getForegroundProcess: async (ptyId) => {
@@ -1095,9 +1153,23 @@ export function registerPtyHandlers(
         }
         result = await provider.spawn(spawnOptions)
       } catch (err) {
+        const rawMessage = err instanceof Error ? err.message : String(err)
         const spawnError = normalizeNodePtySpawnError(err)
         if (effectiveSessionId !== undefined) {
           ptySizes.delete(effectiveSessionId)
+        }
+        if (
+          args.connectionId &&
+          effectiveSessionId !== undefined &&
+          (spawnError.message.includes(SSH_SESSION_EXPIRED_ERROR) ||
+            rawMessage.includes(SSH_SESSION_EXPIRED_ERROR))
+        ) {
+          // Why: expired remote reattach means the relay has already dropped
+          // the backing PTY. Clear the durable lease so later session writes
+          // cannot restore the stale pane binding.
+          clearProviderPtyState(effectiveSessionId)
+          deletePtyOwnership(effectiveSessionId)
+          store?.markSshRemotePtyLease(args.connectionId, effectiveSessionId, 'expired')
         }
         // Why: when buildPtyHostEnv materialized a Pi overlay for this id
         // but provider.spawn failed, the overlay would leak.
@@ -1136,19 +1208,32 @@ export function registerPtyHandlers(
         }
       }
       ptyOwnership.set(result.id, args.connectionId ?? null)
+      if (store && args.connectionId) {
+        // Why: remote PTYs live in the SSH relay grace window after Orca
+        // detaches. Persist their IDs immediately so reconnect can reattach
+        // instead of treating the tab as a fresh shell.
+        store.upsertSshRemotePtyLease({
+          targetId: args.connectionId,
+          ptyId: result.id,
+          ...(typeof args.worktreeId === 'string' ? { worktreeId: args.worktreeId } : {}),
+          ...(typeof args.tabId === 'string' ? { tabId: args.tabId } : {}),
+          ...(typeof args.leafId === 'string' ? { leafId: args.leafId } : {}),
+          state: 'attached',
+          lastAttachedAt: Date.now()
+        })
+      }
       if (preAllocatedHandle) {
         runtime?.registerPreAllocatedHandleForPty(result.id, preAllocatedHandle)
       }
       ptySizes.set(result.id, { cols: args.cols, rows: args.rows })
-      // Why: closes the SIGKILL-between-spawn-and-persist race (Issue #217).
+      // Why: closes the SIGKILL-between-spawn-and-persist race (Issue #217)
+      // for local daemon PTYs and the equivalent remote-relay race for SSH.
       // The renderer's debounced session writer runs in parallel for every
-      // other field; we patch the load-bearing (tab.ptyId, ptyIdsByLeafId)
+      // other field; patch the load-bearing (tab.ptyId, ptyIdsByLeafId)
       // binding synchronously so a force-quit in the ~450 ms debounce window
-      // can no longer orphan the daemon's history dir. Other spawn callers
-      // (mobile, runtime CLI, SSH) leave tabId/leafId undefined and this
-      // short-circuits — preserves their existing behavior.
+      // cannot orphan either daemon history or a remote relay PTY lease.
       if (
-        isDaemonHostSpawn &&
+        (isDaemonHostSpawn || args.connectionId) &&
         store &&
         args.worktreeId !== undefined &&
         args.tabId !== undefined &&
@@ -1305,7 +1390,7 @@ export function registerPtyHandlers(
     if (runtime?.getDriver(args.id).kind === 'mobile') {
       return
     }
-    getProviderForPty(args.id).write(args.id, args.data)
+    tryGetProviderForPty(args.id)?.write(args.id, args.data)
   })
 
   // Why: resize is fire-and-forget — the renderer doesn't need a reply.
@@ -1332,7 +1417,7 @@ export function registerPtyHandlers(
       return
     }
     ptySizes.set(args.id, { cols: args.cols, rows: args.rows })
-    getProviderForPty(args.id).resize(args.id, args.cols, args.rows)
+    tryGetProviderForPty(args.id)?.resize(args.id, args.cols, args.rows)
     runtime?.onExternalPtyResize(args.id, args.cols, args.rows)
   })
 
@@ -1356,42 +1441,47 @@ export function registerPtyHandlers(
   // Why: fire-and-forget — clears the DaemonPtyAdapter's sticky cold restore
   // cache after the renderer has consumed the data. No-op for non-daemon providers.
   ipcMain.on('pty:ackColdRestore', (_event, args: { id: string }) => {
-    const provider = getProviderForPty(args.id)
-    if ('ackColdRestore' in provider && typeof provider.ackColdRestore === 'function') {
+    const provider = tryGetProviderForPty(args.id)
+    if (provider && 'ackColdRestore' in provider && typeof provider.ackColdRestore === 'function') {
       provider.ackColdRestore(args.id)
     }
   })
 
   ipcMain.removeAllListeners('pty:signal')
   ipcMain.on('pty:signal', (_event, args: { id: string; signal: string }) => {
-    getProviderForPty(args.id)
-      .sendSignal(args.id, args.signal)
+    tryGetProviderForPty(args.id)
+      ?.sendSignal(args.id, args.signal)
       .catch(() => {})
   })
 
   ipcMain.handle('pty:kill', async (_event, args: { id: string; keepHistory?: boolean }) => {
-    // Why: try/finally ensures ptyOwnership is cleaned up even if shutdown
-    // throws (e.g. SSH connection already gone or daemon session already
-    // reaped). Swallowing the error prevents noisy renderer-side rejections
-    // when killing orphaned sessions that the daemon has already discarded.
+    const connectionId = ptyOwnership.get(args.id)
+    const provider = tryGetProviderForPty(args.id)
+    if (!provider && connectionId) {
+      // Why: detached SSH PTYs intentionally keep ownership after their
+      // provider is unregistered. If the user closes the pane while detached,
+      // make the lease non-restorable instead of reviving it on reconnect.
+      finishPtyShutdown(args.id, connectionId, store)
+      return
+    }
     try {
-      await getProviderForPty(args.id).shutdown(args.id, {
+      await (provider ?? getProviderForPty(args.id)).shutdown(args.id, {
         immediate: true,
         keepHistory: args.keepHistory ?? false
       })
-    } catch {
+    } catch (err) {
+      if (!isPtyAlreadyGoneError(err)) {
+        // Why: a failed SSH shutdown can leave the remote process alive in
+        // the relay grace window; daemon failures have the same risk locally.
+        // Keep ownership/lease state so the user can retry.
+        throw err
+      }
       /* session already dead — cleanup below handles the rest */
-    } finally {
-      // Why: onExit clears provider state for LocalPtyProvider, but remote
-      // SSH and daemon shutdown paths do not emit onExit through the local
-      // provider's listener. Call clearProviderPtyState explicitly here so
-      // the hook-server paneKey cache and OpenCode/Pi PTY-scoped state are
-      // cleared on explicit kill. clearProviderPtyState is idempotent — safe
-      // if onExit already ran.
-      clearProviderPtyState(args.id)
-      ptyOwnership.delete(args.id)
-      markClaudePtyExited(args.id)
     }
+    // Why: onExit clears provider state for LocalPtyProvider, but remote SSH
+    // and daemon shutdown paths do not emit onExit through the local provider's
+    // listener. Explicit cleanup is idempotent and covers already-dead PTYs.
+    finishPtyShutdown(args.id, connectionId, store)
   })
 
   ipcMain.handle(

--- a/src/main/ipc/ssh.test.ts
+++ b/src/main/ipc/ssh.test.ts
@@ -1,3 +1,6 @@
+/* eslint-disable max-lines -- Why: SSH IPC session lifecycle tests share a
+single mocked Electron/connection harness; splitting them would obscure active
+session state that the terminate/disconnect assertions depend on. */
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 
 const {
@@ -38,7 +41,9 @@ const {
   mockPtyProvider: {
     onData: vi.fn(),
     onExit: vi.fn(),
-    onReplay: vi.fn()
+    onReplay: vi.fn(),
+    attach: vi.fn(),
+    shutdown: vi.fn()
   },
   mockFsProvider: {},
   mockGitProvider: {},
@@ -90,6 +95,8 @@ vi.mock('../ssh/ssh-channel-multiplexer', () => ({
 }))
 
 vi.mock('../providers/ssh-pty-provider', () => ({
+  isSshPtyNotFoundError: (err: unknown) =>
+    (err instanceof Error ? err.message : String(err)).includes('not found'),
   SshPtyProvider: class MockSshPtyProvider {
     constructor() {
       return mockPtyProvider
@@ -111,6 +118,7 @@ vi.mock('./pty', () => ({
   clearPtyOwnershipForConnection: vi.fn(),
   clearProviderPtyState: vi.fn(),
   deletePtyOwnership: vi.fn(),
+  setPtyOwnership: vi.fn(),
   getSshPtyProvider: vi.fn(),
   getPtyIdsForConnection: vi.fn().mockReturnValue([])
 }))
@@ -144,10 +152,17 @@ vi.mock('../ssh/ssh-port-forward', () => ({
 
 import { registerSshHandlers } from './ssh'
 import type { SshTarget } from '../../shared/ssh-types'
+import { getSshPtyProvider, getPtyIdsForConnection } from './pty'
 
 describe('SSH IPC handlers', () => {
   const handlers = new Map<string, (_event: unknown, args: unknown) => unknown>()
-  const mockStore = { getRepos: () => [] } as never
+  const mockStore = {
+    getRepos: () => [],
+    getSshRemotePtyLeases: vi.fn().mockReturnValue([]),
+    markSshRemotePtyLease: vi.fn(),
+    markSshRemotePtyLeases: vi.fn(),
+    removeSshRemotePtyLeases: vi.fn()
+  }
   const mockWindow = {
     isDestroyed: () => false,
     webContents: { send: vi.fn() }
@@ -166,6 +181,10 @@ describe('SSH IPC handlers', () => {
     mockSshStore.updateTarget.mockReset()
     mockSshStore.removeTarget.mockReset()
     mockSshStore.importFromSshConfig.mockReset().mockReturnValue([])
+    mockStore.getSshRemotePtyLeases.mockReset().mockReturnValue([])
+    mockStore.markSshRemotePtyLease.mockReset()
+    mockStore.markSshRemotePtyLeases.mockReset()
+    mockStore.removeSshRemotePtyLeases.mockReset()
 
     mockConnectionManager.connect.mockReset()
     mockConnectionManager.disconnect.mockReset()
@@ -183,8 +202,11 @@ describe('SSH IPC handlers', () => {
     mockPtyProvider.onData.mockReset()
     mockPtyProvider.onExit.mockReset()
     mockPtyProvider.onReplay.mockReset()
+    mockPtyProvider.shutdown.mockReset()
+    vi.mocked(getSshPtyProvider).mockReset()
+    vi.mocked(getPtyIdsForConnection).mockReset().mockReturnValue([])
 
-    registerSshHandlers(mockStore, () => mockWindow as never)
+    registerSshHandlers(mockStore as never, () => mockWindow as never)
   })
 
   it('registers all expected IPC channels', () => {
@@ -196,6 +218,7 @@ describe('SSH IPC handlers', () => {
     expect(channels).toContain('ssh:importConfig')
     expect(channels).toContain('ssh:connect')
     expect(channels).toContain('ssh:disconnect')
+    expect(channels).toContain('ssh:terminateSessions')
     expect(channels).toContain('ssh:getState')
     expect(channels).toContain('ssh:testConnection')
   })
@@ -227,6 +250,36 @@ describe('SSH IPC handlers', () => {
 
   it('ssh:removeTarget calls store.removeTarget', async () => {
     await handlers.get('ssh:removeTarget')!(null, { id: 'ssh-1' })
+    expect(mockSshStore.removeTarget).toHaveBeenCalledWith('ssh-1')
+  })
+
+  it('ssh:removeTarget tears down an active relay before deleting the target', async () => {
+    const target: SshTarget = {
+      id: 'ssh-1',
+      label: 'Server',
+      host: 'example.com',
+      port: 22,
+      username: 'deploy'
+    }
+    mockSshStore.getTarget.mockReturnValue(target)
+    mockConnectionManager.connect.mockResolvedValue({})
+    mockConnectionManager.getState.mockReturnValue({
+      targetId: 'ssh-1',
+      status: 'connected',
+      error: null,
+      reconnectAttempt: 0
+    })
+    await handlers.get('ssh:connect')!(null, { targetId: 'ssh-1' })
+    mockPortForwardManager.removeAllForwards.mockClear()
+    mockConnectionManager.disconnect.mockClear().mockResolvedValue(undefined)
+
+    await handlers.get('ssh:removeTarget')!(null, { id: 'ssh-1' })
+
+    expect(mockPortForwardManager.removeAllForwards).toHaveBeenCalledWith('ssh-1')
+    expect(mockMux.dispose).toHaveBeenCalledWith('shutdown')
+    expect(mockStore.markSshRemotePtyLeases).toHaveBeenCalledWith('ssh-1', 'terminated')
+    expect(mockConnectionManager.disconnect).toHaveBeenCalledWith('ssh-1')
+    expect(mockStore.removeSshRemotePtyLeases).toHaveBeenCalledWith('ssh-1')
     expect(mockSshStore.removeTarget).toHaveBeenCalledWith('ssh-1')
   })
 
@@ -275,7 +328,7 @@ describe('SSH IPC handlers', () => {
       onPtyData: vi.fn(),
       onPtyExit: vi.fn()
     }
-    registerSshHandlers(mockStore, () => mockWindow as never, runtime as never)
+    registerSshHandlers(mockStore as never, () => mockWindow as never, runtime as never)
     const target: SshTarget = {
       id: 'ssh-1',
       label: 'Server',
@@ -312,6 +365,53 @@ describe('SSH IPC handlers', () => {
 
     await handlers.get('ssh:disconnect')!(null, { targetId: 'ssh-1' })
 
+    expect(mockConnectionManager.disconnect).toHaveBeenCalledWith('ssh-1')
+  })
+
+  it('ssh:terminateSessions preserves tracking when relay shutdown fails', async () => {
+    const target: SshTarget = {
+      id: 'ssh-1',
+      label: 'Server',
+      host: 'example.com',
+      port: 22,
+      username: 'deploy'
+    }
+    mockSshStore.getTarget.mockReturnValue(target)
+    mockConnectionManager.connect.mockResolvedValue({})
+    mockConnectionManager.getState.mockReturnValue({
+      targetId: 'ssh-1',
+      status: 'connected',
+      error: null,
+      reconnectAttempt: 0
+    })
+    mockStore.getSshRemotePtyLeases.mockReturnValue([
+      { targetId: 'ssh-1', ptyId: 'pty-1', state: 'detached' }
+    ])
+    vi.mocked(getSshPtyProvider).mockReturnValue(mockPtyProvider as never)
+    vi.mocked(getPtyIdsForConnection).mockReturnValue(['pty-1'])
+    mockPtyProvider.shutdown.mockRejectedValue(new Error('mux down'))
+
+    await handlers.get('ssh:connect')!(null, { targetId: 'ssh-1' })
+
+    await expect(
+      handlers.get('ssh:terminateSessions')!(null, { targetId: 'ssh-1' })
+    ).rejects.toThrow('Failed to terminate remote SSH sessions')
+    expect(mockStore.markSshRemotePtyLease).not.toHaveBeenCalledWith('ssh-1', 'pty-1', 'terminated')
+    expect(mockConnectionManager.disconnect).not.toHaveBeenCalledWith('ssh-1')
+  })
+
+  it('ssh:terminateSessions ignores expired leases when disconnected', async () => {
+    mockStore.getSshRemotePtyLeases.mockReturnValue([
+      { targetId: 'ssh-1', ptyId: 'pty-expired', state: 'expired' }
+    ])
+    vi.mocked(getSshPtyProvider).mockReturnValue(undefined)
+    vi.mocked(getPtyIdsForConnection).mockReturnValue([])
+
+    await expect(
+      handlers.get('ssh:terminateSessions')!(null, { targetId: 'ssh-1' })
+    ).resolves.toBeUndefined()
+
+    expect(mockPtyProvider.shutdown).not.toHaveBeenCalled()
     expect(mockConnectionManager.disconnect).toHaveBeenCalledWith('ssh-1')
   })
 

--- a/src/main/ipc/ssh.ts
+++ b/src/main/ipc/ssh.ts
@@ -14,9 +14,17 @@ import type {
   DetectedPort,
   SavedPortForward
 } from '../../shared/ssh-types'
+import { SSH_TERMINATE_RECONNECT_REQUIRED } from '../../shared/constants'
 import { isAuthError } from '../ssh/ssh-connection-utils'
+import { isSshPtyNotFoundError } from '../providers/ssh-pty-provider'
 import { registerSshBrowseHandler } from './ssh-browse'
 import { requestCredential, registerCredentialHandler } from './ssh-passphrase'
+import {
+  clearProviderPtyState,
+  deletePtyOwnership,
+  getPtyIdsForConnection,
+  getSshPtyProvider
+} from './pty'
 import type { OrcaRuntimeService } from '../runtime/orca-runtime'
 
 let sshStore: SshConnectionStore | null = null
@@ -194,6 +202,7 @@ export function registerSshHandlers(
     'ssh:importConfig',
     'ssh:connect',
     'ssh:disconnect',
+    'ssh:terminateSessions',
     'ssh:getState',
     'ssh:needsPassphrasePrompt',
     'ssh:testConnection',
@@ -278,7 +287,24 @@ export function registerSshHandlers(
     }
   )
 
-  ipcMain.handle('ssh:removeTarget', (_event, args: { id: string }) => {
+  ipcMain.handle('ssh:removeTarget', async (_event, args: { id: string }) => {
+    const session = activeSessions.get(args.id)
+    if (session) {
+      // Why: removing a target is destructive. Tear down the live relay before
+      // deleting metadata so callbacks cannot keep using an orphan target id.
+      await portForwardManager!.removeAllForwards(args.id)
+      session.dispose()
+      activeSessions.delete(args.id)
+      clearRelayLostBackoff(args.id)
+    }
+    try {
+      await connectionManager!.disconnect(args.id)
+    } catch (err) {
+      console.warn(
+        `[ssh] Failed to disconnect removed target ${args.id}: ${err instanceof Error ? err.message : String(err)}`
+      )
+    }
+    store.removeSshRemotePtyLeases(args.id)
     sshStore!.removeTarget(args.id)
   })
 
@@ -322,7 +348,7 @@ export function registerSshHandlers(
       // local ports. Without this, restorePortForwards in the new session
       // can hit EADDRINUSE on the same ports the old session was using.
       await portForwardManager!.removeAllForwards(targetId)
-      existingSession.dispose()
+      existingSession.detach()
       activeSessions.delete(targetId)
       clearRelayLostBackoff(targetId)
     }
@@ -540,6 +566,52 @@ export function registerSshHandlers(
       // Why: await port teardown so local listeners are fully released
       // before the disconnect completes. Without this, an immediate
       // reconnect can hit EADDRINUSE on the same ports.
+      await portForwardManager!.removeAllForwards(args.targetId)
+      session.detach()
+      activeSessions.delete(args.targetId)
+      clearRelayLostBackoff(args.targetId)
+    }
+    await connectionManager!.disconnect(args.targetId)
+  })
+
+  ipcMain.handle('ssh:terminateSessions', async (_event, args: { targetId: string }) => {
+    const session = activeSessions.get(args.targetId)
+    const provider = getSshPtyProvider(args.targetId)
+    const leasedIds = store
+      .getSshRemotePtyLeases(args.targetId)
+      .filter((lease) => lease.state !== 'terminated' && lease.state !== 'expired')
+      .map((lease) => lease.ptyId)
+    const ptyIds = Array.from(new Set([...getPtyIdsForConnection(args.targetId), ...leasedIds]))
+
+    if (ptyIds.length > 0 && !provider) {
+      throw new Error(
+        `${SSH_TERMINATE_RECONNECT_REQUIRED}: SSH relay is not connected; reconnect before terminating remote sessions.`
+      )
+    }
+    const shutdownResults = provider
+      ? await Promise.allSettled(
+          ptyIds.map((ptyId) => provider.shutdown(ptyId, { immediate: true, keepHistory: false }))
+        )
+      : []
+    const shutdownFailures: string[] = []
+    for (const [index, result] of shutdownResults.entries()) {
+      const ptyId = ptyIds[index]
+      if (result.status !== 'fulfilled' && !isSshPtyNotFoundError(result.reason)) {
+        shutdownFailures.push(
+          `${ptyId}: ${result.reason instanceof Error ? result.reason.message : String(result.reason)}`
+        )
+        continue
+      }
+      clearProviderPtyState(ptyId)
+      deletePtyOwnership(ptyId)
+      store.markSshRemotePtyLease(args.targetId, ptyId, 'terminated')
+    }
+    if (shutdownFailures.length > 0) {
+      // Why: a failed relay shutdown can leave the remote process alive in the
+      // grace window. Keep the lease/session intact so the user can retry.
+      throw new Error(`Failed to terminate remote SSH sessions: ${shutdownFailures.join('; ')}`)
+    }
+    if (session) {
       await portForwardManager!.removeAllForwards(args.targetId)
       session.dispose()
       activeSessions.delete(args.targetId)

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -862,6 +862,732 @@ describe('Store', () => {
     expect(store.getWorkspaceSession()).toEqual(session)
   })
 
+  it('does not restore cleared SSH bindings after a lease expired', async () => {
+    const store = await createStore()
+    store.upsertSshRemotePtyLease({
+      targetId: 'ssh-1',
+      ptyId: 'remote-pty',
+      worktreeId: 'wt1',
+      tabId: 'tab1',
+      leafId: 'leaf1',
+      state: 'expired'
+    })
+    store.setWorkspaceSession({
+      activeRepoId: 'r1',
+      activeWorktreeId: 'wt1',
+      activeTabId: 'tab1',
+      tabsByWorktree: {
+        wt1: [
+          {
+            id: 'tab1',
+            worktreeId: 'wt1',
+            title: 'Terminal',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1,
+            ptyId: 'remote-pty'
+          }
+        ]
+      },
+      terminalLayoutsByTabId: {
+        tab1: {
+          root: { type: 'leaf', leafId: 'leaf1' },
+          activeLeafId: 'leaf1',
+          expandedLeafId: null,
+          ptyIdsByLeafId: { leaf1: 'remote-pty' }
+        }
+      }
+    })
+
+    store.setWorkspaceSession({
+      activeRepoId: 'r1',
+      activeWorktreeId: 'wt1',
+      activeTabId: 'tab1',
+      tabsByWorktree: {
+        wt1: [
+          {
+            id: 'tab1',
+            worktreeId: 'wt1',
+            title: 'Terminal',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1,
+            ptyId: null
+          }
+        ]
+      },
+      terminalLayoutsByTabId: {
+        tab1: {
+          root: { type: 'leaf', leafId: 'leaf1' },
+          activeLeafId: 'leaf1',
+          expandedLeafId: null,
+          ptyIdsByLeafId: {}
+        }
+      }
+    })
+
+    const session = store.getWorkspaceSession()
+    expect(session.tabsByWorktree.wt1[0].ptyId).toBeNull()
+    expect(session.terminalLayoutsByTabId.tab1.ptyIdsByLeafId).toEqual({})
+  })
+
+  it('does not let an expired lease for another tab suppress a matching pty id', async () => {
+    const store = await createStore()
+    store.upsertSshRemotePtyLease({
+      targetId: 'ssh-1',
+      ptyId: 'remote-pty',
+      worktreeId: 'wt1',
+      tabId: 'tab-expired',
+      leafId: 'leaf-expired',
+      state: 'expired'
+    })
+    store.setWorkspaceSession({
+      activeRepoId: 'r1',
+      activeWorktreeId: 'wt1',
+      activeTabId: 'tab-live',
+      tabsByWorktree: {
+        wt1: [
+          {
+            id: 'tab-live',
+            worktreeId: 'wt1',
+            title: 'Terminal',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1,
+            ptyId: 'remote-pty'
+          }
+        ]
+      },
+      terminalLayoutsByTabId: {
+        'tab-live': {
+          root: { type: 'leaf', leafId: 'leaf-live' },
+          activeLeafId: 'leaf-live',
+          expandedLeafId: null,
+          ptyIdsByLeafId: { 'leaf-live': 'remote-pty' }
+        }
+      }
+    })
+
+    store.setWorkspaceSession({
+      activeRepoId: 'r1',
+      activeWorktreeId: 'wt1',
+      activeTabId: 'tab-live',
+      tabsByWorktree: {
+        wt1: [
+          {
+            id: 'tab-live',
+            worktreeId: 'wt1',
+            title: 'Terminal',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1,
+            ptyId: null
+          }
+        ]
+      },
+      terminalLayoutsByTabId: {
+        'tab-live': {
+          root: { type: 'leaf', leafId: 'leaf-live' },
+          activeLeafId: 'leaf-live',
+          expandedLeafId: null,
+          ptyIdsByLeafId: {}
+        }
+      }
+    })
+
+    const session = store.getWorkspaceSession()
+    expect(session.tabsByWorktree.wt1[0].ptyId).toBe('remote-pty')
+    expect(session.terminalLayoutsByTabId['tab-live'].ptyIdsByLeafId).toEqual({
+      'leaf-live': 'remote-pty'
+    })
+  })
+
+  it('does not let an expired lease for another SSH target suppress the same tab binding', async () => {
+    const store = await createStore()
+    store.addRepo(makeRepo({ id: 'repo-live', connectionId: 'ssh-live' }))
+    store.upsertSshRemotePtyLease({
+      targetId: 'ssh-expired',
+      ptyId: 'remote-pty',
+      worktreeId: 'repo-live::/wt',
+      tabId: 'tab-live',
+      leafId: 'leaf-live',
+      state: 'expired'
+    })
+    store.upsertSshRemotePtyLease({
+      targetId: 'ssh-live',
+      ptyId: 'remote-pty',
+      worktreeId: 'repo-live::/wt',
+      tabId: 'tab-live',
+      leafId: 'leaf-live',
+      state: 'detached'
+    })
+    store.setWorkspaceSession({
+      activeRepoId: 'repo-live',
+      activeWorktreeId: 'repo-live::/wt',
+      activeTabId: 'tab-live',
+      tabsByWorktree: {
+        'repo-live::/wt': [
+          {
+            id: 'tab-live',
+            worktreeId: 'repo-live::/wt',
+            title: 'Terminal',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1,
+            ptyId: 'remote-pty'
+          }
+        ]
+      },
+      terminalLayoutsByTabId: {
+        'tab-live': {
+          root: { type: 'leaf', leafId: 'leaf-live' },
+          activeLeafId: 'leaf-live',
+          expandedLeafId: null,
+          ptyIdsByLeafId: { 'leaf-live': 'remote-pty' }
+        }
+      }
+    })
+
+    store.setWorkspaceSession({
+      activeRepoId: 'repo-live',
+      activeWorktreeId: 'repo-live::/wt',
+      activeTabId: 'tab-live',
+      tabsByWorktree: {
+        'repo-live::/wt': [
+          {
+            id: 'tab-live',
+            worktreeId: 'repo-live::/wt',
+            title: 'Terminal',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1,
+            ptyId: null
+          }
+        ]
+      },
+      terminalLayoutsByTabId: {
+        'tab-live': {
+          root: { type: 'leaf', leafId: 'leaf-live' },
+          activeLeafId: 'leaf-live',
+          expandedLeafId: null,
+          ptyIdsByLeafId: {}
+        }
+      }
+    })
+
+    const session = store.getWorkspaceSession()
+    expect(session.tabsByWorktree['repo-live::/wt'][0].ptyId).toBe('remote-pty')
+    expect(session.terminalLayoutsByTabId['tab-live'].ptyIdsByLeafId).toEqual({
+      'leaf-live': 'remote-pty'
+    })
+  })
+
+  it('does not treat contextless expired leases as wildcards for contextual bindings', async () => {
+    const store = await createStore()
+    store.upsertSshRemotePtyLease({
+      targetId: 'ssh-1',
+      ptyId: 'remote-pty',
+      state: 'expired'
+    })
+    store.setWorkspaceSession({
+      activeRepoId: 'r1',
+      activeWorktreeId: 'wt1',
+      activeTabId: 'tab1',
+      tabsByWorktree: {
+        wt1: [
+          {
+            id: 'tab1',
+            worktreeId: 'wt1',
+            title: 'Terminal',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1,
+            ptyId: 'remote-pty'
+          }
+        ]
+      },
+      terminalLayoutsByTabId: {
+        tab1: {
+          root: { type: 'leaf', leafId: 'leaf1' },
+          activeLeafId: 'leaf1',
+          expandedLeafId: null,
+          ptyIdsByLeafId: { leaf1: 'remote-pty' }
+        }
+      }
+    })
+
+    store.setWorkspaceSession({
+      activeRepoId: 'r1',
+      activeWorktreeId: 'wt1',
+      activeTabId: 'tab1',
+      tabsByWorktree: {
+        wt1: [
+          {
+            id: 'tab1',
+            worktreeId: 'wt1',
+            title: 'Terminal',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1,
+            ptyId: null
+          }
+        ]
+      },
+      terminalLayoutsByTabId: {
+        tab1: {
+          root: { type: 'leaf', leafId: 'leaf1' },
+          activeLeafId: 'leaf1',
+          expandedLeafId: null,
+          ptyIdsByLeafId: {}
+        }
+      }
+    })
+
+    const session = store.getWorkspaceSession()
+    expect(session.tabsByWorktree.wt1[0].ptyId).toBe('remote-pty')
+    expect(session.terminalLayoutsByTabId.tab1.ptyIdsByLeafId).toEqual({ leaf1: 'remote-pty' })
+  })
+
+  it('does not treat layout-level leases missing worktree context as contextual matches', async () => {
+    const store = await createStore()
+    store.upsertSshRemotePtyLease({
+      targetId: 'ssh-1',
+      ptyId: 'remote-pty',
+      tabId: 'tab1',
+      leafId: 'leaf1',
+      state: 'expired'
+    })
+    store.setWorkspaceSession({
+      activeRepoId: 'r1',
+      activeWorktreeId: 'wt1',
+      activeTabId: 'tab1',
+      tabsByWorktree: {
+        wt1: [
+          {
+            id: 'tab1',
+            worktreeId: 'wt1',
+            title: 'Terminal',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1,
+            ptyId: null
+          }
+        ]
+      },
+      terminalLayoutsByTabId: {
+        tab1: {
+          root: { type: 'leaf', leafId: 'leaf1' },
+          activeLeafId: 'leaf1',
+          expandedLeafId: null,
+          ptyIdsByLeafId: { leaf1: 'remote-pty' }
+        }
+      }
+    })
+
+    store.setWorkspaceSession({
+      activeRepoId: 'r1',
+      activeWorktreeId: 'wt1',
+      activeTabId: 'tab1',
+      tabsByWorktree: {
+        wt1: [
+          {
+            id: 'tab1',
+            worktreeId: 'wt1',
+            title: 'Terminal',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1,
+            ptyId: null
+          }
+        ]
+      },
+      terminalLayoutsByTabId: {
+        tab1: {
+          root: { type: 'leaf', leafId: 'leaf1' },
+          activeLeafId: 'leaf1',
+          expandedLeafId: null,
+          ptyIdsByLeafId: {}
+        }
+      }
+    })
+
+    expect(store.getWorkspaceSession().terminalLayoutsByTabId.tab1.ptyIdsByLeafId).toEqual({
+      leaf1: 'remote-pty'
+    })
+  })
+
+  it('merges missing prior layout bindings into partial renderer snapshots', async () => {
+    const store = await createStore()
+    store.upsertSshRemotePtyLease({
+      targetId: 'ssh-1',
+      ptyId: 'remote-pty-1',
+      worktreeId: 'wt1',
+      tabId: 'tab1',
+      leafId: 'leaf1',
+      state: 'detached'
+    })
+    store.upsertSshRemotePtyLease({
+      targetId: 'ssh-1',
+      ptyId: 'remote-pty-2',
+      worktreeId: 'wt1',
+      tabId: 'tab1',
+      leafId: 'leaf2',
+      state: 'detached'
+    })
+    store.setWorkspaceSession({
+      activeRepoId: 'r1',
+      activeWorktreeId: 'wt1',
+      activeTabId: 'tab1',
+      tabsByWorktree: {
+        wt1: [
+          {
+            id: 'tab1',
+            worktreeId: 'wt1',
+            title: 'Terminal',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1,
+            ptyId: 'remote-pty-1'
+          }
+        ]
+      },
+      terminalLayoutsByTabId: {
+        tab1: {
+          root: {
+            type: 'split',
+            direction: 'horizontal',
+            first: { type: 'leaf', leafId: 'leaf1' },
+            second: { type: 'leaf', leafId: 'leaf2' },
+            ratio: 0.5
+          },
+          activeLeafId: 'leaf2',
+          expandedLeafId: null,
+          ptyIdsByLeafId: { leaf1: 'remote-pty-1', leaf2: 'remote-pty-2' }
+        }
+      }
+    })
+
+    store.setWorkspaceSession({
+      activeRepoId: 'r1',
+      activeWorktreeId: 'wt1',
+      activeTabId: 'tab1',
+      tabsByWorktree: {
+        wt1: [
+          {
+            id: 'tab1',
+            worktreeId: 'wt1',
+            title: 'Terminal',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1,
+            ptyId: 'remote-pty-1'
+          }
+        ]
+      },
+      terminalLayoutsByTabId: {
+        tab1: {
+          root: {
+            type: 'split',
+            direction: 'horizontal',
+            first: { type: 'leaf', leafId: 'leaf1' },
+            second: { type: 'leaf', leafId: 'leaf2' },
+            ratio: 0.5
+          },
+          activeLeafId: 'leaf1',
+          expandedLeafId: null,
+          ptyIdsByLeafId: { leaf1: 'remote-pty-1' }
+        }
+      }
+    })
+
+    expect(store.getWorkspaceSession().terminalLayoutsByTabId.tab1.ptyIdsByLeafId).toEqual({
+      leaf1: 'remote-pty-1',
+      leaf2: 'remote-pty-2'
+    })
+  })
+
+  it('does not restore layout bindings for leaves removed from the incoming layout', async () => {
+    const store = await createStore()
+    store.upsertSshRemotePtyLease({
+      targetId: 'ssh-1',
+      ptyId: 'remote-pty-1',
+      tabId: 'tab1',
+      leafId: 'leaf1',
+      state: 'detached'
+    })
+    store.upsertSshRemotePtyLease({
+      targetId: 'ssh-1',
+      ptyId: 'remote-pty-2',
+      tabId: 'tab1',
+      leafId: 'leaf2',
+      state: 'detached'
+    })
+    store.setWorkspaceSession({
+      activeRepoId: 'r1',
+      activeWorktreeId: 'wt1',
+      activeTabId: 'tab1',
+      tabsByWorktree: {
+        wt1: [
+          {
+            id: 'tab1',
+            worktreeId: 'wt1',
+            title: 'Terminal',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1,
+            ptyId: 'remote-pty-1'
+          }
+        ]
+      },
+      terminalLayoutsByTabId: {
+        tab1: {
+          root: {
+            type: 'split',
+            direction: 'horizontal',
+            first: { type: 'leaf', leafId: 'leaf1' },
+            second: { type: 'leaf', leafId: 'leaf2' },
+            ratio: 0.5
+          },
+          activeLeafId: 'leaf2',
+          expandedLeafId: null,
+          ptyIdsByLeafId: { leaf1: 'remote-pty-1', leaf2: 'remote-pty-2' }
+        }
+      }
+    })
+
+    store.setWorkspaceSession({
+      activeRepoId: 'r1',
+      activeWorktreeId: 'wt1',
+      activeTabId: 'tab1',
+      tabsByWorktree: {
+        wt1: [
+          {
+            id: 'tab1',
+            worktreeId: 'wt1',
+            title: 'Terminal',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1,
+            ptyId: 'remote-pty-1'
+          }
+        ]
+      },
+      terminalLayoutsByTabId: {
+        tab1: {
+          root: { type: 'leaf', leafId: 'leaf1' },
+          activeLeafId: 'leaf1',
+          expandedLeafId: null,
+          ptyIdsByLeafId: { leaf1: 'remote-pty-1' }
+        }
+      }
+    })
+
+    expect(store.getWorkspaceSession().terminalLayoutsByTabId.tab1.ptyIdsByLeafId).toEqual({
+      leaf1: 'remote-pty-1'
+    })
+  })
+
+  it('does not restore missing layout bindings without a live SSH lease', async () => {
+    const store = await createStore()
+    store.setWorkspaceSession({
+      activeRepoId: 'r1',
+      activeWorktreeId: 'wt1',
+      activeTabId: 'tab1',
+      tabsByWorktree: {
+        wt1: [
+          {
+            id: 'tab1',
+            worktreeId: 'wt1',
+            title: 'Terminal',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1,
+            ptyId: 'local-pty-1'
+          }
+        ]
+      },
+      terminalLayoutsByTabId: {
+        tab1: {
+          root: {
+            type: 'split',
+            direction: 'horizontal',
+            first: { type: 'leaf', leafId: 'leaf1' },
+            second: { type: 'leaf', leafId: 'leaf2' },
+            ratio: 0.5
+          },
+          activeLeafId: 'leaf2',
+          expandedLeafId: null,
+          ptyIdsByLeafId: { leaf1: 'local-pty-1', leaf2: 'local-pty-2' }
+        }
+      }
+    })
+
+    store.setWorkspaceSession({
+      activeRepoId: 'r1',
+      activeWorktreeId: 'wt1',
+      activeTabId: 'tab1',
+      tabsByWorktree: {
+        wt1: [
+          {
+            id: 'tab1',
+            worktreeId: 'wt1',
+            title: 'Terminal',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1,
+            ptyId: 'local-pty-1'
+          }
+        ]
+      },
+      terminalLayoutsByTabId: {
+        tab1: {
+          root: {
+            type: 'split',
+            direction: 'horizontal',
+            first: { type: 'leaf', leafId: 'leaf1' },
+            second: { type: 'leaf', leafId: 'leaf2' },
+            ratio: 0.5
+          },
+          activeLeafId: 'leaf1',
+          expandedLeafId: null,
+          ptyIdsByLeafId: { leaf1: 'local-pty-1' }
+        }
+      }
+    })
+
+    expect(store.getWorkspaceSession().terminalLayoutsByTabId.tab1.ptyIdsByLeafId).toEqual({
+      leaf1: 'local-pty-1'
+    })
+  })
+
+  it('clears workspace bindings before removing SSH remote PTY leases for a target', async () => {
+    const store = await createStore()
+    store.upsertSshRemotePtyLease({
+      targetId: 'ssh-1',
+      ptyId: 'remote-pty',
+      worktreeId: 'wt1',
+      tabId: 'tab1',
+      leafId: 'leaf1',
+      state: 'detached'
+    })
+    store.setWorkspaceSession({
+      activeRepoId: 'r1',
+      activeWorktreeId: 'wt1',
+      activeTabId: 'tab1',
+      tabsByWorktree: {
+        wt1: [
+          {
+            id: 'tab1',
+            worktreeId: 'wt1',
+            title: 'Terminal',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1,
+            ptyId: 'remote-pty'
+          }
+        ]
+      },
+      terminalLayoutsByTabId: {
+        tab1: {
+          root: { type: 'leaf', leafId: 'leaf1' },
+          activeLeafId: 'leaf1',
+          expandedLeafId: null,
+          ptyIdsByLeafId: { leaf1: 'remote-pty' }
+        }
+      }
+    })
+
+    store.removeSshRemotePtyLeases('ssh-1')
+
+    const session = store.getWorkspaceSession()
+    expect(store.getSshRemotePtyLeases('ssh-1')).toEqual([])
+    expect(session.tabsByWorktree.wt1[0].ptyId).toBeNull()
+    expect(session.terminalLayoutsByTabId.tab1.ptyIdsByLeafId).toEqual({})
+  })
+
+  it('clears workspace bindings before removing contextless SSH remote PTY leases', async () => {
+    const store = await createStore()
+    store.upsertSshRemotePtyLease({
+      targetId: 'ssh-1',
+      ptyId: 'remote-pty',
+      state: 'detached'
+    })
+    store.setWorkspaceSession({
+      activeRepoId: 'r1',
+      activeWorktreeId: 'wt1',
+      activeTabId: 'tab1',
+      tabsByWorktree: {
+        wt1: [
+          {
+            id: 'tab1',
+            worktreeId: 'wt1',
+            title: 'Terminal',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1,
+            ptyId: 'remote-pty'
+          }
+        ]
+      },
+      terminalLayoutsByTabId: {
+        tab1: {
+          root: { type: 'leaf', leafId: 'leaf1' },
+          activeLeafId: 'leaf1',
+          expandedLeafId: null,
+          ptyIdsByLeafId: { leaf1: 'remote-pty' }
+        }
+      }
+    })
+
+    store.removeSshRemotePtyLeases('ssh-1')
+
+    const session = store.getWorkspaceSession()
+    expect(store.getSshRemotePtyLeases('ssh-1')).toEqual([])
+    expect(session.tabsByWorktree.wt1[0].ptyId).toBeNull()
+    expect(session.terminalLayoutsByTabId.tab1.ptyIdsByLeafId).toEqual({})
+  })
+
+  it('does not revive expired leases when marking a target detached', async () => {
+    const store = await createStore()
+    store.upsertSshRemotePtyLease({
+      targetId: 'ssh-1',
+      ptyId: 'live-pty',
+      state: 'attached'
+    })
+    store.upsertSshRemotePtyLease({
+      targetId: 'ssh-1',
+      ptyId: 'expired-pty',
+      state: 'expired'
+    })
+
+    store.markSshRemotePtyLeases('ssh-1', 'detached')
+
+    expect(store.getSshRemotePtyLeases('ssh-1')).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ ptyId: 'live-pty', state: 'detached' }),
+        expect.objectContaining({ ptyId: 'expired-pty', state: 'expired' })
+      ])
+    )
+  })
+
   // ── getAllWorktreeMeta ─────────────────────────────────────────────
 
   it('getAllWorktreeMeta returns all entries', async () => {

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -15,9 +15,10 @@ import type {
   GlobalSettings,
   OnboardingChecklistState,
   OnboardingOutcome,
-  OnboardingState
+  OnboardingState,
+  TerminalPaneLayoutNode
 } from '../shared/types'
-import type { SshTarget } from '../shared/ssh-types'
+import type { SshRemotePtyLease, SshTarget } from '../shared/ssh-types'
 import { isFolderRepo } from '../shared/repo-kind'
 import { getGitUsername } from './git/repo'
 import {
@@ -190,6 +191,33 @@ function readLegacySidekickFlag(parsed: PersistedState | undefined): boolean | u
   return (parsed?.settings as { experimentalSidekick?: boolean } | undefined)?.experimentalSidekick
 }
 
+function normalizeSshRemotePtyLease(value: unknown): SshRemotePtyLease | null {
+  if (!value || typeof value !== 'object') {
+    return null
+  }
+  const raw = value as Partial<SshRemotePtyLease>
+  if (typeof raw.targetId !== 'string' || typeof raw.ptyId !== 'string') {
+    return null
+  }
+  const state = raw.state ?? 'detached'
+  if (!['attached', 'detached', 'terminated', 'expired'].includes(state)) {
+    return null
+  }
+  const now = Date.now()
+  return {
+    targetId: raw.targetId,
+    ptyId: raw.ptyId,
+    ...(typeof raw.worktreeId === 'string' ? { worktreeId: raw.worktreeId } : {}),
+    ...(typeof raw.tabId === 'string' ? { tabId: raw.tabId } : {}),
+    ...(typeof raw.leafId === 'string' ? { leafId: raw.leafId } : {}),
+    state,
+    createdAt: typeof raw.createdAt === 'number' ? raw.createdAt : now,
+    updatedAt: typeof raw.updatedAt === 'number' ? raw.updatedAt : now,
+    ...(typeof raw.lastAttachedAt === 'number' ? { lastAttachedAt: raw.lastAttachedAt } : {}),
+    ...(typeof raw.lastDetachedAt === 'number' ? { lastDetachedAt: raw.lastDetachedAt } : {})
+  }
+}
+
 export class Store {
   private state: PersistedState
   private writeTimer: ReturnType<typeof setTimeout> | null = null
@@ -356,6 +384,9 @@ export class Store {
             return { ...defaults.workspaceSession, ...result.value }
           })(),
           sshTargets: (parsed.sshTargets ?? []).map(normalizeSshTarget),
+          sshRemotePtyLeases: (parsed.sshRemotePtyLeases ?? [])
+            .map(normalizeSshRemotePtyLease)
+            .filter((lease): lease is SshRemotePtyLease => lease !== null),
           onboarding: (() => {
             // Why: if we successfully parsed an existing orca-data.json that
             // lacks an onboarding block, this is an upgrade-cohort user —
@@ -865,6 +896,12 @@ export class Store {
     if (session && prior) {
       const priorTabs = prior.tabsByWorktree ?? {}
       const nextTabs = session.tabsByWorktree ?? {}
+      const worktreeIdByTabId = new Map<string, string>()
+      for (const [worktreeId, tabs] of Object.entries({ ...priorTabs, ...nextTabs })) {
+        for (const tab of tabs) {
+          worktreeIdByTabId.set(tab.id, worktreeId)
+        }
+      }
       for (const [worktreeId, tabs] of Object.entries(nextTabs)) {
         const priorList = priorTabs[worktreeId]
         if (!priorList) {
@@ -875,7 +912,15 @@ export class Store {
             continue
           }
           const priorTab = priorList.find((t) => t.id === tab.id)
-          if (priorTab?.ptyId) {
+          if (
+            priorTab?.ptyId &&
+            this.isRestorablePtyBinding({
+              ptyId: priorTab.ptyId,
+              worktreeId,
+              targetId: this.getConnectionIdForWorktree(worktreeId),
+              tabId: tab.id
+            })
+          ) {
             tab.ptyId = priorTab.ptyId
           }
         }
@@ -887,15 +932,143 @@ export class Store {
         if (!priorLayout?.ptyIdsByLeafId) {
           continue
         }
-        const incoming = layout.ptyIdsByLeafId
-        if (incoming && Object.keys(incoming).length > 0) {
-          continue
+        const incoming = layout.ptyIdsByLeafId ?? {}
+        const incomingHasAnyBinding = Object.keys(incoming).length > 0
+        const liveLeafIds = this.getTerminalLayoutLeafIds(layout.root)
+        const worktreeId = worktreeIdByTabId.get(tabId)
+        const targetId = worktreeId ? this.getConnectionIdForWorktree(worktreeId) : null
+        const restorableBindings = Object.fromEntries(
+          Object.entries(priorLayout.ptyIdsByLeafId).filter(
+            ([leafId, ptyId]) =>
+              liveLeafIds.has(leafId) &&
+              incoming[leafId] === undefined &&
+              // Why: an empty layout map can be a stale pre-spawn snapshot; a
+              // partial map is intentional unless a durable SSH lease proves it.
+              (incomingHasAnyBinding
+                ? this.hasRestorableSshRemotePtyLease({
+                    ptyId,
+                    targetId,
+                    worktreeId,
+                    tabId,
+                    leafId
+                  })
+                : this.isRestorablePtyBinding({ ptyId, targetId, worktreeId, tabId, leafId }))
+          )
+        )
+        if (Object.keys(restorableBindings).length > 0) {
+          layout.ptyIdsByLeafId = { ...restorableBindings, ...incoming }
         }
-        layout.ptyIdsByLeafId = { ...priorLayout.ptyIdsByLeafId }
       }
     }
     this.state.workspaceSession = session
     this.scheduleSave()
+  }
+
+  private getTerminalLayoutLeafIds(root: TerminalPaneLayoutNode | null): Set<string> {
+    const leafIds = new Set<string>()
+    const visit = (node: TerminalPaneLayoutNode | null): void => {
+      if (!node) {
+        return
+      }
+      if (node.type === 'leaf') {
+        leafIds.add(node.leafId)
+        return
+      }
+      visit(node.first)
+      visit(node.second)
+    }
+    visit(root)
+    return leafIds
+  }
+
+  private isRestorablePtyBinding(binding: {
+    ptyId: string
+    targetId?: string | null
+    worktreeId?: string
+    tabId?: string
+    leafId?: string
+  }): boolean {
+    const leases = this.state.sshRemotePtyLeases?.filter((entry) =>
+      this.sshRemotePtyLeaseMatchesBinding(entry, binding)
+    )
+    return !leases?.some((lease) => lease.state === 'terminated' || lease.state === 'expired')
+  }
+
+  private sshRemotePtyLeaseMatchesBinding(
+    lease: SshRemotePtyLease,
+    binding: {
+      ptyId: string
+      targetId?: string | null
+      worktreeId?: string
+      tabId?: string
+      leafId?: string
+    }
+  ): boolean {
+    if (lease.ptyId !== binding.ptyId) {
+      return false
+    }
+    // Why: remote PTY ids are scoped to a relay target. Workspace PTY bindings
+    // only store the id, so derive target/context when possible and require
+    // stored lease context to match instead of treating missing fields as
+    // wildcards that can tombstone unrelated panes.
+    return (
+      (binding.targetId === undefined ||
+        binding.targetId === null ||
+        lease.targetId === binding.targetId) &&
+      (binding.worktreeId === undefined || lease.worktreeId === binding.worktreeId) &&
+      (binding.tabId === undefined || lease.tabId === binding.tabId) &&
+      (binding.leafId === undefined || lease.leafId === binding.leafId)
+    )
+  }
+
+  private hasRestorableSshRemotePtyLease(binding: {
+    ptyId: string
+    targetId?: string | null
+    worktreeId?: string
+    tabId?: string
+    leafId?: string
+  }): boolean {
+    return (
+      this.state.sshRemotePtyLeases?.some(
+        (lease) =>
+          this.sshRemotePtyLeaseMatchesBinding(lease, binding) &&
+          lease.state !== 'terminated' &&
+          lease.state !== 'expired'
+      ) ?? false
+    )
+  }
+
+  private sshRemotePtyLeaseMayReferenceBinding(
+    lease: SshRemotePtyLease,
+    binding: {
+      ptyId: string
+      targetId: string
+      worktreeId?: string
+      tabId?: string
+      leafId?: string
+    }
+  ): boolean {
+    if (lease.targetId !== binding.targetId || lease.ptyId !== binding.ptyId) {
+      return false
+    }
+    // Why: target removal is destructive. Legacy/contextless leases should
+    // scrub matching workspace bindings before the lease record is deleted,
+    // otherwise removing the tombstone can let stale PTY ids revive later.
+    return (
+      (binding.worktreeId === undefined ||
+        lease.worktreeId === undefined ||
+        lease.worktreeId === binding.worktreeId) &&
+      (binding.tabId === undefined || lease.tabId === undefined || lease.tabId === binding.tabId) &&
+      (binding.leafId === undefined ||
+        lease.leafId === undefined ||
+        lease.leafId === binding.leafId)
+    )
+  }
+
+  private getConnectionIdForWorktree(worktreeId: string): string | null {
+    const separatorIdx = worktreeId.indexOf('::')
+    const repoId = separatorIdx === -1 ? worktreeId : worktreeId.slice(0, separatorIdx)
+    return this.state.repos.find((repo) => repo.id === repoId)?.connectionId ?? null
   }
 
   // Why: closes the SIGKILL-between-spawn-and-persist race (Issue #217). The
@@ -978,6 +1151,149 @@ export class Store {
     }
     this.state.sshTargets = this.state.sshTargets.filter((t) => t.id !== id)
     this.scheduleSave()
+  }
+
+  // ── SSH Remote PTY Leases ──────────────────────────────────────────
+
+  getSshRemotePtyLeases(targetId?: string): SshRemotePtyLease[] {
+    const leases = this.state.sshRemotePtyLeases ?? []
+    return leases.filter((lease) => targetId === undefined || lease.targetId === targetId)
+  }
+
+  upsertSshRemotePtyLease(
+    lease: Omit<SshRemotePtyLease, 'createdAt' | 'updatedAt'> &
+      Partial<Pick<SshRemotePtyLease, 'createdAt' | 'updatedAt'>>
+  ): void {
+    this.state.sshRemotePtyLeases ??= []
+    const now = Date.now()
+    const existingIndex = this.state.sshRemotePtyLeases.findIndex(
+      (entry) => entry.targetId === lease.targetId && entry.ptyId === lease.ptyId
+    )
+    const existing = existingIndex >= 0 ? this.state.sshRemotePtyLeases[existingIndex] : undefined
+    const next: SshRemotePtyLease = {
+      ...existing,
+      ...lease,
+      createdAt: existing?.createdAt ?? lease.createdAt ?? now,
+      updatedAt: lease.updatedAt ?? now
+    }
+    if (existingIndex >= 0) {
+      this.state.sshRemotePtyLeases[existingIndex] = next
+    } else {
+      this.state.sshRemotePtyLeases.push(next)
+    }
+    this.flush()
+  }
+
+  markSshRemotePtyLeases(targetId: string, state: SshRemotePtyLease['state']): void {
+    const now = Date.now()
+    let changed = false
+    this.state.sshRemotePtyLeases ??= []
+    for (const lease of this.state.sshRemotePtyLeases) {
+      if (lease.targetId !== targetId || lease.state === state) {
+        continue
+      }
+      if (state === 'detached' && lease.state !== 'attached') {
+        continue
+      }
+      lease.state = state
+      lease.updatedAt = now
+      if (state === 'attached') {
+        lease.lastAttachedAt = now
+      } else if (state === 'detached') {
+        lease.lastDetachedAt = now
+      }
+      changed = true
+    }
+    if (changed) {
+      this.flush()
+    }
+  }
+
+  markSshRemotePtyLease(targetId: string, ptyId: string, state: SshRemotePtyLease['state']): void {
+    const lease = this.state.sshRemotePtyLeases?.find(
+      (entry) => entry.targetId === targetId && entry.ptyId === ptyId
+    )
+    if (!lease || lease.state === state) {
+      return
+    }
+    const now = Date.now()
+    lease.state = state
+    lease.updatedAt = now
+    if (state === 'attached') {
+      lease.lastAttachedAt = now
+    } else if (state === 'detached') {
+      lease.lastDetachedAt = now
+    }
+    this.flush()
+  }
+
+  removeSshRemotePtyLeases(targetId: string): void {
+    this.state.sshRemotePtyLeases ??= []
+    this.clearSshRemotePtyBindingsForTarget(targetId)
+    const before = this.state.sshRemotePtyLeases.length
+    this.state.sshRemotePtyLeases = this.state.sshRemotePtyLeases.filter(
+      (lease) => lease.targetId !== targetId
+    )
+    if (this.state.sshRemotePtyLeases.length !== before) {
+      this.flush()
+    }
+  }
+
+  private clearSshRemotePtyBindingsForTarget(targetId: string): void {
+    const leases = this.state.sshRemotePtyLeases?.filter((lease) => lease.targetId === targetId)
+    const session = this.state.workspaceSession
+    if (!leases?.length || !session) {
+      return
+    }
+    let changed = false
+    for (const [worktreeId, tabs] of Object.entries(session.tabsByWorktree ?? {})) {
+      for (const tab of tabs) {
+        if (
+          tab.ptyId &&
+          leases.some((lease) =>
+            this.sshRemotePtyLeaseMayReferenceBinding(lease, {
+              ptyId: tab.ptyId!,
+              worktreeId,
+              targetId,
+              tabId: tab.id
+            })
+          )
+        ) {
+          tab.ptyId = null
+          changed = true
+        }
+      }
+    }
+    for (const [tabId, layout] of Object.entries(session.terminalLayoutsByTabId ?? {})) {
+      const bindings = layout.ptyIdsByLeafId
+      if (!bindings) {
+        continue
+      }
+      const worktreeId = Object.entries(session.tabsByWorktree ?? {}).find(([, tabs]) =>
+        tabs.some((tab) => tab.id === tabId)
+      )?.[0]
+      const nextBindings = Object.fromEntries(
+        Object.entries(bindings).filter(
+          ([leafId, ptyId]) =>
+            !leases.some((lease) =>
+              this.sshRemotePtyLeaseMayReferenceBinding(lease, {
+                ptyId,
+                targetId,
+                worktreeId,
+                tabId,
+                leafId
+              })
+            )
+        )
+      )
+      if (Object.keys(nextBindings).length !== Object.keys(bindings).length) {
+        layout.ptyIdsByLeafId = nextBindings
+        changed = true
+      }
+    }
+    if (changed) {
+      this.scheduleSave()
+    }
   }
 
   // ── Flush (for shutdown) ───────────────────────────────────────────

--- a/src/main/providers/ssh-pty-provider.test.ts
+++ b/src/main/providers/ssh-pty-provider.test.ts
@@ -83,12 +83,12 @@ describe('SshPtyProvider', () => {
       })
     })
 
-    it('falls back to fresh spawn when session reattach fails', async () => {
-      mux.request
-        .mockRejectedValueOnce(new Error('not found'))
-        .mockResolvedValueOnce({ id: 'pty-new' })
+    it('does not fresh-spawn over an expired reattach session', async () => {
+      mux.request.mockRejectedValueOnce(new Error('PTY "pty-old" not found'))
 
-      const result = await provider.spawn({ cols: 80, rows: 24, sessionId: 'pty-old' })
+      await expect(provider.spawn({ cols: 80, rows: 24, sessionId: 'pty-old' })).rejects.toThrow(
+        'SSH_SESSION_EXPIRED: pty-old'
+      )
 
       expect(mux.request).toHaveBeenNthCalledWith(1, 'pty.attach', {
         id: 'pty-old',
@@ -96,13 +96,17 @@ describe('SshPtyProvider', () => {
         rows: 24,
         suppressReplayNotification: true
       })
-      expect(mux.request).toHaveBeenNthCalledWith(2, 'pty.spawn', {
-        cols: 80,
-        rows: 24,
-        cwd: undefined,
-        env: undefined
-      })
-      expect(result).toEqual({ id: 'pty-new', sessionExpired: true })
+      expect(mux.request).toHaveBeenCalledTimes(1)
+    })
+
+    it('preserves transient reattach failures for retry handling', async () => {
+      mux.request.mockRejectedValueOnce(new Error('SSH connection lost, reconnecting...'))
+
+      await expect(provider.spawn({ cols: 80, rows: 24, sessionId: 'pty-old' })).rejects.toThrow(
+        'SSH connection lost, reconnecting...'
+      )
+
+      expect(mux.request).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/src/main/providers/ssh-pty-provider.ts
+++ b/src/main/providers/ssh-pty-provider.ts
@@ -5,6 +5,13 @@ type DataCallback = (payload: { id: string; data: string }) => void
 type ReplayCallback = (payload: { id: string; data: string }) => void
 type ExitCallback = (payload: { id: string; code: number }) => void
 
+export const SSH_SESSION_EXPIRED_ERROR = 'SSH_SESSION_EXPIRED'
+
+export function isSshPtyNotFoundError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err)
+  return /PTY ".+" not found/i.test(message)
+}
+
 /**
  * Remote PTY provider that proxies all operations through the relay
  * via the JSON-RPC multiplexer. Implements the same IPtyProvider interface
@@ -87,13 +94,15 @@ export class SshPtyProvider implements IPtyProvider {
           ...(attachResult.replay ? { replay: attachResult.replay } : {})
         }
       } catch (err) {
-        // Why: pty.attach fails when the relay grace window has elapsed. Fall
-        // through to pty.spawn so the user gets a fresh shell; sessionExpired
-        // lets the renderer show a brief "Session expired" message.
-        console.warn(
-          `[ssh-pty] pty.attach FAILED for ${opts.sessionId}, falling back to fresh spawn:`,
-          err
-        )
+        // Why: pty.attach fails when the relay grace window has elapsed.
+        // Do not silently replace the saved tab with a fresh shell; the
+        // renderer should show an expired-session state so users know the
+        // original remote process is gone.
+        console.warn(`[ssh-pty] pty.attach FAILED for ${opts.sessionId}:`, err)
+        if (isSshPtyNotFoundError(err)) {
+          throw new Error(`${SSH_SESSION_EXPIRED_ERROR}: ${opts.sessionId}`)
+        }
+        throw err
       }
     }
 

--- a/src/main/ssh/ssh-relay-session-terminal-error.test.ts
+++ b/src/main/ssh/ssh-relay-session-terminal-error.test.ts
@@ -25,6 +25,8 @@ vi.mock('./ssh-channel-multiplexer', () => {
 })
 
 vi.mock('../providers/ssh-pty-provider', () => ({
+  isSshPtyNotFoundError: (err: unknown) =>
+    (err instanceof Error ? err.message : String(err)).includes('not found'),
   SshPtyProvider: class MockSshPtyProvider {
     onData = vi.fn().mockReturnValue(() => {})
     onReplay = vi.fn().mockReturnValue(() => {})
@@ -54,7 +56,8 @@ vi.mock('../ipc/pty', () => ({
   getPtyIdsForConnection: vi.fn().mockReturnValue([]),
   clearPtyOwnershipForConnection: vi.fn(),
   clearProviderPtyState: vi.fn(),
-  deletePtyOwnership: vi.fn()
+  deletePtyOwnership: vi.fn(),
+  setPtyOwnership: vi.fn()
 }))
 
 vi.mock('../providers/ssh-filesystem-dispatch', () => ({
@@ -78,7 +81,10 @@ function createMockDeps(): {
 } {
   const mockConn = {} as SshConnection
   const mockStore = {
-    getRepos: vi.fn().mockReturnValue([])
+    getRepos: vi.fn().mockReturnValue([]),
+    getSshRemotePtyLeases: vi.fn().mockReturnValue([]),
+    markSshRemotePtyLease: vi.fn(),
+    markSshRemotePtyLeases: vi.fn()
   } as unknown as Store
   const mockPortForward = {
     removeAllForwards: vi.fn()
@@ -159,5 +165,6 @@ describe('SshRelaySession terminal relay error (RelayVersionMismatchError)', () 
     await session.reconnect(mockConn)
     expect(onTerminal).toHaveBeenCalledTimes(1)
     expect(onTerminal).toHaveBeenCalledWith('target-1', mismatchErr)
+    expect(session.getState()).toBe('idle')
   })
 })

--- a/src/main/ssh/ssh-relay-session.test.ts
+++ b/src/main/ssh/ssh-relay-session.test.ts
@@ -1,3 +1,6 @@
+/* eslint-disable max-lines -- Why: relay session tests need one shared mocked
+provider/multiplexer harness to cover establish, reconnect, detach, and dispose
+state transitions without duplicating brittle setup. */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { SshRelaySession } from './ssh-relay-session'
 import type { SshConnection } from './ssh-connection'
@@ -22,6 +25,8 @@ vi.mock('./ssh-channel-multiplexer', () => {
 })
 
 vi.mock('../providers/ssh-pty-provider', () => ({
+  isSshPtyNotFoundError: (err: unknown) =>
+    (err instanceof Error ? err.message : String(err)).includes('not found'),
   SshPtyProvider: class MockSshPtyProvider {
     onData = vi.fn().mockReturnValue(() => {})
     onReplay = vi.fn().mockReturnValue(() => {})
@@ -51,7 +56,8 @@ vi.mock('../ipc/pty', () => ({
   getPtyIdsForConnection: vi.fn().mockReturnValue([]),
   clearPtyOwnershipForConnection: vi.fn(),
   clearProviderPtyState: vi.fn(),
-  deletePtyOwnership: vi.fn()
+  deletePtyOwnership: vi.fn(),
+  setPtyOwnership: vi.fn()
 }))
 
 vi.mock('../providers/ssh-filesystem-dispatch', () => ({
@@ -71,7 +77,8 @@ const {
   unregisterSshPtyProvider,
   getPtyIdsForConnection,
   clearProviderPtyState,
-  deletePtyOwnership
+  deletePtyOwnership,
+  setPtyOwnership
 } = await import('../ipc/pty')
 const { registerSshFilesystemProvider, unregisterSshFilesystemProvider } =
   await import('../providers/ssh-filesystem-dispatch')
@@ -81,7 +88,10 @@ const { registerSshGitProvider, unregisterSshGitProvider } =
 function createMockDeps() {
   const mockConn = {} as SshConnection
   const mockStore = {
-    getRepos: vi.fn().mockReturnValue([])
+    getRepos: vi.fn().mockReturnValue([]),
+    getSshRemotePtyLeases: vi.fn().mockReturnValue([]),
+    markSshRemotePtyLease: vi.fn(),
+    markSshRemotePtyLeases: vi.fn()
   } as unknown as Store
   const mockPortForward = {
     removeAllForwards: vi.fn()
@@ -110,6 +120,7 @@ describe('SshRelaySession', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockDeploySuccess()
+    vi.mocked(getPtyIdsForConnection).mockReturnValue([])
   })
 
   it('starts in idle state', () => {
@@ -193,6 +204,113 @@ describe('SshRelaySession', () => {
     expect(mockAttach).toHaveBeenCalledWith('pty-2')
   })
 
+  it('establish re-attaches owned PTYs after explicit disconnect', async () => {
+    const { mockConn, mockStore, mockPortForward, getMainWindow } = createMockDeps()
+    const { getSshPtyProvider } = await import('../ipc/pty')
+    const mockAttach = vi.fn().mockResolvedValue(undefined)
+    vi.mocked(getSshPtyProvider).mockReturnValue({
+      attach: mockAttach,
+      dispose: vi.fn()
+    } as unknown as ReturnType<typeof getSshPtyProvider>)
+    vi.mocked(getPtyIdsForConnection).mockReturnValue(['pty-1'])
+
+    const session = new SshRelaySession('target-1', getMainWindow, mockStore, mockPortForward)
+
+    await session.establish(mockConn)
+
+    expect(mockAttach).toHaveBeenCalledWith('pty-1')
+    expect(setPtyOwnership).toHaveBeenCalledWith('pty-1', 'target-1')
+    expect(mockStore.markSshRemotePtyLease).toHaveBeenCalledWith('target-1', 'pty-1', 'attached')
+  })
+
+  it('establish re-attaches durable leases after app restart', async () => {
+    const { mockConn, mockStore, mockPortForward, getMainWindow } = createMockDeps()
+    const { getSshPtyProvider } = await import('../ipc/pty')
+    const mockAttach = vi.fn().mockResolvedValue(undefined)
+    vi.mocked(getSshPtyProvider).mockReturnValue({
+      attach: mockAttach,
+      dispose: vi.fn()
+    } as unknown as ReturnType<typeof getSshPtyProvider>)
+    vi.mocked(getPtyIdsForConnection).mockReturnValue([])
+    vi.mocked(mockStore.getSshRemotePtyLeases).mockReturnValue([
+      { targetId: 'target-1', ptyId: 'pty-live', state: 'detached' },
+      { targetId: 'target-1', ptyId: 'pty-expired', state: 'expired' }
+    ] as ReturnType<typeof mockStore.getSshRemotePtyLeases>)
+
+    const session = new SshRelaySession('target-1', getMainWindow, mockStore, mockPortForward)
+
+    await session.establish(mockConn)
+
+    expect(mockAttach).toHaveBeenCalledWith('pty-live')
+    expect(mockAttach).not.toHaveBeenCalledWith('pty-expired')
+    expect(setPtyOwnership).toHaveBeenCalledWith('pty-live', 'target-1')
+    expect(mockStore.markSshRemotePtyLease).toHaveBeenCalledWith('target-1', 'pty-live', 'attached')
+  })
+
+  it('rejects establish if detach wins while reattach is in flight', async () => {
+    const { mockConn, mockStore, mockPortForward, getMainWindow } = createMockDeps()
+    const { getSshPtyProvider } = await import('../ipc/pty')
+    let resolveAttach!: () => void
+    const mockAttach = vi.fn().mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveAttach = resolve
+      })
+    )
+    vi.mocked(getSshPtyProvider).mockReturnValue({
+      attach: mockAttach,
+      dispose: vi.fn()
+    } as unknown as ReturnType<typeof getSshPtyProvider>)
+    vi.mocked(getPtyIdsForConnection).mockReturnValue(['pty-1'])
+
+    const session = new SshRelaySession('target-1', getMainWindow, mockStore, mockPortForward)
+    const establish = session.establish(mockConn)
+    await vi.waitFor(() => expect(mockAttach).toHaveBeenCalledWith('pty-1'))
+    session.detach()
+    resolveAttach()
+
+    await expect(establish).rejects.toThrow('Session disposed during establish')
+    expect(setPtyOwnership).not.toHaveBeenCalledWith('pty-1', 'target-1')
+    expect(mockStore.markSshRemotePtyLease).not.toHaveBeenCalledWith(
+      'target-1',
+      'pty-1',
+      'attached'
+    )
+  })
+
+  it('does not mark PTYs attached if detach wins while reattach is in flight', async () => {
+    const { mockConn, mockStore, mockPortForward, getMainWindow } = createMockDeps()
+    const session = new SshRelaySession('target-1', getMainWindow, mockStore, mockPortForward)
+    await session.establish(mockConn)
+    vi.clearAllMocks()
+    mockDeploySuccess()
+
+    const { getSshPtyProvider } = await import('../ipc/pty')
+    let resolveAttach!: () => void
+    const mockAttach = vi.fn().mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveAttach = resolve
+      })
+    )
+    vi.mocked(getSshPtyProvider).mockReturnValue({
+      attach: mockAttach,
+      dispose: vi.fn()
+    } as unknown as ReturnType<typeof getSshPtyProvider>)
+    vi.mocked(getPtyIdsForConnection).mockReturnValue(['pty-1'])
+
+    const reconnect = session.reconnect(mockConn)
+    await vi.waitFor(() => expect(mockAttach).toHaveBeenCalledWith('pty-1'))
+    session.detach()
+    resolveAttach()
+    await reconnect
+
+    expect(setPtyOwnership).not.toHaveBeenCalledWith('pty-1', 'target-1')
+    expect(mockStore.markSshRemotePtyLease).not.toHaveBeenCalledWith(
+      'target-1',
+      'pty-1',
+      'attached'
+    )
+  })
+
   it('invalidates and broadcasts remote PTYs that cannot reattach after relay reconnect', async () => {
     const { mockConn, mockStore, mockPortForward, getMainWindow, mockWindow } = createMockDeps()
     const session = new SshRelaySession('target-1', getMainWindow, mockStore, mockPortForward)
@@ -203,7 +321,7 @@ describe('SshRelaySession', () => {
     const { getSshPtyProvider } = await import('../ipc/pty')
     const mockAttach = vi
       .fn()
-      .mockRejectedValueOnce(new Error('missing pty'))
+      .mockRejectedValueOnce(new Error('PTY "pty-stale" not found'))
       .mockResolvedValueOnce(undefined)
     vi.mocked(getSshPtyProvider).mockReturnValue({
       attach: mockAttach,
@@ -221,6 +339,34 @@ describe('SshRelaySession', () => {
       id: 'pty-stale',
       code: -1
     })
+  })
+
+  it('routes transient reattach failures through relay-lost retry handling', async () => {
+    const { mockConn, mockStore, mockPortForward, getMainWindow } = createMockDeps()
+    const session = new SshRelaySession('target-1', getMainWindow, mockStore, mockPortForward)
+    const onRelayLost = vi.fn()
+    session.setOnRelayLost(onRelayLost)
+    await session.establish(mockConn)
+    vi.clearAllMocks()
+    mockDeploySuccess()
+
+    const { getSshPtyProvider } = await import('../ipc/pty')
+    const mockAttach = vi.fn().mockRejectedValue(new Error('Multiplexer disposed'))
+    vi.mocked(getSshPtyProvider).mockReturnValue({
+      attach: mockAttach,
+      dispose: vi.fn()
+    } as unknown as ReturnType<typeof getSshPtyProvider>)
+    vi.mocked(getPtyIdsForConnection).mockReturnValue(['pty-live'])
+
+    await session.reconnect(mockConn)
+
+    expect(mockAttach).toHaveBeenCalledWith('pty-live')
+    expect(onRelayLost).toHaveBeenCalledWith('target-1')
+    expect(mockStore.markSshRemotePtyLease).not.toHaveBeenCalledWith(
+      'target-1',
+      'pty-live',
+      'expired'
+    )
   })
 
   it('dispose transitions to disposed and unregisters providers', async () => {

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -13,7 +13,7 @@ import { deployAndLaunchRelay } from './ssh-relay-deploy'
 import { isRelayVersionMismatchError } from './ssh-relay-version-mismatch-error'
 import type { RelayVersionMismatchError } from './ssh-relay-version-mismatch-error'
 import { SshChannelMultiplexer } from './ssh-channel-multiplexer'
-import { SshPtyProvider } from '../providers/ssh-pty-provider'
+import { SshPtyProvider, isSshPtyNotFoundError } from '../providers/ssh-pty-provider'
 import { SshFilesystemProvider } from '../providers/ssh-filesystem-provider'
 import { SshGitProvider } from '../providers/ssh-git-provider'
 import {
@@ -23,7 +23,8 @@ import {
   getPtyIdsForConnection,
   clearPtyOwnershipForConnection,
   clearProviderPtyState,
-  deletePtyOwnership
+  deletePtyOwnership,
+  setPtyOwnership
 } from '../ipc/pty'
 import {
   registerSshFilesystemProvider,
@@ -135,6 +136,7 @@ export class SshRelaySession {
 
       const mux = new SshChannelMultiplexer(transport)
       this.mux = mux
+      const ownsAttempt = (): boolean => this.mux === mux && !this.isDisposed()
 
       // Why: verify the relay is actually responsive before registering
       // providers. In --connect mode the bridge may have already closed
@@ -156,7 +158,15 @@ export class SshRelaySession {
       }
 
       if (this.isDisposed()) {
-        this.teardownProviders('shutdown')
+        this.teardownProviders('connection_lost')
+        throw new Error('Session disposed during establish')
+      }
+
+      // Why: explicit disconnect keeps PTY ownership so a later manual connect
+      // must reattach those remote PTYs through the fresh relay connection.
+      await this.reattachKnownPtys(ownsAttempt)
+
+      if (!ownsAttempt()) {
         throw new Error('Session disposed during establish')
       }
 
@@ -170,7 +180,7 @@ export class SshRelaySession {
       // registered. teardownProviders cleans up everything so a subsequent
       // establish() call starts from a clean slate.
       if (!this.isDisposed()) {
-        this.teardownProviders('shutdown')
+        this.teardownProviders('connection_lost')
         this._state = 'idle'
       }
       // Why: a wire-handshake mismatch on the FIRST connect is also terminal
@@ -278,34 +288,7 @@ export class SshRelaySession {
         return
       }
 
-      // Re-attach to any PTYs that were alive before the disconnect.
-      const ptyIds = getPtyIdsForConnection(this.targetId)
-      const ptyProvider = getSshPtyProvider(this.targetId) as SshPtyProvider | undefined
-      if (ptyProvider) {
-        for (const ptyId of ptyIds) {
-          if (!ownsAttempt()) {
-            return
-          }
-          try {
-            await ptyProvider.attach(ptyId)
-          } catch (err) {
-            console.warn(
-              `[ssh-relay-session] Dropping stale PTY ${ptyId} for ${this.targetId} after relay reattach failed: ${
-                err instanceof Error ? err.message : String(err)
-              }`
-            )
-            clearProviderPtyState(ptyId)
-            deletePtyOwnership(ptyId)
-            // Why: if the new relay cannot reattach this id, the remote
-            // backing process is gone. Tell the renderer so it clears stale
-            // pane bindings instead of keeping a cursor-only terminal.
-            const win = this.getMainWindow()
-            if (win && !win.isDestroyed()) {
-              win.webContents.send('pty:exit', { id: ptyId, code: -1 })
-            }
-          }
-        }
-      }
+      await this.reattachKnownPtys(ownsAttempt)
 
       if (!ownsAttempt()) {
         return
@@ -330,6 +313,9 @@ export class SshRelaySession {
         console.warn(
           `[ssh-relay-session] Terminal relay version mismatch for ${this.targetId}: ${err.message}`
         )
+        if (this.abortController === abortController && !this.isDisposed()) {
+          this._state = 'idle'
+        }
         this._onTerminalRelayError?.(this.targetId, err)
         return
       }
@@ -339,6 +325,13 @@ export class SshRelaySession {
       console.warn(
         `[ssh-relay-session] Failed to re-establish relay for ${this.targetId}: ${err instanceof Error ? err.message : String(err)}`
       )
+      if (this.abortController === abortController && !this.isDisposed()) {
+        // Why: non-not-found PTY attach failures are usually transient mux or
+        // relay transport failures. Treat them like relay loss so ssh.ts's
+        // bounded backoff retries instead of stranding the session forever in
+        // reconnecting.
+        this._onRelayLost?.(this.targetId)
+      }
     } finally {
       if (this.abortController === abortController) {
         this.abortController = null
@@ -357,6 +350,22 @@ export class SshRelaySession {
     void this.portForwardManager.removeAllForwards(this.targetId)
     this.broadcastEmptyLists()
     this.teardownProviders('shutdown')
+    this.store.markSshRemotePtyLeases(this.targetId, 'terminated')
+    this._state = 'disposed'
+  }
+
+  detach(): void {
+    if (this._state === 'disposed') {
+      return
+    }
+    this.abortController?.abort()
+    this.stopPortScanning()
+    this.broadcastEmptyLists()
+    // Why: app/window disconnect is non-destructive for remote PTYs. The relay
+    // owns the grace timer, so Orca must unregister local providers without
+    // clearing PTY ownership needed for reattach.
+    this.teardownProviders('connection_lost')
+    this.store.markSshRemotePtyLeases(this.targetId, 'detached')
     this._state = 'disposed'
   }
 
@@ -519,11 +528,58 @@ export class SshRelaySession {
     ptyProvider.onExit((payload) => {
       clearProviderPtyState(payload.id)
       deletePtyOwnership(payload.id)
+      this.store.markSshRemotePtyLease(this.targetId, payload.id, 'terminated')
       this.runtime?.onPtyExit(payload.id, payload.code)
       const win = getWin()
       if (win && !win.isDestroyed()) {
         win.webContents.send('pty:exit', payload)
       }
     })
+  }
+
+  private async reattachKnownPtys(shouldContinue: () => boolean): Promise<void> {
+    const leasedPtyIds = this.store
+      .getSshRemotePtyLeases(this.targetId)
+      .filter((lease) => lease.state !== 'terminated' && lease.state !== 'expired')
+      .map((lease) => lease.ptyId)
+    // Why: after app restart, ptyOwnership is empty but durable SSH leases
+    // still describe remote PTYs that survived in the relay grace window.
+    const ptyIds = Array.from(new Set([...getPtyIdsForConnection(this.targetId), ...leasedPtyIds]))
+    const ptyProvider = getSshPtyProvider(this.targetId) as SshPtyProvider | undefined
+    if (!ptyProvider) {
+      return
+    }
+    for (const ptyId of ptyIds) {
+      if (!shouldContinue()) {
+        return
+      }
+      try {
+        await ptyProvider.attach(ptyId)
+        if (!shouldContinue()) {
+          return
+        }
+        setPtyOwnership(ptyId, this.targetId)
+        this.store.markSshRemotePtyLease(this.targetId, ptyId, 'attached')
+      } catch (err) {
+        if (!isSshPtyNotFoundError(err)) {
+          throw err
+        }
+        console.warn(
+          `[ssh-relay-session] Dropping stale PTY ${ptyId} for ${this.targetId} after relay reattach failed: ${
+            err instanceof Error ? err.message : String(err)
+          }`
+        )
+        clearProviderPtyState(ptyId)
+        deletePtyOwnership(ptyId)
+        this.store.markSshRemotePtyLease(this.targetId, ptyId, 'expired')
+        // Why: if the new relay cannot reattach this id, the remote backing
+        // process is gone. Tell the renderer so it clears stale pane bindings
+        // instead of keeping a cursor-only terminal.
+        const win = this.getMainWindow()
+        if (win && !win.isDestroyed()) {
+          win.webContents.send('pty:exit', { id: ptyId, code: -1 })
+        }
+      }
+    }
   }
 }

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1220,6 +1220,7 @@ export type PreloadApi = {
     importConfig: () => Promise<SshTarget[]>
     connect: (args: { targetId: string }) => Promise<SshConnectionState | null>
     disconnect: (args: { targetId: string }) => Promise<void>
+    terminateSessions: (args: { targetId: string }) => Promise<void>
     getState: (args: { targetId: string }) => Promise<SshConnectionState | null>
     needsPassphrasePrompt: (args: { targetId: string }) => Promise<boolean>
     testConnection: (args: {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2243,6 +2243,9 @@ const api = {
     disconnect: (args: { targetId: string }): Promise<void> =>
       ipcRenderer.invoke('ssh:disconnect', args),
 
+    terminateSessions: (args: { targetId: string }): Promise<void> =>
+      ipcRenderer.invoke('ssh:terminateSessions', args),
+
     getState: (args: { targetId: string }): Promise<SshConnectionState | null> =>
       ipcRenderer.invoke('ssh:getState', args),
 

--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -189,8 +189,8 @@ function Terminal(): React.JSX.Element | null {
   // new click on the next dialog still works.
   const isClosingRef = useRef(false)
 
-  // Window close confirmation dialog — shown when the user tries to close the
-  // window (X button, Cmd+Q) while terminals with running processes exist.
+  // Window close confirmation dialog — shown for local terminals with running
+  // child processes. SSH terminals detach/persist through the relay lifecycle.
   const [windowCloseDialogOpen, setWindowCloseDialogOpen] = useState(false)
 
   // Why: when the main process requests a close while editor tabs are dirty, we
@@ -204,26 +204,31 @@ function Terminal(): React.JSX.Element | null {
     // a dirty-tab preventDefault() does not fire during the initial quit IPC
     // (that path can emit will-prevent-unload and clear isQuitting in main).
     window.dispatchEvent(new Event('beforeunload'))
-
-    if (isQuitting) {
-      window.api.ui.confirmWindowClose()
-      return
-    }
-    const state = useAppStore.getState()
-    const allPtyIds = Object.values(state.ptyIdsByTabId).flat()
-    if (allPtyIds.length === 0) {
-      window.api.ui.confirmWindowClose()
-      return
-    }
-    void Promise.all(allPtyIds.map((id) => window.api.pty.hasChildProcesses(id))).then(
-      (results) => {
-        if (results.some(Boolean)) {
-          setWindowCloseDialogOpen(true)
-        } else {
-          window.api.ui.confirmWindowClose()
+    if (!isQuitting) {
+      const state = useAppStore.getState()
+      const localPtyIds = Object.entries(state.tabsByWorktree).flatMap(
+        ([worktreeId, worktreeTabs]) => {
+          const connectionId = getConnectionId(worktreeId)
+          if (connectionId !== null) {
+            return []
+          }
+          return worktreeTabs.flatMap((tab) => state.ptyIdsByTabId[tab.id] ?? [])
         }
+      )
+      if (localPtyIds.length > 0) {
+        void Promise.all(localPtyIds.map((id) => window.api.pty.hasChildProcesses(id))).then(
+          (results) => {
+            if (results.some(Boolean)) {
+              setWindowCloseDialogOpen(true)
+            } else {
+              window.api.ui.confirmWindowClose()
+            }
+          }
+        )
+        return
       }
-    )
+    }
+    window.api.ui.confirmWindowClose()
   }, [])
 
   const waitForFileClosed = useCallback((fileId: string, timeoutMs: number): Promise<boolean> => {
@@ -1059,8 +1064,9 @@ function Terminal(): React.JSX.Element | null {
     return () => window.removeEventListener('beforeunload', handler)
   }, [])
 
-  // Listen for main-process window close requests. When any terminal has a
-  // child process running (not just an idle shell), show a confirmation dialog.
+  // Listen for main-process window close requests. Terminal sessions are
+  // detached by the daemon/SSH lifecycle; only dirty editor files should block
+  // close here. Explicit destructive terminal actions keep their own confirms.
   useEffect(() => {
     return window.api.ui.onWindowCloseRequested(({ isQuitting }) => {
       if (isUpdaterQuitAndInstallInProgress()) {
@@ -1084,36 +1090,9 @@ function Terminal(): React.JSX.Element | null {
         return
       }
 
-      // Why: capture terminal scrollback buffers while TerminalPane components
-      // are still mounted. Dispatching beforeunload triggers the App.tsx
-      // captureAndFlush handler which serializes each pane's xterm buffer
-      // and writes the session to disk via synchronous IPC.
-      window.dispatchEvent(new Event('beforeunload'))
-      // Why: during a quit (Cmd+Q), PTYs are still alive (cleanup is deferred
-      // to will-quit so buffers can be captured first). Skip the child-process
-      // confirmation dialog and proceed directly — the user's intent to quit
-      // is unambiguous.
-      if (isQuitting) {
-        window.api.ui.confirmWindowClose()
-        return
-      }
-      const state = useAppStore.getState()
-      const allPtyIds = Object.values(state.ptyIdsByTabId).flat()
-      if (allPtyIds.length === 0) {
-        window.api.ui.confirmWindowClose()
-        return
-      }
-      void Promise.all(allPtyIds.map((id) => window.api.pty.hasChildProcesses(id))).then(
-        (results) => {
-          if (results.some(Boolean)) {
-            setWindowCloseDialogOpen(true)
-          } else {
-            window.api.ui.confirmWindowClose()
-          }
-        }
-      )
+      proceedToNativeWindowClose(isQuitting)
     })
-  }, [queueEditorCloseRequests])
+  }, [proceedToNativeWindowClose, queueEditorCloseRequests])
 
   // Why: browser page state can disappear through store-only paths (CLI tab
   // close, worktree deletion). The store cannot call destroyPersistentWebview
@@ -1441,8 +1420,7 @@ function Terminal(): React.JSX.Element | null {
         </DialogContent>
       </Dialog>
 
-      {/* Window close confirmation dialog — shown when the window is being
-          closed and terminals are still running. */}
+      {/* Window close confirmation dialog */}
       <Dialog
         open={windowCloseDialogOpen}
         onOpenChange={(open) => {
@@ -1455,8 +1433,7 @@ function Terminal(): React.JSX.Element | null {
           <DialogHeader>
             <DialogTitle className="text-sm">Close Window?</DialogTitle>
             <DialogDescription className="text-xs">
-              There are terminals with running processes. If you close the window, those processes
-              will be killed.
+              There are local terminals with running processes. Close the window anyway?
             </DialogDescription>
           </DialogHeader>
           <DialogFooter className="gap-2">

--- a/src/renderer/src/components/settings/SshPane.tsx
+++ b/src/renderer/src/components/settings/SshPane.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react'
 import { toast } from 'sonner'
 import { Plus, Upload } from 'lucide-react'
 import type { SshTarget } from '../../../../shared/ssh-types'
+import { SSH_TERMINATE_RECONNECT_REQUIRED } from '../../../../shared/constants'
 import { useAppStore } from '@/store'
 import { Button } from '../ui/button'
 import {
@@ -52,6 +53,9 @@ export function SshPane(_props: SshPaneProps): React.JSX.Element {
   const [form, setForm] = useState<EditingTarget>(EMPTY_FORM)
   const [testingIds, setTestingIds] = useState<Set<string>>(new Set())
   const [pendingRemove, setPendingRemove] = useState<{ id: string; label: string } | null>(null)
+  const [pendingTerminate, setPendingTerminate] = useState<{ id: string; label: string } | null>(
+    null
+  )
 
   const setSshTargetLabels = useAppStore((s) => s.setSshTargetLabels)
 
@@ -130,15 +134,26 @@ export function SshPane(_props: SshPaneProps): React.JSX.Element {
     }
   }
 
+  const terminateSessionsWithReconnect = async (targetId: string): Promise<void> => {
+    try {
+      await window.api.ssh.terminateSessions({ targetId })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      if (!message.includes(SSH_TERMINATE_RECONNECT_REQUIRED)) {
+        throw err
+      }
+      // Why: disconnect is now non-destructive, so preserved remote PTYs may
+      // require a fresh relay attachment before they can be explicitly killed.
+      await window.api.ssh.connect({ targetId })
+      await window.api.ssh.terminateSessions({ targetId })
+    }
+  }
+
   const handleRemove = async (id: string): Promise<void> => {
     try {
-      // Why: disconnect any non-disconnected connection, including transitional
-      // states (connecting, reconnecting, deploying-relay). Leaving these alive
-      // would orphan SSH connections with providers registered for a removed target.
-      const state = sshConnectionStates.get(id)
-      if (state && state.status !== 'disconnected') {
-        await window.api.ssh.disconnect({ targetId: id })
-      }
+      // Why: removing a target is destructive even after non-destructive
+      // disconnect, when remote PTYs can still be alive in the grace window.
+      await terminateSessionsWithReconnect(id)
       await window.api.ssh.removeTarget({ id })
       toast.success('Target removed')
       await loadTargets()
@@ -176,6 +191,15 @@ export function SshPane(_props: SshPaneProps): React.JSX.Element {
       await window.api.ssh.disconnect({ targetId })
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Disconnect failed')
+    }
+  }
+
+  const handleTerminateSessions = async (targetId: string): Promise<void> => {
+    try {
+      await terminateSessionsWithReconnect(targetId)
+      toast.success('Remote sessions terminated')
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to terminate sessions')
     }
   }
 
@@ -272,6 +296,7 @@ export function SshPane(_props: SshPaneProps): React.JSX.Element {
               testing={testingIds.has(target.id)}
               onConnect={(id) => void handleConnect(id)}
               onDisconnect={(id) => void handleDisconnect(id)}
+              onTerminateSessions={(id) => setPendingTerminate({ id, label: target.label })}
               onTest={(id) => void handleTest(id)}
               onEdit={handleEdit}
               onRemove={(id) => setPendingRemove({ id, label: target.label })}
@@ -304,7 +329,7 @@ export function SshPane(_props: SshPaneProps): React.JSX.Element {
           <DialogHeader>
             <DialogTitle className="text-sm">Remove SSH Target</DialogTitle>
             <DialogDescription className="text-xs">
-              This will remove the target and disconnect any active sessions.
+              This will remove the target and terminate any active remote sessions.
             </DialogDescription>
           </DialogHeader>
 
@@ -328,6 +353,48 @@ export function SshPane(_props: SshPaneProps): React.JSX.Element {
               }}
             >
               Remove
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Terminate confirmation dialog */}
+      <Dialog
+        open={!!pendingTerminate}
+        onOpenChange={(open) => {
+          if (!open) {
+            setPendingTerminate(null)
+          }
+        }}
+      >
+        <DialogContent className="max-w-sm sm:max-w-sm" showCloseButton={false}>
+          <DialogHeader>
+            <DialogTitle className="text-sm">Terminate Remote Sessions</DialogTitle>
+            <DialogDescription className="text-xs">
+              This will kill active remote terminals for this SSH target.
+            </DialogDescription>
+          </DialogHeader>
+
+          {pendingTerminate ? (
+            <div className="rounded-md border border-border/70 bg-muted/35 px-3 py-2 text-xs">
+              <div className="break-all text-muted-foreground">{pendingTerminate.label}</div>
+            </div>
+          ) : null}
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setPendingTerminate(null)}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => {
+                if (pendingTerminate) {
+                  void handleTerminateSessions(pendingTerminate.id)
+                  setPendingTerminate(null)
+                }
+              }}
+            >
+              Terminate
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/renderer/src/components/settings/SshTargetCard.tsx
+++ b/src/renderer/src/components/settings/SshTargetCard.tsx
@@ -49,6 +49,7 @@ type SshTargetCardProps = {
   testing: boolean
   onConnect: (targetId: string) => void
   onDisconnect: (targetId: string) => void
+  onTerminateSessions: (targetId: string) => void
   onTest: (targetId: string) => void
   onEdit: (target: SshTarget) => void
   onRemove: (targetId: string) => void
@@ -60,12 +61,15 @@ export function SshTargetCard({
   testing,
   onConnect,
   onDisconnect,
+  onTerminateSessions,
   onTest,
   onEdit,
   onRemove
 }: SshTargetCardProps): React.JSX.Element {
   const status: SshConnectionStatus = state?.status ?? 'disconnected'
-  const [actionInFlight, setActionInFlight] = useState<'connect' | 'disconnect' | null>(null)
+  const [actionInFlight, setActionInFlight] = useState<
+    'connect' | 'disconnect' | 'terminate' | null
+  >(null)
 
   const handleConnect = (): void => {
     if (actionInFlight) {
@@ -81,6 +85,14 @@ export function SshTargetCard({
     }
     setActionInFlight('disconnect')
     Promise.resolve(onDisconnect(target.id)).finally(() => setActionInFlight(null))
+  }
+
+  const handleTerminateSessions = (): void => {
+    if (actionInFlight) {
+      return
+    }
+    setActionInFlight('terminate')
+    Promise.resolve(onTerminateSessions(target.id)).finally(() => setActionInFlight(null))
   }
 
   return (
@@ -104,16 +116,32 @@ export function SshTargetCard({
 
       <div className="flex shrink-0 items-center gap-1">
         {status === 'connected' ? (
-          <Button
-            variant="ghost"
-            size="xs"
-            onClick={handleDisconnect}
-            className="gap-1.5"
-            disabled={actionInFlight !== null}
-          >
-            <ServerOff className="size-3" />
-            Disconnect
-          </Button>
+          <>
+            <Button
+              variant="ghost"
+              size="xs"
+              onClick={handleDisconnect}
+              className="gap-1.5"
+              disabled={actionInFlight !== null}
+            >
+              <ServerOff className="size-3" />
+              Disconnect
+            </Button>
+            <Button
+              variant="ghost"
+              size="xs"
+              onClick={handleTerminateSessions}
+              className="gap-1.5 text-muted-foreground hover:text-red-400"
+              disabled={actionInFlight !== null}
+            >
+              {actionInFlight === 'terminate' ? (
+                <Loader2 className="size-3 animate-spin" />
+              ) : (
+                <Trash2 className="size-3" />
+              )}
+              Terminate
+            </Button>
+          </>
         ) : isConnecting(status) ? (
           <Button variant="ghost" size="xs" disabled className="gap-1.5">
             <Loader2 className="size-3 animate-spin" />
@@ -148,6 +176,20 @@ export function SshTargetCard({
                 <MonitorSmartphone className="size-3" />
               )}
               Test
+            </Button>
+            <Button
+              variant="ghost"
+              size="xs"
+              onClick={handleTerminateSessions}
+              className="gap-1.5 text-muted-foreground hover:text-red-400"
+              disabled={actionInFlight !== null}
+            >
+              {actionInFlight === 'terminate' ? (
+                <Loader2 className="size-3 animate-spin" />
+              ) : (
+                <Trash2 className="size-3" />
+              )}
+              Terminate
             </Button>
           </>
         )}

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -60,6 +60,7 @@ const shouldSeedCacheTimerOnInitialTitle = vi.fn(() => false)
 let mockStoreState: StoreState
 let transportFactoryQueue: MockTransport[] = []
 let createdTransportOptions: Record<string, unknown>[] = []
+let storeSubscribers: ((state: StoreState) => void)[] = []
 
 vi.mock('@/runtime/sync-runtime-graph', () => ({
   scheduleRuntimeGraphSync
@@ -67,9 +68,21 @@ vi.mock('@/runtime/sync-runtime-graph', () => ({
 
 vi.mock('@/store', () => ({
   useAppStore: {
-    getState: () => mockStoreState
+    getState: () => mockStoreState,
+    subscribe: (listener: (state: StoreState) => void) => {
+      storeSubscribers.push(listener)
+      return () => {
+        storeSubscribers = storeSubscribers.filter((candidate) => candidate !== listener)
+      }
+    }
   }
 }))
+
+function notifyStoreSubscribers(): void {
+  for (const listener of storeSubscribers.slice()) {
+    listener(mockStoreState)
+  }
+}
 
 vi.mock('@/lib/agent-status', async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>()
@@ -217,6 +230,7 @@ describe('connectPanePty', () => {
     vi.clearAllMocks()
     transportFactoryQueue = []
     createdTransportOptions = []
+    storeSubscribers = []
     mockStoreState = {
       tabsByWorktree: {
         'wt-1': [{ id: 'tab-1', ptyId: 'tab-pty' }]
@@ -244,7 +258,8 @@ describe('connectPanePty', () => {
     ;(globalThis as unknown as { window: unknown }).window = {
       api: {
         ssh: {
-          connect: vi.fn().mockResolvedValue({ status: 'connected' })
+          connect: vi.fn().mockResolvedValue({ status: 'connected' }),
+          needsPassphrasePrompt: vi.fn().mockResolvedValue(false)
         },
         pty: {
           signal: vi.fn(),
@@ -613,6 +628,39 @@ describe('connectPanePty', () => {
     expect(deps.clearTabPtyId).toHaveBeenCalledWith('tab-1', 'stale-pty')
     expect(deps.syncPanePtyLayoutBinding).toHaveBeenCalledWith(2, 'fresh-pty')
     expect(deps.updateTabPtyId).toHaveBeenCalledWith('tab-1', 'fresh-pty')
+  })
+
+  it('shows a terminal error instead of fresh-spawning when a non-deferred SSH reattach reports expired via onError', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    transport.connect.mockImplementation(async (opts: { callbacks?: ConnectCallbacks }) => {
+      opts.callbacks?.onError?.('SSH_SESSION_EXPIRED: restored-session')
+      return undefined
+    })
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: 'restored-session' }] },
+      repos: [{ id: 'repo1', connectionId: 'conn-1' }],
+      sshConnectionStates: new Map([['conn-1', { status: 'connected' }]])
+    } as StoreState
+    const pane = createPane(2)
+    const manager = createManager(2)
+    const deps = createDeps({
+      restoredLeafId: 'pane:2',
+      restoredPtyIdByLeafId: { 'pane:2': 'restored-session' }
+    })
+
+    connectPanePty(pane as never, manager as never, deps as never)
+    await flushAsyncTicks(10)
+
+    expect(deps.onPtyErrorRef.current).toHaveBeenCalledWith(
+      2,
+      'Previous SSH session expired. Start a new terminal to continue.'
+    )
+    expect(transport.connect).toHaveBeenCalledTimes(1)
+    expect(deps.syncPanePtyLayoutBinding).toHaveBeenCalledWith(2, null)
+    expect(deps.clearTabPtyId).toHaveBeenCalledWith('tab-1', 'restored-session')
   })
 
   it('resets focus reporting after daemon snapshot replay without applying the full mode reset', async () => {
@@ -1110,11 +1158,60 @@ describe('connectPanePty', () => {
     expect(api.pty.signal).toHaveBeenCalledWith('leaf-session', 'SIGWINCH')
   })
 
-  it('shows an informational toast instead of a terminal error when an SSH session expired', async () => {
+  it('does not auto-reconnect after a user cancels deferred SSH passphrase auth', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport()
-    transport.connect.mockImplementation(async (opts: { sessionId?: string }) => {
-      return { id: opts.sessionId ?? 'pty-new', sessionExpired: true }
+    transportFactoryQueue.push(transport)
+
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: null }] },
+      repos: [{ id: 'repo1', connectionId: 'conn-1' }],
+      sshConnectionStates: new Map([['conn-1', { status: 'disconnected' }]]),
+      deferredSshReconnectTargets: ['conn-1'],
+      deferredSshSessionIdsByTabId: { 'tab-1': 'saved-session' }
+    }
+
+    const api = (
+      globalThis as unknown as {
+        window: {
+          api: {
+            ssh: {
+              connect: ReturnType<typeof vi.fn>
+              needsPassphrasePrompt: ReturnType<typeof vi.fn>
+            }
+          }
+        }
+      }
+    ).window.api
+    api.ssh.needsPassphrasePrompt.mockResolvedValue(true)
+
+    const pane = createPane(1)
+    const manager = createManager(1)
+    const deps = createDeps()
+
+    connectPanePty(pane as never, manager as never, deps as never)
+    await flushAsyncTicks(3)
+
+    mockStoreState.sshConnectionStates = new Map([['conn-1', { status: 'connecting' }]])
+    notifyStoreSubscribers()
+    mockStoreState.sshConnectionStates = new Map([['conn-1', { status: 'disconnected' }]])
+    notifyStoreSubscribers()
+    await flushAsyncTicks(10)
+
+    expect(api.ssh.connect).not.toHaveBeenCalled()
+    expect(transport.connect).not.toHaveBeenCalled()
+    expect(deps.onPtyErrorRef.current).not.toHaveBeenCalled()
+    expect(mockStoreState.removeDeferredSshSessionId).not.toHaveBeenCalled()
+    expect(mockStoreState.removeDeferredSshReconnectTarget).not.toHaveBeenCalled()
+  })
+
+  it('shows a terminal error instead of fresh-spawning when an SSH session expired', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    transport.connect.mockImplementation(async (opts) => {
+      opts.callbacks?.onError?.('SSH_SESSION_EXPIRED: expired-session')
+      return undefined
     })
     transportFactoryQueue.push(transport)
 
@@ -1136,14 +1233,12 @@ describe('connectPanePty', () => {
     connectPanePty(pane as never, manager as never, deps as never)
     await flushAsyncTicks(20)
 
-    expect(deps.onPtyErrorRef.current).not.toHaveBeenCalledWith(
-      expect.any(Number),
-      expect.stringContaining('Previous session expired')
+    expect(deps.onPtyErrorRef.current).toHaveBeenCalledWith(
+      1,
+      'Previous SSH session expired. Start a new terminal to continue.'
     )
-    expect(toastInfo).toHaveBeenCalledWith('Previous SSH session expired.', {
-      id: 'ssh-session-expired-tab-1',
-      description: 'Started a new shell.'
-    })
+    expect(toastInfo).not.toHaveBeenCalled()
+    expect(transport.connect).toHaveBeenCalledTimes(1)
   })
 
   // Why: the working→idle transition fires an 'agent-task-complete' OS

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -4,7 +4,6 @@ import type { IDisposable } from '@xterm/xterm'
 import { isGeminiTerminalTitle, isClaudeAgent } from '@/lib/agent-status'
 import { scheduleRuntimeGraphSync } from '@/runtime/sync-runtime-graph'
 import { useAppStore } from '@/store'
-import { toast } from 'sonner'
 import type { PtyConnectResult } from './pty-transport'
 import { createIpcPtyTransport } from './pty-transport'
 import { shouldSeedCacheTimerOnInitialTitle } from './cache-timer-seeding'
@@ -29,14 +28,42 @@ import {
 } from '@/lib/pane-manager/pane-terminal-output-scheduler'
 
 const pendingSpawnByPaneKey = new Map<string, Promise<string | null>>()
+const SSH_SESSION_EXPIRED_ERROR = 'SSH_SESSION_EXPIRED'
 
 // Why: when multiple panes/tabs need the same deferred SSH connection,
 // the first one calls ssh.connect() and subsequent ones must wait for it
 // rather than returning early (which would leave them disconnected). This
 // helper either connects or waits for an in-flight connect to finish.
 type SshConnectResult = { connected: true } | { connected: false; error: string }
+type UserInitiatedSshConnectOutcome = 'connected' | 'cancelled' | 'failed'
 
 const sshConnectPromises = new Map<string, Promise<SshConnectResult>>()
+
+function isSshSessionExpiredError(err: unknown): boolean {
+  return (err instanceof Error ? err.message : String(err)).includes(SSH_SESSION_EXPIRED_ERROR)
+}
+
+function formatSshSessionExpiredMessage(): string {
+  return 'Previous SSH session expired. Start a new terminal to continue.'
+}
+
+function sshPromptConnectOutcomeForStatus(
+  status: string | undefined,
+  sawNonDisconnected: boolean
+): UserInitiatedSshConnectOutcome | null {
+  if (status === 'connected') {
+    return 'connected'
+  }
+  if (status === 'auth-failed' || status === 'error' || status === 'reconnection-failed') {
+    return 'failed'
+  }
+  // Why: this only counts after a real connect attempt; the entry-time
+  // disconnected state just means the user still needs to initiate auth.
+  if (sawNonDisconnected && status === 'disconnected') {
+    return 'cancelled'
+  }
+  return null
+}
 
 async function waitForSshConnection(connectionId: string): Promise<SshConnectResult> {
   const state = useAppStore.getState().sshConnectionStates.get(connectionId)
@@ -668,6 +695,14 @@ export function connectPanePty(
         startFreshSpawn()
         return
       }
+      if (connectResult?.sessionExpired) {
+        reportError(formatSshSessionExpiredMessage())
+        deps.syncPanePtyLayoutBinding(pane.id, null)
+        if (staleSessionId) {
+          deps.clearTabPtyId(deps.tabId, staleSessionId)
+        }
+        return
+      }
       bindPanePtyId(pane.id, ptyId, deps.tabId)
       pane.container.dataset.ptyId = ptyId
       deps.syncPanePtyLayoutBinding(pane.id, ptyId)
@@ -730,13 +765,6 @@ export function connectPanePty(
         writeReplayData(POST_REPLAY_MODE_RESET)
         window.api.pty.ackColdRestore(ptyId)
       }
-      if (connectResult?.sessionExpired) {
-        toast.info('Previous SSH session expired.', {
-          id: `ssh-session-expired-${deps.tabId}`,
-          description: 'Started a new shell.'
-        })
-      }
-
       // Why: when a mobile-fit override is active, skip sending desktop dims
       // to the PTY — the PTY is already at phone dimensions and must stay there.
       const reattachPtyId = transport.getPtyId()
@@ -803,7 +831,7 @@ export function connectPanePty(
               // forever if the user cancels or the connect fails —
               // waitForSshConnection below has its own error path that will
               // surface the failure via reportError.
-              await new Promise<void>((resolve) => {
+              const outcome = await new Promise<UserInitiatedSshConnectOutcome>((resolve) => {
                 // Why: 'disconnected' counts as terminal only after we've
                 // observed a non-disconnected status — i.e. the user actually
                 // initiated a connect attempt that returned to 'disconnected'
@@ -814,51 +842,41 @@ export function connectPanePty(
                   useAppStore.getState().sshConnectionStates.get(connectionId)?.status !==
                     'disconnected' &&
                   useAppStore.getState().sshConnectionStates.get(connectionId)?.status !== undefined
-                const isTerminalStatus = (status: string | undefined): boolean => {
-                  if (
-                    status === 'connected' ||
-                    status === 'auth-failed' ||
-                    status === 'error' ||
-                    status === 'reconnection-failed'
-                  ) {
-                    return true
-                  }
-                  // Why: a return to 'disconnected' after a connect attempt
-                  // means the user cancelled or the dialog was dismissed —
-                  // resolve so the gate doesn't hang forever.
-                  return sawNonDisconnected && status === 'disconnected'
-                }
+                let resolvedOutcome: UserInitiatedSshConnectOutcome = 'cancelled'
                 let settled = false
-                const finish = (): void => {
+                const finish = (nextOutcome: UserInitiatedSshConnectOutcome): void => {
                   if (settled) {
                     return
                   }
+                  resolvedOutcome = nextOutcome
                   settled = true
                   unsub()
-                  const idx = waitTeardowns.indexOf(finish)
+                  const idx = waitTeardowns.indexOf(teardown)
                   if (idx !== -1) {
                     waitTeardowns.splice(idx, 1)
                   }
-                  resolve()
+                  resolve(resolvedOutcome)
                 }
+                const teardown = (): void => finish('cancelled')
                 // Why: registering a teardown lets dispose() actively
                 // unsubscribe + resolve if the pane is torn down while the
                 // wait is in flight. Without this the zustand subscriber and
                 // the surrounding async IIFE leak for the rest of the app
                 // session because the callback only checks `disposed` when
                 // it next fires — and it may never fire again.
-                waitTeardowns.push(finish)
+                waitTeardowns.push(teardown)
                 const unsub = useAppStore.subscribe((state) => {
                   if (disposed) {
-                    finish()
+                    finish('cancelled')
                     return
                   }
                   const status = state.sshConnectionStates.get(connectionId)?.status
                   if (status && status !== 'disconnected') {
                     sawNonDisconnected = true
                   }
-                  if (isTerminalStatus(status)) {
-                    finish()
+                  const nextOutcome = sshPromptConnectOutcomeForStatus(status, sawNonDisconnected)
+                  if (nextOutcome) {
+                    finish(nextOutcome)
                   }
                 })
                 // Why: re-read state immediately after subscribing to close the
@@ -866,17 +884,28 @@ export function connectPanePty(
                 // check above and the subscribe registration — otherwise we'd
                 // wait forever for a state change that already happened.
                 if (disposed) {
-                  finish()
+                  finish('cancelled')
                   return
                 }
                 const currentStatus = useAppStore
                   .getState()
                   .sshConnectionStates.get(connectionId)?.status
-                if (isTerminalStatus(currentStatus)) {
-                  finish()
+                const currentOutcome = sshPromptConnectOutcomeForStatus(
+                  currentStatus,
+                  sawNonDisconnected
+                )
+                if (currentOutcome) {
+                  finish(currentOutcome)
                 }
               })
               if (disposed) {
+                return
+              }
+              if (outcome === 'cancelled') {
+                return
+              }
+              if (outcome === 'failed') {
+                reportError('SSH connection failed')
                 return
               }
             }
@@ -912,6 +941,7 @@ export function connectPanePty(
             const preSignalPromise = window.api.pty
               .declarePendingPaneSerializer(cacheKey)
               .catch(() => null)
+            let expiredReattachError = false
             const reattachPromise = transport.connect({
               url: '',
               cols,
@@ -920,7 +950,13 @@ export function connectPanePty(
               callbacks: {
                 onData: dataCallback,
                 onReplayData: replayDataCallback,
-                onError: reportError
+                onError: (message) => {
+                  if (isSshSessionExpiredError(message)) {
+                    expiredReattachError = true
+                    return
+                  }
+                  reportError(message)
+                }
               }
             })
             void Promise.resolve(reattachPromise)
@@ -934,6 +970,16 @@ export function connectPanePty(
                       }
                     : 'undefined'
                 )
+                if (!result && expiredReattachError) {
+                  reportError(formatSshSessionExpiredMessage())
+                  deps.syncPanePtyLayoutBinding(pane.id, null)
+                  deps.clearTabPtyId(deps.tabId, pendingSessionId)
+                  const gen = await preSignalPromise
+                  if (typeof gen === 'number') {
+                    void window.api.pty.clearPendingPaneSerializer(cacheKey, gen).catch(() => {})
+                  }
+                  return
+                }
                 handleReattachResult(result, pendingSessionId)
                 const gen = await preSignalPromise
                 if (typeof gen === 'number') {
@@ -947,6 +993,12 @@ export function connectPanePty(
                 }
                 console.warn(`[pty-connection] Reattach FAILED for tab=${deps.tabId}:`, err)
                 if (disposed) {
+                  return
+                }
+                if (isSshSessionExpiredError(err)) {
+                  reportError(formatSshSessionExpiredMessage())
+                  deps.syncPanePtyLayoutBinding(pane.id, null)
+                  deps.clearTabPtyId(deps.tabId, pendingSessionId)
                   return
                 }
                 startFreshSpawn()
@@ -1018,6 +1070,7 @@ export function connectPanePty(
         .declarePendingPaneSerializer(cacheKey)
         .catch(() => null)
 
+      let expiredReattachError = false
       const reattachPromise = transport.connect({
         url: '',
         cols,
@@ -1026,12 +1079,28 @@ export function connectPanePty(
         callbacks: {
           onData: dataCallback,
           onReplayData: replayDataCallback,
-          onError: reportError
+          onError: (message) => {
+            if (isSshSessionExpiredError(message)) {
+              expiredReattachError = true
+              return
+            }
+            reportError(message)
+          }
         }
       })
 
       void Promise.resolve(reattachPromise)
         .then(async (result) => {
+          if (!result && expiredReattachError) {
+            reportError(formatSshSessionExpiredMessage())
+            deps.syncPanePtyLayoutBinding(pane.id, null)
+            deps.clearTabPtyId(deps.tabId, deferredReattachSessionId)
+            const gen = await preSignalPromise
+            if (typeof gen === 'number') {
+              void window.api.pty.clearPendingPaneSerializer(cacheKey, gen).catch(() => {})
+            }
+            return
+          }
           handleReattachResult(result, deferredReattachSessionId)
           const gen = await preSignalPromise
           if (typeof gen === 'number') {
@@ -1052,9 +1121,13 @@ export function connectPanePty(
             ptyId: deferredReattachSessionId,
             reason: message
           })
-          reportError(message)
           deps.syncPanePtyLayoutBinding(pane.id, null)
           deps.clearTabPtyId(deps.tabId, deferredReattachSessionId)
+          if (connectionId && isSshSessionExpiredError(err)) {
+            reportError(formatSshSessionExpiredMessage())
+            return
+          }
+          reportError(message)
           startFreshSpawn()
         })
     } else if (detachedLivePtyId) {

--- a/src/renderer/src/components/terminal-pane/pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.ts
@@ -42,6 +42,7 @@ export { extractLastOscTitle } from '../../../../shared/agent-detection'
 // 1337=iTerm2, 9001=Warp). Agents report structured status by printing
 // printf '\x1b]9999;{"state":"working","prompt":"..."}\x07'
 const OSC_AGENT_STATUS_PREFIX = '\x1b]9999;'
+const SSH_SESSION_EXPIRED_ERROR = 'SSH_SESSION_EXPIRED'
 
 export type ProcessedAgentStatusChunk = {
   cleanData: string
@@ -400,6 +401,12 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
         return spawnResult.id
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err)
+        if (connectionId && options.sessionId && msg.includes(SSH_SESSION_EXPIRED_ERROR)) {
+          return {
+            id: options.sessionId,
+            sessionExpired: true
+          } satisfies PtyConnectResult
+        }
         // Why: after "Kill All" from Settings → Manage Sessions, mounted panes
         // can still trigger pty:spawn with the killed session ID (tab remount,
         // navigating back to the workspace). The main-side adapter correctly

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -26,6 +26,10 @@ export const ORCA_BROWSER_PARTITION = 'persist:orca-browser'
 // data URL while still rejecting arbitrary renderer-provided data URLs.
 export const ORCA_BROWSER_BLANK_URL = 'data:text/html,'
 
+// Why: Electron's invoke error path preserves message text, not arbitrary
+// custom Error fields. Keep this stable token shared across main/renderer.
+export const SSH_TERMINATE_RECONNECT_REQUIRED = 'SSH_TERMINATE_RECONNECT_REQUIRED'
+
 export const BROWSER_FAMILY_LABELS: Record<string, string> = {
   chrome: 'Google Chrome',
   chromium: 'Chromium',
@@ -273,6 +277,7 @@ export function getDefaultPersistedState(homedir: string): PersistedState {
     githubCache: { pr: {}, issue: {} },
     workspaceSession: getDefaultWorkspaceSession(),
     sshTargets: [],
+    sshRemotePtyLeases: [],
     onboarding: getDefaultOnboardingState()
   }
 }

--- a/src/shared/ssh-types.ts
+++ b/src/shared/ssh-types.ts
@@ -52,6 +52,21 @@ export type SshConnectionState = {
   reconnectAttempt: number
 }
 
+export type SshRemotePtyLeaseState = 'attached' | 'detached' | 'terminated' | 'expired'
+
+export type SshRemotePtyLease = {
+  targetId: string
+  ptyId: string
+  worktreeId?: string
+  tabId?: string
+  leafId?: string
+  state: SshRemotePtyLeaseState
+  createdAt: number
+  updatedAt: number
+  lastAttachedAt?: number
+  lastDetachedAt?: number
+}
+
 // ─── Port Forwarding Types ─────────────────────────────────────────
 
 export type PortForwardEntry = {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines */
-import type { SshTarget } from './ssh-types'
+import type { SshRemotePtyLease, SshTarget } from './ssh-types'
 import type { WorkspaceSource } from './telemetry-events'
 import type { GitHubProjectSettings } from './github-project-types'
 
@@ -1648,6 +1648,7 @@ export type PersistedState = {
   }
   workspaceSession: WorkspaceSessionState
   sshTargets: SshTarget[]
+  sshRemotePtyLeases: SshRemotePtyLease[]
   onboarding: OnboardingState
 }
 


### PR DESCRIPTION
## Summary

- Persist SSH remote PTY leases from the main process so remote terminals can survive Orca close/quit within the relay grace window.
- Make normal SSH disconnect/window close non-destructive, with explicit terminate actions for killing remote sessions.
- Treat only confirmed missing remote PTYs as expired; keep tracking across transient mux/relay failures.
- Remove the inaccurate terminal-running close dialog and keep dirty editor files as the only close blocker.
- Harden stale restore handling with target/worktree/tab/leaf-aware lease matching and split-pane layout guards.

## Test Plan

- npm test -- --run src/main/persistence.test.ts src/main/ipc/ssh.test.ts src/main/ipc/pty.test.ts src/main/ssh/ssh-relay-session.test.ts src/main/providers/ssh-pty-provider.test.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts
- npm run typecheck -- --pretty false
- npm run lint
- git diff --check

## Review Notes

- Ran multiple subagent review passes over persistence and SSH lifecycle paths.
- Fixed validated findings around stale lease matching, transient shutdown/attach failures, and layout binding restore overreach.
- `npm run lint` passes with existing React hook warnings in GitHub project components.

Made with [Orca](https://github.com/stablyai/orca) 🐋
