### PR TITLE
Update Orca Mobile Android release link

### DIFF
--- a/src/renderer/src/components/settings/MobileSettingsPane.tsx
+++ b/src/renderer/src/components/settings/MobileSettingsPane.tsx
@@ -6,7 +6,7 @@ import { useAppStore } from '../../store'
 import { MobilePane, MOBILE_PANE_SEARCH_ENTRIES } from './MobilePane'
 
 const ORCA_IOS_APP_STORE_URL = 'https://apps.apple.com/app/orca-ide/id6766130217'
-const ORCA_ANDROID_RELEASE_URL = 'https://github.com/stablyai/orca/releases/tag/mobile-v0.0.2'
+const ORCA_ANDROID_RELEASE_URL = 'https://github.com/stablyai/orca/releases/tag/mobile-v0.0.7'
 
 const MOBILE_ENABLE_SEARCH_ENTRY: SettingsSearchEntry = {
   title: 'Mobile',
@@ -69,10 +69,9 @@ export function MobileSettingsPane({
                 or the Android APK from{' '}
                 <button
                   type="button"
-                  // Why: Android still ships from the current mobile release tag rather than
-                  // the generic /releases page, which is dominated by desktop
-                  // releases and forces the user to scroll. Update this URL
-                  // when cutting a new mobile-v* tag.
+                  // Why: Android is moving to Google Play soon, but until then
+                  // link directly to the current mobile release tag instead of
+                  // the noisy desktop-dominated releases index.
                   onClick={() => void window.api.shell.openUrl(ORCA_ANDROID_RELEASE_URL)}
                   className="cursor-pointer underline underline-offset-2 hover:text-foreground"
                 >


### PR DESCRIPTION
## Summary
- update the Android APK link in Mobile settings from `mobile-v0.0.2` to `mobile-v0.0.7`
- adjust the inline comment to note this is temporary until Google Play distribution is available

## Validation
- pnpm exec oxlint src/main/ipc/mobile.ts src/preload/index.ts src/preload/api-types.ts src/renderer/src/components/settings/MobileSettingsPane.tsx
- pnpm run tc:node
- pnpm run tc:web

Note: typecheck commands print the existing Node engine warning because this shell is on Node v25.9.0 while package.json wants Node 24.