### PR TITLE
fix(ssh): treat symlinked directories as folders

### DIFF
--- a/src/main/ipc/filesystem.test.ts
+++ b/src/main/ipc/filesystem.test.ts
@@ -241,6 +241,26 @@ describe('registerFilesystemHandlers', () => {
     expect(listWorktreesMock).not.toHaveBeenCalled()
   })
 
+  it('reports symlinked directories from readDir as directories', async () => {
+    const modelLinkPath = path.join(REPO_PATH, 'Model')
+    readdirMock.mockResolvedValue([
+      dirEntry({ name: 'README.md', file: true }),
+      dirEntry({ name: 'Model', symlink: true })
+    ])
+    statMock.mockImplementation(async (targetPath: string) => ({
+      size: 10,
+      isDirectory: () => targetPath === modelLinkPath,
+      mtimeMs: 123
+    }))
+
+    registerFilesystemHandlers(store as never)
+
+    await expect(handlers.get('fs:readDir')!(null, { dirPath: REPO_PATH })).resolves.toEqual([
+      { name: 'Model', isDirectory: true, isSymlink: true },
+      { name: 'README.md', isDirectory: false, isSymlink: false }
+    ])
+  })
+
   it('allows deletePath when a registered worktree parent resolves to a macOS canonical alias', async () => {
     const aliasWorktreePath = path.resolve('/var/folders/orca/worktrees/feature')
     const canonicalWorktreePath = path.resolve('/private/var/folders/orca/worktrees/feature')

--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines */
 import { ipcMain, shell } from 'electron'
 import { readdir, readFile, writeFile, stat, lstat, open } from 'fs/promises'
-import { extname } from 'path'
+import { extname, join } from 'path'
 import type { ChildProcess } from 'child_process'
 import { wslAwareSpawn } from '../git/runner'
 import { parseWslPath, toWindowsWslPath } from '../wsl'
@@ -104,6 +104,27 @@ async function isBinaryFilePrefix(filePath: string): Promise<boolean> {
   }
 }
 
+async function isDirectoryEntry(
+  dirPath: string,
+  entry: { name: string; isDirectory(): boolean; isSymbolicLink(): boolean },
+  resolveEntryPath: (entryPath: string) => Promise<string>
+): Promise<boolean> {
+  if (entry.isDirectory()) {
+    return true
+  }
+  if (!entry.isSymbolicLink()) {
+    return false
+  }
+  try {
+    // Why: directory symlinks inside a workspace should navigate like folders
+    // without bypassing the local authorized-path boundary.
+    const entryPath = await resolveEntryPath(join(dirPath, entry.name))
+    return (await stat(entryPath)).isDirectory()
+  } catch {
+    return false
+  }
+}
+
 export function registerFilesystemHandlers(store: Store): void {
   const activeTextSearches = new Map<string, ChildProcess>()
 
@@ -120,18 +141,21 @@ export function registerFilesystemHandlers(store: Store): void {
       }
       const dirPath = await resolveAuthorizedPath(args.dirPath, store)
       const entries = await readdir(dirPath, { withFileTypes: true })
-      return entries
-        .map((entry) => ({
+      const mapped = await Promise.all(
+        entries.map(async (entry) => ({
           name: entry.name,
-          isDirectory: entry.isDirectory(),
+          isDirectory: await isDirectoryEntry(dirPath, entry, (entryPath) =>
+            resolveAuthorizedPath(entryPath, store)
+          ),
           isSymlink: entry.isSymbolicLink()
         }))
-        .sort((a, b) => {
-          if (a.isDirectory !== b.isDirectory) {
-            return a.isDirectory ? -1 : 1
-          }
-          return a.name.localeCompare(b.name)
-        })
+      )
+      return mapped.sort((a, b) => {
+        if (a.isDirectory !== b.isDirectory) {
+          return a.isDirectory ? -1 : 1
+        }
+        return a.name.localeCompare(b.name)
+      })
     }
   )
 

--- a/src/relay/fs-handler.test.ts
+++ b/src/relay/fs-handler.test.ts
@@ -119,6 +119,25 @@ describe('FsHandler', () => {
     expect(result.find((e) => e.name === 'aaa.txt')).toBeDefined()
   })
 
+  it('readDir reports symlinked directories as directories', async () => {
+    const targetDir = path.join(tmpDir, 'external-models')
+    const linkPath = path.join(tmpDir, 'Model')
+    mkdirSync(targetDir)
+    symlinkSync(targetDir, linkPath, process.platform === 'win32' ? 'junction' : 'dir')
+
+    const result = (await dispatcher.callRequest('fs.readDir', { dirPath: tmpDir })) as {
+      name: string
+      isDirectory: boolean
+      isSymlink: boolean
+    }[]
+
+    expect(result.find((e) => e.name === 'Model')).toEqual({
+      name: 'Model',
+      isDirectory: true,
+      isSymlink: true
+    })
+  })
+
   it('readFile returns text content for text files', async () => {
     const filePath = path.join(tmpDir, 'test.txt')
     writeFileSync(filePath, 'hello world')
@@ -209,6 +228,19 @@ describe('FsHandler', () => {
     const result = (await dispatcher.callRequest('fs.stat', { filePath: tmpDir })) as {
       type: string
     }
+    expect(result.type).toBe('directory')
+  })
+
+  it('stat returns directory type for symlinked directories', async () => {
+    const targetDir = path.join(tmpDir, 'external-models')
+    const linkPath = path.join(tmpDir, 'Model')
+    mkdirSync(targetDir)
+    symlinkSync(targetDir, linkPath, process.platform === 'win32' ? 'junction' : 'dir')
+
+    const result = (await dispatcher.callRequest('fs.stat', { filePath: linkPath })) as {
+      type: string
+    }
+
     expect(result.type).toBe('directory')
   })
 

--- a/src/relay/fs-handler.ts
+++ b/src/relay/fs-handler.ts
@@ -1,5 +1,6 @@
 import { readdir, writeFile, stat, lstat, mkdir, rename, cp, rm, realpath } from 'fs/promises'
 import { execFile } from 'child_process'
+import { join } from 'path'
 import type { RelayDispatcher, RequestContext } from './dispatcher'
 import type { RelayContext } from './context'
 // Why: RelayContext is accepted in the constructor for protocol back-compat
@@ -23,6 +24,25 @@ type WatchState = {
   unwatchFn: (() => void) | null
   setupPromise: Promise<void> | null
   isStale: () => boolean
+}
+
+async function isDirectoryEntry(
+  dirPath: string,
+  entry: { name: string; isDirectory(): boolean; isSymbolicLink(): boolean }
+): Promise<boolean> {
+  if (entry.isDirectory()) {
+    return true
+  }
+  if (!entry.isSymbolicLink()) {
+    return false
+  }
+  try {
+    // Why: the file explorer needs target type for symlinked directories so a
+    // workspace link to an external folder expands instead of opening as a file.
+    return (await stat(join(dirPath, entry.name))).isDirectory()
+  } catch {
+    return false
+  }
 }
 
 export class FsHandler {
@@ -57,18 +77,19 @@ export class FsHandler {
   private async readDir(params: Record<string, unknown>) {
     const dirPath = expandTilde(params.dirPath as string)
     const entries = await readdir(dirPath, { withFileTypes: true })
-    return entries
-      .map((entry) => ({
+    const mapped = await Promise.all(
+      entries.map(async (entry) => ({
         name: entry.name,
-        isDirectory: entry.isDirectory(),
+        isDirectory: await isDirectoryEntry(dirPath, entry),
         isSymlink: entry.isSymbolicLink()
       }))
-      .sort((a, b) => {
-        if (a.isDirectory !== b.isDirectory) {
-          return a.isDirectory ? -1 : 1
-        }
-        return a.name.localeCompare(b.name)
-      })
+    )
+    return mapped.sort((a, b) => {
+      if (a.isDirectory !== b.isDirectory) {
+        return a.isDirectory ? -1 : 1
+      }
+      return a.name.localeCompare(b.name)
+    })
   }
 
   private async readFile(params: Record<string, unknown>) {
@@ -110,15 +131,24 @@ export class FsHandler {
 
   private async stat(params: Record<string, unknown>) {
     const filePath = expandTilde(params.filePath as string)
-    // Why: lstat is used instead of stat so that symlinks are reported as
-    // symlinks rather than being silently followed. stat() follows symlinks,
-    // meaning isSymbolicLink() would always return false.
     const stats = await lstat(filePath)
+    if (stats.isSymbolicLink()) {
+      try {
+        // Why: callers use stat to decide whether to read a path or enumerate
+        // it; symlink-to-directory must behave like its target for that choice.
+        const targetStats = await stat(filePath)
+        return {
+          size: targetStats.size,
+          type: targetStats.isDirectory() ? 'directory' : 'file',
+          mtime: targetStats.mtimeMs
+        }
+      } catch {
+        return { size: stats.size, type: 'symlink', mtime: stats.mtimeMs }
+      }
+    }
     let type: 'file' | 'directory' | 'symlink' = 'file'
     if (stats.isDirectory()) {
       type = 'directory'
-    } else if (stats.isSymbolicLink()) {
-      type = 'symlink'
     }
     return { size: stats.size, type, mtime: stats.mtimeMs }
   }


### PR DESCRIPTION
## Summary

Follow-up to #1661 and #1672.

PR #1672 removed the SSH relay path allowlist so symlink targets outside the workspace can be opened, but directory symlinks were still misclassified by directory listings:

- `fs.readDir` used `Dirent.isDirectory()`, which returns `false` for symlink entries.
- The file explorer therefore treated a symlink-to-directory like a file.
- Clicking it called `readFile`, which failed with `EISDIR: illegal operation on a directory, read`.

This PR makes directory listings report symlink-to-directory entries as directories while preserving `isSymlink: true`.

## What changed

- Relay `fs.readDir` follows symlink entries with `stat()` only to determine whether the target is a directory.
- Relay `fs.stat` returns the target file/directory type for symlinks, falling back to `symlink` for broken links.
- Local `fs:readDir` gets the same symlink-to-directory behavior, but still resolves through the existing authorized-path boundary.
- Added regression coverage for directory symlinks in both relay and local filesystem tests.

## Verification

- `pnpm test src/relay/fs-handler.test.ts src/main/ipc/filesystem.test.ts`
- `pnpm tc:node`
- Manual SSH repro on `openclaw 2` using `/home/jinwoo/Documents/repo-test/Model -> /tmp/orca-repo-test-symlink-target`

Note: local commands emitted the existing Node engine warning because this machine is on Node v25.9.0 while the repo wants Node 24, but both commands passed.

Made with [Orca](https://github.com/stablyai/orca) 🐋
