### PR TITLE
Add workspace space analyzer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,6 @@ playwright-report/
 /.claude/skills/
 /.agents/skills/
 /skills-lock.json
+
+# Agent hook runtime endpoints (machine-local secrets)
+/agent-hooks/

--- a/src/main/computer/macos-computer-use-permissions.test.ts
+++ b/src/main/computer/macos-computer-use-permissions.test.ts
@@ -135,6 +135,15 @@ describe('openComputerUsePermissions', () => {
     expect(() => openComputerUsePermissions()).toThrow('Orca Computer Use.app was not found')
   })
 
+  it('throws when the helper executable is missing during setup', () => {
+    resolveHelperAppPathMock.mockReturnValue('/Applications/Orca Computer Use.app')
+    resolveHelperExecutablePathMock.mockReturnValue(null)
+
+    expect(() => openComputerUsePermissions('accessibility')).toThrow(
+      '/Applications/Orca Computer Use.app/Contents/MacOS/orca-computer-use-macos was not found'
+    )
+  })
+
   it('reads permission status through the helper app executable', async () => {
     const { getComputerUsePermissionStatus } = await import('./macos-computer-use-permissions')
     resolveHelperAppPathMock.mockReturnValue('/Applications/Orca Computer Use.app')
@@ -142,6 +151,8 @@ describe('openComputerUsePermissions', () => {
 
     expect(getComputerUsePermissionStatus()).toEqual({
       platform: 'darwin',
+      helperAppPath: '/Applications/Orca Computer Use.app',
+      helperUnavailableReason: null,
       permissions: [
         { id: 'accessibility', status: 'granted' },
         { id: 'screenshots', status: 'not-granted' }
@@ -152,6 +163,22 @@ describe('openComputerUsePermissions', () => {
       ['--permission-status'],
       { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }
     )
+  })
+
+  it('returns unavailable permission status when the helper app is missing on macOS', async () => {
+    const { getComputerUsePermissionStatus } = await import('./macos-computer-use-permissions')
+    resolveHelperAppPathMock.mockReturnValue(null)
+
+    expect(getComputerUsePermissionStatus()).toEqual({
+      platform: 'darwin',
+      helperAppPath: null,
+      helperUnavailableReason: 'Orca Computer Use.app was not found',
+      permissions: [
+        { id: 'accessibility', status: 'not-granted' },
+        { id: 'screenshots', status: 'not-granted' }
+      ]
+    })
+    expect(execFileSync).not.toHaveBeenCalled()
   })
 })
 

--- a/src/main/computer/macos-computer-use-permissions.ts
+++ b/src/main/computer/macos-computer-use-permissions.ts
@@ -34,6 +34,9 @@ export function openComputerUsePermissions(
     throw new RuntimeClientError('accessibility_error', 'Orca Computer Use.app was not found')
   }
   const status = getComputerUsePermissionStatus()
+  if (status.helperUnavailableReason) {
+    throw new RuntimeClientError('accessibility_error', status.helperUnavailableReason)
+  }
   const nextStep = nextPermissionStep(status.permissions)
 
   if (!permissionId && !nextStep) {
@@ -80,6 +83,8 @@ export function getComputerUsePermissionStatus(): ComputerUsePermissionStatusRes
   if (process.platform !== 'darwin') {
     return {
       platform: process.platform,
+      helperAppPath: null,
+      helperUnavailableReason: null,
       permissions: [
         { id: 'accessibility', status: 'unsupported' },
         { id: 'screenshots', status: 'unsupported' }
@@ -89,13 +94,23 @@ export function getComputerUsePermissionStatus(): ComputerUsePermissionStatusRes
 
   const helperAppPath = resolveMacOSComputerUseAppPath()
   if (!helperAppPath) {
-    throw new RuntimeClientError('accessibility_error', 'Orca Computer Use.app was not found')
+    return createUnavailablePermissionStatus('Orca Computer Use.app was not found', null)
   }
 
-  const raw = readPermissionStatusFromHelperApp(helperAppPath)
+  const executablePath = resolveMacOSComputerUseExecutablePath()
+  if (!executablePath) {
+    return createUnavailablePermissionStatus(
+      `${helperAppPath}/Contents/MacOS/orca-computer-use-macos was not found`,
+      helperAppPath
+    )
+  }
+
+  const raw = readPermissionStatusFromHelperExecutable(executablePath)
 
   return {
     platform: process.platform,
+    helperAppPath,
+    helperUnavailableReason: null,
     permissions: [
       { id: 'accessibility', status: raw.accessibility ?? 'not-granted' },
       { id: 'screenshots', status: raw.screenshots ?? 'not-granted' }
@@ -103,16 +118,24 @@ export function getComputerUsePermissionStatus(): ComputerUsePermissionStatusRes
   }
 }
 
-function readPermissionStatusFromHelperApp(
-  helperAppPath: string
-): Partial<Record<ComputerUsePermissionId, ComputerUsePermissionStatus>> {
-  const executablePath = resolveMacOSComputerUseExecutablePath()
-  if (!executablePath) {
-    throw new RuntimeClientError(
-      'accessibility_error',
-      `${helperAppPath}/Contents/MacOS/orca-computer-use-macos was not found`
-    )
+function createUnavailablePermissionStatus(
+  reason: string,
+  helperAppPath: string | null
+): ComputerUsePermissionStatusResult {
+  return {
+    platform: process.platform,
+    helperAppPath,
+    helperUnavailableReason: reason,
+    permissions: [
+      { id: 'accessibility', status: 'not-granted' },
+      { id: 'screenshots', status: 'not-granted' }
+    ]
   }
+}
+
+function readPermissionStatusFromHelperExecutable(
+  executablePath: string
+): Partial<Record<ComputerUsePermissionId, ComputerUsePermissionStatus>> {
   // Why: launching the nested helper via LaunchServices can make TCC evaluate
   // Orca.app as responsible; the signed helper executable owns this grant.
   const output = execFileSync(executablePath, ['--permission-status'], {

--- a/src/main/ipc/register-core-handlers.test.ts
+++ b/src/main/ipc/register-core-handlers.test.ts
@@ -41,7 +41,8 @@ const {
   registerHostedReviewHandlersMock,
   registerExportHandlersMock,
   registerOnboardingHandlersMock,
-  registerSpeechHandlersMock
+  registerSpeechHandlersMock,
+  registerWorkspaceSpaceHandlersMock
 } = vi.hoisted(() => ({
   registerCliHandlersMock: vi.fn(),
   registerPreflightHandlersMock: vi.fn(),
@@ -81,7 +82,8 @@ const {
   registerHostedReviewHandlersMock: vi.fn(),
   registerExportHandlersMock: vi.fn(),
   registerOnboardingHandlersMock: vi.fn(),
-  registerSpeechHandlersMock: vi.fn()
+  registerSpeechHandlersMock: vi.fn(),
+  registerWorkspaceSpaceHandlersMock: vi.fn()
 }))
 
 vi.mock('./onboarding', () => ({
@@ -150,6 +152,10 @@ vi.mock('./computer-use-permissions', () => ({
 
 vi.mock('./settings', () => ({
   registerSettingsHandlers: registerSettingsHandlersMock
+}))
+
+vi.mock('./workspace-space', () => ({
+  registerWorkspaceSpaceHandlers: registerWorkspaceSpaceHandlersMock
 }))
 
 vi.mock('./telemetry', () => ({
@@ -273,6 +279,7 @@ describe('registerCoreHandlers', () => {
     registerHostedReviewHandlersMock.mockReset()
     registerExportHandlersMock.mockReset()
     registerSpeechHandlersMock.mockReset()
+    registerWorkspaceSpaceHandlersMock.mockReset()
   })
 
   it('passes the store through to handler registrars that need it', () => {
@@ -315,6 +322,7 @@ describe('registerCoreHandlers', () => {
     expect(registerDeveloperPermissionHandlersMock).toHaveBeenCalled()
     expect(registerComputerUsePermissionHandlersMock).toHaveBeenCalled()
     expect(registerSettingsHandlersMock).toHaveBeenCalledWith(store)
+    expect(registerWorkspaceSpaceHandlersMock).toHaveBeenCalledWith(store)
     expect(registerTelemetryHandlersMock).toHaveBeenCalledWith(store)
     expect(registerSessionHandlersMock).toHaveBeenCalledWith(store)
     expect(registerUIHandlersMock).toHaveBeenCalledWith(store)

--- a/src/main/ipc/register-core-handlers.ts
+++ b/src/main/ipc/register-core-handlers.ts
@@ -27,6 +27,7 @@ import { registerComputerUsePermissionHandlers } from './computer-use-permission
 import { setTrustedBrowserRendererWebContentsId, setAgentBrowserBridgeRef } from './browser'
 import { registerSessionHandlers } from './session'
 import { registerSettingsHandlers } from './settings'
+import { registerWorkspaceSpaceHandlers } from './workspace-space'
 import { registerAutomationHandlers } from './automations'
 import { registerTelemetryHandlers } from './telemetry'
 import { registerBrowserHandlers } from './browser'
@@ -115,6 +116,7 @@ export function registerCoreHandlers(
   registerPetHandlers()
   registerSessionHandlers(store)
   registerUIHandlers(store)
+  registerWorkspaceSpaceHandlers(store)
   registerFilesystemHandlers(store)
   registerFilesystemWatcherHandlers()
   registerRuntimeHandlers(runtime)

--- a/src/main/ipc/workspace-space.test.ts
+++ b/src/main/ipc/workspace-space.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { WorkspaceSpaceAnalysis } from '../../shared/workspace-space-types'
+import type { Store } from '../persistence'
+
+const { handlers, analyzeWorkspaceSpaceMock, removeHandlerMock, handleMock } = vi.hoisted(() => ({
+  handlers: new Map<string, () => Promise<WorkspaceSpaceAnalysis>>(),
+  analyzeWorkspaceSpaceMock: vi.fn(),
+  removeHandlerMock: vi.fn(),
+  handleMock: vi.fn((channel: string, handler: () => Promise<WorkspaceSpaceAnalysis>) => {
+    handlers.set(channel, handler)
+  })
+}))
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    removeHandler: removeHandlerMock,
+    handle: handleMock
+  }
+}))
+
+vi.mock('../workspace-space-analysis', () => ({
+  analyzeWorkspaceSpace: analyzeWorkspaceSpaceMock
+}))
+
+import { registerWorkspaceSpaceHandlers } from './workspace-space'
+
+function createAnalysis(scannedAt: number): WorkspaceSpaceAnalysis {
+  return {
+    scannedAt,
+    totalSizeBytes: 0,
+    reclaimableBytes: 0,
+    worktreeCount: 0,
+    scannedWorktreeCount: 0,
+    unavailableWorktreeCount: 0,
+    repos: [],
+    worktrees: []
+  }
+}
+
+describe('registerWorkspaceSpaceHandlers', () => {
+  it('shares an in-flight analysis request', async () => {
+    const store = {} as Store
+    let resolveFirstScan: (analysis: WorkspaceSpaceAnalysis) => void = () => {}
+    const firstScan = new Promise<WorkspaceSpaceAnalysis>((resolve) => {
+      resolveFirstScan = resolve
+    })
+    const secondScan = Promise.resolve(createAnalysis(2))
+    analyzeWorkspaceSpaceMock.mockReturnValueOnce(firstScan).mockReturnValueOnce(secondScan)
+
+    registerWorkspaceSpaceHandlers(store)
+    expect(removeHandlerMock).toHaveBeenCalledWith('workspaceSpace:analyze')
+
+    const handler = handlers.get('workspaceSpace:analyze')
+    expect(handler).toBeDefined()
+
+    const first = handler!()
+    const duplicate = handler!()
+    expect(analyzeWorkspaceSpaceMock).toHaveBeenCalledTimes(1)
+    expect(analyzeWorkspaceSpaceMock).toHaveBeenCalledWith(store)
+
+    const firstResult = createAnalysis(1)
+    resolveFirstScan(firstResult)
+    await expect(first).resolves.toBe(firstResult)
+    await expect(duplicate).resolves.toBe(firstResult)
+
+    await expect(handler!()).resolves.toEqual(createAnalysis(2))
+    expect(analyzeWorkspaceSpaceMock).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/main/ipc/workspace-space.ts
+++ b/src/main/ipc/workspace-space.ts
@@ -1,0 +1,19 @@
+import { ipcMain } from 'electron'
+import type { Store } from '../persistence'
+import type { WorkspaceSpaceAnalysis } from '../../shared/workspace-space-types'
+import { analyzeWorkspaceSpace } from '../workspace-space-analysis'
+
+export function registerWorkspaceSpaceHandlers(store: Store): void {
+  let inFlightScan: Promise<WorkspaceSpaceAnalysis> | null = null
+  ipcMain.removeHandler('workspaceSpace:analyze')
+  ipcMain.handle('workspaceSpace:analyze', async (): Promise<WorkspaceSpaceAnalysis> => {
+    if (!inFlightScan) {
+      // Why: large worktree fleets require real disk traversal; duplicate
+      // requests should share that IO instead of starting competing scans.
+      inFlightScan = analyzeWorkspaceSpace(store).finally(() => {
+        inFlightScan = null
+      })
+    }
+    return inFlightScan
+  })
+}

--- a/src/main/workspace-space-analysis.test.ts
+++ b/src/main/workspace-space-analysis.test.ts
@@ -1,0 +1,239 @@
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Repo } from '../shared/types'
+import type { Store } from './persistence'
+
+const { listRepoWorktreesMock, getSshFilesystemProviderMock, getSshGitProviderMock } = vi.hoisted(
+  () => ({
+    listRepoWorktreesMock: vi.fn(),
+    getSshFilesystemProviderMock: vi.fn(),
+    getSshGitProviderMock: vi.fn()
+  })
+)
+
+vi.mock('./repo-worktrees', () => ({
+  createFolderWorktree: (repo: Repo) => ({
+    path: repo.path,
+    head: '',
+    branch: '',
+    isBare: false,
+    isMainWorktree: true
+  }),
+  listRepoWorktrees: listRepoWorktreesMock
+}))
+
+vi.mock('./providers/ssh-filesystem-dispatch', () => ({
+  getSshFilesystemProvider: getSshFilesystemProviderMock
+}))
+
+vi.mock('./providers/ssh-git-dispatch', () => ({
+  getSshGitProvider: getSshGitProviderMock
+}))
+
+import { analyzeWorkspaceSpace } from './workspace-space-analysis'
+
+function createStore(repos: Repo[]): Store {
+  return {
+    getRepos: () => repos,
+    getWorktreeMeta: (worktreeId: string) => {
+      if (worktreeId.endsWith('feature')) {
+        return { displayName: 'Feature Workspace', lastActivityAt: 200 }
+      }
+      return undefined
+    }
+  } as Store
+}
+
+async function writeSizedFile(filePath: string, size: number): Promise<void> {
+  await writeFile(filePath, Buffer.alloc(size, 1))
+}
+
+describe('analyzeWorkspaceSpace', () => {
+  let tempDir: string | null = null
+
+  beforeEach(async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-14T12:00:00Z'))
+    tempDir = await mkdtemp(join(tmpdir(), 'orca-space-'))
+    listRepoWorktreesMock.mockReset()
+    getSshFilesystemProviderMock.mockReset()
+    getSshGitProviderMock.mockReset()
+  })
+
+  afterEach(async () => {
+    vi.useRealTimers()
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true })
+      tempDir = null
+    }
+  })
+
+  it('scans local worktrees and counts only linked worktrees as reclaimable', async () => {
+    const root = tempDir!
+    const mainPath = join(root, 'repo')
+    const featurePath = join(root, 'feature')
+    await mkdir(join(mainPath, 'src'), { recursive: true })
+    await mkdir(join(featurePath, 'node_modules'), { recursive: true })
+    await mkdir(join(featurePath, 'src'), { recursive: true })
+    await writeSizedFile(join(mainPath, 'src', 'main.ts'), 256)
+    await writeSizedFile(join(featurePath, 'node_modules', 'pkg.js'), 2048)
+    await writeSizedFile(join(featurePath, 'src', 'feature.ts'), 512)
+
+    const repo: Repo = {
+      id: 'repo-1',
+      path: mainPath,
+      displayName: 'orca',
+      badgeColor: '#000',
+      addedAt: 0
+    }
+    listRepoWorktreesMock.mockResolvedValue([
+      {
+        path: mainPath,
+        head: 'a',
+        branch: 'refs/heads/main',
+        isBare: false,
+        isMainWorktree: true
+      },
+      {
+        path: featurePath,
+        head: 'b',
+        branch: 'refs/heads/feature',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+
+    const result = await analyzeWorkspaceSpace(createStore([repo]))
+    const main = result.worktrees.find((row) => row.path === mainPath)
+    const feature = result.worktrees.find((row) => row.path === featurePath)
+
+    expect(result.scannedAt).toBe(Date.parse('2026-05-14T12:00:00Z'))
+    expect(result.worktreeCount).toBe(2)
+    expect(main?.status).toBe('ok')
+    expect(main?.canDelete).toBe(false)
+    expect(main?.reclaimableBytes).toBe(0)
+    expect(feature?.status).toBe('ok')
+    expect(feature?.displayName).toBe('Feature Workspace')
+    expect(feature?.canDelete).toBe(true)
+    expect(feature?.sizeBytes).toBeGreaterThanOrEqual(2048 + 512)
+    expect(feature?.reclaimableBytes).toBe(feature?.sizeBytes)
+    expect(feature?.topLevelItems[0]?.name).toBe('node_modules')
+    expect(result.reclaimableBytes).toBe(feature?.sizeBytes)
+  })
+
+  it('isolates missing worktrees as row-level scan failures', async () => {
+    const root = tempDir!
+    const repoPath = join(root, 'repo')
+    const missingPath = join(root, 'missing')
+    await mkdir(repoPath, { recursive: true })
+
+    const repo: Repo = {
+      id: 'repo-1',
+      path: repoPath,
+      displayName: 'orca',
+      badgeColor: '#000',
+      addedAt: 0
+    }
+    listRepoWorktreesMock.mockResolvedValue([
+      {
+        path: missingPath,
+        head: 'b',
+        branch: 'refs/heads/feature',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+
+    const result = await analyzeWorkspaceSpace(createStore([repo]))
+
+    expect(result.worktreeCount).toBe(1)
+    expect(result.scannedWorktreeCount).toBe(0)
+    expect(result.unavailableWorktreeCount).toBe(1)
+    expect(result.worktrees[0]?.status).toBe('missing')
+    expect(result.worktrees[0]?.sizeBytes).toBe(0)
+  })
+
+  it('scans SSH worktrees through the remote filesystem provider without following symlinks', async () => {
+    const repo: Repo = {
+      id: 'repo-remote',
+      path: '/remote/repo',
+      displayName: 'remote',
+      badgeColor: '#000',
+      addedAt: 0,
+      connectionId: 'ssh-1'
+    }
+    getSshGitProviderMock.mockReturnValue({
+      listWorktrees: vi.fn().mockResolvedValue([
+        {
+          path: '/remote/feature',
+          head: 'c',
+          branch: 'refs/heads/feature',
+          isBare: false,
+          isMainWorktree: false
+        }
+      ])
+    })
+
+    const statByPath = new Map([
+      ['/remote/feature', { size: 10, type: 'directory' as const, mtime: 0 }],
+      ['/remote/feature/node_modules', { size: 5, type: 'directory' as const, mtime: 0 }],
+      ['/remote/feature/node_modules/pkg.js', { size: 1000, type: 'file' as const, mtime: 0 }],
+      ['/remote/feature/file.log', { size: 200, type: 'file' as const, mtime: 0 }]
+    ])
+    const readDirMock = vi.fn(async (dirPath: string) => {
+      if (dirPath === '/remote/feature') {
+        return [
+          { name: 'node_modules', isDirectory: true, isSymlink: false },
+          { name: 'linked-cache', isDirectory: true, isSymlink: true },
+          { name: 'file.log', isDirectory: false, isSymlink: false }
+        ]
+      }
+      if (dirPath === '/remote/feature/node_modules') {
+        return [{ name: 'pkg.js', isDirectory: false, isSymlink: false }]
+      }
+      return []
+    })
+    const statMock = vi.fn(async (filePath: string) => {
+      const stat = statByPath.get(filePath)
+      if (!stat) {
+        throw Object.assign(new Error(`missing ${filePath}`), { code: 'ENOENT' })
+      }
+      return stat
+    })
+    getSshFilesystemProviderMock.mockReturnValue({
+      readDir: readDirMock,
+      stat: statMock
+    })
+
+    const result = await analyzeWorkspaceSpace(createStore([repo]))
+
+    expect(result.worktrees[0]?.status).toBe('ok')
+    expect(result.worktrees[0]?.sizeBytes).toBe(1215)
+    expect(result.worktrees[0]?.topLevelItems.map((item) => item.name)).toEqual([
+      'node_modules',
+      'file.log',
+      'linked-cache'
+    ])
+    expect(statMock).not.toHaveBeenCalledWith('/remote/feature/linked-cache')
+  })
+
+  it('reports disconnected SSH repos without failing the whole analysis', async () => {
+    const repo: Repo = {
+      id: 'repo-remote',
+      path: '/remote/repo',
+      displayName: 'remote',
+      badgeColor: '#000',
+      addedAt: 0,
+      connectionId: 'ssh-1'
+    }
+    getSshGitProviderMock.mockReturnValue(undefined)
+
+    const result = await analyzeWorkspaceSpace(createStore([repo]))
+
+    expect(result.worktrees).toEqual([])
+    expect(result.repos[0]?.error).toContain('not connected')
+    expect(result.unavailableWorktreeCount).toBe(1)
+  })
+})

--- a/src/main/workspace-space-analysis.ts
+++ b/src/main/workspace-space-analysis.ts
@@ -1,0 +1,689 @@
+/* eslint-disable max-lines -- Why: this module keeps local and SSH directory-walk
+   semantics paired so reclaimable-byte, symlink, and partial-failure behavior cannot drift. */
+import { lstat, readdir } from 'node:fs/promises'
+import { execFile } from 'node:child_process'
+import { basename, posix, win32 } from 'node:path'
+import { platform } from 'node:process'
+import { promisify } from 'node:util'
+import type { Dirent } from 'node:fs'
+import type { Store } from './persistence'
+import { isFolderRepo } from '../shared/repo-kind'
+import type { GitWorktreeInfo, Repo, Worktree } from '../shared/types'
+import type {
+  WorkspaceSpaceAnalysis,
+  WorkspaceSpaceItem,
+  WorkspaceSpaceItemKind,
+  WorkspaceSpaceRepoSummary,
+  WorkspaceSpaceScanStatus,
+  WorkspaceSpaceWorktree
+} from '../shared/workspace-space-types'
+import type { IFilesystemProvider } from './providers/types'
+import { getSshFilesystemProvider } from './providers/ssh-filesystem-dispatch'
+import { getSshGitProvider } from './providers/ssh-git-dispatch'
+import { createFolderWorktree, listRepoWorktrees } from './repo-worktrees'
+import { mergeWorktree } from './ipc/worktree-logic'
+
+const MAX_TOP_LEVEL_ITEMS = 48
+const WORKTREE_SCAN_CONCURRENCY = 3
+const LOCAL_FS_CONCURRENCY = 48
+const REMOTE_FS_CONCURRENCY = 10
+const DU_TIMEOUT_MS = 120_000
+const DU_MAX_BUFFER_BYTES = 16 * 1024 * 1024
+const execFileAsync = promisify(execFile)
+
+type AsyncLimiter = <T>(task: () => Promise<T>) => Promise<T>
+
+type ScanStats = {
+  name: string
+  path: string
+  kind: WorkspaceSpaceItemKind
+  sizeBytes: number
+  skippedEntryCount: number
+  children?: ScanStats[]
+}
+
+type WorktreeListResult =
+  | { ok: true; worktrees: GitWorktreeInfo[] }
+  | { ok: false; status: Exclude<WorkspaceSpaceScanStatus, 'ok'>; error: string }
+
+type RepoScanResult = {
+  summary: WorkspaceSpaceRepoSummary
+  worktrees: WorkspaceSpaceWorktree[]
+}
+
+function createAsyncLimiter(maxConcurrent: number): AsyncLimiter {
+  let active = 0
+  const queue: (() => void)[] = []
+
+  const acquire = async (): Promise<void> => {
+    if (active < maxConcurrent) {
+      active += 1
+      return
+    }
+    await new Promise<void>((resolve) => queue.push(resolve))
+    active += 1
+  }
+
+  return async <T>(task: () => Promise<T>): Promise<T> => {
+    await acquire()
+    try {
+      return await task()
+    } finally {
+      active -= 1
+      const next = queue.shift()
+      if (next) {
+        next()
+      }
+    }
+  }
+}
+
+async function mapLimit<T, R>(
+  items: readonly T[],
+  maxConcurrent: number,
+  mapper: (item: T) => Promise<R>
+): Promise<R[]> {
+  const limit = createAsyncLimiter(maxConcurrent)
+  return Promise.all(items.map((item) => limit(() => mapper(item))))
+}
+
+function looksLikeWindowsPath(pathValue: string): boolean {
+  return /^[A-Za-z]:[\\/]/.test(pathValue) || pathValue.startsWith('\\\\')
+}
+
+function joinFilesystemPath(parent: string, child: string): string {
+  return looksLikeWindowsPath(parent) ? win32.join(parent, child) : posix.join(parent, child)
+}
+
+function normalizeLocalDuPath(pathValue: string): string {
+  const trimmed = pathValue.replace(/[\\/]+$/, '')
+  return trimmed.length > 0 ? trimmed : pathValue
+}
+
+function parseDuDepthOneOutput(stdout: string): Map<string, number> {
+  const sizes = new Map<string, number>()
+  for (const line of stdout.split('\n')) {
+    const trimmed = line.trim()
+    if (!trimmed) {
+      continue
+    }
+    const match = /^(\d+)\s+(.+)$/.exec(trimmed)
+    if (!match) {
+      continue
+    }
+    sizes.set(normalizeLocalDuPath(match[2]), Number(match[1]) * 1024)
+  }
+  return sizes
+}
+
+async function readLocalDuDepthOne(rootPath: string): Promise<Map<string, number>> {
+  const { stdout } = await execFileAsync('du', ['-k', '-d', '1', rootPath], {
+    encoding: 'utf8',
+    maxBuffer: DU_MAX_BUFFER_BYTES,
+    timeout: DU_TIMEOUT_MS
+  })
+  return parseDuDepthOneOutput(stdout)
+}
+
+function classifyError(error: unknown): {
+  status: Exclude<WorkspaceSpaceScanStatus, 'ok'>
+  message: string
+} {
+  const code =
+    error && typeof error === 'object' && 'code' in error
+      ? String((error as { code?: unknown }).code)
+      : ''
+  const message = error instanceof Error ? error.message : String(error)
+
+  if (code === 'ENOENT' || code === 'ENOTDIR') {
+    return { status: 'missing', message }
+  }
+  if (code === 'EACCES' || code === 'EPERM') {
+    return { status: 'permission-denied', message }
+  }
+  return { status: 'error', message }
+}
+
+function toWorkspaceSpaceItem(stats: ScanStats): WorkspaceSpaceItem {
+  return {
+    name: stats.name,
+    path: stats.path,
+    kind: stats.kind,
+    sizeBytes: stats.sizeBytes
+  }
+}
+
+function compactTopLevelItems(items: WorkspaceSpaceItem[]): {
+  topLevelItems: WorkspaceSpaceItem[]
+  omittedTopLevelItemCount: number
+  omittedTopLevelSizeBytes: number
+} {
+  const sorted = [...items].sort(
+    (a, b) => b.sizeBytes - a.sizeBytes || a.name.localeCompare(b.name)
+  )
+  if (sorted.length <= MAX_TOP_LEVEL_ITEMS) {
+    return {
+      topLevelItems: sorted,
+      omittedTopLevelItemCount: 0,
+      omittedTopLevelSizeBytes: 0
+    }
+  }
+
+  const visible = sorted.slice(0, MAX_TOP_LEVEL_ITEMS - 1)
+  const omitted = sorted.slice(MAX_TOP_LEVEL_ITEMS - 1)
+  const other = omitted.reduce<WorkspaceSpaceItem>(
+    (acc, item) => ({
+      ...acc,
+      sizeBytes: acc.sizeBytes + item.sizeBytes
+    }),
+    {
+      name: 'Other',
+      path: '',
+      kind: 'other',
+      sizeBytes: 0
+    }
+  )
+
+  return {
+    topLevelItems: [...visible, other],
+    omittedTopLevelItemCount: omitted.length,
+    omittedTopLevelSizeBytes: other.sizeBytes
+  }
+}
+
+function createBaseWorktreeRow(
+  repo: Repo,
+  worktree: Worktree,
+  scannedAt: number
+): Omit<
+  WorkspaceSpaceWorktree,
+  | 'status'
+  | 'error'
+  | 'sizeBytes'
+  | 'reclaimableBytes'
+  | 'skippedEntryCount'
+  | 'topLevelItems'
+  | 'omittedTopLevelItemCount'
+  | 'omittedTopLevelSizeBytes'
+> {
+  const canDelete = !worktree.isMainWorktree
+  return {
+    worktreeId: worktree.id,
+    repoId: repo.id,
+    repoDisplayName: repo.displayName,
+    repoPath: repo.path,
+    displayName: worktree.displayName,
+    path: worktree.path,
+    branch: worktree.branch,
+    isMainWorktree: worktree.isMainWorktree,
+    isRemote: Boolean(repo.connectionId),
+    isSparse: worktree.isSparse === true,
+    canDelete,
+    lastActivityAt: worktree.lastActivityAt,
+    scannedAt
+  }
+}
+
+function createUnavailableWorktreeRow(
+  repo: Repo,
+  worktree: Worktree,
+  scannedAt: number,
+  status: Exclude<WorkspaceSpaceScanStatus, 'ok'>,
+  error: string
+): WorkspaceSpaceWorktree {
+  return {
+    ...createBaseWorktreeRow(repo, worktree, scannedAt),
+    status,
+    error,
+    sizeBytes: 0,
+    reclaimableBytes: 0,
+    skippedEntryCount: 0,
+    topLevelItems: [],
+    omittedTopLevelItemCount: 0,
+    omittedTopLevelSizeBytes: 0
+  }
+}
+
+async function scanLocalEntry(
+  entryPath: string,
+  name: string,
+  limit: AsyncLimiter
+): Promise<ScanStats> {
+  const stats = await limit(() => lstat(entryPath))
+
+  if (stats.isSymbolicLink()) {
+    return {
+      name,
+      path: entryPath,
+      kind: 'symlink',
+      // Why: symlink targets may be shared outside the worktree. Counting the
+      // link itself reflects what deleting this worktree can actually reclaim.
+      sizeBytes: stats.size,
+      skippedEntryCount: 0
+    }
+  }
+
+  if (!stats.isDirectory()) {
+    return {
+      name,
+      path: entryPath,
+      kind: 'file',
+      sizeBytes: stats.size,
+      skippedEntryCount: 0
+    }
+  }
+
+  let entries: Dirent[]
+  try {
+    entries = await limit(() => readdir(entryPath, { withFileTypes: true }))
+  } catch {
+    return {
+      name,
+      path: entryPath,
+      kind: 'directory',
+      sizeBytes: stats.size,
+      skippedEntryCount: 1
+    }
+  }
+
+  const childStats = await Promise.all(
+    entries.map(async (entry): Promise<ScanStats | null> => {
+      try {
+        return await scanLocalEntry(joinFilesystemPath(entryPath, entry.name), entry.name, limit)
+      } catch {
+        return null
+      }
+    })
+  )
+
+  let sizeBytes = stats.size
+  let skippedEntryCount = 0
+  for (const child of childStats) {
+    if (!child) {
+      skippedEntryCount += 1
+      continue
+    }
+    sizeBytes += child.sizeBytes
+    skippedEntryCount += child.skippedEntryCount
+  }
+
+  return {
+    name,
+    path: entryPath,
+    kind: 'directory',
+    sizeBytes,
+    skippedEntryCount,
+    children: childStats.filter((child): child is ScanStats => child !== null)
+  }
+}
+
+async function scanRemoteEntry(
+  entryPath: string,
+  name: string,
+  provider: IFilesystemProvider,
+  limit: AsyncLimiter,
+  knownSymlink = false
+): Promise<ScanStats> {
+  if (knownSymlink) {
+    return {
+      name,
+      path: entryPath,
+      kind: 'symlink',
+      sizeBytes: 0,
+      skippedEntryCount: 0
+    }
+  }
+
+  const stats = await limit(() => provider.stat(entryPath))
+  if (stats.type === 'symlink') {
+    return {
+      name,
+      path: entryPath,
+      kind: 'symlink',
+      sizeBytes: stats.size,
+      skippedEntryCount: 0
+    }
+  }
+
+  if (stats.type !== 'directory') {
+    return {
+      name,
+      path: entryPath,
+      kind: 'file',
+      sizeBytes: stats.size,
+      skippedEntryCount: 0
+    }
+  }
+
+  let entries
+  try {
+    entries = await limit(() => provider.readDir(entryPath))
+  } catch {
+    return {
+      name,
+      path: entryPath,
+      kind: 'directory',
+      sizeBytes: stats.size,
+      skippedEntryCount: 1
+    }
+  }
+
+  const childStats = await Promise.all(
+    entries.map(async (entry): Promise<ScanStats | null> => {
+      try {
+        return await scanRemoteEntry(
+          joinFilesystemPath(entryPath, entry.name),
+          entry.name,
+          provider,
+          limit,
+          entry.isSymlink
+        )
+      } catch {
+        return null
+      }
+    })
+  )
+
+  let sizeBytes = stats.size
+  let skippedEntryCount = 0
+  for (const child of childStats) {
+    if (!child) {
+      skippedEntryCount += 1
+      continue
+    }
+    sizeBytes += child.sizeBytes
+    skippedEntryCount += child.skippedEntryCount
+  }
+
+  return {
+    name,
+    path: entryPath,
+    kind: 'directory',
+    sizeBytes,
+    skippedEntryCount,
+    children: childStats.filter((child): child is ScanStats => child !== null)
+  }
+}
+
+async function scanLocalTopLevelEntry(
+  entryPath: string,
+  name: string,
+  duSizes: Map<string, number>,
+  limit: AsyncLimiter
+): Promise<ScanStats> {
+  const stats = await limit(() => lstat(entryPath))
+
+  if (stats.isSymbolicLink()) {
+    return {
+      name,
+      path: entryPath,
+      kind: 'symlink',
+      sizeBytes: stats.size,
+      skippedEntryCount: 0
+    }
+  }
+
+  if (!stats.isDirectory()) {
+    return {
+      name,
+      path: entryPath,
+      kind: 'file',
+      sizeBytes: stats.size,
+      skippedEntryCount: 0
+    }
+  }
+
+  return {
+    name,
+    path: entryPath,
+    kind: 'directory',
+    sizeBytes: duSizes.get(normalizeLocalDuPath(entryPath)) ?? stats.size,
+    skippedEntryCount: 0
+  }
+}
+
+async function scanLocalWorktreeWithDu(
+  repo: Repo,
+  worktree: Worktree,
+  scannedAt: number
+): Promise<WorkspaceSpaceWorktree> {
+  const rootStats = await lstat(worktree.path)
+  if (!rootStats.isDirectory() || rootStats.isSymbolicLink()) {
+    const limit = createAsyncLimiter(LOCAL_FS_CONCURRENCY)
+    const root = await scanLocalEntry(worktree.path, basename(worktree.path), limit)
+    const compact = compactTopLevelItems((root.children ?? []).map(toWorkspaceSpaceItem))
+    return {
+      ...createBaseWorktreeRow(repo, worktree, scannedAt),
+      status: 'ok',
+      error: null,
+      sizeBytes: root.sizeBytes,
+      reclaimableBytes: worktree.isMainWorktree ? 0 : root.sizeBytes,
+      skippedEntryCount: root.skippedEntryCount,
+      ...compact
+    }
+  }
+
+  const [entries, duSizes] = await Promise.all([
+    readdir(worktree.path, { withFileTypes: true }),
+    readLocalDuDepthOne(worktree.path)
+  ])
+  const limit = createAsyncLimiter(LOCAL_FS_CONCURRENCY)
+  const childStats = await Promise.all(
+    entries.map(async (entry): Promise<ScanStats | null> => {
+      try {
+        return await scanLocalTopLevelEntry(
+          joinFilesystemPath(worktree.path, entry.name),
+          entry.name,
+          duSizes,
+          limit
+        )
+      } catch {
+        return null
+      }
+    })
+  )
+  const children = childStats.filter((child): child is ScanStats => child !== null)
+  const skippedEntryCount = childStats.length - children.length
+  const rootSize =
+    duSizes.get(normalizeLocalDuPath(worktree.path)) ??
+    rootStats.size + children.reduce((sum, child) => sum + child.sizeBytes, 0)
+  const compact = compactTopLevelItems(children.map(toWorkspaceSpaceItem))
+
+  return {
+    ...createBaseWorktreeRow(repo, worktree, scannedAt),
+    status: 'ok',
+    error: null,
+    sizeBytes: rootSize,
+    reclaimableBytes: worktree.isMainWorktree ? 0 : rootSize,
+    skippedEntryCount,
+    ...compact
+  }
+}
+
+async function scanLocalWorktreeWithNode(
+  repo: Repo,
+  worktree: Worktree,
+  scannedAt: number
+): Promise<WorkspaceSpaceWorktree> {
+  try {
+    const limit = createAsyncLimiter(LOCAL_FS_CONCURRENCY)
+    const root = await scanLocalEntry(worktree.path, basename(worktree.path), limit)
+    const compact = compactTopLevelItems((root.children ?? []).map(toWorkspaceSpaceItem))
+    return {
+      ...createBaseWorktreeRow(repo, worktree, scannedAt),
+      status: 'ok',
+      error: null,
+      sizeBytes: root.sizeBytes,
+      reclaimableBytes: worktree.isMainWorktree ? 0 : root.sizeBytes,
+      skippedEntryCount: root.skippedEntryCount,
+      ...compact
+    }
+  } catch (error) {
+    const classified = classifyError(error)
+    return createUnavailableWorktreeRow(
+      repo,
+      worktree,
+      scannedAt,
+      classified.status,
+      classified.message
+    )
+  }
+}
+
+async function scanLocalWorktree(
+  repo: Repo,
+  worktree: Worktree,
+  scannedAt: number
+): Promise<WorkspaceSpaceWorktree> {
+  if (platform !== 'win32') {
+    try {
+      // Why: JS per-file stats are too slow for large local workspace fleets;
+      // POSIX du gives bounded top-level sizing without following symlinks.
+      return await scanLocalWorktreeWithDu(repo, worktree, scannedAt)
+    } catch {
+      // Fall through to the portable scanner so unsupported du variants or
+      // permission edge cases still produce partial rows instead of failing.
+    }
+  }
+  return scanLocalWorktreeWithNode(repo, worktree, scannedAt)
+}
+
+async function scanRemoteWorktree(
+  repo: Repo,
+  worktree: Worktree,
+  scannedAt: number,
+  provider: IFilesystemProvider
+): Promise<WorkspaceSpaceWorktree> {
+  try {
+    const limit = createAsyncLimiter(REMOTE_FS_CONCURRENCY)
+    const root = await scanRemoteEntry(worktree.path, basename(worktree.path), provider, limit)
+    const compact = compactTopLevelItems((root.children ?? []).map(toWorkspaceSpaceItem))
+    return {
+      ...createBaseWorktreeRow(repo, worktree, scannedAt),
+      status: 'ok',
+      error: null,
+      sizeBytes: root.sizeBytes,
+      reclaimableBytes: worktree.isMainWorktree ? 0 : root.sizeBytes,
+      skippedEntryCount: root.skippedEntryCount,
+      ...compact
+    }
+  } catch (error) {
+    const classified = classifyError(error)
+    return createUnavailableWorktreeRow(
+      repo,
+      worktree,
+      scannedAt,
+      classified.status,
+      classified.message
+    )
+  }
+}
+
+async function listWorktreesForSpaceScan(repo: Repo): Promise<WorktreeListResult> {
+  try {
+    if (isFolderRepo(repo)) {
+      return { ok: true, worktrees: [createFolderWorktree(repo)] }
+    }
+    if (repo.connectionId) {
+      const provider = getSshGitProvider(repo.connectionId)
+      if (!provider) {
+        return {
+          ok: false,
+          status: 'unavailable',
+          error: `SSH connection "${repo.connectionId}" is not connected.`
+        }
+      }
+      return { ok: true, worktrees: await provider.listWorktrees(repo.path) }
+    }
+    return { ok: true, worktrees: await listRepoWorktrees(repo) }
+  } catch (error) {
+    const classified = classifyError(error)
+    return { ok: false, status: classified.status, error: classified.message }
+  }
+}
+
+function mergeForSpaceScan(repo: Repo, gitWorktree: GitWorktreeInfo, store: Store): Worktree {
+  const worktreeId = `${repo.id}::${gitWorktree.path}`
+  return mergeWorktree(repo.id, gitWorktree, store.getWorktreeMeta(worktreeId), repo.displayName)
+}
+
+async function scanRepo(repo: Repo, scannedAt: number, store: Store): Promise<RepoScanResult> {
+  const listed = await listWorktreesForSpaceScan(repo)
+  if (!listed.ok) {
+    return {
+      worktrees: [],
+      summary: {
+        repoId: repo.id,
+        displayName: repo.displayName,
+        path: repo.path,
+        isRemote: Boolean(repo.connectionId),
+        worktreeCount: 0,
+        scannedWorktreeCount: 0,
+        unavailableWorktreeCount: 1,
+        totalSizeBytes: 0,
+        reclaimableBytes: 0,
+        error: listed.error
+      }
+    }
+  }
+
+  const worktrees = listed.worktrees.map((gitWorktree) =>
+    mergeForSpaceScan(repo, gitWorktree, store)
+  )
+  const remoteProvider = repo.connectionId ? getSshFilesystemProvider(repo.connectionId) : undefined
+  const rows = await mapLimit(worktrees, WORKTREE_SCAN_CONCURRENCY, async (worktree) => {
+    if (repo.connectionId) {
+      if (!remoteProvider) {
+        return createUnavailableWorktreeRow(
+          repo,
+          worktree,
+          scannedAt,
+          'unavailable',
+          `SSH filesystem for "${repo.connectionId}" is not connected.`
+        )
+      }
+      return scanRemoteWorktree(repo, worktree, scannedAt, remoteProvider)
+    }
+    return scanLocalWorktree(repo, worktree, scannedAt)
+  })
+
+  return {
+    worktrees: rows,
+    summary: {
+      repoId: repo.id,
+      displayName: repo.displayName,
+      path: repo.path,
+      isRemote: Boolean(repo.connectionId),
+      worktreeCount: rows.length,
+      scannedWorktreeCount: rows.filter((row) => row.status === 'ok').length,
+      unavailableWorktreeCount: rows.filter((row) => row.status !== 'ok').length,
+      totalSizeBytes: rows.reduce((sum, row) => sum + row.sizeBytes, 0),
+      reclaimableBytes: rows.reduce((sum, row) => sum + row.reclaimableBytes, 0),
+      error: null
+    }
+  }
+}
+
+export async function analyzeWorkspaceSpace(store: Store): Promise<WorkspaceSpaceAnalysis> {
+  const scannedAt = Date.now()
+  const repoResults = await mapLimit(store.getRepos(), 2, (repo) =>
+    scanRepo(repo, scannedAt, store)
+  )
+  const repos = repoResults.map((result) => result.summary)
+  const worktrees = repoResults
+    .flatMap((result) => result.worktrees)
+    .sort((a, b) => b.sizeBytes - a.sizeBytes || a.displayName.localeCompare(b.displayName))
+
+  return {
+    scannedAt,
+    totalSizeBytes: worktrees.reduce((sum, row) => sum + row.sizeBytes, 0),
+    reclaimableBytes: worktrees.reduce((sum, row) => sum + row.reclaimableBytes, 0),
+    worktreeCount: worktrees.length,
+    scannedWorktreeCount: worktrees.filter((row) => row.status === 'ok').length,
+    unavailableWorktreeCount:
+      worktrees.filter((row) => row.status !== 'ok').length +
+      repos.filter((repo) => repo.error !== null).length,
+    repos,
+    worktrees
+  }
+}

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -165,6 +165,7 @@ import type {
 } from '../shared/claude-usage-types'
 import type { RateLimitState } from '../shared/rate-limit-types'
 import type { SpeechModelManifest, SpeechModelState } from '../shared/speech-types'
+import type { WorkspaceSpaceAnalysis } from '../shared/workspace-space-types'
 import type { GhAuthDiagnostic } from '../shared/github-auth-types'
 import type {
   SshConnectionState,
@@ -525,6 +526,9 @@ export type PreloadApi = {
     onRemoteBranchConflict: (
       callback: (data: WorktreeRemoteBranchConflictEvent) => void
     ) => () => void
+  }
+  workspaceSpace: {
+    analyze: () => Promise<WorkspaceSpaceAnalysis>
   }
   pty: {
     spawn: (opts: {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -38,6 +38,7 @@ import type {
   RuntimeMobileMarkdownResponse
 } from '../shared/mobile-markdown-document'
 import type { RateLimitState } from '../shared/rate-limit-types'
+import type { WorkspaceSpaceAnalysis } from '../shared/workspace-space-types'
 import type { GhAuthDiagnostic } from '../shared/github-auth-types'
 import type {
   AddIssueCommentBySlugArgs,
@@ -487,6 +488,10 @@ const api = {
       ipcRenderer.on('worktree:remoteBranchConflict', listener)
       return () => ipcRenderer.removeListener('worktree:remoteBranchConflict', listener)
     }
+  },
+
+  workspaceSpace: {
+    analyze: (): Promise<WorkspaceSpaceAnalysis> => ipcRenderer.invoke('workspaceSpace:analyze')
   },
 
   pty: {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -49,6 +49,7 @@ import { TelemetryFirstLaunchSurface } from './components/TelemetryFirstLaunchSu
 import { ZoomOverlay } from './components/ZoomOverlay'
 import { shouldShowOnboarding } from './components/onboarding/should-show-onboarding'
 import { SshPassphraseDialog } from './components/settings/SshPassphraseDialog'
+import DeleteWorktreeDialog from './components/sidebar/DeleteWorktreeDialog'
 import {
   FloatingTerminalPanel,
   FloatingTerminalToggleButton
@@ -159,6 +160,7 @@ const TaskPage = lazy(() => import('./components/TaskPage'))
 const AutomationsPage = lazy(() => import('./components/automations/AutomationsPage'))
 const ActivityPrototypePage = lazy(() => import('./components/activity/ActivityPrototypePage'))
 const Settings = lazy(() => import('./components/settings/Settings'))
+const WorkspaceSpacePage = lazy(() => import('./components/workspace-space/WorkspaceSpacePage'))
 const QuickOpen = lazy(() => import('./components/QuickOpen'))
 const WorktreeJumpPalette = lazy(() => import('./components/WorktreeJumpPalette'))
 const NewWorkspaceComposerModal = lazy(() => import('./components/NewWorkspaceComposerModal'))
@@ -802,10 +804,10 @@ function App(): React.JSX.Element {
     activeWorktreeId !== null &&
     !hasTabBar &&
     effectiveActiveTabExpanded
-  // Why: Activity is a full-page navigation surface — same treatment as
-  // Settings — so the worktree sidebar is removed for that view, letting the
-  // thread list + agent terminal span edge-to-edge.
-  const showSidebar = activeView !== 'settings' && activeView !== 'activity'
+  // Why: Activity and Space are full-page navigation surfaces — same
+  // treatment as Settings — so the worktree sidebar is removed for those views.
+  const showSidebar =
+    activeView !== 'settings' && activeView !== 'activity' && activeView !== 'space'
   // Why: only the terminal workspace replaces the full-width titlebar with
   // split-column chrome. Full-page navigation views keep the draggable app
   // titlebar so their page-level controls can live in that window strip.
@@ -816,7 +818,8 @@ function App(): React.JSX.Element {
     activeView !== 'settings' &&
     activeView !== 'tasks' &&
     activeView !== 'activity' &&
-    activeView !== 'automations'
+    activeView !== 'automations' &&
+    activeView !== 'space'
 
   const handleToggleExpand = (): void => {
     if (!effectiveActiveTabId) {
@@ -903,7 +906,12 @@ function App(): React.JSX.Element {
 
       // Why: full-page navigation surfaces should not reveal the right sidebar;
       // they are designed as distraction-free content areas.
-      if (activeView === 'tasks' || activeView === 'activity' || activeView === 'automations') {
+      if (
+        activeView === 'tasks' ||
+        activeView === 'activity' ||
+        activeView === 'automations' ||
+        activeView === 'space'
+      ) {
         return
       }
 
@@ -1137,7 +1145,10 @@ function App(): React.JSX.Element {
 
   useEffect(() => {
     if (
-      (activeView === 'tasks' || activeView === 'activity' || activeView === 'automations') &&
+      (activeView === 'tasks' ||
+        activeView === 'activity' ||
+        activeView === 'automations' ||
+        activeView === 'space') &&
       rightSidebarOpen
     ) {
       // Why: hide the right sidebar immediately when entering full-page
@@ -1307,6 +1318,7 @@ function App(): React.JSX.Element {
                     {activeView === 'tasks' ? <TaskPage /> : null}
                     {activeView === 'automations' ? <AutomationsPage /> : null}
                     {activeView === 'activity' ? <ActivityPrototypePage /> : null}
+                    {activeView === 'space' ? <WorkspaceSpacePage /> : null}
                     {activeView === 'terminal' && !activeWorktreeId ? <Landing /> : null}
                   </Suspense>
                 </div>
@@ -1370,6 +1382,7 @@ function App(): React.JSX.Element {
       <TelemetryFirstLaunchSurface />
       <ZoomOverlay />
       <SshPassphraseDialog />
+      <DeleteWorktreeDialog />
       {onboarding && shouldShowOnboarding(onboarding) ? (
         <Suspense fallback={null}>
           <OnboardingFlow onboarding={onboarding} onOnboardingChange={setOnboarding} />

--- a/src/renderer/src/components/onboarding/onboarding-feature-setup.test.ts
+++ b/src/renderer/src/components/onboarding/onboarding-feature-setup.test.ts
@@ -52,6 +52,8 @@ const INSTALLED_CLI_STATUS: CliInstallStatus = {
 
 const GRANTED_COMPUTER_USE_STATUS: ComputerUsePermissionStatusResult = {
   platform: 'darwin',
+  helperAppPath: '/Applications/Orca Computer Use.app',
+  helperUnavailableReason: null,
   permissions: [
     { id: 'accessibility', status: 'granted' },
     { id: 'screenshots', status: 'granted' }
@@ -157,6 +159,8 @@ describe('onboarding feature setup runner', () => {
       getComputerUsePermissionStatus: vi.fn(
         async (): Promise<ComputerUsePermissionStatusResult> => ({
           platform: 'darwin',
+          helperAppPath: '/Applications/Orca Computer Use.app',
+          helperUnavailableReason: null,
           permissions: [
             { id: 'accessibility', status: 'not-granted' },
             { id: 'screenshots', status: 'granted' }

--- a/src/renderer/src/components/settings/AppearancePane.tsx
+++ b/src/renderer/src/components/settings/AppearancePane.tsx
@@ -61,23 +61,11 @@ const STATUS_BAR_TOGGLES: readonly {
   },
   {
     id: 'resource-usage',
-    title: 'Resource Usage',
-    description: 'Show CPU, memory, and terminal session indicators in the status bar.',
-    keywords: [
-      'status bar',
-      'resource',
-      'usage',
-      'memory',
-      'ram',
-      'cpu',
-      'terminal',
-      'sessions',
-      'pty',
-      'monitoring',
-      'performance'
-    ],
+    title: 'Resource Manager',
+    description: 'Show CPU, memory, terminal sessions, and workspace disk usage in the status bar.',
+    keywords: ['status bar', 'resource', 'manager', 'memory', 'cpu', 'terminal', 'disk', 'space'],
     toggleDescription:
-      'Show CPU, memory, and terminal session counts. Click it for a per-workspace breakdown and daemon controls.'
+      'Show the Resource Manager. Click it for CPU, memory, sessions, daemon controls, and workspace disk scans.'
   }
 ]
 

--- a/src/renderer/src/components/settings/ComputerUsePane.tsx
+++ b/src/renderer/src/components/settings/ComputerUsePane.tsx
@@ -67,20 +67,12 @@ function statusClass(status: ComputerUsePermissionStatus | undefined): string {
   return 'border-border bg-muted text-muted-foreground'
 }
 
-function isExpectedDevMissingHelperError(error: unknown): boolean {
-  return (
-    import.meta.env.DEV &&
-    error instanceof Error &&
-    error.message.includes('Orca Computer Use.app was not found')
-  )
-}
-
 export function ComputerUsePane(): React.JSX.Element {
   const [platform, setPlatform] = useState<NodeJS.Platform | null>(null)
   const [states, setStates] = useState<ComputerUsePermissionState[]>([])
   const [loading, setLoading] = useState(true)
   const [pendingId, setPendingId] = useState<ComputerUsePermissionId | null>(null)
-  const [helperUnavailableInDev, setHelperUnavailableInDev] = useState(false)
+  const [helperUnavailableReason, setHelperUnavailableReason] = useState<string | null>(null)
 
   const stateById = useMemo(
     () => new Map(states.map((state) => [state.id, state.status] as const)),
@@ -93,14 +85,8 @@ export function ComputerUsePane(): React.JSX.Element {
       const result = await window.api.computerUsePermissions.getStatus()
       setPlatform(result.platform)
       setStates(result.permissions)
-      setHelperUnavailableInDev(false)
+      setHelperUnavailableReason(result.helperUnavailableReason)
     } catch (error) {
-      if (isExpectedDevMissingHelperError(error)) {
-        setPlatform('darwin')
-        setStates(PERMISSIONS.map((permission) => ({ id: permission.id, status: 'not-granted' })))
-        setHelperUnavailableInDev(true)
-        return
-      }
       toast.error(
         error instanceof Error ? error.message : 'Could not load Computer Use permissions'
       )
@@ -166,10 +152,9 @@ export function ComputerUsePane(): React.JSX.Element {
                 Computer Use needs macOS privacy permissions before agents can inspect and operate
                 app windows.
               </p>
-              {helperUnavailableInDev ? (
+              {helperUnavailableReason ? (
                 <p className="text-xs text-muted-foreground">
-                  Computer Use permissions are unavailable in this dev build because the helper app
-                  has not been built.
+                  Computer Use permissions are unavailable because {helperUnavailableReason}.
                 </p>
               ) : null}
             </div>
@@ -208,7 +193,9 @@ export function ComputerUsePane(): React.JSX.Element {
                   <Button
                     variant="outline"
                     size="sm"
-                    disabled={pending || status === 'unsupported' || helperUnavailableInDev}
+                    disabled={
+                      pending || status === 'unsupported' || helperUnavailableReason !== null
+                    }
                     onClick={() => void openPermission(permission.id)}
                     className="shrink-0 gap-1.5"
                   >

--- a/src/renderer/src/components/sidebar/DeleteWorktreeDialog.tsx
+++ b/src/renderer/src/components/sidebar/DeleteWorktreeDialog.tsx
@@ -35,6 +35,10 @@ const DeleteWorktreeDialog = React.memo(function DeleteWorktreeDialog() {
           : [],
     [modalData.worktreeIds, worktreeId]
   )
+  const onDeleted =
+    typeof modalData.onDeleted === 'function'
+      ? (modalData.onDeleted as (worktreeIds: string[]) => void)
+      : null
   const worktree = useMemo(
     () => (worktreeId ? (allWorktrees().find((item) => item.id === worktreeId) ?? null) : null),
     [allWorktrees, worktreeId]
@@ -146,7 +150,9 @@ const DeleteWorktreeDialog = React.memo(function DeleteWorktreeDialog() {
               toast.error('Force delete failed', {
                 description: result.error
               })
+              return
             }
+            onDeleted?.([worktreeId])
           })
           .catch((err: unknown) => {
             toast.error('Failed to delete worktree', {
@@ -154,15 +160,23 @@ const DeleteWorktreeDialog = React.memo(function DeleteWorktreeDialog() {
             })
           })
       } else {
-        for (const target of worktrees) {
-          runWorktreeDeleteWithToast(target.id, target.displayName)
-        }
+        void Promise.all(
+          worktrees.map((target) => runWorktreeDeleteWithToast(target.id, target.displayName))
+        ).then((results) => {
+          const deletedIds = worktrees
+            .filter((_, index) => results[index])
+            .map((target) => target.id)
+          if (deletedIds.length > 0) {
+            onDeleted?.(deletedIds)
+          }
+        })
       }
       closeModal()
     },
     [
       closeModal,
       dontAskAgain,
+      onDeleted,
       persistDontAskAgainPreference,
       removeWorktree,
       worktreeIds.length,

--- a/src/renderer/src/components/sidebar/delete-worktree-flow.test.ts
+++ b/src/renderer/src/components/sidebar/delete-worktree-flow.test.ts
@@ -33,6 +33,7 @@ vi.mock('sonner', () => ({
   }
 }))
 
+import { toast } from 'sonner'
 import { runWorktreeBatchDelete } from './delete-worktree-flow'
 
 function setWorktrees(
@@ -57,14 +58,17 @@ describe('runWorktreeBatchDelete', () => {
     mocks.state.openModal.mockClear()
     mocks.state.removeWorktree.mockClear().mockResolvedValue({ ok: true })
     mocks.state.deleteStateByWorktreeId = {}
+    vi.mocked(toast.error).mockClear()
+    vi.mocked(toast.info).mockClear()
     setWorktrees([])
   })
 
   it('filters main worktrees and opens a batch confirmation for eligible targets', () => {
     setWorktrees([{ id: 'main', isMainWorktree: true }, { id: 'wt-1' }, { id: 'wt-2' }])
 
-    runWorktreeBatchDelete(['main', 'wt-1', 'wt-2'])
+    const started = runWorktreeBatchDelete(['main', 'wt-1', 'wt-2'])
 
+    expect(started).toBe(true)
     expect(mocks.state.clearWorktreeDeleteState).toHaveBeenCalledWith('wt-1')
     expect(mocks.state.clearWorktreeDeleteState).toHaveBeenCalledWith('wt-2')
     expect(mocks.state.clearWorktreeDeleteState).not.toHaveBeenCalledWith('main')
@@ -76,22 +80,41 @@ describe('runWorktreeBatchDelete', () => {
   it('opens the single-delete confirmation when only one target is eligible', () => {
     setWorktrees([{ id: 'main', isMainWorktree: true }, { id: 'wt-1' }])
 
-    runWorktreeBatchDelete(['main', 'wt-1'])
+    const started = runWorktreeBatchDelete(['main', 'wt-1'])
 
+    expect(started).toBe(true)
     expect(mocks.state.openModal).toHaveBeenCalledWith('delete-worktree', { worktreeId: 'wt-1' })
   })
 
-  it('runs every eligible delete immediately when confirmation is skipped', () => {
+  it('runs every eligible delete immediately when confirmation is skipped', async () => {
     mocks.state.settings = { skipDeleteWorktreeConfirm: true }
     setWorktrees([
       { id: 'wt-1', displayName: 'one' },
       { id: 'wt-2', displayName: 'two' }
     ])
+    const onDeleted = vi.fn()
 
-    runWorktreeBatchDelete(['wt-1', 'wt-2'])
+    const started = runWorktreeBatchDelete(['wt-1', 'wt-2'], { onDeleted })
 
+    expect(started).toBe(true)
     expect(mocks.state.openModal).not.toHaveBeenCalled()
     expect(mocks.state.removeWorktree).toHaveBeenCalledWith('wt-1', false)
     expect(mocks.state.removeWorktree).toHaveBeenCalledWith('wt-2', false)
+    await vi.waitFor(() => {
+      expect(onDeleted).toHaveBeenCalledWith(['wt-1', 'wt-2'])
+    })
+  })
+
+  it('reports when no selected worktrees are eligible', () => {
+    setWorktrees([{ id: 'main', isMainWorktree: true }])
+
+    const started = runWorktreeBatchDelete(['main', 'missing'])
+
+    expect(started).toBe(false)
+    expect(mocks.state.clearWorktreeDeleteState).not.toHaveBeenCalled()
+    expect(mocks.state.openModal).not.toHaveBeenCalled()
+    expect(toast.info).toHaveBeenCalledWith('No deletable workspaces selected', {
+      description: 'Refresh Space and try again if the workspace list looks stale.'
+    })
   })
 })

--- a/src/renderer/src/components/sidebar/delete-worktree-flow.ts
+++ b/src/renderer/src/components/sidebar/delete-worktree-flow.ts
@@ -5,6 +5,10 @@ import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 import { getDeleteWorktreeToastCopy } from './delete-worktree-toast'
 import type { Worktree } from '../../../../shared/types'
 
+type WorktreeBatchDeleteOptions = {
+  onDeleted?: (worktreeIds: string[]) => void
+}
+
 // Why: a failed delete almost always means the worktree still has changes
 // that need attention (uncommitted work, unpushed commits, conflicts). The
 // "View" affordance should surface those changes directly, not just bring
@@ -30,13 +34,16 @@ function viewWorktreeDiff(worktreeId: string): void {
  * concerns into the store slice while still preventing the two delete
  * entry points from drifting apart.
  */
-export function runWorktreeDeleteWithToast(worktreeId: string, worktreeName: string): void {
+export function runWorktreeDeleteWithToast(
+  worktreeId: string,
+  worktreeName: string
+): Promise<boolean> {
   const removeWorktree = useAppStore.getState().removeWorktree
 
-  removeWorktree(worktreeId, false)
+  return removeWorktree(worktreeId, false)
     .then((result) => {
       if (result.ok) {
-        return
+        return true
       }
       const state = useAppStore.getState().deleteStateByWorktreeId[worktreeId]
       const canForceDelete = state?.canForceDelete ?? false
@@ -80,11 +87,13 @@ export function runWorktreeDeleteWithToast(worktreeId: string, worktreeName: str
             }
           : undefined
       })
+      return false
     })
     .catch((err: unknown) => {
       toast.error('Failed to delete worktree', {
         description: err instanceof Error ? err.message : String(err)
       })
+      return false
     })
 }
 
@@ -122,13 +131,16 @@ export function runWorktreeDelete(worktreeId: string): void {
   state.clearWorktreeDeleteState(worktreeId)
   const skipConfirm = state.settings?.skipDeleteWorktreeConfirm ?? false
   if (skipConfirm) {
-    runWorktreeDeleteWithToast(worktreeId, target.displayName)
+    void runWorktreeDeleteWithToast(worktreeId, target.displayName)
     return
   }
   state.openModal('delete-worktree', { worktreeId })
 }
 
-export function runWorktreeBatchDelete(worktreeIds: readonly string[]): void {
+export function runWorktreeBatchDelete(
+  worktreeIds: readonly string[],
+  options: WorktreeBatchDeleteOptions = {}
+): boolean {
   const state = useAppStore.getState()
   const worktreeMap = getWorktreeMapFromState(state)
   const targets = worktreeIds
@@ -136,7 +148,10 @@ export function runWorktreeBatchDelete(worktreeIds: readonly string[]): void {
     .filter((worktree): worktree is Worktree => worktree != null && !worktree.isMainWorktree)
 
   if (targets.length === 0) {
-    return
+    toast.info('No deletable workspaces selected', {
+      description: 'Refresh Space and try again if the workspace list looks stale.'
+    })
+    return false
   }
 
   for (const target of targets) {
@@ -145,16 +160,28 @@ export function runWorktreeBatchDelete(worktreeIds: readonly string[]): void {
 
   const skipConfirm = state.settings?.skipDeleteWorktreeConfirm ?? false
   if (skipConfirm) {
-    for (const target of targets) {
-      runWorktreeDeleteWithToast(target.id, target.displayName)
-    }
-    return
+    void Promise.all(
+      targets.map((target) => runWorktreeDeleteWithToast(target.id, target.displayName))
+    ).then((results) => {
+      const deletedIds = targets.filter((_, index) => results[index]).map((target) => target.id)
+      if (deletedIds.length > 0) {
+        options.onDeleted?.(deletedIds)
+      }
+    })
+    return true
   }
 
   if (targets.length === 1) {
-    state.openModal('delete-worktree', { worktreeId: targets[0].id })
-    return
+    state.openModal('delete-worktree', {
+      worktreeId: targets[0].id,
+      ...(options.onDeleted ? { onDeleted: options.onDeleted } : {})
+    })
+    return true
   }
 
-  state.openModal('delete-worktree', { worktreeIds: targets.map((target) => target.id) })
+  state.openModal('delete-worktree', {
+    worktreeIds: targets.map((target) => target.id),
+    ...(options.onDeleted ? { onDeleted: options.onDeleted } : {})
+  })
+  return true
 }

--- a/src/renderer/src/components/sidebar/index.tsx
+++ b/src/renderer/src/components/sidebar/index.tsx
@@ -7,7 +7,6 @@ import SidebarNav from './SidebarNav'
 import WorktreeList from './WorktreeList'
 import SidebarToolbar from './SidebarToolbar'
 import WorktreeMetaDialog from './WorktreeMetaDialog'
-import DeleteWorktreeDialog from './DeleteWorktreeDialog'
 import NonGitFolderDialog from './NonGitFolderDialog'
 import RemoveFolderDialog from './RemoveFolderDialog'
 import AddRepoDialog from './AddRepoDialog'
@@ -64,7 +63,6 @@ function Sidebar(): React.JSX.Element {
 
       {/* Dialog (rendered outside sidebar to avoid clipping) */}
       <WorktreeMetaDialog />
-      <DeleteWorktreeDialog />
       <NonGitFolderDialog />
       <RemoveFolderDialog />
       <AddRepoDialog />

--- a/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.tsx
@@ -47,6 +47,7 @@ import {
   type UnifiedSessionRow,
   type UnifiedWorktreeRow
 } from './mergeSnapshotAndSessions'
+import { WorkspaceSpaceCompactPanel } from './WorkspaceSpaceCompactPanel'
 
 const POLL_MS = 2_000
 const SESSIONS_POLL_MS = 10_000
@@ -654,6 +655,7 @@ export function ResourceUsageStatusSegment({
   const tabsByWorktree = useAppStore((s) => s.tabsByWorktree)
   const runtimePaneTitlesByTabId = useAppStore((s) => s.runtimePaneTitlesByTabId)
   const setActiveView = useAppStore((s) => s.setActiveView)
+  const openSpacePage = useAppStore((s) => s.openSpacePage)
   const repos = useAppStore((s) => s.repos)
 
   const [open, setOpen] = useState(false)
@@ -985,6 +987,11 @@ export function ResourceUsageStatusSegment({
     }
   }, [killConfirm, refreshSessions])
 
+  const openSpaceResults = useCallback((): void => {
+    setOpen(false)
+    openSpacePage()
+  }, [openSpacePage])
+
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <Tooltip delayDuration={150}>
@@ -993,7 +1000,7 @@ export function ResourceUsageStatusSegment({
             <button
               type="button"
               className="inline-flex items-center gap-1.5 cursor-pointer rounded px-1 py-0.5 hover:bg-accent/70"
-              aria-label="Resource usage"
+              aria-label="Resource manager"
             >
               <MemoryStick className="size-3 text-muted-foreground" />
               {!iconOnly && (
@@ -1023,7 +1030,7 @@ export function ResourceUsageStatusSegment({
           </PopoverTrigger>
         </TooltipTrigger>
         <TooltipContent side="top" sideOffset={6}>
-          Resource usage — {memBadgeLabel} · {sessions.length} session
+          Resource Manager — {memBadgeLabel} · {sessions.length} session
           {sessions.length === 1 ? '' : 's'}
         </TooltipContent>
       </Tooltip>
@@ -1032,7 +1039,7 @@ export function ResourceUsageStatusSegment({
         side="top"
         align="end"
         sideOffset={8}
-        className="w-[26rem] p-0"
+        className="w-[26rem] max-w-[calc(100vw-2rem)] p-0"
         onOpenAutoFocus={(event) => event.preventDefault()}
         // Why: clicking a terminal row activates a tab, which causes xterm
         // to programmatically focus the terminal DOM node. Radix would
@@ -1041,13 +1048,10 @@ export function ResourceUsageStatusSegment({
         // outside-click (onPointerDownOutside default) and Escape.
         onFocusOutside={(event) => event.preventDefault()}
       >
-        {/* Why: header strip — title on the left, daemon-control icons on
-            the right. The tab switcher was removed because a single unified
-            list now covers what the two tabs used to show. */}
         <div className="flex items-center justify-between gap-2 border-b border-border px-3 py-1.5">
-          <div className="flex items-center gap-1.5 text-[11px] font-medium text-foreground">
-            <MemoryStick className="size-3 text-muted-foreground" />
-            <span>Resource Usage</span>
+          <div className="flex min-w-0 items-center gap-1.5 text-[11px] font-medium text-foreground">
+            <MemoryStick className="size-3 shrink-0 text-muted-foreground" />
+            <span className="truncate">Resource Manager</span>
           </div>
 
           <div className="flex items-center gap-0.5">
@@ -1280,6 +1284,8 @@ export function ResourceUsageStatusSegment({
             </button>
           </div>
         )}
+
+        <WorkspaceSpaceCompactPanel onOpenFullPage={openSpaceResults} />
       </PopoverContent>
       {/* Why: Radix Dialog must not be a descendant of PopoverContent — when
           the popover unmounts (e.g. clicking outside, focus moving to the

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -985,7 +985,7 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
             onCheckedChange={() => toggleStatusBarItem('resource-usage')}
           >
             <Activity className="size-3.5" />
-            Resource Usage
+            Resource Manager
           </DropdownMenuCheckboxItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/src/renderer/src/components/status-bar/WorkspaceSpaceCompactPanel.tsx
+++ b/src/renderer/src/components/status-bar/WorkspaceSpaceCompactPanel.tsx
@@ -1,0 +1,92 @@
+import { useCallback } from 'react'
+import { AlertTriangle, HardDrive, Loader2, RefreshCw } from 'lucide-react'
+import { useAppStore } from '../../store'
+import { Badge } from '../ui/badge'
+import { Button } from '../ui/button'
+import { formatBytes, getWorkspaceSpaceScanTimeLabel } from './workspace-space-format'
+
+export function WorkspaceSpaceCompactPanel({
+  onOpenFullPage
+}: {
+  onOpenFullPage: () => void
+}): React.JSX.Element {
+  const analysis = useAppStore((state) => state.workspaceSpaceAnalysis)
+  const scanError = useAppStore((state) => state.workspaceSpaceScanError)
+  const isScanning = useAppStore((state) => state.workspaceSpaceScanning)
+  const refreshWorkspaceSpace = useAppStore((state) => state.refreshWorkspaceSpace)
+
+  const scan = useCallback((): void => {
+    void refreshWorkspaceSpace().catch(() => {
+      /* scanError is stored by the slice */
+    })
+  }, [refreshWorkspaceSpace])
+
+  return (
+    <div className="border-t border-border/50 bg-muted/15 px-3 py-2">
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <HardDrive className="size-3.5 shrink-0 text-muted-foreground" />
+          <div className="min-w-0">
+            <div className="flex min-w-0 items-center gap-1.5 text-[11px] font-medium text-foreground">
+              <span className="truncate">Space</span>
+              <Badge variant="secondary" className="px-1.5 py-0 text-[9px]">
+                Beta
+              </Badge>
+            </div>
+            <div className="truncate text-[11px] text-muted-foreground">
+              {analysis
+                ? `${formatBytes(analysis.reclaimableBytes)} reclaimable · ${analysis.scannedWorktreeCount} workspaces`
+                : isScanning
+                  ? 'Scanning workspace sizes.'
+                  : 'Workspace disk usage is not scanned.'}
+            </div>
+          </div>
+        </div>
+
+        <div className="flex shrink-0 items-center gap-1">
+          <Button variant="outline" size="xs" onClick={scan} disabled={isScanning}>
+            {isScanning ? (
+              <Loader2 className="size-3 animate-spin" />
+            ) : (
+              <RefreshCw className="size-3" />
+            )}
+            {isScanning ? 'Scanning' : analysis ? 'Refresh' : 'Scan'}
+          </Button>
+          <Button variant="ghost" size="xs" onClick={onOpenFullPage}>
+            Open
+          </Button>
+        </div>
+      </div>
+
+      {analysis ? (
+        <div className="mt-2 grid grid-cols-3 gap-1 text-[10px] tabular-nums">
+          <div className="rounded border border-border/60 bg-background/40 px-2 py-1">
+            <div className="text-muted-foreground">Scanned</div>
+            <div className="truncate font-medium text-foreground">
+              {formatBytes(analysis.totalSizeBytes)}
+            </div>
+          </div>
+          <div className="rounded border border-border/60 bg-background/40 px-2 py-1">
+            <div className="text-muted-foreground">Freeable</div>
+            <div className="truncate font-medium text-foreground">
+              {formatBytes(analysis.reclaimableBytes)}
+            </div>
+          </div>
+          <div className="rounded border border-border/60 bg-background/40 px-2 py-1">
+            <div className="text-muted-foreground">Updated</div>
+            <div className="truncate font-medium text-foreground">
+              {getWorkspaceSpaceScanTimeLabel(analysis.scannedAt)}
+            </div>
+          </div>
+        </div>
+      ) : null}
+
+      {scanError ? (
+        <div className="mt-1.5 flex items-start gap-1.5 text-[11px] text-destructive">
+          <AlertTriangle className="mt-0.5 size-3 shrink-0" />
+          <span className="min-w-0 truncate">{scanError}</span>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/src/renderer/src/components/status-bar/WorkspaceSpaceManagerPanel.tsx
+++ b/src/renderer/src/components/status-bar/WorkspaceSpaceManagerPanel.tsx
@@ -1,0 +1,685 @@
+/* eslint-disable max-lines -- Why: the analyzer's private treemap, selection,
+   breakdown, and table pieces share one scan state and should evolve as one resource-manager surface. */
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import {
+  AlertTriangle,
+  ArrowDown,
+  ArrowUp,
+  Check,
+  Circle,
+  GitBranch,
+  HardDrive,
+  Loader2,
+  RefreshCw,
+  Search,
+  Server,
+  Trash2
+} from 'lucide-react'
+import type {
+  WorkspaceSpaceItem,
+  WorkspaceSpaceWorktree
+} from '../../../../shared/workspace-space-types'
+import { cn } from '@/lib/utils'
+import { toast } from 'sonner'
+import { useAppStore } from '../../store'
+import { runWorktreeBatchDelete } from '../sidebar/delete-worktree-flow'
+import { Badge } from '../ui/badge'
+import { Button } from '../ui/button'
+import { Input } from '../ui/input'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
+import {
+  formatBytes,
+  formatCompactCount,
+  getWorkspaceSpaceBranchLabel,
+  getWorkspaceSpaceScanTimeLabel,
+  getWorkspaceSpaceStatusLabel
+} from './workspace-space-format'
+import { buildTreemapLayout, type TreemapRect } from './workspace-space-layout'
+import {
+  filterWorkspaceSpaceRows,
+  getSelectedDeletableWorkspaceIds,
+  sortWorkspaceSpaceRows,
+  type WorkspaceSpaceSortDirection,
+  type WorkspaceSpaceSortKey
+} from './workspace-space-presentation'
+
+const TREEMAP_FILLS = [
+  'color-mix(in srgb, var(--chart-2) 34%, var(--card))',
+  'color-mix(in srgb, var(--foreground) 20%, var(--card))',
+  'color-mix(in srgb, var(--chart-4) 28%, var(--card))',
+  'color-mix(in srgb, var(--primary) 24%, var(--card))',
+  'color-mix(in srgb, var(--chart-1) 38%, var(--card))'
+]
+
+function getTreemapFill(rect: TreemapRect, selected: boolean): string {
+  if (selected) {
+    return 'color-mix(in srgb, var(--ring) 40%, var(--card))'
+  }
+  return TREEMAP_FILLS[rect.index % TREEMAP_FILLS.length]
+}
+
+function Metric({ label, value }: { label: string; value: string }): React.JSX.Element {
+  return (
+    <div className="min-w-0 px-4 py-3">
+      <div className="truncate text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
+        {label}
+      </div>
+      <div className="mt-1 truncate text-lg font-semibold tabular-nums">{value}</div>
+    </div>
+  )
+}
+
+function CheckButton({
+  checked,
+  disabled,
+  label,
+  onClick
+}: {
+  checked: boolean
+  disabled?: boolean
+  label: string
+  onClick: () => void
+}): React.JSX.Element {
+  return (
+    <button
+      type="button"
+      role="checkbox"
+      aria-checked={checked}
+      aria-label={label}
+      disabled={disabled}
+      onClick={(event) => {
+        event.stopPropagation()
+        onClick()
+      }}
+      className={cn(
+        'flex size-4 shrink-0 items-center justify-center rounded-sm border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+        checked
+          ? 'border-foreground bg-foreground text-background'
+          : 'border-muted-foreground/50 bg-background/40 text-transparent',
+        disabled && 'cursor-default opacity-35'
+      )}
+    >
+      {checked ? <Check className="size-3" strokeWidth={3} /> : null}
+    </button>
+  )
+}
+
+function SortIndicator({
+  sortKey,
+  activeKey,
+  direction
+}: {
+  sortKey: WorkspaceSpaceSortKey
+  activeKey: WorkspaceSpaceSortKey
+  direction: WorkspaceSpaceSortDirection
+}): React.JSX.Element {
+  if (sortKey !== activeKey) {
+    return <Circle className="size-3 opacity-0" />
+  }
+  return direction === 'asc' ? <ArrowUp className="size-3" /> : <ArrowDown className="size-3" />
+}
+
+function StatusBadge({ worktree }: { worktree: WorkspaceSpaceWorktree }): React.JSX.Element {
+  if (worktree.status !== 'ok') {
+    return (
+      <Badge variant="outline" className="border-destructive/30 text-destructive">
+        {getWorkspaceSpaceStatusLabel(worktree.status)}
+      </Badge>
+    )
+  }
+  if (worktree.isMainWorktree) {
+    return <Badge variant="outline">Main</Badge>
+  }
+  return <Badge variant="secondary">Deletable</Badge>
+}
+
+function WorkspaceTreemap({
+  rows,
+  isScanning,
+  selectedWorktreeId,
+  onSelect
+}: {
+  rows: WorkspaceSpaceWorktree[]
+  isScanning: boolean
+  selectedWorktreeId: string | null
+  onSelect: (worktreeId: string) => void
+}): React.JSX.Element {
+  const rects = useMemo(
+    () =>
+      buildTreemapLayout(
+        rows
+          .filter((row) => row.status === 'ok' && row.sizeBytes > 0)
+          .map((row) => ({
+            id: row.worktreeId,
+            label: row.displayName,
+            sizeBytes: row.sizeBytes
+          }))
+      ),
+    [rows]
+  )
+
+  if (rects.length === 0) {
+    return (
+      <div className="flex h-72 items-center justify-center rounded-lg border border-dashed border-border/70 bg-muted/20 text-sm text-muted-foreground">
+        <span className="flex items-center gap-2">
+          {isScanning ? <Loader2 className="size-4 animate-spin" /> : null}
+          {isScanning
+            ? 'Scanning workspace sizes. You can leave this page.'
+            : 'No scanned workspace sizes yet.'}
+        </span>
+      </div>
+    )
+  }
+
+  return (
+    <div className="relative h-72 overflow-hidden rounded-lg border border-border/70 bg-muted/20">
+      {rects.map((rect) => {
+        const area = rect.width * rect.height
+        const selected = rect.id === selectedWorktreeId
+        return (
+          <button
+            key={rect.id}
+            type="button"
+            aria-label={`${rect.label}, ${formatBytes(rect.sizeBytes)}`}
+            title={`${rect.label} • ${formatBytes(rect.sizeBytes)}`}
+            onClick={() => onSelect(rect.id)}
+            className={cn(
+              'absolute overflow-hidden border border-background/80 p-2 text-left transition-[filter,outline] hover:brightness-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+              selected && 'ring-2 ring-ring ring-offset-1 ring-offset-background'
+            )}
+            style={{
+              left: `${rect.x}%`,
+              top: `${rect.y}%`,
+              width: `${rect.width}%`,
+              height: `${rect.height}%`,
+              background: getTreemapFill(rect, selected)
+            }}
+          >
+            {area >= 80 ? (
+              <span className="block min-w-0 text-[11px] font-medium leading-tight text-foreground">
+                <span className="block truncate">{rect.label}</span>
+                {area >= 180 ? (
+                  <span className="mt-0.5 block truncate text-muted-foreground">
+                    {formatBytes(rect.sizeBytes)}
+                  </span>
+                ) : null}
+              </span>
+            ) : null}
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+function SizeBar({ value, max }: { value: number; max: number }): React.JSX.Element {
+  const pct = max > 0 ? Math.max(2, Math.min(100, (value / max) * 100)) : 0
+  return (
+    <div className="h-1.5 overflow-hidden rounded-full bg-muted">
+      <div className="h-full rounded-full bg-foreground/65" style={{ width: `${pct}%` }} />
+    </div>
+  )
+}
+
+function BreakdownList({
+  worktree,
+  isScanning
+}: {
+  worktree: WorkspaceSpaceWorktree | null
+  isScanning: boolean
+}): React.JSX.Element {
+  if (!worktree) {
+    return (
+      <div className="flex h-full min-h-72 items-center justify-center rounded-lg border border-dashed border-border/70 bg-muted/15 text-sm text-muted-foreground">
+        <span className="flex items-center gap-2">
+          {isScanning ? <Loader2 className="size-4 animate-spin" /> : null}
+          {isScanning
+            ? 'Scanning workspace sizes. You can leave this page.'
+            : 'Select a workspace to inspect.'}
+        </span>
+      </div>
+    )
+  }
+
+  const maxChildSize = Math.max(...worktree.topLevelItems.map((item) => item.sizeBytes), 0)
+  const topLevelItemCount = worktree.topLevelItems.length + worktree.omittedTopLevelItemCount
+  return (
+    <div className="min-h-72 rounded-lg border border-border/70 bg-background/35">
+      <div className="border-b border-border/60 px-4 py-3">
+        <div className="flex min-w-0 items-center justify-between gap-3">
+          <div className="min-w-0">
+            <div className="truncate text-sm font-semibold">{worktree.displayName}</div>
+            <div className="mt-0.5 truncate text-xs text-muted-foreground">
+              {worktree.repoDisplayName}
+            </div>
+          </div>
+          <div className="shrink-0 text-right">
+            <div className="text-sm font-semibold tabular-nums">
+              {formatBytes(worktree.sizeBytes)}
+            </div>
+            <div className="text-[11px] text-muted-foreground">
+              {formatCompactCount(topLevelItemCount)} top-level items
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {worktree.status !== 'ok' ? (
+        <div className="flex items-start gap-2 px-4 py-4 text-xs text-destructive">
+          <AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
+          <span className="min-w-0 break-words">{worktree.error ?? 'Scan failed.'}</span>
+        </div>
+      ) : worktree.topLevelItems.length === 0 ? (
+        <div className="px-4 py-8 text-center text-sm text-muted-foreground">No files found.</div>
+      ) : (
+        <div className="max-h-72 overflow-y-auto scrollbar-sleek px-3 py-3">
+          <div className="space-y-2">
+            {worktree.topLevelItems.slice(0, 12).map((item) => (
+              <BreakdownRow key={`${item.path}:${item.name}`} item={item} maxSize={maxChildSize} />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function BreakdownRow({
+  item,
+  maxSize
+}: {
+  item: WorkspaceSpaceItem
+  maxSize: number
+}): React.JSX.Element {
+  return (
+    <div className="space-y-1.5 rounded-md px-2 py-1.5 hover:bg-accent/50">
+      <div className="flex min-w-0 items-center justify-between gap-3 text-xs">
+        <span className="min-w-0 truncate font-medium">{item.name}</span>
+        <span className="shrink-0 tabular-nums text-muted-foreground">
+          {formatBytes(item.sizeBytes)}
+        </span>
+      </div>
+      <SizeBar value={item.sizeBytes} max={maxSize} />
+    </div>
+  )
+}
+
+function WorkspaceRow({
+  worktree,
+  maxSize,
+  selected,
+  inspected,
+  onToggleSelected,
+  onInspect
+}: {
+  worktree: WorkspaceSpaceWorktree
+  maxSize: number
+  selected: boolean
+  inspected: boolean
+  onToggleSelected: () => void
+  onInspect: () => void
+}): React.JSX.Element {
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={onInspect}
+      onKeyDown={(event) => {
+        if (event.key !== 'Enter' && event.key !== ' ') {
+          return
+        }
+        event.preventDefault()
+        onInspect()
+      }}
+      className={cn(
+        'grid w-full cursor-pointer grid-cols-[1.75rem_minmax(0,1.35fr)_minmax(9rem,0.65fr)_8rem_6rem] items-center gap-3 border-b border-border/45 px-3 py-2.5 text-left text-sm transition-colors last:border-b-0 hover:bg-accent/45 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+        inspected && 'bg-accent/55'
+      )}
+    >
+      <CheckButton
+        checked={selected}
+        disabled={!worktree.canDelete || worktree.status !== 'ok'}
+        label={`Select ${worktree.displayName}`}
+        onClick={onToggleSelected}
+      />
+
+      <div className="min-w-0">
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="min-w-0 truncate font-medium">{worktree.displayName}</span>
+          {worktree.isRemote ? (
+            <Server className="size-3.5 shrink-0 text-muted-foreground" />
+          ) : null}
+          {worktree.isSparse ? <Badge variant="outline">Sparse</Badge> : null}
+        </div>
+        <div className="mt-1 flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
+          <GitBranch className="size-3 shrink-0" />
+          <span className="truncate">{getWorkspaceSpaceBranchLabel(worktree)}</span>
+        </div>
+        <div className="mt-0.5 truncate font-mono text-[11px] text-muted-foreground">
+          {worktree.path}
+        </div>
+      </div>
+
+      <div className="min-w-0 text-xs">
+        <div className="truncate font-medium">{worktree.repoDisplayName}</div>
+        <div className="mt-0.5 truncate font-mono text-[11px] text-muted-foreground">
+          {worktree.repoPath}
+        </div>
+      </div>
+
+      <div className="min-w-0 space-y-1.5">
+        <div className="text-right text-sm font-medium tabular-nums">
+          {worktree.status === 'ok' ? formatBytes(worktree.sizeBytes) : '—'}
+        </div>
+        <SizeBar value={worktree.sizeBytes} max={maxSize} />
+      </div>
+
+      <div className="flex justify-end">
+        <StatusBadge worktree={worktree} />
+      </div>
+    </div>
+  )
+}
+
+export function WorkspaceSpaceManagerPanel(): React.JSX.Element {
+  const analysis = useAppStore((state) => state.workspaceSpaceAnalysis)
+  const scanError = useAppStore((state) => state.workspaceSpaceScanError)
+  const isScanning = useAppStore((state) => state.workspaceSpaceScanning)
+  const refreshWorkspaceSpace = useAppStore((state) => state.refreshWorkspaceSpace)
+  const removeWorkspaceSpaceWorktrees = useAppStore((state) => state.removeWorkspaceSpaceWorktrees)
+  const [query, setQuery] = useState('')
+  const [onlyDeletable, setOnlyDeletable] = useState(false)
+  const [sortKey, setSortKey] = useState<WorkspaceSpaceSortKey>('size')
+  const [sortDirection, setSortDirection] = useState<WorkspaceSpaceSortDirection>('desc')
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(() => new Set())
+  const [inspectedWorktreeId, setInspectedWorktreeId] = useState<string | null>(null)
+
+  const refresh = useCallback((): void => {
+    void refreshWorkspaceSpace().catch(() => {
+      /* scanError is stored by the slice */
+    })
+  }, [refreshWorkspaceSpace])
+
+  const sourceRows = useMemo(() => analysis?.worktrees ?? [], [analysis?.worktrees])
+
+  const rows = useMemo(
+    () =>
+      sortWorkspaceSpaceRows(
+        filterWorkspaceSpaceRows(sourceRows, query, onlyDeletable),
+        sortKey,
+        sortDirection
+      ),
+    [onlyDeletable, query, sortDirection, sortKey, sourceRows]
+  )
+
+  const inspectedWorktree =
+    rows.find((row) => row.worktreeId === inspectedWorktreeId) ??
+    rows.find((row) => row.status === 'ok') ??
+    null
+  const maxSize = Math.max(...rows.map((row) => row.sizeBytes), 0)
+  const selectedDeletableIds = getSelectedDeletableWorkspaceIds(rows, selectedIds)
+  const visibleDeletableIds = rows
+    .filter((row) => row.canDelete && row.status === 'ok')
+    .map((row) => row.worktreeId)
+  const allVisibleSelected =
+    visibleDeletableIds.length > 0 && visibleDeletableIds.every((id) => selectedIds.has(id))
+  const isInitialScan = isScanning && !analysis
+
+  useEffect(() => {
+    if (!analysis) {
+      setInspectedWorktreeId(null)
+      return
+    }
+    setInspectedWorktreeId((current) =>
+      current && analysis.worktrees.some((worktree) => worktree.worktreeId === current)
+        ? current
+        : (analysis.worktrees.find((worktree) => worktree.status === 'ok')?.worktreeId ?? null)
+    )
+  }, [analysis])
+
+  useEffect(() => {
+    setSelectedIds((current) => {
+      const valid = new Set(sourceRows.map((row) => row.worktreeId))
+      const next = new Set([...current].filter((id) => valid.has(id)))
+      return next.size === current.size ? current : next
+    })
+  }, [sourceRows])
+
+  const toggleSort = (key: WorkspaceSpaceSortKey): void => {
+    if (sortKey === key) {
+      setSortDirection((current) => (current === 'asc' ? 'desc' : 'asc'))
+      return
+    }
+    setSortKey(key)
+    setSortDirection(key === 'name' || key === 'repo' ? 'asc' : 'desc')
+  }
+
+  const toggleSelection = (worktreeId: string): void => {
+    setSelectedIds((current) => {
+      const next = new Set(current)
+      if (next.has(worktreeId)) {
+        next.delete(worktreeId)
+      } else {
+        next.add(worktreeId)
+      }
+      return next
+    })
+  }
+
+  const toggleVisibleSelection = (): void => {
+    setSelectedIds((current) => {
+      const next = new Set(current)
+      if (allVisibleSelected) {
+        for (const id of visibleDeletableIds) {
+          next.delete(id)
+        }
+      } else {
+        for (const id of visibleDeletableIds) {
+          next.add(id)
+        }
+      }
+      return next
+    })
+  }
+
+  const deleteSelected = (): void => {
+    if (selectedDeletableIds.length === 0) {
+      return
+    }
+    const started = runWorktreeBatchDelete(selectedDeletableIds, {
+      onDeleted: (deletedIds) => {
+        removeWorkspaceSpaceWorktrees(deletedIds)
+        setInspectedWorktreeId((current) =>
+          current && deletedIds.includes(current) ? null : current
+        )
+        toast.success(deletedIds.length === 1 ? 'Workspace deleted' : 'Workspaces deleted', {
+          description: `${deletedIds.length} ${deletedIds.length === 1 ? 'workspace' : 'workspaces'} removed from Space.`
+        })
+      }
+    })
+    if (started) {
+      setSelectedIds(new Set<string>())
+    }
+  }
+
+  return (
+    <div className="space-y-5">
+      <div className="grid overflow-hidden rounded-lg border border-border/65 bg-background/35 md:grid-cols-4 md:divide-x md:divide-border/60">
+        <Metric label="Scanned" value={analysis ? formatBytes(analysis.totalSizeBytes) : '—'} />
+        <Metric
+          label="Reclaimable"
+          value={analysis ? formatBytes(analysis.reclaimableBytes) : '—'}
+        />
+        <Metric label="Workspaces" value={analysis ? String(analysis.scannedWorktreeCount) : '—'} />
+        <Metric
+          label="Updated"
+          value={
+            analysis
+              ? getWorkspaceSpaceScanTimeLabel(analysis.scannedAt)
+              : isScanning
+                ? 'Scanning'
+                : '—'
+          }
+        />
+      </div>
+
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex min-w-0 items-center gap-2 text-xs text-muted-foreground">
+          <HardDrive className="size-4 shrink-0" />
+          <span className="truncate">
+            {analysis
+              ? `${formatBytes(analysis.reclaimableBytes)} can be reclaimed from linked worktrees.`
+              : isScanning
+                ? 'Scanning workspace sizes in the background. You can leave this page.'
+                : 'Run a scan to inspect workspace sizes.'}
+          </span>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={refresh}
+          disabled={isScanning}
+          className="w-28 gap-1.5"
+        >
+          {isScanning ? (
+            <Loader2 className="size-3.5 animate-spin" />
+          ) : (
+            <RefreshCw className="size-3.5" />
+          )}
+          {isScanning ? 'Scanning' : analysis ? 'Refresh' : 'Scan'}
+        </Button>
+      </div>
+
+      {scanError ? (
+        <div className="flex items-start gap-2 rounded-md border border-destructive/35 bg-destructive/8 px-3 py-2 text-xs text-destructive">
+          <AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
+          <span className="min-w-0 break-words">{scanError}</span>
+        </div>
+      ) : null}
+
+      <div className="grid gap-4 xl:grid-cols-[minmax(0,1.4fr)_minmax(20rem,0.6fr)]">
+        <WorkspaceTreemap
+          rows={sourceRows}
+          isScanning={isInitialScan}
+          selectedWorktreeId={inspectedWorktree?.worktreeId ?? null}
+          onSelect={setInspectedWorktreeId}
+        />
+        <BreakdownList worktree={inspectedWorktree} isScanning={isInitialScan} />
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="relative min-w-[16rem] flex-1">
+          <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Filter workspaces"
+            className="pl-9"
+          />
+        </div>
+
+        <Select
+          value={sortKey}
+          onValueChange={(value) => setSortKey(value as WorkspaceSpaceSortKey)}
+        >
+          <SelectTrigger className="w-36">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="size">Size</SelectItem>
+            <SelectItem value="name">Name</SelectItem>
+            <SelectItem value="repo">Repository</SelectItem>
+            <SelectItem value="activity">Activity</SelectItem>
+          </SelectContent>
+        </Select>
+
+        <Button
+          variant={onlyDeletable ? 'secondary' : 'outline'}
+          size="sm"
+          onClick={() => setOnlyDeletable((current) => !current)}
+          className="w-32"
+        >
+          {onlyDeletable ? 'Deletable' : 'All'}
+        </Button>
+
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={toggleVisibleSelection}
+          disabled={visibleDeletableIds.length === 0}
+          className="w-32 gap-1.5"
+        >
+          <Check className="size-3.5" />
+          {allVisibleSelected ? 'Clear' : 'Select'}
+        </Button>
+
+        <Button
+          variant="destructive"
+          size="sm"
+          onClick={deleteSelected}
+          disabled={selectedDeletableIds.length === 0}
+          className="w-32 gap-1.5"
+        >
+          <Trash2 className="size-3.5" />
+          {selectedDeletableIds.length > 0 ? `Delete ${selectedDeletableIds.length}` : 'Delete'}
+        </Button>
+      </div>
+
+      <div className="overflow-hidden rounded-lg border border-border/70 bg-background/30">
+        <div className="grid grid-cols-[1.75rem_minmax(0,1.35fr)_minmax(9rem,0.65fr)_8rem_6rem] gap-3 border-b border-border/60 px-3 py-2 text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
+          <div />
+          <button
+            type="button"
+            onClick={() => toggleSort('name')}
+            className="flex items-center gap-1 text-left"
+          >
+            Workspace
+            <SortIndicator sortKey="name" activeKey={sortKey} direction={sortDirection} />
+          </button>
+          <button
+            type="button"
+            onClick={() => toggleSort('repo')}
+            className="flex items-center gap-1 text-left"
+          >
+            Repository
+            <SortIndicator sortKey="repo" activeKey={sortKey} direction={sortDirection} />
+          </button>
+          <button
+            type="button"
+            onClick={() => toggleSort('size')}
+            className="flex items-center justify-end gap-1 text-right"
+          >
+            Size
+            <SortIndicator sortKey="size" activeKey={sortKey} direction={sortDirection} />
+          </button>
+          <div className="text-right">State</div>
+        </div>
+
+        <div className="max-h-[28rem] overflow-y-auto scrollbar-sleek">
+          {isInitialScan ? (
+            <div className="flex items-center justify-center gap-2 px-4 py-10 text-center text-sm text-muted-foreground">
+              <Loader2 className="size-4 animate-spin" />
+              Scanning workspaces. You can leave this page.
+            </div>
+          ) : rows.length === 0 ? (
+            <div className="px-4 py-10 text-center text-sm text-muted-foreground">
+              No matching workspaces.
+            </div>
+          ) : (
+            rows.map((worktree) => (
+              <WorkspaceRow
+                key={worktree.worktreeId}
+                worktree={worktree}
+                maxSize={maxSize}
+                selected={selectedIds.has(worktree.worktreeId)}
+                inspected={inspectedWorktree?.worktreeId === worktree.worktreeId}
+                onToggleSelected={() => toggleSelection(worktree.worktreeId)}
+                onInspect={() => setInspectedWorktreeId(worktree.worktreeId)}
+              />
+            ))
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/status-bar/mergeSnapshotAndSessions.ts
+++ b/src/renderer/src/components/status-bar/mergeSnapshotAndSessions.ts
@@ -4,7 +4,7 @@
    in ResourceUsageStatusSegment.tsx. Splitting would scatter logic that has
    exactly one consumer. See docs/resource-usage-merge-spec.md. */
 /**
- * Resource Usage popover merge helper.
+ * Resource Manager popover merge helper.
  *
  * Produces a single grouped list (repo → worktree → session) by unifying:
  *

--- a/src/renderer/src/components/status-bar/workspace-space-format.test.ts
+++ b/src/renderer/src/components/status-bar/workspace-space-format.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import {
+  formatBytes,
+  formatCompactCount,
+  getWorkspaceSpaceStatusLabel
+} from './workspace-space-format'
+
+describe('workspace space format helpers', () => {
+  it('formats byte values with stable units', () => {
+    expect(formatBytes(0)).toBe('0 B')
+    expect(formatBytes(512)).toBe('512 B')
+    expect(formatBytes(1536)).toBe('1.50 KB')
+    expect(formatBytes(5 * 1024 * 1024)).toBe('5.00 MB')
+  })
+
+  it('formats counts and statuses for dense table UI', () => {
+    expect(formatCompactCount(1530)).toBe('1.5k')
+    expect(formatCompactCount(25_000)).toBe('25k')
+    expect(getWorkspaceSpaceStatusLabel('permission-denied')).toBe('No access')
+  })
+})

--- a/src/renderer/src/components/status-bar/workspace-space-format.ts
+++ b/src/renderer/src/components/status-bar/workspace-space-format.ts
@@ -1,0 +1,59 @@
+import type {
+  WorkspaceSpaceScanStatus,
+  WorkspaceSpaceWorktree
+} from '../../../../shared/workspace-space-types'
+
+const BYTE_UNITS = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'] as const
+
+export function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) {
+    return '0 B'
+  }
+
+  let value = bytes
+  let unitIndex = 0
+  while (value >= 1024 && unitIndex < BYTE_UNITS.length - 1) {
+    value /= 1024
+    unitIndex += 1
+  }
+
+  const precision = value >= 100 || unitIndex === 0 ? 0 : value >= 10 ? 1 : 2
+  return `${value.toFixed(precision)} ${BYTE_UNITS[unitIndex]}`
+}
+
+export function formatCompactCount(count: number): string {
+  if (!Number.isFinite(count) || count <= 0) {
+    return '0'
+  }
+  if (count < 1000) {
+    return String(count)
+  }
+  if (count < 1_000_000) {
+    return `${(count / 1000).toFixed(count >= 10_000 ? 0 : 1)}k`
+  }
+  return `${(count / 1_000_000).toFixed(count >= 10_000_000 ? 0 : 1)}m`
+}
+
+export function getWorkspaceSpaceScanTimeLabel(scannedAt: number): string {
+  return new Date(scannedAt).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })
+}
+
+export function getWorkspaceSpaceStatusLabel(status: WorkspaceSpaceScanStatus): string {
+  switch (status) {
+    case 'ok':
+      return 'Scanned'
+    case 'missing':
+      return 'Missing'
+    case 'permission-denied':
+      return 'No access'
+    case 'unavailable':
+      return 'Unavailable'
+    case 'error':
+      return 'Failed'
+  }
+}
+
+export function getWorkspaceSpaceBranchLabel(worktree: WorkspaceSpaceWorktree): string {
+  const branch = worktree.branch.replace(/^refs\/heads\//, '').trim()
+  return branch || (worktree.isMainWorktree ? 'main worktree' : 'detached')
+}

--- a/src/renderer/src/components/status-bar/workspace-space-layout.test.ts
+++ b/src/renderer/src/components/status-bar/workspace-space-layout.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { buildTreemapLayout } from './workspace-space-layout'
+
+describe('buildTreemapLayout', () => {
+  it('lays out positive-size items inside a 100x100 treemap', () => {
+    const rects = buildTreemapLayout([
+      { id: 'a', label: 'A', sizeBytes: 60 },
+      { id: 'b', label: 'B', sizeBytes: 30 },
+      { id: 'c', label: 'C', sizeBytes: 10 },
+      { id: 'empty', label: 'Empty', sizeBytes: 0 }
+    ])
+
+    expect(rects.map((rect) => rect.id)).toEqual(['a', 'b', 'c'])
+    for (const rect of rects) {
+      expect(rect.x).toBeGreaterThanOrEqual(0)
+      expect(rect.y).toBeGreaterThanOrEqual(0)
+      expect(rect.x + rect.width).toBeLessThanOrEqual(100)
+      expect(rect.y + rect.height).toBeLessThanOrEqual(100)
+    }
+    const area = rects.reduce((sum, rect) => sum + rect.width * rect.height, 0)
+    expect(area).toBeCloseTo(10_000, 5)
+    expect(rects[0].width * rects[0].height).toBeGreaterThan(rects[1].width * rects[1].height)
+  })
+})

--- a/src/renderer/src/components/status-bar/workspace-space-layout.ts
+++ b/src/renderer/src/components/status-bar/workspace-space-layout.ts
@@ -1,0 +1,124 @@
+export type TreemapInput = {
+  id: string
+  label: string
+  sizeBytes: number
+}
+
+export type TreemapRect = TreemapInput & {
+  x: number
+  y: number
+  width: number
+  height: number
+  depth: number
+  index: number
+}
+
+type Bounds = {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+function sumSizes(items: readonly TreemapInput[]): number {
+  return items.reduce((sum, item) => sum + Math.max(0, item.sizeBytes), 0)
+}
+
+function splitBalanced(items: readonly TreemapInput[]): {
+  first: TreemapInput[]
+  second: TreemapInput[]
+} {
+  const total = sumSizes(items)
+  if (items.length <= 1 || total <= 0) {
+    return { first: [...items], second: [] }
+  }
+
+  const target = total / 2
+  let running = 0
+  let splitIndex = 0
+  for (let index = 0; index < items.length; index += 1) {
+    const next = running + Math.max(0, items[index].sizeBytes)
+    if (index > 0 && Math.abs(target - running) < Math.abs(target - next)) {
+      break
+    }
+    running = next
+    splitIndex = index + 1
+  }
+
+  splitIndex = Math.min(items.length - 1, Math.max(1, splitIndex))
+  return {
+    first: items.slice(0, splitIndex),
+    second: items.slice(splitIndex)
+  }
+}
+
+function layoutTreemapRecursive(
+  items: readonly TreemapInput[],
+  bounds: Bounds,
+  depth: number,
+  output: TreemapRect[]
+): void {
+  if (items.length === 0 || bounds.width <= 0 || bounds.height <= 0) {
+    return
+  }
+
+  if (items.length === 1) {
+    const item = items[0]
+    output.push({
+      ...item,
+      ...bounds,
+      depth,
+      index: output.length
+    })
+    return
+  }
+
+  const total = sumSizes(items)
+  if (total <= 0) {
+    return
+  }
+
+  const { first, second } = splitBalanced(items)
+  const firstSize = sumSizes(first)
+  const ratio = firstSize / total
+
+  if (bounds.width >= bounds.height) {
+    const firstWidth = bounds.width * ratio
+    layoutTreemapRecursive(first, { ...bounds, width: firstWidth }, depth + 1, output)
+    layoutTreemapRecursive(
+      second,
+      {
+        x: bounds.x + firstWidth,
+        y: bounds.y,
+        width: bounds.width - firstWidth,
+        height: bounds.height
+      },
+      depth + 1,
+      output
+    )
+    return
+  }
+
+  const firstHeight = bounds.height * ratio
+  layoutTreemapRecursive(first, { ...bounds, height: firstHeight }, depth + 1, output)
+  layoutTreemapRecursive(
+    second,
+    {
+      x: bounds.x,
+      y: bounds.y + firstHeight,
+      width: bounds.width,
+      height: bounds.height - firstHeight
+    },
+    depth + 1,
+    output
+  )
+}
+
+export function buildTreemapLayout(items: readonly TreemapInput[]): TreemapRect[] {
+  const filtered = items
+    .filter((item) => item.sizeBytes > 0)
+    .sort((a, b) => b.sizeBytes - a.sizeBytes || a.label.localeCompare(b.label))
+  const output: TreemapRect[] = []
+  layoutTreemapRecursive(filtered, { x: 0, y: 0, width: 100, height: 100 }, 0, output)
+  return output
+}

--- a/src/renderer/src/components/status-bar/workspace-space-presentation.test.ts
+++ b/src/renderer/src/components/status-bar/workspace-space-presentation.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+import type { WorkspaceSpaceWorktree } from '../../../../shared/workspace-space-types'
+import {
+  filterWorkspaceSpaceRows,
+  getSelectedDeletableWorkspaceIds,
+  sortWorkspaceSpaceRows
+} from './workspace-space-presentation'
+
+function row(overrides: Partial<WorkspaceSpaceWorktree>): WorkspaceSpaceWorktree {
+  return {
+    worktreeId: 'wt',
+    repoId: 'repo',
+    repoDisplayName: 'repo',
+    repoPath: '/repo',
+    displayName: 'workspace',
+    path: '/workspace',
+    branch: 'refs/heads/main',
+    isMainWorktree: false,
+    isRemote: false,
+    isSparse: false,
+    canDelete: true,
+    lastActivityAt: 0,
+    status: 'ok',
+    error: null,
+    scannedAt: 0,
+    sizeBytes: 0,
+    reclaimableBytes: 0,
+    skippedEntryCount: 0,
+    topLevelItems: [],
+    omittedTopLevelItemCount: 0,
+    omittedTopLevelSizeBytes: 0,
+    ...overrides
+  }
+}
+
+describe('workspace space presentation helpers', () => {
+  it('sorts rows by the selected key and direction', () => {
+    const rows = [
+      row({ worktreeId: 'small', displayName: 'Small', sizeBytes: 10 }),
+      row({ worktreeId: 'large', displayName: 'Large', sizeBytes: 100 }),
+      row({ worktreeId: 'mid', displayName: 'Mid', sizeBytes: 50 })
+    ]
+
+    expect(sortWorkspaceSpaceRows(rows, 'size', 'desc').map((item) => item.worktreeId)).toEqual([
+      'large',
+      'mid',
+      'small'
+    ])
+    expect(sortWorkspaceSpaceRows(rows, 'name', 'asc').map((item) => item.worktreeId)).toEqual([
+      'large',
+      'mid',
+      'small'
+    ])
+  })
+
+  it('filters by search text and deletable status', () => {
+    const rows = [
+      row({ worktreeId: 'a', displayName: 'Frontend Cache', repoDisplayName: 'app' }),
+      row({ worktreeId: 'b', displayName: 'Main', repoDisplayName: 'api', canDelete: false })
+    ]
+
+    expect(filterWorkspaceSpaceRows(rows, 'cache', false).map((item) => item.worktreeId)).toEqual([
+      'a'
+    ])
+    expect(filterWorkspaceSpaceRows(rows, '', true).map((item) => item.worktreeId)).toEqual(['a'])
+  })
+
+  it('returns only selected worktrees that can be deleted', () => {
+    const rows = [
+      row({ worktreeId: 'ok', canDelete: true, status: 'ok' }),
+      row({ worktreeId: 'main', canDelete: false, status: 'ok' }),
+      row({ worktreeId: 'failed', canDelete: true, status: 'error' })
+    ]
+
+    expect(getSelectedDeletableWorkspaceIds(rows, new Set(['ok', 'main', 'failed']))).toEqual([
+      'ok'
+    ])
+  })
+})

--- a/src/renderer/src/components/status-bar/workspace-space-presentation.ts
+++ b/src/renderer/src/components/status-bar/workspace-space-presentation.ts
@@ -1,0 +1,78 @@
+import type { WorkspaceSpaceWorktree } from '../../../../shared/workspace-space-types'
+
+export type WorkspaceSpaceSortKey = 'size' | 'name' | 'repo' | 'activity'
+export type WorkspaceSpaceSortDirection = 'asc' | 'desc'
+
+export function getWorkspaceSpaceSearchText(worktree: WorkspaceSpaceWorktree): string {
+  return [
+    worktree.displayName,
+    worktree.repoDisplayName,
+    worktree.path,
+    worktree.branch,
+    worktree.status
+  ]
+    .join(' ')
+    .toLowerCase()
+}
+
+function compareRows(
+  left: WorkspaceSpaceWorktree,
+  right: WorkspaceSpaceWorktree,
+  sortKey: WorkspaceSpaceSortKey
+): number {
+  switch (sortKey) {
+    case 'size':
+      return left.sizeBytes - right.sizeBytes
+    case 'name':
+      return left.displayName.localeCompare(right.displayName)
+    case 'repo':
+      return (
+        left.repoDisplayName.localeCompare(right.repoDisplayName) ||
+        left.displayName.localeCompare(right.displayName)
+      )
+    case 'activity':
+      return left.lastActivityAt - right.lastActivityAt
+  }
+}
+
+export function sortWorkspaceSpaceRows(
+  rows: readonly WorkspaceSpaceWorktree[],
+  sortKey: WorkspaceSpaceSortKey,
+  direction: WorkspaceSpaceSortDirection
+): WorkspaceSpaceWorktree[] {
+  const multiplier = direction === 'asc' ? 1 : -1
+  return [...rows].sort((left, right) => {
+    const primary = compareRows(left, right, sortKey) * multiplier
+    return (
+      primary ||
+      right.sizeBytes - left.sizeBytes ||
+      left.displayName.localeCompare(right.displayName)
+    )
+  })
+}
+
+export function filterWorkspaceSpaceRows(
+  rows: readonly WorkspaceSpaceWorktree[],
+  query: string,
+  onlyDeletable: boolean
+): WorkspaceSpaceWorktree[] {
+  const normalizedQuery = query.trim().toLowerCase()
+  return rows.filter((row) => {
+    if (onlyDeletable && !row.canDelete) {
+      return false
+    }
+    if (!normalizedQuery) {
+      return true
+    }
+    return getWorkspaceSpaceSearchText(row).includes(normalizedQuery)
+  })
+}
+
+export function getSelectedDeletableWorkspaceIds(
+  rows: readonly WorkspaceSpaceWorktree[],
+  selectedIds: ReadonlySet<string>
+): string[] {
+  return rows
+    .filter((row) => row.canDelete && row.status === 'ok' && selectedIds.has(row.worktreeId))
+    .map((row) => row.worktreeId)
+}

--- a/src/renderer/src/components/workspace-space/WorkspaceSpacePage.tsx
+++ b/src/renderer/src/components/workspace-space/WorkspaceSpacePage.tsx
@@ -1,0 +1,59 @@
+import { useEffect } from 'react'
+import { ArrowLeft, HardDrive } from 'lucide-react'
+import { Badge } from '../ui/badge'
+import { Button } from '../ui/button'
+import { WorkspaceSpaceManagerPanel } from '../status-bar/WorkspaceSpaceManagerPanel'
+import { useAppStore } from '../../store'
+
+export default function WorkspaceSpacePage(): React.JSX.Element {
+  const closeSpacePage = useAppStore((state) => state.closeSpacePage)
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (event.key !== 'Escape' || event.defaultPrevented) {
+        return
+      }
+      // Why: confirmation dialogs own Escape first; page-level Escape should
+      // only leave the full Space surface when no modal is active.
+      if (document.querySelector('[role="dialog"]')) {
+        return
+      }
+      event.preventDefault()
+      closeSpacePage()
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [closeSpacePage])
+
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-background">
+      <div className="flex shrink-0 items-center gap-3 border-b border-border px-5 py-3">
+        <Button variant="outline" size="sm" onClick={closeSpacePage} className="shrink-0 gap-1.5">
+          <ArrowLeft className="size-3.5" />
+          Back
+        </Button>
+        <div className="flex min-w-0 items-center gap-3">
+          <div className="flex size-8 shrink-0 items-center justify-center rounded-md border border-border bg-muted/30">
+            <HardDrive className="size-4 text-muted-foreground" />
+          </div>
+          <div className="min-w-0">
+            <div className="flex min-w-0 items-center gap-2">
+              <h1 className="truncate text-base font-semibold text-foreground">Space</h1>
+              <Badge variant="secondary">Beta</Badge>
+            </div>
+            <p className="truncate text-xs text-muted-foreground">
+              Workspace disk usage and reclaimable worktree storage.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-y-auto p-5 scrollbar-sleek">
+        <div className="mx-auto max-w-7xl">
+          <WorkspaceSpaceManagerPanel />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/hooks/resolve-zoom-target.ts
+++ b/src/renderer/src/hooks/resolve-zoom-target.ts
@@ -3,7 +3,7 @@
  * based on current view, tab type, and focused element.
  */
 export function resolveZoomTarget(args: {
-  activeView: 'terminal' | 'settings' | 'tasks' | 'activity' | 'automations'
+  activeView: 'terminal' | 'settings' | 'tasks' | 'activity' | 'automations' | 'space'
   activeTabType: 'terminal' | 'editor' | 'browser' | 'notes'
   activeElement: unknown
 }): 'terminal' | 'editor' | 'ui' {

--- a/src/renderer/src/store/index.ts
+++ b/src/renderer/src/store/index.ts
@@ -13,6 +13,7 @@ import { createLinearSlice } from './slices/linear'
 import { createEditorSlice } from './slices/editor'
 import { createStatsSlice } from './slices/stats'
 import { createMemorySlice } from './slices/memory'
+import { createWorkspaceSpaceSlice } from './slices/workspace-space'
 import { createClaudeUsageSlice } from './slices/claude-usage'
 import { createCodexUsageSlice } from './slices/codex-usage'
 import { createBrowserSlice } from './slices/browser'
@@ -40,6 +41,7 @@ export const useAppStore = create<AppState>()((...a) => ({
   ...createEditorSlice(...a),
   ...createStatsSlice(...a),
   ...createMemorySlice(...a),
+  ...createWorkspaceSpaceSlice(...a),
   ...createClaudeUsageSlice(...a),
   ...createCodexUsageSlice(...a),
   ...createBrowserSlice(...a),

--- a/src/renderer/src/store/slices/diffComments.test.ts
+++ b/src/renderer/src/store/slices/diffComments.test.ts
@@ -85,6 +85,7 @@ import { createLinearSlice } from './linear'
 import { createEditorSlice } from './editor'
 import { createStatsSlice } from './stats'
 import { createMemorySlice } from './memory'
+import { createWorkspaceSpaceSlice } from './workspace-space'
 import { createClaudeUsageSlice } from './claude-usage'
 import { createCodexUsageSlice } from './codex-usage'
 import { createBrowserSlice } from './browser'
@@ -111,6 +112,7 @@ function createTestStore() {
     ...createEditorSlice(...a),
     ...createStatsSlice(...a),
     ...createMemorySlice(...a),
+    ...createWorkspaceSpaceSlice(...a),
     ...createClaudeUsageSlice(...a),
     ...createCodexUsageSlice(...a),
     ...createBrowserSlice(...a),

--- a/src/renderer/src/store/slices/memory.ts
+++ b/src/renderer/src/store/slices/memory.ts
@@ -17,7 +17,7 @@ export const createMemorySlice: StateCreator<AppState, [], [], MemorySlice> = (s
       const snapshot = await window.api.memory.getSnapshot()
       set({ memorySnapshot: snapshot, memorySnapshotError: null })
     } catch (err) {
-      // Why: the always-on Resource Usage status-bar segment needs to know when
+      // Why: the always-on Resource Manager status-bar segment needs to know when
       // the snapshot IPC is failing so it can surface a "daemon not responding"
       // banner with a Restart CTA. Prior code only console.error'd.
       console.error('Failed to fetch memory snapshot:', err)

--- a/src/renderer/src/store/slices/store-session-cascades.test.ts
+++ b/src/renderer/src/store/slices/store-session-cascades.test.ts
@@ -102,6 +102,7 @@ import { createLinearSlice } from './linear'
 import { createEditorSlice } from './editor'
 import { createStatsSlice } from './stats'
 import { createMemorySlice } from './memory'
+import { createWorkspaceSpaceSlice } from './workspace-space'
 import { createClaudeUsageSlice } from './claude-usage'
 import { createCodexUsageSlice } from './codex-usage'
 import { createBrowserSlice } from './browser'
@@ -128,6 +129,7 @@ function createTestStore() {
     ...createEditorSlice(...a),
     ...createStatsSlice(...a),
     ...createMemorySlice(...a),
+    ...createWorkspaceSpaceSlice(...a),
     ...createClaudeUsageSlice(...a),
     ...createCodexUsageSlice(...a),
     ...createBrowserSlice(...a),

--- a/src/renderer/src/store/slices/store-test-helpers.ts
+++ b/src/renderer/src/store/slices/store-test-helpers.ts
@@ -21,6 +21,7 @@ import { createLinearSlice } from './linear'
 import { createEditorSlice } from './editor'
 import { createStatsSlice } from './stats'
 import { createMemorySlice } from './memory'
+import { createWorkspaceSpaceSlice } from './workspace-space'
 import { createClaudeUsageSlice } from './claude-usage'
 import { createCodexUsageSlice } from './codex-usage'
 import { createBrowserSlice } from './browser'
@@ -55,6 +56,7 @@ export function createTestStore() {
     ...createEditorSlice(...a),
     ...createStatsSlice(...a),
     ...createMemorySlice(...a),
+    ...createWorkspaceSpaceSlice(...a),
     ...createClaudeUsageSlice(...a),
     ...createCodexUsageSlice(...a),
     ...createBrowserSlice(...a),

--- a/src/renderer/src/store/slices/tabs.test.ts
+++ b/src/renderer/src/store/slices/tabs.test.ts
@@ -97,6 +97,7 @@ import { createLinearSlice } from './linear'
 import { createEditorSlice } from './editor'
 import { createStatsSlice } from './stats'
 import { createMemorySlice } from './memory'
+import { createWorkspaceSpaceSlice } from './workspace-space'
 import { createClaudeUsageSlice } from './claude-usage'
 import { createCodexUsageSlice } from './codex-usage'
 import { createBrowserSlice } from './browser'
@@ -125,6 +126,7 @@ function createTestStore() {
     ...createEditorSlice(...a),
     ...createStatsSlice(...a),
     ...createMemorySlice(...a),
+    ...createWorkspaceSpaceSlice(...a),
     ...createClaudeUsageSlice(...a),
     ...createCodexUsageSlice(...a),
     ...createBrowserSlice(...a),

--- a/src/renderer/src/store/slices/ui.test.ts
+++ b/src/renderer/src/store/slices/ui.test.ts
@@ -446,3 +446,33 @@ describe('createUISlice feature tour nudge', () => {
     expect(store.getState().featureTourNudgeVisible).toBe(false)
   })
 })
+
+describe('createUISlice space navigation', () => {
+  it('returns to the tasks page after opening Space from an in-progress draft', () => {
+    const store = createUIStore()
+
+    store.getState().openTaskPage({ preselectedRepoId: 'repo-1' })
+    store.getState().openSpacePage()
+
+    expect(store.getState().activeView).toBe('space')
+    expect(store.getState().previousViewBeforeSpace).toBe('tasks')
+
+    store.getState().closeSpacePage()
+
+    expect(store.getState().activeView).toBe('tasks')
+  })
+
+  it('keeps the original return target when Space is reopened while already visible', () => {
+    const store = createUIStore()
+
+    store.getState().openTaskPage()
+    store.getState().openSpacePage()
+    store.getState().openSpacePage()
+
+    expect(store.getState().previousViewBeforeSpace).toBe('tasks')
+
+    store.getState().closeSpacePage()
+
+    expect(store.getState().activeView).toBe('tasks')
+  })
+})

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -194,11 +194,12 @@ export type UISlice = {
   acknowledgedAgentsByPaneKey: Record<string, number>
   acknowledgeAgents: (paneKeys: string[]) => void
   unacknowledgeAgents: (paneKeys: string[]) => void
-  activeView: 'terminal' | 'settings' | 'tasks' | 'activity' | 'automations'
-  previousViewBeforeTasks: 'terminal' | 'settings' | 'activity' | 'automations'
-  previousViewBeforeSettings: 'terminal' | 'tasks' | 'activity' | 'automations'
-  previousViewBeforeActivity: 'terminal' | 'settings' | 'tasks' | 'automations'
-  previousViewBeforeAutomations: 'terminal' | 'settings' | 'tasks' | 'activity'
+  activeView: 'terminal' | 'settings' | 'tasks' | 'activity' | 'automations' | 'space'
+  previousViewBeforeTasks: 'terminal' | 'settings' | 'activity' | 'automations' | 'space'
+  previousViewBeforeSettings: 'terminal' | 'tasks' | 'activity' | 'automations' | 'space'
+  previousViewBeforeActivity: 'terminal' | 'settings' | 'tasks' | 'automations' | 'space'
+  previousViewBeforeAutomations: 'terminal' | 'settings' | 'tasks' | 'activity' | 'space'
+  previousViewBeforeSpace: 'terminal' | 'settings' | 'tasks' | 'activity' | 'automations'
   setActiveView: (view: UISlice['activeView']) => void
   taskPageData: {
     preselectedRepoId?: string
@@ -238,6 +239,8 @@ export type UISlice = {
   setSelectedAutomationId: (id: string | null) => void
   openAutomationsPage: () => void
   closeAutomationsPage: () => void
+  openSpacePage: () => void
+  closeSpacePage: () => void
   setNewWorkspaceDraft: (draft: NonNullable<UISlice['newWorkspaceDraft']>) => void
   clearNewWorkspaceDraft: () => void
   openSettingsPage: () => void
@@ -423,6 +426,7 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
   previousViewBeforeSettings: 'terminal',
   previousViewBeforeActivity: 'terminal',
   previousViewBeforeAutomations: 'terminal',
+  previousViewBeforeSpace: 'terminal',
   setActiveView: (view) => set({ activeView: view }),
   taskPageData: {},
   taskResumeState: undefined,
@@ -535,6 +539,16 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
   closeAutomationsPage: () =>
     set((state) => ({
       activeView: state.previousViewBeforeAutomations
+    })),
+  openSpacePage: () =>
+    set((state) => ({
+      activeView: 'space',
+      previousViewBeforeSpace:
+        state.activeView === 'space' ? state.previousViewBeforeSpace : state.activeView
+    })),
+  closeSpacePage: () =>
+    set((state) => ({
+      activeView: state.previousViewBeforeSpace
     })),
   setNewWorkspaceDraft: (draft) => set({ newWorkspaceDraft: draft }),
   clearNewWorkspaceDraft: () => set({ newWorkspaceDraft: null }),

--- a/src/renderer/src/store/slices/workspace-space.ts
+++ b/src/renderer/src/store/slices/workspace-space.ts
@@ -1,0 +1,96 @@
+import type { StateCreator } from 'zustand'
+import type { WorkspaceSpaceAnalysis } from '../../../../shared/workspace-space-types'
+import type { AppState } from '../types'
+
+let inFlightScan: Promise<WorkspaceSpaceAnalysis> | null = null
+
+export type WorkspaceSpaceSlice = {
+  workspaceSpaceAnalysis: WorkspaceSpaceAnalysis | null
+  workspaceSpaceScanError: string | null
+  workspaceSpaceScanning: boolean
+  refreshWorkspaceSpace: () => Promise<WorkspaceSpaceAnalysis>
+  removeWorkspaceSpaceWorktrees: (worktreeIds: readonly string[]) => void
+}
+
+function removeDeletedWorktreesFromAnalysis(
+  analysis: WorkspaceSpaceAnalysis,
+  deletedWorktreeIds: readonly string[]
+): WorkspaceSpaceAnalysis {
+  const deletedSet = new Set(deletedWorktreeIds)
+  const worktrees = analysis.worktrees.filter((worktree) => !deletedSet.has(worktree.worktreeId))
+  const rowsByRepoId = new Map<string, typeof worktrees>()
+  for (const worktree of worktrees) {
+    const repoRows = rowsByRepoId.get(worktree.repoId) ?? []
+    repoRows.push(worktree)
+    rowsByRepoId.set(worktree.repoId, repoRows)
+  }
+  const repos = analysis.repos.map((repo) => {
+    const repoRows = rowsByRepoId.get(repo.repoId) ?? []
+    return {
+      ...repo,
+      worktreeCount: repoRows.length,
+      scannedWorktreeCount: repoRows.filter((row) => row.status === 'ok').length,
+      unavailableWorktreeCount: repoRows.filter((row) => row.status !== 'ok').length,
+      totalSizeBytes: repoRows.reduce((sum, row) => sum + row.sizeBytes, 0),
+      reclaimableBytes: repoRows.reduce((sum, row) => sum + row.reclaimableBytes, 0)
+    }
+  })
+
+  return {
+    ...analysis,
+    totalSizeBytes: worktrees.reduce((sum, row) => sum + row.sizeBytes, 0),
+    reclaimableBytes: worktrees.reduce((sum, row) => sum + row.reclaimableBytes, 0),
+    worktreeCount: worktrees.length,
+    scannedWorktreeCount: worktrees.filter((row) => row.status === 'ok').length,
+    unavailableWorktreeCount:
+      worktrees.filter((row) => row.status !== 'ok').length +
+      repos.filter((repo) => repo.error !== null).length,
+    repos,
+    worktrees
+  }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+export const createWorkspaceSpaceSlice: StateCreator<AppState, [], [], WorkspaceSpaceSlice> = (
+  set
+) => ({
+  workspaceSpaceAnalysis: null,
+  workspaceSpaceScanError: null,
+  workspaceSpaceScanning: false,
+  refreshWorkspaceSpace: async () => {
+    if (inFlightScan) {
+      return inFlightScan
+    }
+    set({ workspaceSpaceScanning: true, workspaceSpaceScanError: null })
+    // Why: the compact Resource Manager card and the full Space page share
+    // one manual scan result; duplicate button presses should join the same IO.
+    inFlightScan = window.api.workspaceSpace
+      .analyze()
+      .then((analysis) => {
+        set({ workspaceSpaceAnalysis: analysis, workspaceSpaceScanning: false })
+        return analysis
+      })
+      .catch((error: unknown) => {
+        set({ workspaceSpaceScanError: errorMessage(error), workspaceSpaceScanning: false })
+        throw error
+      })
+      .finally(() => {
+        inFlightScan = null
+      })
+    return inFlightScan
+  },
+  removeWorkspaceSpaceWorktrees: (worktreeIds) =>
+    set((state) =>
+      state.workspaceSpaceAnalysis
+        ? {
+            workspaceSpaceAnalysis: removeDeletedWorktreesFromAnalysis(
+              state.workspaceSpaceAnalysis,
+              worktreeIds
+            )
+          }
+        : state
+    )
+})

--- a/src/renderer/src/store/types.ts
+++ b/src/renderer/src/store/types.ts
@@ -11,6 +11,7 @@ import type { LinearSlice } from './slices/linear'
 import type { EditorSlice } from './slices/editor'
 import type { StatsSlice } from './slices/stats'
 import type { MemorySlice } from './slices/memory'
+import type { WorkspaceSpaceSlice } from './slices/workspace-space'
 import type { ClaudeUsageSlice } from './slices/claude-usage'
 import type { CodexUsageSlice } from './slices/codex-usage'
 import type { BrowserSlice } from './slices/browser'
@@ -35,6 +36,7 @@ export type AppState = RepoSlice &
   EditorSlice &
   StatsSlice &
   MemorySlice &
+  WorkspaceSpaceSlice &
   ClaudeUsageSlice &
   CodexUsageSlice &
   BrowserSlice &

--- a/src/shared/computer-use-permissions-types.ts
+++ b/src/shared/computer-use-permissions-types.ts
@@ -9,6 +9,8 @@ export type ComputerUsePermissionState = {
 
 export type ComputerUsePermissionStatusResult = {
   platform: NodeJS.Platform
+  helperAppPath: string | null
+  helperUnavailableReason: string | null
   permissions: ComputerUsePermissionState[]
 }
 

--- a/src/shared/workspace-space-types.ts
+++ b/src/shared/workspace-space-types.ts
@@ -1,0 +1,63 @@
+export type WorkspaceSpaceScanStatus =
+  | 'ok'
+  | 'missing'
+  | 'permission-denied'
+  | 'unavailable'
+  | 'error'
+
+export type WorkspaceSpaceItemKind = 'directory' | 'file' | 'symlink' | 'other'
+
+export type WorkspaceSpaceItem = {
+  name: string
+  path: string
+  kind: WorkspaceSpaceItemKind
+  sizeBytes: number
+}
+
+export type WorkspaceSpaceWorktree = {
+  worktreeId: string
+  repoId: string
+  repoDisplayName: string
+  repoPath: string
+  displayName: string
+  path: string
+  branch: string
+  isMainWorktree: boolean
+  isRemote: boolean
+  isSparse: boolean
+  canDelete: boolean
+  lastActivityAt: number
+  status: WorkspaceSpaceScanStatus
+  error: string | null
+  scannedAt: number
+  sizeBytes: number
+  reclaimableBytes: number
+  skippedEntryCount: number
+  topLevelItems: WorkspaceSpaceItem[]
+  omittedTopLevelItemCount: number
+  omittedTopLevelSizeBytes: number
+}
+
+export type WorkspaceSpaceRepoSummary = {
+  repoId: string
+  displayName: string
+  path: string
+  isRemote: boolean
+  worktreeCount: number
+  scannedWorktreeCount: number
+  unavailableWorktreeCount: number
+  totalSizeBytes: number
+  reclaimableBytes: number
+  error: string | null
+}
+
+export type WorkspaceSpaceAnalysis = {
+  scannedAt: number
+  totalSizeBytes: number
+  reclaimableBytes: number
+  worktreeCount: number
+  scannedWorktreeCount: number
+  unavailableWorktreeCount: number
+  repos: WorkspaceSpaceRepoSummary[]
+  worktrees: WorkspaceSpaceWorktree[]
+}


### PR DESCRIPTION
## Summary
- add manual workspace disk scans with local/SSH-aware analysis and deduped scan IPC
- add slim Space entry in Resource Manager plus a full-page results surface
- fix worktree delete callbacks so Space rows update after confirmed deletes
- report missing Computer Use helper as UI state instead of repeated console errors

## Review + perf notes
- scan work only runs from the Scan buttons; duplicate scan requests share one in-flight promise
- local scans use bounded du subprocesses with portable fallback; remote scans use bounded filesystem concurrency
- compact Resource Manager card is split from the full results module so the always-mounted status bar does not import the treemap/table surface
- local agent hook endpoint files are ignored to prevent committing runtime tokens

## Tests
- pnpm typecheck
- pnpm lint (passes with existing GitHub project warnings)
- pnpm vitest run --config config/vitest.config.ts src/main/workspace-space-analysis.test.ts src/main/ipc/workspace-space.test.ts src/main/computer/macos-computer-use-permissions.test.ts src/main/ipc/register-core-handlers.test.ts src/renderer/src/store/slices/ui.test.ts src/renderer/src/components/sidebar/delete-worktree-flow.test.ts src/renderer/src/components/status-bar/workspace-space-format.test.ts src/renderer/src/components/status-bar/workspace-space-layout.test.ts src/renderer/src/components/status-bar/workspace-space-presentation.test.ts
- pnpm test
- Electron smoke: Resource Manager compact card, Open full page, Back, Escape, scan-in-progress copy, console errors