### PR TITLE
Fix select dropdown overflow

### DIFF
--- a/src/renderer/src/components/ui/select.test.tsx
+++ b/src/renderer/src/components/ui/select.test.tsx
@@ -1,0 +1,20 @@
+import { isValidElement } from 'react'
+import { describe, expect, it } from 'vitest'
+
+import { SelectContent } from './select'
+
+describe('SelectContent', () => {
+  it('caps long menus and keeps scrolling inside the select content', () => {
+    const portal = SelectContent({ children: null })
+
+    expect(isValidElement(portal)).toBe(true)
+    const content = portal.props.children
+    expect(isValidElement(content)).toBe(true)
+
+    expect(content.props.className).toContain(
+      'max-h-[min(var(--radix-select-content-available-height),20rem)]'
+    )
+    expect(content.props.className).toContain('overflow-y-auto')
+    expect(content.props.className).toContain('scrollbar-sleek')
+  })
+})

--- a/src/renderer/src/components/ui/select.tsx
+++ b/src/renderer/src/components/ui/select.tsx
@@ -56,7 +56,7 @@ function SelectContent({
       <SelectPrimitive.Content
         data-slot="select-content"
         className={cn(
-          'relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border border-border/50 bg-popover text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
+          'scrollbar-sleek relative z-50 max-h-[min(var(--radix-select-content-available-height),20rem)] min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border border-border/50 bg-popover text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
           position === 'popper' &&
             'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
           className


### PR DESCRIPTION
## Summary
- cap shared shadcn SelectContent height to the available viewport or 20rem, whichever is smaller
- apply the existing sleek scrollbar so long select lists scroll internally
- add a focused test covering the reusable SelectContent overflow classes

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/ui/select.test.tsx
- pnpm exec oxlint src/renderer/src/components/ui/select.tsx src/renderer/src/components/ui/select.test.tsx
- pnpm run lint (passes with pre-existing warnings in github-project components)
- pnpm run typecheck

Made with [Orca](https://github.com/stablyai/orca) 🐋
