### PR TITLE
Fix relative Codex file links in terminal

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
@@ -215,6 +215,31 @@ describe('handleOscLink', () => {
       expect.objectContaining({ filePath: '/tmp/test.txt' })
     )
   })
+
+  it('opens relative OSC file links against the terminal cwd', async () => {
+    setPlatform('Macintosh')
+
+    handleOscLink(
+      'docs/README.md',
+      { metaKey: true, ctrlKey: false },
+      {
+        ...deps,
+        startupCwd: '/tmp/project'
+      }
+    )
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(authorizeExternalPathMock).toHaveBeenCalledWith({
+      targetPath: '/tmp/project/docs/README.md'
+    })
+    expect(openFileMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filePath: '/tmp/project/docs/README.md',
+        relativePath: 'project/docs/README.md'
+      })
+    )
+  })
 })
 
 describe('createFilePathLinkProvider range bounds', () => {

--- a/src/renderer/src/components/terminal-pane/terminal-link-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-handlers.ts
@@ -4,6 +4,7 @@ import {
   extractTerminalFileLinks,
   isPathInsideWorktree,
   resolveTerminalFileLink,
+  resolveTerminalFileLinkText,
   toWorktreeRelativePath
 } from '@/lib/terminal-links'
 import { useAppStore } from '@/store'
@@ -233,7 +234,8 @@ export function isTerminalLinkActivation(
 export function handleOscLink(
   rawText: string,
   event: TerminalLinkEvent | undefined,
-  deps: Pick<LinkHandlerDeps, 'worktreeId' | 'worktreePath'>
+  deps: Pick<LinkHandlerDeps, 'worktreeId' | 'worktreePath'> &
+    Partial<Pick<LinkHandlerDeps, 'startupCwd'>>
 ): void {
   if (!isTerminalLinkActivation(event)) {
     return
@@ -254,6 +256,10 @@ export function handleOscLink(
   try {
     parsed = new URL(rawText)
   } catch {
+    const resolved = resolveTerminalFileLinkText(rawText, deps.startupCwd || deps.worktreePath)
+    if (resolved) {
+      openDetectedFilePath(resolved.absolutePath, resolved.line, resolved.column, deps)
+    }
     return
   }
 

--- a/src/renderer/src/lib/terminal-links.test.ts
+++ b/src/renderer/src/lib/terminal-links.test.ts
@@ -3,6 +3,7 @@ import {
   extractTerminalFileLinks,
   isPathInsideWorktree,
   resolveTerminalFileLink,
+  resolveTerminalFileLinkText,
   toWorktreeRelativePath
 } from './terminal-links'
 
@@ -71,5 +72,25 @@ describe('terminal path helpers', () => {
       line: 12,
       column: 3
     })
+  })
+
+  it('resolves exact repo-relative OSC hyperlink text', () => {
+    expect(resolveTerminalFileLinkText('docs/README.md', '/repo')).toEqual({
+      absolutePath: '/repo/docs/README.md',
+      line: null,
+      column: null
+    })
+  })
+
+  it('keeps line and column suffixes from exact OSC hyperlink text', () => {
+    expect(resolveTerminalFileLinkText('docs/README.md:12:3', '/repo')).toEqual({
+      absolutePath: '/repo/docs/README.md',
+      line: 12,
+      column: 3
+    })
+  })
+
+  it('does not resolve partial text as an OSC hyperlink target', () => {
+    expect(resolveTerminalFileLinkText('open docs/README.md', '/repo')).toBeNull()
   })
 })

--- a/src/renderer/src/lib/terminal-links.ts
+++ b/src/renderer/src/lib/terminal-links.ts
@@ -332,6 +332,15 @@ export function resolveTerminalFileLink(
   }
 }
 
+export function resolveTerminalFileLinkText(
+  linkText: string,
+  cwd: string
+): ResolvedTerminalFileLink | null {
+  const links = extractTerminalFileLinks(linkText)
+  const exactLink = links.find((link) => link.startIndex === 0 && link.endIndex === linkText.length)
+  return exactLink ? resolveTerminalFileLink(exactLink, cwd) : null
+}
+
 export function isPathInsideWorktree(filePath: string, worktreePath: string): boolean {
   const normalizedFile = normalizeAbsolutePath(filePath)
   const normalizedWorktree = normalizeAbsolutePath(worktreePath)


### PR DESCRIPTION
## Summary
- Resolve relative OSC 8 terminal hyperlink targets like `docs/README.md` through the existing terminal file-link resolver.
- Prefer the terminal startup cwd for those relative targets, falling back to the worktree root.
- Add focused coverage for exact relative OSC hyperlink text and the terminal handler path.

## Correctness report
The Slack report shows Codex rendering a link target such as `docs/README.md`. The plain terminal file-link provider already handles that shape, but OSC 8 links went through `handleOscLink`, which tried `new URL(rawText)` and returned on relative targets. That meant Codex-emitted relative file links were ignored even though adjacent detected gray file links worked. This PR routes non-URL OSC targets through the same path parser and `openDetectedFilePath` flow used for detected terminal file links, preserving line and column suffixes.

## Verification
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/lib/terminal-links.test.ts src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts`
- `pnpm oxlint src/renderer/src/lib/terminal-links.ts src/renderer/src/lib/terminal-links.test.ts src/renderer/src/components/terminal-pane/terminal-link-handlers.ts src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts`
- `pnpm tsgo --noEmit -p config/tsconfig.tc.web.json`
- `pnpm typecheck`
- `pnpm lint` (0 errors; existing warnings in GitHub project files)
- Electron dev app validation via `playwright-cli` on CDP `9334`: imported the terminal link handler in the running renderer and activated `handleOscLink('docs/README.md', Meta-click event, cmd-click-image worktree deps)`. Orca opened `/Users/nwparker/orca/workspaces/orca/cmd-click-image/docs/README.md` as an editor tab with `relativePath: docs/README.md`.

Slack: https://stablygroup.slack.com/archives/C0ASMDT6LQZ/p1778717651959809
