### PR TITLE
Add task provider visibility settings

### DIFF
--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -93,6 +93,7 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     skipDeleteAutomationConfirm: false,
     defaultTaskViewPreset: 'all',
     defaultTaskSource: 'github',
+    visibleTaskProviders: ['github', 'gitlab', 'linear'],
     defaultRepoSelection: null,
     defaultLinearTeamSelection: null,
     opencodeSessionCookie: '',

--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -86,6 +86,7 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     skipDeleteAutomationConfirm: false,
     defaultTaskViewPreset: 'all',
     defaultTaskSource: 'github',
+    visibleTaskProviders: ['github', 'gitlab', 'linear'],
     defaultRepoSelection: null,
     defaultLinearTeamSelection: null,
     opencodeSessionCookie: '',

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -165,6 +165,7 @@ describe('Store', () => {
     expect(settings.terminalFontWeight).toBe(500)
     expect(settings.rightSidebarOpenByDefault).toBe(true)
     expect(settings.showTasksButton).toBe(true)
+    expect(settings.visibleTaskProviders).toEqual(['github', 'gitlab', 'linear'])
     expect(settings.experimentalActivity).toBe(true)
     expect(settings.floatingTerminalEnabled).toBe(true)
     expect(settings.floatingTerminalDefaultedForAllUsers).toBe(true)
@@ -306,10 +307,26 @@ describe('Store', () => {
     expect(store.getSettings().refreshLocalBaseRefOnWorktreeCreate).toBe(false)
     expect(store.getSettings().rightSidebarOpenByDefault).toBe(true)
     expect(store.getSettings().showTasksButton).toBe(true)
+    expect(store.getSettings().visibleTaskProviders).toEqual(['github', 'gitlab', 'linear'])
     expect(store.getSettings().experimentalActivity).toBe(true)
     expect(store.getSettings().notifications.customSoundPath).toBeNull()
     // repos should be loaded
     expect(store.getRepos()).toHaveLength(1)
+  })
+
+  it('normalizes malformed visible task providers on load', async () => {
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [],
+      worktreeMeta: {},
+      settings: { visibleTaskProviders: ['gitlab', 'unknown', 'gitlab'] },
+      ui: {},
+      githubCache: { pr: {}, issue: {} },
+      workspaceSession: {}
+    })
+
+    const store = await createStore()
+    expect(store.getSettings().visibleTaskProviders).toEqual(['gitlab'])
   })
 
   it('migrates the legacy floating terminal disabled default to enabled', async () => {

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -66,6 +66,7 @@ import { pruneLocalTerminalScrollbackBuffers } from '../shared/workspace-session
 import { pruneWorkspaceSessionBrowserHistory } from '../shared/workspace-session-browser-history'
 import { getRepoIdFromWorktreeId } from '../shared/worktree-id'
 import { normalizeTerminalQuickCommands } from '../shared/terminal-quick-commands'
+import { normalizeVisibleTaskProviders } from '../shared/task-providers'
 import {
   DEFAULT_WORKSPACE_STATUS_ID,
   clampWorkspaceBoardOpacity,
@@ -989,6 +990,9 @@ export class Store {
             terminalQuickCommands: normalizeTerminalQuickCommands(
               parsed.settings?.terminalQuickCommands
             ),
+            visibleTaskProviders: normalizeVisibleTaskProviders(
+              parsed.settings?.visibleTaskProviders
+            ),
             notifications: {
               ...getDefaultNotificationSettings(),
               ...parsed.settings?.notifications
@@ -1739,6 +1743,11 @@ export class Store {
     if ('terminalQuickCommands' in updates) {
       sanitizedUpdates.terminalQuickCommands = normalizeTerminalQuickCommands(
         updates.terminalQuickCommands
+      )
+    }
+    if ('visibleTaskProviders' in updates) {
+      sanitizedUpdates.visibleTaskProviders = normalizeVisibleTaskProviders(
+        updates.visibleTaskProviders
       )
     }
     // Why: `telemetry` is deep-merged for the same reason `notifications` is —

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -87,12 +87,17 @@ import type {
   LinearIssue,
   LinearTeam,
   Repo,
+  TaskProvider,
   TaskViewPresetId
 } from '../../../shared/types'
 import { shouldSuppressEnterSubmit } from '@/lib/new-workspace-enter-guard'
 import { linearCreateIssue, linearGetIssue, linearListTeams } from '@/runtime/runtime-linear-client'
+import {
+  normalizeVisibleTaskProviders,
+  resolveVisibleTaskProvider
+} from '../../../shared/task-providers'
 
-type TaskSource = 'github' | 'linear' | 'gitlab'
+type TaskSource = TaskProvider
 
 type GitLabTaskFilter = 'opened' | 'merged' | 'closed' | 'all'
 
@@ -604,6 +609,14 @@ export default function TaskPage(): React.JSX.Element {
     linearStatus.activeWorkspaceId ??
     linearWorkspaces[0]?.id ??
     null
+  const visibleTaskProviders = useMemo(
+    () => normalizeVisibleTaskProviders(settings?.visibleTaskProviders),
+    [settings?.visibleTaskProviders]
+  )
+  const visibleSourceOptions = useMemo(
+    () => SOURCE_OPTIONS.filter((source) => visibleTaskProviders.includes(source.id)),
+    [visibleTaskProviders]
+  )
 
   // Why: seed the preset + query from the user's saved default synchronously
   // so the first fetch effect issues exactly one request keyed to the final
@@ -614,7 +627,9 @@ export default function TaskPage(): React.JSX.Element {
   const initialTaskQuery = getTaskPresetQuery(defaultTaskViewPreset)
 
   const defaultTaskSource = settings?.defaultTaskSource ?? 'github'
-  const [taskSource, setTaskSource] = useState<TaskSource>(pageData.taskSource ?? defaultTaskSource)
+  const [taskSource, setTaskSource] = useState<TaskSource>(
+    resolveVisibleTaskProvider(pageData.taskSource ?? defaultTaskSource, visibleTaskProviders)
+  )
   const taskResumeAppliedRef = useRef(false)
   const githubSearchPersistReadyRef = useRef(false)
   const linearSearchPersistReadyRef = useRef(false)
@@ -625,9 +640,15 @@ export default function TaskPage(): React.JSX.Element {
   // initializes once, so sync from the store when the value changes.
   useEffect(() => {
     if (pageData.taskSource) {
-      setTaskSource(pageData.taskSource)
+      setTaskSource(resolveVisibleTaskProvider(pageData.taskSource, visibleTaskProviders))
     }
-  }, [pageData.taskSource])
+  }, [pageData.taskSource, visibleTaskProviders])
+
+  useEffect(() => {
+    if (!visibleTaskProviders.includes(taskSource)) {
+      setTaskSource(resolveVisibleTaskProvider(settings?.defaultTaskSource, visibleTaskProviders))
+    }
+  }, [settings?.defaultTaskSource, taskSource, visibleTaskProviders])
 
   // Why: Project mode is a sub-tab within the GitHub source. Visible whenever
   // the user is on the GitHub task source — actual entry into Project mode is
@@ -875,7 +896,12 @@ export default function TaskPage(): React.JSX.Element {
       return
     }
 
-    setTaskSource(pageData.taskSource ?? settings.defaultTaskSource)
+    setTaskSource(
+      resolveVisibleTaskProvider(
+        pageData.taskSource ?? settings.defaultTaskSource,
+        visibleTaskProviders
+      )
+    )
     setRepoSelection(resolvedInitialSelection)
 
     const nextGithubMode = taskResumeState?.githubMode ?? 'items'
@@ -905,7 +931,14 @@ export default function TaskPage(): React.JSX.Element {
     // Tasks context exactly once so later source/filter clicks remain local.
     taskResumeAppliedRef.current = true
     setTaskResumeApplied(true)
-  }, [persistedUIReady, settings, pageData.taskSource, resolvedInitialSelection, taskResumeState])
+  }, [
+    persistedUIReady,
+    settings,
+    pageData.taskSource,
+    resolvedInitialSelection,
+    taskResumeState,
+    visibleTaskProviders
+  ])
 
   // Why: fetch the full team list from the Linear API so the selector shows
   // all teams the user belongs to, not just teams with issues in the current
@@ -1929,7 +1962,7 @@ export default function TaskPage(): React.JSX.Element {
                       </TooltipContent>
                     </Tooltip>
                     <div className="mx-1 h-5 w-px bg-border/50" aria-hidden />
-                    {SOURCE_OPTIONS.map((source) => {
+                    {visibleSourceOptions.map((source) => {
                       const active = taskSource === source.id
                       return (
                         <Tooltip key={source.id}>

--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -10,6 +10,7 @@ import {
   Globe,
   Info,
   Keyboard,
+  ListChecks,
   Lock,
   MousePointerClick,
   Network,
@@ -56,6 +57,8 @@ import { ORCHESTRATION_PANE_SEARCH_ENTRIES } from './orchestration-search'
 import { AccountsPane, ACCOUNTS_PANE_SEARCH_ENTRIES } from './AccountsPane'
 import { StatsPane, STATS_PANE_SEARCH_ENTRIES } from '../stats/StatsPane'
 import { IntegrationsPane, INTEGRATIONS_PANE_SEARCH_ENTRIES } from './IntegrationsPane'
+import { TasksPane } from './TasksPane'
+import { TASKS_PANE_SEARCH_ENTRIES } from './tasks-search'
 import {
   DeveloperPermissionsPane,
   DEVELOPER_PERMISSIONS_PANE_SEARCH_ENTRIES
@@ -80,6 +83,7 @@ type SettingsNavTarget =
   | 'accounts'
   | 'browser'
   | 'git'
+  | 'tasks'
   | 'appearance'
   | 'terminal'
   | 'notifications'
@@ -446,6 +450,13 @@ function Settings(): React.JSX.Element {
         // so its search entries belong to Git too — that way a query like
         // "claude" or "thinking" still surfaces the section.
         searchEntries: [...GIT_PANE_SEARCH_ENTRIES, ...COMMIT_MESSAGE_AI_PANE_SEARCH_ENTRIES]
+      },
+      {
+        id: 'tasks',
+        title: 'Tasks',
+        description: 'Choose which task providers appear in the Tasks page and sidebar.',
+        icon: ListChecks,
+        searchEntries: TASKS_PANE_SEARCH_ENTRIES
       },
       {
         id: 'appearance',
@@ -829,6 +840,15 @@ function Settings(): React.JSX.Element {
                     displayedGitUsername={displayedGitUsername}
                   />
                   <CommitMessageAiPane settings={settings} updateSettings={updateSettings} />
+                </SettingsSection>
+
+                <SettingsSection
+                  id="tasks"
+                  title="Tasks"
+                  description="Choose which task providers appear in the Tasks page and sidebar."
+                  searchEntries={TASKS_PANE_SEARCH_ENTRIES}
+                >
+                  <TasksPane settings={settings} updateSettings={updateSettings} />
                 </SettingsSection>
 
                 <SettingsSection

--- a/src/renderer/src/components/settings/TasksPane.tsx
+++ b/src/renderer/src/components/settings/TasksPane.tsx
@@ -1,0 +1,142 @@
+import { Check, Github, Gitlab } from 'lucide-react'
+import type { GlobalSettings, TaskProvider } from '../../../../shared/types'
+import {
+  TASK_PROVIDERS,
+  normalizeVisibleTaskProviders,
+  resolveVisibleTaskProvider
+} from '../../../../shared/task-providers'
+import { cn } from '@/lib/utils'
+import { LinearIcon } from '@/components/icons/LinearIcon'
+import { Label } from '../ui/label'
+import { SearchableSetting } from './SearchableSetting'
+
+type TasksPaneProps = {
+  settings: GlobalSettings
+  updateSettings: (updates: Partial<GlobalSettings>) => void
+}
+
+const TASK_PROVIDER_OPTIONS: readonly {
+  id: TaskProvider
+  label: string
+  description: string
+  Icon: (props: { className?: string }) => React.JSX.Element
+}[] = [
+  {
+    id: 'github',
+    label: 'GitHub',
+    description: 'Show GitHub in the Tasks source picker and sidebar shortcuts.',
+    Icon: ({ className }) => <Github className={className} />
+  },
+  {
+    id: 'gitlab',
+    label: 'GitLab',
+    description: 'Show GitLab in the Tasks source picker and sidebar shortcuts.',
+    Icon: ({ className }) => <Gitlab className={className} />
+  },
+  {
+    id: 'linear',
+    label: 'Linear',
+    description: 'Show Linear in the Tasks source picker and sidebar shortcuts.',
+    Icon: ({ className }) => <LinearIcon className={className} />
+  }
+]
+
+export function TasksPane({ settings, updateSettings }: TasksPaneProps): React.JSX.Element {
+  const visibleProviders = normalizeVisibleTaskProviders(settings.visibleTaskProviders)
+
+  const toggleProvider = (provider: TaskProvider): void => {
+    const isVisible = visibleProviders.includes(provider)
+    if (isVisible && visibleProviders.length === 1) {
+      return
+    }
+
+    const nextProviders = isVisible
+      ? visibleProviders.filter((entry) => entry !== provider)
+      : TASK_PROVIDERS.filter((entry) => entry === provider || visibleProviders.includes(entry))
+
+    updateSettings({
+      visibleTaskProviders: nextProviders,
+      defaultTaskSource: resolveVisibleTaskProvider(settings.defaultTaskSource, nextProviders)
+    })
+  }
+
+  return (
+    <div className="space-y-6">
+      <section className="space-y-4">
+        <div className="space-y-1">
+          <h3 className="text-sm font-semibold">Task Sources</h3>
+          <p className="text-xs text-muted-foreground">
+            Choose which task providers appear in the Tasks page source picker and sidebar
+            shortcuts. At least one provider must stay visible.
+          </p>
+        </div>
+
+        <SearchableSetting
+          title="Task Providers"
+          description="Choose which task providers appear in the Tasks page and sidebar shortcuts."
+          keywords={[
+            'tasks',
+            'provider',
+            'source',
+            'github',
+            'gitlab',
+            'linear',
+            'display',
+            'hide'
+          ]}
+          className="grid gap-2"
+        >
+          {TASK_PROVIDER_OPTIONS.map((option) => {
+            const enabled = visibleProviders.includes(option.id)
+            const isLastEnabled = enabled && visibleProviders.length === 1
+            const Icon = option.Icon
+
+            return (
+              <button
+                key={option.id}
+                type="button"
+                role="checkbox"
+                aria-checked={enabled}
+                aria-disabled={isLastEnabled}
+                onClick={() => toggleProvider(option.id)}
+                className={cn(
+                  'flex w-full items-center gap-3 rounded-md border border-border/60 px-3 py-2.5 text-left transition-colors',
+                  enabled
+                    ? 'bg-accent/70 text-accent-foreground'
+                    : 'bg-transparent hover:bg-muted/50',
+                  isLastEnabled && 'cursor-not-allowed'
+                )}
+              >
+                <span
+                  className={cn(
+                    'flex size-7 shrink-0 items-center justify-center rounded-md border',
+                    enabled
+                      ? 'border-foreground/20 bg-background/70'
+                      : 'border-border/60 bg-muted/40 text-muted-foreground'
+                  )}
+                >
+                  <Icon className="size-3.5" />
+                </span>
+                <span className="min-w-0 flex-1 space-y-0.5">
+                  <Label className="cursor-inherit">{option.label}</Label>
+                  <span className="block text-xs text-muted-foreground">{option.description}</span>
+                </span>
+                <span
+                  aria-hidden
+                  className={cn(
+                    'flex size-4 shrink-0 items-center justify-center rounded border text-[10px]',
+                    enabled
+                      ? 'border-foreground/50 bg-foreground text-background'
+                      : 'border-border bg-background'
+                  )}
+                >
+                  {enabled ? <Check className="size-3" /> : null}
+                </span>
+              </button>
+            )
+          })}
+        </SearchableSetting>
+      </section>
+    </div>
+  )
+}

--- a/src/renderer/src/components/settings/tasks-search.ts
+++ b/src/renderer/src/components/settings/tasks-search.ts
@@ -1,0 +1,9 @@
+import type { SettingsSearchEntry } from './settings-search'
+
+export const TASKS_PANE_SEARCH_ENTRIES: SettingsSearchEntry[] = [
+  {
+    title: 'Task Providers',
+    description: 'Choose which task providers appear in the Tasks page and sidebar shortcuts.',
+    keywords: ['tasks', 'provider', 'source', 'github', 'gitlab', 'linear', 'display', 'hide']
+  }
+]

--- a/src/renderer/src/components/sidebar/SidebarNav.tsx
+++ b/src/renderer/src/components/sidebar/SidebarNav.tsx
@@ -7,6 +7,10 @@ import { isGitRepoKind } from '../../../../shared/repo-kind'
 import { getTaskPresetQuery, PER_REPO_FETCH_LIMIT } from '@/lib/new-workspace'
 import { LinearIcon } from '@/components/icons/LinearIcon'
 import { migrationUnsupportedToAgentStatusEntry } from '@/lib/migration-unsupported-agent-entry'
+import {
+  normalizeVisibleTaskProviders,
+  resolveVisibleTaskProvider
+} from '../../../../shared/task-providers'
 
 const isMac = typeof navigator !== 'undefined' && navigator.userAgent.includes('Mac')
 
@@ -22,6 +26,16 @@ const SidebarNav = React.memo(function SidebarNav() {
   // Why: the setting is opt-out (default true). `!== false` keeps the button
   // visible for users whose persisted settings predate this field.
   const showTasksButton = useAppStore((s) => s.settings?.showTasksButton !== false)
+  const rawVisibleTaskProviders = useAppStore((s) => s.settings?.visibleTaskProviders)
+  const defaultTaskSource = useAppStore((s) => s.settings?.defaultTaskSource ?? 'github')
+  const visibleTaskProviders = React.useMemo(
+    () => normalizeVisibleTaskProviders(rawVisibleTaskProviders),
+    [rawVisibleTaskProviders]
+  )
+  const resolvedDefaultTaskSource = React.useMemo(
+    () => resolveVisibleTaskProvider(defaultTaskSource, visibleTaskProviders),
+    [defaultTaskSource, visibleTaskProviders]
+  )
 
   // Why: warm the GitHub work-item cache on hover/focus so by the time the
   // user's click finishes the round-trip has either completed or is already
@@ -30,7 +44,7 @@ const SidebarNav = React.memo(function SidebarNav() {
   const activeRepoId = useAppStore((s) => s.activeRepoId)
   const defaultTaskViewPreset = useAppStore((s) => s.settings?.defaultTaskViewPreset ?? 'all')
   const handlePrefetch = React.useCallback(() => {
-    if (!canBrowseTasks) {
+    if (!canBrowseTasks || resolvedDefaultTaskSource !== 'github') {
       return
     }
     const activeRepo = activeRepoId ? (repoMap.get(activeRepoId) ?? null) : null
@@ -48,7 +62,15 @@ const SidebarNav = React.memo(function SidebarNav() {
         getTaskPresetQuery(defaultTaskViewPreset)
       )
     }
-  }, [activeRepoId, canBrowseTasks, defaultTaskViewPreset, prefetchWorkItems, repoMap, repos])
+  }, [
+    activeRepoId,
+    canBrowseTasks,
+    defaultTaskViewPreset,
+    prefetchWorkItems,
+    repoMap,
+    repos,
+    resolvedDefaultTaskSource
+  ])
 
   const tasksActive = activeView === 'tasks'
   const automationsActive = activeView === 'automations'
@@ -119,49 +141,57 @@ const SidebarNav = React.memo(function SidebarNav() {
           />
           <span className="flex-1">Tasks</span>
           <span className="flex items-center gap-1">
-            <span
-              role="button"
-              tabIndex={-1}
-              onClick={(e) => {
-                e.stopPropagation()
-                if (!canBrowseTasks) {
-                  return
-                }
-                openTaskPage({ taskSource: 'github' })
-              }}
-              className="rounded p-0.5 text-muted-foreground/70 transition-colors hover:text-foreground"
-            >
-              <Github className="size-3.5" aria-hidden />
-            </span>
-            <span
-              role="button"
-              tabIndex={-1}
-              onClick={(e) => {
-                e.stopPropagation()
-                if (!canBrowseTasks) {
-                  return
-                }
-                openTaskPage({ taskSource: 'gitlab' })
-              }}
-              className="rounded p-0.5 text-muted-foreground/70 transition-colors hover:text-foreground"
-              aria-label="Open GitLab tasks"
-            >
-              <Gitlab className="size-3.5" aria-hidden />
-            </span>
-            <span
-              role="button"
-              tabIndex={-1}
-              onClick={(e) => {
-                e.stopPropagation()
-                if (!canBrowseTasks) {
-                  return
-                }
-                openTaskPage({ taskSource: 'linear' })
-              }}
-              className="rounded p-0.5 text-muted-foreground/70 transition-colors hover:text-foreground"
-            >
-              <LinearIcon className="size-3.5" />
-            </span>
+            {visibleTaskProviders.includes('github') ? (
+              <span
+                role="button"
+                tabIndex={-1}
+                onClick={(e) => {
+                  e.stopPropagation()
+                  if (!canBrowseTasks) {
+                    return
+                  }
+                  openTaskPage({ taskSource: 'github' })
+                }}
+                className="rounded p-0.5 text-muted-foreground/70 transition-colors hover:text-foreground"
+                aria-label="Open GitHub tasks"
+              >
+                <Github className="size-3.5" aria-hidden />
+              </span>
+            ) : null}
+            {visibleTaskProviders.includes('gitlab') ? (
+              <span
+                role="button"
+                tabIndex={-1}
+                onClick={(e) => {
+                  e.stopPropagation()
+                  if (!canBrowseTasks) {
+                    return
+                  }
+                  openTaskPage({ taskSource: 'gitlab' })
+                }}
+                className="rounded p-0.5 text-muted-foreground/70 transition-colors hover:text-foreground"
+                aria-label="Open GitLab tasks"
+              >
+                <Gitlab className="size-3.5" aria-hidden />
+              </span>
+            ) : null}
+            {visibleTaskProviders.includes('linear') ? (
+              <span
+                role="button"
+                tabIndex={-1}
+                onClick={(e) => {
+                  e.stopPropagation()
+                  if (!canBrowseTasks) {
+                    return
+                  }
+                  openTaskPage({ taskSource: 'linear' })
+                }}
+                className="rounded p-0.5 text-muted-foreground/70 transition-colors hover:text-foreground"
+                aria-label="Open Linear tasks"
+              >
+                <LinearIcon className="size-3.5" />
+              </span>
+            ) : null}
           </span>
         </button>
       ) : null}

--- a/src/renderer/src/store/slices/settings.ts
+++ b/src/renderer/src/store/slices/settings.ts
@@ -8,6 +8,7 @@ import {
   getRemoteRuntimeTerminalHandle
 } from '@/runtime/runtime-terminal-stream'
 import { normalizeTerminalQuickCommands } from '../../../../shared/terminal-quick-commands'
+import { normalizeVisibleTaskProviders } from '../../../../shared/task-providers'
 
 export type SettingsSlice = {
   settings: GlobalSettings | null
@@ -227,6 +228,11 @@ export const createSettingsSlice: StateCreator<AppState, [], [], SettingsSlice> 
       if ('terminalQuickCommands' in updates) {
         sanitizedUpdates.terminalQuickCommands = normalizeTerminalQuickCommands(
           updates.terminalQuickCommands
+        )
+      }
+      if ('visibleTaskProviders' in updates) {
+        sanitizedUpdates.visibleTaskProviders = normalizeVisibleTaskProviders(
+          updates.visibleTaskProviders
         )
       }
       await window.api.settings.set(sanitizedUpdates)

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -8,6 +8,7 @@ import type {
   PersistedTrustedOrcaHooks,
   PersistedUIState,
   StatusBarItem,
+  TaskProvider,
   TaskResumeState,
   TaskViewPresetId,
   TuiAgent,
@@ -17,6 +18,10 @@ import type {
 } from '../../../../shared/types'
 import { PET_SIZE_DEFAULT, PET_SIZE_MAX, PET_SIZE_MIN } from '../../../../shared/types'
 import { PER_REPO_FETCH_LIMIT } from '../../../../shared/work-items'
+import {
+  normalizeVisibleTaskProviders,
+  resolveVisibleTaskProvider
+} from '../../../../shared/task-providers'
 import {
   DEFAULT_STATUS_BAR_ITEMS,
   DEFAULT_WORKTREE_CARD_PROPERTIES
@@ -211,7 +216,7 @@ export type UISlice = {
   taskPageData: {
     preselectedRepoId?: string
     prefilledName?: string
-    taskSource?: 'github' | 'linear' | 'gitlab'
+    taskSource?: TaskProvider
   }
   taskResumeState: TaskResumeState | undefined
   setTaskResumeState: (updates: Partial<TaskResumeState>) => void
@@ -257,6 +262,7 @@ export type UISlice = {
       | 'general'
       | 'browser'
       | 'appearance'
+      | 'tasks'
       | 'terminal'
       | 'computer-use'
       | 'developer-permissions'
@@ -465,7 +471,11 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
     // be deduped. This removes ~300–800ms of perceived latency on initial
     // page load.
     const state = get()
-    const resolvedSource = data.taskSource ?? state.settings?.defaultTaskSource ?? 'github'
+    const visibleTaskProviders = normalizeVisibleTaskProviders(state.settings?.visibleTaskProviders)
+    const resolvedSource = resolveVisibleTaskProvider(
+      data.taskSource ?? state.settings?.defaultTaskSource,
+      visibleTaskProviders
+    )
     const resolvedMode = state.taskResumeState?.githubMode ?? 'items'
     if (resolvedSource === 'github' && resolvedMode === 'items') {
       const eligibleRepos = state.repos.filter((repo) => isGitRepoKind(repo) && repo.path)

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -14,6 +14,7 @@ import { DEFAULT_TERMINAL_FONT_WEIGHT } from './terminal-fonts'
 import { getDefaultTerminalQuickCommands } from './terminal-quick-commands'
 import type { VoiceSettings } from './speech-types'
 import { cloneDefaultWorkspaceStatuses } from './workspace-statuses'
+import { TASK_PROVIDERS } from './task-providers'
 
 export const SCHEMA_VERSION = 1
 export const DEFAULT_APP_FONT_FAMILY = 'Geist'
@@ -230,6 +231,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     skipDeleteAutomationConfirm: false,
     defaultTaskViewPreset: 'all',
     defaultTaskSource: 'github',
+    visibleTaskProviders: [...TASK_PROVIDERS],
     defaultRepoSelection: null,
     defaultLinearTeamSelection: null,
     opencodeSessionCookie: '',

--- a/src/shared/task-providers.test.ts
+++ b/src/shared/task-providers.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeVisibleTaskProviders, resolveVisibleTaskProvider } from './task-providers'
+
+describe('task providers', () => {
+  it('normalizes provider lists while preserving supported order', () => {
+    expect(normalizeVisibleTaskProviders(['gitlab', 'unknown', 'gitlab', 'linear'])).toEqual([
+      'gitlab',
+      'linear'
+    ])
+  })
+
+  it('falls back to all providers when none are visible', () => {
+    expect(normalizeVisibleTaskProviders([])).toEqual(['github', 'gitlab', 'linear'])
+  })
+
+  it('resolves hidden preferred providers to the first visible provider', () => {
+    expect(resolveVisibleTaskProvider('github', ['linear'])).toBe('linear')
+  })
+})

--- a/src/shared/task-providers.ts
+++ b/src/shared/task-providers.ts
@@ -1,0 +1,35 @@
+export type TaskProvider = 'github' | 'gitlab' | 'linear'
+
+export const TASK_PROVIDERS: readonly TaskProvider[] = ['github', 'gitlab', 'linear']
+
+const TASK_PROVIDER_SET = new Set<TaskProvider>(TASK_PROVIDERS)
+
+export function normalizeVisibleTaskProviders(value: unknown): TaskProvider[] {
+  if (!Array.isArray(value)) {
+    return [...TASK_PROVIDERS]
+  }
+
+  const normalized: TaskProvider[] = []
+  for (const provider of value) {
+    if (!TASK_PROVIDER_SET.has(provider as TaskProvider)) {
+      continue
+    }
+    if (!normalized.includes(provider as TaskProvider)) {
+      normalized.push(provider as TaskProvider)
+    }
+  }
+
+  // Why: at least one provider must remain visible so the Tasks surface always
+  // has a valid source to select after settings hydration or manual edits.
+  return normalized.length > 0 ? normalized : [...TASK_PROVIDERS]
+}
+
+export function resolveVisibleTaskProvider(
+  preferred: TaskProvider | null | undefined,
+  visibleProviders: readonly TaskProvider[]
+): TaskProvider {
+  if (preferred && visibleProviders.includes(preferred)) {
+    return preferred
+  }
+  return visibleProviders[0] ?? 'github'
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -6,10 +6,12 @@ import type { GitHubProjectSettings } from './github-project-types'
 import type { MigrationUnsupportedPtyEntry } from './agent-status-types'
 import type { VoiceSettings } from './speech-types'
 import type { GitLabProjectSettings } from './gitlab-types'
+import type { TaskProvider } from './task-providers'
 
 // Re-exported for backward compat with renderer call sites that import
 // `WorkspaceCreateTelemetrySource` from '../../../shared/types'.
 export type { WorkspaceSource as WorkspaceCreateTelemetrySource } from './telemetry-events'
+export type { TaskProvider } from './task-providers'
 
 // ─── Shell PATH hydration ────────────────────────────────────────────
 // Why: shared so the main-side `HydrationResult` discriminator and the
@@ -1348,7 +1350,11 @@ export type GlobalSettings = {
   defaultTaskViewPreset: TaskViewPresetId
   /** Why: persists the user's last-used task source so the Tasks page
    *  reopens to the same provider instead of always defaulting to GitHub. */
-  defaultTaskSource: 'github' | 'linear' | 'gitlab'
+  defaultTaskSource: TaskProvider
+  /** Why: users may only work from one hosted task system. Persisting this
+   *  list hides unused providers from Tasks chrome and sidebar shortcuts while
+   *  leaving the chosen default source stable when it is still visible. */
+  visibleTaskProviders: TaskProvider[]
   /** Why: persists the user's repo selection in the cross-repo tasks view.
    *  `null` means sticky-all — every eligible repo is selected, including
    *  repos added in future sessions, so the "All repos" label stays


### PR DESCRIPTION
## Summary
- Add a Tasks settings section for choosing which task providers are visible
- Make the setting explicit: it controls the Tasks page source picker and sidebar provider shortcuts
- Persist and normalize visibleTaskProviders so the Tasks surface always has at least one visible provider

## Verification
- pnpm run lint
- pnpm run tc
- pnpm exec vitest run --config config/vitest.config.ts src/shared/task-providers.test.ts src/main/persistence.test.ts src/renderer/src/store/slices/settings.test.ts src/renderer/src/store/slices/ui.test.ts src/main/codex-accounts/runtime-home-service.test.ts src/main/codex-accounts/service.test.ts