### PR TITLE
feat(activity): isolate the agent's pane in the activity view

### DIFF
--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -1314,6 +1314,10 @@ function Terminal(): React.JSX.Element | null {
                           // Keeping `isVisible` true for the portaled tab lets
                           // xterm fit and stream foreground output in-place.
                           isVisible={isActiveTerminalTab || isActivityPortalTab}
+                          // Why: when portaled to Activity for a specific agent
+                          // pane, isolate that leaf so split siblings stay
+                          // hidden. Workspace renders pass null → no override.
+                          isolatedPaneId={activityTerminalPortal?.paneId ?? null}
                           onPtyExit={(ptyId) => handlePtyExit(tab.id, ptyId)}
                           onCloseTab={() => handleCloseTab(tab.id)}
                         />

--- a/src/renderer/src/components/activity/ActivityPrototypePage.tsx
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.tsx
@@ -799,6 +799,7 @@ export default function ActivityPrototypePage(): React.JSX.Element {
         target: activePortalTargetEl,
         worktreeId: visibleThread.worktree.id,
         tabId: visibleThread.latestEvent.tab.id,
+        paneId: paneIdFromPaneKey(visibleThread.paneKey),
         active: true
       })
     }
@@ -808,6 +809,7 @@ export default function ActivityPrototypePage(): React.JSX.Element {
         target: inactivePortalTargetEl,
         worktreeId: stagedThread.worktree.id,
         tabId: stagedThread.latestEvent.tab.id,
+        paneId: paneIdFromPaneKey(stagedThread.paneKey),
         active: false
       })
     }

--- a/src/renderer/src/components/activity/activity-terminal-portal.ts
+++ b/src/renderer/src/components/activity/activity-terminal-portal.ts
@@ -5,6 +5,11 @@ export type ActivityTerminalPortalTarget = {
   target: HTMLElement
   worktreeId: string
   tabId: string
+  // Why: each Activity thread is keyed on a single agent pane within a tab.
+  // Carrying paneId here lets TerminalPane isolate that pane visually
+  // (hiding split siblings) without touching the user-facing expanded-pane
+  // state or the persisted layout snapshot.
+  paneId: number | null
   active: boolean
 }
 

