### PR TITLE
perf(fs): prevent overlapping WSL watcher polls

### DIFF
--- a/src/main/ipc/filesystem-watcher-wsl.test.ts
+++ b/src/main/ipc/filesystem-watcher-wsl.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { readdirMock } = vi.hoisted(() => ({
+  readdirMock: vi.fn()
+}))
+
+vi.mock('fs/promises', () => ({
+  readdir: readdirMock
+}))
+
+import { createWslWatcher } from './filesystem-watcher-wsl'
+import type { WatchedRoot } from './filesystem-watcher-wsl'
+
+describe('createWslWatcher', () => {
+  const rootPath = '/mnt/wsl/repo'
+  const rootKey = rootPath
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    readdirMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  function deps(scheduleBatchFlush: (rootKey: string, root: WatchedRoot) => void) {
+    return {
+      ignoreDirs: ['node_modules', '.git'],
+      scheduleBatchFlush,
+      watchedRoots: new Map<string, WatchedRoot>()
+    }
+  }
+
+  function releasePollWith(
+    releasePoll: ((entries: string[]) => void) | null,
+    entries: string[]
+  ): void {
+    if (!releasePoll) {
+      throw new Error('expected an in-flight poll')
+    }
+    releasePoll(entries)
+  }
+
+  it('does not overlap polling when a WSL snapshot scan is still in flight', async () => {
+    const scheduleBatchFlush = vi.fn()
+    let rootReads = 0
+    let releasePoll: ((entries: string[]) => void) | null = null
+
+    readdirMock.mockImplementation((dirPath: string) => {
+      if (dirPath !== rootPath) {
+        return Promise.resolve([])
+      }
+      rootReads += 1
+      if (rootReads === 1) {
+        return Promise.resolve(['src'])
+      }
+      if (rootReads === 2) {
+        return new Promise<string[]>((resolve) => {
+          releasePoll = resolve
+        })
+      }
+      return Promise.resolve(['src'])
+    })
+
+    const root = await createWslWatcher(rootKey, rootPath, deps(scheduleBatchFlush))
+
+    expect(rootReads).toBe(1)
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(rootReads).toBe(2)
+    await vi.advanceTimersByTimeAsync(4_000)
+    expect(rootReads).toBe(2)
+
+    releasePollWith(releasePoll, ['src', 'new-file.ts'])
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(scheduleBatchFlush).toHaveBeenCalledOnce()
+    await root.subscription.unsubscribe()
+  })
+
+  it('does not flush a poll that completes after unsubscribe', async () => {
+    const scheduleBatchFlush = vi.fn()
+    let rootReads = 0
+    let releasePoll: ((entries: string[]) => void) | null = null
+
+    readdirMock.mockImplementation((dirPath: string) => {
+      if (dirPath !== rootPath) {
+        return Promise.resolve([])
+      }
+      rootReads += 1
+      if (rootReads === 1) {
+        return Promise.resolve(['src'])
+      }
+      return new Promise<string[]>((resolve) => {
+        releasePoll = resolve
+      })
+    })
+
+    const root = await createWslWatcher(rootKey, rootPath, deps(scheduleBatchFlush))
+    await vi.advanceTimersByTimeAsync(2_000)
+    await root.subscription.unsubscribe()
+
+    releasePollWith(releasePoll, ['src', 'late-file.ts'])
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(scheduleBatchFlush).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/ipc/filesystem-watcher-wsl.ts
+++ b/src/main/ipc/filesystem-watcher-wsl.ts
@@ -139,9 +139,18 @@ export async function createWslWatcher(
   // Take initial snapshot
   let prevSnapshot = await takeSnapshot(worktreePath, deps.ignoreDirs)
 
-  const intervalId = setInterval(async () => {
+  let polling = false
+  let disposed = false
+  const poll = async (): Promise<void> => {
+    if (polling || disposed) {
+      return
+    }
+    polling = true
     try {
       const nextSnapshot = await takeSnapshot(worktreePath, deps.ignoreDirs)
+      if (disposed) {
+        return
+      }
       const events = diffSnapshots(prevSnapshot, nextSnapshot)
       prevSnapshot = nextSnapshot
 
@@ -153,11 +162,21 @@ export async function createWslWatcher(
       // Why: if the WSL filesystem becomes temporarily unavailable
       // (e.g. WSL distro shuts down), skip this poll cycle rather
       // than crashing.  The next cycle will retry.
+    } finally {
+      polling = false
     }
+  }
+
+  const intervalId = setInterval(() => {
+    // Why: WSL UNC scans can exceed the poll interval on large repos or cold
+    // network filesystems. Run at most one tree diff at a time so a slow scan
+    // cannot stack concurrent readdir storms on the same root.
+    void poll()
   }, POLL_INTERVAL_MS)
 
   root.subscription = {
     unsubscribe: async () => {
+      disposed = true
       clearInterval(intervalId)
     }
   }


### PR DESCRIPTION
## Summary
- Prevent overlapping WSL watcher scans when a UNC tree poll takes longer than the interval.
- Suppress late batch flushes after unsubscribe so disposed watchers do not emit stale updates.
- Add focused coverage for non-overlapping polls and late unsubscribe behavior.

## Why
WSL/UNC filesystem scans are latency-sensitive and can occasionally exceed the 2s interval. Without an in-flight guard, each interval can start another recursive scan, multiplying `readdir` work and CPU/IO pressure on large worktrees.

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/filesystem-watcher-wsl.test.ts`
