### PR TITLE
Make Activity default-on

### DIFF
--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -102,7 +102,7 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     experimentalMobile: false,
     mobileAutoRestoreFitMs: null,
     experimentalPet: false,
-    experimentalActivity: false,
+    experimentalActivity: true,
     experimentalWorktreeSymlinks: false,
     terminalWindowsShell: 'powershell.exe',
     terminalWindowsPowerShellImplementation: 'powershell.exe',

--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -95,7 +95,7 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     experimentalMobile: false,
     mobileAutoRestoreFitMs: null,
     experimentalPet: false,
-    experimentalActivity: false,
+    experimentalActivity: true,
     experimentalWorktreeSymlinks: false,
     terminalWindowsShell: 'powershell.exe',
     terminalWindowsPowerShellImplementation: 'powershell.exe',

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -90,6 +90,7 @@ describe('Store', () => {
     expect(settings.terminalFontWeight).toBe(500)
     expect(settings.rightSidebarOpenByDefault).toBe(true)
     expect(settings.showTasksButton).toBe(true)
+    expect(settings.experimentalActivity).toBe(true)
     expect(settings.notifications.customSoundPath).toBeNull()
   })
 
@@ -159,6 +160,7 @@ describe('Store', () => {
     expect(store.getSettings().refreshLocalBaseRefOnWorktreeCreate).toBe(false)
     expect(store.getSettings().rightSidebarOpenByDefault).toBe(true)
     expect(store.getSettings().showTasksButton).toBe(true)
+    expect(store.getSettings().experimentalActivity).toBe(true)
     expect(store.getSettings().notifications.customSoundPath).toBeNull()
     // repos should be loaded
     expect(store.getRepos()).toHaveLength(1)
@@ -664,6 +666,22 @@ describe('Store', () => {
     const store = await createStore()
 
     expect(store.getSettings().experimentalPet).toBe(true)
+  })
+
+  it('promotes legacy experimentalActivity profiles to default-on', async () => {
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [],
+      worktreeMeta: {},
+      settings: { experimentalActivity: false },
+      ui: {},
+      githubCache: { pr: {}, issue: {} },
+      workspaceSession: {}
+    })
+
+    const store = await createStore()
+
+    expect(store.getSettings().experimentalActivity).toBe(true)
   })
 
   // ── inline-agents card-property migration ──────────────────────────

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -287,6 +287,10 @@ export class Store {
             // the old persisted flag forward once so enabled users don't lose it.
             experimentalPet:
               parsed.settings?.experimentalPet ?? readLegacySidekickFlag(parsed) ?? false,
+            // Why: Activity graduated from its experimental gate. Force the
+            // legacy flag on so existing profiles and rollback builds see the
+            // same default-on behavior as fresh installs.
+            experimentalActivity: true,
             terminalMacOptionAsAlt: migratedOptionAsAlt,
             terminalMacOptionAsAltMigrated: true,
             notifications: {

--- a/src/relay/fs-handler-stream.test.ts
+++ b/src/relay/fs-handler-stream.test.ts
@@ -242,12 +242,29 @@ describe('FsHandler readFileStream', () => {
     }
 
     const isStale = () => false
-    for (let i = 0; i < 16; i++) {
-      await dispatcher.callRequest('fs.readFileStream', { filePath: paths[i] }, { isStale })
+    const queuedPumps: (() => void)[] = []
+    // Why: the concurrency cap is about registered active streams. Hold the
+    // scheduled pumps so fast CI machines cannot finish early streams before
+    // the 17th request checks the registry size.
+    const setImmediateSpy = vi
+      .spyOn(globalThis, 'setImmediate')
+      .mockImplementation((callback: (...args: unknown[]) => void, ...args: unknown[]) => {
+        queuedPumps.push(() => callback(...args))
+        return {} as NodeJS.Immediate
+      })
+    try {
+      for (let i = 0; i < 16; i++) {
+        await dispatcher.callRequest('fs.readFileStream', { filePath: paths[i] }, { isStale })
+      }
+      await expect(
+        dispatcher.callRequest('fs.readFileStream', { filePath: paths[16] }, { isStale })
+      ).rejects.toThrow(/Too many concurrent streams/)
+    } finally {
+      setImmediateSpy.mockRestore()
     }
-    await expect(
-      dispatcher.callRequest('fs.readFileStream', { filePath: paths[16] }, { isStale })
-    ).rejects.toThrow(/Too many concurrent streams/)
+    for (const runPump of queuedPumps) {
+      runPump()
+    }
     await flush(50)
   }, 20_000)
 })

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -229,7 +229,6 @@ function App(): React.JSX.Element {
   const isFullScreen = useAppStore((s) => s.isFullScreen)
   const settings = useAppStore((s) => s.settings)
   const petEnabled = useAppStore((s) => s.settings?.experimentalPet === true)
-  const activityEnabled = settings?.experimentalActivity === true
   const petVisible = useAppStore((s) => s.petVisible)
   const canGoBackWorktree = useAppStore(canGoBackWorktreeHistory)
   const canGoForwardWorktree = useAppStore(canGoForwardWorktreeHistory)
@@ -957,12 +956,6 @@ function App(): React.JSX.Element {
     }
   }, [activeView, rightSidebarOpen, actions])
 
