### PR TITLE
Add Explorer refresh action

### DIFF
--- a/src/renderer/src/components/right-sidebar/FileExplorer.test.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorer.test.tsx
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from 'vitest'
+import { Loader2, RefreshCw } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { FileExplorerToolbar } from './FileExplorerToolbar'
+
+type ReactElementLike = {
+  type: unknown
+  props: Record<string, unknown>
+}
+
+function visit(node: unknown, cb: (node: ReactElementLike) => void): void {
+  if (node == null || typeof node === 'string' || typeof node === 'number') {
+    return
+  }
+  if (Array.isArray(node)) {
+    node.forEach((entry) => visit(entry, cb))
+    return
+  }
+  const element = node as ReactElementLike
+  cb(element)
+  if (element.props?.children) {
+    visit(element.props.children, cb)
+  }
+}
+
+function findRefreshButton(node: unknown): ReactElementLike {
+  let found: ReactElementLike | null = null
+  visit(node, (entry) => {
+    if (entry.type === Button && entry.props['aria-label'] === 'Refresh Explorer') {
+      found = entry
+    }
+  })
+  if (!found) {
+    throw new Error('refresh button not found')
+  }
+  return found
+}
+
+function findRepoNameLabel(node: unknown, repoName: string): ReactElementLike {
+  let found: ReactElementLike | null = null
+  visit(node, (entry) => {
+    if (entry.type === 'span' && entry.props.title === repoName) {
+      found = entry
+    }
+  })
+  if (!found) {
+    throw new Error('repo name label not found')
+  }
+  return found
+}
+
+function hasIcon(node: unknown, icon: unknown): boolean {
+  let found = false
+  visit(node, (entry) => {
+    if (entry.type === icon) {
+      found = true
+    }
+  })
+  return found
+}
+
+function makeRefreshState(
+  overrides: Partial<{
+    isRefreshing: boolean
+    showRefreshSpinner: boolean
+    handleRefresh: () => void
+  }> = {}
+) {
+  return {
+    isRefreshing: false,
+    showRefreshSpinner: false,
+    handleRefresh: vi.fn(),
+    ...overrides
+  }
+}
+
+describe('FileExplorerToolbar', () => {
+  it('fires the refresh action from the icon button', () => {
+    const onRefresh = vi.fn()
+    const element = FileExplorerToolbar({
+      repoName: 'orca',
+      refresh: makeRefreshState({ handleRefresh: onRefresh })
+    })
+
+    const button = findRefreshButton(element)
+    ;(button.props.onClick as () => void)()
+
+    expect(onRefresh).toHaveBeenCalledTimes(1)
+    expect(button.props.disabled).toBe(false)
+    expect(hasIcon(button, RefreshCw)).toBe(true)
+    expect(hasIcon(button, Loader2)).toBe(false)
+  })
+
+  it('shows the repo name in a truncated label', () => {
+    const repoName = 'really-long-repo-name-that-should-not-push-refresh-offscreen'
+    const element = FileExplorerToolbar({
+      repoName,
+      refresh: makeRefreshState()
+    })
+
+    const label = findRepoNameLabel(element, repoName)
+
+    expect(label.props.children).toBe(repoName)
+    expect(label.props.className).toContain('truncate')
+    expect(label.props.className).toContain('min-w-0')
+  })
+
+  it('disables the refresh button and shows a spinner while refreshing', () => {
+    const element = FileExplorerToolbar({
+      repoName: 'orca',
+      refresh: makeRefreshState({ isRefreshing: true, showRefreshSpinner: true })
+    })
+
+    const button = findRefreshButton(element)
+
+    expect(button.props.disabled).toBe(true)
+    expect(hasIcon(button, Loader2)).toBe(true)
+    expect(hasIcon(button, RefreshCw)).toBe(false)
+  })
+})

--- a/src/renderer/src/components/right-sidebar/FileExplorer.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorer.tsx
@@ -1,12 +1,13 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useVirtualizer } from '@tanstack/react-virtual'
-import { Loader2 } from 'lucide-react'
 import { useAppStore } from '@/store'
-import { useActiveWorktree } from '@/store/selectors'
-import { dirname } from '@/lib/path'
+import { useActiveWorktree, useRepoById } from '@/store/selectors'
+import { basename, dirname } from '@/lib/path'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { cn } from '@/lib/utils'
 import { FileExplorerBackgroundMenu } from './FileExplorerBackgroundMenu'
