### PR TITLE
Add terminal quick commands

### DIFF
--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -46,6 +46,7 @@ import { parseWorkspaceSession } from '../shared/workspace-session-schema'
 import { pruneLocalTerminalScrollbackBuffers } from '../shared/workspace-session-terminal-buffers'
 import { pruneWorkspaceSessionBrowserHistory } from '../shared/workspace-session-browser-history'
 import { getRepoIdFromWorktreeId } from '../shared/worktree-id'
+import { normalizeTerminalQuickCommands } from '../shared/terminal-quick-commands'
 
 function encrypt(plaintext: string): string {
   if (!plaintext || !safeStorage.isEncryptionAvailable()) {
@@ -318,6 +319,9 @@ export class Store {
             terminalMacOptionAsAltMigrated: true,
             floatingTerminalEnabled: migratedFloatingTerminalEnabled,
             floatingTerminalDefaultedForAllUsers: true,
+            terminalQuickCommands: normalizeTerminalQuickCommands(
+              parsed.settings?.terminalQuickCommands
+            ),
             notifications: {
               ...getDefaultNotificationSettings(),
               ...parsed.settings?.notifications
@@ -1009,6 +1013,12 @@ export class Store {
   }
 
   updateSettings(updates: Partial<GlobalSettings>): GlobalSettings {
+    const sanitizedUpdates = { ...updates }
+    if ('terminalQuickCommands' in updates) {
+      sanitizedUpdates.terminalQuickCommands = normalizeTerminalQuickCommands(
+        updates.terminalQuickCommands
+      )
+    }
     // Why: `telemetry` is deep-merged for the same reason `notifications` is —
     // partial updates from the Privacy pane / consent flow (e.g., flipping
     // only `optedIn`) must not clobber sibling fields like `installId` or
@@ -1016,15 +1026,15 @@ export class Store {
     // synthesize a `telemetry` key on the result when at least one side has
     // one.
     const mergedTelemetry =
-      updates.telemetry !== undefined
-        ? { ...this.state.settings.telemetry, ...updates.telemetry }
+      sanitizedUpdates.telemetry !== undefined
+        ? { ...this.state.settings.telemetry, ...sanitizedUpdates.telemetry }
         : this.state.settings.telemetry
     this.state.settings = {
       ...this.state.settings,
-      ...updates,
+      ...sanitizedUpdates,
       notifications: {
         ...this.state.settings.notifications,
-        ...updates.notifications
+        ...sanitizedUpdates.notifications
       },
       ...(mergedTelemetry !== undefined ? { telemetry: mergedTelemetry } : {})
     }

--- a/src/renderer/src/components/settings/TerminalPane.tsx
+++ b/src/renderer/src/components/settings/TerminalPane.tsx
@@ -44,6 +44,7 @@ import {
   TERMINAL_MAC_OPTION_SEARCH_ENTRIES,
   TERMINAL_FLOATING_SEARCH_ENTRIES,
   TERMINAL_PANE_STYLE_SEARCH_ENTRIES,
+  TERMINAL_QUICK_COMMANDS_SEARCH_ENTRIES,
   TERMINAL_RENDERING_SEARCH_ENTRIES,
   TERMINAL_SETUP_SCRIPT_SEARCH_ENTRIES,
   TERMINAL_TYPOGRAPHY_SEARCH_ENTRIES,
@@ -61,6 +62,7 @@ import { TerminalWindowSection } from './TerminalWindowSection'
 import { GhosttyImportModal } from './GhosttyImportModal'
 import type { UseGhosttyImportReturn } from './useGhosttyImport'
 import { ManageSessionsSection } from './ManageSessionsSection'
+import { TerminalQuickCommandsSection } from './TerminalQuickCommandsSection'
 
 type TerminalPaneProps = {
   settings: GlobalSettings
@@ -266,6 +268,28 @@ export function TerminalPane({
               The keyboard shortcut works regardless of where the toggle is shown.
             </p>
           </div>
+        </SearchableSetting>
+      </section>
+    ) : null,
+    matchesSettingsSearch(searchQuery, TERMINAL_QUICK_COMMANDS_SEARCH_ENTRIES) ? (
+      <section key="quick-commands" className="space-y-4">
+        <div className="space-y-1">
+          <h3 className="text-sm font-semibold">Quick Commands</h3>
+          <p className="text-xs text-muted-foreground">
+            Save terminal input snippets for the terminal right-click menu.
+          </p>
+        </div>
+
+        <SearchableSetting
+          title="Quick Commands"
+          description="Create, edit, and remove terminal command snippets for the right-click menu."
+          keywords={['terminal', 'command', 'snippet', 'quick command', 'send', 'context menu']}
+          className="space-y-3"
+        >
+          <TerminalQuickCommandsSection
+            commands={settings.terminalQuickCommands ?? []}
+            onChange={(terminalQuickCommands) => updateSettings({ terminalQuickCommands })}
+          />
         </SearchableSetting>
       </section>
     ) : null,

--- a/src/renderer/src/components/settings/TerminalQuickCommandsSection.tsx
+++ b/src/renderer/src/components/settings/TerminalQuickCommandsSection.tsx
@@ -1,0 +1,218 @@
+import { useEffect, useState } from 'react'
+import { Pencil, Plus, Trash2 } from 'lucide-react'
+import type { TerminalQuickCommand } from '../../../../shared/types'
+import { Button } from '../ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '../ui/dialog'
+import { Input } from '../ui/input'
+import { Label } from '../ui/label'
+
+type TerminalQuickCommandsSectionProps = {
+  commands: TerminalQuickCommand[]
+  onChange: (commands: TerminalQuickCommand[]) => void
+}
+
+type EditorState =
+  | {
+      mode: 'add'
+      command: TerminalQuickCommand
+    }
+  | {
+      mode: 'edit'
+      command: TerminalQuickCommand
+    }
+  | null
+
+function createQuickCommand(): TerminalQuickCommand {
+  const randomId =
+    typeof crypto !== 'undefined' && 'randomUUID' in crypto
+      ? crypto.randomUUID()
+      : `${Date.now()}-${Math.random().toString(16).slice(2)}`
+  return {
+    id: `quick-command-${randomId}`,
+    label: '',
+    command: '',
+    appendEnter: true
+  }
+}
+
+export function TerminalQuickCommandsSection({
+  commands,
+  onChange
+}: TerminalQuickCommandsSectionProps): React.JSX.Element {
+  const [editor, setEditor] = useState<EditorState>(null)
+  const [draft, setDraft] = useState<TerminalQuickCommand>(createQuickCommand)
+
+  useEffect(() => {
+    if (editor) {
+      setDraft({ ...editor.command })
+    }
+  }, [editor])
+
+  const saveDraft = (): void => {
+    const next = {
+      ...draft,
+      label: draft.label.trim(),
+      command: draft.command.trimEnd()
+    }
+    if (!next.label || !next.command) {
+      return
+    }
+    if (editor?.mode === 'edit') {
+      onChange(commands.map((command) => (command.id === next.id ? next : command)))
+    } else {
+      onChange([...commands, next])
+    }
+    setEditor(null)
+  }
+
+  const removeCommand = (id: string): void => {
+    onChange(commands.filter((command) => command.id !== id))
+  }
+
+  const canSave = draft.label.trim().length > 0 && draft.command.trimEnd().length > 0
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between gap-3">
+        <div className="space-y-1">
+          <Label>Saved Commands</Label>
+          <p className="text-xs text-muted-foreground">
+            Commands are sent as plain terminal input to the active pane.
+          </p>
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => setEditor({ mode: 'add', command: createQuickCommand() })}
+        >
+          <Plus />
+          Add Command
+        </Button>
+      </div>
+
+      <div className="overflow-hidden rounded-lg border border-border/50">
+        {commands.length === 0 ? (
+          <div className="px-3 py-6 text-sm text-muted-foreground">No quick commands saved.</div>
+        ) : (
+          <div className="divide-y divide-border/50">
+            {commands.map((command) => (
+              <div key={command.id} className="flex items-center gap-3 px-3 py-2">
+                <div className="min-w-0 flex-1">
+                  <div className="truncate text-sm font-medium">{command.label || 'Untitled'}</div>
+                  <div className="truncate font-mono text-xs text-muted-foreground">
+                    {command.command || 'No command text'}
+                  </div>
+                </div>
+                <div className="shrink-0 text-[11px] text-muted-foreground">
+                  {command.appendEnter ? 'Enter' : 'Insert'}
+                </div>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  aria-label={`Edit ${command.label || 'quick command'}`}
+                  onClick={() => setEditor({ mode: 'edit', command })}
+                >
+                  <Pencil />
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  aria-label={`Remove ${command.label || 'quick command'}`}
+                  onClick={() => removeCommand(command.id)}
+                  className="text-muted-foreground hover:text-destructive"
+                >
+                  <Trash2 />
+                </Button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <Dialog open={editor !== null} onOpenChange={(open) => !open && setEditor(null)}>
+        <DialogContent className="max-w-md sm:max-w-md" showCloseButton={false}>
+          <DialogHeader>
+            <DialogTitle className="text-sm">
+              {editor?.mode === 'edit' ? 'Edit Quick Command' : 'Add Quick Command'}
+            </DialogTitle>
+            <DialogDescription className="text-xs">
+              Save terminal input text for the context menu.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label>Label</Label>
+              <Input
+                value={draft.label}
+                onChange={(event) =>
+                  setDraft((current) => ({ ...current, label: event.target.value }))
+                }
+                placeholder="Restart server"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label>Command Text</Label>
+              <textarea
+                value={draft.command}
+                onChange={(event) =>
+                  setDraft((current) => ({ ...current, command: event.target.value }))
+                }
+                placeholder="npm run dev"
+                rows={4}
+                className="min-h-24 w-full resize-y rounded-md border border-input bg-transparent px-3 py-2 text-sm font-mono shadow-xs outline-none transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
+              />
+            </div>
+
+            <div className="flex items-center justify-between gap-4 rounded-md border border-border/50 px-3 py-2">
+              <div className="space-y-0.5">
+                <div className="text-sm font-medium">Append Enter</div>
+                <div className="text-xs text-muted-foreground">
+                  Submit immediately instead of only inserting text.
+                </div>
+              </div>
+              <button
+                type="button"
+                role="switch"
+                aria-checked={draft.appendEnter}
+                aria-label="Toggle append Enter"
+                onClick={() =>
+                  setDraft((current) => ({ ...current, appendEnter: !current.appendEnter }))
+                }
+                className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent transition-colors ${
+                  draft.appendEnter ? 'bg-foreground' : 'bg-muted-foreground/30'
+                }`}
+              >
+                <span
+                  className={`pointer-events-none block size-3.5 rounded-full bg-background shadow-sm transition-transform ${
+                    draft.appendEnter ? 'translate-x-4' : 'translate-x-0.5'
+                  }`}
+                />
+              </button>
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => setEditor(null)}>
+              Cancel
+            </Button>
+            <Button type="button" onClick={saveDraft} disabled={!canSave}>
+              Save
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/src/renderer/src/components/settings/terminal-search.ts
+++ b/src/renderer/src/components/settings/terminal-search.ts
@@ -95,6 +95,14 @@ export const TERMINAL_FLOATING_SEARCH_ENTRIES: SettingsSearchEntry[] = [
   }
 ]
 
+export const TERMINAL_QUICK_COMMANDS_SEARCH_ENTRIES: SettingsSearchEntry[] = [
+  {
+    title: 'Quick Commands',
+    description: 'Saved terminal command snippets available from the terminal right-click menu.',
+    keywords: ['terminal', 'command', 'snippet', 'quick command', 'send', 'context menu']
+  }
+]
+
 export const TERMINAL_PANE_STYLE_SEARCH_ENTRIES: SettingsSearchEntry[] = [
   {
     title: 'Inactive Pane Opacity',
@@ -293,6 +301,7 @@ export function getTerminalPaneSearchEntries(platform: {
   return [
     ...TERMINAL_TYPOGRAPHY_SEARCH_ENTRIES,
     ...TERMINAL_FLOATING_SEARCH_ENTRIES,
+    ...TERMINAL_QUICK_COMMANDS_SEARCH_ENTRIES,
     ...TERMINAL_RENDERING_SEARCH_ENTRIES,
     ...TERMINAL_CURSOR_SEARCH_ENTRIES,
     ...TERMINAL_PANE_STYLE_SEARCH_ENTRIES,

--- a/src/renderer/src/components/terminal-pane/TerminalContextMenu.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalContextMenu.tsx
@@ -7,6 +7,7 @@ import {
   PanelBottomClose,
   PanelRightClose,
   Pencil,
+  SquareTerminal,
   X
 } from 'lucide-react'
 import {
@@ -15,9 +16,13 @@ import {
   DropdownMenuItem,
   DropdownMenuSeparator,
   DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
 import { shouldIgnoreTerminalMenuPointerDownOutside } from './terminal-context-menu-dismiss'
+import type { TerminalQuickCommand } from '../../../../shared/types'
 
 type TerminalContextMenuProps = {
   open: boolean
@@ -33,6 +38,8 @@ type TerminalContextMenuProps = {
   onSplitDown: () => void
   onClosePane: () => void
   onClearScreen: () => void
+  quickCommands: TerminalQuickCommand[]
+  onQuickCommand: (command: TerminalQuickCommand) => void
   onToggleExpand: () => void
   onSetTitle: () => void
 }
@@ -51,6 +58,8 @@ export default function TerminalContextMenu({
   onSplitDown,
   onClosePane,
   onClearScreen,
+  quickCommands,
+  onQuickCommand,
   onToggleExpand,
   onSetTitle
 }: TerminalContextMenuProps): React.JSX.Element {
@@ -112,6 +121,24 @@ export default function TerminalContextMenu({
           Paste
           <DropdownMenuShortcut>{mod}V</DropdownMenuShortcut>
         </DropdownMenuItem>
+        {quickCommands.length > 0 ? (
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger>
+              <SquareTerminal />
+              Quick Commands
+            </DropdownMenuSubTrigger>
+            <DropdownMenuSubContent className="w-60">
+              {quickCommands.map((command) => (
+                <DropdownMenuItem key={command.id} onSelect={() => onQuickCommand(command)}>
+                  <span className="truncate">{command.label}</span>
+                  {!command.appendEnter ? (
+                    <DropdownMenuShortcut className="shrink-0">Insert</DropdownMenuShortcut>
+                  ) : null}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
+        ) : null}
         <DropdownMenuSeparator />
         <DropdownMenuItem onSelect={onSplitRight}>
           <PanelRightClose />

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -1132,6 +1132,10 @@ export default function TerminalPane({
         onSplitDown={contextMenu.onSplitDown}
         onClosePane={contextMenu.onClosePane}
         onClearScreen={contextMenu.onClearScreen}
+        quickCommands={(settings?.terminalQuickCommands ?? []).filter(
+          (command) => command.label.trim() && command.command.trimEnd()
+        )}
+        onQuickCommand={contextMenu.onQuickCommand}
         onToggleExpand={contextMenu.onToggleExpand}
         onSetTitle={contextMenu.onSetTitle}
       />

--- a/src/renderer/src/components/terminal-pane/terminal-quick-command-dispatch.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-quick-command-dispatch.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from 'vitest'
+import { sendTerminalQuickCommandToPane } from './terminal-quick-command-dispatch'
+
+describe('sendTerminalQuickCommandToPane', () => {
+  it('writes the formatted command to the PTY transport and refocuses the terminal', () => {
+    const sendInput = vi.fn(() => true)
+    const focus = vi.fn()
+
+    const sent = sendTerminalQuickCommandToPane({
+      command: {
+        id: 'status',
+        label: 'Status',
+        command: 'git status',
+        appendEnter: true
+      },
+      pane: { terminal: { focus } },
+      transport: { sendInput }
+    })
+
+    expect(sent).toBe(true)
+    expect(sendInput).toHaveBeenCalledWith('git status\r')
+    expect(focus).toHaveBeenCalledOnce()
+  })
+
+  it('does not focus the terminal when no connected transport accepts input', () => {
+    const sendInput = vi.fn(() => false)
+    const focus = vi.fn()
+
+    const sent = sendTerminalQuickCommandToPane({
+      command: {
+        id: 'draft',
+        label: 'Draft',
+        command: 'npm test',
+        appendEnter: false
+      },
+      pane: { terminal: { focus } },
+      transport: { sendInput }
+    })
+
+    expect(sent).toBe(false)
+    expect(sendInput).toHaveBeenCalledWith('npm test')
+    expect(focus).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-quick-command-dispatch.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-quick-command-dispatch.ts
@@ -1,0 +1,32 @@
+import type { TerminalQuickCommand } from '../../../../shared/types'
+import { buildTerminalQuickCommandInput } from '../../../../shared/terminal-quick-commands'
+
+type QuickCommandPane = {
+  terminal: {
+    focus: () => void
+  }
+}
+
+type QuickCommandTransport = {
+  sendInput: (data: string) => boolean
+}
+
+export function sendTerminalQuickCommandToPane({
+  command,
+  pane,
+  transport
+}: {
+  command: TerminalQuickCommand
+  pane: QuickCommandPane
+  transport: QuickCommandTransport | null | undefined
+}): boolean {
+  if (!transport) {
+    return false
+  }
+
+  const sent = transport.sendInput(buildTerminalQuickCommandInput(command))
+  if (sent) {
+    pane.terminal.focus()
+  }
+  return sent
+}

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
@@ -2,6 +2,8 @@ import { useEffect, useRef, useState } from 'react'
 import type { ManagedPane, PaneManager } from '@/lib/pane-manager/pane-manager'
 import type { PtyTransport } from './pty-transport'
 import { resolveSplitCwd, type PaneCwdMap } from './resolve-split-cwd'
+import type { TerminalQuickCommand } from '../../../../shared/types'
+import { sendTerminalQuickCommandToPane } from './terminal-quick-command-dispatch'
 
 const CLOSE_ALL_CONTEXT_MENUS_EVENT = 'orca-close-all-context-menus'
 
@@ -30,6 +32,7 @@ type TerminalMenuState = {
   onSplitDown: () => void
   onClosePane: () => void
   onClearScreen: () => void
+  onQuickCommand: (command: TerminalQuickCommand) => void
   onToggleExpand: () => void
   onSetTitle: () => void
 }
@@ -159,6 +162,18 @@ export function useTerminalPaneContextMenu({
     }
   }
 
+  const onQuickCommand = (command: TerminalQuickCommand): void => {
+    const pane = resolveMenuPane()
+    if (!pane) {
+      return
+    }
+    sendTerminalQuickCommandToPane({
+      command,
+      pane,
+      transport: paneTransportsRef.current.get(pane.id)
+    })
+  }
+
   const onToggleExpand = (): void => {
     const pane = resolveMenuPane()
     if (pane) {
@@ -228,6 +243,7 @@ export function useTerminalPaneContextMenu({
     onSplitDown,
     onClosePane,
     onClearScreen,
+    onQuickCommand,
     onToggleExpand,
     onSetTitle: handleSetTitle
   }

--- a/src/renderer/src/components/ui/dropdown-menu.tsx
+++ b/src/renderer/src/components/ui/dropdown-menu.tsx
@@ -205,17 +205,19 @@ function DropdownMenuSubContent({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
   return (
-    <DropdownMenuPrimitive.SubContent
-      data-slot="dropdown-menu-sub-content"
-      className={cn(
-        'z-50 min-w-[11rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-[11px] border border-black/14 bg-[rgba(255,255,255,0.82)] p-1 text-black dark:text-white shadow-[0_16px_36px_rgba(0,0,0,0.24),inset_0_1px_0_rgba(255,255,255,0.14)] backdrop-blur-2xl dark:border-white/14 dark:bg-[rgba(0,0,0,0.72)] dark:shadow-[0_20px_44px_rgba(0,0,0,0.42),inset_0_1px_0_rgba(255,255,255,0.04)] data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
-        className
-      )}
-      // Why: same no-drag fix as DropdownMenuContent — titlebar drag region
-      // would otherwise capture clicks when submenu overlaps it.
-      style={{ ...style, WebkitAppRegion: 'no-drag' } as React.CSSProperties}
-      {...props}
-    />
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.SubContent
+        data-slot="dropdown-menu-sub-content"
+        className={cn(
+          'z-50 min-w-[11rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-[11px] border border-black/14 bg-[rgba(255,255,255,0.82)] p-1 text-black dark:text-white shadow-[0_16px_36px_rgba(0,0,0,0.24),inset_0_1px_0_rgba(255,255,255,0.14)] backdrop-blur-2xl dark:border-white/14 dark:bg-[rgba(0,0,0,0.72)] dark:shadow-[0_20px_44px_rgba(0,0,0,0.42),inset_0_1px_0_rgba(255,255,255,0.04)] data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
+          className
+        )}
+        // Why: same no-drag fix as DropdownMenuContent — titlebar drag region
+        // would otherwise capture clicks when submenu overlaps it.
+        style={{ ...style, WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
   )
 }
 

--- a/src/renderer/src/store/slices/settings.ts
+++ b/src/renderer/src/store/slices/settings.ts
@@ -1,6 +1,7 @@
 import type { StateCreator } from 'zustand'
 import type { AppState } from '../types'
 import type { GlobalSettings } from '../../../../shared/types'
+import { normalizeTerminalQuickCommands } from '../../../../shared/terminal-quick-commands'
 
 export type SettingsSlice = {
   settings: GlobalSettings | null
@@ -26,7 +27,13 @@ export const createSettingsSlice: StateCreator<AppState, [], [], SettingsSlice> 
 
   updateSettings: async (updates) => {
     try {
-      await window.api.settings.set(updates)
+      const sanitizedUpdates = { ...updates }
+      if ('terminalQuickCommands' in updates) {
+        sanitizedUpdates.terminalQuickCommands = normalizeTerminalQuickCommands(
+          updates.terminalQuickCommands
+        )
+      }
+      await window.api.settings.set(sanitizedUpdates)
       set((s) => {
         if (!s.settings) {
           return { settings: null }
@@ -40,16 +47,16 @@ export const createSettingsSlice: StateCreator<AppState, [], [], SettingsSlice> 
         // the spread would produce an empty object and we'd materialize a
         // telemetry key that shouldn't exist.
         const mergedTelemetry =
-          updates.telemetry !== undefined
-            ? { ...s.settings.telemetry, ...updates.telemetry }
+          sanitizedUpdates.telemetry !== undefined
+            ? { ...s.settings.telemetry, ...sanitizedUpdates.telemetry }
             : s.settings.telemetry
         return {
           settings: {
             ...s.settings,
-            ...updates,
+            ...sanitizedUpdates,
             notifications: {
               ...s.settings.notifications,
-              ...updates.notifications
+              ...sanitizedUpdates.notifications
             },
             ...(mergedTelemetry !== undefined ? { telemetry: mergedTelemetry } : {})
           }

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -11,6 +11,7 @@ import type {
   WorktreeCardProperty
 } from './types'
 import { DEFAULT_TERMINAL_FONT_WEIGHT } from './terminal-fonts'
+import { getDefaultTerminalQuickCommands } from './terminal-quick-commands'
 
 export const SCHEMA_VERSION = 1
 export const DEFAULT_APP_FONT_FAMILY = 'Geist'
@@ -192,6 +193,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     // is installed, with a safe fallback to the inbox Windows PowerShell.
     terminalWindowsPowerShellImplementation: 'auto',
     terminalMouseHideWhileTyping: false,
+    terminalQuickCommands: getDefaultTerminalQuickCommands(),
     // Default false: opt-in only (matches Ghostty's default). Existing users
     // on upgrade inherit this default via persistence.ts's
     // { ...defaults.settings, ...parsed.settings } merge, so enabling

--- a/src/shared/terminal-quick-commands.test.ts
+++ b/src/shared/terminal-quick-commands.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildTerminalQuickCommandInput,
+  getDefaultTerminalQuickCommands,
+  normalizeTerminalQuickCommands
+} from './terminal-quick-commands'
+
+describe('terminal quick commands', () => {
+  it('returns safe defaults when persisted settings are missing', () => {
+    expect(normalizeTerminalQuickCommands(undefined)).toEqual([])
+    expect(getDefaultTerminalQuickCommands()).toEqual([])
+  })
+
+  it('keeps an intentionally empty command list', () => {
+    expect(normalizeTerminalQuickCommands([])).toEqual([])
+  })
+
+  it('removes quick commands from the abandoned preset rollout', () => {
+    expect(
+      normalizeTerminalQuickCommands([
+        {
+          id: 'default-pwd',
+          label: 'Print Working Directory',
+          command: 'pwd',
+          appendEnter: true
+        },
+        {
+          id: 'default-git-status',
+          label: 'Git Status',
+          command: 'git status',
+          appendEnter: true
+        }
+      ])
+    ).toEqual([])
+  })
+
+  it('drops malformed entries and normalizes valid commands and drafts', () => {
+    expect(
+      normalizeTerminalQuickCommands([
+        null,
+        { id: 'status', label: '  Status  ', command: 'git status\n', appendEnter: false },
+        { id: 'empty-command', label: 'Empty', command: '   ' },
+        { id: 'status', label: 'Duplicate', command: 'pwd' },
+        { label: 'No ID', command: 'date' }
+      ])
+    ).toEqual([
+      {
+        id: 'status',
+        label: 'Status',
+        command: 'git status',
+        appendEnter: false
+      },
+      {
+        id: 'empty-command',
+        label: 'Empty',
+        command: '',
+        appendEnter: true
+      },
+      {
+        id: 'status-2',
+        label: 'Duplicate',
+        command: 'pwd',
+        appendEnter: true
+      },
+      {
+        id: 'quick-command-4',
+        label: 'No ID',
+        command: 'date',
+        appendEnter: true
+      }
+    ])
+  })
+
+  it('formats terminal input without assuming shell semantics', () => {
+    expect(
+      buildTerminalQuickCommandInput({
+        id: 'status',
+        label: 'Status',
+        command: 'git status',
+        appendEnter: true
+      })
+    ).toBe('git status\r')
+    expect(
+      buildTerminalQuickCommandInput({
+        id: 'status',
+        label: 'Status',
+        command: 'git status',
+        appendEnter: false
+      })
+    ).toBe('git status')
+  })
+})

--- a/src/shared/terminal-quick-commands.ts
+++ b/src/shared/terminal-quick-commands.ts
@@ -1,0 +1,67 @@
+import type { TerminalQuickCommand } from './types'
+
+const MAX_QUICK_COMMANDS = 40
+const MAX_QUICK_COMMAND_LABEL_LENGTH = 80
+const MAX_QUICK_COMMAND_TEXT_LENGTH = 4000
+const REMOVED_PRESET_IDS = new Set(['default-pwd', 'default-git-status'])
+
+export const DEFAULT_TERMINAL_QUICK_COMMANDS: TerminalQuickCommand[] = []
+
+export function getDefaultTerminalQuickCommands(): TerminalQuickCommand[] {
+  return DEFAULT_TERMINAL_QUICK_COMMANDS.map((command) => ({ ...command }))
+}
+
+export function normalizeTerminalQuickCommands(input: unknown): TerminalQuickCommand[] {
+  if (!Array.isArray(input)) {
+    return getDefaultTerminalQuickCommands()
+  }
+
+  const normalized: TerminalQuickCommand[] = []
+  const seenIds = new Set<string>()
+
+  for (const item of input) {
+    if (!item || typeof item !== 'object' || Array.isArray(item)) {
+      continue
+    }
+    const record = item as Record<string, unknown>
+    const rawId = typeof record.id === 'string' ? record.id.trim() : ''
+    if (REMOVED_PRESET_IDS.has(rawId)) {
+      continue
+    }
+    const hasLabel = typeof record.label === 'string'
+    const hasCommand = typeof record.command === 'string'
+    // Why: settings saves on every edit; preserve incomplete rows so a newly
+    // added command is not deleted before the user fills in the command text.
+    if (!hasLabel && !hasCommand) {
+      continue
+    }
+    const label = hasLabel ? String(record.label).trim() : ''
+    const command = hasCommand ? String(record.command).trimEnd() : ''
+
+    const idBase = rawId || `quick-command-${normalized.length + 1}`
+    let id = idBase.slice(0, MAX_QUICK_COMMAND_LABEL_LENGTH)
+    let suffix = 2
+    while (seenIds.has(id)) {
+      id = `${idBase.slice(0, MAX_QUICK_COMMAND_LABEL_LENGTH - 4)}-${suffix}`
+      suffix += 1
+    }
+    seenIds.add(id)
+
+    normalized.push({
+      id,
+      label: label.slice(0, MAX_QUICK_COMMAND_LABEL_LENGTH),
+      command: command.slice(0, MAX_QUICK_COMMAND_TEXT_LENGTH),
+      appendEnter: record.appendEnter !== false
+    })
+
+    if (normalized.length >= MAX_QUICK_COMMANDS) {
+      break
+    }
+  }
+
+  return normalized
+}
+
+export function buildTerminalQuickCommandInput(command: TerminalQuickCommand): string {
+  return command.appendEnter ? `${command.command}\r` : command.command
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1101,6 +1101,13 @@ export type TerminalColorOverrides = {
   bold?: string
 }
 
+export type TerminalQuickCommand = {
+  id: string
+  label: string
+  command: string
+  appendEnter: boolean
+}
+
 export type FloatingTerminalCwdRequest = {
   path?: string
 }
@@ -1153,6 +1160,7 @@ export type GlobalSettings = {
   terminalMouseHideWhileTyping?: boolean
   terminalWordSeparator?: string
   terminalCursorOpacity?: number
+  terminalQuickCommands?: TerminalQuickCommand[]
   windowBackgroundBlur?: boolean
   /** Why: Windows terminals conventionally use right-click as a paste gesture.
    *  The setting stays Windows-only so macOS/Linux keep their existing context


### PR DESCRIPTION
## Summary
- add settings-backed terminal quick commands with label, command text, and append-Enter behavior
- expose saved commands from the terminal right-click menu
- add a compact settings list with modal add/edit flow
- normalize persisted command data and keep defaults empty

## Validation
- pnpm vitest run --config config/vitest.config.ts src/shared/terminal-quick-commands.test.ts src/renderer/src/components/terminal-pane/terminal-quick-command-dispatch.test.ts
- pnpm exec oxlint on changed files
- pnpm run typecheck
- git diff --check
- checked this branch diff and new files for external project-name references; none found

Made with [Orca](https://github.com/stablyai/orca) 🐋
