### PR TITLE
Add GitHub PR file viewed tracking

### DIFF
--- a/src/main/github/client-file-viewed.test.ts
+++ b/src/main/github/client-file-viewed.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { ghExecFileAsyncMock, acquireMock, releaseMock } = vi.hoisted(() => ({
+  ghExecFileAsyncMock: vi.fn(),
+  acquireMock: vi.fn(),
+  releaseMock: vi.fn()
+}))
+
+vi.mock('./gh-utils', () => ({
+  execFileAsync: vi.fn(),
+  ghExecFileAsync: ghExecFileAsyncMock,
+  gitExecFileAsync: vi.fn(),
+  getOwnerRepo: vi.fn(),
+  getIssueOwnerRepo: vi.fn(),
+  getOwnerRepoForRemote: vi.fn(),
+  resolveIssueSource: vi.fn(),
+  ghRepoExecOptions: vi.fn((context) => (context.connectionId ? {} : { cwd: context.repoPath })),
+  githubRepoContext: vi.fn((repoPath, connectionId) => ({
+    repoPath,
+    connectionId: connectionId ?? null
+  })),
+  classifyGhError: vi.fn(),
+  classifyListIssuesError: vi.fn(),
+  acquire: acquireMock,
+  release: releaseMock,
+  _resetOwnerRepoCache: vi.fn()
+}))
+
+import { setPRFileViewed } from './client'
+
+describe('setPRFileViewed', () => {
+  beforeEach(() => {
+    ghExecFileAsyncMock.mockReset()
+    acquireMock.mockReset()
+    releaseMock.mockReset()
+    acquireMock.mockResolvedValue(undefined)
+  })
+
+  it('uses GitHub GraphQL file-viewed mutations', async () => {
+    ghExecFileAsyncMock.mockResolvedValueOnce({ stdout: '{}' })
+
+    await expect(
+      setPRFileViewed({
+        repoPath: '/repo-root',
+        pullRequestId: 'PR_kwDO123',
+        path: 'src/app.ts',
+        viewed: true
+      })
+    ).resolves.toBe(true)
+
+    const args = ghExecFileAsyncMock.mock.calls[0][0]
+    expect(args[0]).toBe('api')
+    expect(args[1]).toBe('graphql')
+    expect(args.find((arg: string) => arg.startsWith('query='))).toContain('markFileAsViewed')
+    expect(args).toContain('pullRequestId=PR_kwDO123')
+    expect(args).toContain('path=src/app.ts')
+    expect(ghExecFileAsyncMock.mock.calls[0][1]).toEqual({ cwd: '/repo-root' })
+    expect(releaseMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses GitHub GraphQL file-unviewed mutations', async () => {
+    ghExecFileAsyncMock.mockResolvedValueOnce({ stdout: '{}' })
+
+    await expect(
+      setPRFileViewed({
+        repoPath: '/repo-root',
+        pullRequestId: 'PR_kwDO123',
+        path: 'src/app.ts',
+        viewed: false
+      })
+    ).resolves.toBe(true)
+
+    const args = ghExecFileAsyncMock.mock.calls[0][0]
+    expect(args.find((arg: string) => arg.startsWith('query='))).toContain('unmarkFileAsViewed')
+  })
+})

--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -1795,6 +1795,47 @@ export async function getPRComments(
 }
 
 /**
+ * Mark or unmark a PR file as viewed via GitHub's GraphQL API.
+ */
+export async function setPRFileViewed(args: {
+  repoPath: string
+  connectionId?: string | null
+  pullRequestId: string
+  path: string
+  viewed: boolean
+}): Promise<boolean> {
+  const ghOptions = ghRepoExecOptions(githubRepoContext(args.repoPath, args.connectionId))
+  const mutation = args.viewed ? 'markFileAsViewed' : 'unmarkFileAsViewed'
+  const query = `mutation($pullRequestId: ID!, $path: String!) {
+    ${mutation}(input: { pullRequestId: $pullRequestId, path: $path }) {
+      pullRequest { id }
+    }
+  }`
+  await acquire()
+  try {
+    await ghExecFileAsync(
+      [
+        'api',
+        'graphql',
+        '-f',
+        `query=${query}`,
+        '-f',
+        `pullRequestId=${args.pullRequestId}`,
+        '-f',
+        `path=${args.path}`
+      ],
+      ghOptions
+    )
+    return true
+  } catch (err) {
+    console.warn(`${mutation} failed:`, err)
+    return false
+  } finally {
+    release()
+  }
+}
+
+/**
  * Resolve or unresolve a PR review thread via GraphQL.
  */
 export async function resolveReviewThread(

--- a/src/main/github/work-item-details-file-viewed.test.ts
+++ b/src/main/github/work-item-details-file-viewed.test.ts
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+type RateLimitGuardResult =
+  | { blocked: false }
+  | { blocked: true; remaining: number; limit: number; resetAt: number }
+
+const {
+  ghExecFileAsyncMock,
+  getOwnerRepoMock,
+  getIssueOwnerRepoMock,
+  getWorkItemMock,
+  getPRChecksMock,
+  getPRCommentsMock,
+  rateLimitGuardMock,
+  noteRateLimitSpendMock,
+  acquireMock,
+  releaseMock
+} = vi.hoisted(() => ({
+  ghExecFileAsyncMock: vi.fn(),
+  getOwnerRepoMock: vi.fn(),
+  getIssueOwnerRepoMock: vi.fn(),
+  getWorkItemMock: vi.fn(),
+  getPRChecksMock: vi.fn(),
+  getPRCommentsMock: vi.fn(),
+  rateLimitGuardMock: vi.fn<() => RateLimitGuardResult>(() => ({ blocked: false })),
+  noteRateLimitSpendMock: vi.fn(),
+  acquireMock: vi.fn(),
+  releaseMock: vi.fn()
+}))
+
+vi.mock('./gh-utils', () => ({
+  ghExecFileAsync: ghExecFileAsyncMock,
+  getOwnerRepo: getOwnerRepoMock,
+  getIssueOwnerRepo: getIssueOwnerRepoMock,
+  ghRepoExecOptions: vi.fn((context) => (context.connectionId ? {} : { cwd: context.repoPath })),
+  githubRepoContext: vi.fn((repoPath, connectionId) => ({
+    repoPath,
+    connectionId: connectionId ?? null
+  })),
+  acquire: acquireMock,
+  release: releaseMock
+}))
+
+vi.mock('./client', () => ({
+  getWorkItem: getWorkItemMock,
+  getPRChecks: getPRChecksMock,
+  getPRComments: getPRCommentsMock
+}))
+
+vi.mock('./rate-limit', () => ({
+  rateLimitGuard: rateLimitGuardMock,
+  noteRateLimitSpend: noteRateLimitSpendMock
+}))
+
+import { getWorkItemDetails } from './work-item-details'
+
+describe('getWorkItemDetails PR file viewed state', () => {
+  beforeEach(() => {
+    ghExecFileAsyncMock.mockReset()
+    getOwnerRepoMock.mockReset()
+    getIssueOwnerRepoMock.mockReset()
+    getWorkItemMock.mockReset()
+    getPRChecksMock.mockReset()
+    getPRCommentsMock.mockReset()
+    rateLimitGuardMock.mockReset()
+    rateLimitGuardMock.mockReturnValue({ blocked: false })
+    noteRateLimitSpendMock.mockReset()
+    acquireMock.mockReset()
+    releaseMock.mockReset()
+    acquireMock.mockResolvedValue(undefined)
+  })
+
+  it('merges GitHub viewer viewed state into PR files', async () => {
+    getWorkItemMock.mockResolvedValueOnce({
+      id: 'pr:42',
+      type: 'pr',
+      number: 42,
+      title: 'Review files',
+      state: 'open',
+      url: 'https://github.com/stablyai/orca/pull/42',
+      labels: [],
+      updatedAt: '2026-04-01T00:00:00Z',
+      author: null
+    })
+    getOwnerRepoMock.mockResolvedValue({ owner: 'stablyai', repo: 'orca' })
+    getPRCommentsMock.mockResolvedValue([])
+    getPRChecksMock.mockResolvedValue([])
+    ghExecFileAsyncMock.mockImplementation((args: string[]) => {
+      const query = args.find((arg) => arg.startsWith('query=')) ?? ''
+      if (query.includes('viewerViewedState')) {
+        return Promise.resolve({
+          stdout: JSON.stringify({
+            data: {
+              repository: {
+                pullRequest: {
+                  id: 'PR_kwDO123',
+                  files: {
+                    pageInfo: { hasNextPage: false, endCursor: null },
+                    nodes: [
+                      { path: 'src/viewed.ts', viewerViewedState: 'VIEWED' },
+                      { path: 'src/changed.ts', viewerViewedState: 'DISMISSED' }
+                    ]
+                  }
+                }
+              }
+            }
+          })
+        })
+      }
+      if (query.includes('participants')) {
+        return Promise.resolve({
+          stdout: JSON.stringify({
+            data: { repository: { pullRequest: { participants: { nodes: [] } } } }
+          })
+        })
+      }
+      const endpoint = args.find((arg) => arg.startsWith('repos/')) ?? ''
+      if (endpoint === 'repos/stablyai/orca/pulls/42') {
+        return Promise.resolve({
+          stdout: JSON.stringify({
+            body: 'PR body',
+            head: { sha: 'head-sha' },
+            base: { sha: 'base-sha' }
+          })
+        })
+      }
+      if (endpoint === 'repos/stablyai/orca/pulls/42/files?per_page=100') {
+        return Promise.resolve({
+          stdout: JSON.stringify([
+            {
+              filename: 'src/viewed.ts',
+              status: 'modified',
+              additions: 3,
+              deletions: 1,
+              changes: 4,
+              patch: '@@'
+            },
+            {
+              filename: 'src/changed.ts',
+              status: 'modified',
+              additions: 1,
+              deletions: 0,
+              changes: 1,
+              patch: '@@'
+            }
+          ])
+        })
+      }
+      return Promise.reject(new Error(`unexpected gh call: ${args.join(' ')}`))
+    })
+
+    const details = await getWorkItemDetails('/repo-root', 42, 'pr')
+
+    expect(details?.pullRequestId).toBe('PR_kwDO123')
+    expect(details?.headSha).toBe('head-sha')
+    expect(details?.baseSha).toBe('base-sha')
+    expect(details?.files?.map((file) => [file.path, file.viewerViewedState])).toEqual([
+      ['src/viewed.ts', 'VIEWED'],
+      ['src/changed.ts', 'DISMISSED']
+    ])
+    expect(getPRChecksMock).toHaveBeenCalledWith('/repo-root', 42, 'head-sha', undefined, undefined)
+  })
+})

--- a/src/main/github/work-item-details.ts
+++ b/src/main/github/work-item-details.ts
@@ -5,6 +5,7 @@ import type {
   GitHubAssignableUser,
   GitHubPRFile,
   GitHubPRFileContents,
+  GitHubPRFileViewedState,
   GitHubWorkItem,
   GitHubWorkItemDetails,
   PRComment
@@ -25,6 +26,21 @@ import { noteRateLimitSpend, rateLimitGuard } from './rate-limit'
 // at 100 per page; we cap at a reasonable total so a massive PR cannot starve
 // the gh semaphore while we fetch file listings.
 const MAX_PR_FILES = 300
+
+const PR_FILE_VIEWED_STATES_QUERY = `query($owner: String!, $repo: String!, $number: Int!, $after: String) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $number) {
+      id
+      files(first: 100, after: $after) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          path
+          viewerViewedState
+        }
+      }
+    }
+  }
+}`
 
 const WORK_ITEM_PARTICIPANTS_QUERY = `query($owner: String!, $repo: String!, $number: Int!, $isPr: Boolean!) {
   repository(owner: $owner, name: $repo) {
@@ -316,6 +332,102 @@ async function getPRFiles(
   } catch {
     return []
   }
+}
+
+type PRFileViewedStatesResult = {
+  pullRequestId: string
+  viewedStates: Map<string, GitHubPRFileViewedState>
+}
+
+async function getPRFileViewedStates(
+  repoPath: string,
+  prNumber: number,
+  connectionId?: string | null
+): Promise<PRFileViewedStatesResult | null> {
+  const ghOptions = ghRepoExecOptions(githubRepoContext(repoPath, connectionId))
+  const ownerRepo = await getOwnerRepo(repoPath, connectionId)
+  if (!ownerRepo) {
+    return null
+  }
+  if (rateLimitGuard('graphql').blocked) {
+    return null
+  }
+  const viewedStates = new Map<string, GitHubPRFileViewedState>()
+  let pullRequestId: string | null = null
+  let after: string | null = null
+
+  try {
+    for (let fetched = 0; fetched < MAX_PR_FILES; fetched += 100) {
+      const args = [
+        'api',
+        'graphql',
+        '-f',
+        `query=${PR_FILE_VIEWED_STATES_QUERY}`,
+        '-f',
+        `owner=${ownerRepo.owner}`,
+        '-f',
+        `repo=${ownerRepo.repo}`,
+        '-F',
+        `number=${prNumber}`
+      ]
+      if (after) {
+        args.push('-f', `after=${after}`)
+      }
+      noteRateLimitSpend('graphql')
+      const { stdout } = await ghExecFileAsync(args, ghOptions)
+      const parsed = JSON.parse(stdout) as {
+        data?: {
+          repository?: {
+            pullRequest?: {
+              id?: string
+              files?: {
+                pageInfo?: { hasNextPage?: boolean; endCursor?: string | null }
+                nodes?: {
+                  path?: string | null
+                  viewerViewedState?: GitHubPRFileViewedState | null
+                }[]
+              }
+            } | null
+          } | null
+        }
+        errors?: { message?: string }[]
+      }
+      if (parsed.errors && parsed.errors.length > 0) {
+        return null
+      }
+      const pullRequest = parsed.data?.repository?.pullRequest
+      if (!pullRequest?.id) {
+        return null
+      }
+      pullRequestId = pullRequest.id
+      for (const file of pullRequest.files?.nodes ?? []) {
+        if (file.path && file.viewerViewedState) {
+          viewedStates.set(file.path, file.viewerViewedState)
+        }
+      }
+      if (!pullRequest.files?.pageInfo?.hasNextPage || !pullRequest.files.pageInfo.endCursor) {
+        break
+      }
+      after = pullRequest.files.pageInfo.endCursor
+    }
+  } catch {
+    return null
+  }
+
+  return pullRequestId ? { pullRequestId, viewedStates } : null
+}
+
+function mergePRFileViewedStates(
+  files: GitHubPRFile[],
+  viewedStates: PRFileViewedStatesResult | null
+): GitHubPRFile[] {
+  if (!viewedStates) {
+    return files
+  }
+  return files.map((file) => ({
+    ...file,
+    viewerViewedState: viewedStates.viewedStates.get(file.path) ?? 'UNVIEWED'
+  }))
 }
 
 async function getIssueBodyAndComments(
@@ -614,11 +726,12 @@ export async function getWorkItemDetails(
     }
 
     // PR: fetch body + comments + checks + files + head/base SHAs in parallel.
-    const [body, comments, shas, files, participants] = await Promise.all([
+    const [body, comments, shas, files, viewedStates, participants] = await Promise.all([
       getPRBody(repoPath, item.number, connectionId),
       getPRComments(repoPath, item.number, undefined, connectionId),
       getPRHeadBaseSha(repoPath, item.number, connectionId),
       getPRFiles(repoPath, item.number, connectionId),
+      getPRFileViewedStates(repoPath, item.number, connectionId),
       getWorkItemParticipants(repoPath, item, connectionId)
     ])
 
@@ -638,8 +751,9 @@ export async function getWorkItemDetails(
       comments,
       headSha: shas?.headSha,
       baseSha: shas?.baseSha,
+      pullRequestId: viewedStates?.pullRequestId,
       checks,
-      files,
+      files: mergePRFileViewedStates(files, viewedStates),
       participants: mentionParticipants
     }
   } finally {

--- a/src/main/ipc/github.ts
+++ b/src/main/ipc/github.ts
@@ -25,6 +25,7 @@ import {
   getPRChecks,
   getPRComments,
   resolveReviewThread,
+  setPRFileViewed,
   addPRReviewComment,
   addPRReviewCommentReply,
   updatePRTitle,
@@ -313,6 +314,47 @@ export function registerGitHubHandlers(store: Store, stats: StatsCollector): voi
       // event shape; instead, the drawer's existing thread-resolve UI updates
       // its local state immediately and the next reopen pays one fresh fetch.
       return resolveReviewThread(repo.path, args.threadId, args.resolve, repoConnectionId(repo))
+    }
+  )
+
+  ipcMain.handle(
+    'gh:setPRFileViewed',
+    async (
+      event,
+      args: {
+        repoPath: string
+        repoId?: string
+        prNumber: number
+        pullRequestId: string
+        path: string
+        viewed: boolean
+      }
+    ) => {
+      const repo = assertRegisteredRepo(args, store)
+      if (
+        typeof args.prNumber !== 'number' ||
+        !Number.isInteger(args.prNumber) ||
+        args.prNumber < 1
+      ) {
+        return false
+      }
+      if (!args.pullRequestId?.trim() || !args.path?.trim()) {
+        return false
+      }
+      const ok = await setPRFileViewed({
+        repoPath: repo.path,
+        connectionId: repoConnectionId(repo),
+        pullRequestId: args.pullRequestId.trim(),
+        path: args.path,
+        viewed: Boolean(args.viewed)
+      })
+      if (ok) {
+        broadcastWorkItemMutated(
+          { repoPath: repo.path, type: 'pr', number: args.prNumber },
+          event.sender.id
+        )
+      }
+      return ok
     }
   )
 

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -95,6 +95,7 @@ import {
   getPRComments,
   getIssue,
   resolveReviewThread,
+  setPRFileViewed,
   getWorkItemByOwnerRepo,
   updatePRTitle,
   mergePR,
@@ -4565,6 +4566,19 @@ export class OrcaRuntimeService {
     const repo = await this.resolveRepoSelector(repoSelector)
     this.assertHostIntegrationRepoIsLocal(repo, 'repo_pr_review_thread')
     return resolveReviewThread(repo.path, threadId, resolve)
+  }
+
+  async setRepoPRFileViewed(
+    repoSelector: string,
+    args: {
+      pullRequestId: string
+      path: string
+      viewed: boolean
+    }
+  ): Promise<Awaited<ReturnType<typeof setPRFileViewed>>> {
+    const repo = await this.resolveRepoSelector(repoSelector)
+    this.assertHostIntegrationRepoIsLocal(repo, 'repo_pr_file_viewed')
+    return setPRFileViewed({ repoPath: repo.path, ...args })
   }
 
   async updateRepoPRTitle(

--- a/src/main/runtime/rpc/methods/github.test.ts
+++ b/src/main/runtime/rpc/methods/github.test.ts
@@ -219,6 +219,30 @@ describe('github RPC methods', () => {
     expect(response).toMatchObject({ ok: true, result: true })
   })
 
+  it('marks PR files viewed on the runtime server', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      setRepoPRFileViewed: vi.fn().mockResolvedValue(true)
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: GITHUB_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest('github.setPRFileViewed', {
+        repo: 'repo-1',
+        pullRequestId: 'PR_kwDO123',
+        path: 'src/app.ts',
+        viewed: true
+      })
+    )
+
+    expect(runtime.setRepoPRFileViewed).toHaveBeenCalledWith('repo-1', {
+      pullRequestId: 'PR_kwDO123',
+      path: 'src/app.ts',
+      viewed: true
+    })
+    expect(response).toMatchObject({ ok: true, result: true })
+  })
+
   it('updates PR titles on the runtime server', async () => {
     const runtime = {
       getRuntimeId: () => 'test-runtime',

--- a/src/main/runtime/rpc/methods/github.ts
+++ b/src/main/runtime/rpc/methods/github.ts
@@ -71,6 +71,12 @@ const PullRequestFileContents = RepoSelector.extend({
   baseSha: requiredString('Missing base SHA')
 })
 
+const PullRequestFileViewed = RepoSelector.extend({
+  pullRequestId: requiredString('Missing pull request ID'),
+  path: requiredString('Missing file path'),
+  viewed: z.boolean()
+})
+
 const ReviewThread = RepoSelector.extend({
   threadId: requiredString('Missing thread ID'),
   resolve: z.boolean()
@@ -312,6 +318,16 @@ export const GITHUB_METHODS: RpcMethod[] = [
     params: ReviewThread,
     handler: async (params, { runtime }) =>
       runtime.resolveRepoReviewThread(params.repo, params.threadId, params.resolve)
+  }),
+  defineMethod({
+    name: 'github.setPRFileViewed',
+    params: PullRequestFileViewed,
+    handler: async (params, { runtime }) =>
+      runtime.setRepoPRFileViewed(params.repo, {
+        pullRequestId: params.pullRequestId,
+        path: params.path,
+        viewed: params.viewed
+      })
   }),
   defineMethod({
     name: 'github.updatePRTitle',

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -716,6 +716,14 @@ export type PreloadApi = {
       threadId: string
       resolve: boolean
     }) => Promise<boolean>
+    setPRFileViewed: (args: {
+      repoPath: string
+      repoId?: string
+      prNumber: number
+      pullRequestId: string
+      path: string
+      viewed: boolean
+    }) => Promise<boolean>
     updatePRTitle: (args: {
       repoPath: string
       repoId?: string

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -780,6 +780,15 @@ const api = {
       resolve: boolean
     }): Promise<boolean> => ipcRenderer.invoke('gh:resolveReviewThread', args),
 
+    setPRFileViewed: (args: {
+      repoPath: string
+      repoId?: string
+      prNumber: number
+      pullRequestId: string
+      path: string
+      viewed: boolean
+    }): Promise<boolean> => ipcRenderer.invoke('gh:setPRFileViewed', args),
+
     updatePRTitle: (args: {
       repoPath: string
       repoId?: string

--- a/src/renderer/src/components/GitHubItemDialog.tsx
+++ b/src/renderer/src/components/GitHubItemDialog.tsx
@@ -80,6 +80,7 @@ import type {
   GitHubOwnerRepo,
   GitHubPRFile,
   GitHubPRFileContents,
+  GitHubPRFileViewedState,
   GitHubWorkItem,
   GitHubWorkItemDetails,
   GitHubAssignableUser,
@@ -355,6 +356,16 @@ function fileStatusLabel(status: GitHubPRFile['status']): string {
   }
 }
 
+function isPRFileViewed(file: GitHubPRFile): boolean {
+  return file.viewerViewedState === 'VIEWED'
+}
+
+// Why: GitHub's viewed toggle auto-collapses the file; keying rows by the
+// viewed state resets the row's local expanded/content state without an Effect.
+function getPRFileRowKey(file: GitHubPRFile): string {
+  return `${file.path}:${file.viewerViewedState ?? 'UNVIEWED'}`
+}
+
 function findNearestBraceBlock(
   lines: string[],
   targetLine: number
@@ -400,6 +411,9 @@ type FileRowProps = {
   prNumber: number
   headSha: string | undefined
   baseSha: string | undefined
+  viewed: boolean
+  viewedPending: boolean
+  onViewedChange: (path: string, viewed: boolean) => Promise<boolean>
 }
 
 type DiffViewMode = 'flat' | 'tree'
@@ -414,7 +428,9 @@ type DiffTreeNodeProps = {
   prNumber: number
   headSha: string | undefined
   baseSha: string | undefined
+  pendingViewedPaths: ReadonlySet<string>
   onCommentAdded: (comment: PRComment) => void
+  onViewedChange: (path: string, viewed: boolean) => Promise<boolean>
 }
 
 function PRDiffTreeNode({
@@ -425,7 +441,9 @@ function PRDiffTreeNode({
   prNumber,
   headSha,
   baseSha,
-  onCommentAdded
+  pendingViewedPaths,
+  onCommentAdded,
+  onViewedChange
 }: DiffTreeNodeProps): React.JSX.Element {
   const [open, setOpen] = useState(true)
 
@@ -438,7 +456,10 @@ function PRDiffTreeNode({
         prNumber={prNumber}
         headSha={headSha}
         baseSha={baseSha}
+        viewed={isPRFileViewed(node.file)}
+        viewedPending={pendingViewedPaths.has(node.file.path)}
         onCommentAdded={onCommentAdded}
+        onViewedChange={onViewedChange}
         // Why: tree-view file rows are indented by a CSS left-padding proportional
         // to depth so the expand chevron of PRFileRow stays at position 0 while
         // the folder hierarchy is communicated purely through indentation.
@@ -477,7 +498,7 @@ function PRDiffTreeNode({
         <div role="group">
           {node.children.map((child) => (
             <PRDiffTreeNode
-              key={child.kind === 'file' ? child.file.path : child.path}
+              key={child.kind === 'file' ? getPRFileRowKey(child.file) : child.path}
               node={child}
               depth={depth + 1}
               repoPath={repoPath}
@@ -485,7 +506,9 @@ function PRDiffTreeNode({
               prNumber={prNumber}
               headSha={headSha}
               baseSha={baseSha}
+              pendingViewedPaths={pendingViewedPaths}
               onCommentAdded={onCommentAdded}
+              onViewedChange={onViewedChange}
             />
           ))}
         </div>
@@ -501,7 +524,9 @@ type PRDiffTreeViewProps = {
   prNumber: number
   headSha: string | undefined
   baseSha: string | undefined
+  pendingViewedPaths: ReadonlySet<string>
   onCommentAdded: (comment: PRComment) => void
+  onViewedChange: (path: string, viewed: boolean) => Promise<boolean>
 }
 
 function PRDiffTreeView({
@@ -511,14 +536,16 @@ function PRDiffTreeView({
   prNumber,
   headSha,
   baseSha,
-  onCommentAdded
+  pendingViewedPaths,
+  onCommentAdded,
+  onViewedChange
 }: PRDiffTreeViewProps): React.JSX.Element {
   const tree = useMemo(() => buildDiffTree(files), [files])
   return (
     <div role="tree" aria-label="Changed files">
       {tree.map((node) => (
         <PRDiffTreeNode
-          key={node.kind === 'file' ? node.file.path : node.path}
+          key={node.kind === 'file' ? getPRFileRowKey(node.file) : node.path}
           node={node}
           depth={0}
           repoPath={repoPath}
@@ -526,7 +553,9 @@ function PRDiffTreeView({
           prNumber={prNumber}
           headSha={headSha}
           baseSha={baseSha}
+          pendingViewedPaths={pendingViewedPaths}
           onCommentAdded={onCommentAdded}
+          onViewedChange={onViewedChange}
         />
       ))}
     </div>
@@ -636,6 +665,35 @@ function invalidateWorkItemDetailsCacheByMatch(args: {
   if (removed) {
     notifyWorkItemDetailsCache()
   }
+}
+
+function patchCachedPRFileViewedState(
+  cacheKey: string,
+  path: string,
+  viewerViewedState: GitHubPRFileViewedState
+): GitHubPRFileViewedState | undefined {
+  const prev = workItemDetailsCache.get(cacheKey)
+  const files = prev?.details?.files
+  if (!prev?.details || !files) {
+    return undefined
+  }
+  let previousState: GitHubPRFileViewedState | undefined
+  const nextFiles = files.map((file) => {
+    if (file.path !== path) {
+      return file
+    }
+    previousState = file.viewerViewedState ?? 'UNVIEWED'
+    return { ...file, viewerViewedState }
+  })
+  if (previousState === undefined || previousState === viewerViewedState) {
+    return previousState
+  }
+  touchWorkItemDetailsCache(cacheKey, {
+    ...prev,
+    details: { ...prev.details, files: nextFiles },
+    error: undefined
+  })
+  return previousState
 }
 
 // Why: install once at module load — every dialog instance shares the cache,
@@ -798,6 +856,24 @@ function addPRReviewCommentReplyForRepo(args: {
   })
 }
 
+function setPRFileViewedForRepo(args: {
+  repoId?: string
+  repoPath: string
+  prNumber: number
+  pullRequestId: string
+  path: string
+  viewed: boolean
+}): Promise<boolean> {
+  return window.api.gh.setPRFileViewed({
+    repoPath: args.repoPath,
+    repoId: args.repoId,
+    prNumber: args.prNumber,
+    pullRequestId: args.pullRequestId,
+    path: args.path,
+    viewed: args.viewed
+  })
+}
+
 function getWorkItemDetailsForRepo(args: {
   repoId?: string
   repoPath: string
@@ -812,6 +888,60 @@ function getWorkItemDetailsForRepo(args: {
   })
 }
 
+function PRViewedCheckbox({
+  checked,
+  pending,
+  filePath,
+  onToggle
+}: {
+  checked: boolean
+  pending: boolean
+  filePath: string
+  onToggle: () => void
+}): React.JSX.Element {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          role="checkbox"
+          aria-checked={checked}
+          aria-label={`${checked ? 'Unmark' : 'Mark'} ${filePath} as viewed`}
+          disabled={pending}
+          onClick={(event) => {
+            event.stopPropagation()
+            onToggle()
+          }}
+          className={cn(
+            'flex h-6 shrink-0 items-center gap-1.5 rounded-md px-1.5 text-[11px] text-muted-foreground transition hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+            checked && 'text-foreground',
+            pending && 'cursor-default opacity-60'
+          )}
+        >
+          <span
+            className={cn(
+              'flex size-4 items-center justify-center rounded-sm border transition-colors',
+              checked
+                ? 'border-foreground bg-foreground text-background'
+                : 'border-muted-foreground/50 bg-background text-transparent'
+            )}
+          >
+            {pending ? (
+              <LoaderCircle className="size-3 animate-spin text-muted-foreground" />
+            ) : checked ? (
+              <Check className="size-3" strokeWidth={3} />
+            ) : null}
+          </span>
+          <span>Viewed</span>
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom" sideOffset={4}>
+        {checked ? 'Unmark viewed' : 'Mark viewed'}
+      </TooltipContent>
+    </Tooltip>
+  )
+}
+
 function PRFileRow({
   file,
   repoPath,
@@ -819,6 +949,9 @@ function PRFileRow({
   prNumber,
   headSha,
   baseSha,
+  viewed,
+  viewedPending,
+  onViewedChange,
   onCommentAdded,
   indentDepth = 0,
   label
@@ -899,76 +1032,99 @@ function PRFileRow({
     [file.path, headSha, onCommentAdded, prNumber, repoId, repoPath]
   )
 
+  const handleViewedToggle = useCallback(async () => {
+    if (viewedPending) {
+      return
+    }
+    await onViewedChange(file.path, !viewed)
+  }, [file.path, onViewedChange, viewed, viewedPending])
+
   return (
-    <div className="border-b border-border/50" {...(label != null ? { role: 'treeitem' } : {})}>
-      <button
-        type="button"
-        onClick={handleToggle}
-        className="flex w-full items-center gap-2 py-2 pr-3 text-left transition hover:bg-muted/40"
+    <div
+      className={cn('border-b border-border/50', viewed && 'bg-muted/15')}
+      {...(label != null ? { role: 'treeitem' } : {})}
+    >
+      <div
+        className={cn(
+          'flex w-full items-center gap-2 py-2 pr-3 text-left transition hover:bg-muted/40',
+          viewed && 'opacity-60'
+        )}
         style={{ paddingLeft: `${12 + indentDepth * 16}px` }}
       >
-        {expanded ? (
-          <ChevronDown className="size-3.5 shrink-0 text-muted-foreground" />
-        ) : (
-          <ChevronRight className="size-3.5 shrink-0 text-muted-foreground" />
-        )}
-        <span
-          className={cn(
-            'inline-flex size-5 shrink-0 items-center justify-center rounded border border-border/60 font-mono text-[10px]',
-            fileStatusTone(file.status)
-          )}
-          aria-label={file.status}
+        <button
+          type="button"
+          onClick={handleToggle}
+          className="flex min-w-0 flex-1 items-center gap-2 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         >
-          {fileStatusLabel(file.status)}
-        </span>
-        <span className="min-w-0 flex-1 truncate font-mono text-[12px] text-foreground">
-          {file.oldPath && file.oldPath !== file.path ? (
-            label ? (
-              // Why: in tree view we only have room for basenames, but still need to
-              // communicate the rename so the user doesn't have to expand or switch
-              // to flat view to discover what was renamed. When basenames match (i.e.
-              // only the directory changed), we include the parent directory so the
-              // display isn't a meaningless "foo.ts → foo.ts".
-              (() => {
-                const oldBase = file.oldPath!.split('/').pop() ?? file.oldPath!
-                if (oldBase === label) {
-                  const oldParts = file.oldPath!.split('/')
-                  const newParts = file.path.split('/')
-                  const oldShort = oldParts.slice(-2).join('/')
-                  const newShort = newParts.slice(-2).join('/')
+          {expanded ? (
+            <ChevronDown className="size-3.5 shrink-0 text-muted-foreground" />
+          ) : (
+            <ChevronRight className="size-3.5 shrink-0 text-muted-foreground" />
+          )}
+          <span
+            className={cn(
+              'inline-flex size-5 shrink-0 items-center justify-center rounded border border-border/60 font-mono text-[10px]',
+              fileStatusTone(file.status)
+            )}
+            aria-label={file.status}
+          >
+            {fileStatusLabel(file.status)}
+          </span>
+          <span className="min-w-0 flex-1 truncate font-mono text-[12px] text-foreground">
+            {file.oldPath && file.oldPath !== file.path ? (
+              label ? (
+                // Why: in tree view we only have room for basenames, but still need to
+                // communicate the rename so the user doesn't have to expand or switch
+                // to flat view to discover what was renamed. When basenames match (i.e.
+                // only the directory changed), we include the parent directory so the
+                // display isn't a meaningless "foo.ts → foo.ts".
+                (() => {
+                  const oldBase = file.oldPath!.split('/').pop() ?? file.oldPath!
+                  if (oldBase === label) {
+                    const oldParts = file.oldPath!.split('/')
+                    const newParts = file.path.split('/')
+                    const oldShort = oldParts.slice(-2).join('/')
+                    const newShort = newParts.slice(-2).join('/')
+                    return (
+                      <>
+                        <span className="text-muted-foreground">{oldShort}</span>
+                        <span className="mx-1 text-muted-foreground">→</span>
+                        {newShort}
+                      </>
+                    )
+                  }
                   return (
                     <>
-                      <span className="text-muted-foreground">{oldShort}</span>
+                      <span className="text-muted-foreground">{oldBase}</span>
                       <span className="mx-1 text-muted-foreground">→</span>
-                      {newShort}
+                      {label}
                     </>
                   )
-                }
-                return (
-                  <>
-                    <span className="text-muted-foreground">{oldBase}</span>
-                    <span className="mx-1 text-muted-foreground">→</span>
-                    {label}
-                  </>
-                )
-              })()
+                })()
+              ) : (
+                <>
+                  <span className="text-muted-foreground">{file.oldPath}</span>
+                  <span className="mx-1 text-muted-foreground">→</span>
+                  {file.path}
+                </>
+              )
             ) : (
-              <>
-                <span className="text-muted-foreground">{file.oldPath}</span>
-                <span className="mx-1 text-muted-foreground">→</span>
-                {file.path}
-              </>
-            )
-          ) : (
-            (label ?? file.path)
-          )}
-        </span>
+              (label ?? file.path)
+            )}
+          </span>
+        </button>
         <span className="shrink-0 font-mono text-[11px] text-muted-foreground">
           <span className="text-emerald-500">+{file.additions}</span>
           <span className="mx-1">/</span>
           <span className="text-rose-500">−{file.deletions}</span>
         </span>
-      </button>
+        <PRViewedCheckbox
+          checked={viewed}
+          pending={viewedPending}
+          filePath={file.path}
+          onToggle={handleViewedToggle}
+        />
+      </div>
 
       {expanded && (
         // Why: DiffViewer's inner layout uses flex-1/min-h-0, so this wrapper
@@ -2845,6 +3001,8 @@ export default function GitHubItemDialog({
   const comments = details?.comments ?? []
   const files = details?.files ?? []
   const checks = details?.checks ?? []
+  const viewedFileCount = files.filter(isPRFileViewed).length
+  const [pendingViewedPaths, setPendingViewedPaths] = useState<Set<string>>(() => new Set())
 
   useEffect(() => {
     setLinkCopied(false)
@@ -2905,6 +3063,45 @@ export default function GitHubItemDialog({
       setOptimisticTick((n) => n + 1)
     },
     [detailsCacheKey]
+  )
+
+  const handlePRFileViewedChange = useCallback(
+    async (path: string, viewed: boolean): Promise<boolean> => {
+      if (!repoPath || !details?.pullRequestId || !workItem || workItem.type !== 'pr') {
+        toast.error('Unable to sync viewed state for this pull request.')
+        return false
+      }
+      setPendingViewedPaths((prev) => new Set(prev).add(path))
+      const nextState: GitHubPRFileViewedState = viewed ? 'VIEWED' : 'UNVIEWED'
+      const previousState = detailsCacheKey
+        ? patchCachedPRFileViewedState(detailsCacheKey, path, nextState)
+        : undefined
+      try {
+        const ok = await setPRFileViewedForRepo({
+          repoId: workItem.repoId,
+          repoPath,
+          prNumber: workItem.number,
+          pullRequestId: details.pullRequestId,
+          path,
+          viewed
+        })
+        if (!ok) {
+          if (detailsCacheKey && previousState) {
+            patchCachedPRFileViewedState(detailsCacheKey, path, previousState)
+          }
+          toast.error('Failed to sync viewed state with GitHub.')
+          return false
+        }
+        return true
+      } finally {
+        setPendingViewedPaths((prev) => {
+          const next = new Set(prev)
+          next.delete(path)
+          return next
+        })
+      }
+    },
+    [details?.pullRequestId, detailsCacheKey, repoPath, workItem]
   )
 
   return (
@@ -3108,63 +3305,71 @@ export default function GitHubItemDialog({
                         ) : (
                           <div>
                             {/* Files-tab toolbar: view-mode toggle */}
-                            <div className="flex items-center justify-end gap-1 border-b border-border/40 px-3 py-1.5">
-                              <Tooltip>
-                                <TooltipTrigger asChild>
-                                  <button
-                                    id="pr-files-flat-view"
-                                    type="button"
-                                    onClick={() => setDiffViewMode('flat')}
-                                    aria-label="Flat view"
-                                    aria-pressed={diffViewMode === 'flat'}
-                                    className={cn(
-                                      'flex size-6 items-center justify-center rounded transition hover:bg-muted',
-                                      diffViewMode === 'flat'
-                                        ? 'bg-muted text-foreground'
-                                        : 'text-muted-foreground'
-                                    )}
-                                  >
-                                    <AlignJustify className="size-3.5" />
-                                  </button>
-                                </TooltipTrigger>
-                                <TooltipContent side="bottom" sideOffset={4}>
-                                  Flat view
-                                </TooltipContent>
-                              </Tooltip>
-                              <Tooltip>
-                                <TooltipTrigger asChild>
-                                  <button
-                                    id="pr-files-tree-view"
-                                    type="button"
-                                    onClick={() => setDiffViewMode('tree')}
-                                    aria-label="Tree view"
-                                    aria-pressed={diffViewMode === 'tree'}
-                                    className={cn(
-                                      'flex size-6 items-center justify-center rounded transition hover:bg-muted',
-                                      diffViewMode === 'tree'
-                                        ? 'bg-muted text-foreground'
-                                        : 'text-muted-foreground'
-                                    )}
-                                  >
-                                    <LayoutList className="size-3.5" />
-                                  </button>
-                                </TooltipTrigger>
-                                <TooltipContent side="bottom" sideOffset={4}>
-                                  Tree view
-                                </TooltipContent>
-                              </Tooltip>
+                            <div className="flex items-center justify-between gap-3 border-b border-border/40 px-3 py-1.5">
+                              <span className="text-[11px] text-muted-foreground">
+                                {viewedFileCount} / {files.length} files viewed
+                              </span>
+                              <div className="flex items-center gap-1">
+                                <Tooltip>
+                                  <TooltipTrigger asChild>
+                                    <button
+                                      id="pr-files-flat-view"
+                                      type="button"
+                                      onClick={() => setDiffViewMode('flat')}
+                                      aria-label="Flat view"
+                                      aria-pressed={diffViewMode === 'flat'}
+                                      className={cn(
+                                        'flex size-6 items-center justify-center rounded transition hover:bg-muted',
+                                        diffViewMode === 'flat'
+                                          ? 'bg-muted text-foreground'
+                                          : 'text-muted-foreground'
+                                      )}
+                                    >
+                                      <AlignJustify className="size-3.5" />
+                                    </button>
+                                  </TooltipTrigger>
+                                  <TooltipContent side="bottom" sideOffset={4}>
+                                    Flat view
+                                  </TooltipContent>
+                                </Tooltip>
+                                <Tooltip>
+                                  <TooltipTrigger asChild>
+                                    <button
+                                      id="pr-files-tree-view"
+                                      type="button"
+                                      onClick={() => setDiffViewMode('tree')}
+                                      aria-label="Tree view"
+                                      aria-pressed={diffViewMode === 'tree'}
+                                      className={cn(
+                                        'flex size-6 items-center justify-center rounded transition hover:bg-muted',
+                                        diffViewMode === 'tree'
+                                          ? 'bg-muted text-foreground'
+                                          : 'text-muted-foreground'
+                                      )}
+                                    >
+                                      <LayoutList className="size-3.5" />
+                                    </button>
+                                  </TooltipTrigger>
+                                  <TooltipContent side="bottom" sideOffset={4}>
+                                    Tree view
+                                  </TooltipContent>
+                                </Tooltip>
+                              </div>
                             </div>
                             {diffViewMode === 'flat' ? (
                               files.map((file) => (
                                 <PRFileRow
-                                  key={file.path}
+                                  key={getPRFileRowKey(file)}
                                   file={file}
                                   repoPath={repoPath ?? ''}
                                   repoId={effectiveRepoId ?? ''}
                                   prNumber={workItem.number}
                                   headSha={details?.headSha}
                                   baseSha={details?.baseSha}
+                                  viewed={isPRFileViewed(file)}
+                                  viewedPending={pendingViewedPaths.has(file.path)}
                                   onCommentAdded={appendOptimisticComment}
+                                  onViewedChange={handlePRFileViewedChange}
                                 />
                               ))
                             ) : (
@@ -3175,7 +3380,9 @@ export default function GitHubItemDialog({
                                 prNumber={workItem.number}
                                 headSha={details?.headSha}
                                 baseSha={details?.baseSha}
+                                pendingViewedPaths={pendingViewedPaths}
                                 onCommentAdded={appendOptimisticComment}
+                                onViewedChange={handlePRFileViewedChange}
                               />
                             )}
                           </div>

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -599,6 +599,7 @@ function createGitHubApi(): NonNullable<Partial<PreloadApi>['gh']> {
     prChecks: direct('github.prChecks'),
     prComments: direct('github.prComments'),
     resolveReviewThread: direct('github.resolveReviewThread'),
+    setPRFileViewed: direct('github.setPRFileViewed'),
     updatePRTitle: direct('github.updatePRTitle'),
     mergePR: direct('github.mergePR'),
     updateIssue: direct('github.updateIssue'),

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -610,6 +610,8 @@ export type GitHubAssignableUser = {
   avatarUrl: string
 }
 
+export type GitHubPRFileViewedState = 'DISMISSED' | 'VIEWED' | 'UNVIEWED'
+
 export type GitHubWorkItem = {
   id: string
   type: 'issue' | 'pr'
@@ -641,6 +643,8 @@ export type GitHubPRFile = {
   deletions: number
   /** GitHub marks files above its diff size limit as binary-like; we skip content fetches for these. */
   isBinary: boolean
+  /** GitHub's per-viewer review state. DISMISSED means new changes arrived after the file was viewed. */
+  viewerViewedState?: GitHubPRFileViewedState
 }
 
 export type GitHubPRFileContents = {
@@ -669,6 +673,8 @@ export type GitHubWorkItemDetails = {
   /** Only set for PRs. Head/base SHAs used by the Files tab to fetch per-file content. */
   headSha?: string
   baseSha?: string
+  /** GraphQL node ID required by GitHub's file-viewed mutations. Only set for PRs. */
+  pullRequestId?: string
   checks?: PRCheckDetail[]
   files?: GitHubPRFile[]
   participants?: GitHubAssignableUser[]


### PR DESCRIPTION
Closes #1744

## Summary
- Fetch GitHub `viewerViewedState` and PR node IDs in PR details using the repo connection context and rate-limit guard.
- Sync file viewed/unviewed state through GraphQL, IPC, runtime RPC, and the web preload bridge.
- Add per-file Viewed checkboxes, progress, viewed row dimming, optimistic rollback, and GitHub-style auto-collapse in flat/tree file views.

## Screenshots
Flat view, no files viewed:
![Flat PR files view with per-file viewed checkboxes](https://raw.githubusercontent.com/stablyai/orca/nwparker/pr-1914-images-20260515-2105/.github/pr-assets/1914/pr-files-flat-unviewed.png)

Flat view, one file marked viewed:
![Flat PR files view after marking one file viewed](https://raw.githubusercontent.com/stablyai/orca/nwparker/pr-1914-images-20260515-2105/.github/pr-assets/1914/pr-files-flat-one-viewed.png)

Tree view, one file marked viewed:
![Tree PR files view showing the viewed checkbox state](https://raw.githubusercontent.com/stablyai/orca/nwparker/pr-1914-images-20260515-2105/.github/pr-assets/1914/pr-files-tree-one-viewed.png)

## Working evidence
- Rebased onto `origin/main` at `e7f3bb6034` and force-pushed with lease.
- Ran the rebased Electron dev build on CDP 9333, then opened Tasks -> Issues/PRs -> PRs -> PR #8725.
- Files tab initially showed `0 / 19 files viewed` with per-file Viewed checkboxes.
- Marking the first file changed progress to `1 / 19`, updated the checkbox label to Unmark, and collapsed the viewed row.
- Tree view showed the same checked Viewed state.
- Unmarked the same file and confirmed the state returned to `0 / 19`.
- Playwright/Electron console check: 0 errors.

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/main/github/work-item-details.test.ts src/main/github/work-item-details-file-viewed.test.ts src/main/github/client.test.ts src/main/github/client-file-viewed.test.ts src/main/runtime/rpc/methods/github.test.ts` (5 files, 46 tests)
- `pnpm run tc:web`
- `pnpm run tc:node`
- `pnpm run lint`
- `git diff --check`