### PR TITLE
Fix slow quick workspace creation

### DIFF
--- a/src/renderer/src/components/NewWorkspaceComposerModal.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerModal.tsx
@@ -112,7 +112,9 @@ function QuickTabBody({
     ...(modalData.initialBaseBranch ? { initialBaseBranch: modalData.initialBaseBranch } : {}),
     persistDraft: false,
     onCreated: onClose,
-    ...(modalData.telemetrySource ? { telemetrySource: modalData.telemetrySource } : {})
+    ...(modalData.telemetrySource ? { telemetrySource: modalData.telemetrySource } : {}),
+    enableIssueAutomation: false,
+    createGateMode: 'quick'
   })
   // Why: the composer's built-in `onOpenAgentSettings` handler navigates to
   // the settings page and closes the modal. For the quick-create flow we want

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -46,13 +46,21 @@ import {
   renderIssueCommandTemplate,
   type LinkedWorkItemSummary
 } from '@/lib/new-workspace'
+import {
+  getFullComposerCreateDisabled,
+  getQuickComposerCreateDisabled
+} from '@/lib/new-workspace-create-gates'
 import { getSuggestedCreatureName } from '@/components/sidebar/worktree-name-suggestions'
 import type { SmartWorkspaceNameSelection } from '@/components/new-workspace/SmartWorkspaceNameField'
 import { ensureHooksConfirmed } from '@/lib/ensure-hooks-confirmed'
 import { normalizeSparseDirectoryLines, sparseDirectoriesMatch } from '@/lib/sparse-paths'
 import { joinPath } from '@/lib/path'
 import { importExternalPathsToRuntime } from '@/runtime/runtime-file-client'
-import { checkRuntimeHooks, readRuntimeIssueCommand } from '@/runtime/runtime-hooks-client'
+import {
+  checkRuntimeHooks,
+  readRuntimeIssueCommand,
+  type HookCheckResult
+} from '@/runtime/runtime-hooks-client'
 
 export type UseComposerStateOptions = {
   initialRepoId?: string
@@ -80,6 +88,11 @@ export type UseComposerStateOptions = {
    *  `sidebar`, keyboard shortcut → `shortcut`). Omitted callers default
    *  to `unknown` at the IPC boundary. */
   telemetrySource?: WorkspaceCreateTelemetrySource
+  /** Quick-create launches a blank/draft agent session and does not run
+   *  issueCommand automation, so it can skip the issue-command probe that the
+   *  full composer needs for linked-item prompt previews. */
+  enableIssueAutomation?: boolean
+  createGateMode?: 'full' | 'quick'
 }
 
 export type ComposerCardProps = {
@@ -198,7 +211,9 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     onCreated,
     repoIdOverride,
     onRepoIdOverrideChange,
-    telemetrySource
+    telemetrySource,
+    enableIssueAutomation = true,
+    createGateMode = 'full'
   } = options
 
   // Why: each `useAppStore(s => s.someAction)` registers its own equality
@@ -256,6 +271,8 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
 
   const [internalRepoId, setInternalRepoId] = useState<string>(resolvedInitialRepoId)
   const repoId = repoIdOverride ?? internalRepoId
