### PR TITLE
perf(terminal): batch daemon PTY stream output

### DIFF
--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -183,6 +183,19 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       await waitFor(() => dataPayloads.length > 0)
       expect(dataPayloads[0]).toEqual({ id, data: 'hello' })
     })
+
+    it('coalesces burst data events before serializing daemon stream output', async () => {
+      const dataPayloads: { id: string; data: string }[] = []
+      adapter.onData((payload) => dataPayloads.push(payload))
+
+      const { id } = await adapter.spawn({ cols: 80, rows: 24 })
+      lastSubprocess._simulateData('a')
+      lastSubprocess._simulateData('b')
+      lastSubprocess._simulateData('c')
+
+      await waitFor(() => dataPayloads.length > 0)
+      expect(dataPayloads).toEqual([{ id, data: 'abc' }])
+    })
   })
 
   describe('onExit', () => {

--- a/src/main/daemon/daemon-server.ts
+++ b/src/main/daemon/daemon-server.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'crypto'
 import { writeFileSync, chmodSync, unlinkSync } from 'fs'
 import { encodeNdjson, createNdjsonParser } from './ndjson'
 import { TerminalHost } from './terminal-host'
+import { DaemonStreamDataBatcher } from './daemon-stream-data-batcher'
 import type { SubprocessHandle } from './session'
 import {
   PROTOCOL_VERSION,
@@ -40,6 +41,7 @@ export class DaemonServer {
   private tokenPath: string
 
   private clients = new Map<string, ConnectedClient>()
+  private streamDataBatcher = new DaemonStreamDataBatcher((clientId) => this.clients.get(clientId))
 
   constructor(opts: DaemonServerOptions) {
     this.socketPath = opts.socketPath
@@ -70,6 +72,7 @@ export class DaemonServer {
 
   async shutdown(): Promise<void> {
     this.host.dispose()
+    this.streamDataBatcher.clear()
 
     for (const [, client] of this.clients) {
       client.controlSocket.destroy()
@@ -158,6 +161,7 @@ export class DaemonServer {
     socket.on('data', (chunk) => parser.feed(chunk.toString()))
 
     socket.on('close', () => {
+      this.streamDataBatcher.clear(clientId)
       this.clients.delete(clientId)
     })
   }
@@ -205,18 +209,12 @@ export class DaemonServer {
           shellReadySupported: p.shellReadySupported,
           streamClient: {
             onData: (data) => {
-              if (client?.streamSocket) {
-                client.streamSocket.write(
-                  encodeNdjson({
-                    type: 'event',
-                    event: 'data',
-                    sessionId: p.sessionId,
-                    payload: { data }
-                  })
-                )
-              }
+              this.streamDataBatcher.enqueue(clientId, p.sessionId, data)
             },
             onExit: (code) => {
+              // Why: exit tears down renderer handlers; flush final output first
+              // so the last few milliseconds of PTY data are not stranded.
+              this.streamDataBatcher.flush(clientId)
               if (client?.streamSocket) {
                 client.streamSocket.write(
                   encodeNdjson({

--- a/src/main/daemon/daemon-stream-data-batcher.ts
+++ b/src/main/daemon/daemon-stream-data-batcher.ts
@@ -1,0 +1,91 @@
+import type { Socket } from 'net'
+import { encodeNdjson } from './ndjson'
+
+type StreamDataClient = {
+  streamSocket: Socket | null
+}
+
+type PendingStreamDataBatch = {
+  timer: ReturnType<typeof setTimeout> | null
+  queue: { sessionId: string; data: string }[]
+}
+
+// Why: match main-process PTY IPC batching to avoid adding latency while
+// removing daemon socket writes and JSON framing during bursty output.
+const STREAM_DATA_BATCH_INTERVAL_MS = 8
+
+export class DaemonStreamDataBatcher {
+  private pendingByClient = new Map<string, PendingStreamDataBatch>()
+  private getClient: (clientId: string) => StreamDataClient | undefined
+
+  constructor(getClient: (clientId: string) => StreamDataClient | undefined) {
+    this.getClient = getClient
+  }
+
+  enqueue(clientId: string, sessionId: string, data: string): void {
+    const client = this.getClient(clientId)
+    if (!client?.streamSocket || client.streamSocket.destroyed) {
+      return
+    }
+
+    let batch = this.pendingByClient.get(clientId)
+    if (!batch) {
+      batch = { timer: null, queue: [] }
+      this.pendingByClient.set(clientId, batch)
+    }
+
+    const last = batch.queue.at(-1)
+    if (last?.sessionId === sessionId) {
+      last.data += data
+    } else {
+      batch.queue.push({ sessionId, data })
+    }
+
+    if (!batch.timer) {
+      batch.timer = setTimeout(() => this.flush(clientId), STREAM_DATA_BATCH_INTERVAL_MS)
+    }
+  }
+
+  flush(clientId: string): void {
+    const batch = this.pendingByClient.get(clientId)
+    if (!batch) {
+      return
+    }
+
+    if (batch.timer) {
+      clearTimeout(batch.timer)
+      batch.timer = null
+    }
+    this.pendingByClient.delete(clientId)
+
+    const client = this.getClient(clientId)
+    if (!client?.streamSocket || client.streamSocket.destroyed) {
+      return
+    }
+
+    for (const entry of batch.queue) {
+      client.streamSocket.write(
+        encodeNdjson({
+          type: 'event',
+          event: 'data',
+          sessionId: entry.sessionId,
+          payload: { data: entry.data }
+        })
+      )
+    }
+  }
+
+  clear(clientId?: string): void {
+    const batches =
+      clientId === undefined
+        ? Array.from(this.pendingByClient.entries())
+        : [[clientId, this.pendingByClient.get(clientId)] as const]
+
+    for (const [id, batch] of batches) {
+      if (batch?.timer) {
+        clearTimeout(batch.timer)
+      }
+      this.pendingByClient.delete(id)
+    }
+  }
+}


### PR DESCRIPTION
Category: Terminal throughput

Symptom: daemon-backed terminal bursts still serialized and written one NDJSON event per subprocess chunk before the main-process PTY IPC batcher can coalesce them.

Wasted resource: extra daemon socket writes, JSON.stringify/parse work, and event dispatches under high-output PTY bursts.

Measurement: added a daemon adapter regression test that emits three synchronous PTY chunks and asserts the daemon stream delivers one coalesced data event (`abc`) instead of three events.

Fix: add a small daemon stream data batcher with the same 8 ms window as the existing main-process PTY IPC batcher. It merges adjacent same-session chunks, preserves interleaved event order, clears pending timers on shutdown/client close, and flushes before exit events so final output is not stranded behind teardown.

Verification:
- `pnpm vitest run --config config/vitest.config.ts src/main/daemon/daemon-pty-adapter.test.ts`
- `pnpm exec oxlint src/main/daemon/daemon-server.ts src/main/daemon/daemon-stream-data-batcher.ts src/main/daemon/daemon-pty-adapter.test.ts`
- `pnpm run tc:node`

Notes: scanned PTY IPC, daemon PTY streaming, renderer dispatcher, xterm output scheduler, resize IPC, and nearby tests. Main-process `pty:data` already had an 8 ms IPC batcher and resize IPC is already fire-and-forget; the defensible remaining win was the daemon stream serialization boundary.