### PR TITLE
perf(metadata): dedupe metadata cache requests

### DIFF
--- a/src/renderer/src/hooks/metadata-request-cache.test.ts
+++ b/src/renderer/src/hooks/metadata-request-cache.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  clearMetadataRequestStore,
+  createMetadataRequestStore,
+  getFreshMetadata,
+  loadMetadata
+} from './metadata-request-cache'
+
+describe('metadata-request-cache', () => {
+  it('dedupes concurrent requests for the same cache key', async () => {
+    const store = createMetadataRequestStore<string[]>()
+    let resolveRequest: (value: string[]) => void = () => {}
+    const fetcher = vi.fn(
+      () =>
+        new Promise<string[]>((resolve) => {
+          resolveRequest = resolve
+        })
+    )
+
+    const first = loadMetadata(store, 'repo:labels', fetcher, () => 1_000)
+    const second = loadMetadata(store, 'repo:labels', fetcher, () => 1_000)
+
+    expect(fetcher).toHaveBeenCalledTimes(1)
+
+    resolveRequest(['bug'])
+    await expect(Promise.all([first, second])).resolves.toEqual([['bug'], ['bug']])
+
+    const cached = await loadMetadata(
+      store,
+      'repo:labels',
+      () => Promise.resolve(['should-not-fetch']),
+      () => 1_100
+    )
+    expect(cached).toEqual(['bug'])
+    expect(fetcher).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps different cache keys isolated', async () => {
+    const store = createMetadataRequestStore<string[]>()
+    const fetcher = vi.fn((key: string) => Promise.resolve([key]))
+
+    await Promise.all([
+      loadMetadata(store, 'repo-a:labels', () => fetcher('a')),
+      loadMetadata(store, 'repo-b:labels', () => fetcher('b'))
+    ])
+
+    expect(fetcher).toHaveBeenCalledTimes(2)
+    expect(getFreshMetadata(store, 'repo-a:labels')?.data).toEqual(['a'])
+    expect(getFreshMetadata(store, 'repo-b:labels')?.data).toEqual(['b'])
+  })
+
+  it('does not cache failed requests', async () => {
+    const store = createMetadataRequestStore<string[]>()
+    const fetcher = vi
+      .fn<() => Promise<string[]>>()
+      .mockRejectedValueOnce(new Error('network'))
+      .mockResolvedValueOnce(['triage'])
+
+    await expect(loadMetadata(store, 'repo:labels', fetcher)).rejects.toThrow('network')
+    await expect(loadMetadata(store, 'repo:labels', fetcher)).resolves.toEqual(['triage'])
+
+    expect(fetcher).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not let stale in-flight responses repopulate after clear', async () => {
+    const store = createMetadataRequestStore<string[]>()
+    let resolveRequest: (value: string[]) => void = () => {}
+
+    const pending = loadMetadata(
+      store,
+      'team:members',
+      () =>
+        new Promise<string[]>((resolve) => {
+          resolveRequest = resolve
+        }),
+      () => 1_000
+    )
+
+    clearMetadataRequestStore(store)
+    resolveRequest(['old-user'])
+
+    await expect(pending).resolves.toEqual(['old-user'])
+    expect(getFreshMetadata(store, 'team:members', 1_100)).toBeNull()
+  })
+})

