### PR TITLE
Fix restored working agent status

### DIFF
--- a/src/renderer/src/components/sidebar/use-worktree-activity-status.test.tsx
+++ b/src/renderer/src/components/sidebar/use-worktree-activity-status.test.tsx
@@ -1,0 +1,91 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
+import type { TerminalTab } from '../../../../shared/types'
+import { useWorktreeActivityStatus } from './use-worktree-activity-status'
+
+type MockState = {
+  tabsByWorktree: Record<string, TerminalTab[]>
+  browserTabsByWorktree: Record<string, { id: string }[]>
+  runtimePaneTitlesByTabId: Record<string, Record<number, string>>
+  ptyIdsByTabId: Record<string, string[]>
+  agentStatusEpoch: number
+  agentStatusByPaneKey: Record<string, AgentStatusEntry>
+  retainedAgentsByPaneKey: Record<string, unknown>
+}
+
+let mockState: MockState
+
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: MockState) => unknown) => selector(mockState)
+}))
+
+function makeTab(id: string, worktreeId: string): TerminalTab {
+  return {
+    id,
+    worktreeId,
+    ptyId: 'pty-1',
+    title: 'bash',
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 0
+  }
+}
+
+function makeAgentStatusEntry(args: {
+  paneKey: string
+  state: AgentStatusEntry['state']
+}): AgentStatusEntry {
+  return {
+    paneKey: args.paneKey,
+    state: args.state,
+    prompt: '',
+    updatedAt: 1_000,
+    stateStartedAt: 1_000,
+    stateHistory: []
+  }
+}
+
+function StatusProbe({ worktreeId }: { worktreeId: string }) {
+  return <span>{useWorktreeActivityStatus(worktreeId)}</span>
+}
+
+describe('useWorktreeActivityStatus', () => {
+  beforeEach(() => {
+    vi.spyOn(Date, 'now').mockReturnValue(2_000)
+    mockState = {
+      tabsByWorktree: {},
+      browserTabsByWorktree: {},
+      runtimePaneTitlesByTabId: {},
+      ptyIdsByTabId: {},
+      agentStatusEpoch: 0,
+      agentStatusByPaneKey: {},
+      retainedAgentsByPaneKey: {}
+    }
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('keeps a restored offscreen working agent yellow from the hook snapshot', () => {
+    const worktreeId = 'repo1::/path/wt1'
+    mockState = {
+      ...mockState,
+      tabsByWorktree: {
+        [worktreeId]: [makeTab('tab-1', worktreeId)]
+      },
+      ptyIdsByTabId: {
+        'tab-1': ['pty-1']
+      },
+      agentStatusByPaneKey: {
+        'tab-1:1': makeAgentStatusEntry({ paneKey: 'tab-1:1', state: 'working' })
+      }
+    }
+
+    expect(renderToStaticMarkup(<StatusProbe worktreeId={worktreeId} />)).toBe(
+      '<span>working</span>'
+    )
+  })
+})

--- a/src/renderer/src/components/sidebar/use-worktree-activity-status.ts
+++ b/src/renderer/src/components/sidebar/use-worktree-activity-status.ts
@@ -19,14 +19,15 @@ export function useWorktreeActivityStatus(worktreeId: string): WorktreeStatus {
   const ptyIdsForWorktree = useAppStore(
     useShallow((s) => selectLivePtyIdsForWorktree(s, worktreeId))
   )
-  const { hasPermission, hasLiveDone, hasRetainedDone } = useAppStore(
+  const { hasPermission, hasLiveWorking, hasLiveDone, hasRetainedDone } = useAppStore(
     useShallow((s) => {
       // Touch the epoch so this selector re-runs when a fresh hook entry
       // crosses the stale boundary.
       void s.agentStatusEpoch
       const wtTabs = s.tabsByWorktree[worktreeId] ?? EMPTY_TABS
       let perm = false
-      let live = false
+      let working = false
+      let done = false
       if (wtTabs.length > 0) {
         const tabIds = new Set(wtTabs.map((tab) => tab.id))
         const now = Date.now()
@@ -44,8 +45,10 @@ export function useWorktreeActivityStatus(worktreeId: string): WorktreeStatus {
           }
           if (entry.state === 'blocked' || entry.state === 'waiting') {
             perm = true
+          } else if (entry.state === 'working') {
+            working = true
           } else if (entry.state === 'done') {
-            live = true
+            done = true
           }
         }
       }
@@ -57,13 +60,18 @@ export function useWorktreeActivityStatus(worktreeId: string): WorktreeStatus {
           break
         }
       }
-      return { hasPermission: perm, hasLiveDone: live, hasRetainedDone: retained }
+      return {
+        hasPermission: perm,
+        hasLiveWorking: working,
+        hasLiveDone: done,
+        hasRetainedDone: retained
+      }
     })
   )
 
   // Why: compact and detailed cards need the same status-dot semantics:
   // runtime liveness gates title-derived states, then explicit agent rows can
-  // promote permission/done so the dot matches visible agent state.
+  // promote working/permission/done so the dot matches visible agent state.
   return useMemo(
     () =>
       resolveWorktreeStatus({
@@ -72,6 +80,7 @@ export function useWorktreeActivityStatus(worktreeId: string): WorktreeStatus {
         ptyIdsByTabId: ptyIdsForWorktree,
         runtimePaneTitlesByTabId: runtimePaneTitlesForWorktree,
         hasPermission,
+        hasLiveWorking,
         hasLiveDone,
         hasRetainedDone
       }),
@@ -81,6 +90,7 @@ export function useWorktreeActivityStatus(worktreeId: string): WorktreeStatus {
       ptyIdsForWorktree,
       runtimePaneTitlesForWorktree,
       hasPermission,
+      hasLiveWorking,
       hasLiveDone,
       hasRetainedDone
     ]

--- a/src/renderer/src/lib/worktree-status.test.ts
+++ b/src/renderer/src/lib/worktree-status.test.ts
@@ -86,6 +86,7 @@ describe('resolveWorktreeStatus', () => {
       // Slept: live-pty array empty; tab.ptyId would be the wake-hint sessionId.
       ptyIdsByTabId: { 'tab-1': [] },
       hasPermission: false,
+      hasLiveWorking: false,
       hasLiveDone: false,
       hasRetainedDone: false
     })
@@ -99,6 +100,7 @@ describe('resolveWorktreeStatus', () => {
       browserTabs: [],
       ptyIdsByTabId: { 'tab-1': [] },
       hasPermission: false,
+      hasLiveWorking: false,
       hasLiveDone: false,
       hasRetainedDone: true
     })
@@ -112,6 +114,7 @@ describe('resolveWorktreeStatus', () => {
       browserTabs: [],
       ptyIdsByTabId: { 'tab-1': [] },
       hasPermission: true,
+      hasLiveWorking: false,
       hasLiveDone: false,
       hasRetainedDone: false
     })
@@ -125,11 +128,26 @@ describe('resolveWorktreeStatus', () => {
       browserTabs: [],
       ptyIdsByTabId: livePtyMap('tab-1'),
       hasPermission: true,
+      hasLiveWorking: false,
       hasLiveDone: false,
       hasRetainedDone: false
     })
 
     expect(status).toBe('permission')
+  })
+
+  it('promotes to working from a fresh explicit agent row before pane titles restore', () => {
+    const status = resolveWorktreeStatus({
+      tabs: [{ id: 'tab-1', title: 'bash' }],
+      browserTabs: [],
+      ptyIdsByTabId: livePtyMap('tab-1'),
+      hasPermission: false,
+      hasLiveWorking: true,
+      hasLiveDone: false,
+      hasRetainedDone: false
+    })
+
+    expect(status).toBe('working')
   })
 
   it('lets heuristic working beat hasLiveDone (newer in-progress signal wins)', () => {
@@ -138,6 +156,7 @@ describe('resolveWorktreeStatus', () => {
       browserTabs: [],
       ptyIdsByTabId: livePtyMap('tab-1'),
       hasPermission: false,
+      hasLiveWorking: false,
       hasLiveDone: true,
       hasRetainedDone: false
     })
@@ -156,6 +175,7 @@ describe('resolveWorktreeStatus', () => {
       browserTabs: [],
       ptyIdsByTabId: livePtyMap('tab-1'),
       hasPermission: false,
+      hasLiveWorking: false,
       hasLiveDone: true,
       hasRetainedDone: false
     })
@@ -169,6 +189,7 @@ describe('resolveWorktreeStatus', () => {
       browserTabs: [],
       ptyIdsByTabId: livePtyMap('tab-1'),
       hasPermission: false,
+      hasLiveWorking: false,
       hasLiveDone: false,
       hasRetainedDone: true
     })
@@ -182,6 +203,7 @@ describe('resolveWorktreeStatus', () => {
       browserTabs: [],
       ptyIdsByTabId: livePtyMap('tab-1'),
       hasPermission: false,
+      hasLiveWorking: false,
       hasLiveDone: false,
       hasRetainedDone: false
     })

--- a/src/renderer/src/lib/worktree-status.ts
+++ b/src/renderer/src/lib/worktree-status.ts
@@ -78,9 +78,10 @@ export function getWorktreeStatusLabel(status: WorktreeStatus): string {
  * Apply the WorktreeCard priority overlay (permission > working > done >
  * heuristic) on top of the title-heuristic base. Live PTY liveness still gates
  * title-derived working/permission, but explicit agent rows are allowed to
- * promote the dot: if the sidebar shows a completed/blocking inline agent row,
- * the worktree status must agree with that visible row. Sleep cleanup owns
- * removing stale retained rows; once they are gone, no promotion occurs.
+ * promote the dot: if the sidebar shows a running/completed/blocking inline
+ * agent row, the worktree status must agree with that visible row. Sleep
+ * cleanup owns removing stale retained rows; once they are gone, no promotion
+ * occurs.
  *
  * Argument semantics (sourced by the WorktreeCard caller from the store):
  * - `tabs`, `browserTabs`: the worktree's terminal and browser tabs.
@@ -90,6 +91,8 @@ export function getWorktreeStatusLabel(status: WorktreeStatus): string {
  *   worktree (used by the title-heuristic for split-pane spinners).
  * - `hasPermission`: any fresh hook entry in {blocked, waiting} for a tab in
  *   this worktree.
+ * - `hasLiveWorking`: any fresh hook entry in {working} for a tab in this
+ *   worktree.
  * - `hasLiveDone`: any fresh hook entry in {done} for a tab in this worktree.
  * - `hasRetainedDone`: any retained-agent snapshot scoped to this worktreeId.
  */
@@ -99,6 +102,7 @@ export function resolveWorktreeStatus(args: {
   ptyIdsByTabId: Record<string, string[]>
   runtimePaneTitlesByTabId?: Record<string, Record<number, string>>
   hasPermission: boolean
+  hasLiveWorking: boolean
   hasLiveDone: boolean
   hasRetainedDone: boolean
 }): WorktreeStatus {
@@ -119,7 +123,10 @@ export function resolveWorktreeStatus(args: {
   if (heuristic === 'permission') {
     return 'permission'
   }
-  if (heuristic === 'working') {
+  // Why: restored-but-unfocused cards may have the startup hook snapshot before
+  // their terminal pane mounts and repopulates runtimePaneTitlesByTabId.
+  // Trust the fresh explicit working row so those cards stay yellow on restart.
+  if (args.hasLiveWorking || heuristic === 'working') {
     return 'working'
   }
   if (args.hasLiveDone || args.hasRetainedDone) {


### PR DESCRIPTION
## Summary
- keep restored/unfocused worktree cards yellow when a fresh hook status says an agent is working
- thread explicit working status into the WorktreeCard status resolver
- add regression coverage for the offscreen restart state

## Verification
- pnpm vitest run --config config/vitest.config.ts src/renderer/src/lib/worktree-status.test.ts src/renderer/src/components/sidebar/use-worktree-activity-status.test.tsx src/renderer/src/store/slices/store-session-cascades.test.ts
- pnpm tsgo --noEmit -p config/tsconfig.tc.web.json
- pnpm oxlint src/renderer/src/lib/worktree-status.ts src/renderer/src/lib/worktree-status.test.ts src/renderer/src/components/sidebar/use-worktree-activity-status.ts src/renderer/src/components/sidebar/use-worktree-activity-status.test.tsx