### PR TITLE
feat: add multi-select support to explorer file tree

### DIFF
--- a/src/renderer/src/components/right-sidebar/FileExplorer.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorer.tsx
@@ -29,6 +29,7 @@ import { useFileExplorerTree } from './useFileExplorerTree'
 import { useFileExplorerWatch } from './useFileExplorerWatch'
 import { useFileExplorerSelection } from './useFileExplorerSelection'
 import { useFileExplorerGitIgnoredRows } from './useFileExplorerGitIgnoredRows'
+import type { TreeNode } from './file-explorer-types'
 
 function FileExplorerInner(): React.JSX.Element {
   const activeWorktreeId = useAppStore((s) => s.activeWorktreeId)
@@ -98,6 +99,7 @@ function FileExplorerInner(): React.JSX.Element {
     selectedPath,
     selectedPaths,
     setSingleSelectedPath,
+    setSelectedPaths,
     resetSelection,
     selectRowWithModifiers,
     preserveSelectionForContextMenu,
@@ -118,13 +120,12 @@ function FileExplorerInner(): React.JSX.Element {
   const statusByRelativePath = useMemo(() => buildStatusMap(entries), [entries])
   const folderStatusByRelativePath = useMemo(() => buildFolderStatusMap(entries), [entries])
 
-  const { deleteShortcutLabel, requestDelete } = useFileDeletion({
+  const { deleteShortcutLabel, requestDelete, requestDeleteAll } = useFileDeletion({
     activeWorktreeId,
     openFiles,
     closeFile,
     refreshDir,
-    selectedPath,
-    setSelectedPath: setSingleSelectedPath,
+    setSelectedPaths,
     isWindows
   })
 
@@ -282,14 +283,20 @@ function FileExplorerInner(): React.JSX.Element {
   }, [inlineInputIndex, virtualizer])
 
   const selectedNode = selectedPath ? (rowsByPath.get(selectedPath) ?? null) : null
+  const selectedNodes = useMemo(
+    () => visibleFlatRows.filter((row) => selectedPaths.has(row.path)),
+    [visibleFlatRows, selectedPaths]
+  )
   useFileExplorerKeys({
     containerRef: explorerShellRef,
     flatRows: visibleFlatRows,
     inlineInput,
     selectedPaths,
     selectedNode,
+    selectedNodes,
     startRename,
-    requestDelete
+    requestDelete,
+    requestDeleteAll
   })
 
   const { handleClick, handleDoubleClick, handleWheelCapture } = useFileExplorerHandlers({
@@ -300,6 +307,20 @@ function FileExplorerInner(): React.JSX.Element {
     setSelectedPath: setSingleSelectedPath,
     scrollRef
   })
+
+  // Why: context-menu Delete should respect the multi-selection — if the
+  // right-clicked node is already part of a multi-selection, delete the whole
+  // set; otherwise fall through to single-node delete.
+  const handleContextMenuDelete = useCallback(
+    (node: TreeNode) => {
+      if (selectedPaths.has(node.path) && selectedNodes.length > 1) {
+        requestDeleteAll(selectedNodes)
+      } else {
+        requestDelete(node)
+      }
+    },
+    [selectedPaths, selectedNodes, requestDelete, requestDeleteAll]
+  )
 
   const handleDuplicate = useFileDuplicate({ activeWorktreeId, worktreePath, refreshDir })
   const handleRowClick = useCallback(
@@ -349,7 +370,6 @@ function FileExplorerInner(): React.JSX.Element {
   const isEmptyState = visibleFlatRows.length === 0 && !inlineInput
   const isLoading = isEmptyState && (rootCache?.loading ?? true)
   const hasError = isEmptyState && !isLoading && !!rootError
-  const isEmpty = isEmptyState && !isLoading && !hasError
   const showTree = !isEmptyState
 
   return (
@@ -419,7 +439,7 @@ function FileExplorerInner(): React.JSX.Element {
             <FileExplorerTreeStatus
               isLoading={isLoading}
               error={hasError ? rootError : null}
-              isEmpty={isEmpty}
+              isEmpty={isEmptyState && !isLoading && !hasError}
             />
           )}
           {showTree && (
@@ -446,7 +466,7 @@ function FileExplorerInner(): React.JSX.Element {
               onStartNew={startNew}
               onStartRename={startRename}
               onDuplicate={handleDuplicate}
-              onRequestDelete={requestDelete}
+              onRequestDelete={handleContextMenuDelete}
               onCollapseFolderSubtree={handleCollapseFolderSubtree}
               onFindInFolder={handleFindInFolder}
               onMoveDrop={handleMoveDrop}

--- a/src/renderer/src/components/right-sidebar/FileExplorerRow.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorerRow.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable max-lines -- File Explorer rows own dense context-menu and drag/drop interactions. */
 import React, { useCallback, useEffect, useRef } from 'react'
+import { basename } from '@/lib/path'
 import {
   ChevronRight,
   CircleSlash,
@@ -34,7 +35,11 @@ import { useShortcutLabel } from '@/hooks/useShortcutLabel'
 import { detectLanguage } from '@/lib/language-detect'
 import { getFileTypeIcon } from '@/lib/file-type-icons'
 import { openFileInBrowserTab } from '@/lib/file-preview'
-import { WORKSPACE_FILE_PATH_MIME } from '@/lib/workspace-file-drag'
+import {
+  encodeWorkspaceFilePaths,
+  WORKSPACE_FILE_PATH_MIME,
+  WORKSPACE_FILE_PATHS_MIME
+} from '@/lib/workspace-file-drag'
 import type { GitFileStatus } from '../../../../shared/types'
 import { STATUS_LABELS } from './status-display'
 import type { TreeNode } from './file-explorer-types'
@@ -213,6 +218,7 @@ type FileExplorerRowProps = {
   isLoading: boolean
   isSelected: boolean
   isFlashing: boolean
+  selectedPaths: Set<string>
   nodeStatus: GitFileStatus | null
   statusColor: string | null
   isIgnored: boolean
@@ -252,6 +258,7 @@ export function FileExplorerRow({
   isLoading,
   isSelected,
   isFlashing,
+  selectedPaths,
   nodeStatus,
   statusColor,
   isIgnored,
@@ -317,17 +324,67 @@ export function FileExplorerRow({
           data-native-file-drop-dir={rowDropDir}
           draggable
           onDragStart={(event) => {
+            const paths =
+              selectedPaths.has(node.path) && selectedPaths.size > 1
+                ? [...selectedPaths]
+                : [node.path]
             event.dataTransfer.setData(WORKSPACE_FILE_PATH_MIME, node.path)
-            // Allow both file explorer moving and copying to terminal
+            if (paths.length > 1) {
+              event.dataTransfer.setData(WORKSPACE_FILE_PATHS_MIME, encodeWorkspaceFilePaths(paths))
+            }
             event.dataTransfer.effectAllowed = 'copyMove'
             onDragSourceChange(node.path)
+
+            if (paths.length > 1) {
+              const MAX_SHOWN = 5
+              const btn = event.currentTarget
+              const rowW = btn.getBoundingClientRect().width
+
+              // Why: drag images are detached DOM nodes, so inline the same
+              // file glyph the real row renders.
+              const FILE_ICON =
+                '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><polyline points="14 2 14 8 20 8"/></svg>'
+
+              const makeRow = (label: string, faded = false): HTMLDivElement => {
+                const row = document.createElement('div')
+                row.style.cssText = `display:flex;align-items:center;gap:4px;height:26px;padding:4px 8px;width:${rowW}px;box-sizing:border-box;font-size:12px;border-radius:2px;background:var(--accent);color:var(--accent-foreground);${faded ? 'opacity:0.6;' : ''}`
+                const spacer = document.createElement('span')
+                spacer.style.cssText = 'width:12px;height:12px;flex-shrink:0;'
+                row.appendChild(spacer)
+                const icon = document.createElement('span')
+                icon.style.cssText =
+                  'width:12px;height:12px;flex-shrink:0;display:flex;align-items:center;color:var(--muted-foreground);'
+                icon.innerHTML = FILE_ICON
+                row.appendChild(icon)
+                const name = document.createElement('span')
+                name.style.cssText = 'overflow:hidden;text-overflow:ellipsis;white-space:nowrap;'
+                name.textContent = label
+                row.appendChild(name)
+                return row
+              }
+
+              const ghost = document.createElement('div')
+              ghost.style.cssText =
+                'position:fixed;top:-9999px;left:-9999px;pointer-events:none;display:flex;flex-direction:column;gap:1px;'
+
+              for (const p of paths.slice(0, MAX_SHOWN)) {
+                ghost.appendChild(makeRow(basename(p)))
+              }
+              if (paths.length > MAX_SHOWN) {
+                ghost.appendChild(makeRow(`+${paths.length - MAX_SHOWN} more`, true))
+              }
+
+              document.body.appendChild(ghost)
+              event.dataTransfer.setDragImage(ghost, 12, 12)
+              setTimeout(() => document.body.removeChild(ghost), 0)
+            }
           }}
           onDragEnd={() => onDragSourceChange(null)}
           onDragOver={handleDragOver}
           onDragEnter={handleDragEnter}
           onDragLeave={handleDragLeave}
           onDrop={handleDrop}
-          onClick={onClick}
+          onClick={(e) => onClick(e)}
           onDoubleClick={onDoubleClick}
           onContextMenu={onContextMenuSelect}
         >

--- a/src/renderer/src/components/right-sidebar/FileExplorerVirtualRows.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorerVirtualRows.tsx
@@ -153,6 +153,7 @@ export function FileExplorerVirtualRows(props: FileExplorerVirtualRowsProps): Re
               isExpanded={expanded.has(n.path)}
               isLoading={n.isDirectory && Boolean(dirCache[n.path]?.loading)}
               isSelected={selectedPaths.has(n.path) || activeFileId === n.path}
+              selectedPaths={selectedPaths}
               isFlashing={flashingPath === n.path}
               nodeStatus={nodeStatus}
               statusColor={nodeStatus ? STATUS_COLORS[nodeStatus] : null}

--- a/src/renderer/src/components/right-sidebar/useFileDeletion.ts
+++ b/src/renderer/src/components/right-sidebar/useFileDeletion.ts
@@ -1,5 +1,4 @@
 import { useCallback, useMemo, useRef } from 'react'
-import type { Dispatch, SetStateAction } from 'react'
 import { toast } from 'sonner'
 import { useAppStore } from '@/store'
 import { useConfirmationDialog } from '@/components/confirmation-dialog'
@@ -30,14 +29,14 @@ type UseFileDeletionParams = {
   }[]
   closeFile: (fileId: string) => void
   refreshDir: (dirPath: string) => Promise<void>
-  selectedPath: string | null
-  setSelectedPath: Dispatch<SetStateAction<string | null>>
+  setSelectedPaths: (paths: Set<string>) => void
   isWindows: boolean
 }
 
 type UseFileDeletionResult = {
   deleteShortcutLabel: string
   requestDelete: (node: TreeNode) => void
+  requestDeleteAll: (nodes: TreeNode[]) => void
 }
 
 export function useFileDeletion({
@@ -45,8 +44,7 @@ export function useFileDeletion({
   openFiles,
   closeFile,
   refreshDir,
-  selectedPath,
-  setSelectedPath,
+  setSelectedPaths,
   isWindows
 }: UseFileDeletionParams): UseFileDeletionResult {
   const confirm = useConfirmationDialog()
@@ -56,9 +54,9 @@ export function useFileDeletion({
   const inFlightRef = useRef<Set<string>>(new Set())
 
   const runDelete = useCallback(
-    async (node: TreeNode) => {
+    async (node: TreeNode): Promise<boolean> => {
       if (inFlightRef.current.has(node.path)) {
-        return
+        return false
       }
       inFlightRef.current.add(node.path)
 
@@ -92,7 +90,7 @@ export function useFileDeletion({
         })
         if (!confirmed) {
           inFlightRef.current.delete(node.path)
-          return
+          return false
         }
       }
 
@@ -176,9 +174,6 @@ export function useFileDeletion({
           })
         }
 
-        if (selectedPath && isPathEqualOrDescendant(selectedPath, node.path)) {
-          setSelectedPath(null)
-        }
         // Why: use targeted refreshDir instead of refreshTree so only the parent
         // directory is reloaded, preserving scroll position and avoiding redundant
         // full-tree reloads (the watcher will also trigger a targeted refresh).
@@ -194,41 +189,88 @@ export function useFileDeletion({
           const destination = isWindows ? 'Recycle Bin' : 'Trash'
           toast.success(`'${node.name}' moved to ${destination}`)
         }
+        return true
       } catch (error) {
         const action = isRemote ? 'delete' : isWindows ? 'move to Recycle Bin' : 'move to Trash'
         toast.error(error instanceof Error ? error.message : `Failed to ${action} '${node.name}'.`)
+        return false
       } finally {
         inFlightRef.current.delete(node.path)
       }
     },
-    [
-      activeWorktreeId,
-      closeFile,
-      confirm,
-      isWindows,
-      openFiles,
-      refreshDir,
-      selectedPath,
-      setSelectedPath
-    ]
+    [activeWorktreeId, closeFile, confirm, isWindows, openFiles, refreshDir]
   )
 
   const requestDelete = useCallback(
     (node: TreeNode) => {
-      setSelectedPath(node.path)
+      setSelectedPaths(new Set([node.path]))
       // Why: local deletes skip confirmation because they're reversible
       // (OS-level Trash + in-app undo). Remote deletes are permanent, so
       // runDelete prompts for confirmation internally before calling `rm`.
-      void runDelete(node)
+      void runDelete(node).then((deleted) => {
+        if (deleted) {
+          setSelectedPaths(new Set())
+        }
+      })
     },
-    [runDelete, setSelectedPath]
+    [runDelete, setSelectedPaths]
+  )
+
+  const requestDeleteAll = useCallback(
+    (nodes: TreeNode[]) => {
+      if (nodes.length === 0) {
+        return
+      }
+      if (nodes.length === 1) {
+        requestDelete(nodes[0])
+        return
+      }
+      // Why: skip descendants of other selected directories — deleting a parent
+      // already removes the child, and issuing both requests races on the
+      // now-missing path and produces spurious errors.
+      const roots = nodes.filter(
+        (n) =>
+          !nodes.some(
+            (other) =>
+              other !== n && other.isDirectory && isPathEqualOrDescendant(n.path, other.path)
+          )
+      )
+      // Why: process sequentially in the caller's tree order so each delete
+      // fully settles before the next begins — this avoids concurrent writes
+      // to the same parent directory and makes failure toasts deterministic.
+      // Selection is cleared once after the entire batch settles rather than
+      // per-node, so no concurrent completion can restore a partial stale set.
+      void (async () => {
+        const deletedRoots: TreeNode[] = []
+        for (const node of roots) {
+          if (await runDelete(node)) {
+            deletedRoots.push(node)
+          }
+        }
+        if (deletedRoots.length === 0) {
+          return
+        }
+        setSelectedPaths(
+          new Set(
+            nodes
+              .filter(
+                (node) =>
+                  !deletedRoots.some((deleted) => isPathEqualOrDescendant(node.path, deleted.path))
+              )
+              .map((node) => node.path)
+          )
+        )
+      })()
+    },
+    [runDelete, requestDelete, setSelectedPaths]
   )
 
   return useMemo(
     () => ({
       deleteShortcutLabel,
-      requestDelete
+      requestDelete,
+      requestDeleteAll
     }),
-    [deleteShortcutLabel, requestDelete]
+    [deleteShortcutLabel, requestDelete, requestDeleteAll]
   )
 }

--- a/src/renderer/src/components/right-sidebar/useFileExplorerAutoReveal.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerAutoReveal.ts
@@ -1,5 +1,4 @@
 import { useEffect, useRef } from 'react'
-import type { Dispatch, SetStateAction } from 'react'
 import type { Virtualizer } from '@tanstack/react-virtual'
 import { useAppStore } from '@/store'
 import type { OpenFile } from '@/store/slices/editor'
@@ -13,7 +12,7 @@ type UseFileExplorerAutoRevealParams = {
   openFiles: OpenFile[]
   rowsByPath: Map<string, TreeNode>
   flatRows: TreeNode[]
-  setSelectedPath: Dispatch<SetStateAction<string | null>>
+  setSelectedPath: (path: string | null) => void
   virtualizer: Virtualizer<HTMLDivElement, Element>
 }
 

--- a/src/renderer/src/components/right-sidebar/useFileExplorerDragDrop.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerDragDrop.ts
@@ -7,7 +7,7 @@ import { toast } from 'sonner'
 import { useAppStore } from '@/store'
 import { basename, dirname, joinPath } from '@/lib/path'
 import { getConnectionId } from '@/lib/connection-context'
-import { WORKSPACE_FILE_PATH_MIME } from '@/lib/workspace-file-drag'
+import { getWorkspaceFileDragPaths, WORKSPACE_FILE_PATH_MIME } from '@/lib/workspace-file-drag'
 import { remapOpenEditorTabsForPathChange } from '@/lib/remap-open-editor-tabs-for-path-change'
 import { requestEditorSaveQuiesce } from '@/components/editor/editor-autosave'
 import { commitFileExplorerOp } from './fileExplorerUndoRedo'
@@ -340,9 +340,10 @@ export function useFileExplorerDragDrop({
         // not the React drop handler. We only clear native drag visual state
         // here; the actual import is triggered from onFileDrop.
         clearNativeDragState()
-        const sourcePath = e.dataTransfer.getData(WORKSPACE_FILE_PATH_MIME)
-        if (sourcePath && worktreePath) {
-          handleMoveDrop(sourcePath, worktreePath)
+        if (worktreePath) {
+          for (const sourcePath of getWorkspaceFileDragPaths(e.dataTransfer)) {
+            handleMoveDrop(sourcePath, worktreePath)
+          }
         }
       },
       [worktreePath, handleMoveDrop, stopDragEdgeScroll, clearNativeDragState]

--- a/src/renderer/src/components/right-sidebar/useFileExplorerImport.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerImport.ts
@@ -1,5 +1,4 @@
 import { useEffect, useRef } from 'react'
-import type { Dispatch, SetStateAction } from 'react'
 import { toast } from 'sonner'
 import { getConnectionId } from '@/lib/connection-context'
 import { extractIpcErrorMessage } from '@/lib/ipc-error'
@@ -11,7 +10,7 @@ type UseFileExplorerImportParams = {
   activeWorktreeId: string | null
   refreshDir: (dirPath: string) => Promise<void>
   clearNativeDragState: () => void
-  setSelectedPath: Dispatch<SetStateAction<string | null>>
+  setSelectedPath: (path: string | null) => void
 }
 
 /**

--- a/src/renderer/src/components/right-sidebar/useFileExplorerKeys.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerKeys.ts
@@ -58,8 +58,10 @@ export function useFileExplorerKeys(opts: {
   inlineInput: InlineInput | null
   selectedPaths: Set<string>
   selectedNode: TreeNode | null
+  selectedNodes: TreeNode[]
   startRename: (node: TreeNode) => void
   requestDelete: (node: TreeNode) => void
+  requestDeleteAll: (nodes: TreeNode[]) => void
 }): void {
   const rightSidebarOpen = useAppStore((s) => s.rightSidebarOpen)
   const rightSidebarTab = useAppStore((s) => s.rightSidebarTab)
@@ -73,10 +75,14 @@ export function useFileExplorerKeys(opts: {
   selectedPathsRef.current = opts.selectedPaths
   const selectedNodeRef = useRef(opts.selectedNode)
   selectedNodeRef.current = opts.selectedNode
+  const selectedNodesRef = useRef(opts.selectedNodes)
+  selectedNodesRef.current = opts.selectedNodes
   const startRenameRef = useRef(opts.startRename)
   startRenameRef.current = opts.startRename
   const requestDeleteRef = useRef(opts.requestDelete)
   requestDeleteRef.current = opts.requestDelete
+  const requestDeleteAllRef = useRef(opts.requestDeleteAll)
+  requestDeleteAllRef.current = opts.requestDeleteAll
 
   useEffect(() => {
     // Find the node that the focused button represents (for bare-key shortcuts).
@@ -151,7 +157,9 @@ export function useFileExplorerKeys(opts: {
             : matchesLegacyFileDeleteShortcut(e)
           if (wantsDelete) {
             e.preventDefault()
-            requestDeleteRef.current(node)
+            requestDeleteAllRef.current(
+              selectedNodesRef.current.length > 1 ? selectedNodesRef.current : [node]
+            )
             return
           }
         }

--- a/src/renderer/src/components/right-sidebar/useFileExplorerReveal.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerReveal.ts
@@ -21,7 +21,7 @@ type UseFileExplorerRevealParams = {
   rowsByPath: Map<string, TreeNode>
   flatRows: TreeNode[]
   loadDir: (dirPath: string, depth: number, options?: { force?: boolean }) => Promise<boolean>
-  setSelectedPath: Dispatch<SetStateAction<string | null>>
+  setSelectedPath: (path: string | null) => void
   setFlashingPath: Dispatch<SetStateAction<string | null>>
   flashTimeoutRef: RefObject<number | null>
   virtualizer: Virtualizer<HTMLDivElement, Element>

--- a/src/renderer/src/components/right-sidebar/useFileExplorerRowDrag.test.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerRowDrag.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import {
+  decodeWorkspaceFilePaths,
+  encodeWorkspaceFilePaths,
+  getWorkspaceFileDragPaths,
+  WORKSPACE_FILE_PATH_MIME,
+  WORKSPACE_FILE_PATHS_MIME
+} from '@/lib/workspace-file-drag'
+
+describe('encodeWorkspaceFilePaths / decodeWorkspaceFilePaths', () => {
+  it('encodes and decodes a single path as a plain string', () => {
+    const encoded = encodeWorkspaceFilePaths(['/repo/a.ts'])
+    expect(encoded).toBe('/repo/a.ts')
+    expect(decodeWorkspaceFilePaths(encoded)).toEqual(['/repo/a.ts'])
+  })
+
+  it('encodes and decodes multiple paths as a JSON array', () => {
+    const paths = ['/repo/a.ts', '/repo/b.ts', '/repo/c.ts']
+    const encoded = encodeWorkspaceFilePaths(paths)
+    expect(decodeWorkspaceFilePaths(encoded)).toEqual(paths)
+  })
+
+  it('round-trips any number of paths correctly', () => {
+    const paths = ['/a', '/b', '/c', '/d', '/e']
+    expect(decodeWorkspaceFilePaths(encodeWorkspaceFilePaths(paths))).toEqual(paths)
+  })
+})
+
+describe('decodeWorkspaceFilePaths', () => {
+  it('returns empty array for an empty string', () => {
+    expect(decodeWorkspaceFilePaths('')).toEqual([])
+  })
+
+  it('returns the plain string wrapped in an array when not JSON', () => {
+    expect(decodeWorkspaceFilePaths('/repo/a.ts')).toEqual(['/repo/a.ts'])
+  })
+
+  it('filters out non-string entries from a JSON array', () => {
+    expect(decodeWorkspaceFilePaths(JSON.stringify(['/repo/a.ts', 42, null]))).toEqual([
+      '/repo/a.ts'
+    ])
+  })
+})
+
+describe('getWorkspaceFileDragPaths', () => {
+  it('falls back to the legacy single-path MIME', () => {
+    expect(
+      getWorkspaceFileDragPaths({
+        getData: (type) => (type === WORKSPACE_FILE_PATH_MIME ? '/repo/a.ts' : '')
+      })
+    ).toEqual(['/repo/a.ts'])
+  })
+
+  it('prefers the multi-path MIME when present', () => {
+    const paths = ['/repo/a.ts', '/repo/b.ts']
+    expect(
+      getWorkspaceFileDragPaths({
+        getData: (type) =>
+          type === WORKSPACE_FILE_PATHS_MIME
+            ? encodeWorkspaceFilePaths(paths)
+            : type === WORKSPACE_FILE_PATH_MIME
+              ? '/repo/a.ts'
+              : ''
+      })
+    ).toEqual(paths)
+  })
+})

--- a/src/renderer/src/components/right-sidebar/useFileExplorerRowDrag.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerRowDrag.ts
@@ -1,5 +1,5 @@
 import React, { useCallback, useRef } from 'react'
-import { WORKSPACE_FILE_PATH_MIME } from '@/lib/workspace-file-drag'
+import { getWorkspaceFileDragPaths, WORKSPACE_FILE_PATH_MIME } from '@/lib/workspace-file-drag'
 
 const DRAG_EXPAND_DELAY_MS = 500
 
@@ -148,8 +148,7 @@ export function useFileExplorerRowDrag({
       clearNativeExpandTimer()
       onDragTargetChange(null)
       onNativeDragTargetChange(null)
-      const sourcePath = e.dataTransfer.getData(WORKSPACE_FILE_PATH_MIME)
-      if (sourcePath) {
+      for (const sourcePath of getWorkspaceFileDragPaths(e.dataTransfer)) {
         onMoveDrop(sourcePath, rowDropDir)
       }
       // Why: native Files drops are handled by the preload-relayed IPC event,

--- a/src/renderer/src/components/right-sidebar/useFileExplorerSelection.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerSelection.ts
@@ -15,6 +15,7 @@ type UseFileExplorerSelectionResult = {
   selectedPath: string | null
   selectedPaths: Set<string>
   setSingleSelectedPath: React.Dispatch<React.SetStateAction<string | null>>
+  setSelectedPaths: (paths: Set<string>) => void
   resetSelection: () => void
   selectRowWithModifiers: (
     node: TreeNode,
@@ -51,6 +52,17 @@ export function useFileExplorerSelection(
 
   const resetSelection = useCallback(() => {
     setSelectionState(createEmptyFileExplorerSelection())
+  }, [])
+
+  const setSelectedPaths = useCallback((paths: Set<string>) => {
+    setSelectionState((prev) => {
+      const nextActive = paths.has(prev.activePath ?? '')
+        ? prev.activePath
+        : paths.size > 0
+          ? [...paths][0]
+          : null
+      return { activePath: nextActive, anchorPath: nextActive, selectedPaths: paths }
+    })
   }, [])
 
   const selectRowWithModifiers = useCallback(
@@ -103,6 +115,7 @@ export function useFileExplorerSelection(
     selectedPath: selectionState.activePath,
     selectedPaths: selectionState.selectedPaths,
     setSingleSelectedPath,
+    setSelectedPaths,
     resetSelection,
     selectRowWithModifiers,
     preserveSelectionForContextMenu,

--- a/src/renderer/src/lib/workspace-file-drag.ts
+++ b/src/renderer/src/lib/workspace-file-drag.ts
@@ -1,1 +1,29 @@
 export const WORKSPACE_FILE_PATH_MIME = 'text/x-orca-file-path'
+export const WORKSPACE_FILE_PATHS_MIME = 'text/x-orca-file-paths'
+
+export function encodeWorkspaceFilePaths(paths: readonly string[]): string {
+  return paths.length === 1 ? paths[0] : JSON.stringify(paths)
+}
+
+export function decodeWorkspaceFilePaths(data: string): string[] {
+  if (!data) {
+    return []
+  }
+  try {
+    const parsed: unknown = JSON.parse(data)
+    if (Array.isArray(parsed)) {
+      return parsed.filter((value): value is string => typeof value === 'string')
+    }
+  } catch {
+    // Plain path string from legacy single-file drags.
+  }
+  return [data]
+}
+
+export function getWorkspaceFileDragPaths(dataTransfer: Pick<DataTransfer, 'getData'>): string[] {
+  const multiPathData = dataTransfer.getData(WORKSPACE_FILE_PATHS_MIME)
+  if (multiPathData) {
+    return decodeWorkspaceFilePaths(multiPathData)
+  }
+  return decodeWorkspaceFilePaths(dataTransfer.getData(WORKSPACE_FILE_PATH_MIME))
+}


### PR DESCRIPTION
## Summary

Fixes #1810

Replace single-file selection with a proper multi-select model (selectedPaths: Set<string> + anchorPath)
Add Shift+click range select and Cmd/Ctrl+click toggle select to the file explorer
Wire batch operations (delete, drag-and-drop) to work across all selected files
Show a multi-file drag ghost that matches the real row appearance

## Screenshots


https://github.com/user-attachments/assets/73b5563c-ed73-4e39-9d06-548c73e35b1f


## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

## Checklist
 - [x] Shift+click selects an inclusive range from the anchor to the clicked row
 - [x] Cmd+click (Mac) / Ctrl+click (Linux/Windows) toggles individual files in/out of the selection
 - [x] Plain click clears to a single selection (existing behavior unchanged)
 - [x] Dragging any selected file drags the entire selection
 - [x] The drag ghost shows up to 5 filenames and a +N more row, styled to match real file rows
 - [x] Delete (keyboard shortcut) deletes all selected files at once
 - [x] Tests added for getExplorerSelectionRange and encodeDragPaths/decodeDragPaths

## Test plan
 - Shift+click a range of files → all rows between anchor and click highlight
 - Cmd/Ctrl+click individual files → each toggles independently
 - Drag a file while multiple are selected → all move to the drop target
 - Press Delete with multiple files selected → confirmation and batch removal
 - Single-file behavior (click to open, double-click to pin, right-click menu) unchanged

