### PR TITLE
Rename Activity tab to Agent View

### DIFF
--- a/src/renderer/src/components/activity/ActivityTitlebarControls.tsx
+++ b/src/renderer/src/components/activity/ActivityTitlebarControls.tsx
@@ -58,17 +58,17 @@ export function ActivityTitlebarControls(): React.JSX.Element {
               variant="ghost"
               size="icon-xs"
               onClick={closeActivityPage}
-              aria-label="Close agent view"
+              aria-label="Close agents"
             >
               <ArrowLeft className="size-3.5" />
             </Button>
           </TooltipTrigger>
           <TooltipContent side="bottom" sideOffset={6}>
-            Close agent view
+            Close agents
           </TooltipContent>
         </Tooltip>
         <Bell className="size-3.5 shrink-0 text-muted-foreground" />
-        <span className="truncate text-xs font-medium">Agent View</span>
+        <span className="truncate text-xs font-medium">agents</span>
         <Badge variant="secondary" className="h-5 px-1.5 text-[11px] font-normal">
           {unreadCount} unread
         </Badge>

--- a/src/renderer/src/components/activity/ActivityTitlebarControls.tsx
+++ b/src/renderer/src/components/activity/ActivityTitlebarControls.tsx
@@ -58,17 +58,17 @@ export function ActivityTitlebarControls(): React.JSX.Element {
               variant="ghost"
               size="icon-xs"
               onClick={closeActivityPage}
-              aria-label="Close activity"
+              aria-label="Close agent view"
             >
               <ArrowLeft className="size-3.5" />
             </Button>
           </TooltipTrigger>
           <TooltipContent side="bottom" sideOffset={6}>
-            Close activity
+            Close agent view
           </TooltipContent>
         </Tooltip>
         <Bell className="size-3.5 shrink-0 text-muted-foreground" />
-        <span className="truncate text-xs font-medium">Activity</span>
+        <span className="truncate text-xs font-medium">Agent View</span>
         <Badge variant="secondary" className="h-5 px-1.5 text-[11px] font-normal">
           {unreadCount} unread
         </Badge>

--- a/src/renderer/src/components/sidebar/SidebarNav.tsx
+++ b/src/renderer/src/components/sidebar/SidebarNav.tsx
@@ -153,7 +153,7 @@ const SidebarNav = React.memo(function SidebarNav() {
           className={cn('size-4 shrink-0', !activityActive && 'text-sidebar-foreground/30')}
           strokeWidth={activityActive ? 2.25 : 1.75}
         />
-        <span className="flex-1">Agent View</span>
+        <span className="flex-1">Agents</span>
         {activityUnreadCount > 0 ? (
           <span className="rounded-full bg-primary px-1.5 py-px text-[10px] font-semibold text-primary-foreground">
             {activityUnreadCount}

--- a/src/renderer/src/components/sidebar/SidebarNav.tsx
+++ b/src/renderer/src/components/sidebar/SidebarNav.tsx
@@ -153,7 +153,7 @@ const SidebarNav = React.memo(function SidebarNav() {
           className={cn('size-4 shrink-0', !activityActive && 'text-sidebar-foreground/30')}
           strokeWidth={activityActive ? 2.25 : 1.75}
         />
-        <span className="flex-1">Activity</span>
+        <span className="flex-1">Agent View</span>
         {activityUnreadCount > 0 ? (
           <span className="rounded-full bg-primary px-1.5 py-px text-[10px] font-semibold text-primary-foreground">
             {activityUnreadCount}


### PR DESCRIPTION
Renames the user-visible tab label from **Activity** to **Agent View**.

## Changes
- `src/renderer/src/components/sidebar/SidebarNav.tsx` — sidebar nav label
- `src/renderer/src/components/activity/ActivityTitlebarControls.tsx` — titlebar label, Close button `aria-label`, and tooltip text

## Scope decision
Only **user-visible strings** were changed. Internal identifiers (`activeView === 'activity'`, store actions `openActivityPage`/`closeActivityPage`, component names `ActivityTitlebarControls`/`ActivityPrototypePage`, folder `components/activity/`) are intentionally left untouched. Renaming those would touch ~50 files across store slices, IPC, persistence, and the menu module with no user-visible benefit and meaningful regression risk (persisted view state, menu rebuilds, portal targets).

## Validation
- ✅ `pnpm typecheck` clean (node + cli + web)
- ✅ `pnpm lint` clean (6 pre-existing warnings, none in touched files)
- ✅ Searched for e2e selectors / unit tests asserting on the old "Activity" / "Close activity" strings — none found
- ✅ Vitest failures present but pre-existing on `main` (unrelated `@/lib/e2e-config` alias resolution); confirmed by stashing this PR's diff and re-running

## Out of scope
Adjacent unrelated labels were left as-is:
- `SidebarHeader.tsx` "Agent activity" toggle (different feature — the inline per-card list)
- `StatusBar.tsx` "Resource Usage" `<Activity>` icon (lucide icon, not a tab)