### PR TITLE
Make remote fetch failures transparent

### DIFF
--- a/src/renderer/src/components/right-sidebar/CommitArea.chevron-spinner.test.tsx
+++ b/src/renderer/src/components/right-sidebar/CommitArea.chevron-spinner.test.tsx
@@ -84,6 +84,7 @@ function baseProps(overrides: Partial<PrimaryActionInputs> = {}) {
   return {
     commitMessage: 'feat: add commit area',
     commitError: null as string | null,
+    remoteActionError: null as string | null,
     isCommitting: inputs.isCommitting,
     aiEnabled: false,
     aiAgentConfigured: false,

--- a/src/renderer/src/components/right-sidebar/CommitArea.generate.test.tsx
+++ b/src/renderer/src/components/right-sidebar/CommitArea.generate.test.tsx
@@ -102,6 +102,7 @@ function baseProps(overrides: Partial<PrimaryActionInputs> = {}) {
   return {
     commitMessage: 'feat: add commit area',
     commitError: null as string | null,
+    remoteActionError: null as string | null,
     isCommitting: inputs.isCommitting,
     aiEnabled: false,
     aiAgentConfigured: false,

--- a/src/renderer/src/components/right-sidebar/CommitArea.primary-icons.test.tsx
+++ b/src/renderer/src/components/right-sidebar/CommitArea.primary-icons.test.tsx
@@ -72,6 +72,7 @@ function baseProps(overrides: Partial<PrimaryActionInputs> = {}) {
   return {
     commitMessage: 'feat: add commit area',
     commitError: null as string | null,
+    remoteActionError: null as string | null,
     isCommitting: inputs.isCommitting,
     aiEnabled: false,
     aiAgentConfigured: false,

--- a/src/renderer/src/components/right-sidebar/CommitArea.test.tsx
+++ b/src/renderer/src/components/right-sidebar/CommitArea.test.tsx
@@ -125,6 +125,7 @@ function baseProps(overrides: Partial<PrimaryActionInputs> = {}) {
   return {
     commitMessage: 'feat: add commit area',
     commitError: null as string | null,
+    remoteActionError: null as string | null,
     isCommitting: inputs.isCommitting,
     aiEnabled: false,
     aiAgentConfigured: false,
@@ -280,6 +281,14 @@ describe('CommitArea', () => {
   it('shows an inline error message when the commit fails', () => {
     const element = CommitArea({ ...baseProps(), commitError: 'pre-commit hook failed' })
     expect(hasText(element, 'pre-commit hook failed')).toBe(true)
+  })
+
+  it('shows an inline error message when a remote action fails', () => {
+    const element = CommitArea({
+      ...baseProps(),
+      remoteActionError: 'Fetch failed. network timeout'
+    })
+    expect(hasText(element, 'Fetch failed. network timeout')).toBe(true)
   })
 
   it('keeps the primary button labelled Commit when the tree is staged, even with commits to push', () => {

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -32,6 +32,7 @@ import {
   type LucideIcon
 } from 'lucide-react'
 import { useAppStore } from '@/store'
+import { resolveRemoteOperationErrorMessage } from '@/store/slices/editor'
 import { useActiveWorktree, useRepoById, useWorktreeMap } from '@/store/selectors'
 import { getHostedReviewCacheKey } from '@/store/slices/hosted-review'
 import { detectLanguage } from '@/lib/language-detect'
@@ -135,6 +136,7 @@ import { STATUS_COLORS, STATUS_LABELS } from './status-display'
 
 type SourceControlScope = 'all' | 'uncommitted'
 type SourceControlViewMode = 'list' | 'tree'
+type RemoteActionError = { kind: RemoteOpKind; message: string }
 
 // Why: directional signifiers ahead of each primary action label. Commit
 // (✓) is affirmative; Push (↑) points in the direction data flows; Sync
@@ -261,6 +263,15 @@ function hostedReviewStateClass(review: HostedReviewInfo): string {
     return 'text-muted-foreground/60'
   }
   return 'text-muted-foreground/50'
+}
+
+function resolveRemoteActionError(kind: RemoteOpKind, error: unknown): string {
+  return resolveRemoteOperationErrorMessage(error, {
+    publish: kind === 'publish',
+    isPush: kind === 'push',
+    isSync: kind === 'sync',
+    isFetch: kind === 'fetch'
+  })
 }
 
 function HostedReviewIcon({
@@ -463,6 +474,9 @@ function SourceControlInner(): React.JSX.Element {
   // so switching worktrees restores each draft instead of wiping it.
   const [commitDrafts, setCommitDrafts] = useState<CommitDraftsByWorktree>({})
   const [commitErrors, setCommitErrors] = useState<Record<string, string | null>>({})
+  const [remoteActionErrors, setRemoteActionErrors] = useState<
+    Record<string, RemoteActionError | null>
+  >({})
   // Why: keep commit-in-flight state per-worktree. A single boolean would be
   // cleared when the user switched worktrees, letting them double-click Commit
   // on worktree A after briefly navigating to B and back while A's original
@@ -488,6 +502,7 @@ function SourceControlInner(): React.JSX.Element {
   const filterInputRef = useRef<HTMLInputElement>(null)
   const commitMessage = readCommitDraftForWorktree(commitDrafts, activeWorktreeId)
   const commitError = commitErrors[activeWorktreeId ?? ''] ?? null
+  const remoteActionError = remoteActionErrors[activeWorktreeId ?? ''] ?? null
 
   const isFolder = activeRepo ? isFolderRepo(activeRepo) : false
   const worktreePath = activeWorktree?.path ?? null
@@ -831,6 +846,7 @@ function SourceControlInner(): React.JSX.Element {
     }
     setCommitDrafts((prev) => pruneRecord(prev))
     setCommitErrors((prev) => pruneRecord(prev))
+    setRemoteActionErrors((prev) => pruneRecord(prev))
     setCommitInFlightByWorktree((prev) => pruneRecord(prev))
     setGenerateInFlightByWorktree((prev) => pruneRecord(prev))
     setGenerateErrors((prev) => pruneRecord(prev))
@@ -1071,6 +1087,7 @@ function SourceControlInner(): React.JSX.Element {
         return
       }
       const connectionId = getConnectionId(activeWorktreeId) ?? undefined
+      setRemoteActionErrors((prev) => ({ ...prev, [activeWorktreeId]: null }))
       try {
         if (kind === 'publish') {
           await pushBranch(
@@ -1101,9 +1118,19 @@ function SourceControlInner(): React.JSX.Element {
           return
         }
         await syncBranch(activeWorktreeId, worktreePath, connectionId, activeWorktree?.pushTarget)
-      } catch {
+        setRemoteActionErrors((prev) => ({ ...prev, [activeWorktreeId]: null }))
+      } catch (error) {
         // Why: remote action failures are surfaced by editor-slice actions to keep
         // one consistent toast path and avoid duplicate notifications in the UI.
+        // Keep the latest failure inline too: dropdown-only actions like Fetch can
+        // otherwise look like nothing happened once the menu closes.
+        setRemoteActionErrors((prev) => ({
+          ...prev,
+          [activeWorktreeId]: {
+            kind,
+            message: resolveRemoteActionError(kind, error)
+          }
+        }))
       }
     },
     [
@@ -2484,6 +2511,7 @@ function SourceControlInner(): React.JSX.Element {
             <CommitArea
               commitMessage={commitMessage}
               commitError={commitError}
+              remoteActionError={remoteActionError?.message ?? null}
               isCommitting={isCommitting}
               aiEnabled={commitMessageAi?.enabled === true}
               aiAgentConfigured={
@@ -2921,6 +2949,7 @@ export default SourceControl
 type CommitAreaProps = {
   commitMessage: string
   commitError: string | null
+  remoteActionError: string | null
   isCommitting: boolean
   aiEnabled: boolean
   aiAgentConfigured: boolean
@@ -2942,6 +2971,7 @@ type CommitAreaProps = {
 export function CommitArea({
   commitMessage,
   commitError,
+  remoteActionError,
   isCommitting,
   aiEnabled,
   aiAgentConfigured,
@@ -2994,6 +3024,13 @@ export function CommitArea({
   const PrimaryIcon = PRIMARY_ICONS[primaryAction.kind]
 
   const hasMessage = commitMessage.trim().length > 0
+  const describedBy = [
+    commitError ? 'commit-area-error' : null,
+    remoteActionError ? 'commit-area-remote-error' : null,
+    generateError ? 'commit-area-generate-error' : null
+  ]
+    .filter(Boolean)
+    .join(' ')
 
   // Why: only render the Generate button when the user has opted into the
   // feature. Mounting a perma-disabled button would leak space and add noise
@@ -3028,13 +3065,7 @@ export function CommitArea({
           onChange={(e) => onCommitMessageChange(e.target.value)}
           placeholder="Message"
           aria-label="Commit message"
-          aria-describedby={
-            commitError
-              ? 'commit-area-error'
-              : generateError
-                ? 'commit-area-generate-error'
-                : undefined
-          }
+          aria-describedby={describedBy || undefined}
           // Why: reserve right padding so typed text does not slide under the
           // absolute-positioned Generate icon in the top-right corner.
           className={`mt-0.5 w-full resize-none rounded-md border border-border bg-background px-2 py-1.5 text-xs text-foreground outline-none placeholder:text-muted-foreground/70 focus-visible:ring-1 focus-visible:ring-ring ${
@@ -3164,6 +3195,16 @@ export function CommitArea({
           className="mt-1 text-[11px] text-destructive"
         >
           {commitError}
+        </p>
+      )}
+      {remoteActionError && (
+        <p
+          id="commit-area-remote-error"
+          role="alert"
+          aria-live="polite"
+          className="mt-1 text-[11px] text-destructive"
+        >
+          {remoteActionError}
         </p>
       )}
       {generateError && (

--- a/src/renderer/src/store/slices/editor.test.ts
+++ b/src/renderer/src/store/slices/editor.test.ts
@@ -990,6 +990,21 @@ describe('createEditorSlice remote branch actions', () => {
     )
   })
 
+  it('surfaces an explicit toast when pull stops on merge conflicts', async () => {
+    const store = createEditorStore()
+    gitPullMock.mockRejectedValueOnce(
+      new Error(
+        'Auto-merging src/app.ts\nCONFLICT (content): Merge conflict in src/app.ts\nAutomatic merge failed; fix conflicts and then commit the result.'
+      )
+    )
+
+    await expect(store.getState().pullBranch('wt-1', '/repo')).rejects.toThrow()
+
+    expect(toastErrorMock).toHaveBeenCalledWith(
+      'Pull stopped with merge conflicts. Resolve them in Source Control, then commit the merge.'
+    )
+  })
+
   it('runs publish branch through push with publish=true', async () => {
     // Why: pushBranch no longer awaits a post-op git status / upstream
     // refresh. The 3s git-status poll and the upstream-status effect in the
@@ -1160,7 +1175,7 @@ describe('createEditorSlice remote branch actions', () => {
 
     await expect(store.getState().fetchBranch('wt-1', '/repo')).rejects.toThrow('network timeout')
 
-    expect(toastErrorMock).toHaveBeenCalledWith('network timeout')
+    expect(toastErrorMock).toHaveBeenCalledWith('Fetch failed. network timeout')
     expect(gitUpstreamStatusMock).not.toHaveBeenCalled()
     expect(store.getState().isRemoteOperationActive).toBe(false)
   })
@@ -1331,6 +1346,24 @@ describe('createEditorSlice remote branch actions', () => {
     expect(toastErrorMock).toHaveBeenCalledTimes(1)
     expect(toastErrorMock).toHaveBeenCalledWith(
       'Pull blocked — commit or stash your local changes first.'
+    )
+    expect(gitPushMock).not.toHaveBeenCalled()
+    expect(store.getState().isRemoteOperationActive).toBe(false)
+  })
+
+  it('surfaces a sync-labeled toast when syncBranch stops on merge conflicts', async () => {
+    const store = createEditorStore()
+    gitPullMock.mockRejectedValueOnce(
+      new Error(
+        'Auto-merging src/app.ts\nCONFLICT (content): Merge conflict in src/app.ts\nAutomatic merge failed; fix conflicts and then commit the result.'
+      )
+    )
+
+    await expect(store.getState().syncBranch('wt-1', '/repo')).rejects.toThrow()
+
+    expect(toastErrorMock).toHaveBeenCalledTimes(1)
+    expect(toastErrorMock).toHaveBeenCalledWith(
+      'Sync stopped with merge conflicts. Resolve them in Source Control, then commit the merge.'
     )
     expect(gitPushMock).not.toHaveBeenCalled()
     expect(store.getState().isRemoteOperationActive).toBe(false)

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -470,12 +470,24 @@ function extractPublishFailureDetail(message: string): string | null {
   return null
 }
 
-function resolveRemoteOperationErrorMessage(
+export function resolveRemoteOperationErrorMessage(
   error: unknown,
-  options?: { publish?: boolean; isPush?: boolean; isSync?: boolean }
+  options?: { publish?: boolean; isPush?: boolean; isSync?: boolean; isFetch?: boolean }
 ): string {
   if (!(error instanceof Error)) {
     return REMOTE_OPERATION_FAILED_MESSAGE
+  }
+
+  if (/unmerged files|needs merge|you have not concluded your merge/i.test(error.message)) {
+    return options?.isSync
+      ? 'Sync blocked — resolve existing merge conflicts first.'
+      : 'Pull blocked — resolve existing merge conflicts first.'
+  }
+
+  if (/automatic merge failed|CONFLICT \(|fix conflicts/i.test(error.message)) {
+    return options?.isSync
+      ? 'Sync stopped with merge conflicts. Resolve them in Source Control, then commit the merge.'
+      : 'Pull stopped with merge conflicts. Resolve them in Source Control, then commit the merge.'
   }
 
   // Why: under sync, the inner push runs *after* a successful pull, so a
@@ -537,6 +549,13 @@ function resolveRemoteOperationErrorMessage(
       return `Push failed. ${detail}. Check your remote access and try again.`
     }
     return 'Push failed. Check your connection and try again.'
+  }
+
+  if (options?.isFetch) {
+    const detail =
+      extractPublishFailureDetail(error.message) ??
+      truncateDetail(stripCredentialsFromMessage(error.message))
+    return `Fetch failed. ${detail}`
   }
 
   return error.message
@@ -2126,7 +2145,7 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
     try {
       await fetchRuntimeGit({ settings: get().settings, worktreeId, worktreePath, connectionId })
     } catch (error) {
-      toast.error(resolveRemoteOperationErrorMessage(error))
+      toast.error(resolveRemoteOperationErrorMessage(error, { isFetch: true }))
       throw error
     } finally {
       get().endRemoteOperation()


### PR DESCRIPTION
## Summary
- show remote action failures inline in Source Control so dropdown actions like Fetch have visible feedback
- improve fetch, pull, and sync failure messages for network errors and merge conflicts
- add unit coverage for inline remote errors and labeled remote-operation toasts

## Tests
- pnpm typecheck
- pnpm test src/renderer/src/components/right-sidebar/CommitArea.test.tsx src/renderer/src/components/right-sidebar/CommitArea.generate.test.tsx src/renderer/src/components/right-sidebar/CommitArea.primary-icons.test.tsx src/renderer/src/components/right-sidebar/CommitArea.chevron-spinner.test.tsx src/renderer/src/store/slices/editor.test.ts