### PR TITLE
Add multi-select worktree actions

### DIFF
--- a/src/renderer/src/components/sidebar/DeleteWorktreeDialog.tsx
+++ b/src/renderer/src/components/sidebar/DeleteWorktreeDialog.tsx
@@ -26,10 +26,26 @@ const DeleteWorktreeDialog = React.memo(function DeleteWorktreeDialog() {
 
   const isOpen = activeModal === 'delete-worktree'
   const worktreeId = typeof modalData.worktreeId === 'string' ? modalData.worktreeId : ''
+  const worktreeIds = useMemo(
+    () =>
+      Array.isArray(modalData.worktreeIds)
+        ? modalData.worktreeIds.filter((id): id is string => typeof id === 'string')
+        : worktreeId
+          ? [worktreeId]
+          : [],
+    [modalData.worktreeIds, worktreeId]
+  )
   const worktree = useMemo(
     () => (worktreeId ? (allWorktrees().find((item) => item.id === worktreeId) ?? null) : null),
     [allWorktrees, worktreeId]
   )
+  const worktrees = useMemo(() => {
+    if (worktreeIds.length === 0) {
+      return []
+    }
+    const selected = new Set(worktreeIds)
+    return allWorktrees().filter((item) => selected.has(item.id))
+  }, [allWorktrees, worktreeIds])
   const deleteState = useAppStore((s) =>
     worktreeId ? s.deleteStateByWorktreeId[worktreeId] : undefined
   )
@@ -37,11 +53,11 @@ const DeleteWorktreeDialog = React.memo(function DeleteWorktreeDialog() {
   const deleteError = deleteState?.error ?? null
   const canForceDelete = deleteState?.canForceDelete ?? false
   const confirmButtonRef = useRef<HTMLButtonElement>(null)
-  const worktreeName = worktree?.displayName ?? 'unknown'
+  const isBatchDelete = worktreeIds.length > 1
   // Why: the main worktree is the repo's original clone directory — `git worktree remove`
   // always rejects it. We block the delete button upfront so the user doesn't have to
   // discover this limitation via a confusing force-delete dead-end.
-  const isMainWorktree = worktree?.isMainWorktree ?? false
+  const isMainWorktree = !isBatchDelete && (worktree?.isMainWorktree ?? false)
   const [dontAskAgain, setDontAskAgain] = useState(false)
 
   // Why: the checkbox is a one-shot intent captured inside the dialog — when
@@ -55,11 +71,19 @@ const DeleteWorktreeDialog = React.memo(function DeleteWorktreeDialog() {
   }, [isOpen])
 
   useEffect(() => {
-    if (isOpen && worktreeId && !worktree && !isDeleting) {
+    if (isOpen && worktreeIds.length > 0 && worktrees.length === 0 && !isDeleting) {
       clearWorktreeDeleteState(worktreeId)
       closeModal()
     }
-  }, [clearWorktreeDeleteState, closeModal, isDeleting, isOpen, worktree, worktreeId])
+  }, [
+    clearWorktreeDeleteState,
+    closeModal,
+    isDeleting,
+    isOpen,
+    worktreeId,
+    worktreeIds.length,
+    worktrees.length
+  ])
 
   const handleOpenChange = useCallback(
     (open: boolean) => {
@@ -101,7 +125,7 @@ const DeleteWorktreeDialog = React.memo(function DeleteWorktreeDialog() {
 
   const handleDelete = useCallback(
     (force = false) => {
-      if (!worktreeId) {
+      if (worktreeIds.length === 0) {
         return
       }
       // Why: force-delete is a recovery path taken after a failed first delete.
@@ -130,7 +154,9 @@ const DeleteWorktreeDialog = React.memo(function DeleteWorktreeDialog() {
             })
           })
       } else {
-        runWorktreeDeleteWithToast(worktreeId, worktreeName)
+        for (const target of worktrees) {
+          runWorktreeDeleteWithToast(target.id, target.displayName)
+        }
       }
       closeModal()
     },
@@ -139,8 +165,9 @@ const DeleteWorktreeDialog = React.memo(function DeleteWorktreeDialog() {
       dontAskAgain,
       persistDontAskAgainPreference,
       removeWorktree,
+      worktreeIds.length,
       worktreeId,
-      worktreeName
+      worktrees
     ]
   )
 
@@ -162,20 +189,43 @@ const DeleteWorktreeDialog = React.memo(function DeleteWorktreeDialog() {
         }}
       >
         <DialogHeader>
-          <DialogTitle className="text-sm">Delete Worktree</DialogTitle>
+          <DialogTitle className="text-sm">
+            {isBatchDelete ? 'Delete Worktrees' : 'Delete Worktree'}
+          </DialogTitle>
           <DialogDescription className="text-xs">
-            Remove{' '}
-            <span className="break-all font-medium text-foreground">{worktree?.displayName}</span>{' '}
-            from git and delete its working tree folder.
+            {isBatchDelete ? (
+              <>
+                Remove{' '}
+                <span className="font-medium text-foreground">{worktrees.length} worktrees</span>{' '}
+                from git and delete their working tree folders.
+              </>
+            ) : (
+              <>
+                Remove{' '}
+                <span className="break-all font-medium text-foreground">
+                  {worktree?.displayName}
+                </span>{' '}
+                from git and delete its working tree folder.
+              </>
+            )}
           </DialogDescription>
         </DialogHeader>
 
-        {worktree && (
+        {isBatchDelete ? (
+          <div className="max-h-48 space-y-1 overflow-y-auto rounded-md border border-border/70 bg-muted/35 px-3 py-2 text-xs">
+            {worktrees.map((item) => (
+              <div key={item.id} className="min-w-0 border-b border-border/50 py-1 last:border-0">
+                <div className="break-all font-medium text-foreground">{item.displayName}</div>
+                <div className="mt-0.5 break-all text-muted-foreground">{item.path}</div>
+              </div>
+            ))}
+          </div>
+        ) : worktree ? (
           <div className="rounded-md border border-border/70 bg-muted/35 px-3 py-2 text-xs">
             <div className="break-all font-medium text-foreground">{worktree.displayName}</div>
             <div className="mt-1 break-all text-muted-foreground">{worktree.path}</div>
           </div>
-        )}
+        ) : null}
 
         {isMainWorktree && (
           <div className="rounded-md border border-blue-500/40 bg-blue-500/8 px-3 py-2 text-xs text-blue-700 dark:text-blue-300">
@@ -245,7 +295,7 @@ const DeleteWorktreeDialog = React.memo(function DeleteWorktreeDialog() {
                 disabled={isDeleting}
               >
                 {isDeleting ? <LoaderCircle className="size-4 animate-spin" /> : <Trash2 />}
-                {isDeleting ? 'Deleting…' : 'Delete'}
+                {isDeleting ? 'Deleting…' : isBatchDelete ? `Delete ${worktrees.length}` : 'Delete'}
               </Button>
             ))}
         </DialogFooter>

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -48,7 +48,11 @@ type WorktreeCardProps = {
   worktree: Worktree
   repo: Repo | undefined
   isActive: boolean
+  isMultiSelected?: boolean
+  selectedWorktrees?: readonly Worktree[]
   hideRepoBadge?: boolean
+  onSelectionGesture?: (event: React.MouseEvent<HTMLDivElement>, worktreeId: string) => boolean
+  onContextMenuSelect?: (event: React.MouseEvent<HTMLDivElement>) => readonly Worktree[]
 }
 
 function formatSparseDirectoryPreview(directories: string[]): string {
@@ -60,6 +64,10 @@ const WorktreeCard = React.memo(function WorktreeCard({
   worktree,
   repo,
   isActive,
+  isMultiSelected = false,
+  selectedWorktrees,
+  onSelectionGesture,
+  onContextMenuSelect,
   hideRepoBadge
 }: WorktreeCardProps) {
   const openModal = useAppStore((s) => s.openModal)
@@ -339,6 +347,12 @@ const WorktreeCard = React.memo(function WorktreeCard({
           return
         }
       }
+      const selectionOnly = onSelectionGesture?.(event, worktree.id) ?? false
+      if (selectionOnly) {
+        event.preventDefault()
+        event.stopPropagation()
+        return
+      }
       // Why: route sidebar clicks through the shared activation path so the
       // back/forward stack stays complete for the primary worktree navigation
       // surface instead of only recording palette-driven switches.
@@ -347,7 +361,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
         setShowDisconnectedDialog(true)
       }
     },
-    [worktree.id, isSshDisconnected]
+    [worktree.id, isSshDisconnected, onSelectionGesture]
   )
 
   const handleDoubleClick = useCallback(() => {
@@ -378,10 +392,14 @@ const WorktreeCard = React.memo(function WorktreeCard({
   const cardBody = (
     <div
       className={cn(
-        'group relative flex items-start gap-1.5 px-2 py-2 rounded-lg cursor-pointer transition-all duration-200 outline-none select-none ml-1',
+        'group relative flex items-start gap-1.5 px-2 py-2 cursor-pointer transition-all duration-200 outline-none select-none ml-1',
+        isMultiSelected ? 'rounded-sm' : 'rounded-lg',
         isActive
           ? 'bg-black/[0.08] shadow-[0_1px_2px_rgba(0,0,0,0.04)] border border-black/[0.015] dark:bg-white/[0.10] dark:border-border/40 dark:shadow-[0_1px_2px_rgba(0,0,0,0.03)]'
-          : 'border border-transparent hover:bg-accent/40',
+          : isMultiSelected
+            ? 'border border-sidebar-ring/35 bg-sidebar-accent/70 ring-1 ring-sidebar-ring/30'
+            : 'border border-transparent hover:bg-sidebar-accent/40',
+        isActive && isMultiSelected && 'ring-1 ring-sidebar-ring/35',
         isDeleting && 'opacity-50 grayscale cursor-not-allowed',
         isSshDisconnected && !isDeleting && 'opacity-60'
       )}
@@ -624,7 +642,13 @@ const WorktreeCard = React.memo(function WorktreeCard({
 
   return (
     <>
-      <WorktreeContextMenu worktree={worktree}>{cardBody}</WorktreeContextMenu>
+      <WorktreeContextMenu
+        worktree={worktree}
+        selectedWorktrees={selectedWorktrees}
+        onContextMenuSelect={onContextMenuSelect}
+      >
+        {cardBody}
+      </WorktreeContextMenu>
 
       {repo?.connectionId && (
         <SshDisconnectedDialog

--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -21,17 +21,19 @@ import {
   Trash2
 } from 'lucide-react'
 import { useAppStore } from '@/store'
-import { useRepoById } from '@/store/selectors'
+import { useRepoById, useRepoMap } from '@/store/selectors'
 import { cn } from '@/lib/utils'
 import type { Worktree } from '../../../../shared/types'
 import { isFolderRepo } from '../../../../shared/repo-kind'
-import { runWorktreeDelete } from './delete-worktree-flow'
-import { runSleepWorktree } from './sleep-worktree-flow'
+import { runWorktreeBatchDelete, runWorktreeDelete } from './delete-worktree-flow'
+import { runSleepWorktrees } from './sleep-worktree-flow'
 
 type Props = {
   worktree: Worktree
   children: React.ReactNode
   contentClassName?: string
+  selectedWorktrees?: readonly Worktree[]
+  onContextMenuSelect?: (event: React.MouseEvent<HTMLDivElement>) => readonly Worktree[]
 }
 
 const CLOSE_ALL_CONTEXT_MENUS_EVENT = 'orca-close-all-context-menus'
@@ -39,7 +41,9 @@ const CLOSE_ALL_CONTEXT_MENUS_EVENT = 'orca-close-all-context-menus'
 const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
   worktree,
   children,
-  contentClassName
+  contentClassName,
+  selectedWorktrees = [worktree],
+  onContextMenuSelect
 }: Props) {
   const updateWorktreeMeta = useAppStore((s) => s.updateWorktreeMeta)
   const openModal = useAppStore((s) => s.openModal)
@@ -47,8 +51,46 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
   const deleteState = useAppStore((s) => s.deleteStateByWorktreeId[worktree.id])
   const [menuOpen, setMenuOpen] = useState(false)
   const [menuPoint, setMenuPoint] = useState({ x: 0, y: 0 })
+  const [contextWorktrees, setContextWorktrees] = useState<readonly Worktree[]>(selectedWorktrees)
   const isDeleting = deleteState?.isDeleting ?? false
   const isFolder = repo ? isFolderRepo(repo) : false
+  const repoMap = useRepoMap()
+  const tabsByWorktree = useAppStore((s) => s.tabsByWorktree)
+  const ptyIdsByTabId = useAppStore((s) => s.ptyIdsByTabId)
+  const browserTabsByWorktree = useAppStore((s) => s.browserTabsByWorktree)
+  const deleteStateByWorktreeId = useAppStore((s) => s.deleteStateByWorktreeId)
+  const activeContextWorktrees = menuOpen ? contextWorktrees : selectedWorktrees
+  const isMultiContext = activeContextWorktrees.length > 1
+  const sleepableWorktrees = useMemo(
+    () =>
+      activeContextWorktrees.filter((item) => {
+        const tabs = tabsByWorktree[item.id] ?? []
+        const hasLiveTerminal = tabs.some((tab) => ptyIdsByTabId[tab.id] != null)
+        const hasBrowser = (browserTabsByWorktree[item.id] ?? []).length > 0
+        return hasLiveTerminal || hasBrowser
+      }),
+    [activeContextWorktrees, browserTabsByWorktree, ptyIdsByTabId, tabsByWorktree]
+  )
+  const deletingContext = useMemo(
+    () => activeContextWorktrees.some((item) => deleteStateByWorktreeId[item.id]?.isDeleting),
+    [activeContextWorktrees, deleteStateByWorktreeId]
+  )
+  const batchDeleteWorktrees = useMemo(
+    () =>
+      activeContextWorktrees.filter((item) => {
+        const itemRepo = repoMap.get(item.repoId)
+        return !item.isMainWorktree && itemRepo != null && !isFolderRepo(itemRepo)
+      }),
+    [activeContextWorktrees, repoMap]
+  )
+  const sleepLabel =
+    isMultiContext && sleepableWorktrees.length > 0
+      ? `Sleep ${sleepableWorktrees.length} Workspace${sleepableWorktrees.length === 1 ? '' : 's'}`
+      : 'Sleep'
+  const deleteLabel =
+    isMultiContext && batchDeleteWorktrees.length > 0
+      ? `Delete ${batchDeleteWorktrees.length} Workspace${batchDeleteWorktrees.length === 1 ? '' : 's'}`
+      : 'Delete Selected'
 
   useEffect(() => {
     const closeMenu = (): void => setMenuOpen(false)
@@ -103,13 +145,17 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
   }, [worktree.id, worktree.displayName, worktree.linkedIssue, worktree.comment, openModal])
 
   const handleCloseTerminals = useCallback(async () => {
-    await runSleepWorktree(worktree.id)
-  }, [worktree.id])
+    await runSleepWorktrees(sleepableWorktrees.map((item) => item.id))
+  }, [sleepableWorktrees])
 
   const handleDelete = useCallback(() => {
     // Folder mode handled inline because it routes to a different modal;
     // standard delete delegates to the shared runWorktreeDelete helper.
     setMenuOpen(false)
+    if (isMultiContext) {
+      runWorktreeBatchDelete(batchDeleteWorktrees.map((item) => item.id))
+      return
+    }
     if (isFolder) {
       // Why: folder mode reuses the worktree row UI for a synthetic root entry,
       // but users still expect "remove" to disconnect the folder from Orca,
@@ -125,7 +171,15 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
     // popover's inline Delete action. Folder mode short-circuits above
     // because the confirm-remove-folder modal is unique to this caller.
     runWorktreeDelete(worktree.id)
-  }, [worktree.id, worktree.repoId, worktree.displayName, isFolder, openModal])
+  }, [
+    batchDeleteWorktrees,
+    isFolder,
+    isMultiContext,
+    openModal,
+    worktree.displayName,
+    worktree.id,
+    worktree.repoId
+  ])
 
   return (
     <>
@@ -134,6 +188,7 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
         onContextMenuCapture={(event) => {
           event.preventDefault()
           window.dispatchEvent(new Event(CLOSE_ALL_CONTEXT_MENUS_EVENT))
+          setContextWorktrees(onContextMenuSelect?.(event) ?? selectedWorktrees)
           const bounds = event.currentTarget.getBoundingClientRect()
           setMenuPoint({ x: event.clientX - bounds.left, y: event.clientY - bounds.top })
           setMenuOpen(true)
@@ -152,45 +207,58 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
           />
         </DropdownMenuTrigger>
         <DropdownMenuContent className={cn('w-52', contentClassName)} sideOffset={0} align="start">
-          <DropdownMenuItem onSelect={handleOpenInFinder} disabled={isDeleting}>
-            <FolderOpen className="size-3.5" />
-            Open in Finder
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={handleCopyPath} disabled={isDeleting}>
-            <Copy className="size-3.5" />
-            Copy Path
-          </DropdownMenuItem>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem onSelect={handleTogglePin} disabled={isDeleting}>
-            {worktree.isPinned ? <PinOff className="size-3.5" /> : <Pin className="size-3.5" />}
-            {worktree.isPinned ? 'Unpin' : 'Pin'}
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={handleRename} disabled={isDeleting}>
-            <Pencil className="size-3.5" />
-            Rename
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={handleToggleRead} disabled={isDeleting}>
-            {worktree.isUnread ? <BellOff className="size-3.5" /> : <Bell className="size-3.5" />}
-            {worktree.isUnread ? 'Mark Read' : 'Mark Unread'}
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={handleLinkIssue} disabled={isDeleting}>
-            <Link className="size-3.5" />
-            {worktree.linkedIssue ? 'Edit GH Issue' : 'Link GH Issue'}
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={handleComment} disabled={isDeleting}>
-            <MessageSquare className="size-3.5" />
-            {worktree.comment ? 'Edit Comment' : 'Add Comment'}
-          </DropdownMenuItem>
-          <DropdownMenuSeparator />
+          {!isMultiContext && (
+            <>
+              <DropdownMenuItem onSelect={handleOpenInFinder} disabled={isDeleting}>
+                <FolderOpen className="size-3.5" />
+                Open in Finder
+              </DropdownMenuItem>
+              <DropdownMenuItem onSelect={handleCopyPath} disabled={isDeleting}>
+                <Copy className="size-3.5" />
+                Copy Path
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onSelect={handleTogglePin} disabled={isDeleting}>
+                {worktree.isPinned ? <PinOff className="size-3.5" /> : <Pin className="size-3.5" />}
+                {worktree.isPinned ? 'Unpin' : 'Pin'}
+              </DropdownMenuItem>
+              <DropdownMenuItem onSelect={handleRename} disabled={isDeleting}>
+                <Pencil className="size-3.5" />
+                Rename
+              </DropdownMenuItem>
+              <DropdownMenuItem onSelect={handleToggleRead} disabled={isDeleting}>
+                {worktree.isUnread ? (
+                  <BellOff className="size-3.5" />
+                ) : (
+                  <Bell className="size-3.5" />
+                )}
+                {worktree.isUnread ? 'Mark Read' : 'Mark Unread'}
+              </DropdownMenuItem>
+              <DropdownMenuItem onSelect={handleLinkIssue} disabled={isDeleting}>
+                <Link className="size-3.5" />
+                {worktree.linkedIssue ? 'Edit GH Issue' : 'Link GH Issue'}
+              </DropdownMenuItem>
+              <DropdownMenuItem onSelect={handleComment} disabled={isDeleting}>
+                <MessageSquare className="size-3.5" />
+                {worktree.comment ? 'Edit Comment' : 'Add Comment'}
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+            </>
+          )}
           <Tooltip>
             <TooltipTrigger asChild>
-              <DropdownMenuItem onSelect={handleCloseTerminals} disabled={isDeleting}>
+              <DropdownMenuItem
+                onSelect={handleCloseTerminals}
+                disabled={deletingContext || sleepableWorktrees.length === 0}
+              >
                 <Moon className="size-3.5" />
-                Sleep
+                {sleepLabel}
               </DropdownMenuItem>
             </TooltipTrigger>
             <TooltipContent side="right" sideOffset={8} className="max-w-[200px] text-pretty">
-              Close all active panels in this workspace to free up memory and CPU.
+              {isMultiContext
+                ? 'Close all active panels in the selected workspaces to free up memory and CPU.'
+                : 'Close all active panels in this workspace to free up memory and CPU.'}
             </TooltipContent>
           </Tooltip>
           {/* Why: `git worktree remove` always rejects the main worktree, so we
@@ -200,15 +268,25 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
           <DropdownMenuItem
             variant="destructive"
             onSelect={handleDelete}
-            disabled={isDeleting || (!isFolder && worktree.isMainWorktree)}
+            disabled={
+              deletingContext ||
+              (!isMultiContext && !isFolder && worktree.isMainWorktree) ||
+              (isMultiContext && batchDeleteWorktrees.length === 0)
+            }
             title={
-              !isFolder && worktree.isMainWorktree
+              !isMultiContext && !isFolder && worktree.isMainWorktree
                 ? 'The main worktree cannot be deleted'
                 : undefined
             }
           >
             <Trash2 className="size-3.5" />
-            {isDeleting ? 'Deleting…' : isFolder ? 'Remove Folder from Orca' : 'Delete'}
+            {deletingContext
+              ? 'Deleting…'
+              : isMultiContext
+                ? deleteLabel
+                : isFolder
+                  ? 'Remove Folder from Orca'
+                  : 'Delete'}
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -37,6 +37,12 @@ import {
 } from './visible-worktrees'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 import { useRepoHeaderDrag } from './repo-header-drag'
+import {
+  areWorktreeSelectionsEqual,
+  getWorktreeSelectionIntent,
+  pruneWorktreeSelection,
+  updateWorktreeSelection
+} from './worktree-multi-selection'
 
 // How long to wait after a sortEpoch bump before actually re-sorting.
 // Prevents jarring position shifts when background events (AI starting work,
@@ -79,6 +85,13 @@ type VirtualizedWorktreeViewportProps = {
   pendingRevealWorktreeId: string | null
   clearPendingRevealWorktreeId: () => void
   worktrees: Worktree[]
+  selectedWorktreeIds: ReadonlySet<string>
+  selectedWorktrees: readonly Worktree[]
+  onSelectionGesture: (event: React.MouseEvent<HTMLDivElement>, worktreeId: string) => boolean
+  onContextMenuSelect: (
+    event: React.MouseEvent<HTMLDivElement>,
+    worktree: Worktree
+  ) => readonly Worktree[]
   repoMap: Map<string, Repo>
   repoOrder: Map<string, number>
   // The full canonical state.repos id ordering — the drag controller commits
@@ -108,6 +121,10 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
   pendingRevealWorktreeId,
   clearPendingRevealWorktreeId,
   worktrees,
+  selectedWorktreeIds,
+  selectedWorktrees,
+  onSelectionGesture,
+  onContextMenuSelect,
   repoMap,
   repoOrder,
   allRepoIds,
@@ -376,10 +393,12 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
   return (
     <div
       ref={scrollRef}
+      data-worktree-sidebar
       tabIndex={0}
       role="listbox"
       aria-label="Worktrees"
       aria-orientation="vertical"
+      aria-multiselectable="true"
       aria-activedescendant={activeDescendantId}
       onKeyDown={handleContainerKeyDown}
       className="worktree-sidebar-scrollbar flex-1 overflow-y-scroll overflow-x-hidden pl-1 scrollbar-sleek outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-inset pt-px"
@@ -510,7 +529,8 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
               key={vItem.key}
               id={getWorktreeOptionId(row.worktree.id)}
               role="option"
-              aria-selected={activeWorktreeId === row.worktree.id}
+              aria-selected={selectedWorktreeIds.has(row.worktree.id)}
+              aria-current={activeWorktreeId === row.worktree.id ? 'page' : undefined}
               data-index={vItem.index}
               ref={virtualizer.measureElement}
               className="absolute left-0 right-0"
@@ -520,6 +540,10 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                 worktree={row.worktree}
                 repo={row.repo}
                 isActive={activeWorktreeId === row.worktree.id}
+                isMultiSelected={selectedWorktreeIds.has(row.worktree.id)}
+                selectedWorktrees={selectedWorktrees}
+                onSelectionGesture={onSelectionGesture}
+                onContextMenuSelect={(event) => onContextMenuSelect(event, row.worktree)}
                 hideRepoBadge={groupBy === 'repo'}
               />
             </div>
@@ -799,6 +823,84 @@ const WorktreeList = React.memo(function WorktreeList() {
         .map((r) => r.worktree),
     [rows]
   )
+  const renderedWorktreeIds = useMemo(
+    () => renderedWorktrees.map((worktree) => worktree.id),
+    [renderedWorktrees]
+  )
+  const [selectedWorktreeIds, setSelectedWorktreeIds] = useState<Set<string>>(new Set())
+  const [selectionAnchorId, setSelectionAnchorId] = useState<string | null>(null)
+
+  useEffect(() => {
+    setSelectedWorktreeIds((previous) => {
+      const pruned = pruneWorktreeSelection(previous, selectionAnchorId, renderedWorktreeIds)
+      if (pruned.anchorId !== selectionAnchorId) {
+        setSelectionAnchorId(pruned.anchorId)
+      }
+      return areWorktreeSelectionsEqual(previous, pruned.selectedIds)
+        ? previous
+        : pruned.selectedIds
+    })
+  }, [renderedWorktreeIds, selectionAnchorId])
+
+  const selectedWorktrees = useMemo(() => {
+    if (selectedWorktreeIds.size === 0) {
+      return []
+    }
+    return renderedWorktrees.filter((worktree) => selectedWorktreeIds.has(worktree.id))
+  }, [renderedWorktrees, selectedWorktreeIds])
+
+  useEffect(() => {
+    if (selectedWorktreeIds.size === 0) {
+      return
+    }
+
+    const clearSelectionOutsideSidebar = (event: PointerEvent): void => {
+      const target = event.target
+      const sidebar = document.querySelector('[data-worktree-sidebar]')
+      if (target instanceof Node && sidebar?.contains(target)) {
+        return
+      }
+      setSelectedWorktreeIds(new Set())
+      setSelectionAnchorId(null)
+    }
+
+    document.addEventListener('pointerdown', clearSelectionOutsideSidebar, { capture: true })
+    return () => {
+      document.removeEventListener('pointerdown', clearSelectionOutsideSidebar, { capture: true })
+    }
+  }, [selectedWorktreeIds.size])
+
+  const updateSelectionForGesture = useCallback(
+    (event: React.MouseEvent<HTMLDivElement>, worktreeId: string): boolean => {
+      const intent = getWorktreeSelectionIntent(event, navigator.userAgent.includes('Mac'))
+      const result = updateWorktreeSelection({
+        visibleIds: renderedWorktreeIds,
+        previousSelectedIds: selectedWorktreeIds,
+        previousAnchorId: selectionAnchorId,
+        targetId: worktreeId,
+        intent
+      })
+      setSelectedWorktreeIds(result.selectedIds)
+      setSelectionAnchorId(result.anchorId)
+      // Plain click keeps its existing navigation behavior; modifier gestures
+      // are selection-only so users can build a batch without switching away.
+      return intent !== 'replace'
+    },
+    [renderedWorktreeIds, selectedWorktreeIds, selectionAnchorId]
+  )
+
+  const selectForContextMenu = useCallback(
+    (_event: React.MouseEvent<HTMLDivElement>, worktree: Worktree): readonly Worktree[] => {
+      if (selectedWorktreeIds.has(worktree.id) && selectedWorktreeIds.size > 1) {
+        return selectedWorktrees
+      }
+      setSelectedWorktreeIds(new Set([worktree.id]))
+      setSelectionAnchorId(worktree.id)
+      return [worktree]
+    },
+    [selectedWorktreeIds, selectedWorktrees]
+  )
+
   // Why: full-page navigation views are not scoped to one worktree, so no
   // sidebar card should appear selected while one of them is active.
   const selectedSidebarWorktreeId =
@@ -809,8 +911,8 @@ const WorktreeList = React.memo(function WorktreeList() {
   // Publishing after paint leaves a brief window where the sidebar shows the
   // new numbering but the shortcut cache still points at the previous order.
   useLayoutEffect(() => {
-    setVisibleWorktreeIds(renderedWorktrees.map((w) => w.id))
-  }, [renderedWorktrees])
+    setVisibleWorktreeIds(renderedWorktreeIds)
+  }, [renderedWorktreeIds])
 
   const handleCreateForRepo = useCallback(
     (repoId: string) => {
@@ -878,6 +980,10 @@ const WorktreeList = React.memo(function WorktreeList() {
       pendingRevealWorktreeId={pendingRevealWorktreeId}
       clearPendingRevealWorktreeId={clearPendingRevealWorktreeId}
       worktrees={worktrees}
+      selectedWorktreeIds={selectedWorktreeIds}
+      selectedWorktrees={selectedWorktrees}
+      onSelectionGesture={updateSelectionForGesture}
+      onContextMenuSelect={selectForContextMenu}
       repoMap={repoMap}
       repoOrder={repoOrder}
       allRepoIds={allRepoIds}

--- a/src/renderer/src/components/sidebar/delete-worktree-flow.test.ts
+++ b/src/renderer/src/components/sidebar/delete-worktree-flow.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => {
+  const state = {
+    settings: { skipDeleteWorktreeConfirm: false },
+    worktreeMap: new Map<string, { id: string; displayName: string; isMainWorktree: boolean }>(),
+    clearWorktreeDeleteState: vi.fn(),
+    openModal: vi.fn(),
+    removeWorktree: vi.fn().mockResolvedValue({ ok: true }),
+    deleteStateByWorktreeId: {}
+  }
+  return { state }
+})
+
+vi.mock('@/store', () => ({
+  useAppStore: {
+    getState: () => mocks.state
+  }
+}))
+
+vi.mock('@/store/selectors', () => ({
+  getWorktreeMapFromState: () => mocks.state.worktreeMap
+}))
+
+vi.mock('@/lib/worktree-activation', () => ({
+  activateAndRevealWorktree: vi.fn()
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+    info: vi.fn()
+  }
+}))
+
+import { runWorktreeBatchDelete } from './delete-worktree-flow'
+
+function setWorktrees(
+  worktrees: { id: string; displayName?: string; isMainWorktree?: boolean }[]
+): void {
+  mocks.state.worktreeMap = new Map(
+    worktrees.map((worktree) => [
+      worktree.id,
+      {
+        id: worktree.id,
+        displayName: worktree.displayName ?? worktree.id,
+        isMainWorktree: worktree.isMainWorktree ?? false
+      }
+    ])
+  )
+}
+
+describe('runWorktreeBatchDelete', () => {
+  beforeEach(() => {
+    mocks.state.settings = { skipDeleteWorktreeConfirm: false }
+    mocks.state.clearWorktreeDeleteState.mockClear()
+    mocks.state.openModal.mockClear()
+    mocks.state.removeWorktree.mockClear().mockResolvedValue({ ok: true })
+    mocks.state.deleteStateByWorktreeId = {}
+    setWorktrees([])
+  })
+
+  it('filters main worktrees and opens a batch confirmation for eligible targets', () => {
+    setWorktrees([{ id: 'main', isMainWorktree: true }, { id: 'wt-1' }, { id: 'wt-2' }])
+
+    runWorktreeBatchDelete(['main', 'wt-1', 'wt-2'])
+
+    expect(mocks.state.clearWorktreeDeleteState).toHaveBeenCalledWith('wt-1')
+    expect(mocks.state.clearWorktreeDeleteState).toHaveBeenCalledWith('wt-2')
+    expect(mocks.state.clearWorktreeDeleteState).not.toHaveBeenCalledWith('main')
+    expect(mocks.state.openModal).toHaveBeenCalledWith('delete-worktree', {
+      worktreeIds: ['wt-1', 'wt-2']
+    })
+  })
+
+  it('opens the single-delete confirmation when only one target is eligible', () => {
+    setWorktrees([{ id: 'main', isMainWorktree: true }, { id: 'wt-1' }])
+
+    runWorktreeBatchDelete(['main', 'wt-1'])
+
+    expect(mocks.state.openModal).toHaveBeenCalledWith('delete-worktree', { worktreeId: 'wt-1' })
+  })
+
+  it('runs every eligible delete immediately when confirmation is skipped', () => {
+    mocks.state.settings = { skipDeleteWorktreeConfirm: true }
+    setWorktrees([
+      { id: 'wt-1', displayName: 'one' },
+      { id: 'wt-2', displayName: 'two' }
+    ])
+
+    runWorktreeBatchDelete(['wt-1', 'wt-2'])
+
+    expect(mocks.state.openModal).not.toHaveBeenCalled()
+    expect(mocks.state.removeWorktree).toHaveBeenCalledWith('wt-1', false)
+    expect(mocks.state.removeWorktree).toHaveBeenCalledWith('wt-2', false)
+  })
+})

--- a/src/renderer/src/components/sidebar/delete-worktree-flow.ts
+++ b/src/renderer/src/components/sidebar/delete-worktree-flow.ts
@@ -3,6 +3,7 @@ import { useAppStore } from '@/store'
 import { getWorktreeMapFromState } from '@/store/selectors'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 import { getDeleteWorktreeToastCopy } from './delete-worktree-toast'
+import type { Worktree } from '../../../../shared/types'
 
 // Why: a failed delete almost always means the worktree still has changes
 // that need attention (uncommitted work, unpushed commits, conflicts). The
@@ -125,4 +126,35 @@ export function runWorktreeDelete(worktreeId: string): void {
     return
   }
   state.openModal('delete-worktree', { worktreeId })
+}
+
+export function runWorktreeBatchDelete(worktreeIds: readonly string[]): void {
+  const state = useAppStore.getState()
+  const worktreeMap = getWorktreeMapFromState(state)
+  const targets = worktreeIds
+    .map((id) => worktreeMap.get(id) ?? null)
+    .filter((worktree): worktree is Worktree => worktree != null && !worktree.isMainWorktree)
+
+  if (targets.length === 0) {
+    return
+  }
+
+  for (const target of targets) {
+    state.clearWorktreeDeleteState(target.id)
+  }
+
+  const skipConfirm = state.settings?.skipDeleteWorktreeConfirm ?? false
+  if (skipConfirm) {
+    for (const target of targets) {
+      runWorktreeDeleteWithToast(target.id, target.displayName)
+    }
+    return
+  }
+
+  if (targets.length === 1) {
+    state.openModal('delete-worktree', { worktreeId: targets[0].id })
+    return
+  }
+
+  state.openModal('delete-worktree', { worktreeIds: targets.map((target) => target.id) })
 }

--- a/src/renderer/src/components/sidebar/sleep-worktree-flow.test.ts
+++ b/src/renderer/src/components/sidebar/sleep-worktree-flow.test.ts
@@ -19,7 +19,7 @@ vi.mock('@/store', () => ({
 
 vi.mock('sonner', () => ({ toast: { error: mocks.toastError } }))
 
-import { runSleepWorktree } from './sleep-worktree-flow'
+import { runSleepWorktree, runSleepWorktrees } from './sleep-worktree-flow'
 
 describe('runSleepWorktree', () => {
   beforeEach(() => {
@@ -78,5 +78,45 @@ describe('runSleepWorktree', () => {
       'Failed to sleep workspace',
       expect.objectContaining({ description: 'boom' })
     )
+  })
+
+  it('continues sleeping later worktrees when one selected worktree fails', async () => {
+    mocks.state.shutdownWorktreeBrowsers.mockImplementation((worktreeId: string) => {
+      if (worktreeId === 'wt-1') {
+        return Promise.reject(new Error('first failed'))
+      }
+      return Promise.resolve()
+    })
+
+    await runSleepWorktrees(['wt-1', 'wt-2'])
+
+    expect(mocks.state.shutdownWorktreeTerminals).not.toHaveBeenCalledWith('wt-1', {
+      keepIdentifiers: true
+    })
+    expect(mocks.state.shutdownWorktreeBrowsers).toHaveBeenCalledWith('wt-2')
+    expect(mocks.state.shutdownWorktreeTerminals).toHaveBeenCalledWith('wt-2', {
+      keepIdentifiers: true
+    })
+    expect(mocks.toastError).toHaveBeenCalledWith(
+      'Failed to sleep some workspaces',
+      expect.objectContaining({ description: 'first failed' })
+    )
+  })
+
+  it('sleeps multiple worktrees and clears active only once when included', async () => {
+    mocks.state.activeWorktreeId = 'wt-2'
+
+    await runSleepWorktrees(['wt-1', 'wt-2'])
+
+    expect(mocks.state.setActiveWorktree).toHaveBeenCalledTimes(1)
+    expect(mocks.state.setActiveWorktree).toHaveBeenCalledWith(null)
+    expect(mocks.state.shutdownWorktreeBrowsers).toHaveBeenNthCalledWith(1, 'wt-1')
+    expect(mocks.state.shutdownWorktreeTerminals).toHaveBeenNthCalledWith(1, 'wt-1', {
+      keepIdentifiers: true
+    })
+    expect(mocks.state.shutdownWorktreeBrowsers).toHaveBeenNthCalledWith(2, 'wt-2')
+    expect(mocks.state.shutdownWorktreeTerminals).toHaveBeenNthCalledWith(2, 'wt-2', {
+      keepIdentifiers: true
+    })
   })
 })

--- a/src/renderer/src/components/sidebar/sleep-worktree-flow.ts
+++ b/src/renderer/src/components/sidebar/sleep-worktree-flow.ts
@@ -15,36 +15,52 @@ import { useAppStore } from '@/store'
  * a new caller can't accidentally skip it.
  */
 export async function runSleepWorktree(worktreeId: string): Promise<void> {
+  await runSleepWorktrees([worktreeId])
+}
+
+export async function runSleepWorktrees(worktreeIds: readonly string[]): Promise<void> {
+  if (worktreeIds.length === 0) {
+    return
+  }
   const {
     activeWorktreeId,
     setActiveWorktree,
     shutdownWorktreeBrowsers,
     shutdownWorktreeTerminals
   } = useAppStore.getState()
-  if (activeWorktreeId === worktreeId) {
+  if (activeWorktreeId && worktreeIds.includes(activeWorktreeId)) {
     setActiveWorktree(null)
   }
-  try {
-    // Why: sleep mirrors removeWorktree's shutdown sequence — browsers first
-    // so destroyPersistentWebview unregisters the Chromium guests before any
-    // other teardown runs, terminals second so the PTY kill uses the same
-    // ordering on both paths. Without the browser thunk here, sleep leaks
-    // browserPagesByWorkspace entries and live webviews for the slept worktree.
-    await shutdownWorktreeBrowsers(worktreeId)
-    // Why: sleep is reversible — the tab record stays in tabsByWorktree, the
-    // layout stays in terminalLayoutsByTabId, only the live PTY processes are
-    // released. keepIdentifiers preserves tab.ptyId / ptyIdsByLeafId /
-    // lastKnownRelayPtyIdByTabId so wake re-spawns against the same on-disk
-    // history dir (local) or relay session id (SSH); it also captures
-    // serializer buffers into buffersByLeafId for SSH wake to reseed
-    // scrollback. See DESIGN_DOC_TERMINAL_HISTORY_FIX_V2.md §3.3.c.
-    await shutdownWorktreeTerminals(worktreeId, { keepIdentifiers: true })
-  } catch (err) {
+  const errors: string[] = []
+  for (const worktreeId of worktreeIds) {
+    try {
+      // Why: sleep mirrors removeWorktree's shutdown sequence — browsers first
+      // so destroyPersistentWebview unregisters the Chromium guests before any
+      // other teardown runs, terminals second so the PTY kill uses the same
+      // ordering on both paths. Without the browser thunk here, sleep leaks
+      // browserPagesByWorkspace entries and live webviews for the slept worktree.
+      await shutdownWorktreeBrowsers(worktreeId)
+      // Why: sleep is reversible — the tab record stays in tabsByWorktree, the
+      // layout stays in terminalLayoutsByTabId, only the live PTY processes are
+      // released. keepIdentifiers preserves tab.ptyId / ptyIdsByLeafId /
+      // lastKnownRelayPtyIdByTabId so wake re-spawns against the same on-disk
+      // history dir (local) or relay session id (SSH); it also captures
+      // serializer buffers into buffersByLeafId for SSH wake to reseed
+      // scrollback. See DESIGN_DOC_TERMINAL_HISTORY_FIX_V2.md §3.3.c.
+      await shutdownWorktreeTerminals(worktreeId, { keepIdentifiers: true })
+    } catch (err) {
+      errors.push(err instanceof Error ? err.message : String(err))
+    }
+  }
+  if (errors.length > 0) {
     // Why: callers are fire-and-forget; surface the failure as a toast and
     // otherwise continue — the active-worktree reset already happened so we
     // don't leave the UI in a stale state.
-    toast.error('Failed to sleep workspace', {
-      description: err instanceof Error ? err.message : String(err)
-    })
+    toast.error(
+      worktreeIds.length === 1 ? 'Failed to sleep workspace' : 'Failed to sleep some workspaces',
+      {
+        description: errors.join('\n')
+      }
+    )
   }
 }

--- a/src/renderer/src/components/sidebar/worktree-multi-selection.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-multi-selection.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getWorktreeSelectionIntent,
+  pruneWorktreeSelection,
+  updateWorktreeSelection
+} from './worktree-multi-selection'
+
+const visibleIds = ['wt-1', 'wt-2', 'wt-3', 'wt-4']
+
+describe('worktree multi selection', () => {
+  it('uses Cmd on Mac and Ctrl elsewhere for toggle selection', () => {
+    expect(
+      getWorktreeSelectionIntent({ metaKey: true, ctrlKey: false, shiftKey: false }, true)
+    ).toBe('toggle')
+    expect(
+      getWorktreeSelectionIntent({ metaKey: false, ctrlKey: true, shiftKey: false }, false)
+    ).toBe('toggle')
+    expect(
+      getWorktreeSelectionIntent({ metaKey: false, ctrlKey: false, shiftKey: true }, false)
+    ).toBe('range')
+  })
+
+  it('replaces selection on plain click', () => {
+    const result = updateWorktreeSelection({
+      visibleIds,
+      previousSelectedIds: new Set(['wt-1', 'wt-2']),
+      previousAnchorId: 'wt-1',
+      targetId: 'wt-3',
+      intent: 'replace'
+    })
+
+    expect([...result.selectedIds]).toEqual(['wt-3'])
+    expect(result.anchorId).toBe('wt-3')
+  })
+
+  it('toggles one worktree without dropping the rest', () => {
+    const result = updateWorktreeSelection({
+      visibleIds,
+      previousSelectedIds: new Set(['wt-1', 'wt-2']),
+      previousAnchorId: 'wt-2',
+      targetId: 'wt-3',
+      intent: 'toggle'
+    })
+
+    expect([...result.selectedIds]).toEqual(['wt-1', 'wt-2', 'wt-3'])
+    expect(result.anchorId).toBe('wt-3')
+  })
+
+  it('allows toggling the last selected worktree off', () => {
+    const result = updateWorktreeSelection({
+      visibleIds,
+      previousSelectedIds: new Set(['wt-2']),
+      previousAnchorId: 'wt-2',
+      targetId: 'wt-2',
+      intent: 'toggle'
+    })
+
+    expect([...result.selectedIds]).toEqual([])
+    expect(result.anchorId).toBe('wt-2')
+  })
+
+  it('selects the visible range from the anchor to the target', () => {
+    const result = updateWorktreeSelection({
+      visibleIds,
+      previousSelectedIds: new Set(['wt-1']),
+      previousAnchorId: 'wt-1',
+      targetId: 'wt-3',
+      intent: 'range'
+    })
+
+    expect([...result.selectedIds]).toEqual(['wt-1', 'wt-2', 'wt-3'])
+    expect(result.anchorId).toBe('wt-1')
+  })
+
+  it('prunes selection when filtering hides selected worktrees', () => {
+    const result = pruneWorktreeSelection(new Set(['wt-1', 'wt-3']), 'wt-1', ['wt-2', 'wt-3'])
+
+    expect([...result.selectedIds]).toEqual(['wt-3'])
+    expect(result.anchorId).toBe('wt-3')
+  })
+})

--- a/src/renderer/src/components/sidebar/worktree-multi-selection.ts
+++ b/src/renderer/src/components/sidebar/worktree-multi-selection.ts
@@ -1,0 +1,91 @@
+export type WorktreeSelectionIntent = 'replace' | 'toggle' | 'range'
+
+export type WorktreeSelectionResult = {
+  selectedIds: Set<string>
+  anchorId: string
+}
+
+export function getWorktreeSelectionIntent(
+  event: Pick<MouseEvent, 'metaKey' | 'ctrlKey' | 'shiftKey'>,
+  isMac: boolean
+): WorktreeSelectionIntent {
+  if (event.shiftKey) {
+    return 'range'
+  }
+  const toggle = isMac ? event.metaKey && !event.ctrlKey : event.ctrlKey && !event.metaKey
+  return toggle ? 'toggle' : 'replace'
+}
+
+export function updateWorktreeSelection(params: {
+  visibleIds: readonly string[]
+  previousSelectedIds: ReadonlySet<string>
+  previousAnchorId: string | null
+  targetId: string
+  intent: WorktreeSelectionIntent
+}): WorktreeSelectionResult {
+  const { visibleIds, previousSelectedIds, previousAnchorId, targetId, intent } = params
+
+  if (intent === 'replace') {
+    return { selectedIds: new Set([targetId]), anchorId: targetId }
+  }
+
+  if (intent === 'toggle') {
+    const next = new Set(previousSelectedIds)
+    if (next.has(targetId)) {
+      next.delete(targetId)
+    } else {
+      next.add(targetId)
+    }
+    return { selectedIds: next, anchorId: targetId }
+  }
+
+  const anchorId = previousAnchorId
+  if (!anchorId) {
+    return { selectedIds: new Set([targetId]), anchorId: targetId }
+  }
+  const targetIndex = visibleIds.indexOf(targetId)
+  const anchorIndex = visibleIds.indexOf(anchorId)
+  if (targetIndex === -1 || anchorIndex === -1) {
+    return { selectedIds: new Set([targetId]), anchorId: targetId }
+  }
+
+  const start = Math.min(anchorIndex, targetIndex)
+  const end = Math.max(anchorIndex, targetIndex)
+  return {
+    selectedIds: new Set(visibleIds.slice(start, end + 1)),
+    anchorId
+  }
+}
+
+export function pruneWorktreeSelection(
+  selectedIds: ReadonlySet<string>,
+  anchorId: string | null,
+  visibleIds: readonly string[]
+): { selectedIds: Set<string>; anchorId: string | null } {
+  const visible = new Set(visibleIds)
+  const next = new Set<string>()
+  for (const id of selectedIds) {
+    if (visible.has(id)) {
+      next.add(id)
+    }
+  }
+  return {
+    selectedIds: next,
+    anchorId: anchorId && visible.has(anchorId) ? anchorId : (next.values().next().value ?? null)
+  }
+}
+
+export function areWorktreeSelectionsEqual(
+  a: ReadonlySet<string>,
+  b: ReadonlySet<string>
+): boolean {
+  if (a.size !== b.size) {
+    return false
+  }
+  for (const id of a) {
+    if (!b.has(id)) {
+      return false
+    }
+  }
+  return true
+}

--- a/tests/e2e/workspace-back-forward-navigation.spec.ts
+++ b/tests/e2e/workspace-back-forward-navigation.spec.ts
@@ -140,11 +140,10 @@ test.describe('Workspace Back/Forward Navigation', () => {
     await expect(back).toBeEnabled()
     await expect(forward).toBeDisabled()
 
-    // Why: use the sidebar's `role="option"` + `aria-selected="true"` as the
-    // DOM signal for "this worktree is currently active". A store-only
-    // `activeWorktreeId` check would pass even if the sidebar stopped
-    // re-painting the selected row — exactly the kind of render-layer
-    // regression the AGENTS.md rule targets.
+    // Why: use the sidebar's option `aria-current` as the DOM signal for "this
+    // worktree is currently active". `aria-selected` is reserved for batch
+    // multi-select state, so a store-only `activeWorktreeId` check would miss
+    // render-layer regressions in the active row.
     const primaryRow = orcaPage.locator(
       `[id="worktree-list-option-${encodeURIComponent(primaryId)}"]`
     )
@@ -158,8 +157,8 @@ test.describe('Workspace Back/Forward Navigation', () => {
         message: 'Back click did not activate the previous worktree'
       })
       .toBe(primaryId)
-    await expect(primaryRow).toHaveAttribute('aria-selected', 'true')
-    await expect(secondaryRow).toHaveAttribute('aria-selected', 'false')
+    await expect(primaryRow).toHaveAttribute('aria-current', 'page')
+    await expect(secondaryRow).not.toHaveAttribute('aria-current', 'page')
     await expect(back).toBeDisabled()
     await expect(forward).toBeEnabled()
 
@@ -169,8 +168,8 @@ test.describe('Workspace Back/Forward Navigation', () => {
         message: 'Forward click did not re-activate the next worktree'
       })
       .toBe(secondaryId)
-    await expect(secondaryRow).toHaveAttribute('aria-selected', 'true')
-    await expect(primaryRow).toHaveAttribute('aria-selected', 'false')
+    await expect(secondaryRow).toHaveAttribute('aria-current', 'page')
+    await expect(primaryRow).not.toHaveAttribute('aria-current', 'page')
     await expect(forward).toBeDisabled()
   })
 


### PR DESCRIPTION
## Summary
- Add sidebar worktree multi-select with plain-click replace, Cmd/Ctrl-click toggle, and Shift-click visible range selection
- Apply context menu sleep/delete actions to selected worktrees, with sleep ignoring already-sleeping workspaces
- Add batch delete confirmation support and focused coverage for selection, sleep, and delete flows

## Verification
- pnpm exec tsc --noEmit -p config/tsconfig.web.json --composite false
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/worktree-multi-selection.test.ts src/renderer/src/components/sidebar/sleep-worktree-flow.test.ts src/renderer/src/components/sidebar/delete-worktree-flow.test.ts
- pnpm exec oxlint src/renderer/src/components/sidebar/WorktreeList.tsx src/renderer/src/components/sidebar/WorktreeCard.tsx src/renderer/src/components/sidebar/WorktreeContextMenu.tsx src/renderer/src/components/sidebar/DeleteWorktreeDialog.tsx src/renderer/src/components/sidebar/delete-worktree-flow.ts src/renderer/src/components/sidebar/delete-worktree-flow.test.ts src/renderer/src/components/sidebar/sleep-worktree-flow.ts src/renderer/src/components/sidebar/worktree-multi-selection.ts src/renderer/src/components/sidebar/worktree-multi-selection.test.ts src/renderer/src/components/sidebar/sleep-worktree-flow.test.ts

## Review
- Subagent review found batch sleep should continue after per-worktree failures; fixed and covered with a regression test.

Made with [Orca](https://github.com/stablyai/orca) 🐋
