### PR TITLE
Fix agent pane identity migration bridge

### DIFF
--- a/src/main/agent-hooks/server.test.ts
+++ b/src/main/agent-hooks/server.test.ts
@@ -2213,6 +2213,70 @@ describe('Last-status persistence', () => {
     }
   })
 
+  it('clears hydrated stable statuses when their persisted legacy alias PTY is cleared', async () => {
+    mkdirSync(join(userDataPath, 'agent-hooks'), { recursive: true })
+    writeFileSync(
+      lastStatusPath(),
+      JSON.stringify({
+        version: 2,
+        entries: {
+          'tab-1:0': {
+            paneKey: 'tab-1:0',
+            tabId: 'tab-1',
+            worktreeId: 'wt-1',
+            connectionId: null,
+            receivedAt: recentTs(),
+            stateStartedAt: recentTs(-1000),
+            payload: { state: 'working', prompt: 'legacy cached', agentType: 'claude' }
+          }
+        }
+      }),
+      'utf8'
+    )
+    const server = new AgentHookServer()
+    const statusListener = vi.fn()
+    server.registerPaneKeyAlias('tab-1:0', PANE, 'pty-1')
+    server.subscribeStatusChanges(statusListener)
+    await server.start({
+      env: 'production',
+      userDataPath
+    })
+    try {
+      expect(server.getStatusSnapshot()).toHaveLength(1)
+
+      server.clearPaneKeyAliasesForPty('pty-1')
+
+      expect(server.getStatusSnapshot()).toEqual([])
+      expect(statusListener).toHaveBeenCalledWith([])
+    } finally {
+      server.stop()
+    }
+  })
+
+  it('does not clear a stable status when alias cleanup no longer owns that pane', () => {
+    const server = new AgentHookServer()
+    server.registerPaneKeyAlias('tab-1:0', PANE, 'old-pty')
+    server.ingestRemote(
+      {
+        paneKey: PANE,
+        tabId: 'tab-1',
+        worktreeId: 'wt-1',
+        payload: { state: 'working', agentType: 'claude' }
+      },
+      'conn-1'
+    )
+
+    server.clearPaneKeyAliasesForPty('old-pty', { shouldClearStablePaneKey: () => false })
+
+    expect(server.getStatusSnapshot()).toEqual([
+      expect.objectContaining({
+        paneKey: PANE,
+        state: 'working',
+        agentType: 'claude'
+      })
+    ])
+  })
+
   it('drops a hydrate entry whose tabId disagrees with the paneKey prefix', async () => {
     mkdirSync(join(userDataPath, 'agent-hooks'), { recursive: true })
     writeFileSync(

--- a/src/main/agent-hooks/server.test.ts
+++ b/src/main/agent-hooks/server.test.ts
@@ -290,6 +290,50 @@ describe('AgentHookServer listener replay', () => {
     }
   })
 
+  it('maps registered legacy numeric HTTP pane keys to stable pane keys', async () => {
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    try {
+      server.registerPaneKeyAlias('tab-1:0', PANE)
+      const env = server.buildPtyEnv()
+      const response = await fetch(`http://127.0.0.1:${env.ORCA_AGENT_HOOK_PORT}/hook/claude`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Orca-Agent-Hook-Token': env.ORCA_AGENT_HOOK_TOKEN
+        },
+        body: JSON.stringify(
+          buildBody(
+            {
+              hook_event_name: 'UserPromptSubmit',
+              prompt: 'legacy pane'
+            },
+            { paneKey: 'tab-1:0' }
+          )
+        )
+      })
+      expect(response.status).toBe(204)
+
+      const listener = vi.fn()
+      server.setListener(listener)
+
+      expect(listener).toHaveBeenCalledWith(
+        expect.objectContaining({
+          paneKey: PANE,
+          tabId: 'tab-1',
+          worktreeId: 'wt-1',
+          payload: expect.objectContaining({
+            state: 'working',
+            prompt: 'legacy pane',
+            agentType: 'claude'
+          })
+        })
+      )
+    } finally {
+      server.stop()
+    }
+  })
+
   it('tracks hook posts with an empty paneKey before dropping them', async () => {
     const server = new AgentHookServer()
     await server.start({ env: 'production' })
@@ -2127,6 +2171,48 @@ describe('Last-status persistence', () => {
     }
   })
 
+  it('hydrates registered legacy numeric pane keys as stable pane status entries', async () => {
+    mkdirSync(join(userDataPath, 'agent-hooks'), { recursive: true })
+    writeFileSync(
+      lastStatusPath(),
+      JSON.stringify({
+        version: 2,
+        entries: {
+          'tab-1:0': {
+            paneKey: 'tab-1:0',
+            tabId: 'tab-1',
+            worktreeId: 'wt-1',
+            connectionId: null,
+            receivedAt: recentTs(),
+            stateStartedAt: recentTs(-1000),
+            payload: { state: 'working', prompt: 'legacy cached', agentType: 'claude' }
+          }
+        }
+      }),
+      'utf8'
+    )
+    const server = new AgentHookServer()
+    server.registerPaneKeyAlias('tab-1:0', PANE)
+    await server.start({
+      env: 'production',
+      userDataPath
+    })
+    try {
+      expect(server.getStatusSnapshot()).toEqual([
+        expect.objectContaining({
+          paneKey: PANE,
+          tabId: 'tab-1',
+          worktreeId: 'wt-1',
+          state: 'working',
+          prompt: 'legacy cached',
+          agentType: 'claude'
+        })
+      ])
+    } finally {
+      server.stop()
+    }
+  })
+
   it('drops a hydrate entry whose tabId disagrees with the paneKey prefix', async () => {
     mkdirSync(join(userDataPath, 'agent-hooks'), { recursive: true })
     writeFileSync(
@@ -2316,6 +2402,40 @@ describe('AgentHookServer ingestRemote', () => {
     )
     expect(listener).not.toHaveBeenCalled()
     expect(server.getStatusSnapshot()).toEqual([])
+  })
+
+  it('maps registered legacy numeric relay pane keys to stable pane keys', () => {
+    const server = new AgentHookServer()
+    const payload = parseAgentStatusPayload(
+      JSON.stringify({ state: 'working', prompt: 'p', agentType: 'claude' })
+    )
+    if (!payload) {
+      throw new Error('parseAgentStatusPayload returned null for a known-good fixture')
+    }
+    const listener = vi.fn()
+    server.registerPaneKeyAlias('tab-1:0', PANE)
+    server.setListener(listener)
+    server.ingestRemote(
+      { paneKey: 'tab-1:0', tabId: 'tab-1', worktreeId: 'wt-1', payload },
+      'conn-1'
+    )
+    expect(listener).toHaveBeenCalledWith(
+      expect.objectContaining({
+        paneKey: PANE,
+        tabId: 'tab-1',
+        worktreeId: 'wt-1',
+        connectionId: 'conn-1',
+        payload
+      })
+    )
+    expect(server.getStatusSnapshot()).toEqual([
+      expect.objectContaining({
+        paneKey: PANE,
+        tabId: 'tab-1',
+        state: 'working',
+        prompt: 'p'
+      })
+    ])
   })
 
   it('drops remote relay envelopes whose tabId disagrees with the paneKey tab', () => {

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -39,7 +39,7 @@ import {
   type AgentStatusState,
   normalizeAgentStatusPayload
 } from '../../shared/agent-status-types'
-import { parsePaneKey } from '../../shared/stable-pane-id'
+import { parseLegacyNumericPaneKey, parsePaneKey } from '../../shared/stable-pane-id'
 
 export type { AgentHookSource }
 
@@ -215,6 +215,7 @@ export class AgentHookServer {
   // Why: hydrated last-status rows are useful UI continuity, but they are not
   // evidence of live agent work in this main-process runtime.
   private runtimeObservedStatusPaneKeys = new Set<string>()
+  private legacyPaneKeyAliases = new Map<string, string>()
   // Why: full path to the on-disk last-status cache. Set in start() from
   // userDataPath. Null when the server runs without a userDataPath (e.g.
   // tests that skip the userDataPath option) — in that case, persistence is
@@ -305,6 +306,35 @@ export class AgentHookServer {
     }
   }
 
+  registerPaneKeyAlias(legacyPaneKey: string, stablePaneKey: string): void {
+    const legacy = parseLegacyNumericPaneKey(legacyPaneKey)
+    const stable = parsePaneKey(stablePaneKey)
+    if (!legacy || !stable || legacy.tabId !== stable.tabId) {
+      return
+    }
+    this.legacyPaneKeyAliases.set(legacy.paneKey, stablePaneKey)
+  }
+
+  private resolvePaneKeyAlias(paneKey: string): string {
+    return this.legacyPaneKeyAliases.get(paneKey) ?? paneKey
+  }
+
+  private normalizeHookBodyPaneKeyAlias(body: unknown): unknown {
+    if (typeof body !== 'object' || body === null) {
+      return body
+    }
+    const record = body as Record<string, unknown>
+    const rawPaneKey = typeof record.paneKey === 'string' ? record.paneKey.trim() : ''
+    const stablePaneKey = this.legacyPaneKeyAliases.get(rawPaneKey)
+    if (!stablePaneKey) {
+      return body
+    }
+    // Why: pre-migration live shells keep posting their immutable numeric
+    // ORCA_PANE_KEY. The reattach path proves the UUID leaf once, then this
+    // bridge lets hook caches and renderer state use only the stable key.
+    return { ...record, paneKey: stablePaneKey }
+  }
+
   /** Ingest a payload that arrived over the relay JSON-RPC channel rather
    *  than the local HTTP server. `connectionId` is the SshChannelMultiplexer
    *  identity Orca holds (the wire envelope carries connectionId: null and
@@ -341,7 +371,7 @@ export class AgentHookServer {
     // Why: match the listener's HTTP path — `normalizeHookPayload` trims and
     // length-caps paneKey before caching, so the cache key here must follow
     // the same rule or remote-vs-local events for the same pane would diverge.
-    const paneKey = envelope.paneKey.trim()
+    const paneKey = this.resolvePaneKeyAlias(envelope.paneKey.trim())
     const parsedPaneKey = parsePaneKey(paneKey)
     if (paneKey.length === 0) {
       track('agent_hook_unattributed', { reason: 'empty_pane_key' })
@@ -460,7 +490,12 @@ export class AgentHookServer {
         }
 
         trackEmptyPaneKeyHook(body)
-        const normalized = normalizeHookPayload(this.state, source, body, this.env)
+        const normalized = normalizeHookPayload(
+          this.state,
+          source,
+          this.normalizeHookBodyPaneKeyAlias(body),
+          this.env
+        )
         if (normalized) {
           const enriched = this.attachStatusTiming(normalized)
           this.runtimeObservedStatusPaneKeys.add(enriched.paneKey)
@@ -527,6 +562,7 @@ export class AgentHookServer {
     this.lastStatusFilePath = null
     this.lastWrittenJson = null
     this.runtimeObservedStatusPaneKeys.clear()
+    this.legacyPaneKeyAliases.clear()
     clearAllListenerCaches(this.state)
     this.notifyStatusChangeListeners()
   }
@@ -539,24 +575,32 @@ export class AgentHookServer {
    *  lands. clearPaneState (which wipes all three caches) is the right shape
    *  only for PTY-teardown. */
   dropStatusEntry(paneKey: string): void {
-    if (!this.state.lastStatusByPaneKey.has(paneKey)) {
+    const resolvedPaneKey = this.resolvePaneKeyAlias(paneKey)
+    if (!this.state.lastStatusByPaneKey.has(resolvedPaneKey)) {
       return
     }
-    this.state.lastStatusByPaneKey.delete(paneKey)
-    this.runtimeObservedStatusPaneKeys.delete(paneKey)
+    this.state.lastStatusByPaneKey.delete(resolvedPaneKey)
+    this.runtimeObservedStatusPaneKeys.delete(resolvedPaneKey)
     this.scheduleStatusPersist()
     this.notifyStatusChangeListeners()
   }
 
   clearPaneState(paneKey: string): void {
+    const resolvedPaneKey = this.resolvePaneKeyAlias(paneKey)
     // Why: only schedule a write when we actually evicted a status entry —
     // dropping prompt/tool caches for a pane that never produced a hook
     // event does not change the on-disk file, and skipping the write avoids
     // re-stat'ing on every dead-pane teardown.
-    const hadStatus = this.state.lastStatusByPaneKey.has(paneKey)
-    clearPaneCacheState(this.state, paneKey)
+    const hadStatus = this.state.lastStatusByPaneKey.has(resolvedPaneKey)
+    clearPaneCacheState(this.state, resolvedPaneKey)
+    for (const [legacyPaneKey, stablePaneKey] of this.legacyPaneKeyAliases) {
+      if (stablePaneKey === resolvedPaneKey) {
+        this.legacyPaneKeyAliases.delete(legacyPaneKey)
+        clearPaneCacheState(this.state, legacyPaneKey)
+      }
+    }
     if (hadStatus) {
-      this.runtimeObservedStatusPaneKeys.delete(paneKey)
+      this.runtimeObservedStatusPaneKeys.delete(resolvedPaneKey)
       this.scheduleStatusPersist()
       this.notifyStatusChangeListeners()
     }
@@ -655,9 +699,14 @@ export class AgentHookServer {
     // tick.
     const ttlCutoff = Date.now() - HYDRATE_MAX_AGE_MS
     for (const [paneKey, rawEntry] of Object.entries(entries)) {
-      const entry = sanitizeHydratedEntry(paneKey, rawEntry)
+      const resolvedPaneKey = this.resolvePaneKeyAlias(paneKey)
+      const rawResolvedEntry =
+        resolvedPaneKey === paneKey || typeof rawEntry !== 'object' || rawEntry === null
+          ? rawEntry
+          : { ...(rawEntry as Record<string, unknown>), paneKey: resolvedPaneKey }
+      const entry = sanitizeHydratedEntry(resolvedPaneKey, rawResolvedEntry)
       if (entry && entry.receivedAt >= ttlCutoff) {
-        this.state.lastStatusByPaneKey.set(paneKey, entry)
+        this.state.lastStatusByPaneKey.set(resolvedPaneKey, entry)
         hydrated += 1
       } else {
         dropped += 1

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -40,6 +40,7 @@ import {
   normalizeAgentStatusPayload
 } from '../../shared/agent-status-types'
 import { parseLegacyNumericPaneKey, parsePaneKey } from '../../shared/stable-pane-id'
+import type { LegacyPaneKeyAliasEntry } from '../../shared/types'
 
 export type { AgentHookSource }
 
@@ -63,6 +64,12 @@ export type AgentHookStatusChangeEntry = {
 }
 
 type StatusChangeListener = (statuses: AgentHookStatusChangeEntry[]) => void
+type PaneKeyAliasPersistenceListener = (entries: LegacyPaneKeyAliasEntry[]) => void
+type PaneKeyAliasEntry = {
+  stablePaneKey: string
+  ptyId: string | null
+  updatedAt: number
+}
 
 // Why: name of the on-disk cache that survives Orca restart. Lives next to
 // the endpoint file in userData/agent-hooks/ so all hook-server-owned cross-
@@ -215,7 +222,8 @@ export class AgentHookServer {
   // Why: hydrated last-status rows are useful UI continuity, but they are not
   // evidence of live agent work in this main-process runtime.
   private runtimeObservedStatusPaneKeys = new Set<string>()
-  private legacyPaneKeyAliases = new Map<string, string>()
+  private legacyPaneKeyAliases = new Map<string, PaneKeyAliasEntry>()
+  private paneKeyAliasPersistenceListener: PaneKeyAliasPersistenceListener | null = null
   // Why: full path to the on-disk last-status cache. Set in start() from
   // userDataPath. Null when the server runs without a userDataPath (e.g.
   // tests that skip the userDataPath option) — in that case, persistence is
@@ -306,17 +314,103 @@ export class AgentHookServer {
     }
   }
 
-  registerPaneKeyAlias(legacyPaneKey: string, stablePaneKey: string): void {
+  setPaneKeyAliasPersistenceListener(listener: PaneKeyAliasPersistenceListener | null): void {
+    this.paneKeyAliasPersistenceListener = listener
+  }
+
+  private getPersistedPaneKeyAliases(): LegacyPaneKeyAliasEntry[] {
+    return Array.from(this.legacyPaneKeyAliases.entries()).flatMap(([legacyPaneKey, entry]) =>
+      entry.ptyId
+        ? [
+            {
+              ptyId: entry.ptyId,
+              legacyPaneKey,
+              stablePaneKey: entry.stablePaneKey,
+              updatedAt: entry.updatedAt
+            }
+          ]
+        : []
+    )
+  }
+
+  private notifyPaneKeyAliasPersistenceListener(): void {
+    this.paneKeyAliasPersistenceListener?.(this.getPersistedPaneKeyAliases())
+  }
+
+  registerPaneKeyAlias(
+    legacyPaneKey: string,
+    stablePaneKey: string,
+    ptyId?: string,
+    updatedAt = Date.now(),
+    options?: { overwriteExisting?: boolean }
+  ): void {
     const legacy = parseLegacyNumericPaneKey(legacyPaneKey)
     const stable = parsePaneKey(stablePaneKey)
     if (!legacy || !stable || legacy.tabId !== stable.tabId) {
       return
     }
-    this.legacyPaneKeyAliases.set(legacy.paneKey, stablePaneKey)
+    const existing = this.legacyPaneKeyAliases.get(legacy.paneKey)
+    if (existing && options?.overwriteExisting === false) {
+      return
+    }
+    const normalizedPtyId =
+      typeof ptyId === 'string' && ptyId.trim().length > 0 ? ptyId.trim() : existing?.ptyId
+    const normalizedUpdatedAt =
+      Number.isFinite(updatedAt) && updatedAt > 0 ? updatedAt : (existing?.updatedAt ?? Date.now())
+    if (
+      existing &&
+      existing.stablePaneKey === stablePaneKey &&
+      existing.ptyId === (normalizedPtyId ?? null) &&
+      existing.updatedAt === normalizedUpdatedAt
+    ) {
+      return
+    }
+    this.legacyPaneKeyAliases.set(legacy.paneKey, {
+      stablePaneKey,
+      ptyId: normalizedPtyId ?? null,
+      updatedAt: normalizedUpdatedAt
+    })
+    if (normalizedPtyId) {
+      this.notifyPaneKeyAliasPersistenceListener()
+    }
+  }
+
+  clearPaneKeyAliasesForPty(
+    ptyId: string,
+    options?: { shouldClearStablePaneKey?: (paneKey: string) => boolean }
+  ): void {
+    let aliasChanged = false
+    let statusChanged = false
+    for (const [legacyPaneKey, entry] of this.legacyPaneKeyAliases) {
+      if (entry.ptyId === ptyId) {
+        this.legacyPaneKeyAliases.delete(legacyPaneKey)
+        clearPaneCacheState(this.state, legacyPaneKey)
+        const shouldClearStablePaneKey =
+          options?.shouldClearStablePaneKey?.(entry.stablePaneKey) ?? true
+        if (shouldClearStablePaneKey && this.state.lastStatusByPaneKey.has(entry.stablePaneKey)) {
+          statusChanged = true
+        }
+        if (shouldClearStablePaneKey) {
+          // Why: after hydrate, legacy rows are stored under the stable key. If
+          // this PTY is later proven dead before ptyPaneKey is rebuilt, alias
+          // cleanup is the only path that can evict that retained status.
+          clearPaneCacheState(this.state, entry.stablePaneKey)
+          this.runtimeObservedStatusPaneKeys.delete(entry.stablePaneKey)
+        }
+        aliasChanged = true
+      }
+    }
+    if (aliasChanged) {
+      this.notifyPaneKeyAliasPersistenceListener()
+    }
+    if (statusChanged) {
+      this.scheduleStatusPersist()
+      this.notifyStatusChangeListeners()
+    }
   }
 
   private resolvePaneKeyAlias(paneKey: string): string {
-    return this.legacyPaneKeyAliases.get(paneKey) ?? paneKey
+    return this.legacyPaneKeyAliases.get(paneKey)?.stablePaneKey ?? paneKey
   }
 
   private normalizeHookBodyPaneKeyAlias(body: unknown): unknown {
@@ -325,7 +419,7 @@ export class AgentHookServer {
     }
     const record = body as Record<string, unknown>
     const rawPaneKey = typeof record.paneKey === 'string' ? record.paneKey.trim() : ''
-    const stablePaneKey = this.legacyPaneKeyAliases.get(rawPaneKey)
+    const stablePaneKey = this.legacyPaneKeyAliases.get(rawPaneKey)?.stablePaneKey
     if (!stablePaneKey) {
       return body
     }
@@ -593,11 +687,16 @@ export class AgentHookServer {
     // re-stat'ing on every dead-pane teardown.
     const hadStatus = this.state.lastStatusByPaneKey.has(resolvedPaneKey)
     clearPaneCacheState(this.state, resolvedPaneKey)
+    let clearedAlias = false
     for (const [legacyPaneKey, stablePaneKey] of this.legacyPaneKeyAliases) {
-      if (stablePaneKey === resolvedPaneKey) {
+      if (stablePaneKey.stablePaneKey === resolvedPaneKey) {
         this.legacyPaneKeyAliases.delete(legacyPaneKey)
         clearPaneCacheState(this.state, legacyPaneKey)
+        clearedAlias = true
       }
+    }
+    if (clearedAlias) {
+      this.notifyPaneKeyAliasPersistenceListener()
     }
     if (hadStatus) {
       this.runtimeObservedStatusPaneKeys.delete(resolvedPaneKey)

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -21,6 +21,7 @@ const {
   openCodeClearPtyMock,
   buildAgentHookEnvMock,
   clearAgentHookPaneStateMock,
+  registerPaneKeyAliasMock,
   piBuildPtyEnvMock,
   piClearPtyMock,
   isPwshAvailableMock,
@@ -50,6 +51,7 @@ const {
   openCodeClearPtyMock: vi.fn(),
   buildAgentHookEnvMock: vi.fn(),
   clearAgentHookPaneStateMock: vi.fn(),
+  registerPaneKeyAliasMock: vi.fn(),
   piBuildPtyEnvMock: vi.fn(),
   piClearPtyMock: vi.fn(),
   trackMock: vi.fn(),
@@ -101,7 +103,8 @@ vi.mock('../opencode/hook-service', () => ({
 vi.mock('../agent-hooks/server', () => ({
   agentHookServer: {
     buildPtyEnv: buildAgentHookEnvMock,
-    clearPaneState: clearAgentHookPaneStateMock
+    clearPaneState: clearAgentHookPaneStateMock,
+    registerPaneKeyAlias: registerPaneKeyAliasMock
   }
 }))
 
@@ -206,6 +209,7 @@ describe('registerPtyHandlers', () => {
     openCodeClearPtyMock.mockReset()
     buildAgentHookEnvMock.mockReset()
     clearAgentHookPaneStateMock.mockReset()
+    registerPaneKeyAliasMock.mockReset()
     piBuildPtyEnvMock.mockReset()
     piClearPtyMock.mockReset()
     isPwshAvailableMock.mockReset()
@@ -2326,9 +2330,10 @@ describe('registerPtyHandlers', () => {
     }
   })
 
-  it('registers only validated stable pane keys in the local PTY memory registry', async () => {
+  it('upgrades legacy numeric pane keys when the spawn metadata proves the stable leaf', async () => {
     registerPtyHandlers(mainWindow as never)
     const leafId = '11111111-1111-4111-8111-111111111111'
+    const stablePaneKey = makePaneKey('tab-1', leafId)
     await handlers.get('pty:spawn')!(null, {
       cols: 80,
       rows: 24,
@@ -2340,22 +2345,13 @@ describe('registerPtyHandlers', () => {
 
     expect(registerPtyMock).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        paneKey: null
+        paneKey: stablePaneKey
       })
     )
-    expect(setMigrationUnsupportedPtyMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        ptyId: expect.any(String),
-        worktreeId: 'wt-1',
-        tabId: 'tab-1',
-        leafId,
-        paneKey: makePaneKey('tab-1', leafId),
-        reason: 'legacy-numeric-pane-key',
-        source: 'local'
-      })
-    )
+    expect(registerPaneKeyAliasMock).toHaveBeenCalledWith('tab-1:0', stablePaneKey)
+    expect(clearMigrationUnsupportedPtysForPaneKeyMock).toHaveBeenCalledWith(stablePaneKey)
+    expect(setMigrationUnsupportedPtyMock).not.toHaveBeenCalled()
 
-    const stablePaneKey = makePaneKey('tab-1', leafId)
     await handlers.get('pty:spawn')!(null, {
       cols: 80,
       rows: 24,

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -31,7 +31,8 @@ const {
   unregisterPtyMock,
   setMigrationUnsupportedPtyMock,
   clearMigrationUnsupportedPtyMock,
-  clearMigrationUnsupportedPtysForPaneKeyMock
+  clearMigrationUnsupportedPtysForPaneKeyMock,
+  clearPaneKeyAliasesForPtyMock
 } = vi.hoisted(() => ({
   handleMock: vi.fn(),
   onMock: vi.fn(),
@@ -60,7 +61,8 @@ const {
   unregisterPtyMock: vi.fn(),
   setMigrationUnsupportedPtyMock: vi.fn(),
   clearMigrationUnsupportedPtyMock: vi.fn(),
-  clearMigrationUnsupportedPtysForPaneKeyMock: vi.fn()
+  clearMigrationUnsupportedPtysForPaneKeyMock: vi.fn(),
+  clearPaneKeyAliasesForPtyMock: vi.fn()
 }))
 
 vi.mock('electron', () => ({
@@ -104,7 +106,8 @@ vi.mock('../agent-hooks/server', () => ({
   agentHookServer: {
     buildPtyEnv: buildAgentHookEnvMock,
     clearPaneState: clearAgentHookPaneStateMock,
-    registerPaneKeyAlias: registerPaneKeyAliasMock
+    registerPaneKeyAlias: registerPaneKeyAliasMock,
+    clearPaneKeyAliasesForPty: clearPaneKeyAliasesForPtyMock
   }
 }))
 
@@ -220,6 +223,7 @@ describe('registerPtyHandlers', () => {
     setMigrationUnsupportedPtyMock.mockReset()
     clearMigrationUnsupportedPtyMock.mockReset()
     clearMigrationUnsupportedPtysForPaneKeyMock.mockReset()
+    clearPaneKeyAliasesForPtyMock.mockReset()
     mainWindow.webContents.on.mockReset()
     mainWindow.webContents.send.mockReset()
 
@@ -2348,7 +2352,11 @@ describe('registerPtyHandlers', () => {
         paneKey: stablePaneKey
       })
     )
-    expect(registerPaneKeyAliasMock).toHaveBeenCalledWith('tab-1:0', stablePaneKey)
+    expect(registerPaneKeyAliasMock).toHaveBeenCalledWith(
+      'tab-1:0',
+      stablePaneKey,
+      expect.any(String)
+    )
     expect(clearMigrationUnsupportedPtysForPaneKeyMock).toHaveBeenCalledWith(stablePaneKey)
     expect(setMigrationUnsupportedPtyMock).not.toHaveBeenCalled()
 
@@ -2416,6 +2424,31 @@ describe('registerPtyHandlers', () => {
     clearProviderPtyState(second.id)
     expect(getPtyIdForPaneKey(stablePaneKey)).toBeUndefined()
     expect(clearAgentHookPaneStateMock).toHaveBeenCalledWith(stablePaneKey)
+  })
+
+  it('does not let restart-era alias cleanup clear a newer pane-key owner', async () => {
+    registerPtyHandlers(mainWindow as never)
+    const leafId = '11111111-1111-4111-8111-111111111111'
+    const stablePaneKey = makePaneKey('tab-1', leafId)
+
+    const current = (await handlers.get('pty:spawn')!(null, {
+      cols: 80,
+      rows: 24,
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      leafId,
+      env: { ORCA_PANE_KEY: stablePaneKey }
+    })) as { id: string }
+
+    expect(getPtyIdForPaneKey(stablePaneKey)).toBe(current.id)
+    clearPaneKeyAliasesForPtyMock.mockClear()
+
+    clearProviderPtyState('old-pty-without-forward-pane-key')
+
+    const cleanupOptions = clearPaneKeyAliasesForPtyMock.mock.calls.find(
+      ([ptyId]) => ptyId === 'old-pty-without-forward-pane-key'
+    )?.[1]
+    expect(cleanupOptions?.shouldClearStablePaneKey(stablePaneKey)).toBe(false)
   })
 
   it('prefers args.env.SHELL and normalizes the child env after fallback', async () => {

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -444,19 +444,31 @@ export function clearProviderPtyState(id: string): void {
   openCodeHookService.clearPty(id)
   piTitlebarExtensionService.clearPty(id)
   ptySizes.delete(id)
+  const paneKey = ptyPaneKey.get(id)
+  const stillOwnsPaneKey = paneKey ? paneKeyPtyId.get(paneKey) === id : false
   // Why: drop the memory-collector registration so a dead PTY does not keep
   // trying to resolve its (now-dead) pid on every snapshot. Safe no-op for
   // PTYs that were never registered (SSH-owned).
   unregisterPty(id)
   clearMigrationUnsupportedPty(id)
+  agentHookServer.clearPaneKeyAliasesForPty(id, {
+    shouldClearStablePaneKey: (stablePaneKey) => {
+      // Why: when this PTY never rebuilt ptyPaneKey after restart, alias
+      // ownership is our only proof. Once a newer PTY owns the same stable
+      // paneKey, alias teardown must not erase that newer status.
+      const stablePaneOwner = paneKeyPtyId.get(stablePaneKey)
+      if (stablePaneOwner && stablePaneOwner !== id) {
+        return false
+      }
+      return !paneKey || (stillOwnsPaneKey && stablePaneKey === paneKey)
+    }
+  })
   rendererSerializerByPtyId.delete(id)
   // Why: the hook server's per-paneKey caches (lastPrompt / lastTool) would
   // otherwise accumulate entries for dead panes over the process lifetime.
   // Use the spawn-time paneKey mapping since the server has no other way to
   // correlate a ptyId back to its paneKey.
-  const paneKey = ptyPaneKey.get(id)
   if (paneKey) {
-    const stillOwnsPaneKey = paneKeyPtyId.get(paneKey) === id
     if (stillOwnsPaneKey) {
       agentHookServer.clearPaneState(paneKey)
       paneKeyPtyId.delete(paneKey)
@@ -1431,7 +1443,8 @@ export function registerPtyHandlers(
       if (legacySpawnPaneKey && migrationUnsupportedPaneKey) {
         agentHookServer.registerPaneKeyAlias(
           legacySpawnPaneKey.paneKey,
-          migrationUnsupportedPaneKey
+          migrationUnsupportedPaneKey,
+          result.id
         )
         clearMigrationUnsupportedPtysForPaneKey(migrationUnsupportedPaneKey)
       } else if (validatedPaneKey) {

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -38,11 +38,15 @@ import {
 } from '../../shared/telemetry-events'
 import { isRemoteAgentHooksEnabled } from '../../shared/agent-hook-relay'
 import { readShellStartupEnvVar } from '../pty/shell-startup-env'
-import { isTerminalLeafId, makePaneKey, parsePaneKey } from '../../shared/stable-pane-id'
+import {
+  isTerminalLeafId,
+  makePaneKey,
+  parseLegacyNumericPaneKey,
+  parsePaneKey
+} from '../../shared/stable-pane-id'
 import {
   clearMigrationUnsupportedPty,
-  clearMigrationUnsupportedPtysForPaneKey,
-  setMigrationUnsupportedPty
+  clearMigrationUnsupportedPtysForPaneKey
 } from '../agent-hooks/migration-unsupported-pty-state'
 
 // ─── Provider Registry ──────────────────────────────────────────────
@@ -117,28 +121,6 @@ function parseValidPaneKey(paneKey: unknown): ReturnType<typeof parsePaneKey> {
 
 function isValidPaneKey(paneKey: unknown): paneKey is string {
   return parseValidPaneKey(paneKey) !== null
-}
-
-function parseLegacyNumericPaneKey(
-  paneKey: unknown
-): { tabId: string; numericPaneId: string } | null {
-  if (typeof paneKey !== 'string' || paneKey.length > 256) {
-    return null
-  }
-  const trimmed = paneKey.trim()
-  const delimiter = trimmed.indexOf(':')
-  if (
-    delimiter <= 0 ||
-    delimiter !== trimmed.lastIndexOf(':') ||
-    delimiter === trimmed.length - 1
-  ) {
-    return null
-  }
-  const numericPaneId = trimmed.slice(delimiter + 1)
-  if (!/^\d+$/.test(numericPaneId)) {
-    return null
-  }
-  return { tabId: trimmed.slice(0, delimiter), numericPaneId }
 }
 
 function rememberPaneKeyForPty(ptyId: string, paneKey: unknown): string | null {
@@ -1151,15 +1133,16 @@ export function registerPtyHandlers(
         isTerminalLeafId(args.leafId)
           ? makePaneKey(args.tabId, args.leafId)
           : null
+      const stablePaneKey = verifiedPaneKey ?? migrationUnsupportedPaneKey
       const baseEnv = baseEnvWithAuth
-        ? { ...baseEnvWithAuth, ...(verifiedPaneKey ? { ORCA_PANE_KEY: verifiedPaneKey } : {}) }
+        ? { ...baseEnvWithAuth, ...(stablePaneKey ? { ORCA_PANE_KEY: stablePaneKey } : {}) }
         : undefined
-      if (baseEnv && !verifiedPaneKey) {
+      if (baseEnv && !stablePaneKey) {
         // Why: ORCA_PANE_KEY crosses into shells and hook registries. Only the
         // key proven to match this spawn's tab+leaf may leave the IPC boundary.
         delete baseEnv.ORCA_PANE_KEY
       }
-      const validatedPaneKey = verifiedPaneKey
+      const validatedPaneKey = stablePaneKey
       const validatedLeafId = verifiedLeafId ?? metadataLeafId
       let env: Record<string, string> | undefined = baseEnv
       const preAllocatedHandle =
@@ -1445,24 +1428,16 @@ export function registerPtyHandlers(
       const rememberedPaneKey = validatedPaneKey
         ? rememberPaneKeyForPty(result.id, validatedPaneKey)
         : null
-      if (validatedPaneKey) {
+      if (legacySpawnPaneKey && migrationUnsupportedPaneKey) {
+        agentHookServer.registerPaneKeyAlias(
+          legacySpawnPaneKey.paneKey,
+          migrationUnsupportedPaneKey
+        )
+        clearMigrationUnsupportedPtysForPaneKey(migrationUnsupportedPaneKey)
+      } else if (validatedPaneKey) {
         if (!result.isReattach) {
           clearMigrationUnsupportedPtysForPaneKey(validatedPaneKey)
         }
-      } else if (migrationUnsupportedPaneKey && legacySpawnPaneKey) {
-        // Why: old live PTYs can still carry `${tabId}:${numericPaneId}` in
-        // ORCA_PANE_KEY. Only surface a migration row when this spawn also
-        // proves the owning UUID leaf through the renderer IPC metadata.
-        setMigrationUnsupportedPty({
-          ptyId: result.id,
-          ...(typeof args.worktreeId === 'string' ? { worktreeId: args.worktreeId } : {}),
-          tabId: legacySpawnPaneKey.tabId,
-          leafId: args.leafId,
-          paneKey: migrationUnsupportedPaneKey,
-          reason: 'legacy-numeric-pane-key',
-          source: args.connectionId ? 'ssh' : 'local',
-          updatedAt: Date.now()
-        })
       }
       // Why: register local PTYs (connectionId falsy) with the memory
       // collector so it can walk each PTY's process subtree and attribute

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -1529,6 +1529,262 @@ describe('Store', () => {
     }
   })
 
+  it('persists legacy pane-key aliases after the layout has been normalized', async () => {
+    const agentHooksDir = join(testState.dir, 'agent-hooks')
+    mkdirSync(agentHooksDir, { recursive: true })
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [],
+      worktreeMeta: {},
+      settings: {},
+      ui: {},
+      githubCache: { pr: {}, issue: {} },
+      workspaceSession: {
+        activeRepoId: 'r1',
+        activeWorktreeId: 'wt1',
+        activeTabId: 'tab1',
+        tabsByWorktree: {
+          wt1: [
+            {
+              id: 'tab1',
+              worktreeId: 'wt1',
+              title: 'Terminal',
+              customTitle: null,
+              color: null,
+              sortOrder: 0,
+              createdAt: 1,
+              ptyId: 'local-pty'
+            }
+          ]
+        },
+        terminalLayoutsByTabId: {
+          tab1: {
+            root: { type: 'leaf', leafId: 'pane:1' },
+            activeLeafId: 'pane:1',
+            expandedLeafId: null,
+            ptyIdsByLeafId: { 'pane:1': 'local-pty' }
+          }
+        }
+      }
+    })
+
+    const firstStore = await createStore()
+    const root = firstStore.getWorkspaceSession().terminalLayoutsByTabId.tab1.root
+    const stableLeafId = root?.type === 'leaf' ? root.leafId : null
+    if (stableLeafId === null) {
+      throw new Error('Expected remapped leaf id')
+    }
+    const stablePaneKey = makePaneKey('tab1', stableLeafId)
+    firstStore.flush()
+
+    expect(readDataFile()).toEqual(
+      expect.objectContaining({
+        legacyPaneKeyAliasEntries: [
+          expect.objectContaining({
+            ptyId: 'local-pty',
+            legacyPaneKey: 'tab1:1',
+            stablePaneKey
+          })
+        ]
+      })
+    )
+
+    const now = Date.now()
+    writeFileSync(
+      join(agentHooksDir, 'last-status.json'),
+      JSON.stringify({
+        version: 2,
+        entries: {
+          'tab1:1': {
+            paneKey: 'tab1:1',
+            tabId: 'tab1',
+            worktreeId: 'wt1',
+            connectionId: null,
+            receivedAt: now,
+            stateStartedAt: now - 1000,
+            payload: { state: 'working', prompt: 'post-normalize legacy prompt' }
+          }
+        }
+      }),
+      'utf-8'
+    )
+
+    await createStore()
+    const { agentHookServer } = await import('./agent-hooks/server')
+    await agentHookServer.start({ env: 'production', userDataPath: testState.dir })
+    try {
+      expect(agentHookServer.getStatusSnapshot()).toEqual([
+        expect.objectContaining({
+          paneKey: stablePaneKey,
+          state: 'working',
+          prompt: 'post-normalize legacy prompt'
+        })
+      ])
+    } finally {
+      agentHookServer.stop()
+    }
+  })
+
+  it('persists fallback aliases when a legacy split layout has no PTY leaf bindings', async () => {
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [],
+      worktreeMeta: {},
+      settings: {},
+      ui: {},
+      githubCache: { pr: {}, issue: {} },
+      workspaceSession: {
+        activeRepoId: 'r1',
+        activeWorktreeId: 'wt1',
+        activeTabId: 'tab1',
+        tabsByWorktree: {
+          wt1: [
+            {
+              id: 'tab1',
+              worktreeId: 'wt1',
+              title: 'Terminal',
+              customTitle: null,
+              color: null,
+              sortOrder: 0,
+              createdAt: 1,
+              ptyId: 'local-pty'
+            }
+          ]
+        },
+        terminalLayoutsByTabId: {
+          tab1: {
+            root: {
+              type: 'split',
+              direction: 'vertical',
+              first: { type: 'leaf', leafId: 'pane:1' },
+              second: { type: 'leaf', leafId: 'pane:2' },
+              sizes: [50, 50]
+            },
+            activeLeafId: 'pane:2',
+            expandedLeafId: null
+          }
+        }
+      }
+    })
+
+    const store = await createStore()
+    const layout = store.getWorkspaceSession().terminalLayoutsByTabId.tab1
+    const firstLeafId =
+      layout.root?.type === 'split' && layout.root.first.type === 'leaf'
+        ? layout.root.first.leafId
+        : null
+    const secondLeafId =
+      layout.root?.type === 'split' && layout.root.second.type === 'leaf'
+        ? layout.root.second.leafId
+        : null
+    if (
+      !firstLeafId ||
+      !secondLeafId ||
+      !isTerminalLeafId(firstLeafId) ||
+      !isTerminalLeafId(secondLeafId)
+    ) {
+      throw new Error('Expected remapped split leaf ids')
+    }
+    const activePaneKey = makePaneKey('tab1', secondLeafId)
+    const firstPaneKey = makePaneKey('tab1', firstLeafId)
+    const secondPaneKey = makePaneKey('tab1', secondLeafId)
+    store.flush()
+
+    expect(readDataFile()).toEqual(
+      expect.objectContaining({
+        legacyPaneKeyAliasEntries: expect.arrayContaining([
+          expect.objectContaining({
+            ptyId: 'local-pty',
+            legacyPaneKey: 'tab1:0',
+            stablePaneKey: activePaneKey
+          }),
+          expect.objectContaining({
+            ptyId: 'local-pty',
+            legacyPaneKey: 'tab1:1',
+            stablePaneKey: firstPaneKey
+          }),
+          expect.objectContaining({
+            ptyId: 'local-pty',
+            legacyPaneKey: 'tab1:2',
+            stablePaneKey: secondPaneKey
+          })
+        ])
+      })
+    )
+  })
+
+  it('converts unambiguous dev migration rows into persisted aliases', async () => {
+    const stablePaneKey = makePaneKey('tab1', TEST_LEAF_1)
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [],
+      worktreeMeta: {},
+      settings: {},
+      ui: {},
+      githubCache: { pr: {}, issue: {} },
+      workspaceSession: {
+        activeRepoId: 'r1',
+        activeWorktreeId: 'wt1',
+        activeTabId: 'tab1',
+        tabsByWorktree: {
+          wt1: [
+            {
+              id: 'tab1',
+              worktreeId: 'wt1',
+              title: 'Terminal',
+              customTitle: null,
+              color: null,
+              sortOrder: 0,
+              createdAt: 1,
+              ptyId: 'local-pty'
+            }
+          ]
+        },
+        terminalLayoutsByTabId: {
+          tab1: {
+            root: { type: 'leaf', leafId: TEST_LEAF_1 },
+            activeLeafId: TEST_LEAF_1,
+            expandedLeafId: null,
+            ptyIdsByLeafId: { [TEST_LEAF_1]: 'local-pty' }
+          }
+        }
+      },
+      migrationUnsupportedPtyEntries: [
+        {
+          ptyId: 'local-pty',
+          worktreeId: 'wt1',
+          tabId: 'tab1',
+          leafId: TEST_LEAF_1,
+          paneKey: stablePaneKey,
+          reason: 'legacy-numeric-pane-key',
+          source: 'local',
+          updatedAt: 123
+        }
+      ]
+    })
+
+    const store = await createStore()
+    store.flush()
+
+    expect(readDataFile()).toEqual(
+      expect.objectContaining({
+        migrationUnsupportedPtyEntries: [],
+        legacyPaneKeyAliasEntries: expect.arrayContaining([
+          expect.objectContaining({
+            ptyId: 'local-pty',
+            legacyPaneKey: 'tab1:0',
+            stablePaneKey
+          }),
+          expect.objectContaining({
+            ptyId: 'local-pty',
+            legacyPaneKey: 'tab1:1',
+            stablePaneKey
+          })
+        ])
+      })
+    )
+  })
+
   it('remaps legacy SSH lease leaf ids by PTY when the layout is already normalized', async () => {
     writeDataFile({
       schemaVersion: 1,

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -6,7 +6,7 @@ import { writeFileSync, readFileSync, rmSync, mkdtempSync, mkdirSync, existsSync
 import { join } from 'path'
 import { tmpdir } from 'os'
 import type { Repo, TerminalTab, WorkspaceSessionState } from '../shared/types'
-import { isTerminalLeafId } from '../shared/stable-pane-id'
+import { isTerminalLeafId, makePaneKey } from '../shared/stable-pane-id'
 import { MAX_BROWSER_HISTORY_ENTRIES } from '../shared/workspace-session-browser-history'
 
 // Shared mutable state so the electron mock can reference a per-test directory
@@ -1222,6 +1222,311 @@ describe('Store', () => {
     expect(isTerminalLeafId(leafId)).toBe(true)
     expect(layout.ptyIdsByLeafId).toEqual({ [leafId]: 'remote-pty' })
     expect(store.getSshRemotePtyLeases('ssh-1')[0].leafId).toBe(leafId)
+  })
+
+  it('hydrates legacy numeric agent status cache through the pane identity migration', async () => {
+    const agentHooksDir = join(testState.dir, 'agent-hooks')
+    mkdirSync(agentHooksDir, { recursive: true })
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [],
+      worktreeMeta: {},
+      settings: {},
+      ui: {},
+      githubCache: { pr: {}, issue: {} },
+      workspaceSession: {
+        activeRepoId: 'r1',
+        activeWorktreeId: 'wt1',
+        activeTabId: 'tab1',
+        tabsByWorktree: {
+          wt1: [
+            {
+              id: 'tab1',
+              worktreeId: 'wt1',
+              title: 'Terminal',
+              customTitle: null,
+              color: null,
+              sortOrder: 0,
+              createdAt: 1,
+              ptyId: 'local-pty'
+            }
+          ]
+        },
+        terminalLayoutsByTabId: {
+          tab1: {
+            root: { type: 'leaf', leafId: 'pane:1' },
+            activeLeafId: 'pane:1',
+            expandedLeafId: null,
+            ptyIdsByLeafId: { 'pane:1': 'local-pty' }
+          }
+        }
+      }
+    })
+    writeFileSync(
+      join(agentHooksDir, 'last-status.json'),
+      JSON.stringify({
+        version: 2,
+        entries: {
+          'tab1:1': {
+            paneKey: 'tab1:1',
+            tabId: 'tab1',
+            worktreeId: 'wt1',
+            connectionId: null,
+            receivedAt: Date.now(),
+            stateStartedAt: Date.now() - 1000,
+            payload: { state: 'working', prompt: 'legacy numeric prompt', agentType: 'claude' }
+          }
+        }
+      }),
+      'utf-8'
+    )
+
+    const store = await createStore()
+    const { agentHookServer } = await import('./agent-hooks/server')
+    await agentHookServer.start({ env: 'production', userDataPath: testState.dir })
+    try {
+      const layout = store.getWorkspaceSession().terminalLayoutsByTabId.tab1
+      const leafId = layout.root?.type === 'leaf' ? layout.root.leafId : null
+      if (leafId === null) {
+        throw new Error('Expected remapped leaf id')
+      }
+      const stablePaneKey = makePaneKey('tab1', leafId)
+      expect(agentHookServer.getStatusSnapshot()).toEqual([
+        expect.objectContaining({
+          paneKey: stablePaneKey,
+          tabId: 'tab1',
+          worktreeId: 'wt1',
+          state: 'working',
+          prompt: 'legacy numeric prompt',
+          agentType: 'claude'
+        })
+      ])
+    } finally {
+      agentHookServer.stop()
+    }
+  })
+
+  it('hydrates split-pane legacy numeric agent status rows onto the matching remapped leaves', async () => {
+    const agentHooksDir = join(testState.dir, 'agent-hooks')
+    mkdirSync(agentHooksDir, { recursive: true })
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [],
+      worktreeMeta: {},
+      settings: {},
+      ui: {},
+      githubCache: { pr: {}, issue: {} },
+      workspaceSession: {
+        activeRepoId: 'r1',
+        activeWorktreeId: 'wt1',
+        activeTabId: 'tab1',
+        tabsByWorktree: {
+          wt1: [
+            {
+              id: 'tab1',
+              worktreeId: 'wt1',
+              title: 'Terminal',
+              customTitle: null,
+              color: null,
+              sortOrder: 0,
+              createdAt: 1,
+              ptyId: 'local-pty-1'
+            }
+          ]
+        },
+        terminalLayoutsByTabId: {
+          tab1: {
+            root: {
+              type: 'split',
+              direction: 'horizontal',
+              first: { type: 'leaf', leafId: 'pane:1' },
+              second: { type: 'leaf', leafId: 'pane:2' },
+              sizes: [50, 50]
+            },
+            activeLeafId: 'pane:1',
+            expandedLeafId: null,
+            ptyIdsByLeafId: { 'pane:1': 'local-pty-1', 'pane:2': 'local-pty-2' }
+          }
+        }
+      }
+    })
+    const now = Date.now()
+    writeFileSync(
+      join(agentHooksDir, 'last-status.json'),
+      JSON.stringify({
+        version: 2,
+        entries: {
+          'tab1:1': {
+            paneKey: 'tab1:1',
+            tabId: 'tab1',
+            worktreeId: 'wt1',
+            connectionId: null,
+            receivedAt: now,
+            stateStartedAt: now - 2000,
+            payload: { state: 'working', prompt: 'left legacy prompt', agentType: 'claude' }
+          },
+          'tab1:2': {
+            paneKey: 'tab1:2',
+            tabId: 'tab1',
+            worktreeId: 'wt1',
+            connectionId: null,
+            receivedAt: now,
+            stateStartedAt: now - 1000,
+            payload: { state: 'blocked', prompt: 'right legacy prompt', agentType: 'codex' }
+          }
+        }
+      }),
+      'utf-8'
+    )
+
+    const store = await createStore()
+    const { agentHookServer } = await import('./agent-hooks/server')
+    await agentHookServer.start({ env: 'production', userDataPath: testState.dir })
+    try {
+      const layout = store.getWorkspaceSession().terminalLayoutsByTabId.tab1
+      const firstLeafId =
+        layout.root?.type === 'split' && layout.root.first.type === 'leaf'
+          ? layout.root.first.leafId
+          : null
+      const secondLeafId =
+        layout.root?.type === 'split' && layout.root.second.type === 'leaf'
+          ? layout.root.second.leafId
+          : null
+      if (firstLeafId === null || secondLeafId === null) {
+        throw new Error('Expected remapped split leaves')
+      }
+      const byPaneKey = new Map(
+        agentHookServer.getStatusSnapshot().map((entry) => [entry.paneKey, entry])
+      )
+
+      expect(byPaneKey.get(makePaneKey('tab1', firstLeafId))).toEqual(
+        expect.objectContaining({
+          state: 'working',
+          prompt: 'left legacy prompt',
+          agentType: 'claude'
+        })
+      )
+      expect(byPaneKey.get(makePaneKey('tab1', secondLeafId))).toEqual(
+        expect.objectContaining({
+          state: 'blocked',
+          prompt: 'right legacy prompt',
+          agentType: 'codex'
+        })
+      )
+    } finally {
+      agentHookServer.stop()
+    }
+  })
+
+  it('hydrates split-pane legacy status rows even when PTY leaf bindings are absent', async () => {
+    const agentHooksDir = join(testState.dir, 'agent-hooks')
+    mkdirSync(agentHooksDir, { recursive: true })
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [],
+      worktreeMeta: {},
+      settings: {},
+      ui: {},
+      githubCache: { pr: {}, issue: {} },
+      workspaceSession: {
+        activeRepoId: 'r1',
+        activeWorktreeId: 'wt1',
+        activeTabId: 'tab1',
+        tabsByWorktree: {
+          wt1: [
+            {
+              id: 'tab1',
+              worktreeId: 'wt1',
+              title: 'Terminal',
+              customTitle: null,
+              color: null,
+              sortOrder: 0,
+              createdAt: 1,
+              ptyId: 'local-pty-1'
+            }
+          ]
+        },
+        terminalLayoutsByTabId: {
+          tab1: {
+            root: {
+              type: 'split',
+              direction: 'vertical',
+              first: { type: 'leaf', leafId: 'pane:1' },
+              second: { type: 'leaf', leafId: 'pane:2' },
+              sizes: [50, 50]
+            },
+            activeLeafId: 'pane:2',
+            expandedLeafId: null
+          }
+        }
+      }
+    })
+    const now = Date.now()
+    writeFileSync(
+      join(agentHooksDir, 'last-status.json'),
+      JSON.stringify({
+        version: 2,
+        entries: {
+          'tab1:1': {
+            paneKey: 'tab1:1',
+            tabId: 'tab1',
+            worktreeId: 'wt1',
+            connectionId: null,
+            receivedAt: now,
+            stateStartedAt: now - 2000,
+            payload: { state: 'working', prompt: 'left no binding', agentType: 'claude' }
+          },
+          'tab1:2': {
+            paneKey: 'tab1:2',
+            tabId: 'tab1',
+            worktreeId: 'wt1',
+            connectionId: null,
+            receivedAt: now,
+            stateStartedAt: now - 1000,
+            payload: { state: 'blocked', prompt: 'right no binding', agentType: 'codex' }
+          }
+        }
+      }),
+      'utf-8'
+    )
+
+    const store = await createStore()
+    const { agentHookServer } = await import('./agent-hooks/server')
+    await agentHookServer.start({ env: 'production', userDataPath: testState.dir })
+    try {
+      const layout = store.getWorkspaceSession().terminalLayoutsByTabId.tab1
+      const firstLeafId =
+        layout.root?.type === 'split' && layout.root.first.type === 'leaf'
+          ? layout.root.first.leafId
+          : null
+      const secondLeafId =
+        layout.root?.type === 'split' && layout.root.second.type === 'leaf'
+          ? layout.root.second.leafId
+          : null
+      if (firstLeafId === null || secondLeafId === null) {
+        throw new Error('Expected remapped split leaves')
+      }
+      const byPaneKey = new Map(
+        agentHookServer.getStatusSnapshot().map((entry) => [entry.paneKey, entry])
+      )
+
+      expect(byPaneKey.get(makePaneKey('tab1', firstLeafId))).toEqual(
+        expect.objectContaining({
+          state: 'working',
+          prompt: 'left no binding',
+          agentType: 'claude'
+        })
+      )
+      expect(byPaneKey.get(makePaneKey('tab1', secondLeafId))).toEqual(
+        expect.objectContaining({
+          state: 'blocked',
+          prompt: 'right no binding',
+          agentType: 'codex'
+        })
+      )
+    } finally {
+      agentHookServer.stop()
+    }
   })
 
   it('remaps legacy SSH lease leaf ids by PTY when the layout is already normalized', async () => {

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -62,6 +62,7 @@ import {
   setMigrationUnsupportedPty,
   setMigrationUnsupportedPtyPersistenceListener
 } from './agent-hooks/migration-unsupported-pty-state'
+import { agentHookServer } from './agent-hooks/server'
 import { pruneLocalTerminalScrollbackBuffers } from '../shared/workspace-session-terminal-buffers'
 import { pruneWorkspaceSessionBrowserHistory } from '../shared/workspace-session-browser-history'
 import { getRepoIdFromWorktreeId } from '../shared/worktree-id'
@@ -420,12 +421,11 @@ function collectMigrationUnsupportedPtyEntries(args: {
   leafIdByInputLeafId: Map<string, string>
   sourceForPtyId: (ptyId: string) => 'local' | 'ssh'
 }): MigrationUnsupportedPtyEntry[] {
-  const entries: MigrationUnsupportedPtyEntry[] = []
   const worktreeId = findWorktreeIdForTab(args.session, args.tabId)
   const tab = worktreeId
     ? args.session.tabsByWorktree?.[worktreeId]?.find((entry) => entry.id === args.tabId)
     : undefined
-  const pushEntry = (ptyId: string, leafId: string): void => {
+  const registerLegacyAlias = (inputLeafId: string, leafId: string): void => {
     if (!isTerminalLeafId(leafId)) {
       return
     }
@@ -435,41 +435,46 @@ function collectMigrationUnsupportedPtyEntries(args: {
     } catch {
       return
     }
-    entries.push({
-      ptyId,
-      ...(worktreeId ? { worktreeId } : {}),
-      tabId: args.tabId,
-      leafId,
-      paneKey,
-      reason: 'legacy-numeric-pane-key',
-      source: args.sourceForPtyId(ptyId),
-      updatedAt: Date.now()
-    })
+    const numeric = /^(?:pane:)?(\d+)$/.exec(inputLeafId)?.[1]
+    if (!numeric) {
+      return
+    }
+    // Why: persisted PaneManager ids are 1-based. A zero-based alias in split
+    // layouts would make tab:1 ambiguous and can route the first pane to the second.
+    agentHookServer.registerPaneKeyAlias(`${args.tabId}:${numeric}`, paneKey)
   }
-  for (const [inputLeafId, ptyId] of Object.entries(args.inputLayout.ptyIdsByLeafId ?? {})) {
+  let registeredAlias = false
+  const inputLeafIds = new Set([
+    ...collectLayoutLeafIdsInOrder(args.inputLayout.root),
+    ...Object.keys(args.inputLayout.ptyIdsByLeafId ?? {})
+  ])
+  for (const inputLeafId of inputLeafIds) {
     if (isTerminalLeafId(inputLeafId)) {
       continue
     }
     const leafId = args.leafIdByInputLeafId.get(inputLeafId)
     if (leafId) {
-      pushEntry(ptyId, leafId)
+      registerLegacyAlias(inputLeafId, leafId)
+      registeredAlias = true
     }
   }
   if (
-    entries.length === 0 &&
+    !registeredAlias &&
     tab?.ptyId &&
     Object.keys(args.inputLayout.ptyIdsByLeafId ?? {}).length === 0
   ) {
     const fallbackLeafId =
       args.normalizedLayout.activeLeafId ?? firstLayoutLeafId(args.normalizedLayout.root)
-    if (fallbackLeafId) {
-      // Why: older single-pane sessions can reattach from tab.ptyId only, with
-      // no leaf binding to migrate. Their live shell env can still hold the
-      // legacy pane key, so surface the restart-required row for that PTY.
-      pushEntry(tab.ptyId, fallbackLeafId)
+    if (fallbackLeafId && isTerminalLeafId(fallbackLeafId)) {
+      const paneKey = makePaneKey(args.tabId, fallbackLeafId)
+      agentHookServer.registerPaneKeyAlias(`${args.tabId}:0`, paneKey)
+      agentHookServer.registerPaneKeyAlias(`${args.tabId}:1`, paneKey)
     }
   }
-  return entries
+  // Why: legacy numeric pane keys are now bridged by aliases instead of
+  // persisted as restart-required rows. Existing saved rows are pruned during
+  // normalizePersistedPaneIdentityState.
+  return []
 }
 
 function normalizeTerminalLayoutSnapshotForPersistence(
@@ -697,10 +702,7 @@ function normalizePersistedPaneIdentityState(state: PersistedState): {
     normalizedSession.leafIdByInputLeafIdByTabId,
     normalizedSession.leafIdByPtyIdByTabId
   )
-  const mergedMigrationUnsupportedEntries = mergeMigrationUnsupportedPtyEntries([
-    ...(state.migrationUnsupportedPtyEntries ?? []),
-    ...normalizedSession.migrationUnsupportedEntries
-  ])
+  const mergedMigrationUnsupportedEntries: MigrationUnsupportedPtyEntry[] = []
   const migrationUnsupportedChanged = !migrationUnsupportedEntriesEqual(
     state.migrationUnsupportedPtyEntries ?? [],
     mergedMigrationUnsupportedEntries
@@ -722,19 +724,6 @@ function normalizePersistedPaneIdentityState(state: PersistedState): {
     changed: true,
     migrationUnsupportedEntries: mergedMigrationUnsupportedEntries
   }
-}
-
-function mergeMigrationUnsupportedPtyEntries(
-  entries: MigrationUnsupportedPtyEntry[]
-): MigrationUnsupportedPtyEntry[] {
-  const byPtyId = new Map<string, MigrationUnsupportedPtyEntry>()
-  for (const entry of entries) {
-    const existing = byPtyId.get(entry.ptyId)
-    if (!existing || existing.updatedAt <= entry.updatedAt) {
-      byPtyId.set(entry.ptyId, entry)
-    }
-  }
-  return [...byPtyId.values()]
 }
 
 function normalizeMigrationUnsupportedPtyEntries(value: unknown): MigrationUnsupportedPtyEntry[] {

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -37,6 +37,7 @@ import type {
   OnboardingChecklistState,
   OnboardingOutcome,
   OnboardingState,
+  LegacyPaneKeyAliasEntry,
   TerminalPaneLayoutNode,
   TerminalLayoutSnapshot,
   TerminalTab,
@@ -57,7 +58,12 @@ import {
   ONBOARDING_FINAL_STEP
 } from '../shared/constants'
 import { parseWorkspaceSession } from '../shared/workspace-session-schema'
-import { isTerminalLeafId, makePaneKey } from '../shared/stable-pane-id'
+import {
+  isTerminalLeafId,
+  makePaneKey,
+  parseLegacyNumericPaneKey,
+  parsePaneKey
+} from '../shared/stable-pane-id'
 import {
   setMigrationUnsupportedPty,
   setMigrationUnsupportedPtyPersistenceListener
@@ -413,37 +419,57 @@ function findWorktreeIdForTab(session: WorkspaceSessionState, tabId: string): st
   return undefined
 }
 
+type PaneIdentityMigrationEntries = {
+  migrationUnsupportedEntries: MigrationUnsupportedPtyEntry[]
+  legacyPaneKeyAliasEntries: LegacyPaneKeyAliasEntry[]
+}
+
 function collectMigrationUnsupportedPtyEntries(args: {
   session: WorkspaceSessionState
   tabId: string
   inputLayout: TerminalLayoutSnapshot
   normalizedLayout: TerminalLayoutSnapshot
   leafIdByInputLeafId: Map<string, string>
-  sourceForPtyId: (ptyId: string) => 'local' | 'ssh'
-}): MigrationUnsupportedPtyEntry[] {
+}): PaneIdentityMigrationEntries {
   const worktreeId = findWorktreeIdForTab(args.session, args.tabId)
   const tab = worktreeId
     ? args.session.tabsByWorktree?.[worktreeId]?.find((entry) => entry.id === args.tabId)
     : undefined
-  const registerLegacyAlias = (inputLeafId: string, leafId: string): void => {
+  const legacyPaneKeyAliasEntries: LegacyPaneKeyAliasEntry[] = []
+  const registeredLegacyPaneKeys = new Set<string>()
+  const hasLeafPtyBindings = Object.keys(args.inputLayout.ptyIdsByLeafId ?? {}).length > 0
+  const fallbackPtyId =
+    !hasLeafPtyBindings && typeof tab?.ptyId === 'string' ? tab.ptyId : undefined
+  const registerLegacyAlias = (inputLeafId: string, leafId: string, ptyId?: string): boolean => {
     if (!isTerminalLeafId(leafId)) {
-      return
+      return false
     }
     let paneKey: string
     try {
       paneKey = makePaneKey(args.tabId, leafId)
     } catch {
-      return
+      return false
     }
     const numeric = /^(?:pane:)?(\d+)$/.exec(inputLeafId)?.[1]
     if (!numeric) {
-      return
+      return false
     }
     // Why: persisted PaneManager ids are 1-based. A zero-based alias in split
     // layouts would make tab:1 ambiguous and can route the first pane to the second.
-    agentHookServer.registerPaneKeyAlias(`${args.tabId}:${numeric}`, paneKey)
+    const legacyPaneKey = `${args.tabId}:${numeric}`
+    agentHookServer.registerPaneKeyAlias(legacyPaneKey, paneKey, ptyId)
+    registeredLegacyPaneKeys.add(legacyPaneKey)
+    if (ptyId) {
+      legacyPaneKeyAliasEntries.push({
+        ptyId,
+        legacyPaneKey,
+        stablePaneKey: paneKey,
+        updatedAt: Date.now()
+      })
+      return true
+    }
+    return false
   }
-  let registeredAlias = false
   const inputLeafIds = new Set([
     ...collectLayoutLeafIdsInOrder(args.inputLayout.root),
     ...Object.keys(args.inputLayout.ptyIdsByLeafId ?? {})
@@ -454,27 +480,74 @@ function collectMigrationUnsupportedPtyEntries(args: {
     }
     const leafId = args.leafIdByInputLeafId.get(inputLeafId)
     if (leafId) {
-      registerLegacyAlias(inputLeafId, leafId)
-      registeredAlias = true
+      registerLegacyAlias(
+        inputLeafId,
+        leafId,
+        args.inputLayout.ptyIdsByLeafId?.[inputLeafId] ?? fallbackPtyId
+      )
     }
   }
-  if (
-    !registeredAlias &&
-    tab?.ptyId &&
-    Object.keys(args.inputLayout.ptyIdsByLeafId ?? {}).length === 0
-  ) {
+  if (tab?.ptyId && !hasLeafPtyBindings) {
     const fallbackLeafId =
       args.normalizedLayout.activeLeafId ?? firstLayoutLeafId(args.normalizedLayout.root)
     if (fallbackLeafId && isTerminalLeafId(fallbackLeafId)) {
       const paneKey = makePaneKey(args.tabId, fallbackLeafId)
-      agentHookServer.registerPaneKeyAlias(`${args.tabId}:0`, paneKey)
-      agentHookServer.registerPaneKeyAlias(`${args.tabId}:1`, paneKey)
+      for (const legacyPaneKey of [`${args.tabId}:0`, `${args.tabId}:1`]) {
+        if (registeredLegacyPaneKeys.has(legacyPaneKey)) {
+          continue
+        }
+        agentHookServer.registerPaneKeyAlias(legacyPaneKey, paneKey, tab.ptyId)
+        legacyPaneKeyAliasEntries.push({
+          ptyId: tab.ptyId,
+          legacyPaneKey,
+          stablePaneKey: paneKey,
+          updatedAt: Date.now()
+        })
+      }
     }
   }
   // Why: legacy numeric pane keys are now bridged by aliases instead of
   // persisted as restart-required rows. Existing saved rows are pruned during
   // normalizePersistedPaneIdentityState.
-  return []
+  return { migrationUnsupportedEntries: [], legacyPaneKeyAliasEntries }
+}
+
+function legacyMigrationUnsupportedRowsToAliasEntries(
+  entries: MigrationUnsupportedPtyEntry[]
+): LegacyPaneKeyAliasEntry[] {
+  const normalizedEntries = normalizeMigrationUnsupportedPtyEntries(entries).filter(
+    (entry) => entry.tabId && entry.paneKey && parsePaneKey(entry.paneKey)
+  )
+  const entriesByTabId = new Map<string, MigrationUnsupportedPtyEntry[]>()
+  for (const entry of normalizedEntries) {
+    const tabId = entry.tabId
+    if (!tabId) {
+      continue
+    }
+    entriesByTabId.set(tabId, [...(entriesByTabId.get(tabId) ?? []), entry])
+  }
+  const aliasEntries: LegacyPaneKeyAliasEntry[] = []
+  for (const [tabId, tabEntries] of entriesByTabId) {
+    if (tabEntries.length !== 1) {
+      continue
+    }
+    const [entry] = tabEntries
+    if (!entry.paneKey) {
+      continue
+    }
+    // Why: pre-stable dev/RC migration rows did not store the old numeric
+    // key. Only synthesize the single-pane aliases when the row is unambiguous
+    // for its tab; split rows need layout-derived aliases instead of a guess.
+    for (const legacyPaneKey of [`${tabId}:0`, `${tabId}:1`]) {
+      aliasEntries.push({
+        ptyId: entry.ptyId,
+        legacyPaneKey,
+        stablePaneKey: entry.paneKey,
+        updatedAt: entry.updatedAt
+      })
+    }
+  }
+  return aliasEntries
 }
 
 function normalizeTerminalLayoutSnapshotForPersistence(
@@ -600,19 +673,20 @@ function normalizeTerminalLayoutSnapshotForPersistence(
 
 function normalizeWorkspaceSessionPaneIdentities(
   session: WorkspaceSessionState,
-  priorLayoutsByTabId: Record<string, TerminalLayoutSnapshot> = {},
-  sourceForPtyId: (ptyId: string) => 'local' | 'ssh' = () => 'local'
+  priorLayoutsByTabId: Record<string, TerminalLayoutSnapshot> = {}
 ): {
   session: WorkspaceSessionState
   changed: boolean
   leafIdByInputLeafIdByTabId: Map<string, Map<string, string>>
   leafIdByPtyIdByTabId: Map<string, Map<string, string>>
   migrationUnsupportedEntries: MigrationUnsupportedPtyEntry[]
+  legacyPaneKeyAliasEntries: LegacyPaneKeyAliasEntry[]
 } {
   let changed = false
   const leafIdByInputLeafIdByTabId = new Map<string, Map<string, string>>()
   const leafIdByPtyIdByTabId = new Map<string, Map<string, string>>()
   const migrationUnsupportedEntries: MigrationUnsupportedPtyEntry[] = []
+  const legacyPaneKeyAliasEntries: LegacyPaneKeyAliasEntry[] = []
   const terminalLayoutsByTabId: Record<string, TerminalLayoutSnapshot> = {}
   for (const [tabId, layout] of Object.entries(session.terminalLayoutsByTabId ?? {})) {
     const normalized = normalizeTerminalLayoutSnapshotForPersistence(
@@ -621,16 +695,15 @@ function normalizeWorkspaceSessionPaneIdentities(
     )
     terminalLayoutsByTabId[tabId] = normalized.snapshot
     leafIdByInputLeafIdByTabId.set(tabId, normalized.leafIdByInputLeafId)
-    migrationUnsupportedEntries.push(
-      ...collectMigrationUnsupportedPtyEntries({
-        session,
-        tabId,
-        inputLayout: layout,
-        normalizedLayout: normalized.snapshot,
-        leafIdByInputLeafId: normalized.leafIdByInputLeafId,
-        sourceForPtyId
-      })
-    )
+    const migrationEntries = collectMigrationUnsupportedPtyEntries({
+      session,
+      tabId,
+      inputLayout: layout,
+      normalizedLayout: normalized.snapshot,
+      leafIdByInputLeafId: normalized.leafIdByInputLeafId
+    })
+    migrationUnsupportedEntries.push(...migrationEntries.migrationUnsupportedEntries)
+    legacyPaneKeyAliasEntries.push(...migrationEntries.legacyPaneKeyAliasEntries)
     const leafIdByPtyId = new Map<string, string>()
     const duplicatePtyIds = new Set<string>()
     for (const [leafId, ptyId] of Object.entries(normalized.snapshot.ptyIdsByLeafId ?? {})) {
@@ -652,7 +725,8 @@ function normalizeWorkspaceSessionPaneIdentities(
     changed,
     leafIdByInputLeafIdByTabId,
     leafIdByPtyIdByTabId,
-    migrationUnsupportedEntries
+    migrationUnsupportedEntries,
+    legacyPaneKeyAliasEntries
   }
 }
 
@@ -690,28 +764,39 @@ function normalizePersistedPaneIdentityState(state: PersistedState): {
   state: PersistedState
   changed: boolean
   migrationUnsupportedEntries: MigrationUnsupportedPtyEntry[]
+  legacyPaneKeyAliasEntries: LegacyPaneKeyAliasEntry[]
 } {
-  const sshPtyIds = new Set((state.sshRemotePtyLeases ?? []).map((lease) => lease.ptyId))
-  const normalizedSession = normalizeWorkspaceSessionPaneIdentities(
-    state.workspaceSession,
-    {},
-    (ptyId) => (sshPtyIds.has(ptyId) ? 'ssh' : 'local')
-  )
+  const normalizedSession = normalizeWorkspaceSessionPaneIdentities(state.workspaceSession, {})
   const remappedLeases = remapSshRemotePtyLeaseLeafIds(
     state.sshRemotePtyLeases ?? [],
     normalizedSession.leafIdByInputLeafIdByTabId,
     normalizedSession.leafIdByPtyIdByTabId
   )
   const mergedMigrationUnsupportedEntries: MigrationUnsupportedPtyEntry[] = []
+  const mergedLegacyPaneKeyAliasEntries = mergeLegacyPaneKeyAliasEntries([
+    ...normalizeLegacyPaneKeyAliasEntries(state.legacyPaneKeyAliasEntries),
+    ...legacyMigrationUnsupportedRowsToAliasEntries(state.migrationUnsupportedPtyEntries ?? []),
+    ...normalizedSession.legacyPaneKeyAliasEntries
+  ])
   const migrationUnsupportedChanged = !migrationUnsupportedEntriesEqual(
     state.migrationUnsupportedPtyEntries ?? [],
     mergedMigrationUnsupportedEntries
   )
-  if (!normalizedSession.changed && !remappedLeases.changed && !migrationUnsupportedChanged) {
+  const legacyAliasesChanged = !legacyPaneKeyAliasEntriesEqual(
+    state.legacyPaneKeyAliasEntries ?? [],
+    mergedLegacyPaneKeyAliasEntries
+  )
+  if (
+    !normalizedSession.changed &&
+    !remappedLeases.changed &&
+    !migrationUnsupportedChanged &&
+    !legacyAliasesChanged
+  ) {
     return {
       state,
       changed: false,
-      migrationUnsupportedEntries: mergedMigrationUnsupportedEntries
+      migrationUnsupportedEntries: mergedMigrationUnsupportedEntries,
+      legacyPaneKeyAliasEntries: mergedLegacyPaneKeyAliasEntries
     }
   }
   return {
@@ -719,10 +804,12 @@ function normalizePersistedPaneIdentityState(state: PersistedState): {
       ...state,
       workspaceSession: normalizedSession.session,
       sshRemotePtyLeases: remappedLeases.leases,
-      migrationUnsupportedPtyEntries: mergedMigrationUnsupportedEntries
+      migrationUnsupportedPtyEntries: mergedMigrationUnsupportedEntries,
+      legacyPaneKeyAliasEntries: mergedLegacyPaneKeyAliasEntries
     },
     changed: true,
-    migrationUnsupportedEntries: mergedMigrationUnsupportedEntries
+    migrationUnsupportedEntries: mergedMigrationUnsupportedEntries,
+    legacyPaneKeyAliasEntries: mergedLegacyPaneKeyAliasEntries
   }
 }
 
@@ -746,6 +833,57 @@ function normalizeMigrationUnsupportedPtyEntries(value: unknown): MigrationUnsup
       (candidate.source === 'local' || candidate.source === 'ssh') &&
       Number.isFinite(candidate.updatedAt)
     )
+  })
+}
+
+function normalizeLegacyPaneKeyAliasEntries(value: unknown): LegacyPaneKeyAliasEntry[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+  return value.filter((entry): entry is LegacyPaneKeyAliasEntry => {
+    if (!entry || typeof entry !== 'object') {
+      return false
+    }
+    const candidate = entry as Partial<LegacyPaneKeyAliasEntry>
+    if (
+      typeof candidate.ptyId !== 'string' ||
+      candidate.ptyId.trim().length === 0 ||
+      typeof candidate.legacyPaneKey !== 'string' ||
+      typeof candidate.stablePaneKey !== 'string' ||
+      !Number.isFinite(candidate.updatedAt)
+    ) {
+      return false
+    }
+    const legacy = parseLegacyNumericPaneKey(candidate.legacyPaneKey)
+    const stable = parsePaneKey(candidate.stablePaneKey)
+    return Boolean(legacy && stable && legacy.tabId === stable.tabId)
+  })
+}
+
+function mergeLegacyPaneKeyAliasEntries(
+  entries: LegacyPaneKeyAliasEntry[]
+): LegacyPaneKeyAliasEntry[] {
+  const byLegacyPaneKey = new Map<string, LegacyPaneKeyAliasEntry>()
+  for (const entry of normalizeLegacyPaneKeyAliasEntries(entries)) {
+    const existing = byLegacyPaneKey.get(entry.legacyPaneKey)
+    if (!existing || existing.updatedAt <= entry.updatedAt) {
+      byLegacyPaneKey.set(entry.legacyPaneKey, entry)
+    }
+  }
+  return [...byLegacyPaneKey.values()]
+}
+
+function legacyPaneKeyAliasEntriesEqual(
+  left: LegacyPaneKeyAliasEntry[],
+  right: LegacyPaneKeyAliasEntry[]
+): boolean {
+  if (left.length !== right.length) {
+    return false
+  }
+  const rightByLegacyPaneKey = new Map(right.map((entry) => [entry.legacyPaneKey, entry]))
+  return left.every((entry) => {
+    const other = rightByLegacyPaneKey.get(entry.legacyPaneKey)
+    return other ? JSON.stringify(entry) === JSON.stringify(other) : false
   })
 }
 
@@ -803,8 +941,21 @@ export class Store {
     for (const entry of normalized.migrationUnsupportedEntries) {
       setMigrationUnsupportedPty(entry)
     }
+    for (const entry of normalized.legacyPaneKeyAliasEntries) {
+      agentHookServer.registerPaneKeyAlias(
+        entry.legacyPaneKey,
+        entry.stablePaneKey,
+        entry.ptyId,
+        entry.updatedAt,
+        { overwriteExisting: false }
+      )
+    }
     setMigrationUnsupportedPtyPersistenceListener((entries) => {
       this.state.migrationUnsupportedPtyEntries = entries
+      this.scheduleSave()
+    })
+    agentHookServer.setPaneKeyAliasPersistenceListener((entries) => {
+      this.state.legacyPaneKeyAliasEntries = entries
       this.scheduleSave()
     })
     if (normalized.changed) {
@@ -1082,6 +1233,9 @@ export class Store {
             .filter((lease): lease is SshRemotePtyLease => lease !== null),
           migrationUnsupportedPtyEntries: normalizeMigrationUnsupportedPtyEntries(
             parsed.migrationUnsupportedPtyEntries
+          ),
+          legacyPaneKeyAliasEntries: normalizeLegacyPaneKeyAliasEntries(
+            parsed.legacyPaneKeyAliasEntries
           ),
           automations: Array.isArray(parsed.automations) ? parsed.automations : [],
           automationRuns: Array.isArray(parsed.automationRuns) ? parsed.automationRuns : [],
@@ -1852,14 +2006,21 @@ export class Store {
     // the durable binding and re-open the orphan window. Merge in any
     // existing bindings whenever the incoming snapshot's binding is empty.
     const prior = this.state.workspaceSession
-    const sshPtyIds = new Set((this.state.sshRemotePtyLeases ?? []).map((lease) => lease.ptyId))
     const normalized = normalizeWorkspaceSessionPaneIdentities(
       session,
-      prior?.terminalLayoutsByTabId,
-      (ptyId) => (sshPtyIds.has(ptyId) ? 'ssh' : 'local')
+      prior?.terminalLayoutsByTabId
     )
     for (const entry of normalized.migrationUnsupportedEntries) {
       setMigrationUnsupportedPty(entry)
+    }
+    for (const entry of normalized.legacyPaneKeyAliasEntries) {
+      agentHookServer.registerPaneKeyAlias(
+        entry.legacyPaneKey,
+        entry.stablePaneKey,
+        entry.ptyId,
+        entry.updatedAt,
+        { overwriteExisting: false }
+      )
     }
     session = normalized.session
     const remappedLeases = remapSshRemotePtyLeaseLeafIds(

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -320,6 +320,7 @@ export function getDefaultPersistedState(homedir: string): PersistedState {
     sshTargets: [],
     sshRemotePtyLeases: [],
     migrationUnsupportedPtyEntries: [],
+    legacyPaneKeyAliasEntries: [],
     automations: [],
     automationRuns: [],
     onboarding: getDefaultOnboardingState()

--- a/src/shared/stable-pane-id.test.ts
+++ b/src/shared/stable-pane-id.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { isStablePaneId, isTerminalLeafId, makePaneKey, parsePaneKey } from './stable-pane-id'
+import {
+  isStablePaneId,
+  isTerminalLeafId,
+  makePaneKey,
+  parseLegacyNumericPaneKey,
+  parsePaneKey
+} from './stable-pane-id'
 
 const LEAF_ID = '11111111-1111-4111-8111-111111111111'
 
@@ -38,5 +44,15 @@ describe('stable pane ids', () => {
     expect(parsePaneKey(`tab:1:${LEAF_ID}`)).toBeNull()
     expect(parsePaneKey(`:${LEAF_ID}`)).toBeNull()
     expect(parsePaneKey('tab-1:')).toBeNull()
+  })
+
+  it('parses legacy numeric pane keys only for migration aliases', () => {
+    expect(parseLegacyNumericPaneKey(' tab-1:12 ')).toEqual({
+      tabId: 'tab-1',
+      numericPaneId: '12',
+      paneKey: 'tab-1:12'
+    })
+    expect(parseLegacyNumericPaneKey(`tab-1:${LEAF_ID}`)).toBeNull()
+    expect(parseLegacyNumericPaneKey('tab:1:12')).toBeNull()
   })
 })

--- a/src/shared/stable-pane-id.ts
+++ b/src/shared/stable-pane-id.ts
@@ -43,3 +43,25 @@ export function parsePaneKey(
   }
   return { tabId, leafId, stablePaneId: leafId }
 }
+
+export function parseLegacyNumericPaneKey(
+  paneKey: unknown
+): { tabId: string; numericPaneId: string; paneKey: string } | null {
+  if (typeof paneKey !== 'string' || paneKey.length > 256) {
+    return null
+  }
+  const trimmed = paneKey.trim()
+  const delimiter = trimmed.indexOf(':')
+  if (
+    delimiter <= 0 ||
+    delimiter !== trimmed.lastIndexOf(':') ||
+    delimiter === trimmed.length - 1
+  ) {
+    return null
+  }
+  const numericPaneId = trimmed.slice(delimiter + 1)
+  if (!/^\d+$/.test(numericPaneId)) {
+    return null
+  }
+  return { tabId: trimmed.slice(0, delimiter), numericPaneId, paneKey: trimmed }
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1796,6 +1796,13 @@ export type PersistedTrustedOrcaHookRepo = {
 
 export type PersistedTrustedOrcaHooks = Record<string, PersistedTrustedOrcaHookRepo>
 
+export type LegacyPaneKeyAliasEntry = {
+  ptyId: string
+  legacyPaneKey: string
+  stablePaneKey: string
+  updatedAt: number
+}
+
 // ─── Persistence shape ──────────────────────────────────────────────
 export type PersistedState = {
   schemaVersion: number
@@ -1814,6 +1821,7 @@ export type PersistedState = {
   sshTargets: SshTarget[]
   sshRemotePtyLeases: SshRemotePtyLease[]
   migrationUnsupportedPtyEntries: MigrationUnsupportedPtyEntry[]
+  legacyPaneKeyAliasEntries: LegacyPaneKeyAliasEntry[]
   automations: Automation[]
   automationRuns: AutomationRun[]
   onboarding: OnboardingState


### PR DESCRIPTION
## Summary
- bridge legacy numeric agent pane keys to stable UUID pane keys during persisted layout migration
- resolve legacy cached status hydration, local hook posts, SSH relay ingests, PTY reattach, and user-initiated drop/clear paths through aliases
- prune recoverable synthetic migration-unavailable rows instead of persisting restart-required placeholders
- add regression coverage for single-pane, split-pane, and missing PTY binding upgrade fixtures

## Verification
- pnpm vitest run src/main/agent-hooks/server.test.ts src/main/persistence.test.ts src/main/ipc/pty.test.ts src/shared/stable-pane-id.test.ts
- pnpm run tc:node
- pnpm lint
- git diff --check
- manual pn dev legacy fixture: seeded old `tabId:1` entries in `agent-hooks/last-status.json` plus matching `pane:1` layouts after stopping Orca, restarted `pn dev`, and verified restored working/waiting agent rows render under migrated stable pane keys

## Notes
- Preserves real cached statuses when the pre-migration `last-status.json` still exists; it cannot reconstruct statuses if an earlier broken dev migration already rewrote that file empty.

Made with [Orca](https://github.com/stablyai/orca) 🐋
