### PR TITLE
docs: pin Android mobile release link

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Control your agents from your phone.
 </p>
 
 - **iOS:** [Download from App Store](https://apps.apple.com/us/app/orca-ide/id6766130217)
-- **Android:** [Download from GH release (find latest mobile)](https://github.com/stablyai/orca/releases)
+- **Android:** [Download from GH release](https://github.com/stablyai/orca/releases/tag/mobile-v0.0.7)
 
 ---
 


### PR DESCRIPTION
## Summary
- Update the README Android install link to point directly at the mobile-v0.0.7 release tag
- Remove the stale "find latest mobile" note from the link label

## Testing
- Not run; README-only change

Made with [Orca](https://github.com/stablyai/orca) 🐋
