### PR TITLE
Fix dead terminal setup e2e hook

### DIFF
--- a/tests/e2e/dead-terminal-repro.spec.ts
+++ b/tests/e2e/dead-terminal-repro.spec.ts
@@ -44,21 +44,6 @@ test.describe('Dead Terminal Reproduction @headful', () => {
         return
       }
       state.updateSettings({ setupScriptLaunchMode: 'split-vertical' })
-
-      // Why: write orca.yaml into the repo so createWorktree IPC returns a
-      // WorktreeSetupLaunch with a runner script, triggering the setup split.
-      // This is scoped to the dead-terminal tests to avoid breaking other
-      // specs that don't expect setup scripts to fire on worktree creation.
-      const wt = Object.values(state.worktreesByRepo)
-        .flat()
-        .find((w) => w.id === state.activeWorktreeId)
-      if (wt) {
-        const sep = wt.path.includes('\\') ? '\\' : '/'
-        await window.api.fs.writeFile({
-          filePath: `${wt.path}${sep}orca.yaml`,
-          content: 'scripts:\n  setup: echo SETUP_COMPLETE\n'
-        })
-      }
     })
   })
 

--- a/tests/e2e/dead-terminal-stress.spec.ts
+++ b/tests/e2e/dead-terminal-stress.spec.ts
@@ -39,17 +39,6 @@ test.describe('Dead Terminal Stress @headful', () => {
         return
       }
       state.updateSettings({ setupScriptLaunchMode: 'split-vertical' })
-
-      const wt = Object.values(state.worktreesByRepo)
-        .flat()
-        .find((w) => w.id === state.activeWorktreeId)
-      if (wt) {
-        const sep = wt.path.includes('\\') ? '\\' : '/'
-        await window.api.fs.writeFile({
-          filePath: `${wt.path}${sep}orca.yaml`,
-          content: 'scripts:\n  setup: echo SETUP_COMPLETE\n'
-        })
-      }
     })
   })
 

--- a/tests/e2e/helpers/dead-terminal.ts
+++ b/tests/e2e/helpers/dead-terminal.ts
@@ -6,9 +6,44 @@
  */
 
 import { expect } from '@playwright/test'
+import { execFileSync } from 'child_process'
+import { writeFileSync } from 'fs'
+import path from 'path'
 import type { getActiveWorktreeId } from './store'
 
 type TestPage = Parameters<typeof getActiveWorktreeId>[0]
+
+const SETUP_HOOK_CONTENT = 'scripts:\n  setup: echo SETUP_COMPLETE\n'
+
+async function ensureSetupHookCommitted(page: TestPage): Promise<void> {
+  const activeWorktreePath = await page.evaluate(() => {
+    const state = window.__store?.getState()
+    if (!state?.activeWorktreeId) {
+      throw new Error('No active worktree')
+    }
+    const activeWorktree = Object.values(state.worktreesByRepo)
+      .flat()
+      .find((wt) => wt.id === state.activeWorktreeId)
+    if (!activeWorktree) {
+      throw new Error('Active worktree not found in store')
+    }
+    return activeWorktree.path
+  })
+
+  writeFileSync(path.join(activeWorktreePath, 'orca.yaml'), SETUP_HOOK_CONTENT, 'utf-8')
+  execFileSync('git', ['add', 'orca.yaml'], { cwd: activeWorktreePath, stdio: 'pipe' })
+
+  try {
+    execFileSync('git', ['diff', '--cached', '--quiet'], { cwd: activeWorktreePath, stdio: 'pipe' })
+  } catch {
+    // Why: worktree creation reads orca.yaml from the created worktree, so the
+    // temp repo must commit this hook before `git worktree add` copies it.
+    execFileSync('git', ['commit', '-m', 'Add e2e setup hook'], {
+      cwd: activeWorktreePath,
+      stdio: 'pipe'
+    })
+  }
+}
 
 /**
  * Create a worktree with setup via the real IPC flow, then activate it
@@ -21,6 +56,8 @@ export async function createAndActivateWorktreeWithSetup(
   suffix: string,
   direction: 'vertical' | 'horizontal'
 ): Promise<string> {
+  await ensureSetupHookCommitted(page)
+
   const name = `e2e-dead-term-${suffix}-${Date.now()}`
   return page.evaluate(
     async ({ worktreeName, direction }) => {


### PR DESCRIPTION
## Summary
- commit the temp e2e repo setup hook before creating worktrees so setup-split tests exercise the real create flow
- centralize dead-terminal setup hook preparation in the shared helper

## Verification
- SKIP_BUILD=1 npx stably test --config tests/playwright.config.ts --project electron-headless --workers=1
- SKIP_BUILD=1 npx stably test --config tests/playwright.config.ts --project electron-headful --workers=1
- pnpm typecheck
- pnpm lint (warnings only: existing GitHub project hook deps)
- pnpm run test:e2e:computer (skipped by platform/opt-in gates)