### PR TITLE
Fix Claude scoped Keychain auth

### DIFF
--- a/docs/claude-auth-runtime.md
+++ b/docs/claude-auth-runtime.md
@@ -1,0 +1,36 @@
+# Claude Runtime Auth Switching
+
+Orca switches Claude Code accounts by materializing a selected managed account into Claude's shared runtime auth surfaces. The runtime surfaces are:
+
+- `.claude/.credentials.json`
+- macOS scoped Keychain credentials for the active `CLAUDE_CONFIG_DIR`
+- macOS legacy `Claude Code-credentials`
+- `.claude.json` `oauthAccount`
+
+## Core Invariants
+
+1. Never write a user/runtime surface unless Orca can prove it owns the current value on that surface.
+2. Treat each credential surface independently. File, scoped Keychain, and legacy Keychain can each be owned, external, missing, or unknown.
+3. `oauthAccount` metadata is restored or cleared only when metadata itself matches Orca's last managed value, or when a credential surface has already proved the current runtime state belongs to the managed account being cleaned up.
+4. Invalid or unparsable runtime config is unknown, not null. Unknown config must be preserved.
+5. Missing managed account records are unknown. Orca clears the active selection but does not mutate runtime auth without account identity proof.
+6. Missing managed credentials for an existing account can be cleaned up using the account record identity. Only surfaces whose current credentials match that account are restored or cleared.
+7. Read-back of refreshed tokens must evaluate all runtime credential candidates and persist only a single unambiguous managed-account match.
+
+## Snapshot Policy
+
+Before entering managed mode from system mode, Orca captures the system-default runtime state. On restore, the snapshot is only applied to surfaces whose current value still equals Orca's managed value, except for missing-managed-credential recovery where account identity is the proof.
+
+Snapshots are schema-validated before use. Invalid snapshots are deleted and treated as absent.
+
+When recapturing while the credentials file still equals the managed account, Orca preserves any previous snapshot value for Keychain surfaces that still equal the managed credentials. This prevents a failed restore followed by restart from recapturing managed Keychain values as system defaults.
+
+## Read-Back Policy
+
+Claude can refresh OAuth tokens in any runtime credential surface. Orca reads all available candidates, filters out stale or ambiguous matches, then chooses the freshest accepted candidate. Cold-start read-back is conservative: credentials must be newer than the matched managed account. Warm read-back rejects only metadata-proven older credentials, allowing equal-expiry token rotation.
+
+## Failure Policy
+
+Keychain reads during snapshot capture must succeed for both active services on macOS; otherwise Orca aborts managed entry. Best-effort Keychain reads are acceptable for token read-back because another surface may still contain a fresh candidate.
+
+Add-account cleanup must restore/delete the legacy active Keychain item before reporting success. If cleanup fails, the login is treated as failed so Orca does not silently leave the user's legacy Claude state pointing at the captured account.

--- a/src/main/claude-accounts/keychain.test.ts
+++ b/src/main/claude-accounts/keychain.test.ts
@@ -1,0 +1,148 @@
+import { createHash } from 'node:crypto'
+import { execFile } from 'node:child_process'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  deleteActiveClaudeKeychainCredentials,
+  readActiveClaudeKeychainCredentials,
+  writeActiveClaudeKeychainCredentials
+} from './keychain'
+
+vi.mock('node:child_process', () => ({
+  execFile: vi.fn()
+}))
+
+const execFileMock = vi.mocked(execFile)
+const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', {
+    configurable: true,
+    value: platform
+  })
+}
+
+function serviceForConfigDir(configDir: string): string {
+  const suffix = createHash('sha256').update(configDir).digest('hex').slice(0, 8)
+  return `Claude Code-credentials-${suffix}`
+}
+
+function invokeExecFileCallback(
+  callback: unknown,
+  error: Error | null,
+  stdout: string,
+  stderr: string
+): void {
+  const execCallback = callback as (error: Error | null, stdout: string, stderr: string) => void
+  execCallback(error, stdout, stderr)
+}
+
+describe('Claude Keychain credentials', () => {
+  beforeEach(() => {
+    setPlatform('darwin')
+    execFileMock.mockReset()
+  })
+
+  afterEach(() => {
+    if (originalPlatform) {
+      Object.defineProperty(process, 'platform', originalPlatform)
+    }
+  })
+
+  it('reads config-scoped Claude Code 2.1 credentials before legacy credentials', async () => {
+    const configDir = '/tmp/orca-claude-login-test'
+    const scopedService = serviceForConfigDir(configDir)
+    execFileMock.mockImplementationOnce((_file, _args, _options, callback) => {
+      invokeExecFileCallback(callback, null, '{"claudeAiOauth":{"accessToken":"scoped"}}\n', '')
+      return null as never
+    })
+
+    await expect(readActiveClaudeKeychainCredentials(configDir)).resolves.toBe(
+      '{"claudeAiOauth":{"accessToken":"scoped"}}'
+    )
+
+    expect(execFileMock).toHaveBeenCalledTimes(1)
+    expect(execFileMock.mock.calls[0][1]).toEqual([
+      'find-generic-password',
+      '-s',
+      scopedService,
+      '-a',
+      process.env.USER || process.env.USERNAME || 'user',
+      '-w'
+    ])
+  })
+
+  it('falls back to the legacy unsuffixed Claude Code credentials service', async () => {
+    const configDir = '/tmp/orca-claude-login-test'
+    const notFound = Object.assign(new Error('not found'), { code: 44 })
+    execFileMock
+      .mockImplementationOnce((_file, _args, _options, callback) => {
+        invokeExecFileCallback(callback, notFound, '', 'could not be found')
+        return null as never
+      })
+      .mockImplementationOnce((_file, _args, _options, callback) => {
+        invokeExecFileCallback(callback, null, 'legacy\n', '')
+        return null as never
+      })
+
+    await expect(readActiveClaudeKeychainCredentials(configDir)).resolves.toBe('legacy')
+
+    expect(execFileMock.mock.calls[1][1]).toEqual([
+      'find-generic-password',
+      '-s',
+      'Claude Code-credentials',
+      '-a',
+      process.env.USER || process.env.USERNAME || 'user',
+      '-w'
+    ])
+  })
+
+  it('writes active credentials to the config-scoped Claude Code service', async () => {
+    const configDir = '/tmp/orca-claude-login-test'
+    const scopedService = serviceForConfigDir(configDir)
+    execFileMock.mockImplementationOnce((_file, _args, _options, callback) => {
+      invokeExecFileCallback(callback, null, '', '')
+      return null as never
+    })
+
+    await writeActiveClaudeKeychainCredentials('credentials-json', configDir)
+
+    expect(execFileMock.mock.calls[0][1]).toEqual([
+      'add-generic-password',
+      '-U',
+      '-s',
+      scopedService,
+      '-a',
+      process.env.USER || process.env.USERNAME || 'user',
+      '-w',
+      'credentials-json'
+    ])
+  })
+
+  it('deletes both scoped and legacy active credentials for config-dir cleanup', async () => {
+    const configDir = '/tmp/orca-claude-login-test'
+    const scopedService = serviceForConfigDir(configDir)
+    execFileMock.mockImplementation((_file, _args, _options, callback) => {
+      invokeExecFileCallback(callback, null, '', '')
+      return null as never
+    })
+
+    await deleteActiveClaudeKeychainCredentials(configDir)
+
+    expect(execFileMock.mock.calls.map((call) => call[1])).toEqual([
+      [
+        'delete-generic-password',
+        '-s',
+        scopedService,
+        '-a',
+        process.env.USER || process.env.USERNAME || 'user'
+      ],
+      [
+        'delete-generic-password',
+        '-s',
+        'Claude Code-credentials',
+        '-a',
+        process.env.USER || process.env.USERNAME || 'user'
+      ]
+    ])
+  })
+})

--- a/src/main/claude-accounts/keychain.test.ts
+++ b/src/main/claude-accounts/keychain.test.ts
@@ -4,7 +4,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   deleteActiveClaudeKeychainCredentials,
   readActiveClaudeKeychainCredentials,
-  writeActiveClaudeKeychainCredentials
+  readActiveClaudeKeychainCredentialsStrict,
+  writeActiveClaudeKeychainCredentials,
+  writeActiveClaudeKeychainCredentialsForRuntime
 } from './keychain'
 
 vi.mock('node:child_process', () => ({
@@ -115,6 +117,61 @@ describe('Claude Keychain credentials', () => {
       process.env.USER || process.env.USERNAME || 'user',
       '-w',
       'credentials-json'
+    ])
+  })
+
+  it('writes runtime credentials to scoped and legacy services for old Claude Code compatibility', async () => {
+    const configDir = '/tmp/orca-claude-login-test'
+    const scopedService = serviceForConfigDir(configDir)
+    execFileMock.mockImplementation((_file, _args, _options, callback) => {
+      invokeExecFileCallback(callback, null, '', '')
+      return null as never
+    })
+
+    await writeActiveClaudeKeychainCredentialsForRuntime('credentials-json', configDir)
+
+    expect(execFileMock.mock.calls.map((call) => call[1])).toEqual([
+      [
+        'add-generic-password',
+        '-U',
+        '-s',
+        scopedService,
+        '-a',
+        process.env.USER || process.env.USERNAME || 'user',
+        '-w',
+        'credentials-json'
+      ],
+      [
+        'add-generic-password',
+        '-U',
+        '-s',
+        'Claude Code-credentials',
+        '-a',
+        process.env.USER || process.env.USERNAME || 'user',
+        '-w',
+        'credentials-json'
+      ]
+    ])
+  })
+
+  it('strictly reads only the requested active credentials service', async () => {
+    const configDir = '/tmp/orca-claude-login-test'
+    const scopedService = serviceForConfigDir(configDir)
+    execFileMock.mockImplementationOnce((_file, _args, _options, callback) => {
+      invokeExecFileCallback(callback, null, 'scoped\n', '')
+      return null as never
+    })
+
+    await expect(readActiveClaudeKeychainCredentialsStrict(configDir)).resolves.toBe('scoped')
+
+    expect(execFileMock).toHaveBeenCalledTimes(1)
+    expect(execFileMock.mock.calls[0][1]).toEqual([
+      'find-generic-password',
+      '-s',
+      scopedService,
+      '-a',
+      process.env.USER || process.env.USERNAME || 'user',
+      '-w'
     ])
   })
 

--- a/src/main/claude-accounts/keychain.ts
+++ b/src/main/claude-accounts/keychain.ts
@@ -1,22 +1,38 @@
 import { execFile } from 'node:child_process'
+import { createHash } from 'node:crypto'
 
 const ACTIVE_CLAUDE_SERVICE = 'Claude Code-credentials'
 const ORCA_CLAUDE_SERVICE = 'Orca Claude Code Managed Credentials'
 
-export async function readActiveClaudeKeychainCredentials(): Promise<string | null> {
-  return readKeychainPassword(ACTIVE_CLAUDE_SERVICE, getKeychainUser())
+export async function readActiveClaudeKeychainCredentials(
+  configDir?: string
+): Promise<string | null> {
+  for (const service of getActiveClaudeServices(configDir)) {
+    const credentials = await readKeychainPassword(service, getKeychainUser())
+    if (credentials) {
+      return credentials
+    }
+  }
+  return null
 }
 
-export async function writeActiveClaudeKeychainCredentials(contents: string): Promise<void> {
-  await writeKeychainPassword(ACTIVE_CLAUDE_SERVICE, getKeychainUser(), contents)
+export async function writeActiveClaudeKeychainCredentials(
+  contents: string,
+  configDir?: string
+): Promise<void> {
+  await writeKeychainPassword(getActiveClaudeService(configDir), getKeychainUser(), contents)
 }
 
-export async function deleteActiveClaudeKeychainCredentials(): Promise<void> {
-  await deleteKeychainPassword(ACTIVE_CLAUDE_SERVICE, getKeychainUser())
+export async function deleteActiveClaudeKeychainCredentials(configDir?: string): Promise<void> {
+  for (const service of getActiveClaudeServices(configDir)) {
+    await deleteKeychainPassword(service, getKeychainUser())
+  }
 }
 
-export async function deleteActiveClaudeKeychainCredentialsStrict(): Promise<void> {
-  await deleteKeychainPassword(ACTIVE_CLAUDE_SERVICE, getKeychainUser(), {
+export async function deleteActiveClaudeKeychainCredentialsStrict(
+  configDir?: string
+): Promise<void> {
+  await deleteKeychainPassword(getActiveClaudeService(configDir), getKeychainUser(), {
     failOnAccessError: true
   })
 }
@@ -40,6 +56,23 @@ export async function deleteManagedClaudeKeychainCredentials(accountId: string):
 
 function getKeychainUser(): string {
   return process.env.USER || process.env.USERNAME || 'user'
+}
+
+function getActiveClaudeService(configDir?: string): string {
+  if (!configDir) {
+    return ACTIVE_CLAUDE_SERVICE
+  }
+  // Why: Claude Code 2.1+ scopes macOS Keychain credentials by config dir
+  // using the first 8 hex chars of sha256(CLAUDE_CONFIG_DIR).
+  const suffix = createHash('sha256').update(configDir).digest('hex').slice(0, 8)
+  return `${ACTIVE_CLAUDE_SERVICE}-${suffix}`
+}
+
+function getActiveClaudeServices(configDir?: string): string[] {
+  const scopedService = getActiveClaudeService(configDir)
+  return scopedService === ACTIVE_CLAUDE_SERVICE
+    ? [ACTIVE_CLAUDE_SERVICE]
+    : [scopedService, ACTIVE_CLAUDE_SERVICE]
 }
 
 async function readKeychainPassword(service: string, account: string): Promise<string | null> {

--- a/src/main/claude-accounts/keychain.ts
+++ b/src/main/claude-accounts/keychain.ts
@@ -16,11 +16,29 @@ export async function readActiveClaudeKeychainCredentials(
   return null
 }
 
+export async function readActiveClaudeKeychainCredentialsStrict(
+  configDir?: string
+): Promise<string | null> {
+  return readKeychainPassword(getActiveClaudeService(configDir), getKeychainUser())
+}
+
 export async function writeActiveClaudeKeychainCredentials(
   contents: string,
   configDir?: string
 ): Promise<void> {
   await writeKeychainPassword(getActiveClaudeService(configDir), getKeychainUser(), contents)
+}
+
+export async function writeActiveClaudeKeychainCredentialsForRuntime(
+  contents: string,
+  configDir: string
+): Promise<void> {
+  const user = getKeychainUser()
+  const scopedService = getActiveClaudeService(configDir)
+  await writeKeychainPassword(scopedService, user, contents)
+  if (scopedService !== ACTIVE_CLAUDE_SERVICE) {
+    await writeKeychainPassword(ACTIVE_CLAUDE_SERVICE, user, contents)
+  }
 }
 
 export async function deleteActiveClaudeKeychainCredentials(configDir?: string): Promise<void> {

--- a/src/main/claude-accounts/managed-auth-path.ts
+++ b/src/main/claude-accounts/managed-auth-path.ts
@@ -1,0 +1,112 @@
+import { existsSync, lstatSync, readFileSync, realpathSync, writeFileSync } from 'node:fs'
+import { join, relative, resolve, sep } from 'node:path'
+import { app } from 'electron'
+import { writeFileAtomically } from '../codex-accounts/fs-utils'
+
+const MANAGED_AUTH_MARKER = '.orca-managed-claude-auth'
+
+export function getClaudeManagedAccountsRoot(): string {
+  return join(app.getPath('userData'), 'claude-accounts')
+}
+
+export function resolveOwnedClaudeManagedAuthPath(
+  accountId: string,
+  candidatePath: string,
+  options: { adoptLegacyMarker?: boolean } = {}
+): string | null {
+  const rootPath = getClaudeManagedAccountsRoot()
+  const resolvedCandidate = resolve(candidatePath)
+  if (!existsSync(resolvedCandidate) || !existsSync(rootPath)) {
+    return null
+  }
+  try {
+    if (lstatSync(resolvedCandidate).isSymbolicLink()) {
+      return null
+    }
+    const canonicalCandidate = realpathSync(resolvedCandidate)
+    const canonicalRoot = realpathSync(rootPath)
+    if (
+      canonicalCandidate === canonicalRoot ||
+      !canonicalCandidate.startsWith(canonicalRoot + sep)
+    ) {
+      return null
+    }
+    const relativePath = relative(canonicalRoot, canonicalCandidate)
+    const relativeParts = relativePath.split(sep)
+    const escaped = relativePath.startsWith('..') || relativePath.includes(`..${sep}`)
+    if (
+      escaped ||
+      relativeParts.length !== 2 ||
+      relativeParts[0] !== accountId ||
+      relativeParts[1] !== 'auth'
+    ) {
+      return null
+    }
+    const markerPath = join(canonicalCandidate, MANAGED_AUTH_MARKER)
+    const markerValid = isManagedAuthMarkerValid(markerPath, accountId)
+    if (!markerValid && options.adoptLegacyMarker) {
+      writeFileSync(markerPath, `${accountId}\n`, { encoding: 'utf-8', mode: 0o600, flag: 'wx' })
+    }
+    if (!markerValid && !isManagedAuthMarkerValid(markerPath, accountId)) {
+      return null
+    }
+    return canonicalCandidate
+  } catch {
+    return null
+  }
+}
+
+export function readClaudeManagedAuthFile(
+  managedAuthPath: string,
+  filename: '.credentials.json' | 'oauth-account.json'
+): string | null {
+  const filePath = resolve(managedAuthPath, filename)
+  try {
+    if (!isOwnedChildFile(managedAuthPath, filePath)) {
+      return null
+    }
+    return readFileSync(filePath, 'utf-8')
+  } catch {
+    return null
+  }
+}
+
+export function writeClaudeManagedAuthFile(
+  managedAuthPath: string,
+  filename: '.credentials.json' | 'oauth-account.json',
+  contents: string
+): void {
+  const filePath = resolve(managedAuthPath, filename)
+  if (existsSync(filePath) && !isOwnedChildFile(managedAuthPath, filePath)) {
+    throw new Error('Managed Claude auth child file is not owned by Orca.')
+  }
+  writeFileAtomically(filePath, contents, { mode: 0o600 })
+}
+
+function isManagedAuthMarkerValid(markerPath: string, accountId: string): boolean {
+  try {
+    if (
+      !existsSync(markerPath) ||
+      lstatSync(markerPath).isSymbolicLink() ||
+      !lstatSync(markerPath).isFile()
+    ) {
+      return false
+    }
+    return readFileSync(markerPath, 'utf-8').trim() === accountId
+  } catch {
+    return false
+  }
+}
+
+function isOwnedChildFile(managedAuthPath: string, filePath: string): boolean {
+  if (
+    !existsSync(filePath) ||
+    lstatSync(filePath).isSymbolicLink() ||
+    !lstatSync(filePath).isFile()
+  ) {
+    return false
+  }
+  const canonicalAuthPath = realpathSync(managedAuthPath)
+  const canonicalFilePath = realpathSync(filePath)
+  return canonicalFilePath.startsWith(canonicalAuthPath + sep)
+}

--- a/src/main/claude-accounts/runtime-auth-service.test.ts
+++ b/src/main/claude-accounts/runtime-auth-service.test.ts
@@ -47,6 +47,10 @@ vi.mock('./keychain', () => ({
   deleteActiveClaudeKeychainCredentialsStrict: vi.fn(async () => {
     testState.activeKeychainCredentials = null
   }),
+  readActiveClaudeKeychainCredentialsStrict: vi.fn(async () => testState.activeKeychainCredentials),
+  writeActiveClaudeKeychainCredentialsForRuntime: vi.fn(async (contents: string) => {
+    testState.activeKeychainCredentials = contents
+  }),
   readManagedClaudeKeychainCredentials: vi.fn(
     async (accountId: string) => testState.managedKeychainCredentials.get(accountId) ?? null
   ),

--- a/src/main/claude-accounts/runtime-auth-service.test.ts
+++ b/src/main/claude-accounts/runtime-auth-service.test.ts
@@ -273,10 +273,11 @@ describe('ClaudeRuntimeAuthService', () => {
 
   it('rematerializes unchanged managed credentials when the runtime file is missing', async () => {
     const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const managedCredentials = createClaudeCredentialsJson('user@example.com', 'managed')
     const managedAuthPath = createManagedClaudeAuth(
       testState.userDataDir,
       'account-1',
-      '{"token":"managed"}\n'
+      managedCredentials
     )
     const settings = createSettings({
       claudeManagedAccounts: [createClaudeAccount('account-1', managedAuthPath)],
@@ -288,12 +289,12 @@ describe('ClaudeRuntimeAuthService', () => {
     const service = new ClaudeRuntimeAuthService(store as never)
     await service.syncForCurrentSelection()
 
-    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe('{"token":"managed"}\n')
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(managedCredentials)
 
     rmSync(runtimeCredentialsPath, { force: true })
     await service.prepareForClaudeLaunch()
 
-    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe('{"token":"managed"}\n')
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(managedCredentials)
     expect(testState.runtimeWriteConfigDir).toBe(expectedRuntimeConfigDir())
   })
 
@@ -320,13 +321,37 @@ describe('ClaudeRuntimeAuthService', () => {
     expect(testState.legacyKeychainCredentials).toBe(systemCredentials)
   })
 
+  it('restores system default instead of materializing wrong-shaped managed credentials', async () => {
+    const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const systemCredentials = createClaudeCredentialsJson('system@example.com', 'system')
+    writeFileSync(runtimeCredentialsPath, systemCredentials, 'utf-8')
+    testState.scopedKeychainCredentials = systemCredentials
+    testState.legacyKeychainCredentials = systemCredentials
+    const managedAuthPath = createManagedClaudeAuth(testState.userDataDir, 'account-1', '{}\n')
+    const settings = createSettings({
+      claudeManagedAccounts: [createClaudeAccount('account-1', managedAuthPath)],
+      activeClaudeManagedAccountId: 'account-1'
+    })
+    const store = createStore(settings)
+
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const service = new ClaudeRuntimeAuthService(store as never)
+    await service.syncForCurrentSelection()
+
+    expect(store.getSettings().activeClaudeManagedAccountId).toBeNull()
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(systemCredentials)
+    expect(testState.scopedKeychainCredentials).toBe(systemCredentials)
+    expect(testState.legacyKeychainCredentials).toBe(systemCredentials)
+  })
+
   it('removes runtime credentials when deselecting with a missing system-default snapshot', async () => {
     const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
-    writeFileSync(runtimeCredentialsPath, '{"token":"managed"}\n', 'utf-8')
+    const managedCredentials = createClaudeCredentialsJson('user@example.com', 'managed')
+    writeFileSync(runtimeCredentialsPath, managedCredentials, 'utf-8')
     const managedAuthPath = createManagedClaudeAuth(
       testState.userDataDir,
       'account-1',
-      '{"token":"managed"}\n'
+      managedCredentials
     )
     const settings = createSettings({
       claudeManagedAccounts: [createClaudeAccount('account-1', managedAuthPath)],
@@ -354,10 +379,12 @@ describe('ClaudeRuntimeAuthService', () => {
 
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const managedCredentials = createClaudeCredentialsJson('user@example.com', 'managed')
+    const rotatedCredentials = createClaudeCredentialsJson('user@example.com', 'rotated')
     const managedAuthPath = createManagedClaudeAuth(
       testState.userDataDir,
       'account-1',
-      '{"token":"managed"}\n'
+      managedCredentials
     )
     const settings = createSettings({
       claudeManagedAccounts: [createClaudeAccount('account-1', managedAuthPath)]
@@ -369,8 +396,8 @@ describe('ClaudeRuntimeAuthService', () => {
     settings.activeClaudeManagedAccountId = 'account-1'
     await service.syncForCurrentSelection()
 
-    testState.managedKeychainCredentials.set('account-1', '{"token":"rotated"}\n')
-    writeFileSync(join(managedAuthPath, '.credentials.json'), '{"token":"rotated"}\n', 'utf-8')
+    testState.managedKeychainCredentials.set('account-1', rotatedCredentials)
+    writeFileSync(join(managedAuthPath, '.credentials.json'), rotatedCredentials, 'utf-8')
     chmodSync(runtimeCredentialsPath, 0o000)
     try {
       await service.syncForCurrentSelection()
@@ -381,7 +408,7 @@ describe('ClaudeRuntimeAuthService', () => {
       warn.mockRestore()
     }
 
-    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe('{"token":"rotated"}\n')
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(rotatedCredentials)
   })
 
   it('tightens credential file permissions when unchanged content is already present', async () => {
@@ -390,10 +417,11 @@ describe('ClaudeRuntimeAuthService', () => {
     }
 
     const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const managedCredentials = createClaudeCredentialsJson('user@example.com', 'managed')
     const managedAuthPath = createManagedClaudeAuth(
       testState.userDataDir,
       'account-1',
-      '{"token":"managed"}\n'
+      managedCredentials
     )
     const settings = createSettings({
       claudeManagedAccounts: [createClaudeAccount('account-1', managedAuthPath)]
@@ -434,6 +462,37 @@ describe('ClaudeRuntimeAuthService', () => {
 
     expect(readManagedCredentialsForTest('account-1', managedAuthPath)).toBe(refreshedCredentials)
     expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(refreshedCredentials)
+  })
+
+  it('rejects wrong-shaped refreshed credentials during read-back', async () => {
+    const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const originalCredentials = createClaudeCredentialsJson('user@example.com', 'original')
+    const wrongShapedRefresh = `${JSON.stringify({
+      claudeAiOauth: {
+        email: 'user@example.com',
+        expiresAt: Date.now() + 120_000
+      }
+    })}\n`
+    const managedAuthPath = createManagedClaudeAuth(
+      testState.userDataDir,
+      'account-1',
+      originalCredentials
+    )
+    const settings = createSettings({
+      claudeManagedAccounts: [createClaudeAccount('account-1', managedAuthPath)]
+    })
+    const store = createStore(settings)
+
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const service = new ClaudeRuntimeAuthService(store as never)
+    settings.activeClaudeManagedAccountId = 'account-1'
+    await service.syncForCurrentSelection()
+
+    writeFileSync(runtimeCredentialsPath, wrongShapedRefresh, 'utf-8')
+    await service.syncForCurrentSelection()
+
+    expect(readManagedCredentialsForTest('account-1', managedAuthPath)).toBe(originalCredentials)
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(originalCredentials)
   })
 
   it('reads back verified same-account credentials on first sync after restart', async () => {

--- a/src/main/claude-accounts/runtime-auth-service.test.ts
+++ b/src/main/claude-accounts/runtime-auth-service.test.ts
@@ -22,6 +22,10 @@ const testState = {
   activeKeychainCredentials: null as string | null,
   scopedKeychainCredentials: null as string | null,
   legacyKeychainCredentials: null as string | null,
+  throwScopedKeychainRead: false,
+  throwLegacyKeychainRead: false,
+  throwRuntimeKeychainWrite: false,
+  throwScopedKeychainWrite: false,
   runtimeWriteConfigDir: null as string | null,
   managedKeychainCredentials: new Map<string, string>()
 }
@@ -59,6 +63,9 @@ vi.mock('./keychain', () => ({
       if (configDir !== expectedRuntimeConfigDir()) {
         throw new Error(`Unexpected Claude config dir: ${configDir}`)
       }
+      if (testState.throwScopedKeychainWrite) {
+        throw new Error('scoped keychain write failed')
+      }
       testState.scopedKeychainCredentials = contents
     } else {
       testState.legacyKeychainCredentials = contents
@@ -83,15 +90,28 @@ vi.mock('./keychain', () => ({
   }),
   readActiveClaudeKeychainCredentialsStrict: vi.fn(async (configDir?: string) =>
     configDir
-      ? configDir === expectedRuntimeConfigDir()
-        ? testState.scopedKeychainCredentials
-        : null
-      : testState.legacyKeychainCredentials
+      ? (() => {
+          if (testState.throwScopedKeychainRead) {
+            throw new Error('scoped keychain read failed')
+          }
+          return configDir === expectedRuntimeConfigDir()
+            ? testState.scopedKeychainCredentials
+            : null
+        })()
+      : (() => {
+          if (testState.throwLegacyKeychainRead) {
+            throw new Error('legacy keychain read failed')
+          }
+          return testState.legacyKeychainCredentials
+        })()
   ),
   writeActiveClaudeKeychainCredentialsForRuntime: vi.fn(
     async (contents: string, configDir: string) => {
       if (configDir !== expectedRuntimeConfigDir()) {
         throw new Error(`Unexpected Claude config dir: ${configDir}`)
+      }
+      if (testState.throwRuntimeKeychainWrite) {
+        throw new Error('runtime keychain write failed')
       }
       testState.runtimeWriteConfigDir = configDir
       testState.scopedKeychainCredentials = contents
@@ -209,6 +229,16 @@ function readManagedCredentialsForTest(accountId: string, managedAuthPath: strin
   return readFileSync(join(managedAuthPath, '.credentials.json'), 'utf-8')
 }
 
+function readRuntimeOauthAccountForTest(): unknown {
+  const configPath = join(testState.fakeHomeDir, '.claude.json')
+  if (!existsSync(configPath)) {
+    return null
+  }
+  return (
+    (JSON.parse(readFileSync(configPath, 'utf-8')) as Record<string, unknown>).oauthAccount ?? null
+  )
+}
+
 describe('ClaudeRuntimeAuthService', () => {
   beforeEach(() => {
     setPlatform('darwin')
@@ -217,6 +247,10 @@ describe('ClaudeRuntimeAuthService', () => {
     testState.activeKeychainCredentials = null
     testState.scopedKeychainCredentials = null
     testState.legacyKeychainCredentials = null
+    testState.throwScopedKeychainRead = false
+    testState.throwLegacyKeychainRead = false
+    testState.throwRuntimeKeychainWrite = false
+    testState.throwScopedKeychainWrite = false
     testState.runtimeWriteConfigDir = null
     testState.managedKeychainCredentials.clear()
     testState.userDataDir = mkdtempSync(join(tmpdir(), 'orca-claude-runtime-'))
@@ -852,6 +886,8 @@ describe('ClaudeRuntimeAuthService', () => {
     await service.syncForCurrentSelection()
 
     expect(existsSync(runtimeCredentialsPath)).toBe(false)
+    expect(testState.scopedKeychainCredentials).toBeNull()
+    expect(testState.legacyKeychainCredentials).toBeNull()
   })
 
   it('reads back refreshed active keychain credentials on macOS', async () => {
@@ -1014,9 +1050,11 @@ describe('ClaudeRuntimeAuthService', () => {
     const store = createStore(settings)
 
     const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const { readActiveClaudeKeychainCredentials } = await import('./keychain')
     const service = new ClaudeRuntimeAuthService(store as never)
     settings.activeClaudeManagedAccountId = 'account-1'
     await service.syncForCurrentSelection()
+    expect(readActiveClaudeKeychainCredentials).toHaveBeenCalledWith(expectedRuntimeConfigDir())
 
     testState.scopedKeychainCredentials = externalScopedCredentials
     settings.activeClaudeManagedAccountId = null
@@ -1025,6 +1063,86 @@ describe('ClaudeRuntimeAuthService', () => {
     expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(systemCredentials)
     expect(testState.scopedKeychainCredentials).toBe(externalScopedCredentials)
     expect(testState.legacyKeychainCredentials).toBe(systemCredentials)
+  })
+
+  it('preserves external oauth metadata while restoring owned credentials', async () => {
+    const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const runtimeConfigPath = join(testState.fakeHomeDir, '.claude.json')
+    const systemCredentials = createClaudeCredentialsJson('system@example.com', 'system')
+    const managedCredentials = createClaudeCredentialsJson('user@example.com', 'managed')
+    const systemOauthAccount = { accountUuid: 'system-account' }
+    const externalOauthAccount = { accountUuid: 'external-account' }
+    writeFileSync(runtimeCredentialsPath, systemCredentials, 'utf-8')
+    writeFileSync(
+      runtimeConfigPath,
+      `${JSON.stringify({ oauthAccount: systemOauthAccount })}\n`,
+      'utf-8'
+    )
+    testState.scopedKeychainCredentials = systemCredentials
+    testState.legacyKeychainCredentials = systemCredentials
+    const managedAuthPath = createManagedClaudeAuth(
+      testState.userDataDir,
+      'account-1',
+      managedCredentials
+    )
+    const settings = createSettings({
+      claudeManagedAccounts: [createClaudeAccount('account-1', managedAuthPath)]
+    })
+    const store = createStore(settings)
+
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const service = new ClaudeRuntimeAuthService(store as never)
+    settings.activeClaudeManagedAccountId = 'account-1'
+    await service.syncForCurrentSelection()
+
+    writeFileSync(
+      runtimeConfigPath,
+      `${JSON.stringify({ oauthAccount: externalOauthAccount })}\n`,
+      'utf-8'
+    )
+    settings.activeClaudeManagedAccountId = null
+    await service.syncForCurrentSelection()
+
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(systemCredentials)
+    expect(readRuntimeOauthAccountForTest()).toEqual(externalOauthAccount)
+  })
+
+  it('restores owned oauth metadata when external credentials change but metadata does not', async () => {
+    const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const runtimeConfigPath = join(testState.fakeHomeDir, '.claude.json')
+    const systemCredentials = createClaudeCredentialsJson('system@example.com', 'system')
+    const managedCredentials = createClaudeCredentialsJson('user@example.com', 'managed')
+    const externalCredentials = createClaudeCredentialsJson('external@example.com', 'external')
+    const systemOauthAccount = { accountUuid: 'system-account' }
+    writeFileSync(runtimeCredentialsPath, systemCredentials, 'utf-8')
+    writeFileSync(
+      runtimeConfigPath,
+      `${JSON.stringify({ oauthAccount: systemOauthAccount })}\n`,
+      'utf-8'
+    )
+    testState.scopedKeychainCredentials = systemCredentials
+    testState.legacyKeychainCredentials = systemCredentials
+    const managedAuthPath = createManagedClaudeAuth(
+      testState.userDataDir,
+      'account-1',
+      managedCredentials
+    )
+    const settings = createSettings({
+      claudeManagedAccounts: [createClaudeAccount('account-1', managedAuthPath)]
+    })
+    const store = createStore(settings)
+
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const service = new ClaudeRuntimeAuthService(store as never)
+    settings.activeClaudeManagedAccountId = 'account-1'
+    await service.syncForCurrentSelection()
+
+    writeFileSync(runtimeCredentialsPath, externalCredentials, 'utf-8')
+    settings.activeClaudeManagedAccountId = null
+    await service.syncForCurrentSelection()
+
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(externalCredentials)
+    expect(readRuntimeOauthAccountForTest()).toEqual(systemOauthAccount)
   })
 
   it('uses managed credentials as ownership baseline after restart with partial external changes', async () => {
@@ -1152,6 +1270,387 @@ describe('ClaudeRuntimeAuthService', () => {
     expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(systemCredentials)
     expect(testState.scopedKeychainCredentials).toBe(systemCredentials)
     expect(testState.legacyKeychainCredentials).toBe(systemCredentials)
+  })
+
+  it('does not recapture managed file as system default after a partial keychain write failure', async () => {
+    const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const systemCredentials = createClaudeCredentialsJson('system@example.com', 'system')
+    const managedCredentials = createClaudeCredentialsJson('user@example.com', 'managed')
+    writeFileSync(runtimeCredentialsPath, systemCredentials, 'utf-8')
+    testState.scopedKeychainCredentials = systemCredentials
+    testState.legacyKeychainCredentials = systemCredentials
+    const managedAuthPath = createManagedClaudeAuth(
+      testState.userDataDir,
+      'account-1',
+      managedCredentials
+    )
+    const settings = createSettings({
+      claudeManagedAccounts: [createClaudeAccount('account-1', managedAuthPath)]
+    })
+    const store = createStore(settings)
+
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const service = new ClaudeRuntimeAuthService(store as never)
+    settings.activeClaudeManagedAccountId = 'account-1'
+    testState.throwRuntimeKeychainWrite = true
+    await expect(service.syncForCurrentSelection()).rejects.toThrow('runtime keychain write failed')
+
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(managedCredentials)
+    expect(testState.scopedKeychainCredentials).toBe(systemCredentials)
+    testState.throwRuntimeKeychainWrite = false
+    await service.syncForCurrentSelection()
+
+    settings.activeClaudeManagedAccountId = null
+    await service.syncForCurrentSelection()
+
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(systemCredentials)
+    expect(testState.scopedKeychainCredentials).toBe(systemCredentials)
+    expect(testState.legacyKeychainCredentials).toBe(systemCredentials)
+  })
+
+  it('keeps managed ownership baseline when keychain restore fails and retries', async () => {
+    const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const systemCredentials = createClaudeCredentialsJson('system@example.com', 'system')
+    const managedCredentials = createClaudeCredentialsJson('user@example.com', 'managed')
+    writeFileSync(runtimeCredentialsPath, systemCredentials, 'utf-8')
+    testState.scopedKeychainCredentials = systemCredentials
+    testState.legacyKeychainCredentials = systemCredentials
+    const managedAuthPath = createManagedClaudeAuth(
+      testState.userDataDir,
+      'account-1',
+      managedCredentials
+    )
+    const settings = createSettings({
+      claudeManagedAccounts: [createClaudeAccount('account-1', managedAuthPath)]
+    })
+    const store = createStore(settings)
+
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const service = new ClaudeRuntimeAuthService(store as never)
+    settings.activeClaudeManagedAccountId = 'account-1'
+    await service.syncForCurrentSelection()
+
+    settings.activeClaudeManagedAccountId = null
+    testState.throwScopedKeychainWrite = true
+    await expect(service.syncForCurrentSelection()).rejects.toThrow('scoped keychain write failed')
+
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(systemCredentials)
+    expect(testState.scopedKeychainCredentials).toBe(managedCredentials)
+    testState.throwScopedKeychainWrite = false
+    await service.syncForCurrentSelection()
+
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(systemCredentials)
+    expect(testState.scopedKeychainCredentials).toBe(systemCredentials)
+    expect(testState.legacyKeychainCredentials).toBe(systemCredentials)
+  })
+
+  it('does not enter managed mode when keychain snapshot capture fails', async () => {
+    const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const systemCredentials = createClaudeCredentialsJson('system@example.com', 'system')
+    const managedCredentials = createClaudeCredentialsJson('user@example.com', 'managed')
+    writeFileSync(runtimeCredentialsPath, systemCredentials, 'utf-8')
+    testState.scopedKeychainCredentials = systemCredentials
+    testState.legacyKeychainCredentials = systemCredentials
+    const managedAuthPath = createManagedClaudeAuth(
+      testState.userDataDir,
+      'account-1',
+      managedCredentials
+    )
+    const settings = createSettings({
+      claudeManagedAccounts: [createClaudeAccount('account-1', managedAuthPath)]
+    })
+    const store = createStore(settings)
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const service = new ClaudeRuntimeAuthService(store as never)
+    settings.activeClaudeManagedAccountId = 'account-1'
+    testState.throwScopedKeychainRead = true
+    await expect(service.syncForCurrentSelection()).rejects.toThrow(
+      'Cannot capture current Claude Keychain credentials'
+    )
+
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(systemCredentials)
+    expect(testState.scopedKeychainCredentials).toBe(systemCredentials)
+    expect(testState.legacyKeychainCredentials).toBe(systemCredentials)
+    warn.mockRestore()
+  })
+
+  it('treats corrupt system-default snapshots as missing and clears owned runtime auth', async () => {
+    const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const runtimeConfigPath = join(testState.fakeHomeDir, '.claude.json')
+    const snapshotPath = join(
+      testState.userDataDir,
+      'claude-runtime-auth',
+      'system-default-auth.json'
+    )
+    const managedCredentials = createClaudeCredentialsJson('user@example.com', 'managed')
+    mkdirSync(join(testState.userDataDir, 'claude-runtime-auth'), { recursive: true })
+    writeFileSync(snapshotPath, '{not-json', 'utf-8')
+    writeFileSync(runtimeCredentialsPath, managedCredentials, 'utf-8')
+    writeFileSync(
+      runtimeConfigPath,
+      `${JSON.stringify({ oauthAccount: { accountUuid: 'account-1' } })}\n`,
+      'utf-8'
+    )
+    testState.scopedKeychainCredentials = managedCredentials
+    testState.legacyKeychainCredentials = managedCredentials
+    const managedAuthPath = createManagedClaudeAuth(
+      testState.userDataDir,
+      'account-1',
+      managedCredentials
+    )
+    const settings = createSettings({
+      claudeManagedAccounts: [createClaudeAccount('account-1', managedAuthPath)],
+      activeClaudeManagedAccountId: 'account-1'
+    })
+    const store = createStore(settings)
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const service = new ClaudeRuntimeAuthService(store as never)
+    settings.activeClaudeManagedAccountId = null
+    await service.syncForCurrentSelection()
+
+    expect(existsSync(snapshotPath)).toBe(false)
+    expect(existsSync(runtimeCredentialsPath)).toBe(false)
+    expect(readRuntimeOauthAccountForTest()).toBeNull()
+    expect(testState.scopedKeychainCredentials).toBeNull()
+    expect(testState.legacyKeychainCredentials).toBeNull()
+    warn.mockRestore()
+  })
+
+  it('treats wrong-shaped system-default snapshots as missing and clears owned runtime auth', async () => {
+    const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const runtimeConfigPath = join(testState.fakeHomeDir, '.claude.json')
+    const snapshotPath = join(
+      testState.userDataDir,
+      'claude-runtime-auth',
+      'system-default-auth.json'
+    )
+    const managedCredentials = createClaudeCredentialsJson('user@example.com', 'managed')
+    mkdirSync(join(testState.userDataDir, 'claude-runtime-auth'), { recursive: true })
+    writeFileSync(
+      snapshotPath,
+      `${JSON.stringify({
+        credentialsJson: { token: 'system' },
+        keychainCredentialsJson: managedCredentials,
+        scopedKeychainCredentialsJson: { token: 'scoped' },
+        legacyKeychainCredentialsJson: managedCredentials,
+        capturedAt: Date.now()
+      })}\n`,
+      'utf-8'
+    )
+    writeFileSync(runtimeCredentialsPath, managedCredentials, 'utf-8')
+    writeFileSync(
+      runtimeConfigPath,
+      `${JSON.stringify({ oauthAccount: { accountUuid: 'account-1' } })}\n`,
+      'utf-8'
+    )
+    testState.scopedKeychainCredentials = managedCredentials
+    testState.legacyKeychainCredentials = managedCredentials
+    const managedAuthPath = createManagedClaudeAuth(
+      testState.userDataDir,
+      'account-1',
+      managedCredentials
+    )
+    const settings = createSettings({
+      claudeManagedAccounts: [createClaudeAccount('account-1', managedAuthPath)],
+      activeClaudeManagedAccountId: 'account-1'
+    })
+    const store = createStore(settings)
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const service = new ClaudeRuntimeAuthService(store as never)
+    settings.activeClaudeManagedAccountId = null
+    await service.syncForCurrentSelection()
+
+    expect(existsSync(snapshotPath)).toBe(false)
+    expect(existsSync(runtimeCredentialsPath)).toBe(false)
+    expect(readRuntimeOauthAccountForTest()).toBeNull()
+    expect(testState.scopedKeychainCredentials).toBeNull()
+    expect(testState.legacyKeychainCredentials).toBeNull()
+    warn.mockRestore()
+  })
+
+  it('preserves invalid external runtime oauth metadata when deselecting', async () => {
+    const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const runtimeConfigPath = join(testState.fakeHomeDir, '.claude.json')
+    const systemCredentials = createClaudeCredentialsJson('system@example.com', 'system')
+    const managedCredentials = createClaudeCredentialsJson('user@example.com', 'managed')
+    writeFileSync(runtimeCredentialsPath, systemCredentials, 'utf-8')
+    writeFileSync(runtimeConfigPath, `${JSON.stringify({})}\n`, 'utf-8')
+    const managedAuthPath = createManagedClaudeAuth(
+      testState.userDataDir,
+      'account-1',
+      managedCredentials,
+      'null\n'
+    )
+    const settings = createSettings({
+      claudeManagedAccounts: [createClaudeAccount('account-1', managedAuthPath)]
+    })
+    const store = createStore(settings)
+
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const service = new ClaudeRuntimeAuthService(store as never)
+    settings.activeClaudeManagedAccountId = 'account-1'
+    await service.syncForCurrentSelection()
+
+    writeFileSync(runtimeConfigPath, '{not-json', 'utf-8')
+    settings.activeClaudeManagedAccountId = null
+    await service.syncForCurrentSelection()
+
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(systemCredentials)
+    expect(readFileSync(runtimeConfigPath, 'utf-8')).toBe('{not-json')
+  })
+
+  it('preserves external oauth logout when managed oauth metadata is null', async () => {
+    const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const runtimeConfigPath = join(testState.fakeHomeDir, '.claude.json')
+    const systemCredentials = createClaudeCredentialsJson('system@example.com', 'system')
+    const managedCredentials = createClaudeCredentialsJson('user@example.com', 'managed')
+    writeFileSync(runtimeCredentialsPath, systemCredentials, 'utf-8')
+    writeFileSync(
+      runtimeConfigPath,
+      `${JSON.stringify({ oauthAccount: { accountUuid: 'system-account' } })}\n`,
+      'utf-8'
+    )
+    testState.scopedKeychainCredentials = systemCredentials
+    testState.legacyKeychainCredentials = systemCredentials
+    const managedAuthPath = createManagedClaudeAuth(
+      testState.userDataDir,
+      'account-1',
+      managedCredentials,
+      'null\n'
+    )
+    const settings = createSettings({
+      claudeManagedAccounts: [createClaudeAccount('account-1', managedAuthPath)]
+    })
+    const store = createStore(settings)
+
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const service = new ClaudeRuntimeAuthService(store as never)
+    settings.activeClaudeManagedAccountId = 'account-1'
+    await service.syncForCurrentSelection()
+
+    rmSync(runtimeCredentialsPath, { force: true })
+    testState.scopedKeychainCredentials = null
+    testState.legacyKeychainCredentials = null
+    writeFileSync(runtimeConfigPath, `${JSON.stringify({})}\n`, 'utf-8')
+    settings.activeClaudeManagedAccountId = null
+    await service.syncForCurrentSelection()
+
+    expect(existsSync(runtimeCredentialsPath)).toBe(false)
+    expect(readRuntimeOauthAccountForTest()).toBeNull()
+    expect(testState.scopedKeychainCredentials).toBeNull()
+    expect(testState.legacyKeychainCredentials).toBeNull()
+  })
+
+  it('restores reordered owned oauth metadata using stable json equality', async () => {
+    const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const runtimeConfigPath = join(testState.fakeHomeDir, '.claude.json')
+    const systemCredentials = createClaudeCredentialsJson('system@example.com', 'system')
+    const managedCredentials = createClaudeCredentialsJson('user@example.com', 'managed')
+    const systemOauthAccount = { accountUuid: 'system-account', emailAddress: 'system@example.com' }
+    writeFileSync(runtimeCredentialsPath, systemCredentials, 'utf-8')
+    writeFileSync(
+      runtimeConfigPath,
+      `${JSON.stringify({ oauthAccount: systemOauthAccount })}\n`,
+      'utf-8'
+    )
+    const managedAuthPath = createManagedClaudeAuth(
+      testState.userDataDir,
+      'account-1',
+      managedCredentials,
+      '{"accountUuid":"account-1","emailAddress":"user@example.com"}\n'
+    )
+    const settings = createSettings({
+      claudeManagedAccounts: [createClaudeAccount('account-1', managedAuthPath)]
+    })
+    const store = createStore(settings)
+
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const service = new ClaudeRuntimeAuthService(store as never)
+    settings.activeClaudeManagedAccountId = 'account-1'
+    await service.syncForCurrentSelection()
+
+    writeFileSync(
+      runtimeConfigPath,
+      '{"oauthAccount":{"emailAddress":"user@example.com","accountUuid":"account-1"}}\n',
+      'utf-8'
+    )
+    settings.activeClaudeManagedAccountId = null
+    await service.syncForCurrentSelection()
+
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(systemCredentials)
+    expect(readRuntimeOauthAccountForTest()).toEqual(systemOauthAccount)
+  })
+
+  it('restores owned oauth metadata during rollback after removing the added account', async () => {
+    const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const runtimeConfigPath = join(testState.fakeHomeDir, '.claude.json')
+    const systemCredentials = createClaudeCredentialsJson('system@example.com', 'system')
+    const managedCredentials = createClaudeCredentialsJson('user@example.com', 'managed')
+    const systemOauthAccount = { accountUuid: 'system-account' }
+    writeFileSync(runtimeCredentialsPath, systemCredentials, 'utf-8')
+    writeFileSync(
+      runtimeConfigPath,
+      `${JSON.stringify({ oauthAccount: systemOauthAccount })}\n`,
+      'utf-8'
+    )
+    const managedAuthPath = createManagedClaudeAuth(
+      testState.userDataDir,
+      'account-1',
+      managedCredentials,
+      '{"accountUuid":"account-1"}\n'
+    )
+    const settings = createSettings({
+      claudeManagedAccounts: [createClaudeAccount('account-1', managedAuthPath)]
+    })
+    const store = createStore(settings)
+
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const service = new ClaudeRuntimeAuthService(store as never)
+    settings.activeClaudeManagedAccountId = 'account-1'
+    await service.syncForCurrentSelection()
+
+    settings.activeClaudeManagedAccountId = null
+    settings.claudeManagedAccounts = []
+    await service.forceMaterializeCurrentSelectionForRollback()
+
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(systemCredentials)
+    expect(readRuntimeOauthAccountForTest()).toEqual(systemOauthAccount)
+  })
+
+  it('reads back refreshed file credentials when keychain reads fail', async () => {
+    const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const originalCredentials = createClaudeCredentialsJson('user@example.com', 'original')
+    const refreshedCredentials = createClaudeCredentialsJson('user@example.com', 'refreshed')
+    const managedAuthPath = createManagedClaudeAuth(
+      testState.userDataDir,
+      'account-1',
+      originalCredentials
+    )
+    const settings = createSettings({
+      claudeManagedAccounts: [createClaudeAccount('account-1', managedAuthPath)],
+      activeClaudeManagedAccountId: 'account-1'
+    })
+    const store = createStore(settings)
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const service = new ClaudeRuntimeAuthService(store as never)
+    await service.syncForCurrentSelection()
+
+    writeFileSync(runtimeCredentialsPath, refreshedCredentials, 'utf-8')
+    testState.throwScopedKeychainRead = true
+    testState.throwLegacyKeychainRead = true
+    await service.syncForCurrentSelection()
+
+    expect(readManagedCredentialsForTest('account-1', managedAuthPath)).toBe(refreshedCredentials)
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(refreshedCredentials)
+    warn.mockRestore()
   })
 
   it('captures a fresh system-default snapshot when re-entering managed mode', async () => {
@@ -1312,6 +1811,88 @@ describe('ClaudeRuntimeAuthService', () => {
       expect(testState.scopedKeychainCredentials).toBe(activeCredentials)
       expect(testState.legacyKeychainCredentials).toBe(activeCredentials)
     }
+  })
+
+  it('rejects same-email read-back when another account needs organization proof', async () => {
+    const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const noOrgCredentials = createClaudeCredentialsJson('same@example.com', 'no-org')
+    const orgCredentials = createClaudeCredentialsJson('same@example.com', 'org', 'org-b')
+    const refreshedWithoutOrg = createClaudeCredentialsJson('same@example.com', 'refreshed')
+    const managedAuthPath1 = createManagedClaudeAuth(
+      testState.userDataDir,
+      'account-1',
+      noOrgCredentials
+    )
+    const managedAuthPath2 = createManagedClaudeAuth(
+      testState.userDataDir,
+      'account-2',
+      orgCredentials
+    )
+    const settings = createSettings({
+      claudeManagedAccounts: [
+        createClaudeAccount('account-1', managedAuthPath1, { email: 'same@example.com' }),
+        createClaudeAccount('account-2', managedAuthPath2, {
+          email: 'same@example.com',
+          organizationUuid: 'org-b'
+        })
+      ],
+      activeClaudeManagedAccountId: 'account-1'
+    })
+    const store = createStore(settings)
+
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const service = new ClaudeRuntimeAuthService(store as never)
+    await service.syncForCurrentSelection()
+
+    writeFileSync(runtimeCredentialsPath, refreshedWithoutOrg, 'utf-8')
+    await service.syncForCurrentSelection()
+
+    expect(readManagedCredentialsForTest('account-1', managedAuthPath1)).toBe(noOrgCredentials)
+    expect(readManagedCredentialsForTest('account-2', managedAuthPath2)).toBe(orgCredentials)
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(noOrgCredentials)
+  })
+
+  it('rejects same-email read-back with conflicting organization for no-org accounts', async () => {
+    const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const noOrgCredentials = createClaudeCredentialsJson('same@example.com', 'no-org')
+    const orgCredentials = createClaudeCredentialsJson('same@example.com', 'org', 'org-b')
+    const conflictingOrgCredentials = createClaudeCredentialsJson(
+      'same@example.com',
+      'conflicting-org',
+      'org-c'
+    )
+    const managedAuthPath1 = createManagedClaudeAuth(
+      testState.userDataDir,
+      'account-1',
+      noOrgCredentials
+    )
+    const managedAuthPath2 = createManagedClaudeAuth(
+      testState.userDataDir,
+      'account-2',
+      orgCredentials
+    )
+    const settings = createSettings({
+      claudeManagedAccounts: [
+        createClaudeAccount('account-1', managedAuthPath1, { email: 'same@example.com' }),
+        createClaudeAccount('account-2', managedAuthPath2, {
+          email: 'same@example.com',
+          organizationUuid: 'org-b'
+        })
+      ],
+      activeClaudeManagedAccountId: 'account-1'
+    })
+    const store = createStore(settings)
+
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const service = new ClaudeRuntimeAuthService(store as never)
+    await service.syncForCurrentSelection()
+
+    writeFileSync(runtimeCredentialsPath, conflictingOrgCredentials, 'utf-8')
+    await service.syncForCurrentSelection()
+
+    expect(readManagedCredentialsForTest('account-1', managedAuthPath1)).toBe(noOrgCredentials)
+    expect(readManagedCredentialsForTest('account-2', managedAuthPath2)).toBe(orgCredentials)
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(noOrgCredentials)
   })
 
   it('clears an invalid active Claude account before launch preparation', async () => {

--- a/src/main/claude-accounts/runtime-auth-service.test.ts
+++ b/src/main/claude-accounts/runtime-auth-service.test.ts
@@ -297,6 +297,29 @@ describe('ClaudeRuntimeAuthService', () => {
     expect(testState.runtimeWriteConfigDir).toBe(expectedRuntimeConfigDir())
   })
 
+  it('restores system default instead of materializing corrupt managed credentials', async () => {
+    const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const systemCredentials = createClaudeCredentialsJson('system@example.com', 'system')
+    writeFileSync(runtimeCredentialsPath, systemCredentials, 'utf-8')
+    testState.scopedKeychainCredentials = systemCredentials
+    testState.legacyKeychainCredentials = systemCredentials
+    const managedAuthPath = createManagedClaudeAuth(testState.userDataDir, 'account-1', '{not-json')
+    const settings = createSettings({
+      claudeManagedAccounts: [createClaudeAccount('account-1', managedAuthPath)],
+      activeClaudeManagedAccountId: 'account-1'
+    })
+    const store = createStore(settings)
+
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const service = new ClaudeRuntimeAuthService(store as never)
+    await service.syncForCurrentSelection()
+
+    expect(store.getSettings().activeClaudeManagedAccountId).toBeNull()
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(systemCredentials)
+    expect(testState.scopedKeychainCredentials).toBe(systemCredentials)
+    expect(testState.legacyKeychainCredentials).toBe(systemCredentials)
+  })
+
   it('removes runtime credentials when deselecting with a missing system-default snapshot', async () => {
     const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
     writeFileSync(runtimeCredentialsPath, '{"token":"managed"}\n', 'utf-8')

--- a/src/main/claude-accounts/runtime-auth-service.test.ts
+++ b/src/main/claude-accounts/runtime-auth-service.test.ts
@@ -2669,6 +2669,67 @@ describe('ClaudeRuntimeAuthService', () => {
     expect(testState.legacyKeychainCredentials).toBe(systemCredentials)
   })
 
+  it('keeps missing-managed selection until cleanup can retry after keychain failure', async () => {
+    const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const runtimeConfigPath = join(testState.fakeHomeDir, '.claude.json')
+    const snapshotPath = join(
+      testState.userDataDir,
+      'claude-runtime-auth',
+      'system-default-auth.json'
+    )
+    const systemCredentials = createClaudeCredentialsJson('system@example.com', 'system')
+    const staleManagedCredentials = createClaudeCredentialsJson('managed@example.com', 'managed')
+    const systemOauthAccount = { accountUuid: 'system-account' }
+    const managedAuthPath = join(testState.userDataDir, 'claude-accounts', 'account-1', 'auth')
+    mkdirSync(join(testState.userDataDir, 'claude-runtime-auth'), { recursive: true })
+    mkdirSync(managedAuthPath, { recursive: true })
+    writeFileSync(
+      snapshotPath,
+      `${JSON.stringify({
+        credentialsJson: systemCredentials,
+        configOauthAccount: systemOauthAccount,
+        keychainCredentialsJson: systemCredentials,
+        scopedKeychainCredentialsJson: systemCredentials,
+        legacyKeychainCredentialsJson: systemCredentials,
+        capturedAt: Date.now()
+      })}\n`,
+      'utf-8'
+    )
+    writeFileSync(runtimeCredentialsPath, staleManagedCredentials, 'utf-8')
+    writeFileSync(
+      runtimeConfigPath,
+      `${JSON.stringify({ oauthAccount: { accountUuid: 'account-1' } })}\n`,
+      'utf-8'
+    )
+    testState.scopedKeychainCredentials = staleManagedCredentials
+    testState.legacyKeychainCredentials = staleManagedCredentials
+    const settings = createSettings({
+      claudeManagedAccounts: [
+        createClaudeAccount('account-1', managedAuthPath, { email: 'managed@example.com' })
+      ],
+      activeClaudeManagedAccountId: 'account-1'
+    })
+    const store = createStore(settings)
+
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const service = new ClaudeRuntimeAuthService(store as never)
+    testState.throwScopedKeychainWrite = true
+    await expect(service.prepareForClaudeLaunch()).rejects.toThrow('scoped keychain write failed')
+
+    expect(store.getSettings().activeClaudeManagedAccountId).toBe('account-1')
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(systemCredentials)
+    expect(readRuntimeOauthAccountForTest()).toEqual(systemOauthAccount)
+    expect(testState.scopedKeychainCredentials).toBe(staleManagedCredentials)
+
+    testState.throwScopedKeychainWrite = false
+    const preparation = await service.prepareForClaudeLaunch()
+
+    expect(preparation.provenance).toBe('system')
+    expect(store.getSettings().activeClaudeManagedAccountId).toBeNull()
+    expect(testState.scopedKeychainCredentials).toBe(systemCredentials)
+    expect(testState.legacyKeychainCredentials).toBe(systemCredentials)
+  })
+
   it('restores missing-managed oauth metadata when only keychain proves ownership', async () => {
     const runtimeConfigPath = join(testState.fakeHomeDir, '.claude.json')
     const snapshotPath = join(

--- a/src/main/claude-accounts/runtime-auth-service.test.ts
+++ b/src/main/claude-accounts/runtime-auth-service.test.ts
@@ -1766,6 +1766,50 @@ describe('ClaudeRuntimeAuthService', () => {
     }
   })
 
+  it('rejects stale cold-start read-back for inactive matching account', async () => {
+    const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const account1ManagedNewer = createClaudeCredentialsJson(
+      'one@example.com',
+      'one-managed-newer',
+      null,
+      5_000
+    )
+    const account1RuntimeStale = createClaudeCredentialsJson(
+      'one@example.com',
+      'one-runtime-stale',
+      null,
+      2_000
+    )
+    const account2Credentials = createClaudeCredentialsJson('two@example.com', 'two', null, 1_000)
+    writeFileSync(runtimeCredentialsPath, account1RuntimeStale, 'utf-8')
+    const managedAuthPath1 = createManagedClaudeAuth(
+      testState.userDataDir,
+      'account-1',
+      account1ManagedNewer
+    )
+    const managedAuthPath2 = createManagedClaudeAuth(
+      testState.userDataDir,
+      'account-2',
+      account2Credentials
+    )
+    const settings = createSettings({
+      claudeManagedAccounts: [
+        createClaudeAccount('account-1', managedAuthPath1, { email: 'one@example.com' }),
+        createClaudeAccount('account-2', managedAuthPath2, { email: 'two@example.com' })
+      ],
+      activeClaudeManagedAccountId: 'account-2'
+    })
+    const store = createStore(settings)
+
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const service = new ClaudeRuntimeAuthService(store as never)
+    await service.syncForCurrentSelection()
+
+    expect(readManagedCredentialsForTest('account-1', managedAuthPath1)).toBe(account1ManagedNewer)
+    expect(readManagedCredentialsForTest('account-2', managedAuthPath2)).toBe(account2Credentials)
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(account2Credentials)
+  })
+
   it('rejects ambiguous Claude read-back instead of choosing a managed account', async () => {
     const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
     const originalCredentials = createClaudeCredentialsJson('same@example.com', 'same-original')

--- a/src/main/claude-accounts/runtime-auth-service.test.ts
+++ b/src/main/claude-accounts/runtime-auth-service.test.ts
@@ -3,11 +3,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   chmodSync,
   existsSync,
+  lstatSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
   rmSync,
   statSync,
+  symlinkSync,
   writeFileSync
 } from 'node:fs'
 import { tmpdir } from 'node:os'
@@ -170,6 +172,7 @@ function createManagedClaudeAuth(
 ): string {
   const managedAuthPath = join(rootDir, 'claude-accounts', accountId, 'auth')
   mkdirSync(managedAuthPath, { recursive: true })
+  writeFileSync(join(managedAuthPath, '.orca-managed-claude-auth'), `${accountId}\n`, 'utf-8')
   writeFileSync(join(managedAuthPath, '.credentials.json'), credentialsJson, 'utf-8')
   writeFileSync(join(managedAuthPath, 'oauth-account.json'), oauthAccountJson, 'utf-8')
   testState.managedKeychainCredentials.set(accountId, credentialsJson)
@@ -342,6 +345,272 @@ describe('ClaudeRuntimeAuthService', () => {
     expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(systemCredentials)
     expect(testState.scopedKeychainCredentials).toBe(systemCredentials)
     expect(testState.legacyKeychainCredentials).toBe(systemCredentials)
+  })
+
+  it('does not materialize managed credentials from unowned auth paths', async () => {
+    const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const systemCredentials = createClaudeCredentialsJson('system@example.com', 'system')
+    const managedCredentials = createClaudeCredentialsJson('user@example.com', 'managed')
+    writeFileSync(runtimeCredentialsPath, systemCredentials, 'utf-8')
+    const unownedAuthPath = join(testState.fakeHomeDir, 'unowned-claude-auth')
+    mkdirSync(unownedAuthPath, { recursive: true })
+    writeFileSync(join(unownedAuthPath, '.credentials.json'), managedCredentials, 'utf-8')
+    writeFileSync(
+      join(unownedAuthPath, 'oauth-account.json'),
+      `${JSON.stringify({ accountUuid: 'account-1' })}\n`,
+      'utf-8'
+    )
+    const settings = createSettings({
+      claudeManagedAccounts: [createClaudeAccount('account-1', unownedAuthPath)],
+      activeClaudeManagedAccountId: 'account-1'
+    })
+    const store = createStore(settings)
+
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const service = new ClaudeRuntimeAuthService(store as never)
+    await service.syncForCurrentSelection()
+
+    expect(store.getSettings().activeClaudeManagedAccountId).toBeNull()
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(systemCredentials)
+  })
+
+  it('adopts canonical legacy managed auth paths without existing markers', async () => {
+    setPlatform('linux')
+    const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const managedCredentials = createClaudeCredentialsJson('user@example.com', 'managed')
+    const managedAuthPath = join(testState.userDataDir, 'claude-accounts', 'account-1', 'auth')
+    mkdirSync(managedAuthPath, { recursive: true })
+    writeFileSync(join(managedAuthPath, '.credentials.json'), managedCredentials, 'utf-8')
+    writeFileSync(
+      join(managedAuthPath, 'oauth-account.json'),
+      '{"accountUuid":"account-1"}\n',
+      'utf-8'
+    )
+    const settings = createSettings({
+      claudeManagedAccounts: [createClaudeAccount('account-1', managedAuthPath)],
+      activeClaudeManagedAccountId: 'account-1'
+    })
+    const store = createStore(settings)
+
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const service = new ClaudeRuntimeAuthService(store as never)
+    await service.syncForCurrentSelection()
+
+    const markerPath = join(managedAuthPath, '.orca-managed-claude-auth')
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(managedCredentials)
+    expect(lstatSync(markerPath).isFile()).toBe(true)
+    expect(readFileSync(markerPath, 'utf-8')).toBe('account-1\n')
+  })
+
+  it('rejects symlinked managed credential children', async () => {
+    setPlatform('linux')
+    const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const systemCredentials = createClaudeCredentialsJson('system@example.com', 'system')
+    const escapedCredentials = createClaudeCredentialsJson('user@example.com', 'escaped')
+    const managedAuthPath = join(testState.userDataDir, 'claude-accounts', 'account-1', 'auth')
+    const escapedCredentialsPath = join(testState.fakeHomeDir, 'escaped-credentials.json')
+    mkdirSync(managedAuthPath, { recursive: true })
+    writeFileSync(join(managedAuthPath, '.orca-managed-claude-auth'), 'account-1\n', 'utf-8')
+    writeFileSync(
+      join(managedAuthPath, 'oauth-account.json'),
+      '{"accountUuid":"account-1"}\n',
+      'utf-8'
+    )
+    writeFileSync(escapedCredentialsPath, escapedCredentials, 'utf-8')
+    symlinkSync(escapedCredentialsPath, join(managedAuthPath, '.credentials.json'))
+    writeFileSync(runtimeCredentialsPath, systemCredentials, 'utf-8')
+    const settings = createSettings({
+      claudeManagedAccounts: [createClaudeAccount('account-1', managedAuthPath)],
+      activeClaudeManagedAccountId: 'account-1'
+    })
+    const store = createStore(settings)
+
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const service = new ClaudeRuntimeAuthService(store as never)
+    await service.syncForCurrentSelection()
+
+    expect(store.getSettings().activeClaudeManagedAccountId).toBeNull()
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(systemCredentials)
+  })
+
+  it('restores system auth when switching from an owned account to an unowned account', async () => {
+    setPlatform('linux')
+    const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const runtimeConfigPath = join(testState.fakeHomeDir, '.claude.json')
+    const systemCredentials = createClaudeCredentialsJson('system@example.com', 'system')
+    const ownedCredentials = createClaudeCredentialsJson('owned@example.com', 'owned')
+    const unownedCredentials = createClaudeCredentialsJson('unowned@example.com', 'unowned')
+    const systemOauthAccount = { accountUuid: 'system-account' }
+    writeFileSync(runtimeCredentialsPath, systemCredentials, 'utf-8')
+    writeFileSync(
+      runtimeConfigPath,
+      `${JSON.stringify({ oauthAccount: systemOauthAccount })}\n`,
+      'utf-8'
+    )
+    const ownedAuthPath = createManagedClaudeAuth(
+      testState.userDataDir,
+      'account-1',
+      ownedCredentials
+    )
+    const unownedAuthPath = join(testState.fakeHomeDir, 'unowned-claude-auth')
+    mkdirSync(unownedAuthPath, { recursive: true })
+    writeFileSync(join(unownedAuthPath, '.credentials.json'), unownedCredentials, 'utf-8')
+    let settings = createSettings({
+      claudeManagedAccounts: [
+        createClaudeAccount('account-1', ownedAuthPath, { email: 'owned@example.com' }),
+        createClaudeAccount('account-2', unownedAuthPath, { email: 'unowned@example.com' })
+      ],
+      activeClaudeManagedAccountId: null
+    })
+    const store = {
+      getSettings: vi.fn(() => settings),
+      updateSettings: vi.fn((updates: Partial<GlobalSettings>) => {
+        settings = {
+          ...settings,
+          ...updates,
+          notifications: {
+            ...settings.notifications,
+            ...updates.notifications
+          }
+        }
+        return settings
+      })
+    }
+
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const service = new ClaudeRuntimeAuthService(store as never)
+    store.updateSettings({ activeClaudeManagedAccountId: 'account-1' })
+    await service.syncForCurrentSelection()
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(ownedCredentials)
+
+    store.updateSettings({ activeClaudeManagedAccountId: 'account-2' })
+    await service.syncForCurrentSelection()
+
+    expect(store.getSettings().activeClaudeManagedAccountId).toBeNull()
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(systemCredentials)
+    expect(readRuntimeOauthAccountForTest()).toEqual(systemOauthAccount)
+  })
+
+  it('restores system auth when the previously synced account is no longer in settings', async () => {
+    setPlatform('linux')
+    const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const runtimeConfigPath = join(testState.fakeHomeDir, '.claude.json')
+    const systemCredentials = createClaudeCredentialsJson('system@example.com', 'system')
+    const ownedCredentials = createClaudeCredentialsJson('owned@example.com', 'owned')
+    const systemOauthAccount = { accountUuid: 'system-account' }
+    writeFileSync(runtimeCredentialsPath, systemCredentials, 'utf-8')
+    writeFileSync(
+      runtimeConfigPath,
+      `${JSON.stringify({ oauthAccount: systemOauthAccount })}\n`,
+      'utf-8'
+    )
+    const ownedAuthPath = createManagedClaudeAuth(
+      testState.userDataDir,
+      'account-1',
+      ownedCredentials
+    )
+    const unownedAuthPath = join(testState.fakeHomeDir, 'unowned-claude-auth')
+    mkdirSync(unownedAuthPath, { recursive: true })
+    let settings = createSettings({
+      claudeManagedAccounts: [
+        createClaudeAccount('account-1', ownedAuthPath, { email: 'owned@example.com' })
+      ],
+      activeClaudeManagedAccountId: null
+    })
+    const store = {
+      getSettings: vi.fn(() => settings),
+      updateSettings: vi.fn((updates: Partial<GlobalSettings>) => {
+        settings = {
+          ...settings,
+          ...updates,
+          notifications: {
+            ...settings.notifications,
+            ...updates.notifications
+          }
+        }
+        return settings
+      })
+    }
+
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const service = new ClaudeRuntimeAuthService(store as never)
+    store.updateSettings({ activeClaudeManagedAccountId: 'account-1' })
+    await service.syncForCurrentSelection()
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(ownedCredentials)
+
+    store.updateSettings({
+      claudeManagedAccounts: [
+        createClaudeAccount('account-2', unownedAuthPath, { email: 'unowned@example.com' })
+      ],
+      activeClaudeManagedAccountId: 'account-2'
+    })
+    await service.syncForCurrentSelection()
+
+    expect(store.getSettings().activeClaudeManagedAccountId).toBeNull()
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(systemCredentials)
+    expect(readRuntimeOauthAccountForTest()).toEqual(systemOauthAccount)
+  })
+
+  it('restores system auth when switching from an owned account to missing credentials', async () => {
+    setPlatform('linux')
+    const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const runtimeConfigPath = join(testState.fakeHomeDir, '.claude.json')
+    const systemCredentials = createClaudeCredentialsJson('system@example.com', 'system')
+    const account1Credentials = createClaudeCredentialsJson('one@example.com', 'one')
+    const systemOauthAccount = { accountUuid: 'system-account' }
+    writeFileSync(runtimeCredentialsPath, systemCredentials, 'utf-8')
+    writeFileSync(
+      runtimeConfigPath,
+      `${JSON.stringify({ oauthAccount: systemOauthAccount })}\n`,
+      'utf-8'
+    )
+    const managedAuthPath1 = createManagedClaudeAuth(
+      testState.userDataDir,
+      'account-1',
+      account1Credentials
+    )
+    const managedAuthPath2 = join(testState.userDataDir, 'claude-accounts', 'account-2', 'auth')
+    mkdirSync(managedAuthPath2, { recursive: true })
+    writeFileSync(join(managedAuthPath2, '.orca-managed-claude-auth'), 'account-2\n', 'utf-8')
+    writeFileSync(
+      join(managedAuthPath2, 'oauth-account.json'),
+      '{"accountUuid":"account-2"}\n',
+      'utf-8'
+    )
+    let settings = createSettings({
+      claudeManagedAccounts: [
+        createClaudeAccount('account-1', managedAuthPath1, { email: 'one@example.com' }),
+        createClaudeAccount('account-2', managedAuthPath2, { email: 'two@example.com' })
+      ],
+      activeClaudeManagedAccountId: null
+    })
+    const store = {
+      getSettings: vi.fn(() => settings),
+      updateSettings: vi.fn((updates: Partial<GlobalSettings>) => {
+        settings = {
+          ...settings,
+          ...updates,
+          notifications: {
+            ...settings.notifications,
+            ...updates.notifications
+          }
+        }
+        return settings
+      })
+    }
+
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const service = new ClaudeRuntimeAuthService(store as never)
+    store.updateSettings({ activeClaudeManagedAccountId: 'account-1' })
+    await service.syncForCurrentSelection()
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(account1Credentials)
+
+    store.updateSettings({ activeClaudeManagedAccountId: 'account-2' })
+    await service.syncForCurrentSelection()
+
+    expect(store.getSettings().activeClaudeManagedAccountId).toBeNull()
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(systemCredentials)
+    expect(readRuntimeOauthAccountForTest()).toEqual(systemOauthAccount)
   })
 
   it('removes runtime credentials when deselecting with a missing system-default snapshot', async () => {
@@ -696,6 +965,34 @@ describe('ClaudeRuntimeAuthService', () => {
 
     expect(readManagedCredentialsForTest('account-1', managedAuthPath)).toBe(selectedCredentials)
     expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(selectedCredentials)
+  })
+
+  it('rejects no-email refreshed credentials even when organization identity matches', async () => {
+    const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const originalCredentials = createClaudeCredentialsJson('user@example.com', 'original', 'org-a')
+    const refreshedCredentials = createClaudeCredentialsWithoutEmail('refreshed', 'org-a')
+    const managedAuthPath = createManagedClaudeAuth(
+      testState.userDataDir,
+      'account-1',
+      originalCredentials
+    )
+    const settings = createSettings({
+      claudeManagedAccounts: [
+        createClaudeAccount('account-1', managedAuthPath, { organizationUuid: 'org-a' })
+      ],
+      activeClaudeManagedAccountId: 'account-1'
+    })
+    const store = createStore(settings)
+
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const service = new ClaudeRuntimeAuthService(store as never)
+    await service.syncForCurrentSelection()
+
+    writeFileSync(runtimeCredentialsPath, refreshedCredentials, 'utf-8')
+    await service.syncForCurrentSelection()
+
+    expect(readManagedCredentialsForTest('account-1', managedAuthPath)).toBe(originalCredentials)
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(originalCredentials)
   })
 
   it('rejects unverifiable refreshed runtime credentials', async () => {
@@ -1800,6 +2097,7 @@ describe('ClaudeRuntimeAuthService', () => {
     const staleManagedCredentials = createClaudeCredentialsJson('managed@example.com', 'managed')
     const managedAuthPath = join(testState.userDataDir, 'claude-accounts', 'account-1', 'auth')
     mkdirSync(managedAuthPath, { recursive: true })
+    writeFileSync(join(managedAuthPath, '.orca-managed-claude-auth'), 'account-1\n', 'utf-8')
     mkdirSync(join(testState.userDataDir, 'claude-runtime-auth'), { recursive: true })
     writeFileSync(
       snapshotPath,
@@ -1831,11 +2129,11 @@ describe('ClaudeRuntimeAuthService', () => {
     const service = new ClaudeRuntimeAuthService(store as never)
     await service.prepareForClaudeLaunch()
 
-    expect(existsSync(snapshotPath)).toBe(false)
-    expect(existsSync(runtimeCredentialsPath)).toBe(false)
-    expect(readRuntimeOauthAccountForTest()).toBeNull()
-    expect(testState.scopedKeychainCredentials).toBeNull()
-    expect(testState.legacyKeychainCredentials).toBeNull()
+    expect(existsSync(snapshotPath)).toBe(true)
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(staleManagedCredentials)
+    expect(readRuntimeOauthAccountForTest()).toEqual({ accountUuid: 'account-1' })
+    expect(testState.scopedKeychainCredentials).toBe(staleManagedCredentials)
+    expect(testState.legacyKeychainCredentials).toBe(staleManagedCredentials)
     warn.mockRestore()
   })
 
@@ -1844,6 +2142,7 @@ describe('ClaudeRuntimeAuthService', () => {
     const staleManagedCredentials = createClaudeCredentialsJson('managed@example.com', 'managed')
     const managedAuthPath = join(testState.userDataDir, 'claude-accounts', 'account-1', 'auth')
     mkdirSync(managedAuthPath, { recursive: true })
+    writeFileSync(join(managedAuthPath, '.orca-managed-claude-auth'), 'account-1\n', 'utf-8')
     writeFileSync(
       runtimeConfigPath,
       `${JSON.stringify({ oauthAccount: { accountUuid: 'account-1' } })}\n`,
@@ -1863,9 +2162,9 @@ describe('ClaudeRuntimeAuthService', () => {
     const service = new ClaudeRuntimeAuthService(store as never)
     await service.prepareForClaudeLaunch()
 
-    expect(readRuntimeOauthAccountForTest()).toBeNull()
-    expect(testState.scopedKeychainCredentials).toBeNull()
-    expect(testState.legacyKeychainCredentials).toBeNull()
+    expect(readRuntimeOauthAccountForTest()).toEqual({ accountUuid: 'account-1' })
+    expect(testState.scopedKeychainCredentials).toBe(staleManagedCredentials)
+    expect(testState.legacyKeychainCredentials).toBe(staleManagedCredentials)
   })
 
   it('preserves missing-managed oauth metadata without credential ownership proof', async () => {
@@ -2630,6 +2929,7 @@ describe('ClaudeRuntimeAuthService', () => {
     const managedAuthPath = join(testState.userDataDir, 'claude-accounts', 'account-1', 'auth')
     mkdirSync(join(testState.userDataDir, 'claude-runtime-auth'), { recursive: true })
     mkdirSync(managedAuthPath, { recursive: true })
+    writeFileSync(join(managedAuthPath, '.orca-managed-claude-auth'), 'account-1\n', 'utf-8')
     writeFileSync(
       snapshotPath,
       `${JSON.stringify({
@@ -2663,10 +2963,10 @@ describe('ClaudeRuntimeAuthService', () => {
     const preparation = await service.prepareForClaudeLaunch()
 
     expect(preparation.provenance).toBe('system')
-    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(systemCredentials)
-    expect(readRuntimeOauthAccountForTest()).toEqual(systemOauthAccount)
-    expect(testState.scopedKeychainCredentials).toBe(systemCredentials)
-    expect(testState.legacyKeychainCredentials).toBe(systemCredentials)
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(staleManagedCredentials)
+    expect(readRuntimeOauthAccountForTest()).toEqual({ accountUuid: 'account-1' })
+    expect(testState.scopedKeychainCredentials).toBe(staleManagedCredentials)
+    expect(testState.legacyKeychainCredentials).toBe(staleManagedCredentials)
   })
 
   it('keeps missing-managed selection until cleanup can retry after keychain failure', async () => {
@@ -2683,6 +2983,7 @@ describe('ClaudeRuntimeAuthService', () => {
     const managedAuthPath = join(testState.userDataDir, 'claude-accounts', 'account-1', 'auth')
     mkdirSync(join(testState.userDataDir, 'claude-runtime-auth'), { recursive: true })
     mkdirSync(managedAuthPath, { recursive: true })
+    writeFileSync(join(managedAuthPath, '.orca-managed-claude-auth'), 'account-1\n', 'utf-8')
     writeFileSync(
       snapshotPath,
       `${JSON.stringify({
@@ -2714,11 +3015,12 @@ describe('ClaudeRuntimeAuthService', () => {
     const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
     const service = new ClaudeRuntimeAuthService(store as never)
     testState.throwScopedKeychainWrite = true
-    await expect(service.prepareForClaudeLaunch()).rejects.toThrow('scoped keychain write failed')
+    const failedPreparation = await service.prepareForClaudeLaunch()
 
-    expect(store.getSettings().activeClaudeManagedAccountId).toBe('account-1')
-    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(systemCredentials)
-    expect(readRuntimeOauthAccountForTest()).toEqual(systemOauthAccount)
+    expect(failedPreparation.provenance).toBe('system')
+    expect(store.getSettings().activeClaudeManagedAccountId).toBeNull()
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(staleManagedCredentials)
+    expect(readRuntimeOauthAccountForTest()).toEqual({ accountUuid: 'account-1' })
     expect(testState.scopedKeychainCredentials).toBe(staleManagedCredentials)
 
     testState.throwScopedKeychainWrite = false
@@ -2726,8 +3028,8 @@ describe('ClaudeRuntimeAuthService', () => {
 
     expect(preparation.provenance).toBe('system')
     expect(store.getSettings().activeClaudeManagedAccountId).toBeNull()
-    expect(testState.scopedKeychainCredentials).toBe(systemCredentials)
-    expect(testState.legacyKeychainCredentials).toBe(systemCredentials)
+    expect(testState.scopedKeychainCredentials).toBe(staleManagedCredentials)
+    expect(testState.legacyKeychainCredentials).toBe(staleManagedCredentials)
   })
 
   it('restores missing-managed oauth metadata when only keychain proves ownership', async () => {
@@ -2743,6 +3045,7 @@ describe('ClaudeRuntimeAuthService', () => {
     const managedAuthPath = join(testState.userDataDir, 'claude-accounts', 'account-1', 'auth')
     mkdirSync(join(testState.userDataDir, 'claude-runtime-auth'), { recursive: true })
     mkdirSync(managedAuthPath, { recursive: true })
+    writeFileSync(join(managedAuthPath, '.orca-managed-claude-auth'), 'account-1\n', 'utf-8')
     writeFileSync(
       snapshotPath,
       `${JSON.stringify({
@@ -2774,9 +3077,9 @@ describe('ClaudeRuntimeAuthService', () => {
     const service = new ClaudeRuntimeAuthService(store as never)
     await service.prepareForClaudeLaunch()
 
-    expect(readRuntimeOauthAccountForTest()).toEqual(systemOauthAccount)
-    expect(testState.scopedKeychainCredentials).toBe(systemCredentials)
-    expect(testState.legacyKeychainCredentials).toBe(systemCredentials)
+    expect(readRuntimeOauthAccountForTest()).toEqual({ accountUuid: 'account-1' })
+    expect(testState.scopedKeychainCredentials).toBe(staleManagedCredentials)
+    expect(testState.legacyKeychainCredentials).toBe(staleManagedCredentials)
   })
 
   it('preserves unknown runtime auth when invalid active account has no system snapshot', async () => {

--- a/src/main/claude-accounts/runtime-auth-service.test.ts
+++ b/src/main/claude-accounts/runtime-auth-service.test.ts
@@ -44,6 +44,9 @@ vi.mock('./keychain', () => ({
   deleteActiveClaudeKeychainCredentials: vi.fn(async () => {
     testState.activeKeychainCredentials = null
   }),
+  deleteActiveClaudeKeychainCredentialsStrict: vi.fn(async () => {
+    testState.activeKeychainCredentials = null
+  }),
   readManagedClaudeKeychainCredentials: vi.fn(
     async (accountId: string) => testState.managedKeychainCredentials.get(accountId) ?? null
   ),
@@ -210,6 +213,10 @@ describe('ClaudeRuntimeAuthService', () => {
 
     expect(existsSync(runtimeCredentialsPath)).toBe(false)
     if (process.platform === 'darwin') {
+      const { deleteActiveClaudeKeychainCredentialsStrict } = await import('./keychain')
+      expect(deleteActiveClaudeKeychainCredentialsStrict).toHaveBeenCalledWith(
+        join(testState.fakeHomeDir, '.claude')
+      )
       expect(testState.activeKeychainCredentials).toBeNull()
     }
   })
@@ -1013,6 +1020,7 @@ describe('ClaudeRuntimeAuthService', () => {
     const preparation = await service.prepareForClaudeLaunch()
 
     expect(store.updateSettings).toHaveBeenCalledWith({ activeClaudeManagedAccountId: null })
+    expect(preparation.configDir).toBe(join(testState.fakeHomeDir, '.claude'))
     expect(preparation.stripAuthEnv).toBe(false)
     expect(preparation.provenance).toBe('system')
   })

--- a/src/main/claude-accounts/runtime-auth-service.test.ts
+++ b/src/main/claude-accounts/runtime-auth-service.test.ts
@@ -25,6 +25,7 @@ const testState = {
   throwScopedKeychainRead: false,
   throwLegacyKeychainRead: false,
   throwRuntimeKeychainWrite: false,
+  throwLegacyRuntimeKeychainWrite: false,
   throwScopedKeychainWrite: false,
   runtimeWriteConfigDir: null as string | null,
   managedKeychainCredentials: new Map<string, string>()
@@ -115,6 +116,9 @@ vi.mock('./keychain', () => ({
       }
       testState.runtimeWriteConfigDir = configDir
       testState.scopedKeychainCredentials = contents
+      if (testState.throwLegacyRuntimeKeychainWrite) {
+        throw new Error('legacy runtime keychain write failed')
+      }
       testState.legacyKeychainCredentials = contents
       testState.activeKeychainCredentials = contents
     }
@@ -250,6 +254,7 @@ describe('ClaudeRuntimeAuthService', () => {
     testState.throwScopedKeychainRead = false
     testState.throwLegacyKeychainRead = false
     testState.throwRuntimeKeychainWrite = false
+    testState.throwLegacyRuntimeKeychainWrite = false
     testState.throwScopedKeychainWrite = false
     testState.runtimeWriteConfigDir = null
     testState.managedKeychainCredentials.clear()
@@ -953,6 +958,81 @@ describe('ClaudeRuntimeAuthService', () => {
     expect(testState.legacyKeychainCredentials).toBe(refreshedCredentials)
   })
 
+  it('rejects stale legacy keychain credentials after a fresher managed write', async () => {
+    const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const staleCredentials = createClaudeCredentialsJson('user@example.com', 'stale', null, 1_000)
+    const managedCredentials = createClaudeCredentialsJson(
+      'user@example.com',
+      'managed-newer',
+      null,
+      2_000
+    )
+    const managedAuthPath = createManagedClaudeAuth(
+      testState.userDataDir,
+      'account-1',
+      managedCredentials
+    )
+    const settings = createSettings({
+      claudeManagedAccounts: [createClaudeAccount('account-1', managedAuthPath)],
+      activeClaudeManagedAccountId: 'account-1'
+    })
+    const store = createStore(settings)
+
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const service = new ClaudeRuntimeAuthService(store as never)
+    await service.syncForCurrentSelection()
+
+    testState.scopedKeychainCredentials = managedCredentials
+    testState.legacyKeychainCredentials = staleCredentials
+    await service.syncForCurrentSelection()
+
+    expect(readManagedCredentialsForTest('account-1', managedAuthPath)).toBe(managedCredentials)
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(managedCredentials)
+    expect(testState.scopedKeychainCredentials).toBe(managedCredentials)
+    expect(testState.legacyKeychainCredentials).toBe(managedCredentials)
+  })
+
+  it('uses fresher file credentials when scoped keychain is stale', async () => {
+    const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const staleCredentials = createClaudeCredentialsJson('user@example.com', 'stale', null, 1_000)
+    const managedCredentials = createClaudeCredentialsJson(
+      'user@example.com',
+      'managed',
+      null,
+      2_000
+    )
+    const refreshedCredentials = createClaudeCredentialsJson(
+      'user@example.com',
+      'refreshed',
+      null,
+      3_000
+    )
+    const managedAuthPath = createManagedClaudeAuth(
+      testState.userDataDir,
+      'account-1',
+      managedCredentials
+    )
+    const settings = createSettings({
+      claudeManagedAccounts: [createClaudeAccount('account-1', managedAuthPath)],
+      activeClaudeManagedAccountId: 'account-1'
+    })
+    const store = createStore(settings)
+
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const service = new ClaudeRuntimeAuthService(store as never)
+    await service.syncForCurrentSelection()
+
+    writeFileSync(runtimeCredentialsPath, refreshedCredentials, 'utf-8')
+    testState.scopedKeychainCredentials = staleCredentials
+    testState.legacyKeychainCredentials = managedCredentials
+    await service.syncForCurrentSelection()
+
+    expect(readManagedCredentialsForTest('account-1', managedAuthPath)).toBe(refreshedCredentials)
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(refreshedCredentials)
+    expect(testState.scopedKeychainCredentials).toBe(refreshedCredentials)
+    expect(testState.legacyKeychainCredentials).toBe(refreshedCredentials)
+  })
+
   it('restores system default when mismatched Claude keychain auth appears before deselect', async () => {
     if (process.platform !== 'darwin') {
       return
@@ -1295,13 +1375,43 @@ describe('ClaudeRuntimeAuthService', () => {
     testState.throwRuntimeKeychainWrite = true
     await expect(service.syncForCurrentSelection()).rejects.toThrow('runtime keychain write failed')
 
-    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(managedCredentials)
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(systemCredentials)
     expect(testState.scopedKeychainCredentials).toBe(systemCredentials)
     testState.throwRuntimeKeychainWrite = false
     await service.syncForCurrentSelection()
 
     settings.activeClaudeManagedAccountId = null
     await service.syncForCurrentSelection()
+
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(systemCredentials)
+    expect(testState.scopedKeychainCredentials).toBe(systemCredentials)
+    expect(testState.legacyKeychainCredentials).toBe(systemCredentials)
+  })
+
+  it('restores scoped keychain after legacy runtime keychain write fails', async () => {
+    const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const systemCredentials = createClaudeCredentialsJson('system@example.com', 'system')
+    const managedCredentials = createClaudeCredentialsJson('user@example.com', 'managed')
+    writeFileSync(runtimeCredentialsPath, systemCredentials, 'utf-8')
+    testState.scopedKeychainCredentials = systemCredentials
+    testState.legacyKeychainCredentials = systemCredentials
+    const managedAuthPath = createManagedClaudeAuth(
+      testState.userDataDir,
+      'account-1',
+      managedCredentials
+    )
+    const settings = createSettings({
+      claudeManagedAccounts: [createClaudeAccount('account-1', managedAuthPath)]
+    })
+    const store = createStore(settings)
+
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const service = new ClaudeRuntimeAuthService(store as never)
+    settings.activeClaudeManagedAccountId = 'account-1'
+    testState.throwLegacyRuntimeKeychainWrite = true
+    await expect(service.syncForCurrentSelection()).rejects.toThrow(
+      'legacy runtime keychain write failed'
+    )
 
     expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(systemCredentials)
     expect(testState.scopedKeychainCredentials).toBe(systemCredentials)
@@ -1337,6 +1447,43 @@ describe('ClaudeRuntimeAuthService', () => {
     expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(systemCredentials)
     expect(testState.scopedKeychainCredentials).toBe(managedCredentials)
     testState.throwScopedKeychainWrite = false
+    await service.syncForCurrentSelection()
+
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(systemCredentials)
+    expect(testState.scopedKeychainCredentials).toBe(systemCredentials)
+    expect(testState.legacyKeychainCredentials).toBe(systemCredentials)
+  })
+
+  it('preserves previous keychain snapshot after restart following partial restore failure', async () => {
+    const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const systemCredentials = createClaudeCredentialsJson('system@example.com', 'system')
+    const managedCredentials = createClaudeCredentialsJson('user@example.com', 'managed')
+    writeFileSync(runtimeCredentialsPath, systemCredentials, 'utf-8')
+    testState.scopedKeychainCredentials = systemCredentials
+    testState.legacyKeychainCredentials = systemCredentials
+    const managedAuthPath = createManagedClaudeAuth(
+      testState.userDataDir,
+      'account-1',
+      managedCredentials
+    )
+    const settings = createSettings({
+      claudeManagedAccounts: [createClaudeAccount('account-1', managedAuthPath)]
+    })
+    const store = createStore(settings)
+
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    let service = new ClaudeRuntimeAuthService(store as never)
+    settings.activeClaudeManagedAccountId = 'account-1'
+    await service.syncForCurrentSelection()
+    settings.activeClaudeManagedAccountId = null
+    testState.throwScopedKeychainWrite = true
+    await expect(service.syncForCurrentSelection()).rejects.toThrow('scoped keychain write failed')
+
+    testState.throwScopedKeychainWrite = false
+    service = new ClaudeRuntimeAuthService(store as never)
+    settings.activeClaudeManagedAccountId = 'account-1'
+    await service.syncForCurrentSelection()
+    settings.activeClaudeManagedAccountId = null
     await service.syncForCurrentSelection()
 
     expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(systemCredentials)
@@ -1472,6 +1619,130 @@ describe('ClaudeRuntimeAuthService', () => {
     expect(testState.scopedKeychainCredentials).toBeNull()
     expect(testState.legacyKeychainCredentials).toBeNull()
     warn.mockRestore()
+  })
+
+  it('treats snapshots missing all keychain credential fields as invalid', async () => {
+    const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const snapshotPath = join(
+      testState.userDataDir,
+      'claude-runtime-auth',
+      'system-default-auth.json'
+    )
+    const managedCredentials = createClaudeCredentialsJson('user@example.com', 'managed')
+    mkdirSync(join(testState.userDataDir, 'claude-runtime-auth'), { recursive: true })
+    writeFileSync(
+      snapshotPath,
+      `${JSON.stringify({
+        credentialsJson: null,
+        configOauthAccount: null,
+        capturedAt: Date.now()
+      })}\n`,
+      'utf-8'
+    )
+    writeFileSync(runtimeCredentialsPath, managedCredentials, 'utf-8')
+    testState.scopedKeychainCredentials = managedCredentials
+    testState.legacyKeychainCredentials = managedCredentials
+    const managedAuthPath = createManagedClaudeAuth(
+      testState.userDataDir,
+      'account-1',
+      managedCredentials
+    )
+    const settings = createSettings({
+      claudeManagedAccounts: [createClaudeAccount('account-1', managedAuthPath)],
+      activeClaudeManagedAccountId: 'account-1'
+    })
+    const store = createStore(settings)
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const service = new ClaudeRuntimeAuthService(store as never)
+    settings.activeClaudeManagedAccountId = null
+    await service.syncForCurrentSelection()
+
+    expect(existsSync(snapshotPath)).toBe(false)
+    expect(existsSync(runtimeCredentialsPath)).toBe(false)
+    expect(testState.scopedKeychainCredentials).toBeNull()
+    expect(testState.legacyKeychainCredentials).toBeNull()
+    warn.mockRestore()
+  })
+
+  it('treats snapshots missing credentialsJson as invalid and clears missing-managed runtime auth', async () => {
+    const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const runtimeConfigPath = join(testState.fakeHomeDir, '.claude.json')
+    const snapshotPath = join(
+      testState.userDataDir,
+      'claude-runtime-auth',
+      'system-default-auth.json'
+    )
+    const staleManagedCredentials = createClaudeCredentialsJson('managed@example.com', 'managed')
+    const managedAuthPath = join(testState.userDataDir, 'claude-accounts', 'account-1', 'auth')
+    mkdirSync(managedAuthPath, { recursive: true })
+    mkdirSync(join(testState.userDataDir, 'claude-runtime-auth'), { recursive: true })
+    writeFileSync(
+      snapshotPath,
+      `${JSON.stringify({
+        configOauthAccount: null,
+        keychainCredentialsJson: null,
+        capturedAt: Date.now()
+      })}\n`,
+      'utf-8'
+    )
+    writeFileSync(runtimeCredentialsPath, staleManagedCredentials, 'utf-8')
+    writeFileSync(
+      runtimeConfigPath,
+      `${JSON.stringify({ oauthAccount: { accountUuid: 'account-1' } })}\n`,
+      'utf-8'
+    )
+    testState.scopedKeychainCredentials = staleManagedCredentials
+    testState.legacyKeychainCredentials = staleManagedCredentials
+    const settings = createSettings({
+      claudeManagedAccounts: [
+        createClaudeAccount('account-1', managedAuthPath, { email: 'managed@example.com' })
+      ],
+      activeClaudeManagedAccountId: 'account-1'
+    })
+    const store = createStore(settings)
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const service = new ClaudeRuntimeAuthService(store as never)
+    await service.prepareForClaudeLaunch()
+
+    expect(existsSync(snapshotPath)).toBe(false)
+    expect(existsSync(runtimeCredentialsPath)).toBe(false)
+    expect(readRuntimeOauthAccountForTest()).toBeNull()
+    expect(testState.scopedKeychainCredentials).toBeNull()
+    expect(testState.legacyKeychainCredentials).toBeNull()
+    warn.mockRestore()
+  })
+
+  it('clears missing-managed oauth metadata when only keychain proves ownership', async () => {
+    const runtimeConfigPath = join(testState.fakeHomeDir, '.claude.json')
+    const staleManagedCredentials = createClaudeCredentialsJson('managed@example.com', 'managed')
+    const managedAuthPath = join(testState.userDataDir, 'claude-accounts', 'account-1', 'auth')
+    mkdirSync(managedAuthPath, { recursive: true })
+    writeFileSync(
+      runtimeConfigPath,
+      `${JSON.stringify({ oauthAccount: { accountUuid: 'account-1' } })}\n`,
+      'utf-8'
+    )
+    testState.scopedKeychainCredentials = staleManagedCredentials
+    testState.legacyKeychainCredentials = staleManagedCredentials
+    const settings = createSettings({
+      claudeManagedAccounts: [
+        createClaudeAccount('account-1', managedAuthPath, { email: 'managed@example.com' })
+      ],
+      activeClaudeManagedAccountId: 'account-1'
+    })
+    const store = createStore(settings)
+
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const service = new ClaudeRuntimeAuthService(store as never)
+    await service.prepareForClaudeLaunch()
+
+    expect(readRuntimeOauthAccountForTest()).toBeNull()
+    expect(testState.scopedKeychainCredentials).toBeNull()
+    expect(testState.legacyKeychainCredentials).toBeNull()
   })
 
   it('preserves invalid external runtime oauth metadata when deselecting', async () => {
@@ -1686,6 +1957,58 @@ describe('ClaudeRuntimeAuthService', () => {
     expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(systemCredentials2)
   })
 
+  it('refreshes keychain and oauth snapshot surfaces when the credentials file is unchanged', async () => {
+    const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const runtimeConfigPath = join(testState.fakeHomeDir, '.claude.json')
+    const systemCredentials1 = createClaudeCredentialsJson('system1@example.com', 'system1')
+    const systemCredentials2 = createClaudeCredentialsJson('system2@example.com', 'system2')
+    const managedCredentials = createClaudeCredentialsJson('user@example.com', 'managed')
+    const systemOauthAccount1 = { accountUuid: 'system-account-1' }
+    const systemOauthAccount2 = { accountUuid: 'system-account-2' }
+    writeFileSync(runtimeCredentialsPath, systemCredentials1, 'utf-8')
+    writeFileSync(
+      runtimeConfigPath,
+      `${JSON.stringify({ oauthAccount: systemOauthAccount1 })}\n`,
+      'utf-8'
+    )
+    testState.scopedKeychainCredentials = systemCredentials1
+    testState.legacyKeychainCredentials = systemCredentials1
+    const managedAuthPath = createManagedClaudeAuth(
+      testState.userDataDir,
+      'account-1',
+      managedCredentials
+    )
+    const settings = createSettings({
+      claudeManagedAccounts: [createClaudeAccount('account-1', managedAuthPath)]
+    })
+    const store = createStore(settings)
+
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const service = new ClaudeRuntimeAuthService(store as never)
+    settings.activeClaudeManagedAccountId = 'account-1'
+    await service.syncForCurrentSelection()
+    settings.activeClaudeManagedAccountId = null
+    await service.syncForCurrentSelection()
+
+    writeFileSync(runtimeCredentialsPath, managedCredentials, 'utf-8')
+    writeFileSync(
+      runtimeConfigPath,
+      `${JSON.stringify({ oauthAccount: systemOauthAccount2 })}\n`,
+      'utf-8'
+    )
+    testState.scopedKeychainCredentials = systemCredentials2
+    testState.legacyKeychainCredentials = systemCredentials2
+    settings.activeClaudeManagedAccountId = 'account-1'
+    await service.syncForCurrentSelection()
+    settings.activeClaudeManagedAccountId = null
+    await service.syncForCurrentSelection()
+
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(systemCredentials1)
+    expect(readRuntimeOauthAccountForTest()).toEqual(systemOauthAccount2)
+    expect(testState.scopedKeychainCredentials).toBe(systemCredentials2)
+    expect(testState.legacyKeychainCredentials).toBe(systemCredentials2)
+  })
+
   it('reads back refreshed credentials for the outgoing Claude account before switching', async () => {
     const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
     const account1Original = createClaudeCredentialsJson('one@example.com', 'one-original')
@@ -1896,6 +2219,50 @@ describe('ClaudeRuntimeAuthService', () => {
     expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(noOrgCredentials)
   })
 
+  it('ignores unrelated org-scoped accounts when reading back no-org credentials', async () => {
+    const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const account1Credentials = createClaudeCredentialsJson('one@example.com', 'one')
+    const account1RefreshedCredentials = createClaudeCredentialsJson(
+      'one@example.com',
+      'one-refreshed'
+    )
+    const account2Credentials = createClaudeCredentialsJson('two@example.com', 'two', 'org-b')
+    const managedAuthPath1 = createManagedClaudeAuth(
+      testState.userDataDir,
+      'account-1',
+      account1Credentials
+    )
+    const managedAuthPath2 = createManagedClaudeAuth(
+      testState.userDataDir,
+      'account-2',
+      account2Credentials
+    )
+    const settings = createSettings({
+      claudeManagedAccounts: [
+        createClaudeAccount('account-1', managedAuthPath1, { email: 'one@example.com' }),
+        createClaudeAccount('account-2', managedAuthPath2, {
+          email: 'two@example.com',
+          organizationUuid: 'org-b'
+        })
+      ],
+      activeClaudeManagedAccountId: 'account-1'
+    })
+    const store = createStore(settings)
+
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const service = new ClaudeRuntimeAuthService(store as never)
+    await service.syncForCurrentSelection()
+
+    writeFileSync(runtimeCredentialsPath, account1RefreshedCredentials, 'utf-8')
+    await service.syncForCurrentSelection()
+
+    expect(readManagedCredentialsForTest('account-1', managedAuthPath1)).toBe(
+      account1RefreshedCredentials
+    )
+    expect(readManagedCredentialsForTest('account-2', managedAuthPath2)).toBe(account2Credentials)
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(account1RefreshedCredentials)
+  })
+
   it('rejects same-email read-back with conflicting organization for no-org accounts', async () => {
     const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
     const noOrgCredentials = createClaudeCredentialsJson('same@example.com', 'no-org')
@@ -1939,7 +2306,38 @@ describe('ClaudeRuntimeAuthService', () => {
     expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(noOrgCredentials)
   })
 
-  it('clears an invalid active Claude account before launch preparation', async () => {
+  it('preserves unknown runtime auth when invalid active account has no ownership proof', async () => {
+    const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const runtimeConfigPath = join(testState.fakeHomeDir, '.claude.json')
+    const snapshotPath = join(
+      testState.userDataDir,
+      'claude-runtime-auth',
+      'system-default-auth.json'
+    )
+    const systemCredentials = createClaudeCredentialsJson('system@example.com', 'system')
+    const staleManagedCredentials = createClaudeCredentialsJson('managed@example.com', 'managed')
+    const systemOauthAccount = { accountUuid: 'system-account' }
+    mkdirSync(join(testState.userDataDir, 'claude-runtime-auth'), { recursive: true })
+    writeFileSync(
+      snapshotPath,
+      `${JSON.stringify({
+        credentialsJson: systemCredentials,
+        configOauthAccount: systemOauthAccount,
+        keychainCredentialsJson: systemCredentials,
+        scopedKeychainCredentialsJson: systemCredentials,
+        legacyKeychainCredentialsJson: systemCredentials,
+        capturedAt: Date.now()
+      })}\n`,
+      'utf-8'
+    )
+    writeFileSync(runtimeCredentialsPath, staleManagedCredentials, 'utf-8')
+    writeFileSync(
+      runtimeConfigPath,
+      `${JSON.stringify({ oauthAccount: { accountUuid: 'missing-account' } })}\n`,
+      'utf-8'
+    )
+    testState.scopedKeychainCredentials = staleManagedCredentials
+    testState.legacyKeychainCredentials = staleManagedCredentials
     const settings = createSettings({
       activeClaudeManagedAccountId: 'missing-account'
     })
@@ -1953,6 +2351,140 @@ describe('ClaudeRuntimeAuthService', () => {
     expect(preparation.configDir).toBe(join(testState.fakeHomeDir, '.claude'))
     expect(preparation.stripAuthEnv).toBe(false)
     expect(preparation.provenance).toBe('system')
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(staleManagedCredentials)
+    expect(readRuntimeOauthAccountForTest()).toEqual({ accountUuid: 'missing-account' })
+    expect(testState.scopedKeychainCredentials).toBe(staleManagedCredentials)
+    expect(testState.legacyKeychainCredentials).toBe(staleManagedCredentials)
+  })
+
+  it('restores system snapshot when active account credentials are missing but runtime matches account', async () => {
+    const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const runtimeConfigPath = join(testState.fakeHomeDir, '.claude.json')
+    const snapshotPath = join(
+      testState.userDataDir,
+      'claude-runtime-auth',
+      'system-default-auth.json'
+    )
+    const systemCredentials = createClaudeCredentialsJson('system@example.com', 'system')
+    const staleManagedCredentials = createClaudeCredentialsJson('managed@example.com', 'managed')
+    const systemOauthAccount = { accountUuid: 'system-account' }
+    const managedAuthPath = join(testState.userDataDir, 'claude-accounts', 'account-1', 'auth')
+    mkdirSync(join(testState.userDataDir, 'claude-runtime-auth'), { recursive: true })
+    mkdirSync(managedAuthPath, { recursive: true })
+    writeFileSync(
+      snapshotPath,
+      `${JSON.stringify({
+        credentialsJson: systemCredentials,
+        configOauthAccount: systemOauthAccount,
+        keychainCredentialsJson: systemCredentials,
+        scopedKeychainCredentialsJson: systemCredentials,
+        legacyKeychainCredentialsJson: systemCredentials,
+        capturedAt: Date.now()
+      })}\n`,
+      'utf-8'
+    )
+    writeFileSync(runtimeCredentialsPath, staleManagedCredentials, 'utf-8')
+    writeFileSync(
+      runtimeConfigPath,
+      `${JSON.stringify({ oauthAccount: { accountUuid: 'account-1' } })}\n`,
+      'utf-8'
+    )
+    testState.scopedKeychainCredentials = staleManagedCredentials
+    testState.legacyKeychainCredentials = staleManagedCredentials
+    const settings = createSettings({
+      claudeManagedAccounts: [
+        createClaudeAccount('account-1', managedAuthPath, { email: 'managed@example.com' })
+      ],
+      activeClaudeManagedAccountId: 'account-1'
+    })
+    const store = createStore(settings)
+
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const service = new ClaudeRuntimeAuthService(store as never)
+    const preparation = await service.prepareForClaudeLaunch()
+
+    expect(preparation.provenance).toBe('system')
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(systemCredentials)
+    expect(readRuntimeOauthAccountForTest()).toEqual(systemOauthAccount)
+    expect(testState.scopedKeychainCredentials).toBe(systemCredentials)
+    expect(testState.legacyKeychainCredentials).toBe(systemCredentials)
+  })
+
+  it('restores missing-managed oauth metadata when only keychain proves ownership', async () => {
+    const runtimeConfigPath = join(testState.fakeHomeDir, '.claude.json')
+    const snapshotPath = join(
+      testState.userDataDir,
+      'claude-runtime-auth',
+      'system-default-auth.json'
+    )
+    const systemCredentials = createClaudeCredentialsJson('system@example.com', 'system')
+    const staleManagedCredentials = createClaudeCredentialsJson('managed@example.com', 'managed')
+    const systemOauthAccount = { accountUuid: 'system-account' }
+    const managedAuthPath = join(testState.userDataDir, 'claude-accounts', 'account-1', 'auth')
+    mkdirSync(join(testState.userDataDir, 'claude-runtime-auth'), { recursive: true })
+    mkdirSync(managedAuthPath, { recursive: true })
+    writeFileSync(
+      snapshotPath,
+      `${JSON.stringify({
+        credentialsJson: systemCredentials,
+        configOauthAccount: systemOauthAccount,
+        keychainCredentialsJson: systemCredentials,
+        scopedKeychainCredentialsJson: systemCredentials,
+        legacyKeychainCredentialsJson: systemCredentials,
+        capturedAt: Date.now()
+      })}\n`,
+      'utf-8'
+    )
+    writeFileSync(
+      runtimeConfigPath,
+      `${JSON.stringify({ oauthAccount: { accountUuid: 'account-1' } })}\n`,
+      'utf-8'
+    )
+    testState.scopedKeychainCredentials = staleManagedCredentials
+    testState.legacyKeychainCredentials = staleManagedCredentials
+    const settings = createSettings({
+      claudeManagedAccounts: [
+        createClaudeAccount('account-1', managedAuthPath, { email: 'managed@example.com' })
+      ],
+      activeClaudeManagedAccountId: 'account-1'
+    })
+    const store = createStore(settings)
+
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const service = new ClaudeRuntimeAuthService(store as never)
+    await service.prepareForClaudeLaunch()
+
+    expect(readRuntimeOauthAccountForTest()).toEqual(systemOauthAccount)
+    expect(testState.scopedKeychainCredentials).toBe(systemCredentials)
+    expect(testState.legacyKeychainCredentials).toBe(systemCredentials)
+  })
+
+  it('preserves unknown runtime auth when invalid active account has no system snapshot', async () => {
+    const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const runtimeConfigPath = join(testState.fakeHomeDir, '.claude.json')
+    const staleManagedCredentials = createClaudeCredentialsJson('managed@example.com', 'managed')
+    writeFileSync(runtimeCredentialsPath, staleManagedCredentials, 'utf-8')
+    writeFileSync(
+      runtimeConfigPath,
+      `${JSON.stringify({ oauthAccount: { accountUuid: 'missing-account' } })}\n`,
+      'utf-8'
+    )
+    testState.scopedKeychainCredentials = staleManagedCredentials
+    testState.legacyKeychainCredentials = staleManagedCredentials
+    const settings = createSettings({
+      activeClaudeManagedAccountId: 'missing-account'
+    })
+    const store = createStore(settings)
+
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const service = new ClaudeRuntimeAuthService(store as never)
+    const preparation = await service.prepareForClaudeLaunch()
+
+    expect(preparation.provenance).toBe('system')
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(staleManagedCredentials)
+    expect(readRuntimeOauthAccountForTest()).toEqual({ accountUuid: 'missing-account' })
+    expect(testState.scopedKeychainCredentials).toBe(staleManagedCredentials)
+    expect(testState.legacyKeychainCredentials).toBe(staleManagedCredentials)
   })
 
   it('does not clobber fresh Claude credentials after clearLastWrittenCredentialsJson', async () => {

--- a/src/main/claude-accounts/runtime-auth-service.test.ts
+++ b/src/main/claude-accounts/runtime-auth-service.test.ts
@@ -19,6 +19,8 @@ const testState = {
   userDataDir: '',
   fakeHomeDir: '',
   activeKeychainCredentials: null as string | null,
+  scopedKeychainCredentials: null as string | null,
+  legacyKeychainCredentials: null as string | null,
   managedKeychainCredentials: new Map<string, string>()
 }
 
@@ -37,18 +39,45 @@ vi.mock('node:os', async () => {
 })
 
 vi.mock('./keychain', () => ({
-  readActiveClaudeKeychainCredentials: vi.fn(async () => testState.activeKeychainCredentials),
-  writeActiveClaudeKeychainCredentials: vi.fn(async (contents: string) => {
+  readActiveClaudeKeychainCredentials: vi.fn(async (configDir?: string) => {
+    if (configDir) {
+      return (
+        testState.scopedKeychainCredentials ??
+        testState.legacyKeychainCredentials ??
+        testState.activeKeychainCredentials
+      )
+    }
+    return testState.legacyKeychainCredentials ?? testState.activeKeychainCredentials
+  }),
+  writeActiveClaudeKeychainCredentials: vi.fn(async (contents: string, configDir?: string) => {
+    if (configDir) {
+      testState.scopedKeychainCredentials = contents
+    } else {
+      testState.legacyKeychainCredentials = contents
+    }
     testState.activeKeychainCredentials = contents
   }),
   deleteActiveClaudeKeychainCredentials: vi.fn(async () => {
+    testState.scopedKeychainCredentials = null
+    testState.legacyKeychainCredentials = null
     testState.activeKeychainCredentials = null
   }),
-  deleteActiveClaudeKeychainCredentialsStrict: vi.fn(async () => {
+  deleteActiveClaudeKeychainCredentialsStrict: vi.fn(async (configDir?: string) => {
+    if (configDir) {
+      testState.scopedKeychainCredentials = null
+    } else {
+      testState.legacyKeychainCredentials = null
+    }
     testState.activeKeychainCredentials = null
   }),
-  readActiveClaudeKeychainCredentialsStrict: vi.fn(async () => testState.activeKeychainCredentials),
+  readActiveClaudeKeychainCredentialsStrict: vi.fn(async (configDir?: string) =>
+    configDir
+      ? (testState.scopedKeychainCredentials ?? testState.activeKeychainCredentials)
+      : (testState.legacyKeychainCredentials ?? testState.activeKeychainCredentials)
+  ),
   writeActiveClaudeKeychainCredentialsForRuntime: vi.fn(async (contents: string) => {
+    testState.scopedKeychainCredentials = contents
+    testState.legacyKeychainCredentials = contents
     testState.activeKeychainCredentials = contents
   }),
   readManagedClaudeKeychainCredentials: vi.fn(
@@ -159,6 +188,8 @@ describe('ClaudeRuntimeAuthService', () => {
     vi.resetModules()
     vi.clearAllMocks()
     testState.activeKeychainCredentials = null
+    testState.scopedKeychainCredentials = null
+    testState.legacyKeychainCredentials = null
     testState.managedKeychainCredentials.clear()
     testState.userDataDir = mkdtempSync(join(tmpdir(), 'orca-claude-runtime-'))
     testState.fakeHomeDir = mkdtempSync(join(tmpdir(), 'orca-claude-home-'))
@@ -782,6 +813,8 @@ describe('ClaudeRuntimeAuthService', () => {
 
     rmSync(runtimeCredentialsPath, { force: true })
     testState.activeKeychainCredentials = null
+    testState.scopedKeychainCredentials = null
+    testState.legacyKeychainCredentials = null
     settings.activeClaudeManagedAccountId = null
     await service.syncForCurrentSelection()
 
@@ -811,11 +844,44 @@ describe('ClaudeRuntimeAuthService', () => {
     const service = new ClaudeRuntimeAuthService(store as never)
     await service.syncForCurrentSelection()
 
-    testState.activeKeychainCredentials = refreshedCredentials
+    testState.scopedKeychainCredentials = refreshedCredentials
     await service.syncForCurrentSelection()
 
     expect(readManagedCredentialsForTest('account-1', managedAuthPath)).toBe(refreshedCredentials)
     expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(refreshedCredentials)
+  })
+
+  it('reads back refreshed legacy keychain credentials on old Claude Code builds', async () => {
+    if (process.platform !== 'darwin') {
+      return
+    }
+
+    const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const originalCredentials = createClaudeCredentialsJson('user@example.com', 'original')
+    const refreshedCredentials = createClaudeCredentialsJson('user@example.com', 'refreshed')
+    const managedAuthPath = createManagedClaudeAuth(
+      testState.userDataDir,
+      'account-1',
+      originalCredentials
+    )
+    const settings = createSettings({
+      claudeManagedAccounts: [createClaudeAccount('account-1', managedAuthPath)],
+      activeClaudeManagedAccountId: 'account-1'
+    })
+    const store = createStore(settings)
+
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const service = new ClaudeRuntimeAuthService(store as never)
+    await service.syncForCurrentSelection()
+
+    testState.scopedKeychainCredentials = originalCredentials
+    testState.legacyKeychainCredentials = refreshedCredentials
+    await service.syncForCurrentSelection()
+
+    expect(readManagedCredentialsForTest('account-1', managedAuthPath)).toBe(refreshedCredentials)
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(refreshedCredentials)
+    expect(testState.scopedKeychainCredentials).toBe(refreshedCredentials)
+    expect(testState.legacyKeychainCredentials).toBe(refreshedCredentials)
   })
 
   it('restores system default when mismatched Claude keychain auth appears before deselect', async () => {

--- a/src/main/claude-accounts/runtime-auth-service.test.ts
+++ b/src/main/claude-accounts/runtime-auth-service.test.ts
@@ -15,13 +15,19 @@ import { join } from 'node:path'
 import { getDefaultSettings } from '../../shared/constants'
 import type { ClaudeManagedAccount, GlobalSettings } from '../../shared/types'
 
+const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
 const testState = {
   userDataDir: '',
   fakeHomeDir: '',
   activeKeychainCredentials: null as string | null,
   scopedKeychainCredentials: null as string | null,
   legacyKeychainCredentials: null as string | null,
+  runtimeWriteConfigDir: null as string | null,
   managedKeychainCredentials: new Map<string, string>()
+}
+
+function expectedRuntimeConfigDir(): string {
+  return join(testState.fakeHomeDir, '.claude')
 }
 
 vi.mock('electron', () => ({
@@ -41,16 +47,18 @@ vi.mock('node:os', async () => {
 vi.mock('./keychain', () => ({
   readActiveClaudeKeychainCredentials: vi.fn(async (configDir?: string) => {
     if (configDir) {
-      return (
-        testState.scopedKeychainCredentials ??
-        testState.legacyKeychainCredentials ??
-        testState.activeKeychainCredentials
-      )
+      if (configDir !== expectedRuntimeConfigDir()) {
+        return testState.legacyKeychainCredentials
+      }
+      return testState.scopedKeychainCredentials ?? testState.legacyKeychainCredentials
     }
-    return testState.legacyKeychainCredentials ?? testState.activeKeychainCredentials
+    return testState.legacyKeychainCredentials
   }),
   writeActiveClaudeKeychainCredentials: vi.fn(async (contents: string, configDir?: string) => {
     if (configDir) {
+      if (configDir !== expectedRuntimeConfigDir()) {
+        throw new Error(`Unexpected Claude config dir: ${configDir}`)
+      }
       testState.scopedKeychainCredentials = contents
     } else {
       testState.legacyKeychainCredentials = contents
@@ -64,6 +72,9 @@ vi.mock('./keychain', () => ({
   }),
   deleteActiveClaudeKeychainCredentialsStrict: vi.fn(async (configDir?: string) => {
     if (configDir) {
+      if (configDir !== expectedRuntimeConfigDir()) {
+        throw new Error(`Unexpected Claude config dir: ${configDir}`)
+      }
       testState.scopedKeychainCredentials = null
     } else {
       testState.legacyKeychainCredentials = null
@@ -72,14 +83,22 @@ vi.mock('./keychain', () => ({
   }),
   readActiveClaudeKeychainCredentialsStrict: vi.fn(async (configDir?: string) =>
     configDir
-      ? (testState.scopedKeychainCredentials ?? testState.activeKeychainCredentials)
-      : (testState.legacyKeychainCredentials ?? testState.activeKeychainCredentials)
+      ? configDir === expectedRuntimeConfigDir()
+        ? testState.scopedKeychainCredentials
+        : null
+      : testState.legacyKeychainCredentials
   ),
-  writeActiveClaudeKeychainCredentialsForRuntime: vi.fn(async (contents: string) => {
-    testState.scopedKeychainCredentials = contents
-    testState.legacyKeychainCredentials = contents
-    testState.activeKeychainCredentials = contents
-  }),
+  writeActiveClaudeKeychainCredentialsForRuntime: vi.fn(
+    async (contents: string, configDir: string) => {
+      if (configDir !== expectedRuntimeConfigDir()) {
+        throw new Error(`Unexpected Claude config dir: ${configDir}`)
+      }
+      testState.runtimeWriteConfigDir = configDir
+      testState.scopedKeychainCredentials = contents
+      testState.legacyKeychainCredentials = contents
+      testState.activeKeychainCredentials = contents
+    }
+  ),
   readManagedClaudeKeychainCredentials: vi.fn(
     async (accountId: string) => testState.managedKeychainCredentials.get(accountId) ?? null
   ),
@@ -87,6 +106,13 @@ vi.mock('./keychain', () => ({
     testState.managedKeychainCredentials.set(accountId, contents)
   })
 }))
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', {
+    configurable: true,
+    value: platform
+  })
+}
 
 function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings {
   return {
@@ -185,11 +211,13 @@ function readManagedCredentialsForTest(accountId: string, managedAuthPath: strin
 
 describe('ClaudeRuntimeAuthService', () => {
   beforeEach(() => {
+    setPlatform('darwin')
     vi.resetModules()
     vi.clearAllMocks()
     testState.activeKeychainCredentials = null
     testState.scopedKeychainCredentials = null
     testState.legacyKeychainCredentials = null
+    testState.runtimeWriteConfigDir = null
     testState.managedKeychainCredentials.clear()
     testState.userDataDir = mkdtempSync(join(tmpdir(), 'orca-claude-runtime-'))
     testState.fakeHomeDir = mkdtempSync(join(tmpdir(), 'orca-claude-home-'))
@@ -197,6 +225,9 @@ describe('ClaudeRuntimeAuthService', () => {
   })
 
   afterEach(() => {
+    if (originalPlatform) {
+      Object.defineProperty(process, 'platform', originalPlatform)
+    }
     rmSync(testState.userDataDir, { recursive: true, force: true })
     rmSync(testState.fakeHomeDir, { recursive: true, force: true })
   })
@@ -224,6 +255,7 @@ describe('ClaudeRuntimeAuthService', () => {
     await service.prepareForClaudeLaunch()
 
     expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe('{"token":"managed"}\n')
+    expect(testState.runtimeWriteConfigDir).toBe(expectedRuntimeConfigDir())
   })
 
   it('removes runtime credentials when deselecting with a missing system-default snapshot', async () => {
@@ -248,11 +280,8 @@ describe('ClaudeRuntimeAuthService', () => {
 
     expect(existsSync(runtimeCredentialsPath)).toBe(false)
     if (process.platform === 'darwin') {
-      const { deleteActiveClaudeKeychainCredentialsStrict } = await import('./keychain')
-      expect(deleteActiveClaudeKeychainCredentialsStrict).toHaveBeenCalledWith(
-        join(testState.fakeHomeDir, '.claude')
-      )
-      expect(testState.activeKeychainCredentials).toBeNull()
+      expect(testState.scopedKeychainCredentials).toBeNull()
+      expect(testState.legacyKeychainCredentials).toBeNull()
     }
   })
 
@@ -638,12 +667,14 @@ describe('ClaudeRuntimeAuthService', () => {
     expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(systemCredentials)
   })
 
-  it('restores system default when stale Claude credentials are rejected on deselect', async () => {
+  it('preserves external stale Claude credentials without writing them to managed storage', async () => {
     const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
     const systemCredentials = createClaudeCredentialsJson('system@example.com', 'system')
     const selectedCredentials = createClaudeCredentialsJson('selected@example.com', 'selected')
     const staleCredentials = createClaudeCredentialsJson('stale@example.com', 'stale')
     writeFileSync(runtimeCredentialsPath, systemCredentials, 'utf-8')
+    testState.scopedKeychainCredentials = systemCredentials
+    testState.legacyKeychainCredentials = systemCredentials
     const managedAuthPath = createManagedClaudeAuth(
       testState.userDataDir,
       'account-1',
@@ -666,7 +697,9 @@ describe('ClaudeRuntimeAuthService', () => {
     await service.syncForCurrentSelection()
 
     expect(readManagedCredentialsForTest('account-1', managedAuthPath)).toBe(selectedCredentials)
-    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(systemCredentials)
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(staleCredentials)
+    expect(testState.scopedKeychainCredentials).toBe(systemCredentials)
+    expect(testState.legacyKeychainCredentials).toBe(systemCredentials)
   })
 
   it('does not persist unverifiable stale Claude credentials into another active account', async () => {
@@ -897,7 +930,8 @@ describe('ClaudeRuntimeAuthService', () => {
       'external'
     )
     writeFileSync(runtimeCredentialsPath, systemCredentials, 'utf-8')
-    testState.activeKeychainCredentials = systemCredentials
+    testState.scopedKeychainCredentials = systemCredentials
+    testState.legacyKeychainCredentials = systemCredentials
     const managedAuthPath = createManagedClaudeAuth(
       testState.userDataDir,
       'account-1',
@@ -913,12 +947,211 @@ describe('ClaudeRuntimeAuthService', () => {
     settings.activeClaudeManagedAccountId = 'account-1'
     await service.syncForCurrentSelection()
 
-    testState.activeKeychainCredentials = externalKeychainCredentials
+    testState.scopedKeychainCredentials = externalKeychainCredentials
+    testState.legacyKeychainCredentials = externalKeychainCredentials
     settings.activeClaudeManagedAccountId = null
     await service.syncForCurrentSelection()
 
     expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(systemCredentials)
-    expect(testState.activeKeychainCredentials).toBe(systemCredentials)
+    expect(testState.scopedKeychainCredentials).toBe(externalKeychainCredentials)
+    expect(testState.legacyKeychainCredentials).toBe(externalKeychainCredentials)
+  })
+
+  it('restores unchanged scoped keychain while preserving external legacy keychain logout', async () => {
+    if (process.platform !== 'darwin') {
+      return
+    }
+
+    const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const systemCredentials = createClaudeCredentialsJson('system@example.com', 'system')
+    const managedCredentials = createClaudeCredentialsJson('user@example.com', 'managed')
+    writeFileSync(runtimeCredentialsPath, systemCredentials, 'utf-8')
+    testState.scopedKeychainCredentials = systemCredentials
+    testState.legacyKeychainCredentials = systemCredentials
+    const managedAuthPath = createManagedClaudeAuth(
+      testState.userDataDir,
+      'account-1',
+      managedCredentials
+    )
+    const settings = createSettings({
+      claudeManagedAccounts: [createClaudeAccount('account-1', managedAuthPath)]
+    })
+    const store = createStore(settings)
+
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const service = new ClaudeRuntimeAuthService(store as never)
+    settings.activeClaudeManagedAccountId = 'account-1'
+    await service.syncForCurrentSelection()
+
+    testState.legacyKeychainCredentials = null
+    settings.activeClaudeManagedAccountId = null
+    await service.syncForCurrentSelection()
+
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(systemCredentials)
+    expect(testState.scopedKeychainCredentials).toBe(systemCredentials)
+    expect(testState.legacyKeychainCredentials).toBeNull()
+  })
+
+  it('preserves external scoped keychain login while restoring unchanged legacy keychain', async () => {
+    const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const systemCredentials = createClaudeCredentialsJson('system@example.com', 'system')
+    const managedCredentials = createClaudeCredentialsJson('user@example.com', 'managed')
+    const externalScopedCredentials = createClaudeCredentialsJson(
+      'external@example.com',
+      'external'
+    )
+    writeFileSync(runtimeCredentialsPath, systemCredentials, 'utf-8')
+    testState.scopedKeychainCredentials = systemCredentials
+    testState.legacyKeychainCredentials = systemCredentials
+    const managedAuthPath = createManagedClaudeAuth(
+      testState.userDataDir,
+      'account-1',
+      managedCredentials
+    )
+    const settings = createSettings({
+      claudeManagedAccounts: [createClaudeAccount('account-1', managedAuthPath)]
+    })
+    const store = createStore(settings)
+
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const service = new ClaudeRuntimeAuthService(store as never)
+    settings.activeClaudeManagedAccountId = 'account-1'
+    await service.syncForCurrentSelection()
+
+    testState.scopedKeychainCredentials = externalScopedCredentials
+    settings.activeClaudeManagedAccountId = null
+    await service.syncForCurrentSelection()
+
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(systemCredentials)
+    expect(testState.scopedKeychainCredentials).toBe(externalScopedCredentials)
+    expect(testState.legacyKeychainCredentials).toBe(systemCredentials)
+  })
+
+  it('uses managed credentials as ownership baseline after restart with partial external changes', async () => {
+    const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const systemCredentials = createClaudeCredentialsJson('system@example.com', 'system')
+    const managedCredentials = createClaudeCredentialsJson('user@example.com', 'managed')
+    const externalScopedCredentials = createClaudeCredentialsJson(
+      'external@example.com',
+      'external'
+    )
+    const snapshotPath = join(
+      testState.userDataDir,
+      'claude-runtime-auth',
+      'system-default-auth.json'
+    )
+    mkdirSync(join(testState.userDataDir, 'claude-runtime-auth'), { recursive: true })
+    writeFileSync(
+      snapshotPath,
+      `${JSON.stringify({
+        credentialsJson: systemCredentials,
+        configOauthAccount: null,
+        keychainCredentialsJson: systemCredentials,
+        scopedKeychainCredentialsJson: systemCredentials,
+        legacyKeychainCredentialsJson: systemCredentials,
+        capturedAt: Date.now()
+      })}\n`,
+      'utf-8'
+    )
+    writeFileSync(runtimeCredentialsPath, managedCredentials, 'utf-8')
+    testState.scopedKeychainCredentials = externalScopedCredentials
+    testState.legacyKeychainCredentials = managedCredentials
+    const managedAuthPath = createManagedClaudeAuth(
+      testState.userDataDir,
+      'account-1',
+      managedCredentials
+    )
+    const settings = createSettings({
+      claudeManagedAccounts: [createClaudeAccount('account-1', managedAuthPath)],
+      activeClaudeManagedAccountId: 'account-1'
+    })
+    const store = createStore(settings)
+
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const service = new ClaudeRuntimeAuthService(store as never)
+    settings.activeClaudeManagedAccountId = null
+    await service.syncForCurrentSelection()
+
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(systemCredentials)
+    expect(testState.scopedKeychainCredentials).toBe(externalScopedCredentials)
+    expect(testState.legacyKeychainCredentials).toBe(systemCredentials)
+  })
+
+  it('preserves external file and scoped login while restoring unchanged legacy keychain', async () => {
+    const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const systemCredentials = createClaudeCredentialsJson('system@example.com', 'system')
+    const managedCredentials = createClaudeCredentialsJson('user@example.com', 'managed')
+    const externalCredentials = createClaudeCredentialsJson('external@example.com', 'external')
+    writeFileSync(runtimeCredentialsPath, systemCredentials, 'utf-8')
+    testState.scopedKeychainCredentials = systemCredentials
+    testState.legacyKeychainCredentials = systemCredentials
+    const managedAuthPath = createManagedClaudeAuth(
+      testState.userDataDir,
+      'account-1',
+      managedCredentials
+    )
+    const settings = createSettings({
+      claudeManagedAccounts: [createClaudeAccount('account-1', managedAuthPath)]
+    })
+    const store = createStore(settings)
+
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const service = new ClaudeRuntimeAuthService(store as never)
+    settings.activeClaudeManagedAccountId = 'account-1'
+    await service.syncForCurrentSelection()
+
+    writeFileSync(runtimeCredentialsPath, externalCredentials, 'utf-8')
+    testState.scopedKeychainCredentials = externalCredentials
+    settings.activeClaudeManagedAccountId = null
+    await service.syncForCurrentSelection()
+
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(externalCredentials)
+    expect(testState.scopedKeychainCredentials).toBe(externalCredentials)
+    expect(testState.legacyKeychainCredentials).toBe(systemCredentials)
+  })
+
+  it('restores legacy keychain credentials from old system-default snapshots', async () => {
+    const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const snapshotPath = join(
+      testState.userDataDir,
+      'claude-runtime-auth',
+      'system-default-auth.json'
+    )
+    const systemCredentials = createClaudeCredentialsJson('system@example.com', 'system')
+    const managedCredentials = createClaudeCredentialsJson('user@example.com', 'managed')
+    mkdirSync(join(testState.userDataDir, 'claude-runtime-auth'), { recursive: true })
+    writeFileSync(
+      snapshotPath,
+      `${JSON.stringify({
+        credentialsJson: systemCredentials,
+        configOauthAccount: null,
+        keychainCredentialsJson: systemCredentials,
+        capturedAt: Date.now()
+      })}\n`,
+      'utf-8'
+    )
+    writeFileSync(runtimeCredentialsPath, managedCredentials, 'utf-8')
+    testState.scopedKeychainCredentials = managedCredentials
+    testState.legacyKeychainCredentials = managedCredentials
+    const managedAuthPath = createManagedClaudeAuth(
+      testState.userDataDir,
+      'account-1',
+      managedCredentials
+    )
+    const settings = createSettings({
+      claudeManagedAccounts: [createClaudeAccount('account-1', managedAuthPath)],
+      activeClaudeManagedAccountId: 'account-1'
+    })
+    const store = createStore(settings)
+
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const service = new ClaudeRuntimeAuthService(store as never)
+    settings.activeClaudeManagedAccountId = null
+    await service.syncForCurrentSelection()
+
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(systemCredentials)
+    expect(testState.scopedKeychainCredentials).toBe(systemCredentials)
+    expect(testState.legacyKeychainCredentials).toBe(systemCredentials)
   })
 
   it('captures a fresh system-default snapshot when re-entering managed mode', async () => {
@@ -1022,14 +1255,15 @@ describe('ClaudeRuntimeAuthService', () => {
     // Orca selected account-2. Persist that refresh to account-1, then restore
     // the selected account in the shared Claude runtime credentials.
     writeFileSync(runtimeCredentialsPath, account1Refreshed, 'utf-8')
-    testState.activeKeychainCredentials = account1Refreshed
+    testState.scopedKeychainCredentials = account1Refreshed
     await service.syncForCurrentSelection()
 
     expect(readManagedCredentialsForTest('account-1', managedAuthPath1)).toBe(account1Refreshed)
     expect(readManagedCredentialsForTest('account-2', managedAuthPath2)).toBe(account2Credentials)
     expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(account2Credentials)
     if (process.platform === 'darwin') {
-      expect(testState.activeKeychainCredentials).toBe(account2Credentials)
+      expect(testState.scopedKeychainCredentials).toBe(account2Credentials)
+      expect(testState.legacyKeychainCredentials).toBe(account2Credentials)
     }
   })
 
@@ -1068,14 +1302,15 @@ describe('ClaudeRuntimeAuthService', () => {
     await service.syncForCurrentSelection()
 
     writeFileSync(runtimeCredentialsPath, refreshedCredentials, 'utf-8')
-    testState.activeKeychainCredentials = refreshedCredentials
+    testState.scopedKeychainCredentials = refreshedCredentials
     await service.syncForCurrentSelection()
 
     expect(readManagedCredentialsForTest('account-1', managedAuthPath1)).toBe(originalCredentials)
     expect(readManagedCredentialsForTest('account-2', managedAuthPath2)).toBe(originalCredentials)
     expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(activeCredentials)
     if (process.platform === 'darwin') {
-      expect(testState.activeKeychainCredentials).toBe(activeCredentials)
+      expect(testState.scopedKeychainCredentials).toBe(activeCredentials)
+      expect(testState.legacyKeychainCredentials).toBe(activeCredentials)
     }
   })
 

--- a/src/main/claude-accounts/runtime-auth-service.test.ts
+++ b/src/main/claude-accounts/runtime-auth-service.test.ts
@@ -1145,7 +1145,7 @@ describe('ClaudeRuntimeAuthService', () => {
     expect(testState.legacyKeychainCredentials).toBe(systemCredentials)
   })
 
-  it('preserves external oauth metadata while restoring owned credentials', async () => {
+  it('restores oauth metadata when credentials prove managed ownership', async () => {
     const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
     const runtimeConfigPath = join(testState.fakeHomeDir, '.claude.json')
     const systemCredentials = createClaudeCredentialsJson('system@example.com', 'system')
@@ -1184,7 +1184,7 @@ describe('ClaudeRuntimeAuthService', () => {
     await service.syncForCurrentSelection()
 
     expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(systemCredentials)
-    expect(readRuntimeOauthAccountForTest()).toEqual(externalOauthAccount)
+    expect(readRuntimeOauthAccountForTest()).toEqual(systemOauthAccount)
   })
 
   it('restores owned oauth metadata when external credentials change but metadata does not', async () => {
@@ -1223,6 +1223,47 @@ describe('ClaudeRuntimeAuthService', () => {
 
     expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(externalCredentials)
     expect(readRuntimeOauthAccountForTest()).toEqual(systemOauthAccount)
+  })
+
+  it('restores owned oauth metadata when only keychain proves managed ownership', async () => {
+    const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const runtimeConfigPath = join(testState.fakeHomeDir, '.claude.json')
+    const systemCredentials = createClaudeCredentialsJson('system@example.com', 'system')
+    const managedCredentials = createClaudeCredentialsJson('user@example.com', 'managed')
+    const externalCredentials = createClaudeCredentialsJson('external@example.com', 'external')
+    const systemOauthAccount = { accountUuid: 'system-account' }
+    writeFileSync(runtimeCredentialsPath, systemCredentials, 'utf-8')
+    writeFileSync(
+      runtimeConfigPath,
+      `${JSON.stringify({ oauthAccount: systemOauthAccount })}\n`,
+      'utf-8'
+    )
+    testState.scopedKeychainCredentials = systemCredentials
+    testState.legacyKeychainCredentials = systemCredentials
+    const managedAuthPath = createManagedClaudeAuth(
+      testState.userDataDir,
+      'account-1',
+      managedCredentials,
+      'null\n'
+    )
+    const settings = createSettings({
+      claudeManagedAccounts: [createClaudeAccount('account-1', managedAuthPath)]
+    })
+    const store = createStore(settings)
+
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const service = new ClaudeRuntimeAuthService(store as never)
+    settings.activeClaudeManagedAccountId = 'account-1'
+    await service.syncForCurrentSelection()
+
+    writeFileSync(runtimeCredentialsPath, externalCredentials, 'utf-8')
+    settings.activeClaudeManagedAccountId = null
+    await service.syncForCurrentSelection()
+
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(externalCredentials)
+    expect(readRuntimeOauthAccountForTest()).toEqual(systemOauthAccount)
+    expect(testState.scopedKeychainCredentials).toBe(systemCredentials)
+    expect(testState.legacyKeychainCredentials).toBe(systemCredentials)
   })
 
   it('uses managed credentials as ownership baseline after restart with partial external changes', async () => {
@@ -1745,6 +1786,36 @@ describe('ClaudeRuntimeAuthService', () => {
     expect(testState.legacyKeychainCredentials).toBeNull()
   })
 
+  it('preserves missing-managed oauth metadata without credential ownership proof', async () => {
+    const runtimeConfigPath = join(testState.fakeHomeDir, '.claude.json')
+    const externalCredentials = createClaudeCredentialsJson('external@example.com', 'external')
+    const managedAuthPath = join(testState.userDataDir, 'claude-accounts', 'account-1', 'auth')
+    const managedOauthAccount = { accountUuid: 'account-1' }
+    mkdirSync(managedAuthPath, { recursive: true })
+    writeFileSync(
+      runtimeConfigPath,
+      `${JSON.stringify({ oauthAccount: managedOauthAccount })}\n`,
+      'utf-8'
+    )
+    testState.scopedKeychainCredentials = externalCredentials
+    testState.legacyKeychainCredentials = externalCredentials
+    const settings = createSettings({
+      claudeManagedAccounts: [
+        createClaudeAccount('account-1', managedAuthPath, { email: 'managed@example.com' })
+      ],
+      activeClaudeManagedAccountId: 'account-1'
+    })
+    const store = createStore(settings)
+
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const service = new ClaudeRuntimeAuthService(store as never)
+    await service.prepareForClaudeLaunch()
+
+    expect(readRuntimeOauthAccountForTest()).toEqual(managedOauthAccount)
+    expect(testState.scopedKeychainCredentials).toBe(externalCredentials)
+    expect(testState.legacyKeychainCredentials).toBe(externalCredentials)
+  })
+
   it('preserves invalid external runtime oauth metadata when deselecting', async () => {
     const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
     const runtimeConfigPath = join(testState.fakeHomeDir, '.claude.json')
@@ -1774,6 +1845,112 @@ describe('ClaudeRuntimeAuthService', () => {
 
     expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(systemCredentials)
     expect(readFileSync(runtimeConfigPath, 'utf-8')).toBe('{not-json')
+  })
+
+  it('preserves invalid runtime config while materializing managed credentials', async () => {
+    const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const runtimeConfigPath = join(testState.fakeHomeDir, '.claude.json')
+    const systemCredentials = createClaudeCredentialsJson('system@example.com', 'system')
+    const managedCredentials = createClaudeCredentialsJson('user@example.com', 'managed')
+    writeFileSync(runtimeCredentialsPath, systemCredentials, 'utf-8')
+    writeFileSync(runtimeConfigPath, '{not-json', 'utf-8')
+    testState.scopedKeychainCredentials = systemCredentials
+    testState.legacyKeychainCredentials = systemCredentials
+    const managedAuthPath = createManagedClaudeAuth(
+      testState.userDataDir,
+      'account-1',
+      managedCredentials
+    )
+    const settings = createSettings({
+      claudeManagedAccounts: [createClaudeAccount('account-1', managedAuthPath)]
+    })
+    const store = createStore(settings)
+
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const service = new ClaudeRuntimeAuthService(store as never)
+    settings.activeClaudeManagedAccountId = 'account-1'
+    await service.syncForCurrentSelection()
+
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(managedCredentials)
+    expect(testState.scopedKeychainCredentials).toBe(managedCredentials)
+    expect(testState.legacyKeychainCredentials).toBe(managedCredentials)
+    expect(readFileSync(runtimeConfigPath, 'utf-8')).toBe('{not-json')
+
+    settings.activeClaudeManagedAccountId = null
+    await service.syncForCurrentSelection()
+
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(systemCredentials)
+    expect(readFileSync(runtimeConfigPath, 'utf-8')).toBe('{not-json')
+  })
+
+  it('preserves non-object runtime config while materializing managed credentials', async () => {
+    const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const runtimeConfigPath = join(testState.fakeHomeDir, '.claude.json')
+    const systemCredentials = createClaudeCredentialsJson('system@example.com', 'system')
+    const managedCredentials = createClaudeCredentialsJson('user@example.com', 'managed')
+    writeFileSync(runtimeCredentialsPath, systemCredentials, 'utf-8')
+    writeFileSync(runtimeConfigPath, '[]', 'utf-8')
+    const managedAuthPath = createManagedClaudeAuth(
+      testState.userDataDir,
+      'account-1',
+      managedCredentials
+    )
+    const settings = createSettings({
+      claudeManagedAccounts: [createClaudeAccount('account-1', managedAuthPath)]
+    })
+    const store = createStore(settings)
+
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const service = new ClaudeRuntimeAuthService(store as never)
+    settings.activeClaudeManagedAccountId = 'account-1'
+    await service.syncForCurrentSelection()
+
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(managedCredentials)
+    expect(readFileSync(runtimeConfigPath, 'utf-8')).toBe('[]')
+  })
+
+  it('does not use skipped oauth writes as ownership proof on deselect', async () => {
+    const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const runtimeConfigPath = join(testState.fakeHomeDir, '.claude.json')
+    const systemCredentials = createClaudeCredentialsJson('system@example.com', 'system')
+    const managedCredentials = createClaudeCredentialsJson('user@example.com', 'managed')
+    const externalCredentials = createClaudeCredentialsJson('external@example.com', 'external')
+    const managedOauthAccount = { accountUuid: 'account-1' }
+    writeFileSync(runtimeCredentialsPath, systemCredentials, 'utf-8')
+    writeFileSync(runtimeConfigPath, '{not-json', 'utf-8')
+    testState.scopedKeychainCredentials = systemCredentials
+    testState.legacyKeychainCredentials = systemCredentials
+    const managedAuthPath = createManagedClaudeAuth(
+      testState.userDataDir,
+      'account-1',
+      managedCredentials,
+      `${JSON.stringify(managedOauthAccount)}\n`
+    )
+    const settings = createSettings({
+      claudeManagedAccounts: [createClaudeAccount('account-1', managedAuthPath)]
+    })
+    const store = createStore(settings)
+
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const service = new ClaudeRuntimeAuthService(store as never)
+    settings.activeClaudeManagedAccountId = 'account-1'
+    await service.syncForCurrentSelection()
+
+    writeFileSync(runtimeCredentialsPath, externalCredentials, 'utf-8')
+    writeFileSync(
+      runtimeConfigPath,
+      `${JSON.stringify({ oauthAccount: managedOauthAccount })}\n`,
+      'utf-8'
+    )
+    testState.scopedKeychainCredentials = externalCredentials
+    testState.legacyKeychainCredentials = externalCredentials
+    settings.activeClaudeManagedAccountId = null
+    await service.syncForCurrentSelection()
+
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(externalCredentials)
+    expect(readRuntimeOauthAccountForTest()).toEqual(managedOauthAccount)
+    expect(testState.scopedKeychainCredentials).toBe(externalCredentials)
+    expect(testState.legacyKeychainCredentials).toBe(externalCredentials)
   })
 
   it('preserves external oauth logout when managed oauth metadata is null', async () => {

--- a/src/main/claude-accounts/runtime-auth-service.test.ts
+++ b/src/main/claude-accounts/runtime-auth-service.test.ts
@@ -1157,6 +1157,72 @@ describe('ClaudeRuntimeAuthService', () => {
     expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(account2Credentials)
   })
 
+  it('materializes only the selected managed account into shared Claude runtime files', async () => {
+    setPlatform('linux')
+    const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const account1Credentials = createClaudeCredentialsJson('one@example.com', 'one-token')
+    const account2Credentials = createClaudeCredentialsJson('two@example.com', 'two-token')
+    const account1Oauth = '{"accountUuid":"account-1","emailAddress":"one@example.com"}\n'
+    const account2Oauth = '{"accountUuid":"account-2","emailAddress":"two@example.com"}\n'
+    const managedAuthPath1 = createManagedClaudeAuth(
+      testState.userDataDir,
+      'account-1',
+      account1Credentials,
+      account1Oauth
+    )
+    const managedAuthPath2 = createManagedClaudeAuth(
+      testState.userDataDir,
+      'account-2',
+      account2Credentials,
+      account2Oauth
+    )
+    const settings = createSettings({
+      claudeManagedAccounts: [
+        createClaudeAccount('account-1', managedAuthPath1, { email: 'one@example.com' }),
+        createClaudeAccount('account-2', managedAuthPath2, { email: 'two@example.com' })
+      ],
+      activeClaudeManagedAccountId: 'account-1'
+    })
+    const store = createStore(settings)
+
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const service = new ClaudeRuntimeAuthService(store as never)
+
+    await service.syncForCurrentSelection()
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(account1Credentials)
+    expect(readRuntimeOauthAccountForTest()).toEqual({
+      accountUuid: 'account-1',
+      emailAddress: 'one@example.com'
+    })
+
+    settings.activeClaudeManagedAccountId = 'account-2'
+    await service.syncForCurrentSelection()
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(account2Credentials)
+    expect(readRuntimeOauthAccountForTest()).toEqual({
+      accountUuid: 'account-2',
+      emailAddress: 'two@example.com'
+    })
+
+    settings.activeClaudeManagedAccountId = 'account-1'
+    await service.syncForCurrentSelection()
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(account1Credentials)
+    expect(readRuntimeOauthAccountForTest()).toEqual({
+      accountUuid: 'account-1',
+      emailAddress: 'one@example.com'
+    })
+
+    // Why: switching rewrites only the shared Claude runtime surface; the
+    // managed account files remain per-account sources of truth.
+    expect(readFileSync(join(managedAuthPath1, '.credentials.json'), 'utf-8')).toBe(
+      account1Credentials
+    )
+    expect(readFileSync(join(managedAuthPath2, '.credentials.json'), 'utf-8')).toBe(
+      account2Credentials
+    )
+    expect(readFileSync(join(managedAuthPath1, 'oauth-account.json'), 'utf-8')).toBe(account1Oauth)
+    expect(readFileSync(join(managedAuthPath2, 'oauth-account.json'), 'utf-8')).toBe(account2Oauth)
+  })
+
   it('does not carry the reauth read-back skip across Claude account switches', async () => {
     const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
     const account1Credentials = createClaudeCredentialsJson('one@example.com', 'one')

--- a/src/main/claude-accounts/runtime-auth-service.ts
+++ b/src/main/claude-accounts/runtime-auth-service.ts
@@ -239,7 +239,7 @@ export class ClaudeRuntimeAuthService {
         this.lastWrittenCredentialsJson = runtimeContents
         if (process.platform === 'darwin') {
           const paths = this.pathResolver.getRuntimePaths()
-          await writeActiveClaudeKeychainCredentials(runtimeContents, paths.configDir)
+          await writeActiveClaudeKeychainCredentialsForRuntime(runtimeContents, paths.configDir)
         }
       }
       return { status: 'persisted' }
@@ -260,18 +260,33 @@ export class ClaudeRuntimeAuthService {
       ? readFileSync(paths.credentialsPath, 'utf-8')
       : null
     if (process.platform === 'darwin') {
-      const keychainCredentials = await readActiveClaudeKeychainCredentials(paths.configDir)
+      const scopedKeychainCredentials = await readActiveClaudeKeychainCredentialsStrict(
+        paths.configDir
+      )
+      const legacyKeychainCredentials = await readActiveClaudeKeychainCredentialsStrict()
       if (this.lastWrittenCredentialsJson === null) {
-        if (keychainCredentials && keychainCredentials !== baselineCredentialsJson) {
-          return keychainCredentials
+        if (scopedKeychainCredentials && scopedKeychainCredentials !== baselineCredentialsJson) {
+          return scopedKeychainCredentials
+        }
+        if (legacyKeychainCredentials && legacyKeychainCredentials !== baselineCredentialsJson) {
+          return legacyKeychainCredentials
         }
         if (fileCredentials && fileCredentials !== baselineCredentialsJson) {
           return fileCredentials
         }
-        return keychainCredentials ?? fileCredentials
+        return scopedKeychainCredentials ?? legacyKeychainCredentials ?? fileCredentials
       }
-      if (keychainCredentials && keychainCredentials !== this.lastWrittenCredentialsJson) {
-        return keychainCredentials
+      if (
+        scopedKeychainCredentials &&
+        scopedKeychainCredentials !== this.lastWrittenCredentialsJson
+      ) {
+        return scopedKeychainCredentials
+      }
+      if (
+        legacyKeychainCredentials &&
+        legacyKeychainCredentials !== this.lastWrittenCredentialsJson
+      ) {
+        return legacyKeychainCredentials
       }
     }
     if (!fileCredentials) {

--- a/src/main/claude-accounts/runtime-auth-service.ts
+++ b/src/main/claude-accounts/runtime-auth-service.ts
@@ -171,9 +171,9 @@ export class ClaudeRuntimeAuthService {
     }
 
     let credentialsJson = await this.readManagedCredentials(activeAccount)
-    if (!credentialsJson) {
+    if (!credentialsJson || !this.isValidCredentialsJsonObject(credentialsJson)) {
       console.warn(
-        '[claude-runtime-auth] Active managed account is missing credentials, restoring system default'
+        '[claude-runtime-auth] Active managed account is missing or has invalid credentials, restoring system default'
       )
       this.store.updateSettings({ activeClaudeManagedAccountId: null })
       if (this.lastSyncedAccountId !== null) {
@@ -209,7 +209,10 @@ export class ClaudeRuntimeAuthService {
           updateLastWrittenCredentialsJson: true
         })
         if (readBackResult.status === 'persisted') {
-          credentialsJson = (await this.readManagedCredentials(activeAccount)) ?? credentialsJson
+          const updatedCredentialsJson = await this.readManagedCredentials(activeAccount)
+          if (updatedCredentialsJson && this.isValidCredentialsJsonObject(updatedCredentialsJson)) {
+            credentialsJson = updatedCredentialsJson
+          }
         }
       }
     }
@@ -467,6 +470,14 @@ export class ClaudeRuntimeAuthService {
       organizationUuid: this.normalizeField(
         this.readString(oauth, 'organizationUuid') ?? this.readString(oauth, 'organizationId')
       )
+    }
+  }
+
+  private isValidCredentialsJsonObject(credentialsJson: string): boolean {
+    try {
+      return this.asRecord(JSON.parse(credentialsJson)) !== null
+    } catch {
+      return false
     }
   }
 

--- a/src/main/claude-accounts/runtime-auth-service.ts
+++ b/src/main/claude-accounts/runtime-auth-service.ts
@@ -283,6 +283,9 @@ export class ClaudeRuntimeAuthService {
       }[] = []
       let sawAmbiguousCandidate = false
       for (const runtimeContents of changedCandidates) {
+        if (!this.isValidCredentialsJsonObject(runtimeContents)) {
+          continue
+        }
         const match = await this.findManagedAccountForRuntimeCredentials(runtimeContents)
         if (match.kind === 'ambiguous') {
           sawAmbiguousCandidate = true
@@ -475,7 +478,9 @@ export class ClaudeRuntimeAuthService {
 
   private isValidCredentialsJsonObject(credentialsJson: string): boolean {
     try {
-      return this.asRecord(JSON.parse(credentialsJson)) !== null
+      const parsed = this.asRecord(JSON.parse(credentialsJson))
+      const oauth = this.asRecord(parsed?.claudeAiOauth)
+      return this.normalizeField(this.readString(oauth, 'accessToken')) !== null
     } catch {
       return false
     }

--- a/src/main/claude-accounts/runtime-auth-service.ts
+++ b/src/main/claude-accounts/runtime-auth-service.ts
@@ -12,8 +12,10 @@ import { ClaudeRuntimePathResolver } from './runtime-paths'
 import {
   deleteActiveClaudeKeychainCredentialsStrict,
   readActiveClaudeKeychainCredentials,
+  readActiveClaudeKeychainCredentialsStrict,
   readManagedClaudeKeychainCredentials,
   writeActiveClaudeKeychainCredentials,
+  writeActiveClaudeKeychainCredentialsForRuntime,
   writeManagedClaudeKeychainCredentials
 } from './keychain'
 
@@ -28,6 +30,8 @@ type ClaudeSystemDefaultSnapshot = {
   credentialsJson: string | null
   configOauthAccount: unknown
   keychainCredentialsJson: string | null
+  scopedKeychainCredentialsJson?: string | null
+  legacyKeychainCredentialsJson?: string | null
   capturedAt: number
 }
 
@@ -175,7 +179,9 @@ export class ClaudeRuntimeAuthService {
     const paths = this.pathResolver.getRuntimePaths()
     this.writeRuntimeCredentials(credentialsJson)
     if (process.platform === 'darwin') {
-      await writeActiveClaudeKeychainCredentials(credentialsJson, paths.configDir)
+      // Why: Claude Code 2.1+ reads the scoped service, while older builds read
+      // the legacy unsuffixed service. Runtime switching must satisfy both.
+      await writeActiveClaudeKeychainCredentialsForRuntime(credentialsJson, paths.configDir)
     }
     this.writeRuntimeOauthAccount(this.readManagedOauthAccount(activeAccount))
     this.lastSyncedAccountId = activeAccount.id
@@ -508,10 +514,18 @@ export class ClaudeRuntimeAuthService {
       ? readFileSync(paths.credentialsPath, 'utf-8')
       : null
     const keychainCredentialsJson = await readActiveClaudeKeychainCredentials(paths.configDir)
+    const scopedKeychainCredentialsJson =
+      process.platform === 'darwin'
+        ? await readActiveClaudeKeychainCredentialsStrict(paths.configDir)
+        : null
+    const legacyKeychainCredentialsJson =
+      process.platform === 'darwin' ? await readActiveClaudeKeychainCredentialsStrict() : null
     const snapshot: ClaudeSystemDefaultSnapshot = {
       credentialsJson,
       configOauthAccount: this.readRuntimeOauthAccount(),
       keychainCredentialsJson,
+      scopedKeychainCredentialsJson,
+      legacyKeychainCredentialsJson,
       capturedAt: Date.now()
     }
     this.writeJson(snapshotPath, snapshot)
@@ -533,6 +547,7 @@ export class ClaudeRuntimeAuthService {
       rmSync(paths.credentialsPath, { force: true })
       if (process.platform === 'darwin') {
         await deleteActiveClaudeKeychainCredentialsStrict(paths.configDir)
+        await deleteActiveClaudeKeychainCredentialsStrict()
       }
       this.lastWrittenCredentialsJson = null
       return
@@ -546,11 +561,26 @@ export class ClaudeRuntimeAuthService {
     this.writeRuntimeOauthAccount(snapshot.configOauthAccount)
     if (process.platform === 'darwin') {
       if (externalState !== 'keychain-change') {
-        await (snapshot.keychainCredentialsJson !== null
-          ? writeActiveClaudeKeychainCredentials(snapshot.keychainCredentialsJson, paths.configDir)
-          : deleteActiveClaudeKeychainCredentialsStrict(paths.configDir))
+        const scopedSnapshot = Object.hasOwn(snapshot, 'scopedKeychainCredentialsJson')
+          ? snapshot.scopedKeychainCredentialsJson
+          : snapshot.keychainCredentialsJson
+        await this.restoreActiveClaudeKeychainCredentials(scopedSnapshot ?? null, paths.configDir)
+        if (Object.hasOwn(snapshot, 'legacyKeychainCredentialsJson')) {
+          await this.restoreActiveClaudeKeychainCredentials(
+            snapshot.legacyKeychainCredentialsJson ?? null
+          )
+        }
       }
     }
+  }
+
+  private async restoreActiveClaudeKeychainCredentials(
+    credentialsJson: string | null,
+    configDir?: string
+  ): Promise<void> {
+    await (credentialsJson !== null
+      ? writeActiveClaudeKeychainCredentials(credentialsJson, configDir)
+      : deleteActiveClaudeKeychainCredentialsStrict(configDir))
   }
 
   // Why: detects whether an external tool (e.g. `claude auth login`) overwrote
@@ -565,14 +595,16 @@ export class ClaudeRuntimeAuthService {
     }
     const paths = this.pathResolver.getRuntimePaths()
     if (!existsSync(paths.credentialsPath)) {
-      const currentKeychainCredentials =
+      const currentScopedKeychainCredentials =
         process.platform === 'darwin'
-          ? await readActiveClaudeKeychainCredentials(paths.configDir)
+          ? await readActiveClaudeKeychainCredentialsStrict(paths.configDir)
           : null
-      if (
-        process.platform === 'darwin' &&
-        currentKeychainCredentials === this.lastWrittenCredentialsJson
-      ) {
+      const currentLegacyKeychainCredentials =
+        process.platform === 'darwin' ? await readActiveClaudeKeychainCredentialsStrict() : null
+      const runtimeKeychainStillPresent =
+        currentScopedKeychainCredentials === this.lastWrittenCredentialsJson ||
+        currentLegacyKeychainCredentials === this.lastWrittenCredentialsJson
+      if (process.platform === 'darwin' && runtimeKeychainStillPresent) {
         return 'none'
       }
       const snapshotPath = this.getSystemDefaultSnapshotPath()
@@ -581,15 +613,17 @@ export class ClaudeRuntimeAuthService {
       return 'file-logout'
     }
     const currentCredentials = readFileSync(paths.credentialsPath, 'utf-8')
-    const currentKeychainCredentials =
+    const currentScopedKeychainCredentials =
       process.platform === 'darwin'
-        ? await readActiveClaudeKeychainCredentials(paths.configDir)
+        ? await readActiveClaudeKeychainCredentialsStrict(paths.configDir)
         : null
+    const currentLegacyKeychainCredentials =
+      process.platform === 'darwin' ? await readActiveClaudeKeychainCredentialsStrict() : null
     if (currentCredentials === this.lastWrittenCredentialsJson) {
-      if (
-        process.platform === 'darwin' &&
-        currentKeychainCredentials !== this.lastWrittenCredentialsJson
-      ) {
+      const runtimeKeychainChanged =
+        currentScopedKeychainCredentials !== this.lastWrittenCredentialsJson ||
+        currentLegacyKeychainCredentials !== this.lastWrittenCredentialsJson
+      if (process.platform === 'darwin' && runtimeKeychainChanged) {
         return 'keychain-change'
       }
       return 'none'

--- a/src/main/claude-accounts/runtime-auth-service.ts
+++ b/src/main/claude-accounts/runtime-auth-service.ts
@@ -157,10 +157,14 @@ export class ClaudeRuntimeAuthService {
         this.store.updateSettings({ activeClaudeManagedAccountId: null })
       }
       if (this.lastSyncedAccountId !== null) {
-        await this.restoreSystemDefaultSnapshot(
-          previousManagedCredentialsJson,
-          previousManagedOauthAccount
-        )
+        if (previousAccount) {
+          await this.restoreSystemDefaultSnapshot(
+            previousManagedCredentialsJson,
+            previousManagedOauthAccount
+          )
+        } else {
+          this.clearLastWrittenRuntimeState()
+        }
         this.lastSyncedAccountId = null
       }
       return
@@ -173,9 +177,9 @@ export class ClaudeRuntimeAuthService {
       )
       this.store.updateSettings({ activeClaudeManagedAccountId: null })
       if (this.lastSyncedAccountId !== null) {
-        await this.restoreSystemDefaultSnapshot(
-          previousManagedCredentialsJson,
-          previousManagedOauthAccount
+        await this.restoreSystemDefaultSnapshotForMissingManagedCredentials(
+          activeAccount,
+          this.readManagedOauthAccount(activeAccount)
         )
         this.lastSyncedAccountId = null
       }
@@ -187,7 +191,10 @@ export class ClaudeRuntimeAuthService {
       const runtimeCredentialsJson = existsSync(paths.credentialsPath)
         ? readFileSync(paths.credentialsPath, 'utf-8')
         : null
-      await this.captureSystemDefaultSnapshot({ force: runtimeCredentialsJson !== credentialsJson })
+      await this.captureSystemDefaultSnapshotForManagedEntry(
+        runtimeCredentialsJson,
+        credentialsJson
+      )
     }
 
     // Why: Claude CLI refreshes expired OAuth tokens and writes them back to
@@ -215,7 +222,15 @@ export class ClaudeRuntimeAuthService {
     if (process.platform === 'darwin') {
       // Why: Claude Code 2.1+ reads the scoped service, while older builds read
       // the legacy unsuffixed service. Runtime switching must satisfy both.
-      await writeActiveClaudeKeychainCredentialsForRuntime(credentialsJson, paths.configDir)
+      try {
+        await writeActiveClaudeKeychainCredentialsForRuntime(credentialsJson, paths.configDir)
+      } catch (error) {
+        await this.restoreSystemDefaultSnapshot(
+          credentialsJson,
+          this.readManagedOauthAccount(activeAccount)
+        )
+        throw error
+      }
     }
     const managedOauthAccount = this.readManagedOauthAccount(activeAccount)
     this.writeRuntimeOauthAccount(managedOauthAccount)
@@ -242,33 +257,53 @@ export class ClaudeRuntimeAuthService {
     options: { updateLastWrittenCredentialsJson: boolean }
   ): Promise<ClaudeReadBackResult> {
     try {
-      const runtimeContents = await this.readRuntimeCredentialsForReadBack(baselineCredentialsJson)
-      if (!runtimeContents) {
+      const candidates =
+        await this.readRuntimeCredentialCandidatesForReadBack(baselineCredentialsJson)
+      if (candidates.length === 0) {
         return { status: 'unchanged' }
       }
-      if (
-        this.lastWrittenCredentialsJson !== null &&
-        runtimeContents === this.lastWrittenCredentialsJson
-      ) {
+      const changedCandidates =
+        this.lastWrittenCredentialsJson === null
+          ? candidates
+          : candidates.filter((candidate) => candidate !== this.lastWrittenCredentialsJson)
+      if (changedCandidates.length === 0) {
         return { status: 'unchanged' }
       }
 
-      const match = await this.findManagedAccountForRuntimeCredentials(runtimeContents)
-      if (match.kind !== 'matched') {
+      const acceptedCandidates: {
+        credentialsJson: string
+        match: Extract<ClaudeReadBackMatch, { kind: 'matched' }>
+      }[] = []
+      let sawAmbiguousCandidate = false
+      for (const runtimeContents of changedCandidates) {
+        const match = await this.findManagedAccountForRuntimeCredentials(runtimeContents)
         if (match.kind === 'ambiguous') {
+          sawAmbiguousCandidate = true
+          continue
+        }
+        if (match.kind !== 'matched') {
+          continue
+        }
+        // Why: on cold app start we cannot tell whether matching runtime
+        // credentials are a fresh CLI refresh or stale state unless token
+        // metadata proves runtime is newer than managed storage.
+        if (this.lastWrittenCredentialsJson === null) {
+          if (!this.runtimeCredentialsAreFresher(runtimeContents, match.managedCredentialsJson)) {
+            continue
+          }
+        } else if (this.runtimeCredentialsAreOlder(runtimeContents, match.managedCredentialsJson)) {
+          continue
+        }
+        acceptedCandidates.push({ credentialsJson: runtimeContents, match })
+      }
+      if (acceptedCandidates.length === 0) {
+        if (sawAmbiguousCandidate) {
           console.warn('[claude-runtime-auth] Refusing ambiguous Claude auth read-back')
         }
         return { status: 'rejected' }
       }
-      // Why: on cold app start we cannot tell whether matching runtime
-      // credentials are a fresh CLI refresh or stale state unless token
-      // metadata proves runtime is newer than managed storage.
-      if (
-        this.lastWrittenCredentialsJson === null &&
-        !this.runtimeCredentialsAreFresher(runtimeContents, match.managedCredentialsJson)
-      ) {
-        return { status: 'rejected' }
-      }
+      const { credentialsJson: runtimeContents, match } =
+        this.chooseFreshestReadBackCandidate(acceptedCandidates)
 
       await this.writeManagedCredentials(match.account, runtimeContents)
       if (options.updateLastWrittenCredentialsJson) {
@@ -289,47 +324,35 @@ export class ClaudeRuntimeAuthService {
     }
   }
 
-  private async readRuntimeCredentialsForReadBack(
+  private async readRuntimeCredentialCandidatesForReadBack(
     baselineCredentialsJson: string
-  ): Promise<string | null> {
+  ): Promise<string[]> {
     const paths = this.pathResolver.getRuntimePaths()
     const fileCredentials = existsSync(paths.credentialsPath)
       ? readFileSync(paths.credentialsPath, 'utf-8')
       : null
+    const candidates: string[] = []
+    const pushCandidate = (credentialsJson: string | null): void => {
+      if (credentialsJson && !candidates.includes(credentialsJson)) {
+        candidates.push(credentialsJson)
+      }
+    }
     if (process.platform === 'darwin') {
       const scopedKeychainCredentials = await this.readActiveClaudeKeychainCredentialsBestEffort(
         paths.configDir
       )
       const legacyKeychainCredentials = await this.readActiveClaudeKeychainCredentialsBestEffort()
       if (this.lastWrittenCredentialsJson === null) {
-        if (scopedKeychainCredentials && scopedKeychainCredentials !== baselineCredentialsJson) {
-          return scopedKeychainCredentials
-        }
-        if (legacyKeychainCredentials && legacyKeychainCredentials !== baselineCredentialsJson) {
-          return legacyKeychainCredentials
-        }
-        if (fileCredentials && fileCredentials !== baselineCredentialsJson) {
-          return fileCredentials
-        }
-        return scopedKeychainCredentials ?? legacyKeychainCredentials ?? fileCredentials
+        pushCandidate(scopedKeychainCredentials)
+        pushCandidate(legacyKeychainCredentials)
+        pushCandidate(fileCredentials)
+        return candidates.filter((candidate) => candidate !== baselineCredentialsJson)
       }
-      if (
-        scopedKeychainCredentials &&
-        scopedKeychainCredentials !== this.lastWrittenCredentialsJson
-      ) {
-        return scopedKeychainCredentials
-      }
-      if (
-        legacyKeychainCredentials &&
-        legacyKeychainCredentials !== this.lastWrittenCredentialsJson
-      ) {
-        return legacyKeychainCredentials
-      }
+      pushCandidate(scopedKeychainCredentials)
+      pushCandidate(legacyKeychainCredentials)
     }
-    if (!fileCredentials) {
-      return null
-    }
-    return fileCredentials
+    pushCandidate(fileCredentials)
+    return candidates
   }
 
   private getPreparation(): ClaudeRuntimeAuthPreparation {
@@ -404,6 +427,12 @@ export class ClaudeRuntimeAuthService {
         managedIdentity?.organizationUuid ??
         managedOauthIdentity.organizationUuid
     )
+    if (!identity.email) {
+      return 'unverifiable'
+    }
+    if (account.email && this.normalizeField(account.email) !== identity.email) {
+      return 'mismatch'
+    }
     if (selectedOrganizationUuid && !identity.organizationUuid) {
       return 'unverifiable'
     }
@@ -416,12 +445,6 @@ export class ClaudeRuntimeAuthService {
     }
     if (!selectedOrganizationUuid && identity.organizationUuid) {
       return 'unverifiable'
-    }
-    if (!identity.email) {
-      return 'unverifiable'
-    }
-    if (account.email && identity.email && this.normalizeField(account.email) !== identity.email) {
-      return 'mismatch'
     }
 
     return 'match'
@@ -452,6 +475,39 @@ export class ClaudeRuntimeAuthService {
     return (
       runtimeFreshness !== null && managedFreshness !== null && runtimeFreshness > managedFreshness
     )
+  }
+
+  private runtimeCredentialsAreOlder(
+    runtimeCredentialsJson: string,
+    managedCredentialsJson: string
+  ): boolean {
+    const runtimeFreshness = this.readFreshnessFromCredentials(runtimeCredentialsJson)
+    const managedFreshness = this.readFreshnessFromCredentials(managedCredentialsJson)
+    return (
+      runtimeFreshness !== null && managedFreshness !== null && runtimeFreshness < managedFreshness
+    )
+  }
+
+  private chooseFreshestReadBackCandidate(
+    candidates: {
+      credentialsJson: string
+      match: Extract<ClaudeReadBackMatch, { kind: 'matched' }>
+    }[]
+  ): {
+    credentialsJson: string
+    match: Extract<ClaudeReadBackMatch, { kind: 'matched' }>
+  } {
+    return candidates.reduce((freshest, candidate) => {
+      const candidateFreshness = this.readFreshnessFromCredentials(candidate.credentialsJson)
+      const freshestFreshness = this.readFreshnessFromCredentials(freshest.credentialsJson)
+      if (
+        candidateFreshness !== null &&
+        (freshestFreshness === null || candidateFreshness > freshestFreshness)
+      ) {
+        return candidate
+      }
+      return freshest
+    })
   }
 
   private readFreshnessFromCredentials(credentialsJson: string): number | null {
@@ -549,16 +605,50 @@ export class ClaudeRuntimeAuthService {
     }
   }
 
-  private async captureSystemDefaultSnapshot(options: { force: boolean }): Promise<void> {
+  private async captureSystemDefaultSnapshotForManagedEntry(
+    runtimeCredentialsJson: string | null,
+    managedCredentialsJson: string
+  ): Promise<void> {
+    const snapshotPath = this.getSystemDefaultSnapshotPath()
+    const existingSnapshot = this.readSystemDefaultSnapshot(snapshotPath)
+    if (runtimeCredentialsJson !== managedCredentialsJson) {
+      await this.captureSystemDefaultSnapshot({
+        force: true,
+        previousSnapshot: existingSnapshot,
+        managedCredentialsJson
+      })
+      return
+    }
+    if (existingSnapshot) {
+      await this.captureSystemDefaultSnapshot({
+        force: true,
+        credentialsJsonOverride: existingSnapshot.credentialsJson,
+        previousSnapshot: existingSnapshot,
+        managedCredentialsJson
+      })
+      return
+    }
+    await this.captureSystemDefaultSnapshot({ force: false })
+  }
+
+  private async captureSystemDefaultSnapshot(options: {
+    force: boolean
+    credentialsJsonOverride?: string | null
+    previousSnapshot?: ClaudeSystemDefaultSnapshot | null
+    managedCredentialsJson?: string
+  }): Promise<void> {
     const snapshotPath = this.getSystemDefaultSnapshotPath()
     if (!options.force && existsSync(snapshotPath)) {
       return
     }
 
     const paths = this.pathResolver.getRuntimePaths()
-    const credentialsJson = existsSync(paths.credentialsPath)
-      ? readFileSync(paths.credentialsPath, 'utf-8')
-      : null
+    const credentialsJson =
+      options.credentialsJsonOverride !== undefined
+        ? options.credentialsJsonOverride
+        : existsSync(paths.credentialsPath)
+          ? readFileSync(paths.credentialsPath, 'utf-8')
+          : null
     const keychainCredentialsJson = await this.readAggregateClaudeKeychainCredentialsBestEffort(
       paths.configDir
     )
@@ -576,20 +666,32 @@ export class ClaudeRuntimeAuthService {
     ) {
       throw new Error('Cannot capture current Claude Keychain credentials')
     }
+    const scopedKeychainCredentialsJson =
+      scopedKeychainCredentials.status === 'captured'
+        ? this.snapshotKeychainCredentials(
+            scopedKeychainCredentials.credentialsJson,
+            options.previousSnapshot,
+            'scoped',
+            options.managedCredentialsJson
+          )
+        : undefined
+    const legacyKeychainSnapshotJson =
+      legacyKeychainCredentialsJson.status === 'captured'
+        ? this.snapshotKeychainCredentials(
+            legacyKeychainCredentialsJson.credentialsJson,
+            options.previousSnapshot,
+            'legacy',
+            options.managedCredentialsJson
+          )
+        : undefined
     const configOauthAccount = this.readRuntimeOauthAccount()
     const snapshot: ClaudeSystemDefaultSnapshot = {
       credentialsJson,
       configOauthAccount:
         configOauthAccount === RUNTIME_OAUTH_ACCOUNT_PARSE_ERROR ? null : configOauthAccount,
       keychainCredentialsJson,
-      scopedKeychainCredentialsJson:
-        scopedKeychainCredentials.status === 'captured'
-          ? scopedKeychainCredentials.credentialsJson
-          : undefined,
-      legacyKeychainCredentialsJson:
-        legacyKeychainCredentialsJson.status === 'captured'
-          ? legacyKeychainCredentialsJson.credentialsJson
-          : undefined,
+      scopedKeychainCredentialsJson,
+      legacyKeychainCredentialsJson: legacyKeychainSnapshotJson,
       scopedKeychainCredentialsCaptured: scopedKeychainCredentials.status === 'captured',
       legacyKeychainCredentialsCaptured: legacyKeychainCredentialsJson.status === 'captured',
       capturedAt: Date.now()
@@ -661,6 +763,121 @@ export class ClaudeRuntimeAuthService {
     }
   }
 
+  private async clearRuntimeAuthForAccount(
+    account: ClaudeManagedAccount,
+    managedOauthAccount: unknown
+  ): Promise<void> {
+    const paths = this.pathResolver.getRuntimePaths()
+    let clearedCredentials = false
+    if (
+      this.runtimeCredentialsBelongToAccount(
+        this.readRuntimeCredentialsFile(),
+        account,
+        managedOauthAccount
+      )
+    ) {
+      rmSync(paths.credentialsPath, { force: true })
+      clearedCredentials = true
+    }
+    if (process.platform === 'darwin') {
+      clearedCredentials =
+        (await this.clearActiveKeychainCredentialsForAccount(
+          account,
+          managedOauthAccount,
+          paths.configDir
+        )) || clearedCredentials
+      clearedCredentials =
+        (await this.clearActiveKeychainCredentialsForAccount(account, managedOauthAccount)) ||
+        clearedCredentials
+    }
+    this.restoreRuntimeOauthAccountIfOwned(null, managedOauthAccount, {
+      allowNullOwnership: clearedCredentials
+    })
+  }
+
+  private async restoreSystemDefaultSnapshotForMissingManagedCredentials(
+    account: ClaudeManagedAccount,
+    managedOauthAccount: unknown
+  ): Promise<void> {
+    const snapshot = this.readSystemDefaultSnapshot(this.getSystemDefaultSnapshotPath())
+    if (!snapshot) {
+      await this.clearRuntimeAuthForAccount(account, managedOauthAccount)
+      this.clearLastWrittenRuntimeState()
+      return
+    }
+    const paths = this.pathResolver.getRuntimePaths()
+    let restoredCredentials = false
+    if (
+      this.runtimeCredentialsBelongToAccount(
+        this.readRuntimeCredentialsFile(),
+        account,
+        managedOauthAccount
+      )
+    ) {
+      if (snapshot.credentialsJson !== null) {
+        this.writeRuntimeCredentials(snapshot.credentialsJson)
+      } else {
+        rmSync(paths.credentialsPath, { force: true })
+      }
+      restoredCredentials = true
+    }
+    if (process.platform === 'darwin') {
+      restoredCredentials =
+        (await this.restoreKeychainSnapshotValueForAccount(
+          this.readKeychainSnapshotValue(snapshot, 'scoped'),
+          account,
+          managedOauthAccount,
+          paths.configDir
+        )) || restoredCredentials
+      restoredCredentials =
+        (await this.restoreKeychainSnapshotValueForAccount(
+          this.readKeychainSnapshotValue(snapshot, 'legacy'),
+          account,
+          managedOauthAccount
+        )) || restoredCredentials
+    }
+    this.restoreRuntimeOauthAccountIfOwned(snapshot.configOauthAccount, managedOauthAccount, {
+      allowNullOwnership: restoredCredentials
+    })
+    this.clearLastWrittenRuntimeState()
+  }
+
+  private readRuntimeCredentialsFile(): string | null {
+    const credentialsPath = this.pathResolver.getRuntimePaths().credentialsPath
+    return existsSync(credentialsPath) ? readFileSync(credentialsPath, 'utf-8') : null
+  }
+
+  private runtimeCredentialsBelongToAccount(
+    credentialsJson: string | null,
+    account: ClaudeManagedAccount,
+    managedOauthAccount: unknown
+  ): boolean {
+    if (!credentialsJson) {
+      return false
+    }
+    const identity = this.readIdentityFromCredentials(credentialsJson)
+    if (
+      !identity?.email ||
+      (account.email && this.normalizeField(account.email) !== identity.email)
+    ) {
+      return false
+    }
+    const oauthIdentity = this.readIdentityFromOauthAccount(managedOauthAccount)
+    const selectedOrganizationUuid = this.normalizeField(
+      account.organizationUuid ?? oauthIdentity.organizationUuid
+    )
+    if (selectedOrganizationUuid) {
+      return identity.organizationUuid === selectedOrganizationUuid
+    }
+    return !identity.organizationUuid
+  }
+
+  private clearLastWrittenRuntimeState(): void {
+    this.lastWrittenCredentialsJson = null
+    this.lastWrittenOauthAccount = null
+    this.hasLastWrittenOauthAccount = false
+  }
+
   private restoreRuntimeCredentialsIfOwned(
     credentialsJson: string | null,
     previouslyWrittenCredentialsJson: string | null
@@ -689,6 +906,9 @@ export class ClaudeRuntimeAuthService {
     options: { allowNullOwnership: boolean }
   ): void {
     const currentOauthAccount = this.readRuntimeOauthAccount()
+    if (currentOauthAccount === RUNTIME_OAUTH_ACCOUNT_PARSE_ERROR) {
+      return
+    }
     if (
       (ownedOauthAccount === null || ownedOauthAccount === undefined) &&
       !options.allowNullOwnership
@@ -696,9 +916,13 @@ export class ClaudeRuntimeAuthService {
       return
     }
     if (
-      currentOauthAccount === RUNTIME_OAUTH_ACCOUNT_PARSE_ERROR ||
-      !this.jsonValuesEqual(currentOauthAccount, ownedOauthAccount)
+      (ownedOauthAccount === null || ownedOauthAccount === undefined) &&
+      options.allowNullOwnership
     ) {
+      this.writeRuntimeOauthAccount(oauthAccount)
+      return
+    }
+    if (!this.jsonValuesEqual(currentOauthAccount, ownedOauthAccount)) {
       return
     }
     this.writeRuntimeOauthAccount(oauthAccount)
@@ -729,6 +953,42 @@ export class ClaudeRuntimeAuthService {
     await (credentialsJson !== null
       ? writeActiveClaudeKeychainCredentials(credentialsJson, configDir)
       : deleteActiveClaudeKeychainCredentialsStrict(configDir))
+  }
+
+  private async restoreKeychainSnapshotValueForAccount(
+    snapshotValue: ClaudeKeychainSnapshotValue,
+    account: ClaudeManagedAccount,
+    managedOauthAccount: unknown,
+    configDir?: string
+  ): Promise<boolean> {
+    if (snapshotValue.status === 'unknown') {
+      return false
+    }
+    const currentCredentialsJson =
+      await this.readActiveClaudeKeychainCredentialsBestEffort(configDir)
+    if (
+      this.runtimeCredentialsBelongToAccount(currentCredentialsJson, account, managedOauthAccount)
+    ) {
+      await this.restoreActiveClaudeKeychainCredentials(snapshotValue.credentialsJson, configDir)
+      return true
+    }
+    return false
+  }
+
+  private async clearActiveKeychainCredentialsForAccount(
+    account: ClaudeManagedAccount,
+    managedOauthAccount: unknown,
+    configDir?: string
+  ): Promise<boolean> {
+    const currentCredentialsJson =
+      await this.readActiveClaudeKeychainCredentialsBestEffort(configDir)
+    if (
+      this.runtimeCredentialsBelongToAccount(currentCredentialsJson, account, managedOauthAccount)
+    ) {
+      await deleteActiveClaudeKeychainCredentialsStrict(configDir)
+      return true
+    }
+    return false
   }
 
   private readRuntimeOauthAccount(): unknown {
@@ -781,12 +1041,15 @@ export class ClaudeRuntimeAuthService {
     const snapshot = this.asRecord(value)
     return (
       snapshot !== null &&
+      Object.hasOwn(snapshot, 'credentialsJson') &&
       this.isOptionalNullableString(snapshot.credentialsJson) &&
       this.isOptionalNullableString(snapshot.keychainCredentialsJson) &&
       this.isOptionalNullableString(snapshot.scopedKeychainCredentialsJson) &&
       this.isOptionalNullableString(snapshot.legacyKeychainCredentialsJson) &&
       this.isOptionalBoolean(snapshot.scopedKeychainCredentialsCaptured) &&
       this.isOptionalBoolean(snapshot.legacyKeychainCredentialsCaptured) &&
+      this.hasValidKeychainSnapshotValue(snapshot, 'scoped') &&
+      this.hasValidKeychainSnapshotValue(snapshot, 'legacy') &&
       (snapshot.capturedAt === undefined || typeof snapshot.capturedAt === 'number')
     )
   }
@@ -797,6 +1060,39 @@ export class ClaudeRuntimeAuthService {
 
   private isOptionalBoolean(value: unknown): boolean {
     return value === undefined || typeof value === 'boolean'
+  }
+
+  private snapshotKeychainCredentials(
+    credentialsJson: string | null,
+    previousSnapshot: ClaudeSystemDefaultSnapshot | null | undefined,
+    service: 'scoped' | 'legacy',
+    managedCredentialsJson: string | undefined
+  ): string | null {
+    if (managedCredentialsJson && credentialsJson === managedCredentialsJson && previousSnapshot) {
+      const previousValue = this.readKeychainSnapshotValue(previousSnapshot, service)
+      if (previousValue.status === 'captured') {
+        return previousValue.credentialsJson
+      }
+    }
+    return credentialsJson
+  }
+
+  private hasValidKeychainSnapshotValue(
+    snapshot: Record<string, unknown>,
+    service: 'scoped' | 'legacy'
+  ): boolean {
+    const capturedKey =
+      service === 'scoped'
+        ? 'scopedKeychainCredentialsCaptured'
+        : 'legacyKeychainCredentialsCaptured'
+    if (snapshot[capturedKey] === false) {
+      return true
+    }
+    const credentialsKey =
+      service === 'scoped' ? 'scopedKeychainCredentialsJson' : 'legacyKeychainCredentialsJson'
+    return (
+      Object.hasOwn(snapshot, credentialsKey) || Object.hasOwn(snapshot, 'keychainCredentialsJson')
+    )
   }
 
   private readKeychainSnapshotValue(

--- a/src/main/claude-accounts/runtime-auth-service.ts
+++ b/src/main/claude-accounts/runtime-auth-service.ts
@@ -32,6 +32,8 @@ type ClaudeSystemDefaultSnapshot = {
   keychainCredentialsJson: string | null
   scopedKeychainCredentialsJson?: string | null
   legacyKeychainCredentialsJson?: string | null
+  scopedKeychainCredentialsCaptured?: boolean
+  legacyKeychainCredentialsCaptured?: boolean
   capturedAt: number
 }
 
@@ -44,6 +46,14 @@ type ClaudeReadBackResult = { status: 'unchanged' | 'persisted' | 'rejected' }
 type ClaudeReadBackMatch =
   | { kind: 'matched'; account: ClaudeManagedAccount }
   | { kind: 'none' | 'ambiguous' }
+type ClaudeKeychainReadResult =
+  | { status: 'captured'; credentialsJson: string | null }
+  | { status: 'failed' }
+type ClaudeKeychainSnapshotValue =
+  | { status: 'captured'; credentialsJson: string | null }
+  | { status: 'unknown' }
+
+const RUNTIME_OAUTH_ACCOUNT_PARSE_ERROR = Symbol('runtime-oauth-account-parse-error')
 
 export class ClaudeRuntimeAuthService {
   private readonly pathResolver = new ClaudeRuntimePathResolver()
@@ -54,6 +64,8 @@ export class ClaudeRuntimeAuthService {
   // an external login (e.g. `claude auth login`) overwrote it — so Orca adopts
   // the file as the new system default instead of restoring a stale snapshot.
   private lastWrittenCredentialsJson: string | null = null
+  private hasLastWrittenOauthAccount = false
+  private lastWrittenOauthAccount: unknown = null
   private skipNextReadBackForAccountId: string | null = null
 
   constructor(private readonly store: Store) {
@@ -79,7 +91,14 @@ export class ClaudeRuntimeAuthService {
     await this.serializeMutation(async () => {
       const settings = this.store.getSettings()
       if (!settings.activeClaudeManagedAccountId) {
-        await this.restoreSystemDefaultSnapshot()
+        const previousAccount = this.getActiveAccount(
+          settings.claudeManagedAccounts,
+          this.lastSyncedAccountId
+        )
+        await this.restoreSystemDefaultSnapshot(
+          previousAccount ? await this.readManagedCredentials(previousAccount) : null,
+          previousAccount ? this.readManagedOauthAccount(previousAccount) : undefined
+        )
         this.lastSyncedAccountId = null
         return
       }
@@ -123,6 +142,9 @@ export class ClaudeRuntimeAuthService {
     const previousManagedCredentialsJson = previousAccount
       ? await this.readManagedCredentials(previousAccount)
       : null
+    const previousManagedOauthAccount = previousAccount
+      ? this.readManagedOauthAccount(previousAccount)
+      : null
     if (previousAccount && previousAccount.id !== activeAccount?.id) {
       if (previousManagedCredentialsJson) {
         await this.readBackRefreshedTokens(previousManagedCredentialsJson, {
@@ -135,7 +157,10 @@ export class ClaudeRuntimeAuthService {
         this.store.updateSettings({ activeClaudeManagedAccountId: null })
       }
       if (this.lastSyncedAccountId !== null) {
-        await this.restoreSystemDefaultSnapshot(previousManagedCredentialsJson)
+        await this.restoreSystemDefaultSnapshot(
+          previousManagedCredentialsJson,
+          previousManagedOauthAccount
+        )
         this.lastSyncedAccountId = null
       }
       return
@@ -148,14 +173,21 @@ export class ClaudeRuntimeAuthService {
       )
       this.store.updateSettings({ activeClaudeManagedAccountId: null })
       if (this.lastSyncedAccountId !== null) {
-        await this.restoreSystemDefaultSnapshot(previousManagedCredentialsJson)
+        await this.restoreSystemDefaultSnapshot(
+          previousManagedCredentialsJson,
+          previousManagedOauthAccount
+        )
         this.lastSyncedAccountId = null
       }
       return
     }
 
     if (this.lastSyncedAccountId === null) {
-      await this.captureSystemDefaultSnapshot({ force: true })
+      const paths = this.pathResolver.getRuntimePaths()
+      const runtimeCredentialsJson = existsSync(paths.credentialsPath)
+        ? readFileSync(paths.credentialsPath, 'utf-8')
+        : null
+      await this.captureSystemDefaultSnapshot({ force: runtimeCredentialsJson !== credentialsJson })
     }
 
     // Why: Claude CLI refreshes expired OAuth tokens and writes them back to
@@ -185,7 +217,10 @@ export class ClaudeRuntimeAuthService {
       // the legacy unsuffixed service. Runtime switching must satisfy both.
       await writeActiveClaudeKeychainCredentialsForRuntime(credentialsJson, paths.configDir)
     }
-    this.writeRuntimeOauthAccount(this.readManagedOauthAccount(activeAccount))
+    const managedOauthAccount = this.readManagedOauthAccount(activeAccount)
+    this.writeRuntimeOauthAccount(managedOauthAccount)
+    this.lastWrittenOauthAccount = managedOauthAccount
+    this.hasLastWrittenOauthAccount = true
     this.lastSyncedAccountId = activeAccount.id
   }
 
@@ -262,10 +297,10 @@ export class ClaudeRuntimeAuthService {
       ? readFileSync(paths.credentialsPath, 'utf-8')
       : null
     if (process.platform === 'darwin') {
-      const scopedKeychainCredentials = await readActiveClaudeKeychainCredentialsStrict(
+      const scopedKeychainCredentials = await this.readActiveClaudeKeychainCredentialsBestEffort(
         paths.configDir
       )
-      const legacyKeychainCredentials = await readActiveClaudeKeychainCredentialsStrict()
+      const legacyKeychainCredentials = await this.readActiveClaudeKeychainCredentialsBestEffort()
       if (this.lastWrittenCredentialsJson === null) {
         if (scopedKeychainCredentials && scopedKeychainCredentials !== baselineCredentialsJson) {
           return scopedKeychainCredentials
@@ -323,27 +358,29 @@ export class ClaudeRuntimeAuthService {
     runtimeCredentialsJson: string
   ): Promise<ClaudeReadBackMatch> {
     const matches: ClaudeManagedAccount[] = []
+    let unverifiableCount = 0
     for (const account of this.store.getSettings().claudeManagedAccounts) {
       const managedCredentialsJson = await this.readManagedCredentials(account)
       if (!managedCredentialsJson) {
         continue
       }
-      if (
-        this.runtimeCredentialsMatchAccount(
-          runtimeCredentialsJson,
-          account,
-          managedCredentialsJson,
-          this.readManagedOauthAccount(account)
-        ) === 'match'
-      ) {
+      const match = this.runtimeCredentialsMatchAccount(
+        runtimeCredentialsJson,
+        account,
+        managedCredentialsJson,
+        this.readManagedOauthAccount(account)
+      )
+      if (match === 'match') {
         matches.push(account)
+      } else if (match === 'unverifiable') {
+        unverifiableCount += 1
       }
     }
 
-    if (matches.length === 1) {
+    if (matches.length === 1 && unverifiableCount === 0) {
       return { kind: 'matched', account: matches[0] }
     }
-    return { kind: matches.length === 0 ? 'none' : 'ambiguous' }
+    return { kind: matches.length === 0 && unverifiableCount === 0 ? 'none' : 'ambiguous' }
   }
 
   private runtimeCredentialsMatchAccount(
@@ -376,6 +413,9 @@ export class ClaudeRuntimeAuthService {
       selectedOrganizationUuid !== identity.organizationUuid
     ) {
       return 'mismatch'
+    }
+    if (!selectedOrganizationUuid && identity.organizationUuid) {
+      return 'unverifiable'
     }
     if (!identity.email) {
       return 'unverifiable'
@@ -519,62 +559,106 @@ export class ClaudeRuntimeAuthService {
     const credentialsJson = existsSync(paths.credentialsPath)
       ? readFileSync(paths.credentialsPath, 'utf-8')
       : null
-    const keychainCredentialsJson = await readActiveClaudeKeychainCredentials(paths.configDir)
-    const scopedKeychainCredentialsJson =
+    const keychainCredentialsJson = await this.readAggregateClaudeKeychainCredentialsBestEffort(
+      paths.configDir
+    )
+    const scopedKeychainCredentials =
       process.platform === 'darwin'
-        ? await readActiveClaudeKeychainCredentialsStrict(paths.configDir)
-        : null
+        ? await this.readActiveClaudeKeychainCredentialsForSnapshot(paths.configDir)
+        : ({ status: 'captured', credentialsJson: null } as const)
     const legacyKeychainCredentialsJson =
-      process.platform === 'darwin' ? await readActiveClaudeKeychainCredentialsStrict() : null
+      process.platform === 'darwin'
+        ? await this.readActiveClaudeKeychainCredentialsForSnapshot()
+        : ({ status: 'captured', credentialsJson: null } as const)
+    if (
+      scopedKeychainCredentials.status === 'failed' ||
+      legacyKeychainCredentialsJson.status === 'failed'
+    ) {
+      throw new Error('Cannot capture current Claude Keychain credentials')
+    }
+    const configOauthAccount = this.readRuntimeOauthAccount()
     const snapshot: ClaudeSystemDefaultSnapshot = {
       credentialsJson,
-      configOauthAccount: this.readRuntimeOauthAccount(),
+      configOauthAccount:
+        configOauthAccount === RUNTIME_OAUTH_ACCOUNT_PARSE_ERROR ? null : configOauthAccount,
       keychainCredentialsJson,
-      scopedKeychainCredentialsJson,
-      legacyKeychainCredentialsJson,
+      scopedKeychainCredentialsJson:
+        scopedKeychainCredentials.status === 'captured'
+          ? scopedKeychainCredentials.credentialsJson
+          : undefined,
+      legacyKeychainCredentialsJson:
+        legacyKeychainCredentialsJson.status === 'captured'
+          ? legacyKeychainCredentialsJson.credentialsJson
+          : undefined,
+      scopedKeychainCredentialsCaptured: scopedKeychainCredentials.status === 'captured',
+      legacyKeychainCredentialsCaptured: legacyKeychainCredentialsJson.status === 'captured',
       capturedAt: Date.now()
     }
     this.writeJson(snapshotPath, snapshot)
   }
 
-  private async restoreSystemDefaultSnapshot(ownedCredentialsJson?: string | null): Promise<void> {
+  private async restoreSystemDefaultSnapshot(
+    ownedCredentialsJson?: string | null,
+    ownedOauthAccount?: unknown
+  ): Promise<void> {
     const snapshotPath = this.getSystemDefaultSnapshotPath()
     const paths = this.pathResolver.getRuntimePaths()
     const previouslyWrittenCredentialsJson =
       this.lastWrittenCredentialsJson ?? ownedCredentialsJson ?? null
-    const snapshot = existsSync(snapshotPath)
-      ? (JSON.parse(readFileSync(snapshotPath, 'utf-8')) as ClaudeSystemDefaultSnapshot)
-      : null
+    const previouslyWrittenOauthAccount =
+      ownedOauthAccount !== undefined
+        ? ownedOauthAccount
+        : this.hasLastWrittenOauthAccount
+          ? this.lastWrittenOauthAccount
+          : null
+    const snapshot = this.readSystemDefaultSnapshot(snapshotPath)
 
     const restoredCredentials = this.restoreRuntimeCredentialsIfOwned(
       snapshot?.credentialsJson ?? null,
       previouslyWrittenCredentialsJson
     )
-    if (restoredCredentials && snapshot) {
-      this.writeRuntimeOauthAccount(snapshot.configOauthAccount)
-    }
+    // Why: writeRuntimeCredentials updates lastWrittenCredentialsJson to the
+    // restored system value. Keep the managed baseline until every owned
+    // surface has restored, so a later retry can still clean up Keychain.
+    this.lastWrittenCredentialsJson = previouslyWrittenCredentialsJson
+    this.restoreRuntimeOauthAccountIfOwned(
+      snapshot?.configOauthAccount ?? null,
+      previouslyWrittenOauthAccount,
+      { allowNullOwnership: restoredCredentials }
+    )
     if (process.platform === 'darwin') {
-      const scopedSnapshot = snapshot
-        ? Object.hasOwn(snapshot, 'scopedKeychainCredentialsJson')
-          ? snapshot.scopedKeychainCredentialsJson
-          : snapshot.keychainCredentialsJson
-        : null
-      const legacySnapshot = snapshot
-        ? Object.hasOwn(snapshot, 'legacyKeychainCredentialsJson')
-          ? snapshot.legacyKeychainCredentialsJson
-          : snapshot.keychainCredentialsJson
-        : null
+      const scopedSnapshot = this.readKeychainSnapshotValue(snapshot, 'scoped')
+      const legacySnapshot = this.readKeychainSnapshotValue(snapshot, 'legacy')
       await this.restoreUnchangedActiveClaudeKeychainCredentials(
-        scopedSnapshot ?? null,
+        scopedSnapshot,
         previouslyWrittenCredentialsJson,
         paths.configDir
       )
       await this.restoreUnchangedActiveClaudeKeychainCredentials(
-        legacySnapshot ?? null,
+        legacySnapshot,
         previouslyWrittenCredentialsJson
       )
     }
     this.lastWrittenCredentialsJson = null
+    this.lastWrittenOauthAccount = null
+    this.hasLastWrittenOauthAccount = false
+  }
+
+  private readSystemDefaultSnapshot(snapshotPath: string): ClaudeSystemDefaultSnapshot | null {
+    if (!existsSync(snapshotPath)) {
+      return null
+    }
+    try {
+      const parsed = JSON.parse(readFileSync(snapshotPath, 'utf-8')) as unknown
+      if (this.isSystemDefaultSnapshot(parsed)) {
+        return parsed
+      }
+      throw new Error('Invalid Claude system-default auth snapshot shape')
+    } catch (error) {
+      console.warn('[claude-runtime-auth] Ignoring invalid system-default auth snapshot:', error)
+      rmSync(snapshotPath, { force: true })
+      return null
+    }
   }
 
   private restoreRuntimeCredentialsIfOwned(
@@ -599,17 +683,42 @@ export class ClaudeRuntimeAuthService {
     return true
   }
 
+  private restoreRuntimeOauthAccountIfOwned(
+    oauthAccount: unknown,
+    ownedOauthAccount: unknown,
+    options: { allowNullOwnership: boolean }
+  ): void {
+    const currentOauthAccount = this.readRuntimeOauthAccount()
+    if (
+      (ownedOauthAccount === null || ownedOauthAccount === undefined) &&
+      !options.allowNullOwnership
+    ) {
+      return
+    }
+    if (
+      currentOauthAccount === RUNTIME_OAUTH_ACCOUNT_PARSE_ERROR ||
+      !this.jsonValuesEqual(currentOauthAccount, ownedOauthAccount)
+    ) {
+      return
+    }
+    this.writeRuntimeOauthAccount(oauthAccount)
+  }
+
   private async restoreUnchangedActiveClaudeKeychainCredentials(
-    credentialsJson: string | null,
+    snapshotValue: ClaudeKeychainSnapshotValue,
     previouslyWrittenCredentialsJson: string | null,
     configDir?: string
   ): Promise<void> {
-    const currentCredentialsJson = await readActiveClaudeKeychainCredentialsStrict(configDir)
+    if (snapshotValue.status === 'unknown') {
+      return
+    }
+    const currentCredentialsJson =
+      await this.readActiveClaudeKeychainCredentialsBestEffort(configDir)
     if (
       previouslyWrittenCredentialsJson !== null &&
       currentCredentialsJson === previouslyWrittenCredentialsJson
     ) {
-      await this.restoreActiveClaudeKeychainCredentials(credentialsJson, configDir)
+      await this.restoreActiveClaudeKeychainCredentials(snapshotValue.credentialsJson, configDir)
     }
   }
 
@@ -631,7 +740,7 @@ export class ClaudeRuntimeAuthService {
       const parsed = JSON.parse(readFileSync(configPath, 'utf-8')) as Record<string, unknown>
       return parsed.oauthAccount ?? null
     } catch {
-      return null
+      return RUNTIME_OAUTH_ACCOUNT_PARSE_ERROR
     }
   }
 
@@ -644,6 +753,111 @@ export class ClaudeRuntimeAuthService {
       existing.oauthAccount = oauthAccount
     }
     this.writeJson(configPath, existing)
+  }
+
+  private jsonValuesEqual(left: unknown, right: unknown): boolean {
+    return (
+      JSON.stringify(this.sortJsonValue(left ?? null)) ===
+      JSON.stringify(this.sortJsonValue(right ?? null))
+    )
+  }
+
+  private sortJsonValue(value: unknown): unknown {
+    if (Array.isArray(value)) {
+      return value.map((item) => this.sortJsonValue(item))
+    }
+    const record = this.asRecord(value)
+    if (!record) {
+      return value
+    }
+    return Object.fromEntries(
+      Object.entries(record)
+        .sort(([leftKey], [rightKey]) => leftKey.localeCompare(rightKey))
+        .map(([key, nestedValue]) => [key, this.sortJsonValue(nestedValue)])
+    )
+  }
+
+  private isSystemDefaultSnapshot(value: unknown): value is ClaudeSystemDefaultSnapshot {
+    const snapshot = this.asRecord(value)
+    return (
+      snapshot !== null &&
+      this.isOptionalNullableString(snapshot.credentialsJson) &&
+      this.isOptionalNullableString(snapshot.keychainCredentialsJson) &&
+      this.isOptionalNullableString(snapshot.scopedKeychainCredentialsJson) &&
+      this.isOptionalNullableString(snapshot.legacyKeychainCredentialsJson) &&
+      this.isOptionalBoolean(snapshot.scopedKeychainCredentialsCaptured) &&
+      this.isOptionalBoolean(snapshot.legacyKeychainCredentialsCaptured) &&
+      (snapshot.capturedAt === undefined || typeof snapshot.capturedAt === 'number')
+    )
+  }
+
+  private isOptionalNullableString(value: unknown): boolean {
+    return value === undefined || value === null || typeof value === 'string'
+  }
+
+  private isOptionalBoolean(value: unknown): boolean {
+    return value === undefined || typeof value === 'boolean'
+  }
+
+  private readKeychainSnapshotValue(
+    snapshot: ClaudeSystemDefaultSnapshot | null,
+    service: 'scoped' | 'legacy'
+  ): ClaudeKeychainSnapshotValue {
+    if (!snapshot) {
+      return { status: 'captured', credentialsJson: null }
+    }
+    const capturedKey =
+      service === 'scoped'
+        ? 'scopedKeychainCredentialsCaptured'
+        : 'legacyKeychainCredentialsCaptured'
+    if (snapshot[capturedKey] === false) {
+      return { status: 'unknown' }
+    }
+    const credentialsKey =
+      service === 'scoped' ? 'scopedKeychainCredentialsJson' : 'legacyKeychainCredentialsJson'
+    if (Object.hasOwn(snapshot, credentialsKey)) {
+      return {
+        status: 'captured',
+        credentialsJson: snapshot[credentialsKey] ?? null
+      }
+    }
+    return { status: 'captured', credentialsJson: snapshot.keychainCredentialsJson }
+  }
+
+  private async readAggregateClaudeKeychainCredentialsBestEffort(
+    configDir: string
+  ): Promise<string | null> {
+    try {
+      return await readActiveClaudeKeychainCredentials(configDir)
+    } catch (error) {
+      console.warn('[claude-runtime-auth] Failed to read Claude Keychain credentials:', error)
+      return null
+    }
+  }
+
+  private async readActiveClaudeKeychainCredentialsBestEffort(
+    configDir?: string
+  ): Promise<string | null> {
+    try {
+      return await readActiveClaudeKeychainCredentialsStrict(configDir)
+    } catch (error) {
+      console.warn('[claude-runtime-auth] Failed to read Claude Keychain credentials:', error)
+      return null
+    }
+  }
+
+  private async readActiveClaudeKeychainCredentialsForSnapshot(
+    configDir?: string
+  ): Promise<ClaudeKeychainReadResult> {
+    try {
+      return {
+        status: 'captured',
+        credentialsJson: await readActiveClaudeKeychainCredentialsStrict(configDir)
+      }
+    } catch (error) {
+      console.warn('[claude-runtime-auth] Failed to read Claude Keychain credentials:', error)
+      return { status: 'failed' }
+    }
   }
 
   private writeRuntimeCredentials(contents: string): void {

--- a/src/main/claude-accounts/runtime-auth-service.ts
+++ b/src/main/claude-accounts/runtime-auth-service.ts
@@ -44,7 +44,7 @@ type ClaudeAuthIdentity = {
 
 type ClaudeReadBackResult = { status: 'unchanged' | 'persisted' | 'rejected' }
 type ClaudeReadBackMatch =
-  | { kind: 'matched'; account: ClaudeManagedAccount }
+  | { kind: 'matched'; account: ClaudeManagedAccount; managedCredentialsJson: string }
   | { kind: 'none' | 'ambiguous' }
 type ClaudeKeychainReadResult =
   | { status: 'captured'; credentialsJson: string | null }
@@ -265,7 +265,7 @@ export class ClaudeRuntimeAuthService {
       // metadata proves runtime is newer than managed storage.
       if (
         this.lastWrittenCredentialsJson === null &&
-        !this.runtimeCredentialsAreFresher(runtimeContents, baselineCredentialsJson)
+        !this.runtimeCredentialsAreFresher(runtimeContents, match.managedCredentialsJson)
       ) {
         return { status: 'rejected' }
       }
@@ -357,7 +357,7 @@ export class ClaudeRuntimeAuthService {
   private async findManagedAccountForRuntimeCredentials(
     runtimeCredentialsJson: string
   ): Promise<ClaudeReadBackMatch> {
-    const matches: ClaudeManagedAccount[] = []
+    const matches: { account: ClaudeManagedAccount; managedCredentialsJson: string }[] = []
     let unverifiableCount = 0
     for (const account of this.store.getSettings().claudeManagedAccounts) {
       const managedCredentialsJson = await this.readManagedCredentials(account)
@@ -371,14 +371,14 @@ export class ClaudeRuntimeAuthService {
         this.readManagedOauthAccount(account)
       )
       if (match === 'match') {
-        matches.push(account)
+        matches.push({ account, managedCredentialsJson })
       } else if (match === 'unverifiable') {
         unverifiableCount += 1
       }
     }
 
     if (matches.length === 1 && unverifiableCount === 0) {
-      return { kind: 'matched', account: matches[0] }
+      return { kind: 'matched', ...matches[0] }
     }
     return { kind: matches.length === 0 && unverifiableCount === 0 ? 'none' : 'ambiguous' }
   }

--- a/src/main/claude-accounts/runtime-auth-service.ts
+++ b/src/main/claude-accounts/runtime-auth-service.ts
@@ -175,14 +175,14 @@ export class ClaudeRuntimeAuthService {
       console.warn(
         '[claude-runtime-auth] Active managed account is missing or has invalid credentials, restoring system default'
       )
-      this.store.updateSettings({ activeClaudeManagedAccountId: null })
       if (this.lastSyncedAccountId !== null) {
         await this.restoreSystemDefaultSnapshotForMissingManagedCredentials(
           activeAccount,
           this.readManagedOauthAccount(activeAccount)
         )
-        this.lastSyncedAccountId = null
       }
+      this.store.updateSettings({ activeClaudeManagedAccountId: null })
+      this.lastSyncedAccountId = null
       return
     }
 

--- a/src/main/claude-accounts/runtime-auth-service.ts
+++ b/src/main/claude-accounts/runtime-auth-service.ts
@@ -233,9 +233,13 @@ export class ClaudeRuntimeAuthService {
       }
     }
     const managedOauthAccount = this.readManagedOauthAccount(activeAccount)
-    this.writeRuntimeOauthAccount(managedOauthAccount)
-    this.lastWrittenOauthAccount = managedOauthAccount
-    this.hasLastWrittenOauthAccount = true
+    if (this.writeRuntimeOauthAccount(managedOauthAccount)) {
+      this.lastWrittenOauthAccount = managedOauthAccount
+      this.hasLastWrittenOauthAccount = true
+    } else {
+      this.lastWrittenOauthAccount = null
+      this.hasLastWrittenOauthAccount = false
+    }
     this.lastSyncedAccountId = activeAccount.id
   }
 
@@ -707,43 +711,73 @@ export class ClaudeRuntimeAuthService {
     const paths = this.pathResolver.getRuntimePaths()
     const previouslyWrittenCredentialsJson =
       this.lastWrittenCredentialsJson ?? ownedCredentialsJson ?? null
-    const previouslyWrittenOauthAccount =
-      ownedOauthAccount !== undefined
-        ? ownedOauthAccount
-        : this.hasLastWrittenOauthAccount
-          ? this.lastWrittenOauthAccount
-          : null
     const snapshot = this.readSystemDefaultSnapshot(snapshotPath)
 
-    const restoredCredentials = this.restoreRuntimeCredentialsIfOwned(
-      snapshot?.credentialsJson ?? null,
+    const fileCredentialsOwned = this.hasUnchangedRuntimeCredentials(
       previouslyWrittenCredentialsJson
     )
-    // Why: writeRuntimeCredentials updates lastWrittenCredentialsJson to the
-    // restored system value. Keep the managed baseline until every owned
-    // surface has restored, so a later retry can still clean up Keychain.
+    let hasCredentialSurfaceOwnership = fileCredentialsOwned
+    // Why: runtime auth restore is two-phase: prove ownership before mutating
+    // any surface, then restore OAuth first. If OAuth fails, the credential
+    // proof remains intact for retry.
     this.lastWrittenCredentialsJson = previouslyWrittenCredentialsJson
-    this.restoreRuntimeOauthAccountIfOwned(
-      snapshot?.configOauthAccount ?? null,
-      previouslyWrittenOauthAccount,
-      { allowNullOwnership: restoredCredentials }
-    )
+    let scopedSnapshot: ClaudeKeychainSnapshotValue | null = null
+    let legacySnapshot: ClaudeKeychainSnapshotValue | null = null
+    let scopedKeychainOwned = false
+    let legacyKeychainOwned = false
     if (process.platform === 'darwin') {
-      const scopedSnapshot = this.readKeychainSnapshotValue(snapshot, 'scoped')
-      const legacySnapshot = this.readKeychainSnapshotValue(snapshot, 'legacy')
-      await this.restoreUnchangedActiveClaudeKeychainCredentials(
+      scopedSnapshot = this.readKeychainSnapshotValue(snapshot, 'scoped')
+      legacySnapshot = this.readKeychainSnapshotValue(snapshot, 'legacy')
+      scopedKeychainOwned = await this.hasUnchangedActiveClaudeKeychainCredentials(
         scopedSnapshot,
         previouslyWrittenCredentialsJson,
         paths.configDir
       )
-      await this.restoreUnchangedActiveClaudeKeychainCredentials(
+      legacyKeychainOwned = await this.hasUnchangedActiveClaudeKeychainCredentials(
         legacySnapshot,
         previouslyWrittenCredentialsJson
       )
+      hasCredentialSurfaceOwnership =
+        fileCredentialsOwned || scopedKeychainOwned || legacyKeychainOwned
+    }
+    this.restoreRuntimeOauthAccountIfOwned(
+      snapshot?.configOauthAccount ?? null,
+      this.getOwnedRuntimeOauthBaseline(ownedOauthAccount, hasCredentialSurfaceOwnership),
+      { allowCredentialSurfaceOwnership: hasCredentialSurfaceOwnership }
+    )
+    if (fileCredentialsOwned) {
+      this.restoreRuntimeCredentials(snapshot?.credentialsJson ?? null)
+    }
+    if (process.platform === 'darwin') {
+      if (scopedSnapshot?.status === 'captured' && scopedKeychainOwned) {
+        await this.restoreActiveClaudeKeychainCredentials(
+          scopedSnapshot.credentialsJson,
+          paths.configDir
+        )
+      }
+      if (legacySnapshot?.status === 'captured' && legacyKeychainOwned) {
+        await this.restoreActiveClaudeKeychainCredentials(legacySnapshot.credentialsJson)
+      }
     }
     this.lastWrittenCredentialsJson = null
     this.lastWrittenOauthAccount = null
     this.hasLastWrittenOauthAccount = false
+  }
+
+  private getOwnedRuntimeOauthBaseline(
+    ownedOauthAccount: unknown,
+    hasCredentialSurfaceOwnership: boolean
+  ): unknown {
+    if (this.hasLastWrittenOauthAccount) {
+      return this.lastWrittenOauthAccount
+    }
+    // Why: persisted managed metadata is an account identity hint, not proof
+    // that Orca wrote .claude.json. Use it only after another surface proves
+    // the current runtime auth still belongs to the managed account.
+    if (hasCredentialSurfaceOwnership && ownedOauthAccount !== undefined) {
+      return ownedOauthAccount
+    }
+    return null
   }
 
   private readSystemDefaultSnapshot(snapshotPath: string): ClaudeSystemDefaultSnapshot | null {
@@ -768,31 +802,44 @@ export class ClaudeRuntimeAuthService {
     managedOauthAccount: unknown
   ): Promise<void> {
     const paths = this.pathResolver.getRuntimePaths()
-    let clearedCredentials = false
-    if (
-      this.runtimeCredentialsBelongToAccount(
-        this.readRuntimeCredentialsFile(),
+    const fileCredentialsOwned = this.runtimeCredentialsBelongToAccount(
+      this.readRuntimeCredentialsFile(),
+      account,
+      managedOauthAccount
+    )
+    let scopedKeychainOwned = false
+    let legacyKeychainOwned = false
+    if (process.platform === 'darwin') {
+      scopedKeychainOwned = await this.hasActiveKeychainCredentialsForAccount(
+        account,
+        managedOauthAccount,
+        paths.configDir
+      )
+      legacyKeychainOwned = await this.hasActiveKeychainCredentialsForAccount(
         account,
         managedOauthAccount
       )
-    ) {
+    }
+    const hasCredentialSurfaceOwnership =
+      fileCredentialsOwned || scopedKeychainOwned || legacyKeychainOwned
+    this.restoreRuntimeOauthAccountIfOwned(
+      null,
+      this.getOwnedRuntimeOauthBaseline(managedOauthAccount, hasCredentialSurfaceOwnership),
+      {
+        allowCredentialSurfaceOwnership: hasCredentialSurfaceOwnership
+      }
+    )
+    if (fileCredentialsOwned) {
       rmSync(paths.credentialsPath, { force: true })
-      clearedCredentials = true
     }
     if (process.platform === 'darwin') {
-      clearedCredentials =
-        (await this.clearActiveKeychainCredentialsForAccount(
-          account,
-          managedOauthAccount,
-          paths.configDir
-        )) || clearedCredentials
-      clearedCredentials =
-        (await this.clearActiveKeychainCredentialsForAccount(account, managedOauthAccount)) ||
-        clearedCredentials
+      if (scopedKeychainOwned) {
+        await deleteActiveClaudeKeychainCredentialsStrict(paths.configDir)
+      }
+      if (legacyKeychainOwned) {
+        await deleteActiveClaudeKeychainCredentialsStrict()
+      }
     }
-    this.restoreRuntimeOauthAccountIfOwned(null, managedOauthAccount, {
-      allowNullOwnership: clearedCredentials
-    })
   }
 
   private async restoreSystemDefaultSnapshotForMissingManagedCredentials(
@@ -806,39 +853,51 @@ export class ClaudeRuntimeAuthService {
       return
     }
     const paths = this.pathResolver.getRuntimePaths()
-    let restoredCredentials = false
-    if (
-      this.runtimeCredentialsBelongToAccount(
-        this.readRuntimeCredentialsFile(),
+    const fileCredentialsOwned = this.runtimeCredentialsBelongToAccount(
+      this.readRuntimeCredentialsFile(),
+      account,
+      managedOauthAccount
+    )
+    let scopedSnapshot: ClaudeKeychainSnapshotValue | null = null
+    let legacySnapshot: ClaudeKeychainSnapshotValue | null = null
+    let scopedKeychainOwned = false
+    let legacyKeychainOwned = false
+    if (process.platform === 'darwin') {
+      scopedSnapshot = this.readKeychainSnapshotValue(snapshot, 'scoped')
+      legacySnapshot = this.readKeychainSnapshotValue(snapshot, 'legacy')
+      scopedKeychainOwned = await this.hasActiveKeychainCredentialsForAccount(
+        account,
+        managedOauthAccount,
+        paths.configDir
+      )
+      legacyKeychainOwned = await this.hasActiveKeychainCredentialsForAccount(
         account,
         managedOauthAccount
       )
-    ) {
-      if (snapshot.credentialsJson !== null) {
-        this.writeRuntimeCredentials(snapshot.credentialsJson)
-      } else {
-        rmSync(paths.credentialsPath, { force: true })
+    }
+    const hasCredentialSurfaceOwnership =
+      fileCredentialsOwned || scopedKeychainOwned || legacyKeychainOwned
+    this.restoreRuntimeOauthAccountIfOwned(
+      snapshot.configOauthAccount,
+      this.getOwnedRuntimeOauthBaseline(managedOauthAccount, hasCredentialSurfaceOwnership),
+      {
+        allowCredentialSurfaceOwnership: hasCredentialSurfaceOwnership
       }
-      restoredCredentials = true
+    )
+    if (fileCredentialsOwned) {
+      this.restoreRuntimeCredentials(snapshot.credentialsJson)
     }
     if (process.platform === 'darwin') {
-      restoredCredentials =
-        (await this.restoreKeychainSnapshotValueForAccount(
-          this.readKeychainSnapshotValue(snapshot, 'scoped'),
-          account,
-          managedOauthAccount,
+      if (scopedSnapshot?.status === 'captured' && scopedKeychainOwned) {
+        await this.restoreActiveClaudeKeychainCredentials(
+          scopedSnapshot.credentialsJson,
           paths.configDir
-        )) || restoredCredentials
-      restoredCredentials =
-        (await this.restoreKeychainSnapshotValueForAccount(
-          this.readKeychainSnapshotValue(snapshot, 'legacy'),
-          account,
-          managedOauthAccount
-        )) || restoredCredentials
+        )
+      }
+      if (legacySnapshot?.status === 'captured' && legacyKeychainOwned) {
+        await this.restoreActiveClaudeKeychainCredentials(legacySnapshot.credentialsJson)
+      }
     }
-    this.restoreRuntimeOauthAccountIfOwned(snapshot.configOauthAccount, managedOauthAccount, {
-      allowNullOwnership: restoredCredentials
-    })
     this.clearLastWrittenRuntimeState()
   }
 
@@ -878,10 +937,7 @@ export class ClaudeRuntimeAuthService {
     this.hasLastWrittenOauthAccount = false
   }
 
-  private restoreRuntimeCredentialsIfOwned(
-    credentialsJson: string | null,
-    previouslyWrittenCredentialsJson: string | null
-  ): boolean {
+  private hasUnchangedRuntimeCredentials(previouslyWrittenCredentialsJson: string | null): boolean {
     if (previouslyWrittenCredentialsJson === null) {
       return false
     }
@@ -889,37 +945,35 @@ export class ClaudeRuntimeAuthService {
     const currentCredentialsJson = existsSync(paths.credentialsPath)
       ? readFileSync(paths.credentialsPath, 'utf-8')
       : null
-    if (currentCredentialsJson !== previouslyWrittenCredentialsJson) {
-      return false
-    }
+    return currentCredentialsJson === previouslyWrittenCredentialsJson
+  }
+
+  private restoreRuntimeCredentials(credentialsJson: string | null): void {
+    const paths = this.pathResolver.getRuntimePaths()
     if (credentialsJson !== null) {
       this.writeRuntimeCredentials(credentialsJson)
     } else {
       rmSync(paths.credentialsPath, { force: true })
     }
-    return true
   }
 
   private restoreRuntimeOauthAccountIfOwned(
     oauthAccount: unknown,
     ownedOauthAccount: unknown,
-    options: { allowNullOwnership: boolean }
+    options: { allowCredentialSurfaceOwnership: boolean }
   ): void {
     const currentOauthAccount = this.readRuntimeOauthAccount()
     if (currentOauthAccount === RUNTIME_OAUTH_ACCOUNT_PARSE_ERROR) {
       return
     }
-    if (
-      (ownedOauthAccount === null || ownedOauthAccount === undefined) &&
-      !options.allowNullOwnership
-    ) {
+    if (options.allowCredentialSurfaceOwnership) {
+      this.writeRuntimeOauthAccount(oauthAccount)
       return
     }
     if (
       (ownedOauthAccount === null || ownedOauthAccount === undefined) &&
-      options.allowNullOwnership
+      !options.allowCredentialSurfaceOwnership
     ) {
-      this.writeRuntimeOauthAccount(oauthAccount)
       return
     }
     if (!this.jsonValuesEqual(currentOauthAccount, ownedOauthAccount)) {
@@ -928,22 +982,20 @@ export class ClaudeRuntimeAuthService {
     this.writeRuntimeOauthAccount(oauthAccount)
   }
 
-  private async restoreUnchangedActiveClaudeKeychainCredentials(
+  private async hasUnchangedActiveClaudeKeychainCredentials(
     snapshotValue: ClaudeKeychainSnapshotValue,
     previouslyWrittenCredentialsJson: string | null,
     configDir?: string
-  ): Promise<void> {
+  ): Promise<boolean> {
     if (snapshotValue.status === 'unknown') {
-      return
+      return false
     }
     const currentCredentialsJson =
       await this.readActiveClaudeKeychainCredentialsBestEffort(configDir)
-    if (
+    return (
       previouslyWrittenCredentialsJson !== null &&
       currentCredentialsJson === previouslyWrittenCredentialsJson
-    ) {
-      await this.restoreActiveClaudeKeychainCredentials(snapshotValue.credentialsJson, configDir)
-    }
+    )
   }
 
   private async restoreActiveClaudeKeychainCredentials(
@@ -955,40 +1007,18 @@ export class ClaudeRuntimeAuthService {
       : deleteActiveClaudeKeychainCredentialsStrict(configDir))
   }
 
-  private async restoreKeychainSnapshotValueForAccount(
-    snapshotValue: ClaudeKeychainSnapshotValue,
-    account: ClaudeManagedAccount,
-    managedOauthAccount: unknown,
-    configDir?: string
-  ): Promise<boolean> {
-    if (snapshotValue.status === 'unknown') {
-      return false
-    }
-    const currentCredentialsJson =
-      await this.readActiveClaudeKeychainCredentialsBestEffort(configDir)
-    if (
-      this.runtimeCredentialsBelongToAccount(currentCredentialsJson, account, managedOauthAccount)
-    ) {
-      await this.restoreActiveClaudeKeychainCredentials(snapshotValue.credentialsJson, configDir)
-      return true
-    }
-    return false
-  }
-
-  private async clearActiveKeychainCredentialsForAccount(
+  private async hasActiveKeychainCredentialsForAccount(
     account: ClaudeManagedAccount,
     managedOauthAccount: unknown,
     configDir?: string
   ): Promise<boolean> {
     const currentCredentialsJson =
       await this.readActiveClaudeKeychainCredentialsBestEffort(configDir)
-    if (
-      this.runtimeCredentialsBelongToAccount(currentCredentialsJson, account, managedOauthAccount)
-    ) {
-      await deleteActiveClaudeKeychainCredentialsStrict(configDir)
-      return true
-    }
-    return false
+    return this.runtimeCredentialsBelongToAccount(
+      currentCredentialsJson,
+      account,
+      managedOauthAccount
+    )
   }
 
   private readRuntimeOauthAccount(): unknown {
@@ -997,22 +1027,30 @@ export class ClaudeRuntimeAuthService {
       return null
     }
     try {
-      const parsed = JSON.parse(readFileSync(configPath, 'utf-8')) as Record<string, unknown>
-      return parsed.oauthAccount ?? null
+      const parsed = JSON.parse(readFileSync(configPath, 'utf-8')) as unknown
+      const record = this.asRecord(parsed)
+      if (!record) {
+        return RUNTIME_OAUTH_ACCOUNT_PARSE_ERROR
+      }
+      return record.oauthAccount ?? null
     } catch {
       return RUNTIME_OAUTH_ACCOUNT_PARSE_ERROR
     }
   }
 
-  private writeRuntimeOauthAccount(oauthAccount: unknown): void {
+  private writeRuntimeOauthAccount(oauthAccount: unknown): boolean {
     const configPath = this.pathResolver.getRuntimePaths().configPath
     const existing = this.readJsonObject(configPath)
+    if (existing === null) {
+      return false
+    }
     if (oauthAccount === null || oauthAccount === undefined) {
       delete existing.oauthAccount
     } else {
       existing.oauthAccount = oauthAccount
     }
     this.writeJson(configPath, existing)
+    return true
   }
 
   private jsonValuesEqual(left: unknown, right: unknown): boolean {
@@ -1208,7 +1246,7 @@ export class ClaudeRuntimeAuthService {
     }
   }
 
-  private readJsonObject(targetPath: string): Record<string, unknown> {
+  private readJsonObject(targetPath: string): Record<string, unknown> | null {
     if (!existsSync(targetPath)) {
       return {}
     }
@@ -1218,9 +1256,11 @@ export class ClaudeRuntimeAuthService {
         return parsed as Record<string, unknown>
       }
     } catch {
-      /* Preserve no invalid JSON; Claude can recreate unsupported config files. */
+      // Why: invalid config is an unknown external state. Replacing it with a
+      // fresh object could silently erase user or Claude-owned settings.
+      return null
     }
-    return {}
+    return null
   }
 
   private getRuntimeMetadataDir(): string {

--- a/src/main/claude-accounts/runtime-auth-service.ts
+++ b/src/main/claude-accounts/runtime-auth-service.ts
@@ -8,6 +8,11 @@ import type { ClaudeManagedAccount } from '../../shared/types'
 import type { Store } from '../persistence'
 import { writeFileAtomically } from '../codex-accounts/fs-utils'
 import type { ClaudeEnvPatch } from './environment'
+import {
+  readClaudeManagedAuthFile,
+  resolveOwnedClaudeManagedAuthPath,
+  writeClaudeManagedAuthFile
+} from './managed-auth-path'
 import { ClaudeRuntimePathResolver } from './runtime-paths'
 import {
   deleteActiveClaudeKeychainCredentialsStrict,
@@ -64,6 +69,7 @@ export class ClaudeRuntimeAuthService {
   // an external login (e.g. `claude auth login`) overwrote it — so Orca adopts
   // the file as the new system default instead of restoring a stale snapshot.
   private lastWrittenCredentialsJson: string | null = null
+  private hasMaterializedRuntimeAuth = false
   private hasLastWrittenOauthAccount = false
   private lastWrittenOauthAccount: unknown = null
   private skipNextReadBackForAccountId: string | null = null
@@ -157,16 +163,38 @@ export class ClaudeRuntimeAuthService {
         this.store.updateSettings({ activeClaudeManagedAccountId: null })
       }
       if (this.lastSyncedAccountId !== null) {
-        if (previousAccount) {
-          await this.restoreSystemDefaultSnapshot(
-            previousManagedCredentialsJson,
-            previousManagedOauthAccount
-          )
-        } else {
-          this.clearLastWrittenRuntimeState()
-        }
+        await (previousAccount
+          ? this.restoreSystemDefaultSnapshot(
+              previousManagedCredentialsJson,
+              previousManagedOauthAccount
+            )
+          : this.restoreSystemDefaultSnapshot(this.lastWrittenCredentialsJson, undefined))
         this.lastSyncedAccountId = null
       }
+      return
+    }
+
+    if (!this.getOwnedManagedAuthPath(activeAccount)) {
+      console.warn(
+        '[claude-runtime-auth] Active managed account is not owned by Orca, restoring system default'
+      )
+      if (this.lastSyncedAccountId !== null) {
+        if (
+          previousAccount &&
+          (previousAccount.id !== activeAccount.id ||
+            this.hasMaterializedRuntimeAuth ||
+            this.runtimeOauthAccountMatches(this.readManagedOauthAccount(previousAccount)))
+        ) {
+          await this.restoreSystemDefaultSnapshotForMissingManagedCredentials(
+            previousAccount,
+            previousManagedOauthAccount
+          )
+        } else if (!previousAccount && this.hasMaterializedRuntimeAuth) {
+          await this.restoreSystemDefaultSnapshot(this.lastWrittenCredentialsJson, undefined)
+        }
+      }
+      this.store.updateSettings({ activeClaudeManagedAccountId: null })
+      this.lastSyncedAccountId = null
       return
     }
 
@@ -176,10 +204,19 @@ export class ClaudeRuntimeAuthService {
         '[claude-runtime-auth] Active managed account is missing or has invalid credentials, restoring system default'
       )
       if (this.lastSyncedAccountId !== null) {
-        await this.restoreSystemDefaultSnapshotForMissingManagedCredentials(
-          activeAccount,
-          this.readManagedOauthAccount(activeAccount)
-        )
+        if (
+          previousAccount &&
+          (previousAccount.id !== activeAccount.id ||
+            this.hasMaterializedRuntimeAuth ||
+            this.runtimeOauthAccountMatches(previousManagedOauthAccount))
+        ) {
+          await this.restoreSystemDefaultSnapshotForMissingManagedCredentials(
+            previousAccount,
+            previousManagedOauthAccount
+          )
+        } else if (!previousAccount && this.hasMaterializedRuntimeAuth) {
+          await this.restoreSystemDefaultSnapshot(this.lastWrittenCredentialsJson, undefined)
+        }
       }
       this.store.updateSettings({ activeClaudeManagedAccountId: null })
       this.lastSyncedAccountId = null
@@ -244,6 +281,7 @@ export class ClaudeRuntimeAuthService {
       this.hasLastWrittenOauthAccount = false
     }
     this.lastSyncedAccountId = activeAccount.id
+    this.hasMaterializedRuntimeAuth = true
   }
 
   // Why: called by ClaudeAccountService before syncForCurrentSelection() after
@@ -591,38 +629,48 @@ export class ClaudeRuntimeAuthService {
   }
 
   private async readManagedCredentials(account: ClaudeManagedAccount): Promise<string | null> {
+    const managedAuthPath = this.getOwnedManagedAuthPath(account)
+    if (!managedAuthPath) {
+      return null
+    }
     if (process.platform === 'darwin') {
       return readManagedClaudeKeychainCredentials(account.id)
     }
-    const credentialsPath = join(account.managedAuthPath, '.credentials.json')
-    if (!existsSync(credentialsPath)) {
-      return null
-    }
-    return readFileSync(credentialsPath, 'utf-8')
+    return readClaudeManagedAuthFile(managedAuthPath, '.credentials.json')
   }
 
   private async writeManagedCredentials(
     account: ClaudeManagedAccount,
     credentialsJson: string
   ): Promise<void> {
+    const managedAuthPath = this.getOwnedManagedAuthPath(account)
+    if (!managedAuthPath) {
+      throw new Error('Managed Claude auth storage is not owned by Orca.')
+    }
     if (process.platform === 'darwin') {
       await writeManagedClaudeKeychainCredentials(account.id, credentialsJson)
       return
     }
-    const credentialsPath = join(account.managedAuthPath, '.credentials.json')
-    writeFileAtomically(credentialsPath, credentialsJson, { mode: 0o600 })
+    writeClaudeManagedAuthFile(managedAuthPath, '.credentials.json', credentialsJson)
   }
 
   private readManagedOauthAccount(account: ClaudeManagedAccount): unknown {
-    const oauthPath = join(account.managedAuthPath, 'oauth-account.json')
-    if (!existsSync(oauthPath)) {
+    const managedAuthPath = this.getOwnedManagedAuthPath(account)
+    if (!managedAuthPath) {
       return null
     }
     try {
-      return JSON.parse(readFileSync(oauthPath, 'utf-8')) as unknown
+      const contents = readClaudeManagedAuthFile(managedAuthPath, 'oauth-account.json')
+      return contents ? (JSON.parse(contents) as unknown) : null
     } catch {
       return null
     }
+  }
+
+  private getOwnedManagedAuthPath(account: ClaudeManagedAccount): string | null {
+    return resolveOwnedClaudeManagedAuthPath(account.id, account.managedAuthPath, {
+      adoptLegacyMarker: true
+    })
   }
 
   private async captureSystemDefaultSnapshotForManagedEntry(
@@ -778,6 +826,7 @@ export class ClaudeRuntimeAuthService {
     this.lastWrittenCredentialsJson = null
     this.lastWrittenOauthAccount = null
     this.hasLastWrittenOauthAccount = false
+    this.hasMaterializedRuntimeAuth = false
   }
 
   private getOwnedRuntimeOauthBaseline(
@@ -951,6 +1000,7 @@ export class ClaudeRuntimeAuthService {
     this.lastWrittenCredentialsJson = null
     this.lastWrittenOauthAccount = null
     this.hasLastWrittenOauthAccount = false
+    this.hasMaterializedRuntimeAuth = false
   }
 
   private hasUnchangedRuntimeCredentials(previouslyWrittenCredentialsJson: string | null): boolean {
@@ -1052,6 +1102,17 @@ export class ClaudeRuntimeAuthService {
     } catch {
       return RUNTIME_OAUTH_ACCOUNT_PARSE_ERROR
     }
+  }
+
+  private runtimeOauthAccountMatches(managedOauthAccount: unknown): boolean {
+    if (managedOauthAccount === null || managedOauthAccount === undefined) {
+      return false
+    }
+    const currentOauthAccount = this.readRuntimeOauthAccount()
+    if (currentOauthAccount === RUNTIME_OAUTH_ACCOUNT_PARSE_ERROR) {
+      return false
+    }
+    return this.jsonValuesEqual(currentOauthAccount, managedOauthAccount)
   }
 
   private writeRuntimeOauthAccount(oauthAccount: unknown): boolean {

--- a/src/main/claude-accounts/runtime-auth-service.ts
+++ b/src/main/claude-accounts/runtime-auth-service.ts
@@ -171,9 +171,10 @@ export class ClaudeRuntimeAuthService {
     if (this.lastSyncedAccountId !== activeAccount.id) {
       this.skipNextReadBackForAccountId = null
     }
+    const paths = this.pathResolver.getRuntimePaths()
     this.writeRuntimeCredentials(credentialsJson)
     if (process.platform === 'darwin') {
-      await writeActiveClaudeKeychainCredentials(credentialsJson)
+      await writeActiveClaudeKeychainCredentials(credentialsJson, paths.configDir)
     }
     this.writeRuntimeOauthAccount(this.readManagedOauthAccount(activeAccount))
     this.lastSyncedAccountId = activeAccount.id
@@ -230,7 +231,8 @@ export class ClaudeRuntimeAuthService {
         this.writeRuntimeCredentials(runtimeContents)
         this.lastWrittenCredentialsJson = runtimeContents
         if (process.platform === 'darwin') {
-          await writeActiveClaudeKeychainCredentials(runtimeContents)
+          const paths = this.pathResolver.getRuntimePaths()
+          await writeActiveClaudeKeychainCredentials(runtimeContents, paths.configDir)
         }
       }
       return { status: 'persisted' }
@@ -251,7 +253,7 @@ export class ClaudeRuntimeAuthService {
       ? readFileSync(paths.credentialsPath, 'utf-8')
       : null
     if (process.platform === 'darwin') {
-      const keychainCredentials = await readActiveClaudeKeychainCredentials()
+      const keychainCredentials = await readActiveClaudeKeychainCredentials(paths.configDir)
       if (this.lastWrittenCredentialsJson === null) {
         if (keychainCredentials && keychainCredentials !== baselineCredentialsJson) {
           return keychainCredentials
@@ -503,7 +505,7 @@ export class ClaudeRuntimeAuthService {
     const credentialsJson = existsSync(paths.credentialsPath)
       ? readFileSync(paths.credentialsPath, 'utf-8')
       : null
-    const keychainCredentialsJson = await readActiveClaudeKeychainCredentials()
+    const keychainCredentialsJson = await readActiveClaudeKeychainCredentials(paths.configDir)
     const snapshot: ClaudeSystemDefaultSnapshot = {
       credentialsJson,
       configOauthAccount: this.readRuntimeOauthAccount(),
@@ -527,7 +529,7 @@ export class ClaudeRuntimeAuthService {
     if (!existsSync(snapshotPath)) {
       rmSync(this.pathResolver.getRuntimePaths().credentialsPath, { force: true })
       if (process.platform === 'darwin') {
-        await deleteActiveClaudeKeychainCredentials()
+        await deleteActiveClaudeKeychainCredentials(this.pathResolver.getRuntimePaths().configDir)
       }
       this.lastWrittenCredentialsJson = null
       return
@@ -542,8 +544,11 @@ export class ClaudeRuntimeAuthService {
     if (process.platform === 'darwin') {
       if (externalState !== 'keychain-change') {
         await (snapshot.keychainCredentialsJson !== null
-          ? writeActiveClaudeKeychainCredentials(snapshot.keychainCredentialsJson)
-          : deleteActiveClaudeKeychainCredentials())
+          ? writeActiveClaudeKeychainCredentials(
+              snapshot.keychainCredentialsJson,
+              this.pathResolver.getRuntimePaths().configDir
+            )
+          : deleteActiveClaudeKeychainCredentials(this.pathResolver.getRuntimePaths().configDir))
       }
     }
   }
@@ -561,7 +566,9 @@ export class ClaudeRuntimeAuthService {
     const paths = this.pathResolver.getRuntimePaths()
     if (!existsSync(paths.credentialsPath)) {
       const currentKeychainCredentials =
-        process.platform === 'darwin' ? await readActiveClaudeKeychainCredentials() : null
+        process.platform === 'darwin'
+          ? await readActiveClaudeKeychainCredentials(paths.configDir)
+          : null
       if (
         process.platform === 'darwin' &&
         currentKeychainCredentials === this.lastWrittenCredentialsJson
@@ -575,7 +582,9 @@ export class ClaudeRuntimeAuthService {
     }
     const currentCredentials = readFileSync(paths.credentialsPath, 'utf-8')
     const currentKeychainCredentials =
-      process.platform === 'darwin' ? await readActiveClaudeKeychainCredentials() : null
+      process.platform === 'darwin'
+        ? await readActiveClaudeKeychainCredentials(paths.configDir)
+        : null
     if (currentCredentials === this.lastWrittenCredentialsJson) {
       if (
         process.platform === 'darwin' &&

--- a/src/main/claude-accounts/runtime-auth-service.ts
+++ b/src/main/claude-accounts/runtime-auth-service.ts
@@ -79,7 +79,7 @@ export class ClaudeRuntimeAuthService {
     await this.serializeMutation(async () => {
       const settings = this.store.getSettings()
       if (!settings.activeClaudeManagedAccountId) {
-        await this.restoreSystemDefaultSnapshot({ detectExternalLogin: true })
+        await this.restoreSystemDefaultSnapshot()
         this.lastSyncedAccountId = null
         return
       }
@@ -120,20 +120,22 @@ export class ClaudeRuntimeAuthService {
       settings.claudeManagedAccounts,
       this.lastSyncedAccountId
     )
-    let outgoingReadBackResult: ClaudeReadBackResult = { status: 'unchanged' }
+    const previousManagedCredentialsJson = previousAccount
+      ? await this.readManagedCredentials(previousAccount)
+      : null
     if (previousAccount && previousAccount.id !== activeAccount?.id) {
-      outgoingReadBackResult = await this.readBackRefreshedTokensForAccount(previousAccount, {
-        updateLastWrittenCredentialsJson: true
-      })
+      if (previousManagedCredentialsJson) {
+        await this.readBackRefreshedTokens(previousManagedCredentialsJson, {
+          updateLastWrittenCredentialsJson: true
+        })
+      }
     }
     if (!activeAccount) {
       if (settings.activeClaudeManagedAccountId) {
         this.store.updateSettings({ activeClaudeManagedAccountId: null })
       }
       if (this.lastSyncedAccountId !== null) {
-        await this.restoreSystemDefaultSnapshot({
-          detectExternalLogin: outgoingReadBackResult.status !== 'rejected'
-        })
+        await this.restoreSystemDefaultSnapshot(previousManagedCredentialsJson)
         this.lastSyncedAccountId = null
       }
       return
@@ -146,7 +148,7 @@ export class ClaudeRuntimeAuthService {
       )
       this.store.updateSettings({ activeClaudeManagedAccountId: null })
       if (this.lastSyncedAccountId !== null) {
-        await this.restoreSystemDefaultSnapshot({ detectExternalLogin: true })
+        await this.restoreSystemDefaultSnapshot(previousManagedCredentialsJson)
         this.lastSyncedAccountId = null
       }
       return
@@ -293,17 +295,6 @@ export class ClaudeRuntimeAuthService {
       return null
     }
     return fileCredentials
-  }
-
-  private async readBackRefreshedTokensForAccount(
-    account: ClaudeManagedAccount,
-    options: { updateLastWrittenCredentialsJson: boolean }
-  ): Promise<ClaudeReadBackResult> {
-    const managedCredentialsJson = await this.readManagedCredentials(account)
-    if (!managedCredentialsJson) {
-      return { status: 'unchanged' }
-    }
-    return this.readBackRefreshedTokens(managedCredentialsJson, options)
   }
 
   private getPreparation(): ClaudeRuntimeAuthPreparation {
@@ -546,46 +537,79 @@ export class ClaudeRuntimeAuthService {
     this.writeJson(snapshotPath, snapshot)
   }
 
-  private async restoreSystemDefaultSnapshot(options: {
-    detectExternalLogin: boolean
-  }): Promise<void> {
-    const externalState = options.detectExternalLogin
-      ? await this.detectExternalLoginAndUpdateSnapshot()
-      : 'none'
-    if (externalState === 'file-logout') {
-      return
-    }
-
+  private async restoreSystemDefaultSnapshot(ownedCredentialsJson?: string | null): Promise<void> {
     const snapshotPath = this.getSystemDefaultSnapshotPath()
     const paths = this.pathResolver.getRuntimePaths()
-    if (!existsSync(snapshotPath)) {
-      rmSync(paths.credentialsPath, { force: true })
-      if (process.platform === 'darwin') {
-        await deleteActiveClaudeKeychainCredentialsStrict(paths.configDir)
-        await deleteActiveClaudeKeychainCredentialsStrict()
-      }
-      this.lastWrittenCredentialsJson = null
-      return
+    const previouslyWrittenCredentialsJson =
+      this.lastWrittenCredentialsJson ?? ownedCredentialsJson ?? null
+    const snapshot = existsSync(snapshotPath)
+      ? (JSON.parse(readFileSync(snapshotPath, 'utf-8')) as ClaudeSystemDefaultSnapshot)
+      : null
+
+    const restoredCredentials = this.restoreRuntimeCredentialsIfOwned(
+      snapshot?.credentialsJson ?? null,
+      previouslyWrittenCredentialsJson
+    )
+    if (restoredCredentials && snapshot) {
+      this.writeRuntimeOauthAccount(snapshot.configOauthAccount)
     }
-    const snapshot = JSON.parse(readFileSync(snapshotPath, 'utf-8')) as ClaudeSystemDefaultSnapshot
-    if (snapshot.credentialsJson !== null) {
-      this.writeRuntimeCredentials(snapshot.credentialsJson)
-    } else {
-      rmSync(this.pathResolver.getRuntimePaths().credentialsPath, { force: true })
-    }
-    this.writeRuntimeOauthAccount(snapshot.configOauthAccount)
     if (process.platform === 'darwin') {
-      if (externalState !== 'keychain-change') {
-        const scopedSnapshot = Object.hasOwn(snapshot, 'scopedKeychainCredentialsJson')
+      const scopedSnapshot = snapshot
+        ? Object.hasOwn(snapshot, 'scopedKeychainCredentialsJson')
           ? snapshot.scopedKeychainCredentialsJson
           : snapshot.keychainCredentialsJson
-        await this.restoreActiveClaudeKeychainCredentials(scopedSnapshot ?? null, paths.configDir)
-        if (Object.hasOwn(snapshot, 'legacyKeychainCredentialsJson')) {
-          await this.restoreActiveClaudeKeychainCredentials(
-            snapshot.legacyKeychainCredentialsJson ?? null
-          )
-        }
-      }
+        : null
+      const legacySnapshot = snapshot
+        ? Object.hasOwn(snapshot, 'legacyKeychainCredentialsJson')
+          ? snapshot.legacyKeychainCredentialsJson
+          : snapshot.keychainCredentialsJson
+        : null
+      await this.restoreUnchangedActiveClaudeKeychainCredentials(
+        scopedSnapshot ?? null,
+        previouslyWrittenCredentialsJson,
+        paths.configDir
+      )
+      await this.restoreUnchangedActiveClaudeKeychainCredentials(
+        legacySnapshot ?? null,
+        previouslyWrittenCredentialsJson
+      )
+    }
+    this.lastWrittenCredentialsJson = null
+  }
+
+  private restoreRuntimeCredentialsIfOwned(
+    credentialsJson: string | null,
+    previouslyWrittenCredentialsJson: string | null
+  ): boolean {
+    if (previouslyWrittenCredentialsJson === null) {
+      return false
+    }
+    const paths = this.pathResolver.getRuntimePaths()
+    const currentCredentialsJson = existsSync(paths.credentialsPath)
+      ? readFileSync(paths.credentialsPath, 'utf-8')
+      : null
+    if (currentCredentialsJson !== previouslyWrittenCredentialsJson) {
+      return false
+    }
+    if (credentialsJson !== null) {
+      this.writeRuntimeCredentials(credentialsJson)
+    } else {
+      rmSync(paths.credentialsPath, { force: true })
+    }
+    return true
+  }
+
+  private async restoreUnchangedActiveClaudeKeychainCredentials(
+    credentialsJson: string | null,
+    previouslyWrittenCredentialsJson: string | null,
+    configDir?: string
+  ): Promise<void> {
+    const currentCredentialsJson = await readActiveClaudeKeychainCredentialsStrict(configDir)
+    if (
+      previouslyWrittenCredentialsJson !== null &&
+      currentCredentialsJson === previouslyWrittenCredentialsJson
+    ) {
+      await this.restoreActiveClaudeKeychainCredentials(credentialsJson, configDir)
     }
   }
 
@@ -596,57 +620,6 @@ export class ClaudeRuntimeAuthService {
     await (credentialsJson !== null
       ? writeActiveClaudeKeychainCredentials(credentialsJson, configDir)
       : deleteActiveClaudeKeychainCredentialsStrict(configDir))
-  }
-
-  // Why: detects whether an external tool (e.g. `claude auth login`) overwrote
-  // the credentials file while a managed account was active. If the file
-  // differs from what Orca last wrote, that external login becomes the new
-  // system default — no manual "refresh" button needed.
-  private async detectExternalLoginAndUpdateSnapshot(): Promise<
-    'none' | 'file-logout' | 'keychain-change'
-  > {
-    if (this.lastWrittenCredentialsJson === null) {
-      return 'none'
-    }
-    const paths = this.pathResolver.getRuntimePaths()
-    if (!existsSync(paths.credentialsPath)) {
-      const currentScopedKeychainCredentials =
-        process.platform === 'darwin'
-          ? await readActiveClaudeKeychainCredentialsStrict(paths.configDir)
-          : null
-      const currentLegacyKeychainCredentials =
-        process.platform === 'darwin' ? await readActiveClaudeKeychainCredentialsStrict() : null
-      const runtimeKeychainStillPresent =
-        currentScopedKeychainCredentials === this.lastWrittenCredentialsJson ||
-        currentLegacyKeychainCredentials === this.lastWrittenCredentialsJson
-      if (process.platform === 'darwin' && runtimeKeychainStillPresent) {
-        return 'none'
-      }
-      const snapshotPath = this.getSystemDefaultSnapshotPath()
-      rmSync(snapshotPath, { force: true })
-      this.lastWrittenCredentialsJson = null
-      return 'file-logout'
-    }
-    const currentCredentials = readFileSync(paths.credentialsPath, 'utf-8')
-    const currentScopedKeychainCredentials =
-      process.platform === 'darwin'
-        ? await readActiveClaudeKeychainCredentialsStrict(paths.configDir)
-        : null
-    const currentLegacyKeychainCredentials =
-      process.platform === 'darwin' ? await readActiveClaudeKeychainCredentialsStrict() : null
-    if (currentCredentials === this.lastWrittenCredentialsJson) {
-      const runtimeKeychainChanged =
-        currentScopedKeychainCredentials !== this.lastWrittenCredentialsJson ||
-        currentLegacyKeychainCredentials !== this.lastWrittenCredentialsJson
-      if (process.platform === 'darwin' && runtimeKeychainChanged) {
-        return 'keychain-change'
-      }
-      return 'none'
-    }
-    const snapshotPath = this.getSystemDefaultSnapshotPath()
-    rmSync(snapshotPath, { force: true })
-    this.lastWrittenCredentialsJson = null
-    return 'file-logout'
   }
 
   private readRuntimeOauthAccount(): unknown {

--- a/src/main/claude-accounts/runtime-auth-service.ts
+++ b/src/main/claude-accounts/runtime-auth-service.ts
@@ -10,7 +10,7 @@ import { writeFileAtomically } from '../codex-accounts/fs-utils'
 import type { ClaudeEnvPatch } from './environment'
 import { ClaudeRuntimePathResolver } from './runtime-paths'
 import {
-  deleteActiveClaudeKeychainCredentials,
+  deleteActiveClaudeKeychainCredentialsStrict,
   readActiveClaudeKeychainCredentials,
   readManagedClaudeKeychainCredentials,
   writeActiveClaudeKeychainCredentials,
@@ -18,6 +18,7 @@ import {
 } from './keychain'
 
 export type ClaudeRuntimeAuthPreparation = {
+  configDir: string
   envPatch: ClaudeEnvPatch
   stripAuthEnv: boolean
   provenance: string
@@ -289,6 +290,7 @@ export class ClaudeRuntimeAuthService {
     const paths = this.pathResolver.getRuntimePaths()
     const activeAccountId = settings.activeClaudeManagedAccountId
     return {
+      configDir: paths.configDir,
       envPatch: paths.envPatch,
       stripAuthEnv: Boolean(activeAccountId),
       provenance: activeAccountId ? `managed:${activeAccountId}` : 'system'
@@ -526,10 +528,11 @@ export class ClaudeRuntimeAuthService {
     }
 
     const snapshotPath = this.getSystemDefaultSnapshotPath()
+    const paths = this.pathResolver.getRuntimePaths()
     if (!existsSync(snapshotPath)) {
-      rmSync(this.pathResolver.getRuntimePaths().credentialsPath, { force: true })
+      rmSync(paths.credentialsPath, { force: true })
       if (process.platform === 'darwin') {
-        await deleteActiveClaudeKeychainCredentials(this.pathResolver.getRuntimePaths().configDir)
+        await deleteActiveClaudeKeychainCredentialsStrict(paths.configDir)
       }
       this.lastWrittenCredentialsJson = null
       return
@@ -544,11 +547,8 @@ export class ClaudeRuntimeAuthService {
     if (process.platform === 'darwin') {
       if (externalState !== 'keychain-change') {
         await (snapshot.keychainCredentialsJson !== null
-          ? writeActiveClaudeKeychainCredentials(
-              snapshot.keychainCredentialsJson,
-              this.pathResolver.getRuntimePaths().configDir
-            )
-          : deleteActiveClaudeKeychainCredentials(this.pathResolver.getRuntimePaths().configDir))
+          ? writeActiveClaudeKeychainCredentials(snapshot.keychainCredentialsJson, paths.configDir)
+          : deleteActiveClaudeKeychainCredentialsStrict(paths.configDir))
       }
     }
   }

--- a/src/main/claude-accounts/service.test.ts
+++ b/src/main/claude-accounts/service.test.ts
@@ -1,12 +1,15 @@
+/* eslint-disable max-lines -- test suite covers Claude capture and rollback edge cases */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
   deleteActiveClaudeKeychainCredentialsStrict,
   readActiveClaudeKeychainCredentials,
   readActiveClaudeKeychainCredentialsStrict,
-  writeActiveClaudeKeychainCredentials
+  readManagedClaudeKeychainCredentials,
+  writeActiveClaudeKeychainCredentials,
+  writeManagedClaudeKeychainCredentials
 } from './keychain'
 
 vi.mock('electron', () => ({
@@ -24,6 +27,7 @@ vi.mock('./keychain', () => ({
   deleteManagedClaudeKeychainCredentials: vi.fn(async () => {}),
   readActiveClaudeKeychainCredentials: vi.fn(),
   readActiveClaudeKeychainCredentialsStrict: vi.fn(),
+  readManagedClaudeKeychainCredentials: vi.fn(),
   writeActiveClaudeKeychainCredentials: vi.fn(async () => {}),
   writeManagedClaudeKeychainCredentials: vi.fn(async () => {})
 }))
@@ -69,9 +73,12 @@ describe('ClaudeAccountService credential capture', () => {
     tempDir = null
     vi.mocked(readActiveClaudeKeychainCredentials).mockReset()
     vi.mocked(readActiveClaudeKeychainCredentialsStrict).mockReset()
+    vi.mocked(readManagedClaudeKeychainCredentials).mockReset()
     vi.mocked(deleteActiveClaudeKeychainCredentialsStrict).mockClear()
     vi.mocked(writeActiveClaudeKeychainCredentials).mockReset()
     vi.mocked(writeActiveClaudeKeychainCredentials).mockResolvedValue()
+    vi.mocked(writeManagedClaudeKeychainCredentials).mockReset()
+    vi.mocked(writeManagedClaudeKeychainCredentials).mockResolvedValue()
   })
 
   afterEach(() => {
@@ -153,5 +160,299 @@ describe('ClaudeAccountService credential capture', () => {
     testService.runClaudeCommand = vi.fn(async () => '{"account":{"email":"user@example.com"}}')
 
     await expect(testService.runClaudeLoginAndCapture()).rejects.toThrow('restore failed')
+  })
+
+  it('restores previous managed auth when reauth materialization fails', async () => {
+    setPlatform('linux')
+    tempDir = '/tmp/orca-claude-service-test'
+    rmSync(tempDir, { recursive: true, force: true })
+    const managedAuthPath = join(tempDir, 'claude-accounts', 'account-1', 'auth')
+    mkdirSync(managedAuthPath, { recursive: true })
+    writeFileSync(join(managedAuthPath, '.orca-managed-claude-auth'), 'account-1\n', 'utf-8')
+    writeFileSync(join(managedAuthPath, '.credentials.json'), '{"old":true}\n', 'utf-8')
+    writeFileSync(join(managedAuthPath, 'oauth-account.json'), '{"oldOauth":true}\n', 'utf-8')
+    let settings = {
+      claudeManagedAccounts: [
+        {
+          id: 'account-1',
+          email: 'old@example.com',
+          managedAuthPath,
+          authMethod: 'subscription-oauth',
+          organizationUuid: null,
+          organizationName: null,
+          createdAt: 1,
+          updatedAt: 1,
+          lastAuthenticatedAt: 1
+        }
+      ],
+      activeClaudeManagedAccountId: 'account-1'
+    }
+    const store = {
+      getSettings: vi.fn(() => settings),
+      updateSettings: vi.fn((updates: Partial<typeof settings>) => {
+        settings = { ...settings, ...updates }
+        return settings
+      })
+    }
+    const runtimeAuth = {
+      clearLastWrittenCredentialsJson: vi.fn(),
+      forceMaterializeCurrentSelectionForRollback: vi.fn(async () => {}),
+      syncForCurrentSelection: vi.fn(async () => {
+        throw new Error('materialize failed')
+      })
+    }
+    const rateLimits = { refreshForClaudeAccountChange: vi.fn() }
+    const { ClaudeAccountService } = await import('./service')
+    const service = new ClaudeAccountService(
+      store as never,
+      rateLimits as never,
+      runtimeAuth as never
+    )
+    ;(
+      service as unknown as {
+        runClaudeLoginAndCapture(): Promise<{
+          credentialsJson: string
+          oauthAccount: unknown
+          identity: { email: string; organizationUuid: null; organizationName: null }
+        }>
+      }
+    ).runClaudeLoginAndCapture = vi.fn(async () => ({
+      credentialsJson: '{"new":true}\n',
+      oauthAccount: { newOauth: true },
+      identity: { email: 'new@example.com', organizationUuid: null, organizationName: null }
+    }))
+
+    await expect(service.reauthenticateAccount('account-1')).rejects.toThrow('materialize failed')
+
+    expect(readFileSync(join(managedAuthPath, '.credentials.json'), 'utf-8')).toBe('{"old":true}\n')
+    expect(readFileSync(join(managedAuthPath, 'oauth-account.json'), 'utf-8')).toBe(
+      '{"oldOauth":true}\n'
+    )
+    expect(store.getSettings().claudeManagedAccounts[0].email).toBe('old@example.com')
+    expect(runtimeAuth.forceMaterializeCurrentSelectionForRollback).toHaveBeenCalled()
+  })
+
+  it('restores settings without rematerializing when managed-auth rollback write fails', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    tempDir = '/tmp/orca-claude-service-test'
+    rmSync(tempDir, { recursive: true, force: true })
+    const managedAuthPath = join(tempDir, 'claude-accounts', 'account-1', 'auth')
+    mkdirSync(managedAuthPath, { recursive: true })
+    writeFileSync(join(managedAuthPath, '.orca-managed-claude-auth'), 'account-1\n', 'utf-8')
+    writeFileSync(join(managedAuthPath, 'oauth-account.json'), '{"oldOauth":true}\n', 'utf-8')
+    vi.mocked(readManagedClaudeKeychainCredentials).mockResolvedValue('{"old":true}\n')
+    vi.mocked(writeManagedClaudeKeychainCredentials)
+      .mockResolvedValueOnce()
+      .mockRejectedValueOnce(new Error('managed restore failed'))
+    let settings = {
+      claudeManagedAccounts: [
+        {
+          id: 'account-1',
+          email: 'old@example.com',
+          managedAuthPath,
+          authMethod: 'subscription-oauth',
+          organizationUuid: null,
+          organizationName: null,
+          createdAt: 1,
+          updatedAt: 1,
+          lastAuthenticatedAt: 1
+        }
+      ],
+      activeClaudeManagedAccountId: 'account-1'
+    }
+    const store = {
+      getSettings: vi.fn(() => settings),
+      updateSettings: vi.fn((updates: Partial<typeof settings>) => {
+        settings = { ...settings, ...updates }
+        return settings
+      })
+    }
+    const runtimeAuth = {
+      clearLastWrittenCredentialsJson: vi.fn(),
+      forceMaterializeCurrentSelectionForRollback: vi.fn(async () => {}),
+      syncForCurrentSelection: vi.fn(async () => {
+        throw new Error('materialize failed')
+      })
+    }
+    const rateLimits = { refreshForClaudeAccountChange: vi.fn() }
+    const { ClaudeAccountService } = await import('./service')
+    const service = new ClaudeAccountService(
+      store as never,
+      rateLimits as never,
+      runtimeAuth as never
+    )
+    ;(
+      service as unknown as {
+        runClaudeLoginAndCapture(): Promise<{
+          credentialsJson: string
+          oauthAccount: unknown
+          identity: { email: string; organizationUuid: null; organizationName: null }
+        }>
+      }
+    ).runClaudeLoginAndCapture = vi.fn(async () => ({
+      credentialsJson: '{"new":true}\n',
+      oauthAccount: { newOauth: true },
+      identity: { email: 'new@example.com', organizationUuid: null, organizationName: null }
+    }))
+
+    await expect(service.reauthenticateAccount('account-1')).rejects.toThrow('materialize failed')
+
+    expect(store.getSettings().claudeManagedAccounts[0].email).toBe('new@example.com')
+    expect(runtimeAuth.forceMaterializeCurrentSelectionForRollback).not.toHaveBeenCalled()
+    expect(warn).toHaveBeenCalledWith(
+      '[claude-accounts] Failed to restore managed credentials during rollback:',
+      expect.any(Error)
+    )
+    warn.mockRestore()
+  })
+
+  it('restores oauth metadata when new credential write and credential rollback fail', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    tempDir = '/tmp/orca-claude-service-test'
+    rmSync(tempDir, { recursive: true, force: true })
+    const managedAuthPath = join(tempDir, 'claude-accounts', 'account-1', 'auth')
+    mkdirSync(managedAuthPath, { recursive: true })
+    writeFileSync(join(managedAuthPath, '.orca-managed-claude-auth'), 'account-1\n', 'utf-8')
+    writeFileSync(join(managedAuthPath, 'oauth-account.json'), '{"oldOauth":true}\n', 'utf-8')
+    vi.mocked(readManagedClaudeKeychainCredentials).mockResolvedValue('{"old":true}\n')
+    vi.mocked(writeManagedClaudeKeychainCredentials)
+      .mockRejectedValueOnce(new Error('new credentials failed'))
+      .mockRejectedValueOnce(new Error('credential rollback failed'))
+    let settings = {
+      claudeManagedAccounts: [
+        {
+          id: 'account-1',
+          email: 'old@example.com',
+          managedAuthPath,
+          authMethod: 'subscription-oauth',
+          organizationUuid: null,
+          organizationName: null,
+          createdAt: 1,
+          updatedAt: 1,
+          lastAuthenticatedAt: 1
+        }
+      ],
+      activeClaudeManagedAccountId: 'account-1'
+    }
+    const store = {
+      getSettings: vi.fn(() => settings),
+      updateSettings: vi.fn((updates: Partial<typeof settings>) => {
+        settings = { ...settings, ...updates }
+        return settings
+      })
+    }
+    const runtimeAuth = {
+      clearLastWrittenCredentialsJson: vi.fn(),
+      forceMaterializeCurrentSelectionForRollback: vi.fn(async () => {}),
+      syncForCurrentSelection: vi.fn()
+    }
+    const rateLimits = { refreshForClaudeAccountChange: vi.fn() }
+    const { ClaudeAccountService } = await import('./service')
+    const service = new ClaudeAccountService(
+      store as never,
+      rateLimits as never,
+      runtimeAuth as never
+    )
+    ;(
+      service as unknown as {
+        runClaudeLoginAndCapture(): Promise<{
+          credentialsJson: string
+          oauthAccount: unknown
+          identity: { email: string; organizationUuid: null; organizationName: null }
+        }>
+      }
+    ).runClaudeLoginAndCapture = vi.fn(async () => ({
+      credentialsJson: '{"new":true}\n',
+      oauthAccount: { newOauth: true },
+      identity: { email: 'new@example.com', organizationUuid: null, organizationName: null }
+    }))
+
+    await expect(service.reauthenticateAccount('account-1')).rejects.toThrow(
+      'new credentials failed'
+    )
+
+    expect(readFileSync(join(managedAuthPath, 'oauth-account.json'), 'utf-8')).toBe(
+      '{"oldOauth":true}\n'
+    )
+    expect(store.getSettings().claudeManagedAccounts[0].email).toBe('old@example.com')
+    expect(runtimeAuth.forceMaterializeCurrentSelectionForRollback).not.toHaveBeenCalled()
+    expect(warn).toHaveBeenCalledWith(
+      '[claude-accounts] Failed to restore managed credentials during rollback:',
+      expect.any(Error)
+    )
+    warn.mockRestore()
+  })
+
+  it('restores old metadata when rollback restores credentials but oauth restore fails', async () => {
+    setPlatform('linux')
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    tempDir = '/tmp/orca-claude-service-test'
+    rmSync(tempDir, { recursive: true, force: true })
+    const managedAuthPath = join(tempDir, 'claude-accounts', 'account-1', 'auth')
+    const oauthPath = join(managedAuthPath, 'oauth-account.json')
+    mkdirSync(managedAuthPath, { recursive: true })
+    writeFileSync(join(managedAuthPath, '.orca-managed-claude-auth'), 'account-1\n', 'utf-8')
+    writeFileSync(join(managedAuthPath, '.credentials.json'), '{"old":true}\n', 'utf-8')
+    writeFileSync(oauthPath, '{"oldOauth":true}\n', 'utf-8')
+    let settings = {
+      claudeManagedAccounts: [
+        {
+          id: 'account-1',
+          email: 'old@example.com',
+          managedAuthPath,
+          authMethod: 'subscription-oauth',
+          organizationUuid: null,
+          organizationName: null,
+          createdAt: 1,
+          updatedAt: 1,
+          lastAuthenticatedAt: 1
+        }
+      ],
+      activeClaudeManagedAccountId: 'account-1'
+    }
+    const store = {
+      getSettings: vi.fn(() => settings),
+      updateSettings: vi.fn((updates: Partial<typeof settings>) => {
+        settings = { ...settings, ...updates }
+        return settings
+      })
+    }
+    const runtimeAuth = {
+      clearLastWrittenCredentialsJson: vi.fn(),
+      forceMaterializeCurrentSelectionForRollback: vi.fn(async () => {}),
+      syncForCurrentSelection: vi.fn(async () => {
+        rmSync(oauthPath, { force: true })
+        mkdirSync(oauthPath)
+        throw new Error('materialize failed')
+      })
+    }
+    const rateLimits = { refreshForClaudeAccountChange: vi.fn() }
+    const { ClaudeAccountService } = await import('./service')
+    const service = new ClaudeAccountService(
+      store as never,
+      rateLimits as never,
+      runtimeAuth as never
+    )
+    ;(
+      service as unknown as {
+        runClaudeLoginAndCapture(): Promise<{
+          credentialsJson: string
+          oauthAccount: unknown
+          identity: { email: string; organizationUuid: null; organizationName: null }
+        }>
+      }
+    ).runClaudeLoginAndCapture = vi.fn(async () => ({
+      credentialsJson: '{"new":true}\n',
+      oauthAccount: { newOauth: true },
+      identity: { email: 'new@example.com', organizationUuid: null, organizationName: null }
+    }))
+
+    await expect(service.reauthenticateAccount('account-1')).rejects.toThrow('materialize failed')
+
+    expect(readFileSync(join(managedAuthPath, '.credentials.json'), 'utf-8')).toBe('{"old":true}\n')
+    expect(store.getSettings().claudeManagedAccounts[0].email).toBe('old@example.com')
+    expect(runtimeAuth.forceMaterializeCurrentSelectionForRollback).toHaveBeenCalled()
+    expect(warn).toHaveBeenCalled()
+    warn.mockRestore()
   })
 })

--- a/src/main/claude-accounts/service.test.ts
+++ b/src/main/claude-accounts/service.test.ts
@@ -201,7 +201,7 @@ describe('ClaudeAccountService credential capture', () => {
         throw new Error('materialize failed')
       })
     }
-    const rateLimits = { refreshForClaudeAccountChange: vi.fn() }
+    const rateLimits = { evictInactiveClaudeCache: vi.fn(), refreshForClaudeAccountChange: vi.fn() }
     const { ClaudeAccountService } = await import('./service')
     const service = new ClaudeAccountService(
       store as never,
@@ -274,7 +274,7 @@ describe('ClaudeAccountService credential capture', () => {
         throw new Error('materialize failed')
       })
     }
-    const rateLimits = { refreshForClaudeAccountChange: vi.fn() }
+    const rateLimits = { evictInactiveClaudeCache: vi.fn(), refreshForClaudeAccountChange: vi.fn() }
     const { ClaudeAccountService } = await import('./service')
     const service = new ClaudeAccountService(
       store as never,
@@ -346,7 +346,7 @@ describe('ClaudeAccountService credential capture', () => {
       forceMaterializeCurrentSelectionForRollback: vi.fn(async () => {}),
       syncForCurrentSelection: vi.fn()
     }
-    const rateLimits = { refreshForClaudeAccountChange: vi.fn() }
+    const rateLimits = { evictInactiveClaudeCache: vi.fn(), refreshForClaudeAccountChange: vi.fn() }
     const { ClaudeAccountService } = await import('./service')
     const service = new ClaudeAccountService(
       store as never,
@@ -426,7 +426,7 @@ describe('ClaudeAccountService credential capture', () => {
         throw new Error('materialize failed')
       })
     }
-    const rateLimits = { refreshForClaudeAccountChange: vi.fn() }
+    const rateLimits = { evictInactiveClaudeCache: vi.fn(), refreshForClaudeAccountChange: vi.fn() }
     const { ClaudeAccountService } = await import('./service')
     const service = new ClaudeAccountService(
       store as never,
@@ -454,5 +454,129 @@ describe('ClaudeAccountService credential capture', () => {
     expect(runtimeAuth.forceMaterializeCurrentSelectionForRollback).toHaveBeenCalled()
     expect(warn).toHaveBeenCalled()
     warn.mockRestore()
+  })
+
+  it('refreshes rate limits without recaching a removed active account', async () => {
+    setPlatform('linux')
+    tempDir = '/tmp/orca-claude-service-test'
+    rmSync(tempDir, { recursive: true, force: true })
+    const managedAuthPath = join(tempDir, 'claude-accounts', 'account-1', 'auth')
+    mkdirSync(managedAuthPath, { recursive: true })
+    writeFileSync(join(managedAuthPath, '.orca-managed-claude-auth'), 'account-1\n', 'utf-8')
+    writeFileSync(join(managedAuthPath, '.credentials.json'), '{"old":true}\n', 'utf-8')
+    let settings = {
+      claudeManagedAccounts: [
+        {
+          id: 'account-1',
+          email: 'old@example.com',
+          managedAuthPath,
+          authMethod: 'subscription-oauth',
+          organizationUuid: null,
+          organizationName: null,
+          createdAt: 1,
+          updatedAt: 1,
+          lastAuthenticatedAt: 1
+        }
+      ],
+      activeClaudeManagedAccountId: 'account-1'
+    }
+    const store = {
+      getSettings: vi.fn(() => settings),
+      updateSettings: vi.fn((updates: Partial<typeof settings>) => {
+        settings = { ...settings, ...updates }
+        return settings
+      })
+    }
+    const runtimeAuth = {
+      syncForCurrentSelection: vi.fn(async () => {}),
+      forceMaterializeCurrentSelectionForRollback: vi.fn(async () => {})
+    }
+    const rateLimits = {
+      evictInactiveClaudeCache: vi.fn(),
+      refreshForClaudeAccountChange: vi.fn(async () => ({ accounts: [], activeAccountId: null }))
+    }
+    const { ClaudeAccountService } = await import('./service')
+    const service = new ClaudeAccountService(
+      store as never,
+      rateLimits as never,
+      runtimeAuth as never
+    )
+
+    await service.removeAccount('account-1')
+
+    expect(rateLimits.evictInactiveClaudeCache).toHaveBeenCalledWith('account-1')
+    expect(rateLimits.refreshForClaudeAccountChange).toHaveBeenCalledWith()
+    expect(settings).toMatchObject({
+      claudeManagedAccounts: [],
+      activeClaudeManagedAccountId: null
+    })
+  })
+
+  it('evicts inactive rate-limit cache after successful reauth', async () => {
+    setPlatform('linux')
+    tempDir = '/tmp/orca-claude-service-test'
+    rmSync(tempDir, { recursive: true, force: true })
+    const managedAuthPath = join(tempDir, 'claude-accounts', 'account-1', 'auth')
+    mkdirSync(managedAuthPath, { recursive: true })
+    writeFileSync(join(managedAuthPath, '.orca-managed-claude-auth'), 'account-1\n', 'utf-8')
+    writeFileSync(join(managedAuthPath, '.credentials.json'), '{"old":true}\n', 'utf-8')
+    writeFileSync(join(managedAuthPath, 'oauth-account.json'), '{"oldOauth":true}\n', 'utf-8')
+    let settings = {
+      claudeManagedAccounts: [
+        {
+          id: 'account-1',
+          email: 'old@example.com',
+          managedAuthPath,
+          authMethod: 'subscription-oauth',
+          organizationUuid: null,
+          organizationName: null,
+          createdAt: 1,
+          updatedAt: 1,
+          lastAuthenticatedAt: 1
+        }
+      ],
+      activeClaudeManagedAccountId: null
+    }
+    const store = {
+      getSettings: vi.fn(() => settings),
+      updateSettings: vi.fn((updates: Partial<typeof settings>) => {
+        settings = { ...settings, ...updates }
+        return settings
+      })
+    }
+    const runtimeAuth = {
+      clearLastWrittenCredentialsJson: vi.fn(),
+      syncForCurrentSelection: vi.fn(async () => {}),
+      forceMaterializeCurrentSelectionForRollback: vi.fn(async () => {})
+    }
+    const rateLimits = {
+      evictInactiveClaudeCache: vi.fn(),
+      refreshForClaudeAccountChange: vi.fn(async () => ({ accounts: [], activeAccountId: null }))
+    }
+    const { ClaudeAccountService } = await import('./service')
+    const service = new ClaudeAccountService(
+      store as never,
+      rateLimits as never,
+      runtimeAuth as never
+    )
+    ;(
+      service as unknown as {
+        runClaudeLoginAndCapture(): Promise<{
+          credentialsJson: string
+          oauthAccount: unknown
+          identity: { email: string; organizationUuid: null; organizationName: null }
+        }>
+      }
+    ).runClaudeLoginAndCapture = vi.fn(async () => ({
+      credentialsJson: '{"new":true}\n',
+      oauthAccount: { newOauth: true },
+      identity: { email: 'new@example.com', organizationUuid: null, organizationName: null }
+    }))
+
+    await service.reauthenticateAccount('account-1')
+
+    expect(rateLimits.evictInactiveClaudeCache).toHaveBeenCalledWith('account-1')
+    expect(rateLimits.refreshForClaudeAccountChange).toHaveBeenCalledWith()
+    expect(settings.claudeManagedAccounts[0].email).toBe('new@example.com')
   })
 })

--- a/src/main/claude-accounts/service.test.ts
+++ b/src/main/claude-accounts/service.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  readActiveClaudeKeychainCredentials,
+  readActiveClaudeKeychainCredentialsStrict
+} from './keychain'
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: () => '/tmp/orca-claude-service-test'
+  }
+}))
+
+vi.mock('../codex-cli/command', () => ({
+  resolveClaudeCommand: () => 'claude'
+}))
+
+vi.mock('./keychain', () => ({
+  deleteActiveClaudeKeychainCredentialsStrict: vi.fn(async () => {}),
+  deleteManagedClaudeKeychainCredentials: vi.fn(async () => {}),
+  readActiveClaudeKeychainCredentials: vi.fn(),
+  readActiveClaudeKeychainCredentialsStrict: vi.fn(),
+  writeActiveClaudeKeychainCredentials: vi.fn(async () => {}),
+  writeManagedClaudeKeychainCredentials: vi.fn(async () => {})
+}))
+
+const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', {
+    configurable: true,
+    value: platform
+  })
+}
+
+function createService(): unknown {
+  return {}
+}
+
+async function readCapturedCredentials(
+  configDir: string,
+  previousLegacyKeychain: string | null
+): Promise<string | null> {
+  const { ClaudeAccountService } = await import('./service')
+  const service = new ClaudeAccountService(
+    createService() as never,
+    createService() as never,
+    createService() as never
+  )
+  return (
+    service as unknown as {
+      readCapturedCredentials(
+        configDir: string,
+        previousLegacyKeychain: string | null
+      ): Promise<string | null>
+    }
+  ).readCapturedCredentials(configDir, previousLegacyKeychain)
+}
+
+describe('ClaudeAccountService credential capture', () => {
+  beforeEach(() => {
+    setPlatform('darwin')
+    vi.mocked(readActiveClaudeKeychainCredentials).mockReset()
+    vi.mocked(readActiveClaudeKeychainCredentialsStrict).mockReset()
+  })
+
+  afterEach(() => {
+    if (originalPlatform) {
+      Object.defineProperty(process, 'platform', originalPlatform)
+    }
+  })
+
+  it('accepts scoped Keychain capture even when it matches the previous legacy item', async () => {
+    vi.mocked(readActiveClaudeKeychainCredentialsStrict)
+      .mockResolvedValueOnce('same-account')
+      .mockResolvedValueOnce('same-account')
+
+    await expect(readCapturedCredentials('/tmp/claude-config', 'same-account')).resolves.toBe(
+      'same-account'
+    )
+
+    expect(readActiveClaudeKeychainCredentialsStrict).toHaveBeenCalledWith('/tmp/claude-config')
+    expect(readActiveClaudeKeychainCredentials).not.toHaveBeenCalled()
+  })
+
+  it('rejects unchanged legacy fallback when scoped capture is missing', async () => {
+    vi.mocked(readActiveClaudeKeychainCredentialsStrict)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce('previous')
+
+    await expect(readCapturedCredentials('/tmp/claude-config', 'previous')).resolves.toBeNull()
+
+    expect(readActiveClaudeKeychainCredentialsStrict).toHaveBeenNthCalledWith(
+      1,
+      '/tmp/claude-config'
+    )
+    expect(readActiveClaudeKeychainCredentialsStrict).toHaveBeenNthCalledWith(2)
+  })
+
+  it('accepts changed legacy fallback for old Claude Code builds', async () => {
+    vi.mocked(readActiveClaudeKeychainCredentialsStrict)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce('new-legacy')
+
+    await expect(readCapturedCredentials('/tmp/claude-config', 'previous')).resolves.toBe(
+      'new-legacy'
+    )
+
+    expect(readActiveClaudeKeychainCredentialsStrict).toHaveBeenNthCalledWith(
+      1,
+      '/tmp/claude-config'
+    )
+    expect(readActiveClaudeKeychainCredentialsStrict).toHaveBeenNthCalledWith(2)
+  })
+})

--- a/src/main/claude-accounts/service.test.ts
+++ b/src/main/claude-accounts/service.test.ts
@@ -1,7 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import {
+  deleteActiveClaudeKeychainCredentialsStrict,
   readActiveClaudeKeychainCredentials,
-  readActiveClaudeKeychainCredentialsStrict
+  readActiveClaudeKeychainCredentialsStrict,
+  writeActiveClaudeKeychainCredentials
 } from './keychain'
 
 vi.mock('electron', () => ({
@@ -57,15 +62,24 @@ async function readCapturedCredentials(
 }
 
 describe('ClaudeAccountService credential capture', () => {
+  let tempDir: string | null = null
+
   beforeEach(() => {
     setPlatform('darwin')
+    tempDir = null
     vi.mocked(readActiveClaudeKeychainCredentials).mockReset()
     vi.mocked(readActiveClaudeKeychainCredentialsStrict).mockReset()
+    vi.mocked(deleteActiveClaudeKeychainCredentialsStrict).mockClear()
+    vi.mocked(writeActiveClaudeKeychainCredentials).mockReset()
+    vi.mocked(writeActiveClaudeKeychainCredentials).mockResolvedValue()
   })
 
   afterEach(() => {
     if (originalPlatform) {
       Object.defineProperty(process, 'platform', originalPlatform)
+    }
+    if (tempDir) {
+      rmSync(tempDir, { recursive: true, force: true })
     }
   })
 
@@ -110,5 +124,34 @@ describe('ClaudeAccountService credential capture', () => {
       '/tmp/claude-config'
     )
     expect(readActiveClaudeKeychainCredentialsStrict).toHaveBeenNthCalledWith(2)
+  })
+
+  it('falls back to captured credentials file on macOS', async () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'orca-claude-capture-'))
+    writeFileSync(join(tempDir, '.credentials.json'), '{"token":"file"}\n', 'utf-8')
+    vi.mocked(readActiveClaudeKeychainCredentialsStrict)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce('previous')
+
+    await expect(readCapturedCredentials(tempDir, 'previous')).resolves.toBe('{"token":"file"}\n')
+  })
+
+  it('fails login capture when legacy Keychain cleanup fails', async () => {
+    vi.mocked(readActiveClaudeKeychainCredentials).mockResolvedValue('previous-legacy')
+    vi.mocked(readActiveClaudeKeychainCredentialsStrict).mockResolvedValue('captured-scoped')
+    vi.mocked(writeActiveClaudeKeychainCredentials).mockRejectedValue(new Error('restore failed'))
+    const { ClaudeAccountService } = await import('./service')
+    const service = new ClaudeAccountService(
+      createService() as never,
+      createService() as never,
+      createService() as never
+    )
+    const testService = service as unknown as {
+      runClaudeCommand: () => Promise<string>
+      runClaudeLoginAndCapture(): Promise<{ credentialsJson: string }>
+    }
+    testService.runClaudeCommand = vi.fn(async () => '{"account":{"email":"user@example.com"}}')
+
+    await expect(testService.runClaudeLoginAndCapture()).rejects.toThrow('restore failed')
   })
 })

--- a/src/main/claude-accounts/service.ts
+++ b/src/main/claude-accounts/service.ts
@@ -289,7 +289,11 @@ export class ClaudeAccountService {
       return await this.captureAuthFromConfigDir(tempConfigDir, status)
     } finally {
       if (process.platform === 'darwin') {
-        await deleteActiveClaudeKeychainCredentialsStrict(tempConfigDir)
+        try {
+          await deleteActiveClaudeKeychainCredentialsStrict(tempConfigDir)
+        } catch (error) {
+          console.warn('[claude-accounts] Failed to clean temporary Claude Keychain item:', error)
+        }
       }
       if (process.platform === 'darwin' && previousLegacyKeychain) {
         // Why: older Claude versions ignored CLAUDE_CONFIG_DIR and wrote the

--- a/src/main/claude-accounts/service.ts
+++ b/src/main/claude-accounts/service.ts
@@ -277,7 +277,7 @@ export class ClaudeAccountService {
 
   private async runClaudeLoginAndCapture(): Promise<CapturedClaudeAuth> {
     const tempConfigDir = mkdtempSync(join(tmpdir(), 'orca-claude-login-'))
-    const previousActiveKeychain = await readActiveClaudeKeychainCredentials()
+    const previousLegacyKeychain = await readActiveClaudeKeychainCredentials()
     try {
       await this.runClaudeCommand(['auth', 'login', '--claudeai'], tempConfigDir, LOGIN_TIMEOUT_MS)
       const status = await this.runClaudeCommand(
@@ -288,11 +288,13 @@ export class ClaudeAccountService {
       )
       return await this.captureAuthFromConfigDir(tempConfigDir, status)
     } finally {
-      if (process.platform === 'darwin' && previousActiveKeychain) {
-        // Why: Claude login writes the global active Keychain item even when
-        // CLAUDE_CONFIG_DIR points elsewhere. Restore it so adding an account
-        // does not switch the user's external Claude CLI out from under them.
-        await writeActiveClaudeKeychainCredentials(previousActiveKeychain)
+      if (process.platform === 'darwin') {
+        await deleteActiveClaudeKeychainCredentialsStrict(tempConfigDir)
+      }
+      if (process.platform === 'darwin' && previousLegacyKeychain) {
+        // Why: older Claude versions ignored CLAUDE_CONFIG_DIR and wrote the
+        // legacy active Keychain item. Preserve that external CLI state.
+        await writeActiveClaudeKeychainCredentials(previousLegacyKeychain)
       } else if (process.platform === 'darwin') {
         await deleteActiveClaudeKeychainCredentialsStrict()
       }
@@ -315,7 +317,7 @@ export class ClaudeAccountService {
 
   private async readCapturedCredentials(configDir: string): Promise<string | null> {
     if (process.platform === 'darwin') {
-      return readActiveClaudeKeychainCredentials()
+      return readActiveClaudeKeychainCredentials(configDir)
     }
     const credentialsPath = join(configDir, '.credentials.json')
     return existsSync(credentialsPath) ? readFileSync(credentialsPath, 'utf-8') : null

--- a/src/main/claude-accounts/service.ts
+++ b/src/main/claude-accounts/service.ts
@@ -175,12 +175,18 @@ export class ClaudeAccountService {
         ? null
         : settings.activeClaudeManagedAccountId
 
-    this.store.updateSettings({
-      claudeManagedAccounts: nextAccounts,
-      activeClaudeManagedAccountId: nextActiveId
-    })
     try {
-      await this.syncRuntimeAuthWithLivePtyGate()
+      if (settings.activeClaudeManagedAccountId === accountId) {
+        this.store.updateSettings({ activeClaudeManagedAccountId: null })
+        await this.syncRuntimeAuthWithLivePtyGate()
+        this.store.updateSettings({ claudeManagedAccounts: nextAccounts })
+      } else {
+        this.store.updateSettings({
+          claudeManagedAccounts: nextAccounts,
+          activeClaudeManagedAccountId: nextActiveId
+        })
+        await this.syncRuntimeAuthWithLivePtyGate()
+      }
       await this.safeRemoveManagedAuth(accountId, account.managedAuthPath)
       this.rateLimits.evictInactiveClaudeCache(accountId)
       await this.rateLimits.refreshForClaudeAccountChange(
@@ -279,6 +285,9 @@ export class ClaudeAccountService {
   private async runClaudeLoginAndCapture(): Promise<CapturedClaudeAuth> {
     const tempConfigDir = mkdtempSync(join(tmpdir(), 'orca-claude-login-'))
     const previousLegacyKeychain = await readActiveClaudeKeychainCredentials()
+    let captured: CapturedClaudeAuth | null = null
+    let captureError: unknown = null
+    let cleanupError: unknown = null
     try {
       await this.runClaudeCommand(['auth', 'login', '--claudeai'], tempConfigDir, LOGIN_TIMEOUT_MS)
       const status = await this.runClaudeCommand(
@@ -287,7 +296,9 @@ export class ClaudeAccountService {
         STATUS_TIMEOUT_MS,
         { allowFailure: true }
       )
-      return await this.captureAuthFromConfigDir(tempConfigDir, status, previousLegacyKeychain)
+      captured = await this.captureAuthFromConfigDir(tempConfigDir, status, previousLegacyKeychain)
+    } catch (error) {
+      captureError = error
     } finally {
       if (process.platform === 'darwin') {
         try {
@@ -296,15 +307,26 @@ export class ClaudeAccountService {
           console.warn('[claude-accounts] Failed to clean temporary Claude Keychain item:', error)
         }
       }
-      if (process.platform === 'darwin' && previousLegacyKeychain) {
-        // Why: older Claude versions ignored CLAUDE_CONFIG_DIR and wrote the
-        // legacy active Keychain item. Preserve that external CLI state.
-        await writeActiveClaudeKeychainCredentials(previousLegacyKeychain)
-      } else if (process.platform === 'darwin') {
-        await deleteActiveClaudeKeychainCredentialsStrict()
+      if (process.platform === 'darwin') {
+        try {
+          // Why: older Claude versions ignored CLAUDE_CONFIG_DIR and wrote the
+          // legacy active Keychain item. Preserve that external CLI state.
+          await (previousLegacyKeychain
+            ? writeActiveClaudeKeychainCredentials(previousLegacyKeychain)
+            : deleteActiveClaudeKeychainCredentialsStrict())
+        } catch (error) {
+          cleanupError = error
+        }
       }
       rmSync(tempConfigDir, { recursive: true, force: true })
     }
+    if (captureError) {
+      throw captureError
+    }
+    if (cleanupError) {
+      throw cleanupError
+    }
+    return captured!
   }
 
   private async captureAuthFromConfigDir(
@@ -331,7 +353,9 @@ export class ClaudeAccountService {
         return scopedCredentialsJson
       }
       const legacyCredentialsJson = await readActiveClaudeKeychainCredentialsStrict()
-      return legacyCredentialsJson === previousLegacyKeychain ? null : legacyCredentialsJson
+      if (legacyCredentialsJson && legacyCredentialsJson !== previousLegacyKeychain) {
+        return legacyCredentialsJson
+      }
     }
     const credentialsPath = join(configDir, '.credentials.json')
     return existsSync(credentialsPath) ? readFileSync(credentialsPath, 'utf-8') : null

--- a/src/main/claude-accounts/service.ts
+++ b/src/main/claude-accounts/service.ts
@@ -2,18 +2,9 @@
 for login, credential capture, Keychain storage, selection, and rate-limit refresh. */
 import { randomUUID } from 'node:crypto'
 import { spawn } from 'node:child_process'
-import {
-  existsSync,
-  mkdirSync,
-  mkdtempSync,
-  readFileSync,
-  realpathSync,
-  rmSync,
-  writeFileSync
-} from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, relative, resolve, sep } from 'node:path'
-import { app } from 'electron'
 import type {
   ClaudeManagedAccount,
   ClaudeManagedAccountSummary,
@@ -21,9 +12,14 @@ import type {
 } from '../../shared/types'
 import type { Store } from '../persistence'
 import type { RateLimitService } from '../rate-limits/service'
-import { writeFileAtomically } from '../codex-accounts/fs-utils'
 import { resolveClaudeCommand } from '../codex-cli/command'
 import type { ClaudeRuntimeAuthService } from './runtime-auth-service'
+import {
+  getClaudeManagedAccountsRoot,
+  readClaudeManagedAuthFile,
+  resolveOwnedClaudeManagedAuthPath,
+  writeClaudeManagedAuthFile
+} from './managed-auth-path'
 import {
   deleteActiveClaudeKeychainCredentialsStrict,
   deleteManagedClaudeKeychainCredentials,
@@ -136,7 +132,7 @@ export class ClaudeAccountService {
 
   private async doReauthenticateAccount(accountId: string): Promise<ClaudeRateLimitAccountsState> {
     const account = this.requireAccount(accountId)
-    const managedAuthPath = this.assertManagedAuthPath(account.managedAuthPath)
+    const managedAuthPath = this.assertManagedAuthPath(account.managedAuthPath, accountId)
     const previousSettings = this.store.getSettings()
     const previousManagedAuth = await this.readManagedAuthSnapshot(accountId, managedAuthPath)
     const captured = await this.runClaudeLoginAndCapture()
@@ -160,11 +156,12 @@ export class ClaudeAccountService {
     )
     let wroteManagedCredentials = false
     try {
-      await this.writeManagedOauthAccount(managedAuthPath, captured.oauthAccount)
+      await this.writeManagedOauthAccount(accountId, managedAuthPath, captured.oauthAccount)
       await this.writeManagedCredentials(accountId, managedAuthPath, captured.credentialsJson)
       wroteManagedCredentials = true
       this.store.updateSettings({ claudeManagedAccounts: reauthenticatedAccounts })
       this.runtimeAuth.clearLastWrittenCredentialsJson(accountId)
+      this.rateLimits.evictInactiveClaudeCache(accountId)
       await this.syncRuntimeAuthWithLivePtyGate()
       await this.rateLimits.refreshForClaudeAccountChange()
       return this.getSnapshot()
@@ -185,7 +182,7 @@ export class ClaudeAccountService {
       }
       if (restoredManagedCredentials || !wroteManagedCredentials) {
         try {
-          this.restoreManagedOauthSnapshot(managedAuthPath, previousManagedAuth)
+          this.restoreManagedOauthSnapshot(accountId, managedAuthPath, previousManagedAuth)
         } catch (rollbackError) {
           console.warn(
             '[claude-accounts] Failed to restore managed oauth metadata during rollback:',
@@ -228,11 +225,7 @@ export class ClaudeAccountService {
       }
       await this.safeRemoveManagedAuth(accountId, account.managedAuthPath)
       this.rateLimits.evictInactiveClaudeCache(accountId)
-      await this.rateLimits.refreshForClaudeAccountChange(
-        settings.activeClaudeManagedAccountId === accountId
-          ? settings.activeClaudeManagedAccountId
-          : undefined
-      )
+      await this.rateLimits.refreshForClaudeAccountChange()
       return this.getSnapshot()
     } catch (error) {
       this.restoreClaudeSettings(settings)
@@ -452,7 +445,7 @@ export class ClaudeAccountService {
     captured: CapturedClaudeAuth
   ): Promise<void> {
     await this.writeManagedCredentials(accountId, managedAuthPath, captured.credentialsJson)
-    await this.writeManagedOauthAccount(managedAuthPath, captured.oauthAccount)
+    await this.writeManagedOauthAccount(accountId, managedAuthPath, captured.oauthAccount)
   }
 
   private async writeManagedCredentials(
@@ -460,25 +453,24 @@ export class ClaudeAccountService {
     managedAuthPath: string,
     credentialsJson: string
   ): Promise<void> {
-    const trustedPath = this.assertManagedAuthPath(managedAuthPath)
+    const trustedPath = this.assertManagedAuthPath(managedAuthPath, accountId)
     if (process.platform === 'darwin') {
       await writeManagedClaudeKeychainCredentials(accountId, credentialsJson)
     } else {
-      writeFileAtomically(join(trustedPath, '.credentials.json'), credentialsJson, {
-        mode: 0o600
-      })
+      writeClaudeManagedAuthFile(trustedPath, '.credentials.json', credentialsJson)
     }
   }
 
   private async writeManagedOauthAccount(
+    accountId: string,
     managedAuthPath: string,
     oauthAccount: unknown
   ): Promise<void> {
-    const trustedPath = this.assertManagedAuthPath(managedAuthPath)
-    writeFileAtomically(
-      join(trustedPath, 'oauth-account.json'),
-      `${JSON.stringify(oauthAccount, null, 2)}\n`,
-      { mode: 0o600 }
+    const trustedPath = this.assertManagedAuthPath(managedAuthPath, accountId)
+    writeClaudeManagedAuthFile(
+      trustedPath,
+      'oauth-account.json',
+      `${JSON.stringify(oauthAccount, null, 2)}\n`
     )
   }
 
@@ -486,17 +478,13 @@ export class ClaudeAccountService {
     accountId: string,
     managedAuthPath: string
   ): Promise<ManagedClaudeAuthSnapshot> {
-    const trustedPath = this.assertManagedAuthPath(managedAuthPath)
-    const credentialsPath = join(trustedPath, '.credentials.json')
-    const oauthPath = join(trustedPath, 'oauth-account.json')
+    const trustedPath = this.assertManagedAuthPath(managedAuthPath, accountId)
     return {
       credentialsJson:
         process.platform === 'darwin'
           ? await readManagedClaudeKeychainCredentials(accountId)
-          : existsSync(credentialsPath)
-            ? readFileSync(credentialsPath, 'utf-8')
-            : null,
-      oauthAccountJson: existsSync(oauthPath) ? readFileSync(oauthPath, 'utf-8') : null
+          : readClaudeManagedAuthFile(trustedPath, '.credentials.json'),
+      oauthAccountJson: readClaudeManagedAuthFile(trustedPath, 'oauth-account.json')
     }
   }
 
@@ -505,27 +493,28 @@ export class ClaudeAccountService {
     managedAuthPath: string,
     snapshot: ManagedClaudeAuthSnapshot
   ): Promise<void> {
-    const trustedPath = this.assertManagedAuthPath(managedAuthPath)
+    const trustedPath = this.assertManagedAuthPath(managedAuthPath, accountId)
     const credentialsPath = join(trustedPath, '.credentials.json')
     if (process.platform === 'darwin') {
       await (snapshot.credentialsJson !== null
         ? writeManagedClaudeKeychainCredentials(accountId, snapshot.credentialsJson)
         : deleteManagedClaudeKeychainCredentials(accountId))
     } else if (snapshot.credentialsJson !== null) {
-      writeFileAtomically(credentialsPath, snapshot.credentialsJson, { mode: 0o600 })
+      writeClaudeManagedAuthFile(trustedPath, '.credentials.json', snapshot.credentialsJson)
     } else {
       rmSync(credentialsPath, { force: true })
     }
   }
 
   private restoreManagedOauthSnapshot(
+    accountId: string,
     managedAuthPath: string,
     snapshot: ManagedClaudeAuthSnapshot
   ): void {
-    const trustedPath = this.assertManagedAuthPath(managedAuthPath)
+    const trustedPath = this.assertManagedAuthPath(managedAuthPath, accountId)
     const oauthPath = join(trustedPath, 'oauth-account.json')
     if (snapshot.oauthAccountJson !== null) {
-      writeFileAtomically(oauthPath, snapshot.oauthAccountJson, { mode: 0o600 })
+      writeClaudeManagedAuthFile(trustedPath, 'oauth-account.json', snapshot.oauthAccountJson)
     } else {
       rmSync(oauthPath, { force: true })
     }
@@ -535,44 +524,40 @@ export class ClaudeAccountService {
     const managedAuthPath = join(this.getManagedAccountsRoot(), accountId, 'auth')
     mkdirSync(managedAuthPath, { recursive: true })
     writeFileSync(join(managedAuthPath, '.orca-managed-claude-auth'), `${accountId}\n`, 'utf-8')
-    return this.assertManagedAuthPath(managedAuthPath)
+    return this.assertManagedAuthPath(managedAuthPath, accountId)
   }
 
   private getManagedAccountsRoot(): string {
-    const root = join(app.getPath('userData'), 'claude-accounts')
+    const root = getClaudeManagedAccountsRoot()
     mkdirSync(root, { recursive: true })
     return root
   }
 
-  private assertManagedAuthPath(candidatePath: string): string {
-    const rootPath = this.getManagedAccountsRoot()
-    const resolvedCandidate = resolve(candidatePath)
-    const resolvedRoot = resolve(rootPath)
-    if (!existsSync(resolvedCandidate)) {
+  private assertManagedAuthPath(candidatePath: string, expectedAccountId?: string): string {
+    this.getManagedAccountsRoot()
+    const accountId = expectedAccountId ?? this.readManagedAuthAccountIdFromPath(candidatePath)
+    if (!accountId || (expectedAccountId && accountId !== expectedAccountId)) {
       throw new Error('Managed Claude auth directory does not exist on disk.')
     }
-    const canonicalCandidate = realpathSync(resolvedCandidate)
-    const canonicalRoot = realpathSync(resolvedRoot)
-    if (
-      canonicalCandidate !== canonicalRoot &&
-      !canonicalCandidate.startsWith(canonicalRoot + sep)
-    ) {
-      throw new Error(
-        `Managed Claude auth is outside current storage root (expected under ${canonicalRoot}).`
-      )
-    }
-    const relativePath = relative(canonicalRoot, canonicalCandidate)
-    const escaped =
-      relativePath === '' || relativePath.startsWith('..') || relativePath.includes(`..${sep}`)
-    if (escaped || !existsSync(join(canonicalCandidate, '.orca-managed-claude-auth'))) {
+    const trustedPath = resolveOwnedClaudeManagedAuthPath(accountId, candidatePath, {
+      adoptLegacyMarker: true
+    })
+    if (!trustedPath) {
       throw new Error('Managed Claude auth storage is not owned by Orca.')
     }
-    return canonicalCandidate
+    return trustedPath
+  }
+
+  private readManagedAuthAccountIdFromPath(candidatePath: string): string | null {
+    const rootPath = this.getManagedAccountsRoot()
+    const relativePath = relative(resolve(rootPath), resolve(candidatePath))
+    const parts = relativePath.split(sep)
+    return parts.length === 2 && parts[1] === 'auth' ? parts[0] : null
   }
 
   private async safeRemoveManagedAuth(accountId: string, candidatePath: string): Promise<void> {
     try {
-      const managedAuthPath = this.assertManagedAuthPath(candidatePath)
+      const managedAuthPath = this.assertManagedAuthPath(candidatePath, accountId)
       rmSync(resolve(managedAuthPath, '..'), { recursive: true, force: true })
     } catch (error) {
       console.warn('[claude-accounts] Refusing to remove untrusted managed auth:', error)

--- a/src/main/claude-accounts/service.ts
+++ b/src/main/claude-accounts/service.ts
@@ -29,6 +29,7 @@ import {
   deleteManagedClaudeKeychainCredentials,
   readActiveClaudeKeychainCredentials,
   readActiveClaudeKeychainCredentialsStrict,
+  readManagedClaudeKeychainCredentials,
   writeActiveClaudeKeychainCredentials,
   writeManagedClaudeKeychainCredentials
 } from './keychain'
@@ -48,6 +49,11 @@ type CapturedClaudeAuth = {
   credentialsJson: string
   oauthAccount: unknown
   identity: ClaudeIdentity
+}
+
+type ManagedClaudeAuthSnapshot = {
+  credentialsJson: string | null
+  oauthAccountJson: string | null
 }
 
 export class ClaudeAccountService {
@@ -132,36 +138,69 @@ export class ClaudeAccountService {
     const account = this.requireAccount(accountId)
     const managedAuthPath = this.assertManagedAuthPath(account.managedAuthPath)
     const previousSettings = this.store.getSettings()
+    const previousManagedAuth = await this.readManagedAuthSnapshot(accountId, managedAuthPath)
     const captured = await this.runClaudeLoginAndCapture()
     if (!captured.identity.email) {
       throw new Error('Claude login completed, but Orca could not resolve the account email.')
     }
-    await this.writeManagedAuth(accountId, managedAuthPath, captured)
 
     const settings = this.store.getSettings()
     const now = Date.now()
-    this.store.updateSettings({
-      claudeManagedAccounts: settings.claudeManagedAccounts.map((entry) =>
-        entry.id === accountId
-          ? {
-              ...entry,
-              email: captured.identity.email!,
-              organizationUuid: captured.identity.organizationUuid,
-              organizationName: captured.identity.organizationName,
-              updatedAt: now,
-              lastAuthenticatedAt: now
-            }
-          : entry
-      )
-    })
+    const reauthenticatedAccounts = settings.claudeManagedAccounts.map((entry) =>
+      entry.id === accountId
+        ? {
+            ...entry,
+            email: captured.identity.email!,
+            organizationUuid: captured.identity.organizationUuid,
+            organizationName: captured.identity.organizationName,
+            updatedAt: now,
+            lastAuthenticatedAt: now
+          }
+        : entry
+    )
+    let wroteManagedCredentials = false
     try {
+      await this.writeManagedOauthAccount(managedAuthPath, captured.oauthAccount)
+      await this.writeManagedCredentials(accountId, managedAuthPath, captured.credentialsJson)
+      wroteManagedCredentials = true
+      this.store.updateSettings({ claudeManagedAccounts: reauthenticatedAccounts })
       this.runtimeAuth.clearLastWrittenCredentialsJson(accountId)
       await this.syncRuntimeAuthWithLivePtyGate()
       await this.rateLimits.refreshForClaudeAccountChange()
       return this.getSnapshot()
     } catch (error) {
-      this.restoreClaudeSettings(previousSettings)
-      await this.runtimeAuth.forceMaterializeCurrentSelectionForRollback()
+      let restoredManagedCredentials = false
+      try {
+        await this.restoreManagedCredentialsSnapshot(
+          accountId,
+          managedAuthPath,
+          previousManagedAuth
+        )
+        restoredManagedCredentials = true
+      } catch (rollbackError) {
+        console.warn(
+          '[claude-accounts] Failed to restore managed credentials during rollback:',
+          rollbackError
+        )
+      }
+      if (restoredManagedCredentials || !wroteManagedCredentials) {
+        try {
+          this.restoreManagedOauthSnapshot(managedAuthPath, previousManagedAuth)
+        } catch (rollbackError) {
+          console.warn(
+            '[claude-accounts] Failed to restore managed oauth metadata during rollback:',
+            rollbackError
+          )
+        }
+      }
+      if (restoredManagedCredentials) {
+        this.restoreClaudeSettings(previousSettings)
+        await this.runtimeAuth.forceMaterializeCurrentSelectionForRollback()
+      } else if (wroteManagedCredentials) {
+        this.store.updateSettings({ claudeManagedAccounts: reauthenticatedAccounts })
+      } else {
+        this.restoreClaudeSettings(previousSettings)
+      }
       throw error
     }
   }
@@ -412,19 +451,84 @@ export class ClaudeAccountService {
     managedAuthPath: string,
     captured: CapturedClaudeAuth
   ): Promise<void> {
+    await this.writeManagedCredentials(accountId, managedAuthPath, captured.credentialsJson)
+    await this.writeManagedOauthAccount(managedAuthPath, captured.oauthAccount)
+  }
+
+  private async writeManagedCredentials(
+    accountId: string,
+    managedAuthPath: string,
+    credentialsJson: string
+  ): Promise<void> {
     const trustedPath = this.assertManagedAuthPath(managedAuthPath)
     if (process.platform === 'darwin') {
-      await writeManagedClaudeKeychainCredentials(accountId, captured.credentialsJson)
+      await writeManagedClaudeKeychainCredentials(accountId, credentialsJson)
     } else {
-      writeFileAtomically(join(trustedPath, '.credentials.json'), captured.credentialsJson, {
+      writeFileAtomically(join(trustedPath, '.credentials.json'), credentialsJson, {
         mode: 0o600
       })
     }
+  }
+
+  private async writeManagedOauthAccount(
+    managedAuthPath: string,
+    oauthAccount: unknown
+  ): Promise<void> {
+    const trustedPath = this.assertManagedAuthPath(managedAuthPath)
     writeFileAtomically(
       join(trustedPath, 'oauth-account.json'),
-      `${JSON.stringify(captured.oauthAccount, null, 2)}\n`,
+      `${JSON.stringify(oauthAccount, null, 2)}\n`,
       { mode: 0o600 }
     )
+  }
+
+  private async readManagedAuthSnapshot(
+    accountId: string,
+    managedAuthPath: string
+  ): Promise<ManagedClaudeAuthSnapshot> {
+    const trustedPath = this.assertManagedAuthPath(managedAuthPath)
+    const credentialsPath = join(trustedPath, '.credentials.json')
+    const oauthPath = join(trustedPath, 'oauth-account.json')
+    return {
+      credentialsJson:
+        process.platform === 'darwin'
+          ? await readManagedClaudeKeychainCredentials(accountId)
+          : existsSync(credentialsPath)
+            ? readFileSync(credentialsPath, 'utf-8')
+            : null,
+      oauthAccountJson: existsSync(oauthPath) ? readFileSync(oauthPath, 'utf-8') : null
+    }
+  }
+
+  private async restoreManagedCredentialsSnapshot(
+    accountId: string,
+    managedAuthPath: string,
+    snapshot: ManagedClaudeAuthSnapshot
+  ): Promise<void> {
+    const trustedPath = this.assertManagedAuthPath(managedAuthPath)
+    const credentialsPath = join(trustedPath, '.credentials.json')
+    if (process.platform === 'darwin') {
+      await (snapshot.credentialsJson !== null
+        ? writeManagedClaudeKeychainCredentials(accountId, snapshot.credentialsJson)
+        : deleteManagedClaudeKeychainCredentials(accountId))
+    } else if (snapshot.credentialsJson !== null) {
+      writeFileAtomically(credentialsPath, snapshot.credentialsJson, { mode: 0o600 })
+    } else {
+      rmSync(credentialsPath, { force: true })
+    }
+  }
+
+  private restoreManagedOauthSnapshot(
+    managedAuthPath: string,
+    snapshot: ManagedClaudeAuthSnapshot
+  ): void {
+    const trustedPath = this.assertManagedAuthPath(managedAuthPath)
+    const oauthPath = join(trustedPath, 'oauth-account.json')
+    if (snapshot.oauthAccountJson !== null) {
+      writeFileAtomically(oauthPath, snapshot.oauthAccountJson, { mode: 0o600 })
+    } else {
+      rmSync(oauthPath, { force: true })
+    }
   }
 
   private createManagedAuthDir(accountId: string): string {

--- a/src/main/claude-accounts/service.ts
+++ b/src/main/claude-accounts/service.ts
@@ -28,6 +28,7 @@ import {
   deleteActiveClaudeKeychainCredentialsStrict,
   deleteManagedClaudeKeychainCredentials,
   readActiveClaudeKeychainCredentials,
+  readActiveClaudeKeychainCredentialsStrict,
   writeActiveClaudeKeychainCredentials,
   writeManagedClaudeKeychainCredentials
 } from './keychain'
@@ -286,7 +287,7 @@ export class ClaudeAccountService {
         STATUS_TIMEOUT_MS,
         { allowFailure: true }
       )
-      return await this.captureAuthFromConfigDir(tempConfigDir, status)
+      return await this.captureAuthFromConfigDir(tempConfigDir, status, previousLegacyKeychain)
     } finally {
       if (process.platform === 'darwin') {
         try {
@@ -308,9 +309,10 @@ export class ClaudeAccountService {
 
   private async captureAuthFromConfigDir(
     configDir: string,
-    statusOutput: string
+    statusOutput: string,
+    previousLegacyKeychain: string | null
   ): Promise<CapturedClaudeAuth> {
-    const credentialsJson = await this.readCapturedCredentials(configDir)
+    const credentialsJson = await this.readCapturedCredentials(configDir, previousLegacyKeychain)
     if (!credentialsJson) {
       throw new Error('Claude login completed, but no OAuth credentials were captured.')
     }
@@ -319,9 +321,17 @@ export class ClaudeAccountService {
     return { credentialsJson, oauthAccount, identity }
   }
 
-  private async readCapturedCredentials(configDir: string): Promise<string | null> {
+  private async readCapturedCredentials(
+    configDir: string,
+    previousLegacyKeychain: string | null
+  ): Promise<string | null> {
     if (process.platform === 'darwin') {
-      return readActiveClaudeKeychainCredentials(configDir)
+      const scopedCredentialsJson = await readActiveClaudeKeychainCredentialsStrict(configDir)
+      if (scopedCredentialsJson) {
+        return scopedCredentialsJson
+      }
+      const legacyCredentialsJson = await readActiveClaudeKeychainCredentialsStrict()
+      return legacyCredentialsJson === previousLegacyKeychain ? null : legacyCredentialsJson
     }
     const credentialsPath = join(configDir, '.credentials.json')
     return existsSync(credentialsPath) ? readFileSync(credentialsPath, 'utf-8') : null

--- a/src/main/rate-limits/claude-fetcher.test.ts
+++ b/src/main/rate-limits/claude-fetcher.test.ts
@@ -1,21 +1,33 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { fetchClaudeRateLimits } from './claude-fetcher'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fetchClaudeRateLimits, fetchManagedAccountUsage } from './claude-fetcher'
 import { fetchViaPty } from './claude-pty'
-import { readActiveClaudeKeychainCredentialsStrict } from '../claude-accounts/keychain'
+import {
+  readActiveClaudeKeychainCredentialsStrict,
+  readManagedClaudeKeychainCredentials
+} from '../claude-accounts/keychain'
 import type { ClaudeRuntimeAuthPreparation } from '../claude-accounts/runtime-auth-service'
 
-const { netFetchMock, readFileMock, resolveProxyMock, setProxyMock } = vi.hoisted(() => ({
-  netFetchMock: vi.fn(),
-  readFileMock: vi.fn(),
-  resolveProxyMock: vi.fn(),
-  setProxyMock: vi.fn()
-}))
+const { netFetchMock, readFileMock, resolveProxyMock, setProxyMock, appGetPathMock } = vi.hoisted(
+  () => ({
+    netFetchMock: vi.fn(),
+    readFileMock: vi.fn(),
+    resolveProxyMock: vi.fn(),
+    setProxyMock: vi.fn(),
+    appGetPathMock: vi.fn()
+  })
+)
 
 vi.mock('node:fs/promises', () => ({
   readFile: readFileMock
 }))
 
 vi.mock('electron', () => ({
+  app: {
+    getPath: appGetPathMock
+  },
   net: {
     fetch: netFetchMock
   },
@@ -33,7 +45,8 @@ vi.mock('./claude-pty', () => ({
 
 vi.mock('../claude-accounts/keychain', () => ({
   readActiveClaudeKeychainCredentials: vi.fn(),
-  readActiveClaudeKeychainCredentialsStrict: vi.fn()
+  readActiveClaudeKeychainCredentialsStrict: vi.fn(),
+  readManagedClaudeKeychainCredentials: vi.fn()
 }))
 
 const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
@@ -46,11 +59,16 @@ function setPlatform(platform: NodeJS.Platform): void {
 }
 
 describe('fetchClaudeRateLimits', () => {
+  let tempDir: string | null = null
+
   beforeEach(() => {
     setPlatform('darwin')
+    tempDir = null
     vi.clearAllMocks()
     readFileMock.mockRejectedValue(new Error('missing file'))
     vi.mocked(readActiveClaudeKeychainCredentialsStrict).mockResolvedValue(null)
+    vi.mocked(readManagedClaudeKeychainCredentials).mockResolvedValue(null)
+    appGetPathMock.mockReturnValue('/tmp/orca-claude-fetcher-test')
     resolveProxyMock.mockResolvedValue('DIRECT')
     netFetchMock.mockResolvedValue(
       new Response(
@@ -74,6 +92,9 @@ describe('fetchClaudeRateLimits', () => {
   afterEach(() => {
     if (originalPlatform) {
       Object.defineProperty(process, 'platform', originalPlatform)
+    }
+    if (tempDir) {
+      rmSync(tempDir, { recursive: true, force: true })
     }
   })
 
@@ -219,5 +240,35 @@ describe('fetchClaudeRateLimits', () => {
     expect(netFetchMock).not.toHaveBeenCalled()
     expect(readFileMock).not.toHaveBeenCalled()
     expect(fetchViaPty).toHaveBeenCalledWith({ authPreparation })
+  })
+
+  it('does not read inactive managed credentials from unowned auth paths', async () => {
+    setPlatform('linux')
+    tempDir = mkdtempSync(join(tmpdir(), 'orca-claude-fetcher-'))
+    appGetPathMock.mockReturnValue(tempDir)
+    const unownedAuthPath = join(tempDir, 'unowned', 'auth')
+    mkdirSync(unownedAuthPath, { recursive: true })
+    writeFileSync(join(unownedAuthPath, '.orca-managed-claude-auth'), 'account-1\n', 'utf-8')
+    writeFileSync(
+      join(unownedAuthPath, '.credentials.json'),
+      JSON.stringify({
+        claudeAiOauth: {
+          accessToken: 'unowned-token',
+          expiresAt: Date.now() + 60_000
+        }
+      }),
+      'utf-8'
+    )
+
+    await expect(
+      fetchManagedAccountUsage({ id: 'account-1', managedAuthPath: unownedAuthPath })
+    ).resolves.toMatchObject({
+      provider: 'claude',
+      status: 'error',
+      error: 'No credentials'
+    })
+
+    expect(netFetchMock).not.toHaveBeenCalled()
+    expect(readFileMock).not.toHaveBeenCalled()
   })
 })

--- a/src/main/rate-limits/claude-fetcher.test.ts
+++ b/src/main/rate-limits/claude-fetcher.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { fetchClaudeRateLimits } from './claude-fetcher'
+import { readActiveClaudeKeychainCredentials } from '../claude-accounts/keychain'
+import type { ClaudeRuntimeAuthPreparation } from '../claude-accounts/runtime-auth-service'
+
+const { netFetchMock, resolveProxyMock, setProxyMock } = vi.hoisted(() => ({
+  netFetchMock: vi.fn(),
+  resolveProxyMock: vi.fn(),
+  setProxyMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  net: {
+    fetch: netFetchMock
+  },
+  session: {
+    defaultSession: {
+      resolveProxy: resolveProxyMock,
+      setProxy: setProxyMock
+    }
+  }
+}))
+
+vi.mock('./claude-pty', () => ({
+  fetchViaPty: vi.fn()
+}))
+
+vi.mock('../claude-accounts/keychain', () => ({
+  readActiveClaudeKeychainCredentials: vi.fn()
+}))
+
+const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', {
+    configurable: true,
+    value: platform
+  })
+}
+
+describe('fetchClaudeRateLimits', () => {
+  beforeEach(() => {
+    setPlatform('darwin')
+    vi.clearAllMocks()
+    resolveProxyMock.mockResolvedValue('DIRECT')
+    netFetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          five_hour: { utilization: 12 },
+          seven_day: { utilization: 34 }
+        }),
+        { status: 200 }
+      )
+    )
+  })
+
+  afterEach(() => {
+    if (originalPlatform) {
+      Object.defineProperty(process, 'platform', originalPlatform)
+    }
+  })
+
+  it('reads scoped default-config Keychain credentials for OAuth usage fetches', async () => {
+    const configDir = '/Users/test/.claude'
+    const authPreparation: ClaudeRuntimeAuthPreparation = {
+      configDir,
+      envPatch: {},
+      stripAuthEnv: false,
+      provenance: 'system'
+    }
+    vi.mocked(readActiveClaudeKeychainCredentials).mockResolvedValue(
+      JSON.stringify({
+        claudeAiOauth: {
+          accessToken: 'oauth-token',
+          expiresAt: Date.now() + 60_000
+        }
+      })
+    )
+
+    await expect(fetchClaudeRateLimits({ authPreparation })).resolves.toMatchObject({
+      provider: 'claude',
+      status: 'ok',
+      session: { usedPercent: 12 },
+      weekly: { usedPercent: 34 }
+    })
+
+    expect(readActiveClaudeKeychainCredentials).toHaveBeenCalledWith(configDir)
+    expect(netFetchMock).toHaveBeenCalledWith(
+      'https://api.anthropic.com/api/oauth/usage',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer oauth-token'
+        })
+      })
+    )
+  })
+})

--- a/src/main/rate-limits/claude-fetcher.test.ts
+++ b/src/main/rate-limits/claude-fetcher.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { fetchClaudeRateLimits } from './claude-fetcher'
-import { readActiveClaudeKeychainCredentials } from '../claude-accounts/keychain'
+import { readActiveClaudeKeychainCredentialsStrict } from '../claude-accounts/keychain'
 import type { ClaudeRuntimeAuthPreparation } from '../claude-accounts/runtime-auth-service'
 
 const { netFetchMock, readFileMock, resolveProxyMock, setProxyMock } = vi.hoisted(() => ({
@@ -31,7 +31,8 @@ vi.mock('./claude-pty', () => ({
 }))
 
 vi.mock('../claude-accounts/keychain', () => ({
-  readActiveClaudeKeychainCredentials: vi.fn()
+  readActiveClaudeKeychainCredentials: vi.fn(),
+  readActiveClaudeKeychainCredentialsStrict: vi.fn()
 }))
 
 const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
@@ -48,6 +49,7 @@ describe('fetchClaudeRateLimits', () => {
     setPlatform('darwin')
     vi.clearAllMocks()
     readFileMock.mockRejectedValue(new Error('missing file'))
+    vi.mocked(readActiveClaudeKeychainCredentialsStrict).mockResolvedValue(null)
     resolveProxyMock.mockResolvedValue('DIRECT')
     netFetchMock.mockResolvedValue(
       new Response(
@@ -74,7 +76,7 @@ describe('fetchClaudeRateLimits', () => {
       stripAuthEnv: false,
       provenance: 'system'
     }
-    vi.mocked(readActiveClaudeKeychainCredentials).mockResolvedValue(
+    vi.mocked(readActiveClaudeKeychainCredentialsStrict).mockResolvedValueOnce(
       JSON.stringify({
         claudeAiOauth: {
           accessToken: 'oauth-token',
@@ -90,7 +92,7 @@ describe('fetchClaudeRateLimits', () => {
       weekly: { usedPercent: 34 }
     })
 
-    expect(readActiveClaudeKeychainCredentials).toHaveBeenCalledWith(configDir)
+    expect(readActiveClaudeKeychainCredentialsStrict).toHaveBeenCalledWith(configDir)
     expect(netFetchMock).toHaveBeenCalledWith(
       'https://api.anthropic.com/api/oauth/usage',
       expect.objectContaining({
@@ -109,7 +111,9 @@ describe('fetchClaudeRateLimits', () => {
       stripAuthEnv: false,
       provenance: 'system'
     }
-    vi.mocked(readActiveClaudeKeychainCredentials).mockRejectedValue(new Error('Keychain locked'))
+    vi.mocked(readActiveClaudeKeychainCredentialsStrict).mockRejectedValue(
+      new Error('Keychain locked')
+    )
     readFileMock.mockResolvedValue(
       JSON.stringify({
         claudeAiOauth: {
@@ -130,6 +134,42 @@ describe('fetchClaudeRateLimits', () => {
       expect.objectContaining({
         headers: expect.objectContaining({
           Authorization: 'Bearer file-oauth-token'
+        })
+      })
+    )
+  })
+
+  it('falls back to legacy Keychain when scoped credentials are unusable', async () => {
+    const configDir = '/Users/test/.claude'
+    const authPreparation: ClaudeRuntimeAuthPreparation = {
+      configDir,
+      envPatch: {},
+      stripAuthEnv: false,
+      provenance: 'system'
+    }
+    vi.mocked(readActiveClaudeKeychainCredentialsStrict)
+      .mockResolvedValueOnce('{not-json')
+      .mockResolvedValueOnce(
+        JSON.stringify({
+          claudeAiOauth: {
+            accessToken: 'legacy-oauth-token',
+            expiresAt: Date.now() + 60_000
+          }
+        })
+      )
+
+    await expect(fetchClaudeRateLimits({ authPreparation })).resolves.toMatchObject({
+      provider: 'claude',
+      status: 'ok'
+    })
+
+    expect(readActiveClaudeKeychainCredentialsStrict).toHaveBeenNthCalledWith(1, configDir)
+    expect(readActiveClaudeKeychainCredentialsStrict).toHaveBeenNthCalledWith(2, undefined)
+    expect(netFetchMock).toHaveBeenCalledWith(
+      'https://api.anthropic.com/api/oauth/usage',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer legacy-oauth-token'
         })
       })
     )

--- a/src/main/rate-limits/claude-fetcher.test.ts
+++ b/src/main/rate-limits/claude-fetcher.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { fetchClaudeRateLimits } from './claude-fetcher'
+import { fetchViaPty } from './claude-pty'
 import { readActiveClaudeKeychainCredentialsStrict } from '../claude-accounts/keychain'
 import type { ClaudeRuntimeAuthPreparation } from '../claude-accounts/runtime-auth-service'
 
@@ -60,6 +61,14 @@ describe('fetchClaudeRateLimits', () => {
         { status: 200 }
       )
     )
+    vi.mocked(fetchViaPty).mockResolvedValue({
+      provider: 'claude',
+      session: { usedPercent: 56, windowMinutes: 300, resetsAt: null, resetDescription: null },
+      weekly: null,
+      updatedAt: 1,
+      error: null,
+      status: 'ok'
+    })
   })
 
   afterEach(() => {
@@ -80,6 +89,14 @@ describe('fetchClaudeRateLimits', () => {
       JSON.stringify({
         claudeAiOauth: {
           accessToken: 'oauth-token',
+          expiresAt: Date.now() + 60_000
+        }
+      })
+    )
+    readFileMock.mockResolvedValue(
+      JSON.stringify({
+        claudeAiOauth: {
+          accessToken: 'file-oauth-token',
           expiresAt: Date.now() + 60_000
         }
       })
@@ -173,5 +190,34 @@ describe('fetchClaudeRateLimits', () => {
         })
       })
     )
+  })
+
+  it('tries PTY usage when OAuth credentials are expired but refreshable', async () => {
+    const configDir = '/Users/test/.claude'
+    const authPreparation: ClaudeRuntimeAuthPreparation = {
+      configDir,
+      envPatch: {},
+      stripAuthEnv: false,
+      provenance: 'system'
+    }
+    vi.mocked(readActiveClaudeKeychainCredentialsStrict).mockResolvedValueOnce(
+      JSON.stringify({
+        claudeAiOauth: {
+          accessToken: 'expired-oauth-token',
+          refreshToken: 'refresh-token',
+          expiresAt: Date.now() - 60_000
+        }
+      })
+    )
+
+    await expect(fetchClaudeRateLimits({ authPreparation })).resolves.toMatchObject({
+      provider: 'claude',
+      status: 'ok',
+      session: { usedPercent: 56 }
+    })
+
+    expect(netFetchMock).not.toHaveBeenCalled()
+    expect(readFileMock).not.toHaveBeenCalled()
+    expect(fetchViaPty).toHaveBeenCalledWith({ authPreparation })
   })
 })

--- a/src/main/rate-limits/claude-fetcher.test.ts
+++ b/src/main/rate-limits/claude-fetcher.test.ts
@@ -3,10 +3,15 @@ import { fetchClaudeRateLimits } from './claude-fetcher'
 import { readActiveClaudeKeychainCredentials } from '../claude-accounts/keychain'
 import type { ClaudeRuntimeAuthPreparation } from '../claude-accounts/runtime-auth-service'
 
-const { netFetchMock, resolveProxyMock, setProxyMock } = vi.hoisted(() => ({
+const { netFetchMock, readFileMock, resolveProxyMock, setProxyMock } = vi.hoisted(() => ({
   netFetchMock: vi.fn(),
+  readFileMock: vi.fn(),
   resolveProxyMock: vi.fn(),
   setProxyMock: vi.fn()
+}))
+
+vi.mock('node:fs/promises', () => ({
+  readFile: readFileMock
 }))
 
 vi.mock('electron', () => ({
@@ -42,6 +47,7 @@ describe('fetchClaudeRateLimits', () => {
   beforeEach(() => {
     setPlatform('darwin')
     vi.clearAllMocks()
+    readFileMock.mockRejectedValue(new Error('missing file'))
     resolveProxyMock.mockResolvedValue('DIRECT')
     netFetchMock.mockResolvedValue(
       new Response(
@@ -90,6 +96,40 @@ describe('fetchClaudeRateLimits', () => {
       expect.objectContaining({
         headers: expect.objectContaining({
           Authorization: 'Bearer oauth-token'
+        })
+      })
+    )
+  })
+
+  it('falls back to the credentials file when Keychain access fails', async () => {
+    const configDir = '/Users/test/.claude'
+    const authPreparation: ClaudeRuntimeAuthPreparation = {
+      configDir,
+      envPatch: {},
+      stripAuthEnv: false,
+      provenance: 'system'
+    }
+    vi.mocked(readActiveClaudeKeychainCredentials).mockRejectedValue(new Error('Keychain locked'))
+    readFileMock.mockResolvedValue(
+      JSON.stringify({
+        claudeAiOauth: {
+          accessToken: 'file-oauth-token',
+          expiresAt: Date.now() + 60_000
+        }
+      })
+    )
+
+    await expect(fetchClaudeRateLimits({ authPreparation })).resolves.toMatchObject({
+      provider: 'claude',
+      status: 'ok'
+    })
+
+    expect(readFileMock).toHaveBeenCalledWith('/Users/test/.claude/.credentials.json', 'utf-8')
+    expect(netFetchMock).toHaveBeenCalledWith(
+      'https://api.anthropic.com/api/oauth/usage',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer file-oauth-token'
         })
       })
     )

--- a/src/main/rate-limits/claude-fetcher.ts
+++ b/src/main/rate-limits/claude-fetcher.ts
@@ -7,6 +7,7 @@ import { fetchViaPty } from './claude-pty'
 import type { ClaudeRuntimeAuthPreparation } from '../claude-accounts/runtime-auth-service'
 import {
   readActiveClaudeKeychainCredentials,
+  readActiveClaudeKeychainCredentialsStrict,
   readManagedClaudeKeychainCredentials
 } from '../claude-accounts/keychain'
 
@@ -107,8 +108,29 @@ async function readFromKeychain(configDir?: string): Promise<string | null> {
     return null
   }
 
+  if (configDir) {
+    const scopedToken = await readTokenFromStrictKeychain(configDir)
+    if (scopedToken) {
+      return scopedToken
+    }
+    const legacyToken = await readTokenFromStrictKeychain()
+    if (legacyToken) {
+      return legacyToken
+    }
+    return null
+  }
+
   try {
     const credentials = await readActiveClaudeKeychainCredentials(configDir)
+    return credentials ? parseOAuthTokenFromCredentialsJson(credentials) : null
+  } catch {
+    return null
+  }
+}
+
+async function readTokenFromStrictKeychain(configDir?: string): Promise<string | null> {
+  try {
+    const credentials = await readActiveClaudeKeychainCredentialsStrict(configDir)
     return credentials ? parseOAuthTokenFromCredentialsJson(credentials) : null
   } catch {
     return null

--- a/src/main/rate-limits/claude-fetcher.ts
+++ b/src/main/rate-limits/claude-fetcher.ts
@@ -1,12 +1,14 @@
 import { readFile } from 'node:fs/promises'
-import { execFile } from 'node:child_process'
 import { homedir } from 'node:os'
 import path from 'node:path'
 import { net, session } from 'electron'
 import type { ProviderRateLimits, RateLimitWindow } from '../../shared/rate-limit-types'
 import { fetchViaPty } from './claude-pty'
 import type { ClaudeRuntimeAuthPreparation } from '../claude-accounts/runtime-auth-service'
-import { readManagedClaudeKeychainCredentials } from '../claude-accounts/keychain'
+import {
+  readActiveClaudeKeychainCredentials,
+  readManagedClaudeKeychainCredentials
+} from '../claude-accounts/keychain'
 
 const OAUTH_USAGE_URL = 'https://api.anthropic.com/api/oauth/usage'
 const OAUTH_BETA_HEADER = 'oauth-2025-04-20'
@@ -97,36 +99,16 @@ function parseOAuthTokenFromCredentialsJson(raw: string): string | null {
 
 /**
  * Read OAuth token from macOS Keychain.
- * Why: Claude Code v2.x+ stores OAuth credentials in the macOS Keychain
- * under service "Claude Code-credentials". This is the standard location
- * for Claude Max/Pro OAuth tokens. Only returns a token if the keychain
- * entry has a `claudeAiOauth.accessToken` — API key users won't have this.
+ * Why: Claude Code 2.1+ scopes OAuth Keychain services by CLAUDE_CONFIG_DIR;
+ * older builds used the legacy unsuffixed service. The shared reader handles both.
  */
-async function readFromKeychain(): Promise<string | null> {
+async function readFromKeychain(configDir?: string): Promise<string | null> {
   if (process.platform !== 'darwin') {
     return null
   }
 
-  return new Promise<string | null>((resolve) => {
-    const user = process.env.USER ?? ''
-    if (!user) {
-      resolve(null)
-      return
-    }
-
-    execFile(
-      'security',
-      ['find-generic-password', '-s', 'Claude Code-credentials', '-a', user, '-w'],
-      { timeout: 3_000 },
-      (err, stdout) => {
-        if (err || !stdout.trim()) {
-          resolve(null)
-          return
-        }
-        resolve(parseOAuthTokenFromCredentialsJson(stdout.trim()))
-      }
-    )
-  })
+  const credentials = await readActiveClaudeKeychainCredentials(configDir)
+  return credentials ? parseOAuthTokenFromCredentialsJson(credentials) : null
 }
 
 /**
@@ -163,7 +145,7 @@ async function readFromCredentialsFile(configDir?: string): Promise<string | nul
  */
 async function readOAuthCredentials(configDir?: string): Promise<string | null> {
   // 1. macOS Keychain (Claude Max/Pro OAuth)
-  const fromKeychain = await readFromKeychain()
+  const fromKeychain = await readFromKeychain(configDir)
   if (fromKeychain) {
     return fromKeychain
   }

--- a/src/main/rate-limits/claude-fetcher.ts
+++ b/src/main/rate-limits/claude-fetcher.ts
@@ -107,8 +107,12 @@ async function readFromKeychain(configDir?: string): Promise<string | null> {
     return null
   }
 
-  const credentials = await readActiveClaudeKeychainCredentials(configDir)
-  return credentials ? parseOAuthTokenFromCredentialsJson(credentials) : null
+  try {
+    const credentials = await readActiveClaudeKeychainCredentials(configDir)
+    return credentials ? parseOAuthTokenFromCredentialsJson(credentials) : null
+  } catch {
+    return null
+  }
 }
 
 /**

--- a/src/main/rate-limits/claude-fetcher.ts
+++ b/src/main/rate-limits/claude-fetcher.ts
@@ -64,37 +64,40 @@ async function ensureProxyFromEnv(): Promise<void> {
 // Credential reading — tries multiple sources for an OAuth bearer token
 // ---------------------------------------------------------------------------
 
-type ClaudeCredentials = {
-  claudeAiOauth?: {
-    accessToken?: string
-    refreshToken?: string
-    expiresAt?: number // unix ms
-  }
-}
-
 type KeychainCredentials = {
   claudeAiOauth?: {
     accessToken?: string
+    refreshToken?: string
     expiresAt?: number
   }
 }
 
+type OAuthCredentialReadResult = {
+  token: string | null
+  hasRefreshableCredentials: boolean
+}
+
 // Why: factored out so both the active-account Keychain reader and the
 // managed-account reader share the same JSON parsing + expiry check.
-function parseOAuthTokenFromCredentialsJson(raw: string): string | null {
+function parseOAuthCredentialsJson(raw: string): OAuthCredentialReadResult {
   try {
     const parsed = JSON.parse(raw) as KeychainCredentials
-    const token = parsed?.claudeAiOauth?.accessToken
+    const oauth = parsed?.claudeAiOauth
+    const token = oauth?.accessToken
     if (!token || typeof token !== 'string') {
-      return null
+      return { token: null, hasRefreshableCredentials: false }
     }
-    const expiresAt = parsed.claudeAiOauth?.expiresAt
+    const refreshToken = oauth?.refreshToken
+    const expiresAt = oauth?.expiresAt
     if (typeof expiresAt === 'number' && expiresAt < Date.now()) {
-      return null
+      return {
+        token: null,
+        hasRefreshableCredentials: typeof refreshToken === 'string' && refreshToken.trim() !== ''
+      }
     }
-    return token
+    return { token, hasRefreshableCredentials: true }
   } catch {
-    return null
+    return { token: null, hasRefreshableCredentials: false }
   }
 }
 
@@ -103,37 +106,50 @@ function parseOAuthTokenFromCredentialsJson(raw: string): string | null {
  * Why: Claude Code 2.1+ scopes OAuth Keychain services by CLAUDE_CONFIG_DIR;
  * older builds used the legacy unsuffixed service. The shared reader handles both.
  */
-async function readFromKeychain(configDir?: string): Promise<string | null> {
+async function readFromKeychain(configDir?: string): Promise<OAuthCredentialReadResult> {
   if (process.platform !== 'darwin') {
-    return null
+    return { token: null, hasRefreshableCredentials: false }
   }
 
   if (configDir) {
-    const scopedToken = await readTokenFromStrictKeychain(configDir)
-    if (scopedToken) {
-      return scopedToken
+    const scopedCredentials = await readCredentialsFromStrictKeychain(configDir)
+    if (scopedCredentials.token) {
+      return scopedCredentials
     }
-    const legacyToken = await readTokenFromStrictKeychain()
-    if (legacyToken) {
-      return legacyToken
+    if (scopedCredentials.hasRefreshableCredentials) {
+      return scopedCredentials
     }
-    return null
+    const legacyCredentials = await readCredentialsFromStrictKeychain()
+    if (legacyCredentials.token) {
+      return legacyCredentials
+    }
+    return {
+      token: null,
+      hasRefreshableCredentials:
+        scopedCredentials.hasRefreshableCredentials || legacyCredentials.hasRefreshableCredentials
+    }
   }
 
   try {
     const credentials = await readActiveClaudeKeychainCredentials(configDir)
-    return credentials ? parseOAuthTokenFromCredentialsJson(credentials) : null
+    return credentials
+      ? parseOAuthCredentialsJson(credentials)
+      : { token: null, hasRefreshableCredentials: false }
   } catch {
-    return null
+    return { token: null, hasRefreshableCredentials: false }
   }
 }
 
-async function readTokenFromStrictKeychain(configDir?: string): Promise<string | null> {
+async function readCredentialsFromStrictKeychain(
+  configDir?: string
+): Promise<OAuthCredentialReadResult> {
   try {
     const credentials = await readActiveClaudeKeychainCredentialsStrict(configDir)
-    return credentials ? parseOAuthTokenFromCredentialsJson(credentials) : null
+    return credentials
+      ? parseOAuthCredentialsJson(credentials)
+      : { token: null, hasRefreshableCredentials: false }
   } catch {
-    return null
+    return { token: null, hasRefreshableCredentials: false }
   }
 }
 
@@ -142,24 +158,13 @@ async function readTokenFromStrictKeychain(configDir?: string): Promise<string |
  * Why: older Claude CLI versions store credentials in this plain JSON
  * file. We keep it as a fallback for compatibility.
  */
-async function readFromCredentialsFile(configDir?: string): Promise<string | null> {
+async function readFromCredentialsFile(configDir?: string): Promise<OAuthCredentialReadResult> {
   const credPath = path.join(configDir ?? path.join(homedir(), '.claude'), '.credentials.json')
   try {
     const raw = await readFile(credPath, 'utf-8')
-    const parsed = JSON.parse(raw) as ClaudeCredentials
-    const token = parsed?.claudeAiOauth?.accessToken
-    if (!token || typeof token !== 'string') {
-      return null
-    }
-
-    const expiresAt = parsed.claudeAiOauth?.expiresAt
-    if (typeof expiresAt === 'number' && expiresAt < Date.now()) {
-      return null
-    }
-
-    return token
+    return parseOAuthCredentialsJson(raw)
   } catch {
-    return null
+    return { token: null, hasRefreshableCredentials: false }
   }
 }
 
@@ -169,20 +174,27 @@ async function readFromCredentialsFile(configDir?: string): Promise<string | nul
  * here — those are API keys which return 401 on the OAuth usage endpoint.
  * API-key users are served by the PTY fallback instead.
  */
-async function readOAuthCredentials(configDir?: string): Promise<string | null> {
+async function readOAuthCredentials(configDir?: string): Promise<OAuthCredentialReadResult> {
   // 1. macOS Keychain (Claude Max/Pro OAuth)
   const fromKeychain = await readFromKeychain(configDir)
-  if (fromKeychain) {
+  if (fromKeychain.token) {
+    return fromKeychain
+  }
+  if (fromKeychain.hasRefreshableCredentials) {
     return fromKeychain
   }
 
   // 2. Legacy credentials file
   const fromFile = await readFromCredentialsFile(configDir)
-  if (fromFile) {
+  if (fromFile.token) {
     return fromFile
   }
 
-  return null
+  return {
+    token: null,
+    hasRefreshableCredentials:
+      fromKeychain.hasRefreshableCredentials || fromFile.hasRefreshableCredentials
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -282,19 +294,20 @@ export async function fetchClaudeRateLimits(options?: {
   authPreparation?: ClaudeRuntimeAuthPreparation
 }): Promise<ProviderRateLimits> {
   // Path A: try OAuth API if we have a genuine OAuth token
-  const oauthToken = await readOAuthCredentials(options?.authPreparation?.configDir)
-  if (oauthToken) {
+  const oauthCredentials = await readOAuthCredentials(options?.authPreparation?.configDir)
+  if (oauthCredentials.token) {
     try {
-      return await fetchViaOAuth(oauthToken)
+      return await fetchViaOAuth(oauthCredentials.token)
     } catch {
       // OAuth API failed — fall through to PTY scraping as a backup
       // for subscription users whose token may still be valid for the CLI.
     }
+  }
 
-    // Path B: PTY fallback — only for subscription plan users (Max/Pro)
-    // whose OAuth token we found but the API call failed. The CLI's
-    // `/usage` command is subscription-only, so there's no point
-    // attempting PTY for API key users.
+  // Path B: PTY fallback — only for subscription plan users (Max/Pro)
+  // whose OAuth credentials exist. The CLI can refresh expired OAuth tokens,
+  // so an expired access token should not be treated like API-key billing.
+  if (oauthCredentials.token || oauthCredentials.hasRefreshableCredentials) {
     try {
       return await fetchViaPty({ authPreparation: options?.authPreparation })
     } catch (err) {
@@ -341,11 +354,11 @@ async function readManagedOAuthToken(account: InactiveClaudeAccountInfo): Promis
     if (process.platform === 'darwin') {
       const raw = await readManagedClaudeKeychainCredentials(account.id)
       if (raw) {
-        return parseOAuthTokenFromCredentialsJson(raw)
+        return parseOAuthCredentialsJson(raw).token
       }
       return null
     }
-    return await readFromCredentialsFile(account.managedAuthPath)
+    return (await readFromCredentialsFile(account.managedAuthPath)).token
   } catch {
     return null
   }

--- a/src/main/rate-limits/claude-fetcher.ts
+++ b/src/main/rate-limits/claude-fetcher.ts
@@ -256,9 +256,7 @@ export async function fetchClaudeRateLimits(options?: {
   authPreparation?: ClaudeRuntimeAuthPreparation
 }): Promise<ProviderRateLimits> {
   // Path A: try OAuth API if we have a genuine OAuth token
-  const oauthToken = await readOAuthCredentials(
-    options?.authPreparation?.envPatch.CLAUDE_CONFIG_DIR
-  )
+  const oauthToken = await readOAuthCredentials(options?.authPreparation?.configDir)
   if (oauthToken) {
     try {
       return await fetchViaOAuth(oauthToken)

--- a/src/main/rate-limits/claude-fetcher.ts
+++ b/src/main/rate-limits/claude-fetcher.ts
@@ -10,6 +10,10 @@ import {
   readActiveClaudeKeychainCredentialsStrict,
   readManagedClaudeKeychainCredentials
 } from '../claude-accounts/keychain'
+import {
+  readClaudeManagedAuthFile,
+  resolveOwnedClaudeManagedAuthPath
+} from '../claude-accounts/managed-auth-path'
 
 const OAUTH_USAGE_URL = 'https://api.anthropic.com/api/oauth/usage'
 const OAUTH_BETA_HEADER = 'oauth-2025-04-20'
@@ -351,6 +355,12 @@ export type InactiveClaudeAccountInfo = {
 // Using ClaudeRuntimeAuthService would overwrite the active account's auth.
 async function readManagedOAuthToken(account: InactiveClaudeAccountInfo): Promise<string | null> {
   try {
+    const managedAuthPath = resolveOwnedClaudeManagedAuthPath(account.id, account.managedAuthPath, {
+      adoptLegacyMarker: true
+    })
+    if (!managedAuthPath) {
+      return null
+    }
     if (process.platform === 'darwin') {
       const raw = await readManagedClaudeKeychainCredentials(account.id)
       if (raw) {
@@ -358,7 +368,8 @@ async function readManagedOAuthToken(account: InactiveClaudeAccountInfo): Promis
       }
       return null
     }
-    return (await readFromCredentialsFile(account.managedAuthPath)).token
+    const raw = readClaudeManagedAuthFile(managedAuthPath, '.credentials.json')
+    return raw ? parseOAuthCredentialsJson(raw).token : null
   } catch {
     return null
   }

--- a/src/main/rate-limits/service.test.ts
+++ b/src/main/rate-limits/service.test.ts
@@ -5,13 +5,14 @@ Keeping them in one file makes the ordering contract reviewable as a unit. */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ProviderRateLimits } from '../../shared/rate-limit-types'
 import { RateLimitService } from './service'
-import { fetchClaudeRateLimits } from './claude-fetcher'
+import { fetchClaudeRateLimits, fetchManagedAccountUsage } from './claude-fetcher'
 import { fetchCodexRateLimits } from './codex-fetcher'
 import { fetchGeminiRateLimits } from './gemini-usage-fetcher'
 import { fetchOpenCodeGoRateLimits } from './opencode-go-usage-fetcher'
 
 vi.mock('./claude-fetcher', () => ({
-  fetchClaudeRateLimits: vi.fn()
+  fetchClaudeRateLimits: vi.fn(),
+  fetchManagedAccountUsage: vi.fn()
 }))
 
 vi.mock('./codex-fetcher', () => ({
@@ -370,5 +371,74 @@ describe('RateLimitService', () => {
     expect(state.opencodeGo?.status).toBe('error')
     expect(state.opencodeGo?.session).toBeNull()
     expect(state.opencodeGo?.error).toBe('No workspace ID found')
+  })
+
+  it('does not recache an inactive Claude account removed during fetch-on-open', async () => {
+    const service = new RateLimitService()
+    const accountFetch = deferred<ProviderRateLimits>()
+    let inactiveAccounts = [{ id: 'account-1', managedAuthPath: '/tmp/account-1/auth' }]
+    service.setInactiveClaudeAccountsResolver(() => inactiveAccounts)
+    service.setClaudeAuthPreparationResolver(async () => ({
+      configDir: '/tmp/.claude',
+      envPatch: {},
+      stripAuthEnv: false,
+      provenance: 'system'
+    }))
+    vi.mocked(fetchClaudeRateLimits).mockResolvedValue(okProvider('claude', 7))
+    await service.refresh()
+    vi.mocked(fetchManagedAccountUsage).mockReturnValueOnce(accountFetch.promise)
+
+    const fetchOnOpen = service.fetchInactiveClaudeAccountsOnOpen()
+    await Promise.resolve()
+    expect(service.getState().inactiveClaudeAccounts).toEqual([
+      { accountId: 'account-1', claude: null, updatedAt: 0, isFetching: true }
+    ])
+
+    service.evictInactiveClaudeCache('account-1')
+    inactiveAccounts = [{ id: 'account-1', managedAuthPath: '/tmp/account-1/auth' }]
+    await service.refreshForClaudeAccountChange('account-1')
+    expect(service.getState().inactiveClaudeAccounts[0]?.accountId).toBe('account-1')
+
+    inactiveAccounts = []
+    service.evictInactiveClaudeCache('account-1')
+    accountFetch.resolve(okProvider('claude', 42))
+    await fetchOnOpen
+
+    expect(service.getState().inactiveClaudeAccounts).toEqual([])
+  })
+
+  it('does not overwrite inactive Claude cache from a stale same-id fetch', async () => {
+    const service = new RateLimitService()
+    const accountFetch = deferred<ProviderRateLimits>()
+    service.setInactiveClaudeAccountsResolver(() => [
+      { id: 'account-1', managedAuthPath: '/tmp/account-1/auth' }
+    ])
+    service.setClaudeAuthPreparationResolver(async () => ({
+      configDir: '/tmp/.claude',
+      envPatch: {},
+      stripAuthEnv: false,
+      provenance: 'system'
+    }))
+    vi.mocked(fetchClaudeRateLimits).mockResolvedValue(okProvider('claude', 7))
+    await service.refresh()
+    vi.mocked(fetchManagedAccountUsage).mockReturnValueOnce(accountFetch.promise)
+
+    const fetchOnOpen = service.fetchInactiveClaudeAccountsOnOpen()
+    await Promise.resolve()
+
+    await service.refreshForClaudeAccountChange('account-1')
+    accountFetch.resolve(okProvider('claude', 42))
+    await fetchOnOpen
+
+    expect(service.getState().inactiveClaudeAccounts).toEqual([
+      {
+        accountId: 'account-1',
+        claude: expect.objectContaining({
+          session: expect.objectContaining({ usedPercent: 7 })
+        }),
+        updatedAt: expect.any(Number),
+        isFetching: false
+      }
+    ])
   })
 })

--- a/src/main/rate-limits/service.ts
+++ b/src/main/rate-limits/service.ts
@@ -73,6 +73,7 @@ export class RateLimitService {
   private inactiveClaudeFetching = new Set<string>()
   private inactiveCodexFetching = new Set<string>()
   private lastInactiveClaudeFetchAt = 0
+  private inactiveClaudeAccountsGeneration = 0
   private lastInactiveCodexFetchAt = 0
   private stateListeners = new Set<(state: RateLimitState) => void>()
 
@@ -105,6 +106,7 @@ export class RateLimitService {
 
   setInactiveClaudeAccountsResolver(resolver: () => InactiveClaudeAccountInfo[]): void {
     this.inactiveClaudeAccountsResolver = resolver
+    this.inactiveClaudeAccountsGeneration += 1
   }
 
   setInactiveCodexAccountsResolver(resolver: () => InactiveCodexAccountInfo[]): void {
@@ -193,6 +195,8 @@ export class RateLimitService {
     if (outgoingAccountId && this.state.claude?.session) {
       this.inactiveClaudeCache.set(outgoingAccountId, this.state.claude)
     }
+    this.inactiveClaudeAccountsGeneration += 1
+    this.pruneInactiveClaudeState()
     this.claudeFetchGeneration += 1
     this.lastInactiveClaudeFetchAt = 0
     this.updateState({
@@ -207,10 +211,12 @@ export class RateLimitService {
     if (Date.now() - this.lastInactiveClaudeFetchAt < INACTIVE_FETCH_DEBOUNCE_MS) {
       return
     }
+    this.pruneInactiveClaudeState()
     const accounts = this.inactiveClaudeAccountsResolver?.() ?? []
     if (accounts.length === 0) {
       return
     }
+    const fetchGeneration = this.inactiveClaudeAccountsGeneration
 
     for (const account of accounts) {
       this.inactiveClaudeFetching.add(account.id)
@@ -218,19 +224,49 @@ export class RateLimitService {
     this.pushToRenderer()
 
     for (const account of accounts) {
+      if (
+        fetchGeneration !== this.inactiveClaudeAccountsGeneration ||
+        !this.isCurrentInactiveClaudeAccount(account.id)
+      ) {
+        this.inactiveClaudeFetching.delete(account.id)
+        if (!this.isCurrentInactiveClaudeAccount(account.id)) {
+          this.inactiveClaudeCache.delete(account.id)
+        }
+        this.pushToRenderer()
+        continue
+      }
       try {
         const fresh = await fetchManagedAccountUsage(account)
+        if (
+          fetchGeneration !== this.inactiveClaudeAccountsGeneration ||
+          !this.isCurrentInactiveClaudeAccount(account.id)
+        ) {
+          this.inactiveClaudeFetching.delete(account.id)
+          if (!this.isCurrentInactiveClaudeAccount(account.id)) {
+            this.inactiveClaudeCache.delete(account.id)
+          }
+          this.pushToRenderer()
+          continue
+        }
         const cached = this.inactiveClaudeCache.get(account.id) ?? null
         this.inactiveClaudeCache.set(account.id, this.applyStalePolicy(fresh, cached))
       } catch {
         // Why: per-account try/catch prevents one Keychain rejection or
         // network error from aborting the remaining accounts in the batch.
+        if (
+          fetchGeneration !== this.inactiveClaudeAccountsGeneration ||
+          !this.isCurrentInactiveClaudeAccount(account.id)
+        ) {
+          this.inactiveClaudeCache.delete(account.id)
+        }
       }
       this.inactiveClaudeFetching.delete(account.id)
       this.pushToRenderer()
     }
 
-    this.lastInactiveClaudeFetchAt = Date.now()
+    if (fetchGeneration === this.inactiveClaudeAccountsGeneration) {
+      this.lastInactiveClaudeFetchAt = Date.now()
+    }
   }
 
   async fetchInactiveCodexAccountsOnOpen(): Promise<void> {
@@ -266,9 +302,32 @@ export class RateLimitService {
   }
 
   evictInactiveClaudeCache(accountId: string): void {
+    this.inactiveClaudeAccountsGeneration += 1
     this.inactiveClaudeCache.delete(accountId)
     this.inactiveClaudeFetching.delete(accountId)
     this.pushToRenderer()
+  }
+
+  private isCurrentInactiveClaudeAccount(accountId: string): boolean {
+    return (this.inactiveClaudeAccountsResolver?.() ?? []).some(
+      (account) => account.id === accountId
+    )
+  }
+
+  private pruneInactiveClaudeState(): void {
+    const currentIds = new Set(
+      (this.inactiveClaudeAccountsResolver?.() ?? []).map((account) => account.id)
+    )
+    for (const accountId of this.inactiveClaudeCache.keys()) {
+      if (!currentIds.has(accountId)) {
+        this.inactiveClaudeCache.delete(accountId)
+      }
+    }
+    for (const accountId of this.inactiveClaudeFetching) {
+      if (!currentIds.has(accountId)) {
+        this.inactiveClaudeFetching.delete(accountId)
+      }
+    }
   }
 
   evictInactiveCodexCache(accountId: string): void {
@@ -735,6 +794,7 @@ export class RateLimitService {
     cache: Map<string, ProviderRateLimits>,
     fetching: Set<string>
   ): InactiveAccountUsage[] {
+    this.pruneInactiveClaudeState()
     const result: InactiveAccountUsage[] = []
     for (const [accountId, limits] of cache) {
       result.push({

--- a/src/renderer/src/components/settings/AccountsPane.tsx
+++ b/src/renderer/src/components/settings/AccountsPane.tsx
@@ -332,15 +332,8 @@ export function AccountsPane({ settings, updateSettings }: AccountsPaneProps): R
                 const isBusy = claudeAction !== 'idle'
 
                 return (
-                  <button
+                  <div
                     key={account.id}
-                    type="button"
-                    onClick={() =>
-                      void runClaudeAccountAction(`select:${account.id}`, () =>
-                        window.api.claudeAccounts.select({ accountId: account.id })
-                      )
-                    }
-                    disabled={isBusy}
                     className={`flex w-full items-center justify-between gap-3 rounded-md border px-3 py-2.5 text-left transition-colors ${
                       isActive
                         ? 'border-foreground/20 bg-accent/15'
@@ -348,7 +341,16 @@ export function AccountsPane({ settings, updateSettings }: AccountsPaneProps): R
                     }`}
                   >
                     <div className="flex w-full items-center justify-between gap-3 max-md:flex-col max-md:items-start">
-                      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                      <button
+                        type="button"
+                        onClick={() =>
+                          void runClaudeAccountAction(`select:${account.id}`, () =>
+                            window.api.claudeAccounts.select({ accountId: account.id })
+                          )
+                        }
+                        disabled={isBusy}
+                        className="flex min-w-0 flex-1 flex-col gap-0.5 text-left disabled:cursor-default"
+                      >
                         <div className="flex min-w-0 items-center gap-2">
                           <span className="truncate text-sm font-medium">{account.email}</span>
                           {isActive ? (
@@ -365,7 +367,7 @@ export function AccountsPane({ settings, updateSettings }: AccountsPaneProps): R
                             ? `${account.organizationName} · ${formatAccountTimestamp(account.lastAuthenticatedAt)}`
                             : formatAccountTimestamp(account.lastAuthenticatedAt)}
                         </span>
-                      </div>
+                      </button>
                       <div className="flex shrink-0 items-center justify-end gap-1 max-md:w-full max-md:flex-wrap">
                         <Button
                           variant="ghost"
@@ -401,7 +403,7 @@ export function AccountsPane({ settings, updateSettings }: AccountsPaneProps): R
                         </Button>
                       </div>
                     </div>
-                  </button>
+                  </div>
                 )
               })
             )}
@@ -514,15 +516,8 @@ export function AccountsPane({ settings, updateSettings }: AccountsPaneProps): R
                 const isBusy = codexAction !== 'idle'
 
                 return (
-                  <button
+                  <div
                     key={account.id}
-                    type="button"
-                    onClick={() =>
-                      void runCodexAccountAction(`select:${account.id}`, () =>
-                        window.api.codexAccounts.select({ accountId: account.id })
-                      )
-                    }
-                    disabled={isBusy}
                     className={`flex w-full items-center justify-between gap-3 rounded-md border px-3 py-2.5 text-left transition-colors ${
                       isActive
                         ? 'border-foreground/20 bg-accent/15'
@@ -530,7 +525,16 @@ export function AccountsPane({ settings, updateSettings }: AccountsPaneProps): R
                     }`}
                   >
                     <div className="flex w-full items-center justify-between gap-3 max-md:flex-col max-md:items-start">
-                      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                      <button
+                        type="button"
+                        onClick={() =>
+                          void runCodexAccountAction(`select:${account.id}`, () =>
+                            window.api.codexAccounts.select({ accountId: account.id })
+                          )
+                        }
+                        disabled={isBusy}
+                        className="flex min-w-0 flex-1 flex-col gap-0.5 text-left disabled:cursor-default"
+                      >
                         <div className="flex min-w-0 items-center gap-2">
                           <span className="truncate text-sm font-medium">{account.email}</span>
                           {isActive ? (
@@ -553,7 +557,7 @@ export function AccountsPane({ settings, updateSettings }: AccountsPaneProps): R
                             {formatAccountTimestamp(account.lastAuthenticatedAt)}
                           </span>
                         </div>
-                      </div>
+                      </button>
 
                       <div className="flex shrink-0 items-center justify-end gap-1 max-md:w-full max-md:flex-wrap">
                         {/* Why: selecting an account is the primary action in this row.
@@ -597,7 +601,7 @@ export function AccountsPane({ settings, updateSettings }: AccountsPaneProps): R
                         </Button>
                       </div>
                     </div>
-                  </button>
+                  </div>
                 )
               })}
             </div>


### PR DESCRIPTION
## Summary
- read Claude Code 2.1+ config-scoped macOS Keychain credentials using the sha256(CLAUDE_CONFIG_DIR) suffix
- preserve legacy unsuffixed Claude Code Keychain fallback for older CLI versions
- thread scoped Keychain reads/writes through Claude account add, runtime sync, and rate-limit fetches
- add regression coverage for scoped read/write/delete and legacy fallback

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/main/claude-accounts/keychain.test.ts src/main/claude-accounts/runtime-auth-service.test.ts
- pnpm run tc:node

Made with [Orca](https://github.com/stablyai/orca) 🐋
