### PR TITLE
Add floating terminal orchestration setup

### DIFF
--- a/src/renderer/src/components/floating-terminal/FloatingTerminalOrchestrationDialog.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalOrchestrationDialog.tsx
@@ -129,17 +129,12 @@ export function FloatingTerminalOrchestrationDialog({
                 <p className="text-sm font-medium">Orca CLI</p>
                 <p className="flex min-w-0 items-center gap-2 text-xs text-muted-foreground">
                   <span className="shrink-0">{cliLabel}</span>
-                  {cliStatus?.commandPath ? (
+                  {cliInstalled && cliStatus?.commandPath ? (
                     <code className="min-w-0 overflow-x-auto whitespace-nowrap rounded bg-background px-2 py-0.5 text-[11px] text-muted-foreground">
                       {cliStatus.commandPath}
                     </code>
                   ) : null}
                 </p>
-                {cliStatus?.platform === 'darwin' && !cliInstalled ? (
-                  <p className="text-[11px] text-muted-foreground">
-                    macOS may ask for your password so Orca can create the shell command.
-                  </p>
-                ) : null}
               </div>
               <div className="shrink-0">
                 {cliInstalled ? (
@@ -155,11 +150,11 @@ export function FloatingTerminalOrchestrationDialog({
                   </Button>
                 ) : (
                   <Button
-                    variant="default"
-                    size="sm"
+                    variant="outline"
+                    size="xs"
                     onClick={() => void handleInstallCli()}
                     disabled={cliLoading || cliBusy || !cliSupported}
-                    className="gap-1.5"
+                    className="shrink-0 gap-1.5"
                   >
                     {cliBusy ? <Loader2 className="size-3.5 animate-spin" /> : null}
                     Add to PATH

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalOrchestrationDialog.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalOrchestrationDialog.tsx
@@ -1,0 +1,182 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Check, Clipboard, Loader2, Terminal } from 'lucide-react'
+import { toast } from 'sonner'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog'
+import { PASTE_TERMINAL_TEXT_EVENT } from '@/constants/terminal'
+import { ORCHESTRATION_SKILL_INSTALL_COMMAND } from '@/lib/orchestration-install-command'
+import type { CliInstallStatus } from '../../../../shared/cli-install-types'
+
+type FloatingTerminalOrchestrationDialogProps = {
+  open: boolean
+  activeTabId: string | null
+  onOpenChange: (open: boolean) => void
+}
+
+export function FloatingTerminalOrchestrationDialog({
+  open,
+  activeTabId,
+  onOpenChange
+}: FloatingTerminalOrchestrationDialogProps): React.JSX.Element {
+  const [cliStatus, setCliStatus] = useState<CliInstallStatus | null>(null)
+  const [cliLoading, setCliLoading] = useState(false)
+  const [cliBusy, setCliBusy] = useState(false)
+  const [skillBusy, setSkillBusy] = useState(false)
+
+  const refreshCliStatus = useCallback(async (): Promise<void> => {
+    setCliLoading(true)
+    try {
+      setCliStatus(await window.api.cli.getInstallStatus())
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to load CLI status.')
+    } finally {
+      setCliLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (open) {
+      void refreshCliStatus()
+    }
+  }, [open, refreshCliStatus])
+
+  const cliInstalled = cliStatus?.state === 'installed'
+  const cliSupported = cliStatus?.supported ?? false
+  const cliLabel = cliInstalled
+    ? 'orca is already on PATH'
+    : cliLoading
+      ? 'Checking CLI status...'
+      : (cliStatus?.detail ?? 'Register orca so agents can call Orca from a terminal.')
+
+  const handleInstallCli = async (): Promise<void> => {
+    setCliBusy(true)
+    try {
+      const next = await window.api.cli.install()
+      setCliStatus(next)
+      toast.success('Registered `orca` in PATH.')
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to register `orca` in PATH.')
+    } finally {
+      setCliBusy(false)
+    }
+  }
+
+  const handlePasteSkillCommand = async (): Promise<void> => {
+    setSkillBusy(true)
+    try {
+      localStorage.setItem('orca.orchestration.enabled', '1')
+      await window.api.ui.writeClipboardText(ORCHESTRATION_SKILL_INSTALL_COMMAND)
+      if (activeTabId) {
+        window.dispatchEvent(
+          new CustomEvent(PASTE_TERMINAL_TEXT_EVENT, {
+            detail: {
+              tabId: activeTabId,
+              text: ORCHESTRATION_SKILL_INSTALL_COMMAND
+            }
+          })
+        )
+        toast.success('Pasted the skill install command. Press Enter to run it.')
+      } else {
+        toast.success('Copied the skill install command.')
+      }
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to copy skill command.')
+    } finally {
+      setSkillBusy(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="gap-5 sm:max-w-xl">
+        <DialogHeader>
+          <DialogTitle>Enable orchestration</DialogTitle>
+          <DialogDescription>
+            Add the Orca CLI, then install the agent skill in this terminal.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-2">
+          <div className="rounded-md border border-border/60 bg-muted/30 p-3">
+            <div className="grid grid-cols-[1.25rem_minmax(0,1fr)] gap-x-3 gap-y-2 sm:grid-cols-[1.25rem_minmax(0,1fr)_auto]">
+              <div className="mt-0.5 flex size-5 shrink-0 items-center justify-center rounded bg-background text-muted-foreground">
+                {cliInstalled ? <Check className="size-3.5" /> : <Terminal className="size-3.5" />}
+              </div>
+              <div className="min-w-0 space-y-1">
+                <p className="text-sm font-medium">1. Add the Orca CLI to PATH</p>
+                <p className="text-xs text-muted-foreground">{cliLabel}</p>
+              </div>
+              <div className="col-start-2 w-fit sm:col-start-3 sm:row-start-1">
+                {cliInstalled ? (
+                  <Badge variant="outline" className="gap-1.5">
+                    <Check className="size-3" />
+                    Added
+                  </Badge>
+                ) : (
+                  <Button
+                    variant="default"
+                    size="sm"
+                    onClick={() => void handleInstallCli()}
+                    disabled={cliLoading || cliBusy || !cliSupported}
+                    className="gap-1.5"
+                  >
+                    {cliBusy ? <Loader2 className="size-3.5 animate-spin" /> : null}
+                    Add to PATH
+                  </Button>
+                )}
+              </div>
+              <div className="col-start-2 min-w-0 space-y-1 sm:col-end-3">
+                {cliStatus?.commandPath ? (
+                  <code className="inline-block max-w-full overflow-x-auto whitespace-nowrap rounded bg-background px-2 py-0.5 text-[11px] text-muted-foreground">
+                    {cliStatus.commandPath}
+                  </code>
+                ) : null}
+                {cliStatus?.platform === 'darwin' && !cliInstalled ? (
+                  <p className="text-[11px] text-muted-foreground">
+                    macOS may ask for your password so Orca can create the shell command.
+                  </p>
+                ) : null}
+              </div>
+            </div>
+          </div>
+
+          <div className="rounded-md border border-border/60 bg-muted/30 p-3">
+            <div className="grid grid-cols-[1.25rem_minmax(0,1fr)] gap-x-3 gap-y-2 sm:grid-cols-[1.25rem_minmax(0,1fr)_auto]">
+              <div className="mt-0.5 flex size-5 shrink-0 items-center justify-center rounded bg-background text-muted-foreground">
+                <Clipboard className="size-3.5" />
+              </div>
+              <div className="min-w-0 space-y-1">
+                <p className="text-sm font-medium">2. Install the orchestration skill</p>
+                <p className="text-xs text-muted-foreground">
+                  Paste this command into the terminal so agents learn the orchestration commands.
+                </p>
+              </div>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => void handlePasteSkillCommand()}
+                disabled={skillBusy}
+                className="col-start-2 w-fit gap-1.5 sm:col-start-3 sm:row-start-1"
+              >
+                {skillBusy ? <Loader2 className="size-3.5 animate-spin" /> : null}
+                {activeTabId ? 'Paste command' : 'Copy command'}
+              </Button>
+              <div className="col-start-2 min-w-0 sm:col-end-3">
+                <code className="inline-block max-w-full overflow-x-auto whitespace-nowrap rounded bg-background px-2 py-0.5 text-[11px] text-muted-foreground">
+                  {ORCHESTRATION_SKILL_INSTALL_COMMAND}
+                </code>
+              </div>
+            </div>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalOrchestrationDialog.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalOrchestrationDialog.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
-import { Check, Clipboard, Loader2, Terminal } from 'lucide-react'
+import { Check, Clipboard, Copy, Loader2 } from 'lucide-react'
 import { toast } from 'sonner'
-import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -12,18 +11,21 @@ import {
 } from '@/components/ui/dialog'
 import { PASTE_TERMINAL_TEXT_EVENT } from '@/constants/terminal'
 import { ORCHESTRATION_SKILL_INSTALL_COMMAND } from '@/lib/orchestration-install-command'
+import { notifyOrchestrationSetupStateChanged } from '@/lib/orchestration-setup-state'
 import type { CliInstallStatus } from '../../../../shared/cli-install-types'
 
 type FloatingTerminalOrchestrationDialogProps = {
   open: boolean
   activeTabId: string | null
   onOpenChange: (open: boolean) => void
+  onSetupStateChange: () => void
 }
 
 export function FloatingTerminalOrchestrationDialog({
   open,
   activeTabId,
-  onOpenChange
+  onOpenChange,
+  onSetupStateChange
 }: FloatingTerminalOrchestrationDialogProps): React.JSX.Element {
   const [cliStatus, setCliStatus] = useState<CliInstallStatus | null>(null)
   const [cliLoading, setCliLoading] = useState(false)
@@ -60,6 +62,8 @@ export function FloatingTerminalOrchestrationDialog({
     try {
       const next = await window.api.cli.install()
       setCliStatus(next)
+      notifyOrchestrationSetupStateChanged()
+      onSetupStateChange()
       toast.success('Registered `orca` in PATH.')
     } catch (error) {
       toast.error(error instanceof Error ? error.message : 'Failed to register `orca` in PATH.')
@@ -72,6 +76,8 @@ export function FloatingTerminalOrchestrationDialog({
     setSkillBusy(true)
     try {
       localStorage.setItem('orca.orchestration.enabled', '1')
+      localStorage.removeItem('orca.orchestration.setupDismissed')
+      notifyOrchestrationSetupStateChanged()
       await window.api.ui.writeClipboardText(ORCHESTRATION_SKILL_INSTALL_COMMAND)
       if (activeTabId) {
         window.dispatchEvent(
@@ -86,6 +92,10 @@ export function FloatingTerminalOrchestrationDialog({
       } else {
         toast.success('Copied the skill install command.')
       }
+      onSetupStateChange()
+      if (cliInstalled) {
+        onOpenChange(false)
+      }
     } catch (error) {
       toast.error(error instanceof Error ? error.message : 'Failed to copy skill command.')
     } finally {
@@ -93,9 +103,18 @@ export function FloatingTerminalOrchestrationDialog({
     }
   }
 
+  const handleCopySkillCommand = async (): Promise<void> => {
+    try {
+      await window.api.ui.writeClipboardText(ORCHESTRATION_SKILL_INSTALL_COMMAND)
+      toast.success('Copied the skill install command.')
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to copy skill command.')
+    }
+  }
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="gap-5 sm:max-w-xl">
+      <DialogContent className="gap-4 sm:max-w-[620px]">
         <DialogHeader>
           <DialogTitle>Enable orchestration</DialogTitle>
           <DialogDescription>
@@ -103,22 +122,37 @@ export function FloatingTerminalOrchestrationDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <div className="space-y-2">
-          <div className="rounded-md border border-border/60 bg-muted/30 p-3">
-            <div className="grid grid-cols-[1.25rem_minmax(0,1fr)] gap-x-3 gap-y-2 sm:grid-cols-[1.25rem_minmax(0,1fr)_auto]">
-              <div className="mt-0.5 flex size-5 shrink-0 items-center justify-center rounded bg-background text-muted-foreground">
-                {cliInstalled ? <Check className="size-3.5" /> : <Terminal className="size-3.5" />}
-              </div>
+        <div className="min-w-0 divide-y divide-border/60 overflow-hidden rounded-md border border-border/60 bg-muted/20">
+          <div className="min-w-0 px-3 py-3">
+            <div className="flex items-start justify-between gap-4">
               <div className="min-w-0 space-y-1">
-                <p className="text-sm font-medium">1. Add the Orca CLI to PATH</p>
-                <p className="text-xs text-muted-foreground">{cliLabel}</p>
+                <p className="text-sm font-medium">Orca CLI</p>
+                <p className="flex min-w-0 items-center gap-2 text-xs text-muted-foreground">
+                  <span className="shrink-0">{cliLabel}</span>
+                  {cliStatus?.commandPath ? (
+                    <code className="min-w-0 overflow-x-auto whitespace-nowrap rounded bg-background px-2 py-0.5 text-[11px] text-muted-foreground">
+                      {cliStatus.commandPath}
+                    </code>
+                  ) : null}
+                </p>
+                {cliStatus?.platform === 'darwin' && !cliInstalled ? (
+                  <p className="text-[11px] text-muted-foreground">
+                    macOS may ask for your password so Orca can create the shell command.
+                  </p>
+                ) : null}
               </div>
-              <div className="col-start-2 w-fit sm:col-start-3 sm:row-start-1">
+              <div className="shrink-0">
                 {cliInstalled ? (
-                  <Badge variant="outline" className="gap-1.5">
+                  <Button
+                    variant="outline"
+                    size="xs"
+                    disabled
+                    className="shrink-0 gap-1.5 disabled:opacity-100"
+                    aria-label="Orca CLI added to PATH"
+                  >
                     <Check className="size-3" />
                     Added
-                  </Badge>
+                  </Button>
                 ) : (
                   <Button
                     variant="default"
@@ -132,46 +166,46 @@ export function FloatingTerminalOrchestrationDialog({
                   </Button>
                 )}
               </div>
-              <div className="col-start-2 min-w-0 space-y-1 sm:col-end-3">
-                {cliStatus?.commandPath ? (
-                  <code className="inline-block max-w-full overflow-x-auto whitespace-nowrap rounded bg-background px-2 py-0.5 text-[11px] text-muted-foreground">
-                    {cliStatus.commandPath}
-                  </code>
-                ) : null}
-                {cliStatus?.platform === 'darwin' && !cliInstalled ? (
-                  <p className="text-[11px] text-muted-foreground">
-                    macOS may ask for your password so Orca can create the shell command.
-                  </p>
-                ) : null}
-              </div>
             </div>
           </div>
 
-          <div className="rounded-md border border-border/60 bg-muted/30 p-3">
-            <div className="grid grid-cols-[1.25rem_minmax(0,1fr)] gap-x-3 gap-y-2 sm:grid-cols-[1.25rem_minmax(0,1fr)_auto]">
-              <div className="mt-0.5 flex size-5 shrink-0 items-center justify-center rounded bg-background text-muted-foreground">
-                <Clipboard className="size-3.5" />
+          <div className="px-3 py-3">
+            <div className="space-y-2">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0 space-y-1">
+                  <p className="text-sm font-medium">Orchestration skill</p>
+                  <p className="text-xs text-muted-foreground">
+                    Paste this command into the terminal so agents learn orchestration.
+                  </p>
+                </div>
+                <Button
+                  variant="outline"
+                  size="xs"
+                  onClick={() => void handlePasteSkillCommand()}
+                  disabled={skillBusy}
+                  className="shrink-0 gap-1.5"
+                >
+                  {skillBusy ? (
+                    <Loader2 className="size-3.5 animate-spin" />
+                  ) : (
+                    <Clipboard className="size-3.5" />
+                  )}
+                  {activeTabId ? 'Paste' : 'Copy'}
+                </Button>
               </div>
-              <div className="min-w-0 space-y-1">
-                <p className="text-sm font-medium">2. Install the orchestration skill</p>
-                <p className="text-xs text-muted-foreground">
-                  Paste this command into the terminal so agents learn the orchestration commands.
-                </p>
-              </div>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => void handlePasteSkillCommand()}
-                disabled={skillBusy}
-                className="col-start-2 w-fit gap-1.5 sm:col-start-3 sm:row-start-1"
-              >
-                {skillBusy ? <Loader2 className="size-3.5 animate-spin" /> : null}
-                {activeTabId ? 'Paste command' : 'Copy command'}
-              </Button>
-              <div className="col-start-2 min-w-0 sm:col-end-3">
-                <code className="inline-block max-w-full overflow-x-auto whitespace-nowrap rounded bg-background px-2 py-0.5 text-[11px] text-muted-foreground">
+              <div className="flex min-w-0 items-center gap-2 rounded bg-background px-2 py-1.5">
+                <code className="min-w-0 flex-1 text-[11px] leading-relaxed break-all whitespace-normal text-muted-foreground">
                   {ORCHESTRATION_SKILL_INSTALL_COMMAND}
                 </code>
+                <Button
+                  variant="ghost"
+                  size="icon-xs"
+                  className="shrink-0"
+                  onClick={() => void handleCopySkillCommand()}
+                  aria-label="Copy orchestration skill install command"
+                >
+                  <Copy className="size-3.5" />
+                </Button>
               </div>
             </div>
           </div>

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { Maximize2, Minimize2, Minus, TerminalSquare } from 'lucide-react'
+import { Maximize2, Minimize2, Network, X } from 'lucide-react'
 import TabBar from '@/components/tab-bar/TabBar'
 import TerminalPane from '@/components/terminal-pane/TerminalPane'
 import { Button } from '@/components/ui/button'
@@ -8,56 +8,20 @@ import { focusTerminalTabSurface } from '@/lib/focus-terminal-tab-surface'
 import { useAppStore } from '@/store'
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
 import type { TerminalTab } from '../../../../shared/types'
+import { FloatingTerminalOrchestrationDialog } from './FloatingTerminalOrchestrationDialog'
 import { FloatingTerminalResizeHandles } from './FloatingTerminalResizeHandles'
+export { FloatingTerminalToggleButton } from './FloatingTerminalToggleButton'
 import {
   clampFloatingTerminalBounds,
   getDefaultFloatingTerminalBounds,
   getMaximizedFloatingTerminalBounds,
   type FloatingTerminalPanelBounds
 } from './floating-terminal-panel-bounds'
-import { FloatingTerminalIconContextMenu } from './FloatingTerminalIconContextMenu'
 const EMPTY_TERMINAL_TABS: TerminalTab[] = []
 
 type FloatingTerminalPanelProps = {
   open: boolean
   onOpenChange: (open: boolean) => void
-}
-
-export function FloatingTerminalToggleButton({
-  open,
-  onToggle
-}: {
-  open: boolean
-  onToggle: () => void
-}): React.JSX.Element {
-  const shortcutLabel =
-    typeof navigator !== 'undefined' && navigator.userAgent.includes('Mac') ? '⌘⌥T' : 'Ctrl+Alt+T'
-  return (
-    <FloatingTerminalIconContextMenu
-      currentLocation="floating-button"
-      className="fixed bottom-8 right-3 z-40"
-    >
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            type="button"
-            variant="outline"
-            size="icon-sm"
-            className="bg-card/95 shadow-xs"
-            aria-label={open ? 'Minimize floating terminal' : 'Show floating terminal'}
-            aria-pressed={open}
-            onClick={onToggle}
-          >
-            <TerminalSquare className="size-3.5" />
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent
-          side="left"
-          sideOffset={6}
-        >{`${open ? 'Minimize' : 'Show'} floating terminal (${shortcutLabel})`}</TooltipContent>
-      </Tooltip>
-    </FloatingTerminalIconContextMenu>
-  )
 }
 
 export function FloatingTerminalPanel({
@@ -80,6 +44,7 @@ export function FloatingTerminalPanel({
   const [cwd, setCwd] = useState<string | null>(null)
   const [bounds, setBounds] = useState(() => getDefaultFloatingTerminalBounds())
   const [maximized, setMaximized] = useState(false)
+  const [orchestrationDialogOpen, setOrchestrationDialogOpen] = useState(false)
   const restoreBoundsRef = useRef<FloatingTerminalPanelBounds | null>(null)
   const normalizedInitialBoundsRef = useRef(false)
   const panelRef = useRef<HTMLDivElement>(null)
@@ -296,6 +261,16 @@ export function FloatingTerminalPanel({
             />
           </div>
           <div className="flex items-center gap-1 px-2" data-floating-terminal-no-drag>
+            <Button
+              type="button"
+              variant="ghost"
+              size="xs"
+              className="h-6 gap-1.5 px-2 text-xs"
+              onClick={() => setOrchestrationDialogOpen(true)}
+            >
+              <Network className="size-3.5" />
+              Enable orchestration
+            </Button>
             <Tooltip>
               <TooltipTrigger asChild>
                 <Button
@@ -363,6 +338,11 @@ export function FloatingTerminalPanel({
         </div>
       </div>
       {!maximized && <FloatingTerminalResizeHandles bounds={bounds} setBounds={setBounds} />}
+      <FloatingTerminalOrchestrationDialog
+        open={orchestrationDialogOpen}
+        activeTabId={activeTab?.id ?? null}
+        onOpenChange={setOrchestrationDialogOpen}
+      />
     </div>
   )
 }

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
@@ -1,10 +1,16 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { Maximize2, Minimize2, Network, X } from 'lucide-react'
+import { Maximize2, Minimize2, Minus } from 'lucide-react'
 import TabBar from '@/components/tab-bar/TabBar'
 import TerminalPane from '@/components/terminal-pane/TerminalPane'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { focusTerminalTabSurface } from '@/lib/focus-terminal-tab-surface'
+import {
+  ORCHESTRATION_SETUP_STATE_EVENT,
+  hasOrchestrationSetupMarker,
+  isOrchestrationSetupDismissed,
+  notifyOrchestrationSetupStateChanged
+} from '@/lib/orchestration-setup-state'
 import { useAppStore } from '@/store'
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
 import type { TerminalTab } from '../../../../shared/types'
@@ -45,6 +51,9 @@ export function FloatingTerminalPanel({
   const [bounds, setBounds] = useState(() => getDefaultFloatingTerminalBounds())
   const [maximized, setMaximized] = useState(false)
   const [orchestrationDialogOpen, setOrchestrationDialogOpen] = useState(false)
+  const [showOrchestrationSetup, setShowOrchestrationSetup] = useState(
+    () => !hasOrchestrationSetupMarker() && !isOrchestrationSetupDismissed()
+  )
   const restoreBoundsRef = useRef<FloatingTerminalPanelBounds | null>(null)
   const normalizedInitialBoundsRef = useRef(false)
   const panelRef = useRef<HTMLDivElement>(null)
@@ -98,6 +107,39 @@ export function FloatingTerminalPanel({
     }
     focusTerminalTabSurface(activeFloatingTabId)
   }, [activeFloatingTabId, open])
+
+  const refreshOrchestrationSetupVisibility = useCallback(async (): Promise<void> => {
+    if (isOrchestrationSetupDismissed()) {
+      setShowOrchestrationSetup(false)
+      return
+    }
+    if (!hasOrchestrationSetupMarker()) {
+      setShowOrchestrationSetup(true)
+      return
+    }
+    try {
+      const status = await window.api.cli.getInstallStatus()
+      setShowOrchestrationSetup(status.state !== 'installed')
+    } catch {
+      setShowOrchestrationSetup(true)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (open) {
+      void refreshOrchestrationSetupVisibility()
+    }
+  }, [open, refreshOrchestrationSetupVisibility])
+
+  useEffect(() => {
+    const handleSetupStateChange = (): void => {
+      void refreshOrchestrationSetupVisibility()
+    }
+    window.addEventListener(ORCHESTRATION_SETUP_STATE_EVENT, handleSetupStateChange)
+    return () => {
+      window.removeEventListener(ORCHESTRATION_SETUP_STATE_EVENT, handleSetupStateChange)
+    }
+  }, [refreshOrchestrationSetupVisibility])
 
   const createFloatingTab = useCallback(() => {
     const tab = createTab(FLOATING_TERMINAL_WORKTREE_ID, undefined, undefined, { activate: false })
@@ -207,6 +249,12 @@ export function FloatingTerminalPanel({
     }
   }
 
+  const dismissOrchestrationSetup = useCallback(() => {
+    localStorage.setItem('orca.orchestration.setupDismissed', '1')
+    setShowOrchestrationSetup(false)
+    notifyOrchestrationSetupStateChanged()
+  }, [])
+
   return (
     <div
       ref={panelRef}
@@ -261,16 +309,6 @@ export function FloatingTerminalPanel({
             />
           </div>
           <div className="flex items-center gap-1 px-2" data-floating-terminal-no-drag>
-            <Button
-              type="button"
-              variant="ghost"
-              size="xs"
-              className="h-6 gap-1.5 px-2 text-xs"
-              onClick={() => setOrchestrationDialogOpen(true)}
-            >
-              <Network className="size-3.5" />
-              Enable orchestration
-            </Button>
             <Tooltip>
               <TooltipTrigger asChild>
                 <Button
@@ -337,11 +375,47 @@ export function FloatingTerminalPanel({
             : null}
         </div>
       </div>
+      {showOrchestrationSetup ? (
+        <div
+          className="absolute right-4 bottom-4 z-10 w-[280px] rounded-md border border-border/60 bg-card/95 p-3 text-card-foreground shadow-xs"
+          data-floating-terminal-no-drag
+        >
+          <div className="space-y-2">
+            <div className="space-y-0.5">
+              <p className="text-sm font-medium">Enable orchestration</p>
+              <p className="text-xs leading-5 text-muted-foreground">
+                Set up the Orca CLI and agent skill so agents can coordinate through Orca.
+              </p>
+            </div>
+            <div className="flex items-center gap-2">
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="flex-1"
+                onClick={dismissOrchestrationSetup}
+              >
+                Dismiss
+              </Button>
+              <Button
+                type="button"
+                variant="default"
+                size="sm"
+                className="flex-1"
+                onClick={() => setOrchestrationDialogOpen(true)}
+              >
+                Enable
+              </Button>
+            </div>
+          </div>
+        </div>
+      ) : null}
       {!maximized && <FloatingTerminalResizeHandles bounds={bounds} setBounds={setBounds} />}
       <FloatingTerminalOrchestrationDialog
         open={orchestrationDialogOpen}
         activeTabId={activeTab?.id ?? null}
         onOpenChange={setOrchestrationDialogOpen}
+        onSetupStateChange={() => void refreshOrchestrationSetupVisibility()}
       />
     </div>
   )

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalToggleButton.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalToggleButton.tsx
@@ -1,6 +1,7 @@
 import { TerminalSquare } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { FloatingTerminalIconContextMenu } from './FloatingTerminalIconContextMenu'
 
 export function FloatingTerminalToggleButton({
   open,
@@ -12,25 +13,30 @@ export function FloatingTerminalToggleButton({
   const shortcutLabel =
     typeof navigator !== 'undefined' && navigator.userAgent.includes('Mac') ? '⌘⌥T' : 'Ctrl+Alt+T'
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <Button
-          type="button"
-          variant="outline"
-          size="icon-sm"
-          className="fixed bottom-8 right-3 z-40 bg-card/95 shadow-xs"
-          data-floating-terminal-toggle
-          aria-label={open ? 'Hide floating terminal' : 'Show floating terminal'}
-          aria-pressed={open}
-          onClick={onToggle}
-        >
-          <TerminalSquare className="size-3.5" />
-        </Button>
-      </TooltipTrigger>
-      <TooltipContent
-        side="left"
-        sideOffset={6}
-      >{`${open ? 'Hide' : 'Show'} floating terminal (${shortcutLabel})`}</TooltipContent>
-    </Tooltip>
+    <FloatingTerminalIconContextMenu
+      currentLocation="floating-button"
+      className="fixed bottom-8 right-3 z-40"
+    >
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            type="button"
+            variant="outline"
+            size="icon-sm"
+            className="bg-card/95 shadow-xs"
+            data-floating-terminal-toggle
+            aria-label={open ? 'Minimize floating terminal' : 'Show floating terminal'}
+            aria-pressed={open}
+            onClick={onToggle}
+          >
+            <TerminalSquare className="size-3.5" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent
+          side="left"
+          sideOffset={6}
+        >{`${open ? 'Minimize' : 'Show'} floating terminal (${shortcutLabel})`}</TooltipContent>
+      </Tooltip>
+    </FloatingTerminalIconContextMenu>
   )
 }

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalToggleButton.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalToggleButton.tsx
@@ -1,0 +1,36 @@
+import { TerminalSquare } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+
+export function FloatingTerminalToggleButton({
+  open,
+  onToggle
+}: {
+  open: boolean
+  onToggle: () => void
+}): React.JSX.Element {
+  const shortcutLabel =
+    typeof navigator !== 'undefined' && navigator.userAgent.includes('Mac') ? '⌘⌥T' : 'Ctrl+Alt+T'
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          size="icon-sm"
+          className="fixed bottom-8 right-3 z-40 bg-card/95 shadow-xs"
+          data-floating-terminal-toggle
+          aria-label={open ? 'Hide floating terminal' : 'Show floating terminal'}
+          aria-pressed={open}
+          onClick={onToggle}
+        >
+          <TerminalSquare className="size-3.5" />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent
+        side="left"
+        sideOffset={6}
+      >{`${open ? 'Hide' : 'Show'} floating terminal (${shortcutLabel})`}</TooltipContent>
+    </Tooltip>
+  )
+}

--- a/src/renderer/src/components/settings/ExperimentalPane.tsx
+++ b/src/renderer/src/components/settings/ExperimentalPane.tsx
@@ -1,12 +1,6 @@
-import { useState } from 'react'
-import { Copy } from 'lucide-react'
-import { toast } from 'sonner'
 import type { GlobalSettings } from '../../../../shared/types'
-import { Button } from '../ui/button'
 import { Label } from '../ui/label'
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/tooltip'
 import { useAppStore } from '../../store'
-import { ORCHESTRATION_SKILL_INSTALL_COMMAND } from '@/lib/orchestration-install-command'
 import { SearchableSetting } from './SearchableSetting'
 import { matchesSettingsSearch } from './settings-search'
 import { EXPERIMENTAL_PANE_SEARCH_ENTRIES, EXPERIMENTAL_SEARCH_ENTRY } from './experimental-search'
@@ -29,39 +23,10 @@ export function ExperimentalPane({
 }: ExperimentalPaneProps): React.JSX.Element {
   const searchQuery = useAppStore((s) => s.settingsSearchQuery)
   const showPet = matchesSettingsSearch(searchQuery, [EXPERIMENTAL_SEARCH_ENTRY.pet])
-  const showOrchestration = matchesSettingsSearch(searchQuery, [
-    EXPERIMENTAL_SEARCH_ENTRY.orchestration
-  ])
+  const showActivity = matchesSettingsSearch(searchQuery, [EXPERIMENTAL_SEARCH_ENTRY.activity])
   const showWorktreeSymlinks = matchesSettingsSearch(searchQuery, [
     EXPERIMENTAL_SEARCH_ENTRY.symlinks
   ])
-
-  const [orchestrationEnabled, setOrchestrationEnabled] = useState<boolean>(() => {
-    return localStorage.getItem('orca.orchestration.enabled') === '1'
-  })
-
-  const [orchestrationSkillInstalled, setOrchestrationSkillInstalled] = useState<boolean>(() => {
-    return localStorage.getItem('orca.orchestration.skillInstalled') === '1'
-  })
-
-  const toggleOrchestration = (value: boolean): void => {
-    setOrchestrationEnabled(value)
-    localStorage.setItem('orca.orchestration.enabled', value ? '1' : '0')
-  }
-
-  const markOrchestrationSkillInstalled = (value: boolean): void => {
-    setOrchestrationSkillInstalled(value)
-    localStorage.setItem('orca.orchestration.skillInstalled', value ? '1' : '0')
-  }
-
-  const handleCopyOrchestrationCommand = async (): Promise<void> => {
-    try {
-      await window.api.ui.writeClipboardText(ORCHESTRATION_SKILL_INSTALL_COMMAND)
-      toast.success('Copied install command. Run it in your agent project.')
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Failed to copy command.')
-    }
-  }
 
   return (
     <div className="space-y-4">
@@ -104,84 +69,42 @@ export function ExperimentalPane({
         </SearchableSetting>
       ) : null}
 
-      {showOrchestration ? (
+      {showActivity ? (
         <SearchableSetting
-          title="Agent Orchestration"
-          description="Coordinate multiple coding agents via messaging, task DAGs, dispatch, and decision gates."
-          keywords={EXPERIMENTAL_SEARCH_ENTRY.orchestration.keywords}
+          title="Activity Page"
+          description="Slack-style worktree activity feed for agent completions and blocking states."
+          keywords={EXPERIMENTAL_SEARCH_ENTRY.activity.keywords}
           className="space-y-3 px-1 py-2"
         >
           <div className="flex items-start justify-between gap-4">
             <div className="min-w-0 shrink space-y-0.5">
-              <Label>Agent Orchestration</Label>
+              <Label>Activity Page</Label>
               <p className="text-xs text-muted-foreground">
-                Coordinate multiple coding agents with messaging, task DAGs, dispatch with preamble
-                injection, decision gates, and coordinator loops. Experimental — APIs may change.
+                Adds an Activity entry under Tasks with a threaded worktree feed for completed
+                agents, blocking questions, unread state, and worktree creation events. Experimental
+                — the event model and UI may change.
               </p>
             </div>
             <button
+              type="button"
               role="switch"
-              aria-checked={orchestrationEnabled}
-              onClick={() => toggleOrchestration(!orchestrationEnabled)}
+              aria-checked={settings.experimentalActivity}
+              onClick={() =>
+                updateSettings({
+                  experimentalActivity: !settings.experimentalActivity
+                })
+              }
               className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent transition-colors ${
-                orchestrationEnabled ? 'bg-foreground' : 'bg-muted-foreground/30'
+                settings.experimentalActivity ? 'bg-foreground' : 'bg-muted-foreground/30'
               }`}
             >
               <span
                 className={`inline-block h-3.5 w-3.5 transform rounded-full bg-background shadow-sm transition-transform ${
-                  orchestrationEnabled ? 'translate-x-4' : 'translate-x-0.5'
+                  settings.experimentalActivity ? 'translate-x-4' : 'translate-x-0.5'
                 }`}
               />
             </button>
           </div>
-
-          {orchestrationEnabled ? (
-            <div className="space-y-3 rounded-xl border border-border/60 bg-card/50 p-4">
-              <div className="space-y-1">
-                <p className="text-sm font-medium">Install Orchestration Skill</p>
-                <p className="text-xs text-muted-foreground">
-                  Run this in your agent project so agents learn to use inter-agent orchestration
-                  commands.
-                </p>
-              </div>
-              <div className="flex max-w-full items-center gap-2 rounded-lg border border-border/60 bg-background/60 px-3 py-2">
-                <code className="flex-1 overflow-x-auto whitespace-nowrap text-[11px] text-muted-foreground">
-                  {ORCHESTRATION_SKILL_INSTALL_COMMAND}
-                </code>
-                <TooltipProvider delayDuration={250}>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button
-                        variant="ghost"
-                        size="icon-xs"
-                        onClick={() => void handleCopyOrchestrationCommand()}
-                        aria-label="Copy orchestration skill install command"
-                      >
-                        <Copy className="size-3.5" />
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent side="bottom" sideOffset={6}>
-                      Copy
-                    </TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
-              </div>
-              <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
-                <span>
-                  {orchestrationSkillInstalled
-                    ? 'Marked as installed on this machine.'
-                    : "Check off once you've run it in your project."}
-                </span>
-                <button
-                  type="button"
-                  className="underline-offset-2 hover:text-foreground hover:underline"
-                  onClick={() => markOrchestrationSkillInstalled(!orchestrationSkillInstalled)}
-                >
-                  {orchestrationSkillInstalled ? 'Undo' : 'I ran it'}
-                </button>
-              </div>
-            </div>
-          ) : null}
         </SearchableSetting>
       ) : null}
 

--- a/src/renderer/src/components/settings/ExperimentalPane.tsx
+++ b/src/renderer/src/components/settings/ExperimentalPane.tsx
@@ -6,15 +6,13 @@ import { Button } from '../ui/button'
 import { Label } from '../ui/label'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/tooltip'
 import { useAppStore } from '../../store'
+import { ORCHESTRATION_SKILL_INSTALL_COMMAND } from '@/lib/orchestration-install-command'
 import { SearchableSetting } from './SearchableSetting'
 import { matchesSettingsSearch } from './settings-search'
 import { EXPERIMENTAL_PANE_SEARCH_ENTRIES, EXPERIMENTAL_SEARCH_ENTRY } from './experimental-search'
 import { HiddenExperimentalGroup } from './HiddenExperimentalGroup'
 
 export { EXPERIMENTAL_PANE_SEARCH_ENTRIES }
-
-const ORCHESTRATION_SKILL_INSTALL_COMMAND =
-  'npx skills add https://github.com/stablyai/orca --skill orchestration'
 
 type ExperimentalPaneProps = {
   settings: GlobalSettings

--- a/src/renderer/src/components/settings/OrchestrationPane.tsx
+++ b/src/renderer/src/components/settings/OrchestrationPane.tsx
@@ -1,0 +1,147 @@
+import { useEffect, useState } from 'react'
+import { Copy } from 'lucide-react'
+import { toast } from 'sonner'
+import { Button } from '../ui/button'
+import { Label } from '../ui/label'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/tooltip'
+import { ORCHESTRATION_SKILL_INSTALL_COMMAND } from '@/lib/orchestration-install-command'
+import {
+  ORCHESTRATION_SETUP_STATE_EVENT,
+  isOrchestrationSetupEnabled,
+  isOrchestrationSkillMarkedInstalled,
+  notifyOrchestrationSetupStateChanged
+} from '@/lib/orchestration-setup-state'
+import { SearchableSetting } from './SearchableSetting'
+import { matchesSettingsSearch } from './settings-search'
+import { useAppStore } from '../../store'
+import { ORCHESTRATION_PANE_SEARCH_ENTRIES } from './orchestration-search'
+
+export function OrchestrationPane(): React.JSX.Element {
+  const searchQuery = useAppStore((s) => s.settingsSearchQuery)
+  const showOrchestration = matchesSettingsSearch(searchQuery, ORCHESTRATION_PANE_SEARCH_ENTRIES)
+
+  const [orchestrationEnabled, setOrchestrationEnabled] = useState<boolean>(() => {
+    return isOrchestrationSetupEnabled()
+  })
+
+  const [orchestrationSkillInstalled, setOrchestrationSkillInstalled] = useState<boolean>(() => {
+    return isOrchestrationSkillMarkedInstalled()
+  })
+
+  useEffect(() => {
+    const syncSetupState = (): void => {
+      setOrchestrationEnabled(isOrchestrationSetupEnabled())
+      setOrchestrationSkillInstalled(isOrchestrationSkillMarkedInstalled())
+    }
+    window.addEventListener(ORCHESTRATION_SETUP_STATE_EVENT, syncSetupState)
+    return () => {
+      window.removeEventListener(ORCHESTRATION_SETUP_STATE_EVENT, syncSetupState)
+    }
+  }, [])
+
+  const toggleOrchestration = (value: boolean): void => {
+    setOrchestrationEnabled(value)
+    localStorage.setItem('orca.orchestration.enabled', value ? '1' : '0')
+    notifyOrchestrationSetupStateChanged()
+  }
+
+  const markOrchestrationSkillInstalled = (value: boolean): void => {
+    setOrchestrationSkillInstalled(value)
+    localStorage.setItem('orca.orchestration.skillInstalled', value ? '1' : '0')
+    notifyOrchestrationSetupStateChanged()
+  }
+
+  const handleCopyOrchestrationCommand = async (): Promise<void> => {
+    try {
+      await window.api.ui.writeClipboardText(ORCHESTRATION_SKILL_INSTALL_COMMAND)
+      toast.success('Copied install command. Run it in your agent project.')
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to copy command.')
+    }
+  }
+
+  if (!showOrchestration) {
+    return <div />
+  }
+
+  return (
+    <SearchableSetting
+      title="Agent Orchestration"
+      description="Coordinate multiple coding agents via messaging, task DAGs, dispatch, and decision gates."
+      keywords={ORCHESTRATION_PANE_SEARCH_ENTRIES[0].keywords}
+      className="space-y-3 px-1 py-2"
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0 shrink space-y-0.5">
+          <Label>Agent Orchestration</Label>
+          <p className="text-xs text-muted-foreground">
+            Coordinate multiple coding agents with messaging, task DAGs, dispatch with preamble
+            injection, decision gates, and coordinator loops.
+          </p>
+        </div>
+        <button
+          role="switch"
+          aria-checked={orchestrationEnabled}
+          onClick={() => toggleOrchestration(!orchestrationEnabled)}
+          className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent transition-colors ${
+            orchestrationEnabled ? 'bg-foreground' : 'bg-muted-foreground/30'
+          }`}
+        >
+          <span
+            className={`inline-block h-3.5 w-3.5 transform rounded-full bg-background shadow-sm transition-transform ${
+              orchestrationEnabled ? 'translate-x-4' : 'translate-x-0.5'
+            }`}
+          />
+        </button>
+      </div>
+
+      {orchestrationEnabled ? (
+        <div className="space-y-3 rounded-xl border border-border/60 bg-card/50 p-4">
+          <div className="space-y-1">
+            <p className="text-sm font-medium">Install Orchestration Skill</p>
+            <p className="text-xs text-muted-foreground">
+              Run this in your agent project so agents learn to use inter-agent orchestration
+              commands.
+            </p>
+          </div>
+          <div className="flex max-w-full items-center gap-2 rounded-lg border border-border/60 bg-background/60 px-3 py-2">
+            <code className="flex-1 overflow-x-auto whitespace-nowrap text-[11px] text-muted-foreground">
+              {ORCHESTRATION_SKILL_INSTALL_COMMAND}
+            </code>
+            <TooltipProvider delayDuration={250}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon-xs"
+                    onClick={() => void handleCopyOrchestrationCommand()}
+                    aria-label="Copy orchestration skill install command"
+                  >
+                    <Copy className="size-3.5" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" sideOffset={6}>
+                  Copy
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          </div>
+          <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
+            <span>
+              {orchestrationSkillInstalled
+                ? 'Marked as installed on this machine.'
+                : "Check off once you've run it in your project."}
+            </span>
+            <button
+              type="button"
+              className="underline-offset-2 hover:text-foreground hover:underline"
+              onClick={() => markOrchestrationSkillInstalled(!orchestrationSkillInstalled)}
+            >
+              {orchestrationSkillInstalled ? 'Undo' : 'I ran it'}
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </SearchableSetting>
+  )
+}

--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -11,6 +11,7 @@ import {
   Keyboard,
   Lock,
   MousePointerClick,
+  Network,
   ShieldCheck,
   Palette,
   Server,
@@ -44,6 +45,8 @@ import { NotificationsPane, NOTIFICATIONS_PANE_SEARCH_ENTRIES } from './Notifica
 import { SshPane, SSH_PANE_SEARCH_ENTRIES } from './SshPane'
 import { ExperimentalPane, EXPERIMENTAL_PANE_SEARCH_ENTRIES } from './ExperimentalPane'
 import { AgentsPane, AGENTS_PANE_SEARCH_ENTRIES } from './AgentsPane'
+import { OrchestrationPane } from './OrchestrationPane'
+import { ORCHESTRATION_PANE_SEARCH_ENTRIES } from './orchestration-search'
 import { AccountsPane, ACCOUNTS_PANE_SEARCH_ENTRIES } from './AccountsPane'
 import { StatsPane, STATS_PANE_SEARCH_ENTRIES } from '../stats/StatsPane'
 import { IntegrationsPane, INTEGRATIONS_PANE_SEARCH_ENTRIES } from './IntegrationsPane'
@@ -76,6 +79,7 @@ type SettingsNavTarget =
   | 'ssh'
   | 'experimental'
   | 'agents'
+  | 'orchestration'
   | 'mobile'
   | 'repo'
 
@@ -116,18 +120,14 @@ function computerUsePlatformLabel(args: { isWindows: boolean; isMac: boolean }):
 const SECTION_FLASH_CLASS = 'settings-section-flash'
 const SECTION_FLASH_DURATION_MS = 900
 
-function scrollSectionIntoView(sectionId: string, container: HTMLElement | null): void {
+function scrollSectionIntoView(sectionId: string): void {
   const target = document.getElementById(sectionId)
   if (!target) {
     return
   }
-  // Why: centering a tall section pushes its heading above the viewport,
-  // which defeats the purpose of jumping to it. Only center when the whole
-  // section fits; otherwise align to the top so the title is always visible.
-  const fitsInViewport = container
-    ? target.getBoundingClientRect().height <= container.clientHeight
-    : true
-  target.scrollIntoView({ block: fitsInViewport ? 'center' : 'start' })
+  // Why: the scroll spy samples from the upper part of the viewport. Top-align
+  // sidebar jumps so it does not immediately reselect the previous section.
+  target.scrollIntoView({ block: 'start' })
 }
 
 function flashSectionHighlight(sectionId: string): void {
@@ -434,6 +434,13 @@ function Settings(): React.JSX.Element {
         searchEntries: NOTIFICATIONS_PANE_SEARCH_ENTRIES
       },
       {
+        id: 'orchestration',
+        title: 'Orchestration',
+        description: 'Coordinate multiple coding agents through Orca.',
+        icon: Network,
+        searchEntries: ORCHESTRATION_PANE_SEARCH_ENTRIES
+      },
+      {
         id: 'mobile',
         title: 'Mobile',
         description: 'Control terminals and agents from your phone.',
@@ -527,7 +534,7 @@ function Settings(): React.JSX.Element {
     const visibleIds = new Set(visibleNavSections.map((section) => section.id))
 
     if (scrollTargetId && pendingNavSectionId && visibleIds.has(pendingNavSectionId)) {
-      scrollSectionIntoView(scrollTargetId, contentScrollRef.current)
+      scrollSectionIntoView(scrollTargetId)
       flashSectionHighlight(scrollTargetId)
       setActiveSectionId(pendingNavSectionId)
       pendingNavSectionRef.current = null
@@ -632,7 +639,7 @@ function Settings(): React.JSX.Element {
       if (sectionId === 'experimental' && modifiers?.shiftKey) {
         setHiddenExperimentalUnlocked((previous) => !previous)
       }
-      scrollSectionIntoView(sectionId, contentScrollRef.current)
+      scrollSectionIntoView(sectionId)
       flashSectionHighlight(sectionId)
       setActiveSectionId(sectionId)
     },
@@ -789,6 +796,15 @@ function Settings(): React.JSX.Element {
                   searchEntries={NOTIFICATIONS_PANE_SEARCH_ENTRIES}
                 >
                   <NotificationsPane settings={settings} updateSettings={updateSettings} />
+                </SettingsSection>
+
+                <SettingsSection
+                  id="orchestration"
+                  title="Orchestration"
+                  description="Coordinate multiple coding agents through Orca."
+                  searchEntries={ORCHESTRATION_PANE_SEARCH_ENTRIES}
+                >
+                  <OrchestrationPane />
                 </SettingsSection>
 
                 <SettingsSection

--- a/src/renderer/src/components/settings/experimental-search.ts
+++ b/src/renderer/src/components/settings/experimental-search.ts
@@ -16,21 +16,17 @@ export const EXPERIMENTAL_PANE_SEARCH_ENTRIES: SettingsSearchEntry[] = [
     ]
   },
   {
-    title: 'Agent Orchestration',
-    description:
-      'Coordinate multiple coding agents via messaging, task DAGs, dispatch, and decision gates.',
+    title: 'Activity Page',
+    description: 'Slack-style worktree activity feed for agent completions and blocking states.',
     keywords: [
       'experimental',
-      'orchestration',
-      'multi-agent',
+      'activity',
+      'notifications',
       'agents',
-      'coordination',
-      'messaging',
-      'dispatch',
-      'task',
-      'DAG',
-      'worker',
-      'coordinator'
+      'worktrees',
+      'timeline',
+      'unread',
+      'bell'
     ]
   },
   {
@@ -65,6 +61,6 @@ function findEntry(title: string): SettingsSearchEntry {
 
 export const EXPERIMENTAL_SEARCH_ENTRY = {
   pet: findEntry('Pet'),
-  orchestration: findEntry('Agent Orchestration'),
+  activity: findEntry('Activity Page'),
   symlinks: findEntry('Symlinks on worktrees')
 } as const

--- a/src/renderer/src/components/settings/orchestration-search.ts
+++ b/src/renderer/src/components/settings/orchestration-search.ts
@@ -1,0 +1,21 @@
+import type { SettingsSearchEntry } from './settings-search'
+
+export const ORCHESTRATION_PANE_SEARCH_ENTRIES: SettingsSearchEntry[] = [
+  {
+    title: 'Agent Orchestration',
+    description:
+      'Coordinate multiple coding agents via messaging, task DAGs, dispatch, and decision gates.',
+    keywords: [
+      'orchestration',
+      'multi-agent',
+      'agents',
+      'coordination',
+      'messaging',
+      'dispatch',
+      'task',
+      'DAG',
+      'worker',
+      'coordinator'
+    ]
+  }
+]

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.ts
@@ -1,9 +1,11 @@
 import { useEffect, useRef } from 'react'
 import {
   FOCUS_TERMINAL_PANE_EVENT,
+  PASTE_TERMINAL_TEXT_EVENT,
   SYNC_FIT_PANES_EVENT,
   TOGGLE_TERMINAL_PANE_EXPAND_EVENT,
-  type FocusTerminalPaneDetail
+  type FocusTerminalPaneDetail,
+  type PasteTerminalTextDetail
 } from '@/constants/terminal'
 import type { PaneManager } from '@/lib/pane-manager/pane-manager'
 import { fitAndFocusPanes, fitPanes } from './pane-helpers'
@@ -127,6 +129,27 @@ export function useTerminalPaneGlobalEffects({
     }
     window.addEventListener(FOCUS_TERMINAL_PANE_EVENT, onFocusPane)
     return () => window.removeEventListener(FOCUS_TERMINAL_PANE_EVENT, onFocusPane)
+  }, [tabId, managerRef])
+
+  useEffect(() => {
+    const onPasteText = (event: Event): void => {
+      const detail = (event as CustomEvent<PasteTerminalTextDetail | undefined>).detail
+      if (!detail?.tabId || detail.tabId !== tabId || !detail.text) {
+        return
+      }
+      const manager = managerRef.current
+      if (!manager) {
+        return
+      }
+      const pane = manager.getActivePane() ?? manager.getPanes()[0]
+      if (!pane) {
+        return
+      }
+      pane.terminal.paste(detail.text)
+      pane.terminal.focus()
+    }
+    window.addEventListener(PASTE_TERMINAL_TEXT_EVENT, onPasteText)
+    return () => window.removeEventListener(PASTE_TERMINAL_TEXT_EVENT, onPasteText)
   }, [tabId, managerRef])
 
   // Why: sidebar open/close toggles dispatch SYNC_FIT_PANES_EVENT from a

--- a/src/renderer/src/constants/terminal.ts
+++ b/src/renderer/src/constants/terminal.ts
@@ -1,5 +1,6 @@
 export const TOGGLE_TERMINAL_PANE_EXPAND_EVENT = 'orca-toggle-terminal-pane-expand'
 export const FOCUS_TERMINAL_PANE_EVENT = 'orca-focus-terminal-pane'
+export const PASTE_TERMINAL_TEXT_EVENT = 'orca-paste-terminal-text'
 export const SPLIT_TERMINAL_PANE_EVENT = 'orca-split-terminal-pane'
 export const CLOSE_TERMINAL_PANE_EVENT = 'orca-close-terminal-pane'
 
@@ -24,6 +25,11 @@ export type ToggleTerminalPaneExpandDetail = {
 export type FocusTerminalPaneDetail = {
   tabId: string
   paneId: number
+}
+
+export type PasteTerminalTextDetail = {
+  tabId: string
+  text: string
 }
 
 export type SplitTerminalPaneDetail = {

--- a/src/renderer/src/lib/orchestration-install-command.ts
+++ b/src/renderer/src/lib/orchestration-install-command.ts
@@ -1,0 +1,2 @@
+export const ORCHESTRATION_SKILL_INSTALL_COMMAND =
+  'npx skills add https://github.com/stablyai/orca --skill orchestration'

--- a/src/renderer/src/lib/orchestration-setup-state.ts
+++ b/src/renderer/src/lib/orchestration-setup-state.ts
@@ -1,0 +1,21 @@
+export const ORCHESTRATION_SETUP_STATE_EVENT = 'orca:orchestration-setup-state'
+
+export function isOrchestrationSetupEnabled(): boolean {
+  return localStorage.getItem('orca.orchestration.enabled') === '1'
+}
+
+export function isOrchestrationSkillMarkedInstalled(): boolean {
+  return localStorage.getItem('orca.orchestration.skillInstalled') === '1'
+}
+
+export function hasOrchestrationSetupMarker(): boolean {
+  return isOrchestrationSetupEnabled() || isOrchestrationSkillMarkedInstalled()
+}
+
+export function isOrchestrationSetupDismissed(): boolean {
+  return localStorage.getItem('orca.orchestration.setupDismissed') === '1'
+}
+
+export function notifyOrchestrationSetupStateChanged(): void {
+  window.dispatchEvent(new CustomEvent(ORCHESTRATION_SETUP_STATE_EVENT))
+}


### PR DESCRIPTION
## Summary
- add an "Enable orchestration" action to the floating terminal toolbar
- reuse the existing CLI installer to register the orca shell command
- copy and paste the orchestration skill install command into the active floating terminal pane
- share the orchestration install command with Settings

## Test plan
- pnpm run tc:web
- pnpm exec oxlint src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.ts src/renderer/src/components/settings/ExperimentalPane.tsx src/renderer/src/constants/terminal.ts src/renderer/src/lib/orchestration-install-command.ts
- git diff --check

Made with [Orca](https://github.com/stablyai/orca) 🐋
