### PR TITLE
Seed file search from selected text

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -81,6 +81,7 @@ import {
 } from './lib/startup-ui-hydration'
 import { applyDocumentTheme } from './lib/document-theme'
 import { isEditableTarget } from './lib/editable-target'
+import { getSelectedTextForFileSearch } from './lib/file-search-selection'
 import {
   canGoBackWorktreeHistory,
   canGoForwardWorktreeHistory
@@ -215,8 +216,8 @@ function App(): React.JSX.Element {
 
   // Why: Zustand actions are referentially stable, but each individual
   // useAppStore(s => s.someAction) still registers a subscription that React
-  // must check on every store mutation. Consolidating 19 action refs into one
-  // useShallow subscription means one equality check instead of 19.
+  // must check on every store mutation. Consolidating action refs into one
+  // useShallow subscription means one equality check instead of many.
   const actions = useAppStore(
     useShallow((s) => ({
       toggleSidebar: s.toggleSidebar,
@@ -241,6 +242,7 @@ function App(): React.JSX.Element {
       toggleRightSidebar: s.toggleRightSidebar,
       setRightSidebarOpen: s.setRightSidebarOpen,
       setRightSidebarTab: s.setRightSidebarTab,
+      seedFileSearchQuery: s.seedFileSearchQuery,
       setActiveView: s.setActiveView,
       updateSettings: s.updateSettings,
       pruneLastVisitedTimestamps: s.pruneLastVisitedTimestamps,
@@ -921,6 +923,31 @@ function App(): React.JSX.Element {
       // browser guest has focus. The renderer keeps matching handlers for
       // local-focus cases and to preserve the same guards in one place.
 
+      const isSearchShortcut = e.shiftKey && !e.altKey && e.key.toLowerCase() === 'f'
+      const canRevealRightSidebar =
+        activeView !== 'tasks' &&
+        activeView !== 'activity' &&
+        activeView !== 'automations' &&
+        activeView !== 'space' &&
+        activeView !== 'skills'
+
+      const openSearchSidebar = (query: string | null): void => {
+        if (query && activeWorktreeId) {
+          actions.seedFileSearchQuery(activeWorktreeId, query)
+        }
+        actions.setRightSidebarTab('search')
+        actions.setRightSidebarOpen(true)
+      }
+
+      if (mod && isSearchShortcut && canRevealRightSidebar) {
+        const selectedText = getSelectedTextForFileSearch()
+        if (selectedText) {
+          e.preventDefault()
+          openSearchSidebar(selectedText)
+          return
+        }
+      }
+
       // Why: keep this guard. TipTap's Cmd+B bold binding depends on the
       // window-level handler *not* toggling the sidebar when focus lives in an
       // editable surface. The main-process before-input-event already carves out
@@ -975,13 +1002,7 @@ function App(): React.JSX.Element {
 
       // Why: full-page navigation surfaces should not reveal the right sidebar;
       // they are designed as distraction-free content areas.
-      if (
-        activeView === 'tasks' ||
-        activeView === 'activity' ||
-        activeView === 'automations' ||
-        activeView === 'space' ||
-        activeView === 'skills'
-      ) {
+      if (!canRevealRightSidebar) {
         return
       }
 
@@ -1001,10 +1022,9 @@ function App(): React.JSX.Element {
       }
 
       // Cmd/Ctrl+Shift+F — toggle right sidebar / search tab
-      if (e.shiftKey && !e.altKey && e.key.toLowerCase() === 'f') {
+      if (isSearchShortcut) {
         e.preventDefault()
-        actions.setRightSidebarTab('search')
-        actions.setRightSidebarOpen(true)
+        openSearchSidebar(null)
         return
       }
 

--- a/src/renderer/src/components/editor/MonacoEditor.tsx
+++ b/src/renderer/src/components/editor/MonacoEditor.tsx
@@ -9,6 +9,7 @@ import { useAppStore } from '@/store'
 import { scrollTopCache, cursorPositionCache, setWithLRU } from '@/lib/scroll-cache'
 import '@/lib/monaco-setup'
 import { computeEditorFontSize } from '@/lib/editor-font-zoom'
+import { registerFileSearchSelectedTextProvider } from '@/lib/file-search-selection'
 
 import { useContextualCopySetup } from './useContextualCopySetup'
 import { MAX_REVEAL_CONTENT_WAIT_FRAMES, performReveal } from './monaco-reveal'
@@ -75,6 +76,7 @@ export default function MonacoEditor({
   const revealHighlightTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const revealRafRef = useRef<number | null>(null)
   const revealInnerRafRef = useRef<number | null>(null)
+  const unregisterFileSearchSelectionRef = useRef<(() => void) | null>(null)
   const { setupCopy, toastNode } = useContextualCopySetup()
   // Why: The scroll throttle timer must be accessible from useLayoutEffect cleanup
   // so we can cancel any pending write before synchronously snapshotting the final
@@ -285,6 +287,20 @@ export default function MonacoEditor({
       }
 
       setupCopy(editorInstance, monaco, filePath, propsRef)
+      unregisterFileSearchSelectionRef.current?.()
+      unregisterFileSearchSelectionRef.current = registerFileSearchSelectedTextProvider(() => {
+        if (!editorInstance.hasTextFocus()) {
+          return null
+        }
+        const model = editorInstance.getModel()
+        const selection = editorInstance.getSelection()
+        if (!model || !selection || selection.isEmpty()) {
+          return null
+        }
+        // Why: Monaco selections live in its text model, not the DOM selection
+        // API that app-level keyboard shortcuts can read.
+        return model.getValueInRange(selection)
+      })
 
       // Add Cmd+S save keybinding
       editorInstance.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS, () => {
@@ -491,6 +507,8 @@ export default function MonacoEditor({
       }
       cancelScheduledReveal()
       clearTransientRevealHighlight()
+      unregisterFileSearchSelectionRef.current?.()
+      unregisterFileSearchSelectionRef.current = null
     }
   }, [cancelScheduledReveal, clearTransientRevealHighlight, viewStateKey])
 

--- a/src/renderer/src/components/right-sidebar/Search.tsx
+++ b/src/renderer/src/components/right-sidebar/Search.tsx
@@ -33,8 +33,10 @@ export default function Search(): React.JSX.Element {
   const fileSearchResults = searchState?.results ?? null
   const fileSearchLoading = searchState?.loading ?? false
   const fileSearchCollapsedFiles = searchState?.collapsedFiles ?? EMPTY_COLLAPSED_FILES
+  const fileSearchSeedRequestId = searchState?.seedRequestId
 
   const updateFileSearchState = useAppStore((s) => s.updateFileSearchState)
+  const consumeFileSearchSeedRequest = useAppStore((s) => s.consumeFileSearchSeedRequest)
   const toggleFileSearchCollapsedFile = useAppStore((s) => s.toggleFileSearchCollapsedFile)
   const clearFileSearch = useAppStore((s) => s.clearFileSearch)
 
@@ -44,6 +46,7 @@ export default function Search(): React.JSX.Element {
   const resultsScrollRef = useRef<HTMLDivElement>(null)
   const revealRafRef = useRef<number | null>(null)
   const revealInnerRafRef = useRef<number | null>(null)
+  const seededInputSelectionRafRef = useRef<number | null>(null)
   const includeInputRef = useRef<HTMLInputElement>(null)
   const excludeInputRef = useRef<HTMLInputElement>(null)
 
@@ -85,6 +88,24 @@ export default function Search(): React.JSX.Element {
 
   const worktreePath = activeWorktree?.path ?? null
 
+  const cancelSeededInputSelectionFrame = useCallback(() => {
+    if (seededInputSelectionRafRef.current !== null) {
+      cancelAnimationFrame(seededInputSelectionRafRef.current)
+      seededInputSelectionRafRef.current = null
+    }
+  }, [])
+
+  const scheduleSeededInputSelection = useCallback(() => {
+    cancelSeededInputSelectionFrame()
+    // Why: match VS Code's seeded file search behavior; typing should replace
+    // the selected query after the sidebar finishes opening/loading.
+    seededInputSelectionRafRef.current = requestAnimationFrame(() => {
+      seededInputSelectionRafRef.current = null
+      inputRef.current?.focus()
+      inputRef.current?.select()
+    })
+  }, [cancelSeededInputSelectionFrame])
+
   // Focus input on mount
   useEffect(() => {
     inputRef.current?.focus()
@@ -94,10 +115,11 @@ export default function Search(): React.JSX.Element {
   useEffect(() => {
     return () => {
       cancelPendingSearch()
+      cancelSeededInputSelectionFrame()
       cancelRevealFrame(revealRafRef)
       cancelRevealFrame(revealInnerRafRef)
     }
-  }, [cancelPendingSearch])
+  }, [cancelPendingSearch, cancelSeededInputSelectionFrame])
 
   useEffect(() => {
     if (!worktreePath) {
@@ -214,6 +236,27 @@ export default function Search(): React.JSX.Element {
     },
     [worktreePath, updateActiveSearchState, activeWorktreeId]
   )
+
+  useEffect(() => {
+    if (!activeWorktreeId || fileSearchSeedRequestId === undefined) {
+      return
+    }
+
+    // Why: Cmd/Ctrl+Shift+F can seed the query before this lazy panel mounts.
+    // The one-shot request lets the mounted panel run the real runtime search.
+    if (fileSearchQuery.trim()) {
+      executeSearch(fileSearchQuery)
+      scheduleSeededInputSelection()
+    }
+    consumeFileSearchSeedRequest(activeWorktreeId, fileSearchSeedRequestId)
+  }, [
+    activeWorktreeId,
+    consumeFileSearchSeedRequest,
+    executeSearch,
+    fileSearchQuery,
+    fileSearchSeedRequestId,
+    scheduleSeededInputSelection
+  ])
 
   const handleClearSearch = useCallback(() => {
     cancelPendingSearch()

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -483,6 +483,16 @@ export default function TerminalPane({
     [executeClosePane]
   )
 
+  const handleSearchSelectedText = useCallback(
+    (selectedText: string): void => {
+      const state = useAppStore.getState()
+      state.seedFileSearchQuery(worktreeId, selectedText)
+      state.setRightSidebarTab('search')
+      state.setRightSidebarOpen(true)
+    },
+    [worktreeId]
+  )
+
   const handleConfirmClose = useCallback(() => {
     if (closeConfirmPaneId === null) {
       return
@@ -734,6 +744,7 @@ export default function TerminalPane({
     persistLayoutSnapshot,
     toggleExpandPane,
     setSearchOpen,
+    onSearchSelectedText: handleSearchSelectedText,
     onRequestClosePane: handleRequestClosePane,
     searchOpenRef,
     searchStateRef,

--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.test.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.test.ts
@@ -1,6 +1,6 @@
 // src/renderer/src/components/terminal-pane/keyboard-handlers.test.ts
 import { describe, it, expect } from 'vitest'
-import { matchSearchNavigate } from './keyboard-handlers'
+import { matchFileSearchShortcut, matchSearchNavigate } from './keyboard-handlers'
 
 function makeKeyEvent(
   overrides: Partial<{
@@ -9,14 +9,16 @@ function makeKeyEvent(
     ctrlKey: boolean
     shiftKey: boolean
     altKey: boolean
+    repeat: boolean
   }>
-): Pick<KeyboardEvent, 'key' | 'metaKey' | 'ctrlKey' | 'shiftKey' | 'altKey'> {
+): Pick<KeyboardEvent, 'key' | 'metaKey' | 'ctrlKey' | 'shiftKey' | 'altKey' | 'repeat'> {
   return {
     key: 'g',
     metaKey: false,
     ctrlKey: false,
     shiftKey: false,
     altKey: false,
+    repeat: false,
     ...overrides
   }
 }
@@ -70,5 +72,37 @@ describe('matchSearchNavigate', () => {
   it('returns null for Ctrl+G on macOS (wrong modifier)', () => {
     const e = makeKeyEvent({ ctrlKey: true })
     expect(matchSearchNavigate(e, true, true, searchState)).toBeNull()
+  })
+})
+
+describe('matchFileSearchShortcut', () => {
+  it('matches Cmd+Shift+F on macOS', () => {
+    expect(
+      matchFileSearchShortcut(makeKeyEvent({ key: 'F', metaKey: true, shiftKey: true }), true)
+    ).toBe(true)
+  })
+
+  it('matches Ctrl+Shift+F on Linux/Windows', () => {
+    expect(
+      matchFileSearchShortcut(makeKeyEvent({ key: 'F', ctrlKey: true, shiftKey: true }), false)
+    ).toBe(true)
+  })
+
+  it('rejects repeats, alt, and the wrong platform modifier', () => {
+    expect(
+      matchFileSearchShortcut(
+        makeKeyEvent({ key: 'F', metaKey: true, shiftKey: true, repeat: true }),
+        true
+      )
+    ).toBe(false)
+    expect(
+      matchFileSearchShortcut(
+        makeKeyEvent({ key: 'F', metaKey: true, shiftKey: true, altKey: true }),
+        true
+      )
+    ).toBe(false)
+    expect(
+      matchFileSearchShortcut(makeKeyEvent({ key: 'F', ctrlKey: true, shiftKey: true }), true)
+    ).toBe(false)
   })
 })

--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
@@ -1,3 +1,6 @@
+/* eslint-disable max-lines -- Why: terminal keyboard routing keeps shortcut
+ * precedence in one ordered handler so shell input, pane commands, search, and
+ * split actions do not race across separate window listeners. */
 import { useEffect } from 'react'
 import type { PaneManager } from '@/lib/pane-manager/pane-manager'
 import type { PtyTransport } from './pty-transport'
@@ -5,6 +8,7 @@ import { resolveTerminalShortcutAction } from './terminal-shortcut-policy'
 import type { MacOptionAsAlt } from './terminal-shortcut-policy'
 import { resolveSplitCwd, type PaneCwdMap } from './resolve-split-cwd'
 import { keyboardEventBelongsToScope } from './terminal-keyboard-scope'
+import { normalizeSelectedTextForFileSearch } from '@/lib/file-search-selection'
 
 function isEditableTarget(target: EventTarget | null): boolean {
   if (!(target instanceof HTMLElement)) {
@@ -64,6 +68,17 @@ export function matchSearchNavigate(
   return e.shiftKey ? 'previous' : 'next'
 }
 
+export function matchFileSearchShortcut(
+  e: Pick<KeyboardEvent, 'key' | 'metaKey' | 'ctrlKey' | 'shiftKey' | 'altKey' | 'repeat'>,
+  isMac: boolean
+): boolean {
+  if (e.repeat || e.altKey) {
+    return false
+  }
+  const mod = isMac ? e.metaKey && !e.ctrlKey : e.ctrlKey && !e.metaKey
+  return mod && e.shiftKey && e.key.toLowerCase() === 'f'
+}
+
 type KeyboardHandlersDeps = {
   isActive: boolean
   keyboardScopeRef: React.RefObject<HTMLElement | null>
@@ -79,6 +94,7 @@ type KeyboardHandlersDeps = {
   persistLayoutSnapshot: () => void
   toggleExpandPane: (paneId: number) => void
   setSearchOpen: React.Dispatch<React.SetStateAction<boolean>>
+  onSearchSelectedText: (text: string) => void
   onRequestClosePane: (paneId: number) => void
   searchOpenRef: React.RefObject<boolean>
   searchStateRef: React.RefObject<SearchState>
@@ -99,6 +115,7 @@ export function useTerminalKeyboardShortcuts({
   persistLayoutSnapshot,
   toggleExpandPane,
   setSearchOpen,
+  onSearchSelectedText,
   onRequestClosePane,
   searchOpenRef,
   searchStateRef,
@@ -135,6 +152,17 @@ export function useTerminalKeyboardShortcuts({
       const keyboardScope = keyboardScopeRef.current
       if (keyboardScope && !keyboardEventBelongsToScope(e, keyboardScope)) {
         return
+      }
+
+      if (matchFileSearchShortcut(e, isMac)) {
+        const pane = manager.getActivePane() ?? manager.getPanes()[0]
+        const selectedText = normalizeSelectedTextForFileSearch(pane?.terminal.getSelection())
+        if (selectedText) {
+          e.preventDefault()
+          e.stopImmediatePropagation()
+          onSearchSelectedText(selectedText)
+          return
+        }
       }
 
       // Cmd+G / Cmd+Shift+G navigates terminal search matches even when focus
@@ -352,6 +380,7 @@ export function useTerminalKeyboardShortcuts({
     persistLayoutSnapshot,
     toggleExpandPane,
     setSearchOpen,
+    onSearchSelectedText,
     onRequestClosePane,
     searchOpenRef,
     searchStateRef,

--- a/src/renderer/src/lib/file-search-selection.test.ts
+++ b/src/renderer/src/lib/file-search-selection.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  getSelectedTextForFileSearch,
+  normalizeSelectedTextForFileSearch,
+  registerFileSearchSelectedTextProvider
+} from './file-search-selection'
+
+const unregisterCallbacks: (() => void)[] = []
+
+afterEach(() => {
+  while (unregisterCallbacks.length > 0) {
+    unregisterCallbacks.pop()?.()
+  }
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+function registerForTest(provider: () => string | null | undefined): void {
+  unregisterCallbacks.push(registerFileSearchSelectedTextProvider(provider))
+}
+
+describe('normalizeSelectedTextForFileSearch', () => {
+  it('trims and collapses multi-line selections into the single-line search box shape', () => {
+    expect(normalizeSelectedTextForFileSearch('  foo\r\n  bar\n\n baz  ')).toBe('foo bar baz')
+  })
+
+  it('returns null for empty selections', () => {
+    expect(normalizeSelectedTextForFileSearch(' \n\t ')).toBeNull()
+    expect(normalizeSelectedTextForFileSearch(null)).toBeNull()
+  })
+})
+
+describe('getSelectedTextForFileSearch', () => {
+  it('uses the most recently registered non-empty provider', () => {
+    registerForTest(() => 'older')
+    registerForTest(() => 'newer')
+
+    expect(getSelectedTextForFileSearch()).toBe('newer')
+  })
+
+  it('falls back through empty providers', () => {
+    registerForTest(() => 'needle')
+    registerForTest(() => ' ')
+
+    expect(getSelectedTextForFileSearch()).toBe('needle')
+  })
+
+  it('unregisters providers so closed editors do not accumulate stale selection readers', () => {
+    const unregister = registerFileSearchSelectedTextProvider(() => 'stale')
+    unregister()
+
+    registerForTest(() => 'active')
+
+    expect(getSelectedTextForFileSearch()).toBe('active')
+  })
+
+  it('falls back to the DOM selection when no provider has selected text', () => {
+    vi.stubGlobal('window', {
+      getSelection: () => ({
+        toString: () => 'dom selection'
+      })
+    })
+
+    expect(getSelectedTextForFileSearch()).toBe('dom selection')
+  })
+})

--- a/src/renderer/src/lib/file-search-selection.ts
+++ b/src/renderer/src/lib/file-search-selection.ts
@@ -1,0 +1,49 @@
+export type FileSearchSelectedTextProvider = () => string | null | undefined
+
+type ProviderEntry = {
+  id: number
+  provider: FileSearchSelectedTextProvider
+}
+
+const selectedTextProviders: ProviderEntry[] = []
+let nextProviderId = 1
+
+export function normalizeSelectedTextForFileSearch(text: string | null | undefined): string | null {
+  const trimmed = text?.replace(/\r\n?/g, '\n').trim()
+  if (!trimmed) {
+    return null
+  }
+  return trimmed
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .join(' ')
+}
+
+export function registerFileSearchSelectedTextProvider(
+  provider: FileSearchSelectedTextProvider
+): () => void {
+  const entry = { id: nextProviderId++, provider }
+  selectedTextProviders.push(entry)
+  return () => {
+    const index = selectedTextProviders.findIndex((candidate) => candidate.id === entry.id)
+    if (index !== -1) {
+      selectedTextProviders.splice(index, 1)
+    }
+  }
+}
+
+export function getSelectedTextForFileSearch(): string | null {
+  for (let index = selectedTextProviders.length - 1; index >= 0; index -= 1) {
+    const selectedText = normalizeSelectedTextForFileSearch(selectedTextProviders[index].provider())
+    if (selectedText) {
+      return selectedText
+    }
+  }
+
+  if (typeof window === 'undefined') {
+    return null
+  }
+
+  return normalizeSelectedTextForFileSearch(window.getSelection()?.toString())
+}

--- a/src/renderer/src/store/slices/editor.test.ts
+++ b/src/renderer/src/store/slices/editor.test.ts
@@ -65,6 +65,63 @@ describe('createEditorSlice right sidebar state', () => {
   })
 })
 
+describe('createEditorSlice file search seed state', () => {
+  it('seeds file search with a one-shot request id', () => {
+    const store = createEditorStore()
+
+    store.getState().seedFileSearchQuery('wt-1', 'selectedText')
+
+    expect(store.getState().fileSearchStateByWorktree['wt-1']).toMatchObject({
+      query: 'selectedText',
+      results: null,
+      loading: false,
+      seedRequestId: 1
+    })
+  })
+
+  it('preserves search options while replacing stale results and collapsed files', () => {
+    const store = createEditorStore()
+    store.getState().updateFileSearchState('wt-1', {
+      query: 'old',
+      caseSensitive: true,
+      wholeWord: true,
+      useRegex: true,
+      includePattern: '*.ts',
+      excludePattern: 'dist/**',
+      results: { files: [], totalMatches: 1, truncated: false },
+      loading: true,
+      collapsedFiles: new Set(['/repo/file.ts'])
+    })
+
+    store.getState().seedFileSearchQuery('wt-1', 'next')
+
+    const state = store.getState().fileSearchStateByWorktree['wt-1']
+    expect(state).toMatchObject({
+      query: 'next',
+      caseSensitive: true,
+      wholeWord: true,
+      useRegex: true,
+      includePattern: '*.ts',
+      excludePattern: 'dist/**',
+      results: null,
+      loading: false,
+      seedRequestId: 1
+    })
+    expect(state.collapsedFiles.size).toBe(0)
+  })
+
+  it('consumes only the matching seed request id', () => {
+    const store = createEditorStore()
+    store.getState().seedFileSearchQuery('wt-1', 'selectedText')
+
+    store.getState().consumeFileSearchSeedRequest('wt-1', 2)
+    expect(store.getState().fileSearchStateByWorktree['wt-1']?.seedRequestId).toBe(1)
+
+    store.getState().consumeFileSearchSeedRequest('wt-1', 1)
+    expect(store.getState().fileSearchStateByWorktree['wt-1']?.seedRequestId).toBeUndefined()
+  })
+})
+
 describe('createEditorSlice openDiff', () => {
   it('keeps staged and unstaged diffs in separate tabs', () => {
     const store = createEditorStore()

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -382,12 +382,15 @@ export type EditorSlice = {
       results: SearchResult | null
       loading: boolean
       collapsedFiles: Set<string>
+      seedRequestId?: number
     }
   >
   updateFileSearchState: (
     worktreeId: string,
     updates: Partial<EditorSlice['fileSearchStateByWorktree'][string]>
   ) => void
+  seedFileSearchQuery: (worktreeId: string, query: string) => void
+  consumeFileSearchSeedRequest: (worktreeId: string, seedRequestId: number) => void
   toggleFileSearchCollapsedFile: (worktreeId: string, filePath: string) => void
   clearFileSearch: (worktreeId: string) => void
 
@@ -2206,6 +2209,48 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
         fileSearchStateByWorktree: {
           ...s.fileSearchStateByWorktree,
           [worktreeId]: { ...current, ...updates }
+        }
+      }
+    }),
+  seedFileSearchQuery: (worktreeId, query) =>
+    set((s) => {
+      const current = s.fileSearchStateByWorktree[worktreeId] || {
+        query: '',
+        caseSensitive: false,
+        wholeWord: false,
+        useRegex: false,
+        includePattern: '',
+        excludePattern: '',
+        results: null,
+        loading: false,
+        collapsedFiles: new Set()
+      }
+      return {
+        fileSearchStateByWorktree: {
+          ...s.fileSearchStateByWorktree,
+          [worktreeId]: {
+            ...current,
+            query,
+            results: null,
+            loading: false,
+            collapsedFiles: new Set(),
+            seedRequestId: (current.seedRequestId ?? 0) + 1
+          }
+        }
+      }
+    }),
+  consumeFileSearchSeedRequest: (worktreeId, seedRequestId) =>
+    set((s) => {
+      const current = s.fileSearchStateByWorktree[worktreeId]
+      if (!current || current.seedRequestId !== seedRequestId) {
+        return s
+      }
+      const next = { ...current }
+      delete next.seedRequestId
+      return {
+        fileSearchStateByWorktree: {
+          ...s.fileSearchStateByWorktree,
+          [worktreeId]: next
         }
       }
     }),


### PR DESCRIPTION
## Summary
- seed file search from selected text on Cmd/Ctrl+Shift+F, including Monaco selections
- add terminal selected-text support for the same shortcut
- focus and select the seeded Search input text after opening the panel

## Perf review
- Shortcut work is gated to the explicit file-search shortcut, not typing, terminal output, polling, or render loops.
- Monaco selected-text readers are registered per mounted editor and cleaned up on unmount; added a cleanup regression test to prevent stale provider accumulation.
- Search execution remains debounced and uses a one-shot seed request so lazy mounting does not add background polling or persistent timers.

## Verification
- pnpm vitest run --config config/vitest.config.ts src/renderer/src/lib/file-search-selection.test.ts src/renderer/src/store/slices/editor.test.ts src/renderer/src/components/terminal-pane/keyboard-handlers.test.ts
- pnpm typecheck
- pnpm lint
- pnpm run tc:web
- Electron validation: Cmd+Shift+F with selected text opens Search with the seeded query focused and selected
