### PR TITLE
Fix worktree chevron hover cursor

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -625,10 +625,10 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                     </div>
                   </div>
 
-                  <div className="flex size-4 shrink-0 items-center justify-center text-muted-foreground/60 opacity-0 group-hover:opacity-100 transition-opacity">
+                  <div className="flex size-4 shrink-0 cursor-pointer items-center justify-center text-muted-foreground/60 opacity-0 transition-opacity group-hover:opacity-100">
                     <ChevronDown
                       className={cn(
-                        'size-3.5 transition-transform',
+                        'size-3.5 cursor-pointer transition-transform [&_path]:cursor-pointer',
                         collapsedGroups.has(row.key) && '-rotate-90'
                       )}
                     />

--- a/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
@@ -319,4 +319,13 @@ describe('WorktreeList header styles', () => {
 
     expect(source).not.toContain('leading-none capitalize')
   })
+
+  it('shows a pointer cursor over the disclosure chevron path', () => {
+    const source = readFileSync(
+      fileURLToPath(new URL('./WorktreeList.tsx', import.meta.url)),
+      'utf8'
+    )
+
+    expect(source).toContain('[&_path]:cursor-pointer')
+  })
 })


### PR DESCRIPTION
## Summary
- Apply pointer cursor styling to the worktree group disclosure chevron and its SVG path
- Add a regression assertion for the chevron path cursor class

## Verification
- pnpm oxlint src/renderer/src/components/sidebar/WorktreeList.tsx src/renderer/src/components/sidebar/worktree-list-groups.test.ts
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/worktree-list-groups.test.ts