### PR TITLE
Fix start-from-PR display refresh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ docs/*.md
 !.stably/docs/
 .playwright-cli
 .validate-ui-screenshots/
+validation-screenshots/
 .stably-browser
 
 # Playwright

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -222,7 +222,9 @@ export async function createRemoteWorktree(
       ? { displayName: requestedDisplayName }
       : shouldSetDisplayName(requestedName, branchName, sanitizedName)
         ? { displayName: requestedName }
-        : {})
+        : {}),
+    ...(args.linkedIssue !== undefined ? { linkedIssue: args.linkedIssue } : {}),
+    ...(args.linkedPR !== undefined ? { linkedPR: args.linkedPR } : {})
   }
   const meta = store.setWorktreeMeta(worktreeId, metaUpdates)
   const worktree = mergeWorktree(repo.id, created, meta)
@@ -488,7 +490,9 @@ export async function createLocalWorktree(
           sparseBaseRef: baseBranch,
           sparsePresetId
         }
-      : {})
+      : {}),
+    ...(args.linkedIssue !== undefined ? { linkedIssue: args.linkedIssue } : {}),
+    ...(args.linkedPR !== undefined ? { linkedPR: args.linkedPR } : {})
   }
   const meta = store.setWorktreeMeta(worktreeId, metaUpdates)
   const worktree = mergeWorktree(repo.id, created, meta)

--- a/src/main/ipc/worktrees-windows.test.ts
+++ b/src/main/ipc/worktrees-windows.test.ts
@@ -248,20 +248,26 @@ describe('registerWorktreeHandlers – Windows path handling', () => {
     listWorktreesMock.mockResolvedValueOnce([worktreeEntry]).mockResolvedValueOnce([worktreeEntry])
     store.setWorktreeMeta.mockReturnValue({
       lastActivityAt: 123,
-      displayName: 'Improve Dashboard'
+      displayName: 'Improve Dashboard',
+      linkedIssue: 123,
+      linkedPR: 456
     })
     store.getWorktreeMeta.mockImplementation((worktreeId: string) =>
       worktreeId === 'repo-1::C:/workspaces/improve-dashboard'
         ? {
             lastActivityAt: 123,
-            displayName: 'Improve Dashboard'
+            displayName: 'Improve Dashboard',
+            linkedIssue: 123,
+            linkedPR: 456
           }
         : undefined
     )
 
     await handlers['worktrees:create'](null, {
       repoId: 'repo-1',
-      name: 'Improve Dashboard'
+      name: 'Improve Dashboard',
+      linkedIssue: 123,
+      linkedPR: 456
     })
     const listed = await handlers['worktrees:list'](null, {
       repoId: 'repo-1'
@@ -271,6 +277,8 @@ describe('registerWorktreeHandlers – Windows path handling', () => {
       {
         id: 'repo-1::C:/workspaces/improve-dashboard',
         displayName: 'Improve Dashboard',
+        linkedIssue: 123,
+        linkedPR: 456,
         lastActivityAt: 123
       }
     ])

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -21,7 +21,9 @@ const {
   loadHooksMock,
   computeWorktreePathMock,
   ensurePathWithinWorkspaceMock,
-  gitExecFileAsyncMock
+  gitExecFileAsyncMock,
+  getSshGitProviderMock,
+  getActiveMultiplexerMock
 } = vi.hoisted(() => ({
   handleMock: vi.fn(),
   removeHandlerMock: vi.fn(),
@@ -42,7 +44,9 @@ const {
   loadHooksMock: vi.fn(),
   computeWorktreePathMock: vi.fn(),
   ensurePathWithinWorkspaceMock: vi.fn(),
-  gitExecFileAsyncMock: vi.fn()
+  gitExecFileAsyncMock: vi.fn(),
+  getSshGitProviderMock: vi.fn(),
+  getActiveMultiplexerMock: vi.fn()
 }))
 
 vi.mock('electron', () => ({
@@ -72,6 +76,14 @@ vi.mock('../git/repo', () => ({
 
 vi.mock('../github/client', () => ({
   getPRForBranch: getPRForBranchMock
+}))
+
+vi.mock('../providers/ssh-git-dispatch', () => ({
+  getSshGitProvider: getSshGitProviderMock
+}))
+
+vi.mock('./ssh', () => ({
+  getActiveMultiplexer: getActiveMultiplexerMock
 }))
 
 vi.mock('../hooks', () => ({
@@ -169,6 +181,8 @@ describe('registerWorktreeHandlers', () => {
       computeWorktreePathMock,
       ensurePathWithinWorkspaceMock,
       gitExecFileAsyncMock,
+      getSshGitProviderMock,
+      getActiveMultiplexerMock,
       mainWindow.webContents.send,
       store.getRepos,
       store.getRepo,
@@ -340,6 +354,95 @@ describe('registerWorktreeHandlers', () => {
     expect(result).toEqual({
       worktree: expect.objectContaining({
         displayName: 'Fix: dashboards for PRs'
+      })
+    })
+  })
+
+  it('persists linked issue and PR metadata during local create', async () => {
+    listWorktreesMock.mockResolvedValue([
+      {
+        path: '/workspace/improve-dashboard',
+        head: 'abc123',
+        branch: 'improve-dashboard',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+    store.setWorktreeMeta.mockImplementation((_worktreeId, meta) => meta)
+
+    const result = await handlers['worktrees:create'](null, {
+      repoId: 'repo-1',
+      name: 'improve-dashboard',
+      linkedIssue: 123,
+      linkedPR: 456
+    })
+
+    expect(store.setWorktreeMeta).toHaveBeenCalledWith(
+      'repo-1::/workspace/improve-dashboard',
+      expect.objectContaining({
+        linkedIssue: 123,
+        linkedPR: 456
+      })
+    )
+    expect(result).toEqual({
+      worktree: expect.objectContaining({
+        linkedIssue: 123,
+        linkedPR: 456
+      })
+    })
+  })
+
+  it('persists linked issue and PR metadata during remote create', async () => {
+    const repo = {
+      id: 'repo-ssh',
+      path: '/remote/repo',
+      displayName: 'ssh',
+      badgeColor: '#000',
+      addedAt: 0,
+      connectionId: 'conn-1',
+      worktreeBaseRef: 'origin/main'
+    }
+    const provider = {
+      exec: vi.fn().mockResolvedValue({ stdout: '', stderr: '' }),
+      addWorktree: vi.fn().mockResolvedValue(undefined),
+      listWorktrees: vi.fn().mockResolvedValue([
+        {
+          path: '/remote/improve-dashboard',
+          head: 'abc123',
+          branch: 'refs/heads/improve-dashboard',
+          isBare: false,
+          isMainWorktree: false
+        }
+      ])
+    }
+    const mux = {
+      request: vi.fn().mockResolvedValue(undefined),
+      notify: vi.fn()
+    }
+    store.getRepos.mockReturnValue([repo])
+    store.getRepo.mockReturnValue(repo)
+    getSshGitProviderMock.mockReturnValue(provider)
+    getActiveMultiplexerMock.mockReturnValue(mux)
+    store.setWorktreeMeta.mockImplementation((_worktreeId, meta) => meta)
+
+    const result = await handlers['worktrees:create'](null, {
+      repoId: 'repo-ssh',
+      name: 'improve-dashboard',
+      linkedIssue: 123,
+      linkedPR: 456
+    })
+
+    expect(store.setWorktreeMeta).toHaveBeenCalledWith(
+      'repo-ssh::/remote/improve-dashboard',
+      expect.objectContaining({
+        linkedIssue: 123,
+        linkedPR: 456
+      })
+    )
+    expect(result).toEqual({
+      worktree: expect.objectContaining({
+        linkedIssue: 123,
+        linkedPR: 456
       })
     })
   })

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -39,6 +39,7 @@ import {
   FilledBellIcon
 } from './WorktreeCardHelpers'
 import { IssueSection, PrSection, CommentSection } from './WorktreeCardMeta'
+import { getWorktreeCardPrDisplay } from './worktree-card-pr-display'
 import {
   selectLivePtyIdsForWorktree,
   selectRuntimePaneTitlesForWorktree
@@ -178,6 +179,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
           title: issue === null ? 'Issue details unavailable' : 'Loading issue...'
         }
       : null)
+  const prDisplay = getWorktreeCardPrDisplay(pr, worktree.linkedPR)
 
   const isDeleting = deleteState?.isDeleting ?? false
 
@@ -608,13 +610,15 @@ const WorktreeCard = React.memo(function WorktreeCard({
              Layout coupling: spacing here is used to derive size estimates in
              WorktreeList's estimateSize. Update that function if changing spacing. */}
         {((cardProps.includes('issue') && issueDisplay) ||
-          (cardProps.includes('pr') && pr) ||
+          (cardProps.includes('pr') && prDisplay) ||
           (cardProps.includes('comment') && worktree.comment)) && (
           <div className="flex flex-col gap-[3px] mt-0.5">
             {cardProps.includes('issue') && issueDisplay && (
               <IssueSection issue={issueDisplay} onClick={handleEditIssue} />
             )}
-            {cardProps.includes('pr') && pr && <PrSection pr={pr} onClick={handleEditIssue} />}
+            {cardProps.includes('pr') && prDisplay && (
+              <PrSection pr={prDisplay} onClick={handleEditIssue} />
+            )}
             {cardProps.includes('comment') && worktree.comment && (
               <CommentSection comment={worktree.comment} onDoubleClick={handleEditComment} />
             )}

--- a/src/renderer/src/components/sidebar/WorktreeCardMeta.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardMeta.tsx
@@ -11,7 +11,8 @@ import { CircleDot } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import CommentMarkdown from './CommentMarkdown'
 import { PullRequestIcon, prStateLabel, checksLabel } from './WorktreeCardHelpers'
-import type { PRInfo, IssueInfo } from '../../../../shared/types'
+import type { WorktreeCardPrDisplay } from './worktree-card-pr-display'
+import type { IssueInfo } from '../../../../shared/types'
 
 // ── Issue section ────────────────────────────────────────────────────
 
@@ -82,11 +83,14 @@ export function IssueSection({ issue, onClick }: IssueSectionProps): React.JSX.E
 // ── PR section ───────────────────────────────────────────────────────
 
 type PrSectionProps = {
-  pr: PRInfo
+  pr: WorktreeCardPrDisplay
   onClick: (e: React.MouseEvent) => void
 }
 
 export function PrSection({ pr, onClick: _onClick }: PrSectionProps): React.JSX.Element {
+  const state = pr.state
+  const checksStatus = pr.checksStatus
+  const hasChecks = checksStatus && checksStatus !== 'neutral'
   return (
     <HoverCard openDelay={300}>
       <HoverCardTrigger asChild>
@@ -100,11 +104,11 @@ export function PrSection({ pr, onClick: _onClick }: PrSectionProps): React.JSX.
           <PullRequestIcon
             className={cn(
               'size-3 shrink-0',
-              pr.state === 'merged' && 'text-purple-600/70 dark:text-purple-400/70',
-              pr.state === 'open' && 'text-emerald-500/80',
-              pr.state === 'closed' && 'text-muted-foreground/60',
-              pr.state === 'draft' && 'text-muted-foreground/50',
-              (!pr.state || !['merged', 'open', 'closed', 'draft'].includes(pr.state)) &&
+              state === 'merged' && 'text-purple-600/70 dark:text-purple-400/70',
+              state === 'open' && 'text-emerald-500/80',
+              state === 'closed' && 'text-muted-foreground/60',
+              state === 'draft' && 'text-muted-foreground/50',
+              (!state || !['merged', 'open', 'closed', 'draft'].includes(state)) &&
                 'text-muted-foreground opacity-60'
             )}
           />
@@ -122,19 +126,23 @@ export function PrSection({ pr, onClick: _onClick }: PrSectionProps): React.JSX.
         <div className="font-semibold text-[13px]">
           #{pr.number} {pr.title}
         </div>
-        <div className="flex items-center gap-2 text-muted-foreground">
-          <span>State: {prStateLabel(pr.state)}</span>
-          {pr.checksStatus !== 'neutral' && <span>Checks: {checksLabel(pr.checksStatus)}</span>}
-        </div>
-        <a
-          href={pr.url}
-          target="_blank"
-          rel="noreferrer"
-          className="text-muted-foreground underline underline-offset-2 hover:text-foreground"
-          onClick={(e) => e.stopPropagation()}
-        >
-          View on GitHub
-        </a>
+        {state && (
+          <div className="flex items-center gap-2 text-muted-foreground">
+            <span>State: {prStateLabel(state)}</span>
+            {hasChecks && <span>Checks: {checksLabel(checksStatus)}</span>}
+          </div>
+        )}
+        {pr.url && (
+          <a
+            href={pr.url}
+            target="_blank"
+            rel="noreferrer"
+            className="text-muted-foreground underline underline-offset-2 hover:text-foreground"
+            onClick={(e) => e.stopPropagation()}
+          >
+            View on GitHub
+          </a>
+        )}
       </HoverCardContent>
     </HoverCard>
   )

--- a/src/renderer/src/components/sidebar/worktree-card-pr-display.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-card-pr-display.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import type { PRInfo } from '../../../../shared/types'
+import { getWorktreeCardPrDisplay } from './worktree-card-pr-display'
+
+const pr: PRInfo = {
+  number: 123,
+  title: 'Ready PR',
+  state: 'open',
+  url: 'https://github.com/stablyai/orca/pull/123',
+  checksStatus: 'success',
+  updatedAt: '2026-05-13T00:00:00.000Z',
+  mergeable: 'MERGEABLE'
+}
+
+describe('getWorktreeCardPrDisplay', () => {
+  it('uses cached PR details when available', () => {
+    expect(getWorktreeCardPrDisplay(pr, 456)).toBe(pr)
+  })
+
+  it('falls back to linkedPR while PR details load', () => {
+    expect(getWorktreeCardPrDisplay(undefined, 456)).toEqual({
+      number: 456,
+      title: 'Loading PR...'
+    })
+  })
+
+  it('keeps linkedPR visible when PR details are unavailable', () => {
+    expect(getWorktreeCardPrDisplay(null, 456)).toEqual({
+      number: 456,
+      title: 'PR details unavailable'
+    })
+  })
+
+  it('does not show a PR row for unlinked worktrees', () => {
+    expect(getWorktreeCardPrDisplay(undefined, null)).toBeNull()
+  })
+})

--- a/src/renderer/src/components/sidebar/worktree-card-pr-display.ts
+++ b/src/renderer/src/components/sidebar/worktree-card-pr-display.ts
@@ -1,0 +1,31 @@
+import type { PRInfo } from '../../../../shared/types'
+
+export type WorktreeCardPrDisplay =
+  | PRInfo
+  | {
+      number: number
+      title: string
+      state?: PRInfo['state']
+      url?: string
+      checksStatus?: PRInfo['checksStatus']
+    }
+
+export function getWorktreeCardPrDisplay(
+  pr: PRInfo | null | undefined,
+  linkedPR: number | null
+): WorktreeCardPrDisplay | null {
+  if (pr) {
+    return pr
+  }
+
+  if (linkedPR === null) {
+    return null
+  }
+
+  return {
+    number: linkedPR,
+    // Why: linked PR metadata is persisted before GitHub details are cached.
+    // Keep the row visible on cold first render while the PR lookup catches up.
+    title: pr === null ? 'PR details unavailable' : 'Loading PR...'
+  }
+}

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -1237,8 +1237,6 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     async (
       worktreeId: string,
       meta: {
-        linkedIssue?: number
-        linkedPR?: number
         comment?: string
       }
     ): Promise<void> => {
@@ -1297,15 +1295,14 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
             }
           : undefined,
         telemetrySource,
-        linkedWorkItem?.title
+        linkedWorkItem?.title,
+        parsedLinkedIssueNumber ?? undefined,
+        effectiveLinkedPR ?? undefined
       )
       const worktree = result.worktree
 
-      await applyWorktreeMeta(worktree.id, {
-        ...(parsedLinkedIssueNumber !== null ? { linkedIssue: parsedLinkedIssueNumber } : {}),
-        ...(effectiveLinkedPR !== null ? { linkedPR: effectiveLinkedPR } : {}),
-        ...(note.trim() ? { comment: note.trim() } : {})
-      })
+      const trimmedNote = note.trim()
+      await applyWorktreeMeta(worktree.id, trimmedNote ? { comment: trimmedNote } : {})
 
       const issueCommand =
         shouldRunIssueAutomation && issueCommandTrustDecision === 'run'
@@ -1447,16 +1444,14 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
               }
             : undefined,
           telemetrySource,
-          linkedWorkItem?.title
+          linkedWorkItem?.title,
+          parsedLinkedIssueNumber ?? undefined,
+          effectiveLinkedPR ?? undefined
         )
         const worktree = result.worktree
 
         const trimmedNote = note.trim()
