### PR TITLE
Shard Electron E2E workflow under CI time cap

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,8 +9,10 @@ on:
         type: string
 
 jobs:
-  e2e:
+  build:
+    name: build e2e app
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout
@@ -18,9 +20,77 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
 
-      # Why: electron-vite's globalSetup invokes a full app build, which
-      # compiles native modules via node-gyp. Mirrors the install step in
-      # pr.yml's verify job so E2E doesn't hit missing-toolchain errors.
+      # Why: the E2E build compiles native modules via node-gyp. Mirrors the
+      # install step in pr.yml's verify job so E2E doesn't hit missing-toolchain
+      # errors.
+      - name: Install native build tools
+        run: sudo apt-get update && sudo apt-get install -y build-essential python3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: package.json
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      # Why: this job runs the same pnpm install path as pr.yml's verify
+      # job, so it needs the same pinned node-gyp override to avoid pnpm's
+      # broken bundled gyp_main.py on Linux.
+      - name: Use external node-gyp to avoid pnpm's bundled copy (Linux only)
+        if: runner.os == 'Linux'
+        run: |
+          npm install -g node-gyp@11.5.0
+          echo "npm_config_node_gyp=$(npm root -g)/node-gyp/bin/node-gyp.js" >> "$GITHUB_ENV"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Why: building once avoids five parallel electron-vite builds inside
+      # Playwright globalSetup, which otherwise contends for CPU/RAM on OSS
+      # runners before the sharded tests even start.
+      - name: Build Electron app for E2E
+        run: npx electron-vite build --mode e2e
+
+      - name: Upload E2E build output
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-build-out
+          path: out/
+          retention-days: 1
+          if-no-files-found: error
+
+  e2e:
+    name: e2e ${{ matrix.shard_name }}
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - shard: '1/5'
+            shard_name: 1-of-5
+          - shard: '2/5'
+            shard_name: 2-of-5
+          - shard: '3/5'
+            shard_name: 3-of-5
+          - shard: '4/5'
+            shard_name: 4-of-5
+          - shard: '5/5'
+            shard_name: 5-of-5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      # Why: pnpm install rebuilds native modules, and those postinstall
+      # scripts still need the Linux toolchain even though this shard reuses
+      # the prebuilt Electron output.
       - name: Install native build tools
         run: sudo apt-get update && sudo apt-get install -y build-essential python3
 
@@ -55,8 +125,21 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Run E2E tests
-        run: xvfb-run --auto-servernum pnpm run test:e2e
+      - name: Download E2E build output
+        uses: actions/download-artifact@v4
+        with:
+          name: e2e-build-out
+          path: out/
+
+      # Why: the Electron suite is wall-clock constrained on OSS runners, but
+      # raising workers on one runner OOMs. Sharding keeps each VM at 4 workers
+      # while splitting the 91-test headless suite across separate runners.
+      # SKIP_BUILD makes Playwright globalSetup reuse the single build job's
+      # artifact instead of starting five concurrent electron-vite builds.
+      # ORCA_E2E_FORWARD_APP_LOGS keeps startup failures visible when Electron
+      # launches but never creates a BrowserWindow.
+      - name: Run E2E tests (${{ matrix.shard_name }})
+        run: xvfb-run --auto-servernum env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run test:e2e --shard=${{ matrix.shard }}
 
       # Why: Playwright retains traces/screenshots only on failure. Uploading
       # them as an artifact makes post-mortem debugging on CI possible without
@@ -65,7 +148,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-traces
+          name: playwright-traces-${{ matrix.shard_name }}
           path: test-results/
           retention-days: 7
           if-no-files-found: ignore

--- a/src/main/electron-updater-loader.ts
+++ b/src/main/electron-updater-loader.ts
@@ -1,0 +1,10 @@
+import type { autoUpdater as electronUpdaterAutoUpdater } from 'electron-updater'
+
+export type ElectronAutoUpdater = typeof electronUpdaterAutoUpdater
+
+export function loadElectronAutoUpdater(): ElectronAutoUpdater {
+  // Why: electron-updater validates app.getVersion() while loading. Keep the
+  // require behind packaged-update guards so direct dev/E2E launches do not
+  // fail before setupAutoUpdater() can return.
+  return (require('electron-updater') as { autoUpdater: ElectronAutoUpdater }).autoUpdater
+}

