### PR TITLE
Add skills discovery page

### DIFF
--- a/src/main/ipc/register-core-handlers.test.ts
+++ b/src/main/ipc/register-core-handlers.test.ts
@@ -43,6 +43,7 @@ const {
   registerExportHandlersMock,
   registerOnboardingHandlersMock,
   registerSpeechHandlersMock,
+  registerSkillsHandlersMock,
   registerWorkspaceSpaceHandlersMock
 } = vi.hoisted(() => ({
   registerCliHandlersMock: vi.fn(),
@@ -85,6 +86,7 @@ const {
   registerExportHandlersMock: vi.fn(),
   registerOnboardingHandlersMock: vi.fn(),
   registerSpeechHandlersMock: vi.fn(),
+  registerSkillsHandlersMock: vi.fn(),
   registerWorkspaceSpaceHandlersMock: vi.fn()
 }))
 
@@ -154,6 +156,10 @@ vi.mock('./computer-use-permissions', () => ({
 
 vi.mock('./settings', () => ({
   registerSettingsHandlers: registerSettingsHandlersMock
+}))
+
+vi.mock('./skills', () => ({
+  registerSkillsHandlers: registerSkillsHandlersMock
 }))
 
 vi.mock('./workspace-space', () => ({
@@ -286,6 +292,7 @@ describe('registerCoreHandlers', () => {
     registerHostedReviewHandlersMock.mockReset()
     registerExportHandlersMock.mockReset()
     registerSpeechHandlersMock.mockReset()
+    registerSkillsHandlersMock.mockReset()
     registerWorkspaceSpaceHandlersMock.mockReset()
   })
 
@@ -332,6 +339,7 @@ describe('registerCoreHandlers', () => {
     expect(registerDeveloperPermissionHandlersMock).toHaveBeenCalled()
     expect(registerComputerUsePermissionHandlersMock).toHaveBeenCalled()
     expect(registerSettingsHandlersMock).toHaveBeenCalledWith(store, undefined)
+    expect(registerSkillsHandlersMock).toHaveBeenCalledWith(store)
     expect(registerWorkspaceSpaceHandlersMock).toHaveBeenCalledWith(store)
     expect(registerTelemetryHandlersMock).toHaveBeenCalledWith(store)
     expect(registerSessionHandlersMock).toHaveBeenCalledWith(store)

--- a/src/main/ipc/register-core-handlers.ts
+++ b/src/main/ipc/register-core-handlers.ts
@@ -31,6 +31,7 @@ import { registerComputerUsePermissionHandlers } from './computer-use-permission
 import { setTrustedBrowserRendererWebContentsId, setAgentBrowserBridgeRef } from './browser'
 import { registerSessionHandlers } from './session'
 import { registerSettingsHandlers } from './settings'
+import { registerSkillsHandlers } from './skills'
 import { registerWorkspaceSpaceHandlers } from './workspace-space'
 import { registerAutomationHandlers } from './automations'
 import { registerTelemetryHandlers } from './telemetry'
@@ -111,6 +112,7 @@ export function registerCoreHandlers(
   registerDeveloperPermissionHandlers()
   registerComputerUsePermissionHandlers()
   registerSettingsHandlers(store, agentAwakeService)
+  registerSkillsHandlers(store)
   if (automations) {
     registerAutomationHandlers(store, automations)
   }

--- a/src/main/ipc/skills.ts
+++ b/src/main/ipc/skills.ts
@@ -1,0 +1,10 @@
+import { ipcMain } from 'electron'
+import type { Store } from '../persistence'
+import { discoverSkills } from '../skills/discovery'
+import type { SkillDiscoveryResult } from '../../shared/skills'
+
+export function registerSkillsHandlers(store: Store): void {
+  ipcMain.handle('skills:discover', async (): Promise<SkillDiscoveryResult> => {
+    return discoverSkills({ repos: store.getRepos() })
+  })
+}

--- a/src/main/skills/discovery.test.ts
+++ b/src/main/skills/discovery.test.ts
@@ -1,0 +1,58 @@
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { buildSkillDiscoverySources, discoverSkills } from './discovery'
+import type { Repo } from '../../shared/types'
+
+function makeRepo(path: string, connectionId: string | null = null): Repo {
+  return {
+    id: `repo-${path}`,
+    path,
+    displayName: 'Repo',
+    badgeColor: '#737373',
+    addedAt: 1,
+    kind: 'git',
+    connectionId
+  }
+}
+
+describe('skill discovery', () => {
+  it('discovers home and repo SKILL.md packages with provider metadata', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-skills-'))
+    const home = join(root, 'home')
+    const repo = join(root, 'repo')
+    const codexSkill = join(home, '.codex', 'skills', 'review')
+    const repoSkill = join(repo, '.claude', 'skills', 'docs')
+    await mkdir(codexSkill, { recursive: true })
+    await mkdir(repoSkill, { recursive: true })
+    await writeFile(
+      join(codexSkill, 'SKILL.md'),
+      ['---', 'name: code-review', 'description: Review code changes.', '---', ''].join('\n')
+    )
+    await writeFile(join(repoSkill, 'SKILL.md'), '# Docs\n\nWrite project docs.')
+
+    const result = await discoverSkills({
+      homeDir: home,
+      cwd: join(root, 'missing-cwd'),
+      repos: [makeRepo(repo)]
+    })
+
+    expect(result.skills.map((skill) => skill.name).sort()).toEqual(['Docs', 'code-review'])
+    expect(result.skills.find((skill) => skill.name === 'code-review')?.providers).toEqual([
+      'codex'
+    ])
+    expect(result.skills.find((skill) => skill.name === 'Docs')?.providers).toEqual(['claude'])
+  })
+
+  it('does not add SSH-backed repository paths to local scan roots', () => {
+    const roots = buildSkillDiscoverySources({
+      homeDir: '/home/test',
+      cwd: '/workspace/current',
+      repos: [makeRepo('/remote/repo', 'ssh-1')]
+    })
+
+    expect(roots.map((root) => root.path)).not.toContain('/remote/repo/.claude/skills')
+    expect(roots.map((root) => root.path)).toContain('/workspace/current/.claude/skills')
+  })
+})

--- a/src/main/skills/discovery.ts
+++ b/src/main/skills/discovery.ts
@@ -1,0 +1,264 @@
+import { createHash } from 'node:crypto'
+import type { Dirent } from 'node:fs'
+import { readdir, readFile, stat } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { basename, dirname, join, relative, sep } from 'node:path'
+import type { Repo } from '../../shared/types'
+import { summarizeSkillMarkdown } from '../../shared/skill-metadata'
+import type {
+  DiscoveredSkill,
+  SkillDiscoveryResult,
+  SkillDiscoverySource,
+  SkillProvider,
+  SkillSourceKind
+} from '../../shared/skills'
+
+type SkillScanRoot = Omit<SkillDiscoverySource, 'exists' | 'skippedReason'>
+
+const SKILL_FILE_NAME = 'SKILL.md'
+const MAX_MARKDOWN_BYTES = 256 * 1024
+const MAX_SKILL_FILES = 200
+
+async function pathExists(pathValue: string): Promise<boolean> {
+  try {
+    await stat(pathValue)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function stableId(pathValue: string): string {
+  return createHash('sha1').update(pathValue).digest('hex').slice(0, 16)
+}
+
+function compareSkills(a: DiscoveredSkill, b: DiscoveredSkill): number {
+  return (
+    a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }) ||
+    a.sourceLabel.localeCompare(b.sourceLabel, undefined, { sensitivity: 'base' }) ||
+    a.skillFilePath.localeCompare(b.skillFilePath)
+  )
+}
+
+function isWithinDepth(rootPath: string, childPath: string, maxDepth: number): boolean {
+  const rel = relative(rootPath, childPath)
+  if (!rel || rel.startsWith('..')) {
+    return true
+  }
+  return rel.split(sep).length <= maxDepth
+}
+
+function sourceKindForSkill(root: SkillScanRoot, skillFilePath: string): SkillSourceKind {
+  if (
+    root.sourceKind === 'home' &&
+    relative(root.path, skillFilePath).split(sep)[0] === '.system'
+  ) {
+    return 'bundled'
+  }
+  return root.sourceKind
+}
+
+function sourceLabelForSkill(root: SkillScanRoot, sourceKind: SkillSourceKind): string {
+  if (sourceKind === 'bundled') {
+    return `${root.label} bundled`
+  }
+  return root.label
+}
+
+async function findSkillFiles(rootPath: string, maxDepth: number): Promise<string[]> {
+  const out: string[] = []
+  async function visit(dirPath: string): Promise<void> {
+    if (!isWithinDepth(rootPath, dirPath, maxDepth)) {
+      return
+    }
+    let entries: Dirent[]
+    try {
+      entries = await readdir(dirPath, { withFileTypes: true })
+    } catch {
+      return
+    }
+    for (const entry of entries) {
+      const entryPath = join(dirPath, entry.name)
+      if (entry.isFile() && entry.name === SKILL_FILE_NAME) {
+        out.push(entryPath)
+        continue
+      }
+      if (entry.isDirectory()) {
+        await visit(entryPath)
+      }
+    }
+  }
+  await visit(rootPath)
+  return out
+}
+
+async function countFiles(dirPath: string): Promise<number> {
+  let count = 0
+  async function visit(currentPath: string): Promise<void> {
+    if (count >= MAX_SKILL_FILES) {
+      return
+    }
+    let entries: Dirent[]
+    try {
+      entries = await readdir(currentPath, { withFileTypes: true })
+    } catch {
+      return
+    }
+    for (const entry of entries) {
+      if (count >= MAX_SKILL_FILES) {
+        return
+      }
+      const entryPath = join(currentPath, entry.name)
+      if (entry.isFile()) {
+        count += 1
+      } else if (entry.isDirectory()) {
+        await visit(entryPath)
+      }
+    }
+  }
+  await visit(dirPath)
+  return count
+}
+
+async function readSkillSummary(skillFilePath: string): Promise<{
+  name: string | null
+  description: string | null
+  updatedAt: number | null
+}> {
+  try {
+    const fileStat = await stat(skillFilePath)
+    const content = await readFile(skillFilePath, {
+      encoding: 'utf8',
+      flag: 'r'
+    })
+    return {
+      ...summarizeSkillMarkdown(content.slice(0, MAX_MARKDOWN_BYTES)),
+      updatedAt: fileStat.mtimeMs
+    }
+  } catch {
+    return { name: null, description: null, updatedAt: null }
+  }
+}
+
+async function scanRoot(root: SkillScanRoot): Promise<DiscoveredSkill[]> {
+  const maxDepth = root.sourceKind === 'plugin' ? 9 : 4
+  const skillFiles = await findSkillFiles(root.path, maxDepth)
+  const skills = await Promise.all(
+    skillFiles.map(async (skillFilePath) => {
+      const directoryPath = dirname(skillFilePath)
+      const summary = await readSkillSummary(skillFilePath)
+      const sourceKind = sourceKindForSkill(root, skillFilePath)
+      return {
+        id: stableId(skillFilePath),
+        name: summary.name ?? basename(directoryPath),
+        description: summary.description,
+        providers: root.providers,
+        sourceKind,
+        sourceLabel: sourceLabelForSkill(root, sourceKind),
+        rootPath: root.path,
+        directoryPath,
+        skillFilePath,
+        installed: true,
+        fileCount: await countFiles(directoryPath),
+        updatedAt: summary.updatedAt
+      } satisfies DiscoveredSkill
+    })
+  )
+  return skills
+}
+
+function source(
+  id: string,
+  label: string,
+  path: string,
+  sourceKind: SkillSourceKind,
+  providers: SkillProvider[]
+): SkillScanRoot {
+  return { id, label, path, sourceKind, providers }
+}
+
+export function buildSkillDiscoverySources(
+  args: {
+    homeDir?: string
+    cwd?: string
+    repos?: Repo[]
+  } = {}
+): SkillScanRoot[] {
+  const home = args.homeDir ?? homedir()
+  const cwd = args.cwd ?? process.cwd()
+  const roots: SkillScanRoot[] = [
+    source('home-codex', 'Codex home', join(home, '.codex', 'skills'), 'home', ['codex']),
+    source('home-agents', 'Agent skills home', join(home, '.agents', 'skills'), 'home', [
+      'agent-skills'
+    ]),
+    source('home-claude', 'Claude home', join(home, '.claude', 'skills'), 'home', ['claude']),
+    source(
+      'codex-plugin-cache',
+      'Codex plugin cache',
+      join(home, '.codex', 'plugins', 'cache'),
+      'plugin',
+      ['codex', 'agent-skills']
+    )
+  ]
+
+  const repoPaths = new Set<string>()
+  for (const repo of args.repos ?? []) {
+    if (repo.connectionId) {
+      continue
+    }
+    repoPaths.add(repo.path)
+  }
+  repoPaths.add(cwd)
+
+  for (const repoPath of repoPaths) {
+    const label = `Repo ${basename(repoPath)}`
+    roots.push(
+      source(
+        `repo-agents-${stableId(repoPath)}`,
+        `${label} .agents`,
+        join(repoPath, '.agents', 'skills'),
+        'repo',
+        ['agent-skills']
+      ),
+      source(
+        `repo-claude-${stableId(repoPath)}`,
+        `${label} .claude`,
+        join(repoPath, '.claude', 'skills'),
+        'repo',
+        ['claude']
+      )
+    )
+  }
+
+  return roots
+}
+
+export async function discoverSkills(args: {
+  repos?: Repo[]
+  homeDir?: string
+  cwd?: string
+}): Promise<SkillDiscoveryResult> {
+  const roots = buildSkillDiscoverySources(args)
+  const sources: SkillDiscoverySource[] = []
+  const skillGroups = await Promise.all(
+    roots.map(async (root) => {
+      const exists = await pathExists(root.path)
+      sources.push({ ...root, exists, skippedReason: exists ? undefined : 'missing' })
+      if (!exists) {
+        return []
+      }
+      return scanRoot(root)
+    })
+  )
+  const seen = new Map<string, DiscoveredSkill>()
+  for (const skill of skillGroups.flat()) {
+    seen.set(skill.skillFilePath, skill)
+  }
+  return {
+    skills: Array.from(seen.values()).sort(compareSkills),
+    sources: sources.sort((a, b) =>
+      a.label.localeCompare(b.label, undefined, { sensitivity: 'base' })
+    ),
+    scannedAt: Date.now()
+  }
+}

--- a/src/main/skills/discovery.ts
+++ b/src/main/skills/discovery.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto'
 import type { Dirent } from 'node:fs'
-import { readdir, readFile, stat } from 'node:fs/promises'
+import { open, readdir, stat } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { basename, dirname, join, relative, sep } from 'node:path'
 import type { Repo } from '../../shared/types'
@@ -127,12 +127,17 @@ async function readSkillSummary(skillFilePath: string): Promise<{
 }> {
   try {
     const fileStat = await stat(skillFilePath)
-    const content = await readFile(skillFilePath, {
-      encoding: 'utf8',
-      flag: 'r'
-    })
+    const file = await open(skillFilePath, 'r')
+    let content = ''
+    try {
+      const buffer = Buffer.alloc(Math.min(fileStat.size, MAX_MARKDOWN_BYTES))
+      const { bytesRead } = await file.read(buffer, 0, buffer.length, 0)
+      content = buffer.toString('utf8', 0, bytesRead)
+    } finally {
+      await file.close()
+    }
     return {
-      ...summarizeSkillMarkdown(content.slice(0, MAX_MARKDOWN_BYTES)),
+      ...summarizeSkillMarkdown(content),
       updatedAt: fileStat.mtimeMs
     }
   } catch {

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -157,6 +157,7 @@ import type {
   RuntimeTerminalDriverState
 } from '../shared/runtime-types'
 import type { ShellOpenLocalPathResult } from '../shared/shell-open-types'
+import type { SkillDiscoveryResult } from '../shared/skills'
 
 export type { ShellOpenLocalPathResult } from '../shared/shell-open-types'
 
@@ -1118,6 +1119,9 @@ export type PreloadApi = {
     pickAudio: () => Promise<string | null>
     pickDirectory: (args: { defaultPath?: string }) => Promise<string | null>
     copyFile: (args: { srcPath: string; destPath: string }) => Promise<void>
+  }
+  skills: {
+    discover: () => Promise<SkillDiscoveryResult>
   }
   pet: {
     import: () => Promise<CustomPet | null>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -33,6 +33,7 @@ import type {
   WorktreeRemoteBranchConflictEvent
 } from '../shared/types'
 import type { ShellOpenLocalPathResult } from '../shared/shell-open-types'
+import type { SkillDiscoveryResult } from '../shared/skills'
 import type {
   RuntimeStatus,
   RuntimeSyncWindowGraph,
@@ -1259,6 +1260,10 @@ const api = {
 
     copyFile: (args: { srcPath: string; destPath: string }): Promise<void> =>
       ipcRenderer.invoke('shell:copyFile', args)
+  },
+
+  skills: {
+    discover: (): Promise<SkillDiscoveryResult> => ipcRenderer.invoke('skills:discover')
   },
 
   pet: {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -161,6 +161,7 @@ const TaskPage = lazy(() => import('./components/TaskPage'))
 const AutomationsPage = lazy(() => import('./components/automations/AutomationsPage'))
 const ActivityPrototypePage = lazy(() => import('./components/activity/ActivityPrototypePage'))
 const Settings = lazy(() => import('./components/settings/Settings'))
+const SkillsPage = lazy(() => import('./components/skills/SkillsPage'))
 const WorkspaceSpacePage = lazy(() => import('./components/workspace-space/WorkspaceSpacePage'))
 const QuickOpen = lazy(() => import('./components/QuickOpen'))
 const WorktreeJumpPalette = lazy(() => import('./components/WorktreeJumpPalette'))
@@ -865,7 +866,10 @@ function App(): React.JSX.Element {
   // Why: Activity and Space are full-page navigation surfaces — same
   // treatment as Settings — so the worktree sidebar is removed for those views.
   const showSidebar =
-    activeView !== 'settings' && activeView !== 'activity' && activeView !== 'space'
+    activeView !== 'settings' &&
+    activeView !== 'activity' &&
+    activeView !== 'space' &&
+    activeView !== 'skills'
   // Why: only the terminal workspace replaces the full-width titlebar with
   // split-column chrome. Full-page navigation views keep the draggable app
   // titlebar so their page-level controls can live in that window strip.
@@ -877,7 +881,8 @@ function App(): React.JSX.Element {
     activeView !== 'tasks' &&
     activeView !== 'activity' &&
     activeView !== 'automations' &&
-    activeView !== 'space'
+    activeView !== 'space' &&
+    activeView !== 'skills'
 
   const handleToggleExpand = (): void => {
     if (!effectiveActiveTabId) {
@@ -968,7 +973,8 @@ function App(): React.JSX.Element {
         activeView === 'tasks' ||
         activeView === 'activity' ||
         activeView === 'automations' ||
-        activeView === 'space'
+        activeView === 'space' ||
+        activeView === 'skills'
       ) {
         return
       }
@@ -1207,7 +1213,8 @@ function App(): React.JSX.Element {
       (activeView === 'tasks' ||
         activeView === 'activity' ||
         activeView === 'automations' ||
-        activeView === 'space') &&
+        activeView === 'space' ||
+        activeView === 'skills') &&
       rightSidebarOpen
     ) {
       // Why: hide the right sidebar immediately when entering full-page
@@ -1374,6 +1381,7 @@ function App(): React.JSX.Element {
                   </div>
                   <Suspense fallback={null}>
                     {activeView === 'settings' ? <Settings /> : null}
+                    {activeView === 'skills' ? <SkillsPage /> : null}
                     {activeView === 'tasks' ? <TaskPage /> : null}
                     {activeView === 'automations' ? <AutomationsPage /> : null}
                     {activeView === 'activity' ? <ActivityPrototypePage /> : null}

--- a/src/renderer/src/components/editor/DiffSectionHeader.tsx
+++ b/src/renderer/src/components/editor/DiffSectionHeader.tsx
@@ -1,0 +1,83 @@
+import { ChevronDown, ChevronRight, ExternalLink } from 'lucide-react'
+import type { MouseEvent, ReactElement } from 'react'
+
+export function DiffSectionHeader({
+  path,
+  dirty,
+  collapsed,
+  added,
+  removed,
+  onToggle,
+  onOpenInEditor
+}: {
+  path: string
+  dirty: boolean
+  collapsed: boolean
+  added: number
+  removed: number
+  onToggle: () => void
+  onOpenInEditor: (event: MouseEvent) => void
+}): ReactElement {
+  return (
+    <div
+      className="sticky top-0 z-10 bg-background flex items-center w-full px-3 py-1.5 text-left text-xs hover:bg-accent transition-colors group cursor-pointer"
+      onClick={onToggle}
+    >
+      <span className="min-w-0 flex-1 truncate text-muted-foreground">
+        <span
+          role="button"
+          tabIndex={0}
+          className="cursor-copy hover:underline"
+          onMouseDown={(event) => {
+            event.preventDefault()
+            event.stopPropagation()
+          }}
+          onClick={(event) => {
+            event.preventDefault()
+            event.stopPropagation()
+            // Why: stop both mouse-down and click on the path affordance so
+            // the parent section-toggle row cannot consume the interaction.
+            void window.api.ui.writeClipboardText(path).catch((error) => {
+              console.error('Failed to copy diff path:', error)
+            })
+          }}
+          onKeyDown={(event) => {
+            if (event.key !== 'Enter' && event.key !== ' ') {
+              return
+            }
+            event.preventDefault()
+            event.stopPropagation()
+            void window.api.ui.writeClipboardText(path).catch((error) => {
+              console.error('Failed to copy diff path:', error)
+            })
+          }}
+          title="Copy path"
+        >
+          {path}
+        </span>
+        {dirty && <span className="font-medium ml-1">M</span>}
+        {(added > 0 || removed > 0) && (
+          <span className="tabular-nums ml-2">
+            {added > 0 && <span className="text-green-600 dark:text-green-500">+{added}</span>}
+            {added > 0 && removed > 0 && <span> </span>}
+            {removed > 0 && <span className="text-red-500">-{removed}</span>}
+          </span>
+        )}
+      </span>
+      <div className="flex items-center gap-1 shrink-0 ml-2">
+        <button
+          className="p-0.5 rounded text-muted-foreground hover:text-foreground opacity-0 group-hover:opacity-100 transition-opacity"
+          onClick={onOpenInEditor}
+          title="Open in editor"
+        >
+          <ExternalLink className="size-3.5" />
+        </button>
+        {collapsed ? (
+          <ChevronRight className="size-3.5 shrink-0 text-muted-foreground" />
+        ) : (
+          <ChevronDown className="size-3.5 shrink-0 text-muted-foreground" />
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/editor/DiffSectionItem.tsx
+++ b/src/renderer/src/components/editor/DiffSectionItem.tsx
@@ -8,7 +8,6 @@ import {
   type MutableRefObject
 } from 'react'
 import { LazySection } from './LazySection'
-import { ChevronDown, ChevronRight, ExternalLink } from 'lucide-react'
 import { DiffEditor, type DiffOnMount } from '@monaco-editor/react'
 import type { editor as monacoEditor } from 'monaco-editor'
 import { monaco } from '@/lib/monaco-setup'
@@ -22,6 +21,7 @@ import { DiffCommentPopover } from '../diff-comments/DiffCommentPopover'
 import { getDiffCommentPopoverTop } from '../diff-comments/diff-comment-popover-position'
 import { applyDiffEditorLineNumberOptions } from './diff-editor-line-number-options'
 import { computeLineStats } from './diff-line-stats'
+import { DiffSectionHeader } from './DiffSectionHeader'
 import type { DiffComment, GitDiffResult } from '../../../../shared/types'
 import { isDiffComment } from '@/lib/diff-comment-compat'
 
@@ -292,69 +292,15 @@ export function DiffSectionItem({
 
   return (
     <LazySection key={section.key} index={index} onVisible={loadSection}>
-      <div
-        className="sticky top-0 z-10 bg-background flex items-center w-full px-3 py-1.5 text-left text-xs hover:bg-accent transition-colors group cursor-pointer"
-        onClick={() => toggleSection(index)}
-      >
-        <span className="min-w-0 flex-1 truncate text-muted-foreground">
-          <span
-            role="button"
-            tabIndex={0}
-            className="cursor-copy hover:underline"
-            onMouseDown={(e) => {
-              e.preventDefault()
-              e.stopPropagation()
-            }}
-            onClick={(e) => {
-              e.preventDefault()
-              e.stopPropagation()
-              // Why: stop both mouse-down and click on the path affordance so
-              // the parent section-toggle row cannot consume the interaction
-              // before the Electron clipboard write runs.
-              void window.api.ui.writeClipboardText(section.path).catch((err) => {
-                console.error('Failed to copy diff path:', err)
-              })
-            }}
-            onKeyDown={(e) => {
-              if (e.key !== 'Enter' && e.key !== ' ') {
-                return
-              }
-              e.preventDefault()
-              e.stopPropagation()
-              void window.api.ui.writeClipboardText(section.path).catch((err) => {
-                console.error('Failed to copy diff path:', err)
-              })
-            }}
-            title="Copy path"
-          >
-            {section.path}
-          </span>
-          {section.dirty && <span className="font-medium ml-1">M</span>}
-          {lineStats && (lineStats.added > 0 || lineStats.removed > 0) && (
-            <span className="tabular-nums ml-2">
-              {lineStats.added > 0 && (
-                <span className="text-green-600 dark:text-green-500">+{lineStats.added}</span>
-              )}
-              {lineStats.added > 0 && lineStats.removed > 0 && <span> </span>}
-              {lineStats.removed > 0 && <span className="text-red-500">-{lineStats.removed}</span>}
-            </span>
-          )}
-        </span>
-        <div className="flex items-center gap-1 shrink-0 ml-2">
-          <button
-            className="p-0.5 rounded text-muted-foreground hover:text-foreground opacity-0 group-hover:opacity-100 transition-opacity"
-            onClick={handleOpenInEditor}
-            title="Open in editor"
-          >
-            <ExternalLink className="size-3.5" />
-          </button>
-          {section.collapsed ? (
-            <ChevronRight className="size-3.5 shrink-0 text-muted-foreground" />
-          ) : (
-            <ChevronDown className="size-3.5 shrink-0 text-muted-foreground" />
-          )}
-        </div>
-      </div>
+      <DiffSectionHeader
+        path={section.path}
+        dirty={section.dirty}
+        collapsed={section.collapsed}
+        added={lineStats?.added ?? 0}
+        removed={lineStats?.removed ?? 0}
+        onToggle={() => toggleSection(index)}
+        onOpenInEditor={handleOpenInEditor}
+      />
 
       {!section.collapsed && (
         <div

--- a/src/renderer/src/components/skills/SkillsPage.tsx
+++ b/src/renderer/src/components/skills/SkillsPage.tsx
@@ -1,0 +1,321 @@
+import { useEffect, useMemo, useState } from 'react'
+import { BookOpen, Clock, FolderOpen, Loader2, RefreshCw, Search, X } from 'lucide-react'
+import { toast } from 'sonner'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@/components/ui/select'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
+import { useAppStore } from '@/store'
+import type {
+  DiscoveredSkill,
+  SkillDiscoveryResult,
+  SkillProvider,
+  SkillSourceKind
+} from '../../../../shared/skills'
+import { countSkillsBySource, filterSkills, type SkillsFilterState } from './skills-filter'
+
+const providerLabels: Record<SkillProvider, string> = {
+  codex: 'Codex',
+  claude: 'Claude',
+  'agent-skills': 'Agent Skills'
+}
+
+const sourceLabels: Record<SkillSourceKind, string> = {
+  home: 'Home',
+  repo: 'Repository',
+  bundled: 'Bundled',
+  plugin: 'Plugin'
+}
+
+const dateFormatter = new Intl.DateTimeFormat(undefined, {
+  month: 'short',
+  day: 'numeric',
+  hour: 'numeric',
+  minute: '2-digit'
+})
+
+const EMPTY_SKILLS: DiscoveredSkill[] = []
+
+function formatUpdatedAt(value: number | null): string {
+  return value ? dateFormatter.format(new Date(value)) : 'Unknown'
+}
+
+function pluralize(count: number, singular: string): string {
+  return `${count} ${singular}${count === 1 ? '' : 's'}`
+}
+
+function SkillCard({ skill }: { skill: DiscoveredSkill }): React.JSX.Element {
+  const revealSkill = async (): Promise<void> => {
+    const result = await window.api.shell.openInFileManager(skill.skillFilePath)
+    if (!result.ok) {
+      toast.error('Could not reveal skill file')
+    }
+  }
+
+  return (
+    <Card className="rounded-lg">
+      <CardContent className="space-y-3 p-4">
+        <div className="flex min-w-0 items-start gap-3">
+          <div className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-md border border-border bg-background">
+            <BookOpen className="size-4 text-muted-foreground" />
+          </div>
+          <div className="min-w-0 flex-1 space-y-1">
+            <div className="flex min-w-0 flex-wrap items-center gap-2">
+              <h3 className="min-w-0 truncate text-sm font-semibold">{skill.name}</h3>
+              <Badge
+                variant={skill.installed ? 'secondary' : 'outline'}
+                className="h-5 text-[10px]"
+              >
+                {skill.installed ? 'Local' : 'Available'}
+              </Badge>
+              <Badge variant="outline" className="h-5 text-[10px]">
+                {sourceLabels[skill.sourceKind]}
+              </Badge>
+            </div>
+            {skill.description ? (
+              <p className="line-clamp-2 text-xs leading-5 text-muted-foreground">
+                {skill.description}
+              </p>
+            ) : (
+              <p className="text-xs text-muted-foreground">No description found.</p>
+            )}
+          </div>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                className="shrink-0"
+                onClick={() => {
+                  void revealSkill()
+                }}
+              >
+                <FolderOpen className="size-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="top" sideOffset={4}>
+              Reveal file
+            </TooltipContent>
+          </Tooltip>
+        </div>
+
+        <div className="grid gap-2 text-[11px] text-muted-foreground md:grid-cols-[1fr_auto_auto] md:items-center">
+          <div className="min-w-0 truncate font-mono" title={skill.skillFilePath}>
+            {skill.skillFilePath}
+          </div>
+          <div className="flex flex-wrap items-center gap-1.5">
+            {skill.providers.map((provider) => (
+              <Badge key={provider} variant="outline" className="h-5 text-[10px]">
+                {providerLabels[provider]}
+              </Badge>
+            ))}
+          </div>
+          <div className="flex items-center gap-3 whitespace-nowrap">
+            <span>{skill.sourceLabel}</span>
+            <span>{pluralize(skill.fileCount, 'file')}</span>
+            <span className="inline-flex items-center gap-1">
+              <Clock className="size-3" />
+              {formatUpdatedAt(skill.updatedAt)}
+            </span>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+function EmptyState({
+  loading,
+  hasSkills,
+  onRefresh
+}: {
+  loading: boolean
+  hasSkills: boolean
+  onRefresh: () => void
+}): React.JSX.Element {
+  return (
+    <div className="flex flex-1 items-center justify-center p-8">
+      <div className="flex max-w-sm flex-col items-center gap-3 text-center">
+        {loading ? (
+          <Loader2 className="size-7 animate-spin text-muted-foreground" />
+        ) : (
+          <BookOpen className="size-7 text-muted-foreground" />
+        )}
+        <div className="space-y-1">
+          <h3 className="text-sm font-semibold">
+            {loading ? 'Scanning skills' : hasSkills ? 'No matches' : 'No local skills found'}
+          </h3>
+          <p className="text-xs leading-5 text-muted-foreground">
+            {hasSkills
+              ? 'Adjust the search or filters.'
+              : 'Checked local home, repository, bundled, and plugin skill folders.'}
+          </p>
+        </div>
+        {!loading ? (
+          <Button variant="outline" size="sm" onClick={onRefresh}>
+            <RefreshCw className="size-4" />
+            Refresh
+          </Button>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+export default function SkillsPage(): React.JSX.Element {
+  const closeSkillsPage = useAppStore((s) => s.closeSkillsPage)
+  const [result, setResult] = useState<SkillDiscoveryResult | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [filters, setFilters] = useState<SkillsFilterState>({
+    query: '',
+    sourceKind: 'all',
+    provider: 'all'
+  })
+
+  const loadSkills = async (): Promise<void> => {
+    setLoading(true)
+    try {
+      setResult(await window.api.skills.discover())
+    } catch (error) {
+      console.error('Failed to discover skills:', error)
+      toast.error('Could not scan local skills')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    void loadSkills()
+  }, [])
+
+  const skills = result?.skills ?? EMPTY_SKILLS
+  const visibleSkills = useMemo(() => filterSkills(skills, filters), [filters, skills])
+  const sourceCounts = useMemo(() => countSkillsBySource(skills), [skills])
+  const activeSourceCount = result?.sources.filter((source) => source.exists).length ?? 0
+
+  return (
+    <main className="flex min-h-0 flex-1 flex-col bg-background">
+      <header className="flex shrink-0 items-center gap-3 border-b border-border px-5 py-3">
+        <div className="flex min-w-0 flex-1 items-center gap-3">
+          <BookOpen className="size-4 text-muted-foreground" />
+          <div className="min-w-0">
+            <h1 className="truncate text-sm font-semibold">Skills</h1>
+            <p className="truncate text-xs text-muted-foreground">
+              {pluralize(skills.length, 'skill')} from {pluralize(activeSourceCount, 'source')}
+            </p>
+          </div>
+        </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          onClick={closeSkillsPage}
+          aria-label="Close Skills"
+        >
+          <X className="size-4" />
+        </Button>
+      </header>
+
+      <section className="flex shrink-0 flex-col gap-3 border-b border-border px-5 py-4">
+        <div className="flex flex-col gap-2 lg:flex-row lg:items-center">
+          <div className="relative min-w-0 flex-1">
+            <Search className="pointer-events-none absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              value={filters.query}
+              onChange={(event) => setFilters((next) => ({ ...next, query: event.target.value }))}
+              placeholder="Search skills"
+              className="h-8 pl-8 text-sm"
+            />
+          </div>
+          <div className="flex gap-2">
+            <Select
+              value={filters.provider}
+              onValueChange={(value) =>
+                setFilters((next) => ({
+                  ...next,
+                  provider: value as SkillsFilterState['provider']
+                }))
+              }
+            >
+              <SelectTrigger className="h-8 w-[150px]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All providers</SelectItem>
+                <SelectItem value="codex">Codex</SelectItem>
+                <SelectItem value="claude">Claude</SelectItem>
+                <SelectItem value="agent-skills">Agent Skills</SelectItem>
+              </SelectContent>
+            </Select>
+            <Select
+              value={filters.sourceKind}
+              onValueChange={(value) =>
+                setFilters((next) => ({
+                  ...next,
+                  sourceKind: value as SkillsFilterState['sourceKind']
+                }))
+              }
+            >
+              <SelectTrigger className="h-8 w-[150px]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All sources</SelectItem>
+                <SelectItem value="home">Home</SelectItem>
+                <SelectItem value="repo">Repository</SelectItem>
+                <SelectItem value="bundled">Bundled</SelectItem>
+                <SelectItem value="plugin">Plugin</SelectItem>
+              </SelectContent>
+            </Select>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="h-8"
+              disabled={loading}
+              onClick={() => {
+                void loadSkills()
+              }}
+            >
+              <RefreshCw className={cn('size-4', loading && 'animate-spin')} />
+              Refresh
+            </Button>
+          </div>
+        </div>
+        <div className="flex flex-wrap gap-2 text-[11px] text-muted-foreground">
+          {(['home', 'repo', 'bundled', 'plugin'] as const).map((sourceKind) => (
+            <span key={sourceKind} className="rounded-full border border-border px-2 py-1">
+              {sourceLabels[sourceKind]} {sourceCounts[sourceKind]}
+            </span>
+          ))}
+        </div>
+      </section>
+
+      <section className="scrollbar-sleek min-h-0 flex-1 overflow-y-auto px-5 py-4">
+        {visibleSkills.length > 0 ? (
+          <div className="mx-auto flex max-w-5xl flex-col gap-3">
+            {visibleSkills.map((skill) => (
+              <SkillCard key={skill.id} skill={skill} />
+            ))}
+          </div>
+        ) : (
+          <EmptyState
+            loading={loading}
+            hasSkills={skills.length > 0}
+            onRefresh={() => void loadSkills()}
+          />
+        )}
+      </section>
+    </main>
+  )
+}

--- a/src/renderer/src/components/skills/skills-filter.test.ts
+++ b/src/renderer/src/components/skills/skills-filter.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import type { DiscoveredSkill } from '../../../../shared/skills'
+import { countSkillsBySource, filterSkills } from './skills-filter'
+
+function skill(overrides: Partial<DiscoveredSkill>): DiscoveredSkill {
+  return {
+    id: 'id',
+    name: 'Review',
+    description: 'Code review',
+    providers: ['codex'],
+    sourceKind: 'home',
+    sourceLabel: 'Codex home',
+    rootPath: '/root',
+    directoryPath: '/root/review',
+    skillFilePath: '/root/review/SKILL.md',
+    installed: true,
+    fileCount: 1,
+    updatedAt: null,
+    ...overrides
+  }
+}
+
+describe('skills filtering', () => {
+  it('filters by provider, source, and text query', () => {
+    const skills = [
+      skill({ name: 'React Patterns', providers: ['codex'], sourceKind: 'home' }),
+      skill({
+        id: 'repo',
+        name: 'Docs Writer',
+        description: 'Write docs',
+        providers: ['claude'],
+        sourceKind: 'repo'
+      })
+    ]
+
+    expect(
+      filterSkills(skills, { query: 'docs', provider: 'claude', sourceKind: 'repo' }).map(
+        (item) => item.name
+      )
+    ).toEqual(['Docs Writer'])
+    expect(filterSkills(skills, { query: 'docs', provider: 'codex', sourceKind: 'all' })).toEqual(
+      []
+    )
+  })
+
+  it('counts skills by source kind', () => {
+    expect(
+      countSkillsBySource([
+        skill({ sourceKind: 'home' }),
+        skill({ id: 'repo', sourceKind: 'repo' }),
+        skill({ id: 'plugin', sourceKind: 'plugin' })
+      ])
+    ).toEqual({ home: 1, repo: 1, bundled: 0, plugin: 1 })
+  })
+})

--- a/src/renderer/src/components/skills/skills-filter.ts
+++ b/src/renderer/src/components/skills/skills-filter.ts
@@ -1,0 +1,51 @@
+import type { DiscoveredSkill, SkillProvider, SkillSourceKind } from '../../../../shared/skills'
+
+export type SkillsFilterState = {
+  query: string
+  sourceKind: SkillSourceKind | 'all'
+  provider: SkillProvider | 'all'
+}
+
+function normalize(value: string): string {
+  return value.trim().toLowerCase()
+}
+
+export function filterSkills(
+  skills: readonly DiscoveredSkill[],
+  filters: SkillsFilterState
+): DiscoveredSkill[] {
+  const query = normalize(filters.query)
+  return skills.filter((skill) => {
+    if (filters.sourceKind !== 'all' && skill.sourceKind !== filters.sourceKind) {
+      return false
+    }
+    if (filters.provider !== 'all' && !skill.providers.includes(filters.provider)) {
+      return false
+    }
+    if (!query) {
+      return true
+    }
+    const haystack = [
+      skill.name,
+      skill.description ?? '',
+      skill.sourceLabel,
+      skill.directoryPath,
+      skill.providers.join(' ')
+    ]
+      .join(' ')
+      .toLowerCase()
+    return haystack.includes(query)
+  })
+}
+
+export function countSkillsBySource(
+  skills: readonly DiscoveredSkill[]
+): Record<SkillSourceKind, number> {
+  return skills.reduce<Record<SkillSourceKind, number>>(
+    (counts, skill) => {
+      counts[skill.sourceKind] += 1
+      return counts
+    },
+    { home: 0, repo: 0, bundled: 0, plugin: 0 }
+  )
+}

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -4,6 +4,7 @@ states stay consistent across Claude and Codex. */
 import {
   AlertTriangle,
   Activity,
+  BookOpen,
   ChevronDown,
   ChevronRight,
   RefreshCw,
@@ -729,6 +730,7 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
   // statusBarItems checkbox would double-toggle the surface). It is driven
   // purely by the experimentalPet settings flag.
   const petEnabled = useAppStore((s) => s.settings?.experimentalPet === true)
+  const openSkillsPage = useAppStore((s) => s.openSkillsPage)
   const toggleStatusBarItem = useAppStore((s) => s.toggleStatusBarItem)
   const containerRef = useRef<HTMLDivElement>(null)
   const [isRefreshing, setIsRefreshing] = useState(false)
@@ -901,6 +903,21 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
 
       <div className="flex items-center gap-3">
         <UpdateStatusSegment compact={compact} iconOnly={iconOnly} />
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              className="inline-flex size-5 cursor-pointer items-center justify-center rounded border border-border bg-secondary text-secondary-foreground shadow-xs transition-colors hover:bg-accent hover:text-accent-foreground"
+              aria-label="Open Skills"
+              onClick={openSkillsPage}
+            >
+              <BookOpen className="size-3.5" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="top" sideOffset={6}>
+            Skills
+          </TooltipContent>
+        </Tooltip>
         {petEnabled && <PetStatusSegment />}
         {showResourceUsage && <ResourceUsageStatusSegment compact={compact} iconOnly={iconOnly} />}
         {showSsh && <SshStatusSegment compact={compact} iconOnly={iconOnly} />}

--- a/src/renderer/src/hooks/resolve-zoom-target.ts
+++ b/src/renderer/src/hooks/resolve-zoom-target.ts
@@ -3,7 +3,7 @@
  * based on current view, tab type, and focused element.
  */
 export function resolveZoomTarget(args: {
-  activeView: 'terminal' | 'settings' | 'tasks' | 'activity' | 'automations' | 'space'
+  activeView: 'terminal' | 'settings' | 'tasks' | 'activity' | 'automations' | 'space' | 'skills'
   activeTabType: 'terminal' | 'editor' | 'browser'
   activeElement: unknown
 }): 'terminal' | 'editor' | 'ui' {

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -244,12 +244,13 @@ export type UISlice = {
   acknowledgedAgentsByPaneKey: Record<string, number>
   acknowledgeAgents: (paneKeys: string[]) => void
   unacknowledgeAgents: (paneKeys: string[]) => void
-  activeView: 'terminal' | 'settings' | 'tasks' | 'activity' | 'automations' | 'space'
-  previousViewBeforeTasks: 'terminal' | 'settings' | 'activity' | 'automations' | 'space'
-  previousViewBeforeSettings: 'terminal' | 'tasks' | 'activity' | 'automations' | 'space'
-  previousViewBeforeActivity: 'terminal' | 'settings' | 'tasks' | 'automations' | 'space'
-  previousViewBeforeAutomations: 'terminal' | 'settings' | 'tasks' | 'activity' | 'space'
-  previousViewBeforeSpace: 'terminal' | 'settings' | 'tasks' | 'activity' | 'automations'
+  activeView: 'terminal' | 'settings' | 'tasks' | 'activity' | 'automations' | 'space' | 'skills'
+  previousViewBeforeTasks: 'terminal' | 'settings' | 'activity' | 'automations' | 'space' | 'skills'
+  previousViewBeforeSettings: 'terminal' | 'tasks' | 'activity' | 'automations' | 'space' | 'skills'
+  previousViewBeforeActivity: 'terminal' | 'settings' | 'tasks' | 'automations' | 'space' | 'skills'
+  previousViewBeforeAutomations: 'terminal' | 'settings' | 'tasks' | 'activity' | 'space' | 'skills'
+  previousViewBeforeSpace: 'terminal' | 'settings' | 'tasks' | 'activity' | 'automations' | 'skills'
+  previousViewBeforeSkills: 'terminal' | 'settings' | 'tasks' | 'activity' | 'automations' | 'space'
   setActiveView: (view: UISlice['activeView']) => void
   taskPageData: {
     preselectedRepoId?: string
@@ -291,6 +292,8 @@ export type UISlice = {
   closeAutomationsPage: () => void
   openSpacePage: () => void
   closeSpacePage: () => void
+  openSkillsPage: () => void
+  closeSkillsPage: () => void
   setNewWorkspaceDraft: (draft: NonNullable<UISlice['newWorkspaceDraft']>) => void
   clearNewWorkspaceDraft: () => void
   openSettingsPage: () => void
@@ -486,6 +489,7 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
   previousViewBeforeActivity: 'terminal',
   previousViewBeforeAutomations: 'terminal',
   previousViewBeforeSpace: 'terminal',
+  previousViewBeforeSkills: 'terminal',
   setActiveView: (view) => set({ activeView: view }),
   taskPageData: {},
   taskResumeState: undefined,
@@ -612,6 +616,16 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
   closeSpacePage: () =>
     set((state) => ({
       activeView: state.previousViewBeforeSpace
+    })),
+  openSkillsPage: () =>
+    set((state) => ({
+      activeView: 'skills',
+      previousViewBeforeSkills:
+        state.activeView === 'skills' ? state.previousViewBeforeSkills : state.activeView
+    })),
+  closeSkillsPage: () =>
+    set((state) => ({
+      activeView: state.previousViewBeforeSkills
     })),
   setNewWorkspaceDraft: (draft) => set({ newWorkspaceDraft: draft }),
   clearNewWorkspaceDraft: () => set({ newWorkspaceDraft: null }),

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -154,6 +154,9 @@ function createWebPreloadApi(): Partial<PreloadApi> {
     computerUsePermissions: createComputerUsePermissionsApi(),
     updater: createUpdaterApi(),
     shell: createShellApi(),
+    skills: {
+      discover: () => Promise.resolve({ skills: [], sources: [], scannedAt: Date.now() })
+    },
     pty: createPtyApi(),
     ssh: createSshApi(),
     wsl: { isAvailable: () => Promise.resolve(false) },

--- a/src/shared/skill-metadata.test.ts
+++ b/src/shared/skill-metadata.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { summarizeSkillMarkdown } from './skill-metadata'
+
+describe('summarizeSkillMarkdown', () => {
+  it('reads name and folded description from YAML frontmatter', () => {
+    const summary = summarizeSkillMarkdown(`---
+name: orca-cli
+description: >-
+  Use the orca CLI to drive a running editor;
+  keep worktree comments current.
+---
+
+# Orca CLI
+`)
+
+    expect(summary).toEqual({
+      name: 'orca-cli',
+      description: 'Use the orca CLI to drive a running editor; keep worktree comments current.'
+    })
+  })
+
+  it('falls back to heading and first paragraph when frontmatter is absent', () => {
+    const summary = summarizeSkillMarkdown(`# Design Review
+
+Use when reviewing UI implementation quality.
+`)
+
+    expect(summary).toEqual({
+      name: 'Design Review',
+      description: 'Use when reviewing UI implementation quality.'
+    })
+  })
+})

--- a/src/shared/skill-metadata.ts
+++ b/src/shared/skill-metadata.ts
@@ -1,0 +1,110 @@
+import type { SkillFrontmatterSummary } from './skills'
+
+type FrontmatterValue = string | string[]
+
+function stripQuotePair(value: string): string {
+  const trimmed = value.trim()
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1)
+  }
+  return trimmed
+}
+
+function parseYamlFrontmatter(raw: string): Record<string, FrontmatterValue> {
+  const lines = raw.replace(/\r\n/g, '\n').split('\n')
+  const data: Record<string, FrontmatterValue> = {}
+  let index = 0
+  while (index < lines.length) {
+    const line = lines[index]
+    const match = /^([A-Za-z0-9_-]+):\s*(.*)$/.exec(line)
+    if (!match) {
+      index += 1
+      continue
+    }
+
+    const key = match[1]
+    const value = match[2].trim()
+    if (value === '|' || value === '|-' || value === '>' || value === '>-') {
+      const block: string[] = []
+      index += 1
+      while (index < lines.length && /^(?:\s{2,}|\s*$)/.test(lines[index])) {
+        block.push(lines[index].replace(/^\s{2}/, ''))
+        index += 1
+      }
+      data[key] = block
+        .join(value.startsWith('>') ? ' ' : '\n')
+        .replace(/\s+/g, ' ')
+        .trim()
+      continue
+    }
+
+    if (value === '') {
+      const items: string[] = []
+      index += 1
+      while (index < lines.length) {
+        const itemMatch = /^\s*-\s*(.+)$/.exec(lines[index])
+        if (!itemMatch) {
+          break
+        }
+        items.push(stripQuotePair(itemMatch[1]))
+        index += 1
+      }
+      if (items.length > 0) {
+        data[key] = items
+        continue
+      }
+      data[key] = ''
+      continue
+    }
+
+    data[key] = stripQuotePair(value)
+    index += 1
+  }
+  return data
+}
+
+function firstHeading(body: string): string | null {
+  const match = /^#\s+(.+)$/m.exec(body)
+  return match?.[1].trim() || null
+}
+
+function firstParagraph(body: string): string | null {
+  const lines = body.replace(/\r\n/g, '\n').split('\n')
+  const paragraph: string[] = []
+  for (const line of lines) {
+    const trimmed = line.trim()
+    if (!trimmed || trimmed.startsWith('#') || trimmed.startsWith('```')) {
+      if (paragraph.length > 0) {
+        break
+      }
+      continue
+    }
+    paragraph.push(trimmed)
+    if (paragraph.join(' ').length > 240) {
+      break
+    }
+  }
+  return paragraph.length > 0 ? paragraph.join(' ') : null
+}
+
+export function summarizeSkillMarkdown(markdown: string): SkillFrontmatterSummary {
+  const normalized = markdown.replace(/^\uFEFF/, '')
+  const frontmatterMatch = /^---\s*\n([\s\S]*?)\n---\s*(?:\n|$)/.exec(normalized)
+  const body = frontmatterMatch ? normalized.slice(frontmatterMatch[0].length) : normalized
+  const frontmatter = frontmatterMatch ? parseYamlFrontmatter(frontmatterMatch[1]) : {}
+  const nameValue = frontmatter.name
+  const descriptionValue = frontmatter.description
+  const name =
+    typeof nameValue === 'string' && nameValue.trim() ? nameValue.trim() : firstHeading(body)
+  const description =
+    typeof descriptionValue === 'string' && descriptionValue.trim()
+      ? descriptionValue.trim()
+      : firstParagraph(body)
+  return {
+    name: name || null,
+    description: description || null
+  }
+}

--- a/src/shared/skills.ts
+++ b/src/shared/skills.ts
@@ -1,0 +1,39 @@
+export type SkillProvider = 'codex' | 'claude' | 'agent-skills'
+
+export type SkillSourceKind = 'home' | 'repo' | 'bundled' | 'plugin'
+
+export type DiscoveredSkill = {
+  id: string
+  name: string
+  description: string | null
+  providers: SkillProvider[]
+  sourceKind: SkillSourceKind
+  sourceLabel: string
+  rootPath: string
+  directoryPath: string
+  skillFilePath: string
+  installed: boolean
+  fileCount: number
+  updatedAt: number | null
+}
+
+export type SkillDiscoverySource = {
+  id: string
+  label: string
+  path: string
+  sourceKind: SkillSourceKind
+  providers: SkillProvider[]
+  exists: boolean
+  skippedReason?: 'missing' | 'remote-repo'
+}
+
+export type SkillDiscoveryResult = {
+  skills: DiscoveredSkill[]
+  sources: SkillDiscoverySource[]
+  scannedAt: number
+}
+
+export type SkillFrontmatterSummary = {
+  name: string | null
+  description: string | null
+}


### PR DESCRIPTION
## Summary
- add main-process skill discovery across Codex, agent skills, Claude, repo, bundled, and plugin skill roots
- expose skill discovery through IPC/preload and add a Skills full-page renderer surface from the status bar
- add metadata parsing, filtering, and focused tests for discovery/filtering/frontmatter handling

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/main/skills/discovery.test.ts src/renderer/src/components/skills/skills-filter.test.ts src/shared/skill-metadata.test.ts src/main/ipc/register-core-handlers.test.ts
- pnpm typecheck

Review loop:
- Round 1: 1 Medium finding fixed (bounded SKILL.md reads)
- Round 2: No issues found