--- a/src/renderer/src/hooks/metadata-request-cache.ts
+++ b/src/renderer/src/hooks/metadata-request-cache.ts
@@ -1,0 +1,71 @@
+const METADATA_TTL = 300_000 // 5 min
+
+type CachedMetadata<T> = { data: T; fetchedAt: number }
+
+export type MetadataRequestStore<T> = {
+  cache: Map<string, CachedMetadata<T>>
+  inflight: Map<string, Promise<T>>
+  generation: number
+}
+
+export function createMetadataRequestStore<T>(): MetadataRequestStore<T> {
+  return {
+    cache: new Map(),
+    inflight: new Map(),
+    generation: 0
+  }
+}
+
+export function clearMetadataRequestStore<T>(store: MetadataRequestStore<T>): void {
+  store.generation += 1
+  store.cache.clear()
+  store.inflight.clear()
+}
+
+export function getFreshMetadata<T>(
+  store: MetadataRequestStore<T>,
+  key: string,
+  now = Date.now()
+): CachedMetadata<T> | null {
+  const entry = store.cache.get(key)
+  if (!entry || now - entry.fetchedAt >= METADATA_TTL) {
+    return null
+  }
+  return entry
+}
+
+export function loadMetadata<T>(
+  store: MetadataRequestStore<T>,
+  key: string,
+  fetcher: () => Promise<T>,
+  now = Date.now
+): Promise<T> {
+  const cached = getFreshMetadata(store, key, now())
+  if (cached) {
+    return Promise.resolve(cached.data)
+  }
+
+  const inflight = store.inflight.get(key)
+  if (inflight) {
+    return inflight
+  }
+
+  // Why: clearMetadataRequestStore invalidates auth/repo boundaries; late
+  // responses from the previous generation must not repopulate the cache.
+  const generation = store.generation
+  const promise = fetcher()
+    .then((data) => {
+      if (store.generation === generation) {
+        store.cache.set(key, { data, fetchedAt: now() })
+      }
+      return data
+    })
+    .finally(() => {
+      if (store.inflight.get(key) === promise) {
+        store.inflight.delete(key)
+      }
+    })
+
+  store.inflight.set(key, promise)
+  return promise
+}

--- a/src/renderer/src/hooks/useGitHubSlugMetadata.ts
+++ b/src/renderer/src/hooks/useGitHubSlugMetadata.ts
@@ -6,6 +6,12 @@
 // and so this file remains under the lint line cap.
 import { useEffect, useRef, useState } from 'react'
 import type { GitHubAssignableUser } from '../../../shared/types'
