### PR TITLE
Open workspace board on header hover

### DIFF
--- a/src/renderer/src/components/sidebar/SidebarHeader.tsx
+++ b/src/renderer/src/components/sidebar/SidebarHeader.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react'
-import { Kanban, Plus, SlidersHorizontal } from 'lucide-react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { Plus, SlidersHorizontal } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
@@ -51,9 +51,18 @@ const SORT_OPTIONS = [
 
 const isMac = navigator.userAgent.includes('Mac')
 const newWorktreeShortcutLabel = isMac ? '⌘N' : 'Ctrl+N'
+const WORKSPACE_BOARD_HOVER_OPEN_DELAY_MS = 50
+// Why: gives the pointer room to travel from the header into the board before
+// the temporary hover preview collapses.
+const WORKSPACE_BOARD_HOVER_CLOSE_DELAY_MS = 220
 
 const SidebarHeader = React.memo(function SidebarHeader() {
   const [workspaceBoardOpen, setWorkspaceBoardOpen] = useState(false)
+  // Why: entering the board turns the hover preview into a persistent drawer
+  // until the user explicitly closes it or clicks outside.
+  const workspaceBoardPinnedOpenRef = useRef(false)
+  const workspaceBoardHoverOpenTimerRef = useRef<number | null>(null)
+  const workspaceBoardHoverCloseTimerRef = useRef<number | null>(null)
   const openModal = useAppStore((s) => s.openModal)
   const repos = useAppStore((s) => s.repos)
   const canCreateWorktree = repos.some((repo) => isGitRepoKind(repo))
@@ -64,30 +73,107 @@ const SidebarHeader = React.memo(function SidebarHeader() {
   const setSortBy = useAppStore((s) => s.setSortBy)
   const groupBy = useAppStore((s) => s.groupBy)
   const setGroupBy = useAppStore((s) => s.setGroupBy)
+
+  const clearWorkspaceBoardHoverClose = useCallback(() => {
+    if (workspaceBoardHoverCloseTimerRef.current === null) {
+      return
+    }
+    window.clearTimeout(workspaceBoardHoverCloseTimerRef.current)
+    workspaceBoardHoverCloseTimerRef.current = null
+  }, [])
+
+  const clearWorkspaceBoardHoverOpen = useCallback(() => {
+    if (workspaceBoardHoverOpenTimerRef.current === null) {
+      return
+    }
+    window.clearTimeout(workspaceBoardHoverOpenTimerRef.current)
+    workspaceBoardHoverOpenTimerRef.current = null
+  }, [])
+
+  useEffect(
+    () => () => {
+      clearWorkspaceBoardHoverOpen()
+      clearWorkspaceBoardHoverClose()
+    },
+    [clearWorkspaceBoardHoverClose, clearWorkspaceBoardHoverOpen]
+  )
+
+  const setWorkspaceBoardPinned = useCallback((pinned: boolean) => {
+    workspaceBoardPinnedOpenRef.current = pinned
+  }, [])
+
+  const handleWorkspaceBoardOpenChange = useCallback(
+    (open: boolean) => {
+      clearWorkspaceBoardHoverOpen()
+      clearWorkspaceBoardHoverClose()
+      setWorkspaceBoardOpen(open)
+      if (!open) {
+        setWorkspaceBoardPinned(false)
+      }
+    },
+    [clearWorkspaceBoardHoverClose, clearWorkspaceBoardHoverOpen, setWorkspaceBoardPinned]
+  )
+
+  const handleWorkspaceHeaderPointerEnter = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      if (event.pointerType !== 'mouse') {
+        return
+      }
+      clearWorkspaceBoardHoverClose()
+      if (workspaceBoardOpen) {
+        return
+      }
+      clearWorkspaceBoardHoverOpen()
+      workspaceBoardHoverOpenTimerRef.current = window.setTimeout(() => {
+        workspaceBoardHoverOpenTimerRef.current = null
+        setWorkspaceBoardOpen(true)
+      }, WORKSPACE_BOARD_HOVER_OPEN_DELAY_MS)
+    },
+    [clearWorkspaceBoardHoverClose, clearWorkspaceBoardHoverOpen, workspaceBoardOpen]
+  )
+
+  const handleWorkspaceHeaderPointerLeave = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      clearWorkspaceBoardHoverOpen()
+      if (event.pointerType !== 'mouse' || workspaceBoardPinnedOpenRef.current) {
+        return
+      }
+      clearWorkspaceBoardHoverClose()
+      workspaceBoardHoverCloseTimerRef.current = window.setTimeout(() => {
+        workspaceBoardHoverCloseTimerRef.current = null
+        if (workspaceBoardPinnedOpenRef.current) {
+          return
+        }
+        setWorkspaceBoardOpen(false)
+      }, WORKSPACE_BOARD_HOVER_CLOSE_DELAY_MS)
+    },
+    [clearWorkspaceBoardHoverClose, clearWorkspaceBoardHoverOpen]
+  )
+
+  const handleWorkspaceBoardPointerEnter = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      if (event.pointerType !== 'mouse') {
+        return
+      }
+      clearWorkspaceBoardHoverOpen()
+      clearWorkspaceBoardHoverClose()
+      setWorkspaceBoardPinned(true)
+      setWorkspaceBoardOpen(true)
+    },
+    [clearWorkspaceBoardHoverClose, clearWorkspaceBoardHoverOpen, setWorkspaceBoardPinned]
+  )
+
   return (
     <>
-      <div className="flex h-8 items-center justify-between px-2 gap-2">
+      <div
+        className="flex h-8 items-center justify-between px-2 gap-2"
+        onPointerEnter={handleWorkspaceHeaderPointerEnter}
+        onPointerLeave={handleWorkspaceHeaderPointerLeave}
+      >
         <div className="flex min-w-0 items-center gap-1">
           <span className="px-2 text-[10.5px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/80 select-none">
             Workspaces
           </span>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon-xs"
-                className="text-muted-foreground"
-                aria-label="Workspace board"
-                aria-pressed={workspaceBoardOpen}
-                onClick={() => setWorkspaceBoardOpen((open) => !open)}
-              >
-                <Kanban className="size-3.5" strokeWidth={2.25} />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent side="bottom" sideOffset={6}>
-              Workspace board
-            </TooltipContent>
-          </Tooltip>
         </div>
         <div className="flex items-center gap-1.5 shrink-0">
           <SidebarFilter />
@@ -208,7 +294,11 @@ const SidebarHeader = React.memo(function SidebarHeader() {
           </Tooltip>
         </div>
       </div>
-      <WorkspaceKanbanDrawer open={workspaceBoardOpen} onOpenChange={setWorkspaceBoardOpen} />
+      <WorkspaceKanbanDrawer
+        open={workspaceBoardOpen}
+        onOpenChange={handleWorkspaceBoardOpenChange}
+        onPointerEnter={handleWorkspaceBoardPointerEnter}
+      />
     </>
   )
 })

