### PR TITLE
Add Gitea hosted review support

### DIFF
--- a/src/main/gitea/client.test.ts
+++ b/src/main/gitea/client.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { gitExecFileAsyncMock } = vi.hoisted(() => ({
+  gitExecFileAsyncMock: vi.fn()
+}))
+
+vi.mock('../git/runner', () => ({
+  gitExecFileAsync: gitExecFileAsyncMock
+}))
+
+import {
+  getGiteaAuthStatus,
+  getGiteaPullRequestForBranch,
+  normalizeGiteaApiBaseUrl
+} from './client'
+import { _resetGiteaRepoRefCache } from './repository-ref'
+
+const OLD_ENV = process.env
+
+function giteaPr(index = 7, branch = 'feature/gitea') {
+  return {
+    number: index,
+    title: 'Add Gitea',
+    state: 'open',
+    html_url: `https://git.example.com/team/repo/pulls/${index}`,
+    updated_at: '2026-05-15T00:00:00Z',
+    mergeable: true,
+    head: {
+      ref: branch,
+      label: `team:${branch}`,
+      sha: 'abc123'
+    }
+  }
+}
+
+describe('Gitea client', () => {
+  beforeEach(() => {
+    process.env = { ...OLD_ENV }
+    process.env.ORCA_GITEA_TOKEN = 'gitea-token'
+    delete process.env.ORCA_GITEA_API_BASE_URL
+    gitExecFileAsyncMock.mockReset()
+    gitExecFileAsyncMock.mockResolvedValue({
+      stdout: 'https://git.example.com/team/repo.git\n',
+      stderr: ''
+    })
+    _resetGiteaRepoRefCache()
+    vi.unstubAllGlobals()
+  })
+
+  it('normalizes Gitea API base URLs', () => {
+    expect(normalizeGiteaApiBaseUrl('https://git.example.com')).toBe(
+      'https://git.example.com/api/v1'
+    )
+    expect(normalizeGiteaApiBaseUrl('https://git.example.com/api/v1/')).toBe(
+      'https://git.example.com/api/v1'
+    )
+  })
+
+  it('fetches a branch pull request and commit status', async () => {
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      const parsed = new URL(url)
+      if (!init) {
+        throw new Error('expected request init')
+      }
+      expect((init.headers as Record<string, string>).Authorization).toBe('token gitea-token')
+      if (parsed.pathname.endsWith('/commits/abc123/status')) {
+        return Response.json({ state: 'success' })
+      }
+      return Response.json([giteaPr()])
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(
+      getGiteaPullRequestForBranch('/repo', 'refs/heads/feature/gitea')
+    ).resolves.toEqual({
+      number: 7,
+      title: 'Add Gitea',
+      state: 'open',
+      url: 'https://git.example.com/team/repo/pulls/7',
+      status: 'success',
+      updatedAt: '2026-05-15T00:00:00Z',
+      mergeable: 'MERGEABLE',
+      headSha: 'abc123'
+    })
+
+    const listUrl = new URL(String(fetchMock.mock.calls[0]?.[0]))
+    expect(listUrl.origin).toBe('https://git.example.com')
+    expect(listUrl.pathname).toBe('/api/v1/repos/team/repo/pulls')
+    expect(listUrl.searchParams.get('state')).toBe('all')
+    expect(listUrl.searchParams.get('sort')).toBe('recentupdate')
+    expect(listUrl.searchParams.get('page')).toBe('1')
+    expect(listUrl.searchParams.get('limit')).toBe('50')
+  })
+
+  it('uses an API base URL override for subpath or non-standard deployments', async () => {
+    process.env.ORCA_GITEA_API_BASE_URL = 'https://git.example.com/code'
+    const fetchMock = vi.fn(async (url: string | URL) => {
+      if (String(url).includes('/commits/abc123/status')) {
+        return Response.json({ state: 'pending' })
+      }
+      return Response.json([giteaPr()])
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(getGiteaPullRequestForBranch('/repo', 'feature/gitea')).resolves.toMatchObject({
+      number: 7,
+      status: 'pending'
+    })
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain(
+      'https://git.example.com/code/api/v1/repos/team/repo/pulls'
+    )
+  })
+
+  it('falls back to a linked PR number when branch lookup misses', async () => {
+    const fetchMock = vi.fn(async (url: string | URL) => {
+      const requestUrl = String(url)
+      if (requestUrl.includes('/commits/abc123/status')) {
+        return Response.json({ state: 'success' })
+      }
+      if (requestUrl.endsWith('/pulls/42')) {
+        return Response.json(giteaPr(42, 'renamed-local-branch'))
+      }
+      return Response.json([])
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(getGiteaPullRequestForBranch('/repo', 'local-name', 42)).resolves.toMatchObject({
+      number: 42,
+      status: 'success'
+    })
+  })
+
+  it('reports configured token auth without a global API base URL', async () => {
+    await expect(getGiteaAuthStatus()).resolves.toEqual({
+      configured: true,
+      authenticated: true,
+      account: null,
+      baseUrl: null,
+      tokenConfigured: true
+    })
+  })
+
+  it('verifies token auth when a global API base URL is configured', async () => {
+    process.env.ORCA_GITEA_API_BASE_URL = 'https://git.example.com'
+    const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) =>
+      Response.json({ login: 'gitea-user' })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(getGiteaAuthStatus()).resolves.toEqual({
+      configured: true,
+      authenticated: true,
+      account: 'gitea-user',
+      baseUrl: 'https://git.example.com/api/v1',
+      tokenConfigured: true
+    })
+    expect(String(fetchMock.mock.calls[0]?.[0])).toBe('https://git.example.com/api/v1/user')
+  })
+})

--- a/src/main/gitea/client.ts
+++ b/src/main/gitea/client.ts
@@ -1,0 +1,253 @@
+import {
+  deriveGiteaCommitStatus,
+  mapGiteaPullRequest,
+  type GiteaPullRequestInfo,
+  type RawGiteaCombinedStatus,
+  type RawGiteaPullRequest
+} from './pull-request-mappers'
+import { getGiteaRepoRef, type GiteaRepoRef } from './repository-ref'
+
+const REQUEST_TIMEOUT_MS = 5000
+const PULL_REQUEST_PAGE_LIMIT = 50
+const MAX_PULL_REQUEST_PAGES = 5
+
+type GiteaAuthConfig = {
+  apiBaseUrl: string | null
+  token: string | null
+}
+
+export type GiteaAuthStatus = {
+  configured: boolean
+  authenticated: boolean
+  account: string | null
+  baseUrl: string | null
+  tokenConfigured: boolean
+}
+
+type RequestOptions = {
+  searchParams?: Record<string, string | number>
+  timeoutMs?: number
+}
+
+function envValue(name: string): string | null {
+  const value = process.env[name]?.trim() ?? ''
+  return value.length > 0 ? value : null
+}
+
+export function normalizeGiteaApiBaseUrl(value: string): string {
+  const trimmed = value.trim().replace(/\/+$/, '')
+  return /\/api\/v1$/i.test(trimmed) ? trimmed : `${trimmed}/api/v1`
+}
+
+function getAuthConfig(): GiteaAuthConfig {
+  const apiBaseUrl = envValue('ORCA_GITEA_API_BASE_URL')
+  return {
+    apiBaseUrl: apiBaseUrl ? normalizeGiteaApiBaseUrl(apiBaseUrl) : null,
+    token: envValue('ORCA_GITEA_TOKEN')
+  }
+}
+
+function authHeaders(config: Pick<GiteaAuthConfig, 'token'>): Record<string, string> {
+  return config.token ? { Authorization: `token ${config.token}` } : {}
+}
+
+function configuredApiBaseUrl(repo: GiteaRepoRef): string {
+  return getAuthConfig().apiBaseUrl ?? repo.apiBaseUrl
+}
+
+function apiUrl(baseUrl: string, path: string, searchParams?: RequestOptions['searchParams']): URL {
+  const url = new URL(`${baseUrl.replace(/\/+$/, '')}${path}`)
+  if (searchParams) {
+    for (const [key, value] of Object.entries(searchParams)) {
+      url.searchParams.set(key, String(value))
+    }
+  }
+  return url
+}
+
+async function requestJsonAtBase<T>(
+  baseUrl: string,
+  path: string,
+  options: RequestOptions = {}
+): Promise<T | null> {
+  const config = getAuthConfig()
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), options.timeoutMs ?? REQUEST_TIMEOUT_MS)
+  try {
+    const response = await fetch(apiUrl(baseUrl, path, options.searchParams), {
+      headers: {
+        Accept: 'application/json',
+        ...authHeaders(config)
+      },
+      signal: controller.signal
+    })
+    if (!response.ok) {
+      return null
+    }
+    return (await response.json()) as T
+  } catch {
+    return null
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+function requestJson<T>(
+  repo: GiteaRepoRef,
+  path: string,
+  options: RequestOptions = {}
+): Promise<T | null> {
+  return requestJsonAtBase(configuredApiBaseUrl(repo), path, options)
+}
+
+function encodedRepoPath(repo: GiteaRepoRef): string {
+  return `${encodeURIComponent(repo.owner)}/${encodeURIComponent(repo.repo)}`
+}
+
+async function getCommitStatus(
+  repo: GiteaRepoRef,
+  headSha: string | undefined
+): Promise<ReturnType<typeof deriveGiteaCommitStatus>> {
+  if (!headSha) {
+    return 'neutral'
+  }
+  const data = await requestJson<RawGiteaCombinedStatus>(
+    repo,
+    `/repos/${encodedRepoPath(repo)}/commits/${encodeURIComponent(headSha)}/status`
+  )
+  return deriveGiteaCommitStatus(data)
+}
+
+async function normalizePullRequest(
+  repo: GiteaRepoRef,
+  raw: RawGiteaPullRequest
+): Promise<GiteaPullRequestInfo | null> {
+  const status = await getCommitStatus(repo, raw.head?.sha?.trim())
+  return mapGiteaPullRequest(raw, status)
+}
+
+function matchesBranch(raw: RawGiteaPullRequest, branchName: string): boolean {
+  const ref = raw.head?.ref?.trim()
+  if (ref === branchName) {
+    return true
+  }
+  const label = raw.head?.label?.trim()
+  return label === branchName || label?.endsWith(`:${branchName}`) === true
+}
+
+export async function getGiteaAuthStatus(): Promise<GiteaAuthStatus> {
+  const config = getAuthConfig()
+  const tokenConfigured = config.token !== null
+  if (!config.apiBaseUrl && !tokenConfigured) {
+    return {
+      configured: false,
+      authenticated: false,
+      account: null,
+      baseUrl: null,
+      tokenConfigured: false
+    }
+  }
+  if (!config.apiBaseUrl) {
+    return {
+      configured: true,
+      authenticated: true,
+      account: null,
+      baseUrl: null,
+      tokenConfigured
+    }
+  }
+
+  if (!tokenConfigured) {
+    const version = await requestJsonAtBase<{ version?: string }>(config.apiBaseUrl, '/version', {
+      timeoutMs: 4000
+    })
+    return {
+      configured: version !== null,
+      authenticated: false,
+      account: null,
+      baseUrl: config.apiBaseUrl,
+      tokenConfigured
+    }
+  }
+
+  const user = await requestJsonAtBase<{
+    login?: string | null
+    username?: string | null
+    full_name?: string | null
+  }>(config.apiBaseUrl, '/user', { timeoutMs: 4000 })
+  return {
+    configured: true,
+    authenticated: user !== null,
+    account: user?.login ?? user?.username ?? user?.full_name ?? null,
+    baseUrl: config.apiBaseUrl,
+    tokenConfigured
+  }
+}
+
+export async function getGiteaPullRequest(
+  repoPath: string,
+  prNumber: number
+): Promise<GiteaPullRequestInfo | null> {
+  const repo = await getGiteaRepoRef(repoPath)
+  if (!repo) {
+    return null
+  }
+  const raw = await requestJson<RawGiteaPullRequest>(
+    repo,
+    `/repos/${encodedRepoPath(repo)}/pulls/${encodeURIComponent(String(prNumber))}`
+  )
+  return raw ? normalizePullRequest(repo, raw) : null
+}
+
+export async function getGiteaPullRequestForBranch(
+  repoPath: string,
+  branch: string,
+  linkedPRNumber?: number | null
+): Promise<GiteaPullRequestInfo | null> {
+  const branchName = branch.replace(/^refs\/heads\//, '')
+  if (!branchName && linkedPRNumber == null) {
+    return null
+  }
+
+  const repo = await getGiteaRepoRef(repoPath)
+  if (!repo) {
+    return null
+  }
+
+  if (branchName) {
+    for (let page = 1; page <= MAX_PULL_REQUEST_PAGES; page++) {
+      const list = await requestJson<RawGiteaPullRequest[]>(
+        repo,
+        `/repos/${encodedRepoPath(repo)}/pulls`,
+        {
+          searchParams: {
+            state: 'all',
+            sort: 'recentupdate',
+            page,
+            limit: PULL_REQUEST_PAGE_LIMIT
+          }
+        }
+      )
+      const raw = list?.find((item) => matchesBranch(item, branchName))
+      if (raw) {
+        return normalizePullRequest(repo, raw)
+      }
+      if (!list || list.length < PULL_REQUEST_PAGE_LIMIT) {
+        break
+      }
+    }
+  }
+
+  if (typeof linkedPRNumber !== 'number') {
+    return null
+  }
+  const raw = await requestJson<RawGiteaPullRequest>(
+    repo,
+    `/repos/${encodedRepoPath(repo)}/pulls/${encodeURIComponent(String(linkedPRNumber))}`
+  )
+  return raw ? normalizePullRequest(repo, raw) : null
+}
+
+export async function getGiteaRepoSlug(repoPath: string): Promise<GiteaRepoRef | null> {
+  return getGiteaRepoRef(repoPath)
+}

--- a/src/main/gitea/pull-request-mappers.test.ts
+++ b/src/main/gitea/pull-request-mappers.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import {
+  deriveGiteaCommitStatus,
+  mapGiteaMergeable,
+  mapGiteaPullRequest,
+  mapGiteaPullRequestState
+} from './pull-request-mappers'
+
+describe('Gitea pull request mappers', () => {
+  it('maps pull request states', () => {
+    expect(mapGiteaPullRequestState({ state: 'open' })).toBe('open')
+    expect(mapGiteaPullRequestState({ state: 'closed' })).toBe('closed')
+    expect(mapGiteaPullRequestState({ state: 'open', draft: true })).toBe('draft')
+    expect(mapGiteaPullRequestState({ state: 'closed', merged: true })).toBe('merged')
+  })
+
+  it('maps mergeability', () => {
+    expect(mapGiteaMergeable(true)).toBe('MERGEABLE')
+    expect(mapGiteaMergeable(false)).toBe('CONFLICTING')
+    expect(mapGiteaMergeable(undefined)).toBe('UNKNOWN')
+  })
+
+  it('derives commit status from the combined state', () => {
+    expect(deriveGiteaCommitStatus({ state: 'success' })).toBe('success')
+    expect(deriveGiteaCommitStatus({ state: 'failure' })).toBe('failure')
+    expect(deriveGiteaCommitStatus({ state: 'error' })).toBe('failure')
+    expect(deriveGiteaCommitStatus({ state: 'pending' })).toBe('pending')
+    expect(deriveGiteaCommitStatus({ state: 'skipped' })).toBe('neutral')
+  })
+
+  it('rolls up individual statuses when the combined state is neutral', () => {
+    expect(
+      deriveGiteaCommitStatus({
+        state: '',
+        statuses: [{ status: 'success' }, { status: 'failure' }]
+      })
+    ).toBe('failure')
+    expect(
+      deriveGiteaCommitStatus({
+        statuses: [{ status: 'success' }, { status: 'pending' }]
+      })
+    ).toBe('pending')
+    expect(deriveGiteaCommitStatus({ statuses: [{ status: 'success' }] })).toBe('success')
+    expect(deriveGiteaCommitStatus({ statuses: [] })).toBe('neutral')
+  })
+
+  it('maps a raw pull request to the hosted review shape', () => {
+    expect(
+      mapGiteaPullRequest(
+        {
+          number: 12,
+          title: 'Gitea branch',
+          state: 'open',
+          html_url: 'https://git.example.com/team/project/pulls/12',
+          updated_at: '2026-05-15T00:00:00Z',
+          mergeable: true,
+          head: { sha: 'abc123' }
+        },
+        'success'
+      )
+    ).toEqual({
+      number: 12,
+      title: 'Gitea branch',
+      state: 'open',
+      url: 'https://git.example.com/team/project/pulls/12',
+      status: 'success',
+      updatedAt: '2026-05-15T00:00:00Z',
+      mergeable: 'MERGEABLE',
+      headSha: 'abc123'
+    })
+  })
+
+  it('rejects incomplete pull request payloads', () => {
+    expect(mapGiteaPullRequest({ number: 1, title: 'missing url' }, 'neutral')).toBeNull()
+  })
+})

--- a/src/main/gitea/pull-request-mappers.ts
+++ b/src/main/gitea/pull-request-mappers.ts
@@ -1,0 +1,129 @@
+import type { CheckStatus, PRMergeableState } from '../../shared/types'
+
+export type RawGiteaPullRequest = {
+  number?: number
+  title?: string
+  state?: string | null
+  html_url?: string | null
+  updated_at?: string | null
+  merged?: boolean | null
+  draft?: boolean | null
+  mergeable?: boolean | null
+  head?: {
+    ref?: string | null
+    label?: string | null
+    sha?: string | null
+  } | null
+}
+
+export type GiteaPullRequestInfo = {
+  number: number
+  title: string
+  state: 'open' | 'closed' | 'merged' | 'draft'
+  url: string
+  status: CheckStatus
+  updatedAt: string
+  mergeable: PRMergeableState
+  headSha?: string
+}
+
+export type RawGiteaCombinedStatus = {
+  state?: string | null
+  statuses?: RawGiteaCommitStatus[] | null
+}
+
+export type RawGiteaCommitStatus = {
+  status?: string | null
+  state?: string | null
+}
+
+function classifyGiteaStatus(status: string | null | undefined): CheckStatus {
+  switch (status?.trim().toLowerCase()) {
+    case 'success':
+      return 'success'
+    case 'failure':
+    case 'error':
+    case 'warning':
+      return 'failure'
+    case 'pending':
+      return 'pending'
+    case 'skipped':
+    default:
+      return 'neutral'
+  }
+}
+
+export function deriveGiteaCommitStatus(rollup: RawGiteaCombinedStatus | null): CheckStatus {
+  if (!rollup) {
+    return 'neutral'
+  }
+  const combined = classifyGiteaStatus(rollup.state)
+  if (combined !== 'neutral') {
+    return combined
+  }
+  const statuses = rollup.statuses ?? []
+  if (statuses.length === 0) {
+    return 'neutral'
+  }
+
+  let hasPending = false
+  for (const status of statuses) {
+    const classified = classifyGiteaStatus(status.status ?? status.state)
+    if (classified === 'failure') {
+      return 'failure'
+    }
+    if (classified === 'pending') {
+      hasPending = true
+    }
+  }
+  if (hasPending) {
+    return 'pending'
+  }
+  return statuses.every(
+    (status) => classifyGiteaStatus(status.status ?? status.state) === 'success'
+  )
+    ? 'success'
+    : 'neutral'
+}
+
+export function mapGiteaPullRequestState(
+  raw: Pick<RawGiteaPullRequest, 'draft' | 'merged' | 'state'>
+): GiteaPullRequestInfo['state'] {
+  if (raw.merged) {
+    return 'merged'
+  }
+  if (raw.draft) {
+    return 'draft'
+  }
+  return raw.state?.trim().toLowerCase() === 'closed' ? 'closed' : 'open'
+}
+
+export function mapGiteaMergeable(value: boolean | null | undefined): PRMergeableState {
+  if (value === true) {
+    return 'MERGEABLE'
+  }
+  if (value === false) {
+    return 'CONFLICTING'
+  }
+  return 'UNKNOWN'
+}
+
+export function mapGiteaPullRequest(
+  raw: RawGiteaPullRequest,
+  status: CheckStatus
+): GiteaPullRequestInfo | null {
+  if (typeof raw.number !== 'number' || !raw.title || !raw.html_url) {
+    return null
+  }
+  const headSha = raw.head?.sha?.trim()
+  return {
+    number: raw.number,
+    title: raw.title,
+    state: mapGiteaPullRequestState(raw),
+    url: raw.html_url,
+    status,
+    updatedAt: raw.updated_at ?? '',
+    mergeable: mapGiteaMergeable(raw.mergeable),
+    ...(headSha ? { headSha } : {})
+  }
+}

--- a/src/main/gitea/repository-ref.test.ts
+++ b/src/main/gitea/repository-ref.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { gitExecFileAsyncMock } = vi.hoisted(() => ({
+  gitExecFileAsyncMock: vi.fn()
+}))
+
+vi.mock('../git/runner', () => ({
+  gitExecFileAsync: gitExecFileAsyncMock
+}))
+
+import { _resetGiteaRepoRefCache, getGiteaRepoRef, parseGiteaRepoRef } from './repository-ref'
+
+describe('Gitea repository ref parsing', () => {
+  beforeEach(() => {
+    gitExecFileAsyncMock.mockReset()
+    _resetGiteaRepoRefCache()
+  })
+
+  it('parses HTTPS remotes and derives the API base URL', () => {
+    expect(parseGiteaRepoRef('https://git.example.com/team/project.git')).toEqual({
+      host: 'git.example.com',
+      owner: 'team',
+      repo: 'project',
+      apiBaseUrl: 'https://git.example.com/api/v1',
+      webBaseUrl: 'https://git.example.com'
+    })
+  })
+
+  it('preserves an HTTP subpath when deriving the API base URL', () => {
+    expect(parseGiteaRepoRef('https://git.example.com/code/team/project.git')).toEqual({
+      host: 'git.example.com',
+      owner: 'team',
+      repo: 'project',
+      apiBaseUrl: 'https://git.example.com/code/api/v1',
+      webBaseUrl: 'https://git.example.com/code'
+    })
+  })
+
+  it('parses scp-like SSH remotes with an HTTPS web/API base', () => {
+    expect(parseGiteaRepoRef('git@gitea.example.test:team/project.git')).toEqual({
+      host: 'gitea.example.test',
+      owner: 'team',
+      repo: 'project',
+      apiBaseUrl: 'https://gitea.example.test/api/v1',
+      webBaseUrl: 'https://gitea.example.test'
+    })
+  })
+
+  it('parses ssh:// remotes without carrying the SSH port into web/API URLs', () => {
+    expect(parseGiteaRepoRef('ssh://git@gitea.example.test:2222/team/project.git')).toEqual({
+      host: 'gitea.example.test',
+      owner: 'team',
+      repo: 'project',
+      apiBaseUrl: 'https://gitea.example.test/api/v1',
+      webBaseUrl: 'https://gitea.example.test'
+    })
+  })
+
+  it('does not claim public hosts handled by more specific providers', () => {
+    expect(parseGiteaRepoRef('git@github.com:team/project.git')).toBeNull()
+    expect(parseGiteaRepoRef('https://gitlab.com/team/project.git')).toBeNull()
+    expect(parseGiteaRepoRef('https://bitbucket.org/team/project.git')).toBeNull()
+  })
+
+  it('reads and caches the origin remote', async () => {
+    gitExecFileAsyncMock.mockResolvedValueOnce({
+      stdout: 'https://git.example.com/team/project.git\n',
+      stderr: ''
+    })
+
+    await expect(getGiteaRepoRef('/repo')).resolves.toMatchObject({
+      host: 'git.example.com',
+      owner: 'team',
+      repo: 'project'
+    })
+    await expect(getGiteaRepoRef('/repo')).resolves.toMatchObject({
+      host: 'git.example.com',
+      owner: 'team',
+      repo: 'project'
+    })
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(1)
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(['remote', 'get-url', 'origin'], {
+      cwd: '/repo'
+    })
+  })
+})

--- a/src/main/gitea/repository-ref.ts
+++ b/src/main/gitea/repository-ref.ts
@@ -1,0 +1,131 @@
+import { gitExecFileAsync } from '../git/runner'
+
+export type GiteaRepoRef = {
+  host: string
+  owner: string
+  repo: string
+  apiBaseUrl: string
+  webBaseUrl: string
+}
+
+const KNOWN_NON_GITEA_HOSTS = new Set(['github.com', 'gitlab.com', 'bitbucket.org'])
+const repoRefCache = new Map<string, GiteaRepoRef | null>()
+
+/** @internal - exposed for tests only */
+export function _resetGiteaRepoRefCache(): void {
+  repoRefCache.clear()
+}
+
+function decodeSegment(value: string): string {
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    return value
+  }
+}
+
+function parsePath(pathname: string): { owner: string; repo: string; basePath: string } | null {
+  const withoutSuffix = pathname.replace(/\.git$/i, '')
+  const parts = withoutSuffix
+    .split('/')
+    .map((part) => part.trim())
+    .filter(Boolean)
+  if (parts.length < 2) {
+    return null
+  }
+
+  const owner = decodeSegment(parts.at(-2) ?? '')
+  const repo = decodeSegment(parts.at(-1) ?? '')
+  if (!owner || !repo) {
+    return null
+  }
+
+  return {
+    owner,
+    repo,
+    basePath: parts.slice(0, -2).join('/')
+  }
+}
+
+function apiBaseUrlFromWebBase(webBaseUrl: string): string {
+  return `${webBaseUrl.replace(/\/+$/, '')}/api/v1`
+}
+
+function makeRepoRef(host: string, path: string, webBaseUrl: string): GiteaRepoRef | null {
+  const normalizedHost = host.toLowerCase()
+  if (!normalizedHost || KNOWN_NON_GITEA_HOSTS.has(normalizedHost)) {
+    return null
+  }
+
+  const parsed = parsePath(path)
+  if (!parsed) {
+    return null
+  }
+
+  return {
+    host: normalizedHost,
+    owner: parsed.owner,
+    repo: parsed.repo,
+    apiBaseUrl: apiBaseUrlFromWebBase(webBaseUrl),
+    webBaseUrl
+  }
+}
+
+export function parseGiteaRepoRef(remoteUrl: string): GiteaRepoRef | null {
+  const trimmed = remoteUrl.trim()
+  if (!/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)) {
+    const scpLike = trimmed.match(/^(?:[^@/:]+@)?([^:\s/]+):([^\s]+?)(?:\.git)?$/)
+    if (scpLike) {
+      const host = scpLike[1]
+      const path = scpLike[2]
+      return makeRepoRef(host, path, `https://${host.toLowerCase()}`)
+    }
+  }
+
+  try {
+    const url = new URL(trimmed)
+    const protocol = url.protocol.toLowerCase()
+    if (!['http:', 'https:', 'ssh:', 'git+ssh:'].includes(protocol)) {
+      return null
+    }
+
+    const parsed = parsePath(url.pathname)
+    if (!parsed) {
+      return null
+    }
+
+    const webOrigin =
+      protocol === 'http:' || protocol === 'https:'
+        ? `${protocol}//${url.host}`
+        : `https://${url.hostname.toLowerCase()}`
+    const webBaseUrl = parsed.basePath ? `${webOrigin}/${parsed.basePath}` : webOrigin
+    return makeRepoRef(url.hostname, url.pathname, webBaseUrl)
+  } catch {
+    return null
+  }
+}
+
+export async function getGiteaRepoRefForRemote(
+  repoPath: string,
+  remoteName: string
+): Promise<GiteaRepoRef | null> {
+  const cacheKey = `${repoPath}\0${remoteName}`
+  if (repoRefCache.has(cacheKey)) {
+    return repoRefCache.get(cacheKey)!
+  }
+  try {
+    const { stdout } = await gitExecFileAsync(['remote', 'get-url', remoteName], {
+      cwd: repoPath
+    })
+    const result = parseGiteaRepoRef(stdout)
+    repoRefCache.set(cacheKey, result)
+    return result
+  } catch {
+    repoRefCache.set(cacheKey, null)
+    return null
+  }
+}
+
+export async function getGiteaRepoRef(repoPath: string): Promise<GiteaRepoRef | null> {
+  return getGiteaRepoRefForRemote(repoPath, 'origin')
+}

--- a/src/main/ipc/hosted-review.ts
+++ b/src/main/ipc/hosted-review.ts
@@ -23,7 +23,8 @@ export function registerHostedReviewHandlers(store: Store, stats: StatsCollector
       branch: args.branch,
       linkedGitHubPR: args.linkedGitHubPR ?? null,
       linkedGitLabMR: args.linkedGitLabMR ?? null,
-      linkedBitbucketPR: args.linkedBitbucketPR ?? null
+      linkedBitbucketPR: args.linkedBitbucketPR ?? null,
+      linkedGiteaPR: args.linkedGiteaPR ?? null
     })
     if (review?.provider === 'github' && !stats.hasCountedPR(review.url)) {
       stats.record({

--- a/src/main/ipc/preflight.test.ts
+++ b/src/main/ipc/preflight.test.ts
@@ -1,3 +1,5 @@
+/* eslint-disable max-lines -- Why: preflight tests share expensive process/preload mocks across
+   install, auth, agent detection, and refresh branches. */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
@@ -6,14 +8,16 @@ const {
   execFileAsyncMock,
   hydrateShellPathMock,
   mergePathSegmentsMock,
-  getBitbucketAuthStatusMock
+  getBitbucketAuthStatusMock,
+  getGiteaAuthStatusMock
 } = vi.hoisted(() => ({
   handleMock: vi.fn(),
   execFileMock: vi.fn(),
   execFileAsyncMock: vi.fn(),
   hydrateShellPathMock: vi.fn(),
   mergePathSegmentsMock: vi.fn(),
-  getBitbucketAuthStatusMock: vi.fn()
+  getBitbucketAuthStatusMock: vi.fn(),
+  getGiteaAuthStatusMock: vi.fn()
 }))
 
 vi.mock('electron', () => ({
@@ -41,6 +45,10 @@ vi.mock('../bitbucket/client', () => ({
   getBitbucketAuthStatus: getBitbucketAuthStatusMock
 }))
 
+vi.mock('../gitea/client', () => ({
+  getGiteaAuthStatus: getGiteaAuthStatusMock
+}))
+
 import {
   _resetPreflightCache,
   detectInstalledAgents,
@@ -52,6 +60,14 @@ type HandlerMap = Record<string, (_event?: unknown, args?: { force?: boolean }) 
 
 describe('preflight', () => {
   const handlers: HandlerMap = {}
+  const defaultBitbucketStatus = { configured: false, authenticated: false, account: null }
+  const defaultGiteaStatus = {
+    configured: false,
+    authenticated: false,
+    account: null,
+    baseUrl: null,
+    tokenConfigured: false
+  }
 
   beforeEach(() => {
     handleMock.mockReset()
@@ -59,11 +75,9 @@ describe('preflight', () => {
     hydrateShellPathMock.mockReset()
     mergePathSegmentsMock.mockReset()
     getBitbucketAuthStatusMock.mockReset()
-    getBitbucketAuthStatusMock.mockResolvedValue({
-      configured: false,
-      authenticated: false,
-      account: null
-    })
+    getGiteaAuthStatusMock.mockReset()
+    getBitbucketAuthStatusMock.mockResolvedValue(defaultBitbucketStatus)
+    getGiteaAuthStatusMock.mockResolvedValue(defaultGiteaStatus)
     _resetPreflightCache()
 
     for (const key of Object.keys(handlers)) {
@@ -92,7 +106,8 @@ describe('preflight', () => {
       git: { installed: true },
       gh: { installed: true, authenticated: true },
       glab: { installed: true, authenticated: true },
-      bitbucket: { configured: false, authenticated: false, account: null }
+      bitbucket: defaultBitbucketStatus,
+      gitea: defaultGiteaStatus
     })
     expect(execFileAsyncMock).toHaveBeenNthCalledWith(4, 'gh', ['auth', 'status'], {
       encoding: 'utf-8'
@@ -193,7 +208,8 @@ describe('preflight', () => {
       git: { installed: true },
       gh: { installed: true, authenticated: true },
       glab: { installed: true, authenticated: true },
-      bitbucket: { configured: false, authenticated: false, account: null }
+      bitbucket: defaultBitbucketStatus,
+      gitea: defaultGiteaStatus
     })
   })
 
@@ -219,13 +235,15 @@ describe('preflight', () => {
       git: { installed: true },
       gh: { installed: true, authenticated: false },
       glab: { installed: true, authenticated: true },
-      bitbucket: { configured: false, authenticated: false, account: null }
+      bitbucket: defaultBitbucketStatus,
+      gitea: defaultGiteaStatus
     })
     expect(refreshedStatus).toEqual({
       git: { installed: true },
       gh: { installed: true, authenticated: true },
       glab: { installed: true, authenticated: true },
-      bitbucket: { configured: false, authenticated: false, account: null }
+      bitbucket: defaultBitbucketStatus,
+      gitea: defaultGiteaStatus
     })
   })
 

--- a/src/main/ipc/preflight.ts
+++ b/src/main/ipc/preflight.ts
@@ -6,6 +6,7 @@ import { TUI_AGENT_CONFIG } from '../../shared/tui-agent-config'
 import type { PathSource, ShellHydrationFailureReason } from '../../shared/types'
 import { hydrateShellPath, mergePathSegments } from '../startup/hydrate-shell-path'
 import { getBitbucketAuthStatus } from '../bitbucket/client'
+import { getGiteaAuthStatus } from '../gitea/client'
 import { getActiveMultiplexer } from './ssh'
 
 const execFileAsync = promisify(execFile)
@@ -19,6 +20,13 @@ export type PreflightStatus = {
   // gate on `glab?.authenticated`.
   glab?: { installed: boolean; authenticated: boolean }
   bitbucket?: { configured: boolean; authenticated: boolean; account: string | null }
+  gitea?: {
+    configured: boolean
+    authenticated: boolean
+    account: string | null
+    baseUrl: string | null
+    tokenConfigured: boolean
+  }
 }
 
 // Why: cache the result so repeated Landing mounts don't re-spawn processes.
@@ -150,17 +158,19 @@ export async function runPreflightCheck(force = false): Promise<PreflightStatus>
     isCommandAvailable('glab')
   ])
 
-  const [ghAuthenticated, glabAuthenticated, bitbucket] = await Promise.all([
+  const [ghAuthenticated, glabAuthenticated, bitbucket, gitea] = await Promise.all([
     ghInstalled ? isGhAuthenticated() : Promise.resolve(false),
     glabInstalled ? isGlabAuthenticated() : Promise.resolve(false),
-    getBitbucketAuthStatus()
+    getBitbucketAuthStatus(),
+    getGiteaAuthStatus()
   ])
 
   cached = {
     git: { installed: gitInstalled },
     gh: { installed: ghInstalled, authenticated: ghAuthenticated },
     glab: { installed: glabInstalled, authenticated: glabAuthenticated },
-    bitbucket
+    bitbucket,
+    gitea
   }
 
   return cached

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -4453,6 +4453,7 @@ export class OrcaRuntimeService {
     linkedGitHubPR?: number | null
     linkedGitLabMR?: number | null
     linkedBitbucketPR?: number | null
+    linkedGiteaPR?: number | null
   }): Promise<HostedReviewInfo | null> {
     const repo = await this.resolveRepoSelector(args.repoSelector)
     this.assertHostIntegrationRepoIsLocal(repo, 'hosted_review')
@@ -4461,7 +4462,8 @@ export class OrcaRuntimeService {
       branch: args.branch,
       linkedGitHubPR: args.linkedGitHubPR ?? null,
       linkedGitLabMR: args.linkedGitLabMR ?? null,
-      linkedBitbucketPR: args.linkedBitbucketPR ?? null
+      linkedBitbucketPR: args.linkedBitbucketPR ?? null,
+      linkedGiteaPR: args.linkedGiteaPR ?? null
     })
     if (review?.provider === 'github' && this.stats && !this.stats.hasCountedPR(review.url)) {
       this.stats.record({

--- a/src/main/runtime/rpc/methods/hosted-review.test.ts
+++ b/src/main/runtime/rpc/methods/hosted-review.test.ts
@@ -38,7 +38,8 @@ describe('hosted review RPC methods', () => {
       branch: 'feature/windows',
       linkedGitHubPR: 12,
       linkedGitLabMR: null,
-      linkedBitbucketPR: null
+      linkedBitbucketPR: null,
+      linkedGiteaPR: null
     })
     expect(response).toMatchObject({
       ok: true,

--- a/src/main/runtime/rpc/methods/hosted-review.ts
+++ b/src/main/runtime/rpc/methods/hosted-review.ts
@@ -7,7 +7,8 @@ const HostedReviewForBranch = z.object({
   branch: requiredString('Missing branch'),
   linkedGitHubPR: z.number().int().positive().nullable().optional(),
   linkedGitLabMR: z.number().int().positive().nullable().optional(),
-  linkedBitbucketPR: z.number().int().positive().nullable().optional()
+  linkedBitbucketPR: z.number().int().positive().nullable().optional(),
+  linkedGiteaPR: z.number().int().positive().nullable().optional()
 })
 
 export const HOSTED_REVIEW_METHODS: RpcMethod[] = [
@@ -20,7 +21,8 @@ export const HOSTED_REVIEW_METHODS: RpcMethod[] = [
         branch: params.branch,
         linkedGitHubPR: params.linkedGitHubPR ?? null,
         linkedGitLabMR: params.linkedGitLabMR ?? null,
-        linkedBitbucketPR: params.linkedBitbucketPR ?? null
+        linkedBitbucketPR: params.linkedBitbucketPR ?? null,
+        linkedGiteaPR: params.linkedGiteaPR ?? null
       })
   })
 ]

--- a/src/main/source-control/hosted-review-gitea.integration.test.ts
+++ b/src/main/source-control/hosted-review-gitea.integration.test.ts
@@ -1,0 +1,113 @@
+import { execFile } from 'child_process'
+import { mkdtemp, rm } from 'fs/promises'
+import { createServer, type IncomingMessage, type ServerResponse } from 'http'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { promisify } from 'util'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { _resetGiteaRepoRefCache } from '../gitea/repository-ref'
+import { getHostedReviewForBranch } from './hosted-review'
+
+const execFileAsync = promisify(execFile)
+const OLD_ENV = process.env
+
+type SeenRequest = {
+  pathname: string
+  search: string
+  authorization: string | undefined
+}
+
+function sendJson(res: ServerResponse, body: unknown): void {
+  res.writeHead(200, { 'Content-Type': 'application/json' })
+  res.end(JSON.stringify(body))
+}
+
+describe('Gitea hosted review integration', () => {
+  beforeEach(() => {
+    process.env = { ...OLD_ENV, ORCA_GITEA_TOKEN: 'local-token' }
+    delete process.env.ORCA_GITEA_API_BASE_URL
+    _resetGiteaRepoRefCache()
+  })
+
+  afterEach(() => {
+    process.env = OLD_ENV
+    _resetGiteaRepoRefCache()
+  })
+
+  it('resolves a Gitea PR through real git remote parsing and HTTP API calls', async () => {
+    const seen: SeenRequest[] = []
+    const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+      const url = new URL(req.url ?? '/', `http://${req.headers.host ?? '127.0.0.1'}`)
+      seen.push({
+        pathname: url.pathname,
+        search: url.search,
+        authorization: req.headers.authorization
+      })
+
+      if (url.pathname === '/api/v1/repos/team/repo/pulls') {
+        sendJson(res, [
+          {
+            number: 9,
+            title: 'Local Gitea branch',
+            state: 'open',
+            html_url: 'http://127.0.0.1/team/repo/pulls/9',
+            updated_at: '2026-05-15T00:00:00Z',
+            mergeable: true,
+            head: { ref: 'feature/gitea', label: 'team:feature/gitea', sha: 'abc123' }
+          }
+        ])
+        return
+      }
+
+      if (url.pathname === '/api/v1/repos/team/repo/commits/abc123/status') {
+        sendJson(res, { state: 'success' })
+        return
+      }
+
+      res.writeHead(404, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ message: 'not found' }))
+    })
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+
+    const repoPath = await mkdtemp(join(tmpdir(), 'orca-gitea-review-'))
+    try {
+      const address = server.address()
+      if (!address || typeof address === 'string') {
+        throw new Error('expected TCP server address')
+      }
+
+      await execFileAsync('git', ['init'], { cwd: repoPath })
+      await execFileAsync(
+        'git',
+        ['remote', 'add', 'origin', `http://127.0.0.1:${address.port}/team/repo.git`],
+        { cwd: repoPath }
+      )
+
+      await expect(
+        getHostedReviewForBranch({ repoPath, branch: 'refs/heads/feature/gitea' })
+      ).resolves.toEqual({
+        provider: 'gitea',
+        number: 9,
+        title: 'Local Gitea branch',
+        state: 'open',
+        url: 'http://127.0.0.1/team/repo/pulls/9',
+        status: 'success',
+        updatedAt: '2026-05-15T00:00:00Z',
+        mergeable: 'MERGEABLE',
+        headSha: 'abc123'
+      })
+
+      expect(seen.map((request) => request.pathname)).toEqual([
+        '/api/v1/repos/team/repo/pulls',
+        '/api/v1/repos/team/repo/commits/abc123/status'
+      ])
+      expect(seen.every((request) => request.authorization === 'token local-token')).toBe(true)
+      expect(new URLSearchParams(seen[0].search).get('state')).toBe('all')
+    } finally {
+      await rm(repoPath, { recursive: true, force: true })
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()))
+      })
+    }
+  })
+})

--- a/src/main/source-control/hosted-review.test.ts
+++ b/src/main/source-control/hosted-review.test.ts
@@ -6,14 +6,18 @@ const {
   getRepoSlugMock,
   getPRForBranchMock,
   getBitbucketRepoSlugMock,
-  getBitbucketPullRequestForBranchMock
+  getBitbucketPullRequestForBranchMock,
+  getGiteaRepoSlugMock,
+  getGiteaPullRequestForBranchMock
 } = vi.hoisted(() => ({
   getProjectSlugMock: vi.fn(),
   getMergeRequestForBranchMock: vi.fn(),
   getRepoSlugMock: vi.fn(),
   getPRForBranchMock: vi.fn(),
   getBitbucketRepoSlugMock: vi.fn(),
-  getBitbucketPullRequestForBranchMock: vi.fn()
+  getBitbucketPullRequestForBranchMock: vi.fn(),
+  getGiteaRepoSlugMock: vi.fn(),
+  getGiteaPullRequestForBranchMock: vi.fn()
 }))
 
 vi.mock('../gitlab/client', () => ({
@@ -33,6 +37,12 @@ vi.mock('../bitbucket/client', () => ({
   getBitbucketPullRequest: vi.fn()
 }))
 
+vi.mock('../gitea/client', () => ({
+  getGiteaRepoSlug: getGiteaRepoSlugMock,
+  getGiteaPullRequestForBranch: getGiteaPullRequestForBranchMock,
+  getGiteaPullRequest: vi.fn()
+}))
+
 import { getHostedReviewForBranch } from './hosted-review'
 
 describe('getHostedReviewForBranch', () => {
@@ -43,6 +53,8 @@ describe('getHostedReviewForBranch', () => {
     getPRForBranchMock.mockReset()
     getBitbucketRepoSlugMock.mockReset()
     getBitbucketPullRequestForBranchMock.mockReset()
+    getGiteaRepoSlugMock.mockReset()
+    getGiteaPullRequestForBranchMock.mockReset()
   })
 
   it('maps GitLab merge requests into the hosted review surface', async () => {
@@ -136,5 +148,45 @@ describe('getHostedReviewForBranch', () => {
       'feature/bitbucket',
       11
     )
+  })
+
+  it('falls through to Gitea when origin is not another hosted provider', async () => {
+    getProjectSlugMock.mockResolvedValue(null)
+    getRepoSlugMock.mockResolvedValue(null)
+    getBitbucketRepoSlugMock.mockResolvedValue(null)
+    getGiteaRepoSlugMock.mockResolvedValue({
+      host: 'git.example.com',
+      owner: 'team',
+      repo: 'orca'
+    })
+    getGiteaPullRequestForBranchMock.mockResolvedValue({
+      number: 14,
+      title: 'Gitea branch',
+      state: 'open',
+      url: 'https://git.example.com/team/orca/pulls/14',
+      status: 'pending',
+      updatedAt: '2026-05-15T00:00:00.000Z',
+      mergeable: 'MERGEABLE',
+      headSha: 'def456'
+    })
+
+    await expect(
+      getHostedReviewForBranch({
+        repoPath: '/repo',
+        branch: 'feature/gitea',
+        linkedGiteaPR: 14
+      })
+    ).resolves.toEqual({
+      provider: 'gitea',
+      number: 14,
+      title: 'Gitea branch',
+      state: 'open',
+      url: 'https://git.example.com/team/orca/pulls/14',
+      status: 'pending',
+      updatedAt: '2026-05-15T00:00:00.000Z',
+      mergeable: 'MERGEABLE',
+      headSha: 'def456'
+    })
+    expect(getGiteaPullRequestForBranchMock).toHaveBeenCalledWith('/repo', 'feature/gitea', 14)
   })
 })

--- a/src/main/source-control/hosted-review.ts
+++ b/src/main/source-control/hosted-review.ts
@@ -6,6 +6,12 @@ import {
   getBitbucketRepoSlug
 } from '../bitbucket/client'
 import type { BitbucketPullRequestInfo } from '../bitbucket/pull-request-mappers'
+import {
+  getGiteaPullRequest,
+  getGiteaPullRequestForBranch,
+  getGiteaRepoSlug
+} from '../gitea/client'
+import type { GiteaPullRequestInfo } from '../gitea/pull-request-mappers'
 import { getPRForBranch, getRepoSlug } from '../github/client'
 import { getMergeRequest, getMergeRequestForBranch, getProjectSlug } from '../gitlab/client'
 
@@ -60,19 +66,35 @@ function mapBitbucketReview(pr: BitbucketPullRequestInfo): HostedReviewInfo {
   }
 }
 
+function mapGiteaReview(pr: GiteaPullRequestInfo): HostedReviewInfo {
+  return {
+    provider: 'gitea',
+    number: pr.number,
+    title: pr.title,
+    state: pr.state,
+    url: pr.url,
+    status: pr.status,
+    updatedAt: pr.updatedAt,
+    mergeable: pr.mergeable,
+    ...(pr.headSha ? { headSha: pr.headSha } : {})
+  }
+}
+
 export async function getHostedReviewForBranch(input: {
   repoPath: string
   branch: string
   linkedGitHubPR?: number | null
   linkedGitLabMR?: number | null
   linkedBitbucketPR?: number | null
+  linkedGiteaPR?: number | null
 }): Promise<HostedReviewInfo | null> {
   const branchName = input.branch.replace(/^refs\/heads\//, '')
   if (
     !branchName &&
     input.linkedGitHubPR == null &&
     input.linkedGitLabMR == null &&
-    input.linkedBitbucketPR == null
+    input.linkedBitbucketPR == null &&
+    input.linkedGiteaPR == null
   ) {
     return null
   }
@@ -104,12 +126,22 @@ export async function getHostedReviewForBranch(input: {
     return pr ? mapBitbucketReview(pr) : null
   }
 
+  const giteaRepo = await getGiteaRepoSlug(input.repoPath)
+  if (giteaRepo) {
+    const pr = await getGiteaPullRequestForBranch(
+      input.repoPath,
+      branchName,
+      input.linkedGiteaPR ?? null
+    )
+    return pr ? mapGiteaReview(pr) : null
+  }
+
   return null
 }
 
 export async function getHostedReviewByNumber(input: {
   repoPath: string
-  provider: 'github' | 'gitlab' | 'bitbucket'
+  provider: 'github' | 'gitlab' | 'bitbucket' | 'gitea'
   number: number
 }): Promise<HostedReviewInfo | null> {
   if (input.provider === 'gitlab') {
@@ -119,6 +151,10 @@ export async function getHostedReviewByNumber(input: {
   if (input.provider === 'bitbucket') {
     const pr = await getBitbucketPullRequest(input.repoPath, input.number)
     return pr ? mapBitbucketReview(pr) : null
+  }
+  if (input.provider === 'gitea') {
+    const pr = await getGiteaPullRequest(input.repoPath, input.number)
+    return pr ? mapGiteaReview(pr) : null
   }
   const pr = await getPRForBranch(input.repoPath, '', input.number)
   return pr ? mapGitHubReview(pr) : null

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -312,6 +312,13 @@ export type PreflightStatus = {
    *  include it. Consumers gate on `glab?.installed` / `authenticated`. */
   glab?: { installed: boolean; authenticated: boolean }
   bitbucket?: { configured: boolean; authenticated: boolean; account: string | null }
+  gitea?: {
+    configured: boolean
+    authenticated: boolean
+    account: string | null
+    baseUrl: string | null
+    tokenConfigured: boolean
+  }
 }
 
 export type RefreshAgentsResult = {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1068,6 +1068,13 @@ const api = {
       gh: { installed: boolean; authenticated: boolean }
       glab?: { installed: boolean; authenticated: boolean }
       bitbucket?: { configured: boolean; authenticated: boolean; account: string | null }
+      gitea?: {
+        configured: boolean
+        authenticated: boolean
+        account: string | null
+        baseUrl: string | null
+        tokenConfigured: boolean
+      }
       linear: { connected: boolean }
     }> => ipcRenderer.invoke('preflight:check', args),
     detectAgents: (): Promise<string[]> => ipcRenderer.invoke('preflight:detectAgents'),

--- a/src/renderer/src/components/settings/IntegrationsPane.tsx
+++ b/src/renderer/src/components/settings/IntegrationsPane.tsx
@@ -1,5 +1,5 @@
-/* eslint-disable max-lines -- Why: this pane co-locates GitHub, GitLab,
-   and Linear integration cards so the preflight-check + status-badge +
+/* eslint-disable max-lines -- Why: this pane co-locates source-host and
+   Linear integration cards so the preflight-check + status-badge +
    install/auth-prompt scaffolding lives in one place rather than fanning
    out across per-integration files that would each repeat the same
    pattern. Splitting buys nothing while the surface stays this narrow. */
@@ -54,6 +54,11 @@ export const INTEGRATIONS_PANE_SEARCH_ENTRIES: SettingsSearchEntry[] = [
     keywords: ['bitbucket', 'integration', 'pull request', 'api token']
   },
   {
+    title: 'Gitea Integration',
+    description: 'Gitea authentication via API token environment variables.',
+    keywords: ['gitea', 'self-hosted', 'integration', 'pull request', 'api token']
+  },
+  {
     title: 'Linear Integration',
     description: 'Connect Linear to browse and link issues.',
     keywords: ['linear', 'integration', 'api key', 'connect', 'disconnect']
@@ -65,6 +70,25 @@ type GhStatus = 'checking' | 'connected' | 'not-installed' | 'not-authenticated'
 // modes (probe in-flight / installed-but-unauth / missing entirely).
 type GlabStatus = GhStatus
 type BitbucketStatus = 'checking' | 'connected' | 'not-configured' | 'not-authenticated'
+type GiteaStatus = 'checking' | 'configured' | 'not-configured' | 'not-authenticated'
+
+type GiteaPreflightStatus = {
+  configured: boolean
+  authenticated: boolean
+  account: string | null
+  baseUrl: string | null
+  tokenConfigured: boolean
+}
+
+function giteaStatusFromPreflight(status: GiteaPreflightStatus | undefined): GiteaStatus {
+  if (!status?.configured) {
+    return 'not-configured'
+  }
+  if (status.tokenConfigured && !status.authenticated) {
+    return 'not-authenticated'
+  }
+  return 'configured'
+}
 
 export function IntegrationsPane(): React.JSX.Element {
   const linearStatus = useAppStore((s) => s.linearStatus)
@@ -77,6 +101,9 @@ export function IntegrationsPane(): React.JSX.Element {
   const [glabStatus, setGlabStatus] = useState<GlabStatus>('checking')
   const [bitbucketStatus, setBitbucketStatus] = useState<BitbucketStatus>('checking')
   const [bitbucketAccount, setBitbucketAccount] = useState<string | null>(null)
+  const [giteaStatus, setGiteaStatus] = useState<GiteaStatus>('checking')
+  const [giteaAccount, setGiteaAccount] = useState<string | null>(null)
+  const [giteaBaseUrl, setGiteaBaseUrl] = useState<string | null>(null)
   const [linearDialogOpen, setLinearDialogOpen] = useState(false)
   const [linearApiKeyDraft, setLinearApiKeyDraft] = useState('')
   const [linearConnectState, setLinearConnectState] = useState<'idle' | 'connecting' | 'error'>(
@@ -118,6 +145,10 @@ export function IntegrationsPane(): React.JSX.Element {
       } else {
         setBitbucketStatus('connected')
       }
+      const gitea = status.gitea
+      setGiteaAccount(gitea?.account ?? null)
+      setGiteaBaseUrl(gitea?.baseUrl ?? null)
+      setGiteaStatus(giteaStatusFromPreflight(gitea))
     })
     // eslint-disable-next-line react-hooks/exhaustive-deps -- one-shot mount check
   }, [])
@@ -207,6 +238,16 @@ export function IntegrationsPane(): React.JSX.Element {
       } else {
         setBitbucketStatus('connected')
       }
+    })
+  }
+
+  const handleRefreshGitea = (): void => {
+    setGiteaStatus('checking')
+    void window.api.preflight.check({ force: true }).then((status) => {
+      const gitea = status.gitea
+      setGiteaAccount(gitea?.account ?? null)
+      setGiteaBaseUrl(gitea?.baseUrl ?? null)
+      setGiteaStatus(giteaStatusFromPreflight(gitea))
     })
   }
 
@@ -440,6 +481,90 @@ export function IntegrationsPane(): React.JSX.Element {
                     Learn more
                   </Button>
                   <Button variant="ghost" size="sm" onClick={handleRefreshBitbucket}>
+                    Re-check
+                  </Button>
+                </div>
+              </>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Gitea */}
+      <div className="rounded-md border border-border/50 bg-muted/30 px-4 py-3">
+        <div className="flex items-center gap-3">
+          <GitPullRequestArrow className="size-5 shrink-0 text-muted-foreground" />
+          <div className="min-w-0 flex-1 space-y-0.5">
+            <p className="text-sm font-medium">Gitea</p>
+            <p className="text-xs text-muted-foreground">
+              {giteaStatus === 'configured'
+                ? giteaAccount
+                  ? `${giteaAccount} · Pull requests and commit statuses`
+                  : giteaBaseUrl
+                    ? `${giteaBaseUrl} · Pull requests and commit statuses`
+                    : 'Pull requests and commit statuses for detected repositories'
+                : 'Pull requests and commit statuses via the Gitea REST API.'}
+            </p>
+          </div>
+          {giteaStatus === 'checking' ? (
+            <LoaderCircle className="size-4 shrink-0 animate-spin text-muted-foreground" />
+          ) : giteaStatus === 'configured' ? (
+            <span className="shrink-0 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2.5 py-1 text-[11px] font-medium text-emerald-700 dark:text-emerald-300">
+              {giteaAccount ? 'Connected' : 'Configured'}
+            </span>
+          ) : (
+            <span className="shrink-0 rounded-full border border-amber-500/30 bg-amber-500/10 px-2.5 py-1 text-[11px] font-medium text-amber-700 dark:text-amber-300">
+              {giteaStatus === 'not-configured' ? 'Optional setup' : 'Auth failed'}
+            </span>
+          )}
+        </div>
+
+        {giteaStatus !== 'checking' && giteaStatus !== 'configured' && (
+          <div className="mt-3 rounded-md border border-border/30 bg-background/50 px-3 py-2.5 space-y-2">
+            {giteaStatus === 'not-configured' ? (
+              <>
+                <p className="text-xs text-muted-foreground">
+                  Public repositories are detected from their git remote. Set{' '}
+                  <span className="font-mono text-[11px]">ORCA_GITEA_TOKEN</span> for private
+                  repositories, and set{' '}
+                  <span className="font-mono text-[11px]">ORCA_GITEA_API_BASE_URL</span> only when
+                  Orca cannot derive the API URL from the remote.
+                </p>
+                <div className="flex items-center gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() =>
+                      window.api.shell.openUrl('https://docs.gitea.com/next/development/api-usage')
+                    }
+                  >
+                    <ExternalLink className="size-3.5 mr-1.5" />
+                    Learn more
+                  </Button>
+                  <Button variant="ghost" size="sm" onClick={handleRefreshGitea}>
+                    Re-check
+                  </Button>
+                </div>
+              </>
+            ) : (
+              <>
+                <p className="text-xs text-muted-foreground">
+                  Gitea credentials are configured but could not authenticate. Check the token, API
+                  base URL, and repository permissions, then restart Orca if environment variables
+                  changed.
+                </p>
+                <div className="flex items-center gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() =>
+                      window.api.shell.openUrl('https://docs.gitea.com/next/development/api-usage')
+                    }
+                  >
+                    <ExternalLink className="size-3.5 mr-1.5" />
+                    Learn more
+                  </Button>
+                  <Button variant="ghost" size="sm" onClick={handleRefreshGitea}>
                     Re-check
                   </Button>
                 </div>

--- a/src/renderer/src/components/sidebar/WorktreeCardMeta.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardMeta.tsx
@@ -109,6 +109,9 @@ function getProviderName(review: HostedReviewInfo): string {
   if (review.provider === 'bitbucket') {
     return 'Bitbucket'
   }
+  if (review.provider === 'gitea') {
+    return 'Gitea'
+  }
   return 'GitHub'
 }
 

--- a/src/renderer/src/store/slices/hosted-review.test.ts
+++ b/src/renderer/src/store/slices/hosted-review.test.ts
@@ -71,7 +71,8 @@ describe('hosted review slice', () => {
       branch: 'feature/gitlab',
       linkedGitHubPR: null,
       linkedGitLabMR: 5,
-      linkedBitbucketPR: null
+      linkedBitbucketPR: null,
+      linkedGiteaPR: null
     })
   })
 
@@ -96,7 +97,8 @@ describe('hosted review slice', () => {
         branch: 'feature/windows',
         linkedGitHubPR: 12,
         linkedGitLabMR: null,
-        linkedBitbucketPR: null
+        linkedBitbucketPR: null,
+        linkedGiteaPR: null
       },
       { timeoutMs: 30_000 }
     )

--- a/src/renderer/src/store/slices/hosted-review.ts
+++ b/src/renderer/src/store/slices/hosted-review.ts
@@ -38,6 +38,7 @@ export type HostedReviewSlice = {
       linkedGitHubPR?: number | null
       linkedGitLabMR?: number | null
       linkedBitbucketPR?: number | null
+      linkedGiteaPR?: number | null
     }
   ) => Promise<HostedReviewInfo | null>
 }
@@ -61,7 +62,8 @@ export const createHostedReviewSlice: StateCreator<AppState, [], [], HostedRevie
       cached?.data === null &&
       ((options?.linkedGitHubPR ?? null) !== null ||
         (options?.linkedGitLabMR ?? null) !== null ||
-        (options?.linkedBitbucketPR ?? null) !== null)
+        (options?.linkedBitbucketPR ?? null) !== null ||
+        (options?.linkedGiteaPR ?? null) !== null)
     if (!options?.force && !linkedRefetch && isFresh(cached)) {
       return cached.data
     }
@@ -80,7 +82,8 @@ export const createHostedReviewSlice: StateCreator<AppState, [], [], HostedRevie
           branch,
           linkedGitHubPR: options?.linkedGitHubPR ?? null,
           linkedGitLabMR: options?.linkedGitLabMR ?? null,
-          linkedBitbucketPR: options?.linkedBitbucketPR ?? null
+          linkedBitbucketPR: options?.linkedBitbucketPR ?? null,
+          linkedGiteaPR: options?.linkedGiteaPR ?? null
         }
         const review =
           target.kind === 'environment'

--- a/src/shared/hosted-review.ts
+++ b/src/shared/hosted-review.ts
@@ -1,6 +1,6 @@
 import type { CheckStatus, PRConflictSummary, PRMergeableState } from './types'
 
-export type HostedReviewProvider = 'github' | 'gitlab' | 'bitbucket'
+export type HostedReviewProvider = 'github' | 'gitlab' | 'bitbucket' | 'gitea'
 
 export type HostedReviewState = 'open' | 'closed' | 'merged' | 'draft'
 
@@ -23,4 +23,5 @@ export type HostedReviewForBranchArgs = {
   linkedGitHubPR?: number | null
   linkedGitLabMR?: number | null
   linkedBitbucketPR?: number | null
+  linkedGiteaPR?: number | null
 }


### PR DESCRIPTION
## Summary
- Add Gitea hosted review detection from git remotes, including self-hosted HTTP(S), SSH, and subpath deployments.
- Fetch Gitea pull requests and commit statuses through the existing hosted-review IPC/runtime/store surface.
- Add optional Gitea API token status in Settings for private repositories.

Closes #325

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/main/gitea/repository-ref.test.ts src/main/gitea/pull-request-mappers.test.ts src/main/gitea/client.test.ts src/main/source-control/hosted-review.test.ts src/main/source-control/hosted-review-gitea.integration.test.ts src/main/runtime/rpc/methods/hosted-review.test.ts src/renderer/src/store/slices/hosted-review.test.ts src/main/ipc/preflight.test.ts
- pnpm run typecheck
- pnpm run lint
- pnpm run build:electron-vite
- pnpm exec vitest run --config config/vitest.config.ts --exclude src/main/daemon/node-pty-fd-leak.test.ts
- Electron dev runtime check with local Gitea-shaped API + temp git repo: window.api.hostedReview.forBranch returned PR #17 with success status and Settings rendered the Gitea card.

## Note
- Full pnpm test was also attempted. After rebuilding better-sqlite3, all previously failing runtime/orchestration tests passed. The remaining excluded node-pty fd-leak test cannot allocate a PTY device in this shell (posix_openpt errno 6).