### PR TITLE
Drop the per-workspace AGENTS toggle in the sidebar

### DIFF
--- a/src/renderer/src/components/dashboard/DashboardAgentRow.tsx
+++ b/src/renderer/src/components/dashboard/DashboardAgentRow.tsx
@@ -203,7 +203,7 @@ const DashboardAgentRow = React.memo(function DashboardAgentRow({
     <div
       onClick={handleActivate}
       className={cn(
-        'group relative flex flex-col pl-1 pr-1.5 py-0.5',
+        'group relative flex flex-col pr-1.5 py-0.5',
         // Why: hover tints have to go in opposite directions per theme —
         // dark mode adds light on dark (bg-accent/30), light mode needs to
         // add *dark* on white. Alpha-on-accent in light mode collapses to

--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.test.tsx
@@ -1,0 +1,72 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+let mockAgents = [
+  {
+    paneKey: 'tab-1:1',
+    tab: { id: 'tab-1' },
+    entry: {
+      stateStartedAt: 1000
+    }
+  }
+]
+
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      acknowledgedAgentsByPaneKey: {},
+      dropAgentStatus: vi.fn(),
+      dismissRetainedAgent: vi.fn(),
+      acknowledgeAgents: vi.fn()
+    })
+}))
+
+vi.mock('./useWorktreeAgentRows', () => ({
+  useWorktreeAgentRows: vi.fn(() => mockAgents)
+}))
+
+vi.mock('@/components/dashboard/useNow', () => ({
+  useNow: vi.fn(() => 2000)
+}))
+
+vi.mock('@/components/dashboard/DashboardAgentRow', () => ({
+  default: ({ agent }: { agent: { paneKey: string } }) => (
+    <div data-testid="agent-row">{agent.paneKey}</div>
+  )
+}))
+
+describe('WorktreeCardAgents', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAgents = [
+      {
+        paneKey: 'tab-1:1',
+        tab: { id: 'tab-1' },
+        entry: {
+          stateStartedAt: 1000
+        }
+      }
+    ]
+  })
+
+  it('renders rows in a labeled group without the removed per-card toggle header', async () => {
+    const { default: WorktreeCardAgents } = await import('./WorktreeCardAgents')
+
+    const markup = renderToStaticMarkup(<WorktreeCardAgents worktreeId="wt-1" />)
+
+    expect(markup).toContain('role="group"')
+    expect(markup).toContain('aria-label="Agents"')
+    expect(markup).toContain('data-testid="agent-row"')
+    expect(markup).not.toContain('<button')
+    expect(markup).not.toContain('aria-expanded')
+  })
+
+  it('does not render the labeled wrapper when there are no agent rows', async () => {
+    mockAgents = []
+    const { default: WorktreeCardAgents } = await import('./WorktreeCardAgents')
+
+    const markup = renderToStaticMarkup(<WorktreeCardAgents worktreeId="wt-1" />)
+
+    expect(markup).toBe('')
+  })
+})

