### PR TITLE
Fix file explorer drag edge scroll cleanup

### DIFF
--- a/src/renderer/src/components/right-sidebar/useFileExplorerDragDrop.test.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerDragDrop.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import { getDragEdgeScrollTarget } from './useFileExplorerDragDrop'
+
+describe('getDragEdgeScrollTarget', () => {
+  it('returns null away from the drag edge zones', () => {
+    expect(
+      getDragEdgeScrollTarget({
+        scrollTop: 100,
+        scrollHeight: 1000,
+        clientHeight: 200,
+        localY: 100
+      })
+    ).toBeNull()
+  })
+
+  it('scrolls down near the bottom edge', () => {
+    const next = getDragEdgeScrollTarget({
+      scrollTop: 100,
+      scrollHeight: 1000,
+      clientHeight: 200,
+      localY: 190
+    })
+
+    expect(next).toBeGreaterThan(100)
+  })
+
+  it('scrolls up near the top edge', () => {
+    const next = getDragEdgeScrollTarget({
+      scrollTop: 100,
+      scrollHeight: 1000,
+      clientHeight: 200,
+      localY: 10
+    })
+
+    expect(next).toBeLessThan(100)
+  })
+
+  it('stops at the bottom instead of scheduling a no-op frame forever', () => {
+    expect(
+      getDragEdgeScrollTarget({
+        scrollTop: 800,
+        scrollHeight: 1000,
+        clientHeight: 200,
+        localY: 190
+      })
+    ).toBeNull()
+  })
+
+  it('stops at the top instead of scheduling a no-op frame forever', () => {
+    expect(
+      getDragEdgeScrollTarget({
+        scrollTop: 0,
+        scrollHeight: 1000,
+        clientHeight: 200,
+        localY: 10
+      })
+    ).toBeNull()
+  })
+})

--- a/src/renderer/src/components/right-sidebar/useFileExplorerDragDrop.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerDragDrop.ts
@@ -61,6 +61,37 @@ const ORCA_PATH_MIME = 'text/x-orca-file-path'
 // tree dragging so users need not hug the scrollbar.
 const DRAG_EDGE_ZONE_PX = 48
 
