### PR TITLE
Add MCP config inspector

### DIFF
--- a/src/renderer/src/components/settings/McpConfigSection.tsx
+++ b/src/renderer/src/components/settings/McpConfigSection.tsx
@@ -1,0 +1,375 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { AlertCircle, CheckCircle2, FileCode2, LoaderCircle, Plus, RefreshCw } from 'lucide-react'
+import { toast } from 'sonner'
+import type { Repo, Worktree } from '../../../../shared/types'
+import { getRepoIdFromWorktreeId } from '../../../../shared/worktree-id'
+import {
+  inspectMcpConfigContent,
+  MCP_CONFIG_CANDIDATES,
+  MCP_STARTER_CONFIG,
+  type McpConfigInspection
+} from '../../../../shared/mcp-config'
+import { useAppStore } from '../../store'
+import { joinPath } from '../../lib/path'
+import { extractIpcErrorMessage } from '../../lib/ipc-error'
+import { Button } from '../ui/button'
+
+type LoadedInspection = McpConfigInspection & {
+  absolutePath: string
+  readError?: string
+}
+
+type McpConfigSectionProps = {
+  repo: Repo
+}
+
+const EMPTY_WORKTREES: Worktree[] = []
+
+function isMissingFileError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error)
+  return /ENOENT|no such file|not found/i.test(message)
+}
+
+function isNoFilesystemProviderMessage(message: string | undefined): boolean {
+  return message ? /no filesystem provider/i.test(message) : false
+}
+
+function countServers(configs: LoadedInspection[]): number {
+  return configs.reduce((sum, config) => sum + config.servers.length, 0)
+}
+
+function statusLabel(config: LoadedInspection): string {
+  if (config.readError) {
+    return 'Unreadable'
+  }
+  if (config.status === 'missing') {
+    return 'Not found'
+  }
+  if (config.status === 'invalid') {
+    return 'Invalid JSON'
+  }
+  if (config.servers.length === 0) {
+    return 'No servers'
+  }
+  return `${config.servers.length} server${config.servers.length === 1 ? '' : 's'}`
+}
+
+function statusClassName(config: LoadedInspection): string {
+  if (config.readError || config.status === 'invalid') {
+    return 'border-destructive/30 bg-destructive/10 text-destructive'
+  }
+  if (config.status === 'valid' && config.servers.length > 0) {
+    return 'border-border/60 bg-background text-foreground'
+  }
+  return 'border-border/60 bg-muted/60 text-muted-foreground'
+}
+
+function serverDetailLabel(server: LoadedInspection['servers'][number]): string {
+  if (server.transport === 'http') {
+    return server.url ?? 'HTTP server'
+  }
+  if (server.transport === 'stdio') {
+    return server.command ?? 'stdio server'
+  }
+  return server.issue ?? 'Invalid server'
+}
+
+export function McpConfigSection({ repo }: McpConfigSectionProps): React.JSX.Element {
+  const openFile = useAppStore((state) => state.openFile)
+  const setActiveView = useAppStore((state) => state.setActiveView)
+  const setActiveWorktree = useAppStore((state) => state.setActiveWorktree)
+  const ensureWorktreeRootGroup = useAppStore((state) => state.ensureWorktreeRootGroup)
+  const activeWorktreeId = useAppStore((state) => state.activeWorktreeId)
+  const worktreesForRepo = useAppStore((state) => state.worktreesByRepo[repo.id] ?? EMPTY_WORKTREES)
+  const [configs, setConfigs] = useState<LoadedInspection[]>([])
+  const [loading, setLoading] = useState(true)
+  const [createConfirm, setCreateConfirm] = useState(false)
+
+  const connectionId = repo.connectionId ?? undefined
+  const targetWorktree = useMemo(() => {
+    if (activeWorktreeId && getRepoIdFromWorktreeId(activeWorktreeId) === repo.id) {
+      return (
+        worktreesForRepo.find((worktree) => worktree.id === activeWorktreeId) ?? {
+          id: activeWorktreeId,
+          path: repo.path
+        }
+      )
+    }
+    return (
+      worktreesForRepo.find((worktree) => worktree.isMainWorktree) ??
+      worktreesForRepo.find((worktree) => worktree.path === repo.path) ??
+      worktreesForRepo[0] ?? { id: `${repo.id}::${repo.path}`, path: repo.path }
+    )
+  }, [activeWorktreeId, repo.id, repo.path, worktreesForRepo])
+  const targetWorktreeId = targetWorktree.id
+  const targetRootPath = targetWorktree.path
+  const detectedCount = useMemo(() => configs.filter((config) => config.exists).length, [configs])
+  const remoteFilesystemUnavailable = useMemo(
+    () =>
+      Boolean(connectionId) &&
+      configs.length > 0 &&
+      configs.every((config) => isNoFilesystemProviderMessage(config.readError)),
+    [configs, connectionId]
+  )
+  const visibleConfigs = useMemo(
+    () =>
+      remoteFilesystemUnavailable
+        ? []
+        : configs.filter(
+            (config) => config.exists || config.status === 'invalid' || config.readError
+          ),
+    [configs, remoteFilesystemUnavailable]
+  )
+  const missingConfigs = useMemo(
+    () =>
+      configs.filter(
+        (config) => !config.exists && config.status === 'missing' && !config.readError
+      ),
+    [configs]
+  )
+  const serverCount = useMemo(() => countServers(configs), [configs])
+  const canCreateStarter = detectedCount === 0 && !remoteFilesystemUnavailable
+
+  const loadConfigs = useCallback(async (): Promise<void> => {
+    setLoading(true)
+    const next = await Promise.all(
+      MCP_CONFIG_CANDIDATES.map(async (candidate): Promise<LoadedInspection> => {
+        const absolutePath = joinPath(targetRootPath, candidate.relativePath)
+        try {
+          const result = await window.api.fs.readFile({ filePath: absolutePath, connectionId })
+          const inspection = inspectMcpConfigContent(
+            candidate,
+            result.isBinary ? '' : result.content
+          )
+          return { ...inspection, absolutePath }
+        } catch (error) {
+          if (isMissingFileError(error)) {
+            return { ...inspectMcpConfigContent(candidate, null), absolutePath }
+          }
+          return {
+            ...inspectMcpConfigContent(candidate, null),
+            exists: false,
+            status: 'invalid',
+            absolutePath,
+            readError: extractIpcErrorMessage(error, 'Unable to read config file.')
+          }
+        }
+      })
+    )
+    setConfigs(next)
+    setLoading(false)
+  }, [connectionId, targetRootPath])
+
+  useEffect(() => {
+    void loadConfigs()
+  }, [loadConfigs])
+
+  const handleOpen = (config: LoadedInspection): void => {
+    setActiveWorktree(targetWorktreeId)
+    const targetGroupId = ensureWorktreeRootGroup(targetWorktreeId)
+    openFile(
+      {
+        filePath: config.absolutePath,
+        relativePath: config.candidate.relativePath,
+        worktreeId: targetWorktreeId,
+        language: 'json',
+        mode: 'edit'
+      },
+      { targetGroupId }
+    )
+    setActiveView('terminal')
+  }
+
+  const handleCreateStarter = async (): Promise<void> => {
+    if (!createConfirm) {
+      setCreateConfirm(true)
+      window.setTimeout(() => setCreateConfirm(false), 3000)
+      return
+    }
+
+    const target = joinPath(targetRootPath, '.mcp.json')
+    try {
+      // Why: v1 only creates the root workspace config so we do not need to
+      // guess per-agent directory layouts or mutate agent-specific files.
+      await window.api.fs.writeFile({ filePath: target, content: MCP_STARTER_CONFIG, connectionId })
+      setCreateConfirm(false)
+      await loadConfigs()
+      setActiveWorktree(targetWorktreeId)
+      const targetGroupId = ensureWorktreeRootGroup(targetWorktreeId)
+      openFile(
+        {
+          filePath: target,
+          relativePath: '.mcp.json',
+          worktreeId: targetWorktreeId,
+          language: 'json',
+          mode: 'edit'
+        },
+        { targetGroupId }
+      )
+      setActiveView('terminal')
+      toast.success('MCP config created', { description: '.mcp.json' })
+    } catch (error) {
+      toast.error(extractIpcErrorMessage(error, 'Failed to create MCP config.'))
+    }
+  }
+
+  return (
+    <section className="space-y-4">
+      <div className="flex items-start justify-between gap-4">
+        <div className="space-y-1">
+          <h3 className="text-sm font-semibold">MCP Configs</h3>
+          <p className="text-xs text-muted-foreground">
+            Inspect MCP server definitions that agents can use while working in this repo.
+          </p>
+          {repo.connectionId ? (
+            <p className="text-xs text-muted-foreground">
+              SSH repos are read through the remote filesystem. Starter creation is limited to the
+              workspace root config.
+            </p>
+          ) : null}
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            onClick={() => void loadConfigs()}
+            aria-label="Refresh MCP configs"
+          >
+            {loading ? (
+              <LoaderCircle className="size-3.5 animate-spin" />
+            ) : (
+              <RefreshCw className="size-3.5" />
+            )}
+          </Button>
+          {canCreateStarter ? (
+            <Button
+              variant={createConfirm ? 'default' : 'outline'}
+              size="sm"
+              className="gap-1.5"
+              onClick={() => void handleCreateStarter()}
+            >
+              <Plus className="size-3.5" />
+              {createConfirm ? 'Create empty config' : 'Add MCP config'}
+            </Button>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="rounded-md border border-border/50 bg-muted/20">
+        <div className="flex items-center justify-between border-b border-border/50 px-3 py-2 text-xs text-muted-foreground">
+          <span>
+            {detectedCount} detected · {serverCount} server{serverCount === 1 ? '' : 's'}
+          </span>
+          {loading ? <LoaderCircle className="size-3.5 animate-spin" /> : null}
+        </div>
+        <div>
+          {visibleConfigs.length === 0 ? (
+            <div className="flex items-start gap-2 px-3 py-2.5 text-xs text-muted-foreground">
+              {remoteFilesystemUnavailable ? (
+                <AlertCircle className="mt-0.5 size-3.5 shrink-0" />
+              ) : (
+                <FileCode2 className="mt-0.5 size-3.5 shrink-0" />
+              )}
+              {remoteFilesystemUnavailable ? (
+                <span>Connect this SSH repo to inspect or add MCP configs.</span>
+              ) : (
+                <span>
+                  No MCP config found. Add an empty workspace config when you want this repo to
+                  define its own MCP servers.
+                </span>
+              )}
+            </div>
+          ) : (
+            <div className="divide-y divide-border/50">
+              {visibleConfigs.map((config) => (
+                <div key={config.candidate.relativePath} className="space-y-2 px-3 py-2.5">
+                  <div className="flex items-center gap-2">
+                    {config.status === 'valid' && !config.readError ? (
+                      <CheckCircle2 className="size-3.5 shrink-0 text-muted-foreground" />
+                    ) : (
+                      <AlertCircle className="size-3.5 shrink-0 text-destructive" />
+                    )}
+                    <div className="min-w-0 flex-1">
+                      <div className="flex min-w-0 items-center gap-2">
+                        <p className="truncate text-sm font-medium">{config.candidate.label}</p>
+                        <p className="truncate font-mono text-[11px] text-muted-foreground">
+                          {config.candidate.relativePath}
+                        </p>
+                      </div>
+                    </div>
+                    <span
+                      className={`shrink-0 rounded-full border px-1.5 py-0.5 text-[10px] font-medium ${statusClassName(config)}`}
+                    >
+                      {statusLabel(config)}
+                    </span>
+                    {config.exists ? (
+                      <Button variant="outline" size="xs" onClick={() => handleOpen(config)}>
+                        Open
+                      </Button>
+                    ) : null}
+                  </div>
+
+                  {config.error || config.readError ? (
+                    <p className="pl-5 text-xs text-destructive">
+                      {config.readError ?? config.error}
+                    </p>
+                  ) : null}
+
+                  {config.servers.length > 0 ? (
+                    <div className="grid gap-1.5 pl-5">
+                      {config.servers.map((server) => (
+                        <div
+                          key={server.name}
+                          className="grid grid-cols-[minmax(0,1fr)_auto] gap-2 rounded-md border border-border/40 bg-background/50 px-2.5 py-1.5"
+                        >
+                          <div className="min-w-0">
+                            <div className="flex items-center gap-1.5">
+                              <span className="truncate text-xs font-medium">{server.name}</span>
+                              <span className="rounded-full bg-muted px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wider text-muted-foreground">
+                                {server.transport}
+                              </span>
+                            </div>
+                            <p className="mt-0.5 truncate font-mono text-[11px] text-muted-foreground">
+                              {serverDetailLabel(server)}
+                            </p>
+                            {server.env && Object.keys(server.env).length > 0 ? (
+                              <p className="mt-0.5 truncate font-mono text-[11px] text-muted-foreground">
+                                env:{' '}
+                                {Object.entries(server.env)
+                                  .map(([key, value]) => `${key}=${value}`)
+                                  .join(', ')}
+                              </p>
+                            ) : null}
+                          </div>
+                          <span className="self-start text-[11px] text-muted-foreground">
+                            {server.status}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                  ) : null}
+                </div>
+              ))}
+            </div>
+          )}
+
+          {missingConfigs.length > 0 && !remoteFilesystemUnavailable ? (
+            <div className="space-y-1.5 border-t border-border/50 px-3 py-2">
+              <p className="text-[11px] text-muted-foreground">Checked</p>
+              <div className="flex flex-wrap gap-1.5">
+                {missingConfigs.map((config) => (
+                  <span
+                    key={config.candidate.relativePath}
+                    className="rounded-md border border-border/50 bg-background/40 px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground"
+                  >
+                    {config.candidate.relativePath}
+                  </span>
+                ))}
+              </div>
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/renderer/src/components/settings/RepositoryPane.tsx
+++ b/src/renderer/src/components/settings/RepositoryPane.tsx
@@ -10,6 +10,7 @@ import { Trash2 } from 'lucide-react'
 import { DEFAULT_REPO_HOOK_SETTINGS } from './SettingsConstants'
 import { BaseRefPicker } from './BaseRefPicker'
 import { RepositoryHooksSection } from './RepositoryHooksSection'
+import { McpConfigSection } from './McpConfigSection'
 import { WorktreeSymlinksSection } from './WorktreeSymlinksSection'
 import { SparsePresetSettingsSection } from './SparsePresetSettingsSection'
 import { SearchableSetting } from './SearchableSetting'
@@ -81,6 +82,19 @@ export function getRepositoryPaneSearchEntries(repo: Repo): SettingsSearchEntry[
               'shared',
               'env',
               'node_modules'
+            ]
+          },
+          {
+            title: 'MCP Configs',
+            description: 'Inspect repo-level MCP server config files.',
+            keywords: [
+              repo.displayName,
+              'mcp',
+              'model context protocol',
+              '.mcp.json',
+              '.cursor/mcp.json',
+              '.claude.json',
+              '.claude/mcp.json'
             ]
           },
           {
@@ -206,6 +220,7 @@ export function RepositoryPane({
       'Custom GitHub Issue Command'
     ].includes(entry.title)
   )
+  const mcpEntries = allEntries.filter((entry) => entry.title === 'MCP Configs')
   const symlinkEntries = allEntries.filter((entry) => entry.title === 'Worktree Symlinks')
 
   const visibleSections = [
@@ -312,6 +327,9 @@ export function RepositoryPane({
     ) : null,
     !isFolder && matchesSettingsSearch(searchQuery, sparsePresetEntries) ? (
       <SparsePresetSettingsSection key="sparse-presets" repoId={repo.id} />
+    ) : null,
+    !isFolder && matchesSettingsSearch(searchQuery, mcpEntries) ? (
+      <McpConfigSection key="mcp-configs" repo={repo} />
     ) : null,
     !isFolder && matchesSettingsSearch(searchQuery, hooksEntries) ? (
       <RepositoryHooksSection

--- a/src/shared/mcp-config.test.ts
+++ b/src/shared/mcp-config.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest'
+import {
+  inspectMcpConfigContent,
+  maskMcpEnv,
+  MCP_CONFIG_CANDIDATES,
+  MCP_STARTER_CONFIG
+} from './mcp-config'
+
+describe('mcp-config', () => {
+  const workspaceCandidate = MCP_CONFIG_CANDIDATES[0]
+
+  it('reports missing configs', () => {
+    expect(inspectMcpConfigContent(workspaceCandidate, null)).toMatchObject({
+      exists: false,
+      status: 'missing',
+      servers: []
+    })
+  })
+
+  it('reports invalid JSON without exposing file contents', () => {
+    const result = inspectMcpConfigContent(workspaceCandidate, '{')
+    expect(result.status).toBe('invalid')
+    expect(result.error).toContain('JSON')
+    expect(result.servers).toEqual([])
+  })
+
+  it('summarizes stdio, http, disabled, and invalid servers', () => {
+    const result = inspectMcpConfigContent(
+      workspaceCandidate,
+      JSON.stringify({
+        mcpServers: {
+          filesystem: {
+            command: 'npx',
+            args: ['-y', '@modelcontextprotocol/server-filesystem'],
+            env: { NODE_ENV: 'production', API_TOKEN: 'secret-token' }
+          },
+          docs: { type: 'http', url: 'https://example.com/mcp' },
+          old: { command: 'node', enabled: false },
+          broken: { args: ['missing-command'] }
+        }
+      })
+    )
+
+    expect(result.status).toBe('valid')
+    expect(result.servers).toEqual([
+      {
+        name: 'filesystem',
+        transport: 'stdio',
+        status: 'enabled',
+        command: 'npx',
+        env: { NODE_ENV: 'production', API_TOKEN: '••••••••' }
+      },
+      {
+        name: 'docs',
+        transport: 'http',
+        status: 'enabled',
+        url: 'https://example.com/mcp'
+      },
+      {
+        name: 'old',
+        transport: 'stdio',
+        status: 'disabled',
+        command: 'node'
+      },
+      {
+        name: 'broken',
+        transport: 'unknown',
+        status: 'invalid',
+        issue: 'Missing command or URL.'
+      }
+    ])
+  })
+
+  it('supports agent-specific command and URL shapes from common adapters', () => {
+    const result = inspectMcpConfigContent(
+      workspaceCandidate,
+      JSON.stringify({
+        mcpServers: {
+          opencodeLocal: { type: 'local', command: ['uvx', 'server'] },
+          geminiRemote: { httpUrl: 'https://example.com/sse' }
+        }
+      })
+    )
+
+    expect(result.servers).toMatchObject([
+      { name: 'opencodeLocal', transport: 'stdio', command: 'uvx' },
+      { name: 'geminiRemote', transport: 'http', url: 'https://example.com/sse' }
+    ])
+  })
+
+  it('masks env values that look sensitive by key or value', () => {
+    expect(
+      maskMcpEnv({
+        NORMAL: 'visible',
+        PASSWORD: 'hunter2',
+        MAYBE: 'sk-abc123456789xyz'
+      })
+    ).toEqual({
+      NORMAL: 'visible',
+      PASSWORD: '••••••••',
+      MAYBE: '••••••••'
+    })
+  })
+
+  it('keeps starter config valid and empty', () => {
+    expect(inspectMcpConfigContent(workspaceCandidate, MCP_STARTER_CONFIG)).toMatchObject({
+      exists: true,
+      status: 'valid',
+      servers: []
+    })
+  })
+})

--- a/src/shared/mcp-config.ts
+++ b/src/shared/mcp-config.ts
@@ -1,0 +1,203 @@
+export type McpConfigFormat = 'workspace' | 'cursor' | 'claude'
+
+export type McpConfigCandidate = {
+  format: McpConfigFormat
+  label: string
+  relativePath: string
+  serversPath: string[]
+}
+
+export type McpServerTransport = 'stdio' | 'http' | 'unknown'
+export type McpServerStatus = 'enabled' | 'disabled' | 'invalid'
+
+export type McpServerSummary = {
+  name: string
+  transport: McpServerTransport
+  status: McpServerStatus
+  command?: string
+  url?: string
+  env?: Record<string, string>
+  issue?: string
+}
+
+export type McpConfigInspection = {
+  candidate: McpConfigCandidate
+  exists: boolean
+  status: 'missing' | 'valid' | 'invalid'
+  servers: McpServerSummary[]
+  error?: string
+}
+
+export const MCP_CONFIG_CANDIDATES: McpConfigCandidate[] = [
+  {
+    format: 'workspace',
+    label: 'Workspace',
+    relativePath: '.mcp.json',
+    serversPath: ['mcpServers']
+  },
+  {
+    format: 'cursor',
+    label: 'Cursor',
+    relativePath: '.cursor/mcp.json',
+    serversPath: ['mcpServers']
+  },
+  {
+    format: 'claude',
+    label: 'Claude',
+    relativePath: '.claude.json',
+    serversPath: ['mcpServers']
+  },
+  {
+    format: 'claude',
+    label: 'Claude workspace',
+    relativePath: '.claude/mcp.json',
+    serversPath: ['mcpServers']
+  }
+]
+
+export const MCP_STARTER_CONFIG = `{
+  "mcpServers": {}
+}
+`
+
+const SENSITIVE_ENV_KEY_PATTERN =
+  /(api[_-]?key|auth|bearer|cookie|credential|password|private[_-]?key|secret|session|token)/i
+const SENSITIVE_ENV_VALUE_PATTERN =
+  /(sk-[A-Za-z0-9_-]{12,}|gh[pousr]_[A-Za-z0-9_]{12,}|xox[baprs]-[A-Za-z0-9-]{12,})/
+
+export function inspectMcpConfigContent(
+  candidate: McpConfigCandidate,
+  content: string | null
+): McpConfigInspection {
+  if (content === null) {
+    return { candidate, exists: false, status: 'missing', servers: [] }
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(content)
+  } catch (error) {
+    return {
+      candidate,
+      exists: true,
+      status: 'invalid',
+      servers: [],
+      error: error instanceof Error ? error.message : 'Invalid JSON'
+    }
+  }
+
+  const rawServers = extractObjectAtPath(parsed, candidate.serversPath)
+  if (!rawServers) {
+    return { candidate, exists: true, status: 'valid', servers: [] }
+  }
+
+  return {
+    candidate,
+    exists: true,
+    status: 'valid',
+    servers: Object.entries(rawServers).map(([name, entry]) => summarizeMcpServer(name, entry))
+  }
+}
+
+export function maskMcpEnv(env: unknown): Record<string, string> | undefined {
+  if (!env || typeof env !== 'object' || Array.isArray(env)) {
+    return undefined
+  }
+
+  const masked: Record<string, string> = {}
+  for (const [key, rawValue] of Object.entries(env)) {
+    const value = typeof rawValue === 'string' ? rawValue : String(rawValue)
+    masked[key] =
+      SENSITIVE_ENV_KEY_PATTERN.test(key) || SENSITIVE_ENV_VALUE_PATTERN.test(value)
+        ? '••••••••'
+        : value
+  }
+  return masked
+}
+
+function extractObjectAtPath(
+  value: unknown,
+  pathSegments: string[]
+): Record<string, unknown> | null {
+  let current = value
+  for (const segment of pathSegments) {
+    if (!current || typeof current !== 'object' || Array.isArray(current)) {
+      return null
+    }
+    current = (current as Record<string, unknown>)[segment]
+  }
+  return current && typeof current === 'object' && !Array.isArray(current)
+    ? (current as Record<string, unknown>)
+    : null
+}
+
+function summarizeMcpServer(name: string, entry: unknown): McpServerSummary {
+  if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+    return {
+      name,
+      transport: 'unknown',
+      status: 'invalid',
+      issue: 'Server entry must be an object.'
+    }
+  }
+
+  const raw = entry as Record<string, unknown>
+  const command = readCommand(raw)
+  const url = readUrl(raw)
+  const transport = resolveTransport(raw, command, url)
+  const enabled = raw.enabled !== false && raw.disabled !== true
+  const env = maskMcpEnv(raw.env)
+
+  if (transport === 'unknown') {
+    return {
+      name,
+      transport,
+      status: 'invalid',
+      env,
+      issue: 'Missing command or URL.'
+    }
+  }
+
+  return {
+    name,
+    transport,
+    status: enabled ? 'enabled' : 'disabled',
+    command,
+    url,
+    env
+  }
+}
+
+function readCommand(raw: Record<string, unknown>): string | undefined {
+  if (typeof raw.command === 'string') {
+    return raw.command
+  }
+  if (Array.isArray(raw.command) && typeof raw.command[0] === 'string') {
+    return raw.command[0]
+  }
+  return undefined
+}
+
+function readUrl(raw: Record<string, unknown>): string | undefined {
+  if (typeof raw.url === 'string') {
+    return raw.url
+  }
+  if (typeof raw.httpUrl === 'string') {
+    return raw.httpUrl
+  }
+  return undefined
+}
+
+function resolveTransport(
+  raw: Record<string, unknown>,
+  command: string | undefined,
+  url: string | undefined
+): McpServerTransport {
+  if (raw.type === 'http' || raw.type === 'remote' || url) {
+    return 'http'
+  }
+  if (raw.type === 'local' || command) {
+    return 'stdio'
+  }
+  return 'unknown'
+}


### PR DESCRIPTION
## Summary
- add a repo settings MCP config inspector for common workspace and agent config files
- summarize detected servers with transport/status labels and masked environment values
- support opening detected configs and creating an empty workspace config when none exists
- handle disconnected SSH filesystem state without noisy per-file errors

## Validation
- pnpm exec oxfmt --check src/renderer/src/components/settings/McpConfigSection.tsx src/renderer/src/components/settings/RepositoryPane.tsx src/shared/mcp-config.ts src/shared/mcp-config.test.ts
- pnpm exec oxlint src/renderer/src/components/settings/McpConfigSection.tsx src/renderer/src/components/settings/RepositoryPane.tsx src/shared/mcp-config.ts src/shared/mcp-config.test.ts
- pnpm exec tsc --noEmit -p config/tsconfig.web.json --composite false
- pnpm exec vitest run --config config/vitest.config.ts src/shared/mcp-config.test.ts

Made with [Orca](https://github.com/stablyai/orca) 🐋
