### PR TITLE
fea: Add configurable external editor support for terminal file links

### DIFF
--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -75,6 +75,11 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     setupScriptLaunchMode: 'split-vertical',
     terminalScrollbackBytes: 10_000_000,
     openLinksInApp: false,
+    fileLinkOpenTarget: 'orca',
+    externalEditor: {
+      kind: 'none',
+      strategy: 'cli'
+    },
     rightSidebarOpenByDefault: true,
     sourceControlViewMode: 'list',
     showTitlebarAppName: true,

--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -62,6 +62,11 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     setupScriptLaunchMode: 'split-vertical',
     terminalScrollbackBytes: 10_000_000,
     openLinksInApp: false,
+    fileLinkOpenTarget: 'orca',
+    externalEditor: {
+      kind: 'none',
+      strategy: 'cli'
+    },
     rightSidebarOpenByDefault: true,
     sourceControlViewMode: 'list',
     showTitlebarAppName: true,

--- a/src/main/ipc/external-editor-file-links.test.ts
+++ b/src/main/ipc/external-editor-file-links.test.ts
@@ -1,0 +1,182 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { normalize, resolve } from 'node:path'
+
+const { execFileMock, handleMock, openExternalMock, resolveCliCommandMock, statMock } = vi.hoisted(
+  () => ({
+    execFileMock: vi.fn(
+      (
+        _command: string,
+        _args: string[],
+        _options: Record<string, unknown>,
+        callback: (error: Error | null, stdout: string, stderr: string) => void
+      ) => {
+        queueMicrotask(() => callback(null, '', ''))
+        return {}
+      }
+    ),
+    handleMock: vi.fn(),
+    openExternalMock: vi.fn(),
+    resolveCliCommandMock: vi.fn(),
+    statMock: vi.fn()
+  })
+)
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: handleMock
+  },
+  shell: {
+    openExternal: openExternalMock
+  }
+}))
+
+vi.mock('node:fs/promises', () => ({
+  stat: statMock
+}))
+
+vi.mock('node:child_process', () => ({
+  execFile: execFileMock
+}))
+
+vi.mock('../codex-cli/command', () => ({
+  resolveCliCommand: resolveCliCommandMock
+}))
+
+import { registerExternalEditorFileLinkHandler } from './external-editor-file-links'
+
+function getHandler(
+  store?: Parameters<typeof registerExternalEditorFileLinkHandler>[0]
+): (event: unknown, args: unknown) => Promise<boolean> {
+  registerExternalEditorFileLinkHandler(store)
+  const call = handleMock.mock.calls.find((c: unknown[]) => c[0] === 'shell:openExternalEditor')
+  if (!call) {
+    throw new Error('shell:openExternalEditor handler not registered')
+  }
+  return call[1] as (event: unknown, args: unknown) => Promise<boolean>
+}
+
+function createStore(
+  settings: Partial<{
+    fileLinkOpenTarget: 'orca' | 'external-editor'
+    externalEditor: {
+      kind: 'none' | 'vscode' | 'vscode-insiders' | 'cursor' | 'jetbrains-idea' | 'custom'
+      strategy: 'cli' | 'url'
+      command?: string
+      argsTemplate?: string[]
+      urlTemplate?: string
+    }
+  }> = {}
+): Parameters<typeof registerExternalEditorFileLinkHandler>[0] {
+  return {
+    getSettings: () =>
+      ({
+        fileLinkOpenTarget: 'external-editor',
+        externalEditor: { kind: 'vscode', strategy: 'cli' },
+        ...settings
+      }) as never
+  } as unknown as Parameters<typeof registerExternalEditorFileLinkHandler>[0]
+}
+
+describe('registerExternalEditorFileLinkHandler', () => {
+  beforeEach(() => {
+    handleMock.mockReset()
+    execFileMock.mockClear()
+    openExternalMock.mockReset()
+    resolveCliCommandMock.mockReset()
+    statMock.mockReset()
+    openExternalMock.mockResolvedValue(undefined)
+    resolveCliCommandMock.mockReturnValue('editor-cli')
+  })
+
+  it('opens configured CLI editors with execFile and separate argv entries', async () => {
+    statMock.mockResolvedValueOnce({ isFile: () => true })
+    const filePath = resolve('workspace/a file; rm -rf nope.ts')
+    const handler = getHandler(createStore())
+
+    await expect(handler({}, { filePath, line: 3, column: 4 })).resolves.toBe(true)
+
+    expect(resolveCliCommandMock).toHaveBeenCalledWith('code')
+    expect(execFileMock).toHaveBeenCalledWith(
+      'editor-cli',
+      ['-g', `${normalize(filePath)}:3:4`],
+      { windowsHide: true, timeout: 10_000 },
+      expect.any(Function)
+    )
+    expect(openExternalMock).not.toHaveBeenCalled()
+  })
+
+  it('ignores renderer-supplied launch targets and uses persisted settings', async () => {
+    statMock.mockResolvedValueOnce({ isFile: () => true })
+    const filePath = resolve('workspace/main.ts')
+    const handler = getHandler(createStore())
+
+    await expect(
+      handler({}, { filePath, line: 1, column: 1, kind: 'url', url: 'cursor://file/other' })
+    ).resolves.toBe(true)
+
+    expect(execFileMock).toHaveBeenCalledWith(
+      'editor-cli',
+      ['-g', `${normalize(filePath)}:1:1`],
+      { windowsHide: true, timeout: 10_000 },
+      expect.any(Function)
+    )
+    expect(openExternalMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects directories and missing local files', async () => {
+    statMock.mockResolvedValueOnce({ isFile: () => false })
+    const handler = getHandler(createStore())
+
+    await expect(handler({}, { filePath: resolve('workspace') })).resolves.toBe(false)
+
+    expect(execFileMock).not.toHaveBeenCalled()
+    expect(openExternalMock).not.toHaveBeenCalled()
+  })
+
+  it('opens allowlisted editor URL schemes', async () => {
+    statMock.mockResolvedValueOnce({ isFile: () => true })
+    const filePath = resolve('workspace/main.ts')
+    const handler = getHandler(createStore({ externalEditor: { kind: 'vscode', strategy: 'url' } }))
+
+    await expect(handler({}, { filePath, line: 9, column: 2 })).resolves.toBe(true)
+
+    expect(openExternalMock).toHaveBeenCalledWith(expect.stringMatching(/^vscode:\/\/file\//))
+    expect(execFileMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects custom URL templates with unapproved schemes', async () => {
+    statMock.mockResolvedValueOnce({ isFile: () => true })
+    const handler = getHandler(
+      createStore({
+        externalEditor: {
+          kind: 'custom',
+          strategy: 'url',
+          urlTemplate: 'https://example.com/{pathEncoded}'
+        }
+      })
+    )
+
+    await expect(handler({}, { filePath: resolve('workspace/main.ts') })).resolves.toBe(false)
+
+    expect(openExternalMock).not.toHaveBeenCalled()
+    expect(execFileMock).not.toHaveBeenCalled()
+  })
+
+  it('returns false when the configured editor launch fails so Orca can fall back', async () => {
+    statMock.mockResolvedValueOnce({ isFile: () => true })
+    execFileMock.mockImplementationOnce(
+      (
+        _command: string,
+        _args: string[],
+        _options: Record<string, unknown>,
+        callback: (error: Error | null, stdout: string, stderr: string) => void
+      ) => {
+        queueMicrotask(() => callback(new Error('missing editor'), '', ''))
+        return {}
+      }
+    )
+    const handler = getHandler(createStore())
+
+    await expect(handler({}, { filePath: resolve('workspace/main.ts') })).resolves.toBe(false)
+  })
+})

--- a/src/main/ipc/external-editor-file-links.ts
+++ b/src/main/ipc/external-editor-file-links.ts
@@ -1,0 +1,98 @@
+import { ipcMain, shell } from 'electron'
+import { execFile } from 'node:child_process'
+import { stat } from 'node:fs/promises'
+import { isAbsolute, normalize } from 'node:path'
+import { promisify } from 'node:util'
+import {
+  formatExternalEditorOpenTarget,
+  type ExternalEditorOpenRequest
+} from '../../shared/external-editor'
+import { resolveCliCommand } from '../codex-cli/command'
+import type { Store } from '../persistence'
+
+const execFileAsync = promisify(execFile)
+
+const ALLOWED_EXTERNAL_EDITOR_URL_SCHEMES = new Set([
+  'vscode:',
+  'vscode-insiders:',
+  'cursor:',
+  'windsurf:'
+])
+
+async function validateLocalFileTarget(pathValue: string): Promise<string | null> {
+  const normalizedPath = normalize(pathValue)
+  if (!isAbsolute(normalizedPath)) {
+    return null
+  }
+  try {
+    return (await stat(normalizedPath)).isFile() ? normalizedPath : null
+  } catch {
+    return null
+  }
+}
+
+function isExternalEditorOpenRequest(value: unknown): value is ExternalEditorOpenRequest {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false
+  }
+  const request = value as Record<string, unknown>
+  return (
+    typeof request.filePath === 'string' &&
+    (request.line === undefined || request.line === null || typeof request.line === 'number') &&
+    (request.column === undefined || request.column === null || typeof request.column === 'number')
+  )
+}
+
+async function openExternalEditorForFileLink(
+  store: Store | undefined,
+  request: ExternalEditorOpenRequest
+): Promise<boolean> {
+  const filePath = await validateLocalFileTarget(request.filePath)
+  if (!store || !filePath) {
+    return false
+  }
+
+  const settings = store.getSettings()
+  if (settings.fileLinkOpenTarget !== 'external-editor') {
+    return false
+  }
+
+  const target = formatExternalEditorOpenTarget(settings.externalEditor, {
+    ...request,
+    filePath
+  })
+  if (!target) {
+    return false
+  }
+
+  try {
+    if (target.kind === 'url') {
+      const parsed = new URL(target.url)
+      if (!ALLOWED_EXTERNAL_EDITOR_URL_SCHEMES.has(parsed.protocol)) {
+        return false
+      }
+      await shell.openExternal(parsed.toString())
+      return true
+    }
+
+    const command = resolveCliCommand(target.command)
+    await execFileAsync(command, target.args, {
+      windowsHide: true,
+      timeout: 10_000
+    })
+    return true
+  } catch {
+    return false
+  }
+}
+
+export function registerExternalEditorFileLinkHandler(store?: Store): void {
+  ipcMain.handle('shell:openExternalEditor', async (_event, args: unknown): Promise<boolean> => {
+    // Why: the renderer only supplies the file/position; main derives argv/URL
+    // from persisted settings so a compromised view cannot smuggle launch args.
+    if (!isExternalEditorOpenRequest(args)) {
+      return false
+    }
+    return openExternalEditorForFileLink(store, args)
+  })
+}

--- a/src/main/ipc/register-core-handlers.ts
+++ b/src/main/ipc/register-core-handlers.ts
@@ -144,7 +144,7 @@ export function registerCoreHandlers(
   // CookieMonster reads the imported cookies on first access.
   browserSessionRegistry.applyPendingCookieImport()
   browserSessionRegistry.restorePersistedUserAgent()
-  registerShellHandlers()
+  registerShellHandlers(store)
   registerPetHandlers()
   registerSessionHandlers(store)
   registerUIHandlers(store)

--- a/src/main/ipc/shell.test.ts
+++ b/src/main/ipc/shell.test.ts
@@ -43,6 +43,7 @@ vi.mock('node:fs/promises', () => ({
 }))
 
 vi.mock('node:child_process', () => ({
+  execFile: vi.fn(),
   spawn: spawnMock
 }))
 

--- a/src/main/ipc/shell.ts
+++ b/src/main/ipc/shell.ts
@@ -7,6 +7,8 @@ import type { ShellOpenLocalPathResult } from '../../shared/shell-open-types'
 import { MAX_REPO_ICON_UPLOAD_BYTES } from '../../shared/repo-icon'
 import { resolveCliCommand } from '../codex-cli/command'
 import { getSpawnArgsForWindows } from '../win32-utils'
+import type { Store } from '../persistence'
+import { registerExternalEditorFileLinkHandler } from './external-editor-file-links'
 
 export const EXTERNAL_EDITOR_CLI_COMMAND = 'code'
 
@@ -118,7 +120,7 @@ async function openInExternalEditor(
   }
 }
 
-export function registerShellHandlers(): void {
+export function registerShellHandlers(store?: Store): void {
   ipcMain.handle('shell:openPath', (_event, path: string) => {
     shell.showItemInFolder(path)
   })
@@ -133,6 +135,8 @@ export function registerShellHandlers(): void {
     (_event, path: string, command?: string): Promise<ShellOpenLocalPathResult> =>
       openInExternalEditor(path, command)
   )
+
+  registerExternalEditorFileLinkHandler(store)
 
   ipcMain.handle('shell:openUrl', (_event, rawUrl: string) => {
     let parsed: URL

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -1967,6 +1967,41 @@ describe('Store', () => {
     ])
   })
 
+  it('updateSettings normalizes and merges external editor settings', async () => {
+    const store = await createStore()
+    const first = store.updateSettings({
+      fileLinkOpenTarget: 'external-editor',
+      externalEditor: {
+        kind: 'custom',
+        strategy: 'cli',
+        command: 'my-editor',
+        argsTemplate: ['--goto', '{path}:{line}:{column}']
+      }
+    })
+    expect(first.fileLinkOpenTarget).toBe('external-editor')
+    expect(first.externalEditor).toMatchObject({
+      kind: 'custom',
+      strategy: 'cli',
+      command: 'my-editor',
+      argsTemplate: ['--goto', '{path}:{line}:{column}']
+    })
+
+    const second = store.updateSettings({
+      fileLinkOpenTarget: 'unsafe' as never,
+      externalEditor: {
+        strategy: 'url',
+        urlTemplate: 'vscode://file/{path}:{line}:{column}'
+      } as never
+    })
+    expect(second.fileLinkOpenTarget).toBe('orca')
+    expect(second.externalEditor).toMatchObject({
+      kind: 'custom',
+      strategy: 'url',
+      command: 'my-editor',
+      urlTemplate: 'vscode://file/{path}:{line}:{column}'
+    })
+  })
+
   it('updateSettings deep-merges and clamps notification custom sound volume', async () => {
     const store = await createStore()
     const updated = store.updateSettings({

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -330,6 +330,61 @@ function normalizeNotificationSettings(value: unknown): NotificationSettings {
   }
 }
 
+function normalizeFileLinkOpenTarget(value: unknown): GlobalSettings['fileLinkOpenTarget'] {
+  return value === 'external-editor' ? 'external-editor' : 'orca'
+}
+
+function normalizeExternalEditorSettings(
+  value: unknown,
+  base: GlobalSettings['externalEditor'] = { kind: 'none', strategy: 'cli' }
+): GlobalSettings['externalEditor'] {
+  const defaults: GlobalSettings['externalEditor'] = base
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return defaults
+  }
+
+  const raw = value as Record<string, unknown>
+  const kind =
+    raw.kind === 'vscode' ||
+    raw.kind === 'vscode-insiders' ||
+    raw.kind === 'cursor' ||
+    raw.kind === 'jetbrains-idea' ||
+    raw.kind === 'custom' ||
+    raw.kind === 'none'
+      ? raw.kind
+      : defaults.kind
+  const strategy =
+    raw.strategy === 'url' || raw.strategy === 'cli' ? raw.strategy : defaults.strategy
+  const settings: GlobalSettings['externalEditor'] = { ...defaults, kind, strategy }
+
+  if ('command' in raw) {
+    if (typeof raw.command === 'string') {
+      settings.command = raw.command
+    } else {
+      delete settings.command
+    }
+  }
+  if ('argsTemplate' in raw) {
+    if (
+      Array.isArray(raw.argsTemplate) &&
+      raw.argsTemplate.every((entry) => typeof entry === 'string')
+    ) {
+      settings.argsTemplate = raw.argsTemplate
+    } else {
+      delete settings.argsTemplate
+    }
+  }
+  if ('urlTemplate' in raw) {
+    if (typeof raw.urlTemplate === 'string') {
+      settings.urlTemplate = raw.urlTemplate
+    } else {
+      delete settings.urlTemplate
+    }
+  }
+
+  return settings
+}
+
 function normalizeAutomationRunWorkspaceDisplayName(value: string | null): string | null {
   const trimmed = value?.trim()
   return trimmed ? trimmed : null
@@ -1621,6 +1676,8 @@ export class Store {
             ),
             disabledTuiAgents: normalizeDisabledTuiAgents(parsed.settings?.disabledTuiAgents),
             openInApplications: normalizeOpenInApplications(parsed.settings?.openInApplications),
+            fileLinkOpenTarget: normalizeFileLinkOpenTarget(parsed.settings?.fileLinkOpenTarget),
+            externalEditor: normalizeExternalEditorSettings(parsed.settings?.externalEditor),
             notifications: normalizeNotificationSettings(parsed.settings?.notifications),
             sourceControlAi: migratedSourceControlAi,
             // Why: new builds read sourceControlAi, but rollback builds still
@@ -2729,6 +2786,15 @@ export class Store {
     if ('openInApplications' in updates) {
       sanitizedUpdates.openInApplications = normalizeOpenInApplications(updates.openInApplications)
     }
+    if ('fileLinkOpenTarget' in updates) {
+      sanitizedUpdates.fileLinkOpenTarget = normalizeFileLinkOpenTarget(updates.fileLinkOpenTarget)
+    }
+    if ('externalEditor' in updates) {
+      sanitizedUpdates.externalEditor = normalizeExternalEditorSettings(
+        updates.externalEditor,
+        this.state.settings.externalEditor
+      )
+    }
     if ('terminalShortcutPolicy' in updates) {
       sanitizedUpdates.terminalShortcutPolicy = normalizeTerminalShortcutPolicy(
         updates.terminalShortcutPolicy
@@ -2774,6 +2840,10 @@ export class Store {
       notifications: normalizeNotificationSettings({
         ...this.state.settings.notifications,
         ...sanitizedUpdates.notifications
+      }),
+      externalEditor: normalizeExternalEditorSettings({
+        ...this.state.settings.externalEditor,
+        ...sanitizedUpdates.externalEditor
       }),
       ...(mergedTelemetry !== undefined ? { telemetry: mergedTelemetry } : {})
     }

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -8,6 +8,7 @@ import type {
   HostedReviewInfo
 } from '../shared/hosted-review'
 import type { AppIdentity } from '../shared/app-identity'
+import type { ExternalEditorOpenRequest } from '../shared/external-editor'
 import type {
   BaseRefDefaultResult,
   BaseRefSearchResult,
@@ -1402,6 +1403,7 @@ export type PreloadApi = {
     openPath: (path: string) => Promise<void>
     openInFileManager: (path: string) => Promise<ShellOpenLocalPathResult>
     openInExternalEditor: (path: string, command?: string) => Promise<ShellOpenLocalPathResult>
+    openExternalEditor: (args: ExternalEditorOpenRequest) => Promise<boolean>
     openUrl: (url: string) => Promise<void>
     openFilePath: (path: string) => Promise<void>
     openFileUri: (uri: string) => Promise<void>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -41,6 +41,7 @@ import type {
 } from '../shared/types'
 import type { GitHistoryOptions, GitHistoryResult } from '../shared/git-history'
 import type { ShellOpenLocalPathResult } from '../shared/shell-open-types'
+import type { ExternalEditorOpenRequest } from '../shared/external-editor'
 import type { SkillDiscoveryResult } from '../shared/skills'
 import type {
   RuntimeBrowserDriverState,
@@ -1620,6 +1621,9 @@ const api = {
 
     openInExternalEditor: (path: string, command?: string): Promise<ShellOpenLocalPathResult> =>
       ipcRenderer.invoke('shell:openInExternalEditor', path, command),
+
+    openExternalEditor: (args: ExternalEditorOpenRequest): Promise<boolean> =>
+      ipcRenderer.invoke('shell:openExternalEditor', args),
 
     openUrl: (url: string): Promise<void> => ipcRenderer.invoke('shell:openUrl', url),
 

--- a/src/renderer/src/components/settings/GeneralPane.tsx
+++ b/src/renderer/src/components/settings/GeneralPane.tsx
@@ -2,7 +2,13 @@
    splitting individual settings into separate files would scatter related controls without a
    meaningful abstraction boundary. */
 import { useEffect, useRef, useState } from 'react'
-import type { GlobalSettings, OpenInApplication } from '../../../../shared/types'
+import type {
+  ExternalEditorKind,
+  ExternalEditorOpenStrategy,
+  ExternalEditorSettings,
+  GlobalSettings,
+  OpenInApplication
+} from '../../../../shared/types'
 import { Button } from '../ui/button'
 import { Input } from '../ui/input'
 import { Label } from '../ui/label'
@@ -22,6 +28,7 @@ import {
   GENERAL_CACHE_TIMER_SEARCH_ENTRIES,
   GENERAL_CLI_SEARCH_ENTRIES,
   GENERAL_EDITOR_SEARCH_ENTRIES,
+  GENERAL_FILE_LINK_SEARCH_ENTRIES,
   GENERAL_NAVIGATION_SEARCH_ENTRIES,
   GENERAL_PANE_SEARCH_ENTRIES,
   GENERAL_SUPPORT_SEARCH_ENTRIES,
@@ -38,6 +45,24 @@ import {
   SettingsSwitch,
   SettingsSwitchRow
 } from './SettingsFormControls'
+
+const EXTERNAL_EDITOR_LABELS: Record<ExternalEditorKind, string> = {
+  none: 'None',
+  vscode: 'VS Code',
+  'vscode-insiders': 'VS Code Insiders',
+  cursor: 'Cursor',
+  'jetbrains-idea': 'JetBrains IDEA',
+  custom: 'Custom'
+}
+
+const EXTERNAL_EDITOR_KINDS: ExternalEditorKind[] = [
+  'none',
+  'vscode',
+  'vscode-insiders',
+  'cursor',
+  'jetbrains-idea',
+  'custom'
+]
 
 function createOpenInApplication(): OpenInApplication {
   return {
@@ -71,6 +96,17 @@ export function getDesktopPlatformFromUserAgent(userAgent: string): 'darwin' | '
     return 'win32'
   }
   return 'other'
+}
+
+function formatArgsTemplateForInput(template: string[] | undefined): string {
+  return template?.join('\n') ?? ''
+}
+
+function parseArgsTemplateInput(value: string): string[] {
+  return value
+    .split(/\r?\n/)
+    .map((part) => part.trim())
+    .filter(Boolean)
 }
 
 export { GENERAL_PANE_SEARCH_ENTRIES }
@@ -182,6 +218,15 @@ export function GeneralPane({ settings, updateSettings }: GeneralPaneProps): Rea
   const applyOpenInApplicationsDraft = (applications: OpenInApplication[]): void => {
     setOpenInApplicationsDraft(applications)
     commitOpenInApplications(applications)
+  }
+
+  const updateExternalEditor = (updates: Partial<ExternalEditorSettings>): void => {
+    updateSettings({
+      externalEditor: {
+        ...settings.externalEditor,
+        ...updates
+      }
+    })
   }
 
   const handleBrowseWorkspace = async () => {
@@ -558,6 +603,161 @@ export function GeneralPane({ settings, updateSettings }: GeneralPaneProps): Rea
             }
           />
         </SearchableSetting>
+      </section>
+    ) : null,
+    matchesSettingsSearch(searchQuery, GENERAL_FILE_LINK_SEARCH_ENTRIES) ? (
+      <section key="file-links" className="space-y-4">
+        <SettingsSubsectionHeader
+          title="File Links"
+          description="Choose where terminal file paths open."
+        />
+
+        <SearchableSetting
+          title="Open File Links In"
+          description="Choose where terminal file links open."
+          keywords={['file links', 'terminal links', 'editor', 'external']}
+          className="flex flex-col items-start gap-3 py-2 sm:flex-row sm:items-center sm:justify-between"
+        >
+          <div className="min-w-0 flex-1 space-y-0.5">
+            <Label>Open File Links In</Label>
+            <p className="text-xs text-muted-foreground">
+              Terminal paths keep using Orca unless you opt into an external editor.
+            </p>
+          </div>
+          <SettingsSegmentedControl
+            ariaLabel="Open File Links In"
+            value={settings.fileLinkOpenTarget}
+            onChange={(option) => {
+              const fileLinkOpenTarget = option as GlobalSettings['fileLinkOpenTarget']
+              updateSettings({
+                fileLinkOpenTarget,
+                ...(fileLinkOpenTarget === 'external-editor' &&
+                settings.externalEditor.kind === 'none'
+                  ? { externalEditor: { ...settings.externalEditor, kind: 'vscode' } }
+                  : {})
+              })
+            }}
+            options={[
+              { value: 'orca', label: 'Orca' },
+              { value: 'external-editor', label: 'External' }
+            ]}
+          />
+        </SearchableSetting>
+
+        {settings.fileLinkOpenTarget === 'external-editor' ? (
+          <>
+            <SearchableSetting
+              title="External Editor"
+              description="Choose the external editor used for terminal file links."
+              keywords={['external editor', 'vscode', 'cursor', 'intellij', 'idea', 'custom']}
+              className="flex flex-col items-start gap-3 py-2 sm:flex-row sm:items-center sm:justify-between"
+            >
+              <div className="min-w-0 flex-1 space-y-0.5">
+                <Label>External Editor</Label>
+                <p className="text-xs text-muted-foreground">
+                  Uses the selected editor launcher or URL template.
+                </p>
+              </div>
+              <Select
+                value={settings.externalEditor.kind}
+                onValueChange={(value) =>
+                  updateExternalEditor({ kind: value as ExternalEditorKind })
+                }
+              >
+                <SelectTrigger size="sm" className="h-8 w-[190px] text-xs">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {EXTERNAL_EDITOR_KINDS.map((kind) => (
+                    <SelectItem key={kind} value={kind}>
+                      {EXTERNAL_EDITOR_LABELS[kind]}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </SearchableSetting>
+
+            <SearchableSetting
+              title="Open Strategy"
+              description="Choose whether Orca launches an editor command or opens an editor URL."
+              keywords={['external editor', 'cli', 'url', 'launcher']}
+              className="flex flex-col items-start gap-3 py-2 sm:flex-row sm:items-center sm:justify-between"
+            >
+              <div className="min-w-0 flex-1 space-y-0.5">
+                <Label>Open Strategy</Label>
+                <p className="text-xs text-muted-foreground">CLI launchers are used by default.</p>
+              </div>
+              <SettingsSegmentedControl
+                ariaLabel="Open Strategy"
+                value={settings.externalEditor.strategy}
+                onChange={(option) =>
+                  updateExternalEditor({ strategy: option as ExternalEditorOpenStrategy })
+                }
+                options={[
+                  { value: 'cli', label: 'CLI' },
+                  { value: 'url', label: 'URL' }
+                ]}
+              />
+            </SearchableSetting>
+
+            {settings.externalEditor.kind === 'custom' &&
+            settings.externalEditor.strategy === 'cli' ? (
+              <>
+                <SearchableSetting
+                  title="Custom Command"
+                  description="Command to run when opening terminal file links."
+                  keywords={['custom', 'command', 'external editor']}
+                  className="space-y-2 py-2"
+                >
+                  <Label>Custom Command</Label>
+                  <Input
+                    value={settings.externalEditor.command ?? ''}
+                    onChange={(event) => updateExternalEditor({ command: event.target.value })}
+                    placeholder="my-editor"
+                    className="max-w-md text-xs"
+                  />
+                </SearchableSetting>
+
+                <SearchableSetting
+                  title="Custom Args Template"
+                  description="One argument per line. Supports {path}, {pathEncoded}, {line}, and {column}."
+                  keywords={['custom', 'args', 'template', 'path', 'line', 'column']}
+                  className="space-y-2 py-2"
+                >
+                  <Label>Custom Args Template</Label>
+                  <textarea
+                    value={formatArgsTemplateForInput(settings.externalEditor.argsTemplate)}
+                    onChange={(event) =>
+                      updateExternalEditor({
+                        argsTemplate: parseArgsTemplateInput(event.target.value)
+                      })
+                    }
+                    placeholder={'-g\n{path}:{line}:{column}'}
+                    className="min-h-20 w-full max-w-md rounded-md border border-input bg-background px-3 py-2 text-xs shadow-sm outline-none transition-colors placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
+                  />
+                </SearchableSetting>
+              </>
+            ) : null}
+
+            {settings.externalEditor.kind === 'custom' &&
+            settings.externalEditor.strategy === 'url' ? (
+              <SearchableSetting
+                title="Custom URL Template"
+                description="Supports {path}, {pathEncoded}, {line}, and {column}."
+                keywords={['custom', 'url', 'template', 'path', 'line', 'column']}
+                className="space-y-2 py-2"
+              >
+                <Label>Custom URL Template</Label>
+                <Input
+                  value={settings.externalEditor.urlTemplate ?? ''}
+                  onChange={(event) => updateExternalEditor({ urlTemplate: event.target.value })}
+                  placeholder="vscode://file/{path}:{line}:{column}"
+                  className="max-w-xl text-xs"
+                />
+              </SearchableSetting>
+            ) : null}
+          </>
+        ) : null}
       </section>
     ) : null,
     matchesSettingsSearch(searchQuery, GENERAL_CLI_SEARCH_ENTRIES) ? (

--- a/src/renderer/src/components/settings/general-search.ts
+++ b/src/renderer/src/components/settings/general-search.ts
@@ -78,6 +78,32 @@ export const GENERAL_NAVIGATION_SEARCH_ENTRIES: SettingsSearchEntry[] = [
   }
 ]
 
+export const GENERAL_FILE_LINK_SEARCH_ENTRIES: SettingsSearchEntry[] = [
+  {
+    title: 'Open File Links In',
+    description: 'Choose where terminal file links open.',
+    keywords: [
+      'file links',
+      'terminal links',
+      'editor',
+      'external',
+      'vscode',
+      'cursor',
+      'jetbrains'
+    ]
+  },
+  {
+    title: 'External Editor',
+    description: 'Choose the external editor used for terminal file links.',
+    keywords: ['file links', 'external editor', 'vscode', 'cursor', 'intellij', 'idea', 'custom']
+  },
+  {
+    title: 'Custom Editor Templates',
+    description: 'Configure command arguments or URL templates for a custom editor.',
+    keywords: ['custom', 'command', 'args', 'template', 'url']
+  }
+]
+
 export const GENERAL_CLI_SEARCH_ENTRIES: SettingsSearchEntry[] = [
   {
     title: 'Shell command',
@@ -139,6 +165,7 @@ export const GENERAL_PANE_SEARCH_ENTRIES: SettingsSearchEntry[] = [
   ...GENERAL_WORKSPACE_SEARCH_ENTRIES,
   ...GENERAL_NAVIGATION_SEARCH_ENTRIES,
   ...GENERAL_EDITOR_SEARCH_ENTRIES,
+  ...GENERAL_FILE_LINK_SEARCH_ENTRIES,
   ...GENERAL_CLI_SEARCH_ENTRIES,
   ...GENERAL_CACHE_TIMER_SEARCH_ENTRIES,
   ...GENERAL_UPDATE_SEARCH_ENTRIES,

--- a/src/renderer/src/components/terminal-pane/terminal-file-open-routing.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-file-open-routing.ts
@@ -33,6 +33,23 @@ function openHtmlFileInBrowser(filePath: string, worktreeId: string): void {
   store.createBrowserTab(worktreeId, fileUrl, { title, activate: true })
 }
 
+async function tryOpenFileInExternalEditor(
+  filePath: string,
+  line: number | null,
+  column: number | null
+): Promise<boolean> {
+  const settings = useAppStore.getState().settings
+  if (settings?.fileLinkOpenTarget !== 'external-editor') {
+    return false
+  }
+
+  try {
+    return await window.api.shell.openExternalEditor({ filePath, line, column })
+  } catch {
+    return false
+  }
+}
+
 export function getTerminalFileContext(
   worktreeId: string,
   worktreePath: string,
@@ -96,6 +113,18 @@ export function openDetectedFilePath(
       !isRemoteRuntimeFileOperation(fileContext, filePath)
     ) {
       openHtmlFileInBrowser(filePath, worktreeId)
+      return
+    }
+
+    if (
+      !fileContext.connectionId &&
+      !isRemoteRuntimeFileOperation(fileContext, filePath) &&
+      (await tryOpenFileInExternalEditor(filePath, line, column))
+    ) {
+      return
+    }
+
+    if (requestId !== latestOpenDetectedFilePathRequestId) {
       return
     }
 

--- a/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
@@ -24,6 +24,7 @@ import { clearRuntimeCompatibilityCacheForTests } from '@/runtime/runtime-rpc-cl
 const openUrlMock = vi.fn()
 const openFileUriMock = vi.fn()
 const openFilePathMock = vi.fn()
+const openExternalEditorMock = vi.fn()
 const openFileMock = vi.fn()
 const authorizeExternalPathMock = vi.fn()
 const statMock = vi.fn().mockResolvedValue({ isDirectory: false })
@@ -36,7 +37,11 @@ const setPendingEditorRevealMock = vi.fn()
 const deps = { worktreeId: 'wt-1', worktreePath: '/tmp' }
 const storeState = {
   settings: undefined as
-    | { openLinksInApp?: boolean; activeRuntimeEnvironmentId?: string | null }
+    | {
+        openLinksInApp?: boolean
+        activeRuntimeEnvironmentId?: string | null
+        fileLinkOpenTarget?: 'orca' | 'external-editor'
+      }
     | undefined,
   setActiveWorktree: setActiveWorktreeMock,
   createBrowserTab: createBrowserTabMock,
@@ -90,6 +95,8 @@ async function flushDoubleRaf(): Promise<void> {
 beforeEach(() => {
   clearRuntimeCompatibilityCacheForTests()
   vi.clearAllMocks()
+  openExternalEditorMock.mockReset()
+  openExternalEditorMock.mockResolvedValue(false)
   runtimeEnvironmentTransportCallMock.mockReset()
   runtimeEnvironmentTransportCallMock.mockImplementation((args: RuntimeEnvironmentCallRequest) => {
     return createCompatibleRuntimeStatusResponseIfNeeded(args) ?? runtimeEnvironmentCallMock(args)
@@ -104,6 +111,7 @@ beforeEach(() => {
         openUrl: openUrlMock,
         openFileUri: openFileUriMock,
         openFilePath: openFilePathMock,
+        openExternalEditor: openExternalEditorMock,
         pathExists: vi.fn().mockResolvedValue(true)
       },
       fs: {
@@ -394,9 +402,53 @@ describe('handleOscLink', () => {
     )
   })
 
+  it('opens local terminal file links in the configured external editor', async () => {
+    setPlatform('Macintosh')
+    storeState.settings = { fileLinkOpenTarget: 'external-editor' }
+    openExternalEditorMock.mockResolvedValueOnce(true)
+
+    openDetectedFilePath('/tmp/src/main.ts', 42, 7, deps)
+    await flushAsyncWork()
+
+    expect(openExternalEditorMock).toHaveBeenCalledWith({
+      filePath: '/tmp/src/main.ts',
+      line: 42,
+      column: 7
+    })
+    expect(openFileMock).not.toHaveBeenCalled()
+  })
+
+  it('falls back to Orca when external editor launch fails', async () => {
+    setPlatform('Macintosh')
+    storeState.settings = { fileLinkOpenTarget: 'external-editor' }
+    openExternalEditorMock.mockResolvedValueOnce(false)
+
+    openDetectedFilePath('/tmp/src/main.ts', 42, null, deps)
+    await flushAsyncWork()
+    await flushDoubleRaf()
+
+    expect(openExternalEditorMock).toHaveBeenCalledWith({
+      filePath: '/tmp/src/main.ts',
+      line: 42,
+      column: null
+    })
+    expect(openFileMock).toHaveBeenCalledWith(
+      expect.objectContaining({ filePath: '/tmp/src/main.ts' })
+    )
+    expect(setPendingEditorRevealMock).toHaveBeenNthCalledWith(2, {
+      filePath: '/tmp/src/main.ts',
+      line: 42,
+      column: 1,
+      matchLength: 0
+    })
+  })
+
   it('stats remote-runtime file links through the active runtime environment', async () => {
     setPlatform('Macintosh')
-    storeState.settings = { activeRuntimeEnvironmentId: 'env-1' }
+    storeState.settings = {
+      activeRuntimeEnvironmentId: 'env-1',
+      fileLinkOpenTarget: 'external-editor'
+    }
     runtimeEnvironmentCallMock.mockResolvedValueOnce({
       id: 'rpc-1',
       ok: true,
@@ -409,6 +461,7 @@ describe('handleOscLink', () => {
 
     expect(authorizeExternalPathMock).not.toHaveBeenCalled()
     expect(statMock).not.toHaveBeenCalled()
+    expect(openExternalEditorMock).not.toHaveBeenCalled()
     await vi.waitFor(() => {
       expect(runtimeEnvironmentCallMock).toHaveBeenCalledWith({
         selector: 'env-1',
@@ -460,6 +513,7 @@ describe('handleOscLink', () => {
 
   it('opens SSH file links through Orca without local authorization', async () => {
     setPlatform('Macintosh')
+    storeState.settings = { fileLinkOpenTarget: 'external-editor' }
     vi.mocked(getConnectionId).mockReturnValue('ssh-1')
 
     openDetectedFilePath('/home/me/repo/src/main.ts', null, null, {
@@ -469,6 +523,7 @@ describe('handleOscLink', () => {
     await new Promise((resolve) => setTimeout(resolve, 0))
 
     expect(authorizeExternalPathMock).not.toHaveBeenCalled()
+    expect(openExternalEditorMock).not.toHaveBeenCalled()
     expect(statMock).toHaveBeenCalledWith({
       filePath: '/home/me/repo/src/main.ts',
       connectionId: 'ssh-1'

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -1833,6 +1833,7 @@ function createShellApi(): NonNullable<Partial<PreloadApi>['shell']> {
       Promise.resolve(window.open(path, '_blank', 'noopener,noreferrer') as never),
     openInFileManager: () => Promise.resolve(openResult),
     openInExternalEditor: () => Promise.resolve(openResult),
+    openExternalEditor: () => Promise.resolve(false),
     openUrl: (url) => Promise.resolve(window.open(url, '_blank', 'noopener,noreferrer') as never),
     openFilePath: () => Promise.resolve(),
     openFileUri: (uri) =>

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -213,6 +213,11 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     setupScriptLaunchMode: 'new-tab',
     terminalScrollbackBytes: 10_000_000,
     openLinksInApp: true,
+    fileLinkOpenTarget: 'orca',
+    externalEditor: {
+      kind: 'none',
+      strategy: 'cli'
+    },
     openInApplications: [],
     rightSidebarOpenByDefault: true,
     showGitIgnoredFiles: true,

--- a/src/shared/external-editor.test.ts
+++ b/src/shared/external-editor.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest'
+import { formatExternalEditorOpenTarget } from './external-editor'
+
+describe('formatExternalEditorOpenTarget', () => {
+  it('formats VS Code CLI targets with line and column', () => {
+    expect(
+      formatExternalEditorOpenTarget(
+        { kind: 'vscode', strategy: 'cli' },
+        { filePath: '/repo/src/main.ts', line: 12, column: 5 }
+      )
+    ).toEqual({
+      kind: 'cli',
+      command: 'code',
+      args: ['-g', '/repo/src/main.ts:12:5']
+    })
+  })
+
+  it('defaults missing line and column to one', () => {
+    expect(
+      formatExternalEditorOpenTarget(
+        { kind: 'vscode', strategy: 'cli' },
+        { filePath: '/repo/src/main.ts' }
+      )
+    ).toEqual({
+      kind: 'cli',
+      command: 'code',
+      args: ['-g', '/repo/src/main.ts:1:1']
+    })
+  })
+
+  it('normalizes invalid line and column values to one', () => {
+    expect(
+      formatExternalEditorOpenTarget(
+        { kind: 'vscode', strategy: 'cli' },
+        { filePath: '/repo/src/main.ts', line: 0, column: Number.NaN }
+      )
+    ).toEqual({
+      kind: 'cli',
+      command: 'code',
+      args: ['-g', '/repo/src/main.ts:1:1']
+    })
+  })
+
+  it('formats JetBrains CLI targets with line and column flags', () => {
+    expect(
+      formatExternalEditorOpenTarget(
+        { kind: 'jetbrains-idea', strategy: 'cli' },
+        { filePath: '/repo/src/main.ts', line: 7, column: 3 }
+      )
+    ).toEqual({
+      kind: 'cli',
+      command: 'idea',
+      args: ['--line', '7', '--column', '3', '/repo/src/main.ts']
+    })
+  })
+
+  it('keeps custom args as separate argv entries', () => {
+    expect(
+      formatExternalEditorOpenTarget(
+        {
+          kind: 'custom',
+          strategy: 'cli',
+          command: 'my-editor',
+          argsTemplate: ['--goto', '{path}:{line}:{column}']
+        },
+        { filePath: '/repo/a file; rm -rf nope.ts', line: 2, column: 4 }
+      )
+    ).toEqual({
+      kind: 'cli',
+      command: 'my-editor',
+      args: ['--goto', '/repo/a file; rm -rf nope.ts:2:4']
+    })
+  })
+
+  it('formats custom URL templates with pathEncoded', () => {
+    expect(
+      formatExternalEditorOpenTarget(
+        {
+          kind: 'custom',
+          strategy: 'url',
+          urlTemplate: 'vscode://file/{pathEncoded}:{line}:{column}'
+        },
+        { filePath: '/repo/a file.ts', line: 10, column: 9 }
+      )
+    ).toEqual({
+      kind: 'url',
+      url: 'vscode://file/%2Frepo%2Fa%20file.ts:10:9'
+    })
+  })
+
+  it('rejects unknown editor kinds', () => {
+    expect(
+      formatExternalEditorOpenTarget({ kind: 'zed', strategy: 'cli' } as never, {
+        filePath: '/repo/src/main.ts'
+      })
+    ).toBeNull()
+  })
+})

--- a/src/shared/external-editor.ts
+++ b/src/shared/external-editor.ts
@@ -1,0 +1,112 @@
+import type { ExternalEditorSettings } from './types'
+
+export type ExternalEditorOpenRequest = {
+  filePath: string
+  line?: number | null
+  column?: number | null
+}
+
+export type ExternalEditorOpenTarget =
+  | { kind: 'cli'; command: string; args: string[] }
+  | { kind: 'url'; url: string }
+
+type ExternalEditorPreset = {
+  command: string
+  argsTemplate: string[]
+  urlTemplate?: string
+}
+
+const CLI_GOTO_TEMPLATE = ['-g', '{path}:{line}:{column}']
+
+const PRESETS: Partial<Record<ExternalEditorSettings['kind'], ExternalEditorPreset>> = {
+  vscode: {
+    command: 'code',
+    argsTemplate: CLI_GOTO_TEMPLATE,
+    urlTemplate: 'vscode://file/{path}:{line}:{column}'
+  },
+  'vscode-insiders': {
+    command: 'code-insiders',
+    argsTemplate: CLI_GOTO_TEMPLATE,
+    urlTemplate: 'vscode-insiders://file/{path}:{line}:{column}'
+  },
+  cursor: {
+    command: 'cursor',
+    argsTemplate: CLI_GOTO_TEMPLATE,
+    urlTemplate: 'cursor://file/{path}:{line}:{column}'
+  },
+  'jetbrains-idea': {
+    command: 'idea',
+    argsTemplate: ['--line', '{line}', '--column', '{column}', '{path}']
+  }
+}
+
+function normalizeLocation(value: number | null | undefined): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 1) {
+    return 1
+  }
+  return Math.floor(value)
+}
+
+function formatTemplate(template: string, request: ExternalEditorOpenRequest): string {
+  const line = String(normalizeLocation(request.line))
+  const column = String(normalizeLocation(request.column))
+  return template
+    .replaceAll('{path}', request.filePath)
+    .replaceAll('{pathEncoded}', encodeURIComponent(request.filePath))
+    .replaceAll('{line}', line)
+    .replaceAll('{column}', column)
+}
+
+function formatArgs(template: string[], request: ExternalEditorOpenRequest): string[] {
+  return template.map((part) => formatTemplate(part, request))
+}
+
+export function formatExternalEditorOpenTarget(
+  settings: ExternalEditorSettings,
+  request: ExternalEditorOpenRequest
+): ExternalEditorOpenTarget | null {
+  if (settings.kind === 'none') {
+    return null
+  }
+
+  if (settings.kind === 'custom') {
+    if (settings.strategy === 'url') {
+      const template = settings.urlTemplate?.trim()
+      if (!template) {
+        return null
+      }
+      return { kind: 'url', url: formatTemplate(template, request) }
+    }
+
+    const command = settings.command?.trim()
+    if (!command) {
+      return null
+    }
+    return {
+      kind: 'cli',
+      command,
+      args: formatArgs(
+        settings.argsTemplate?.length ? settings.argsTemplate : CLI_GOTO_TEMPLATE,
+        request
+      )
+    }
+  }
+
+  const preset = PRESETS[settings.kind]
+  if (!preset) {
+    return null
+  }
+
+  if (settings.strategy === 'url') {
+    if (!preset.urlTemplate) {
+      return null
+    }
+    return { kind: 'url', url: formatTemplate(preset.urlTemplate, request) }
+  }
+
+  return {
+    kind: 'cli',
+    command: preset.command,
+    args: formatArgs(preset.argsTemplate, request)
+  }
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1628,6 +1628,24 @@ export type OpenInApplication = {
   command: string
 }
 
+export type ExternalEditorKind =
+  | 'none'
+  | 'vscode'
+  | 'vscode-insiders'
+  | 'cursor'
+  | 'jetbrains-idea'
+  | 'custom'
+
+export type ExternalEditorOpenStrategy = 'cli' | 'url'
+
+export type ExternalEditorSettings = {
+  kind: ExternalEditorKind
+  strategy: ExternalEditorOpenStrategy
+  command?: string
+  argsTemplate?: string[]
+  urlTemplate?: string
+}
+
 export type SourceControlViewMode = 'list' | 'tree'
 
 export type FloatingTerminalCwdRequest = {
@@ -1737,6 +1755,8 @@ export type GlobalSettings = {
    *  The setting stays opt-in so existing workflows continue to use the system browser
    *  until the user explicitly wants worktree-scoped in-app browsing. */
   openLinksInApp: boolean
+  fileLinkOpenTarget: 'orca' | 'external-editor'
+  externalEditor: ExternalEditorSettings
   /** Extra launcher rows for the worktree "Open in" submenu. VS Code is always shown first. */
   openInApplications?: OpenInApplication[]
   /** Deprecated: migration/backward-compat only. Use PersistedUIState.rightSidebarOpen. */


### PR DESCRIPTION
## Summary

This keeps Orca as the default file-link target, while letting users opt into opening detected terminal file links in an external editor.

- add shared external editor settings, defaults, and formatter presets for VS Code, VS Code Insiders, Cursor, JetBrains IDEA, and custom CLI/URL templates
- route terminal file-link opening through a main-process IPC handler that validates local files, allowlisted URL schemes, and launches CLI targets with execFile
- add Settings > General > File Links controls and preserve Orca fallback behavior for remote/SSH/runtime paths and failed external launches
