### PR TITLE
Improve SSH terminate UI

### DIFF
--- a/src/renderer/src/components/settings/SshPane.tsx
+++ b/src/renderer/src/components/settings/SshPane.tsx
@@ -209,9 +209,9 @@ export function SshPane(_props: SshPaneProps): React.JSX.Element {
   const handleTerminateSessions = async (targetId: string): Promise<void> => {
     try {
       await terminateSessionsWithReconnect(targetId)
-      toast.success('Remote sessions terminated')
+      toast.success('Remote terminals ended')
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Failed to terminate sessions')
+      toast.error(err instanceof Error ? err.message : 'Failed to end remote terminals')
     }
   }
 
@@ -341,7 +341,7 @@ export function SshPane(_props: SshPaneProps): React.JSX.Element {
           <DialogHeader>
             <DialogTitle className="text-sm">Remove SSH Target</DialogTitle>
             <DialogDescription className="text-xs">
-              This will remove the target and terminate any active remote sessions.
+              This will remove the target and end any active remote terminals.
             </DialogDescription>
           </DialogHeader>
 
@@ -370,7 +370,7 @@ export function SshPane(_props: SshPaneProps): React.JSX.Element {
         </DialogContent>
       </Dialog>
 
-      {/* Terminate confirmation dialog */}
+      {/* End remote terminals confirmation dialog */}
       <Dialog
         open={!!pendingTerminate}
         onOpenChange={(open) => {
@@ -381,9 +381,10 @@ export function SshPane(_props: SshPaneProps): React.JSX.Element {
       >
         <DialogContent className="max-w-sm sm:max-w-sm" showCloseButton={false}>
           <DialogHeader>
-            <DialogTitle className="text-sm">Terminate Remote Sessions</DialogTitle>
+            <DialogTitle className="text-sm">End Remote Terminals?</DialogTitle>
             <DialogDescription className="text-xs">
-              This will kill active remote terminals for this SSH target.
+              This will stop active terminal sessions on this SSH target. Reconnecting will not
+              restore them.
             </DialogDescription>
           </DialogHeader>
 
@@ -406,7 +407,7 @@ export function SshPane(_props: SshPaneProps): React.JSX.Element {
                 }
               }}
             >
-              Terminate
+              End Terminals
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/renderer/src/components/settings/SshTargetCard.tsx
+++ b/src/renderer/src/components/settings/SshTargetCard.tsx
@@ -1,11 +1,20 @@
 import { useState } from 'react'
-import { Loader2, MonitorSmartphone, Pencil, Server, ServerOff, Trash2 } from 'lucide-react'
+import {
+  CircleStop,
+  Loader2,
+  MonitorSmartphone,
+  Pencil,
+  Server,
+  ServerOff,
+  Trash2
+} from 'lucide-react'
 import type {
   SshTarget,
   SshConnectionState,
   SshConnectionStatus
 } from '../../../../shared/ssh-types'
 import { Button } from '../ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
 
 // ── Shared status helpers ────────────────────────────────────────────
 
@@ -95,6 +104,70 @@ export function SshTargetCard({
     Promise.resolve(onTerminateSessions(target.id)).finally(() => setActionInFlight(null))
   }
 
+  const renderEndRemoteTerminalsButton = (): React.JSX.Element => (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={handleTerminateSessions}
+          className="size-7 text-muted-foreground hover:text-red-400"
+          disabled={actionInFlight !== null}
+          aria-label={
+            actionInFlight === 'terminate' ? 'Ending remote terminals' : 'End remote terminals'
+          }
+        >
+          {actionInFlight === 'terminate' ? (
+            <Loader2 className="size-3 animate-spin" />
+          ) : (
+            <CircleStop className="size-3" />
+          )}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="top" sideOffset={4}>
+        End remote terminals
+      </TooltipContent>
+    </Tooltip>
+  )
+
+  const renderSecondaryIconActions = (includeEndRemoteTerminals: boolean): React.JSX.Element => (
+    <div className="flex items-center gap-1">
+      {includeEndRemoteTerminals ? renderEndRemoteTerminalsButton() : null}
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => onEdit(target)}
+            className="size-7"
+            aria-label="Edit target"
+          >
+            <Pencil className="size-3" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="top" sideOffset={4}>
+          Edit target
+        </TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => onRemove(target.id)}
+            className="size-7 text-muted-foreground hover:text-red-400"
+            aria-label="Remove target"
+          >
+            <Trash2 className="size-3" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="top" sideOffset={4}>
+          Remove target
+        </TooltipContent>
+      </Tooltip>
+    </div>
+  )
+
   return (
     <div className="flex items-center gap-3 rounded-lg border border-border/50 bg-card/40 px-4 py-3">
       <Server className="size-4 shrink-0 text-muted-foreground" />
@@ -117,6 +190,7 @@ export function SshTargetCard({
       <div className="flex shrink-0 items-center gap-1">
         {status === 'connected' ? (
           <>
+            {renderSecondaryIconActions(true)}
             <Button
               variant="ghost"
               size="xs"
@@ -127,42 +201,18 @@ export function SshTargetCard({
               <ServerOff className="size-3" />
               Disconnect
             </Button>
-            <Button
-              variant="ghost"
-              size="xs"
-              onClick={handleTerminateSessions}
-              className="gap-1.5 text-muted-foreground hover:text-red-400"
-              disabled={actionInFlight !== null}
-            >
-              {actionInFlight === 'terminate' ? (
-                <Loader2 className="size-3 animate-spin" />
-              ) : (
-                <Trash2 className="size-3" />
-              )}
-              Terminate
-            </Button>
           </>
         ) : isConnecting(status) ? (
-          <Button variant="ghost" size="xs" disabled className="gap-1.5">
-            <Loader2 className="size-3 animate-spin" />
-            Connecting
-          </Button>
+          <>
+            {renderSecondaryIconActions(false)}
+            <Button variant="ghost" size="xs" disabled className="gap-1.5">
+              <Loader2 className="size-3 animate-spin" />
+              Connecting
+            </Button>
+          </>
         ) : (
           <>
-            <Button
-              variant="ghost"
-              size="xs"
-              onClick={handleConnect}
-              className="gap-1.5"
-              disabled={actionInFlight !== null}
-            >
-              {actionInFlight === 'connect' ? (
-                <Loader2 className="size-3 animate-spin" />
-              ) : (
-                <Server className="size-3" />
-              )}
-              Connect
-            </Button>
+            {renderSecondaryIconActions(true)}
             <Button
               variant="ghost"
               size="xs"
@@ -180,38 +230,19 @@ export function SshTargetCard({
             <Button
               variant="ghost"
               size="xs"
-              onClick={handleTerminateSessions}
-              className="gap-1.5 text-muted-foreground hover:text-red-400"
+              onClick={handleConnect}
+              className="gap-1.5"
               disabled={actionInFlight !== null}
             >
-              {actionInFlight === 'terminate' ? (
+              {actionInFlight === 'connect' ? (
                 <Loader2 className="size-3 animate-spin" />
               ) : (
-                <Trash2 className="size-3" />
+                <Server className="size-3" />
               )}
-              Terminate
+              Connect
             </Button>
           </>
         )}
-
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={() => onEdit(target)}
-          className="size-7"
-          aria-label="Edit target"
-        >
-          <Pencil className="size-3" />
-        </Button>
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={() => onRemove(target.id)}
-          className="size-7 text-muted-foreground hover:text-red-400"
-          aria-label="Remove target"
-        >
-          <Trash2 className="size-3" />
-        </Button>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary

Clarifies the SSH destructive action by renaming terminate-session copy to ending remote terminals and moving it into a compact icon action with tooltip.

## Screenshots

Not captured; small settings-row UI copy/action placement change.

## Testing

- [ ] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

No tests added; this is a copy and settings-row presentation change with no new business logic.

## AI Review Report

Ran a single-agent review of the branch diff against `origin/main` for correctness, logical bugs, security, type safety, error handling, performance, dead code, and unused imports. The review found no issues. It explicitly considered cross-platform compatibility for macOS, Linux, and Windows; the PR does not touch shortcuts, labels with platform-specific modifier keys, filesystem paths, shell behavior, or Electron platform branches.

## Security Audit

Reviewed the changed SSH settings UI flow for input handling, command execution, path handling, auth, secrets, dependency, and IPC risks. The PR only changes labels, icon affordances, tooltip wrapping, and confirmation copy around an existing handler; it does not introduce new command execution, IPC calls, credentials handling, filesystem access, or dependencies.

## Notes

The SSH use case is preserved: the confirmation copy now states that ending remote terminals stops active sessions and reconnecting will not restore them.