### PR TITLE
Block publishing merged pull request branches

### DIFF
--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -462,12 +462,15 @@ function SourceControlInner(): React.JSX.Element {
   const branchName = activeWorktree?.branch.replace(/^refs\/heads\//, '') ?? 'HEAD'
   const hostedReviewCacheKey =
     activeRepo && branchName ? getHostedReviewCacheKey(activeRepo.path, branchName, settings) : null
+  const hostedReviewEntry = hostedReviewCacheKey ? hostedReviewCache[hostedReviewCacheKey] : undefined
   const hostedReview: HostedReviewInfo | null = hostedReviewCacheKey
-    ? (hostedReviewCache[hostedReviewCacheKey]?.data ?? null)
+    ? (hostedReviewEntry?.data ?? null)
     : null
 
   const linkedGitHubPR = activeWorktree?.linkedPR ?? null
   const linkedGitLabMR = activeWorktree?.linkedGitLabMR ?? null
+  const isHostedReviewStateLoading =
+    (linkedGitHubPR !== null || linkedGitLabMR !== null) && hostedReviewEntry === undefined
   useEffect(() => {
     if (!isBranchVisible || !activeRepo || isFolder || !branchName || branchName === 'HEAD') {
       return
@@ -894,6 +897,8 @@ function SourceControlInner(): React.JSX.Element {
         isCommitting,
         isRemoteOperationActive,
         upstreamStatus: remoteStatus,
+        prState: hostedReview?.state ?? null,
+        isPRStateLoading: isHostedReviewStateLoading,
         inFlightRemoteOpKind
       }),
     [
@@ -903,6 +908,8 @@ function SourceControlInner(): React.JSX.Element {
       isCommitting,
       isRemoteOperationActive,
       inFlightRemoteOpKind,
+      isHostedReviewStateLoading,
+      hostedReview?.state,
       remoteStatus,
       unresolvedConflicts.length
     ]
@@ -918,6 +925,8 @@ function SourceControlInner(): React.JSX.Element {
         isCommitting,
         isRemoteOperationActive,
         upstreamStatus: remoteStatus,
+        prState: hostedReview?.state ?? null,
+        isPRStateLoading: isHostedReviewStateLoading,
         inFlightRemoteOpKind
       }),
     [
@@ -927,6 +936,8 @@ function SourceControlInner(): React.JSX.Element {
       isCommitting,
       isRemoteOperationActive,
       inFlightRemoteOpKind,
+      isHostedReviewStateLoading,
+      hostedReview?.state,
       remoteStatus,
       unresolvedConflicts.length
     ]

--- a/src/renderer/src/components/right-sidebar/source-control-dropdown-items.test.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-dropdown-items.test.ts
@@ -168,6 +168,39 @@ describe('resolveDropdownItems', () => {
     expect(byKind.publish.disabled).toBe(false)
   })
 
+  it('does not mention Publish Branch when the linked PR is already merged', () => {
+    const items = resolveDropdownItems(
+      inputs({
+        upstreamStatus: { hasUpstream: false, ahead: 0, behind: 0 },
+        prState: 'merged'
+      })
+    )
+    const byKind = Object.fromEntries(
+      items.filter((e) => e.kind !== 'separator').map((e) => [e.kind, e])
+    )
+    expect(byKind.push.title).toBe('PR is already merged')
+    expect(byKind.pull.title).toBe('PR is already merged')
+    expect(byKind.sync.title).toBe('PR is already merged')
+    expect(byKind.publish.label).toBe('PR Status')
+    expect(byKind.publish.title).toBe('PR is already merged')
+    expect(byKind.publish.disabled).toBe(true)
+  })
+
+  it('waits for linked PR state before showing a publish prompt', () => {
+    const items = resolveDropdownItems(
+      inputs({
+        upstreamStatus: { hasUpstream: false, ahead: 0, behind: 0 },
+        isPRStateLoading: true
+      })
+    )
+    const byKind = Object.fromEntries(
+      items.filter((e) => e.kind !== 'separator').map((e) => [e.kind, e])
+    )
+    expect(byKind.publish.label).toBe('PR Status')
+    expect(byKind.publish.title).toBe('Checking PR status…')
+    expect(byKind.publish.disabled).toBe(true)
+  })
+
   it('omits counts from compound commit labels even when ahead/behind are nonzero', () => {
     // Why: the commit itself changes ahead/behind, so pre-commit counts would
     // be stale the moment the action fires. Plain Push/Pull/Sync continue to

--- a/src/renderer/src/components/right-sidebar/source-control-dropdown-items.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-dropdown-items.ts
@@ -58,7 +58,9 @@ export function resolveDropdownItems(inputs: PrimaryActionInputs): DropdownEntry
     hasUnresolvedConflicts,
     isCommitting,
     isRemoteOperationActive,
-    upstreamStatus
+    upstreamStatus,
+    prState,
+    isPRStateLoading
   } = inputs
 
   const hasStaged = stagedCount > 0
@@ -71,6 +73,8 @@ export function resolveDropdownItems(inputs: PrimaryActionInputs): DropdownEntry
   // button's stable-frame guarantee extends to the dropdown.
   const upstreamLoading = upstreamStatus === undefined
   const hasUpstream = upstreamStatus?.hasUpstream ?? false
+  const publishBlockedByMergedPR = !hasUpstream && prState === 'merged'
+  const publishBlockedByPRLoading = !hasUpstream && !!isPRStateLoading
   const ahead = upstreamStatus?.ahead ?? 0
   const behind = upstreamStatus?.behind ?? 0
 
@@ -108,19 +112,35 @@ export function resolveDropdownItems(inputs: PrimaryActionInputs): DropdownEntry
   // so the "publish first" instruction is consistent across the menu.
   const commitPushTitle = upstreamLoading
     ? 'Checking branch status…'
-    : !hasUpstream
-      ? 'Publish the branch first to push commits'
-      : (commitDisabledReason ?? 'Commit staged changes and push')
+    : publishBlockedByPRLoading
+      ? 'Checking PR status…'
+      : publishBlockedByMergedPR
+        ? 'PR is already merged'
+        : !hasUpstream
+          ? 'Publish the branch first to push commits'
+          : (commitDisabledReason ?? 'Commit staged changes and push')
   const commitPushItem: DropdownItem = {
     kind: 'commit_push',
     label: 'Commit & Push',
     title: commitPushTitle,
-    disabled: globalBusy || upstreamLoading || !hasUpstream || commitDisabledReason !== null
+    disabled:
+      globalBusy ||
+      upstreamLoading ||
+      !hasUpstream ||
+      publishBlockedByPRLoading ||
+      publishBlockedByMergedPR ||
+      commitDisabledReason !== null
   }
 
   const commitSyncTitle = (() => {
     if (upstreamLoading) {
       return 'Checking branch status…'
+    }
+    if (publishBlockedByPRLoading) {
+      return 'Checking PR status…'
+    }
+    if (publishBlockedByMergedPR) {
+      return 'PR is already merged'
     }
     if (!hasUpstream) {
       // Why: mirror pushItem/syncItem — direct the user to Publish Branch
@@ -146,11 +166,15 @@ export function resolveDropdownItems(inputs: PrimaryActionInputs): DropdownEntry
     label: formatCountLabel('Push', ahead),
     title: upstreamLoading
       ? 'Checking branch status…'
-      : !hasUpstream
-        ? 'Publish the branch first to push commits'
-        : ahead === 0
-          ? 'Nothing to push'
-          : describePushCount(ahead),
+      : publishBlockedByPRLoading
+        ? 'Checking PR status…'
+        : publishBlockedByMergedPR
+          ? 'PR is already merged'
+          : !hasUpstream
+            ? 'Publish the branch first to push commits'
+            : ahead === 0
+              ? 'Nothing to push'
+              : describePushCount(ahead),
     disabled: globalBusy || upstreamLoading || !hasUpstream || ahead === 0
   }
 
@@ -159,11 +183,15 @@ export function resolveDropdownItems(inputs: PrimaryActionInputs): DropdownEntry
     label: formatCountLabel('Pull', behind),
     title: upstreamLoading
       ? 'Checking branch status…'
-      : !hasUpstream
-        ? 'Publish the branch first to pull commits'
-        : behind === 0
-          ? 'Nothing to pull'
-          : describePullCount(behind),
+      : publishBlockedByPRLoading
+        ? 'Checking PR status…'
+        : publishBlockedByMergedPR
+          ? 'PR is already merged'
+          : !hasUpstream
+            ? 'Publish the branch first to pull commits'
+            : behind === 0
+              ? 'Nothing to pull'
+              : describePullCount(behind),
     disabled: globalBusy || upstreamLoading || !hasUpstream || behind === 0
   }
 
@@ -172,11 +200,15 @@ export function resolveDropdownItems(inputs: PrimaryActionInputs): DropdownEntry
     label: formatSyncLabel('Sync', ahead, behind),
     title: upstreamLoading
       ? 'Checking branch status…'
-      : !hasUpstream
-        ? 'Publish the branch first to sync commits'
-        : ahead === 0 && behind === 0
-          ? 'Branch is up to date'
-          : describeSyncCounts(ahead, behind),
+      : publishBlockedByPRLoading
+        ? 'Checking PR status…'
+        : publishBlockedByMergedPR
+          ? 'PR is already merged'
+          : !hasUpstream
+            ? 'Publish the branch first to sync commits'
+            : ahead === 0 && behind === 0
+              ? 'Branch is up to date'
+              : describeSyncCounts(ahead, behind),
     disabled: globalBusy || upstreamLoading || !hasUpstream || (ahead === 0 && behind === 0)
   }
 
@@ -189,13 +221,22 @@ export function resolveDropdownItems(inputs: PrimaryActionInputs): DropdownEntry
 
   const publishItem: DropdownItem = {
     kind: 'publish',
-    label: 'Publish Branch',
+    label: publishBlockedByMergedPR || publishBlockedByPRLoading ? 'PR Status' : 'Publish Branch',
     title: upstreamLoading
       ? 'Checking branch status…'
-      : hasUpstream
-        ? 'Branch is already published'
-        : 'Publish this branch to origin',
-    disabled: globalBusy || upstreamLoading || hasUpstream
+      : publishBlockedByPRLoading
+        ? 'Checking PR status…'
+        : publishBlockedByMergedPR
+          ? 'PR is already merged'
+          : hasUpstream
+            ? 'Branch is already published'
+            : 'Publish this branch to origin',
+    disabled:
+      globalBusy ||
+      upstreamLoading ||
+      hasUpstream ||
+      publishBlockedByPRLoading ||
+      publishBlockedByMergedPR
   }
 
   return [

--- a/src/renderer/src/components/right-sidebar/source-control-primary-action.test.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-primary-action.test.ts
@@ -182,6 +182,16 @@ describe('resolvePrimaryAction', () => {
     })
   })
 
+  it.each([
+    [{ prState: 'merged' as const }, 'Nothing to commit. PR is already merged.'],
+    [{ isPRStateLoading: true }, 'Checking PR status…']
+  ])('does not offer Publish Branch when linked PR state blocks it', (overrides, title) => {
+    const result = resolvePrimaryAction(
+      inputs({ upstreamStatus: { hasUpstream: false, ahead: 0, behind: 0 }, ...overrides })
+    )
+    expect(result).toEqual({ kind: 'commit', label: 'Commit', title, disabled: true })
+  })
+
   it('returns Sync when clean + tracked + diverged both ways', () => {
     const result = resolvePrimaryAction(
       inputs({ upstreamStatus: { hasUpstream: true, ahead: 2, behind: 3 } })

--- a/src/renderer/src/components/right-sidebar/source-control-primary-action.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-primary-action.ts
@@ -1,6 +1,6 @@
 // Why: split from the combined primary+dropdown module because the primary and dropdown are independent derivations with different priority ladders; together they exceed the max-lines budget and tangle unrelated concerns.
 
-import type { GitUpstreamStatus } from '../../../../shared/types'
+import type { GitUpstreamStatus, PRState } from '../../../../shared/types'
 
 // Why: this module owns the pure state-machine logic for the Source Control
 // primary action (split button). Keeping the logic outside the React component
@@ -39,6 +39,8 @@ export type PrimaryActionInputs = {
   isCommitting: boolean
   isRemoteOperationActive: boolean
   upstreamStatus: GitUpstreamStatus | undefined
+  prState?: PRState | null
+  isPRStateLoading?: boolean
   // Why: which remote op is currently running, when one is. null when no
   // remote op is in flight. Used by the in-flight branch below to mirror
   // the user-triggered action on the primary button instead of leaving a
@@ -93,6 +95,8 @@ export function resolvePrimaryAction(inputs: PrimaryActionInputs): PrimaryAction
     isCommitting,
     isRemoteOperationActive,
     upstreamStatus,
+    prState,
+    isPRStateLoading,
     inFlightRemoteOpKind
   } = inputs
 
@@ -214,6 +218,24 @@ export function resolvePrimaryAction(inputs: PrimaryActionInputs): PrimaryAction
   }
 
   if (!upstreamStatus.hasUpstream) {
+    if (isPRStateLoading) {
+      return {
+        kind: 'commit',
+        label: 'Commit',
+        title: 'Checking PR status…',
+        disabled: true
+      }
+    }
+
+    if (prState === 'merged') {
+      return {
+        kind: 'commit',
+        label: 'Commit',
+        title: 'Nothing to commit. PR is already merged.',
+        disabled: true
+      }
+    }
+
     return {
       kind: 'publish',
       label: 'Publish Branch',


### PR DESCRIPTION
## Summary
- block Source Control publish/push/sync affordances when the linked review is already merged
- use hosted review state while preserving loading behavior for linked PR/MR worktrees
- add focused unit coverage for merged and loading states

## Tests
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/source-control-primary-action.test.ts src/renderer/src/components/right-sidebar/source-control-dropdown-items.test.ts