### PR TITLE
perf(terminal): checkpoint only dirty daemon sessions

### DIFF
--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -475,6 +475,41 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       )
     })
 
+    it('checkpoints only dirty sessions on the periodic timer', async () => {
+      const adapterClass = DaemonPtyAdapter as unknown as { CHECKPOINT_INTERVAL_MS: number }
+      const previousInterval = adapterClass.CHECKPOINT_INTERVAL_MS
+      adapterClass.CHECKPOINT_INTERVAL_MS = 25
+
+      try {
+        historyAdapter = new DaemonPtyAdapter({ socketPath, tokenPath, historyPath: historyDir })
+        const { id } = await historyAdapter.spawn({
+          cols: 80,
+          rows: 24,
+          cwd: '/home/user',
+          sessionId: 'dirty-checkpoint'
+        })
+        const checkpointSpy = vi.spyOn(historyAdapter.getHistoryManager()!, 'checkpoint')
+
+        await new Promise((r) => setTimeout(r, 80))
+
+        // Why: idle terminals can be numerous. A periodic pass with no data
+        // must not serialize every live daemon session just because it exists.
+        expect(checkpointSpy).not.toHaveBeenCalled()
+
+        lastSubprocess._simulateData('new output\r\n')
+        await waitFor(() => checkpointSpy.mock.calls.length === 1)
+        expect(checkpointSpy).toHaveBeenCalledWith(
+          id,
+          expect.objectContaining({ snapshotAnsi: expect.stringContaining('new output') })
+        )
+
+        await new Promise((r) => setTimeout(r, 80))
+        expect(checkpointSpy).toHaveBeenCalledTimes(1)
+      } finally {
+        adapterClass.CHECKPOINT_INTERVAL_MS = previousInterval
+      }
+    })
+
     it('writes meta.json with endedAt on exit', async () => {
       historyAdapter = new DaemonPtyAdapter({ socketPath, tokenPath, historyPath: historyDir })
 

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -65,6 +65,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
   // second mount until the renderer explicitly acknowledges it.
   private coldRestoreCache = new Map<string, { scrollback: string; cwd: string }>()
   private activeSessionIds = new Set<string>()
+  private dirtySessionVersions = new Map<string, number>()
   private checkpointInterval: ReturnType<typeof setInterval> | null = null
   private checkpointInFlight: Promise<void> | null = null
   // Why: checkpoint-based persistence requires the getSnapshot RPC (v4+).
@@ -223,16 +224,19 @@ export class DaemonPtyAdapter implements IPtyProvider {
   }
 
   write(id: string, data: string): void {
+    this.markSessionDirty(id)
     this.client.notify('write', { sessionId: id, data })
   }
 
   resize(id: string, cols: number, rows: number): void {
+    this.markSessionDirty(id)
     this.client.notify('resize', { sessionId: id, cols, rows })
   }
 
   async shutdown(id: string, opts: { immediate?: boolean; keepHistory?: boolean }): Promise<void> {
     await this.client.request('kill', { sessionId: id })
     this.activeSessionIds.delete(id)
+    this.dirtySessionVersions.delete(id)
     this.initialCwds.delete(id)
     // Why: history removal is for the "user explicitly closed this terminal"
     // path. Sleep also calls shutdown but expects scrollback to survive — wake
@@ -288,6 +292,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
 
   async clearBuffer(id: string): Promise<void> {
     await this.client.request('clearScrollback', { sessionId: id })
+    this.markSessionDirty(id)
   }
 
   acknowledgeDataEvent(_id: string, _charCount: number): void {
@@ -392,6 +397,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
   fanoutSyntheticExits(code: number): void {
     const ids = [...this.activeSessionIds]
     this.activeSessionIds.clear()
+    this.dirtySessionVersions.clear()
     for (const id of ids) {
       // Why: listener throws are intentionally *not* caught — matches the
       // natural onExit fanout in setupEventRouting, so synthetic exits don't
@@ -451,6 +457,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
       clearInterval(this.checkpointInterval)
       this.checkpointInterval = null
     }
+    this.dirtySessionVersions.clear()
     this.removeEventListener?.()
     this.removeEventListener = null
     // Why: final checkpoints are written daemon-side in TerminalHost.dispose()
@@ -487,6 +494,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
     // before disconnecting — fire-and-forget would race with client.disconnect()
     // and the pending getSnapshot RPCs would be rejected.
     await this.checkpointAllSessions()
+    this.dirtySessionVersions.clear()
     this.removeEventListener?.()
     this.removeEventListener = null
     this.client.disconnect()
@@ -510,10 +518,39 @@ export class DaemonPtyAdapter implements IPtyProvider {
       if (this.checkpointInFlight) {
         return
       }
-      this.checkpointInFlight = this.checkpointAllSessions().finally(() => {
+      this.checkpointInFlight = this.checkpointDirtySessions().finally(() => {
         this.checkpointInFlight = null
       })
     }, DaemonPtyAdapter.CHECKPOINT_INTERVAL_MS)
+  }
+
+  private markSessionDirty(sessionId: string): void {
+    if (!this.activeSessionIds.has(sessionId)) {
+      return
+    }
+    this.dirtySessionVersions.set(sessionId, (this.dirtySessionVersions.get(sessionId) ?? 0) + 1)
+  }
+
+  private async checkpointDirtySessions(): Promise<void> {
+    if (!this.historyManager || this.dirtySessionVersions.size === 0) {
+      return
+    }
+    // Why: getSnapshot serializes the daemon's terminal buffer. On large
+    // workspaces, checkpointing every live idle session every 5s burns CPU and
+    // disk for identical payloads; dirty versions keep retries precise without
+    // dropping writes that arrive during an in-flight checkpoint.
+    const versions = new Map(
+      [...this.dirtySessionVersions].filter(([sessionId]) => this.activeSessionIds.has(sessionId))
+    )
+    if (versions.size === 0) {
+      return
+    }
+    const completed = await this.checkpointSessions(versions.keys())
+    for (const [sessionId, version] of versions) {
+      if (completed.has(sessionId) && this.dirtySessionVersions.get(sessionId) === version) {
+        this.dirtySessionVersions.delete(sessionId)
+      }
+    }
   }
 
   // Why: the adapter runs in the Electron main process and does not have direct
@@ -521,24 +558,36 @@ export class DaemonPtyAdapter implements IPtyProvider {
   // daemon socket per session. Returns a promise that resolves when all
   // checkpoint writes complete (callers that don't need to wait can void it).
   private async checkpointAllSessions(): Promise<void> {
+    const completed = await this.checkpointSessions(this.activeSessionIds)
+    for (const sessionId of completed) {
+      this.dirtySessionVersions.delete(sessionId)
+    }
+  }
+
+  private async checkpointSessions(sessionIds: Iterable<string>): Promise<Set<string>> {
+    const completed = new Set<string>()
     if (!this.historyManager) {
-      return
+      return completed
     }
     const promises: Promise<void>[] = []
-    for (const sessionId of this.activeSessionIds) {
+    for (const sessionId of sessionIds) {
       promises.push(
         this.client
           .request<GetSnapshotResult>('getSnapshot', { sessionId })
           .then((result) => {
             if (result.snapshot && this.historyManager) {
-              return this.historyManager.checkpoint(sessionId, result.snapshot)
+              return this.historyManager.checkpoint(sessionId, result.snapshot).then(() => {
+                completed.add(sessionId)
+              })
             }
+            completed.add(sessionId)
             return undefined
           })
           .catch((err) => console.warn('[history] checkpoint failed:', sessionId, err))
       )
     }
     await Promise.all(promises)
+    return completed
   }
 
   // Why: when the daemon process dies, operations fail with ENOENT (socket
@@ -584,12 +633,14 @@ export class DaemonPtyAdapter implements IPtyProvider {
       }
 
       if (event.event === 'data') {
+        this.markSessionDirty(event.sessionId)
         // oxlint-disable-next-line unicorn/no-useless-spread -- copy-safe: listeners may unsubscribe during iteration
         for (const listener of [...this.dataListeners]) {
           listener({ id: event.sessionId, data: event.payload.data })
         }
       } else if (event.event === 'exit') {
         this.activeSessionIds.delete(event.sessionId)
+        this.dirtySessionVersions.delete(event.sessionId)
         if (this.historyManager) {
           void this.historyManager
             .closeSession(event.sessionId, event.payload.code)


### PR DESCRIPTION
## Summary
- Track dirty daemon PTY sessions and checkpoint only sessions that changed since the last periodic tick.
- Mark sessions dirty on data, write, resize, and clear-buffer events.
- Preserve full checkpointing on disconnect/shutdown paths.
- Add focused coverage that idle sessions stay uncheckpointed across periodic ticks.

## Why
The periodic checkpoint loop previously snapshotted every live daemon session, even idle ones. That makes `getSnapshot()` cost scale with total session count instead of active session count, which is expensive for large terminal-heavy workspaces.

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/daemon-pty-adapter.test.ts`
