### PR TITLE
fix: handle non-git worktree paths

### DIFF
--- a/src/main/git/remove-worktree.test.ts
+++ b/src/main/git/remove-worktree.test.ts
@@ -362,6 +362,25 @@ describe('listWorktrees', () => {
     warnSpy.mockRestore()
   })
 
+  it('returns no worktrees when the path exists but is not a git repo', async () => {
+    const warnSpy = vi.spyOn(console, 'warn')
+    gitExecFileAsyncMock.mockRejectedValueOnce(
+      Object.assign(new Error('Command failed: git worktree list --porcelain'), {
+        code: 128,
+        stdout: '',
+        stderr: 'fatal: not a git repository (or any of the parent directories): .git\n'
+      })
+    )
+
+    await expect(listWorktrees('/private/tmp/orca-issue-1582-test/my-repo')).resolves.toEqual([])
+
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(['worktree', 'list', '--porcelain'], {
+      cwd: '/private/tmp/orca-issue-1582-test/my-repo'
+    })
+    expect(warnSpy).not.toHaveBeenCalled()
+    warnSpy.mockRestore()
+  })
+
   it('detects sparse checkout after translating paths when porcelain omits sparse token', async () => {
     gitExecFileAsyncMock.mockImplementation((args: string[]) => {
       if (args.join(' ') === 'worktree list --porcelain') {

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -14,6 +14,24 @@ function getErrorCode(error: unknown): string | undefined {
     : undefined
 }
 
+function getErrorText(error: unknown): string {
+  if (typeof error === 'object' && error !== null) {
+    const parts: string[] = []
+    if ('message' in error && typeof error.message === 'string') {
+      parts.push(error.message)
+    }
+    if ('stderr' in error && typeof error.stderr === 'string') {
+      parts.push(error.stderr)
+    }
+    return parts.join('\n')
+  }
+  return String(error)
+}
+
+function isNotGitRepositoryError(error: unknown): boolean {
+  return /not a git repository/i.test(getErrorText(error))
+}
+
 function normalizeLocalBranchRef(branch: string): string {
   return branch.replace(/^refs\/heads\//, '')
 }
@@ -121,6 +139,9 @@ export async function listWorktrees(repoPath: string): Promise<GitWorktreeInfo[]
           return []
         }
       }
+    }
+    if (isNotGitRepositoryError(err)) {
+      return []
     }
     // Why: a silent catch turned issue #1453's underlying
     // "git: unknown switch -z" into the opaque "not found in listing" toast.


### PR DESCRIPTION
## Summary
- return an empty worktree list without warning when git reports an existing path is not a repository
- add coverage for the non-git path failure case

## Tests
- pnpm vitest run src/main/git/remove-worktree.test.ts
- pnpm typecheck