### PR TITLE
Improve Claude and Codex usage tracking

### DIFF
--- a/src/main/claude-usage/scanner-scan.test.ts
+++ b/src/main/claude-usage/scanner-scan.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'os'
 import { join } from 'path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type * as Os from 'os'
+import type * as FsPromises from 'fs/promises'
 
 const tempRoots: string[] = []
 
@@ -16,6 +17,7 @@ async function makeClaudeProjectsRoot(): Promise<string> {
 
 afterEach(async () => {
   vi.doUnmock('os')
+  vi.doUnmock('fs/promises')
   vi.resetModules()
   await Promise.all(tempRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
 })
@@ -161,5 +163,59 @@ describe('scanClaudeUsageFiles', () => {
 
     expect(second.processedFiles[0]?.sessions[0]?.totalInputTokens).toBe(999)
     expect(second.dailyAggregates[0]?.inputTokens).toBe(999)
+  })
+
+  it('canonicalizes repeated cwd paths once per scan file', async () => {
+    const root = await makeClaudeProjectsRoot()
+    const projectDir = join(root, '.claude', 'projects', 'project-a')
+    const transcriptFile = join(projectDir, 'session-1.jsonl')
+    const repeatedCwd = '/workspace/repo-a/packages/app'
+
+    await writeFile(
+      transcriptFile,
+      [1, 2, 3]
+        .map((index) =>
+          JSON.stringify({
+            type: 'assistant',
+            sessionId: 'session-1',
+            timestamp: `2026-04-09T10:0${index}:00.000Z`,
+            cwd: repeatedCwd,
+            message: {
+              model: 'claude-sonnet-4-6',
+              usage: {
+                input_tokens: 100,
+                output_tokens: 20
+              }
+            }
+          })
+        )
+        .join('\n')
+    )
+
+    const realpathCalls: string[] = []
+    vi.resetModules()
+    vi.doMock('os', async () => ({
+      ...(await vi.importActual<typeof Os>('os')),
+      homedir: () => root
+    }))
+    vi.doMock('fs/promises', async () => ({
+      ...(await vi.importActual<typeof FsPromises>('fs/promises')),
+      realpath: vi.fn(async (pathValue: string) => {
+        realpathCalls.push(pathValue)
+        return pathValue
+      })
+    }))
+    const { scanClaudeUsageFiles } = await import('./scanner')
+
+    await scanClaudeUsageFiles([
+      {
+        repoId: 'repo-1',
+        worktreeId: 'worktree-1',
+        path: '/workspace/repo-a',
+        displayName: 'Repo A'
+      }
+    ])
+
+    expect(realpathCalls.filter((pathValue) => pathValue === repeatedCwd)).toHaveLength(1)
   })
 })

--- a/src/main/claude-usage/scanner-scan.test.ts
+++ b/src/main/claude-usage/scanner-scan.test.ts
@@ -10,6 +10,7 @@ async function makeClaudeProjectsRoot(): Promise<string> {
   const root = await mkdtemp(join(tmpdir(), 'orca-claude-usage-'))
   tempRoots.push(root)
   await mkdir(join(root, '.claude', 'projects', 'project-a'), { recursive: true })
+  await mkdir(join(root, '.claude', 'transcripts'), { recursive: true })
   return root
 }
 
@@ -23,8 +24,10 @@ describe('scanClaudeUsageFiles', () => {
   it('scans transcript files from the configured Claude projects directory', async () => {
     const root = await makeClaudeProjectsRoot()
     const projectDir = join(root, '.claude', 'projects', 'project-a')
+    const transcriptsDir = join(root, '.claude', 'transcripts')
     const firstFile = join(projectDir, 'a.jsonl')
     const secondFile = join(projectDir, 'b.jsonl')
+    const transcriptFile = join(transcriptsDir, 'ses_123.jsonl')
 
     await writeFile(
       firstFile,
@@ -63,6 +66,22 @@ describe('scanClaudeUsageFiles', () => {
         }
       })
     )
+    await writeFile(
+      transcriptFile,
+      JSON.stringify({
+        type: 'assistant',
+        timestamp: '2026-04-11T10:00:00.000Z',
+        cwd: '/workspace/repo-a/packages/app',
+        message: {
+          model: 'claude-sonnet-4-6',
+          usage: {
+            input_tokens: 70,
+            output_tokens: 15,
+            cache_read_input_tokens: 20
+          }
+        }
+      })
+    )
 
     vi.resetModules()
     vi.doMock('os', async () => ({
@@ -82,10 +101,65 @@ describe('scanClaudeUsageFiles', () => {
 
     expect(result.processedFiles.map((file) => [file.path, file.lineCount])).toEqual([
       [firstFile, 2],
-      [secondFile, 1]
+      [secondFile, 1],
+      [transcriptFile, 1]
     ])
-    expect(result.sessions.map((session) => session.sessionId)).toEqual(['session-2', 'session-1'])
-    expect(result.dailyAggregates).toHaveLength(2)
+    expect(result.sessions.map((session) => session.sessionId)).toEqual([
+      'ses_123',
+      'session-2',
+      'session-1'
+    ])
+    expect(result.dailyAggregates).toHaveLength(3)
     expect(result.dailyAggregates[0]?.projectLabel).toBe('Repo A')
+    expect(result.dailyAggregates[2]?.projectLabel).toBe('Repo A')
+  })
+
+  it('reuses unchanged transcript projections from the previous scan', async () => {
+    const root = await makeClaudeProjectsRoot()
+    const projectDir = join(root, '.claude', 'projects', 'project-a')
+    const transcriptFile = join(projectDir, 'session-1.jsonl')
+
+    await writeFile(
+      transcriptFile,
+      JSON.stringify({
+        type: 'assistant',
+        sessionId: 'session-1',
+        timestamp: '2026-04-09T10:00:00.000Z',
+        cwd: '/workspace/repo-a',
+        message: {
+          model: 'claude-sonnet-4-6',
+          usage: {
+            input_tokens: 100,
+            output_tokens: 20
+          }
+        }
+      })
+    )
+
+    vi.resetModules()
+    vi.doMock('os', async () => ({
+      ...(await vi.importActual<typeof Os>('os')),
+      homedir: () => root
+    }))
+    const { scanClaudeUsageFiles } = await import('./scanner')
+    const worktrees = [
+      {
+        repoId: 'repo-1',
+        worktreeId: 'worktree-1',
+        path: '/workspace/repo-a',
+        displayName: 'Repo A'
+      }
+    ]
+
+    const first = await scanClaudeUsageFiles(worktrees)
+    const cachedFile = structuredClone(first.processedFiles[0]!)
+    cachedFile.sessions[0]!.totalInputTokens = 999
+    cachedFile.sessions[0]!.locationBreakdown[0]!.inputTokens = 999
+    cachedFile.dailyAggregates[0]!.inputTokens = 999
+
+    const second = await scanClaudeUsageFiles(worktrees, [cachedFile])
+
+    expect(second.processedFiles[0]?.sessions[0]?.totalInputTokens).toBe(999)
+    expect(second.dailyAggregates[0]?.inputTokens).toBe(999)
   })
 })

--- a/src/main/claude-usage/scanner.test.ts
+++ b/src/main/claude-usage/scanner.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from 'vitest'
-import { aggregateClaudeUsage, attributeClaudeUsageTurns, parseClaudeUsageRecord } from './scanner'
+import {
+  aggregateClaudeUsage,
+  attributeClaudeUsageTurns,
+  parseClaudeUsageFile,
+  parseClaudeUsageRecord
+} from './scanner'
+import { mkdtemp, rm, writeFile } from 'fs/promises'
+import { join } from 'path'
+import { tmpdir } from 'os'
 
 describe('parseClaudeUsageRecord', () => {
   it('extracts token usage from assistant transcript lines', () => {
@@ -33,6 +41,66 @@ describe('parseClaudeUsageRecord', () => {
       cacheReadTokens: 10,
       cacheWriteTokens: 5
     })
+  })
+
+  it('merges duplicate streamed assistant usage by message and request id', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-claude-dedupe-'))
+    const filePath = join(root, 'session.jsonl')
+    try {
+      await writeFile(
+        filePath,
+        [
+          JSON.stringify({
+            type: 'assistant',
+            sessionId: 'session-1',
+            timestamp: '2026-04-09T10:00:00.000Z',
+            requestId: 'req-1',
+            message: {
+              id: 'msg-1',
+              model: 'claude-sonnet-4-6',
+              usage: {
+                input_tokens: 100,
+                output_tokens: 25,
+                cache_read_input_tokens: 10,
+                cache_creation_input_tokens: 5
+              }
+            }
+          }),
+          JSON.stringify({
+            type: 'assistant',
+            sessionId: 'session-1',
+            timestamp: '2026-04-09T10:00:01.000Z',
+            requestId: 'req-1',
+            message: {
+              id: 'msg-1',
+              model: 'claude-sonnet-4-6',
+              usage: {
+                input_tokens: 120,
+                output_tokens: 30,
+                cache_read_input_tokens: 12,
+                cache_creation_input_tokens: 7
+              }
+            }
+          })
+        ].join('\n')
+      )
+
+      await expect(parseClaudeUsageFile(filePath)).resolves.toEqual([
+        {
+          sessionId: 'session-1',
+          timestamp: '2026-04-09T10:00:00.000Z',
+          model: 'claude-sonnet-4-6',
+          cwd: null,
+          gitBranch: null,
+          inputTokens: 120,
+          outputTokens: 30,
+          cacheReadTokens: 12,
+          cacheWriteTokens: 7
+        }
+      ])
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
   })
 })
 
@@ -103,5 +171,37 @@ describe('Claude usage aggregation', () => {
         cacheWriteTokens: 0
       }
     ])
+  })
+
+  it('attributes nested cwd paths to the containing worktree', async () => {
+    const attributed = await attributeClaudeUsageTurns(
+      [
+        {
+          sessionId: 'session-1',
+          timestamp: '2026-04-09T10:00:00.000Z',
+          model: 'claude-sonnet-4-6',
+          cwd: '/workspace/repo-a/packages/app',
+          gitBranch: 'feature/a',
+          inputTokens: 100,
+          outputTokens: 20,
+          cacheReadTokens: 10,
+          cacheWriteTokens: 5
+        }
+      ],
+      new Map([
+        [
+          '/workspace/repo-a',
+          {
+            repoId: 'repo-1',
+            worktreeId: 'repo-1::/workspace/repo-a',
+            path: '/workspace/repo-a',
+            displayName: 'Repo A'
+          }
+        ]
+      ])
+    )
+
+    expect(attributed[0]?.projectKey).toBe('worktree:repo-1::/workspace/repo-a')
+    expect(attributed[0]?.projectLabel).toBe('Repo A')
   })
 })

--- a/src/main/claude-usage/scanner.ts
+++ b/src/main/claude-usage/scanner.ts
@@ -51,6 +51,13 @@ type ClaudeUsageParsedSourceTurn = ClaudeUsageParsedTurn & {
   dedupeKey: string | null
 }
 
