### PR TITLE
Enable remote agent hooks by default

### DIFF
--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -1314,7 +1314,7 @@ describe('registerPtyHandlers', () => {
         expect(runtime.onPtyExit).not.toHaveBeenCalled()
       })
 
-      it('strips ORCA_PANE_KEY/TAB_ID/WORKTREE_ID from SSH spawn env when feature flag is off', async () => {
+      it('strips ORCA_PANE_KEY/TAB_ID/WORKTREE_ID from SSH spawn env when remote agent hooks are disabled', async () => {
         const sshSpawn = vi.fn(async (_opts: { env: Record<string, string> }) => ({
           id: 'ssh-pty'
         }))
@@ -1343,7 +1343,7 @@ describe('registerPtyHandlers', () => {
         handlers.clear()
         registerPtyHandlers(mainWindow as never)
         const prevFlag = process.env.ORCA_FEATURE_REMOTE_AGENT_HOOKS
-        delete process.env.ORCA_FEATURE_REMOTE_AGENT_HOOKS
+        process.env.ORCA_FEATURE_REMOTE_AGENT_HOOKS = '0'
         try {
           await handlers.get('pty:spawn')!(null, {
             cols: 80,
@@ -1374,7 +1374,7 @@ describe('registerPtyHandlers', () => {
         }
       })
 
-      it('forwards ORCA_PANE_KEY/TAB_ID/WORKTREE_ID over SSH when feature flag is on', async () => {
+      it('forwards ORCA_PANE_KEY/TAB_ID/WORKTREE_ID over SSH by default', async () => {
         const sshSpawn = vi.fn(async (_opts: { env: Record<string, string> }) => ({
           id: 'ssh-pty'
         }))
@@ -1403,7 +1403,7 @@ describe('registerPtyHandlers', () => {
         handlers.clear()
         registerPtyHandlers(mainWindow as never)
         const prevFlag = process.env.ORCA_FEATURE_REMOTE_AGENT_HOOKS
-        process.env.ORCA_FEATURE_REMOTE_AGENT_HOOKS = '1'
+        delete process.env.ORCA_FEATURE_REMOTE_AGENT_HOOKS
         try {
           const leafId = '22222222-2222-4222-8222-222222222222'
           const paneKey = makePaneKey('tab-2', leafId)

--- a/src/shared/agent-hook-relay.test.ts
+++ b/src/shared/agent-hook-relay.test.ts
@@ -39,8 +39,8 @@ describe('agent-hook-relay wire shape', () => {
 })
 
 describe('isRemoteAgentHooksEnabled', () => {
-  it('is off when the env var is absent', () => {
-    expect(isRemoteAgentHooksEnabled({})).toBe(false)
+  it('is on when the env var is absent', () => {
+    expect(isRemoteAgentHooksEnabled({})).toBe(true)
   })
 
   it('is off for empty / "0"', () => {

--- a/src/shared/agent-hook-relay.ts
+++ b/src/shared/agent-hook-relay.ts
@@ -78,14 +78,13 @@ export const AGENT_HOOK_REQUEST_REPLAY_METHOD = 'agent_hook.requestReplay' as co
 export const AGENT_HOOK_INSTALL_PLUGINS_METHOD = 'agent_hook.installPlugins' as const
 
 /** Feature-flag env var. Read once at process start by Orca and the relay.
- *  Absent / empty / "0" = off; anything else = on. See §8 of the design doc
- *  for the gate locations. */
+ *  Remote agent hooks ship as the default SSH behavior; set "0" to opt out. */
 export const ORCA_FEATURE_REMOTE_AGENT_HOOKS_ENV = 'ORCA_FEATURE_REMOTE_AGENT_HOOKS' as const
 
 export function isRemoteAgentHooksEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
   const raw = env[ORCA_FEATURE_REMOTE_AGENT_HOOKS_ENV]
   if (raw === undefined) {
-    return false
+    return true
   }
   const trimmed = raw.trim()
   if (trimmed.length === 0 || trimmed === '0') {

--- a/tests/e2e/ssh-localhost.spec.ts
+++ b/tests/e2e/ssh-localhost.spec.ts
@@ -21,9 +21,9 @@ type LocalhostSshTarget = {
 
 const RUN_LOCALHOST_SSH = process.env.ORCA_E2E_SSH_LOCALHOST === '1'
 const RUN_REMOTE_HOOKS =
-  process.env.ORCA_FEATURE_REMOTE_AGENT_HOOKS !== undefined &&
-  process.env.ORCA_FEATURE_REMOTE_AGENT_HOOKS.trim() !== '' &&
-  process.env.ORCA_FEATURE_REMOTE_AGENT_HOOKS.trim() !== '0'
+  process.env.ORCA_FEATURE_REMOTE_AGENT_HOOKS === undefined ||
+  (process.env.ORCA_FEATURE_REMOTE_AGENT_HOOKS.trim() !== '' &&
+    process.env.ORCA_FEATURE_REMOTE_AGENT_HOOKS.trim() !== '0')
 
 function parsePort(value: string | undefined): number {
   const parsed = Number(value ?? '22')
@@ -79,7 +79,7 @@ test.describe('Localhost SSH', () => {
   )
   test.skip(
     !RUN_REMOTE_HOOKS,
-    'Set ORCA_FEATURE_REMOTE_AGENT_HOOKS=1 so remote PTYs keep pane identity and forward hook events.'
+    'Unset ORCA_FEATURE_REMOTE_AGENT_HOOKS or set it to 1 so remote PTYs keep pane identity and forward hook events.'
   )
   test.skip(process.platform === 'win32', 'Localhost SSH hook E2E uses POSIX hook scripts.')
 


### PR DESCRIPTION
## Summary
- default remote agent hooks to enabled when ORCA_FEATURE_REMOTE_AGENT_HOOKS is unset
- keep ORCA_FEATURE_REMOTE_AGENT_HOOKS=0 / empty string as opt-out
- update SSH and relay tests for the new default

## Validation
- pnpm typecheck
- review agent: pnpm test src/shared/agent-hook-relay.test.ts src/main/ipc/pty.test.ts src/main/ssh/ssh-relay-session.test.ts src/main/ssh/ssh-relay-session-agent-hooks.integration.test.ts

Note: local broad Vitest run failed because better-sqlite3 was compiled for NODE_MODULE_VERSION 145 while this Node requires 137.