### PR TITLE
feat(automations): manage external automation jobs

### DIFF
--- a/src/main/automations/external-job-mappers.ts
+++ b/src/main/automations/external-job-mappers.ts
@@ -1,0 +1,164 @@
+import type { ExternalAutomationJob } from '../../shared/automations-types'
+
+type ExternalJobRecord = Record<string, unknown>
+
+function asString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value : null
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function asNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
+}
+
+function formatDurationMs(value: unknown): string {
+  const ms = asNumber(value)
+  if (!ms) {
+    return '?'
+  }
+  if (ms % 86_400_000 === 0) {
+    return `${ms / 86_400_000}d`
+  }
+  if (ms % 3_600_000 === 0) {
+    return `${ms / 3_600_000}h`
+  }
+  if (ms % 60_000 === 0) {
+    return `${ms / 60_000}m`
+  }
+  if (ms % 1000 === 0) {
+    return `${ms / 1000}s`
+  }
+  return `${ms}ms`
+}
+
+function isoFromMs(value: unknown): string | null {
+  const ms = asNumber(value)
+  if (!ms) {
+    return null
+  }
+  const date = new Date(ms)
+  return Number.isNaN(date.getTime()) ? null : date.toISOString()
+}
+
+function hermesScheduleDisplay(job: ExternalJobRecord): string {
+  const direct = asString(job.schedule_display)
+  if (direct) {
+    return direct
+  }
+  const schedule = job.schedule
+  if (isRecord(schedule)) {
+    return (
+      asString(schedule.display) ??
+      asString(schedule.value) ??
+      asString(schedule.expr) ??
+      asString(schedule.run_at) ??
+      '?'
+    )
+  }
+  return asString(schedule) ?? '?'
+}
+
+function hermesPromptPreview(job: ExternalJobRecord): string {
+  const prompt = asString(job.prompt) ?? ''
+  if (prompt) {
+    return prompt.length > 120 ? `${prompt.slice(0, 117)}...` : prompt
+  }
+  const script = asString(job.script)
+  if (script) {
+    return job.no_agent ? `Script: ${script}` : `Prompt uses script context: ${script}`
+  }
+  const skills = Array.isArray(job.skills) ? job.skills.map((skill) => String(skill)) : []
+  return skills.length > 0 ? `Skills: ${skills.join(', ')}` : ''
+}
+
+function openClawScheduleDisplay(job: ExternalJobRecord): string {
+  const schedule = job.schedule
+  if (!isRecord(schedule)) {
+    return asString(schedule) ?? '?'
+  }
+  const kind = asString(schedule.kind)
+  if (kind === 'at') {
+    return `at ${asString(schedule.at) ?? '?'}`
+  }
+  if (kind === 'every') {
+    return `every ${formatDurationMs(schedule.everyMs)}`
+  }
+  if (kind === 'cron') {
+    const expr = asString(schedule.expr) ?? asString(schedule.cron) ?? '?'
+    const tz = asString(schedule.tz)
+    return tz ? `cron ${expr} @ ${tz}` : `cron ${expr}`
+  }
+  return kind ?? '?'
+}
+
+function openClawPromptPreview(job: ExternalJobRecord): string {
+  const payload = job.payload
+  if (!isRecord(payload)) {
+    return ''
+  }
+  const text = asString(payload.message) ?? asString(payload.text) ?? ''
+  return text.length > 120 ? `${text.slice(0, 117)}...` : text
+}
+
+export function mapHermesJobs(managerId: string, rawJobs: unknown): ExternalAutomationJob[] {
+  if (!Array.isArray(rawJobs)) {
+    return []
+  }
+  return rawJobs.filter(isRecord).map((job) => {
+    const id = asString(job.id) ?? 'unknown'
+    const enabled = job.enabled !== false && job.state !== 'paused'
+    const preview = hermesPromptPreview(job)
+    return {
+      id,
+      managerId,
+      provider: 'hermes',
+      name: (asString(job.name) ?? preview) || id,
+      schedule: hermesScheduleDisplay(job),
+      enabled,
+      state: asString(job.state) ?? (enabled ? 'scheduled' : 'paused'),
+      promptPreview: preview,
+      nextRunAt: asString(job.next_run_at),
+      lastRunAt: asString(job.last_run_at),
+      lastStatus: asString(job.last_status),
+      lastError: asString(job.last_error) ?? asString(job.last_delivery_error),
+      workdir: asString(job.workdir)
+    }
+  })
+}
+
+export function mapOpenClawJobs(managerId: string, rawJobs: unknown): ExternalAutomationJob[] {
+  const jobs = Array.isArray(rawJobs)
+    ? rawJobs
+    : isRecord(rawJobs) && Array.isArray(rawJobs.jobs)
+      ? rawJobs.jobs
+      : []
+  return jobs.filter(isRecord).map((job) => {
+    const id = asString(job.id) ?? 'unknown'
+    const enabled = job.enabled !== false
+    const state = isRecord(job.state) ? job.state : {}
+    const preview = openClawPromptPreview(job)
+    const lastStatus = asString(state.lastRunStatus) ?? asString(state.lastStatus)
+    return {
+      id,
+      managerId,
+      provider: 'openclaw',
+      name: (asString(job.name) ?? preview) || id,
+      schedule: openClawScheduleDisplay(job),
+      enabled,
+      state: !enabled
+        ? 'disabled'
+        : asNumber(state.runningAtMs)
+          ? 'running'
+          : (lastStatus ?? 'idle'),
+      promptPreview: preview,
+      nextRunAt: isoFromMs(state.nextRunAtMs),
+      lastRunAt: isoFromMs(state.lastRunAtMs),
+      lastStatus,
+      lastError: asString(state.lastError) ?? asString(state.lastDeliveryError),
+      workdir: null
+    }
+  })
+}

