### PR TITLE
Polish inactive workspace cleanup copy

### DIFF
--- a/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.tsx
@@ -7,7 +7,6 @@
 import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   AlertTriangle,
-  ArchiveX,
   ChevronDown,
   ChevronRight,
   LoaderCircle,
@@ -1325,13 +1324,15 @@ export function ResourceUsageStatusSegment({
           <button
             type="button"
             onClick={handleOpenWorkspaceCleanup}
-            className="inline-flex w-full items-center justify-between gap-2 rounded-md border border-border/70 px-2.5 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-accent/60"
+            className="relative inline-flex w-full items-center justify-center rounded-md border border-border/70 px-2.5 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-accent/60"
           >
-            <span className="inline-flex min-w-0 items-center gap-1.5">
-              <ArchiveX className="size-3.5 shrink-0" />
-              <span className="truncate">Clean up old workspaces ({oldWorkspaceCount})</span>
+            <span className="min-w-0 truncate px-4 text-center">
+              delete inactive workspaces ({oldWorkspaceCount})
             </span>
-            <ChevronRight className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
+            <ChevronRight
+              className="absolute right-2.5 size-3.5 text-muted-foreground"
+              aria-hidden
+            />
           </button>
           {orphanCount > 0 ? (
             <button

--- a/src/renderer/src/components/workspace-cleanup/WorkspaceCleanupDialog.tsx
+++ b/src/renderer/src/components/workspace-cleanup/WorkspaceCleanupDialog.tsx
@@ -100,7 +100,7 @@ function formatScanNoticeMessage(
   if (visibleErrors.length === 1) {
     const error = visibleErrors[0]
     const repoName = formatScanErrorRepoName(error, repoNameById)
-    return `Could not check ${repoName}: ${formatScanErrorReason(error.message)}. Some old workspaces may be missing. Refresh to try again.`
+    return `Could not check ${repoName}: ${formatScanErrorReason(error.message)}. Some inactive workspaces may be missing. Refresh to try again.`
   }
   const repoNames = visibleErrors
     .slice(0, 3)
@@ -108,7 +108,7 @@ function formatScanNoticeMessage(
     .join(', ')
   const moreCount = visibleErrors.length - 3
   const suffix = moreCount > 0 ? `, +${moreCount} more` : ''
-  return `Could not check ${visibleErrors.length} repositories (${repoNames}${suffix}). Some old workspaces may be missing. Refresh to try again.`
+  return `Could not check ${visibleErrors.length} repositories (${repoNames}${suffix}). Some inactive workspaces may be missing. Refresh to try again.`
 }
 
 function formatScanErrorRepoName(
@@ -412,9 +412,9 @@ export default function WorkspaceCleanupDialog(): React.JSX.Element {
             <DialogHeader className="border-b border-border px-5 py-4">
               <div className="flex items-start justify-between gap-4">
                 <div className="min-w-0">
-                  <DialogTitle className="text-base">Clean Up Old Workspaces</DialogTitle>
+                  <DialogTitle className="text-base">Delete Inactive Workspaces</DialogTitle>
                   <DialogDescription className="mt-1 text-xs">
-                    Review old workspaces before deleting their local files and Orca state.
+                    Review inactive workspaces before deleting their local files and Orca state.
                   </DialogDescription>
                 </div>
                 <div className="flex shrink-0 items-center gap-2">
@@ -450,7 +450,7 @@ export default function WorkspaceCleanupDialog(): React.JSX.Element {
             {initialLoading ? (
               <div className="flex items-center gap-2 border-b border-border bg-muted/25 px-5 py-3 text-xs text-muted-foreground">
                 <Loader2 className="size-3.5 animate-spin" />
-                Checking old workspaces
+                Checking inactive workspaces
               </div>
             ) : oldCandidateCount > 0 || hiddenByKeepCount > 0 ? (
               <div className="flex flex-wrap items-center justify-between gap-3 border-b border-border bg-muted/25 px-4 py-2.5">
@@ -551,10 +551,10 @@ export default function WorkspaceCleanupDialog(): React.JSX.Element {
                   <div>
                     {initialLoading ? <SkeletonRows /> : null}
                     {!loading && scan && candidates.length === 0 && !scanNoticeMessage ? (
-                      <EmptyState title="No old workspaces to clean up." />
+                      <EmptyState title="No inactive workspaces to delete." />
                     ) : null}
                     {!loading && scan && candidates.length === 0 && scanNoticeMessage ? (
-                      <EmptyState title="No old workspaces found in checked repositories." />
+                      <EmptyState title="No inactive workspaces found in checked repositories." />
                     ) : null}
                     {!loading && scan && candidates.length > 0 && visibleCandidates.length === 0 ? (
                       <EmptyState


### PR DESCRIPTION
## Summary
- Rename workspace cleanup entry point to "delete inactive workspaces"
- Match the cleanup button styling to the orphan-terminal action while keeping the right chevron
- Update cleanup dialog copy from old workspaces to inactive workspaces

## Tests
- pnpm exec oxlint src/renderer/src/components/status-bar/ResourceUsageStatusSegment.tsx
- pnpm exec oxfmt --check src/renderer/src/components/status-bar/ResourceUsageStatusSegment.tsx
- pnpm run tc:web
- pnpm exec oxlint src/renderer/src/components/workspace-cleanup/WorkspaceCleanupDialog.tsx src/renderer/src/components/status-bar/ResourceUsageStatusSegment.tsx
- pnpm exec oxfmt --check src/renderer/src/components/workspace-cleanup/WorkspaceCleanupDialog.tsx src/renderer/src/components/status-bar/ResourceUsageStatusSegment.tsx

Made with [Orca](https://github.com/stablyai/orca) 🐋
