### PR TITLE
Refine Floating Terminal controls

### DIFF
--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -71,6 +71,7 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     showTasksButton: true,
     floatingTerminalEnabled: false,
     floatingTerminalCwd: '~',
+    floatingTerminalTriggerLocation: 'floating-button',
     diffDefaultView: 'inline',
     notifications: {
       enabled: true,

--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -64,6 +64,7 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     showTasksButton: true,
     floatingTerminalEnabled: false,
     floatingTerminalCwd: '~',
+    floatingTerminalTriggerLocation: 'floating-button',
     diffDefaultView: 'inline',
     notifications: {
       enabled: true,

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -195,6 +195,9 @@ function App(): React.JSX.Element {
   const canExpandPaneByTabId = useAppStore((s) => s.canExpandPaneByTabId)
   const workspaceSessionReady = useAppStore((s) => s.workspaceSessionReady)
   const floatingTerminalEnabled = useAppStore((s) => s.settings?.floatingTerminalEnabled === true)
+  const floatingTerminalTriggerLocation = useAppStore(
+    (s) => s.settings?.floatingTerminalTriggerLocation ?? 'floating-button'
+  )
 
   useEffect(() => {
     const toggleFloatingTerminal = (): void => {
@@ -1128,13 +1131,15 @@ function App(): React.JSX.Element {
               open={floatingTerminalOpen}
               onOpenChange={setFloatingTerminalOpen}
             />
-            <FloatingTerminalToggleButton
-              open={floatingTerminalOpen}
-              onToggle={() => setFloatingTerminalOpen((open) => !open)}
-            />
+            {floatingTerminalTriggerLocation === 'floating-button' ? (
+              <FloatingTerminalToggleButton
+                open={floatingTerminalOpen}
+                onToggle={() => setFloatingTerminalOpen((open) => !open)}
+              />
+            ) : null}
           </>
         ) : null}
-        <StatusBar />
+        <StatusBar floatingTerminalOpen={floatingTerminalOpen} />
         {/* Why: NewWorkspaceComposerCard renders Radix <Tooltip>s that crash
             when mounted outside a TooltipProvider ancestor. Keep the global
             composer modal inside this provider so the card renders safely

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { Maximize2, Minimize2, Pin, PinOff, TerminalSquare, X } from 'lucide-react'
+import { Maximize2, Minimize2, TerminalSquare, X } from 'lucide-react'
 import TabBar from '@/components/tab-bar/TabBar'
 import TerminalPane from '@/components/terminal-pane/TerminalPane'
 import { Button } from '@/components/ui/button'
@@ -73,7 +73,6 @@ export function FloatingTerminalPanel({
   const floatingTerminalCwd = useAppStore((s) => s.settings?.floatingTerminalCwd ?? '~')
 
   const [cwd, setCwd] = useState<string | null>(null)
-  const [pinned, setPinned] = useState(true)
   const [bounds, setBounds] = useState(() => getDefaultFloatingTerminalBounds())
   const [maximized, setMaximized] = useState(false)
   const restoreBoundsRef = useRef<FloatingTerminalPanelBounds | null>(null)
@@ -116,30 +115,6 @@ export function FloatingTerminalPanel({
     const tab = createTab(FLOATING_TERMINAL_WORKTREE_ID, undefined, undefined, { activate: false })
     setActiveTabForWorktree(FLOATING_TERMINAL_WORKTREE_ID, tab.id)
   }, [createTab, open, setActiveTabForWorktree, tabs.length])
-
-  useEffect(() => {
-    if (!open || pinned) {
-      return
-    }
-    const handlePointerDown = (event: PointerEvent): void => {
-      const target = event.target
-      if (target instanceof Node && panelRef.current?.contains(target)) {
-        return
-      }
-      if (target instanceof HTMLElement && target.closest('[data-floating-terminal-toggle]')) {
-        return
-      }
-      if (
-        target instanceof HTMLElement &&
-        target.closest('[role="menu"], [data-radix-popper-content-wrapper]')
-      ) {
-        return
-      }
-      onOpenChange(false)
-    }
-    window.addEventListener('pointerdown', handlePointerDown)
-    return () => window.removeEventListener('pointerdown', handlePointerDown)
-  }, [onOpenChange, open, pinned])
 
   const activeTab = useMemo(
     () => tabs.find((tab) => tab.id === activeTabId) ?? tabs[0] ?? null,
@@ -308,23 +283,6 @@ export function FloatingTerminalPanel({
             />
           </div>
           <div className="flex items-center gap-1 px-2" data-floating-terminal-no-drag>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon-xs"
-                  aria-label={pinned ? 'Unpin floating terminal' : 'Pin floating terminal'}
-                  aria-pressed={pinned}
-                  onClick={() => setPinned((value) => !value)}
-                >
-                  {pinned ? <PinOff className="size-3.5" /> : <Pin className="size-3.5" />}
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom" sideOffset={6}>
-                {pinned ? 'Unpin floating terminal' : 'Pin floating terminal'}
-              </TooltipContent>
-            </Tooltip>
             <Tooltip>
               <TooltipTrigger asChild>
                 <Button

--- a/src/renderer/src/components/settings/ComputerUsePane.tsx
+++ b/src/renderer/src/components/settings/ComputerUsePane.tsx
@@ -69,11 +69,20 @@ function statusClass(status: ComputerUsePermissionStatus | undefined): string {
   return 'border-border bg-muted text-muted-foreground'
 }
 
+function isExpectedDevMissingHelperError(error: unknown): boolean {
+  return (
+    import.meta.env.DEV &&
+    error instanceof Error &&
+    error.message.includes('Orca Computer Use.app was not found')
+  )
+}
+
 export function ComputerUsePane(): React.JSX.Element {
   const [platform, setPlatform] = useState<NodeJS.Platform | null>(null)
   const [states, setStates] = useState<ComputerUsePermissionState[]>([])
   const [loading, setLoading] = useState(true)
   const [pendingId, setPendingId] = useState<ComputerUsePermissionId | null>(null)
+  const [helperUnavailableInDev, setHelperUnavailableInDev] = useState(false)
 
   const stateById = useMemo(
     () => new Map(states.map((state) => [state.id, state.status] as const)),
@@ -86,7 +95,14 @@ export function ComputerUsePane(): React.JSX.Element {
       const result = await window.api.computerUsePermissions.getStatus()
       setPlatform(result.platform)
       setStates(result.permissions)
+      setHelperUnavailableInDev(false)
     } catch (error) {
+      if (isExpectedDevMissingHelperError(error)) {
+        setPlatform('darwin')
+        setStates(PERMISSIONS.map((permission) => ({ id: permission.id, status: 'not-granted' })))
+        setHelperUnavailableInDev(true)
+        return
+      }
       toast.error(
         error instanceof Error ? error.message : 'Could not load Computer Use permissions'
       )
@@ -152,6 +168,12 @@ export function ComputerUsePane(): React.JSX.Element {
                 Computer Use needs macOS privacy permissions before agents can inspect and operate
                 app windows.
               </p>
+              {helperUnavailableInDev ? (
+                <p className="text-xs text-muted-foreground">
+                  Computer Use permissions are unavailable in this dev build because the helper app
+                  has not been built.
+                </p>
+              ) : null}
             </div>
             <Button variant="outline" size="sm" className="gap-1.5" onClick={() => void refresh()}>
               <RefreshCw className={`size-3.5 ${loading ? 'animate-spin' : ''}`} />
@@ -188,7 +210,7 @@ export function ComputerUsePane(): React.JSX.Element {
                   <Button
                     variant="outline"
                     size="sm"
-                    disabled={pending || status === 'unsupported'}
+                    disabled={pending || status === 'unsupported' || helperUnavailableInDev}
                     onClick={() => void openPermission(permission.id)}
                     className="shrink-0 gap-1.5"
                   >

--- a/src/renderer/src/components/settings/TerminalPane.tsx
+++ b/src/renderer/src/components/settings/TerminalPane.tsx
@@ -2,7 +2,11 @@
    splitting individual settings into separate files would scatter related controls without a
    meaningful abstraction boundary. Mirrors the same decision made for GeneralPane.tsx. */
 import { useState } from 'react'
-import type { GlobalSettings, SetupScriptLaunchMode } from '../../../../shared/types'
+import type {
+  FloatingTerminalTriggerLocation,
+  GlobalSettings,
+  SetupScriptLaunchMode
+} from '../../../../shared/types'
 import {
   DEFAULT_TERMINAL_FONT_WEIGHT,
   TERMINAL_FONT_WEIGHT_MAX,
@@ -237,6 +241,29 @@ export function TerminalPane({
             </div>
             <p className="text-xs text-muted-foreground">
               Takes effect for new Floating Terminal tabs. Use ~ for your home directory.
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <Label>Toggle Button Location</Label>
+            <ToggleGroup
+              type="single"
+              value={settings.floatingTerminalTriggerLocation ?? 'floating-button'}
+              onValueChange={(value) => {
+                if (!value) {
+                  return
+                }
+                updateSettings({
+                  floatingTerminalTriggerLocation: value as FloatingTerminalTriggerLocation
+                })
+              }}
+              className="justify-start"
+            >
+              <ToggleGroupItem value="floating-button">Floating Button</ToggleGroupItem>
+              <ToggleGroupItem value="status-bar">Status Bar</ToggleGroupItem>
+            </ToggleGroup>
+            <p className="text-xs text-muted-foreground">
+              The keyboard shortcut works regardless of where the toggle is shown.
             </p>
           </div>
         </SearchableSetting>

--- a/src/renderer/src/components/settings/terminal-search.ts
+++ b/src/renderer/src/components/settings/terminal-search.ts
@@ -81,8 +81,17 @@ export const TERMINAL_CURSOR_SEARCH_ENTRIES: SettingsSearchEntry[] = [
 export const TERMINAL_FLOATING_SEARCH_ENTRIES: SettingsSearchEntry[] = [
   {
     title: 'Floating Terminal',
-    description: 'Enable the global floating terminal and choose where new tabs start.',
-    keywords: ['terminal', 'global', 'floating', 'quick terminal', 'launch directory']
+    description:
+      'Enable the global floating terminal, choose where new tabs start, and choose where the toggle button appears.',
+    keywords: [
+      'terminal',
+      'global',
+      'floating',
+      'quick terminal',
+      'launch directory',
+      'toggle button',
+      'status bar'
+    ]
   }
 ]
 

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -1,7 +1,15 @@
 /* eslint-disable max-lines -- Why: the status bar keeps provider rendering,
 interaction menus, and compact-layout behavior together so the hover/click
 states stay consistent across Claude and Codex. */
-import { AlertTriangle, Activity, ChevronDown, ChevronRight, RefreshCw, Server } from 'lucide-react'
+import {
+  AlertTriangle,
+  Activity,
+  ChevronDown,
+  ChevronRight,
+  RefreshCw,
+  Server,
+  TerminalSquare
+} from 'lucide-react'
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import {
@@ -28,6 +36,11 @@ import { UpdateStatusSegment } from './UpdateStatusSegment'
 import { ResourceUsageStatusSegment } from './ResourceUsageStatusSegment'
 import { isStatusBarItemAvailable } from './status-bar-agent-gating'
 import { PetStatusSegment } from './PetStatusSegment'
+import { TOGGLE_FLOATING_TERMINAL_EVENT } from '@/lib/floating-terminal'
+
+type StatusBarProps = {
+  floatingTerminalOpen: boolean
+}
 
 function getCodexAccountLabel(
   state: CodexRateLimitAccountsState,
@@ -693,11 +706,15 @@ function ProviderDetailsMenu({
 
 const CLOSE_ALL_CONTEXT_MENUS_EVENT = 'orca-close-all-context-menus'
 
-function StatusBarInner(): React.JSX.Element | null {
+function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Element | null {
   const rateLimits = useAppStore((s) => s.rateLimits)
   const refreshRateLimits = useAppStore((s) => s.refreshRateLimits)
   const statusBarVisible = useAppStore((s) => s.statusBarVisible)
   const statusBarItems = useAppStore((s) => s.statusBarItems)
+  const floatingTerminalEnabled = useAppStore((s) => s.settings?.floatingTerminalEnabled === true)
+  const floatingTerminalTriggerLocation = useAppStore(
+    (s) => s.settings?.floatingTerminalTriggerLocation ?? 'floating-button'
+  )
   // Why: usage bars exist to surface CLI rate limits — showing one for an
   // agent that isn't on the user's PATH is just noise (e.g. a fresh Ubuntu
   // install showing "Gemini Usage" with no Gemini CLI installed). We gate
@@ -799,6 +816,8 @@ function StatusBarInner(): React.JSX.Element | null {
   const showOpencodeGo = opencodeGo !== null && statusBarItems.includes('opencode-go')
   const showSsh = statusBarItems.includes('ssh')
   const showResourceUsage = statusBarItems.includes('resource-usage')
+  const showFloatingTerminalToggle =
+    floatingTerminalEnabled && floatingTerminalTriggerLocation === 'status-bar'
   const anyVisible = showClaude || showCodex || showGemini || showOpencodeGo || showResourceUsage
   const anyFetching =
     claude?.status === 'fetching' ||
@@ -808,6 +827,7 @@ function StatusBarInner(): React.JSX.Element | null {
 
   const compact = containerWidth < 900
   const iconOnly = containerWidth < 500
+  const floatingTerminalActionLabel = floatingTerminalOpen ? 'Hide Terminal' : 'Show Terminal'
 
   return (
     <div
@@ -873,6 +893,34 @@ function StatusBarInner(): React.JSX.Element | null {
       <div className="flex items-center gap-3">
         <UpdateStatusSegment compact={compact} iconOnly={iconOnly} />
         {petEnabled && <PetStatusSegment />}
+        {showFloatingTerminalToggle && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                aria-label={floatingTerminalActionLabel}
+                onClick={() => {
+                  window.dispatchEvent(new CustomEvent(TOGGLE_FLOATING_TERMINAL_EVENT))
+                }}
+              >
+                <TerminalSquare className="size-3.5" />
+                {!iconOnly && (
+                  <span className="inline-block w-[86px] whitespace-nowrap text-left">
+                    {floatingTerminalActionLabel}
+                  </span>
+                )}
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="top" sideOffset={6}>
+              {floatingTerminalActionLabel} (
+              {typeof navigator !== 'undefined' && navigator.userAgent.includes('Mac')
+                ? '⌘⌥T'
+                : 'Ctrl+Alt+T'}
+              )
+            </TooltipContent>
+          </Tooltip>
+        )}
         {showResourceUsage && <ResourceUsageStatusSegment compact={compact} iconOnly={iconOnly} />}
         {showSsh && <SshStatusSegment compact={compact} iconOnly={iconOnly} />}
       </div>

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -200,6 +200,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     showTasksButton: true,
     floatingTerminalEnabled: false,
     floatingTerminalCwd: '~',
+    floatingTerminalTriggerLocation: 'floating-button',
     notifications: getDefaultNotificationSettings(),
     diffDefaultView: 'inline',
     promptCacheTimerEnabled: false,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1180,6 +1180,9 @@ export type GlobalSettings = {
   /** Where new Floating Terminal tabs start. Defaults to '~' so the visible
    *  setting matches the shell-oriented directory users expect. */
   floatingTerminalCwd: string
+  /** Where the Floating Terminal toggle is shown. Defaults to the floating
+   *  button for discoverability after the user opts into the feature. */
+  floatingTerminalTriggerLocation: FloatingTerminalTriggerLocation
   diffDefaultView: 'inline' | 'side-by-side'
   notifications: NotificationSettings
   /** When true, a countdown timer is shown after a Claude agent becomes idle,
@@ -1434,6 +1437,7 @@ export type WorktreeCardProperty =
   | 'inline-agents'
 
 export type StatusBarItem = 'claude' | 'codex' | 'gemini' | 'opencode-go' | 'ssh' | 'resource-usage'
+export type FloatingTerminalTriggerLocation = 'floating-button' | 'status-bar'
 
 export type TaskResumeState = {
   githubMode?: 'items' | 'project'


### PR DESCRIPTION
## Summary
- add a setting to choose the Floating Terminal toggle location: floating button or status bar
- update the status bar trigger to Show/Hide Terminal with stable width
- remove the extra frontmost/pin control so the panel stays open until explicitly hidden
- suppress the expected dev-only Computer Use helper missing toast in Settings

## Validation
- pnpm typecheck
- pnpm oxlint (existing GitHub project hook warnings only)

Made with [Orca](https://github.com/stablyai/orca) 🐋