+  const repoIdRef = useRef(repoId)
+  repoIdRef.current = repoId
   const setRepoId = useCallback(
     (value: string) => {
       if (onRepoIdOverrideChange) {
@@ -414,6 +431,31 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
   selectedRepoPathRef.current = selectedRepoPath
   const settingsRef = useRef(settings)
   settingsRef.current = settings
+  const hookCheckRef = useRef<{
+    key: string
+    promise: Promise<HookCheckResult>
+  } | null>(null)
+  const loadHookCheckForRepo = useCallback((targetRepoId: string): Promise<HookCheckResult> => {
+    const key = `${settingsRef.current?.activeRuntimeEnvironmentId ?? 'local'}:${targetRepoId}`
+    const existing = hookCheckRef.current
+    if (existing?.key === key) {
+      return existing.promise
+    }
+    const promise = checkRuntimeHooks(settingsRef.current, targetRepoId)
+    hookCheckRef.current = { key, promise }
+    return promise
+  }, [])
+  const commitHookCheckIfCurrent = useCallback(
+    (targetRepoId: string, hooks: OrcaHooks | null): boolean => {
+      if (repoIdRef.current !== targetRepoId) {
+        return false
+      }
+      setYamlHooks(hooks)
+      setCheckedHooksRepoId(targetRepoId)
+      return true
+    },
+    []
+  )
   useEffect(() => {
     if (!selectedRepo || !selectedRepoPath) {
       setSelectedRepoSlug(null)
@@ -515,14 +557,17 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     [selectedRepo, yamlHooks]
   )
   const setupPolicy: SetupRunPolicy = selectedRepo?.hookSettings?.setupRunPolicy ?? 'run-by-default'
-  const hasIssueAutomationConfig = issueCommandTemplate.length > 0
+  const hasIssueAutomationConfig = enableIssueAutomation && issueCommandTemplate.length > 0
   const canOfferIssueAutomation = parsedLinkedIssueNumber !== null && hasIssueAutomationConfig
   // Why: the "no prompt + linked item" path below rehydrates the issueCommand
   // template into the main startup prompt. When that happens we suppress the
   // separate split pane that would otherwise run the same command twice.
-  const willApplyIssueCommandAsPrompt = !agentPrompt.trim() && Boolean(linkedWorkItem)
+  const willApplyIssueCommandAsPrompt =
+    enableIssueAutomation && !agentPrompt.trim() && Boolean(linkedWorkItem)
   const shouldWaitForIssueAutomationCheck =
-    (parsedLinkedIssueNumber !== null || willApplyIssueCommandAsPrompt) && !hasLoadedIssueCommand
+    enableIssueAutomation &&
+    (parsedLinkedIssueNumber !== null || willApplyIssueCommandAsPrompt) &&
+    !hasLoadedIssueCommand
   const shouldRunIssueAutomation = canOfferIssueAutomation && !willApplyIssueCommandAsPrompt
   const requiresExplicitSetupChoice = Boolean(setupConfig) && setupPolicy === 'ask'
   const resolvedSetupDecision =
@@ -561,7 +606,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
   // the common "paste a link and hit enter" flow produce a useful agent task
   // instead of a bare URL bullet.
   const shouldApplyLinkedOnlyTemplate =
-    !agentPrompt.trim() && Boolean(linkedWorkItem) && hasLoadedIssueCommand
+    enableIssueAutomation && !agentPrompt.trim() && Boolean(linkedWorkItem) && hasLoadedIssueCommand
   const linkedOnlyTemplatePrompt = useMemo(() => {
     if (!shouldApplyLinkedOnlyTemplate || !linkedWorkItem) {
       return ''
@@ -712,19 +757,24 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     setYamlHooks(null)
     setCheckedHooksRepoId(null)
 
-    void checkRuntimeHooks(settings, repoId)
+    void loadHookCheckForRepo(repoId)
       .then((result) => {
         if (!cancelled) {
-          setYamlHooks(result.hooks)
-          setCheckedHooksRepoId(repoId)
+          commitHookCheckIfCurrent(repoId, result.hooks)
         }
       })
       .catch(() => {
         if (!cancelled) {
-          setYamlHooks(null)
-          setCheckedHooksRepoId(repoId)
+          commitHookCheckIfCurrent(repoId, null)
         }
       })
+
+    if (!enableIssueAutomation) {
+      setHasLoadedIssueCommand(true)
+      return () => {
+        cancelled = true
+      }
+    }
 
     void readRuntimeIssueCommand(settings, repoId)
       .then((result) => {
@@ -743,7 +793,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     return () => {
       cancelled = true
     }
-  }, [repoId, settings])
+  }, [commitHookCheckIfCurrent, enableIssueAutomation, loadHookCheckForRepo, repoId, settings])
 
   // Why: warm the Start-from picker's PR cache on composer mount and whenever
   // the selected repo changes so opening the picker paints instantly from
@@ -1673,7 +1723,6 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
         !repoId ||
         !workspaceName ||
         !selectedRepo ||
-        shouldWaitForSetupCheck ||
         (requiresExplicitSetupChoice && !setupDecision) ||
         sparseError !== null
       ) {
@@ -1683,11 +1732,37 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       setCreateError(null)
       setCreating(true)
       try {
+        let submitSetupConfig = setupConfig
+        let submitResolvedSetupDecision = resolvedSetupDecision
+        if (checkedHooksRepoId !== repoId) {
+          let hookCheck: HookCheckResult
+          try {
+            hookCheck = await loadHookCheckForRepo(repoId)
+          } catch {
+            hookCheck = { hasHooks: false, hooks: null, mayNeedUpdate: false }
+          }
+          if (!commitHookCheckIfCurrent(repoId, hookCheck.hooks)) {
+            return
+          }
+          submitSetupConfig = getSetupConfig(selectedRepo, hookCheck.hooks)
+          submitResolvedSetupDecision =
+            setupDecision ??
+            (!submitSetupConfig || setupPolicy === 'ask'
+              ? null
+              : setupPolicy === 'run-by-default'
+                ? 'run'
+                : 'skip')
+        }
+        if (submitSetupConfig && setupPolicy === 'ask' && !setupDecision) {
+          setAdvancedOpen(true)
+          return
+        }
+
         const trustDecision = await ensureHooksConfirmed(useAppStore.getState(), repoId, 'setup')
         const effectiveSetupDecision: SetupDecision =
           trustDecision === 'skip'
             ? 'skip'
-            : ((resolvedSetupDecision ?? 'inherit') as SetupDecision)
+            : ((submitResolvedSetupDecision ?? 'inherit') as SetupDecision)
 
         const linkedLinearIssue = linkedWorkItem?.linearIdentifier
         const result = await createWorktree(
@@ -1858,18 +1933,28 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       sparseError,
       effectivePresetId,
       telemetrySource,
-      shouldWaitForSetupCheck
+      checkedHooksRepoId,
+      commitHookCheckIfCurrent,
+      loadHookCheckForRepo,
+      setupConfig,
+      setupPolicy
     ]
   )
 
+  const createGateInput = {
+    repoId,
+    workspaceSeedName,
+    creating,
+    shouldWaitForSetupCheck,
+    shouldWaitForIssueAutomationCheck,
+    requiresExplicitSetupChoice,
+    hasSetupDecision: Boolean(setupDecision),
+    sparseError
+  }
   const createDisabled =
-    !repoId ||
-    !workspaceSeedName ||
-    creating ||
-    shouldWaitForSetupCheck ||
-    shouldWaitForIssueAutomationCheck ||
-    (requiresExplicitSetupChoice && !setupDecision) ||
-    sparseError !== null
+    createGateMode === 'quick'
+      ? getQuickComposerCreateDisabled(createGateInput)
+      : getFullComposerCreateDisabled(createGateInput)
 
   const cardProps: ComposerCardProps = {
     eligibleRepos,

--- a/src/renderer/src/lib/new-workspace-create-gates.test.ts
+++ b/src/renderer/src/lib/new-workspace-create-gates.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getFullComposerCreateDisabled,
+  getQuickComposerCreateDisabled,
+  type ComposerCreateGateInput
+} from './new-workspace-create-gates'
+
+const readyInput: ComposerCreateGateInput = {
+  repoId: 'repo-1',
+  workspaceSeedName: 'feature',
+  creating: false,
+  shouldWaitForSetupCheck: false,
+  shouldWaitForIssueAutomationCheck: false,
+  requiresExplicitSetupChoice: false,
+  hasSetupDecision: false,
+  sparseError: null
+}
+
+describe('new workspace create gates', () => {
+  it('keeps the full composer disabled while setup and issue automation probes are pending', () => {
+    expect(
+      getFullComposerCreateDisabled({
+        ...readyInput,
+        shouldWaitForSetupCheck: true
+      })
+    ).toBe(true)
+
+    expect(
+      getFullComposerCreateDisabled({
+        ...readyInput,
+        shouldWaitForIssueAutomationCheck: true
+      })
+    ).toBe(true)
+  })
+
+  it('lets quick create submit while background setup and issue probes are pending', () => {
+    expect(
+      getQuickComposerCreateDisabled({
+        ...readyInput,
+        shouldWaitForSetupCheck: true,
+        shouldWaitForIssueAutomationCheck: true
+      })
+    ).toBe(false)
+  })
+
+  it('still blocks quick create for missing form state and explicit setup choices', () => {
+    expect(getQuickComposerCreateDisabled({ ...readyInput, repoId: '' })).toBe(true)
+    expect(getQuickComposerCreateDisabled({ ...readyInput, workspaceSeedName: '' })).toBe(true)
+    expect(getQuickComposerCreateDisabled({ ...readyInput, creating: true })).toBe(true)
+    expect(
+      getQuickComposerCreateDisabled({
+        ...readyInput,
+        requiresExplicitSetupChoice: true,
+        hasSetupDecision: false
+      })
+    ).toBe(true)
+    expect(getQuickComposerCreateDisabled({ ...readyInput, sparseError: 'Bad sparse path' })).toBe(
+      true
+    )
+  })
+})

--- a/src/renderer/src/lib/new-workspace-create-gates.ts
+++ b/src/renderer/src/lib/new-workspace-create-gates.ts
@@ -1,0 +1,36 @@
+export type ComposerCreateGateInput = {
+  repoId: string
+  workspaceSeedName: string
+  creating: boolean
+  shouldWaitForSetupCheck: boolean
+  shouldWaitForIssueAutomationCheck: boolean
+  requiresExplicitSetupChoice: boolean
+  hasSetupDecision: boolean
+  sparseError: string | null
+}
+
+function hasBlockingCreateState(input: ComposerCreateGateInput): boolean {
+  return (
+    !input.repoId ||
+    !input.workspaceSeedName ||
+    input.creating ||
+    (input.requiresExplicitSetupChoice && !input.hasSetupDecision) ||
+    input.sparseError !== null
+  )
+}
+
+export function getFullComposerCreateDisabled(input: ComposerCreateGateInput): boolean {
+  return (
+    hasBlockingCreateState(input) ||
+    input.shouldWaitForSetupCheck ||
+    input.shouldWaitForIssueAutomationCheck
+  )
+}
+
+export function getQuickComposerCreateDisabled(input: ComposerCreateGateInput): boolean {
+  // Why: Cmd/Ctrl+N quick create can resolve setup hooks inside the submit
+  // handler, and it never runs issue-command automation. Keeping those
+  // background probes out of the disabled gate makes the primary action usable
+  // as soon as the form has enough local state to submit.
+  return hasBlockingCreateState(input)
+}


### PR DESCRIPTION
## Summary
- keep Cmd/Ctrl+N quick-create enabled while hook and issue-command probes are still pending
- skip issue-command automation reads for the quick-create modal, since that path launches blank/draft sessions instead
- resolve setup hook state on submit when needed, with guarded hook-check commits to avoid stale repo races

## Verification
- pnpm exec vitest run src/renderer/src/lib/new-workspace-create-gates.test.ts --config config/vitest.config.ts
- pnpm exec oxlint src/renderer/src/components/NewWorkspaceComposerModal.tsx src/renderer/src/hooks/useComposerState.ts src/renderer/src/lib/new-workspace-create-gates.ts src/renderer/src/lib/new-workspace-create-gates.test.ts
- pnpm typecheck

Note: an initial broad Vitest invocation accidentally ran the full suite and failed only on local better-sqlite3 native ABI mismatch (compiled for NODE_MODULE_VERSION 145, current Node requires 137).