### PR TITLE
Double-click floating terminal titlebar to expand

### DIFF
--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
@@ -30,6 +30,13 @@ type FloatingTerminalPanelProps = {
   onOpenChange: (open: boolean) => void
 }
 
+const FLOATING_TERMINAL_NO_DRAG_SELECTOR =
+  'button,input,textarea,select,[role="menuitem"],[data-testid="sortable-tab"],[data-floating-terminal-no-drag]'
+
+function isFloatingTerminalDragTarget(target: EventTarget): boolean {
+  return !(target instanceof HTMLElement && target.closest(FLOATING_TERMINAL_NO_DRAG_SELECTOR))
+}
+
 export function FloatingTerminalPanel({
   open,
   onOpenChange
@@ -211,12 +218,7 @@ export function FloatingTerminalPanel({
       return
     }
     const target = event.target
-    if (
-      target instanceof HTMLElement &&
-      target.closest(
-        'button,input,textarea,select,[role="menuitem"],[data-testid="sortable-tab"],[data-floating-terminal-no-drag]'
-      )
-    ) {
+    if (!isFloatingTerminalDragTarget(target)) {
       return
     }
     dragRef.current = {
@@ -247,6 +249,14 @@ export function FloatingTerminalPanel({
     if (dragRef.current?.pointerId === event.pointerId) {
       dragRef.current = null
     }
+  }
+
+  const handleTitlebarDoubleClick = (event: React.MouseEvent<HTMLDivElement>): void => {
+    if (event.button !== 0 || !isFloatingTerminalDragTarget(event.target)) {
+      return
+    }
+    event.preventDefault()
+    toggleMaximized()
   }
 
   const dismissOrchestrationSetup = useCallback(() => {
@@ -285,6 +295,7 @@ export function FloatingTerminalPanel({
           onPointerMove={handleDragMove}
           onPointerUp={handleDragEnd}
           onPointerCancel={handleDragEnd}
+          onDoubleClick={handleTitlebarDoubleClick}
         >
           <div className="flex h-full min-w-0 flex-1">
             <TabBar


### PR DESCRIPTION
## Summary
- Add double-click handling to the floating terminal titlebar drag surface.
- Reuse the existing non-drag target selector so tab buttons and controls keep their normal behavior.
- Double-click expands the floating terminal; double-clicking again restores the previous bounds.

## Verification
- pnpm exec oxfmt --check src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
- pnpm exec oxlint src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
- pnpm run tc:web
- pnpm typecheck
- pnpm lint
- Electron CDP verification: double-click titlebar changed bounds from 920x560 at top 424 to maximized 1729x996 at top 36; second double-click restored to the original 920x560/top 424 bounds; console had 0 errors.
- Visual screenshot confirmed expanded floating terminal is flush against the titlebar.