### PR TITLE
Add Forgejo hosted review support

### DIFF
--- a/src/main/forgejo/client.test.ts
+++ b/src/main/forgejo/client.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { gitExecFileAsyncMock } = vi.hoisted(() => ({
+  gitExecFileAsyncMock: vi.fn()
+}))
+
+vi.mock('../git/runner', () => ({
+  gitExecFileAsync: gitExecFileAsyncMock
+}))
+
+import {
+  getForgejoAuthStatus,
+  getForgejoPullRequestForBranch,
+  normalizeForgejoApiBaseUrl
+} from './client'
+import { _resetForgejoRepoRefCache } from './repository-ref'
+
+const OLD_ENV = process.env
+
+function forgejoPr(index = 7, branch = 'feature/forgejo') {
+  return {
+    number: index,
+    title: 'Add Forgejo',
+    state: 'open',
+    html_url: `https://code.example.com/team/repo/pulls/${index}`,
+    updated_at: '2026-05-15T00:00:00Z',
+    mergeable: true,
+    head: {
+      ref: branch,
+      label: `team:${branch}`,
+      sha: 'abc123'
+    }
+  }
+}
+
+describe('Forgejo client', () => {
+  beforeEach(() => {
+    process.env = { ...OLD_ENV }
+    process.env.ORCA_FORGEJO_TOKEN = 'forgejo-token'
+    process.env.ORCA_FORGEJO_API_BASE_URL = 'https://code.example.com'
+    delete process.env.ORCA_GITEA_TOKEN
+    delete process.env.ORCA_GITEA_API_BASE_URL
+    gitExecFileAsyncMock.mockReset()
+    gitExecFileAsyncMock.mockResolvedValue({
+      stdout: 'https://git.example.com/team/repo.git\n',
+      stderr: ''
+    })
+    _resetForgejoRepoRefCache()
+    vi.unstubAllGlobals()
+  })
+
+  it('normalizes Forgejo API base URLs', () => {
+    expect(normalizeForgejoApiBaseUrl('https://git.example.com')).toBe(
+      'https://git.example.com/api/v1'
+    )
+    expect(normalizeForgejoApiBaseUrl('https://git.example.com/api/v1/')).toBe(
+      'https://git.example.com/api/v1'
+    )
+  })
+
+  it('fetches a branch pull request and commit status', async () => {
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      const parsed = new URL(url)
+      if (!init) {
+        throw new Error('expected request init')
+      }
+      expect((init.headers as Record<string, string>).Authorization).toBe('token forgejo-token')
+      if (parsed.pathname.endsWith('/commits/abc123/status')) {
+        return Response.json({ state: 'success' })
+      }
+      return Response.json([forgejoPr()])
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(
+      getForgejoPullRequestForBranch('/repo', 'refs/heads/feature/forgejo')
+    ).resolves.toEqual({
+      number: 7,
+      title: 'Add Forgejo',
+      state: 'open',
+      url: 'https://code.example.com/team/repo/pulls/7',
+      status: 'success',
+      updatedAt: '2026-05-15T00:00:00Z',
+      mergeable: 'MERGEABLE',
+      headSha: 'abc123'
+    })
+
+    const listUrl = new URL(String(fetchMock.mock.calls[0]?.[0]))
+    expect(listUrl.origin).toBe('https://code.example.com')
+    expect(listUrl.pathname).toBe('/api/v1/repos/team/repo/pulls')
+    expect(listUrl.searchParams.get('state')).toBe('all')
+  })
+
+  it('reports configured token auth without a global API base URL', async () => {
+    delete process.env.ORCA_FORGEJO_API_BASE_URL
+    gitExecFileAsyncMock.mockResolvedValue({
+      stdout: 'https://codeberg.org/team/repo.git\n',
+      stderr: ''
+    })
+    await expect(getForgejoAuthStatus()).resolves.toEqual({
+      configured: true,
+      authenticated: true,
+      account: null,
+      baseUrl: null,
+      tokenConfigured: true
+    })
+  })
+
+  it('verifies token auth when a global API base URL is configured', async () => {
+    const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) =>
+      Response.json({ login: 'forgejo-user' })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(getForgejoAuthStatus()).resolves.toEqual({
+      configured: true,
+      authenticated: true,
+      account: 'forgejo-user',
+      baseUrl: 'https://code.example.com/api/v1',
+      tokenConfigured: true
+    })
+    expect(String(fetchMock.mock.calls[0]?.[0])).toBe('https://code.example.com/api/v1/user')
+  })
+})

--- a/src/main/forgejo/client.ts
+++ b/src/main/forgejo/client.ts
@@ -1,0 +1,46 @@
+import {
+  getGiteaCompatibleAuthStatus,
+  getGiteaCompatiblePullRequest,
+  getGiteaCompatiblePullRequestForBranch,
+  normalizeGiteaCompatibleApiBaseUrl,
+  type GiteaCompatibleAuthStatus,
+  type GiteaCompatibleClientConfig
+} from '../gitea-compatible/client'
+import { getForgejoRepoRef, type ForgejoRepoRef } from './repository-ref'
+
+export type ForgejoAuthStatus = GiteaCompatibleAuthStatus
+
+const FORGEJO_CLIENT_CONFIG: GiteaCompatibleClientConfig = {
+  apiBaseUrlEnv: 'ORCA_FORGEJO_API_BASE_URL',
+  tokenEnv: 'ORCA_FORGEJO_TOKEN',
+  getRepoRef: getForgejoRepoRef
+}
+
+export function normalizeForgejoApiBaseUrl(value: string): string {
+  return normalizeGiteaCompatibleApiBaseUrl(value)
+}
+
+export function getForgejoAuthStatus(): Promise<ForgejoAuthStatus> {
+  return getGiteaCompatibleAuthStatus(FORGEJO_CLIENT_CONFIG)
+}
+
+export function getForgejoPullRequest(repoPath: string, prNumber: number) {
+  return getGiteaCompatiblePullRequest(FORGEJO_CLIENT_CONFIG, repoPath, prNumber)
+}
+
+export function getForgejoPullRequestForBranch(
+  repoPath: string,
+  branch: string,
+  linkedPRNumber?: number | null
+) {
+  return getGiteaCompatiblePullRequestForBranch(
+    FORGEJO_CLIENT_CONFIG,
+    repoPath,
+    branch,
+    linkedPRNumber
+  )
+}
+
+export function getForgejoRepoSlug(repoPath: string): Promise<ForgejoRepoRef | null> {
+  return getForgejoRepoRef(repoPath)
+}

--- a/src/main/forgejo/pull-request-mappers.ts
+++ b/src/main/forgejo/pull-request-mappers.ts
@@ -1,0 +1,22 @@
+import type {
+  GiteaCompatiblePullRequestInfo,
+  RawGiteaCompatibleCombinedStatus,
+  RawGiteaCompatibleCommitStatus,
+  RawGiteaCompatiblePullRequest
+} from '../gitea-compatible/pull-request-mappers'
+import {
+  deriveGiteaCompatibleCommitStatus,
+  mapGiteaCompatibleMergeable,
+  mapGiteaCompatiblePullRequest,
+  mapGiteaCompatiblePullRequestState
+} from '../gitea-compatible/pull-request-mappers'
+
+export type RawForgejoPullRequest = RawGiteaCompatiblePullRequest
+export type ForgejoPullRequestInfo = GiteaCompatiblePullRequestInfo
+export type RawForgejoCombinedStatus = RawGiteaCompatibleCombinedStatus
+export type RawForgejoCommitStatus = RawGiteaCompatibleCommitStatus
+
+export const deriveForgejoCommitStatus = deriveGiteaCompatibleCommitStatus
+export const mapForgejoPullRequestState = mapGiteaCompatiblePullRequestState
+export const mapForgejoMergeable = mapGiteaCompatibleMergeable
+export const mapForgejoPullRequest = mapGiteaCompatiblePullRequest

--- a/src/main/forgejo/repository-ref.test.ts
+++ b/src/main/forgejo/repository-ref.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { gitExecFileAsyncMock } = vi.hoisted(() => ({
+  gitExecFileAsyncMock: vi.fn()
+}))
+
+vi.mock('../git/runner', () => ({
+  gitExecFileAsync: gitExecFileAsyncMock
+}))
+
+import { _resetForgejoRepoRefCache, getForgejoRepoRef, parseForgejoRepoRef } from './repository-ref'
+
+const OLD_ENV = process.env
+
+describe('Forgejo repository ref parsing', () => {
+  beforeEach(() => {
+    process.env = { ...OLD_ENV }
+    delete process.env.ORCA_FORGEJO_API_BASE_URL
+    gitExecFileAsyncMock.mockReset()
+    _resetForgejoRepoRefCache()
+  })
+
+  it('parses known Forgejo HTTPS remotes and derives the API base URL', () => {
+    expect(parseForgejoRepoRef('https://codeberg.org/team/project.git')).toEqual({
+      host: 'codeberg.org',
+      owner: 'team',
+      repo: 'project',
+      apiBaseUrl: 'https://codeberg.org/api/v1',
+      webBaseUrl: 'https://codeberg.org'
+    })
+  })
+
+  it('parses Forgejo-named SSH remotes', () => {
+    expect(parseForgejoRepoRef('git@forgejo.example.test:team/project.git')).toEqual({
+      host: 'forgejo.example.test',
+      owner: 'team',
+      repo: 'project',
+      apiBaseUrl: 'https://forgejo.example.test/api/v1',
+      webBaseUrl: 'https://forgejo.example.test'
+    })
+  })
+
+  it('does not claim arbitrary self-hosted remotes without an explicit Forgejo API base', () => {
+    expect(parseForgejoRepoRef('https://git.example.com/team/project.git')).toBeNull()
+  })
+
+  it('uses an explicit Forgejo API base as a self-hosted provider signal', () => {
+    process.env.ORCA_FORGEJO_API_BASE_URL = 'https://git.example.com'
+    expect(parseForgejoRepoRef('https://git.example.com/team/project.git')).toEqual({
+      host: 'git.example.com',
+      owner: 'team',
+      repo: 'project',
+      apiBaseUrl: 'https://git.example.com/api/v1',
+      webBaseUrl: 'https://git.example.com'
+    })
+  })
+
+  it('reads and caches the origin remote', async () => {
+    gitExecFileAsyncMock.mockResolvedValueOnce({
+      stdout: 'https://codeberg.org/team/project.git\n',
+      stderr: ''
+    })
+
+    await expect(getForgejoRepoRef('/repo')).resolves.toMatchObject({
+      host: 'codeberg.org',
+      owner: 'team',
+      repo: 'project'
+    })
+    await expect(getForgejoRepoRef('/repo')).resolves.toMatchObject({
+      host: 'codeberg.org',
+      owner: 'team',
+      repo: 'project'
+    })
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(1)
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(['remote', 'get-url', 'origin'], {
+      cwd: '/repo'
+    })
+  })
+})

