### PR TITLE
Fix right sidebar header drag region

### DIFF
--- a/docs/right-sidebar-header-drag.md
+++ b/docs/right-sidebar-header-drag.md
@@ -1,0 +1,54 @@
+# Right Sidebar Header Drag Region
+
+## Problem
+
+Right sidebar header blank space does not drag the window.
+
+- In top mode, the header row (`right-sidebar/index.tsx`, current line ~313) has no `-webkit-app-region: drag`.
+- In side mode, the title row (`right-sidebar/index.tsx`, current line ~332) has no `-webkit-app-region: drag`.
+- The app already uses draggable titlebar surfaces elsewhere (`.titlebar`, `.titlebar-left` in `main.css`), so this is an inconsistency.
+
+## Current Behavior (Verified)
+
+- `ActivityBarButton` renders plain `<button>` elements with no `no-drag` class.
+- Close button is already safe because `.sidebar-toggle` sets `-webkit-app-region: no-drag`.
+- Top-mode activity bar context menu is currently bound to the full header row via `ContextMenuTrigger`.
+- Side-mode activity bar context menu is bound to the side icon strip, not the side-mode title row.
+
+## Constraints That Matter
+
+- `-webkit-app-region: drag` is required for Electron window drag hit-testing.
+- Interactive descendants inside a drag region must be `-webkit-app-region: no-drag`, or click behavior becomes unreliable.
+- Do not depend on blank-space right-click inside a drag region for opening menus; attach context-menu trigger to a guaranteed `no-drag` target.
+- No visual/layout changes; keep existing Windows inset behavior (`right-sidebar-header-inset`, `right-sidebar-header-side-inset`, `side-activity-bar-windows-inset`).
+
+## Design
+
+1. Add utility classes in `src/renderer/src/assets/main.css`:
+   - `.right-sidebar-header-drag { -webkit-app-region: drag; user-select: none; }`
+   - `.right-sidebar-header-no-drag { -webkit-app-region: no-drag; }`
+2. Apply `.right-sidebar-header-drag` to both header wrappers:
+   - top activity-bar row
+   - side-mode title row
+3. Apply `.right-sidebar-header-no-drag` to all interactive header descendants:
+   - `ActivityBarButton` root button
+   - top-mode icon-row wrapper that owns context-menu trigger
+   - close button is already covered by `.sidebar-toggle` (keep as-is)
+4. Move top-mode `ContextMenuTrigger` from the whole header row to a `no-drag` target (icon-row wrapper). Do not bind it to the drag surface.
+5. Keep side-mode context-menu wiring on the side icon strip unchanged.
+
+## Validation
+
+- Top mode: blank area drags window.
+- Top mode: tab icons click reliably; close button click remains reliable.
+- Top mode: context menu opens from icon row (not blank drag area).
+- Side mode: title/blank area drags; close button remains clickable.
+- Left-edge resize handle remains usable (`z-10`, absolute overlay).
+- Windows: overlay controls do not cover close button/icons after insets.
+- Sidebar closed (`width: 0`, `overflow-hidden`): no leaked hit targets.
+
+## Concurrency / Consistency
+
+- Multi-window safe: renderer-local CSS/DOM only, no shared mutable state.
+- Store updates (`activityBarPosition`, `rightSidebarTab`, `rightSidebarOpen`) are safe: drag/no-drag is static class wiring on re-rendered elements.
+- No IPC or async cross-process dependency, so no invalidation races introduced.

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -470,6 +470,15 @@
   width: var(--window-controls-width, 0px);
 }
 
+.right-sidebar-header-drag {
+  -webkit-app-region: drag;
+  user-select: none;
+}
+
+.right-sidebar-header-no-drag {
+  -webkit-app-region: no-drag;
+}
+
 /* Why: the right sidebar header extends to the window's right edge. On Windows
    the fixed-position window-controls overlay sits on top of that edge, so we
    add matching padding-right so the header's close button (pr-1) isn't hidden

--- a/src/renderer/src/components/right-sidebar/index.tsx
+++ b/src/renderer/src/components/right-sidebar/index.tsx
@@ -309,14 +309,16 @@ function RightSidebarInner(): React.JSX.Element {
         {activityBarPosition === 'top' ? (
           /* ── Top activity bar: horizontal icon row ── */
           <ContextMenu>
-            <ContextMenuTrigger asChild>
-              <div className="flex items-center justify-between border-b border-border h-[36px] min-h-[36px] pl-2 pr-1 right-sidebar-header-inset">
-                <TooltipProvider delayDuration={400}>
-                  <div className="flex items-center">{activityBarIcons}</div>
-                  <div className="flex items-center">{closeButton}</div>
-                </TooltipProvider>
-              </div>
-            </ContextMenuTrigger>
+            <div className="flex items-center justify-between border-b border-border h-[36px] min-h-[36px] pl-2 pr-1 right-sidebar-header-inset right-sidebar-header-drag">
+              <TooltipProvider delayDuration={400}>
+                <ContextMenuTrigger asChild>
+                  <div className="flex items-center right-sidebar-header-no-drag">
+                    {activityBarIcons}
+                  </div>
+                </ContextMenuTrigger>
+                <div className="flex items-center">{closeButton}</div>
+              </TooltipProvider>
+            </div>
             <ActivityBarPositionMenu
               currentPosition={activityBarPosition}
               onChangePosition={setActivityBarPosition}
@@ -329,7 +331,7 @@ function RightSidebarInner(): React.JSX.Element {
              the panel header. right-sidebar-header-side-inset applies exactly
              that remainder (138-40=98px) as padding-right so the close button
              clears the minimize button without the full 138px gap. */
-          <div className="flex items-center justify-between h-[36px] min-h-[36px] px-3 border-b border-border right-sidebar-header-side-inset">
+          <div className="flex items-center justify-between h-[36px] min-h-[36px] px-3 border-b border-border right-sidebar-header-side-inset right-sidebar-header-drag">
             <span className="text-[11px] font-semibold uppercase tracking-wider text-foreground">
               {visibleItems.find((item) => item.id === effectiveTab)?.title ?? ''}
             </span>
@@ -423,7 +425,7 @@ function ActivityBarButton({
       <TooltipTrigger asChild>
         <button
           className={cn(
-            'relative flex items-center justify-center transition-colors',
+            'relative flex items-center justify-center transition-colors right-sidebar-header-no-drag',
             isTop ? 'h-[36px] w-9' : 'w-10 h-10',
             active ? 'text-foreground' : 'text-muted-foreground/60 hover:text-muted-foreground'
           )}


### PR DESCRIPTION
## Summary
- make the right sidebar top/title header blank space an Electron drag region
- keep header controls in no-drag regions so icons and close button remain clickable
- move the top activity-bar context menu trigger onto the no-drag icon row
- include design notes in `docs/right-sidebar-header-drag.md`

## Verification
- `pnpm typecheck`
- `pnpm lint`

## Note
Electron validation for native window dragging could not attach to a CDP target in this environment, so manual drag verification was not completed before this PR was opened.