### PR TITLE
feat(ssh): make remote workspaces first-class

### DIFF
--- a/.github/workflows/computer-e2e.yml
+++ b/.github/workflows/computer-e2e.yml
@@ -40,6 +40,14 @@ jobs:
           run_install: false
       - if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y python3 python3-gi gir1.2-atspi-2.0 at-spi2-core xclip xdotool
+      # Why: pnpm's bundled node-gyp can ship gyp_main.py without execute
+      # permission on Linux runners; node-pty's install fallback then fails
+      # before this smoke job can exercise the native package.
+      - name: Use external node-gyp to avoid pnpm's bundled copy (Linux only)
+        if: runner.os == 'Linux'
+        run: |
+          npm install -g node-gyp@11.5.0
+          echo "npm_config_node_gyp=$(npm root -g)/node-gyp/bin/node-gyp.js" >> "$GITHUB_ENV"
       - run: pnpm install --frozen-lockfile
       - run: pnpm verify:computer-native
       - run: pnpm build:cli
@@ -80,6 +88,12 @@ jobs:
         with:
           run_install: false
       - run: sudo apt-get update && sudo apt-get install -y build-essential python3 python3-gi gir1.2-atspi-2.0 gedit at-spi2-core xvfb xclip xdotool
+      # Why: keep scheduled Linux e2e on the same native install path as PR
+      # smoke and pr.yml's verify job.
+      - name: Use external node-gyp to avoid pnpm's bundled copy (Linux only)
+        run: |
+          npm install -g node-gyp@11.5.0
+          echo "npm_config_node_gyp=$(npm root -g)/node-gyp/bin/node-gyp.js" >> "$GITHUB_ENV"
       - run: pnpm install --frozen-lockfile
       - run: pnpm verify:computer-native
       - run: pnpm build:cli

--- a/config/electron-builder.config.cjs
+++ b/config/electron-builder.config.cjs
@@ -7,6 +7,13 @@ const featureWallResources = {
   from: 'resources/onboarding/feature-wall',
   to: 'onboarding/feature-wall'
 }
+// Why: SSH relay deploy resolves bundles from process.resourcesPath in packaged
+// apps. Keeping relay assets as extraResources makes them real directories
+// instead of paths hidden inside app.asar.
+const relayExtraResource = {
+  from: 'out/relay',
+  to: 'relay'
+}
 
 /** @type {import('electron-builder').Configuration} */
 module.exports = {
@@ -85,6 +92,7 @@ module.exports = {
   win: {
     executableName: 'Orca',
     extraResources: [
+      relayExtraResource,
       {
         from: 'resources/win32/bin/orca.cmd',
         to: 'bin/orca.cmd'
@@ -138,6 +146,7 @@ module.exports = {
     hardenedRuntime: isMacRelease,
     notarize: isMacRelease,
     extraResources: [
+      relayExtraResource,
       {
         from: 'resources/darwin/bin/orca',
         to: 'bin/orca'
@@ -174,6 +183,7 @@ module.exports = {
     // The Linux installer should not claim those system package/file names.
     executableName: 'orca-ide',
     extraResources: [
+      relayExtraResource,
       {
         from: 'resources/linux/bin/orca',
         to: 'bin/orca'

--- a/docs/design/ssh-remote-workspace-sync-plan.md
+++ b/docs/design/ssh-remote-workspace-sync-plan.md
@@ -1,0 +1,198 @@
+# SSH Remote Workspace Sync Plan
+
+Planning note for refreshing PR #1690 against current `main`. This is not a merge plan for #1690; current `main` already owns same-client SSH PTY persistence through durable remote PTY leases, relay grace reconnect, explicit expired-session behavior, and provider cleanup semantics.
+
+## Product Boundary
+
+Orca should support an opt-in mode for an SSH target where terminal workspace chrome for that target is stored on the remote host and can be restored by another Orca client connecting to the same target.
+
+In scope:
+
+- Per-SSH-target remote workspace snapshots: terminal tabs, split layouts, active worktree/tab state, and remote PTY IDs needed to reattach live relay PTYs.
+- Device presence for clients currently connected to the same synced target.
+- Cross-client PTY reattach when the remote relay still owns the PTY.
+- Conflict-safe snapshot writes with revisions and stale-write handling.
+- Packaged app relay asset lookup and deployment reliability.
+
+Out of scope:
+
+- A general cloud sync service.
+- Syncing local repos, local PTYs, local browser runtime state, credentials, secrets, shell history, or local filesystem paths.
+- Guaranteed survival after the remote relay/host process exits.
+- Automatic agent recovery as core PTY persistence.
+
+Keep explicit/user-driven:
+
+- Enabling sync per SSH target.
+- Terminating remote sessions through an explicit destructive action. Normal disconnect detaches only.
+- Resuming expired Claude/Codex agent sessions. Show an affordance using stored metadata; do not auto-inject resume commands into a shell.
+- Resolving true conflicts that cannot be merged by target/worktree scope.
+
+## Gap Analysis
+
+Already covered on current `main`:
+
+- Same-client SSH PTY survival across close/quit/reconnect through `activeConnectionIdsAtShutdown`, `remoteSessionIdsByTabId`, durable `SshRemotePtyLease` records, relay grace reconnect, and renderer deferred reattach.
+- Explicit expired-session behavior: failed `pty.attach` marks leases expired and the renderer starts from the expired state rather than silently pretending the old process survived.
+- Provider absence and relay teardown semantics: disconnect detaches, terminate/remove is destructive, and provider registration/ownership are centralized in `SshRelaySession`/`pty.ts`.
+- Relay-side PTY buffering, attach, shutdown, and grace timers.
+
+#1690 adds beyond that:
+
+- Relay-side `workspace.*` RPCs and JSON snapshot storage on the remote host.
+- A target-scoped session filter and scoped merge so one target's snapshot does not overwrite unrelated local/remote workspaces.
+- Remote workspace IPC (`remoteWorkspace:*`) and preload API.
+- Renderer hydration of remote snapshots and event-driven application of `workspace.changed`.
+- Device presence polling and status UI.
+- Multi-client relay dispatcher/socket support so more than one Orca client can talk to the same relay daemon.
+- Resize ownership logic so background clients do not resize a shared remote PTY.
+- Packaged relay asset lookup through `process.resourcesPath`/`extraResources`.
+- Agent resume metadata tied to pane keys. This remains deferred for this implementation.
+
+Now redundant or risky from #1690:
+
+- Do not copy the renderer terminal restore changes wholesale. They overlap directly with recently stabilized `reconnectPersistedTerminals`, deferred SSH session IDs, split-leaf PTY mappings, and expired-session handling.
+- Do not replace same-client persistence with relay snapshots. Local workspace session remains the source of truth for classic SSH targets and for non-synced targets.
+- Do not default sync to on for existing or new targets until product decides retention/privacy behavior.
+- Do not use unlimited relay lifetime as an implicit consequence of sync without a visible setting and cleanup story.
+- Do not auto-run agent resume commands after an expired PTY.
+
+## Fresh Architecture
+
+Use two separate layers:
+
+1. **Local session persistence remains authoritative for this Orca install.** It continues to write normal workspace sessions and durable SSH PTY leases exactly as current `main` does.
+2. **Remote workspace sync is an opt-in target-level overlay.** When enabled and connected, Orca pushes only that target's scoped workspace slice to the relay and hydrates only that target's slice from the relay.
+
+Data ownership:
+
+- Main process owns target configuration, active SSH sessions, remote workspace IPC, snapshot revision checks, ID translation, and old-relay compatibility handling.
+- Relay owns synced snapshot storage under a per-user remote directory, keyed by a sanitized namespace derived from stable target identity.
+- Renderer owns local Zustand workspace state and applies remote snapshots only through a guarded hydration path.
+- PTY lifetime remains owned by the relay and current `SshRemotePtyLease`/PTY ownership maps. Remote snapshots store PTY IDs as references, not as process ownership.
+
+Remote snapshot shape:
+
+- `namespace`, `revision`, `updatedAt`, `schemaVersion`, `clientId`, and `session`.
+- `session` is an explicit v1 projection, not raw `WorkspaceSessionState`.
+- v1 includes only terminal/worktree state, keyed by stable remote worktree path. Import/export translates between remote worktree paths and local `repoId::path` IDs at the main/renderer boundary.
+- Editor/browser chrome, browser URL history, browser profile IDs, and global active connection IDs are excluded from v1 to avoid syncing local-install identifiers or privacy-sensitive local state.
+- Additive fields are okay; wrong-typed core fields must fall back safely.
+
+Sync flow:
+
+- On connect for sync-enabled target: register providers, fetch worktrees, fetch `workspace.get`, translate remote path IDs to local worktree IDs, scope-merge into local state, then let existing terminal reattach paths consume the resulting PTY IDs.
+- Local state remains authoritative immediately after startup. A remote snapshot is applied only if this target has no local dirty state newer than the last synced revision, or the user explicitly refreshes from remote.
+- On local session write: if workspace session is ready and the target was hydrated, export only that target's terminal/worktree slice using remote worktree paths and `workspace.patch` with the last known revision.
+- On stale revision: if both local and newer remote touched the same worktree since the base revision, set conflict state. Otherwise preserve out-of-scope/untouched remote state, merge local touched worktrees, and retry once.
+- On relay `workspace.changed`: ignore self-originated events, queue per target, apply only newer revisions, and avoid triggering a resize unless there is trusted local foreground intent.
+
+Failure semantics:
+
+- Old relay without `workspace.*`: keep classic SSH behavior, mark sync "unavailable until reconnect/update", and do not fail SSH connection.
+- Remote snapshot parse failure: ignore the remote snapshot, leave local session intact, and show sync error for that target.
+- Patch failure: keep local session as-is and retry on next session write or reconnect.
+- Expired PTY referenced by remote snapshot: use the current expired-session path; do not silently replace with a live shell unless the existing UI path already does that intentionally.
+- Explicit disconnect keeps remote PTYs according to current detach semantics. `Terminate remote sessions` kills PTYs. Target removal is destructive after confirmation and must clear or tombstone that target's synced PTY references.
+
+## Phased Implementation Plan
+
+1. **Relay packaging and compatibility PR**
+   - Add relay `extraResources` packaging and `getLocalRelayCandidates(platform)` lookup using `process.resourcesPath`.
+   - Keep current dev path and `ORCA_RELAY_PATH`.
+   - Add tests for packaged candidate order and missing package diagnostics.
+
+2. **Target setting and main IPC skeleton PR**
+   - Add `remoteWorkspaceSyncEnabled` and bounded `remoteWorkspaceSyncGracePeriodSeconds` to `SshTarget`.
+   - Default to false unless product explicitly chooses otherwise.
+   - Add preload/main `remoteWorkspace:*` IPC behind feature availability.
+   - No renderer hydration yet; verify old targets normalize cleanly.
+
+3. **Relay workspace snapshot RPC PR**
+   - Add relay `workspace.get`, `workspace.patch`, and `workspace.presence`.
+   - Store snapshots atomically under a user-private remote directory.
+   - Include namespace sanitization, revisions, schema version, and stale-revision responses.
+   - Wire old-relay method-not-found handling in main as "sync unavailable", not connection failure.
+
+4. **Projected session filtering/merge PR**
+   - Implement target-scoped session extraction in main using repo `connectionId`.
+   - Export/import terminal workspace state through a path-keyed projected schema.
+   - Implement merge that replaces only known in-scope worktrees and preserves out-of-scope remote state.
+   - Cover terminal tabs, split layouts, active IDs, `remoteSessionIdsByTabId`, and last-visited timestamps. Defer editor/browser chrome.
+
+5. **Renderer guarded hydrate/push PR**
+   - Fetch synced snapshots only after target worktrees are loaded.
+   - Apply snapshots through a remote-hydration guard and per-target queue.
+   - Push snapshots from the existing debounced session writer only for hydrated, connected, sync-enabled targets.
+   - Reuse existing `reconnectPersistedTerminals`; only feed it scoped remote session IDs.
+   - Do not enable live cross-client PTY attach unless the multi-client dispatcher and resize ownership from phase 6 are also present.
+
+6. **Multi-client relay + resize ownership PR**
+   - Extend relay dispatcher/socket bridge to support independent client frame state.
+   - Broadcast notifications to all clients, but keep request/response routing per client.
+   - Add foreground/local-intent resize ownership so background hydration or non-focused clients do not resize shared PTYs.
+   - Treat mobile fit locks and current PTY locks as higher priority than desktop resize.
+
+7. **Presence and status UI PR**
+   - Add lightweight presence polling and status display for sync-enabled connected targets.
+   - Show sync phase: idle, pulling, pushing, synced, conflict, error, unavailable/offline.
+   - Follow `docs/STYLEGUIDE.md` tokens and existing status bar patterns.
+
+8. **Agent resume metadata polish PR**
+   - Persist provider/session/cwd metadata as recovery hints only.
+   - Add an explicit "Resume Claude/Codex session" action when a synced PTY expired.
+   - Avoid auto-sending commands on mount or after snapshot hydration.
+
+## Test Plan
+
+Unit:
+
+- Target normalization preserves existing targets and defaults sync off.
+- Namespace derivation is stable and sanitization rejects path traversal/control chars.
+- Relay snapshot read/write handles missing, corrupt, stale, and atomic-write cases.
+- Target-scoped filter excludes local repos and other SSH targets.
+- Projected snapshot import/export translates stable remote worktree paths to local `repoId::path` IDs.
+- Scoped merge preserves out-of-scope remote worktrees and deletes in-scope records when the remote snapshot says they are gone.
+- Stale revision retry preserves edits from the newer remote snapshot.
+- Old relay `-32601` maps to sync unavailable.
+- Packaged relay candidate lookup searches `process.resourcesPath` and dev paths.
+- Resize ownership gates remote resize on focused/local user intent.
+
+Integration:
+
+- Current same-client persistence still passes: close/quit/reconnect restores SSH PTYs without remote workspace sync enabled.
+- Sync-enabled target push writes only that target's session slice.
+- Cross-device simulation with two mux clients: client A pushes, client B receives `workspace.changed`, hydrates, and attaches the same relay PTY.
+- Two clients patch concurrently: one stale response, one retry, no out-of-scope data loss.
+- Explicit disconnect detaches but preserves leases; terminate sessions kills remote PTYs and marks leases terminated.
+- Relay restart or expired grace marks PTY references expired and does not auto-resume agents.
+- Provider-registration wait, if still needed, waits only for restored SSH reattach and does not mask normal spawn failures.
+
+E2E/manual:
+
+- Packaged macOS/Linux/Windows app can deploy the relay from packaged resources.
+- Old running relay continues classic SSH behavior and shows sync unavailable until reconnected with a new relay.
+- Two Orca clients on different machines connect to the same target, open a shared remote workspace, and verify tab/layout sync.
+- Resize a focused terminal on one client while another client is backgrounded; full-screen TUI dimensions follow only the focused client.
+- Mobile/desktop mixed client does not fight PTY dimensions when mobile fit lock is active.
+- Passphrase-protected targets defer reconnect without losing remote session IDs.
+
+## Risks And Decisions
+
+Decisions before implementation:
+
+- Default: should remote workspace sync be opt-in off for all targets? Recommendation: yes.
+- Retention: is `0` unlimited relay lifetime acceptable, or should sync use a large bounded default with visible cleanup?
+- Namespace identity: include `configHost`, host, port, and username. Label changes do not affect namespace.
+- Snapshot scope: v1 is terminal + layout + active worktree/tab only. Editor/browser comes later with explicit allowlists and translation rules.
+- Conflict UX: retry once automatically, then surface "Refresh from remote" / "Overwrite remote" choices.
+- Agent resume UX: explicit action location in expired terminal state or status toast.
+
+Main risks:
+
+- Cross-device resize fights can corrupt TUI layout; ship ownership gates with the first cross-client PTY attach.
+- Snapshot merge bugs can delete unrelated local or remote workspace state; keep target filtering/merge isolated and heavily tested.
+- Unlimited remote relay lifetime can leave processes running unexpectedly; make retention visible and terminate explicit.
+- Old relays may live across app updates; every new RPC must fail open.
+- Renderer hydration can trigger existing session writers and feedback loops; use hydration guards and per-target revision tracking.
+- Remote snapshots contain path/workspace metadata on the SSH host; treat as local-to-remote-user data and document the storage path.

--- a/src/main/github/client-issue-source.test.ts
+++ b/src/main/github/client-issue-source.test.ts
@@ -128,6 +128,42 @@ describe('GitHub issue source split', () => {
     )
   })
 
+  it('lists SSH repo work items with explicit owner/repo and no local cwd', async () => {
+    resolveIssueSourceMock.mockResolvedValueOnce({
+      source: { owner: 'stablyai', repo: 'orca' },
+      fellBack: false
+    })
+    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'fork', repo: 'orca' })
+    ghExecFileAsyncMock.mockResolvedValueOnce({ stdout: '[]' }).mockResolvedValueOnce({
+      stdout: '[]'
+    })
+
+    await listWorkItems('/home/jinwoo/orca', 10, undefined, undefined, 'auto', 'openclaw-2')
+
+    expect(resolveIssueSourceMock).toHaveBeenCalledWith('/home/jinwoo/orca', 'auto', 'openclaw-2')
+    expect(getOwnerRepoMock).toHaveBeenCalledWith('/home/jinwoo/orca', 'openclaw-2')
+    expect(ghExecFileAsyncMock).toHaveBeenNthCalledWith(
+      1,
+      [
+        'api',
+        '--cache',
+        '120s',
+        'repos/stablyai/orca/issues?per_page=10&state=open&sort=updated&direction=desc'
+      ],
+      {}
+    )
+    expect(ghExecFileAsyncMock).toHaveBeenNthCalledWith(
+      2,
+      [
+        'api',
+        '--cache',
+        '120s',
+        'repos/fork/orca/pulls?per_page=10&state=open&sort=updated&direction=desc'
+      ],
+      {}
+    )
+  })
+
   it('uses upstream for issue-only queries and origin for PR-only queries', async () => {
     getIssueOwnerRepoMock.mockResolvedValueOnce({ owner: 'stablyai', repo: 'orca' })
     getOwnerRepoMock.mockResolvedValueOnce({ owner: 'fork', repo: 'orca' })
@@ -332,7 +368,7 @@ describe('GitHub issue source split', () => {
 
       const result = await listWorkItems('/repo-root', 10, undefined, undefined, 'auto')
 
-      expect(resolveIssueSourceMock).toHaveBeenCalledWith('/repo-root', 'auto')
+      expect(resolveIssueSourceMock).toHaveBeenCalledWith('/repo-root', 'auto', undefined)
       expect(ghExecFileAsyncMock).toHaveBeenNthCalledWith(
         1,
         [

--- a/src/main/github/client-pr-checks.test.ts
+++ b/src/main/github/client-pr-checks.test.ts
@@ -21,6 +21,11 @@ const {
 vi.mock('./gh-utils', () => ({
   execFileAsync: execFileAsyncMock,
   ghExecFileAsync: ghExecFileAsyncMock,
+  githubRepoContext: (repoPath: string, connectionId?: string | null) => ({
+    repoPath,
+    connectionId: connectionId ?? null
+  }),
+  ghRepoExecOptions: (context: { repoPath: string }) => ({ cwd: context.repoPath }),
   getOwnerRepo: getOwnerRepoMock,
   getIssueOwnerRepo: getIssueOwnerRepoMock,
   acquire: acquireMock,
@@ -91,7 +96,7 @@ describe('getPRChecks', () => {
 
     expect(ghExecFileAsyncMock).toHaveBeenNthCalledWith(
       2,
-      ['pr', 'checks', '42', '--json', 'name,state,link'],
+      ['pr', 'checks', '42', '--json', 'name,state,link', '--repo', 'acme/widgets'],
       { cwd: '/repo-root' }
     )
     expect(checks).toEqual([

--- a/src/main/github/client-work-items.test.ts
+++ b/src/main/github/client-work-items.test.ts
@@ -28,6 +28,11 @@ const {
 vi.mock('./gh-utils', () => ({
   execFileAsync: execFileAsyncMock,
   ghExecFileAsync: ghExecFileAsyncMock,
+  githubRepoContext: (repoPath: string, connectionId?: string | null) => ({
+    repoPath,
+    connectionId: connectionId ?? null
+  }),
+  ghRepoExecOptions: (context: { repoPath: string }) => ({ cwd: context.repoPath }),
   getOwnerRepo: getOwnerRepoMock,
   getIssueOwnerRepo: getIssueOwnerRepoMock,
   getOwnerRepoForRemote: getOwnerRepoForRemoteMock,

--- a/src/main/github/client.test.ts
+++ b/src/main/github/client.test.ts
@@ -1,3 +1,4 @@
+/* oxlint-disable max-lines -- Why: GitHub client fixtures cover local and SSH repo identity paths in one suite so mocked CLI behavior stays consistent. */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
@@ -6,7 +7,10 @@ const {
   getOwnerRepoMock,
   getIssueOwnerRepoMock,
   getOwnerRepoForRemoteMock,
+  getRemoteUrlForRepoMock,
   gitExecFileAsyncMock,
+  ghRepoExecOptionsMock,
+  githubRepoContextMock,
   acquireMock,
   releaseMock
 } = vi.hoisted(() => ({
@@ -15,7 +19,15 @@ const {
   getOwnerRepoMock: vi.fn(),
   getIssueOwnerRepoMock: vi.fn(),
   getOwnerRepoForRemoteMock: vi.fn(),
+  getRemoteUrlForRepoMock: vi.fn(),
   gitExecFileAsyncMock: vi.fn(),
+  ghRepoExecOptionsMock: vi.fn((context) =>
+    context.connectionId ? {} : { cwd: context.repoPath }
+  ),
+  githubRepoContextMock: vi.fn((repoPath, connectionId) => ({
+    repoPath,
+    connectionId: connectionId ?? null
+  })),
   acquireMock: vi.fn(),
   releaseMock: vi.fn()
 }))
@@ -26,7 +38,10 @@ vi.mock('./gh-utils', () => ({
   getOwnerRepo: getOwnerRepoMock,
   getIssueOwnerRepo: getIssueOwnerRepoMock,
   getOwnerRepoForRemote: getOwnerRepoForRemoteMock,
+  getRemoteUrlForRepo: getRemoteUrlForRepoMock,
   gitExecFileAsync: gitExecFileAsyncMock,
+  ghRepoExecOptions: ghRepoExecOptionsMock,
+  githubRepoContext: githubRepoContextMock,
   parseGitHubOwnerRepo: (remoteUrl: string) => {
     const match = remoteUrl.trim().match(/github\.com[:/]([^/]+)\/([^/]+?)(?:\.git)?$/)
     return match ? { owner: match[1], repo: match[2] } : null
@@ -49,7 +64,10 @@ describe('getPRForBranch', () => {
     getOwnerRepoMock.mockReset()
     getIssueOwnerRepoMock.mockReset()
     getOwnerRepoForRemoteMock.mockReset()
+    getRemoteUrlForRepoMock.mockReset()
     gitExecFileAsyncMock.mockReset()
+    ghRepoExecOptionsMock.mockClear()
+    githubRepoContextMock.mockClear()
     acquireMock.mockReset()
     releaseMock.mockReset()
     acquireMock.mockResolvedValue(undefined)
@@ -79,7 +97,7 @@ describe('getPRForBranch', () => {
 
     const pr = await getPRForBranch('/repo-root', 'refs/heads/feature/test')
 
-    expect(getOwnerRepoMock).toHaveBeenCalledWith('/repo-root')
+    expect(getOwnerRepoMock).toHaveBeenCalledWith('/repo-root', undefined)
     expect(ghExecFileAsyncMock).toHaveBeenCalledWith(
       [
         'pr',

--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -29,6 +29,9 @@ import {
   resolveIssueSource,
   classifyGhError,
   classifyListIssuesError,
+  ghRepoExecOptions,
+  githubRepoContext,
+  getRemoteUrlForRepo,
   type OwnerRepo
 } from './gh-utils'
 export { _resetOwnerRepoCache } from './gh-utils'
@@ -98,9 +101,12 @@ function sanitizeRemoteName(owner: string, repo: string): string {
 
 export async function getPullRequestPushTarget(
   repoPath: string,
-  prNumber: number
+  prNumber: number,
+  connectionId?: string | null
 ): Promise<GitPushTarget | null> {
-  const ownerRepo = await getOwnerRepo(repoPath)
+  const context = githubRepoContext(repoPath, connectionId)
+  const ghOptions = ghRepoExecOptions(context)
+  const ownerRepo = await getOwnerRepo(repoPath, connectionId)
   if (!ownerRepo) {
     return null
   }
@@ -109,9 +115,9 @@ export async function getPullRequestPushTarget(
   try {
     const [{ stdout: prStdout }, origin] = await Promise.all([
       ghExecFileAsync(['api', `repos/${ownerRepo.owner}/${ownerRepo.repo}/pulls/${prNumber}`], {
-        cwd: repoPath
+        ...ghOptions
       }),
-      getOwnerRepoForRemote(repoPath, 'origin')
+      getOwnerRepoForRemote(repoPath, 'origin', connectionId)
     ])
     const pr = JSON.parse(prStdout) as {
       head?: {
@@ -144,8 +150,10 @@ export async function getPullRequestPushTarget(
 
     let originUrl: string | null = null
     try {
-      const { stdout } = await gitExecFileAsync(['remote', 'get-url', 'origin'], { cwd: repoPath })
-      originUrl = stdout.trim() || null
+      const rawOriginUrl = connectionId
+        ? await getRemoteUrlForRepo(context, 'origin')
+        : (await gitExecFileAsync(['remote', 'get-url', 'origin'], { cwd: repoPath })).stdout
+      originUrl = rawOriginUrl?.trim() || null
     } catch {
       originUrl = null
     }
@@ -318,12 +326,14 @@ function mapPullRequestWorkItem(
 async function fetchIssueWorkItem(
   repoPath: string,
   ownerRepo: OwnerRepo | null,
-  number: number
+  number: number,
+  connectionId?: string | null
 ): Promise<MainWorkItem | null> {
+  const ghOptions = ghRepoExecOptions(githubRepoContext(repoPath, connectionId))
   if (ownerRepo) {
     const { stdout } = await ghExecFileAsync(
       ['api', `repos/${ownerRepo.owner}/${ownerRepo.repo}/issues/${number}`],
-      { cwd: repoPath }
+      ghOptions
     )
     const item = JSON.parse(stdout) as Record<string, unknown>
     if ('pull_request' in item) {
@@ -334,7 +344,7 @@ async function fetchIssueWorkItem(
 
   const { stdout } = await ghExecFileAsync(
     ['issue', 'view', String(number), '--json', 'number,title,state,url,labels,updatedAt,author'],
-    { cwd: repoPath }
+    ghOptions
   )
   return mapIssueWorkItem(JSON.parse(stdout) as Record<string, unknown>)
 }
@@ -342,12 +352,14 @@ async function fetchIssueWorkItem(
 async function fetchPullRequestWorkItem(
   repoPath: string,
   ownerRepo: OwnerRepo | null,
-  number: number
+  number: number,
+  connectionId?: string | null
 ): Promise<MainWorkItem> {
+  const ghOptions = ghRepoExecOptions(githubRepoContext(repoPath, connectionId))
   if (ownerRepo) {
     const { stdout } = await ghExecFileAsync(
       ['api', `repos/${ownerRepo.owner}/${ownerRepo.repo}/pulls/${number}`],
-      { cwd: repoPath }
+      ghOptions
     )
     return mapPullRequestWorkItem(JSON.parse(stdout) as Record<string, unknown>, ownerRepo.owner)
   }
@@ -360,7 +372,7 @@ async function fetchPullRequestWorkItem(
       '--json',
       'number,title,state,url,labels,updatedAt,author,isDraft,headRefName,baseRefName,headRepositoryOwner'
     ],
-    { cwd: repoPath }
+    ghOptions
   )
   return mapPullRequestWorkItem(JSON.parse(stdout) as Record<string, unknown>)
 }
@@ -447,8 +459,10 @@ async function listRecentWorkItems(
   repoPath: string,
   issueOwnerRepo: OwnerRepo | null,
   prOwnerRepo: OwnerRepo | null,
-  limit: number
+  limit: number,
+  connectionId?: string | null
 ): Promise<PartialWorkItemsResult> {
+  const ghOptions = ghRepoExecOptions(githubRepoContext(repoPath, connectionId))
   if (issueOwnerRepo || prOwnerRepo) {
     // Why: allSettled so a 403 on upstream issues doesn't zero out the origin
     // PR half — the UI renders partial results plus a banner for the failing
@@ -462,7 +476,7 @@ async function listRecentWorkItems(
               '120s',
               `repos/${issueOwnerRepo.owner}/${issueOwnerRepo.repo}/issues?per_page=${limit}&state=open&sort=updated&direction=desc`
             ],
-            { cwd: repoPath }
+            ghOptions
           )
         : ghExecFileAsync(
             [
@@ -475,7 +489,7 @@ async function listRecentWorkItems(
               '--json',
               'number,title,state,url,labels,updatedAt,author'
             ],
-            { cwd: repoPath }
+            ghOptions
           ),
       prOwnerRepo
         ? ghExecFileAsync(
@@ -485,7 +499,7 @@ async function listRecentWorkItems(
               '120s',
               `repos/${prOwnerRepo.owner}/${prOwnerRepo.repo}/pulls?per_page=${limit}&state=open&sort=updated&direction=desc`
             ],
-            { cwd: repoPath }
+            ghOptions
           )
         : ghExecFileAsync(
             [
@@ -498,7 +512,7 @@ async function listRecentWorkItems(
               '--json',
               'number,title,state,url,labels,updatedAt,author,isDraft,headRefName,baseRefName,headRepositoryOwner'
             ],
-            { cwd: repoPath }
+            ghOptions
           )
     ])
 
@@ -569,7 +583,7 @@ async function listRecentWorkItems(
         '--json',
         'number,title,state,url,labels,updatedAt,author'
       ],
-      { cwd: repoPath }
+      ghOptions
     ),
     ghExecFileAsync(
       [
@@ -582,7 +596,7 @@ async function listRecentWorkItems(
         '--json',
         'number,title,state,url,labels,updatedAt,author,isDraft,headRefName,baseRefName,headRepositoryOwner'
       ],
-      { cwd: repoPath }
+      ghOptions
     )
   ])
 
@@ -604,8 +618,10 @@ async function listQueriedWorkItems(
   prOwnerRepo: OwnerRepo | null,
   query: ParsedTaskQuery,
   limit: number,
-  before?: string
+  before?: string,
+  connectionId?: string | null
 ): Promise<PartialWorkItemsResult> {
+  const ghOptions = ghRepoExecOptions(githubRepoContext(repoPath, connectionId))
   const issueScope = query.scope !== 'pr'
   const prScope = query.scope !== 'issue'
 
@@ -624,7 +640,7 @@ async function listQueriedWorkItems(
       before
     })
     try {
-      const { stdout } = await ghExecFileAsync(args, { cwd: repoPath })
+      const { stdout } = await ghExecFileAsync(args, ghOptions)
       return {
         items: (JSON.parse(stdout) as Record<string, unknown>[]).map(mapIssueWorkItem)
       }
@@ -646,7 +662,7 @@ async function listQueriedWorkItems(
       before
     })
     try {
-      const { stdout } = await ghExecFileAsync(args, { cwd: repoPath })
+      const { stdout } = await ghExecFileAsync(args, ghOptions)
       return (JSON.parse(stdout) as Record<string, unknown>[]).map((item) =>
         mapPullRequestWorkItem(item, prOwnerRepo?.owner ?? null)
       )
@@ -668,7 +684,8 @@ export async function listWorkItems(
   limit = 24,
   query?: string,
   before?: string,
-  preference?: IssueSourcePreference
+  preference?: IssueSourcePreference,
+  connectionId?: string | null
 ): Promise<ListWorkItemsResult<MainWorkItem>> {
   // Why: resolve the raw upstream candidate alongside the preference-aware
   // issue source. The selector needs to know whether an upstream remote
@@ -676,9 +693,9 @@ export async function listWorkItems(
   // has picked 'origin' (which would otherwise make `sources.issues` equal
   // origin and hide the selector permanently).
   const [issueResolved, prOwnerRepo, upstreamCandidate] = await Promise.all([
-    resolveIssueSource(repoPath, preference),
-    getOwnerRepo(repoPath),
-    getOwnerRepoForRemote(repoPath, 'upstream')
+    resolveIssueSource(repoPath, preference, connectionId),
+    getOwnerRepo(repoPath, connectionId),
+    getOwnerRepoForRemote(repoPath, 'upstream', connectionId)
   ])
   const issueOwnerRepo = issueResolved.source
   const trimmedQuery = query?.trim() ?? ''
@@ -689,14 +706,15 @@ export async function listWorkItems(
     // catch-all here would make an auth/network failure indistinguishable from
     // an empty result and silently under-report per-repo failures.
     const partial = !trimmedQuery
-      ? await listRecentWorkItems(repoPath, issueOwnerRepo, prOwnerRepo, limit)
+      ? await listRecentWorkItems(repoPath, issueOwnerRepo, prOwnerRepo, limit, connectionId)
       : await listQueriedWorkItems(
           repoPath,
           issueOwnerRepo,
           prOwnerRepo,
           parseTaskQuery(trimmedQuery),
           limit,
-          before
+          before,
+          connectionId
         )
 
     const errors = partial.issuesError ? { issues: partial.issuesError } : undefined
@@ -759,9 +777,11 @@ function buildSearchQueryString(
 async function countWorkItemsForQuery(
   repoPath: string,
   ownerRepo: OwnerRepo,
-  query: ParsedTaskQuery
+  query: ParsedTaskQuery,
+  connectionId?: string | null
 ): Promise<number> {
   const searchQ = buildSearchQueryString(ownerRepo, query)
+  const ghOptions = ghRepoExecOptions(githubRepoContext(repoPath, connectionId))
   const { stdout } = await ghExecFileAsync(
     [
       'api',
@@ -771,7 +791,7 @@ async function countWorkItemsForQuery(
       '--jq',
       '.total_count'
     ],
-    { cwd: repoPath }
+    ghOptions
   )
   return parseInt(stdout.trim(), 10) || 0
 }
@@ -806,11 +826,12 @@ function defaultOpenWorkItemQuery(): ParsedTaskQuery {
 export async function countWorkItems(
   repoPath: string,
   query?: string,
-  preference?: IssueSourcePreference
+  preference?: IssueSourcePreference,
+  connectionId?: string | null
 ): Promise<number> {
   const [issueResolved, prOwnerRepo] = await Promise.all([
-    resolveIssueSource(repoPath, preference),
-    getOwnerRepo(repoPath)
+    resolveIssueSource(repoPath, preference, connectionId),
+    getOwnerRepo(repoPath, connectionId)
   ])
   const issueOwnerRepo = issueResolved.source
   const ownerRepo = prOwnerRepo ?? issueOwnerRepo
@@ -825,7 +846,7 @@ export async function countWorkItems(
   await acquire()
   try {
     if (sameOwnerRepo(issueOwnerRepo, prOwnerRepo)) {
-      return await countWorkItemsForQuery(repoPath, ownerRepo, effectiveQuery)
+      return await countWorkItemsForQuery(repoPath, ownerRepo, effectiveQuery, connectionId)
     }
 
     const counts: Promise<number>[] = []
@@ -843,11 +864,23 @@ export async function countWorkItems(
       issueOwnerRepo
     ) {
       counts.push(
-        countWorkItemsForQuery(repoPath, issueOwnerRepo, { ...effectiveQuery, scope: 'issue' })
+        countWorkItemsForQuery(
+          repoPath,
+          issueOwnerRepo,
+          { ...effectiveQuery, scope: 'issue' },
+          connectionId
+        )
       )
     }
     if (effectiveQuery.scope !== 'issue' && prOwnerRepo) {
-      counts.push(countWorkItemsForQuery(repoPath, prOwnerRepo, { ...effectiveQuery, scope: 'pr' }))
+      counts.push(
+        countWorkItemsForQuery(
+          repoPath,
+          prOwnerRepo,
+          { ...effectiveQuery, scope: 'pr' },
+          connectionId
+        )
+      )
     }
     // Why: allSettled so a single failing search (e.g. transient network, rate
     // limit on one side) doesn't silently zero out the total; sum only the
@@ -871,27 +904,44 @@ export async function countWorkItems(
 }
 
 export async function getRepoSlug(
-  repoPath: string
+  repoPath: string,
+  connectionId?: string | null
 ): Promise<{ owner: string; repo: string } | null> {
-  return getOwnerRepo(repoPath)
+  return getOwnerRepo(repoPath, connectionId)
 }
 
 export async function getWorkItem(
   repoPath: string,
   number: number,
-  type?: 'issue' | 'pr'
+  type?: 'issue' | 'pr',
+  connectionId?: string | null
 ): Promise<MainWorkItem | null> {
   await acquire()
   try {
     if (type === 'issue') {
-      return await fetchIssueWorkItem(repoPath, await getIssueOwnerRepo(repoPath), number)
+      return await fetchIssueWorkItem(
+        repoPath,
+        await getIssueOwnerRepo(repoPath, connectionId),
+        number,
+        connectionId
+      )
     }
     if (type === 'pr') {
-      return await fetchPullRequestWorkItem(repoPath, await getOwnerRepo(repoPath), number)
+      return await fetchPullRequestWorkItem(
+        repoPath,
+        await getOwnerRepo(repoPath, connectionId),
+        number,
+        connectionId
+      )
     }
 
     try {
-      const issue = await fetchIssueWorkItem(repoPath, await getIssueOwnerRepo(repoPath), number)
+      const issue = await fetchIssueWorkItem(
+        repoPath,
+        await getIssueOwnerRepo(repoPath, connectionId),
+        number,
+        connectionId
+      )
       if (issue) {
         return issue
       }
@@ -907,7 +957,12 @@ export async function getWorkItem(
         throw err
       }
     }
-    return await fetchPullRequestWorkItem(repoPath, await getOwnerRepo(repoPath), number)
+    return await fetchPullRequestWorkItem(
+      repoPath,
+      await getOwnerRepo(repoPath, connectionId),
+      number,
+      connectionId
+    )
   } catch {
     return null
   } finally {
@@ -919,14 +974,15 @@ export async function getWorkItemByOwnerRepo(
   repoPath: string,
   ownerRepo: OwnerRepo,
   number: number,
-  type: 'issue' | 'pr'
+  type: 'issue' | 'pr',
+  connectionId?: string | null
 ): Promise<MainWorkItem | null> {
   await acquire()
   try {
     if (type === 'issue') {
-      return await fetchIssueWorkItem(repoPath, ownerRepo, number)
+      return await fetchIssueWorkItem(repoPath, ownerRepo, number, connectionId)
     }
-    return await fetchPullRequestWorkItem(repoPath, ownerRepo, number)
+    return await fetchPullRequestWorkItem(repoPath, ownerRepo, number, connectionId)
   } catch {
     return null
   } finally {
@@ -947,14 +1003,17 @@ export async function getWorkItemByOwnerRepo(
 export async function getPRForBranch(
   repoPath: string,
   branch: string,
-  linkedPRNumber?: number | null
+  linkedPRNumber?: number | null,
+  connectionId?: string | null
 ): Promise<PRInfo | null> {
   // Strip refs/heads/ prefix if present
   const branchName = branch.replace(/^refs\/heads\//, '')
+  const context = githubRepoContext(repoPath, connectionId)
+  const ghOptions = ghRepoExecOptions(context)
 
   await acquire()
   try {
-    const ownerRepo = await getOwnerRepo(repoPath)
+    const ownerRepo = await getOwnerRepo(repoPath, connectionId)
     let data: {
       number: number
       title: string
@@ -990,7 +1049,7 @@ export async function getPRForBranch(
             '--json',
             'number,title,state,url,statusCheckRollup,updatedAt,isDraft,mergeable,baseRefName,headRefName,baseRefOid,headRefOid'
           ],
-          { cwd: repoPath }
+          ghOptions
         )
         const list = JSON.parse(stdout) as NonNullable<typeof data>[]
         data = list[0] ?? null
@@ -1003,7 +1062,7 @@ export async function getPRForBranch(
             '--json',
             'number,title,state,url,statusCheckRollup,updatedAt,isDraft,mergeable,baseRefName,headRefName,baseRefOid,headRefOid'
           ],
-          { cwd: repoPath }
+          ghOptions
         )
         data = JSON.parse(stdout)
       }
@@ -1028,7 +1087,7 @@ export async function getPRForBranch(
             'number,title,state,url,statusCheckRollup,updatedAt,isDraft,mergeable,baseRefName,headRefName,baseRefOid,headRefOid'
           ]
       try {
-        const { stdout } = await ghExecFileAsync(args, { cwd: repoPath })
+        const { stdout } = await ghExecFileAsync(args, ghOptions)
         data = JSON.parse(stdout)
       } catch {
         // Why: a stale linkedPRNumber (PR deleted, wrong repo, …) makes
@@ -1044,7 +1103,11 @@ export async function getPRForBranch(
     }
 
     const conflictSummary =
-      data.mergeable === 'CONFLICTING' && data.baseRefName && data.baseRefOid && data.headRefOid
+      !connectionId &&
+      data.mergeable === 'CONFLICTING' &&
+      data.baseRefName &&
+      data.baseRefOid &&
+      data.headRefOid
         ? await getPRConflictSummary(repoPath, data.baseRefName, data.baseRefOid, data.headRefOid)
         : undefined
 
@@ -1075,9 +1138,11 @@ export async function getPRChecks(
   repoPath: string,
   prNumber: number,
   headSha?: string,
-  options?: { noCache?: boolean }
+  options?: { noCache?: boolean },
+  connectionId?: string | null
 ): Promise<PRCheckDetail[]> {
-  const ownerRepo = headSha ? await getOwnerRepo(repoPath) : null
+  const ghOptions = ghRepoExecOptions(githubRepoContext(repoPath, connectionId))
+  const ownerRepo = await getOwnerRepo(repoPath, connectionId)
   await acquire()
   try {
     if (ownerRepo && headSha) {
@@ -1091,7 +1156,7 @@ export async function getPRChecks(
             ...cacheArgs,
             `repos/${ownerRepo.owner}/${ownerRepo.repo}/commits/${encodeURIComponent(headSha)}/check-runs?per_page=100`
           ],
-          { cwd: repoPath }
+          ghOptions
         )
         const data = JSON.parse(stdout) as {
           check_runs: {
@@ -1116,10 +1181,11 @@ export async function getPRChecks(
       }
     }
     // Fallback: no branch provided or non-GitHub remote
-    const { stdout } = await ghExecFileAsync(
-      ['pr', 'checks', String(prNumber), '--json', 'name,state,link'],
-      { cwd: repoPath }
-    )
+    const fallbackArgs = ['pr', 'checks', String(prNumber), '--json', 'name,state,link']
+    if (ownerRepo) {
+      fallbackArgs.push('--repo', `${ownerRepo.owner}/${ownerRepo.repo}`)
+    }
+    const { stdout } = await ghExecFileAsync(fallbackArgs, ghOptions)
     const data = JSON.parse(stdout) as { name: string; state: string; link: string }[]
     return data.map((d) => ({
       name: d.name,
@@ -1195,9 +1261,11 @@ query($owner: String!, $repo: String!, $pr: Int!) {
 export async function getPRComments(
   repoPath: string,
   prNumber: number,
-  options?: { noCache?: boolean }
+  options?: { noCache?: boolean },
+  connectionId?: string | null
 ): Promise<PRComment[]> {
-  const ownerRepo = await getOwnerRepo(repoPath)
+  const ghOptions = ghRepoExecOptions(githubRepoContext(repoPath, connectionId))
+  const ownerRepo = await getOwnerRepo(repoPath, connectionId)
   await acquire()
   try {
     if (ownerRepo) {
@@ -1211,9 +1279,10 @@ export async function getPRComments(
       // Each source is parsed independently; failed sources contribute zero
       // comments instead of aborting the entire fetch.
       const [issueResult, threadsResult, reviewsResult] = await Promise.allSettled([
-        ghExecFileAsync(['api', ...cacheArgs, `${base}/issues/${prNumber}/comments?per_page=100`], {
-          cwd: repoPath
-        }),
+        ghExecFileAsync(
+          ['api', ...cacheArgs, `${base}/issues/${prNumber}/comments?per_page=100`],
+          ghOptions
+        ),
         ghExecFileAsync(
           [
             'api',
@@ -1227,15 +1296,16 @@ export async function getPRComments(
             '-F',
             `pr=${prNumber}`
           ],
-          { cwd: repoPath }
+          ghOptions
         ),
         // Why: review summaries (approve, request changes, general comments) live
         // under pulls/{n}/reviews, not under issue comments or review threads.
         // Without this, a reviewer who submits "LGTM" without inline threads
         // would have their comment silently dropped from the panel.
-        ghExecFileAsync(['api', ...cacheArgs, `${base}/pulls/${prNumber}/reviews?per_page=100`], {
-          cwd: repoPath
-        })
+        ghExecFileAsync(
+          ['api', ...cacheArgs, `${base}/pulls/${prNumber}/reviews?per_page=100`],
+          ghOptions
+        )
       ])
 
       // Parse issue comments (REST)
@@ -1384,9 +1454,7 @@ export async function getPRComments(
     // Fallback: non-GitHub remote — use gh pr view (only returns issue-level comments)
     const { stdout } = await ghExecFileAsync(
       ['pr', 'view', String(prNumber), '--json', 'comments'],
-      {
-        cwd: repoPath
-      }
+      ghOptions
     )
     const data = JSON.parse(stdout) as {
       comments: {
@@ -1418,16 +1486,17 @@ export async function getPRComments(
 export async function resolveReviewThread(
   repoPath: string,
   threadId: string,
-  resolve: boolean
+  resolve: boolean,
+  connectionId?: string | null
 ): Promise<boolean> {
   const mutation = resolve ? 'resolveReviewThread' : 'unresolveReviewThread'
   const query = `mutation($threadId: ID!) { ${mutation}(input: { threadId: $threadId }) { thread { isResolved } } }`
+  const ghOptions = ghRepoExecOptions(githubRepoContext(repoPath, connectionId))
   await acquire()
   try {
-    await execFileAsync(
-      'gh',
+    await ghExecFileAsync(
       ['api', 'graphql', '-f', `query=${query}`, '-f', `threadId=${threadId}`],
-      { cwd: repoPath, encoding: 'utf-8' }
+      ghOptions
     )
     return true
   } catch (err) {
@@ -1476,9 +1545,11 @@ export async function addPRReviewCommentReply(
   body: string,
   threadId?: string,
   path?: string,
-  line?: number
+  line?: number,
+  connectionId?: string | null
 ): Promise<GitHubCommentResult> {
-  const ownerRepo = await getOwnerRepo(repoPath)
+  const ghOptions = ghRepoExecOptions(githubRepoContext(repoPath, connectionId))
+  const ownerRepo = await getOwnerRepo(repoPath, connectionId)
   if (!ownerRepo) {
     return { ok: false, error: 'Could not resolve GitHub owner/repo for this repository' }
   }
@@ -1493,7 +1564,7 @@ export async function addPRReviewCommentReply(
         '--raw-field',
         `body=${body}`
       ],
-      { cwd: repoPath }
+      ghOptions
     )
     return {
       ok: true,
@@ -1508,9 +1579,10 @@ export async function addPRReviewCommentReply(
 }
 
 export async function addPRReviewComment(
-  args: GitHubPRReviewCommentInput
+  args: GitHubPRReviewCommentInput & { connectionId?: string | null }
 ): Promise<GitHubCommentResult> {
-  const ownerRepo = await getOwnerRepo(args.repoPath)
+  const ghOptions = ghRepoExecOptions(githubRepoContext(args.repoPath, args.connectionId))
+  const ownerRepo = await getOwnerRepo(args.repoPath, args.connectionId)
   if (!ownerRepo) {
     return { ok: false, error: 'Could not resolve GitHub owner/repo for this repository' }
   }
@@ -1540,7 +1612,7 @@ export async function addPRReviewComment(
         'start_side=RIGHT'
       )
     }
-    const { stdout } = await ghExecFileAsync(fields, { cwd: args.repoPath })
+    const { stdout } = await ghExecFileAsync(fields, ghOptions)
     return {
       ok: true,
       comment: mapReviewCommentResponse(
@@ -1566,15 +1638,22 @@ export async function addPRReviewComment(
 export async function mergePR(
   repoPath: string,
   prNumber: number,
-  method: 'merge' | 'squash' | 'rebase' = 'squash'
+  method: 'merge' | 'squash' | 'rebase' = 'squash',
+  connectionId?: string | null
 ): Promise<{ ok: true } | { ok: false; error: string }> {
+  const ghOptions = ghRepoExecOptions(githubRepoContext(repoPath, connectionId))
+  const ownerRepo = await getOwnerRepo(repoPath, connectionId)
   await acquire()
   try {
     // Don't use --delete-branch: it tries to delete the local branch which
     // fails when the user's worktree is checked out on it. Branch cleanup
     // is handled by worktree deletion (local) and GitHub's auto-delete setting (remote).
-    await ghExecFileAsync(['pr', 'merge', String(prNumber), `--${method}`], {
-      cwd: repoPath,
+    const args = ['pr', 'merge', String(prNumber), `--${method}`]
+    if (ownerRepo) {
+      args.push('--repo', `${ownerRepo.owner}/${ownerRepo.repo}`)
+    }
+    await ghExecFileAsync(args, {
+      ...ghOptions,
       env: { ...process.env, GH_PROMPT_DISABLED: '1' }
     })
     return { ok: true }
@@ -1593,12 +1672,19 @@ export async function mergePR(
 export async function updatePRTitle(
   repoPath: string,
   prNumber: number,
-  title: string
+  title: string,
+  connectionId?: string | null
 ): Promise<boolean> {
+  const ghOptions = ghRepoExecOptions(githubRepoContext(repoPath, connectionId))
+  const ownerRepo = await getOwnerRepo(repoPath, connectionId)
   await acquire()
   try {
-    await ghExecFileAsync(['pr', 'edit', String(prNumber), '--title', title], {
-      cwd: repoPath
+    const args = ['pr', 'edit', String(prNumber), '--title', title]
+    if (ownerRepo) {
+      args.push('--repo', `${ownerRepo.owner}/${ownerRepo.repo}`)
+    }
+    await ghExecFileAsync(args, {
+      ...ghOptions
     })
     return true
   } catch (err) {

--- a/src/main/github/gh-utils.test.ts
+++ b/src/main/github/gh-utils.test.ts
@@ -1,12 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { gitExecFileAsyncMock } = vi.hoisted(() => ({
-  gitExecFileAsyncMock: vi.fn()
+const { gitExecFileAsyncMock, getSshGitProviderMock } = vi.hoisted(() => ({
+  gitExecFileAsyncMock: vi.fn(),
+  getSshGitProviderMock: vi.fn()
 }))
 
 vi.mock('../git/runner', () => ({
   gitExecFileAsync: gitExecFileAsyncMock,
   ghExecFileAsync: vi.fn()
+}))
+
+vi.mock('../providers/ssh-git-dispatch', () => ({
+  getSshGitProvider: getSshGitProviderMock
 }))
 
 import {
@@ -22,6 +27,7 @@ import {
 describe('github owner/repo resolution', () => {
   beforeEach(() => {
     gitExecFileAsyncMock.mockReset()
+    getSshGitProviderMock.mockReset()
     _resetOwnerRepoCache()
   })
 
@@ -85,11 +91,42 @@ describe('github owner/repo resolution', () => {
     await expect(getOwnerRepo('/repo')).resolves.toEqual({ owner: 'fork', repo: 'orca' })
     await expect(getIssueOwnerRepo('/repo')).resolves.toEqual({ owner: 'stablyai', repo: 'orca' })
   })
+
+  it('resolves SSH repo remotes through the registered SSH git provider', async () => {
+    const sshProvider = {
+      exec: vi.fn().mockResolvedValue({ stdout: 'git@github.com:stablyai/orca.git\n', stderr: '' })
+    }
+    getSshGitProviderMock.mockReturnValue(sshProvider)
+
+    await expect(getOwnerRepo('/home/user/orca', 'openclaw-2')).resolves.toEqual({
+      owner: 'stablyai',
+      repo: 'orca'
+    })
+
+    expect(gitExecFileAsyncMock).not.toHaveBeenCalled()
+    expect(getSshGitProviderMock).toHaveBeenCalledWith('openclaw-2')
+    expect(sshProvider.exec).toHaveBeenCalledWith(
+      ['remote', 'get-url', 'origin'],
+      '/home/user/orca'
+    )
+  })
+
+  it('keeps local and SSH owner/repo cache entries separate for the same path', async () => {
+    const sshProvider = {
+      exec: vi.fn().mockResolvedValue({ stdout: 'git@github.com:remote/orca.git\n', stderr: '' })
+    }
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'git@github.com:local/orca.git\n' })
+    getSshGitProviderMock.mockReturnValue(sshProvider)
+
+    await expect(getOwnerRepo('/repo')).resolves.toEqual({ owner: 'local', repo: 'orca' })
+    await expect(getOwnerRepo('/repo', 'ssh-1')).resolves.toEqual({ owner: 'remote', repo: 'orca' })
+  })
 })
 
 describe('resolveIssueSource', () => {
   beforeEach(() => {
     gitExecFileAsyncMock.mockReset()
+    getSshGitProviderMock.mockReset()
     _resetOwnerRepoCache()
   })
 

--- a/src/main/github/gh-utils.ts
+++ b/src/main/github/gh-utils.ts
@@ -2,6 +2,7 @@ import { execFile } from 'child_process'
 import { promisify } from 'util'
 import { gitExecFileAsync, ghExecFileAsync } from '../git/runner'
 import type { ClassifiedError, GitHubOwnerRepo, IssueSourcePreference } from '../../shared/types'
+import { getSshGitProvider } from '../providers/ssh-git-dispatch'
 
 // Why: legacy generic execFile wrapper — only used by callers that don't need
 // WSL-aware routing (e.g. non-repo-scoped gh commands). Repo-scoped callers
@@ -112,6 +113,28 @@ export function classifyListIssuesError(stderr: string): ClassifiedError {
 // short local name `OwnerRepo`.
 export type OwnerRepo = GitHubOwnerRepo
 
+export type GitHubRepoContext = {
+  repoPath: string
+  connectionId?: string | null
+}
+
+export function githubRepoContext(
+  repoPath: string,
+  connectionId?: string | null
+): GitHubRepoContext {
+  return { repoPath, connectionId: connectionId ?? null }
+}
+
+export function ghRepoExecOptions(context: GitHubRepoContext): {
+  cwd?: string
+  encoding?: BufferEncoding
+} {
+  // Why: SSH repo paths are meaningful only on the remote host. All GitHub
+  // calls in this layer pass explicit --repo/API targets, so local gh should
+  // not receive a remote-only cwd.
+  return context.connectionId ? {} : { cwd: context.repoPath }
+}
+
 const ownerRepoCache = new Map<string, OwnerRepo | null>()
 
 /** @internal — exposed for tests only */
@@ -127,19 +150,37 @@ export function parseGitHubOwnerRepo(remoteUrl: string): OwnerRepo | null {
   return { owner: match[1], repo: match[2] }
 }
 
+export async function getRemoteUrlForRepo(
+  context: GitHubRepoContext,
+  remoteName: string
+): Promise<string | null> {
+  if (context.connectionId) {
+    const provider = getSshGitProvider(context.connectionId)
+    if (!provider) {
+      return null
+    }
+    const { stdout } = await provider.exec(['remote', 'get-url', remoteName], context.repoPath)
+    return stdout
+  }
+  const { stdout } = await gitExecFileAsync(['remote', 'get-url', remoteName], {
+    cwd: context.repoPath
+  })
+  return stdout
+}
+
 export async function getOwnerRepoForRemote(
   repoPath: string,
-  remoteName: string
+  remoteName: string,
+  connectionId?: string | null
 ): Promise<OwnerRepo | null> {
-  const cacheKey = `${repoPath}\0${remoteName}`
+  const context = githubRepoContext(repoPath, connectionId)
+  const cacheKey = `${context.connectionId ?? 'local'}\0${context.repoPath}\0${remoteName}`
   if (ownerRepoCache.has(cacheKey)) {
     return ownerRepoCache.get(cacheKey)!
   }
   try {
-    const { stdout } = await gitExecFileAsync(['remote', 'get-url', remoteName], {
-      cwd: repoPath
-    })
-    const result = parseGitHubOwnerRepo(stdout)
+    const remoteUrl = await getRemoteUrlForRepo(context, remoteName)
+    const result = remoteUrl ? parseGitHubOwnerRepo(remoteUrl) : null
     if (result) {
       ownerRepoCache.set(cacheKey, result)
       return result
@@ -151,16 +192,22 @@ export async function getOwnerRepoForRemote(
   return null
 }
 
-export async function getOwnerRepo(repoPath: string): Promise<OwnerRepo | null> {
-  return getOwnerRepoForRemote(repoPath, 'origin')
+export async function getOwnerRepo(
+  repoPath: string,
+  connectionId?: string | null
+): Promise<OwnerRepo | null> {
+  return getOwnerRepoForRemote(repoPath, 'origin', connectionId)
 }
 
-export async function getIssueOwnerRepo(repoPath: string): Promise<OwnerRepo | null> {
-  const upstream = await getOwnerRepoForRemote(repoPath, 'upstream')
+export async function getIssueOwnerRepo(
+  repoPath: string,
+  connectionId?: string | null
+): Promise<OwnerRepo | null> {
+  const upstream = await getOwnerRepoForRemote(repoPath, 'upstream', connectionId)
   if (upstream) {
     return upstream
   }
-  return getOwnerRepoForRemote(repoPath, 'origin')
+  return getOwnerRepoForRemote(repoPath, 'origin', connectionId)
 }
 
 export type ResolvedIssueSource = {
@@ -181,10 +228,11 @@ export type ResolvedIssueSource = {
  */
 export async function resolveIssueSource(
   repoPath: string,
-  preference: IssueSourcePreference | undefined
+  preference: IssueSourcePreference | undefined,
+  connectionId?: string | null
 ): Promise<ResolvedIssueSource> {
   if (preference === 'upstream') {
-    const upstream = await getOwnerRepoForRemote(repoPath, 'upstream')
+    const upstream = await getOwnerRepoForRemote(repoPath, 'upstream', connectionId)
     if (upstream) {
       return { source: upstream, fellBack: false }
     }
@@ -194,12 +242,15 @@ export async function resolveIssueSource(
     // UI toast "using origin" would be misleading. Do NOT auto-reset the
     // preference: the user may be mid-way through a workflow and expect
     // their choice to re-engage if `upstream` is re-added.
-    const origin = await getOwnerRepoForRemote(repoPath, 'origin')
+    const origin = await getOwnerRepoForRemote(repoPath, 'origin', connectionId)
     return { source: origin, fellBack: origin !== null }
   }
   if (preference === 'origin') {
-    return { source: await getOwnerRepoForRemote(repoPath, 'origin'), fellBack: false }
+    return {
+      source: await getOwnerRepoForRemote(repoPath, 'origin', connectionId),
+      fellBack: false
+    }
   }
   // 'auto' or undefined
-  return { source: await getIssueOwnerRepo(repoPath), fellBack: false }
+  return { source: await getIssueOwnerRepo(repoPath, connectionId), fellBack: false }
 }

--- a/src/main/github/issues.ts
+++ b/src/main/github/issues.ts
@@ -13,7 +13,7 @@ import type {
 } from '../../shared/types'
 import { mapIssueInfo } from './mappers'
 // prettier-ignore
-import { ghExecFileAsync, acquire, release, getIssueOwnerRepo, resolveIssueSource, classifyGhError, classifyListIssuesError } from './gh-utils'
+import { ghExecFileAsync, acquire, release, getIssueOwnerRepo, resolveIssueSource, classifyGhError, classifyListIssuesError, ghRepoExecOptions, githubRepoContext } from './gh-utils'
 
 // Why: distinguishes a successful-empty listing from a failed fetch. The
 // previous `catch { return [] }` conflated a 403 on a private upstream with an
@@ -40,8 +40,14 @@ export type IssueListResult = {
  * #1186 / the parent design doc guard against. List and create paths honor
  * preference; number-resolution stays on the heuristic.
  */
-export async function getIssue(repoPath: string, issueNumber: number): Promise<IssueInfo | null> {
-  const ownerRepo = await getIssueOwnerRepo(repoPath)
+export async function getIssue(
+  repoPath: string,
+  issueNumber: number,
+  connectionId?: string | null
+): Promise<IssueInfo | null> {
+  const context = githubRepoContext(repoPath, connectionId)
+  const ghOptions = ghRepoExecOptions(context)
+  const ownerRepo = await getIssueOwnerRepo(repoPath, connectionId)
   await acquire()
   try {
     if (ownerRepo) {
@@ -52,7 +58,7 @@ export async function getIssue(repoPath: string, issueNumber: number): Promise<I
           '300s',
           `repos/${ownerRepo.owner}/${ownerRepo.repo}/issues/${issueNumber}`
         ],
-        { cwd: repoPath }
+        ghOptions
       )
       const data = JSON.parse(stdout)
       return mapIssueInfo(data)
@@ -60,7 +66,7 @@ export async function getIssue(repoPath: string, issueNumber: number): Promise<I
     // Fallback for non-GitHub remotes
     const { stdout } = await ghExecFileAsync(
       ['issue', 'view', String(issueNumber), '--json', 'number,title,state,url,labels'],
-      { cwd: repoPath }
+      ghOptions
     )
     const data = JSON.parse(stdout)
     return mapIssueInfo(data)
@@ -85,9 +91,12 @@ export async function getIssue(repoPath: string, issueNumber: number): Promise<I
 export async function listIssues(
   repoPath: string,
   limit = 20,
-  preference?: IssueSourcePreference
+  preference?: IssueSourcePreference,
+  connectionId?: string | null
 ): Promise<IssueListResult> {
-  const { source: ownerRepo } = await resolveIssueSource(repoPath, preference)
+  const context = githubRepoContext(repoPath, connectionId)
+  const ghOptions = ghRepoExecOptions(context)
+  const { source: ownerRepo } = await resolveIssueSource(repoPath, preference, connectionId)
   await acquire()
   try {
     if (ownerRepo) {
@@ -98,7 +107,7 @@ export async function listIssues(
           '120s',
           `repos/${ownerRepo.owner}/${ownerRepo.repo}/issues?per_page=${limit}&state=open&sort=updated&direction=desc`
         ],
-        { cwd: repoPath }
+        ghOptions
       )
       const data = JSON.parse(stdout) as Record<string, unknown>[]
       // Why: the GitHub REST `/repos/{owner}/{repo}/issues` endpoint returns
@@ -114,7 +123,7 @@ export async function listIssues(
     // Fallback for non-GitHub remotes
     const { stdout } = await ghExecFileAsync(
       ['issue', 'list', '--json', 'number,title,state,url,labels', '--limit', String(limit)],
-      { cwd: repoPath }
+      ghOptions
     )
     const data = JSON.parse(stdout) as unknown[]
     return {
@@ -140,13 +149,16 @@ export async function createIssue(
   repoPath: string,
   title: string,
   body: string,
-  preference?: IssueSourcePreference
+  preference?: IssueSourcePreference,
+  connectionId?: string | null
 ): Promise<{ ok: true; number: number; url: string } | { ok: false; error: string }> {
   const trimmedTitle = title.trim()
   if (!trimmedTitle) {
     return { ok: false, error: 'Title is required' }
   }
-  const { source: ownerRepo } = await resolveIssueSource(repoPath, preference)
+  const context = githubRepoContext(repoPath, connectionId)
+  const ghOptions = ghRepoExecOptions(context)
+  const { source: ownerRepo } = await resolveIssueSource(repoPath, preference, connectionId)
   if (!ownerRepo) {
     return { ok: false, error: 'Could not resolve GitHub owner/repo for this repository' }
   }
@@ -163,7 +175,7 @@ export async function createIssue(
         '--raw-field',
         `body=${body}`
       ],
-      { cwd: repoPath }
+      ghOptions
     )
     const data = JSON.parse(stdout) as { number?: number; html_url?: string; url?: string }
     if (typeof data.number !== 'number') {
@@ -198,9 +210,12 @@ export async function createIssue(
 export async function updateIssue(
   repoPath: string,
   issueNumber: number,
-  updates: GitHubIssueUpdate
+  updates: GitHubIssueUpdate,
+  connectionId?: string | null
 ): Promise<{ ok: true } | { ok: false; error: string }> {
-  const ownerRepo = await getIssueOwnerRepo(repoPath)
+  const context = githubRepoContext(repoPath, connectionId)
+  const ghOptions = ghRepoExecOptions(context)
+  const ownerRepo = await getIssueOwnerRepo(repoPath, connectionId)
   if (!ownerRepo) {
     return { ok: false, error: 'Could not resolve GitHub owner/repo for this repository' }
   }
@@ -214,7 +229,7 @@ export async function updateIssue(
     try {
       const cmd = updates.state === 'closed' ? 'close' : 'reopen'
       await ghExecFileAsync(['issue', cmd, String(issueNumber), '--repo', repo], {
-        cwd: repoPath
+        ...ghOptions
       })
     } catch (err) {
       const stderr = err instanceof Error ? err.message : String(err)
@@ -255,7 +270,7 @@ export async function updateIssue(
   if (hasEditArgs) {
     await acquire()
     try {
-      await ghExecFileAsync(editArgs, { cwd: repoPath })
+      await ghExecFileAsync(editArgs, ghOptions)
     } catch (err) {
       const stderr = err instanceof Error ? err.message : String(err)
       errors.push(classifyGhError(stderr).message)
@@ -285,9 +300,12 @@ export async function updateIssue(
 export async function addIssueComment(
   repoPath: string,
   issueNumber: number,
-  body: string
+  body: string,
+  connectionId?: string | null
 ): Promise<GitHubCommentResult> {
-  const ownerRepo = await getIssueOwnerRepo(repoPath)
+  const context = githubRepoContext(repoPath, connectionId)
+  const ghOptions = ghRepoExecOptions(context)
+  const ownerRepo = await getIssueOwnerRepo(repoPath, connectionId)
   if (!ownerRepo) {
     return { ok: false, error: 'Could not resolve GitHub owner/repo for this repository' }
   }
@@ -302,7 +320,7 @@ export async function addIssueComment(
         '--raw-field',
         `body=${body}`
       ],
-      { cwd: repoPath }
+      ghOptions
     )
     const data = JSON.parse(stdout) as {
       id?: number
@@ -331,9 +349,12 @@ export async function addIssueComment(
 
 export async function listLabels(
   repoPath: string,
-  preference?: IssueSourcePreference
+  preference?: IssueSourcePreference,
+  connectionId?: string | null
 ): Promise<string[]> {
-  const { source: ownerRepo } = await resolveIssueSource(repoPath, preference)
+  const context = githubRepoContext(repoPath, connectionId)
+  const ghOptions = ghRepoExecOptions(context)
+  const { source: ownerRepo } = await resolveIssueSource(repoPath, preference, connectionId)
   if (!ownerRepo) {
     return []
   }
@@ -347,7 +368,7 @@ export async function listLabels(
         '--jq',
         '.[].name'
       ],
-      { cwd: repoPath }
+      ghOptions
     )
     return stdout
       .trim()
@@ -362,9 +383,12 @@ export async function listLabels(
 
 export async function listAssignableUsers(
   repoPath: string,
-  preference?: IssueSourcePreference
+  preference?: IssueSourcePreference,
+  connectionId?: string | null
 ): Promise<GitHubAssignableUser[]> {
-  const { source: ownerRepo } = await resolveIssueSource(repoPath, preference)
+  const context = githubRepoContext(repoPath, connectionId)
+  const ghOptions = ghRepoExecOptions(context)
+  const { source: ownerRepo } = await resolveIssueSource(repoPath, preference, connectionId)
   if (!ownerRepo) {
     return []
   }
@@ -383,7 +407,7 @@ export async function listAssignableUsers(
         '--jq',
         '.[] | {login, avatar_url}'
       ],
-      { cwd: repoPath }
+      ghOptions
     )
     type RESTAssignee = { login?: string; avatar_url?: string | null }
     const users: GitHubAssignableUser[] = []

--- a/src/main/github/work-item-details.test.ts
+++ b/src/main/github/work-item-details.test.ts
@@ -7,6 +7,8 @@ const {
   getWorkItemMock,
   getPRChecksMock,
   getPRCommentsMock,
+  ghRepoExecOptionsMock,
+  githubRepoContextMock,
   acquireMock,
   releaseMock
 } = vi.hoisted(() => ({
@@ -16,6 +18,13 @@ const {
   getWorkItemMock: vi.fn(),
   getPRChecksMock: vi.fn(),
   getPRCommentsMock: vi.fn(),
+  ghRepoExecOptionsMock: vi.fn((context) =>
+    context.connectionId ? {} : { cwd: context.repoPath }
+  ),
+  githubRepoContextMock: vi.fn((repoPath, connectionId) => ({
+    repoPath,
+    connectionId: connectionId ?? null
+  })),
   acquireMock: vi.fn(),
   releaseMock: vi.fn()
 }))
@@ -24,6 +33,8 @@ vi.mock('./gh-utils', () => ({
   ghExecFileAsync: ghExecFileAsyncMock,
   getOwnerRepo: getOwnerRepoMock,
   getIssueOwnerRepo: getIssueOwnerRepoMock,
+  ghRepoExecOptions: ghRepoExecOptionsMock,
+  githubRepoContext: githubRepoContextMock,
   acquire: acquireMock,
   release: releaseMock
 }))
@@ -44,6 +55,8 @@ describe('getWorkItemDetails', () => {
     getWorkItemMock.mockReset()
     getPRChecksMock.mockReset()
     getPRCommentsMock.mockReset()
+    ghRepoExecOptionsMock.mockClear()
+    githubRepoContextMock.mockClear()
     acquireMock.mockReset()
     releaseMock.mockReset()
     acquireMock.mockResolvedValue(undefined)
@@ -91,7 +104,7 @@ describe('getWorkItemDetails', () => {
 
     const details = await getWorkItemDetails('/repo-root', 923, 'issue')
 
-    expect(getWorkItemMock).toHaveBeenCalledWith('/repo-root', 923, 'issue')
+    expect(getWorkItemMock).toHaveBeenCalledWith('/repo-root', 923, 'issue', undefined)
     // Why: a single gh subprocess call replaces the previous REST + REST + GraphQL fan-out.
     expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(1)
     expect(ghExecFileAsyncMock.mock.calls[0][0][0]).toBe('api')
@@ -143,5 +156,41 @@ describe('getWorkItemDetails', () => {
       { cwd: '/repo-root' }
     )
     expect(details?.body).toBe('Issue body')
+  })
+
+  it('uses SSH connection context for issue details without local cwd', async () => {
+    getWorkItemMock.mockResolvedValueOnce({
+      id: 'issue:923',
+      type: 'issue',
+      number: 923,
+      title: 'Use upstream issues',
+      state: 'open',
+      url: 'https://github.com/stablyai/orca/issues/923',
+      labels: [],
+      updatedAt: '2026-04-01T00:00:00Z',
+      author: 'octocat'
+    })
+    getIssueOwnerRepoMock.mockResolvedValue({ owner: 'stablyai', repo: 'orca' })
+    ghExecFileAsyncMock.mockResolvedValueOnce({
+      stdout: JSON.stringify({
+        data: {
+          repository: {
+            issue: {
+              body: 'Remote issue body',
+              assignees: { nodes: [] },
+              participants: { nodes: [] },
+              comments: { nodes: [] }
+            }
+          }
+        }
+      })
+    })
+
+    const details = await getWorkItemDetails('/home/jinwoo/orca', 923, 'issue', 'openclaw-2')
+
+    expect(getWorkItemMock).toHaveBeenCalledWith('/home/jinwoo/orca', 923, 'issue', 'openclaw-2')
+    expect(getIssueOwnerRepoMock).toHaveBeenCalledWith('/home/jinwoo/orca', 'openclaw-2')
+    expect(ghExecFileAsyncMock.mock.calls[0][1]).toEqual({})
+    expect(details?.body).toBe('Remote issue body')
   })
 })

--- a/src/main/github/work-item-details.ts
+++ b/src/main/github/work-item-details.ts
@@ -9,7 +9,15 @@ import type {
   GitHubWorkItemDetails,
   PRComment
 } from '../../shared/types'
-import { ghExecFileAsync, acquire, release, getOwnerRepo, getIssueOwnerRepo } from './gh-utils'
+import {
+  ghExecFileAsync,
+  acquire,
+  release,
+  getOwnerRepo,
+  getIssueOwnerRepo,
+  ghRepoExecOptions,
+  githubRepoContext
+} from './gh-utils'
 import { getWorkItem, getPRChecks, getPRComments } from './client'
 
 // Why: a PR "changed file" listing returned by the REST endpoint is paginated
@@ -91,14 +99,16 @@ type GraphQLIssueDetailsResponse = {
 
 async function getIssueDetailsViaGraphQL(
   repoPath: string,
-  issueNumber: number
+  issueNumber: number,
+  connectionId?: string | null
 ): Promise<{
   body: string
   comments: PRComment[]
   assignees: string[]
   participants: GitHubAssignableUser[]
 } | null> {
-  const ownerRepo = await getIssueOwnerRepo(repoPath)
+  const ghOptions = ghRepoExecOptions(githubRepoContext(repoPath, connectionId))
+  const ownerRepo = await getIssueOwnerRepo(repoPath, connectionId)
   if (!ownerRepo) {
     return null
   }
@@ -116,7 +126,7 @@ async function getIssueDetailsViaGraphQL(
         '-F',
         `number=${issueNumber}`
       ],
-      { cwd: repoPath }
+      ghOptions
     )
     const parsed = JSON.parse(stdout) as GraphQLIssueDetailsResponse
     if (parsed.errors && parsed.errors.length > 0) {
@@ -235,14 +245,16 @@ function isBinaryHint(file: RESTPRFile): boolean {
 
 async function getPRHeadBaseSha(
   repoPath: string,
-  prNumber: number
+  prNumber: number,
+  connectionId?: string | null
 ): Promise<{ headSha: string; baseSha: string } | null> {
-  const ownerRepo = await getOwnerRepo(repoPath)
+  const ghOptions = ghRepoExecOptions(githubRepoContext(repoPath, connectionId))
+  const ownerRepo = await getOwnerRepo(repoPath, connectionId)
   try {
     if (ownerRepo) {
       const { stdout } = await ghExecFileAsync(
         ['api', '--cache', '60s', `repos/${ownerRepo.owner}/${ownerRepo.repo}/pulls/${prNumber}`],
-        { cwd: repoPath }
+        ghOptions
       )
       const data = JSON.parse(stdout) as {
         head?: { sha?: string }
@@ -255,7 +267,7 @@ async function getPRHeadBaseSha(
     }
     const { stdout } = await ghExecFileAsync(
       ['pr', 'view', String(prNumber), '--json', 'headRefOid,baseRefOid'],
-      { cwd: repoPath }
+      ghOptions
     )
     const data = JSON.parse(stdout) as { headRefOid?: string; baseRefOid?: string }
     if (data.headRefOid && data.baseRefOid) {
@@ -267,8 +279,13 @@ async function getPRHeadBaseSha(
   }
 }
 
-async function getPRFiles(repoPath: string, prNumber: number): Promise<GitHubPRFile[]> {
-  const ownerRepo = await getOwnerRepo(repoPath)
+async function getPRFiles(
+  repoPath: string,
+  prNumber: number,
+  connectionId?: string | null
+): Promise<GitHubPRFile[]> {
+  const ghOptions = ghRepoExecOptions(githubRepoContext(repoPath, connectionId))
+  const ownerRepo = await getOwnerRepo(repoPath, connectionId)
   if (!ownerRepo) {
     return []
   }
@@ -280,7 +297,7 @@ async function getPRFiles(repoPath: string, prNumber: number): Promise<GitHubPRF
         '60s',
         `repos/${ownerRepo.owner}/${ownerRepo.repo}/pulls/${prNumber}/files?per_page=100`
       ],
-      { cwd: repoPath }
+      ghOptions
     )
     const data = JSON.parse(stdout) as RESTPRFile[]
     return data.slice(0, MAX_PR_FILES).map((file) => ({
@@ -298,9 +315,11 @@ async function getPRFiles(repoPath: string, prNumber: number): Promise<GitHubPRF
 
 async function getIssueBodyAndComments(
   repoPath: string,
-  issueNumber: number
+  issueNumber: number,
+  connectionId?: string | null
 ): Promise<{ body: string; comments: PRComment[]; assignees: string[] }> {
-  const ownerRepo = await getIssueOwnerRepo(repoPath)
+  const ghOptions = ghRepoExecOptions(githubRepoContext(repoPath, connectionId))
+  const ownerRepo = await getIssueOwnerRepo(repoPath, connectionId)
   try {
     if (ownerRepo) {
       const [issueResult, commentsResult] = await Promise.all([
@@ -311,7 +330,7 @@ async function getIssueBodyAndComments(
             '60s',
             `repos/${ownerRepo.owner}/${ownerRepo.repo}/issues/${issueNumber}`
           ],
-          { cwd: repoPath }
+          ghOptions
         ),
         ghExecFileAsync(
           [
@@ -320,7 +339,7 @@ async function getIssueBodyAndComments(
             '60s',
             `repos/${ownerRepo.owner}/${ownerRepo.repo}/issues/${issueNumber}/comments?per_page=100`
           ],
-          { cwd: repoPath }
+          ghOptions
         )
       ])
       const issue = JSON.parse(issueResult.stdout) as {
@@ -351,7 +370,7 @@ async function getIssueBodyAndComments(
     // Fallback: non-GitHub remote
     const { stdout } = await ghExecFileAsync(
       ['issue', 'view', String(issueNumber), '--json', 'body,comments,assignees'],
-      { cwd: repoPath }
+      ghOptions
     )
     const data = JSON.parse(stdout) as {
       body?: string
@@ -380,20 +399,26 @@ async function getIssueBodyAndComments(
   }
 }
 
-async function getPRBody(repoPath: string, prNumber: number): Promise<string> {
-  const ownerRepo = await getOwnerRepo(repoPath)
+async function getPRBody(
+  repoPath: string,
+  prNumber: number,
+  connectionId?: string | null
+): Promise<string> {
+  const ghOptions = ghRepoExecOptions(githubRepoContext(repoPath, connectionId))
+  const ownerRepo = await getOwnerRepo(repoPath, connectionId)
   try {
     if (ownerRepo) {
       const { stdout } = await ghExecFileAsync(
         ['api', '--cache', '60s', `repos/${ownerRepo.owner}/${ownerRepo.repo}/pulls/${prNumber}`],
-        { cwd: repoPath }
+        ghOptions
       )
       const data = JSON.parse(stdout) as { body?: string | null }
       return data.body ?? ''
     }
-    const { stdout } = await ghExecFileAsync(['pr', 'view', String(prNumber), '--json', 'body'], {
-      cwd: repoPath
-    })
+    const { stdout } = await ghExecFileAsync(
+      ['pr', 'view', String(prNumber), '--json', 'body'],
+      ghOptions
+    )
     const data = JSON.parse(stdout) as { body?: string }
     return data.body ?? ''
   } catch {
@@ -403,13 +428,16 @@ async function getPRBody(repoPath: string, prNumber: number): Promise<string> {
 
 async function getWorkItemParticipants(
   repoPath: string,
-  item: Pick<GitHubWorkItem, 'number' | 'type'>
+  item: Pick<GitHubWorkItem, 'number' | 'type'>,
+  connectionId?: string | null
 ): Promise<GitHubAssignableUser[]> {
   // Why: issues in a fork live on the upstream remote, so participants must be
   // resolved via getIssueOwnerRepo to stay consistent with getIssueBodyAndComments.
   // PRs remain tied to origin via getOwnerRepo.
   const ownerRepo =
-    item.type === 'issue' ? await getIssueOwnerRepo(repoPath) : await getOwnerRepo(repoPath)
+    item.type === 'issue'
+      ? await getIssueOwnerRepo(repoPath, connectionId)
+      : await getOwnerRepo(repoPath, connectionId)
   if (!ownerRepo) {
     return []
   }
@@ -429,7 +457,7 @@ async function getWorkItemParticipants(
         '-F',
         `isPr=${item.type === 'pr'}`
       ],
-      { cwd: repoPath }
+      ghRepoExecOptions(githubRepoContext(repoPath, connectionId))
     )
     const data = JSON.parse(stdout) as {
       data?: {
@@ -461,7 +489,8 @@ async function getWorkItemParticipants(
 
 async function getGitHubUsersByLogin(
   repoPath: string,
-  logins: string[]
+  logins: string[],
+  connectionId?: string | null
 ): Promise<GitHubAssignableUser[]> {
   const uniqueLogins = Array.from(
     new Set(logins.filter((login) => login && login !== 'ghost').map((login) => login.trim()))
@@ -478,9 +507,7 @@ async function getGitHubUsersByLogin(
   try {
     const { stdout } = await ghExecFileAsync(
       ['api', 'graphql', '-f', `query=query { ${fields} }`],
-      {
-        cwd: repoPath
-      }
+      ghRepoExecOptions(githubRepoContext(repoPath, connectionId))
     )
     const data = JSON.parse(stdout) as {
       data?: Record<
@@ -506,26 +533,33 @@ async function getMentionParticipants(
   repoPath: string,
   item: Pick<GitHubWorkItem, 'author' | 'number' | 'type'>,
   comments: PRComment[],
-  participants: GitHubAssignableUser[]
+  participants: GitHubAssignableUser[],
+  connectionId?: string | null
 ): Promise<GitHubAssignableUser[]> {
   const visibleLogins = [item.author ?? '', ...comments.map((comment) => comment.author)]
   // Why: one aliased GraphQL query returns login/name/avatarUrl for every
   // mentioned author in a single round-trip. The previous REST fan-out
   // (/users/<login>) returned the same fields but cost one rate-limit point
   // per user.
-  const graphQlUsers = await getGitHubUsersByLogin(repoPath, visibleLogins)
+  const graphQlUsers = await getGitHubUsersByLogin(repoPath, visibleLogins, connectionId)
   return mergeGitHubUsers([...participants, ...graphQlUsers])
 }
 
 export async function getWorkItemDetails(
   repoPath: string,
   number: number,
-  type?: 'issue' | 'pr'
+  type?: 'issue' | 'pr',
+  connectionId?: string | null
 ): Promise<GitHubWorkItemDetails | null> {
   // Why: getWorkItem already handles acquire/release. We call it first (outside
   // our semaphore) so the known-cheap lookup doesn't compete with the richer
   // detail fetches that follow.
-  const item: Omit<GitHubWorkItem, 'repoId'> | null = await getWorkItem(repoPath, number, type)
+  const item: Omit<GitHubWorkItem, 'repoId'> | null = await getWorkItem(
+    repoPath,
+    number,
+    type,
+    connectionId
+  )
   if (!item) {
     return null
   }
@@ -540,7 +574,7 @@ export async function getWorkItemDetails(
       // is preserved. The GraphQL `participants` connection includes every
       // commenter, so we skip the extra `getMentionParticipants` aliased
       // user-hydration trip when the collapsed path succeeds.
-      const collapsed = await getIssueDetailsViaGraphQL(repoPath, item.number)
+      const collapsed = await getIssueDetailsViaGraphQL(repoPath, item.number, connectionId)
       if (collapsed) {
         return {
           item,
@@ -553,35 +587,36 @@ export async function getWorkItemDetails(
       // Why: fall back to body/comments and GraphQL participants in parallel;
       // the mention-participant merge is a cheap local operation afterward.
       const [{ body, comments, assignees }, participants] = await Promise.all([
-        getIssueBodyAndComments(repoPath, item.number),
-        getWorkItemParticipants(repoPath, item)
+        getIssueBodyAndComments(repoPath, item.number, connectionId),
+        getWorkItemParticipants(repoPath, item, connectionId)
       ])
       const mentionParticipants = await getMentionParticipants(
         repoPath,
         item,
         comments,
-        participants
+        participants,
+        connectionId
       )
       return { item, body, comments, assignees, participants: mentionParticipants }
     }
 
     // PR: fetch body + comments + checks + files + head/base SHAs in parallel.
     const [body, comments, shas, files, participants] = await Promise.all([
-      getPRBody(repoPath, item.number),
-      getPRComments(repoPath, item.number),
-      getPRHeadBaseSha(repoPath, item.number),
-      getPRFiles(repoPath, item.number),
-      getWorkItemParticipants(repoPath, item)
+      getPRBody(repoPath, item.number, connectionId),
+      getPRComments(repoPath, item.number, undefined, connectionId),
+      getPRHeadBaseSha(repoPath, item.number, connectionId),
+      getPRFiles(repoPath, item.number, connectionId),
+      getWorkItemParticipants(repoPath, item, connectionId)
     ])
 
     // Why: run the mention-author GraphQL lookup in parallel with the final
     // checks fetch instead of serially — both depend only on data from the
     // Promise.all above, so there's no ordering requirement between them.
     const [mentionParticipants, checks] = await Promise.all([
-      getMentionParticipants(repoPath, item, comments, participants),
+      getMentionParticipants(repoPath, item, comments, participants, connectionId),
       shas?.headSha
-        ? getPRChecks(repoPath, item.number, shas.headSha)
-        : getPRChecks(repoPath, item.number)
+        ? getPRChecks(repoPath, item.number, shas.headSha, undefined, connectionId)
+        : getPRChecks(repoPath, item.number, undefined, undefined, connectionId)
     ])
 
     return {
@@ -605,6 +640,7 @@ export async function getWorkItemDetails(
 // during rapid file-expand clicks in the drawer.
 async function fetchContentAtRef(args: {
   repoPath: string
+  connectionId?: string | null
   owner: string
   repo: string
   path: string
@@ -620,7 +656,7 @@ async function fetchContentAtRef(args: {
         'Accept: application/vnd.github.raw',
         `repos/${args.owner}/${args.repo}/contents/${encodeURI(args.path)}?ref=${encodeURIComponent(args.ref)}`
       ],
-      { cwd: args.repoPath }
+      ghRepoExecOptions(githubRepoContext(args.repoPath, args.connectionId))
     )
     // Raw content response: Electron's execFile returns string in utf-8. If the
     // file is binary, the string will contain replacement characters — we treat
@@ -637,6 +673,7 @@ async function fetchContentAtRef(args: {
 
 export async function getPRFileContents(args: {
   repoPath: string
+  connectionId?: string | null
   prNumber: number
   path: string
   oldPath?: string
@@ -644,7 +681,7 @@ export async function getPRFileContents(args: {
   headSha: string
   baseSha: string
 }): Promise<GitHubPRFileContents> {
-  const ownerRepo = await getOwnerRepo(args.repoPath)
+  const ownerRepo = await getOwnerRepo(args.repoPath, args.connectionId)
   if (!ownerRepo) {
     return {
       original: '',
@@ -668,6 +705,7 @@ export async function getPRFileContents(args: {
       needsOriginal
         ? fetchContentAtRef({
             repoPath: args.repoPath,
+            connectionId: args.connectionId,
             owner: ownerRepo.owner,
             repo: ownerRepo.repo,
             path: originalPath,
@@ -677,6 +715,7 @@ export async function getPRFileContents(args: {
       needsModified
         ? fetchContentAtRef({
             repoPath: args.repoPath,
+            connectionId: args.connectionId,
             owner: ownerRepo.owner,
             repo: ownerRepo.repo,
             path: args.path,

--- a/src/main/ipc/filesystem-watcher.test.ts
+++ b/src/main/ipc/filesystem-watcher.test.ts
@@ -98,7 +98,10 @@ describe('registerFilesystemWatcherHandlers', () => {
     expect(warnSpy).toHaveBeenCalledWith(
       '[filesystem-watcher] SSH filesystem provider unavailable; retrying watch for /home/me/repo on connection conn-1'
     )
-    handlers['fs:unwatchWorktree'](null, { worktreePath: '/home/me/repo', connectionId: 'conn-1' })
+    handlers['fs:unwatchWorktree'](
+      { sender: { id: 1 } },
+      { worktreePath: '/home/me/repo', connectionId: 'conn-1' }
+    )
     warnSpy.mockRestore()
     vi.useRealTimers()
   })
@@ -128,7 +131,10 @@ describe('registerFilesystemWatcherHandlers', () => {
       events: [{ path: '/home/me/repo/file.txt', type: 'update' }]
     })
     warnSpy.mockRestore()
-    handlers['fs:unwatchWorktree'](null, { worktreePath: '/home/me/repo', connectionId: 'conn-1' })
+    handlers['fs:unwatchWorktree'](
+      { sender: { id: 1 } },
+      { worktreePath: '/home/me/repo', connectionId: 'conn-1' }
+    )
     vi.useRealTimers()
   })
 
@@ -150,5 +156,42 @@ describe('registerFilesystemWatcherHandlers', () => {
     expect(watchMock).not.toHaveBeenCalled()
     warnSpy.mockRestore()
     vi.useRealTimers()
+  })
+
+  it('shares SSH worktree watchers across renderer senders until the last unwatch', async () => {
+    const sendOne = vi.fn()
+    const sendTwo = vi.fn()
+    const senderOne = { isDestroyed: () => false, send: sendOne, once: vi.fn(), id: 1 }
+    const senderTwo = { isDestroyed: () => false, send: sendTwo, once: vi.fn(), id: 2 }
+    const unwatchMock = vi.fn()
+    const watchMock = vi.fn().mockResolvedValue(unwatchMock)
+    getSshFilesystemProviderMock.mockReturnValue({ watch: watchMock })
+
+    await handlers['fs:watchWorktree'](
+      { sender: senderOne },
+      { worktreePath: '/home/me/repo', connectionId: 'conn-1' }
+    )
+    await handlers['fs:watchWorktree'](
+      { sender: senderTwo },
+      { worktreePath: '/home/me/repo', connectionId: 'conn-1' }
+    )
+
+    expect(watchMock).toHaveBeenCalledTimes(1)
+    const onEvents = watchMock.mock.calls[0][1]
+    onEvents([{ path: '/home/me/repo/file.txt', type: 'update' }])
+    expect(sendOne).toHaveBeenCalledTimes(1)
+    expect(sendTwo).toHaveBeenCalledTimes(1)
+
+    handlers['fs:unwatchWorktree'](
+      { sender: { id: 1 } },
+      { worktreePath: '/home/me/repo', connectionId: 'conn-1' }
+    )
+    expect(unwatchMock).not.toHaveBeenCalled()
+
+    handlers['fs:unwatchWorktree'](
+      { sender: { id: 2 } },
+      { worktreePath: '/home/me/repo', connectionId: 'conn-1' }
+    )
+    expect(unwatchMock).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/main/ipc/filesystem-watcher.ts
+++ b/src/main/ipc/filesystem-watcher.ts
@@ -432,8 +432,13 @@ function unsubscribe(worktreePath: string, senderId: number): void {
 }
 
 // ── Remote watcher state ─────────────────────────────────────────────
-// Key: `${connectionId}:${worktreePath}`, Value: unwatch function
-const remoteWatchers = new Map<string, () => void>()
+type RemoteWatcherState = {
+  unwatch: () => void
+  listeners: Map<number, WebContents>
+}
+
+// Key: `${connectionId}:${worktreePath}`, Value: shared remote watch state.
+const remoteWatchers = new Map<string, RemoteWatcherState>()
 const loggedUnavailableRemoteWatchers = new Set<string>()
 const pendingRemoteWatcherRetries = new Map<string, ReturnType<typeof setTimeout>>()
 // Why: track in-flight `provider.watch()` calls so an unwatch/shutdown that
@@ -444,16 +449,28 @@ const inFlightRemoteInstalls = new Map<string, { cancelled: boolean }>()
 const REMOTE_WATCH_RETRY_MS = 1_000
 const REMOTE_WATCH_RETRY_TIMEOUT_MS = 60_000
 
-function replaceRemoteWatcher(key: string, unwatch: () => void): void {
-  const previous = remoteWatchers.get(key)
-  if (previous) {
-    // Why: SSH reconnect swaps in a fresh filesystem provider, but the
-    // renderer keeps watching the same worktree path. Replacing the existing
-    // unwatch callback here ensures a post-reconnect watch request rebinds to
-    // the new provider instead of early-returning forever on stale state.
-    previous()
+function addRemoteWatchListener(key: string, sender: WebContents): void {
+  const state = remoteWatchers.get(key)
+  if (!state) {
+    return
   }
-  remoteWatchers.set(key, unwatch)
+  state.listeners.set(sender.id, sender)
+  sender.once('destroyed', () => {
+    releaseRemoteWatchListener(key, sender.id)
+  })
+}
+
+function releaseRemoteWatchListener(key: string, senderId: number): void {
+  const state = remoteWatchers.get(key)
+  if (!state) {
+    return
+  }
+  state.listeners.delete(senderId)
+  if (state.listeners.size > 0) {
+    return
+  }
+  state.unwatch()
+  remoteWatchers.delete(key)
 }
 
 type RemoteWatcherInstallResult = 'installed' | 'unavailable' | 'cancelled'
@@ -469,13 +486,25 @@ async function installRemoteWatcher(
   }
 
   const key = `${connectionId}:${worktreePath}`
+  const existing = remoteWatchers.get(key)
+  if (existing) {
+    addRemoteWatchListener(key, sender)
+    return 'installed'
+  }
   const cancelToken = { cancelled: false }
   inFlightRemoteInstalls.set(key, cancelToken)
   let unwatch: () => void
   try {
     unwatch = await provider.watch(worktreePath, (events) => {
-      if (!sender.isDestroyed()) {
-        sender.send('fs:changed', {
+      const state = remoteWatchers.get(key)
+      if (!state) {
+        return
+      }
+      for (const listener of state.listeners.values()) {
+        if (listener.isDestroyed()) {
+          continue
+        }
+        listener.send('fs:changed', {
           worktreePath,
           events
         } satisfies FsChangedPayload)
@@ -494,21 +523,9 @@ async function installRemoteWatcher(
     }
     return 'cancelled'
   }
-  replaceRemoteWatcher(key, unwatch)
+  remoteWatchers.set(key, { unwatch, listeners: new Map() })
+  addRemoteWatchListener(key, sender)
   loggedUnavailableRemoteWatchers.delete(key)
-
-  sender.once('destroyed', () => {
-    const unwatchFn = remoteWatchers.get(key)
-    if (unwatchFn) {
-      unwatchFn()
-      remoteWatchers.delete(key)
-    }
-    const retryTimer = pendingRemoteWatcherRetries.get(key)
-    if (retryTimer) {
-      clearTimeout(retryTimer)
-      pendingRemoteWatcherRetries.delete(key)
-    }
-  })
   return 'installed'
 }
 
@@ -609,11 +626,7 @@ export function registerFilesystemWatcherHandlers(): void {
           inFlight.cancelled = true
         }
         loggedUnavailableRemoteWatchers.delete(key)
-        const unwatchFn = remoteWatchers.get(key)
-        if (unwatchFn) {
-          unwatchFn()
-          remoteWatchers.delete(key)
-        }
+        releaseRemoteWatchListener(key, _event?.sender?.id ?? 0)
         return
       }
       const senderId = _event.sender.id
@@ -657,9 +670,9 @@ export async function closeAllWatchers(): Promise<void> {
   // subscriptions. Without cleaning them up here, their unwatch callbacks
   // would never fire, leaving the relay polling for FS changes after the
   // app has shut down.
-  for (const [key, unwatchFn] of remoteWatchers) {
+  for (const [key, state] of remoteWatchers) {
     try {
-      unwatchFn()
+      state.unwatch()
     } catch (err) {
       console.error(`[filesystem-watcher] remote unwatch error for ${key}:`, err)
     }

--- a/src/main/ipc/github-work-item-args.test.ts
+++ b/src/main/ipc/github-work-item-args.test.ts
@@ -2,16 +2,18 @@ import { describe, expect, it, vi } from 'vitest'
 import { dispatchWorkItem } from './github-work-item-args'
 
 describe('dispatchWorkItem', () => {
+  const repo = { path: '/r', connectionId: null }
+
   it('rejects non-integer numbers', () => {
     const fn = vi.fn()
-    expect(dispatchWorkItem({ repoPath: '/r', number: 1.5 }, '/r', fn)).toBeNull()
+    expect(dispatchWorkItem({ repoPath: '/r', number: 1.5 }, repo, fn)).toBeNull()
     expect(fn).not.toHaveBeenCalled()
   })
 
   it('rejects numbers < 1', () => {
     const fn = vi.fn()
-    expect(dispatchWorkItem({ repoPath: '/r', number: 0 }, '/r', fn)).toBeNull()
-    expect(dispatchWorkItem({ repoPath: '/r', number: -5 }, '/r', fn)).toBeNull()
+    expect(dispatchWorkItem({ repoPath: '/r', number: 0 }, repo, fn)).toBeNull()
+    expect(dispatchWorkItem({ repoPath: '/r', number: -5 }, repo, fn)).toBeNull()
     expect(fn).not.toHaveBeenCalled()
   })
 
@@ -19,7 +21,7 @@ describe('dispatchWorkItem', () => {
     const fn = vi.fn()
     // Renderer can send anything; simulate a string that slips past TS.
     const bogus = { repoPath: '/r', number: 'abc' as unknown as number }
-    expect(dispatchWorkItem(bogus, '/r', fn)).toBeNull()
+    expect(dispatchWorkItem(bogus, repo, fn)).toBeNull()
     expect(fn).not.toHaveBeenCalled()
   })
 
@@ -30,19 +32,29 @@ describe('dispatchWorkItem', () => {
       number: 42,
       type: 'bogus' as unknown as 'issue' | 'pr'
     }
-    await dispatchWorkItem(bogus, '/r', fn)
-    expect(fn).toHaveBeenCalledWith('/r', 42, undefined)
+    await dispatchWorkItem(bogus, repo, fn)
+    expect(fn).toHaveBeenCalledWith('/r', 42, undefined, null)
   })
 
   it('passes valid issue type through', async () => {
     const fn = vi.fn().mockResolvedValue(null)
-    await dispatchWorkItem({ repoPath: '/r', number: 42, type: 'issue' }, '/r', fn)
-    expect(fn).toHaveBeenCalledWith('/r', 42, 'issue')
+    await dispatchWorkItem({ repoPath: '/r', number: 42, type: 'issue' }, repo, fn)
+    expect(fn).toHaveBeenCalledWith('/r', 42, 'issue', null)
   })
 
   it('passes valid pr type through', async () => {
     const fn = vi.fn().mockResolvedValue(null)
-    await dispatchWorkItem({ repoPath: '/r', number: 42, type: 'pr' }, '/r', fn)
-    expect(fn).toHaveBeenCalledWith('/r', 42, 'pr')
+    await dispatchWorkItem({ repoPath: '/r', number: 42, type: 'pr' }, repo, fn)
+    expect(fn).toHaveBeenCalledWith('/r', 42, 'pr', null)
+  })
+
+  it('passes SSH connection context through', async () => {
+    const fn = vi.fn().mockResolvedValue(null)
+    await dispatchWorkItem(
+      { repoPath: '/remote/repo', number: 42, type: 'issue' },
+      { path: '/remote/repo', connectionId: 'ssh-1' },
+      fn
+    )
+    expect(fn).toHaveBeenCalledWith('/remote/repo', 42, 'issue', 'ssh-1')
   })
 })

--- a/src/main/ipc/github-work-item-args.ts
+++ b/src/main/ipc/github-work-item-args.ts
@@ -4,19 +4,29 @@ export type WorkItemArgs = {
   type?: 'issue' | 'pr'
 }
 
+type RegisteredRepoContext = {
+  path: string
+  connectionId?: string | null
+}
+
 // Why: renderer input crosses the IPC boundary and is untrusted. Reject
 // non-integer or < 1 numbers, and coerce unrecognised `type` values to
 // undefined so getWorkItem falls through to its issue-then-PR probe rather
 // than silently dispatching to the wrong branch.
 export function dispatchWorkItem<T>(
   args: WorkItemArgs,
-  repoPath: string,
-  fn: (path: string, n: number, t?: 'issue' | 'pr') => Promise<T | null>
+  repo: RegisteredRepoContext,
+  fn: (
+    path: string,
+    n: number,
+    t?: 'issue' | 'pr',
+    connectionId?: string | null
+  ) => Promise<T | null>
 ): Promise<T | null> | null {
   const { number, type } = args
   if (typeof number !== 'number' || !Number.isInteger(number) || number < 1) {
     return null
   }
   const safeType = type === 'issue' || type === 'pr' ? type : undefined
-  return fn(repoPath, number, safeType)
+  return fn(repo.path, number, safeType, repo.connectionId ?? null)
 }

--- a/src/main/ipc/github.test.ts
+++ b/src/main/ipc/github.test.ts
@@ -42,6 +42,7 @@ describe('registerGitHubHandlers', () => {
     displayName: string
     badgeColor: string
     addedAt: number
+    connectionId?: string | null
     issueSourcePreference?: 'origin' | 'upstream'
   }
   let repos: FixtureRepo[] = []
@@ -93,7 +94,7 @@ describe('registerGitHubHandlers', () => {
       branch: 'feature/test'
     })
 
-    expect(getPRForBranchMock).toHaveBeenCalledWith('/workspace/repo', 'feature/test', null)
+    expect(getPRForBranchMock).toHaveBeenCalledWith('/workspace/repo', 'feature/test', null, null)
   })
 
   it('rejects unknown repository paths', async () => {
@@ -119,7 +120,7 @@ describe('registerGitHubHandlers', () => {
       limit: 5
     })
 
-    expect(listIssuesMock).toHaveBeenCalledWith('/workspace/repo', 5, undefined)
+    expect(listIssuesMock).toHaveBeenCalledWith('/workspace/repo', 5, undefined, null)
     expect(result).toEqual([])
   })
 
@@ -147,7 +148,7 @@ describe('registerGitHubHandlers', () => {
       limit: 5
     })
 
-    expect(listIssuesMock).toHaveBeenCalledWith('/workspace/repo', 5, undefined)
+    expect(listIssuesMock).toHaveBeenCalledWith('/workspace/repo', 5, undefined, null)
     expect(result).toEqual([])
   })
 
@@ -166,7 +167,7 @@ describe('registerGitHubHandlers', () => {
       limit: 5
     })
 
-    expect(listIssuesMock).toHaveBeenCalledWith('/workspace/repo', 5, 'upstream')
+    expect(listIssuesMock).toHaveBeenCalledWith('/workspace/repo', 5, 'upstream', null)
   })
 
   it('threads issueSourcePreference through gh:listWorkItems', async () => {
@@ -189,7 +190,30 @@ describe('registerGitHubHandlers', () => {
       10,
       'is:open',
       'cursor-1',
-      'origin'
+      'origin',
+      null
+    )
+  })
+
+  it('threads SSH connectionId through GitHub work-item handlers', async () => {
+    repos[0].connectionId = 'openclaw-2'
+    listWorkItemsMock.mockResolvedValue({ items: [] })
+
+    registerGitHubHandlers(store as never, stats as never)
+
+    await handlers['gh:listWorkItems'](null, {
+      repoPath: '/workspace/repo',
+      limit: 10,
+      query: ''
+    })
+
+    expect(listWorkItemsMock).toHaveBeenCalledWith(
+      '/workspace/repo',
+      10,
+      '',
+      undefined,
+      undefined,
+      'openclaw-2'
     )
   })
 

--- a/src/main/ipc/github.ts
+++ b/src/main/ipc/github.ts
@@ -82,6 +82,7 @@ import type {
 function broadcastWorkItemMutated(
   payload: {
     repoPath: string
+    repoId?: string
     type: 'issue' | 'pr'
     number: number
   },
@@ -100,21 +101,39 @@ function broadcastWorkItemMutated(
 
 // Why: returns the full Repo object instead of just the path string so that
 // callers have access to repo.id for stat tracking and other context.
-function assertRegisteredRepo(repoPath: string, store: Store): Repo {
+type RepoScopedArgs = { repoPath: string; repoId?: string }
+
+function assertRegisteredRepo(args: string | RepoScopedArgs, store: Store): Repo {
+  const repoPath = typeof args === 'string' ? args : args.repoPath
+  const repoId = typeof args === 'string' ? undefined : args.repoId
   const resolvedRepoPath = resolve(repoPath)
-  const repo = store.getRepos().find((r) => resolve(r.path) === resolvedRepoPath)
+  const repo = store
+    .getRepos()
+    .find((r) => (repoId ? r.id === repoId : resolve(r.path) === resolvedRepoPath))
   if (!repo) {
     throw new Error('Access denied: unknown repository path')
   }
+  if (repoId && resolve(repo.path) !== resolvedRepoPath) {
+    throw new Error('Access denied: repository path does not match repo id')
+  }
   return repo
+}
+
+function repoConnectionId(repo: Repo): string | null {
+  return repo.connectionId ?? null
 }
 
 export function registerGitHubHandlers(store: Store, stats: StatsCollector): void {
   ipcMain.handle(
     'gh:prForBranch',
     async (_event, args: { repoPath: string; branch: string; linkedPRNumber?: number | null }) => {
-      const repo = assertRegisteredRepo(args.repoPath, store)
-      const pr = await getPRForBranch(repo.path, args.branch, args.linkedPRNumber ?? null)
+      const repo = assertRegisteredRepo(args, store)
+      const pr = await getPRForBranch(
+        repo.path,
+        args.branch,
+        args.linkedPRNumber ?? null,
+        repoConnectionId(repo)
+      )
       // Emit pr_created when a PR is first detected for a branch.
       // Why here: the renderer polls gh:prForBranch to check PR status per worktree.
       // This captures PRs opened from any workflow (Orca UI, gh CLI, github.com).
@@ -131,47 +150,62 @@ export function registerGitHubHandlers(store: Store, stats: StatsCollector): voi
   )
 
   ipcMain.handle('gh:issue', (_event, args: { repoPath: string; number: number }) => {
-    const repo = assertRegisteredRepo(args.repoPath, store)
-    return getIssue(repo.path, args.number)
+    const repo = assertRegisteredRepo(args, store)
+    return getIssue(repo.path, args.number, repoConnectionId(repo))
   })
 
   ipcMain.handle('gh:listIssues', (_event, args: { repoPath: string; limit?: number }) => {
-    const repo = assertRegisteredRepo(args.repoPath, store)
+    const repo = assertRegisteredRepo(args, store)
     // Why: listIssues now returns { items, error? }. The IPC handler unwraps to
     // the items array for the existing contract; feature 1's UI consumes the
     // richer envelope through `gh:listWorkItems` instead.
-    return listIssues(repo.path, args.limit, repo.issueSourcePreference).then((r) => r.items)
+    return listIssues(
+      repo.path,
+      args.limit,
+      repo.issueSourcePreference,
+      repoConnectionId(repo)
+    ).then((r) => r.items)
   })
 
   ipcMain.handle(
     'gh:createIssue',
     (_event, args: { repoPath: string; title: string; body: string }) => {
-      const repo = assertRegisteredRepo(args.repoPath, store)
-      return createIssue(repo.path, args.title, args.body, repo.issueSourcePreference)
+      const repo = assertRegisteredRepo(args, store)
+      return createIssue(
+        repo.path,
+        args.title,
+        args.body,
+        repo.issueSourcePreference,
+        repoConnectionId(repo)
+      )
     }
   )
 
   ipcMain.handle(
     'gh:listWorkItems',
-    (_event, args: { repoPath: string; limit?: number; query?: string; before?: string }) => {
-      const repo = assertRegisteredRepo(args.repoPath, store)
+    (
+      _event,
+      args: { repoPath: string; repoId?: string; limit?: number; query?: string; before?: string }
+    ) => {
+      const repo = assertRegisteredRepo(args, store)
       return listWorkItems(
         repo.path,
         args.limit,
         args.query,
         args.before,
-        repo.issueSourcePreference
+        repo.issueSourcePreference,
+        repoConnectionId(repo)
       )
     }
   )
 
   ipcMain.handle('gh:countWorkItems', (_event, args: { repoPath: string; query?: string }) => {
-    const repo = assertRegisteredRepo(args.repoPath, store)
-    return countWorkItems(repo.path, args.query, repo.issueSourcePreference)
+    const repo = assertRegisteredRepo(args, store)
+    return countWorkItems(repo.path, args.query, repo.issueSourcePreference, repoConnectionId(repo))
   })
 
   ipcMain.handle('gh:workItem', (_event, args: WorkItemArgs) =>
-    dispatchWorkItem(args, assertRegisteredRepo(args.repoPath, store).path, getWorkItem)
+    dispatchWorkItem(args, assertRegisteredRepo(args, store), getWorkItem)
   )
   ipcMain.handle(
     'gh:workItemByOwnerRepo',
@@ -184,16 +218,19 @@ export function registerGitHubHandlers(store: Store, stats: StatsCollector): voi
         number: number
         type: 'issue' | 'pr'
       }
-    ) =>
-      getWorkItemByOwnerRepo(
-        assertRegisteredRepo(args.repoPath, store).path,
+    ) => {
+      const repo = assertRegisteredRepo(args, store)
+      return getWorkItemByOwnerRepo(
+        repo.path,
         { owner: args.owner, repo: args.repo },
         args.number,
-        args.type
+        args.type,
+        repoConnectionId(repo)
       )
+    }
   )
   ipcMain.handle('gh:workItemDetails', (_event, args: WorkItemArgs) =>
-    dispatchWorkItem(args, assertRegisteredRepo(args.repoPath, store).path, getWorkItemDetails)
+    dispatchWorkItem(args, assertRegisteredRepo(args, store), getWorkItemDetails)
   )
 
   ipcMain.handle(
@@ -210,9 +247,10 @@ export function registerGitHubHandlers(store: Store, stats: StatsCollector): voi
         baseSha: string
       }
     ) => {
-      const repo = assertRegisteredRepo(args.repoPath, store)
+      const repo = assertRegisteredRepo(args, store)
       return getPRFileContents({
         repoPath: repo.path,
+        connectionId: repoConnectionId(repo),
         prNumber: args.prNumber,
         path: args.path,
         oldPath: args.oldPath,
@@ -224,8 +262,8 @@ export function registerGitHubHandlers(store: Store, stats: StatsCollector): voi
   )
 
   ipcMain.handle('gh:repoSlug', (_event, args: { repoPath: string }) => {
-    const repo = assertRegisteredRepo(args.repoPath, store)
-    return getRepoSlug(repo.path)
+    const repo = assertRegisteredRepo(args, store)
+    return getRepoSlug(repo.path, repoConnectionId(repo))
   })
 
   ipcMain.handle(
@@ -239,31 +277,42 @@ export function registerGitHubHandlers(store: Store, stats: StatsCollector): voi
         noCache?: boolean
       }
     ) => {
-      const repo = assertRegisteredRepo(args.repoPath, store)
-      return getPRChecks(repo.path, args.prNumber, args.headSha, {
-        noCache: args.noCache
-      })
+      const repo = assertRegisteredRepo(args, store)
+      return getPRChecks(
+        repo.path,
+        args.prNumber,
+        args.headSha,
+        {
+          noCache: args.noCache
+        },
+        repoConnectionId(repo)
+      )
     }
   )
 
   ipcMain.handle(
     'gh:prComments',
     (_event, args: { repoPath: string; prNumber: number; noCache?: boolean }) => {
-      const repo = assertRegisteredRepo(args.repoPath, store)
-      return getPRComments(repo.path, args.prNumber, { noCache: args.noCache })
+      const repo = assertRegisteredRepo(args, store)
+      return getPRComments(
+        repo.path,
+        args.prNumber,
+        { noCache: args.noCache },
+        repoConnectionId(repo)
+      )
     }
   )
 
   ipcMain.handle(
     'gh:resolveReviewThread',
     async (_event, args: { repoPath: string; threadId: string; resolve: boolean }) => {
-      const repo = assertRegisteredRepo(args.repoPath, store)
+      const repo = assertRegisteredRepo(args, store)
       // Why: thread resolve doesn't carry the PR number, so we cannot target
       // a specific cache entry. The renderer cache stores per-(repo, type, number)
       // entries — emitting a path-wide invalidation here would require a new
       // event shape; instead, the drawer's existing thread-resolve UI updates
       // its local state immediately and the next reopen pays one fresh fetch.
-      return resolveReviewThread(repo.path, args.threadId, args.resolve)
+      return resolveReviewThread(repo.path, args.threadId, args.resolve, repoConnectionId(repo))
     }
   )
 
@@ -281,7 +330,7 @@ export function registerGitHubHandlers(store: Store, stats: StatsCollector): voi
         line?: number
       }
     ) => {
-      const repo = assertRegisteredRepo(args.repoPath, store)
+      const repo = assertRegisteredRepo(args, store)
       if (
         typeof args.prNumber !== 'number' ||
         !Number.isInteger(args.prNumber) ||
@@ -306,11 +355,12 @@ export function registerGitHubHandlers(store: Store, stats: StatsCollector): voi
         args.body.trim(),
         args.threadId,
         args.path,
-        args.line
+        args.line,
+        repoConnectionId(repo)
       )
       if (result.ok) {
         broadcastWorkItemMutated(
-          { repoPath: repo.path, type: 'pr', number: args.prNumber },
+          { repoPath: repo.path, repoId: repo.id, type: 'pr', number: args.prNumber },
           event.sender.id
         )
       }
@@ -332,7 +382,7 @@ export function registerGitHubHandlers(store: Store, stats: StatsCollector): voi
         body: string
       }
     ) => {
-      const repo = assertRegisteredRepo(args.repoPath, store)
+      const repo = assertRegisteredRepo(args, store)
       if (
         typeof args.prNumber !== 'number' ||
         !Number.isInteger(args.prNumber) ||
@@ -368,11 +418,12 @@ export function registerGitHubHandlers(store: Store, stats: StatsCollector): voi
         path: args.path,
         line: args.line,
         startLine: args.startLine,
-        body: args.body.trim()
+        body: args.body.trim(),
+        connectionId: repoConnectionId(repo)
       })
       if (result.ok) {
         broadcastWorkItemMutated(
-          { repoPath: repo.path, type: 'pr', number: args.prNumber },
+          { repoPath: repo.path, repoId: repo.id, type: 'pr', number: args.prNumber },
           event.sender.id
         )
       }
@@ -383,11 +434,11 @@ export function registerGitHubHandlers(store: Store, stats: StatsCollector): voi
   ipcMain.handle(
     'gh:updatePRTitle',
     async (event, args: { repoPath: string; prNumber: number; title: string }) => {
-      const repo = assertRegisteredRepo(args.repoPath, store)
-      const ok = await updatePRTitle(repo.path, args.prNumber, args.title)
+      const repo = assertRegisteredRepo(args, store)
+      const ok = await updatePRTitle(repo.path, args.prNumber, args.title, repoConnectionId(repo))
       if (ok) {
         broadcastWorkItemMutated(
-          { repoPath: repo.path, type: 'pr', number: args.prNumber },
+          { repoPath: repo.path, repoId: repo.id, type: 'pr', number: args.prNumber },
           event.sender.id
         )
       }
@@ -401,11 +452,11 @@ export function registerGitHubHandlers(store: Store, stats: StatsCollector): voi
       event,
       args: { repoPath: string; prNumber: number; method?: 'merge' | 'squash' | 'rebase' }
     ) => {
-      const repo = assertRegisteredRepo(args.repoPath, store)
-      const result = await mergePR(repo.path, args.prNumber, args.method)
+      const repo = assertRegisteredRepo(args, store)
+      const result = await mergePR(repo.path, args.prNumber, args.method, repoConnectionId(repo))
       if (result.ok) {
         broadcastWorkItemMutated(
-          { repoPath: repo.path, type: 'pr', number: args.prNumber },
+          { repoPath: repo.path, repoId: repo.id, type: 'pr', number: args.prNumber },
           event.sender.id
         )
       }
@@ -415,18 +466,21 @@ export function registerGitHubHandlers(store: Store, stats: StatsCollector): voi
 
   ipcMain.handle(
     'gh:updateIssue',
-    async (event, args: { repoPath: string; number: number; updates: GitHubIssueUpdate }) => {
-      const repo = assertRegisteredRepo(args.repoPath, store)
+    async (
+      event,
+      args: { repoPath: string; repoId?: string; number: number; updates: GitHubIssueUpdate }
+    ) => {
+      const repo = assertRegisteredRepo(args, store)
       if (typeof args.number !== 'number' || !Number.isInteger(args.number) || args.number < 1) {
         return { ok: false, error: 'Invalid issue number' }
       }
       if (!args.updates || typeof args.updates !== 'object') {
         return { ok: false, error: 'Updates object is required' }
       }
-      const result = await updateIssue(repo.path, args.number, args.updates)
+      const result = await updateIssue(repo.path, args.number, args.updates, repoConnectionId(repo))
       if (result.ok) {
         broadcastWorkItemMutated(
-          { repoPath: repo.path, type: 'issue', number: args.number },
+          { repoPath: repo.path, repoId: repo.id, type: 'issue', number: args.number },
           event.sender.id
         )
       }
@@ -440,14 +494,19 @@ export function registerGitHubHandlers(store: Store, stats: StatsCollector): voi
       event,
       args: { repoPath: string; number: number; body: string; type?: 'issue' | 'pr' }
     ) => {
-      const repo = assertRegisteredRepo(args.repoPath, store)
+      const repo = assertRegisteredRepo(args, store)
       if (typeof args.number !== 'number' || !Number.isInteger(args.number) || args.number < 1) {
         return { ok: false, error: 'Invalid issue number' }
       }
       if (!args.body?.trim()) {
         return { ok: false, error: 'Comment body required' }
       }
-      const result = await addIssueComment(repo.path, args.number, args.body.trim())
+      const result = await addIssueComment(
+        repo.path,
+        args.number,
+        args.body.trim(),
+        repoConnectionId(repo)
+      )
       if (result.ok) {
         // Why: PR conversation comments hit `/issues/N/comments` too, but the
         // drawer's cache key uses type='pr'. The caller passes through which
@@ -455,7 +514,7 @@ export function registerGitHubHandlers(store: Store, stats: StatsCollector): voi
         // — broadcasting both would evict an unrelated PR/issue that happens
         // to share the number.
         broadcastWorkItemMutated(
-          { repoPath: repo.path, type: args.type ?? 'issue', number: args.number },
+          { repoPath: repo.path, repoId: repo.id, type: args.type ?? 'issue', number: args.number },
           event.sender.id
         )
       }
@@ -464,13 +523,13 @@ export function registerGitHubHandlers(store: Store, stats: StatsCollector): voi
   )
 
   ipcMain.handle('gh:listLabels', (_event, args: { repoPath: string }) => {
-    const repo = assertRegisteredRepo(args.repoPath, store)
-    return listLabels(repo.path, repo.issueSourcePreference)
+    const repo = assertRegisteredRepo(args, store)
+    return listLabels(repo.path, repo.issueSourcePreference, repoConnectionId(repo))
   })
 
   ipcMain.handle('gh:listAssignableUsers', (_event, args: { repoPath: string }) => {
-    const repo = assertRegisteredRepo(args.repoPath, store)
-    return listAssignableUsers(repo.path, repo.issueSourcePreference)
+    const repo = assertRegisteredRepo(args, store)
+    return listAssignableUsers(repo.path, repo.issueSourcePreference, repoConnectionId(repo))
   })
 
   // Star operations target the Orca repo itself — no repoPath validation needed

--- a/src/main/ipc/hosted-review.ts
+++ b/src/main/ipc/hosted-review.ts
@@ -6,7 +6,14 @@ import type { Store } from '../persistence'
 import type { StatsCollector } from '../stats/collector'
 import { getHostedReviewForBranch } from '../source-control/hosted-review'
 
-function assertRegisteredRepo(repoPath: string, store: Store): Repo {
+function assertRegisteredRepo(repoPath: string, store: Store, repoId?: string): Repo {
+  if (repoId) {
+    const repo = store.getRepo(repoId)
+    if (!repo || repo.path !== repoPath) {
+      throw new Error('Access denied: unknown repository')
+    }
+    return repo
+  }
   const resolvedRepoPath = resolve(repoPath)
   const repo = store.getRepos().find((r) => resolve(r.path) === resolvedRepoPath)
   if (!repo) {
@@ -17,9 +24,10 @@ function assertRegisteredRepo(repoPath: string, store: Store): Repo {
 
 export function registerHostedReviewHandlers(store: Store, stats: StatsCollector): void {
   ipcMain.handle('hostedReview:forBranch', async (_event, args: HostedReviewForBranchArgs) => {
-    const repo = assertRegisteredRepo(args.repoPath, store)
+    const repo = assertRegisteredRepo(args.repoPath, store, args.repoId)
     const review = await getHostedReviewForBranch({
       repoPath: repo.path,
+      connectionId: repo.connectionId,
       branch: args.branch,
       linkedGitHubPR: args.linkedGitHubPR ?? null,
       linkedGitLabMR: args.linkedGitLabMR ?? null,

--- a/src/main/ipc/remote-workspace-events.ts
+++ b/src/main/ipc/remote-workspace-events.ts
@@ -1,0 +1,24 @@
+type RemoteWorkspaceNotificationHandler = (
+  targetId: string,
+  method: string,
+  params: Record<string, unknown>
+) => void
+
+const handlers = new Set<RemoteWorkspaceNotificationHandler>()
+
+export function registerRemoteWorkspaceNotificationHandler(
+  handler: RemoteWorkspaceNotificationHandler
+): () => void {
+  handlers.add(handler)
+  return () => handlers.delete(handler)
+}
+
+export function notifyRemoteWorkspaceHandlers(
+  targetId: string,
+  method: string,
+  params: Record<string, unknown>
+): void {
+  for (const handler of handlers) {
+    handler(targetId, method, params)
+  }
+}

--- a/src/main/ipc/remote-workspace-namespace.ts
+++ b/src/main/ipc/remote-workspace-namespace.ts
@@ -1,0 +1,12 @@
+import { createHash } from 'crypto'
+import type { SshTarget } from '../../shared/ssh-types'
+
+export function getRemoteWorkspaceNamespace(target: SshTarget): string {
+  const stableKey = [
+    target.configHost || target.host,
+    target.host,
+    String(target.port),
+    target.username
+  ].join('\n')
+  return createHash('sha256').update(stableKey).digest('hex').slice(0, 32)
+}

--- a/src/main/ipc/remote-workspace.test.ts
+++ b/src/main/ipc/remote-workspace.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest'
+import { remoteWorkspaceSessionMatchesSnapshot } from './remote-workspace'
+import type {
+  RemoteWorkspaceSession,
+  RemoteWorkspaceSnapshot
+} from '../../shared/remote-workspace-types'
+
+function snapshot(session: RemoteWorkspaceSession): RemoteWorkspaceSnapshot {
+  return {
+    namespace: 'target',
+    revision: 7,
+    updatedAt: 123,
+    schemaVersion: 1,
+    session
+  }
+}
+
+describe('remoteWorkspaceSessionMatchesSnapshot', () => {
+  it('matches normalized equivalent sessions', () => {
+    expect(
+      remoteWorkspaceSessionMatchesSnapshot(
+        snapshot({
+          activeWorktreePath: null,
+          activeTabId: null,
+          tabsByWorktreePath: {},
+          terminalLayoutsByTabId: {}
+        }),
+        {
+          activeWorktreePath: null,
+          activeTabId: null,
+          tabsByWorktreePath: {},
+          terminalLayoutsByTabId: {},
+          activeWorktreePathsOnShutdown: undefined,
+          activeTabIdByWorktreePath: undefined,
+          remoteSessionIdsByTabId: undefined,
+          lastVisitedAtByWorktreePath: undefined
+        }
+      )
+    ).toBe(true)
+  })
+
+  it('treats empty optional projection fields as equivalent to absent fields', () => {
+    expect(
+      remoteWorkspaceSessionMatchesSnapshot(
+        snapshot({
+          activeWorktreePath: null,
+          activeTabId: null,
+          tabsByWorktreePath: {},
+          terminalLayoutsByTabId: {},
+          activeWorktreePathsOnShutdown: [],
+          activeTabIdByWorktreePath: {},
+          remoteSessionIdsByTabId: {},
+          lastVisitedAtByWorktreePath: {}
+        }),
+        {
+          activeWorktreePath: null,
+          activeTabId: null,
+          tabsByWorktreePath: {},
+          terminalLayoutsByTabId: {}
+        }
+      )
+    ).toBe(true)
+  })
+
+  it('detects actual target session changes', () => {
+    expect(
+      remoteWorkspaceSessionMatchesSnapshot(
+        snapshot({
+          activeWorktreePath: '/repo',
+          activeTabId: 'tab-1',
+          tabsByWorktreePath: {
+            '/repo': [{ id: 'tab-1', type: 'terminal', title: 'Shell' } as never]
+          },
+          terminalLayoutsByTabId: {}
+        }),
+        {
+          activeWorktreePath: '/repo',
+          activeTabId: 'tab-2',
+          tabsByWorktreePath: {
+            '/repo': [{ id: 'tab-2', type: 'terminal', title: 'Shell 2' } as never]
+          },
+          terminalLayoutsByTabId: {}
+        }
+      )
+    ).toBe(false)
+  })
+})

--- a/src/main/ipc/remote-workspace.ts
+++ b/src/main/ipc/remote-workspace.ts
@@ -1,0 +1,385 @@
+/* oxlint-disable max-lines -- Why: remote workspace IPC keeps snapshot normalization, relay compatibility, and handler registration together so revision/cache semantics stay auditable. */
+import { randomUUID } from 'crypto'
+import { ipcMain, type BrowserWindow } from 'electron'
+import { hostname } from 'os'
+import { isDeepStrictEqual } from 'util'
+import type { Store } from '../persistence'
+import { getActiveMultiplexer, getSshConnectionStore } from './ssh'
+import {
+  exportRemoteWorkspaceSession,
+  importRemoteWorkspaceSession
+} from '../../shared/remote-workspace-session-projection'
+import type {
+  RemoteWorkspaceChangedEvent,
+  RemoteWorkspaceConnectedClient,
+  RemoteWorkspacePatchResult,
+  RemoteWorkspaceSession,
+  RemoteWorkspaceSnapshot
+} from '../../shared/remote-workspace-types'
+import type { SshTarget } from '../../shared/ssh-types'
+import type { WorkspaceSessionState } from '../../shared/types'
+import { getRepoIdFromWorktreeId, splitWorktreeId } from '../../shared/worktree-id'
+import { getRemoteWorkspaceNamespace } from './remote-workspace-namespace'
+import { registerRemoteWorkspaceNotificationHandler } from './remote-workspace-events'
+
+const CLIENT_ID = randomUUID()
+const CLIENT_NAME = hostname() || 'This device'
+const SNAPSHOT_SCHEMA_VERSION = 1
+
+let mainWindowGetter: (() => BrowserWindow | null) | null = null
+const latestSnapshotByTargetId = new Map<string, RemoteWorkspaceSnapshot>()
+let unregisterRemoteWorkspaceNotifications: (() => void) | null = null
+
+function emptyRemoteSession(): RemoteWorkspaceSession {
+  return {
+    activeWorktreePath: null,
+    activeTabId: null,
+    tabsByWorktreePath: {},
+    terminalLayoutsByTabId: {}
+  }
+}
+
+function normalizeOptionalStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined
+  }
+  const normalized = value.filter((entry): entry is string => typeof entry === 'string')
+  return normalized.length > 0 ? normalized : undefined
+}
+
+function normalizeOptionalRecord<T extends Record<string, unknown>>(value: unknown): T | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined
+  }
+  return Object.keys(value).length > 0 ? (value as T) : undefined
+}
+
+function normalizeRemoteSession(raw: unknown): RemoteWorkspaceSession {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return emptyRemoteSession()
+  }
+  const input = raw as Partial<RemoteWorkspaceSession>
+  return {
+    activeWorktreePath:
+      typeof input.activeWorktreePath === 'string' ? input.activeWorktreePath : null,
+    activeTabId: typeof input.activeTabId === 'string' ? input.activeTabId : null,
+    tabsByWorktreePath:
+      input.tabsByWorktreePath &&
+      typeof input.tabsByWorktreePath === 'object' &&
+      !Array.isArray(input.tabsByWorktreePath)
+        ? input.tabsByWorktreePath
+        : {},
+    terminalLayoutsByTabId:
+      input.terminalLayoutsByTabId &&
+      typeof input.terminalLayoutsByTabId === 'object' &&
+      !Array.isArray(input.terminalLayoutsByTabId)
+        ? input.terminalLayoutsByTabId
+        : {},
+    activeWorktreePathsOnShutdown: normalizeOptionalStringArray(
+      input.activeWorktreePathsOnShutdown
+    ),
+    activeTabIdByWorktreePath: normalizeOptionalRecord<Record<string, string | null>>(
+      input.activeTabIdByWorktreePath
+    ),
+    remoteSessionIdsByTabId: normalizeOptionalRecord<Record<string, string>>(
+      input.remoteSessionIdsByTabId
+    ),
+    lastVisitedAtByWorktreePath: normalizeOptionalRecord<Record<string, number>>(
+      input.lastVisitedAtByWorktreePath
+    )
+  }
+}
+
+function normalizeSnapshot(raw: unknown, fallbackNamespace: string): RemoteWorkspaceSnapshot {
+  const input = raw as Partial<RemoteWorkspaceSnapshot> | null
+  return {
+    namespace: typeof input?.namespace === 'string' ? input.namespace : fallbackNamespace,
+    revision:
+      typeof input?.revision === 'number' && Number.isFinite(input.revision) ? input.revision : 0,
+    updatedAt:
+      typeof input?.updatedAt === 'number' && Number.isFinite(input.updatedAt)
+        ? input.updatedAt
+        : 0,
+    schemaVersion:
+      typeof input?.schemaVersion === 'number' && Number.isFinite(input.schemaVersion)
+        ? input.schemaVersion
+        : SNAPSHOT_SCHEMA_VERSION,
+    session: normalizeRemoteSession(input?.session)
+  }
+}
+
+export function remoteWorkspaceSessionMatchesSnapshot(
+  snapshot: RemoteWorkspaceSnapshot | undefined,
+  session: RemoteWorkspaceSession
+): boolean {
+  if (!snapshot) {
+    return false
+  }
+  return isDeepStrictEqual(
+    normalizeRemoteSession(snapshot.session),
+    normalizeRemoteSession(session)
+  )
+}
+
+function normalizeConnectedClients(
+  raw: unknown,
+  currentClientId: string
+): RemoteWorkspaceConnectedClient[] {
+  const clients = (raw as { clients?: unknown } | null)?.clients
+  if (!Array.isArray(clients)) {
+    return []
+  }
+  return clients
+    .map((entry): RemoteWorkspaceConnectedClient | null => {
+      const item = entry as Partial<RemoteWorkspaceConnectedClient> | null
+      const clientId = typeof item?.clientId === 'string' ? item.clientId.trim() : ''
+      if (!clientId || clientId.length > 200) {
+        return null
+      }
+      return {
+        clientId,
+        name:
+          typeof item?.name === 'string' && item.name.trim()
+            ? item.name.replace(/\s+/g, ' ').trim().slice(0, 80)
+            : 'Unknown device',
+        lastSeenAt:
+          typeof item?.lastSeenAt === 'number' && Number.isFinite(item.lastSeenAt)
+            ? item.lastSeenAt
+            : 0,
+        isCurrent: clientId === currentClientId
+      }
+    })
+    .filter((entry): entry is RemoteWorkspaceConnectedClient => entry !== null)
+}
+
+function targetForWorktree(store: Store, worktreeId: string): string | null {
+  const repoId = getRepoIdFromWorktreeId(worktreeId)
+  return store.getRepo(repoId)?.connectionId ?? null
+}
+
+function exportSessionForTarget(
+  store: Store,
+  targetId: string,
+  session: WorkspaceSessionState
+): RemoteWorkspaceSession {
+  return exportRemoteWorkspaceSession(session, {
+    isTargetWorktree: (worktreeId) => targetForWorktree(store, worktreeId) === targetId
+  })
+}
+
+function importSessionForTarget(
+  store: Store,
+  targetId: string,
+  remote: RemoteWorkspaceSession
+): WorkspaceSessionState {
+  const repos = store.getRepos().filter((repo) => repo.connectionId === targetId)
+  const repoById = new Map(repos.map((repo) => [repo.id, repo]))
+  return importRemoteWorkspaceSession(remote, {
+    resolveWorktreeId: (worktreePath) => {
+      for (const repo of repoById.values()) {
+        const candidate = `${repo.id}::${worktreePath}`
+        // Main does not own the live worktree list for SSH repos, so resolve
+        // against repo identity only. Renderer hydration later validates IDs
+        // against its fetched worktree list before panes mount.
+        if (splitWorktreeId(candidate)) {
+          return candidate
+        }
+      }
+      return null
+    }
+  })
+}
+
+async function getRemoteSnapshot(target: SshTarget): Promise<RemoteWorkspaceSnapshot | null> {
+  if (!target.remoteWorkspaceSyncEnabled) {
+    return null
+  }
+  const mux = getActiveMultiplexer(target.id)
+  if (!mux) {
+    return null
+  }
+  const namespace = getRemoteWorkspaceNamespace(target)
+  try {
+    const raw = await mux.request('workspace.get', { namespace })
+    const snapshot = normalizeSnapshot(raw, namespace)
+    latestSnapshotByTargetId.set(target.id, snapshot)
+    return snapshot
+  } catch (err) {
+    if ((err as { code?: unknown })?.code === -32601) {
+      return null
+    }
+    throw err
+  }
+}
+
+export function handleRemoteWorkspaceNotification(
+  targetId: string,
+  method: string,
+  params: Record<string, unknown>
+): void {
+  if (method !== 'workspace.changed') {
+    return
+  }
+  const target = getSshConnectionStore()?.getTarget(targetId)
+  if (!target?.remoteWorkspaceSyncEnabled) {
+    return
+  }
+  const namespace = getRemoteWorkspaceNamespace(target)
+  const snapshot = normalizeSnapshot(params.snapshot, namespace)
+  latestSnapshotByTargetId.set(targetId, snapshot)
+  const event: RemoteWorkspaceChangedEvent = {
+    targetId,
+    snapshot,
+    sourceClientId: typeof params.sourceClientId === 'string' ? params.sourceClientId : undefined
+  }
+  const win = mainWindowGetter?.()
+  if (win && !win.isDestroyed()) {
+    win.webContents.send('remoteWorkspace:changed', event)
+  }
+}
+
+export function registerRemoteWorkspaceHandlers(
+  store: Store,
+  getMainWindow: () => BrowserWindow | null
+): void {
+  mainWindowGetter = getMainWindow
+  unregisterRemoteWorkspaceNotifications?.()
+  unregisterRemoteWorkspaceNotifications = registerRemoteWorkspaceNotificationHandler(
+    handleRemoteWorkspaceNotification
+  )
+  ipcMain.removeHandler('remoteWorkspace:get')
+  ipcMain.removeHandler('remoteWorkspace:setForConnectedTargets')
+  ipcMain.removeHandler('remoteWorkspace:listEnabledConnectedTargets')
+  ipcMain.removeHandler('remoteWorkspace:listConnectedClients')
+  ipcMain.removeHandler('remoteWorkspace:clientId')
+
+  ipcMain.handle('remoteWorkspace:get', async (_event, args: { targetId: string }) => {
+    const target = getSshConnectionStore()?.getTarget(args.targetId)
+    if (!target) {
+      return null
+    }
+    return getRemoteSnapshot(target)
+  })
+
+  ipcMain.handle(
+    'remoteWorkspace:setForConnectedTargets',
+    async (_event, args: { session: WorkspaceSessionState; hydratedTargetIds?: string[] }) => {
+      const hydratedTargetIds = Array.isArray(args.hydratedTargetIds)
+        ? new Set(args.hydratedTargetIds)
+        : null
+      const targets =
+        getSshConnectionStore()
+          ?.listTargets()
+          .filter(
+            (target) =>
+              target.remoteWorkspaceSyncEnabled &&
+              getActiveMultiplexer(target.id) &&
+              (!hydratedTargetIds || hydratedTargetIds.has(target.id))
+          ) ?? []
+
+      const results: { targetId: string; result: RemoteWorkspacePatchResult }[] = []
+      for (const target of targets) {
+        const mux = getActiveMultiplexer(target.id)
+        if (!mux) {
+          continue
+        }
+        const namespace = getRemoteWorkspaceNamespace(target)
+        const current =
+          latestSnapshotByTargetId.get(target.id) ?? (await getRemoteSnapshot(target)) ?? undefined
+        const session = exportSessionForTarget(store, target.id, args.session)
+        let result: RemoteWorkspacePatchResult
+        if (current && remoteWorkspaceSessionMatchesSnapshot(current, session)) {
+          // Why: a pulled workspace snapshot rehydrates local state and can
+          // trigger session persistence. Identical target sessions must be a
+          // local no-op or two clients will echo revisions indefinitely.
+          result = { ok: true, snapshot: current }
+          results.push({ targetId: target.id, result })
+          continue
+        }
+        try {
+          result = (await mux.request('workspace.patch', {
+            namespace,
+            baseRevision: current?.revision ?? 0,
+            clientId: CLIENT_ID,
+            patch: { kind: 'replace-session', session }
+          })) as RemoteWorkspacePatchResult
+        } catch (err) {
+          result =
+            (err as { code?: unknown })?.code === -32601
+              ? {
+                  ok: false,
+                  reason: 'unavailable',
+                  message: 'Remote workspace sync is unavailable on this relay'
+                }
+              : {
+                  ok: false,
+                  reason: 'unavailable',
+                  message: err instanceof Error ? err.message : 'Remote workspace sync failed'
+                }
+        }
+        if (result.ok) {
+          latestSnapshotByTargetId.set(target.id, result.snapshot)
+        }
+        results.push({ targetId: target.id, result })
+      }
+      return results
+    }
+  )
+
+  ipcMain.handle(
+    'remoteWorkspace:listEnabledConnectedTargets',
+    async () =>
+      getSshConnectionStore()
+        ?.listTargets()
+        .filter((target) => target.remoteWorkspaceSyncEnabled && getActiveMultiplexer(target.id))
+        .map((target) => target.id) ?? []
+  )
+
+  ipcMain.handle(
+    'remoteWorkspace:listConnectedClients',
+    async (_event, args?: { targetIds?: string[] }) => {
+      const requestedTargetIds = Array.isArray(args?.targetIds) ? new Set(args.targetIds) : null
+      const targets =
+        getSshConnectionStore()
+          ?.listTargets()
+          .filter(
+            (target) =>
+              target.remoteWorkspaceSyncEnabled &&
+              getActiveMultiplexer(target.id) &&
+              (!requestedTargetIds || requestedTargetIds.has(target.id))
+          ) ?? []
+      const results: { targetId: string; clients: RemoteWorkspaceConnectedClient[] }[] = []
+      for (const target of targets) {
+        const mux = getActiveMultiplexer(target.id)
+        if (!mux) {
+          continue
+        }
+        const namespace = getRemoteWorkspaceNamespace(target)
+        try {
+          const raw = await mux.request('workspace.presence', {
+            namespace,
+            clientId: CLIENT_ID,
+            clientName: CLIENT_NAME
+          })
+          results.push({
+            targetId: target.id,
+            clients: normalizeConnectedClients(raw, CLIENT_ID)
+          })
+        } catch {
+          results.push({ targetId: target.id, clients: [] })
+        }
+      }
+      return results
+    }
+  )
+
+  ipcMain.handle('remoteWorkspace:clientId', () => CLIENT_ID)
+}
+
+export function materializeRemoteWorkspaceForTarget(
+  store: Store,
+  targetId: string,
+  snapshot: RemoteWorkspaceSnapshot
+): WorkspaceSessionState {
+  return importSessionForTarget(store, targetId, snapshot.session)
+}

--- a/src/main/ipc/ssh.ts
+++ b/src/main/ipc/ssh.ts
@@ -36,6 +36,15 @@ let portForwardManager: SshPortForwardManager | null = null
 // scattered Maps/Sets that previously tracked this state independently.
 const activeSessions = new Map<string, SshRelaySession>()
 
+function relayGracePeriodForTarget(target: SshTarget | null | undefined): number | undefined {
+  if (!target?.remoteWorkspaceSyncEnabled) {
+    return target?.relayGracePeriodSeconds
+  }
+  // Why: cross-device sync should survive transient app closes, but an
+  // unset value must not mean "keep remote PTYs forever" after disconnect.
+  return target.remoteWorkspaceSyncGracePeriodSeconds ?? 300
+}
+
 // Why: multiple renderer tabs for the same SSH target can fire ssh:connect
 // concurrently. Without serialization, the second call interleaves with the
 // first — both see no existing session, both create one, and the first one
@@ -260,7 +269,7 @@ export function registerSshHandlers(
         const target = sshStore?.getTarget(targetId)
         const conn = connectionManager?.getConnection(targetId)
         if (conn) {
-          void session.reconnect(conn, target?.relayGracePeriodSeconds)
+          void session.reconnect(conn, relayGracePeriodForTarget(target))
         }
       }
     }
@@ -495,7 +504,7 @@ export function registerSshHandlers(
           if (!liveConn || !activeSessions.has(tid)) {
             return
           }
-          void s.reconnect(liveConn, t?.relayGracePeriodSeconds)
+          void s.reconnect(liveConn, relayGracePeriodForTarget(t))
         }, delay)
         relayLostBackoff.set(tid, state)
         console.warn(
@@ -523,7 +532,7 @@ export function registerSshHandlers(
         void restorePortForwards(tid, getMainWindow)
       })
 
-      await session.establish(conn, target.relayGracePeriodSeconds)
+      await session.establish(conn, relayGracePeriodForTarget(target))
 
       // Why: we manually pushed `deploying-relay` above, so the renderer's
       // state is stuck there. Send `connected` directly to the renderer

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -22,6 +22,7 @@ import { getPRForBranch } from '../github/client'
 import { listWorktrees, addWorktree, addSparseWorktree } from '../git/worktree'
 import { getGitUsername, getDefaultBaseRef, getBranchConflictKind } from '../git/repo'
 import { validateGitPushTarget } from '../git/push-target-validation'
+import { assertGitPushTargetShape } from '../../shared/git-push-target-validation'
 import { gitExecFileAsync } from '../git/runner'
 import { parseGitHubOwnerRepo } from '../github/gh-utils'
 import type { OrcaRuntimeService } from '../runtime/orca-runtime'
@@ -150,6 +151,108 @@ export async function configureCreatedWorktreePushTarget(
   return target
 }
 
+async function findRemoteForUrlSsh(
+  provider: SshGitProvider,
+  repoPath: string,
+  remoteUrl: string
+): Promise<string | null> {
+  const target = parseGitHubOwnerRepo(remoteUrl)
+  try {
+    const { stdout } = await provider.exec(['remote'], repoPath)
+    for (const remote of stdout
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)) {
+      try {
+        const { stdout: urlStdout } = await provider.exec(['remote', 'get-url', remote], repoPath)
+        const candidateUrl = urlStdout.trim()
+        const candidate = parseGitHubOwnerRepo(candidateUrl)
+        if (
+          target &&
+          candidate &&
+          target.owner.toLowerCase() === candidate.owner.toLowerCase() &&
+          target.repo.toLowerCase() === candidate.repo.toLowerCase()
+        ) {
+          return remote
+        }
+        if (candidateUrl === remoteUrl) {
+          return remote
+        }
+      } catch {
+        // Ignore a remote that disappeared or has no fetch URL.
+      }
+    }
+  } catch {
+    return null
+  }
+  return null
+}
+
+async function ensureUniqueRemoteNameSsh(
+  provider: SshGitProvider,
+  repoPath: string,
+  preferred: string
+): Promise<string> {
+  const { stdout } = await provider.exec(['remote'], repoPath)
+  const existing = new Set(
+    stdout
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+  )
+  if (!existing.has(preferred)) {
+    return preferred
+  }
+  for (let suffix = 2; suffix < 100; suffix += 1) {
+    const candidate = `${preferred}-${suffix}`
+    if (!existing.has(candidate)) {
+      return candidate
+    }
+  }
+  throw new Error(`Could not find an available remote name for ${preferred}.`)
+}
+
+async function prepareWorktreePushTargetSsh(
+  provider: SshGitProvider,
+  repoPath: string,
+  target: GitPushTarget
+): Promise<GitPushTarget> {
+  assertGitPushTargetShape(target)
+  await provider.exec(['check-ref-format', '--branch', target.branchName], repoPath)
+  let remoteName = target.remoteName
+  if (target.remoteUrl) {
+    const existingRemote = await findRemoteForUrlSsh(provider, repoPath, target.remoteUrl)
+    if (existingRemote) {
+      remoteName = existingRemote
+    } else {
+      remoteName = await ensureUniqueRemoteNameSsh(provider, repoPath, target.remoteName)
+      await provider.exec(['remote', 'add', remoteName, target.remoteUrl], repoPath)
+    }
+  }
+  await provider.exec(
+    [
+      'fetch',
+      remoteName,
+      `+refs/heads/${target.branchName}:refs/remotes/${remoteName}/${target.branchName}`
+    ],
+    repoPath
+  )
+  return { ...target, remoteName }
+}
+
+async function configureCreatedWorktreePushTargetSsh(
+  provider: SshGitProvider,
+  worktreePath: string,
+  branchName: string,
+  target: GitPushTarget
+): Promise<GitPushTarget> {
+  await provider.exec(
+    ['branch', '--set-upstream-to', `${target.remoteName}/${target.branchName}`, branchName],
+    worktreePath
+  )
+  return target
+}
+
 export function notifyWorktreesChanged(mainWindow: BrowserWindow, repoId: string): void {
   if (!mainWindow.isDestroyed()) {
     mainWindow.webContents.send('worktrees:changed', { repoId })
@@ -250,6 +353,13 @@ export async function createRemoteWorktree(
     /* best-effort */
   }
 
+  let preparedPushTarget: GitPushTarget | undefined
+  if (args.pushTarget) {
+    // Why: fork-PR SSH worktrees need the same contributor-remote setup as
+    // local worktrees before creation, otherwise Push/Sync can target origin.
+    preparedPushTarget = await prepareWorktreePushTargetSsh(provider, repo.path, args.pushTarget)
+  }
+
   const mux = getActiveMultiplexer(repo.connectionId!)
   if (!mux) {
     throw new Error('SSH connection is not available. Please reconnect and try again.')
@@ -310,6 +420,15 @@ export async function createRemoteWorktree(
 
   const worktreeId = `${repo.id}::${created.path}`
   const now = Date.now()
+  let configuredPushTarget: GitPushTarget | undefined
+  if (preparedPushTarget) {
+    configuredPushTarget = await configureCreatedWorktreePushTargetSsh(
+      provider,
+      created.path,
+      branchName,
+      preparedPushTarget
+    )
+  }
   const metaUpdates: Partial<WorktreeMeta> = {
     lastActivityAt: now,
     // Why: grants the new worktree a short grace window at the top of the
@@ -319,6 +438,8 @@ export async function createRemoteWorktree(
     // max(lastActivityAt, createdAt + GRACE_MS) to keep it on top until the
     // window elapses. See smart-sort.ts `CREATE_GRACE_MS`.
     createdAt: now,
+    baseRef: baseBranch,
+    ...(configuredPushTarget ? { pushTarget: configuredPushTarget } : {}),
     ...(requestedDisplayName
       ? { displayName: requestedDisplayName }
       : shouldSetDisplayName(requestedName, branchName, sanitizedName)
@@ -326,7 +447,8 @@ export async function createRemoteWorktree(
         : {}),
     ...(isTuiAgent(args.createdWithAgent) ? { createdWithAgent: args.createdWithAgent } : {}),
     ...(args.linkedIssue !== undefined ? { linkedIssue: args.linkedIssue } : {}),
-    ...(args.linkedPR !== undefined ? { linkedPR: args.linkedPR } : {})
+    ...(args.linkedPR !== undefined ? { linkedPR: args.linkedPR } : {}),
+    ...(args.linkedLinearIssue !== undefined ? { linkedLinearIssue: args.linkedLinearIssue } : {})
   }
   const meta = store.setWorktreeMeta(worktreeId, metaUpdates)
   const worktree = mergeWorktree(repo.id, created, meta)
@@ -617,7 +739,8 @@ export async function createLocalWorktree(
       : {}),
     ...(isTuiAgent(args.createdWithAgent) ? { createdWithAgent: args.createdWithAgent } : {}),
     ...(args.linkedIssue !== undefined ? { linkedIssue: args.linkedIssue } : {}),
-    ...(args.linkedPR !== undefined ? { linkedPR: args.linkedPR } : {})
+    ...(args.linkedPR !== undefined ? { linkedPR: args.linkedPR } : {}),
+    ...(args.linkedLinearIssue !== undefined ? { linkedLinearIssue: args.linkedLinearIssue } : {})
   }
   const meta = store.setWorktreeMeta(worktreeId, metaUpdates)
   const worktree = mergeWorktree(repo.id, created, meta)

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -427,20 +427,23 @@ describe('registerWorktreeHandlers', () => {
       repoId: 'repo-1',
       name: 'improve-dashboard',
       linkedIssue: 123,
-      linkedPR: 456
+      linkedPR: 456,
+      linkedLinearIssue: 'ENG-123'
     })
 
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
       'repo-1::/workspace/improve-dashboard',
       expect.objectContaining({
         linkedIssue: 123,
-        linkedPR: 456
+        linkedPR: 456,
+        linkedLinearIssue: 'ENG-123'
       })
     )
     expect(result).toEqual({
       worktree: expect.objectContaining({
         linkedIssue: 123,
-        linkedPR: 456
+        linkedPR: 456,
+        linkedLinearIssue: 'ENG-123'
       })
     })
   })
@@ -602,7 +605,8 @@ describe('registerWorktreeHandlers', () => {
       name: 'improve-dashboard',
       linkedIssue: 123,
       linkedPR: 456,
-      createdWithAgent: 'codex'
+      createdWithAgent: 'codex',
+      linkedLinearIssue: 'ENG-123'
     })
 
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
@@ -610,14 +614,16 @@ describe('registerWorktreeHandlers', () => {
       expect.objectContaining({
         linkedIssue: 123,
         linkedPR: 456,
-        createdWithAgent: 'codex'
+        createdWithAgent: 'codex',
+        linkedLinearIssue: 'ENG-123'
       })
     )
     expect(result).toEqual({
       worktree: expect.objectContaining({
         linkedIssue: 123,
         linkedPR: 456,
-        createdWithAgent: 'codex'
+        createdWithAgent: 'codex',
+        linkedLinearIssue: 'ENG-123'
       })
     })
   })

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -377,13 +377,20 @@ export function registerWorktreeHandlers(
       if (!repo) {
         return { error: 'Repo not found' }
       }
-      // Why: remote SSH repos are out of scope in v1. The picker already
-      // disables its PR tab for them — this guard belt-and-suspenders it.
-      if (repo.connectionId) {
-        return { error: 'PR start points are not supported for remote repos yet.' }
-      }
       if (isFolderRepo(repo)) {
         return { error: 'Folder mode does not support creating worktrees.' }
+      }
+      const gitExec = async (args: string[]): Promise<{ stdout: string; stderr: string }> => {
+        if (!repo.connectionId) {
+          return gitExecFileAsync(args, { cwd: repo.path })
+        }
+        const provider = getSshGitProvider(repo.connectionId)
+        if (!provider) {
+          throw new Error(
+            'SSH Git provider is not available. Reconnect to this target and try again.'
+          )
+        }
+        return provider.exec(args, repo.path)
       }
 
       let headRefName = args.headRefName?.trim() ?? ''
@@ -395,7 +402,7 @@ export function registerWorktreeHandlers(
         // Why: the caller already knows this is a PR number, so scope the
         // lookup to `type: 'pr'` and skip the speculative issue-first probe
         // that would hit the upstream issue tracker for fork checkouts.
-        const item = await getWorkItem(repo.path, args.prNumber, 'pr')
+        const item = await getWorkItem(repo.path, args.prNumber, 'pr', repo.connectionId ?? null)
         if (!item || item.type !== 'pr') {
           return { error: `PR #${args.prNumber} not found.` }
         }
@@ -409,7 +416,9 @@ export function registerWorktreeHandlers(
       }
       if (isCrossRepository) {
         try {
-          pushTarget = (await getPullRequestPushTarget(repo.path, args.prNumber)) ?? undefined
+          pushTarget =
+            (await getPullRequestPushTarget(repo.path, args.prNumber, repo.connectionId ?? null)) ??
+            undefined
         } catch (error) {
           return {
             error:
@@ -425,7 +434,16 @@ export function registerWorktreeHandlers(
 
       let remote: string
       try {
-        remote = await getDefaultRemote(repo.path)
+        if (repo.connectionId) {
+          const { stdout } = await gitExec(['remote'])
+          remote =
+            stdout
+              .split('\n')
+              .map((line) => line.trim())
+              .find(Boolean) ?? 'origin'
+        } else {
+          remote = await getDefaultRemote(repo.path)
+        }
       } catch (error) {
         return { error: error instanceof Error ? error.message : 'Could not resolve git remote.' }
       }
@@ -440,7 +458,7 @@ export function registerWorktreeHandlers(
       if (isCrossRepository) {
         const pullRef = `refs/pull/${args.prNumber}/head`
         try {
-          await gitExecFileAsync(['fetch', remote, pullRef], { cwd: repo.path })
+          await gitExec(['fetch', remote, pullRef])
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error)
           return {
@@ -449,9 +467,7 @@ export function registerWorktreeHandlers(
         }
         let sha: string
         try {
-          const { stdout } = await gitExecFileAsync(['rev-parse', '--verify', 'FETCH_HEAD'], {
-            cwd: repo.path
-          })
+          const { stdout } = await gitExec(['rev-parse', '--verify', 'FETCH_HEAD'])
           sha = stdout.trim()
         } catch {
           return { error: `Could not resolve fork PR #${args.prNumber} head after fetch.` }
@@ -463,10 +479,11 @@ export function registerWorktreeHandlers(
       }
 
       try {
-        await gitExecFileAsync(
-          ['fetch', remote, `+refs/heads/${headRefName}:refs/remotes/${remote}/${headRefName}`],
-          { cwd: repo.path }
-        )
+        await gitExec([
+          'fetch',
+          remote,
+          `+refs/heads/${headRefName}:refs/remotes/${remote}/${headRefName}`
+        ])
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error)
         return {
@@ -476,7 +493,7 @@ export function registerWorktreeHandlers(
 
       const remoteRef = `${remote}/${headRefName}`
       try {
-        await gitExecFileAsync(['rev-parse', '--verify', remoteRef], { cwd: repo.path })
+        await gitExec(['rev-parse', '--verify', remoteRef])
       } catch {
         return { error: `Remote ref ${remoteRef} does not exist after fetch.` }
       }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -4943,6 +4943,7 @@ export class OrcaRuntimeService {
     baseBranch?: string
     linkedIssue?: number | null
     linkedPR?: number | null
+    linkedLinearIssue?: string
     comment?: string
     displayName?: string
     sparseCheckout?: { directories: string[]; presetId?: string }
@@ -5100,6 +5101,9 @@ export class OrcaRuntimeService {
         : {}),
       ...(args.linkedIssue !== undefined ? { linkedIssue: args.linkedIssue } : {}),
       ...(args.linkedPR !== undefined ? { linkedPR: args.linkedPR } : {}),
+      ...(args.linkedLinearIssue !== undefined
+        ? { linkedLinearIssue: args.linkedLinearIssue }
+        : {}),
       ...(args.createdWithAgent ? { createdWithAgent: args.createdWithAgent } : {}),
       ...(args.comment !== undefined ? { comment: args.comment } : {})
     })

--- a/src/main/runtime/rpc/methods/worktree.ts
+++ b/src/main/runtime/rpc/methods/worktree.ts
@@ -38,6 +38,7 @@ const WorktreeCreate = z.object({
   baseBranch: OptionalString,
   linkedIssue: TriStateLinkedIssue,
   linkedPR: TriStateLinkedIssue,
+  linkedLinearIssue: z.string().optional(),
   comment: OptionalString,
   displayName: OptionalString,
   sparseCheckout: z
@@ -155,6 +156,7 @@ export const WORKTREE_METHODS: RpcMethod[] = [
         baseBranch: params.baseBranch,
         linkedIssue: params.linkedIssue,
         linkedPR: params.linkedPR,
+        linkedLinearIssue: params.linkedLinearIssue,
         comment: params.comment,
         displayName: params.displayName,
         sparseCheckout: params.sparseCheckout,

--- a/src/main/source-control/hosted-review.test.ts
+++ b/src/main/source-control/hosted-review.test.ts
@@ -108,7 +108,7 @@ describe('getHostedReviewForBranch', () => {
       number: 3,
       status: 'pending'
     })
-    expect(getPRForBranchMock).toHaveBeenCalledWith('/repo', 'feature', 3)
+    expect(getPRForBranchMock).toHaveBeenCalledWith('/repo', 'feature', 3, undefined)
   })
 
   it('falls through to Bitbucket when origin is not GitLab or GitHub', async () => {

--- a/src/main/source-control/hosted-review.ts
+++ b/src/main/source-control/hosted-review.ts
@@ -82,6 +82,7 @@ function mapGiteaReview(pr: GiteaPullRequestInfo): HostedReviewInfo {
 
 export async function getHostedReviewForBranch(input: {
   repoPath: string
+  connectionId?: string | null
   branch: string
   linkedGitHubPR?: number | null
   linkedGitLabMR?: number | null
@@ -110,9 +111,14 @@ export async function getHostedReviewForBranch(input: {
     return mr ? mapGitLabReview(mr) : null
   }
 
-  const githubRepo = await getRepoSlug(input.repoPath)
+  const githubRepo = await getRepoSlug(input.repoPath, input.connectionId)
   if (githubRepo) {
-    const pr = await getPRForBranch(input.repoPath, branchName, input.linkedGitHubPR ?? null)
+    const pr = await getPRForBranch(
+      input.repoPath,
+      branchName,
+      input.linkedGitHubPR ?? null,
+      input.connectionId
+    )
     return pr ? mapGitHubReview(pr) : null
   }
 

--- a/src/main/ssh/ssh-channel-multiplexer.ts
+++ b/src/main/ssh/ssh-channel-multiplexer.ts
@@ -216,10 +216,12 @@ export class SshChannelMultiplexer {
     if (this.disposed) {
       return
     }
-    console.warn(
-      `[ssh-mux] Disposing multiplexer (reason: ${reason})`,
-      new Error('dispose trace').stack
-    )
+    if (process.env.ORCA_SSH_MUX_DEBUG === '1') {
+      console.warn(
+        `[ssh-mux] Disposing multiplexer (reason: ${reason})`,
+        new Error('dispose trace').stack
+      )
+    }
     this.disposed = true
 
     if (this.keepaliveTimer) {

--- a/src/main/ssh/ssh-relay-deploy.ts
+++ b/src/main/ssh/ssh-relay-deploy.ts
@@ -185,7 +185,7 @@ async function uploadRelay(
   const localRelayDir = getLocalRelayPath(platform)
   if (!localRelayDir || !existsSync(localRelayDir)) {
     throw new Error(
-      `Relay package for ${platform} not found at ${localRelayDir}. ` +
+      `Relay package for ${platform} not found. Searched: ${getLocalRelayCandidates(platform).join(', ')}. ` +
         `This may be a packaging issue — try reinstalling Orca.`
     )
   }
@@ -221,7 +221,10 @@ async function uploadRelay(
   }
 }
 
-const RELAY_NATIVE_DEPS = ['node-pty', '@parcel/watcher'] as const
+const RELAY_NATIVE_DEPS = {
+  'node-pty': '1.1.0',
+  '@parcel/watcher': '2.5.6'
+} as const
 
 async function hasRequiredNativeDeps(conn: SshConnection, remoteDir: string): Promise<boolean> {
   const nodePath = await resolveRemoteNodePath(conn)
@@ -298,7 +301,7 @@ async function installNativeDeps(
     version: '1.0.0',
     private: true,
     type: 'commonjs',
-    dependencies: Object.fromEntries(RELAY_NATIVE_DEPS.map((name) => [name, '*']))
+    dependencies: RELAY_NATIVE_DEPS
   })}\n`
   const sftpPkg = await conn.sftp()
   try {
@@ -316,10 +319,12 @@ async function installNativeDeps(
   }
 
   try {
-    const installArgs = RELAY_NATIVE_DEPS.map((dep) => shellEscape(dep)).join(' ')
+    const installArgs = Object.entries(RELAY_NATIVE_DEPS)
+      .map(([dep, version]) => shellEscape(`${dep}@${version}`))
+      .join(' ')
     await execCommand(
       conn,
-      `export PATH=${escapedBinDir}:$PATH && cd ${escapedDir} && npm install ${installArgs} 2>&1`
+      `export PATH=${escapedBinDir}:$PATH && cd ${escapedDir} && npm install --omit=dev --no-audit --no-fund ${installArgs} 2>&1`
     )
   } catch (err) {
     // Don't write .install-complete on hard fail; reconnect retries on a
@@ -364,26 +369,34 @@ async function installNativeDeps(
 }
 
 function getLocalRelayPath(platform: RelayPlatform): string | null {
-  if (process.env.ORCA_RELAY_PATH) {
-    const override = join(process.env.ORCA_RELAY_PATH, platform)
-    if (existsSync(override)) {
-      return override
+  for (const candidate of getLocalRelayCandidates(platform)) {
+    if (existsSync(candidate)) {
+      return candidate
     }
   }
-
-  // Production: bundled alongside the app
-  const prodPath = join(app.getAppPath(), 'resources', 'relay', platform)
-  if (existsSync(prodPath)) {
-    return prodPath
-  }
-
-  // Development: built by `pnpm build:relay` into out/relay/{platform}/
-  const devPath = join(app.getAppPath(), 'out', 'relay', platform)
-  if (existsSync(devPath)) {
-    return devPath
-  }
-
   return null
+}
+
+export function getLocalRelayCandidates(platform: RelayPlatform): string[] {
+  const candidates: string[] = []
+  if (process.env.ORCA_RELAY_PATH) {
+    candidates.push(join(process.env.ORCA_RELAY_PATH, platform))
+  }
+
+  // Why: electron-builder copies extraResources next to the app bundle, while
+  // app.getAppPath() points at app.asar in packaged builds.
+  if (process.resourcesPath) {
+    candidates.push(join(process.resourcesPath, 'relay', platform))
+    candidates.push(join(process.resourcesPath, 'app.asar.unpacked', 'out', 'relay', platform))
+  }
+
+  const appPath = app.getAppPath()
+  candidates.push(
+    join(appPath, 'resources', 'relay', platform),
+    join(appPath, 'out', 'relay', platform)
+  )
+
+  return [...new Set(candidates)]
 }
 
 async function launchRelay(
@@ -400,7 +413,8 @@ async function launchRelay(
   const nodePath = await resolveRemoteNodePath(conn)
   // Why: graceTimeSeconds originates from user-editable SshTarget config.
   // Clamping to integer prevents shell injection if the type ever loosened.
-  const graceTime = Math.max(60, Math.min(3600, Math.floor(graceTimeSeconds ?? 300)))
+  const requestedGraceTime = Math.floor(graceTimeSeconds ?? 300)
+  const graceTime = requestedGraceTime === 0 ? 0 : Math.max(60, Math.min(3600, requestedGraceTime))
   const escapedDir = shellEscape(remoteDir)
   const escapedNode = shellEscape(nodePath)
   // Why: remoteRelayDir is shared by every Orca target for the same remote

--- a/src/main/ssh/ssh-relay-native-deps-install.test.ts
+++ b/src/main/ssh/ssh-relay-native-deps-install.test.ts
@@ -234,7 +234,7 @@ describe('installNativeDeps (via deployAndLaunchRelay)', () => {
     // Why: pin commonjs so a future Node default flip doesn't silently
     // break `require('node-pty')`.
     expect(parsed.type).toBe('commonjs')
-    expect(parsed.dependencies).toEqual({ '@parcel/watcher': '*', 'node-pty': '*' })
+    expect(parsed.dependencies).toEqual({ '@parcel/watcher': '2.5.6', 'node-pty': '1.1.0' })
 
     const execCalls = vi.mocked(execCommand).mock.calls.map(([, c]) => c)
     const npmInstallIdx = execCalls.findIndex(

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -41,6 +41,7 @@ import {
   getSshFilesystemProvider
 } from '../providers/ssh-filesystem-dispatch'
 import { registerSshGitProvider, unregisterSshGitProvider } from '../providers/ssh-git-dispatch'
+import { notifyRemoteWorkspaceHandlers } from '../ipc/remote-workspace-events'
 import { PortScanner } from './ssh-port-scanner'
 import type { SshPortForwardManager } from './ssh-port-forward'
 import type { SshConnection } from './ssh-connection'
@@ -449,6 +450,7 @@ export class SshRelaySession {
 
     this.wireUpPtyEvents(ptyProvider)
     this.wireUpAgentHookEvents(mux)
+    this.wireUpRemoteWorkspaceEvents(mux)
     return true
   }
 
@@ -491,6 +493,12 @@ export class SshRelaySession {
         }`
       )
     }
+  }
+
+  private wireUpRemoteWorkspaceEvents(mux: SshChannelMultiplexer): void {
+    mux.onNotification((method, params) => {
+      notifyRemoteWorkspaceHandlers(this.targetId, method, params)
+    })
   }
 
   // Why: route the relay's `agent.hook` JSON-RPC notification into Orca's

--- a/src/main/window/attach-main-window-services.ts
+++ b/src/main/window/attach-main-window-services.ts
@@ -13,6 +13,7 @@ import { registerWorktreeHandlers } from '../ipc/worktrees'
 import { registerPtyHandlers } from '../ipc/pty'
 import { registerDaemonManagementHandlers } from '../ipc/pty-management'
 import { registerSshHandlers } from '../ipc/ssh'
+import { registerRemoteWorkspaceHandlers } from '../ipc/remote-workspace'
 import { browserManager } from '../browser/browser-manager'
 import { hasSystemMediaAccess, requestSystemMediaAccess } from '../browser/browser-media-access'
 import type { OrcaRuntimeService } from '../runtime/orca-runtime'
@@ -75,6 +76,7 @@ export function attachMainWindowServices(
   // git I/O or daemon RPC.
   void hydrateLocalPtyRegistryAtBoot(store)
   registerSshHandlers(store, () => mainWindow, runtime)
+  registerRemoteWorkspaceHandlers(store, () => mainWindow)
   registerFileDropRelay(mainWindow)
   setupAutoUpdater(mainWindow, {
     getLastUpdateCheckAt: () => store.getUI().lastUpdateCheckAt,

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -207,6 +207,12 @@ import type {
 import type { TelemetryConsentState } from '../shared/telemetry-consent-types'
 import type { AgentKind, LaunchSource, RequestKind } from '../shared/telemetry-events'
 import type {
+  RemoteWorkspaceChangedEvent,
+  RemoteWorkspaceConnectedClient,
+  RemoteWorkspacePatchResult,
+  RemoteWorkspaceSnapshot
+} from '../shared/remote-workspace-types'
+import type {
   Automation,
   AutomationCreateInput,
   AutomationDispatchRequest,
@@ -618,20 +624,30 @@ export type PreloadApi = {
   export: ExportApi
   gh: {
     viewer: () => Promise<GitHubViewer | null>
-    repoSlug: (args: { repoPath: string }) => Promise<{ owner: string; repo: string } | null>
+    repoSlug: (args: {
+      repoPath: string
+      repoId?: string
+    }) => Promise<{ owner: string; repo: string } | null>
     prForBranch: (args: {
       repoPath: string
+      repoId?: string
       branch: string
       linkedPRNumber?: number | null
     }) => Promise<PRInfo | null>
-    issue: (args: { repoPath: string; number: number }) => Promise<IssueInfo | null>
+    issue: (args: {
+      repoPath: string
+      repoId?: string
+      number: number
+    }) => Promise<IssueInfo | null>
     workItem: (args: {
       repoPath: string
+      repoId?: string
       number: number
       type?: 'issue' | 'pr'
     }) => Promise<Omit<GitHubWorkItem, 'repoId'> | null>
     workItemByOwnerRepo: (args: {
       repoPath: string
+      repoId?: string
       owner: string
       repo: string
       number: number
@@ -639,11 +655,13 @@ export type PreloadApi = {
     }) => Promise<Omit<GitHubWorkItem, 'repoId'> | null>
     workItemDetails: (args: {
       repoPath: string
+      repoId?: string
       number: number
       type?: 'issue' | 'pr'
     }) => Promise<GitHubWorkItemDetails | null>
     prFileContents: (args: {
       repoPath: string
+      repoId?: string
       prNumber: number
       path: string
       oldPath?: string
@@ -651,48 +669,65 @@ export type PreloadApi = {
       headSha: string
       baseSha: string
     }) => Promise<GitHubPRFileContents>
-    listIssues: (args: { repoPath: string; limit?: number }) => Promise<IssueInfo[]>
+    listIssues: (args: {
+      repoPath: string
+      repoId?: string
+      limit?: number
+    }) => Promise<IssueInfo[]>
     createIssue: (args: {
       repoPath: string
+      repoId?: string
       title: string
       body: string
     }) => Promise<{ ok: true; number: number; url: string } | { ok: false; error: string }>
-    countWorkItems: (args: { repoPath: string; query?: string }) => Promise<number>
+    countWorkItems: (args: { repoPath: string; repoId?: string; query?: string }) => Promise<number>
     listWorkItems: (args: {
       repoPath: string
+      repoId?: string
       limit?: number
       query?: string
       before?: string
     }) => Promise<ListWorkItemsResult<Omit<GitHubWorkItem, 'repoId'>>>
     prChecks: (args: {
       repoPath: string
+      repoId?: string
       prNumber: number
       headSha?: string
       noCache?: boolean
     }) => Promise<PRCheckDetail[]>
     prComments: (args: {
       repoPath: string
+      repoId?: string
       prNumber: number
       noCache?: boolean
     }) => Promise<PRComment[]>
     resolveReviewThread: (args: {
       repoPath: string
+      repoId?: string
       threadId: string
       resolve: boolean
     }) => Promise<boolean>
-    updatePRTitle: (args: { repoPath: string; prNumber: number; title: string }) => Promise<boolean>
+    updatePRTitle: (args: {
+      repoPath: string
+      repoId?: string
+      prNumber: number
+      title: string
+    }) => Promise<boolean>
     mergePR: (args: {
       repoPath: string
+      repoId?: string
       prNumber: number
       method?: 'merge' | 'squash' | 'rebase'
     }) => Promise<{ ok: true } | { ok: false; error: string }>
     updateIssue: (args: {
       repoPath: string
+      repoId?: string
       number: number
       updates: GitHubIssueUpdate
     }) => Promise<{ ok: true } | { ok: false; error: string }>
     addIssueComment: (args: {
       repoPath: string
+      repoId?: string
       number: number
       body: string
       /** Why: GitHub stores PR conversation comments under `/issues/N/comments`
@@ -704,6 +739,7 @@ export type PreloadApi = {
     }) => Promise<GitHubCommentResult>
     addPRReviewCommentReply: (args: {
       repoPath: string
+      repoId?: string
       prNumber: number
       commentId: number
       body: string
@@ -711,16 +747,26 @@ export type PreloadApi = {
       path?: string
       line?: number
     }) => Promise<GitHubCommentResult>
-    addPRReviewComment: (args: GitHubPRReviewCommentInput) => Promise<GitHubCommentResult>
-    listLabels: (args: { repoPath: string }) => Promise<string[]>
-    listAssignableUsers: (args: { repoPath: string }) => Promise<GitHubAssignableUser[]>
+    addPRReviewComment: (
+      args: GitHubPRReviewCommentInput & { repoId?: string }
+    ) => Promise<GitHubCommentResult>
+    listLabels: (args: { repoPath: string; repoId?: string }) => Promise<string[]>
+    listAssignableUsers: (args: {
+      repoPath: string
+      repoId?: string
+    }) => Promise<GitHubAssignableUser[]>
     /**
      * Subscribe to local-mutation broadcasts. Used by the work-item-drawer
      * cache to invalidate entries across windows after a successful mutation.
      * Returns an unsubscribe function.
      */
     onWorkItemMutated: (
-      callback: (payload: { repoPath: string; type: 'issue' | 'pr'; number: number }) => void
+      callback: (payload: {
+        repoPath: string
+        repoId?: string
+        type: 'issue' | 'pr'
+        number: number
+      }) => void
     ) => () => void
     checkOrcaStarred: () => Promise<boolean | null>
     starOrca: () => Promise<boolean>
@@ -1051,6 +1097,19 @@ export type PreloadApi = {
     get: () => Promise<WorkspaceSessionState>
     set: (args: WorkspaceSessionState) => Promise<void>
     setSync: (args: WorkspaceSessionState) => void
+  }
+  remoteWorkspace: {
+    get: (args: { targetId: string }) => Promise<RemoteWorkspaceSnapshot | null>
+    setForConnectedTargets: (args: {
+      session: WorkspaceSessionState
+      hydratedTargetIds?: string[]
+    }) => Promise<{ targetId: string; result: RemoteWorkspacePatchResult }[]>
+    listEnabledConnectedTargets: () => Promise<string[]>
+    listConnectedClients: (args?: {
+      targetIds?: string[]
+    }) => Promise<{ targetId: string; clients: RemoteWorkspaceConnectedClient[] }[]>
+    clientId: () => Promise<string>
+    onChanged: (callback: (event: RemoteWorkspaceChangedEvent) => void) => () => void
   }
   updater: {
     getVersion: () => Promise<string>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -683,26 +683,29 @@ const api = {
   gh: {
     viewer: (): Promise<unknown> => ipcRenderer.invoke('gh:viewer'),
 
-    repoSlug: (args: { repoPath: string }): Promise<unknown> =>
+    repoSlug: (args: { repoPath: string; repoId?: string }): Promise<unknown> =>
       ipcRenderer.invoke('gh:repoSlug', args),
 
     prForBranch: (args: {
       repoPath: string
+      repoId?: string
       branch: string
       linkedPRNumber?: number | null
     }): Promise<unknown> => ipcRenderer.invoke('gh:prForBranch', args),
 
-    issue: (args: { repoPath: string; number: number }): Promise<unknown> =>
+    issue: (args: { repoPath: string; repoId?: string; number: number }): Promise<unknown> =>
       ipcRenderer.invoke('gh:issue', args),
 
     workItem: (args: {
       repoPath: string
+      repoId?: string
       number: number
       type?: 'issue' | 'pr'
     }): Promise<unknown> => ipcRenderer.invoke('gh:workItem', args),
 
     workItemByOwnerRepo: (args: {
       repoPath: string
+      repoId?: string
       owner: string
       repo: string
       number: number
@@ -711,12 +714,14 @@ const api = {
 
     workItemDetails: (args: {
       repoPath: string
+      repoId?: string
       number: number
       type?: 'issue' | 'pr'
     }): Promise<unknown> => ipcRenderer.invoke('gh:workItemDetails', args),
 
     prFileContents: (args: {
       repoPath: string
+      repoId?: string
       prNumber: number
       path: string
       oldPath?: string
@@ -725,21 +730,26 @@ const api = {
       baseSha: string
     }): Promise<unknown> => ipcRenderer.invoke('gh:prFileContents', args),
 
-    listIssues: (args: { repoPath: string; limit?: number }): Promise<unknown[]> =>
+    listIssues: (args: { repoPath: string; repoId?: string; limit?: number }): Promise<unknown[]> =>
       ipcRenderer.invoke('gh:listIssues', args),
 
     createIssue: (args: {
       repoPath: string
+      repoId?: string
       title: string
       body: string
     }): Promise<{ ok: true; number: number; url: string } | { ok: false; error: string }> =>
       ipcRenderer.invoke('gh:createIssue', args),
 
-    countWorkItems: (args: { repoPath: string; query?: string }): Promise<number> =>
-      ipcRenderer.invoke('gh:countWorkItems', args),
+    countWorkItems: (args: {
+      repoPath: string
+      repoId?: string
+      query?: string
+    }): Promise<number> => ipcRenderer.invoke('gh:countWorkItems', args),
 
     listWorkItems: (args: {
       repoPath: string
+      repoId?: string
       limit?: number
       query?: string
       before?: string
@@ -748,6 +758,7 @@ const api = {
 
     prChecks: (args: {
       repoPath: string
+      repoId?: string
       prNumber: number
       headSha?: string
       noCache?: boolean
@@ -755,24 +766,28 @@ const api = {
 
     prComments: (args: {
       repoPath: string
+      repoId?: string
       prNumber: number
       noCache?: boolean
     }): Promise<unknown[]> => ipcRenderer.invoke('gh:prComments', args),
 
     resolveReviewThread: (args: {
       repoPath: string
+      repoId?: string
       threadId: string
       resolve: boolean
     }): Promise<boolean> => ipcRenderer.invoke('gh:resolveReviewThread', args),
 
     updatePRTitle: (args: {
       repoPath: string
+      repoId?: string
       prNumber: number
       title: string
     }): Promise<boolean> => ipcRenderer.invoke('gh:updatePRTitle', args),
 
     mergePR: (args: {
       repoPath: string
+      repoId?: string
       prNumber: number
       method?: 'merge' | 'squash' | 'rebase'
     }): Promise<{ ok: true } | { ok: false; error: string }> =>
@@ -780,6 +795,7 @@ const api = {
 
     updateIssue: (args: {
       repoPath: string
+      repoId?: string
       number: number
       updates: unknown
     }): Promise<{ ok: true } | { ok: false; error: string }> =>
@@ -787,6 +803,7 @@ const api = {
 
     addIssueComment: (args: {
       repoPath: string
+      repoId?: string
       number: number
       body: string
       type?: 'issue' | 'pr'
@@ -794,6 +811,7 @@ const api = {
 
     addPRReviewCommentReply: (args: {
       repoPath: string
+      repoId?: string
       prNumber: number
       commentId: number
       body: string
@@ -804,6 +822,7 @@ const api = {
 
     addPRReviewComment: (args: {
       repoPath: string
+      repoId?: string
       prNumber: number
       commitId: string
       path: string
@@ -812,22 +831,29 @@ const api = {
       body: string
     }): Promise<GitHubCommentResult> => ipcRenderer.invoke('gh:addPRReviewComment', args),
 
-    listLabels: (args: { repoPath: string }): Promise<string[]> =>
+    listLabels: (args: { repoPath: string; repoId?: string }): Promise<string[]> =>
       ipcRenderer.invoke('gh:listLabels', args),
 
-    listAssignableUsers: (args: { repoPath: string }): Promise<GitHubAssignableUser[]> =>
-      ipcRenderer.invoke('gh:listAssignableUsers', args),
+    listAssignableUsers: (args: {
+      repoPath: string
+      repoId?: string
+    }): Promise<GitHubAssignableUser[]> => ipcRenderer.invoke('gh:listAssignableUsers', args),
 
     // Why: every renderer subscribes to local mutation broadcasts so each
     // window's work-item-details cache invalidates the affected entry. The
     // event fires after a successful mutation in any window — see
     // src/main/ipc/github.ts broadcastWorkItemMutated.
     onWorkItemMutated: (
-      callback: (payload: { repoPath: string; type: 'issue' | 'pr'; number: number }) => void
+      callback: (payload: {
+        repoPath: string
+        repoId?: string
+        type: 'issue' | 'pr'
+        number: number
+      }) => void
     ): (() => void) => {
       const listener = (
         _event: Electron.IpcRendererEvent,
-        payload: { repoPath: string; type: 'issue' | 'pr'; number: number }
+        payload: { repoPath: string; repoId?: string; type: 'issue' | 'pr'; number: number }
       ): void => callback(payload)
       ipcRenderer.on('gh:workItemMutated', listener)
       return () => ipcRenderer.removeListener('gh:workItemMutated', listener)
@@ -1556,6 +1582,25 @@ const api = {
     /** Synchronous session save for beforeunload — blocks until flushed to disk. */
     setSync: (args: unknown): void => {
       ipcRenderer.sendSync('session:set-sync', args)
+    }
+  },
+
+  remoteWorkspace: {
+    get: (args: { targetId: string }): Promise<unknown> =>
+      ipcRenderer.invoke('remoteWorkspace:get', args),
+    setForConnectedTargets: (args: {
+      session: unknown
+      hydratedTargetIds?: string[]
+    }): Promise<unknown> => ipcRenderer.invoke('remoteWorkspace:setForConnectedTargets', args),
+    listEnabledConnectedTargets: (): Promise<string[]> =>
+      ipcRenderer.invoke('remoteWorkspace:listEnabledConnectedTargets'),
+    listConnectedClients: (args?: { targetIds?: string[] }): Promise<unknown> =>
+      ipcRenderer.invoke('remoteWorkspace:listConnectedClients', args),
+    clientId: (): Promise<string> => ipcRenderer.invoke('remoteWorkspace:clientId'),
+    onChanged: (callback: (event: unknown) => void): (() => void) => {
+      const listener = (_event: Electron.IpcRendererEvent, data: unknown) => callback(data)
+      ipcRenderer.on('remoteWorkspace:changed', listener)
+      return () => ipcRenderer.removeListener('remoteWorkspace:changed', listener)
     }
   },
 

--- a/src/relay/agent-exec-handler.test.ts
+++ b/src/relay/agent-exec-handler.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'os'
 import { join } from 'path'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type * as ChildProcess from 'child_process'
-import type { MethodHandler } from './dispatcher'
+import type { MethodHandler, RequestContext } from './dispatcher'
 import { AgentExecHandler } from './agent-exec-handler'
 
 vi.mock('child_process', async (importOriginal) => {
@@ -58,6 +58,10 @@ function createHandlers(): Map<string, MethodHandler> {
   return handlers
 }
 
+function requestContext(clientId = 1): RequestContext {
+  return { clientId, isStale: () => false }
+}
+
 describe('AgentExecHandler', () => {
   beforeEach(() => {
     spawnMock.mockReset()
@@ -77,7 +81,7 @@ describe('AgentExecHandler', () => {
         stdin: 'PROMPT',
         timeoutMs: 5_000
       },
-      { isStale: () => false }
+      requestContext()
     )
 
     child.stdout.emit('data', Buffer.from('message'))
@@ -117,7 +121,7 @@ describe('AgentExecHandler', () => {
           PATH: '/managed/bin'
         }
       },
-      { isStale: () => false }
+      requestContext()
     )
 
     child.emit('close', 0)
@@ -159,7 +163,7 @@ describe('AgentExecHandler', () => {
             timeoutMs: 5_000,
             env: { PATH: tempDir }
           },
-          { isStale: () => false }
+          requestContext()
         )
 
         child.emit('close', 0)
@@ -201,7 +205,7 @@ describe('AgentExecHandler', () => {
           stdin: null,
           timeoutMs: 5_000
         },
-        { isStale: () => false }
+        requestContext()
       )
 
       expect(result).toEqual({
@@ -228,11 +232,11 @@ describe('AgentExecHandler', () => {
         stdin: null,
         timeoutMs: 5_000
       },
-      { isStale: () => false }
+      requestContext()
     )
 
     await expect(
-      handlers.get('agent.cancelExec')!({ cwd: '/repo' }, { isStale: () => false })
+      handlers.get('agent.cancelExec')!({ cwd: '/repo' }, requestContext())
     ).resolves.toEqual({ canceled: true })
 
     if (process.platform === 'win32') {
@@ -253,7 +257,7 @@ describe('AgentExecHandler', () => {
     const handlers = createHandlers()
 
     await expect(
-      handlers.get('agent.cancelExec')!({ cwd: '/repo' }, { isStale: () => false })
+      handlers.get('agent.cancelExec')!({ cwd: '/repo' }, requestContext())
     ).resolves.toEqual({ canceled: false })
   })
 })

--- a/src/relay/client-request-aborts.ts
+++ b/src/relay/client-request-aborts.ts
@@ -1,0 +1,33 @@
+export class ClientRequestAborts {
+  private readonly controllers = new Map<string, AbortController>()
+
+  create(clientId: number, requestId: number): { key: string; controller: AbortController } {
+    const key = this.key(clientId, requestId)
+    const controller = new AbortController()
+    this.controllers.set(key, controller)
+    return { key, controller }
+  }
+
+  get(clientId: number, requestId: number): AbortController | undefined {
+    return this.controllers.get(this.key(clientId, requestId))
+  }
+
+  delete(key: string): void {
+    this.controllers.delete(key)
+  }
+
+  abortClient(clientId: number): void {
+    const prefix = `${clientId}:`
+    for (const [key, controller] of this.controllers) {
+      if (!key.startsWith(prefix)) {
+        continue
+      }
+      controller.abort()
+      this.controllers.delete(key)
+    }
+  }
+
+  private key(clientId: number, requestId: number): string {
+    return `${clientId}:${requestId}`
+  }
+}

--- a/src/relay/dispatcher.test.ts
+++ b/src/relay/dispatcher.test.ts
@@ -153,7 +153,10 @@ describe('RelayDispatcher', () => {
     }
     dispatcher.feed(encodeJsonRpcFrame(notif, 1, 0))
 
-    expect(handler).toHaveBeenCalledWith({ x: 1 })
+    expect(handler).toHaveBeenCalledWith(
+      { x: 1 },
+      expect.objectContaining({ clientId: 1, isStale: expect.any(Function) })
+    )
   })
 
   it('sends notifications via notify()', () => {
@@ -176,6 +179,43 @@ describe('RelayDispatcher', () => {
     const msg = JSON.parse(decodeFirstFrame(notifs[0]).payload.toString('utf-8'))
     expect(msg.method).toBe('my.event')
     expect(msg.params).toEqual({ data: 'hello' })
+  })
+
+  it('broadcasts notifications to attached socket clients with independent frame state', () => {
+    const socketWritten: Buffer[] = []
+    const clientId = dispatcher.attachClient((data) => {
+      socketWritten.push(Buffer.from(data))
+    })
+
+    dispatcher.notify('workspace.changed', { revision: 1 })
+
+    expect(written).toHaveLength(1)
+    expect(socketWritten).toHaveLength(1)
+    expect(decodeFirstFrame(written[0]).id).toBe(1)
+    expect(decodeFirstFrame(socketWritten[0]).id).toBe(1)
+
+    dispatcher.detachClient(clientId)
+    dispatcher.notify('workspace.changed', { revision: 2 })
+
+    expect(written).toHaveLength(2)
+    expect(socketWritten).toHaveLength(1)
+  })
+
+  it('isolates failed socket-client writes from other clients', () => {
+    const goodSocketWritten: Buffer[] = []
+    const failingClientId = dispatcher.attachClient(() => {
+      throw new Error('socket closed')
+    })
+    dispatcher.attachClient((data) => {
+      goodSocketWritten.push(Buffer.from(data))
+    })
+
+    dispatcher.notify('workspace.changed', { revision: 1 })
+    dispatcher.notify('workspace.changed', { revision: 2 })
+
+    expect(written).toHaveLength(2)
+    expect(goodSocketWritten).toHaveLength(2)
+    dispatcher.detachClient(failingClientId)
   })
 
   it('tracks highest received seq in ack field', async () => {
@@ -268,5 +308,14 @@ describe('RelayDispatcher', () => {
     expect(observedSignal?.aborted).toBe(true)
     resolveHandler()
     await vi.advanceTimersByTimeAsync(0)
+  })
+
+  it('notifies listeners when the primary client is invalidated', () => {
+    const listener = vi.fn()
+    dispatcher.onClientDetached(listener)
+
+    dispatcher.invalidateClient()
+
+    expect(listener).toHaveBeenCalledWith(1)
   })
 })

--- a/src/relay/dispatcher.ts
+++ b/src/relay/dispatcher.ts
@@ -10,8 +10,10 @@ import {
   type JsonRpcNotification,
   type JsonRpcResponse
 } from './protocol'
+import { ClientRequestAborts } from './client-request-aborts'
 
 export type RequestContext = {
+  clientId: number
   isStale: () => boolean
   signal?: AbortSignal
 }
@@ -21,26 +23,32 @@ export type MethodHandler = (
   context: RequestContext
 ) => Promise<unknown>
 
-export type NotificationHandler = (params: Record<string, unknown>) => void
+export type NotificationHandler = (params: Record<string, unknown>, context: RequestContext) => void
+
+type RelayClient = {
+  id: number
+  decoder: FrameDecoder
+  write: (data: Buffer) => void
+  nextOutgoingSeq: number
+  highestReceivedSeq: number
+  generation: number
+  closed: boolean
+}
 
 export class RelayDispatcher {
-  private decoder: FrameDecoder
-  private write: (data: Buffer) => void
+  private readonly primaryClient: RelayClient
+  private readonly clients = new Map<number, RelayClient>()
   private requestHandlers = new Map<string, MethodHandler>()
   private notificationHandlers = new Map<string, NotificationHandler>()
-  private requestAbortControllers = new Map<number, AbortController>()
-  private nextOutgoingSeq = 1
-  private highestReceivedSeq = 0
+  private readonly requestAborts = new ClientRequestAborts()
+  private clientDetachListeners = new Set<(clientId: number) => void>()
   private keepaliveTimer: ReturnType<typeof setInterval> | null = null
   private disposed = false
-  // Why: incremented on every setWrite() call so async request handlers
-  // that started before a client swap can detect that their response
-  // would go to a different client and discard it instead of misrouting.
-  private generation = 0
+  private nextClientId = 1
 
   constructor(write: (data: Buffer) => void) {
-    this.write = write
-    this.decoder = new FrameDecoder((frame) => this.handleFrame(frame))
+    this.primaryClient = this.createClient(write)
+    this.clients.set(this.primaryClient.id, this.primaryClient)
     this.startKeepalive()
   }
 
@@ -53,23 +61,52 @@ export class RelayDispatcher {
   // client's SshChannelMultiplexer starts at seq=1. Without resetting, the
   // relay's highestReceivedSeq stays at the old client's last value, so it
   // never acks the new client's frames until the new client's seq catches
-  // up — causing the client's unacked-timeout checker to accumulate stale
+  // up - causing the client's unacked-timeout checker to accumulate stale
   // timestamps that could eventually fire a false connection-dead signal.
   setWrite(write: (data: Buffer) => void): void {
-    this.abortActiveRequests()
-    this.write = write
-    this.nextOutgoingSeq = 1
-    this.highestReceivedSeq = 0
-    this.decoder.reset()
-    this.generation++
+    this.requestAborts.abortClient(this.primaryClient.id)
+    this.primaryClient.write = write
+    this.primaryClient.closed = false
+    this.resetClient(this.primaryClient)
   }
 
   // Why: in-flight mutating requests must become stale when the active client
   // disconnects even if no replacement has connected yet. Otherwise a late
   // pty.spawn/fs.watch completion can create remote state nobody can own.
   invalidateClient(): void {
-    this.abortActiveRequests()
-    this.generation++
+    this.requestAborts.abortClient(this.primaryClient.id)
+    this.primaryClient.generation++
+    this.primaryClient.closed = true
+    this.notifyClientDetached(this.primaryClient.id)
+  }
+
+  // Why: synced remote workspaces can have more than one Orca client attached
+  // to the same relay. Frame sequence numbers and JSON-RPC request ids are per
+  // SSH channel, so each socket client needs independent protocol state.
+  attachClient(write: (data: Buffer) => void): number {
+    const client = this.createClient(write)
+    this.clients.set(client.id, client)
+    return client.id
+  }
+
+  detachClient(clientId: number): void {
+    const client = this.clients.get(clientId)
+    if (!client || client === this.primaryClient) {
+      return
+    }
+    this.requestAborts.abortClient(clientId)
+    client.generation++
+    client.closed = true
+    this.clients.delete(clientId)
+    this.notifyClientDetached(clientId)
+  }
+
+  feedClient(clientId: number, data: Buffer): void {
+    const client = this.clients.get(clientId)
+    if (!client) {
+      return
+    }
+    this.feedForClient(client, data)
   }
 
   onRequest(method: string, handler: MethodHandler): void {
@@ -80,19 +117,21 @@ export class RelayDispatcher {
     this.notificationHandlers.set(method, handler)
   }
 
-  private abortActiveRequests(): void {
-    for (const controller of this.requestAbortControllers.values()) {
-      controller.abort()
-    }
-    this.requestAbortControllers.clear()
+  onClientDetached(listener: (clientId: number) => void): () => void {
+    this.clientDetachListeners.add(listener)
+    return () => this.clientDetachListeners.delete(listener)
   }
 
   feed(data: Buffer): void {
+    this.feedForClient(this.primaryClient, data)
+  }
+
+  private feedForClient(client: RelayClient, data: Buffer): void {
     if (this.disposed) {
       return
     }
     try {
-      this.decoder.feed(data)
+      client.decoder.feed(data)
     } catch (err) {
       process.stderr.write(
         `[relay] Protocol error: ${err instanceof Error ? err.message : String(err)}\n`
@@ -109,7 +148,9 @@ export class RelayDispatcher {
       method,
       ...(params !== undefined ? { params } : {})
     }
-    this.sendFrame(msg)
+    for (const client of this.clients.values()) {
+      this.sendFrame(client, msg)
+    }
   }
 
   dispose(): void {
@@ -123,9 +164,31 @@ export class RelayDispatcher {
     }
   }
 
-  private handleFrame(frame: DecodedFrame): void {
-    if (frame.id > this.highestReceivedSeq) {
-      this.highestReceivedSeq = frame.id
+  private createClient(write: (data: Buffer) => void): RelayClient {
+    const id = this.nextClientId++
+    const client: RelayClient = {
+      id,
+      decoder: new FrameDecoder((frame) => this.handleFrame(client, frame)),
+      write,
+      nextOutgoingSeq: 1,
+      highestReceivedSeq: 0,
+      generation: 0,
+      closed: false
+    }
+    return client
+  }
+
+  private resetClient(client: RelayClient): void {
+    client.nextOutgoingSeq = 1
+    client.highestReceivedSeq = 0
+    client.decoder.reset()
+    client.generation++
+    client.closed = false
+  }
+
+  private handleFrame(client: RelayClient, frame: DecodedFrame): void {
+    if (frame.id > client.highestReceivedSeq) {
+      client.highestReceivedSeq = frame.id
     }
 
     if (frame.type === MessageType.KeepAlive) {
@@ -135,7 +198,7 @@ export class RelayDispatcher {
     if (frame.type === MessageType.Regular) {
       try {
         const msg = parseJsonRpcMessage(frame.payload)
-        this.handleMessage(msg)
+        this.handleMessage(client, msg)
       } catch (err) {
         process.stderr.write(
           `[relay] Parse error: ${err instanceof Error ? err.message : String(err)}\n`
@@ -144,68 +207,78 @@ export class RelayDispatcher {
     }
   }
 
-  private handleMessage(msg: JsonRpcRequest | JsonRpcNotification | JsonRpcResponse): void {
+  private handleMessage(
+    client: RelayClient,
+    msg: JsonRpcRequest | JsonRpcNotification | JsonRpcResponse
+  ): void {
     if ('id' in msg && 'method' in msg) {
-      void this.handleRequest(msg as JsonRpcRequest)
+      void this.handleRequest(client, msg as JsonRpcRequest)
     } else if ('method' in msg && !('id' in msg)) {
-      this.handleNotification(msg as JsonRpcNotification)
+      this.handleNotification(client, msg as JsonRpcNotification)
     }
   }
 
-  private async handleRequest(req: JsonRpcRequest): Promise<void> {
+  private async handleRequest(client: RelayClient, req: JsonRpcRequest): Promise<void> {
     const handler = this.requestHandlers.get(req.method)
     if (!handler) {
-      this.sendResponse(req.id, undefined, {
+      this.sendResponse(client, req.id, undefined, {
         code: -32601,
         message: `Method not found: ${req.method}`
       })
       return
     }
 
-    // Why: capture generation before the async handler runs. If a new
-    // client connects (setWrite increments generation) while this handler
-    // is in flight, the response belongs to the old client's request ID
-    // space. Sending it would misroute — the new client may have issued
-    // its own request with the same JSON-RPC id.
-    const gen = this.generation
-    const abortController = new AbortController()
-    this.requestAbortControllers.set(req.id, abortController)
+    // Why: capture this client's generation before the async handler runs.
+    // If that client disconnects while the handler is in flight, the response
+    // belongs to a dead request-id space and mutating work may need cleanup.
+    const gen = client.generation
+    const { key: abortKey, controller: abortController } = this.requestAborts.create(
+      client.id,
+      req.id
+    )
     const context: RequestContext = {
-      isStale: () => this.generation !== gen || abortController.signal.aborted,
+      clientId: client.id,
+      isStale: () =>
+        client.generation !== gen || !this.clients.has(client.id) || abortController.signal.aborted,
       signal: abortController.signal
     }
     try {
       const result = await handler(req.params ?? {}, context)
-      if (this.generation !== gen || abortController.signal.aborted) {
+      if (context.isStale()) {
         return
       }
-      this.sendResponse(req.id, result)
+      this.sendResponse(client, req.id, result)
     } catch (err) {
-      if (this.generation !== gen || abortController.signal.aborted) {
+      if (context.isStale()) {
         return
       }
       const message = err instanceof Error ? err.message : String(err)
       const code = (err as { code?: number }).code ?? -32000
-      this.sendResponse(req.id, undefined, { code, message })
+      this.sendResponse(client, req.id, undefined, { code, message })
     } finally {
-      this.requestAbortControllers.delete(req.id)
+      this.requestAborts.delete(abortKey)
     }
   }
 
-  private handleNotification(notif: JsonRpcNotification): void {
+  private handleNotification(client: RelayClient, notif: JsonRpcNotification): void {
     if (notif.method === 'rpc.cancel') {
       const id = Number((notif.params ?? {}).id)
-      const controller = this.requestAbortControllers.get(id)
+      const controller = this.requestAborts.get(client.id, id)
       controller?.abort()
       return
     }
     const handler = this.notificationHandlers.get(notif.method)
     if (handler) {
-      handler(notif.params ?? {})
+      const gen = client.generation
+      handler(notif.params ?? {}, {
+        clientId: client.id,
+        isStale: () => client.generation !== gen || !this.clients.has(client.id)
+      })
     }
   }
 
   private sendResponse(
+    client: RelayClient,
     id: number,
     result?: unknown,
     error?: { code: number; message: string; data?: unknown }
@@ -215,16 +288,19 @@ export class RelayDispatcher {
       id,
       ...(error ? { error } : { result: result ?? null })
     }
-    this.sendFrame(msg)
+    this.sendFrame(client, msg)
   }
 
-  private sendFrame(msg: JsonRpcRequest | JsonRpcResponse | JsonRpcNotification): void {
-    if (this.disposed) {
+  private sendFrame(
+    client: RelayClient,
+    msg: JsonRpcRequest | JsonRpcResponse | JsonRpcNotification
+  ): void {
+    if (this.disposed || client.closed) {
       return
     }
-    const seq = this.nextOutgoingSeq++
-    const frame = encodeJsonRpcFrame(msg, seq, this.highestReceivedSeq)
-    this.write(frame)
+    const seq = client.nextOutgoingSeq++
+    const frame = encodeJsonRpcFrame(msg, seq, client.highestReceivedSeq)
+    this.writeFrame(client, frame)
   }
 
   private startKeepalive(): void {
@@ -232,13 +308,46 @@ export class RelayDispatcher {
       if (this.disposed) {
         return
       }
-      const seq = this.nextOutgoingSeq++
-      const frame = encodeKeepAliveFrame(seq, this.highestReceivedSeq)
-      this.write(frame)
+      for (const client of this.clients.values()) {
+        if (client.closed) {
+          continue
+        }
+        const seq = client.nextOutgoingSeq++
+        const frame = encodeKeepAliveFrame(seq, client.highestReceivedSeq)
+        this.writeFrame(client, frame)
+      }
     }, KEEPALIVE_SEND_MS)
     // Why: without unref, the keepalive interval keeps the event loop alive
     // even when the relay should be winding down (e.g. after stdin ends and
     // all PTYs have exited). unref lets the process exit naturally.
     this.keepaliveTimer.unref()
+  }
+
+  private writeFrame(client: RelayClient, frame: Buffer): void {
+    try {
+      client.write(frame)
+    } catch (err) {
+      client.closed = true
+      client.generation++
+      if (client !== this.primaryClient) {
+        this.clients.delete(client.id)
+        this.notifyClientDetached(client.id)
+      }
+      process.stderr.write(
+        `[relay] Client write failed: ${err instanceof Error ? err.message : String(err)}\n`
+      )
+    }
+  }
+
+  private notifyClientDetached(clientId: number): void {
+    for (const listener of this.clientDetachListeners) {
+      try {
+        listener(clientId)
+      } catch (err) {
+        process.stderr.write(
+          `[relay] Client detach listener failed: ${err instanceof Error ? err.message : String(err)}\n`
+        )
+      }
+    }
   }
 }

--- a/src/relay/fs-handler.test.ts
+++ b/src/relay/fs-handler.test.ts
@@ -20,9 +20,19 @@ vi.mock('@parcel/watcher', () => ({
 function createMockDispatcher() {
   const requestHandlers = new Map<
     string,
-    (params: Record<string, unknown>, context?: { isStale: () => boolean }) => Promise<unknown>
+    (
+      params: Record<string, unknown>,
+      context?: { clientId: number; isStale: () => boolean }
+    ) => Promise<unknown>
   >()
-  const notificationHandlers = new Map<string, (params: Record<string, unknown>) => void>()
+  const notificationHandlers = new Map<
+    string,
+    (
+      params: Record<string, unknown>,
+      context?: { clientId: number; isStale: () => boolean }
+    ) => void
+  >()
+  const detachListeners = new Set<(clientId: number) => void>()
   const notifications: { method: string; params?: Record<string, unknown> }[] = []
 
   return {
@@ -31,17 +41,29 @@ function createMockDispatcher() {
         method: string,
         handler: (
           params: Record<string, unknown>,
-          context?: { isStale: () => boolean }
+          context?: { clientId: number; isStale: () => boolean }
         ) => Promise<unknown>
       ) => {
         requestHandlers.set(method, handler)
       }
     ),
-    onNotification: vi.fn((method: string, handler: (params: Record<string, unknown>) => void) => {
-      notificationHandlers.set(method, handler)
-    }),
+    onNotification: vi.fn(
+      (
+        method: string,
+        handler: (
+          params: Record<string, unknown>,
+          context?: { clientId: number; isStale: () => boolean }
+        ) => void
+      ) => {
+        notificationHandlers.set(method, handler)
+      }
+    ),
     notify: vi.fn((method: string, params?: Record<string, unknown>) => {
       notifications.push({ method, params })
+    }),
+    onClientDetached: vi.fn((listener: (clientId: number) => void) => {
+      detachListeners.add(listener)
+      return () => detachListeners.delete(listener)
     }),
     _requestHandlers: requestHandlers,
     _notificationHandlers: notificationHandlers,
@@ -49,20 +71,32 @@ function createMockDispatcher() {
     async callRequest(
       method: string,
       params: Record<string, unknown> = {},
-      context?: { isStale: () => boolean }
+      context?: { clientId?: number; isStale: () => boolean }
     ) {
       const handler = requestHandlers.get(method)
       if (!handler) {
         throw new Error(`No handler for ${method}`)
       }
-      return handler(params, context)
+      return handler(params, {
+        clientId: context?.clientId ?? 1,
+        isStale: context?.isStale ?? (() => false)
+      })
     },
-    callNotification(method: string, params: Record<string, unknown> = {}) {
+    callNotification(
+      method: string,
+      params: Record<string, unknown> = {},
+      context?: { clientId: number; isStale: () => boolean }
+    ) {
       const handler = notificationHandlers.get(method)
       if (!handler) {
         throw new Error(`No handler for ${method}`)
       }
-      handler(params)
+      handler(params, context ?? { clientId: 1, isStale: () => false })
+    },
+    detachClient(clientId: number) {
+      for (const listener of detachListeners) {
+        listener(clientId)
+      }
     }
   }
 }
@@ -415,5 +449,109 @@ describe('FsHandler', () => {
 
     expect(firstUnsubscribe).toHaveBeenCalled()
     expect(replacementUnsubscribe).not.toHaveBeenCalled()
+  })
+
+  it('removes stale watches for any root before enforcing the watch cap', async () => {
+    const staleUnsubscribe = vi.fn()
+    mockSubscribe
+      .mockResolvedValueOnce({ unsubscribe: staleUnsubscribe })
+      .mockResolvedValue({ unsubscribe: vi.fn() })
+
+    let stale = false
+    await dispatcher.callRequest('fs.watch', { rootPath: path.join(tmpDir, 'stale-root') }, {
+      isStale: () => stale
+    })
+    for (let index = 0; index < 19; index += 1) {
+      await dispatcher.callRequest('fs.watch', {
+        rootPath: path.join(tmpDir, `watched-${index}`)
+      })
+    }
+
+    stale = true
+
+    await expect(
+      dispatcher.callRequest('fs.watch', { rootPath: path.join(tmpDir, 'new-root') })
+    ).resolves.toBeUndefined()
+    expect(staleUnsubscribe).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps a shared watch alive until every client unwatches it', async () => {
+    const unsubscribe = vi.fn()
+    mockSubscribe.mockResolvedValue({ unsubscribe })
+
+    await dispatcher.callRequest('fs.watch', { rootPath: tmpDir }, { isStale: () => false })
+    await dispatcher.callRequest(
+      'fs.watch',
+      { rootPath: tmpDir },
+      {
+        clientId: 2,
+        isStale: () => false
+      }
+    )
+
+    dispatcher.callNotification(
+      'fs.unwatch',
+      { rootPath: tmpDir },
+      {
+        clientId: 1,
+        isStale: () => false
+      }
+    )
+    expect(unsubscribe).not.toHaveBeenCalled()
+
+    dispatcher.callNotification(
+      'fs.unwatch',
+      { rootPath: tmpDir },
+      {
+        clientId: 2,
+        isStale: () => false
+      }
+    )
+    expect(unsubscribe).toHaveBeenCalledTimes(1)
+  })
+
+  it('allows a shared watch attach even when the root watch cap is full', async () => {
+    mockSubscribe.mockResolvedValue({ unsubscribe: vi.fn() })
+
+    for (let index = 0; index < 20; index += 1) {
+      const dir = path.join(tmpDir, `watched-${index}`)
+      await fs.mkdir(dir)
+      await dispatcher.callRequest(
+        'fs.watch',
+        { rootPath: dir },
+        {
+          clientId: index + 1,
+          isStale: () => false
+        }
+      )
+    }
+
+    await expect(
+      dispatcher.callRequest(
+        'fs.watch',
+        { rootPath: path.join(tmpDir, 'watched-0') },
+        {
+          clientId: 99,
+          isStale: () => false
+        }
+      )
+    ).resolves.toBeUndefined()
+  })
+
+  it('releases a client watch when the dispatcher detaches that client', async () => {
+    const unsubscribe = vi.fn()
+    mockSubscribe.mockResolvedValue({ unsubscribe })
+
+    await dispatcher.callRequest(
+      'fs.watch',
+      { rootPath: tmpDir },
+      {
+        clientId: 7,
+        isStale: () => false
+      }
+    )
+    dispatcher.detachClient(7)
+
+    expect(unsubscribe).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/relay/fs-handler.ts
+++ b/src/relay/fs-handler.ts
@@ -26,7 +26,7 @@ type WatchState = {
   rootPath: string
   unwatchFn: (() => void) | null
   setupPromise: Promise<void> | null
-  isStale: () => boolean
+  clients: Map<number, () => boolean>
 }
 
 async function isDirectoryEntry(
@@ -56,6 +56,7 @@ export class FsHandler {
   constructor(dispatcher: RelayDispatcher, _context: RelayContext) {
     this.dispatcher = dispatcher
     this.registerHandlers()
+    this.dispatcher.onClientDetached?.((clientId) => this.releaseClientWatches(clientId))
   }
 
   private registerHandlers(): void {
@@ -75,7 +76,7 @@ export class FsHandler {
     this.dispatcher.onRequest('fs.listFiles', (p) => this.listFiles(p))
     this.dispatcher.onRequest('fs.workspaceSpaceScan', (p, c) => this.workspaceSpaceScan(p, c))
     this.dispatcher.onRequest('fs.watch', (p, context) => this.watch(p, context))
-    this.dispatcher.onNotification('fs.unwatch', (p) => this.unwatch(p))
+    this.dispatcher.onNotification('fs.unwatch', (p, context) => this.unwatch(p, context))
     this.dispatcher.onNotification('fs.cancelStream', (p) => this.cancelStream(p))
   }
 
@@ -102,12 +103,9 @@ export class FsHandler {
     return readRelayFileContent(filePath)
   }
 
-  private async readFileStream(
-    params: Record<string, unknown>,
-    context?: { isStale: () => boolean }
-  ) {
+  private async readFileStream(params: Record<string, unknown>, context?: RequestContext) {
     const filePath = expandTilde(params.filePath as string)
-    const ctx = context ?? { isStale: () => false }
+    const ctx = context ?? { clientId: 0, isStale: () => false }
     return readRelayFileStreamMetadata(filePath, this.dispatcher, this.streamRegistry, ctx)
   }
 
@@ -289,14 +287,17 @@ export class FsHandler {
   private async watch(params: Record<string, unknown>, context?: RequestContext) {
     const rootPath = expandTilde(params.rootPath as string)
 
+    this.releaseStaleWatches()
+
     const existing = this.watches.get(rootPath)
-    if (existing && !existing.isStale()) {
-      if (existing.setupPromise) {
-        await existing.setupPromise
+    if (existing) {
+      if ([...existing.clients.values()].some((isStale) => !isStale())) {
+        existing.clients.set(context?.clientId ?? 0, context?.isStale ?? (() => false))
+        if (existing.setupPromise) {
+          await existing.setupPromise
+        }
+        return
       }
-      return
-    }
-    if (existing?.isStale()) {
       existing.unwatchFn?.()
       this.watches.delete(rootPath)
     }
@@ -309,7 +310,7 @@ export class FsHandler {
       rootPath,
       unwatchFn: null,
       setupPromise: null,
-      isStale: () => context?.isStale() ?? false
+      clients: new Map([[context?.clientId ?? 0, context?.isStale ?? (() => false)]])
     }
     this.watches.set(rootPath, watchState)
 
@@ -335,11 +336,14 @@ export class FsHandler {
       watchState.unwatchFn = () => {
         void subscription.unsubscribe()
       }
-      if (watchState.isStale() || this.watches.get(rootPath) !== watchState) {
-        // Why: if the client reconnects while watcher setup is in flight, the
-        // response is discarded and no client can later balance it with
-        // fs.unwatch. Tear down only this request's subscription so a newer
-        // replacement watch for the same root is not removed.
+      if (
+        [...watchState.clients.values()].every((isStale) => isStale()) ||
+        this.watches.get(rootPath) !== watchState
+      ) {
+        // Why: if the only requesting client reconnects while watcher setup is
+        // in flight, no client can later balance it with fs.unwatch. Tear down
+        // only this request's subscription so a newer replacement watch for the
+        // same root is not removed.
         void subscription.unsubscribe()
         if (this.watches.get(rootPath) === watchState) {
           this.watches.delete(rootPath)
@@ -359,13 +363,37 @@ export class FsHandler {
     }
   }
 
-  private unwatch(params: Record<string, unknown>): void {
+  private unwatch(params: Record<string, unknown>, context?: RequestContext): void {
     const rootPath = expandTilde(params.rootPath as string)
     const state = this.watches.get(rootPath)
     if (state) {
+      this.releaseWatchClient(rootPath, state, context?.clientId ?? 0)
+    }
+  }
+
+  private releaseClientWatches(clientId: number): void {
+    for (const [rootPath, state] of this.watches) {
+      this.releaseWatchClient(rootPath, state, clientId)
+    }
+  }
+
+  private releaseStaleWatches(): void {
+    for (const [rootPath, state] of this.watches) {
+      if ([...state.clients.values()].some((isStale) => !isStale())) {
+        continue
+      }
       state.unwatchFn?.()
       this.watches.delete(rootPath)
     }
+  }
+
+  private releaseWatchClient(rootPath: string, state: WatchState, clientId: number): void {
+    state.clients.delete(clientId)
+    if (state.clients.size > 0) {
+      return
+    }
+    state.unwatchFn?.()
+    this.watches.delete(rootPath)
   }
 
   dispose(): void {

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -627,6 +627,9 @@ export class PtyHandler {
 
   startGraceTimer(onExpire: () => void): void {
     this.cancelGraceTimer()
+    if (this.graceTimeMs === 0) {
+      return
+    }
     // Why: always wait the full grace period even with zero PTYs.  A detached
     // relay may have no PTYs yet but a --connect client will arrive shortly.
     // Firing immediately would kill the relay before anyone could connect.

--- a/src/relay/relay.ts
+++ b/src/relay/relay.ts
@@ -33,6 +33,7 @@ import { GitHandler } from './git-handler'
 import { PreflightHandler } from './preflight-handler'
 import { PortScanHandler } from './port-scan-handler'
 import { AgentExecHandler } from './agent-exec-handler'
+import { WorkspaceSessionHandler } from './workspace-session-handler'
 import { endpointDirForRelaySocket, RelayAgentHookServer } from './agent-hook-server'
 import { PluginOverlayManager } from './plugin-overlay'
 import {
@@ -60,8 +61,10 @@ function parseArgs(argv: string[]): {
   for (let i = 2; i < argv.length; i++) {
     if (argv[i] === '--grace-time' && argv[i + 1]) {
       const parsed = parseInt(argv[i + 1], 10)
-      // Why: the CLI flag is in seconds for ergonomics, but internally we track ms.
-      if (!isNaN(parsed) && parsed > 0) {
+      // Why: the CLI flag is in seconds for ergonomics, but internally we track
+      // ms. 0 is allowed for opt-in synced workspaces that intentionally keep a
+      // relay alive until explicitly terminated.
+      if (!isNaN(parsed) && parsed >= 0) {
         graceTimeMs = parsed * 1000
       }
       i++
@@ -240,6 +243,9 @@ async function main(): Promise<void> {
   const _agentExecHandler = new AgentExecHandler(dispatcher)
   void _agentExecHandler
 
+  const _workspaceSessionHandler = new WorkspaceSessionHandler(dispatcher)
+  void _workspaceSessionHandler
+
   // ── Agent-hook server ─────────────────────────────────────────────
   // Why: hosts a loopback HTTP receiver inside the relay process so agent
   // CLIs running in remote PTYs can post hook events without leaving the
@@ -380,53 +386,37 @@ async function main(): Promise<void> {
   // a new --connect bridge pipe data to the same dispatcher that owns the
   // live PTYs — no serialization or process handoff needed.
 
-  let activeSocket: Socket | null = null
+  const socketClients = new Map<Socket, number>()
   let socketServer: Server | null = null
   const launchVersion = readLaunchVersion()
 
   function attachAcceptedSocket(sock: Socket, leftover: Buffer): void {
-    // Why: only one client at a time. If a second reconnect arrives (e.g.
-    // user restarts again quickly), close the stale bridge so the new one
-    // takes over cleanly. We null activeSocket BEFORE destroying so the old
-    // socket's close handler sees it's been replaced and skips starting the
-    // grace timer.
-    if (activeSocket) {
-      process.stderr.write('[relay] Replacing existing socket client with new connection\n')
-      const replaced = activeSocket
-      activeSocket = null
-      replaced.destroy()
-    }
-    activeSocket = sock
-
-    // Why: stdin's data listener is still registered from the initial
-    // connection. If the old SSH channel hasn't fully closed yet (TCP FIN
-    // delayed), buffered stdin data would interleave with the new socket
-    // client's frames, corrupting the frame decoder.
+    // Why: stdin's data listener is still registered from the initial connection.
+    // Pause/remove it once the first socket client is accepted so stale bytes
+    // from the original SSH channel cannot interleave with socket frames.
     process.stdin.pause()
     process.stdin.removeAllListeners('data')
 
     ptyHandler.cancelGraceTimer()
 
-    dispatcher.setWrite((data) => {
+    const clientId = dispatcher.attachClient((data) => {
       if (!sock.destroyed) {
         sock.write(data)
       }
     })
+    socketClients.set(sock, clientId)
 
     // Why: bytes that arrived in the same TCP send as the handshake frame
     // were buffered inside the handshake's FrameDecoder. Feed them into the
     // dispatcher BEFORE wiring sock.on('data'), so frame ordering is
     // preserved and no client data is silently dropped at the transition.
     if (leftover.length > 0) {
-      dispatcher.feed(leftover)
+      dispatcher.feedClient(clientId, leftover)
     }
 
     sock.on('data', (chunk: Buffer) => {
-      if (activeSocket !== sock) {
-        return
-      }
       ptyHandler.cancelGraceTimer()
-      dispatcher.feed(chunk)
+      dispatcher.feedClient(clientId, chunk)
     })
   }
 
@@ -451,9 +441,12 @@ async function main(): Promise<void> {
       })
 
       sock.on('close', () => {
-        if (activeSocket === sock) {
-          activeSocket = null
-          dispatcher.invalidateClient()
+        const clientId = socketClients.get(sock)
+        socketClients.delete(sock)
+        if (clientId !== undefined) {
+          dispatcher.detachClient(clientId)
+        }
+        if (!stdoutAlive && socketClients.size === 0) {
           startGrace()
         }
       })
@@ -486,6 +479,7 @@ async function main(): Promise<void> {
   // before the grace period starts.
   process.stdout.on('error', () => {
     stdoutAlive = false
+    dispatcher.invalidateClient()
   })
 
   function startGrace(): void {
@@ -512,19 +506,19 @@ async function main(): Promise<void> {
     process.stdin.on('end', () => {
       // Why: stdout is piped to the SSH channel — once stdin closes the
       // channel is gone and stdout writes would hit a dead pipe.  Mark it
-      // dead so the dispatcher's write callback becomes a no-op until a
-      // socket client reconnects and calls setWrite with a live target.
+      // dead so the primary client write callback becomes a no-op while
+      // socket clients, if any, keep their own live transports.
       stdoutAlive = false
-      if (!activeSocket) {
-        dispatcher.invalidateClient()
+      dispatcher.invalidateClient()
+      if (socketClients.size === 0) {
         startGrace()
       }
     })
 
     process.stdin.on('error', () => {
       stdoutAlive = false
-      if (!activeSocket) {
-        dispatcher.invalidateClient()
+      dispatcher.invalidateClient()
+      if (socketClients.size === 0) {
         startGrace()
       }
     })

--- a/src/relay/workspace-session-handler.test.ts
+++ b/src/relay/workspace-session-handler.test.ts
@@ -1,0 +1,142 @@
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { RelayDispatcher } from './dispatcher'
+import { WorkspaceSessionHandler } from './workspace-session-handler'
+import { encodeJsonRpcFrame, MessageType, type JsonRpcRequest } from './protocol'
+
+function decodeJsonFrames(written: Buffer[]): unknown[] {
+  return written
+    .filter((buf) => buf[0] === MessageType.Regular)
+    .map((buf) => {
+      const len = buf.readUInt32BE(9)
+      return JSON.parse(buf.subarray(13, 13 + len).toString('utf-8')) as unknown
+    })
+}
+
+async function sendRequest(
+  dispatcher: RelayDispatcher,
+  method: string,
+  params: Record<string, unknown>,
+  id: number
+): Promise<void> {
+  const req: JsonRpcRequest = {
+    jsonrpc: '2.0',
+    id,
+    method,
+    params
+  }
+  dispatcher.feed(encodeJsonRpcFrame(req, id, 0))
+  await Promise.resolve()
+}
+
+describe('WorkspaceSessionHandler', () => {
+  let baseDir: string
+  let dispatcher: RelayDispatcher
+  let written: Buffer[]
+
+  beforeEach(() => {
+    baseDir = mkdtempSync(join(tmpdir(), 'orca-workspace-session-'))
+    written = []
+    dispatcher = new RelayDispatcher((data) => {
+      written.push(Buffer.from(data))
+    })
+    new WorkspaceSessionHandler(dispatcher, baseDir)
+  })
+
+  afterEach(() => {
+    dispatcher.dispose()
+    rmSync(baseDir, { recursive: true, force: true })
+  })
+
+  it('stores snapshots atomically and rejects stale revisions', async () => {
+    const session = {
+      activeWorktreePath: '/repo/worktree',
+      activeTabId: 'tab-1',
+      tabsByWorktreePath: {
+        '/repo/worktree': [{ id: 'tab-1', title: 'Terminal', worktreePath: '/repo/worktree' }]
+      },
+      terminalLayoutsByTabId: {}
+    }
+
+    await sendRequest(
+      dispatcher,
+      'workspace.patch',
+      {
+        namespace: 'ssh target/path',
+        baseRevision: 0,
+        clientId: 'client-a',
+        patch: { kind: 'replace-session', session }
+      },
+      1
+    )
+
+    const frames = decodeJsonFrames(written)
+    const response = frames.find((frame) => (frame as { id?: number }).id === 1) as {
+      result: { ok: boolean; snapshot: { revision: number; session: unknown } }
+    }
+    expect(response.result.ok).toBe(true)
+    expect(response.result.snapshot.revision).toBe(1)
+    expect(response.result.snapshot.session).toEqual(session)
+    expect(
+      frames.some((frame) => (frame as { method?: string }).method === 'workspace.changed')
+    ).toBe(true)
+
+    written = []
+    await sendRequest(
+      dispatcher,
+      'workspace.patch',
+      {
+        namespace: 'ssh target/path',
+        baseRevision: 0,
+        clientId: 'client-b',
+        patch: { kind: 'replace-session', session: { ...session, activeTabId: 'tab-2' } }
+      },
+      2
+    )
+
+    const staleResponse = decodeJsonFrames(written).find(
+      (frame) => (frame as { id?: number }).id === 2
+    ) as { result: { ok: boolean; reason: string; snapshot: { revision: number } } }
+    expect(staleResponse.result.ok).toBe(false)
+    expect(staleResponse.result.reason).toBe('stale-revision')
+    expect(staleResponse.result.snapshot.revision).toBe(1)
+  })
+
+  it('tracks presence per namespace', async () => {
+    await sendRequest(
+      dispatcher,
+      'workspace.presence',
+      {
+        namespace: 'team',
+        clientId: 'client-a',
+        clientName: ' Laptop   A '
+      },
+      1
+    )
+    await sendRequest(
+      dispatcher,
+      'workspace.presence',
+      {
+        namespace: 'team',
+        clientId: 'client-b',
+        clientName: 'Laptop B'
+      },
+      2
+    )
+
+    const response = decodeJsonFrames(written).find(
+      (frame) => (frame as { id?: number }).id === 2
+    ) as {
+      result: { clients: { clientId: string; name: string }[] }
+    }
+    expect(response.result.clients.map((client) => client.clientId).sort()).toEqual([
+      'client-a',
+      'client-b'
+    ])
+    expect(response.result.clients.find((client) => client.clientId === 'client-a')?.name).toBe(
+      'Laptop A'
+    )
+  })
+})

--- a/src/relay/workspace-session-handler.ts
+++ b/src/relay/workspace-session-handler.ts
@@ -1,0 +1,187 @@
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'fs'
+import { homedir } from 'os'
+import { dirname, join } from 'path'
+import type { RelayDispatcher } from './dispatcher'
+
+type RemoteWorkspaceSnapshot = {
+  namespace: string
+  revision: number
+  updatedAt: number
+  schemaVersion: number
+  session: Record<string, unknown>
+}
+
+type ConnectedClient = {
+  clientId: string
+  name: string
+  lastSeenAt: number
+}
+
+type PatchResult =
+  | { ok: true; snapshot: RemoteWorkspaceSnapshot }
+  | {
+      ok: false
+      reason: 'stale-revision' | 'unavailable'
+      snapshot?: RemoteWorkspaceSnapshot
+      message?: string
+    }
+
+const SNAPSHOT_SCHEMA_VERSION = 1
+const PRESENCE_TTL_MS = 45_000
+
+function emptySession(): Record<string, unknown> {
+  return {
+    activeRepoId: null,
+    activeWorktreeId: null,
+    activeTabId: null,
+    tabsByWorktree: {},
+    terminalLayoutsByTabId: {}
+  }
+}
+
+function sanitizeNamespace(namespace: unknown): string {
+  const raw = typeof namespace === 'string' && namespace.trim() ? namespace.trim() : 'default'
+  return raw.replace(/[^a-zA-Z0-9._-]/g, '_').slice(0, 160) || 'default'
+}
+
+function sanitizeClientName(value: string): string {
+  return value.replace(/\s+/g, ' ').trim().slice(0, 80)
+}
+
+function sanitizeClientId(value: string): string {
+  return value.trim().slice(0, 200)
+}
+
+export class WorkspaceSessionHandler {
+  private readonly clientsByNamespace = new Map<string, Map<string, ConnectedClient>>()
+
+  constructor(
+    private dispatcher: RelayDispatcher,
+    private baseDir = join(homedir(), '.orca', 'sessions')
+  ) {
+    this.dispatcher.onRequest('workspace.get', (params) => this.get(params))
+    this.dispatcher.onRequest('workspace.patch', (params) => this.patch(params))
+    this.dispatcher.onRequest('workspace.presence', (params) => this.presence(params))
+  }
+
+  private snapshotPath(namespace: string): string {
+    return join(this.baseDir, `${namespace}.json`)
+  }
+
+  private read(namespace: string): RemoteWorkspaceSnapshot {
+    const path = this.snapshotPath(namespace)
+    if (!existsSync(path)) {
+      return {
+        namespace,
+        revision: 0,
+        updatedAt: 0,
+        schemaVersion: SNAPSHOT_SCHEMA_VERSION,
+        session: emptySession()
+      }
+    }
+
+    try {
+      const parsed = JSON.parse(readFileSync(path, 'utf-8')) as Partial<RemoteWorkspaceSnapshot>
+      return {
+        namespace,
+        revision:
+          typeof parsed.revision === 'number' && Number.isFinite(parsed.revision)
+            ? parsed.revision
+            : 0,
+        updatedAt:
+          typeof parsed.updatedAt === 'number' && Number.isFinite(parsed.updatedAt)
+            ? parsed.updatedAt
+            : 0,
+        schemaVersion:
+          typeof parsed.schemaVersion === 'number' && Number.isFinite(parsed.schemaVersion)
+            ? parsed.schemaVersion
+            : SNAPSHOT_SCHEMA_VERSION,
+        session:
+          parsed.session && typeof parsed.session === 'object' && !Array.isArray(parsed.session)
+            ? (parsed.session as Record<string, unknown>)
+            : emptySession()
+      }
+    } catch {
+      return {
+        namespace,
+        revision: 0,
+        updatedAt: 0,
+        schemaVersion: SNAPSHOT_SCHEMA_VERSION,
+        session: emptySession()
+      }
+    }
+  }
+
+  private write(snapshot: RemoteWorkspaceSnapshot): void {
+    const path = this.snapshotPath(snapshot.namespace)
+    mkdirSync(dirname(path), { recursive: true, mode: 0o700 })
+    const tmpPath = `${path}.tmp`
+    writeFileSync(tmpPath, JSON.stringify(snapshot, null, 2), { mode: 0o600 })
+    renameSync(tmpPath, path)
+  }
+
+  private async get(params: Record<string, unknown>): Promise<RemoteWorkspaceSnapshot> {
+    return this.read(sanitizeNamespace(params.namespace))
+  }
+
+  private async patch(params: Record<string, unknown>): Promise<PatchResult> {
+    const namespace = sanitizeNamespace(params.namespace)
+    const current = this.read(namespace)
+    const baseRevision = Number(params.baseRevision)
+    if (Number.isFinite(baseRevision) && baseRevision !== current.revision) {
+      return { ok: false, reason: 'stale-revision', snapshot: current }
+    }
+
+    const patch = params.patch as { kind?: unknown; session?: unknown } | undefined
+    if (
+      !patch ||
+      patch.kind !== 'replace-session' ||
+      !patch.session ||
+      typeof patch.session !== 'object' ||
+      Array.isArray(patch.session)
+    ) {
+      return { ok: false, reason: 'unavailable', message: 'Invalid workspace patch' }
+    }
+
+    const snapshot: RemoteWorkspaceSnapshot = {
+      namespace,
+      revision: current.revision + 1,
+      updatedAt: Date.now(),
+      schemaVersion: SNAPSHOT_SCHEMA_VERSION,
+      session: patch.session as Record<string, unknown>
+    }
+    this.write(snapshot)
+    this.dispatcher.notify('workspace.changed', {
+      namespace,
+      snapshot,
+      sourceClientId: typeof params.clientId === 'string' ? params.clientId : undefined
+    })
+    return { ok: true, snapshot }
+  }
+
+  private async presence(params: Record<string, unknown>): Promise<{ clients: ConnectedClient[] }> {
+    const namespace = sanitizeNamespace(params.namespace)
+    const clientId = typeof params.clientId === 'string' ? sanitizeClientId(params.clientId) : ''
+    const name = typeof params.clientName === 'string' ? sanitizeClientName(params.clientName) : ''
+    const clients = this.clientsByNamespace.get(namespace) ?? new Map<string, ConnectedClient>()
+    this.clientsByNamespace.set(namespace, clients)
+
+    const now = Date.now()
+    for (const [id, client] of clients) {
+      if (now - client.lastSeenAt > PRESENCE_TTL_MS) {
+        clients.delete(id)
+      }
+    }
+    if (clientId) {
+      clients.set(clientId, {
+        clientId,
+        name: name || 'Unknown device',
+        lastSeenAt: now
+      })
+    }
+
+    return {
+      clients: Array.from(clients.values()).sort((a, b) => b.lastSeenAt - a.lastSeenAt)
+    }
+  }
+}

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -33,7 +33,7 @@ import {
 } from '@/components/ui/context-menu'
 import { useAppStore } from './store'
 import { useShallow } from 'zustand/react/shallow'
-import { useIpcEvents } from './hooks/useIpcEvents'
+import { isRemoteWorkspaceSnapshotApplyInProgress, useIpcEvents } from './hooks/useIpcEvents'
 import { useAutomationDispatchEvents } from './hooks/useAutomationDispatchEvents'
 import RetainedAgentsSyncGate from './components/dashboard/RetainedAgentsSyncGate'
 import { ActivityTitlebarControls } from './components/activity/ActivityTitlebarControls'
@@ -84,6 +84,7 @@ import {
   canGoBackWorktreeHistory,
   canGoForwardWorktreeHistory
 } from '@/store/slices/worktree-nav-history'
+import type { RemoteWorkspacePatchResult } from '../../shared/remote-workspace-types'
 import type { OnboardingState } from '../../shared/types'
 
 const isMac = navigator.userAgent.includes('Mac')
@@ -172,6 +173,36 @@ const PetOverlay = lazy(() => import('./components/pet/PetOverlay'))
 // past first-launch. The gate `shouldShowOnboarding` lives in its own tiny
 // module so no eager import path pulls OnboardingFlow into the main chunk.
 const OnboardingFlow = lazy(() => import('./components/onboarding/OnboardingFlow'))
+
+function applyRemoteWorkspacePatchStatus(
+  targetId: string,
+  result: RemoteWorkspacePatchResult
+): void {
+  const store = useAppStore.getState()
+  if (result.ok) {
+    store.setRemoteWorkspaceSyncStatus(targetId, {
+      phase: 'synced',
+      direction: 'push',
+      revision: result.snapshot.revision,
+      updatedAt: result.snapshot.updatedAt,
+      lastSyncedAt: Date.now(),
+      message: 'Workspace uploaded'
+    })
+    return
+  }
+  store.setRemoteWorkspaceSyncStatus(targetId, {
+    phase: result.reason === 'stale-revision' ? 'conflict' : 'offline',
+    direction: 'push',
+    revision: result.snapshot?.revision,
+    updatedAt: result.snapshot?.updatedAt,
+    lastSyncedAt: Date.now(),
+    message:
+      result.message ??
+      (result.reason === 'stale-revision'
+        ? 'Workspace changed on another device'
+        : 'Remote workspace sync unavailable')
+  })
+}
 
 function App(): React.JSX.Element {
   useUnreadDockBadge()
@@ -661,7 +692,32 @@ function App(): React.JSX.Element {
   useEffect(() => {
     return createSessionWriteSubscriber({
       store: useAppStore,
-      persist: (payload) => void window.api.session.set(payload)
+      shouldSchedulePersist: () => !isRemoteWorkspaceSnapshotApplyInProgress(),
+      persist: (payload) => {
+        void window.api.session.set(payload)
+        const state = useAppStore.getState()
+        const hydratedTargetIds = Array.from(state.remoteWorkspaceHydratedTargetIds).filter(
+          (targetId) => state.remoteWorkspaceSyncStatusByTargetId[targetId]?.phase !== 'conflict'
+        )
+        if (hydratedTargetIds.length > 0) {
+          void window.api.remoteWorkspace
+            ?.setForConnectedTargets({ session: payload, hydratedTargetIds })
+            .then((results) => {
+              for (const { targetId, result } of results) {
+                applyRemoteWorkspacePatchStatus(targetId, result)
+              }
+            })
+            .catch((err) => {
+              for (const targetId of hydratedTargetIds) {
+                useAppStore.getState().setRemoteWorkspaceSyncStatus(targetId, {
+                  phase: 'error',
+                  direction: 'push',
+                  message: err instanceof Error ? err.message : 'Workspace upload failed'
+                })
+              }
+            })
+        }
+      }
     })
   }, [])
 

--- a/src/renderer/src/components/GitHubItemDialog.tsx
+++ b/src/renderer/src/components/GitHubItemDialog.tsx
@@ -164,6 +164,7 @@ export type GitHubItemDialogProjectOrigin = {
 type GitHubItemDialogProps = {
   workItem: GitHubWorkItem | null
   repoPath: string | null
+  repoId?: string | null
   /** Called when the user clicks the primary CTA to start work from this item. */
   onUse: (item: GitHubWorkItem) => void
   onClose: () => void
@@ -394,8 +395,8 @@ function findNearestBraceBlock(
 
 type FileRowProps = {
   file: GitHubPRFile
-  repoId?: string
   repoPath: string
+  repoId: string
   prNumber: number
   headSha: string | undefined
   baseSha: string | undefined
@@ -408,8 +409,8 @@ type DiffViewMode = 'flat' | 'tree'
 type DiffTreeNodeProps = {
   node: DiffTreeNode
   depth: number
-  repoId?: string
   repoPath: string
+  repoId: string
   prNumber: number
   headSha: string | undefined
   baseSha: string | undefined
@@ -419,8 +420,8 @@ type DiffTreeNodeProps = {
 function PRDiffTreeNode({
   node,
   depth,
-  repoId,
   repoPath,
+  repoId,
   prNumber,
   headSha,
   baseSha,
@@ -432,8 +433,8 @@ function PRDiffTreeNode({
     return (
       <PRFileRow
         file={node.file}
-        repoId={repoId}
         repoPath={repoPath}
+        repoId={repoId}
         prNumber={prNumber}
         headSha={headSha}
         baseSha={baseSha}
@@ -479,8 +480,8 @@ function PRDiffTreeNode({
               key={child.kind === 'file' ? child.file.path : child.path}
               node={child}
               depth={depth + 1}
-              repoId={repoId}
               repoPath={repoPath}
+              repoId={repoId}
               prNumber={prNumber}
               headSha={headSha}
               baseSha={baseSha}
@@ -495,8 +496,8 @@ function PRDiffTreeNode({
 
 type PRDiffTreeViewProps = {
   files: GitHubPRFile[]
-  repoId?: string
   repoPath: string
+  repoId: string
   prNumber: number
   headSha: string | undefined
   baseSha: string | undefined
@@ -505,8 +506,8 @@ type PRDiffTreeViewProps = {
 
 function PRDiffTreeView({
   files,
-  repoId,
   repoPath,
+  repoId,
   prNumber,
   headSha,
   baseSha,
@@ -520,8 +521,8 @@ function PRDiffTreeView({
           key={node.kind === 'file' ? node.file.path : node.path}
           node={node}
           depth={0}
-          repoId={repoId}
           repoPath={repoPath}
+          repoId={repoId}
           prNumber={prNumber}
           headSha={headSha}
           baseSha={baseSha}
@@ -567,21 +568,15 @@ function notifyWorkItemDetailsCache(): void {
 }
 
 function getWorkItemDetailsCacheKey(args: {
-  runtimeScope: string
   repoPath: string
+  repoId: string
   issueSourcePreference: string | undefined
   type: 'issue' | 'pr'
   number: number
 }): string {
   // Why: include all axes that change which (repo, item) the IPC resolves to.
   // `\0` separator avoids ambiguity between fields that may contain `:` or `/`.
-  return [
-    args.runtimeScope,
-    args.repoPath,
-    args.issueSourcePreference ?? 'auto',
-    args.type,
-    args.number
-  ].join('\0')
+  return [args.repoId, args.issueSourcePreference ?? 'auto', args.type, args.number].join('\0')
 }
 
 function touchWorkItemDetailsCache(key: string, entry: WorkItemDetailsCacheEntry): void {
@@ -624,14 +619,16 @@ let workItemDetailsCacheGeneration = 0
 // matches the (repoPath, type, number) tuple regardless of source preference.
 function invalidateWorkItemDetailsCacheByMatch(args: {
   repoPath: string
+  repoId?: string
   type: 'issue' | 'pr'
   number: number
 }): void {
   workItemDetailsCacheGeneration += 1
+  const suffix = `\0${args.type}\0${args.number}`
+  const prefix = `${args.repoId ?? args.repoPath}\0`
   let removed = false
   for (const key of Array.from(workItemDetailsCache.keys())) {
-    const [, repoPath, , type, number] = key.split('\0')
-    if (repoPath === args.repoPath && type === args.type && number === String(args.number)) {
+    if (key.startsWith(prefix) && key.endsWith(suffix)) {
       workItemDetailsCache.delete(key)
       removed = true
     }
@@ -651,6 +648,7 @@ if (typeof window !== 'undefined' && window.api?.gh?.onWorkItemMutated) {
   workItemMutatedUnsub = window.api.gh.onWorkItemMutated((payload) => {
     invalidateWorkItemDetailsCacheByMatch({
       repoPath: payload.repoPath,
+      repoId: payload.repoId,
       type: payload.type,
       number: payload.number
     })
@@ -685,16 +683,15 @@ function touchPRFileContentCache(
 }
 
 function getPRFileContentCacheKey(args: {
-  repoId?: string
   repoPath: string
+  repoId: string
   prNumber: number
   file: GitHubPRFile
   headSha: string
   baseSha: string
 }): string {
   return [
-    args.repoId ?? '',
-    args.repoPath,
+    args.repoId,
     args.prNumber,
     args.file.path,
     args.file.oldPath ?? '',
@@ -705,8 +702,8 @@ function getPRFileContentCacheKey(args: {
 }
 
 function loadPRFileContents(args: {
-  repoId?: string
   repoPath: string
+  repoId: string
   prNumber: number
   file: GitHubPRFile
   headSha: string
@@ -718,33 +715,17 @@ function loadPRFileContents(args: {
     touchPRFileContentCache(cacheKey, cached)
     return Promise.resolve(cached)
   }
-  const target = getRuntimeTargetForRepoId(args.repoId)
-  const request = (
-    target
-      ? callRuntimeRpc<GitHubPRFileContents>(
-          target,
-          'github.prFileContents',
-          {
-            repo: args.repoId,
-            prNumber: args.prNumber,
-            path: args.file.path,
-            oldPath: args.file.oldPath,
-            status: args.file.status,
-            headSha: args.headSha,
-            baseSha: args.baseSha
-          },
-          { timeoutMs: 30_000 }
-        )
-      : window.api.gh.prFileContents({
-          repoPath: args.repoPath,
-          prNumber: args.prNumber,
-          path: args.file.path,
-          oldPath: args.file.oldPath,
-          status: args.file.status,
-          headSha: args.headSha,
-          baseSha: args.baseSha
-        })
-  )
+  const request = window.api.gh
+    .prFileContents({
+      repoPath: args.repoPath,
+      repoId: args.repoId,
+      prNumber: args.prNumber,
+      path: args.file.path,
+      oldPath: args.file.oldPath,
+      status: args.file.status,
+      headSha: args.headSha,
+      baseSha: args.baseSha
+    })
     .then((contents) => {
       touchPRFileContentCache(cacheKey, contents)
       return contents
@@ -757,18 +738,6 @@ function loadPRFileContents(args: {
   return request
 }
 
-function getRuntimeTargetForRepoId(repoId: string | null | undefined) {
-  if (!repoId) {
-    return null
-  }
-  const state = useAppStore.getState()
-  const target = getActiveRuntimeTarget(state.settings)
-  if (target.kind !== 'environment') {
-    return null
-  }
-  return state.repos.some((repo) => repo.id === repoId) ? target : null
-}
-
 function addIssueCommentForRepo(args: {
   repoId?: string
   repoPath: string
@@ -776,17 +745,9 @@ function addIssueCommentForRepo(args: {
   body: string
   type?: 'issue' | 'pr'
 }): Promise<Awaited<ReturnType<typeof window.api.gh.addIssueComment>>> {
-  const target = getRuntimeTargetForRepoId(args.repoId)
-  if (target) {
-    return callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.addIssueComment>>>(
-      target,
-      'github.addIssueComment',
-      { repo: args.repoId, number: args.number, body: args.body, type: args.type },
-      { timeoutMs: 30_000 }
-    )
-  }
   return window.api.gh.addIssueComment({
     repoPath: args.repoPath,
+    repoId: args.repoId,
     number: args.number,
     body: args.body,
     type: args.type
@@ -803,25 +764,9 @@ function addPRReviewCommentForRepo(args: {
   startLine?: number
   body: string
 }): Promise<Awaited<ReturnType<typeof window.api.gh.addPRReviewComment>>> {
-  const target = getRuntimeTargetForRepoId(args.repoId)
-  if (target) {
-    return callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.addPRReviewComment>>>(
-      target,
-      'github.addPRReviewComment',
-      {
-        repo: args.repoId,
-        prNumber: args.prNumber,
-        commitId: args.commitId,
-        path: args.path,
-        line: args.line,
-        startLine: args.startLine,
-        body: args.body
-      },
-      { timeoutMs: 30_000 }
-    )
-  }
   return window.api.gh.addPRReviewComment({
     repoPath: args.repoPath,
+    repoId: args.repoId,
     prNumber: args.prNumber,
     commitId: args.commitId,
     path: args.path,
@@ -841,25 +786,9 @@ function addPRReviewCommentReplyForRepo(args: {
   path?: string
   line?: number
 }): Promise<Awaited<ReturnType<typeof window.api.gh.addPRReviewCommentReply>>> {
-  const target = getRuntimeTargetForRepoId(args.repoId)
-  if (target) {
-    return callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.addPRReviewCommentReply>>>(
-      target,
-      'github.addPRReviewCommentReply',
-      {
-        repo: args.repoId,
-        prNumber: args.prNumber,
-        commentId: args.commentId,
-        body: args.body,
-        threadId: args.threadId,
-        path: args.path,
-        line: args.line
-      },
-      { timeoutMs: 30_000 }
-    )
-  }
   return window.api.gh.addPRReviewCommentReply({
     repoPath: args.repoPath,
+    repoId: args.repoId,
     prNumber: args.prNumber,
     commentId: args.commentId,
     body: args.body,
@@ -875,17 +804,9 @@ function getWorkItemDetailsForRepo(args: {
   number: number
   type: 'issue' | 'pr'
 }): Promise<GitHubWorkItemDetails | null> {
-  const target = getRuntimeTargetForRepoId(args.repoId)
-  if (target) {
-    return callRuntimeRpc<GitHubWorkItemDetails | null>(
-      target,
-      'github.workItemDetails',
-      { repo: args.repoId, number: args.number, type: args.type },
-      { timeoutMs: 30_000 }
-    )
-  }
   return window.api.gh.workItemDetails({
     repoPath: args.repoPath,
+    repoId: args.repoId,
     number: args.number,
     type: args.type
   })
@@ -893,8 +814,8 @@ function getWorkItemDetailsForRepo(args: {
 
 function PRFileRow({
   file,
-  repoId,
   repoPath,
+  repoId,
   prNumber,
   headSha,
   baseSha,
@@ -920,8 +841,8 @@ function PRFileRow({
         setLoading(true)
         setError(null)
         loadPRFileContents({
-          repoId,
           repoPath,
+          repoId,
           prNumber,
           file,
           headSha,
@@ -958,8 +879,8 @@ function PRFileRow({
         return false
       }
       const result = await addPRReviewCommentForRepo({
-        repoId,
         repoPath,
+        repoId,
         prNumber,
         commitId: headSha,
         path: file.path,
@@ -1105,6 +1026,7 @@ function PRFileRow({
 function CommentCodeContext({
   comment,
   repoPath,
+  repoId,
   prNumber,
   files,
   headSha,
@@ -1112,6 +1034,7 @@ function CommentCodeContext({
 }: {
   comment: PRComment
   repoPath: string | null
+  repoId: string
   prNumber: number
   files: GitHubPRFile[]
   headSha: string | undefined
@@ -1135,7 +1058,7 @@ function CommentCodeContext({
       return
     }
     let cancelled = false
-    loadPRFileContents({ repoPath, prNumber, file, headSha, baseSha })
+    loadPRFileContents({ repoPath, repoId, prNumber, file, headSha, baseSha })
       .then((result) => {
         if (!cancelled) {
           setContents(result)
@@ -1149,7 +1072,7 @@ function CommentCodeContext({
     return () => {
       cancelled = true
     }
-  }, [baseSha, file, headSha, line, prNumber, repoPath])
+  }, [baseSha, file, headSha, line, prNumber, repoId, repoPath])
 
   useEffect(() => {
     setContextBefore(0)
@@ -1343,7 +1266,6 @@ function CommentCodeContext({
 
 function ConversationTab({
   item,
-  repoId,
   repoPath,
   body,
   comments,
@@ -1357,7 +1279,6 @@ function ConversationTab({
   onCommentAdded
 }: {
   item: GitHubWorkItem
-  repoId?: string
   repoPath: string | null
   body: string
   comments: PRComment[]
@@ -1370,11 +1291,10 @@ function ConversationTab({
   onUse: (item: GitHubWorkItem) => void
   onCommentAdded: (comment: PRComment) => void
 }): React.JSX.Element {
-  const settings = useAppStore((s) => s.settings)
   const authorLabel = item.author ?? 'unknown'
   const [replyingTo, setReplyingTo] = useState<number | null>(null)
   const [commentFilter, setCommentFilter] = useState<PRCommentAudienceFilter>('all')
-  const repoAssignees = useRepoAssignees(repoPath, repoId, settings)
+  const repoAssignees = useRepoAssignees(repoPath, item.repoId)
   const commentCounts = useMemo(() => getPRCommentAudienceCounts(comments), [comments])
   const visibleComments = useMemo(
     () => filterPRCommentsByAudience(comments, commentFilter),
@@ -1407,8 +1327,8 @@ function ConversationTab({
       const result =
         comment.path && item.type === 'pr'
           ? await addPRReviewCommentReplyForRepo({
-              repoId,
               repoPath,
+              repoId: item.repoId,
               prNumber: item.number,
               commentId: comment.id,
               body: replyBody,
@@ -1417,8 +1337,8 @@ function ConversationTab({
               line: comment.line
             })
           : await addIssueCommentForRepo({
-              repoId,
               repoPath,
+              repoId: item.repoId,
               number: item.number,
               body: `@${comment.author} ${replyBody}`,
               type: item.type
@@ -1433,7 +1353,7 @@ function ConversationTab({
       toast.success('Reply posted.')
       return true
     },
-    [item.number, item.type, onCommentAdded, repoId, repoPath]
+    [item.number, item.repoId, item.type, onCommentAdded, repoPath]
   )
 
   const startWorkspaceButton = (
@@ -1545,6 +1465,7 @@ function ConversationTab({
         <CommentCodeContext
           comment={comment}
           repoPath={repoPath}
+          repoId={item.repoId}
           prNumber={item.number}
           files={files}
           headSha={headSha}
@@ -1688,8 +1609,8 @@ function ConversationTab({
         {repoPath && (
           <GHCommentComposer
             className="mt-1"
-            repoId={repoId}
             repoPath={repoPath}
+            repoId={item.repoId}
             issueNumber={item.number}
             itemType={item.type}
             mentionOptions={mentionOptions}
@@ -2004,8 +1925,8 @@ function MentionTextarea({
 // to a thrown rejection so the existing `useImmediateMutation` flow
 // (which expects throws on failure) continues to work unchanged.
 async function runIssueUpdate(args: {
-  repoId?: string
   repoPath: string | null
+  repoId?: string | null
   projectOrigin: GitHubItemDialogProjectOrigin | undefined
   number: number
   updates: Parameters<typeof window.api.gh.updateIssue>[0]['updates']
@@ -2035,21 +1956,9 @@ async function runIssueUpdate(args: {
   if (!args.repoPath) {
     throw new Error('No repo context available for this edit.')
   }
-  const target = getRuntimeTargetForRepoId(args.repoId)
-  if (target) {
-    const res = await callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.updateIssue>>>(
-      target,
-      'github.updateIssue',
-      { repo: args.repoId, number: args.number, updates: args.updates },
-      { timeoutMs: 30_000 }
-    )
-    if (!res.ok) {
-      throw new Error(res.error)
-    }
-    return
-  }
   await window.api.gh.updateIssue({
     repoPath: args.repoPath,
+    repoId: args.repoId ?? undefined,
     number: args.number,
     updates: args.updates
   })
@@ -2058,6 +1967,7 @@ async function runIssueUpdate(args: {
 function GHEditSection({
   item,
   repoPath,
+  repoId,
   projectOrigin,
   localState,
   localLabels,
@@ -2069,6 +1979,7 @@ function GHEditSection({
 }: {
   item: GitHubWorkItem
   repoPath: string | null
+  repoId: string | null
   projectOrigin: GitHubItemDialogProjectOrigin | undefined
   localState: GitHubWorkItem['state']
   localLabels: string[]
@@ -2088,8 +1999,6 @@ function GHEditSection({
   const patchWorkItem = useAppStore((s) => s.patchWorkItem)
   const patchProjectRowContent = useAppStore((s) => s.patchProjectRowContent)
   const { isPending, run } = useImmediateMutation()
-  const settings = useAppStore((s) => s.settings)
-
   // Why: when the dialog opens from a Project view, mutations route through
   // *BySlug IPCs and we must keep `projectViewCache` in sync alongside
   // `workItemsCache` — `patchWorkItem` only walks the latter, so without this
@@ -2112,17 +2021,15 @@ function GHEditSection({
   const slugRepo = projectOrigin?.repo ?? null
   const repoLabelsByPath = useRepoLabels(
     projectOrigin ? null : repoPath,
-    projectOrigin ? null : item.repoId,
-    settings
+    projectOrigin ? null : repoId
   )
-  const repoLabelsBySlug = useRepoLabelsBySlug(slugOwner, slugRepo, settings)
+  const repoLabelsBySlug = useRepoLabelsBySlug(slugOwner, slugRepo)
   const repoLabels = projectOrigin ? repoLabelsBySlug : repoLabelsByPath
   const repoAssigneesByPath = useRepoAssignees(
     projectOrigin ? null : repoPath,
-    projectOrigin ? null : item.repoId,
-    settings
+    projectOrigin ? null : repoId
   )
-  const repoAssigneesBySlug = useRepoAssigneesBySlug(slugOwner, slugRepo, assignees, settings)
+  const repoAssigneesBySlug = useRepoAssigneesBySlug(slugOwner, slugRepo, assignees)
   const repoAssignees = projectOrigin ? repoAssigneesBySlug : repoAssigneesByPath
 
   // Why: sync local assignees when item changes or when the detail fetch
@@ -2522,16 +2429,16 @@ function GHEditSection({
 
 function GHCommentComposer({
   className,
-  repoId,
   repoPath,
+  repoId,
   issueNumber,
   itemType,
   mentionOptions,
   onCommentAdded
 }: {
   className?: string
-  repoId?: string
   repoPath: string
+  repoId?: string | null
   issueNumber: number
   itemType: 'issue' | 'pr'
   mentionOptions: MentionOption[]
@@ -2558,8 +2465,8 @@ function GHCommentComposer({
     setSubmitting(true)
     try {
       const result = await addIssueCommentForRepo({
-        repoId,
         repoPath,
+        repoId: repoId ?? undefined,
         number: issueNumber,
         body: trimmed,
         type: itemType
@@ -2578,7 +2485,7 @@ function GHCommentComposer({
     } finally {
       setSubmitting(false)
     }
-  }, [autoGrow, body, repoId, repoPath, issueNumber, itemType, onCommentAdded])
+  }, [autoGrow, body, repoPath, repoId, issueNumber, itemType, onCommentAdded])
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
@@ -2640,10 +2547,10 @@ function GHCommentComposer({
 // doc §1 rule: hide when either side is unknown rather than guessing.
 function WorkItemIssueSourceIndicator({
   url,
-  repoPath
+  repoId
 }: {
   url: string
-  repoPath: string | null
+  repoId: string | null
 }): React.JSX.Element | null {
   // Why: subscribe to a single store-side selector that returns the resolved
   // sources for this repo — either the primary `(repoPath, PER_REPO_FETCH_LIMIT, '')`
@@ -2657,7 +2564,7 @@ function WorkItemIssueSourceIndicator({
   // indicator is small and the cache rewrite rate is bounded by user-initiated
   // refresh/search actions.
   const sources = useAppStore((s) =>
-    s.getWorkItemsAnySourcesForRepo(repoPath ?? '', PER_REPO_FETCH_LIMIT)
+    s.getWorkItemsAnySourcesForRepo(repoId ?? '', PER_REPO_FETCH_LIMIT)
   )
   const issues = useMemo<GitHubOwnerRepo | null>(() => {
     const fromUrl = parseOwnerRepoFromItemUrl(url)
@@ -2688,6 +2595,7 @@ function WorkItemIssueSourceIndicator({
 export default function GitHubItemDialog({
   workItem,
   repoPath,
+  repoId,
   projectOrigin,
   onUse,
   onClose
@@ -2700,6 +2608,7 @@ export default function GitHubItemDialog({
   const workItemId = workItem?.id
   const workItemState = workItem?.state
   const workItemLabels = workItem?.labels
+  const effectiveRepoId = repoId ?? workItem?.repoId ?? null
 
   // Why: the cache key has to include the issue source preference so a user
   // toggling between origin/upstream for the same issue number doesn't read
@@ -2707,28 +2616,24 @@ export default function GitHubItemDialog({
   // than threading it as a prop because every existing call site already has
   // the repo registered in the store.
   const issueSourcePreference = useAppStore((s) => {
-    if (!repoPath) {
+    if (!repoPath && !effectiveRepoId) {
       return undefined
     }
-    return s.repos.find((r) => r.path === repoPath)?.issueSourcePreference
+    return s.repos.find((r) => (effectiveRepoId ? r.id === effectiveRepoId : r.path === repoPath))
+      ?.issueSourcePreference
   })
-  const runtimeScope = useAppStore((s) =>
-    s.settings?.activeRuntimeEnvironmentId
-      ? `runtime:${s.settings.activeRuntimeEnvironmentId}`
-      : 'local'
-  )
   const detailsCacheKey = useMemo(() => {
-    if (!workItem || !repoPath) {
+    if (!workItem || !repoPath || !effectiveRepoId) {
       return null
     }
     return getWorkItemDetailsCacheKey({
-      runtimeScope,
       repoPath,
+      repoId: effectiveRepoId,
       issueSourcePreference,
       type: workItem.type,
       number: workItem.number
     })
-  }, [runtimeScope, repoPath, workItem, issueSourcePreference])
+  }, [repoPath, effectiveRepoId, workItem, issueSourcePreference])
 
   // Why: reset lifted edit state when the dialog switches items or when the
   // same item receives an optimistic cache patch from the surrounding table.
@@ -2871,8 +2776,8 @@ export default function GitHubItemDialog({
     const inflight: Promise<GitHubWorkItemDetails | null> =
       cached?.pending ??
       getWorkItemDetailsForRepo({
-        repoId: workItem.repoId,
         repoPath,
+        repoId: effectiveRepoId ?? undefined,
         number: workItem.number,
         type: workItem.type
       })
@@ -2933,7 +2838,7 @@ export default function GitHubItemDialog({
           error: message
         })
       })
-  }, [repoPath, workItem, detailsCacheKey, refetchTick])
+  }, [repoPath, effectiveRepoId, workItem, detailsCacheKey, refetchTick])
 
   const Icon = workItem?.type === 'pr' ? GitPullRequest : CircleDot
   const body = details?.body ?? ''
@@ -3054,7 +2959,7 @@ export default function GitHubItemDialog({
                     )}
                   </div>
                   {workItem.type === 'issue' && (
-                    <WorkItemIssueSourceIndicator url={workItem.url} repoPath={repoPath} />
+                    <WorkItemIssueSourceIndicator url={workItem.url} repoId={effectiveRepoId} />
                   )}
                 </div>
                 <div className="flex shrink-0 items-center gap-1">
@@ -3116,6 +3021,7 @@ export default function GitHubItemDialog({
               <GHEditSection
                 item={workItem}
                 repoPath={repoPath}
+                repoId={effectiveRepoId}
                 projectOrigin={projectOrigin}
                 localState={localState}
                 localLabels={localLabels}
@@ -3130,6 +3036,7 @@ export default function GitHubItemDialog({
                   if (repoPath) {
                     invalidateWorkItemDetailsCacheByMatch({
                       repoPath,
+                      repoId: effectiveRepoId ?? undefined,
                       type: workItem.type,
                       number: workItem.number
                     })
@@ -3174,7 +3081,6 @@ export default function GitHubItemDialog({
                     <TabsContent value="conversation" className="mt-0">
                       <ConversationTab
                         item={workItem}
-                        repoId={workItem.repoId}
                         repoPath={repoPath}
                         body={body}
                         comments={comments}
@@ -3253,8 +3159,8 @@ export default function GitHubItemDialog({
                                 <PRFileRow
                                   key={file.path}
                                   file={file}
-                                  repoId={workItem.repoId}
                                   repoPath={repoPath ?? ''}
+                                  repoId={effectiveRepoId ?? ''}
                                   prNumber={workItem.number}
                                   headSha={details?.headSha}
                                   baseSha={details?.baseSha}
@@ -3264,8 +3170,8 @@ export default function GitHubItemDialog({
                             ) : (
                               <PRDiffTreeView
                                 files={files}
-                                repoId={workItem.repoId}
                                 repoPath={repoPath ?? ''}
+                                repoId={effectiveRepoId ?? ''}
                                 prNumber={workItem.number}
                                 headSha={details?.headSha}
                                 baseSha={details?.baseSha}

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -274,6 +274,7 @@ function GHStatusCell({
             )
           : window.api.gh.updateIssue({
               repoPath: repo.path,
+              repoId: repo.id,
               number: item.number,
               updates: { state: newState }
             })
@@ -895,7 +896,7 @@ export default function TaskPage(): React.JSX.Element {
     const trimmed = initialTaskQuery.trim()
     const merged: GitHubWorkItem[] = []
     for (const r of selectedRepos) {
-      const cached = getCachedWorkItems(r.path, PER_REPO_FETCH_LIMIT, trimmed)
+      const cached = getCachedWorkItems(r.id, PER_REPO_FETCH_LIMIT, trimmed)
       if (cached) {
         merged.push(...cached)
       }
@@ -1473,7 +1474,7 @@ export default function TaskPage(): React.JSX.Element {
     const preMerged: GitHubWorkItem[] = []
     let anyUncached = false
     for (const r of selectedRepos) {
-      const cached = getCachedWorkItems(r.path, PER_REPO_FETCH_LIMIT, q)
+      const cached = getCachedWorkItems(r.id, PER_REPO_FETCH_LIMIT, q)
       if (cached === null) {
         anyUncached = true
       } else {
@@ -1573,7 +1574,7 @@ export default function TaskPage(): React.JSX.Element {
     // The search API is cached 120s server-side so this doesn't add
     // meaningful latency or rate-limit pressure.
     void countWorkItemsAcrossRepos(
-      selectedRepos.map((r) => ({ path: r.path })),
+      selectedRepos.map((r) => ({ repoId: r.id, path: r.path })),
       q
     ).then((count) => {
       if (!cancelled) {
@@ -1697,6 +1698,7 @@ export default function TaskPage(): React.JSX.Element {
           )
         : await window.api.gh.createIssue({
             repoPath: newIssueTargetRepo.path,
+            repoId: newIssueTargetRepo.id,
             title,
             body: newIssueBody
           })
@@ -1744,6 +1746,7 @@ export default function TaskPage(): React.JSX.Element {
           )
         : window.api.gh.workItem({
             repoPath: newIssueTargetRepo.path,
+            repoId: newIssueTargetRepo.id,
             number: result.number,
             type: 'issue'
           })
@@ -1965,7 +1968,8 @@ export default function TaskPage(): React.JSX.Element {
         type: 'issue',
         number: 0,
         title: issue.title,
-        url: issue.url
+        url: issue.url,
+        linearIdentifier: issue.identifier
       }
       openModal('new-workspace-composer', {
         linkedWorkItem,
@@ -3552,6 +3556,7 @@ export default function TaskPage(): React.JSX.Element {
           // scan on every render while the dialog is open.
           dialogWorkItem ? (repoMap.get(dialogWorkItem.repoId)?.path ?? null) : null
         }
+        repoId={dialogWorkItem?.repoId ?? null}
         onUse={(item) => {
           setDialogWorkItem(null)
           handleUseWorkItem(item)

--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -23,7 +23,6 @@ import { cn } from '@/lib/utils'
 import { getWorktreeStatus, getWorktreeStatusLabel } from '@/lib/worktree-status'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 import { findWorktreeById } from '@/store/slices/worktree-helpers'
-import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
 import {
   searchWorktrees,
   type MatchRange,
@@ -42,8 +41,6 @@ import {
 import type {
   BrowserPage,
   BrowserWorkspace,
-  GitHubWorkItem,
-  Repo,
   Worktree
 } from '../../../shared/types'
 import { isGitRepoKind } from '../../../shared/repo-kind'
@@ -81,55 +78,6 @@ type BrowserSelection = {
   worktree: Worktree
   workspace: BrowserWorkspace
   page: BrowserPage
-}
-
-type GitHubWorkItemWithoutRepo = Omit<GitHubWorkItem, 'repoId'>
-
-function getRuntimeTargetForRepo(
-  repo: Repo
-): { kind: 'environment'; environmentId: string } | null {
-  const target = getActiveRuntimeTarget(useAppStore.getState().settings)
-  if (target.kind !== 'environment') {
-    return null
-  }
-  return useAppStore.getState().repos.some((candidate) => candidate.id === repo.id) ? target : null
-}
-
-function getWorkItemForRepo(repo: Repo, number: number): Promise<GitHubWorkItemWithoutRepo | null> {
-  const target = getRuntimeTargetForRepo(repo)
-  if (target) {
-    return callRuntimeRpc<GitHubWorkItemWithoutRepo | null>(
-      target,
-      'github.workItem',
-      { repo: repo.id, number },
-      { timeoutMs: 30_000 }
-    )
-  }
-  return window.api.gh.workItem({ repoPath: repo.path, number })
-}
-
-function getWorkItemByOwnerRepoForRepo(
-  repo: Repo,
-  slug: { owner: string; repo: string },
-  number: number,
-  type: 'issue' | 'pr'
-): Promise<GitHubWorkItemWithoutRepo | null> {
-  const target = getRuntimeTargetForRepo(repo)
-  if (target) {
-    return callRuntimeRpc<GitHubWorkItemWithoutRepo | null>(
-      target,
-      'github.workItemByOwnerRepo',
-      { repo: repo.id, owner: slug.owner, ownerRepo: slug.repo, number, type },
-      { timeoutMs: 30_000 }
-    )
-  }
-  return window.api.gh.workItemByOwnerRepo({
-    repoPath: repo.path,
-    owner: slug.owner,
-    repo: slug.repo,
-    number,
-    type
-  })
 }
 
 function HighlightedText({
@@ -741,7 +689,15 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
       // indefinitely on slow networks. Close immediately and populate the
       // composer once the lookup returns.
       closeModal()
-      void getWorkItemByOwnerRepoForRepo(repoForLookup, slug, number, ghLink.type)
+      void window.api.gh
+        .workItemByOwnerRepo({
+          repoPath: repoForLookup.path,
+          repoId: repoForLookup.id,
+          owner: slug.owner,
+          repo: slug.repo,
+          number,
+          type: ghLink.type
+        })
         .then((item) => {
           const data: Record<string, unknown> = { initialRepoId: repoForLookup.id }
           if (item) {
@@ -794,7 +750,8 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
       }
 
       closeModal()
-      void getWorkItemForRepo(repoForLookup, ghNumber)
+      void window.api.gh
+        .workItem({ repoPath: repoForLookup.path, repoId: repoForLookup.id, number: ghNumber })
         .then((item) => {
           const data: Record<string, unknown> = { initialRepoId: repoForLookup.id }
           if (item) {

--- a/src/renderer/src/components/github-project/ProjectViewWrapper.tsx
+++ b/src/renderer/src/components/github-project/ProjectViewWrapper.tsx
@@ -317,6 +317,7 @@ export default function ProjectViewWrapper(_props: Props = {} as Props): React.J
   const [dialogRepoItem, setDialogRepoItem] = useState<{
     workItem: GitHubWorkItem
     repoPath: string
+    repoId: string
     origin: GitHubItemDialogProjectOrigin
   } | null>(null)
   // Why: the slug dialog is only opened for rows whose repo isn't registered
@@ -405,11 +406,12 @@ export default function ProjectViewWrapper(_props: Props = {} as Props): React.J
         }
         return
       }
-      const matched = lookupSlug(`${origin.owner}/${origin.repo}`)
+      const matches = lookupSlug(`${origin.owner}/${origin.repo}`)
+      const matched = matches.length === 1 ? matches[0] : null
       if (matched) {
         const workItem = buildWorkItem(row, matched.id)
         if (workItem) {
-          setDialogRepoItem({ workItem, repoPath: matched.path, origin })
+          setDialogRepoItem({ workItem, repoPath: matched.path, repoId: matched.id, origin })
           return
         }
       }
@@ -428,7 +430,8 @@ export default function ProjectViewWrapper(_props: Props = {} as Props): React.J
       if (!origin) {
         return
       }
-      const matched = lookupSlug(`${origin.owner}/${origin.repo}`)
+      const matches = lookupSlug(`${origin.owner}/${origin.repo}`)
+      const matched = matches.length === 1 ? matches[0] : null
       if (!matched) {
         setRepoNotInOrca({
           owner: origin.owner,
@@ -700,6 +703,7 @@ export default function ProjectViewWrapper(_props: Props = {} as Props): React.J
       <GitHubItemDialog
         workItem={dialogRepoItem?.workItem ?? null}
         repoPath={dialogRepoItem?.repoPath ?? null}
+        repoId={dialogRepoItem?.repoId ?? null}
         projectOrigin={dialogRepoItem?.origin}
         onUse={(item) => {
           const current = dialogRepoItem

--- a/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
+++ b/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
@@ -41,11 +41,9 @@ import {
 import { parseGitLabIssueOrMRLink } from '@/lib/gitlab-links'
 import { cn } from '@/lib/utils'
 import { LinearIcon } from '@/components/icons/LinearIcon'
-import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
 import type {
   GitHubWorkItem,
   GitLabWorkItem,
-  GlobalSettings,
   LinearIssue
 } from '../../../../shared/types'
 
@@ -63,7 +61,6 @@ const MR_STATE_FILTERS: { id: MrStateFilter; label: string }[] = [
 ]
 
 type RepoOption = ReturnType<typeof useAppStore.getState>['repos'][number]
-type GitHubWorkItemWithoutRepo = Omit<GitHubWorkItem, 'repoId'>
 
 type SmartWorkspaceNameFieldProps = {
   repos: RepoOption[]
@@ -166,8 +163,6 @@ export default function SmartWorkspaceNameField({
       searchLinearIssues: s.searchLinearIssues
     }))
   )
-  const settings = useAppStore((s) => s.settings)
-
   const selectedRepo = useMemo(
     () => repos.find((repo) => repo.id === repoId) ?? null,
     [repoId, repos]
@@ -235,7 +230,7 @@ export default function SmartWorkspaceNameField({
   const shouldQueryLinear = mode === 'smart' || mode === 'linear'
 
   useEffect(() => {
-    if (!shouldQueryGithub || !selectedRepo?.path || selectedRepo.connectionId) {
+    if (!shouldQueryGithub || !selectedRepo?.path) {
       setGithubItems([])
       setGithubLoading(false)
       return
@@ -245,20 +240,21 @@ export default function SmartWorkspaceNameField({
     const directLink = parsedGhLink
     if (directLink !== null && handledCrossRepoUrlRef.current !== debouncedQuery.trim()) {
       setGithubLoading(true)
-      void getRepoSlugCached(selectedRepo, repoSlugCacheRef.current, settings)
+      void getRepoSlugCached(selectedRepo, repoSlugCacheRef.current)
         .then(async (selectedSlug) => {
           if (stale) {
             return
           }
           if (!selectedSlug || sameSlug(selectedSlug, directLink.slug)) {
             handledCrossRepoUrlRef.current = debouncedQuery.trim()
-            const item = await getWorkItemByOwnerRepo(
-              selectedRepo,
-              directLink.slug,
-              directLink.number,
-              directLink.type,
-              settings
-            )
+            const item = await window.api.gh.workItemByOwnerRepo({
+              repoPath: selectedRepo.path,
+              repoId: selectedRepo.id,
+              owner: directLink.slug.owner,
+              repo: directLink.slug.repo,
+              number: directLink.number,
+              type: directLink.type
+            })
             if (!stale) {
               setGithubItems(item ? [{ ...item, repoId: selectedRepo.id } as GitHubWorkItem] : [])
             }
@@ -267,8 +263,7 @@ export default function SmartWorkspaceNameField({
           const matchingRepo = await findMatchingRepoForSlug(
             repos,
             directLink.slug,
-            repoSlugCacheRef.current,
-            settings
+            repoSlugCacheRef.current
           )
           if (!stale) {
             setGithubItems([])
@@ -289,14 +284,19 @@ export default function SmartWorkspaceNameField({
       setGithubLoading(true)
       const request =
         directLink !== null
-          ? getWorkItemByOwnerRepo(
-              selectedRepo,
-              directLink.slug,
-              directLink.number,
-              directLink.type,
-              settings
-            )
-          : getWorkItem(selectedRepo, directNumber, undefined, settings)
+          ? window.api.gh.workItemByOwnerRepo({
+              repoPath: selectedRepo.path,
+              repoId: selectedRepo.id,
+              owner: directLink.slug.owner,
+              repo: directLink.slug.repo,
+              number: directLink.number,
+              type: directLink.type
+            })
+          : window.api.gh.workItem({
+              repoPath: selectedRepo.path,
+              repoId: selectedRepo.id,
+              number: directNumber
+            })
       void request
         .then((item) => {
           if (!stale) {
@@ -320,7 +320,7 @@ export default function SmartWorkspaceNameField({
 
     const trimmed = normalizedGhQuery.query.trim()
     const query = trimmed ? normalizedGhQuery.query : ''
-    const cached = getCachedWorkItems(selectedRepo.path, RESULT_LIMIT, query)
+    const cached = getCachedWorkItems(selectedRepo.id, RESULT_LIMIT, query)
     if (cached) {
       setGithubItems(cached.slice(0, RESULT_LIMIT))
       setGithubLoading(false)
@@ -354,7 +354,6 @@ export default function SmartWorkspaceNameField({
     parsedGhLink,
     repos,
     selectedRepo,
-    settings,
     shouldQueryGithub
   ])
 
@@ -715,13 +714,14 @@ export default function SmartWorkspaceNameField({
       handledCrossRepoUrlRef.current = debouncedQuery.trim()
       setGithubLoading(true)
       try {
-        const item = await getWorkItemByOwnerRepo(
-          targetRepo,
-          crossRepoPrompt.link.slug,
-          crossRepoPrompt.link.number,
-          crossRepoPrompt.link.type,
-          settings
-        )
+        const item = await window.api.gh.workItemByOwnerRepo({
+          repoPath: targetRepo.path,
+          repoId: targetRepo.id,
+          owner: crossRepoPrompt.link.slug.owner,
+          repo: crossRepoPrompt.link.slug.repo,
+          number: crossRepoPrompt.link.number,
+          type: crossRepoPrompt.link.type
+        })
         if (!item) {
           return
         }
@@ -733,7 +733,7 @@ export default function SmartWorkspaceNameField({
         setGithubLoading(false)
       }
     },
-    [crossRepoPrompt, debouncedQuery, onGitHubItemSelect, onRepoChange, settings]
+    [crossRepoPrompt, debouncedQuery, onGitHubItemSelect, onRepoChange]
   )
 
   const handleUseCurrentRepo = useCallback(async (): Promise<void> => {
@@ -753,11 +753,11 @@ export default function SmartWorkspaceNameField({
       return
     }
     repoSlugCacheRef.current.delete(added.id)
-    const slug = await getRepoSlugCached(added, repoSlugCacheRef.current, settings)
+    const slug = await getRepoSlugCached(added, repoSlugCacheRef.current)
     if (slug && sameSlug(slug, crossRepoPrompt.link.slug)) {
       await acceptGitHubLink(added)
     }
-  }, [acceptGitHubLink, addRepo, crossRepoPrompt, settings])
+  }, [acceptGitHubLink, addRepo, crossRepoPrompt])
 
   const dismissCrossRepoPrompt = useCallback((): void => {
     handledCrossRepoUrlRef.current = debouncedQuery.trim()
@@ -1175,37 +1175,16 @@ function sameSlug(left: RepoSlug, right: RepoSlug): boolean {
   )
 }
 
-function runtimeSlugScope(
-  settings: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined
-): string {
-  const target = getActiveRuntimeTarget(settings)
-  return target.kind === 'environment' ? `runtime:${target.environmentId}` : 'local'
-}
-
 async function getRepoSlugCached(
   repo: RepoOption,
-  cache: Map<string, RepoSlug | null>,
-  settings: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined
+  cache: Map<string, RepoSlug | null>
 ): Promise<RepoSlug | null> {
-  const cacheKey = `${runtimeSlugScope(settings)}:${repo.id}`
+  const cacheKey = repo.id
   if (cache.has(cacheKey)) {
     return cache.get(cacheKey) ?? null
   }
-  if (repo.connectionId) {
-    cache.set(cacheKey, null)
-    return null
-  }
   try {
-    const target = getActiveRuntimeTarget(settings)
-    const slug =
-      target.kind === 'environment'
-        ? await callRuntimeRpc<RepoSlug | null>(
-            target,
-            'github.repoSlug',
-            { repo: repo.id },
-            { timeoutMs: 30_000 }
-          )
-        : await window.api.gh.repoSlug({ repoPath: repo.path })
+    const slug = await window.api.gh.repoSlug({ repoPath: repo.path, repoId: repo.id })
     cache.set(cacheKey, slug)
     return slug
   } catch {
@@ -1217,63 +1196,13 @@ async function getRepoSlugCached(
 async function findMatchingRepoForSlug(
   repos: RepoOption[],
   slug: RepoSlug,
-  cache: Map<string, RepoSlug | null>,
-  settings: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined
+  cache: Map<string, RepoSlug | null>
 ): Promise<RepoOption | null> {
   for (const repo of repos) {
-    const candidate = await getRepoSlugCached(repo, cache, settings)
+    const candidate = await getRepoSlugCached(repo, cache)
     if (candidate && sameSlug(candidate, slug)) {
       return repo
     }
   }
   return null
-}
-
-function getWorkItem(
-  repo: RepoOption,
-  number: number,
-  type: 'issue' | 'pr' | undefined,
-  settings: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined
-): Promise<GitHubWorkItemWithoutRepo | null> {
-  const target = getActiveRuntimeTarget(settings)
-  if (target.kind === 'environment') {
-    return callRuntimeRpc<GitHubWorkItemWithoutRepo | null>(
-      target,
-      'github.workItem',
-      { repo: repo.id, number, ...(type ? { type } : {}) },
-      { timeoutMs: 30_000 }
-    )
-  }
-  return window.api.gh.workItem({ repoPath: repo.path, number, ...(type ? { type } : {}) })
-}
-
-function getWorkItemByOwnerRepo(
-  repo: RepoOption,
-  slug: RepoSlug,
-  number: number,
-  type: 'issue' | 'pr',
-  settings: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined
-): Promise<GitHubWorkItemWithoutRepo | null> {
-  const target = getActiveRuntimeTarget(settings)
-  if (target.kind === 'environment') {
-    return callRuntimeRpc<GitHubWorkItemWithoutRepo | null>(
-      target,
-      'github.workItemByOwnerRepo',
-      {
-        repo: repo.id,
-        owner: slug.owner,
-        ownerRepo: slug.repo,
-        number,
-        type
-      },
-      { timeoutMs: 30_000 }
-    )
-  }
-  return window.api.gh.workItemByOwnerRepo({
-    repoPath: repo.path,
-    owner: slug.owner,
-    repo: slug.repo,
-    number,
-    type
-  })
 }

--- a/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
@@ -17,7 +17,6 @@ import {
 } from './checks-panel-content'
 import { ENTRY_REFRESH_GRACE_MS, shouldEntryRefresh } from './checks-entry-refresh'
 import type { PRInfo, PRCheckDetail, PRComment } from '../../../../shared/types'
-import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
 
 export default function ChecksPanel(): React.JSX.Element {
   const activeWorktree = useActiveWorktree()
@@ -76,7 +75,7 @@ export default function ChecksPanel(): React.JSX.Element {
   // Find active worktree and repo
   const branch = activeWorktree ? activeWorktree.branch.replace(/^refs\/heads\//, '') : ''
   const isFolder = repo ? isFolderRepo(repo) : false
-  const prCacheKey = repo && branch ? `${repo.path}::${branch}` : ''
+  const prCacheKey = repo && branch ? `${repo.id}::${branch}` : ''
   const pr: PRInfo | null = prCacheKey ? (prCache[prCacheKey]?.data ?? null) : null
   const prNumber = pr?.number ?? null
   const conflictOperation = activeWorktreeId
@@ -89,8 +88,8 @@ export default function ChecksPanel(): React.JSX.Element {
   const prFetchedAt = useAppStore((s) =>
     prCacheKey ? s.prCache[prCacheKey]?.fetchedAt : undefined
   )
-  const checksCacheKey = repo && prNumber ? `${repo.path}::pr-checks::${prNumber}` : ''
-  const commentsCacheKey = repo && prNumber ? `${repo.path}::pr-comments::${prNumber}` : ''
+  const checksCacheKey = repo && prNumber ? `${repo.id}::pr-checks::${prNumber}` : ''
+  const commentsCacheKey = repo && prNumber ? `${repo.id}::pr-comments::${prNumber}` : ''
   const checksFetchedAt = useAppStore((s) =>
     checksCacheKey ? s.checksCache[checksCacheKey]?.fetchedAt : undefined
   )
@@ -104,7 +103,7 @@ export default function ChecksPanel(): React.JSX.Element {
   const linkedPR = activeWorktree?.linkedPR ?? null
   useEffect(() => {
     if (repo && !isFolder && branch) {
-      void fetchPRForBranch(repo.path, branch, { linkedPRNumber: linkedPR })
+      void fetchPRForBranch(repo.path, branch, { repoId: repo.id, linkedPRNumber: linkedPR })
     }
   }, [repo, isFolder, branch, linkedPR, fetchPRForBranch])
 
@@ -126,16 +125,18 @@ export default function ChecksPanel(): React.JSX.Element {
     // lists from an older payload.
     conflictSummaryRefreshKeyRef.current = refreshKey
     setConflictDetailsRefreshing(true)
-    void fetchPRForBranch(repo.path, branch, { force: true, linkedPRNumber: linkedPR }).finally(
-      () => {
-        // Why: fetchPRForBranch updates the PR cache before resolving, which
-        // can rerun this effect. Only the current refresh key may clear the
-        // spinner so stale requests don't race newer worktrees/branches.
-        if (conflictSummaryRefreshKeyRef.current === refreshKey) {
-          setConflictDetailsRefreshing(false)
-        }
+    void fetchPRForBranch(repo.path, branch, {
+      force: true,
+      repoId: repo.id,
+      linkedPRNumber: linkedPR
+    }).finally(() => {
+      // Why: fetchPRForBranch updates the PR cache before resolving, which
+      // can rerun this effect. Only the current refresh key may clear the
+      // spinner so stale requests don't race newer worktrees/branches.
+      if (conflictSummaryRefreshKeyRef.current === refreshKey) {
+        setConflictDetailsRefreshing(false)
       }
-    )
+    })
   }, [repo, isFolder, branch, pr, linkedPR, fetchPRForBranch])
 
   // Fetch checks via cached store method
@@ -151,7 +152,8 @@ export default function ChecksPanel(): React.JSX.Element {
       setChecksLoading(true)
       try {
         const result = await fetchPRChecks(repo.path, targetPRNumber, branch, pr?.headSha, {
-          force
+          force,
+          repoId: repo.id
         })
         setChecks(result)
 
@@ -219,7 +221,7 @@ export default function ChecksPanel(): React.JSX.Element {
       }
       setCommentsLoading(true)
       try {
-        const result = await fetchPRComments(repo.path, targetPRNumber, { force })
+        const result = await fetchPRComments(repo.path, targetPRNumber, { force, repoId: repo.id })
         setComments(result)
       } catch (err) {
         console.warn('Failed to fetch PR comments:', err)
@@ -240,7 +242,7 @@ export default function ChecksPanel(): React.JSX.Element {
     // state after the user switches worktrees, showing the wrong PR's comments.
     let cancelled = false
     setCommentsLoading(true)
-    void fetchPRComments(repo.path, prNumber).then(
+    void fetchPRComments(repo.path, prNumber, { repoId: repo.id }).then(
       (result) => {
         if (!cancelled) {
           setComments(result)
@@ -267,6 +269,7 @@ export default function ChecksPanel(): React.JSX.Element {
     try {
       const refreshedPR = await fetchPRForBranch(repo.path, branch, {
         force: true,
+        repoId: repo.id,
         linkedPRNumber: linkedPR
       })
       if (refreshedPR) {
@@ -279,7 +282,7 @@ export default function ChecksPanel(): React.JSX.Element {
           refreshedPR.number,
           branch,
           refreshedPR.headSha,
-          { force: true }
+          { force: true, repoId: repo.id }
         ).then(
           (result) => {
             setChecks(result)
@@ -378,23 +381,19 @@ export default function ChecksPanel(): React.JSX.Element {
     }
     setTitleSaving(true)
     try {
-      const target = getActiveRuntimeTarget(useAppStore.getState().settings)
-      const ok =
-        target.kind === 'environment'
-          ? await callRuntimeRpc<boolean>(
-              target,
-              'github.updatePRTitle',
-              { repo: repo.id, prNumber: pr.number, title: titleDraft.trim() },
-              { timeoutMs: 30_000 }
-            )
-          : await window.api.gh.updatePRTitle({
-              repoPath: repo.path,
-              prNumber: pr.number,
-              title: titleDraft.trim()
-            })
+      const ok = await window.api.gh.updatePRTitle({
+        repoPath: repo.path,
+        repoId: repo.id,
+        prNumber: pr.number,
+        title: titleDraft.trim()
+      })
       if (ok) {
         // Re-fetch PR to get updated title
-        await fetchPRForBranch(repo.path, branch, { force: true, linkedPRNumber: linkedPR })
+        await fetchPRForBranch(repo.path, branch, {
+          force: true,
+          repoId: repo.id,
+          linkedPRNumber: linkedPR
+        })
       }
     } finally {
       setTitleSaving(false)
@@ -419,14 +418,16 @@ export default function ChecksPanel(): React.JSX.Element {
       if (!repo || !prNumber) {
         return
       }
-      void resolveReviewThread(repo.path, prNumber, threadId, resolve).then((ok) => {
-        if (ok) {
-          // Update local state to match the optimistic store update
-          setComments((prev) =>
-            prev.map((c) => (c.threadId === threadId ? { ...c, isResolved: resolve } : c))
-          )
+      void resolveReviewThread(repo.path, prNumber, threadId, resolve, { repoId: repo.id }).then(
+        (ok) => {
+          if (ok) {
+            // Update local state to match the optimistic store update
+            setComments((prev) =>
+              prev.map((c) => (c.threadId === threadId ? { ...c, isResolved: resolve } : c))
+            )
+          }
         }
-      })
+      )
     },
     [repo, prNumber, resolveReviewThread]
   )
@@ -434,7 +435,11 @@ export default function ChecksPanel(): React.JSX.Element {
   // Refresh PR (passed to PRActions)
   const handleRefreshPR = useCallback(async () => {
     if (repo && branch) {
-      await fetchPRForBranch(repo.path, branch, { force: true, linkedPRNumber: linkedPR })
+      await fetchPRForBranch(repo.path, branch, {
+        force: true,
+        repoId: repo.id,
+        linkedPRNumber: linkedPR
+      })
     }
   }, [repo, branch, linkedPR, fetchPRForBranch])
 

--- a/src/renderer/src/components/right-sidebar/PRActions.tsx
+++ b/src/renderer/src/components/right-sidebar/PRActions.tsx
@@ -6,7 +6,6 @@ import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from '@/components/ui/tooltip'
 import type { PRInfo, Repo, Worktree } from '../../../../shared/types'
 import { runWorktreeDeleteWithToast } from '../sidebar/delete-worktree-flow'
-import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
 
 const MERGE_METHODS = ['squash', 'merge', 'rebase'] as const
 
@@ -40,20 +39,12 @@ export default function PRActions({
       setMergeError(null)
       setMergeMenuOpen(false)
       try {
-        const target = getActiveRuntimeTarget(useAppStore.getState().settings)
-        const result =
-          target.kind === 'environment'
-            ? await callRuntimeRpc<{ ok: true } | { ok: false; error: string }>(
-                target,
-                'github.mergePR',
-                { repo: repo.id, prNumber: pr.number, method },
-                { timeoutMs: 30_000 }
-              )
-            : await window.api.gh.mergePR({
-                repoPath: repo.path,
-                prNumber: pr.number,
-                method
-              })
+        const result = await window.api.gh.mergePR({
+          repoPath: repo.path,
+          repoId: repo.id,
+          prNumber: pr.number,
+          method
+        })
         if (!result.ok) {
           setMergeError(result.error)
         } else {

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -461,10 +461,10 @@ function SourceControlInner(): React.JSX.Element {
 
   const branchName = activeWorktree?.branch.replace(/^refs\/heads\//, '') ?? 'HEAD'
   const hostedReviewCacheKey =
-    activeRepo && branchName ? getHostedReviewCacheKey(activeRepo.path, branchName, settings) : null
-  const hostedReviewEntry = hostedReviewCacheKey
-    ? hostedReviewCache[hostedReviewCacheKey]
-    : undefined
+    activeRepo && branchName
+      ? getHostedReviewCacheKey(activeRepo.path, branchName, settings, activeRepo.id)
+      : null
+  const hostedReviewEntry = hostedReviewCacheKey ? hostedReviewCache[hostedReviewCacheKey] : undefined
   const hostedReview: HostedReviewInfo | null = hostedReviewCacheKey
     ? (hostedReviewEntry?.data ?? null)
     : null
@@ -477,16 +477,16 @@ function SourceControlInner(): React.JSX.Element {
     if (!isBranchVisible || !activeRepo || isFolder || !branchName || branchName === 'HEAD') {
       return
     }
-    if (activeRepo.connectionId) {
-      return
-    }
-
     // Why: the Source Control panel renders branch review status directly.
     // When a terminal checkout moves this worktree onto a new branch, we need
     // to fetch that branch's PR/MR immediately instead of waiting for the user
     // to reselect the worktree. The linked ids handle create-from-review
     // worktrees whose local branch differs from the remote head branch.
-    void fetchHostedReviewForBranch(activeRepo.path, branchName, { linkedGitHubPR, linkedGitLabMR })
+    void fetchHostedReviewForBranch(activeRepo.path, branchName, {
+      repoId: activeRepo.id,
+      linkedGitHubPR,
+      linkedGitLabMR
+    })
   }, [
     activeRepo,
     branchName,

--- a/src/renderer/src/components/right-sidebar/useGitStatusPolling.test.ts
+++ b/src/renderer/src/components/right-sidebar/useGitStatusPolling.test.ts
@@ -3,7 +3,7 @@ import type * as React from 'react'
 import type { GitStatusResult } from '../../../../shared/types'
 
 const worktree = { id: 'repo-1::/repo', repoId: 'repo-1', path: '/repo' }
-const repo = { id: 'repo-1', path: '/repo', kind: 'git' }
+const repo = { id: 'repo-1', path: '/repo', kind: 'git', connectionId: null as string | null }
 
 type PollState = {
   activeWorktreeId: string
@@ -13,6 +13,7 @@ type PollState = {
   setUpstreamStatus: ReturnType<typeof vi.fn>
   setConflictOperation: ReturnType<typeof vi.fn>
   gitConflictOperationByWorktree: Record<string, unknown>
+  sshConnectionStates: Map<string, { status: string }>
 }
 
 type GitStatusPollingHook = () => void
@@ -22,7 +23,14 @@ function GitStatusPollingHarness({ runPolling }: { runPolling: GitStatusPollingH
   return null
 }
 
-async function usePollingOnce(status: GitStatusResult): Promise<PollState> {
+async function usePollingOnce(
+  status: GitStatusResult,
+  options: {
+    connectionId?: string | null
+    sshStatus?: string
+    expectStatusCall?: boolean
+  } = {}
+): Promise<{ state: PollState; gitStatus: ReturnType<typeof vi.fn> }> {
   vi.resetModules()
 
   const state: PollState = {
@@ -32,8 +40,15 @@ async function usePollingOnce(status: GitStatusResult): Promise<PollState> {
     fetchUpstreamStatus: vi.fn().mockResolvedValue(undefined),
     setUpstreamStatus: vi.fn(),
     setConflictOperation: vi.fn(),
-    gitConflictOperationByWorktree: {}
+    gitConflictOperationByWorktree: {},
+    sshConnectionStates: new Map(
+      options.connectionId && options.sshStatus
+        ? [[options.connectionId, { status: options.sshStatus }]]
+        : []
+    )
   }
+  const mockedRepo = { ...repo, connectionId: options.connectionId ?? null }
+  const gitStatus = vi.fn().mockResolvedValue(status)
 
   vi.doMock('react', async () => {
     const actual = await vi.importActual<typeof React>('react')
@@ -56,18 +71,18 @@ async function usePollingOnce(status: GitStatusResult): Promise<PollState> {
   vi.doMock('@/store/selectors', () => ({
     useActiveWorktree: () => worktree,
     useAllWorktrees: () => [worktree],
-    useRepoById: () => repo,
-    useRepoMap: () => new Map([[repo.id, repo]])
+    useRepoById: () => mockedRepo,
+    useRepoMap: () => new Map([[mockedRepo.id, mockedRepo]])
   }))
 
   vi.doMock('@/lib/connection-context', () => ({
-    getConnectionId: () => undefined
+    getConnectionId: () => options.connectionId ?? undefined
   }))
 
   vi.stubGlobal('window', {
     api: {
       git: {
-        status: vi.fn().mockResolvedValue(status)
+        status: gitStatus
       }
     },
     addEventListener: vi.fn(),
@@ -80,11 +95,13 @@ async function usePollingOnce(status: GitStatusResult): Promise<PollState> {
 
   const { useGitStatusPolling: runPolling } = await import('./useGitStatusPolling')
   GitStatusPollingHarness({ runPolling })
-  await vi.waitFor(() => {
-    expect(state.setGitStatus).toHaveBeenCalled()
-  })
+  await (options.expectStatusCall !== false
+    ? vi.waitFor(() => {
+        expect(state.setGitStatus).toHaveBeenCalled()
+      })
+    : Promise.resolve())
 
-  return state
+  return { state, gitStatus }
 }
 
 describe('useGitStatusPolling', () => {
@@ -94,7 +111,7 @@ describe('useGitStatusPolling', () => {
   })
 
   it('uses upstream data from git status instead of spawning a separate upstream refresh', async () => {
-    const state = await usePollingOnce({
+    const { state } = await usePollingOnce({
       entries: [],
       conflictOperation: 'unknown',
       head: 'abc123',
@@ -117,7 +134,7 @@ describe('useGitStatusPolling', () => {
   })
 
   it('falls back to the upstream IPC for legacy status payloads', async () => {
-    const state = await usePollingOnce({
+    const { state } = await usePollingOnce({
       entries: [],
       conflictOperation: 'unknown',
       head: 'abc123',
@@ -126,5 +143,20 @@ describe('useGitStatusPolling', () => {
 
     expect(state.setUpstreamStatus).not.toHaveBeenCalled()
     expect(state.fetchUpstreamStatus).toHaveBeenCalledWith(worktree.id, '/repo', undefined)
+  })
+
+  it('skips remote git status polling while the SSH target is disconnected', async () => {
+    const { state, gitStatus } = await usePollingOnce(
+      {
+        entries: [],
+        conflictOperation: 'unknown',
+        head: 'abc123',
+        branch: 'refs/heads/main'
+      },
+      { connectionId: 'ssh-target-1', sshStatus: 'disconnected', expectStatusCall: false }
+    )
+
+    expect(gitStatus).not.toHaveBeenCalled()
+    expect(state.setGitStatus).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/components/right-sidebar/useGitStatusPolling.ts
+++ b/src/renderer/src/components/right-sidebar/useGitStatusPolling.ts
@@ -19,12 +19,19 @@ export function useGitStatusPolling(): void {
   const setUpstreamStatus = useAppStore((s) => s.setUpstreamStatus)
   const setConflictOperation = useAppStore((s) => s.setConflictOperation)
   const conflictOperationByWorktree = useAppStore((s) => s.gitConflictOperationByWorktree)
+  const sshConnectionStates = useAppStore((s) => s.sshConnectionStates)
   const repoMap = useRepoMap()
 
   const worktreePath = activeWorktree?.path ?? null
   const activeRepoId = activeWorktree?.repoId ?? null
   const activeRepo = useRepoById(activeRepoId)
   const activeRepoSupportsGit = activeRepo ? isGitRepoKind(activeRepo) : false
+  const activeConnectionId = activeRepo?.connectionId ?? null
+  const isConnectionReady = useCallback(
+    (connectionId: string | null | undefined): boolean =>
+      !connectionId || sshConnectionStates.get(connectionId)?.status === 'connected',
+    [sshConnectionStates]
+  )
 
   // Why: build a list of non-active worktrees that still have a known conflict
   // operation (merge/rebase/cherry-pick). These need lightweight polling so
@@ -52,6 +59,9 @@ export function useGitStatusPolling(): void {
     if (!activeWorktreeId || !worktreePath || !activeRepoSupportsGit) {
       return
     }
+    if (!isConnectionReady(activeConnectionId)) {
+      return
+    }
     try {
       const connectionId = getConnectionId(activeWorktreeId) ?? undefined
       await refreshGitStatusForWorktree({
@@ -71,8 +81,10 @@ export function useGitStatusPolling(): void {
     }
   }, [
     activeRepoSupportsGit,
+    activeConnectionId,
     activeWorktreeId,
     fetchUpstreamStatus,
+    isConnectionReady,
     worktreePath,
     setGitStatus,
     setUpstreamStatus,
@@ -111,11 +123,17 @@ export function useGitStatusPolling(): void {
     const pollStale = async (): Promise<void> => {
       for (const { id, path } of staleConflictWorktrees) {
         try {
+          const connectionId = getConnectionId(id) ?? undefined
+          // Why: after explicit SSH disconnect the provider is intentionally
+          // gone; keep remote polling quiet until the target reconnects.
+          if (!isConnectionReady(connectionId)) {
+            continue
+          }
           const op = (await getRuntimeGitConflictOperation({
             settings: useAppStore.getState().settings,
             worktreeId: id,
             worktreePath: path,
-            connectionId: getConnectionId(id) ?? undefined
+            connectionId
           })) as GitConflictOperation
           setConflictOperation(id, op)
         } catch {
@@ -136,5 +154,5 @@ export function useGitStatusPolling(): void {
       clearInterval(intervalId)
       window.removeEventListener('focus', onFocus)
     }
-  }, [staleConflictWorktrees, setConflictOperation])
+  }, [staleConflictWorktrees, setConflictOperation, isConnectionReady])
 }

--- a/src/renderer/src/components/settings/SshPane.tsx
+++ b/src/renderer/src/components/settings/SshPane.tsx
@@ -57,7 +57,7 @@ export function SshPane(_props: SshPaneProps): React.JSX.Element {
     null
   )
 
-  const setSshTargetLabels = useAppStore((s) => s.setSshTargetLabels)
+  const setSshTargetsMetadata = useAppStore((s) => s.setSshTargetsMetadata)
 
   const loadTargets = useCallback(
     async (opts?: { signal?: AbortSignal }) => {
@@ -67,18 +67,14 @@ export function SshPane(_props: SshPaneProps): React.JSX.Element {
           return
         }
         setTargets(result)
-        const labels = new Map<string, string>()
-        for (const t of result) {
-          labels.set(t.id, t.label)
-        }
-        setSshTargetLabels(labels)
+        setSshTargetsMetadata(result)
       } catch {
         if (!opts?.signal?.aborted) {
           toast.error('Failed to load SSH targets')
         }
       }
     },
-    [setSshTargetLabels]
+    [setSshTargetsMetadata]
   )
 
   useEffect(() => {
@@ -104,6 +100,14 @@ export function SshPane(_props: SshPaneProps): React.JSX.Element {
       toast.error('Relay grace period must be between 60 and 3600 seconds')
       return
     }
+    const remoteGraceSeconds = parseInt(form.remoteWorkspaceSyncGracePeriodSeconds, 10)
+    if (
+      form.remoteWorkspaceSyncEnabled &&
+      (isNaN(remoteGraceSeconds) || remoteGraceSeconds < 0 || remoteGraceSeconds > 3600)
+    ) {
+      toast.error('Synced relay grace period must be between 0 and 3600 seconds')
+      return
+    }
 
     const target = {
       label: form.label.trim() || `${form.username}@${form.host}`,
@@ -112,6 +116,10 @@ export function SshPane(_props: SshPaneProps): React.JSX.Element {
       port,
       username: form.username.trim(),
       relayGracePeriodSeconds: graceSeconds,
+      remoteWorkspaceSyncEnabled: form.remoteWorkspaceSyncEnabled,
+      remoteWorkspaceSyncGracePeriodSeconds: form.remoteWorkspaceSyncEnabled
+        ? remoteGraceSeconds
+        : 300,
       ...(form.identityFile.trim() ? { identityFile: form.identityFile.trim() } : {}),
       ...(form.proxyCommand.trim() ? { proxyCommand: form.proxyCommand.trim() } : {}),
       ...(form.jumpHost.trim() ? { jumpHost: form.jumpHost.trim() } : {})
@@ -173,7 +181,11 @@ export function SshPane(_props: SshPaneProps): React.JSX.Element {
       identityFile: target.identityFile ?? '',
       proxyCommand: target.proxyCommand ?? '',
       jumpHost: target.jumpHost ?? '',
-      relayGracePeriodSeconds: String(target.relayGracePeriodSeconds ?? 300)
+      relayGracePeriodSeconds: String(target.relayGracePeriodSeconds ?? 300),
+      remoteWorkspaceSyncEnabled: target.remoteWorkspaceSyncEnabled === true,
+      remoteWorkspaceSyncGracePeriodSeconds: String(
+        target.remoteWorkspaceSyncGracePeriodSeconds ?? 300
+      )
     })
     setShowForm(true)
   }

--- a/src/renderer/src/components/settings/SshTargetForm.tsx
+++ b/src/renderer/src/components/settings/SshTargetForm.tsx
@@ -13,6 +13,8 @@ export type EditingTarget = {
   proxyCommand: string
   jumpHost: string
   relayGracePeriodSeconds: string
+  remoteWorkspaceSyncEnabled: boolean
+  remoteWorkspaceSyncGracePeriodSeconds: string
 }
 
 export const EMPTY_FORM: EditingTarget = {
@@ -24,7 +26,9 @@ export const EMPTY_FORM: EditingTarget = {
   identityFile: '',
   proxyCommand: '',
   jumpHost: '',
-  relayGracePeriodSeconds: '300'
+  relayGracePeriodSeconds: '300',
+  remoteWorkspaceSyncEnabled: false,
+  remoteWorkspaceSyncGracePeriodSeconds: '300'
 }
 
 type SshTargetFormProps = {
@@ -139,6 +143,47 @@ export function SshTargetForm({
           <p className="text-[11px] text-muted-foreground">
             How long the relay keeps terminals alive after disconnect. Default: 300 (5 minutes).
           </p>
+        </div>
+        <div className="col-span-2 space-y-3 border-t border-border/50 pt-3">
+          <label className="flex items-start gap-3 text-sm">
+            <input
+              type="checkbox"
+              className="mt-0.5 size-4 accent-foreground"
+              checked={form.remoteWorkspaceSyncEnabled}
+              onChange={(e) =>
+                onFormChange((f) => ({ ...f, remoteWorkspaceSyncEnabled: e.target.checked }))
+              }
+            />
+            <span className="space-y-1">
+              <span className="block font-medium">Sync remote workspace</span>
+              <span className="block text-[11px] text-muted-foreground">
+                Store terminal tabs and split layouts on the SSH host so another Orca client can
+                restore the same remote workspace.
+              </span>
+            </span>
+          </label>
+          {form.remoteWorkspaceSyncEnabled && (
+            <div className="space-y-1.5 pl-7">
+              <Label>Synced Relay Grace Period (seconds)</Label>
+              <Input
+                type="number"
+                value={form.remoteWorkspaceSyncGracePeriodSeconds}
+                onChange={(e) =>
+                  onFormChange((f) => ({
+                    ...f,
+                    remoteWorkspaceSyncGracePeriodSeconds: e.target.value
+                  }))
+                }
+                placeholder="0"
+                min={0}
+                max={3600}
+              />
+              <p className="text-[11px] text-muted-foreground">
+                How long synced remote workspace terminals stay alive after all clients disconnect.
+                0 keeps them alive until explicitly terminated.
+              </p>
+            </div>
+          )}
         </div>
       </div>
 

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -146,8 +146,8 @@ const WorktreeCard = React.memo(function WorktreeCard({
   const branch = branchDisplayName(worktree.branch)
   const isFolder = repo ? isFolderRepo(repo) : false
   const hostedReviewCacheKey =
-    repo && branch ? getHostedReviewCacheKey(repo.path, branch, settings) : ''
-  const issueCacheKey = repo && worktree.linkedIssue ? `${repo.path}::${worktree.linkedIssue}` : ''
+    repo && branch ? getHostedReviewCacheKey(repo.path, branch, settings, repo.id) : ''
+  const issueCacheKey = repo && worktree.linkedIssue ? `${repo.id}::${worktree.linkedIssue}` : ''
 
   // Subscribe to ONLY the specific cache entry, not entire review/issue caches.
   const hostedReviewEntry = useAppStore((s) =>
@@ -185,18 +185,12 @@ const WorktreeCard = React.memo(function WorktreeCard({
   // This preference is purely presentational, so background refreshes would
   // spend rate limit budget on data the user cannot see.
   useEffect(() => {
-    if (
-      repo &&
-      !repo.connectionId &&
-      !isFolder &&
-      !worktree.isBare &&
-      hostedReviewCacheKey &&
-      (showPR || showCI)
-    ) {
+    if (repo && !isFolder && !worktree.isBare && hostedReviewCacheKey && (showPR || showCI)) {
       // Why: pass linkedPR so worktrees created from a PR (whose new local
       // branch differs from the remote head ref) still resolve their PR/MR via
       // a number-based fallback in the main process.
       fetchHostedReviewForBranch(repo.path, branch, {
+        repoId: repo.id,
         linkedGitHubPR: worktree.linkedPR ?? null,
         linkedGitLabMR: worktree.linkedGitLabMR ?? null
       })
@@ -221,11 +215,11 @@ const WorktreeCard = React.memo(function WorktreeCard({
       return
     }
 
-    fetchIssue(repo.path, worktree.linkedIssue)
+    fetchIssue(repo.path, worktree.linkedIssue, { repoId: repo.id })
 
     // Background poll as fallback (activity triggers handle the fast path)
     const interval = setInterval(() => {
-      fetchIssue(repo.path, worktree.linkedIssue!)
+      fetchIssue(repo.path, worktree.linkedIssue!, { repoId: repo.id })
     }, 5 * 60_000) // 5 minutes
 
     return () => clearInterval(interval)

--- a/src/renderer/src/components/status-bar/SshStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/SshStatusSegment.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useState } from 'react'
-import { Loader2, MonitorSmartphone, Server, ServerOff } from 'lucide-react'
+import { AlertTriangle, Cloud, Loader2, MonitorSmartphone, Server, ServerOff } from 'lucide-react'
 import { toast } from 'sonner'
 import {
   DropdownMenu,
@@ -11,6 +11,7 @@ import {
 import { useAppStore } from '../../store'
 import { STATUS_LABELS, statusColor } from '../settings/SshTargetCard'
 import type { SshConnectionStatus } from '../../../../shared/ssh-types'
+import type { RemoteWorkspaceSyncStatus } from '../../store/slices/ssh'
 
 function isConnecting(status: SshConnectionStatus): boolean {
   return ['connecting', 'deploying-relay', 'reconnecting'].includes(status)
@@ -64,14 +65,54 @@ function overallLabel(status: 'connected' | 'partial' | 'disconnected' | 'connec
   }
 }
 
+function syncStatusLabel(status: RemoteWorkspaceSyncStatus | undefined): string {
+  switch (status?.phase) {
+    case 'pulling':
+      return 'Sync pulling'
+    case 'pushing':
+      return 'Sync pushing'
+    case 'synced':
+      return status.direction === 'pull' ? 'Sync pulled' : 'Sync uploaded'
+    case 'conflict':
+      return 'Sync conflict'
+    case 'error':
+      return 'Sync error'
+    case 'offline':
+      return 'Sync unavailable'
+    default:
+      return 'Sync idle'
+  }
+}
+
+function syncStatusTone(status: RemoteWorkspaceSyncStatus | undefined): string {
+  switch (status?.phase) {
+    case 'conflict':
+    case 'error':
+      return 'text-destructive'
+    case 'offline':
+      return 'text-muted-foreground'
+    case 'pulling':
+    case 'pushing':
+      return 'text-yellow-500'
+    case 'synced':
+      return 'text-emerald-500'
+    default:
+      return 'text-muted-foreground'
+  }
+}
+
 function TargetRow({
   targetId,
   label,
-  status
+  status,
+  syncEnabled,
+  syncStatus
 }: {
   targetId: string
   label: string
   status: SshConnectionStatus
+  syncEnabled: boolean
+  syncStatus: RemoteWorkspaceSyncStatus | undefined
 }): React.JSX.Element {
   const [busy, setBusy] = useState(false)
 
@@ -102,7 +143,26 @@ function TargetRow({
       <span className={`size-1.5 shrink-0 rounded-full ${statusColor(status)}`} />
       <div className="min-w-0 flex-1">
         <div className="truncate text-[12px] font-medium">{label}</div>
-        <div className="text-[10px] text-muted-foreground">{STATUS_LABELS[status]}</div>
+        <div className="flex min-w-0 items-center gap-1.5 text-[10px] text-muted-foreground">
+          <span>{STATUS_LABELS[status]}</span>
+          {syncEnabled && (
+            <>
+              <span aria-hidden="true">·</span>
+              <span
+                className={`inline-flex min-w-0 items-center gap-1 ${syncStatusTone(syncStatus)}`}
+              >
+                {syncStatus?.phase === 'pulling' || syncStatus?.phase === 'pushing' ? (
+                  <Loader2 className="size-2.5 shrink-0 animate-spin" />
+                ) : syncStatus?.phase === 'conflict' || syncStatus?.phase === 'error' ? (
+                  <AlertTriangle className="size-2.5 shrink-0" />
+                ) : (
+                  <Cloud className="size-2.5 shrink-0" />
+                )}
+                <span className="truncate">{syncStatusLabel(syncStatus)}</span>
+              </span>
+            </>
+          )}
+        </div>
       </div>
       {busy ? (
         <Loader2 className="size-3 shrink-0 animate-spin text-muted-foreground" />
@@ -136,12 +196,22 @@ export function SshStatusSegment({
 }): React.JSX.Element | null {
   const sshConnectionStates = useAppStore((s) => s.sshConnectionStates)
   const sshTargetLabels = useAppStore((s) => s.sshTargetLabels)
+  const sshTargetRemoteSyncEnabled = useAppStore((s) => s.sshTargetRemoteSyncEnabled)
+  const remoteWorkspaceSyncStatusByTargetId = useAppStore(
+    (s) => s.remoteWorkspaceSyncStatusByTargetId
+  )
   const setActiveView = useAppStore((s) => s.setActiveView)
   const openSettingsTarget = useAppStore((s) => s.openSettingsTarget)
 
   const targets = Array.from(sshTargetLabels.entries()).map(([id, label]) => {
     const state = sshConnectionStates.get(id)
-    return { id, label, status: (state?.status ?? 'disconnected') as SshConnectionStatus }
+    return {
+      id,
+      label,
+      status: (state?.status ?? 'disconnected') as SshConnectionStatus,
+      syncEnabled: sshTargetRemoteSyncEnabled.get(id) === true,
+      syncStatus: remoteWorkspaceSyncStatusByTargetId[id]
+    }
   })
 
   if (targets.length === 0) {
@@ -151,6 +221,14 @@ export function SshStatusSegment({
   const statuses = targets.map((t) => t.status)
   const overall = overallStatus(statuses)
   const anyConnecting = overall === 'connecting'
+  const syncProblem = targets.find(
+    (t) => t.syncStatus?.phase === 'conflict' || t.syncStatus?.phase === 'error'
+  )
+  const syncProblemLabel = syncProblem
+    ? syncProblem.syncStatus?.phase === 'conflict'
+      ? 'Workspace conflict'
+      : 'Workspace sync error'
+    : null
 
   return (
     <DropdownMenu>
@@ -162,8 +240,14 @@ export function SshStatusSegment({
         >
           {iconOnly ? (
             <span className="inline-flex items-center gap-1">
-              <span className={`inline-block size-2 rounded-full ${overallDotColor(overall)}`} />
-              {anyConnecting ? (
+              <span
+                className={`inline-block size-2 rounded-full ${
+                  syncProblem ? 'bg-destructive' : overallDotColor(overall)
+                }`}
+              />
+              {syncProblem ? (
+                <AlertTriangle className="size-3 text-destructive" />
+              ) : anyConnecting ? (
                 <Loader2 className="size-3 animate-spin text-muted-foreground" />
               ) : (
                 <MonitorSmartphone className="size-3 text-muted-foreground" />
@@ -171,7 +255,9 @@ export function SshStatusSegment({
             </span>
           ) : (
             <span className="inline-flex items-center gap-1.5">
-              {anyConnecting ? (
+              {syncProblem ? (
+                <AlertTriangle className="size-3 text-destructive" />
+              ) : anyConnecting ? (
                 <Loader2 className="size-3 animate-spin text-yellow-500" />
               ) : overall === 'connected' ? (
                 <Server className="size-3 text-emerald-500" />
@@ -182,10 +268,17 @@ export function SshStatusSegment({
               )}
               {!compact && (
                 <span className="text-[11px]">
-                  SSH <span className="text-muted-foreground">{overallLabel(overall)}</span>
+                  SSH{' '}
+                  <span className={syncProblem ? 'text-destructive' : 'text-muted-foreground'}>
+                    {syncProblemLabel ?? overallLabel(overall)}
+                  </span>
                 </span>
               )}
-              <span className={`inline-block size-1.5 rounded-full ${overallDotColor(overall)}`} />
+              <span
+                className={`inline-block size-1.5 rounded-full ${
+                  syncProblem ? 'bg-destructive' : overallDotColor(overall)
+                }`}
+              />
             </span>
           )}
         </button>
@@ -195,7 +288,14 @@ export function SshStatusSegment({
           SSH Connections
         </div>
         {targets.map((t) => (
-          <TargetRow key={t.id} targetId={t.id} label={t.label} status={t.status} />
+          <TargetRow
+            key={t.id}
+            targetId={t.id}
+            label={t.label}
+            status={t.status}
+            syncEnabled={t.syncEnabled}
+            syncStatus={t.syncStatus}
+          />
         ))}
         <DropdownMenuSeparator />
         <DropdownMenuItem

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -143,7 +143,7 @@ export type ComposerCardProps = {
   baseBranchLinkedPrNumber: number | null
   /** Absolute path of the selected repo, used by Start-from picker for SWR. */
   selectedRepoPath: string | null
-  /** True when the selected repo is a remote SSH repo; disables the PR tab in v1. */
+  /** True when the selected repo is a remote SSH repo. */
   selectedRepoIsRemote: boolean
   /** Transient inline hint shown next to the Start-from trigger after a repo
    *  switch resets a prior selection (e.g. "was PR #8778"). Null when none. */
@@ -286,7 +286,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     if (persistDraft && newWorkspaceDraft?.linkedIssue) {
       return newWorkspaceDraft.linkedIssue
     }
-    if (initialLinkedWorkItem?.type === 'issue') {
+    if (initialLinkedWorkItem?.type === 'issue' && !initialLinkedWorkItem.linearIdentifier) {
       return String(initialLinkedWorkItem.number)
     }
     return ''
@@ -420,20 +420,12 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       return
     }
     let cancelled = false
-    const target = getActiveRuntimeTarget(settings)
-    const request =
-      target.kind === 'environment'
-        ? callRuntimeRpc<{ owner: string; repo: string } | null>(
-            target,
-            'github.repoSlug',
-            { repo: selectedRepo.id },
-            { timeoutMs: 30_000 }
-          )
-        : (window.api.gh.repoSlug({ repoPath: selectedRepoPath }) as Promise<{
-            owner: string
-            repo: string
-          } | null>)
-    void request
+    void (
+      window.api.gh.repoSlug({ repoPath: selectedRepoPath, repoId }) as Promise<{
+        owner: string
+        repo: string
+      } | null>
+    )
       .then((result) => {
         if (cancelled) {
           return
@@ -448,7 +440,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     return () => {
       cancelled = true
     }
-  }, [selectedRepo, selectedRepoPath, settings])
+  }, [repoId, selectedRepo, selectedRepoPath])
   const sparsePresetsForRepo = sparsePresetsByRepo[repoId]
   const sparsePresets = sparsePresetsForRepo ?? EMPTY_SPARSE_PRESETS
   const normalizedSparseDirectories = useMemo(
@@ -755,13 +747,13 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
 
   // Why: warm the Start-from picker's PR cache on composer mount and whenever
   // the selected repo changes so opening the picker paints instantly from
-  // cache. Local repos only — remote SSH repos disable the PR tab in v1.
+  // cache.
   useEffect(() => {
-    if (!selectedRepo?.path || selectedRepo.connectionId) {
+    if (!selectedRepo?.path) {
       return
     }
     prefetchWorkItems(selectedRepo.id, selectedRepo.path, PER_REPO_FETCH_LIMIT, 'is:pr is:open')
-  }, [prefetchWorkItems, selectedRepo?.connectionId, selectedRepo?.id, selectedRepo?.path])
+  }, [prefetchWorkItems, selectedRepo?.id, selectedRepo?.path])
 
   // Reset setup decision when config / policy changes.
   useEffect(() => {
@@ -795,17 +787,8 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     setLinkItemsLoading(true)
 
     const lookupRepoId = selectedRepo.id
-    const target = getActiveRuntimeTarget(settings)
-    const request =
-      target.kind === 'environment'
-        ? callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.listWorkItems>>>(
-            target,
-            'github.listWorkItems',
-            { repo: selectedRepo.id, limit: 100 },
-            { timeoutMs: 30_000 }
-          )
-        : window.api.gh.listWorkItems({ repoPath: selectedRepo.path, limit: 100 })
-    void request
+    void window.api.gh
+      .listWorkItems({ repoPath: selectedRepo.path, repoId: selectedRepo.id, limit: 100 })
       .then((envelope) => {
         if (!cancelled) {
           // Why: IPC payload omits repoId — stamp it here from the repo we
@@ -852,7 +835,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     return () => {
       cancelled = true
     }
-  }, [linkPopoverOpen, selectedRepo, settings])
+  }, [linkPopoverOpen, selectedRepo])
 
   useEffect(() => {
     if (!linkPopoverOpen || !selectedRepo || normalizedLinkQuery.directNumber === null) {
@@ -868,20 +851,12 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     // resolving direct lookups against the selected repo instead of requiring a
     // text match in the recent-items list.
     const lookupRepoId = selectedRepo.id
-    const target = getActiveRuntimeTarget(settings)
-    const request =
-      target.kind === 'environment'
-        ? callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.workItem>>>(
-            target,
-            'github.workItem',
-            { repo: selectedRepo.id, number: normalizedLinkQuery.directNumber },
-            { timeoutMs: 30_000 }
-          )
-        : window.api.gh.workItem({
-            repoPath: selectedRepo.path,
-            number: normalizedLinkQuery.directNumber
-          })
-    void request
+    void window.api.gh
+      .workItem({
+        repoPath: selectedRepo.path,
+        repoId: selectedRepo.id,
+        number: normalizedLinkQuery.directNumber
+      })
       .then((item) => {
         if (!cancelled) {
           setLinkDirectItem(
@@ -903,7 +878,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     return () => {
       cancelled = true
     }
-  }, [linkPopoverOpen, normalizedLinkQuery.directNumber, selectedRepo, settings])
+  }, [linkPopoverOpen, normalizedLinkQuery.directNumber, selectedRepo])
 
   const applyLinkedWorkItem = useCallback(
     (item: GitHubWorkItem): void => {
@@ -1551,6 +1526,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
             : await ensureHooksConfirmed(useAppStore.getState(), repoId, 'issueCommand')
       }
 
+      const linkedLinearIssue = linkedWorkItem?.linearIdentifier
       const result = await createWorktree(
         repoId,
         workspaceName,
@@ -1567,7 +1543,8 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
         parsedLinkedIssueNumber ?? undefined,
         effectiveLinkedPR ?? undefined,
         pushTarget,
-        tuiAgent
+        tuiAgent,
+        linkedLinearIssue
       )
       const worktree = result.worktree
 
@@ -1652,6 +1629,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     effectiveLinkedPR,
     linkedGitLabIssue,
     linkedGitLabMR,
+    linkedWorkItem?.linearIdentifier,
     linkedWorkItem?.title,
     linkedWorkItem?.url,
     normalizedSparseDirectories,
@@ -1711,6 +1689,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
             ? 'skip'
             : ((resolvedSetupDecision ?? 'inherit') as SetupDecision)
 
+        const linkedLinearIssue = linkedWorkItem?.linearIdentifier
         const result = await createWorktree(
           repoId,
           workspaceName,
@@ -1727,7 +1706,8 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
           parsedLinkedIssueNumber ?? undefined,
           effectiveLinkedPR ?? undefined,
           pushTarget,
-          agent ?? undefined
+          agent ?? undefined,
+          linkedLinearIssue
         )
         const worktree = result.worktree
 

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -1696,6 +1696,7 @@ describe('useIpcEvents agent status snapshot integration', () => {
     onSet: (cb: (data: AgentStatusSetData) => void) => () => void
     getSnapshot?: () => Promise<AgentStatusSetData[]>
     drop?: (paneKey: string) => void
+    remoteWorkspace?: Record<string, unknown>
   }): Record<string, unknown> {
     return {
       api: {
@@ -1785,7 +1786,8 @@ describe('useIpcEvents agent status snapshot integration', () => {
           onSet: args.onSet,
           getSnapshot: args.getSnapshot ?? vi.fn(() => Promise.resolve([])),
           drop: args.drop ?? vi.fn()
-        }
+        },
+        remoteWorkspace: args.remoteWorkspace
       }
     }
   }
@@ -2021,6 +2023,103 @@ describe('useIpcEvents agent status snapshot integration', () => {
     await Promise.resolve()
     expect(getSnapshot).toHaveBeenCalledTimes(1)
     expect(setAgentStatus).not.toHaveBeenCalled()
+  })
+
+  it('waits for the remote workspace client id before dropping self notifications', async () => {
+    const hydrateWorkspaceSession = vi.fn()
+    const hydrateTabsSession = vi.fn()
+    const hydrateEditorSession = vi.fn()
+    const hydrateBrowserSession = vi.fn()
+    let resolveClientId!: (id: string) => void
+    const clientId = new Promise<string>((resolve) => {
+      resolveClientId = resolve
+    })
+    const onChangedListenerRef: {
+      current:
+        | ((event: {
+            targetId: string
+            sourceClientId?: string
+            snapshot: Record<string, unknown>
+          }) => void)
+        | null
+    } = { current: null }
+    const storeState: StoreLike = buildStoreState({
+      workspaceSessionReady: true,
+      repos: [{ id: 'repo-1', connectionId: 'conn-1' }],
+      worktreesByRepo: { 'repo-1': [{ id: 'repo-1::/repo', repoId: 'repo-1' }] },
+      hydrateWorkspaceSession,
+      hydrateTabsSession,
+      hydrateEditorSession,
+      hydrateBrowserSession,
+      markRemoteWorkspaceHydrated: vi.fn(),
+      setRemoteWorkspaceSyncStatus: vi.fn(),
+      reconnectPersistedTerminals: vi.fn(() => Promise.resolve())
+    })
+
+    stubReactSyncEffect()
+    vi.doMock('../store', () => ({
+      useAppStore: {
+        subscribe: vi.fn(() => () => {}),
+        getState: () => storeState
+      }
+    }))
+    stubAuxiliaryModules()
+    vi.stubGlobal(
+      'window',
+      buildWindowApi({
+        onSet: () => () => {},
+        remoteWorkspace: {
+          clientId: () => clientId,
+          onChanged: (cb: typeof onChangedListenerRef.current) => {
+            onChangedListenerRef.current = cb
+            return () => {}
+          }
+        }
+      })
+    )
+
+    const { useIpcEvents } = await import('./useIpcEvents')
+
+    useIpcEvents()
+    await Promise.resolve()
+
+    onChangedListenerRef.current?.({
+      targetId: 'conn-1',
+      sourceClientId: 'client-self',
+      snapshot: {
+        revision: 1,
+        updatedAt: Date.now(),
+        session: {
+          activeWorktreePath: '/repo',
+          activeTabId: 'tab-1',
+          tabsByWorktreePath: {
+            '/repo': [
+              {
+                id: 'tab-1',
+                ptyId: null,
+                worktreePath: '/repo',
+                title: 'Remote',
+                customTitle: null,
+                color: null,
+                sortOrder: 1,
+                createdAt: 1
+              }
+            ]
+          },
+          terminalLayoutsByTabId: {}
+        }
+      }
+    })
+    await Promise.resolve()
+    expect(hydrateWorkspaceSession).not.toHaveBeenCalled()
+
+    resolveClientId('client-self')
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(hydrateWorkspaceSession).not.toHaveBeenCalled()
+    expect(hydrateTabsSession).not.toHaveBeenCalled()
+    expect(hydrateEditorSession).not.toHaveBeenCalled()
+    expect(hydrateBrowserSession).not.toHaveBeenCalled()
   })
 
   it('silently discards snapshot entries whose tabs are still unknown', async () => {

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -9,10 +9,15 @@ import { SPLIT_TERMINAL_PANE_EVENT, CLOSE_TERMINAL_PANE_EVENT } from '@/constant
 import type { SplitTerminalPaneDetail, CloseTerminalPaneDetail } from '@/constants/terminal'
 import { getVisibleWorktreeIds } from '@/components/sidebar/visible-worktrees'
 import { nextEditorFontZoomLevel, computeEditorFontSize } from '@/lib/editor-font-zoom'
-import type { UpdateStatus } from '../../../shared/types'
+import type { UpdateStatus, WorkspaceSessionState } from '../../../shared/types'
+import type {
+  RemoteWorkspacePatchResult,
+  RemoteWorkspaceSnapshot
+} from '../../../shared/remote-workspace-types'
 import type { RateLimitState } from '../../../shared/rate-limit-types'
 import type { SshConnectionState } from '../../../shared/ssh-types'
 import type { RuntimeTerminalDriverState } from '../../../shared/runtime-types'
+import { importRemoteWorkspaceSession } from '../../../shared/remote-workspace-session-projection'
 import { zoomLevelToPercent, ZOOM_MIN, ZOOM_MAX } from '@/components/settings/SettingsConstants'
 import { dispatchZoomLevelChanged } from '@/lib/zoom-events'
 import { resolveZoomTarget } from './resolve-zoom-target'
@@ -38,10 +43,276 @@ import { parsePaneKey } from '../../../shared/stable-pane-id'
 import { collectLeafIdsInOrder } from '@/components/terminal-pane/layout-serialization'
 import { track } from '@/lib/telemetry'
 import { singlePaneLayoutSnapshot } from '@/store/slices/terminal-helpers'
+import { buildWorkspaceSessionPayload } from '@/lib/workspace-session'
 
 export { resolveZoomTarget } from './resolve-zoom-target'
 
 const ZOOM_STEP = 0.5
+let remoteWorkspaceSnapshotApplyDepth = 0
+let remoteWorkspaceSnapshotWriteSuppressUntil = 0
+const REMOTE_WORKSPACE_SNAPSHOT_WRITE_SUPPRESS_MS = 1000
+
+export function isRemoteWorkspaceSnapshotApplyInProgress(): boolean {
+  return (
+    remoteWorkspaceSnapshotApplyDepth > 0 || Date.now() < remoteWorkspaceSnapshotWriteSuppressUntil
+  )
+}
+
+async function waitForWorkspaceSessionReady(): Promise<boolean> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (useAppStore.getState().workspaceSessionReady) {
+      return true
+    }
+    await new Promise((resolve) => window.setTimeout(resolve, 100))
+  }
+  return useAppStore.getState().workspaceSessionReady
+}
+
+async function prepareRemoteWorkspaceTarget(targetId: string): Promise<boolean> {
+  if (!(await waitForWorkspaceSessionReady())) {
+    return false
+  }
+  const store = useAppStore.getState()
+  let repos = store.repos.filter((repo) => repo.connectionId === targetId)
+  if (repos.length === 0) {
+    await store.fetchRepos()
+    repos = useAppStore.getState().repos.filter((repo) => repo.connectionId === targetId)
+  }
+  await Promise.all(repos.map((repo) => useAppStore.getState().fetchWorktrees(repo.id)))
+  return true
+}
+
+function targetRepoIds(targetId: string): Set<string> {
+  return new Set(
+    useAppStore
+      .getState()
+      .repos.filter((repo) => repo.connectionId === targetId)
+      .map((repo) => repo.id)
+  )
+}
+
+function targetWorktreeIds(targetId: string): Set<string> {
+  const repoIds = targetRepoIds(targetId)
+  return new Set(
+    Object.values(useAppStore.getState().worktreesByRepo)
+      .flat()
+      .filter((worktree) => repoIds.has(worktree.repoId))
+      .map((worktree) => worktree.id)
+  )
+}
+
+function mergeRemoteWorkspaceSession(
+  current: WorkspaceSessionState,
+  remote: WorkspaceSessionState,
+  targetId: string
+): WorkspaceSessionState {
+  const replaceWorktreeIds = targetWorktreeIds(targetId)
+  const remoteTabIds = new Set(
+    Object.values(remote.tabsByWorktree)
+      .flat()
+      .map((tab) => tab.id)
+  )
+  const replacedTabIds = new Set([
+    ...remoteTabIds,
+    ...Object.entries(current.tabsByWorktree)
+      .filter(([worktreeId]) => replaceWorktreeIds.has(worktreeId))
+      .flatMap(([, tabs]) => tabs.map((tab) => tab.id))
+  ])
+  const omitTargetWorktrees = <T>(record: Record<string, T> | undefined): Record<string, T> =>
+    Object.fromEntries(
+      Object.entries(record ?? {}).filter(([worktreeId]) => !replaceWorktreeIds.has(worktreeId))
+    )
+
+  return {
+    ...current,
+    activeRepoId:
+      remote.activeRepoId ??
+      (current.activeWorktreeId && replaceWorktreeIds.has(current.activeWorktreeId)
+        ? null
+        : current.activeRepoId),
+    activeWorktreeId:
+      remote.activeWorktreeId ??
+      (current.activeWorktreeId && replaceWorktreeIds.has(current.activeWorktreeId)
+        ? null
+        : current.activeWorktreeId),
+    activeTabId:
+      remote.activeTabId ??
+      (current.activeTabId && replacedTabIds.has(current.activeTabId) ? null : current.activeTabId),
+    tabsByWorktree: {
+      ...omitTargetWorktrees(current.tabsByWorktree),
+      ...remote.tabsByWorktree
+    },
+    terminalLayoutsByTabId: {
+      ...Object.fromEntries(
+        Object.entries(current.terminalLayoutsByTabId).filter(
+          ([tabId]) => !replacedTabIds.has(tabId)
+        )
+      ),
+      ...remote.terminalLayoutsByTabId
+    },
+    activeWorktreeIdsOnShutdown: [
+      ...(current.activeWorktreeIdsOnShutdown ?? []).filter((id) => !replaceWorktreeIds.has(id)),
+      ...(remote.activeWorktreeIdsOnShutdown ?? [])
+    ],
+    activeTabIdByWorktree: {
+      ...omitTargetWorktrees(current.activeTabIdByWorktree),
+      ...remote.activeTabIdByWorktree
+    },
+    remoteSessionIdsByTabId: {
+      ...Object.fromEntries(
+        Object.entries(current.remoteSessionIdsByTabId ?? {}).filter(
+          ([tabId]) => !replacedTabIds.has(tabId)
+        )
+      ),
+      ...remote.remoteSessionIdsByTabId
+    },
+    lastVisitedAtByWorktreeId: {
+      ...omitTargetWorktrees(current.lastVisitedAtByWorktreeId),
+      ...remote.lastVisitedAtByWorktreeId
+    }
+  }
+}
+
+async function applyRemoteWorkspaceSnapshot(
+  targetId: string,
+  snapshot: RemoteWorkspaceSnapshot
+): Promise<void> {
+  if (!(await prepareRemoteWorkspaceTarget(targetId))) {
+    throw new Error('Workspace sync waited for local session hydration and timed out')
+  }
+  const worktreeIds = targetWorktreeIds(targetId)
+  const localByPath = new Map(
+    Array.from(worktreeIds).map((worktreeId) => {
+      const separator = worktreeId.indexOf('::')
+      return [separator === -1 ? worktreeId : worktreeId.slice(separator + 2), worktreeId] as const
+    })
+  )
+  const remoteSession = importRemoteWorkspaceSession(snapshot.session, {
+    resolveWorktreeId: (worktreePath) => localByPath.get(worktreePath) ?? null
+  })
+  const current = buildWorkspaceSessionPayload(useAppStore.getState())
+  const merged = mergeRemoteWorkspaceSession(current, remoteSession, targetId)
+  const store = useAppStore.getState()
+  remoteWorkspaceSnapshotApplyDepth += 1
+  try {
+    store.hydrateWorkspaceSession(merged)
+    store.hydrateTabsSession(merged)
+    store.hydrateEditorSession(merged)
+    store.hydrateBrowserSession(merged)
+    store.markRemoteWorkspaceHydrated(targetId)
+    store.setRemoteWorkspaceSyncStatus(targetId, {
+      phase: 'synced',
+      direction: 'pull',
+      revision: snapshot.revision,
+      updatedAt: snapshot.updatedAt,
+      lastSyncedAt: Date.now(),
+      message: 'Workspace synced'
+    })
+    await useAppStore.getState().reconnectPersistedTerminals()
+  } finally {
+    // Why: remote terminal reattach can update pty ids and titles just after
+    // hydration. Those local side effects came from the remote snapshot and
+    // must not echo back as a fresh workspace revision.
+    remoteWorkspaceSnapshotWriteSuppressUntil =
+      Date.now() + REMOTE_WORKSPACE_SNAPSHOT_WRITE_SUPPRESS_MS
+    remoteWorkspaceSnapshotApplyDepth -= 1
+  }
+}
+
+async function syncRemoteWorkspaceAfterConnect(targetId: string): Promise<void> {
+  const store = useAppStore.getState()
+  if (store.sshTargetRemoteSyncEnabled.get(targetId) !== true) {
+    return
+  }
+  if (!(await prepareRemoteWorkspaceTarget(targetId))) {
+    store.setRemoteWorkspaceSyncStatus(targetId, {
+      phase: 'error',
+      direction: 'pull',
+      message: 'Workspace sync waited for local session hydration and timed out'
+    })
+    return
+  }
+  store.setRemoteWorkspaceSyncStatus(targetId, { phase: 'pulling', direction: 'pull' })
+  const worktreeIds = targetWorktreeIds(targetId)
+  const hasLocalTabs = Array.from(worktreeIds).some(
+    (worktreeId) => (useAppStore.getState().tabsByWorktree[worktreeId] ?? []).length > 0
+  )
+  const snapshot = await window.api.remoteWorkspace.get({ targetId })
+  if (!snapshot) {
+    useAppStore.getState().setRemoteWorkspaceSyncStatus(targetId, {
+      phase: 'offline',
+      direction: 'pull',
+      message: 'Remote workspace sync unavailable'
+    })
+    return
+  }
+  if (snapshot.revision > 0) {
+    await applyRemoteWorkspaceSnapshot(targetId, snapshot)
+    return
+  }
+
+  useAppStore.getState().markRemoteWorkspaceHydrated(targetId)
+  if (hasLocalTabs) {
+    // Why: first connect must read the relay before publishing local tabs.
+    // Otherwise a reconnecting device can overwrite a newer cross-device
+    // workspace snapshot with stale local renderer state.
+    const session = buildWorkspaceSessionPayload(useAppStore.getState())
+    const results = await window.api.remoteWorkspace.setForConnectedTargets({
+      session,
+      hydratedTargetIds: [targetId]
+    })
+    const result = results.find((entry) => entry.targetId === targetId)?.result
+    applyRemoteWorkspacePatchStatus(targetId, result)
+    if (result?.ok) {
+      useAppStore.getState().markRemoteWorkspaceHydrated(targetId)
+    }
+    return
+  }
+  useAppStore.getState().setRemoteWorkspaceSyncStatus(targetId, {
+    phase: 'idle',
+    revision: snapshot.revision,
+    updatedAt: snapshot.updatedAt,
+    message: 'No remote workspace yet'
+  })
+}
+
+function applyRemoteWorkspacePatchStatus(
+  targetId: string,
+  result: RemoteWorkspacePatchResult | undefined
+): void {
+  if (!result) {
+    useAppStore.getState().setRemoteWorkspaceSyncStatus(targetId, {
+      phase: 'offline',
+      direction: 'push',
+      lastSyncedAt: Date.now(),
+      message: 'Remote workspace sync unavailable'
+    })
+    return
+  }
+  if (result.ok) {
+    useAppStore.getState().setRemoteWorkspaceSyncStatus(targetId, {
+      phase: 'synced',
+      direction: 'push',
+      revision: result.snapshot.revision,
+      updatedAt: result.snapshot.updatedAt,
+      lastSyncedAt: Date.now(),
+      message: 'Workspace uploaded'
+    })
+    return
+  }
+  useAppStore.getState().setRemoteWorkspaceSyncStatus(targetId, {
+    phase: result.reason === 'stale-revision' ? 'conflict' : 'offline',
+    direction: 'push',
+    revision: result.snapshot?.revision,
+    updatedAt: result.snapshot?.updatedAt,
+    lastSyncedAt: Date.now(),
+    message:
+      result.message ??
+      (result.reason === 'stale-revision'
+        ? 'Workspace changed on another device'
+        : 'Remote workspace sync unavailable')
+  })
+}
 
 function isRuntimeEnvironmentActive(): boolean {
   return Boolean(useAppStore.getState().settings?.activeRuntimeEnvironmentId?.trim())
@@ -905,15 +1176,9 @@ export function useIpcEvents(): void {
     // reflect the correct connected/disconnected state on app launch.
     void (async () => {
       try {
-        const targets = (await window.api.ssh.listTargets()) as {
-          id: string
-          label: string
-        }[]
-        // Why: populate target labels map so WorktreeCard (and other components)
-        // can look up display labels without issuing per-card IPC calls.
-        const labels = new Map<string, string>()
+        const targets = await window.api.ssh.listTargets()
+        useAppStore.getState().setSshTargetsMetadata(targets)
         for (const target of targets) {
-          labels.set(target.id, target.label)
           const state = await window.api.ssh.getState({ targetId: target.id })
           if (state) {
             useAppStore.getState().setSshConnectionState(target.id, state as SshConnectionState)
@@ -934,10 +1199,17 @@ export function useIpcEvents(): void {
                 useAppStore.getState().setPortForwards(target.id, forwards)
                 useAppStore.getState().setDetectedPorts(target.id, detected)
               }
+              if (target.remoteWorkspaceSyncEnabled) {
+                void syncRemoteWorkspaceAfterConnect(target.id).catch((err) => {
+                  useAppStore.getState().setRemoteWorkspaceSyncStatus(target.id, {
+                    phase: 'error',
+                    message: err instanceof Error ? err.message : 'Workspace sync failed'
+                  })
+                })
+              }
             }
           }
         }
-        useAppStore.getState().setSshTargetLabels(labels)
       } catch {
         // SSH may not be configured
       }
@@ -980,11 +1252,7 @@ export function useIpcEvents(): void {
           window.api.ssh
             .listTargets()
             .then((targets) => {
-              const labels = new Map<string, string>()
-              for (const t of targets as { id: string; label: string }[]) {
-                labels.set(t.id, t.label)
-              }
-              useAppStore.getState().setSshTargetLabels(labels)
+              useAppStore.getState().setSshTargetsMetadata(targets)
             })
             .catch(() => {})
         }
@@ -1054,10 +1322,58 @@ export function useIpcEvents(): void {
                 }))
               }
             }
+            void syncRemoteWorkspaceAfterConnect(data.targetId).catch((err) => {
+              useAppStore.getState().setRemoteWorkspaceSyncStatus(data.targetId, {
+                phase: 'error',
+                message: err instanceof Error ? err.message : 'Workspace sync failed'
+              })
+            })
           })
         }
       })
     )
+
+    let remoteWorkspaceClientId: string | null = null
+    let remoteWorkspaceClientIdPromise: Promise<string | null> | null = null
+    const getRemoteWorkspaceClientId = (): Promise<string | null> => {
+      const remoteWorkspace = window.api.remoteWorkspace
+      if (!remoteWorkspace) {
+        return Promise.resolve(null)
+      }
+      if (remoteWorkspaceClientId) {
+        return Promise.resolve(remoteWorkspaceClientId)
+      }
+      remoteWorkspaceClientIdPromise ??= remoteWorkspace
+        .clientId()
+        .then((id) => {
+          remoteWorkspaceClientId = id
+          return id
+        })
+        .catch(() => null)
+      return remoteWorkspaceClientIdPromise
+    }
+    if (window.api.remoteWorkspace) {
+      void getRemoteWorkspaceClientId()
+      unsubs.push(
+        window.api.remoteWorkspace.onChanged((event) => {
+          void (async () => {
+            // Why: relay notifications can race the initial client-id IPC.
+            // Self-originated writes must never bounce back into restore.
+            const clientId = await getRemoteWorkspaceClientId()
+            if (event.sourceClientId && clientId && event.sourceClientId === clientId) {
+              return
+            }
+            await applyRemoteWorkspaceSnapshot(event.targetId, event.snapshot).catch((err) => {
+              useAppStore.getState().setRemoteWorkspaceSyncStatus(event.targetId, {
+                phase: 'error',
+                revision: event.snapshot.revision,
+                message: err instanceof Error ? err.message : 'Failed to apply remote workspace'
+              })
+            })
+          })()
+        })
+      )
+    }
 
     // Zoom handling for menu accelerators and keyboard fallback paths.
     unsubs.push(

--- a/src/renderer/src/hooks/useIssueMetadata.ts
+++ b/src/renderer/src/hooks/useIssueMetadata.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines -- Why: repo metadata hooks share TTL caches and
 Linear/GitHub cache invalidation entrypoints used by the issue dialog. */
 import { useEffect, useRef, useState } from 'react'
-import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
+import { getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
 import {
   linearTeamLabels,
   linearTeamMembers,
@@ -34,8 +34,7 @@ const ghAssigneeStore = createMetadataRequestStore<GitHubAssignableUser[]>()
 
 export function useRepoLabels(
   repoPath: string | null,
-  repoId?: string | null,
-  settings?: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null
+  repoId?: string | null
 ): MetadataState<string[]> {
   const [state, setState] = useState<MetadataState<string[]>>({
     data: [],
@@ -45,13 +44,10 @@ export function useRepoLabels(
   const activeKeyRef = useRef<string | null>(null)
 
   useEffect(() => {
-    const target = getActiveRuntimeTarget(settings)
-    if (!repoPath && !(target.kind === 'environment' && repoId)) {
+    if (!repoPath && !repoId) {
       return
     }
-    const cacheKey =
-      target.kind === 'environment' ? `runtime:${target.environmentId}:${repoId}` : (repoPath ?? '')
-
+    const cacheKey = repoId ?? repoPath ?? ''
     const cached = getFreshMetadata(ghLabelStore, cacheKey)
     if (cached) {
       if (activeKeyRef.current !== cacheKey) {
@@ -70,16 +66,9 @@ export function useRepoLabels(
       error: null
     }))
     loadMetadata(ghLabelStore, cacheKey, () =>
-      target.kind === 'environment'
-        ? callRuntimeRpc<string[]>(
-            target,
-            'github.listLabels',
-            { repo: repoId ?? '' },
-            { timeoutMs: 30_000 }
-          )
-        : window.api.gh
-            .listLabels({ repoPath: repoPath ?? '' })
-            .then((labels) => labels as string[])
+      window.api.gh
+        .listLabels({ repoPath: repoPath ?? '', repoId: repoId ?? undefined })
+        .then((labels) => labels as string[])
     )
       .then((data) => {
         if (activeKeyRef.current !== requestKey) {
@@ -98,15 +87,14 @@ export function useRepoLabels(
           error: err instanceof Error ? err.message : 'Failed to load labels'
         }))
       })
-  }, [repoId, repoPath, settings])
+  }, [repoPath, repoId])
 
   return state
 }
 
 export function useRepoAssignees(
   repoPath: string | null,
-  repoId?: string | null,
-  settings?: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null
+  repoId?: string | null
 ): MetadataState<GitHubAssignableUser[]> {
   const [state, setState] = useState<MetadataState<GitHubAssignableUser[]>>({
     data: [],
@@ -116,13 +104,10 @@ export function useRepoAssignees(
   const activeKeyRef = useRef<string | null>(null)
 
   useEffect(() => {
-    const target = getActiveRuntimeTarget(settings)
-    if (!repoPath && !(target.kind === 'environment' && repoId)) {
+    if (!repoPath && !repoId) {
       return
     }
-    const cacheKey =
-      target.kind === 'environment' ? `runtime:${target.environmentId}:${repoId}` : (repoPath ?? '')
-
+    const cacheKey = repoId ?? repoPath ?? ''
     const cached = getFreshMetadata(ghAssigneeStore, cacheKey)
     if (cached) {
       if (activeKeyRef.current !== cacheKey) {
@@ -141,16 +126,9 @@ export function useRepoAssignees(
       error: null
     }))
     loadMetadata(ghAssigneeStore, cacheKey, () =>
-      target.kind === 'environment'
-        ? callRuntimeRpc<GitHubAssignableUser[]>(
-            target,
-            'github.listAssignableUsers',
-            { repo: repoId ?? '' },
-            { timeoutMs: 30_000 }
-          )
-        : window.api.gh
-            .listAssignableUsers({ repoPath: repoPath ?? '' })
-            .then((users) => users as GitHubAssignableUser[])
+      window.api.gh
+        .listAssignableUsers({ repoPath: repoPath ?? '', repoId: repoId ?? undefined })
+        .then((users) => users as GitHubAssignableUser[])
     )
       .then((data) => {
         if (activeKeyRef.current !== requestKey) {
@@ -169,7 +147,7 @@ export function useRepoAssignees(
           error: err instanceof Error ? err.message : 'Failed to load assignees'
         }))
       })
-  }, [repoId, repoPath, settings])
+  }, [repoPath, repoId])
 
   return state
 }

--- a/src/renderer/src/lib/launch-work-item-direct.ts
+++ b/src/renderer/src/lib/launch-work-item-direct.ts
@@ -223,26 +223,13 @@ export async function launchWorkItemDirect(args: LaunchWorkItemDirectArgs): Prom
       telemetrySource,
       item.title,
       item.type === 'issue' && item.number ? item.number : undefined,
-      item.type === 'pr' && item.number ? item.number : undefined
+      item.type === 'pr' && item.number ? item.number : undefined,
+      undefined,
+      undefined,
+      item.linearIdentifier
     )
     worktreeId = result.worktree.id
     const worktreePath = result.worktree.path
-    const meta: {
-      linkedLinearIssue?: string
-    } = {}
-    if (item.linearIdentifier) {
-      meta.linkedLinearIssue = item.linearIdentifier
-    }
-    if (Object.keys(meta).length > 0) {
-      // Why: Project direct-launch activates the new workspace immediately.
-      // GitHub issue/PR links are persisted during create; Linear metadata
-      // still uses a best-effort follow-up because create args do not carry it.
-      // Best-effort: the worktree is already created on disk, so a meta
-      // write failure must not abort activation and orphan it.
-      void store.updateWorktreeMeta(worktreeId, meta).catch(() => {
-        // Non-critical: continue into activation without the link metadata.
-      })
-    }
 
     const detectedIds = new Set(await detectedAgentsPromise)
     effectiveAgent = pickAgent(settings?.defaultTuiAgent, detectedIds)

--- a/src/renderer/src/lib/new-workspace.ts
+++ b/src/renderer/src/lib/new-workspace.ts
@@ -49,6 +49,9 @@ export type LinkedWorkItemSummary = {
   number: number
   title: string
   url: string
+  /** Linear identifier (for example ENG-123) when this linked item came from
+   *  Linear rather than GitHub. */
+  linearIdentifier?: string
 }
 
 // Why: when a repo has no `orca.yaml` issueCommand and no per-user override,

--- a/src/renderer/src/lib/repo-slug-index.ts
+++ b/src/renderer/src/lib/repo-slug-index.ts
@@ -1,7 +1,7 @@
 // Why: Project mode rows carry a GitHub `owner/repo` slug, but Orca's
 // `state.repos` stores only absolute paths. Before any repo-context action
 // (opening the item dialog in repo-backed mode, launching a worktree) can
-// dispatch correctly, we need a renderer-side index mapping slug → Repo.
+// dispatch correctly, we need a renderer-side index mapping slug → Repo[].
 //
 // The index is built lazily from `window.api.gh.repoSlug({ repoPath })` —
 // the main-process resolver that reads `git remote` and classifies the
@@ -19,11 +19,11 @@ import type { Repo } from '../../../shared/types'
 import type { GlobalSettings } from '../../../shared/types'
 import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
 
-/** Lowercased `owner/repo` → Repo. Case folded because GitHub treats slugs
+/** Lowercased `owner/repo` → Repo[]. Case folded because GitHub treats slugs
  *  case-insensitively but displays the canonical casing; the lookup side
  *  uses the row's `content.repository` which may or may not match the
  *  canonical casing depending on when the project item was indexed. */
-type SlugIndex = Map<string, Repo>
+type SlugIndex = Map<string, Repo[]>
 
 /** Module-scope cache keyed by runtime scope + repo.id. A Repo that has already failed
  *  resolution is not retried on re-mount; the value in the map is `null`
@@ -73,7 +73,7 @@ async function resolveRepoSlug(
             { repo: repo.id },
             { timeoutMs: 30_000 }
           )
-        : await window.api.gh.repoSlug({ repoPath: repo.path })
+        : await window.api.gh.repoSlug({ repoPath: repo.path, repoId: repo.id })
     if (!result) {
       slugByRepoId.set(cacheKey, null)
       return null
@@ -109,16 +109,16 @@ async function buildIndex(
   )
   for (const { repo, slug } of results) {
     if (slug) {
-      next.set(slug, repo)
+      next.set(slug, [...(next.get(slug) ?? []), repo])
     }
   }
   return next
 }
 
-/** Returns a lookup function `(slug) => Repo | null`. The lookup is stable
+/** Returns a lookup function `(slug) => Repo[]`. The lookup is stable
  *  across renders until `state.repos` changes; callers in deep trees can
  *  treat it as referentially equal inside a single render cycle. */
-export function useRepoSlugIndex(): (slug: string | null | undefined) => Repo | null {
+export function useRepoSlugIndex(): (slug: string | null | undefined) => Repo[] {
   const repos = useAppStore((s) => s.repos)
   const settings = useAppStore((s) => s.settings)
   const [index, setIndex] = useState<SlugIndex>(() => new Map())
@@ -138,11 +138,11 @@ export function useRepoSlugIndex(): (slug: string | null | undefined) => Repo | 
 
   return useMemo(
     () =>
-      (slug: string | null | undefined): Repo | null => {
+      (slug: string | null | undefined): Repo[] => {
         if (!slug) {
-          return null
+          return []
         }
-        return index.get(slug.toLowerCase()) ?? null
+        return index.get(slug.toLowerCase()) ?? []
       },
     [index]
   )

--- a/src/renderer/src/lib/session-write-subscriber.test.ts
+++ b/src/renderer/src/lib/session-write-subscriber.test.ts
@@ -112,6 +112,45 @@ describe('createSessionWriteSubscriber', () => {
     cleanup()
   })
 
+  it('updates its baseline without scheduling when shouldSchedulePersist returns false', () => {
+    const persist = vi.fn<(payload: WorkspaceSessionState) => void>()
+    let shouldSchedule = false
+    const cleanup = createSessionWriteSubscriber({
+      store: useAppStore,
+      persist,
+      shouldSchedulePersist: () => shouldSchedule
+    })
+
+    useAppStore.setState({ workspaceSessionReady: true, hydrationSucceeded: true })
+    vi.advanceTimersByTime(200)
+    expect(persist).not.toHaveBeenCalled()
+
+    shouldSchedule = true
+    useAppStore.setState({ activeTabId: 'tab-1' })
+    vi.advanceTimersByTime(200)
+    expect(persist).toHaveBeenCalledTimes(1)
+    cleanup()
+  })
+
+  it('cancels a pending debounce when shouldSchedulePersist returns false', () => {
+    const persist = vi.fn<(payload: WorkspaceSessionState) => void>()
+    let shouldSchedule = true
+    const cleanup = createSessionWriteSubscriber({
+      store: useAppStore,
+      persist,
+      shouldSchedulePersist: () => shouldSchedule
+    })
+
+    useAppStore.setState({ workspaceSessionReady: true })
+    vi.advanceTimersByTime(50)
+    shouldSchedule = false
+    useAppStore.setState({ activeTabId: 'remote-tab' })
+    vi.advanceTimersByTime(200)
+
+    expect(persist).not.toHaveBeenCalled()
+    cleanup()
+  })
+
   it('coalesces multiple relevant mutations within a debounce window', () => {
     const persist = vi.fn<(payload: WorkspaceSessionState) => void>()
     const cleanup = createSessionWriteSubscriber({ store: useAppStore, persist })

--- a/src/renderer/src/lib/session-write-subscriber.ts
+++ b/src/renderer/src/lib/session-write-subscriber.ts
@@ -12,6 +12,7 @@ export type SessionWriteSubscriberDeps = {
     getState: () => AppState
   }
   persist: (payload: WorkspaceSessionState) => void
+  shouldSchedulePersist?: () => boolean
   debounceMs?: number
 }
 
@@ -24,6 +25,7 @@ export type SessionWriteSubscriberDeps = {
 export function createSessionWriteSubscriber({
   store,
   persist,
+  shouldSchedulePersist,
   debounceMs = 150
 }: SessionWriteSubscriberDeps): () => void {
   let timer: ReturnType<typeof setTimeout> | null = null
@@ -59,6 +61,13 @@ export function createSessionWriteSubscriber({
       next[key] = state[key]
     }
     prev = next
+    if (shouldSchedulePersist && !shouldSchedulePersist()) {
+      if (timer !== null) {
+        clearTimeout(timer)
+        timer = null
+      }
+      return
+    }
     if (timer !== null) {
       clearTimeout(timer)
     }

--- a/src/renderer/src/store/slices/github.test.ts
+++ b/src/renderer/src/store/slices/github.test.ts
@@ -309,7 +309,7 @@ describe('createGitHubSlice.fetchWorkItems source/error envelope', () => {
 
     await store.getState().fetchWorkItems('repo-id', '/repo', 24, '')
 
-    const result = store.getState().getWorkItemsSourcesAndError('/repo', 24, '')
+    const result = store.getState().getWorkItemsSourcesAndError('repo-id', 24, '')
     expect(result.sources).toEqual({
       issues: { owner: 'up', repo: 'r' },
       prs: { owner: 'fork', repo: 'r' }
@@ -333,7 +333,7 @@ describe('createGitHubSlice.fetchWorkItems source/error envelope', () => {
 
     await store.getState().fetchWorkItems('repo-id', '/repo', 24, '')
 
-    const result = store.getState().getWorkItemsSourcesAndError('/repo', 24, '')
+    const result = store.getState().getWorkItemsSourcesAndError('repo-id', 24, '')
     expect(result.error).toMatchObject({
       type: 'permission_denied',
       message: 'no access',
@@ -369,11 +369,11 @@ describe('createGitHubSlice.fetchWorkItems source/error envelope', () => {
     await forcedFetch
 
     expect(mockApi.gh.listWorkItems).toHaveBeenCalledTimes(2)
-    const after = store.getState().getWorkItemsSourcesAndError('/repo', 24, '')
+    const after = store.getState().getWorkItemsSourcesAndError('repo-id', 24, '')
     expect(after.error).toBeNull()
   })
 
-  it('routes work item fetches through the active runtime environment', async () => {
+  it('routes work item fetches through repo-scoped IPC even when a runtime is active', async () => {
     const store = createTestStore()
     store.setState({
       settings: { activeRuntimeEnvironmentId: 'env-1' },
@@ -387,26 +387,21 @@ describe('createGitHubSlice.fetchWorkItems source/error envelope', () => {
         }
       ]
     } as Partial<AppState>)
-    runtimeEnvironmentCall.mockResolvedValueOnce({
-      id: 'rpc-1',
-      ok: true,
-      result: {
-        items: [{ type: 'issue', number: 7, title: 'Server issue', url: 'https://example.test/7' }],
-        sources: { issues: { owner: 'up', repo: 'r' }, prs: { owner: 'up', repo: 'r' } }
-      },
-      _meta: { runtimeId: 'remote-runtime' }
+    mockApi.gh.listWorkItems.mockResolvedValueOnce({
+      items: [{ type: 'issue', number: 7, title: 'Server issue', url: 'https://example.test/7' }],
+      sources: { issues: { owner: 'up', repo: 'r' }, prs: { owner: 'up', repo: 'r' } }
     })
 
     await store.getState().fetchWorkItems('repo-id', '/server/repo', 24, '')
 
-    expect(mockApi.gh.listWorkItems).not.toHaveBeenCalled()
-    expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
-      selector: 'env-1',
-      method: 'github.listWorkItems',
-      params: { repo: 'repo-id', limit: 24, query: undefined },
-      timeoutMs: 30_000
+    expect(runtimeEnvironmentCall).not.toHaveBeenCalled()
+    expect(mockApi.gh.listWorkItems).toHaveBeenCalledWith({
+      repoPath: '/server/repo',
+      repoId: 'repo-id',
+      limit: 24,
+      query: undefined
     })
-    expect(store.getState().workItemsCache['/server/repo::24::'].data?.[0]).toMatchObject({
+    expect(store.getState().workItemsCache['repo-id::24::'].data?.[0]).toMatchObject({
       repoId: 'repo-id',
       number: 7
     })

--- a/src/renderer/src/store/slices/github.ts
+++ b/src/renderer/src/store/slices/github.ts
@@ -11,7 +11,6 @@ import type {
   IssueInfo,
   PRCheckDetail,
   PRComment,
-  Repo,
   Worktree,
   GitHubWorkItem
 } from '../../../../shared/types'
@@ -77,18 +76,6 @@ function queryOverrideKeyPart(queryOverride: string | undefined): string {
     return ''
   }
   return `:q=${queryOverride}`
-}
-
-function getRuntimeRepoTarget(
-  state: AppState,
-  repoPath: string
-): { target: { kind: 'environment'; environmentId: string }; repo: Repo } | null {
-  const target = getActiveRuntimeTarget(state.settings)
-  if (target.kind !== 'environment') {
-    return null
-  }
-  const repo = state.repos.find((candidate) => candidate.path === repoPath)
-  return repo ? { target, repo } : null
 }
 
 export function projectViewCacheKey(
@@ -302,6 +289,10 @@ type FetchOptions = {
   force?: boolean
 }
 
+type RepoScopedFetchOptions = FetchOptions & {
+  repoId?: string
+}
+
 const CACHE_TTL = 300_000 // 5 minutes (stale data shown instantly, then refreshed)
 const CHECKS_CACHE_TTL = 60_000 // 1 minute — checks change more frequently
 // Why: the NewWorkspace page's work-item list is a browse surface, not a
@@ -356,8 +347,12 @@ function releaseWorkItemSlot(): void {
   workItemFetchInFlight -= 1
 }
 
-export function workItemsCacheKey(repoPath: string, limit: number, query: string): string {
-  return `${repoPath}::${limit}::${query}`
+export function workItemsCacheKey(repoId: string, limit: number, query: string): string {
+  return `${repoId}::${limit}::${query}`
+}
+
+function repoScopedCacheKey(repoPath: string, repoId: string | undefined, suffix: string): string {
+  return `${repoId ?? repoPath}::${suffix}`
 }
 
 // Why: 500 entries is generous enough that active developers will never hit it
@@ -414,33 +409,39 @@ export type GitHubSlice = {
   issueCache: Record<string, CacheEntry<IssueInfo>>
   checksCache: Record<string, CacheEntry<PRCheckDetail[]>>
   commentsCache: Record<string, CacheEntry<PRComment[]>>
-  // Why: keyed by repoPath + limit + query so the NewWorkspace page can render
+  // Why: keyed by repoId + limit + query so remote repos with the same path on
+  // different SSH targets do not share issue/PR results.
   // from cache instantly on mount (and on hover-prefetch from sidebar buttons)
   // while a background refresh keeps the list fresh.
   workItemsCache: Record<string, CacheEntry<GitHubWorkItem[]>>
   fetchPRForBranch: (
     repoPath: string,
     branch: string,
-    options?: FetchOptions & { linkedPRNumber?: number | null }
+    options?: RepoScopedFetchOptions & { linkedPRNumber?: number | null }
   ) => Promise<PRInfo | null>
-  fetchIssue: (repoPath: string, number: number) => Promise<IssueInfo | null>
+  fetchIssue: (
+    repoPath: string,
+    number: number,
+    options?: RepoScopedFetchOptions
+  ) => Promise<IssueInfo | null>
   fetchPRChecks: (
     repoPath: string,
     prNumber: number,
     branch?: string,
     headSha?: string,
-    options?: FetchOptions
+    options?: RepoScopedFetchOptions
   ) => Promise<PRCheckDetail[]>
   fetchPRComments: (
     repoPath: string,
     prNumber: number,
-    options?: FetchOptions
+    options?: RepoScopedFetchOptions
   ) => Promise<PRComment[]>
   resolveReviewThread: (
     repoPath: string,
     prNumber: number,
     threadId: string,
-    resolve: boolean
+    resolve: boolean,
+    options?: RepoScopedFetchOptions
   ) => Promise<boolean>
   initGitHubCache: () => Promise<void>
   refreshAllGitHub: () => void
@@ -451,7 +452,7 @@ export type GitHubSlice = {
    * background refresh when stale. Callers can render the cached list while
    * the SWR revalidate hydrates the latest.
    */
-  getCachedWorkItems: (repoPath: string, limit: number, query: string) => GitHubWorkItem[] | null
+  getCachedWorkItems: (repoId: string, limit: number, query: string) => GitHubWorkItem[] | null
   /**
    * Why: the Tasks view header reads sources from the cache to render the
    * "Issues from owner/repo" indicator, and the Tasks empty/partial banner
@@ -461,7 +462,7 @@ export type GitHubSlice = {
    * through the equality check.
    */
   getWorkItemsSourcesAndError: (
-    repoPath: string,
+    repoId: string,
     limit: number,
     query: string
   ) => { sources: WorkItemsCacheSources | null; error: WorkItemsCacheError | null }
@@ -480,7 +481,7 @@ export type GitHubSlice = {
    * mutated) on every write, so reference equality is preserved between
    * unchanged entries.
    */
-  getWorkItemsAnySourcesForRepo: (repoPath: string, limit: number) => WorkItemsCacheSources | null
+  getWorkItemsAnySourcesForRepo: (repoId: string, limit: number) => WorkItemsCacheSources | null
   fetchWorkItems: (
     repoId: string,
     repoPath: string,
@@ -518,7 +519,10 @@ export type GitHubSlice = {
    * Count total work items across repos using GitHub's search API.
    * Returns the sum of per-repo counts for the given query.
    */
-  countWorkItemsAcrossRepos: (repos: { path: string }[], query: string) => Promise<number>
+  countWorkItemsAcrossRepos: (
+    repos: { repoId: string; path: string }[],
+    query: string
+  ) => Promise<number>
   /**
    * Fire-and-forget prefetch used by UI entry points (hover/focus of the
    * "new workspace" buttons) to warm the cache before the page mounts.
@@ -537,9 +541,9 @@ export type GitHubSlice = {
   /**
    * Persist a per-repo issue-source preference, update the local Repo record
    * for reactive UI, and invalidate all cached work-items entries that key
-   * off this repo's path so the Tasks list re-fetches against the new source.
+   * off this repo's identity so the Tasks list re-fetches against the new source.
    *
-   * Why invalidate all `${repoPath}::*` keys and not only the primary entry:
+   * Why invalidate all `${repoId}::*` keys and not only the primary entry:
    * preferences flip the issue source for every list query (query-less +
    * user-entered queries alike). Surgical eviction of the primary key alone
    * would leave stale results in alternate-query cache lines.
@@ -1032,13 +1036,13 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
     applyRowPatch(set, cacheKey, rowId, nextRow)
   },
 
-  getCachedWorkItems: (repoPath, limit, query) => {
-    const key = workItemsCacheKey(repoPath, limit, query)
+  getCachedWorkItems: (repoId, limit, query) => {
+    const key = workItemsCacheKey(repoId, limit, query)
     return get().workItemsCache[key]?.data ?? null
   },
 
-  getWorkItemsSourcesAndError: (repoPath, limit, query) => {
-    const key = workItemsCacheKey(repoPath, limit, query)
+  getWorkItemsSourcesAndError: (repoId, limit, query) => {
+    const key = workItemsCacheKey(repoId, limit, query)
     const entry = get().workItemsCache[key]
     return {
       sources: entry?.sources ?? null,
@@ -1046,14 +1050,14 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
     }
   },
 
-  getWorkItemsAnySourcesForRepo: (repoPath, limit) => {
+  getWorkItemsAnySourcesForRepo: (repoId, limit) => {
     const cache = get().workItemsCache
-    const primaryKey = workItemsCacheKey(repoPath, limit, '')
+    const primaryKey = workItemsCacheKey(repoId, limit, '')
     const primary = cache[primaryKey]?.sources
     if (primary) {
       return primary
     }
-    const prefix = `${repoPath}::`
+    const prefix = `${repoId}::`
     for (const [key, entry] of Object.entries(cache)) {
       if (key.startsWith(prefix) && entry.sources) {
         return entry.sources
@@ -1063,7 +1067,7 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
   },
 
   fetchWorkItems: async (repoId, repoPath, limit, query, options): Promise<GitHubWorkItem[]> => {
-    const key = workItemsCacheKey(repoPath, limit, query)
+    const key = workItemsCacheKey(repoId, limit, query)
     const cached = get().workItemsCache[key]
     if (!options?.force && isFresh(cached, WORK_ITEMS_CACHE_TTL)) {
       return cached.data ?? []
@@ -1087,19 +1091,12 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
     const request = (async () => {
       await acquireWorkItemSlot()
       try {
-        const runtimeRepo = getRuntimeRepoTarget(get(), repoPath)
-        const envelope = runtimeRepo
-          ? await callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.listWorkItems>>>(
-              runtimeRepo.target,
-              'github.listWorkItems',
-              { repo: runtimeRepo.repo.id, limit, query: query || undefined },
-              { timeoutMs: 30_000 }
-            )
-          : await window.api.gh.listWorkItems({
-              repoPath,
-              limit,
-              query: query || undefined
-            })
+        const envelope = await window.api.gh.listWorkItems({
+          repoPath,
+          repoId,
+          limit,
+          query: query || undefined
+        })
         // Why: stamp repoId at the renderer fetch boundary so every downstream
         // consumer (cross-repo merge, row rendering, drawer) can rely on the
         // field being present. Main doesn't know Orca's Repo.id.
@@ -1168,7 +1165,7 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
           // nothing at all to contribute.
           // Why: must use perRepoLimit (not displayLimit) so the cache key
           // matches what fetchWorkItems wrote.
-          const key = workItemsCacheKey(r.path, perRepoLimit, query)
+          const key = workItemsCacheKey(r.repoId, perRepoLimit, query)
           const cached = get().workItemsCache[key]?.data
           if (cached) {
             console.warn(`[workItems] ${r.repoId} failed, serving cached:`, err)
@@ -1190,25 +1187,13 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
       repos.map(async (r) => {
         await acquireWorkItemSlot()
         try {
-          const runtimeRepo = getRuntimeRepoTarget(get(), r.path)
-          const envelope = runtimeRepo
-            ? await callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.listWorkItems>>>(
-                runtimeRepo.target,
-                'github.listWorkItems',
-                {
-                  repo: runtimeRepo.repo.id,
-                  limit: perRepoLimit,
-                  query: query || undefined,
-                  before
-                },
-                { timeoutMs: 30_000 }
-              )
-            : await window.api.gh.listWorkItems({
-                repoPath: r.path,
-                limit: perRepoLimit,
-                query: query || undefined,
-                before
-              })
+          const envelope = await window.api.gh.listWorkItems({
+            repoPath: r.path,
+            repoId: r.repoId,
+            limit: perRepoLimit,
+            query: query || undefined,
+            before
+          })
           // Why: page-N partial failures don't participate in the cache's per-repo
           // error banner (which is keyed on the initial-fetch cache entry). Log the
           // classified issues-side error so pagination failures are at least
@@ -1240,18 +1225,11 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
     const counts = await Promise.all(
       repos.map(async (r) => {
         try {
-          const runtimeRepo = getRuntimeRepoTarget(get(), r.path)
-          return runtimeRepo
-            ? await callRuntimeRpc<number>(
-                runtimeRepo.target,
-                'github.countWorkItems',
-                { repo: runtimeRepo.repo.id, query: query || undefined },
-                { timeoutMs: 30_000 }
-              )
-            : await window.api.gh.countWorkItems({
-                repoPath: r.path,
-                query: query || undefined
-              })
+          return await window.api.gh.countWorkItems({
+            repoPath: r.path,
+            repoId: r.repoId,
+            query: query || undefined
+          })
         } catch {
           return 0
         }
@@ -1261,7 +1239,7 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
   },
 
   prefetchWorkItems: (repoId, repoPath, limit = PER_REPO_FETCH_LIMIT, query = '') => {
-    const key = workItemsCacheKey(repoPath, limit, query)
+    const key = workItemsCacheKey(repoId, limit, query)
     const cached = get().workItemsCache[key]
     // Skip when the cache is fresh or a request is already in flight.
     if (isFresh(cached, WORK_ITEMS_CACHE_TTL) || inflightWorkItemsRequests.has(key)) {
@@ -1287,7 +1265,8 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
   },
 
   fetchPRForBranch: async (repoPath, branch, options): Promise<PRInfo | null> => {
-    const cacheKey = `${repoPath}::${branch}`
+    const repoId = options?.repoId ?? get().repos?.find((repo) => repo.path === repoPath)?.id
+    const cacheKey = repoScopedCacheKey(repoPath, repoId, branch)
     const cached = get().prCache[cacheKey]
     // Why: if a prior caller without a linkedPR cached `null` for this branch,
     // the worktree-card lookup (which has a linked PR fallback) would otherwise
@@ -1309,15 +1288,7 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
     const linkedPRNumber = options?.linkedPRNumber ?? null
     const request = (async () => {
       try {
-        const runtimeRepo = getRuntimeRepoTarget(get(), repoPath)
-        const pr = runtimeRepo
-          ? await callRuntimeRpc<PRInfo | null>(
-              runtimeRepo.target,
-              'github.prForBranch',
-              { repo: runtimeRepo.repo.id, branch, linkedPRNumber },
-              { timeoutMs: 30_000 }
-            )
-          : await window.api.gh.prForBranch({ repoPath, branch, linkedPRNumber })
+        const pr = await window.api.gh.prForBranch({ repoPath, repoId, branch, linkedPRNumber })
         if (prRequestGenerations.get(cacheKey) === generation) {
           set((s) => ({
             prCache: { ...s.prCache, [cacheKey]: { data: pr, fetchedAt: Date.now() } }
@@ -1350,8 +1321,9 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
     return request
   },
 
-  fetchIssue: async (repoPath, number) => {
-    const cacheKey = `${repoPath}::${number}`
+  fetchIssue: async (repoPath, number, options) => {
+    const repoId = options?.repoId ?? get().repos?.find((repo) => repo.path === repoPath)?.id
+    const cacheKey = repoScopedCacheKey(repoPath, repoId, String(number))
     const cached = get().issueCache[cacheKey]
     if (isFresh(cached)) {
       return cached.data
@@ -1364,15 +1336,7 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
 
     const request = (async () => {
       try {
-        const runtimeRepo = getRuntimeRepoTarget(get(), repoPath)
-        const issue = runtimeRepo
-          ? await callRuntimeRpc<IssueInfo | null>(
-              runtimeRepo.target,
-              'github.issue',
-              { repo: runtimeRepo.repo.id, number },
-              { timeoutMs: 30_000 }
-            )
-          : await window.api.gh.issue({ repoPath, number })
+        const issue = await window.api.gh.issue({ repoPath, repoId, number })
         set((s) => ({
           issueCache: { ...s.issueCache, [cacheKey]: { data: issue, fetchedAt: Date.now() } }
         }))
@@ -1395,7 +1359,8 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
   },
 
   fetchPRChecks: async (repoPath, prNumber, branch, headSha, options): Promise<PRCheckDetail[]> => {
-    const cacheKey = `${repoPath}::pr-checks::${prNumber}`
+    const repoId = options?.repoId ?? get().repos?.find((repo) => repo.path === repoPath)?.id
+    const cacheKey = repoScopedCacheKey(repoPath, repoId, `pr-checks::${prNumber}`)
     const cached = get().checksCache[cacheKey]
     if (!options?.force && isFresh(cached, CHECKS_CACHE_TTL)) {
       const cachedChecks = cached.data ?? []
@@ -1414,20 +1379,13 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
 
     const request = (async () => {
       try {
-        const runtimeRepo = getRuntimeRepoTarget(get(), repoPath)
-        const checks = runtimeRepo
-          ? await callRuntimeRpc<PRCheckDetail[]>(
-              runtimeRepo.target,
-              'github.prChecks',
-              { repo: runtimeRepo.repo.id, prNumber, headSha, noCache: options?.force },
-              { timeoutMs: 30_000 }
-            )
-          : ((await window.api.gh.prChecks({
-              repoPath,
-              prNumber,
-              headSha,
-              noCache: options?.force
-            })) as PRCheckDetail[])
+        const checks = (await window.api.gh.prChecks({
+          repoPath,
+          repoId,
+          prNumber,
+          headSha,
+          noCache: options?.force
+        })) as PRCheckDetail[]
         set((s) => {
           const nextState: Partial<AppState> = {
             checksCache: { ...s.checksCache, [cacheKey]: { data: checks, fetchedAt: Date.now() } }
@@ -1455,7 +1413,8 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
   },
 
   fetchPRComments: async (repoPath, prNumber, options): Promise<PRComment[]> => {
-    const cacheKey = `${repoPath}::pr-comments::${prNumber}`
+    const repoId = options?.repoId ?? get().repos?.find((repo) => repo.path === repoPath)?.id
+    const cacheKey = repoScopedCacheKey(repoPath, repoId, `pr-comments::${prNumber}`)
     const cached = get().commentsCache[cacheKey]
     if (!options?.force && isFresh(cached)) {
       return cached.data ?? []
@@ -1468,19 +1427,12 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
 
     const request = (async () => {
       try {
-        const runtimeRepo = getRuntimeRepoTarget(get(), repoPath)
-        const comments = runtimeRepo
-          ? await callRuntimeRpc<PRComment[]>(
-              runtimeRepo.target,
-              'github.prComments',
-              { repo: runtimeRepo.repo.id, prNumber, noCache: options?.force },
-              { timeoutMs: 30_000 }
-            )
-          : ((await window.api.gh.prComments({
-              repoPath,
-              prNumber,
-              noCache: options?.force
-            })) as PRComment[])
+        const comments = (await window.api.gh.prComments({
+          repoPath,
+          repoId,
+          prNumber,
+          noCache: options?.force
+        })) as PRComment[]
         set((s) => ({
           commentsCache: {
             ...s.commentsCache,
@@ -1500,8 +1452,9 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
     return request
   },
 
-  resolveReviewThread: async (repoPath, prNumber, threadId, resolve) => {
-    const cacheKey = `${repoPath}::pr-comments::${prNumber}`
+  resolveReviewThread: async (repoPath, prNumber, threadId, resolve, options) => {
+    const repoId = options?.repoId ?? get().repos?.find((repo) => repo.path === repoPath)?.id
+    const cacheKey = repoScopedCacheKey(repoPath, repoId, `pr-comments::${prNumber}`)
 
     // Optimistic update: toggle isResolved on all comments in this thread immediately
     // so the UI feels instant. Reverts if the API call fails.
@@ -1518,15 +1471,7 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
       }))
     }
 
-    const runtimeRepo = getRuntimeRepoTarget(get(), repoPath)
-    const ok = runtimeRepo
-      ? await callRuntimeRpc<boolean>(
-          runtimeRepo.target,
-          'github.resolveReviewThread',
-          { repo: runtimeRepo.repo.id, threadId, resolve },
-          { timeoutMs: 30_000 }
-        )
-      : await window.api.gh.resolveReviewThread({ repoPath, threadId, resolve })
+    const ok = await window.api.gh.resolveReviewThread({ repoPath, repoId, threadId, resolve })
     if (!ok && prev) {
       // Revert optimistic update on failure
       set((s) => ({
@@ -1571,17 +1516,17 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
 
         const branch = wt.branch.replace(/^refs\/heads\//, '')
         if (!wt.isBare && branch) {
-          const prKey = `${repo.path}::${branch}`
+          const prKey = repoScopedCacheKey(repo.path, repo.id, branch)
           const prEntry = state.prCache[prKey]
           if (!prEntry || now - prEntry.fetchedAt >= CACHE_TTL) {
-            void get().fetchPRForBranch(repo.path, branch)
+            void get().fetchPRForBranch(repo.path, branch, { repoId: repo.id })
           }
         }
         if (wt.linkedIssue) {
-          const issueKey = `${repo.path}::${wt.linkedIssue}`
+          const issueKey = repoScopedCacheKey(repo.path, repo.id, String(wt.linkedIssue))
           const issueEntry = state.issueCache[issueKey]
           if (!issueEntry || now - issueEntry.fetchedAt >= CACHE_TTL) {
-            void get().fetchIssue(repo.path, wt.linkedIssue)
+            void get().fetchIssue(repo.path, wt.linkedIssue, { repoId: repo.id })
           }
         }
       }
@@ -1608,8 +1553,10 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
 
     // Invalidate this worktree's cache entries
     const branch = worktree.branch.replace(/^refs\/heads\//, '')
-    const prKey = `${repo.path}::${branch}`
-    const issueKey = worktree.linkedIssue ? `${repo.path}::${worktree.linkedIssue}` : ''
+    const prKey = repoScopedCacheKey(repo.path, repo.id, branch)
+    const issueKey = worktree.linkedIssue
+      ? repoScopedCacheKey(repo.path, repo.id, String(worktree.linkedIssue))
+      : ''
 
     set((s) => {
       const updates: Partial<AppState> = {}
@@ -1627,10 +1574,10 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
 
     // Re-fetch (skip when branch is empty — detached HEAD during rebase)
     if (!worktree.isBare && branch) {
-      void get().fetchPRForBranch(repo.path, branch, { force: true })
+      void get().fetchPRForBranch(repo.path, branch, { force: true, repoId: repo.id })
     }
     if (worktree.linkedIssue) {
-      void get().fetchIssue(repo.path, worktree.linkedIssue)
+      void get().fetchIssue(repo.path, worktree.linkedIssue, { repoId: repo.id })
     }
   },
 
@@ -1704,22 +1651,22 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
     // first makes the "new fetch gets a fresh request" invariant impossible
     // to trip on later refactors that change zustand or React flush timing.
     for (const key of Array.from(inflightWorkItemsRequests.keys())) {
-      if (key.startsWith(`${repoPath}::`)) {
+      if (key.startsWith(`${repoId}::`) || key.startsWith(`${repoPath}::`)) {
         inflightWorkItemsRequests.delete(key)
       }
     }
-    // Why: evict every cache entry keyed on this repo's path AFTER the IPC
+    // Why: evict every cache entry keyed on this repo AFTER the IPC
     // resolves. If we evicted before awaiting, an overlapping fetch triggered
     // by a different subscriber would hit main with the pre-flip persisted
     // preference and repopulate the cache with stale-source data. Work-items
-    // cache keys are `${repoPath}::${limit}::${query}` so we can't selectively
-    // invalidate by query — the preference change affects all queries against
-    // this repo.
+    // cache keys are repo-scoped, but we also drop legacy path-scoped entries
+    // that may have been restored from older persisted cache data.
     set((s) => {
-      const prefix = `${repoPath}::`
+      const prefix = `${repoId}::`
+      const legacyPrefix = `${repoPath}::`
       const next: Record<string, CacheEntry<GitHubWorkItem[]>> = {}
       for (const [key, entry] of Object.entries(s.workItemsCache)) {
-        if (!key.startsWith(prefix)) {
+        if (!key.startsWith(prefix) && !key.startsWith(legacyPrefix)) {
           next[key] = entry
         }
       }
@@ -1755,19 +1702,19 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
 
     const now = Date.now()
     const branch = worktree.branch.replace(/^refs\/heads\//, '')
-    const prKey = `${repo.path}::${branch}`
+    const prKey = repoScopedCacheKey(repo.path, repo.id, branch)
     const prEntry = state.prCache[prKey]
     const prStale = !prEntry || now - prEntry.fetchedAt >= CACHE_TTL
 
     if (!worktree.isBare && branch && prStale) {
-      void get().fetchPRForBranch(repo.path, branch, { force: true })
+      void get().fetchPRForBranch(repo.path, branch, { force: true, repoId: repo.id })
     }
 
     if (worktree.linkedIssue) {
-      const issueKey = `${repo.path}::${worktree.linkedIssue}`
+      const issueKey = repoScopedCacheKey(repo.path, repo.id, String(worktree.linkedIssue))
       const issueEntry = state.issueCache[issueKey]
       if (!issueEntry || now - issueEntry.fetchedAt >= CACHE_TTL) {
-        void get().fetchIssue(repo.path, worktree.linkedIssue)
+        void get().fetchIssue(repo.path, worktree.linkedIssue, { repoId: repo.id })
       }
     }
   }

--- a/src/renderer/src/store/slices/hosted-review.test.ts
+++ b/src/renderer/src/store/slices/hosted-review.test.ts
@@ -94,6 +94,7 @@ describe('hosted review slice', () => {
       'hostedReview.forBranch',
       {
         repo: 'C:\\repo',
+        repoPath: 'C:\\repo',
         branch: 'feature/windows',
         linkedGitHubPR: 12,
         linkedGitLabMR: null,

--- a/src/renderer/src/store/slices/hosted-review.ts
+++ b/src/renderer/src/store/slices/hosted-review.ts
@@ -5,7 +5,7 @@ import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-cl
 import type { AppState } from '../types'
 
 type CacheEntry<T> = { data: T | null; fetchedAt: number }
-type FetchOptions = { force?: boolean }
+type FetchOptions = { force?: boolean; repoId?: string }
 
 const CACHE_TTL_MS = 60_000
 
@@ -22,11 +22,12 @@ function isFresh<T>(entry: CacheEntry<T> | undefined): entry is CacheEntry<T> {
 export function getHostedReviewCacheKey(
   repoPath: string,
   branch: string,
-  settings?: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null
+  settings?: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null,
+  repoId?: string | null
 ): string {
   const target = getActiveRuntimeTarget(settings)
   const scope = target.kind === 'environment' ? `runtime:${target.environmentId}` : 'local'
-  return `${scope}::${repoPath}::${branch}`
+  return `${scope}::${repoId ?? repoPath}::${branch}`
 }
 
 export type HostedReviewSlice = {
@@ -56,7 +57,7 @@ export const createHostedReviewSlice: StateCreator<AppState, [], [], HostedRevie
   ): Promise<HostedReviewInfo | null> => {
     const settings = get().settings
     const target = getActiveRuntimeTarget(settings)
-    const cacheKey = getHostedReviewCacheKey(repoPath, branch, settings)
+    const cacheKey = getHostedReviewCacheKey(repoPath, branch, settings, options?.repoId)
     const cached = get().hostedReviewCache[cacheKey]
     const linkedRefetch =
       cached?.data === null &&
@@ -80,6 +81,7 @@ export const createHostedReviewSlice: StateCreator<AppState, [], [], HostedRevie
       try {
         const args = {
           branch,
+          ...(options?.repoId !== undefined ? { repoId: options.repoId } : {}),
           linkedGitHubPR: options?.linkedGitHubPR ?? null,
           linkedGitLabMR: options?.linkedGitLabMR ?? null,
           linkedBitbucketPR: options?.linkedBitbucketPR ?? null,
@@ -90,7 +92,7 @@ export const createHostedReviewSlice: StateCreator<AppState, [], [], HostedRevie
             ? await callRuntimeRpc<HostedReviewInfo | null>(
                 target,
                 'hostedReview.forBranch',
-                { repo: repoPath, ...args },
+                { repo: options?.repoId ?? repoPath, repoPath, ...args },
                 // Why: remote dev boxes can be slower at `git`/`gh` lookups
                 // than local desktop repos, especially on Windows filesystem
                 // paths. The main-process queue caps concurrency, so a longer

--- a/src/renderer/src/store/slices/ssh.ts
+++ b/src/renderer/src/store/slices/ssh.ts
@@ -3,8 +3,18 @@ import type { AppState } from '../types'
 import type {
   SshConnectionState,
   PortForwardEntry,
-  DetectedPort
+  DetectedPort,
+  SshTarget
 } from '../../../../shared/ssh-types'
+
+export type RemoteWorkspaceSyncStatus = {
+  phase: 'idle' | 'pulling' | 'pushing' | 'synced' | 'conflict' | 'error' | 'offline'
+  direction?: 'pull' | 'push'
+  revision?: number
+  updatedAt?: number
+  lastSyncedAt?: number
+  message?: string
+}
 
 export type SshCredentialRequest = {
   requestId: string
@@ -18,6 +28,9 @@ export type SshSlice = {
   /** Maps target IDs to their user-facing labels. Populated during hydration
    * so components can look up labels without per-component IPC calls. */
   sshTargetLabels: Map<string, string>
+  sshTargetRemoteSyncEnabled: Map<string, boolean>
+  remoteWorkspaceHydratedTargetIds: Set<string>
+  remoteWorkspaceSyncStatusByTargetId: Record<string, RemoteWorkspaceSyncStatus>
   sshCredentialQueue: SshCredentialRequest[]
   /** Incremented when an SSH target transitions to 'connected'. Allows
    * components like the file explorer to re-trigger data loads that failed
@@ -33,6 +46,12 @@ export type SshSlice = {
   detectedPortsByConnection: Record<string, DetectedPort[]>
   setSshConnectionState: (targetId: string, state: SshConnectionState) => void
   setSshTargetLabels: (labels: Map<string, string>) => void
+  setSshTargetsMetadata: (
+    targets: Pick<SshTarget, 'id' | 'label' | 'remoteWorkspaceSyncEnabled'>[]
+  ) => void
+  markRemoteWorkspaceHydrated: (targetId: string) => void
+  clearRemoteWorkspaceHydrated: (targetId: string) => void
+  setRemoteWorkspaceSyncStatus: (targetId: string, status: RemoteWorkspaceSyncStatus) => void
   enqueueSshCredentialRequest: (req: SshCredentialRequest) => void
   removeSshCredentialRequest: (requestId: string) => void
   bumpSshConnectedGeneration: () => void
@@ -44,6 +63,9 @@ export type SshSlice = {
 export const createSshSlice: StateCreator<AppState, [], [], SshSlice> = (set) => ({
   sshConnectionStates: new Map(),
   sshTargetLabels: new Map(),
+  sshTargetRemoteSyncEnabled: new Map(),
+  remoteWorkspaceHydratedTargetIds: new Set(),
+  remoteWorkspaceSyncStatusByTargetId: {},
   sshCredentialQueue: [],
   sshConnectedGeneration: 0,
   portForwardsByConnection: {},
@@ -57,6 +79,32 @@ export const createSshSlice: StateCreator<AppState, [], [], SshSlice> = (set) =>
     }),
 
   setSshTargetLabels: (labels) => set({ sshTargetLabels: labels }),
+  setSshTargetsMetadata: (targets) =>
+    set({
+      sshTargetLabels: new Map(targets.map((target) => [target.id, target.label])),
+      sshTargetRemoteSyncEnabled: new Map(
+        targets.map((target) => [target.id, target.remoteWorkspaceSyncEnabled === true])
+      )
+    }),
+  markRemoteWorkspaceHydrated: (targetId) =>
+    set((s) => {
+      const next = new Set(s.remoteWorkspaceHydratedTargetIds)
+      next.add(targetId)
+      return { remoteWorkspaceHydratedTargetIds: next }
+    }),
+  clearRemoteWorkspaceHydrated: (targetId) =>
+    set((s) => {
+      const next = new Set(s.remoteWorkspaceHydratedTargetIds)
+      next.delete(targetId)
+      return { remoteWorkspaceHydratedTargetIds: next }
+    }),
+  setRemoteWorkspaceSyncStatus: (targetId, status) =>
+    set((s) => ({
+      remoteWorkspaceSyncStatusByTargetId: {
+        ...s.remoteWorkspaceSyncStatusByTargetId,
+        [targetId]: status
+      }
+    })),
   enqueueSshCredentialRequest: (req) =>
     set((s) => ({ sshCredentialQueue: [...s.sshCredentialQueue, req] })),
   removeSshCredentialRequest: (requestId) =>

--- a/src/renderer/src/store/slices/worktree-helpers.ts
+++ b/src/renderer/src/store/slices/worktree-helpers.ts
@@ -76,7 +76,8 @@ export type WorktreeSlice = {
     linkedIssue?: number,
     linkedPR?: number,
     pushTarget?: GitPushTarget,
-    createdWithAgent?: TuiAgent
+    createdWithAgent?: TuiAgent,
+    linkedLinearIssue?: string
   ) => Promise<CreateWorktreeResult>
   removeWorktree: (
     worktreeId: string,

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -289,7 +289,8 @@ describe('createWorktree base status merge', () => {
       path: '/path/wt1',
       linkedIssue: 123,
       linkedPR: 456,
-      createdWithAgent: 'codex'
+      createdWithAgent: 'codex',
+      linkedLinearIssue: 'ENG-123'
     })
     mockApi.worktrees.create.mockResolvedValue({ worktree: wt })
 
@@ -306,7 +307,8 @@ describe('createWorktree base status merge', () => {
         123,
         456,
         undefined,
-        'codex'
+        'codex',
+        'ENG-123'
       )
 
     expect(mockApi.worktrees.create).toHaveBeenCalledWith(
@@ -315,13 +317,15 @@ describe('createWorktree base status merge', () => {
         name: 'feature',
         linkedIssue: 123,
         linkedPR: 456,
-        createdWithAgent: 'codex'
+        createdWithAgent: 'codex',
+        linkedLinearIssue: 'ENG-123'
       })
     )
     expect(store.getState().worktreesByRepo.repo1[0]).toMatchObject({
       linkedIssue: 123,
       linkedPR: 456,
-      createdWithAgent: 'codex'
+      createdWithAgent: 'codex',
+      linkedLinearIssue: 'ENG-123'
     })
   })
 

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -271,7 +271,8 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
     linkedIssue,
     linkedPR,
     pushTarget,
-    createdWithAgent
+    createdWithAgent,
+    linkedLinearIssue
   ) => {
     const retryableConflictPatterns = [
       /already exists locally/i,
@@ -296,7 +297,8 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
             ...(linkedIssue !== undefined ? { linkedIssue } : {}),
             ...(linkedPR !== undefined ? { linkedPR } : {}),
             ...(pushTarget ? { pushTarget } : {}),
-            ...(createdWithAgent ? { createdWithAgent } : {})
+            ...(createdWithAgent ? { createdWithAgent } : {}),
+            ...(linkedLinearIssue !== undefined ? { linkedLinearIssue } : {})
           }
           const target = getActiveRuntimeTarget(get().settings)
           const result =
@@ -315,7 +317,8 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
                     ...(linkedIssue !== undefined ? { linkedIssue } : {}),
                     ...(linkedPR !== undefined ? { linkedPR } : {}),
                     ...(pushTarget ? { pushTarget } : {}),
-                    ...(createdWithAgent ? { createdWithAgent } : {})
+                    ...(createdWithAgent ? { createdWithAgent } : {}),
+                    ...(linkedLinearIssue !== undefined ? { linkedLinearIssue } : {})
                   },
                   { timeoutMs: 10 * 60_000 }
                 )

--- a/src/shared/hosted-review.ts
+++ b/src/shared/hosted-review.ts
@@ -19,6 +19,7 @@ export type HostedReviewInfo = {
 
 export type HostedReviewForBranchArgs = {
   repoPath: string
+  repoId?: string
   branch: string
   linkedGitHubPR?: number | null
   linkedGitLabMR?: number | null

--- a/src/shared/remote-workspace-session-projection.test.ts
+++ b/src/shared/remote-workspace-session-projection.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest'
+import {
+  exportRemoteWorkspaceSession,
+  importRemoteWorkspaceSession
+} from './remote-workspace-session-projection'
+import { getDefaultWorkspaceSession } from './constants'
+
+describe('remote workspace session projection', () => {
+  it('exports terminal state using remote worktree paths instead of local repo ids', () => {
+    const session = {
+      ...getDefaultWorkspaceSession(),
+      activeRepoId: 'repo-a',
+      activeWorktreeId: 'repo-a::/srv/app',
+      activeTabId: 'tab-1',
+      tabsByWorktree: {
+        'repo-a::/srv/app': [
+          {
+            id: 'tab-1',
+            ptyId: 'pty-1',
+            worktreeId: 'repo-a::/srv/app',
+            title: 'Remote',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1
+          }
+        ],
+        'repo-local::/tmp/local': [
+          {
+            id: 'tab-local',
+            ptyId: 'pty-local',
+            worktreeId: 'repo-local::/tmp/local',
+            title: 'Local',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1
+          }
+        ]
+      },
+      terminalLayoutsByTabId: {
+        'tab-1': { root: null, activeLeafId: null, expandedLeafId: null },
+        'tab-local': { root: null, activeLeafId: null, expandedLeafId: null }
+      },
+      remoteSessionIdsByTabId: {
+        'tab-1': 'pty-1',
+        'tab-local': 'pty-local'
+      }
+    }
+
+    const projected = exportRemoteWorkspaceSession(session, {
+      isTargetWorktree: (worktreeId) => worktreeId.startsWith('repo-a::')
+    })
+
+    expect(Object.keys(projected.tabsByWorktreePath)).toEqual(['/srv/app'])
+    expect(projected.tabsByWorktreePath['/srv/app'][0]).toMatchObject({
+      id: 'tab-1',
+      worktreePath: '/srv/app'
+    })
+    expect(projected.terminalLayoutsByTabId).toEqual({
+      'tab-1': { root: null, activeLeafId: null, expandedLeafId: null }
+    })
+    expect(projected.remoteSessionIdsByTabId).toEqual({ 'tab-1': 'pty-1' })
+  })
+
+  it('imports projected terminal state into this client repo id', () => {
+    const session = importRemoteWorkspaceSession(
+      {
+        activeWorktreePath: '/srv/app',
+        activeTabId: 'tab-1',
+        tabsByWorktreePath: {
+          '/srv/app': [
+            {
+              id: 'tab-1',
+              ptyId: 'pty-1',
+              worktreePath: '/srv/app',
+              title: 'Remote',
+              customTitle: null,
+              color: null,
+              sortOrder: 0,
+              createdAt: 1
+            }
+          ]
+        },
+        terminalLayoutsByTabId: {
+          'tab-1': { root: null, activeLeafId: null, expandedLeafId: null }
+        },
+        remoteSessionIdsByTabId: { 'tab-1': 'pty-1' }
+      },
+      { resolveWorktreeId: (path) => (path === '/srv/app' ? 'repo-b::/srv/app' : null) }
+    )
+
+    expect(session.activeRepoId).toBe('repo-b')
+    expect(session.activeWorktreeId).toBe('repo-b::/srv/app')
+    expect(session.tabsByWorktree['repo-b::/srv/app'][0]).toMatchObject({
+      id: 'tab-1',
+      worktreeId: 'repo-b::/srv/app'
+    })
+    expect(session.remoteSessionIdsByTabId).toEqual({ 'tab-1': 'pty-1' })
+  })
+
+  it('imports active worktree metadata even when the worktree has no terminal tabs', () => {
+    const session = importRemoteWorkspaceSession(
+      {
+        activeWorktreePath: '/srv/app',
+        activeTabId: null,
+        tabsByWorktreePath: {},
+        terminalLayoutsByTabId: {},
+        activeTabIdByWorktreePath: { '/srv/app': null },
+        lastVisitedAtByWorktreePath: { '/srv/app': 456 }
+      },
+      { resolveWorktreeId: (path) => (path === '/srv/app' ? 'repo-b::/srv/app' : null) }
+    )
+
+    expect(session.activeRepoId).toBe('repo-b')
+    expect(session.activeWorktreeId).toBe('repo-b::/srv/app')
+    expect(session.activeTabIdByWorktree).toEqual({ 'repo-b::/srv/app': null })
+    expect(session.lastVisitedAtByWorktreeId).toEqual({ 'repo-b::/srv/app': 456 })
+  })
+})

--- a/src/shared/remote-workspace-session-projection.ts
+++ b/src/shared/remote-workspace-session-projection.ts
@@ -1,0 +1,184 @@
+import { getDefaultWorkspaceSession } from './constants'
+import type { RemoteWorkspaceSession, RemoteWorkspaceTerminalTab } from './remote-workspace-types'
+import type { TerminalTab, WorkspaceSessionState } from './types'
+import { splitWorktreeId } from './worktree-id'
+
+type ExportOptions = {
+  isTargetWorktree: (worktreeId: string) => boolean
+}
+
+type ImportOptions = {
+  resolveWorktreeId: (worktreePath: string) => string | null
+}
+
+function worktreePathFromId(worktreeId: string): string | null {
+  return splitWorktreeId(worktreeId)?.worktreePath ?? null
+}
+
+function tabToRemote(tab: TerminalTab, worktreePath: string): RemoteWorkspaceTerminalTab {
+  const { worktreeId: _worktreeId, pendingActivationSpawn: _pendingActivationSpawn, ...rest } = tab
+  void _worktreeId
+  void _pendingActivationSpawn
+  return { ...rest, worktreePath }
+}
+
+function tabToLocal(tab: RemoteWorkspaceTerminalTab, worktreeId: string): TerminalTab {
+  const { worktreePath: _worktreePath, ...rest } = tab
+  void _worktreePath
+  return { ...rest, worktreeId }
+}
+
+export function exportRemoteWorkspaceSession(
+  session: WorkspaceSessionState,
+  options: ExportOptions
+): RemoteWorkspaceSession {
+  const tabsByWorktreePath: Record<string, RemoteWorkspaceTerminalTab[]> = {}
+  const terminalTabIds = new Set<string>()
+
+  for (const [worktreeId, tabs] of Object.entries(session.tabsByWorktree)) {
+    if (!options.isTargetWorktree(worktreeId)) {
+      continue
+    }
+    const worktreePath = worktreePathFromId(worktreeId)
+    if (!worktreePath) {
+      continue
+    }
+    tabsByWorktreePath[worktreePath] = tabs.map((tab) => {
+      terminalTabIds.add(tab.id)
+      return tabToRemote(tab, worktreePath)
+    })
+  }
+
+  const activeWorktreePath =
+    session.activeWorktreeId && options.isTargetWorktree(session.activeWorktreeId)
+      ? worktreePathFromId(session.activeWorktreeId)
+      : null
+
+  const activeTabId =
+    session.activeTabId && terminalTabIds.has(session.activeTabId) ? session.activeTabId : null
+
+  const activeTabIdByWorktreePath: Record<string, string | null> = {}
+  for (const [worktreeId, tabId] of Object.entries(session.activeTabIdByWorktree ?? {})) {
+    if (!options.isTargetWorktree(worktreeId)) {
+      continue
+    }
+    const worktreePath = worktreePathFromId(worktreeId)
+    if (worktreePath) {
+      activeTabIdByWorktreePath[worktreePath] = tabId && terminalTabIds.has(tabId) ? tabId : null
+    }
+  }
+
+  const lastVisitedAtByWorktreePath: Record<string, number> = {}
+  for (const [worktreeId, timestamp] of Object.entries(session.lastVisitedAtByWorktreeId ?? {})) {
+    if (!options.isTargetWorktree(worktreeId)) {
+      continue
+    }
+    const worktreePath = worktreePathFromId(worktreeId)
+    if (worktreePath) {
+      lastVisitedAtByWorktreePath[worktreePath] = timestamp
+    }
+  }
+
+  return {
+    activeWorktreePath,
+    activeTabId,
+    tabsByWorktreePath,
+    terminalLayoutsByTabId: Object.fromEntries(
+      Object.entries(session.terminalLayoutsByTabId ?? {}).filter(([tabId]) =>
+        terminalTabIds.has(tabId)
+      )
+    ),
+    activeWorktreePathsOnShutdown: session.activeWorktreeIdsOnShutdown
+      ?.filter(options.isTargetWorktree)
+      .map(worktreePathFromId)
+      .filter((path): path is string => Boolean(path)),
+    activeTabIdByWorktreePath,
+    remoteSessionIdsByTabId: session.remoteSessionIdsByTabId
+      ? Object.fromEntries(
+          Object.entries(session.remoteSessionIdsByTabId).filter(([tabId]) =>
+            terminalTabIds.has(tabId)
+          )
+        )
+      : undefined,
+    lastVisitedAtByWorktreePath
+  }
+}
+
+export function importRemoteWorkspaceSession(
+  remote: RemoteWorkspaceSession,
+  options: ImportOptions
+): WorkspaceSessionState {
+  const session = getDefaultWorkspaceSession()
+  const tabsByWorktree: Record<string, TerminalTab[]> = {}
+  const terminalTabIds = new Set<string>()
+  const worktreeIdByPath = new Map<string, string>()
+  const resolvePath = (worktreePath: string): string | null => {
+    if (worktreeIdByPath.has(worktreePath)) {
+      return worktreeIdByPath.get(worktreePath) ?? null
+    }
+    const worktreeId = options.resolveWorktreeId(worktreePath)
+    if (worktreeId) {
+      worktreeIdByPath.set(worktreePath, worktreeId)
+    }
+    return worktreeId
+  }
+
+  for (const [worktreePath, tabs] of Object.entries(remote.tabsByWorktreePath ?? {})) {
+    const worktreeId = resolvePath(worktreePath)
+    if (!worktreeId) {
+      continue
+    }
+    tabsByWorktree[worktreeId] = tabs.map((tab) => {
+      terminalTabIds.add(tab.id)
+      return tabToLocal(tab, worktreeId)
+    })
+  }
+
+  const activeWorktreeId = remote.activeWorktreePath ? resolvePath(remote.activeWorktreePath) : null
+
+  const activeTabId =
+    remote.activeTabId && terminalTabIds.has(remote.activeTabId) ? remote.activeTabId : null
+
+  const activeTabIdByWorktree: Record<string, string | null> = {}
+  for (const [worktreePath, tabId] of Object.entries(remote.activeTabIdByWorktreePath ?? {})) {
+    const worktreeId = resolvePath(worktreePath)
+    if (worktreeId) {
+      activeTabIdByWorktree[worktreeId] = tabId && terminalTabIds.has(tabId) ? tabId : null
+    }
+  }
+
+  const lastVisitedAtByWorktreeId: Record<string, number> = {}
+  for (const [worktreePath, timestamp] of Object.entries(
+    remote.lastVisitedAtByWorktreePath ?? {}
+  )) {
+    const worktreeId = resolvePath(worktreePath)
+    if (worktreeId) {
+      lastVisitedAtByWorktreeId[worktreeId] = timestamp
+    }
+  }
+
+  return {
+    ...session,
+    activeRepoId: activeWorktreeId ? (splitWorktreeId(activeWorktreeId)?.repoId ?? null) : null,
+    activeWorktreeId,
+    activeTabId,
+    tabsByWorktree,
+    terminalLayoutsByTabId: Object.fromEntries(
+      Object.entries(remote.terminalLayoutsByTabId ?? {}).filter(([tabId]) =>
+        terminalTabIds.has(tabId)
+      )
+    ),
+    activeWorktreeIdsOnShutdown: remote.activeWorktreePathsOnShutdown
+      ?.map((path) => worktreeIdByPath.get(path))
+      .filter((id): id is string => Boolean(id)),
+    activeTabIdByWorktree,
+    remoteSessionIdsByTabId: remote.remoteSessionIdsByTabId
+      ? Object.fromEntries(
+          Object.entries(remote.remoteSessionIdsByTabId).filter(([tabId]) =>
+            terminalTabIds.has(tabId)
+          )
+        )
+      : undefined,
+    lastVisitedAtByWorktreeId
+  }
+}

--- a/src/shared/remote-workspace-types.ts
+++ b/src/shared/remote-workspace-types.ts
@@ -1,0 +1,54 @@
+import type { TerminalLayoutSnapshot, TerminalTab } from './types'
+
+export type RemoteWorkspaceTerminalTab = Omit<TerminalTab, 'worktreeId'> & {
+  worktreePath: string
+}
+
+export type RemoteWorkspaceSession = {
+  activeWorktreePath: string | null
+  activeTabId: string | null
+  tabsByWorktreePath: Record<string, RemoteWorkspaceTerminalTab[]>
+  terminalLayoutsByTabId: Record<string, TerminalLayoutSnapshot>
+  activeWorktreePathsOnShutdown?: string[]
+  activeTabIdByWorktreePath?: Record<string, string | null>
+  remoteSessionIdsByTabId?: Record<string, string>
+  lastVisitedAtByWorktreePath?: Record<string, number>
+}
+
+export type RemoteWorkspaceSnapshot = {
+  namespace: string
+  revision: number
+  updatedAt: number
+  schemaVersion: number
+  session: RemoteWorkspaceSession
+}
+
+export type RemoteWorkspaceConnectedClient = {
+  clientId: string
+  name: string
+  lastSeenAt: number
+  isCurrent?: boolean
+}
+
+export type RemoteWorkspacePatch = {
+  kind: 'replace-session'
+  session: RemoteWorkspaceSession
+}
+
+export type RemoteWorkspacePatchResult =
+  | {
+      ok: true
+      snapshot: RemoteWorkspaceSnapshot
+    }
+  | {
+      ok: false
+      reason: 'stale-revision' | 'unavailable'
+      snapshot?: RemoteWorkspaceSnapshot
+      message?: string
+    }
+
+export type RemoteWorkspaceChangedEvent = {
+  targetId: string
+  snapshot: RemoteWorkspaceSnapshot
+  sourceClientId?: string
+}

--- a/src/shared/ssh-types.ts
+++ b/src/shared/ssh-types.ts
@@ -17,6 +17,12 @@ export type SshTarget = {
   /** Grace period in seconds before relay shuts down after disconnect.
    *  Default: 300 (5 minutes). */
   relayGracePeriodSeconds?: number
+  /** Opt in to remote-host-owned workspace/session state for this SSH target.
+   *  Classic SSH remains local-session-backed when this is false/absent. */
+  remoteWorkspaceSyncEnabled?: boolean
+  /** Grace period in seconds for synced remote workspace relays.
+   *  0 disables expiry. Only applies when remoteWorkspaceSyncEnabled is true. */
+  remoteWorkspaceSyncGracePeriodSeconds?: number
   /** Set to true after a successful connection that triggered a credential
    *  prompt (passphrase or password). Persisted so startup reconnect can
    *  partition targets into eager (no passphrase) vs deferred (passphrase)

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -963,6 +963,7 @@ export type CreateWorktreeArgs = {
   sparseCheckout?: CreateSparseCheckoutRequest
   linkedIssue?: number
   linkedPR?: number
+  linkedLinearIssue?: string
   pushTarget?: GitPushTarget
   /** Agent selected in the create surface. Omitted for blank-shell creates. */
   createdWithAgent?: TuiAgent


### PR DESCRIPTION
## Summary
- Add opt-in SSH remote workspace sync with relay-backed workspace snapshots, revision/stale-write handling, cross-client notifications, and device presence/status UI.
- Make SSH/remote repos first-class across GitHub work-item flows, repo identity, file search/list/upload/watch, and fork PR worktree metadata.
- Improve SSH relay deployment/package lookup and native dependency setup, plus multi-client relay/watch isolation and resize ownership safeguards.

## Verification
- `pnpm vitest run --config config/vitest.config.ts src/shared/remote-workspace-session-projection.test.ts src/main/ipc/remote-workspace.test.ts src/renderer/src/lib/session-write-subscriber.test.ts src/renderer/src/hooks/useIpcEvents.test.ts src/main/ipc/filesystem-import-ssh-ops.test.ts src/main/providers/ssh-filesystem-provider.test.ts src/main/ipc/filesystem-watcher.test.ts src/main/ipc/github-work-item-args.test.ts src/main/ipc/worktrees.test.ts src/main/ssh/ssh-relay-deploy.test.ts src/main/ssh/ssh-relay-native-deps-install.test.ts`
- `pnpm vitest run --config config/vitest.config.ts src/main/ipc/ssh.test.ts src/main/ipc/github.test.ts src/main/ipc/repos-remote.test.ts src/main/providers/ssh-git-provider.test.ts src/main/ssh/ssh-relay-cross-version-isolation.test.ts src/main/ssh/relay-protocol.test.ts src/renderer/src/store/slices/ssh.test.ts src/renderer/src/components/status-bar/SshStatusSegment.test.tsx`
- `pnpm run tc:node`
- `pnpm run tc:web`
- `pnpm run build:relay`
- `git diff --check`
- Electron e2e with two dev clients against `openclaw 2`: verified remote workspace push/hydrate, cross-client SSH terminal tab propagation, bounded revision convergence, cleanup, and restored target sync disabled.
- Electron e2e with a temporary GitHub-backed SSH repo on `openclaw 2`: verified `repoSlug` resolves `stablyai/orca` and PR `#1690` loads through the SSH repo path; cleaned up temp repo and remote directory.

Made with [Orca](https://github.com/stablyai/orca) 🐋
