### PR TITLE
Fix pane key acknowledgement migration

### DIFF
--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -6,7 +6,7 @@ import { writeFileSync, readFileSync, rmSync, mkdtempSync, mkdirSync, existsSync
 import { join } from 'path'
 import { tmpdir } from 'os'
 import type { Repo, TerminalTab, WorkspaceSessionState } from '../shared/types'
-import { isTerminalLeafId } from '../shared/stable-pane-id'
+import { isTerminalLeafId, makePaneKey } from '../shared/stable-pane-id'
 import { MAX_BROWSER_HISTORY_ENTRIES } from '../shared/workspace-session-browser-history'
 
 // Shared mutable state so the electron mock can reference a per-test directory
@@ -219,6 +219,135 @@ describe('Store', () => {
     const store = await createStore()
 
     expect(store.getRepos()).toHaveLength(1)
+  })
+
+  it('remaps persisted agent acknowledgement pane keys when terminal leaves migrate to UUIDs', async () => {
+    const acknowledgedAt = 1_700_000_000_000
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [makeRepo()],
+      worktreeMeta: {},
+      settings: {},
+      ui: {
+        acknowledgedAgentsByPaneKey: {
+          'tab1:0': acknowledgedAt,
+          'tab1:pane:1': acknowledgedAt - 1_000,
+          'other-tab:0': acknowledgedAt - 2_000
+        }
+      },
+      githubCache: { pr: {}, issue: {} },
+      workspaceSession: {
+        activeRepoId: 'r1',
+        activeWorktreeId: 'repo1::/worktree',
+        activeTabId: 'tab1',
+        tabsByWorktree: {
+          'repo1::/worktree': [
+            makeTerminalTab({
+              id: 'tab1',
+              ptyId: 'pty1',
+              worktreeId: 'repo1::/worktree'
+            })
+          ]
+        },
+        terminalLayoutsByTabId: {
+          tab1: {
+            root: {
+              type: 'split',
+              direction: 'horizontal',
+              first: { type: 'leaf', leafId: '0' },
+              second: { type: 'leaf', leafId: 'pane:1' }
+            },
+            activeLeafId: '0',
+            expandedLeafId: null,
+            ptyIdsByLeafId: { '0': 'pty1', 'pane:1': 'pty2' }
+          }
+        }
+      }
+    })
+
+    const store = await createStore()
+    const layout = store.getWorkspaceSession().terminalLayoutsByTabId.tab1
+    const migratedLeafIds = Object.keys(layout.ptyIdsByLeafId ?? {})
+
+    expect(migratedLeafIds).toHaveLength(2)
+    expect(migratedLeafIds.every(isTerminalLeafId)).toBe(true)
+
+    const ui = store.getUI()
+    expect(ui.acknowledgedAgentsByPaneKey).toEqual({
+      [makePaneKey('tab1', migratedLeafIds[0])]: acknowledgedAt,
+      [makePaneKey('tab1', migratedLeafIds[1])]: acknowledgedAt - 1_000,
+      'other-tab:0': acknowledgedAt - 2_000
+    })
+  })
+
+  it('keeps the newest acknowledgement when legacy and migrated pane keys collide', async () => {
+    const legacyAcknowledgedAt = 1_700_000_000_000
+    const migratedAcknowledgedAt = legacyAcknowledgedAt + 5_000
+    const migratedPaneKey = makePaneKey('tab1', TEST_LEAF_1)
+
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [makeRepo()],
+      worktreeMeta: {},
+      settings: {},
+      ui: {
+        acknowledgedAgentsByPaneKey: {
+          'tab1:0': legacyAcknowledgedAt,
+          [migratedPaneKey]: migratedAcknowledgedAt
+        }
+      },
+      githubCache: { pr: {}, issue: {} },
+      workspaceSession: {
+        activeRepoId: 'r1',
+        activeWorktreeId: 'repo1::/worktree',
+        activeTabId: 'tab1',
+        tabsByWorktree: {
+          'repo1::/worktree': [
+            makeTerminalTab({
+              id: 'tab1',
+              ptyId: 'pty1',
+              worktreeId: 'repo1::/worktree'
+            })
+          ]
+        },
+        terminalLayoutsByTabId: {
+          tab1: {
+            root: { type: 'leaf', leafId: TEST_LEAF_1 },
+            activeLeafId: TEST_LEAF_1,
+            expandedLeafId: null,
+            ptyIdsByLeafId: { [TEST_LEAF_1]: 'pty1' }
+          }
+        }
+      }
+    })
+
+    const store = await createStore()
+    store.setWorkspaceSession({
+      activeRepoId: 'r1',
+      activeWorktreeId: 'repo1::/worktree',
+      activeTabId: 'tab1',
+      tabsByWorktree: {
+        'repo1::/worktree': [
+          makeTerminalTab({
+            id: 'tab1',
+            ptyId: 'pty1',
+            worktreeId: 'repo1::/worktree'
+          })
+        ]
+      },
+      terminalLayoutsByTabId: {
+        tab1: {
+          root: { type: 'leaf', leafId: '0' },
+          activeLeafId: '0',
+          expandedLeafId: null,
+          ptyIdsByLeafId: { '0': 'pty1' }
+        }
+      }
+    })
+
+    expect(store.getUI().acknowledgedAgentsByPaneKey).toEqual({
+      [migratedPaneKey]: migratedAcknowledgedAt
+    })
   })
 
   it('can clear an automation back to the project default branch', async () => {

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -57,7 +57,7 @@ import {
   ONBOARDING_FINAL_STEP
 } from '../shared/constants'
 import { parseWorkspaceSession } from '../shared/workspace-session-schema'
-import { isTerminalLeafId, makePaneKey } from '../shared/stable-pane-id'
+import { isTerminalLeafId, makePaneKey, parsePaneKey } from '../shared/stable-pane-id'
 import {
   setMigrationUnsupportedPty,
   setMigrationUnsupportedPtyPersistenceListener
@@ -702,11 +702,20 @@ function normalizePersistedPaneIdentityState(state: PersistedState): {
     ...(state.migrationUnsupportedPtyEntries ?? []),
     ...normalizedSession.migrationUnsupportedEntries
   ])
+  const remappedAcknowledgements = remapAcknowledgedAgentPaneKeys(
+    state.ui?.acknowledgedAgentsByPaneKey,
+    normalizedSession.leafIdByInputLeafIdByTabId
+  )
   const migrationUnsupportedChanged = !migrationUnsupportedEntriesEqual(
     state.migrationUnsupportedPtyEntries ?? [],
     mergedMigrationUnsupportedEntries
   )
-  if (!normalizedSession.changed && !remappedLeases.changed && !migrationUnsupportedChanged) {
+  if (
+    !normalizedSession.changed &&
+    !remappedLeases.changed &&
+    !migrationUnsupportedChanged &&
+    !remappedAcknowledgements.changed
+  ) {
     return {
       state,
       changed: false,
@@ -718,7 +727,15 @@ function normalizePersistedPaneIdentityState(state: PersistedState): {
       ...state,
       workspaceSession: normalizedSession.session,
       sshRemotePtyLeases: remappedLeases.leases,
-      migrationUnsupportedPtyEntries: mergedMigrationUnsupportedEntries
+      migrationUnsupportedPtyEntries: mergedMigrationUnsupportedEntries,
+      ...(remappedAcknowledgements.changed
+        ? {
+            ui: {
+              ...state.ui,
+              acknowledgedAgentsByPaneKey: remappedAcknowledgements.acknowledgements
+            }
+          }
+        : {})
     },
     changed: true,
     migrationUnsupportedEntries: mergedMigrationUnsupportedEntries
@@ -736,6 +753,55 @@ function mergeMigrationUnsupportedPtyEntries(
     }
   }
   return [...byPtyId.values()]
+}
+
+function remapAcknowledgedAgentPaneKeys(
+  acknowledgements: PersistedState['ui']['acknowledgedAgentsByPaneKey'],
+  leafIdByInputLeafIdByTabId: Map<string, Map<string, string>>
+): { acknowledgements: PersistedState['ui']['acknowledgedAgentsByPaneKey']; changed: boolean } {
+  if (!acknowledgements || Object.keys(acknowledgements).length === 0) {
+    return { acknowledgements, changed: false }
+  }
+
+  let changed = false
+  const next: NonNullable<PersistedState['ui']['acknowledgedAgentsByPaneKey']> = {}
+  const setAcknowledgement = (paneKey: string, acknowledgedAt: number): void => {
+    const existing = next[paneKey]
+    next[paneKey] = existing === undefined ? acknowledgedAt : Math.max(existing, acknowledgedAt)
+  }
+  for (const [paneKey, acknowledgedAt] of Object.entries(acknowledgements)) {
+    const parsed = parsePaneKey(paneKey)
+    if (parsed) {
+      setAcknowledgement(paneKey, acknowledgedAt)
+      continue
+    }
+
+    const delimiter = paneKey.indexOf(':')
+    if (delimiter <= 0 || delimiter === paneKey.length - 1) {
+      setAcknowledgement(paneKey, acknowledgedAt)
+      continue
+    }
+
+    const tabId = paneKey.slice(0, delimiter)
+    const legacyLeafId = paneKey.slice(delimiter + 1)
+    const remappedLeafId = leafIdByInputLeafIdByTabId.get(tabId)?.get(legacyLeafId)
+    if (!remappedLeafId || !isTerminalLeafId(remappedLeafId)) {
+      setAcknowledgement(paneKey, acknowledgedAt)
+      continue
+    }
+
+    try {
+      // Why: UI acks are keyed by paneKey just like hook rows. When a legacy
+      // numeric/pane:* leaf is promoted to a UUID, carry the read marker over
+      // so already-seen Activity/sidebar rows do not come back unread.
+      setAcknowledgement(makePaneKey(tabId, remappedLeafId), acknowledgedAt)
+      changed = true
+    } catch {
+      setAcknowledgement(paneKey, acknowledgedAt)
+    }
+  }
+
+  return { acknowledgements: next, changed }
 }
 
 function normalizeMigrationUnsupportedPtyEntries(value: unknown): MigrationUnsupportedPtyEntry[] {
@@ -1880,6 +1946,16 @@ export class Store {
     )
     for (const entry of normalized.migrationUnsupportedEntries) {
       setMigrationUnsupportedPty(entry)
+    }
+    const remappedAcknowledgements = remapAcknowledgedAgentPaneKeys(
+      this.state.ui?.acknowledgedAgentsByPaneKey,
+      normalized.leafIdByInputLeafIdByTabId
+    )
+    if (remappedAcknowledgements.changed) {
+      this.state.ui = {
+        ...this.state.ui,
+        acknowledgedAgentsByPaneKey: remappedAcknowledgements.acknowledgements
+      }
     }
     session = normalized.session
     const remappedLeases = remapSshRemotePtyLeaseLeafIds(

--- a/tests/e2e/activity-agent-pane-isolation.spec.ts
+++ b/tests/e2e/activity-agent-pane-isolation.spec.ts
@@ -279,6 +279,55 @@ test.describe('Activity Agent Pane Isolation', () => {
       })
   })
 
+  test('acknowledged stable pane keys clear the Agents unread badge', async ({ orcaPage }) => {
+    await splitActiveTerminalPane(orcaPage, 'vertical')
+    await waitForPaneCount(orcaPage, 2)
+    const snapshot = await waitForPaneIdentitySnapshot(orcaPage, 2)
+    const firstPane = snapshot.panes[0]
+    if (!firstPane) {
+      throw new Error('Activity acknowledgement test needs a split pane')
+    }
+    const now = Date.now()
+    const thread: SeededActivityThread = {
+      paneKey: `${snapshot.tabId}:${firstPane.leafId}`,
+      leafId: firstPane.leafId,
+      prompt: `ACTIVITY_ACK_STABLE_PANE_${now}`
+    }
+
+    await orcaPage.evaluate(() => {
+      const store = window.__store
+      if (!store) {
+        throw new Error('window.__store is not available')
+      }
+      const state = store.getState()
+      for (const worktree of Object.values(state.worktreesByRepo).flat()) {
+        state.markWorktreeVisited(worktree.id)
+      }
+    })
+
+    await seedActivityThread(
+      orcaPage,
+      thread,
+      'Codex acknowledged pane',
+      'blocked',
+      'Waiting for acknowledgement migration coverage.',
+      now - 5_000
+    )
+
+    await expect(orcaPage.getByRole('button', { name: /^Agents\s+1$/ })).toBeVisible()
+
+    await orcaPage.evaluate((paneKey) => {
+      const store = window.__store
+      if (!store) {
+        throw new Error('window.__store is not available')
+      }
+      store.getState().acknowledgeAgents([paneKey])
+    }, thread.paneKey)
+
+    await expect(orcaPage.getByRole('button', { name: /^Agents$/ })).toBeVisible()
+    await expect(orcaPage.getByRole('button', { name: /^Agents\s+1$/ })).toHaveCount(0)
+  })
+
   test('workspace card agent rows focus the matching terminal split pane', async ({ orcaPage }) => {
     await splitActiveTerminalPane(orcaPage, 'vertical')
     await waitForPaneCount(orcaPage, 2)


### PR DESCRIPTION
## Summary
- remap persisted legacy Activity/sidebar acknowledgement pane keys when terminal leaves migrate to UUIDs
- preserve the newest acknowledgement timestamp if legacy and migrated keys collide
- add unit and Electron Playwright coverage for the Activity unread-badge path

## Reproduction
- temporarily reversed the persistence implementation patch and ran `pnpm vitest run --config config/vitest.config.ts src/main/persistence.test.ts`
- reproduced the regression: legacy keys stayed as `tab1:0` / `tab1:pane:1`, causing the new regression tests to fail

## Verification
- `pnpm vitest run --config config/vitest.config.ts src/main/persistence.test.ts`
- `pnpm vitest run --config config/vitest.config.ts src/main/persistence.test.ts src/renderer/src/components/activity/ActivityPrototypePage.test.ts src/renderer/src/components/sidebar/SidebarNav.test.tsx src/renderer/src/components/sidebar/WorktreeCardAgents.test.tsx`
- `pnpm run tc:node`
- `pnpm exec playwright test tests/e2e/activity-agent-pane-isolation.spec.ts --config tests/playwright.config.ts --project electron-headless`
- Electron CDP verification with a seeded legacy `orca-data.json`: running Orca remapped `tab1:0` / `tab1:pane:1` acknowledgements to UUID pane keys in both `window.__store` and `window.api.ui.get()`