--- a/src/renderer/src/components/tab-group/TabGroupPanel.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.tsx
@@ -381,6 +381,10 @@ export default function TabGroupPanel({
                 // tab must still be visible so xterm fits against the activity
                 // pane and continues foreground output scheduling.
                 isVisible={isVisibleTerminalTab || isActivityPortalTab}
+                // Why: when portaled to Activity for a specific agent pane,
+                // isolate that leaf so split siblings stay hidden. Workspace
+                // renders pass null → no override.
+                isolatedPaneId={activityTerminalPortal?.paneId ?? null}
                 onPtyExit={(ptyId) => {
                   if (commands.consumeSuppressedPtyExit(ptyId)) {
                     return

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -15,7 +15,11 @@ import type { PtyTransport } from './pty-transport'
 import { fitPanes, isWindowsUserAgent, shellEscapePath } from './pane-helpers'
 import { getConnectionId } from '@/lib/connection-context'
 import { EMPTY_LAYOUT, paneLeafId, serializeTerminalLayout } from './layout-serialization'
-import { createExpandCollapseActions } from './expand-collapse'
+import {
+  applyExpandedLayoutTo,
+  createExpandCollapseActions,
+  restoreExpandedLayoutFrom
+} from './expand-collapse'
 import { useTerminalKeyboardShortcuts, type SearchState } from './keyboard-handlers'
 import type { MacOptionAsAlt } from './terminal-shortcut-policy'
 import { useEffectiveMacOptionAsAlt } from '@/lib/keyboard-layout/use-effective-mac-option-as-alt'
@@ -50,6 +54,12 @@ type TerminalPaneProps = {
   cwd?: string
   isActive: boolean
   isVisible?: boolean
+  // Why: when set (Activity portal), this pane visually isolates the given
+  // split pane so only that leaf is shown. Implemented as a transient layout
+  // override (separate snapshot ref) — does NOT touch expandedPaneId state
+  // or persist to the layout snapshot, so returning to the workspace shows
+  // the original split layout unchanged.
+  isolatedPaneId?: number | null
   onPtyExit: (ptyId: string) => void
   onCloseTab: () => void
 }
@@ -60,6 +70,7 @@ export default function TerminalPane({
   cwd,
   isActive,
   isVisible = true,
+  isolatedPaneId = null,
   onPtyExit,
   onCloseTab
 }: TerminalPaneProps): React.JSX.Element {
@@ -68,6 +79,14 @@ export default function TerminalPane({
   const paneFontSizesRef = useRef<Map<number, number>>(new Map())
   const expandedPaneIdRef = useRef<number | null>(null)
   const expandedStyleSnapshotRef = useRef<Map<HTMLElement, { display: string; flex: string }>>(
+    new Map()
+  )
+  // Why (separate from expandedStyleSnapshotRef): Activity isolation is a
+  // transient view override that must not collide with the user-facing
+  // expanded-pane state or the layout snapshot. Keeping its own snapshot
+  // map means applyExpandedLayoutTo's internal restore (which targets the
+  // ref it was passed) only clears Activity's overlay, not the user's.
+  const activityIsolationSnapshotRef = useRef<Map<HTMLElement, { display: string; flex: string }>>(
     new Map()
   )
   const paneTransportsRef = useRef<Map<number, PtyTransport>>(new Map())
@@ -99,7 +118,7 @@ export default function TerminalPane({
   // read — the portal map at line ~914 calls `managerRef.current?.getPanes()`
   // imperatively, so `setPaneCount` is used only as a render-trigger side
   // effect to force that map to re-run when a pane is split or closed.
-  const [, setPaneCount] = useState<number>(0)
+  const [paneCount, setPaneCount] = useState<number>(0)
   const [searchOpen, setSearchOpen] = useState(false)
   const searchOpenRef = useRef(false)
   searchOpenRef.current = searchOpen
@@ -509,6 +528,56 @@ export default function TerminalPane({
     setRenamingPaneId,
     setPaneCount
   })
+
+  // Why (Activity-only pane isolation): when this TerminalPane is being
+  // portaled into the Activity page for a specific agent pane, hide the
+  // other split siblings so the user only sees that agent's pane. Uses
+  // applyExpandedLayoutTo with a separate snapshot ref so the override is
+  // independent of the user-facing expanded-pane state and the persisted
+  // layout snapshot — closing Activity restores the original split layout.
+  // useLayoutEffect: layout style writes must land before paint to avoid
+  // a flash of all panes. paneCount is in deps so the effect re-applies
+  // after splits/closes change the manager's pane list.
+  useLayoutEffect(() => {
+    const snapshots = activityIsolationSnapshotRef.current
+    if (isolatedPaneId === null) {
+      restoreExpandedLayoutFrom(snapshots)
+      return
+    }
+    const applied = applyExpandedLayoutTo(isolatedPaneId, {
+      managerRef,
+      containerRef,
+      expandedStyleSnapshotRef: activityIsolationSnapshotRef
+    })
+    if (!applied) {
+      restoreExpandedLayoutFrom(snapshots)
+      return
+    }
+    // Why: refit on rAF so xterm measures the post-layout DOM, not the
+    // pre-toggle one. Mirrors expand-collapse.refreshPaneSizes.
+    const frame = requestAnimationFrame(() => {
+      const manager = managerRef.current
+      if (!manager) {
+        return
+      }
+      for (const pane of manager.getPanes()) {
+        safeFit(pane)
+      }
+    })
+    return () => {
+      cancelAnimationFrame(frame)
+    }
+  }, [isolatedPaneId, paneCount])
+
+  // Why: belt-and-suspenders unmount cleanup. If the component unmounts
+  // while isolation is active (e.g. tab closed mid-Activity-view), restore
+  // sibling display/flex so the captured DOM doesn't leak inline styles.
+  useEffect(() => {
+    const snapshots = activityIsolationSnapshotRef.current
+    return () => {
+      restoreExpandedLayoutFrom(snapshots)
+    }
+  }, [])
 
   const handleRestartCodexPane = useCallback(
     (paneId: number) => {

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -540,9 +540,28 @@ export default function TerminalPane({
   // after splits/closes change the manager's pane list.
   useLayoutEffect(() => {
     const snapshots = activityIsolationSnapshotRef.current
+    // Why: refit on rAF so xterm measures the post-layout DOM, not the
+    // pre-toggle one. Mirrors expand-collapse.refreshPaneSizes. Both the
+    // apply and restore paths must refit — restoring without a fit leaves
+    // xterm sized for the isolated single-pane geometry, so the workspace
+    // view (or staging slot) renders at the wrong cols/rows until some
+    // unrelated event triggers another fit.
+    const scheduleRefit = (): number =>
+      requestAnimationFrame(() => {
+        const manager = managerRef.current
+        if (!manager) {
+          return
+        }
+        for (const pane of manager.getPanes()) {
+          safeFit(pane)
+        }
+      })
     if (isolatedPaneId === null) {
       restoreExpandedLayoutFrom(snapshots)
-      return
+      const frame = scheduleRefit()
+      return () => {
+        cancelAnimationFrame(frame)
+      }
     }
     const applied = applyExpandedLayoutTo(isolatedPaneId, {
       managerRef,
@@ -551,19 +570,12 @@ export default function TerminalPane({
     })
     if (!applied) {
       restoreExpandedLayoutFrom(snapshots)
-      return
+      const frame = scheduleRefit()
+      return () => {
+        cancelAnimationFrame(frame)
+      }
     }
-    // Why: refit on rAF so xterm measures the post-layout DOM, not the
-    // pre-toggle one. Mirrors expand-collapse.refreshPaneSizes.
-    const frame = requestAnimationFrame(() => {
-      const manager = managerRef.current
-      if (!manager) {
-        return
-      }
-      for (const pane of manager.getPanes()) {
-        safeFit(pane)
-      }
-    })
+    const frame = scheduleRefit()
     return () => {
       cancelAnimationFrame(frame)
     }


### PR DESCRIPTION
## Summary
- When the activity page hosts a tab that has split panes, only the agent's specific pane should be visible — not the whole tab.
- Reuses the existing `applyExpandedLayoutTo` helper from `expand-collapse.ts` with a separate snapshot ref, so the activity view's isolation is fully independent of the user-facing expanded-pane state and the persisted layout snapshot. Closing activity restores the original split layout untouched.

## How it works
1. `ActivityTerminalPortalTarget` now carries `paneId` (already known via `paneIdFromPaneKey(thread.paneKey)`).
2. `TabGroupPanel.tsx` (the live tab-group render path) passes that paneId into `TerminalPane` as a new optional `isolatedPaneId` prop on the portaled tab; null elsewhere. `Terminal.tsx` (legacy single-group path) is wired the same way for parity.
3. `TerminalPane` runs a `useLayoutEffect` that calls `applyExpandedLayoutTo` against its own `activityIsolationSnapshotRef` when isolated, restores when null, and re-applies on pane count change (handles split-while-isolated).
4. Unmount cleanup restores siblings, even if the activity view is closed mid-flight.

## Why this isn't hacky
- View-only override: never writes to `expandedPaneId` state, never calls `persistLayoutSnapshot`. That's why returning to the workspace shows the original split layout without any explicit "remember and restore" logic.
- Separate snapshot ref means the activity overlay can't collide with the user's own expand/collapse state.
- Reuses the same DOM-style-toggle primitive the user-facing expand feature uses, instead of inventing a parallel mechanism.

## Validated in dev build
Manually tested end-to-end in a fresh Electron dev build on a 2-pane terminal tab (Claude in pane 1 with prompt "say only the word LEFT", Codex in pane 2 with prompt "say only the word right"):

- ✅ Click LEFT thread → only Claude pane visible, Codex hidden, status bar shows Opus/Claude.
- ✅ Click right thread → only Codex pane visible, Claude hidden, header shows OpenAI Codex.
- ✅ Jump to workspace → both panes restored side-by-side at equal widths, DOM has clean `display: block; flex: 1 1 0%` on both panes (no inline-style leak).
- ✅ Cross-tab thread switch (123432 → activity-page-fixes → back) → 2-pane layout still intact after returning.
- ✅ Store state untouched after returning: `expandedPaneByTabId` stays `false`, `layout.expandedLeafId` stays `null` — confirms the view-only override claim.

## Regression risks audited
1. **User expand/collapse collisions** — Activity uses a separate `activityIsolationSnapshotRef`; `applyExpandedLayoutTo` only clears whichever ref is passed in, so the user-facing `expandedStyleSnapshotRef` is never touched.
2. **Workspace render path no-ops** — `Terminal.tsx` and `TabGroupPanel.tsx` pass `null` when not portaling; the `useLayoutEffect` early-returns into a no-op restore on an empty map.
3. **Single-pane tab** — `applyExpandedLayoutTo` returns `false` when `panes.length <= 1`; the activity branch falls through to `restoreExpandedLayoutFrom(emptyMap)` — no-op.
4. **Pane closed externally while isolated** — fallback path keeps tab visible (verified with a stale thread whose pane was closed).
5. **Inline-style leak on unmount** — belt-and-suspenders `useEffect` cleanup in `TerminalPane.tsx` restores siblings if TerminalPane unmounts mid-isolation.
6. **Split-while-isolated** — `paneCount` is in the effect deps, so the effect re-runs after splits/closes.

## Test plan
- [x] Open Activity for an agent in a tab with multiple split panes — only the agent's pane shows, full-width.
- [x] Close Activity / jump to workspace — the original split layout returns intact.
- [x] Switch between Activity threads in the same tab (different panes) — isolation re-targets correctly.
- [x] Switch between threads in different tabs.
- [x] Single-pane tab — Activity behaves as before (no-op isolation, since the helper returns false on ≤1 panes).
- [x] Pane that was isolated gets closed externally — fallback path leaves the tab visible.
- [x] User-facing expand/collapse of a different pane in the workspace is unaffected (verified by inspection of `expandedStyleSnapshotRef` separation and post-isolation store state).

Made with [Orca](https://github.com/stablyai/orca) 🐋