### PR TITLE
fix(pty): preserve WSL worktree cwd in terminals

### DIFF
--- a/src/main/daemon/pty-subprocess.test.ts
+++ b/src/main/daemon/pty-subprocess.test.ts
@@ -501,6 +501,34 @@ describe('createPtySubprocess', () => {
     )
   })
 
+  it('keeps WSL UNC worktree terminals in the matching distro cwd on Windows', () => {
+    const proc = mockPtyProcess()
+    spawnMock.mockReturnValue(proc)
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')
+
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+
+    try {
+      createPtySubprocess({
+        sessionId: 'test',
+        cols: 80,
+        rows: 24,
+        cwd: '\\\\wsl.localhost\\Ubuntu\\home\\alice\\repo',
+        shellOverride: 'wsl.exe'
+      })
+    } finally {
+      if (platform) {
+        Object.defineProperty(process, 'platform', platform)
+      }
+    }
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      'wsl.exe',
+      ['-d', 'Ubuntu', '--', 'bash', '-c', "cd '/home/alice/repo' && exec bash -l"],
+      expect.objectContaining({ cwd: expect.any(String) })
+    )
+  })
+
   // Why: node-pty's UnixTerminal.destroy() registers _socket.once('close', () =>
   // this.kill('SIGHUP')), and the socket 'close' event can fire concurrently
   // with onExit. If kill is not neutralized by the time close fires, SIGHUP

--- a/src/main/providers/windows-shell-args.test.ts
+++ b/src/main/providers/windows-shell-args.test.ts
@@ -73,6 +73,37 @@ describe('resolveWindowsShellLaunchArgs', () => {
     expect(result.shellArgs[3]).toBe("cd '/mnt/c' && exec bash -l")
   })
 
+  it('keeps WSL UNC worktree cwd inside the matching distro', () => {
+    const originalPlatform = process.platform
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: 'win32'
+    })
+
+    try {
+      const result = resolveWindowsShellLaunchArgs(
+        'wsl.exe',
+        '\\\\wsl.localhost\\Ubuntu\\home\\alice\\repo',
+        'C:\\Users\\alice'
+      )
+      expect(result.shellArgs).toEqual([
+        '-d',
+        'Ubuntu',
+        '--',
+        'bash',
+        '-c',
+        "cd '/home/alice/repo' && exec bash -l"
+      ])
+      expect(result.effectiveCwd).toBe('C:\\Users\\alice')
+      expect(result.validationCwd).toBe('\\\\wsl.localhost\\Ubuntu\\home\\alice\\repo')
+    } finally {
+      Object.defineProperty(process, 'platform', {
+        configurable: true,
+        value: originalPlatform
+      })
+    }
+  })
+
   it('falls back to empty args + same cwd for unknown shells', () => {
     const result = resolveWindowsShellLaunchArgs(
       'C:\\tools\\fish.exe',

--- a/src/main/providers/windows-shell-args.ts
+++ b/src/main/providers/windows-shell-args.ts
@@ -1,4 +1,5 @@
 import { win32 as pathWin32 } from 'path'
+import { parseWslPath, toLinuxPath } from '../wsl'
 
 /** Result of resolving a Windows shell to its launch args + effective cwd.
  *
@@ -62,8 +63,17 @@ export function resolveWindowsShellLaunchArgs(
   }
 
   if (shellBasename === 'wsl.exe') {
+    const wslInfo = parseWslPath(cwd)
+    if (wslInfo) {
+      const escapedLinuxCwd = wslInfo.linuxPath.replace(/'/g, "'\\''")
+      return {
+        shellArgs: ['-d', wslInfo.distro, '--', 'bash', '-c', `cd '${escapedLinuxCwd}' && exec bash -l`],
+        effectiveCwd: defaultCwd,
+        validationCwd: cwd
+      }
+    }
     const driveMatch = cwd.replace(/\\/g, '/').match(/^([A-Za-z]):\/?(.*)$/)
-    const linuxCwd = driveMatch ? `/mnt/${driveMatch[1].toLowerCase()}/${driveMatch[2]}` : '/mnt/c'
+    const linuxCwd = driveMatch ? toLinuxPath(cwd) : '/mnt/c'
     const escapedLinuxCwd = linuxCwd.replace(/'/g, "'\\''")
     return {
       shellArgs: ['--', 'bash', '-c', `cd '${escapedLinuxCwd}' && exec bash -l`],


### PR DESCRIPTION
## Summary
- detect WSL UNC cwd values before drive-letter conversion in Windows shell launch args
- launch wsl.exe with the matching distro and cd into the parsed Linux worktree path
- add regression coverage for the daemon terminal path and shared shell-args helper

## Root Cause
Daemon-backed Windows PTYs route wsl.exe through resolveWindowsShellLaunchArgs. That helper handled drive-letter cwd values, while WSL worktree paths such as \\wsl.localhost\Ubuntu\home\user\repo fell through to the generic non-drive fallback and opened at /mnt/c.

## Validation
- node node_modules/.pnpm/vitest@4.1.5_@types+node@25.6.0_msw@2.14.3_@types+node@25.6.0_typescript@5.9.3__vite@7._3f4515e029db78135ef9cfa9ec3d5a91/node_modules/vitest/vitest.mjs run src/main/providers/windows-shell-args.test.ts src/main/daemon/pty-subprocess.test.ts src/main/wsl.test.ts
- 3 test files passed, 43 tests passed