### PR TITLE
Fix workspace sidebar scroll anchoring

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -84,6 +84,7 @@ import {
   canGoBackWorktreeHistory,
   canGoForwardWorktreeHistory
 } from '@/store/slices/worktree-nav-history'
+import type { VirtualizedScrollAnchor } from './hooks/useVirtualizedScrollAnchor'
 import type { RemoteWorkspacePatchResult } from '../../shared/remote-workspace-types'
 import type { OnboardingState } from '../../shared/types'
 
@@ -250,6 +251,11 @@ function App(): React.JSX.Element {
   const activeView = useAppStore((s) => s.activeView)
   const activeModal = useAppStore((s) => s.activeModal)
   const activeWorktreeId = useAppStore((s) => s.activeWorktreeId)
+  // Why: App swaps the sidebar between workspace and landing layouts when the
+  // active workspace is slept/deleted. Keep virtualized scroll memory above
+  // that remount so the left workspace list doesn't restart at scrollTop 0.
+  const worktreeSidebarScrollOffsetRef = useRef(0)
+  const worktreeSidebarScrollAnchorRef = useRef<VirtualizedScrollAnchor>(null)
   const tabsByWorktree = useAppStore((s) => s.tabsByWorktree)
   const activeTabId = useAppStore((s) => s.activeTabId)
   const expandedPaneByTabId = useAppStore((s) => s.expandedPaneByTabId)
@@ -1340,11 +1346,17 @@ function App(): React.JSX.Element {
                           the sidebar falls back to its content height, so the
                           worktree list loses its scroll viewport and the fixed
                           bottom toolbar (including Add Project) gets pushed offscreen. */}
-                      <Sidebar />
+                      <Sidebar
+                        worktreeScrollOffsetRef={worktreeSidebarScrollOffsetRef}
+                        worktreeScrollAnchorRef={worktreeSidebarScrollAnchorRef}
+                      />
                     </div>
                   </div>
                 ) : (
-                  <Sidebar />
+                  <Sidebar
+                    worktreeScrollOffsetRef={worktreeSidebarScrollOffsetRef}
+                    worktreeScrollAnchorRef={worktreeSidebarScrollAnchorRef}
+                  />
                 )
               ) : null}
               <div className="relative flex flex-1 min-w-0 min-h-0 overflow-hidden">

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -785,6 +785,18 @@
   padding: 0 4px;
 }
 
