### PR TITLE
perf(fs): avoid probing WSL root files

### DIFF
--- a/src/main/ipc/filesystem-watcher-wsl.test.ts
+++ b/src/main/ipc/filesystem-watcher-wsl.test.ts
@@ -1,3 +1,4 @@
+import * as path from 'path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { readdirMock } = vi.hoisted(() => ({
@@ -33,8 +34,8 @@ describe('createWslWatcher', () => {
   }
 
   function releasePollWith(
-    releasePoll: ((entries: string[]) => void) | null,
-    entries: string[]
+    releasePoll: ((entries: ReturnType<typeof dirent>[]) => void) | null,
+    entries: ReturnType<typeof dirent>[]
   ): void {
     if (!releasePoll) {
       throw new Error('expected an in-flight poll')
@@ -42,10 +43,18 @@ describe('createWslWatcher', () => {
     releasePoll(entries)
   }
 
+  function dirent(name: string, type: 'dir' | 'file' | 'symlink' = 'file') {
+    return {
+      name,
+      isDirectory: () => type === 'dir',
+      isSymbolicLink: () => type === 'symlink'
+    }
+  }
+
   it('does not overlap polling when a WSL snapshot scan is still in flight', async () => {
     const scheduleBatchFlush = vi.fn()
     let rootReads = 0
-    let releasePoll: ((entries: string[]) => void) | null = null
+    let releasePoll: ((entries: ReturnType<typeof dirent>[]) => void) | null = null
 
     readdirMock.mockImplementation((dirPath: string) => {
       if (dirPath !== rootPath) {
@@ -53,14 +62,14 @@ describe('createWslWatcher', () => {
       }
       rootReads += 1
       if (rootReads === 1) {
-        return Promise.resolve(['src'])
+        return Promise.resolve([dirent('src', 'dir')])
       }
       if (rootReads === 2) {
-        return new Promise<string[]>((resolve) => {
+        return new Promise<ReturnType<typeof dirent>[]>((resolve) => {
           releasePoll = resolve
         })
       }
-      return Promise.resolve(['src'])
+      return Promise.resolve([dirent('src', 'dir')])
     })
 
     const root = await createWslWatcher(rootKey, rootPath, deps(scheduleBatchFlush))
@@ -71,7 +80,7 @@ describe('createWslWatcher', () => {
     await vi.advanceTimersByTimeAsync(4_000)
     expect(rootReads).toBe(2)
 
-    releasePollWith(releasePoll, ['src', 'new-file.ts'])
+    releasePollWith(releasePoll, [dirent('src', 'dir'), dirent('new-file.ts')])
     await vi.advanceTimersByTimeAsync(0)
 
     expect(scheduleBatchFlush).toHaveBeenCalledOnce()
@@ -81,7 +90,7 @@ describe('createWslWatcher', () => {
   it('does not flush a poll that completes after unsubscribe', async () => {
     const scheduleBatchFlush = vi.fn()
     let rootReads = 0
-    let releasePoll: ((entries: string[]) => void) | null = null
+    let releasePoll: ((entries: ReturnType<typeof dirent>[]) => void) | null = null
 
     readdirMock.mockImplementation((dirPath: string) => {
       if (dirPath !== rootPath) {
@@ -89,9 +98,9 @@ describe('createWslWatcher', () => {
       }
       rootReads += 1
       if (rootReads === 1) {
-        return Promise.resolve(['src'])
+        return Promise.resolve([dirent('src', 'dir')])
       }
-      return new Promise<string[]>((resolve) => {
+      return new Promise<ReturnType<typeof dirent>[]>((resolve) => {
         releasePoll = resolve
       })
     })
@@ -100,9 +109,37 @@ describe('createWslWatcher', () => {
     await vi.advanceTimersByTimeAsync(2_000)
     await root.subscription.unsubscribe()
 
-    releasePollWith(releasePoll, ['src', 'late-file.ts'])
+    releasePollWith(releasePoll, [dirent('src', 'dir'), dirent('late-file.ts')])
     await vi.advanceTimersByTimeAsync(0)
 
     expect(scheduleBatchFlush).not.toHaveBeenCalled()
+  })
+
+  it('does not probe root-level files during WSL snapshots', async () => {
+    const scheduleBatchFlush = vi.fn()
+
+    readdirMock.mockImplementation((dirPath: string) => {
+      if (dirPath === rootPath) {
+        return Promise.resolve([
+          dirent('src', 'dir'),
+          dirent('README.md'),
+          dirent('package.json'),
+          dirent('linked-dir', 'symlink')
+        ])
+      }
+      return Promise.resolve([])
+    })
+
+    const root = await createWslWatcher(rootKey, rootPath, deps(scheduleBatchFlush))
+
+    const readPaths = readdirMock.mock.calls.map(([dirPath]) => dirPath)
+    expect(readPaths).toEqual([
+      rootPath,
+      path.join(rootPath, 'src'),
+      path.join(rootPath, 'linked-dir')
+    ])
+    expect(readPaths).not.toContain(path.join(rootPath, 'README.md'))
+    expect(readPaths).not.toContain(path.join(rootPath, 'package.json'))
+    await root.subscription.unsubscribe()
   })
 })

--- a/src/main/ipc/filesystem-watcher-wsl.ts
+++ b/src/main/ipc/filesystem-watcher-wsl.ts
@@ -9,6 +9,7 @@
  * balance between responsiveness and CPU cost — nobody stares at the file
  * explorer waiting for instant refresh.
  */
+import type { Dirent } from 'fs'
 import { readdir } from 'fs/promises'
 import * as path from 'path'
 import type { WebContents } from 'electron'
@@ -40,9 +41,9 @@ const POLL_INTERVAL_MS = 2000
 
 type DirSnapshot = Map<string, Set<string>>
 
-async function readDirSafe(dirPath: string): Promise<string[]> {
+async function readDirEntriesSafe(dirPath: string): Promise<Dirent[]> {
   try {
-    const entries = await readdir(dirPath)
+    const entries = await readdir(dirPath, { withFileTypes: true })
     return entries
   } catch {
     return []
@@ -60,25 +61,24 @@ function shouldIgnore(name: string, ignoreDirs: string[]): boolean {
 async function takeSnapshot(rootPath: string, ignoreDirs: string[]): Promise<DirSnapshot> {
   const snapshot: DirSnapshot = new Map()
 
-  const rootEntries = await readDirSafe(rootPath)
-  const filtered = rootEntries.filter((name) => !shouldIgnore(name, ignoreDirs))
-  snapshot.set(rootPath, new Set(filtered))
+  const rootEntries = await readDirEntriesSafe(rootPath)
+  const filtered = rootEntries.filter((entry) => !shouldIgnore(entry.name, ignoreDirs))
+  snapshot.set(rootPath, new Set(filtered.map((entry) => entry.name)))
 
   // Why: poll one level of subdirectories so changes inside immediate
-  // children are detected (e.g. editing src/foo.ts).  Going deeper
-  // would be too expensive for large repos.  The renderer requests
-  // deeper directories explicitly via readDir when the user expands.
+  // children are detected, but use Dirent metadata to avoid probing every
+  // root-level file with a failing readdir on each WSL poll.
   await Promise.all(
-    filtered.map(async (name) => {
-      const childPath = path.join(rootPath, name)
-      try {
-        const childEntries = await readDirSafe(childPath)
-        const childFiltered = childEntries.filter((n) => !shouldIgnore(n, ignoreDirs))
+    filtered
+      .filter((entry) => entry.isDirectory() || entry.isSymbolicLink())
+      .map(async (entry) => {
+        const childPath = path.join(rootPath, entry.name)
+        const childEntries = await readDirEntriesSafe(childPath)
+        const childFiltered = childEntries
+          .filter((childEntry) => !shouldIgnore(childEntry.name, ignoreDirs))
+          .map((childEntry) => childEntry.name)
         snapshot.set(childPath, new Set(childFiltered))
-      } catch {
-        // Not a directory or inaccessible — skip
-      }
-    })
+      })
   )
 
   return snapshot


### PR DESCRIPTION
Category: Filesystem watching

Symptom: On WSL worktrees, the polling watcher spent extra time on every 2s snapshot when a repo had many root-level files.

Wasted resource: Each poll read the root directory and then attempted a child readdir for every root entry, including plain files. Those file probes fail and are repeated indefinitely while the watcher is active.

Measurement: Added a focused WSL watcher test that records snapshot readdir paths and verifies root-level files are not probed; only directories and symlinks are scanned as one-level children.

Fix: Use readdir({ withFileTypes: true }) for WSL snapshots, keep root create/delete detection from Dirent names, and only recurse one level into entries that are directories or symlinks.

Verification:
- pnpm vitest run --config config/vitest.config.ts src/main/ipc/filesystem-watcher-wsl.test.ts
- pnpm exec oxlint src/main/ipc/filesystem-watcher-wsl.ts src/main/ipc/filesystem-watcher-wsl.test.ts
- pnpm exec oxfmt --write src/main/ipc/filesystem-watcher-wsl.ts src/main/ipc/filesystem-watcher-wsl.test.ts
- pnpm exec tsc --noEmit -p config/tsconfig.node.json --composite false --pretty false