### PR TITLE
perf(renderer): remove agent command draft reset effect

### DIFF
--- a/src/renderer/src/components/settings/AgentsPane.tsx
+++ b/src/renderer/src/components/settings/AgentsPane.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 import { Check, ChevronDown, ExternalLink, RefreshCw, Terminal } from 'lucide-react'
 import type { GlobalSettings, TuiAgent } from '../../../../shared/types'
 import { AGENT_CATALOG, AgentIcon } from '@/lib/agent-catalog'
@@ -26,6 +26,69 @@ type AgentRowProps = {
   onSaveOverride: (value: string) => void
 }
 
+type AgentCommandOverrideInputProps = {
+  defaultCmd: string
+  cmdOverride: string | undefined
+  onSaveOverride: (value: string) => void
+}
+
+function AgentCommandOverrideInput({
+  defaultCmd,
+  cmdOverride,
+  onSaveOverride
+}: AgentCommandOverrideInputProps): React.JSX.Element {
+  const draftSeed = cmdOverride ?? defaultCmd
+  const [cmdDraft, setCmdDraft] = useState(draftSeed)
+
+  const commitCmd = (): void => {
+    const trimmed = cmdDraft.trim()
+    if (!trimmed || trimmed === defaultCmd) {
+      onSaveOverride('')
+      setCmdDraft(defaultCmd)
+    } else {
+      onSaveOverride(trimmed)
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <span className="shrink-0 text-xs text-muted-foreground">Command</span>
+      <Input
+        value={cmdDraft}
+        onChange={(e) => setCmdDraft(e.target.value)}
+        onBlur={commitCmd}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            commitCmd()
+            e.currentTarget.blur()
+          }
+          if (e.key === 'Escape') {
+            setCmdDraft(draftSeed)
+            e.currentTarget.blur()
+          }
+        }}
+        placeholder={defaultCmd}
+        spellCheck={false}
+        className="h-7 flex-1 font-mono text-xs"
+      />
+      {cmdOverride && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="xs"
+          onClick={() => {
+            onSaveOverride('')
+            setCmdDraft(defaultCmd)
+          }}
+          className="h-7 shrink-0 text-xs text-muted-foreground hover:text-foreground"
+        >
+          Reset
+        </Button>
+      )}
+    </div>
+  )
+}
+
 function AgentRow({
   agentId,
   label,
@@ -38,21 +101,6 @@ function AgentRow({
   onSaveOverride
 }: AgentRowProps): React.JSX.Element {
   const [cmdOpen, setCmdOpen] = useState(Boolean(cmdOverride))
-  const [cmdDraft, setCmdDraft] = useState(cmdOverride ?? defaultCmd)
-
-  useEffect(() => {
-    setCmdDraft(cmdOverride ?? defaultCmd)
-  }, [cmdOverride, defaultCmd])
-
-  const commitCmd = (): void => {
-    const trimmed = cmdDraft.trim()
-    if (!trimmed || trimmed === defaultCmd) {
-      onSaveOverride('')
-      setCmdDraft(defaultCmd)
-    } else {
-      onSaveOverride(trimmed)
-    }
-  }
 
   return (
     <div
@@ -160,41 +208,13 @@ function AgentRow({
       {/* Command override row */}
       {isDetected && cmdOpen && (
         <div className="border-t border-border/40 px-4 py-3">
-          <div className="flex items-center gap-2">
-            <span className="shrink-0 text-xs text-muted-foreground">Command</span>
-            <Input
-              value={cmdDraft}
-              onChange={(e) => setCmdDraft(e.target.value)}
-              onBlur={commitCmd}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') {
-                  commitCmd()
-                  e.currentTarget.blur()
-                }
-                if (e.key === 'Escape') {
-                  setCmdDraft(cmdOverride ?? defaultCmd)
-                  e.currentTarget.blur()
-                }
-              }}
-              placeholder={defaultCmd}
-              spellCheck={false}
-              className="h-7 flex-1 font-mono text-xs"
-            />
-            {cmdOverride && (
-              <Button
-                type="button"
-                variant="ghost"
-                size="xs"
-                onClick={() => {
-                  onSaveOverride('')
-                  setCmdDraft(defaultCmd)
-                }}
-                className="h-7 shrink-0 text-xs text-muted-foreground hover:text-foreground"
-              >
-                Reset
-              </Button>
-            )}
-          </div>
+          {/* Why: key by the persisted seed so settings changes reset the draft during reconciliation, not in a follow-up effect commit. */}
+          <AgentCommandOverrideInput
+            key={cmdOverride ?? defaultCmd}
+            defaultCmd={defaultCmd}
+            cmdOverride={cmdOverride}
+            onSaveOverride={onSaveOverride}
+          />
           <p className="mt-1.5 text-[11px] text-muted-foreground">
             Override the binary path or name used to launch this agent.
           </p>


### PR DESCRIPTION
Category: React effects

Symptom: The agent command override row mirrored `cmdOverride ?? defaultCmd` into local draft state with `useEffect`. Saving or resetting an override could commit the settings update, render once with the stale draft, then run the effect and commit again with the corrected draft.

Wasted resource: Extra React render/commit work in Settings > Agents for each command seed change, plus a stale intermediate input value.

Measurement: Static scan for renderer `.tsx` effects that only call `setState` for derived/reset state found `AgentsPane.tsx` as a narrow case. After the change, `rg "useEffect" src/renderer/src/components/settings/AgentsPane.tsx` has no matches and the branch diff is limited to `AgentsPane.tsx`.

Fix: Move command draft state into a keyed `AgentCommandOverrideInput`. The key is the persisted command seed, so React resets the draft during reconciliation when the setting changes instead of doing a follow-up effect commit.

Verification:
- `pnpm exec oxlint src/renderer/src/components/settings/AgentsPane.tsx`
- `pnpm exec oxfmt --check src/renderer/src/components/settings/AgentsPane.tsx`
- `git diff --check -- src/renderer/src/components/settings/AgentsPane.tsx`

Note: `pnpm exec tsgo --noEmit -p config/tsconfig.tc.web.json --pretty false` is currently blocked by existing errors in `src/renderer/src/components/editor/editor-autosave-controller.ts` around nullable `settings` / missing `GlobalSettings` properties, outside this change.