### PR TITLE
Add built-in LSP support

### DIFF
--- a/src/main/ipc/lsp.ts
+++ b/src/main/ipc/lsp.ts
@@ -1,0 +1,55 @@
+import { ipcMain } from 'electron'
+import type {
+  LspCompletionResult,
+  LspDocumentChange,
+  LspDocumentContext,
+  LspDocumentIdentity,
+  LspHover,
+  LspLocation,
+  LspRequestContext,
+  LspServerStatus
+} from '../../shared/lsp-types'
+import { lspService, type LspServiceStats } from '../lsp/lsp-service'
+
+export function registerLspHandlers(): void {
+  ipcMain.handle('lsp:getStatus', (_event, args: LspDocumentIdentity): Promise<LspServerStatus> => {
+    return lspService.getStatus(args)
+  })
+
+  ipcMain.handle(
+    'lsp:openDocument',
+    (_event, args: LspDocumentContext): Promise<LspServerStatus> => {
+      return lspService.openDocument(args)
+    }
+  )
+
+  ipcMain.handle('lsp:changeDocument', (_event, args: LspDocumentChange): Promise<void> => {
+    return lspService.changeDocument(args)
+  })
+
+  ipcMain.handle(
+    'lsp:closeDocument',
+    (_event, args: Omit<LspDocumentChange, 'content'>): Promise<void> => {
+      return lspService.closeDocument(args)
+    }
+  )
+
+  ipcMain.handle(
+    'lsp:completion',
+    (_event, args: LspRequestContext): Promise<LspCompletionResult | null> => {
+      return lspService.completion(args)
+    }
+  )
+
+  ipcMain.handle('lsp:hover', (_event, args: LspRequestContext): Promise<LspHover | null> => {
+    return lspService.hover(args)
+  })
+
+  ipcMain.handle('lsp:definition', (_event, args: LspRequestContext): Promise<LspLocation[]> => {
+    return lspService.definition(args)
+  })
+
+  ipcMain.handle('lsp:getStats', (): LspServiceStats => {
+    return lspService.getStats()
+  })
+}