--- a/src/main/automations/external-manager.test.ts
+++ b/src/main/automations/external-manager.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { runExternalAutomationAction } from './external-manager'
+import { mapHermesJobs, mapOpenClawJobs } from './external-job-mappers'
+
+const execFileMock = vi.hoisted(() =>
+  vi.fn((...args: unknown[]) => {
+    const callback = args.at(-1)
+    if (typeof callback === 'function') {
+      const execCallback = callback as (error: Error | null, stdout: string, stderr: string) => void
+      execCallback(null, '', '')
+    }
+  })
+)
+
+vi.mock('child_process', () => ({ execFile: execFileMock }))
+
+vi.mock('../ipc/ssh', () => ({
+  getActiveMultiplexer: vi.fn()
+}))
+
+beforeEach(() => {
+  execFileMock.mockClear()
+})
+
+describe('mapHermesJobs', () => {
+  it('normalizes Hermes cron jobs into external automation rows', () => {
+    const jobs = mapHermesJobs('hermes:local', [
+      {
+        id: 'job-1',
+        name: 'Nightly audit',
+        prompt: 'Audit the repo for risky dependency changes',
+        schedule_display: '0 9 * * 1-5',
+        enabled: true,
+        state: 'scheduled',
+        next_run_at: '2026-05-16T09:00:00Z',
+        last_run_at: '2026-05-15T09:00:00Z',
+        last_status: 'ok',
+        workdir: '/repo'
+      }
+    ])
+
+    expect(jobs).toEqual([
+      {
+        id: 'job-1',
+        managerId: 'hermes:local',
+        provider: 'hermes',
+        name: 'Nightly audit',
+        schedule: '0 9 * * 1-5',
+        enabled: true,
+        state: 'scheduled',
+        promptPreview: 'Audit the repo for risky dependency changes',
+        nextRunAt: '2026-05-16T09:00:00Z',
+        lastRunAt: '2026-05-15T09:00:00Z',
+        lastStatus: 'ok',
+        lastError: null,
+        workdir: '/repo'
+      }
+    ])
+  })
+
+  it('falls back to script and schedule fields for older Hermes records', () => {
+    const jobs = mapHermesJobs('hermes:local', [
+      {
+        id: 'job-2',
+        script: 'disk-check.sh',
+        no_agent: true,
+        schedule: { display: 'every 30m' },
+        enabled: false,
+        state: 'paused',
+        last_delivery_error: 'home channel missing'
+      }
+    ])
+
+    expect(jobs[0]).toMatchObject({
+      id: 'job-2',
+      name: 'Script: disk-check.sh',
+      schedule: 'every 30m',
+      enabled: false,
+      state: 'paused',
+      promptPreview: 'Script: disk-check.sh',
+      lastError: 'home channel missing'
+    })
+  })
+})
+
+describe('runExternalAutomationAction', () => {
+  it('runs local Hermes lifecycle actions through the CLI', async () => {
+    await runExternalAutomationAction({
+      managerId: 'hermes:local',
+      provider: 'hermes',
+      target: { type: 'local' },
+      jobId: 'job-1',
+      action: 'run'
+    })
+
+    expect(execFileMock).toHaveBeenCalledWith(
+      'hermes',
+      ['cron', 'run', 'job-1'],
+      { encoding: 'utf-8' },
+      expect.any(Function)
+    )
+  })
+
+  it('rejects job IDs that could be parsed as CLI options', async () => {
+    await expect(
+      runExternalAutomationAction({
+        managerId: 'hermes:local',
+        provider: 'hermes',
+        target: { type: 'local' },
+        jobId: '-help',
+        action: 'run'
+      })
+    ).rejects.toThrow('Invalid external automation job ID.')
+
+    expect(execFileMock).not.toHaveBeenCalled()
+  })
+
+  it('maps OpenClaw lifecycle actions through its cron CLI names', async () => {
+    await runExternalAutomationAction({
+      managerId: 'openclaw:local',
+      provider: 'openclaw',
+      target: { type: 'local' },
+      jobId: 'job-1',
+      action: 'pause'
+    })
+
+    expect(execFileMock).toHaveBeenCalledWith(
+      'openclaw',
+      ['cron', 'disable', 'job-1'],
+      { encoding: 'utf-8' },
+      expect.any(Function)
+    )
+  })
+})
+
+describe('mapOpenClawJobs', () => {
+  it('normalizes OpenClaw cron jobs into external automation rows', () => {
+    const jobs = mapOpenClawJobs('openclaw:local', {
+      version: 1,
+      jobs: [
+        {
+          id: 'claw-1',
+          name: 'Morning report',
+          enabled: true,
+          schedule: { kind: 'cron', expr: '0 9 * * *', tz: 'America/Phoenix' },
+          payload: { kind: 'agentTurn', message: 'Summarize overnight alerts' },
+          state: {
+            nextRunAtMs: Date.parse('2026-05-16T16:00:00Z'),
+            lastRunAtMs: Date.parse('2026-05-15T16:00:00Z'),
+            lastRunStatus: 'ok'
+          }
+        }
+      ]
+    })
+
+    expect(jobs[0]).toMatchObject({
+      id: 'claw-1',
+      managerId: 'openclaw:local',
+      provider: 'openclaw',
+      name: 'Morning report',
+      schedule: 'cron 0 9 * * * @ America/Phoenix',
+      enabled: true,
+      state: 'ok',
+      promptPreview: 'Summarize overnight alerts',
+      nextRunAt: '2026-05-16T16:00:00.000Z',
+      lastRunAt: '2026-05-15T16:00:00.000Z',
+      lastStatus: 'ok'
+    })
+  })
+})

