### PR TITLE
perf(renderer): gate mobile pairing polling

### DIFF
--- a/src/renderer/src/components/settings/MobilePane.tsx
+++ b/src/renderer/src/components/settings/MobilePane.tsx
@@ -16,6 +16,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from '../ui/dialog'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
 import type { SettingsSearchEntry } from './settings-search'
 import { useAppStore } from '../../store'
+import { useMobilePairingDevicePolling } from './mobile-pairing-device-polling'
 
 // Why: the section heading "When you leave the mobile app" carries the
 // "what happens" framing so the option labels only need to vary on the
@@ -177,13 +178,11 @@ export function MobilePane(): React.JSX.Element {
     setDeviceCountAtQr(devices.length)
   }, [qrDataUrl]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  useEffect(() => {
-    if (deviceCountAtQr === null || devices.length > deviceCountAtQr) {
-      return
-    }
-    const interval = setInterval(() => void loadDevices(), 3000)
-    return () => clearInterval(interval)
-  }, [deviceCountAtQr, devices.length, loadDevices])
+  useMobilePairingDevicePolling({
+    deviceCountAtQr,
+    currentDeviceCount: devices.length,
+    loadDevices
+  })
 
   async function copyPairingCode() {
     if (!pairingUrl) {

--- a/src/renderer/src/components/settings/mobile-pairing-device-polling.test.ts
+++ b/src/renderer/src/components/settings/mobile-pairing-device-polling.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { shouldPollMobilePairingDevices } from './mobile-pairing-device-polling'
+
+describe('mobile pairing device polling', () => {
+  it('polls only while waiting for a new device in the visible focused window', () => {
+    expect(
+      shouldPollMobilePairingDevices({
+        deviceCountAtQr: 1,
+        currentDeviceCount: 1,
+        visibilityState: 'visible',
+        focused: true
+      })
+    ).toBe(true)
+
+    expect(
+      shouldPollMobilePairingDevices({
+        deviceCountAtQr: 1,
+        currentDeviceCount: 2,
+        visibilityState: 'visible',
+        focused: true
+      })
+    ).toBe(false)
+
+    expect(
+      shouldPollMobilePairingDevices({
+        deviceCountAtQr: 1,
+        currentDeviceCount: 1,
+        visibilityState: 'hidden',
+        focused: true
+      })
+    ).toBe(false)
+
+    expect(
+      shouldPollMobilePairingDevices({
+        deviceCountAtQr: 1,
+        currentDeviceCount: 1,
+        visibilityState: 'visible',
+        focused: false
+      })
+    ).toBe(false)
+  })
+})

--- a/src/renderer/src/components/settings/mobile-pairing-device-polling.ts
+++ b/src/renderer/src/components/settings/mobile-pairing-device-polling.ts
@@ -1,0 +1,108 @@
+import { useEffect } from 'react'
+
+export const MOBILE_PAIRING_DEVICE_POLL_MS = 3000
+
+export type MobilePairingDevicePollState = {
+  deviceCountAtQr: number | null
+  currentDeviceCount: number
+  visibilityState: Document['visibilityState']
+  focused: boolean
+}
+
+export function shouldPollMobilePairingDevices({
+  deviceCountAtQr,
+  currentDeviceCount,
+  visibilityState,
+  focused
+}: MobilePairingDevicePollState): boolean {
+  return (
+    deviceCountAtQr !== null &&
+    currentDeviceCount <= deviceCountAtQr &&
+    visibilityState === 'visible' &&
+    focused
+  )
+}
+
+export function useMobilePairingDevicePolling({
+  deviceCountAtQr,
+  currentDeviceCount,
+  loadDevices
+}: {
+  deviceCountAtQr: number | null
+  currentDeviceCount: number
+  loadDevices: () => Promise<void>
+}): void {
+  useEffect(() => {
+    if (deviceCountAtQr === null || currentDeviceCount > deviceCountAtQr) {
+      return
+    }
+
+    let stopped = false
+    let pollInFlight = false
+    let timeoutId: number | null = null
+
+    const clearPendingPoll = (): void => {
+      if (timeoutId !== null) {
+        window.clearTimeout(timeoutId)
+        timeoutId = null
+      }
+    }
+
+    const canPoll = (): boolean =>
+      shouldPollMobilePairingDevices({
+        deviceCountAtQr,
+        currentDeviceCount,
+        visibilityState: document.visibilityState,
+        focused: document.hasFocus()
+      })
+
+    const scheduleNextPoll = (): void => {
+      clearPendingPoll()
+      if (stopped || !canPoll()) {
+        return
+      }
+      timeoutId = window.setTimeout(() => {
+        timeoutId = null
+        if (stopped || !canPoll()) {
+          return
+        }
+        if (pollInFlight) {
+          scheduleNextPoll()
+          return
+        }
+        pollInFlight = true
+        // Why: wait for each IPC call to settle before scheduling the next
+        // poll, avoiding overlapping device-list requests on a slow host.
+        void loadDevices().finally(() => {
+          pollInFlight = false
+          scheduleNextPoll()
+        })
+      }, MOBILE_PAIRING_DEVICE_POLL_MS)
+    }
+
+    const resumePolling = (): void => {
+      if (!canPoll()) {
+        clearPendingPoll()
+        return
+      }
+      if (pollInFlight) {
+        return
+      }
+      pollInFlight = true
+      void loadDevices().finally(() => {
+        pollInFlight = false
+        scheduleNextPoll()
+      })
+    }
+
+    scheduleNextPoll()
+    window.addEventListener('focus', resumePolling)
+    document.addEventListener('visibilitychange', resumePolling)
+    return () => {
+      stopped = true
+      clearPendingPoll()
+      window.removeEventListener('focus', resumePolling)
+      document.removeEventListener('visibilitychange', resumePolling)
+    }
+  }, [deviceCountAtQr, currentDeviceCount, loadDevices])
+}


### PR DESCRIPTION
Category: Polling

Symptom: After generating a mobile pairing QR code, the settings pane polled `mobile.listDevices()` every 3 seconds until a new device appeared. If the phone never connected, the loop kept running while Orca was hidden or unfocused.

Wasted resource: Repeated renderer timers and mobile device-list IPC work for invisible UI, with no liveness gating and no protection against overlapping slow polls.

Measurement: Added a focused unit test for the polling gate so hidden/unfocused windows and completed pairing do not qualify for polling. This catches the bug as a count/eligibility regression: hidden or unfocused pairing state now returns `false` instead of allowing the 3s device-list loop.

Fix: Moved pairing polling into `mobile-pairing-device-polling.ts`, replaced the fixed `setInterval` with a one-shot timeout loop, gated polling by `document.visibilityState === 'visible'` and `document.hasFocus()`, resumed immediately on focus/visibility, and waited for each `loadDevices()` IPC call to settle before scheduling the next poll.

Verification:
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/settings/mobile-pairing-device-polling.test.ts`
- `pnpm run tc:web`
- `pnpm exec oxlint src/renderer/src/components/settings/MobilePane.tsx src/renderer/src/components/settings/mobile-pairing-device-polling.ts src/renderer/src/components/settings/mobile-pairing-device-polling.test.ts`

Scanned: production `setInterval`/polling sites in main, renderer, and mobile. Nearby git/GitHub/status polling already had focus/visibility gates or explicit liveness comments; this mobile QR loop was the narrow safe fix.
