### PR TITLE
Fix AI commit prompt input persistence

### DIFF
--- a/src/renderer/src/components/settings/CommitMessageAiPane.test.tsx
+++ b/src/renderer/src/components/settings/CommitMessageAiPane.test.tsx
@@ -64,6 +64,8 @@ describe('CommitMessageAiPane', () => {
     expect(markup).toContain('Thinking effort')
     expect(markup).toContain('Higher effort produces more careful messages')
     expect(markup).toContain('Use Conventional Commits.')
+    expect(markup).toContain('Save')
+    expect(markup).toContain('Saved')
   })
 
   it('renders custom command settings for custom agents', () => {

--- a/src/renderer/src/components/settings/CommitMessageAiPane.tsx
+++ b/src/renderer/src/components/settings/CommitMessageAiPane.tsx
@@ -2,7 +2,7 @@
    model dropdown, thinking effort dropdown, custom command, custom prompt) is
    a SearchableSetting block, and splitting the pane across files would scatter
    the ~6 conditional render branches without making any of them clearer. */
-import { useMemo } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { Terminal } from 'lucide-react'
 import type { CommitMessageAiSettings, GlobalSettings, TuiAgent } from '../../../../shared/types'
 import {
@@ -17,6 +17,7 @@ import {
 } from '../../../../shared/commit-message-agent-spec'
 import { CUSTOM_PROMPT_PLACEHOLDER } from '../../../../shared/commit-message-prompt'
 import { AGENT_CATALOG, AgentIcon } from '@/lib/agent-catalog'
+import { Button } from '../ui/button'
 import { Label } from '../ui/label'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
 import { useAppStore } from '../../store'
@@ -25,7 +26,9 @@ import { matchesSettingsSearch } from './settings-search'
 
 type CommitMessageAiPaneProps = {
   settings: GlobalSettings
-  updateSettings: (updates: Partial<GlobalSettings>) => void
+  updateSettings: (updates: Partial<GlobalSettings>) => void | Promise<void>
+  onCustomPromptDirtyChange?: (dirty: boolean) => void
+  customPromptDiscardSignal?: number
 }
 
 const EMPTY_SETTINGS: CommitMessageAiSettings = {
@@ -76,10 +79,44 @@ function resolveSelectedThinking(
 
 export function CommitMessageAiPane({
   settings,
-  updateSettings
+  updateSettings,
+  onCustomPromptDirtyChange,
+  customPromptDiscardSignal
 }: CommitMessageAiPaneProps): React.JSX.Element {
   const searchQuery = useAppStore((s) => s.settingsSearchQuery)
   const config = readSettings(settings)
+  const persistedCustomPrompt = config.customPrompt
+  const [customPromptDraft, setCustomPromptDraft] = useState(persistedCustomPrompt)
+  const [isSavingCustomPrompt, setIsSavingCustomPrompt] = useState(false)
+  const persistedCustomPromptRef = useRef(persistedCustomPrompt)
+  const isCustomPromptDirty = customPromptDraft !== persistedCustomPrompt
+
+  useEffect(() => {
+    persistedCustomPromptRef.current = persistedCustomPrompt
+  }, [persistedCustomPrompt])
+
+  useEffect(() => {
+    if (!isCustomPromptDirty) {
+      setCustomPromptDraft(persistedCustomPrompt)
+    }
+  }, [isCustomPromptDirty, persistedCustomPrompt])
+
+  useEffect(() => {
+    setCustomPromptDraft(persistedCustomPromptRef.current)
+    // Why: parent navigation guards use this signal after the user confirms
+    // they want to leave without saving the prompt draft.
+  }, [customPromptDiscardSignal])
+
+  useEffect(() => {
+    onCustomPromptDirtyChange?.(isCustomPromptDirty)
+  }, [isCustomPromptDirty, onCustomPromptDirtyChange])
+
+  useEffect(
+    () => () => {
+      onCustomPromptDirtyChange?.(false)
+    },
+    [onCustomPromptDirtyChange]
+  )
 
   const agentCapabilities = useMemo(listCommitMessageAgentCapabilities, [])
   const activeAgentId: CommitMessageAgentChoice = config.agentId ?? DEFAULT_COMMIT_MESSAGE_AGENT_ID
@@ -197,8 +234,20 @@ export function CommitMessageAiPane({
     })
   }
 
-  const onCustomPromptChange = (value: string): void => {
-    writeConfig({ customPrompt: value })
+  const onSaveCustomPrompt = async (): Promise<void> => {
+    if (!isCustomPromptDirty || isSavingCustomPrompt) {
+      return
+    }
+    setIsSavingCustomPrompt(true)
+    try {
+      await updateSettings({ commitMessageAi: { ...config, customPrompt: customPromptDraft } })
+    } finally {
+      setIsSavingCustomPrompt(false)
+    }
+  }
+
+  const onDiscardCustomPrompt = (): void => {
+    setCustomPromptDraft(persistedCustomPrompt)
   }
 
   const sections: React.ReactNode[] = []
@@ -425,13 +474,14 @@ export function CommitMessageAiPane({
   }
 
   if (
-    config.enabled &&
-    matchesSettingsSearch(searchQuery, {
-      title: 'Custom prompt',
-      description:
-        'Optional instructions appended to the base prompt (e.g. Conventional Commits style).',
-      keywords: ['prompt', 'conventional commits', 'gitmoji', 'style']
-    })
+    (config.enabled || isCustomPromptDirty) &&
+    (isCustomPromptDirty ||
+      matchesSettingsSearch(searchQuery, {
+        title: 'Custom prompt',
+        description:
+          'Optional instructions appended to the base prompt (e.g. Conventional Commits style).',
+        keywords: ['prompt', 'conventional commits', 'gitmoji', 'style']
+      }))
   ) {
     sections.push(
       <SearchableSetting
@@ -439,6 +489,7 @@ export function CommitMessageAiPane({
         title="Custom prompt"
         description="Optional instructions appended to the base prompt (e.g. Conventional Commits style)."
         keywords={['prompt', 'conventional commits', 'gitmoji', 'style']}
+        forceVisible={isCustomPromptDirty}
         className="space-y-2 px-1 py-2"
       >
         <div className="space-y-0.5">
@@ -451,11 +502,38 @@ export function CommitMessageAiPane({
         <textarea
           id="commit-message-ai-custom-prompt"
           rows={4}
-          value={config.customPrompt}
-          onChange={(e) => onCustomPromptChange(e.target.value)}
+          value={customPromptDraft}
+          onChange={(e) => setCustomPromptDraft(e.target.value)}
           placeholder="Use Conventional Commits format (feat:, fix:, ...). Reference the ticket key when present."
           className="w-full resize-y rounded-md border border-border bg-background px-2 py-1.5 text-xs text-foreground outline-none placeholder:text-muted-foreground/70 focus-visible:ring-1 focus-visible:ring-ring"
         />
+        <div className="flex items-center justify-between gap-3">
+          <p className="text-[11px] text-muted-foreground">
+            {isCustomPromptDirty ? 'Unsaved changes' : 'Saved'}
+          </p>
+          <div className="flex items-center gap-2">
+            {isCustomPromptDirty ? (
+              <Button
+                type="button"
+                variant="ghost"
+                size="xs"
+                onClick={onDiscardCustomPrompt}
+                disabled={isSavingCustomPrompt}
+              >
+                Discard
+              </Button>
+            ) : null}
+            <Button
+              type="button"
+              variant="secondary"
+              size="xs"
+              onClick={() => void onSaveCustomPrompt()}
+              disabled={!isCustomPromptDirty || isSavingCustomPrompt}
+            >
+              {isSavingCustomPrompt ? 'Saving...' : 'Save'}
+            </Button>
+          </div>
+        </div>
       </SearchableSetting>
     )
   }

--- a/src/renderer/src/components/settings/SearchableSetting.tsx
+++ b/src/renderer/src/components/settings/SearchableSetting.tsx
@@ -5,19 +5,21 @@ import { matchesSettingsSearch, type SettingsSearchEntry } from './settings-sear
 type SearchableSettingProps = SettingsSearchEntry & {
   children: React.ReactNode
   className?: string
+  forceVisible?: boolean
   id?: string
 }
 
 export function SearchableSetting({
   title,
   description,
+  forceVisible = false,
   keywords,
   children,
   className,
   id
 }: SearchableSettingProps): React.JSX.Element | null {
   const query = useAppStore((state) => state.settingsSearchQuery)
-  if (!matchesSettingsSearch(query, { title, description, keywords })) {
+  if (!forceVisible && !matchesSettingsSearch(query, { title, description, keywords })) {
     return null
   }
 

--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -245,6 +245,8 @@ function Settings(): React.JSX.Element {
   )
   const [activeSectionId, setActiveSectionId] = useState('general')
   const [pendingNavRequestTick, setPendingNavRequestTick] = useState(0)
+  const [hasUnsavedCommitPromptChanges, setHasUnsavedCommitPromptChanges] = useState(false)
+  const [commitPromptDiscardSignal, setCommitPromptDiscardSignal] = useState(0)
   // Why: the hidden-experimental group is an unlock — Shift-clicking the
   // Experimental sidebar entry reveals it for the remainder of the session.
   // Not persisted on purpose: it's a power-user affordance we don't want to
@@ -255,6 +257,27 @@ function Settings(): React.JSX.Element {
   const terminalFontsLoadedRef = useRef(false)
   const pendingNavSectionRef = useRef<string | null>(null)
   const pendingScrollTargetRef = useRef<string | null>(null)
+
+  const confirmDiscardCommitPromptChanges = useCallback((): boolean => {
+    if (!hasUnsavedCommitPromptChanges) {
+      return true
+    }
+    const shouldDiscard = window.confirm(
+      'You have unsaved AI commit prompt changes. Leave without saving?'
+    )
+    if (shouldDiscard) {
+      setCommitPromptDiscardSignal((signal) => signal + 1)
+      setHasUnsavedCommitPromptChanges(false)
+    }
+    return shouldDiscard
+  }, [hasUnsavedCommitPromptChanges])
+
+  const closeSettingsPageWithPromptGuard = useCallback((): void => {
+    if (!confirmDiscardCommitPromptChanges()) {
+      return
+    }
+    closeSettingsPage()
+  }, [closeSettingsPage, confirmDiscardCommitPromptChanges])
 
   useEffect(() => {
     fetchSettings()
@@ -273,12 +296,23 @@ function Settings(): React.JSX.Element {
       if (isEditableTarget(event.target)) {
         return
       }
-      closeSettingsPage()
+      closeSettingsPageWithPromptGuard()
     }
 
     document.addEventListener('keydown', handleKeyDown)
     return () => document.removeEventListener('keydown', handleKeyDown)
-  }, [closeSettingsPage])
+  }, [closeSettingsPageWithPromptGuard])
+
+  useEffect(() => {
+    const handleBeforeUnload = (event: BeforeUnloadEvent): void => {
+      if (!hasUnsavedCommitPromptChanges) {
+        return
+      }
+      event.preventDefault()
+    }
+    window.addEventListener('beforeunload', handleBeforeUnload)
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload)
+  }, [hasUnsavedCommitPromptChanges])
 
   useEffect(() => {
     const handleFindShortcut = (event: KeyboardEvent): void => {
@@ -613,9 +647,11 @@ function Settings(): React.JSX.Element {
   const visibleNavSections = useMemo(
     () =>
       navSections.filter((section) =>
-        matchesSettingsSearch(settingsSearchQuery, section.searchEntries)
+        section.id === 'git' && hasUnsavedCommitPromptChanges
+          ? true
+          : matchesSettingsSearch(settingsSearchQuery, section.searchEntries)
       ),
-    [navSections, settingsSearchQuery]
+    [hasUnsavedCommitPromptChanges, navSections, settingsSearchQuery]
   )
 
   useEffect(() => {
@@ -723,6 +759,9 @@ function Settings(): React.JSX.Element {
       sectionId: string,
       modifiers?: { metaKey: boolean; ctrlKey: boolean; shiftKey: boolean; altKey: boolean }
     ) => {
+      if (sectionId !== activeSectionId && !confirmDiscardCommitPromptChanges()) {
+        return
+      }
       // Why: Shift-clicking the Experimental sidebar entry unlocks a hidden
       // power-user group. Keep this scoped to the Experimental row so normal
       // shortcut combos on other rows don't accidentally flip state. The
@@ -735,10 +774,13 @@ function Settings(): React.JSX.Element {
       flashSectionHighlight(sectionId)
       setActiveSectionId(sectionId)
     },
-    []
+    [activeSectionId, confirmDiscardCommitPromptChanges]
   )
 
   const openComputerUseFromBrowser = useCallback(() => {
+    if (!confirmDiscardCommitPromptChanges()) {
+      return
+    }
     pendingNavSectionRef.current = 'computer-use'
     pendingScrollTargetRef.current = 'computer-use'
     if (settingsSearchQuery !== '') {
@@ -748,7 +790,7 @@ function Settings(): React.JSX.Element {
     // Why: the pending section refs do not schedule a render by themselves.
     // When search is already clear, this reruns the centralized jump effect.
     setPendingNavRequestTick((tick) => tick + 1)
-  }, [setSettingsSearchQuery, settingsSearchQuery])
+  }, [confirmDiscardCommitPromptChanges, setSettingsSearchQuery, settingsSearchQuery])
 
   if (!settings) {
     return (
@@ -775,7 +817,7 @@ function Settings(): React.JSX.Element {
         hasRepos={repos.length > 0}
         searchQuery={settingsSearchQuery}
         searchInputRef={searchInputRef}
-        onBack={closeSettingsPage}
+        onBack={closeSettingsPageWithPromptGuard}
         onSearchChange={setSettingsSearchQuery}
         onSelectSection={scrollToSection}
       />
@@ -833,13 +875,19 @@ function Settings(): React.JSX.Element {
                     ...GIT_PANE_SEARCH_ENTRIES,
                     ...COMMIT_MESSAGE_AI_PANE_SEARCH_ENTRIES
                   ]}
+                  forceVisible={hasUnsavedCommitPromptChanges}
                 >
                   <GitPane
                     settings={settings}
                     updateSettings={updateSettings}
                     displayedGitUsername={displayedGitUsername}
                   />
-                  <CommitMessageAiPane settings={settings} updateSettings={updateSettings} />
+                  <CommitMessageAiPane
+                    settings={settings}
+                    updateSettings={updateSettings}
+                    onCustomPromptDirtyChange={setHasUnsavedCommitPromptChanges}
+                    customPromptDiscardSignal={commitPromptDiscardSignal}
+                  />
                 </SettingsSection>
 
                 <SettingsSection

--- a/src/renderer/src/components/settings/SettingsSection.tsx
+++ b/src/renderer/src/components/settings/SettingsSection.tsx
@@ -11,6 +11,7 @@ type SettingsSectionProps = {
   className?: string
   badge?: string
   badgeAccessory?: React.ReactNode
+  forceVisible?: boolean
   /** Rendered in the section header's upper-right corner — intended for
    *  section-scoped actions (e.g. "Import from Ghostty") that would otherwise
    *  crowd the settings list as their own row. */
@@ -26,10 +27,11 @@ export function SettingsSection({
   className,
   badge,
   badgeAccessory,
+  forceVisible = false,
   headerAction
 }: SettingsSectionProps): React.JSX.Element | null {
   const query = useAppStore((state) => state.settingsSearchQuery)
-  if (!matchesSettingsSearch(query, searchEntries)) {
+  if (!forceVisible && !matchesSettingsSearch(query, searchEntries)) {
     return null
   }
 


### PR DESCRIPTION
## Summary
- keep AI commit custom prompt edits local until explicit Save
- add Save/Discard state and unsaved-change prompts when leaving settings
- keep dirty prompt visible while settings search changes

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/settings/CommitMessageAiPane.test.tsx
- pnpm lint
- pnpm typecheck