### PR TITLE
Add diff AI notes controls

### DIFF
--- a/src/renderer/src/components/diff-comments/DiffCommentPopover.tsx
+++ b/src/renderer/src/components/diff-comments/DiffCommentPopover.tsx
@@ -12,6 +12,7 @@ type Props = {
   lineNumber: number
   startLine?: number
   top: number
+  left?: number
   title?: string
   placeholder?: string
   submitLabel?: string
@@ -24,6 +25,7 @@ export function DiffCommentPopover({
   lineNumber,
   startLine,
   top,
+  left,
   title,
   placeholder = 'Add note for the AI',
   submitLabel = 'Add note',
@@ -110,7 +112,7 @@ export function DiffCommentPopover({
     <div
       ref={popoverRef}
       className="orca-diff-comment-popover"
-      style={{ top: `${top}px` }}
+      style={{ top: `${top}px`, ...(left == null ? {} : { left: `${left}px` }) }}
       role="dialog"
       aria-modal="true"
       aria-labelledby={labelId}

--- a/src/renderer/src/components/diff-comments/diff-comment-popover-position.test.ts
+++ b/src/renderer/src/components/diff-comments/diff-comment-popover-position.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import type { editor as monacoEditor } from 'monaco-editor'
-import { getDiffCommentPopoverTop } from './diff-comment-popover-position'
+import {
+  getDiffCommentPopoverLeft,
+  getDiffCommentPopoverTop
+} from './diff-comment-popover-position'
 
 function makeEditor({
   lineCount = 10,
@@ -16,6 +19,12 @@ function makeEditor({
     getScrollTop: () => scrollTop,
     getTopForLineNumber: topForLine
   }
+}
+
+function makeElementWithLeft(left: number): HTMLElement {
+  return {
+    getBoundingClientRect: () => ({ left }) as DOMRect
+  } as HTMLElement
 }
 
 describe('getDiffCommentPopoverTop', () => {
@@ -43,5 +52,28 @@ describe('getDiffCommentPopoverTop', () => {
   it('returns null for out-of-range line numbers', () => {
     expect(getDiffCommentPopoverTop(makeEditor({ lineCount: 2 }), 3, 20)).toBeNull()
     expect(getDiffCommentPopoverTop(makeEditor({ lineCount: 2 }), 0, 20)).toBeNull()
+  })
+})
+
+describe('getDiffCommentPopoverLeft', () => {
+  it('aligns the popover to the editor content column inside its overlay parent', () => {
+    const editor = {
+      getDomNode: () => makeElementWithLeft(230),
+      getLayoutInfo: () => ({ contentLeft: 72 }) as monacoEditor.EditorLayoutInfo
+    }
+
+    expect(getDiffCommentPopoverLeft(editor, makeElementWithLeft(100))).toBe(202)
+  })
+
+  it('returns null when the editor DOM node or overlay parent is unavailable', () => {
+    const editor = {
+      getDomNode: () => null,
+      getLayoutInfo: () => ({ contentLeft: 72 }) as monacoEditor.EditorLayoutInfo
+    }
+
+    expect(getDiffCommentPopoverLeft(editor, makeElementWithLeft(100))).toBeNull()
+    expect(
+      getDiffCommentPopoverLeft({ ...editor, getDomNode: () => makeElementWithLeft(230) }, null)
+    ).toBeNull()
   })
 })

--- a/src/renderer/src/components/diff-comments/diff-comment-popover-position.ts
+++ b/src/renderer/src/components/diff-comments/diff-comment-popover-position.ts
@@ -5,6 +5,8 @@ type DiffCommentPopoverEditor = Pick<
   'getModel' | 'getScrollTop' | 'getTopForLineNumber'
 >
 
+type DiffCommentPopoverLeftEditor = Pick<monacoEditor.ICodeEditor, 'getDomNode' | 'getLayoutInfo'>
+
 const FALLBACK_LINE_HEIGHT_PX = 19
 
 export function getDiffCommentPopoverTop(
@@ -22,4 +24,23 @@ export function getDiffCommentPopoverTop(
   const resolvedLineHeight =
     typeof lineHeight === 'number' && lineHeight > 0 ? lineHeight : FALLBACK_LINE_HEIGHT_PX
   return editor.getTopForLineNumber(lineNumber) - editor.getScrollTop() + resolvedLineHeight
+}
+
+export function getDiffCommentPopoverLeft(
+  editor: DiffCommentPopoverLeftEditor,
+  offsetParent: HTMLElement | null
+): number | null {
+  const editorDomNode = editor.getDomNode()
+  if (!editorDomNode || !offsetParent) {
+    return null
+  }
+  const editorRect = editorDomNode.getBoundingClientRect()
+  const parentRect = offsetParent.getBoundingClientRect()
+  // Why: saved notes live in Monaco view zones, which start at the editor
+  // content column. The popover is a React sibling overlay, so it must add the
+  // editor pane's offset before applying Monaco's contentLeft.
+  return Math.max(
+    0,
+    Math.round(editorRect.left - parentRect.left + editor.getLayoutInfo().contentLeft)
+  )
 }

--- a/src/renderer/src/components/editor/CombinedDiffViewer.tsx
+++ b/src/renderer/src/components/editor/CombinedDiffViewer.tsx
@@ -13,10 +13,31 @@ import { findWorktreeById } from '@/store/slices/worktree-helpers'
 import { writeRuntimeFile } from '@/runtime/runtime-file-client'
 import { settingsForRuntimeOwner } from '@/runtime/runtime-rpc-client'
 import { getRuntimeGitBranchDiff, getRuntimeGitDiff } from '@/runtime/runtime-git-client'
+import { formatDiffComments } from '@/lib/diff-comments-format'
 import '@/lib/monaco-setup'
 import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { QuickLaunchAgentMenuItems } from '@/components/tab-bar/QuickLaunchButton'
+import { focusTerminalTabSurface } from '@/lib/focus-terminal-tab-surface'
 import type { OpenFile } from '@/store/slices/editor'
-import type { GitBranchChangeEntry, GitDiffResult } from '../../../../shared/types'
+import type { DiffComment, GitBranchChangeEntry, GitDiffResult } from '../../../../shared/types'
+import { getDiffCommentLineLabel } from '@/lib/diff-comment-compat'
+import { Check, Copy, MessageSquare, Send, Trash2 } from 'lucide-react'
+import { toast } from 'sonner'
 import { DiffSectionItem } from './DiffSectionItem'
 import { getCombinedUncommittedEntries } from './combined-diff-entries'
 import type { DiffSection } from './diff-section-types'
@@ -47,13 +68,32 @@ export default function CombinedDiffViewer({
   const openAllDiffs = useAppStore((s) => s.openAllDiffs)
   const openConflictReview = useAppStore((s) => s.openConflictReview)
   const openBranchAllDiffs = useAppStore((s) => s.openBranchAllDiffs)
+  const clearDiffComments = useAppStore((s) => s.clearDiffComments)
+  const diffCommentsForWorktree = useAppStore((s) => s.getDiffComments(file.worktreeId))
+  const activeGroupId = useAppStore((s) => s.activeGroupIdByWorktree[file.worktreeId])
   const isDark =
     settings?.theme === 'dark' ||
     (settings?.theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)
 
+  const diffCommentCount = diffCommentsForWorktree.length
+  const diffCommentsPrompt = React.useMemo(
+    () => formatDiffComments(diffCommentsForWorktree),
+    [diffCommentsForWorktree]
+  )
+  const previewDiffComments = React.useMemo(
+    () =>
+      [...diffCommentsForWorktree]
+        .sort((a, b) => a.filePath.localeCompare(b.filePath) || a.lineNumber - b.lineNumber)
+        .slice(0, 4),
+    [diffCommentsForWorktree]
+  )
+
   const [sections, setSections] = useState<DiffSection[]>([])
   const [sideBySide, setSideBySide] = useState(settings?.diffDefaultView === 'side-by-side')
   const [sectionHeights, setSectionHeights] = useState<Record<number, number>>({})
+  const [clearNotesDialogOpen, setClearNotesDialogOpen] = useState(false)
+  const [isClearingNotes, setIsClearingNotes] = useState(false)
+  const [notesCopied, setNotesCopied] = useState(false)
   // Why: `generation` is a state counter used as a React key to force remounting
   // DiffSectionItem components when the entry list changes. A separate ref
   // (`generationRef`) is kept in sync for stale-async-result detection inside
@@ -425,6 +465,50 @@ export default function CombinedDiffViewer({
     }
   }, [branchSummary, file, openAllDiffs, openBranchAllDiffs])
 
+  useEffect(() => {
+    if (diffCommentCount === 0 && !isClearingNotes) {
+      setClearNotesDialogOpen(false)
+    }
+  }, [diffCommentCount, isClearingNotes])
+
+  useEffect(() => {
+    if (!notesCopied) {
+      return
+    }
+    const handle = window.setTimeout(() => setNotesCopied(false), 1500)
+    return () => window.clearTimeout(handle)
+  }, [notesCopied])
+
+  const handleCopyNotes = useCallback(async (): Promise<void> => {
+    if (diffCommentCount === 0) {
+      return
+    }
+    try {
+      await window.api.ui.writeClipboardText(diffCommentsPrompt)
+      setNotesCopied(true)
+    } catch {
+      // Why: clipboard writes can fail while the app is not focused; this
+      // mirrors the sidebar notes action and keeps the popover non-blocking.
+    }
+  }, [diffCommentCount, diffCommentsPrompt])
+
+  const handleConfirmClearNotes = useCallback(async (): Promise<void> => {
+    if (diffCommentCount === 0 || isClearingNotes) {
+      return
+    }
+    setIsClearingNotes(true)
+    try {
+      const ok = await clearDiffComments(file.worktreeId)
+      if (ok) {
+        setClearNotesDialogOpen(false)
+      } else {
+        toast.error('Failed to clear notes.')
+      }
+    } finally {
+      setIsClearingNotes(false)
+    }
+  }, [clearDiffComments, diffCommentCount, file.worktreeId, isClearingNotes])
+
   if (sections.length === 0 && (file.skippedConflicts?.length ?? 0) > 0) {
     return (
       <div className="flex h-full items-center justify-center px-6 text-center">
@@ -505,66 +589,238 @@ export default function CombinedDiffViewer({
     ) : null
 
   return (
-    <div className="flex flex-col flex-1 min-h-0">
-      <div className="flex items-center justify-between px-3 py-1.5 border-b border-border bg-background/50 shrink-0">
-        <span className="text-xs text-muted-foreground">
-          {sections.length} changed files
-          {isBranchMode && branchCompare ? ` vs ${branchCompare.baseRef}` : ''}
-        </span>
-        <div className="flex items-center gap-2">
-          {file.combinedAlternate && (
+    <>
+      <div className="flex flex-col flex-1 min-h-0">
+        <div className="flex items-center justify-between gap-3 px-3 py-1.5 border-b border-border bg-background/50 shrink-0">
+          <div className="flex min-w-0 items-center gap-2">
+            <span className="truncate text-xs text-muted-foreground">
+              {sections.length} changed files
+              {isBranchMode && branchCompare ? ` vs ${branchCompare.baseRef}` : ''}
+            </span>
+            {diffCommentCount > 0 && (
+              <div className="ml-2 flex shrink-0 items-center overflow-hidden rounded-md border border-border/60 bg-muted/20">
+                <Popover>
+                  <PopoverTrigger asChild>
+                    <button
+                      type="button"
+                      className="inline-flex h-7 items-center gap-1 px-2 text-[11px] leading-none text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                      aria-label={`Show ${diffCommentCount} AI ${diffCommentCount === 1 ? 'note' : 'notes'}`}
+                    >
+                      <MessageSquare className="size-3" />
+                      AI notes
+                      <span className="tabular-nums">{diffCommentCount}</span>
+                    </button>
+                  </PopoverTrigger>
+                  <PopoverContent align="start" side="bottom" sideOffset={6} className="w-80 p-0">
+                    <DiffNotesPreviewPopover
+                      comments={previewDiffComments}
+                      totalCount={diffCommentCount}
+                      copied={notesCopied}
+                      onCopy={() => void handleCopyNotes()}
+                      onClear={() => setClearNotesDialogOpen(true)}
+                    />
+                  </PopoverContent>
+                </Popover>
+                <DropdownMenu>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon-xs"
+                          className="h-7 rounded-none border-l border-border/60 text-muted-foreground hover:text-foreground"
+                          aria-label="Send AI notes to a new agent"
+                        >
+                          <Send className="size-3" />
+                        </Button>
+                      </DropdownMenuTrigger>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom" sideOffset={6}>
+                      Send notes to AI
+                    </TooltipContent>
+                  </Tooltip>
+                  <DropdownMenuContent align="end" className="min-w-[180px]">
+                    <QuickLaunchAgentMenuItems
+                      worktreeId={file.worktreeId}
+                      groupId={activeGroupId ?? file.worktreeId}
+                      onFocusTerminal={focusTerminalTabSurface}
+                      prompt={diffCommentsPrompt}
+                      launchSource="notes_send"
+                    />
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+            )}
+          </div>
+          <div className="flex shrink-0 items-center gap-2">
+            {file.combinedAlternate && (
+              <button
+                className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+                onClick={openAlternateDiff}
+              >
+                {file.combinedAlternate.source === 'combined-branch'
+                  ? 'Open Branch Diff'
+                  : 'Open Uncommitted Diff'}
+              </button>
+            )}
             <button
               className="text-xs text-muted-foreground hover:text-foreground transition-colors"
-              onClick={openAlternateDiff}
+              onClick={() => setSections((prev) => prev.map((s) => ({ ...s, collapsed: true })))}
             >
-              {file.combinedAlternate.source === 'combined-branch'
-                ? 'Open Branch Diff'
-                : 'Open Uncommitted Diff'}
+              Collapse All
             </button>
-          )}
-          <button
-            className="text-xs text-muted-foreground hover:text-foreground transition-colors"
-            onClick={() => setSections((prev) => prev.map((s) => ({ ...s, collapsed: true })))}
-          >
-            Collapse All
-          </button>
-          <button
-            className="text-xs text-muted-foreground hover:text-foreground transition-colors"
-            onClick={() => setSections((prev) => prev.map((s) => ({ ...s, collapsed: false })))}
-          >
-            Expand All
-          </button>
-          <button
-            className="px-2 py-0.5 text-xs rounded border border-border text-muted-foreground hover:text-foreground transition-colors"
-            onClick={() => setSideBySide((prev) => !prev)}
-          >
-            {sideBySide ? 'Inline' : 'Side by Side'}
-          </button>
+            <button
+              className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+              onClick={() => setSections((prev) => prev.map((s) => ({ ...s, collapsed: false })))}
+            >
+              Expand All
+            </button>
+            <button
+              className="px-2 py-0.5 text-xs rounded border border-border text-muted-foreground hover:text-foreground transition-colors"
+              onClick={() => setSideBySide((prev) => !prev)}
+            >
+              {sideBySide ? 'Inline' : 'Side by Side'}
+            </button>
+          </div>
+        </div>
+
+        <div ref={scrollContainerRef} className="flex-1 overflow-auto scrollbar-editor">
+          {skippedConflictNotice}
+          {sections.map((section, index) => (
+            <DiffSectionItem
+              key={`${section.key}:${generation}`}
+              section={section}
+              index={index}
+              isBranchMode={isBranchMode}
+              sideBySide={sideBySide}
+              isDark={isDark}
+              settings={settings}
+              sectionHeight={sectionHeights[index]}
+              worktreeId={file.worktreeId}
+              worktreeRoot={file.filePath}
+              loadSection={loadSection}
+              toggleSection={toggleSection}
+              setSectionHeights={setSectionHeights}
+              setSections={setSections}
+              modifiedEditorsRef={modifiedEditorsRef}
+              handleSectionSaveRef={handleSectionSaveRef}
+            />
+          ))}
         </div>
       </div>
+      <Dialog
+        open={clearNotesDialogOpen}
+        onOpenChange={(open) => {
+          if (!open && !isClearingNotes) {
+            setClearNotesDialogOpen(false)
+          } else if (open) {
+            setClearNotesDialogOpen(true)
+          }
+        }}
+      >
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle className="text-sm">Clear Notes</DialogTitle>
+            <DialogDescription className="text-xs">
+              Clear {diffCommentCount} {diffCommentCount === 1 ? 'note' : 'notes'} from this
+              worktree?
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setClearNotesDialogOpen(false)}
+              disabled={isClearingNotes}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              onClick={() => void handleConfirmClearNotes()}
+              disabled={isClearingNotes || diffCommentCount === 0}
+            >
+              <Trash2 className="size-4" />
+              Clear Notes
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}
 
-      <div ref={scrollContainerRef} className="flex-1 overflow-auto scrollbar-editor">
-        {skippedConflictNotice}
-        {sections.map((section, index) => (
-          <DiffSectionItem
-            key={`${section.key}:${generation}`}
-            section={section}
-            index={index}
-            isBranchMode={isBranchMode}
-            sideBySide={sideBySide}
-            isDark={isDark}
-            settings={settings}
-            sectionHeight={sectionHeights[index]}
-            worktreeId={file.worktreeId}
-            worktreeRoot={file.filePath}
-            loadSection={loadSection}
-            toggleSection={toggleSection}
-            setSectionHeights={setSectionHeights}
-            setSections={setSections}
-            modifiedEditorsRef={modifiedEditorsRef}
-            handleSectionSaveRef={handleSectionSaveRef}
-          />
+function DiffNotesPreviewPopover({
+  comments,
+  totalCount,
+  copied,
+  onCopy,
+  onClear
+}: {
+  comments: DiffComment[]
+  totalCount: number
+  copied: boolean
+  onCopy: () => void
+  onClear: () => void
+}): React.JSX.Element {
+  const remainingCount = Math.max(0, totalCount - comments.length)
+
+  return (
+    <div className="text-xs">
+      <div className="flex items-center justify-between gap-2 border-b border-border/60 px-3 py-2">
+        <div className="flex min-w-0 items-center gap-1.5 font-medium text-foreground">
+          <MessageSquare className="size-3.5 shrink-0 text-muted-foreground" />
+          <span>AI notes</span>
+          <span className="text-[11px] font-normal tabular-nums text-muted-foreground">
+            {totalCount}
+          </span>
+        </div>
+        <div className="flex shrink-0 items-center gap-1">
+          <Button
+            type="button"
+            variant="ghost"
+            size="xs"
+            className="h-6 text-muted-foreground hover:text-foreground"
+            onClick={onCopy}
+            disabled={totalCount === 0}
+          >
+            {copied ? <Check className="size-3" /> : <Copy className="size-3" />}
+            Copy
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="xs"
+            className="h-6 text-muted-foreground hover:text-destructive"
+            onClick={onClear}
+            disabled={totalCount === 0}
+          >
+            <Trash2 className="size-3" />
+            Clear
+          </Button>
+        </div>
+      </div>
+      <div className="max-h-72 overflow-y-auto p-2">
+        {comments.map((comment) => (
+          <div key={comment.id} className="rounded-md px-2 py-1.5 hover:bg-accent/50">
+            <div className="flex items-center gap-1.5 text-[11px] leading-none text-muted-foreground">
+              <span className="min-w-0 flex-1 truncate font-mono">{comment.filePath}</span>
+              <span className="shrink-0 tabular-nums">
+                {getDiffCommentLineLabel(comment, true)}
+              </span>
+            </div>
+            <div className="mt-1 max-h-10 overflow-hidden whitespace-pre-wrap break-words text-[12px] leading-snug text-foreground">
+              {comment.body}
+            </div>
+          </div>
         ))}
+        {remainingCount > 0 && (
+          <div className="px-2 py-1 text-[11px] text-muted-foreground">
+            {remainingCount} more {remainingCount === 1 ? 'note' : 'notes'} in Source Control
+          </div>
+        )}
       </div>
     </div>
   )

--- a/src/renderer/src/components/editor/DiffSectionItem.tsx
+++ b/src/renderer/src/components/editor/DiffSectionItem.tsx
@@ -19,7 +19,10 @@ import { computeEditorFontSize } from '@/lib/editor-font-zoom'
 import { findWorktreeById } from '@/store/slices/worktree-helpers'
 import { useDiffCommentDecorator } from '../diff-comments/useDiffCommentDecorator'
 import { DiffCommentPopover } from '../diff-comments/DiffCommentPopover'
-import { getDiffCommentPopoverTop } from '../diff-comments/diff-comment-popover-position'
+import {
+  getDiffCommentPopoverLeft,
+  getDiffCommentPopoverTop
+} from '../diff-comments/diff-comment-popover-position'
 import { applyDiffEditorLineNumberOptions } from './diff-editor-line-number-options'
 import { computeLineStats } from './diff-line-stats'
 import { DiffSectionHeader } from './DiffSectionHeader'
@@ -96,11 +99,13 @@ export function DiffSectionItem({
 
   const [modifiedEditor, setModifiedEditor] = useState<monacoEditor.ICodeEditor | null>(null)
   const diffEditorRef = useRef<monacoEditor.IStandaloneDiffEditor | null>(null)
+  const sectionBodyRef = useRef<HTMLDivElement | null>(null)
   const lineNumberOptionsSubRef = useRef<{ dispose: () => void } | null>(null)
   const [popover, setPopover] = useState<{
     lineNumber: number
     startLine?: number
     top: number
+    left?: number
   } | null>(null)
 
   const disposeDiffModels = useCallback(() => {
@@ -140,7 +145,14 @@ export function DiffSectionItem({
     worktreeId,
     comments: diffComments,
     onAddCommentClick: ({ lineNumber, startLine, top }) =>
-      setPopover({ lineNumber, startLine, top }),
+      setPopover({
+        lineNumber,
+        startLine,
+        top,
+        left: modifiedEditor
+          ? (getDiffCommentPopoverLeft(modifiedEditor, sectionBodyRef.current) ?? undefined)
+          : undefined
+      }),
     onDeleteComment: (id) => void deleteDiffComment(worktreeId, id),
     onUpdateComment: (id, body) => updateDiffComment(worktreeId, id, body),
     pendingScrollCommentId: pendingScrollForThisSection,
@@ -161,13 +173,16 @@ export function DiffSectionItem({
         setPopover(null)
         return
       }
-      setPopover((prev) => (prev ? { ...prev, top } : prev))
+      const left = getDiffCommentPopoverLeft(modifiedEditor, sectionBodyRef.current)
+      setPopover((prev) => (prev ? { ...prev, top, left: left == null ? prev.left : left } : prev))
     }
     const scrollSub = modifiedEditor.onDidScrollChange(update)
     const contentSub = modifiedEditor.onDidContentSizeChange(update)
+    const layoutSub = modifiedEditor.onDidLayoutChange(update)
     return () => {
       scrollSub.dispose()
       contentSub.dispose()
+      layoutSub.dispose()
     }
     // Why: depend on popover.lineNumber (not the whole popover object) so the
     // effect doesn't re-subscribe on every top update it dispatches. The guard
@@ -303,6 +318,7 @@ export function DiffSectionItem({
 
       {!section.collapsed && (
         <div
+          ref={sectionBodyRef}
           className={cn('relative', useIntrinsicImageHeight && 'overflow-visible')}
           style={sectionBodyHeight === undefined ? undefined : { height: sectionBodyHeight }}
         >
@@ -315,6 +331,7 @@ export function DiffSectionItem({
               lineNumber={popover.lineNumber}
               startLine={popover.startLine}
               top={popover.top}
+              left={popover.left}
               onCancel={() => setPopover(null)}
               onSubmit={handleSubmitComment}
             />

--- a/src/renderer/src/components/editor/DiffViewer.tsx
+++ b/src/renderer/src/components/editor/DiffViewer.tsx
@@ -9,7 +9,10 @@ import { useContextualCopySetup } from './useContextualCopySetup'
 import { findWorktreeById } from '@/store/slices/worktree-helpers'
 import { useDiffCommentDecorator } from '../diff-comments/useDiffCommentDecorator'
 import { DiffCommentPopover } from '../diff-comments/DiffCommentPopover'
-import { getDiffCommentPopoverTop } from '../diff-comments/diff-comment-popover-position'
+import {
+  getDiffCommentPopoverLeft,
+  getDiffCommentPopoverTop
+} from '../diff-comments/diff-comment-popover-position'
 import { applyDiffEditorLineNumberOptions } from './diff-editor-line-number-options'
 import type { DiffComment } from '../../../../shared/types'
 import { isDiffComment } from '@/lib/diff-comment-compat'
@@ -84,12 +87,14 @@ export default function DiffViewer({
     (settings?.theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)
 
   const diffEditorRef = useRef<editor.IStandaloneDiffEditor | null>(null)
+  const diffBodyRef = useRef<HTMLDivElement | null>(null)
   const lineNumberOptionsSubRef = useRef<{ dispose: () => void } | null>(null)
   const [modifiedEditor, setModifiedEditor] = useState<editor.ICodeEditor | null>(null)
   const [popover, setPopover] = useState<{
     lineNumber: number
     startLine?: number
     top: number
+    left?: number
   } | null>(null)
 
   const hasLineCommentAction = Boolean(worktreeId || onAddLineComment)
@@ -114,7 +119,14 @@ export default function DiffViewer({
     comments: worktreeId ? diffComments : [],
     addButtonLabel: addLineCommentLabel,
     onAddCommentClick: ({ lineNumber, startLine, top }) =>
-      setPopover({ lineNumber, startLine, top }),
+      setPopover({
+        lineNumber,
+        startLine,
+        top,
+        left: modifiedEditor
+          ? (getDiffCommentPopoverLeft(modifiedEditor, diffBodyRef.current) ?? undefined)
+          : undefined
+      }),
     onDeleteComment: (id) => {
       if (worktreeId) {
         void deleteDiffComment(worktreeId, id)
@@ -139,13 +151,16 @@ export default function DiffViewer({
         setPopover(null)
         return
       }
-      setPopover((prev) => (prev ? { ...prev, top } : prev))
+      const left = getDiffCommentPopoverLeft(modifiedEditor, diffBodyRef.current)
+      setPopover((prev) => (prev ? { ...prev, top, left: left == null ? prev.left : left } : prev))
     }
     const scrollSub = modifiedEditor.onDidScrollChange(update)
     const contentSub = modifiedEditor.onDidContentSizeChange(update)
+    const layoutSub = modifiedEditor.onDidLayoutChange(update)
     return () => {
       scrollSub.dispose()
       contentSub.dispose()
+      layoutSub.dispose()
     }
     // Why: depend on popover.lineNumber (not the whole popover object) so the
     // effect doesn't re-subscribe on every top update it dispatches.
@@ -369,13 +384,14 @@ export default function DiffViewer({
 
   return (
     <div className="flex flex-col flex-1 min-h-0">
-      <div className="flex-1 min-h-0 relative">
+      <div ref={diffBodyRef} className="flex-1 min-h-0 relative">
         {popover && hasLineCommentAction && (
           <DiffCommentPopover
             key={popover.lineNumber}
             lineNumber={popover.lineNumber}
             startLine={popover.startLine}
             top={popover.top}
+            left={popover.left}
             placeholder={addLineCommentPlaceholder}
             submitLabel={addLineCommentLabel}
             submittingLabel="Posting…"

--- a/src/renderer/src/components/editor/MonacoEditor.tsx
+++ b/src/renderer/src/components/editor/MonacoEditor.tsx
@@ -33,6 +33,7 @@ import type { DiffComment } from '../../../../shared/types'
 import { isMarkdownComment } from '@/lib/diff-comment-compat'
 import { useDiffCommentDecorator } from '../diff-comments/useDiffCommentDecorator'
 import { DiffCommentPopover } from '../diff-comments/DiffCommentPopover'
+import { getDiffCommentPopoverLeft } from '../diff-comments/diff-comment-popover-position'
 
 type MonacoEditorProps = {
   filePath: string
@@ -66,6 +67,7 @@ export default function MonacoEditor({
   markdownAnnotationsEnabled = false
 }: MonacoEditorProps): React.JSX.Element {
   const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null)
+  const editorContainerRef = useRef<HTMLDivElement | null>(null)
   const [mountedEditor, setMountedEditor] = useState<editor.IStandaloneCodeEditor | null>(null)
   const modelKeyRef = useRef<string | null>(null)
   const languageRef = useRef(language)
@@ -133,6 +135,7 @@ export default function MonacoEditor({
     lineNumber: number
     startLine?: number
     top: number
+    left?: number
   } | null>(null)
   const isDark =
     settings?.theme === 'dark' ||
@@ -172,7 +175,14 @@ export default function MonacoEditor({
     worktreeId: worktreeId ?? '',
     comments: shouldShowMarkdownAnnotations ? markdownComments : [],
     onAddCommentClick: ({ lineNumber, startLine, top }) =>
-      setCommentPopover({ lineNumber, startLine, top }),
+      setCommentPopover({
+        lineNumber,
+        startLine,
+        top,
+        left: mountedEditor
+          ? (getDiffCommentPopoverLeft(mountedEditor, editorContainerRef.current) ?? undefined)
+          : undefined
+      }),
     onDeleteComment: (id) => {
       if (worktreeId) {
         void deleteDiffComment(worktreeId, id)
@@ -391,13 +401,18 @@ export default function MonacoEditor({
     const update = (): void => {
       const top =
         mountedEditor.getTopForLineNumber(commentPopover.lineNumber) - mountedEditor.getScrollTop()
-      setCommentPopover((prev) => (prev ? { ...prev, top } : prev))
+      const left = getDiffCommentPopoverLeft(mountedEditor, editorContainerRef.current)
+      setCommentPopover((prev) =>
+        prev ? { ...prev, top, left: left == null ? prev.left : left } : prev
+      )
     }
     const scrollSub = mountedEditor.onDidScrollChange(update)
     const contentSub = mountedEditor.onDidContentSizeChange(update)
+    const layoutSub = mountedEditor.onDidLayoutChange(update)
     return () => {
       scrollSub.dispose()
       contentSub.dispose()
+      layoutSub.dispose()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- match DiffViewer: don't resubscribe on top updates.
   }, [mountedEditor, commentPopover?.lineNumber])
@@ -538,13 +553,14 @@ export default function MonacoEditor({
   }, [queueReveal, revealLine, revealColumn, revealMatchLength, setPendingEditorReveal])
 
   return (
-    <div className="relative h-full">
+    <div ref={editorContainerRef} className="relative h-full">
       {commentPopover && shouldShowMarkdownAnnotations && (
         <DiffCommentPopover
           key={commentPopover.lineNumber}
           lineNumber={commentPopover.lineNumber}
           startLine={commentPopover.startLine}
           top={commentPopover.top}
+          left={commentPopover.left}
           onCancel={() => setCommentPopover(null)}
           onSubmit={handleSubmitMarkdownComment}
         />


### PR DESCRIPTION
## Summary
- add a combined diff toolbar preview for AI notes with copy, send, and clear actions
- align diff comment popovers to the Monaco content column across combined, standalone diff, and markdown editor views
- cover popover left positioning with focused tests

## Tests
- pnpm typecheck