### PR TITLE
Fix signed Windows updater checksum metadata

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -736,7 +736,10 @@ jobs:
           }
 
           $latestYml = Get-Content -Path 'dist/latest.yml' -Raw
-          $latestYml = $latestYml -replace '(?m)^sha512: .+$', "sha512: $hash"
+          $latestYml = [regex]::Replace($latestYml, '(?m)^(\s*)sha512: .+$', {
+            param($match)
+            "$($match.Groups[1].Value)sha512: $hash"
+          })
           $latestYml = $latestYml -replace '(?m)^    size: \d+$', "    size: $($installer.Length)"
           $latestYml = $latestYml -replace '(?m)^    blockMapSize: \d+$', "    blockMapSize: $($blockmap.Length)"
           Set-Content -Path 'dist/latest.yml' -Value $latestYml -NoNewline


### PR DESCRIPTION
## Summary
- update every `sha512` entry in Windows `latest.yml` after SignPath returns the signed installer
- fixes signed Windows releases where the top-level checksum was updated but `files[0].sha512` still pointed at the unsigned installer

## Validation
- patched live `v1.3.49` `latest.yml` and re-downloaded it to verify both hashes match the published installer
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-cut.yml"); puts "release-cut.yml parses"'\n- git diff --check\n