### PR TITLE
fix(tasks): remove duplicate top band on Tasks page

### DIFF
--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -1794,15 +1794,6 @@ export default function TaskPage(): React.JSX.Element {
 
   return (
     <div className="relative flex h-full min-h-0 flex-1 overflow-hidden bg-background text-foreground">
-      {/* Why: no z-index here. App.tsx's floating titlebar-left (traffic lights
-          + sidebar-expand toggle + agent badge) is absolutely positioned at
-          z-10 in the root stacking context when the sidebar is collapsed. If
-          this wrapper also sits at z-10 it ties with titlebar-left on
-          z-index and wins on DOM order (later sibling), so even though our
-          top-left spacer is pointer-events-none, the click still lands on
-          this wrapper behind the spacer instead of falling through to the
-          sidebar toggle. Keeping this at z-auto lets titlebar-left's z-10
-          paint above our content and receive the click cleanly. */}
       <div className="relative flex min-h-0 flex-1 flex-col">
         {/* Why: pt-1.5 vertically centers this row's 32px icon cluster (X +
             source toggles) with the sidebar's "Tasks" nav row. Sidebar Tasks

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -677,19 +677,6 @@ export default function TaskPage(): React.JSX.Element {
   const searchLinearIssues = useAppStore((s) => s.searchLinearIssues)
   const listLinearIssues = useAppStore((s) => s.listLinearIssues)
   const checkLinearConnection = useAppStore((s) => s.checkLinearConnection)
-  // Why: in workspace view (a worktree is active) App.tsx hides its
-  // full-width titlebar, so this page renders its own 36px titlebar strip to
-  // keep the top band continuous with the sidebar header and tab rows. When
-  // the sidebar is also collapsed, App.tsx floats its titlebar-left controls
-  // (traffic lights, sidebar toggle, agent badge) over our strip — reserve
-  // the measured width of those controls on the left so the titlebar strip
-  // never sits behind them. In non-workspace mode App.tsx already owns the
-  // top titlebar, so skip our strip to avoid a duplicate band.
-  const sidebarOpen = useAppStore((s) => s.sidebarOpen)
-  const activeWorktreeId = useAppStore((s) => s.activeWorktreeId)
-  const workspaceActive = activeWorktreeId !== null
-  const reserveCollapsedHeaderSpace = workspaceActive && !sidebarOpen
-
   const eligibleRepos = useMemo(() => repos.filter((repo) => isGitRepoKind(repo)), [repos])
 
   // Why: initial selection resolution honors (1) an explicit preselection from
@@ -1817,47 +1804,6 @@ export default function TaskPage(): React.JSX.Element {
           sidebar toggle. Keeping this at z-auto lets titlebar-left's z-10
           paint above our content and receive the click cleanly. */}
       <div className="relative flex min-h-0 flex-1 flex-col">
-        {/* Why: in workspace view App.tsx suppresses its full-width titlebar,
-            so render a matching 36px strip here to keep the top band
-            continuous with the sidebar header and tab rows. When the sidebar
-            is collapsed, App.tsx floats its titlebar-left controls (traffic
-            lights, sidebar toggle, agent badge) over the top-left of this
-            page at z-10, and the page wrapper stays at z-auto so that float
-            always paints above our content. Keep the reserved region
-            transparent so the floating titlebar-left's own bg + border-bottom
-            is what the user sees on the left — the two segments then read as
-            one continuous band. The painted remainder is a drag-region so the
-            window stays movable here, matching other top chrome. Skipped in
-            non-workspace mode because App.tsx already owns the top titlebar
-            and a second strip would produce a duplicate band. */}
-        {workspaceActive ? (
-          <div className="flex-none flex h-9">
-            {reserveCollapsedHeaderSpace ? (
-              // Why: the floating titlebar-left hosts real interactive chrome
-              // (sidebar-expand toggle, agent badge) under this segment. Both
-              // pointer-events-none AND WebkitAppRegion='no-drag' are needed:
-              // without pointer-events-none, this transparent div absorbs
-              // clicks before they reach the toggle; without no-drag, Electron
-              // marks the area as window-drag and still consumes clicks even
-              // when the element itself is click-through.
-              <div
-                aria-hidden
-                className="h-full shrink-0 pointer-events-none"
-                style={
-                  {
-                    width: 'var(--collapsed-sidebar-header-width)',
-                    WebkitAppRegion: 'no-drag'
-                  } as React.CSSProperties
-                }
-              />
-            ) : null}
-            <div
-              className="flex h-full flex-1 items-center border-b border-border bg-card"
-              style={{ WebkitAppRegion: 'drag' } as React.CSSProperties}
-            />
-          </div>
-        ) : null}
-
         {/* Why: pt-1.5 vertically centers this row's 32px icon cluster (X +
             source toggles) with the sidebar's "Tasks" nav row. Sidebar Tasks
             center sits 22px below the titlebar (pt-2 + py-1.5 + half size-4


### PR DESCRIPTION
## Summary
- The Activity-page work in #1703 tightened App.tsx's `workspaceActive` to require `activeView === 'terminal'`, so App.tsx now keeps its full-width titlebar on the Tasks page. TaskPage's own `workspaceActive` was still just `activeWorktreeId !== null`, so it kept rendering its own 36px placeholder strip below the App titlebar — producing the doubled band visible when opening Tasks with a worktree active.
- TaskPage only mounts when `activeView === 'tasks'`, where App.tsx never suppresses its titlebar, so the placeholder strip was always redundant. Drop it along with the now-unused `sidebarOpen` / `activeWorktreeId` reads.

## Test plan
- [x] Tasks page with worktree active + sidebar open: single 36px titlebar (verified via Electron, no second band below)
- [x] Tasks page with worktree active + sidebar collapsed: single titlebar with floating titlebar-left controls (traffic lights + sidebar toggle + back/forward) at top-left
- [x] Activity page: unchanged, ActivityTitlebarControls render in App's titlebar as before
- [x] Terminal/workspace view: unchanged, App titlebar is suppressed and tabs extend to top of window
- [x] `pnpm typecheck` passes

Made with [Orca](https://github.com/stablyai/orca) 🐋