--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useMemo } from 'react'
-import { ChevronDown } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 import { activateTabAndFocusPane } from '@/lib/activate-tab-and-focus-pane'
@@ -53,12 +52,6 @@ const WorktreeCardAgentsBody = React.memo(function WorktreeCardAgentsBody({
   const dropAgentStatus = useAppStore((s) => s.dropAgentStatus)
   const dismissRetainedAgent = useAppStore((s) => s.dismissRetainedAgent)
   const acknowledgeAgents = useAppStore((s) => s.acknowledgeAgents)
-
-  // Why: per-worktree collapse is session-only UI state. Single-primitive
-  // subscription so the card only re-renders when THIS worktree's collapsed
-  // flag flips — not on any other worktree's toggle.
-  const isCollapsed = useAppStore((s) => s.collapsedInlineAgentsByWorktreeId[worktreeId] === true)
-  const toggleInlineAgentsCollapsed = useAppStore((s) => s.toggleInlineAgentsCollapsed)
 
   // Why: subscribe to the ack map reference (Object.is equality) and derive
   // per-agent unvisited flags locally. Keeps the inline list's bold/mute
@@ -115,72 +108,49 @@ const WorktreeCardAgentsBody = React.memo(function WorktreeCardAgentsBody({
     [worktreeId, acknowledgeAgents]
   )
 
-  const handleToggleCollapsed = useCallback(
-    (e: React.MouseEvent) => {
-      // Why: the header is inside WorktreeCard, whose outer click handler
-      // activates the worktree. Stop propagation so expanding/collapsing the
-      // list doesn't also navigate away — the user's intent is clearly the
-      // toggle, not a worktree switch.
-      e.stopPropagation()
-      toggleInlineAgentsCollapsed(worktreeId)
-    },
-    [toggleInlineAgentsCollapsed, worktreeId]
-  )
-
   // Why: own one 30s tick per non-empty inline list. Cards with zero agents
   // never mount this component (see WorktreeCardAgents), so idle worktrees
   // don't pay any timer cost.
   const now = useNow(30_000)
 
+  const stopBubble = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation()
+  }, [])
+
   return (
+    // Why: swallow bubbling so clicks on the gutter around the agent rows
+    // don't reach WorktreeCard's activate / edit-meta handlers.
     <div
-      className={cn('flex flex-col mt-1', className)}
-      onClick={(e) => e.stopPropagation()}
-      onDoubleClick={(e) => e.stopPropagation()}
+      className={cn('flex flex-col mt-1 divide-y divide-border/30', className)}
+      onClick={stopBubble}
+      onDoubleClick={stopBubble}
+      role="group"
+      aria-label="Agents"
     >
-      {/* Why: clickable header toggles the section open/closed. Using a real
-          <button> keeps keyboard + a11y semantics correct (Enter/Space
-          activate, proper focus ring, aria-expanded for screen readers). */}
-      <button
-        type="button"
-        onClick={handleToggleCollapsed}
-        aria-expanded={!isCollapsed}
-        aria-label={isCollapsed ? 'Expand agent activity' : 'Collapse agent activity'}
-        className="flex items-center gap-1 mb-0.5 px-0.5 text-[9px] font-semibold uppercase tracking-[0.08em] text-muted-foreground/60 hover:text-muted-foreground transition-colors"
-      >
-        <ChevronDown
-          className={cn('size-2.5 transition-transform duration-150', isCollapsed && '-rotate-90')}
-        />
-        <span>Agents ({agents.length})</span>
-      </button>
-      {!isCollapsed && (
-        <div className="flex flex-col divide-y divide-border/30">
-          {agents.map((agent) => (
-            <div key={agent.paneKey} className="py-0.5">
-              <DashboardAgentRow
-                agent={agent}
-                onDismiss={handleDismissAgent}
-                onActivate={handleActivateAgentTab}
-                now={now}
-                // Why: bold an agent row until the user has visited its tab.
-                // useAutoAckViewedAgent acks automatically when the user
-                // focuses the agent's tab, which mutes the row in lockstep.
-                isUnvisited={unvisitedByPaneKey[agent.paneKey] ?? false}
-                // Why: inline rows pack tighter than a full-panel layout;
-                // 'md' reads as a second ~12px glyph users confuse with the
-                // agent identity icon right next to it. 'sm' keeps the two
-                // distinguishable at a glance.
-                stateDotSize="sm"
-                // Why: in the per-card inline list clicking the row jumps
-                // directly to the agent, so the expand chevron is redundant.
-                // Keep the identity glyph (Claude/Gemini/…) so users can tell
-                // agents apart at a glance within a worktree.
-                hideExpand
-              />
-            </div>
-          ))}
+      {agents.map((agent) => (
+        <div key={agent.paneKey} className="py-0.5">
+          <DashboardAgentRow
+            agent={agent}
+            onDismiss={handleDismissAgent}
+            onActivate={handleActivateAgentTab}
+            now={now}
+            // Why: bold an agent row until the user has visited its tab.
+            // useAutoAckViewedAgent acks automatically when the user
+            // focuses the agent's tab, which mutes the row in lockstep.
+            isUnvisited={unvisitedByPaneKey[agent.paneKey] ?? false}
+            // Why: inline rows pack tighter than a full-panel layout;
+            // 'md' reads as a second ~12px glyph users confuse with the
+            // agent identity icon right next to it. 'sm' keeps the two
+            // distinguishable at a glance.
+            stateDotSize="sm"
+            // Why: in the per-card inline list clicking the row jumps
+            // directly to the agent, so the expand chevron is redundant.
+            // Keep the identity glyph (Claude/Gemini/…) so users can tell
+            // agents apart at a glance within a worktree.
+            hideExpand
+          />
         </div>
-      )}
+      ))}
     </div>
   )
 })

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -194,12 +194,6 @@ export type UISlice = {
   acknowledgedAgentsByPaneKey: Record<string, number>
   acknowledgeAgents: (paneKeys: string[]) => void
   unacknowledgeAgents: (paneKeys: string[]) => void
-  /** Per-worktree collapsed state for the inline agents section shown inside
-   *  each workspace card. Session-only — a restart defaults back to expanded,
-   *  which matches the expected default (people rarely want agents hidden
-   *  across launches). */
-  collapsedInlineAgentsByWorktreeId: Record<string, boolean>
-  toggleInlineAgentsCollapsed: (worktreeId: string) => void
   activeView: 'terminal' | 'settings' | 'tasks' | 'activity'
   previousViewBeforeTasks: 'terminal' | 'settings' | 'activity'
   previousViewBeforeSettings: 'terminal' | 'tasks' | 'activity'
@@ -407,18 +401,6 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
         }
       }
       return next ? { acknowledgedAgentsByPaneKey: next } : s
