### PR TITLE
Fix workspace filter reset spacing

### DIFF
--- a/config/electron-builder.config.cjs
+++ b/config/electron-builder.config.cjs
@@ -152,9 +152,6 @@ module.exports = {
   dmg: {
     artifactName: 'orca-macos-${arch}.${ext}'
   },
-  deb: {
-    depends: ['python3', 'python3-gi', 'gir1.2-atspi-2.0', 'at-spi2-core', 'xdotool', 'xclip']
-  },
   linux: {
     // Why: Ubuntu 26 ships GNOME Orca as the `orca` package and /usr/bin/orca.
     // The Linux installer should not claim those system package/file names.
@@ -182,7 +179,8 @@ module.exports = {
   },
   deb: {
     packageName: 'orca-ide',
-    artifactName: 'orca-ide_${version}_${arch}.${ext}'
+    artifactName: 'orca-ide_${version}_${arch}.${ext}',
+    depends: ['python3', 'python3-gi', 'gir1.2-atspi-2.0', 'at-spi2-core', 'xdotool', 'xclip']
   },
   // Why: must be true so that electron-builder rebuilds native modules
   // (node-pty) for each target architecture when producing dual-arch macOS

--- a/src/renderer/src/components/sidebar/SidebarFilter.tsx
+++ b/src/renderer/src/components/sidebar/SidebarFilter.tsx
@@ -118,15 +118,14 @@ const SidebarFilter = React.memo(function SidebarFilter() {
       <PopoverContent align="end" className="w-72 p-0">
         <div className="flex items-center justify-between gap-2 px-3 py-2">
           <span className="text-xs font-medium text-foreground">Filters</span>
-          <div className="flex items-center gap-1">
+          <div className="flex items-center gap-2">
             {hasAnyFilter ? (
               <button
                 type="button"
                 onClick={clearAll}
-                className="inline-flex items-center gap-1 text-[11px] text-muted-foreground hover:text-foreground"
+                className="inline-flex h-6 items-center rounded-md bg-accent/70 px-2 text-[11px] text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
               >
-                <X className="size-3" />
-                Clear all
+                Reset filters
               </button>
             ) : null}
             <Tooltip>


### PR DESCRIPTION
## Summary
- replace the workspace filter header reset affordance with the option B reset chip
- keep the close icon separated from the reset action
- merge duplicate Linux deb config keys so lint passes

## Validation
- pnpm typecheck
- pnpm lint
- Electron validation via playwright-cli CDP on port 9333: confirmed Reset filters chip and Close filters button render separately with an 8px gap