-  useEffect(() => {
-    if (settings && !activityEnabled && activeView === 'activity') {
-      actions.setActiveView('terminal')
-    }
-  }, [activeView, activityEnabled, actions, settings])
-
   return (
     <div
       className="flex flex-col h-screen w-screen overflow-hidden"
@@ -1002,7 +995,7 @@ function App(): React.JSX.Element {
                 >
                   {titlebarLeftControls}
                 </div>
-                {activeView === 'activity' && activityEnabled ? (
+                {activeView === 'activity' ? (
                   <ActivityTitlebarControls />
                 ) : (
                   <div
@@ -1122,9 +1115,7 @@ function App(): React.JSX.Element {
                   <Suspense fallback={null}>
                     {activeView === 'settings' ? <Settings /> : null}
                     {activeView === 'tasks' ? <TaskPage /> : null}
-                    {activeView === 'activity' && activityEnabled ? (
-                      <ActivityPrototypePage />
-                    ) : null}
+                    {activeView === 'activity' ? <ActivityPrototypePage /> : null}
                     {activeView === 'terminal' && !activeWorktreeId ? <Landing /> : null}
                   </Suspense>
                 </div>

--- a/src/renderer/src/components/settings/ExperimentalPane.tsx
+++ b/src/renderer/src/components/settings/ExperimentalPane.tsx
@@ -34,7 +34,6 @@ export function ExperimentalPane({
   const showOrchestration = matchesSettingsSearch(searchQuery, [
     EXPERIMENTAL_SEARCH_ENTRY.orchestration
   ])
-  const showActivity = matchesSettingsSearch(searchQuery, [EXPERIMENTAL_SEARCH_ENTRY.activity])
   const showWorktreeSymlinks = matchesSettingsSearch(searchQuery, [
     EXPERIMENTAL_SEARCH_ENTRY.symlinks
   ])
@@ -185,45 +184,6 @@ export function ExperimentalPane({
               </div>
             </div>
           ) : null}
-        </SearchableSetting>
-      ) : null}
-
-      {showActivity ? (
-        <SearchableSetting
-          title="Activity Page"
-          description="Slack-style worktree activity feed for agent completions and blocking states."
-          keywords={EXPERIMENTAL_SEARCH_ENTRY.activity.keywords}
-          className="space-y-3 px-1 py-2"
-        >
-          <div className="flex items-start justify-between gap-4">
-            <div className="min-w-0 shrink space-y-0.5">
-              <Label>Activity Page</Label>
-              <p className="text-xs text-muted-foreground">
-                Adds an Activity entry under Tasks with a threaded worktree feed for completed
-                agents, blocking questions, unread state, and worktree creation events. Experimental
-                — the event model and UI may change.
-              </p>
-            </div>
-            <button
-              type="button"
-              role="switch"
-              aria-checked={settings.experimentalActivity}
-              onClick={() =>
-                updateSettings({
-                  experimentalActivity: !settings.experimentalActivity
-                })
-              }
-              className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent transition-colors ${
-                settings.experimentalActivity ? 'bg-foreground' : 'bg-muted-foreground/30'
-              }`}
-            >
-              <span
-                className={`inline-block h-3.5 w-3.5 transform rounded-full bg-background shadow-sm transition-transform ${
-                  settings.experimentalActivity ? 'translate-x-4' : 'translate-x-0.5'
-                }`}
-              />
-            </button>
-          </div>
         </SearchableSetting>
       ) : null}
 

--- a/src/renderer/src/components/settings/experimental-search.ts
+++ b/src/renderer/src/components/settings/experimental-search.ts
@@ -34,20 +34,6 @@ export const EXPERIMENTAL_PANE_SEARCH_ENTRIES: SettingsSearchEntry[] = [
     ]
   },
   {
-    title: 'Activity Page',
-    description: 'Slack-style worktree activity feed for agent completions and blocking states.',
-    keywords: [
-      'experimental',
-      'activity',
-      'notifications',
-      'agents',
-      'worktrees',
-      'timeline',
-      'unread',
-      'bell'
-    ]
-  },
-  {
     title: 'Symlinks on worktrees',
     description:
       'Automatically symlink configured files or folders into newly created worktrees so shared state (envs, caches, installs) stays connected.',
@@ -80,6 +66,5 @@ function findEntry(title: string): SettingsSearchEntry {
 export const EXPERIMENTAL_SEARCH_ENTRY = {
   pet: findEntry('Pet'),
   orchestration: findEntry('Agent Orchestration'),
-  activity: findEntry('Activity Page'),
   symlinks: findEntry('Symlinks on worktrees')
 } as const

--- a/src/renderer/src/components/sidebar/SidebarNav.tsx
+++ b/src/renderer/src/components/sidebar/SidebarNav.tsx
@@ -20,7 +20,6 @@ const SidebarNav = React.memo(function SidebarNav() {
   // Why: the setting is opt-out (default true). `!== false` keeps the button
   // visible for users whose persisted settings predate this field.
   const showTasksButton = useAppStore((s) => s.settings?.showTasksButton !== false)
-  const showActivityButton = useAppStore((s) => s.settings?.experimentalActivity === true)
 
   // Why: warm the GitHub work-item cache on hover/focus so by the time the
   // user's click finishes the round-trip has either completed or is already
@@ -52,9 +51,6 @@ const SidebarNav = React.memo(function SidebarNav() {
   const tasksActive = activeView === 'tasks'
   const activityActive = activeView === 'activity'
   const activityUnreadCount = useAppStore((s) => {
-    if (s.settings?.experimentalActivity !== true) {
-      return 0
-    }
     let count = 0
     for (const worktrees of Object.values(s.worktreesByRepo)) {
       for (const worktree of worktrees) {
@@ -142,30 +138,28 @@ const SidebarNav = React.memo(function SidebarNav() {
           </span>
         </button>
       ) : null}
-      {showActivityButton ? (
-        <button
-          type="button"
-          onClick={openActivityPage}
-          aria-current={activityActive ? 'page' : undefined}
-          className={cn(
-            'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] font-medium tracking-tight transition-colors',
-            activityActive
-              ? 'bg-sidebar-accent text-sidebar-accent-foreground'
-              : 'text-sidebar-foreground/60 hover:bg-sidebar-foreground/8'
-          )}
-        >
-          <Bell
-            className={cn('size-4 shrink-0', !activityActive && 'text-sidebar-foreground/30')}
-            strokeWidth={activityActive ? 2.25 : 1.75}
-          />
-          <span className="flex-1">Activity</span>
-          {activityUnreadCount > 0 ? (
-            <span className="rounded-full bg-primary px-1.5 py-px text-[10px] font-semibold text-primary-foreground">
-              {activityUnreadCount}
-            </span>
-          ) : null}
-        </button>
-      ) : null}
+      <button
+        type="button"
+        onClick={openActivityPage}
+        aria-current={activityActive ? 'page' : undefined}
+        className={cn(
+          'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] font-medium tracking-tight transition-colors',
+          activityActive
+            ? 'bg-sidebar-accent text-sidebar-accent-foreground'
+            : 'text-sidebar-foreground/60 hover:bg-sidebar-foreground/8'
+        )}
+      >
+        <Bell
+          className={cn('size-4 shrink-0', !activityActive && 'text-sidebar-foreground/30')}
+          strokeWidth={activityActive ? 2.25 : 1.75}
+        />
+        <span className="flex-1">Activity</span>
+        {activityUnreadCount > 0 ? (
+          <span className="rounded-full bg-primary px-1.5 py-px text-[10px] font-semibold text-primary-foreground">
+            {activityUnreadCount}
+          </span>
+        ) : null}
+      </button>
       <button
         type="button"
         onClick={() => openModal('worktree-palette')}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -240,7 +240,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     // Why: off by default — opt-in cosmetic joke feature. Leaving the default
     // false keeps the overlay unmounted for users who never enable it.
     experimentalPet: false,
-    experimentalActivity: false,
+    experimentalActivity: true,
     experimentalWorktreeSymlinks: false,
     // Why: hydrate an empty default so the renderer's optional-chained reads
     // (`settings?.githubProjects?.activeProject`) land on a stable shape

--- a/src/shared/telemetry-events.ts
+++ b/src/shared/telemetry-events.ts
@@ -174,7 +174,6 @@ export const SETTINGS_CHANGED_WHITELIST = [
   'openLinksInApp',
   'experimentalMobile',
   'experimentalPet',
-  'experimentalActivity',
   'experimentalWorktreeSymlinks',
   'geminiCliOAuthEnabled'
 ] as const satisfies readonly BooleanGlobalSettingsKey[]

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1284,9 +1284,8 @@ export type GlobalSettings = {
   /** Legacy persisted key from before the sidekick -> pet rename. Read only
    *  during migration; new writes use experimentalPet. */
   experimentalSidekick?: boolean
-  /** Experimental: Slack-style Activity page that groups agent/worktree status
-   *  events by worktree. Opt-in while the UI and backend event model are still
-   *  being refined. */
+  /** Legacy persisted flag from when Activity was experimental. Activity is
+   *  now default-on and this no longer gates the page. */
   experimentalActivity: boolean
   /** Experimental: when creating a worktree, automatically symlink a
    *  user-configured set of files/folders from the primary checkout (e.g.


### PR DESCRIPTION
## Summary
- Enable Activity by default and remove the experimental runtime gate.
- Always show the Activity sidebar entry and render the Activity page/titlebar controls.
- Remove Activity from Experimental settings/search while keeping the legacy `experimentalActivity` field normalized to `true` for existing profiles.
- Stabilize the relay stream concurrency-limit test that failed CI by holding scheduled pumps until the 17th active-stream assertion runs.

## Verification
- `pnpm run tc:web`
- `pnpm run tc:node`
- `pnpm exec vitest run --config config/vitest.config.ts src/main/persistence.test.ts src/main/codex-accounts/service.test.ts src/main/codex-accounts/runtime-home-service.test.ts src/shared/telemetry-events.test.ts`
- `pnpm exec oxlint src/main/codex-accounts/runtime-home-service.test.ts src/main/codex-accounts/service.test.ts src/main/persistence.test.ts src/main/persistence.ts src/renderer/src/App.tsx src/renderer/src/components/settings/ExperimentalPane.tsx src/renderer/src/components/settings/experimental-search.ts src/renderer/src/components/sidebar/SidebarNav.tsx src/shared/constants.ts src/shared/telemetry-events.ts src/shared/types.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/relay/fs-handler-stream.test.ts`
- `pnpm exec oxlint src/relay/fs-handler-stream.test.ts`
- Focused `src/relay/fs-handler-stream.test.ts` passed 10 consecutive local runs.
- Electron validation with a fresh isolated dev profile:
  - `settings.experimentalActivity === true`
  - Sidebar shows Activity by default for a new user.
  - Clicking Activity opens the Activity page and renders the empty state.
  - Settings search for `activity` returns no Activity setting.

## Local note
- Full local `pnpm test` is blocked by a local native-module mismatch: `better-sqlite3` was compiled for `NODE_MODULE_VERSION 145`, while this Node runtime needs `137`. The CI failure was isolated to `src/relay/fs-handler-stream.test.ts` and is addressed here.
- `pnpm run tc:cli` is still blocked by existing TS6307 project file-list errors unrelated to this change.

Made with [Orca](https://github.com/stablyai/orca) 🐋