### PR TITLE
fix(shell-ready): honor user's ZDOTDIR (XDG-layout fix)

### DIFF
--- a/src/main/daemon/shell-ready.test.ts
+++ b/src/main/daemon/shell-ready.test.ts
@@ -1,7 +1,12 @@
+/* eslint-disable max-lines -- Why: daemon shell-ready coverage keeps the
+   zsh/bash launch config, durable wrapper rcfile generation, env
+   normalization, and real-zsh wrapper validation in one suite so the
+   generated wrapper contract is reviewed as a unit. */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { tmpdir } from 'os'
 import { join } from 'path'
-import { existsSync, mkdtempSync, readFileSync, rmSync } from 'fs'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
+import { spawnSync } from 'child_process'
 import type * as ShellReadyModule from './shell-ready'
 
 async function importFreshShellReady(): Promise<typeof ShellReadyModule> {
@@ -277,5 +282,160 @@ describePosix('daemon shell-ready launch config', () => {
         process.env.ZDOTDIR = previousZdotdir
       }
     }
+  })
+
+  it('writes a zshenv that lets user .zshenv compute its own ZDOTDIR (XDG case)', async () => {
+    // Why: the bug being fixed is that the old wrapper captured ORCA_ORIG_ZDOTDIR
+    // before user .zshenv ran, so XDG-layout users (where .zshenv sets ZDOTDIR
+    // to ~/.config/zsh) ended up sourcing ~/.zshrc instead of the real one.
+    // Pin the new template's three load-bearing lines so a future refactor
+    // can't silently regress the contract.
+    const { getShellReadyLaunchConfig } = await importFreshShellReady()
+    getShellReadyLaunchConfig('/bin/zsh')
+
+    const zshenv = readFileSync(join(userDataPath, 'shell-ready', 'zsh', '.zshenv'), 'utf8')
+    expect(zshenv).toContain('unset ZDOTDIR')
+    expect(zshenv).toContain('__orca_source_user_zshenv()')
+    expect(zshenv).toContain(
+      'export ORCA_ORIG_ZDOTDIR="${ZDOTDIR:-${_orca_spawn_orig_zdotdir:-$HOME}}"'
+    )
+    expect(zshenv).toContain(`export ZDOTDIR='${join(userDataPath, 'shell-ready', 'zsh')}'`)
+  })
+
+  it('attribution launch config produces the same zsh wrapper content', async () => {
+    // Why: getAttributionShellLaunchConfig is a separate public entry point
+    // (used for attribution-shim PTYs that don't emit the ready marker).
+    // It must go through the same ensureShellReadyWrappers path, so the
+    // wrapper files on disk are identical and the XDG fix applies there too.
+    const { getShellReadyLaunchConfig, getAttributionShellLaunchConfig } =
+      await importFreshShellReady()
+
+    const ready = getShellReadyLaunchConfig('/bin/zsh')
+    const zshenvAfterReady = readFileSync(
+      join(userDataPath, 'shell-ready', 'zsh', '.zshenv'),
+      'utf8'
+    )
+
+    const attribution = getAttributionShellLaunchConfig('/bin/zsh')
+    const zshenvAfterAttribution = readFileSync(
+      join(userDataPath, 'shell-ready', 'zsh', '.zshenv'),
+      'utf8'
+    )
+
+    expect(zshenvAfterAttribution).toBe(zshenvAfterReady)
+    expect(attribution.env.ZDOTDIR).toBe(ready.env.ZDOTDIR)
+    expect(attribution.env.ORCA_ORIG_ZDOTDIR).toBe(ready.env.ORCA_ORIG_ZDOTDIR)
+    expect(attribution.env.ORCA_SHELL_READY_MARKER).toBe('0')
+    expect(attribution.supportsReadyMarker).toBe(false)
+  })
+})
+
+const zshBinary = (() => {
+  const result = spawnSync('zsh', ['-c', 'echo zsh-ok'])
+  return result.status === 0 ? 'zsh' : null
+})()
+
+const describeWithZsh =
+  process.platform === 'win32' || zshBinary === null ? describe.skip : describe
+
+describeWithZsh('daemon shell-ready wrapper sourced by real zsh', () => {
+  let previousUserDataPath: string | undefined
+  let userDataPath: string
+  let homeDir: string
+
+  beforeEach(() => {
+    previousUserDataPath = process.env.ORCA_USER_DATA_PATH
+    userDataPath = mkdtempSync(join(tmpdir(), 'daemon-shell-ready-zsh-test-'))
+    homeDir = mkdtempSync(join(tmpdir(), 'daemon-shell-ready-zsh-home-'))
+    mkdirSync(join(homeDir, '.config', 'zsh'), { recursive: true })
+    process.env.ORCA_USER_DATA_PATH = userDataPath
+  })
+
+  afterEach(() => {
+    if (previousUserDataPath === undefined) {
+      delete process.env.ORCA_USER_DATA_PATH
+    } else {
+      process.env.ORCA_USER_DATA_PATH = previousUserDataPath
+    }
+    rmSync(userDataPath, { recursive: true, force: true })
+    rmSync(homeDir, { recursive: true, force: true })
+    vi.restoreAllMocks()
+  })
+
+  function runWrapperZshenv(env: Record<string, string>): { stdout: string; stderr: string } {
+    const wrapperZdotdir = join(userDataPath, 'shell-ready', 'zsh')
+    const result = spawnSync(
+      zshBinary as string,
+      [
+        '-f',
+        '-c',
+        `source "$ZDOTDIR/.zshenv"; printf 'ZDOTDIR=%s\\nORCA_ORIG_ZDOTDIR=%s\\n' "$ZDOTDIR" "$ORCA_ORIG_ZDOTDIR"`
+      ],
+      {
+        env: {
+          PATH: process.env.PATH || '/usr/bin:/bin',
+          HOME: homeDir,
+          ZDOTDIR: wrapperZdotdir,
+          ...env
+        },
+        encoding: 'utf8'
+      }
+    )
+    if (result.status !== 0) {
+      throw new Error(`zsh exited ${result.status}: ${result.stderr}`)
+    }
+    return { stdout: result.stdout, stderr: result.stderr }
+  }
+
+  it('captures the XDG-resolved ZDOTDIR into ORCA_ORIG_ZDOTDIR', async () => {
+    writeFileSync(
+      join(homeDir, '.zshenv'),
+      'export XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"\n' +
+        'export ZDOTDIR="${ZDOTDIR:-$XDG_CONFIG_HOME/zsh}"\n',
+      'utf8'
+    )
+    const { getShellReadyLaunchConfig } = await importFreshShellReady()
+    getShellReadyLaunchConfig('/bin/zsh')
+
+    const { stdout } = runWrapperZshenv({})
+
+    expect(stdout).toContain(`ZDOTDIR=${join(userDataPath, 'shell-ready', 'zsh')}\n`)
+    expect(stdout).toContain(`ORCA_ORIG_ZDOTDIR=${join(homeDir, '.config', 'zsh')}\n`)
+  })
+
+  it('survives early-return in user .zshenv and still re-pins ZDOTDIR to the wrapper', async () => {
+    writeFileSync(join(homeDir, '.zshenv'), 'return 0\nexport ZDOTDIR=/never/reached\n', 'utf8')
+    const { getShellReadyLaunchConfig } = await importFreshShellReady()
+    getShellReadyLaunchConfig('/bin/zsh')
+
+    const { stdout } = runWrapperZshenv({ ORCA_ORIG_ZDOTDIR: homeDir })
+
+    expect(stdout).toContain(`ZDOTDIR=${join(userDataPath, 'shell-ready', 'zsh')}\n`)
+    expect(stdout).toContain(`ORCA_ORIG_ZDOTDIR=${homeDir}\n`)
+  })
+
+  it('preserves spawn-env ORCA_ORIG_ZDOTDIR when user .zshenv does not set ZDOTDIR', async () => {
+    writeFileSync(join(homeDir, '.zshenv'), 'export FOO=bar\n', 'utf8')
+    const { getShellReadyLaunchConfig } = await importFreshShellReady()
+    getShellReadyLaunchConfig('/bin/zsh')
+
+    const customZdotdir = join(homeDir, '.config', 'zsh')
+    const { stdout } = runWrapperZshenv({ ORCA_ORIG_ZDOTDIR: customZdotdir })
+
+    expect(stdout).toContain(`ORCA_ORIG_ZDOTDIR=${customZdotdir}\n`)
+  })
+
+  it('normalizes a wrapper-shaped ZDOTDIR with multiple trailing slashes', async () => {
+    // Why: matches the Node-side normalizer that strips all trailing slashes.
+    // Without the loop in the wrapper, `${var%/}` only strips one and the
+    // suffix check misses, restoring the recursion bug.
+    const fakeWrapper = '/some/other/orca/shell-ready/zsh///'
+    writeFileSync(join(homeDir, '.zshenv'), `export ZDOTDIR='${fakeWrapper}'\n`, 'utf8')
+    const { getShellReadyLaunchConfig } = await importFreshShellReady()
+    getShellReadyLaunchConfig('/bin/zsh')
+
+    const { stdout } = runWrapperZshenv({})
+
+    expect(stdout).toContain(`ORCA_ORIG_ZDOTDIR=${homeDir}\n`)
   })
 })

