### PR TITLE
Fix terminal file URL line reveals

### DIFF
--- a/src/renderer/src/components/editor/MonacoEditor.tsx
+++ b/src/renderer/src/components/editor/MonacoEditor.tsx
@@ -523,29 +523,6 @@ export default function MonacoEditor({
     }
   }, [])
 
-  useEffect(() => {
-    const handler = (event: Event): void => {
-      const detail = (event as CustomEvent).detail as
-        | { filePath?: string; line?: number; column?: number | null }
-        | undefined
-      if (!detail || detail.filePath !== filePath || !detail.line) {
-        return
-      }
-      const editor = editorRef.current
-      if (!editor) {
-        return
-      }
-      const targetColumn = Math.max(1, detail.column ?? 1)
-      const targetLine = Math.max(1, detail.line)
-      editor.revealPositionInCenter({ lineNumber: targetLine, column: targetColumn })
-      editor.setPosition({ lineNumber: targetLine, column: targetColumn })
-      editor.focus()
-    }
-
-    window.addEventListener('orca:editor-reveal-location', handler as EventListener)
-    return () => window.removeEventListener('orca:editor-reveal-location', handler as EventListener)
-  }, [filePath])
-
   // Navigate to line and highlight match when requested (for already-mounted editor)
   useEffect(() => {
     if (!revealLine || !editorRef.current) {

--- a/src/renderer/src/components/terminal-pane/terminal-file-url-target.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-file-url-target.ts
@@ -1,0 +1,49 @@
+export type TerminalFileUrlTarget = {
+  filePath: string
+  line: number | null
+  column: number | null
+}
+
+function parseFileUrlLineHash(hash: string): { line: number; column: number | null } | null {
+  const trimmed = hash.startsWith('#') ? hash.slice(1) : hash
+  const match = /^L(\d+)(?:C(\d+))?$/i.exec(trimmed)
+  if (!match) {
+    return null
+  }
+  return {
+    line: Number(match[1]),
+    column: match[2] ? Number(match[2]) : null
+  }
+}
+
+function parseFilePathTrailingLineTarget(filePath: string): TerminalFileUrlTarget | null {
+  const match = /^(.*?)(?::(\d+))(?::(\d+))?$/.exec(filePath)
+  if (!match || !match[1] || match[1].endsWith('/') || match[1].endsWith('\\')) {
+    return null
+  }
+  return {
+    filePath: match[1],
+    line: Number(match[2]),
+    column: match[3] ? Number(match[3]) : null
+  }
+}
+
+export function resolveTerminalFileUrlTarget(parsed: URL): TerminalFileUrlTarget | null {
+  if (parsed.hostname && parsed.hostname !== 'localhost') {
+    return null
+  }
+
+  let filePath = decodeURIComponent(parsed.pathname)
+  // Why: on Windows, file:///C:/foo yields pathname "/C:/foo". The leading
+  // slash must be stripped to produce a valid Windows path ("C:/foo").
+  if (/^\/[A-Za-z]:/.test(filePath)) {
+    filePath = filePath.slice(1)
+  }
+
+  const hashTarget = parseFileUrlLineHash(parsed.hash)
+  if (hashTarget) {
+    return { filePath, line: hashTarget.line, column: hashTarget.column }
+  }
+
+  return parseFilePathTrailingLineTarget(filePath) ?? { filePath, line: null, column: null }
+}

--- a/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
@@ -301,6 +301,46 @@ describe('handleOscLink', () => {
     )
   })
 
+  it('preserves #L line anchors from file URL links', async () => {
+    setPlatform('Macintosh')
+
+    handleOscLink('file:///tmp/test.txt#L42', { metaKey: true, ctrlKey: false }, deps)
+    await flushAsyncWork()
+    await flushDoubleRaf()
+
+    expect(authorizeExternalPathMock).toHaveBeenCalledWith({ targetPath: '/tmp/test.txt' })
+    expect(openFileMock).toHaveBeenCalledWith(
+      expect.objectContaining({ filePath: '/tmp/test.txt' })
+    )
+    expect(setPendingEditorRevealMock).toHaveBeenNthCalledWith(1, null)
+    expect(setPendingEditorRevealMock).toHaveBeenNthCalledWith(2, {
+      filePath: '/tmp/test.txt',
+      line: 42,
+      column: 1,
+      matchLength: 0
+    })
+  })
+
+  it('preserves trailing line and column suffixes from file URL links', async () => {
+    setPlatform('Macintosh')
+
+    handleOscLink('file:///tmp/test.txt:42:7', { metaKey: true, ctrlKey: false }, deps)
+    await flushAsyncWork()
+    await flushDoubleRaf()
+
+    expect(authorizeExternalPathMock).toHaveBeenCalledWith({ targetPath: '/tmp/test.txt' })
+    expect(openFileMock).toHaveBeenCalledWith(
+      expect.objectContaining({ filePath: '/tmp/test.txt' })
+    )
+    expect(setPendingEditorRevealMock).toHaveBeenNthCalledWith(1, null)
+    expect(setPendingEditorRevealMock).toHaveBeenNthCalledWith(2, {
+      filePath: '/tmp/test.txt',
+      line: 42,
+      column: 7,
+      matchLength: 0
+    })
+  })
+
   it('opens relative OSC file links against the terminal cwd', async () => {
     setPlatform('Macintosh')
 

--- a/src/renderer/src/components/terminal-pane/terminal-link-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-handlers.ts
@@ -20,6 +20,7 @@ import {
   type RuntimeFileOperationArgs
 } from '@/runtime/runtime-file-client'
 import { settingsForRuntimeOwner } from '@/runtime/runtime-rpc-client'
+import { resolveTerminalFileUrlTarget } from './terminal-file-url-target'
 
 export type LinkHandlerDeps = {
   worktreeId: string
@@ -178,11 +179,6 @@ export function openDetectedFilePath(
             column: targetColumn,
             matchLength: 0
           })
-          window.dispatchEvent(
-            new CustomEvent('orca:editor-reveal-location', {
-              detail: { filePath, line, column: targetColumn }
-            })
-          )
         })
       })
     }
