### PR TITLE
Fix terminal file drops for split groups

### DIFF
--- a/src/main/window/attach-main-window-services.ts
+++ b/src/main/window/attach-main-window-services.ts
@@ -325,7 +325,7 @@ function registerFileDropRelay(mainWindow: BrowserWindow): void {
       _event,
       args:
         | { paths: string[]; target: 'editor' }
-        | { paths: string[]; target: 'terminal' }
+        | { paths: string[]; target: 'terminal'; tabId?: string }
         | { paths: string[]; target: 'composer' }
         | { paths: string[]; target: 'file-explorer'; destinationDir: string }
     ) => {

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1169,7 +1169,7 @@ export type PreloadApi = {
       callback: (
         data:
           | { paths: string[]; target: 'editor' }
-          | { paths: string[]; target: 'terminal' }
+          | { paths: string[]; target: 'terminal'; tabId?: string }
           | { paths: string[]; target: 'composer' }
           | { paths: string[]; target: 'file-explorer'; destinationDir: string }
       ) => void

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -90,13 +90,50 @@ import {
 
 type NativeDropResolution =
   | { target: 'editor' }
-  | { target: 'terminal' }
+  | { target: 'terminal'; tabId?: string }
   | { target: 'composer' }
   | { target: 'file-explorer'; destinationDir: string }
   // Why: returned when the explorer marker was found but no destinationDir
   // could be resolved. The caller must suppress the drop entirely instead of
   // falling back to 'editor' — fail-closed behavior per design §7.1.
   | { target: 'rejected' }
+
+type NativeFileDropPayload =
+  | { paths: string[]; target: 'editor' }
+  | { paths: string[]; target: 'terminal'; tabId?: string }
+  | { paths: string[]; target: 'composer' }
+  | { paths: string[]; target: 'file-explorer'; destinationDir: string }
+
+type NativeFileDropCallback = (data: NativeFileDropPayload) => void
+
+const nativeFileDropCallbacks: NativeFileDropCallback[] = []
+let nativeFileDropListenerRegistered = false
+
+const onNativeFileDrop = (_event: Electron.IpcRendererEvent, data: NativeFileDropPayload): void => {
+  for (const callback of Array.from(nativeFileDropCallbacks)) {
+    callback(data)
+  }
+}
+
+function subscribeNativeFileDrop(callback: NativeFileDropCallback): () => void {
+  nativeFileDropCallbacks.push(callback)
+  if (!nativeFileDropListenerRegistered) {
+    // Why: terminal panes subscribe per visible split group, so the IPC layer
+    // must keep one real listener and fan out locally to avoid listener warnings.
+    ipcRenderer.on('terminal:file-drop', onNativeFileDrop)
+    nativeFileDropListenerRegistered = true
+  }
+  return () => {
+    const callbackIndex = nativeFileDropCallbacks.indexOf(callback)
+    if (callbackIndex !== -1) {
+      nativeFileDropCallbacks.splice(callbackIndex, 1)
+    }
+    if (nativeFileDropCallbacks.length === 0 && nativeFileDropListenerRegistered) {
+      ipcRenderer.removeListener('terminal:file-drop', onNativeFileDrop)
+      nativeFileDropListenerRegistered = false
+    }
+  }
+}
 
 // Why: one shared HTMLAudioElement per sound file, restarted from t=0 on each
 // play, with an in-flight guard that drops new plays while the sound is still
@@ -142,7 +179,10 @@ function resolveNativeFileDrop(event: DragEvent): NativeDropResolution | null {
     }
 
     const target = entry.dataset.nativeFileDropTarget
-    if (target === 'editor' || target === 'terminal' || target === 'composer') {
+    if (target === 'terminal') {
+      return { target, tabId: entry.dataset.terminalTabId }
+    }
+    if (target === 'editor' || target === 'composer') {
       return { target }
     }
     if (target === 'file-explorer') {
@@ -241,7 +281,10 @@ document.addEventListener(
       // behavior instead of being silently discarded.
       ipcRenderer.send('terminal:file-dropped-from-preload', {
         paths,
-        target: resolution?.target ?? 'editor'
+        target: resolution?.target ?? 'editor',
+        ...(resolution?.target === 'terminal' && resolution.tabId
+          ? { tabId: resolution.tabId }
+          : {})
       })
     }
   },
@@ -2035,26 +2078,8 @@ const api = {
       ipcRenderer.invoke('clipboard:writeText', text),
     writeClipboardImage: (dataUrl: string): Promise<void> =>
       ipcRenderer.invoke('clipboard:writeImage', dataUrl),
-    onFileDrop: (
-      callback: (
-        data:
-          | { paths: string[]; target: 'editor' }
-          | { paths: string[]; target: 'terminal' }
-          | { paths: string[]; target: 'composer' }
-          | { paths: string[]; target: 'file-explorer'; destinationDir: string }
-      ) => void
-    ): (() => void) => {
-      const listener = (
-        _event: Electron.IpcRendererEvent,
-        data:
-          | { paths: string[]; target: 'editor' }
-          | { paths: string[]; target: 'terminal' }
-          | { paths: string[]; target: 'composer' }
-          | { paths: string[]; target: 'file-explorer'; destinationDir: string }
-      ) => callback(data)
-      ipcRenderer.on('terminal:file-drop', listener)
-      return () => ipcRenderer.removeListener('terminal:file-drop', listener)
-    },
+    onFileDrop: (callback: (data: NativeFileDropPayload) => void): (() => void) =>
+      subscribeNativeFileDrop(callback),
     getZoomLevel: (): number => webFrame.getZoomLevel(),
     setZoomLevel: (level: number): void => webFrame.setZoomLevel(level),
     syncTrafficLights: (zoomFactor: number): void =>

--- a/src/renderer/src/components/terminal-pane/terminal-drop-handler.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-drop-handler.ts
@@ -11,7 +11,7 @@ type Args = {
   paneTransports: Map<number, PtyTransport>
   worktreeId: string
   cwd: string | undefined
-  data: { paths: string[]; target: string }
+  data: { paths: string[]; target: string; tabId?: string }
 }
 
 /**

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts
@@ -1,10 +1,12 @@
 import type * as ReactModule from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useTerminalPaneGlobalEffects } from './use-terminal-pane-global-effects'
 
 const mocks = vi.hoisted(() => ({
   fitAndFocusPanes: vi.fn(),
   fitPanes: vi.fn(),
-  flushTerminalOutput: vi.fn()
+  flushTerminalOutput: vi.fn(),
+  handleTerminalFileDrop: vi.fn()
 }))
 
 vi.mock('react', async (importOriginal) => {
@@ -27,9 +29,65 @@ vi.mock('@/lib/pane-manager/pane-terminal-output-scheduler', () => ({
   flushTerminalOutput: mocks.flushTerminalOutput
 }))
 
+vi.mock('./terminal-drop-handler', () => ({
+  handleTerminalFileDrop: mocks.handleTerminalFileDrop
+}))
+
 class MockResizeObserver {
   observe = vi.fn()
   disconnect = vi.fn()
+}
+
+type DropCallback = (data: { paths: string[]; target: string; tabId?: string }) => void
+
+function useMountForFileDrop(
+  options: {
+    tabId?: string
+    worktreeId?: string
+    cwd?: string
+    isActive?: boolean
+    isVisible?: boolean
+  } = {}
+): {
+  onFileDrop: DropCallback
+  manager: {
+    getPanes: ReturnType<typeof vi.fn>
+    resumeRendering: ReturnType<typeof vi.fn>
+    suspendRendering: ReturnType<typeof vi.fn>
+    getActivePane: ReturnType<typeof vi.fn>
+  }
+  paneTransports: Map<number, never>
+} {
+  let onFileDrop: DropCallback = () => {
+    throw new Error('onFileDrop callback was not registered')
+  }
+  window.api.ui.onFileDrop = vi.fn((callback) => {
+    onFileDrop = callback
+    return vi.fn()
+  })
+  const manager = {
+    getPanes: vi.fn(() => []),
+    resumeRendering: vi.fn(),
+    suspendRendering: vi.fn(),
+    getActivePane: vi.fn(() => null)
+  }
+  const paneTransports = new Map<number, never>()
+
+  useTerminalPaneGlobalEffects({
+    tabId: options.tabId ?? 'tab-1',
+    worktreeId: options.worktreeId ?? 'wt-1',
+    cwd: options.cwd,
+    isActive: options.isActive ?? true,
+    isVisible: options.isVisible ?? true,
+    managerRef: { current: manager as never },
+    containerRef: { current: null },
+    paneTransportsRef: { current: paneTransports },
+    isActiveRef: { current: false },
+    isVisibleRef: { current: false },
+    toggleExpandPane: vi.fn()
+  })
+
+  return { onFileDrop, manager, paneTransports }
 }
 
 describe('useTerminalPaneGlobalEffects', () => {
@@ -52,8 +110,7 @@ describe('useTerminalPaneGlobalEffects', () => {
     delete (globalThis as unknown as { ResizeObserver?: unknown }).ResizeObserver
   })
 
-  it('flushes visible terminal panes before resuming rendering and fitting', async () => {
-    const { useTerminalPaneGlobalEffects } = await import('./use-terminal-pane-global-effects')
+  it('flushes visible terminal panes before resuming rendering and fitting', () => {
     const order: string[] = []
     const terminalA = { name: 'terminal-a' }
     const terminalB = { name: 'terminal-b' }
@@ -92,5 +149,61 @@ describe('useTerminalPaneGlobalEffects', () => {
     expect(mocks.fitPanes).not.toHaveBeenCalled()
     expect(isActiveRef.current).toBe(true)
     expect(isVisibleRef.current).toBe(true)
+  })
+
+  it('ignores terminal file drops for another terminal tab', () => {
+    const { onFileDrop } = useMountForFileDrop()
+
+    onFileDrop({ paths: ['/tmp/image.png'], target: 'terminal', tabId: 'tab-2' })
+
+    expect(mocks.handleTerminalFileDrop).not.toHaveBeenCalled()
+  })
+
+  it('handles terminal file drops for the matching terminal tab', () => {
+    const { onFileDrop, manager, paneTransports } = useMountForFileDrop({
+      cwd: '/worktree'
+    })
+
+    const data = { paths: ['/tmp/image.png'], target: 'terminal', tabId: 'tab-1' }
+    onFileDrop(data)
+
+    expect(mocks.handleTerminalFileDrop).toHaveBeenCalledWith({
+      manager,
+      paneTransports,
+      worktreeId: 'wt-1',
+      cwd: '/worktree',
+      data
+    })
+  })
+
+  it('keeps handling legacy terminal file drops without a terminal tab id', () => {
+    const { onFileDrop, manager, paneTransports } = useMountForFileDrop()
+
+    const data = { paths: ['/tmp/image.png'], target: 'terminal' }
+    onFileDrop(data)
+
+    expect(mocks.handleTerminalFileDrop).toHaveBeenCalledWith({
+      manager,
+      paneTransports,
+      worktreeId: 'wt-1',
+      cwd: undefined,
+      data
+    })
+  })
+
+  it('handles terminal file drops for visible unfocused split-group terminals', () => {
+    const { onFileDrop } = useMountForFileDrop({ isActive: false, isVisible: true })
+
+    onFileDrop({ paths: ['/tmp/image.png'], target: 'terminal', tabId: 'tab-1' })
+
+    expect(mocks.handleTerminalFileDrop).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores legacy terminal file drops in visible unfocused split-group terminals', () => {
+    const { onFileDrop } = useMountForFileDrop({ isActive: false, isVisible: true })
+
+    onFileDrop({ paths: ['/tmp/image.png'], target: 'terminal' })
+
+    expect(mocks.handleTerminalFileDrop).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.ts
@@ -223,15 +223,22 @@ export function useTerminalPaneGlobalEffects({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isVisible])
 
-  // Why: only the active tab's terminal should process file drops. Registering
-  // a listener per mounted tab causes a MaxListenersExceededWarning when 11+
-  // tabs are open. Gating on isActive ensures at most one listener exists.
+  // Why: visible but unfocused split-group terminals can still receive native
+  // OS drops. Route tab-id-aware payloads to the dropped pane, while legacy
+  // payloads without a tab id keep the old active-terminal-only behavior.
   useEffect(() => {
-    if (!isActive) {
+    if (!isActive && !isVisible) {
       return
     }
     return window.api.ui.onFileDrop((data) => {
       if (data.target !== 'terminal') {
+        return
+      }
+      if (data.tabId) {
+        if (data.tabId !== tabId) {
+          return
+        }
+      } else if (!isActive) {
         return
       }
       const manager = managerRef.current
@@ -250,5 +257,5 @@ export function useTerminalPaneGlobalEffects({
         data
       })
     })
-  }, [isActive, managerRef, paneTransportsRef])
+  }, [isActive, isVisible, managerRef, paneTransportsRef, tabId])
 }


### PR DESCRIPTION
## Summary
- route native terminal file drops with an optional terminal tab id
- fan out preload file-drop IPC through a single listener to avoid listener warnings
- keep legacy terminal drop behavior active-only and cover tab routing with tests

## Tests
- not run (auto-pr-merge will wait for CI)