--- a/src/main/startup/configure-process.test.ts
+++ b/src/main/startup/configure-process.test.ts
@@ -12,6 +12,7 @@ vi.mock('electron', () => {
       quit: vi.fn(),
       exit: vi.fn(),
       isPackaged: false,
+      disableHardwareAcceleration: vi.fn(),
       commandLine: {
         appendSwitch: vi.fn(),
         getSwitchValue: vi.fn(() => '')
@@ -247,10 +248,32 @@ describe('installDevParentWatchdog', () => {
 })
 
 describe('enableMainProcessGpuFeatures', () => {
+  const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+  const originalE2EUserDataDir = process.env.ORCA_E2E_USER_DATA_DIR
+
+  function setPlatform(platform: NodeJS.Platform): void {
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: platform
+    })
+  }
+
+  afterEach(() => {
+    if (originalPlatform) {
+      Object.defineProperty(process, 'platform', originalPlatform)
+    }
+    if (originalE2EUserDataDir === undefined) {
+      delete process.env.ORCA_E2E_USER_DATA_DIR
+    } else {
+      process.env.ORCA_E2E_USER_DATA_DIR = originalE2EUserDataDir
+    }
+  })
+
   it('appends VS Code-style GPU channel flags without unsafe WebGPU/Vulkan opt-ins', async () => {
     const { app } = await import('electron')
     const { enableMainProcessGpuFeatures } = await import('./configure-process')
 
+    delete process.env.ORCA_E2E_USER_DATA_DIR
     vi.mocked(app.commandLine.appendSwitch).mockClear()
     enableMainProcessGpuFeatures()
 
@@ -261,10 +284,30 @@ describe('enableMainProcessGpuFeatures', () => {
     expect(app.commandLine.appendSwitch).not.toHaveBeenCalledWith('enable-unsafe-webgpu')
   })
 
+  it('disables the GPU process for Linux E2E runs', async () => {
+    const { app } = await import('electron')
+    const { enableMainProcessGpuFeatures } = await import('./configure-process')
+
+    setPlatform('linux')
+    process.env.ORCA_E2E_USER_DATA_DIR = '/tmp/orca-e2e'
+    vi.mocked(app.disableHardwareAcceleration).mockClear()
+    vi.mocked(app.commandLine.appendSwitch).mockClear()
+
+    enableMainProcessGpuFeatures()
+
+    expect(app.disableHardwareAcceleration).toHaveBeenCalledTimes(1)
+    expect(app.commandLine.appendSwitch).toHaveBeenCalledWith('disable-gpu')
+    expect(app.commandLine.appendSwitch).not.toHaveBeenCalledWith(
+      'enable-features',
+      expect.any(String)
+    )
+  })
+
   it('preserves existing enable-features switches', async () => {
     const { app } = await import('electron')
     const { enableMainProcessGpuFeatures } = await import('./configure-process')
 
+    delete process.env.ORCA_E2E_USER_DATA_DIR
     vi.mocked(app.commandLine.appendSwitch).mockClear()
     vi.mocked(app.commandLine.getSwitchValue).mockReturnValue('ExistingFeature')
     enableMainProcessGpuFeatures()

--- a/src/main/startup/configure-process.ts
+++ b/src/main/startup/configure-process.ts
@@ -170,6 +170,16 @@ export function installDevParentWatchdog(isDev: boolean): void {
 }
 
 export function enableMainProcessGpuFeatures(): void {
+  if (process.platform === 'linux' && getMainE2EConfig().userDataDir) {
+    // Why: Ubuntu/Xvfb runners can fail Electron startup with
+    // "GPU process isn't usable" before Playwright sees the first window.
+    // E2E coverage does not depend on GPU compositing, so keep CI on the
+    // software path instead of retrying around a crashed app process.
+    app.disableHardwareAcceleration()
+    app.commandLine.appendSwitch('disable-gpu')
+    return
+  }
+
   const existingFeatures = app.commandLine.getSwitchValue('enable-features')
   const features = [
     // Why: mirror VS Code's conservative Electron GPU-channel startup flags

--- a/src/main/updater-events.ts
+++ b/src/main/updater-events.ts
@@ -1,5 +1,4 @@
 import { app, autoUpdater as nativeUpdater } from 'electron'
-import { autoUpdater } from 'electron-updater'
 import type { UpdateStatus } from '../shared/types'
 import {
   consumeMacInstallGuardBypass,
@@ -11,11 +10,13 @@ import {
 } from './updater-mac-install'
 import { compareVersions } from './updater-fallback'
 import { fetchChangelog } from './updater-changelog'
+import type { ElectronAutoUpdater } from './electron-updater-loader'
 
 const AUTO_UPDATE_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000
 const AUTO_UPDATE_RETRY_INTERVAL_MS = 60 * 60 * 1000
 
 type UpdaterHandlerContext = {
+  autoUpdater: ElectronAutoUpdater
   clearBackgroundCheckLaunchPending: () => void
   clearAvailableUpdateContext: () => void
   consumeMissingManifestPrereleaseFallbackResult: () => { userInitiated: boolean } | null
@@ -45,6 +46,7 @@ type UpdaterHandlerContext = {
 }
 
 export function registerAutoUpdaterHandlers({
+  autoUpdater,
   clearBackgroundCheckLaunchPending,
   clearAvailableUpdateContext,
   consumeMissingManifestPrereleaseFallbackResult,

--- a/src/main/updater.check-failure.test.ts
+++ b/src/main/updater.check-failure.test.ts
@@ -79,6 +79,10 @@ vi.mock('electron-updater', () => ({
   autoUpdater: autoUpdaterMock
 }))
 
+vi.mock('./electron-updater-loader', () => ({
+  loadElectronAutoUpdater: () => autoUpdaterMock
+}))
+
 vi.mock('@electron-toolkit/utils', () => ({
   is: isMock
 }))

--- a/src/main/updater.mac-install.test.ts
+++ b/src/main/updater.mac-install.test.ts
@@ -96,6 +96,10 @@ vi.mock('electron-updater', () => ({
   autoUpdater: autoUpdaterMock
 }))
 
+vi.mock('./electron-updater-loader', () => ({
+  loadElectronAutoUpdater: () => autoUpdaterMock
+}))
+
 vi.mock('@electron-toolkit/utils', () => ({
   is: isMock
 }))

--- a/src/main/updater.test.ts
+++ b/src/main/updater.test.ts
@@ -48,6 +48,7 @@ const {
     autoUpdaterMock.downloadUpdate.mockReset()
     autoUpdaterMock.quitAndInstall.mockReset()
     autoUpdaterMock.setFeedURL.mockClear()
+    autoUpdaterMock.updateConfigPath = undefined
     autoUpdaterMock.allowPrerelease = false
     delete (autoUpdaterMock as Record<string, unknown>).verifyUpdateCodeSignature
   }
@@ -61,6 +62,7 @@ const {
     downloadUpdate: vi.fn(),
     quitAndInstall: vi.fn(),
     setFeedURL: vi.fn(),
+    updateConfigPath: undefined as string | undefined,
     emit,
     reset
   }
@@ -96,6 +98,10 @@ vi.mock('electron', () => ({
 
 vi.mock('electron-updater', () => ({
   autoUpdater: autoUpdaterMock
+}))
+
+vi.mock('./electron-updater-loader', () => ({
+  loadElectronAutoUpdater: () => autoUpdaterMock
 }))
 
 vi.mock('@electron-toolkit/utils', () => ({
@@ -149,6 +155,22 @@ describe('updater', () => {
     fetchNewerReleaseTagsMock.mockReset().mockResolvedValue([])
     vi.unstubAllGlobals()
     vi.useRealTimers()
+  })
+
+  it('does not load or configure electron-updater during dev setup', async () => {
+    isMock.dev = true
+    const mainWindow = { webContents: { send: vi.fn() } }
+
+    const { setupAutoUpdater } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never)
+
+    // Why: E2E launches use dev mode and Electron's direct script runner, whose
+    // default app version makes electron-updater throw during module load.
+    expect(autoUpdaterMock.updateConfigPath).toBeUndefined()
+    expect(autoUpdaterMock.setFeedURL).not.toHaveBeenCalled()
+    expect(autoUpdaterMock.checkForUpdates).not.toHaveBeenCalled()
+    expect(powerMonitorOnMock).not.toHaveBeenCalled()
   })
 
   it('deduplicates identical check errors from the event and rejected promise', async () => {

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -1,11 +1,10 @@
 /* eslint-disable max-lines */
-import path from 'node:path'
 import { app, BrowserWindow, powerMonitor } from 'electron'
-import { autoUpdater } from 'electron-updater'
 import type { NsisUpdater } from 'electron-updater'
 import { is } from '@electron-toolkit/utils'
 import type { UpdateStatus } from '../shared/types'
 import { killAllPty } from './ipc/pty'
+import { loadElectronAutoUpdater, type ElectronAutoUpdater } from './electron-updater-loader'
 import {
   beginMacUpdateDownload,
   deferMacQuitUntilInstallerReady,
@@ -81,6 +80,14 @@ let downloadInFlight = false
 /** Guards against the macOS `activate` handler re-opening the old version
  *  while Squirrel's ShipIt is replacing the .app bundle. */
 let quittingForUpdate = false
+let autoUpdater: ElectronAutoUpdater | null = null
+
+function getAutoUpdater(): ElectronAutoUpdater {
+  if (!autoUpdater) {
+    autoUpdater = loadElectronAutoUpdater()
+  }
+  return autoUpdater
+}
 
 function clearAvailableUpdateContext(): void {
   availableVersion = null
@@ -226,7 +233,7 @@ function performQuitAndInstall(): void {
     win.removeAllListeners('close')
   }
 
-  autoUpdater.quitAndInstall(false, true)
+  getAutoUpdater().quitAndInstall(false, true)
 }
 
 async function sendCheckFailureStatus(
@@ -419,6 +426,7 @@ function markMissingManifestPrereleaseFallbackPromiseHandled(message: string): v
 }
 
 async function pinDefaultReleaseFeed(): Promise<void> {
+  const autoUpdater = getAutoUpdater()
   // Why: the /releases/latest/download/ redirect can move between the update
   // check and the later manual download click. Pinning to the concrete tag
   // keeps the manifest and ZIP asset on the same release.
@@ -497,6 +505,7 @@ function retryPrereleaseFallbackAfterMissingManifest(
   console.info(
     `[updater] prerelease manifest missing for ${primaryTag}; retrying once against ${url}`
   )
+  const autoUpdater = getAutoUpdater()
   autoUpdater.setFeedURL({ provider: 'generic', url })
   userInitiatedCheck = Boolean(userInitiated)
   backgroundCheckLaunchPending = !userInitiated
@@ -537,6 +546,7 @@ function runBackgroundUpdateCheck(
   backgroundCheckLaunchPending = true
   // Don't send 'checking' here — the 'checking-for-update' event handler does it,
   // and sending it from both places causes duplicate notifications (issue #35).
+  const autoUpdater = getAutoUpdater()
   const launch = (): Promise<unknown> => autoUpdater.checkForUpdates()
   const run = pinDefaultReleaseFeed().then(launch)
   void Promise.resolve(run).catch((err) => {
@@ -557,7 +567,7 @@ function enableIncludePrerelease(): void {
   // accept a prerelease manifest for users who intentionally Shift-clicked.
   // We keep using the manifest-probed generic feed instead of the native
   // GitHub provider because cancelled RC releases can appear without assets.
-  autoUpdater.allowPrerelease = true
+  getAutoUpdater().allowPrerelease = true
   includePrereleaseActive = true
 }
 
@@ -581,6 +591,7 @@ export function checkForUpdatesFromMenu(options?: { includePrerelease?: boolean 
   // Don't send 'checking' here — the 'checking-for-update' event handler does it,
   // and sending it from both places causes duplicate notifications (issue #35).
 
+  const autoUpdater = getAutoUpdater()
   const launch = (): Promise<unknown> => autoUpdater.checkForUpdates()
   const run = pinDefaultReleaseFeed().then(launch)
   void Promise.resolve(run).catch((err) => {
@@ -708,14 +719,10 @@ export function setupAutoUpdater(
     return
   }
   if (is.dev) {
-    // Why: dev-app-update.yml lives at config/dev-app-update.yml (not repo root)
-    // so the root directory stays short. electron-updater only reads it when
-    // the dev-mode early-return below is temporarily disabled to exercise the
-    // update flow locally — point it at the new path up-front so that works.
-    autoUpdater.updateConfigPath = path.join(app.getAppPath(), 'config', 'dev-app-update.yml')
     return
   }
 
+  const autoUpdater = getAutoUpdater()
   autoUpdater.autoDownload = false
   autoUpdater.autoInstallOnAppQuit = true
 
@@ -769,6 +776,7 @@ export function setupAutoUpdater(
   autoUpdaterInitialized = true
 
   registerAutoUpdaterHandlers({
+    autoUpdater,
     clearAvailableUpdateContext,
     consumeMissingManifestPrereleaseFallbackResult,
     getMissingManifestPrereleaseFallbackUserInitiated,
@@ -849,8 +857,10 @@ export function downloadUpdate(): void {
   }
   downloadInFlight = true
   beginMacUpdateDownload()
-  autoUpdater.downloadUpdate().catch((err) => {
-    downloadInFlight = false
-    sendErrorStatus(String(err?.message ?? err))
-  })
+  getAutoUpdater()
+    .downloadUpdate()
+    .catch((err) => {
+      downloadInFlight = false
+      sendErrorStatus(String(err?.message ?? err))
+    })
 }

--- a/tests/e2e/droid-notification.spec.ts
+++ b/tests/e2e/droid-notification.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from './helpers/orca-app'
-import type { ElectronApplication } from '@stablyai/playwright-test'
+import type { ElectronApplication, Page } from '@stablyai/playwright-test'
+import { getRendererTitleLog, installRendererTitleLog } from './helpers/terminal-title-log'
 import {
   sendToTerminal,
   waitForActivePanePtyId,
@@ -13,11 +14,7 @@ type NotificationDispatch = {
   terminalTitle?: string
 }
 
-async function emitOscTitle(
-  page: Parameters<typeof sendToTerminal>[0],
-  ptyId: string,
-  title: string
-) {
+async function emitOscTitle(page: Page, ptyId: string, title: string) {
   await sendToTerminal(page, ptyId, `printf '\\033]0;${title}\\007'\r`)
 }
 
@@ -61,6 +58,7 @@ test.describe('Droid notifications', () => {
     // Why: contextBridge freezes window.api, so notification invokes must be
     // observed in Electron's main process rather than monkey-patched renderer-side.
     await installMainProcessNotificationDispatchSpy(electronApp)
+    await installRendererTitleLog(orcaPage)
 
     const ptyId = await waitForActivePanePtyId(orcaPage)
     const marker = `__DROID_NOTIFY_READY_${Date.now()}__`
@@ -72,16 +70,7 @@ test.describe('Droid notifications', () => {
 
     await expect
       .poll(
-        async () =>
-          orcaPage.evaluate(() => {
-            const store = window.__store
-            if (!store) {
-              return false
-            }
-            return Object.values(store.getState().tabsByWorktree ?? {})
-              .flat()
-              .some((tab) => tab.title === 'Factory Droid needs input')
-          }),
+        async () => (await getRendererTitleLog(orcaPage)).includes('Factory Droid needs input'),
         {
           timeout: 10_000,
           message: 'Factory Droid marker title did not land'

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -38,7 +38,6 @@ export default function globalSetup(): void {
     })
     console.log('[e2e] Build complete.')
   }
-
   if (process.env.ORCA_E2E_SSH_LOCALHOST === '1') {
     // Why: the localhost SSH spec deploys Orca's relay from out/relay. The
     // normal Electron E2E build does not produce that bundle, so build it only

--- a/tests/e2e/helpers/orca-app.ts
+++ b/tests/e2e/helpers/orca-app.ts
@@ -70,6 +70,24 @@ function shouldLaunchHeadful(testInfo: TestInfo): boolean {
   return testInfo.project.metadata.orcaHeadful === true
 }
 
+function forwardElectronProcessLogs(app: ElectronApplication, testInfo: TestInfo): void {
+  if (process.env.ORCA_E2E_FORWARD_APP_LOGS !== '1') {
+    return
+  }
+
+  const child = app.process()
+  const prefix = `[electron:${testInfo.title}]`
+  child.stdout?.on('data', (chunk: Buffer) => {
+    console.log(`${prefix} stdout: ${chunk.toString().trimEnd()}`)
+  })
+  child.stderr?.on('data', (chunk: Buffer) => {
+    console.error(`${prefix} stderr: ${chunk.toString().trimEnd()}`)
+  })
+  child.on('exit', (code, signal) => {
+    console.log(`${prefix} exit: code=${code ?? 'null'} signal=${signal ?? 'null'}`)
+  })
+}
+
 function isValidGitRepo(repoPath: string): boolean {
   if (!repoPath || !existsSync(repoPath)) {
     return false
@@ -227,6 +245,7 @@ export const test = base.extend<OrcaTestFixtures, OrcaWorkerFixtures>({
         ...(headful ? { ORCA_E2E_HEADFUL: '1' } : { ORCA_E2E_HEADLESS: '1' })
       }
     })
+    forwardElectronProcessLogs(app, testInfo)
     await provideFixture(app)
     // Why: the Playwright close promise can settle before all Electron and PTY
     // descendants are gone in CI; worker teardown then hangs on open handles.

--- a/tests/e2e/helpers/terminal-title-log.ts
+++ b/tests/e2e/helpers/terminal-title-log.ts
@@ -1,0 +1,45 @@
+import type { Page } from '@stablyai/playwright-test'
+
+export async function installRendererTitleLog(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const w = window as unknown as {
+      __orcaE2eTitleLog?: string[]
+      __orcaE2eTitleUnsubscribe?: () => void
+    }
+    const store = window.__store
+    if (!store) {
+      throw new Error('window.__store is not available')
+    }
+
+    w.__orcaE2eTitleUnsubscribe?.()
+    w.__orcaE2eTitleLog = []
+
+    const recordTitles = (): void => {
+      const state = store.getState()
+      const paneTitles = Object.values(state.runtimePaneTitlesByTabId ?? {}).flatMap((byPane) =>
+        Object.values(byPane ?? {})
+      )
+      const tabTitles = Object.values(state.tabsByWorktree ?? {})
+        .flat()
+        .map((tab) => tab.title)
+
+      for (const title of [...paneTitles, ...tabTitles]) {
+        if (typeof title === 'string') {
+          w.__orcaE2eTitleLog!.push(title)
+        }
+      }
+    }
+
+    // Why: shell prompts can immediately overwrite OSC titles. Logging every
+    // renderer title state lets tests assert transient title frames landed.
+    recordTitles()
+    w.__orcaE2eTitleUnsubscribe = store.subscribe(recordTitles)
+  })
+}
+
+export async function getRendererTitleLog(page: Page): Promise<string[]> {
+  return page.evaluate(() => {
+    const w = window as unknown as { __orcaE2eTitleLog?: string[] }
+    return w.__orcaE2eTitleLog ?? []
+  })
+}

--- a/tests/e2e/source-control-create-pr.spec.ts
+++ b/tests/e2e/source-control-create-pr.spec.ts
@@ -21,7 +21,7 @@ async function openSourceControl(page: Page): Promise<void> {
     state?.setRightSidebarTab('source-control')
   })
   await expect(page.getByRole('button', { name: /Source Control/ })).toBeVisible()
-  await expect(page.getByLabel('Commit message')).toBeVisible()
+  await expect(page.getByRole('textbox', { name: 'Commit message' })).toBeVisible()
 }
 
 async function forceCreatePREligibleStatus(

--- a/tests/e2e/terminal-attention.spec.ts
+++ b/tests/e2e/terminal-attention.spec.ts
@@ -12,6 +12,7 @@ import {
   waitForActiveWorktree,
   waitForSessionReady
 } from './helpers/store'
+import { getRendererTitleLog, installRendererTitleLog } from './helpers/terminal-title-log'
 import { POST_REPLAY_MODE_RESET } from '../../src/renderer/src/components/terminal-pane/layout-serialization'
 
 test.describe.configure({ mode: 'serial' })
@@ -177,6 +178,7 @@ test.describe('Terminal attention', () => {
     }
     const activePtyId = await waitForActivePanePtyId(orcaPage)
     await proveShellReadyWithSingleWrite(orcaPage, activePtyId)
+    await installRendererTitleLog(orcaPage)
 
     // Emit the BEL, then a deterministic OSC title marker. When the marker
     // title lands, all prior PTY bytes (including the BEL) have been
@@ -189,22 +191,10 @@ test.describe('Terminal attention', () => {
     await execInTerminal(orcaPage, activePtyId, `printf '\\033]0;${MARKER_TITLE}\\007'`)
 
     await expect
-      .poll(
-        async () =>
-          orcaPage.evaluate((want) => {
-            const store = window.__store
-            if (!store) {
-              return false
-            }
-            return Object.values(store.getState().tabsByWorktree ?? {})
-              .flat()
-              .some((tab) => tab.title === want)
-          }, MARKER_TITLE),
-        {
-          timeout: 10_000,
-          message: 'Marker title did not land — byte stream may not have been flushed'
-        }
-      )
+      .poll(async () => (await getRendererTitleLog(orcaPage)).includes(MARKER_TITLE), {
+        timeout: 10_000,
+        message: 'Marker title did not land — byte stream may not have been flushed'
+      })
       .toBe(true)
 
     // The focused tab is now unread — the bell persists until the user

--- a/tests/e2e/usage-overview.spec.ts
+++ b/tests/e2e/usage-overview.spec.ts
@@ -11,13 +11,13 @@ test.describe('usage overview', () => {
   }) => {
     await orcaPage.evaluate(() => {
       const state = window.__store!.getState()
-      state.openSettingsTarget({ pane: 'stats' })
       state.openSettingsPage()
     })
 
     await expect
       .poll(async () => getStoreState<string>(orcaPage, 'activeView'), { timeout: 5_000 })
       .toBe('settings')
+    await orcaPage.getByRole('button', { name: 'Stats & Usage' }).click()
     await expect(orcaPage.getByRole('heading', { name: 'Usage Analytics' })).toBeVisible()
     const providerDropdown = orcaPage.getByTestId('usage-provider-select')
     await expect(providerDropdown).toHaveAttribute(


### PR DESCRIPTION
## Summary

This PR brings the Electron E2E workflow back under the CI wall-clock cap by sharding the existing Playwright suite across five GitHub-hosted Linux runners while preserving the current per-runner worker count. It also includes the startup/reliability fixes found during review so the sharded Linux jobs can reuse a single build artifact instead of doing five competing Electron builds.

The release-blocking problem was elapsed CI time. The referenced release run entered `Run E2E tests` at `2026-05-16T04:01:33Z` and was still running past the 30-minute cap. Increasing Playwright workers on one runner is risky for this suite because each worker launches isolated Electron app instances. This PR adds horizontal CI parallelism instead.

## What Changed

### CI workflow

- Added a `build e2e app` prerequisite job in `.github/workflows/e2e.yml`.
- The build job mirrors the Linux native-toolchain and `node-gyp` setup from the existing jobs, installs dependencies, runs `npx electron-vite build --mode e2e`, and uploads `out/` as the short-lived `e2e-build-out` artifact.
- Converted the E2E job to a 5-way Playwright shard matrix:
  - `1/5` (`e2e 1-of-5`)
  - `2/5` (`e2e 2-of-5`)
  - `3/5` (`e2e 3-of-5`)
  - `4/5` (`e2e 4-of-5`)
  - `5/5` (`e2e 5-of-5`)
- Each shard downloads the shared build artifact and runs with `SKIP_BUILD=1`, so Playwright global setup reuses the prebuilt app instead of launching five concurrent `electron-vite` builds.
- Kept the existing Playwright `workers: 4` setting. The PR adds runner-level parallelism without increasing per-runner Electron concurrency.
- Kept `fail-fast: false` so one shard failure does not hide failures from the other shards.
- Added shard-specific trace artifact names such as `playwright-traces-3-of-5`.
- Set build timeout to 10 minutes and shard timeout to 20 minutes.
- Runs shards under `xvfb-run` with `ORCA_E2E_FORWARD_APP_LOGS=1` so Electron stdout/stderr is visible when the app launches but fails before `firstWindow()`.

### E2E startup hardening

- Added `src/main/electron-updater-loader.ts` and moved `electron-updater` behind the packaged-update guards.
- Passed the loaded updater instance into `registerAutoUpdaterHandlers()` so `src/main/updater-events.ts` no longer imports `electron-updater` at module load.
- This fixes the CI startup failure where direct Electron E2E launches reported app version `0.0`; `electron-updater` validates `app.getVersion()` while loading, before the prior dev-mode guard could return.
- Added regression coverage proving dev/E2E setup does not configure or load the updater path.
- Disabled the Electron GPU process only for Linux E2E launches, keyed off the existing `ORCA_E2E_USER_DATA_DIR` signal. Ubuntu/Xvfb runners were hitting `GPU process isn't usable`; E2E coverage does not depend on GPU compositing.
- Added unit coverage for the Linux E2E GPU branch.
- Removed the attempted CI `ORCA_E2E_FORCE_HEADFUL=1` override after logs showed it was not the root fix and could expose extra Xvfb/GPU instability.

### E2E reliability fixes

- Added `tests/e2e/helpers/terminal-title-log.ts` to observe transient terminal title changes from the renderer.
- Updated Droid notification and terminal attention specs to assert against the observed title log instead of only polling the current active tab title. This removes a race where the expected state appears briefly and transitions again before polling samples it.
- Updated the Source Control create-PR test to target the `Commit message` textbox by accessible role/name instead of a brittle ambiguous selector.
- Updated the usage overview test to open `Stats & Usage` through the visible Settings navigation item, matching the exposed UI path.

## Why This Approach

- It targets the CI timeout directly by splitting the 91-test Electron suite across five runners.
- It avoids increasing Playwright workers on a single runner, where Electron app concurrency can exhaust memory.
- It avoids the first naive shard design's hidden cost: each shard would have run Playwright global setup and performed its own Electron build. Building once and downloading `out/` keeps setup deterministic and avoids five parallel builds competing for CPU/RAM.
- It preserves full test coverage. No specs are skipped or removed.
- It keeps debugging practical because each shard uploads its own trace bundle on failure and app-process startup failures now show stderr in the job log.
- It keeps E2E-only startup hardening scoped behind existing E2E signals, so packaged user launches keep normal updater and GPU behavior.

## Validation

Local validation on the final commit:

- `pnpm exec oxlint src/main/updater.ts src/main/updater-events.ts src/main/electron-updater-loader.ts src/main/updater.test.ts src/main/updater.check-failure.test.ts src/main/updater.mac-install.test.ts src/main/startup/configure-process.ts src/main/startup/configure-process.test.ts tests/e2e/global-setup.ts tests/e2e/helpers/orca-app.ts`
- `pnpm exec vitest run src/main/updater.test.ts src/main/updater.check-failure.test.ts src/main/updater.mac-install.test.ts src/main/startup/configure-process.test.ts` passed: 58 tests.
- `pnpm typecheck`
- `npx electron-vite build --mode e2e`
- `git diff --check`
- `.github/workflows/e2e.yml` parsed successfully as YAML.
- `CI=1 SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run test:e2e -- tests/e2e/usage-overview.spec.ts --retries=0` passed: 1 Electron smoke test.

Earlier local shard validation for the same 5-way split:

| Shard | Local result |
| --- | --- |
| `1/5` | 19 passed in 30s |
| `2/5` | 17 passed, 1 skipped in 25s |
| `3/5` | 20 passed in 43s |
| `4/5` | 16 passed in 53s |
| `5/5` | 18 passed in 25s |

Targeted affected-spec validation also passed: 5 tests passed in 16.0s.

## CI Review Notes

- The initial sharding-only version passed `verify`, but each shard built Electron separately, which defeated the wall-clock goal.
- The shared-build version confirmed shards downloaded `e2e-build-out` and skipped local builds, but Electron startup timed out before `firstWindow()`.
- App-log forwarding exposed two Linux CI blockers: `electron-updater` validating direct-launch version `0.0`, and Ubuntu/Xvfb GPU-process crashes.
- The final pushed version addresses those blockers by lazy-loading `electron-updater` only after packaged-update guards and disabling GPU only for Linux E2E runs.

## Risk and Follow-Up Notes

- This increases total GitHub Actions runner usage because shards run in parallel, but it reduces wall-clock time and keeps each runner at the existing worker cap.
- The workflow now depends on the `e2e-build-out` artifact between jobs. `if-no-files-found: error` makes missing build output fail in the build job instead of surfacing later as confusing shard failures.
- The shard layout uses Playwright's built-in sharding, so future spec additions are automatically distributed without maintaining manual test lists.