+.worktree-sidebar-layout-animate [data-worktree-virtual-row] {
+  transition: transform 180ms cubic-bezier(0.16, 1, 0.3, 1);
+  will-change: transform;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .worktree-sidebar-layout-animate [data-worktree-virtual-row] {
+    transition: none;
+    will-change: auto;
+  }
+}
+
 .worktree-item {
   display: flex;
   flex-direction: column;

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -54,6 +54,10 @@ import {
   setVisibleWorktreeIds,
   sidebarHasActiveFilters
 } from './visible-worktrees'
+import {
+  useVirtualizedScrollAnchor,
+  type VirtualizedScrollAnchor
+} from '@/hooks/useVirtualizedScrollAnchor'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 import { useRepoHeaderDrag } from './repo-header-drag'
 import WorktreeContextMenu from './WorktreeContextMenu'
@@ -70,6 +74,12 @@ import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-cl
 // Prevents jarring position shifts when background events (AI starting work,
 // terminal title changes) trigger score recalculations.
 const SORT_SETTLE_MS = 3_000
+const WORKTREE_SIDEBAR_SCROLL_STYLE: React.CSSProperties = {
+  // Why: TanStack Virtual owns scroll correction. Native browser anchoring can
+  // fight virtual row measurement/remounts and produce visible jumps.
+  overflowAnchor: 'none'
+}
+const WORKTREE_REMOVE_LAYOUT_ANIMATION_MS = 180
 
 function isEditableTarget(target: EventTarget | null): boolean {
   if (!(target instanceof HTMLElement)) {
@@ -133,13 +143,11 @@ type VirtualizedWorktreeViewportProps = {
   workspaceStatuses: readonly WorkspaceStatusDefinition[]
   onMoveWorktreeToStatus: (worktreeId: string, status: WorkspaceStatus) => void
   onPinWorktree: (worktreeId: string) => void
-  // Why: the viewport remounts when the row structure changes (see
-  // viewportResetKey) so the virtualizer's measurementsCache cannot hold
-  // heights tied to shifted indices. A fresh virtualizer would otherwise
-  // start at scrollTop 0, which makes the sidebar snap to the top whenever
-  // a worktree is deleted. The parent persists the last observed scrollTop
-  // in a ref and seeds the new virtualizer via initialOffset.
+  // Why: broad grouping changes still remount the viewport, while add/delete
+  // stays mounted for row-key anchoring and layout animation. These refs bridge
+  // both paths so the virtualizer never falls back to scrollTop 0.
   scrollOffsetRef: React.MutableRefObject<number>
+  scrollAnchorRef: React.MutableRefObject<VirtualizedScrollAnchor>
 }
 
 type WorktreeItemRow = Extract<Row, { type: 'item' }>
@@ -236,7 +244,8 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
   workspaceStatuses,
   onMoveWorktreeToStatus,
   onPinWorktree,
-  scrollOffsetRef
+  scrollOffsetRef,
+  scrollAnchorRef
 }: VirtualizedWorktreeViewportProps) {
   const scrollRef = useRef<HTMLDivElement>(null)
   const [dragOverStatus, setDragOverStatus] = useState<WorkspaceStatus | null>(null)
@@ -254,9 +263,21 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
     () => buildRenderableRows(rows, showWorkspaceLineage),
     [rows, showWorkspaceLineage]
   )
+  const [layoutAnimationActive, setLayoutAnimationActive] = useState(false)
+  const previousRenderRowCountRef = useRef(renderRows.length)
   const activeWorktreeRowIndex = useMemo(
     () => renderRows.findIndex((row) => renderRowContainsWorktree(row, activeWorktreeId)),
     [renderRows, activeWorktreeId]
+  )
+  const getVirtualItemKey = useCallback(
+    (index: number) => {
+      const row = renderRows[index]
+      if (!row) {
+        return `__stale_${index}`
+      }
+      return getRenderRowKey(row)
+    },
+    [renderRows]
   )
 
   const virtualizer = useVirtualizer({
@@ -277,59 +298,8 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
     // mirrors this onto the actual scrollElement.scrollTop so the DOM and
     // virtualizer stay aligned across remounts.
     initialOffset: () => scrollOffsetRef.current,
-    getItemKey: (index) => {
-      const row = renderRows[index]
-      if (!row) {
-        return `__stale_${index}`
-      }
-      return getRenderRowKey(row)
-    }
+    getItemKey: getVirtualItemKey
   })
-
-  // Why: the viewport remounts when row structure changes (see
-  // viewportResetKey). The fresh DOM element starts at scrollTop=0, which
-  // snaps the sidebar back to the top every time a worktree is added or
-  // deleted. Restoring the last observed scrollTop from a ref before the
-  // browser paints keeps the user's scroll position stable across remounts.
-  //
-  // The saved offset is only captured via our scroll listener; we
-  // suppress saving during the initial restoration pass so that the
-  // browser's clamp-to-current-scrollHeight (temporarily smaller because
-  // the virtualizer has not yet measured every row) doesn't overwrite the
-  // user's intended offset with a clamped value.
-  useLayoutEffect(() => {
-    const el = scrollRef.current
-    if (!el) {
-      return
-    }
-    const targetOffset = scrollOffsetRef.current
-    let restoring = targetOffset > 0
-    if (restoring) {
-      el.scrollTop = targetOffset
-    }
-    const onScroll = (): void => {
-      if (restoring) {
-        // Virtualizer has not yet produced its final totalSize, so the
-        // browser may clamp our applied scrollTop to a lower value. Keep
-        // re-applying the target offset each tick until the DOM accepts
-        // it, then start recording user-driven scrolls.
-        if (el.scrollTop === targetOffset) {
-          restoring = false
-          return
-        }
-        if (el.scrollHeight - el.clientHeight >= targetOffset) {
-          el.scrollTop = targetOffset
-          if (el.scrollTop === targetOffset) {
-            restoring = false
-          }
-        }
-        return
-      }
-      scrollOffsetRef.current = el.scrollTop
-    }
-    el.addEventListener('scroll', onScroll, { passive: true })
-    return () => el.removeEventListener('scroll', onScroll)
-  }, [scrollOffsetRef])
 
   React.useEffect(() => {
     if (!pendingRevealWorktreeId) {
@@ -417,6 +387,31 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
 
   const prCacheLen = useAppStore((s) => Object.keys(s.prCache).length)
   const issueCacheLen = useAppStore((s) => Object.keys(s.issueCache).length)
+  const totalSize = virtualizer.getTotalSize()
+  useVirtualizedScrollAnchor({
+    anchorRef: scrollAnchorRef,
+    getRowKey: getRenderRowKey,
+    rows: renderRows,
+    scrollElementRef: scrollRef,
+    scrollOffsetRef,
+    totalSize,
+    virtualizer
+  })
+
+  useEffect(() => {
+    const previousCount = previousRenderRowCountRef.current
+    previousRenderRowCountRef.current = renderRows.length
+    if (renderRows.length >= previousCount) {
+      return
+    }
+
+    setLayoutAnimationActive(true)
+    const timeoutId = window.setTimeout(
+      () => setLayoutAnimationActive(false),
+      WORKTREE_REMOVE_LAYOUT_ANIMATION_MS
+    )
+    return () => window.clearTimeout(timeoutId)
+  }, [renderRows.length])
 
   useLayoutEffect(() => {
     virtualizer.elementsCache.forEach((element) => {
@@ -636,7 +631,11 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
       aria-multiselectable="true"
       aria-activedescendant={activeDescendantId}
       onKeyDown={handleContainerKeyDown}
-      className="worktree-sidebar-scrollbar flex-1 overflow-y-scroll overflow-x-hidden pl-1 scrollbar-sleek outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-inset pt-px"
+      className={cn(
+        'worktree-sidebar-scrollbar flex-1 overflow-y-scroll overflow-x-hidden pl-1 scrollbar-sleek outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-inset pt-px',
+        layoutAnimationActive && 'worktree-sidebar-layout-animate'
+      )}
+      style={WORKTREE_SIDEBAR_SCROLL_STYLE}
     >
       <div
         role="presentation"
@@ -672,6 +671,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
               <div
                 key={vItem.key}
                 role="presentation"
+                data-worktree-virtual-row
                 data-index={vItem.index}
                 ref={virtualizer.measureElement}
                 className="absolute left-0 right-0"
@@ -985,6 +985,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
               <div
                 key={vItem.key}
                 role="presentation"
+                data-worktree-virtual-row
                 data-index={vItem.index}
                 ref={virtualizer.measureElement}
                 className="absolute left-0 right-0"
@@ -1011,6 +1012,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
             <div
               key={vItem.key}
               role="presentation"
+              data-worktree-virtual-row
               data-index={vItem.index}
               ref={virtualizer.measureElement}
               data-workspace-status-drop-target={itemWorkspaceStatus ? '' : undefined}
@@ -1038,10 +1040,15 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
   )
 })
 
-const WorktreeList = React.memo(function WorktreeList() {
-  // Why: persists the sidebar scroll offset across the VirtualizedWorktreeViewport
-  // remount that row-structure changes trigger. See viewportResetKey.
-  const sidebarScrollOffsetRef = useRef(0)
+type WorktreeListProps = {
+  scrollOffsetRef: React.MutableRefObject<number>
+  scrollAnchorRef: React.MutableRefObject<VirtualizedScrollAnchor>
+}
+
+const WorktreeList = React.memo(function WorktreeList({
+  scrollOffsetRef,
+  scrollAnchorRef
+}: WorktreeListProps) {
   // ── Granular selectors (each is a primitive or shallow-stable ref) ──
   const allWorktrees = useAllWorktrees()
   const repoMap = useRepoMap()
@@ -1391,22 +1398,17 @@ const WorktreeList = React.memo(function WorktreeList() {
       showWorkspaceLineage
     ]
   )
-  // Why: rows.length alone can stay the same when items migrate between
-  // groups (e.g., PR cache loads on restart and a collapsed group absorbs
-  // an item while its header is added — net row count unchanged). Including
-  // the header keys ensures the virtualizer remounts when group structure
-  // changes, preventing stale height measurements from causing overlap.
-  // We also key on rows.length so add/delete invalidates the virtualizer's
-  // per-index measurementsCache; scroll position is preserved across the
-  // remount via the ref below so deleting an off-screen worktree doesn't
-  // snap the sidebar back to the top.
+  // Why: header/mode changes can shift entire groups, so remount the
+  // virtualizer for those broad structure changes. Do not key on rows.length:
+  // add/delete must keep the same row DOM long enough for the remaining rows
+  // to animate upward and for the scroll anchor to hold the viewport steady.
   const viewportResetKey = useMemo(() => {
     const headers = rows
       .filter((r): r is GroupHeaderRow => r.type === 'header')
       .map((r) => r.key)
       .join(',')
-    return `${groupBy}:${rows.length}:${headers}`
-  }, [groupBy, rows])
+    return `${groupBy}:${showWorkspaceLineage ? 'lineage' : 'flat'}:${headers}`
+  }, [groupBy, rows, showWorkspaceLineage])
 
   // Why: derive the rendered item order from the post-buildRows() row list,
   // not the flat `worktrees` array, because grouping (groupBy: 'repo' or
@@ -1618,7 +1620,8 @@ const WorktreeList = React.memo(function WorktreeList() {
       workspaceStatuses={workspaceStatuses}
       onMoveWorktreeToStatus={moveWorktreeToStatus}
       onPinWorktree={pinWorktree}
-      scrollOffsetRef={sidebarScrollOffsetRef}
+      scrollOffsetRef={scrollOffsetRef}
+      scrollAnchorRef={scrollAnchorRef}
     />
   )
 })

--- a/src/renderer/src/components/sidebar/index.tsx
+++ b/src/renderer/src/components/sidebar/index.tsx
@@ -11,11 +11,20 @@ import NonGitFolderDialog from './NonGitFolderDialog'
 import RemoveFolderDialog from './RemoveFolderDialog'
 import AddRepoDialog from './AddRepoDialog'
 import OrcaYamlTrustDialog from './OrcaYamlTrustDialog'
+import type { VirtualizedScrollAnchor } from '@/hooks/useVirtualizedScrollAnchor'
 
 const MIN_WIDTH = 220
 const MAX_WIDTH = 500
 
-function Sidebar(): React.JSX.Element {
+type SidebarProps = {
+  worktreeScrollOffsetRef: React.MutableRefObject<number>
+  worktreeScrollAnchorRef: React.MutableRefObject<VirtualizedScrollAnchor>
+}
+
+function Sidebar({
+  worktreeScrollOffsetRef,
+  worktreeScrollAnchorRef
+}: SidebarProps): React.JSX.Element {
   const sidebarOpen = useAppStore((s) => s.sidebarOpen)
   const sidebarWidth = useAppStore((s) => s.sidebarWidth)
   const setSidebarWidth = useAppStore((s) => s.setSidebarWidth)
@@ -49,7 +58,10 @@ function Sidebar(): React.JSX.Element {
         <SidebarNav />
         <SidebarHeader />
 
-        <WorktreeList />
+        <WorktreeList
+          scrollOffsetRef={worktreeScrollOffsetRef}
+          scrollAnchorRef={worktreeScrollAnchorRef}
+        />
 
         {/* Fixed bottom toolbar */}
         <SidebarToolbar />

--- a/src/renderer/src/components/sidebar/sleep-worktree-flow.test.ts
+++ b/src/renderer/src/components/sidebar/sleep-worktree-flow.test.ts
@@ -5,7 +5,11 @@ const mocks = vi.hoisted(() => {
     activeWorktreeId: null as string | null,
     setActiveWorktree: vi.fn(),
     shutdownWorktreeBrowsers: vi.fn().mockResolvedValue(undefined),
-    shutdownWorktreeTerminals: vi.fn().mockResolvedValue(undefined)
+    shutdownWorktreeTerminals: vi.fn().mockResolvedValue(undefined),
+    suppressPtyExit: vi.fn(),
+    consumeSuppressedPtyExit: vi.fn(),
+    tabsByWorktree: {} as Record<string, { id: string }[]>,
+    ptyIdsByTabId: {} as Record<string, string[]>
   }
   const toastError = vi.fn()
   return { state, toastError }
@@ -26,8 +30,12 @@ describe('runSleepWorktree', () => {
     mocks.state.setActiveWorktree.mockClear()
     mocks.state.shutdownWorktreeBrowsers.mockClear().mockResolvedValue(undefined)
     mocks.state.shutdownWorktreeTerminals.mockClear().mockResolvedValue(undefined)
+    mocks.state.suppressPtyExit.mockClear()
+    mocks.state.consumeSuppressedPtyExit.mockClear()
     mocks.toastError.mockClear()
     mocks.state.activeWorktreeId = null
+    mocks.state.tabsByWorktree = {}
+    mocks.state.ptyIdsByTabId = {}
   })
 
   it('tears down browsers before terminals on the sleep path', async () => {
@@ -59,21 +67,48 @@ describe('runSleepWorktree', () => {
     expect(activeClear).toBeLessThan(browsersCall)
   })
 
+  it('suppresses active PTY exits before clearing the active slept worktree', async () => {
+    mocks.state.activeWorktreeId = 'wt-1'
+    mocks.state.tabsByWorktree = {
+      'wt-1': [{ id: 'tab-1' }, { id: 'tab-2' }],
+      'wt-2': [{ id: 'tab-other' }]
+    }
+    mocks.state.ptyIdsByTabId = {
+      'tab-1': ['pty-1'],
+      'tab-2': ['pty-2', 'pty-3'],
+      'tab-other': ['pty-other']
+    }
+
+    await runSleepWorktree('wt-1')
+
+    expect(mocks.state.suppressPtyExit).toHaveBeenCalledTimes(3)
+    expect(mocks.state.suppressPtyExit).toHaveBeenNthCalledWith(1, 'pty-1')
+    expect(mocks.state.suppressPtyExit).toHaveBeenNthCalledWith(2, 'pty-2')
+    expect(mocks.state.suppressPtyExit).toHaveBeenNthCalledWith(3, 'pty-3')
+    const suppressCall = mocks.state.suppressPtyExit.mock.invocationCallOrder[0]
+    const activeClear = mocks.state.setActiveWorktree.mock.invocationCallOrder[0]
+    expect(suppressCall).toBeLessThan(activeClear)
+  })
+
   it('leaves activeWorktreeId alone when sleeping a background worktree', async () => {
     mocks.state.activeWorktreeId = 'wt-other'
 
     await runSleepWorktree('wt-1')
 
     expect(mocks.state.setActiveWorktree).not.toHaveBeenCalled()
+    expect(mocks.state.suppressPtyExit).not.toHaveBeenCalled()
   })
 
   it('surfaces a toast and skips terminals when browsers throws', async () => {
     mocks.state.activeWorktreeId = 'wt-1'
     mocks.state.shutdownWorktreeBrowsers.mockRejectedValueOnce(new Error('boom'))
+    mocks.state.tabsByWorktree = { 'wt-1': [{ id: 'tab-1' }] }
+    mocks.state.ptyIdsByTabId = { 'tab-1': ['pty-1'] }
 
     await runSleepWorktree('wt-1')
 
     expect(mocks.state.shutdownWorktreeTerminals).not.toHaveBeenCalled()
+    expect(mocks.state.consumeSuppressedPtyExit).toHaveBeenCalledWith('pty-1')
     expect(mocks.toastError).toHaveBeenCalledWith(
       'Failed to sleep workspace',
       expect.objectContaining({ description: 'boom' })

--- a/src/renderer/src/components/sidebar/sleep-worktree-flow.ts
+++ b/src/renderer/src/components/sidebar/sleep-worktree-flow.ts
@@ -18,6 +18,25 @@ export async function runSleepWorktree(worktreeId: string): Promise<void> {
   await runSleepWorktrees([worktreeId])
 }
 
+function suppressActiveSleepPtyExitActivity(worktreeId: string): string[] {
+  const { ptyIdsByTabId, suppressPtyExit, tabsByWorktree } = useAppStore.getState()
+  const ptyIds: string[] = []
+  for (const tab of tabsByWorktree[worktreeId] ?? []) {
+    for (const ptyId of ptyIdsByTabId[tab.id] ?? []) {
+      ptyIds.push(ptyId)
+      suppressPtyExit(ptyId)
+    }
+  }
+  return ptyIds
+}
+
+function releaseActiveSleepPtyExitSuppressions(ptyIds: readonly string[]): void {
+  const { consumeSuppressedPtyExit } = useAppStore.getState()
+  for (const ptyId of ptyIds) {
+    consumeSuppressedPtyExit(ptyId)
+  }
+}
+
 export async function runSleepWorktrees(worktreeIds: readonly string[]): Promise<void> {
   if (worktreeIds.length === 0) {
     return
@@ -28,7 +47,13 @@ export async function runSleepWorktrees(worktreeIds: readonly string[]): Promise
     shutdownWorktreeBrowsers,
     shutdownWorktreeTerminals
   } = useAppStore.getState()
+  let preSuppressedActivePtyIds: string[] = []
   if (activeWorktreeId && worktreeIds.includes(activeWorktreeId)) {
+    // Why: clearing the active workspace unmounts its TerminalPanes before
+    // shutdownWorktreeTerminals can mark exits as intentional. Pre-suppress
+    // those PTYs so the unmount does not stamp lastActivityAt and reorder the
+    // slept card to the top.
+    preSuppressedActivePtyIds = suppressActiveSleepPtyExitActivity(activeWorktreeId)
     setActiveWorktree(null)
   }
   const errors: string[] = []
@@ -40,6 +65,14 @@ export async function runSleepWorktrees(worktreeIds: readonly string[]): Promise
       // ordering on both paths. Without the browser thunk here, sleep leaks
       // browserPagesByWorkspace entries and live webviews for the slept worktree.
       await shutdownWorktreeBrowsers(worktreeId)
+    } catch (err) {
+      if (worktreeId === activeWorktreeId) {
+        releaseActiveSleepPtyExitSuppressions(preSuppressedActivePtyIds)
+      }
+      errors.push(err instanceof Error ? err.message : String(err))
+      continue
+    }
+    try {
       // Why: sleep is reversible — the tab record stays in tabsByWorktree, the
       // layout stays in terminalLayoutsByTabId, only the live PTY processes are
       // released. keepIdentifiers preserves tab.ptyId / ptyIdsByLeafId /

--- a/src/renderer/src/hooks/useVirtualizedScrollAnchor.ts
+++ b/src/renderer/src/hooks/useVirtualizedScrollAnchor.ts
@@ -1,0 +1,158 @@
+import { useCallback, useLayoutEffect, useMemo, type MutableRefObject, type RefObject } from 'react'
+import type { Virtualizer } from '@tanstack/react-virtual'
+
+export type VirtualizedScrollAnchor = { key: string; offset: number } | null
+
+type UseVirtualizedScrollAnchorOptions<
+  TRow,
+  TScrollElement extends Element,
+  TItemElement extends Element
+> = {
+  anchorRef: MutableRefObject<VirtualizedScrollAnchor>
+  getRowKey: (row: TRow) => string
+  rows: readonly TRow[]
+  scrollElementRef: RefObject<TScrollElement | null>
+  scrollOffsetRef: MutableRefObject<number>
+  totalSize: number
+  virtualizer: Virtualizer<TScrollElement, TItemElement>
+}
+
+/**
+ * Preserves a virtualized scroller by visible row identity, not just pixels.
+ *
+ * Raw scrollTop is not enough when rows are removed or their measured heights
+ * change: the same pixel can point at a different item. The anchor keeps the
+ * top visible row plus its within-row offset and restores that after the
+ * virtualizer has rebuilt or remeasured.
+ */
+export function useVirtualizedScrollAnchor<
+  TRow,
+  TScrollElement extends Element,
+  TItemElement extends Element
+>({
+  anchorRef,
+  getRowKey,
+  rows,
+  scrollElementRef,
+  scrollOffsetRef,
+  totalSize,
+  virtualizer
+}: UseVirtualizedScrollAnchorOptions<TRow, TScrollElement, TItemElement>): void {
+  const rowIndexByKey = useMemo(() => {
+    const indexByKey = new Map<string, number>()
+    rows.forEach((row, index) => {
+      indexByKey.set(getRowKey(row), index)
+    })
+    return indexByKey
+  }, [getRowKey, rows])
+
+  const recordScrollAnchor = useCallback(
+    (scrollTop: number) => {
+      const firstVisible = virtualizer.getVirtualItems().find((item) => item.end > scrollTop)
+      const row = firstVisible ? rows[firstVisible.index] : undefined
+      if (!firstVisible || !row) {
+        anchorRef.current = null
+        return
+      }
+      anchorRef.current = {
+        key: getRowKey(row),
+        offset: Math.max(0, scrollTop - firstVisible.start)
+      }
+    },
+    [anchorRef, getRowKey, rows, virtualizer]
+  )
+
+  useLayoutEffect(() => {
+    const el = scrollElementRef.current
+    if (!el) {
+      return
+    }
+
+    const targetOffset = scrollOffsetRef.current
+    let restoring = targetOffset > 0
+    if (restoring) {
+      el.scrollTop = targetOffset
+    }
+
+    const onScroll = (): void => {
+      if (restoring) {
+        // Why: during a fresh virtualizer mount, total height may still be
+        // estimate-based. Avoid persisting a browser-clamped offset as the
+        // user's real position until the intended offset is reachable.
+        if (el.scrollTop === targetOffset) {
+          restoring = false
+          scrollOffsetRef.current = el.scrollTop
+          recordScrollAnchor(el.scrollTop)
+          return
+        }
+        if (el.scrollHeight - el.clientHeight >= targetOffset) {
+          el.scrollTop = targetOffset
+          if (el.scrollTop === targetOffset) {
+            restoring = false
+            scrollOffsetRef.current = el.scrollTop
+            recordScrollAnchor(el.scrollTop)
+          }
+        }
+        return
+      }
+      scrollOffsetRef.current = el.scrollTop
+      recordScrollAnchor(el.scrollTop)
+    }
+
+    el.addEventListener('scroll', onScroll, { passive: true })
+    return () => {
+      scrollOffsetRef.current = el.scrollTop
+      recordScrollAnchor(el.scrollTop)
+      el.removeEventListener('scroll', onScroll)
+    }
+  }, [recordScrollAnchor, scrollElementRef, scrollOffsetRef])
+
+  useLayoutEffect(() => {
+    const anchor = anchorRef.current
+    const el = scrollElementRef.current
+    if (!anchor || !el) {
+      return
+    }
+
+    const index = rowIndexByKey.get(anchor.key)
+    if (index === undefined) {
+      return
+    }
+
+    const restoreFromMeasuredItem = (): boolean => {
+      const item = virtualizer.getVirtualItems().find((candidate) => candidate.index === index)
+      if (!item) {
+        return false
+      }
+      const maxScrollTop = Math.max(0, el.scrollHeight - el.clientHeight)
+      const nextScrollTop = Math.min(maxScrollTop, Math.max(0, item.start + anchor.offset))
+      if (Math.abs(el.scrollTop - nextScrollTop) > 1) {
+        el.scrollTop = nextScrollTop
+      }
+      scrollOffsetRef.current = el.scrollTop
+      recordScrollAnchor(el.scrollTop)
+      return true
+    }
+
+    if (restoreFromMeasuredItem()) {
+      return
+    }
+
+    // Why: after add/delete the virtualizer can initially render the wrong
+    // window. Move to the anchored row, then apply the within-row offset once
+    // TanStack Virtual has mounted and measured that row.
+    virtualizer.scrollToIndex(index, { align: 'start' })
+    const frameId = window.requestAnimationFrame(() => {
+      restoreFromMeasuredItem()
+    })
+    return () => window.cancelAnimationFrame(frameId)
+  }, [
+    anchorRef,
+    recordScrollAnchor,
+    rowIndexByKey,
+    scrollElementRef,
+    scrollOffsetRef,
+    totalSize,
+    virtualizer
+  ])
+}


### PR DESCRIPTION
## Summary
- Preserve the workspace sidebar virtual scroll position by row identity across sleep/delete and layout swaps
- Keep add/delete mounted with stable virtual item keys so rows below animate upward
- Suppress active PTY exit activity before sleeping the active workspace so sleep does not reorder the card

## Verification
- pnpm exec oxlint src/renderer/src/App.tsx src/renderer/src/components/sidebar/index.tsx src/renderer/src/components/sidebar/WorktreeList.tsx src/renderer/src/components/sidebar/sleep-worktree-flow.ts src/renderer/src/components/sidebar/sleep-worktree-flow.test.ts src/renderer/src/hooks/useVirtualizedScrollAnchor.ts
- pnpm run tc:web
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/delete-worktree-flow.test.ts src/renderer/src/components/sidebar/worktree-list-groups.test.ts src/renderer/src/components/sidebar/sleep-worktree-flow.test.ts
- Electron CDP verification: bottom disposable delete kept scrollDelta 0, below row moved -62px, animation observed, no temp worktrees remained