-        await applyWorktreeMeta(worktree.id, {
-          ...(parsedLinkedIssueNumber !== null ? { linkedIssue: parsedLinkedIssueNumber } : {}),
-          ...(effectiveLinkedPR !== null ? { linkedPR: effectiveLinkedPR } : {}),
-          ...(trimmedNote ? { comment: trimmedNote } : {})
-        })
+        await applyWorktreeMeta(worktree.id, trimmedNote ? { comment: trimmedNote } : {})
 
         // Why: when a linked work item is selected in the quick flow, launch
         // the agent with a blank prompt and type the URL into its input as a

--- a/src/renderer/src/lib/launch-work-item-direct.ts
+++ b/src/renderer/src/lib/launch-work-item-direct.ts
@@ -220,27 +220,22 @@ export async function launchWorkItemDirect(args: LaunchWorkItemDirectArgs): Prom
       finalSetupDecision,
       undefined,
       telemetrySource,
-      item.title
+      item.title,
+      item.type === 'issue' && item.number ? item.number : undefined,
+      item.type === 'pr' && item.number ? item.number : undefined
     )
     worktreeId = result.worktree.id
     const worktreePath = result.worktree.path
     const meta: {
-      linkedIssue?: number
-      linkedPR?: number
       linkedLinearIssue?: string
     } = {}
