### PR TITLE
Allow removing linked PRs from worktrees

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines -- Why: the worktree card centralizes sidebar card state (selection, drag, agent status, git info, context menu) in one cohesive component so sidebar rendering doesn't fan out across files. */
-import React, { useEffect, useMemo, useCallback, useState } from 'react'
+import React, { useEffect, useMemo, useCallback, useRef, useState } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { useAppStore } from '@/store'
 import { Badge } from '@/components/ui/badge'
@@ -83,6 +83,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
         worktreeId: worktree.id,
         currentDisplayName: worktree.displayName,
         currentIssue: worktree.linkedIssue,
+        currentPR: worktree.linkedPR,
         currentComment: worktree.comment,
         focus: 'issue'
       })
@@ -97,12 +98,28 @@ const WorktreeCard = React.memo(function WorktreeCard({
         worktreeId: worktree.id,
         currentDisplayName: worktree.displayName,
         currentIssue: worktree.linkedIssue,
+        currentPR: worktree.linkedPR,
         currentComment: worktree.comment,
         focus: 'comment'
       })
     },
     [worktree, openModal]
   )
+
+  const handleEditPr = useCallback(() => {
+    openModal('edit-meta', {
+      worktreeId: worktree.id,
+      currentDisplayName: worktree.displayName,
+      currentIssue: worktree.linkedIssue,
+      currentPR: worktree.linkedPR,
+      currentComment: worktree.comment,
+      focus: 'pr'
+    })
+  }, [worktree, openModal])
+
+  const handleRemovePr = useCallback(() => {
+    updateWorktreeMeta(worktree.id, { linkedPR: null })
+  }, [worktree.id, updateWorktreeMeta])
 
   const deleteState = useAppStore((s) => s.deleteStateByWorktreeId[worktree.id])
   const conflictOperation = useAppStore((s) => s.gitConflictOperationByWorktree[worktree.id])
