### PR TITLE
Improve source control discard flow

### DIFF
--- a/src/main/git/status.test.ts
+++ b/src/main/git/status.test.ts
@@ -27,6 +27,7 @@ vi.mock('fs', () => ({
 
 import {
   bulkStageFiles,
+  bulkDiscardChanges,
   bulkUnstageFiles,
   detectConflictOperation,
   discardChanges,
@@ -98,6 +99,7 @@ describe('discardChanges', () => {
 describe('bulk git helpers', () => {
   beforeEach(() => {
     gitExecFileAsyncMock.mockReset()
+    rmMock.mockReset()
   })
 
   it('chunks bulk stage requests to avoid oversized argv payloads', async () => {
@@ -137,6 +139,48 @@ describe('bulk git helpers', () => {
         cwd: '/repo'
       }
     )
+  })
+
+  it('discards tracked and untracked paths in bulk', async () => {
+    gitExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: 'src/file.ts\0docs/readme.md\0' })
+      .mockResolvedValueOnce({ stdout: '' })
+
+    await bulkDiscardChanges('/repo', ['src/file.ts', 'src/new-file.ts', 'docs', 'scratch'])
+
+    expect(gitExecFileAsyncMock).toHaveBeenNthCalledWith(
+      1,
+      ['ls-files', '-z', '--', 'src/file.ts', 'src/new-file.ts', 'docs', 'scratch'],
+      {
+        cwd: '/repo'
+      }
+    )
+    // Why: a pathspec is tracked if git reports either the exact path or a
+    // tracked descendant, which keeps directory pathspecs on the restore path.
+    expect(gitExecFileAsyncMock).toHaveBeenNthCalledWith(
+      2,
+      ['restore', '--worktree', '--source=HEAD', '--', 'src/file.ts', 'docs'],
+      {
+        cwd: '/repo'
+      }
+    )
+    expect(rmMock).toHaveBeenCalledWith(path.resolve('/repo', 'src', 'new-file.ts'), {
+      force: true,
+      recursive: true
+    })
+    expect(rmMock).toHaveBeenCalledWith(path.resolve('/repo', 'scratch'), {
+      force: true,
+      recursive: true
+    })
+  })
+
+  it('rejects bulk discard paths that traverse outside the worktree', async () => {
+    await expect(bulkDiscardChanges('/repo', ['src/file.ts', '../outside.txt'])).rejects.toThrow(
+      'resolves outside the worktree'
+    )
+
+    expect(gitExecFileAsyncMock).not.toHaveBeenCalled()
+    expect(rmMock).not.toHaveBeenCalled()
   })
 })
 

--- a/src/main/git/status.ts
+++ b/src/main/git/status.ts
@@ -17,6 +17,7 @@ import type {
 import { gitExecFileAsync, gitExecFileAsyncBuffer } from './runner'
 
 const MAX_GIT_SHOW_BYTES = 10 * 1024 * 1024
+const BULK_CHUNK_SIZE = 100
 
 /**
  * Parse `git status --porcelain=v2` output into structured entries.
@@ -779,6 +780,69 @@ export async function discardChanges(worktreePath: string, filePath: string): Pr
     : rm(resolvedTarget, { force: true, recursive: true }))
 }
 
+function normalizeGitPathForCompare(filePath: string): string {
+  return filePath.replace(/\\/g, '/').replace(/\/+$/, '')
+}
+
+function isTrackedPathSpec(filePath: string, trackedPaths: readonly string[]): boolean {
+  const normalized = normalizeGitPathForCompare(filePath)
+  return trackedPaths.some((trackedPath) => {
+    const normalizedTracked = normalizeGitPathForCompare(trackedPath)
+    return normalizedTracked === normalized || normalizedTracked.startsWith(`${normalized}/`)
+  })
+}
+
+async function listTrackedPathSpecs(
+  worktreePath: string,
+  filePaths: readonly string[]
+): Promise<string[]> {
+  const trackedPaths: string[] = []
+  for (let i = 0; i < filePaths.length; i += BULK_CHUNK_SIZE) {
+    const chunk = filePaths.slice(i, i + BULK_CHUNK_SIZE)
+    const { stdout } = await gitExecFileAsync(['ls-files', '-z', '--', ...chunk], {
+      cwd: worktreePath
+    })
+    trackedPaths.push(...stdout.split('\0').filter(Boolean))
+  }
+  return trackedPaths
+}
+
+/**
+ * Discard working tree changes for many paths in a small number of subprocesses.
+ */
+export async function bulkDiscardChanges(worktreePath: string, filePaths: string[]): Promise<void> {
+  if (filePaths.length === 0) {
+    return
+  }
+
+  const resolvedWorktree = path.resolve(worktreePath)
+  for (const filePath of filePaths) {
+    const resolvedTarget = path.resolve(worktreePath, filePath)
+    if (!isWithinWorktree(path, resolvedWorktree, resolvedTarget)) {
+      throw new Error(`Path "${filePath}" resolves outside the worktree`)
+    }
+  }
+
+  const trackedPathSpecs = await listTrackedPathSpecs(worktreePath, filePaths)
+  const trackedPaths = filePaths.filter((filePath) => isTrackedPathSpec(filePath, trackedPathSpecs))
+  const untrackedPaths = filePaths.filter(
+    (filePath) => !isTrackedPathSpec(filePath, trackedPathSpecs)
+  )
+
+  for (let i = 0; i < trackedPaths.length; i += BULK_CHUNK_SIZE) {
+    const chunk = trackedPaths.slice(i, i + BULK_CHUNK_SIZE)
+    await gitExecFileAsync(['restore', '--worktree', '--source=HEAD', '--', ...chunk], {
+      cwd: worktreePath
+    })
+  }
+
+  await Promise.all(
+    untrackedPaths.map((filePath) =>
+      rm(path.resolve(worktreePath, filePath), { force: true, recursive: true })
+    )
+  )
+}
+
 export function isWithinWorktree(
   pathApi: Pick<typeof path, 'isAbsolute' | 'relative' | 'sep'>,
   resolvedWorktree: string,
@@ -800,9 +864,8 @@ export async function bulkStageFiles(worktreePath: string, filePaths: string[]):
   if (filePaths.length === 0) {
     return
   }
-  const CHUNK_SIZE = 100
-  for (let i = 0; i < filePaths.length; i += CHUNK_SIZE) {
-    const chunk = filePaths.slice(i, i + CHUNK_SIZE)
+  for (let i = 0; i < filePaths.length; i += BULK_CHUNK_SIZE) {
+    const chunk = filePaths.slice(i, i + BULK_CHUNK_SIZE)
     await gitExecFileAsync(['add', '--', ...chunk], { cwd: worktreePath })
   }
 }
@@ -814,9 +877,8 @@ export async function bulkUnstageFiles(worktreePath: string, filePaths: string[]
   if (filePaths.length === 0) {
     return
   }
-  const CHUNK_SIZE = 100
-  for (let i = 0; i < filePaths.length; i += CHUNK_SIZE) {
-    const chunk = filePaths.slice(i, i + CHUNK_SIZE)
+  for (let i = 0; i < filePaths.length; i += BULK_CHUNK_SIZE) {
+    const chunk = filePaths.slice(i, i + BULK_CHUNK_SIZE)
     await gitExecFileAsync(['restore', '--staged', '--', ...chunk], { cwd: worktreePath })
   }
 }

--- a/src/main/ipc/filesystem.test.ts
+++ b/src/main/ipc/filesystem.test.ts
@@ -22,6 +22,7 @@ const {
   bulkStageFilesMock,
   unstageFileMock,
   bulkUnstageFilesMock,
+  bulkDiscardChangesMock,
   discardChangesMock,
   listWorktreesMock,
   getSshFilesystemProviderMock,
@@ -45,6 +46,7 @@ const {
   bulkStageFilesMock: vi.fn(),
   unstageFileMock: vi.fn(),
   bulkUnstageFilesMock: vi.fn(),
+  bulkDiscardChangesMock: vi.fn(),
   discardChangesMock: vi.fn(),
   listWorktreesMock: vi.fn(),
   getSshFilesystemProviderMock: vi.fn(),
@@ -80,6 +82,7 @@ vi.mock('../git/status', () => ({
   bulkStageFiles: bulkStageFilesMock,
   unstageFile: unstageFileMock,
   bulkUnstageFiles: bulkUnstageFilesMock,
+  bulkDiscardChanges: bulkDiscardChangesMock,
   discardChanges: discardChangesMock
 }))
 
@@ -162,6 +165,7 @@ describe('registerFilesystemHandlers', () => {
       bulkStageFilesMock,
       unstageFileMock,
       bulkUnstageFilesMock,
+      bulkDiscardChangesMock,
       discardChangesMock,
       listWorktreesMock,
       getSshFilesystemProviderMock,
@@ -493,6 +497,22 @@ describe('registerFilesystemHandlers', () => {
     ])
   })
 
+  it('normalizes git file paths for bulk discard requests', async () => {
+    bulkDiscardChangesMock.mockResolvedValue(undefined)
+
+    registerFilesystemHandlers(store as never)
+
+    await handlers.get('git:bulkDiscard')!(null, {
+      worktreePath: WORKTREE_FEATURE_PATH,
+      filePaths: ['./src/../src/file.ts', 'nested//child.ts']
+    })
+
+    expect(bulkDiscardChangesMock).toHaveBeenCalledWith(WORKTREE_FEATURE_PATH, [
+      path.join('src', 'file.ts'),
+      path.join('nested', 'child.ts')
+    ])
+  })
+
   it('rejects bulk unstage requests that escape the selected worktree', async () => {
     registerFilesystemHandlers(store as never)
 
@@ -504,6 +524,19 @@ describe('registerFilesystemHandlers', () => {
     ).rejects.toThrow('Access denied: git file path escapes the selected worktree')
 
     expect(bulkUnstageFilesMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects bulk discard requests that escape the selected worktree', async () => {
+    registerFilesystemHandlers(store as never)
+
+    await expect(
+      handlers.get('git:bulkDiscard')!(null, {
+        worktreePath: WORKTREE_FEATURE_PATH,
+        filePaths: ['src/file.ts', '../outside.txt']
+      })
+    ).rejects.toThrow('Access denied: git file path escapes the selected worktree')
+
+    expect(bulkDiscardChangesMock).not.toHaveBeenCalled()
   })
 
   it('lists markdown documents recursively for a registered worktree', async () => {
@@ -703,6 +736,22 @@ describe('registerFilesystemHandlers', () => {
 
     expect(sshCommitMock).toHaveBeenCalledWith('/remote/repo', 'feat: remote commit')
     expect(commitChangesMock).not.toHaveBeenCalled()
+  })
+
+  it('routes ssh git:bulkDiscard through the SSH provider', async () => {
+    const sshBulkDiscardMock = vi.fn().mockResolvedValue(undefined)
+    getSshGitProviderMock.mockReturnValue({ bulkDiscardChanges: sshBulkDiscardMock })
+
+    registerFilesystemHandlers(store as never)
+
+    await handlers.get('git:bulkDiscard')!(null, {
+      worktreePath: '/remote/repo',
+      filePaths: ['a.ts', 'b.ts'],
+      connectionId: 'conn-1'
+    })
+
+    expect(sshBulkDiscardMock).toHaveBeenCalledWith('/remote/repo', ['a.ts', 'b.ts'])
+    expect(bulkDiscardChangesMock).not.toHaveBeenCalled()
   })
 
   it('rejects git:commit with empty message and does not call commitChanges', async () => {

--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -35,6 +35,7 @@ import {
   unstageFile,
   bulkStageFiles,
   bulkUnstageFiles,
+  bulkDiscardChanges,
   discardChanges,
   getBranchCompare,
   getBranchDiff
@@ -760,6 +761,25 @@ export function registerFilesystemHandlers(store: Store): void {
       const worktreePath = await resolveRegisteredWorktreePath(args.worktreePath, store)
       const filePath = validateGitRelativeFilePath(worktreePath, args.filePath)
       await discardChanges(worktreePath, filePath)
+    }
+  )
+
+  ipcMain.handle(
+    'git:bulkDiscard',
+    async (
+      _event,
+      args: { worktreePath: string; filePaths: string[]; connectionId?: string }
+    ): Promise<void> => {
+      if (args.connectionId) {
+        const provider = getSshGitProvider(args.connectionId)
+        if (!provider) {
+          throw new Error(`No git provider for connection "${args.connectionId}"`)
+        }
+        return provider.bulkDiscardChanges(args.worktreePath, args.filePaths)
+      }
+      const worktreePath = await resolveRegisteredWorktreePath(args.worktreePath, store)
+      const filePaths = args.filePaths.map((p) => validateGitRelativeFilePath(worktreePath, p))
+      await bulkDiscardChanges(worktreePath, filePaths)
     }
   )
 

--- a/src/main/providers/ssh-git-provider.test.ts
+++ b/src/main/providers/ssh-git-provider.test.ts
@@ -107,6 +107,14 @@ describe('SshGitProvider', () => {
     })
   })
 
+  it('bulkDiscardChanges sends git.bulkDiscard request', async () => {
+    await provider.bulkDiscardChanges('/home/user/repo', ['a.ts', 'b.ts'])
+    expect(mux.request).toHaveBeenCalledWith('git.bulkDiscard', {
+      worktreePath: '/home/user/repo',
+      filePaths: ['a.ts', 'b.ts']
+    })
+  })
+
   it('detectConflictOperation sends git.conflictOperation request', async () => {
     mux.request.mockResolvedValue('rebase')
     const result = await provider.detectConflictOperation('/home/user/repo')

--- a/src/main/providers/ssh-git-provider.ts
+++ b/src/main/providers/ssh-git-provider.ts
@@ -72,6 +72,10 @@ export class SshGitProvider implements IGitProvider {
     await this.mux.request('git.discard', { worktreePath, filePath })
   }
 
+  async bulkDiscardChanges(worktreePath: string, filePaths: string[]): Promise<void> {
+    await this.mux.request('git.bulkDiscard', { worktreePath, filePaths })
+  }
+
   async detectConflictOperation(worktreePath: string): Promise<GitConflictOperation> {
     return (await this.mux.request('git.conflictOperation', {
       worktreePath

--- a/src/main/providers/types.ts
+++ b/src/main/providers/types.ts
@@ -146,6 +146,7 @@ export type IGitProvider = {
   bulkStageFiles(worktreePath: string, filePaths: string[]): Promise<void>
   bulkUnstageFiles(worktreePath: string, filePaths: string[]): Promise<void>
   discardChanges(worktreePath: string, filePath: string): Promise<void>
+  bulkDiscardChanges(worktreePath: string, filePaths: string[]): Promise<void>
   detectConflictOperation(worktreePath: string): Promise<GitConflictOperation>
   getBranchCompare(worktreePath: string, baseRef: string): Promise<GitBranchCompareResult>
   getUpstreamStatus(worktreePath: string): Promise<GitUpstreamStatus>

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1055,6 +1055,11 @@ export type PreloadApi = {
       filePath: string
       connectionId?: string
     }) => Promise<void>
+    bulkDiscard: (args: {
+      worktreePath: string
+      filePaths: string[]
+      connectionId?: string
+    }) => Promise<void>
     remoteFileUrl: (args: {
       worktreePath: string
       relativePath: string

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1733,6 +1733,11 @@ const api = {
       filePath: string
       connectionId?: string
     }): Promise<void> => ipcRenderer.invoke('git:discard', args),
+    bulkDiscard: (args: {
+      worktreePath: string
+      filePaths: string[]
+      connectionId?: string
+    }): Promise<void> => ipcRenderer.invoke('git:bulkDiscard', args),
     remoteFileUrl: (args: {
       worktreePath: string
       relativePath: string

--- a/src/relay/git-handler.test.ts
+++ b/src/relay/git-handler.test.ts
@@ -44,6 +44,7 @@ describe('GitHandler', () => {
     expect(methods).toContain('git.bulkStage')
     expect(methods).toContain('git.bulkUnstage')
     expect(methods).toContain('git.discard')
+    expect(methods).toContain('git.bulkDiscard')
     expect(methods).toContain('git.conflictOperation')
     expect(methods).toContain('git.branchCompare')
     expect(methods).toContain('git.upstreamStatus')
@@ -257,12 +258,41 @@ describe('GitHandler', () => {
       await expect(fs.access(path.join(tmpDir, 'new.txt'))).rejects.toThrow()
     })
 
+    it('bulk discards tracked and untracked files', async () => {
+      gitInit(tmpDir)
+      writeFileSync(path.join(tmpDir, 'a.txt'), 'a')
+      writeFileSync(path.join(tmpDir, 'b.txt'), 'b')
+      gitCommit(tmpDir, 'initial')
+      writeFileSync(path.join(tmpDir, 'a.txt'), 'a-modified')
+      writeFileSync(path.join(tmpDir, 'b.txt'), 'b-modified')
+      writeFileSync(path.join(tmpDir, 'new.txt'), 'untracked')
+
+      await dispatcher.callRequest('git.bulkDiscard', {
+        worktreePath: tmpDir,
+        filePaths: ['a.txt', 'b.txt', 'new.txt']
+      })
+
+      await expect(fs.readFile(path.join(tmpDir, 'a.txt'), 'utf-8')).resolves.toBe('a')
+      await expect(fs.readFile(path.join(tmpDir, 'b.txt'), 'utf-8')).resolves.toBe('b')
+      await expect(fs.access(path.join(tmpDir, 'new.txt'))).rejects.toThrow()
+    })
+
     it('rejects path traversal', async () => {
       gitInit(tmpDir)
       await expect(
         dispatcher.callRequest('git.discard', {
           worktreePath: tmpDir,
           filePath: '../../../etc/passwd'
+        })
+      ).rejects.toThrow('outside the worktree')
+    })
+
+    it('rejects bulk discard path traversal', async () => {
+      gitInit(tmpDir)
+      await expect(
+        dispatcher.callRequest('git.bulkDiscard', {
+          worktreePath: tmpDir,
+          filePaths: ['file.txt', '../../../etc/passwd']
         })
       ).rejects.toThrow('outside the worktree')
     })

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -42,6 +42,7 @@ export class GitHandler {
     this.dispatcher.onRequest('git.bulkStage', (p) => this.bulkStage(p))
     this.dispatcher.onRequest('git.bulkUnstage', (p) => this.bulkUnstage(p))
     this.dispatcher.onRequest('git.discard', (p) => this.discard(p))
+    this.dispatcher.onRequest('git.bulkDiscard', (p) => this.bulkDiscard(p))
     this.dispatcher.onRequest('git.conflictOperation', (p) => this.conflictOperation(p))
     this.dispatcher.onRequest('git.branchCompare', (p) => this.branchCompare(p))
     this.dispatcher.onRequest('git.upstreamStatus', (p) => this.upstreamStatus(p))
@@ -138,17 +139,40 @@ export class GitHandler {
     }
   }
 
-  private async discard(params: Record<string, unknown>) {
-    const worktreePath = params.worktreePath as string
-    const filePath = params.filePath as string
+  private normalizeGitPathForCompare(filePath: string): string {
+    return filePath.replace(/\\/g, '/').replace(/\/+$/, '')
+  }
 
+  private isTrackedPathSpec(filePath: string, trackedPaths: readonly string[]): boolean {
+    const normalized = this.normalizeGitPathForCompare(filePath)
+    return trackedPaths.some((trackedPath) => {
+      const normalizedTracked = this.normalizeGitPathForCompare(trackedPath)
+      return normalizedTracked === normalized || normalizedTracked.startsWith(`${normalized}/`)
+    })
+  }
+
+  private assertInWorktree(worktreePath: string, filePath: string): string {
     const resolved = path.resolve(worktreePath, filePath)
     const rel = path.relative(path.resolve(worktreePath), resolved)
     // Why: empty rel or '.' means the path IS the worktree root — rm -rf would
     // delete the entire worktree. Reject along with parent-escaping paths.
-    if (!rel || rel === '.' || rel === '..' || rel.startsWith('../') || path.isAbsolute(rel)) {
+    if (
+      !rel ||
+      rel === '.' ||
+      rel === '..' ||
+      rel.startsWith(`..${path.sep}`) ||
+      path.isAbsolute(rel)
+    ) {
       throw new Error(`Path "${filePath}" resolves outside the worktree`)
     }
+    return resolved
+  }
+
+  private async discard(params: Record<string, unknown>) {
+    const worktreePath = params.worktreePath as string
+    const filePath = params.filePath as string
+
+    const resolved = this.assertInWorktree(worktreePath, filePath)
 
     let tracked = false
     try {
@@ -161,6 +185,43 @@ export class GitHandler {
     await (tracked
       ? this.git(['restore', '--worktree', '--source=HEAD', '--', filePath], worktreePath)
       : rm(resolved, { force: true, recursive: true }))
+  }
+
+  private async bulkDiscard(params: Record<string, unknown>) {
+    const worktreePath = params.worktreePath as string
+    const filePaths = params.filePaths as string[]
+    if (filePaths.length === 0) {
+      return
+    }
+
+    for (const filePath of filePaths) {
+      this.assertInWorktree(worktreePath, filePath)
+    }
+
+    const trackedPathSpecs: string[] = []
+    for (let i = 0; i < filePaths.length; i += BULK_CHUNK_SIZE) {
+      const chunk = filePaths.slice(i, i + BULK_CHUNK_SIZE)
+      const { stdout } = await this.git(['ls-files', '-z', '--', ...chunk], worktreePath)
+      trackedPathSpecs.push(...stdout.split('\0').filter(Boolean))
+    }
+
+    const trackedPaths = filePaths.filter((filePath) =>
+      this.isTrackedPathSpec(filePath, trackedPathSpecs)
+    )
+    const untrackedPaths = filePaths.filter(
+      (filePath) => !this.isTrackedPathSpec(filePath, trackedPathSpecs)
+    )
+
+    for (let i = 0; i < trackedPaths.length; i += BULK_CHUNK_SIZE) {
+      const chunk = trackedPaths.slice(i, i + BULK_CHUNK_SIZE)
+      await this.git(['restore', '--worktree', '--source=HEAD', '--', ...chunk], worktreePath)
+    }
+
+    await Promise.all(
+      untrackedPaths.map((filePath) =>
+        rm(path.resolve(worktreePath, filePath), { force: true, recursive: true })
+      )
+    )
   }
 
   private async conflictOperation(params: Record<string, unknown>) {

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -62,6 +62,12 @@ import {
   runDiscardAllForArea,
   type DiscardAllArea
 } from './discard-all-sequence'
+import {
+  getDiscardAreaConfirmationCopy,
+  getDiscardEntryConfirmationCopy,
+  type DiscardConfirmationCopy
+} from './source-control-discard-confirmation'
+import { refreshGitStatusForWorktree } from './git-status-refresh'
 import { toast } from 'sonner'
 import {
   ContextMenu,
@@ -73,6 +79,7 @@ import {
   Dialog,
   DialogContent,
   DialogDescription,
+  DialogFooter,
   DialogHeader,
   DialogTitle
 } from '@/components/ui/dialog'
@@ -151,6 +158,10 @@ const BRANCH_REFRESH_INTERVAL_MS = 5000
 
 type CommitDraftsByWorktree = Record<string, string>
 
+type PendingDiscardConfirmation =
+  | { kind: 'entry'; entry: GitStatusEntry }
+  | { kind: 'area'; area: DiscardAllArea; paths: readonly string[] }
+
 export function readCommitDraftForWorktree(
   drafts: CommitDraftsByWorktree,
   worktreeId: string | null | undefined
@@ -201,9 +212,12 @@ function SourceControlInner(): React.JSX.Element {
   const prCache = useAppStore((s) => s.prCache)
   const fetchPRForBranch = useAppStore((s) => s.fetchPRForBranch)
   const updateRepo = useAppStore((s) => s.updateRepo)
+  const setGitStatus = useAppStore((s) => s.setGitStatus)
+  const updateWorktreeGitIdentity = useAppStore((s) => s.updateWorktreeGitIdentity)
   const beginGitBranchCompareRequest = useAppStore((s) => s.beginGitBranchCompareRequest)
   const setGitBranchCompareResult = useAppStore((s) => s.setGitBranchCompareResult)
   const fetchUpstreamStatus = useAppStore((s) => s.fetchUpstreamStatus)
+  const setUpstreamStatus = useAppStore((s) => s.setUpstreamStatus)
   const pushBranch = useAppStore((s) => s.pushBranch)
   const pullBranch = useAppStore((s) => s.pullBranch)
   const syncBranch = useAppStore((s) => s.syncBranch)
@@ -270,6 +284,7 @@ function SourceControlInner(): React.JSX.Element {
   const [scope, setScope] = useState<SourceControlScope>('all')
   const [collapsedSections, setCollapsedSections] = useState<Set<string>>(new Set())
   const [baseRefDialogOpen, setBaseRefDialogOpen] = useState(false)
+  const [pendingDiscard, setPendingDiscard] = useState<PendingDiscardConfirmation | null>(null)
   // Why: start null rather than 'origin/main' so branch compare doesn't fire
   // with a fabricated ref before the IPC resolves. effectiveBaseRef stays
   // falsy until we have a real answer from the main process.
@@ -320,6 +335,40 @@ function SourceControlInner(): React.JSX.Element {
   // this guard the branchCompare interval and PR fetch would keep running
   // with no visible consumer, wasting git process spawns and API calls.
   const isBranchVisible = rightSidebarTab === 'source-control' && rightSidebarOpen
+
+  const refreshActiveGitStatus = useCallback(async (): Promise<void> => {
+    if (!activeWorktreeId || !worktreePath || isFolder) {
+      return
+    }
+    const connectionId = getConnectionId(activeWorktreeId) ?? undefined
+    await refreshGitStatusForWorktree({
+      worktreeId: activeWorktreeId,
+      worktreePath,
+      connectionId,
+      deps: {
+        setGitStatus,
+        updateWorktreeGitIdentity,
+        setUpstreamStatus,
+        fetchUpstreamStatus
+      }
+    })
+  }, [
+    activeWorktreeId,
+    fetchUpstreamStatus,
+    isFolder,
+    setGitStatus,
+    setUpstreamStatus,
+    updateWorktreeGitIdentity,
+    worktreePath
+  ])
+
+  const refreshActiveGitStatusAfterMutation = useCallback(async (): Promise<void> => {
+    try {
+      await refreshActiveGitStatus()
+    } catch (error) {
+      console.warn('[SourceControl] post-mutation git status refresh failed', error)
+    }
+  }, [refreshActiveGitStatus])
 
   useEffect(() => {
     if (!activeRepo || isFolder) {
@@ -428,6 +477,15 @@ function SourceControlInner(): React.JSX.Element {
   }, [filteredGrouped, collapsedSections])
 
   const [isExecutingBulk, setIsExecutingBulk] = useState(false)
+  const pendingDiscardCopy = useMemo<DiscardConfirmationCopy | null>(() => {
+    if (!pendingDiscard) {
+      return null
+    }
+    if (pendingDiscard.kind === 'entry') {
+      return getDiscardEntryConfirmationCopy(pendingDiscard.entry)
+    }
+    return getDiscardAreaConfirmationCopy(pendingDiscard.area, pendingDiscard.paths.length)
+  }, [pendingDiscard])
 
   const unresolvedConflicts = useMemo(
     () => entries.filter((entry) => entry.conflictStatus === 'unresolved' && entry.conflictKind),
@@ -479,6 +537,7 @@ function SourceControlInner(): React.JSX.Element {
     setScope('all')
     setCollapsedSections(new Set())
     setBaseRefDialogOpen(false)
+    setPendingDiscard(null)
     // Why: do NOT reset defaultBaseRef here. It is repo-scoped, not
     // worktree-scoped, and is resolved by the effect above on activeRepo
     // change. Resetting it to a hard-coded 'origin/main' on every worktree
@@ -543,6 +602,7 @@ function SourceControlInner(): React.JSX.Element {
         return writeCommitDraftForWorktree(prev, activeWorktreeId, '')
       })
       setCommitErrors((prev) => ({ ...prev, [activeWorktreeId]: null }))
+      void refreshActiveGitStatusAfterMutation()
       // Why: flip branchSummary to 'loading' synchronously so the empty-state
       // guard
       //   (!hasUncommittedEntries && branchSummary.status === 'ready' &&
@@ -583,6 +643,7 @@ function SourceControlInner(): React.JSX.Element {
     commitMessage,
     effectiveBaseRef,
     grouped.staged.length,
+    refreshActiveGitStatusAfterMutation,
     unresolvedConflicts.length,
     worktreePath
   ])
@@ -850,11 +911,18 @@ function SourceControlInner(): React.JSX.Element {
     try {
       const connectionId = getConnectionId(activeWorktreeId ?? null) ?? undefined
       await window.api.git.bulkStage({ worktreePath, filePaths: bulkStagePaths, connectionId })
+      await refreshActiveGitStatusAfterMutation()
       clearSelection()
     } finally {
       setIsExecutingBulk(false)
     }
-  }, [worktreePath, bulkStagePaths, clearSelection, activeWorktreeId])
+  }, [
+    worktreePath,
+    bulkStagePaths,
+    clearSelection,
+    activeWorktreeId,
+    refreshActiveGitStatusAfterMutation
+  ])
 
   const handleBulkUnstage = useCallback(async () => {
     if (!worktreePath || bulkUnstagePaths.length === 0) {
@@ -864,11 +932,18 @@ function SourceControlInner(): React.JSX.Element {
     try {
       const connectionId = getConnectionId(activeWorktreeId ?? null) ?? undefined
       await window.api.git.bulkUnstage({ worktreePath, filePaths: bulkUnstagePaths, connectionId })
+      await refreshActiveGitStatusAfterMutation()
       clearSelection()
     } finally {
       setIsExecutingBulk(false)
     }
-  }, [worktreePath, bulkUnstagePaths, clearSelection, activeWorktreeId])
+  }, [
+    worktreePath,
+    bulkUnstagePaths,
+    clearSelection,
+    activeWorktreeId,
+    refreshActiveGitStatusAfterMutation
+  ])
 
   // Why: "Stage all" on the Changes section intentionally skips unresolved
   // conflict rows. `git add` on a conflicted file silently clears the `u`
@@ -887,12 +962,20 @@ function SourceControlInner(): React.JSX.Element {
       try {
         const connectionId = getConnectionId(activeWorktreeId ?? null) ?? undefined
         await window.api.git.bulkStage({ worktreePath, filePaths: paths, connectionId })
+        await refreshActiveGitStatusAfterMutation()
         clearSelection()
       } finally {
         setIsExecutingBulk(false)
       }
     },
-    [worktreePath, grouped, activeWorktreeId, isExecutingBulk, clearSelection]
+    [
+      worktreePath,
+      grouped,
+      activeWorktreeId,
+      isExecutingBulk,
+      clearSelection,
+      refreshActiveGitStatusAfterMutation
+    ]
   )
 
   // Why: 'stage' primary stages every unstaged + untracked path in one
@@ -914,11 +997,19 @@ function SourceControlInner(): React.JSX.Element {
     try {
       const connectionId = getConnectionId(activeWorktreeId ?? null) ?? undefined
       await window.api.git.bulkStage({ worktreePath, filePaths, connectionId })
+      await refreshActiveGitStatusAfterMutation()
       clearSelection()
     } finally {
       setIsExecutingBulk(false)
     }
-  }, [worktreePath, isExecutingBulk, grouped, activeWorktreeId, clearSelection])
+  }, [
+    worktreePath,
+    isExecutingBulk,
+    grouped,
+    activeWorktreeId,
+    clearSelection,
+    refreshActiveGitStatusAfterMutation
+  ])
 
   // Why: PrimaryActionKind is narrowed to the single-action kinds the
   // primary can emit ('commit' | 'stage' | 'push' | 'pull' | 'sync' |
@@ -958,11 +1049,19 @@ function SourceControlInner(): React.JSX.Element {
     try {
       const connectionId = getConnectionId(activeWorktreeId ?? null) ?? undefined
       await window.api.git.bulkUnstage({ worktreePath, filePaths: paths, connectionId })
+      await refreshActiveGitStatusAfterMutation()
       clearSelection()
     } finally {
       setIsExecutingBulk(false)
     }
-  }, [worktreePath, grouped.staged, activeWorktreeId, isExecutingBulk, clearSelection])
+  }, [
+    worktreePath,
+    grouped.staged,
+    activeWorktreeId,
+    isExecutingBulk,
+    clearSelection,
+    refreshActiveGitStatusAfterMutation
+  ])
 
   const refreshBranchCompare = useCallback(async () => {
     if (!activeWorktreeId || !worktreePath || !effectiveBaseRef || isFolder) {
@@ -1178,11 +1277,12 @@ function SourceControlInner(): React.JSX.Element {
       try {
         const connectionId = getConnectionId(activeWorktreeId ?? null) ?? undefined
         await window.api.git.stage({ worktreePath, filePath, connectionId })
+        await refreshActiveGitStatusAfterMutation()
       } catch {
         // git operation failed silently
       }
     },
-    [worktreePath, activeWorktreeId]
+    [worktreePath, activeWorktreeId, refreshActiveGitStatusAfterMutation]
   )
 
   const handleUnstage = useCallback(
@@ -1193,11 +1293,12 @@ function SourceControlInner(): React.JSX.Element {
       try {
         const connectionId = getConnectionId(activeWorktreeId ?? null) ?? undefined
         await window.api.git.unstage({ worktreePath, filePath, connectionId })
+        await refreshActiveGitStatusAfterMutation()
       } catch {
         // git operation failed silently
       }
     },
-    [worktreePath, activeWorktreeId]
+    [worktreePath, activeWorktreeId, refreshActiveGitStatusAfterMutation]
   )
 
   // Why: split into two variants — `discardSingle` throws so bulk callers can
@@ -1228,33 +1329,64 @@ function SourceControlInner(): React.JSX.Element {
     [activeWorktreeId, worktreePath]
   )
 
+  const discardMany = useCallback(
+    async (filePaths: string[]) => {
+      if (!worktreePath || !activeWorktreeId) {
+        return
+      }
+      // Why: bulk discard replaces many working-tree files at once. Quiesce
+      // any matching editor autosaves before git mutates the files so a delayed
+      // save cannot recreate edits after the restore.
+      await Promise.all(
+        filePaths.map((relativePath) =>
+          requestEditorSaveQuiesce({
+            worktreeId: activeWorktreeId,
+            worktreePath,
+            relativePath
+          })
+        )
+      )
+      const connectionId = getConnectionId(activeWorktreeId) ?? undefined
+      await window.api.git.bulkDiscard({ worktreePath, filePaths, connectionId })
+      for (const relativePath of filePaths) {
+        notifyEditorExternalFileChange({
+          worktreeId: activeWorktreeId,
+          worktreePath,
+          relativePath
+        })
+      }
+    },
+    [activeWorktreeId, worktreePath]
+  )
+
   const handleDiscard = useCallback(
     async (filePath: string) => {
       try {
         await discardSingle(filePath)
+        await refreshActiveGitStatusAfterMutation()
       } catch {
         // Why: per-row discard is fire-and-forget for the UI; failures are not
         // surfaced individually. Bulk callers use `discardSingle` directly so
         // they can aggregate failures into a single toast.
       }
     },
-    [discardSingle]
+    [discardSingle, refreshActiveGitStatusAfterMutation]
   )
 
   // Why: "Discard all" mirrors the per-row discard rules — it skips unresolved
   // and resolved_locally rows because discarding those can silently re-create
   // the conflict or lose the resolution (no v1 UX to explain this clearly).
-  // There is no bulk discard IPC, so we serialize per-file discard calls that
-  // run the same editor-quiesce + external-change notification as the row action.
+  // The happy path uses bulk discard IPC; the sequencing helper falls back to
+  // per-file discard when an older SSH relay does not support that method yet.
   // The sequencing + filter rules live in discard-all-sequence.ts so they can
   // be unit-tested independently of the full component (staged area needs a
   // bulk-unstage first, and a failed unstage must skip the discard loop).
   const handleRevertAllInArea = useCallback(
-    async (area: DiscardAllArea) => {
+    async (area: DiscardAllArea, confirmedPaths?: readonly string[]) => {
       if (!worktreePath || !activeWorktreeId || isExecutingBulk) {
         return
       }
-      const paths = getDiscardAllPaths(grouped[area], area)
+      const paths = confirmedPaths ? [...confirmedPaths] : getDiscardAllPaths(grouped[area], area)
       if (paths.length === 0) {
         return
       }
@@ -1269,6 +1401,7 @@ function SourceControlInner(): React.JSX.Element {
         const result = await runDiscardAllForArea(area, paths, {
           bulkUnstage: (filePaths) =>
             window.api.git.bulkUnstage({ worktreePath, filePaths, connectionId }),
+          discardMany,
           discardOne: discardSingle,
           onError: (error) => {
             errors.push(error)
@@ -1294,14 +1427,61 @@ function SourceControlInner(): React.JSX.Element {
           )
         }
         if (!result.aborted) {
+          await refreshActiveGitStatusAfterMutation()
           clearSelection()
         }
       } finally {
         setIsExecutingBulk(false)
       }
     },
-    [worktreePath, activeWorktreeId, grouped, isExecutingBulk, clearSelection, discardSingle]
+    [
+      worktreePath,
+      activeWorktreeId,
+      grouped,
+      isExecutingBulk,
+      clearSelection,
+      discardMany,
+      discardSingle,
+      refreshActiveGitStatusAfterMutation
+    ]
   )
+
+  const requestDiscardAllInArea = useCallback(
+    (area: DiscardAllArea): void => {
+      if (!worktreePath || !activeWorktreeId || isExecutingBulk) {
+        return
+      }
+      const paths = getDiscardAllPaths(grouped[area], area)
+      if (paths.length === 0) {
+        return
+      }
+      setPendingDiscard({ kind: 'area', area, paths })
+    },
+    [activeWorktreeId, grouped, isExecutingBulk, worktreePath]
+  )
+
+  const requestDiscardEntry = useCallback(
+    (entry: GitStatusEntry): void => {
+      if (!worktreePath || !activeWorktreeId || isExecutingBulk) {
+        return
+      }
+      setPendingDiscard({ kind: 'entry', entry })
+    },
+    [activeWorktreeId, isExecutingBulk, worktreePath]
+  )
+
+  const confirmPendingDiscard = useCallback((): void => {
+    const pending = pendingDiscard
+    if (!pending) {
+      return
+    }
+    setPendingDiscard(null)
+    if (pending.kind === 'entry') {
+      void handleDiscard(pending.entry.path)
+      return
+    }
+    void handleRevertAllInArea(pending.area, pending.paths)
+  }, [handleDiscard, handleRevertAllInArea, pendingDiscard])
 
   if (!activeWorktree || !activeRepo || !worktreePath) {
     return (
@@ -1326,6 +1506,7 @@ function SourceControlInner(): React.JSX.Element {
   const showGenericEmptyState =
     !hasUncommittedEntries && branchSummary?.status === 'ready' && branchEntries.length === 0
   const currentWorktreeId = activeWorktree.id
+  const PendingDiscardIcon = pendingDiscardCopy?.confirmLabel.startsWith('Delete') ? Trash : Undo2
 
   return (
     <>
@@ -1639,7 +1820,7 @@ function SourceControlInner(): React.JSX.Element {
                           <div className="flex items-center opacity-0 transition-opacity group-hover/section:opacity-100 focus-within:opacity-100 [@media(hover:none)]:opacity-100">
                             {canRevertAll && (
                               <ActionButton
-                                icon={Undo2}
+                                icon={area === 'untracked' ? Trash : Undo2}
                                 // Why: for untracked files, discard deletes the file
                                 // outright (rm -rf via git.discard's untracked branch).
                                 // A generic "Discard all" label hides that severity —
@@ -1649,7 +1830,7 @@ function SourceControlInner(): React.JSX.Element {
                                 }
                                 onClick={(event) => {
                                   event.stopPropagation()
-                                  void handleRevertAllInArea(area)
+                                  requestDiscardAllInArea(area)
                                 }}
                                 disabled={isExecutingBulk}
                               />
@@ -1730,7 +1911,7 @@ function SourceControlInner(): React.JSX.Element {
                             onOpen={handleOpenDiff}
                             onStage={handleStage}
                             onUnstage={handleUnstage}
-                            onDiscard={handleDiscard}
+                            onDiscard={requestDiscardEntry}
                             commentCount={diffCommentCountByPath.get(entry.path) ?? 0}
                           />
                         )
@@ -1804,6 +1985,46 @@ function SourceControlInner(): React.JSX.Element {
           />
         )}
       </div>
+
+      <Dialog
+        open={pendingDiscard !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setPendingDiscard(null)
+          }
+        }}
+      >
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle className="text-sm">
+              {pendingDiscardCopy?.title ?? 'Discard changes?'}
+            </DialogTitle>
+            <DialogDescription className="text-xs">
+              {pendingDiscardCopy?.description ?? 'This cannot be undone.'}
+            </DialogDescription>
+          </DialogHeader>
+          {pendingDiscard?.kind === 'area' ? (
+            <div className="rounded-md border border-border/70 bg-muted/35 px-3 py-2 text-xs text-muted-foreground">
+              {pendingDiscard.paths.length} {pendingDiscard.paths.length === 1 ? 'file' : 'files'}
+            </div>
+          ) : pendingDiscard?.kind === 'entry' ? (
+            <div className="rounded-md border border-border/70 bg-muted/35 px-3 py-2 text-xs">
+              <div className="break-all font-medium text-foreground">
+                {pendingDiscard.entry.path}
+              </div>
+            </div>
+          ) : null}
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => setPendingDiscard(null)}>
+              Cancel
+            </Button>
+            <Button type="button" variant="destructive" onClick={confirmPendingDiscard}>
+              <PendingDiscardIcon className="size-4" />
+              {pendingDiscardCopy?.confirmLabel ?? 'Discard'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       <Dialog open={baseRefDialogOpen} onOpenChange={setBaseRefDialogOpen}>
         <DialogContent className="max-w-xl">
@@ -2384,7 +2605,7 @@ const UncommittedEntryRow = React.memo(function UncommittedEntryRow({
   onOpen: (entry: GitStatusEntry) => void
   onStage: (filePath: string) => Promise<void>
   onUnstage: (filePath: string) => Promise<void>
-  onDiscard: (filePath: string) => Promise<void>
+  onDiscard: (entry: GitStatusEntry) => void
   commentCount: number
 }): React.JSX.Element {
   const StatusIcon = STATUS_ICONS[entry.status] ?? FileQuestion
@@ -2426,6 +2647,9 @@ const UncommittedEntryRow = React.memo(function UncommittedEntryRow({
       }}
     >
       <div
+        data-testid="source-control-entry"
+        data-source-control-path={entry.path}
+        data-source-control-area={entry.area}
         className={cn(
           'group relative flex cursor-pointer items-center gap-1 pl-5 pr-3 py-1 transition-colors hover:bg-accent/40',
           selected && 'bg-accent/60'
@@ -2483,11 +2707,17 @@ const UncommittedEntryRow = React.memo(function UncommittedEntryRow({
         <div className="absolute right-0 top-0 bottom-0 shrink-0 hidden group-hover:flex items-center gap-1.5 bg-accent pr-3 pl-2">
           {canDiscard && (
             <ActionButton
-              icon={Undo2}
-              title={entry.area === 'untracked' ? 'Revert untracked file' : 'Discard changes'}
+              icon={entry.area === 'untracked' ? Trash : Undo2}
+              title={
+                entry.area === 'untracked'
+                  ? 'Delete untracked file'
+                  : entry.status === 'deleted'
+                    ? 'Restore file'
+                    : 'Discard changes'
+              }
               onClick={(event) => {
                 event.stopPropagation()
-                void onDiscard(entry.path)
+                onDiscard(entry)
               }}
             />
           )}

--- a/src/renderer/src/components/right-sidebar/discard-all-sequence.test.ts
+++ b/src/renderer/src/components/right-sidebar/discard-all-sequence.test.ts
@@ -156,10 +156,12 @@ describe('runDiscardAllForArea', () => {
   function makeDeps(
     overrides: {
       bulkUnstageError?: unknown
+      discardManyError?: unknown
       discardOneError?: (path: string) => unknown
     } = {}
   ) {
     const bulkUnstageCalls: string[][] = []
+    const discardManyCalls: string[][] = []
     const discardOneCalls: string[] = []
     const errors: unknown[] = []
 
@@ -167,6 +169,12 @@ describe('runDiscardAllForArea', () => {
       bulkUnstageCalls.push([...paths])
       if (overrides.bulkUnstageError !== undefined) {
         throw overrides.bulkUnstageError
+      }
+    })
+    const discardMany = vi.fn(async (paths: string[]) => {
+      discardManyCalls.push([...paths])
+      if (overrides.discardManyError !== undefined) {
+        throw overrides.discardManyError
       }
     })
     const discardOne = vi.fn(async (path: string) => {
@@ -184,10 +192,13 @@ describe('runDiscardAllForArea', () => {
 
     return {
       deps: { bulkUnstage, discardOne, onError },
+      depsWithBulkDiscard: { bulkUnstage, discardMany, discardOne, onError },
       bulkUnstageCalls,
+      discardManyCalls,
       discardOneCalls,
       errors,
       bulkUnstage,
+      discardMany,
       discardOne,
       onError
     }
@@ -229,6 +240,37 @@ describe('runDiscardAllForArea', () => {
     expect(ctx.bulkUnstage.mock.invocationCallOrder[0]).toBeLessThan(
       ctx.discardOne.mock.invocationCallOrder[0]
     )
+  })
+
+  it('uses bulk discard when the dependency is available', async () => {
+    const ctx = makeDeps()
+    const result = await runDiscardAllForArea('unstaged', ['a.ts', 'b.ts'], ctx.depsWithBulkDiscard)
+    expect(result).toEqual({ discarded: ['a.ts', 'b.ts'], failed: [], aborted: false })
+    expect(ctx.discardManyCalls).toEqual([['a.ts', 'b.ts']])
+    expect(ctx.discardOne).not.toHaveBeenCalled()
+  })
+
+  it('bulk-unstages staged paths before bulk discard', async () => {
+    const ctx = makeDeps()
+    const result = await runDiscardAllForArea('staged', ['a.ts', 'b.ts'], ctx.depsWithBulkDiscard)
+    expect(result).toEqual({ discarded: ['a.ts', 'b.ts'], failed: [], aborted: false })
+    expect(ctx.bulkUnstageCalls).toEqual([['a.ts', 'b.ts']])
+    expect(ctx.discardManyCalls).toEqual([['a.ts', 'b.ts']])
+    expect(ctx.discardOne).not.toHaveBeenCalled()
+    // Why: staged discard is a two-step mutation. The index must be reset
+    // before the worktree restore/delete batch runs or staged deltas survive.
+    expect(ctx.bulkUnstage.mock.invocationCallOrder[0]).toBeLessThan(
+      ctx.discardMany.mock.invocationCallOrder[0]
+    )
+  })
+
+  it('falls back to per-file discard when bulk discard rejects', async () => {
+    const ctx = makeDeps({ discardManyError: new Error('unknown method') })
+    const result = await runDiscardAllForArea('unstaged', ['a.ts', 'b.ts'], ctx.depsWithBulkDiscard)
+    expect(result).toEqual({ discarded: ['a.ts', 'b.ts'], failed: [], aborted: false })
+    expect(ctx.discardManyCalls).toEqual([['a.ts', 'b.ts']])
+    expect(ctx.discardOneCalls).toEqual(['a.ts', 'b.ts'])
+    expect(ctx.onError).not.toHaveBeenCalled()
   })
 
   it('aborts and skips the discard loop if bulk-unstage rejects', async () => {

--- a/src/renderer/src/components/right-sidebar/discard-all-sequence.ts
+++ b/src/renderer/src/components/right-sidebar/discard-all-sequence.ts
@@ -48,6 +48,11 @@ export function getUnstageAllPaths(entries: readonly GitStatusEntry[]): string[]
 export type DiscardAllDeps = {
   /** Unstage the given paths in one IPC round-trip. Only called for 'staged'. */
   bulkUnstage: (paths: string[]) => Promise<void>
+  /**
+   * Discard the given paths in one IPC round-trip. Callers may omit this to
+   * keep the legacy per-file sequence in tests or older surfaces.
+   */
+  discardMany?: (paths: string[]) => Promise<void>
   /** Discard a single path (restore working-tree to HEAD, or rm if untracked). */
   discardOne: (path: string) => Promise<void>
   /**
@@ -102,6 +107,16 @@ export async function runDiscardAllForArea(
     } catch (error) {
       deps.onError?.(error)
       return { discarded: [], failed: [], aborted: true }
+    }
+  }
+
+  if (deps.discardMany) {
+    try {
+      await deps.discardMany([...paths])
+      return { discarded: [...paths], failed: [], aborted: false }
+    } catch {
+      // Why: older SSH relays may not support the bulk discard RPC yet. Fall
+      // back to the long-standing per-file path so the action still completes.
     }
   }
 

--- a/src/renderer/src/components/right-sidebar/git-status-refresh.test.ts
+++ b/src/renderer/src/components/right-sidebar/git-status-refresh.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { refreshGitStatusForWorktree, type GitStatusRefreshDeps } from './git-status-refresh'
+import type { GitStatusResult } from '../../../../shared/types'
+
+function makeDeps(): GitStatusRefreshDeps {
+  return {
+    setGitStatus: vi.fn(),
+    updateWorktreeGitIdentity: vi.fn(),
+    setUpstreamStatus: vi.fn(),
+    fetchUpstreamStatus: vi.fn().mockResolvedValue(undefined)
+  }
+}
+
+describe('refreshGitStatusForWorktree', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('stores status, branch identity, and upstream data from git status', async () => {
+    const status: GitStatusResult = {
+      entries: [{ path: 'src/index.ts', status: 'modified', area: 'unstaged' }],
+      conflictOperation: 'unknown',
+      head: 'abc123',
+      branch: 'refs/heads/feature',
+      upstreamStatus: {
+        hasUpstream: true,
+        upstreamName: 'origin/feature',
+        ahead: 2,
+        behind: 1
+      }
+    }
+    const gitStatus = vi.fn().mockResolvedValue(status)
+    vi.stubGlobal('window', { api: { git: { status: gitStatus } } })
+    const deps = makeDeps()
+
+    await refreshGitStatusForWorktree({
+      worktreeId: 'wt-1',
+      worktreePath: '/repo',
+      connectionId: 'ssh-1',
+      deps
+    })
+
+    expect(gitStatus).toHaveBeenCalledWith({ worktreePath: '/repo', connectionId: 'ssh-1' })
+    expect(deps.setGitStatus).toHaveBeenCalledWith('wt-1', status)
+    expect(deps.updateWorktreeGitIdentity).toHaveBeenCalledWith('wt-1', {
+      head: 'abc123',
+      branch: 'refs/heads/feature'
+    })
+    expect(deps.setUpstreamStatus).toHaveBeenCalledWith('wt-1', status.upstreamStatus)
+    expect(deps.fetchUpstreamStatus).not.toHaveBeenCalled()
+  })
+
+  it('falls back to explicit upstream refresh for legacy status payloads', async () => {
+    const status: GitStatusResult = {
+      entries: [],
+      conflictOperation: 'unknown',
+      head: 'def456',
+      branch: 'refs/heads/main'
+    }
+    const gitStatus = vi.fn().mockResolvedValue(status)
+    vi.stubGlobal('window', { api: { git: { status: gitStatus } } })
+    const deps = makeDeps()
+
+    await refreshGitStatusForWorktree({
+      worktreeId: 'wt-2',
+      worktreePath: '/repo',
+      connectionId: 'ssh-2',
+      deps
+    })
+
+    expect(deps.setGitStatus).toHaveBeenCalledWith('wt-2', status)
+    expect(deps.updateWorktreeGitIdentity).toHaveBeenCalledWith('wt-2', {
+      head: 'def456',
+      branch: 'refs/heads/main'
+    })
+    expect(deps.setUpstreamStatus).not.toHaveBeenCalled()
+    expect(deps.fetchUpstreamStatus).toHaveBeenCalledWith('wt-2', '/repo', 'ssh-2')
+  })
+})

--- a/src/renderer/src/components/right-sidebar/git-status-refresh.ts
+++ b/src/renderer/src/components/right-sidebar/git-status-refresh.ts
@@ -1,0 +1,45 @@
+import type { GitStatusResult, GitUpstreamStatus } from '../../../../shared/types'
+
+export type GitStatusRefreshDeps = {
+  setGitStatus: (worktreeId: string, status: GitStatusResult) => void
+  updateWorktreeGitIdentity: (
+    worktreeId: string,
+    identity: { head?: string; branch?: string }
+  ) => void
+  setUpstreamStatus: (worktreeId: string, status: GitUpstreamStatus) => void
+  fetchUpstreamStatus: (
+    worktreeId: string,
+    worktreePath: string,
+    connectionId?: string
+  ) => Promise<void>
+}
+
+export async function refreshGitStatusForWorktree({
+  worktreeId,
+  worktreePath,
+  connectionId,
+  deps
+}: {
+  worktreeId: string
+  worktreePath: string
+  connectionId?: string
+  deps: GitStatusRefreshDeps
+}): Promise<void> {
+  const status = (await window.api.git.status({
+    worktreePath,
+    connectionId
+  })) as GitStatusResult
+
+  deps.setGitStatus(worktreeId, status)
+  // Why: branch switches can happen inside a terminal. `git status --branch`
+  // gives us the new identity without a separate worktree-list poll.
+  deps.updateWorktreeGitIdentity(worktreeId, {
+    head: status.head,
+    branch: status.branch
+  })
+  if (status.upstreamStatus) {
+    deps.setUpstreamStatus(worktreeId, status.upstreamStatus)
+    return
+  }
+  await deps.fetchUpstreamStatus(worktreeId, worktreePath, connectionId)
+}

--- a/src/renderer/src/components/right-sidebar/source-control-discard-confirmation.test.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-discard-confirmation.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getDiscardAreaConfirmationCopy,
+  getDiscardEntryConfirmationCopy
+} from './source-control-discard-confirmation'
+import type { GitStatusEntry } from '../../../../shared/types'
+
+function entry(partial: Partial<GitStatusEntry> & { path: string }): GitStatusEntry {
+  return {
+    area: 'unstaged',
+    status: 'modified',
+    ...partial
+  }
+}
+
+describe('getDiscardEntryConfirmationCopy', () => {
+  it('uses delete copy for untracked files', () => {
+    expect(
+      getDiscardEntryConfirmationCopy(
+        entry({ area: 'untracked', path: 'src/new-file.ts', status: 'untracked' })
+      )
+    ).toEqual({
+      title: 'Delete "new-file.ts"?',
+      description: 'This will permanently delete this file. This cannot be undone.',
+      confirmLabel: 'Delete'
+    })
+  })
+
+  it('uses delete copy for files added to the index', () => {
+    expect(
+      getDiscardEntryConfirmationCopy(
+        entry({ area: 'staged', path: 'src/added.ts', status: 'added' })
+      )
+    ).toEqual({
+      title: 'Delete "added.ts"?',
+      description: 'This will permanently delete this file. This cannot be undone.',
+      confirmLabel: 'Delete'
+    })
+  })
+
+  it('uses restore copy for deleted tracked files', () => {
+    expect(
+      getDiscardEntryConfirmationCopy(
+        entry({ area: 'unstaged', path: 'src/removed.ts', status: 'deleted' })
+      )
+    ).toEqual({
+      title: 'Restore "removed.ts"?',
+      description:
+        'This will restore the file from HEAD and discard the deletion. This cannot be undone.',
+      confirmLabel: 'Restore'
+    })
+  })
+
+  it('uses discard copy for modified tracked files', () => {
+    expect(
+      getDiscardEntryConfirmationCopy(entry({ path: 'src/changed.ts', status: 'modified' }))
+    ).toEqual({
+      title: 'Discard changes to "changed.ts"?',
+      description: 'This will revert all changes to this file. This cannot be undone.',
+      confirmLabel: 'Discard'
+    })
+  })
+
+  it('handles Windows-style paths', () => {
+    expect(
+      getDiscardEntryConfirmationCopy(
+        entry({ area: 'untracked', path: 'src\\windows-file.ts', status: 'untracked' })
+      ).title
+    ).toBe('Delete "windows-file.ts"?')
+  })
+})
+
+describe('getDiscardAreaConfirmationCopy', () => {
+  it('uses singular delete copy for one untracked file', () => {
+    expect(getDiscardAreaConfirmationCopy('untracked', 1)).toEqual({
+      title: 'Delete 1 untracked file?',
+      description: 'This will permanently delete this untracked file. This cannot be undone.',
+      confirmLabel: 'Delete'
+    })
+  })
+
+  it('uses plural delete copy for multiple untracked files', () => {
+    expect(getDiscardAreaConfirmationCopy('untracked', 3)).toEqual({
+      title: 'Delete 3 untracked files?',
+      description: 'This will permanently delete these 3 untracked files. This cannot be undone.',
+      confirmLabel: 'Delete 3'
+    })
+  })
+
+  it('warns that staged new files will be deleted', () => {
+    expect(getDiscardAreaConfirmationCopy('staged', 4)).toEqual({
+      title: 'Discard all staged changes?',
+      description:
+        'This will unstage and revert all staged changes. Staged new files will be deleted. This cannot be undone.',
+      confirmLabel: 'Discard all'
+    })
+  })
+
+  it('uses singular unstaged copy', () => {
+    expect(getDiscardAreaConfirmationCopy('unstaged', 1)).toEqual({
+      title: 'Discard all unstaged changes?',
+      description: 'This will revert the unstaged changes in 1 file. This cannot be undone.',
+      confirmLabel: 'Discard all'
+    })
+  })
+
+  it('uses plural unstaged copy', () => {
+    expect(getDiscardAreaConfirmationCopy('unstaged', 2)).toEqual({
+      title: 'Discard all unstaged changes?',
+      description: 'This will revert unstaged changes in 2 files. This cannot be undone.',
+      confirmLabel: 'Discard all'
+    })
+  })
+})

--- a/src/renderer/src/components/right-sidebar/source-control-discard-confirmation.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-discard-confirmation.ts
@@ -1,0 +1,77 @@
+import { basename } from '@/lib/path'
+import type { GitStatusEntry } from '../../../../shared/types'
+import type { DiscardAllArea } from './discard-all-sequence'
+
+export type DiscardConfirmationCopy = {
+  title: string
+  description: string
+  confirmLabel: string
+}
+
+export function getDiscardEntryConfirmationCopy(
+  entry: Pick<GitStatusEntry, 'area' | 'path' | 'status'>
+): DiscardConfirmationCopy {
+  const name = basename(entry.path)
+
+  // Why: untracked and newly-added paths have no HEAD version to restore.
+  // Orca's discard path removes the working-tree file in those cases.
+  if (entry.area === 'untracked' || entry.status === 'untracked' || entry.status === 'added') {
+    return {
+      title: `Delete "${name}"?`,
+      description: 'This will permanently delete this file. This cannot be undone.',
+      confirmLabel: 'Delete'
+    }
+  }
+
+  if (entry.status === 'deleted') {
+    return {
+      title: `Restore "${name}"?`,
+      description:
+        'This will restore the file from HEAD and discard the deletion. This cannot be undone.',
+      confirmLabel: 'Restore'
+    }
+  }
+
+  return {
+    title: `Discard changes to "${name}"?`,
+    description: 'This will revert all changes to this file. This cannot be undone.',
+    confirmLabel: 'Discard'
+  }
+}
+
+export function getDiscardAreaConfirmationCopy(
+  area: DiscardAllArea,
+  count: number
+): DiscardConfirmationCopy {
+  switch (area) {
+    case 'untracked':
+      return {
+        title: count === 1 ? 'Delete 1 untracked file?' : `Delete ${count} untracked files?`,
+        description:
+          count === 1
+            ? 'This will permanently delete this untracked file. This cannot be undone.'
+            : `This will permanently delete these ${count} untracked files. This cannot be undone.`,
+        confirmLabel: count === 1 ? 'Delete' : `Delete ${count}`
+      }
+    case 'staged':
+      return {
+        title: 'Discard all staged changes?',
+        description:
+          'This will unstage and revert all staged changes. Staged new files will be deleted. This cannot be undone.',
+        confirmLabel: 'Discard all'
+      }
+    case 'unstaged':
+      return {
+        title: 'Discard all unstaged changes?',
+        description:
+          count === 1
+            ? 'This will revert the unstaged changes in 1 file. This cannot be undone.'
+            : `This will revert unstaged changes in ${count} files. This cannot be undone.`,
+        confirmLabel: 'Discard all'
+      }
+    default: {
+      const _exhaustive: never = area
+      return _exhaustive
+    }
+  }
+}

--- a/src/renderer/src/components/right-sidebar/useGitStatusPolling.ts
+++ b/src/renderer/src/components/right-sidebar/useGitStatusPolling.ts
@@ -1,9 +1,10 @@
 import { useCallback, useEffect, useMemo } from 'react'
 import { useAppStore } from '@/store'
 import { useActiveWorktree, useAllWorktrees, useRepoById, useRepoMap } from '@/store/selectors'
-import type { GitConflictOperation, GitStatusResult } from '../../../../shared/types'
+import type { GitConflictOperation } from '../../../../shared/types'
 import { isGitRepoKind } from '../../../../shared/repo-kind'
 import { getConnectionId } from '@/lib/connection-context'
+import { refreshGitStatusForWorktree } from './git-status-refresh'
 
 const POLL_INTERVAL_MS = 3000
 
@@ -52,23 +53,17 @@ export function useGitStatusPolling(): void {
     }
     try {
       const connectionId = getConnectionId(activeWorktreeId) ?? undefined
-      const status = (await window.api.git.status({
+      await refreshGitStatusForWorktree({
+        worktreeId: activeWorktreeId,
         worktreePath,
-        connectionId
-      })) as GitStatusResult
-      setGitStatus(activeWorktreeId, status)
-      // Why: branch switches can happen inside a terminal. `git status
-      // --branch` gives us the new identity without a separate worktree-list
-      // poll that would repeatedly touch repo/worktree roots.
-      updateWorktreeGitIdentity(activeWorktreeId, {
-        head: status.head,
-        branch: status.branch
+        connectionId,
+        deps: {
+          setGitStatus,
+          updateWorktreeGitIdentity,
+          setUpstreamStatus,
+          fetchUpstreamStatus
+        }
       })
-      if (status.upstreamStatus) {
-        setUpstreamStatus(activeWorktreeId, status.upstreamStatus)
-      } else {
-        await fetchUpstreamStatus(activeWorktreeId, worktreePath, connectionId)
-      }
     } catch {
       // ignore
     }

--- a/tests/e2e/source-control-discard-confirmation.spec.ts
+++ b/tests/e2e/source-control-discard-confirmation.spec.ts
@@ -1,0 +1,119 @@
+import { test, expect } from './helpers/orca-app'
+import { waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+import type { Page } from '@playwright/test'
+
+type SeededUntrackedFile = {
+  relativePath: string
+  fileName: string
+}
+
+async function openSourceControl(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const state = window.__store?.getState()
+    state?.setRightSidebarOpen(true)
+  })
+  await page.getByRole('button', { name: /Source Control/ }).click()
+  await expect(page.getByPlaceholder(/Filter files/)).toBeVisible()
+}
+
+async function seedUntrackedFile(page: Page): Promise<SeededUntrackedFile> {
+  return page.evaluate(async () => {
+    const store = window.__store
+    if (!store) {
+      throw new Error('window.__store is not available')
+    }
+
+    const state = store.getState()
+    const worktreeId = state.activeWorktreeId
+    const worktree = Object.values(state.worktreesByRepo)
+      .flat()
+      .find((entry) => entry.id === worktreeId)
+    if (!worktree) {
+      throw new Error('active worktree not found')
+    }
+
+    const separator = worktree.path.includes('\\') ? '\\' : '/'
+    const fileName = `orca-discard-confirm-${Date.now()}.txt`
+    const relativePath = fileName
+    await window.api.fs.writeFile({
+      filePath: `${worktree.path}${separator}${relativePath}`,
+      content: 'delete me\n'
+    })
+
+    const status = await window.api.git.status({ worktreePath: worktree.path })
+    state.setGitStatus(worktree.id, status)
+    const statusEntry = status.entries.find((entry) => entry.path.endsWith(fileName))
+    if (!statusEntry) {
+      throw new Error(`git status did not include ${fileName}`)
+    }
+
+    return {
+      relativePath: statusEntry.path,
+      fileName
+    }
+  })
+}
+
+async function refreshGitStatus(page: Page): Promise<void> {
+  await page.evaluate(async () => {
+    const store = window.__store
+    if (!store) {
+      return
+    }
+    const state = store.getState()
+    const worktreeId = state.activeWorktreeId
+    const worktree = Object.values(state.worktreesByRepo)
+      .flat()
+      .find((entry) => entry.id === worktreeId)
+    if (!worktree) {
+      return
+    }
+    state.setGitStatus(worktree.id, await window.api.git.status({ worktreePath: worktree.path }))
+  })
+}
+
+test.describe('Source Control discard confirmation', () => {
+  test.beforeEach(async ({ orcaPage }) => {
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+  })
+
+  test('cancel keeps an untracked file and confirm deletes it', async ({ orcaPage }) => {
+    const seededFile = await seedUntrackedFile(orcaPage)
+    await openSourceControl(orcaPage)
+
+    const row = orcaPage
+      .locator('[data-testid="source-control-entry"]')
+      .filter({ hasText: seededFile.fileName })
+    await expect(row).toBeVisible()
+
+    await row.hover()
+    await row.getByRole('button', { name: 'Delete untracked file' }).click()
+
+    const dialog = orcaPage.getByRole('dialog', {
+      name: `Delete "${seededFile.fileName}"?`
+    })
+    await expect(dialog).toBeVisible()
+    await expect(dialog).toContainText(seededFile.relativePath)
+
+    await dialog.getByRole('button', { name: 'Cancel' }).click()
+    await expect(dialog).toBeHidden()
+    await expect(row).toBeVisible()
+
+    await row.hover()
+    await row.getByRole('button', { name: 'Delete untracked file' }).click()
+    await orcaPage
+      .getByRole('dialog', { name: `Delete "${seededFile.fileName}"?` })
+      .getByRole('button', { name: 'Delete' })
+      .click()
+
+    await expect(row).toHaveCount(0, { timeout: 10_000 })
+
+    await refreshGitStatus(orcaPage)
+    await expect(
+      orcaPage.locator('[data-testid="source-control-entry"]').filter({
+        hasText: seededFile.fileName
+      })
+    ).toHaveCount(0)
+  })
+})


### PR DESCRIPTION
## Summary
- add confirmations for destructive source-control discard/delete actions
- add bulk discard IPC for local and SSH git providers, with fallback behavior for older relays
- refresh git status immediately after source-control mutations so rows disappear without waiting for polling

## Validation
- pnpm test src/main/git/status.test.ts src/main/ipc/filesystem.test.ts src/main/providers/ssh-git-provider.test.ts src/relay/git-handler.test.ts src/renderer/src/components/right-sidebar/discard-all-sequence.test.ts src/renderer/src/components/right-sidebar/git-status-refresh.test.ts src/renderer/src/components/right-sidebar/source-control-discard-confirmation.test.ts
- pnpm run lint (passes with existing warnings in GitHub project components)
- pnpm run tc:node
- pnpm run tc:web
- npx stably test tests/e2e/source-control-discard-confirmation.spec.ts --config tests/playwright.config.ts --project electron-headless
- Manual Electron CDP validation via playwright-cli: cancel kept an untracked file, confirm deleted it, tracked discard restored committed content, bulk delete removed 40 untracked files in 612 ms

Note: full pnpm run tc is currently blocked by unrelated config/tsconfig.tc.cli.json file-list errors.

Made with [Orca](https://github.com/stablyai/orca) 🐋
