### PR TITLE
test(e2e): make terminal-attention BEL emission PATH-independent

### DIFF
--- a/tests/e2e/terminal-attention.spec.ts
+++ b/tests/e2e/terminal-attention.spec.ts
@@ -78,11 +78,13 @@ async function activateTerminalTab(page: Page, tabId: string): Promise<void> {
 }
 
 async function emitBell(page: Page, ptyId: string): Promise<void> {
-  // Why: `tput bel` is the canonical way to emit BEL from the shell — this is
-  // the exact command the user will run to reproduce the attention path. Prefer
-  // it over `node -e` so the test exercises the same PTY byte stream a real
-  // user sees.
-  await execInTerminal(page, ptyId, `tput bel`)
+  // Why: `printf '\a'` emits a raw BEL byte without depending on terminfo or
+  // PATH-resolved binaries. CI shells can launch with a stripped PATH that
+  // excludes `/usr/bin`, breaking `tput` and silently emitting nothing —
+  // the `bash: groups: command not found` startup output in failure
+  // snapshots is the same symptom. printf is a shell builtin, so it works
+  // even when the PATH is broken.
+  await execInTerminal(page, ptyId, `printf '\\a'`)
 }
 
 async function proveShellReadyWithSingleWrite(page: Page, ptyId: string): Promise<void> {

--- a/tests/e2e/terminal-attention.spec.ts
+++ b/tests/e2e/terminal-attention.spec.ts
@@ -184,11 +184,9 @@ test.describe('Terminal attention', () => {
     // async PTY pipeline.
     await emitBell(orcaPage, activePtyId)
     const MARKER_TITLE = 'focused-tab-bell-marker'
-    await execInTerminal(
-      orcaPage,
-      activePtyId,
-      `node -e "process.stdout.write('\\u001b]0;${MARKER_TITLE}\\u0007')"`
-    )
+    // Why: printf is a shell builtin so it works even when CI launches the
+    // shell with a stripped PATH (no /usr/bin → no `node` resolvable).
+    await execInTerminal(orcaPage, activePtyId, `printf '\\033]0;${MARKER_TITLE}\\007'`)
 
     await expect
       .poll(


### PR DESCRIPTION
## Summary

Two test-only changes to `tests/e2e/terminal-attention.spec.ts` so the BEL/title-marker emission no longer depends on PATH-resolved binaries:

- Replace `tput bel` with `printf '\a'` in `emitBell()`
- Replace `node -e "..."` with `printf '\033]0;...\007'` for the OSC title marker

## Why

CI Linux runners launch the daemon-spawned shell with a stripped PATH (no `/usr/bin`). The failure page snapshot consistently shows the symptom in the bash startup output:

\`\`\`
bash: groups: command not found
* /usr/bin/groups
The command could not be located because '/bin:/usr/bin' is not included in the PATH environment variable.
\`\`\`

`tput` lives in `/usr/bin` and `node` is also PATH-resolved, so neither runs under that environment — the BEL byte / OSC marker never reaches xterm and the unread/title assertions hang. `printf` is a shell builtin, so it works regardless of PATH.

This was discovered while investigating a deterministic e2e failure on a different branch and verified locally: the affected test passes on macOS with `tput` but the CI Linux failure mode reproduces every run.

## Test plan
- [x] All three `terminal-attention` tests pass locally with the change
- [ ] CI run on this PR confirms the Linux flake is gone

Made with [Orca](https://github.com/stablyai/orca) 🐋
