### PR TITLE
Recover expired SSH reattach sessions

### DIFF
--- a/src/main/providers/ssh-pty-provider.ts
+++ b/src/main/providers/ssh-pty-provider.ts
@@ -95,9 +95,8 @@ export class SshPtyProvider implements IPtyProvider {
         }
       } catch (err) {
         // Why: pty.attach fails when the relay grace window has elapsed.
-        // Do not silently replace the saved tab with a fresh shell; the
-        // renderer should show an expired-session state so users know the
-        // original remote process is gone.
+        // Surface the exact condition so the renderer can clear the stale
+        // binding before replacing the dead relay PTY in the same pane.
         console.warn(`[ssh-pty] pty.attach FAILED for ${opts.sessionId}:`, err)
         if (isSshPtyNotFoundError(err)) {
           throw new Error(`${SSH_SESSION_EXPIRED_ERROR}: ${opts.sessionId}`)

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -724,13 +724,22 @@ describe('connectPanePty', () => {
     expect(deps.updateTabPtyId).toHaveBeenCalledWith('tab-1', 'fresh-pty')
   })
 
-  it('shows a terminal error instead of fresh-spawning when a non-deferred SSH reattach reports expired via onError', async () => {
+  it('spawns a fresh PTY when a non-deferred SSH reattach reports expired via onError', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport()
-    transport.connect.mockImplementation(async (opts: { callbacks?: ConnectCallbacks }) => {
-      opts.callbacks?.onError?.('SSH_SESSION_EXPIRED: restored-session')
-      return undefined
-    })
+    transport.connect.mockImplementation(
+      async (opts: { sessionId?: string; callbacks?: ConnectCallbacks }) => {
+        if (opts.sessionId) {
+          opts.callbacks?.onError?.('SSH_SESSION_EXPIRED: restored-session')
+          return undefined
+        }
+        const onPtySpawn = createdTransportOptions[0]?.onPtySpawn as
+          | ((ptyId: string) => void)
+          | undefined
+        onPtySpawn?.('fresh-ssh-pty')
+        return 'fresh-ssh-pty'
+      }
+    )
     transportFactoryQueue.push(transport)
     mockStoreState = {
       ...mockStoreState,
@@ -748,13 +757,12 @@ describe('connectPanePty', () => {
     connectPanePty(pane as never, manager as never, deps as never)
     await flushAsyncTicks(10)
 
-    expect(deps.onPtyErrorRef.current).toHaveBeenCalledWith(
-      2,
-      'Previous SSH session expired. Start a new terminal to continue.'
-    )
-    expect(transport.connect).toHaveBeenCalledTimes(1)
+    expect(deps.onPtyErrorRef.current).not.toHaveBeenCalled()
+    expect(transport.connect).toHaveBeenCalledTimes(2)
     expect(deps.syncPanePtyLayoutBinding).toHaveBeenCalledWith(2, null)
     expect(deps.clearTabPtyId).toHaveBeenCalledWith('tab-1', 'restored-session')
+    expect(deps.syncPanePtyLayoutBinding).toHaveBeenCalledWith(2, 'fresh-ssh-pty')
+    expect(deps.updateTabPtyId).toHaveBeenCalledWith('tab-1', 'fresh-ssh-pty')
   })
 
   it('resets focus reporting after daemon snapshot replay without applying the full mode reset', async () => {
@@ -1359,12 +1367,19 @@ describe('connectPanePty', () => {
     expect(mockStoreState.removeDeferredSshReconnectTarget).not.toHaveBeenCalled()
   })
 
-  it('shows a terminal error instead of fresh-spawning when an SSH session expired', async () => {
+  it('spawns a fresh PTY when a deferred SSH session expired', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport()
     transport.connect.mockImplementation(async (opts) => {
-      opts.callbacks?.onError?.('SSH_SESSION_EXPIRED: expired-session')
-      return undefined
+      if (opts.sessionId) {
+        opts.callbacks?.onError?.('SSH_SESSION_EXPIRED: expired-session')
+        return undefined
+      }
+      const onPtySpawn = createdTransportOptions[0]?.onPtySpawn as
+        | ((ptyId: string) => void)
+        | undefined
+      onPtySpawn?.('fresh-ssh-pty')
+      return 'fresh-ssh-pty'
     })
     transportFactoryQueue.push(transport)
 
@@ -1378,20 +1393,18 @@ describe('connectPanePty', () => {
 
     const pane = createPane(1)
     const manager = createManager(1)
-    const deps = createDeps({
-      restoredLeafId: LEAF_1,
-      restoredPtyIdByLeafId: { [LEAF_1]: 'leaf-session' }
-    })
+    const deps = createDeps()
 
     connectPanePty(pane as never, manager as never, deps as never)
     await flushAsyncTicks(20)
 
-    expect(deps.onPtyErrorRef.current).toHaveBeenCalledWith(
-      1,
-      'Previous SSH session expired. Start a new terminal to continue.'
-    )
+    expect(deps.onPtyErrorRef.current).not.toHaveBeenCalled()
     expect(toastInfo).not.toHaveBeenCalled()
-    expect(transport.connect).toHaveBeenCalledTimes(1)
+    expect(transport.connect).toHaveBeenCalledTimes(2)
+    expect(deps.syncPanePtyLayoutBinding).toHaveBeenCalledWith(1, null)
+    expect(deps.clearTabPtyId).toHaveBeenCalledWith('tab-1', 'expired-session')
+    expect(deps.syncPanePtyLayoutBinding).toHaveBeenCalledWith(1, 'fresh-ssh-pty')
+    expect(deps.updateTabPtyId).toHaveBeenCalledWith('tab-1', 'fresh-ssh-pty')
   })
 
   // Why: the working→idle transition fires an 'agent-task-complete' OS

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -59,10 +59,6 @@ function isSshSessionExpiredError(err: unknown): boolean {
   return (err instanceof Error ? err.message : String(err)).includes(SSH_SESSION_EXPIRED_ERROR)
 }
 
-function formatSshSessionExpiredMessage(): string {
-  return 'Previous SSH session expired. Start a new terminal to continue.'
-}
-
 function isRemoteRuntimePtyId(ptyId: string | null | undefined): boolean {
   return typeof ptyId === 'string' && ptyId.startsWith(REMOTE_PTY_ID_PREFIX)
 }
@@ -739,11 +735,14 @@ export function connectPanePty(
         return
       }
       if (connectResult?.sessionExpired) {
-        reportError(formatSshSessionExpiredMessage())
         deps.syncPanePtyLayoutBinding(pane.id, null)
         if (staleSessionId) {
           deps.clearTabPtyId(deps.tabId, staleSessionId)
         }
+        // Why: SSH sleep/reconnect can invalidate the relay-held PTY while
+        // leaving the tab mounted. Replace the dead lease in-place instead of
+        // stranding the pane behind a stale expired-session overlay.
+        startFreshSpawn()
         return
       }
       bindPanePtyId(pane.id, ptyId, deps.tabId)
@@ -1023,13 +1022,16 @@ export function connectPanePty(
                     : 'undefined'
                 )
                 if (!result && expiredReattachError) {
-                  reportError(formatSshSessionExpiredMessage())
+                  if (disposed) {
+                    return
+                  }
                   deps.syncPanePtyLayoutBinding(pane.id, null)
                   deps.clearTabPtyId(deps.tabId, pendingSessionId)
                   const gen = await preSignalPromise
                   if (typeof gen === 'number') {
                     void window.api.pty.clearPendingPaneSerializer(cacheKey, gen).catch(() => {})
                   }
+                  startFreshSpawn()
                   return
                 }
                 handleReattachResult(result, pendingSessionId)
@@ -1050,9 +1052,9 @@ export function connectPanePty(
                   return
                 }
                 if (isSshSessionExpiredError(err)) {
-                  reportError(formatSshSessionExpiredMessage())
                   deps.syncPanePtyLayoutBinding(pane.id, null)
                   deps.clearTabPtyId(deps.tabId, pendingSessionId)
+                  startFreshSpawn()
                   return
                 }
                 startFreshSpawn()
@@ -1144,13 +1146,16 @@ export function connectPanePty(
       void Promise.resolve(reattachPromise)
         .then(async (result) => {
           if (!result && expiredReattachError) {
-            reportError(formatSshSessionExpiredMessage())
+            if (disposed) {
+              return
+            }
             deps.syncPanePtyLayoutBinding(pane.id, null)
             deps.clearTabPtyId(deps.tabId, deferredReattachSessionId)
             const gen = await preSignalPromise
             if (typeof gen === 'number') {
               void window.api.pty.clearPendingPaneSerializer(cacheKey, gen).catch(() => {})
             }
+            startFreshSpawn()
             return
           }
           handleReattachResult(result, deferredReattachSessionId)
@@ -1178,7 +1183,7 @@ export function connectPanePty(
           deps.syncPanePtyLayoutBinding(pane.id, null)
           deps.clearTabPtyId(deps.tabId, deferredReattachSessionId)
           if (connectionId && isSshSessionExpiredError(err)) {
-            reportError(formatSshSessionExpiredMessage())
+            startFreshSpawn()
             return
           }
           reportError(message)


### PR DESCRIPTION
## Summary
- replace expired SSH reattach sessions with a fresh PTY in the same pane
- clear stale pane/tab bindings before spawning the replacement session
- update SSH terminal connection tests for expired reattach recovery

## Verification
- pnpm typecheck
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts

Note: an earlier broad pnpm test invocation failed because local better-sqlite3 was built for Node module ABI 145 while this shell requires ABI 137; the focused renderer test passes.