### PR TITLE
Tighten Bitbucket environment handling

### DIFF
--- a/src/main/bitbucket/client.test.ts
+++ b/src/main/bitbucket/client.test.ts
@@ -122,28 +122,4 @@ describe('Bitbucket client', () => {
       account: 'bitbucket-user'
     })
   })
-
-  it('accepts T3Code-compatible Bitbucket environment variable names', async () => {
-    delete process.env.ORCA_BITBUCKET_EMAIL
-    delete process.env.ORCA_BITBUCKET_API_TOKEN
-    process.env.T3CODE_BITBUCKET_EMAIL = 't3@example.com'
-    process.env.T3CODE_BITBUCKET_API_TOKEN = 't3-token'
-    const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) =>
-      Response.json({ username: 't3-user' })
-    )
-    vi.stubGlobal('fetch', fetchMock)
-
-    await expect(getBitbucketAuthStatus()).resolves.toEqual({
-      configured: true,
-      authenticated: true,
-      account: 't3-user'
-    })
-    const init = fetchMock.mock.calls[0]?.[1]
-    if (!init) {
-      throw new Error('expected request init')
-    }
-    expect((init.headers as Record<string, string>).Authorization).toBe(
-      `Basic ${Buffer.from('t3@example.com:t3-token').toString('base64')}`
-    )
-  })
 })

--- a/src/main/bitbucket/client.ts
+++ b/src/main/bitbucket/client.ts
@@ -31,19 +31,17 @@ type RequestOptions = {
   timeoutMs?: number
 }
 
-function envValue(primary: string, fallback: string): string | null {
-  const value = process.env[primary]?.trim() || process.env[fallback]?.trim() || ''
+function envValue(name: string): string | null {
+  const value = process.env[name]?.trim() ?? ''
   return value.length > 0 ? value : null
 }
 
 function getAuthConfig(): BitbucketAuthConfig {
   return {
-    baseUrl:
-      envValue('ORCA_BITBUCKET_API_BASE_URL', 'T3CODE_BITBUCKET_API_BASE_URL') ??
-      DEFAULT_API_BASE_URL,
-    accessToken: envValue('ORCA_BITBUCKET_ACCESS_TOKEN', 'T3CODE_BITBUCKET_ACCESS_TOKEN'),
-    email: envValue('ORCA_BITBUCKET_EMAIL', 'T3CODE_BITBUCKET_EMAIL'),
-    apiToken: envValue('ORCA_BITBUCKET_API_TOKEN', 'T3CODE_BITBUCKET_API_TOKEN')
+    baseUrl: envValue('ORCA_BITBUCKET_API_BASE_URL') ?? DEFAULT_API_BASE_URL,
+    accessToken: envValue('ORCA_BITBUCKET_ACCESS_TOKEN'),
+    email: envValue('ORCA_BITBUCKET_EMAIL'),
+    apiToken: envValue('ORCA_BITBUCKET_API_TOKEN')
   }
 }
 

--- a/src/main/opencode/hook-service.test.ts
+++ b/src/main/opencode/hook-service.test.ts
@@ -102,8 +102,8 @@ describe('OpenCode hook plugin source', () => {
     // must forward both so the server-side normalizer can map each to
     // `waiting` and render the red indicator. Dropping `question.asked`
     // leaves the pane stuck in `working` while the agent is actually idle,
-    // waiting on a human reply — exactly the bug three other OpenCode
-    // integrations (cmux, t3code, open-vibe-island) all handle.
+    // waiting on a human reply — exactly the bug other OpenCode integrations
+    // also handle.
     const source = _internals.getOpenCodePluginSource()
 
     expect(source).toContain('if (event.type === "question.asked")')

--- a/src/renderer/src/components/TelemetryFirstLaunchSurface.tsx
+++ b/src/renderer/src/components/TelemetryFirstLaunchSurface.tsx
@@ -1,8 +1,6 @@
 // Root-mounted gate for the existing-user first-launch notice. New users
-// get NO first-launch surface — default-on with no first-run notice
-// matches the category norm set by every direct-shape competitor (emdash,
-// Conductor, superset-sh, cmux, T3 Code, Continue, GitButler); see
-// telemetry-plan.md §First-launch experience for the rationale.
+// get NO first-launch surface; see telemetry-plan.md §First-launch experience
+// for the rationale.
 //
 // Cohort marker populated by the migration in `src/main/persistence.ts`:
 //


### PR DESCRIPTION
## Summary
- Keep Bitbucket auth configuration on ORCA_BITBUCKET_* variables only.
- Remove obsolete comment references.

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/main/bitbucket/client.test.ts src/main/opencode/hook-service.test.ts
- pnpm run typecheck
- pnpm run lint
- git diff --check origin/main...HEAD
- targeted repository string scan