-    if (item.type === 'issue' && item.number) {
-      meta.linkedIssue = item.number
-    } else if (item.type === 'pr' && item.number) {
-      meta.linkedPR = item.number
-    }
     if (item.linearIdentifier) {
       meta.linkedLinearIssue = item.linearIdentifier
     }
     if (Object.keys(meta).length > 0) {
-      // Why: the Project direct-launch path activates the new workspace
-      // immediately. Persist the link first so the first sidebar render can
-      // show the issue/PR association instead of briefly looking unlinked.
+      // Why: Project direct-launch activates the new workspace immediately.
+      // GitHub issue/PR links are persisted during create; Linear metadata
+      // still uses a best-effort follow-up because create args do not carry it.
       // Best-effort: the worktree is already created on disk, so a meta
       // write failure must not abort activation and orphan it.
       void store.updateWorktreeMeta(worktreeId, meta).catch(() => {

--- a/src/renderer/src/store/slices/worktree-helpers.ts
+++ b/src/renderer/src/store/slices/worktree-helpers.ts
@@ -69,7 +69,9 @@ export type WorktreeSlice = {
      *  so existing callers default to `unknown`; specify when the surface
      *  matters for the activation funnel. */
     telemetrySource?: WorkspaceCreateTelemetrySource,
-    displayName?: string
+    displayName?: string,
+    linkedIssue?: number,
+    linkedPR?: number
   ) => Promise<CreateWorktreeResult>
   removeWorktree: (
     worktreeId: string,

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -228,6 +228,45 @@ describe('createWorktree base status merge', () => {
     vi.clearAllMocks()
   })
 
+  it('passes linked issue and PR metadata through the create IPC payload', async () => {
+    const store = createTestStore()
+    const wt = makeWorktree({
+      id: 'repo1::/path/wt1',
+      repoId: 'repo1',
+      path: '/path/wt1',
+      linkedIssue: 123,
+      linkedPR: 456
+    })
+    mockApi.worktrees.create.mockResolvedValue({ worktree: wt })
+
+    await store
+      .getState()
+      .createWorktree(
+        'repo1',
+        'feature',
+        'origin/main',
+        'inherit',
+        undefined,
+        'sidebar',
+        'Feature Title',
+        123,
+        456
+      )
+
+    expect(mockApi.worktrees.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repoId: 'repo1',
+        name: 'feature',
+        linkedIssue: 123,
+        linkedPR: 456
+      })
+    )
+    expect(store.getState().worktreesByRepo.repo1[0]).toMatchObject({
+      linkedIssue: 123,
+      linkedPR: 456
+    })
+  })
+
   it('does not overwrite a newer reconcile status with the initial checking status', async () => {
     const store = createTestStore()
     const wt = makeWorktree({ id: 'repo1::/path/wt1', repoId: 'repo1', path: '/path/wt1' })

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -224,7 +224,9 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
     setupDecision = 'inherit',
     sparseCheckout,
     telemetrySource,
-    displayName
+    displayName,
+    linkedIssue,
+    linkedPR
   ) => {
     const retryableConflictPatterns = [
       /already exists locally/i,
@@ -245,7 +247,9 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
             setupDecision,
             sparseCheckout,
             ...(displayName ? { displayName } : {}),
-            ...(telemetrySource ? { telemetrySource } : {})
+            ...(telemetrySource ? { telemetrySource } : {}),
+            ...(linkedIssue !== undefined ? { linkedIssue } : {}),
+            ...(linkedPR !== undefined ? { linkedPR } : {})
           })
           // Why: a file watcher (worktrees.onChanged) can fire between the
           // backend creating the worktree and this callback running, causing

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -867,6 +867,8 @@ export type CreateWorktreeArgs = {
   baseBranch?: string
   setupDecision?: SetupDecision
   sparseCheckout?: CreateSparseCheckoutRequest
+  linkedIssue?: number
+  linkedPR?: number
   /** Telemetry-only: which UI surface initiated this create. Threaded from
    *  the renderer entry point so main can emit `workspace_created` with the
    *  correct `source`. `unknown` is a valid wire value — an unrecognized


### PR DESCRIPTION
## Summary
- Fix start-from-PR worktree display refresh behavior.
- Add implementation coverage and focused docs for PR link create/refresh behavior.

## Validation
- Typecheck passed.
- Targeted pnpm test passed 66 tests.
- Lint passed with 6 existing warnings.
- Electron validation round 2 passed all four scenarios; console had 7 WebView detached DOM errors during state swaps/restoration with no assertion failures.
- Local screenshots in validation-screenshots/ are uncommitted.