--- a/src/main/ipc/register-core-handlers.test.ts
+++ b/src/main/ipc/register-core-handlers.test.ts
@@ -47,7 +47,8 @@ const {
   registerSpeechHandlersMock,
   registerSkillsHandlersMock,
   registerWorkspaceSpaceHandlersMock,
-  registerWorkspacePortHandlersMock
+  registerWorkspacePortHandlersMock,
+  registerLspHandlersMock
 } = vi.hoisted(() => ({
   registerCliHandlersMock: vi.fn(),
   registerPreflightHandlersMock: vi.fn(),
@@ -93,7 +94,8 @@ const {
   registerSpeechHandlersMock: vi.fn(),
   registerSkillsHandlersMock: vi.fn(),
   registerWorkspaceSpaceHandlersMock: vi.fn(),
-  registerWorkspacePortHandlersMock: vi.fn()
+  registerWorkspacePortHandlersMock: vi.fn(),
+  registerLspHandlersMock: vi.fn()
 }))
 
 vi.mock('./onboarding', () => ({
@@ -270,6 +272,10 @@ vi.mock('./hosted-review', () => ({
   registerHostedReviewHandlers: registerHostedReviewHandlersMock
 }))
 
+vi.mock('./lsp', () => ({
+  registerLspHandlers: registerLspHandlersMock
+}))
+
 import { registerCoreHandlers } from './register-core-handlers'
 
 describe('registerCoreHandlers', () => {
@@ -318,6 +324,7 @@ describe('registerCoreHandlers', () => {
     registerSkillsHandlersMock.mockReset()
     registerWorkspaceSpaceHandlersMock.mockReset()
     registerWorkspacePortHandlersMock.mockReset()
+    registerLspHandlersMock.mockReset()
   })
 
   it('passes the store through to handler registrars that need it', () => {
@@ -391,6 +398,7 @@ describe('registerCoreHandlers', () => {
     expect(registerBrowserHandlersMock).toHaveBeenCalled()
     expect(registerFilesystemWatcherHandlersMock).toHaveBeenCalled()
     expect(registerSpeechHandlersMock).toHaveBeenCalledWith(store)
+    expect(registerLspHandlersMock).toHaveBeenCalled()
   })
 
   it('only registers IPC handlers once but always updates web contents id', () => {
@@ -425,6 +433,7 @@ describe('registerCoreHandlers', () => {
     expect(registerCliHandlersMock).not.toHaveBeenCalled()
     expect(registerPreflightHandlersMock).not.toHaveBeenCalled()
     expect(registerBrowserHandlersMock).not.toHaveBeenCalled()
+    expect(registerLspHandlersMock).not.toHaveBeenCalled()
     // Why: ipcMain.handle throws on duplicate channel registration, so the
     // memory handler must not be wired up a second time on reactivation.
     expect(registerMemoryHandlersMock).not.toHaveBeenCalled()

--- a/src/main/ipc/register-core-handlers.ts
+++ b/src/main/ipc/register-core-handlers.ts
@@ -14,6 +14,7 @@ import { registerGitHubHandlers } from './github'
 import { registerGitLabHandlers } from './gitlab'
 import { registerHostedReviewHandlers } from './hosted-review'
 import { registerLinearHandlers } from './linear'
+import { registerLspHandlers } from './lsp'
 import { registerFeedbackHandlers } from './feedback'
 import { registerCrashReportingHandlers } from './crash-reporting'
 import { registerExportHandlers } from './export'
@@ -111,6 +112,7 @@ export function registerCoreHandlers(
   registerGitLabHandlers(store)
   registerHostedReviewHandlers(store, stats)
   registerLinearHandlers()
+  registerLspHandlers()
   registerFeedbackHandlers()
   if (crashReports) {
     registerCrashReportingHandlers(crashReports)

--- a/src/main/ipc/ssh.ts
+++ b/src/main/ipc/ssh.ts
@@ -92,6 +92,22 @@ export function getRegisteredSshState(targetId: string): SshConnectionState | un
 // (multiplexer, providers, abort controller, state machine). Eliminates the
 // scattered Maps/Sets that previously tracked this state independently.
 const activeSessions = new Map<string, SshRelaySession>()
+const activeMultiplexerReadyListeners = new Set<(connectionId: string) => void>()
+
+export function onActiveMultiplexerReady(listener: (connectionId: string) => void): () => void {
+  activeMultiplexerReadyListeners.add(listener)
+  return () => activeMultiplexerReadyListeners.delete(listener)
+}
+
+function notifyActiveMultiplexerReady(connectionId: string): void {
+  for (const listener of activeMultiplexerReadyListeners) {
+    try {
+      listener(connectionId)
+    } catch (error) {
+      console.warn(`[ssh] Active multiplexer ready listener failed for ${connectionId}:`, error)
+    }
+  }
+}
 
 function relayGracePeriodForTarget(target: SshTarget | null | undefined): number | undefined {
   return target?.relayGracePeriodSeconds
@@ -745,6 +761,122 @@ export function registerSshHandlers(
         reconnectAttempt: 0
       })
 
+      // Why: the relay exec channel can close independently of the SSH
+      // connection (e.g. --connect bridge exits, relay process crashes).
+      // When that happens, the mux is disposed but onStateChange never
+      // fires because the SSH connection is still alive. This callback
+      // triggers session.reconnect() using the live SSH connection.
+      // Set before establish() so the callback is in place if the relay
+      // dies during the deploy/connect sequence.
+      // Why: a wire-handshake mismatch (typed RelayVersionMismatchError) means
+      // the local client and remote daemon are at different code versions —
+      // no amount of backoff will reconcile them. Skip the relay-lost loop
+      // entirely and surface a terminal "please reconnect manually" error.
+      session.setOnTerminalRelayError((tid, err) => {
+        clearRelayLostBackoff(tid)
+        console.warn(
+          `[ssh] Terminal relay error for ${tid}: ${err.message}; skipping reconnect backoff.`
+        )
+        const win = getMainWindow()
+        if (win && !win.isDestroyed()) {
+          win.webContents.send('ssh:state-changed', {
+            targetId: tid,
+            state: {
+              targetId: tid,
+              status: 'error',
+              error: err.message,
+              reconnectAttempt: 0
+            }
+          })
+        }
+      })
+
+      session.setOnRelayLost((tid) => {
+        const s = activeSessions.get(tid)
+        if (!s) {
+          return
+        }
+        const c = connectionManager?.getConnection(tid)
+        if (!c) {
+          return
+        }
+        const t = sshStore?.getTarget(tid)
+
+        // Why: bounded exponential backoff. Without this, a remote-side bug
+        // that closes every fresh --connect channel turns into an infinite
+        // tight loop spawning relay deploys until the user force-quits.
+        const state = relayLostBackoff.get(tid) ?? {
+          attempts: 0,
+          lastAttemptStartedAt: 0,
+          pendingTimer: null
+        }
+        if (state.pendingTimer) {
+          // A retry is already scheduled — coalesce this burst.
+          return
+        }
+        if (state.attempts >= RELAY_LOST_MAX_ATTEMPTS) {
+          console.warn(
+            `[ssh] Relay channel for ${tid} kept dying across ${state.attempts} attempts; giving up. User must reconnect manually.`
+          )
+          relayLostBackoff.delete(tid)
+          // Why: surface the failure so the renderer can prompt the user.
+          // A still-live SSH connection with a dead relay is otherwise an
+          // invisible failure — typing in remote terminals just stops working.
+          const win = getMainWindow()
+          if (win && !win.isDestroyed()) {
+            win.webContents.send('ssh:state-changed', {
+              targetId: tid,
+              state: {
+                targetId: tid,
+                status: 'error',
+                error: 'Relay channel kept dropping. Please reconnect.',
+                reconnectAttempt: 0
+              }
+            })
+          }
+          return
+        }
+        const delay = Math.min(
+          RELAY_LOST_BASE_DELAY_MS * 2 ** state.attempts,
+          RELAY_LOST_MAX_DELAY_MS
+        )
+        state.attempts += 1
+        state.pendingTimer = setTimeout(() => {
+          state.pendingTimer = null
+          state.lastAttemptStartedAt = Date.now()
+          relayLostBackoff.set(tid, state)
+          const liveConn = connectionManager?.getConnection(tid)
+          if (!liveConn || !activeSessions.has(tid)) {
+            return
+          }
+          void s.reconnect(liveConn, relayGracePeriodForTarget(t))
+        }, delay)
+        relayLostBackoff.set(tid, state)
+        console.warn(
+          `[ssh] Relay channel for ${tid} lost; reconnect attempt ${state.attempts}/${RELAY_LOST_MAX_ATTEMPTS} in ${delay}ms`
+        )
+      })
+
+      // Why: fires after both establish() and reconnect() reach 'ready'.
+      // Re-creates persisted port forwards so they survive app restarts
+      // and network blips without manual re-configuration. We also clear
+      // the relay-lost backoff state so a subsequent genuine drop starts
+      // from a fresh attempt counter — but only if the session had a chance
+      // to stabilize, otherwise rapid `ready → lost → ready → lost` flaps
+      // would silently keep retrying forever.
+      session.setOnReady((tid) => {
+        const state = relayLostBackoff.get(tid)
+        if (state) {
+          const stabilized =
+            state.lastAttemptStartedAt === 0 ||
+            Date.now() - state.lastAttemptStartedAt >= RELAY_LOST_STABILIZED_MS
+          if (stabilized) {
+            relayLostBackoff.delete(tid)
+          }
+        }
+        void restorePortForwards(tid, getMainWindow)
+        notifyActiveMultiplexerReady(tid)
+      })
       await session.establish(conn, relayGracePeriodForTarget(target))
 
       // Why: we manually pushed `deploying-relay` above, so the renderer's

--- a/src/main/lsp/language-server-registry.test.ts
+++ b/src/main/lsp/language-server-registry.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { chmodSync, mkdtempSync, readFileSync, writeFileSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { delimiter, join } from 'path'
+import {
+  resetLanguageServerDiscoveryCache,
+  resolveLanguageServerCommand
+} from './language-server-registry'
+
+function createFakeCommand(
+  dir: string,
+  name: string,
+  exitCode = 0,
+  options: { counterPath?: string } = {}
+): string {
+  const isWindows = process.platform === 'win32'
+  const commandPath = join(dir, isWindows ? `${name}.cmd` : name)
+  writeFileSync(
+    commandPath,
+    isWindows
+      ? `@echo off\r\n${options.counterPath ? `>> "${options.counterPath}" echo x\r\n` : ''}exit /b ${exitCode}\r\n`
+      : `#!/bin/sh\n${options.counterPath ? `printf 'x\\n' >> "${options.counterPath}"\n` : ''}exit ${exitCode}\n`
+  )
+  if (!isWindows) {
+    chmodSync(commandPath, 0o755)
+  }
+  return commandPath
+}
+
+function readInvocationCount(path: string): number {
+  try {
+    return readFileSync(path, 'utf-8').split(/\r?\n/).filter(Boolean).length
+  } catch {
+    return 0
+  }
+}
+
+describe('language-server-registry', () => {
+  let originalPath: string | undefined
+  let dir: string
+
+  beforeEach(() => {
+    originalPath = process.env.PATH
+    dir = mkdtempSync(join(tmpdir(), 'orca-lsp-registry-'))
+    process.env.PATH = originalPath ? `${dir}${delimiter}${originalPath}` : dir
+    resetLanguageServerDiscoveryCache()
+  })
+
+  afterEach(() => {
+    process.env.PATH = originalPath
+    vi.restoreAllMocks()
+    resetLanguageServerDiscoveryCache()
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('discovers configured language servers from PATH', async () => {
+    const commandPath = createFakeCommand(dir, 'rust-analyzer')
+
+    await expect(resolveLanguageServerCommand('rust')).resolves.toEqual({
+      ok: true,
+      command: { command: commandPath, args: [] }
+    })
+  })
+
+  it('dedupes concurrent discovery probes for the same language', async () => {
+    const counterPath = join(dir, 'probe-count.txt')
+    const commandPath = createFakeCommand(dir, 'rust-analyzer', 0, { counterPath })
+
+    await expect(
+      Promise.all([resolveLanguageServerCommand('rust'), resolveLanguageServerCommand('rust')])
+    ).resolves.toEqual([
+      { ok: true, command: { command: commandPath, args: [] } },
+      { ok: true, command: { command: commandPath, args: [] } }
+    ])
+    expect(readInvocationCount(counterPath)).toBe(1)
+  })
+
+  it('rejects configured language servers that fail their startup probe', async () => {
+    createFakeCommand(dir, 'rust-analyzer', 1)
+
+    const result = await resolveLanguageServerCommand('rust')
+
+    expect(result.ok).toBe(false)
+    if (result.ok) {
+      throw new Error('expected rust-analyzer discovery to fail')
+    }
+    expect(result.reason).toContain('rust-analyzer')
+  })
+
+  it('rechecks missing language servers on the next retry', async () => {
+    const now = vi.spyOn(Date, 'now').mockReturnValue(1_000)
+    const missing = await resolveLanguageServerCommand('rust')
+    expect(missing.ok).toBe(false)
+
+    const commandPath = createFakeCommand(dir, 'rust-analyzer')
+
+    await expect(resolveLanguageServerCommand('rust')).resolves.toEqual(missing)
+
+    now.mockReturnValue(2_001)
+    await expect(resolveLanguageServerCommand('rust')).resolves.toEqual({
+      ok: true,
+      command: { command: commandPath, args: [] }
+    })
+  })
+
+  it('does not fall back to the legacy TypeScript language server', async () => {
+    createFakeCommand(dir, 'typescript-language-server')
+
+    const result = await resolveLanguageServerCommand('typescript')
+
+    expect(result.ok).toBe(false)
+    if (result.ok) {
+      throw new Error('expected TypeScript LSP discovery to fail')
+    }
+    expect(result.reason).not.toContain('typescript-language-server')
+  })
+})

--- a/src/main/lsp/language-server-registry.ts
+++ b/src/main/lsp/language-server-registry.ts
@@ -1,0 +1,186 @@
+import { execFile } from 'child_process'
+import { promisify } from 'util'
+import { getSpawnArgsForWindows } from '../win32-utils'
+
+const execFileAsync = promisify(execFile)
+
+export type LanguageServerCommand = {
+  command: string
+  args: string[]
+}
+
+type LanguageServerDiscoveryResult =
+  | { ok: true; command: LanguageServerCommand }
+  | { ok: false; reason: string }
+
+type LanguageServerCandidate = LanguageServerCommand & {
+  detectCommand?: string
+  probeArgs?: string[]
+  requiredHelpText?: string
+  unavailableReason?: string
+}
+
+const COMMAND_DISCOVERY_TTL_MS = 30_000
+const FAILED_COMMAND_DISCOVERY_TTL_MS = 1_000
+
+const LANGUAGE_SERVER_CANDIDATES: Record<string, LanguageServerCandidate[]> = {
+  rust: [{ command: 'rust-analyzer', args: [], probeArgs: ['--version'] }],
+  c: [{ command: 'clangd', args: [], probeArgs: ['--version'] }],
+  cpp: [{ command: 'clangd', args: [], probeArgs: ['--version'] }],
+  go: [{ command: 'gopls', args: [], probeArgs: ['version'] }],
+  python: [{ command: 'pyright-langserver', args: ['--stdio'], probeArgs: ['--version'] }],
+  typescript: [
+    {
+      command: 'tsgo',
+      args: ['--lsp'],
+      probeArgs: ['--help', '--all'],
+      requiredHelpText: '--lsp',
+      unavailableReason:
+        'native TypeScript Go is installed, but this build does not expose LSP mode'
+    }
+  ],
+  javascript: [
+    {
+      command: 'tsgo',
+      args: ['--lsp'],
+      probeArgs: ['--help', '--all'],
+      requiredHelpText: '--lsp',
+      unavailableReason:
+        'native TypeScript Go is installed, but this build does not expose LSP mode'
+    }
+  ]
+}
+
+type CachedDiscovery =
+  | { expiresAt: number; command: LanguageServerCommand }
+  | { expiresAt: number; reason: string }
+
+const discoveryCache = new Map<string, CachedDiscovery>()
+const discoveryInFlight = new Map<string, Promise<LanguageServerDiscoveryResult>>()
+
+function finderCommand(): { command: string; argsFor: (candidate: string) => string[] } {
+  if (process.platform === 'win32') {
+    return { command: 'where', argsFor: (candidate) => [candidate] }
+  }
+  return { command: 'which', argsFor: (candidate) => [candidate] }
+}
+
+async function findCommandPath(command: string): Promise<string | null> {
+  const finder = finderCommand()
+  try {
+    const { stdout } = await execFileAsync(finder.command, finder.argsFor(command), {
+      encoding: 'utf-8',
+      timeout: 2_000
+    })
+    return (
+      stdout
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .find(Boolean) ?? null
+    )
+  } catch {
+    return null
+  }
+}
+
+async function candidatePassesProbe(
+  candidate: LanguageServerCandidate,
+  commandPath: string
+): Promise<boolean> {
+  if (!candidate.probeArgs) {
+    return true
+  }
+  const { spawnCmd, spawnArgs } = getSpawnArgsForWindows(commandPath, candidate.probeArgs)
+  try {
+    const { stdout, stderr } = await execFileAsync(spawnCmd, spawnArgs, {
+      encoding: 'utf-8',
+      timeout: 3_000
+    })
+    if (!candidate.requiredHelpText) {
+      return true
+    }
+    return `${stdout}\n${stderr}`.includes(candidate.requiredHelpText)
+  } catch {
+    return false
+  }
+}
+
+export function supportedLspLanguages(): string[] {
+  return Object.keys(LANGUAGE_SERVER_CANDIDATES)
+}
+
+export function resetLanguageServerDiscoveryCache(): void {
+  discoveryCache.clear()
+  discoveryInFlight.clear()
+}
+
+async function discoverLanguageServerCommand(
+  cacheKey: string,
+  candidates: LanguageServerCandidate[]
+): Promise<LanguageServerDiscoveryResult> {
+  let installedButRejectedReason: string | null = null
+  for (const candidate of candidates) {
+    const detectCommand = candidate.detectCommand ?? candidate.command
+    const detectedCommandPath = await findCommandPath(detectCommand)
+    if (!detectedCommandPath) {
+      continue
+    }
+    const commandPath =
+      detectCommand === candidate.command
+        ? detectedCommandPath
+        : ((await findCommandPath(candidate.command)) ?? candidate.command)
+    if (!(await candidatePassesProbe(candidate, commandPath))) {
+      installedButRejectedReason =
+        candidate.unavailableReason ??
+        `${candidate.command} is installed but failed capability probing`
+      continue
+    }
+    const command = { command: commandPath, args: candidate.args }
+    discoveryCache.set(cacheKey, { expiresAt: Date.now() + COMMAND_DISCOVERY_TTL_MS, command })
+    return { ok: true, command }
+  }
+
+  const reason =
+    installedButRejectedReason ??
+    `install one of: ${candidates.map((candidate) => candidate.command).join(', ')}`
+  // Why: the renderer retries unavailable LSP activation after a short delay.
+  // Keep failed probes below that cooldown so installs are picked up quickly.
+  discoveryCache.set(cacheKey, { expiresAt: Date.now() + FAILED_COMMAND_DISCOVERY_TTL_MS, reason })
+  return { ok: false, reason }
+}
+
+export async function resolveLanguageServerCommand(
+  languageId: string
+): Promise<LanguageServerDiscoveryResult> {
+  const candidates = LANGUAGE_SERVER_CANDIDATES[languageId]
+  if (!candidates) {
+    return { ok: false, reason: `no built-in LSP server is configured for ${languageId}` }
+  }
+
+  const cacheKey = `${process.platform}:${process.env.PATH ?? ''}:${languageId}`
+  const cached = discoveryCache.get(cacheKey)
+  if (cached && cached.expiresAt > Date.now()) {
+    if ('command' in cached) {
+      return { ok: true, command: cached.command }
+    }
+    return { ok: false, reason: cached.reason }
+  }
+
+  const inFlight = discoveryInFlight.get(cacheKey)
+  if (inFlight) {
+    return inFlight
+  }
+
+  // Why: opening several same-language files can race before the TTL cache is
+  // populated. Share the probe so startup does not multiply `which`/`--version`
+  // subprocesses by visible panes.
+  const discovery = discoverLanguageServerCommand(cacheKey, candidates)
+  discoveryInFlight.set(cacheKey, discovery)
+  try {
+    return await discovery
+  } finally {
+    if (discoveryInFlight.get(cacheKey) === discovery) {
+      discoveryInFlight.delete(cacheKey)
+    }
+  }
+}

--- a/src/main/lsp/lsp-process-session.test.ts
+++ b/src/main/lsp/lsp-process-session.test.ts
@@ -1,0 +1,527 @@
+/* eslint-disable max-lines -- Why: these integration-style tests define small
+fake language servers inline so process lifecycle and JSON-RPC edge cases stay
+self-contained. */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { LspProcessSession } from './lsp-process-session'
+import type { LspDiagnostic } from '../../shared/lsp-types'
+
+const FAKE_LSP_SERVER = String.raw`
+const documents = new Map()
+let buffer = Buffer.alloc(0)
+
+function send(message) {
+  const body = Buffer.from(JSON.stringify(message), 'utf8')
+  process.stdout.write('Content-Length: ' + body.length + '\r\n\r\n')
+  process.stdout.write(body)
+}
+
+function diagnostics(uri) {
+  const text = documents.get(uri) || ''
+  send({
+    jsonrpc: '2.0',
+    method: 'textDocument/publishDiagnostics',
+    params: {
+      uri,
+      diagnostics: text.includes('bad')
+        ? [{
+            range: { start: { line: 0, character: 3 }, end: { line: 0, character: 6 } },
+            severity: 1,
+            source: 'fake-lsp',
+            message: 'bad symbol'
+          }]
+        : []
+    }
+  })
+}
+
+function handle(message) {
+  if (message.method === 'initialize') {
+    send({
+      jsonrpc: '2.0',
+      id: message.id,
+      result: {
+        capabilities: {
+          textDocumentSync: { openClose: true, change: 2 },
+          completionProvider: { triggerCharacters: ['.'] },
+          hoverProvider: true,
+          definitionProvider: true
+        }
+      }
+    })
+    return
+  }
+  if (message.method === 'shutdown') {
+    send({ jsonrpc: '2.0', id: message.id, result: null })
+    return
+  }
+  if (message.method === 'exit') {
+    process.exit(0)
+  }
+  if (message.method === 'textDocument/didOpen') {
+    const doc = message.params.textDocument
+    documents.set(doc.uri, doc.text)
+    diagnostics(doc.uri)
+    return
+  }
+  if (message.method === 'textDocument/didChange') {
+    const uri = message.params.textDocument.uri
+    const change = message.params.contentChanges[0]
+    documents.set(uri, change.text)
+    diagnostics(uri)
+    return
+  }
+  if (message.method === 'textDocument/didClose') {
+    documents.delete(message.params.textDocument.uri)
+    return
+  }
+  if (message.method === 'textDocument/completion') {
+    send({
+      jsonrpc: '2.0',
+      id: message.id,
+      result: { isIncomplete: false, items: [{ label: 'completionItem', kind: 3 }] }
+    })
+    return
+  }
+  if (message.method === 'textDocument/hover') {
+    send({
+      jsonrpc: '2.0',
+      id: message.id,
+      result: { contents: { kind: 'markdown', value: '**hovered**' } }
+    })
+    return
+  }
+  if (message.method === 'textDocument/definition') {
+    const uri = message.params.textDocument.uri
+    send({
+      jsonrpc: '2.0',
+      id: message.id,
+      result: {
+        uri,
+        range: { start: { line: 0, character: 0 }, end: { line: 0, character: 2 } }
+      }
+    })
+    return
+  }
+  if (message.id !== undefined) {
+    send({ jsonrpc: '2.0', id: message.id, result: null })
+  }
+}
+
+process.stdin.on('data', chunk => {
+  buffer = Buffer.concat([buffer, chunk])
+  while (true) {
+    const headerEnd = buffer.indexOf('\r\n\r\n')
+    if (headerEnd === -1) break
+    const header = buffer.subarray(0, headerEnd).toString('utf8')
+    const match = /Content-Length:\s*(\d+)/i.exec(header)
+    if (!match) {
+      buffer = buffer.subarray(headerEnd + 4)
+      continue
+    }
+    const length = Number(match[1])
+    const start = headerEnd + 4
+    const end = start + length
+    if (buffer.length < end) break
+    const message = JSON.parse(buffer.subarray(start, end).toString('utf8'))
+    buffer = buffer.subarray(end)
+    handle(message)
+  }
+})
+`
+
+const EXITING_LSP_SERVER = String.raw`
+let buffer = Buffer.alloc(0)
+
+function send(message) {
+  const body = Buffer.from(JSON.stringify(message), 'utf8')
+  process.stdout.write('Content-Length: ' + body.length + '\r\n\r\n')
+  process.stdout.write(body)
+}
+
+function handle(message) {
+  if (message.method === 'initialize') {
+    send({
+      jsonrpc: '2.0',
+      id: message.id,
+      result: { capabilities: { textDocumentSync: { openClose: true, change: 1 } } }
+    })
+    return
+  }
+  if (message.method === 'textDocument/didOpen') {
+    process.exit(42)
+  }
+}
+
+process.stdin.on('data', chunk => {
+  buffer = Buffer.concat([buffer, chunk])
+  while (true) {
+    const headerEnd = buffer.indexOf('\r\n\r\n')
+    if (headerEnd === -1) break
+    const header = buffer.subarray(0, headerEnd).toString('utf8')
+    const match = /Content-Length:\s*(\d+)/i.exec(header)
+    if (!match) {
+      buffer = buffer.subarray(headerEnd + 4)
+      continue
+    }
+    const length = Number(match[1])
+    const start = headerEnd + 4
+    const end = start + length
+    if (buffer.length < end) break
+    const message = JSON.parse(buffer.subarray(start, end).toString('utf8'))
+    buffer = buffer.subarray(end)
+    handle(message)
+  }
+})
+`
+
+const UNC_DIAGNOSTIC_LSP_SERVER = String.raw`
+let buffer = Buffer.alloc(0)
+
+function send(message) {
+  const body = Buffer.from(JSON.stringify(message), 'utf8')
+  process.stdout.write('Content-Length: ' + body.length + '\r\n\r\n')
+  process.stdout.write(body)
+}
+
+function handle(message) {
+  if (message.method === 'initialize') {
+    send({
+      jsonrpc: '2.0',
+      id: message.id,
+      result: { capabilities: { textDocumentSync: { openClose: true, change: 1 } } }
+    })
+    return
+  }
+  if (message.method === 'textDocument/didOpen') {
+    send({
+      jsonrpc: '2.0',
+      method: 'textDocument/publishDiagnostics',
+      params: {
+        uri: 'file://server/share/repo/main.rs',
+        diagnostics: [{
+          range: { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } },
+          message: 'unc diagnostic'
+        }]
+      }
+    })
+  }
+}
+
+process.stdin.on('data', chunk => {
+  buffer = Buffer.concat([buffer, chunk])
+  while (true) {
+    const headerEnd = buffer.indexOf('\r\n\r\n')
+    if (headerEnd === -1) break
+    const header = buffer.subarray(0, headerEnd).toString('utf8')
+    const match = /Content-Length:\s*(\d+)/i.exec(header)
+    if (!match) {
+      buffer = buffer.subarray(headerEnd + 4)
+      continue
+    }
+    const length = Number(match[1])
+    const start = headerEnd + 4
+    const end = start + length
+    if (buffer.length < end) break
+    const message = JSON.parse(buffer.subarray(start, end).toString('utf8'))
+    buffer = buffer.subarray(end)
+    handle(message)
+  }
+})
+`
+
+const CONFIG_REQUEST_LSP_SERVER = String.raw`
+let buffer = Buffer.alloc(0)
+let documentUri = null
+
+function send(message) {
+  const body = Buffer.from(JSON.stringify(message), 'utf8')
+  process.stdout.write('Content-Length: ' + body.length + '\r\n\r\n')
+  process.stdout.write(body)
+}
+
+function handle(message) {
+  if (message.method === 'initialize') {
+    send({
+      jsonrpc: '2.0',
+      id: message.id,
+      result: { capabilities: { textDocumentSync: { openClose: true, change: 1 } } }
+    })
+    return
+  }
+  if (message.method === 'textDocument/didOpen') {
+    documentUri = message.params.textDocument.uri
+    send({
+      jsonrpc: '2.0',
+      id: 99,
+      method: 'workspace/configuration',
+      params: { items: [{ section: 'a' }, { section: 'b' }] }
+    })
+    return
+  }
+  if (message.id === 99) {
+    send({
+      jsonrpc: '2.0',
+      method: 'textDocument/publishDiagnostics',
+      params: {
+        uri: documentUri,
+        diagnostics: [{
+          range: { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } },
+          message: 'config entries: ' + message.result.length
+        }]
+      }
+    })
+  }
+}
+
+process.stdin.on('data', chunk => {
+  buffer = Buffer.concat([buffer, chunk])
+  while (true) {
+    const headerEnd = buffer.indexOf('\r\n\r\n')
+    if (headerEnd === -1) break
+    const header = buffer.subarray(0, headerEnd).toString('utf8')
+    const match = /Content-Length:\s*(\d+)/i.exec(header)
+    if (!match) {
+      buffer = buffer.subarray(headerEnd + 4)
+      continue
+    }
+    const length = Number(match[1])
+    const start = headerEnd + 4
+    const end = start + length
+    if (buffer.length < end) break
+    const message = JSON.parse(buffer.subarray(start, end).toString('utf8'))
+    buffer = buffer.subarray(end)
+    handle(message)
+  }
+})
+`
+
+const STUBBORN_LSP_SERVER = String.raw`
+const fs = require('fs')
+fs.writeFileSync(process.argv[2], String(process.pid))
+let buffer = Buffer.alloc(0)
+
+function send(message) {
+  const body = Buffer.from(JSON.stringify(message), 'utf8')
+  process.stdout.write('Content-Length: ' + body.length + '\r\n\r\n')
+  process.stdout.write(body)
+}
+
+function handle(message) {
+  if (message.method === 'initialize') {
+    send({
+      jsonrpc: '2.0',
+      id: message.id,
+      result: { capabilities: { textDocumentSync: { openClose: true, change: 1 } } }
+    })
+    return
+  }
+  if (message.method === 'shutdown') {
+    send({ jsonrpc: '2.0', id: message.id, result: null })
+    return
+  }
+  if (message.method === 'exit') {
+    return
+  }
+  if (message.id !== undefined) {
+    send({ jsonrpc: '2.0', id: message.id, result: null })
+  }
+}
+
+process.on('SIGTERM', () => {})
+setInterval(() => {}, 1_000)
+process.stdin.on('data', chunk => {
+  buffer = Buffer.concat([buffer, chunk])
+  while (true) {
+    const headerEnd = buffer.indexOf('\r\n\r\n')
+    if (headerEnd === -1) break
+    const header = buffer.subarray(0, headerEnd).toString('utf8')
+    const match = /Content-Length:\s*(\d+)/i.exec(header)
+    if (!match) {
+      buffer = buffer.subarray(headerEnd + 4)
+      continue
+    }
+    const length = Number(match[1])
+    const start = headerEnd + 4
+    const end = start + length
+    if (buffer.length < end) break
+    const message = JSON.parse(buffer.subarray(start, end).toString('utf8'))
+    buffer = buffer.subarray(end)
+    handle(message)
+  }
+})
+`
+
+async function waitForDiagnostics(
+  events: { diagnostics: LspDiagnostic[] }[],
+  count: number
+): Promise<LspDiagnostic[]> {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < 2_000) {
+    const last = events.at(-1)
+    if (last && last.diagnostics.length === count) {
+      return last.diagnostics
+    }
+    await new Promise((resolve) => setTimeout(resolve, 20))
+  }
+  throw new Error(`Timed out waiting for ${count} diagnostics`)
+}
+
+async function waitForCondition(assertion: () => boolean, message: string): Promise<void> {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < 2_000) {
+    if (assertion()) {
+      return
+    }
+    await new Promise((resolve) => setTimeout(resolve, 20))
+  }
+  throw new Error(message)
+}
+
+function processIsRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+describe('LspProcessSession', () => {
+  let dir: string
+  let session: LspProcessSession | null = null
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'orca-lsp-session-'))
+  })
+
+  afterEach(async () => {
+    await session?.dispose()
+    session = null
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('handles initialize, document sync, diagnostics, completion, hover, and definition', async () => {
+    const serverPath = join(dir, 'fake-lsp.cjs')
+    const filePath = join(dir, 'main.rs')
+    const diagnostics: { diagnostics: LspDiagnostic[] }[] = []
+    writeFileSync(serverPath, FAKE_LSP_SERVER)
+    writeFileSync(filePath, 'fn bad() {}')
+
+    session = new LspProcessSession({
+      rootPath: dir,
+      languageId: 'rust',
+      server: { command: process.execPath, args: [serverPath] },
+      onDiagnostics: (event) => diagnostics.push(event)
+    })
+
+    await session.openDocument(filePath, 'rust', 'fn bad() {}')
+    expect(await waitForDiagnostics(diagnostics, 1)).toMatchObject([
+      { message: 'bad symbol', source: 'fake-lsp' }
+    ])
+
+    const completion = await session.completion(filePath, { line: 0, character: 3 })
+    expect(completion).toMatchObject({ items: [{ label: 'completionItem' }] })
+
+    const hover = await session.hover(filePath, { line: 0, character: 3 })
+    expect(hover).toEqual({ contents: { kind: 'markdown', value: '**hovered**' } })
+
+    const definition = await session.definition(filePath, { line: 0, character: 3 })
+    expect(definition).toHaveLength(1)
+    expect(definition[0].range.start).toEqual({ line: 0, character: 0 })
+
+    await session.changeDocument(filePath, 'fn ok() {}')
+    expect(await waitForDiagnostics(diagnostics, 0)).toEqual([])
+
+    await session.closeDocument(filePath)
+    expect(session.getOpenDocumentCount()).toBe(0)
+  })
+
+  it('rejects later requests without writing to a crashed server pipe', async () => {
+    const serverPath = join(dir, 'exiting-lsp.cjs')
+    const filePath = join(dir, 'main.rs')
+    writeFileSync(serverPath, EXITING_LSP_SERVER)
+
+    session = new LspProcessSession({
+      rootPath: dir,
+      languageId: 'rust',
+      server: { command: process.execPath, args: [serverPath] }
+    })
+
+    await session.openDocument(filePath, 'rust', 'fn main() {}')
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    await expect(session.completion(filePath, { line: 0, character: 1 })).rejects.toThrow(
+      'LSP session is not running'
+    )
+  })
+
+  it('preserves UNC hosts when converting diagnostic file URIs', async () => {
+    const serverPath = join(dir, 'unc-lsp.cjs')
+    const filePath = join(dir, 'main.rs')
+    const diagnostics: { filePath: string; diagnostics: LspDiagnostic[] }[] = []
+    writeFileSync(serverPath, UNC_DIAGNOSTIC_LSP_SERVER)
+
+    session = new LspProcessSession({
+      rootPath: dir,
+      languageId: 'rust',
+      server: { command: process.execPath, args: [serverPath] },
+      onDiagnostics: (event) => diagnostics.push(event)
+    })
+
+    await session.openDocument(filePath, 'rust', 'fn main() {}')
+    await waitForDiagnostics(diagnostics, 1)
+
+    expect(diagnostics.at(-1)?.filePath).toBe('\\\\server\\share\\repo\\main.rs')
+  })
+
+  it('responds to workspace configuration requests with one entry per item', async () => {
+    const serverPath = join(dir, 'config-lsp.cjs')
+    const filePath = join(dir, 'main.rs')
+    const diagnostics: { diagnostics: LspDiagnostic[] }[] = []
+    writeFileSync(serverPath, CONFIG_REQUEST_LSP_SERVER)
+
+    session = new LspProcessSession({
+      rootPath: dir,
+      languageId: 'rust',
+      server: { command: process.execPath, args: [serverPath] },
+      onDiagnostics: (event) => diagnostics.push(event)
+    })
+
+    await session.openDocument(filePath, 'rust', 'fn main() {}')
+
+    expect(await waitForDiagnostics(diagnostics, 1)).toMatchObject([
+      { message: 'config entries: 2' }
+    ])
+  })
+
+  it('kills a language-server process that ignores exit during dispose', async () => {
+    const serverPath = join(dir, 'stubborn-lsp.cjs')
+    const pidPath = join(dir, 'stubborn.pid')
+    const filePath = join(dir, 'main.rs')
+    writeFileSync(serverPath, STUBBORN_LSP_SERVER)
+
+    session = new LspProcessSession({
+      rootPath: dir,
+      languageId: 'rust',
+      server: { command: process.execPath, args: [serverPath, pidPath] }
+    })
+
+    await session.openDocument(filePath, 'rust', 'fn main() {}')
+    await waitForCondition(
+      () => existsSync(pidPath) && readFileSync(pidPath, 'utf-8').trim().length > 0,
+      'missing pid'
+    )
+    const pid = Number(readFileSync(pidPath, 'utf-8'))
+
+    await session.dispose()
+    session = null
+
+    await waitForCondition(
+      () => !processIsRunning(pid),
+      'stubborn LSP process still running after dispose'
+    )
+  })
+})

--- a/src/main/lsp/lsp-process-session.ts
+++ b/src/main/lsp/lsp-process-session.ts
@@ -1,0 +1,592 @@
+/* eslint-disable max-lines -- Why: this file owns the complete stdio LSP JSON-RPC
+client state machine (framing, lifecycle, document sync, and request routing);
+splitting those pieces would make protocol ordering harder to audit. */
+import { spawn, type ChildProcessWithoutNullStreams } from 'child_process'
+import { fileURLToPath, pathToFileURL } from 'url'
+import type {
+  LspCompletionResult,
+  LspDiagnostic,
+  LspHover,
+  LspLocation,
+  LspPosition
+} from '../../shared/lsp-types'
+import { getSpawnArgsForWindows } from '../win32-utils'
+import type { LanguageServerCommand } from './language-server-registry'
+
+type JsonRpcRequest = {
+  jsonrpc: '2.0'
+  id: number
+  method: string
+  params?: unknown
+}
+
+type JsonRpcNotification = {
+  jsonrpc: '2.0'
+  method: string
+  params?: unknown
+}
+
+type JsonRpcResponse = {
+  jsonrpc: '2.0'
+  id: number
+  result?: unknown
+  error?: { code: number; message: string }
+}
+
+type JsonRpcMessage = JsonRpcRequest | JsonRpcNotification | JsonRpcResponse
+
+type PendingRequest = {
+  resolve: (value: unknown) => void
+  reject: (error: Error) => void
+  timer: ReturnType<typeof setTimeout>
+}
+
+type OpenDocument = {
+  filePath: string
+  languageId: string
+  text: string
+  version: number
+}
+
+type TextDocumentSyncKind = 0 | 1 | 2
+
+export type LspProcessSessionOptions = {
+  rootPath: string
+  languageId: string
+  server: LanguageServerCommand
+  connectionId?: string
+  onDiagnostics?: (event: {
+    filePath: string
+    languageId: string
+    diagnostics: LspDiagnostic[]
+  }) => void
+}
+
+export type LspProcessStats = {
+  startedAt: number
+  initializedAt: number
+  requestCount: number
+  notificationCount: number
+  openDocumentCount: number
+}
+
+const DEFAULT_REQUEST_TIMEOUT_MS = 8_000
+const SHUTDOWN_REQUEST_TIMEOUT_MS = 1_500
+const DISPOSE_EXIT_TIMEOUT_MS = 500
+const DISPOSE_KILL_TIMEOUT_MS = 500
+
+function lspPathToUri(filePath: string): string {
+  return pathToFileURL(filePath).toString()
+}
+
+function lspUriToPath(uri: string): string {
+  const parsed = new URL(uri)
+  const isWindowsFileUri =
+    process.platform === 'win32' || parsed.hostname !== '' || /^\/[A-Za-z]:/.test(parsed.pathname)
+  return fileURLToPath(uri, { windows: isWindowsFileUri })
+}
+
+function endPosition(text: string): LspPosition {
+  const lines = text.split(/\r\n|\r|\n/)
+  return {
+    line: lines.length - 1,
+    character: lines.at(-1)?.length ?? 0
+  }
+}
+
+function extractTextDocumentSyncKind(capabilities: Record<string, unknown>): TextDocumentSyncKind {
+  const sync = capabilities.textDocumentSync
+  if (typeof sync === 'number') {
+    return sync === 2 ? 2 : sync === 1 ? 1 : 0
+  }
+  if (sync && typeof sync === 'object') {
+    const change = (sync as { change?: unknown }).change
+    return change === 2 ? 2 : change === 1 ? 1 : 0
+  }
+  return 1
+}
+
+function parseContentLength(header: string): number | null {
+  const match = /(?:^|\r\n)Content-Length:\s*(\d+)/i.exec(header)
+  if (!match) {
+    return null
+  }
+  const length = Number(match[1])
+  return Number.isFinite(length) && length >= 0 ? length : null
+}
+
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error))
+}
+
+export class LspProcessSession {
+  private readonly rootPath: string
+  private readonly languageId: string
+  private readonly server: LanguageServerCommand
+  private readonly onDiagnostics?: LspProcessSessionOptions['onDiagnostics']
+  private child: ChildProcessWithoutNullStreams | null = null
+  private buffer = Buffer.alloc(0)
+  private nextRequestId = 1
+  private pending = new Map<number, PendingRequest>()
+  private documents = new Map<string, OpenDocument>()
+  private initializePromise: Promise<void> | null = null
+  private textDocumentSyncKind: TextDocumentSyncKind = 1
+  private disposed = false
+  private stats: LspProcessStats = {
+    startedAt: 0,
+    initializedAt: 0,
+    requestCount: 0,
+    notificationCount: 0,
+    openDocumentCount: 0
+  }
+
+  constructor(options: LspProcessSessionOptions) {
+    this.rootPath = options.rootPath
+    this.languageId = options.languageId
+    this.server = options.server
+    this.onDiagnostics = options.onDiagnostics
+  }
+
+  getStats(): LspProcessStats {
+    return {
+      ...this.stats,
+      openDocumentCount: this.documents.size
+    }
+  }
+
+  getOpenDocumentCount(): number {
+    return this.documents.size
+  }
+
+  async openDocument(filePath: string, languageId: string, text: string): Promise<void> {
+    await this.ensureInitialized()
+    const uri = lspPathToUri(filePath)
+    const existing = this.documents.get(uri)
+    if (existing) {
+      await this.changeDocument(filePath, text)
+      return
+    }
+    this.documents.set(uri, { filePath, languageId, text, version: 1 })
+    this.notify('textDocument/didOpen', {
+      textDocument: {
+        uri,
+        languageId,
+        version: 1,
+        text
+      }
+    })
+  }
+
+  async changeDocument(filePath: string, text: string): Promise<void> {
+    await this.ensureInitialized()
+    const uri = lspPathToUri(filePath)
+    const existing = this.documents.get(uri)
+    if (!existing) {
+      await this.openDocument(filePath, this.languageId, text)
+      return
+    }
+    if (existing.text === text) {
+      return
+    }
+    const nextVersion = existing.version + 1
+    const previousText = existing.text
+    existing.text = text
+    existing.version = nextVersion
+    const contentChanges =
+      this.textDocumentSyncKind === 2
+        ? [
+            {
+              range: {
+                start: { line: 0, character: 0 },
+                end: endPosition(previousText)
+              },
+              text
+            }
+          ]
+        : [{ text }]
+    this.notify('textDocument/didChange', {
+      textDocument: { uri, version: nextVersion },
+      contentChanges
+    })
+  }
+
+  async closeDocument(filePath: string): Promise<void> {
+    if (!this.initializePromise) {
+      return
+    }
+    await this.ensureInitialized().catch(() => undefined)
+    const uri = lspPathToUri(filePath)
+    if (!this.documents.has(uri)) {
+      return
+    }
+    this.documents.delete(uri)
+    this.notify('textDocument/didClose', {
+      textDocument: { uri }
+    })
+  }
+
+  async completion(
+    filePath: string,
+    position: LspPosition,
+    text?: string
+  ): Promise<LspCompletionResult | null> {
+    await (text !== undefined ? this.changeDocument(filePath, text) : this.ensureInitialized())
+    return (await this.request(
+      'textDocument/completion',
+      {
+        textDocument: { uri: lspPathToUri(filePath) },
+        position
+      },
+      DEFAULT_REQUEST_TIMEOUT_MS
+    )) as LspCompletionResult | null
+  }
+
+  async hover(filePath: string, position: LspPosition, text?: string): Promise<LspHover | null> {
+    await (text !== undefined ? this.changeDocument(filePath, text) : this.ensureInitialized())
+    return (await this.request(
+      'textDocument/hover',
+      {
+        textDocument: { uri: lspPathToUri(filePath) },
+        position
+      },
+      DEFAULT_REQUEST_TIMEOUT_MS
+    )) as LspHover | null
+  }
+
+  async definition(filePath: string, position: LspPosition, text?: string): Promise<LspLocation[]> {
+    await (text !== undefined ? this.changeDocument(filePath, text) : this.ensureInitialized())
+    const result = await this.request(
+      'textDocument/definition',
+      {
+        textDocument: { uri: lspPathToUri(filePath) },
+        position
+      },
+      DEFAULT_REQUEST_TIMEOUT_MS
+    )
+    if (!result) {
+      return []
+    }
+    if (Array.isArray(result)) {
+      return result.flatMap((item) => this.normalizeLocation(item))
+    }
+    return this.normalizeLocation(result)
+  }
+
+  async dispose(): Promise<void> {
+    if (this.disposed) {
+      return
+    }
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timer)
+      pending.reject(new Error('LSP session disposed'))
+    }
+    this.pending.clear()
+    const child = this.child
+    if (!child) {
+      this.disposed = true
+      return
+    }
+    try {
+      await this.request('shutdown', null, SHUTDOWN_REQUEST_TIMEOUT_MS)
+      this.notify('exit')
+    } catch {
+      // Shutdown is best-effort; a timed-out server still needs process cleanup.
+    } finally {
+      this.disposed = true
+    }
+    if (await this.waitForExit(child, DISPOSE_EXIT_TIMEOUT_MS)) {
+      return
+    }
+    child.kill()
+    if (await this.waitForExit(child, DISPOSE_KILL_TIMEOUT_MS)) {
+      return
+    }
+    child.kill('SIGKILL')
+    await this.waitForExit(child, DISPOSE_KILL_TIMEOUT_MS)
+  }
+
+  private normalizeLocation(value: unknown): LspLocation[] {
+    if (!value || typeof value !== 'object') {
+      return []
+    }
+    if ('targetUri' in value) {
+      const link = value as {
+        targetUri?: string
+        targetSelectionRange?: LspLocation['range']
+        targetRange?: LspLocation['range']
+      }
+      if (!link.targetUri || (!link.targetSelectionRange && !link.targetRange)) {
+        return []
+      }
+      return [
+        {
+          uri: link.targetUri,
+          range: link.targetSelectionRange ?? link.targetRange!
+        }
+      ]
+    }
+    const location = value as Partial<LspLocation>
+    if (!location.uri || !location.range) {
+      return []
+    }
+    return [{ uri: location.uri, range: location.range }]
+  }
+
+  private ensureInitialized(): Promise<void> {
+    if (this.disposed) {
+      return Promise.reject(new Error('LSP session is not running'))
+    }
+    if (this.initializePromise) {
+      return this.initializePromise
+    }
+    this.initializePromise = this.start()
+    return this.initializePromise
+  }
+
+  private async start(): Promise<void> {
+    this.stats.startedAt = Date.now()
+    const { spawnCmd, spawnArgs } = getSpawnArgsForWindows(this.server.command, this.server.args)
+    const child = spawn(spawnCmd, spawnArgs, {
+      cwd: this.rootPath,
+      stdio: 'pipe',
+      env: process.env
+    })
+    this.child = child
+
+    child.stdout.on('data', (chunk: Buffer) => this.handleData(chunk))
+    child.stderr.on('data', (chunk: Buffer) => {
+      const text = chunk.toString('utf-8').trim()
+      if (text) {
+        console.debug(`[lsp:${this.languageId}] ${text}`)
+      }
+    })
+    child.on('error', (error) => this.failSession(error))
+    child.stdin.on('error', (error) => this.failSession(error))
+    child.on('exit', () => {
+      this.failSession(new Error(`${this.server.command} exited`))
+    })
+
+    const result = (await this.request(
+      'initialize',
+      {
+        processId: process.pid,
+        rootUri: lspPathToUri(this.rootPath),
+        workspaceFolders: [
+          {
+            uri: lspPathToUri(this.rootPath),
+            name: this.rootPath.split(/[\\/]/).pop() || this.rootPath
+          }
+        ],
+        capabilities: {
+          textDocument: {
+            synchronization: {
+              didSave: true,
+              dynamicRegistration: false
+            },
+            completion: {
+              completionItem: {
+                snippetSupport: true,
+                documentationFormat: ['markdown', 'plaintext']
+              }
+            },
+            hover: {
+              contentFormat: ['markdown', 'plaintext']
+            },
+            definition: {
+              linkSupport: true
+            },
+            publishDiagnostics: {
+              relatedInformation: false
+            }
+          },
+          workspace: {
+            workspaceFolders: true,
+            configuration: true
+          }
+        }
+      },
+      10_000
+    )) as { capabilities?: Record<string, unknown> } | null
+
+    this.textDocumentSyncKind = extractTextDocumentSyncKind(result?.capabilities ?? {})
+    this.notify('initialized', {})
+    this.stats.initializedAt = Date.now()
+  }
+
+  private request(
+    method: string,
+    params?: unknown,
+    timeoutMs = DEFAULT_REQUEST_TIMEOUT_MS
+  ): Promise<unknown> {
+    if (!this.child || this.disposed) {
+      return Promise.reject(new Error('LSP session is not running'))
+    }
+    const id = this.nextRequestId++
+    const message: JsonRpcRequest = {
+      jsonrpc: '2.0',
+      id,
+      method,
+      ...(params !== undefined ? { params } : {})
+    }
+    this.stats.requestCount++
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id)
+        reject(new Error(`LSP request timed out: ${method}`))
+      }, timeoutMs)
+      this.pending.set(id, { resolve, reject, timer })
+      try {
+        this.writeMessage(message)
+      } catch (error) {
+        clearTimeout(timer)
+        this.pending.delete(id)
+        reject(toError(error))
+      }
+    })
+  }
+
+  private notify(method: string, params?: unknown): void {
+    if (!this.child || this.disposed) {
+      return
+    }
+    this.stats.notificationCount++
+    this.writeMessage({
+      jsonrpc: '2.0',
+      method,
+      ...(params !== undefined ? { params } : {})
+    })
+  }
+
+  private respond(id: number, result: unknown): void {
+    this.writeMessage({ jsonrpc: '2.0', id, result } as JsonRpcResponse)
+  }
+
+  private writeMessage(message: JsonRpcMessage): void {
+    const child = this.child
+    if (!child || this.disposed || child.stdin.destroyed || !child.stdin.writable) {
+      throw new Error('LSP session is not running')
+    }
+    const body = Buffer.from(JSON.stringify(message), 'utf-8')
+    const header = Buffer.from(`Content-Length: ${body.length}\r\n\r\n`, 'utf-8')
+    child.stdin.write(Buffer.concat([header, body]))
+  }
+
+  private failSession(error: Error): void {
+    this.child = null
+    this.disposed = true
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timer)
+      pending.reject(error)
+    }
+    this.pending.clear()
+  }
+
+  private waitForExit(child: ChildProcessWithoutNullStreams, timeoutMs: number): Promise<boolean> {
+    if (child.exitCode !== null || child.signalCode !== null) {
+      return Promise.resolve(true)
+    }
+    return new Promise((resolve) => {
+      const onExit = (): void => {
+        clearTimeout(timer)
+        resolve(true)
+      }
+      const timer = setTimeout(() => {
+        child.off('exit', onExit)
+        resolve(false)
+      }, timeoutMs)
+      timer.unref?.()
+      child.once('exit', onExit)
+    })
+  }
+
+  private handleData(chunk: Buffer): void {
+    this.buffer = Buffer.concat([this.buffer, chunk])
+    while (true) {
+      const headerEnd = this.buffer.indexOf('\r\n\r\n')
+      if (headerEnd === -1) {
+        return
+      }
+      const header = this.buffer.subarray(0, headerEnd).toString('utf-8')
+      const contentLength = parseContentLength(header)
+      if (contentLength === null) {
+        this.buffer = this.buffer.subarray(headerEnd + 4)
+        continue
+      }
+      const messageStart = headerEnd + 4
+      const messageEnd = messageStart + contentLength
+      if (this.buffer.length < messageEnd) {
+        return
+      }
+      const raw = this.buffer.subarray(messageStart, messageEnd).toString('utf-8')
+      this.buffer = this.buffer.subarray(messageEnd)
+      try {
+        this.handleMessage(JSON.parse(raw) as JsonRpcMessage)
+      } catch (error) {
+        console.warn('[lsp] failed to parse server message', error)
+      }
+    }
+  }
+
+  private handleMessage(message: JsonRpcMessage): void {
+    if ('id' in message && !('method' in message)) {
+      const pending = this.pending.get(message.id)
+      if (!pending) {
+        return
+      }
+      clearTimeout(pending.timer)
+      this.pending.delete(message.id)
+      if (message.error) {
+        pending.reject(new Error(message.error.message))
+      } else {
+        pending.resolve(message.result ?? null)
+      }
+      return
+    }
+
+    if ('id' in message && 'method' in message) {
+      this.handleServerRequest(message)
+      return
+    }
+
+    if ('method' in message) {
+      this.handleNotification(message)
+    }
+  }
+
+  private handleServerRequest(message: JsonRpcRequest): void {
+    if (message.method === 'workspace/configuration') {
+      const params = message.params as { items?: unknown[] } | undefined
+      this.respond(
+        message.id,
+        (params?.items ?? []).map(() => null)
+      )
+      return
+    }
+    if (message.method === 'workspace/applyEdit') {
+      this.respond(message.id, { applied: false })
+      return
+    }
+    this.respond(message.id, null)
+  }
+
+  private handleNotification(message: JsonRpcNotification): void {
+    if (message.method !== 'textDocument/publishDiagnostics') {
+      return
+    }
+    const params = message.params as
+      | {
+          uri?: string
+          diagnostics?: LspDiagnostic[]
+        }
+      | undefined
+    if (!params?.uri) {
+      return
+    }
+    const filePath = lspUriToPath(params.uri)
+    this.onDiagnostics?.({
+      filePath,
+      languageId: this.languageId,
+      diagnostics: params.diagnostics ?? []
+    })
+  }
+}

--- a/src/main/lsp/lsp-service.test.ts
+++ b/src/main/lsp/lsp-service.test.ts
@@ -1,0 +1,486 @@
+/* eslint-disable max-lines -- Why: LspService owns local and SSH lifecycle
+recovery; keeping the paired regression tests together prevents the two paths
+from drifting. */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { LspDocumentContext, LspRequestContext } from '../../shared/lsp-types'
+
+const mocks = vi.hoisted(() => {
+  const instances: MockLspProcessSession[] = []
+  const resolveLanguageServerCommandMock = vi.fn()
+  const getAllWindowsMock = vi.fn(() => [])
+  const multiplexerReadyListeners = new Set<(connectionId: string) => void>()
+
+  class MockLspProcessSession {
+    readonly documents = new Set<string>()
+    readonly openDocument = vi.fn(async (filePath: string) => {
+      this.documents.add(filePath)
+    })
+    readonly changeDocument = vi.fn(async (filePath: string) => {
+      this.documents.add(filePath)
+    })
+    readonly closeDocument = vi.fn(async (filePath: string) => {
+      this.documents.delete(filePath)
+    })
+    readonly dispose = vi.fn(async () => undefined)
+    readonly completion = vi.fn(async () => null)
+    readonly hover = vi.fn(async () => null)
+    readonly definition = vi.fn(async () => [])
+    readonly getOpenDocumentCount = vi.fn(() => this.documents.size)
+    readonly getStats = vi.fn(() => ({
+      startedAt: 0,
+      initializedAt: 0,
+      requestCount: 0,
+      notificationCount: 0,
+      openDocumentCount: this.documents.size
+    }))
+
+    constructor() {
+      instances.push(this)
+    }
+  }
+
+  return {
+    instances,
+    MockLspProcessSession,
+    getAllWindowsMock,
+    multiplexerReadyListeners,
+    resolveLanguageServerCommandMock
+  }
+})
+
+vi.mock('electron', () => ({
+  BrowserWindow: {
+    getAllWindows: mocks.getAllWindowsMock
+  }
+}))
+
+vi.mock('../ipc/ssh', () => ({
+  getActiveMultiplexer: vi.fn(() => null),
+  onActiveMultiplexerReady: vi.fn((listener: (connectionId: string) => void) => {
+    mocks.multiplexerReadyListeners.add(listener)
+    return () => mocks.multiplexerReadyListeners.delete(listener)
+  })
+}))
+
+vi.mock('./language-server-registry', () => ({
+  resolveLanguageServerCommand: mocks.resolveLanguageServerCommandMock
+}))
+
+vi.mock('./lsp-process-session', () => ({
+  LspProcessSession: mocks.MockLspProcessSession
+}))
+
+import { getActiveMultiplexer, onActiveMultiplexerReady } from '../ipc/ssh'
+import { LspService } from './lsp-service'
+
+function deferred<T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+} {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
+async function flushPromises(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+function documentArgs(overrides: Partial<LspDocumentContext> = {}): LspDocumentContext {
+  return {
+    worktreeId: 'wt-1',
+    worktreePath: '/repo',
+    filePath: '/repo/main.c',
+    languageId: 'c',
+    content: 'int main(void) { return 0; }',
+    ...overrides
+  }
+}
+
+function requestArgs(overrides: Partial<LspRequestContext> = {}): LspRequestContext {
+  return {
+    ...documentArgs(),
+    content: undefined,
+    position: { line: 0, character: 4 },
+    ...overrides
+  }
+}
+
+function createMuxMock() {
+  const disposeCallbacks: (() => void)[] = []
+  return {
+    isDisposed: vi.fn(() => false),
+    request: vi.fn(async (method: string) =>
+      method === 'lsp.openDocument' ? { state: 'available', languageId: 'c' } : null
+    ),
+    onNotificationByMethod: vi.fn(() => vi.fn()),
+    onDispose: vi.fn((callback: () => void) => {
+      disposeCallbacks.push(callback)
+      return vi.fn()
+    }),
+    disposeMux: () => {
+      for (const callback of disposeCallbacks) {
+        callback()
+      }
+    }
+  }
+}
+
+describe('LspService', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    mocks.instances.length = 0
+    mocks.getAllWindowsMock.mockReset()
+    mocks.getAllWindowsMock.mockReturnValue([] as never)
+    mocks.multiplexerReadyListeners.clear()
+    mocks.resolveLanguageServerCommandMock.mockReset()
+    mocks.resolveLanguageServerCommandMock.mockResolvedValue({
+      ok: true,
+      command: { command: '/usr/bin/clangd', args: [] }
+    })
+    vi.mocked(getActiveMultiplexer).mockReset()
+    vi.mocked(getActiveMultiplexer).mockReturnValue(null as never)
+    vi.mocked(onActiveMultiplexerReady).mockClear()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('does not start a language-server process when only checking status', async () => {
+    const service = new LspService()
+
+    await expect(
+      service.getStatus({ worktreePath: '/repo', languageId: 'c' })
+    ).resolves.toMatchObject({ state: 'available', languageId: 'c' })
+
+    expect(mocks.instances).toHaveLength(0)
+  })
+
+  it('delays shutdown after the last local document closes and cancels it on quick return', async () => {
+    const service = new LspService()
+    await service.openDocument(documentArgs())
+    const session = mocks.instances[0]
+
+    await service.closeDocument(documentArgs())
+
+    expect(session.dispose).not.toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(59_999)
+    expect(session.dispose).not.toHaveBeenCalled()
+
+    await service.openDocument(documentArgs({ filePath: '/repo/other.c', content: 'int other;' }))
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(session.dispose).not.toHaveBeenCalled()
+
+    await service.closeDocument(documentArgs({ filePath: '/repo/other.c' }))
+    await vi.advanceTimersByTimeAsync(60_000)
+
+    expect(session.dispose).toHaveBeenCalledTimes(1)
+  })
+
+  it('dedupes concurrent local session creation for the same key', async () => {
+    const discovery = deferred<{
+      ok: true
+      command: { command: string; args: string[] }
+    }>()
+    mocks.resolveLanguageServerCommandMock.mockReturnValue(discovery.promise)
+    const service = new LspService()
+
+    const firstOpen = service.openDocument(documentArgs({ filePath: '/repo/a.c' }))
+    const secondOpen = service.openDocument(documentArgs({ filePath: '/repo/b.c' }))
+    await Promise.resolve()
+    expect(mocks.resolveLanguageServerCommandMock).toHaveBeenCalledTimes(1)
+
+    discovery.resolve({ ok: true, command: { command: '/usr/bin/clangd', args: [] } })
+    await Promise.all([firstOpen, secondOpen])
+
+    expect(mocks.instances).toHaveLength(1)
+    expect(mocks.instances[0].documents).toEqual(new Set(['/repo/a.c', '/repo/b.c']))
+  })
+
+  it('reopens tracked documents when recovering a lost local session', async () => {
+    const service = new LspService()
+    await service.openDocument(documentArgs({ content: 'int before;' }))
+    await service.changeDocument(documentArgs({ content: 'int after;' }))
+    const crashed = mocks.instances[0]
+    crashed.completion.mockRejectedValueOnce(new Error('server exited'))
+
+    await expect(service.completion(requestArgs())).resolves.toBeNull()
+
+    expect(mocks.instances).toHaveLength(2)
+    expect(mocks.instances[1].openDocument).toHaveBeenCalledWith('/repo/main.c', 'c', 'int after;')
+    expect(mocks.instances[1].completion).toHaveBeenCalledWith(
+      '/repo/main.c',
+      { line: 0, character: 4 },
+      undefined
+    )
+  })
+
+  it('recreates a local session when edits arrive after a server crash', async () => {
+    const send = vi.fn()
+    mocks.getAllWindowsMock.mockReturnValue([
+      {
+        isDestroyed: () => false,
+        webContents: { send }
+      }
+    ] as never)
+    const service = new LspService()
+    await service.openDocument(documentArgs({ content: 'int before;' }))
+    const crashed = mocks.instances[0]
+    crashed.changeDocument.mockRejectedValueOnce(new Error('server exited'))
+
+    await service.changeDocument(documentArgs({ content: 'int after;' }))
+
+    expect(mocks.instances).toHaveLength(2)
+    expect(mocks.instances[1].openDocument).toHaveBeenCalledWith('/repo/main.c', 'c', 'int after;')
+    expect(mocks.instances[1].changeDocument).toHaveBeenCalledWith('/repo/main.c', 'int after;')
+    expect(send).toHaveBeenCalledWith(
+      'lsp:diagnostics',
+      expect.objectContaining({
+        filePath: '/repo/main.c',
+        diagnostics: []
+      })
+    )
+  })
+
+  it('keeps a local LSP document open until all views close it', async () => {
+    const service = new LspService()
+    await service.openDocument(documentArgs({ content: 'int first;', documentId: 'doc-1' }))
+    await service.openDocument(documentArgs({ content: 'int second;', documentId: 'doc-2' }))
+    const session = mocks.instances[0]
+
+    await service.closeDocument(documentArgs({ documentId: 'doc-1' }))
+
+    expect(session.closeDocument).not.toHaveBeenCalled()
+
+    await service.closeDocument(documentArgs({ documentId: 'doc-2' }))
+
+    expect(session.closeDocument).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not spawn a local session after shutdown while creation is pending', async () => {
+    const discovery = deferred<{
+      ok: true
+      command: { command: string; args: string[] }
+    }>()
+    mocks.resolveLanguageServerCommandMock.mockReturnValue(discovery.promise)
+    const service = new LspService()
+
+    const open = service.openDocument(documentArgs())
+    await Promise.resolve()
+    await service.disposeAll()
+    discovery.resolve({ ok: true, command: { command: '/usr/bin/clangd', args: [] } })
+
+    await expect(open).rejects.toThrow('LSP service is shutting down')
+    expect(mocks.instances).toHaveLength(0)
+  })
+
+  it('re-registers remote diagnostics when rehydrating documents on a new SSH mux', async () => {
+    const firstMux = createMuxMock()
+    const secondMux = createMuxMock()
+    vi.mocked(getActiveMultiplexer).mockReturnValue(firstMux as never)
+    const service = new LspService()
+
+    await service.openDocument(documentArgs({ connectionId: 'ssh-1', content: 'int before;' }))
+    expect(firstMux.onNotificationByMethod).toHaveBeenCalledTimes(1)
+
+    vi.mocked(getActiveMultiplexer).mockReturnValue(secondMux as never)
+    await service.completion(requestArgs({ connectionId: 'ssh-1' }))
+
+    expect(secondMux.onNotificationByMethod).toHaveBeenCalledTimes(1)
+    expect(secondMux.request).toHaveBeenCalledWith(
+      'lsp.openDocument',
+      expect.objectContaining({
+        connectionId: 'ssh-1',
+        filePath: '/repo/main.c',
+        content: 'int before;'
+      })
+    )
+    expect(secondMux.request).toHaveBeenCalledWith(
+      'lsp.completion',
+      expect.objectContaining({ filePath: '/repo/main.c' })
+    )
+  })
+
+  it('returns unavailable when an older SSH relay does not support LSP status', async () => {
+    const mux = createMuxMock()
+    mux.request.mockRejectedValueOnce(
+      Object.assign(new Error('Method not found: lsp.getStatus'), {
+        code: -32601
+      })
+    )
+    vi.mocked(getActiveMultiplexer).mockReturnValue(mux as never)
+    const service = new LspService()
+
+    await expect(
+      service.getStatus({ worktreePath: '/repo', languageId: 'c', connectionId: 'ssh-1' })
+    ).resolves.toMatchObject({
+      state: 'unavailable',
+      languageId: 'c',
+      reason: expect.stringContaining('Remote relay does not support LSP')
+    })
+  })
+
+  it('reopens remote documents before forwarding edits on a new SSH mux', async () => {
+    const firstMux = createMuxMock()
+    const secondMux = createMuxMock()
+    vi.mocked(getActiveMultiplexer).mockReturnValue(firstMux as never)
+    const service = new LspService()
+
+    await service.openDocument(documentArgs({ connectionId: 'ssh-1', content: 'int before;' }))
+
+    vi.mocked(getActiveMultiplexer).mockReturnValue(secondMux as never)
+    await service.changeDocument(documentArgs({ connectionId: 'ssh-1', content: 'int after;' }))
+
+    expect(secondMux.request).toHaveBeenCalledWith(
+      'lsp.openDocument',
+      expect.objectContaining({
+        connectionId: 'ssh-1',
+        filePath: '/repo/main.c',
+        content: 'int after;'
+      })
+    )
+    expect(secondMux.request).toHaveBeenCalledWith(
+      'lsp.changeDocument',
+      expect.objectContaining({
+        connectionId: 'ssh-1',
+        filePath: '/repo/main.c',
+        content: 'int after;'
+      })
+    )
+  })
+
+  it('eagerly reopens tracked remote documents when an SSH mux becomes ready', async () => {
+    const firstMux = createMuxMock()
+    const secondMux = createMuxMock()
+    vi.mocked(getActiveMultiplexer).mockReturnValue(firstMux as never)
+    const service = new LspService()
+
+    await service.openDocument(
+      documentArgs({ connectionId: 'ssh-1', content: 'int before;', documentId: 'doc-1' })
+    )
+
+    vi.mocked(getActiveMultiplexer).mockReturnValue(secondMux as never)
+    for (const listener of mocks.multiplexerReadyListeners) {
+      listener('ssh-1')
+    }
+    await flushPromises()
+
+    expect(secondMux.onNotificationByMethod).toHaveBeenCalledTimes(1)
+    expect(secondMux.request).toHaveBeenCalledWith(
+      'lsp.openDocument',
+      expect.objectContaining({
+        connectionId: 'ssh-1',
+        filePath: '/repo/main.c',
+        documentId: 'doc-1',
+        content: 'int before;'
+      })
+    )
+
+    await service.disposeAll()
+    expect(mocks.multiplexerReadyListeners.size).toBe(0)
+  })
+
+  it('reopens tracked remote documents when an SSH relay reconnects on the same mux', async () => {
+    const mux = createMuxMock()
+    vi.mocked(getActiveMultiplexer).mockReturnValue(mux as never)
+    const service = new LspService()
+
+    await service.openDocument(
+      documentArgs({ connectionId: 'ssh-1', content: 'int before;', documentId: 'doc-1' })
+    )
+    mux.request.mockClear()
+
+    for (const listener of mocks.multiplexerReadyListeners) {
+      listener('ssh-1')
+    }
+    await flushPromises()
+
+    expect(mux.request).toHaveBeenCalledWith(
+      'lsp.openDocument',
+      expect.objectContaining({
+        connectionId: 'ssh-1',
+        filePath: '/repo/main.c',
+        documentId: 'doc-1',
+        content: 'int before;'
+      })
+    )
+  })
+
+  it('does not double-count a remote document reopened after SSH reconnect', async () => {
+    const firstMux = createMuxMock()
+    const secondMux = createMuxMock()
+    vi.mocked(getActiveMultiplexer).mockReturnValue(firstMux as never)
+    const service = new LspService()
+
+    await service.openDocument(
+      documentArgs({ connectionId: 'ssh-1', content: 'int before;', documentId: 'doc-1' })
+    )
+
+    vi.mocked(getActiveMultiplexer).mockReturnValue(secondMux as never)
+    await service.openDocument(
+      documentArgs({ connectionId: 'ssh-1', content: 'int after;', documentId: 'doc-1' })
+    )
+    await service.closeDocument(documentArgs({ connectionId: 'ssh-1', documentId: 'doc-1' }))
+
+    expect(secondMux.request).toHaveBeenCalledWith(
+      'lsp.closeDocument',
+      expect.objectContaining({ filePath: '/repo/main.c', documentId: 'doc-1' })
+    )
+  })
+
+  it('replays every remote document id for a multi-view file after SSH reconnect', async () => {
+    const firstMux = createMuxMock()
+    const secondMux = createMuxMock()
+    vi.mocked(getActiveMultiplexer).mockReturnValue(firstMux as never)
+    const service = new LspService()
+
+    await service.openDocument(
+      documentArgs({ connectionId: 'ssh-1', content: 'int first;', documentId: 'doc-1' })
+    )
+    await service.openDocument(
+      documentArgs({ connectionId: 'ssh-1', content: 'int second;', documentId: 'doc-2' })
+    )
+
+    vi.mocked(getActiveMultiplexer).mockReturnValue(secondMux as never)
+    await service.completion(requestArgs({ connectionId: 'ssh-1' }))
+
+    expect(secondMux.request).toHaveBeenCalledWith(
+      'lsp.openDocument',
+      expect.objectContaining({ filePath: '/repo/main.c', documentId: 'doc-1' })
+    )
+    expect(secondMux.request).toHaveBeenCalledWith(
+      'lsp.openDocument',
+      expect.objectContaining({ filePath: '/repo/main.c', documentId: 'doc-2' })
+    )
+  })
+
+  it('clears tracked remote diagnostics when an SSH mux is disposed', async () => {
+    const mux = createMuxMock()
+    const send = vi.fn()
+    mocks.getAllWindowsMock.mockReturnValue([
+      {
+        isDestroyed: () => false,
+        webContents: { send }
+      }
+    ] as never)
+    vi.mocked(getActiveMultiplexer).mockReturnValue(mux as never)
+    const service = new LspService()
+
+    await service.openDocument(documentArgs({ connectionId: 'ssh-1', content: 'int before;' }))
+
+    mux.disposeMux()
+
+    expect(send).toHaveBeenCalledWith(
+      'lsp:diagnostics',
+      expect.objectContaining({
+        connectionId: 'ssh-1',
+        filePath: '/repo/main.c',
+        diagnostics: []
+      })
+    )
+  })
+})

--- a/src/main/lsp/lsp-service.ts
+++ b/src/main/lsp/lsp-service.ts
@@ -1,0 +1,665 @@
+/* eslint-disable max-lines -- Why: this service owns the local/SSH routing
+boundary for all LSP lifecycle methods; keeping the paired paths together makes
+failure cleanup and diagnostics forwarding easier to audit. */
+import { BrowserWindow } from 'electron'
+import type {
+  LspCompletionResult,
+  LspDiagnosticsEvent,
+  LspDocumentChange,
+  LspDocumentContext,
+  LspHover,
+  LspLocation,
+  LspRequestContext,
+  LspServerStatus
+} from '../../shared/lsp-types'
+import { getActiveMultiplexer, onActiveMultiplexerReady } from '../ipc/ssh'
+import { resolveLanguageServerCommand } from './language-server-registry'
+import { LspProcessSession, type LspProcessStats } from './lsp-process-session'
+
+type SessionKey = string
+
+type ManagedSession = {
+  key: SessionKey
+  worktreePath: string
+  languageId: string
+  connectionId?: string
+  runtimeEnvironmentId?: string
+  session: LspProcessSession
+  idleTimer: ReturnType<typeof setTimeout> | null
+}
+
+type TrackedDocument = LspDocumentContext & { documentIds: Set<string> }
+type ActiveMultiplexer = NonNullable<ReturnType<typeof getActiveMultiplexer>>
+
+export type LspServiceStats = {
+  activeSessions: number
+  sessions: ({
+    key: string
+    worktreePath: string
+    languageId: string
+    connectionId?: string
+    runtimeEnvironmentId?: string
+  } & LspProcessStats)[]
+}
+
+const IDLE_SESSION_TTL_MS = 60_000
+
+function sessionKey(args: {
+  worktreePath: string
+  languageId: string
+  connectionId?: string
+  runtimeEnvironmentId?: string
+}): string {
+  return `${args.connectionId ?? 'local'}\0${args.runtimeEnvironmentId ?? 'default'}\0${args.worktreePath}\0${args.languageId}`
+}
+
+function assertRuntimeSupported(args: {
+  runtimeEnvironmentId?: string
+  connectionId?: string
+}): void {
+  if (args.runtimeEnvironmentId) {
+    throw new Error('LSP is not available for runtime environments yet')
+  }
+}
+
+function documentReferenceId(args: { filePath: string; documentId?: string }): string {
+  return args.documentId ?? `legacy:${args.filePath}`
+}
+
+function isRelayMethodNotFound(error: unknown, method: string): boolean {
+  const candidate = error as { code?: unknown; message?: unknown }
+  return (
+    candidate.code === -32601 ||
+    (typeof candidate.message === 'string' &&
+      candidate.message.includes(`Method not found: ${method}`))
+  )
+}
+
+function publishDiagnostics(event: LspDiagnosticsEvent): void {
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (!win.isDestroyed()) {
+      win.webContents.send('lsp:diagnostics', event)
+    }
+  }
+}
+
+export class LspService {
+  private sessions = new Map<SessionKey, ManagedSession>()
+  private pendingSessions = new Map<SessionKey, Promise<ManagedSession>>()
+  private openDocuments = new Map<SessionKey, Map<string, TrackedDocument>>()
+  private remoteDiagnosticsDisposers = new Map<string, () => void>()
+  private remoteDiagnosticsMultiplexers = new Map<string, ActiveMultiplexer>()
+  private remoteSessionMultiplexers = new Map<SessionKey, ActiveMultiplexer>()
+  private readonly disposeMultiplexerReadyListener: () => void
+  private disposed = false
+
+  constructor() {
+    this.disposeMultiplexerReadyListener = onActiveMultiplexerReady((connectionId) => {
+      void this.reopenRemoteDocumentsForConnection(connectionId).catch((error) => {
+        console.warn(`[lsp] Failed to reopen remote documents for ${connectionId}:`, error)
+      })
+    })
+  }
+
+  async getStatus(args: {
+    worktreePath: string
+    languageId: string
+    connectionId?: string
+    runtimeEnvironmentId?: string
+  }): Promise<LspServerStatus> {
+    if (args.runtimeEnvironmentId) {
+      return {
+        state: 'unavailable',
+        languageId: args.languageId,
+        reason: 'LSP is not available for runtime environments yet'
+      }
+    }
+    if (args.connectionId) {
+      const mux = getActiveMultiplexer(args.connectionId)
+      if (!mux || mux.isDisposed()) {
+        return {
+          state: 'unavailable',
+          languageId: args.languageId,
+          reason: `No active SSH connection for "${args.connectionId}"`
+        }
+      }
+      try {
+        return (await mux.request('lsp.getStatus', {
+          worktreePath: args.worktreePath,
+          languageId: args.languageId
+        })) as LspServerStatus
+      } catch (error) {
+        if (isRelayMethodNotFound(error, 'lsp.getStatus')) {
+          return {
+            state: 'unavailable',
+            languageId: args.languageId,
+            reason: 'Remote relay does not support LSP yet; reconnect SSH to update it'
+          }
+        }
+        throw error
+      }
+    }
+    const resolved = await resolveLanguageServerCommand(args.languageId)
+    if (!resolved.ok) {
+      return { state: 'unavailable', languageId: args.languageId, reason: resolved.reason }
+    }
+    return {
+      state: 'available',
+      languageId: args.languageId,
+      command: [resolved.command.command, ...resolved.command.args].join(' ')
+    }
+  }
+
+  async openDocument(args: LspDocumentContext): Promise<LspServerStatus> {
+    assertRuntimeSupported(args)
+    const key = sessionKey(args)
+    const wasTracked = this.openDocuments.get(key)?.has(args.filePath) ?? false
+    if (args.connectionId) {
+      this.ensureRemoteDiagnosticsHandler(args.connectionId)
+      await this.ensureRemoteDocumentsOpen(args)
+      const status = await this.remoteRequest<LspServerStatus>(
+        args.connectionId,
+        'lsp.openDocument',
+        args
+      )
+      this.trackOpenDocument(args)
+      this.rememberRemoteMultiplexer(args)
+      return status
+    }
+    const session = await this.getOrCreateLocalSession(args)
+    try {
+      await (wasTracked
+        ? session.session.changeDocument(args.filePath, args.content)
+        : session.session.openDocument(args.filePath, args.languageId, args.content))
+      this.trackOpenDocument(args)
+    } catch (error) {
+      await this.disposeBrokenSession(session)
+      throw error
+    }
+    return {
+      state: 'available',
+      languageId: args.languageId
+    }
+  }
+
+  async changeDocument(args: LspDocumentChange): Promise<void> {
+    assertRuntimeSupported(args)
+    const tracked = this.updateTrackedDocument(args)
+    if (args.connectionId) {
+      await this.ensureRemoteDocumentsOpen(args)
+      await this.remoteRequest(args.connectionId, 'lsp.changeDocument', args)
+      return
+    }
+    const existing = this.sessions.get(sessionKey(args))
+    if (!existing) {
+      if (tracked) {
+        const recreated = await this.getOrCreateLocalSession(tracked)
+        await recreated.session.changeDocument(args.filePath, args.content)
+      }
+      return
+    }
+    this.cancelIdleDispose(existing)
+    try {
+      await existing.session.changeDocument(args.filePath, args.content)
+    } catch (error) {
+      await this.disposeBrokenSession(existing)
+      if (!tracked) {
+        throw error
+      }
+      const recreated = await this.getOrCreateLocalSession(tracked)
+      try {
+        await recreated.session.changeDocument(args.filePath, args.content)
+      } catch (retryError) {
+        await this.disposeBrokenSession(recreated)
+        throw retryError
+      }
+    }
+  }
+
+  async closeDocument(args: Omit<LspDocumentChange, 'content'>): Promise<void> {
+    assertRuntimeSupported(args)
+    const key = sessionKey(args)
+    const shouldCloseDocument = this.releaseOpenDocument(key, args)
+    if (!shouldCloseDocument) {
+      return
+    }
+    if (args.connectionId) {
+      await this.remoteRequest(args.connectionId, 'lsp.closeDocument', args)
+      return
+    }
+    const existing = this.sessions.get(key)
+    if (!existing) {
+      return
+    }
+    try {
+      await existing.session.closeDocument(args.filePath)
+    } catch (error) {
+      await this.disposeBrokenSession(existing)
+      throw error
+    }
+    if (existing.session.getOpenDocumentCount() === 0) {
+      this.scheduleIdleDispose(existing)
+    }
+  }
+
+  async completion(args: LspRequestContext): Promise<LspCompletionResult | null> {
+    assertRuntimeSupported(args)
+    if (args.connectionId) {
+      await this.ensureRemoteDocumentsOpen(args)
+      return this.remoteRequest(args.connectionId, 'lsp.completion', args)
+    }
+    const session = await this.getOrCreateLocalSession({
+      ...args,
+      worktreeId: args.worktreeId,
+      content: args.content ?? ''
+    })
+    try {
+      return await session.session.completion(args.filePath, args.position, args.content)
+    } catch {
+      await this.disposeBrokenSession(session)
+      return await this.retryLocalRequest(args, (entry) =>
+        entry.session.completion(args.filePath, args.position, args.content)
+      )
+    }
+  }
+
+  async hover(args: LspRequestContext): Promise<LspHover | null> {
+    assertRuntimeSupported(args)
+    if (args.connectionId) {
+      await this.ensureRemoteDocumentsOpen(args)
+      return this.remoteRequest(args.connectionId, 'lsp.hover', args)
+    }
+    const session = await this.getOrCreateLocalSession({
+      ...args,
+      worktreeId: args.worktreeId,
+      content: args.content ?? ''
+    })
+    try {
+      return await session.session.hover(args.filePath, args.position, args.content)
+    } catch {
+      await this.disposeBrokenSession(session)
+      return await this.retryLocalRequest(args, (entry) =>
+        entry.session.hover(args.filePath, args.position, args.content)
+      )
+    }
+  }
+
+  async definition(args: LspRequestContext): Promise<LspLocation[]> {
+    assertRuntimeSupported(args)
+    if (args.connectionId) {
+      await this.ensureRemoteDocumentsOpen(args)
+      return this.remoteRequest(args.connectionId, 'lsp.definition', args)
+    }
+    const session = await this.getOrCreateLocalSession({
+      ...args,
+      worktreeId: args.worktreeId,
+      content: args.content ?? ''
+    })
+    try {
+      return await session.session.definition(args.filePath, args.position, args.content)
+    } catch {
+      await this.disposeBrokenSession(session)
+      return await this.retryLocalRequest(args, (entry) =>
+        entry.session.definition(args.filePath, args.position, args.content)
+      )
+    }
+  }
+
+  getStats(): LspServiceStats {
+    return {
+      activeSessions: this.sessions.size,
+      sessions: Array.from(this.sessions.values()).map((entry) => ({
+        key: entry.key,
+        worktreePath: entry.worktreePath,
+        languageId: entry.languageId,
+        connectionId: entry.connectionId,
+        runtimeEnvironmentId: entry.runtimeEnvironmentId,
+        ...entry.session.getStats()
+      }))
+    }
+  }
+
+  async disposeAll(): Promise<void> {
+    this.disposed = true
+    this.disposeMultiplexerReadyListener()
+    const sessions = Array.from(this.sessions.values())
+    this.sessions.clear()
+    this.pendingSessions.clear()
+    this.openDocuments.clear()
+    this.remoteDiagnosticsMultiplexers.clear()
+    this.remoteSessionMultiplexers.clear()
+    for (const dispose of this.remoteDiagnosticsDisposers.values()) {
+      dispose()
+    }
+    this.remoteDiagnosticsDisposers.clear()
+    await Promise.all(
+      sessions.map(async (entry) => {
+        if (entry.idleTimer) {
+          clearTimeout(entry.idleTimer)
+        }
+        await entry.session.dispose()
+      })
+    )
+  }
+
+  private async remoteRequest<T>(connectionId: string, method: string, args: unknown): Promise<T> {
+    const mux = getActiveMultiplexer(connectionId)
+    if (!mux || mux.isDisposed()) {
+      throw new Error(`No active SSH connection for "${connectionId}"`)
+    }
+    return (await mux.request(method, args as Record<string, unknown>)) as T
+  }
+
+  private ensureRemoteDiagnosticsHandler(connectionId: string): void {
+    const mux = getActiveMultiplexer(connectionId)
+    if (!mux || mux.isDisposed()) {
+      return
+    }
+    if (this.remoteDiagnosticsMultiplexers.get(connectionId) === mux) {
+      return
+    }
+    this.remoteDiagnosticsDisposers.get(connectionId)?.()
+    this.remoteDiagnosticsDisposers.delete(connectionId)
+    this.remoteDiagnosticsMultiplexers.delete(connectionId)
+    const disposeDiagnostics = mux.onNotificationByMethod('lsp.diagnostics', (params) => {
+      const event = params as unknown as Omit<LspDiagnosticsEvent, 'connectionId'>
+      publishDiagnostics({ ...event, connectionId })
+    })
+    const disposeMux = mux.onDispose(() => {
+      this.remoteDiagnosticsDisposers.delete(connectionId)
+      this.remoteDiagnosticsMultiplexers.delete(connectionId)
+      for (const [key, trackedMux] of this.remoteSessionMultiplexers) {
+        if (trackedMux === mux) {
+          this.clearTrackedDiagnostics(key, connectionId)
+          this.remoteSessionMultiplexers.delete(key)
+        }
+      }
+    })
+    this.remoteDiagnosticsDisposers.set(connectionId, () => {
+      disposeDiagnostics()
+      disposeMux()
+    })
+    this.remoteDiagnosticsMultiplexers.set(connectionId, mux)
+  }
+
+  private async reopenRemoteDocumentsForConnection(connectionId: string): Promise<void> {
+    if (this.disposed) {
+      return
+    }
+    const mux = getActiveMultiplexer(connectionId)
+    if (!mux || mux.isDisposed()) {
+      return
+    }
+    this.ensureRemoteDiagnosticsHandler(connectionId)
+    for (const documents of this.openDocuments.values()) {
+      const firstDocument = documents.values().next().value
+      if (!firstDocument || firstDocument.connectionId !== connectionId) {
+        continue
+      }
+      try {
+        await this.ensureRemoteDocumentsOpen(firstDocument, { force: true })
+      } catch {
+        // Why: readiness is an opportunistic recovery signal; user-initiated
+        // requests still surface relay/version failures with their own context.
+      }
+    }
+  }
+
+  private rememberRemoteMultiplexer(args: {
+    connectionId?: string
+    worktreePath: string
+    languageId: string
+    runtimeEnvironmentId?: string
+  }): void {
+    if (!args.connectionId) {
+      return
+    }
+    const mux = getActiveMultiplexer(args.connectionId)
+    if (mux && !mux.isDisposed()) {
+      this.remoteSessionMultiplexers.set(sessionKey(args), mux)
+    }
+  }
+
+  private trackOpenDocument(args: LspDocumentContext): void {
+    const key = sessionKey(args)
+    const documents = this.openDocuments.get(key) ?? new Map<string, TrackedDocument>()
+    const existing = documents.get(args.filePath)
+    const documentIds = existing?.documentIds ?? new Set<string>()
+    documentIds.add(documentReferenceId(args))
+    documents.set(args.filePath, {
+      ...args,
+      documentIds
+    })
+    this.openDocuments.set(key, documents)
+  }
+
+  private updateTrackedDocument(args: LspDocumentChange): TrackedDocument | undefined {
+    const documents = this.openDocuments.get(sessionKey(args))
+    const tracked = documents?.get(args.filePath)
+    if (!tracked) {
+      return undefined
+    }
+    tracked.content = args.content
+    return tracked
+  }
+
+  private releaseOpenDocument(
+    key: SessionKey,
+    args: { filePath: string; documentId?: string }
+  ): boolean {
+    const documents = this.openDocuments.get(key)
+    if (!documents) {
+      return true
+    }
+    const tracked = documents.get(args.filePath)
+    if (!tracked) {
+      return true
+    }
+    tracked.documentIds.delete(documentReferenceId(args))
+    if (tracked.documentIds.size > 0) {
+      return false
+    }
+    documents.delete(args.filePath)
+    if (documents.size === 0) {
+      this.openDocuments.delete(key)
+    }
+    return true
+  }
+
+  private async ensureRemoteDocumentsOpen(
+    args: {
+      connectionId?: string
+      worktreePath: string
+      languageId: string
+      runtimeEnvironmentId?: string
+    },
+    options: { force?: boolean } = {}
+  ): Promise<void> {
+    if (!args.connectionId) {
+      return
+    }
+    const mux = getActiveMultiplexer(args.connectionId)
+    if (!mux || mux.isDisposed()) {
+      throw new Error(`No active SSH connection for "${args.connectionId}"`)
+    }
+    const key = sessionKey(args)
+    if (!options.force && this.remoteSessionMultiplexers.get(key) === mux) {
+      return
+    }
+    this.ensureRemoteDiagnosticsHandler(args.connectionId)
+    const documents = this.openDocuments.get(key)
+    if (!documents) {
+      this.remoteSessionMultiplexers.set(key, mux)
+      return
+    }
+    // Why: a new SSH multiplexer usually means a new relay process. Re-open
+    // tracked docs once so request-time completions still avoid sending content.
+    for (const document of documents.values()) {
+      const { documentIds: _documentIds, ...payload } = document
+      for (const documentId of document.documentIds) {
+        await mux.request('lsp.openDocument', { ...payload, documentId })
+      }
+    }
+    this.remoteSessionMultiplexers.set(key, mux)
+  }
+
+  private clearTrackedDiagnostics(key: SessionKey, connectionId?: string): void {
+    const documents = this.openDocuments.get(key)
+    if (!documents) {
+      return
+    }
+    for (const document of documents.values()) {
+      publishDiagnostics({
+        worktreePath: document.worktreePath,
+        filePath: document.filePath,
+        languageId: document.languageId,
+        connectionId,
+        runtimeEnvironmentId: document.runtimeEnvironmentId,
+        diagnostics: []
+      })
+    }
+  }
+
+  private async retryLocalRequest<T>(
+    args: LspRequestContext,
+    request: (entry: ManagedSession) => Promise<T>
+  ): Promise<T> {
+    const retried = await this.getOrCreateLocalSession({
+      ...args,
+      worktreeId: args.worktreeId,
+      content: args.content ?? ''
+    })
+    try {
+      return await request(retried)
+    } catch (error) {
+      await this.disposeBrokenSession(retried)
+      throw error
+    }
+  }
+
+  private async getOrCreateLocalSession(args: LspDocumentContext): Promise<ManagedSession> {
+    if (this.disposed) {
+      throw new Error('LSP service is shutting down')
+    }
+    const key = sessionKey(args)
+    const existing = this.sessions.get(key)
+    if (existing) {
+      this.cancelIdleDispose(existing)
+      return existing
+    }
+    const pending = this.pendingSessions.get(key)
+    if (pending) {
+      return pending
+    }
+    // Why: restoring split panes can open same-language files concurrently.
+    // Share one creation promise so command discovery cannot orphan an
+    // overwritten language-server process for the same session key.
+    const created = this.createLocalSession(key, args)
+    this.pendingSessions.set(key, created)
+    try {
+      return await created
+    } finally {
+      if (this.pendingSessions.get(key) === created) {
+        this.pendingSessions.delete(key)
+      }
+    }
+  }
+
+  private async createLocalSession(
+    key: SessionKey,
+    args: LspDocumentContext
+  ): Promise<ManagedSession> {
+    if (this.disposed) {
+      throw new Error('LSP service is shutting down')
+    }
+    const resolved = await resolveLanguageServerCommand(args.languageId)
+    if (this.disposed) {
+      throw new Error('LSP service is shutting down')
+    }
+    if (!resolved.ok) {
+      throw new Error(resolved.reason)
+    }
+    const entry: ManagedSession = {
+      key,
+      worktreePath: args.worktreePath,
+      languageId: args.languageId,
+      connectionId: args.connectionId,
+      runtimeEnvironmentId: args.runtimeEnvironmentId,
+      session: new LspProcessSession({
+        rootPath: args.worktreePath,
+        languageId: args.languageId,
+        server: resolved.command,
+        connectionId: args.connectionId,
+        onDiagnostics: (event) => {
+          publishDiagnostics({
+            worktreePath: args.worktreePath,
+            filePath: event.filePath,
+            languageId: event.languageId,
+            connectionId: args.connectionId,
+            runtimeEnvironmentId: args.runtimeEnvironmentId,
+            diagnostics: event.diagnostics
+          })
+        }
+      }),
+      idleTimer: null
+    }
+    this.sessions.set(key, entry)
+    try {
+      await this.reopenTrackedDocuments(entry)
+      if (this.disposed) {
+        throw new Error('LSP service is shutting down')
+      }
+    } catch (error) {
+      this.sessions.delete(key)
+      await entry.session.dispose().catch(() => undefined)
+      throw error
+    }
+    return entry
+  }
+
+  private async reopenTrackedDocuments(entry: ManagedSession): Promise<void> {
+    const documents = this.openDocuments.get(entry.key)
+    if (!documents) {
+      return
+    }
+    // Why: request paths intentionally omit document content for perf. If a
+    // language-server process is recreated, replay the last synced open docs.
+    for (const document of documents.values()) {
+      await entry.session.openDocument(document.filePath, document.languageId, document.content)
+    }
+  }
+
+  private cancelIdleDispose(entry: ManagedSession): void {
+    if (entry.idleTimer) {
+      clearTimeout(entry.idleTimer)
+      entry.idleTimer = null
+    }
+  }
+
+  private scheduleIdleDispose(entry: ManagedSession): void {
+    this.cancelIdleDispose(entry)
+    // Why: language servers hold project indexes and file handles. Keep the
+    // server warm for quick tab switches, then tear it down once Orca has no
+    // open documents for that worktree/language.
+    entry.idleTimer = setTimeout(() => {
+      if (entry.session.getOpenDocumentCount() > 0) {
+        return
+      }
+      this.sessions.delete(entry.key)
+      void entry.session.dispose()
+    }, IDLE_SESSION_TTL_MS)
+    entry.idleTimer.unref?.()
+  }
+
+  private async disposeBrokenSession(entry: ManagedSession): Promise<void> {
+    this.sessions.delete(entry.key)
+    if (entry.idleTimer) {
+      clearTimeout(entry.idleTimer)
+      entry.idleTimer = null
+    }
+    this.clearTrackedDiagnostics(entry.key, entry.connectionId)
+    await entry.session.dispose().catch(() => undefined)
+  }
+}
+
+export const lspService = new LspService()

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -313,6 +313,17 @@ import type {
   AutomationUpdateInput
 } from '../shared/automations-types'
 import type {
+  LspCompletionResult,
+  LspDiagnosticsEvent,
+  LspDocumentChange,
+  LspDocumentContext,
+  LspDocumentIdentity,
+  LspHover,
+  LspLocation,
+  LspRequestContext,
+  LspServerStatus
+} from '../shared/lsp-types'
+import type {
   WorkspaceCleanupDismissArgs,
   WorkspaceCleanupLocalProcessArgs,
   WorkspaceCleanupLocalProcessResult,
@@ -1632,6 +1643,20 @@ export type PreloadApi = {
   claudeUsage: ClaudeUsageApi
   codexUsage: CodexUsageApi
   openCodeUsage: OpenCodeUsageApi
+  lsp: {
+    getStatus: (args: LspDocumentIdentity) => Promise<LspServerStatus>
+    openDocument: (args: LspDocumentContext) => Promise<LspServerStatus>
+    changeDocument: (args: LspDocumentChange) => Promise<void>
+    closeDocument: (args: Omit<LspDocumentChange, 'content'>) => Promise<void>
+    completion: (args: LspRequestContext) => Promise<LspCompletionResult | null>
+    hover: (args: LspRequestContext) => Promise<LspHover | null>
+    definition: (args: LspRequestContext) => Promise<LspLocation[]>
+    getStats: () => Promise<{
+      activeSessions: number
+      sessions: Record<string, unknown>[]
+    }>
+    onDiagnostics: (callback: (event: LspDiagnosticsEvent) => void) => () => void
+  }
   fs: {
     readDir: (args: { dirPath: string; connectionId?: string }) => Promise<DirEntry[]>
     readFile: (args: {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -157,6 +157,17 @@ import type {
   ReactErrorBoundaryReportResult
 } from '../shared/crash-reporting'
 import type { PreloadApi } from './api-types'
+import type {
+  LspCompletionResult,
+  LspDiagnosticsEvent,
+  LspDocumentChange,
+  LspDocumentContext,
+  LspDocumentIdentity,
+  LspHover,
+  LspLocation,
+  LspRequestContext,
+  LspServerStatus
+} from '../shared/lsp-types'
 
 type NativeFileDropCallback = (data: NativeFileDropPayload) => void
 
@@ -2025,6 +2036,31 @@ const api = {
       return () => ipcRenderer.removeListener('updater:clearDismissal', listener)
     }
   } satisfies PreloadApi['updater'],
+
+  lsp: {
+    getStatus: (args: LspDocumentIdentity): Promise<LspServerStatus> =>
+      ipcRenderer.invoke('lsp:getStatus', args),
+    openDocument: (args: LspDocumentContext): Promise<LspServerStatus> =>
+      ipcRenderer.invoke('lsp:openDocument', args),
+    changeDocument: (args: LspDocumentChange): Promise<void> =>
+      ipcRenderer.invoke('lsp:changeDocument', args),
+    closeDocument: (args: Omit<LspDocumentChange, 'content'>): Promise<void> =>
+      ipcRenderer.invoke('lsp:closeDocument', args),
+    completion: (args: LspRequestContext): Promise<LspCompletionResult | null> =>
+      ipcRenderer.invoke('lsp:completion', args),
+    hover: (args: LspRequestContext): Promise<LspHover | null> =>
+      ipcRenderer.invoke('lsp:hover', args),
+    definition: (args: LspRequestContext): Promise<LspLocation[]> =>
+      ipcRenderer.invoke('lsp:definition', args),
+    getStats: (): Promise<{ activeSessions: number; sessions: Record<string, unknown>[] }> =>
+      ipcRenderer.invoke('lsp:getStats'),
+    onDiagnostics: (callback: (event: LspDiagnosticsEvent) => void): (() => void) => {
+      const listener = (_event: Electron.IpcRendererEvent, payload: LspDiagnosticsEvent) =>
+        callback(payload)
+      ipcRenderer.on('lsp:diagnostics', listener)
+      return () => ipcRenderer.removeListener('lsp:diagnostics', listener)
+    }
+  },
 
   notebook: {
     runPythonCell: (args: {

--- a/src/relay/lsp-handler-session.test.ts
+++ b/src/relay/lsp-handler-session.test.ts
@@ -1,0 +1,263 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RelayDispatcher } from './dispatcher'
+
+const mocks = vi.hoisted(() => {
+  const instances: MockLspProcessSession[] = []
+  const resolveLanguageServerCommandMock = vi.fn()
+
+  class MockLspProcessSession {
+    readonly documents = new Set<string>()
+    readonly openDocument = vi.fn(async (filePath: string) => {
+      this.documents.add(filePath)
+    })
+    readonly changeDocument = vi.fn(async (filePath: string) => {
+      this.documents.add(filePath)
+    })
+    readonly closeDocument = vi.fn(async (filePath: string) => {
+      this.documents.delete(filePath)
+    })
+    readonly dispose = vi.fn(async () => undefined)
+    readonly completion = vi.fn(async () => null)
+    readonly hover = vi.fn(async () => null)
+    readonly definition = vi.fn(async () => [])
+    readonly getOpenDocumentCount = vi.fn(() => this.documents.size)
+    readonly getStats = vi.fn(() => ({
+      startedAt: 0,
+      initializedAt: 0,
+      requestCount: 0,
+      notificationCount: 0,
+      openDocumentCount: this.documents.size
+    }))
+
+    constructor() {
+      instances.push(this)
+    }
+  }
+
+  return { instances, MockLspProcessSession, resolveLanguageServerCommandMock }
+})
+
+vi.mock('../main/lsp/language-server-registry', () => ({
+  resolveLanguageServerCommand: mocks.resolveLanguageServerCommandMock
+}))
+
+vi.mock('../main/lsp/lsp-process-session', () => ({
+  LspProcessSession: mocks.MockLspProcessSession
+}))
+
+import { LspHandler } from './lsp-handler'
+
+function deferred<T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+} {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
+function createMockDispatcher() {
+  const requestHandlers = new Map<string, (params: Record<string, unknown>) => Promise<unknown>>()
+  return {
+    onRequest: vi.fn(
+      (method: string, handler: (params: Record<string, unknown>) => Promise<unknown>) => {
+        requestHandlers.set(method, handler)
+      }
+    ),
+    notify: vi.fn(),
+    async callRequest(method: string, params: Record<string, unknown> = {}) {
+      const handler = requestHandlers.get(method)
+      if (!handler) {
+        throw new Error(`No handler for ${method}`)
+      }
+      return handler(params)
+    }
+  }
+}
+
+describe('LspHandler session ownership', () => {
+  beforeEach(() => {
+    mocks.instances.length = 0
+    mocks.resolveLanguageServerCommandMock.mockReset()
+    mocks.resolveLanguageServerCommandMock.mockResolvedValue({
+      ok: true,
+      command: { command: '/usr/bin/clangd', args: [] }
+    })
+  })
+
+  it('dedupes concurrent relay session creation for the same key', async () => {
+    const discovery = deferred<{
+      ok: true
+      command: { command: string; args: string[] }
+    }>()
+    mocks.resolveLanguageServerCommandMock.mockReturnValue(discovery.promise)
+    const dispatcher = createMockDispatcher()
+    const handler = new LspHandler(dispatcher as unknown as RelayDispatcher)
+
+    const firstOpen = dispatcher.callRequest('lsp.openDocument', {
+      worktreeId: 'wt-1',
+      worktreePath: '/repo',
+      filePath: '/repo/a.c',
+      languageId: 'c',
+      content: 'int a;'
+    })
+    const secondOpen = dispatcher.callRequest('lsp.openDocument', {
+      worktreeId: 'wt-1',
+      worktreePath: '/repo',
+      filePath: '/repo/b.c',
+      languageId: 'c',
+      content: 'int b;'
+    })
+    await Promise.resolve()
+    expect(mocks.resolveLanguageServerCommandMock).toHaveBeenCalledTimes(1)
+
+    discovery.resolve({ ok: true, command: { command: '/usr/bin/clangd', args: [] } })
+    await Promise.all([firstOpen, secondOpen])
+
+    expect(mocks.instances).toHaveLength(1)
+    expect(mocks.instances[0].documents).toEqual(new Set(['/repo/a.c', '/repo/b.c']))
+    await handler.dispose()
+  })
+
+  it('reopens tracked documents when recovering a lost relay session', async () => {
+    const dispatcher = createMockDispatcher()
+    const handler = new LspHandler(dispatcher as unknown as RelayDispatcher)
+
+    await dispatcher.callRequest('lsp.openDocument', {
+      worktreeId: 'wt-1',
+      worktreePath: '/repo',
+      filePath: '/repo/main.c',
+      languageId: 'c',
+      content: 'int before;'
+    })
+    await dispatcher.callRequest('lsp.changeDocument', {
+      worktreePath: '/repo',
+      filePath: '/repo/main.c',
+      languageId: 'c',
+      content: 'int after;'
+    })
+    const crashed = mocks.instances[0]
+    crashed.completion.mockRejectedValueOnce(new Error('server exited'))
+
+    await expect(
+      dispatcher.callRequest('lsp.completion', {
+        worktreeId: 'wt-1',
+        worktreePath: '/repo',
+        filePath: '/repo/main.c',
+        languageId: 'c',
+        position: { line: 0, character: 4 }
+      })
+    ).resolves.toBeNull()
+
+    expect(mocks.instances).toHaveLength(2)
+    expect(mocks.instances[1].openDocument).toHaveBeenCalledWith('/repo/main.c', 'c', 'int after;')
+    expect(mocks.instances[1].completion).toHaveBeenCalledWith(
+      '/repo/main.c',
+      { line: 0, character: 4 },
+      undefined
+    )
+    await handler.dispose()
+  })
+
+  it('recreates a relay session when edits arrive after a server crash', async () => {
+    const dispatcher = createMockDispatcher()
+    const handler = new LspHandler(dispatcher as unknown as RelayDispatcher)
+
+    await dispatcher.callRequest('lsp.openDocument', {
+      worktreeId: 'wt-1',
+      worktreePath: '/repo',
+      filePath: '/repo/main.c',
+      languageId: 'c',
+      content: 'int before;'
+    })
+    const crashed = mocks.instances[0]
+    crashed.changeDocument.mockRejectedValueOnce(new Error('server exited'))
+
+    await dispatcher.callRequest('lsp.changeDocument', {
+      worktreePath: '/repo',
+      filePath: '/repo/main.c',
+      languageId: 'c',
+      content: 'int after;'
+    })
+
+    expect(mocks.instances).toHaveLength(2)
+    expect(mocks.instances[1].openDocument).toHaveBeenCalledWith('/repo/main.c', 'c', 'int after;')
+    expect(mocks.instances[1].changeDocument).toHaveBeenCalledWith('/repo/main.c', 'int after;')
+    expect(dispatcher.notify).toHaveBeenCalledWith(
+      'lsp.diagnostics',
+      expect.objectContaining({
+        filePath: '/repo/main.c',
+        diagnostics: []
+      })
+    )
+    await handler.dispose()
+  })
+
+  it('keeps a relay LSP document open until all views close it', async () => {
+    const dispatcher = createMockDispatcher()
+    const handler = new LspHandler(dispatcher as unknown as RelayDispatcher)
+
+    await dispatcher.callRequest('lsp.openDocument', {
+      worktreeId: 'wt-1',
+      worktreePath: '/repo',
+      filePath: '/repo/main.c',
+      languageId: 'c',
+      content: 'int first;',
+      documentId: 'doc-1'
+    })
+    await dispatcher.callRequest('lsp.openDocument', {
+      worktreeId: 'wt-1',
+      worktreePath: '/repo',
+      filePath: '/repo/main.c',
+      languageId: 'c',
+      content: 'int second;',
+      documentId: 'doc-2'
+    })
+    const session = mocks.instances[0]
+
+    await dispatcher.callRequest('lsp.closeDocument', {
+      worktreePath: '/repo',
+      filePath: '/repo/main.c',
+      languageId: 'c',
+      documentId: 'doc-1'
+    })
+
+    expect(session.closeDocument).not.toHaveBeenCalled()
+
+    await dispatcher.callRequest('lsp.closeDocument', {
+      worktreePath: '/repo',
+      filePath: '/repo/main.c',
+      languageId: 'c',
+      documentId: 'doc-2'
+    })
+
+    expect(session.closeDocument).toHaveBeenCalledTimes(1)
+    await handler.dispose()
+  })
+
+  it('does not spawn a relay session after shutdown while creation is pending', async () => {
+    const discovery = deferred<{
+      ok: true
+      command: { command: string; args: string[] }
+    }>()
+    mocks.resolveLanguageServerCommandMock.mockReturnValue(discovery.promise)
+    const dispatcher = createMockDispatcher()
+    const handler = new LspHandler(dispatcher as unknown as RelayDispatcher)
+
+    const open = dispatcher.callRequest('lsp.openDocument', {
+      worktreeId: 'wt-1',
+      worktreePath: '/repo',
+      filePath: '/repo/a.c',
+      languageId: 'c',
+      content: 'int a;'
+    })
+    await Promise.resolve()
+    await handler.dispose()
+    discovery.resolve({ ok: true, command: { command: '/usr/bin/clangd', args: [] } })
+
+    await expect(open).rejects.toThrow('LSP handler is shutting down')
+    expect(mocks.instances).toHaveLength(0)
+  })
+})

--- a/src/relay/lsp-handler.test.ts
+++ b/src/relay/lsp-handler.test.ts
@@ -1,0 +1,226 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import type { RelayDispatcher } from './dispatcher'
+
+const { resolveLanguageServerCommandMock } = vi.hoisted(() => ({
+  resolveLanguageServerCommandMock: vi.fn()
+}))
+
+vi.mock('../main/lsp/language-server-registry', () => ({
+  resolveLanguageServerCommand: resolveLanguageServerCommandMock
+}))
+
+import { LspHandler } from './lsp-handler'
+
+const FAKE_RELAY_LSP_SERVER = String.raw`
+const documents = new Map()
+let buffer = Buffer.alloc(0)
+
+function send(message) {
+  const body = Buffer.from(JSON.stringify(message), 'utf8')
+  process.stdout.write('Content-Length: ' + body.length + '\r\n\r\n')
+  process.stdout.write(body)
+}
+
+function handle(message) {
+  if (message.method === 'initialize') {
+    send({
+      jsonrpc: '2.0',
+      id: message.id,
+      result: { capabilities: { textDocumentSync: { openClose: true, change: 1 }, hoverProvider: true } }
+    })
+    return
+  }
+  if (message.method === 'textDocument/didOpen') {
+    const doc = message.params.textDocument
+    documents.set(doc.uri, doc.text)
+    send({
+      jsonrpc: '2.0',
+      method: 'textDocument/publishDiagnostics',
+      params: {
+        uri: doc.uri,
+        diagnostics: [{
+          range: { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } },
+          severity: 2,
+          message: 'relay diagnostic'
+        }]
+      }
+    })
+    return
+  }
+  if (message.method === 'textDocument/hover') {
+    send({ jsonrpc: '2.0', id: message.id, result: { contents: 'relay hover' } })
+    return
+  }
+  if (message.method === 'shutdown') {
+    send({ jsonrpc: '2.0', id: message.id, result: null })
+    return
+  }
+  if (message.method === 'exit') {
+    process.exit(0)
+  }
+  if (message.id !== undefined) {
+    send({ jsonrpc: '2.0', id: message.id, result: null })
+  }
+}
+
+process.stdin.on('data', chunk => {
+  buffer = Buffer.concat([buffer, chunk])
+  while (true) {
+    const headerEnd = buffer.indexOf('\r\n\r\n')
+    if (headerEnd === -1) break
+    const header = buffer.subarray(0, headerEnd).toString('utf8')
+    const match = /Content-Length:\s*(\d+)/i.exec(header)
+    if (!match) {
+      buffer = buffer.subarray(headerEnd + 4)
+      continue
+    }
+    const length = Number(match[1])
+    const start = headerEnd + 4
+    const end = start + length
+    if (buffer.length < end) break
+    const message = JSON.parse(buffer.subarray(start, end).toString('utf8'))
+    buffer = buffer.subarray(end)
+    handle(message)
+  }
+})
+`
+
+function createMockDispatcher() {
+  const requestHandlers = new Map<string, (params: Record<string, unknown>) => Promise<unknown>>()
+  const notifications: { method: string; params?: Record<string, unknown> }[] = []
+  return {
+    onRequest: vi.fn(
+      (method: string, handler: (params: Record<string, unknown>) => Promise<unknown>) => {
+        requestHandlers.set(method, handler)
+      }
+    ),
+    notify: vi.fn((method: string, params?: Record<string, unknown>) => {
+      notifications.push({ method, params })
+    }),
+    async callRequest(method: string, params: Record<string, unknown> = {}) {
+      const handler = requestHandlers.get(method)
+      if (!handler) {
+        throw new Error(`No handler for ${method}`)
+      }
+      return handler(params)
+    },
+    notifications
+  }
+}
+
+async function waitForNotification(
+  notifications: { method: string; params?: Record<string, unknown> }[],
+  method: string
+): Promise<Record<string, unknown>> {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < 2_000) {
+    const match = notifications.find((item) => item.method === method)
+    if (match?.params) {
+      return match.params
+    }
+    await new Promise((resolve) => setTimeout(resolve, 20))
+  }
+  throw new Error(`Timed out waiting for ${method}`)
+}
+
+describe('LspHandler', () => {
+  let dir: string
+  let dispatcher: ReturnType<typeof createMockDispatcher>
+  let handler: LspHandler | null = null
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'orca-relay-lsp-'))
+    dispatcher = createMockDispatcher()
+    resolveLanguageServerCommandMock.mockReset()
+  })
+
+  afterEach(async () => {
+    await handler?.dispose()
+    handler = null
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('registers relay LSP methods and hosts the server process remotely', async () => {
+    const serverPath = join(dir, 'fake-relay-lsp.cjs')
+    const filePath = join(dir, 'main.rs')
+    writeFileSync(serverPath, FAKE_RELAY_LSP_SERVER)
+    writeFileSync(filePath, 'fn main() {}')
+    resolveLanguageServerCommandMock.mockResolvedValue({
+      ok: true,
+      command: { command: process.execPath, args: [serverPath] }
+    })
+
+    handler = new LspHandler(dispatcher as unknown as RelayDispatcher)
+
+    await expect(
+      dispatcher.callRequest('lsp.getStatus', { worktreePath: dir, languageId: 'rust' })
+    ).resolves.toMatchObject({ state: 'available', languageId: 'rust' })
+
+    await dispatcher.callRequest('lsp.openDocument', {
+      worktreeId: 'repo::worktree',
+      worktreePath: dir,
+      filePath,
+      languageId: 'rust',
+      content: 'fn main() {}'
+    })
+
+    const diagnostic = await waitForNotification(dispatcher.notifications, 'lsp.diagnostics')
+    expect(diagnostic).toMatchObject({
+      worktreePath: dir,
+      filePath,
+      languageId: 'rust',
+      diagnostics: [{ message: 'relay diagnostic' }]
+    })
+
+    await expect(
+      dispatcher.callRequest('lsp.hover', {
+        worktreeId: 'repo::worktree',
+        worktreePath: dir,
+        filePath,
+        languageId: 'rust',
+        content: 'fn main() {}',
+        position: { line: 0, character: 1 }
+      })
+    ).resolves.toEqual({ contents: 'relay hover' })
+  })
+
+  it('does not start relay LSP sessions for runtime environments yet', async () => {
+    const serverPath = join(dir, 'fake-relay-lsp.cjs')
+    const filePath = join(dir, 'main.rs')
+    writeFileSync(serverPath, FAKE_RELAY_LSP_SERVER)
+    writeFileSync(filePath, 'fn main() {}')
+    resolveLanguageServerCommandMock.mockResolvedValue({
+      ok: true,
+      command: { command: process.execPath, args: [serverPath] }
+    })
+
+    handler = new LspHandler(dispatcher as unknown as RelayDispatcher)
+
+    await expect(
+      dispatcher.callRequest('lsp.getStatus', {
+        worktreePath: dir,
+        languageId: 'rust',
+        runtimeEnvironmentId: 'env-a'
+      })
+    ).resolves.toMatchObject({
+      state: 'unavailable',
+      reason: 'LSP is not available for runtime environments yet'
+    })
+
+    await expect(
+      dispatcher.callRequest('lsp.openDocument', {
+        worktreeId: 'repo::worktree',
+        worktreePath: dir,
+        filePath,
+        languageId: 'rust',
+        runtimeEnvironmentId: 'env-a',
+        content: 'fn main() {}'
+      })
+    ).rejects.toThrow('LSP is not available for runtime environments yet')
+
+    expect(handler.getStats().activeSessions).toBe(0)
+  })
+})

--- a/src/relay/lsp-handler.ts
+++ b/src/relay/lsp-handler.ts
@@ -1,0 +1,434 @@
+/* eslint-disable max-lines -- Why: relay LSP request registration and session
+lifecycle recovery need to stay in one file so local/remote protocol behavior
+is easy to audit. */
+import type {
+  LspCompletionResult,
+  LspDocumentChange,
+  LspDocumentContext,
+  LspHover,
+  LspLocation,
+  LspRequestContext,
+  LspServerStatus
+} from '../shared/lsp-types'
+import { resolveLanguageServerCommand } from '../main/lsp/language-server-registry'
+import { LspProcessSession } from '../main/lsp/lsp-process-session'
+import type { RelayDispatcher } from './dispatcher'
+
+type ManagedSession = {
+  key: string
+  session: LspProcessSession
+  idleTimer: ReturnType<typeof setTimeout> | null
+}
+
+type TrackedDocument = LspDocumentContext & { documentIds: Set<string> }
+
+const IDLE_SESSION_TTL_MS = 60_000
+
+function sessionKey(args: {
+  worktreePath: string
+  languageId: string
+  runtimeEnvironmentId?: string
+}): string {
+  return `${args.runtimeEnvironmentId ?? 'default'}\0${args.worktreePath}\0${args.languageId}`
+}
+
+function assertRuntimeSupported(args: { runtimeEnvironmentId?: string }): void {
+  if (args.runtimeEnvironmentId) {
+    throw new Error('LSP is not available for runtime environments yet')
+  }
+}
+
+function documentReferenceId(args: { filePath: string; documentId?: string }): string {
+  return args.documentId ?? `legacy:${args.filePath}`
+}
+
+export class LspHandler {
+  private readonly dispatcher: RelayDispatcher
+  private sessions = new Map<string, ManagedSession>()
+  private pendingSessions = new Map<string, Promise<ManagedSession>>()
+  private openDocuments = new Map<string, Map<string, TrackedDocument>>()
+  private disposed = false
+
+  constructor(dispatcher: RelayDispatcher) {
+    this.dispatcher = dispatcher
+    dispatcher.onRequest('lsp.getStatus', (params) =>
+      this.getStatus(params as unknown as LspDocumentChange)
+    )
+    dispatcher.onRequest('lsp.openDocument', (params) =>
+      this.openDocument(params as unknown as LspDocumentContext)
+    )
+    dispatcher.onRequest('lsp.changeDocument', async (params) => {
+      await this.changeDocument(params as unknown as LspDocumentChange)
+      return { ok: true }
+    })
+    dispatcher.onRequest('lsp.closeDocument', async (params) => {
+      await this.closeDocument(params as unknown as Omit<LspDocumentChange, 'content'>)
+      return { ok: true }
+    })
+    dispatcher.onRequest('lsp.completion', (params) =>
+      this.completion(params as unknown as LspRequestContext)
+    )
+    dispatcher.onRequest('lsp.hover', (params) =>
+      this.hover(params as unknown as LspRequestContext)
+    )
+    dispatcher.onRequest('lsp.definition', (params) =>
+      this.definition(params as unknown as LspRequestContext)
+    )
+    dispatcher.onRequest('lsp.getStats', async () => this.getStats())
+  }
+
+  async getStatus(args: LspDocumentChange): Promise<LspServerStatus> {
+    if (args.runtimeEnvironmentId) {
+      return {
+        state: 'unavailable',
+        languageId: args.languageId,
+        reason: 'LSP is not available for runtime environments yet'
+      }
+    }
+    const resolved = await resolveLanguageServerCommand(args.languageId)
+    if (!resolved.ok) {
+      return { state: 'unavailable', languageId: args.languageId, reason: resolved.reason }
+    }
+    return {
+      state: 'available',
+      languageId: args.languageId,
+      command: [resolved.command.command, ...resolved.command.args].join(' ')
+    }
+  }
+
+  async openDocument(args: LspDocumentContext): Promise<LspServerStatus> {
+    assertRuntimeSupported(args)
+    const key = sessionKey(args)
+    const wasTracked = this.openDocuments.get(key)?.has(args.filePath) ?? false
+    const entry = await this.getOrCreateSession(args)
+    try {
+      await (wasTracked
+        ? entry.session.changeDocument(args.filePath, args.content)
+        : entry.session.openDocument(args.filePath, args.languageId, args.content))
+      this.trackOpenDocument(args)
+    } catch (error) {
+      await this.disposeBrokenSession(entry)
+      throw error
+    }
+    return { state: 'available', languageId: args.languageId }
+  }
+
+  async changeDocument(args: LspDocumentChange): Promise<void> {
+    assertRuntimeSupported(args)
+    const key = sessionKey(args)
+    const tracked = this.updateTrackedDocument(args)
+    const entry = this.sessions.get(key)
+    if (!entry) {
+      if (tracked) {
+        const recreated = await this.getOrCreateSession(tracked)
+        await recreated.session.changeDocument(args.filePath, args.content)
+      }
+      return
+    }
+    this.cancelIdleDispose(entry)
+    try {
+      await entry.session.changeDocument(args.filePath, args.content)
+    } catch (error) {
+      await this.disposeBrokenSession(entry)
+      if (!tracked) {
+        throw error
+      }
+      const recreated = await this.getOrCreateSession(tracked)
+      try {
+        await recreated.session.changeDocument(args.filePath, args.content)
+      } catch (retryError) {
+        await this.disposeBrokenSession(recreated)
+        throw retryError
+      }
+    }
+  }
+
+  async closeDocument(args: Omit<LspDocumentChange, 'content'>): Promise<void> {
+    assertRuntimeSupported(args)
+    const key = sessionKey(args)
+    const shouldCloseDocument = this.releaseOpenDocument(key, args)
+    if (!shouldCloseDocument) {
+      return
+    }
+    const entry = this.sessions.get(key)
+    if (!entry) {
+      return
+    }
+    try {
+      await entry.session.closeDocument(args.filePath)
+    } catch (error) {
+      await this.disposeBrokenSession(entry)
+      throw error
+    }
+    if (entry.session.getOpenDocumentCount() === 0) {
+      this.scheduleIdleDispose(entry)
+    }
+  }
+
+  async completion(args: LspRequestContext): Promise<LspCompletionResult | null> {
+    assertRuntimeSupported(args)
+    const entry = await this.getOrCreateSession({ ...args, content: args.content ?? '' })
+    try {
+      return await entry.session.completion(args.filePath, args.position, args.content)
+    } catch {
+      await this.disposeBrokenSession(entry)
+      return await this.retryRequest(args, (retried) =>
+        retried.session.completion(args.filePath, args.position, args.content)
+      )
+    }
+  }
+
+  async hover(args: LspRequestContext): Promise<LspHover | null> {
+    assertRuntimeSupported(args)
+    const entry = await this.getOrCreateSession({ ...args, content: args.content ?? '' })
+    try {
+      return await entry.session.hover(args.filePath, args.position, args.content)
+    } catch {
+      await this.disposeBrokenSession(entry)
+      return await this.retryRequest(args, (retried) =>
+        retried.session.hover(args.filePath, args.position, args.content)
+      )
+    }
+  }
+
+  async definition(args: LspRequestContext): Promise<LspLocation[]> {
+    assertRuntimeSupported(args)
+    const entry = await this.getOrCreateSession({ ...args, content: args.content ?? '' })
+    try {
+      return await entry.session.definition(args.filePath, args.position, args.content)
+    } catch {
+      await this.disposeBrokenSession(entry)
+      return await this.retryRequest(args, (retried) =>
+        retried.session.definition(args.filePath, args.position, args.content)
+      )
+    }
+  }
+
+  getStats(): {
+    activeSessions: number
+    sessions: {
+      key: string
+      worktreePath: string
+      languageId: string
+      runtimeEnvironmentId?: string
+    }[]
+  } {
+    return {
+      activeSessions: this.sessions.size,
+      sessions: Array.from(this.sessions.entries()).map(([key, entry]) => {
+        const [runtimeEnvironmentId, worktreePath, languageId] = key.split('\0')
+        return {
+          key,
+          runtimeEnvironmentId:
+            runtimeEnvironmentId === 'default' ? undefined : runtimeEnvironmentId,
+          worktreePath,
+          languageId,
+          ...entry.session.getStats()
+        }
+      })
+    }
+  }
+
+  async dispose(): Promise<void> {
+    this.disposed = true
+    const sessions = Array.from(this.sessions.values())
+    this.sessions.clear()
+    this.pendingSessions.clear()
+    this.openDocuments.clear()
+    await Promise.all(
+      sessions.map(async (entry) => {
+        if (entry.idleTimer) {
+          clearTimeout(entry.idleTimer)
+        }
+        await entry.session.dispose()
+      })
+    )
+  }
+
+  private async getOrCreateSession(args: LspDocumentContext): Promise<ManagedSession> {
+    if (this.disposed) {
+      throw new Error('LSP handler is shutting down')
+    }
+    const key = sessionKey(args)
+    const existing = this.sessions.get(key)
+    if (existing) {
+      this.cancelIdleDispose(existing)
+      return existing
+    }
+    const pending = this.pendingSessions.get(key)
+    if (pending) {
+      return pending
+    }
+    // Why: concurrent opens over SSH can race command discovery. Deduping the
+    // creation promise prevents one relay-side language server from being
+    // overwritten and left untracked.
+    const created = this.createSession(key, args)
+    this.pendingSessions.set(key, created)
+    try {
+      return await created
+    } finally {
+      if (this.pendingSessions.get(key) === created) {
+        this.pendingSessions.delete(key)
+      }
+    }
+  }
+
+  private trackOpenDocument(args: LspDocumentContext): void {
+    const key = sessionKey(args)
+    const documents = this.openDocuments.get(key) ?? new Map<string, TrackedDocument>()
+    const existing = documents.get(args.filePath)
+    const documentIds = existing?.documentIds ?? new Set<string>()
+    documentIds.add(documentReferenceId(args))
+    documents.set(args.filePath, {
+      ...args,
+      documentIds
+    })
+    this.openDocuments.set(key, documents)
+  }
+
+  private updateTrackedDocument(args: LspDocumentChange): TrackedDocument | undefined {
+    const documents = this.openDocuments.get(sessionKey(args))
+    const tracked = documents?.get(args.filePath)
+    if (!tracked) {
+      return undefined
+    }
+    tracked.content = args.content
+    return tracked
+  }
+
+  private releaseOpenDocument(
+    key: string,
+    args: { filePath: string; documentId?: string }
+  ): boolean {
+    const documents = this.openDocuments.get(key)
+    if (!documents) {
+      return true
+    }
+    const tracked = documents.get(args.filePath)
+    if (!tracked) {
+      return true
+    }
+    tracked.documentIds.delete(documentReferenceId(args))
+    if (tracked.documentIds.size > 0) {
+      return false
+    }
+    documents.delete(args.filePath)
+    if (documents.size === 0) {
+      this.openDocuments.delete(key)
+    }
+    return true
+  }
+
+  private async retryRequest<T>(
+    args: LspRequestContext,
+    request: (entry: ManagedSession) => Promise<T>
+  ): Promise<T> {
+    const retried = await this.getOrCreateSession({ ...args, content: args.content ?? '' })
+    try {
+      return await request(retried)
+    } catch (error) {
+      await this.disposeBrokenSession(retried)
+      throw error
+    }
+  }
+
+  private async createSession(key: string, args: LspDocumentContext): Promise<ManagedSession> {
+    if (this.disposed) {
+      throw new Error('LSP handler is shutting down')
+    }
+    const resolved = await resolveLanguageServerCommand(args.languageId)
+    if (this.disposed) {
+      throw new Error('LSP handler is shutting down')
+    }
+    if (!resolved.ok) {
+      throw new Error(resolved.reason)
+    }
+    const entry: ManagedSession = {
+      key,
+      session: new LspProcessSession({
+        rootPath: args.worktreePath,
+        languageId: args.languageId,
+        server: resolved.command,
+        onDiagnostics: (event) => {
+          this.dispatcher.notify('lsp.diagnostics', {
+            worktreePath: args.worktreePath,
+            filePath: event.filePath,
+            languageId: event.languageId,
+            runtimeEnvironmentId: args.runtimeEnvironmentId,
+            diagnostics: event.diagnostics
+          })
+        }
+      }),
+      idleTimer: null
+    }
+    this.sessions.set(key, entry)
+    try {
+      await this.reopenTrackedDocuments(entry)
+      if (this.disposed) {
+        throw new Error('LSP handler is shutting down')
+      }
+    } catch (error) {
+      this.sessions.delete(key)
+      await entry.session.dispose().catch(() => undefined)
+      throw error
+    }
+    return entry
+  }
+
+  private async reopenTrackedDocuments(entry: ManagedSession): Promise<void> {
+    const documents = this.openDocuments.get(entry.key)
+    if (!documents) {
+      return
+    }
+    // Why: relay request methods avoid resending content. Recreated server
+    // processes need the relay's last synced open docs replayed first.
+    for (const document of documents.values()) {
+      await entry.session.openDocument(document.filePath, document.languageId, document.content)
+    }
+  }
+
+  private clearTrackedDiagnostics(key: string): void {
+    const documents = this.openDocuments.get(key)
+    if (!documents) {
+      return
+    }
+    for (const document of documents.values()) {
+      this.dispatcher.notify('lsp.diagnostics', {
+        worktreePath: document.worktreePath,
+        filePath: document.filePath,
+        languageId: document.languageId,
+        runtimeEnvironmentId: document.runtimeEnvironmentId,
+        diagnostics: []
+      })
+    }
+  }
+
+  private cancelIdleDispose(entry: ManagedSession): void {
+    if (entry.idleTimer) {
+      clearTimeout(entry.idleTimer)
+      entry.idleTimer = null
+    }
+  }
+
+  private scheduleIdleDispose(entry: ManagedSession): void {
+    this.cancelIdleDispose(entry)
+    entry.idleTimer = setTimeout(() => {
+      if (entry.session.getOpenDocumentCount() > 0) {
+        return
+      }
+      this.sessions.delete(entry.key)
+      void entry.session.dispose()
+    }, IDLE_SESSION_TTL_MS)
+    entry.idleTimer.unref?.()
+  }
+
+  private async disposeBrokenSession(entry: ManagedSession): Promise<void> {
+    this.sessions.delete(entry.key)
+    if (entry.idleTimer) {
+      clearTimeout(entry.idleTimer)
+      entry.idleTimer = null
+    }
+    this.clearTrackedDiagnostics(entry.key)
+    await entry.session.dispose().catch(() => undefined)
+  }
+}

--- a/src/relay/relay.ts
+++ b/src/relay/relay.ts
@@ -30,6 +30,7 @@ import { RelayContext } from './context'
 import { PtyHandler } from './pty-handler'
 import { FsHandler } from './fs-handler'
 import { GitHandler } from './git-handler'
+import { LspHandler } from './lsp-handler'
 import { PreflightHandler } from './preflight-handler'
 import { ExternalAutomationsHandler } from './external-automations-handler'
 import { PortScanHandler } from './port-scan-handler'
@@ -291,6 +292,8 @@ async function main(): Promise<void> {
   // so we hold the reference only for potential future disposal.
   const _gitHandler = new GitHandler(dispatcher, context)
   void _gitHandler
+
+  const lspHandler = new LspHandler(dispatcher)
 
   const _preflightHandler = new PreflightHandler(dispatcher)
   const _externalAutomationsHandler = new ExternalAutomationsHandler(dispatcher)
@@ -776,7 +779,7 @@ async function main(): Promise<void> {
     )
     ptyHandler.startGraceTimer(() => {
       process.stderr.write(`[relay] Grace expired (${reason}); shutting down\n`)
-      shutdown()
+      void shutdown()
     }, timeoutMs)
   }
 
@@ -816,7 +819,12 @@ async function main(): Promise<void> {
     })
   }
 
-  function shutdown(): void {
+  let shuttingDown = false
+  async function shutdown(): Promise<void> {
+    if (shuttingDown) {
+      return
+    }
+    shuttingDown = true
     process.stderr.write(
       `[relay] Shutdown: ptys=${ptyHandler.activePtyCount}, clients=${socketClients.size}, ownsSocket=${ownsSocketPath}\n`
     )
@@ -825,6 +833,7 @@ async function main(): Promise<void> {
     dispatcher.dispose()
     ptyHandler.dispose()
     fsHandler.dispose()
+    await lspHandler.dispose().catch(() => undefined)
     hookServer.stop()
     // Why: Node's Unix server.close() can unlink the listen path. If the path
     // was externally removed and rebound by a newer relay, closing this older
@@ -836,8 +845,8 @@ async function main(): Promise<void> {
     process.exit(0)
   }
 
-  process.on('SIGTERM', shutdown)
-  process.on('SIGINT', shutdown)
+  process.on('SIGTERM', () => void shutdown())
+  process.on('SIGINT', () => void shutdown())
   // Why: when the SSH session drops, the OS sends SIGHUP to the relay's
   // process group. Node's default SIGHUP behavior is to exit immediately,
   // which kills all PTYs before the grace period can start. Ignoring

--- a/src/renderer/src/components/editor/EditorContent.tsx
+++ b/src/renderer/src/components/editor/EditorContent.tsx
@@ -9,6 +9,7 @@ import { AlertCircle, RefreshCw } from 'lucide-react'
 import { detectLanguage } from '@/lib/language-detect'
 import { joinPath } from '@/lib/path'
 import { useAppStore } from '@/store'
+import { findWorktreeById } from '@/store/slices/worktree-helpers'
 import { Button } from '@/components/ui/button'
 import { ChangesModeView } from './ChangesModeView'
 import {
@@ -105,6 +106,7 @@ export function EditorContent({
   mdViewMode,
   isChangesMode,
   sideBySide,
+  isWorkspaceActive = true,
   showMarkdownTableOfContents = false,
   onCloseMarkdownTableOfContents = () => {},
   markdownAnnotationsEnabled = true,
@@ -131,6 +133,7 @@ export function EditorContent({
   mdViewMode: MarkdownViewMode
   isChangesMode: boolean
   sideBySide: boolean
+  isWorkspaceActive?: boolean
   showMarkdownTableOfContents?: boolean
   onCloseMarkdownTableOfContents?: () => void
   markdownAnnotationsEnabled?: boolean
@@ -163,6 +166,22 @@ export function EditorContent({
     Record<string, number>
   >({})
   const md = useMarkdownDocuments(activeFile, isMarkdown, mdViewMode, handleSave)
+  const worktreePath = useAppStore(
+    (s) => findWorktreeById(s.worktreesByRepo, activeFile.worktreeId)?.path ?? null
+  )
+  // Why: repo metadata can hydrate after the editor mounts. Wait until the repo
+  // is known so SSH worktrees cannot briefly register LSP as local sessions.
+  const lspTransport = useAppStore((s) => {
+    const worktree = findWorktreeById(s.worktreesByRepo, activeFile.worktreeId)
+    if (!worktree) {
+      return { resolved: false, connectionId: undefined }
+    }
+    const repo = s.repos?.find((repo) => repo.id === worktree.repoId)
+    if (!repo) {
+      return { resolved: false, connectionId: undefined }
+    }
+    return { resolved: true, connectionId: repo.connectionId ?? undefined }
+  })
   const activeConflictEntry =
     worktreeEntries.find((entry) => entry.path === activeFile.relativePath) ?? null
   const selectedConflictReviewFile =
@@ -286,9 +305,16 @@ export function EditorContent({
       relativePath={activeFile.relativePath}
       content={editBuffers[activeFile.id] ?? fc.content}
       language={monacoLanguage}
+      worktreeId={activeFile.worktreeId}
+      worktreePath={worktreePath}
+      connectionId={lspTransport.connectionId}
+      runtimeEnvironmentId={activeFile.runtimeEnvironmentId ?? undefined}
+      // Why: runtime environments need their own process launcher. Until the
+      // relay can spawn inside the selected runtime, enabling LSP would return
+      // completions/diagnostics from the host workspace instead.
+      lspEnabled={isWorkspaceActive && lspTransport.resolved && !activeFile.runtimeEnvironmentId}
       onContentChange={handleContentChange}
       onSave={isMarkdown ? md.mdSave : handleSave}
-      worktreeId={activeFile.worktreeId}
       markdownAnnotationsEnabled={markdownAnnotationsEnabled && isMarkdown}
       conflictDecorationsEnabled={activeFile.conflict?.conflictStatus === 'unresolved'}
       revealLine={
@@ -534,6 +560,8 @@ export function EditorContent({
             }
             onSave={readOnly ? () => {} : (content) => handleSaveForFile(contentFile, content)}
             worktreeId={contentFile.worktreeId}
+            worktreePath={worktreePath}
+            lspEnabled={false}
             markdownAnnotationsEnabled={false}
             conflictDecorationsEnabled={contentFile.conflict?.conflictStatus === 'unresolved'}
             readOnly={readOnly}

--- a/src/renderer/src/components/editor/EditorPanel.tsx
+++ b/src/renderer/src/components/editor/EditorPanel.tsx
@@ -22,11 +22,13 @@ import { useUntitledFileRename } from './useUntitledFileRename'
 function EditorPanelInner({
   activeFileId: activeFileIdProp,
   activeViewStateId: activeViewStateIdProp,
-  markdownAnnotationsEnabled = true
+  markdownAnnotationsEnabled = true,
+  isWorkspaceActive = true
 }: {
   activeFileId?: string | null
   activeViewStateId?: string | null
   markdownAnnotationsEnabled?: boolean
+  isWorkspaceActive?: boolean
 } = {}): React.JSX.Element | null {
   const openFiles = useAppStore((s) => s.openFiles)
   const globalActiveFileId = useAppStore((s) => s.activeFileId)
@@ -306,6 +308,7 @@ function EditorPanelInner({
       diffContents={diffContents}
       editorDrafts={editorDrafts}
       pendingEditorReveal={pendingEditorReveal}
+      isWorkspaceActive={isWorkspaceActive}
       renameDialogFile={renameDialogFile}
       renameError={renameError}
       disableRenameBrowse={disableRenameBrowse}

--- a/src/renderer/src/components/editor/EditorPanelShell.tsx
+++ b/src/renderer/src/components/editor/EditorPanelShell.tsx
@@ -25,6 +25,7 @@ type EditorPanelShellProps = {
   diffContents: Record<string, DiffContent>
   editorDrafts: Record<string, string>
   pendingEditorReveal: ReturnType<typeof useAppStore.getState>['pendingEditorReveal']
+  isWorkspaceActive?: boolean
   renameDialogFile: OpenFile | null
   renameError: string | null
   disableRenameBrowse: boolean
@@ -62,6 +63,7 @@ export function EditorPanelShell({
   diffContents,
   editorDrafts,
   pendingEditorReveal,
+  isWorkspaceActive = true,
   renameDialogFile,
   renameError,
   disableRenameBrowse,
@@ -136,6 +138,7 @@ export function EditorPanelShell({
           mdViewMode={model.mdViewMode}
           isChangesMode={model.isDiffSurface && !model.isSingleDiff}
           sideBySide={sideBySide}
+          isWorkspaceActive={isWorkspaceActive}
           pendingEditorReveal={pendingEditorReveal}
           handleContentChange={onContentChange}
           handleContentChangeForFile={onContentChangeForFile}

--- a/src/renderer/src/components/editor/MonacoEditor.tsx
+++ b/src/renderer/src/components/editor/MonacoEditor.tsx
@@ -1,6 +1,7 @@
-/* eslint-disable max-lines -- Why: MonacoEditor centralizes Monaco setup,
-source-mode markdown annotations, persistence-safe content sync, reveal
-handling, and editor-local UI overlays so split-pane state remains coherent. */
+/* eslint-disable max-lines -- Why: MonacoEditor centralizes retained-model lifecycle,
+source-mode markdown annotations, scroll/cursor restore, markdown links, copy
+behavior, and LSP registration around one editor instance so cleanup ordering
+stays explicit. */
 import React, { useRef, useCallback, useEffect, useLayoutEffect, useMemo, useState } from 'react'
 import Editor, { type OnMount } from '@monaco-editor/react'
 import type { editor } from 'monaco-editor'
@@ -10,6 +11,7 @@ import { scrollTopCache, cursorPositionCache, setWithLRU } from '@/lib/scroll-ca
 import '@/lib/monaco-setup'
 import { computeEditorFontSize } from '@/lib/editor-font-zoom'
 import { registerFileSearchSelectedTextProvider } from '@/lib/file-search-selection'
+import { registerMonacoLspDocument, updateMonacoLspDocumentContent } from '@/lib/monaco-lsp'
 
 import { useContextualCopySetup } from './useContextualCopySetup'
 import { MAX_REVEAL_CONTENT_WAIT_FRAMES, performReveal } from './monaco-reveal'
@@ -56,13 +58,17 @@ type MonacoEditorProps = {
   relativePath: string
   content: string
   language: string
+  worktreeId: string
+  worktreePath: string | null
+  connectionId?: string
+  runtimeEnvironmentId?: string
+  lspEnabled: boolean
   onContentChange: (content: string) => void
   onSave: (content: string) => void
   revealLine?: number
   revealColumn?: number
   revealMatchLength?: number
   markdownDocuments?: MarkdownDocument[]
-  worktreeId?: string
   markdownAnnotationsEnabled?: boolean
   conflictDecorationsEnabled?: boolean
   readOnly?: boolean
@@ -80,13 +86,17 @@ export default function MonacoEditor({
   relativePath,
   content,
   language,
+  worktreeId,
+  worktreePath,
+  connectionId,
+  runtimeEnvironmentId,
+  lspEnabled,
   onContentChange,
   onSave,
   revealLine,
   revealColumn,
   revealMatchLength,
   markdownDocuments,
-  worktreeId,
   markdownAnnotationsEnabled = false,
   conflictDecorationsEnabled = false,
   readOnly = false,
@@ -96,11 +106,13 @@ export default function MonacoEditor({
   const editorContainerRef = useRef<HTMLDivElement | null>(null)
   const [mountedEditor, setMountedEditor] = useState<editor.IStandaloneCodeEditor | null>(null)
   const [autoHeightContentHeight, setAutoHeightContentHeight] = useState<number | null>(null)
+  const monacoRef = useRef<Parameters<OnMount>[1] | null>(null)
   const modelKeyRef = useRef<string | null>(null)
   const languageRef = useRef(language)
   languageRef.current = language
   const markdownDocLinkDecorationsRef = useRef<MarkdownDocLinkDecorationController | null>(null)
   const conflictDecorationsRef = useRef<editor.IEditorDecorationsCollection | null>(null)
+  const lspDisposeRef = useRef<(() => void) | null>(null)
   const revealDecorationRef = useRef<editor.IEditorDecorationsCollection | null>(null)
   const revealHighlightTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const revealRafRef = useRef<number | null>(null)
@@ -173,6 +185,7 @@ export default function MonacoEditor({
   const [commentPopover, setCommentPopover] = useState<MarkdownCommentPopoverState | null>(null)
   const [selectionAnnotationTarget, setSelectionAnnotationTarget] =
     useState<MonacoMarkdownSelectionAnnotationTarget | null>(null)
+  const [monacoReadyVersion, setMonacoReadyVersion] = useState(0)
   const isDark =
     settings?.theme === 'dark' ||
     (settings?.theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)
@@ -315,6 +328,8 @@ export default function MonacoEditor({
     (editorInstance, monaco) => {
       editorRef.current = editorInstance
       setMountedEditor(editorInstance)
+      monacoRef.current = monaco
+      setMonacoReadyVersion((version) => version + 1)
       let autoHeightSub: { dispose: () => void } | null = null
       let autoHeightFrame: number | null = null
       const updateAutoHeight = (): void => {
@@ -600,6 +615,10 @@ export default function MonacoEditor({
           return
         }
         lastSyncedContentRef.current = value
+        const modelUri = editorRef.current?.getModel()?.uri.toString()
+        if (modelUri) {
+          updateMonacoLspDocumentContent(modelUri, value)
+        }
         onContentChange(value)
       }
     },
@@ -620,11 +639,53 @@ export default function MonacoEditor({
     try {
       syncContentUpdate(ed, content)
       lastSyncedContentRef.current = content
+      const modelUri = ed.getModel()?.uri.toString()
+      if (modelUri) {
+        updateMonacoLspDocumentContent(modelUri, content)
+      }
     } finally {
       isApplyingProgrammaticContentRef.current = false
       endProgrammaticContentSync(filePath)
     }
   }, [content, filePath])
+
+  useEffect(() => {
+    const editorInstance = editorRef.current
+    const monaco = monacoRef.current
+    lspDisposeRef.current?.()
+    lspDisposeRef.current = null
+    if (!lspEnabled || !editorInstance || !monaco || !worktreePath) {
+      return
+    }
+
+    // Why: worktree metadata can arrive after Monaco mounts, especially for
+    // newly added folder/SSH worktrees. Also gate on the visible workspace so
+    // retained hidden editors do not keep language servers hot after a switch.
+    lspDisposeRef.current = registerMonacoLspDocument(monaco, {
+      modelUri: editorInstance.getModel()?.uri.toString() ?? filePath,
+      worktreeId,
+      worktreePath,
+      filePath,
+      languageId: languageRef.current,
+      content: contentRef.current,
+      connectionId,
+      runtimeEnvironmentId
+    })
+
+    return () => {
+      lspDisposeRef.current?.()
+      lspDisposeRef.current = null
+    }
+  }, [
+    connectionId,
+    filePath,
+    language,
+    lspEnabled,
+    monacoReadyVersion,
+    runtimeEnvironmentId,
+    worktreeId,
+    worktreePath
+  ])
 
   // Snapshot scroll position synchronously on unmount so tab switches always
   // capture the latest value, even if the trailing throttle hasn't fired yet.
@@ -702,6 +763,8 @@ export default function MonacoEditor({
       if (modelKeyRef.current) {
         clearMarkdownDocCompletionDocuments(modelKeyRef.current)
       }
+      lspDisposeRef.current?.()
+      lspDisposeRef.current = null
       markdownDocLinkDecorationsRef.current?.dispose()
       markdownDocLinkDecorationsRef.current = null
       conflictDecorationsRef.current?.clear()

--- a/src/renderer/src/components/tab-group/TabGroupPanel.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.tsx
@@ -26,6 +26,7 @@ const EditorPanel = lazy(() => import('../editor/EditorPanel'))
 export default function TabGroupPanel({
   groupId,
   worktreeId,
+  isWorktreeActive,
   isFocused,
   hasSplitGroups,
   touchesRightEdge,
@@ -38,6 +39,7 @@ export default function TabGroupPanel({
 }: {
   groupId: string
   worktreeId: string
+  isWorktreeActive: boolean
   isFocused: boolean
   hasSplitGroups: boolean
   touchesRightEdge: boolean
@@ -356,7 +358,11 @@ export default function TabGroupPanel({
                   </div>
                 }
               >
-                <EditorPanel activeFileId={activeTab.entityId} activeViewStateId={activeTab.id} />
+                <EditorPanel
+                  activeFileId={activeTab.entityId}
+                  activeViewStateId={activeTab.id}
+                  isWorkspaceActive={isWorktreeActive}
+                />
               </Suspense>
             </div>
           )}

--- a/src/renderer/src/components/tab-group/TabGroupSplitLayout.test.ts
+++ b/src/renderer/src/components/tab-group/TabGroupSplitLayout.test.ts
@@ -71,6 +71,7 @@ describe('TabGroupSplitLayout', () => {
     return tabGroupPanelElement.props as {
       groupId: string
       worktreeId: string
+      isWorktreeActive: boolean
       isFocused: boolean
       hasSplitGroups: boolean
       reserveClosedExplorerToggleSpace: boolean
@@ -83,6 +84,7 @@ describe('TabGroupSplitLayout', () => {
       expect.objectContaining({
         groupId: 'group-1',
         worktreeId: 'wt-1',
+        isWorktreeActive: false,
         isFocused: false,
         hasSplitGroups: false,
         reserveClosedExplorerToggleSpace: true,
@@ -96,6 +98,7 @@ describe('TabGroupSplitLayout', () => {
       expect.objectContaining({
         groupId: 'group-1',
         worktreeId: 'wt-1',
+        isWorktreeActive: true,
         isFocused: true,
         hasSplitGroups: false,
         reserveClosedExplorerToggleSpace: true,

--- a/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
@@ -122,6 +122,7 @@ function SplitNode({
       <TabGroupPanel
         groupId={node.groupId}
         worktreeId={worktreeId}
+        isWorktreeActive={isWorktreeActive}
         // Why: hidden worktrees stay mounted so their PTYs and split layouts
         // survive worktree switches, but only the visible worktree may own the
         // global terminal shortcuts. If an offscreen group's pane stays

--- a/src/renderer/src/lib/monaco-lsp.test.ts
+++ b/src/renderer/src/lib/monaco-lsp.test.ts
@@ -1,0 +1,730 @@
+/* eslint-disable max-lines -- Why: this file exercises the Monaco LSP adapter's
+provider registration, document lifecycle, diagnostics, and retry sequencing in
+one module so module-level provider state can be reset consistently per test. */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type {
+  LspCompletionResult,
+  LspDiagnosticsEvent,
+  LspDocumentChange,
+  LspDocumentContext,
+  LspDocumentIdentity,
+  LspHover,
+  LspLocation,
+  LspRequestContext,
+  LspServerStatus
+} from '../../../shared/lsp-types'
+
+type CompletionProvider = {
+  provideCompletionItems: (
+    model: ModelMock,
+    position: { lineNumber: number; column: number }
+  ) => Promise<{ suggestions: Record<string, unknown>[] }>
+}
+
+type DefinitionProvider = {
+  provideDefinition: (
+    model: ModelMock,
+    position: { lineNumber: number; column: number }
+  ) => Promise<unknown[]>
+}
+
+type ModelMock = {
+  uri: { toString: () => string }
+  getValue: () => string
+  getWordUntilPosition: () => { startColumn: number; endColumn: number }
+}
+
+function deferred<T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+} {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
+async function waitForAssertion(assertion: () => void): Promise<void> {
+  const startedAt = Date.now()
+  let lastError: unknown
+  while (Date.now() - startedAt < 1_000) {
+    try {
+      assertion()
+      return
+    } catch (error) {
+      lastError = error
+      await new Promise((resolve) => setTimeout(resolve, 10))
+    }
+  }
+  throw lastError
+}
+
+function installWindowApi(lsp: unknown): void {
+  Object.defineProperty(globalThis, 'window', {
+    value: { api: { lsp } },
+    configurable: true
+  })
+}
+
+function createLspApi(
+  overrides: Partial<{
+    getStatus: (args: LspDocumentIdentity) => Promise<LspServerStatus>
+    openDocument: (args: LspDocumentContext) => Promise<LspServerStatus>
+    changeDocument: (args: LspDocumentChange) => Promise<void>
+    closeDocument: (args: Omit<LspDocumentChange, 'content'>) => Promise<void>
+    completion: (args: LspRequestContext) => Promise<LspCompletionResult | null>
+    hover: (args: LspRequestContext) => Promise<LspHover | null>
+    definition: (args: LspRequestContext) => Promise<LspLocation[]>
+    getStats: () => Promise<{ activeSessions: number; sessions: Record<string, unknown>[] }>
+    onDiagnostics: (callback: (event: LspDiagnosticsEvent) => void) => () => void
+  }> = {}
+) {
+  const api = {
+    getStatus: vi.fn(async (args: LspDocumentIdentity) => ({
+      state: 'available' as const,
+      languageId: args.languageId
+    })),
+    openDocument: vi.fn(async (args: LspDocumentContext) => ({
+      state: 'available' as const,
+      languageId: args.languageId
+    })),
+    changeDocument: vi.fn(async () => undefined),
+    closeDocument: vi.fn(async () => undefined),
+    completion: vi.fn(async () => null),
+    hover: vi.fn(async () => null),
+    definition: vi.fn(async () => []),
+    getStats: vi.fn(async () => ({ activeSessions: 0, sessions: [] })),
+    onDiagnostics: vi.fn((_callback: (event: LspDiagnosticsEvent) => void) => () => {})
+  }
+  return { ...api, ...overrides }
+}
+
+function createMonacoMock(
+  modelUri = 'file:///tmp/project/main.c',
+  content = 'struct Foo foo;'
+): {
+  monaco: never
+  model: ModelMock
+  completionProviders: Map<string, CompletionProvider>
+  definitionProviders: Map<string, DefinitionProvider>
+  addModel: (uri: string, modelContent?: string) => ModelMock
+  setModelContent: (value: string) => void
+} {
+  let modelContent = content
+  const createModel = (uri: string, getContent: () => string): ModelMock => ({
+    uri: { toString: () => uri },
+    getValue: vi.fn(getContent),
+    getWordUntilPosition: () => ({ startColumn: 4, endColumn: 7 })
+  })
+  const model: ModelMock = {
+    uri: { toString: () => modelUri },
+    getValue: vi.fn(() => modelContent),
+    getWordUntilPosition: () => ({ startColumn: 4, endColumn: 7 })
+  }
+  const models = new Map([[modelUri, model]])
+  const completionProviders = new Map<string, CompletionProvider>()
+  const definitionProviders = new Map<string, DefinitionProvider>()
+  class Range {
+    constructor(
+      readonly startLineNumber: number,
+      readonly startColumn: number,
+      readonly endLineNumber: number,
+      readonly endColumn: number
+    ) {}
+  }
+  const monaco = {
+    Range,
+    Uri: {
+      parse: (value: string) => ({ toString: () => value })
+    },
+    MarkerSeverity: {
+      Error: 8,
+      Warning: 4,
+      Info: 2,
+      Hint: 1
+    },
+    languages: {
+      CompletionItemKind: {
+        Text: 1,
+        Method: 2,
+        Function: 3,
+        Constructor: 4,
+        Field: 5,
+        Variable: 6,
+        Class: 7,
+        Interface: 8,
+        Module: 9,
+        Property: 10,
+        Unit: 11,
+        Value: 12,
+        Enum: 13,
+        Keyword: 14,
+        Snippet: 15,
+        Color: 16,
+        File: 17,
+        Reference: 18,
+        Folder: 19,
+        EnumMember: 20,
+        Constant: 21,
+        Struct: 22,
+        Event: 23,
+        Operator: 24,
+        TypeParameter: 25
+      },
+      CompletionItemInsertTextRule: {
+        InsertAsSnippet: 4
+      },
+      registerCompletionItemProvider: vi.fn((language: string, provider: CompletionProvider) => {
+        completionProviders.set(language, provider)
+        return { dispose: vi.fn() }
+      }),
+      registerHoverProvider: vi.fn(() => ({ dispose: vi.fn() })),
+      registerDefinitionProvider: vi.fn((language: string, provider: DefinitionProvider) => {
+        definitionProviders.set(language, provider)
+        return { dispose: vi.fn() }
+      })
+    },
+    editor: {
+      getModel: vi.fn((uri: { toString: () => string }) => models.get(uri.toString()) ?? null),
+      setModelMarkers: vi.fn()
+    }
+  }
+  return {
+    monaco: monaco as never,
+    model,
+    completionProviders,
+    definitionProviders,
+    addModel: (uri, value = content) => {
+      let addedModelContent = value
+      const addedModel = createModel(uri, () => addedModelContent)
+      models.set(uri, addedModel)
+      return addedModel
+    },
+    setModelContent: (value: string) => {
+      modelContent = value
+    }
+  }
+}
+
+function documentArgs(
+  content = 'struct Foo foo;',
+  overrides: Partial<LspDocumentContext & { modelUri: string }> = {}
+): LspDocumentContext & { modelUri: string } {
+  return {
+    modelUri: 'file:///tmp/project/main.c',
+    worktreeId: 'repo::/tmp/project',
+    worktreePath: '/tmp/project',
+    filePath: '/tmp/project/main.c',
+    languageId: 'c',
+    content,
+    ...overrides
+  }
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+  Reflect.deleteProperty(globalThis, 'window')
+})
+
+describe('monaco-lsp', () => {
+  it('keeps the LSP document open while split panes share the same Monaco model', async () => {
+    vi.resetModules()
+    const api = createLspApi()
+    installWindowApi(api)
+    const { monaco } = createMonacoMock()
+    const { registerMonacoLspDocument } = await import('./monaco-lsp')
+
+    const disposeFirst = registerMonacoLspDocument(monaco, documentArgs())
+    await waitForAssertion(() => expect(api.openDocument).toHaveBeenCalledTimes(1))
+    const disposeSecond = registerMonacoLspDocument(monaco, documentArgs())
+
+    disposeSecond()
+    expect(api.closeDocument).not.toHaveBeenCalled()
+
+    disposeFirst()
+    await waitForAssertion(() => expect(api.closeDocument).toHaveBeenCalledTimes(1))
+  })
+
+  it('does not register external providers for Monaco-owned TypeScript languages', async () => {
+    vi.resetModules()
+    const api = createLspApi()
+    installWindowApi(api)
+    const { monaco, completionProviders } = createMonacoMock()
+    const { ensureMonacoLspProviders } = await import('./monaco-lsp')
+
+    ensureMonacoLspProviders(monaco)
+
+    expect(completionProviders.has('typescript')).toBe(false)
+    expect(completionProviders.has('javascript')).toBe(false)
+  })
+
+  it('does not start external LSP sessions for Monaco-owned TypeScript languages', async () => {
+    vi.resetModules()
+    const api = createLspApi()
+    installWindowApi(api)
+    const { monaco } = createMonacoMock('file:///tmp/project/main.ts', 'const x = 1')
+    const { registerMonacoLspDocument } = await import('./monaco-lsp')
+
+    const dispose = registerMonacoLspDocument(
+      monaco,
+      documentArgs('const x = 1', {
+        modelUri: 'file:///tmp/project/main.ts',
+        filePath: '/tmp/project/main.ts',
+        languageId: 'typescript'
+      })
+    )
+
+    expect(api.getStatus).not.toHaveBeenCalled()
+    expect(api.openDocument).not.toHaveBeenCalled()
+    dispose()
+  })
+
+  it('checks LSP status without sending full document content', async () => {
+    vi.resetModules()
+    const api = createLspApi()
+    installWindowApi(api)
+    const { monaco } = createMonacoMock()
+    const { registerMonacoLspDocument } = await import('./monaco-lsp')
+
+    const dispose = registerMonacoLspDocument(monaco, documentArgs('large content'))
+    await waitForAssertion(() => expect(api.getStatus).toHaveBeenCalledTimes(1))
+
+    expect(api.getStatus).toHaveBeenCalledWith(
+      expect.not.objectContaining({ content: 'large content' })
+    )
+    dispose()
+  })
+
+  it('closes a document that finishes opening after its editor unmounts', async () => {
+    vi.resetModules()
+    const openDeferred = deferred<LspServerStatus>()
+    const api = createLspApi({
+      openDocument: vi.fn((args: LspDocumentContext) => {
+        return openDeferred.promise.then(() => ({
+          state: 'available' as const,
+          languageId: args.languageId
+        }))
+      })
+    })
+    installWindowApi(api)
+    const { monaco } = createMonacoMock()
+    const { registerMonacoLspDocument } = await import('./monaco-lsp')
+
+    const dispose = registerMonacoLspDocument(monaco, documentArgs())
+    await waitForAssertion(() => expect(api.openDocument).toHaveBeenCalledTimes(1))
+
+    dispose()
+    expect(api.closeDocument).not.toHaveBeenCalled()
+    openDeferred.resolve({ state: 'available', languageId: 'c' })
+
+    await waitForAssertion(() => expect(api.closeDocument).toHaveBeenCalledTimes(1))
+  })
+
+  it('flushes edits that arrive while the initial open is still pending', async () => {
+    vi.resetModules()
+    const openDeferred = deferred<LspServerStatus>()
+    const api = createLspApi({
+      openDocument: vi.fn((args: LspDocumentContext) => {
+        return openDeferred.promise.then(() => ({
+          state: 'available' as const,
+          languageId: args.languageId
+        }))
+      })
+    })
+    installWindowApi(api)
+    const { monaco, model } = createMonacoMock()
+    const { registerMonacoLspDocument, updateMonacoLspDocumentContent } =
+      await import('./monaco-lsp')
+
+    const dispose = registerMonacoLspDocument(monaco, documentArgs('before'))
+    await waitForAssertion(() => expect(api.openDocument).toHaveBeenCalledTimes(1))
+
+    updateMonacoLspDocumentContent(model.uri.toString(), 'after')
+    openDeferred.resolve({ state: 'available', languageId: 'c' })
+
+    await waitForAssertion(() =>
+      expect(api.changeDocument).toHaveBeenCalledWith(expect.objectContaining({ content: 'after' }))
+    )
+    expect(api.openDocument).toHaveBeenCalledWith(expect.objectContaining({ content: 'before' }))
+
+    dispose()
+  })
+
+  it('serializes document changes so older IPC writes cannot overtake newer text', async () => {
+    vi.resetModules()
+    const firstChange = deferred<void>()
+    const sentContents: string[] = []
+    const api = createLspApi({
+      changeDocument: vi.fn((args: LspDocumentChange) => {
+        sentContents.push(args.content)
+        return sentContents.length === 1 ? firstChange.promise : Promise.resolve()
+      })
+    })
+    installWindowApi(api)
+    const { monaco, model } = createMonacoMock()
+    const { registerMonacoLspDocument, updateMonacoLspDocumentContent } =
+      await import('./monaco-lsp')
+
+    const dispose = registerMonacoLspDocument(monaco, documentArgs('initial'))
+    await waitForAssertion(() => expect(api.openDocument).toHaveBeenCalledTimes(1))
+    vi.useFakeTimers()
+
+    updateMonacoLspDocumentContent(model.uri.toString(), 'first')
+    await vi.advanceTimersByTimeAsync(251)
+    expect(api.changeDocument).toHaveBeenCalledTimes(1)
+
+    updateMonacoLspDocumentContent(model.uri.toString(), 'second')
+    await vi.advanceTimersByTimeAsync(251)
+    expect(api.changeDocument).toHaveBeenCalledTimes(1)
+
+    firstChange.resolve(undefined)
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(api.changeDocument).toHaveBeenCalledTimes(2)
+    expect(sentContents).toEqual(['first', 'second'])
+
+    dispose()
+  })
+
+  it('waits for an in-flight document change before closing on unmount', async () => {
+    vi.resetModules()
+    const change = deferred<void>()
+    const api = createLspApi({
+      changeDocument: vi.fn(() => change.promise)
+    })
+    installWindowApi(api)
+    const { monaco, model } = createMonacoMock()
+    const { registerMonacoLspDocument, updateMonacoLspDocumentContent } =
+      await import('./monaco-lsp')
+
+    const dispose = registerMonacoLspDocument(monaco, documentArgs('initial'))
+    await waitForAssertion(() => expect(api.openDocument).toHaveBeenCalledTimes(1))
+    vi.useFakeTimers()
+
+    updateMonacoLspDocumentContent(model.uri.toString(), 'edited')
+    await vi.advanceTimersByTimeAsync(251)
+    expect(api.changeDocument).toHaveBeenCalledTimes(1)
+
+    dispose()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(api.closeDocument).not.toHaveBeenCalled()
+
+    change.resolve(undefined)
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(api.closeDocument).toHaveBeenCalledTimes(1)
+  })
+
+  it('closes the old document id when the same model remounts quickly', async () => {
+    vi.resetModules()
+    const api = createLspApi()
+    installWindowApi(api)
+    const { monaco } = createMonacoMock()
+    const { registerMonacoLspDocument } = await import('./monaco-lsp')
+
+    const disposeFirst = registerMonacoLspDocument(monaco, documentArgs('first'))
+    await waitForAssertion(() => expect(api.openDocument).toHaveBeenCalledTimes(1))
+    const openDocumentMock = vi.mocked(api.openDocument)
+    const firstDocumentId = openDocumentMock.mock.calls[0][0].documentId
+
+    disposeFirst()
+    const disposeSecond = registerMonacoLspDocument(monaco, documentArgs('second'))
+    await waitForAssertion(() => expect(api.openDocument).toHaveBeenCalledTimes(2))
+    const secondDocumentId = openDocumentMock.mock.calls[1][0].documentId
+
+    expect(secondDocumentId).not.toBe(firstDocumentId)
+    await waitForAssertion(() =>
+      expect(api.closeDocument).toHaveBeenCalledWith(
+        expect.objectContaining({ documentId: firstDocumentId })
+      )
+    )
+
+    disposeSecond()
+  })
+
+  it('uses completion text edits without resending full document content per request', async () => {
+    vi.resetModules()
+    const api = createLspApi({
+      completion: vi.fn(async () => ({
+        isIncomplete: false,
+        items: [
+          {
+            label: 'alpha',
+            kind: 22,
+            insertText: 'ignored',
+            textEdit: {
+              range: { start: { line: 0, character: 1 }, end: { line: 0, character: 4 } },
+              newText: 'alpha()'
+            },
+            additionalTextEdits: [
+              {
+                range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
+                newText: '#include <alpha.h>\n'
+              }
+            ]
+          }
+        ]
+      }))
+    })
+    installWindowApi(api)
+    const { monaco, model, completionProviders } = createMonacoMock()
+    const { registerMonacoLspDocument, updateMonacoLspDocumentContent } =
+      await import('./monaco-lsp')
+
+    const dispose = registerMonacoLspDocument(monaco, documentArgs())
+    await waitForAssertion(() => expect(api.openDocument).toHaveBeenCalledTimes(1))
+
+    const provider = completionProviders.get('c')
+    if (!provider) {
+      throw new Error('expected C completion provider to be registered')
+    }
+    updateMonacoLspDocumentContent(model.uri.toString(), 'struct Alpha alpha;')
+    const result = await provider.provideCompletionItems(model, { lineNumber: 1, column: 7 })
+
+    expect(model.getValue).not.toHaveBeenCalled()
+    expect(api.changeDocument).toHaveBeenCalledWith(
+      expect.objectContaining({ content: 'struct Alpha alpha;' })
+    )
+    expect(api.completion).toHaveBeenCalledWith(
+      expect.not.objectContaining({ content: expect.any(String) })
+    )
+    expect(result.suggestions[0]).toMatchObject({
+      label: 'alpha',
+      kind: 22,
+      insertText: 'alpha()',
+      range: {
+        startLineNumber: 1,
+        startColumn: 2,
+        endLineNumber: 1,
+        endColumn: 5
+      },
+      additionalTextEdits: [
+        {
+          text: '#include <alpha.h>\n',
+          range: {
+            startLineNumber: 1,
+            startColumn: 1,
+            endLineNumber: 1,
+            endColumn: 1
+          }
+        }
+      ]
+    })
+
+    dispose()
+  })
+
+  it('keeps diagnostics scoped to the matching runtime environment', async () => {
+    vi.resetModules()
+    let onDiagnostics: ((event: LspDiagnosticsEvent) => void) | null = null
+    const api = createLspApi({
+      onDiagnostics: vi.fn((callback: (event: LspDiagnosticsEvent) => void) => {
+        onDiagnostics = callback
+        return () => {}
+      })
+    })
+    installWindowApi(api)
+    const { monaco, addModel } = createMonacoMock('file:///runtime-a/main.c')
+    const runtimeBModel = addModel('file:///runtime-b/main.c')
+    const { registerMonacoLspDocument } = await import('./monaco-lsp')
+
+    const disposeA = registerMonacoLspDocument(
+      monaco,
+      documentArgs('int main(void);', {
+        modelUri: 'file:///runtime-a/main.c',
+        runtimeEnvironmentId: 'runtime-a'
+      })
+    )
+    const disposeB = registerMonacoLspDocument(
+      monaco,
+      documentArgs('int main(void);', {
+        modelUri: 'file:///runtime-b/main.c',
+        runtimeEnvironmentId: 'runtime-b'
+      })
+    )
+    await waitForAssertion(() => expect(api.openDocument).toHaveBeenCalledTimes(2))
+
+    const emitDiagnostics = onDiagnostics as ((event: LspDiagnosticsEvent) => void) | null
+    if (!emitDiagnostics) {
+      throw new Error('expected diagnostics listener to be registered')
+    }
+    emitDiagnostics({
+      worktreePath: '/tmp/project',
+      filePath: '/tmp/project/main.c',
+      languageId: 'c',
+      runtimeEnvironmentId: 'runtime-b',
+      diagnostics: [
+        {
+          range: { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } },
+          message: 'runtime-b diagnostic'
+        }
+      ]
+    })
+
+    const monacoMock = monaco as unknown as {
+      editor: { setModelMarkers: ReturnType<typeof vi.fn> }
+    }
+    expect(monacoMock.editor.setModelMarkers).toHaveBeenCalledTimes(1)
+    expect(monacoMock.editor.setModelMarkers).toHaveBeenCalledWith(
+      runtimeBModel,
+      'orca-lsp',
+      expect.arrayContaining([expect.objectContaining({ message: 'runtime-b diagnostic' })])
+    )
+
+    disposeA()
+    disposeB()
+  })
+
+  it('retries document activation after an initial unavailable status', async () => {
+    vi.resetModules()
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-15T12:00:00Z'))
+    const api = createLspApi({
+      getStatus: vi
+        .fn()
+        .mockResolvedValueOnce({ state: 'unavailable', languageId: 'c', reason: 'reconnecting' })
+        .mockResolvedValue({ state: 'available', languageId: 'c' }),
+      completion: vi.fn(async () => [{ label: 'ready' }])
+    })
+    installWindowApi(api)
+    const { monaco, model, completionProviders } = createMonacoMock()
+    const { registerMonacoLspDocument } = await import('./monaco-lsp')
+
+    const dispose = registerMonacoLspDocument(monaco, documentArgs())
+    await waitForAssertion(() => expect(api.getStatus).toHaveBeenCalledTimes(1))
+    const provider = completionProviders.get('c')
+    if (!provider) {
+      throw new Error('expected C completion provider to be registered')
+    }
+
+    await expect(
+      provider.provideCompletionItems(model, { lineNumber: 1, column: 7 })
+    ).resolves.toEqual({ suggestions: [] })
+    expect(api.openDocument).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(2_001)
+    const result = await provider.provideCompletionItems(model, { lineNumber: 1, column: 7 })
+
+    expect(api.getStatus).toHaveBeenCalledTimes(2)
+    expect(api.openDocument).toHaveBeenCalledTimes(1)
+    expect(api.completion).toHaveBeenCalledTimes(1)
+    expect(result.suggestions[0]).toMatchObject({ label: 'ready' })
+
+    dispose()
+  })
+
+  it('marks a document for status retry after an LSP request failure', async () => {
+    vi.resetModules()
+    const api = createLspApi({
+      completion: vi
+        .fn()
+        .mockRejectedValueOnce(new Error('No active SSH connection for "ssh-1"'))
+        .mockResolvedValue([{ label: 'ready' }])
+    })
+    installWindowApi(api)
+    const { monaco, model, completionProviders } = createMonacoMock()
+    const { registerMonacoLspDocument } = await import('./monaco-lsp')
+
+    const dispose = registerMonacoLspDocument(
+      monaco,
+      documentArgs('int main(void);', { connectionId: 'ssh-1' })
+    )
+    await waitForAssertion(() => expect(api.openDocument).toHaveBeenCalledTimes(1))
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-15T12:00:00Z'))
+    const provider = completionProviders.get('c')
+    if (!provider) {
+      throw new Error('expected C completion provider to be registered')
+    }
+
+    await expect(
+      provider.provideCompletionItems(model, { lineNumber: 1, column: 7 })
+    ).resolves.toEqual({ suggestions: [] })
+
+    await vi.advanceTimersByTimeAsync(2_001)
+    const result = await provider.provideCompletionItems(model, { lineNumber: 1, column: 7 })
+
+    expect(api.getStatus).toHaveBeenCalledTimes(2)
+    expect(api.openDocument).toHaveBeenCalledTimes(2)
+    expect(result.suggestions[0]).toMatchObject({ label: 'ready' })
+
+    dispose()
+  })
+
+  it('returns single definition targets to Monaco without opening files as a side effect', async () => {
+    vi.resetModules()
+    const api = createLspApi({
+      definition: vi.fn(async () => [
+        {
+          uri: 'file:///tmp/project/include/foo.h',
+          range: { start: { line: 4, character: 2 }, end: { line: 4, character: 5 } }
+        }
+      ])
+    })
+    installWindowApi(api)
+    const { monaco, model, definitionProviders } = createMonacoMock()
+    const { registerMonacoLspDocument } = await import('./monaco-lsp')
+
+    const dispose = registerMonacoLspDocument(monaco, documentArgs())
+    await waitForAssertion(() => expect(api.openDocument).toHaveBeenCalledTimes(1))
+    const provider = definitionProviders.get('c')
+    if (!provider) {
+      throw new Error('expected C definition provider to be registered')
+    }
+
+    const definitions = await provider.provideDefinition(model, { lineNumber: 1, column: 7 })
+    expect(definitions).toHaveLength(1)
+    expect(definitions[0]).toMatchObject({
+      range: {
+        startLineNumber: 5,
+        startColumn: 3,
+        endLineNumber: 5,
+        endColumn: 6
+      }
+    })
+
+    dispose()
+  })
+
+  it('returns multiple definition targets to Monaco instead of forcing the first one', async () => {
+    vi.resetModules()
+    const api = createLspApi({
+      definition: vi.fn(async () => [
+        {
+          uri: 'file:///tmp/project/include/foo.h',
+          range: { start: { line: 4, character: 2 }, end: { line: 4, character: 5 } }
+        },
+        {
+          uri: 'file:///tmp/project/include/bar.h',
+          range: { start: { line: 8, character: 1 }, end: { line: 8, character: 4 } }
+        }
+      ])
+    })
+    installWindowApi(api)
+    const { monaco, model, definitionProviders } = createMonacoMock()
+    const { registerMonacoLspDocument } = await import('./monaco-lsp')
+
+    const dispose = registerMonacoLspDocument(monaco, documentArgs())
+    await waitForAssertion(() => expect(api.openDocument).toHaveBeenCalledTimes(1))
+    const provider = definitionProviders.get('c')
+    if (!provider) {
+      throw new Error('expected C definition provider to be registered')
+    }
+
+    const definitions = await provider.provideDefinition(model, { lineNumber: 1, column: 7 })
+
+    expect(definitions).toHaveLength(2)
+    expect(definitions[0]).toMatchObject({
+      range: {
+        startLineNumber: 5,
+        startColumn: 3,
+        endLineNumber: 5,
+        endColumn: 6
+      }
+    })
+
+    dispose()
+  })
+})

--- a/src/renderer/src/lib/monaco-lsp.ts
+++ b/src/renderer/src/lib/monaco-lsp.ts
@@ -1,0 +1,622 @@
+/* eslint-disable max-lines -- Why: Monaco's LSP adapter needs shared context for
+providers, diagnostics, document sync, and cleanup; keeping it together prevents
+provider/document lifecycle drift. */
+import type * as monacoTypes from 'monaco-editor'
+import type {
+  LspCompletionItem,
+  LspCompletionResult,
+  LspDiagnosticsEvent,
+  LspDocumentContext,
+  LspHover,
+  LspLocation,
+  LspPosition,
+  LspRange,
+  LspServerStatus
+} from '../../../shared/lsp-types'
+
+type Monaco = typeof monacoTypes
+
+type LspModelContext = LspDocumentContext & {
+  modelUri: string
+  opened: boolean
+  status: LspServerStatus | null
+  lastSyncedContent: string
+  changeTimer: ReturnType<typeof setTimeout> | null
+  changePromise: Promise<void> | null
+  openPromise: Promise<void> | null
+  nextOpenRetryAt: number
+}
+
+type LspModelEntry = {
+  context: LspModelContext
+  references: number
+  disposed: boolean
+}
+
+const LSP_MARKER_OWNER = 'orca-lsp'
+const CHANGE_DEBOUNCE_MS = 250
+const OPEN_RETRY_DELAY_MS = 2_000
+// Why: Monaco already wires its TypeScript worker for JS/TS. Registering a
+// second external provider there duplicates completions and definitions.
+const SUPPORTED_LSP_LANGUAGES = ['rust', 'c', 'cpp', 'go', 'python']
+
+const entriesByModelUri = new Map<string, LspModelEntry>()
+let providersRegistered = false
+let diagnosticsRegistered = false
+const rendererLspInstanceId = Math.random().toString(36).slice(2)
+let nextLspDocumentId = 1
+
+function hasLspApi(): boolean {
+  return typeof window !== 'undefined' && Boolean(window.api?.lsp)
+}
+
+function createDocumentId(modelUri: string): string {
+  return `${rendererLspInstanceId}:${nextLspDocumentId++}:${modelUri}`
+}
+
+function lspPosition(position: monacoTypes.Position): LspPosition {
+  return {
+    line: position.lineNumber - 1,
+    character: position.column - 1
+  }
+}
+
+function monacoRange(monaco: Monaco, range: LspRange): monacoTypes.Range {
+  return new monaco.Range(
+    range.start.line + 1,
+    range.start.character + 1,
+    range.end.line + 1,
+    range.end.character + 1
+  )
+}
+
+function markerSeverity(monaco: Monaco, severity: number | undefined): monacoTypes.MarkerSeverity {
+  switch (severity) {
+    case 1:
+      return monaco.MarkerSeverity.Error
+    case 2:
+      return monaco.MarkerSeverity.Warning
+    case 3:
+      return monaco.MarkerSeverity.Info
+    case 4:
+      return monaco.MarkerSeverity.Hint
+    default:
+      return monaco.MarkerSeverity.Warning
+  }
+}
+
+function completionKind(
+  monaco: Monaco,
+  kind: number | undefined
+): monacoTypes.languages.CompletionItemKind {
+  const k = monaco.languages.CompletionItemKind
+  switch (kind) {
+    case 2:
+      return k.Method
+    case 3:
+      return k.Function
+    case 4:
+      return k.Constructor
+    case 5:
+      return k.Field
+    case 6:
+      return k.Variable
+    case 7:
+      return k.Class
+    case 8:
+      return k.Interface
+    case 9:
+      return k.Module
+    case 10:
+      return k.Property
+    case 11:
+      return k.Unit
+    case 12:
+      return k.Value
+    case 13:
+      return k.Enum
+    case 14:
+      return k.Keyword
+    case 15:
+      return k.Snippet
+    case 16:
+      return k.Color
+    case 17:
+      return k.File
+    case 18:
+      return k.Reference
+    case 19:
+      return k.Folder
+    case 20:
+      return k.EnumMember
+    case 21:
+      return k.Constant
+    case 22:
+      return k.Struct
+    case 23:
+      return k.Event
+    case 24:
+      return k.Operator
+    case 25:
+      return k.TypeParameter
+    default:
+      return k.Text
+  }
+}
+
+function documentationToMarkdown(
+  documentation: LspCompletionItem['documentation'] | undefined
+): string | undefined {
+  if (!documentation) {
+    return undefined
+  }
+  if (typeof documentation === 'string') {
+    return documentation
+  }
+  return documentation.value
+}
+
+function hoverContents(hover: LspHover | null): monacoTypes.IMarkdownString[] {
+  if (!hover) {
+    return []
+  }
+  const raw = Array.isArray(hover.contents) ? hover.contents : [hover.contents]
+  return raw.flatMap((entry) => {
+    if (typeof entry === 'string') {
+      return entry ? [{ value: entry }] : []
+    }
+    if ('language' in entry) {
+      return [{ value: `\`\`\`${entry.language}\n${entry.value}\n\`\`\`` }]
+    }
+    return entry.value ? [{ value: entry.value }] : []
+  })
+}
+
+function completionItems(result: LspCompletionResult | null): LspCompletionItem[] {
+  if (!result) {
+    return []
+  }
+  return Array.isArray(result) ? result : result.items
+}
+
+function findContext(model: monacoTypes.editor.ITextModel): LspModelContext | undefined {
+  return entriesByModelUri.get(model.uri.toString())?.context
+}
+
+function contexts(): Iterable<LspModelContext> {
+  return Array.from(entriesByModelUri.values(), (entry) => entry.context)
+}
+
+function documentPayload(context: LspModelContext, content = context.content): LspDocumentContext {
+  return {
+    worktreeId: context.worktreeId,
+    worktreePath: context.worktreePath,
+    filePath: context.filePath,
+    languageId: context.languageId,
+    content,
+    connectionId: context.connectionId,
+    runtimeEnvironmentId: context.runtimeEnvironmentId,
+    documentId: context.documentId
+  }
+}
+
+function documentIdentityPayload(context: LspModelContext): Omit<LspDocumentContext, 'content'> {
+  return {
+    worktreeId: context.worktreeId,
+    worktreePath: context.worktreePath,
+    filePath: context.filePath,
+    languageId: context.languageId,
+    connectionId: context.connectionId,
+    runtimeEnvironmentId: context.runtimeEnvironmentId,
+    documentId: context.documentId
+  }
+}
+
+async function openContext(context: LspModelContext): Promise<void> {
+  if (!hasLspApi()) {
+    return
+  }
+  try {
+    const status = await window.api.lsp.getStatus(documentIdentityPayload(context))
+    context.status = status
+    if (status.state !== 'available') {
+      context.opened = false
+      context.nextOpenRetryAt = Date.now() + OPEN_RETRY_DELAY_MS
+      return
+    }
+    const openedContent = context.content
+    await window.api.lsp.openDocument(documentPayload(context, openedContent))
+    context.opened = true
+    context.nextOpenRetryAt = 0
+    context.lastSyncedContent = openedContent
+    if (context.content !== openedContent) {
+      await queueDocumentChange(context, context.content)
+    }
+  } catch {
+    context.opened = false
+    context.nextOpenRetryAt = Date.now() + OPEN_RETRY_DELAY_MS
+    throw new Error('LSP document open failed')
+  }
+}
+
+async function ensureContextOpen(context: LspModelContext): Promise<boolean> {
+  await context.openPromise
+  if (context.status?.state === 'available' && context.opened) {
+    return true
+  }
+  if (Date.now() < context.nextOpenRetryAt) {
+    return false
+  }
+  // Why: SSH reconnects and late server installs can turn an unavailable LSP
+  // into an available one while the editor stays mounted. Retry on demand with
+  // a short cooldown instead of making availability sticky for the tab lifetime.
+  context.openPromise = openContext(context).catch(() => undefined)
+  await context.openPromise
+  return context.status?.state === 'available' && context.opened
+}
+
+async function ensureLatestContent(context: LspModelContext): Promise<boolean> {
+  if (!hasLspApi()) {
+    return false
+  }
+  if (!(await ensureContextOpen(context))) {
+    return false
+  }
+  // Why: Monaco already gives us full-document content through onChange.
+  // Reading the model again on completion/hover would copy large files on the
+  // interactive request path even when no edit is pending.
+  const content = context.content
+  if (content !== context.lastSyncedContent) {
+    if (context.changeTimer) {
+      clearTimeout(context.changeTimer)
+      context.changeTimer = null
+    }
+    await queueDocumentChange(context, content)
+  } else if (context.changePromise) {
+    await context.changePromise
+  }
+  return true
+}
+
+function scheduleChange(context: LspModelContext, content: string): void {
+  context.content = content
+  if (!context.opened || context.status?.state !== 'available' || !hasLspApi()) {
+    return
+  }
+  if (context.changeTimer) {
+    clearTimeout(context.changeTimer)
+  }
+  context.changeTimer = setTimeout(() => {
+    context.changeTimer = null
+    void queueDocumentChange(context, content).catch(() => {})
+  }, CHANGE_DEBOUNCE_MS)
+}
+
+function markContextUnavailable(context: LspModelContext): void {
+  context.opened = false
+  context.status = null
+  context.nextOpenRetryAt = Date.now() + OPEN_RETRY_DELAY_MS
+}
+
+function registerDiagnostics(monaco: Monaco): void {
+  if (diagnosticsRegistered || !hasLspApi()) {
+    return
+  }
+  diagnosticsRegistered = true
+  window.api.lsp.onDiagnostics((event: LspDiagnosticsEvent) => {
+    for (const context of contexts()) {
+      if (
+        context.filePath !== event.filePath ||
+        context.worktreePath !== event.worktreePath ||
+        context.languageId !== event.languageId ||
+        (context.connectionId ?? undefined) !== (event.connectionId ?? undefined) ||
+        (context.runtimeEnvironmentId ?? undefined) !== (event.runtimeEnvironmentId ?? undefined)
+      ) {
+        continue
+      }
+      const model = monaco.editor.getModel(monaco.Uri.parse(context.modelUri))
+      if (!model) {
+        continue
+      }
+      monaco.editor.setModelMarkers(
+        model,
+        LSP_MARKER_OWNER,
+        event.diagnostics.map((diagnostic) => ({
+          severity: markerSeverity(monaco, diagnostic.severity),
+          message: diagnostic.message,
+          source: diagnostic.source ?? 'LSP',
+          code: diagnostic.code === undefined ? undefined : String(diagnostic.code),
+          startLineNumber: diagnostic.range.start.line + 1,
+          startColumn: diagnostic.range.start.character + 1,
+          endLineNumber: diagnostic.range.end.line + 1,
+          endColumn: diagnostic.range.end.character + 1
+        }))
+      )
+    }
+  })
+}
+
+function sameDocumentIdentity(context: LspModelContext, args: LspDocumentContext): boolean {
+  return (
+    context.worktreePath === args.worktreePath &&
+    context.filePath === args.filePath &&
+    context.languageId === args.languageId &&
+    (context.connectionId ?? undefined) === (args.connectionId ?? undefined) &&
+    (context.runtimeEnvironmentId ?? undefined) === (args.runtimeEnvironmentId ?? undefined) &&
+    (!args.documentId || !context.documentId || context.documentId === args.documentId)
+  )
+}
+
+function completionInsertText(item: LspCompletionItem): string {
+  return item.textEdit?.newText ?? item.insertText ?? item.label
+}
+
+function completionRange(
+  monaco: Monaco,
+  item: LspCompletionItem,
+  fallbackRange: monacoTypes.Range
+): monacoTypes.languages.CompletionItem['range'] {
+  const textEdit = item.textEdit
+  if (!textEdit) {
+    return fallbackRange
+  }
+  if ('insert' in textEdit) {
+    return {
+      insert: monacoRange(monaco, textEdit.insert),
+      replace: monacoRange(monaco, textEdit.replace)
+    }
+  }
+  return monacoRange(monaco, textEdit.range)
+}
+
+function additionalTextEdits(
+  monaco: Monaco,
+  item: LspCompletionItem
+): monacoTypes.languages.TextEdit[] | undefined {
+  return item.additionalTextEdits?.map((edit) => ({
+    range: monacoRange(monaco, edit.range),
+    text: edit.newText
+  }))
+}
+
+function monacoLocation(monaco: Monaco, location: LspLocation): monacoTypes.languages.Location {
+  return {
+    uri: monaco.Uri.parse(location.uri),
+    range: monacoRange(monaco, location.range)
+  }
+}
+
+function queueDocumentChange(context: LspModelContext, content: string): Promise<void> {
+  const previous = context.changePromise?.catch(() => undefined) ?? Promise.resolve()
+  const run = previous.then(async () => {
+    if (!context.opened || context.status?.state !== 'available' || !hasLspApi()) {
+      return
+    }
+    await window.api.lsp.changeDocument(documentPayload(context, content))
+    if (context.content === content) {
+      context.lastSyncedContent = content
+    }
+  })
+  const queued = run.catch(() => undefined)
+  context.changePromise = queued
+  void queued.finally(() => {
+    if (context.changePromise === queued) {
+      context.changePromise = null
+    }
+  })
+  return run
+}
+
+function startOpening(entry: LspModelEntry): void {
+  const context = entry.context
+  context.openPromise = openContext(context).catch(() => undefined)
+}
+
+function releaseEntry(monaco: Monaco, modelUri: string, entry: LspModelEntry): void {
+  if (entry.references <= 0) {
+    return
+  }
+  entry.references--
+  if (entry.references > 0) {
+    return
+  }
+
+  entry.disposed = true
+  const isCurrentEntry = entriesByModelUri.get(modelUri) === entry
+  if (isCurrentEntry) {
+    entriesByModelUri.delete(modelUri)
+  }
+  if (entry.context.changeTimer) {
+    clearTimeout(entry.context.changeTimer)
+    entry.context.changeTimer = null
+  }
+  const pendingChange = entry.context.changePromise
+  if (isCurrentEntry) {
+    const model = monaco.editor.getModel(monaco.Uri.parse(modelUri))
+    if (model) {
+      monaco.editor.setModelMarkers(model, LSP_MARKER_OWNER, [])
+    }
+  }
+  void entry.context.openPromise
+    ?.then(async () => {
+      await pendingChange?.catch(() => undefined)
+      const currentEntry = entriesByModelUri.get(modelUri)
+      if (currentEntry && sameDocumentIdentity(currentEntry.context, entry.context)) {
+        return
+      }
+      if (entry.context.opened && hasLspApi()) {
+        await window.api.lsp.closeDocument(documentIdentityPayload(entry.context))
+      }
+    })
+    .catch(() => {})
+}
+
+export function ensureMonacoLspProviders(monaco: Monaco): void {
+  registerDiagnostics(monaco)
+  if (providersRegistered) {
+    return
+  }
+  providersRegistered = true
+
+  for (const language of SUPPORTED_LSP_LANGUAGES) {
+    monaco.languages.registerCompletionItemProvider(language, {
+      triggerCharacters: ['.', ':', '"', "'", '/', '<'],
+      provideCompletionItems: async (model, position) => {
+        const context = findContext(model)
+        try {
+          if (!context || !(await ensureLatestContent(context))) {
+            return { suggestions: [] }
+          }
+          const result = await window.api.lsp.completion({
+            ...documentIdentityPayload(context),
+            position: lspPosition(position)
+          })
+          const range = model.getWordUntilPosition(position)
+          const replaceRange = new monaco.Range(
+            position.lineNumber,
+            range.startColumn,
+            position.lineNumber,
+            range.endColumn
+          )
+          return {
+            suggestions: completionItems(result).map((item) => ({
+              label: item.label,
+              kind: completionKind(monaco, item.kind),
+              detail: item.detail,
+              documentation: documentationToMarkdown(item.documentation),
+              insertText: completionInsertText(item),
+              insertTextRules:
+                item.insertTextFormat === 2
+                  ? monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet
+                  : undefined,
+              sortText: item.sortText,
+              filterText: item.filterText,
+              range: completionRange(monaco, item, replaceRange),
+              additionalTextEdits: additionalTextEdits(monaco, item)
+            }))
+          }
+        } catch {
+          if (context) {
+            markContextUnavailable(context)
+          }
+          return { suggestions: [] }
+        }
+      }
+    })
+
+    monaco.languages.registerHoverProvider(language, {
+      provideHover: async (model, position) => {
+        const context = findContext(model)
+        try {
+          if (!context || !(await ensureLatestContent(context))) {
+            return null
+          }
+          const hover = await window.api.lsp.hover({
+            ...documentIdentityPayload(context),
+            position: lspPosition(position)
+          })
+          const contents = hoverContents(hover)
+          return contents.length === 0
+            ? null
+            : {
+                contents,
+                range: hover?.range ? monacoRange(monaco, hover.range) : undefined
+              }
+        } catch {
+          if (context) {
+            markContextUnavailable(context)
+          }
+          return null
+        }
+      }
+    })
+
+    monaco.languages.registerDefinitionProvider(language, {
+      provideDefinition: async (model, position) => {
+        const context = findContext(model)
+        try {
+          if (!context || !(await ensureLatestContent(context))) {
+            return []
+          }
+          const definitions = await window.api.lsp.definition({
+            ...documentIdentityPayload(context),
+            position: lspPosition(position)
+          })
+          return definitions.map((location) => monacoLocation(monaco, location))
+        } catch {
+          if (context) {
+            markContextUnavailable(context)
+          }
+          return []
+        }
+      }
+    })
+  }
+}
+
+export function registerMonacoLspDocument(
+  monaco: Monaco,
+  args: LspDocumentContext & { modelUri: string }
+): () => void {
+  if (!SUPPORTED_LSP_LANGUAGES.includes(args.languageId)) {
+    return () => {}
+  }
+  ensureMonacoLspProviders(monaco)
+  const existing = entriesByModelUri.get(args.modelUri)
+  if (existing && sameDocumentIdentity(existing.context, args)) {
+    existing.references++
+    existing.context.content = args.content
+    let released = false
+    return () => {
+      if (released) {
+        return
+      }
+      released = true
+      releaseEntry(monaco, args.modelUri, existing)
+    }
+  }
+  if (existing) {
+    // Why: Monaco providers are keyed only by model URI. If the same URI is
+    // reused for a different backend identity, keeping both contexts would make
+    // request routing ambiguous; replace the stale owner before opening a new one.
+    while (existing.references > 0) {
+      releaseEntry(monaco, args.modelUri, existing)
+    }
+  }
+
+  const context: LspModelContext = {
+    ...args,
+    opened: false,
+    status: null,
+    lastSyncedContent: args.content,
+    changeTimer: null,
+    changePromise: null,
+    openPromise: null,
+    nextOpenRetryAt: 0,
+    documentId: args.documentId ?? createDocumentId(args.modelUri)
+  }
+  const entry: LspModelEntry = {
+    context,
+    references: 1,
+    disposed: false
+  }
+  entriesByModelUri.set(args.modelUri, entry)
+  startOpening(entry)
+
+  let released = false
+  return () => {
+    if (released) {
+      return
+    }
+    released = true
+    releaseEntry(monaco, args.modelUri, entry)
+  }
+}
+
+export function updateMonacoLspDocumentContent(modelUri: string, content: string): void {
+  const entry = entriesByModelUri.get(modelUri)
+  if (!entry) {
+    return
+  }
+  scheduleChange(entry.context, content)
+}

--- a/src/renderer/src/lib/monaco-setup.ts
+++ b/src/renderer/src/lib/monaco-setup.ts
@@ -11,6 +11,7 @@ import { registerAstroLanguage } from './monaco-languages/register-astro'
 import { registerSvelteLanguage } from './monaco-languages/register-svelte'
 import { registerVueLanguage } from './monaco-languages/register-vue'
 import { installMonacoDiffEditorDisposalGuard } from './monaco-diff-editor-disposal'
+import { ensureMonacoLspProviders } from './monaco-lsp'
 
 globalThis.MonacoEnvironment = {
   getWorker(_workerId, label) {
@@ -73,6 +74,7 @@ registerVueLanguage(monaco)
 registerSvelteLanguage(monaco)
 registerAstroLanguage(monaco)
 installMonacoDiffEditorDisposalGuard(monaco)
+ensureMonacoLspProviders(monaco)
 
 // Configure Monaco to use the locally bundled editor instead of CDN
 loader.config({ monaco })

--- a/src/shared/lsp-types.ts
+++ b/src/shared/lsp-types.ts
@@ -1,0 +1,102 @@
+export type LspPosition = {
+  line: number
+  character: number
+}
+
+export type LspRange = {
+  start: LspPosition
+  end: LspPosition
+}
+
+export type LspLocation = {
+  uri: string
+  range: LspRange
+}
+
+export type LspDiagnostic = {
+  range: LspRange
+  severity?: number
+  code?: string | number
+  source?: string
+  message: string
+}
+
+export type LspTextEdit = {
+  range: LspRange
+  newText: string
+}
+
+export type LspInsertReplaceEdit = {
+  insert: LspRange
+  replace: LspRange
+  newText: string
+}
+
+export type LspCompletionItem = {
+  label: string
+  kind?: number
+  detail?: string
+  documentation?: string | { kind: string; value: string }
+  insertText?: string
+  insertTextFormat?: number
+  textEdit?: LspTextEdit | LspInsertReplaceEdit
+  additionalTextEdits?: LspTextEdit[]
+  sortText?: string
+  filterText?: string
+}
+
+export type LspCompletionResult =
+  | LspCompletionItem[]
+  | {
+      isIncomplete?: boolean
+      items: LspCompletionItem[]
+    }
+
+export type LspHover = {
+  contents:
+    | string
+    | { kind: string; value: string }
+    | { language: string; value: string }
+    | (string | { kind: string; value: string } | { language: string; value: string })[]
+  range?: LspRange
+}
+
+export type LspServerState = 'available' | 'unavailable'
+
+export type LspServerStatus = {
+  state: LspServerState
+  languageId: string
+  command?: string
+  reason?: string
+}
+
+export type LspDocumentContext = {
+  worktreeId: string
+  worktreePath: string
+  filePath: string
+  languageId: string
+  content: string
+  connectionId?: string
+  runtimeEnvironmentId?: string
+  documentId?: string
+}
+
+export type LspDocumentChange = Omit<LspDocumentContext, 'worktreeId'> & {
+  worktreeId?: string
+}
+
+export type LspDocumentIdentity = Omit<LspDocumentChange, 'content'>
+
+export type LspRequestContext = Omit<LspDocumentContext, 'content'> & {
+  content?: string
+  position: LspPosition
+}
+
+export type LspDiagnosticsEvent = {
+  worktreePath: string
+  filePath: string
+  languageId: string
+  connectionId?: string
+  runtimeEnvironmentId?: string
+  diagnostics: LspDiagnostic[]
+}


### PR DESCRIPTION
## Summary
- Adds a built-in LSP service with stdio JSON-RPC session management, lifecycle cleanup, diagnostics fanout, completion, hover, and definition support.
- Wires Monaco through preload IPC so editor documents open/change/close against LSP sessions and render diagnostics/completions/hovers/definitions.
- Adds SSH relay LSP forwarding so remote worktrees can own language-server processes on the remote host.
- Uses VS Code's TypeScript-native-preview direction: TypeScript/JavaScript support is `tsgo --lsp` only when the installed `tsgo` advertises LSP support; there is no `typescript-language-server` fallback.

## Language Scope
- Built in for v1: `rust-analyzer`, `clangd` for C/C++, `gopls`, `pyright-langserver --stdio`, and `tsgo --lsp` when supported.
- No plugin/extension system in this PR. Discovery is registry-driven and probe-based so stale shims are reported unavailable instead of starting broken sessions. A future plugin surface can add server candidates to that registry.

## Review Fixes Added
- Fixed split-pane lifecycle: multiple visible Monaco panes sharing one retained model now ref-count the LSP document instead of closing it when one pane unmounts.
- Fixed async open/unmount race: if an editor unmounts before `openDocument` finishes, the document is closed after the open promise settles.
- Reduced hot-path payloads: completion/hover/definition requests no longer resend full document content after `ensureLatestContent()` has synchronized the document.
- Added completion `textEdit` and `additionalTextEdits` mapping so servers can control replacement ranges and side edits.
- Relay shutdown now disposes LSP child sessions with the other relay handlers.

## Reference Notes
- Checked VS Code OSS via `$ref-oss`, especially `extensions/typescript-language-features/src/extension.ts` and `commands/useTsgo.ts`, to mirror the native-preview-only TypeScript policy.
- Also reviewed VS Code language-client based JSON/HTML/Markdown extensions for lifecycle and request-shape precedent.

## Performance / Runtime Evidence
- Electron/CDP local UI check: Monaco mounted with one open C LSP document and one active session; screenshot saved at `.playwright-cli/lsp-fix-ui-open.png`.
- Local `clangd` via Electron IPC: status 14ms, document change 0ms, completion 5ms returning `alpha`/`beta`, hover 4ms, diagnostic publish 64ms.
- Focused renderer unit verifies completion/hover/definition provider requests are identity/position-only after sync, not full-document payloads.
- Docker SSH relay smoke: Orca connected to a throwaway Linux container, deployed the relay, resolved remote `/usr/local/bin/clangd`, then remote LSP status 9ms, open 19ms, completion 2ms returning `alpha`/`beta`, hover 1ms, diagnostics 2ms.
- Stale local `rust-analyzer` shim was correctly reported unavailable after probe failure instead of creating a broken session.

## Verification
- `pnpm run lint` passed.
- `pnpm run tc:node` passed.
- `pnpm run tc:web` passed.
- `pnpm run build:relay` passed for linux/darwin x64/arm64 relay bundles.
- `pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/register-core-handlers.test.ts src/main/lsp/language-server-registry.test.ts src/main/lsp/lsp-process-session.test.ts src/relay/lsp-handler.test.ts src/renderer/src/lib/monaco-lsp.test.ts` passed: 5 files, 10 tests.
- `git diff --check` passed.
- Full `pnpm test` exact-commit rerun previously executed 586 files and only failed the pre-existing `src/main/daemon/node-pty-fd-leak.test.ts` because this host currently cannot allocate a pseudo-terminal (`node-pty: posix_openpt failed: errno 6, Device not configured`). The LSP-related tests passed in that run and in the focused reruns.

Risk: high
Historic risk metadata backfill based on the existing `risk:high` label.