### PR TITLE
feat(cli): create GitHub and Linear issues

### DIFF
--- a/src/cli/args.test.ts
+++ b/src/cli/args.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
-import { parseArgs } from './args'
+import { parseArgs, supportsBrowserPageFlag, validateCommandAndFlags } from './args'
+import { COMMAND_SPECS } from './specs'
 
 describe('parseArgs', () => {
   it('keeps an empty string as a flag value', () => {
@@ -36,5 +37,28 @@ describe('parseArgs', () => {
     expect(parsed.commandPath).toEqual(['tab', 'create'])
     expect(parsed.flags.get('json')).toBe(true)
     expect(parsed.flags.get('url')).toBe('https://example.com')
+  })
+})
+
+describe('validateCommandAndFlags', () => {
+  it('does not allow the browser page flag on issue commands', () => {
+    expect(supportsBrowserPageFlag(['issue', 'create'])).toBe(false)
+
+    const parsed = parseArgs([
+      'issue',
+      'create',
+      '--provider',
+      'github',
+      '--repo',
+      'id:repo-1',
+      '--title',
+      'Bug',
+      '--page',
+      'main'
+    ])
+
+    expect(() => validateCommandAndFlags(COMMAND_SPECS, parsed)).toThrow(
+      'Unknown flag --page for command: issue create'
+    )
   })
 })

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -75,7 +75,7 @@ export function supportsBrowserPageFlag(commandPath: string[]): boolean {
     return false
   }
   if (
-    ['automations', 'repo', 'worktree', 'terminal', 'file', 'computer', 'note'].includes(
+    ['automations', 'repo', 'worktree', 'terminal', 'file', 'computer', 'note', 'issue'].includes(
       commandPath[0]
     )
   ) {
@@ -112,7 +112,8 @@ export function isCommandGroup(commandPath: string[]): boolean {
         'orchestration',
         'computer',
         'agent',
-        'environment'
+        'environment',
+        'issue'
       ].includes(commandPath[0])) ||
     (commandPath.length === 2 && commandPath[0] === 'agent' && commandPath[1] === 'hooks') ||
     (commandPath.length === 2 &&

--- a/src/cli/dispatch.ts
+++ b/src/cli/dispatch.ts
@@ -2,6 +2,7 @@ import type { RuntimeClient } from './runtime-client'
 import { RuntimeClientError } from './runtime-client'
 import { CORE_HANDLERS } from './handlers/core'
 import { AUTOMATION_HANDLERS } from './handlers/automations'
+import { ISSUE_HANDLERS } from './handlers/issue'
 import { REPO_HANDLERS } from './handlers/repo'
 import { WORKTREE_HANDLERS } from './handlers/worktree'
 import { FILE_HANDLERS } from './handlers/file'
@@ -33,6 +34,7 @@ function buildHandlers(): Map<string, CommandHandler> {
   const groups = [
     CORE_HANDLERS,
     AUTOMATION_HANDLERS,
+    ISSUE_HANDLERS,
     REPO_HANDLERS,
     WORKTREE_HANDLERS,
     FILE_HANDLERS,

--- a/src/cli/format.ts
+++ b/src/cli/format.ts
@@ -17,6 +17,7 @@ import type {
   ComputerListWindowsResult,
   ComputerSnapshotResult,
   CliStatusResult,
+  RuntimeIssueCreateResult,
   RuntimeRepoList,
   RuntimeRepoSearchRefs,
   RuntimeTerminalClose,
@@ -113,6 +114,13 @@ export function formatCliStatus(status: CliStatusResult): string {
 
 export function formatStatus(status: CliStatusResult): string {
   return formatCliStatus(status)
+}
+
+export function formatIssueCreate(result: RuntimeIssueCreateResult): string {
+  if (result.provider === 'github') {
+    return [`Created GitHub issue #${result.number}`, result.url].filter(Boolean).join('\n')
+  }
+  return [`Created Linear issue ${result.identifier}`, result.url].filter(Boolean).join('\n')
 }
 
 export function formatEnvironmentList(result: {

--- a/src/cli/handlers/issue.ts
+++ b/src/cli/handlers/issue.ts
@@ -1,0 +1,61 @@
+import type {
+  RuntimeIssueCreateProvider,
+  RuntimeIssueCreateResult
+} from '../../shared/runtime-types'
+import type { CommandHandler } from '../dispatch'
+import { formatIssueCreate, printResult } from '../format'
+import { getOptionalStringFlag, getRequiredStringFlag } from '../flags'
+import { RuntimeClientError } from '../runtime-client'
+
+function getRequiredNonBlankFlag(flags: Map<string, string | boolean>, name: string): string {
+  const value = getRequiredStringFlag(flags, name)
+  if (value.trim().length === 0) {
+    throw new RuntimeClientError('invalid_argument', `Missing required --${name}`)
+  }
+  return value
+}
+
+function getIssueProvider(flags: Map<string, string | boolean>): RuntimeIssueCreateProvider {
+  const provider = getRequiredStringFlag(flags, 'provider')
+  if (provider === 'github' || provider === 'linear') {
+    return provider
+  }
+  throw new RuntimeClientError(
+    'invalid_argument',
+    `Unsupported issue provider "${provider}". Use github or linear.`
+  )
+}
+
+export const ISSUE_HANDLERS: Record<string, CommandHandler> = {
+  'issue create': async ({ flags, client, json }) => {
+    const provider = getIssueProvider(flags)
+    const repo = getOptionalStringFlag(flags, 'repo')
+    const team = getOptionalStringFlag(flags, 'team')
+    if (provider === 'github' && !repo) {
+      throw new RuntimeClientError('invalid_argument', 'GitHub issue creation requires --repo')
+    }
+    if (provider === 'github' && team) {
+      throw new RuntimeClientError(
+        'invalid_argument',
+        'GitHub issue creation uses --repo, not --team'
+      )
+    }
+    if (provider === 'linear' && !team) {
+      throw new RuntimeClientError('invalid_argument', 'Linear issue creation requires --team')
+    }
+    if (provider === 'linear' && repo) {
+      throw new RuntimeClientError(
+        'invalid_argument',
+        'Linear issue creation uses --team, not --repo'
+      )
+    }
+    const result = await client.call<RuntimeIssueCreateResult>('issue.create', {
+      provider,
+      repo,
+      team,
+      title: getRequiredNonBlankFlag(flags, 'title'),
+      body: getRequiredNonBlankFlag(flags, 'body')
+    })
+    printResult(result, json, formatIssueCreate)
+  }
+}

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -93,6 +93,9 @@ Computer Use:
   computer paste-text       Paste text through the native clipboard path
   computer set-value        Set the value of a settable app element
 
+Issues:
+  issue create              Create a GitHub or Linear issue
+
 Browser Automation:
   tab create                Create a new browser tab (navigates to --url)
   tab list                  List open browser tabs
@@ -190,6 +193,8 @@ Common Commands:
   orca repo show --repo <selector> [--json]
   orca repo set-base-ref --repo <selector> --ref <ref> [--json]
   orca repo search-refs --repo <selector> --query <text> [--limit <n>] [--json]
+  orca issue create --provider github --repo <selector> --title <title> --body <text> [--json]
+  orca issue create --provider linear --team <team-id> --title <title> --body <text> [--json]
 
 Selectors:
   --repo <selector>         Registered repo selector such as id:<id>, name:<name>, or path:<path>
@@ -339,6 +344,7 @@ export function formatGroupHelp(specs: CommandSpec[], group: string): string {
 export function formatFlagHelp(flag: string): string {
   const helpByFlag: Record<string, string> = {
     'base-branch': '--base-branch <ref>    Base branch/ref to create the worktree from',
+    body: '--body <text>          Issue body or Linear description',
     command: '--command <text>       Command to run in the terminal on startup',
     comment: '--comment <text>       Comment stored in Orca metadata',
     cursor: '--cursor <n>           Line cursor from a previous read (returns only new output)',
@@ -349,7 +355,7 @@ export function formatFlagHelp(flag: string): string {
       '--direction <dir>      Direction: up|down|left|right for scroll, horizontal|vertical for split',
     'display-name': '--display-name <name>  Override the Orca display name',
     'element-index': '--element-index <n>   Element index from get-app-state',
-    title: '--title <text>         Custom title for the terminal tab (omit to reset)',
+    title: '--title <text>         Terminal tab title or issue title',
     enter: '--enter                Append Enter after sending text',
     force: '--force                Force worktree removal when supported',
     focus: '--focus                Reveal the created terminal session in Orca',
@@ -372,12 +378,14 @@ export function formatFlagHelp(flag: string): string {
     'parent-worktree':
       '--parent-worktree <selector> Parent selector; create infers the caller/current worktree by default',
     path: '--path <path>          Path argument for the command',
+    provider: '--provider <name>      Issue provider or automation agent id',
     query: '--query <text>        Search text for matching refs',
     ref: '--ref <ref>            Base ref to persist for the repo',
     repo: '--repo <selector>      Repo selector such as id:<id>, name:<name>, or path:<path>',
     'restore-window':
       '--restore-window     Bring the target app/window forward before the operation',
     session: '--session <id>        Snapshot namespace for a related computer-use workflow',
+    team: '--team <id>            Linear team ID',
     terminal: '--terminal <handle>  Runtime-issued terminal handle',
     text: '--text <text>          Text payload to send or type',
     'text-stdin': '--text-stdin          Read text payload from stdin',
@@ -390,7 +398,6 @@ export function formatFlagHelp(flag: string): string {
     workspace: '--workspace <selector> Existing worktree selector for automation runs',
     prompt: '--prompt <text>        Automation prompt to pass to the agent',
     staged: '--staged               Open staged source-control changes',
-    provider: '--provider <agent>     Agent id such as codex, claude, or gemini',
     trigger: '--trigger <schedule>   Automation schedule preset, cron, or RRULE',
     schedule: '--schedule <schedule>  Alias for --trigger',
     time: '--time <HH:MM>        Time used with daily/weekdays/weekly presets',

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -891,6 +891,223 @@ describe('orca cli worktree awareness', () => {
     })
   })
 
+  it('creates GitHub issues through the runtime', async () => {
+    queueFixtures(
+      callMock,
+      okFixture('req_issue', {
+        provider: 'github',
+        number: 42,
+        url: 'https://github.com/o/r/issues/42',
+        repo: { id: 'repo-1', path: '/repo', displayName: 'repo' }
+      })
+    )
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(
+      [
+        'issue',
+        'create',
+        '--provider',
+        'github',
+        '--repo',
+        'id:repo-1',
+        '--title',
+        'Bug',
+        '--body',
+        'Steps',
+        '--json'
+      ],
+      '/tmp/repo'
+    )
+
+    expect(callMock).toHaveBeenCalledWith('issue.create', {
+      provider: 'github',
+      repo: 'id:repo-1',
+      team: undefined,
+      title: 'Bug',
+      body: 'Steps'
+    })
+    expect(JSON.parse(logSpy.mock.calls.flat().join('\n'))).toMatchObject({
+      ok: true,
+      result: { provider: 'github', number: 42 }
+    })
+    expect(logSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('creates Linear issues through the runtime', async () => {
+    queueFixtures(
+      callMock,
+      okFixture('req_issue', {
+        provider: 'linear',
+        id: 'lin-1',
+        identifier: 'ENG-42',
+        url: 'https://linear.app/team/issue/ENG-42'
+      })
+    )
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(
+      [
+        'issue',
+        'create',
+        '--provider',
+        'linear',
+        '--team',
+        'team-1',
+        '--title',
+        'Follow up',
+        '--body',
+        'Context',
+        '--json'
+      ],
+      '/tmp/repo'
+    )
+
+    expect(callMock).toHaveBeenCalledWith('issue.create', {
+      provider: 'linear',
+      repo: undefined,
+      team: 'team-1',
+      title: 'Follow up',
+      body: 'Context'
+    })
+  })
+
+  it('prints issue creation text output', async () => {
+    queueFixtures(
+      callMock,
+      okFixture('req_issue', {
+        provider: 'linear',
+        id: 'lin-1',
+        identifier: 'ENG-42',
+        url: 'https://linear.app/team/issue/ENG-42'
+      })
+    )
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(
+      [
+        'issue',
+        'create',
+        '--provider',
+        'linear',
+        '--team',
+        'team-1',
+        '--title',
+        'Follow up',
+        '--body',
+        'Context'
+      ],
+      '/tmp/repo'
+    )
+
+    expect(logSpy.mock.calls.flat().join('\n')).toBe(
+      'Created Linear issue ENG-42\nhttps://linear.app/team/issue/ENG-42'
+    )
+  })
+
+  it.each([
+    {
+      name: 'unsupported provider',
+      argv: [
+        'issue',
+        'create',
+        '--provider',
+        'gitlab',
+        '--repo',
+        'id:repo-1',
+        '--title',
+        'Bug',
+        '--body',
+        'Steps'
+      ],
+      message: 'Unsupported issue provider "gitlab". Use github or linear.'
+    },
+    {
+      name: 'missing GitHub target',
+      argv: ['issue', 'create', '--provider', 'github', '--title', 'Bug', '--body', 'Steps'],
+      message: 'GitHub issue creation requires --repo'
+    },
+    {
+      name: 'missing Linear target',
+      argv: ['issue', 'create', '--provider', 'linear', '--title', 'Bug', '--body', 'Steps'],
+      message: 'Linear issue creation requires --team'
+    },
+    {
+      name: 'missing title',
+      argv: ['issue', 'create', '--provider', 'github', '--repo', 'id:repo-1', '--body', 'Steps'],
+      message: 'Missing required --title'
+    },
+    {
+      name: 'missing body',
+      argv: ['issue', 'create', '--provider', 'github', '--repo', 'id:repo-1', '--title', 'Bug'],
+      message: 'Missing required --body'
+    },
+    {
+      name: 'GitHub with Linear target',
+      argv: [
+        'issue',
+        'create',
+        '--provider',
+        'github',
+        '--repo',
+        'id:repo-1',
+        '--team',
+        'team-1',
+        '--title',
+        'Bug',
+        '--body',
+        'Steps'
+      ],
+      message: 'GitHub issue creation uses --repo, not --team'
+    }
+  ])('rejects issue create before runtime calls for $name', async ({ argv, message }) => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const priorExitCode = process.exitCode
+
+    await main(argv, '/tmp/repo')
+
+    expect(callMock).not.toHaveBeenCalled()
+    expect([...logSpy.mock.calls, ...errSpy.mock.calls].flat().join('\n')).toContain(message)
+    expect(process.exitCode).toBe(1)
+
+    process.exitCode = priorExitCode
+  })
+
+  it('shows issue command group help without treating it as an unknown command', async () => {
+    const priorExitCode = process.exitCode
+    process.exitCode = undefined
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(['issue', '--help'], '/tmp/repo')
+
+    const output = logSpy.mock.calls.flat().join('\n')
+    expect(callMock).not.toHaveBeenCalled()
+    expect(output).toContain('orca issue')
+    expect(output).toContain('create             Create a GitHub or Linear issue')
+    expect(process.exitCode).toBeUndefined()
+
+    process.exitCode = priorExitCode
+  })
+
+  it('shows issue create help without runtime calls', async () => {
+    const priorExitCode = process.exitCode
+    process.exitCode = undefined
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(['issue', 'create', '--help'], '/tmp/repo')
+
+    const output = logSpy.mock.calls.flat().join('\n')
+    expect(callMock).not.toHaveBeenCalled()
+    expect(output).toContain(
+      'orca issue create --provider github --repo <selector> --title <title> --body <text>'
+    )
+    expect(output).toContain('Issue provider or automation agent id')
+    expect(process.exitCode).toBeUndefined()
+
+    process.exitCode = priorExitCode
+  })
+
   it('passes explicit focus through terminal.create', async () => {
     queueFixtures(
       callMock,

--- a/src/cli/specs/index.ts
+++ b/src/cli/specs/index.ts
@@ -4,6 +4,7 @@ import { BROWSER_BASIC_COMMAND_SPECS } from './browser-basic'
 import { AUTOMATION_COMMAND_SPECS } from './automations'
 import { CORE_COMMAND_SPECS } from './core'
 import { FILE_COMMAND_SPECS } from './file'
+import { ISSUE_COMMAND_SPECS } from './issue'
 import { ORCHESTRATION_COMMAND_SPECS } from './orchestration'
 import { COMPUTER_COMMAND_SPECS } from './computer'
 import { ENVIRONMENT_COMMAND_SPECS } from './environment'
@@ -13,6 +14,7 @@ export const COMMAND_SPECS: CommandSpec[] = [
   ...CORE_COMMAND_SPECS,
   ...FILE_COMMAND_SPECS,
   ...AUTOMATION_COMMAND_SPECS,
+  ...ISSUE_COMMAND_SPECS,
   ...BROWSER_BASIC_COMMAND_SPECS,
   ...BROWSER_ADVANCED_COMMAND_SPECS,
   ...ORCHESTRATION_COMMAND_SPECS,

--- a/src/cli/specs/issue.ts
+++ b/src/cli/specs/issue.ts
@@ -1,0 +1,22 @@
+import type { CommandSpec } from '../args'
+import { GLOBAL_FLAGS } from '../args'
+
+export const ISSUE_COMMAND_SPECS: CommandSpec[] = [
+  {
+    path: ['issue', 'create'],
+    summary: 'Create a GitHub or Linear issue',
+    usage:
+      'orca issue create --provider github --repo <selector> --title <title> --body <text> [--json]\n' +
+      'orca issue create --provider linear --team <team-id> --title <title> --body <text> [--json]',
+    allowedFlags: [...GLOBAL_FLAGS, 'provider', 'repo', 'team', 'title', 'body'],
+    notes: [
+      'GitHub issue creation requires a registered Git repo selector.',
+      'Linear issue creation requires a Linear team ID and an active Linear connection.',
+      '--body is required and is used as the GitHub body or Linear description.'
+    ],
+    examples: [
+      'orca issue create --provider github --repo id:repo-1 --title "Bug found" --body "Steps to reproduce..." --json',
+      'orca issue create --provider linear --team team-id --title "Follow up" --body "Context..." --json'
+    ]
+  }
+]

--- a/src/main/runtime/orca-runtime-issue-create.test.ts
+++ b/src/main/runtime/orca-runtime-issue-create.test.ts
@@ -1,0 +1,196 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Repo } from '../../shared/types'
+
+const issueMocks = vi.hoisted(() => ({
+  createGitHubIssue: vi.fn(),
+  createLinearIssue: vi.fn()
+}))
+
+vi.mock('../github/issues', () => ({
+  createIssue: issueMocks.createGitHubIssue
+}))
+
+vi.mock('../linear/issues', () => ({
+  createIssue: issueMocks.createLinearIssue
+}))
+
+import { OrcaRuntimeService } from './orca-runtime'
+
+const gitRepo: Repo = {
+  id: 'repo-1',
+  path: '/repo',
+  displayName: 'repo',
+  badgeColor: '#fff',
+  addedAt: 1,
+  kind: 'git',
+  connectionId: 'ssh-1',
+  issueSourcePreference: 'upstream'
+}
+
+const folderRepo: Repo = {
+  id: 'folder-1',
+  path: '/folder',
+  displayName: 'folder',
+  badgeColor: '#000',
+  addedAt: 2,
+  kind: 'folder'
+}
+
+function makeRuntime(repos: Repo[] = [gitRepo]): OrcaRuntimeService {
+  return new OrcaRuntimeService({
+    getRepos: () => repos
+  } as never)
+}
+
+describe('OrcaRuntimeService issue creation', () => {
+  beforeEach(() => {
+    issueMocks.createGitHubIssue.mockReset()
+    issueMocks.createLinearIssue.mockReset()
+  })
+
+  it('creates GitHub issues through a registered git repo selector', async () => {
+    issueMocks.createGitHubIssue.mockResolvedValueOnce({
+      ok: true,
+      number: 42,
+      url: 'https://github.com/o/r/issues/42'
+    })
+
+    await expect(
+      makeRuntime().createIssue({
+        provider: 'github',
+        repo: 'id:repo-1',
+        title: ' New bug ',
+        body: 'Steps'
+      })
+    ).resolves.toEqual({
+      provider: 'github',
+      number: 42,
+      url: 'https://github.com/o/r/issues/42',
+      repo: {
+        id: 'repo-1',
+        path: '/repo',
+        displayName: 'repo'
+      }
+    })
+    expect(issueMocks.createGitHubIssue).toHaveBeenCalledWith(
+      '/repo',
+      'New bug',
+      'Steps',
+      'upstream',
+      'ssh-1'
+    )
+  })
+
+  it('rejects unsupported providers before issue creation', async () => {
+    await expect(
+      makeRuntime().createIssue({
+        provider: 'gitlab',
+        repo: 'id:repo-1',
+        title: 'Bug',
+        body: 'Steps'
+      } as never)
+    ).rejects.toThrow('Unsupported issue provider')
+    expect(issueMocks.createGitHubIssue).not.toHaveBeenCalled()
+    expect(issueMocks.createLinearIssue).not.toHaveBeenCalled()
+  })
+
+  it('rejects blank titles and bodies before issue creation', async () => {
+    await expect(
+      makeRuntime().createIssue({
+        provider: 'github',
+        repo: 'id:repo-1',
+        title: ' ',
+        body: 'Steps'
+      })
+    ).rejects.toThrow('Title is required')
+    await expect(
+      makeRuntime().createIssue({
+        provider: 'github',
+        repo: 'id:repo-1',
+        title: 'Bug',
+        body: ' '
+      })
+    ).rejects.toThrow('Body is required')
+    await expect(
+      makeRuntime().createIssue({
+        provider: 'github',
+        repo: 'id:repo-1',
+        title: 'Bug'
+      } as never)
+    ).rejects.toThrow('Body is required')
+    expect(issueMocks.createGitHubIssue).not.toHaveBeenCalled()
+  })
+
+  it('rejects missing and mismatched provider targets before issue creation', async () => {
+    await expect(
+      makeRuntime().createIssue({
+        provider: 'github',
+        title: 'Bug',
+        body: 'Steps'
+      })
+    ).rejects.toThrow('GitHub issue creation requires --repo')
+    await expect(
+      makeRuntime().createIssue({
+        provider: 'linear',
+        title: 'Bug',
+        body: 'Steps'
+      })
+    ).rejects.toThrow('Linear issue creation requires --team')
+    await expect(
+      makeRuntime().createIssue({
+        provider: 'github',
+        repo: 'id:repo-1',
+        team: 'team-1',
+        title: 'Bug',
+        body: 'Steps'
+      })
+    ).rejects.toThrow('GitHub issue creation uses --repo, not --team')
+    await expect(
+      makeRuntime().createIssue({
+        provider: 'linear',
+        repo: 'id:repo-1',
+        team: 'team-1',
+        title: 'Bug',
+        body: 'Steps'
+      })
+    ).rejects.toThrow('Linear issue creation uses --team, not --repo')
+    expect(issueMocks.createGitHubIssue).not.toHaveBeenCalled()
+    expect(issueMocks.createLinearIssue).not.toHaveBeenCalled()
+  })
+
+  it('rejects GitHub issue creation for folder-mode repos', async () => {
+    await expect(
+      makeRuntime([folderRepo]).createIssue({
+        provider: 'github',
+        repo: 'id:folder-1',
+        title: 'Bug',
+        body: 'Steps'
+      })
+    ).rejects.toThrow('GitHub issue creation requires a git repo.')
+    expect(issueMocks.createGitHubIssue).not.toHaveBeenCalled()
+  })
+
+  it('creates Linear issues with a required team ID', async () => {
+    issueMocks.createLinearIssue.mockResolvedValueOnce({
+      ok: true,
+      id: 'lin-1',
+      identifier: 'ENG-42',
+      url: 'https://linear.app/team/issue/ENG-42'
+    })
+
+    await expect(
+      makeRuntime().createIssue({
+        provider: 'linear',
+        team: ' team-1 ',
+        title: ' Follow up ',
+        body: 'Context'
+      })
+    ).resolves.toEqual({
+      provider: 'linear',
+      id: 'lin-1',
+      identifier: 'ENG-42',
+      url: 'https://linear.app/team/issue/ENG-42'
+    })
+    expect(issueMocks.createLinearIssue).toHaveBeenCalledWith('team-1', 'Follow up', 'Context')
+  })
+})

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -142,7 +142,9 @@ import type {
   RuntimeSyncWindowGraph,
   RuntimeWorktreeListResult,
   BrowserTabInfo,
-  BrowserScreencastResult
+  BrowserScreencastResult,
+  RuntimeIssueCreateRequest,
+  RuntimeIssueCreateResult
 } from '../../shared/runtime-types'
 import type { AutomationService } from '../automations/service'
 import { RuntimeBrowserCommands } from './orca-runtime-browser'
@@ -6862,6 +6864,72 @@ export class OrcaRuntimeService {
       } catch (error) {
         console.warn('[runtime] Could not update remote .gitignore to exclude .orca', error)
       }
+    }
+  }
+
+  async createIssue(params: RuntimeIssueCreateRequest): Promise<RuntimeIssueCreateResult> {
+    if (params.provider !== 'github' && params.provider !== 'linear') {
+      throw new Error('Unsupported issue provider')
+    }
+    const title = typeof params.title === 'string' ? params.title.trim() : ''
+    if (!title) {
+      throw new Error('Title is required')
+    }
+    const body = typeof params.body === 'string' ? params.body.trim() : ''
+    if (!body) {
+      throw new Error('Body is required')
+    }
+
+    if (params.provider === 'github') {
+      const selector = params.repo?.trim()
+      if (!selector) {
+        throw new Error('GitHub issue creation requires --repo')
+      }
+      if (params.team?.trim()) {
+        throw new Error('GitHub issue creation uses --repo, not --team')
+      }
+      const repo = await this.resolveRepoSelector(selector)
+      if (isFolderRepo(repo)) {
+        throw new Error('GitHub issue creation requires a git repo.')
+      }
+      const result = await createIssue(
+        repo.path,
+        title,
+        body,
+        repo.issueSourcePreference,
+        repo.connectionId ?? null
+      )
+      if (!result.ok) {
+        throw new Error(result.error)
+      }
+      return {
+        provider: 'github',
+        number: result.number,
+        url: result.url,
+        repo: {
+          id: repo.id,
+          path: repo.path,
+          displayName: repo.displayName
+        }
+      }
+    }
+
+    const teamId = params.team?.trim()
+    if (!teamId) {
+      throw new Error('Linear issue creation requires --team')
+    }
+    if (params.repo?.trim()) {
+      throw new Error('Linear issue creation uses --team, not --repo')
+    }
+    const result = await createLinearIssue(teamId, title, body)
+    if (!result.ok) {
+      throw new Error(result.error)
+    }
+    return {
+      provider: 'linear',
+      id: result.id,
+      identifier: result.identifier,
+      url: result.url
     }
   }
 

--- a/src/main/runtime/rpc/methods/index.ts
+++ b/src/main/runtime/rpc/methods/index.ts
@@ -2,6 +2,7 @@ import type { RpcAnyMethod } from '../core'
 import { STATUS_METHODS } from './status'
 import { AUTOMATION_METHODS } from './automations'
 import { REPO_METHODS } from './repo'
+import { ISSUE_METHODS } from './issue'
 import { WORKTREE_METHODS } from './worktree'
 import { TERMINAL_METHODS } from './terminal'
 import { BROWSER_CORE_METHODS } from './browser-core'
@@ -32,6 +33,7 @@ export const ALL_RPC_METHODS: readonly RpcAnyMethod[] = [
   ...STATUS_METHODS,
   ...AUTOMATION_METHODS,
   ...REPO_METHODS,
+  ...ISSUE_METHODS,
   ...WORKTREE_METHODS,
   ...TERMINAL_METHODS,
   ...BROWSER_CORE_METHODS,

--- a/src/main/runtime/rpc/methods/issue.test.ts
+++ b/src/main/runtime/rpc/methods/issue.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from 'vitest'
+import { buildRegistry, type RpcContext } from '../core'
+import { ISSUE_METHODS } from './issue'
+
+describe('issue RPC methods', () => {
+  const createIssue = vi.fn()
+  const ctx = { runtime: { createIssue } as never } as RpcContext
+
+  function findMethod(name: string) {
+    const method = ISSUE_METHODS.find((m) => m.name === name)
+    if (!method) {
+      throw new Error(`Method not found: ${name}`)
+    }
+    return method
+  }
+
+  async function call(params: Record<string, unknown>) {
+    const method = findMethod('issue.create')
+    const parsed = method.params ? method.params.parse(params) : undefined
+    return await method.handler(parsed, ctx)
+  }
+
+  it('registers the issue create method', () => {
+    const registry = buildRegistry(ISSUE_METHODS)
+
+    expect([...registry.keys()]).toEqual(['issue.create'])
+  })
+
+  it('passes validated create params to the runtime', async () => {
+    const issue = { provider: 'github', number: 42, url: 'https://github.com/o/r/issues/42' }
+    createIssue.mockResolvedValueOnce(issue)
+
+    await expect(
+      call({
+        provider: 'github',
+        repo: 'id:repo-1',
+        title: 'Bug',
+        body: 'Steps'
+      })
+    ).resolves.toBe(issue)
+    expect(createIssue).toHaveBeenCalledWith({
+      provider: 'github',
+      repo: 'id:repo-1',
+      title: 'Bug',
+      body: 'Steps'
+    })
+  })
+
+  it('rejects invalid providers and missing titles or bodies', () => {
+    const method = findMethod('issue.create')
+
+    expect(() => method.params!.parse({ provider: 'jira', title: 'Bug' })).toThrow()
+    expect(() =>
+      method.params!.parse({ provider: 'github', repo: 'id:repo-1', body: 'Steps' })
+    ).toThrow()
+    expect(() =>
+      method.params!.parse({ provider: 'github', repo: 'id:repo-1', title: 'Bug' })
+    ).toThrow()
+  })
+
+  it('rejects missing or mismatched provider targets', () => {
+    const method = findMethod('issue.create')
+
+    expect(() =>
+      method.params!.parse({ provider: 'github', title: 'Bug', body: 'Steps' })
+    ).toThrow()
+    expect(() =>
+      method.params!.parse({ provider: 'linear', title: 'Bug', body: 'Steps' })
+    ).toThrow()
+    expect(() =>
+      method.params!.parse({
+        provider: 'github',
+        repo: 'id:repo-1',
+        team: 'team-1',
+        title: 'Bug',
+        body: 'Steps'
+      })
+    ).toThrow()
+    expect(() =>
+      method.params!.parse({
+        provider: 'linear',
+        repo: 'id:repo-1',
+        team: 'team-1',
+        title: 'Bug',
+        body: 'Steps'
+      })
+    ).toThrow()
+  })
+})

--- a/src/main/runtime/rpc/methods/issue.ts
+++ b/src/main/runtime/rpc/methods/issue.ts
@@ -1,0 +1,57 @@
+import { z } from 'zod'
+import { defineMethod, type RpcMethod } from '../core'
+import { requiredString } from '../schemas'
+
+function requiredNonBlankString(message: string) {
+  return requiredString(message).refine((value) => value.trim().length > 0, { message })
+}
+
+const IssueCreate = z
+  .object({
+    provider: z.enum(['github', 'linear']),
+    repo: z.string().optional(),
+    team: z.string().optional(),
+    title: requiredNonBlankString('Missing --title'),
+    body: requiredNonBlankString('Missing --body')
+  })
+  .superRefine((params, ctx) => {
+    if (params.provider === 'github') {
+      if (!params.repo?.trim()) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['repo'],
+          message: 'GitHub issue creation requires --repo'
+        })
+      }
+      if (params.team?.trim()) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['team'],
+          message: 'GitHub issue creation uses --repo, not --team'
+        })
+      }
+      return
+    }
+    if (!params.team?.trim()) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['team'],
+        message: 'Linear issue creation requires --team'
+      })
+    }
+    if (params.repo?.trim()) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['repo'],
+        message: 'Linear issue creation uses --team, not --repo'
+      })
+    }
+  })
+
+export const ISSUE_METHODS: RpcMethod[] = [
+  defineMethod({
+    name: 'issue.create',
+    params: IssueCreate,
+    handler: async (params, { runtime }) => await runtime.createIssue(params)
+  })
+]

--- a/src/shared/runtime-types.ts
+++ b/src/shared/runtime-types.ts
@@ -74,6 +74,34 @@ export type CliStatusResult = {
   }
 }
 
+export type RuntimeIssueCreateProvider = 'github' | 'linear'
+
+export type RuntimeIssueCreateRequest = {
+  provider: RuntimeIssueCreateProvider
+  repo?: string
+  team?: string
+  title: string
+  body: string
+}
+
+export type RuntimeIssueCreateResult =
+  | {
+      provider: 'github'
+      number: number
+      url: string
+      repo: {
+        id: string
+        path: string
+        displayName: string
+      }
+    }
+  | {
+      provider: 'linear'
+      id: string
+      identifier: string
+      url: string
+    }
+
 export type RuntimeSyncedTab = {
   tabId: string
   worktreeId: string


### PR DESCRIPTION
## Summary

Adds `orca issue create` so CLI users can create GitHub or Linear issues through Orca's existing local runtime.

The command accepts title, body, provider, and provider target options, then delegates to the same authenticated provider handlers already used by the app. The scope is limited to CLI issue creation.

## Files

- `src/cli/specs/issue.ts`, `src/cli/specs/index.ts` - register the `issue create` command spec, allowed flags, usage text, notes, and examples.
- `src/cli/args.ts` - treats `issue` as a command group and rejects browser page flags for issue commands.
- `src/cli/dispatch.ts` - registers the issue command handlers with the CLI dispatch table.
- `src/cli/handlers/issue.ts` - adds the `issue create` handler, reads provider/repo/team/title/body flags, calls `issue.create`, and prints text or JSON output.
- `src/cli/format.ts` - formats GitHub and Linear issue-create results for non-JSON CLI output.
- `src/cli/help.ts` - adds issue commands, usage examples, and flag help text.
- `src/main/runtime/orca-runtime.ts` - adds `createIssue`, validates provider-specific targets, resolves GitHub repos, rejects folder repos for GitHub, and delegates to existing GitHub or Linear issue handlers.
- `src/main/runtime/rpc/methods/issue.ts`, `src/main/runtime/rpc/methods/index.ts` - expose the `issue.create` runtime RPC method and validate provider/title input before calling the runtime.
- `src/shared/runtime-types.ts` - adds request and result types for GitHub and Linear issue creation.
- Tests updated across `src/cli/args.test.ts`, `src/cli/index.test.ts`, `src/main/runtime/orca-runtime-issue-create.test.ts`, and `src/main/runtime/rpc/methods/issue.test.ts`.

## Testing

- [x] `pnpm lint`
  - Result: passed in a clean checkout with 6 existing warnings and 0 errors.
- [x] `pnpm typecheck`
  - Result: passed.
- [x] `pnpm test -- src/cli/args.test.ts src/cli/index.test.ts src/main/runtime/orca-runtime-issue-create.test.ts src/main/runtime/rpc/methods/issue.test.ts`
  - Result: 4 files passed, 24 tests passed.
- [x] `pnpm build:cli`
  - Result: passed.
- [x] `node out/cli/index.js issue create --help`
  - Result: passed.
- [x] `node out/cli/index.js issue --help`
  - Result: passed.
- [x] `pnpm build`
  - Result: passed on Node 24.15.0.
- [x] `git diff --check`
  - Result: passed.

## AI Review Report

Reviewed risks:

- Provider validation: GitHub requires a repo selector and rejects folder repos; Linear requires a team ID; runtime tests cover both providers and missing targets.
- CLI parser behavior: `issue` is registered as a command group and `--page` is rejected for issue commands; parser tests cover the flag boundary.
- RPC boundary: `issue.create` validates provider and title before runtime dispatch; RPC tests cover registration, valid params, invalid providers, and missing titles.
- Output behavior: CLI tests cover text/JSON result handling, issue group help, and issue create help.
- Cross-platform: checked macOS, Linux, and Windows. The command uses the existing Node CLI and local runtime RPC path; it does not add shortcuts, labels, platform-specific paths, shell commands, or Electron platform branches.

## Security Audit

Reviewed input handling, IPC/RPC, auth, secrets, dependency, command execution, and path handling.

The CLI does not store tokens, add credential handling, shell out to provider CLIs, add dependencies, or add unauthenticated network paths. It sends explicit user-provided issue fields through the existing local runtime to existing authenticated GitHub and Linear handlers. Provider options are validated before dispatch.

## Notes

- Purely additive CLI command. Existing command output, exit-code behavior, and provider auth contracts are unchanged.
- The command creates an issue only after the user supplies an explicit provider, title, and provider target.
- GitHub creation uses the registered repo selector path; Linear creation uses the provided team ID.
- This PR does not add labels, assignees, milestones, Linear projects, or other issue metadata.

Risk: high
Historic risk metadata backfill based on the existing `risk:high` label.

## ELI5

CLI command `orca issue create` creates GitHub or Linear issues through Orca’s authenticated runtime from the terminal.