-    }),
-  collapsedInlineAgentsByWorktreeId: {},
-  toggleInlineAgentsCollapsed: (worktreeId) =>
-    set((s) => {
-      const current = s.collapsedInlineAgentsByWorktreeId[worktreeId] === true
-      const next = { ...s.collapsedInlineAgentsByWorktreeId }
-      if (current) {
-        delete next[worktreeId]
-      } else {
-        next[worktreeId] = true
-      }
-      return { collapsedInlineAgentsByWorktreeId: next }
     }),
 
   activeView: 'terminal',


### PR DESCRIPTION
Fixes #1736

## Summary

- Remove the `▾ AGENTS (n)` chevron from each worktree card. Visibility of the inline agent list is now controlled by the single global `inline-agents` view option in the sidebar header — no per-card override.
- Delete the matching session-only state (`collapsedInlineAgentsByWorktreeId` + `toggleInlineAgentsCollapsed`) from the UI store. Nothing else read it; no persisted state, no migration.
- Drop the leading `pl-1` on `DashboardAgentRow` for a touch more horizontal room. The component has only one render site (this inline list), so there's no asymmetry to fix elsewhere.

The wrapper around the rows keeps a `stopPropagation` handler so clicks on the empty gutter don't fire `WorktreeCard`'s outer activate/edit-meta handlers. It also gets `role="group"` + `aria-label="Agents"` so screen-reader users still get a labeled region.

## Open decision

Are we OK losing the "AGENTS (n)" header. This PR drops it entirely rather than keeping a non-clickable label. Most cards only have one or two agents, the rows self-identify with the spark icon, and the freed vertical space matters more than the grouping signal. Screen-reader users still get the group via aria-label.

## Test plan

- [ ] Sidebar renders agent rows on cards when the global `inline-agents` view option is on.
- [ ] Sidebar hides agent rows on cards when the global option is off.
- [ ] Clicking an agent row activates the worktree and focuses the agent's tab.
- [ ] Clicking the empty padding around an agent row does **not** activate the worktree or open edit-meta.
- [ ] Screen reader announces a group labeled "Agents" when entering the inline list region.