### PR TITLE
Add workspace status board

### DIFF
--- a/src/main/ipc/worktree-logic.test.ts
+++ b/src/main/ipc/worktree-logic.test.ts
@@ -221,7 +221,9 @@ describe('mergeWorktree', () => {
       isUnread: true,
       isPinned: true,
       sortOrder: 5,
-      lastActivityAt: 1000
+      lastActivityAt: 1000,
+      workspaceStatus: 'in-review',
+      diffComments: []
     }
     const result = mergeWorktree('repo1', baseGit, meta)
     expect(result).toEqual({
@@ -243,7 +245,9 @@ describe('mergeWorktree', () => {
       isUnread: true,
       isPinned: true,
       sortOrder: 5,
-      lastActivityAt: 1000
+      lastActivityAt: 1000,
+      workspaceStatus: 'in-review',
+      diffComments: []
     })
   })
 
@@ -258,6 +262,7 @@ describe('mergeWorktree', () => {
     expect(result.isPinned).toBe(false)
     expect(result.sortOrder).toBe(0)
     expect(result.lastActivityAt).toBe(0)
+    expect(result.workspaceStatus).toBe('in-progress')
   })
 
   it('strips refs/heads/ prefix from branch for display name', () => {

--- a/src/main/ipc/worktree-logic.ts
+++ b/src/main/ipc/worktree-logic.ts
@@ -1,6 +1,7 @@
 import { basename, join, resolve, relative, isAbsolute, posix, win32 } from 'path'
 import type { GitWorktreeInfo, Worktree, WorktreeMeta } from '../../shared/types'
 import { splitWorktreeId } from '../../shared/worktree-id'
+import { DEFAULT_WORKSPACE_STATUS_ID } from '../../shared/workspace-statuses'
 import { getWslHome, parseWslPath } from '../wsl'
 
 /**
@@ -205,6 +206,7 @@ export function mergeWorktree(
       : {}),
     ...(meta?.baseRef !== undefined ? { baseRef: meta.baseRef } : {}),
     ...(meta?.pushTarget !== undefined ? { pushTarget: meta.pushTarget } : {}),
+    workspaceStatus: meta?.workspaceStatus ?? DEFAULT_WORKSPACE_STATUS_ID,
     // Why: diff comments are persisted on WorktreeMeta (see `WorktreeMeta` in
     // shared/types) and forwarded verbatim so the renderer store mirrors
     // on-disk state. `undefined` here means the worktree has no comments yet.

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -60,6 +60,7 @@ import { normalizeTerminalQuickCommands } from '../shared/terminal-quick-command
 import {
   DEFAULT_WORKSPACE_STATUS_ID,
   clampWorkspaceBoardOpacity,
+  normalizeWorkspaceBoardCompact,
   normalizeWorkspaceStatuses
 } from '../shared/workspace-statuses'
 
@@ -1213,7 +1214,8 @@ export class Store {
       groupBy: normalizeGroupBy(this.state.ui?.groupBy),
       sortBy: normalizeSortBy(this.state.ui?.sortBy),
       workspaceStatuses: normalizeWorkspaceStatuses(this.state.ui?.workspaceStatuses),
-      workspaceBoardOpacity: clampWorkspaceBoardOpacity(this.state.ui?.workspaceBoardOpacity)
+      workspaceBoardOpacity: clampWorkspaceBoardOpacity(this.state.ui?.workspaceBoardOpacity),
+      workspaceBoardCompact: normalizeWorkspaceBoardCompact(this.state.ui?.workspaceBoardCompact)
     }
   }
 
@@ -1232,6 +1234,9 @@ export class Store {
       ),
       workspaceBoardOpacity: clampWorkspaceBoardOpacity(
         updates.workspaceBoardOpacity ?? this.state.ui?.workspaceBoardOpacity
+      ),
+      workspaceBoardCompact: normalizeWorkspaceBoardCompact(
+        updates.workspaceBoardCompact ?? this.state.ui?.workspaceBoardCompact
       )
     }
     this.scheduleSave()

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -57,6 +57,11 @@ import { pruneLocalTerminalScrollbackBuffers } from '../shared/workspace-session
 import { pruneWorkspaceSessionBrowserHistory } from '../shared/workspace-session-browser-history'
 import { getRepoIdFromWorktreeId } from '../shared/worktree-id'
 import { normalizeTerminalQuickCommands } from '../shared/terminal-quick-commands'
+import {
+  DEFAULT_WORKSPACE_STATUS_ID,
+  clampWorkspaceBoardOpacity,
+  normalizeWorkspaceStatuses
+} from '../shared/workspace-statuses'
 
 function encrypt(plaintext: string): string {
   if (!plaintext || !safeStorage.isEncryptionAvailable()) {
@@ -130,6 +135,16 @@ const BACKUP_MIN_INTERVAL_MS = 60 * 60 * 1000
 
 function backupPath(dataFile: string, index: number): string {
   return `${dataFile}.bak.${index}`
+}
+
+function normalizeGroupBy(groupBy: unknown): PersistedState['ui']['groupBy'] {
+  if (groupBy === 'none' || groupBy === 'repo' || groupBy === 'pr-status') {
+    return groupBy
+  }
+  if (groupBy === 'workspace-status') {
+    return 'none'
+  }
+  return getDefaultUIState().groupBy
 }
 
 function normalizeSortBy(sortBy: unknown): 'name' | 'smart' | 'recent' | 'repo' {
@@ -1195,7 +1210,10 @@ export class Store {
     return {
       ...getDefaultUIState(),
       ...this.state.ui,
-      sortBy: normalizeSortBy(this.state.ui?.sortBy)
+      groupBy: normalizeGroupBy(this.state.ui?.groupBy),
+      sortBy: normalizeSortBy(this.state.ui?.sortBy),
+      workspaceStatuses: normalizeWorkspaceStatuses(this.state.ui?.workspaceStatuses),
+      workspaceBoardOpacity: clampWorkspaceBoardOpacity(this.state.ui?.workspaceBoardOpacity)
     }
   }
 
@@ -1203,9 +1221,18 @@ export class Store {
     this.state.ui = {
       ...this.state.ui,
       ...updates,
+      groupBy: updates.groupBy
+        ? normalizeGroupBy(updates.groupBy)
+        : normalizeGroupBy(this.state.ui?.groupBy),
       sortBy: updates.sortBy
         ? normalizeSortBy(updates.sortBy)
-        : normalizeSortBy(this.state.ui?.sortBy)
+        : normalizeSortBy(this.state.ui?.sortBy),
+      workspaceStatuses: normalizeWorkspaceStatuses(
+        updates.workspaceStatuses ?? this.state.ui?.workspaceStatuses
+      ),
+      workspaceBoardOpacity: clampWorkspaceBoardOpacity(
+        updates.workspaceBoardOpacity ?? this.state.ui?.workspaceBoardOpacity
+      )
     }
     this.scheduleSave()
   }
@@ -1706,6 +1733,7 @@ function getDefaultWorktreeMeta(): WorktreeMeta {
     isUnread: false,
     isPinned: false,
     sortOrder: Date.now(),
-    lastActivityAt: 0
+    lastActivityAt: 0,
+    workspaceStatus: DEFAULT_WORKSPACE_STATUS_ID
   }
 }

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -728,6 +728,41 @@
   overflow: hidden;
 }
 
+/* Why: the workspace board is offset to the sidebar edge. The generic left
+   sheet translates by its full width, which makes an offset board fly in from
+   far offscreen; this reveals it from the sidebar boundary instead. */
+.workspace-kanban-sheet-content[data-state='open'] {
+  animation-name: workspace-kanban-sheet-in;
+  animation-duration: 300ms;
+  animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.workspace-kanban-sheet-content[data-state='closed'] {
+  animation-name: workspace-kanban-sheet-out;
+  animation-duration: 200ms;
+  animation-timing-function: cubic-bezier(0.7, 0, 0.84, 0);
+}
+
+@keyframes workspace-kanban-sheet-in {
+  from {
+    clip-path: inset(0 100% 0 0);
+  }
+
+  to {
+    clip-path: inset(0 0 0 0);
+  }
+}
+
+@keyframes workspace-kanban-sheet-out {
+  from {
+    clip-path: inset(0 0 0 0);
+  }
+
+  to {
+    clip-path: inset(0 100% 0 0);
+  }
+}
+
 .sidebar-header {
   padding: 12px 16px 8px;
   font-size: 11px;

--- a/src/renderer/src/components/sidebar/SidebarHeader.tsx
+++ b/src/renderer/src/components/sidebar/SidebarHeader.tsx
@@ -1,5 +1,5 @@
-import React from 'react'
-import { Plus, SlidersHorizontal } from 'lucide-react'
+import React, { useState } from 'react'
+import { Kanban, Plus, SlidersHorizontal } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
@@ -17,10 +17,11 @@ import {
 } from '@/components/ui/dropdown-menu'
 import type { WorktreeCardProperty } from '../../../../shared/types'
 import SidebarFilter from './SidebarFilter'
+import WorkspaceKanbanDrawer from './WorkspaceKanbanDrawer'
 
 const GROUP_BY_OPTIONS = [
-  { id: 'none', label: 'All' },
-  { id: 'pr-status', label: 'PR Status' },
+  { id: 'none', label: 'Status' },
+  { id: 'pr-status', label: 'PR' },
   { id: 'repo', label: 'Repo' }
 ] as const
 
@@ -52,6 +53,7 @@ const isMac = navigator.userAgent.includes('Mac')
 const newWorktreeShortcutLabel = isMac ? '⌘N' : 'Ctrl+N'
 
 const SidebarHeader = React.memo(function SidebarHeader() {
+  const [workspaceBoardOpen, setWorkspaceBoardOpen] = useState(false)
   const openModal = useAppStore((s) => s.openModal)
   const repos = useAppStore((s) => s.repos)
   const canCreateWorktree = repos.some((repo) => isGitRepoKind(repo))
@@ -63,129 +65,150 @@ const SidebarHeader = React.memo(function SidebarHeader() {
   const groupBy = useAppStore((s) => s.groupBy)
   const setGroupBy = useAppStore((s) => s.setGroupBy)
   return (
-    <div className="flex h-8 items-center justify-between px-2 gap-2">
-      <span className="px-2 text-[10.5px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/80 select-none">
-        Workspaces
-      </span>
-      <div className="flex items-center gap-1.5 shrink-0">
-        <SidebarFilter />
-        <DropdownMenu>
+    <>
+      <div className="flex h-8 items-center justify-between px-2 gap-2">
+        <div className="flex min-w-0 items-center gap-1">
+          <span className="px-2 text-[10.5px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/80 select-none">
+            Workspaces
+          </span>
           <Tooltip>
             <TooltipTrigger asChild>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon-xs"
-                  className="text-muted-foreground"
-                  aria-label="View options"
-                >
-                  <SlidersHorizontal className="size-3.5" strokeWidth={2.25} />
-                </Button>
-              </DropdownMenuTrigger>
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                className="text-muted-foreground"
+                aria-label="Workspace board"
+                onClick={() => setWorkspaceBoardOpen(true)}
+              >
+                <Kanban className="size-3.5" strokeWidth={2.25} />
+              </Button>
             </TooltipTrigger>
             <TooltipContent side="bottom" sideOffset={6}>
-              View options
+              Workspace board
             </TooltipContent>
           </Tooltip>
-          <DropdownMenuContent side="right" align="start" sideOffset={8} className="w-56 pb-2">
-            <DropdownMenuLabel>Group by</DropdownMenuLabel>
-            <div className="px-2 pt-0.5 pb-1">
-              <ToggleGroup
-                type="single"
-                value={groupBy}
-                onValueChange={(v) => {
-                  if (v) {
-                    setGroupBy(v as typeof groupBy)
+        </div>
+        <div className="flex items-center gap-1.5 shrink-0">
+          <SidebarFilter />
+          <DropdownMenu>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon-xs"
+                    className="text-muted-foreground"
+                    aria-label="View options"
+                  >
+                    <SlidersHorizontal className="size-3.5" strokeWidth={2.25} />
+                  </Button>
+                </DropdownMenuTrigger>
+              </TooltipTrigger>
+              <TooltipContent side="bottom" sideOffset={6}>
+                View options
+              </TooltipContent>
+            </Tooltip>
+            <DropdownMenuContent side="right" align="start" sideOffset={8} className="w-56 pb-2">
+              <DropdownMenuLabel>Group by</DropdownMenuLabel>
+              <div className="px-2 pt-0.5 pb-1">
+                <ToggleGroup
+                  type="single"
+                  value={groupBy}
+                  onValueChange={(v) => {
+                    if (v) {
+                      setGroupBy(v as typeof groupBy)
+                    }
+                  }}
+                  variant="outline"
+                  size="sm"
+                  className="h-6 w-full justify-start"
+                >
+                  {GROUP_BY_OPTIONS.map((opt) => (
+                    <ToggleGroupItem
+                      key={opt.id}
+                      value={opt.id}
+                      className="h-6 px-2 text-[10px] data-[state=on]:bg-foreground/10 data-[state=on]:font-semibold data-[state=on]:text-foreground"
+                    >
+                      {opt.label}
+                    </ToggleGroupItem>
+                  ))}
+                </ToggleGroup>
+              </div>
+
+              <DropdownMenuSeparator />
+              <DropdownMenuLabel>Sort by</DropdownMenuLabel>
+              <DropdownMenuRadioGroup
+                value={sortBy}
+                onValueChange={(v) => setSortBy(v as typeof sortBy)}
+              >
+                {SORT_OPTIONS.map((opt) => {
+                  const radioItem = (
+                    <DropdownMenuRadioItem
+                      key={opt.id}
+                      value={opt.id}
+                      // Keep the menu open so people can compare sort modes and
+                      // toggle card properties without reopening the same panel.
+                      onSelect={(e) => e.preventDefault()}
+                    >
+                      {opt.label}
+                    </DropdownMenuRadioItem>
+                  )
+                  if (!opt.description) {
+                    return radioItem
                   }
+                  return (
+                    <Tooltip key={opt.id}>
+                      <TooltipTrigger asChild>{radioItem}</TooltipTrigger>
+                      <TooltipContent side="right" sideOffset={6}>
+                        {opt.description}
+                      </TooltipContent>
+                    </Tooltip>
+                  )
+                })}
+              </DropdownMenuRadioGroup>
+
+              <DropdownMenuSeparator />
+              <DropdownMenuLabel>Show properties</DropdownMenuLabel>
+              {PROPERTY_OPTIONS.map((opt) => (
+                <DropdownMenuCheckboxItem
+                  key={opt.id}
+                  checked={worktreeCardProperties.includes(opt.id)}
+                  onCheckedChange={() => toggleWorktreeCardProperty(opt.id)}
+                  onSelect={(e) => e.preventDefault()}
+                >
+                  {opt.label}
+                </DropdownMenuCheckboxItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                onClick={() => {
+                  if (!canCreateWorktree) {
+                    return
+                  }
+                  openModal('new-workspace-composer', { telemetrySource: 'sidebar' })
                 }}
-                variant="outline"
-                size="sm"
-                className="h-6 w-full justify-start"
+                aria-label="New workspace"
+                disabled={!canCreateWorktree}
               >
-                {GROUP_BY_OPTIONS.map((opt) => (
-                  <ToggleGroupItem
-                    key={opt.id}
-                    value={opt.id}
-                    className="h-6 px-2 text-[10px] data-[state=on]:bg-foreground/10 data-[state=on]:font-semibold data-[state=on]:text-foreground"
-                  >
-                    {opt.label}
-                  </ToggleGroupItem>
-                ))}
-              </ToggleGroup>
-            </div>
-
-            <DropdownMenuSeparator />
-            <DropdownMenuLabel>Sort by</DropdownMenuLabel>
-            <DropdownMenuRadioGroup
-              value={sortBy}
-              onValueChange={(v) => setSortBy(v as typeof sortBy)}
-            >
-              {SORT_OPTIONS.map((opt) => {
-                const radioItem = (
-                  <DropdownMenuRadioItem
-                    key={opt.id}
-                    value={opt.id}
-                    // Keep the menu open so people can compare sort modes and
-                    // toggle card properties without reopening the same panel.
-                    onSelect={(e) => e.preventDefault()}
-                  >
-                    {opt.label}
-                  </DropdownMenuRadioItem>
-                )
-                if (!opt.description) {
-                  return radioItem
-                }
-                return (
-                  <Tooltip key={opt.id}>
-                    <TooltipTrigger asChild>{radioItem}</TooltipTrigger>
-                    <TooltipContent side="right" sideOffset={6}>
-                      {opt.description}
-                    </TooltipContent>
-                  </Tooltip>
-                )
-              })}
-            </DropdownMenuRadioGroup>
-
-            <DropdownMenuSeparator />
-            <DropdownMenuLabel>Show properties</DropdownMenuLabel>
-            {PROPERTY_OPTIONS.map((opt) => (
-              <DropdownMenuCheckboxItem
-                key={opt.id}
-                checked={worktreeCardProperties.includes(opt.id)}
-                onCheckedChange={() => toggleWorktreeCardProperty(opt.id)}
-                onSelect={(e) => e.preventDefault()}
-              >
-                {opt.label}
-              </DropdownMenuCheckboxItem>
-            ))}
-          </DropdownMenuContent>
-        </DropdownMenu>
-
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              variant="ghost"
-              size="icon-xs"
-              onClick={() => {
-                if (!canCreateWorktree) {
-                  return
-                }
-                openModal('new-workspace-composer', { telemetrySource: 'sidebar' })
-              }}
-              aria-label="New workspace"
-              disabled={!canCreateWorktree}
-            >
-              <Plus className="size-3.5" strokeWidth={2.25} />
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent side="right" sideOffset={6}>
-            {canCreateWorktree
-              ? `New workspace (${newWorktreeShortcutLabel})`
-              : 'Add a Git project to create worktrees'}
-          </TooltipContent>
-        </Tooltip>
+                <Plus className="size-3.5" strokeWidth={2.25} />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="right" sideOffset={6}>
+              {canCreateWorktree
+                ? `New workspace (${newWorktreeShortcutLabel})`
+                : 'Add a Git project to create worktrees'}
+            </TooltipContent>
+          </Tooltip>
+        </div>
       </div>
-    </div>
+      <WorkspaceKanbanDrawer open={workspaceBoardOpen} onOpenChange={setWorkspaceBoardOpen} />
+    </>
   )
 })
 

--- a/src/renderer/src/components/sidebar/SidebarHeader.tsx
+++ b/src/renderer/src/components/sidebar/SidebarHeader.tsx
@@ -78,7 +78,8 @@ const SidebarHeader = React.memo(function SidebarHeader() {
                 size="icon-xs"
                 className="text-muted-foreground"
                 aria-label="Workspace board"
-                onClick={() => setWorkspaceBoardOpen(true)}
+                aria-pressed={workspaceBoardOpen}
+                onClick={() => setWorkspaceBoardOpen((open) => !open)}
               >
                 <Kanban className="size-3.5" strokeWidth={2.25} />
               </Button>

--- a/src/renderer/src/components/sidebar/WorkspaceKanbanCard.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanCard.tsx
@@ -1,0 +1,85 @@
+import React, { useCallback } from 'react'
+import { Pin } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card'
+import { activateAndRevealWorktree } from '@/lib/worktree-activation'
+import { cn } from '@/lib/utils'
+import type { Repo, Worktree } from '../../../../shared/types'
+import WorktreeCard from './WorktreeCard'
+import { writeWorkspaceDragData } from './workspace-status'
+
+type WorkspaceKanbanCardProps = {
+  worktree: Worktree
+  repo: Repo | undefined
+  isActive: boolean
+  compact: boolean
+  onActivate: () => void
+}
+
+export default function WorkspaceKanbanCard({
+  worktree,
+  repo,
+  isActive,
+  compact,
+  onActivate
+}: WorkspaceKanbanCardProps): React.JSX.Element {
+  const handleActivate = useCallback(() => {
+    activateAndRevealWorktree(worktree.id)
+    onActivate()
+  }, [onActivate, worktree.id])
+
+  const handleDragStart = useCallback(
+    (event: React.DragEvent<HTMLButtonElement>) => {
+      writeWorkspaceDragData(event.dataTransfer, worktree.id)
+    },
+    [worktree.id]
+  )
+
+  if (compact) {
+    return (
+      <HoverCard openDelay={450} closeDelay={100}>
+        <HoverCardTrigger asChild>
+          <button
+            type="button"
+            draggable
+            onDragStart={handleDragStart}
+            onClick={handleActivate}
+            className={cn(
+              'flex h-8 w-full min-w-0 cursor-pointer items-center rounded-md border px-2 text-left text-[12px] outline-none transition-colors',
+              isActive
+                ? 'border-sidebar-ring bg-sidebar-accent text-sidebar-accent-foreground'
+                : 'border-transparent text-foreground hover:bg-sidebar-accent/60 focus-visible:border-sidebar-ring'
+            )}
+            data-workspace-board-card-mode="compact"
+            aria-label={`Open ${worktree.displayName}`}
+          >
+            <span className="min-w-0 truncate">{worktree.displayName}</span>
+          </button>
+        </HoverCardTrigger>
+        <HoverCardContent side="right" align="start" sideOffset={8} className="w-72 p-1.5">
+          <WorktreeCard
+            worktree={worktree}
+            repo={repo}
+            isActive={isActive}
+            onActivate={onActivate}
+          />
+        </HoverCardContent>
+      </HoverCard>
+    )
+  }
+
+  return (
+    <div className="relative" data-workspace-board-card-mode="detailed">
+      {worktree.isPinned ? (
+        <Badge
+          variant="outline"
+          className="pointer-events-none absolute right-2 top-1.5 z-10 h-4 gap-1 rounded-full bg-background/90 px-1.5 text-[9px] leading-none text-muted-foreground"
+        >
+          <Pin className="size-2.5" />
+          Pinned
+        </Badge>
+      ) : null}
+      <WorktreeCard worktree={worktree} repo={repo} isActive={isActive} onActivate={onActivate} />
+    </div>
+  )
+}

--- a/src/renderer/src/components/sidebar/WorkspaceKanbanCard.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanCard.tsx
@@ -1,11 +1,17 @@
 import React, { useCallback } from 'react'
 import { Pin } from 'lucide-react'
+import { useAppStore } from '@/store'
 import { Badge } from '@/components/ui/badge'
 import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
+import { getWorktreeStatusLabel } from '@/lib/worktree-status'
 import { cn } from '@/lib/utils'
 import type { Repo, Worktree } from '../../../../shared/types'
+import StatusIndicator from './StatusIndicator'
 import WorktreeCard from './WorktreeCard'
+import WorktreeContextMenu from './WorktreeContextMenu'
+import { useWorktreeActivityStatus } from './use-worktree-activity-status'
 import { writeWorkspaceDragData } from './workspace-status'
 
 type WorkspaceKanbanCardProps = {
@@ -23,48 +29,14 @@ export default function WorkspaceKanbanCard({
   compact,
   onActivate
 }: WorkspaceKanbanCardProps): React.JSX.Element {
-  const handleActivate = useCallback(() => {
-    activateAndRevealWorktree(worktree.id)
-    onActivate()
-  }, [onActivate, worktree.id])
-
-  const handleDragStart = useCallback(
-    (event: React.DragEvent<HTMLButtonElement>) => {
-      writeWorkspaceDragData(event.dataTransfer, worktree.id)
-    },
-    [worktree.id]
-  )
-
   if (compact) {
     return (
-      <HoverCard openDelay={450} closeDelay={100}>
-        <HoverCardTrigger asChild>
-          <button
-            type="button"
-            draggable
-            onDragStart={handleDragStart}
-            onClick={handleActivate}
-            className={cn(
-              'flex h-8 w-full min-w-0 cursor-pointer items-center rounded-md border px-2 text-left text-[12px] outline-none transition-colors',
-              isActive
-                ? 'border-sidebar-ring bg-sidebar-accent text-sidebar-accent-foreground'
-                : 'border-transparent text-foreground hover:bg-sidebar-accent/60 focus-visible:border-sidebar-ring'
-            )}
-            data-workspace-board-card-mode="compact"
-            aria-label={`Open ${worktree.displayName}`}
-          >
-            <span className="min-w-0 truncate">{worktree.displayName}</span>
-          </button>
-        </HoverCardTrigger>
-        <HoverCardContent side="right" align="start" sideOffset={8} className="w-72 p-1.5">
-          <WorktreeCard
-            worktree={worktree}
-            repo={repo}
-            isActive={isActive}
-            onActivate={onActivate}
-          />
-        </HoverCardContent>
-      </HoverCard>
+      <WorkspaceKanbanCompactCard
+        worktree={worktree}
+        repo={repo}
+        isActive={isActive}
+        onActivate={onActivate}
+      />
     )
   }
 
@@ -81,5 +53,93 @@ export default function WorkspaceKanbanCard({
       ) : null}
       <WorktreeCard worktree={worktree} repo={repo} isActive={isActive} onActivate={onActivate} />
     </div>
+  )
+}
+
+function WorkspaceKanbanCompactCard({
+  worktree,
+  repo,
+  isActive,
+  onActivate
+}: Omit<WorkspaceKanbanCardProps, 'compact'>): React.JSX.Element {
+  const deleteState = useAppStore((s) => s.deleteStateByWorktreeId[worktree.id])
+  const isDeleting = deleteState?.isDeleting ?? false
+  const status = useWorktreeActivityStatus(worktree.id)
+
+  const handleActivate = useCallback(() => {
+    if (isDeleting) {
+      return
+    }
+    activateAndRevealWorktree(worktree.id)
+    onActivate()
+  }, [isDeleting, onActivate, worktree.id])
+
+  const handleDragStart = useCallback(
+    (event: React.DragEvent<HTMLButtonElement>) => {
+      if (isDeleting) {
+        event.preventDefault()
+        return
+      }
+      writeWorkspaceDragData(event.dataTransfer, worktree.id)
+    },
+    [isDeleting, worktree.id]
+  )
+
+  return (
+    <WorktreeContextMenu worktree={worktree}>
+      <HoverCard openDelay={450} closeDelay={100}>
+        <HoverCardTrigger asChild>
+          <button
+            type="button"
+            draggable={!isDeleting}
+            onDragStart={handleDragStart}
+            onClick={handleActivate}
+            className={cn(
+              'flex h-8 w-full min-w-0 cursor-pointer items-center rounded-md border px-2 text-left text-[12px] outline-none transition-colors',
+              isActive
+                ? 'border-sidebar-ring bg-sidebar-accent text-sidebar-accent-foreground'
+                : 'border-transparent text-foreground hover:bg-sidebar-accent/60 focus-visible:border-sidebar-ring',
+              isDeleting && 'cursor-not-allowed opacity-50 grayscale'
+            )}
+            data-workspace-board-card-mode="compact"
+            aria-label={`Open ${worktree.displayName}`}
+            aria-busy={isDeleting}
+          >
+            <StatusIndicator status={status} aria-hidden="true" className="mr-1" />
+            <span className="sr-only">{getWorktreeStatusLabel(status)}</span>
+            <span className="min-w-0 flex-1 truncate">{worktree.displayName}</span>
+            {repo ? (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span
+                    className="ml-2 flex max-w-[25%] shrink-0 items-center gap-1 rounded-[4px] border border-border bg-accent px-1.5 py-0.5 leading-none dark:border-border/60 dark:bg-accent/50"
+                    data-workspace-board-repo-badge=""
+                  >
+                    <span
+                      className="size-1.5 shrink-0 rounded-full"
+                      style={{ backgroundColor: repo.badgeColor }}
+                    />
+                    <span className="min-w-0 truncate text-[10px] font-semibold lowercase text-foreground">
+                      {repo.displayName}
+                    </span>
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent side="top" sideOffset={4}>
+                  {repo.displayName}
+                </TooltipContent>
+              </Tooltip>
+            ) : null}
+          </button>
+        </HoverCardTrigger>
+        <HoverCardContent side="right" align="start" sideOffset={8} className="w-72 p-1.5">
+          <WorktreeCard
+            worktree={worktree}
+            repo={repo}
+            isActive={isActive}
+            onActivate={onActivate}
+          />
+        </HoverCardContent>
+      </HoverCard>
+    </WorktreeContextMenu>
   )
 }

--- a/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.tsx
@@ -1,0 +1,344 @@
+import React, { useCallback, useMemo, useRef, useState } from 'react'
+import { useAppStore } from '@/store'
+import { useAllWorktrees, useRepoMap } from '@/store/selectors'
+import { cn } from '@/lib/utils'
+import {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle
+} from '@/components/ui/sheet'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Pin, X } from 'lucide-react'
+import WorktreeCard from './WorktreeCard'
+import WorkspaceKanbanSettingsMenu from './WorkspaceKanbanSettingsMenu'
+import {
+  getWorkspaceStatus,
+  hasWorkspaceDragData,
+  readWorkspaceDragData,
+  getWorkspaceStatusVisualMeta
+} from './workspace-status'
+import { useWorkspaceStatusDocumentDrop } from './use-workspace-status-drop'
+import type { WorkspaceStatus, Worktree } from '../../../../shared/types'
+import { makeWorkspaceStatusId } from '../../../../shared/workspace-statuses'
+
+type WorkspaceKanbanDrawerProps = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+function sortBoardWorktrees(a: Worktree, b: Worktree): number {
+  return b.lastActivityAt - a.lastActivityAt || a.displayName.localeCompare(b.displayName)
+}
+
+export default function WorkspaceKanbanDrawer({
+  open,
+  onOpenChange
+}: WorkspaceKanbanDrawerProps): React.JSX.Element {
+  const allWorktrees = useAllWorktrees()
+  const repoMap = useRepoMap()
+  const activeWorktreeId = useAppStore((s) => s.activeWorktreeId)
+  const updateWorktreeMeta = useAppStore((s) => s.updateWorktreeMeta)
+  const workspaceStatuses = useAppStore((s) => s.workspaceStatuses)
+  const setWorkspaceStatuses = useAppStore((s) => s.setWorkspaceStatuses)
+  const workspaceBoardOpacity = useAppStore((s) => s.workspaceBoardOpacity)
+  const setWorkspaceBoardOpacity = useAppStore((s) => s.setWorkspaceBoardOpacity)
+  const boardRef = useRef<HTMLDivElement>(null)
+  const [dragOverStatus, setDragOverStatus] = useState<WorkspaceStatus | null>(null)
+  const [pinDragOver, setPinDragOver] = useState(false)
+
+  const worktreesByStatus = useMemo(() => {
+    const grouped = new Map<WorkspaceStatus, Worktree[]>(
+      workspaceStatuses.map((status) => [status.id, []])
+    )
+    for (const worktree of allWorktrees) {
+      if (worktree.isArchived) {
+        continue
+      }
+      grouped.get(getWorkspaceStatus(worktree, workspaceStatuses))!.push(worktree)
+    }
+    for (const items of grouped.values()) {
+      items.sort((a, b) => Number(b.isPinned) - Number(a.isPinned) || sortBoardWorktrees(a, b))
+    }
+    return grouped
+  }, [allWorktrees, workspaceStatuses])
+
+  const moveWorktreeToStatus = useCallback(
+    (worktreeId: string, status: WorkspaceStatus) => {
+      const current = allWorktrees.find((worktree) => worktree.id === worktreeId)
+      if (!current || getWorkspaceStatus(current, workspaceStatuses) === status) {
+        return
+      }
+      void updateWorktreeMeta(worktreeId, { workspaceStatus: status })
+    },
+    [allWorktrees, updateWorktreeMeta, workspaceStatuses]
+  )
+
+  const pinWorktree = useCallback(
+    (worktreeId: string) => {
+      const current = allWorktrees.find((worktree) => worktree.id === worktreeId)
+      if (!current || current.isPinned) {
+        return
+      }
+      void updateWorktreeMeta(worktreeId, { isPinned: true })
+    },
+    [allWorktrees, updateWorktreeMeta]
+  )
+
+  const handleDragOver = useCallback((event: React.DragEvent, status: WorkspaceStatus) => {
+    if (!hasWorkspaceDragData(event.dataTransfer)) {
+      return
+    }
+    event.preventDefault()
+    event.dataTransfer.dropEffect = 'move'
+    setDragOverStatus(status)
+  }, [])
+
+  const handleDragLeave = useCallback((event: React.DragEvent) => {
+    const relatedTarget = event.relatedTarget
+    if (relatedTarget instanceof Node && event.currentTarget.contains(relatedTarget)) {
+      return
+    }
+    setDragOverStatus(null)
+  }, [])
+
+  const handlePinDragOver = useCallback((event: React.DragEvent) => {
+    if (!hasWorkspaceDragData(event.dataTransfer)) {
+      return
+    }
+    event.preventDefault()
+    event.dataTransfer.dropEffect = 'move'
+    setPinDragOver(true)
+  }, [])
+
+  const handlePinDragLeave = useCallback((event: React.DragEvent) => {
+    const relatedTarget = event.relatedTarget
+    if (relatedTarget instanceof Node && event.currentTarget.contains(relatedTarget)) {
+      return
+    }
+    setPinDragOver(false)
+  }, [])
+
+  const handleDragFinish = useCallback(() => {
+    setDragOverStatus(null)
+    setPinDragOver(false)
+  }, [])
+
+  const handleDrop = useCallback(
+    (event: React.DragEvent, status: WorkspaceStatus) => {
+      const worktreeId = readWorkspaceDragData(event.dataTransfer)
+      if (!worktreeId) {
+        return
+      }
+      event.preventDefault()
+      setDragOverStatus(null)
+      moveWorktreeToStatus(worktreeId, status)
+    },
+    [moveWorktreeToStatus]
+  )
+
+  const handleWorktreeActivate = useCallback(() => {
+    onOpenChange(false)
+  }, [onOpenChange])
+
+  const handleOpacityChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      setWorkspaceBoardOpacity(Number(event.target.value) / 100)
+    },
+    [setWorkspaceBoardOpacity]
+  )
+
+  const handleRenameStatus = useCallback(
+    (statusId: string, label: string) => {
+      const trimmed = label.trim()
+      if (!trimmed) {
+        return
+      }
+      setWorkspaceStatuses(
+        workspaceStatuses.map((status) =>
+          status.id === statusId ? { ...status, label: trimmed } : status
+        )
+      )
+    },
+    [setWorkspaceStatuses, workspaceStatuses]
+  )
+
+  const handleMoveStatus = useCallback(
+    (statusId: string, direction: -1 | 1) => {
+      const index = workspaceStatuses.findIndex((status) => status.id === statusId)
+      const nextIndex = index + direction
+      if (index === -1 || nextIndex < 0 || nextIndex >= workspaceStatuses.length) {
+        return
+      }
+      const next = [...workspaceStatuses]
+      const [moved] = next.splice(index, 1)
+      next.splice(nextIndex, 0, moved)
+      setWorkspaceStatuses(next)
+    },
+    [setWorkspaceStatuses, workspaceStatuses]
+  )
+
+  const handleAddStatus = useCallback(() => {
+    const label = `Status ${workspaceStatuses.length + 1}`
+    setWorkspaceStatuses([
+      ...workspaceStatuses,
+      { id: makeWorkspaceStatusId(label, workspaceStatuses), label }
+    ])
+  }, [setWorkspaceStatuses, workspaceStatuses])
+
+  const handleRemoveStatus = useCallback(
+    (statusId: string) => {
+      if (workspaceStatuses.length <= 1) {
+        return
+      }
+      const index = workspaceStatuses.findIndex((status) => status.id === statusId)
+      if (index === -1) {
+        return
+      }
+      const next = workspaceStatuses.filter((status) => status.id !== statusId)
+      const fallbackStatus = next[Math.min(index, next.length - 1)]?.id ?? next[0]!.id
+      setWorkspaceStatuses(next)
+      for (const worktree of allWorktrees) {
+        if (getWorkspaceStatus(worktree, workspaceStatuses) === statusId) {
+          void updateWorktreeMeta(worktree.id, { workspaceStatus: fallbackStatus })
+        }
+      }
+    },
+    [allWorktrees, setWorkspaceStatuses, updateWorktreeMeta, workspaceStatuses]
+  )
+
+  useWorkspaceStatusDocumentDrop(boardRef, moveWorktreeToStatus, pinWorktree, handleDragFinish)
+
+  const opacityPercent = Math.round(workspaceBoardOpacity * 100)
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="left"
+        showCloseButton={false}
+        className="w-[min(96vw,1180px)] bg-sidebar p-0 sm:max-w-none"
+        overlayStyle={{ top: 36 }}
+        style={
+          {
+            top: 36,
+            height: 'calc(100% - 36px)',
+            opacity: workspaceBoardOpacity
+          } as React.CSSProperties
+        }
+      >
+        <SheetHeader className="border-b border-sidebar-border px-4 py-3 pr-24">
+          <SheetTitle className="text-sm">Workspace board</SheetTitle>
+          <SheetDescription className="sr-only">
+            Organize workspaces by status and open workspace cards.
+          </SheetDescription>
+        </SheetHeader>
+
+        <div className="absolute right-3 top-2.5 flex items-center gap-1">
+          <WorkspaceKanbanSettingsMenu
+            opacityPercent={opacityPercent}
+            workspaceStatuses={workspaceStatuses}
+            onOpacityChange={handleOpacityChange}
+            onRenameStatus={handleRenameStatus}
+            onMoveStatus={handleMoveStatus}
+            onRemoveStatus={handleRemoveStatus}
+            onAddStatus={handleAddStatus}
+          />
+          <SheetClose asChild>
+            <Button variant="ghost" size="icon-xs" aria-label="Close">
+              <X className="size-3.5" />
+            </Button>
+          </SheetClose>
+        </div>
+
+        <div ref={boardRef} className="flex min-h-0 flex-1 flex-col overflow-hidden p-3">
+          <div
+            data-workspace-pin-drop-target=""
+            className={cn(
+              'mb-3 flex h-8 shrink-0 items-center gap-2 rounded-md border border-dashed border-sidebar-border bg-background/45 px-3 text-[12px] text-muted-foreground transition-colors',
+              pinDragOver && 'border-sidebar-ring bg-sidebar-accent text-foreground'
+            )}
+            onDragOver={handlePinDragOver}
+            onDragLeave={handlePinDragLeave}
+          >
+            <Pin className="size-3.5" />
+            <span className="font-medium">Pinned</span>
+            <span className="truncate">Drop here to pin without changing status.</span>
+          </div>
+
+          <div className="min-h-0 flex-1 overflow-x-auto overflow-y-hidden scrollbar-sleek">
+            <div
+              className="grid h-full min-h-0 min-w-full grid-rows-[minmax(0,1fr)] gap-3"
+              style={{
+                gridTemplateColumns: `repeat(${workspaceStatuses.length}, minmax(240px, 1fr))`
+              }}
+            >
+              {workspaceStatuses.map((status) => {
+                const meta = getWorkspaceStatusVisualMeta(status.id)
+                const items = worktreesByStatus.get(status.id) ?? []
+                const isDragTarget = dragOverStatus === status.id
+
+                return (
+                  <section
+                    key={status.id}
+                    data-workspace-status-drop-target=""
+                    data-workspace-status={status.id}
+                    className={cn(
+                      'flex h-full min-h-0 min-w-0 flex-col overflow-hidden rounded-md border border-sidebar-border bg-background/55 transition-colors',
+                      isDragTarget && 'border-sidebar-ring bg-sidebar-accent/70'
+                    )}
+                    onDragOver={(event) => handleDragOver(event, status.id)}
+                    onDragLeave={handleDragLeave}
+                    onDrop={(event) => handleDrop(event, status.id)}
+                  >
+                    <div className="flex h-9 shrink-0 items-center gap-2 border-b border-border/70 px-3">
+                      <meta.icon className={cn('size-3.5', meta.tone)} />
+                      <div className="min-w-0 flex-1 truncate text-[12px] font-semibold text-foreground">
+                        {status.label}
+                      </div>
+                      <div className="rounded-full bg-muted px-1.5 py-0.5 text-[9px] font-medium leading-none text-muted-foreground">
+                        {items.length}
+                      </div>
+                    </div>
+
+                    <div className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden px-1.5 py-2 scrollbar-sleek">
+                      {items.length > 0 ? (
+                        <div className="space-y-2">
+                          {items.map((worktree) => (
+                            <div key={worktree.id} className="relative">
+                              {worktree.isPinned ? (
+                                <Badge
+                                  variant="outline"
+                                  className="pointer-events-none absolute right-2 top-1.5 z-10 h-4 gap-1 rounded-full bg-background/90 px-1.5 text-[9px] leading-none text-muted-foreground"
+                                >
+                                  <Pin className="size-2.5" />
+                                  Pinned
+                                </Badge>
+                              ) : null}
+                              <WorktreeCard
+                                worktree={worktree}
+                                repo={repoMap.get(worktree.repoId)}
+                                isActive={activeWorktreeId === worktree.id}
+                                onActivate={handleWorktreeActivate}
+                              />
+                            </div>
+                          ))}
+                        </div>
+                      ) : (
+                        <div className="flex h-20 items-center justify-center rounded-md border border-dashed border-border/70 text-[11px] text-muted-foreground">
+                          Empty
+                        </div>
+                      )}
+                    </div>
+                  </section>
+                )
+              })}
+            </div>
+          </div>
+        </div>
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.tsx
@@ -168,6 +168,24 @@ export default function WorkspaceKanbanDrawer({
     [setWorkspaceStatuses, workspaceStatuses]
   )
 
+  const handleChangeStatusColor = useCallback(
+    (statusId: string, color: string) => {
+      setWorkspaceStatuses(
+        workspaceStatuses.map((status) => (status.id === statusId ? { ...status, color } : status))
+      )
+    },
+    [setWorkspaceStatuses, workspaceStatuses]
+  )
+
+  const handleChangeStatusIcon = useCallback(
+    (statusId: string, icon: string) => {
+      setWorkspaceStatuses(
+        workspaceStatuses.map((status) => (status.id === statusId ? { ...status, icon } : status))
+      )
+    },
+    [setWorkspaceStatuses, workspaceStatuses]
+  )
+
   const handleMoveStatus = useCallback(
     (statusId: string, direction: -1 | 1) => {
       const index = workspaceStatuses.findIndex((status) => status.id === statusId)
@@ -249,6 +267,8 @@ export default function WorkspaceKanbanDrawer({
             workspaceStatuses={workspaceStatuses}
             onOpacityChange={handleOpacityChange}
             onRenameStatus={handleRenameStatus}
+            onChangeStatusColor={handleChangeStatusColor}
+            onChangeStatusIcon={handleChangeStatusIcon}
             onMoveStatus={handleMoveStatus}
             onRemoveStatus={handleRemoveStatus}
             onAddStatus={handleAddStatus}
@@ -283,7 +303,7 @@ export default function WorkspaceKanbanDrawer({
               }}
             >
               {workspaceStatuses.map((status) => {
-                const meta = getWorkspaceStatusVisualMeta(status.id)
+                const meta = getWorkspaceStatusVisualMeta(status)
                 const items = worktreesByStatus.get(status.id) ?? []
                 const isDragTarget = dragOverStatus === status.id
 
@@ -293,7 +313,9 @@ export default function WorkspaceKanbanDrawer({
                     data-workspace-status-drop-target=""
                     data-workspace-status={status.id}
                     className={cn(
-                      'flex h-full min-h-0 min-w-0 flex-col overflow-hidden rounded-md border border-sidebar-border bg-background/55 transition-colors',
+                      'flex h-full min-h-0 min-w-0 flex-col overflow-hidden rounded-md border border-t-2 border-sidebar-border transition-colors',
+                      meta.border,
+                      meta.laneTint,
                       isDragTarget && 'border-sidebar-ring bg-sidebar-accent/70'
                     )}
                     onDragOver={(event) => handleDragOver(event, status.id)}

--- a/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useAppStore } from '@/store'
 import { useAllWorktrees, useRepoMap } from '@/store/selectors'
 import { cn } from '@/lib/utils'
@@ -234,6 +234,30 @@ export default function WorkspaceKanbanDrawer({
 
   useWorkspaceStatusDocumentDrop(boardRef, moveWorktreeToStatus, pinWorktree, handleDragFinish)
 
+  useEffect(() => {
+    if (!open) {
+      return
+    }
+
+    const handlePointerDown = (event: PointerEvent): void => {
+      const content = boardRef.current?.closest<HTMLElement>('[data-slot="sheet-content"]')
+      if (!content) {
+        return
+      }
+      const target = event.target
+      if (target instanceof Node && content.contains(target)) {
+        return
+      }
+      const rect = content.getBoundingClientRect()
+      if (event.clientX > rect.right && event.clientY >= rect.top && event.clientY <= rect.bottom) {
+        onOpenChange(false)
+      }
+    }
+
+    document.addEventListener('pointerdown', handlePointerDown, true)
+    return () => document.removeEventListener('pointerdown', handlePointerDown, true)
+  }, [onOpenChange, open])
+
   const opacityPercent = Math.round(workspaceBoardOpacity * 100)
   const drawerLeft = sidebarOpen ? sidebarWidth : 0
   const BoardModeIcon = workspaceBoardCompact ? Rows3 : LayoutList
@@ -244,7 +268,7 @@ export default function WorkspaceKanbanDrawer({
         side="left"
         showCloseButton={false}
         className="workspace-kanban-sheet-content bg-sidebar p-0 sm:max-w-none"
-        overlayStyle={{ top: 36, left: drawerLeft }}
+        overlayStyle={{ top: 36, left: drawerLeft, pointerEvents: 'none' }}
         style={
           {
             // Why: the board is a companion to the workspace sidebar, so it
@@ -257,10 +281,18 @@ export default function WorkspaceKanbanDrawer({
           } as React.CSSProperties
         }
         data-workspace-board-compact={workspaceBoardCompact ? 'true' : 'false'}
-        onInteractOutside={(event) => {
-          // Why: users need to scroll, click, and drag from the workspace
-          // sidebar while the companion board stays open.
+        onOpenAutoFocus={(event) => {
+          // Why: Radix focuses the first toolbar button on open, which opens
+          // its tooltip without hover and makes the drawer feel noisy.
           event.preventDefault()
+        }}
+        onInteractOutside={(event) => {
+          const originalEvent = event.detail.originalEvent
+          if (originalEvent instanceof PointerEvent && originalEvent.clientX < drawerLeft) {
+            // Why: users need to scroll, click, and drag from the workspace
+            // sidebar while the companion board stays open.
+            event.preventDefault()
+          }
         }}
       >
         <SheetHeader className="border-b border-sidebar-border px-4 py-3 pr-24">

--- a/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.tsx
@@ -232,7 +232,13 @@ export default function WorkspaceKanbanDrawer({
     [allWorktrees, setWorkspaceStatuses, updateWorktreeMeta, workspaceStatuses]
   )
 
-  useWorkspaceStatusDocumentDrop(boardRef, moveWorktreeToStatus, pinWorktree, handleDragFinish)
+  useWorkspaceStatusDocumentDrop(
+    boardRef,
+    moveWorktreeToStatus,
+    pinWorktree,
+    handleDragFinish,
+    open
+  )
 
   useEffect(() => {
     if (!open) {

--- a/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.tsx
@@ -46,6 +46,8 @@ export default function WorkspaceKanbanDrawer({
   const setWorkspaceStatuses = useAppStore((s) => s.setWorkspaceStatuses)
   const workspaceBoardOpacity = useAppStore((s) => s.workspaceBoardOpacity)
   const setWorkspaceBoardOpacity = useAppStore((s) => s.setWorkspaceBoardOpacity)
+  const sidebarOpen = useAppStore((s) => s.sidebarOpen)
+  const sidebarWidth = useAppStore((s) => s.sidebarWidth)
   const boardRef = useRef<HTMLDivElement>(null)
   const [dragOverStatus, setDragOverStatus] = useState<WorkspaceStatus | null>(null)
   const [pinDragOver, setPinDragOver] = useState(false)
@@ -213,18 +215,23 @@ export default function WorkspaceKanbanDrawer({
   useWorkspaceStatusDocumentDrop(boardRef, moveWorktreeToStatus, pinWorktree, handleDragFinish)
 
   const opacityPercent = Math.round(workspaceBoardOpacity * 100)
+  const drawerLeft = sidebarOpen ? sidebarWidth : 0
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent
         side="left"
         showCloseButton={false}
-        className="w-[min(96vw,1180px)] bg-sidebar p-0 sm:max-w-none"
-        overlayStyle={{ top: 36 }}
+        className="bg-sidebar p-0 sm:max-w-none"
+        overlayStyle={{ top: 36, left: drawerLeft }}
         style={
           {
+            // Why: the board is a companion to the workspace sidebar, so it
+            // expands from the sidebar edge instead of covering the sidebar.
+            left: drawerLeft,
             top: 36,
             height: 'calc(100% - 36px)',
+            width: `min(calc(100vw - ${drawerLeft}px), 1180px)`,
             opacity: workspaceBoardOpacity
           } as React.CSSProperties
         }

--- a/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.tsx
@@ -222,7 +222,7 @@ export default function WorkspaceKanbanDrawer({
       <SheetContent
         side="left"
         showCloseButton={false}
-        className="bg-sidebar p-0 sm:max-w-none"
+        className="workspace-kanban-sheet-content bg-sidebar p-0 sm:max-w-none"
         overlayStyle={{ top: 36, left: drawerLeft }}
         style={
           {

--- a/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.tsx
@@ -11,9 +11,9 @@ import {
   SheetTitle
 } from '@/components/ui/sheet'
 import { Button } from '@/components/ui/button'
-import { Badge } from '@/components/ui/badge'
-import { Pin, X } from 'lucide-react'
-import WorktreeCard from './WorktreeCard'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { LayoutList, Pin, Rows3, X } from 'lucide-react'
+import WorkspaceKanbanCard from './WorkspaceKanbanCard'
 import WorkspaceKanbanSettingsMenu from './WorkspaceKanbanSettingsMenu'
 import {
   getWorkspaceStatus,
@@ -46,6 +46,8 @@ export default function WorkspaceKanbanDrawer({
   const setWorkspaceStatuses = useAppStore((s) => s.setWorkspaceStatuses)
   const workspaceBoardOpacity = useAppStore((s) => s.workspaceBoardOpacity)
   const setWorkspaceBoardOpacity = useAppStore((s) => s.setWorkspaceBoardOpacity)
+  const workspaceBoardCompact = useAppStore((s) => s.workspaceBoardCompact)
+  const setWorkspaceBoardCompact = useAppStore((s) => s.setWorkspaceBoardCompact)
   const sidebarOpen = useAppStore((s) => s.sidebarOpen)
   const sidebarWidth = useAppStore((s) => s.sidebarWidth)
   const boardRef = useRef<HTMLDivElement>(null)
@@ -234,9 +236,10 @@ export default function WorkspaceKanbanDrawer({
 
   const opacityPercent = Math.round(workspaceBoardOpacity * 100)
   const drawerLeft = sidebarOpen ? sidebarWidth : 0
+  const BoardModeIcon = workspaceBoardCompact ? Rows3 : LayoutList
 
   return (
-    <Sheet open={open} onOpenChange={onOpenChange}>
+    <Sheet open={open} onOpenChange={onOpenChange} modal={false}>
       <SheetContent
         side="left"
         showCloseButton={false}
@@ -253,6 +256,12 @@ export default function WorkspaceKanbanDrawer({
             opacity: workspaceBoardOpacity
           } as React.CSSProperties
         }
+        data-workspace-board-compact={workspaceBoardCompact ? 'true' : 'false'}
+        onInteractOutside={(event) => {
+          // Why: users need to scroll, click, and drag from the workspace
+          // sidebar while the companion board stays open.
+          event.preventDefault()
+        }}
       >
         <SheetHeader className="border-b border-sidebar-border px-4 py-3 pr-24">
           <SheetTitle className="text-sm">Workspace board</SheetTitle>
@@ -262,6 +271,25 @@ export default function WorkspaceKanbanDrawer({
         </SheetHeader>
 
         <div className="absolute right-3 top-2.5 flex items-center gap-1">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant={workspaceBoardCompact ? 'secondary' : 'ghost'}
+                size="icon-xs"
+                aria-pressed={workspaceBoardCompact}
+                aria-label={
+                  workspaceBoardCompact ? 'Compact workspace cards' : 'Detailed workspace cards'
+                }
+                onClick={() => setWorkspaceBoardCompact(!workspaceBoardCompact)}
+              >
+                <BoardModeIcon className="size-3.5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="top" sideOffset={4}>
+              {workspaceBoardCompact ? 'Show detailed cards' : 'Show compact cards'}
+            </TooltipContent>
+          </Tooltip>
           <WorkspaceKanbanSettingsMenu
             opacityPercent={opacityPercent}
             workspaceStatuses={workspaceStatuses}
@@ -336,23 +364,14 @@ export default function WorkspaceKanbanDrawer({
                       {items.length > 0 ? (
                         <div className="space-y-2">
                           {items.map((worktree) => (
-                            <div key={worktree.id} className="relative">
-                              {worktree.isPinned ? (
-                                <Badge
-                                  variant="outline"
-                                  className="pointer-events-none absolute right-2 top-1.5 z-10 h-4 gap-1 rounded-full bg-background/90 px-1.5 text-[9px] leading-none text-muted-foreground"
-                                >
-                                  <Pin className="size-2.5" />
-                                  Pinned
-                                </Badge>
-                              ) : null}
-                              <WorktreeCard
-                                worktree={worktree}
-                                repo={repoMap.get(worktree.repoId)}
-                                isActive={activeWorktreeId === worktree.id}
-                                onActivate={handleWorktreeActivate}
-                              />
-                            </div>
+                            <WorkspaceKanbanCard
+                              key={worktree.id}
+                              worktree={worktree}
+                              repo={repoMap.get(worktree.repoId)}
+                              isActive={activeWorktreeId === worktree.id}
+                              compact={workspaceBoardCompact}
+                              onActivate={handleWorktreeActivate}
+                            />
                           ))}
                         </div>
                       ) : (

--- a/src/renderer/src/components/sidebar/WorkspaceKanbanSettingsMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanSettingsMenu.tsx
@@ -8,14 +8,10 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 import type { WorkspaceStatusDefinition } from '../../../../shared/types'
-import {
-  WORKSPACE_STATUS_COLOR_OPTIONS,
-  WORKSPACE_STATUS_ICON_OPTIONS,
-  getWorkspaceStatusVisualMeta
-} from './workspace-status'
+import { getWorkspaceStatusVisualMeta } from './workspace-status'
+import WorkspaceStatusAppearancePopover from './WorkspaceStatusAppearancePopover'
 
 type WorkspaceKanbanSettingsMenuProps = {
   opacityPercent: number
@@ -41,7 +37,7 @@ export default function WorkspaceKanbanSettingsMenu({
   onAddStatus
 }: WorkspaceKanbanSettingsMenuProps): React.JSX.Element {
   return (
-    <DropdownMenu>
+    <DropdownMenu modal={false}>
       <DropdownMenuTrigger asChild>
         <Button variant="ghost" size="icon-xs" aria-label="Workspace board settings">
           <Settings2 className="size-3.5" />
@@ -51,6 +47,15 @@ export default function WorkspaceKanbanSettingsMenu({
         align="end"
         sideOffset={8}
         className="max-h-[min(80vh,720px)] w-80 overflow-y-auto p-2 scrollbar-sleek"
+        onInteractOutside={(event) => {
+          const target = event.target
+          if (
+            target instanceof Element &&
+            target.closest('[data-workspace-status-appearance-popover]')
+          ) {
+            event.preventDefault()
+          }
+        }}
       >
         <DropdownMenuLabel>Board opacity</DropdownMenuLabel>
         <div className="px-2 pb-2">
@@ -76,7 +81,7 @@ export default function WorkspaceKanbanSettingsMenu({
             return (
               <div
                 key={status.id}
-                className="space-y-1.5 rounded-md border border-border/70 bg-background/40 p-1.5"
+                className="rounded-md border border-border/70 bg-background/40 p-1.5"
               >
                 <div className="flex items-center gap-1">
                   <meta.icon className={cn('size-3.5 shrink-0', meta.tone)} />
@@ -91,6 +96,11 @@ export default function WorkspaceKanbanSettingsMenu({
                     }}
                     className="h-7 min-w-0 flex-1 rounded-md border border-input bg-background px-2 text-[12px] text-foreground outline-none focus-visible:ring-1 focus-visible:ring-ring"
                     aria-label={`Rename ${status.label}`}
+                  />
+                  <WorkspaceStatusAppearancePopover
+                    status={status}
+                    onChangeColor={onChangeStatusColor}
+                    onChangeIcon={onChangeStatusIcon}
                   />
                   <Button
                     type="button"
@@ -125,49 +135,6 @@ export default function WorkspaceKanbanSettingsMenu({
                   >
                     <Trash2 className="size-3.5" />
                   </Button>
-                </div>
-                <div className="flex items-center gap-1">
-                  {WORKSPACE_STATUS_COLOR_OPTIONS.map((color) => (
-                    <Tooltip key={color.id}>
-                      <TooltipTrigger asChild>
-                        <button
-                          type="button"
-                          className={cn(
-                            'flex size-5 items-center justify-center rounded-full border border-transparent',
-                            status.color === color.id && 'border-ring bg-accent'
-                          )}
-                          onClick={() => onChangeStatusColor(status.id, color.id)}
-                          aria-label={`Set ${status.label} color to ${color.label}`}
-                        >
-                          <span className={cn('size-3 rounded-full', color.swatch)} />
-                        </button>
-                      </TooltipTrigger>
-                      <TooltipContent side="top" sideOffset={4}>
-                        {color.label}
-                      </TooltipContent>
-                    </Tooltip>
-                  ))}
-                </div>
-                <div className="grid grid-cols-6 gap-1">
-                  {WORKSPACE_STATUS_ICON_OPTIONS.map((icon) => (
-                    <Tooltip key={icon.id}>
-                      <TooltipTrigger asChild>
-                        <Button
-                          type="button"
-                          variant={status.icon === icon.id ? 'secondary' : 'ghost'}
-                          size="icon-xs"
-                          className="size-7"
-                          onClick={() => onChangeStatusIcon(status.id, icon.id)}
-                          aria-label={`Set ${status.label} icon to ${icon.label}`}
-                        >
-                          <icon.icon className="size-3.5" />
-                        </Button>
-                      </TooltipTrigger>
-                      <TooltipContent side="top" sideOffset={4}>
-                        {icon.label}
-                      </TooltipContent>
-                    </Tooltip>
-                  ))}
                 </div>
               </div>
             )

--- a/src/renderer/src/components/sidebar/WorkspaceKanbanSettingsMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanSettingsMenu.tsx
@@ -47,7 +47,7 @@ export default function WorkspaceKanbanSettingsMenu({
           </div>
           <input
             type="range"
-            min={65}
+            min={20}
             max={100}
             value={opacityPercent}
             onChange={onOpacityChange}

--- a/src/renderer/src/components/sidebar/WorkspaceKanbanSettingsMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanSettingsMenu.tsx
@@ -1,0 +1,133 @@
+import React from 'react'
+import { ArrowDown, ArrowUp, Pin, Plus, Settings2, Trash2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
+import { cn } from '@/lib/utils'
+import type { WorkspaceStatusDefinition } from '../../../../shared/types'
+import { getWorkspaceStatusVisualMeta } from './workspace-status'
+
+type WorkspaceKanbanSettingsMenuProps = {
+  opacityPercent: number
+  workspaceStatuses: readonly WorkspaceStatusDefinition[]
+  onOpacityChange: (event: React.ChangeEvent<HTMLInputElement>) => void
+  onRenameStatus: (statusId: string, label: string) => void
+  onMoveStatus: (statusId: string, direction: -1 | 1) => void
+  onRemoveStatus: (statusId: string) => void
+  onAddStatus: () => void
+}
+
+export default function WorkspaceKanbanSettingsMenu({
+  opacityPercent,
+  workspaceStatuses,
+  onOpacityChange,
+  onRenameStatus,
+  onMoveStatus,
+  onRemoveStatus,
+  onAddStatus
+}: WorkspaceKanbanSettingsMenuProps): React.JSX.Element {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="icon-xs" aria-label="Workspace board settings">
+          <Settings2 className="size-3.5" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" sideOffset={8} className="w-72 p-2">
+        <DropdownMenuLabel>Board opacity</DropdownMenuLabel>
+        <div className="px-2 pb-2">
+          <div className="mb-1 flex items-center justify-between text-[11px] text-muted-foreground">
+            <span>Pane opacity</span>
+            <span>{opacityPercent}%</span>
+          </div>
+          <input
+            type="range"
+            min={65}
+            max={100}
+            value={opacityPercent}
+            onChange={onOpacityChange}
+            className="h-5 w-full accent-foreground"
+            aria-label="Workspace board opacity"
+          />
+        </div>
+        <DropdownMenuSeparator />
+        <DropdownMenuLabel>Statuses</DropdownMenuLabel>
+        <div className="space-y-1 px-1 pb-1">
+          <div className="flex h-7 items-center gap-2 rounded-md px-2 text-[12px] text-muted-foreground">
+            <Pin className="size-3.5" />
+            <span className="min-w-0 flex-1 truncate">Pinned</span>
+            <span className="text-[10px]">Always first</span>
+          </div>
+          {workspaceStatuses.map((status, index) => {
+            const meta = getWorkspaceStatusVisualMeta(status.id)
+            return (
+              <div key={status.id} className="flex items-center gap-1">
+                <meta.icon className={cn('size-3.5 shrink-0', meta.tone)} />
+                <input
+                  defaultValue={status.label}
+                  onBlur={(event) => onRenameStatus(status.id, event.target.value)}
+                  onKeyDown={(event) => {
+                    event.stopPropagation()
+                    if (event.key === 'Enter') {
+                      event.currentTarget.blur()
+                    }
+                  }}
+                  className="h-7 min-w-0 flex-1 rounded-md border border-input bg-background px-2 text-[12px] text-foreground outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                  aria-label={`Rename ${status.label}`}
+                />
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-xs"
+                  className="size-7"
+                  disabled={index === 0}
+                  onClick={() => onMoveStatus(status.id, -1)}
+                  aria-label={`Move ${status.label} left`}
+                >
+                  <ArrowUp className="size-3.5" />
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-xs"
+                  className="size-7"
+                  disabled={index === workspaceStatuses.length - 1}
+                  onClick={() => onMoveStatus(status.id, 1)}
+                  aria-label={`Move ${status.label} right`}
+                >
+                  <ArrowDown className="size-3.5" />
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-xs"
+                  className="size-7 text-muted-foreground hover:text-destructive"
+                  disabled={workspaceStatuses.length <= 1}
+                  onClick={() => onRemoveStatus(status.id)}
+                  aria-label={`Remove ${status.label}`}
+                >
+                  <Trash2 className="size-3.5" />
+                </Button>
+              </div>
+            )
+          })}
+          <Button
+            type="button"
+            variant="ghost"
+            size="xs"
+            className="mt-1 h-7 w-full justify-start text-[12px]"
+            onClick={onAddStatus}
+          >
+            <Plus className="size-3.5" />
+            Add status
+          </Button>
+        </div>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/src/renderer/src/components/sidebar/WorkspaceKanbanSettingsMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanSettingsMenu.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { ArrowDown, ArrowUp, Pin, Plus, Settings2, Trash2 } from 'lucide-react'
+import { ArrowDown, ArrowUp, Plus, Settings2, Trash2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
@@ -8,15 +8,22 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 import type { WorkspaceStatusDefinition } from '../../../../shared/types'
-import { getWorkspaceStatusVisualMeta } from './workspace-status'
+import {
+  WORKSPACE_STATUS_COLOR_OPTIONS,
+  WORKSPACE_STATUS_ICON_OPTIONS,
+  getWorkspaceStatusVisualMeta
+} from './workspace-status'
 
 type WorkspaceKanbanSettingsMenuProps = {
   opacityPercent: number
   workspaceStatuses: readonly WorkspaceStatusDefinition[]
   onOpacityChange: (event: React.ChangeEvent<HTMLInputElement>) => void
   onRenameStatus: (statusId: string, label: string) => void
+  onChangeStatusColor: (statusId: string, color: string) => void
+  onChangeStatusIcon: (statusId: string, icon: string) => void
   onMoveStatus: (statusId: string, direction: -1 | 1) => void
   onRemoveStatus: (statusId: string) => void
   onAddStatus: () => void
@@ -27,6 +34,8 @@ export default function WorkspaceKanbanSettingsMenu({
   workspaceStatuses,
   onOpacityChange,
   onRenameStatus,
+  onChangeStatusColor,
+  onChangeStatusIcon,
   onMoveStatus,
   onRemoveStatus,
   onAddStatus
@@ -38,7 +47,11 @@ export default function WorkspaceKanbanSettingsMenu({
           <Settings2 className="size-3.5" />
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" sideOffset={8} className="w-72 p-2">
+      <DropdownMenuContent
+        align="end"
+        sideOffset={8}
+        className="max-h-[min(80vh,720px)] w-80 overflow-y-auto p-2 scrollbar-sleek"
+      >
         <DropdownMenuLabel>Board opacity</DropdownMenuLabel>
         <div className="px-2 pb-2">
           <div className="mb-1 flex items-center justify-between text-[11px] text-muted-foreground">
@@ -57,62 +70,105 @@ export default function WorkspaceKanbanSettingsMenu({
         </div>
         <DropdownMenuSeparator />
         <DropdownMenuLabel>Statuses</DropdownMenuLabel>
-        <div className="space-y-1 px-1 pb-1">
-          <div className="flex h-7 items-center gap-2 rounded-md px-2 text-[12px] text-muted-foreground">
-            <Pin className="size-3.5" />
-            <span className="min-w-0 flex-1 truncate">Pinned</span>
-            <span className="text-[10px]">Always first</span>
-          </div>
+        <div className="space-y-2 px-1 pb-1">
           {workspaceStatuses.map((status, index) => {
-            const meta = getWorkspaceStatusVisualMeta(status.id)
+            const meta = getWorkspaceStatusVisualMeta(status)
             return (
-              <div key={status.id} className="flex items-center gap-1">
-                <meta.icon className={cn('size-3.5 shrink-0', meta.tone)} />
-                <input
-                  defaultValue={status.label}
-                  onBlur={(event) => onRenameStatus(status.id, event.target.value)}
-                  onKeyDown={(event) => {
-                    event.stopPropagation()
-                    if (event.key === 'Enter') {
-                      event.currentTarget.blur()
-                    }
-                  }}
-                  className="h-7 min-w-0 flex-1 rounded-md border border-input bg-background px-2 text-[12px] text-foreground outline-none focus-visible:ring-1 focus-visible:ring-ring"
-                  aria-label={`Rename ${status.label}`}
-                />
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon-xs"
-                  className="size-7"
-                  disabled={index === 0}
-                  onClick={() => onMoveStatus(status.id, -1)}
-                  aria-label={`Move ${status.label} left`}
-                >
-                  <ArrowUp className="size-3.5" />
-                </Button>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon-xs"
-                  className="size-7"
-                  disabled={index === workspaceStatuses.length - 1}
-                  onClick={() => onMoveStatus(status.id, 1)}
-                  aria-label={`Move ${status.label} right`}
-                >
-                  <ArrowDown className="size-3.5" />
-                </Button>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon-xs"
-                  className="size-7 text-muted-foreground hover:text-destructive"
-                  disabled={workspaceStatuses.length <= 1}
-                  onClick={() => onRemoveStatus(status.id)}
-                  aria-label={`Remove ${status.label}`}
-                >
-                  <Trash2 className="size-3.5" />
-                </Button>
+              <div
+                key={status.id}
+                className="space-y-1.5 rounded-md border border-border/70 bg-background/40 p-1.5"
+              >
+                <div className="flex items-center gap-1">
+                  <meta.icon className={cn('size-3.5 shrink-0', meta.tone)} />
+                  <input
+                    defaultValue={status.label}
+                    onBlur={(event) => onRenameStatus(status.id, event.target.value)}
+                    onKeyDown={(event) => {
+                      event.stopPropagation()
+                      if (event.key === 'Enter') {
+                        event.currentTarget.blur()
+                      }
+                    }}
+                    className="h-7 min-w-0 flex-1 rounded-md border border-input bg-background px-2 text-[12px] text-foreground outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                    aria-label={`Rename ${status.label}`}
+                  />
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-xs"
+                    className="size-7"
+                    disabled={index === 0}
+                    onClick={() => onMoveStatus(status.id, -1)}
+                    aria-label={`Move ${status.label} left`}
+                  >
+                    <ArrowUp className="size-3.5" />
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-xs"
+                    className="size-7"
+                    disabled={index === workspaceStatuses.length - 1}
+                    onClick={() => onMoveStatus(status.id, 1)}
+                    aria-label={`Move ${status.label} right`}
+                  >
+                    <ArrowDown className="size-3.5" />
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-xs"
+                    className="size-7 text-muted-foreground hover:text-destructive"
+                    disabled={workspaceStatuses.length <= 1}
+                    onClick={() => onRemoveStatus(status.id)}
+                    aria-label={`Remove ${status.label}`}
+                  >
+                    <Trash2 className="size-3.5" />
+                  </Button>
+                </div>
+                <div className="flex items-center gap-1">
+                  {WORKSPACE_STATUS_COLOR_OPTIONS.map((color) => (
+                    <Tooltip key={color.id}>
+                      <TooltipTrigger asChild>
+                        <button
+                          type="button"
+                          className={cn(
+                            'flex size-5 items-center justify-center rounded-full border border-transparent',
+                            status.color === color.id && 'border-ring bg-accent'
+                          )}
+                          onClick={() => onChangeStatusColor(status.id, color.id)}
+                          aria-label={`Set ${status.label} color to ${color.label}`}
+                        >
+                          <span className={cn('size-3 rounded-full', color.swatch)} />
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent side="top" sideOffset={4}>
+                        {color.label}
+                      </TooltipContent>
+                    </Tooltip>
+                  ))}
+                </div>
+                <div className="grid grid-cols-6 gap-1">
+                  {WORKSPACE_STATUS_ICON_OPTIONS.map((icon) => (
+                    <Tooltip key={icon.id}>
+                      <TooltipTrigger asChild>
+                        <Button
+                          type="button"
+                          variant={status.icon === icon.id ? 'secondary' : 'ghost'}
+                          size="icon-xs"
+                          className="size-7"
+                          onClick={() => onChangeStatusIcon(status.id, icon.id)}
+                          aria-label={`Set ${status.label} icon to ${icon.label}`}
+                        >
+                          <icon.icon className="size-3.5" />
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent side="top" sideOffset={4}>
+                        {icon.label}
+                      </TooltipContent>
+                    </Tooltip>
+                  ))}
+                </div>
               </div>
             )
           })}

--- a/src/renderer/src/components/sidebar/WorkspaceStatusAppearancePopover.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceStatusAppearancePopover.tsx
@@ -1,0 +1,106 @@
+import React from 'react'
+import { Button } from '@/components/ui/button'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
+import type { WorkspaceStatusDefinition } from '../../../../shared/types'
+import {
+  WORKSPACE_STATUS_COLOR_OPTIONS,
+  WORKSPACE_STATUS_ICON_OPTIONS,
+  getWorkspaceStatusVisualMeta
+} from './workspace-status'
+
+type WorkspaceStatusAppearancePopoverProps = {
+  status: WorkspaceStatusDefinition
+  onChangeColor: (statusId: string, color: string) => void
+  onChangeIcon: (statusId: string, icon: string) => void
+}
+
+export default function WorkspaceStatusAppearancePopover({
+  status,
+  onChangeColor,
+  onChangeIcon
+}: WorkspaceStatusAppearancePopoverProps): React.JSX.Element {
+  const meta = getWorkspaceStatusVisualMeta(status)
+
+  return (
+    <Popover modal={false}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <PopoverTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              className="relative size-7"
+              aria-label={`Customize ${status.label} appearance`}
+            >
+              <span className={cn('absolute size-4 rounded-full opacity-20', meta.swatch)} />
+              <meta.icon className={cn('relative size-3.5', meta.tone)} />
+            </Button>
+          </PopoverTrigger>
+        </TooltipTrigger>
+        <TooltipContent side="top" sideOffset={4}>
+          Appearance
+        </TooltipContent>
+      </Tooltip>
+
+      <PopoverContent
+        align="end"
+        side="left"
+        sideOffset={8}
+        className="w-72 p-2"
+        data-workspace-status-appearance-popover=""
+        onOpenAutoFocus={(event) => event.preventDefault()}
+      >
+        <div className="px-1 py-1 text-[11px] font-semibold text-muted-foreground">Color</div>
+        <div className="grid grid-cols-4 gap-1">
+          {WORKSPACE_STATUS_COLOR_OPTIONS.map((color) => (
+            <Tooltip key={color.id}>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  className={cn(
+                    'flex h-8 items-center gap-1.5 rounded-md border border-transparent px-2 text-[11px] text-foreground outline-none transition-colors hover:bg-accent focus-visible:ring-1 focus-visible:ring-ring',
+                    status.color === color.id && 'border-ring bg-accent'
+                  )}
+                  onClick={() => onChangeColor(status.id, color.id)}
+                  aria-label={`Set ${status.label} color to ${color.label}`}
+                >
+                  <span className={cn('size-3 rounded-full', color.swatch)} />
+                  <span className="min-w-0 truncate">{color.label}</span>
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="top" sideOffset={4}>
+                {color.label}
+              </TooltipContent>
+            </Tooltip>
+          ))}
+        </div>
+
+        <div className="mt-2 px-1 py-1 text-[11px] font-semibold text-muted-foreground">Icon</div>
+        <div className="grid grid-cols-6 gap-1">
+          {WORKSPACE_STATUS_ICON_OPTIONS.map((icon) => (
+            <Tooltip key={icon.id}>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  variant={status.icon === icon.id ? 'secondary' : 'ghost'}
+                  size="icon-xs"
+                  className="size-8"
+                  onClick={() => onChangeIcon(status.id, icon.id)}
+                  aria-label={`Set ${status.label} icon to ${icon.label}`}
+                >
+                  <icon.icon className="size-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="top" sideOffset={4}>
+                {icon.label}
+              </TooltipContent>
+            </Tooltip>
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -45,6 +45,7 @@ import {
   selectLivePtyIdsForWorktree,
   selectRuntimePaneTitlesForWorktree
 } from './worktree-card-status-inputs'
+import { writeWorkspaceDragData } from './workspace-status'
 
 type WorktreeCardProps = {
   worktree: Worktree
@@ -53,6 +54,7 @@ type WorktreeCardProps = {
   isMultiSelected?: boolean
   selectedWorktrees?: readonly Worktree[]
   hideRepoBadge?: boolean
+  onActivate?: () => void
   onSelectionGesture?: (event: React.MouseEvent<HTMLDivElement>, worktreeId: string) => boolean
   onContextMenuSelect?: (event: React.MouseEvent<HTMLDivElement>) => readonly Worktree[]
 }
@@ -68,6 +70,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
   isActive,
   isMultiSelected = false,
   selectedWorktrees,
+  onActivate,
   onSelectionGesture,
   onContextMenuSelect,
   hideRepoBadge
@@ -399,8 +402,9 @@ const WorktreeCard = React.memo(function WorktreeCard({
       if (isSshDisconnected) {
         setShowDisconnectedDialog(true)
       }
+      onActivate?.()
     },
-    [worktree.id, isSshDisconnected, onSelectionGesture]
+    [worktree.id, isSshDisconnected, onActivate, onSelectionGesture]
   )
 
   const handleDoubleClick = useCallback(() => {
@@ -431,6 +435,17 @@ const WorktreeCard = React.memo(function WorktreeCard({
 
   const unreadTooltip = worktree.isUnread ? 'Mark read' : 'Mark unread'
 
+  const handleDragStart = useCallback(
+    (event: React.DragEvent<HTMLDivElement>) => {
+      if (isDeleting) {
+        event.preventDefault()
+        return
+      }
+      writeWorkspaceDragData(event.dataTransfer, worktree.id)
+    },
+    [isDeleting, worktree.id]
+  )
+
   // Why: the 'unread' card property is the user's opt-out. When off, we render
   // as if the workspace is read so bold emphasis never appears. The persisted
   // `worktree.isUnread` flag is unchanged; only the rendering changes.
@@ -452,6 +467,8 @@ const WorktreeCard = React.memo(function WorktreeCard({
       )}
       onClick={handleClick}
       onDoubleClick={handleDoubleClick}
+      draggable={!isDeleting}
+      onDragStart={handleDragStart}
       aria-busy={isDeleting}
     >
       {isDeleting && (

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable max-lines -- Why: the worktree card centralizes sidebar card state (selection, drag, agent status, git info, context menu) in one cohesive component so sidebar rendering doesn't fan out across files. */
-import React, { useEffect, useMemo, useCallback, useState } from 'react'
-import { useShallow } from 'zustand/react/shallow'
+import React, { useEffect, useCallback, useState } from 'react'
 import { useAppStore } from '@/store'
 import { getHostedReviewCacheKey } from '@/store/slices/hosted-review'
 import { Badge } from '@/components/ui/badge'
@@ -22,13 +21,7 @@ import { SshDisconnectedDialog } from './SshDisconnectedDialog'
 import WorktreeCardAgents from './WorktreeCardAgents'
 import { cn } from '@/lib/utils'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
-import {
-  getWorktreeStatusLabel,
-  resolveWorktreeStatus,
-  type WorktreeStatus
-} from '@/lib/worktree-status'
-import { isExplicitAgentStatusFresh } from '@/lib/agent-status'
-import { AGENT_STATUS_STALE_AFTER_MS } from '../../../../shared/agent-status-types'
+import { getWorktreeStatusLabel } from '@/lib/worktree-status'
 import { getRepoKindLabel, isFolderRepo } from '../../../../shared/repo-kind'
 import type { HostedReviewInfo } from '../../../../shared/hosted-review'
 import type { Worktree, Repo, IssueInfo } from '../../../../shared/types'
@@ -36,16 +29,11 @@ import {
   branchDisplayName,
   checksLabel,
   CONFLICT_OPERATION_LABELS,
-  EMPTY_TABS,
-  EMPTY_BROWSER_TABS,
   FilledBellIcon
 } from './WorktreeCardHelpers'
 import { IssueSection, ReviewSection, CommentSection } from './WorktreeCardMeta'
-import {
-  selectLivePtyIdsForWorktree,
-  selectRuntimePaneTitlesForWorktree
-} from './worktree-card-status-inputs'
 import { writeWorkspaceDragData } from './workspace-status'
+import { useWorktreeActivityStatus } from './use-worktree-activity-status'
 
 type WorktreeCardProps = {
   worktree: Worktree
@@ -155,29 +143,6 @@ const WorktreeCard = React.memo(function WorktreeCard({
     repo?.connectionId ? (s.sshTargetLabels.get(repo.connectionId) ?? '') : ''
   )
 
-  // ── GRANULAR selectors: only subscribe to THIS worktree's data ──
-  const tabs = useAppStore((s) => s.tabsByWorktree[worktree.id] ?? EMPTY_TABS)
-  const browserTabs = useAppStore((s) => s.browserTabsByWorktree[worktree.id] ?? EMPTY_BROWSER_TABS)
-  const hasNotesSurface = useAppStore((s) =>
-    (s.unifiedTabsByWorktree[worktree.id] ?? []).some((tab) => tab.contentType === 'notes')
-  )
-  // Why: keep these as separate shallow selectors. Combining them into one
-  // returned object nests freshly-created maps under fresh keys, so Zustand's
-  // shallow memoization sees every unrelated store write as a change and
-  // re-renders every mounted card.
-  // tab.ptyId is the wake-hint sessionId preserved across sleep, not a
-  // liveness signal; sleep-then-card-render would lie the dot green if we
-  // read tab.ptyId; ptyIdsByTabId is the source of truth.
-  // tab.title is the focused-pane title (onActivePaneChange overwrites it),
-  // so the per-pane title map is needed to keep the sidebar spinner
-  // reflecting *any* working pane, not just the focused one.
-  const runtimePaneTitlesForWorktree = useAppStore(
-    useShallow((s) => selectRuntimePaneTitlesForWorktree(s, worktree.id))
-  )
-  const ptyIdsForWorktree = useAppStore(
-    useShallow((s) => selectLivePtyIdsForWorktree(s, worktree.id))
-  )
-
   const branch = branchDisplayName(worktree.branch)
   const isFolder = repo ? isFolderRepo(repo) : false
   const hostedReviewCacheKey =
@@ -210,109 +175,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
       : null)
   const isDeleting = deleteState?.isDeleting ?? false
 
-  // Why: the sidebar dot overlays the *stable* hook-reported states (blocked,
-  // waiting, done) onto the title-heuristic base. `working` remains on the
-  // heuristic because hook pings flip on/off mid-turn and users complained
-  // that the spinner flickered; the blocked/waiting/done states don't have
-  // that problem — they're terminal (done) or attention-needed (blocked/
-  // waiting) and persist until the user acts. Retained "done" snapshots are
-  // consulted too so the done dot keeps glowing after the agent process exits,
-  // matching the dashboard's retention behavior.
-  //
-  // Priority (highest first): permission (blocked/waiting) > heuristic
-  // 'working' > done > other heuristic ('active'/'inactive').
-  // permission wins over everything because a newer blocked agent in the same
-  // worktree means the user needs to act now, not admire a previous
-  // completion.
-  // heuristic 'working' wins over done because a spinner means the user has
-  // already re-prompted the agent after it reported done — the newer "work
-  // in progress" signal is more informative than a retained completion dot.
-  // Only the 'working' heuristic earns this precedence; 'active'/'inactive'
-  // mean "quiet terminal", which shouldn't drown out a recent done.
-  // Why: collapse live hook entries to booleans inside the selector so the
-  // snapshot is a stable scalar (useShallow compares element identity — an
-  // array of freshly-constructed {state,updatedAt} objects would never hit
-  // the cache and trip React's "getSnapshot should be cached" infinite-loop
-  // guard). Staleness is applied here too so the selector already reflects
-  // the 30-min TTL; agentStatusEpoch pulls in the tick that fires when a
-  // fresh entry crosses the stale boundary. The same useShallow wrapper
-  // covers hasPermission, hasLiveDone, *and* hasRetainedDone — merging the
-  // retained scan into the same selector avoids a second full-map iteration
-  // per card on every retention write (with N sidebar cards on screen a
-  // standalone retained selector scans Object.values(...) N times per tick).
-  const { hasPermission, hasLiveDone, hasRetainedDone } = useAppStore(
-    useShallow((s) => {
-      // Touch the epoch so this selector re-runs when the freshness scheduler
-      // ticks — otherwise a stale transition wouldn't flip the booleans until
-      // some unrelated store write happened to rerun us.
-      void s.agentStatusEpoch
-      const wtTabs = s.tabsByWorktree[worktree.id] ?? EMPTY_TABS
-      let perm = false
-      let live = false
-      if (wtTabs.length > 0) {
-        const tabIds = new Set(wtTabs.map((t) => t.id))
-        const now = Date.now()
-        for (const [paneKey, entry] of Object.entries(s.agentStatusByPaneKey)) {
-          const sepIdx = paneKey.indexOf(':')
-          if (sepIdx <= 0) {
-            continue
-          }
-          const tabId = paneKey.slice(0, sepIdx)
-          if (!tabIds.has(tabId)) {
-            continue
-          }
-          if (!isExplicitAgentStatusFresh(entry, now, AGENT_STATUS_STALE_AFTER_MS)) {
-            continue
-          }
-          if (entry.state === 'blocked' || entry.state === 'waiting') {
-            perm = true
-          } else if (entry.state === 'done') {
-            live = true
-          }
-        }
-      }
-      // Retained scan — one pass in the same selector avoids a second
-      // Object.values(...) per store tick (one per sidebar card).
-      let retained = false
-      for (const ra of Object.values(s.retainedAgentsByPaneKey)) {
-        if (ra.worktreeId === worktree.id) {
-          retained = true
-          break
-        }
-      }
-      return { hasPermission: perm, hasLiveDone: live, hasRetainedDone: retained }
-    })
-  )
-
-  // Why: resolveWorktreeStatus enforces the runtime-liveness precondition —
-  // when no tab in this worktree has a live PTY (and no browser tab exists)
-  // it short-circuits to 'inactive' before consulting hook-reported state or
-  // retained-done snapshots. That keeps the dot honest across sleep, crash,
-  // and slept-with-retained-done while preserving the row data used by the
-  // inline agents list (retained 'done' rows still render inside the card).
-  const status: WorktreeStatus = useMemo(
-    () =>
-      resolveWorktreeStatus({
-        tabs,
-        browserTabs,
-        ptyIdsByTabId: ptyIdsForWorktree,
-        runtimePaneTitlesByTabId: runtimePaneTitlesForWorktree,
-        hasNotesSurface,
-        hasPermission,
-        hasLiveDone,
-        hasRetainedDone
-      }),
-    [
-      tabs,
-      browserTabs,
-      ptyIdsForWorktree,
-      runtimePaneTitlesForWorktree,
-      hasNotesSurface,
-      hasPermission,
-      hasLiveDone,
-      hasRetainedDone
-    ]
-  )
+  const status = useWorktreeActivityStatus(worktree.id)
 
   const showPR = cardProps.includes('pr')
   const showCI = cardProps.includes('ci')

--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
@@ -3,7 +3,12 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
@@ -18,6 +23,7 @@ import {
   Pencil,
   Pin,
   PinOff,
+  Kanban,
   Trash2
 } from 'lucide-react'
 import { useAppStore } from '@/store'
@@ -28,6 +34,7 @@ import { isFolderRepo } from '../../../../shared/repo-kind'
 import { runWorktreeBatchDelete, runWorktreeDelete } from './delete-worktree-flow'
 import { runSleepWorktrees } from './sleep-worktree-flow'
 import { isLocalPathOpenBlocked, showLocalPathOpenBlockedToast } from '@/lib/local-path-open-guard'
+import { getWorkspaceStatus, getWorkspaceStatusVisualMeta } from './workspace-status'
 
 type Props = {
   worktree: Worktree
@@ -48,6 +55,7 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
   onContextMenuSelect
 }: Props) {
   const updateWorktreeMeta = useAppStore((s) => s.updateWorktreeMeta)
+  const workspaceStatuses = useAppStore((s) => s.workspaceStatuses)
   const openModal = useAppStore((s) => s.openModal)
   const repo = useRepoById(worktree.repoId)
   const deleteState = useAppStore((s) => s.deleteStateByWorktreeId[worktree.id])
@@ -77,6 +85,16 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
     () => activeContextWorktrees.some((item) => deleteStateByWorktreeId[item.id]?.isDeleting),
     [activeContextWorktrees, deleteStateByWorktreeId]
   )
+  const contextWorkspaceStatus = useMemo(() => {
+    const [first, ...rest] = activeContextWorktrees
+    if (!first) {
+      return ''
+    }
+    const status = getWorkspaceStatus(first, workspaceStatuses)
+    return rest.every((item) => getWorkspaceStatus(item, workspaceStatuses) === status)
+      ? status
+      : ''
+  }, [activeContextWorktrees, workspaceStatuses])
   const batchDeleteWorktrees = useMemo(
     () =>
       activeContextWorktrees.filter((item) => {
@@ -123,6 +141,20 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
   const handleTogglePin = useCallback(() => {
     updateWorktreeMeta(worktree.id, { isPinned: !worktree.isPinned })
   }, [worktree.id, worktree.isPinned, updateWorktreeMeta])
+
+  const handleAssignWorkspaceStatus = useCallback(
+    (status: string) => {
+      setMenuOpen(false)
+      void Promise.all(
+        activeContextWorktrees.map((item) =>
+          getWorkspaceStatus(item, workspaceStatuses) === status
+            ? Promise.resolve()
+            : updateWorktreeMeta(item.id, { workspaceStatus: status })
+        )
+      )
+    },
+    [activeContextWorktrees, updateWorktreeMeta, workspaceStatuses]
+  )
 
   const handleRename = useCallback(() => {
     openModal('edit-meta', {
@@ -286,6 +318,30 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
               <DropdownMenuSeparator />
             </>
           )}
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger disabled={deletingContext}>
+              <Kanban className="size-3.5" />
+              {isMultiContext ? 'Move Selected to Status' : 'Move to Status'}
+            </DropdownMenuSubTrigger>
+            <DropdownMenuSubContent className="w-44">
+              <DropdownMenuRadioGroup value={contextWorkspaceStatus}>
+                {workspaceStatuses.map((status) => {
+                  const meta = getWorkspaceStatusVisualMeta(status.id)
+                  return (
+                    <DropdownMenuRadioItem
+                      key={status.id}
+                      value={status.id}
+                      onSelect={() => handleAssignWorkspaceStatus(status.id)}
+                    >
+                      <meta.icon className="size-3.5" />
+                      {status.label}
+                    </DropdownMenuRadioItem>
+                  )
+                })}
+              </DropdownMenuRadioGroup>
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
+          <DropdownMenuSeparator />
           <Tooltip>
             <TooltipTrigger asChild>
               <DropdownMenuItem

--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
@@ -326,14 +326,14 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
             <DropdownMenuSubContent className="w-44">
               <DropdownMenuRadioGroup value={contextWorkspaceStatus}>
                 {workspaceStatuses.map((status) => {
-                  const meta = getWorkspaceStatusVisualMeta(status.id)
+                  const meta = getWorkspaceStatusVisualMeta(status)
                   return (
                     <DropdownMenuRadioItem
                       key={status.id}
                       value={status.id}
                       onSelect={() => handleAssignWorkspaceStatus(status.id)}
                     >
-                      <meta.icon className="size-3.5" />
+                      <meta.icon className={cn('size-3.5', meta.tone)} />
                       {status.label}
                     </DropdownMenuRadioItem>
                   )

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -423,6 +423,13 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
       ? getWorktreeOptionId(activeWorktreeId)
       : undefined
 
+  const hasWorkspaceDropTargets = useMemo(
+    () =>
+      groupBy === 'none' ||
+      rows.some((row) => row.type === 'header' && row.key === PINNED_GROUP_KEY),
+    [groupBy, rows]
+  )
+
   const handleWorkspaceStatusDragOver = useCallback(
     (event: React.DragEvent, status: WorkspaceStatus) => {
       if (!hasWorkspaceDragData(event.dataTransfer)) {
@@ -482,7 +489,8 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
     scrollRef,
     onMoveWorktreeToStatus,
     onPinWorktree,
-    handleWorkspaceStatusDragFinish
+    handleWorkspaceStatusDragFinish,
+    hasWorkspaceDropTargets
   )
 
   return (

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -664,12 +664,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
               ref={virtualizer.measureElement}
               data-workspace-status-drop-target={itemWorkspaceStatus ? '' : undefined}
               data-workspace-status={itemWorkspaceStatus ?? undefined}
-              className={cn(
-                'absolute left-0 right-0',
-                itemWorkspaceStatus &&
-                  dragOverStatus === itemWorkspaceStatus &&
-                  'rounded-lg bg-sidebar-accent/40'
-              )}
+              className="absolute left-0 right-0"
               style={{ transform: `translateY(${vItem.start}px)` }}
               onDragOver={
                 itemWorkspaceStatus

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -13,7 +13,12 @@ import WorktreeCard from './WorktreeCard'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
-import type { Worktree, Repo } from '../../../../shared/types'
+import type {
+  Worktree,
+  Repo,
+  WorkspaceStatus,
+  WorkspaceStatusDefinition
+} from '../../../../shared/types'
 import { isGitRepoKind } from '../../../../shared/repo-kind'
 import { buildWorktreeComparator } from './smart-sort'
 import {
@@ -26,11 +31,18 @@ import { tabHasLivePty } from '@/lib/tab-has-live-pty'
 import {
   type GroupHeaderRow,
   type Row,
-  ALL_GROUP_KEY,
+  type WorktreeGroupBy,
   PINNED_GROUP_KEY,
   buildRows,
   getGroupKeyForWorktree
 } from './worktree-list-groups'
+import {
+  getWorkspaceStatus,
+  getWorkspaceStatusFromGroupKey,
+  hasWorkspaceDragData,
+  readWorkspaceDragData
+} from './workspace-status'
+import { useWorkspaceStatusDocumentDrop } from './use-workspace-status-drop'
 import {
   computeClearFilterActions,
   computeVisibleWorktreeIds,
@@ -80,7 +92,7 @@ function getWorktreeOptionId(worktreeId: string): string {
 type VirtualizedWorktreeViewportProps = {
   rows: Row[]
   activeWorktreeId: string | null
-  groupBy: 'none' | 'repo' | 'pr-status'
+  groupBy: WorktreeGroupBy
   toggleGroup: (key: string) => void
   collapsedGroups: Set<string>
   handleCreateForRepo: (repoId: string) => void
@@ -104,6 +116,9 @@ type VirtualizedWorktreeViewportProps = {
   allRepoIds: string[]
   reorderRepos: (orderedIds: string[]) => void
   prCache: Record<string, unknown> | null
+  workspaceStatuses: readonly WorkspaceStatusDefinition[]
+  onMoveWorktreeToStatus: (worktreeId: string, status: WorkspaceStatus) => void
+  onPinWorktree: (worktreeId: string) => void
   // Why: the viewport remounts when the row structure changes (see
   // viewportResetKey) so the virtualizer's measurementsCache cannot hold
   // heights tied to shifted indices. A fresh virtualizer would otherwise
@@ -133,9 +148,14 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
   allRepoIds,
   reorderRepos,
   prCache,
+  workspaceStatuses,
+  onMoveWorktreeToStatus,
+  onPinWorktree,
   scrollOffsetRef
 }: VirtualizedWorktreeViewportProps) {
   const scrollRef = useRef<HTMLDivElement>(null)
+  const [dragOverStatus, setDragOverStatus] = useState<WorkspaceStatus | null>(null)
+  const [pinDragOver, setPinDragOver] = useState(false)
 
   // Drag is only meaningful when the user is grouping by repo. When inert
   // (groupBy !== 'repo'), the controller is still constructed for hook order
@@ -231,18 +251,16 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
         if (collapsedGroups.has(PINNED_GROUP_KEY)) {
           toggleGroup(PINNED_GROUP_KEY)
         }
-      } else if (targetWorktree && groupBy !== 'none') {
-        const groupKey = getGroupKeyForWorktree(groupBy, targetWorktree, repoMap, prCache)
+      } else if (targetWorktree) {
+        const groupKey = getGroupKeyForWorktree(
+          groupBy,
+          targetWorktree,
+          repoMap,
+          prCache,
+          workspaceStatuses
+        )
         if (groupKey && collapsedGroups.has(groupKey)) {
           toggleGroup(groupKey)
-        }
-      } else if (targetWorktree && groupBy === 'none') {
-        // Why: when any worktree is pinned, buildRows emits a sibling "All"
-        // header for the unpinned block (see worktree-list-groups.ts). If that
-        // header is collapsed, revealing an unpinned target would otherwise
-        // leave it hidden — uncollapse it so the card is actually visible.
-        if (collapsedGroups.has(ALL_GROUP_KEY)) {
-          toggleGroup(ALL_GROUP_KEY)
         }
       }
     }
@@ -272,7 +290,8 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
     virtualizer,
     clearPendingRevealWorktreeId,
     toggleGroup,
-    collapsedGroups
+    collapsedGroups,
+    workspaceStatuses
   ])
 
   const prCacheLen = useAppStore((s) => Object.keys(s.prCache).length)
@@ -301,7 +320,8 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
         repoMap,
         prCache,
         new Set<string>(),
-        repoOrder
+        repoOrder,
+        workspaceStatuses
       ).filter((r): r is Extract<Row, { type: 'item' }> => r.type === 'item')
       if (worktreeRows.length === 0) {
         return
@@ -334,7 +354,17 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
         virtualizer.scrollToIndex(rowIndex, { align: 'auto' })
       }
     },
-    [rows, activeWorktreeId, virtualizer, groupBy, worktrees, repoMap, prCache, repoOrder]
+    [
+      rows,
+      activeWorktreeId,
+      virtualizer,
+      groupBy,
+      worktrees,
+      repoMap,
+      prCache,
+      repoOrder,
+      workspaceStatuses
+    ]
   )
 
   useEffect(() => {
@@ -393,6 +423,68 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
       ? getWorktreeOptionId(activeWorktreeId)
       : undefined
 
+  const handleWorkspaceStatusDragOver = useCallback(
+    (event: React.DragEvent, status: WorkspaceStatus) => {
+      if (!hasWorkspaceDragData(event.dataTransfer)) {
+        return
+      }
+      event.preventDefault()
+      event.dataTransfer.dropEffect = 'move'
+      setDragOverStatus(status)
+    },
+    []
+  )
+
+  const handleWorkspaceStatusDragLeave = useCallback((event: React.DragEvent) => {
+    const relatedTarget = event.relatedTarget
+    if (relatedTarget instanceof Node && event.currentTarget.contains(relatedTarget)) {
+      return
+    }
+    setDragOverStatus(null)
+  }, [])
+
+  const handleWorkspacePinDragOver = useCallback((event: React.DragEvent) => {
+    if (!hasWorkspaceDragData(event.dataTransfer)) {
+      return
+    }
+    event.preventDefault()
+    event.dataTransfer.dropEffect = 'move'
+    setPinDragOver(true)
+  }, [])
+
+  const handleWorkspacePinDragLeave = useCallback((event: React.DragEvent) => {
+    const relatedTarget = event.relatedTarget
+    if (relatedTarget instanceof Node && event.currentTarget.contains(relatedTarget)) {
+      return
+    }
+    setPinDragOver(false)
+  }, [])
+
+  const handleWorkspaceStatusDragFinish = useCallback(() => {
+    setDragOverStatus(null)
+    setPinDragOver(false)
+  }, [])
+
+  const handleWorkspaceStatusDrop = useCallback(
+    (event: React.DragEvent, status: WorkspaceStatus) => {
+      const worktreeId = readWorkspaceDragData(event.dataTransfer)
+      if (!worktreeId) {
+        return
+      }
+      event.preventDefault()
+      setDragOverStatus(null)
+      onMoveWorktreeToStatus(worktreeId, status)
+    },
+    [onMoveWorktreeToStatus]
+  )
+
+  useWorkspaceStatusDocumentDrop(
+    scrollRef,
+    onMoveWorktreeToStatus,
+    onPinWorktree,
+    handleWorkspaceStatusDragFinish
+  )
+
   return (
     <div
       ref={scrollRef}
@@ -427,6 +519,9 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
             const isDraggingThis =
               repoDrag.state.draggingRepoId !== null &&
               repoDrag.state.draggingRepoId === repoIdForHeader
+            const headerWorkspaceStatus =
+              groupBy === 'none' ? getWorkspaceStatusFromGroupKey(row.key, workspaceStatuses) : null
+            const isPinnedHeader = row.key === PINNED_GROUP_KEY
             return (
               <div
                 key={vItem.key}
@@ -440,16 +535,44 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                   role="button"
                   tabIndex={0}
                   data-repo-header-id={repoIdForHeader}
+                  data-workspace-status-drop-target={headerWorkspaceStatus ? '' : undefined}
+                  data-workspace-status={headerWorkspaceStatus ?? undefined}
+                  data-workspace-pin-drop-target={isPinnedHeader ? '' : undefined}
                   className={cn(
                     'group flex h-7 w-full items-center gap-1.5 pl-3 pr-1 text-left transition-all',
                     'cursor-pointer',
                     isDraggingThis &&
                       'bg-accent/80 ring-1 ring-ring/40 shadow-md rounded-md scale-[1.01]',
+                    headerWorkspaceStatus &&
+                      dragOverStatus === headerWorkspaceStatus &&
+                      'rounded-md bg-sidebar-accent ring-1 ring-sidebar-ring/40',
+                    isPinnedHeader &&
+                      pinDragOver &&
+                      'rounded-md bg-sidebar-accent ring-1 ring-sidebar-ring/40',
                     // First header sits directly under SidebarHeader, which already
                     // supplies its own spacing — only offset secondary group headers.
                     vItem.index !== firstHeaderIndex && 'mt-2',
                     row.repo ? 'overflow-hidden' : row.tone
                   )}
+                  onDragOver={
+                    isPinnedHeader
+                      ? handleWorkspacePinDragOver
+                      : headerWorkspaceStatus
+                        ? (event) => handleWorkspaceStatusDragOver(event, headerWorkspaceStatus)
+                        : undefined
+                  }
+                  onDragLeave={
+                    isPinnedHeader
+                      ? handleWorkspacePinDragLeave
+                      : headerWorkspaceStatus
+                        ? handleWorkspaceStatusDragLeave
+                        : undefined
+                  }
+                  onDrop={
+                    headerWorkspaceStatus
+                      ? (event) => handleWorkspaceStatusDrop(event, headerWorkspaceStatus)
+                      : undefined
+                  }
                   onClick={() => toggleGroup(row.key)}
                   onKeyDown={(e) => {
                     if (e.key === 'Enter' || e.key === ' ') {
@@ -527,6 +650,9 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
             )
           }
 
+          const itemWorkspaceStatus =
+            groupBy === 'none' ? getWorkspaceStatus(row.worktree, workspaceStatuses) : null
+
           return (
             <div
               key={vItem.key}
@@ -536,8 +662,26 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
               aria-current={activeWorktreeId === row.worktree.id ? 'page' : undefined}
               data-index={vItem.index}
               ref={virtualizer.measureElement}
-              className="absolute left-0 right-0"
+              data-workspace-status-drop-target={itemWorkspaceStatus ? '' : undefined}
+              data-workspace-status={itemWorkspaceStatus ?? undefined}
+              className={cn(
+                'absolute left-0 right-0',
+                itemWorkspaceStatus &&
+                  dragOverStatus === itemWorkspaceStatus &&
+                  'rounded-lg bg-sidebar-accent/40'
+              )}
               style={{ transform: `translateY(${vItem.start}px)` }}
+              onDragOver={
+                itemWorkspaceStatus
+                  ? (event) => handleWorkspaceStatusDragOver(event, itemWorkspaceStatus)
+                  : undefined
+              }
+              onDragLeave={itemWorkspaceStatus ? handleWorkspaceStatusDragLeave : undefined}
+              onDrop={
+                itemWorkspaceStatus
+                  ? (event) => handleWorkspaceStatusDrop(event, itemWorkspaceStatus)
+                  : undefined
+              }
             >
               <WorktreeCard
                 worktree={row.worktree}
@@ -568,11 +712,13 @@ const WorktreeList = React.memo(function WorktreeList() {
   const worktreesByRepo = useAppStore((s) => s.worktreesByRepo)
   const activeWorktreeId = useAppStore((s) => s.activeWorktreeId)
   const groupBy = useAppStore((s) => s.groupBy)
+  const workspaceStatuses = useAppStore((s) => s.workspaceStatuses)
   const sortBy = useAppStore((s) => s.sortBy)
   const showActiveOnly = useAppStore((s) => s.showActiveOnly)
   const hideDefaultBranchWorkspace = useAppStore((s) => s.hideDefaultBranchWorkspace)
   const filterRepoIds = useAppStore((s) => s.filterRepoIds)
   const openModal = useAppStore((s) => s.openModal)
+  const updateWorktreeMeta = useAppStore((s) => s.updateWorktreeMeta)
   const activeView = useAppStore((s) => s.activeView)
   const activeModal = useAppStore((s) => s.activeModal)
   const pendingRevealWorktreeId = useAppStore((s) => s.pendingRevealWorktreeId)
@@ -881,8 +1027,17 @@ const WorktreeList = React.memo(function WorktreeList() {
 
   // Build flat row list for rendering
   const rows: Row[] = useMemo(
-    () => buildRows(groupBy, worktrees, repoMap, prCache, collapsedGroups, repoOrder),
-    [groupBy, worktrees, repoMap, prCache, collapsedGroups, repoOrder]
+    () =>
+      buildRows(
+        groupBy,
+        worktrees,
+        repoMap,
+        prCache,
+        collapsedGroups,
+        repoOrder,
+        workspaceStatuses
+      ),
+    [groupBy, worktrees, repoMap, prCache, collapsedGroups, repoOrder, workspaceStatuses]
   )
   // Why: rows.length alone can stay the same when items migrate between
   // groups (e.g., PR cache loads on restart and a collapsed group absorbs
@@ -1011,6 +1166,28 @@ const WorktreeList = React.memo(function WorktreeList() {
     [openModal]
   )
 
+  const moveWorktreeToStatus = useCallback(
+    (worktreeId: string, status: WorkspaceStatus) => {
+      const current = worktreeMap.get(worktreeId)
+      if (!current || getWorkspaceStatus(current, workspaceStatuses) === status) {
+        return
+      }
+      void updateWorktreeMeta(worktreeId, { workspaceStatus: status })
+    },
+    [updateWorktreeMeta, worktreeMap, workspaceStatuses]
+  )
+
+  const pinWorktree = useCallback(
+    (worktreeId: string) => {
+      const current = worktreeMap.get(worktreeId)
+      if (!current || current.isPinned) {
+        return
+      }
+      void updateWorktreeMeta(worktreeId, { isPinned: true })
+    },
+    [updateWorktreeMeta, worktreeMap]
+  )
+
   // Why: hideDefaultBranchWorkspace is counted as a filter here so the
   // empty-sidebar escape hatch (Clear Filters button below) is reachable when
   // it's the only reason the list is empty — otherwise a user whose only
@@ -1081,6 +1258,9 @@ const WorktreeList = React.memo(function WorktreeList() {
         void reorderReposAction(orderedIds)
       }}
       prCache={prCache}
+      workspaceStatuses={workspaceStatuses}
+      onMoveWorktreeToStatus={moveWorktreeToStatus}
+      onPinWorktree={pinWorktree}
       scrollOffsetRef={sidebarScrollOffsetRef}
     />
   )

--- a/src/renderer/src/components/sidebar/use-workspace-status-drop.ts
+++ b/src/renderer/src/components/sidebar/use-workspace-status-drop.ts
@@ -1,0 +1,76 @@
+import { useEffect } from 'react'
+import type React from 'react'
+import type { WorkspaceStatus } from '../../../../shared/types'
+import { hasWorkspaceDragData, readWorkspaceDragData } from './workspace-status'
+
+const WORKSPACE_STATUS_DROP_TARGET = '[data-workspace-status-drop-target]'
+const WORKSPACE_PIN_DROP_TARGET = '[data-workspace-pin-drop-target]'
+
+type MoveWorktreeToStatus = (worktreeId: string, status: WorkspaceStatus) => void
+type PinWorktree = (worktreeId: string) => void
+
+export function useWorkspaceStatusDocumentDrop<T extends HTMLElement>(
+  containerRef: React.RefObject<T | null>,
+  onMoveWorktreeToStatus: MoveWorktreeToStatus,
+  onPinWorktree: PinWorktree,
+  onDragFinish: () => void
+): void {
+  useEffect(() => {
+    const handleDrop = (event: DragEvent): void => {
+      const dataTransfer = event.dataTransfer
+      if (!dataTransfer || !hasWorkspaceDragData(dataTransfer)) {
+        return
+      }
+
+      onDragFinish()
+
+      const container = containerRef.current
+      const target = event.target
+      if (!container || !(target instanceof Element) || !container.contains(target)) {
+        return
+      }
+
+      const pinTarget = target.closest<HTMLElement>(WORKSPACE_PIN_DROP_TARGET)
+      const statusTarget = target.closest<HTMLElement>(WORKSPACE_STATUS_DROP_TARGET)
+      const dropTarget =
+        pinTarget && container.contains(pinTarget)
+          ? pinTarget
+          : statusTarget && container.contains(statusTarget)
+            ? statusTarget
+            : null
+      if (!dropTarget) {
+        return
+      }
+
+      const worktreeId = readWorkspaceDragData(dataTransfer)
+      if (!worktreeId) {
+        return
+      }
+
+      // Why: Electron's preload bridge stops native drops before React sees
+      // them, so board drops commit from this scoped capture listener.
+      event.preventDefault()
+      event.stopPropagation()
+      if (dropTarget === pinTarget) {
+        onPinWorktree(worktreeId)
+        return
+      }
+
+      const status = dropTarget.dataset.workspaceStatus
+      if (status) {
+        onMoveWorktreeToStatus(worktreeId, status)
+      }
+    }
+
+    const handleDragFinish = (): void => {
+      onDragFinish()
+    }
+
+    document.addEventListener('drop', handleDrop, true)
+    document.addEventListener('dragend', handleDragFinish, true)
+    return () => {
+      document.removeEventListener('drop', handleDrop, true)
+      document.removeEventListener('dragend', handleDragFinish, true)
+    }
+  }, [containerRef, onDragFinish, onMoveWorktreeToStatus, onPinWorktree])
+}

--- a/src/renderer/src/components/sidebar/use-workspace-status-drop.ts
+++ b/src/renderer/src/components/sidebar/use-workspace-status-drop.ts
@@ -13,9 +13,14 @@ export function useWorkspaceStatusDocumentDrop<T extends HTMLElement>(
   containerRef: React.RefObject<T | null>,
   onMoveWorktreeToStatus: MoveWorktreeToStatus,
   onPinWorktree: PinWorktree,
-  onDragFinish: () => void
+  onDragFinish: () => void,
+  enabled = true
 ): void {
   useEffect(() => {
+    if (!enabled) {
+      return
+    }
+
     const handleDrop = (event: DragEvent): void => {
       const dataTransfer = event.dataTransfer
       if (!dataTransfer || !hasWorkspaceDragData(dataTransfer)) {
@@ -72,5 +77,5 @@ export function useWorkspaceStatusDocumentDrop<T extends HTMLElement>(
       document.removeEventListener('drop', handleDrop, true)
       document.removeEventListener('dragend', handleDragFinish, true)
     }
-  }, [containerRef, onDragFinish, onMoveWorktreeToStatus, onPinWorktree])
+  }, [containerRef, enabled, onDragFinish, onMoveWorktreeToStatus, onPinWorktree])
 }

--- a/src/renderer/src/components/sidebar/use-worktree-activity-status.ts
+++ b/src/renderer/src/components/sidebar/use-worktree-activity-status.ts
@@ -1,0 +1,93 @@
+import { useMemo } from 'react'
+import { useShallow } from 'zustand/react/shallow'
+import { useAppStore } from '@/store'
+import { isExplicitAgentStatusFresh } from '@/lib/agent-status'
+import { resolveWorktreeStatus, type WorktreeStatus } from '@/lib/worktree-status'
+import { AGENT_STATUS_STALE_AFTER_MS } from '../../../../shared/agent-status-types'
+import { EMPTY_BROWSER_TABS, EMPTY_TABS } from './WorktreeCardHelpers'
+import {
+  selectLivePtyIdsForWorktree,
+  selectRuntimePaneTitlesForWorktree
+} from './worktree-card-status-inputs'
+
+export function useWorktreeActivityStatus(worktreeId: string): WorktreeStatus {
+  const tabs = useAppStore((s) => s.tabsByWorktree[worktreeId] ?? EMPTY_TABS)
+  const browserTabs = useAppStore((s) => s.browserTabsByWorktree[worktreeId] ?? EMPTY_BROWSER_TABS)
+  const hasNotesSurface = useAppStore((s) =>
+    (s.unifiedTabsByWorktree[worktreeId] ?? []).some((tab) => tab.contentType === 'notes')
+  )
+  const runtimePaneTitlesForWorktree = useAppStore(
+    useShallow((s) => selectRuntimePaneTitlesForWorktree(s, worktreeId))
+  )
+  const ptyIdsForWorktree = useAppStore(
+    useShallow((s) => selectLivePtyIdsForWorktree(s, worktreeId))
+  )
+  const { hasPermission, hasLiveDone, hasRetainedDone } = useAppStore(
+    useShallow((s) => {
+      // Touch the epoch so this selector re-runs when a fresh hook entry
+      // crosses the stale boundary.
+      void s.agentStatusEpoch
+      const wtTabs = s.tabsByWorktree[worktreeId] ?? EMPTY_TABS
+      let perm = false
+      let live = false
+      if (wtTabs.length > 0) {
+        const tabIds = new Set(wtTabs.map((tab) => tab.id))
+        const now = Date.now()
+        for (const [paneKey, entry] of Object.entries(s.agentStatusByPaneKey)) {
+          const sepIdx = paneKey.indexOf(':')
+          if (sepIdx <= 0) {
+            continue
+          }
+          const tabId = paneKey.slice(0, sepIdx)
+          if (!tabIds.has(tabId)) {
+            continue
+          }
+          if (!isExplicitAgentStatusFresh(entry, now, AGENT_STATUS_STALE_AFTER_MS)) {
+            continue
+          }
+          if (entry.state === 'blocked' || entry.state === 'waiting') {
+            perm = true
+          } else if (entry.state === 'done') {
+            live = true
+          }
+        }
+      }
+
+      let retained = false
+      for (const agent of Object.values(s.retainedAgentsByPaneKey)) {
+        if (agent.worktreeId === worktreeId) {
+          retained = true
+          break
+        }
+      }
+      return { hasPermission: perm, hasLiveDone: live, hasRetainedDone: retained }
+    })
+  )
+
+  // Why: compact and detailed cards need the same status-dot semantics:
+  // runtime liveness gates title-derived states, then explicit agent rows can
+  // promote permission/done so the dot matches visible agent state.
+  return useMemo(
+    () =>
+      resolveWorktreeStatus({
+        tabs,
+        browserTabs,
+        ptyIdsByTabId: ptyIdsForWorktree,
+        runtimePaneTitlesByTabId: runtimePaneTitlesForWorktree,
+        hasNotesSurface,
+        hasPermission,
+        hasLiveDone,
+        hasRetainedDone
+      }),
+    [
+      tabs,
+      browserTabs,
+      ptyIdsForWorktree,
+      runtimePaneTitlesForWorktree,
+      hasNotesSurface,
+      hasPermission,
+      hasLiveDone,
+      hasRetainedDone
+    ]
+  )
+}

--- a/src/renderer/src/components/sidebar/workspace-status.ts
+++ b/src/renderer/src/components/sidebar/workspace-status.ts
@@ -1,9 +1,26 @@
 import type React from 'react'
-import { Circle, CircleCheckBig, CircleDot, GitPullRequest } from 'lucide-react'
-import type { WorkspaceStatus } from '../../../../shared/types'
 import {
+  Ban,
+  Circle,
+  CircleAlert,
+  CircleCheckBig,
+  CircleDashed,
+  CircleDot,
+  CircleEllipsis,
+  CirclePause,
+  CirclePlay,
+  Flag,
+  GitPullRequest,
+  Timer
+} from 'lucide-react'
+import type { WorkspaceStatus, WorkspaceStatusDefinition } from '../../../../shared/types'
+import {
+  DEFAULT_WORKSPACE_STATUS_COLOR_ID,
+  DEFAULT_WORKSPACE_STATUS_ICON_ID,
   DEFAULT_WORKSPACE_STATUS_ID,
   DEFAULT_WORKSPACE_STATUSES,
+  WORKSPACE_STATUS_COLOR_IDS,
+  WORKSPACE_STATUS_ICON_IDS,
   getWorkspaceStatus,
   getWorkspaceStatusFromGroupKey,
   getWorkspaceStatusGroupKey,
@@ -11,8 +28,12 @@ import {
 } from '../../../../shared/workspace-statuses'
 
 export {
+  DEFAULT_WORKSPACE_STATUS_COLOR_ID,
+  DEFAULT_WORKSPACE_STATUS_ICON_ID,
   DEFAULT_WORKSPACE_STATUS_ID,
   DEFAULT_WORKSPACE_STATUSES,
+  WORKSPACE_STATUS_COLOR_IDS,
+  WORKSPACE_STATUS_ICON_IDS,
   getWorkspaceStatus,
   getWorkspaceStatusFromGroupKey,
   getWorkspaceStatusGroupKey,
@@ -21,36 +42,174 @@ export {
 
 export const WORKSPACE_STATUS_DRAG_TYPE = 'application/x-orca-worktree-id'
 
-export const DEFAULT_WORKSPACE_STATUS_META: Record<
+type WorkspaceStatusColorOption = {
+  id: string
+  label: string
+  tone: string
+  swatch: string
+  border: string
+  laneTint: string
+}
+
+type WorkspaceStatusIconOption = {
+  id: string
+  label: string
+  icon: React.ComponentType<{ className?: string }>
+}
+
+export const WORKSPACE_STATUS_COLOR_OPTIONS: WorkspaceStatusColorOption[] = [
+  {
+    id: 'neutral',
+    label: 'Neutral',
+    tone: 'text-muted-foreground',
+    swatch: 'bg-muted-foreground',
+    border: 'border-t-muted-foreground/45',
+    laneTint: 'bg-background/55'
+  },
+  {
+    id: 'blue',
+    label: 'Blue',
+    tone: 'text-blue-600 dark:text-blue-300',
+    swatch: 'bg-blue-500',
+    border: 'border-t-blue-500/70',
+    laneTint: 'bg-blue-500/[0.04]'
+  },
+  {
+    id: 'sky',
+    label: 'Sky',
+    tone: 'text-sky-600 dark:text-sky-300',
+    swatch: 'bg-sky-500',
+    border: 'border-t-sky-500/70',
+    laneTint: 'bg-sky-500/[0.04]'
+  },
+  {
+    id: 'violet',
+    label: 'Violet',
+    tone: 'text-violet-600 dark:text-violet-300',
+    swatch: 'bg-violet-500',
+    border: 'border-t-violet-500/70',
+    laneTint: 'bg-violet-500/[0.04]'
+  },
+  {
+    id: 'amber',
+    label: 'Amber',
+    tone: 'text-amber-700 dark:text-amber-200',
+    swatch: 'bg-amber-500',
+    border: 'border-t-amber-500/70',
+    laneTint: 'bg-amber-500/[0.04]'
+  },
+  {
+    id: 'emerald',
+    label: 'Emerald',
+    tone: 'text-emerald-700 dark:text-emerald-200',
+    swatch: 'bg-emerald-500',
+    border: 'border-t-emerald-500/70',
+    laneTint: 'bg-emerald-500/[0.04]'
+  },
+  {
+    id: 'rose',
+    label: 'Rose',
+    tone: 'text-rose-600 dark:text-rose-300',
+    swatch: 'bg-rose-500',
+    border: 'border-t-rose-500/70',
+    laneTint: 'bg-rose-500/[0.04]'
+  },
+  {
+    id: 'zinc',
+    label: 'Zinc',
+    tone: 'text-zinc-600 dark:text-zinc-300',
+    swatch: 'bg-zinc-500',
+    border: 'border-t-zinc-500/70',
+    laneTint: 'bg-zinc-500/[0.04]'
+  }
+]
+
+export const WORKSPACE_STATUS_ICON_OPTIONS: WorkspaceStatusIconOption[] = [
+  { id: 'circle', label: 'Circle', icon: Circle },
+  { id: 'circle-dot', label: 'Dot', icon: CircleDot },
+  { id: 'circle-dashed', label: 'Dashed', icon: CircleDashed },
+  { id: 'circle-ellipsis', label: 'Waiting', icon: CircleEllipsis },
+  { id: 'git-pull-request', label: 'Review', icon: GitPullRequest },
+  { id: 'timer', label: 'Timer', icon: Timer },
+  { id: 'flag', label: 'Flag', icon: Flag },
+  { id: 'circle-alert', label: 'Alert', icon: CircleAlert },
+  { id: 'circle-pause', label: 'Paused', icon: CirclePause },
+  { id: 'circle-play', label: 'Play', icon: CirclePlay },
+  { id: 'circle-check', label: 'Done', icon: CircleCheckBig },
+  { id: 'ban', label: 'Blocked', icon: Ban }
+]
+
+const FALLBACK_COLOR_OPTION: WorkspaceStatusColorOption = WORKSPACE_STATUS_COLOR_OPTIONS[0] ?? {
+  id: DEFAULT_WORKSPACE_STATUS_COLOR_ID,
+  label: 'Neutral',
+  tone: 'text-muted-foreground',
+  swatch: 'bg-muted-foreground',
+  border: 'border-t-muted-foreground/45',
+  laneTint: 'bg-background/55'
+}
+
+const FALLBACK_ICON_OPTION: WorkspaceStatusIconOption = WORKSPACE_STATUS_ICON_OPTIONS[1] ?? {
+  id: DEFAULT_WORKSPACE_STATUS_ICON_ID,
+  label: 'Dot',
+  icon: CircleDot
+}
+
+const DEFAULT_STATUS_VISUALS: Record<
   string,
   {
-    tone: string
-    icon: React.ComponentType<{ className?: string }>
+    color: string
+    icon: string
   }
 > = {
   todo: {
-    tone: 'text-muted-foreground',
-    icon: Circle
+    color: 'neutral',
+    icon: 'circle'
   },
   'in-progress': {
-    tone: 'text-foreground',
-    icon: CircleDot
+    color: 'blue',
+    icon: 'circle-dot'
   },
   'in-review': {
-    tone: 'text-foreground',
-    icon: GitPullRequest
+    color: 'violet',
+    icon: 'git-pull-request'
   },
   completed: {
-    tone: 'text-muted-foreground',
-    icon: CircleCheckBig
+    color: 'emerald',
+    icon: 'circle-check'
   }
 }
 
-export function getWorkspaceStatusVisualMeta(status: WorkspaceStatus): {
+export function getWorkspaceStatusVisualMeta(status: WorkspaceStatus | WorkspaceStatusDefinition): {
   tone: string
+  swatch: string
+  border: string
+  laneTint: string
   icon: React.ComponentType<{ className?: string }>
 } {
-  return DEFAULT_WORKSPACE_STATUS_META[status] ?? { tone: 'text-foreground', icon: CircleDot }
+  const statusId = typeof status === 'string' ? status : status.id
+  const visual = typeof status === 'string' ? DEFAULT_STATUS_VISUALS[status] : status
+  const colorId = visual?.color ?? DEFAULT_STATUS_VISUALS[statusId]?.color
+  const iconId = visual?.icon ?? DEFAULT_STATUS_VISUALS[statusId]?.icon
+  const color =
+    WORKSPACE_STATUS_COLOR_OPTIONS.find((option) => option.id === colorId) ??
+    WORKSPACE_STATUS_COLOR_OPTIONS.find(
+      (option) => option.id === DEFAULT_WORKSPACE_STATUS_COLOR_ID
+    ) ??
+    FALLBACK_COLOR_OPTION
+  const icon =
+    WORKSPACE_STATUS_ICON_OPTIONS.find((option) => option.id === iconId) ??
+    WORKSPACE_STATUS_ICON_OPTIONS.find(
+      (option) => option.id === DEFAULT_WORKSPACE_STATUS_ICON_ID
+    ) ??
+    FALLBACK_ICON_OPTION
+
+  return {
+    tone: color.tone,
+    swatch: color.swatch,
+    border: color.border,
+    laneTint: color.laneTint,
+    icon: icon.icon
+  }
 }
 
 export function writeWorkspaceDragData(dataTransfer: DataTransfer, worktreeId: string): void {

--- a/src/renderer/src/components/sidebar/workspace-status.ts
+++ b/src/renderer/src/components/sidebar/workspace-status.ts
@@ -1,0 +1,73 @@
+import type React from 'react'
+import { Circle, CircleCheckBig, CircleDot, GitPullRequest } from 'lucide-react'
+import type { WorkspaceStatus } from '../../../../shared/types'
+import {
+  DEFAULT_WORKSPACE_STATUS_ID,
+  DEFAULT_WORKSPACE_STATUSES,
+  getWorkspaceStatus,
+  getWorkspaceStatusFromGroupKey,
+  getWorkspaceStatusGroupKey,
+  isWorkspaceStatusId
+} from '../../../../shared/workspace-statuses'
+
+export {
+  DEFAULT_WORKSPACE_STATUS_ID,
+  DEFAULT_WORKSPACE_STATUSES,
+  getWorkspaceStatus,
+  getWorkspaceStatusFromGroupKey,
+  getWorkspaceStatusGroupKey,
+  isWorkspaceStatusId
+}
+
+export const WORKSPACE_STATUS_DRAG_TYPE = 'application/x-orca-worktree-id'
+
+export const DEFAULT_WORKSPACE_STATUS_META: Record<
+  string,
+  {
+    tone: string
+    icon: React.ComponentType<{ className?: string }>
+  }
+> = {
+  todo: {
+    tone: 'text-muted-foreground',
+    icon: Circle
+  },
+  'in-progress': {
+    tone: 'text-foreground',
+    icon: CircleDot
+  },
+  'in-review': {
+    tone: 'text-foreground',
+    icon: GitPullRequest
+  },
+  completed: {
+    tone: 'text-muted-foreground',
+    icon: CircleCheckBig
+  }
+}
+
+export function getWorkspaceStatusVisualMeta(status: WorkspaceStatus): {
+  tone: string
+  icon: React.ComponentType<{ className?: string }>
+} {
+  return DEFAULT_WORKSPACE_STATUS_META[status] ?? { tone: 'text-foreground', icon: CircleDot }
+}
+
+export function writeWorkspaceDragData(dataTransfer: DataTransfer, worktreeId: string): void {
+  dataTransfer.effectAllowed = 'move'
+  dataTransfer.setData(WORKSPACE_STATUS_DRAG_TYPE, worktreeId)
+  dataTransfer.setData('text/plain', worktreeId)
+}
+
+export function readWorkspaceDragData(dataTransfer: DataTransfer): string | null {
+  const typed = dataTransfer.getData(WORKSPACE_STATUS_DRAG_TYPE)
+  if (typed) {
+    return typed
+  }
+  return dataTransfer.getData('text/plain') || null
+}
+
+export function hasWorkspaceDragData(dataTransfer: DataTransfer): boolean {
+  const types = Array.from(dataTransfer.types)
+  return types.includes(WORKSPACE_STATUS_DRAG_TYPE) || types.includes('text/plain')
+}

--- a/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
@@ -57,9 +57,14 @@ describe('buildRows with pinned worktrees', () => {
     expect(rows[1]).toMatchObject({ type: 'item', worktree: { id: 'wt-pinned' } })
   })
 
-  it('emits an All header between pinned and unpinned in groupBy none', () => {
+  it('emits status headers for unpinned worktrees in groupBy none', () => {
     const rows = buildRows('none', [unpinned1, pinned, unpinned2], repoMap, null, new Set())
-    expect(rows[2]).toMatchObject({ type: 'header', key: 'all', label: 'All', count: 2 })
+    expect(rows[2]).toMatchObject({
+      type: 'header',
+      key: 'workspace-status:in-progress',
+      label: 'In progress',
+      count: 2
+    })
     expect(rows[3]).toMatchObject({ type: 'item', worktree: { id: 'wt-1' } })
     expect(rows[4]).toMatchObject({ type: 'item', worktree: { id: 'wt-2' } })
   })
@@ -76,22 +81,36 @@ describe('buildRows with pinned worktrees', () => {
     }
   })
 
-  it('does not emit pinned section when no worktrees are pinned', () => {
+  it('keeps an empty pinned drop section above statuses in groupBy none', () => {
     const rows = buildRows('none', [unpinned1, unpinned2], repoMap, null, new Set())
-    expect(rows.every((r) => r.type === 'item')).toBe(true)
+    expect(rows[0]).toMatchObject({
+      type: 'header',
+      key: 'pinned',
+      label: 'Pinned',
+      count: 0
+    })
+    expect(rows[1]).toMatchObject({
+      type: 'header',
+      key: 'workspace-status:in-progress',
+      label: 'In progress',
+      count: 2
+    })
+    expect(rows[2]).toMatchObject({ type: 'item', worktree: { id: 'wt-1' } })
+    expect(rows[3]).toMatchObject({ type: 'item', worktree: { id: 'wt-2' } })
   })
 
   it('collapses pinned group when in collapsedGroups', () => {
     const rows = buildRows('none', [pinned, unpinned1], repoMap, null, new Set(['pinned']))
     expect(rows[0]).toMatchObject({ type: 'header', key: 'pinned' })
-    expect(rows[1]).toMatchObject({ type: 'header', key: 'all' })
+    expect(rows[1]).toMatchObject({ type: 'header', key: 'workspace-status:in-progress' })
     expect(rows[2]).toMatchObject({ type: 'item', worktree: { id: 'wt-1' } })
   })
 
-  it('does not emit All header when all worktrees are pinned', () => {
+  it('does not emit empty status sections when all worktrees are pinned', () => {
     const allPinned = { ...unpinned1, isPinned: true }
     const rows = buildRows('none', [pinned, allPinned], repoMap, null, new Set())
-    expect(rows.some((r) => r.type === 'header' && r.key === 'all')).toBe(false)
+    expect(rows.filter((r) => r.type === 'header')).toHaveLength(1)
+    expect(rows[0]).toMatchObject({ type: 'header', key: 'pinned', count: 2 })
   })
 
   it('preserves repo display casing in group labels', () => {
@@ -134,6 +153,49 @@ describe('buildRows with pinned worktrees', () => {
       repo: folderRepo
     })
     expect(rows[1]).toMatchObject({ type: 'item', worktree: { id: folderWorktree.id } })
+  })
+
+  it('emits assigned workspace statuses as sections in groupBy none', () => {
+    const review = { ...worktree, id: 'wt-review', workspaceStatus: 'in-review' as const }
+    const rows = buildRows('none', [review], repoMap, null, new Set())
+
+    expect(
+      rows
+        .filter((r) => r.type === 'header')
+        .map((r) => ({ key: r.key, label: r.label, count: r.count }))
+    ).toEqual([
+      { key: 'pinned', label: 'Pinned', count: 0 },
+      { key: 'workspace-status:in-review', label: 'In review', count: 1 }
+    ])
+  })
+
+  it('uses customized workspace status labels and order', () => {
+    const customStatuses = [
+      { id: 'blocked', label: 'Blocked' },
+      { id: 'todo', label: 'Ready' },
+      { id: 'in-progress', label: 'Doing' }
+    ]
+    const blocked = { ...worktree, id: 'wt-blocked', workspaceStatus: 'blocked' }
+    const doing = { ...worktree, id: 'wt-doing', workspaceStatus: 'in-progress' }
+    const rows = buildRows(
+      'none',
+      [doing, blocked],
+      repoMap,
+      null,
+      new Set(),
+      undefined,
+      customStatuses
+    )
+
+    expect(
+      rows
+        .filter((r) => r.type === 'header')
+        .map((r) => ({ key: r.key, label: r.label, count: r.count }))
+    ).toEqual([
+      { key: 'pinned', label: 'Pinned', count: 0 },
+      { key: 'workspace-status:blocked', label: 'Blocked', count: 1 },
+      { key: 'workspace-status:in-progress', label: 'Doing', count: 1 }
+    ])
   })
 })
 

--- a/src/renderer/src/components/sidebar/worktree-list-groups.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.ts
@@ -244,7 +244,7 @@ export function buildRows(
                 workspaceStatuses[0]?.id ??
                 'in-progress'
               const definition = workspaceStatuses.find((status) => status.id === workspaceStatus)
-              const meta = getWorkspaceStatusVisualMeta(workspaceStatus)
+              const meta = getWorkspaceStatusVisualMeta(definition ?? workspaceStatus)
               return {
                 type: 'header' as const,
                 key,

--- a/src/renderer/src/components/sidebar/worktree-list-groups.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.ts
@@ -1,17 +1,18 @@
-import {
-  CircleCheckBig,
-  CircleDot,
-  CircleX,
-  Folder,
-  GitPullRequest,
-  LayoutList,
-  Pin
-} from 'lucide-react'
+import { CircleCheckBig, CircleDot, CircleX, Folder, GitPullRequest, Pin } from 'lucide-react'
 import type React from 'react'
-import type { Repo, Worktree } from '../../../../shared/types'
+import type { Repo, Worktree, WorkspaceStatusDefinition } from '../../../../shared/types'
 import { branchName } from '@/lib/git-utils'
+import {
+  getWorkspaceStatus,
+  getWorkspaceStatusFromGroupKey,
+  getWorkspaceStatusGroupKey,
+  getWorkspaceStatusVisualMeta
+} from './workspace-status'
+import { cloneDefaultWorkspaceStatuses } from '../../../../shared/workspace-statuses'
 
 export { branchName }
+
+export type WorktreeGroupBy = 'none' | 'repo' | 'pr-status'
 
 export type GroupHeaderRow = {
   type: 'header'
@@ -73,14 +74,6 @@ export const PINNED_GROUP_META = {
   icon: Pin
 } as const
 
-export const ALL_GROUP_KEY = 'all'
-
-export const ALL_GROUP_META = {
-  label: 'All',
-  tone: 'text-foreground',
-  icon: LayoutList
-} as const
-
 export function getPRGroupKey(
   worktree: Worktree,
   repoMap: Map<string, Repo>,
@@ -118,10 +111,11 @@ function emitPinnedGroup(
   worktrees: Worktree[],
   repoMap: Map<string, Repo>,
   collapsedGroups: Set<string>,
-  result: Row[]
+  result: Row[],
+  force = false
 ): Set<string> {
   const pinned = worktrees.filter((w) => w.isPinned)
-  if (pinned.length === 0) {
+  if (pinned.length === 0 && !force) {
     return new Set()
   }
 
@@ -146,40 +140,18 @@ function emitPinnedGroup(
  * Extracted here to keep WorktreeList.tsx under the line-count lint limit.
  */
 export function buildRows(
-  groupBy: 'none' | 'repo' | 'pr-status',
+  groupBy: WorktreeGroupBy,
   worktrees: Worktree[],
   repoMap: Map<string, Repo>,
   prCache: Record<string, unknown> | null,
   collapsedGroups: Set<string>,
-  repoOrder?: Map<string, number>
+  repoOrder?: Map<string, number>,
+  workspaceStatuses: readonly WorkspaceStatusDefinition[] = cloneDefaultWorkspaceStatuses()
 ): Row[] {
   const result: Row[] = []
 
-  const pinnedIds = emitPinnedGroup(worktrees, repoMap, collapsedGroups, result)
+  const pinnedIds = emitPinnedGroup(worktrees, repoMap, collapsedGroups, result, groupBy === 'none')
   const unpinned = pinnedIds.size > 0 ? worktrees.filter((w) => !pinnedIds.has(w.id)) : worktrees
-
-  if (groupBy === 'none') {
-    // Without an "All" header, the unpinned block is visually indistinguishable
-    // from a continuation of the Pinned section — so when pinned items exist,
-    // mark the boundary with a sibling header that mirrors the Pinned one.
-    if (pinnedIds.size > 0 && unpinned.length > 0) {
-      result.push({
-        type: 'header',
-        key: ALL_GROUP_KEY,
-        label: ALL_GROUP_META.label,
-        count: unpinned.length,
-        tone: ALL_GROUP_META.tone,
-        icon: ALL_GROUP_META.icon
-      })
-      if (collapsedGroups.has(ALL_GROUP_KEY)) {
-        return result
-      }
-    }
-    for (const w of unpinned) {
-      result.push({ type: 'item', worktree: w, repo: repoMap.get(w.repoId) })
-    }
-    return result
-  }
 
   const grouped = new Map<string, { label: string; items: Worktree[]; repo?: Repo }>()
   for (const w of unpinned) {
@@ -190,6 +162,11 @@ export function buildRows(
       repo = repoMap.get(w.repoId)
       key = `repo:${w.repoId}`
       label = repo?.displayName ?? 'Unknown'
+    } else if (groupBy === 'none') {
+      const workspaceStatus = getWorkspaceStatus(w, workspaceStatuses)
+      key = getWorkspaceStatusGroupKey(workspaceStatus)
+      label =
+        workspaceStatuses.find((status) => status.id === workspaceStatus)?.label ?? workspaceStatus
     } else {
       const prGroup = getPRGroupKey(w, repoMap, prCache)
       key = `pr:${prGroup}`
@@ -205,6 +182,17 @@ export function buildRows(
   if (groupBy === 'pr-status') {
     for (const prGroup of PR_GROUP_ORDER) {
       const key = `pr:${prGroup}`
+      const group = grouped.get(key)
+      if (group) {
+        orderedGroups.push([key, group])
+      }
+    }
+  } else if (groupBy === 'none') {
+    // Why: the old "All" grouping now organizes workspaces by user status.
+    // Keep the sidebar compact by rendering only sections that contain cards;
+    // the board drawer is the wider all-lanes drag target.
+    for (const status of workspaceStatuses) {
+      const key = getWorkspaceStatusGroupKey(status.id)
       const group = grouped.get(key)
       if (group) {
         orderedGroups.push([key, group])
@@ -249,18 +237,35 @@ export function buildRows(
             icon: REPO_GROUP_META.icon,
             repo
           }
-        : (() => {
-            const prGroup = key.replace(/^pr:/, '') as PRGroupKey
-            const meta = PR_GROUP_META[prGroup]
-            return {
-              type: 'header' as const,
-              key,
-              label: meta.label,
-              count: group.items.length,
-              tone: meta.tone,
-              icon: meta.icon
-            }
-          })()
+        : groupBy === 'none'
+          ? (() => {
+              const workspaceStatus =
+                getWorkspaceStatusFromGroupKey(key, workspaceStatuses) ??
+                workspaceStatuses[0]?.id ??
+                'in-progress'
+              const definition = workspaceStatuses.find((status) => status.id === workspaceStatus)
+              const meta = getWorkspaceStatusVisualMeta(workspaceStatus)
+              return {
+                type: 'header' as const,
+                key,
+                label: definition?.label ?? workspaceStatus,
+                count: group.items.length,
+                tone: meta.tone,
+                icon: meta.icon
+              }
+            })()
+          : (() => {
+              const prGroup = key.replace(/^pr:/, '') as PRGroupKey
+              const meta = PR_GROUP_META[prGroup]
+              return {
+                type: 'header' as const,
+                key,
+                label: meta.label,
+                count: group.items.length,
+                tone: meta.tone,
+                icon: meta.icon
+              }
+            })()
 
     result.push(header)
     if (!isCollapsed) {
@@ -274,13 +279,14 @@ export function buildRows(
 }
 
 export function getGroupKeyForWorktree(
-  groupBy: 'none' | 'repo' | 'pr-status',
+  groupBy: WorktreeGroupBy,
   worktree: Worktree,
   repoMap: Map<string, Repo>,
-  prCache: Record<string, unknown> | null
+  prCache: Record<string, unknown> | null,
+  workspaceStatuses: readonly WorkspaceStatusDefinition[] = cloneDefaultWorkspaceStatuses()
 ): string | null {
   if (groupBy === 'none') {
-    return null
+    return getWorkspaceStatusGroupKey(getWorkspaceStatus(worktree, workspaceStatuses))
   }
   if (groupBy === 'repo') {
     return `repo:${worktree.repoId}`

--- a/src/renderer/src/components/ui/sheet.tsx
+++ b/src/renderer/src/components/ui/sheet.tsx
@@ -68,15 +68,19 @@ function SheetContent({
   children,
   side = 'right',
   showCloseButton = true,
+  overlayClassName,
+  overlayStyle,
   style,
   ...props
 }: React.ComponentProps<typeof SheetPrimitive.Content> &
   VariantProps<typeof sheetContentVariants> & {
     showCloseButton?: boolean
+    overlayClassName?: string
+    overlayStyle?: React.CSSProperties
   }) {
   return (
     <SheetPortal>
-      <SheetOverlay />
+      <SheetOverlay className={overlayClassName} style={overlayStyle} />
       <SheetPrimitive.Content
         data-slot="sheet-content"
         className={cn(sheetContentVariants({ side }), className)}

--- a/src/renderer/src/store/slices/ui.test.ts
+++ b/src/renderer/src/store/slices/ui.test.ts
@@ -116,6 +116,24 @@ describe('createUISlice hydratePersistedUI', () => {
     expect(store.getState().hideDefaultBranchWorkspace).toBe(true)
   })
 
+  it('restores compact workspace board mode only from an explicit true', () => {
+    const store = createUIStore()
+
+    store.getState().hydratePersistedUI(
+      makePersistedUI({
+        workspaceBoardCompact: true
+      })
+    )
+    expect(store.getState().workspaceBoardCompact).toBe(true)
+
+    store.getState().hydratePersistedUI(
+      makePersistedUI({
+        workspaceBoardCompact: 'yes' as unknown as boolean
+      })
+    )
+    expect(store.getState().workspaceBoardCompact).toBe(false)
+  })
+
   it('hydrates a valid Kagi session link', () => {
     const store = createUIStore()
 

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -12,6 +12,7 @@ import type {
   TaskViewPresetId,
   TuiAgent,
   UpdateStatus,
+  WorkspaceStatusDefinition,
   WorktreeCardProperty
 } from '../../../../shared/types'
 import { PET_SIZE_DEFAULT, PET_SIZE_MAX, PET_SIZE_MIN } from '../../../../shared/types'
@@ -20,6 +21,11 @@ import {
   DEFAULT_STATUS_BAR_ITEMS,
   DEFAULT_WORKTREE_CARD_PROPERTIES
 } from '../../../../shared/constants'
+import {
+  clampWorkspaceBoardOpacity,
+  cloneDefaultWorkspaceStatuses,
+  normalizeWorkspaceStatuses
+} from '../../../../shared/workspace-statuses'
 import { normalizeKagiSessionLink } from '../../../../shared/browser-url'
 import type { OrcaHookScriptKind } from '../../lib/orca-hook-trust'
 import { DEFAULT_PET_ID, isBundledPetId } from '../../components/pet/pet-models'
@@ -308,6 +314,10 @@ export type UISlice = {
   toggleCollapsedGroup: (key: string) => void
   worktreeCardProperties: WorktreeCardProperty[]
   toggleWorktreeCardProperty: (prop: WorktreeCardProperty) => void
+  workspaceStatuses: WorkspaceStatusDefinition[]
+  setWorkspaceStatuses: (statuses: WorkspaceStatusDefinition[]) => void
+  workspaceBoardOpacity: number
+  setWorkspaceBoardOpacity: (opacity: number) => void
   statusBarItems: StatusBarItem[]
   toggleStatusBarItem: (item: StatusBarItem) => void
   statusBarVisible: boolean
@@ -676,6 +686,20 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
       return { worktreeCardProperties: updated }
     }),
 
+  workspaceStatuses: cloneDefaultWorkspaceStatuses(),
+  setWorkspaceStatuses: (statuses) => {
+    const normalized = normalizeWorkspaceStatuses(statuses)
+    window.api.ui.set({ workspaceStatuses: normalized }).catch(console.error)
+    set({ workspaceStatuses: normalized })
+  },
+
+  workspaceBoardOpacity: 1,
+  setWorkspaceBoardOpacity: (opacity) => {
+    const clamped = clampWorkspaceBoardOpacity(opacity)
+    window.api.ui.set({ workspaceBoardOpacity: clamped }).catch(console.error)
+    set({ workspaceBoardOpacity: clamped })
+  },
+
   statusBarItems: [...DEFAULT_STATUS_BAR_ITEMS],
   toggleStatusBarItem: (item) =>
     set((s) => {
@@ -815,6 +839,8 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
         uiZoomLevel: ui.uiZoomLevel ?? 0,
         editorFontZoomLevel: ui.editorFontZoomLevel ?? 0,
         worktreeCardProperties: ui.worktreeCardProperties ?? [...DEFAULT_WORKTREE_CARD_PROPERTIES],
+        workspaceStatuses: normalizeWorkspaceStatuses(ui.workspaceStatuses),
+        workspaceBoardOpacity: clampWorkspaceBoardOpacity(ui.workspaceBoardOpacity),
         statusBarItems: migrateStatusBarItems(ui.statusBarItems),
         statusBarVisible: ui.statusBarVisible ?? true,
         // Why: absent → true so existing users see the pet the first time

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -24,6 +24,7 @@ import {
 import {
   clampWorkspaceBoardOpacity,
   cloneDefaultWorkspaceStatuses,
+  normalizeWorkspaceBoardCompact,
   normalizeWorkspaceStatuses
 } from '../../../../shared/workspace-statuses'
 import { normalizeKagiSessionLink } from '../../../../shared/browser-url'
@@ -318,6 +319,8 @@ export type UISlice = {
   setWorkspaceStatuses: (statuses: WorkspaceStatusDefinition[]) => void
   workspaceBoardOpacity: number
   setWorkspaceBoardOpacity: (opacity: number) => void
+  workspaceBoardCompact: boolean
+  setWorkspaceBoardCompact: (compact: boolean) => void
   statusBarItems: StatusBarItem[]
   toggleStatusBarItem: (item: StatusBarItem) => void
   statusBarVisible: boolean
@@ -700,6 +703,13 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
     set({ workspaceBoardOpacity: clamped })
   },
 
+  workspaceBoardCompact: false,
+  setWorkspaceBoardCompact: (compact) => {
+    const normalized = normalizeWorkspaceBoardCompact(compact)
+    window.api.ui.set({ workspaceBoardCompact: normalized }).catch(console.error)
+    set({ workspaceBoardCompact: normalized })
+  },
+
   statusBarItems: [...DEFAULT_STATUS_BAR_ITEMS],
   toggleStatusBarItem: (item) =>
     set((s) => {
@@ -841,6 +851,7 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
         worktreeCardProperties: ui.worktreeCardProperties ?? [...DEFAULT_WORKTREE_CARD_PROPERTIES],
         workspaceStatuses: normalizeWorkspaceStatuses(ui.workspaceStatuses),
         workspaceBoardOpacity: clampWorkspaceBoardOpacity(ui.workspaceBoardOpacity),
+        workspaceBoardCompact: normalizeWorkspaceBoardCompact(ui.workspaceBoardCompact),
         statusBarItems: migrateStatusBarItems(ui.statusBarItems),
         statusBarVisible: ui.statusBarVisible ?? true,
         // Why: absent → true so existing users see the pet the first time

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -48,6 +48,7 @@ function areWorktreesEqual(current: Worktree[] | undefined, next: Worktree[]): b
       worktree.isPinned === candidate.isPinned &&
       worktree.sortOrder === candidate.sortOrder &&
       worktree.lastActivityAt === candidate.lastActivityAt &&
+      worktree.workspaceStatus === candidate.workspaceStatus &&
       worktree.createdWithAgent === candidate.createdWithAgent &&
       worktree.baseRef === candidate.baseRef &&
       worktree.pushTarget?.remoteName === candidate.pushTarget?.remoteName &&

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -327,6 +327,7 @@ export function getDefaultUIState(): PersistedUIState {
     worktreeCardProperties: [...DEFAULT_WORKTREE_CARD_PROPERTIES],
     workspaceStatuses: cloneDefaultWorkspaceStatuses(),
     workspaceBoardOpacity: 1,
+    workspaceBoardCompact: false,
     statusBarItems: [...DEFAULT_STATUS_BAR_ITEMS],
     statusBarVisible: true,
     dismissedUpdateVersion: null,

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -13,6 +13,7 @@ import type {
 import { DEFAULT_TERMINAL_FONT_WEIGHT } from './terminal-fonts'
 import { getDefaultTerminalQuickCommands } from './terminal-quick-commands'
 import type { VoiceSettings } from './speech-types'
+import { cloneDefaultWorkspaceStatuses } from './workspace-statuses'
 
 export const SCHEMA_VERSION = 1
 export const DEFAULT_APP_FONT_FAMILY = 'Geist'
@@ -324,6 +325,8 @@ export function getDefaultUIState(): PersistedUIState {
     uiZoomLevel: 0,
     editorFontZoomLevel: 0,
     worktreeCardProperties: [...DEFAULT_WORKTREE_CARD_PROPERTIES],
+    workspaceStatuses: cloneDefaultWorkspaceStatuses(),
+    workspaceBoardOpacity: 1,
     statusBarItems: [...DEFAULT_STATUS_BAR_ITEMS],
     statusBarVisible: true,
     dismissedUpdateVersion: null,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -106,6 +106,13 @@ export type GitWorktreeInfo = {
 }
 
 // ─── Worktree (app-level, enriched) ──────────────────────────────────
+export type WorkspaceStatus = string
+
+export type WorkspaceStatusDefinition = {
+  id: WorkspaceStatus
+  label: string
+}
+
 export type Worktree = {
   id: string // `${repoId}::${path}`
   repoId: string
@@ -147,6 +154,7 @@ export type Worktree = {
   baseRef?: string
   /** Remote/branch Orca should publish review commits to when it created this worktree. */
   pushTarget?: GitPushTarget
+  workspaceStatus?: WorkspaceStatus
   diffComments?: DiffComment[]
 } & GitWorktreeInfo
 
@@ -183,6 +191,8 @@ export type WorktreeMeta = {
   baseRef?: string
   /** See {@link Worktree.pushTarget}. Persisted so refreshed worktree lists keep the target. */
   pushTarget?: GitPushTarget
+  /** User-assigned workspace board status for manual sidebar organization. */
+  workspaceStatus?: WorkspaceStatus
   diffComments?: DiffComment[]
 }
 
@@ -1571,6 +1581,8 @@ export type PersistedUIState = {
   uiZoomLevel: number
   editorFontZoomLevel: number
   worktreeCardProperties: WorktreeCardProperty[]
+  workspaceStatuses?: WorkspaceStatusDefinition[]
+  workspaceBoardOpacity?: number
   statusBarItems: StatusBarItem[]
   statusBarVisible: boolean
   dismissedUpdateVersion: string | null

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -111,6 +111,8 @@ export type WorkspaceStatus = string
 export type WorkspaceStatusDefinition = {
   id: WorkspaceStatus
   label: string
+  color?: string
+  icon?: string
 }
 
 export type Worktree = {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1585,6 +1585,7 @@ export type PersistedUIState = {
   worktreeCardProperties: WorktreeCardProperty[]
   workspaceStatuses?: WorkspaceStatusDefinition[]
   workspaceBoardOpacity?: number
+  workspaceBoardCompact?: boolean
   statusBarItems: StatusBarItem[]
   statusBarVisible: boolean
   dismissedUpdateVersion: string | null

--- a/src/shared/workspace-statuses.ts
+++ b/src/shared/workspace-statuses.ts
@@ -5,12 +5,47 @@ const MAX_STATUS_LABEL_LENGTH = 32
 const MAX_WORKSPACE_STATUSES = 12
 
 export const DEFAULT_WORKSPACE_STATUS_ID: WorkspaceStatus = 'in-progress'
+export const DEFAULT_WORKSPACE_STATUS_COLOR_ID = 'neutral'
+export const DEFAULT_WORKSPACE_STATUS_ICON_ID = 'circle-dot'
+
+export const WORKSPACE_STATUS_COLOR_IDS = [
+  'neutral',
+  'blue',
+  'sky',
+  'violet',
+  'amber',
+  'emerald',
+  'rose',
+  'zinc'
+] as const
+
+export const WORKSPACE_STATUS_ICON_IDS = [
+  'circle',
+  'circle-dot',
+  'circle-dashed',
+  'circle-ellipsis',
+  'git-pull-request',
+  'timer',
+  'flag',
+  'circle-alert',
+  'circle-pause',
+  'circle-play',
+  'circle-check',
+  'ban'
+] as const
+
+const DEFAULT_STATUS_VISUALS: Record<string, { color: string; icon: string }> = {
+  todo: { color: 'neutral', icon: 'circle' },
+  'in-progress': { color: 'blue', icon: 'circle-dot' },
+  'in-review': { color: 'violet', icon: 'git-pull-request' },
+  completed: { color: 'emerald', icon: 'circle-check' }
+}
 
 export const DEFAULT_WORKSPACE_STATUSES = [
-  { id: 'todo', label: 'Todo' },
-  { id: 'in-progress', label: 'In progress' },
-  { id: 'in-review', label: 'In review' },
-  { id: 'completed', label: 'Completed' }
+  { id: 'todo', label: 'Todo', color: 'neutral', icon: 'circle' },
+  { id: 'in-progress', label: 'In progress', color: 'blue', icon: 'circle-dot' },
+  { id: 'in-review', label: 'In review', color: 'violet', icon: 'git-pull-request' },
+  { id: 'completed', label: 'Completed', color: 'emerald', icon: 'circle-check' }
 ] as const satisfies readonly WorkspaceStatusDefinition[]
 
 export function cloneDefaultWorkspaceStatuses(): WorkspaceStatusDefinition[] {
@@ -43,6 +78,24 @@ function sanitizeWorkspaceStatusId(value: unknown, fallbackLabel: string): Works
     return slugWorkspaceStatusLabel(fallbackLabel)
   }
   return trimmed.replace(/[^a-z0-9_-]+/g, '-').replace(/^-+|-+$/g, '') || 'status'
+}
+
+function sanitizeWorkspaceStatusColor(value: unknown, statusId: string, index: number): string {
+  if (typeof value === 'string' && WORKSPACE_STATUS_COLOR_IDS.some((id) => id === value)) {
+    return value
+  }
+  const defaultVisual = DEFAULT_STATUS_VISUALS[statusId]
+  if (defaultVisual) {
+    return defaultVisual.color
+  }
+  return WORKSPACE_STATUS_COLOR_IDS[index % WORKSPACE_STATUS_COLOR_IDS.length]
+}
+
+function sanitizeWorkspaceStatusIcon(value: unknown, statusId: string): string {
+  if (typeof value === 'string' && WORKSPACE_STATUS_ICON_IDS.some((id) => id === value)) {
+    return value
+  }
+  return DEFAULT_STATUS_VISUALS[statusId]?.icon ?? DEFAULT_WORKSPACE_STATUS_ICON_ID
 }
 
 export function makeWorkspaceStatusId(
@@ -82,7 +135,12 @@ export function normalizeWorkspaceStatuses(value: unknown): WorkspaceStatusDefin
       id = makeWorkspaceStatusId(label, statuses)
     }
     usedIds.add(id)
-    statuses.push({ id, label })
+    statuses.push({
+      id,
+      label,
+      color: sanitizeWorkspaceStatusColor(raw.color, id, statuses.length),
+      icon: sanitizeWorkspaceStatusIcon(raw.icon, id)
+    })
   }
 
   return statuses.length > 0 ? statuses : cloneDefaultWorkspaceStatuses()

--- a/src/shared/workspace-statuses.ts
+++ b/src/shared/workspace-statuses.ts
@@ -1,0 +1,139 @@
+import type { Worktree, WorkspaceStatus, WorkspaceStatusDefinition } from './types'
+
+const WORKSPACE_STATUS_GROUP_PREFIX = 'workspace-status:'
+const MAX_STATUS_LABEL_LENGTH = 32
+const MAX_WORKSPACE_STATUSES = 12
+
+export const DEFAULT_WORKSPACE_STATUS_ID: WorkspaceStatus = 'in-progress'
+
+export const DEFAULT_WORKSPACE_STATUSES = [
+  { id: 'todo', label: 'Todo' },
+  { id: 'in-progress', label: 'In progress' },
+  { id: 'in-review', label: 'In review' },
+  { id: 'completed', label: 'Completed' }
+] as const satisfies readonly WorkspaceStatusDefinition[]
+
+export function cloneDefaultWorkspaceStatuses(): WorkspaceStatusDefinition[] {
+  return DEFAULT_WORKSPACE_STATUSES.map((status) => ({ ...status }))
+}
+
+function sanitizeWorkspaceStatusLabel(value: unknown, fallback: string): string {
+  if (typeof value !== 'string') {
+    return fallback
+  }
+  const trimmed = value.trim().replace(/\s+/g, ' ')
+  return trimmed ? trimmed.slice(0, MAX_STATUS_LABEL_LENGTH) : fallback
+}
+
+function slugWorkspaceStatusLabel(label: string): string {
+  const slug = label
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+  return slug || 'status'
+}
+
+function sanitizeWorkspaceStatusId(value: unknown, fallbackLabel: string): WorkspaceStatus {
+  if (typeof value !== 'string') {
+    return slugWorkspaceStatusLabel(fallbackLabel)
+  }
+  const trimmed = value.trim().toLowerCase()
+  if (!trimmed) {
+    return slugWorkspaceStatusLabel(fallbackLabel)
+  }
+  return trimmed.replace(/[^a-z0-9_-]+/g, '-').replace(/^-+|-+$/g, '') || 'status'
+}
+
+export function makeWorkspaceStatusId(
+  label: string,
+  existingStatuses: readonly WorkspaceStatusDefinition[]
+): WorkspaceStatus {
+  const base = slugWorkspaceStatusLabel(label)
+  const existingIds = new Set(existingStatuses.map((status) => status.id))
+  if (!existingIds.has(base)) {
+    return base
+  }
+  for (let index = 2; index < 100; index += 1) {
+    const candidate = `${base}-${index}`
+    if (!existingIds.has(candidate)) {
+      return candidate
+    }
+  }
+  return `status-${Date.now().toString(36)}`
+}
+
+export function normalizeWorkspaceStatuses(value: unknown): WorkspaceStatusDefinition[] {
+  if (!Array.isArray(value)) {
+    return cloneDefaultWorkspaceStatuses()
+  }
+
+  const statuses: WorkspaceStatusDefinition[] = []
+  const usedIds = new Set<string>()
+  for (const rawStatus of value.slice(0, MAX_WORKSPACE_STATUSES)) {
+    if (!rawStatus || typeof rawStatus !== 'object' || Array.isArray(rawStatus)) {
+      continue
+    }
+    const raw = rawStatus as Record<string, unknown>
+    const fallbackLabel = `Status ${statuses.length + 1}`
+    const label = sanitizeWorkspaceStatusLabel(raw.label, fallbackLabel)
+    let id = sanitizeWorkspaceStatusId(raw.id, label)
+    if (usedIds.has(id)) {
+      id = makeWorkspaceStatusId(label, statuses)
+    }
+    usedIds.add(id)
+    statuses.push({ id, label })
+  }
+
+  return statuses.length > 0 ? statuses : cloneDefaultWorkspaceStatuses()
+}
+
+export function clampWorkspaceBoardOpacity(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return 1
+  }
+  return Math.min(1, Math.max(0.65, Math.round(value * 100) / 100))
+}
+
+export function isWorkspaceStatusId(
+  value: string,
+  statuses: readonly WorkspaceStatusDefinition[]
+): value is WorkspaceStatus {
+  return statuses.some((status) => status.id === value)
+}
+
+export function getDefaultWorkspaceStatusId(
+  statuses: readonly WorkspaceStatusDefinition[]
+): WorkspaceStatus {
+  return statuses.some((status) => status.id === DEFAULT_WORKSPACE_STATUS_ID)
+    ? DEFAULT_WORKSPACE_STATUS_ID
+    : (statuses[0]?.id ?? DEFAULT_WORKSPACE_STATUS_ID)
+}
+
+export function getWorkspaceStatus(
+  worktree: Pick<Worktree, 'workspaceStatus'>,
+  statuses: readonly WorkspaceStatusDefinition[]
+): WorkspaceStatus {
+  return worktree.workspaceStatus && isWorkspaceStatusId(worktree.workspaceStatus, statuses)
+    ? worktree.workspaceStatus
+    : getDefaultWorkspaceStatusId(statuses)
+}
+
+export function getWorkspaceStatusGroupKey(status: WorkspaceStatus): string {
+  return `${WORKSPACE_STATUS_GROUP_PREFIX}${encodeURIComponent(status)}`
+}
+
+export function getWorkspaceStatusFromGroupKey(
+  groupKey: string,
+  statuses: readonly WorkspaceStatusDefinition[]
+): WorkspaceStatus | null {
+  if (!groupKey.startsWith(WORKSPACE_STATUS_GROUP_PREFIX)) {
+    return null
+  }
+  try {
+    const status = decodeURIComponent(groupKey.slice(WORKSPACE_STATUS_GROUP_PREFIX.length))
+    return isWorkspaceStatusId(status, statuses) ? status : null
+  } catch {
+    return null
+  }
+}

--- a/src/shared/workspace-statuses.ts
+++ b/src/shared/workspace-statuses.ts
@@ -92,7 +92,7 @@ export function clampWorkspaceBoardOpacity(value: unknown): number {
   if (typeof value !== 'number' || !Number.isFinite(value)) {
     return 1
   }
-  return Math.min(1, Math.max(0.65, Math.round(value * 100) / 100))
+  return Math.min(1, Math.max(0.2, Math.round(value * 100) / 100))
 }
 
 export function isWorkspaceStatusId(

--- a/src/shared/workspace-statuses.ts
+++ b/src/shared/workspace-statuses.ts
@@ -153,6 +153,10 @@ export function clampWorkspaceBoardOpacity(value: unknown): number {
   return Math.min(1, Math.max(0.2, Math.round(value * 100) / 100))
 }
 
+export function normalizeWorkspaceBoardCompact(value: unknown): boolean {
+  return value === true
+}
+
 export function isWorkspaceStatusId(
   value: string,
   statuses: readonly WorkspaceStatusDefinition[]


### PR DESCRIPTION
Summary
- Add customizable workspace statuses and make the former All grouping render status sections.
- Add the workspace board drawer with detailed/compact cards, drag-to-status, pin drops, opacity controls, and status appearance customization.
- Preserve pinned workspaces above status sections and show pinned badges in the board.
- Make the header board button toggle the drawer.

Perf/correctness review
- Scoped native drop capture listeners to only run when their status/pin targets are active.
- Checked persistence normalization for statuses, opacity, compact mode, and legacy groupBy handling.
- Checked drawer outside-click/focus behavior and compact-card context menu/status-dot behavior.

Verification
- pnpm typecheck
- pnpm lint (passes with existing GitHub project hook-dependency warnings only)
- pnpm test src/renderer/src/store/slices/ui.test.ts src/renderer/src/components/sidebar/worktree-list-groups.test.ts src/main/persistence.test.ts
- git diff --check