--- a/src/main/automations/external-manager.ts
+++ b/src/main/automations/external-manager.ts
@@ -1,0 +1,250 @@
+import { execFile } from 'child_process'
+import { existsSync } from 'fs'
+import { readFile } from 'fs/promises'
+import { homedir } from 'os'
+import { join } from 'path'
+import { promisify } from 'util'
+import type {
+  ExternalAutomationAction,
+  ExternalAutomationActionInput,
+  ExternalAutomationManager,
+  ExternalAutomationProvider
+} from '../../shared/automations-types'
+import type { SshTarget } from '../../shared/ssh-types'
+import type { Store } from '../persistence'
+import { getActiveMultiplexer } from '../ipc/ssh'
+import { mapHermesJobs, mapOpenClawJobs } from './external-job-mappers'
+
+const execFileAsync = promisify(execFile)
+const HERMES_JOBS_FILE = join(homedir(), '.hermes', 'cron', 'jobs.json')
+const OPENCLAW_JOBS_FILE = join(homedir(), '.openclaw', 'cron', 'jobs.json')
+const EXTERNAL_JOB_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+async function isCommandOnPath(command: string): Promise<boolean> {
+  const finder = process.platform === 'win32' ? 'where' : 'which'
+  try {
+    await execFileAsync(finder, [command], { encoding: 'utf-8' })
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function readLocalHermesJobs(): Promise<unknown[]> {
+  if (!existsSync(HERMES_JOBS_FILE)) {
+    return []
+  }
+  const content = await readFile(HERMES_JOBS_FILE, 'utf-8')
+  const parsed = JSON.parse(content) as unknown
+  return Array.isArray(parsed) ? parsed : []
+}
+
+async function readLocalOpenClawJobs(): Promise<unknown[]> {
+  if (!existsSync(OPENCLAW_JOBS_FILE)) {
+    return []
+  }
+  const content = await readFile(OPENCLAW_JOBS_FILE, 'utf-8')
+  const parsed = JSON.parse(content) as unknown
+  return isRecord(parsed) && Array.isArray(parsed.jobs) ? parsed.jobs : []
+}
+
+async function listLocalHermesManager(): Promise<ExternalAutomationManager | null> {
+  const [hermesAvailableResult, jobsResult] = await Promise.allSettled([
+    isCommandOnPath('hermes'),
+    readLocalHermesJobs()
+  ])
+  const hermesAvailable =
+    hermesAvailableResult.status === 'fulfilled' && hermesAvailableResult.value
+  const jobs = jobsResult.status === 'fulfilled' ? jobsResult.value : []
+  const readError = jobsResult.status === 'rejected' ? String(jobsResult.reason) : null
+  if (!hermesAvailable && jobs.length === 0 && !readError) {
+    return null
+  }
+  const managerId = 'hermes:local'
+  return {
+    id: managerId,
+    provider: 'hermes',
+    label: 'Hermes on this computer',
+    target: { type: 'local' },
+    status: readError ? 'unavailable' : 'available',
+    error:
+      readError ??
+      (hermesAvailable ? null : 'Hermes jobs were found, but the hermes CLI is not on PATH.'),
+    canManage: !readError && hermesAvailable,
+    jobs: mapHermesJobs(managerId, jobs)
+  }
+}
+
+async function listLocalOpenClawManager(): Promise<ExternalAutomationManager | null> {
+  const [openClawAvailableResult, jobsResult] = await Promise.allSettled([
+    isCommandOnPath('openclaw'),
+    readLocalOpenClawJobs()
+  ])
+  const openClawAvailable =
+    openClawAvailableResult.status === 'fulfilled' && openClawAvailableResult.value
+  const jobs = jobsResult.status === 'fulfilled' ? jobsResult.value : []
+  const readError = jobsResult.status === 'rejected' ? String(jobsResult.reason) : null
+  if (!openClawAvailable && jobs.length === 0 && !readError) {
+    return null
+  }
+  const managerId = 'openclaw:local'
+  return {
+    id: managerId,
+    provider: 'openclaw',
+    label: 'OpenClaw on this computer',
+    target: { type: 'local' },
+    status: readError ? 'unavailable' : 'available',
+    error:
+      readError ??
+      (openClawAvailable ? null : 'OpenClaw jobs were found, but the openclaw CLI is not on PATH.'),
+    canManage: !readError && openClawAvailable,
+    jobs: mapOpenClawJobs(managerId, jobs)
+  }
+}
+
+function remoteRelayErrorMessage(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error)
+  if (message.includes('-32601') || /method not found/i.test(message)) {
+    return 'Remote relay does not support external automation management. Reconnect the SSH target to deploy the latest relay.'
+  }
+  return message
+}
+
+async function listRemoteHermesManager(target: SshTarget): Promise<ExternalAutomationManager> {
+  return listRemoteManager(target, 'hermes')
+}
+
+async function listRemoteOpenClawManager(target: SshTarget): Promise<ExternalAutomationManager> {
+  return listRemoteManager(target, 'openclaw')
+}
+
+async function listRemoteManager(
+  target: SshTarget,
+  provider: ExternalAutomationProvider
+): Promise<ExternalAutomationManager> {
+  const providerLabel = provider === 'hermes' ? 'Hermes' : 'OpenClaw'
+  const managerProviderId = `${provider}:ssh:${target.id}`
+  const mux = getActiveMultiplexer(target.id)
+  if (!mux || mux.isDisposed()) {
+    return {
+      id: managerProviderId,
+      provider,
+      label: `${providerLabel} on ${target.label}`,
+      target: { type: 'ssh', connectionId: target.id },
+      status: 'unavailable',
+      error: 'SSH target is not connected.',
+      canManage: false,
+      jobs: []
+    }
+  }
+  try {
+    const result = (await mux.request('externalAutomations.list', { provider })) as {
+      jobs?: unknown[]
+      hermesAvailable?: boolean
+      openclawAvailable?: boolean
+      error?: string | null
+    }
+    const commandAvailable =
+      provider === 'hermes' ? result.hermesAvailable === true : result.openclawAvailable === true
+    const readError = result.error ?? null
+    return {
+      id: managerProviderId,
+      provider,
+      label: `${providerLabel} on ${target.label}`,
+      target: { type: 'ssh', connectionId: target.id },
+      status: readError ? 'unavailable' : 'available',
+      error:
+        readError ?? (commandAvailable ? null : `${providerLabel} CLI is not on the remote PATH.`),
+      canManage: !readError && commandAvailable,
+      jobs:
+        provider === 'hermes'
+          ? mapHermesJobs(managerProviderId, result.jobs ?? [])
+          : mapOpenClawJobs(managerProviderId, result.jobs ?? [])
+    }
+  } catch (error) {
+    return {
+      id: managerProviderId,
+      provider,
+      label: `${providerLabel} on ${target.label}`,
+      target: { type: 'ssh', connectionId: target.id },
+      status: 'unavailable',
+      error: remoteRelayErrorMessage(error),
+      canManage: false,
+      jobs: []
+    }
+  }
+}
+
+export async function listExternalAutomationManagers(
+  store: Store
+): Promise<ExternalAutomationManager[]> {
+  const [localHermes, localOpenClaw, remote] = await Promise.all([
+    listLocalHermesManager(),
+    listLocalOpenClawManager(),
+    Promise.all(
+      store
+        .getSshTargets()
+        .flatMap((target) => [listRemoteHermesManager(target), listRemoteOpenClawManager(target)])
+    )
+  ])
+  return [
+    ...(localHermes ? [localHermes] : []),
+    ...(localOpenClaw ? [localOpenClaw] : []),
+    ...remote
+  ]
+}
+
+function hermesCommandForAction(action: ExternalAutomationAction): string {
+  switch (action) {
+    case 'pause':
+      return 'pause'
+    case 'resume':
+      return 'resume'
+    case 'run':
+      return 'run'
+    case 'delete':
+      return 'remove'
+  }
+}
+
+function openClawCommandForAction(action: ExternalAutomationAction): string {
+  switch (action) {
+    case 'pause':
+      return 'disable'
+    case 'resume':
+      return 'enable'
+    case 'run':
+      return 'run'
+    case 'delete':
+      return 'rm'
+  }
+}
+
+export async function runExternalAutomationAction(
+  input: ExternalAutomationActionInput
+): Promise<void> {
+  if (!EXTERNAL_JOB_ID_PATTERN.test(input.jobId)) {
+    throw new Error('Invalid external automation job ID.')
+  }
+  const command =
+    input.provider === 'hermes'
+      ? hermesCommandForAction(input.action)
+      : openClawCommandForAction(input.action)
+  if (input.target.type === 'local') {
+    await execFileAsync(input.provider, ['cron', command, input.jobId], { encoding: 'utf-8' })
+    return
+  }
+  const mux = getActiveMultiplexer(input.target.connectionId)
+  if (!mux || mux.isDisposed()) {
+    throw new Error(`SSH target "${input.target.connectionId}" is not connected.`)
+  }
+  await mux.request('externalAutomations.act', {
+    provider: input.provider,
+    action: input.action,
+    jobId: input.jobId
+  })
+}

--- a/src/main/ipc/automations.ts
+++ b/src/main/ipc/automations.ts
@@ -5,9 +5,15 @@ import type {
   Automation,
   AutomationCreateInput,
   AutomationDispatchResult,
+  ExternalAutomationActionInput,
+  ExternalAutomationManager,
   AutomationRun,
   AutomationUpdateInput
 } from '../../shared/automations-types'
+import {
+  listExternalAutomationManagers,
+  runExternalAutomationAction
+} from '../automations/external-manager'
 
 export function registerAutomationHandlers(store: Store, service: AutomationService): void {
   ipcMain.handle('automations:list', (): Automation[] => store.listAutomations())
@@ -15,6 +21,15 @@ export function registerAutomationHandlers(store: Store, service: AutomationServ
     'automations:listRuns',
     (_event, args?: { automationId?: string }): AutomationRun[] =>
       store.listAutomationRuns(args?.automationId)
+  )
+  ipcMain.handle('automations:listExternalManagers', (): Promise<ExternalAutomationManager[]> => {
+    return listExternalAutomationManagers(store)
+  })
+  ipcMain.handle(
+    'automations:runExternalAction',
+    (_event, input: ExternalAutomationActionInput) => {
+      return runExternalAutomationAction(input)
+    }
   )
   ipcMain.handle(
     'automations:create',

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -211,6 +211,8 @@ import type {
   AutomationCreateInput,
   AutomationDispatchRequest,
   AutomationDispatchResult,
+  ExternalAutomationActionInput,
+  ExternalAutomationManager,
   AutomationRun,
   AutomationUpdateInput
 } from '../shared/automations-types'
@@ -1540,6 +1542,8 @@ export type PreloadApi = {
   automations: {
     list: () => Promise<Automation[]>
     listRuns: (args?: { automationId?: string }) => Promise<AutomationRun[]>
+    listExternalManagers: () => Promise<ExternalAutomationManager[]>
+    runExternalAction: (input: ExternalAutomationActionInput) => Promise<void>
     create: (input: AutomationCreateInput) => Promise<Automation>
     update: (args: { id: string; updates: AutomationUpdateInput }) => Promise<Automation>
     delete: (args: { id: string }) => Promise<void>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -100,6 +100,8 @@ import type {
   AutomationCreateInput,
   AutomationDispatchRequest,
   AutomationDispatchResult,
+  ExternalAutomationActionInput,
+  ExternalAutomationManager,
   AutomationRun,
   AutomationUpdateInput
 } from '../shared/automations-types'
@@ -2596,6 +2598,10 @@ const api = {
     list: (): Promise<Automation[]> => ipcRenderer.invoke('automations:list'),
     listRuns: (args?: { automationId?: string }): Promise<AutomationRun[]> =>
       ipcRenderer.invoke('automations:listRuns', args),
+    listExternalManagers: (): Promise<ExternalAutomationManager[]> =>
+      ipcRenderer.invoke('automations:listExternalManagers'),
+    runExternalAction: (input: ExternalAutomationActionInput): Promise<void> =>
+      ipcRenderer.invoke('automations:runExternalAction', input),
     create: (input: AutomationCreateInput): Promise<Automation> =>
       ipcRenderer.invoke('automations:create', input),
     update: (args: { id: string; updates: AutomationUpdateInput }): Promise<Automation> =>

--- a/src/relay/external-automations-handler.ts
+++ b/src/relay/external-automations-handler.ts
@@ -1,0 +1,118 @@
+import { execFile } from 'child_process'
+import { existsSync } from 'fs'
+import { readFile } from 'fs/promises'
+import { homedir } from 'os'
+import { join } from 'path'
+import { promisify } from 'util'
+import type { RelayDispatcher } from './dispatcher'
+
+const execFileAsync = promisify(execFile)
+const HERMES_JOBS_FILE = join(homedir(), '.hermes', 'cron', 'jobs.json')
+const OPENCLAW_JOBS_FILE = join(homedir(), '.openclaw', 'cron', 'jobs.json')
+const EXTERNAL_JOB_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/
+
+type ExternalProvider = 'hermes' | 'openclaw'
+type HermesAction = 'pause' | 'resume' | 'run' | 'delete'
+
+export class ExternalAutomationsHandler {
+  constructor(private readonly dispatcher: RelayDispatcher) {
+    this.dispatcher.onRequest('externalAutomations.list', (params) => this.listJobs(params))
+    this.dispatcher.onRequest('externalAutomations.act', (params) => this.runAction(params))
+  }
+
+  private async isCommandAvailable(command: string): Promise<boolean> {
+    try {
+      await execFileAsync('/bin/sh', ['-lc', `which ${command}`], {
+        encoding: 'utf-8',
+        timeout: 5000
+      })
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  private async readJobs(provider: ExternalProvider): Promise<unknown[]> {
+    const jobsFile = provider === 'hermes' ? HERMES_JOBS_FILE : OPENCLAW_JOBS_FILE
+    if (!existsSync(jobsFile)) {
+      return []
+    }
+    const content = await readFile(jobsFile, 'utf-8')
+    const parsed = JSON.parse(content) as unknown
+    if (Array.isArray(parsed)) {
+      return parsed
+    }
+    return typeof parsed === 'object' &&
+      parsed !== null &&
+      !Array.isArray(parsed) &&
+      Array.isArray((parsed as { jobs?: unknown }).jobs)
+      ? (parsed as { jobs: unknown[] }).jobs
+      : []
+  }
+
+  private async listJobs(params?: Record<string, unknown>): Promise<{
+    jobs: unknown[]
+    hermesAvailable: boolean
+    openclawAvailable: boolean
+    error: string | null
+  }> {
+    const provider = params?.provider === 'openclaw' ? 'openclaw' : 'hermes'
+    const [commandAvailable, jobsResult] = await Promise.allSettled([
+      this.isCommandAvailable(provider),
+      this.readJobs(provider)
+    ])
+    const jobs = jobsResult.status === 'fulfilled' ? jobsResult.value : []
+    const available = commandAvailable.status === 'fulfilled' && commandAvailable.value
+    return {
+      jobs,
+      hermesAvailable: provider === 'hermes' && available,
+      openclawAvailable: provider === 'openclaw' && available,
+      error: jobsResult.status === 'rejected' ? String(jobsResult.reason) : null
+    }
+  }
+
+  private hermesCommand(action: HermesAction): string {
+    switch (action) {
+      case 'pause':
+        return 'pause'
+      case 'resume':
+        return 'resume'
+      case 'run':
+        return 'run'
+      case 'delete':
+        return 'remove'
+    }
+  }
+
+  private openClawCommand(action: HermesAction): string {
+    switch (action) {
+      case 'pause':
+        return 'disable'
+      case 'resume':
+        return 'enable'
+      case 'run':
+        return 'run'
+      case 'delete':
+        return 'rm'
+    }
+  }
+
+  private async runAction(params: Record<string, unknown> = {}): Promise<{ ok: true }> {
+    const provider = params.provider === 'openclaw' ? 'openclaw' : 'hermes'
+    const action = params.action
+    const jobId = params.jobId
+    if (action !== 'pause' && action !== 'resume' && action !== 'run' && action !== 'delete') {
+      throw new Error('Unsupported external automation action.')
+    }
+    if (typeof jobId !== 'string' || !EXTERNAL_JOB_ID_PATTERN.test(jobId)) {
+      throw new Error('Invalid external automation job ID.')
+    }
+    const command =
+      provider === 'hermes' ? this.hermesCommand(action) : this.openClawCommand(action)
+    await execFileAsync('/bin/sh', ['-lc', `${provider} cron ${command} ${jobId}`], {
+      encoding: 'utf-8',
+      timeout: 30_000
+    })
+    return { ok: true }
+  }
+}

--- a/src/relay/relay.ts
+++ b/src/relay/relay.ts
@@ -31,6 +31,7 @@ import { PtyHandler } from './pty-handler'
 import { FsHandler } from './fs-handler'
 import { GitHandler } from './git-handler'
 import { PreflightHandler } from './preflight-handler'
+import { ExternalAutomationsHandler } from './external-automations-handler'
 import { PortScanHandler } from './port-scan-handler'
 import { AgentExecHandler } from './agent-exec-handler'
 import { endpointDirForRelaySocket, RelayAgentHookServer } from './agent-hook-server'
@@ -232,7 +233,9 @@ async function main(): Promise<void> {
   void _gitHandler
 
   const _preflightHandler = new PreflightHandler(dispatcher)
+  const _externalAutomationsHandler = new ExternalAutomationsHandler(dispatcher)
   void _preflightHandler
+  void _externalAutomationsHandler
 
   const _portScanHandler = new PortScanHandler(dispatcher)
   void _portScanHandler

--- a/src/renderer/src/components/automations/AutomationsPage.tsx
+++ b/src/renderer/src/components/automations/AutomationsPage.tsx
@@ -28,6 +28,9 @@ import { useRepoMap, useWorktreeMap } from '@/store/selectors'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 import type {
   Automation,
+  ExternalAutomationAction,
+  ExternalAutomationJob,
+  ExternalAutomationManager,
   AutomationRun,
   AutomationUpdateInput
 } from '../../../../shared/automations-types'
@@ -36,6 +39,7 @@ import { buildAutomationRrule, parseAutomationRrule } from '../../../../shared/a
 import { formatAutomationDateTimeWithRelative } from './automation-page-parts'
 import { AutomationDetail } from './AutomationDetail'
 import { AutomationEditorDialog, type AutomationDraft } from './AutomationEditorDialog'
+import { ExternalAutomationManagers } from './ExternalAutomationManagers'
 
 const AGENTS = AGENT_CATALOG.map((agent) => agent.id)
 const DEFAULT_TIME = '09:00'
@@ -72,6 +76,8 @@ export default function AutomationsPage(): React.JSX.Element {
 
   const [automations, setAutomations] = useState<Automation[]>([])
   const [runs, setRuns] = useState<AutomationRun[]>([])
+  const [externalManagers, setExternalManagers] = useState<ExternalAutomationManager[]>([])
+  const [externalActionKey, setExternalActionKey] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(true)
   const [isSaving, setIsSaving] = useState(false)
   const [createOpen, setCreateOpen] = useState(false)
@@ -79,6 +85,10 @@ export default function AutomationsPage(): React.JSX.Element {
   const [relativeNow, setRelativeNow] = useState(Date.now())
   const [draftAtOpen, setDraftAtOpen] = useState<AutomationDraft | null>(null)
   const [deleteTarget, setDeleteTarget] = useState<Automation | null>(null)
+  const [externalDeleteTarget, setExternalDeleteTarget] = useState<{
+    manager: ExternalAutomationManager
+    job: ExternalAutomationJob
+  } | null>(null)
   const [dontAskDeleteAgain, setDontAskDeleteAgain] = useState(false)
   const editRequestRef = useRef(0)
   const deleteConfirmButtonRef = useRef<HTMLButtonElement>(null)
@@ -129,12 +139,14 @@ export default function AutomationsPage(): React.JSX.Element {
   const refresh = useCallback(async () => {
     setIsLoading(true)
     try {
-      const [nextAutomations, nextRuns] = await Promise.all([
+      const [nextAutomations, nextRuns, nextExternalManagers] = await Promise.all([
         window.api.automations.list(),
-        window.api.automations.listRuns()
+        window.api.automations.listRuns(),
+        window.api.automations.listExternalManagers()
       ])
       setAutomations(nextAutomations)
       setRuns(nextRuns)
+      setExternalManagers(nextExternalManagers)
       const currentSelectedId = useAppStore.getState().selectedAutomationId
       const hasCurrentSelection = nextAutomations.some(
         (automation) => automation.id === currentSelectedId
@@ -464,6 +476,59 @@ export default function AutomationsPage(): React.JSX.Element {
     toast.message('Automation run queued.')
   }
 
+  const runExternalAction = async (
+    manager: ExternalAutomationManager,
+    job: ExternalAutomationJob,
+    action: ExternalAutomationAction
+  ): Promise<void> => {
+    const key = `${manager.id}:${job.id}:${action}`
+    setExternalActionKey(key)
+    try {
+      await window.api.automations.runExternalAction({
+        managerId: manager.id,
+        provider: manager.provider,
+        target: manager.target,
+        jobId: job.id,
+        action
+      })
+      await refresh()
+      toast.success(
+        action === 'delete'
+          ? 'External automation deleted.'
+          : action === 'run'
+            ? 'External automation queued.'
+            : action === 'pause'
+              ? 'External automation paused.'
+              : 'External automation resumed.'
+      )
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'External automation action failed.')
+    } finally {
+      setExternalActionKey(null)
+    }
+  }
+
+  const requestExternalAction = (
+    manager: ExternalAutomationManager,
+    job: ExternalAutomationJob,
+    action: ExternalAutomationAction
+  ): void => {
+    if (action === 'delete') {
+      setExternalDeleteTarget({ manager, job })
+      return
+    }
+    void runExternalAction(manager, job, action)
+  }
+
+  const confirmDeleteExternalAutomation = async (): Promise<void> => {
+    if (!externalDeleteTarget) {
+      return
+    }
+    const target = externalDeleteTarget
+    setExternalDeleteTarget(null)
+    await runExternalAction(target.manager, target.job, 'delete')
+  }
+
   const openRunWorkspace = (run: AutomationRun): void => {
     if (!run.workspaceId || !activateAndRevealWorktree(run.workspaceId)) {
       toast.error('Workspace is not available.')
@@ -613,6 +678,55 @@ export default function AutomationsPage(): React.JSX.Element {
         </DialogContent>
       </Dialog>
 
+      <Dialog
+        open={externalDeleteTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setExternalDeleteTarget(null)
+          }
+        }}
+      >
+        <DialogContent
+          className="max-w-md"
+          onOpenAutoFocus={(event) => {
+            event.preventDefault()
+            deleteConfirmButtonRef.current?.focus()
+          }}
+        >
+          <DialogHeader>
+            <DialogTitle className="text-sm">Delete External Automation</DialogTitle>
+            <DialogDescription className="text-xs">
+              Delete{' '}
+              <span className="break-all font-medium text-foreground">
+                {externalDeleteTarget?.job.name}
+              </span>{' '}
+              from {externalDeleteTarget?.manager.label}.
+            </DialogDescription>
+          </DialogHeader>
+          {externalDeleteTarget ? (
+            <div className="rounded-md border border-border/70 bg-muted/35 px-3 py-2 text-xs">
+              <div className="break-all font-medium text-foreground">
+                {externalDeleteTarget.job.name}
+              </div>
+              <div className="mt-1 text-muted-foreground">{externalDeleteTarget.job.schedule}</div>
+            </div>
+          ) : null}
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setExternalDeleteTarget(null)}>
+              Cancel
+            </Button>
+            <Button
+              ref={deleteConfirmButtonRef}
+              variant="destructive"
+              onClick={() => void confirmDeleteExternalAutomation()}
+            >
+              <Trash2 className="size-4" />
+              Delete
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
       <div className="grid min-h-0 flex-1 grid-cols-[minmax(280px,360px)_1fr] overflow-hidden border-t border-border/50">
         <section className="flex min-h-0 flex-col border-r border-border/50 bg-muted/20">
           <div className="min-h-0 flex-1 overflow-auto p-2">
@@ -715,6 +829,12 @@ export default function AutomationsPage(): React.JSX.Element {
             onEdit={(automation) => void openEditDialog(automation)}
             onToggle={(automation) => void toggleAutomation(automation)}
             onDelete={requestDeleteAutomation}
+          />
+          <ExternalAutomationManagers
+            managers={externalManagers}
+            now={relativeNow}
+            runningActionKey={externalActionKey}
+            onAction={requestExternalAction}
           />
         </section>
       </div>

--- a/src/renderer/src/components/automations/ExternalAutomationManagers.tsx
+++ b/src/renderer/src/components/automations/ExternalAutomationManagers.tsx
@@ -1,0 +1,197 @@
+import React from 'react'
+import { Pause, Play, RefreshCw, Trash2 } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import type {
+  ExternalAutomationAction,
+  ExternalAutomationJob,
+  ExternalAutomationManager
+} from '../../../../shared/automations-types'
+import { formatAutomationDateTimeWithRelative } from './automation-page-parts'
+
+type ExternalAutomationManagersProps = {
+  managers: ExternalAutomationManager[]
+  now: number
+  runningActionKey: string | null
+  onAction: (
+    manager: ExternalAutomationManager,
+    job: ExternalAutomationJob,
+    action: ExternalAutomationAction
+  ) => void
+}
+
+function formatExternalDate(value: string | null, now: number): string {
+  if (!value) {
+    return 'Never'
+  }
+  const parsed = Date.parse(value)
+  if (!Number.isFinite(parsed)) {
+    return value
+  }
+  return formatAutomationDateTimeWithRelative(parsed, now)
+}
+
+function actionKey(
+  manager: ExternalAutomationManager,
+  job: ExternalAutomationJob,
+  action: ExternalAutomationAction
+): string {
+  return `${manager.id}:${job.id}:${action}`
+}
+
+function ExternalActionButton({
+  label,
+  disabled,
+  className,
+  onClick,
+  children
+}: {
+  label: string
+  disabled: boolean
+  className?: string
+  onClick: () => void
+  children: React.ReactNode
+}): React.JSX.Element {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon-xs"
+          aria-label={label}
+          className={className}
+          disabled={disabled}
+          onClick={onClick}
+        >
+          {children}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom" sideOffset={6}>
+        {label}
+      </TooltipContent>
+    </Tooltip>
+  )
+}
+
+export function ExternalAutomationManagers({
+  managers,
+  now,
+  runningActionKey,
+  onAction
+}: ExternalAutomationManagersProps): React.JSX.Element {
+  return (
+    <div className="mt-6 rounded-md border border-border/50 bg-muted/20 shadow-sm">
+      <div className="flex items-center justify-between border-b border-border/50 px-3 py-2">
+        <div>
+          <div className="text-sm font-medium">External managers</div>
+        </div>
+        <Badge variant="outline">
+          {managers.reduce((sum, manager) => sum + manager.jobs.length, 0)} jobs
+        </Badge>
+      </div>
+      <div className="divide-y divide-border/50">
+        {managers.map((manager) => (
+          <div key={manager.id} className="px-3 py-3">
+            <div className="mb-2 flex items-center justify-between gap-3">
+              <div className="min-w-0">
+                <div className="truncate text-sm font-medium">{manager.label}</div>
+                <div className="text-xs text-muted-foreground">
+                  {manager.status === 'available'
+                    ? manager.canManage
+                      ? 'Manageable'
+                      : 'Read-only'
+                    : 'Unavailable'}
+                  {manager.error ? ` - ${manager.error}` : null}
+                </div>
+              </div>
+              <Badge variant={manager.status === 'available' ? 'secondary' : 'outline'}>
+                {manager.provider}
+              </Badge>
+            </div>
+            <div className="divide-y divide-border/40">
+              {manager.jobs.map((job) => (
+                <div
+                  key={job.id}
+                  className="grid grid-cols-[minmax(0,1fr)_minmax(8rem,auto)_auto] items-center gap-3 px-3 py-2 text-sm"
+                >
+                  <div className="min-w-0">
+                    <div className="flex min-w-0 items-center gap-2">
+                      <span className="truncate font-medium">{job.name}</span>
+                      <Badge variant={job.enabled ? 'secondary' : 'outline'}>
+                        {job.enabled ? 'Active' : 'Paused'}
+                      </Badge>
+                    </div>
+                    <div className="mt-1 truncate text-xs text-muted-foreground">
+                      {job.schedule} · next {formatExternalDate(job.nextRunAt, now)}
+                    </div>
+                    {job.promptPreview || job.lastError ? (
+                      <div className="mt-1 truncate text-xs text-muted-foreground">
+                        {job.lastError ?? job.promptPreview}
+                      </div>
+                    ) : null}
+                  </div>
+                  <div className="hidden min-w-0 text-xs text-muted-foreground md:block">
+                    Last {formatExternalDate(job.lastRunAt, now)}
+                    {job.lastStatus ? ` · ${job.lastStatus}` : null}
+                  </div>
+                  <div className="flex items-center justify-end gap-1">
+                    <ExternalActionButton
+                      label="Run external automation"
+                      disabled={!manager.canManage || runningActionKey !== null}
+                      onClick={() => onAction(manager, job, 'run')}
+                    >
+                      {runningActionKey === actionKey(manager, job, 'run') ? (
+                        <RefreshCw className="size-3.5 animate-spin" />
+                      ) : (
+                        <Play className="size-3.5" />
+                      )}
+                    </ExternalActionButton>
+                    <ExternalActionButton
+                      label={
+                        job.enabled ? 'Pause external automation' : 'Resume external automation'
+                      }
+                      disabled={!manager.canManage || runningActionKey !== null}
+                      onClick={() => onAction(manager, job, job.enabled ? 'pause' : 'resume')}
+                    >
+                      {runningActionKey ===
+                      actionKey(manager, job, job.enabled ? 'pause' : 'resume') ? (
+                        <RefreshCw className="size-3.5 animate-spin" />
+                      ) : job.enabled ? (
+                        <Pause className="size-3.5" />
+                      ) : (
+                        <Play className="size-3.5" />
+                      )}
+                    </ExternalActionButton>
+                    <ExternalActionButton
+                      label="Delete external automation"
+                      className="text-destructive hover:text-destructive"
+                      disabled={!manager.canManage || runningActionKey !== null}
+                      onClick={() => onAction(manager, job, 'delete')}
+                    >
+                      {runningActionKey === actionKey(manager, job, 'delete') ? (
+                        <RefreshCw className="size-3.5 animate-spin" />
+                      ) : (
+                        <Trash2 className="size-3.5" />
+                      )}
+                    </ExternalActionButton>
+                  </div>
+                </div>
+              ))}
+              {manager.jobs.length === 0 ? (
+                <div className="px-3 py-4 text-sm text-muted-foreground">
+                  No {manager.provider === 'hermes' ? 'Hermes' : 'OpenClaw'} jobs found.
+                </div>
+              ) : null}
+            </div>
+          </div>
+        ))}
+        {managers.length === 0 ? (
+          <div className="px-3 py-6 text-center text-sm text-muted-foreground">
+            No external automation managers found.
+          </div>
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/settings/agents-search.ts
+++ b/src/renderer/src/components/settings/agents-search.ts
@@ -29,6 +29,7 @@ export const AGENTS_PANE_SEARCH_ENTRIES: SettingsSearchEntry[] = [
       'qwen',
       'rovo',
       'hermes',
+      'openclaw',
       'copilot',
       'github',
       'github copilot',

--- a/src/renderer/src/components/sidebar/use-worktree-activity-status.ts
+++ b/src/renderer/src/components/sidebar/use-worktree-activity-status.ts
@@ -21,14 +21,15 @@ export function useWorktreeActivityStatus(worktreeId: string): WorktreeStatus {
   const ptyIdsForWorktree = useAppStore(
     useShallow((s) => selectLivePtyIdsForWorktree(s, worktreeId))
   )
-  const { hasPermission, hasLiveDone, hasRetainedDone } = useAppStore(
+  const { hasPermission, hasLiveWorking, hasLiveDone, hasRetainedDone } = useAppStore(
     useShallow((s) => {
       // Touch the epoch so this selector re-runs when a fresh hook entry
       // crosses the stale boundary.
       void s.agentStatusEpoch
       const wtTabs = s.tabsByWorktree[worktreeId] ?? EMPTY_TABS
       let perm = false
-      let live = false
+      let working = false
+      let done = false
       if (wtTabs.length > 0) {
         const tabIds = new Set(wtTabs.map((tab) => tab.id))
         const now = Date.now()
@@ -42,11 +43,13 @@ export function useWorktreeActivityStatus(worktreeId: string): WorktreeStatus {
           }
           if (entry.state === 'blocked' || entry.state === 'waiting') {
             perm = true
+          } else if (entry.state === 'working') {
+            working = true
           } else if (entry.state === 'done') {
-            live = true
+            done = true
           }
         }
-        for (const unsupported of Object.values(s.migrationUnsupportedByPtyId)) {
+        for (const unsupported of Object.values(s.migrationUnsupportedByPtyId ?? {})) {
           const entry = migrationUnsupportedToAgentStatusEntry(unsupported)
           if (!entry) {
             continue
@@ -65,13 +68,18 @@ export function useWorktreeActivityStatus(worktreeId: string): WorktreeStatus {
           break
         }
       }
-      return { hasPermission: perm, hasLiveDone: live, hasRetainedDone: retained }
+      return {
+        hasPermission: perm,
+        hasLiveWorking: working,
+        hasLiveDone: done,
+        hasRetainedDone: retained
+      }
     })
   )
 
   // Why: compact and detailed cards need the same status-dot semantics:
   // runtime liveness gates title-derived states, then explicit agent rows can
-  // promote permission/done so the dot matches visible agent state.
+  // promote working/permission/done so the dot matches visible agent state.
   return useMemo(
     () =>
       resolveWorktreeStatus({
@@ -80,6 +88,7 @@ export function useWorktreeActivityStatus(worktreeId: string): WorktreeStatus {
         ptyIdsByTabId: ptyIdsForWorktree,
         runtimePaneTitlesByTabId: runtimePaneTitlesForWorktree,
         hasPermission,
+        hasLiveWorking,
         hasLiveDone,
         hasRetainedDone
       }),
@@ -89,6 +98,7 @@ export function useWorktreeActivityStatus(worktreeId: string): WorktreeStatus {
       ptyIdsForWorktree,
       runtimePaneTitlesForWorktree,
       hasPermission,
+      hasLiveWorking,
       hasLiveDone,
       hasRetainedDone
     ]

--- a/src/renderer/src/lib/agent-catalog.tsx
+++ b/src/renderer/src/lib/agent-catalog.tsx
@@ -182,6 +182,13 @@ export const AGENT_CATALOG: AgentCatalogEntry[] = [
     cmd: 'hermes',
     faviconDomain: 'nousresearch.com',
     homepageUrl: 'https://hermes-agent.nousresearch.com/docs/'
+  },
+  {
+    id: 'openclaw',
+    label: 'OpenClaw',
+    cmd: 'openclaw',
+    faviconDomain: 'openclaw.ai',
+    homepageUrl: 'https://github.com/openclaw/openclaw'
   }
 ]
 

--- a/src/renderer/src/lib/agent-status.ts
+++ b/src/renderer/src/lib/agent-status.ts
@@ -165,6 +165,7 @@ const ICONABLE_AGENT_TYPES: Record<TuiAgent, true> = {
   'qwen-code': true,
   rovo: true,
   hermes: true,
+  openclaw: true,
   copilot: true
 }
 

--- a/src/renderer/src/lib/worktree-status.test.ts
+++ b/src/renderer/src/lib/worktree-status.test.ts
@@ -86,6 +86,7 @@ describe('resolveWorktreeStatus', () => {
       // Slept: live-pty array empty; tab.ptyId would be the wake-hint sessionId.
       ptyIdsByTabId: { 'tab-1': [] },
       hasPermission: false,
+      hasLiveWorking: false,
       hasLiveDone: false,
       hasRetainedDone: false
     })
@@ -99,6 +100,7 @@ describe('resolveWorktreeStatus', () => {
       browserTabs: [],
       ptyIdsByTabId: { 'tab-1': [] },
       hasPermission: false,
+      hasLiveWorking: false,
       hasLiveDone: false,
       hasRetainedDone: true
     })
@@ -112,6 +114,7 @@ describe('resolveWorktreeStatus', () => {
       browserTabs: [],
       ptyIdsByTabId: { 'tab-1': [] },
       hasPermission: true,
+      hasLiveWorking: false,
       hasLiveDone: false,
       hasRetainedDone: false
     })
@@ -125,11 +128,26 @@ describe('resolveWorktreeStatus', () => {
       browserTabs: [],
       ptyIdsByTabId: livePtyMap('tab-1'),
       hasPermission: true,
+      hasLiveWorking: false,
       hasLiveDone: false,
       hasRetainedDone: false
     })
 
     expect(status).toBe('permission')
+  })
+
+  it('promotes to working from a fresh explicit agent row before pane titles restore', () => {
+    const status = resolveWorktreeStatus({
+      tabs: [{ id: 'tab-1', title: 'bash' }],
+      browserTabs: [],
+      ptyIdsByTabId: livePtyMap('tab-1'),
+      hasPermission: false,
+      hasLiveWorking: true,
+      hasLiveDone: false,
+      hasRetainedDone: false
+    })
+
+    expect(status).toBe('working')
   })
 
   it('lets heuristic working beat hasLiveDone (newer in-progress signal wins)', () => {
@@ -138,6 +156,7 @@ describe('resolveWorktreeStatus', () => {
       browserTabs: [],
       ptyIdsByTabId: livePtyMap('tab-1'),
       hasPermission: false,
+      hasLiveWorking: false,
       hasLiveDone: true,
       hasRetainedDone: false
     })
@@ -156,6 +175,7 @@ describe('resolveWorktreeStatus', () => {
       browserTabs: [],
       ptyIdsByTabId: livePtyMap('tab-1'),
       hasPermission: false,
+      hasLiveWorking: false,
       hasLiveDone: true,
       hasRetainedDone: false
     })
@@ -169,6 +189,7 @@ describe('resolveWorktreeStatus', () => {
       browserTabs: [],
       ptyIdsByTabId: livePtyMap('tab-1'),
       hasPermission: false,
+      hasLiveWorking: false,
       hasLiveDone: false,
       hasRetainedDone: true
     })
@@ -182,6 +203,7 @@ describe('resolveWorktreeStatus', () => {
       browserTabs: [],
       ptyIdsByTabId: livePtyMap('tab-1'),
       hasPermission: false,
+      hasLiveWorking: false,
       hasLiveDone: false,
       hasRetainedDone: false
     })

--- a/src/renderer/src/lib/worktree-status.ts
+++ b/src/renderer/src/lib/worktree-status.ts
@@ -78,9 +78,10 @@ export function getWorktreeStatusLabel(status: WorktreeStatus): string {
  * Apply the WorktreeCard priority overlay (permission > working > done >
  * heuristic) on top of the title-heuristic base. Live PTY liveness still gates
  * title-derived working/permission, but explicit agent rows are allowed to
- * promote the dot: if the sidebar shows a completed/blocking inline agent row,
- * the worktree status must agree with that visible row. Sleep cleanup owns
- * removing stale retained rows; once they are gone, no promotion occurs.
+ * promote the dot: if the sidebar shows a running/completed/blocking inline
+ * agent row, the worktree status must agree with that visible row. Sleep
+ * cleanup owns removing stale retained rows; once they are gone, no promotion
+ * occurs.
  *
  * Argument semantics (sourced by the WorktreeCard caller from the store):
  * - `tabs`, `browserTabs`: the worktree's terminal and browser tabs.
@@ -90,6 +91,8 @@ export function getWorktreeStatusLabel(status: WorktreeStatus): string {
  *   worktree (used by the title-heuristic for split-pane spinners).
  * - `hasPermission`: any fresh hook entry in {blocked, waiting} for a tab in
  *   this worktree.
+ * - `hasLiveWorking`: any fresh hook entry in {working} for a tab in this
+ *   worktree.
  * - `hasLiveDone`: any fresh hook entry in {done} for a tab in this worktree.
  * - `hasRetainedDone`: any retained-agent snapshot scoped to this worktreeId.
  */
@@ -99,6 +102,7 @@ export function resolveWorktreeStatus(args: {
   ptyIdsByTabId: Record<string, string[]>
   runtimePaneTitlesByTabId?: Record<string, Record<number, string>>
   hasPermission: boolean
+  hasLiveWorking: boolean
   hasLiveDone: boolean
   hasRetainedDone: boolean
 }): WorktreeStatus {
@@ -119,7 +123,10 @@ export function resolveWorktreeStatus(args: {
   if (heuristic === 'permission') {
     return 'permission'
   }
-  if (heuristic === 'working') {
+  // Why: restored-but-unfocused cards may have the startup hook snapshot before
+  // their terminal pane mounts and repopulates runtimePaneTitlesByTabId.
+  // Trust the fresh explicit working row so those cards stay yellow on restart.
+  if (args.hasLiveWorking || heuristic === 'working') {
     return 'working'
   }
   if (args.hasLiveDone || args.hasRetainedDone) {

--- a/src/shared/agent-detection.ts
+++ b/src/shared/agent-detection.ts
@@ -21,7 +21,16 @@ const GEMINI_PERMISSION = '\u270B' // ✋
 // unsafe under the substring-based detector and would classify ordinary shell
 // titles like "timestamp ready" as agent activity. Product telemetry uses the
 // explicit launch/session facts Orca owns, not this inference path.
-export const AGENT_NAMES = ['claude', 'codex', 'copilot', 'cursor', 'gemini', 'opencode', 'aider']
+export const AGENT_NAMES = [
+  'claude',
+  'codex',
+  'copilot',
+  'cursor',
+  'gemini',
+  'opencode',
+  'openclaw',
+  'aider'
+]
 
 // Why: `android` contains `droid`; unlike the legacy agent names above, Droid
 // must be token-matched so Android terminal titles do not become agent status.

--- a/src/shared/agent-kind.ts
+++ b/src/shared/agent-kind.ts
@@ -37,6 +37,7 @@ const TUI_AGENT_KIND_BY_AGENT = {
   'qwen-code': 'qwen-code',
   rovo: 'rovo',
   hermes: 'hermes',
+  openclaw: 'openclaw',
   copilot: 'copilot'
 } satisfies Record<TuiAgent, ConcreteAgentKind>
 

--- a/src/shared/automations-types.ts
+++ b/src/shared/automations-types.ts
@@ -103,3 +103,51 @@ export type AutomationDispatchResult = {
   terminalSessionId?: string | null
   error?: string | null
 }
+
+export type ExternalAutomationProvider = 'hermes' | 'openclaw'
+export type ExternalAutomationManagerStatus = 'available' | 'unavailable'
+export type ExternalAutomationAction = 'pause' | 'resume' | 'run' | 'delete'
+
+export type ExternalAutomationTarget =
+  | {
+      type: 'local'
+    }
+  | {
+      type: 'ssh'
+      connectionId: string
+    }
+
+export type ExternalAutomationJob = {
+  id: string
+  managerId: string
+  provider: ExternalAutomationProvider
+  name: string
+  schedule: string
+  enabled: boolean
+  state: string
+  promptPreview: string
+  nextRunAt: string | null
+  lastRunAt: string | null
+  lastStatus: string | null
+  lastError: string | null
+  workdir: string | null
+}
+
+export type ExternalAutomationManager = {
+  id: string
+  provider: ExternalAutomationProvider
+  label: string
+  target: ExternalAutomationTarget
+  status: ExternalAutomationManagerStatus
+  error: string | null
+  canManage: boolean
+  jobs: ExternalAutomationJob[]
+}
+
+export type ExternalAutomationActionInput = {
+  managerId: string
+  provider: ExternalAutomationProvider
+  target: ExternalAutomationTarget
+  jobId: string
+  action: ExternalAutomationAction
+}

--- a/src/shared/telemetry-events.ts
+++ b/src/shared/telemetry-events.ts
@@ -58,6 +58,7 @@ export const AGENT_KIND_VALUES = [
   'qwen-code',
   'rovo',
   'hermes',
+  'openclaw',
   'copilot',
   'other'
 ] as const

--- a/src/shared/tui-agent-config.ts
+++ b/src/shared/tui-agent-config.ts
@@ -211,6 +211,12 @@ export const TUI_AGENT_CONFIG: Record<TuiAgent, TuiAgentConfig> = {
     expectedProcess: 'hermes',
     promptInjectionMode: 'stdin-after-start'
   },
+  openclaw: {
+    detectCmd: 'openclaw',
+    launchCmd: 'openclaw',
+    expectedProcess: 'openclaw',
+    promptInjectionMode: 'stdin-after-start'
+  },
   copilot: {
     detectCmd: 'copilot',
     launchCmd: 'copilot',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1136,6 +1136,7 @@ export type TuiAgent =
   | 'qwen-code' // Qwen Code
   | 'rovo' // Rovo Dev
   | 'hermes' // Hermes Agent
+  | 'openclaw' // OpenClaw
   | 'copilot' // GitHub Copilot CLI
 
 export type TaskViewPresetId = 'all' | 'issues' | 'review' | 'my-issues' | 'my-prs' | 'prs'


### PR DESCRIPTION
## Summary
- surface external automation managers in the Automations page
- support local and remote inventory/actions for existing Hermes and OpenClaw cron jobs
- add per-job run, pause/resume, and delete controls with confirmation
- register OpenClaw as a first-class TUI agent/runtime option

## Validation
- pnpm tc
- pnpm lint
- pnpm test src/main/automations/external-manager.test.ts src/shared/agent-kind.test.ts
- git diff --check
- Electron validation with isolated fake Hermes cron store/CLI: manager row rendered, run/pause/delete actions executed
- Electron validation with isolated fake OpenClaw cron store/CLI: manager row rendered, run/disable/delete actions executed

## Notes
- Messaging integrations are intentionally out of scope.
- This is a clean single-commit replacement for the closed prior PR.