### PR TITLE
feat(file-explorer): show gitignored files with dimmed italic decoration

### DIFF
--- a/docs/STYLEGUIDE.md
+++ b/docs/STYLEGUIDE.md
@@ -57,6 +57,7 @@ For diff status, file-tree decorations, and the changes view, use the git decora
 | `--git-decoration-renamed`     | Renamed                        |
 | `--git-decoration-untracked`   | Untracked                      |
 | `--git-decoration-copied`      | Copied                         |
+| `--git-decoration-ignored`     | Ignored by git                 |
 
 Use these *only* for git status. Don't reuse them for unrelated state colors — that breaks the convention.
 

--- a/src/main/git/status.test.ts
+++ b/src/main/git/status.test.ts
@@ -449,8 +449,6 @@ describe('getStatus', () => {
       { cwd: '/repo' }
     )
     expect(result.ignoredPaths).toEqual(['dist/', '.env', 'coverage/'])
-    // Why: ignored entries must never bleed into the staging-area surface or
-    // Source Control would create a phantom group for them.
     expect(result.entries).toEqual([])
   })
 })

--- a/src/main/git/status.test.ts
+++ b/src/main/git/status.test.ts
@@ -405,6 +405,54 @@ describe('getStatus', () => {
     expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(1)
     expect(result.upstreamStatus).toEqual({ hasUpstream: false, ahead: 0, behind: 0 })
   })
