### PR TITLE
Show deleting state on PR detail Delete Worktree button

### DIFF
--- a/src/renderer/src/components/right-sidebar/PRActions.tsx
+++ b/src/renderer/src/components/right-sidebar/PRActions.tsx
@@ -28,6 +28,9 @@ export default function PRActions({
 }): React.JSX.Element | null {
   const openModal = useAppStore((s) => s.openModal)
   const skipDeleteConfirm = useAppStore((s) => s.settings?.skipDeleteWorktreeConfirm ?? false)
+  const isDeletingWorktree = useAppStore(
+    (s) => s.deleteStateByWorktreeId[worktree.id]?.isDeleting ?? false
+  )
   const [merging, setMerging] = useState(false)
   const [mergeError, setMergeError] = useState<string | null>(null)
   const [mergeMenuOpen, setMergeMenuOpen] = useState(false)
@@ -174,11 +177,16 @@ export default function PRActions({
         type="button"
         variant="secondary"
         size="xs"
-        className="w-full cursor-pointer text-[11px]"
+        className="w-full cursor-pointer text-[11px] disabled:opacity-50 disabled:cursor-not-allowed"
         onClick={handleDeleteWorktree}
+        disabled={isDeletingWorktree}
       >
-        <Trash2 className="size-3.5" />
-        Delete Worktree
+        {isDeletingWorktree ? (
+          <LoaderCircle className="size-3.5 animate-spin" />
+        ) : (
+          <Trash2 className="size-3.5" />
+        )}
+        {isDeletingWorktree ? 'Deleting…' : 'Delete Worktree'}
       </Button>
     )
   }


### PR DESCRIPTION
## Summary
- Delete Worktree button on merged-PR detail panel now shows spinner + "Deleting…" while removal runs, matching Squash and merge button.
- Reads existing `deleteStateByWorktreeId[worktree.id].isDeleting` — same flag the Workspaces sidebar overlay uses.

<img width="360" height="128" alt="Screenshot 2026-05-16 at 2 15 24 AM" src="https://github.com/user-attachments/assets/7757048f-55d8-4401-af71-f63e666e3f42" />

Verified manually.