--- a/src/main/daemon/shell-ready.ts
+++ b/src/main/daemon/shell-ready.ts
@@ -18,18 +18,11 @@ function getShellReadyWrapperRoot(): string {
   return join(userDataPath || tmpdir(), userDataPath ? 'shell-ready' : 'orca-shell-ready')
 }
 
-// Why: if our own process inherited ZDOTDIR from a parent shell that was
-// itself an Orca PTY (e.g. the user launched Orca from a terminal inside a
-// running Orca), that ZDOTDIR points at an Orca shell-ready wrapper dir.
-// Propagating it as the new PTY's ORCA_ORIG_ZDOTDIR makes the wrapper's
-// `source "$ORCA_ORIG_ZDOTDIR/.zshenv"` line source itself recursively —
-// zsh gives "job table full or recursion limit exceeded" and the shell
-// never reaches a usable prompt.
-//
-// Any path component ending in `/shell-ready/zsh` is an Orca wrapper dir
-// (regardless of whether it came from this daemon's userData, a packaged
-// Orca, or a different dev build). Treat it as if ZDOTDIR were unset so the
-// caller falls back to HOME for the user's real config root.
+// Why: a wrapper-shaped ZDOTDIR inherited from a parent Orca PTY would make
+// the new PTY's downstream rcfiles re-source $ORCA_ORIG_ZDOTDIR/.zshrc etc.,
+// which is the wrapper file itself — zsh hits "recursion limit exceeded"
+// before reaching a prompt. Strip wrapper-shaped values here so the spawn
+// env stays clean (the wrapper .zshenv has its own self-loop guard too).
 function normalizeOriginalZdotdirCandidate(value: string | undefined): string | null {
   if (!value) {
     return null
@@ -83,11 +76,34 @@ function ensureShellReadyWrappers(): void {
   const bashDir = join(root, 'bash')
 
   const zshEnv = `# Orca daemon zsh shell-ready wrapper
-export ORCA_ORIG_ZDOTDIR="\${ORCA_ORIG_ZDOTDIR:-$HOME}"
-case "\${ORCA_ORIG_ZDOTDIR%/}" in
+_orca_spawn_orig_zdotdir="\${ORCA_ORIG_ZDOTDIR:-}"
+# Why: clearing ZDOTDIR lets user .zshenv use the canonical XDG idiom
+# \`export ZDOTDIR="\${ZDOTDIR:-$XDG_CONFIG_HOME/zsh}"\` to compute its
+# preferred dir; pre-setting it (even to HOME) defeats that default.
+unset ZDOTDIR
+# Why: function isolates user .zshenv \`return\` so it doesn't abort our wrapper.
+# Trade-off: top-level \`setopt LOCAL_OPTIONS\`/\`LOCAL_TRAPS\`, \`TRAPEXIT\`, and
+# bare \`local\`/\`typeset\` in user .zshenv become function-scoped; use \`typeset -g\`
+# or \`export\` to escape.
+__orca_source_user_zshenv() {
+  [[ -f "$HOME/.zshenv" ]] && source "$HOME/.zshenv"
+}
+__orca_source_user_zshenv
+unfunction __orca_source_user_zshenv
+# Why: prefer the ZDOTDIR user .zshenv resolved (XDG case); else preserve
+# the spawn-env value (an inherited resolution from a parent Orca PTY);
+# else HOME.
+export ORCA_ORIG_ZDOTDIR="\${ZDOTDIR:-\${_orca_spawn_orig_zdotdir:-$HOME}}"
+unset _orca_spawn_orig_zdotdir
+# Why: strip trailing slashes (matches Node-side normalizer) before the
+# self-loop check, so a wrapper-shaped ZDOTDIR with one or more trailing
+# slashes still gets normalized away from .zprofile/.zshrc/.zlogin.
+while [[ "\${ORCA_ORIG_ZDOTDIR}" == */ ]]; do
+  ORCA_ORIG_ZDOTDIR="\${ORCA_ORIG_ZDOTDIR%/}"
+done
+case "\${ORCA_ORIG_ZDOTDIR}" in
   */shell-ready/zsh) export ORCA_ORIG_ZDOTDIR="$HOME" ;;
 esac
-[[ -f "$ORCA_ORIG_ZDOTDIR/.zshenv" ]] && source "$ORCA_ORIG_ZDOTDIR/.zshenv"
 export ZDOTDIR=${quotePosixSingle(zshDir)}
 `
   const zshProfile = `# Orca daemon zsh shell-ready wrapper

--- a/src/main/providers/local-pty-shell-ready.test.ts
+++ b/src/main/providers/local-pty-shell-ready.test.ts
@@ -4,7 +4,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { tmpdir } from 'os'
 import { join } from 'path'
-import { mkdtempSync, readFileSync, rmSync } from 'fs'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
+import { spawnSync } from 'child_process'
 import type * as pty from 'node-pty'
 import type * as LocalPtyShellReadyModule from './local-pty-shell-ready'
 import { writeStartupCommandWhenShellReady } from './local-pty-shell-ready'
@@ -342,5 +343,195 @@ describePosix('local PTY shell-ready launch config', () => {
         process.env.ZDOTDIR = previousZdotdir
       }
     }
+  })
+
+  it('writes a zshenv that lets user .zshenv compute its own ZDOTDIR (XDG case)', async () => {
+    // Why: the bug being fixed is that the old wrapper captured ORCA_ORIG_ZDOTDIR
+    // before user .zshenv ran, so XDG-layout users (where .zshenv sets ZDOTDIR
+    // to ~/.config/zsh) ended up sourcing ~/.zshrc instead of the real one.
+    // Pin the new template's three load-bearing lines so a future refactor
+    // can't silently regress the contract.
+    const { getShellReadyLaunchConfig } = await importFreshLocalPtyShellReady()
+    getShellReadyLaunchConfig('/bin/zsh')
+
+    const zshenv = readFileSync(join(userDataPath, 'shell-ready', 'zsh', '.zshenv'), 'utf8')
+    expect(zshenv).toContain('unset ZDOTDIR')
+    expect(zshenv).toContain('__orca_source_user_zshenv()')
+    expect(zshenv).toContain(
+      'export ORCA_ORIG_ZDOTDIR="${ZDOTDIR:-${_orca_spawn_orig_zdotdir:-$HOME}}"'
+    )
+    // Why: re-pin must use the baked wrapper dir, not $ORCA_ORIG_ZDOTDIR — a
+    // captured-from-spawn-env approach would be empty if a caller forgot to
+    // set ZDOTDIR in the spawn env.
+    expect(zshenv).toContain(`export ZDOTDIR='${join(userDataPath, 'shell-ready', 'zsh')}'`)
+  })
+
+  it('attribution launch config produces the same zsh wrapper content', async () => {
+    // Why: getAttributionShellLaunchConfig is a separate public entry point
+    // (used for attribution-shim PTYs that don't emit the ready marker).
+    // It must go through the same ensureShellReadyWrappers path, so the
+    // wrapper files on disk are identical and the XDG fix applies there too.
+    const { getShellReadyLaunchConfig, getAttributionShellLaunchConfig } =
+      await importFreshLocalPtyShellReady()
+
+    const ready = getShellReadyLaunchConfig('/bin/zsh')
+    const zshenvAfterReady = readFileSync(
+      join(userDataPath, 'shell-ready', 'zsh', '.zshenv'),
+      'utf8'
+    )
+
+    const attribution = getAttributionShellLaunchConfig('/bin/zsh')
+    const zshenvAfterAttribution = readFileSync(
+      join(userDataPath, 'shell-ready', 'zsh', '.zshenv'),
+      'utf8'
+    )
+
+    expect(zshenvAfterAttribution).toBe(zshenvAfterReady)
+    expect(attribution.env.ZDOTDIR).toBe(ready.env.ZDOTDIR)
+    expect(attribution.env.ORCA_ORIG_ZDOTDIR).toBe(ready.env.ORCA_ORIG_ZDOTDIR)
+    expect(attribution.env.ORCA_SHELL_READY_MARKER).toBe('0')
+    expect(attribution.supportsReadyMarker).toBe(false)
+  })
+})
+
+const zshBinary = (() => {
+  const result = spawnSync('zsh', ['-c', 'echo zsh-ok'])
+  return result.status === 0 ? 'zsh' : null
+})()
+
+const describeWithZsh =
+  process.platform === 'win32' || zshBinary === null ? describe.skip : describe
+
+describeWithZsh('local PTY shell-ready wrapper sourced by real zsh', () => {
+  let userDataPath: string
+  let homeDir: string
+
+  beforeEach(() => {
+    userDataPath = mkdtempSync(join(tmpdir(), 'local-pty-shell-ready-zsh-test-'))
+    homeDir = mkdtempSync(join(tmpdir(), 'local-pty-shell-ready-zsh-home-'))
+    mkdirSync(join(homeDir, '.config', 'zsh'), { recursive: true })
+    getUserDataPathMock.mockReturnValue(userDataPath)
+  })
+
+  afterEach(() => {
+    rmSync(userDataPath, { recursive: true, force: true })
+    rmSync(homeDir, { recursive: true, force: true })
+    vi.restoreAllMocks()
+  })
+
+  function runWrapperZshenv(env: Record<string, string>): { stdout: string; stderr: string } {
+    const wrapperZdotdir = join(userDataPath, 'shell-ready', 'zsh')
+    // Why: env -i would also work but is harder to drive cross-platform from
+    // Node. Pass an explicit env that only carries what the wrapper needs,
+    // so the parent process's XDG_CONFIG_HOME / ZDOTDIR don't leak through
+    // the user's .zshenv default-expansion idioms.
+    const result = spawnSync(
+      zshBinary as string,
+      [
+        '-f',
+        '-c',
+        `source "$ZDOTDIR/.zshenv"; printf 'ZDOTDIR=%s\\nORCA_ORIG_ZDOTDIR=%s\\n' "$ZDOTDIR" "$ORCA_ORIG_ZDOTDIR"`
+      ],
+      {
+        env: {
+          PATH: process.env.PATH || '/usr/bin:/bin',
+          HOME: homeDir,
+          ZDOTDIR: wrapperZdotdir,
+          ...env
+        },
+        encoding: 'utf8'
+      }
+    )
+    if (result.status !== 0) {
+      throw new Error(`zsh exited ${result.status}: ${result.stderr}`)
+    }
+    return { stdout: result.stdout, stderr: result.stderr }
+  }
+
+  it('captures the XDG-resolved ZDOTDIR into ORCA_ORIG_ZDOTDIR', async () => {
+    // Why: real-zsh proof of the bug fix. With the old wrapper, ORCA_ORIG_ZDOTDIR
+    // would end up at $HOME because user .zshenv ran AFTER the capture.
+    writeFileSync(
+      join(homeDir, '.zshenv'),
+      'export XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"\n' +
+        'export ZDOTDIR="${ZDOTDIR:-$XDG_CONFIG_HOME/zsh}"\n',
+      'utf8'
+    )
+    const { getShellReadyLaunchConfig } = await importFreshLocalPtyShellReady()
+    getShellReadyLaunchConfig('/bin/zsh')
+
+    const { stdout } = runWrapperZshenv({})
+
+    expect(stdout).toContain(`ZDOTDIR=${join(userDataPath, 'shell-ready', 'zsh')}\n`)
+    expect(stdout).toContain(`ORCA_ORIG_ZDOTDIR=${join(homeDir, '.config', 'zsh')}\n`)
+  })
+
+  it('survives early-return in user .zshenv and still re-pins ZDOTDIR to the wrapper', async () => {
+    // Why: user dotfiles often guard expensive .zshenv setup with an early
+    // return (`[[ -o interactive ]] || return`, `[[ -n $TMUX ]] && return`,
+    // etc.). Without the function wrapper, that return would exit our
+    // wrapper .zshenv too — leaving ZDOTDIR unset and breaking the OSC 133;A
+    // ready-marker contract.
+    writeFileSync(join(homeDir, '.zshenv'), 'return 0\nexport ZDOTDIR=/never/reached\n', 'utf8')
+    const { getShellReadyLaunchConfig } = await importFreshLocalPtyShellReady()
+    getShellReadyLaunchConfig('/bin/zsh')
+
+    const { stdout } = runWrapperZshenv({ ORCA_ORIG_ZDOTDIR: homeDir })
+
+    expect(stdout).toContain(`ZDOTDIR=${join(userDataPath, 'shell-ready', 'zsh')}\n`)
+    // spawn-env ORCA_ORIG_ZDOTDIR survives the early return.
+    expect(stdout).toContain(`ORCA_ORIG_ZDOTDIR=${homeDir}\n`)
+  })
+
+  it('preserves spawn-env ORCA_ORIG_ZDOTDIR when user .zshenv does not set ZDOTDIR', async () => {
+    writeFileSync(join(homeDir, '.zshenv'), 'export FOO=bar\n', 'utf8')
+    const { getShellReadyLaunchConfig } = await importFreshLocalPtyShellReady()
+    getShellReadyLaunchConfig('/bin/zsh')
+
+    const customZdotdir = join(homeDir, '.config', 'zsh')
+    const { stdout } = runWrapperZshenv({ ORCA_ORIG_ZDOTDIR: customZdotdir })
+
+    expect(stdout).toContain(`ORCA_ORIG_ZDOTDIR=${customZdotdir}\n`)
+  })
+
+  it('falls back to HOME when neither user .zshenv nor spawn env set ORCA_ORIG_ZDOTDIR', async () => {
+    writeFileSync(join(homeDir, '.zshenv'), '\n', 'utf8')
+    const { getShellReadyLaunchConfig } = await importFreshLocalPtyShellReady()
+    getShellReadyLaunchConfig('/bin/zsh')
+
+    // No ORCA_ORIG_ZDOTDIR in spawn env, and ORCA_ORIG_ZDOTDIR will be
+    // empty after `_orca_spawn_orig_zdotdir="${ORCA_ORIG_ZDOTDIR:-}"`.
+    // Forcing it absent with empty string mimics the unset case at this layer.
+    const { stdout } = runWrapperZshenv({ ORCA_ORIG_ZDOTDIR: '' })
+
+    expect(stdout).toContain(`ORCA_ORIG_ZDOTDIR=${homeDir}\n`)
+  })
+
+  it('normalizes a self-loop ORCA_ORIG_ZDOTDIR back to HOME at runtime', async () => {
+    // Why: pairs with the Node-side normalizer test above, but covers the
+    // case where user .zshenv exports a wrapper-shaped ZDOTDIR itself
+    // (e.g. by echoing back an inherited one).
+    const fakeWrapper = '/some/other/orca/shell-ready/zsh'
+    writeFileSync(join(homeDir, '.zshenv'), `export ZDOTDIR='${fakeWrapper}'\n`, 'utf8')
+    const { getShellReadyLaunchConfig } = await importFreshLocalPtyShellReady()
+    getShellReadyLaunchConfig('/bin/zsh')
+
+    const { stdout } = runWrapperZshenv({})
+
+    expect(stdout).toContain(`ORCA_ORIG_ZDOTDIR=${homeDir}\n`)
+  })
+
+  it('normalizes a wrapper-shaped ZDOTDIR with multiple trailing slashes', async () => {
+    // Why: matches the Node-side normalizer that strips all trailing slashes.
+    // Without the loop in the wrapper, `${var%/}` only strips one and the
+    // suffix check misses, restoring the recursion bug.
+    const fakeWrapper = '/some/other/orca/shell-ready/zsh///'
+    writeFileSync(join(homeDir, '.zshenv'), `export ZDOTDIR='${fakeWrapper}'\n`, 'utf8')
+    const { getShellReadyLaunchConfig } = await importFreshLocalPtyShellReady()
+    getShellReadyLaunchConfig('/bin/zsh')
+
+    const { stdout } = runWrapperZshenv({})
+
+    expect(stdout).toContain(`ORCA_ORIG_ZDOTDIR=${homeDir}\n`)
   })
 })

--- a/src/main/providers/local-pty-shell-ready.ts
+++ b/src/main/providers/local-pty-shell-ready.ts
@@ -77,18 +77,11 @@ function getShellReadyWrapperRoot(): string {
   return `${app.getPath('userData')}/shell-ready`
 }
 
-// Why: if our own process inherited ZDOTDIR from a parent shell that was
-// itself an Orca PTY (e.g. the user launched `pn dev` from a terminal inside
-// a running Orca), that ZDOTDIR points at an Orca shell-ready wrapper dir.
-// Propagating it as the new PTY's ORCA_ORIG_ZDOTDIR makes the wrapper's
-// `source "$ORCA_ORIG_ZDOTDIR/.zshenv"` line source itself recursively —
-// zsh gives "job table full or recursion limit exceeded" and the shell
-// never reaches a usable prompt.
-//
-// Any path component ending in `/shell-ready/zsh` is an Orca wrapper dir
-// (regardless of whether it came from this app's userData, a packaged Orca,
-// or a different dev build). Treat it as if ZDOTDIR were unset so the caller
-// falls back to HOME for the user's real config root.
+// Why: a wrapper-shaped ZDOTDIR inherited from a parent Orca PTY would make
+// the new PTY's downstream rcfiles re-source $ORCA_ORIG_ZDOTDIR/.zshrc etc.,
+// which is the wrapper file itself — zsh hits "recursion limit exceeded"
+// before reaching a prompt. Strip wrapper-shaped values here so the spawn
+// env stays clean (the wrapper .zshenv has its own self-loop guard too).
 function normalizeOriginalZdotdirCandidate(value: string | undefined): string | null {
   if (!value) {
     return null
@@ -171,11 +164,34 @@ function ensureShellReadyWrappers(): void {
   const bashDir = `${root}/bash`
 
   const zshEnv = `# Orca zsh shell-ready wrapper
-export ORCA_ORIG_ZDOTDIR="\${ORCA_ORIG_ZDOTDIR:-$HOME}"
-case "\${ORCA_ORIG_ZDOTDIR%/}" in
+_orca_spawn_orig_zdotdir="\${ORCA_ORIG_ZDOTDIR:-}"
+# Why: clearing ZDOTDIR lets user .zshenv use the canonical XDG idiom
+# \`export ZDOTDIR="\${ZDOTDIR:-$XDG_CONFIG_HOME/zsh}"\` to compute its
+# preferred dir; pre-setting it (even to HOME) defeats that default.
+unset ZDOTDIR
+# Why: function isolates user .zshenv \`return\` so it doesn't abort our wrapper.
+# Trade-off: top-level \`setopt LOCAL_OPTIONS\`/\`LOCAL_TRAPS\`, \`TRAPEXIT\`, and
+# bare \`local\`/\`typeset\` in user .zshenv become function-scoped; use \`typeset -g\`
+# or \`export\` to escape.
+__orca_source_user_zshenv() {
+  [[ -f "$HOME/.zshenv" ]] && source "$HOME/.zshenv"
+}
+__orca_source_user_zshenv
+unfunction __orca_source_user_zshenv
+# Why: prefer the ZDOTDIR user .zshenv resolved (XDG case); else preserve
+# the spawn-env value (an inherited resolution from a parent Orca PTY);
+# else HOME.
+export ORCA_ORIG_ZDOTDIR="\${ZDOTDIR:-\${_orca_spawn_orig_zdotdir:-$HOME}}"
+unset _orca_spawn_orig_zdotdir
+# Why: strip trailing slashes (matches Node-side normalizer) before the
+# self-loop check, so a wrapper-shaped ZDOTDIR with one or more trailing
+# slashes still gets normalized away from .zprofile/.zshrc/.zlogin.
+while [[ "\${ORCA_ORIG_ZDOTDIR}" == */ ]]; do
+  ORCA_ORIG_ZDOTDIR="\${ORCA_ORIG_ZDOTDIR%/}"
+done
+case "\${ORCA_ORIG_ZDOTDIR}" in
   */shell-ready/zsh) export ORCA_ORIG_ZDOTDIR="$HOME" ;;
 esac
-[[ -f "$ORCA_ORIG_ZDOTDIR/.zshenv" ]] && source "$ORCA_ORIG_ZDOTDIR/.zshenv"
 export ZDOTDIR=${quotePosixSingle(zshDir)}
 `
   const zshProfile = `# Orca zsh shell-ready wrapper


### PR DESCRIPTION
Fixes #1739
## Summary

The shell-ready zsh wrapper sources `~/.zshenv` but throws away the `ZDOTDIR` it computes, then sources `~/.zshrc` instead of `$ZDOTDIR/.zshrc`. Users who follow the canonical XDG idiom (`export ZDOTDIR="${ZDOTDIR:-$XDG_CONFIG_HOME/zsh}"` in `~/.zshenv`) end up with an empty config inside any Orca PTY that flows through `getShellReadyLaunchConfig` (startup-command PTYs) or `getAttributionShellLaunchConfig` (attribution-shim PTYs). Both routes share the same wrapper rcfiles, so both routes are fixed by the same template change. SSH PTYs get the fix via the daemon mirror.

The fix:

1. Save the spawn-env `ORCA_ORIG_ZDOTDIR` for fallback.
2. `unset ZDOTDIR` so the user's `.zshenv` can fire the `${ZDOTDIR:-...}` default expansion.
3. Source `~/.zshenv` *inside a function*, so an early `return` (e.g. `[[ -o interactive ]] || return`, common in dotfiles) exits only the function — not our wrapper.
4. Recapture `ORCA_ORIG_ZDOTDIR` from whatever the user's `.zshenv` resolved `ZDOTDIR` to, falling back to the saved spawn-env value, then `$HOME`.
5. Re-pin `ZDOTDIR` to the wrapper dir (baked into the template, not pulled from a captured variable, so the wrapper still works if a future caller forgets to set `ZDOTDIR` in the spawn env).

The renderer-side template (`src/main/providers/local-pty-shell-ready.ts`) and the daemon mirror (`src/main/daemon/shell-ready.ts`) get the same treatment.

## Test plan

Automated (vitest, 38/38 passing locally):

- [x] Existing recursion-guard / self-loop tests still pass in both files.
- [x] New unit test pins the four load-bearing template lines (`unset ZDOTDIR`, function wrapper, recapture, baked re-pin).
- [x] New unit test covers `getAttributionShellLaunchConfig`: same wrapper bytes on disk, same `ZDOTDIR` / `ORCA_ORIG_ZDOTDIR` in the launch env, `ORCA_SHELL_READY_MARKER=0`, `supportsReadyMarker=false`.
- [x] New zsh-subprocess tests (gated on `which zsh`, skipped on Windows / missing zsh) source the generated `.zshenv` in a temp `HOME` and assert the resulting `ZDOTDIR` / `ORCA_ORIG_ZDOTDIR`:
  - XDG case (user `.zshenv` exports `ZDOTDIR=$XDG_CONFIG_HOME/zsh`)
  - Early-return case (user `.zshenv` does `return 0` before setting anything)
  - Spawn-env preservation (no `ZDOTDIR` set by user `.zshenv`, spawn-env `ORCA_ORIG_ZDOTDIR` survives)
  - HOME fallback (no spawn-env, no user-set `ZDOTDIR`)
  - Self-loop normalization (user `.zshenv` itself echoes a wrapper-shaped `ZDOTDIR`), including pathological multi-trailing-slash variants

Manual:

- [ ] Mac with `~/.zshenv` exporting `ZDOTDIR=$XDG_CONFIG_HOME/zsh` and a function defined in `~/.config/zsh/.zshrc`. Spotlight-launch Orca, then `orca terminal create --worktree active --command "<that function>"`. Function resolves.
- [ ] Same Mac, vanilla `~/.zshrc`, no XDG layout. Same command still works (regression check).
- [ ] Nested case: launch an Orca terminal, then from inside it run `orca terminal create --command "..."`. Recursion guard still fires — no `recursion limit exceeded` from zsh.

## Risk

- `~/.zshenv` is sourced once per wrapper invocation, same as before. The change is *when* it runs (now before the wrapper has committed to a `ZDOTDIR`), not how many times.
- For vanilla users (`.zshenv` doesn't touch `ZDOTDIR`), the recapture falls through to the saved spawn-env value, which is what the old code already used. No observable change.
- For XDG users, `ORCA_ORIG_ZDOTDIR` ends up at their XDG dir, and the downstream `.zprofile` / `.zshrc` / `.zlogin` source the right files.
- Exported / `typeset -g` variables set by user `.zshenv` propagate out of the function unchanged (zsh's default scope is global). See the trade-offs section below for the bare `local` / `typeset` caveat.
- The recursion guard moves from "before sourcing user `.zshenv`" to "after the recapture." Behavior is preserved: if user `.zshenv` somehow exports a wrapper-shaped `ZDOTDIR`, it gets normalized away before the downstream rcfiles run.
- SSH PTYs (the daemon runs on the remote host) get the fix via the daemon mirror — no separate change needed.
- `_orca_spawn_orig_zdotdir` is a top-level shell variable (not function-scoped). It lives in the same scope as user `.zshenv`, so a `.zshenv` that explicitly clobbers it (extremely unlikely given the underscore prefix) loses the spawn-env fallback path.

### Known function-scope trade-offs

Sourcing `~/.zshenv` inside `__orca_source_user_zshenv` means a few zsh constructs at the *top level* of user `.zshenv` behave function-scoped under the wrapper that they wouldn't under a vanilla zsh launch. None are silent breakages; all have a documented escape hatch:

- `setopt LOCAL_OPTIONS` / `LOCAL_TRAPS` revert at function exit.
- `TRAPEXIT` / `trap '...' EXIT` inside `~/.zshenv` fires on function return, not shell exit. Move such traps to `~/.zprofile` or `~/.zshrc`.
- Bare `local` / `typeset` (without `-g`) in `~/.zshenv` becomes function-local. Use `typeset -g` or `export` if the binding needs to outlive `~/.zshenv`.

These trade-offs are inherent to early-return survival — sourcing `~/.zshenv` directly at top level would let `[[ -o interactive ]] || return` abort the entire wrapper, which is a worse failure mode (no ready marker, broken startup commands, broken attribution shim).

## Out of scope

- **Bash users:** the standard bash startup chain has no `ZDOTDIR`-style indirection. Users with custom layouts already source from `~/.bash_profile`, which the wrapper sources directly. No analogous fix is needed in the bash wrapper.
- **Windows:** `ensureShellReadyWrappers()` already short-circuits on `process.platform === 'win32'`.
- **`resolveOriginalZdotdir()` (Node side):** unchanged. It still strips wrapper-shaped values out of the spawn env so we don't poison the recapture fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)