### PR TITLE
Enable Floating Terminal by default

### DIFF
--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -202,7 +202,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     rightSidebarOpenByDefault: true,
     showTitlebarAppName: true,
     showTasksButton: true,
-    floatingTerminalEnabled: false,
+    floatingTerminalEnabled: true,
     floatingTerminalCwd: '~',
     floatingTerminalTriggerLocation: 'floating-button',
     notifications: getDefaultNotificationSettings(),


### PR DESCRIPTION
## Summary
- enable Floating Terminal by default for new/default settings
- keep the existing default trigger location as the floating button

## Validation
- pnpm typecheck
- pnpm oxlint (existing GitHub project hook warnings only)

Made with [Orca](https://github.com/stablyai/orca) 🐋
