### PR TITLE
perf(browser): clear anti-detection reattach timers

### DIFF
--- a/src/main/browser/browser-manager.test.ts
+++ b/src/main/browser/browser-manager.test.ts
@@ -1,5 +1,5 @@
 /* oxlint-disable max-lines */
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
   shellOpenExternalMock,
@@ -58,6 +58,10 @@ describe('browserManager', () => {
     guestOpenDevToolsMock.mockReset()
     webContentsFromIdMock.mockReset()
     browserManager.unregisterAll()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   it('validates popup URLs before opening externally', () => {
@@ -1142,6 +1146,54 @@ describe('browserManager', () => {
     expect(
       guestOffMock.mock.calls.filter(([eventName]) => eventName === 'before-input-event')
     ).toHaveLength(2)
+  })
+
+  it('cancels pending anti-detection reattach timers when unregistering a guest', () => {
+    vi.useFakeTimers()
+
+    const debuggerHandlers = new Map<string, () => void>()
+    const debuggerAttachMock = vi.fn()
+    const guest = {
+      id: 809,
+      isDestroyed: vi.fn(() => false),
+      getType: vi.fn(() => 'webview'),
+      setBackgroundThrottling: guestSetBackgroundThrottlingMock,
+      setWindowOpenHandler: guestSetWindowOpenHandlerMock,
+      on: guestOnMock,
+      off: guestOffMock,
+      openDevTools: guestOpenDevToolsMock,
+      getURL: vi.fn(() => 'https://example.com/'),
+      debugger: {
+        isAttached: vi.fn(() => false),
+        attach: debuggerAttachMock,
+        sendCommand: vi.fn().mockResolvedValue(undefined),
+        on: vi.fn((eventName: string, handler: () => void) => {
+          debuggerHandlers.set(eventName, handler)
+        }),
+        off: vi.fn((eventName: string, handler: () => void) => {
+          if (debuggerHandlers.get(eventName) === handler) {
+            debuggerHandlers.delete(eventName)
+          }
+        })
+      }
+    }
+    webContentsFromIdMock.mockReturnValue(guest)
+
+    browserManager.attachGuestPolicies(guest as never)
+    browserManager.registerGuest({
+      browserPageId: 'browser-reattach',
+      webContentsId: 809,
+      rendererWebContentsId
+    })
+
+    debuggerHandlers.get('detach')?.()
+    expect(vi.getTimerCount()).toBe(1)
+
+    browserManager.unregisterGuest('browser-reattach')
+    expect(vi.getTimerCount()).toBe(0)
+
+    vi.advanceTimersByTime(500)
+    expect(debuggerAttachMock).toHaveBeenCalledTimes(1)
   })
 
   describe('setViewportOverride', () => {

--- a/src/main/browser/browser-manager.ts
+++ b/src/main/browser/browser-manager.ts
@@ -132,6 +132,7 @@ export class BrowserManager {
   // further re-attach attempts.
   private injectAntiDetection(guest: Electron.WebContents): () => void {
     let disposed = false
+    let reattachTimer: ReturnType<typeof setTimeout> | null = null
 
     const attach = (): void => {
       if (disposed || guest.isDestroyed()) {
@@ -160,8 +161,11 @@ export class BrowserManager {
     // sessions end. The 500ms delay avoids racing with the proxy/bridge if
     // it is mid-restart (detach → re-attach).
     const onDetach = (): void => {
-      if (!disposed && !guest.isDestroyed()) {
-        setTimeout(attach, 500)
+      if (!disposed && !guest.isDestroyed() && reattachTimer === null) {
+        reattachTimer = setTimeout(() => {
+          reattachTimer = null
+          attach()
+        }, 500)
       }
     }
 
@@ -174,6 +178,10 @@ export class BrowserManager {
 
     return () => {
       disposed = true
+      if (reattachTimer !== null) {
+        clearTimeout(reattachTimer)
+        reattachTimer = null
+      }
       try {
         guest.debugger.off('detach', onDetach)
       } catch {


### PR DESCRIPTION
Category: Resource leaks

Symptom: Browser webview close/re-register can leave a delayed anti-detection debugger reattach timer alive after guest policy cleanup.

Wasted resource: One pending timer per detach retry retains the guest WebContents closure until it fires; repeated debugger detaches can also schedule duplicate retries.

Measurement: Deterministic fake-timer unit test asserts detach creates one pending retry and unregisterGuest clears the timer before it can reattach.

Fix: Track the delayed reattach timer in injectAntiDetection, coalesce duplicate detach retries, and clear the pending timer in the policy cleanup path.

Verification: pnpm vitest run --config config/vitest.config.ts src/main/browser/browser-manager.test.ts (27 tests passed).

Notes: Built the branch from origin/main with only the browser-manager patch; unrelated active-worktree changes were left unstaged.