### PR TITLE
perf(main): bound process cwd cache

### DIFF
--- a/src/main/providers/process-cwd.test.ts
+++ b/src/main/providers/process-cwd.test.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { execFileMock, readlinkMock } = vi.hoisted(() => ({
+  execFileMock: vi.fn(),
+  readlinkMock: vi.fn()
+}))
+
+vi.mock('child_process', () => ({
+  execFile: execFileMock
+}))
+
+vi.mock('fs/promises', () => ({
+  readlink: readlinkMock
+}))
+
+describe('resolveProcessCwd', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.restoreAllMocks()
+    execFileMock.mockReset()
+    readlinkMock.mockReset()
+    vi.spyOn(Date, 'now').mockReturnValue(10_000)
+    readlinkMock.mockImplementation(async (procPath: string) => {
+      const pid = procPath.match(/\/proc\/(\d+)\/cwd$/)?.[1] ?? 'unknown'
+      return `/cwd/${pid}`
+    })
+  })
+
+  it('bounds cached cwd results across unique process ids', async () => {
+    const { resolveProcessCwd } = await import('./process-cwd')
+
+    for (let pid = 1; pid <= 257; pid += 1) {
+      await expect(resolveProcessCwd(pid)).resolves.toBe(`/cwd/${pid}`)
+    }
+
+    expect(readlinkMock).toHaveBeenCalledTimes(257)
+
+    await expect(resolveProcessCwd(257)).resolves.toBe('/cwd/257')
+    expect(readlinkMock).toHaveBeenCalledTimes(257)
+
+    await expect(resolveProcessCwd(1)).resolves.toBe('/cwd/1')
+    expect(readlinkMock).toHaveBeenCalledTimes(258)
+  })
+})

--- a/src/main/providers/process-cwd.ts
+++ b/src/main/providers/process-cwd.ts
@@ -22,6 +22,7 @@ const execFile = promisify(execFileCb)
  * after its own timeout.
  */
 const CACHE_TTL_MS = 1500
+const CACHE_MAX_ENTRIES = 256
 const LSOF_TIMEOUT_MS = 1500
 
 type CacheEntry = { value: string; at: number }
@@ -34,14 +35,10 @@ export async function resolveProcessCwd(pid: number): Promise<string> {
   // return the previous process's cwd — acceptable because our callers
   // (getCwd on an active pty/session) can't outlive their pid.
   const now = Date.now()
+  sweepExpiredResultCache(now)
   const cached = resultCache.get(pid)
   if (cached && now - cached.at < CACHE_TTL_MS) {
     return cached.value
-  }
-  if (cached) {
-    // Evict stale entry on read so the map can't grow unbounded across a
-    // long-lived daemon session.
-    resultCache.delete(pid)
   }
   const existing = inflight.get(pid)
   if (existing) {
@@ -51,12 +48,33 @@ export async function resolveProcessCwd(pid: number): Promise<string> {
   // (including any second caller that joined via `inflight`) observes the
   // result through the same write, rather than racing on a post-await set.
   const promise = doResolve(pid).then((value) => {
-    resultCache.set(pid, { value, at: Date.now() })
+    rememberResult(pid, value, Date.now())
     inflight.delete(pid)
     return value
   })
   inflight.set(pid, promise)
   return promise
+}
+
+function sweepExpiredResultCache(now: number): void {
+  for (const [cachedPid, entry] of resultCache) {
+    if (now - entry.at >= CACHE_TTL_MS) {
+      resultCache.delete(cachedPid)
+    }
+  }
+}
+
+function rememberResult(pid: number, value: string, now: number): void {
+  resultCache.set(pid, { value, at: now })
+  // Why: terminals can churn through many OS PIDs in one app session. A short
+  // TTL only helps if the old PID is queried again, so also bound unique keys.
+  while (resultCache.size > CACHE_MAX_ENTRIES) {
+    const oldest = resultCache.keys().next().value
+    if (oldest === undefined) {
+      break
+    }
+    resultCache.delete(oldest)
+  }
 }
 
 async function doResolve(pid: number): Promise<string> {


### PR DESCRIPTION
Category: Memory growth

Symptom: Long-running app sessions that repeatedly create or reconnect local terminal processes can resolve many unique OS PIDs. `resolveProcessCwd` cached cwd results per PID with a 1.5s TTL, but stale entries were only removed if that same PID was queried again.

Wasted resource: Main-process memory retained by `resultCache` keys/values for one-off PIDs across workspace lifetime.

Measurement: Added a deterministic regression test that freezes `Date.now()`, resolves 257 unique PIDs so TTL expiry cannot help, verifies the newest PID remains cached, and verifies the oldest PID has been evicted and must be re-read.

Fix: Sweep expired cwd cache entries on each lookup and cap the cache at 256 entries, evicting oldest entries by insertion order. In-flight request coalescing remains unchanged.

Verification:
- `pnpm exec vitest run --config config/vitest.config.ts src/main/providers/process-cwd.test.ts`
- `pnpm exec oxfmt --write src/main/providers/process-cwd.ts src/main/providers/process-cwd.test.ts`
- `pnpm exec oxlint src/main/providers/process-cwd.ts src/main/providers/process-cwd.test.ts`
