### PR TITLE
fix(terminal): repaint after WebGL attach

### DIFF
--- a/src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts
@@ -96,6 +96,7 @@ describe('attachWebgl', () => {
     attachWebgl(pane)
     expect(pane.terminal.loadAddon).toHaveBeenCalledTimes(1)
     expect(webglMock.contextLossHandler).not.toBeNull()
+    vi.mocked(pane.terminal.refresh).mockClear()
 
     webglMock.contextLossHandler?.()
 
@@ -107,6 +108,14 @@ describe('attachWebgl', () => {
     attachWebgl(pane)
 
     expect(pane.terminal.loadAddon).toHaveBeenCalledTimes(1)
+  })
+
+  it('repaints the current buffer after WebGL attaches', () => {
+    const pane = createPane()
+
+    attachWebgl(pane)
+
+    expect(pane.terminal.refresh).toHaveBeenCalledWith(0, 23)
   })
 
   it('does not attach WebGL while initial rendering is deferred', () => {

--- a/src/renderer/src/lib/pane-manager/pane-rendering-control.ts
+++ b/src/renderer/src/lib/pane-manager/pane-rendering-control.ts
@@ -47,13 +47,5 @@ export function resumePaneRendering(panes: Iterable<ManagedPaneInternal>): void 
   for (const pane of panes) {
     pane.webglAttachmentDeferred = false
     reattachWebglIfNeeded(pane)
-    // Why: fresh WebGL canvas has no content — refresh prevents frozen terminal.
-    if (pane.webglAddon) {
-      try {
-        pane.terminal.refresh(0, pane.terminal.rows - 1)
-      } catch {
-        /* ignore */
-      }
-    }
   }
 }

--- a/src/renderer/src/lib/pane-manager/pane-webgl-renderer.ts
+++ b/src/renderer/src/lib/pane-manager/pane-webgl-renderer.ts
@@ -21,6 +21,16 @@ function shouldUseWebgl(pane: ManagedPaneInternal): boolean {
   )
 }
 
+function refreshTerminalAfterWebglAttach(pane: ManagedPaneInternal): void {
+  try {
+    // Why: a newly attached WebGL canvas starts empty; repaint immediately so
+    // resume/reparent/settings toggles do not look frozen until new output.
+    pane.terminal.refresh(0, pane.terminal.rows - 1)
+  } catch {
+    /* ignore — pane may have been disposed in the meantime */
+  }
+}
+
 export function disposeWebgl(
   pane: ManagedPaneInternal,
   options?: { refreshDimensions?: boolean }
@@ -84,6 +94,7 @@ export function attachWebgl(pane: ManagedPaneInternal): void {
     })
     pane.terminal.loadAddon(webglAddon)
     pane.webglAddon = webglAddon
+    refreshTerminalAfterWebglAttach(pane)
   } catch (err) {
     if (pane.terminalGpuAcceleration === 'auto') {
       // Why: mirrors VS Code's `terminal.integrated.gpuAcceleration=auto`


### PR DESCRIPTION
Category: Frozen terminal\n\nSymptom: A terminal pane can look frozen/blank after WebGL is recreated for resume, split/reparent, GPU setting changes, or ligature atlas rebuilds because the fresh WebGL canvas is attached before xterm is forced to repaint the existing buffer.\n\nWasted resource: Orca creates and keeps a GPU/WebGL renderer for a live xterm buffer, but the renderer may not display useful pixels until later output or resize work happens. The previous resume-only repaint also duplicated this responsibility outside the WebGL attach path.\n\nMeasurement: Added focused unit coverage for attachWebgl to assert a successful WebGL attach immediately calls terminal.refresh(0, rows - 1). Kept the context-loss test explicit by clearing the attach repaint before asserting the context-loss repaint.\n\nFix: Centralized the repaint in pane-webgl-renderer immediately after successful WebGL addon load, and removed the resume-specific duplicate refresh. This covers resume, reparent/split, GPU toggle, and ligature reattach call sites through the shared attach path.\n\nVerification:\n- pnpm vitest run --config config/vitest.config.ts src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts\n- pnpm run tc:web\n- pnpm oxlint src/renderer/src/lib/pane-manager/pane-webgl-renderer.ts src/renderer/src/lib/pane-manager/pane-rendering-control.ts src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts