### PR TITLE
Fix Cmd-click opening for markdown image file links

### DIFF
--- a/src/renderer/src/components/editor/MarkdownPreview.tsx
+++ b/src/renderer/src/components/editor/MarkdownPreview.tsx
@@ -26,7 +26,9 @@ import { detectLanguage } from '@/lib/language-detect'
 import type { MarkdownDocument, Worktree } from '../../../../shared/types'
 import {
   fileUrlToAbsolutePath,
+  getMarkdownPreviewImageOpenTarget,
   getMarkdownPreviewLinkTarget,
+  isMarkdownPreviewOpenModifier,
   resolveMarkdownPreviewHref
 } from './markdown-preview-links'
 import {
@@ -606,7 +608,53 @@ export default function MarkdownPreview({
         // instantiates component overrides as regular React components, so hooks
         // are valid here despite the lowercase function name.
         const resolvedSrc = useLocalImageSrc(src, filePath)
-        return <img {...props} src={resolvedSrc} alt={alt ?? ''} />
+        const handleImageClick = (event: React.MouseEvent<HTMLImageElement>): void => {
+          if (!isMarkdownPreviewOpenModifier(event, isMac)) {
+            return
+          }
+
+          const target = getMarkdownPreviewImageOpenTarget(src, filePath)
+          if (!target) {
+            return
+          }
+
+          event.preventDefault()
+          event.stopPropagation()
+
+          if (target.protocol === 'http:' || target.protocol === 'https:') {
+            void window.api.shell.openUrl(target.toString())
+            return
+          }
+
+          if (target.protocol !== 'file:') {
+            return
+          }
+
+          const absolutePath = fileUrlToAbsolutePath(target)
+          if (!absolutePath) {
+            return
+          }
+
+          const targetWorktree = findWorktreeForMarkdownPreviewPath(worktreesByRepo, absolutePath)
+          if (!targetWorktree) {
+            void window.api.shell.openFileUri(target.toString())
+            return
+          }
+
+          const relativePath = absolutePath.slice(targetWorktree.path.length + 1)
+          openFile({
+            filePath: absolutePath,
+            relativePath,
+            worktreeId: targetWorktree.id,
+            language: detectLanguage(absolutePath),
+            mode: 'edit'
+          })
+        }
+
+        // Why: display uses IPC-backed blob URLs, but Cmd/Ctrl-click should open
+        // the original markdown target so local and SSH worktree images route
+        // through the same editor path as normal file links.
+        return <img {...props} src={resolvedSrc} alt={alt ?? ''} onClick={handleImageClick} />
       },
       // Why: Intercept code elements to detect mermaid fenced blocks. rehype-highlight
       // sets className="language-mermaid" on the <code> inside <pre> for ```mermaid blocks.

--- a/src/renderer/src/components/editor/RichMarkdownEditor.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownEditor.tsx
@@ -317,6 +317,14 @@ export default function RichMarkdownEditor({
         // Why: doc links are atom nodes (not marks), so resolve(pos).marks()
         // won't find them. Check nodeAt(pos) first for doc link navigation.
         const clickedNode = view.state.doc.nodeAt(pos)
+        if (clickedNode?.type.name === 'image') {
+          const src = (clickedNode.attrs.src as string | undefined) ?? ''
+          if (!src) {
+            return false
+          }
+          void activateMarkdownLink(src, { sourceFilePath: filePath, worktreeId, worktreeRoot })
+          return true
+        }
         if (clickedNode?.type.name === 'markdownDocLink') {
           const target = clickedNode.attrs.target as string
           if (target && onOpenDocLinkRef.current) {

--- a/src/renderer/src/components/editor/markdown-internal-links.test.ts
+++ b/src/renderer/src/components/editor/markdown-internal-links.test.ts
@@ -72,7 +72,31 @@ describe('resolveMarkdownLinkTarget', () => {
 
   it('classifies non-markdown local file as file', () => {
     const r = resolveMarkdownLinkTarget('./image.png', SOURCE, ROOT)
-    expect(r?.kind).toBe('file')
+    expect(r).toMatchObject({
+      kind: 'file',
+      absolutePath: '/repo/docs/image.png',
+      relativePath: 'docs/image.png'
+    })
+  })
+
+  it('classifies explicit file URLs inside the worktree with a relative path', () => {
+    const r = resolveMarkdownLinkTarget('file:///repo/docs/image.png', SOURCE, ROOT)
+    expect(r).toMatchObject({
+      kind: 'file',
+      uri: 'file:///repo/docs/image.png',
+      absolutePath: '/repo/docs/image.png',
+      relativePath: 'docs/image.png'
+    })
+  })
+
+  it('classifies explicit file URLs outside the worktree without a relative path', () => {
+    const r = resolveMarkdownLinkTarget('file:///tmp/image.png', SOURCE, ROOT)
+    expect(r).toMatchObject({
+      kind: 'file',
+      uri: 'file:///tmp/image.png',
+      absolutePath: '/tmp/image.png',
+      relativePath: undefined
+    })
   })
 
   it('never returns markdown when worktreeRoot is null', () => {

--- a/src/renderer/src/components/editor/markdown-internal-links.ts
+++ b/src/renderer/src/components/editor/markdown-internal-links.ts
@@ -15,7 +15,7 @@ export type MarkdownLinkTarget =
       line?: number
       column?: number
     }
-  | { kind: 'file'; uri: string }
+  | { kind: 'file'; uri: string; absolutePath: string; relativePath?: string }
 
 // Why: renderer runs with sandbox + contextIsolation, so process.platform is
 // unavailable. navigator.userAgent is the portable fallback (AGENTS.md).
@@ -200,12 +200,18 @@ export function resolveMarkdownLinkTarget(
     }
   }
 
+  const relativePath =
+    worktreeRoot !== null && isDescendantOf(pathForClassification, worktreeRoot)
+      ? computeRelativePath(pathForClassification, worktreeRoot)
+      : undefined
+
   // Rebuild a file: URI without the line anchor so the OS handler gets a
   // clean path. Use the original resolved URL minus the hash as an
   // approximation; for trailing-colon paths there's no clean URL form,
   // so we reconstruct from the stripped absolute path.
+  const cleanUri = line === undefined ? resolved.toString() : toFileUrl(pathForClassification)
   if (line === undefined) {
-    return { kind: 'file', uri: resolved.toString() }
+    return { kind: 'file', uri: cleanUri, absolutePath: pathForClassification, relativePath }
   }
-  return { kind: 'file', uri: toFileUrl(pathForClassification) }
+  return { kind: 'file', uri: cleanUri, absolutePath: pathForClassification, relativePath }
 }

--- a/src/renderer/src/components/editor/markdown-preview-links.test.ts
+++ b/src/renderer/src/components/editor/markdown-preview-links.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest'
 import {
   fileUrlToAbsolutePath,
   getMarkdownPreviewImageSrc,
+  getMarkdownPreviewImageOpenTarget,
   getMarkdownPreviewLinkTarget,
+  isMarkdownPreviewOpenModifier,
   resolveMarkdownPreviewHref,
   resolveImageAbsolutePath
 } from './markdown-preview-links'
@@ -50,6 +52,39 @@ describe('getMarkdownPreviewImageSrc', () => {
     expect(getMarkdownPreviewImageSrc('data:image/png;base64,abc', '/repo/docs/README.md')).toBe(
       'data:image/png;base64,abc'
     )
+  })
+})
+
+describe('getMarkdownPreviewImageOpenTarget', () => {
+  it('resolves a relative image src to a file URL for opening', () => {
+    expect(
+      getMarkdownPreviewImageOpenTarget('../assets/diagram.png', '/repo/docs/guides/README.md')
+        ?.href
+    ).toBe('file:///repo/docs/assets/diagram.png')
+  })
+
+  it('preserves external image URLs for opening', () => {
+    expect(
+      getMarkdownPreviewImageOpenTarget('https://example.com/img.png', '/repo/README.md')?.href
+    ).toBe('https://example.com/img.png')
+  })
+
+  it('does not open data image URLs', () => {
+    expect(
+      getMarkdownPreviewImageOpenTarget('data:image/png;base64,abc', '/repo/README.md')
+    ).toBeNull()
+  })
+})
+
+describe('isMarkdownPreviewOpenModifier', () => {
+  it('uses Cmd on macOS', () => {
+    expect(isMarkdownPreviewOpenModifier({ metaKey: true, ctrlKey: false }, true)).toBe(true)
+    expect(isMarkdownPreviewOpenModifier({ metaKey: false, ctrlKey: true }, true)).toBe(false)
+  })
+
+  it('uses Ctrl on non-macOS platforms', () => {
+    expect(isMarkdownPreviewOpenModifier({ metaKey: false, ctrlKey: true }, false)).toBe(true)
+    expect(isMarkdownPreviewOpenModifier({ metaKey: true, ctrlKey: false }, false)).toBe(false)
   })
 })
 

--- a/src/renderer/src/components/editor/markdown-preview-links.ts
+++ b/src/renderer/src/components/editor/markdown-preview-links.ts
@@ -74,6 +74,37 @@ export function getMarkdownPreviewImageSrc(
   return rawSrc
 }
 
+export function getMarkdownPreviewImageOpenTarget(
+  rawSrc: string | undefined,
+  filePath: string
+): URL | null {
+  if (!rawSrc) {
+    return null
+  }
+
+  const resolved = resolveMarkdownPreviewHref(rawSrc, filePath)
+  if (!resolved) {
+    return null
+  }
+
+  if (
+    resolved.protocol === 'http:' ||
+    resolved.protocol === 'https:' ||
+    resolved.protocol === 'file:'
+  ) {
+    return resolved
+  }
+
+  return null
+}
+
+export function isMarkdownPreviewOpenModifier(
+  event: Pick<MouseEvent, 'metaKey' | 'ctrlKey'>,
+  isMac: boolean
+): boolean {
+  return isMac ? event.metaKey && !event.ctrlKey : event.ctrlKey && !event.metaKey
+}
+
 /**
  * Resolves a relative image src against the markdown file path to produce an
  * absolute filesystem path. Returns null for external URLs (http, https, data,

--- a/src/renderer/src/store/slices/editor.test.ts
+++ b/src/renderer/src/store/slices/editor.test.ts
@@ -1114,14 +1114,50 @@ describe('createEditorSlice activateMarkdownLink', () => {
     expect(store.getState().openFiles).toEqual([])
   })
 
-  it('delegates outside-worktree files to shell.openFileUri', async () => {
+  it('opens in-worktree file links in Orca', async () => {
     const store = createEditorStore()
     await store.getState().activateMarkdownLink('./image.png', {
       sourceFilePath: '/repo/docs/note.md',
       worktreeId: 'wt-1',
       worktreeRoot: '/repo'
     })
-    expect(openFileUriMock).toHaveBeenCalledTimes(1)
+    expect(store.getState().openFiles).toEqual([
+      expect.objectContaining({
+        filePath: '/repo/docs/image.png',
+        relativePath: 'docs/image.png',
+        mode: 'edit',
+        isPreview: true
+      })
+    ])
+    expect(openFileUriMock).not.toHaveBeenCalled()
+  })
+
+  it('opens explicit file URLs inside the worktree in Orca', async () => {
+    const store = createEditorStore()
+    await store.getState().activateMarkdownLink('file:///repo/docs/image.png', {
+      sourceFilePath: '/repo/docs/note.md',
+      worktreeId: 'wt-1',
+      worktreeRoot: '/repo'
+    })
+    expect(store.getState().openFiles).toEqual([
+      expect.objectContaining({
+        filePath: '/repo/docs/image.png',
+        relativePath: 'docs/image.png',
+        mode: 'edit',
+        isPreview: true
+      })
+    ])
+    expect(openFileUriMock).not.toHaveBeenCalled()
+  })
+
+  it('delegates outside-worktree files to shell.openFileUri', async () => {
+    const store = createEditorStore()
+    await store.getState().activateMarkdownLink('file:///tmp/image.png', {
+      sourceFilePath: '/repo/docs/note.md',
+      worktreeId: 'wt-1',
+      worktreeRoot: '/repo'
+    })
+    expect(openFileUriMock).toHaveBeenCalledWith('file:///tmp/image.png')
     expect(store.getState().openFiles).toEqual([])
   })
 

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -5,6 +5,7 @@ import { joinPath } from '@/lib/path'
 import { toast } from 'sonner'
 import { resolveMarkdownLinkTarget } from '@/components/editor/markdown-internal-links'
 import { openHttpLink } from '@/lib/http-link-routing'
+import { detectLanguage } from '@/lib/language-detect'
 import type {
   GitBranchChangeEntry,
   GitBranchCompareSummary,
@@ -2130,6 +2131,25 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
       return
     }
     if (target.kind === 'file') {
+      if (target.relativePath !== undefined) {
+        // Why: explicit file:// links inside the active worktree should behave
+        // like relative file links and open in Orca, including image files.
+        get().openFile(
+          {
+            filePath: target.absolutePath,
+            relativePath: target.relativePath,
+            worktreeId: ctx.worktreeId,
+            language: detectLanguage(target.absolutePath),
+            mode: 'edit'
+          },
+          {
+            preview: true,
+            targetGroupId: get().activeGroupIdByWorktree?.[ctx.worktreeId],
+            recordReplacedPreview: true
+          }
+        )
+        return
+      }
       void window.api.shell.openFileUri(target.uri)
       return
     }


### PR DESCRIPTION
## Summary
- Open rendered markdown preview images on Cmd/Ctrl-click using the original markdown image target instead of the display blob URL.
- Route in-worktree `file://` and relative non-markdown links through Orca tabs, so images open in Orca instead of the OS default app.
- Add rich markdown image Cmd/Ctrl-click support and extend link classification tests for explicit `file://` paths.

## Correctness report
- The shared markdown link classifier now returns file targets with an absolute path plus an optional worktree-relative path. The editor store uses that relative path as the signal that Orca owns the file and opens it via `openFile`; outside-worktree `file://` links still fall back to `shell.openFileUri`.
- Markdown files keep their existing special handling: in-worktree `.md`/`.mdx`/`.markdown` targets still open as markdown preview/source tabs, with line anchors preserved.
- Preview images resolve click targets from the raw markdown `src`, not from IPC-created blob URLs, so Cmd/Ctrl-click opens the intended local or external image.
- Rich markdown image nodes now dispatch through the same `activateMarkdownLink` path, keeping rich and preview behavior aligned.
- Platform modifier handling uses Cmd on macOS and Ctrl on Linux/Windows.

## Verification
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/editor/markdown-preview-links.test.ts src/renderer/src/components/editor/markdown-internal-links.test.ts src/renderer/src/store/slices/editor.test.ts`
- `pnpm typecheck`
- `pnpm lint` (passes with existing warnings in GitHub project files unrelated to this PR)
- `git diff --check`