### PR TITLE
Improve Orca Mobile discoverability

### DIFF
--- a/src/renderer/src/components/settings/MobileSettingsPane.tsx
+++ b/src/renderer/src/components/settings/MobileSettingsPane.tsx
@@ -10,7 +10,7 @@ const ORCA_ANDROID_RELEASE_URL = 'https://github.com/stablyai/orca/releases/tag/
 
 const MOBILE_ENABLE_SEARCH_ENTRY: SettingsSearchEntry = {
   title: 'Mobile',
-  description: 'Pair a mobile device to control Orca remotely.',
+  description: 'Control terminals and agents from your phone.',
   keywords: [
     'mobile',
     'phone',
@@ -49,7 +49,7 @@ export function MobileSettingsPane({
       {showEnableSetting ? (
         <SearchableSetting
           title="Mobile"
-          description="Pair a mobile device to control Orca remotely."
+          description="Control terminals and agents from your phone."
           keywords={MOBILE_ENABLE_SEARCH_ENTRY.keywords}
           className="space-y-3 px-1 py-2"
         >

--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -274,7 +274,7 @@ function Settings(): React.JSX.Element {
   )
 
   useEffect(() => {
-    if (!settingsNavigationTarget) {
+    if (!settings || !settingsNavigationTarget) {
       return
     }
 
@@ -285,7 +285,7 @@ function Settings(): React.JSX.Element {
     pendingNavSectionRef.current = paneSectionId
     pendingScrollTargetRef.current = settingsNavigationTarget.sectionId ?? paneSectionId
     clearSettingsTarget()
-  }, [clearSettingsTarget, settingsNavigationTarget])
+  }, [clearSettingsTarget, settings, settingsNavigationTarget])
 
   useEffect(() => {
     if (terminalFontsLoadedRef.current) {
@@ -436,7 +436,7 @@ function Settings(): React.JSX.Element {
       {
         id: 'mobile',
         title: 'Mobile',
-        description: 'Pair and manage mobile devices.',
+        description: 'Control terminals and agents from your phone.',
         icon: Smartphone,
         searchEntries: MOBILE_SETTINGS_PANE_SEARCH_ENTRIES,
         badge: 'Beta'
@@ -795,7 +795,7 @@ function Settings(): React.JSX.Element {
                   id="mobile"
                   title="Mobile"
                   badge="Beta"
-                  description="Pair and manage mobile devices."
+                  description="Control terminals and agents from your phone."
                   searchEntries={MOBILE_SETTINGS_PANE_SEARCH_ENTRIES}
                 >
                   <MobileSettingsPane settings={settings} updateSettings={updateSettings} />

--- a/src/renderer/src/components/sidebar/SidebarToolbar.tsx
+++ b/src/renderer/src/components/sidebar/SidebarToolbar.tsx
@@ -1,5 +1,12 @@
 import React, { useState } from 'react'
-import { ExternalLink, FolderPlus, Github, MessageSquareText, Settings } from 'lucide-react'
+import {
+  ExternalLink,
+  FolderPlus,
+  Github,
+  MessageSquareText,
+  Settings,
+  Smartphone
+} from 'lucide-react'
 import { useAppStore } from '@/store'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
@@ -233,7 +240,13 @@ function FeedbackDialog({
 const SidebarToolbar = React.memo(function SidebarToolbar() {
   const openModal = useAppStore((s) => s.openModal)
   const openSettingsPage = useAppStore((s) => s.openSettingsPage)
+  const openSettingsTarget = useAppStore((s) => s.openSettingsTarget)
   const [feedbackOpen, setFeedbackOpen] = useState(false)
+
+  const openMobileSettings = (): void => {
+    openSettingsTarget({ pane: 'mobile', repoId: null })
+    openSettingsPage()
+  }
 
   return (
     <div className="mt-auto shrink-0">
@@ -255,6 +268,22 @@ const SidebarToolbar = React.memo(function SidebarToolbar() {
           </TooltipContent>
         </Tooltip>
         <div className="flex items-center gap-1">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                onClick={openMobileSettings}
+                aria-label="Open Orca Mobile settings"
+                className="text-muted-foreground"
+              >
+                <Smartphone className="size-3.5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="top" sideOffset={4}>
+              Orca Mobile
+            </TooltipContent>
+          </Tooltip>
           <Tooltip>
             <TooltipTrigger asChild>
               <Button

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -252,6 +252,7 @@ export type UISlice = {
       | 'agents'
       | 'accounts'
       | 'experimental'
+      | 'mobile'
       | 'ssh'
     repoId: string | null
     sectionId?: string


### PR DESCRIPTION
## Summary
- add an Orca Mobile shortcut to the sidebar footer that deep-links to Settings > Mobile
- allow Settings deep-links to target the Mobile pane reliably after settings load
- update Mobile settings copy to clarify that users can control terminals and agents from their phone

## Validation
- pnpm exec oxlint src/renderer/src/components/settings/Settings.tsx src/renderer/src/components/settings/MobileSettingsPane.tsx src/renderer/src/components/sidebar/SidebarToolbar.tsx src/renderer/src/store/slices/ui.ts
- pnpm run tc:web

Note: `pnpm run tc:web` prints the existing Node engine warning because this shell is on Node v25.9.0 while package.json wants Node 24.

Made with [Orca](https://github.com/stablyai/orca) 🐋
