### PR TITLE
Avoid Activity unread scans on agent status churn

### DIFF
--- a/src/renderer/src/components/activity/ActivityTitlebarControls.tsx
+++ b/src/renderer/src/components/activity/ActivityTitlebarControls.tsx
@@ -4,49 +4,10 @@ import { useAppStore } from '@/store'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
-import type { AgentStatusEntry, AgentStatusState } from '../../../../shared/agent-status-types'
-import { migrationUnsupportedToAgentStatusEntry } from '@/lib/migration-unsupported-agent-entry'
-
-// Why: keep the unread accumulator local; "Mark all read" moved to the
-// thread-list overflow menu in ActivityPrototypePage so it lives next to
-// the cards it acts on.
-
-function useActivityUnreadCount(): number {
-  return useAppStore((s) => {
-    let count = 0
-    const isUnreadState = (state: AgentStatusState): boolean =>
-      state === 'done' || state === 'blocked' || state === 'waiting'
-    // Why: Activity feed surfaces every historical done/blocked/waiting event from
-    // stateHistory plus the live state, so the badge must mirror the same walk —
-    // counting only on entry.state under-counts panes that started a new turn.
-    const accumulate = (entry: AgentStatusEntry, ackAt: number): void => {
-      for (const history of entry.stateHistory) {
-        if (isUnreadState(history.state) && ackAt < history.startedAt) {
-          count += 1
-        }
-      }
-      if (isUnreadState(entry.state) && ackAt < entry.stateStartedAt) {
-        count += 1
-      }
-    }
-    for (const [paneKey, entry] of Object.entries(s.agentStatusByPaneKey)) {
-      accumulate(entry, s.acknowledgedAgentsByPaneKey[paneKey] ?? 0)
-    }
-    for (const [paneKey, retained] of Object.entries(s.retainedAgentsByPaneKey)) {
-      accumulate(retained.entry, s.acknowledgedAgentsByPaneKey[paneKey] ?? 0)
-    }
-    for (const unsupported of Object.values(s.migrationUnsupportedByPtyId)) {
-      const entry = migrationUnsupportedToAgentStatusEntry(unsupported)
-      if (entry) {
-        accumulate(entry, s.acknowledgedAgentsByPaneKey[entry.paneKey] ?? 0)
-      }
-    }
-    return count
-  })
-}
+import { useActivityUnreadCount } from './useActivityUnreadCount'
 
 export function ActivityTitlebarControls(): React.JSX.Element {
-  const unreadCount = useActivityUnreadCount()
+  const unreadCount = useActivityUnreadCount(true, 'agent-events')
   const closeActivityPage = useAppStore((s) => s.closeActivityPage)
 
   return (

--- a/src/renderer/src/components/activity/useActivityUnreadCount.ts
+++ b/src/renderer/src/components/activity/useActivityUnreadCount.ts
@@ -1,0 +1,136 @@
+import { useMemo } from 'react'
+import { useShallow } from 'zustand/react/shallow'
+
+import { migrationUnsupportedToAgentStatusEntry } from '@/lib/migration-unsupported-agent-entry'
+import { useAppStore } from '@/store'
+import type { AppState } from '@/store/types'
+import type { AgentStatusEntry, AgentStatusState } from '../../../../shared/agent-status-types'
+
+type ActivityUnreadCountSource = Pick<
+  AppState,
+  | 'acknowledgedAgentsByPaneKey'
+  | 'agentStatusByPaneKey'
+  | 'migrationUnsupportedByPtyId'
+  | 'retainedAgentsByPaneKey'
+  | 'worktreesByRepo'
+>
+
+type ActivityUnreadCountMode = 'agent-events' | 'sidebar-badge'
+
+const EMPTY_WORKTREES_BY_REPO: AppState['worktreesByRepo'] = {}
+const EMPTY_MIGRATION_UNSUPPORTED: AppState['migrationUnsupportedByPtyId'] = {}
+const EMPTY_RETAINED_AGENTS: AppState['retainedAgentsByPaneKey'] = {}
+const EMPTY_ACKNOWLEDGED_AGENTS: AppState['acknowledgedAgentsByPaneKey'] = {}
+
+const DISABLED_ACTIVITY_UNREAD_INPUTS = {
+  sortEpoch: 0,
+  worktreesByRepo: EMPTY_WORKTREES_BY_REPO,
+  migrationUnsupportedByPtyId: EMPTY_MIGRATION_UNSUPPORTED,
+  retainedAgentsByPaneKey: EMPTY_RETAINED_AGENTS,
+  acknowledgedAgentsByPaneKey: EMPTY_ACKNOWLEDGED_AGENTS
+}
+
+function isUnreadAgentState(state: AgentStatusState): boolean {
+  return state === 'done' || state === 'blocked' || state === 'waiting'
+}
+
+export function countActivityUnread(
+  source: ActivityUnreadCountSource,
+  mode: ActivityUnreadCountMode
+): number {
+  let count = 0
+
+  if (mode === 'sidebar-badge') {
+    for (const worktrees of Object.values(source.worktreesByRepo)) {
+      for (const worktree of worktrees) {
+        if (worktree.createdAt && worktree.isUnread) {
+          count += 1
+        }
+      }
+    }
+  }
+
+  const countEntry = (entry: AgentStatusEntry, ackAt: number): void => {
+    if (mode === 'agent-events') {
+      // Why: Activity feed surfaces historical done/blocked/waiting events
+      // from stateHistory, so the titlebar badge must mirror that event count.
+      for (const history of entry.stateHistory) {
+        if (isUnreadAgentState(history.state) && ackAt < history.startedAt) {
+          count += 1
+        }
+      }
+    }
+    if (isUnreadAgentState(entry.state) && ackAt < entry.stateStartedAt) {
+      count += 1
+    }
+  }
+
+  for (const [paneKey, entry] of Object.entries(source.agentStatusByPaneKey)) {
+    countEntry(entry, source.acknowledgedAgentsByPaneKey[paneKey] ?? 0)
+  }
+  for (const [paneKey, retained] of Object.entries(source.retainedAgentsByPaneKey)) {
+    if (mode === 'sidebar-badge' && retained.entry.state !== 'done') {
+      continue
+    }
+    countEntry(retained.entry, source.acknowledgedAgentsByPaneKey[paneKey] ?? 0)
+  }
+  for (const unsupported of Object.values(source.migrationUnsupportedByPtyId)) {
+    const entry = migrationUnsupportedToAgentStatusEntry(unsupported)
+    if (entry) {
+      countEntry(entry, source.acknowledgedAgentsByPaneKey[entry.paneKey] ?? 0)
+    }
+  }
+
+  return count
+}
+
+export function useActivityUnreadCount(enabled: boolean, mode: ActivityUnreadCountMode): number {
+  const {
+    sortEpoch,
+    worktreesByRepo,
+    migrationUnsupportedByPtyId,
+    retainedAgentsByPaneKey,
+    acknowledgedAgentsByPaneKey
+  } = useAppStore(
+    useShallow((state) => {
+      if (!enabled) {
+        return DISABLED_ACTIVITY_UNREAD_INPUTS
+      }
+      return {
+        // Why: live status prompt/tool updates churn agentStatusByPaneKey but
+        // cannot change unread count unless a sort-relevant state transition
+        // or removal occurred. sortEpoch is the cheap invalidation signal.
+        sortEpoch: state.sortEpoch,
+        worktreesByRepo: state.worktreesByRepo,
+        migrationUnsupportedByPtyId: state.migrationUnsupportedByPtyId,
+        retainedAgentsByPaneKey: state.retainedAgentsByPaneKey,
+        acknowledgedAgentsByPaneKey: state.acknowledgedAgentsByPaneKey
+      }
+    })
+  )
+
+  return useMemo(() => {
+    if (!enabled) {
+      return 0
+    }
+    void sortEpoch
+    return countActivityUnread(
+      {
+        agentStatusByPaneKey: useAppStore.getState().agentStatusByPaneKey,
+        migrationUnsupportedByPtyId,
+        retainedAgentsByPaneKey,
+        worktreesByRepo,
+        acknowledgedAgentsByPaneKey
+      },
+      mode
+    )
+  }, [
+    acknowledgedAgentsByPaneKey,
+    enabled,
+    migrationUnsupportedByPtyId,
+    mode,
+    retainedAgentsByPaneKey,
+    sortEpoch,
+    worktreesByRepo
+  ])
+}

--- a/src/renderer/src/components/sidebar/SidebarNav.tsx
+++ b/src/renderer/src/components/sidebar/SidebarNav.tsx
@@ -7,12 +7,12 @@ import { isGitRepoKind } from '../../../../shared/repo-kind'
 import type { GlobalSettings } from '../../../../shared/types'
 import { getTaskPresetQuery, PER_REPO_FETCH_LIMIT } from '@/lib/new-workspace'
 import { LinearIcon } from '@/components/icons/LinearIcon'
-import { migrationUnsupportedToAgentStatusEntry } from '@/lib/migration-unsupported-agent-entry'
 import {
   normalizeVisibleTaskProviders,
   restoreAvailableDefaultTaskProvider,
   resolveVisibleTaskProvider
 } from '../../../../shared/task-providers'
+import { useActivityUnreadCount } from '@/components/activity/useActivityUnreadCount'
 
 const isMac = typeof navigator !== 'undefined' && navigator.userAgent.includes('Mac')
 
@@ -116,42 +116,7 @@ const SidebarNav = React.memo(function SidebarNav() {
   const tasksActive = activeView === 'tasks'
   const automationsActive = activeView === 'automations'
   const activityActive = activeView === 'activity'
-  const activityUnreadCount = useAppStore((s) => {
-    let count = 0
-    for (const worktrees of Object.values(s.worktreesByRepo)) {
-      for (const worktree of worktrees) {
-        if (worktree.createdAt && worktree.isUnread) {
-          count += 1
-        }
-      }
-    }
-    for (const [paneKey, entry] of Object.entries(s.agentStatusByPaneKey)) {
-      if (entry.state !== 'done' && entry.state !== 'blocked' && entry.state !== 'waiting') {
-        continue
-      }
-      if ((s.acknowledgedAgentsByPaneKey[paneKey] ?? 0) < entry.stateStartedAt) {
-        count += 1
-      }
-    }
-    for (const [paneKey, retained] of Object.entries(s.retainedAgentsByPaneKey)) {
-      if (retained.entry.state !== 'done') {
-        continue
-      }
-      if ((s.acknowledgedAgentsByPaneKey[paneKey] ?? 0) < retained.entry.stateStartedAt) {
-        count += 1
-      }
-    }
-    for (const unsupported of Object.values(s.migrationUnsupportedByPtyId)) {
-      const entry = migrationUnsupportedToAgentStatusEntry(unsupported)
-      if (!entry) {
-        continue
-      }
-      if ((s.acknowledgedAgentsByPaneKey[entry.paneKey] ?? 0) < entry.stateStartedAt) {
-        count += 1
-      }
-    }
-    return count
-  })
+  const activityUnreadCount = useActivityUnreadCount(showAgentsButton, 'sidebar-badge')
 
   return (
     <div className="flex flex-col gap-0.5 px-2 pt-2 pb-1">


### PR DESCRIPTION
## Summary
- move Activity unread count into a shared hook
- avoid subscribing unread badges to the high-churn live agent status map
- recompute unread count only when sort-relevant status changes, retained rows, acknowledgements, or worktree unread state change

## Perf review
- Symptom: with Activity enabled, prompt/tool status pings could make the sidebar unread badge scan all worktrees and agent rows even when the Activity page was closed.
- Waste: O(worktrees + agent rows) selector work per high-frequency agent status write.
- Measurement that catches it: selector/render counters during repeated setAgentStatus prompt/tool updates with experimental Activity enabled.
- Fix: use sortEpoch plus retained/ack/worktree refs as the invalidation set, and read the live map only inside memoized recomputation.

## Verification
- pnpm run tc:web
- pnpm run lint (existing GitHub Project warnings only)