### PR TITLE
Let slash menu query follow editor input

### DIFF
--- a/src/renderer/src/assets/rich-markdown-editor.css
+++ b/src/renderer/src/assets/rich-markdown-editor.css
@@ -593,19 +593,6 @@
   box-shadow: 0 10px 24px rgba(0, 0, 0, 0.18);
 }
 
-.rich-markdown-slash-query {
-  display: flex;
-  min-height: 32px;
-  align-items: center;
-  gap: 1px;
-  border-bottom: 1px solid color-mix(in srgb, var(--border) 64%, transparent);
-  padding: 5px 12px;
-  color: var(--popover-foreground);
-  font-size: 13px;
-  font-weight: 500;
-  line-height: 20px;
-}
-
 .rich-markdown-slash-section {
   padding: 9px 12px 4px;
   color: var(--muted-foreground);

--- a/src/renderer/src/components/editor/RichMarkdownEditor.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownEditor.tsx
@@ -672,6 +672,9 @@ export default function RichMarkdownEditor({
     selectedCommandIndexRef.current = selectedCommandIndex
   }, [selectedCommandIndex])
   useEffect(() => {
+    setSelectedCommandIndex(0)
+  }, [slashMenu?.query])
+  useEffect(() => {
     if (filteredSlashCommands.length === 0) {
       setSelectedCommandIndex(0)
       return

--- a/src/renderer/src/components/editor/RichMarkdownSlashMenu.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownSlashMenu.tsx
@@ -30,10 +30,6 @@ export function RichMarkdownSlashMenu({
       role="listbox"
       aria-label="Slash commands"
     >
-      <div className="rich-markdown-slash-query" aria-hidden="true">
-        <span className="text-muted-foreground">/</span>
-        <span>{slashMenu.query}</span>
-      </div>
       {filteredCommands.map((command, index) => {
         const showGroup = command.group !== currentGroup
         currentGroup = command.group

--- a/src/renderer/src/components/editor/rich-markdown-key-handler.test.ts
+++ b/src/renderer/src/components/editor/rich-markdown-key-handler.test.ts
@@ -119,7 +119,7 @@ describe('rich markdown key handler', () => {
     }
   })
 
-  it('keeps slash-menu filter input out of the document', () => {
+  it('lets slash-menu filter input fall through to document input', () => {
     const editor = createEditor({
       type: 'doc',
       content: [{ type: 'paragraph', content: [{ type: 'text', text: '/' }] }]
@@ -137,10 +137,10 @@ describe('rich markdown key handler', () => {
       })
       const event = keyEvent('h')
 
-      expect(createRichMarkdownKeyHandler(ctx)(null, event)).toBe(true)
-      expect(event.preventDefault).toHaveBeenCalled()
+      expect(createRichMarkdownKeyHandler(ctx)(null, event)).toBe(false)
+      expect(event.preventDefault).not.toHaveBeenCalled()
       expect(editor.getText()).toBe('/')
-      expect(ctx.slashMenuRef.current?.query).toBe('h')
+      expect(ctx.slashMenuRef.current?.query).toBe('')
     } finally {
       editor.destroy()
     }

--- a/src/renderer/src/components/editor/rich-markdown-key-handler.ts
+++ b/src/renderer/src/components/editor/rich-markdown-key-handler.ts
@@ -234,27 +234,6 @@ export function createRichMarkdownKeyHandler(
 
     const currentFilteredSlashCommands = ctx.filteredSlashCommandsRef.current
 
-    if (!event.metaKey && !event.ctrlKey && !event.altKey && event.key.length === 1) {
-      // Why: when the current query has no matching commands the slash menu UI
-      // is already hidden; intercepting further keystrokes would silently
-      // swallow them. Fall through so ProseMirror inserts the character and
-      // syncSlashMenu refreshes the query from the document.
-      if (currentFilteredSlashCommands.length === 0) {
-        return false
-      }
-      event.preventDefault()
-      ctx.setSlashMenu((menu) => (menu ? { ...menu, query: `${menu.query}${event.key}` } : menu))
-      ctx.setSelectedCommandIndex(0)
-      return true
-    }
-
-    if (event.key === 'Backspace' && currentSlashMenu.query.length > 0) {
-      event.preventDefault()
-      ctx.setSlashMenu((menu) => (menu ? { ...menu, query: menu.query.slice(0, -1) } : menu))
-      ctx.setSelectedCommandIndex(0)
-      return true
-    }
-
     if (currentFilteredSlashCommands.length === 0) {
       return false
     }


### PR DESCRIPTION
## Summary
- let slash-menu text input flow through the editor instead of mirroring keystrokes in React state
- reset the selected slash command when the parsed query changes
- remove the visible slash query header from the menu

## Verification
- pnpm exec vitest run src/renderer/src/components/editor/rich-markdown-key-handler.test.ts --config config/vitest.config.ts
- pnpm typecheck