@@ -288,16 +305,27 @@ const WorktreeCard = React.memo(function WorktreeCard({
   const showPR = cardProps.includes('pr')
   const showCI = cardProps.includes('ci')
   const showIssue = cardProps.includes('issue')
+  const previousPrLookupRef = useRef<{ cacheKey: string; linkedPRNumber: number | null } | null>(
+    null
+  )
 
   // Skip GitHub fetches when the corresponding card sections are hidden.
   // This preference is purely presentational, so background refreshes would
   // spend rate limit budget on data the user cannot see.
   useEffect(() => {
     if (repo && !isFolder && !worktree.isBare && prCacheKey && (showPR || showCI)) {
+      const linkedPRNumber = worktree.linkedPR ?? null
+      const previousLookup = previousPrLookupRef.current
+      const linkedPRChanged =
+        previousLookup !== null &&
+        previousLookup.cacheKey === prCacheKey &&
+        previousLookup.linkedPRNumber !== linkedPRNumber
+      previousPrLookupRef.current = { cacheKey: prCacheKey, linkedPRNumber }
       // Why: pass linkedPR so worktrees created from a PR (whose new local
       // branch differs from the PR's head ref) still resolve their PR via
-      // a number-based fallback in the main process.
-      fetchPRForBranch(repo.path, branch, { linkedPRNumber: worktree.linkedPR ?? null })
+      // a number-based fallback in the main process. Force when that fallback
+      // changes so the branch cache stops showing stale linked-PR data.
+      fetchPRForBranch(repo.path, branch, { linkedPRNumber, force: linkedPRChanged })
     }
   }, [
     repo,
@@ -371,9 +399,17 @@ const WorktreeCard = React.memo(function WorktreeCard({
       worktreeId: worktree.id,
       currentDisplayName: worktree.displayName,
       currentIssue: worktree.linkedIssue,
+      currentPR: worktree.linkedPR,
       currentComment: worktree.comment
     })
-  }, [worktree.id, worktree.displayName, worktree.linkedIssue, worktree.comment, openModal])
+  }, [
+    worktree.id,
+    worktree.displayName,
+    worktree.linkedIssue,
+    worktree.linkedPR,
+    worktree.comment,
+    openModal
+  ])
 
   const handleToggleUnreadQuick = useCallback(
     (event: React.MouseEvent<HTMLButtonElement>) => {
@@ -617,7 +653,12 @@ const WorktreeCard = React.memo(function WorktreeCard({
               <IssueSection issue={issueDisplay} onClick={handleEditIssue} />
             )}
             {cardProps.includes('pr') && prDisplay && (
-              <PrSection pr={prDisplay} onClick={handleEditIssue} />
+              <PrSection
+                pr={prDisplay}
+                onClick={handleEditIssue}
+                onEdit={handleEditPr}
+                onRemove={handleRemovePr}
+              />
             )}
             {cardProps.includes('comment') && worktree.comment && (
               <CommentSection comment={worktree.comment} onDoubleClick={handleEditComment} />

--- a/src/renderer/src/components/sidebar/WorktreeCardMeta.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardMeta.tsx
@@ -6,11 +6,21 @@
  */
 import React from 'react'
 import { Badge } from '@/components/ui/badge'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
 import { HoverCard, HoverCardTrigger, HoverCardContent } from '@/components/ui/hover-card'
-import { CircleDot } from 'lucide-react'
+import { CircleDot, Pencil, Unlink } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import CommentMarkdown from './CommentMarkdown'
 import { PullRequestIcon, prStateLabel, checksLabel } from './WorktreeCardHelpers'
+import {
+  CLOSE_ALL_CONTEXT_MENUS_EVENT,
+  WORKTREE_CONTEXT_MENU_SCOPE_ATTR
+} from './WorktreeContextMenu'
 import type { WorktreeCardPrDisplay } from './worktree-card-pr-display'
 import type { IssueInfo } from '../../../../shared/types'
 
@@ -85,70 +95,112 @@ export function IssueSection({ issue, onClick }: IssueSectionProps): React.JSX.E
 type PrSectionProps = {
   pr: WorktreeCardPrDisplay
   onClick: (e: React.MouseEvent) => void
+  onEdit: () => void
+  onRemove: () => void
 }
 
-export function PrSection({ pr, onClick: _onClick }: PrSectionProps): React.JSX.Element {
+export function PrSection({
+  pr,
+  onClick: _onClick,
+  onEdit,
+  onRemove
+}: PrSectionProps): React.JSX.Element {
+  const [menuOpen, setMenuOpen] = React.useState(false)
+  const [menuPoint, setMenuPoint] = React.useState({ x: 0, y: 0 })
   const state = pr.state
   const checksStatus = pr.checksStatus
   const hasChecks = checksStatus && checksStatus !== 'neutral'
   return (
-    <HoverCard openDelay={300}>
-      <HoverCardTrigger asChild>
-        <a
-          href={pr.url}
-          target="_blank"
-          rel="noreferrer"
-          className="flex items-center gap-1.5 min-w-0 cursor-pointer group/meta -mx-1.5 px-1.5 py-0.5 rounded transition-colors hover:bg-background/40"
-          onClick={(e) => {
-            if (pr.url) {
-              e.stopPropagation()
-            }
-          }}
-        >
-          <PullRequestIcon
-            className={cn(
-              'size-3 shrink-0',
-              state === 'merged' && 'text-purple-600/70 dark:text-purple-400/70',
-              state === 'open' && 'text-emerald-500/80',
-              state === 'closed' && 'text-muted-foreground/60',
-              state === 'draft' && 'text-muted-foreground/50',
-              (!state || !['merged', 'open', 'closed', 'draft'].includes(state)) &&
-                'text-muted-foreground opacity-60'
-            )}
-          />
-          <div className="flex-1 min-w-0 flex items-center gap-1.5 text-[11.5px] leading-none">
-            <span className="text-foreground opacity-80 shrink-0 group-hover/meta:underline">
-              PR #{pr.number}
-            </span>
-            <span className="text-muted-foreground truncate group-hover/meta:text-foreground transition-colors">
-              {pr.title}
-            </span>
-          </div>
-        </a>
-      </HoverCardTrigger>
-      <HoverCardContent side="right" align="start" className="w-72 p-3 text-xs space-y-1.5">
-        <div className="font-semibold text-[13px]">
-          #{pr.number} {pr.title}
-        </div>
-        {state && (
-          <div className="flex items-center gap-2 text-muted-foreground">
-            <span>State: {prStateLabel(state)}</span>
-            {hasChecks && <span>Checks: {checksLabel(checksStatus)}</span>}
-          </div>
-        )}
-        {pr.url && (
+    <div
+      className="relative"
+      {...{ [WORKTREE_CONTEXT_MENU_SCOPE_ATTR]: 'pr' }}
+      onContextMenuCapture={(event) => {
+        event.preventDefault()
+        event.stopPropagation()
+        window.dispatchEvent(new Event(CLOSE_ALL_CONTEXT_MENUS_EVENT))
+        const bounds = event.currentTarget.getBoundingClientRect()
+        setMenuPoint({ x: event.clientX - bounds.left, y: event.clientY - bounds.top })
+        setMenuOpen(true)
+      }}
+    >
+      <HoverCard openDelay={300}>
+        <HoverCardTrigger asChild>
           <a
             href={pr.url}
             target="_blank"
             rel="noreferrer"
-            className="text-muted-foreground underline underline-offset-2 hover:text-foreground"
-            onClick={(e) => e.stopPropagation()}
+            className="flex items-center gap-1.5 min-w-0 cursor-pointer group/meta -mx-1.5 px-1.5 py-0.5 rounded transition-colors hover:bg-background/40"
+            onClick={(e) => {
+              if (pr.url) {
+                e.stopPropagation()
+              }
+            }}
           >
-            View on GitHub
+            <PullRequestIcon
+              className={cn(
+                'size-3 shrink-0',
+                state === 'merged' && 'text-purple-600/70 dark:text-purple-400/70',
+                state === 'open' && 'text-emerald-500/80',
+                state === 'closed' && 'text-muted-foreground/60',
+                state === 'draft' && 'text-muted-foreground/50',
+                (!state || !['merged', 'open', 'closed', 'draft'].includes(state)) &&
+                  'text-muted-foreground opacity-60'
+              )}
+            />
+            <div className="flex-1 min-w-0 flex items-center gap-1.5 text-[11.5px] leading-none">
+              <span className="text-foreground opacity-80 shrink-0 group-hover/meta:underline">
+                PR #{pr.number}
+              </span>
+              <span className="text-muted-foreground truncate group-hover/meta:text-foreground transition-colors">
+                {pr.title}
+              </span>
+            </div>
           </a>
-        )}
-      </HoverCardContent>
-    </HoverCard>
+        </HoverCardTrigger>
+        <HoverCardContent side="right" align="start" className="w-72 p-3 text-xs space-y-1.5">
+          <div className="font-semibold text-[13px]">
+            #{pr.number} {pr.title}
+          </div>
+          {state && (
+            <div className="flex items-center gap-2 text-muted-foreground">
+              <span>State: {prStateLabel(state)}</span>
+              {hasChecks && <span>Checks: {checksLabel(checksStatus)}</span>}
+            </div>
+          )}
+          {pr.url && (
+            <a
+              href={pr.url}
+              target="_blank"
+              rel="noreferrer"
+              className="text-muted-foreground underline underline-offset-2 hover:text-foreground"
+              onClick={(e) => e.stopPropagation()}
+            >
+              View on GitHub
+            </a>
+          )}
+        </HoverCardContent>
+      </HoverCard>
+      <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen} modal={false}>
+        <DropdownMenuTrigger asChild>
+          <button
+            aria-hidden
+            tabIndex={-1}
+            className="pointer-events-none absolute size-px opacity-0"
+            style={{ left: menuPoint.x, top: menuPoint.y }}
+          />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent className="w-44" sideOffset={0} align="start">
+          <DropdownMenuItem onSelect={onEdit}>
+            <Pencil className="size-3.5" />
+            Update GH PR
+          </DropdownMenuItem>
+          <DropdownMenuItem variant="destructive" onSelect={onRemove}>
+            <Unlink className="size-3.5" />
+            Remove GH PR
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
   )
 }
 

--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
@@ -37,6 +37,7 @@ type Props = {
 }
 
 const CLOSE_ALL_CONTEXT_MENUS_EVENT = 'orca-close-all-context-menus'
+const WORKTREE_CONTEXT_MENU_SCOPE_ATTR = 'data-worktree-context-menu-scope'
 
 const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
   worktree,
@@ -119,30 +120,54 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
       worktreeId: worktree.id,
       currentDisplayName: worktree.displayName,
       currentIssue: worktree.linkedIssue,
+      currentPR: worktree.linkedPR,
       currentComment: worktree.comment,
       focus: 'displayName'
     })
-  }, [worktree.id, worktree.displayName, worktree.linkedIssue, worktree.comment, openModal])
+  }, [
+    worktree.id,
+    worktree.displayName,
+    worktree.linkedIssue,
+    worktree.linkedPR,
+    worktree.comment,
+    openModal
+  ])
 
   const handleLinkIssue = useCallback(() => {
     openModal('edit-meta', {
       worktreeId: worktree.id,
       currentDisplayName: worktree.displayName,
       currentIssue: worktree.linkedIssue,
+      currentPR: worktree.linkedPR,
       currentComment: worktree.comment,
       focus: 'issue'
     })
-  }, [worktree.id, worktree.displayName, worktree.linkedIssue, worktree.comment, openModal])
+  }, [
+    worktree.id,
+    worktree.displayName,
+    worktree.linkedIssue,
+    worktree.linkedPR,
+    worktree.comment,
+    openModal
+  ])
 
   const handleComment = useCallback(() => {
     openModal('edit-meta', {
       worktreeId: worktree.id,
       currentDisplayName: worktree.displayName,
       currentIssue: worktree.linkedIssue,
+      currentPR: worktree.linkedPR,
       currentComment: worktree.comment,
       focus: 'comment'
     })
-  }, [worktree.id, worktree.displayName, worktree.linkedIssue, worktree.comment, openModal])
+  }, [
+    worktree.id,
+    worktree.displayName,
+    worktree.linkedIssue,
+    worktree.linkedPR,
+    worktree.comment,
+    openModal
+  ])
 
   const handleCloseTerminals = useCallback(async () => {
     await runSleepWorktrees(sleepableWorktrees.map((item) => item.id))
@@ -186,6 +211,13 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
       <div
         className="relative"
         onContextMenuCapture={(event) => {
+          const target = event.target
+          if (
+            target instanceof Element &&
+            target.closest(`[${WORKTREE_CONTEXT_MENU_SCOPE_ATTR}]`)
+          ) {
+            return
+          }
           event.preventDefault()
           window.dispatchEvent(new Event(CLOSE_ALL_CONTEXT_MENUS_EVENT))
           setContextWorktrees(onContextMenuSelect?.(event) ?? selectedWorktrees)
@@ -295,3 +327,4 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
 })
 
 export default WorktreeContextMenu
+export { CLOSE_ALL_CONTEXT_MENUS_EVENT, WORKTREE_CONTEXT_MENU_SCOPE_ATTR }

--- a/src/renderer/src/components/sidebar/WorktreeMetaDialog.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeMetaDialog.tsx
@@ -27,23 +27,27 @@ const WorktreeMetaDialog = React.memo(function WorktreeMetaDialog() {
     typeof modalData.currentDisplayName === 'string' ? modalData.currentDisplayName : ''
   const currentIssue =
     typeof modalData.currentIssue === 'number' ? String(modalData.currentIssue) : ''
+  const currentPR = typeof modalData.currentPR === 'number' ? String(modalData.currentPR) : ''
   const currentComment =
     typeof modalData.currentComment === 'string' ? modalData.currentComment : ''
   const focusField = typeof modalData.focus === 'string' ? modalData.focus : 'comment'
 
   const [displayNameInput, setDisplayNameInput] = useState('')
   const [issueInput, setIssueInput] = useState('')
+  const [prInput, setPrInput] = useState('')
   const [commentInput, setCommentInput] = useState('')
   const [saving, setSaving] = useState(false)
   const isMac = navigator.userAgent.includes('Mac')
 
   const issueInputRef = useRef<HTMLInputElement>(null)
+  const prInputRef = useRef<HTMLInputElement>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const prevIsOpenRef = useRef(false)
   const displayNameInputRef = useRef<HTMLInputElement>(null)
   if (isOpen && !prevIsOpenRef.current) {
     setDisplayNameInput(currentDisplayName)
     setIssueInput(currentIssue)
+    setPrInput(currentPR)
     setCommentInput(currentComment)
   }
   prevIsOpenRef.current = isOpen
@@ -67,8 +71,12 @@ const WorktreeMetaDialog = React.memo(function WorktreeMetaDialog() {
     if (!worktreeId) {
       return false
     }
-    return issueInput.trim() === '' || parseGitHubIssueOrPRNumber(issueInput) !== null
-  }, [worktreeId, issueInput])
+    const trimmedIssue = issueInput.trim()
+    const trimmedPR = prInput.trim()
+    const issueValid = trimmedIssue === '' || parseGitHubIssueOrPRNumber(trimmedIssue) !== null
+    const prValid = trimmedPR === '' || parseGitHubIssueOrPRNumber(trimmedPR) !== null
+    return issueValid && prValid
+  }, [worktreeId, issueInput, prInput])
 
   const handleOpenChange = useCallback(
     (open: boolean) => {
@@ -80,7 +88,7 @@ const WorktreeMetaDialog = React.memo(function WorktreeMetaDialog() {
   )
 
   const handleSave = useCallback(async () => {
-    if (!worktreeId) {
+    if (!canSave) {
       return
     }
     setSaving(true)
@@ -89,6 +97,10 @@ const WorktreeMetaDialog = React.memo(function WorktreeMetaDialog() {
       const linkedIssueNumber = parseGitHubIssueOrPRNumber(trimmedIssue)
       const finalLinkedIssue =
         trimmedIssue === '' ? null : linkedIssueNumber !== null ? linkedIssueNumber : undefined
+      const trimmedPR = prInput.trim()
+      const linkedPRNumber = parseGitHubIssueOrPRNumber(trimmedPR)
+      const finalLinkedPR =
+        trimmedPR === '' ? null : linkedPRNumber !== null ? linkedPRNumber : undefined
 
       const trimmedDisplayName = displayNameInput.trim()
       const updates: Partial<WorktreeMeta> = {
@@ -100,6 +112,9 @@ const WorktreeMetaDialog = React.memo(function WorktreeMetaDialog() {
       if (finalLinkedIssue !== undefined) {
         updates.linkedIssue = finalLinkedIssue
       }
+      if (finalLinkedPR !== undefined) {
+        updates.linkedPR = finalLinkedPR
+      }
 
       await updateWorktreeMeta(worktreeId, updates)
       closeModal()
@@ -108,9 +123,11 @@ const WorktreeMetaDialog = React.memo(function WorktreeMetaDialog() {
     }
   }, [
     worktreeId,
+    canSave,
     displayNameInput,
     currentDisplayName,
     issueInput,
+    prInput,
     commentInput,
     updateWorktreeMeta,
     closeModal
@@ -147,6 +164,8 @@ const WorktreeMetaDialog = React.memo(function WorktreeMetaDialog() {
             displayNameInputRef.current?.focus()
           } else if (focusField === 'issue') {
             issueInputRef.current?.focus()
+          } else if (focusField === 'pr') {
+            prInputRef.current?.focus()
           } else {
             textareaRef.current?.focus()
           }
@@ -155,7 +174,7 @@ const WorktreeMetaDialog = React.memo(function WorktreeMetaDialog() {
         <DialogHeader>
           <DialogTitle className="text-sm">Edit Worktree Details</DialogTitle>
           <DialogDescription className="text-xs">
-            Edit the GitHub issue link and notes for this worktree.
+            Edit GitHub links and notes for this worktree.
           </DialogDescription>
         </DialogHeader>
 
@@ -188,6 +207,21 @@ const WorktreeMetaDialog = React.memo(function WorktreeMetaDialog() {
             />
             <p className="text-[10px] text-muted-foreground">
               Paste an issue URL, or enter a number. Leave blank to remove the link.
+            </p>
+          </div>
+
+          <div className="space-y-1">
+            <label className="text-[11px] font-medium text-muted-foreground">GH PR</label>
+            <Input
+              ref={prInputRef}
+              value={prInput}
+              onChange={(e) => setPrInput(e.target.value)}
+              onKeyDown={handleIssueKeyDown}
+              placeholder="PR # or GitHub URL"
+              className="h-8 text-xs"
+            />
+            <p className="text-[10px] text-muted-foreground">
+              Paste a pull request URL, or enter a number. Leave blank to remove the link.
             </p>
           </div>
 


### PR DESCRIPTION
## Summary
- add GH PR editing/removal to the worktree metadata dialog and card context menu
- pass existing linked PR metadata into edit flows
- force-refresh PR lookup when linked PR metadata changes to avoid stale card display

## Validation
- pnpm typecheck