### PR TITLE
Fix skipped repo import visibility

### DIFF
--- a/src/renderer/src/components/sidebar/AddRepoDialog.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoDialog.tsx
@@ -21,6 +21,7 @@ import { getDefaultCloneParent } from './clone-defaults'
 import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
 import { isGitRepoKind } from '../../../../shared/repo-kind'
 import type { Repo, Worktree } from '../../../../shared/types'
+import { finalizeImportedRepoAfterSkip } from './add-repo-skip-finalization'
 
 const AddRepoDialog = React.memo(function AddRepoDialog() {
   const activeModal = useAppStore((s) => s.activeModal)
@@ -299,14 +300,26 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
     openSettingsPage()
   }, [closeModal, openSettingsTarget, openSettingsPage, repoId])
 
+  const finishImportedRepoWithoutOpening = useCallback(async () => {
+    const importedRepoId = repoId
+    closeModal()
+    resetState()
+    if (!importedRepoId) {
+      return
+    }
+
+    await fetchWorktrees(importedRepoId)
+    const state = useAppStore.getState()
+    finalizeImportedRepoAfterSkip(state, importedRepoId)
+  }, [closeModal, fetchWorktrees, repoId, resetState])
+
   // Why: handleBack reuses resetState which already aborts clones and resets all fields.
   const handleBack = resetState
 
   const handleSkip = useCallback(() => {
     track('add_repo_setup_step_action', { action: 'skip' })
-    closeModal()
-    resetState()
-  }, [closeModal, resetState])
+    void finishImportedRepoWithoutOpening()
+  }, [finishImportedRepoWithoutOpening])
 
   // Why: only the Setup step's "Add another project" back arrow counts as a
   // funnel event — the in-flight Back arrows on clone/remote/create are not
@@ -328,6 +341,8 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
           // on the Setup step are funnel-equivalent to Skip.
           if (step === 'setup') {
             track('add_repo_setup_step_action', { action: 'skip' })
+            void finishImportedRepoWithoutOpening()
+            return
           }
           closeModal()
           resetState()