+import {
+  clearMetadataRequestStore,
+  createMetadataRequestStore,
+  getFreshMetadata,
+  loadMetadata
+} from './metadata-request-cache'
 
 type MetadataState<T> = {
   data: T
@@ -13,21 +19,12 @@ type MetadataState<T> = {
   error: string | null
 }
 
-const METADATA_TTL = 300_000 // 5 min
-
-type CachedMetadata<T> = { data: T; fetchedAt: number }
-
-const slugLabelCache = new Map<string, CachedMetadata<string[]>>()
-const slugAssigneeCache = new Map<string, CachedMetadata<GitHubAssignableUser[]>>()
-
-function isCacheFresh<T>(cache: Map<string, CachedMetadata<T>>, key: string): boolean {
-  const entry = cache.get(key)
-  return !!entry && Date.now() - entry.fetchedAt < METADATA_TTL
-}
+const slugLabelStore = createMetadataRequestStore<string[]>()
+const slugAssigneeStore = createMetadataRequestStore<GitHubAssignableUser[]>()
 
 export function clearGitHubSlugMetadataCache(): void {
-  slugLabelCache.clear()
-  slugAssigneeCache.clear()
+  clearMetadataRequestStore(slugLabelStore)
+  clearMetadataRequestStore(slugAssigneeStore)
 }
 
 export function useRepoLabelsBySlug(
@@ -47,8 +44,8 @@ export function useRepoLabelsBySlug(
     }
     const key = `${owner}/${repo}`
 
-    const cached = slugLabelCache.get(key)
-    if (cached && isCacheFresh(slugLabelCache, key)) {
+    const cached = getFreshMetadata(slugLabelStore, key)
+    if (cached) {
       // Why: always seed state from cache. A remount with the same key
       // resets local state to defaults but `activeKeyRef.current` from the
       // new ref instance is null on first run — the previous gate that
@@ -66,18 +63,18 @@ export function useRepoLabelsBySlug(
       loading: true,
       error: null
     }))
-    window.api.gh
-      .listLabelsBySlug({ owner, repo })
-      .then((res) => {
+    loadMetadata(slugLabelStore, key, () =>
+      window.api.gh.listLabelsBySlug({ owner, repo }).then((res) => {
+        if (!res.ok) {
+          throw new Error(res.error.message)
+        }
+        return res.labels
+      })
+    )
+      .then((data) => {
         if (activeKeyRef.current !== requestKey) {
           return
         }
-        if (!res.ok) {
-          setState((s) => ({ ...s, loading: false, error: res.error.message }))
-          return
-        }
-        const data = res.labels
-        slugLabelCache.set(key, { data, fetchedAt: Date.now() })
         setState({ data, loading: false, error: null })
       })
       .catch((err) => {
@@ -118,8 +115,8 @@ export function useRepoAssigneesBySlug(
     }
     const key = `${owner}/${repo}#${seedKey}`
 
-    const cached = slugAssigneeCache.get(key)
-    if (cached && isCacheFresh(slugAssigneeCache, key)) {
+    const cached = getFreshMetadata(slugAssigneeStore, key)
+    if (cached) {
       // Why: see useRepoLabelsBySlug — always seed state from cache so a
       // remount with the same key picks up cached data instead of staying
       // at the empty default.
@@ -136,22 +133,24 @@ export function useRepoAssigneesBySlug(
       loading: true,
       error: null
     }))
-    window.api.gh
-      .listAssignableUsersBySlug({
-        owner,
-        repo,
-        ...(seedKey ? { seedLogins: seedKey.split(',') } : {})
-      })
-      .then((res) => {
+    loadMetadata(slugAssigneeStore, key, () =>
+      window.api.gh
+        .listAssignableUsersBySlug({
+          owner,
+          repo,
+          ...(seedKey ? { seedLogins: seedKey.split(',') } : {})
+        })
+        .then((res) => {
+          if (!res.ok) {
+            throw new Error(res.error.message)
+          }
+          return res.users
+        })
+    )
+      .then((data) => {
         if (activeKeyRef.current !== requestKey) {
           return
         }
-        if (!res.ok) {
-          setState((s) => ({ ...s, loading: false, error: res.error.message }))
-          return
-        }
-        const data = res.users
-        slugAssigneeCache.set(key, { data, fetchedAt: Date.now() })
         setState({ data, loading: false, error: null })
       })
       .catch((err) => {

--- a/src/renderer/src/hooks/useIssueMetadata.ts
+++ b/src/renderer/src/hooks/useIssueMetadata.ts
@@ -5,6 +5,12 @@ import type {
   LinearLabel,
   LinearMember
 } from '../../../shared/types'
+import {
+  clearMetadataRequestStore,
+  createMetadataRequestStore,
+  getFreshMetadata,
+  loadMetadata
+} from './metadata-request-cache'
 
 type MetadataState<T> = {
   data: T
@@ -12,19 +18,10 @@ type MetadataState<T> = {
   error: string | null
 }
 
-const METADATA_TTL = 300_000 // 5 min
-
-type CachedMetadata<T> = { data: T; fetchedAt: number }
-
-function isCacheFresh<T>(cache: Map<string, CachedMetadata<T>>, key: string): boolean {
-  const entry = cache.get(key)
-  return !!entry && Date.now() - entry.fetchedAt < METADATA_TTL
-}
-
 // ─── GitHub ────────────────────────────────────────────────
 
-const ghLabelCache = new Map<string, CachedMetadata<string[]>>()
-const ghAssigneeCache = new Map<string, CachedMetadata<GitHubAssignableUser[]>>()
+const ghLabelStore = createMetadataRequestStore<string[]>()
+const ghAssigneeStore = createMetadataRequestStore<GitHubAssignableUser[]>()
 
 export function useRepoLabels(repoPath: string | null): MetadataState<string[]> {
   const [state, setState] = useState<MetadataState<string[]>>({
@@ -39,8 +36,8 @@ export function useRepoLabels(repoPath: string | null): MetadataState<string[]> 
       return
     }
 
-    const cached = ghLabelCache.get(repoPath)
-    if (cached && isCacheFresh(ghLabelCache, repoPath)) {
+    const cached = getFreshMetadata(ghLabelStore, repoPath)
+    if (cached) {
       if (activeKeyRef.current !== repoPath) {
         setState({ data: cached.data, loading: false, error: null })
         activeKeyRef.current = repoPath
@@ -56,14 +53,13 @@ export function useRepoLabels(repoPath: string | null): MetadataState<string[]> 
       loading: true,
       error: null
     }))
-    window.api.gh
-      .listLabels({ repoPath })
-      .then((labels) => {
+    loadMetadata(ghLabelStore, repoPath, () =>
+      window.api.gh.listLabels({ repoPath }).then((labels) => labels as string[])
+    )
+      .then((data) => {
         if (activeKeyRef.current !== requestKey) {
           return
         }
-        const data = labels as string[]
-        ghLabelCache.set(repoPath, { data, fetchedAt: Date.now() })
         setState({ data, loading: false, error: null })
       })
       .catch((err) => {
@@ -95,8 +91,8 @@ export function useRepoAssignees(repoPath: string | null): MetadataState<GitHubA
       return
     }
 
-    const cached = ghAssigneeCache.get(repoPath)
-    if (cached && isCacheFresh(ghAssigneeCache, repoPath)) {
+    const cached = getFreshMetadata(ghAssigneeStore, repoPath)
+    if (cached) {
       if (activeKeyRef.current !== repoPath) {
         setState({ data: cached.data, loading: false, error: null })
         activeKeyRef.current = repoPath
@@ -112,14 +108,15 @@ export function useRepoAssignees(repoPath: string | null): MetadataState<GitHubA
       loading: true,
       error: null
     }))
-    window.api.gh
-      .listAssignableUsers({ repoPath })
-      .then((users) => {
+    loadMetadata(ghAssigneeStore, repoPath, () =>
+      window.api.gh
+        .listAssignableUsers({ repoPath })
+        .then((users) => users as GitHubAssignableUser[])
+    )
+      .then((data) => {
         if (activeKeyRef.current !== requestKey) {
           return
         }
-        const data = users as GitHubAssignableUser[]
-        ghAssigneeCache.set(repoPath, { data, fetchedAt: Date.now() })
         setState({ data, loading: false, error: null })
       })
       .catch((err) => {
@@ -140,19 +137,19 @@ export function useRepoAssignees(repoPath: string | null): MetadataState<GitHubA
 
 // ─── Linear ────────────────────────────────────────────────
 
-const linearStateCache = new Map<string, CachedMetadata<LinearWorkflowState[]>>()
-const linearLabelCache = new Map<string, CachedMetadata<LinearLabel[]>>()
-const linearMemberCache = new Map<string, CachedMetadata<LinearMember[]>>()
+const linearStateStore = createMetadataRequestStore<LinearWorkflowState[]>()
+const linearLabelStore = createMetadataRequestStore<LinearLabel[]>()
+const linearMemberStore = createMetadataRequestStore<LinearMember[]>()
 
 export function clearLinearMetadataCache(): void {
-  linearStateCache.clear()
-  linearLabelCache.clear()
-  linearMemberCache.clear()
+  clearMetadataRequestStore(linearStateStore)
+  clearMetadataRequestStore(linearLabelStore)
+  clearMetadataRequestStore(linearMemberStore)
 }
 
 export function clearGitHubMetadataCache(): void {
-  ghLabelCache.clear()
-  ghAssigneeCache.clear()
+  clearMetadataRequestStore(ghLabelStore)
+  clearMetadataRequestStore(ghAssigneeStore)
 }
 
 export function useTeamStates(teamId: string | null): MetadataState<LinearWorkflowState[]> {
@@ -168,8 +165,8 @@ export function useTeamStates(teamId: string | null): MetadataState<LinearWorkfl
       return
     }
 
-    const cached = linearStateCache.get(teamId)
-    if (cached && isCacheFresh(linearStateCache, teamId)) {
+    const cached = getFreshMetadata(linearStateStore, teamId)
+    if (cached) {
       if (activeKeyRef.current !== teamId) {
         setState({ data: cached.data, loading: false, error: null })
         activeKeyRef.current = teamId
@@ -185,14 +182,13 @@ export function useTeamStates(teamId: string | null): MetadataState<LinearWorkfl
       loading: true,
       error: null
     }))
-    window.api.linear
-      .teamStates({ teamId })
-      .then((states) => {
+    loadMetadata(linearStateStore, teamId, () =>
+      window.api.linear.teamStates({ teamId }).then((states) => states as LinearWorkflowState[])
+    )
+      .then((data) => {
         if (activeKeyRef.current !== requestKey) {
           return
         }
-        const data = states as LinearWorkflowState[]
-        linearStateCache.set(teamId, { data, fetchedAt: Date.now() })
         setState({ data, loading: false, error: null })
       })
       .catch((err) => {
@@ -224,8 +220,8 @@ export function useTeamLabels(teamId: string | null): MetadataState<LinearLabel[
       return
     }
 
-    const cached = linearLabelCache.get(teamId)
-    if (cached && isCacheFresh(linearLabelCache, teamId)) {
+    const cached = getFreshMetadata(linearLabelStore, teamId)
+    if (cached) {
       if (activeKeyRef.current !== teamId) {
         setState({ data: cached.data, loading: false, error: null })
         activeKeyRef.current = teamId
@@ -241,14 +237,13 @@ export function useTeamLabels(teamId: string | null): MetadataState<LinearLabel[
       loading: true,
       error: null
     }))
-    window.api.linear
-      .teamLabels({ teamId })
-      .then((labels) => {
+    loadMetadata(linearLabelStore, teamId, () =>
+      window.api.linear.teamLabels({ teamId }).then((labels) => labels as LinearLabel[])
+    )
+      .then((data) => {
         if (activeKeyRef.current !== requestKey) {
           return
         }
-        const data = labels as LinearLabel[]
-        linearLabelCache.set(teamId, { data, fetchedAt: Date.now() })
         setState({ data, loading: false, error: null })
       })
       .catch((err) => {
@@ -280,8 +275,8 @@ export function useTeamMembers(teamId: string | null): MetadataState<LinearMembe
       return
     }
 
-    const cached = linearMemberCache.get(teamId)
-    if (cached && isCacheFresh(linearMemberCache, teamId)) {
+    const cached = getFreshMetadata(linearMemberStore, teamId)
+    if (cached) {
       if (activeKeyRef.current !== teamId) {
         setState({ data: cached.data, loading: false, error: null })
         activeKeyRef.current = teamId
@@ -297,14 +292,13 @@ export function useTeamMembers(teamId: string | null): MetadataState<LinearMembe
       loading: true,
       error: null
     }))
-    window.api.linear
-      .teamMembers({ teamId })
-      .then((members) => {
+    loadMetadata(linearMemberStore, teamId, () =>
+      window.api.linear.teamMembers({ teamId }).then((members) => members as LinearMember[])
+    )
+      .then((data) => {
         if (activeKeyRef.current !== requestKey) {
           return
         }
-        const data = members as LinearMember[]
-        linearMemberCache.set(teamId, { data, fetchedAt: Date.now() })
         setState({ data, loading: false, error: null })
       })
       .catch((err) => {


### PR DESCRIPTION
Category: Cache/dedupe

Symptom: Opening multiple GitHub/Linear edit surfaces for the same repo, slug, or Linear team before metadata finishes loading starts duplicate label/assignee/state/member IPC requests. Cache invalidation also only cleared fulfilled metadata entries, so a late in-flight response could repopulate a cleared cache.

Wasted resource: Duplicate renderer -> main IPC calls and duplicate GitHub/Linear API work for identical metadata keys during dialog/popover bursts.

Measurement: Added a deterministic metadata request-cache unit test that starts concurrent same-key loads and asserts only one fetcher call, verifies different keys stay isolated, verifies failures are not cached, and verifies clear/invalidation prevents stale in-flight responses from repopulating the cache.

Fix: Introduced a small metadata request store with short-TTL reads, per-key in-flight dedupe, and generation-based invalidation. Wired GitHub repo metadata, GitHub slug metadata, and Linear team metadata hooks through it.

Verification:
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/hooks/metadata-request-cache.test.ts
- pnpm exec oxlint src/renderer/src/hooks/metadata-request-cache.ts src/renderer/src/hooks/metadata-request-cache.test.ts src/renderer/src/hooks/useIssueMetadata.ts src/renderer/src/hooks/useGitHubSlugMetadata.ts
- pnpm exec tsgo --noEmit -p config/tsconfig.tc.web.json --pretty false
- git diff --check -- src/renderer/src/hooks/metadata-request-cache.ts src/renderer/src/hooks/metadata-request-cache.test.ts src/renderer/src/hooks/useIssueMetadata.ts src/renderer/src/hooks/useGitHubSlugMetadata.ts