--- a/src/main/forgejo/repository-ref.ts
+++ b/src/main/forgejo/repository-ref.ts
@@ -1,0 +1,53 @@
+import {
+  createGiteaCompatibleRepoRefResolver,
+  parseGiteaCompatibleRepoRef,
+  type GiteaCompatibleRepoRef,
+  type GiteaCompatibleRepoRefOptions
+} from '../gitea-compatible/repository-ref'
+
+export type ForgejoRepoRef = GiteaCompatibleRepoRef
+
+const KNOWN_FORGEJO_HOSTS = ['codeberg.org'] as const
+const knownForgejoHosts = new Set<string>(KNOWN_FORGEJO_HOSTS)
+
+function envValue(name: string): string | null {
+  const value = process.env[name]?.trim() ?? ''
+  return value.length > 0 ? value : null
+}
+
+function isForgejoHost(host: string): boolean {
+  const normalizedHost = host.toLowerCase()
+  return knownForgejoHosts.has(normalizedHost) || normalizedHost.includes('forgejo')
+}
+
+function forgejoRepoRefOptions(): GiteaCompatibleRepoRefOptions {
+  return {
+    excludedHosts: ['github.com', 'gitlab.com', 'bitbucket.org'],
+    isRecognizedHost: isForgejoHost,
+    // Why: a global API base URL is an explicit self-hosted Forgejo signal for
+    // remotes whose hostname does not include "forgejo".
+    allowUnknownHosts: envValue('ORCA_FORGEJO_API_BASE_URL') !== null
+  }
+}
+
+const resolver = createGiteaCompatibleRepoRefResolver(forgejoRepoRefOptions)
+
+/** @internal - exposed for tests only */
+export function _resetForgejoRepoRefCache(): void {
+  resolver.reset()
+}
+
+export function parseForgejoRepoRef(remoteUrl: string): ForgejoRepoRef | null {
+  return parseGiteaCompatibleRepoRef(remoteUrl, forgejoRepoRefOptions())
+}
+
+export function getForgejoRepoRefForRemote(
+  repoPath: string,
+  remoteName: string
+): Promise<ForgejoRepoRef | null> {
+  return resolver.getRepoRefForRemote(repoPath, remoteName)
+}
+
+export function getForgejoRepoRef(repoPath: string): Promise<ForgejoRepoRef | null> {
+  return resolver.getRepoRef(repoPath)
+}

