### PR TITLE
Fix e2e app teardown

### DIFF
--- a/tests/e2e/helpers/electron-process-cleanup.ts
+++ b/tests/e2e/helpers/electron-process-cleanup.ts
@@ -1,0 +1,119 @@
+import type { ChildProcess } from 'child_process'
+import { execFileSync } from 'child_process'
+import type { ElectronApplication } from '@stablyai/playwright-test'
+
+function waitForProcessExit(proc: ChildProcess, timeoutMs: number): Promise<boolean> {
+  if (proc.exitCode !== null || proc.signalCode !== null) {
+    return Promise.resolve(true)
+  }
+
+  return new Promise((resolve) => {
+    const timeout = setTimeout(() => {
+      proc.off('exit', onExit)
+      proc.off('close', onExit)
+      resolve(false)
+    }, timeoutMs)
+
+    const onExit = (): void => {
+      clearTimeout(timeout)
+      resolve(true)
+    }
+
+    proc.once('exit', onExit)
+    proc.once('close', onExit)
+  })
+}
+
+function childPidsOf(pid: number): number[] {
+  if (process.platform === 'win32') {
+    return []
+  }
+
+  try {
+    const output = execFileSync('pgrep', ['-P', String(pid)], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore']
+    }).trim()
+    if (!output) {
+      return []
+    }
+    return output
+      .split(/\s+/)
+      .map((value) => Number(value))
+      .filter((value) => Number.isInteger(value) && value > 0)
+  } catch {
+    return []
+  }
+}
+
+function collectProcessTree(pid: number): number[] {
+  const descendants: number[] = []
+  const visit = (parentPid: number): void => {
+    for (const childPid of childPidsOf(parentPid)) {
+      visit(childPid)
+      descendants.push(childPid)
+    }
+  }
+
+  visit(pid)
+  return descendants
+}
+
+export async function killProcessTree(proc: ChildProcess | null | undefined): Promise<void> {
+  const pid = proc?.pid
+  if (!pid) {
+    return
+  }
+
+  if (process.platform === 'win32') {
+    try {
+      execFileSync('taskkill', ['/PID', String(pid), '/T', '/F'], { stdio: 'ignore' })
+    } catch {
+      /* process already exited */
+    }
+    await waitForProcessExit(proc, 5_000)
+    return
+  }
+
+  // Why: CI failures left orphan Electron renderer and shell processes after
+  // Playwright reported all tests passed. Kill descendants first so PTY shells
+  // cannot keep the Electron process tree alive during worker teardown.
+  for (const childPid of collectProcessTree(pid)) {
+    try {
+      process.kill(childPid, 'SIGKILL')
+    } catch {
+      /* process already exited */
+    }
+  }
+
+  try {
+    process.kill(pid, 'SIGKILL')
+  } catch {
+    /* process already exited */
+  }
+
+  await waitForProcessExit(proc, 5_000)
+}
+
+export async function closeElectronApp(
+  app: ElectronApplication,
+  options?: { forceOnly?: boolean }
+) {
+  const appProcess = app.process()
+
+  if (options?.forceOnly) {
+    await killProcessTree(appProcess)
+    return
+  }
+
+  try {
+    await Promise.race([
+      app.close(),
+      new Promise<never>((_, reject) => {
+        setTimeout(() => reject(new Error('Timed out closing Electron app')), 10_000)
+      })
+    ])
+  } catch {
+    await killProcessTree(appProcess)
+  }
+}

--- a/tests/e2e/helpers/orca-app.ts
+++ b/tests/e2e/helpers/orca-app.ts
@@ -25,6 +25,7 @@ import { execSync } from 'child_process'
 import os from 'os'
 import path from 'path'
 import { TEST_REPO_PATH_FILE } from '../global-setup'
+import { closeElectronApp } from './electron-process-cleanup'
 
 type OrcaTestFixtures = {
   electronApp: ElectronApplication
@@ -219,27 +220,10 @@ export const test = base.extend<OrcaTestFixtures, OrcaWorkerFixtures>({
       }
     })
     await provideFixture(app)
-    // Why: Electron's graceful shutdown runs before-quit/will-quit handlers,
-    // cleans up PTY child processes, and flushes session state to disk. Give
-    // it 10s for a clean exit, then SIGKILL the process tree immediately.
-    // SIGTERM doesn't reliably stop the Electron process tree on macOS.
-    const appProcess = app.process()
-    try {
-      await Promise.race([
-        app.close(),
-        new Promise<never>((_, reject) => {
-          setTimeout(() => reject(new Error('Timed out closing Electron app')), 10_000)
-        })
-      ])
-    } catch {
-      if (appProcess) {
-        try {
-          appProcess.kill('SIGKILL')
-        } catch {
-          /* already dead */
-        }
-      }
-    }
+    // Why: these profiles are discarded after each test. On CI, native close
+    // can finish assertions but leave Playwright workers stuck behind orphan
+    // Electron/PTY descendants, so teardown force-cleans the process tree.
+    await closeElectronApp(app, { forceOnly: process.env.CI === 'true' })
     rmSync(userDataDir, { recursive: true, force: true })
   },
 

--- a/tests/e2e/helpers/orca-restart.ts
+++ b/tests/e2e/helpers/orca-restart.ts
@@ -19,6 +19,7 @@ import { execSync } from 'child_process'
 import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'fs'
 import os from 'os'
 import path from 'path'
+import { closeElectronApp } from './electron-process-cleanup'
 
 type LaunchedOrca = {
   app: ElectronApplication
@@ -101,23 +102,7 @@ export function createRestartSession(testInfo: TestInfo): RestartSession {
     // Why: mirror the shared fixture's shutdown race — give Electron 10s to run
     // before-quit/will-quit (which drives the beforeunload → session.setSync
     // flush this suite relies on) and only then fall back to SIGKILL.
-    const proc = app.process()
-    try {
-      await Promise.race([
-        app.close(),
-        new Promise<never>((_, reject) => {
-          setTimeout(() => reject(new Error('Timed out closing Electron app')), 10_000)
-        })
-      ])
-    } catch {
-      if (proc) {
-        try {
-          proc.kill('SIGKILL')
-        } catch {
-          /* already dead */
-        }
-      }
-    }
+    await closeElectronApp(app)
   }
 
   const dispose = (): void => {


### PR DESCRIPTION
## Summary
- add shared e2e Electron cleanup that can kill the full Electron process tree
- use force-only cleanup for discarded per-test CI profiles so worker teardown cannot hang behind orphan renderer/PTY children
- keep graceful close for restart-persistence tests that rely on beforeunload state flushing

## Context
The failing CI runs completed all 66 e2e tests, then timed out during Playwright worker teardown with orphan Electron/bash processes. This targets test fixture teardown rather than reducing CI worker count.

## Verification
- pnpm typecheck
- pnpm lint (existing GitHub project warnings only)
- CI=true npx stably test --config tests/playwright.config.ts --project electron-headless --workers=1 tests/e2e/tabs.spec.ts -g "Cmd/Ctrl\+T creates a new terminal tab"