@@ -339,15 +335,10 @@ export function handleOscLink(
     // the same openDetectedFilePath logic used for detected file-path links.
     // Only local files are supported — remote hosts (file://remote/…) are rejected
     // because we cannot open them as local paths.
-    if (parsed.hostname && parsed.hostname !== 'localhost') {
+    const resolved = resolveTerminalFileUrlTarget(parsed)
+    if (!resolved) {
       return
     }
-    let filePath = decodeURIComponent(parsed.pathname)
-    // Why: on Windows, file:///C:/foo yields pathname "/C:/foo". The leading
-    // slash must be stripped to produce a valid Windows path ("C:/foo").
-    if (/^\/[A-Za-z]:/.test(filePath)) {
-      filePath = filePath.slice(1)
-    }
-    openDetectedFilePath(filePath, null, null, deps)
+    openDetectedFilePath(resolved.filePath, resolved.line, resolved.column, deps)
   }
 }


### PR DESCRIPTION
## Summary
- Preserve `#Lline` and trailing `:line:column` targets when terminal OSC/file URL links open files in Orca.
- Route terminal line reveals only through the pending Monaco reveal flow so fresh large-file opens wait for content instead of clamping to line 1.
- Remove the one-shot `orca:editor-reveal-location` event path that bypassed the wait-aware reveal logic.

## Verification
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts src/renderer/src/lib/terminal-links.test.ts src/renderer/src/components/editor/monaco-reveal-range.test.ts`
- `pnpm lint`
- `pnpm run typecheck`
- Electron: Meta-clicked terminal-rendered `/Users/nwparker/orca/workspaces/orca/bug-orca-mobile-can-t-type/pnpm-lock.yaml:150`; Orca opened `pnpm-lock.yaml`, Monaco cursor line was `150`, and visible gutter lines included `132` through `151` with line `150` visible.

Follow-up to #1989 / #1991.