--- a/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.tsx
@@ -28,6 +28,7 @@ import { makeWorkspaceStatusId } from '../../../../shared/workspace-statuses'
 type WorkspaceKanbanDrawerProps = {
   open: boolean
   onOpenChange: (open: boolean) => void
+  onPointerEnter?: React.PointerEventHandler<HTMLDivElement>
 }
 
 function sortBoardWorktrees(a: Worktree, b: Worktree): number {
@@ -36,7 +37,8 @@ function sortBoardWorktrees(a: Worktree, b: Worktree): number {
 
 export default function WorkspaceKanbanDrawer({
   open,
-  onOpenChange
+  onOpenChange,
+  onPointerEnter
 }: WorkspaceKanbanDrawerProps): React.JSX.Element {
   const allWorktrees = useAllWorktrees()
   const repoMap = useRepoMap()
@@ -287,6 +289,7 @@ export default function WorkspaceKanbanDrawer({
           } as React.CSSProperties
         }
         data-workspace-board-compact={workspaceBoardCompact ? 'true' : 'false'}
+        onPointerEnter={onPointerEnter}
         onOpenAutoFocus={(event) => {
           // Why: Radix focuses the first toolbar button on open, which opens
           // its tooltip without hover and makes the drawer feel noisy.


### PR DESCRIPTION
Summary
- Open the workspace board from hovering the Workspaces header after a 50ms delay.
- Cancel quick pointer passes and keep the board open once the pointer enters the drawer until close, outside click, or workspace activation.
- Remove the manual Workspace Board header button so there is no hover/click race.

Perf/correctness review
- Timer refs are cleared on leave, open-change, and unmount; no polling, global listeners, or subprocess work added.
- Persistent drawer state now lives in a ref only, avoiding button-only render state.

Verification
- pnpm typecheck
- pnpm lint
- pnpm test src/renderer/src/store/slices/ui.test.ts src/renderer/src/components/sidebar/worktree-list-groups.test.ts
- git diff --check
- Electron CDP: button absent, rapid hover stayed closed, delayed hover opened, entering the board kept it open, clicking right-side content closed it, console errors stayed at 0.