### PR TITLE
Activity page agent terminal view

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -638,7 +638,7 @@ function App(): React.JSX.Element {
         // Why: Back/Forward traverse mixed worktree + Tasks visits, so the
         // shortcut is active wherever the titlebar button cluster is (terminal
         // or tasks). Still suppressed in Settings to keep that view modal-ish.
-        if (activeView !== 'terminal' && activeView !== 'tasks' && activeView !== 'activity') {
+        if (activeView !== 'terminal' && activeView !== 'tasks') {
           return
         }
         e.preventDefault()
@@ -843,10 +843,11 @@ function App(): React.JSX.Element {
         )}
       </div>
       {/* Why: Back/Forward traverse mixed worktree + Tasks history, so the
-          cluster is shown wherever the history shortcut is live (terminal,
-          tasks, or activity — selecting an agent there records a worktree
-          visit). Hidden in Settings to keep that view modal-ish. */}
-      {(activeView === 'terminal' || activeView === 'tasks' || activeView === 'activity') && (
+          cluster is shown wherever the history shortcut is live (terminal or
+          tasks). Hidden in Settings to keep that view modal-ish, and in
+          Activity since that page owns its own back-out via the Close button
+          in ActivityTitlebarControls. */}
+      {(activeView === 'terminal' || activeView === 'tasks') && (
         <div className="ml-auto mr-3 flex items-center">
           <Tooltip>
             <TooltipTrigger asChild>

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -572,7 +572,10 @@ function App(): React.JSX.Element {
     activeWorktreeId !== null &&
     !hasTabBar &&
     effectiveActiveTabExpanded
-  const showSidebar = activeView !== 'settings'
+  // Why: Activity is a full-page navigation surface — same treatment as
+  // Settings — so the worktree sidebar is removed for that view, letting the
+  // thread list + agent terminal span edge-to-edge.
+  const showSidebar = activeView !== 'settings' && activeView !== 'activity'
   // Why: only the terminal workspace replaces the full-width titlebar with
   // split-column chrome. Full-page navigation views keep the draggable app
   // titlebar so their page-level controls can live in that window strip.
@@ -635,7 +638,7 @@ function App(): React.JSX.Element {
         // Why: Back/Forward traverse mixed worktree + Tasks visits, so the
         // shortcut is active wherever the titlebar button cluster is (terminal
         // or tasks). Still suppressed in Settings to keep that view modal-ish.
-        if (activeView !== 'terminal' && activeView !== 'tasks') {
+        if (activeView !== 'terminal' && activeView !== 'tasks' && activeView !== 'activity') {
           return
         }
         e.preventDefault()
@@ -840,9 +843,10 @@ function App(): React.JSX.Element {
         )}
       </div>
       {/* Why: Back/Forward traverse mixed worktree + Tasks history, so the
-          cluster is shown wherever the history shortcut is live (terminal or
-          tasks). Hidden in Settings to keep that view modal-ish. */}
-      {(activeView === 'terminal' || activeView === 'tasks') && (
+          cluster is shown wherever the history shortcut is live (terminal,
+          tasks, or activity — selecting an agent there records a worktree
+          visit). Hidden in Settings to keep that view modal-ish. */}
+      {(activeView === 'terminal' || activeView === 'tasks' || activeView === 'activity') && (
         <div className="ml-auto mr-3 flex items-center">
           <Tooltip>
             <TooltipTrigger asChild>

--- a/src/renderer/src/components/AgentStateDot.tsx
+++ b/src/renderer/src/components/AgentStateDot.tsx
@@ -44,7 +44,7 @@ export function agentStateLabel(state: AgentDotState): string {
 
 type Props = {
   state: AgentDotState
-  size?: 'sm' | 'md' | 'lg'
+  size?: 'sm' | 'md'
   className?: string
 }
 
@@ -53,12 +53,9 @@ export const AgentStateDot = React.memo(function AgentStateDot({
   size = 'sm',
   className
 }: Props): React.JSX.Element {
-  // Why ('lg' size): the Activity page renders this in its own 32px column
-  // alongside text rows, where 'md' (12px) reads small and floats. 'lg' (18px)
-  // sits center of mass in that cell.
-  const box = size === 'lg' ? 'h-[18px] w-[18px]' : size === 'md' ? 'h-3 w-3' : 'h-2.5 w-2.5'
-  const inner = size === 'lg' ? 'size-3' : size === 'md' ? 'size-2' : 'size-1.5'
-  const icon = size === 'lg' ? 'size-[18px]' : size === 'md' ? 'size-3' : 'size-2.5'
+  const box = size === 'md' ? 'h-3 w-3' : 'h-2.5 w-2.5'
+  const inner = size === 'md' ? 'size-2' : 'size-1.5'
+  const icon = size === 'md' ? 'size-3' : 'size-2.5'
 
   if (state === 'working') {
     return (

--- a/src/renderer/src/components/AgentStateDot.tsx
+++ b/src/renderer/src/components/AgentStateDot.tsx
@@ -44,7 +44,7 @@ export function agentStateLabel(state: AgentDotState): string {
 
 type Props = {
   state: AgentDotState
-  size?: 'sm' | 'md'
+  size?: 'sm' | 'md' | 'lg'
   className?: string
 }
 
@@ -53,9 +53,12 @@ export const AgentStateDot = React.memo(function AgentStateDot({
   size = 'sm',
   className
 }: Props): React.JSX.Element {
-  const box = size === 'md' ? 'h-3 w-3' : 'h-2.5 w-2.5'
-  const inner = size === 'md' ? 'size-2' : 'size-1.5'
-  const icon = size === 'md' ? 'size-3' : 'size-2.5'
+  // Why ('lg' size): the Activity page renders this in its own 32px column
+  // alongside text rows, where 'md' (12px) reads small and floats. 'lg' (18px)
+  // sits center of mass in that cell.
+  const box = size === 'lg' ? 'h-[18px] w-[18px]' : size === 'md' ? 'h-3 w-3' : 'h-2.5 w-2.5'
+  const inner = size === 'lg' ? 'size-3' : size === 'md' ? 'size-2' : 'size-1.5'
+  const icon = size === 'lg' ? 'size-[18px]' : size === 'md' ? 'size-3' : 'size-2.5'
 
   if (state === 'working') {
     return (

--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -55,7 +55,8 @@ import {
 import { appendUniqueOpenFileIds } from './terminal/unsaved-close-queue'
 import CodexRestartChip from './CodexRestartChip'
 import {
-  useActivityTerminalPortalTarget,
+  findActivityTerminalPortal,
+  useActivityTerminalPortals,
   type ActivityTerminalPortalTarget
 } from './activity/activity-terminal-portal'
 
@@ -106,24 +107,15 @@ function Terminal(): React.JSX.Element | null {
   const setTabBarOrder = useAppStore((s) => s.setTabBarOrder)
   const tabBarOrderByWorktree = useAppStore((s) => s.tabBarOrderByWorktree)
   const tabBarOrder = activeWorktreeId ? tabBarOrderByWorktree[activeWorktreeId] : undefined
-  const activityTerminalPortalTarget = useActivityTerminalPortalTarget(activeView === 'activity')
-  // Why: stable identity preserves WorktreeSplitSurface's React.memo bail-out across unrelated Terminal re-renders.
-  const activityTerminalPortal: ActivityTerminalPortalTarget | null = useMemo(() => {
-    if (
-      activeView !== 'activity' ||
-      activeTabType !== 'terminal' ||
-      !activeWorktreeId ||
-      !activeTabId ||
-      !activityTerminalPortalTarget
-    ) {
-      return null
-    }
-    return {
-      target: activityTerminalPortalTarget,
-      worktreeId: activeWorktreeId,
-      tabId: activeTabId
-    }
-  }, [activeView, activeTabType, activeWorktreeId, activeTabId, activityTerminalPortalTarget])
+  // Why (anchored to selected thread, not active tab): the activity page
+  // publishes the full {target, worktreeId, tabId} descriptor sourced from
+  // its selectedThread. Deriving worktreeId/tabId from activeWorktreeId/
+  // activeTabId here used to flash the wrong terminal — selectThread updates
+  // the store in multiple steps and intermediate renders briefly pointed the
+  // portal at the new worktree's stale last-active tab.
+  const activityTerminalPortals: ActivityTerminalPortalTarget[] = useActivityTerminalPortals(
+    activeView === 'activity'
+  )
 
   const tabs = useMemo(
     () => (activeWorktreeId ? (tabsByWorktree[activeWorktreeId] ?? []) : []),
@@ -1269,7 +1261,7 @@ function Terminal(): React.JSX.Element | null {
                   layout={layout}
                   focusedGroupId={activeGroupIdByWorktree[worktree.id]}
                   isVisible={isVisible}
-                  activityTerminalPortal={activityTerminalPortal}
+                  activityTerminalPortals={activityTerminalPortals}
                 />
               )
             })}
@@ -1323,9 +1315,12 @@ function Terminal(): React.JSX.Element | null {
                   >
                     <CodexRestartChip worktreeId={worktree.id} />
                     {(tabsByWorktree[worktree.id] ?? []).map((tab) => {
-                      const isActivityPortalTab =
-                        activityTerminalPortal?.worktreeId === worktree.id &&
-                        activityTerminalPortal.tabId === tab.id
+                      const activityTerminalPortal = findActivityTerminalPortal(
+                        activityTerminalPortals,
+                        worktree.id,
+                        tab.id
+                      )
+                      const isActivityPortalTab = activityTerminalPortal !== null
                       const isActiveTerminalTab =
                         isVisible && tab.id === activeTabId && activeTabType === 'terminal'
                       const terminalPane = (
@@ -1334,7 +1329,7 @@ function Terminal(): React.JSX.Element | null {
                           tabId={tab.id}
                           worktreeId={worktree.id}
                           cwd={worktree.path}
-                          isActive={isActiveTerminalTab || isActivityPortalTab}
+                          isActive={isActiveTerminalTab || activityTerminalPortal?.active === true}
                           // Why: the activity page hosts this existing pane via
                           // portal while the workspace surface remains hidden.
                           // Keeping `isVisible` true for the portaled tab lets
@@ -1344,7 +1339,7 @@ function Terminal(): React.JSX.Element | null {
                           onCloseTab={() => handleCloseTab(tab.id)}
                         />
                       )
-                      if (isActivityPortalTab && activityTerminalPortal) {
+                      if (activityTerminalPortal) {
                         return createPortal(
                           terminalPane,
                           activityTerminalPortal.target,
@@ -1512,13 +1507,13 @@ const WorktreeSplitSurface = React.memo(function WorktreeSplitSurface({
   layout,
   focusedGroupId,
   isVisible,
-  activityTerminalPortal
+  activityTerminalPortals
 }: {
   worktreeId: string
   layout: TabGroupLayoutNode
   focusedGroupId?: string
   isVisible: boolean
-  activityTerminalPortal: ActivityTerminalPortalTarget | null
+  activityTerminalPortals: ActivityTerminalPortalTarget[]
 }): React.JSX.Element {
   return (
     <div
@@ -1531,7 +1526,7 @@ const WorktreeSplitSurface = React.memo(function WorktreeSplitSurface({
         worktreeId={worktreeId}
         focusedGroupId={focusedGroupId}
         isWorktreeActive={isVisible}
-        activityTerminalPortal={activityTerminalPortal}
+        activityTerminalPortals={activityTerminalPortals}
       />
       <BrowserPaneOverlayLayer worktreeId={worktreeId} isWorktreeActive={isVisible} />
     </div>

--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -54,6 +54,10 @@ import {
 } from './terminal/split-group-mount'
 import { appendUniqueOpenFileIds } from './terminal/unsaved-close-queue'
 import CodexRestartChip from './CodexRestartChip'
+import {
+  useActivityTerminalPortalTarget,
+  type ActivityTerminalPortalTarget
+} from './activity/activity-terminal-portal'
 
 const EditorPanel = lazy(() => import('./editor/EditorPanel'))
 
@@ -102,6 +106,19 @@ function Terminal(): React.JSX.Element | null {
   const setTabBarOrder = useAppStore((s) => s.setTabBarOrder)
   const tabBarOrderByWorktree = useAppStore((s) => s.tabBarOrderByWorktree)
   const tabBarOrder = activeWorktreeId ? tabBarOrderByWorktree[activeWorktreeId] : undefined
+  const activityTerminalPortalTarget = useActivityTerminalPortalTarget(activeView === 'activity')
+  const activityTerminalPortal: ActivityTerminalPortalTarget | null =
+    activeView === 'activity' &&
+    activeTabType === 'terminal' &&
+    activeWorktreeId &&
+    activeTabId &&
+    activityTerminalPortalTarget
+      ? {
+          target: activityTerminalPortalTarget,
+          worktreeId: activeWorktreeId,
+          tabId: activeTabId
+        }
+      : null
 
   const tabs = useMemo(
     () => (activeWorktreeId ? (tabsByWorktree[activeWorktreeId] ?? []) : []),
@@ -1247,6 +1264,7 @@ function Terminal(): React.JSX.Element | null {
                   layout={layout}
                   focusedGroupId={activeGroupIdByWorktree[worktree.id]}
                   isVisible={isVisible}
+                  activityTerminalPortal={activityTerminalPortal}
                 />
               )
             })}
@@ -1299,27 +1317,37 @@ function Terminal(): React.JSX.Element | null {
                     aria-hidden={!isVisible}
                   >
                     <CodexRestartChip worktreeId={worktree.id} />
-                    {(tabsByWorktree[worktree.id] ?? []).map((tab) => (
-                      <TerminalPane
-                        key={`${tab.id}-${tab.generation ?? 0}`}
-                        tabId={tab.id}
-                        worktreeId={worktree.id}
-                        cwd={worktree.path}
-                        isActive={
-                          isVisible && tab.id === activeTabId && activeTabType === 'terminal'
-                        }
-                        // Why: the bootstrap fallback still uses the legacy
-                        // workspace-level terminal host, where only the active
-                        // tab should render. Keeping `isVisible` explicit avoids
-                        // multiple panes stacking during the short window before
-                        // the split-group root layout is ready.
-                        isVisible={
-                          isVisible && tab.id === activeTabId && activeTabType === 'terminal'
-                        }
-                        onPtyExit={(ptyId) => handlePtyExit(tab.id, ptyId)}
-                        onCloseTab={() => handleCloseTab(tab.id)}
-                      />
-                    ))}
+                    {(tabsByWorktree[worktree.id] ?? []).map((tab) => {
+                      const isActivityPortalTab =
+                        activityTerminalPortal?.worktreeId === worktree.id &&
+                        activityTerminalPortal.tabId === tab.id
+                      const isActiveTerminalTab =
+                        isVisible && tab.id === activeTabId && activeTabType === 'terminal'
+                      const terminalPane = (
+                        <TerminalPane
+                          key={`${tab.id}-${tab.generation ?? 0}`}
+                          tabId={tab.id}
+                          worktreeId={worktree.id}
+                          cwd={worktree.path}
+                          isActive={isActiveTerminalTab || isActivityPortalTab}
+                          // Why: the activity page hosts this existing pane via
+                          // portal while the workspace surface remains hidden.
+                          // Keeping `isVisible` true for the portaled tab lets
+                          // xterm fit and stream foreground output in-place.
+                          isVisible={isActiveTerminalTab || isActivityPortalTab}
+                          onPtyExit={(ptyId) => handlePtyExit(tab.id, ptyId)}
+                          onCloseTab={() => handleCloseTab(tab.id)}
+                        />
+                      )
+                      if (isActivityPortalTab && activityTerminalPortal) {
+                        return createPortal(
+                          terminalPane,
+                          activityTerminalPortal.target,
+                          `activity-terminal-${tab.id}`
+                        )
+                      }
+                      return terminalPane
+                    })}
                   </div>
                 )
               })}
@@ -1478,12 +1506,14 @@ const WorktreeSplitSurface = React.memo(function WorktreeSplitSurface({
   worktreeId,
   layout,
   focusedGroupId,
-  isVisible
+  isVisible,
+  activityTerminalPortal
 }: {
   worktreeId: string
   layout: TabGroupLayoutNode
   focusedGroupId?: string
   isVisible: boolean
+  activityTerminalPortal: ActivityTerminalPortalTarget | null
 }): React.JSX.Element {
   return (
     <div
@@ -1496,6 +1526,7 @@ const WorktreeSplitSurface = React.memo(function WorktreeSplitSurface({
         worktreeId={worktreeId}
         focusedGroupId={focusedGroupId}
         isWorktreeActive={isVisible}
+        activityTerminalPortal={activityTerminalPortal}
       />
       <BrowserPaneOverlayLayer worktreeId={worktreeId} isWorktreeActive={isVisible} />
     </div>

--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -107,18 +107,23 @@ function Terminal(): React.JSX.Element | null {
   const tabBarOrderByWorktree = useAppStore((s) => s.tabBarOrderByWorktree)
   const tabBarOrder = activeWorktreeId ? tabBarOrderByWorktree[activeWorktreeId] : undefined
   const activityTerminalPortalTarget = useActivityTerminalPortalTarget(activeView === 'activity')
-  const activityTerminalPortal: ActivityTerminalPortalTarget | null =
-    activeView === 'activity' &&
-    activeTabType === 'terminal' &&
-    activeWorktreeId &&
-    activeTabId &&
-    activityTerminalPortalTarget
-      ? {
-          target: activityTerminalPortalTarget,
-          worktreeId: activeWorktreeId,
-          tabId: activeTabId
-        }
-      : null
+  // Why: stable identity preserves WorktreeSplitSurface's React.memo bail-out across unrelated Terminal re-renders.
+  const activityTerminalPortal: ActivityTerminalPortalTarget | null = useMemo(() => {
+    if (
+      activeView !== 'activity' ||
+      activeTabType !== 'terminal' ||
+      !activeWorktreeId ||
+      !activeTabId ||
+      !activityTerminalPortalTarget
+    ) {
+      return null
+    }
+    return {
+      target: activityTerminalPortalTarget,
+      worktreeId: activeWorktreeId,
+      tabId: activeTabId
+    }
+  }, [activeView, activeTabType, activeWorktreeId, activeTabId, activityTerminalPortalTarget])
 
   const tabs = useMemo(
     () => (activeWorktreeId ? (tabsByWorktree[activeWorktreeId] ?? []) : []),

--- a/src/renderer/src/components/activity/ActivityPrototypePage.test.ts
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest'
+import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
+import type { Repo, TerminalTab, Worktree } from '../../../../shared/types'
+import { buildActivityEvents } from './ActivityPrototypePage'
+
+function makeRepo(): Repo {
+  return {
+    id: 'repo-1',
+    path: '/repo',
+    displayName: 'Repo',
+    badgeColor: '#000',
+    addedAt: 1
+  }
+}
+
+function makeWorktree(): Worktree {
+  return {
+    id: 'wt-1',
+    repoId: 'repo-1',
+    path: '/repo/wt-1',
+    head: 'abc123',
+    branch: 'feature',
+    isBare: false,
+    isMainWorktree: false,
+    displayName: 'feature',
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 1
+  }
+}
+
+function makeTab(): TerminalTab {
+  return {
+    id: 'tab-1',
+    ptyId: 'pty-1',
+    worktreeId: 'wt-1',
+    title: 'Claude',
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 1
+  }
+}
+
+function makeWorkingEntryWithPriorDone(): AgentStatusEntry {
+  return {
+    state: 'working',
+    prompt: 'Second prompt',
+    updatedAt: 2_000,
+    stateStartedAt: 2_000,
+    paneKey: 'tab-1:1',
+    terminalTitle: 'Claude',
+    stateHistory: [
+      {
+        state: 'done',
+        prompt: 'First prompt',
+        startedAt: 1_000
+      }
+    ],
+    agentType: 'claude'
+  }
+}
+
+describe('buildActivityEvents', () => {
+  it('keeps a prior done event after the same pane starts working again', () => {
+    const repo = makeRepo()
+    const worktree = makeWorktree()
+    const tab = makeTab()
+
+    const events = buildActivityEvents({
+      agentStatusByPaneKey: {
+        'tab-1:1': makeWorkingEntryWithPriorDone()
+      },
+      retainedAgentsByPaneKey: {},
+      tabsByWorktree: {
+        [worktree.id]: [tab]
+      },
+      worktreeMap: new Map([[worktree.id, worktree]]),
+      repoMap: new Map([[repo.id, repo]]),
+      acknowledgedAgentsByPaneKey: {}
+    })
+
+    expect(events).toHaveLength(1)
+    expect(events[0]).toMatchObject({
+      state: 'done',
+      timestamp: 1_000
+    })
+    expect(events[0].entry.prompt).toBe('First prompt')
+  })
+})

--- a/src/renderer/src/components/activity/ActivityPrototypePage.tsx
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.tsx
@@ -569,7 +569,11 @@ function ThreadRow({
         //   tint, mirroring WorktreeCard's "weight alone" pattern. Three
         //   stacked tints (selected + unread + hover) made selected and
         //   unread look identical when hovered.
-        'group relative grid w-full grid-cols-[minmax(0,1fr)_auto] gap-2 border-b border-border px-3 py-2.5 text-left transition-colors',
+        // Why (asymmetric padding): the title uses leading-snug, which adds
+        // ~3px of internal space above the cap-height that isn't present
+        // below the secondary badge row. Symmetric py made the top read
+        // heavier; pt-2 / pb-2.5 visually evens the row.
+        'group relative grid w-full grid-cols-[minmax(0,1fr)_auto] gap-2 border-b border-border px-3 pt-2 pb-2.5 text-left transition-colors',
         selected
           ? 'bg-black/[0.08] shadow-[0_1px_2px_rgba(0,0,0,0.04)] dark:bg-white/[0.10] dark:shadow-[0_1px_2px_rgba(0,0,0,0.03)]'
           : 'hover:bg-accent/40'

--- a/src/renderer/src/components/activity/ActivityPrototypePage.tsx
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.tsx
@@ -884,7 +884,7 @@ export default function ActivityPrototypePage(): React.JSX.Element {
         <section className="min-w-0 flex-1 overflow-hidden">
           {selectedThread ? (
             <div className="flex h-full min-h-0 flex-col">
-              <div className="flex shrink-0 items-center justify-between gap-4 border-b border-border px-4 pt-2 pb-3">
+              <div className="shrink-0 border-b border-border px-4 pt-2 pb-3">
                 <div className="min-w-0">
                   <div className="flex min-w-0 items-center gap-2">
                     <h2 className="truncate text-base font-semibold">
@@ -896,17 +896,6 @@ export default function ActivityPrototypePage(): React.JSX.Element {
                     Complete workspace history, from creation through latest agent updates
                   </div>
                 </div>
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="xs"
-                  onClick={() => {
-                    markThreadRead(selectedThread)
-                    activateAndRevealWorktree(selectedThread.worktree.id)
-                  }}
-                >
-                  Jump to workspace
-                </Button>
               </div>
               <div className="min-h-0 flex-1 overflow-auto scrollbar-sleek">
                 {(['Today', 'Yesterday', 'Earlier'] as const).map((group) =>

--- a/src/renderer/src/components/activity/ActivityPrototypePage.tsx
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.tsx
@@ -1013,7 +1013,7 @@ export default function ActivityPrototypePage(): React.JSX.Element {
                   type="button"
                   variant="outline"
                   size="xs"
-                  className="shrink-0"
+                  className="shrink-0 self-center"
                   onClick={() => {
                     markThreadRead(selectedThread)
                     activateAndRevealWorktree(selectedThread.worktree.id)

--- a/src/renderer/src/components/activity/ActivityPrototypePage.tsx
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.tsx
@@ -7,21 +7,19 @@ import {
   Bell,
   BellDot,
   BellOff,
-  GitBranch,
   MessageSquareText,
   Search,
-  Settings
+  Settings,
+  TerminalSquare
 } from 'lucide-react'
 
 import { AgentIcon } from '@/lib/agent-catalog'
 import { agentTypeToIconAgent, formatAgentTypeLabel } from '@/lib/agent-status'
 import { activateTabAndFocusPane } from '@/lib/activate-tab-and-focus-pane'
-import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 import { useAppStore } from '@/store'
 import type { RetainedAgentEntry } from '@/store/slices/agent-status'
 import { getRepoMapFromState, getWorktreeMapFromState } from '@/store/selectors'
 import { useSidebarResize } from '@/hooks/useSidebarResize'
-import { AgentStateDot, agentStateLabel, type AgentDotState } from '@/components/AgentStateDot'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
@@ -36,6 +34,7 @@ import { Input } from '@/components/ui/input'
 import { Toggle } from '@/components/ui/toggle'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
+import { ACTIVITY_TERMINAL_PORTAL_TARGET_ID } from './activity-terminal-portal'
 import type { Repo, TerminalTab, Worktree } from '../../../../shared/types'
 import type {
   AgentStatusEntry,
@@ -99,13 +98,6 @@ function formatRelativeTime(timestamp: number): string {
   }
   const diffDays = Math.round(diffHours / 24)
   return relativeTimeFormatter.format(diffDays, 'day')
-}
-
-function asDotState(state: AgentStatusState): AgentDotState {
-  if (state === 'blocked' || state === 'waiting' || state === 'done') {
-    return state
-  }
-  return 'idle'
 }
 
 function paneIdFromPaneKey(paneKey: string): number | null {
@@ -302,108 +294,6 @@ function EventRepoBadge({ repo }: { repo: Repo | null }): React.JSX.Element | nu
   )
 }
 
-function ActivityRow({
-  event,
-  density,
-  onMarkRead
-}: {
-  event: ActivityEvent
-  density: ActivityDensity
-  onMarkRead: (event: ActivityEvent) => void
-}): React.JSX.Element {
-  const compact = density === 'compact'
-  const dotState = asDotState(event.state)
-
-  // Why (row click = navigate + ack): the inline "Jump to agent" button only
-  // rendered when agentAlive (so retained-done rows had no jump affordance at
-  // all) and in compact mode it was hover-only. Users naturally click anywhere
-  // on the row expecting it to navigate, so the row itself takes over the
-  // navigate role and subsumes the button. Per the design doc we drop the
-  // agentAlive gate entirely (option 1): activateAndRevealWorktree is safe
-  // unconditionally and activateTabAndFocusPane silently no-ops on a missing
-  // tab id, so a stale-tab click is just a soft no-op.
-  const openAgent = (clickEvent?: React.MouseEvent | React.KeyboardEvent): void => {
-    clickEvent?.stopPropagation()
-    onMarkRead(event)
-    activateAndRevealWorktree(event.worktree.id)
-    activateTabAndFocusPane(event.tab.id, paneIdFromPaneKey(event.entry.paneKey))
-  }
-
-  return (
-    <div
-      role="button"
-      tabIndex={0}
-      onClick={openAgent}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault()
-          openAgent(e)
-        }
-      }}
-      className={cn(
-        'group relative grid grid-cols-[2rem_minmax(0,1fr)_7.25rem] gap-3 border-b border-border px-3 cursor-pointer transition-colors hover:bg-accent/40',
-        compact ? 'py-2' : 'py-3.5',
-        event.unread && 'bg-accent/20'
-      )}
-    >
-      {/* Why (left-edge bar): matches ThreadRow's unread treatment so the two
-          surfaces share one unread vocabulary. A row-level marker keeps the
-          state-icon column uncrowded — earlier attempts (mini-dot, bell glyph)
-          competed with the AgentStateDot. */}
-      {event.unread ? (
-        <span
-          className="absolute left-0 top-1.5 bottom-1.5 w-0.5 rounded-r-full bg-primary"
-          aria-hidden
-        />
-      ) : null}
-      <div className="flex items-center justify-center pt-0.5">
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <span className="inline-flex">
-              <AgentStateDot state={dotState} size="lg" />
-            </span>
-          </TooltipTrigger>
-          <TooltipContent side="top" sideOffset={4}>
-            {event.entry.interrupted ? 'Interrupted' : agentStateLabel(dotState)}
-          </TooltipContent>
-        </Tooltip>
-      </div>
-
-      <div className="min-w-0">
-        <div className="flex min-w-0 items-center gap-2">
-          <span className={cn('truncate text-sm', event.unread ? 'font-semibold' : 'font-medium')}>
-            {agentTitle(event)}
-          </span>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <span className="inline-flex shrink-0">
-                <AgentIcon agent={agentTypeToIconAgent(event.agentType)} size={14} />
-              </span>
-            </TooltipTrigger>
-            <TooltipContent side="top" sideOffset={4}>
-              {formatAgentTypeLabel(event.agentType)}
-            </TooltipContent>
-          </Tooltip>
-        </div>
-        <div className="mt-0.5 line-clamp-3 break-words whitespace-pre-wrap text-sm text-muted-foreground">
-          {agentSummary(event)}
-        </div>
-        <div className="mt-1.5 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-[11px] text-muted-foreground">
-          <span className="inline-flex min-w-0 items-center gap-1">
-            <GitBranch className="size-3 shrink-0" />
-            <span className="truncate">{event.worktree.displayName}</span>
-          </span>
-          <span>{agentMeta(event)}</span>
-        </div>
-      </div>
-
-      <div className="flex flex-col items-end gap-2 pt-0.5">
-        <EventTime timestamp={event.timestamp} />
-      </div>
-    </div>
-  )
-}
-
 function ThreadRow({
   thread,
   density,
@@ -444,13 +334,17 @@ function ThreadRow({
         <span className="absolute left-0 top-1.5 bottom-1.5 w-0.5 rounded-r-full bg-primary" />
       ) : null}
       <span className="min-w-0">
-        <span className="flex min-w-0 items-center gap-2">
-          <span className="inline-flex shrink-0">
+        <span className="flex min-w-0 items-start gap-2">
+          <span className="inline-flex shrink-0 pt-[3px]">
             <AgentIcon agent={agentTypeToIconAgent(thread.agentType)} size={14} />
           </span>
+          {/* Why (line-clamp-2 + smaller size): prompts can be long; clamping
+              to two lines lets users read more of the prompt while keeping
+              rows scannable. text-[13px] tightens the leading slightly so two
+              clamped lines don't dominate the row vertically. */}
           <span
             className={cn(
-              'truncate text-sm',
+              'line-clamp-2 break-words text-[13px] leading-snug',
               thread.unread ? 'font-semibold text-foreground' : 'font-medium text-foreground'
             )}
           >
@@ -566,17 +460,14 @@ export default function ActivityPrototypePage(): React.JSX.Element {
   }, [allThreads, readFilter, query])
 
   useEffect(() => {
-    if (visibleThreads.length === 0) {
+    if (selectedPaneKey && !allThreads.some((thread) => thread.paneKey === selectedPaneKey)) {
       setSelectedPaneKey(null)
-      return
     }
-    if (!selectedPaneKey || !visibleThreads.some((thread) => thread.paneKey === selectedPaneKey)) {
-      setSelectedPaneKey(visibleThreads[0].paneKey)
-    }
-  }, [selectedPaneKey, visibleThreads])
+  }, [allThreads, selectedPaneKey])
 
-  const selectedThread =
-    visibleThreads.find((thread) => thread.paneKey === selectedPaneKey) ?? visibleThreads[0] ?? null
+  const selectedThread = selectedPaneKey
+    ? (allThreads.find((thread) => thread.paneKey === selectedPaneKey) ?? null)
+    : null
 
   const markThreadRead = (thread: AgentPaneThread): void => {
     storeData.acknowledgeAgents([thread.paneKey])
@@ -586,9 +477,22 @@ export default function ActivityPrototypePage(): React.JSX.Element {
     storeData.unacknowledgeAgents([thread.paneKey])
   }
 
+  const activateThreadTerminal = (thread: AgentPaneThread): void => {
+    const state = useAppStore.getState()
+    if (state.activeRepoId !== thread.worktree.repoId) {
+      state.setActiveRepo(thread.worktree.repoId)
+    }
+    if (state.activeWorktreeId !== thread.worktree.id) {
+      state.setActiveWorktree(thread.worktree.id)
+    }
+    state.setActiveTabType('terminal')
+    activateTabAndFocusPane(thread.latestEvent.tab.id, paneIdFromPaneKey(thread.paneKey))
+  }
+
   const selectThread = (thread: AgentPaneThread): void => {
     setSelectedPaneKey(thread.paneKey)
     markThreadRead(thread)
+    activateThreadTerminal(thread)
   }
 
   const toggleThreadRead = (thread: AgentPaneThread): void => {
@@ -597,10 +501,6 @@ export default function ActivityPrototypePage(): React.JSX.Element {
       return
     }
     markThreadUnread(thread)
-  }
-
-  const markRead = (event: ActivityEvent): void => {
-    storeData.acknowledgeAgents([event.entry.paneKey])
   }
 
   // Why (page padding): drop top + horizontal padding so the page extends to
@@ -722,7 +622,7 @@ export default function ActivityPrototypePage(): React.JSX.Element {
                     <span className="inline-flex shrink-0">
                       <AgentIcon agent={agentTypeToIconAgent(selectedThread.agentType)} size={16} />
                     </span>
-                    <h2 className="truncate text-base font-semibold">{selectedThread.paneTitle}</h2>
+                    <h2 className="truncate text-sm font-semibold">{selectedThread.paneTitle}</h2>
                     <EventRepoBadge repo={selectedThread.repo} />
                   </div>
                   <div className="mt-1 truncate text-xs text-muted-foreground">
@@ -730,21 +630,28 @@ export default function ActivityPrototypePage(): React.JSX.Element {
                   </div>
                 </div>
               </div>
-              <div className="min-h-0 flex-1 overflow-auto scrollbar-sleek">
-                {selectedThread.events.map((event) => (
-                  <ActivityRow
-                    key={event.id}
-                    event={event}
-                    density="comfortable"
-                    onMarkRead={markRead}
-                  />
-                ))}
-              </div>
+              {/* Why: Terminal stays mounted in the hidden workspace tree while
+                  Activity is open. This target lets that existing TerminalPane
+                  move here instead of creating a second PTY/xterm owner. */}
+              <div
+                id={ACTIVITY_TERMINAL_PORTAL_TARGET_ID}
+                className="relative min-h-0 flex-1 overflow-hidden bg-editor-surface"
+                data-activity-terminal-tab-id={selectedThread.latestEvent.tab.id}
+              />
             </div>
           ) : (
             <div className="flex h-full min-h-[240px] flex-col items-center justify-center gap-2 text-sm text-muted-foreground">
-              <MessageSquareText className="size-7" />
-              No activity yet.
+              {visibleThreads.length === 0 ? (
+                <>
+                  <MessageSquareText className="size-7" />
+                  No activity yet.
+                </>
+              ) : (
+                <>
+                  <TerminalSquare className="size-7" />
+                  Select an agent to open its terminal.
+                </>
+              )}
             </div>
           )}
         </section>

--- a/src/renderer/src/components/activity/ActivityPrototypePage.tsx
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.tsx
@@ -323,11 +323,20 @@ function ThreadRow({
         }
       }}
       className={cn(
-        'group relative grid w-full grid-cols-[minmax(0,1fr)_auto] gap-2 border-b border-border px-3 text-left transition-colors hover:bg-accent/40',
+        // Why (selected/hover/unread cues match WorktreeCard):
+        // - selected → solid black/white tint + faint shadow, no hover
+        //   override (the active class wins so hover doesn't fight it).
+        // - non-selected → only then does hover apply (bg-accent/40), so a
+        //   selected row stays visually fixed when the cursor moves over it.
+        // - unread → weight + left-edge primary bar carry the cue; no row
+        //   tint, mirroring WorktreeCard's "weight alone" pattern. Three
+        //   stacked tints (selected + unread + hover) made selected and
+        //   unread look identical when hovered.
+        'group relative grid w-full grid-cols-[minmax(0,1fr)_auto] gap-2 border-b border-border px-3 text-left transition-colors',
         compact ? 'py-1.5' : 'py-2.5',
-        selected &&
-          'bg-black/[0.08] shadow-[0_1px_2px_rgba(0,0,0,0.04)] dark:bg-white/[0.10] dark:shadow-[0_1px_2px_rgba(0,0,0,0.03)]',
-        thread.unread && 'bg-primary/[0.045] dark:bg-primary/[0.08]'
+        selected
+          ? 'bg-black/[0.08] shadow-[0_1px_2px_rgba(0,0,0,0.04)] dark:bg-white/[0.10] dark:shadow-[0_1px_2px_rgba(0,0,0,0.03)]'
+          : 'hover:bg-accent/40'
       )}
     >
       {thread.unread ? (

--- a/src/renderer/src/components/activity/ActivityPrototypePage.tsx
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.tsx
@@ -603,42 +603,42 @@ function ThreadRow({
           </span>
         </span>
       </span>
-      <span className="flex flex-col items-end gap-1 pt-0.5">
-        <span className="flex min-w-16 flex-col items-end gap-1">
-          <span className="relative flex h-6 min-w-16 items-start justify-end">
-            <span className="transition-opacity group-hover:opacity-0">
-              <EventTime timestamp={latest.timestamp} />
-            </span>
-            <span className="absolute right-0 top-0 opacity-0 transition-opacity group-hover:opacity-100">
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="icon-xs"
-                    aria-label={toggleLabel}
-                    onClick={(event) => {
-                      event.stopPropagation()
-                      onToggleRead()
-                    }}
-                    onMouseDown={(event) => event.stopPropagation()}
-                  >
-                    {thread.unread ? <BellOff className="size-3" /> : <Bell className="size-3" />}
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent side="left">{toggleLabel}</TooltipContent>
-              </Tooltip>
-            </span>
+      {/* Why (single-line right cluster): keeping time and count on the same
+          row stops the right column from forcing a ~48px height when the
+          left column's prompt is only one line. The row now collapses to
+          fit a 1-line title and grows naturally for 2-line prompts. */}
+      <span className="inline-flex shrink-0 items-center gap-1.5 pt-[3px]">
+        {thread.unread ? (
+          <span className="rounded-full bg-primary px-1.5 py-0.5 text-[9px] font-semibold leading-none text-primary-foreground">
+            New
           </span>
-          <span className="inline-flex items-center gap-1">
-            {thread.unread ? (
-              <span className="rounded-full bg-primary px-1.5 py-0.5 text-[9px] font-semibold leading-none text-primary-foreground">
-                New
-              </span>
-            ) : null}
-            <Badge variant="outline" className="h-5 px-1.5 text-[10px] font-normal">
-              {thread.events.length}
-            </Badge>
+        ) : null}
+        <Badge variant="outline" className="h-5 px-1.5 text-[10px] font-normal">
+          {thread.events.length}
+        </Badge>
+        <span className="relative inline-flex h-5 min-w-16 items-center justify-end">
+          <span className="transition-opacity group-hover:opacity-0">
+            <EventTime timestamp={latest.timestamp} />
+          </span>
+          <span className="absolute right-0 top-1/2 -translate-y-1/2 opacity-0 transition-opacity group-hover:opacity-100">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon-xs"
+                  aria-label={toggleLabel}
+                  onClick={(event) => {
+                    event.stopPropagation()
+                    onToggleRead()
+                  }}
+                  onMouseDown={(event) => event.stopPropagation()}
+                >
+                  {thread.unread ? <BellOff className="size-3" /> : <Bell className="size-3" />}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="left">{toggleLabel}</TooltipContent>
+            </Tooltip>
           </span>
         </span>
       </span>

--- a/src/renderer/src/components/activity/ActivityPrototypePage.tsx
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.tsx
@@ -391,7 +391,7 @@ function AgentEventRow({
             </TooltipContent>
           </Tooltip>
         </div>
-        <div className="mt-0.5 break-words whitespace-pre-wrap text-sm text-muted-foreground">
+        <div className="mt-0.5 line-clamp-3 break-words whitespace-pre-wrap text-sm text-muted-foreground">
           {agentSummary(event)}
         </div>
         <div className="mt-1.5 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-[11px] text-muted-foreground">

--- a/src/renderer/src/components/activity/ActivityPrototypePage.tsx
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.tsx
@@ -3,15 +3,7 @@ and current visual skeleton together until the next refinement pass decides
 which pieces become production modules. */
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useState } from 'react'
 import { useShallow } from 'zustand/react/shallow'
-import {
-  Bell,
-  BellDot,
-  BellOff,
-  MessageSquareText,
-  Search,
-  Settings,
-  TerminalSquare
-} from 'lucide-react'
+import { Bell, BellDot, BellOff, MessageSquareText, Search, TerminalSquare } from 'lucide-react'
 
 import { AgentIcon } from '@/lib/agent-catalog'
 import { agentTypeToIconAgent, formatAgentTypeLabel } from '@/lib/agent-status'
@@ -23,14 +15,6 @@ import { getRepoMapFromState, getWorktreeMapFromState } from '@/store/selectors'
 import { useSidebarResize } from '@/hooks/useSidebarResize'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import {
-  DropdownMenu,
-  DropdownMenuCheckboxItem,
-  DropdownMenuContent,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger
-} from '@/components/ui/dropdown-menu'
 import { Input } from '@/components/ui/input'
 import { Toggle } from '@/components/ui/toggle'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
@@ -48,7 +32,6 @@ import type {
 } from '../../../../shared/agent-status-types'
 
 type ThreadReadFilter = 'all' | 'unread'
-type ActivityDensity = 'compact' | 'comfortable'
 type ActivityEventState = Extract<AgentStatusState, 'done' | 'blocked' | 'waiting'>
 
 type ActivityEvent = {
@@ -552,19 +535,16 @@ function EventRepoBadge({ repo }: { repo: Repo | null }): React.JSX.Element | nu
 
 function ThreadRow({
   thread,
-  density,
   selected,
   onSelect,
   onToggleRead
 }: {
   thread: AgentPaneThread
-  density: ActivityDensity
   selected: boolean
   onSelect: () => void
   onToggleRead: () => void
 }): React.JSX.Element {
   const latest = thread.latestEvent
-  const compact = density === 'compact'
   const toggleLabel = thread.unread ? 'Mark thread read' : 'Mark thread unread'
   return (
     <div
@@ -588,8 +568,7 @@ function ThreadRow({
         //   tint, mirroring WorktreeCard's "weight alone" pattern. Three
         //   stacked tints (selected + unread + hover) made selected and
         //   unread look identical when hovered.
-        'group relative grid w-full grid-cols-[minmax(0,1fr)_auto] gap-2 border-b border-border px-3 text-left transition-colors',
-        compact ? 'py-1.5' : 'py-2.5',
+        'group relative grid w-full grid-cols-[minmax(0,1fr)_auto] gap-2 border-b border-border px-3 py-1.5 text-left transition-colors',
         selected
           ? 'bg-black/[0.08] shadow-[0_1px_2px_rgba(0,0,0,0.04)] dark:bg-white/[0.10] dark:shadow-[0_1px_2px_rgba(0,0,0,0.03)]'
           : 'hover:bg-accent/40'
@@ -622,13 +601,8 @@ function ThreadRow({
             {thread.worktree.displayName}
           </span>
         </span>
-        {!compact ? (
-          <span className="mt-1 block truncate text-xs text-muted-foreground">
-            {agentTitle(latest)}
-          </span>
-        ) : null}
       </span>
-      <span className={cn('flex flex-col items-end pt-0.5', compact ? 'gap-1' : 'gap-2')}>
+      <span className="flex flex-col items-end gap-1 pt-0.5">
         <span className="flex min-w-16 flex-col items-end gap-1">
           <span className="relative flex h-6 min-w-16 items-start justify-end">
             <span className="transition-opacity group-hover:opacity-0">
@@ -673,8 +647,6 @@ function ThreadRow({
 
 export default function ActivityPrototypePage(): React.JSX.Element {
   const [readFilter, setReadFilter] = useState<ThreadReadFilter>('all')
-  const [leftSidebarCompact, setLeftSidebarCompact] = useState(true)
-  const leftSidebarDensity: ActivityDensity = leftSidebarCompact ? 'compact' : 'comfortable'
   const [query, setQuery] = useState('')
   const [selectedPaneKey, setSelectedPaneKey] = useState<string | null>(null)
   const [displayedPaneKey, setDisplayedPaneKey] = useState<string | null>(null)
@@ -941,33 +913,10 @@ export default function ActivityPrototypePage(): React.JSX.Element {
           style={{ width: threadListWidth }}
         >
           <div className="shrink-0 border-b border-border px-2 pt-1.5 pb-2">
-            <div className="mb-2 flex items-center justify-between gap-2">
+            <div className="mb-2 flex items-center gap-2">
               <div className="text-[11px] font-semibold uppercase tracking-[0.05em] text-muted-foreground">
                 Agents
               </div>
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon-xs"
-                    aria-label="Activity list display options"
-                    className="text-muted-foreground hover:text-foreground"
-                  >
-                    <Settings className="size-3.5" />
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end" side="bottom" className="min-w-44">
-                  <DropdownMenuLabel>Display style</DropdownMenuLabel>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuCheckboxItem
-                    checked={leftSidebarCompact}
-                    onCheckedChange={(checked) => setLeftSidebarCompact(checked === true)}
-                  >
-                    Compact list
-                  </DropdownMenuCheckboxItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
             </div>
             <div className="flex items-center gap-2">
               <div className="relative min-w-0 flex-1">
@@ -1006,7 +955,6 @@ export default function ActivityPrototypePage(): React.JSX.Element {
               <ThreadRow
                 key={thread.paneKey}
                 thread={thread}
-                density={leftSidebarDensity}
                 selected={thread.paneKey === selectedThread?.paneKey}
                 onSelect={() => selectThread(thread)}
                 onToggleRead={() => toggleThreadRead(thread)}

--- a/src/renderer/src/components/activity/ActivityPrototypePage.tsx
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.tsx
@@ -391,12 +391,7 @@ function AgentEventRow({
             </TooltipContent>
           </Tooltip>
         </div>
-        <div
-          className={cn(
-            'mt-0.5 truncate text-sm text-muted-foreground',
-            compact ? 'max-w-[760px]' : 'max-w-[920px]'
-          )}
-        >
+        <div className="mt-0.5 break-words whitespace-pre-wrap text-sm text-muted-foreground">
           {agentSummary(event)}
         </div>
         <div className="mt-1.5 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-[11px] text-muted-foreground">

--- a/src/renderer/src/components/activity/ActivityPrototypePage.tsx
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines -- Why: this prototype keeps the real-data adapter
 and current visual skeleton together until the next refinement pass decides
 which pieces become production modules. */
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useState } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import {
   Bell,
@@ -35,7 +35,10 @@ import { Input } from '@/components/ui/input'
 import { Toggle } from '@/components/ui/toggle'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
-import { setActivityTerminalPortalTarget } from './activity-terminal-portal'
+import {
+  setActivityTerminalPortals,
+  type ActivityTerminalPortalTarget
+} from './activity-terminal-portal'
 import type { Repo, TerminalTab, Worktree } from '../../../../shared/types'
 import type {
   AgentStateHistoryEntry,
@@ -75,6 +78,21 @@ type AgentPaneThread = {
   unread: boolean
 }
 
+type ActivityTerminalPortalReadiness = {
+  target: HTMLElement | null
+  tabId: string | null
+  ready: boolean
+}
+
+type ActivityTerminalPortalDomStatus = {
+  hasSelectedRoot: boolean
+  ready: boolean
+}
+
+type ActivityTerminalPortalSlotId = 'primary' | 'secondary'
+
+const ACTIVITY_TERMINAL_LOADING_LABEL_DELAY_MS = 180
+
 const absoluteDateFormatter = new Intl.DateTimeFormat(undefined, {
   year: 'numeric',
   month: 'short',
@@ -108,6 +126,137 @@ function paneIdFromPaneKey(paneKey: string): number | null {
   const tail = colon > 0 ? paneKey.slice(colon + 1) : ''
   const parsed = /^\d+$/.test(tail) ? Number.parseInt(tail, 10) : NaN
   return Number.isFinite(parsed) && parsed > 0 ? parsed : null
+}
+
+function getSelectedActivityTerminalPortalStatus(
+  target: HTMLElement,
+  tabId: string
+): ActivityTerminalPortalDomStatus {
+  let selectedRoot: HTMLElement | null = null
+  for (const candidate of target.querySelectorAll<HTMLElement>('[data-terminal-tab-id]')) {
+    if (candidate.dataset.terminalTabId === tabId) {
+      selectedRoot = candidate
+      break
+    }
+  }
+  if (!selectedRoot) {
+    return { hasSelectedRoot: false, ready: false }
+  }
+  const hasPtyBinding =
+    selectedRoot.hasAttribute('data-pty-id') ||
+    selectedRoot.querySelector<HTMLElement>('[data-pty-id]') !== null
+  const hasXtermScreen = selectedRoot.querySelector<HTMLElement>('.xterm-screen') !== null
+  return { hasSelectedRoot: true, ready: hasPtyBinding && hasXtermScreen }
+}
+
+function useActivityTerminalPortalReadiness(
+  target: HTMLElement | null,
+  tabId: string | null
+): boolean {
+  const [readiness, setReadiness] = useState<ActivityTerminalPortalReadiness>({
+    target: null,
+    tabId: null,
+    ready: false
+  })
+
+  useLayoutEffect(() => {
+    if (!target || !tabId) {
+      setReadiness((prev) =>
+        prev.target === null && prev.tabId === null && !prev.ready
+          ? prev
+          : { target: null, tabId: null, ready: false }
+      )
+      return
+    }
+
+    let disposed = false
+    let readyFrame: number | null = null
+    let sawUnreadySelectedRoot = false
+
+    const updateReadiness = (ready: boolean): void => {
+      setReadiness((prev) =>
+        prev.target === target && prev.tabId === tabId && prev.ready === ready
+          ? prev
+          : { target, tabId, ready }
+      )
+    }
+
+    const cancelReadyFrame = (): void => {
+      if (readyFrame !== null) {
+        cancelAnimationFrame(readyFrame)
+        readyFrame = null
+      }
+    }
+
+    const checkReadiness = (): void => {
+      const status = getSelectedActivityTerminalPortalStatus(target, tabId)
+      if (status.ready) {
+        if (!sawUnreadySelectedRoot) {
+          cancelReadyFrame()
+          updateReadiness(true)
+          return
+        }
+        if (readyFrame !== null) {
+          return
+        }
+        // Why: the PTY id can appear before xterm has painted replayed output.
+        // Waiting one frame keeps Activity's cover in place for the blank canvas
+        // frame without moving terminal lifecycle work into global layout effects.
+        readyFrame = requestAnimationFrame(() => {
+          readyFrame = null
+          if (!disposed && getSelectedActivityTerminalPortalStatus(target, tabId).ready) {
+            updateReadiness(true)
+          }
+        })
+        return
+      }
+      if (status.hasSelectedRoot) {
+        sawUnreadySelectedRoot = true
+      }
+      cancelReadyFrame()
+      updateReadiness(false)
+    }
+
+    updateReadiness(false)
+    checkReadiness()
+
+    const observer = new MutationObserver(checkReadiness)
+    observer.observe(target, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['data-terminal-tab-id', 'data-pty-id']
+    })
+
+    return () => {
+      disposed = true
+      cancelReadyFrame()
+      observer.disconnect()
+    }
+  }, [target, tabId])
+
+  return readiness.target === target && readiness.tabId === tabId && readiness.ready
+}
+
+function otherActivityTerminalSlot(
+  slotId: ActivityTerminalPortalSlotId
+): ActivityTerminalPortalSlotId {
+  return slotId === 'primary' ? 'secondary' : 'primary'
+}
+
+function useActivityTerminalLoadingLabel(loading: boolean): boolean {
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    if (!loading) {
+      setVisible(false)
+      return
+    }
+    const timer = setTimeout(() => setVisible(true), ACTIVITY_TERMINAL_LOADING_LABEL_DELAY_MS)
+    return () => clearTimeout(timer)
+  }, [loading])
+
+  return visible
 }
 
 function agentTitle(event: ActivityEvent): string {
@@ -528,6 +677,11 @@ export default function ActivityPrototypePage(): React.JSX.Element {
   const leftSidebarDensity: ActivityDensity = leftSidebarCompact ? 'compact' : 'comfortable'
   const [query, setQuery] = useState('')
   const [selectedPaneKey, setSelectedPaneKey] = useState<string | null>(null)
+  const [displayedPaneKey, setDisplayedPaneKey] = useState<string | null>(null)
+  const [activePortalSlotId, setActivePortalSlotId] =
+    useState<ActivityTerminalPortalSlotId>('primary')
+  const [primaryPortalTargetEl, setPrimaryPortalTargetEl] = useState<HTMLElement | null>(null)
+  const [secondaryPortalTargetEl, setSecondaryPortalTargetEl] = useState<HTMLElement | null>(null)
   const [threadListWidth, setThreadListWidth] = useState(340)
   const {
     containerRef: threadListRef,
@@ -587,6 +741,149 @@ export default function ActivityPrototypePage(): React.JSX.Element {
   const selectedThread = selectedPaneKey
     ? (allThreads.find((thread) => thread.paneKey === selectedPaneKey) ?? null)
     : null
+  const selectedTabId = selectedThread?.latestEvent.tab.id ?? null
+  const selectedHasLiveTab =
+    selectedThread && selectedTabId
+      ? (storeData.tabsByWorktree[selectedThread.worktree.id] ?? []).some(
+          (tab) => tab.id === selectedTabId
+        )
+      : false
+  const displayedThread = displayedPaneKey
+    ? (allThreads.find((thread) => thread.paneKey === displayedPaneKey) ?? null)
+    : null
+  const displayedTabId = displayedThread?.latestEvent.tab.id ?? null
+  const displayedHasLiveTab =
+    displayedThread && displayedTabId
+      ? (storeData.tabsByWorktree[displayedThread.worktree.id] ?? []).some(
+          (tab) => tab.id === displayedTabId
+        )
+      : false
+  const displayedIsSelectedTerminal =
+    selectedThread &&
+    displayedThread &&
+    displayedThread.worktree.id === selectedThread.worktree.id &&
+    displayedThread.latestEvent.tab.id === selectedThread.latestEvent.tab.id
+  const visibleThread =
+    selectedThread && selectedHasLiveTab
+      ? displayedThread && displayedHasLiveTab && displayedThread.paneKey !== selectedThread.paneKey
+        ? displayedIsSelectedTerminal
+          ? selectedThread
+          : displayedThread
+        : selectedThread
+      : null
+  const stagedThread =
+    selectedThread &&
+    selectedHasLiveTab &&
+    visibleThread &&
+    visibleThread.paneKey !== selectedThread.paneKey &&
+    !displayedIsSelectedTerminal
+      ? selectedThread
+      : null
+  const inactivePortalSlotId = otherActivityTerminalSlot(activePortalSlotId)
+  const portalTargetBySlot = {
+    primary: primaryPortalTargetEl,
+    secondary: secondaryPortalTargetEl
+  } satisfies Record<ActivityTerminalPortalSlotId, HTMLElement | null>
+  const activePortalTargetEl = portalTargetBySlot[activePortalSlotId]
+  const inactivePortalTargetEl = portalTargetBySlot[inactivePortalSlotId]
+  const visibleTabId = visibleThread?.latestEvent.tab.id ?? null
+  const stagedTabId = stagedThread?.latestEvent.tab.id ?? null
+  const visiblePortalReady = useActivityTerminalPortalReadiness(activePortalTargetEl, visibleTabId)
+  const stagedPortalReady = useActivityTerminalPortalReadiness(inactivePortalTargetEl, stagedTabId)
+  const showTerminalLoadingLabel = useActivityTerminalLoadingLabel(
+    Boolean(visibleThread && !stagedThread && !visiblePortalReady)
+  )
+
+  const setPrimaryPortalTarget = useCallback((target: HTMLElement | null): void => {
+    setPrimaryPortalTargetEl(target)
+  }, [])
+
+  const setSecondaryPortalTarget = useCallback((target: HTMLElement | null): void => {
+    setSecondaryPortalTargetEl(target)
+  }, [])
+
+  // Why (no flash on selection): publish the portal descriptor with the
+  // selected thread's worktreeId+tabId directly, instead of letting Terminal
+  // derive it from activeWorktreeId/activeTabId. selectThread updates the
+  // store in multiple steps (setActiveRepo → setActiveWorktree →
+  // setActiveTabType → setActiveTab) and React commits in between can
+  // briefly reflect the new worktree's stale "last active tab" — that's the
+  // wrong-terminal flash. Anchoring the portal to the selected thread
+  // sidesteps the race entirely.
+  // Why useMemo: keep a stable descriptor identity across unrelated re-renders
+  // so subscribers (Terminal → WorktreeSplitSurface) keep their React.memo
+  // bail-outs. The inactive descriptor is a same-size staging slot: the old
+  // terminal stays visible while the next terminal mounts underneath it.
+  const portalDescriptors = useMemo(() => {
+    const descriptors: ActivityTerminalPortalTarget[] = []
+    if (visibleThread && activePortalTargetEl) {
+      descriptors.push({
+        slotId: activePortalSlotId,
+        target: activePortalTargetEl,
+        worktreeId: visibleThread.worktree.id,
+        tabId: visibleThread.latestEvent.tab.id,
+        active: true
+      })
+    }
+    if (stagedThread && inactivePortalTargetEl) {
+      descriptors.push({
+        slotId: inactivePortalSlotId,
+        target: inactivePortalTargetEl,
+        worktreeId: stagedThread.worktree.id,
+        tabId: stagedThread.latestEvent.tab.id,
+        active: false
+      })
+    }
+    return descriptors
+  }, [
+    activePortalSlotId,
+    activePortalTargetEl,
+    inactivePortalSlotId,
+    inactivePortalTargetEl,
+    stagedThread,
+    visibleThread
+  ])
+
+  useLayoutEffect(() => {
+    if (!selectedThread || !selectedHasLiveTab) {
+      setDisplayedPaneKey(null)
+      return
+    }
+    if (stagedThread && stagedPortalReady) {
+      setActivePortalSlotId(inactivePortalSlotId)
+      setDisplayedPaneKey(stagedThread.paneKey)
+      return
+    }
+    if (!stagedThread && visibleThread?.paneKey === selectedThread.paneKey && visiblePortalReady) {
+      setDisplayedPaneKey(selectedThread.paneKey)
+    }
+  }, [
+    inactivePortalSlotId,
+    selectedHasLiveTab,
+    selectedThread,
+    stagedPortalReady,
+    stagedThread,
+    visiblePortalReady,
+    visibleThread
+  ])
+
+  // Why useLayoutEffect (not useEffect): publish must happen before paint so
+  // Terminal's portal subscriber rerenders in the same commit. With useEffect
+  // the publish runs after paint, so the user briefly sees Terminal's stale
+  // portal target on screen — the "wrong terminal flash" symptom.
+  // Why no cleanup-to-null on every change: clearing on dependency change
+  // forces the portal through a null state on every thread switch (cleanup →
+  // effect within one commit) which can flash the workspace pane behind the
+  // activity slot. We only null on unmount, via a separate effect below.
+  useLayoutEffect(() => {
+    setActivityTerminalPortals(portalDescriptors)
+  }, [portalDescriptors])
+
+  useLayoutEffect(() => {
+    return () => {
+      setActivityTerminalPortals([])
+    }
+  }, [])
 
   const markThreadRead = (thread: AgentPaneThread): void => {
     storeData.acknowledgeAgents([thread.paneKey])
@@ -782,9 +1079,7 @@ export default function ActivityPrototypePage(): React.JSX.Element {
                   move here instead of creating a second PTY/xterm owner. */}
               {(() => {
                 // Why: retained threads can outlive their tab; portal needs a live TerminalPane to render into.
-                const liveTabs = storeData.tabsByWorktree[selectedThread.worktree.id] ?? []
-                const hasLiveTab = liveTabs.some((t) => t.id === selectedThread.latestEvent.tab.id)
-                if (!hasLiveTab) {
+                if (!selectedHasLiveTab) {
                   return (
                     <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-2 p-4 text-sm text-muted-foreground">
                       <TerminalSquare className="size-7" />
@@ -793,11 +1088,43 @@ export default function ActivityPrototypePage(): React.JSX.Element {
                   )
                 }
                 return (
-                  <div
-                    ref={setActivityTerminalPortalTarget}
-                    className="relative min-h-0 flex-1 overflow-hidden bg-editor-surface"
-                    data-activity-terminal-tab-id={selectedThread.latestEvent.tab.id}
-                  />
+                  <div className="relative min-h-0 flex-1 overflow-hidden bg-editor-surface">
+                    <div
+                      ref={setPrimaryPortalTarget}
+                      className={cn(
+                        'absolute inset-0 min-h-0 min-w-0',
+                        activePortalSlotId === 'primary'
+                          ? 'z-10 opacity-100'
+                          : 'pointer-events-none z-0 opacity-0'
+                      )}
+                      aria-hidden={activePortalSlotId !== 'primary'}
+                      data-activity-terminal-slot-id="primary"
+                    />
+                    <div
+                      ref={setSecondaryPortalTarget}
+                      className={cn(
+                        'absolute inset-0 min-h-0 min-w-0',
+                        activePortalSlotId === 'secondary'
+                          ? 'z-10 opacity-100'
+                          : 'pointer-events-none z-0 opacity-0'
+                      )}
+                      aria-hidden={activePortalSlotId !== 'secondary'}
+                      data-activity-terminal-slot-id="secondary"
+                    />
+                    {visibleThread && !stagedThread && !visiblePortalReady ? (
+                      <div
+                        className="pointer-events-none absolute inset-0 z-20 bg-editor-surface"
+                        aria-hidden="true"
+                      >
+                        {showTerminalLoadingLabel ? (
+                          <div className="ml-3 mt-3 inline-flex items-center gap-2 rounded-md border border-border bg-background/85 px-2 py-1 text-xs text-muted-foreground shadow-xs">
+                            <span className="h-3 w-1.5 animate-pulse rounded-sm bg-muted-foreground/70" />
+                            <span>Connecting terminal...</span>
+                          </div>
+                        ) : null}
+                      </div>
+                    ) : null}
+                  </div>
                 )
               })()}
             </div>

--- a/src/renderer/src/components/activity/ActivityPrototypePage.tsx
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.tsx
@@ -618,15 +618,23 @@ export default function ActivityPrototypePage(): React.JSX.Element {
             <div className="flex h-full min-h-0 flex-col">
               <div className="shrink-0 border-b border-border px-4 pt-2 pb-3">
                 <div className="min-w-0">
-                  <div className="flex min-w-0 items-center gap-2">
-                    <span className="inline-flex shrink-0">
+                  <div className="flex min-w-0 items-start gap-2">
+                    <span className="inline-flex shrink-0 pt-[3px]">
                       <AgentIcon agent={agentTypeToIconAgent(selectedThread.agentType)} size={16} />
                     </span>
-                    <h2 className="truncate text-sm font-semibold">{selectedThread.paneTitle}</h2>
-                    <EventRepoBadge repo={selectedThread.repo} />
+                    {/* Why: clamp to 2 lines (matches ThreadRow) so longer
+                        prompts don't get cut to one ellipsis. Badge moves to
+                        the secondary line so it stays at a fixed position
+                        regardless of title height. */}
+                    <h2 className="line-clamp-2 break-words text-sm font-semibold leading-snug">
+                      {selectedThread.paneTitle}
+                    </h2>
                   </div>
-                  <div className="mt-1 truncate text-xs text-muted-foreground">
-                    {selectedThread.worktree.displayName}
+                  <div className="mt-1 flex min-w-0 items-center gap-1.5">
+                    <EventRepoBadge repo={selectedThread.repo} />
+                    <span className="truncate text-xs text-muted-foreground">
+                      {selectedThread.worktree.displayName}
+                    </span>
                   </div>
                 </div>
               </div>

--- a/src/renderer/src/components/activity/ActivityPrototypePage.tsx
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.tsx
@@ -761,15 +761,20 @@ export default function ActivityPrototypePage(): React.JSX.Element {
     storeData.clearWorktreeUnread(event.worktree.id)
   }
 
+  // Why (page padding): drop top padding so the worktree title row in the
+  // right pane and the WORKTREES label in the left pane sit flush with the
+  // titlebar above. The titlebar (ActivityTitlebarControls) already provides
+  // the breathing-room band; doubling it produced a visible gap above the
+  // first row.
   return (
-    <div className="flex h-full min-h-0 flex-col bg-background px-4 py-3">
+    <div className="flex h-full min-h-0 flex-col bg-background px-4 pb-3">
       <main className="flex min-h-0 flex-1 overflow-hidden">
         <aside
           ref={threadListRef}
           className="relative flex min-h-0 shrink-0 flex-col border-r border-border"
           style={{ width: threadListWidth }}
         >
-          <div className="shrink-0 border-b border-border px-2 py-2">
+          <div className="shrink-0 border-b border-border px-2 pt-1.5 pb-2">
             <div className="mb-2 flex items-center justify-between gap-2">
               <div className="text-[11px] font-semibold uppercase tracking-[0.05em] text-muted-foreground">
                 Worktrees
@@ -866,7 +871,7 @@ export default function ActivityPrototypePage(): React.JSX.Element {
           </div>
         </aside>
 
-        <section className="min-w-0 flex-1 overflow-hidden pt-2">
+        <section className="min-w-0 flex-1 overflow-hidden">
           {selectedThread ? (
             <div className="flex h-full min-h-0 flex-col">
               <div className="flex shrink-0 items-center justify-between gap-4 border-b border-border px-4 pb-3">

--- a/src/renderer/src/components/activity/ActivityPrototypePage.tsx
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.tsx
@@ -778,11 +778,12 @@ export default function ActivityPrototypePage(): React.JSX.Element {
 
   // Why (page padding): drop top padding so the worktree title row in the
   // right pane and the WORKTREES label in the left pane sit flush with the
-  // titlebar above. The titlebar (ActivityTitlebarControls) already provides
-  // the breathing-room band; doubling it produced a visible gap above the
-  // first row.
+  // titlebar above; drop *left* padding so the thread list extends to the
+  // window edge (matches how sidebars abut the chrome elsewhere). The
+  // titlebar (ActivityTitlebarControls) already provides the breathing-room
+  // band, so doubling it produced a visible gap above the first row.
   return (
-    <div className="flex h-full min-h-0 flex-col bg-background px-4 pb-3">
+    <div className="flex h-full min-h-0 flex-col bg-background pr-4 pb-3">
       <main className="flex min-h-0 flex-1 overflow-hidden">
         <aside
           ref={threadListRef}

--- a/src/renderer/src/components/activity/ActivityPrototypePage.tsx
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.tsx
@@ -266,26 +266,27 @@ function agentMeta(event: ActivityEvent): string {
   return event.state === 'waiting' ? `${agent} waiting` : `${agent} blocked`
 }
 
-// Why (label hierarchy): mirrors the per-workspace agents dropdown
-// (DashboardAgentRow / WorktreeCardAgents): user-renamed customTitle wins,
-// then a non-default terminal title (set via OSC by some agent CLIs), then
-// the agent's last prompt — the prompt IS what the agent's working on, so
-// it labels the row far better than the default "Terminal N". Falls back
-// to defaultTitle/Terminal only when nothing else is available.
+// Why (label hierarchy): mirror DashboardAgentRow — the agent's last prompt
+// IS what the agent is working on and is the primary signal users want at a
+// glance. A user-renamed customTitle still wins (explicit rename intent), but
+// the OSC-set live title ("Claude Code", "Codex", …) must NOT shadow the
+// prompt: agent CLIs set that title eagerly, so preferring it would pin every
+// row to the agent name and hide the actual turn. Fall back to a non-default
+// liveTitle only when there is no prompt at all.
 function paneTitleForEvent(event: ActivityEvent): string {
   const tab = event.tab
   const customTitle = tab.customTitle?.trim()
   if (customTitle) {
     return customTitle
   }
+  const prompt = event.entry.prompt.trim()
+  if (prompt) {
+    return prompt
+  }
   const liveTitle = tab.title?.trim()
   const defaultTitle = tab.defaultTitle?.trim()
   if (liveTitle && liveTitle !== defaultTitle) {
     return liveTitle
-  }
-  const prompt = event.entry.prompt.trim()
-  if (prompt) {
-    return prompt
   }
   return defaultTitle || liveTitle || 'Terminal'
 }

--- a/src/renderer/src/components/activity/ActivityPrototypePage.tsx
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.tsx
@@ -347,34 +347,32 @@ function AgentEventRow({
         }
       }}
       className={cn(
-        'group grid grid-cols-[2rem_minmax(0,1fr)_7.25rem] gap-3 border-b border-border px-3 cursor-pointer transition-colors hover:bg-accent/40',
+        'group relative grid grid-cols-[2rem_minmax(0,1fr)_7.25rem] gap-3 border-b border-border px-3 cursor-pointer transition-colors hover:bg-accent/40',
         compact ? 'py-2' : 'py-3.5',
         event.unread && 'bg-accent/20'
       )}
     >
+      {/* Why (left-edge bar): matches ThreadRow's unread treatment so the two
+          surfaces share one unread vocabulary. A row-level marker keeps the
+          state-icon column uncrowded — earlier attempts (mini-dot, bell glyph)
+          competed with the AgentStateDot. */}
+      {event.unread ? (
+        <span
+          className="absolute left-0 top-1.5 bottom-1.5 w-0.5 rounded-r-full bg-primary"
+          aria-hidden
+        />
+      ) : null}
       <div className="flex items-center justify-center pt-0.5">
-        <span className="relative inline-flex">
-          {/* Why (bell as unread glyph): visually rhymes with the Bell button on
-              ThreadRow so both surfaces share one unread vocabulary. Sits at
-              the icon's top-right corner with a fill-background halo so the
-              bell reads cleanly against the row's tinted unread background. */}
-          {event.unread ? (
-            <BellDot
-              className="absolute -top-1.5 -right-2 size-3.5 text-primary fill-background"
-              aria-hidden
-            />
-          ) : null}
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <span className="inline-flex">
-                <AgentStateDot state={dotState} size="lg" />
-              </span>
-            </TooltipTrigger>
-            <TooltipContent side="top" sideOffset={4}>
-              {event.entry.interrupted ? 'Interrupted' : agentStateLabel(dotState)}
-            </TooltipContent>
-          </Tooltip>
-        </span>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="inline-flex">
+              <AgentStateDot state={dotState} size="lg" />
+            </span>
+          </TooltipTrigger>
+          <TooltipContent side="top" sideOffset={4}>
+            {event.entry.interrupted ? 'Interrupted' : agentStateLabel(dotState)}
+          </TooltipContent>
+        </Tooltip>
       </div>
 
       <div className="min-w-0">
@@ -449,23 +447,20 @@ function WorktreeEventRow({
         }
       }}
       className={cn(
-        'group grid grid-cols-[2rem_minmax(0,1fr)_7.25rem] gap-3 border-b border-border px-3 cursor-pointer transition-colors hover:bg-accent/40',
+        'group relative grid grid-cols-[2rem_minmax(0,1fr)_7.25rem] gap-3 border-b border-border px-3 cursor-pointer transition-colors hover:bg-accent/40',
         compact ? 'py-2' : 'py-3.5',
         event.unread && 'bg-accent/20'
       )}
     >
+      {/* Why: see AgentEventRow — left-edge bar matches ThreadRow's unread cue. */}
+      {event.unread ? (
+        <span
+          className="absolute left-0 top-1.5 bottom-1.5 w-0.5 rounded-r-full bg-primary"
+          aria-hidden
+        />
+      ) : null}
       <div className="flex items-center justify-center pt-0.5">
-        <span className="relative inline-flex text-muted-foreground">
-          {/* Why: see AgentEventRow — bell at the icon's top-right matches the
-              unread vocabulary used on ThreadRow. */}
-          {event.unread ? (
-            <BellDot
-              className="absolute -top-1.5 -right-2 size-3.5 text-primary fill-background"
-              aria-hidden
-            />
-          ) : null}
-          <Plus className="size-[18px]" />
-        </span>
+        <Plus className="size-[18px] text-muted-foreground" />
       </div>
       <div className="min-w-0">
         <div className="flex min-w-0 items-center gap-2">

--- a/src/renderer/src/components/activity/ActivityPrototypePage.tsx
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.tsx
@@ -320,8 +320,16 @@ function AgentEventRow({
   const compact = density === 'compact'
   const dotState = asDotState(event.state)
 
-  const jumpToAgent = (clickEvent: React.MouseEvent): void => {
-    clickEvent.stopPropagation()
+  // Why (row click = navigate + ack): the inline "Jump to agent" button only
+  // rendered when agentAlive (so retained-done rows had no jump affordance at
+  // all) and in compact mode it was hover-only. Users naturally click anywhere
+  // on the row expecting it to navigate, so the row itself takes over the
+  // navigate role and subsumes the button. Per the design doc we drop the
+  // agentAlive gate entirely (option 1): activateAndRevealWorktree is safe
+  // unconditionally and activateTabAndFocusPane silently no-ops on a missing
+  // tab id, so a stale-tab click is just a soft no-op.
+  const openAgent = (clickEvent?: React.MouseEvent | React.KeyboardEvent): void => {
+    clickEvent?.stopPropagation()
     onMarkRead(event)
     activateAndRevealWorktree(event.worktree.id)
     activateTabAndFocusPane(event.tab.id, paneIdFromPaneKey(event.entry.paneKey))
@@ -329,12 +337,20 @@ function AgentEventRow({
 
   return (
     <div
+      role="button"
+      tabIndex={0}
+      onClick={openAgent}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          openAgent(e)
+        }
+      }}
       className={cn(
-        'group grid grid-cols-[2rem_minmax(0,1fr)_7.25rem] gap-3 border-b border-border px-3 transition-colors hover:bg-accent/40',
+        'group grid grid-cols-[2rem_minmax(0,1fr)_7.25rem] gap-3 border-b border-border px-3 cursor-pointer transition-colors hover:bg-accent/40',
         compact ? 'py-2' : 'py-3.5',
         event.unread && 'bg-accent/20'
       )}
-      onClick={() => onMarkRead(event)}
     >
       <div className="flex justify-center pt-1">
         <span className="relative inline-flex">
@@ -392,28 +408,10 @@ function AgentEventRow({
           </span>
           <span>{agentMeta(event)}</span>
         </div>
-        {!compact && event.agentAlive ? (
-          <div className="mt-2 flex flex-wrap gap-1.5">
-            <Button type="button" variant="outline" size="xs" onClick={jumpToAgent}>
-              Jump to agent
-            </Button>
-          </div>
-        ) : null}
       </div>
 
       <div className="flex flex-col items-end gap-2 pt-0.5">
         <EventTime timestamp={event.timestamp} />
-        {compact && event.agentAlive ? (
-          <Button
-            type="button"
-            variant="outline"
-            size="xs"
-            onClick={jumpToAgent}
-            className="opacity-0 transition-opacity group-hover:opacity-100"
-          >
-            Agent
-          </Button>
-        ) : null}
       </div>
     </div>
   )
@@ -430,14 +428,31 @@ function WorktreeEventRow({
 }): React.JSX.Element {
   const compact = density === 'compact'
 
+  // Why: mirror AgentEventRow — clicking a "Worktree created" row should
+  // navigate to that worktree (and ack the unread). The row is the click
+  // target; there's no separate jump button.
+  const openWorktree = (clickEvent?: React.MouseEvent | React.KeyboardEvent): void => {
+    clickEvent?.stopPropagation()
+    onMarkRead(event)
+    activateAndRevealWorktree(event.worktree.id)
+  }
+
   return (
     <div
+      role="button"
+      tabIndex={0}
+      onClick={openWorktree}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          openWorktree(e)
+        }
+      }}
       className={cn(
-        'group grid grid-cols-[2rem_minmax(0,1fr)_7.25rem] gap-3 border-b border-border px-3 transition-colors hover:bg-accent/40',
+        'group grid grid-cols-[2rem_minmax(0,1fr)_7.25rem] gap-3 border-b border-border px-3 cursor-pointer transition-colors hover:bg-accent/40',
         compact ? 'py-2' : 'py-3.5',
         event.unread && 'bg-accent/20'
       )}
-      onClick={() => onMarkRead(event)}
     >
       <div className="flex justify-center pt-0.5">
         <span className="relative inline-flex text-muted-foreground">

--- a/src/renderer/src/components/activity/ActivityPrototypePage.tsx
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.tsx
@@ -337,9 +337,16 @@ function AgentEventRow({
       onClick={() => onMarkRead(event)}
     >
       <div className="flex justify-center pt-1">
-        <div className="relative flex size-6 items-center justify-center">
+        <span className="relative inline-flex">
+          {/* Why: anchor the unread dot to the icon's own bounding box (not the
+              24×24 cell) so it tracks the icon's top-left corner regardless of
+              icon size. The previous absolute -left-1 top-1 inside a size-6 box
+              landed visibly off-center against the centered AgentStateDot. */}
           {event.unread ? (
-            <span className="absolute -left-1 top-1 size-2 rounded-full bg-primary" />
+            <span
+              className="absolute -top-1 -left-1 size-2 rounded-full bg-primary ring-2 ring-background"
+              aria-hidden
+            />
           ) : null}
           <Tooltip>
             <TooltipTrigger asChild>
@@ -351,7 +358,7 @@ function AgentEventRow({
               {event.entry.interrupted ? 'Interrupted' : agentStateLabel(dotState)}
             </TooltipContent>
           </Tooltip>
-        </div>
+        </span>
       </div>
 
       <div className="min-w-0">
@@ -433,12 +440,17 @@ function WorktreeEventRow({
       onClick={() => onMarkRead(event)}
     >
       <div className="flex justify-center pt-0.5">
-        <div className="relative flex size-6 items-center justify-center text-muted-foreground">
+        <span className="relative inline-flex text-muted-foreground">
+          {/* Why: see AgentEventRow — anchor the unread dot to the icon, not the
+              cell, so it lines up at the icon's top-left corner. */}
           {event.unread ? (
-            <span className="absolute -left-1 top-1 size-2 rounded-full bg-primary" />
+            <span
+              className="absolute -top-1 -left-1 size-2 rounded-full bg-primary ring-2 ring-background"
+              aria-hidden
+            />
           ) : null}
           <Plus className="size-4" />
-        </div>
+        </span>
       </div>
       <div className="min-w-0">
         <div className="flex min-w-0 items-center gap-2">

--- a/src/renderer/src/components/activity/ActivityPrototypePage.tsx
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.tsx
@@ -16,6 +16,7 @@ import {
 import { AgentIcon } from '@/lib/agent-catalog'
 import { agentTypeToIconAgent, formatAgentTypeLabel } from '@/lib/agent-status'
 import { activateTabAndFocusPane } from '@/lib/activate-tab-and-focus-pane'
+import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 import { useAppStore } from '@/store'
 import type { RetainedAgentEntry } from '@/store/slices/agent-status'
 import { getRepoMapFromState, getWorktreeMapFromState } from '@/store/selectors'
@@ -34,7 +35,7 @@ import { Input } from '@/components/ui/input'
 import { Toggle } from '@/components/ui/toggle'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
-import { ACTIVITY_TERMINAL_PORTAL_TARGET_ID } from './activity-terminal-portal'
+import { setActivityTerminalPortalTarget } from './activity-terminal-portal'
 import type { Repo, TerminalTab, Worktree } from '../../../../shared/types'
 import type {
   AgentStateHistoryEntry,
@@ -160,6 +161,9 @@ function paneTitleForEvent(event: ActivityEvent): string {
 function isActivityEventState(state: AgentStatusState): state is ActivityEventState {
   return state === 'done' || state === 'blocked' || state === 'waiting'
 }
+
+// Why: per-pane cap guarantees each agent appears in the left list even when one pane has a long history.
+const EVENTS_PER_PANE_CAP = 5
 
 function historyEntrySnapshot(
   entry: AgentStatusEntry,
@@ -309,7 +313,22 @@ export function buildActivityEvents(args: {
     })
   }
 
-  return events.sort((a, b) => b.timestamp - a.timestamp).slice(0, 80)
+  const sorted = events.sort((a, b) => b.timestamp - a.timestamp)
+  const perPaneCount = new Map<string, number>()
+  const capped: ActivityEvent[] = []
+  for (const event of sorted) {
+    const paneKey = event.entry.paneKey
+    const count = perPaneCount.get(paneKey) ?? 0
+    if (count >= EVENTS_PER_PANE_CAP) {
+      continue
+    }
+    perPaneCount.set(paneKey, count + 1)
+    capped.push(event)
+    if (capped.length >= 80) {
+      break
+    }
+  }
+  return capped
 }
 
 function buildAgentPaneThreads(events: ActivityEvent[]): AgentPaneThread[] {
@@ -543,7 +562,10 @@ export default function ActivityPrototypePage(): React.JSX.Element {
   const visibleThreads = useMemo(() => {
     const trimmedQuery = query.trim().toLowerCase()
     return allThreads.filter((thread) => {
-      if (readFilter === 'unread' && !thread.unread) {
+      // Why: keep the just-selected thread visible even after auto-mark-read
+      // flips it to read, otherwise clicking a row in unread-only mode makes it
+      // vanish from the left list while staying selected on the right.
+      if (readFilter === 'unread' && !thread.unread && thread.paneKey !== selectedPaneKey) {
         return false
       }
       if (!trimmedQuery) {
@@ -554,7 +576,7 @@ export default function ActivityPrototypePage(): React.JSX.Element {
         `${thread.paneTitle} ${thread.worktree.displayName} ${thread.repo?.displayName ?? ''} ${agentTitle(latest)} ${agentSummary(latest)} ${agentMeta(latest)}`.toLowerCase()
       return text.includes(trimmedQuery)
     })
-  }, [allThreads, readFilter, query])
+  }, [allThreads, readFilter, query, selectedPaneKey])
 
   useEffect(() => {
     if (selectedPaneKey && !allThreads.some((thread) => thread.paneKey === selectedPaneKey)) {
@@ -576,6 +598,14 @@ export default function ActivityPrototypePage(): React.JSX.Element {
 
   const activateThreadTerminal = (thread: AgentPaneThread): void => {
     const state = useAppStore.getState()
+    // Why: retained-agent threads can outlive their tab. With no live tab, the
+    // right pane shows the empty-state placeholder; reorienting the workspace
+    // and dispatching focus to a dead tab id would just confuse the user.
+    const liveTabs = state.tabsByWorktree[thread.worktree.id] ?? []
+    const hasLiveTab = liveTabs.some((t) => t.id === thread.latestEvent.tab.id)
+    if (!hasLiveTab) {
+      return
+    }
     if (state.activeRepoId !== thread.worktree.repoId) {
       state.setActiveRepo(thread.worktree.repoId)
     }
@@ -713,7 +743,7 @@ export default function ActivityPrototypePage(): React.JSX.Element {
         <section className="min-w-0 flex-1 overflow-hidden">
           {selectedThread ? (
             <div className="flex h-full min-h-0 flex-col">
-              <div className="shrink-0 border-b border-border px-4 pt-2 pb-3">
+              <div className="flex shrink-0 items-start justify-between gap-4 border-b border-border px-4 pt-2 pb-3">
                 <div className="min-w-0">
                   <div className="flex min-w-0 items-start gap-2">
                     <span className="inline-flex shrink-0 pt-[3px]">
@@ -734,15 +764,42 @@ export default function ActivityPrototypePage(): React.JSX.Element {
                     </span>
                   </div>
                 </div>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="xs"
+                  className="shrink-0"
+                  onClick={() => {
+                    markThreadRead(selectedThread)
+                    activateAndRevealWorktree(selectedThread.worktree.id)
+                  }}
+                >
+                  Jump to workspace
+                </Button>
               </div>
               {/* Why: Terminal stays mounted in the hidden workspace tree while
                   Activity is open. This target lets that existing TerminalPane
                   move here instead of creating a second PTY/xterm owner. */}
-              <div
-                id={ACTIVITY_TERMINAL_PORTAL_TARGET_ID}
-                className="relative min-h-0 flex-1 overflow-hidden bg-editor-surface"
-                data-activity-terminal-tab-id={selectedThread.latestEvent.tab.id}
-              />
+              {(() => {
+                // Why: retained threads can outlive their tab; portal needs a live TerminalPane to render into.
+                const liveTabs = storeData.tabsByWorktree[selectedThread.worktree.id] ?? []
+                const hasLiveTab = liveTabs.some((t) => t.id === selectedThread.latestEvent.tab.id)
+                if (!hasLiveTab) {
+                  return (
+                    <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-2 p-4 text-sm text-muted-foreground">
+                      <TerminalSquare className="size-7" />
+                      Agent terminal closed. Open a new terminal in this workspace to continue.
+                    </div>
+                  )
+                }
+                return (
+                  <div
+                    ref={setActivityTerminalPortalTarget}
+                    className="relative min-h-0 flex-1 overflow-hidden bg-editor-surface"
+                    data-activity-terminal-tab-id={selectedThread.latestEvent.tab.id}
+                  />
+                )
+              })()}
             </div>
           ) : (
             <div className="flex h-full min-h-[240px] flex-col items-center justify-center gap-2 text-sm text-muted-foreground">

--- a/src/renderer/src/components/activity/ActivityPrototypePage.tsx
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.tsx
@@ -37,6 +37,7 @@ import { cn } from '@/lib/utils'
 import { ACTIVITY_TERMINAL_PORTAL_TARGET_ID } from './activity-terminal-portal'
 import type { Repo, TerminalTab, Worktree } from '../../../../shared/types'
 import type {
+  AgentStateHistoryEntry,
   AgentStatusEntry,
   AgentStatusState,
   AgentType
@@ -44,10 +45,11 @@ import type {
 
 type ThreadReadFilter = 'all' | 'unread'
 type ActivityDensity = 'compact' | 'comfortable'
+type ActivityEventState = Extract<AgentStatusState, 'done' | 'blocked' | 'waiting'>
 
 type ActivityEvent = {
   id: string
-  state: Extract<AgentStatusState, 'done' | 'blocked' | 'waiting'>
+  state: ActivityEventState
   timestamp: number
   worktree: Worktree
   repo: Repo | null
@@ -155,7 +157,97 @@ function paneTitleForEvent(event: ActivityEvent): string {
   return defaultTitle || liveTitle || 'Terminal'
 }
 
-function buildActivityEvents(args: {
+function isActivityEventState(state: AgentStatusState): state is ActivityEventState {
+  return state === 'done' || state === 'blocked' || state === 'waiting'
+}
+
+function historyEntrySnapshot(
+  entry: AgentStatusEntry,
+  history: AgentStateHistoryEntry
+): AgentStatusEntry {
+  return {
+    ...entry,
+    state: history.state,
+    prompt: history.prompt,
+    updatedAt: history.startedAt,
+    stateStartedAt: history.startedAt,
+    stateHistory: [],
+    toolName: undefined,
+    toolInput: undefined,
+    lastAssistantMessage: undefined,
+    interrupted: history.interrupted
+  }
+}
+
+function appendActivityEvent(args: {
+  events: ActivityEvent[]
+  seenEventIds: Set<string>
+  state: ActivityEventState
+  timestamp: number
+  worktree: Worktree
+  repo: Repo | null
+  entry: AgentStatusEntry
+  tab: TerminalTab
+  agentType: AgentType
+  agentAlive: boolean
+  acknowledgedAt: number
+}): void {
+  const id = `agent:${args.entry.paneKey}:${args.state}:${args.timestamp}`
+  if (args.seenEventIds.has(id)) {
+    return
+  }
+  args.seenEventIds.add(id)
+  args.events.push({
+    id,
+    state: args.state,
+    timestamp: args.timestamp,
+    worktree: args.worktree,
+    repo: args.repo,
+    entry: args.entry,
+    tab: args.tab,
+    agentType: args.agentType,
+    agentAlive: args.agentAlive,
+    unread: args.acknowledgedAt < args.timestamp
+  })
+}
+
+function appendActivityEventsForEntry(args: {
+  events: ActivityEvent[]
+  seenEventIds: Set<string>
+  entry: AgentStatusEntry
+  worktree: Worktree
+  repo: Repo | null
+  tab: TerminalTab
+  agentType: AgentType
+  agentAlive: boolean
+  acknowledgedAt: number
+}): void {
+  // Why: Activity is an append-only history surface. When a user continues in
+  // the same terminal pane, the live entry moves done→working; stateHistory is
+  // the only place the previous done/blocking event still exists.
+  for (const history of args.entry.stateHistory) {
+    if (!isActivityEventState(history.state)) {
+      continue
+    }
+    appendActivityEvent({
+      ...args,
+      state: history.state,
+      timestamp: history.startedAt,
+      entry: historyEntrySnapshot(args.entry, history)
+    })
+  }
+
+  if (!isActivityEventState(args.entry.state)) {
+    return
+  }
+  appendActivityEvent({
+    ...args,
+    state: args.entry.state,
+    timestamp: args.entry.stateStartedAt
+  })
+}
+
+export function buildActivityEvents(args: {
   agentStatusByPaneKey: Record<string, AgentStatusEntry>
   retainedAgentsByPaneKey: Record<string, RetainedAgentEntry>
   tabsByWorktree: Record<string, TerminalTab[]>
@@ -164,6 +256,7 @@ function buildActivityEvents(args: {
   acknowledgedAgentsByPaneKey: Record<string, number>
 }): ActivityEvent[] {
   const events: ActivityEvent[] = []
+  const seenEventIds = new Set<string>()
   const tabContext = new Map<string, { worktree: Worktree; tab: TerminalTab }>()
 
   for (const worktree of args.worktreeMap.values()) {
@@ -174,9 +267,6 @@ function buildActivityEvents(args: {
   }
 
   for (const [paneKey, entry] of Object.entries(args.agentStatusByPaneKey)) {
-    if (entry.state !== 'done' && entry.state !== 'blocked' && entry.state !== 'waiting') {
-      continue
-    }
     const separatorIndex = paneKey.indexOf(':')
     if (separatorIndex <= 0) {
       continue
@@ -187,37 +277,35 @@ function buildActivityEvents(args: {
       continue
     }
     const ackAt = args.acknowledgedAgentsByPaneKey[paneKey] ?? 0
-    events.push({
-      id: `agent-live:${paneKey}:${entry.stateStartedAt}`,
-      state: entry.state,
-      timestamp: entry.stateStartedAt,
+    appendActivityEventsForEntry({
+      events,
+      seenEventIds,
       worktree: context.worktree,
       repo: args.repoMap.get(context.worktree.repoId) ?? null,
       entry,
       tab: context.tab,
       agentType: entry.agentType ?? 'unknown',
       agentAlive: true,
-      unread: ackAt < entry.stateStartedAt
+      acknowledgedAt: ackAt
     })
   }
 
   for (const [paneKey, retained] of Object.entries(args.retainedAgentsByPaneKey)) {
     const worktree = args.worktreeMap.get(retained.worktreeId)
-    if (!worktree || retained.entry.state !== 'done') {
+    if (!worktree) {
       continue
     }
     const ackAt = args.acknowledgedAgentsByPaneKey[paneKey] ?? 0
-    events.push({
-      id: `agent-retained:${paneKey}:${retained.entry.stateStartedAt}`,
-      state: 'done',
-      timestamp: retained.entry.stateStartedAt,
+    appendActivityEventsForEntry({
+      events,
+      seenEventIds,
       worktree,
       repo: args.repoMap.get(worktree.repoId) ?? null,
       entry: retained.entry,
       tab: retained.tab,
       agentType: retained.agentType,
       agentAlive: false,
-      unread: ackAt < retained.entry.stateStartedAt
+      acknowledgedAt: ackAt
     })
   }
 

--- a/src/renderer/src/components/activity/ActivityPrototypePage.tsx
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.tsx
@@ -9,7 +9,6 @@ import {
   BellOff,
   GitBranch,
   MessageSquareText,
-  Plus,
   Search,
   Settings
 } from 'lucide-react'
@@ -47,9 +46,8 @@ import type {
 type ThreadReadFilter = 'all' | 'unread'
 type ActivityDensity = 'compact' | 'comfortable'
 
-type AgentActivityEvent = {
+type ActivityEvent = {
   id: string
-  kind: 'agent'
   state: Extract<AgentStatusState, 'done' | 'blocked' | 'waiting'>
   timestamp: number
   worktree: Worktree
@@ -61,20 +59,15 @@ type AgentActivityEvent = {
   unread: boolean
 }
 
-type WorktreeActivityEvent = {
-  id: string
-  kind: 'worktree-created'
-  timestamp: number
+// Why (per-pane thread): the activity feed is keyed on the agent pane (a
+// terminal tab + pane id) rather than on the workspace, so the left list
+// shows one entry per agent. paneKey is the stable identity (`${tabId}:${paneId}`).
+type AgentPaneThread = {
+  paneKey: string
+  paneTitle: string
   worktree: Worktree
   repo: Repo | null
-  unread: boolean
-}
-
-type ActivityEvent = AgentActivityEvent | WorktreeActivityEvent
-
-type WorktreeThread = {
-  worktree: Worktree
-  repo: Repo | null
+  agentType: AgentType
   latestEvent: ActivityEvent
   events: ActivityEvent[]
   unread: boolean
@@ -122,14 +115,14 @@ function paneIdFromPaneKey(paneKey: string): number | null {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : null
 }
 
-function agentTitle(event: AgentActivityEvent): string {
+function agentTitle(event: ActivityEvent): string {
   if (event.state === 'done') {
     return event.entry.interrupted ? 'Agent interrupted' : 'Agent finished'
   }
   return event.state === 'waiting' ? 'Agent waiting for input' : 'Agent needs input'
 }
 
-function agentSummary(event: AgentActivityEvent): string {
+function agentSummary(event: ActivityEvent): string {
   const prompt = event.entry.prompt.trim()
   if (event.state === 'done') {
     const message = event.entry.lastAssistantMessage?.trim()
@@ -138,7 +131,7 @@ function agentSummary(event: AgentActivityEvent): string {
   return prompt || event.entry.lastAssistantMessage?.trim() || 'The agent paused for user input.'
 }
 
-function agentMeta(event: AgentActivityEvent): string {
+function agentMeta(event: ActivityEvent): string {
   const agent = formatAgentTypeLabel(event.agentType)
   if (event.state === 'done') {
     return event.entry.interrupted ? `${agent} interrupted` : `${agent} completed`
@@ -146,19 +139,8 @@ function agentMeta(event: AgentActivityEvent): string {
   return event.state === 'waiting' ? `${agent} waiting` : `${agent} blocked`
 }
 
-function eventTitle(event: ActivityEvent): string {
-  return event.kind === 'agent' ? agentTitle(event) : 'Workspace created'
-}
-
-function eventSummary(event: ActivityEvent): string {
-  return event.kind === 'agent' ? agentSummary(event) : event.worktree.displayName
-}
-
-function eventMeta(event: ActivityEvent): string {
-  if (event.kind === 'agent') {
-    return agentMeta(event)
-  }
-  return event.worktree.branch
+function paneTitleForTab(tab: TerminalTab): string {
+  return tab.customTitle?.trim() || tab.title?.trim() || tab.defaultTitle?.trim() || 'Terminal'
 }
 
 function buildActivityEvents(args: {
@@ -168,7 +150,6 @@ function buildActivityEvents(args: {
   worktreeMap: Map<string, Worktree>
   repoMap: Map<string, Repo>
   acknowledgedAgentsByPaneKey: Record<string, number>
-  locallyReadEventIds: Set<string>
 }): ActivityEvent[] {
   const events: ActivityEvent[] = []
   const tabContext = new Map<string, { worktree: Worktree; tab: TerminalTab }>()
@@ -177,17 +158,6 @@ function buildActivityEvents(args: {
     const tabs = args.tabsByWorktree[worktree.id] ?? []
     for (const tab of tabs) {
       tabContext.set(tab.id, { worktree, tab })
-    }
-    if (worktree.createdAt) {
-      const id = `worktree-created:${worktree.id}`
-      events.push({
-        id,
-        kind: 'worktree-created',
-        timestamp: worktree.createdAt,
-        worktree,
-        repo: args.repoMap.get(worktree.repoId) ?? null,
-        unread: worktree.isUnread && !args.locallyReadEventIds.has(id)
-      })
     }
   }
 
@@ -207,7 +177,6 @@ function buildActivityEvents(args: {
     const ackAt = args.acknowledgedAgentsByPaneKey[paneKey] ?? 0
     events.push({
       id: `agent-live:${paneKey}:${entry.stateStartedAt}`,
-      kind: 'agent',
       state: entry.state,
       timestamp: entry.stateStartedAt,
       worktree: context.worktree,
@@ -228,7 +197,6 @@ function buildActivityEvents(args: {
     const ackAt = args.acknowledgedAgentsByPaneKey[paneKey] ?? 0
     events.push({
       id: `agent-retained:${paneKey}:${retained.entry.stateStartedAt}`,
-      kind: 'agent',
       state: 'done',
       timestamp: retained.entry.stateStartedAt,
       worktree,
@@ -244,14 +212,18 @@ function buildActivityEvents(args: {
   return events.sort((a, b) => b.timestamp - a.timestamp).slice(0, 80)
 }
 
-function buildWorktreeThreads(events: ActivityEvent[]): WorktreeThread[] {
-  const byWorktreeId = new Map<string, WorktreeThread>()
+function buildAgentPaneThreads(events: ActivityEvent[]): AgentPaneThread[] {
+  const byPaneKey = new Map<string, AgentPaneThread>()
   for (const event of events) {
-    const existing = byWorktreeId.get(event.worktree.id)
+    const paneKey = event.entry.paneKey
+    const existing = byPaneKey.get(paneKey)
     if (!existing) {
-      byWorktreeId.set(event.worktree.id, {
+      byPaneKey.set(paneKey, {
+        paneKey,
+        paneTitle: paneTitleForTab(event.tab),
         worktree: event.worktree,
         repo: event.repo,
+        agentType: event.agentType,
         latestEvent: event,
         events: [event],
         unread: event.unread
@@ -262,13 +234,15 @@ function buildWorktreeThreads(events: ActivityEvent[]): WorktreeThread[] {
     existing.unread = existing.unread || event.unread
     if (event.timestamp > existing.latestEvent.timestamp) {
       existing.latestEvent = event
+      existing.paneTitle = paneTitleForTab(event.tab)
+      existing.agentType = event.agentType
     }
   }
 
-  return Array.from(byWorktreeId.values())
+  return Array.from(byPaneKey.values())
     .map((thread) => ({
       ...thread,
-      events: [...thread.events].sort((a, b) => a.timestamp - b.timestamp)
+      events: [...thread.events].sort((a, b) => b.timestamp - a.timestamp)
     }))
     .sort((a, b) => b.latestEvent.timestamp - a.latestEvent.timestamp)
 }
@@ -308,12 +282,12 @@ function EventRepoBadge({ repo }: { repo: Repo | null }): React.JSX.Element | nu
   )
 }
 
-function AgentEventRow({
+function ActivityRow({
   event,
   density,
   onMarkRead
 }: {
-  event: AgentActivityEvent
+  event: ActivityEvent
   density: ActivityDensity
   onMarkRead: (event: ActivityEvent) => void
 }): React.JSX.Element {
@@ -410,107 +384,6 @@ function AgentEventRow({
   )
 }
 
-function WorktreeEventRow({
-  event,
-  density,
-  onMarkRead
-}: {
-  event: WorktreeActivityEvent
-  density: ActivityDensity
-  onMarkRead: (event: ActivityEvent) => void
-}): React.JSX.Element {
-  const compact = density === 'compact'
-
-  // Why: mirror AgentEventRow — clicking a "Worktree created" row should
-  // navigate to that worktree (and ack the unread). The row is the click
-  // target; there's no separate jump button.
-  const openWorktree = (clickEvent?: React.MouseEvent | React.KeyboardEvent): void => {
-    clickEvent?.stopPropagation()
-    onMarkRead(event)
-    activateAndRevealWorktree(event.worktree.id)
-  }
-
-  return (
-    <div
-      role="button"
-      tabIndex={0}
-      onClick={openWorktree}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault()
-          openWorktree(e)
-        }
-      }}
-      className={cn(
-        'group relative grid grid-cols-[2rem_minmax(0,1fr)_7.25rem] gap-3 border-b border-border px-3 cursor-pointer transition-colors hover:bg-accent/40',
-        compact ? 'py-2' : 'py-3.5',
-        event.unread && 'bg-accent/20'
-      )}
-    >
-      {/* Why: see AgentEventRow — left-edge bar matches ThreadRow's unread cue. */}
-      {event.unread ? (
-        <span
-          className="absolute left-0 top-1.5 bottom-1.5 w-0.5 rounded-r-full bg-primary"
-          aria-hidden
-        />
-      ) : null}
-      <div className="flex items-center justify-center pt-0.5">
-        <Plus className="size-[18px] text-muted-foreground" />
-      </div>
-      <div className="min-w-0">
-        <div className="flex min-w-0 items-center gap-2">
-          <span className={cn('truncate text-sm', event.unread ? 'font-semibold' : 'font-medium')}>
-            Workspace created
-          </span>
-        </div>
-        <div className="mt-0.5 truncate text-sm text-muted-foreground">
-          {event.worktree.displayName}
-        </div>
-        <div className="mt-1.5 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-[11px] text-muted-foreground">
-          <span className="inline-flex min-w-0 items-center gap-1">
-            <GitBranch className="size-3 shrink-0" />
-            <span className="truncate">{event.worktree.branch}</span>
-          </span>
-          <span>{event.worktree.path}</span>
-        </div>
-      </div>
-      <div className="flex flex-col items-end gap-2 pt-0.5">
-        <EventTime timestamp={event.timestamp} />
-      </div>
-    </div>
-  )
-}
-
-function ActivityRow({
-  event,
-  density,
-  onMarkRead
-}: {
-  event: ActivityEvent
-  density: ActivityDensity
-  onMarkRead: (event: ActivityEvent) => void
-}): React.JSX.Element {
-  return event.kind === 'agent' ? (
-    <AgentEventRow event={event} density={density} onMarkRead={onMarkRead} />
-  ) : (
-    <WorktreeEventRow event={event} density={density} onMarkRead={onMarkRead} />
-  )
-}
-
-function groupForTimestamp(timestamp: number): 'Today' | 'Yesterday' | 'Earlier' {
-  const date = new Date(timestamp)
-  const today = new Date()
-  const startToday = new Date(today.getFullYear(), today.getMonth(), today.getDate()).getTime()
-  const startYesterday = startToday - 24 * 60 * 60 * 1000
-  if (date.getTime() >= startToday) {
-    return 'Today'
-  }
-  if (date.getTime() >= startYesterday) {
-    return 'Yesterday'
-  }
-  return 'Earlier'
-}
-
 function ThreadRow({
   thread,
   density,
@@ -518,7 +391,7 @@ function ThreadRow({
   onSelect,
   onToggleRead
 }: {
-  thread: WorktreeThread
+  thread: AgentPaneThread
   density: ActivityDensity
   selected: boolean
   onSelect: () => void
@@ -552,22 +425,27 @@ function ThreadRow({
       ) : null}
       <span className="min-w-0">
         <span className="flex min-w-0 items-center gap-2">
+          <span className="inline-flex shrink-0">
+            <AgentIcon agent={agentTypeToIconAgent(thread.agentType)} size={14} />
+          </span>
           <span
             className={cn(
               'truncate text-sm',
               thread.unread ? 'font-semibold text-foreground' : 'font-medium text-foreground'
             )}
           >
-            {thread.worktree.displayName}
+            {thread.paneTitle}
           </span>
         </span>
         <span className="mt-1 flex min-w-0 items-center gap-1.5">
           <EventRepoBadge repo={thread.repo} />
-          <span className="truncate text-xs text-muted-foreground">{eventTitle(latest)}</span>
+          <span className="truncate text-xs text-muted-foreground">
+            {thread.worktree.displayName}
+          </span>
         </span>
         {!compact ? (
           <span className="mt-1 block truncate text-xs text-muted-foreground">
-            {eventSummary(latest)}
+            {agentTitle(latest)}
           </span>
         ) : null}
       </span>
@@ -619,8 +497,7 @@ export default function ActivityPrototypePage(): React.JSX.Element {
   const [leftSidebarCompact, setLeftSidebarCompact] = useState(true)
   const leftSidebarDensity: ActivityDensity = leftSidebarCompact ? 'compact' : 'comfortable'
   const [query, setQuery] = useState('')
-  const [locallyReadEventIds, setLocallyReadEventIds] = useState<Set<string>>(() => new Set())
-  const [selectedWorktreeId, setSelectedWorktreeId] = useState<string | null>(null)
+  const [selectedPaneKey, setSelectedPaneKey] = useState<string | null>(null)
   const [threadListWidth, setThreadListWidth] = useState(340)
   const {
     containerRef: threadListRef,
@@ -644,22 +521,13 @@ export default function ActivityPrototypePage(): React.JSX.Element {
       repoMap: getRepoMapFromState(s),
       acknowledgedAgentsByPaneKey: s.acknowledgedAgentsByPaneKey,
       acknowledgeAgents: s.acknowledgeAgents,
-      unacknowledgeAgents: s.unacknowledgeAgents,
-      markWorktreeUnread: s.markWorktreeUnread,
-      clearWorktreeUnread: s.clearWorktreeUnread
+      unacknowledgeAgents: s.unacknowledgeAgents
     }))
   )
 
-  const allEvents = useMemo(
-    () =>
-      buildActivityEvents({
-        ...storeData,
-        locallyReadEventIds
-      }),
-    [storeData, locallyReadEventIds]
-  )
+  const allEvents = useMemo(() => buildActivityEvents(storeData), [storeData])
 
-  const allThreads = useMemo(() => buildWorktreeThreads(allEvents), [allEvents])
+  const allThreads = useMemo(() => buildAgentPaneThreads(allEvents), [allEvents])
 
   const visibleThreads = useMemo(() => {
     const trimmedQuery = query.trim().toLowerCase()
@@ -672,84 +540,38 @@ export default function ActivityPrototypePage(): React.JSX.Element {
       }
       const latest = thread.latestEvent
       const text =
-        `${thread.worktree.displayName} ${thread.repo?.displayName ?? ''} ${eventTitle(latest)} ${eventSummary(latest)} ${eventMeta(latest)}`.toLowerCase()
+        `${thread.paneTitle} ${thread.worktree.displayName} ${thread.repo?.displayName ?? ''} ${agentTitle(latest)} ${agentSummary(latest)} ${agentMeta(latest)}`.toLowerCase()
       return text.includes(trimmedQuery)
     })
   }, [allThreads, readFilter, query])
 
   useEffect(() => {
     if (visibleThreads.length === 0) {
-      setSelectedWorktreeId(null)
+      setSelectedPaneKey(null)
       return
     }
-    if (
-      !selectedWorktreeId ||
-      !visibleThreads.some((thread) => thread.worktree.id === selectedWorktreeId)
-    ) {
-      setSelectedWorktreeId(visibleThreads[0].worktree.id)
+    if (!selectedPaneKey || !visibleThreads.some((thread) => thread.paneKey === selectedPaneKey)) {
+      setSelectedPaneKey(visibleThreads[0].paneKey)
     }
-  }, [selectedWorktreeId, visibleThreads])
+  }, [selectedPaneKey, visibleThreads])
 
   const selectedThread =
-    visibleThreads.find((thread) => thread.worktree.id === selectedWorktreeId) ??
-    visibleThreads[0] ??
-    null
+    visibleThreads.find((thread) => thread.paneKey === selectedPaneKey) ?? visibleThreads[0] ?? null
 
-  const selectedGroupedEvents = useMemo(() => {
-    const groups: Record<'Today' | 'Yesterday' | 'Earlier', ActivityEvent[]> = {
-      Today: [],
-      Yesterday: [],
-      Earlier: []
-    }
-    if (!selectedThread) {
-      return groups
-    }
-    for (const event of selectedThread.events) {
-      groups[groupForTimestamp(event.timestamp)].push(event)
-    }
-    return groups
-  }, [selectedThread])
+  const markThreadRead = (thread: AgentPaneThread): void => {
+    storeData.acknowledgeAgents([thread.paneKey])
+  }
 
-  const selectThread = (thread: WorktreeThread): void => {
-    setSelectedWorktreeId(thread.worktree.id)
+  const markThreadUnread = (thread: AgentPaneThread): void => {
+    storeData.unacknowledgeAgents([thread.paneKey])
+  }
+
+  const selectThread = (thread: AgentPaneThread): void => {
+    setSelectedPaneKey(thread.paneKey)
     markThreadRead(thread)
   }
 
-  const markThreadRead = (thread: WorktreeThread): void => {
-    const agentPaneKeys = thread.events.flatMap((event) =>
-      event.kind === 'agent' ? [event.entry.paneKey] : []
-    )
-    storeData.acknowledgeAgents(agentPaneKeys)
-    if (thread.events.some((event) => event.kind === 'worktree-created')) {
-      storeData.clearWorktreeUnread(thread.worktree.id)
-    }
-    setLocallyReadEventIds((current) => {
-      const next = new Set(current)
-      for (const event of thread.events) {
-        next.add(event.id)
-      }
-      return next
-    })
-  }
-
-  const markThreadUnread = (thread: WorktreeThread): void => {
-    const agentPaneKeys = thread.events.flatMap((event) =>
-      event.kind === 'agent' ? [event.entry.paneKey] : []
-    )
-    storeData.unacknowledgeAgents(agentPaneKeys)
-    if (thread.events.some((event) => event.kind === 'worktree-created')) {
-      storeData.markWorktreeUnread(thread.worktree.id)
-    }
-    setLocallyReadEventIds((current) => {
-      const next = new Set(current)
-      for (const event of thread.events) {
-        next.delete(event.id)
-      }
-      return next
-    })
-  }
-
-  const toggleThreadRead = (thread: WorktreeThread): void => {
+  const toggleThreadRead = (thread: AgentPaneThread): void => {
     if (thread.unread) {
       markThreadRead(thread)
       return
@@ -758,19 +580,14 @@ export default function ActivityPrototypePage(): React.JSX.Element {
   }
 
   const markRead = (event: ActivityEvent): void => {
-    if (event.kind === 'agent') {
-      storeData.acknowledgeAgents([event.entry.paneKey])
-      return
-    }
-    setLocallyReadEventIds((current) => new Set(current).add(event.id))
-    storeData.clearWorktreeUnread(event.worktree.id)
+    storeData.acknowledgeAgents([event.entry.paneKey])
   }
 
   // Why (page padding): drop top + horizontal padding so the page extends to
   // the window's left and right edges (matching how sidebars abut the chrome
   // elsewhere). The titlebar (ActivityTitlebarControls) already provides the
   // breathing-room band above; the right pane's title row supplies its own
-  // top padding (pt-2) so the worktree heading isn't pinned to the titlebar.
+  // top padding (pt-2) so the heading isn't pinned to the titlebar.
   return (
     <div className="flex h-full min-h-0 flex-col bg-background pb-3">
       <main className="flex min-h-0 flex-1 overflow-hidden">
@@ -782,7 +599,7 @@ export default function ActivityPrototypePage(): React.JSX.Element {
           <div className="shrink-0 border-b border-border px-2 pt-1.5 pb-2">
             <div className="mb-2 flex items-center justify-between gap-2">
               <div className="text-[11px] font-semibold uppercase tracking-[0.05em] text-muted-foreground">
-                Workspaces
+                Agents
               </div>
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
@@ -843,17 +660,17 @@ export default function ActivityPrototypePage(): React.JSX.Element {
           <div className="min-h-0 flex-1 overflow-auto scrollbar-sleek">
             {visibleThreads.map((thread) => (
               <ThreadRow
-                key={thread.worktree.id}
+                key={thread.paneKey}
                 thread={thread}
                 density={leftSidebarDensity}
-                selected={thread.worktree.id === selectedThread?.worktree.id}
+                selected={thread.paneKey === selectedThread?.paneKey}
                 onSelect={() => selectThread(thread)}
                 onToggleRead={() => toggleThreadRead(thread)}
               />
             ))}
             {visibleThreads.length === 0 ? (
               <div className="px-3 py-8 text-sm text-muted-foreground">
-                No workspace threads match these filters.
+                No agent activity matches these filters.
               </div>
             ) : null}
           </div>
@@ -882,34 +699,26 @@ export default function ActivityPrototypePage(): React.JSX.Element {
               <div className="shrink-0 border-b border-border px-4 pt-2 pb-3">
                 <div className="min-w-0">
                   <div className="flex min-w-0 items-center gap-2">
-                    <h2 className="truncate text-base font-semibold">
-                      {selectedThread.worktree.displayName}
-                    </h2>
+                    <span className="inline-flex shrink-0">
+                      <AgentIcon agent={agentTypeToIconAgent(selectedThread.agentType)} size={16} />
+                    </span>
+                    <h2 className="truncate text-base font-semibold">{selectedThread.paneTitle}</h2>
                     <EventRepoBadge repo={selectedThread.repo} />
                   </div>
                   <div className="mt-1 truncate text-xs text-muted-foreground">
-                    Complete workspace history, from creation through latest agent updates
+                    {selectedThread.worktree.displayName}
                   </div>
                 </div>
               </div>
               <div className="min-h-0 flex-1 overflow-auto scrollbar-sleek">
-                {(['Today', 'Yesterday', 'Earlier'] as const).map((group) =>
-                  selectedGroupedEvents[group].length > 0 ? (
-                    <section key={group}>
-                      <div className="border-b border-border px-4 py-1.5 text-[11px] font-semibold uppercase tracking-[0.05em] text-muted-foreground">
-                        {group}
-                      </div>
-                      {[...selectedGroupedEvents[group]].reverse().map((event) => (
-                        <ActivityRow
-                          key={event.id}
-                          event={event}
-                          density="comfortable"
-                          onMarkRead={markRead}
-                        />
-                      ))}
-                    </section>
-                  ) : null
-                )}
+                {selectedThread.events.map((event) => (
+                  <ActivityRow
+                    key={event.id}
+                    event={event}
+                    density="comfortable"
+                    onMarkRead={markRead}
+                  />
+                ))}
               </div>
             </div>
           ) : (

--- a/src/renderer/src/components/activity/ActivityPrototypePage.tsx
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.tsx
@@ -569,7 +569,7 @@ function ThreadRow({
         //   tint, mirroring WorktreeCard's "weight alone" pattern. Three
         //   stacked tints (selected + unread + hover) made selected and
         //   unread look identical when hovered.
-        'group relative grid w-full grid-cols-[minmax(0,1fr)_auto] gap-2 border-b border-border px-3 py-1.5 text-left transition-colors',
+        'group relative grid w-full grid-cols-[minmax(0,1fr)_auto] gap-2 border-b border-border px-3 py-2.5 text-left transition-colors',
         selected
           ? 'bg-black/[0.08] shadow-[0_1px_2px_rgba(0,0,0,0.04)] dark:bg-white/[0.10] dark:shadow-[0_1px_2px_rgba(0,0,0,0.03)]'
           : 'hover:bg-accent/40'

--- a/src/renderer/src/components/activity/ActivityPrototypePage.tsx
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.tsx
@@ -147,7 +147,7 @@ function agentMeta(event: AgentActivityEvent): string {
 }
 
 function eventTitle(event: ActivityEvent): string {
-  return event.kind === 'agent' ? agentTitle(event) : 'Worktree created'
+  return event.kind === 'agent' ? agentTitle(event) : 'Workspace created'
 }
 
 function eventSummary(event: ActivityEvent): string {
@@ -465,7 +465,7 @@ function WorktreeEventRow({
       <div className="min-w-0">
         <div className="flex min-w-0 items-center gap-2">
           <span className={cn('truncate text-sm', event.unread ? 'font-semibold' : 'font-medium')}>
-            Worktree created
+            Workspace created
           </span>
         </div>
         <div className="mt-0.5 truncate text-sm text-muted-foreground">
@@ -771,14 +771,13 @@ export default function ActivityPrototypePage(): React.JSX.Element {
     storeData.clearWorktreeUnread(event.worktree.id)
   }
 
-  // Why (page padding): drop top padding so the worktree title row in the
-  // right pane and the WORKTREES label in the left pane sit flush with the
-  // titlebar above; drop *left* padding so the thread list extends to the
-  // window edge (matches how sidebars abut the chrome elsewhere). The
-  // titlebar (ActivityTitlebarControls) already provides the breathing-room
-  // band, so doubling it produced a visible gap above the first row.
+  // Why (page padding): drop top + horizontal padding so the page extends to
+  // the window's left and right edges (matching how sidebars abut the chrome
+  // elsewhere). The titlebar (ActivityTitlebarControls) already provides the
+  // breathing-room band above; the right pane's title row supplies its own
+  // top padding (pt-2) so the worktree heading isn't pinned to the titlebar.
   return (
-    <div className="flex h-full min-h-0 flex-col bg-background pr-4 pb-3">
+    <div className="flex h-full min-h-0 flex-col bg-background pb-3">
       <main className="flex min-h-0 flex-1 overflow-hidden">
         <aside
           ref={threadListRef}
@@ -788,7 +787,7 @@ export default function ActivityPrototypePage(): React.JSX.Element {
           <div className="shrink-0 border-b border-border px-2 pt-1.5 pb-2">
             <div className="mb-2 flex items-center justify-between gap-2">
               <div className="text-[11px] font-semibold uppercase tracking-[0.05em] text-muted-foreground">
-                Worktrees
+                Workspaces
               </div>
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
@@ -859,7 +858,7 @@ export default function ActivityPrototypePage(): React.JSX.Element {
             ))}
             {visibleThreads.length === 0 ? (
               <div className="px-3 py-8 text-sm text-muted-foreground">
-                No worktree threads match these filters.
+                No workspace threads match these filters.
               </div>
             ) : null}
           </div>
@@ -885,7 +884,7 @@ export default function ActivityPrototypePage(): React.JSX.Element {
         <section className="min-w-0 flex-1 overflow-hidden">
           {selectedThread ? (
             <div className="flex h-full min-h-0 flex-col">
-              <div className="flex shrink-0 items-center justify-between gap-4 border-b border-border px-4 pb-3">
+              <div className="flex shrink-0 items-center justify-between gap-4 border-b border-border px-4 pt-2 pb-3">
                 <div className="min-w-0">
                   <div className="flex min-w-0 items-center gap-2">
                     <h2 className="truncate text-base font-semibold">
@@ -894,7 +893,7 @@ export default function ActivityPrototypePage(): React.JSX.Element {
                     <EventRepoBadge repo={selectedThread.repo} />
                   </div>
                   <div className="mt-1 truncate text-xs text-muted-foreground">
-                    Complete worktree history, from creation through latest agent updates
+                    Complete workspace history, from creation through latest agent updates
                   </div>
                 </div>
                 <Button
@@ -906,7 +905,7 @@ export default function ActivityPrototypePage(): React.JSX.Element {
                     activateAndRevealWorktree(selectedThread.worktree.id)
                   }}
                 >
-                  Jump to worktree
+                  Jump to workspace
                 </Button>
               </div>
               <div className="min-h-0 flex-1 overflow-auto scrollbar-sleek">

--- a/src/renderer/src/components/activity/ActivityPrototypePage.tsx
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.tsx
@@ -139,8 +139,28 @@ function agentMeta(event: ActivityEvent): string {
   return event.state === 'waiting' ? `${agent} waiting` : `${agent} blocked`
 }
 
-function paneTitleForTab(tab: TerminalTab): string {
-  return tab.customTitle?.trim() || tab.title?.trim() || tab.defaultTitle?.trim() || 'Terminal'
+// Why (label hierarchy): mirrors the per-workspace agents dropdown
+// (DashboardAgentRow / WorktreeCardAgents): user-renamed customTitle wins,
+// then a non-default terminal title (set via OSC by some agent CLIs), then
+// the agent's last prompt — the prompt IS what the agent's working on, so
+// it labels the row far better than the default "Terminal N". Falls back
+// to defaultTitle/Terminal only when nothing else is available.
+function paneTitleForEvent(event: ActivityEvent): string {
+  const tab = event.tab
+  const customTitle = tab.customTitle?.trim()
+  if (customTitle) {
+    return customTitle
+  }
+  const liveTitle = tab.title?.trim()
+  const defaultTitle = tab.defaultTitle?.trim()
+  if (liveTitle && liveTitle !== defaultTitle) {
+    return liveTitle
+  }
+  const prompt = event.entry.prompt.trim()
+  if (prompt) {
+    return prompt
+  }
+  return defaultTitle || liveTitle || 'Terminal'
 }
 
 function buildActivityEvents(args: {
@@ -220,7 +240,7 @@ function buildAgentPaneThreads(events: ActivityEvent[]): AgentPaneThread[] {
     if (!existing) {
       byPaneKey.set(paneKey, {
         paneKey,
-        paneTitle: paneTitleForTab(event.tab),
+        paneTitle: paneTitleForEvent(event),
         worktree: event.worktree,
         repo: event.repo,
         agentType: event.agentType,
@@ -234,7 +254,7 @@ function buildAgentPaneThreads(events: ActivityEvent[]): AgentPaneThread[] {
     existing.unread = existing.unread || event.unread
     if (event.timestamp > existing.latestEvent.timestamp) {
       existing.latestEvent = event
-      existing.paneTitle = paneTitleForTab(event.tab)
+      existing.paneTitle = paneTitleForEvent(event)
       existing.agentType = event.agentType
     }
   }

--- a/src/renderer/src/components/activity/ActivityPrototypePage.tsx
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.tsx
@@ -352,22 +352,22 @@ function AgentEventRow({
         event.unread && 'bg-accent/20'
       )}
     >
-      <div className="flex justify-center pt-1">
+      <div className="flex items-center justify-center pt-0.5">
         <span className="relative inline-flex">
-          {/* Why: anchor the unread dot to the icon's own bounding box (not the
-              24×24 cell) so it tracks the icon's top-left corner regardless of
-              icon size. The previous absolute -left-1 top-1 inside a size-6 box
-              landed visibly off-center against the centered AgentStateDot. */}
+          {/* Why (bell as unread glyph): visually rhymes with the Bell button on
+              ThreadRow so both surfaces share one unread vocabulary. Sits at
+              the icon's top-right corner with a fill-background halo so the
+              bell reads cleanly against the row's tinted unread background. */}
           {event.unread ? (
-            <span
-              className="absolute -top-1 -left-1 size-2 rounded-full bg-primary ring-2 ring-background"
+            <BellDot
+              className="absolute -top-1.5 -right-2 size-3.5 text-primary fill-background"
               aria-hidden
             />
           ) : null}
           <Tooltip>
             <TooltipTrigger asChild>
               <span className="inline-flex">
-                <AgentStateDot state={dotState} size="md" />
+                <AgentStateDot state={dotState} size="lg" />
               </span>
             </TooltipTrigger>
             <TooltipContent side="top" sideOffset={4}>
@@ -454,17 +454,17 @@ function WorktreeEventRow({
         event.unread && 'bg-accent/20'
       )}
     >
-      <div className="flex justify-center pt-0.5">
+      <div className="flex items-center justify-center pt-0.5">
         <span className="relative inline-flex text-muted-foreground">
-          {/* Why: see AgentEventRow — anchor the unread dot to the icon, not the
-              cell, so it lines up at the icon's top-left corner. */}
+          {/* Why: see AgentEventRow — bell at the icon's top-right matches the
+              unread vocabulary used on ThreadRow. */}
           {event.unread ? (
-            <span
-              className="absolute -top-1 -left-1 size-2 rounded-full bg-primary ring-2 ring-background"
+            <BellDot
+              className="absolute -top-1.5 -right-2 size-3.5 text-primary fill-background"
               aria-hidden
             />
           ) : null}
-          <Plus className="size-4" />
+          <Plus className="size-[18px]" />
         </span>
       </div>
       <div className="min-w-0">

--- a/src/renderer/src/components/activity/ActivityTitlebarControls.tsx
+++ b/src/renderer/src/components/activity/ActivityTitlebarControls.tsx
@@ -1,34 +1,34 @@
-import { Bell } from 'lucide-react'
+import { ArrowLeft, Bell } from 'lucide-react'
 
 import { useAppStore } from '@/store'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import type { AgentStatusEntry, AgentStatusState } from '../../../../shared/agent-status-types'
 
 function useActivityUnreadCount(): number {
   return useAppStore((s) => {
     let count = 0
-    for (const worktrees of Object.values(s.worktreesByRepo)) {
-      for (const worktree of worktrees) {
-        if (worktree.createdAt && worktree.isUnread) {
+    const isUnreadState = (state: AgentStatusState): boolean =>
+      state === 'done' || state === 'blocked' || state === 'waiting'
+    // Why: Activity feed surfaces every historical done/blocked/waiting event from
+    // stateHistory plus the live state, so the badge must mirror the same walk —
+    // counting only on entry.state under-counts panes that started a new turn.
+    const accumulate = (entry: AgentStatusEntry, ackAt: number): void => {
+      for (const history of entry.stateHistory) {
+        if (isUnreadState(history.state) && ackAt < history.startedAt) {
           count += 1
         }
       }
+      if (isUnreadState(entry.state) && ackAt < entry.stateStartedAt) {
+        count += 1
+      }
     }
     for (const [paneKey, entry] of Object.entries(s.agentStatusByPaneKey)) {
-      if (entry.state !== 'done' && entry.state !== 'blocked' && entry.state !== 'waiting') {
-        continue
-      }
-      if ((s.acknowledgedAgentsByPaneKey[paneKey] ?? 0) < entry.stateStartedAt) {
-        count += 1
-      }
+      accumulate(entry, s.acknowledgedAgentsByPaneKey[paneKey] ?? 0)
     }
     for (const [paneKey, retained] of Object.entries(s.retainedAgentsByPaneKey)) {
-      if (retained.entry.state !== 'done') {
-        continue
-      }
-      if ((s.acknowledgedAgentsByPaneKey[paneKey] ?? 0) < retained.entry.stateStartedAt) {
-        count += 1
-      }
+      accumulate(retained.entry, s.acknowledgedAgentsByPaneKey[paneKey] ?? 0)
     }
     return count
   })
@@ -37,31 +37,43 @@ function useActivityUnreadCount(): number {
 export function ActivityTitlebarControls(): React.JSX.Element {
   const unreadCount = useActivityUnreadCount()
   const acknowledgeAgents = useAppStore((s) => s.acknowledgeAgents)
-  const clearWorktreeUnread = useAppStore((s) => s.clearWorktreeUnread)
+  const closeActivityPage = useAppStore((s) => s.closeActivityPage)
 
   const markAllRead = (): void => {
     const state = useAppStore.getState()
+    // Why: ack every pane (live + retained) — Date.now() exceeds all historical
+    // startedAt values, clearing the per-history-event unread flags too.
     acknowledgeAgents([
-      ...Object.values(state.agentStatusByPaneKey)
-        .filter(
-          (entry) =>
-            entry.state === 'done' || entry.state === 'blocked' || entry.state === 'waiting'
-        )
-        .map((entry) => entry.paneKey),
+      ...Object.values(state.agentStatusByPaneKey).map((entry) => entry.paneKey),
       ...Object.values(state.retainedAgentsByPaneKey).map((retained) => retained.entry.paneKey)
     ])
-    for (const worktrees of Object.values(state.worktreesByRepo)) {
-      for (const worktree of worktrees) {
-        if (worktree.createdAt && worktree.isUnread) {
-          clearWorktreeUnread(worktree.id)
-        }
-      }
-    }
   }
 
   return (
     <div className="flex h-full min-w-0 flex-1 items-center justify-between gap-3 border-l border-border px-3">
-      <div className="flex min-w-0 items-center gap-2">
+      <div
+        className="flex min-w-0 items-center gap-2"
+        style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+      >
+        {/* Why: Activity hides the worktree sidebar (full-page surface), so the
+            sidebar's nav row isn't available as the back path. This Back button
+            is the dedicated exit, mirroring Settings' onBack pattern. */}
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              onClick={closeActivityPage}
+              aria-label="Close activity"
+            >
+              <ArrowLeft className="size-3.5" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom" sideOffset={6}>
+            Close activity
+          </TooltipContent>
+        </Tooltip>
         <Bell className="size-3.5 shrink-0 text-muted-foreground" />
         <span className="truncate text-xs font-medium">Activity</span>
         <Badge variant="secondary" className="h-5 px-1.5 text-[11px] font-normal">

--- a/src/renderer/src/components/activity/activity-terminal-portal.ts
+++ b/src/renderer/src/components/activity/activity-terminal-portal.ts
@@ -1,42 +1,60 @@
 import { useLayoutEffect, useState } from 'react'
 
 export type ActivityTerminalPortalTarget = {
+  slotId: string
   target: HTMLElement
   worktreeId: string
   tabId: string
+  active: boolean
 }
 
-let currentTarget: HTMLElement | null = null
-const subscribers = new Set<(target: HTMLElement | null) => void>()
+let currentTargets: ActivityTerminalPortalTarget[] = []
+const subscribers = new Set<(targets: ActivityTerminalPortalTarget[]) => void>()
 
-// Why: replaces a body-wide MutationObserver. ActivityPrototypePage owns the
-// target div's lifecycle and publishes here on mount/unmount; Terminal
-// subscribes. Avoids global DOM observation while activity is open.
-export function setActivityTerminalPortalTarget(target: HTMLElement | null): void {
-  if (currentTarget === target) {
+// Why: the portal target is published with its {worktreeId, tabId} already
+// attached so consumers don't have to derive routing from the global
+// activeTabId/activeWorktreeId. The activity page knows which agent pane it
+// wants to display; deriving from global active state introduced a race where
+// repo/worktree updates landed before the matching setActiveTab, briefly
+// portaling a different terminal into the activity slot ("flash" of the wrong
+// terminal for a few ms).
+export function setActivityTerminalPortals(targets: ActivityTerminalPortalTarget[]): void {
+  if (currentTargets === targets) {
     return
   }
-  currentTarget = target
+  currentTargets = targets
   for (const subscriber of subscribers) {
-    subscriber(target)
+    subscriber(targets)
   }
 }
 
-export function useActivityTerminalPortalTarget(enabled: boolean): HTMLElement | null {
-  const [target, setTarget] = useState<HTMLElement | null>(enabled ? currentTarget : null)
+export function useActivityTerminalPortals(enabled: boolean): ActivityTerminalPortalTarget[] {
+  const [targets, setTargets] = useState<ActivityTerminalPortalTarget[]>(
+    enabled ? currentTargets : []
+  )
 
   useLayoutEffect(() => {
     if (!enabled) {
-      setTarget(null)
+      setTargets([])
       return
     }
-    setTarget(currentTarget)
-    const subscriber = (next: HTMLElement | null): void => setTarget(next)
+    setTargets(currentTargets)
+    const subscriber = (next: ActivityTerminalPortalTarget[]): void => setTargets(next)
     subscribers.add(subscriber)
     return () => {
       subscribers.delete(subscriber)
     }
   }, [enabled])
 
-  return target
+  return targets
+}
+
+export function findActivityTerminalPortal(
+  targets: ActivityTerminalPortalTarget[],
+  worktreeId: string,
+  tabId: string
+): ActivityTerminalPortalTarget | null {
+  return (
+    targets.find((target) => target.worktreeId === worktreeId && target.tabId === tabId) ?? null
+  )
 }

--- a/src/renderer/src/components/activity/activity-terminal-portal.ts
+++ b/src/renderer/src/components/activity/activity-terminal-portal.ts
@@ -1,48 +1,40 @@
 import { useLayoutEffect, useState } from 'react'
 
-export const ACTIVITY_TERMINAL_PORTAL_TARGET_ID = 'activity-terminal-portal-target'
-
 export type ActivityTerminalPortalTarget = {
   target: HTMLElement
   worktreeId: string
   tabId: string
 }
 
+let currentTarget: HTMLElement | null = null
+const subscribers = new Set<(target: HTMLElement | null) => void>()
+
+// Why: replaces a body-wide MutationObserver. ActivityPrototypePage owns the
+// target div's lifecycle and publishes here on mount/unmount; Terminal
+// subscribes. Avoids global DOM observation while activity is open.
+export function setActivityTerminalPortalTarget(target: HTMLElement | null): void {
+  if (currentTarget === target) {
+    return
+  }
+  currentTarget = target
+  for (const subscriber of subscribers) {
+    subscriber(target)
+  }
+}
+
 export function useActivityTerminalPortalTarget(enabled: boolean): HTMLElement | null {
-  const [target, setTarget] = useState<HTMLElement | null>(null)
+  const [target, setTarget] = useState<HTMLElement | null>(enabled ? currentTarget : null)
 
   useLayoutEffect(() => {
-    if (!enabled || typeof document === 'undefined') {
+    if (!enabled) {
       setTarget(null)
       return
     }
-
-    let animationFrame: number | null = null
-    const syncTarget = (): void => {
-      const nextTarget = document.getElementById(ACTIVITY_TERMINAL_PORTAL_TARGET_ID)
-      setTarget((currentTarget) => (currentTarget === nextTarget ? currentTarget : nextTarget))
-    }
-    const scheduleSync = (): void => {
-      if (animationFrame !== null) {
-        return
-      }
-      animationFrame = requestAnimationFrame(() => {
-        animationFrame = null
-        syncTarget()
-      })
-    }
-
-    syncTarget()
-    // Why: ActivityPrototypePage is a lazy sibling of Terminal, so the portal
-    // target can appear/disappear without Terminal itself remounting.
-    const observer = new MutationObserver(scheduleSync)
-    observer.observe(document.body, { childList: true, subtree: true })
-
+    setTarget(currentTarget)
+    const subscriber = (next: HTMLElement | null): void => setTarget(next)
+    subscribers.add(subscriber)
     return () => {
-      observer.disconnect()
-      if (animationFrame !== null) {
-        cancelAnimationFrame(animationFrame)
-      }
+      subscribers.delete(subscriber)
     }
   }, [enabled])
 

--- a/src/renderer/src/components/activity/activity-terminal-portal.ts
+++ b/src/renderer/src/components/activity/activity-terminal-portal.ts
@@ -1,0 +1,50 @@
+import { useLayoutEffect, useState } from 'react'
+
+export const ACTIVITY_TERMINAL_PORTAL_TARGET_ID = 'activity-terminal-portal-target'
+
+export type ActivityTerminalPortalTarget = {
+  target: HTMLElement
+  worktreeId: string
+  tabId: string
+}
+
+export function useActivityTerminalPortalTarget(enabled: boolean): HTMLElement | null {
+  const [target, setTarget] = useState<HTMLElement | null>(null)
+
+  useLayoutEffect(() => {
+    if (!enabled || typeof document === 'undefined') {
+      setTarget(null)
+      return
+    }
+
+    let animationFrame: number | null = null
+    const syncTarget = (): void => {
+      const nextTarget = document.getElementById(ACTIVITY_TERMINAL_PORTAL_TARGET_ID)
+      setTarget((currentTarget) => (currentTarget === nextTarget ? currentTarget : nextTarget))
+    }
+    const scheduleSync = (): void => {
+      if (animationFrame !== null) {
+        return
+      }
+      animationFrame = requestAnimationFrame(() => {
+        animationFrame = null
+        syncTarget()
+      })
+    }
+
+    syncTarget()
+    // Why: ActivityPrototypePage is a lazy sibling of Terminal, so the portal
+    // target can appear/disappear without Terminal itself remounting.
+    const observer = new MutationObserver(scheduleSync)
+    observer.observe(document.body, { childList: true, subtree: true })
+
+    return () => {
+      observer.disconnect()
+      if (animationFrame !== null) {
+        cancelAnimationFrame(animationFrame)
+      }
+    }
+  }, [enabled])
+
+  return target
+}

--- a/src/renderer/src/components/tab-group/TabGroupPanel.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.tsx
@@ -21,7 +21,10 @@ import {
   type HoveredTabInsertion,
   type TabDropZone
 } from './useTabDragSplit'
-import type { ActivityTerminalPortalTarget } from '../activity/activity-terminal-portal'
+import {
+  findActivityTerminalPortal,
+  type ActivityTerminalPortalTarget
+} from '../activity/activity-terminal-portal'
 
 const EditorPanel = lazy(() => import('../editor/EditorPanel'))
 
@@ -38,7 +41,7 @@ export default function TabGroupPanel({
   isTabDragActive = false,
   activeDropZone = null,
   hoveredTabInsertion = null,
-  activityTerminalPortal = null
+  activityTerminalPortals = []
 }: {
   groupId: string
   worktreeId: string
@@ -52,7 +55,7 @@ export default function TabGroupPanel({
   isTabDragActive?: boolean
   activeDropZone?: TabDropZone | null
   hoveredTabInsertion?: HoveredTabInsertion | null
-  activityTerminalPortal?: ActivityTerminalPortalTarget | null
+  activityTerminalPortals?: ActivityTerminalPortalTarget[]
 }): React.JSX.Element {
   const rightSidebarOpen = useAppStore((state) => state.rightSidebarOpen)
   const sidebarOpen = useAppStore((state) => state.sidebarOpen)
@@ -356,9 +359,12 @@ export default function TabGroupPanel({
         {model.groupTabs
           .filter((item) => item.contentType === 'terminal')
           .map((item) => {
-            const isActivityPortalTab =
-              activityTerminalPortal?.worktreeId === worktreeId &&
-              activityTerminalPortal.tabId === item.entityId
+            const activityTerminalPortal = findActivityTerminalPortal(
+              activityTerminalPortals,
+              worktreeId,
+              item.entityId
+            )
+            const isActivityPortalTab = activityTerminalPortal !== null
             const isActiveTerminalTab =
               isFocused && activeTab?.id === item.id && activeTab.contentType === 'terminal'
             const isVisibleTerminalTab =
@@ -369,7 +375,7 @@ export default function TabGroupPanel({
                 tabId={item.entityId}
                 worktreeId={worktreeId}
                 cwd={worktreePath}
-                isActive={isActiveTerminalTab || isActivityPortalTab}
+                isActive={isActiveTerminalTab || activityTerminalPortal?.active === true}
                 // Why: the Activity page shows the selected agent's existing
                 // terminal while the workspace group stays hidden. The portaled
                 // tab must still be visible so xterm fits against the activity
@@ -384,7 +390,7 @@ export default function TabGroupPanel({
                 onCloseTab={() => commands.closeItem(item.id)}
               />
             )
-            if (isActivityPortalTab && activityTerminalPortal) {
+            if (activityTerminalPortal) {
               return createPortal(
                 terminalPane,
                 activityTerminalPortal.target,

--- a/src/renderer/src/components/tab-group/TabGroupPanel.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.tsx
@@ -1,4 +1,5 @@
 import { lazy, Suspense, useEffect, useMemo, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { useDroppable } from '@dnd-kit/core'
 import { Columns2, Ellipsis, Rows2, X } from 'lucide-react'
 import { useAppStore } from '../../store'
@@ -20,6 +21,7 @@ import {
   type HoveredTabInsertion,
   type TabDropZone
 } from './useTabDragSplit'
+import type { ActivityTerminalPortalTarget } from '../activity/activity-terminal-portal'
 
 const EditorPanel = lazy(() => import('../editor/EditorPanel'))
 
@@ -35,7 +37,8 @@ export default function TabGroupPanel({
   reserveCollapsedSidebarHeaderSpace,
   isTabDragActive = false,
   activeDropZone = null,
-  hoveredTabInsertion = null
+  hoveredTabInsertion = null,
+  activityTerminalPortal = null
 }: {
   groupId: string
   worktreeId: string
@@ -49,6 +52,7 @@ export default function TabGroupPanel({
   isTabDragActive?: boolean
   activeDropZone?: TabDropZone | null
   hoveredTabInsertion?: HoveredTabInsertion | null
+  activityTerminalPortal?: ActivityTerminalPortalTarget | null
 }): React.JSX.Element {
   const rightSidebarOpen = useAppStore((state) => state.rightSidebarOpen)
   const sidebarOpen = useAppStore((state) => state.sidebarOpen)
@@ -351,36 +355,44 @@ export default function TabGroupPanel({
         {activeDropZone ? <TabGroupDropOverlay zone={activeDropZone} /> : null}
         {model.groupTabs
           .filter((item) => item.contentType === 'terminal')
-          .map((item) => (
-            <TerminalPane
-              key={`${item.entityId}-${runtimeTerminalTabById.get(item.entityId)?.generation ?? 0}`}
-              tabId={item.entityId}
-              worktreeId={worktreeId}
-              cwd={worktreePath}
-              isActive={
-                isFocused && activeTab?.id === item.id && activeTab.contentType === 'terminal'
-              }
-              // Why: in multi-group splits, the active terminal in each group
-              // must remain visible (display:flex) so the user sees its output,
-              // but only the focused group's terminal should receive keyboard
-              // input. Hidden worktrees stay mounted offscreen, so `isVisible`
-              // must also respect worktree visibility or those detached panes
-              // keep their WebGL renderers alive and exhaust Chromium's context
-              // budget across worktrees.
-              isVisible={
-                isWorktreeActive &&
-                activeTab?.id === item.id &&
-                activeTab.contentType === 'terminal'
-              }
-              onPtyExit={(ptyId) => {
-                if (commands.consumeSuppressedPtyExit(ptyId)) {
-                  return
-                }
-                commands.closeItem(item.id)
-              }}
-              onCloseTab={() => commands.closeItem(item.id)}
-            />
-          ))}
+          .map((item) => {
+            const isActivityPortalTab =
+              activityTerminalPortal?.worktreeId === worktreeId &&
+              activityTerminalPortal.tabId === item.entityId
+            const isActiveTerminalTab =
+              isFocused && activeTab?.id === item.id && activeTab.contentType === 'terminal'
+            const isVisibleTerminalTab =
+              isWorktreeActive && activeTab?.id === item.id && activeTab.contentType === 'terminal'
+            const terminalPane = (
+              <TerminalPane
+                key={`${item.entityId}-${runtimeTerminalTabById.get(item.entityId)?.generation ?? 0}`}
+                tabId={item.entityId}
+                worktreeId={worktreeId}
+                cwd={worktreePath}
+                isActive={isActiveTerminalTab || isActivityPortalTab}
+                // Why: the Activity page shows the selected agent's existing
+                // terminal while the workspace group stays hidden. The portaled
+                // tab must still be visible so xterm fits against the activity
+                // pane and continues foreground output scheduling.
+                isVisible={isVisibleTerminalTab || isActivityPortalTab}
+                onPtyExit={(ptyId) => {
+                  if (commands.consumeSuppressedPtyExit(ptyId)) {
+                    return
+                  }
+                  commands.closeItem(item.id)
+                }}
+                onCloseTab={() => commands.closeItem(item.id)}
+              />
+            )
+            if (isActivityPortalTab && activityTerminalPortal) {
+              return createPortal(
+                terminalPane,
+                activityTerminalPortal.target,
+                `activity-terminal-${item.entityId}`
+              )
+            }
+            return terminalPane
+          })}
 
         {activeTab &&
           activeTab.contentType !== 'terminal' &&

--- a/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
@@ -97,7 +97,7 @@ function SplitNode({
   activeDropGroupId,
   activeDropZone,
   hoveredTabInsertion,
-  activityTerminalPortal
+  activityTerminalPortals
 }: {
   node: TabGroupLayoutNode
   nodePath: string
@@ -112,7 +112,7 @@ function SplitNode({
   activeDropGroupId: string | null
   activeDropZone: TabDropZone | null
   hoveredTabInsertion: HoveredTabInsertion | null
-  activityTerminalPortal: ActivityTerminalPortalTarget | null
+  activityTerminalPortals: ActivityTerminalPortalTarget[]
 }): React.JSX.Element {
   const setTabGroupSplitRatio = useAppStore((state) => state.setTabGroupSplitRatio)
 
@@ -137,7 +137,7 @@ function SplitNode({
         hoveredTabInsertion={
           hoveredTabInsertion?.groupId === node.groupId ? hoveredTabInsertion : null
         }
-        activityTerminalPortal={activityTerminalPortal}
+        activityTerminalPortals={activityTerminalPortals}
       />
     )
   }
@@ -165,7 +165,7 @@ function SplitNode({
           activeDropGroupId={activeDropGroupId}
           activeDropZone={activeDropZone}
           hoveredTabInsertion={hoveredTabInsertion}
-          activityTerminalPortal={activityTerminalPortal}
+          activityTerminalPortals={activityTerminalPortals}
         />
       </div>
       <ResizeHandle
@@ -187,7 +187,7 @@ function SplitNode({
           activeDropGroupId={activeDropGroupId}
           activeDropZone={activeDropZone}
           hoveredTabInsertion={hoveredTabInsertion}
-          activityTerminalPortal={activityTerminalPortal}
+          activityTerminalPortals={activityTerminalPortals}
         />
       </div>
     </div>
@@ -199,13 +199,13 @@ export default function TabGroupSplitLayout({
   worktreeId,
   focusedGroupId,
   isWorktreeActive,
-  activityTerminalPortal = null
+  activityTerminalPortals = []
 }: {
   layout: TabGroupLayoutNode
   worktreeId: string
   focusedGroupId?: string
   isWorktreeActive: boolean
-  activityTerminalPortal?: ActivityTerminalPortalTarget | null
+  activityTerminalPortals?: ActivityTerminalPortalTarget[]
 }): React.JSX.Element {
   const dragSplit = useTabDragSplit({ worktreeId, enabled: isWorktreeActive })
   const hasSplits = layout.type === 'split'
@@ -262,7 +262,7 @@ export default function TabGroupSplitLayout({
             activeDropGroupId={dragSplit.hoveredDropTarget?.groupId ?? null}
             activeDropZone={dragSplit.hoveredDropTarget?.zone ?? null}
             hoveredTabInsertion={dragSplit.hoveredTabInsertion}
-            activityTerminalPortal={activityTerminalPortal}
+            activityTerminalPortals={activityTerminalPortals}
           />
         </div>
       </div>

--- a/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
@@ -5,6 +5,7 @@ import { useAppStore } from '../../store'
 import TabGroupPanel from './TabGroupPanel'
 import TabDragPreview from '../tab-bar/TabDragPreview'
 import { type HoveredTabInsertion, type TabDropZone, useTabDragSplit } from './useTabDragSplit'
+import type { ActivityTerminalPortalTarget } from '../activity/activity-terminal-portal'
 
 const MIN_RATIO = 0.15
 const MAX_RATIO = 0.85
@@ -95,7 +96,8 @@ function SplitNode({
   isTabDragActive,
   activeDropGroupId,
   activeDropZone,
-  hoveredTabInsertion
+  hoveredTabInsertion,
+  activityTerminalPortal
 }: {
   node: TabGroupLayoutNode
   nodePath: string
@@ -110,6 +112,7 @@ function SplitNode({
   activeDropGroupId: string | null
   activeDropZone: TabDropZone | null
   hoveredTabInsertion: HoveredTabInsertion | null
+  activityTerminalPortal: ActivityTerminalPortalTarget | null
 }): React.JSX.Element {
   const setTabGroupSplitRatio = useAppStore((state) => state.setTabGroupSplitRatio)
 
@@ -134,6 +137,7 @@ function SplitNode({
         hoveredTabInsertion={
           hoveredTabInsertion?.groupId === node.groupId ? hoveredTabInsertion : null
         }
+        activityTerminalPortal={activityTerminalPortal}
       />
     )
   }
@@ -161,6 +165,7 @@ function SplitNode({
           activeDropGroupId={activeDropGroupId}
           activeDropZone={activeDropZone}
           hoveredTabInsertion={hoveredTabInsertion}
+          activityTerminalPortal={activityTerminalPortal}
         />
       </div>
       <ResizeHandle
@@ -182,6 +187,7 @@ function SplitNode({
           activeDropGroupId={activeDropGroupId}
           activeDropZone={activeDropZone}
           hoveredTabInsertion={hoveredTabInsertion}
+          activityTerminalPortal={activityTerminalPortal}
         />
       </div>
     </div>
@@ -192,12 +198,14 @@ export default function TabGroupSplitLayout({
   layout,
   worktreeId,
   focusedGroupId,
-  isWorktreeActive
+  isWorktreeActive,
+  activityTerminalPortal = null
 }: {
   layout: TabGroupLayoutNode
   worktreeId: string
   focusedGroupId?: string
   isWorktreeActive: boolean
+  activityTerminalPortal?: ActivityTerminalPortalTarget | null
 }): React.JSX.Element {
   const dragSplit = useTabDragSplit({ worktreeId, enabled: isWorktreeActive })
   const hasSplits = layout.type === 'split'
@@ -254,6 +262,7 @@ export default function TabGroupSplitLayout({
             activeDropGroupId={dragSplit.hoveredDropTarget?.groupId ?? null}
             activeDropZone={dragSplit.hoveredDropTarget?.zone ?? null}
             hoveredTabInsertion={dragSplit.hoveredTabInsertion}
+            activityTerminalPortal={activityTerminalPortal}
           />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Switch the Activity page to an agent-pane list that opens the selected agent terminal in place
- Portal the existing TerminalPane into the Activity page for both split-group and legacy terminal layouts
- Keep unread/read controls and activity filtering while preserving the selected terminal when a row is marked read

## Verification
- pnpm run tc:web
- pnpm exec oxlint src/renderer/src/components/activity/activity-terminal-portal.ts src/renderer/src/components/Terminal.tsx src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx src/renderer/src/components/tab-group/TabGroupPanel.tsx src/renderer/src/components/activity/ActivityPrototypePage.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/tab-group/TabGroupSplitLayout.test.ts

## End-to-end test in a dev build
Tested in a spawned Orca dev build via CDP with three live agents (`claude`, `codex`, `claude`):
- Activity view renders one row per agent pane; clicking a row portals the existing TerminalPane into the right pane with full scrollback and prompt input intact.
- Switching between agents reuses each tab's existing PTY (no respawn) and keeps `activeView='activity'`.
- Selected terminal stays mounted when the row is marked read (single-row "Mark thread read" and header "Mark all read"), confirming the selection-preserve fix.
- Unread badge, "New" pills, bell-toggle, "Show unread threads only" filter, and the text filter all behave correctly; selected row remains visible under the unread filter even after being marked read.
- Closing activity returns to `terminal` view with the last-selected agent tab still active.
- 0 console errors across the full session.

Made with [Orca](https://github.com/stablyai/orca) 🐋