+import { FileExplorerToolbar } from './FileExplorerToolbar'
+import { FileExplorerTreeStatus } from './FileExplorerTreeStatus'
 import { FileExplorerVirtualRows } from './FileExplorerVirtualRows'
 import { splitPathSegments } from './path-tree'
 import { buildFolderStatusMap, buildStatusMap } from './status-display'
@@ -20,12 +21,14 @@ import { useFileExplorerKeys } from './useFileExplorerKeys'
 import { useFileDuplicate } from './useFileDuplicate'
 import { useFileExplorerDragDrop } from './useFileExplorerDragDrop'
 import { useFileExplorerImport } from './useFileExplorerImport'
+import { useFileExplorerManualRefresh } from './useFileExplorerManualRefresh'
 import { useFileExplorerTree } from './useFileExplorerTree'
 import { useFileExplorerWatch } from './useFileExplorerWatch'
 
 function FileExplorerInner(): React.JSX.Element {
   const activeWorktreeId = useAppStore((s) => s.activeWorktreeId)
   const activeWorktree = useActiveWorktree()
+  const activeRepo = useRepoById(activeWorktree?.repoId ?? null)
   const sshConnectedGeneration = useAppStore((s) => s.sshConnectedGeneration)
   const expandedDirs = useAppStore((s) => s.expandedDirs)
   const toggleDir = useAppStore((s) => s.toggleDir)
@@ -39,6 +42,7 @@ function FileExplorerInner(): React.JSX.Element {
   const closeFile = useAppStore((s) => s.closeFile)
 
   const worktreePath = activeWorktree?.path ?? null
+  const repoName = activeRepo?.displayName ?? (worktreePath ? basename(worktreePath) : '')
 
   const expanded = useMemo(
     () =>
@@ -58,6 +62,7 @@ function FileExplorerInner(): React.JSX.Element {
     refreshDir,
     resetAndLoad
   } = useFileExplorerTree(worktreePath, expanded, activeWorktreeId)
+  const manualRefresh = useFileExplorerManualRefresh(refreshTree)
 
   const [selectedPath, setSelectedPath] = useState<string | null>(null)
   const [flashingPath, setFlashingPath] = useState<string | null>(null)
@@ -290,9 +295,10 @@ function FileExplorerInner(): React.JSX.Element {
   return (
     <>
       <div ref={explorerShellRef} data-orca-explorer-shell className="flex h-full min-h-0 flex-col">
+        <FileExplorerToolbar repoName={repoName} refresh={manualRefresh} />
         <ScrollArea
           className={cn(
-            'h-full min-h-0',
+            'min-h-0 flex-1',
             isRootDragOver &&
               !(dragSourcePath && dirname(dragSourcePath) === worktreePath) &&
               'bg-border',
@@ -332,20 +338,12 @@ function FileExplorerInner(): React.JSX.Element {
             startNew('file', worktreePath, 0)
           }}
         >
-          {isLoading && (
-            <div className="flex items-center justify-center h-full text-[11px] text-muted-foreground">
-              <Loader2 className="size-4 animate-spin" />
-            </div>
-          )}
-          {hasError && (
-            <div className="flex h-full items-center justify-center px-4 text-center text-[11px] text-muted-foreground">
-              Could not load files for this worktree: {rootError}
-            </div>
-          )}
-          {isEmpty && (
-            <div className="flex h-full items-center justify-center text-[11px] text-muted-foreground px-4 text-center">
-              No files in this worktree
-            </div>
+          {!showTree && (
+            <FileExplorerTreeStatus
+              isLoading={isLoading}
+              error={hasError ? rootError : null}
+              isEmpty={isEmpty}
+            />
           )}
           {showTree && (
             <FileExplorerVirtualRows

--- a/src/renderer/src/components/right-sidebar/FileExplorerToolbar.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorerToolbar.tsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import { Loader2, RefreshCw } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+
+type FileExplorerToolbarProps = {
+  repoName: string
+  refresh: {
+    isRefreshing: boolean
+    showRefreshSpinner: boolean
+    handleRefresh: () => void
+  }
+}
+
+export function FileExplorerToolbar({
+  repoName,
+  refresh
+}: FileExplorerToolbarProps): React.JSX.Element {
+  return (
+    <div className="flex h-8 min-h-8 items-center gap-2 border-b border-border px-2">
+      <span
+        className="min-w-0 flex-1 truncate text-xs font-medium text-foreground"
+        title={repoName}
+      >
+        {repoName}
+      </span>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            className="text-muted-foreground hover:text-foreground"
+            aria-label="Refresh Explorer"
+            disabled={refresh.isRefreshing}
+            onClick={refresh.handleRefresh}
+          >
+            {refresh.showRefreshSpinner ? (
+              <Loader2 className="size-3 animate-spin" />
+            ) : (
+              <RefreshCw className="size-3" />
+            )}
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom" sideOffset={4}>
+          Refresh Explorer
+        </TooltipContent>
+      </Tooltip>
+    </div>
+  )
+}

--- a/src/renderer/src/components/right-sidebar/FileExplorerTreeStatus.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorerTreeStatus.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import { Loader2 } from 'lucide-react'
+
+type FileExplorerTreeStatusProps = {
+  isLoading: boolean
+  error: string | null
+  isEmpty: boolean
+}
+
+export function FileExplorerTreeStatus({
+  isLoading,
+  error,
+  isEmpty
+}: FileExplorerTreeStatusProps): React.JSX.Element | null {
+  if (isLoading) {
+    return (
+      <div className="flex h-full items-center justify-center text-[11px] text-muted-foreground">
+        <Loader2 className="size-4 animate-spin" />
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="flex h-full items-center justify-center px-4 text-center text-[11px] text-muted-foreground">
+        Could not load files for this worktree: {error}
+      </div>
+    )
+  }
+
+  if (isEmpty) {
+    return (
+      <div className="flex h-full items-center justify-center px-4 text-center text-[11px] text-muted-foreground">
+        No files in this worktree
+      </div>
+    )
+  }
+
+  return null
+}

--- a/src/renderer/src/components/right-sidebar/useFileExplorerManualRefresh.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerManualRefresh.ts
@@ -1,0 +1,56 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+const REFRESH_SPINNER_DELAY_MS = 200
+
+export function useFileExplorerManualRefresh(refreshTree: () => Promise<void>): {
+  isRefreshing: boolean
+  showRefreshSpinner: boolean
+  handleRefresh: () => void
+} {
+  const [isRefreshing, setIsRefreshing] = useState(false)
+  const [showRefreshSpinner, setShowRefreshSpinner] = useState(false)
+  const isRefreshingRef = useRef(false)
+  const spinnerTimerRef = useRef<number | null>(null)
+  const mountedRef = useRef(true)
+
+  const clearSpinnerTimer = useCallback(() => {
+    if (spinnerTimerRef.current !== null) {
+      window.clearTimeout(spinnerTimerRef.current)
+      spinnerTimerRef.current = null
+    }
+  }, [])
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+      clearSpinnerTimer()
+    }
+  }, [clearSpinnerTimer])
+
+  const handleRefresh = useCallback(() => {
+    if (isRefreshingRef.current) {
+      return
+    }
+
+    isRefreshingRef.current = true
+    setIsRefreshing(true)
+    // Why: local refreshes are usually instant, but SSH can be visibly slower.
+    // Delay the spinner so fast refreshes do not flicker.
+    spinnerTimerRef.current = window.setTimeout(
+      () => setShowRefreshSpinner(true),
+      REFRESH_SPINNER_DELAY_MS
+    )
+    void refreshTree().finally(() => {
+      clearSpinnerTimer()
+      isRefreshingRef.current = false
+      if (!mountedRef.current) {
+        return
+      }
+      setShowRefreshSpinner(false)
+      setIsRefreshing(false)
+    })
+  }, [clearSpinnerTimer, refreshTree])
+
+  return { isRefreshing, showRefreshSpinner, handleRefresh }
+}


### PR DESCRIPTION
## Summary
- add a Refresh Explorer action to the right sidebar file explorer
- show the active repo name in the Explorer toolbar with truncation for long names
- preserve cached rows during manual refresh and add focused toolbar coverage

Fixes #1577

## Tests
- pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/FileExplorer.test.tsx src/renderer/src/components/right-sidebar/useFileExplorerWatch.test.ts
- pnpm run tc:web
- pnpm typecheck
- pnpm lint (passes with existing warnings in github-project files)