--- a/src/main/gitea-compatible/client.ts
+++ b/src/main/gitea-compatible/client.ts
@@ -1,0 +1,273 @@
+import {
+  deriveGiteaCompatibleCommitStatus,
+  mapGiteaCompatiblePullRequest,
+  type GiteaCompatiblePullRequestInfo,
+  type RawGiteaCompatibleCombinedStatus,
+  type RawGiteaCompatiblePullRequest
+} from './pull-request-mappers'
+import type { GiteaCompatibleRepoRef } from './repository-ref'
+
+const REQUEST_TIMEOUT_MS = 5000
+const PULL_REQUEST_PAGE_LIMIT = 50
+const MAX_PULL_REQUEST_PAGES = 5
+
+type GiteaCompatibleAuthConfig = {
+  apiBaseUrl: string | null
+  token: string | null
+}
+
+export type GiteaCompatibleAuthStatus = {
+  configured: boolean
+  authenticated: boolean
+  account: string | null
+  baseUrl: string | null
+  tokenConfigured: boolean
+}
+
+export type GiteaCompatibleClientConfig = {
+  apiBaseUrlEnv: string
+  tokenEnv: string
+  getRepoRef: (repoPath: string) => Promise<GiteaCompatibleRepoRef | null>
+}
+
+type RequestOptions = {
+  searchParams?: Record<string, string | number>
+  timeoutMs?: number
+}
+
+function envValue(name: string): string | null {
+  const value = process.env[name]?.trim() ?? ''
+  return value.length > 0 ? value : null
+}
+
+export function normalizeGiteaCompatibleApiBaseUrl(value: string): string {
+  const trimmed = value.trim().replace(/\/+$/, '')
+  return /\/api\/v1$/i.test(trimmed) ? trimmed : `${trimmed}/api/v1`
+}
+
+function getAuthConfig(config: GiteaCompatibleClientConfig): GiteaCompatibleAuthConfig {
+  const apiBaseUrl = envValue(config.apiBaseUrlEnv)
+  return {
+    apiBaseUrl: apiBaseUrl ? normalizeGiteaCompatibleApiBaseUrl(apiBaseUrl) : null,
+    token: envValue(config.tokenEnv)
+  }
+}
+
+function authHeaders(config: Pick<GiteaCompatibleAuthConfig, 'token'>): Record<string, string> {
+  return config.token ? { Authorization: `token ${config.token}` } : {}
+}
+
+function configuredApiBaseUrl(
+  config: GiteaCompatibleClientConfig,
+  repo: GiteaCompatibleRepoRef
+): string {
+  return getAuthConfig(config).apiBaseUrl ?? repo.apiBaseUrl
+}
+
+function apiUrl(baseUrl: string, path: string, searchParams?: RequestOptions['searchParams']): URL {
+  const url = new URL(`${baseUrl.replace(/\/+$/, '')}${path}`)
+  if (searchParams) {
+    for (const [key, value] of Object.entries(searchParams)) {
+      url.searchParams.set(key, String(value))
+    }
+  }
+  return url
+}
+
+async function requestJsonAtBase<T>(
+  config: GiteaCompatibleClientConfig,
+  baseUrl: string,
+  path: string,
+  options: RequestOptions = {}
+): Promise<T | null> {
+  const authConfig = getAuthConfig(config)
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), options.timeoutMs ?? REQUEST_TIMEOUT_MS)
+  try {
+    const response = await fetch(apiUrl(baseUrl, path, options.searchParams), {
+      headers: {
+        Accept: 'application/json',
+        ...authHeaders(authConfig)
+      },
+      signal: controller.signal
+    })
+    if (!response.ok) {
+      return null
+    }
+    return (await response.json()) as T
+  } catch {
+    return null
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+function requestJson<T>(
+  config: GiteaCompatibleClientConfig,
+  repo: GiteaCompatibleRepoRef,
+  path: string,
+  options: RequestOptions = {}
+): Promise<T | null> {
+  return requestJsonAtBase(config, configuredApiBaseUrl(config, repo), path, options)
+}
+
+function encodedRepoPath(repo: GiteaCompatibleRepoRef): string {
+  return `${encodeURIComponent(repo.owner)}/${encodeURIComponent(repo.repo)}`
+}
+
+async function getCommitStatus(
+  config: GiteaCompatibleClientConfig,
+  repo: GiteaCompatibleRepoRef,
+  headSha: string | undefined
+): Promise<ReturnType<typeof deriveGiteaCompatibleCommitStatus>> {
+  if (!headSha) {
+    return 'neutral'
+  }
+  const data = await requestJson<RawGiteaCompatibleCombinedStatus>(
+    config,
+    repo,
+    `/repos/${encodedRepoPath(repo)}/commits/${encodeURIComponent(headSha)}/status`
+  )
+  return deriveGiteaCompatibleCommitStatus(data)
+}
+
+async function normalizePullRequest(
+  config: GiteaCompatibleClientConfig,
+  repo: GiteaCompatibleRepoRef,
+  raw: RawGiteaCompatiblePullRequest
+): Promise<GiteaCompatiblePullRequestInfo | null> {
+  const status = await getCommitStatus(config, repo, raw.head?.sha?.trim())
+  return mapGiteaCompatiblePullRequest(raw, status)
+}
+
+function matchesBranch(raw: RawGiteaCompatiblePullRequest, branchName: string): boolean {
+  const ref = raw.head?.ref?.trim()
+  if (ref === branchName) {
+    return true
+  }
+  const label = raw.head?.label?.trim()
+  return label === branchName || label?.endsWith(`:${branchName}`) === true
+}
+
+export async function getGiteaCompatibleAuthStatus(
+  config: GiteaCompatibleClientConfig
+): Promise<GiteaCompatibleAuthStatus> {
+  const authConfig = getAuthConfig(config)
+  const tokenConfigured = authConfig.token !== null
+  if (!authConfig.apiBaseUrl && !tokenConfigured) {
+    return {
+      configured: false,
+      authenticated: false,
+      account: null,
+      baseUrl: null,
+      tokenConfigured: false
+    }
+  }
+  if (!authConfig.apiBaseUrl) {
+    return {
+      configured: true,
+      authenticated: true,
+      account: null,
+      baseUrl: null,
+      tokenConfigured
+    }
+  }
+
+  if (!tokenConfigured) {
+    const version = await requestJsonAtBase<{ version?: string }>(
+      config,
+      authConfig.apiBaseUrl,
+      '/version',
+      { timeoutMs: 4000 }
+    )
+    return {
+      configured: version !== null,
+      authenticated: false,
+      account: null,
+      baseUrl: authConfig.apiBaseUrl,
+      tokenConfigured
+    }
+  }
+
+  const user = await requestJsonAtBase<{
+    login?: string | null
+    username?: string | null
+    full_name?: string | null
+  }>(config, authConfig.apiBaseUrl, '/user', { timeoutMs: 4000 })
+  return {
+    configured: true,
+    authenticated: user !== null,
+    account: user?.login ?? user?.username ?? user?.full_name ?? null,
+    baseUrl: authConfig.apiBaseUrl,
+    tokenConfigured
+  }
+}
+
+export async function getGiteaCompatiblePullRequest(
+  config: GiteaCompatibleClientConfig,
+  repoPath: string,
+  prNumber: number
+): Promise<GiteaCompatiblePullRequestInfo | null> {
+  const repo = await config.getRepoRef(repoPath)
+  if (!repo) {
+    return null
+  }
+  const raw = await requestJson<RawGiteaCompatiblePullRequest>(
+    config,
+    repo,
+    `/repos/${encodedRepoPath(repo)}/pulls/${encodeURIComponent(String(prNumber))}`
+  )
+  return raw ? normalizePullRequest(config, repo, raw) : null
+}
+
+export async function getGiteaCompatiblePullRequestForBranch(
+  config: GiteaCompatibleClientConfig,
+  repoPath: string,
+  branch: string,
+  linkedPRNumber?: number | null
+): Promise<GiteaCompatiblePullRequestInfo | null> {
+  const branchName = branch.replace(/^refs\/heads\//, '')
+  if (!branchName && linkedPRNumber == null) {
+    return null
+  }
+
+  const repo = await config.getRepoRef(repoPath)
+  if (!repo) {
+    return null
+  }
+
+  if (branchName) {
+    for (let page = 1; page <= MAX_PULL_REQUEST_PAGES; page++) {
+      const list = await requestJson<RawGiteaCompatiblePullRequest[]>(
+        config,
+        repo,
+        `/repos/${encodedRepoPath(repo)}/pulls`,
+        {
+          searchParams: {
+            state: 'all',
+            sort: 'recentupdate',
+            page,
+            limit: PULL_REQUEST_PAGE_LIMIT
+          }
+        }
+      )
+      const raw = list?.find((item) => matchesBranch(item, branchName))
+      if (raw) {
+        return normalizePullRequest(config, repo, raw)
+      }
+      if (!list || list.length < PULL_REQUEST_PAGE_LIMIT) {
+        break
+      }
+    }
+  }
+
+  if (typeof linkedPRNumber !== 'number') {
+    return null
+  }
+  const raw = await requestJson<RawGiteaCompatiblePullRequest>(
+    config,
+    repo,
+    `/repos/${encodedRepoPath(repo)}/pulls/${encodeURIComponent(String(linkedPRNumber))}`
+  )
+  return raw ? normalizePullRequest(config, repo, raw) : null
+}

--- a/src/main/gitea-compatible/pull-request-mappers.ts
+++ b/src/main/gitea-compatible/pull-request-mappers.ts
@@ -1,0 +1,131 @@
+import type { CheckStatus, PRMergeableState } from '../../shared/types'
+
+export type RawGiteaCompatiblePullRequest = {
+  number?: number
+  title?: string
+  state?: string | null
+  html_url?: string | null
+  updated_at?: string | null
+  merged?: boolean | null
+  draft?: boolean | null
+  mergeable?: boolean | null
+  head?: {
+    ref?: string | null
+    label?: string | null
+    sha?: string | null
+  } | null
+}
+
+export type GiteaCompatiblePullRequestInfo = {
+  number: number
+  title: string
+  state: 'open' | 'closed' | 'merged' | 'draft'
+  url: string
+  status: CheckStatus
+  updatedAt: string
+  mergeable: PRMergeableState
+  headSha?: string
+}
+
+export type RawGiteaCompatibleCombinedStatus = {
+  state?: string | null
+  statuses?: RawGiteaCompatibleCommitStatus[] | null
+}
+
+export type RawGiteaCompatibleCommitStatus = {
+  status?: string | null
+  state?: string | null
+}
+
+function classifyGiteaCompatibleStatus(status: string | null | undefined): CheckStatus {
+  switch (status?.trim().toLowerCase()) {
+    case 'success':
+      return 'success'
+    case 'failure':
+    case 'error':
+    case 'warning':
+      return 'failure'
+    case 'pending':
+      return 'pending'
+    case 'skipped':
+    default:
+      return 'neutral'
+  }
+}
+
+export function deriveGiteaCompatibleCommitStatus(
+  rollup: RawGiteaCompatibleCombinedStatus | null
+): CheckStatus {
+  if (!rollup) {
+    return 'neutral'
+  }
+  const combined = classifyGiteaCompatibleStatus(rollup.state)
+  if (combined !== 'neutral') {
+    return combined
+  }
+  const statuses = rollup.statuses ?? []
+  if (statuses.length === 0) {
+    return 'neutral'
+  }
+
+  let hasPending = false
+  for (const status of statuses) {
+    const classified = classifyGiteaCompatibleStatus(status.status ?? status.state)
+    if (classified === 'failure') {
+      return 'failure'
+    }
+    if (classified === 'pending') {
+      hasPending = true
+    }
+  }
+  if (hasPending) {
+    return 'pending'
+  }
+  return statuses.every(
+    (status) => classifyGiteaCompatibleStatus(status.status ?? status.state) === 'success'
+  )
+    ? 'success'
+    : 'neutral'
+}
+
+export function mapGiteaCompatiblePullRequestState(
+  raw: Pick<RawGiteaCompatiblePullRequest, 'draft' | 'merged' | 'state'>
+): GiteaCompatiblePullRequestInfo['state'] {
+  if (raw.merged) {
+    return 'merged'
+  }
+  if (raw.draft) {
+    return 'draft'
+  }
+  return raw.state?.trim().toLowerCase() === 'closed' ? 'closed' : 'open'
+}
+
+export function mapGiteaCompatibleMergeable(value: boolean | null | undefined): PRMergeableState {
+  if (value === true) {
+    return 'MERGEABLE'
+  }
+  if (value === false) {
+    return 'CONFLICTING'
+  }
+  return 'UNKNOWN'
+}
+
+export function mapGiteaCompatiblePullRequest(
+  raw: RawGiteaCompatiblePullRequest,
+  status: CheckStatus
+): GiteaCompatiblePullRequestInfo | null {
+  if (typeof raw.number !== 'number' || !raw.title || !raw.html_url) {
+    return null
+  }
+  const headSha = raw.head?.sha?.trim()
+  return {
+    number: raw.number,
+    title: raw.title,
+    state: mapGiteaCompatiblePullRequestState(raw),
+    url: raw.html_url,
+    status,
+    updatedAt: raw.updated_at ?? '',
+    mergeable: mapGiteaCompatibleMergeable(raw.mergeable),
+    ...(headSha ? { headSha } : {})
+  }
+}

--- a/src/main/gitea-compatible/repository-ref.ts
+++ b/src/main/gitea-compatible/repository-ref.ts
@@ -1,0 +1,183 @@
+import { gitExecFileAsync } from '../git/runner'
+
+export type GiteaCompatibleRepoRef = {
+  host: string
+  owner: string
+  repo: string
+  apiBaseUrl: string
+  webBaseUrl: string
+}
+
+export type GiteaCompatibleRepoRefOptions = {
+  excludedHosts?: readonly string[]
+  recognizedHosts?: readonly string[]
+  isRecognizedHost?: (host: string) => boolean
+  allowUnknownHosts?: boolean
+}
+
+type RepoRefResolverOptions = GiteaCompatibleRepoRefOptions | (() => GiteaCompatibleRepoRefOptions)
+
+const DEFAULT_EXCLUDED_HOSTS = ['github.com', 'gitlab.com', 'bitbucket.org'] as const
+
+function currentOptions(options: RepoRefResolverOptions): GiteaCompatibleRepoRefOptions {
+  return typeof options === 'function' ? options() : options
+}
+
+function hostSet(values: readonly string[] | undefined): Set<string> {
+  return new Set((values ?? []).map((host) => host.toLowerCase()))
+}
+
+function decodeSegment(value: string): string {
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    return value
+  }
+}
+
+function parsePath(pathname: string): { owner: string; repo: string; basePath: string } | null {
+  const withoutSuffix = pathname.replace(/\.git$/i, '')
+  const parts = withoutSuffix
+    .split('/')
+    .map((part) => part.trim())
+    .filter(Boolean)
+  if (parts.length < 2) {
+    return null
+  }
+
+  const owner = decodeSegment(parts.at(-2) ?? '')
+  const repo = decodeSegment(parts.at(-1) ?? '')
+  if (!owner || !repo) {
+    return null
+  }
+
+  return {
+    owner,
+    repo,
+    basePath: parts.slice(0, -2).join('/')
+  }
+}
+
+function apiBaseUrlFromWebBase(webBaseUrl: string): string {
+  return `${webBaseUrl.replace(/\/+$/, '')}/api/v1`
+}
+
+function shouldClaimHost(host: string, options: GiteaCompatibleRepoRefOptions): boolean {
+  const normalizedHost = host.toLowerCase()
+  const excludedHosts = hostSet(options.excludedHosts ?? DEFAULT_EXCLUDED_HOSTS)
+  if (!normalizedHost || excludedHosts.has(normalizedHost)) {
+    return false
+  }
+
+  const recognizedHosts = hostSet(options.recognizedHosts)
+  if (recognizedHosts.has(normalizedHost) || options.isRecognizedHost?.(normalizedHost)) {
+    return true
+  }
+
+  return options.allowUnknownHosts ?? true
+}
+
+function makeRepoRef(
+  host: string,
+  path: string,
+  webBaseUrl: string,
+  options: GiteaCompatibleRepoRefOptions
+): GiteaCompatibleRepoRef | null {
+  const normalizedHost = host.toLowerCase()
+  if (!shouldClaimHost(normalizedHost, options)) {
+    return null
+  }
+
+  const parsed = parsePath(path)
+  if (!parsed) {
+    return null
+  }
+
+  return {
+    host: normalizedHost,
+    owner: parsed.owner,
+    repo: parsed.repo,
+    apiBaseUrl: apiBaseUrlFromWebBase(webBaseUrl),
+    webBaseUrl
+  }
+}
+
+export function parseGiteaCompatibleRepoRef(
+  remoteUrl: string,
+  options: GiteaCompatibleRepoRefOptions = {}
+): GiteaCompatibleRepoRef | null {
+  const trimmed = remoteUrl.trim()
+  if (!/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)) {
+    const scpLike = trimmed.match(/^(?:[^@/:]+@)?([^:\s/]+):([^\s]+?)(?:\.git)?$/)
+    if (scpLike) {
+      const host = scpLike[1]
+      const path = scpLike[2]
+      return makeRepoRef(host, path, `https://${host.toLowerCase()}`, options)
+    }
+  }
+
+  try {
+    const url = new URL(trimmed)
+    const protocol = url.protocol.toLowerCase()
+    if (!['http:', 'https:', 'ssh:', 'git+ssh:'].includes(protocol)) {
+      return null
+    }
+
+    const parsed = parsePath(url.pathname)
+    if (!parsed) {
+      return null
+    }
+
+    const webOrigin =
+      protocol === 'http:' || protocol === 'https:'
+        ? `${protocol}//${url.host}`
+        : `https://${url.hostname.toLowerCase()}`
+    const webBaseUrl = parsed.basePath ? `${webOrigin}/${parsed.basePath}` : webOrigin
+    return makeRepoRef(url.hostname, url.pathname, webBaseUrl, options)
+  } catch {
+    return null
+  }
+}
+
+export function createGiteaCompatibleRepoRefResolver(options: RepoRefResolverOptions): {
+  reset: () => void
+  getRepoRefForRemote: (
+    repoPath: string,
+    remoteName: string
+  ) => Promise<GiteaCompatibleRepoRef | null>
+  getRepoRef: (repoPath: string) => Promise<GiteaCompatibleRepoRef | null>
+} {
+  const repoRefCache = new Map<string, GiteaCompatibleRepoRef | null>()
+
+  const reset = (): void => {
+    repoRefCache.clear()
+  }
+
+  const getRepoRefForRemote = async (
+    repoPath: string,
+    remoteName: string
+  ): Promise<GiteaCompatibleRepoRef | null> => {
+    const cacheKey = `${repoPath}\0${remoteName}`
+    if (repoRefCache.has(cacheKey)) {
+      return repoRefCache.get(cacheKey)!
+    }
+    try {
+      const { stdout } = await gitExecFileAsync(['remote', 'get-url', remoteName], {
+        cwd: repoPath
+      })
+      const result = parseGiteaCompatibleRepoRef(stdout, currentOptions(options))
+      repoRefCache.set(cacheKey, result)
+      return result
+    } catch {
+      repoRefCache.set(cacheKey, null)
+      return null
+    }
+  }
+
+  return {
+    reset,
+    getRepoRefForRemote,
+    getRepoRef: (repoPath: string): Promise<GiteaCompatibleRepoRef | null> =>
+      getRepoRefForRemote(repoPath, 'origin')
+  }
+}

--- a/src/main/gitea/client.ts
+++ b/src/main/gitea/client.ts
@@ -1,253 +1,46 @@
 import {
-  deriveGiteaCommitStatus,
-  mapGiteaPullRequest,
-  type GiteaPullRequestInfo,
-  type RawGiteaCombinedStatus,
-  type RawGiteaPullRequest
-} from './pull-request-mappers'
+  getGiteaCompatibleAuthStatus,
+  getGiteaCompatiblePullRequest,
+  getGiteaCompatiblePullRequestForBranch,
+  normalizeGiteaCompatibleApiBaseUrl,
+  type GiteaCompatibleAuthStatus,
+  type GiteaCompatibleClientConfig
+} from '../gitea-compatible/client'
 import { getGiteaRepoRef, type GiteaRepoRef } from './repository-ref'
 