+type ClaudeUsageWorktreeEntry = [string, ClaudeUsageWorktreeRef]
+
+const sortedWorktreeEntriesByLookup = new WeakMap<
+  Map<string, ClaudeUsageWorktreeRef>,
+  ClaudeUsageWorktreeEntry[]
+>()
+
 function getDefaultProjectLabel(cwd: string | null): string {
   if (!cwd) {
     return 'Unknown location'
@@ -92,16 +99,27 @@ function findContainingWorktree(
     return exact
   }
 
-  const sortedWorktrees = [...worktreeLookup.entries()].sort(
-    ([leftPath], [rightPath]) => rightPath.length - leftPath.length
-  )
-  for (const [worktreePath, worktree] of sortedWorktrees) {
+  for (const [worktreePath, worktree] of getSortedWorktreeEntries(worktreeLookup)) {
     if (isContainedPath(worktreePath, normalizedCwd)) {
       return worktree
     }
   }
 
   return null
+}
+
+function getSortedWorktreeEntries(
+  worktreeLookup: Map<string, ClaudeUsageWorktreeRef>
+): ClaudeUsageWorktreeEntry[] {
+  const cached = sortedWorktreeEntriesByLookup.get(worktreeLookup)
+  if (cached) {
+    return cached
+  }
+  const sorted = [...worktreeLookup.entries()].sort(
+    ([leftPath], [rightPath]) => rightPath.length - leftPath.length
+  )
+  sortedWorktreeEntriesByLookup.set(worktreeLookup, sorted)
+  return sorted
 }
 
 async function yieldToEventLoop(): Promise<void> {
@@ -337,6 +355,7 @@ export async function attributeClaudeUsageTurns(
   worktreeLookup: Map<string, ClaudeUsageWorktreeRef>
 ): Promise<ClaudeUsageAttributedTurn[]> {
   const attributed: ClaudeUsageAttributedTurn[] = []
+  const canonicalCwdByPath = new Map<string, string>()
 
   for (const turn of turns) {
     const day = localDayFromTimestamp(turn.timestamp)
@@ -350,7 +369,14 @@ export async function attributeClaudeUsageTurns(
     let projectLabel = getDefaultProjectLabel(turn.cwd)
 
     if (turn.cwd) {
-      const worktree = findContainingWorktree(await canonicalizePath(turn.cwd), worktreeLookup)
+      let canonicalCwd = canonicalCwdByPath.get(turn.cwd)
+      if (canonicalCwd === undefined) {
+        // Why: Claude transcripts repeat the same cwd for many consecutive
+        // turns. Cache realpath work so attribution scales with unique paths.
+        canonicalCwd = await canonicalizePath(turn.cwd)
+        canonicalCwdByPath.set(turn.cwd, canonicalCwd)
+      }
+      const worktree = findContainingWorktree(canonicalCwd, worktreeLookup)
       if (worktree) {
         repoId = worktree.repoId
         worktreeId = worktree.worktreeId

--- a/src/main/claude-usage/scanner.ts
+++ b/src/main/claude-usage/scanner.ts
@@ -10,6 +10,7 @@ import type {
   ClaudeUsageDailyAggregate,
   ClaudeUsageLocationBreakdown,
   ClaudeUsageParsedTurn,
+  ClaudeUsagePersistedFile,
   ClaudeUsageProcessedFile,
   ClaudeUsageSession
 } from './types'
@@ -27,7 +28,11 @@ type ClaudeUsageSourceRecord = {
   timestamp?: string
   cwd?: string
   gitBranch?: string
+  requestId?: string
+  isSidechain?: boolean
+  agentId?: string
   message?: {
+    id?: string
     model?: string
     usage?: {
       input_tokens?: number
@@ -39,7 +44,12 @@ type ClaudeUsageSourceRecord = {
 }
 
 const CLAUDE_PROJECTS_DIR = join(homedir(), '.claude', 'projects')
+const CLAUDE_TRANSCRIPTS_DIR = join(homedir(), '.claude', 'transcripts')
 const FILE_SCAN_BATCH_SIZE = 4
+
+type ClaudeUsageParsedSourceTurn = ClaudeUsageParsedTurn & {
+  dedupeKey: string | null
+}
 
 function getDefaultProjectLabel(cwd: string | null): string {
   if (!cwd) {
@@ -66,6 +76,34 @@ function normalizeComparablePath(pathValue: string): string {
   return process.platform === 'win32' ? normalized.toLowerCase() : normalized
 }
 
+function isContainedPath(parentPath: string, childPath: string): boolean {
+  const parent = normalizeComparablePath(parentPath).replace(/\/+$/, '')
+  const child = normalizeComparablePath(childPath).replace(/\/+$/, '')
+  return child === parent || child.startsWith(`${parent}/`)
+}
+
+function findContainingWorktree(
+  cwd: string,
+  worktreeLookup: Map<string, ClaudeUsageWorktreeRef>
+): ClaudeUsageWorktreeRef | null {
+  const normalizedCwd = normalizeComparablePath(cwd)
+  const exact = worktreeLookup.get(normalizedCwd)
+  if (exact) {
+    return exact
+  }
+
+  const sortedWorktrees = [...worktreeLookup.entries()].sort(
+    ([leftPath], [rightPath]) => rightPath.length - leftPath.length
+  )
+  for (const [worktreePath, worktree] of sortedWorktrees) {
+    if (isContainedPath(worktreePath, normalizedCwd)) {
+      return worktree
+    }
+  }
+
+  return null
+}
+
 async function yieldToEventLoop(): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, 0))
 }
@@ -89,11 +127,17 @@ async function walkJsonlFiles(dirPath: string): Promise<string[]> {
 }
 
 export async function listClaudeTranscriptFiles(): Promise<string[]> {
-  try {
-    return (await walkJsonlFiles(CLAUDE_PROJECTS_DIR)).sort()
-  } catch {
-    return []
-  }
+  const roots = [CLAUDE_PROJECTS_DIR, CLAUDE_TRANSCRIPTS_DIR]
+  const files = await Promise.all(
+    roots.map(async (root) => {
+      try {
+        return await walkJsonlFiles(root)
+      } catch {
+        return []
+      }
+    })
+  )
+  return [...new Set(files.flat())].sort()
 }
 
 export async function getProcessedFileInfo(filePath: string): Promise<ClaudeUsageProcessedFile> {
@@ -109,11 +153,69 @@ export async function getProcessedFileInfo(filePath: string): Promise<ClaudeUsag
   return {
     path: filePath,
     mtimeMs: fileStat.mtimeMs,
+    size: fileStat.size,
     lineCount
   }
 }
 
-export function parseClaudeUsageRecord(line: string): ClaudeUsageParsedTurn | null {
+async function getProcessedFileStat(
+  filePath: string
+): Promise<Omit<ClaudeUsageProcessedFile, 'lineCount'>> {
+  const fileStat = await stat(filePath)
+  return {
+    path: filePath,
+    mtimeMs: fileStat.mtimeMs,
+    size: fileStat.size
+  }
+}
+
+function stripClaudeSourceMetadata(turn: ClaudeUsageParsedSourceTurn): ClaudeUsageParsedTurn {
+  return {
+    sessionId: turn.sessionId,
+    timestamp: turn.timestamp,
+    model: turn.model,
+    cwd: turn.cwd,
+    gitBranch: turn.gitBranch,
+    inputTokens: turn.inputTokens,
+    outputTokens: turn.outputTokens,
+    cacheReadTokens: turn.cacheReadTokens,
+    cacheWriteTokens: turn.cacheWriteTokens
+  }
+}
+
+function dedupeClaudeUsageTurns(turns: ClaudeUsageParsedSourceTurn[]): ClaudeUsageParsedTurn[] {
+  const dedupeIndexByKey = new Map<string, number>()
+  const deduped: ClaudeUsageParsedTurn[] = []
+
+  for (const turn of turns) {
+    if (turn.dedupeKey) {
+      const existingIndex = dedupeIndexByKey.get(turn.dedupeKey)
+      if (existingIndex !== undefined) {
+        const existing = deduped[existingIndex]
+        // Why: Claude Code streams repeated assistant rows with the same
+        // message/request IDs; later rows can contain more complete usage.
+        existing.inputTokens = Math.max(existing.inputTokens, turn.inputTokens)
+        existing.outputTokens = Math.max(existing.outputTokens, turn.outputTokens)
+        existing.cacheReadTokens = Math.max(existing.cacheReadTokens, turn.cacheReadTokens)
+        existing.cacheWriteTokens = Math.max(existing.cacheWriteTokens, turn.cacheWriteTokens)
+        continue
+      }
+    }
+
+    const stripped = stripClaudeSourceMetadata(turn)
+    deduped.push(stripped)
+    if (turn.dedupeKey) {
+      dedupeIndexByKey.set(turn.dedupeKey, deduped.length - 1)
+    }
+  }
+
+  return deduped
+}
+
+function parseClaudeUsageSourceRecord(
+  line: string,
+  fallbackSessionId: string | null = null
+): ClaudeUsageParsedSourceTurn | null {
   let parsed: ClaudeUsageSourceRecord
   try {
     parsed = JSON.parse(line) as ClaudeUsageSourceRecord
@@ -124,7 +226,8 @@ export function parseClaudeUsageRecord(line: string): ClaudeUsageParsedTurn | nu
   if (parsed.type !== 'assistant') {
     return null
   }
-  if (!parsed.sessionId || !parsed.timestamp) {
+  const sessionId = parsed.sessionId ?? fallbackSessionId
+  if (!sessionId || !parsed.timestamp) {
     return null
   }
 
@@ -139,11 +242,13 @@ export function parseClaudeUsageRecord(line: string): ClaudeUsageParsedTurn | nu
   }
 
   return {
-    sessionId: parsed.sessionId,
+    sessionId,
     timestamp: parsed.timestamp,
     model: parsed.message?.model ?? null,
     cwd: parsed.cwd ?? null,
     gitBranch: parsed.gitBranch ?? null,
+    dedupeKey:
+      parsed.message?.id && parsed.requestId ? `${parsed.message.id}:${parsed.requestId}` : null,
     inputTokens,
     outputTokens,
     cacheReadTokens,
@@ -151,21 +256,27 @@ export function parseClaudeUsageRecord(line: string): ClaudeUsageParsedTurn | nu
   }
 }
 
+export function parseClaudeUsageRecord(line: string): ClaudeUsageParsedTurn | null {
+  const parsed = parseClaudeUsageSourceRecord(line)
+  return parsed ? stripClaudeSourceMetadata(parsed) : null
+}
+
 export async function parseClaudeUsageFile(filePath: string): Promise<ClaudeUsageParsedTurn[]> {
-  const turns: ClaudeUsageParsedTurn[] = []
+  const turns: ClaudeUsageParsedSourceTurn[] = []
+  const fallbackSessionId = basename(filePath, '.jsonl')
   const lines = createInterface({
     input: createReadStream(filePath, { encoding: 'utf-8' }),
     crlfDelay: Infinity
   })
 
   for await (const line of lines) {
-    const parsed = parseClaudeUsageRecord(line)
+    const parsed = parseClaudeUsageSourceRecord(line, fallbackSessionId)
     if (parsed) {
       turns.push(parsed)
     }
   }
 
-  return turns
+  return dedupeClaudeUsageTurns(turns)
 }
 
 async function readClaudeUsageScanFile(filePath: string): Promise<{
@@ -174,7 +285,8 @@ async function readClaudeUsageScanFile(filePath: string): Promise<{
 }> {
   const fileStat = await stat(filePath)
   let lineCount = 0
-  const turns: ClaudeUsageParsedTurn[] = []
+  const turns: ClaudeUsageParsedSourceTurn[] = []
+  const fallbackSessionId = basename(filePath, '.jsonl')
   const lines = createInterface({
     input: createReadStream(filePath, { encoding: 'utf-8' }),
     crlfDelay: Infinity
@@ -182,7 +294,7 @@ async function readClaudeUsageScanFile(filePath: string): Promise<{
 
   for await (const line of lines) {
     lineCount++
-    const parsed = parseClaudeUsageRecord(line)
+    const parsed = parseClaudeUsageSourceRecord(line, fallbackSessionId)
     if (parsed) {
       turns.push(parsed)
     }
@@ -192,9 +304,10 @@ async function readClaudeUsageScanFile(filePath: string): Promise<{
     processedFile: {
       path: filePath,
       mtimeMs: fileStat.mtimeMs,
+      size: fileStat.size,
       lineCount
     },
-    turns
+    turns: dedupeClaudeUsageTurns(turns)
   }
 }
 
@@ -237,7 +350,7 @@ export async function attributeClaudeUsageTurns(
     let projectLabel = getDefaultProjectLabel(turn.cwd)
 
     if (turn.cwd) {
-      const worktree = worktreeLookup.get(await canonicalizePath(turn.cwd))
+      const worktree = findContainingWorktree(await canonicalizePath(turn.cwd), worktreeLookup)
       if (worktree) {
         repoId = worktree.repoId
         worktreeId = worktree.worktreeId
@@ -259,6 +372,90 @@ export async function attributeClaudeUsageTurns(
   }
 
   return attributed
+}
+
+function mergeClaudeSessions(
+  target: Map<string, ClaudeUsageSession>,
+  sessions: ClaudeUsageSession[]
+): void {
+  for (const session of sessions) {
+    const existing = target.get(session.sessionId)
+    if (!existing) {
+      target.set(session.sessionId, structuredClone(session))
+      continue
+    }
+
+    if (session.firstTimestamp < existing.firstTimestamp) {
+      existing.firstTimestamp = session.firstTimestamp
+    }
+    if (session.lastTimestamp > existing.lastTimestamp) {
+      existing.lastTimestamp = session.lastTimestamp
+      existing.lastCwd = session.lastCwd
+      existing.lastGitBranch = session.lastGitBranch
+    }
+    existing.model = session.model ?? existing.model
+    existing.turnCount += session.turnCount
+    existing.totalInputTokens += session.totalInputTokens
+    existing.totalOutputTokens += session.totalOutputTokens
+    existing.totalCacheReadTokens += session.totalCacheReadTokens
+    existing.totalCacheWriteTokens += session.totalCacheWriteTokens
+
+    for (const location of session.locationBreakdown) {
+      const existingLocation =
+        existing.locationBreakdown.find((entry) => entry.locationKey === location.locationKey) ??
+        null
+      if (existingLocation) {
+        existingLocation.turnCount += location.turnCount
+        existingLocation.inputTokens += location.inputTokens
+        existingLocation.outputTokens += location.outputTokens
+        existingLocation.cacheReadTokens += location.cacheReadTokens
+        existingLocation.cacheWriteTokens += location.cacheWriteTokens
+      } else {
+        existing.locationBreakdown.push({ ...location })
+      }
+    }
+  }
+}
+
+function mergeClaudeDailyAggregates(
+  target: Map<string, ClaudeUsageDailyAggregate>,
+  dailyAggregates: ClaudeUsageDailyAggregate[]
+): void {
+  for (const aggregate of dailyAggregates) {
+    const key = [aggregate.day, aggregate.model ?? 'unknown', aggregate.projectKey].join('::')
+    const existing = target.get(key)
+    if (!existing) {
+      target.set(key, { ...aggregate })
+      continue
+    }
+    existing.turnCount += aggregate.turnCount
+    existing.zeroCacheReadTurnCount += aggregate.zeroCacheReadTurnCount
+    existing.inputTokens += aggregate.inputTokens
+    existing.outputTokens += aggregate.outputTokens
+    existing.cacheReadTokens += aggregate.cacheReadTokens
+    existing.cacheWriteTokens += aggregate.cacheWriteTokens
+  }
+}
+
+function finalizeClaudeSessions(
+  sessionsById: Map<string, ClaudeUsageSession>
+): ClaudeUsageSession[] {
+  for (const session of sessionsById.values()) {
+    session.locationBreakdown.sort((left, right) => {
+      const leftTotal = left.inputTokens + left.outputTokens
+      const rightTotal = right.inputTokens + right.outputTokens
+      return rightTotal - leftTotal
+    })
+    const primaryLocation = session.locationBreakdown[0] ?? null
+    if (primaryLocation) {
+      session.primaryRepoId = primaryLocation.repoId
+      session.primaryWorktreeId = primaryLocation.worktreeId
+    }
+  }
+
+  return [...sessionsById.values()].sort((left, right) =>
+    right.lastTimestamp.localeCompare(left.lastTimestamp)
+  )
 }
 
 export function aggregateClaudeUsage(turns: ClaudeUsageAttributedTurn[]): {
@@ -356,23 +553,8 @@ export function aggregateClaudeUsage(turns: ClaudeUsageAttributedTurn[]): {
     }
   }
 
-  for (const session of sessionsById.values()) {
-    session.locationBreakdown.sort((left, right) => {
-      const leftTotal = left.inputTokens + left.outputTokens
-      const rightTotal = right.inputTokens + right.outputTokens
-      return rightTotal - leftTotal
-    })
-    const primaryLocation = session.locationBreakdown[0] ?? null
-    if (primaryLocation) {
-      session.primaryRepoId = primaryLocation.repoId
-      session.primaryWorktreeId = primaryLocation.worktreeId
-    }
-  }
-
   return {
-    sessions: [...sessionsById.values()].sort((left, right) =>
-      right.lastTimestamp.localeCompare(left.lastTimestamp)
-    ),
+    sessions: finalizeClaudeSessions(sessionsById),
     dailyAggregates: [...dailyByKey.values()].sort((left, right) =>
       left.day === right.day
         ? left.projectLabel.localeCompare(right.projectLabel)
@@ -381,22 +563,55 @@ export function aggregateClaudeUsage(turns: ClaudeUsageAttributedTurn[]): {
   }
 }
 
-export async function scanClaudeUsageFiles(worktrees: ClaudeUsageWorktreeRef[]): Promise<{
-  processedFiles: ClaudeUsageProcessedFile[]
+async function parseClaudeUsagePersistedFile(
+  filePath: string,
+  worktreeLookup: Map<string, ClaudeUsageWorktreeRef>
+): Promise<ClaudeUsagePersistedFile> {
+  const { processedFile, turns } = await readClaudeUsageScanFile(filePath)
+  const attributed = await attributeClaudeUsageTurns(turns, worktreeLookup)
+  return {
+    ...processedFile,
+    ...aggregateClaudeUsage(attributed)
+  }
+}
+
+export async function scanClaudeUsageFiles(
+  worktrees: ClaudeUsageWorktreeRef[],
+  previousProcessedFiles: ClaudeUsagePersistedFile[] = []
+): Promise<{
+  processedFiles: ClaudeUsagePersistedFile[]
   sessions: ClaudeUsageSession[]
   dailyAggregates: ClaudeUsageDailyAggregate[]
 }> {
   const files = await listClaudeTranscriptFiles()
-  const processedFiles: ClaudeUsageProcessedFile[] = []
-  const allTurns: ClaudeUsageParsedTurn[] = []
+  const previousByPath = new Map(previousProcessedFiles.map((file) => [file.path, file]))
+  const processedFiles: ClaudeUsagePersistedFile[] = []
   const worktreeLookup = await buildWorktreeLookup(worktrees)
+  const sessionsById = new Map<string, ClaudeUsageSession>()
+  const dailyByKey = new Map<string, ClaudeUsageDailyAggregate>()
 
   for (let index = 0; index < files.length; index += FILE_SCAN_BATCH_SIZE) {
     const batch = files.slice(index, index + FILE_SCAN_BATCH_SIZE)
-    const results = await Promise.all(batch.map((filePath) => readClaudeUsageScanFile(filePath)))
-    for (const result of results) {
-      processedFiles.push(result.processedFile)
-      allTurns.push(...result.turns)
+    const results = await Promise.all(
+      batch.map(async (filePath) => {
+        const fileInfo = await getProcessedFileStat(filePath)
+        const previous = previousByPath.get(filePath)
+        // Why: Claude histories can be gigabytes. Unchanged files should pay
+        // only stat cost on refresh while preserving exactly the old projection.
+        const canReuse =
+          previous &&
+          previous.mtimeMs === fileInfo.mtimeMs &&
+          previous.size === fileInfo.size &&
+          Array.isArray(previous.sessions) &&
+          Array.isArray(previous.dailyAggregates)
+
+        return canReuse ? previous : parseClaudeUsagePersistedFile(filePath, worktreeLookup)
+      })
+    )
+    for (const processed of results) {
+      processedFiles.push(processed)
+      mergeClaudeSessions(sessionsById, processed.sessions)
+      mergeClaudeDailyAggregates(dailyByKey, processed.dailyAggregates)
     }
     // Why: transcript scans run in Electron's main process. Small parallel
     // batches cut independent file I/O without letting Settings stay blocked.
@@ -405,15 +620,23 @@ export async function scanClaudeUsageFiles(worktrees: ClaudeUsageWorktreeRef[]):
     }
   }
 
-  const attributed = await attributeClaudeUsageTurns(allTurns, worktreeLookup)
   return {
     processedFiles,
-    ...aggregateClaudeUsage(attributed)
+    sessions: finalizeClaudeSessions(sessionsById),
+    dailyAggregates: [...dailyByKey.values()].sort((left, right) =>
+      left.day === right.day
+        ? left.projectLabel.localeCompare(right.projectLabel)
+        : left.day.localeCompare(right.day)
+    )
   }
 }
 
 export function getClaudeProjectsDirectory(): string {
   return CLAUDE_PROJECTS_DIR
+}
+
+export function getClaudeTranscriptsDirectory(): string {
+  return CLAUDE_TRANSCRIPTS_DIR
 }
 
 export function createWorktreeRefs(

--- a/src/main/claude-usage/store.test.ts
+++ b/src/main/claude-usage/store.test.ts
@@ -17,6 +17,7 @@ function createStoreWithState(state: Partial<ClaudeUsagePersistedState>): Claude
 
   ;(store as unknown as { state: ClaudeUsagePersistedState }).state = {
     schemaVersion: 1,
+    worktreeFingerprint: null,
     processedFiles: [],
     sessions: [],
     dailyAggregates: [],
@@ -230,5 +231,30 @@ describe('ClaudeUsageStore', () => {
     const summary = await store.getSummary('orca', '30d')
 
     expect(summary.estimatedCostUsd).toBeCloseTo(110.25)
+  })
+
+  it('prices Sonnet long-context usage with threshold rates', async () => {
+    const store = createStoreWithState({
+      dailyAggregates: [
+        {
+          day: '2026-04-09',
+          model: 'claude-sonnet-4-6',
+          projectKey: 'worktree:repo-1::/workspace/repo-a',
+          projectLabel: 'Repo A',
+          repoId: 'repo-1',
+          worktreeId: 'repo-1::/workspace/repo-a',
+          turnCount: 1,
+          zeroCacheReadTurnCount: 0,
+          inputTokens: 300_000,
+          outputTokens: 300_000,
+          cacheReadTokens: 300_000,
+          cacheWriteTokens: 300_000
+        }
+      ]
+    })
+
+    const summary = await store.getSummary('orca', '30d')
+
+    expect(summary.estimatedCostUsd).toBeCloseTo(8.07)
   })
 })

--- a/src/main/claude-usage/store.ts
+++ b/src/main/claude-usage/store.ts
@@ -13,38 +13,87 @@ import type {
   ClaudeUsageSummary
 } from '../../shared/claude-usage-types'
 import type { Store } from '../persistence'
-import { loadKnownUsageWorktreesByRepo } from '../usage-worktree-metadata'
+import { loadKnownUsageWorktreesByRepo, type UsageWorktreeRef } from '../usage-worktree-metadata'
 import type { ClaudeUsagePersistedState } from './types'
 import { createWorktreeRefs, getSessionProjectLabel, scanClaudeUsageFiles } from './scanner'
 
-const SCHEMA_VERSION = 1
+const SCHEMA_VERSION = 3
 const STALE_MS = 5 * 60_000
 
 // Why: capture the path after configureDevUserDataPath() but before app.setName()
 // mutates Electron's derived userData location, matching the persistence/store pattern.
 let _claudeUsageFile: string | null = null
 
-const MODEL_PRICING: Record<
-  string,
-  { input: number; output: number; cacheRead: number; cacheWrite: number }
-> = {
+type ClaudeModelPricing = {
+  input: number
+  output: number
+  cacheRead: number
+  cacheWrite: number
+  thresholdTokens?: number
+  inputAboveThreshold?: number
+  outputAboveThreshold?: number
+  cacheReadAboveThreshold?: number
+  cacheWriteAboveThreshold?: number
+}
+
+const LONG_CONTEXT_THRESHOLD_TOKENS = 200_000
+const SONNET_LONG_CONTEXT_PRICING = {
+  thresholdTokens: LONG_CONTEXT_THRESHOLD_TOKENS,
+  inputAboveThreshold: 6,
+  outputAboveThreshold: 22.5,
+  cacheReadAboveThreshold: 0.6,
+  cacheWriteAboveThreshold: 7.5
+} satisfies Partial<ClaudeModelPricing>
+
+const MODEL_PRICING: Record<string, ClaudeModelPricing> = {
   'claude-opus-4-7': { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
   'claude-opus-4-6': { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
   'claude-opus-4-5': { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
   'claude-opus-4-1': { input: 15, output: 75, cacheRead: 1.5, cacheWrite: 18.75 },
   'claude-opus-4': { input: 15, output: 75, cacheRead: 1.5, cacheWrite: 18.75 },
-  'claude-sonnet-4-6': { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
-  'claude-sonnet-4-5': { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
-  'claude-sonnet-4': { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+  'claude-sonnet-4-6': {
+    input: 3,
+    output: 15,
+    cacheRead: 0.3,
+    cacheWrite: 3.75,
+    ...SONNET_LONG_CONTEXT_PRICING
+  },
+  'claude-sonnet-4-5': {
+    input: 3,
+    output: 15,
+    cacheRead: 0.3,
+    cacheWrite: 3.75,
+    ...SONNET_LONG_CONTEXT_PRICING
+  },
+  'claude-sonnet-4': {
+    input: 3,
+    output: 15,
+    cacheRead: 0.3,
+    cacheWrite: 3.75,
+    ...SONNET_LONG_CONTEXT_PRICING
+  },
   'claude-sonnet-3-7': { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+  'claude-sonnet-3-5': { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
   'claude-haiku-4-5': { input: 1, output: 5, cacheRead: 0.1, cacheWrite: 1.25 },
   'claude-haiku-3-5': { input: 0.8, output: 4, cacheRead: 0.08, cacheWrite: 1 },
   'claude-haiku-3': { input: 0.25, output: 1.25, cacheRead: 0.03, cacheWrite: 0.3 }
 }
 
+const MODEL_ALIASES: Record<string, string> = {
+  model_placeholder_m26: 'claude-opus-4-6',
+  model_placeholder_m35: 'claude-sonnet-4-6',
+  'claude-opus-4.6': 'claude-opus-4-6',
+  'claude-sonnet-4.6': 'claude-sonnet-4-6',
+  'claude-opus-4.6-thinking': 'claude-opus-4-6',
+  'claude-sonnet-4.6-thinking': 'claude-sonnet-4-6',
+  'claude-opus-4-6-thinking': 'claude-opus-4-6',
+  'claude-sonnet-4-6-thinking': 'claude-sonnet-4-6'
+}
+
 function getDefaultState(): ClaudeUsagePersistedState {
   return {
     schemaVersion: SCHEMA_VERSION,
+    worktreeFingerprint: null,
     processedFiles: [],
     sessions: [],
     dailyAggregates: [],
@@ -72,7 +121,14 @@ function normalizeModelForPricing(model: string | null): string | null {
   if (!model) {
     return null
   }
-  const lower = model.toLowerCase()
+  const lower = model
+    .toLowerCase()
+    .trim()
+    .replace(/^anthropic[/:]/, '')
+  const alias = MODEL_ALIASES[lower]
+  if (alias) {
+    return alias
+  }
   if (lower.includes('opus-4-7')) {
     return 'claude-opus-4-7'
   }
@@ -103,8 +159,13 @@ function normalizeModelForPricing(model: string | null): string | null {
   // Why: legacy version-first IDs like `claude-3-5-sonnet-20241022` are still
   // present in historical Claude Code/SDK logs read off disk. Match them so
   // their cost is not silently dropped from the breakdown.
-  if (lower.includes('3-5-sonnet') || lower.includes('3.5-sonnet')) {
-    return 'claude-sonnet-3-7'
+  if (
+    lower.includes('sonnet-3-5') ||
+    lower.includes('sonnet-3.5') ||
+    lower.includes('3-5-sonnet') ||
+    lower.includes('3.5-sonnet')
+  ) {
+    return 'claude-sonnet-3-5'
   }
   if (lower.includes('haiku-4-5')) {
     return 'claude-haiku-4-5'
@@ -121,6 +182,20 @@ function normalizeModelForPricing(model: string | null): string | null {
   return null
 }
 
+function calculateTieredCost(
+  tokens: number,
+  basePrice: number,
+  abovePrice?: number,
+  threshold?: number
+): number {
+  if (threshold === undefined || abovePrice === undefined) {
+    return tokens * basePrice
+  }
+  const belowTokens = Math.min(tokens, threshold)
+  const aboveTokens = Math.max(tokens - threshold, 0)
+  return belowTokens * basePrice + aboveTokens * abovePrice
+}
+
 function estimateCostUsd(
   model: string | null,
   inputTokens: number,
@@ -134,10 +209,30 @@ function estimateCostUsd(
   }
   const pricing = MODEL_PRICING[normalized]
   return (
-    (inputTokens * pricing.input +
-      outputTokens * pricing.output +
-      cacheReadTokens * pricing.cacheRead +
-      cacheWriteTokens * pricing.cacheWrite) /
+    (calculateTieredCost(
+      inputTokens,
+      pricing.input,
+      pricing.inputAboveThreshold,
+      pricing.thresholdTokens
+    ) +
+      calculateTieredCost(
+        outputTokens,
+        pricing.output,
+        pricing.outputAboveThreshold,
+        pricing.thresholdTokens
+      ) +
+      calculateTieredCost(
+        cacheReadTokens,
+        pricing.cacheRead,
+        pricing.cacheReadAboveThreshold,
+        pricing.thresholdTokens
+      ) +
+      calculateTieredCost(
+        cacheWriteTokens,
+        pricing.cacheWrite,
+        pricing.cacheWriteAboveThreshold,
+        pricing.thresholdTokens
+      )) /
     1_000_000
   )
 }
@@ -167,6 +262,22 @@ function getLocalDay(timestamp: string): string | null {
   return `${year}-${month}-${day}`
 }
 
+function getWorktreeFingerprint(worktreesByRepo: Map<string, UsageWorktreeRef[]>): string {
+  const rows = [...worktreesByRepo.entries()]
+    .flatMap(([repoId, worktrees]) =>
+      worktrees.map((worktree) =>
+        JSON.stringify({
+          repoId,
+          worktreeId: worktree.worktreeId,
+          path: worktree.path,
+          displayName: worktree.displayName
+        })
+      )
+    )
+    .sort()
+  return JSON.stringify(rows)
+}
+
 export class ClaudeUsageStore {
   private state: ClaudeUsagePersistedState
   private readonly store: Store
@@ -184,6 +295,11 @@ export class ClaudeUsageStore {
         return getDefaultState()
       }
       const parsed = JSON.parse(readFileSync(usageFile, 'utf-8')) as ClaudeUsagePersistedState
+      if (parsed.schemaVersion !== SCHEMA_VERSION) {
+        // Why: scanner semantics affect persisted totals, so old Claude caches
+        // must be rebuilt after parser/source changes instead of reused briefly.
+        return getDefaultState()
+      }
       return {
         ...getDefaultState(),
         ...parsed,
@@ -233,9 +349,10 @@ export class ClaudeUsageStore {
     if (!this.state.scanState.enabled) {
       return this.getScanState()
     }
+    const currentWorktreeFingerprint = await this.getCurrentWorktreeFingerprint()
     if (!force && this.state.scanState.lastScanCompletedAt) {
       const ageMs = Date.now() - this.state.scanState.lastScanCompletedAt
-      if (ageMs < STALE_MS) {
+      if (ageMs < STALE_MS && this.state.worktreeFingerprint === currentWorktreeFingerprint) {
         return this.getScanState()
       }
     }
@@ -257,10 +374,15 @@ export class ClaudeUsageStore {
       try {
         const repos = this.store.getRepos()
         const worktreesByRepo = loadKnownUsageWorktreesByRepo(this.store, repos)
-        const result = await scanClaudeUsageFiles(createWorktreeRefs(repos, worktreesByRepo))
+        const worktreeFingerprint = getWorktreeFingerprint(worktreesByRepo)
+        const result = await scanClaudeUsageFiles(
+          createWorktreeRefs(repos, worktreesByRepo),
+          this.state.worktreeFingerprint === worktreeFingerprint ? this.state.processedFiles : []
+        )
         this.state.processedFiles = result.processedFiles
         this.state.sessions = result.sessions
         this.state.dailyAggregates = result.dailyAggregates
+        this.state.worktreeFingerprint = worktreeFingerprint
         this.state.scanState.lastScanCompletedAt = Date.now()
         this.state.scanState.lastScanError = null
         this.writeToDisk()
@@ -531,5 +653,11 @@ export class ClaudeUsageStore {
       }
       return true
     })
+  }
+
+  private async getCurrentWorktreeFingerprint(): Promise<string> {
+    const repos = this.store.getRepos()
+    const worktreesByRepo = loadKnownUsageWorktreesByRepo(this.store, repos)
+    return getWorktreeFingerprint(worktreesByRepo)
   }
 }

--- a/src/main/claude-usage/types.ts
+++ b/src/main/claude-usage/types.ts
@@ -1,6 +1,7 @@
 export type ClaudeUsageProcessedFile = {
   path: string
   mtimeMs: number
+  size: number
   lineCount: number
 }
 
@@ -50,7 +51,8 @@ export type ClaudeUsageDailyAggregate = {
 
 export type ClaudeUsagePersistedState = {
   schemaVersion: number
-  processedFiles: ClaudeUsageProcessedFile[]
+  worktreeFingerprint: string | null
+  processedFiles: ClaudeUsagePersistedFile[]
   sessions: ClaudeUsageSession[]
   dailyAggregates: ClaudeUsageDailyAggregate[]
   scanState: {
@@ -59,6 +61,11 @@ export type ClaudeUsagePersistedState = {
     lastScanCompletedAt: number | null
     lastScanError: string | null
   }
+}
+
+export type ClaudeUsagePersistedFile = ClaudeUsageProcessedFile & {
+  sessions: ClaudeUsageSession[]
+  dailyAggregates: ClaudeUsageDailyAggregate[]
 }
 
 export type ClaudeUsageParsedTurn = {

--- a/src/main/codex-usage/scanner.test.ts
+++ b/src/main/codex-usage/scanner.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { attributeCodexUsageEvent, parseCodexUsageRecord } from './scanner'
 
 describe('parseCodexUsageRecord', () => {
-  it('uses cumulative totals to avoid double-counting repeated token snapshots', () => {
+  it('uses token totals only as a duplicate baseline', () => {
     const context = {
       sessionId: 'session-1',
       sessionCwd: null,
@@ -100,7 +100,7 @@ describe('parseCodexUsageRecord', () => {
     expect(duplicate).toBeNull()
   })
 
-  it('falls back to inferred gpt-5 pricing when model metadata is missing', () => {
+  it('preserves unknown model metadata instead of assigning fallback pricing', () => {
     const context = {
       sessionId: 'session-1',
       sessionCwd: '/workspace/repo',
@@ -129,8 +129,53 @@ describe('parseCodexUsageRecord', () => {
       context
     )
 
-    expect(parsed?.model).toBe('gpt-5')
+    expect(parsed?.model).toBeNull()
     expect(parsed?.hasInferredPricing).toBe(true)
+  })
+
+  it('uses last token usage for the first resumed-session event', () => {
+    const context = {
+      sessionId: 'session-1',
+      sessionCwd: '/workspace/repo',
+      currentCwd: '/workspace/repo',
+      currentModel: 'gpt-5.5',
+      previousTotals: null
+    }
+
+    const parsed = parseCodexUsageRecord(
+      JSON.stringify({
+        timestamp: '2026-04-09T10:00:00.000Z',
+        type: 'event_msg',
+        payload: {
+          type: 'token_count',
+          info: {
+            total_token_usage: {
+              input_tokens: 50_000,
+              cached_input_tokens: 40_000,
+              output_tokens: 5_000,
+              reasoning_output_tokens: 1_000,
+              total_tokens: 55_000
+            },
+            last_token_usage: {
+              input_tokens: 2_000,
+              cached_input_tokens: 1_500,
+              output_tokens: 500,
+              reasoning_output_tokens: 100,
+              total_tokens: 2_500
+            }
+          }
+        }
+      }),
+      context
+    )
+
+    expect(parsed).toMatchObject({
+      inputTokens: 2_000,
+      cachedInputTokens: 1_500,
+      outputTokens: 500,
+      reasoningOutputTokens: 100,
+      totalTokens: 2_500
+    })
   })
 })
 

--- a/src/main/codex-usage/scanner.ts
+++ b/src/main/codex-usage/scanner.ts
@@ -47,8 +47,11 @@ type CodexUsageParseContext = {
   previousTotals: CodexUsageRawUsage | null
 }
 
+type CodexUsageDeltaResolution =
+  | { kind: 'event'; delta: CodexUsageRawUsage; nextTotals: CodexUsageRawUsage | null }
+  | { kind: 'baseline'; nextTotals: CodexUsageRawUsage }
+
 const DEFAULT_CODEX_SESSIONS_DIR = join(homedir(), '.codex', 'sessions')
-const LEGACY_FALLBACK_MODEL = 'gpt-5'
 const YIELD_EVERY_FILES = 10
 
 function ensureNumber(value: unknown): number {
@@ -169,6 +172,107 @@ function subtractRawUsage(
     ),
     totalTokens: Math.max(current.totalTokens - (previous?.totalTokens ?? 0), 0)
   }
+}
+
+function addRawUsage(left: CodexUsageRawUsage, right: CodexUsageRawUsage): CodexUsageRawUsage {
+  return {
+    inputTokens: left.inputTokens + right.inputTokens,
+    cachedInputTokens: left.cachedInputTokens + right.cachedInputTokens,
+    outputTokens: left.outputTokens + right.outputTokens,
+    reasoningOutputTokens: left.reasoningOutputTokens + right.reasoningOutputTokens,
+    totalTokens: left.totalTokens + right.totalTokens
+  }
+}
+
+function rawUsageEquals(left: CodexUsageRawUsage, right: CodexUsageRawUsage): boolean {
+  return (
+    left.inputTokens === right.inputTokens &&
+    left.cachedInputTokens === right.cachedInputTokens &&
+    left.outputTokens === right.outputTokens &&
+    left.reasoningOutputTokens === right.reasoningOutputTokens
+  )
+}
+
+function rawUsageIsMonotonic(current: CodexUsageRawUsage, previous: CodexUsageRawUsage): boolean {
+  return (
+    current.inputTokens >= previous.inputTokens &&
+    current.cachedInputTokens >= previous.cachedInputTokens &&
+    current.outputTokens >= previous.outputTokens &&
+    current.reasoningOutputTokens >= previous.reasoningOutputTokens
+  )
+}
+
+function rawUsageMagnitude(usage: CodexUsageRawUsage): number {
+  return (
+    usage.inputTokens + usage.cachedInputTokens + usage.outputTokens + usage.reasoningOutputTokens
+  )
+}
+
+function looksLikeStaleRegression(
+  current: CodexUsageRawUsage,
+  previous: CodexUsageRawUsage,
+  last: CodexUsageRawUsage
+): boolean {
+  const previousTotal = rawUsageMagnitude(previous)
+  const currentTotal = rawUsageMagnitude(current)
+  const lastTotal = rawUsageMagnitude(last)
+  if (previousTotal <= 0 || currentTotal <= 0 || lastTotal <= 0) {
+    return false
+  }
+  return currentTotal * 100 >= previousTotal * 98 || currentTotal + lastTotal * 2 >= previousTotal
+}
+
+function resolveCodexUsageDelta(
+  totalUsage: CodexUsageRawUsage | null,
+  lastUsage: CodexUsageRawUsage | null,
+  previousTotals: CodexUsageRawUsage | null
+): CodexUsageDeltaResolution | null {
+  if (totalUsage && lastUsage && previousTotals) {
+    if (rawUsageEquals(totalUsage, previousTotals)) {
+      return null
+    }
+    if (
+      !rawUsageIsMonotonic(totalUsage, previousTotals) &&
+      looksLikeStaleRegression(totalUsage, previousTotals, lastUsage)
+    ) {
+      return null
+    }
+    // Why: Codex totals are mutable snapshots after compaction/resume. The
+    // last_token_usage payload is the billable increment; totals are the baseline.
+    return { kind: 'event', delta: lastUsage, nextTotals: totalUsage }
+  }
+
+  if (totalUsage && lastUsage) {
+    return { kind: 'event', delta: lastUsage, nextTotals: totalUsage }
+  }
+
+  if (totalUsage && previousTotals) {
+    if (rawUsageEquals(totalUsage, previousTotals)) {
+      return null
+    }
+    if (!rawUsageIsMonotonic(totalUsage, previousTotals)) {
+      return { kind: 'baseline', nextTotals: totalUsage }
+    }
+    return {
+      kind: 'event',
+      delta: subtractRawUsage(totalUsage, previousTotals),
+      nextTotals: totalUsage
+    }
+  }
+
+  if (totalUsage) {
+    return { kind: 'event', delta: totalUsage, nextTotals: totalUsage }
+  }
+
+  if (lastUsage && previousTotals) {
+    return { kind: 'event', delta: lastUsage, nextTotals: addRawUsage(previousTotals, lastUsage) }
+  }
+
+  if (lastUsage) {
+    return { kind: 'event', delta: lastUsage, nextTotals: null }
+  }
+
+  return null
 }
 
 function extractString(value: unknown): string | null {
@@ -688,17 +792,21 @@ export function parseCodexUsageRecord(
   const record = info as Record<string, unknown>
   const totalUsage = normalizeRawUsage(record.total_token_usage)
   const lastUsage = normalizeRawUsage(record.last_token_usage)
-  let delta = totalUsage ? subtractRawUsage(totalUsage, context.previousTotals) : lastUsage
-  if (totalUsage) {
-    context.previousTotals = totalUsage
+  const resolvedUsage = resolveCodexUsageDelta(totalUsage, lastUsage, context.previousTotals)
+  if (!resolvedUsage) {
+    return null
   }
-  if (!delta) {
+  if (resolvedUsage.kind === 'baseline') {
+    context.previousTotals = resolvedUsage.nextTotals
     return null
   }
 
-  delta = {
-    ...delta,
-    cachedInputTokens: Math.min(delta.cachedInputTokens, delta.inputTokens)
+  let delta = {
+    ...resolvedUsage.delta,
+    cachedInputTokens: Math.min(
+      resolvedUsage.delta.cachedInputTokens,
+      resolvedUsage.delta.inputTokens
+    )
   }
 
   if (
@@ -711,15 +819,16 @@ export function parseCodexUsageRecord(
     return null
   }
 
+  context.previousTotals = resolvedUsage.nextTotals
+
   const resolvedModel = extractModel(parsed.payload) ?? context.currentModel
-  const model = resolvedModel ?? LEGACY_FALLBACK_MODEL
   const hasInferredPricing = resolvedModel === null
 
   return {
     sessionId: context.sessionId,
     timestamp: parsed.timestamp,
     cwd: context.currentCwd ?? context.sessionCwd,
-    model,
+    model: resolvedModel,
     hasInferredPricing,
     inputTokens: delta.inputTokens,
     cachedInputTokens: delta.cachedInputTokens,

--- a/src/main/codex-usage/store.test.ts
+++ b/src/main/codex-usage/store.test.ts
@@ -233,15 +233,79 @@ describe('CodexUsageStore', () => {
     const summary = await store.getSummary('orca', '30d')
     const breakdown = await store.getBreakdown('orca', '30d', 'model')
 
-    expect(summary.estimatedCostUsd).toBeCloseTo(85.1)
+    expect(summary.estimatedCostUsd).toBeCloseTo(107.486)
     expect(breakdown.find((row) => row.key === 'gpt-5.2-codex')?.estimatedCostUsd).toBeCloseTo(
       15.925
     )
     expect(breakdown.find((row) => row.key === 'gpt-5.3-codex')?.estimatedCostUsd).toBeCloseTo(
       15.925
     )
-    expect(breakdown.find((row) => row.key === 'gpt-5.4')?.estimatedCostUsd).toBeCloseTo(17.75)
-    expect(breakdown.find((row) => row.key === 'gpt-5.5')?.estimatedCostUsd).toBeCloseTo(35.5)
+    expect(breakdown.find((row) => row.key === 'gpt-5.4')?.estimatedCostUsd).toBeCloseTo(25.212)
+    expect(breakdown.find((row) => row.key === 'gpt-5.5')?.estimatedCostUsd).toBeCloseTo(50.424)
+  })
+
+  it('normalizes Codex model variants and reasoning suffixes before pricing', async () => {
+    const store = createStoreWithState({
+      dailyAggregates: [
+        {
+          day: '2026-04-09',
+          model: 'gpt-5.4-mini-high',
+          projectKey: 'worktree:repo-1::/workspace/repo',
+          projectLabel: 'Repo',
+          repoId: 'repo-1',
+          worktreeId: 'repo-1::/workspace/repo',
+          eventCount: 1,
+          inputTokens: 1_000_000,
+          cachedInputTokens: 500_000,
+          outputTokens: 1_000_000,
+          reasoningOutputTokens: 100_000,
+          totalTokens: 2_000_000,
+          hasInferredPricing: false
+        },
+        {
+          day: '2026-04-09',
+          model: 'gpt-5.3-codex-spark-xhigh',
+          projectKey: 'worktree:repo-1::/workspace/repo',
+          projectLabel: 'Repo',
+          repoId: 'repo-1',
+          worktreeId: 'repo-1::/workspace/repo',
+          eventCount: 1,
+          inputTokens: 2_000_000,
+          cachedInputTokens: 1_000_000,
+          outputTokens: 1_000_000,
+          reasoningOutputTokens: 100_000,
+          totalTokens: 3_000_000,
+          hasInferredPricing: false
+        },
+        {
+          day: '2026-04-09',
+          model: 'gpt-5.5(xhigh)',
+          projectKey: 'worktree:repo-1::/workspace/repo',
+          projectLabel: 'Repo',
+          repoId: 'repo-1',
+          worktreeId: 'repo-1::/workspace/repo',
+          eventCount: 1,
+          inputTokens: 100_000,
+          cachedInputTokens: 50_000,
+          outputTokens: 25_000,
+          reasoningOutputTokens: 5_000,
+          totalTokens: 125_000,
+          hasInferredPricing: false
+        }
+      ]
+    })
+
+    const breakdown = await store.getBreakdown('orca', '30d', 'model')
+
+    expect(breakdown.find((row) => row.key === 'gpt-5.4-mini-high')?.estimatedCostUsd).toBeCloseTo(
+      4.9125
+    )
+    expect(
+      breakdown.find((row) => row.key === 'gpt-5.3-codex-spark-xhigh')?.estimatedCostUsd
+    ).toBeCloseTo(15.925)
+    expect(breakdown.find((row) => row.key === 'gpt-5.5(xhigh)')?.estimatedCostUsd).toBeCloseTo(
+      1.025
+    )
   })
 
   it('keeps cached input out of the full-price input bucket for GPT-5.5 totals', async () => {
@@ -267,7 +331,7 @@ describe('CodexUsageStore', () => {
 
     const summary = await store.getSummary('orca', '30d')
 
-    expect(summary.estimatedCostUsd).toBeCloseTo(446.840002)
+    expect(summary.estimatedCostUsd).toBeCloseTo(858.929724)
   })
 
   it('counts mixed-model sessions once for each real model row in the breakdown', async () => {
@@ -584,7 +648,7 @@ describe('CodexUsageStore', () => {
     } as unknown as CodexUsagePersistedState)
 
     expect(normalized).toEqual({
-      schemaVersion: 2,
+      schemaVersion: 3,
       worktreeFingerprint: null,
       processedFiles: [],
       sessions: [],

--- a/src/main/codex-usage/store.ts
+++ b/src/main/codex-usage/store.ts
@@ -17,19 +17,70 @@ import { loadKnownUsageWorktreesByRepo, type UsageWorktreeRef } from '../usage-w
 import type { CodexUsagePersistedState } from './types'
 import { createWorktreeRefs, scanCodexUsageFiles } from './scanner'
 
-const SCHEMA_VERSION = 2
+const SCHEMA_VERSION = 3
 const STALE_MS = 5 * 60_000
 
 let _codexUsageFile: string | null = null
 
-const MODEL_PRICING: Record<string, { input: number; cachedInput: number; output: number }> = {
+type TieredPrice = { threshold: number; price: number }
+type CodexModelPricing = {
+  input: number
+  cachedInput: number
+  output: number
+  inputTiers?: TieredPrice[]
+  cachedInputTiers?: TieredPrice[]
+  outputTiers?: TieredPrice[]
+}
+
+const LONG_CONTEXT_THRESHOLD_TOKENS = 272_000
+
+const MODEL_PRICING: Record<string, CodexModelPricing> = {
   'gpt-5': { input: 1.25, cachedInput: 0.125, output: 10 },
   'gpt-5.1': { input: 1.25, cachedInput: 0.125, output: 10 },
+  'gpt-5.1-codex': { input: 1.25, cachedInput: 0.125, output: 10 },
+  'gpt-5.1-codex-max': { input: 1.25, cachedInput: 0.125, output: 10 },
   'gpt-5.2': { input: 1.75, cachedInput: 0.175, output: 14 },
+  'gpt-5.2-codex': { input: 1.75, cachedInput: 0.175, output: 14 },
+  'gpt-5.3': { input: 1.75, cachedInput: 0.175, output: 14 },
   'gpt-5.3-codex': { input: 1.75, cachedInput: 0.175, output: 14 },
-  'gpt-5.4': { input: 2.5, cachedInput: 0.25, output: 15 },
-  'gpt-5.5': { input: 5, cachedInput: 0.5, output: 30 }
+  'gpt-5.3-codex-spark': { input: 1.75, cachedInput: 0.175, output: 14 },
+  'gpt-5.4-mini': { input: 0.75, cachedInput: 0.075, output: 4.5 },
+  'gpt-5.4-nano': { input: 0.2, cachedInput: 0.02, output: 1.25 },
+  'gpt-5.4-pro': {
+    input: 30,
+    cachedInput: 30,
+    output: 180,
+    inputTiers: [{ threshold: LONG_CONTEXT_THRESHOLD_TOKENS, price: 60 }],
+    cachedInputTiers: [{ threshold: LONG_CONTEXT_THRESHOLD_TOKENS, price: 60 }],
+    outputTiers: [{ threshold: LONG_CONTEXT_THRESHOLD_TOKENS, price: 270 }]
+  },
+  'gpt-5.4': {
+    input: 2.5,
+    cachedInput: 0.25,
+    output: 15,
+    inputTiers: [{ threshold: LONG_CONTEXT_THRESHOLD_TOKENS, price: 5 }],
+    cachedInputTiers: [{ threshold: LONG_CONTEXT_THRESHOLD_TOKENS, price: 0.5 }],
+    outputTiers: [{ threshold: LONG_CONTEXT_THRESHOLD_TOKENS, price: 22.5 }]
+  },
+  'gpt-5.5-pro': {
+    input: 30,
+    cachedInput: 30,
+    output: 180,
+    inputTiers: [{ threshold: LONG_CONTEXT_THRESHOLD_TOKENS, price: 60 }],
+    cachedInputTiers: [{ threshold: LONG_CONTEXT_THRESHOLD_TOKENS, price: 60 }],
+    outputTiers: [{ threshold: LONG_CONTEXT_THRESHOLD_TOKENS, price: 270 }]
+  },
+  'gpt-5.5': {
+    input: 5,
+    cachedInput: 0.5,
+    output: 30,
+    inputTiers: [{ threshold: LONG_CONTEXT_THRESHOLD_TOKENS, price: 10 }],
+    cachedInputTiers: [{ threshold: LONG_CONTEXT_THRESHOLD_TOKENS, price: 1 }],
+    outputTiers: [{ threshold: LONG_CONTEXT_THRESHOLD_TOKENS, price: 45 }]
+  }
 }
+
+const REASONING_TIER_SUFFIXES = ['minimal', 'low', 'medium', 'high', 'xhigh', 'auto', 'none']
 
 function getDefaultState(): CodexUsagePersistedState {
   return {
@@ -75,31 +126,102 @@ function getCodexUsageFile(): string {
   return _codexUsageFile
 }
 
+function stripParenthesizedReasoningTier(model: string): string | null {
+  const match = model.match(/^(.*)\(([^()]*)\)$/)
+  if (!match) {
+    return model
+  }
+  const tier = match[2].trim().toLowerCase()
+  if (!REASONING_TIER_SUFFIXES.includes(tier)) {
+    return null
+  }
+  return match[1]
+}
+
+function stripDashReasoningTiers(model: string): string {
+  let current = model
+  for (let index = 0; index < 4; index++) {
+    const suffix = REASONING_TIER_SUFFIXES.find((tier) => current.endsWith(`-${tier}`))
+    if (!suffix) {
+      return current
+    }
+    current = current.slice(0, -suffix.length - 1)
+  }
+  return current
+}
+
 function normalizeModelForPricing(model: string | null): string | null {
   if (!model) {
     return null
   }
 
-  const lower = model.toLowerCase()
-  if (lower === 'gpt-5' || lower === 'gpt-5-codex') {
+  const lower = stripParenthesizedReasoningTier(model.toLowerCase().trim())
+  if (!lower) {
+    return null
+  }
+
+  const normalized = stripDashReasoningTiers(lower)
+  if (normalized === 'gpt-5' || normalized === 'gpt-5-codex') {
     return 'gpt-5'
   }
-  if (lower.startsWith('gpt-5.1')) {
+  if (normalized === 'gpt-5.1-codex-max' || normalized.startsWith('gpt-5.1-codex-max-')) {
+    return 'gpt-5.1-codex-max'
+  }
+  if (normalized === 'gpt-5.1-codex' || normalized.startsWith('gpt-5.1-codex-')) {
+    return 'gpt-5.1-codex'
+  }
+  if (normalized === 'gpt-5.1' || normalized.startsWith('gpt-5.1-')) {
     return 'gpt-5.1'
   }
-  if (lower.startsWith('gpt-5.2')) {
+  if (normalized === 'gpt-5.2-codex' || normalized.startsWith('gpt-5.2-codex-')) {
+    return 'gpt-5.2-codex'
+  }
+  if (normalized === 'gpt-5.2' || normalized.startsWith('gpt-5.2-')) {
     return 'gpt-5.2'
   }
-  if (lower.startsWith('gpt-5.3-codex')) {
+  if (normalized === 'gpt-5.3-codex-spark' || normalized.startsWith('gpt-5.3-codex-spark-')) {
+    return 'gpt-5.3-codex-spark'
+  }
+  if (normalized === 'gpt-5.3-codex' || normalized.startsWith('gpt-5.3-codex-')) {
     return 'gpt-5.3-codex'
   }
-  if (lower.startsWith('gpt-5.4')) {
+  if (normalized === 'gpt-5.3' || normalized.startsWith('gpt-5.3-')) {
+    return 'gpt-5.3'
+  }
+  if (normalized === 'gpt-5.4-mini' || normalized.startsWith('gpt-5.4-mini-')) {
+    return 'gpt-5.4-mini'
+  }
+  if (normalized === 'gpt-5.4-nano' || normalized.startsWith('gpt-5.4-nano-')) {
+    return 'gpt-5.4-nano'
+  }
+  if (normalized === 'gpt-5.4-pro' || normalized.startsWith('gpt-5.4-pro-')) {
+    return 'gpt-5.4-pro'
+  }
+  if (normalized === 'gpt-5.4' || normalized.startsWith('gpt-5.4-')) {
     return 'gpt-5.4'
   }
-  if (lower.startsWith('gpt-5.5')) {
+  if (normalized === 'gpt-5.5-pro' || normalized.startsWith('gpt-5.5-pro-')) {
+    return 'gpt-5.5-pro'
+  }
+  if (normalized === 'gpt-5.5' || normalized.startsWith('gpt-5.5-')) {
     return 'gpt-5.5'
   }
   return null
+}
+
+function calculateTieredCost(tokens: number, basePrice: number, tiers: TieredPrice[] = []): number {
+  let cost = 0
+  let lowerBound = 0
+  let activePrice = basePrice
+  for (const tier of tiers) {
+    if (tokens <= tier.threshold) {
+      return cost + Math.max(tokens - lowerBound, 0) * activePrice
+    }
+    cost += (tier.threshold - lowerBound) * activePrice
+    lowerBound = tier.threshold
+    activePrice = tier.price
+  }
+  return cost + Math.max(tokens - lowerBound, 0) * activePrice
 }
 
 function estimateCostUsd(
@@ -119,9 +241,9 @@ function estimateCostUsd(
   // price and again at cache-read price.
   const nonCachedInputTokens = Math.max(inputTokens - clampedCached, 0)
   return (
-    (nonCachedInputTokens * pricing.input +
-      clampedCached * pricing.cachedInput +
-      outputTokens * pricing.output) /
+    (calculateTieredCost(nonCachedInputTokens, pricing.input, pricing.inputTiers) +
+      calculateTieredCost(clampedCached, pricing.cachedInput, pricing.cachedInputTiers) +
+      calculateTieredCost(outputTokens, pricing.output, pricing.outputTiers)) /
     1_000_000
   )
 }

--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -558,7 +558,7 @@ function Settings(): React.JSX.Element {
       {
         id: 'stats',
         title: 'Stats & Usage',
-        description: 'Orca stats and Claude usage analytics.',
+        description: 'Orca stats plus Claude and Codex usage analytics.',
         icon: BarChart3,
         searchEntries: STATS_PANE_SEARCH_ENTRIES
       },

--- a/src/renderer/src/components/stats/StatsPane.tsx
+++ b/src/renderer/src/components/stats/StatsPane.tsx
@@ -4,6 +4,7 @@ import { useAppStore } from '../../store'
 import { StatCard } from './StatCard'
 import { ClaudeUsagePane } from './ClaudeUsagePane'
 import { CodexUsagePane } from './CodexUsagePane'
+import { UsageOverviewPane } from './UsageOverviewPane'
 import type { SettingsSearchEntry } from '../settings/settings-search'
 import { cn } from '@/lib/utils'
 
@@ -11,7 +12,7 @@ export const STATS_PANE_SEARCH_ENTRIES: SettingsSearchEntry[] = [
   {
     title: 'Stats & Usage',
     description:
-      'Orca stats plus Claude and Codex usage analytics, tokens, cache, models, and sessions.',
+      'Orca stats plus combined Claude and Codex usage analytics, tokens, cache, models, and sessions.',
     keywords: [
       'stats',
       'usage',
@@ -59,7 +60,7 @@ function formatTrackingSince(timestamp: number | null): string {
 export function StatsPane(): React.JSX.Element {
   const summary = useAppStore((s) => s.statsSummary)
   const fetchStatsSummary = useAppStore((s) => s.fetchStatsSummary)
-  const [activeUsageTab, setActiveUsageTab] = useState<'claude' | 'codex'>('claude')
+  const [activeUsageTab, setActiveUsageTab] = useState<'overview' | 'claude' | 'codex'>('overview')
 
   useEffect(() => {
     void fetchStatsSummary()
@@ -110,7 +111,7 @@ export function StatsPane(): React.JSX.Element {
             aria-label="Usage analytics provider"
             className="inline-flex w-fit items-center justify-center rounded-lg bg-muted p-[3px] text-muted-foreground"
           >
-            {(['claude', 'codex'] as const).map((tab) => (
+            {(['overview', 'claude', 'codex'] as const).map((tab) => (
               <button
                 key={tab}
                 type="button"
@@ -123,7 +124,7 @@ export function StatsPane(): React.JSX.Element {
                     : 'text-foreground/60 hover:text-foreground dark:text-muted-foreground dark:hover:text-foreground'
                 )}
               >
-                {tab === 'claude' ? 'Claude' : 'Codex'}
+                {tab === 'overview' ? 'Overview' : tab === 'claude' ? 'Claude' : 'Codex'}
               </button>
             ))}
           </div>
@@ -132,7 +133,15 @@ export function StatsPane(): React.JSX.Element {
         {/* Why: the Stats section lives inside the scroll-tracked settings page. Keeping only the
             active panel mounted avoids hidden tab-content layout/focus churn that produced a visible
             vertical jitter below the usage card when switching disabled providers. */}
-        <div>{activeUsageTab === 'claude' ? <ClaudeUsagePane /> : <CodexUsagePane />}</div>
+        <div>
+          {activeUsageTab === 'overview' ? (
+            <UsageOverviewPane />
+          ) : activeUsageTab === 'claude' ? (
+            <ClaudeUsagePane />
+          ) : (
+            <CodexUsagePane />
+          )}
+        </div>
       </div>
     </div>
   )

--- a/src/renderer/src/components/stats/UsageOverviewPane.tsx
+++ b/src/renderer/src/components/stats/UsageOverviewPane.tsx
@@ -1,0 +1,412 @@
+import { useEffect, useMemo } from 'react'
+import {
+  Activity,
+  AlertCircle,
+  CalendarDays,
+  Coins,
+  DatabaseZap,
+  RefreshCw,
+  Sparkles
+} from 'lucide-react'
+import { useAppStore } from '../../store'
+import { Badge } from '../ui/badge'
+import { Button } from '../ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
+import { StatCard } from './StatCard'
+import {
+  buildUsageOverview,
+  formatUsageCost,
+  formatUsageTokens,
+  getRecentUsageDays,
+  type UsageOverviewDailyPoint,
+  type UsageOverviewModel,
+  type UsageProviderOverview
+} from './usage-overview-model'
+
+const RECENT_DAY_COUNT = 42
+
+const INTENSITY_CLASS: Record<UsageOverviewDailyPoint['intensity'], string> = {
+  0: 'border-border/60 bg-muted/40',
+  1: 'border-border/60 bg-muted-foreground/20',
+  2: 'border-border/60 bg-muted-foreground/35',
+  3: 'border-border/60 bg-muted-foreground/55',
+  4: 'border-border/60 bg-foreground/75'
+}
+
+function formatPercent(value: number | null): string {
+  if (value === null) {
+    return 'n/a'
+  }
+  return `${Math.round(value * 100)}%`
+}
+
+function formatUpdatedAt(timestamp: number | null): string {
+  if (!timestamp) {
+    return 'Not scanned yet'
+  }
+  return `Updated ${new Date(timestamp).toLocaleString()}`
+}
+
+function formatDayLabel(day: string): string {
+  const parsed = new Date(`${day}T12:00:00`)
+  if (Number.isNaN(parsed.getTime())) {
+    return day
+  }
+  return parsed.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+}
+
+function TokenMixBar({ overview }: { overview: UsageOverviewModel }): React.JSX.Element {
+  const segments = [
+    {
+      key: 'new-input',
+      label: 'New input',
+      value: overview.newInputTokens,
+      className: 'bg-foreground'
+    },
+    {
+      key: 'output',
+      label: 'Output',
+      value: overview.outputTokens,
+      className: 'bg-muted-foreground'
+    },
+    {
+      key: 'cache',
+      label: 'Cache',
+      value: overview.cacheTokens,
+      className: 'bg-border'
+    }
+  ]
+  // Why: Codex cached input is a subset of input. The overview model normalizes
+  // that into new/cache buckets so the visual mix does not double-count it.
+  const mixTotal = segments.reduce((sum, segment) => sum + segment.value, 0)
+
+  return (
+    <section className="rounded-lg border border-border/60 bg-card/40 p-4">
+      <div className="mb-3 flex items-start justify-between gap-3">
+        <div>
+          <h4 className="text-sm font-semibold text-foreground">Token mix</h4>
+          <p className="text-xs text-muted-foreground">
+            Combined input, output, and cache tokens across enabled providers.
+          </p>
+        </div>
+        {overview.reasoningTokens > 0 ? (
+          <Badge variant="outline" className="shrink-0">
+            {formatUsageTokens(overview.reasoningTokens)} reasoning
+          </Badge>
+        ) : null}
+      </div>
+
+      {mixTotal > 0 ? (
+        <div
+          className="flex h-3 overflow-hidden rounded-full border border-border/60 bg-muted"
+          aria-label="Combined token mix"
+        >
+          {segments.map((segment) =>
+            segment.value > 0 ? (
+              <div
+                key={segment.key}
+                className={segment.className}
+                style={{ width: `${(segment.value / mixTotal) * 100}%` }}
+                aria-label={`${segment.label}: ${segment.value.toLocaleString()} tokens`}
+              />
+            ) : null
+          )}
+        </div>
+      ) : (
+        <div className="h-3 rounded-full border border-dashed border-border/60 bg-muted/40" />
+      )}
+
+      <div className="mt-3 grid gap-2 text-xs text-muted-foreground sm:grid-cols-3">
+        {segments.map((segment) => (
+          <div key={segment.key} className="flex min-w-0 items-center gap-2">
+            <span className={`size-2 shrink-0 rounded-full ${segment.className}`} />
+            <span className="min-w-0 truncate">
+              {segment.label}: {formatUsageTokens(segment.value)}
+            </span>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}
+
+function DailyIntensityGrid({
+  days,
+  bestDay
+}: {
+  days: UsageOverviewDailyPoint[]
+  bestDay: UsageOverviewDailyPoint | null
+}): React.JSX.Element {
+  return (
+    <section className="rounded-lg border border-border/60 bg-card/40 p-4">
+      <div className="mb-3 flex items-start justify-between gap-3">
+        <div>
+          <h4 className="text-sm font-semibold text-foreground">Daily intensity</h4>
+          <p className="text-xs text-muted-foreground">
+            Recent combined Claude and Codex token activity.
+          </p>
+        </div>
+        {bestDay && bestDay.totalTokens > 0 ? (
+          <Badge variant="outline" className="shrink-0">
+            Best: {formatDayLabel(bestDay.day)}
+          </Badge>
+        ) : null}
+      </div>
+
+      <div
+        className="grid grid-cols-[repeat(14,minmax(0,1fr))] gap-1 sm:grid-cols-[repeat(21,minmax(0,1fr))]"
+        aria-label="Recent token activity heatmap"
+      >
+        {days.map((day) => (
+          <div
+            key={day.day}
+            className={`aspect-square min-h-3 rounded-[2px] border ${INTENSITY_CLASS[day.intensity]}`}
+            aria-label={`${day.day}: ${day.totalTokens.toLocaleString()} tokens`}
+          />
+        ))}
+      </div>
+
+      <div className="mt-3 flex items-center justify-between gap-3 text-xs text-muted-foreground">
+        <span>{formatDayLabel(days[0]?.day ?? '')}</span>
+        <span>Less</span>
+        <div className="flex items-center gap-1" aria-hidden>
+          {[0, 1, 2, 3, 4].map((intensity) => (
+            <span
+              key={intensity}
+              className={`size-2 rounded-[2px] border ${INTENSITY_CLASS[intensity as UsageOverviewDailyPoint['intensity']]}`}
+            />
+          ))}
+        </div>
+        <span>More</span>
+        <span>{formatDayLabel(days.at(-1)?.day ?? '')}</span>
+      </div>
+    </section>
+  )
+}
+
+function ProviderRow({
+  provider,
+  totalTokens,
+  onEnable
+}: {
+  provider: UsageProviderOverview
+  totalTokens: number
+  onEnable: () => void
+}): React.JSX.Element {
+  const share = totalTokens > 0 ? provider.totalTokens / totalTokens : 0
+  const status = provider.enabled ? (provider.isScanning ? 'Scanning' : 'Enabled') : 'Off'
+  const statusVariant = provider.enabled ? 'secondary' : 'outline'
+
+  return (
+    <div className="rounded-lg border border-border/60 bg-card/40 p-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="flex min-w-0 items-center gap-2">
+            <h5 className="truncate text-sm font-semibold text-foreground">{provider.label}</h5>
+            <Badge variant={statusVariant}>{status}</Badge>
+          </div>
+          <p className="mt-1 truncate text-xs text-muted-foreground">
+            {provider.topModel ?? 'No model yet'}
+            {provider.topProject ? ` - ${provider.topProject}` : ''}
+          </p>
+        </div>
+        {!provider.enabled ? (
+          <Button variant="outline" size="xs" onClick={onEnable}>
+            Enable
+          </Button>
+        ) : null}
+      </div>
+
+      <div className="mt-3 grid gap-2 text-xs text-muted-foreground sm:grid-cols-3">
+        <span>{formatUsageTokens(provider.totalTokens)} tokens</span>
+        <span>
+          {provider.sessions.toLocaleString()} sessions - {provider.activityCount.toLocaleString()}{' '}
+          {provider.activityLabel}
+        </span>
+        <span>{formatUsageCost(provider.estimatedCostUsd)}</span>
+      </div>
+      <div className="mt-3 h-1.5 overflow-hidden rounded-full bg-muted">
+        <div
+          className="h-full rounded-full bg-foreground/75"
+          style={{ width: `${Math.max(share * 100, provider.totalTokens > 0 ? 2 : 0)}%` }}
+        />
+      </div>
+      {provider.lastScanError ? (
+        <p className="mt-2 flex items-center gap-1 text-xs text-destructive">
+          <AlertCircle className="size-3" />
+          {provider.lastScanError}
+        </p>
+      ) : null}
+    </div>
+  )
+}
+
+export function UsageOverviewPane(): React.JSX.Element {
+  const claudeScanState = useAppStore((state) => state.claudeUsageScanState)
+  const claudeSummary = useAppStore((state) => state.claudeUsageSummary)
+  const claudeDaily = useAppStore((state) => state.claudeUsageDaily)
+  const codexScanState = useAppStore((state) => state.codexUsageScanState)
+  const codexSummary = useAppStore((state) => state.codexUsageSummary)
+  const codexDaily = useAppStore((state) => state.codexUsageDaily)
+  const fetchClaudeUsage = useAppStore((state) => state.fetchClaudeUsage)
+  const fetchCodexUsage = useAppStore((state) => state.fetchCodexUsage)
+  const refreshClaudeUsage = useAppStore((state) => state.refreshClaudeUsage)
+  const refreshCodexUsage = useAppStore((state) => state.refreshCodexUsage)
+  const enableClaudeUsage = useAppStore((state) => state.enableClaudeUsage)
+  const enableCodexUsage = useAppStore((state) => state.enableCodexUsage)
+
+  useEffect(() => {
+    void fetchClaudeUsage()
+    void fetchCodexUsage()
+  }, [fetchClaudeUsage, fetchCodexUsage])
+
+  const overview = useMemo(
+    () =>
+      buildUsageOverview({
+        claude: {
+          scanState: claudeScanState,
+          summary: claudeSummary,
+          daily: claudeDaily
+        },
+        codex: {
+          scanState: codexScanState,
+          summary: codexSummary,
+          daily: codexDaily
+        }
+      }),
+    [claudeDaily, claudeScanState, claudeSummary, codexDaily, codexScanState, codexSummary]
+  )
+  const recentDays = useMemo(
+    () => getRecentUsageDays(overview.daily, RECENT_DAY_COUNT),
+    [overview.daily]
+  )
+  const isScanning = overview.providers.some((provider) => provider.isScanning)
+
+  const handleRefresh = (): void => {
+    void Promise.all([
+      claudeScanState?.enabled ? refreshClaudeUsage() : Promise.resolve(),
+      codexScanState?.enabled ? refreshCodexUsage() : Promise.resolve()
+    ])
+  }
+
+  return (
+    <div className="space-y-4" data-testid="usage-overview-pane">
+      <section className="rounded-lg border border-border/60 bg-card/30 p-4">
+        <div className="flex items-start justify-between gap-4">
+          <div className="min-w-0">
+            <h3 className="text-sm font-semibold text-foreground">Usage Overview</h3>
+            <p className="mt-1 text-xs text-muted-foreground">
+              {formatUpdatedAt(overview.lastUpdatedAt)}
+              {overview.hasPartialCost ? ' - some model prices are unavailable' : ''}
+            </p>
+          </div>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                onClick={handleRefresh}
+                disabled={!overview.hasAnyEnabledProvider || isScanning}
+                aria-label="Refresh usage overview"
+              >
+                <RefreshCw className={`size-3.5 ${isScanning ? 'animate-spin' : ''}`} />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" sideOffset={6}>
+              Refresh
+            </TooltipContent>
+          </Tooltip>
+        </div>
+
+        {!overview.hasAnyEnabledProvider ? (
+          <div className="mt-4 rounded-lg border border-dashed border-border/60 bg-card/30 px-4 py-5">
+            <div className="max-w-xl space-y-3">
+              <div>
+                <h4 className="text-sm font-semibold text-foreground">Start tracking tokens</h4>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  Enable a provider to scan local agent logs and build the combined token ledger.
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <Button size="sm" onClick={() => void enableClaudeUsage()}>
+                  Enable Claude
+                </Button>
+                <Button variant="secondary" size="sm" onClick={() => void enableCodexUsage()}>
+                  Enable Codex
+                </Button>
+              </div>
+            </div>
+          </div>
+        ) : (
+          <>
+            <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+              <StatCard
+                label="Total tokens"
+                value={formatUsageTokens(overview.totalTokens)}
+                icon={<Sparkles className="size-4" />}
+              />
+              <StatCard
+                label="Est. cost"
+                value={formatUsageCost(overview.estimatedCostUsd)}
+                icon={<Coins className="size-4" />}
+              />
+              <StatCard
+                label="Active days"
+                value={overview.activeDays.toLocaleString()}
+                icon={<CalendarDays className="size-4" />}
+              />
+              <StatCard
+                label="Cache share"
+                value={formatPercent(overview.cacheShare)}
+                icon={<DatabaseZap className="size-4" />}
+              />
+            </div>
+
+            {!overview.hasAnyData ? (
+              <div className="mt-4 rounded-lg border border-dashed border-border/60 bg-card/30 px-4 py-5 text-sm text-muted-foreground">
+                No local Claude or Codex usage found yet. The overview will populate after the next
+                agent session writes token logs.
+              </div>
+            ) : (
+              <div className="mt-4 grid gap-4 xl:grid-cols-[minmax(0,1.2fr)_minmax(0,0.8fr)]">
+                <DailyIntensityGrid days={recentDays} bestDay={overview.bestDay} />
+                <TokenMixBar overview={overview} />
+              </div>
+            )}
+          </>
+        )}
+      </section>
+
+      <section className="space-y-3">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <h4 className="text-sm font-semibold text-foreground">Providers</h4>
+            <p className="text-xs text-muted-foreground">
+              {overview.enabledProviderCount} enabled - {overview.dataProviderCount} with data
+            </p>
+          </div>
+          <Badge variant="outline" className="gap-1">
+            <Activity className="size-3" />
+            {overview.sessions.toLocaleString()} sessions
+          </Badge>
+        </div>
+        <div className="grid gap-3 xl:grid-cols-2">
+          {overview.providers.map((provider) => (
+            <ProviderRow
+              key={provider.id}
+              provider={provider}
+              totalTokens={overview.totalTokens}
+              onEnable={() => {
+                if (provider.id === 'claude') {
+                  void enableClaudeUsage()
+                } else {
+                  void enableCodexUsage()
+                }
+              }}
+            />
+          ))}
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/renderer/src/components/stats/usage-overview-model.test.ts
+++ b/src/renderer/src/components/stats/usage-overview-model.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from 'vitest'
+import type {
+  ClaudeUsageDailyPoint,
+  ClaudeUsageScanState,
+  ClaudeUsageSummary
+} from '../../../../shared/claude-usage-types'
+import type {
+  CodexUsageDailyPoint,
+  CodexUsageScanState,
+  CodexUsageSummary
+} from '../../../../shared/codex-usage-types'
+import {
+  buildUsageOverview,
+  formatUsageCost,
+  formatUsageTokens,
+  getRecentUsageDays
+} from './usage-overview-model'
+
+function enabledClaudeScanState(): ClaudeUsageScanState {
+  return {
+    enabled: true,
+    isScanning: false,
+    lastScanStartedAt: 100,
+    lastScanCompletedAt: 200,
+    lastScanError: null,
+    hasAnyClaudeData: true
+  }
+}
+
+function enabledCodexScanState(): CodexUsageScanState {
+  return {
+    enabled: true,
+    isScanning: false,
+    lastScanStartedAt: 300,
+    lastScanCompletedAt: 400,
+    lastScanError: null,
+    hasAnyCodexData: true
+  }
+}
+
+describe('usage overview model', () => {
+  it('combines Claude and Codex totals without double-counting Codex cached input', () => {
+    const claudeSummary: ClaudeUsageSummary = {
+      scope: 'orca',
+      range: '30d',
+      sessions: 2,
+      turns: 4,
+      zeroCacheReadTurns: 1,
+      inputTokens: 1_000,
+      outputTokens: 500,
+      cacheReadTokens: 4_000,
+      cacheWriteTokens: 500,
+      cacheReuseRate: 0.8,
+      estimatedCostUsd: 0.04,
+      topModel: 'claude-sonnet-4-5',
+      topProject: 'orca-main',
+      hasAnyClaudeData: true
+    }
+    const codexSummary: CodexUsageSummary = {
+      scope: 'orca',
+      range: '30d',
+      sessions: 1,
+      events: 3,
+      inputTokens: 2_000,
+      cachedInputTokens: 800,
+      outputTokens: 1_200,
+      reasoningOutputTokens: 300,
+      totalTokens: 3_200,
+      estimatedCostUsd: 0.02,
+      topModel: 'gpt-5.4',
+      topProject: 'orca-secondary',
+      hasAnyCodexData: true
+    }
+    const claudeDaily: ClaudeUsageDailyPoint[] = [
+      {
+        day: '2026-05-13',
+        inputTokens: 500,
+        outputTokens: 500,
+        cacheReadTokens: 2_500,
+        cacheWriteTokens: 0
+      },
+      {
+        day: '2026-05-14',
+        inputTokens: 500,
+        outputTokens: 0,
+        cacheReadTokens: 1_500,
+        cacheWriteTokens: 500
+      }
+    ]
+    const codexDaily: CodexUsageDailyPoint[] = [
+      {
+        day: '2026-05-14',
+        inputTokens: 1_200,
+        cachedInputTokens: 400,
+        outputTokens: 800,
+        reasoningOutputTokens: 100,
+        totalTokens: 2_000
+      },
+      {
+        day: '2026-05-15',
+        inputTokens: 800,
+        cachedInputTokens: 400,
+        outputTokens: 400,
+        reasoningOutputTokens: 200,
+        totalTokens: 1_200
+      }
+    ]
+
+    const overview = buildUsageOverview({
+      claude: {
+        scanState: enabledClaudeScanState(),
+        summary: claudeSummary,
+        daily: claudeDaily
+      },
+      codex: {
+        scanState: enabledCodexScanState(),
+        summary: codexSummary,
+        daily: codexDaily
+      }
+    })
+
+    expect(overview.totalTokens).toBe(9_200)
+    expect(overview.newInputTokens).toBe(2_200)
+    expect(overview.cacheTokens).toBe(5_300)
+    expect(overview.outputTokens).toBe(1_700)
+    expect(overview.reasoningTokens).toBe(300)
+    expect(overview.sessions).toBe(3)
+    expect(overview.activityCount).toBe(7)
+    expect(overview.activeDays).toBe(3)
+    expect(overview.estimatedCostUsd).toBeCloseTo(0.06)
+    expect(overview.cacheShare).toBeCloseTo(5_300 / 7_500)
+    expect(overview.bestDay).toMatchObject({
+      day: '2026-05-14',
+      totalTokens: 4_500,
+      claudeTokens: 2_500,
+      codexTokens: 2_000,
+      intensity: 4
+    })
+    expect(overview.providers.find((provider) => provider.id === 'codex')).toMatchObject({
+      newInputTokens: 1_200,
+      cacheTokens: 800,
+      totalTokens: 3_200
+    })
+  })
+
+  it('pads recent usage days with zero-token cells', () => {
+    const recent = getRecentUsageDays(
+      [
+        {
+          day: '2026-05-14',
+          totalTokens: 4_500,
+          claudeTokens: 2_500,
+          codexTokens: 2_000,
+          intensity: 4
+        }
+      ],
+      3,
+      new Date('2026-05-15T12:00:00')
+    )
+
+    expect(recent).toEqual([
+      {
+        day: '2026-05-13',
+        totalTokens: 0,
+        claudeTokens: 0,
+        codexTokens: 0,
+        intensity: 0
+      },
+      {
+        day: '2026-05-14',
+        totalTokens: 4_500,
+        claudeTokens: 2_500,
+        codexTokens: 2_000,
+        intensity: 4
+      },
+      {
+        day: '2026-05-15',
+        totalTokens: 0,
+        claudeTokens: 0,
+        codexTokens: 0,
+        intensity: 0
+      }
+    ])
+  })
+
+  it('reports disabled providers as an empty overview', () => {
+    const overview = buildUsageOverview({
+      claude: { scanState: null, summary: null, daily: [] },
+      codex: { scanState: null, summary: null, daily: [] }
+    })
+
+    expect(overview.hasAnyEnabledProvider).toBe(false)
+    expect(overview.hasAnyData).toBe(false)
+    expect(overview.totalTokens).toBe(0)
+    expect(overview.estimatedCostUsd).toBeNull()
+    expect(overview.cacheShare).toBeNull()
+  })
+
+  it('formats token and cost values for compact UI labels', () => {
+    expect(formatUsageTokens(999)).toBe('999')
+    expect(formatUsageTokens(1_200)).toBe('1.2k')
+    expect(formatUsageTokens(2_500_000)).toBe('2.5M')
+    expect(formatUsageCost(null)).toBe('n/a')
+    expect(formatUsageCost(0.0042)).toBe('$0.0042')
+    expect(formatUsageCost(1.234)).toBe('$1.23')
+  })
+})

--- a/src/renderer/src/components/stats/usage-overview-model.ts
+++ b/src/renderer/src/components/stats/usage-overview-model.ts
@@ -1,0 +1,319 @@
+import type {
+  ClaudeUsageDailyPoint,
+  ClaudeUsageScanState,
+  ClaudeUsageSummary
+} from '../../../../shared/claude-usage-types'
+import type {
+  CodexUsageDailyPoint,
+  CodexUsageScanState,
+  CodexUsageSummary
+} from '../../../../shared/codex-usage-types'
+
+export type UsageProviderId = 'claude' | 'codex'
+
+export type UsageProviderOverview = {
+  id: UsageProviderId
+  label: string
+  enabled: boolean
+  isScanning: boolean
+  hasData: boolean
+  lastScanCompletedAt: number | null
+  lastScanError: string | null
+  sessions: number
+  activityLabel: 'turns' | 'events'
+  activityCount: number
+  totalTokens: number
+  newInputTokens: number
+  outputTokens: number
+  cacheTokens: number
+  reasoningTokens: number
+  estimatedCostUsd: number | null
+  topModel: string | null
+  topProject: string | null
+  activeDays: number
+}
+
+export type UsageOverviewDailyPoint = {
+  day: string
+  totalTokens: number
+  claudeTokens: number
+  codexTokens: number
+  intensity: 0 | 1 | 2 | 3 | 4
+}
+
+export type UsageOverviewModel = {
+  providers: UsageProviderOverview[]
+  enabledProviderCount: number
+  dataProviderCount: number
+  hasAnyEnabledProvider: boolean
+  hasAnyData: boolean
+  totalTokens: number
+  newInputTokens: number
+  outputTokens: number
+  cacheTokens: number
+  reasoningTokens: number
+  sessions: number
+  activityCount: number
+  activeDays: number
+  estimatedCostUsd: number | null
+  hasPartialCost: boolean
+  cacheShare: number | null
+  daily: UsageOverviewDailyPoint[]
+  bestDay: UsageOverviewDailyPoint | null
+  lastUpdatedAt: number | null
+}
+
+export type UsageOverviewInput = {
+  claude: {
+    scanState: ClaudeUsageScanState | null
+    summary: ClaudeUsageSummary | null
+    daily: ClaudeUsageDailyPoint[]
+  }
+  codex: {
+    scanState: CodexUsageScanState | null
+    summary: CodexUsageSummary | null
+    daily: CodexUsageDailyPoint[]
+  }
+}
+
+function getClaudeDailyTotal(entry: ClaudeUsageDailyPoint): number {
+  return entry.inputTokens + entry.outputTokens + entry.cacheReadTokens + entry.cacheWriteTokens
+}
+
+function getCodexNewInputTokens(summary: CodexUsageSummary | null): number {
+  if (!summary) {
+    return 0
+  }
+  return Math.max(summary.inputTokens - summary.cachedInputTokens, 0)
+}
+
+function getIntensity(totalTokens: number, maxTokens: number): 0 | 1 | 2 | 3 | 4 {
+  if (totalTokens <= 0 || maxTokens <= 0) {
+    return 0
+  }
+  const ratio = totalTokens / maxTokens
+  if (ratio <= 0.25) {
+    return 1
+  }
+  if (ratio <= 0.5) {
+    return 2
+  }
+  if (ratio <= 0.75) {
+    return 3
+  }
+  return 4
+}
+
+function countActiveDays(days: string[]): number {
+  return new Set(days).size
+}
+
+function createClaudeProvider(input: UsageOverviewInput['claude']): UsageProviderOverview {
+  const summary = input.summary
+  const dailyActiveDays = input.daily
+    .filter((entry) => getClaudeDailyTotal(entry) > 0)
+    .map((entry) => entry.day)
+  return {
+    id: 'claude',
+    label: 'Claude',
+    enabled: input.scanState?.enabled ?? false,
+    isScanning: input.scanState?.isScanning ?? false,
+    hasData: summary?.hasAnyClaudeData ?? input.scanState?.hasAnyClaudeData ?? false,
+    lastScanCompletedAt: input.scanState?.lastScanCompletedAt ?? null,
+    lastScanError: input.scanState?.lastScanError ?? null,
+    sessions: summary?.sessions ?? 0,
+    activityLabel: 'turns',
+    activityCount: summary?.turns ?? 0,
+    totalTokens: summary
+      ? summary.inputTokens +
+        summary.outputTokens +
+        summary.cacheReadTokens +
+        summary.cacheWriteTokens
+      : 0,
+    newInputTokens: summary?.inputTokens ?? 0,
+    outputTokens: summary?.outputTokens ?? 0,
+    cacheTokens: summary ? summary.cacheReadTokens + summary.cacheWriteTokens : 0,
+    reasoningTokens: 0,
+    estimatedCostUsd: summary?.estimatedCostUsd ?? null,
+    topModel: summary?.topModel ?? null,
+    topProject: summary?.topProject ?? null,
+    activeDays: countActiveDays(dailyActiveDays)
+  }
+}
+
+function createCodexProvider(input: UsageOverviewInput['codex']): UsageProviderOverview {
+  const summary = input.summary
+  const dailyActiveDays = input.daily
+    .filter((entry) => entry.totalTokens > 0)
+    .map((entry) => entry.day)
+  return {
+    id: 'codex',
+    label: 'Codex',
+    enabled: input.scanState?.enabled ?? false,
+    isScanning: input.scanState?.isScanning ?? false,
+    hasData: summary?.hasAnyCodexData ?? input.scanState?.hasAnyCodexData ?? false,
+    lastScanCompletedAt: input.scanState?.lastScanCompletedAt ?? null,
+    lastScanError: input.scanState?.lastScanError ?? null,
+    sessions: summary?.sessions ?? 0,
+    activityLabel: 'events',
+    activityCount: summary?.events ?? 0,
+    totalTokens: summary?.totalTokens ?? 0,
+    newInputTokens: getCodexNewInputTokens(summary),
+    outputTokens: summary?.outputTokens ?? 0,
+    cacheTokens: summary?.cachedInputTokens ?? 0,
+    reasoningTokens: summary?.reasoningOutputTokens ?? 0,
+    estimatedCostUsd: summary?.estimatedCostUsd ?? null,
+    topModel: summary?.topModel ?? null,
+    topProject: summary?.topProject ?? null,
+    activeDays: countActiveDays(dailyActiveDays)
+  }
+}
+
+function buildDailyOverview(input: UsageOverviewInput): UsageOverviewDailyPoint[] {
+  const byDay = new Map<string, Omit<UsageOverviewDailyPoint, 'intensity'>>()
+
+  for (const entry of input.claude.daily) {
+    const current = byDay.get(entry.day) ?? {
+      day: entry.day,
+      totalTokens: 0,
+      claudeTokens: 0,
+      codexTokens: 0
+    }
+    const total = getClaudeDailyTotal(entry)
+    current.totalTokens += total
+    current.claudeTokens += total
+    byDay.set(entry.day, current)
+  }
+
+  for (const entry of input.codex.daily) {
+    const current = byDay.get(entry.day) ?? {
+      day: entry.day,
+      totalTokens: 0,
+      claudeTokens: 0,
+      codexTokens: 0
+    }
+    current.totalTokens += entry.totalTokens
+    current.codexTokens += entry.totalTokens
+    byDay.set(entry.day, current)
+  }
+
+  const maxTokens = Math.max(0, ...[...byDay.values()].map((entry) => entry.totalTokens))
+  return [...byDay.values()]
+    .sort((left, right) => left.day.localeCompare(right.day))
+    .map((entry) => ({
+      ...entry,
+      intensity: getIntensity(entry.totalTokens, maxTokens)
+    }))
+}
+
+function formatLocalDay(date: Date): string {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+export function getRecentUsageDays(
+  daily: UsageOverviewDailyPoint[],
+  dayCount: number,
+  anchorDate = new Date()
+): UsageOverviewDailyPoint[] {
+  const byDay = new Map(daily.map((entry) => [entry.day, entry]))
+  const count = Math.max(1, Math.floor(dayCount))
+  const end = new Date(anchorDate)
+  end.setHours(0, 0, 0, 0)
+
+  const result: UsageOverviewDailyPoint[] = []
+  for (let offset = count - 1; offset >= 0; offset--) {
+    const date = new Date(end)
+    date.setDate(end.getDate() - offset)
+    const day = formatLocalDay(date)
+    result.push(
+      byDay.get(day) ?? {
+        day,
+        totalTokens: 0,
+        claudeTokens: 0,
+        codexTokens: 0,
+        intensity: 0
+      }
+    )
+  }
+  return result
+}
+
+export function buildUsageOverview(input: UsageOverviewInput): UsageOverviewModel {
+  const providers = [createClaudeProvider(input.claude), createCodexProvider(input.codex)]
+  const daily = buildDailyOverview(input)
+  const bestDay =
+    daily.length === 0
+      ? null
+      : daily.reduce<UsageOverviewDailyPoint | null>(
+          (best, entry) => (!best || entry.totalTokens > best.totalTokens ? entry : best),
+          null
+        )
+  const totalTokens = providers.reduce((sum, provider) => sum + provider.totalTokens, 0)
+  const newInputTokens = providers.reduce((sum, provider) => sum + provider.newInputTokens, 0)
+  const outputTokens = providers.reduce((sum, provider) => sum + provider.outputTokens, 0)
+  const cacheTokens = providers.reduce((sum, provider) => sum + provider.cacheTokens, 0)
+  const reasoningTokens = providers.reduce((sum, provider) => sum + provider.reasoningTokens, 0)
+  const sessions = providers.reduce((sum, provider) => sum + provider.sessions, 0)
+  const activityCount = providers.reduce((sum, provider) => sum + provider.activityCount, 0)
+  const knownCost = providers.reduce((sum, provider) => sum + (provider.estimatedCostUsd ?? 0), 0)
+  const hasKnownCost = providers.some((provider) => provider.estimatedCostUsd !== null)
+  const hasPartialCost = providers.some(
+    (provider) => provider.hasData && provider.estimatedCostUsd === null
+  )
+  const lastUpdatedAt =
+    providers.reduce<number | null>(
+      (latest, provider) =>
+        provider.lastScanCompletedAt && (!latest || provider.lastScanCompletedAt > latest)
+          ? provider.lastScanCompletedAt
+          : latest,
+      null
+    ) ?? null
+
+  return {
+    providers,
+    enabledProviderCount: providers.filter((provider) => provider.enabled).length,
+    dataProviderCount: providers.filter((provider) => provider.hasData).length,
+    hasAnyEnabledProvider: providers.some((provider) => provider.enabled),
+    hasAnyData: providers.some((provider) => provider.hasData),
+    totalTokens,
+    newInputTokens,
+    outputTokens,
+    cacheTokens,
+    reasoningTokens,
+    sessions,
+    activityCount,
+    activeDays: countActiveDays(
+      daily.filter((entry) => entry.totalTokens > 0).map((entry) => entry.day)
+    ),
+    estimatedCostUsd: hasKnownCost ? knownCost : null,
+    hasPartialCost,
+    cacheShare:
+      newInputTokens + cacheTokens > 0 ? cacheTokens / (newInputTokens + cacheTokens) : null,
+    daily,
+    bestDay,
+    lastUpdatedAt
+  }
+}
+
+export function formatUsageTokens(value: number): string {
+  if (value >= 1_000_000_000) {
+    return `${(value / 1_000_000_000).toFixed(1)}B`
+  }
+  if (value >= 1_000_000) {
+    return `${(value / 1_000_000).toFixed(1)}M`
+  }
+  if (value >= 1_000) {
+    return `${(value / 1_000).toFixed(1)}k`
+  }
+  return value.toLocaleString()
+}
+
+export function formatUsageCost(value: number | null): string {
+  if (value === null) {
+    return 'n/a'
+  }
+  return value < 0.01 ? `$${value.toFixed(4)}` : `$${value.toFixed(2)}`
+}

--- a/tests/e2e/usage-overview.spec.ts
+++ b/tests/e2e/usage-overview.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from './helpers/orca-app'
+import { getStoreState, waitForSessionReady } from './helpers/store'
+
+test.describe('usage overview', () => {
+  test.beforeEach(async ({ orcaPage }) => {
+    await waitForSessionReady(orcaPage)
+  })
+
+  test('Stats & Usage opens on the combined overview with provider controls', async ({
+    orcaPage
+  }) => {
+    await orcaPage.evaluate(() => {
+      const state = window.__store!.getState()
+      state.openSettingsTarget({ pane: 'stats' })
+      state.openSettingsPage()
+    })
+
+    await expect
+      .poll(async () => getStoreState<string>(orcaPage, 'activeView'), { timeout: 5_000 })
+      .toBe('settings')
+    await expect(orcaPage.getByRole('heading', { name: 'Usage Analytics' })).toBeVisible()
+    const providerTabs = orcaPage.getByRole('group', { name: 'Usage analytics provider' })
+    await expect(
+      providerTabs.getByRole('button', { name: 'Overview', exact: true })
+    ).toHaveAttribute('aria-pressed', 'true')
+    await expect(orcaPage.getByTestId('usage-overview-pane')).toBeVisible()
+    await expect(orcaPage.getByRole('heading', { name: 'Usage Overview' })).toBeVisible()
+    await expect(orcaPage.getByRole('heading', { name: 'Providers' })).toBeVisible()
+    await expect(orcaPage.getByRole('button', { name: 'Enable Claude' })).toBeVisible()
+    await expect(orcaPage.getByRole('button', { name: 'Enable Codex' })).toBeVisible()
+
+    await providerTabs.getByRole('button', { name: 'Codex', exact: true }).click()
+    await expect(orcaPage.getByRole('heading', { name: 'Codex Usage Tracking' })).toBeVisible()
+  })
+})


### PR DESCRIPTION
## Summary
- add a combined Usage Overview tab for Claude and Codex token analytics
- improve Claude and Codex log parsing, pricing normalization, and worktree attribution
- cache unchanged Claude usage files and repeated cwd attribution so repeat refreshes avoid reparsing and recanonicalizing old JSONL history

## Tests
- pnpm exec vitest run --config config/vitest.config.ts src/main/codex-usage/scanner.test.ts src/main/codex-usage/store.test.ts src/main/claude-usage/scanner.test.ts src/main/claude-usage/scanner-scan.test.ts src/main/claude-usage/store.test.ts src/renderer/src/components/stats/usage-overview-model.test.ts
- pnpm exec oxlint src/main/codex-usage/scanner.ts src/main/codex-usage/store.ts src/main/codex-usage/scanner.test.ts src/main/codex-usage/store.test.ts src/main/claude-usage/scanner.ts src/main/claude-usage/store.ts src/main/claude-usage/types.ts src/main/claude-usage/scanner.test.ts src/main/claude-usage/scanner-scan.test.ts src/main/claude-usage/store.test.ts src/renderer/src/components/settings/Settings.tsx src/renderer/src/components/stats/StatsPane.tsx src/renderer/src/components/stats/UsageOverviewPane.tsx src/renderer/src/components/stats/usage-overview-model.ts src/renderer/src/components/stats/usage-overview-model.test.ts tests/e2e/usage-overview.spec.ts
- pnpm run tc:node
- pnpm run tc:web
- npx stably test tests/e2e/usage-overview.spec.ts --config=tests/playwright.config.ts --project=electron-headless
- git diff --check