### PR TITLE
Fix Linux terminal WebGL glyph corruption

### DIFF
--- a/src/renderer/src/components/settings/TerminalPane.tsx
+++ b/src/renderer/src/components/settings/TerminalPane.tsx
@@ -477,7 +477,7 @@ export function TerminalPane({
 
         <SearchableSetting
           title="GPU Acceleration"
-          description="Controls whether the terminal uses xterm.js WebGL rendering. Auto mirrors VS Code: try GPU and fall back to DOM if WebGL fails."
+          description="Controls whether the terminal uses xterm.js WebGL rendering. Auto uses DOM on Linux to avoid driver glyph corruption, and otherwise tries WebGL with DOM fallback."
           keywords={[
             'terminal',
             'gpu',
@@ -513,7 +513,7 @@ export function TerminalPane({
               ? 'WebGL is disabled; xterm uses the DOM renderer for maximum compatibility.'
               : settings.terminalGpuAcceleration === 'on'
                 ? 'WebGL is always attempted for terminal panes.'
-                : 'Auto tries WebGL for performance and falls back to the DOM renderer if WebGL fails, matching VS Code.'}
+                : 'Auto uses the DOM renderer on Linux to avoid GPU glyph corruption, and otherwise tries WebGL with DOM fallback.'}
           </p>
         </SearchableSetting>
       </section>

--- a/src/renderer/src/components/settings/terminal-search.ts
+++ b/src/renderer/src/components/settings/terminal-search.ts
@@ -45,7 +45,7 @@ export const TERMINAL_RENDERING_SEARCH_ENTRIES: SettingsSearchEntry[] = [
   {
     title: 'GPU Acceleration',
     description:
-      'Controls whether the terminal uses xterm.js WebGL rendering. Auto mirrors VS Code: try GPU and fall back to DOM if WebGL fails.',
+      'Controls whether the terminal uses xterm.js WebGL rendering. Auto uses DOM on Linux to avoid driver glyph corruption, and otherwise tries WebGL with DOM fallback.',
     keywords: [
       'terminal',
       'gpu',

--- a/src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts
@@ -83,6 +83,10 @@ describe('attachWebgl', () => {
     webglMock.dispose.mockClear()
     vi.mocked(WebglAddon).mockClear()
     resetTerminalWebglSuggestion()
+    vi.stubGlobal('navigator', {
+      platform: 'MacIntel',
+      userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)'
+    })
     vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
       callback(16)
       return 1
@@ -139,6 +143,32 @@ describe('attachWebgl', () => {
 
     expect(pane.webglAddon).toBeNull()
     expect(pane.terminal.loadAddon).not.toHaveBeenCalled()
+  })
+
+  it('uses DOM rendering for auto GPU acceleration on Linux', () => {
+    vi.stubGlobal('navigator', {
+      platform: 'Linux x86_64',
+      userAgent: 'Mozilla/5.0 (X11; Linux x86_64)'
+    })
+    const pane = createPane()
+
+    attachWebgl(pane)
+
+    expect(pane.webglAddon).toBeNull()
+    expect(pane.terminal.loadAddon).not.toHaveBeenCalled()
+  })
+
+  it('still allows forced WebGL on Linux', () => {
+    vi.stubGlobal('navigator', {
+      platform: 'Linux x86_64',
+      userAgent: 'Mozilla/5.0 (X11; Linux x86_64)'
+    })
+    const pane = createPane()
+    pane.terminalGpuAcceleration = 'on'
+
+    attachWebgl(pane)
+
+    expect(pane.terminal.loadAddon).toHaveBeenCalledTimes(1)
   })
 
   it('uses DOM for later auto panes after WebGL attach fails until the suggestion resets', () => {

--- a/src/renderer/src/lib/pane-manager/pane-terminal-gpu-acceleration.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-gpu-acceleration.test.ts
@@ -72,4 +72,18 @@ describe('applyTerminalGpuAcceleration', () => {
     expect(pane.webglAddon).toBeNull()
     expect(pane.fitAddon.fit).toHaveBeenCalledTimes(1)
   })
+
+  it('returns Linux panes to DOM when switching from forced WebGL back to auto', () => {
+    vi.stubGlobal('navigator', {
+      platform: 'Linux x86_64',
+      userAgent: 'Mozilla/5.0 (X11; Linux x86_64)'
+    })
+    const pane = createPane()
+    const options: PaneManagerOptions = { terminalGpuAcceleration: 'on' }
+
+    applyTerminalGpuAcceleration([pane], options, 'auto')
+
+    expect(pane.webglAddon).toBeNull()
+    expect(pane.fitAddon.fit).toHaveBeenCalledTimes(1)
+  })
 })

--- a/src/renderer/src/lib/pane-manager/pane-terminal-gpu-acceleration.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-gpu-acceleration.ts
@@ -1,5 +1,10 @@
 import type { ManagedPaneInternal, PaneManagerOptions } from './pane-manager-types'
-import { attachWebgl, disposeWebgl, resetTerminalWebglSuggestion } from './pane-webgl-renderer'
+import {
+  attachWebgl,
+  disposeWebgl,
+  resetTerminalWebglSuggestion,
+  shouldUseTerminalWebgl
+} from './pane-webgl-renderer'
 import { safeFit } from './pane-tree-ops'
 
 export function applyTerminalGpuAcceleration(
@@ -15,7 +20,7 @@ export function applyTerminalGpuAcceleration(
   }
   for (const pane of panes) {
     pane.terminalGpuAcceleration = nextMode
-    if (nextMode === 'off' || (nextMode === 'auto' && pane.hasComplexScriptOutput)) {
+    if (!shouldUseTerminalWebgl(pane)) {
       disposeWebgl(pane, { refreshDimensions: true })
       continue
     }
@@ -23,8 +28,7 @@ export function applyTerminalGpuAcceleration(
       pane.gpuRenderingEnabled &&
       !pane.webglAddon &&
       !pane.webglAttachmentDeferred &&
-      !pane.webglDisabledAfterContextLoss &&
-      (nextMode === 'on' || !pane.hasComplexScriptOutput)
+      !pane.webglDisabledAfterContextLoss
     ) {
       attachWebgl(pane)
       safeFit(pane)

--- a/src/renderer/src/lib/pane-manager/pane-webgl-renderer.ts
+++ b/src/renderer/src/lib/pane-manager/pane-webgl-renderer.ts
@@ -10,9 +10,21 @@ export function resetTerminalWebglSuggestion(): void {
   suggestedRendererType = undefined
 }
 
-function shouldUseWebgl(pane: ManagedPaneInternal): boolean {
+function isLinuxRenderer(): boolean {
+  if (typeof navigator === 'undefined') {
+    return false
+  }
+  return navigator.platform.includes('Linux') || navigator.userAgent.includes('Linux')
+}
+
+export function shouldUseTerminalWebgl(pane: ManagedPaneInternal): boolean {
   if (pane.terminalGpuAcceleration === 'on') {
     return true
+  }
+  if (isLinuxRenderer()) {
+    // Why: multiple Linux/Wayland GPU stacks corrupt xterm's WebGL glyph atlas
+    // without raising context loss; tab switching only masks it by rebuilding WebGL.
+    return false
   }
   return (
     pane.terminalGpuAcceleration === 'auto' &&
@@ -71,7 +83,7 @@ export function attachWebgl(pane: ManagedPaneInternal): void {
   if (
     !ENABLE_WEBGL_RENDERER ||
     !pane.gpuRenderingEnabled ||
-    !shouldUseWebgl(pane) ||
+    !shouldUseTerminalWebgl(pane) ||
     pane.webglAttachmentDeferred ||
     pane.webglDisabledAfterContextLoss
   ) {

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -168,8 +168,8 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     terminalFontFamily: defaultTerminalFontFamily(),
     terminalFontWeight: DEFAULT_TERMINAL_FONT_WEIGHT,
     terminalLineHeight: 1,
-    // Why: VS Code defaults terminal GPU acceleration to "auto": prefer
-    // xterm WebGL for performance, but allow renderer failure to choose DOM.
+    // Why: keep the setting on "auto" so explicit user choices stay available,
+    // but renderer policy maps Linux auto to DOM to avoid GPU glyph corruption.
     terminalGpuAcceleration: 'auto',
     // Why 'auto': when the user has picked a known ligature font we want the
     // feature enabled by default, but we never force it if they pick a font

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1213,7 +1213,7 @@ export type GlobalSettings = {
   terminalFontWeight: number
   terminalLineHeight: number
   /** Mirrors VS Code's terminal.integrated.gpuAcceleration shape.
-   *  - 'auto': try xterm WebGL and fall back to DOM if the renderer fails.
+   *  - 'auto': use DOM on Linux; otherwise try xterm WebGL and fall back to DOM if the renderer fails.
    *  - 'on': always try xterm WebGL.
    *  - 'off': keep terminal rendering on xterm's DOM renderer. */
   terminalGpuAcceleration: 'auto' | 'on' | 'off'


### PR DESCRIPTION
Fixes #1930

## Summary

- Keep the default terminal GPU setting as `auto`, but map Linux `auto` to xterm's DOM renderer to avoid the WebGL glyph-atlas corruption path.
- Keep explicit `On` available for users who want to force WebGL.
- Apply the same policy when settings changes dispose or reattach WebGL, so tab switches, rendering resume, and pane reparenting do not re-enter the bad path on Linux auto.
- Update Settings copy and regression tests for Linux auto, forced WebGL, and switching from forced WebGL back to auto.

## Reproduction / Proof

The reported failure is Linux GPU/Wayland-driver specific, so the local proof uses the renderer seam directly: corrupt xterm's live WebGL glyph atlas after stable terminal output is written. That reproduces the observed symptom: readable output becomes garbled until the WebGL renderer is rebuilt. The fixed policy prevents Linux `auto` from loading WebGL, so the same atlas-corruption path is absent.

Proof harness results:

```text
before: renderer=WebGL, webglLoaded=true, atlasCorrupted=true
after:  renderer=DOM,   webglLoaded=false, atlasCorrupted=false
```

Before fix, Linux `auto` enters WebGL and the corrupted glyph atlas makes terminal output unreadable:

![Before fix: Linux Auto enters WebGL and glyph atlas corruption garbles terminal output](https://raw.githubusercontent.com/nwparker/orca/9407c18cc3af660bf91979331c724835d636ac02/issue-1930-before.png)

After fix, Linux `auto` stays on DOM and the same terminal output remains readable:

![After fix: Linux Auto stays on DOM and terminal output remains readable](https://raw.githubusercontent.com/nwparker/orca/9407c18cc3af660bf91979331c724835d636ac02/issue-1930-after.png)

## Reference OSS Check

- VS Code keeps the `auto` / `on` / `off` setting shape and falls back to DOM when WebGL cannot load.
- WaveTerm exposes an explicit disable-WebGL path.
- Tabby probes known bad WebGL renderers and falls back.
- Ghostty's native renderer uses explicit texture filtering rather than relying on glyph-atlas mipmaps.

This fix follows that pattern: keep a user override, but choose the conservative renderer for Linux `auto` after the latest xterm glyph patch still left #1930 reproducible.

## Validation

- `pnpm exec vitest run --config config/vitest.config.ts $(rg --files src/renderer/src/lib/pane-manager | rg '\.test\.ts$')` -> 109 passed
- `pnpm run typecheck`
- `pnpm lint`
- `pnpm exec oxfmt --check src/renderer/src/components/settings/TerminalPane.tsx src/renderer/src/components/settings/terminal-search.ts src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts src/renderer/src/lib/pane-manager/pane-terminal-gpu-acceleration.test.ts src/renderer/src/lib/pane-manager/pane-terminal-gpu-acceleration.ts src/renderer/src/lib/pane-manager/pane-webgl-renderer.ts src/shared/constants.ts src/shared/types.ts`
- `pnpm run build:electron-vite`
- `git diff --check`
)` -> 109 passed
- `pnpm run typecheck`
- `pnpm lint`
- `pnpm exec oxfmt --check src/renderer/src/components/settings/TerminalPane.tsx src/renderer/src/components/settings/terminal-search.ts src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts src/renderer/src/lib/pane-manager/pane-terminal-gpu-acceleration.test.ts src/renderer/src/lib/pane-manager/pane-terminal-gpu-acceleration.ts src/renderer/src/lib/pane-manager/pane-webgl-renderer.ts src/shared/constants.ts src/shared/types.ts`
- `pnpm run build:electron-vite`
- `git diff --check`
