### PR TITLE
Add beta badge to skills page

### DIFF
--- a/src/renderer/src/components/skills/SkillsPage.tsx
+++ b/src/renderer/src/components/skills/SkillsPage.tsx
@@ -209,7 +209,10 @@ export default function SkillsPage(): React.JSX.Element {
         <div className="flex min-w-0 flex-1 items-center gap-3">
           <BookOpen className="size-4 text-muted-foreground" />
           <div className="min-w-0">
-            <h1 className="truncate text-sm font-semibold">Skills</h1>
+            <div className="flex min-w-0 items-center gap-2">
+              <h1 className="truncate text-sm font-semibold">Skills</h1>
+              <Badge variant="secondary">Beta</Badge>
+            </div>
             <p className="truncate text-xs text-muted-foreground">
               {pluralize(skills.length, 'skill')} from {pluralize(activeSourceCount, 'source')}
             </p>


### PR DESCRIPTION
## Summary
- add a secondary Beta badge next to the Skills page title

## Tests
- pnpm exec oxlint src/renderer/src/components/skills/SkillsPage.tsx
- pnpm run typecheck:web