### PR TITLE
Fix Droid native title completion notifications

### DIFF
--- a/src/renderer/src/lib/agent-status.test.ts
+++ b/src/renderer/src/lib/agent-status.test.ts
@@ -200,6 +200,11 @@ describe('detectAgentStatusFromTitle', () => {
     expect(detectAgentStatusFromTitle('Droid working')).toBe('working')
   })
 
+  it('does not treat Factory Droid native needs-input titles as completion', () => {
+    expect(detectAgentStatusFromTitle('Factory Droid needs input')).toBeNull()
+    expect(detectAgentStatusFromTitle('Factory Droid needs your input')).toBeNull()
+  })
+
   // --- Case insensitivity ---
   it('is case-insensitive for agent names', () => {
     expect(detectAgentStatusFromTitle('CLAUDE')).toBe('idle')
@@ -486,6 +491,15 @@ describe('createAgentStatusTracker', () => {
     tracker.handleTitle('⠋ π - my-project')
     tracker.handleTitle('π - my-project')
     expect(onBecameIdle).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not fire when Factory Droid reports needs input during a working turn', () => {
+    const onBecameIdle = vi.fn()
+    const tracker = createAgentStatusTracker(onBecameIdle)
+
+    tracker.handleTitle('⠋ Droid')
+    tracker.handleTitle('Factory Droid needs input')
+    expect(onBecameIdle).not.toHaveBeenCalled()
   })
 
   // --- Multiple cycles ---

--- a/src/shared/agent-detection.ts
+++ b/src/shared/agent-detection.ts
@@ -151,9 +151,13 @@ function containsBrailleSpinner(title: string): boolean {
   return false
 }
 
-function containsAgentName(title: string): boolean {
+function containsLegacyAgentName(title: string): boolean {
   const lower = title.toLowerCase()
-  return AGENT_NAMES.some((name) => lower.includes(name)) || DROID_AGENT_NAME_RE.test(title)
+  return AGENT_NAMES.some((name) => lower.includes(name))
+}
+
+function containsAgentName(title: string): boolean {
+  return containsLegacyAgentName(title) || DROID_AGENT_NAME_RE.test(title)
 }
 
 function containsAny(title: string, words: readonly string[]): boolean {
@@ -413,7 +417,9 @@ export function detectAgentStatusFromTitle(title: string): AgentStatus | null {
     return 'working'
   }
 
-  if (containsAgentName(title)) {
+  const hasDroidAgentName = DROID_AGENT_NAME_RE.test(title)
+  const hasLegacyAgentName = containsLegacyAgentName(title)
+  if (hasLegacyAgentName || hasDroidAgentName) {
     if (containsAny(title, ['action required', 'permission', 'waiting'])) {
       return 'permission'
     }
@@ -441,6 +447,13 @@ export function detectAgentStatusFromTitle(title: string): AgentStatus | null {
     }
     if (title.startsWith('* ')) {
       return 'idle'
+    }
+
+    // Why: Factory Droid can publish native titles like "Factory Droid needs
+    // input" while an Execute tool is still sleeping. Droid's hook events are
+    // authoritative; don't turn a name-only native title into a completion.
+    if (hasDroidAgentName && !hasLegacyAgentName) {
+      return null
     }
 
     return 'idle'

--- a/tests/e2e/droid-notification.spec.ts
+++ b/tests/e2e/droid-notification.spec.ts
@@ -1,0 +1,98 @@
+import { test, expect } from './helpers/orca-app'
+import type { ElectronApplication } from '@stablyai/playwright-test'
+import {
+  sendToTerminal,
+  waitForActivePanePtyId,
+  waitForActiveTerminalManager,
+  waitForTerminalOutput
+} from './helpers/terminal'
+import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+
+type NotificationDispatch = {
+  source?: string
+  terminalTitle?: string
+}
+
+async function emitOscTitle(
+  page: Parameters<typeof sendToTerminal>[0],
+  ptyId: string,
+  title: string
+) {
+  await sendToTerminal(page, ptyId, `printf '\\033]0;${title}\\007'\r`)
+}
+
+async function installMainProcessNotificationDispatchSpy(app: ElectronApplication): Promise<void> {
+  await app.evaluate(({ ipcMain }) => {
+    const g = globalThis as unknown as {
+      __notificationDispatchLog?: NotificationDispatch[]
+      __notificationDispatchSpyInstalled?: boolean
+    }
+    if (g.__notificationDispatchSpyInstalled) {
+      return
+    }
+    g.__notificationDispatchLog = []
+    g.__notificationDispatchSpyInstalled = true
+    ipcMain.removeHandler('notifications:dispatch')
+    ipcMain.handle('notifications:dispatch', (_event: unknown, args: NotificationDispatch) => {
+      g.__notificationDispatchLog!.push(args)
+      return { delivered: true }
+    })
+  })
+}
+
+async function getNotificationDispatches(
+  app: ElectronApplication
+): Promise<NotificationDispatch[]> {
+  return app.evaluate(() => {
+    const g = globalThis as unknown as { __notificationDispatchLog?: NotificationDispatch[] }
+    return g.__notificationDispatchLog ?? []
+  })
+}
+
+test.describe('Droid notifications', () => {
+  test('Factory Droid needs-input native title does not dispatch a task-complete notification', async ({
+    orcaPage,
+    electronApp
+  }) => {
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+    await ensureTerminalVisible(orcaPage)
+    await waitForActiveTerminalManager(orcaPage, 30_000)
+    // Why: contextBridge freezes window.api, so notification invokes must be
+    // observed in Electron's main process rather than monkey-patched renderer-side.
+    await installMainProcessNotificationDispatchSpy(electronApp)
+
+    const ptyId = await waitForActivePanePtyId(orcaPage)
+    const marker = `__DROID_NOTIFY_READY_${Date.now()}__`
+    await sendToTerminal(orcaPage, ptyId, `printf '${marker}\\n'\r`)
+    await waitForTerminalOutput(orcaPage, marker)
+
+    await emitOscTitle(orcaPage, ptyId, '⠋ Droid')
+    await emitOscTitle(orcaPage, ptyId, 'Factory Droid needs input')
+
+    await expect
+      .poll(
+        async () =>
+          orcaPage.evaluate(() => {
+            const store = window.__store
+            if (!store) {
+              return false
+            }
+            return Object.values(store.getState().tabsByWorktree ?? {})
+              .flat()
+              .some((tab) => tab.title === 'Factory Droid needs input')
+          }),
+        {
+          timeout: 10_000,
+          message: 'Factory Droid marker title did not land'
+        }
+      )
+      .toBe(true)
+
+    // Why: Factory Droid can show this title while Execute is still running
+    // (for example `sleep 180`); hook events own Droid status, not this title.
+    await orcaPage.waitForTimeout(500)
+    const dispatches = await getNotificationDispatches(electronApp)
+    expect(dispatches).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary
- Stop treating Droid-only native terminal titles like `Factory Droid needs input` as idle/completion signals.
- Preserve explicit synthesized Droid status/title handling for working, ready, and permission states.
- Add unit and Electron e2e regression coverage for the notification path.

## Fixes
Fixes Orca feedback from `lukeaus` on Orca 1.4.1 / macOS 25.2.0: Factory Droids incorrectly sent native macOS notifications saying `Factory Droid needs input` after commands like `Execute sleep 180`, even though no user input was needed.

## Verification
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/agent-status.test.ts`
- `pnpm exec playwright test tests/e2e/droid-notification.spec.ts --config tests/playwright.config.ts --project=electron-headless`
- `pnpm exec oxlint src/shared/agent-detection.ts src/renderer/src/lib/agent-status.test.ts tests/e2e/droid-notification.spec.ts`
- `pnpm exec oxfmt --check src/shared/agent-detection.ts src/renderer/src/lib/agent-status.test.ts tests/e2e/droid-notification.spec.ts`
- Live `$electron` verification via `playwright-cli` CDP: shell-emitted OSC titles updated the tab to `Factory Droid needs input` and the real frozen `window.api.notifications.dispatch` was called 0 times.

## Notes
- `pnpm exec tsgo --noEmit -p config/tsconfig.web.json` currently fails before this change on the repo config: TypeScript reports removed `baseUrl` / non-relative path settings.