--- a/src/renderer/src/components/sidebar/add-repo-skip-finalization.test.ts
+++ b/src/renderer/src/components/sidebar/add-repo-skip-finalization.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { Worktree } from '../../../../shared/types'
+import {
+  finalizeImportedRepoAfterSkip,
+  type AddRepoSkipFinalizationState
+} from './add-repo-skip-finalization'
+
+function makeWorktree(overrides: Partial<Worktree> & { id: string; repoId: string }): Worktree {
+  return {
+    path: `/tmp/${overrides.id}`,
+    head: 'abc123',
+    branch: 'refs/heads/feature',
+    isBare: false,
+    isMainWorktree: false,
+    displayName: overrides.id,
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    linkedGitLabMR: null,
+    linkedGitLabIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0,
+    ...overrides
+  }
+}
+
+function makeState(overrides: Partial<AddRepoSkipFinalizationState>): AddRepoSkipFinalizationState {
+  return {
+    activeRepoId: null,
+    filterRepoIds: [],
+    showActiveOnly: false,
+    hideDefaultBranchWorkspace: false,
+    worktreesByRepo: {},
+    setActiveRepo: vi.fn(),
+    setFilterRepoIds: vi.fn(),
+    setShowActiveOnly: vi.fn(),
+    setHideDefaultBranchWorkspace: vi.fn(),
+    ...overrides
+  }
+}
+
+describe('finalizeImportedRepoAfterSkip', () => {
+  it('keeps skipped imported worktrees visible without activating a worktree', () => {
+    const state = makeState({
+      activeRepoId: 'repo-old',
+      filterRepoIds: ['repo-old'],
+      showActiveOnly: true,
+      hideDefaultBranchWorkspace: false,
+      worktreesByRepo: {
+        'repo-new': [makeWorktree({ id: 'repo-new::/repo/feature', repoId: 'repo-new' })]
+      }
+    })
+
+    finalizeImportedRepoAfterSkip(state, 'repo-new')
+
+    expect(state.setActiveRepo).toHaveBeenCalledWith('repo-new')
+    expect(state.setFilterRepoIds).toHaveBeenCalledWith([])
+    expect(state.setShowActiveOnly).toHaveBeenCalledWith(false)
+    expect(state.setHideDefaultBranchWorkspace).not.toHaveBeenCalled()
+  })
+
+  it('clears default-branch hiding when it would hide every imported worktree', () => {
+    const state = makeState({
+      hideDefaultBranchWorkspace: true,
+      worktreesByRepo: {
+        'repo-new': [
+          makeWorktree({
+            id: 'repo-new::/repo/main',
+            repoId: 'repo-new',
+            isMainWorktree: true,
+            branch: 'refs/heads/main'
+          })
+        ]
+      }
+    })
+
+    finalizeImportedRepoAfterSkip(state, 'repo-new')
+
+    expect(state.setHideDefaultBranchWorkspace).toHaveBeenCalledWith(false)
+  })
+
+  it('does nothing when the imported repo has no discovered worktrees yet', () => {
+    const state = makeState({
+      activeRepoId: 'repo-old',
+      filterRepoIds: ['repo-old'],
+      showActiveOnly: true,
+      hideDefaultBranchWorkspace: true,
+      worktreesByRepo: { 'repo-new': [] }
+    })
+
+    finalizeImportedRepoAfterSkip(state, 'repo-new')
+
+    expect(state.setActiveRepo).not.toHaveBeenCalled()
+    expect(state.setFilterRepoIds).not.toHaveBeenCalled()
+    expect(state.setShowActiveOnly).not.toHaveBeenCalled()
+    expect(state.setHideDefaultBranchWorkspace).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/sidebar/add-repo-skip-finalization.ts
+++ b/src/renderer/src/components/sidebar/add-repo-skip-finalization.ts
@@ -1,0 +1,42 @@
+import type { Worktree } from '../../../../shared/types'
+import { isDefaultBranchWorkspace } from './visible-worktrees'
+
+export type AddRepoSkipFinalizationState = {
+  activeRepoId: string | null
+  filterRepoIds: string[]
+  showActiveOnly: boolean
+  hideDefaultBranchWorkspace: boolean
+  worktreesByRepo: Record<string, Worktree[]>
+  setActiveRepo: (repoId: string | null) => void
+  setFilterRepoIds: (repoIds: string[]) => void
+  setShowActiveOnly: (value: boolean) => void
+  setHideDefaultBranchWorkspace: (value: boolean) => void
+}
+
+export function finalizeImportedRepoAfterSkip(
+  state: AddRepoSkipFinalizationState,
+  importedRepoId: string
+): void {
+  const importedWorktrees = state.worktreesByRepo[importedRepoId] ?? []
+  if (importedWorktrees.length === 0) {
+    return
+  }
+
+  // Why: Skip means "do not open or create a worktree", not "hide the
+  // imported project behind sidebar filters so it looks like nothing landed."
+  if (state.activeRepoId !== importedRepoId) {
+    state.setActiveRepo(importedRepoId)
+  }
+  if (state.filterRepoIds.length > 0 && !state.filterRepoIds.includes(importedRepoId)) {
+    state.setFilterRepoIds([])
+  }
+  if (state.showActiveOnly) {
+    state.setShowActiveOnly(false)
+  }
+  if (
+    state.hideDefaultBranchWorkspace &&
+    importedWorktrees.every((worktree) => isDefaultBranchWorkspace(worktree))
+  ) {
+    state.setHideDefaultBranchWorkspace(false)
+  }
+}


### PR DESCRIPTION
## Summary
- finalize skipped repo imports by refreshing their worktrees and making the repo visible
- clear sidebar filters that would otherwise hide the imported worktree list
- add focused regression coverage for skip finalization

## Tests
- pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/add-repo-skip-finalization.test.ts
- pnpm run typecheck:web