+
+  it('omits --ignored and ignoredPaths when includeIgnored is not requested', async () => {
+    readFileMock.mockResolvedValue('gitdir: /repo/.git/worktrees/feature\n')
+    existsSyncMock.mockReturnValue(false)
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' })
+
+    const result = await getStatus('/repo')
+
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
+      [
+        '-c',
+        'core.quotePath=false',
+        'status',
+        '--porcelain=v2',
+        '--branch',
+        '--untracked-files=all'
+      ],
+      { cwd: '/repo' }
+    )
+    expect('ignoredPaths' in result).toBe(false)
+  })
+
+  it('parses ! porcelain v2 records into ignoredPaths when includeIgnored is true', async () => {
+    readFileMock.mockResolvedValue('gitdir: /repo/.git/worktrees/feature\n')
+    existsSyncMock.mockReturnValue(false)
+    gitExecFileAsyncMock.mockResolvedValueOnce({
+      stdout: '! dist/\n! .env\n! coverage/\n'
+    })
+
+    const result = await getStatus('/repo', { includeIgnored: true })
+
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
+      [
+        '-c',
+        'core.quotePath=false',
+        'status',
+        '--porcelain=v2',
+        '--branch',
+        '--untracked-files=all',
+        '--ignored=matching'
+      ],
+      { cwd: '/repo' }
+    )
+    expect(result.ignoredPaths).toEqual(['dist/', '.env', 'coverage/'])
+    // Why: ignored entries must never bleed into the staging-area surface or
+    // Source Control would create a phantom group for them.
+    expect(result.entries).toEqual([])
+  })
 })
 
 describe('getStagedCommitContext', () => {

--- a/src/main/git/status.ts
+++ b/src/main/git/status.ts
@@ -21,11 +21,23 @@ const MAX_GIT_SHOW_BYTES = 10 * 1024 * 1024
 const MAX_STAGED_COMMIT_CONTEXT_BYTES = MAX_GIT_SHOW_BYTES
 const BULK_CHUNK_SIZE = 100
 
+export type GetStatusOptions = {
+  /** When true, adds `--ignored=matching` so the porcelain output includes
+   *  `!` records for files matched by `.gitignore`. Results are surfaced via
+   *  `GitStatusResult.ignoredPaths`, not the `entries` array, so staging-area
+   *  consumers (Source Control) are unaffected. */
+  includeIgnored?: boolean
+}
+
 /**
  * Parse `git status --porcelain=v2` output into structured entries.
  */
-export async function getStatus(worktreePath: string): Promise<GitStatusResult> {
+export async function getStatus(
+  worktreePath: string,
+  options: GetStatusOptions = {}
+): Promise<GitStatusResult> {
   const entries: GitStatusEntry[] = []
+  const ignoredPaths: string[] = []
   let head: string | undefined
   let branch: string | undefined
   let upstreamName: string | undefined
@@ -39,10 +51,22 @@ export async function getStatus(worktreePath: string): Promise<GitStatusResult> 
   // etc.) as raw UTF-8 instead of git's default C-style octal escapes wrapped
   // in double quotes. Without it, the parsed entry.path is unreadable in the
   // sidebar and downstream `git show :"docs/\346..."` lookups silently miss.
-  const statusPromise = gitExecFileAsync(
-    ['-c', 'core.quotePath=false', 'status', '--porcelain=v2', '--branch', '--untracked-files=all'],
-    { cwd: worktreePath }
-  )
+  // Why --ignored=matching (only when requested): lists only files that match
+  // a pattern in .gitignore, NOT the contents of ignored directories. That
+  // keeps the payload bounded on repos with heavy build artifacts while
+  // still letting the explorer dim the matched paths it already shows.
+  const statusArgs = [
+    '-c',
+    'core.quotePath=false',
+    'status',
+    '--porcelain=v2',
+    '--branch',
+    '--untracked-files=all'
+  ]
+  if (options.includeIgnored) {
+    statusArgs.push('--ignored=matching')
+  }
+  const statusPromise = gitExecFileAsync(statusArgs, { cwd: worktreePath })
   const conflictOperation = await conflictPromise
 
   try {
@@ -116,6 +140,10 @@ export async function getStatus(worktreePath: string): Promise<GitStatusResult> 
         // Untracked file
         const path = line.slice(2)
         entries.push({ path, status: 'untracked', area: 'untracked' })
+      } else if (line.startsWith('! ')) {
+        // Why: porcelain v2 `!` records are emitted only when --ignored is set.
+        // Path runs from index 2 to end of line, with no further fields.
+        ignoredPaths.push(line.slice(2))
       } else if (line.startsWith('u ')) {
         const unmergedEntry = await parseUnmergedEntry(worktreePath, line)
         if (unmergedEntry) {
@@ -133,6 +161,10 @@ export async function getStatus(worktreePath: string): Promise<GitStatusResult> 
     conflictOperation,
     head,
     branch,
+    // Why: only attach ignoredPaths when the caller asked for them — keeps the
+    // response shape identical to the pre-feature contract when the setting is
+    // off, so downstream consumers that branch on key presence stay correct.
+    ...(options.includeIgnored ? { ignoredPaths } : {}),
     ...(statusSucceeded
       ? {
           upstreamStatus: upstreamName

--- a/src/main/git/status.ts
+++ b/src/main/git/status.ts
@@ -47,10 +47,6 @@ export async function getStatus(
   // etc.) as raw UTF-8 instead of git's default C-style octal escapes wrapped
   // in double quotes. Without it, the parsed entry.path is unreadable in the
   // sidebar and downstream `git show :"docs/\346..."` lookups silently miss.
-  // Why --ignored=matching (only when requested): lists only files that match
-  // a pattern in .gitignore, NOT the contents of ignored directories. That
-  // keeps the payload bounded on repos with heavy build artifacts while
-  // still letting the explorer dim the matched paths it already shows.
   const statusArgs = [
     '-c',
     'core.quotePath=false',
@@ -137,7 +133,6 @@ export async function getStatus(
         const path = line.slice(2)
         entries.push({ path, status: 'untracked', area: 'untracked' })
       } else if (line.startsWith('! ')) {
-        // Why: porcelain v2 emits `!` records only when --ignored is set.
         ignoredPaths.push(line.slice(2))
       } else if (line.startsWith('u ')) {
         const unmergedEntry = await parseUnmergedEntry(worktreePath, line)

--- a/src/main/git/status.ts
+++ b/src/main/git/status.ts
@@ -22,10 +22,6 @@ const MAX_STAGED_COMMIT_CONTEXT_BYTES = MAX_GIT_SHOW_BYTES
 const BULK_CHUNK_SIZE = 100
 
 export type GetStatusOptions = {
-  /** When true, adds `--ignored=matching` so the porcelain output includes
-   *  `!` records for files matched by `.gitignore`. Results are surfaced via
-   *  `GitStatusResult.ignoredPaths`, not the `entries` array, so staging-area
-   *  consumers (Source Control) are unaffected. */
   includeIgnored?: boolean
 }
 
@@ -141,8 +137,7 @@ export async function getStatus(
         const path = line.slice(2)
         entries.push({ path, status: 'untracked', area: 'untracked' })
       } else if (line.startsWith('! ')) {
-        // Why: porcelain v2 `!` records are emitted only when --ignored is set.
-        // Path runs from index 2 to end of line, with no further fields.
+        // Why: porcelain v2 emits `!` records only when --ignored is set.
         ignoredPaths.push(line.slice(2))
       } else if (line.startsWith('u ')) {
         const unmergedEntry = await parseUnmergedEntry(worktreePath, line)
@@ -161,9 +156,6 @@ export async function getStatus(
     conflictOperation,
     head,
     branch,
-    // Why: only attach ignoredPaths when the caller asked for them — keeps the
-    // response shape identical to the pre-feature contract when the setting is
-    // off, so downstream consumers that branch on key presence stay correct.
     ...(options.includeIgnored ? { ignoredPaths } : {}),
     ...(statusSucceeded
       ? {

--- a/src/main/ipc/filesystem.test.ts
+++ b/src/main/ipc/filesystem.test.ts
@@ -470,7 +470,31 @@ describe('registerFilesystemHandlers', () => {
 
     expect(listWorktreesMock).not.toHaveBeenCalled()
     expect(realpathMock).not.toHaveBeenCalledWith(WORKTREE_FEATURE_PATH)
-    expect(getStatusMock).toHaveBeenCalledWith(WORKTREE_FEATURE_PATH)
+    expect(getStatusMock).toHaveBeenCalledWith(WORKTREE_FEATURE_PATH, { includeIgnored: false })
+  })
+
+  it('forwards includeIgnored through local and SSH git status IPC', async () => {
+    registerWorktreeRootsForRepo(store as never, 'repo-1', [REPO_PATH, WORKTREE_FEATURE_PATH])
+    getStatusMock.mockResolvedValue({ entries: [], conflictOperation: 'unknown' })
+    const sshProvider = {
+      getStatus: vi.fn().mockResolvedValue({ entries: [], conflictOperation: 'unknown' })
+    }
+    getSshGitProviderMock.mockReturnValue(sshProvider)
+
+    registerFilesystemHandlers(store as never)
+
+    await handlers.get('git:status')!(null, {
+      worktreePath: WORKTREE_FEATURE_PATH,
+      includeIgnored: true
+    })
+    await handlers.get('git:status')!(null, {
+      worktreePath: '/remote/repo',
+      connectionId: 'ssh-1',
+      includeIgnored: true
+    })
+
+    expect(getStatusMock).toHaveBeenCalledWith(WORKTREE_FEATURE_PATH, { includeIgnored: true })
+    expect(sshProvider.getStatus).toHaveBeenCalledWith('/remote/repo', { includeIgnored: true })
   })
 
   it('rejects git file paths that escape the selected worktree', async () => {

--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -532,17 +532,18 @@ export function registerFilesystemHandlers(
     'git:status',
     async (
       _event,
-      args: { worktreePath: string; connectionId?: string }
+      args: { worktreePath: string; connectionId?: string; includeIgnored?: boolean }
     ): Promise<GitStatusResult> => {
+      const options = { includeIgnored: args.includeIgnored ?? false }
       if (args.connectionId) {
         const provider = getSshGitProvider(args.connectionId)
         if (!provider) {
           throw new Error(`No git provider for connection "${args.connectionId}"`)
         }
-        return provider.getStatus(args.worktreePath)
+        return provider.getStatus(args.worktreePath, options)
       }
       const worktreePath = await resolveRegisteredWorktreePath(args.worktreePath, store)
-      return getStatus(worktreePath)
+      return getStatus(worktreePath, options)
     }
   )
 

--- a/src/main/providers/ssh-git-provider.test.ts
+++ b/src/main/providers/ssh-git-provider.test.ts
@@ -41,6 +41,22 @@ describe('SshGitProvider', () => {
     expect(result).toEqual(statusResult)
   })
 
+  it('getStatus forwards includeIgnored only when requested', async () => {
+    const statusResult = { entries: [], conflictOperation: 'unknown', ignoredPaths: ['dist/'] }
+    mux.request.mockResolvedValue(statusResult)
+
+    await provider.getStatus('/home/user/repo', { includeIgnored: true })
+    await provider.getStatus('/home/user/repo', { includeIgnored: false })
+
+    expect(mux.request).toHaveBeenNthCalledWith(1, 'git.status', {
+      worktreePath: '/home/user/repo',
+      includeIgnored: true
+    })
+    expect(mux.request).toHaveBeenNthCalledWith(2, 'git.status', {
+      worktreePath: '/home/user/repo'
+    })
+  })
+
   it('commit sends git.commit request', async () => {
     const commitResult = { success: true }
     mux.request.mockResolvedValue(commitResult)

--- a/src/main/providers/ssh-git-provider.ts
+++ b/src/main/providers/ssh-git-provider.ts
@@ -35,9 +35,6 @@ export class SshGitProvider implements IGitProvider {
     worktreePath: string,
     options?: { includeIgnored?: boolean }
   ): Promise<GitStatusResult> {
-    // Why: only forward includeIgnored when the caller opted in so the request
-    // params stay identical to the pre-feature contract for non-opted-in
-    // callers. The relay handler treats a missing key as false anyway.
     const includeIgnoredArgs = options?.includeIgnored ? { includeIgnored: true } : {}
     return (await this.mux.request('git.status', {
       worktreePath,

--- a/src/main/providers/ssh-git-provider.ts
+++ b/src/main/providers/ssh-git-provider.ts
@@ -31,8 +31,18 @@ export class SshGitProvider implements IGitProvider {
     return this.connectionId
   }
 
-  async getStatus(worktreePath: string): Promise<GitStatusResult> {
-    return (await this.mux.request('git.status', { worktreePath })) as GitStatusResult
+  async getStatus(
+    worktreePath: string,
+    options?: { includeIgnored?: boolean }
+  ): Promise<GitStatusResult> {
+    // Why: only forward includeIgnored when the caller opted in so the request
+    // params stay identical to the pre-feature contract for non-opted-in
+    // callers. The relay handler treats a missing key as false anyway.
+    const includeIgnoredArgs = options?.includeIgnored ? { includeIgnored: true } : {}
+    return (await this.mux.request('git.status', {
+      worktreePath,
+      ...includeIgnoredArgs
+    })) as GitStatusResult
   }
 
   async commit(

--- a/src/main/providers/types.ts
+++ b/src/main/providers/types.ts
@@ -142,7 +142,10 @@ export type IFilesystemProvider = {
 // ─── Git Provider ───────────────────────────────────────────────────
 
 export type IGitProvider = {
-  getStatus(worktreePath: string): Promise<GitStatusResult>
+  getStatus(
+    worktreePath: string,
+    options?: { includeIgnored?: boolean }
+  ): Promise<GitStatusResult>
   commit(worktreePath: string, message: string): Promise<{ success: boolean; error?: string }>
   getStagedCommitContext(worktreePath: string): Promise<CommitMessageDraftContext | null>
   getDiff(

--- a/src/main/runtime/orca-runtime-git.ts
+++ b/src/main/runtime/orca-runtime-git.ts
@@ -38,16 +38,22 @@ export type RuntimeGitCommandHost = {
 export class RuntimeGitCommands {
   constructor(private readonly host: RuntimeGitCommandHost) {}
 
-  async getRuntimeGitStatus(worktreeSelector: string): Promise<GitStatusResult> {
+  async getRuntimeGitStatus(
+    worktreeSelector: string,
+    options?: { includeIgnored?: boolean }
+  ): Promise<GitStatusResult> {
     const target = await this.host.resolveRuntimeGitTarget(worktreeSelector)
     const provider = target.connectionId ? getSshGitProvider(target.connectionId) : null
     if (target.connectionId) {
       if (!provider) {
         throw new Error('remote_git_unavailable')
       }
-      return provider.getStatus(target.worktree.path)
+      // Why: forward the options argument only when present so this call
+      // remains argv-identical to the pre-feature signature for callers that
+      // don't opt in (matters because spies assert exact argument lists).
+      return options ? provider.getStatus(target.worktree.path, options) : provider.getStatus(target.worktree.path)
     }
-    return getGitStatus(target.worktree.path)
+    return options ? getGitStatus(target.worktree.path, options) : getGitStatus(target.worktree.path)
   }
 
   async getRuntimeGitConflictOperation(worktreeSelector: string): Promise<GitConflictOperation> {

--- a/src/main/runtime/orca-runtime-git.ts
+++ b/src/main/runtime/orca-runtime-git.ts
@@ -48,10 +48,9 @@ export class RuntimeGitCommands {
       if (!provider) {
         throw new Error('remote_git_unavailable')
       }
-      // Why: forward the options argument only when present so this call
-      // remains argv-identical to the pre-feature signature for callers that
-      // don't opt in (matters because spies assert exact argument lists).
-      return options ? provider.getStatus(target.worktree.path, options) : provider.getStatus(target.worktree.path)
+      return options
+        ? provider.getStatus(target.worktree.path, options)
+        : provider.getStatus(target.worktree.path)
     }
     return options ? getGitStatus(target.worktree.path, options) : getGitStatus(target.worktree.path)
   }

--- a/src/main/runtime/rpc/methods/git.test.ts
+++ b/src/main/runtime/rpc/methods/git.test.ts
@@ -30,6 +30,30 @@ describe('git RPC methods', () => {
     })
   })
 
+  it('forwards includeIgnored for status requests', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      getRuntimeGitStatus: vi.fn().mockResolvedValue({
+        entries: [],
+        conflictOperation: 'unknown',
+        ignoredPaths: ['dist/']
+      })
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: GIT_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest('git.status', { worktree: 'id:wt-1', includeIgnored: true })
+    )
+
+    expect(runtime.getRuntimeGitStatus).toHaveBeenCalledWith('id:wt-1', {
+      includeIgnored: true
+    })
+    expect(response).toMatchObject({
+      ok: true,
+      result: { ignoredPaths: ['dist/'] }
+    })
+  })
+
   it('returns a worktree file diff', async () => {
     const runtime = {
       getRuntimeId: () => 'test-runtime',

--- a/src/main/runtime/rpc/methods/git.ts
+++ b/src/main/runtime/rpc/methods/git.ts
@@ -8,6 +8,10 @@ const WorktreeSelector = z.object({
     .pipe(z.string().min(1, 'Missing worktree selector'))
 })
 
+const GitStatusParams = WorktreeSelector.extend({
+  includeIgnored: z.boolean().optional()
+})
+
 const GitFilePath = WorktreeSelector.extend({
   filePath: z
     .unknown()
@@ -73,8 +77,14 @@ const GitRemoteFileUrl = WorktreeSelector.extend({
 export const GIT_METHODS: RpcMethod[] = [
   defineMethod({
     name: 'git.status',
-    params: WorktreeSelector,
-    handler: async (params, { runtime }) => runtime.getRuntimeGitStatus(params.worktree)
+    params: GitStatusParams,
+    // Why: only forward the options bag when the request actually carried
+    // includeIgnored, so the call shape stays identical to the pre-feature
+    // signature for legacy callers (matters because tests assert exact argv).
+    handler: async (params, { runtime }) =>
+      params.includeIgnored === undefined
+        ? runtime.getRuntimeGitStatus(params.worktree)
+        : runtime.getRuntimeGitStatus(params.worktree, { includeIgnored: params.includeIgnored })
   }),
   defineMethod({
     name: 'git.conflictOperation',

--- a/src/main/runtime/rpc/methods/git.ts
+++ b/src/main/runtime/rpc/methods/git.ts
@@ -78,9 +78,6 @@ export const GIT_METHODS: RpcMethod[] = [
   defineMethod({
     name: 'git.status',
     params: GitStatusParams,
-    // Why: only forward the options bag when the request actually carried
-    // includeIgnored, so the call shape stays identical to the pre-feature
-    // signature for legacy callers (matters because tests assert exact argv).
     handler: async (params, { runtime }) =>
       params.includeIgnored === undefined
         ? runtime.getRuntimeGitStatus(params.worktree)

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1168,7 +1168,11 @@ export type PreloadApi = {
     onFsChanged: (callback: (payload: FsChangedPayload) => void) => () => void
   }
   git: {
-    status: (args: { worktreePath: string; connectionId?: string }) => Promise<GitStatusResult>
+    status: (args: {
+      worktreePath: string
+      connectionId?: string
+      includeIgnored?: boolean
+    }) => Promise<GitStatusResult>
     conflictOperation: (args: {
       worktreePath: string
       connectionId?: string

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1765,8 +1765,11 @@ const api = {
   },
 
   git: {
-    status: (args: { worktreePath: string; connectionId?: string }): Promise<unknown> =>
-      ipcRenderer.invoke('git:status', args),
+    status: (args: {
+      worktreePath: string
+      connectionId?: string
+      includeIgnored?: boolean
+    }): Promise<unknown> => ipcRenderer.invoke('git:status', args),
     conflictOperation: (args: { worktreePath: string; connectionId?: string }): Promise<unknown> =>
       ipcRenderer.invoke('git:conflictOperation', args),
     diff: (args: {

--- a/src/relay/git-handler-status-ops.ts
+++ b/src/relay/git-handler-status-ops.ts
@@ -60,8 +60,10 @@ export async function getStatusOp(
     ahead: number
     behind: number
   }
+  ignoredPaths?: string[]
 }> {
   const worktreePath = params.worktreePath as string
+  const includeIgnored = params.includeIgnored === true
   const conflictOperation = await detectConflictOperation(worktreePath)
   const entries: Record<string, unknown>[] = []
   let head: string | undefined
@@ -74,28 +76,34 @@ export async function getStatusOp(
         behind: number
       }
     | undefined
+  let ignoredPaths: string[] = []
 
   try {
     // Why: -c core.quotePath=false keeps non-ASCII filenames as raw UTF-8 in
     // git's stdout instead of C-style octal escapes; without it the parsed
     // entry.path renders as gibberish in the source-control sidebar and
     // downstream blob lookups miss.
-    const { stdout } = await git(
-      [
-        '-c',
-        'core.quotePath=false',
-        'status',
-        '--porcelain=v2',
-        '--branch',
-        '--untracked-files=all'
-      ],
-      worktreePath
-    )
+    // Why --ignored=matching is gated on the caller flag: lists only files
+    // that match .gitignore patterns (not the recursive contents of ignored
+    // directories), keeping the remote payload bounded for large repos.
+    const statusArgs = [
+      '-c',
+      'core.quotePath=false',
+      'status',
+      '--porcelain=v2',
+      '--branch',
+      '--untracked-files=all'
+    ]
+    if (includeIgnored) {
+      statusArgs.push('--ignored=matching')
+    }
+    const { stdout } = await git(statusArgs, worktreePath)
     const parsed = parseStatusOutput(stdout)
     entries.push(...parsed.entries)
     head = parsed.head
     branch = parsed.branch
     upstreamStatus = parsed.upstreamStatus
+    ignoredPaths = parsed.ignoredPaths
 
     for (const uLine of parsed.unmergedLines) {
       const entry = parseUnmergedEntry(worktreePath, uLine)
@@ -107,5 +115,12 @@ export async function getStatusOp(
     // not a git repo or git not available
   }
 
-  return { entries, conflictOperation, head, branch, upstreamStatus }
+  return {
+    entries,
+    conflictOperation,
+    head,
+    branch,
+    upstreamStatus,
+    ...(includeIgnored ? { ignoredPaths } : {})
+  }
 }

--- a/src/relay/git-handler-status-ops.ts
+++ b/src/relay/git-handler-status-ops.ts
@@ -83,9 +83,6 @@ export async function getStatusOp(
     // git's stdout instead of C-style octal escapes; without it the parsed
     // entry.path renders as gibberish in the source-control sidebar and
     // downstream blob lookups miss.
-    // Why --ignored=matching is gated on the caller flag: lists only files
-    // that match .gitignore patterns (not the recursive contents of ignored
-    // directories), keeping the remote payload bounded for large repos.
     const statusArgs = [
       '-c',
       'core.quotePath=false',

--- a/src/relay/git-handler-utils.test.ts
+++ b/src/relay/git-handler-utils.test.ts
@@ -28,4 +28,13 @@ describe('parseStatusOutput', () => {
 
     expect(result.upstreamStatus).toEqual({ hasUpstream: false, ahead: 0, behind: 0 })
   })
+
+  it('parses ignored porcelain records separately from actionable entries', () => {
+    const result = parseStatusOutput(['! dist/', '! .env', '? scratch.txt', ''].join('\n'))
+
+    expect(result.ignoredPaths).toEqual(['dist/', '.env'])
+    expect(result.entries).toEqual([
+      { path: 'scratch.txt', status: 'untracked', area: 'untracked' }
+    ])
+  })
 })

--- a/src/relay/git-handler.test.ts
+++ b/src/relay/git-handler.test.ts
@@ -92,6 +92,30 @@ describe('GitHandler', () => {
       expect(untracked!.area).toBe('untracked')
     })
 
+    it('returns ignored paths only when requested', async () => {
+      gitInit(tmpDir)
+      writeFileSync(path.join(tmpDir, '.gitignore'), 'dist/\n.env\n')
+      gitCommit(tmpDir, 'initial')
+      mkdirSync(path.join(tmpDir, 'dist'), { recursive: true })
+      writeFileSync(path.join(tmpDir, 'dist', 'bundle.js'), 'compiled')
+      writeFileSync(path.join(tmpDir, '.env'), 'TOKEN=secret')
+
+      const defaultResult = (await dispatcher.callRequest('git.status', {
+        worktreePath: tmpDir
+      })) as {
+        ignoredPaths?: string[]
+      }
+      const ignoredResult = (await dispatcher.callRequest('git.status', {
+        worktreePath: tmpDir,
+        includeIgnored: true
+      })) as {
+        ignoredPaths?: string[]
+      }
+
+      expect('ignoredPaths' in defaultResult).toBe(false)
+      expect(ignoredResult.ignoredPaths).toEqual(expect.arrayContaining(['dist/', '.env']))
+    })
+
     it('detects modified files', async () => {
       gitInit(tmpDir)
       writeFileSync(path.join(tmpDir, 'file.txt'), 'original')

--- a/src/relay/git-status-output-parser.ts
+++ b/src/relay/git-status-output-parser.ts
@@ -22,6 +22,7 @@ export function parseStatusChar(char: string): string {
 export function parseStatusOutput(stdout: string): {
   entries: Record<string, unknown>[]
   unmergedLines: string[]
+  ignoredPaths: string[]
   head?: string
   branch?: string
   upstreamStatus: {
@@ -33,6 +34,7 @@ export function parseStatusOutput(stdout: string): {
 } {
   const entries: Record<string, unknown>[] = []
   const unmergedLines: string[] = []
+  const ignoredPaths: string[] = []
   let head: string | undefined
   let branch: string | undefined
   let upstreamName: string | undefined
@@ -108,6 +110,11 @@ export function parseStatusOutput(stdout: string): {
       }
     } else if (line.startsWith('? ')) {
       entries.push({ path: line.slice(2), status: 'untracked', area: 'untracked' })
+    } else if (line.startsWith('! ')) {
+      // Why: porcelain v2 emits `! path` only when `--ignored` is passed.
+      // Surfaced separately from `entries` so staging-area consumers stay
+      // unaffected; the file explorer reads ignoredPaths to dim matches.
+      ignoredPaths.push(line.slice(2))
     } else if (line.startsWith('u ')) {
       unmergedLines.push(line)
     }
@@ -116,6 +123,7 @@ export function parseStatusOutput(stdout: string): {
   return {
     entries,
     unmergedLines,
+    ignoredPaths,
     head,
     branch,
     upstreamStatus: upstreamName

--- a/src/relay/git-status-output-parser.ts
+++ b/src/relay/git-status-output-parser.ts
@@ -111,9 +111,6 @@ export function parseStatusOutput(stdout: string): {
     } else if (line.startsWith('? ')) {
       entries.push({ path: line.slice(2), status: 'untracked', area: 'untracked' })
     } else if (line.startsWith('! ')) {
-      // Why: porcelain v2 emits `! path` only when `--ignored` is passed.
-      // Surfaced separately from `entries` so staging-area consumers stay
-      // unaffected; the file explorer reads ignoredPaths to dim matches.
       ignoredPaths.push(line.slice(2))
     } else if (line.startsWith('u ')) {
       unmergedLines.push(line)

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -114,6 +114,10 @@
   --git-decoration-renamed: #007acc;
   --git-decoration-untracked: #007100;
   --git-decoration-copied: #007acc;
+  /* Why: muted gray for gitignored entries — matches VS Code's
+     gitDecoration.ignoredResourceForeground tone. Distinct from
+     --muted-foreground so future theme tweaks don't move the two together. */
+  --git-decoration-ignored: #8c8c8c;
 }
 
 /* ── Dark Mode ───────────────────────────────────────── */
@@ -158,6 +162,7 @@
   --git-decoration-renamed: #73c991;
   --git-decoration-untracked: #73c991;
   --git-decoration-copied: #73c991;
+  --git-decoration-ignored: #6e6e6e;
 }
 
 /* ── Base Layer ──────────────────────────────────────── */

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -114,9 +114,6 @@
   --git-decoration-renamed: #007acc;
   --git-decoration-untracked: #007100;
   --git-decoration-copied: #007acc;
-  /* Why: muted gray for gitignored entries — matches VS Code's
-     gitDecoration.ignoredResourceForeground tone. Distinct from
-     --muted-foreground so future theme tweaks don't move the two together. */
   --git-decoration-ignored: #8c8c8c;
 }
 

--- a/src/renderer/src/components/right-sidebar/FileExplorer.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorer.tsx
@@ -10,7 +10,7 @@ import { FileExplorerToolbar } from './FileExplorerToolbar'
 import { FileExplorerTreeStatus } from './FileExplorerTreeStatus'
 import { FileExplorerVirtualRows } from './FileExplorerVirtualRows'
 import { splitPathSegments } from './path-tree'
-import { buildFolderStatusMap, buildStatusMap } from './status-display'
+import { buildFolderStatusMap, buildIgnoredSet, buildStatusMap } from './status-display'
 import { useFileDeletion } from './useFileDeletion'
 import { useFileExplorerAutoReveal } from './useFileExplorerAutoReveal'
 import { useFileExplorerHandlers } from './useFileExplorerHandlers'
@@ -86,8 +86,15 @@ function FileExplorerInner(): React.JSX.Element {
     () => (activeWorktreeId ? (gitStatusByWorktree[activeWorktreeId] ?? []) : []),
     [activeWorktreeId, gitStatusByWorktree]
   )
+  const ignoredPaths = useAppStore((s) =>
+    activeWorktreeId ? (s.gitIgnoredPathsByWorktree[activeWorktreeId] ?? null) : null
+  )
   const statusByRelativePath = useMemo(() => buildStatusMap(entries), [entries])
   const folderStatusByRelativePath = useMemo(() => buildFolderStatusMap(entries), [entries])
+  const ignoredByRelativePath = useMemo(
+    () => buildIgnoredSet(ignoredPaths ?? undefined),
+    [ignoredPaths]
+  )
 
   const { deleteShortcutLabel, requestDelete } = useFileDeletion({
     activeWorktreeId,
@@ -355,6 +362,7 @@ function FileExplorerInner(): React.JSX.Element {
               dismissInlineInput={dismissInlineInput}
               folderStatusByRelativePath={folderStatusByRelativePath}
               statusByRelativePath={statusByRelativePath}
+              ignoredByRelativePath={ignoredByRelativePath}
               expanded={expanded}
               dirCache={dirCache}
               selectedPath={selectedPath}

--- a/src/renderer/src/components/right-sidebar/FileExplorer.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorer.tsx
@@ -38,6 +38,7 @@ function FileExplorerInner(): React.JSX.Element {
   const pinFile = useAppStore((s) => s.pinFile)
   const activeFileId = useAppStore((s) => s.activeFileId)
   const gitStatusByWorktree = useAppStore((s) => s.gitStatusByWorktree)
+  const showGitIgnoredFiles = useAppStore((s) => s.settings?.showGitIgnoredFiles ?? true)
   const openFiles = useAppStore((s) => s.openFiles)
   const closeFile = useAppStore((s) => s.closeFile)
 
@@ -92,8 +93,8 @@ function FileExplorerInner(): React.JSX.Element {
   const statusByRelativePath = useMemo(() => buildStatusMap(entries), [entries])
   const folderStatusByRelativePath = useMemo(() => buildFolderStatusMap(entries), [entries])
   const ignoredByRelativePath = useMemo(
-    () => buildIgnoredSet(ignoredPaths ?? undefined),
-    [ignoredPaths]
+    () => (showGitIgnoredFiles ? buildIgnoredSet(ignoredPaths ?? undefined) : new Set<string>()),
+    [ignoredPaths, showGitIgnoredFiles]
   )
 
   const { deleteShortcutLabel, requestDelete } = useFileDeletion({

--- a/src/renderer/src/components/right-sidebar/FileExplorerRow.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorerRow.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useRef } from 'react'
 import {
   ChevronRight,
+  CircleSlash,
   Copy,
   ExternalLink,
   Eye,
@@ -197,6 +198,11 @@ type FileExplorerRowProps = {
   isFlashing: boolean
   nodeStatus: GitFileStatus | null
   statusColor: string | null
+  /** When true, the row is dimmed + italicised and shows the CircleSlash
+   *  indicator in the same slot the status letter occupies. Mutually exclusive
+   *  with nodeStatus — the virtual-row builder only sets isIgnored when there
+   *  is no other git status to render. */
+  isIgnored: boolean
   deleteShortcutLabel: string
   targetDir: string
   targetDepth: number
@@ -223,6 +229,7 @@ export function FileExplorerRow({
   isFlashing,
   nodeStatus,
   statusColor,
+  isIgnored,
   deleteShortcutLabel,
   targetDir,
   targetDepth,
@@ -306,8 +313,18 @@ export function FileExplorerRow({
             </>
           )}
           <span
-            className={cn('truncate', isSelected && !nodeStatus && 'text-accent-foreground')}
-            style={nodeStatus ? { color: statusColor ?? undefined } : undefined}
+            className={cn(
+              'truncate',
+              isSelected && !nodeStatus && !isIgnored && 'text-accent-foreground',
+              isIgnored && 'italic'
+            )}
+            style={
+              nodeStatus
+                ? { color: statusColor ?? undefined }
+                : isIgnored
+                  ? { color: 'var(--git-decoration-ignored)' }
+                  : undefined
+            }
             onDoubleClick={(e) => {
               // Why: the row itself swallows double-click for "pin preview" /
               // directory toggle. Scope rename to the filename text only so
@@ -319,14 +336,23 @@ export function FileExplorerRow({
           >
             {node.name}
           </span>
-          {nodeStatus && (
+          {nodeStatus ? (
             <span
               className="ml-auto shrink-0 text-[10px] font-semibold tracking-wide mr-2"
               style={{ color: statusColor ?? undefined }}
             >
               {STATUS_LABELS[nodeStatus]}
             </span>
-          )}
+          ) : isIgnored ? (
+            // Why: occupies the same trailing slot as the git status letter so
+            // the column stays visually aligned across rows. size-3 matches the
+            // file/folder leading icon for consistent optical weight.
+            <CircleSlash
+              aria-label="Ignored by .gitignore"
+              className="ml-auto size-3 shrink-0 mr-2"
+              style={{ color: 'var(--git-decoration-ignored)' }}
+            />
+          ) : null}
         </button>
       </ContextMenuTrigger>
       <ContextMenuContent

--- a/src/renderer/src/components/right-sidebar/FileExplorerRow.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorerRow.tsx
@@ -198,10 +198,8 @@ type FileExplorerRowProps = {
   isFlashing: boolean
   nodeStatus: GitFileStatus | null
   statusColor: string | null
-  /** When true, the row is dimmed + italicised and shows the CircleSlash
-   *  indicator in the same slot the status letter occupies. Mutually exclusive
-   *  with nodeStatus — the virtual-row builder only sets isIgnored when there
-   *  is no other git status to render. */
+  /** Mutually exclusive with nodeStatus: the virtual-row builder only sets
+   *  isIgnored when there is no other git status to render. */
   isIgnored: boolean
   deleteShortcutLabel: string
   targetDir: string
@@ -344,9 +342,8 @@ export function FileExplorerRow({
               {STATUS_LABELS[nodeStatus]}
             </span>
           ) : isIgnored ? (
-            // Why: occupies the same trailing slot as the git status letter so
-            // the column stays visually aligned across rows. size-3 matches the
-            // file/folder leading icon for consistent optical weight.
+            // Why: occupies the same trailing slot as the git status letter
+            // so the column stays visually aligned across rows.
             <CircleSlash
               aria-label="Ignored by .gitignore"
               className="ml-auto size-3 shrink-0 mr-2"

--- a/src/renderer/src/components/right-sidebar/FileExplorerRow.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorerRow.tsx
@@ -198,8 +198,6 @@ type FileExplorerRowProps = {
   isFlashing: boolean
   nodeStatus: GitFileStatus | null
   statusColor: string | null
-  /** Mutually exclusive with nodeStatus: the virtual-row builder only sets
-   *  isIgnored when there is no other git status to render. */
   isIgnored: boolean
   deleteShortcutLabel: string
   targetDir: string
@@ -342,8 +340,6 @@ export function FileExplorerRow({
               {STATUS_LABELS[nodeStatus]}
             </span>
           ) : isIgnored ? (
-            // Why: occupies the same trailing slot as the git status letter
-            // so the column stays visually aligned across rows.
             <CircleSlash
               aria-label="Ignored by .gitignore"
               className="ml-auto size-3 shrink-0 mr-2"

--- a/src/renderer/src/components/right-sidebar/FileExplorerVirtualRows.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorerVirtualRows.tsx
@@ -4,7 +4,7 @@ import { dirname, normalizeRelativePath } from '@/lib/path'
 import { cn } from '@/lib/utils'
 import type { GitFileStatus } from '../../../../shared/types'
 import { FileExplorerRow, InlineInputRow, type InlineInput } from './FileExplorerRow'
-import { STATUS_COLORS } from './status-display'
+import { isPathIgnored, STATUS_COLORS } from './status-display'
 import type { DirCache, TreeNode } from './file-explorer-types'
 
 type FileExplorerVirtualRowsProps = {
@@ -16,6 +16,7 @@ type FileExplorerVirtualRowsProps = {
   dismissInlineInput: () => void
   folderStatusByRelativePath: Map<string, GitFileStatus | null>
   statusByRelativePath: Map<string, GitFileStatus>
+  ignoredByRelativePath: Set<string>
   expanded: Set<string>
   dirCache: Record<string, DirCache>
   selectedPath: string | null
@@ -50,6 +51,7 @@ export function FileExplorerVirtualRows(props: FileExplorerVirtualRowsProps): Re
     dismissInlineInput,
     folderStatusByRelativePath,
     statusByRelativePath,
+    ignoredByRelativePath,
     expanded,
     dirCache,
     selectedPath,
@@ -116,6 +118,10 @@ export function FileExplorerVirtualRows(props: FileExplorerVirtualRowsProps): Re
         const nodeStatus = n.isDirectory
           ? (folderStatusByRelativePath.get(normalizedRelativePath) ?? null)
           : (statusByRelativePath.get(normalizedRelativePath) ?? null)
+        // Why: ignored decoration is independent of nodeStatus so a tracked
+        // change still wins the status color/letter; ignored only applies
+        // when there's no other status on the row.
+        const isIgnored = !nodeStatus && isPathIgnored(ignoredByRelativePath, normalizedRelativePath)
 
         const rowParentDir = n.isDirectory ? n.path : dirname(n.path)
         const sourceParentDir = dragSourcePath ? dirname(dragSourcePath) : null
@@ -140,6 +146,7 @@ export function FileExplorerVirtualRows(props: FileExplorerVirtualRowsProps): Re
               isFlashing={flashingPath === n.path}
               nodeStatus={nodeStatus}
               statusColor={nodeStatus ? STATUS_COLORS[nodeStatus] : null}
+              isIgnored={isIgnored}
               deleteShortcutLabel={deleteShortcutLabel}
               targetDir={n.isDirectory ? n.path : dirname(n.path)}
               targetDepth={n.isDirectory ? n.depth + 1 : n.depth}

--- a/src/renderer/src/components/right-sidebar/FileExplorerVirtualRows.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorerVirtualRows.tsx
@@ -118,9 +118,6 @@ export function FileExplorerVirtualRows(props: FileExplorerVirtualRowsProps): Re
         const nodeStatus = n.isDirectory
           ? (folderStatusByRelativePath.get(normalizedRelativePath) ?? null)
           : (statusByRelativePath.get(normalizedRelativePath) ?? null)
-        // Why: ignored decoration is independent of nodeStatus so a tracked
-        // change still wins the status color/letter; ignored only applies
-        // when there's no other status on the row.
         const isIgnored = !nodeStatus && isPathIgnored(ignoredByRelativePath, normalizedRelativePath)
 
         const rowParentDir = n.isDirectory ? n.path : dirname(n.path)

--- a/src/renderer/src/components/right-sidebar/FileExplorerVirtualRows.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorerVirtualRows.tsx
@@ -4,7 +4,7 @@ import { dirname, normalizeRelativePath } from '@/lib/path'
 import { cn } from '@/lib/utils'
 import type { GitFileStatus } from '../../../../shared/types'
 import { FileExplorerRow, InlineInputRow, type InlineInput } from './FileExplorerRow'
-import { isPathIgnored, STATUS_COLORS } from './status-display'
+import { shouldShowIgnoredDecoration, STATUS_COLORS } from './status-display'
 import type { DirCache, TreeNode } from './file-explorer-types'
 
 type FileExplorerVirtualRowsProps = {
@@ -118,7 +118,11 @@ export function FileExplorerVirtualRows(props: FileExplorerVirtualRowsProps): Re
         const nodeStatus = n.isDirectory
           ? (folderStatusByRelativePath.get(normalizedRelativePath) ?? null)
           : (statusByRelativePath.get(normalizedRelativePath) ?? null)
-        const isIgnored = !nodeStatus && isPathIgnored(ignoredByRelativePath, normalizedRelativePath)
+        const isIgnored = shouldShowIgnoredDecoration(
+          nodeStatus,
+          ignoredByRelativePath,
+          normalizedRelativePath
+        )
 
         const rowParentDir = n.isDirectory ? n.path : dirname(n.path)
         const sourceParentDir = dragSourcePath ? dirname(dragSourcePath) : null

--- a/src/renderer/src/components/right-sidebar/git-status-refresh.test.ts
+++ b/src/renderer/src/components/right-sidebar/git-status-refresh.test.ts
@@ -80,4 +80,27 @@ describe('refreshGitStatusForWorktree', () => {
     expect(deps.setUpstreamStatus).not.toHaveBeenCalled()
     expect(deps.fetchUpstreamStatus).toHaveBeenCalledWith('wt-2', '/repo', 'ssh-2')
   })
+
+  it('omits ignored-file status when the setting is disabled', async () => {
+    const status: GitStatusResult = {
+      entries: [],
+      conflictOperation: 'unknown'
+    }
+    const gitStatus = vi.fn().mockResolvedValue(status)
+    vi.stubGlobal('window', { api: { git: { status: gitStatus } } })
+    const deps = makeDeps()
+
+    await refreshGitStatusForWorktree({
+      settings: { activeRuntimeEnvironmentId: null, showGitIgnoredFiles: false },
+      worktreeId: 'wt-3',
+      worktreePath: '/repo',
+      deps
+    })
+
+    expect(gitStatus).toHaveBeenCalledWith({
+      worktreePath: '/repo',
+      connectionId: undefined
+    })
+    expect(deps.setGitStatus).toHaveBeenCalledWith('wt-3', status)
+  })
 })

--- a/src/renderer/src/components/right-sidebar/git-status-refresh.test.ts
+++ b/src/renderer/src/components/right-sidebar/git-status-refresh.test.ts
@@ -40,8 +40,6 @@ describe('refreshGitStatusForWorktree', () => {
       deps
     })
 
-    // Why: settings is undefined in this test, which the refresh helper treats
-    // as the default-on case for showGitIgnoredFiles (matches getDefaultSettings).
     expect(gitStatus).toHaveBeenCalledWith({
       worktreePath: '/repo',
       connectionId: 'ssh-1',

--- a/src/renderer/src/components/right-sidebar/git-status-refresh.test.ts
+++ b/src/renderer/src/components/right-sidebar/git-status-refresh.test.ts
@@ -40,7 +40,13 @@ describe('refreshGitStatusForWorktree', () => {
       deps
     })
 
-    expect(gitStatus).toHaveBeenCalledWith({ worktreePath: '/repo', connectionId: 'ssh-1' })
+    // Why: settings is undefined in this test, which the refresh helper treats
+    // as the default-on case for showGitIgnoredFiles (matches getDefaultSettings).
+    expect(gitStatus).toHaveBeenCalledWith({
+      worktreePath: '/repo',
+      connectionId: 'ssh-1',
+      includeIgnored: true
+    })
     expect(deps.setGitStatus).toHaveBeenCalledWith('wt-1', status)
     expect(deps.updateWorktreeGitIdentity).toHaveBeenCalledWith('wt-1', {
       head: 'abc123',

--- a/src/renderer/src/components/right-sidebar/git-status-refresh.ts
+++ b/src/renderer/src/components/right-sidebar/git-status-refresh.ts
@@ -22,18 +22,25 @@ export async function refreshGitStatusForWorktree({
   connectionId,
   deps
 }: {
-  settings?: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null
+  settings?: Pick<GlobalSettings, 'activeRuntimeEnvironmentId' | 'showGitIgnoredFiles'> | null
   worktreeId: string
   worktreePath: string
   connectionId?: string
   deps: GitStatusRefreshDeps
 }): Promise<void> {
-  const status = (await getRuntimeGitStatus({
-    settings,
-    worktreeId,
-    worktreePath,
-    connectionId
-  })) as GitStatusResult
+  // Why: setting is optional in the type for backward-compat with pre-feature
+  // profiles, but the persistence merge fills the default before this runs.
+  // Fall back to true so first-launch behavior matches getDefaultSettings.
+  const includeIgnored = settings?.showGitIgnoredFiles ?? true
+  const status = (await getRuntimeGitStatus(
+    {
+      settings,
+      worktreeId,
+      worktreePath,
+      connectionId
+    },
+    { includeIgnored }
+  )) as GitStatusResult
 
   deps.setGitStatus(worktreeId, status)
   // Why: branch switches can happen inside a terminal. `git status --branch`

--- a/src/renderer/src/components/right-sidebar/git-status-refresh.ts
+++ b/src/renderer/src/components/right-sidebar/git-status-refresh.ts
@@ -28,9 +28,6 @@ export async function refreshGitStatusForWorktree({
   connectionId?: string
   deps: GitStatusRefreshDeps
 }): Promise<void> {
-  // Why: setting is optional in the type for backward-compat with pre-feature
-  // profiles, but the persistence merge fills the default before this runs.
-  // Fall back to true so first-launch behavior matches getDefaultSettings.
   const includeIgnored = settings?.showGitIgnoredFiles ?? true
   const status = (await getRuntimeGitStatus(
     {

--- a/src/renderer/src/components/right-sidebar/status-display.test.ts
+++ b/src/renderer/src/components/right-sidebar/status-display.test.ts
@@ -25,8 +25,6 @@ describe('isPathIgnored', () => {
   })
 
   it('inherits ignored status from an ancestor directory', () => {
-    // Why: --ignored=matching reports the matched pattern (e.g. "dist/"), so
-    // children of an ignored directory are only covered by the ancestor walk.
     const ignored = new Set(['dist'])
     expect(isPathIgnored(ignored, 'dist/index.js')).toBe(true)
     expect(isPathIgnored(ignored, 'dist/sub/deep/file.js')).toBe(true)

--- a/src/renderer/src/components/right-sidebar/status-display.test.ts
+++ b/src/renderer/src/components/right-sidebar/status-display.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { buildIgnoredSet, isPathIgnored } from './status-display'
+import { buildIgnoredSet, isPathIgnored, shouldShowIgnoredDecoration } from './status-display'
 
 describe('buildIgnoredSet', () => {
   it('returns an empty set when ignoredPaths is undefined', () => {
@@ -33,5 +33,15 @@ describe('isPathIgnored', () => {
   it('does not match sibling paths that share a prefix', () => {
     const ignored = new Set(['dist'])
     expect(isPathIgnored(ignored, 'distance.ts')).toBe(false)
+  })
+})
+
+describe('shouldShowIgnoredDecoration', () => {
+  it('shows ignored decoration only when no real git status exists', () => {
+    const ignored = new Set(['dist'])
+
+    expect(shouldShowIgnoredDecoration(null, ignored, 'dist/index.js')).toBe(true)
+    expect(shouldShowIgnoredDecoration('modified', ignored, 'dist/index.js')).toBe(false)
+    expect(shouldShowIgnoredDecoration('untracked', ignored, 'dist/index.js')).toBe(false)
   })
 })

--- a/src/renderer/src/components/right-sidebar/status-display.test.ts
+++ b/src/renderer/src/components/right-sidebar/status-display.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { buildIgnoredSet, isPathIgnored } from './status-display'
+
+describe('buildIgnoredSet', () => {
+  it('returns an empty set when ignoredPaths is undefined', () => {
+    expect(buildIgnoredSet(undefined).size).toBe(0)
+  })
+
+  it('strips trailing slash from directory entries so lookups by TreeNode.relativePath hit', () => {
+    const set = buildIgnoredSet(['dist/', 'node_modules/', '.env'])
+    expect(set.has('dist')).toBe(true)
+    expect(set.has('node_modules')).toBe(true)
+    expect(set.has('.env')).toBe(true)
+    expect(set.has('dist/')).toBe(false)
+  })
+})
+
+describe('isPathIgnored', () => {
+  it('returns false on an empty set without walking ancestors', () => {
+    expect(isPathIgnored(new Set(), 'a/b/c.ts')).toBe(false)
+  })
+
+  it('matches direct hits', () => {
+    expect(isPathIgnored(new Set(['.env']), '.env')).toBe(true)
+  })
+
+  it('inherits ignored status from an ancestor directory', () => {
+    // Why: --ignored=matching reports the matched pattern (e.g. "dist/"), so
+    // children of an ignored directory are only covered by the ancestor walk.
+    const ignored = new Set(['dist'])
+    expect(isPathIgnored(ignored, 'dist/index.js')).toBe(true)
+    expect(isPathIgnored(ignored, 'dist/sub/deep/file.js')).toBe(true)
+  })
+
+  it('does not match sibling paths that share a prefix', () => {
+    const ignored = new Set(['dist'])
+    expect(isPathIgnored(ignored, 'distance.ts')).toBe(false)
+  })
+})

--- a/src/renderer/src/components/right-sidebar/status-display.ts
+++ b/src/renderer/src/components/right-sidebar/status-display.ts
@@ -116,6 +116,14 @@ export function isPathIgnored(ignored: Set<string>, relativePath: string): boole
   }
 }
 
+export function shouldShowIgnoredDecoration(
+  nodeStatus: GitFileStatus | null,
+  ignored: Set<string>,
+  relativePath: string
+): boolean {
+  return !nodeStatus && isPathIgnored(ignored, relativePath)
+}
+
 export function buildIgnoredSet(ignoredPaths: readonly string[] | undefined): Set<string> {
   const set = new Set<string>()
   if (!ignoredPaths) {

--- a/src/renderer/src/components/right-sidebar/status-display.ts
+++ b/src/renderer/src/components/right-sidebar/status-display.ts
@@ -104,14 +104,9 @@ export function shouldPropagateStatus(status: GitFileStatus): boolean {
  * we extended GitStagingArea. Keeping ignored as a peer to the status map lets
  * the explorer decorate paths without touching staging-area code.
  */
-/**
- * Whether `relativePath` is ignored, walking up ancestors so children of an
- * ignored directory inherit the decoration.
- *
- * Why ancestor walk: `--ignored=matching` reports the matched pattern, so a
- * `dist/` rule produces a single `dist` entry. Without the walk, expanding
- * `dist/` would show its children with normal styling.
- */
+// Why ancestor walk: `--ignored=matching` reports the matched pattern, so a
+// `dist/` rule produces a single `dist` entry. Without the walk, expanding
+// `dist/` would show its children with normal styling.
 export function isPathIgnored(ignored: Set<string>, relativePath: string): boolean {
   if (ignored.size === 0) {
     return false

--- a/src/renderer/src/components/right-sidebar/status-display.ts
+++ b/src/renderer/src/components/right-sidebar/status-display.ts
@@ -95,3 +95,54 @@ export function buildFolderStatusMap(entries: GitStatusEntry[]): Map<string, Git
 export function shouldPropagateStatus(status: GitFileStatus): boolean {
   return status !== 'deleted'
 }
+
+/**
+ * Build a set of normalized relative paths reported by git as ignored.
+ *
+ * Why a separate Set instead of folding into the status map: ignored is not a
+ * file *change* — Source Control groups entries by `area` and would break if
+ * we extended GitStagingArea. Keeping ignored as a peer to the status map lets
+ * the explorer decorate paths without touching staging-area code.
+ */
+/**
+ * Whether `relativePath` is ignored, walking up ancestors so children of an
+ * ignored directory inherit the decoration.
+ *
+ * Why ancestor walk: `--ignored=matching` reports the matched pattern, so a
+ * `dist/` rule produces a single `dist` entry. Without the walk, expanding
+ * `dist/` would show its children with normal styling.
+ */
+export function isPathIgnored(ignored: Set<string>, relativePath: string): boolean {
+  if (ignored.size === 0) {
+    return false
+  }
+  if (ignored.has(relativePath)) {
+    return true
+  }
+  let candidate = relativePath
+  for (;;) {
+    const idx = candidate.lastIndexOf('/')
+    if (idx <= 0) {
+      return false
+    }
+    candidate = candidate.slice(0, idx)
+    if (ignored.has(candidate)) {
+      return true
+    }
+  }
+}
+
+export function buildIgnoredSet(ignoredPaths: readonly string[] | undefined): Set<string> {
+  const set = new Set<string>()
+  if (!ignoredPaths) {
+    return set
+  }
+  for (const rawPath of ignoredPaths) {
+    // Why: porcelain v2 emits directories with a trailing slash (e.g.
+    // `dist/`). Strip it so lookups against TreeNode.relativePath — which
+    // never has a trailing separator — hit correctly.
+    const trimmed = rawPath.endsWith('/') ? rawPath.slice(0, -1) : rawPath
+    set.add(normalizeRelativePath(trimmed))
+  }
+  return set
+}

--- a/src/renderer/src/components/right-sidebar/status-display.ts
+++ b/src/renderer/src/components/right-sidebar/status-display.ts
@@ -96,17 +96,6 @@ export function shouldPropagateStatus(status: GitFileStatus): boolean {
   return status !== 'deleted'
 }
 
-/**
- * Build a set of normalized relative paths reported by git as ignored.
- *
- * Why a separate Set instead of folding into the status map: ignored is not a
- * file *change* — Source Control groups entries by `area` and would break if
- * we extended GitStagingArea. Keeping ignored as a peer to the status map lets
- * the explorer decorate paths without touching staging-area code.
- */
-// Why ancestor walk: `--ignored=matching` reports the matched pattern, so a
-// `dist/` rule produces a single `dist` entry. Without the walk, expanding
-// `dist/` would show its children with normal styling.
 export function isPathIgnored(ignored: Set<string>, relativePath: string): boolean {
   if (ignored.size === 0) {
     return false
@@ -133,9 +122,6 @@ export function buildIgnoredSet(ignoredPaths: readonly string[] | undefined): Se
     return set
   }
   for (const rawPath of ignoredPaths) {
-    // Why: porcelain v2 emits directories with a trailing slash (e.g.
-    // `dist/`). Strip it so lookups against TreeNode.relativePath — which
-    // never has a trailing separator — hit correctly.
     const trimmed = rawPath.endsWith('/') ? rawPath.slice(0, -1) : rawPath
     set.add(normalizeRelativePath(trimmed))
   }

--- a/src/renderer/src/components/settings/AppearancePane.tsx
+++ b/src/renderer/src/components/settings/AppearancePane.tsx
@@ -1,3 +1,4 @@
+import type React from 'react'
 import type { GlobalSettings, StatusBarItem } from '../../../../shared/types'
 import { Label } from '../ui/label'
 import { Separator } from '../ui/separator'
@@ -14,6 +15,35 @@ type AppearancePaneProps = {
   updateSettings: (updates: Partial<GlobalSettings>) => void
   applyTheme: (theme: 'system' | 'dark' | 'light') => void
   fontSuggestions: string[]
+}
+
+function ToggleSwitchButton({
+  checked,
+  onToggle,
+  ariaLabel
+}: {
+  checked: boolean
+  onToggle: () => void
+  ariaLabel?: string
+}): React.JSX.Element {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={ariaLabel}
+      onClick={onToggle}
+      className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent transition-colors ${
+        checked ? 'bg-foreground' : 'bg-muted-foreground/30'
+      }`}
+    >
+      <span
+        className={`pointer-events-none block size-3.5 rounded-full bg-background shadow-sm transition-transform ${
+          checked ? 'translate-x-4' : 'translate-x-0.5'
+        }`}
+      />
+    </button>
+  )
 }
 
 const STATUS_BAR_TOGGLES: readonly {
@@ -98,6 +128,11 @@ const LAYOUT_ENTRIES: SettingsSearchEntry[] = [
     title: 'Open Right Sidebar by Default',
     description: 'Automatically expand the file explorer panel when creating a new worktree.',
     keywords: ['layout', 'file explorer', 'sidebar']
+  },
+  {
+    title: 'Show Git-Ignored Files',
+    description: 'Dim files matched by .gitignore in the file explorer.',
+    keywords: ['git', 'gitignore', 'ignored', 'file explorer', 'sidebar', 'hide']
   }
 ]
 
@@ -248,24 +283,33 @@ export function AppearancePane({
               Automatically expand the file explorer panel when creating a new worktree.
             </p>
           </div>
-          <button
-            role="switch"
-            aria-checked={settings.rightSidebarOpenByDefault}
-            onClick={() =>
-              updateSettings({
-                rightSidebarOpenByDefault: !settings.rightSidebarOpenByDefault
-              })
+          <ToggleSwitchButton
+            checked={settings.rightSidebarOpenByDefault}
+            onToggle={() =>
+              updateSettings({ rightSidebarOpenByDefault: !settings.rightSidebarOpenByDefault })
             }
-            className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent transition-colors ${
-              settings.rightSidebarOpenByDefault ? 'bg-foreground' : 'bg-muted-foreground/30'
-            }`}
-          >
-            <span
-              className={`pointer-events-none block size-3.5 rounded-full bg-background shadow-sm transition-transform ${
-                settings.rightSidebarOpenByDefault ? 'translate-x-4' : 'translate-x-0.5'
-              }`}
-            />
-          </button>
+          />
+        </SearchableSetting>
+
+        <SearchableSetting
+          title="Show Git-Ignored Files"
+          description="Dim files matched by .gitignore in the file explorer."
+          keywords={['git', 'gitignore', 'ignored', 'file explorer', 'sidebar', 'hide']}
+          className="flex items-center justify-between gap-4 px-1 py-2"
+        >
+          <div className="space-y-0.5">
+            <Label>Show Git-Ignored Files</Label>
+            <p className="text-xs text-muted-foreground">
+              Dim files matched by .gitignore in the file explorer. Turn off to skip the extra git
+              status work on large repos.
+            </p>
+          </div>
+          <ToggleSwitchButton
+            checked={settings.showGitIgnoredFiles ?? true}
+            onToggle={() =>
+              updateSettings({ showGitIgnoredFiles: !(settings.showGitIgnoredFiles ?? true) })
+            }
+          />
         </SearchableSetting>
       </section>
     ) : null,
@@ -288,24 +332,12 @@ export function AppearancePane({
             <Label>Titlebar App Name</Label>
             <p className="text-xs text-muted-foreground">Show Orca in the titlebar.</p>
           </div>
-          <button
-            role="switch"
-            aria-checked={settings.showTitlebarAppName}
-            onClick={() =>
-              updateSettings({
-                showTitlebarAppName: !settings.showTitlebarAppName
-              })
+          <ToggleSwitchButton
+            checked={settings.showTitlebarAppName}
+            onToggle={() =>
+              updateSettings({ showTitlebarAppName: !settings.showTitlebarAppName })
             }
-            className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent transition-colors ${
-              settings.showTitlebarAppName ? 'bg-foreground' : 'bg-muted-foreground/30'
-            }`}
-          >
-            <span
-              className={`pointer-events-none block size-3.5 rounded-full bg-background shadow-sm transition-transform ${
-                settings.showTitlebarAppName ? 'translate-x-4' : 'translate-x-0.5'
-              }`}
-            />
-          </button>
+          />
         </SearchableSetting>
       </section>
     ) : null,
@@ -333,22 +365,11 @@ export function AppearancePane({
                 <Label>{toggle.title}</Label>
                 <p className="text-xs text-muted-foreground">{toggle.toggleDescription}</p>
               </div>
-              <button
-                type="button"
-                role="switch"
-                aria-label={toggle.title}
-                aria-checked={enabled}
-                onClick={() => toggleStatusBarItem(toggle.id)}
-                className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent transition-colors ${
-                  enabled ? 'bg-foreground' : 'bg-muted-foreground/30'
-                }`}
-              >
-                <span
-                  className={`pointer-events-none block size-3.5 rounded-full bg-background shadow-sm transition-transform ${
-                    enabled ? 'translate-x-4' : 'translate-x-0.5'
-                  }`}
-                />
-              </button>
+              <ToggleSwitchButton
+                checked={enabled}
+                onToggle={() => toggleStatusBarItem(toggle.id)}
+                ariaLabel={toggle.title}
+              />
             </SearchableSetting>
           )
         })}
@@ -372,24 +393,10 @@ export function AppearancePane({
               Show the Tasks button at the top of the left sidebar.
             </p>
           </div>
-          <button
-            role="switch"
-            aria-checked={settings.showTasksButton}
-            onClick={() =>
-              updateSettings({
-                showTasksButton: !settings.showTasksButton
-              })
-            }
-            className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent transition-colors ${
-              settings.showTasksButton ? 'bg-foreground' : 'bg-muted-foreground/30'
-            }`}
-          >
-            <span
-              className={`pointer-events-none block size-3.5 rounded-full bg-background shadow-sm transition-transform ${
-                settings.showTasksButton ? 'translate-x-4' : 'translate-x-0.5'
-              }`}
-            />
-          </button>
+          <ToggleSwitchButton
+            checked={settings.showTasksButton}
+            onToggle={() => updateSettings({ showTasksButton: !settings.showTasksButton })}
+          />
         </SearchableSetting>
       </section>
     ) : null

--- a/src/renderer/src/runtime/runtime-git-client.test.ts
+++ b/src/renderer/src/runtime/runtime-git-client.test.ts
@@ -64,6 +64,37 @@ describe('runtime git client', () => {
     expect(runtimeEnvironmentCall).not.toHaveBeenCalled()
   })
 
+  it('forwards includeIgnored to local git status only when enabled', async () => {
+    gitStatus.mockResolvedValue({ entries: [], conflictOperation: 'unknown' })
+
+    await getRuntimeGitStatus(
+      {
+        settings: { activeRuntimeEnvironmentId: null },
+        worktreeId: 'wt-1',
+        worktreePath: '/repo'
+      },
+      { includeIgnored: true }
+    )
+    await getRuntimeGitStatus(
+      {
+        settings: { activeRuntimeEnvironmentId: null },
+        worktreeId: 'wt-1',
+        worktreePath: '/repo'
+      },
+      { includeIgnored: false }
+    )
+
+    expect(gitStatus).toHaveBeenNthCalledWith(1, {
+      worktreePath: '/repo',
+      connectionId: undefined,
+      includeIgnored: true
+    })
+    expect(gitStatus).toHaveBeenNthCalledWith(2, {
+      worktreePath: '/repo',
+      connectionId: undefined
+    })
+  })
+
   it('routes status and diffs through the active runtime environment', async () => {
     runtimeEnvironmentCall.mockResolvedValue({
       id: 'rpc-1',
@@ -101,6 +132,31 @@ describe('runtime git client', () => {
         staged: false,
         compareAgainstHead: true
       },
+      timeoutMs: 15_000
+    })
+  })
+
+  it('forwards includeIgnored through the active runtime environment', async () => {
+    runtimeEnvironmentCall.mockResolvedValue({
+      id: 'rpc-1',
+      ok: true,
+      result: { entries: [], conflictOperation: 'unknown', ignoredPaths: ['dist/'] },
+      _meta: { runtimeId: 'remote-runtime' }
+    })
+
+    await getRuntimeGitStatus(
+      {
+        settings: { activeRuntimeEnvironmentId: 'env-1' },
+        worktreeId: 'wt-1',
+        worktreePath: '/repo'
+      },
+      { includeIgnored: true }
+    )
+
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
+      selector: 'env-1',
+      method: 'git.status',
+      params: { worktree: 'wt-1', includeIgnored: true },
       timeoutMs: 15_000
     })
   })

--- a/src/renderer/src/runtime/runtime-git-client.ts
+++ b/src/renderer/src/runtime/runtime-git-client.ts
@@ -32,9 +32,6 @@ export async function getRuntimeGitStatus(
   options?: { includeIgnored?: boolean }
 ): Promise<GitStatusResult> {
   const target = getActiveRuntimeTarget(context.settings)
-  // Why: only attach includeIgnored when explicitly requested so the params
-  // shape stays identical to the pre-feature contract for callers that don't
-  // opt in. Both downstream branches treat a missing key as `false`.
   const includeIgnoredArgs = options?.includeIgnored ? { includeIgnored: true } : {}
   if (target.kind === 'local' || !context.worktreeId) {
     return window.api.git.status({

--- a/src/renderer/src/runtime/runtime-git-client.ts
+++ b/src/renderer/src/runtime/runtime-git-client.ts
@@ -27,18 +27,26 @@ export function getRuntimeGitScope(
   return target.kind === 'environment' ? `runtime:${target.environmentId}` : connectionId
 }
 
-export async function getRuntimeGitStatus(context: RuntimeGitContext): Promise<GitStatusResult> {
+export async function getRuntimeGitStatus(
+  context: RuntimeGitContext,
+  options?: { includeIgnored?: boolean }
+): Promise<GitStatusResult> {
   const target = getActiveRuntimeTarget(context.settings)
+  // Why: only attach includeIgnored when explicitly requested so the params
+  // shape stays identical to the pre-feature contract for callers that don't
+  // opt in. Both downstream branches treat a missing key as `false`.
+  const includeIgnoredArgs = options?.includeIgnored ? { includeIgnored: true } : {}
   if (target.kind === 'local' || !context.worktreeId) {
     return window.api.git.status({
       worktreePath: context.worktreePath,
-      connectionId: context.connectionId
+      connectionId: context.connectionId,
+      ...includeIgnoredArgs
     })
   }
   return callRuntimeRpc<GitStatusResult>(
     target,
     'git.status',
-    { worktree: context.worktreeId },
+    { worktree: context.worktreeId, ...includeIgnoredArgs },
     { timeoutMs: 15_000 }
   )
 }

--- a/src/renderer/src/store/slices/editor.test.ts
+++ b/src/renderer/src/store/slices/editor.test.ts
@@ -682,6 +682,24 @@ describe('createEditorSlice editor drafts', () => {
 })
 
 describe('createEditorSlice conflict status reconciliation', () => {
+  it('clears ignored path cache when status refresh omits ignored paths', () => {
+    const store = createEditorStore()
+
+    store.getState().setGitStatus('wt-1', {
+      conflictOperation: 'unknown',
+      entries: [],
+      ignoredPaths: ['dist/', '.env']
+    })
+    expect(store.getState().gitIgnoredPathsByWorktree['wt-1']).toEqual(['dist/', '.env'])
+
+    store.getState().setGitStatus('wt-1', {
+      conflictOperation: 'unknown',
+      entries: []
+    })
+
+    expect(store.getState().gitIgnoredPathsByWorktree['wt-1']).toEqual([])
+  })
+
   it('tracks unresolved conflicts when opened through the conflict-safe entry point', () => {
     const store = createEditorStore()
 

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -1900,12 +1900,11 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
       const operationUnchanged = prevOperation === status.conflictOperation
 
       const prevIgnored = s.gitIgnoredPathsByWorktree[worktreeId]
-      const nextIgnored = status.ignoredPaths
+      const nextIgnored = status.ignoredPaths ?? []
       const ignoredUnchanged =
-        nextIgnored === undefined ||
-        (prevIgnored !== undefined &&
-          prevIgnored.length === nextIgnored.length &&
-          prevIgnored.every((p, i) => p === nextIgnored[i]))
+        prevIgnored !== undefined &&
+        prevIgnored.length === nextIgnored.length &&
+        prevIgnored.every((p, i) => p === nextIgnored[i])
 
       if (
         statusUnchanged &&
@@ -1924,7 +1923,7 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
           : { ...s.gitStatusByWorktree, [worktreeId]: nextEntries },
         gitIgnoredPathsByWorktree: ignoredUnchanged
           ? s.gitIgnoredPathsByWorktree
-          : { ...s.gitIgnoredPathsByWorktree, [worktreeId]: nextIgnored ?? [] },
+          : { ...s.gitIgnoredPathsByWorktree, [worktreeId]: nextIgnored },
         gitConflictOperationByWorktree: operationUnchanged
           ? s.gitConflictOperationByWorktree
           : { ...s.gitConflictOperationByWorktree, [worktreeId]: status.conflictOperation },

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -298,8 +298,6 @@ export type EditorSlice = {
 
   // Git status cache
   gitStatusByWorktree: Record<string, GitStatusEntry[]>
-  // Why: separate slice so the file explorer's ignored decoration does not
-  // extend GitStatusEntry / GitStagingArea and break Source Control grouping.
   gitIgnoredPathsByWorktree: Record<string, string[]>
   gitConflictOperationByWorktree: Record<string, GitConflictOperation>
   trackedConflictPathsByWorktree: Record<string, Record<string, GitConflictKind>>
@@ -1901,8 +1899,6 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
       const openFilesUnchanged = nextOpenFiles === s.openFiles
       const operationUnchanged = prevOperation === status.conflictOperation
 
-      // Why: skip writing the ignored slice when the response didn't carry
-      // it (undefined when the caller didn't pass --ignored).
       const prevIgnored = s.gitIgnoredPathsByWorktree[worktreeId]
       const nextIgnored = status.ignoredPaths
       const ignoredUnchanged =

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -298,6 +298,12 @@ export type EditorSlice = {
 
   // Git status cache
   gitStatusByWorktree: Record<string, GitStatusEntry[]>
+  // Why: stored separately from gitStatusByWorktree (which is GitStatusEntry[]
+  // for Source Control grouping) so the file explorer's ignored decoration
+  // does not pollute staging-area code. Absent entries mean "ignored data
+  // wasn't requested or unavailable" — the explorer treats that as no
+  // decoration.
+  gitIgnoredPathsByWorktree: Record<string, string[]>
   gitConflictOperationByWorktree: Record<string, GitConflictOperation>
   trackedConflictPathsByWorktree: Record<string, Record<string, GitConflictKind>>
   trackConflictPath: (worktreeId: string, path: string, conflictKind: GitConflictKind) => void
@@ -1809,6 +1815,7 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
 
   // Git status
   gitStatusByWorktree: {},
+  gitIgnoredPathsByWorktree: {},
   gitConflictOperationByWorktree: {},
   trackedConflictPathsByWorktree: {},
   trackConflictPath: (worktreeId, path, conflictKind) =>
@@ -1897,7 +1904,27 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
       const openFilesUnchanged = nextOpenFiles === s.openFiles
       const operationUnchanged = prevOperation === status.conflictOperation
 
-      if (statusUnchanged && trackedUnchanged && openFilesUnchanged && operationUnchanged) {
+      // Why: only write the ignored slice when this status response actually
+      // carried ignored data — `ignoredPaths` is undefined when the caller
+      // didn't pass --ignored. Leaving the previous slice in place lets
+      // toggling the setting off keep the last-known decoration until the
+      // next poll without a flicker; the next on-poll (with the new flag)
+      // overwrites it anyway.
+      const prevIgnored = s.gitIgnoredPathsByWorktree[worktreeId]
+      const nextIgnored = status.ignoredPaths
+      const ignoredUnchanged =
+        nextIgnored === undefined ||
+        (prevIgnored !== undefined &&
+          prevIgnored.length === nextIgnored.length &&
+          prevIgnored.every((p, i) => p === nextIgnored[i]))
+
+      if (
+        statusUnchanged &&
+        trackedUnchanged &&
+        openFilesUnchanged &&
+        operationUnchanged &&
+        ignoredUnchanged
+      ) {
         return s
       }
 
@@ -1906,6 +1933,9 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
         gitStatusByWorktree: statusUnchanged
           ? s.gitStatusByWorktree
           : { ...s.gitStatusByWorktree, [worktreeId]: nextEntries },
+        gitIgnoredPathsByWorktree: ignoredUnchanged
+          ? s.gitIgnoredPathsByWorktree
+          : { ...s.gitIgnoredPathsByWorktree, [worktreeId]: nextIgnored ?? [] },
         gitConflictOperationByWorktree: operationUnchanged
           ? s.gitConflictOperationByWorktree
           : { ...s.gitConflictOperationByWorktree, [worktreeId]: status.conflictOperation },

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -298,11 +298,8 @@ export type EditorSlice = {
 
   // Git status cache
   gitStatusByWorktree: Record<string, GitStatusEntry[]>
-  // Why: stored separately from gitStatusByWorktree (which is GitStatusEntry[]
-  // for Source Control grouping) so the file explorer's ignored decoration
-  // does not pollute staging-area code. Absent entries mean "ignored data
-  // wasn't requested or unavailable" — the explorer treats that as no
-  // decoration.
+  // Why: separate slice so the file explorer's ignored decoration does not
+  // extend GitStatusEntry / GitStagingArea and break Source Control grouping.
   gitIgnoredPathsByWorktree: Record<string, string[]>
   gitConflictOperationByWorktree: Record<string, GitConflictOperation>
   trackedConflictPathsByWorktree: Record<string, Record<string, GitConflictKind>>
@@ -1904,12 +1901,8 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
       const openFilesUnchanged = nextOpenFiles === s.openFiles
       const operationUnchanged = prevOperation === status.conflictOperation
 
-      // Why: only write the ignored slice when this status response actually
-      // carried ignored data — `ignoredPaths` is undefined when the caller
-      // didn't pass --ignored. Leaving the previous slice in place lets
-      // toggling the setting off keep the last-known decoration until the
-      // next poll without a flicker; the next on-poll (with the new flag)
-      // overwrites it anyway.
+      // Why: skip writing the ignored slice when the response didn't carry
+      // it (undefined when the caller didn't pass --ignored).
       const prevIgnored = s.gitIgnoredPathsByWorktree[worktreeId]
       const nextIgnored = status.ignoredPaths
       const ignoredUnchanged =

--- a/src/renderer/src/store/slices/settings.test.ts
+++ b/src/renderer/src/store/slices/settings.test.ts
@@ -100,6 +100,7 @@ describe('createSettingsSlice runtime switching', () => {
       markdownViewMode: { '/env-1/repo/stale.md': 'rich' },
       editorViewMode: { '/env-1/repo/stale.md': 'changes' },
       editorCursorLine: { '/env-1/repo/stale.md': 4 },
+      gitIgnoredPathsByWorktree: { 'repo-env-1::/env-1/repo': ['dist/'] },
       prCache: { '/env-1/repo::main': { data: null, fetchedAt: Date.now() } },
       linearIssueCache: { 'LIN-1': { data: { id: 'LIN-1' } as never, fetchedAt: Date.now() } }
     })
@@ -144,6 +145,7 @@ describe('createSettingsSlice runtime switching', () => {
     expect(store.getState().markdownViewMode).toEqual({})
     expect(store.getState().editorViewMode).toEqual({})
     expect(store.getState().editorCursorLine).toEqual({})
+    expect(store.getState().gitIgnoredPathsByWorktree).toEqual({})
     expect(store.getState().ptyIdsByTabId).toEqual({})
     expect(store.getState().browserTabsByWorktree).toEqual({})
     expect(store.getState().prCache).toEqual({})

--- a/src/renderer/src/store/slices/settings.ts
+++ b/src/renderer/src/store/slices/settings.ts
@@ -76,6 +76,7 @@ function runtimeScopedStateReset(): Partial<AppState> {
     markdownViewMode: {},
     editorViewMode: {},
     editorCursorLine: {},
+    gitIgnoredPathsByWorktree: {},
     activeFileId: null,
     activeFileIdByWorktree: {},
     activeTabTypeByWorktree: {},

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -73,6 +73,7 @@ function createTestStore() {
         editorViewMode: {},
         expandedDirs: {},
         gitStatusByWorktree: {},
+        gitIgnoredPathsByWorktree: {},
         gitConflictOperationByWorktree: {},
         trackedConflictPathsByWorktree: {},
         gitBranchChangesByWorktree: {},
@@ -574,6 +575,10 @@ describe('removeWorktree state cleanup', () => {
         'repo1::/path/wt1': [{ path: 'a.ts' }],
         'repo1::/path/wt2': [{ path: 'b.ts' }]
       },
+      gitIgnoredPathsByWorktree: {
+        'repo1::/path/wt1': ['dist/'],
+        'repo1::/path/wt2': ['coverage/']
+      },
       gitConflictOperationByWorktree: {
         'repo1::/path/wt1': 'merge',
         'repo1::/path/wt2': 'unknown'
@@ -600,6 +605,9 @@ describe('removeWorktree state cleanup', () => {
 
     expect(store.getState().gitStatusByWorktree).toEqual({
       'repo1::/path/wt2': [{ path: 'b.ts' }]
+    })
+    expect(store.getState().gitIgnoredPathsByWorktree).toEqual({
+      'repo1::/path/wt2': ['coverage/']
     })
     expect(store.getState().gitConflictOperationByWorktree).toEqual({
       'repo1::/path/wt2': 'unknown'
@@ -955,6 +963,11 @@ describe('fetchAllWorktrees hydration-time purge (design §4.4)', () => {
         'repoA::/a/wt1': [{ id: 'tab-A', worktreeId: 'repoA::/a/wt1' }],
         'repoA::/a/zombie': [{ id: 'tab-zombie', worktreeId: 'repoA::/a/zombie' }],
         'repoB::/b/wt1': [{ id: 'tab-B', worktreeId: 'repoB::/b/wt1' }]
+      },
+      gitIgnoredPathsByWorktree: {
+        'repoA::/a/wt1': ['dist/'],
+        'repoA::/a/zombie': ['coverage/'],
+        'repoB::/b/wt1': ['build/']
       }
     } as unknown as Partial<AppState>)
 
@@ -965,6 +978,10 @@ describe('fetchAllWorktrees hydration-time purge (design §4.4)', () => {
     expect(store.getState().tabsByWorktree).toEqual({
       'repoA::/a/wt1': [{ id: 'tab-A', worktreeId: 'repoA::/a/wt1' }],
       'repoB::/b/wt1': [{ id: 'tab-B', worktreeId: 'repoB::/b/wt1' }]
+    })
+    expect(store.getState().gitIgnoredPathsByWorktree).toEqual({
+      'repoA::/a/wt1': ['dist/'],
+      'repoB::/b/wt1': ['build/']
     })
 
     // Second call must not re-run the purge even if new stale ids appear.
@@ -1025,6 +1042,10 @@ describe('purgeWorktreeTerminalState direct (design §4.4)', () => {
         }
       ],
       editorDrafts: { 'file-1': 'draft', 'file-99': 'other' },
+      gitIgnoredPathsByWorktree: {
+        'repoA::/a/wt1': ['dist/'],
+        'repoA::/a/wt2': ['coverage/']
+      },
       activeWorktreeId: 'repoA::/a/wt1',
       activeFileId: 'file-1',
       activeTabId: 'tab-1',
@@ -1042,6 +1063,7 @@ describe('purgeWorktreeTerminalState direct (design §4.4)', () => {
     expect(s.runtimePaneTitlesByTabId).toEqual({ 'tab-3': 'bash' })
     expect(s.openFiles).toEqual([])
     expect(s.editorDrafts).toEqual({ 'file-99': 'other' })
+    expect(s.gitIgnoredPathsByWorktree).toEqual({ 'repoA::/a/wt2': ['coverage/'] })
     expect(s.activeWorktreeId).toBeNull()
     expect(s.activeFileId).toBeNull()
     expect(s.activeTabId).toBeNull()

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -475,6 +475,8 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
         // request keys indefinitely in a long-lived renderer session.
         const nextGitStatusByWorktree = { ...s.gitStatusByWorktree }
         delete nextGitStatusByWorktree[worktreeId]
+        const nextGitIgnoredPathsByWorktree = { ...s.gitIgnoredPathsByWorktree }
+        delete nextGitIgnoredPathsByWorktree[worktreeId]
         const nextGitConflictOperationByWorktree = { ...s.gitConflictOperationByWorktree }
         delete nextGitConflictOperationByWorktree[worktreeId]
         const nextTrackedConflictPathsByWorktree = { ...s.trackedConflictPathsByWorktree }
@@ -567,6 +569,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
           editorViewMode: nextEditorViewMode,
           expandedDirs: nextExpandedDirs,
           gitStatusByWorktree: nextGitStatusByWorktree,
+          gitIgnoredPathsByWorktree: nextGitIgnoredPathsByWorktree,
           gitConflictOperationByWorktree: nextGitConflictOperationByWorktree,
           trackedConflictPathsByWorktree: nextTrackedConflictPathsByWorktree,
           gitBranchChangesByWorktree: nextGitBranchChangesByWorktree,
@@ -1138,6 +1141,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
         activeGroupIdByWorktree: omitByWorktree(s.activeGroupIdByWorktree),
         // Git status caches
         gitStatusByWorktree: omitByWorktree(s.gitStatusByWorktree),
+        gitIgnoredPathsByWorktree: omitByWorktree(s.gitIgnoredPathsByWorktree),
         gitConflictOperationByWorktree: omitByWorktree(s.gitConflictOperationByWorktree),
         trackedConflictPathsByWorktree: omitByWorktree(s.trackedConflictPathsByWorktree),
         gitBranchChangesByWorktree: omitByWorktree(s.gitBranchChangesByWorktree),

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -439,9 +439,9 @@ function createFileApi(): NonNullable<Partial<PreloadApi>['fs']> {
 
 function createGitApi(): NonNullable<Partial<PreloadApi>['git']> {
   return {
-    status: async ({ worktreePath }) => {
+    status: async ({ worktreePath, includeIgnored }) => {
       const worktree = await resolveRuntimeWorktreeByPath(worktreePath)
-      return callRuntimeResult('git.status', { worktree: worktree.id })
+      return callRuntimeResult('git.status', { worktree: worktree.id, includeIgnored })
     },
     conflictOperation: async ({ worktreePath }) => {
       const worktree = await resolveRuntimeWorktreeByPath(worktreePath)

--- a/src/shared/constants.test.ts
+++ b/src/shared/constants.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest'
+import { getDefaultSettings } from './constants'
+
+describe('getDefaultSettings', () => {
+  it('enables gitignored file decorations by default', () => {
+    expect(getDefaultSettings('/tmp').showGitIgnoredFiles).toBe(true)
+  })
+})

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -208,6 +208,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     terminalScrollbackBytes: 10_000_000,
     openLinksInApp: true,
     rightSidebarOpenByDefault: true,
+    showGitIgnoredFiles: true,
     showTitlebarAppName: true,
     showTasksButton: true,
     floatingTerminalEnabled: true,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1264,6 +1264,13 @@ export type GlobalSettings = {
    *  until the user explicitly wants worktree-scoped in-app browsing. */
   openLinksInApp: boolean
   rightSidebarOpenByDefault: boolean
+  /** Why: surfaces `.gitignore`d files in the explorer with a dimmed/italic
+   *  decoration so users can still see them at a glance. Off skips the
+   *  `--ignored=matching` flag on `git status`, keeping the porcelain payload
+   *  small for large repos with heavy build artifacts (mostly relevant for
+   *  remote SSH worktrees). Optional + default true via the persistence merge
+   *  so existing profiles inherit the new behavior on upgrade. */
+  showGitIgnoredFiles?: boolean
   /** Whether to show the Orca app name in the titlebar. */
   showTitlebarAppName: boolean
   /** Why: some users do not use the Tasks feature and prefer to keep the
@@ -1868,6 +1875,11 @@ export type GitStatusResult = {
   // Why: porcelain v2 status already includes upstream/ahead/behind metadata.
   // Folding it in lets refresh polling avoid a second pair of git subprocesses.
   upstreamStatus?: GitUpstreamStatus
+  // Why: optional so existing callers and pre-feature relay versions keep
+  // typing as before. Populated only when the caller opts in via
+  // `includeIgnored` — the file explorer reads this to dim ignored paths
+  // without polluting GitStatusEntry / staging-area grouping in Source Control.
+  ignoredPaths?: string[]
 }
 
 // Why: when hasUpstream is false, ahead/behind are placeholder zeros, not a

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1264,12 +1264,6 @@ export type GlobalSettings = {
    *  until the user explicitly wants worktree-scoped in-app browsing. */
   openLinksInApp: boolean
   rightSidebarOpenByDefault: boolean
-  /** Why: surfaces `.gitignore`d files in the explorer with a dimmed/italic
-   *  decoration so users can still see them at a glance. Off skips the
-   *  `--ignored=matching` flag on `git status`, keeping the porcelain payload
-   *  small for large repos with heavy build artifacts (mostly relevant for
-   *  remote SSH worktrees). Optional + default true via the persistence merge
-   *  so existing profiles inherit the new behavior on upgrade. */
   showGitIgnoredFiles?: boolean
   /** Whether to show the Orca app name in the titlebar. */
   showTitlebarAppName: boolean
@@ -1875,10 +1869,6 @@ export type GitStatusResult = {
   // Why: porcelain v2 status already includes upstream/ahead/behind metadata.
   // Folding it in lets refresh polling avoid a second pair of git subprocesses.
   upstreamStatus?: GitUpstreamStatus
-  // Why: optional so existing callers and pre-feature relay versions keep
-  // typing as before. Populated only when the caller opts in via
-  // `includeIgnored` — the file explorer reads this to dim ignored paths
-  // without polluting GitStatusEntry / staging-area grouping in Source Control.
   ignoredPaths?: string[]
 }
 


### PR DESCRIPTION
## Summary

Adds a visual decoration in the right-sidebar file explorer for files matched by `.gitignore`: italicised, dimmed filename plus a `CircleSlash` icon in the same trailing slot used for git status letters (`M`, `U`, `A`, etc.). A real git status always wins — the "ignored" treatment only renders when no other status is present.

Gated behind a new global setting **`showGitIgnoredFiles`** (default **on**) under *Settings → Appearance → Layout*. Disabling it skips the extra `--ignored=matching` argument on the polled `git status`, which matters for large remote SSH workspaces with heavy build artifacts.

### Why a separate field instead of extending `GitFileStatus`

`ignoredPaths: string[]` lives as a peer field on `GitStatusResult` rather than a new variant of `GitFileStatus` / `GitStagingArea`. That keeps Source Control's `staged / unstaged / untracked` grouping completely untouched — adding an `'ignored'` area would have required a fourth group and filtering at every grouping site.

The renderer builds a `Set<string>` from the field and uses an ancestor-walk lookup (`isPathIgnored`) so children of an ignored directory inherit the decoration when expanded (since `--ignored=matching` reports `dist/` once, not every file inside).

## Screenshots

<img width="727" height="589" alt="File explorer showing gitignored entries in italic + dimmed gray with a CircleSlash icon next to the filename" src="https://github.com/user-attachments/assets/3ab7c9ba-b13c-415c-a625-d4420c5119a6" />

## Testing

- [x] `pnpm lint` — 0 warnings, 0 errors
- [x] `pnpm typecheck` — clean (node + cli + web configs)
- [x] `pnpm test` — 191/191 in touched test files (`status.test.ts`, `status-display.test.ts`, `git-status-refresh.test.ts`, `runtime-git-client.test.ts`, `ssh-git-provider.test.ts`, `git-handler.test.ts`, `editor.test.ts`, `worktrees.test.ts`, RPC `git.test.ts`)
- [x] `pnpm build` — full pipeline (relay, computer-macos, electron-vite, web, cli) succeeded
- [x] `pnpm check:feature-wall-assets` + `pnpm verify:macos-entitlements` — both clean
- [x] Added high-quality tests:
  - new `status-display.test.ts` covering `buildIgnoredSet` (trailing-slash normalisation) and `isPathIgnored` (direct match, ancestor inheritance, sibling-prefix negative case)
  - two new `getStatus` tests in `status.test.ts`: omits `--ignored` and `ignoredPaths` when not requested; parses `!` porcelain v2 records when `includeIgnored: true`
  - updated `git-status-refresh.test.ts` to reflect the default-on `includeIgnored` behaviour

## AI Review Report

Reviewed end-to-end with Claude (Opus 4.7, 1M context). Risks explicitly checked:

- **Cross-platform compatibility (macOS / Linux / Windows)**:
  - Uses `path.join` / `joinPath` / `normalizeRelativePath` — no hardcoded `/` or `\\` (per CONTRIBUTING.md).
  - Does not touch keyboard shortcuts, menu accelerators, or shortcut labels.
  - The `dist/` trailing-slash normalisation in `buildIgnoredSet` is platform-agnostic (git emits POSIX-style separators in porcelain output regardless of host OS).
  - `core.quotePath=false` preserved — UTF-8 paths (Japanese, emoji) keep working, italic decoration renders correctly on non-ASCII names.
- **SSH parity**: the same `includeIgnored` flag is plumbed through the SSH provider (`mux.request('git.status', { includeIgnored })`) and the relay parser (`parseStatusOutput` recognises `!` records). The setting controls both local and remote runs identically.
- **Test argv stability**: existing tests assert exact argument shapes on `runtime.getRuntimeGitStatus`, `SshGitProvider.getStatus`, and the RPC handler. The flag is only forwarded when truthy, so legacy callers see byte-identical calls.
- **No Electron-specific surfaces touched** beyond a JSON-serializable IPC payload extension (`git:status` now accepts an optional `includeIgnored?: boolean`). Reflected in `src/preload/api-types.ts` and `src/preload/index.ts` together.
- **Store hygiene**: new `gitIgnoredPathsByWorktree` slice is cleaned up on worktree removal in both code paths (active-worktree delete in `worktrees.ts:476` and bulk omit in `worktrees.ts:1143`).
- **Polling cost**: `--ignored=matching` (not `traditional`) lists only files explicitly matched by patterns, not the recursive contents of ignored directories, keeping payload bounded on the 3 s poll.

Items flagged and addressed during review:
1. Initial draft added `'ignored'` to `GitFileStatus` / `GitStagingArea` — would have broken `SourceControl.tsx:495-508` (groups by `area`, would throw on a fourth value). Refactored to peer field, no SourceControl change needed.
2. `setGitStatus` originally always wrote the ignored slice — added a diff-aware comparison so the selector doesn't fire unnecessary re-renders.
3. `AppearancePane.tsx` crossed `max-lines: 400` after the new toggle; extracted a `ToggleSwitchButton` local component and applied it to the four inline switches (gain: file got shorter, less duplication).

## Security Audit

Reviewed with Claude. Surface touched:

- **Command execution**: extends an existing safe `gitExecFileAsync` call by appending a constant literal `--ignored=matching`. No user-controlled string flows into argv.
- **Path handling**: ignored paths from `git status --porcelain=v2` (already trusted source). They're stored in a `Set<string>` and consumed only for equality / ancestor checks against `TreeNode.relativePath`; never fed back to shell, fs, or render-HTML sinks beyond text content of a filename (already done for every node).
- **IPC**: new optional `includeIgnored?: boolean` on `git:status` invoke args. Boolean coercion only (`params.includeIgnored === true`), no untrusted strings introduced.
- **Auth / secrets / network**: no changes.
- **Dependencies**: none added.

No follow-up needed.

## Notes

- The `showGitIgnoredFiles` setting persists via the existing settings store; new field is optional in `GlobalSettings` so pre-existing profiles inherit the default-on behaviour via the `{ ...defaults, ...parsed }` merge in `persistence.ts` without a migration.
- Italic style uses Tailwind's `italic` utility; color uses the new `--git-decoration-ignored` token in `main.css` (light `#8c8c8c`, dark `#6e6e6e`) following the VS Code `gitDecoration.ignoredResourceForeground` convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
