### PR TITLE
Fix Windows CJK terminal WebGL rendering

### DIFF
--- a/src/renderer/src/lib/pane-manager/terminal-complex-script.test.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-complex-script.test.ts
@@ -10,6 +10,15 @@ describe('terminalOutputPrefersDomRenderer', () => {
     expect(terminalOutputPrefersDomRenderer('Hebrew: שלום')).toBe(true)
   })
 
+  it('detects East Asian wide and fullwidth terminal output', () => {
+    expect(
+      terminalOutputPrefersDomRenderer('直接接请求本地 /api/mcp，带同一个 Bearer token，成功')
+    ).toBe(true)
+    expect(terminalOutputPrefersDomRenderer('Japanese: ターミナル')).toBe(true)
+    expect(terminalOutputPrefersDomRenderer('Korean: 터미널')).toBe(true)
+    expect(terminalOutputPrefersDomRenderer('Fullwidth: ＡＢＣ１２３')).toBe(true)
+  })
+
   it('detects glyph classes common in agent terminal UIs', () => {
     expect(terminalOutputPrefersDomRenderer('⠋ Working')).toBe(true)
     expect(terminalOutputPrefersDomRenderer('├─ file.ts')).toBe(true)

--- a/src/renderer/src/lib/pane-manager/terminal-complex-script.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-complex-script.ts
@@ -10,17 +10,29 @@ function isRendererRiskCodePoint(value: number): boolean {
   return (
     isInRange(value, 0x0590, 0x08ff) ||
     value === 0x200d ||
+    isInRange(value, 0x1100, 0x11ff) ||
     isInRange(value, 0x2500, 0x259f) ||
     isInRange(value, 0x25a0, 0x25ff) ||
     isInRange(value, 0x2800, 0x28ff) ||
+    // Why: xterm WebGL can leave stale atlas cells for East Asian wide glyphs
+    // on Windows; force browser text rendering before long CJK output paints.
+    isInRange(value, 0x2e80, 0x9fff) ||
+    isInRange(value, 0xa960, 0xa97f) ||
+    isInRange(value, 0xac00, 0xd7ff) ||
     isInRange(value, 0xd800, 0xdfff) ||
     isInRange(value, 0xe000, 0xf8ff) ||
+    isInRange(value, 0xf900, 0xfaff) ||
+    isInRange(value, 0xfe10, 0xfe1f) ||
+    isInRange(value, 0xfe30, 0xfe4f) ||
     isInRange(value, 0xfb1d, 0xfdff) ||
     isInRange(value, 0xfe00, 0xfe0f) ||
     isInRange(value, 0xfe70, 0xfeff) ||
+    isInRange(value, 0xff00, 0xffef) ||
     value === 0xfffd ||
     isInRange(value, 0x10ec0, 0x10eff) ||
     isInRange(value, 0x1e900, 0x1e95f) ||
+    isInRange(value, 0x20000, 0x2fa1f) ||
+    isInRange(value, 0x30000, 0x3134f) ||
     isInRange(value, 0xe0100, 0xe01ef)
   )
 }


### PR DESCRIPTION
Fixes #1907

## Summary
- Treat East Asian wide/fullwidth terminal output as renderer-risk output in the existing xterm WebGL auto-fallback detector.
- This makes default GPU auto mode dispose WebGL before long CJK chunks paint, so Windows uses the browser text path instead of stale WebGL atlas cells.
- Add regression coverage for the issue's Chinese output shape plus Japanese, Korean, and fullwidth samples.

## Ref-OSS alignment
- VS Code treats terminal GPU acceleration as `auto | on | off`, defaults to `auto`, falls back to DOM when WebGL cannot be loaded, disposes WebGL on context loss, and refits because WebGL and DOM cell dimensions differ.
- VS Code defaults terminal Unicode width handling to Unicode 11 and documents wide-character width issues as a Unicode-version concern.
- Wave exposes a WebGL/DOM terminal renderer switch and drops to DOM on WebGL context loss.
- Tabby activates Unicode 11 before terminal rendering, supports separate WebGL/non-WebGL frontends, and disables WebGL for a known incompatible renderer class.
- I did not find another app with this exact dynamic CJK-output-triggered fallback, but the PR aligns with the common model: WebGL is opportunistic, DOM is the compatibility path, and wide-glyph handling must be guarded before paint.

## Proof of fix
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/pane-manager/terminal-complex-script.test.ts src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts src/renderer/src/lib/pane-manager/pane-terminal-gpu-acceleration.test.ts` → 3 files / 21 tests passed.
- `pnpm exec tsgo --noEmit -p config/tsconfig.tc.web.json` → passed.
- Commit hook ran `oxlint` and `oxfmt --write` on the changed files successfully.
- GitHub checks are green: `verify`, `e2e / e2e`, and `track-community-pr` passed.