-const REQUEST_TIMEOUT_MS = 5000
-const PULL_REQUEST_PAGE_LIMIT = 50
-const MAX_PULL_REQUEST_PAGES = 5
+export type GiteaAuthStatus = GiteaCompatibleAuthStatus
 
-type GiteaAuthConfig = {
-  apiBaseUrl: string | null
-  token: string | null
-}
-
-export type GiteaAuthStatus = {
-  configured: boolean
-  authenticated: boolean
-  account: string | null
-  baseUrl: string | null
-  tokenConfigured: boolean
-}
-
-type RequestOptions = {
-  searchParams?: Record<string, string | number>
-  timeoutMs?: number
-}
-
-function envValue(name: string): string | null {
-  const value = process.env[name]?.trim() ?? ''
-  return value.length > 0 ? value : null
+const GITEA_CLIENT_CONFIG: GiteaCompatibleClientConfig = {
+  apiBaseUrlEnv: 'ORCA_GITEA_API_BASE_URL',
+  tokenEnv: 'ORCA_GITEA_TOKEN',
+  getRepoRef: getGiteaRepoRef
 }
 
 export function normalizeGiteaApiBaseUrl(value: string): string {
-  const trimmed = value.trim().replace(/\/+$/, '')
-  return /\/api\/v1$/i.test(trimmed) ? trimmed : `${trimmed}/api/v1`
+  return normalizeGiteaCompatibleApiBaseUrl(value)
 }
 
-function getAuthConfig(): GiteaAuthConfig {
-  const apiBaseUrl = envValue('ORCA_GITEA_API_BASE_URL')
-  return {
-    apiBaseUrl: apiBaseUrl ? normalizeGiteaApiBaseUrl(apiBaseUrl) : null,
-    token: envValue('ORCA_GITEA_TOKEN')
-  }
+export function getGiteaAuthStatus(): Promise<GiteaAuthStatus> {
+  return getGiteaCompatibleAuthStatus(GITEA_CLIENT_CONFIG)
 }
 
-function authHeaders(config: Pick<GiteaAuthConfig, 'token'>): Record<string, string> {
-  return config.token ? { Authorization: `token ${config.token}` } : {}
+export function getGiteaPullRequest(repoPath: string, prNumber: number) {
+  return getGiteaCompatiblePullRequest(GITEA_CLIENT_CONFIG, repoPath, prNumber)
 }
 
-function configuredApiBaseUrl(repo: GiteaRepoRef): string {
-  return getAuthConfig().apiBaseUrl ?? repo.apiBaseUrl
-}
-
-function apiUrl(baseUrl: string, path: string, searchParams?: RequestOptions['searchParams']): URL {
-  const url = new URL(`${baseUrl.replace(/\/+$/, '')}${path}`)
-  if (searchParams) {
-    for (const [key, value] of Object.entries(searchParams)) {
-      url.searchParams.set(key, String(value))
-    }
-  }
-  return url
-}
-
-async function requestJsonAtBase<T>(
-  baseUrl: string,
-  path: string,
-  options: RequestOptions = {}
-): Promise<T | null> {
-  const config = getAuthConfig()
-  const controller = new AbortController()
-  const timeout = setTimeout(() => controller.abort(), options.timeoutMs ?? REQUEST_TIMEOUT_MS)
-  try {
-    const response = await fetch(apiUrl(baseUrl, path, options.searchParams), {
-      headers: {
-        Accept: 'application/json',
-        ...authHeaders(config)
-      },
-      signal: controller.signal
-    })
-    if (!response.ok) {
-      return null
-    }
-    return (await response.json()) as T
-  } catch {
-    return null
-  } finally {
-    clearTimeout(timeout)
-  }
-}
-
-function requestJson<T>(
-  repo: GiteaRepoRef,
-  path: string,
-  options: RequestOptions = {}
-): Promise<T | null> {
-  return requestJsonAtBase(configuredApiBaseUrl(repo), path, options)
-}
-
-function encodedRepoPath(repo: GiteaRepoRef): string {
-  return `${encodeURIComponent(repo.owner)}/${encodeURIComponent(repo.repo)}`
-}
-
-async function getCommitStatus(
-  repo: GiteaRepoRef,
-  headSha: string | undefined
-): Promise<ReturnType<typeof deriveGiteaCommitStatus>> {
-  if (!headSha) {
-    return 'neutral'
-  }
-  const data = await requestJson<RawGiteaCombinedStatus>(
-    repo,
-    `/repos/${encodedRepoPath(repo)}/commits/${encodeURIComponent(headSha)}/status`
-  )
-  return deriveGiteaCommitStatus(data)
-}
-
-async function normalizePullRequest(
-  repo: GiteaRepoRef,
-  raw: RawGiteaPullRequest
-): Promise<GiteaPullRequestInfo | null> {
-  const status = await getCommitStatus(repo, raw.head?.sha?.trim())
-  return mapGiteaPullRequest(raw, status)
-}
-
-function matchesBranch(raw: RawGiteaPullRequest, branchName: string): boolean {
-  const ref = raw.head?.ref?.trim()
-  if (ref === branchName) {
-    return true
-  }
-  const label = raw.head?.label?.trim()
-  return label === branchName || label?.endsWith(`:${branchName}`) === true
-}
-
-export async function getGiteaAuthStatus(): Promise<GiteaAuthStatus> {
-  const config = getAuthConfig()
-  const tokenConfigured = config.token !== null
-  if (!config.apiBaseUrl && !tokenConfigured) {
-    return {
-      configured: false,
-      authenticated: false,
-      account: null,
-      baseUrl: null,
-      tokenConfigured: false
-    }
-  }
-  if (!config.apiBaseUrl) {
-    return {
-      configured: true,
-      authenticated: true,
-      account: null,
-      baseUrl: null,
-      tokenConfigured
-    }
-  }
-
-  if (!tokenConfigured) {
-    const version = await requestJsonAtBase<{ version?: string }>(config.apiBaseUrl, '/version', {
-      timeoutMs: 4000
-    })
-    return {
-      configured: version !== null,
-      authenticated: false,
-      account: null,
-      baseUrl: config.apiBaseUrl,
-      tokenConfigured
-    }
-  }
-
-  const user = await requestJsonAtBase<{
-    login?: string | null
-    username?: string | null
-    full_name?: string | null
-  }>(config.apiBaseUrl, '/user', { timeoutMs: 4000 })
-  return {
-    configured: true,
-    authenticated: user !== null,
-    account: user?.login ?? user?.username ?? user?.full_name ?? null,
-    baseUrl: config.apiBaseUrl,
-    tokenConfigured
-  }
-}
-
-export async function getGiteaPullRequest(
-  repoPath: string,
-  prNumber: number
-): Promise<GiteaPullRequestInfo | null> {
-  const repo = await getGiteaRepoRef(repoPath)
-  if (!repo) {
-    return null
-  }
-  const raw = await requestJson<RawGiteaPullRequest>(
-    repo,
-    `/repos/${encodedRepoPath(repo)}/pulls/${encodeURIComponent(String(prNumber))}`
-  )
-  return raw ? normalizePullRequest(repo, raw) : null
-}
-
-export async function getGiteaPullRequestForBranch(
+export function getGiteaPullRequestForBranch(
   repoPath: string,
   branch: string,
   linkedPRNumber?: number | null
-): Promise<GiteaPullRequestInfo | null> {
-  const branchName = branch.replace(/^refs\/heads\//, '')
-  if (!branchName && linkedPRNumber == null) {
-    return null
-  }
-
-  const repo = await getGiteaRepoRef(repoPath)
-  if (!repo) {
-    return null
-  }
-
-  if (branchName) {
-    for (let page = 1; page <= MAX_PULL_REQUEST_PAGES; page++) {
-      const list = await requestJson<RawGiteaPullRequest[]>(
-        repo,
-        `/repos/${encodedRepoPath(repo)}/pulls`,
-        {
-          searchParams: {
-            state: 'all',
-            sort: 'recentupdate',
-            page,
-            limit: PULL_REQUEST_PAGE_LIMIT
-          }
-        }
-      )
-      const raw = list?.find((item) => matchesBranch(item, branchName))
-      if (raw) {
-        return normalizePullRequest(repo, raw)
-      }
-      if (!list || list.length < PULL_REQUEST_PAGE_LIMIT) {
-        break
-      }
-    }
-  }
-
-  if (typeof linkedPRNumber !== 'number') {
-    return null
-  }
-  const raw = await requestJson<RawGiteaPullRequest>(
-    repo,
-    `/repos/${encodedRepoPath(repo)}/pulls/${encodeURIComponent(String(linkedPRNumber))}`
+) {
+  return getGiteaCompatiblePullRequestForBranch(
+    GITEA_CLIENT_CONFIG,
+    repoPath,
+    branch,
+    linkedPRNumber
   )
-  return raw ? normalizePullRequest(repo, raw) : null
 }
 
-export async function getGiteaRepoSlug(repoPath: string): Promise<GiteaRepoRef | null> {
+export function getGiteaRepoSlug(repoPath: string): Promise<GiteaRepoRef | null> {
   return getGiteaRepoRef(repoPath)
 }

--- a/src/main/gitea/pull-request-mappers.ts
+++ b/src/main/gitea/pull-request-mappers.ts
@@ -1,129 +1,20 @@
-import type { CheckStatus, PRMergeableState } from '../../shared/types'
+import {
+  deriveGiteaCompatibleCommitStatus,
+  mapGiteaCompatibleMergeable,
+  mapGiteaCompatiblePullRequest,
+  mapGiteaCompatiblePullRequestState,
+  type GiteaCompatiblePullRequestInfo,
+  type RawGiteaCompatibleCombinedStatus,
+  type RawGiteaCompatibleCommitStatus,
+  type RawGiteaCompatiblePullRequest
+} from '../gitea-compatible/pull-request-mappers'
 
-export type RawGiteaPullRequest = {
-  number?: number
-  title?: string
-  state?: string | null
-  html_url?: string | null
-  updated_at?: string | null
-  merged?: boolean | null
-  draft?: boolean | null
-  mergeable?: boolean | null
-  head?: {
-    ref?: string | null
-    label?: string | null
-    sha?: string | null
-  } | null
-}
+export type RawGiteaPullRequest = RawGiteaCompatiblePullRequest
+export type GiteaPullRequestInfo = GiteaCompatiblePullRequestInfo
+export type RawGiteaCombinedStatus = RawGiteaCompatibleCombinedStatus
+export type RawGiteaCommitStatus = RawGiteaCompatibleCommitStatus
 
-export type GiteaPullRequestInfo = {
-  number: number
-  title: string
-  state: 'open' | 'closed' | 'merged' | 'draft'
-  url: string
-  status: CheckStatus
-  updatedAt: string
-  mergeable: PRMergeableState
-  headSha?: string
-}
-
-export type RawGiteaCombinedStatus = {
-  state?: string | null
-  statuses?: RawGiteaCommitStatus[] | null
-}
-
-export type RawGiteaCommitStatus = {
-  status?: string | null
-  state?: string | null
-}
-
-function classifyGiteaStatus(status: string | null | undefined): CheckStatus {
-  switch (status?.trim().toLowerCase()) {
-    case 'success':
-      return 'success'
-    case 'failure':
-    case 'error':
-    case 'warning':
-      return 'failure'
-    case 'pending':
-      return 'pending'
-    case 'skipped':
-    default:
-      return 'neutral'
-  }
-}
-
-export function deriveGiteaCommitStatus(rollup: RawGiteaCombinedStatus | null): CheckStatus {
-  if (!rollup) {
-    return 'neutral'
-  }
-  const combined = classifyGiteaStatus(rollup.state)
-  if (combined !== 'neutral') {
-    return combined
-  }
-  const statuses = rollup.statuses ?? []
-  if (statuses.length === 0) {
-    return 'neutral'
-  }
-
-  let hasPending = false
-  for (const status of statuses) {
-    const classified = classifyGiteaStatus(status.status ?? status.state)
-    if (classified === 'failure') {
-      return 'failure'
-    }
-    if (classified === 'pending') {
-      hasPending = true
-    }
-  }
-  if (hasPending) {
-    return 'pending'
-  }
-  return statuses.every(
-    (status) => classifyGiteaStatus(status.status ?? status.state) === 'success'
-  )
-    ? 'success'
-    : 'neutral'
-}
-
-export function mapGiteaPullRequestState(
-  raw: Pick<RawGiteaPullRequest, 'draft' | 'merged' | 'state'>
-): GiteaPullRequestInfo['state'] {
-  if (raw.merged) {
-    return 'merged'
-  }
-  if (raw.draft) {
-    return 'draft'
-  }
-  return raw.state?.trim().toLowerCase() === 'closed' ? 'closed' : 'open'
-}
-
-export function mapGiteaMergeable(value: boolean | null | undefined): PRMergeableState {
-  if (value === true) {
-    return 'MERGEABLE'
-  }
-  if (value === false) {
-    return 'CONFLICTING'
-  }
-  return 'UNKNOWN'
-}
-
-export function mapGiteaPullRequest(
-  raw: RawGiteaPullRequest,
-  status: CheckStatus
-): GiteaPullRequestInfo | null {
-  if (typeof raw.number !== 'number' || !raw.title || !raw.html_url) {
-    return null
-  }
-  const headSha = raw.head?.sha?.trim()
-  return {
-    number: raw.number,
-    title: raw.title,
-    state: mapGiteaPullRequestState(raw),
-    url: raw.html_url,
-    status,
-    updatedAt: raw.updated_at ?? '',
-    mergeable: mapGiteaMergeable(raw.mergeable),
-    ...(headSha ? { headSha } : {})
-  }
-}
+export const deriveGiteaCommitStatus = deriveGiteaCompatibleCommitStatus
+export const mapGiteaPullRequestState = mapGiteaCompatiblePullRequestState
+export const mapGiteaMergeable = mapGiteaCompatibleMergeable
+export const mapGiteaPullRequest = mapGiteaCompatiblePullRequest

--- a/src/main/gitea/repository-ref.test.ts
+++ b/src/main/gitea/repository-ref.test.ts
@@ -60,6 +60,7 @@ describe('Gitea repository ref parsing', () => {
     expect(parseGiteaRepoRef('git@github.com:team/project.git')).toBeNull()
     expect(parseGiteaRepoRef('https://gitlab.com/team/project.git')).toBeNull()
     expect(parseGiteaRepoRef('https://bitbucket.org/team/project.git')).toBeNull()
+    expect(parseGiteaRepoRef('https://codeberg.org/team/project.git')).toBeNull()
   })
 
   it('reads and caches the origin remote', async () => {

--- a/src/main/gitea/repository-ref.ts
+++ b/src/main/gitea/repository-ref.ts
@@ -1,131 +1,35 @@
-import { gitExecFileAsync } from '../git/runner'
+import {
+  createGiteaCompatibleRepoRefResolver,
+  parseGiteaCompatibleRepoRef,
+  type GiteaCompatibleRepoRef,
+  type GiteaCompatibleRepoRefOptions
+} from '../gitea-compatible/repository-ref'
 
-export type GiteaRepoRef = {
-  host: string
-  owner: string
-  repo: string
-  apiBaseUrl: string
-  webBaseUrl: string
+export type GiteaRepoRef = GiteaCompatibleRepoRef
+
+const GITEA_REPO_REF_OPTIONS: GiteaCompatibleRepoRefOptions = {
+  excludedHosts: ['github.com', 'gitlab.com', 'bitbucket.org', 'codeberg.org'],
+  allowUnknownHosts: true
 }
 
-const KNOWN_NON_GITEA_HOSTS = new Set(['github.com', 'gitlab.com', 'bitbucket.org'])
-const repoRefCache = new Map<string, GiteaRepoRef | null>()
+const resolver = createGiteaCompatibleRepoRefResolver(GITEA_REPO_REF_OPTIONS)
 
 /** @internal - exposed for tests only */
 export function _resetGiteaRepoRefCache(): void {
-  repoRefCache.clear()
-}
-
-function decodeSegment(value: string): string {
-  try {
-    return decodeURIComponent(value)
-  } catch {
-    return value
-  }
-}
-
-function parsePath(pathname: string): { owner: string; repo: string; basePath: string } | null {
-  const withoutSuffix = pathname.replace(/\.git$/i, '')
-  const parts = withoutSuffix
-    .split('/')
-    .map((part) => part.trim())
-    .filter(Boolean)
-  if (parts.length < 2) {
-    return null
-  }
-
-  const owner = decodeSegment(parts.at(-2) ?? '')
-  const repo = decodeSegment(parts.at(-1) ?? '')
-  if (!owner || !repo) {
-    return null
-  }
-
-  return {
-    owner,
-    repo,
-    basePath: parts.slice(0, -2).join('/')
-  }
-}
-
-function apiBaseUrlFromWebBase(webBaseUrl: string): string {
-  return `${webBaseUrl.replace(/\/+$/, '')}/api/v1`
-}
-
-function makeRepoRef(host: string, path: string, webBaseUrl: string): GiteaRepoRef | null {
-  const normalizedHost = host.toLowerCase()
-  if (!normalizedHost || KNOWN_NON_GITEA_HOSTS.has(normalizedHost)) {
-    return null
-  }
-
-  const parsed = parsePath(path)
-  if (!parsed) {
-    return null
-  }
-
-  return {
-    host: normalizedHost,
-    owner: parsed.owner,
-    repo: parsed.repo,
-    apiBaseUrl: apiBaseUrlFromWebBase(webBaseUrl),
-    webBaseUrl
-  }
+  resolver.reset()
 }
 
 export function parseGiteaRepoRef(remoteUrl: string): GiteaRepoRef | null {
-  const trimmed = remoteUrl.trim()
-  if (!/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)) {
-    const scpLike = trimmed.match(/^(?:[^@/:]+@)?([^:\s/]+):([^\s]+?)(?:\.git)?$/)
-    if (scpLike) {
-      const host = scpLike[1]
-      const path = scpLike[2]
-      return makeRepoRef(host, path, `https://${host.toLowerCase()}`)
-    }
-  }
-
-  try {
-    const url = new URL(trimmed)
-    const protocol = url.protocol.toLowerCase()
-    if (!['http:', 'https:', 'ssh:', 'git+ssh:'].includes(protocol)) {
-      return null
-    }
-
-    const parsed = parsePath(url.pathname)
-    if (!parsed) {
-      return null
-    }
-
-    const webOrigin =
-      protocol === 'http:' || protocol === 'https:'
-        ? `${protocol}//${url.host}`
-        : `https://${url.hostname.toLowerCase()}`
-    const webBaseUrl = parsed.basePath ? `${webOrigin}/${parsed.basePath}` : webOrigin
-    return makeRepoRef(url.hostname, url.pathname, webBaseUrl)
-  } catch {
-    return null
-  }
+  return parseGiteaCompatibleRepoRef(remoteUrl, GITEA_REPO_REF_OPTIONS)
 }
 
-export async function getGiteaRepoRefForRemote(
+export function getGiteaRepoRefForRemote(
   repoPath: string,
   remoteName: string
 ): Promise<GiteaRepoRef | null> {
-  const cacheKey = `${repoPath}\0${remoteName}`
-  if (repoRefCache.has(cacheKey)) {
-    return repoRefCache.get(cacheKey)!
-  }
-  try {
-    const { stdout } = await gitExecFileAsync(['remote', 'get-url', remoteName], {
-      cwd: repoPath
-    })
-    const result = parseGiteaRepoRef(stdout)
-    repoRefCache.set(cacheKey, result)
-    return result
-  } catch {
-    repoRefCache.set(cacheKey, null)
-    return null
-  }
+  return resolver.getRepoRefForRemote(repoPath, remoteName)
 }
 
-export async function getGiteaRepoRef(repoPath: string): Promise<GiteaRepoRef | null> {
-  return getGiteaRepoRefForRemote(repoPath, 'origin')
+export function getGiteaRepoRef(repoPath: string): Promise<GiteaRepoRef | null> {
+  return resolver.getRepoRef(repoPath)
 }

--- a/src/main/ipc/hosted-review.ts
+++ b/src/main/ipc/hosted-review.ts
@@ -24,6 +24,7 @@ export function registerHostedReviewHandlers(store: Store, stats: StatsCollector
       linkedGitHubPR: args.linkedGitHubPR ?? null,
       linkedGitLabMR: args.linkedGitLabMR ?? null,
       linkedBitbucketPR: args.linkedBitbucketPR ?? null,
+      linkedForgejoPR: args.linkedForgejoPR ?? null,
       linkedGiteaPR: args.linkedGiteaPR ?? null
     })
     if (review?.provider === 'github' && !stats.hasCountedPR(review.url)) {

--- a/src/main/ipc/preflight.test.ts
+++ b/src/main/ipc/preflight.test.ts
@@ -9,6 +9,7 @@ const {
   hydrateShellPathMock,
   mergePathSegmentsMock,
   getBitbucketAuthStatusMock,
+  getForgejoAuthStatusMock,
   getGiteaAuthStatusMock
 } = vi.hoisted(() => ({
   handleMock: vi.fn(),
@@ -17,6 +18,7 @@ const {
   hydrateShellPathMock: vi.fn(),
   mergePathSegmentsMock: vi.fn(),
   getBitbucketAuthStatusMock: vi.fn(),
+  getForgejoAuthStatusMock: vi.fn(),
   getGiteaAuthStatusMock: vi.fn()
 }))
 
@@ -45,6 +47,10 @@ vi.mock('../bitbucket/client', () => ({
   getBitbucketAuthStatus: getBitbucketAuthStatusMock
 }))
 
+vi.mock('../forgejo/client', () => ({
+  getForgejoAuthStatus: getForgejoAuthStatusMock
+}))
+
 vi.mock('../gitea/client', () => ({
   getGiteaAuthStatus: getGiteaAuthStatusMock
 }))
@@ -68,6 +74,7 @@ describe('preflight', () => {
     baseUrl: null,
     tokenConfigured: false
   }
+  const defaultForgejoStatus = defaultGiteaStatus
 
   beforeEach(() => {
     handleMock.mockReset()
@@ -75,8 +82,10 @@ describe('preflight', () => {
     hydrateShellPathMock.mockReset()
     mergePathSegmentsMock.mockReset()
     getBitbucketAuthStatusMock.mockReset()
+    getForgejoAuthStatusMock.mockReset()
     getGiteaAuthStatusMock.mockReset()
     getBitbucketAuthStatusMock.mockResolvedValue(defaultBitbucketStatus)
+    getForgejoAuthStatusMock.mockResolvedValue(defaultForgejoStatus)
     getGiteaAuthStatusMock.mockResolvedValue(defaultGiteaStatus)
     _resetPreflightCache()
 
@@ -107,6 +116,7 @@ describe('preflight', () => {
       gh: { installed: true, authenticated: true },
       glab: { installed: true, authenticated: true },
       bitbucket: defaultBitbucketStatus,
+      forgejo: defaultForgejoStatus,
       gitea: defaultGiteaStatus
     })
     expect(execFileAsyncMock).toHaveBeenNthCalledWith(4, 'gh', ['auth', 'status'], {
@@ -209,6 +219,7 @@ describe('preflight', () => {
       gh: { installed: true, authenticated: true },
       glab: { installed: true, authenticated: true },
       bitbucket: defaultBitbucketStatus,
+      forgejo: defaultForgejoStatus,
       gitea: defaultGiteaStatus
     })
   })
@@ -236,6 +247,7 @@ describe('preflight', () => {
       gh: { installed: true, authenticated: false },
       glab: { installed: true, authenticated: true },
       bitbucket: defaultBitbucketStatus,
+      forgejo: defaultForgejoStatus,
       gitea: defaultGiteaStatus
     })
     expect(refreshedStatus).toEqual({
@@ -243,6 +255,7 @@ describe('preflight', () => {
       gh: { installed: true, authenticated: true },
       glab: { installed: true, authenticated: true },
       bitbucket: defaultBitbucketStatus,
+      forgejo: defaultForgejoStatus,
       gitea: defaultGiteaStatus
     })
   })

--- a/src/main/ipc/preflight.ts
+++ b/src/main/ipc/preflight.ts
@@ -6,6 +6,7 @@ import { TUI_AGENT_CONFIG } from '../../shared/tui-agent-config'
 import type { PathSource, ShellHydrationFailureReason } from '../../shared/types'
 import { hydrateShellPath, mergePathSegments } from '../startup/hydrate-shell-path'
 import { getBitbucketAuthStatus } from '../bitbucket/client'
+import { getForgejoAuthStatus } from '../forgejo/client'
 import { getGiteaAuthStatus } from '../gitea/client'
 import { getActiveMultiplexer } from './ssh'
 
@@ -20,6 +21,13 @@ export type PreflightStatus = {
   // gate on `glab?.authenticated`.
   glab?: { installed: boolean; authenticated: boolean }
   bitbucket?: { configured: boolean; authenticated: boolean; account: string | null }
+  forgejo?: {
+    configured: boolean
+    authenticated: boolean
+    account: string | null
+    baseUrl: string | null
+    tokenConfigured: boolean
+  }
   gitea?: {
     configured: boolean
     authenticated: boolean
@@ -169,10 +177,11 @@ export async function runPreflightCheck(force = false): Promise<PreflightStatus>
     isCommandAvailable('glab')
   ])
 
-  const [ghAuthenticated, glabAuthenticated, bitbucket, gitea] = await Promise.all([
+  const [ghAuthenticated, glabAuthenticated, bitbucket, forgejo, gitea] = await Promise.all([
     ghInstalled ? isGhAuthenticated() : Promise.resolve(false),
     glabInstalled ? isGlabAuthenticated() : Promise.resolve(false),
     getBitbucketAuthStatus(),
+    getForgejoAuthStatus(),
     getGiteaAuthStatus()
   ])
 
@@ -181,6 +190,7 @@ export async function runPreflightCheck(force = false): Promise<PreflightStatus>
     gh: { installed: ghInstalled, authenticated: ghAuthenticated },
     glab: { installed: glabInstalled, authenticated: glabAuthenticated },
     bitbucket,
+    forgejo,
     gitea
   }
 

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -4455,6 +4455,7 @@ export class OrcaRuntimeService {
     linkedGitHubPR?: number | null
     linkedGitLabMR?: number | null
     linkedBitbucketPR?: number | null
+    linkedForgejoPR?: number | null
     linkedGiteaPR?: number | null
   }): Promise<HostedReviewInfo | null> {
     const repo = await this.resolveRepoSelector(args.repoSelector)
@@ -4465,6 +4466,7 @@ export class OrcaRuntimeService {
       linkedGitHubPR: args.linkedGitHubPR ?? null,
       linkedGitLabMR: args.linkedGitLabMR ?? null,
       linkedBitbucketPR: args.linkedBitbucketPR ?? null,
+      linkedForgejoPR: args.linkedForgejoPR ?? null,
       linkedGiteaPR: args.linkedGiteaPR ?? null
     })
     if (review?.provider === 'github' && this.stats && !this.stats.hasCountedPR(review.url)) {

--- a/src/main/runtime/rpc/methods/hosted-review.test.ts
+++ b/src/main/runtime/rpc/methods/hosted-review.test.ts
@@ -39,6 +39,7 @@ describe('hosted review RPC methods', () => {
       linkedGitHubPR: 12,
       linkedGitLabMR: null,
       linkedBitbucketPR: null,
+      linkedForgejoPR: null,
       linkedGiteaPR: null
     })
     expect(response).toMatchObject({

--- a/src/main/runtime/rpc/methods/hosted-review.ts
+++ b/src/main/runtime/rpc/methods/hosted-review.ts
@@ -8,6 +8,7 @@ const HostedReviewForBranch = z.object({
   linkedGitHubPR: z.number().int().positive().nullable().optional(),
   linkedGitLabMR: z.number().int().positive().nullable().optional(),
   linkedBitbucketPR: z.number().int().positive().nullable().optional(),
+  linkedForgejoPR: z.number().int().positive().nullable().optional(),
   linkedGiteaPR: z.number().int().positive().nullable().optional()
 })
 
@@ -22,6 +23,7 @@ export const HOSTED_REVIEW_METHODS: RpcMethod[] = [
         linkedGitHubPR: params.linkedGitHubPR ?? null,
         linkedGitLabMR: params.linkedGitLabMR ?? null,
         linkedBitbucketPR: params.linkedBitbucketPR ?? null,
+        linkedForgejoPR: params.linkedForgejoPR ?? null,
         linkedGiteaPR: params.linkedGiteaPR ?? null
       })
   })

--- a/src/main/source-control/hosted-review-forgejo.integration.test.ts
+++ b/src/main/source-control/hosted-review-forgejo.integration.test.ts
@@ -1,0 +1,123 @@
+import { execFile } from 'child_process'
+import { mkdtemp, rm } from 'fs/promises'
+import { createServer, type IncomingMessage, type ServerResponse } from 'http'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { promisify } from 'util'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { _resetForgejoRepoRefCache } from '../forgejo/repository-ref'
+import { _resetGiteaRepoRefCache } from '../gitea/repository-ref'
+import { getHostedReviewForBranch } from './hosted-review'
+
+const execFileAsync = promisify(execFile)
+const OLD_ENV = process.env
+
+type SeenRequest = {
+  pathname: string
+  search: string
+  authorization: string | undefined
+}
+
+function sendJson(res: ServerResponse, body: unknown): void {
+  res.writeHead(200, { 'Content-Type': 'application/json' })
+  res.end(JSON.stringify(body))
+}
+
+describe('Forgejo hosted review integration', () => {
+  beforeEach(() => {
+    process.env = { ...OLD_ENV, ORCA_FORGEJO_TOKEN: 'local-forgejo-token' }
+    delete process.env.ORCA_FORGEJO_API_BASE_URL
+    delete process.env.ORCA_GITEA_TOKEN
+    delete process.env.ORCA_GITEA_API_BASE_URL
+    _resetForgejoRepoRefCache()
+    _resetGiteaRepoRefCache()
+  })
+
+  afterEach(() => {
+    process.env = OLD_ENV
+    _resetForgejoRepoRefCache()
+    _resetGiteaRepoRefCache()
+  })
+
+  it('resolves a Forgejo PR through real git remote parsing and HTTP API calls', async () => {
+    const seen: SeenRequest[] = []
+    const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+      const url = new URL(req.url ?? '/', `http://${req.headers.host ?? '127.0.0.1'}`)
+      seen.push({
+        pathname: url.pathname,
+        search: url.search,
+        authorization: req.headers.authorization
+      })
+
+      if (url.pathname === '/api/v1/repos/team/repo/pulls') {
+        sendJson(res, [
+          {
+            number: 19,
+            title: 'Local Forgejo branch',
+            state: 'open',
+            html_url: 'http://forgejo.localhost/team/repo/pulls/19',
+            updated_at: '2026-05-15T00:00:00Z',
+            mergeable: true,
+            head: { ref: 'feature/forgejo', label: 'team:feature/forgejo', sha: 'def456' }
+          }
+        ])
+        return
+      }
+
+      if (url.pathname === '/api/v1/repos/team/repo/commits/def456/status') {
+        sendJson(res, { state: 'pending' })
+        return
+      }
+
+      res.writeHead(404, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ message: 'not found' }))
+    })
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+
+    const repoPath = await mkdtemp(join(tmpdir(), 'orca-forgejo-review-'))
+    try {
+      const address = server.address()
+      if (!address || typeof address === 'string') {
+        throw new Error('expected TCP server address')
+      }
+      process.env.ORCA_FORGEJO_API_BASE_URL = `http://127.0.0.1:${address.port}`
+
+      await execFileAsync('git', ['init'], { cwd: repoPath })
+      await execFileAsync(
+        'git',
+        ['remote', 'add', 'origin', 'https://git.example.com/team/repo.git'],
+        {
+          cwd: repoPath
+        }
+      )
+
+      await expect(
+        getHostedReviewForBranch({ repoPath, branch: 'refs/heads/feature/forgejo' })
+      ).resolves.toEqual({
+        provider: 'forgejo',
+        number: 19,
+        title: 'Local Forgejo branch',
+        state: 'open',
+        url: 'http://forgejo.localhost/team/repo/pulls/19',
+        status: 'pending',
+        updatedAt: '2026-05-15T00:00:00Z',
+        mergeable: 'MERGEABLE',
+        headSha: 'def456'
+      })
+
+      expect(seen.map((request) => request.pathname)).toEqual([
+        '/api/v1/repos/team/repo/pulls',
+        '/api/v1/repos/team/repo/commits/def456/status'
+      ])
+      expect(seen.every((request) => request.authorization === 'token local-forgejo-token')).toBe(
+        true
+      )
+      expect(new URLSearchParams(seen[0].search).get('state')).toBe('all')
+    } finally {
+      await rm(repoPath, { recursive: true, force: true })
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()))
+      })
+    }
+  })
+})

--- a/src/main/source-control/hosted-review.test.ts
+++ b/src/main/source-control/hosted-review.test.ts
@@ -7,6 +7,8 @@ const {
   getPRForBranchMock,
   getBitbucketRepoSlugMock,
   getBitbucketPullRequestForBranchMock,
+  getForgejoRepoSlugMock,
+  getForgejoPullRequestForBranchMock,
   getGiteaRepoSlugMock,
   getGiteaPullRequestForBranchMock
 } = vi.hoisted(() => ({
@@ -16,6 +18,8 @@ const {
   getPRForBranchMock: vi.fn(),
   getBitbucketRepoSlugMock: vi.fn(),
   getBitbucketPullRequestForBranchMock: vi.fn(),
+  getForgejoRepoSlugMock: vi.fn(),
+  getForgejoPullRequestForBranchMock: vi.fn(),
   getGiteaRepoSlugMock: vi.fn(),
   getGiteaPullRequestForBranchMock: vi.fn()
 }))
@@ -37,6 +41,12 @@ vi.mock('../bitbucket/client', () => ({
   getBitbucketPullRequest: vi.fn()
 }))
 
+vi.mock('../forgejo/client', () => ({
+  getForgejoRepoSlug: getForgejoRepoSlugMock,
+  getForgejoPullRequestForBranch: getForgejoPullRequestForBranchMock,
+  getForgejoPullRequest: vi.fn()
+}))
+
 vi.mock('../gitea/client', () => ({
   getGiteaRepoSlug: getGiteaRepoSlugMock,
   getGiteaPullRequestForBranch: getGiteaPullRequestForBranchMock,
@@ -53,6 +63,8 @@ describe('getHostedReviewForBranch', () => {
     getPRForBranchMock.mockReset()
     getBitbucketRepoSlugMock.mockReset()
     getBitbucketPullRequestForBranchMock.mockReset()
+    getForgejoRepoSlugMock.mockReset()
+    getForgejoPullRequestForBranchMock.mockReset()
     getGiteaRepoSlugMock.mockReset()
     getGiteaPullRequestForBranchMock.mockReset()
   })
@@ -154,6 +166,7 @@ describe('getHostedReviewForBranch', () => {
     getProjectSlugMock.mockResolvedValue(null)
     getRepoSlugMock.mockResolvedValue(null)
     getBitbucketRepoSlugMock.mockResolvedValue(null)
+    getForgejoRepoSlugMock.mockResolvedValue(null)
     getGiteaRepoSlugMock.mockResolvedValue({
       host: 'git.example.com',
       owner: 'team',
@@ -188,5 +201,46 @@ describe('getHostedReviewForBranch', () => {
       headSha: 'def456'
     })
     expect(getGiteaPullRequestForBranchMock).toHaveBeenCalledWith('/repo', 'feature/gitea', 14)
+  })
+
+  it('falls through to Forgejo before generic Gitea-compatible hosts', async () => {
+    getProjectSlugMock.mockResolvedValue(null)
+    getRepoSlugMock.mockResolvedValue(null)
+    getBitbucketRepoSlugMock.mockResolvedValue(null)
+    getForgejoRepoSlugMock.mockResolvedValue({
+      host: 'code.example.com',
+      owner: 'team',
+      repo: 'orca'
+    })
+    getForgejoPullRequestForBranchMock.mockResolvedValue({
+      number: 16,
+      title: 'Forgejo branch',
+      state: 'open',
+      url: 'https://code.example.com/team/orca/pulls/16',
+      status: 'success',
+      updatedAt: '2026-05-15T00:00:00.000Z',
+      mergeable: 'MERGEABLE',
+      headSha: 'abc999'
+    })
+
+    await expect(
+      getHostedReviewForBranch({
+        repoPath: '/repo',
+        branch: 'feature/forgejo',
+        linkedForgejoPR: 16
+      })
+    ).resolves.toEqual({
+      provider: 'forgejo',
+      number: 16,
+      title: 'Forgejo branch',
+      state: 'open',
+      url: 'https://code.example.com/team/orca/pulls/16',
+      status: 'success',
+      updatedAt: '2026-05-15T00:00:00.000Z',
+      mergeable: 'MERGEABLE',
+      headSha: 'abc999'
+    })
+    expect(getForgejoPullRequestForBranchMock).toHaveBeenCalledWith('/repo', 'feature/forgejo', 16)
+    expect(getGiteaRepoSlugMock).not.toHaveBeenCalled()
   })
 })

--- a/src/main/source-control/hosted-review.ts
+++ b/src/main/source-control/hosted-review.ts
@@ -7,6 +7,12 @@ import {
 } from '../bitbucket/client'
 import type { BitbucketPullRequestInfo } from '../bitbucket/pull-request-mappers'
 import {
+  getForgejoPullRequest,
+  getForgejoPullRequestForBranch,
+  getForgejoRepoSlug
+} from '../forgejo/client'
+import type { ForgejoPullRequestInfo } from '../forgejo/pull-request-mappers'
+import {
   getGiteaPullRequest,
   getGiteaPullRequestForBranch,
   getGiteaRepoSlug
@@ -66,6 +72,20 @@ function mapBitbucketReview(pr: BitbucketPullRequestInfo): HostedReviewInfo {
   }
 }
 
+function mapForgejoReview(pr: ForgejoPullRequestInfo): HostedReviewInfo {
+  return {
+    provider: 'forgejo',
+    number: pr.number,
+    title: pr.title,
+    state: pr.state,
+    url: pr.url,
+    status: pr.status,
+    updatedAt: pr.updatedAt,
+    mergeable: pr.mergeable,
+    ...(pr.headSha ? { headSha: pr.headSha } : {})
+  }
+}
+
 function mapGiteaReview(pr: GiteaPullRequestInfo): HostedReviewInfo {
   return {
     provider: 'gitea',
@@ -86,6 +106,7 @@ export async function getHostedReviewForBranch(input: {
   linkedGitHubPR?: number | null
   linkedGitLabMR?: number | null
   linkedBitbucketPR?: number | null
+  linkedForgejoPR?: number | null
   linkedGiteaPR?: number | null
 }): Promise<HostedReviewInfo | null> {
   const branchName = input.branch.replace(/^refs\/heads\//, '')
@@ -94,6 +115,7 @@ export async function getHostedReviewForBranch(input: {
     input.linkedGitHubPR == null &&
     input.linkedGitLabMR == null &&
     input.linkedBitbucketPR == null &&
+    input.linkedForgejoPR == null &&
     input.linkedGiteaPR == null
   ) {
     return null
@@ -126,6 +148,16 @@ export async function getHostedReviewForBranch(input: {
     return pr ? mapBitbucketReview(pr) : null
   }
 
+  const forgejoRepo = await getForgejoRepoSlug(input.repoPath)
+  if (forgejoRepo) {
+    const pr = await getForgejoPullRequestForBranch(
+      input.repoPath,
+      branchName,
+      input.linkedForgejoPR ?? null
+    )
+    return pr ? mapForgejoReview(pr) : null
+  }
+
   const giteaRepo = await getGiteaRepoSlug(input.repoPath)
   if (giteaRepo) {
     const pr = await getGiteaPullRequestForBranch(
@@ -141,7 +173,7 @@ export async function getHostedReviewForBranch(input: {
 
 export async function getHostedReviewByNumber(input: {
   repoPath: string
-  provider: 'github' | 'gitlab' | 'bitbucket' | 'gitea'
+  provider: 'github' | 'gitlab' | 'bitbucket' | 'forgejo' | 'gitea'
   number: number
 }): Promise<HostedReviewInfo | null> {
   if (input.provider === 'gitlab') {
@@ -151,6 +183,10 @@ export async function getHostedReviewByNumber(input: {
   if (input.provider === 'bitbucket') {
     const pr = await getBitbucketPullRequest(input.repoPath, input.number)
     return pr ? mapBitbucketReview(pr) : null
+  }
+  if (input.provider === 'forgejo') {
+    const pr = await getForgejoPullRequest(input.repoPath, input.number)
+    return pr ? mapForgejoReview(pr) : null
   }
   if (input.provider === 'gitea') {
     const pr = await getGiteaPullRequest(input.repoPath, input.number)

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -312,6 +312,13 @@ export type PreflightStatus = {
    *  include it. Consumers gate on `glab?.installed` / `authenticated`. */
   glab?: { installed: boolean; authenticated: boolean }
   bitbucket?: { configured: boolean; authenticated: boolean; account: string | null }
+  forgejo?: {
+    configured: boolean
+    authenticated: boolean
+    account: string | null
+    baseUrl: string | null
+    tokenConfigured: boolean
+  }
   gitea?: {
     configured: boolean
     authenticated: boolean

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1068,6 +1068,13 @@ const api = {
       gh: { installed: boolean; authenticated: boolean }
       glab?: { installed: boolean; authenticated: boolean }
       bitbucket?: { configured: boolean; authenticated: boolean; account: string | null }
+      forgejo?: {
+        configured: boolean
+        authenticated: boolean
+        account: string | null
+        baseUrl: string | null
+        tokenConfigured: boolean
+      }
       gitea?: {
         configured: boolean
         authenticated: boolean

--- a/src/renderer/src/components/settings/IntegrationsPane.tsx
+++ b/src/renderer/src/components/settings/IntegrationsPane.tsx
@@ -59,6 +59,11 @@ export const INTEGRATIONS_PANE_SEARCH_ENTRIES: SettingsSearchEntry[] = [
     keywords: ['gitea', 'self-hosted', 'integration', 'pull request', 'api token']
   },
   {
+    title: 'Forgejo Integration',
+    description: 'Forgejo authentication via API token environment variables.',
+    keywords: ['forgejo', 'self-hosted', 'integration', 'pull request', 'api token']
+  },
+  {
     title: 'Linear Integration',
     description: 'Connect Linear to browse and link issues.',
     keywords: ['linear', 'integration', 'api key', 'connect', 'disconnect']
@@ -71,8 +76,9 @@ type GhStatus = 'checking' | 'connected' | 'not-installed' | 'not-authenticated'
 type GlabStatus = GhStatus
 type BitbucketStatus = 'checking' | 'connected' | 'not-configured' | 'not-authenticated'
 type GiteaStatus = 'checking' | 'configured' | 'not-configured' | 'not-authenticated'
+type ForgejoStatus = GiteaStatus
 
-type GiteaPreflightStatus = {
+type GiteaCompatiblePreflightStatus = {
   configured: boolean
   authenticated: boolean
   account: string | null
@@ -80,7 +86,9 @@ type GiteaPreflightStatus = {
   tokenConfigured: boolean
 }
 
-function giteaStatusFromPreflight(status: GiteaPreflightStatus | undefined): GiteaStatus {
+function giteaCompatibleStatusFromPreflight(
+  status: GiteaCompatiblePreflightStatus | undefined
+): GiteaStatus {
   if (!status?.configured) {
     return 'not-configured'
   }
@@ -101,6 +109,9 @@ export function IntegrationsPane(): React.JSX.Element {
   const [glabStatus, setGlabStatus] = useState<GlabStatus>('checking')
   const [bitbucketStatus, setBitbucketStatus] = useState<BitbucketStatus>('checking')
   const [bitbucketAccount, setBitbucketAccount] = useState<string | null>(null)
+  const [forgejoStatus, setForgejoStatus] = useState<ForgejoStatus>('checking')
+  const [forgejoAccount, setForgejoAccount] = useState<string | null>(null)
+  const [forgejoBaseUrl, setForgejoBaseUrl] = useState<string | null>(null)
   const [giteaStatus, setGiteaStatus] = useState<GiteaStatus>('checking')
   const [giteaAccount, setGiteaAccount] = useState<string | null>(null)
   const [giteaBaseUrl, setGiteaBaseUrl] = useState<string | null>(null)
@@ -145,10 +156,14 @@ export function IntegrationsPane(): React.JSX.Element {
       } else {
         setBitbucketStatus('connected')
       }
+      const forgejo = status.forgejo
+      setForgejoAccount(forgejo?.account ?? null)
+      setForgejoBaseUrl(forgejo?.baseUrl ?? null)
+      setForgejoStatus(giteaCompatibleStatusFromPreflight(forgejo))
       const gitea = status.gitea
       setGiteaAccount(gitea?.account ?? null)
       setGiteaBaseUrl(gitea?.baseUrl ?? null)
-      setGiteaStatus(giteaStatusFromPreflight(gitea))
+      setGiteaStatus(giteaCompatibleStatusFromPreflight(gitea))
     })
     // eslint-disable-next-line react-hooks/exhaustive-deps -- one-shot mount check
   }, [])
@@ -247,7 +262,17 @@ export function IntegrationsPane(): React.JSX.Element {
       const gitea = status.gitea
       setGiteaAccount(gitea?.account ?? null)
       setGiteaBaseUrl(gitea?.baseUrl ?? null)
-      setGiteaStatus(giteaStatusFromPreflight(gitea))
+      setGiteaStatus(giteaCompatibleStatusFromPreflight(gitea))
+    })
+  }
+
+  const handleRefreshForgejo = (): void => {
+    setForgejoStatus('checking')
+    void window.api.preflight.check({ force: true }).then((status) => {
+      const forgejo = status.forgejo
+      setForgejoAccount(forgejo?.account ?? null)
+      setForgejoBaseUrl(forgejo?.baseUrl ?? null)
+      setForgejoStatus(giteaCompatibleStatusFromPreflight(forgejo))
     })
   }
 
@@ -481,6 +506,90 @@ export function IntegrationsPane(): React.JSX.Element {
                     Learn more
                   </Button>
                   <Button variant="ghost" size="sm" onClick={handleRefreshBitbucket}>
+                    Re-check
+                  </Button>
+                </div>
+              </>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Forgejo */}
+      <div className="rounded-md border border-border/50 bg-muted/30 px-4 py-3">
+        <div className="flex items-center gap-3">
+          <GitPullRequestArrow className="size-5 shrink-0 text-muted-foreground" />
+          <div className="min-w-0 flex-1 space-y-0.5">
+            <p className="text-sm font-medium">Forgejo</p>
+            <p className="text-xs text-muted-foreground">
+              {forgejoStatus === 'configured'
+                ? forgejoAccount
+                  ? `${forgejoAccount} · Pull requests and commit statuses`
+                  : forgejoBaseUrl
+                    ? `${forgejoBaseUrl} · Pull requests and commit statuses`
+                    : 'Pull requests and commit statuses for detected repositories'
+                : 'Pull requests and commit statuses via the Forgejo REST API.'}
+            </p>
+          </div>
+          {forgejoStatus === 'checking' ? (
+            <LoaderCircle className="size-4 shrink-0 animate-spin text-muted-foreground" />
+          ) : forgejoStatus === 'configured' ? (
+            <span className="shrink-0 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2.5 py-1 text-[11px] font-medium text-emerald-700 dark:text-emerald-300">
+              {forgejoAccount ? 'Connected' : 'Configured'}
+            </span>
+          ) : (
+            <span className="shrink-0 rounded-full border border-amber-500/30 bg-amber-500/10 px-2.5 py-1 text-[11px] font-medium text-amber-700 dark:text-amber-300">
+              {forgejoStatus === 'not-configured' ? 'Optional setup' : 'Auth failed'}
+            </span>
+          )}
+        </div>
+
+        {forgejoStatus !== 'checking' && forgejoStatus !== 'configured' && (
+          <div className="mt-3 rounded-md border border-border/30 bg-background/50 px-3 py-2.5 space-y-2">
+            {forgejoStatus === 'not-configured' ? (
+              <>
+                <p className="text-xs text-muted-foreground">
+                  Public repositories are detected from their git remote. Set{' '}
+                  <span className="font-mono text-[11px]">ORCA_FORGEJO_TOKEN</span> for private
+                  repositories, and set{' '}
+                  <span className="font-mono text-[11px]">ORCA_FORGEJO_API_BASE_URL</span> for
+                  self-hosted remotes whose host does not identify itself as Forgejo.
+                </p>
+                <div className="flex items-center gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() =>
+                      window.api.shell.openUrl('https://forgejo.org/docs/latest/user/api-usage/')
+                    }
+                  >
+                    <ExternalLink className="size-3.5 mr-1.5" />
+                    Learn more
+                  </Button>
+                  <Button variant="ghost" size="sm" onClick={handleRefreshForgejo}>
+                    Re-check
+                  </Button>
+                </div>
+              </>
+            ) : (
+              <>
+                <p className="text-xs text-muted-foreground">
+                  Forgejo credentials are configured but could not authenticate. Check the token,
+                  API base URL, and repository permissions, then restart Orca if environment
+                  variables changed.
+                </p>
+                <div className="flex items-center gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() =>
+                      window.api.shell.openUrl('https://forgejo.org/docs/latest/user/api-usage/')
+                    }
+                  >
+                    <ExternalLink className="size-3.5 mr-1.5" />
+                    Learn more
+                  </Button>
+                  <Button variant="ghost" size="sm" onClick={handleRefreshForgejo}>
                     Re-check
                   </Button>
                 </div>

--- a/src/renderer/src/components/sidebar/WorktreeCardMeta.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardMeta.tsx
@@ -109,6 +109,9 @@ function getProviderName(review: HostedReviewInfo): string {
   if (review.provider === 'bitbucket') {
     return 'Bitbucket'
   }
+  if (review.provider === 'forgejo') {
+    return 'Forgejo'
+  }
   if (review.provider === 'gitea') {
     return 'Gitea'
   }

--- a/src/renderer/src/store/slices/hosted-review.test.ts
+++ b/src/renderer/src/store/slices/hosted-review.test.ts
@@ -72,6 +72,7 @@ describe('hosted review slice', () => {
       linkedGitHubPR: null,
       linkedGitLabMR: 5,
       linkedBitbucketPR: null,
+      linkedForgejoPR: null,
       linkedGiteaPR: null
     })
   })
@@ -98,6 +99,7 @@ describe('hosted review slice', () => {
         linkedGitHubPR: 12,
         linkedGitLabMR: null,
         linkedBitbucketPR: null,
+        linkedForgejoPR: null,
         linkedGiteaPR: null
       },
       { timeoutMs: 30_000 }

--- a/src/renderer/src/store/slices/hosted-review.ts
+++ b/src/renderer/src/store/slices/hosted-review.ts
@@ -38,6 +38,7 @@ export type HostedReviewSlice = {
       linkedGitHubPR?: number | null
       linkedGitLabMR?: number | null
       linkedBitbucketPR?: number | null
+      linkedForgejoPR?: number | null
       linkedGiteaPR?: number | null
     }
   ) => Promise<HostedReviewInfo | null>
@@ -63,6 +64,7 @@ export const createHostedReviewSlice: StateCreator<AppState, [], [], HostedRevie
       ((options?.linkedGitHubPR ?? null) !== null ||
         (options?.linkedGitLabMR ?? null) !== null ||
         (options?.linkedBitbucketPR ?? null) !== null ||
+        (options?.linkedForgejoPR ?? null) !== null ||
         (options?.linkedGiteaPR ?? null) !== null)
     if (!options?.force && !linkedRefetch && isFresh(cached)) {
       return cached.data
@@ -83,6 +85,7 @@ export const createHostedReviewSlice: StateCreator<AppState, [], [], HostedRevie
           linkedGitHubPR: options?.linkedGitHubPR ?? null,
           linkedGitLabMR: options?.linkedGitLabMR ?? null,
           linkedBitbucketPR: options?.linkedBitbucketPR ?? null,
+          linkedForgejoPR: options?.linkedForgejoPR ?? null,
           linkedGiteaPR: options?.linkedGiteaPR ?? null
         }
         const review =

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -746,7 +746,14 @@ function createPreflightApi(): NonNullable<Partial<PreloadApi>['preflight']> {
     git: { installed: false },
     gh: { installed: false, authenticated: false },
     glab: { installed: false, authenticated: false },
-    bitbucket: { configured: false, authenticated: false, account: null }
+    bitbucket: { configured: false, authenticated: false, account: null },
+    forgejo: {
+      configured: false,
+      authenticated: false,
+      account: null,
+      baseUrl: null,
+      tokenConfigured: false
+    }
   }
   const fallbackRefreshAgents: RefreshAgentsResult = {
     agents: [],

--- a/src/shared/hosted-review.ts
+++ b/src/shared/hosted-review.ts
@@ -1,6 +1,6 @@
 import type { CheckStatus, PRConflictSummary, PRMergeableState } from './types'
 
-export type HostedReviewProvider = 'github' | 'gitlab' | 'bitbucket' | 'gitea'
+export type HostedReviewProvider = 'github' | 'gitlab' | 'bitbucket' | 'forgejo' | 'gitea'
 
 export type HostedReviewState = 'open' | 'closed' | 'merged' | 'draft'
 
@@ -23,5 +23,6 @@ export type HostedReviewForBranchArgs = {
   linkedGitHubPR?: number | null
   linkedGitLabMR?: number | null
   linkedBitbucketPR?: number | null
+  linkedForgejoPR?: number | null
   linkedGiteaPR?: number | null
 }


### PR DESCRIPTION
## Summary
- Add Forgejo as a first-class hosted review provider for branch pull request lookup, linked PR fallback, status mapping, and provider display.
- Extract the compatible REST API parser/client/mappers so Forgejo and the existing compatible provider share the same implementation path.
- Add `ORCA_FORGEJO_TOKEN` and `ORCA_FORGEJO_API_BASE_URL` preflight/settings support; custom self-hosted remotes can opt in with the API base URL when the git remote host is not identifiable.

## Verification
- `pnpm run tc`
- `pnpm run lint`
- `pnpm test`
- Electron dev verification with an isolated profile, temp git repo, and local Forgejo-compatible API: preflight, `repos.add`, `hostedReview.forBranch`, and the settings card all returned the expected Forgejo state.

Risk: high
Historic risk metadata backfill based on the existing `risk:high` label.