+export function getDragEdgeScrollTarget({
+  scrollTop,
+  scrollHeight,
+  clientHeight,
+  localY,
+  edgeZonePx = DRAG_EDGE_ZONE_PX
+}: {
+  scrollTop: number
+  scrollHeight: number
+  clientHeight: number
+  localY: number
+  edgeZonePx?: number
+}): number | null {
+  let delta = 0
+  if (localY < edgeZonePx) {
+    const strength = (edgeZonePx - localY) / edgeZonePx
+    delta = -(1.25 + strength * 9)
+  } else if (localY > clientHeight - edgeZonePx) {
+    const strength = (localY - (clientHeight - edgeZonePx)) / edgeZonePx
+    delta = 1.25 + strength * 9
+  }
+
+  if (delta === 0) {
+    return null
+  }
+
+  const maxScroll = Math.max(0, scrollHeight - clientHeight)
+  const nextScrollTop = Math.max(0, Math.min(maxScroll, scrollTop + delta))
+  return nextScrollTop === scrollTop ? null : nextScrollTop
+}
+
 export function useFileExplorerDragDrop({
   worktreePath,
   activeWorktreeId,
@@ -94,6 +125,40 @@ export function useFileExplorerDragDrop({
 
   useEffect(() => () => stopDragEdgeScroll(), [stopDragEdgeScroll])
 
+  const clearDragState = useCallback(() => {
+    rootDragCounterRef.current = 0
+    nativeRootDragCounterRef.current = 0
+    setIsRootDragOver(false)
+    setDropTargetDir(null)
+    setDragSourcePath(null)
+    setIsNativeDragOver(false)
+    setNativeDropTargetDir(null)
+  }, [])
+
+  const stopAndClearDragState = useCallback(() => {
+    clearDragState()
+    stopDragEdgeScroll()
+  }, [clearDragState, stopDragEdgeScroll])
+
+  useEffect(() => {
+    const handleGlobalDragFinish = (): void => {
+      // Why: native OS drops are consumed by preload in the capture phase, so
+      // React root onDrop may never run. A document-level capture listener keeps
+      // the edge-scroll loop from surviving rejected, cancelled, or row drops.
+      stopAndClearDragState()
+    }
+
+    document.addEventListener('drop', handleGlobalDragFinish, true)
+    document.addEventListener('dragend', handleGlobalDragFinish, true)
+    window.addEventListener('blur', handleGlobalDragFinish)
+
+    return () => {
+      document.removeEventListener('drop', handleGlobalDragFinish, true)
+      document.removeEventListener('dragend', handleGlobalDragFinish, true)
+      window.removeEventListener('blur', handleGlobalDragFinish)
+    }
+  }, [stopAndClearDragState])
+
   // requestAnimationFrame + small per-frame deltas avoids choppy jumps from irregular dragover events
   const tickDragEdgeScroll = useCallback(() => {
     edgeScrollRafRef.current = null
@@ -104,21 +169,18 @@ export function useFileExplorerDragDrop({
     }
     const rect = viewport.getBoundingClientRect()
     const y = clientY - rect.top
-    const h = rect.height
     const zone = DRAG_EDGE_ZONE_PX
 
-    let delta = 0
-    if (y < zone) {
-      const strength = (zone - y) / zone
-      delta = -(1.25 + strength * 9)
-    } else if (y > h - zone) {
-      const strength = (y - (h - zone)) / zone
-      delta = 1.25 + strength * 9
-    }
+    const nextScrollTop = getDragEdgeScrollTarget({
+      scrollTop: viewport.scrollTop,
+      scrollHeight: viewport.scrollHeight,
+      clientHeight: viewport.clientHeight,
+      localY: y,
+      edgeZonePx: zone
+    })
 
-    if (delta !== 0) {
-      const maxScroll = Math.max(0, viewport.scrollHeight - viewport.clientHeight)
-      viewport.scrollTop = Math.max(0, Math.min(maxScroll, viewport.scrollTop + delta))
+    if (nextScrollTop !== null) {
+      viewport.scrollTop = nextScrollTop
       edgeScrollRafRef.current = requestAnimationFrame(tickDragEdgeScroll)
     }
   }, [scrollRef])
@@ -246,15 +308,12 @@ export function useFileExplorerDragDrop({
   )
 
   const clearNativeDragState = useCallback(() => {
-    nativeRootDragCounterRef.current = 0
-    setIsNativeDragOver(false)
-    setNativeDropTargetDir(null)
     // Why: for native OS file drops the preload intercepts the drop event and
     // stops propagation, so React's onDrop (which calls stopDragEdgeScroll)
     // never fires. Without this, the edge-scroll rAF loop keeps running with
     // the last recorded cursor Y, continuously overriding the user's scroll.
-    stopDragEdgeScroll()
-  }, [stopDragEdgeScroll])
+    stopAndClearDragState()
+  }, [stopAndClearDragState])
 
   const rootDragHandlers = {
     onDragOver: useCallback(


### PR DESCRIPTION
## Summary
- stop file explorer drag edge auto-scroll when drag/drop ends outside React root handlers
- reset native and internal drag state through shared cleanup
- add unit coverage for edge-scroll target clamping at scroll bounds

## Tests
- pnpm exec vitest run src/renderer/src/components/right-sidebar/useFileExplorerDragDrop.test.ts --config config/vitest.config.ts
- pnpm exec oxlint src/renderer/src/components/right-sidebar/useFileExplorerDragDrop.ts src/renderer/src/components/right-sidebar/useFileExplorerDragDrop.test.ts
- pnpm exec tsc --noEmit -p config/tsconfig.web.json --composite false --pretty false