### PR TITLE
perf(renderer): cache runtime tab projections by worktree

### DIFF
--- a/src/renderer/src/runtime/sync-runtime-graph-key-reuse.test.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph-key-reuse.test.ts
@@ -97,6 +97,63 @@ describe('runtime mobile session sync key projection reuse', () => {
     expect(titleTickKey.editorDraftsProjection).toBe(baseKey.editorDraftsProjection)
     expect(runtimeMobileSessionSyncKeysEqual(baseKey, titleTickKey)).toBe(false)
   })
+
+  it('does not rebuild serialized projections when only activeTabId changes', () => {
+    const base = makeState({
+      tabsByWorktree: {
+        'wt-1': [{ id: 'term-1', title: 'Codex working', customTitle: null }]
+      } as unknown as AppState['tabsByWorktree']
+    })
+    const baseKey = getRuntimeMobileSessionSyncKey(base)
+    const activated = makeState({
+      ...base,
+      activeTabId: 'term-1'
+    })
+
+    const stringifySpy = vi.spyOn(JSON, 'stringify')
+    stringifySpy.mockClear()
+    const activatedKey = getRuntimeMobileSessionSyncKey(activated, base, baseKey)
+
+    expect(stringifySpy).not.toHaveBeenCalled()
+    expect(activatedKey.tabsProjection).toBe(baseKey.tabsProjection)
+    expect(activatedKey.openFilesProjection).toBe(baseKey.openFilesProjection)
+    expect(activatedKey.editorDraftsProjection).toBe(baseKey.editorDraftsProjection)
+    expect(runtimeMobileSessionSyncKeysEqual(baseKey, activatedKey)).toBe(false)
+  })
+
+  it('reuses unchanged worktree tab projections when one worktree title changes', () => {
+    const unchangedTitle = vi.fn(() => 'Unchanged agent')
+    const unchangedTab = {
+      id: 'term-unchanged',
+      customTitle: null,
+      get title() {
+        return unchangedTitle()
+      }
+    }
+    const base = makeState({
+      tabsByWorktree: {
+        'wt-1': [{ id: 'term-1', title: 'Codex working', customTitle: null }],
+        'wt-2': [unchangedTab]
+      } as unknown as AppState['tabsByWorktree']
+    })
+    const baseKey = getRuntimeMobileSessionSyncKey(base)
+    expect(unchangedTitle).toHaveBeenCalled()
+    unchangedTitle.mockClear()
+
+    const titleTick = makeState({
+      ...base,
+      tabsByWorktree: {
+        ...base.tabsByWorktree,
+        'wt-1': [{ id: 'term-1', title: 'Codex spinner frame', customTitle: null }]
+      } as unknown as AppState['tabsByWorktree']
+    })
+
+    const titleTickKey = getRuntimeMobileSessionSyncKey(titleTick, base, baseKey)
+
+    expect(unchangedTitle).not.toHaveBeenCalled()
+    expect(titleTickKey.tabsProjection).not.toBe(baseKey.tabsProjection)
+    expect(runtimeMobileSessionSyncKeysEqual(baseKey, titleTickKey)).toBe(false)
+  })
 })
 
 describe('mobile session snapshot reuse', () => {

--- a/src/renderer/src/runtime/sync-runtime-graph.test.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph.test.ts
@@ -25,11 +25,12 @@ function makeState(overrides: Partial<AppState> = {}): AppState {
 // Why: the comparator at `runtimeMobileSessionSyncKeysEqual` checks
 // `terminalLayoutsByTabId`, `runtimePaneTitlesByTabId`, `groupsByWorktree`,
 // `activeGroupIdByWorktree`, `unifiedTabsByWorktree`, `tabBarOrderByWorktree`,
-// and `activeFileIdByWorktree` by reference. `makeState`'s defaults allocate
-// fresh `{}` for each, so two unrelated `makeState({...})` calls trivially
-// diverge. Tests that want to isolate a single field must share every other
-// reference-checked map between the two states; this factory produces one
-// `Partial<AppState>` whose fields can be spread into both `makeState` calls.
+// and `activeFileIdByWorktree` by reference, and checks `activeTabId` by scalar
+// equality. `makeState`'s defaults allocate fresh `{}` for each map, so two
+// unrelated `makeState({...})` calls trivially diverge. Tests that want to
+// isolate a single field must share every other reference-checked map between
+// the two states; this factory produces one `Partial<AppState>` whose fields
+// can be spread into both `makeState` calls.
 function makeSharedOverrides(): Partial<AppState> {
   return {
     tabsByWorktree: {},

--- a/src/renderer/src/runtime/sync-runtime-graph.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph.ts
@@ -30,6 +30,16 @@ type OpenFileIndexes = {
   byWorktreeAndId: OpenFileByWorktreeAndId
   idsByWorktree: Map<string, string[]>
 }
+type TabsProjectionCacheEntry = {
+  tabs: NonNullable<AppState['tabsByWorktree'][string]>
+  worktreeIdJson: string
+  projection: string
+}
+type TabsProjectionCache = {
+  source: AppState['tabsByWorktree']
+  entries: Map<string, TabsProjectionCacheEntry>
+  projection: string
+}
 
 const registeredTabs = new Map<string, RegisteredTerminalTab>()
 // Why: track when each tab was registered so we can suppress the "no live
@@ -43,6 +53,7 @@ let syncScheduled = false
 let syncEnabled = false
 let getStoreState: (() => AppState) | null = null
 let mobileSessionSnapshotVersion = 0
+let cachedTabsProjection: TabsProjectionCache | null = null
 let cachedOpenFileIndexesSource: AppState['openFiles'] | null = null
 let cachedOpenFileIndexes: OpenFileIndexes | null = null
 let cachedEditorDraftsSource: AppState['editorDrafts'] | null = null
@@ -117,10 +128,11 @@ export type RuntimeMobileSessionSyncKey = {
   tabBarOrderByWorktree: AppState['tabBarOrderByWorktree']
   activeFileId: AppState['activeFileId']
   activeFileIdByWorktree: AppState['activeFileIdByWorktree']
+  activeTabId: AppState['activeTabId']
   // Why: these projections still need value-level inspection because the
   // underlying references churn even when the mobile-relevant shape is
-  // unchanged (`tabsByWorktree` reallocates on every OSC title frame; the
-  // active-tab marker depends on `activeTabId`). Pre-serialize them once.
+  // unchanged (`tabsByWorktree` reallocates on every OSC title frame).
+  // Pre-serialize them once.
   tabsProjection: string
   openFilesProjection: string
   editorDraftsProjection: string
@@ -142,15 +154,14 @@ export function getRuntimeMobileSessionSyncKey(
     tabBarOrderByWorktree: state.tabBarOrderByWorktree,
     activeFileId: state.activeFileId,
     activeFileIdByWorktree: state.activeFileIdByWorktree,
+    activeTabId: state.activeTabId,
     // Why: background agent title ticks can change runtimePaneTitlesByTabId
     // many times per second while the user types elsewhere. Reuse unchanged
     // projections so those ticks do not rescan all tabs, files, and drafts.
     tabsProjection:
-      canReusePrevious &&
-      state.tabsByWorktree === previousState.tabsByWorktree &&
-      state.activeTabId === previousState.activeTabId
+      canReusePrevious && state.tabsByWorktree === previousState.tabsByWorktree
         ? previousKey.tabsProjection
-        : buildRuntimeMobileTabsProjection(state),
+        : buildRuntimeMobileTabsProjection(state.tabsByWorktree),
     openFilesProjection:
       canReusePrevious && state.openFiles === previousState.openFiles
         ? previousKey.openFilesProjection
@@ -162,20 +173,41 @@ export function getRuntimeMobileSessionSyncKey(
   }
 }
 
-function buildRuntimeMobileTabsProjection(state: AppState): string {
-  return JSON.stringify(
-    Object.fromEntries(
-      Object.entries(state.tabsByWorktree).map(([worktreeId, tabs]) => [
-        worktreeId,
-        tabs.map((tab) => ({
-          id: tab.id,
-          title: tab.title,
-          customTitle: tab.customTitle,
-          active: state.activeTabId === tab.id
-        }))
-      ])
-    )
-  )
+function buildRuntimeMobileTabsProjection(tabsByWorktree: AppState['tabsByWorktree']): string {
+  if (cachedTabsProjection?.source === tabsByWorktree) {
+    return cachedTabsProjection.projection
+  }
+
+  const previousEntries = cachedTabsProjection?.entries
+  const entries = new Map<string, TabsProjectionCacheEntry>()
+  const parts: string[] = []
+
+  for (const [worktreeId, tabs] of Object.entries(tabsByWorktree)) {
+    const previous = previousEntries?.get(worktreeId)
+    const entry =
+      previous?.tabs === tabs
+        ? previous
+        : {
+            tabs,
+            worktreeIdJson: previous?.worktreeIdJson ?? JSON.stringify(worktreeId),
+            projection: JSON.stringify(
+              tabs.map((tab) => ({
+                id: tab.id,
+                title: tab.title,
+                customTitle: tab.customTitle
+              }))
+            )
+          }
+    entries.set(worktreeId, entry)
+    parts.push(`${entry.worktreeIdJson}:${entry.projection}`)
+  }
+
+  cachedTabsProjection = {
+    source: tabsByWorktree,
+    entries,
+    projection: `{${parts.join(',')}}`
+  }
+  return cachedTabsProjection.projection
 }
 
 function buildRuntimeMobileOpenFilesProjection(openFiles: AppState['openFiles']): string {
@@ -215,6 +247,7 @@ export function runtimeMobileSessionSyncKeysEqual(
     a.tabBarOrderByWorktree === b.tabBarOrderByWorktree &&
     a.activeFileId === b.activeFileId &&
     a.activeFileIdByWorktree === b.activeFileIdByWorktree &&
+    a.activeTabId === b.activeTabId &&
     a.tabsProjection === b.tabsProjection &&
     a.openFilesProjection === b.openFilesProjection &&
     a.editorDraftsProjection === b.editorDraftsProjection


### PR DESCRIPTION
## Summary
- cache runtime mobile tab projections per worktree array instead of rebuilding the whole tabs map projection on a single worktree title tick
- move activeTabId into the cheap scalar sync key so active-tab-only changes do not force tab projection serialization
- add regression coverage for active-tab projection reuse and unchanged-worktree projection reuse

## Benchmark
Synthetic 500-worktree / 2000-tab state:
- old one-worktree title tick projection: 0.307ms avg / 0.428ms p95 / 0.674ms max
- new one-worktree title tick projection: 0.103ms avg / 0.165ms p95 / 0.301ms max
- activeTabId-only projection reuse: ~0.000ms avg / ~0.000ms p95 / 0.018ms max

## Validation
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/runtime/sync-runtime-graph.test.ts src/renderer/src/runtime/sync-runtime-graph-key-reuse.test.ts src/renderer/src/components/tab-bar/group-tab-order.test.ts
- pnpm exec oxlint src/renderer/src/runtime/sync-runtime-graph.ts src/renderer/src/runtime/sync-runtime-graph.test.ts src/renderer/src/runtime/sync-runtime-graph-key-reuse.test.ts
- pnpm exec tsc --noEmit -p config/tsconfig.web.json --composite false
- git diff --check
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/runtime src/renderer/src/components/tab-bar
- pnpm exec vitest run --config config/vitest.config.ts (602 files passed, 1 skipped; 6641 tests passed, 10 skipped)