### PR TITLE
Keep workspace board open for sidebar menus

### DIFF
--- a/src/renderer/src/components/sidebar/SidebarFilter.tsx
+++ b/src/renderer/src/components/sidebar/SidebarFilter.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { Activity, Check, FolderPlus, GitBranch, ListFilter, Server } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { Button } from '@/components/ui/button'
@@ -22,7 +22,19 @@ import RepoDotLabel from '@/components/repo/RepoDotLabel'
 import { searchRepos } from '@/lib/repo-search'
 import { cn } from '@/lib/utils'
 
-const SidebarFilter = React.memo(function SidebarFilter() {
+type SidebarFilterProps = {
+  preserveWorkspaceBoardOpen?: boolean
+  tooltipSide?: 'top' | 'right' | 'bottom' | 'left'
+  contentSide?: 'top' | 'right' | 'bottom' | 'left'
+  onMenuOpenChange?: (open: boolean) => void
+}
+
+const SidebarFilter = React.memo(function SidebarFilter({
+  preserveWorkspaceBoardOpen = false,
+  tooltipSide = 'bottom',
+  contentSide = 'right',
+  onMenuOpenChange
+}: SidebarFilterProps) {
   const showActiveOnly = useAppStore((s) => s.showActiveOnly)
   const setShowActiveOnly = useAppStore((s) => s.setShowActiveOnly)
   const hideDefaultBranchWorkspace = useAppStore((s) => s.hideDefaultBranchWorkspace)
@@ -36,12 +48,22 @@ const SidebarFilter = React.memo(function SidebarFilter() {
   const [query, setQuery] = useState('')
   const [commandValue, setCommandValue] = useState('')
 
-  const handleOpenChange = useCallback((next: boolean) => {
-    setOpen(next)
-    if (!next) {
-      setQuery('')
+  const handleOpenChange = useCallback(
+    (next: boolean) => {
+      setOpen(next)
+      onMenuOpenChange?.(next)
+      if (!next) {
+        setQuery('')
+      }
+    },
+    [onMenuOpenChange]
+  )
+
+  useEffect(() => {
+    return () => {
+      onMenuOpenChange?.(false)
     }
-  }, [])
+  }, [onMenuOpenChange])
 
   const handleToggleRepo = useCallback(
     (repoId: string) => {
@@ -90,7 +112,7 @@ const SidebarFilter = React.memo(function SidebarFilter() {
   const clearRepos = useCallback(() => setFilterRepoIds([]), [setFilterRepoIds])
 
   return (
-    <DropdownMenu open={open} onOpenChange={handleOpenChange}>
+    <DropdownMenu modal={false} open={open} onOpenChange={handleOpenChange}>
       <Tooltip>
         <TooltipTrigger asChild>
           <DropdownMenuTrigger asChild>
@@ -102,6 +124,7 @@ const SidebarFilter = React.memo(function SidebarFilter() {
                 hasAnyFilter ? `Edit filters (${activeFilterCount} active)` : 'Filter workspaces'
               }
               className="relative text-muted-foreground"
+              data-workspace-board-preserve-open={preserveWorkspaceBoardOpen ? '' : undefined}
             >
               <ListFilter className="size-3.5" strokeWidth={2.25} />
               {hasAnyFilter && (
@@ -117,11 +140,17 @@ const SidebarFilter = React.memo(function SidebarFilter() {
             </Button>
           </DropdownMenuTrigger>
         </TooltipTrigger>
-        <TooltipContent side="bottom" sideOffset={6}>
+        <TooltipContent side={tooltipSide} sideOffset={6}>
           {hasAnyFilter ? 'Edit filters' : 'Filter workspaces'}
         </TooltipContent>
       </Tooltip>
-      <DropdownMenuContent side="right" align="start" sideOffset={8} className="w-72">
+      <DropdownMenuContent
+        side={contentSide}
+        align="start"
+        sideOffset={8}
+        className="w-72"
+        data-workspace-board-preserve-open={preserveWorkspaceBoardOpen ? '' : undefined}
+      >
         <DropdownMenuCheckboxItem
           checked={showActiveOnly}
           onCheckedChange={(checked) => setShowActiveOnly(Boolean(checked))}

--- a/src/renderer/src/components/sidebar/SidebarHeader.tsx
+++ b/src/renderer/src/components/sidebar/SidebarHeader.tsx
@@ -55,6 +55,7 @@ const newWorktreeShortcutLabel = isMac ? '⌘N' : 'Ctrl+N'
 
 const SidebarHeader = React.memo(function SidebarHeader() {
   const [workspaceBoardOpen, setWorkspaceBoardOpen] = useState(false)
+  const [workspaceBoardMenuOpen, setWorkspaceBoardMenuOpen] = useState(false)
   const openModal = useAppStore((s) => s.openModal)
   const repos = useAppStore((s) => s.repos)
   const canCreateWorktree = repos.some((repo) => isGitRepoKind(repo))
@@ -70,6 +71,9 @@ const SidebarHeader = React.memo(function SidebarHeader() {
 
   const handleWorkspaceBoardOpenChange = useCallback((open: boolean) => {
     setWorkspaceBoardOpen(open)
+    if (!open) {
+      setWorkspaceBoardMenuOpen(false)
+    }
   }, [])
 
   const handleWorkspaceBoardToggle = useCallback(() => {
@@ -85,6 +89,9 @@ const SidebarHeader = React.memo(function SidebarHeader() {
       if (event.key !== 'Escape') {
         return
       }
+      if (workspaceBoardMenuOpen) {
+        return
+      }
       event.preventDefault()
       setWorkspaceBoardOpen(false)
     }
@@ -93,7 +100,7 @@ const SidebarHeader = React.memo(function SidebarHeader() {
     // be outside the sheet when Escape should still dismiss it.
     document.addEventListener('keydown', handleKeyDown, true)
     return () => document.removeEventListener('keydown', handleKeyDown, true)
-  }, [workspaceBoardOpen])
+  }, [workspaceBoardMenuOpen, workspaceBoardOpen])
 
   return (
     <>
@@ -122,8 +129,8 @@ const SidebarHeader = React.memo(function SidebarHeader() {
           </Tooltip>
         </div>
         <div className="flex items-center gap-1.5 shrink-0">
-          <SidebarFilter />
-          <DropdownMenu>
+          <SidebarFilter preserveWorkspaceBoardOpen onMenuOpenChange={setWorkspaceBoardMenuOpen} />
+          <DropdownMenu modal={false} onOpenChange={setWorkspaceBoardMenuOpen}>
             <Tooltip>
               <TooltipTrigger asChild>
                 <DropdownMenuTrigger asChild>
@@ -132,6 +139,7 @@ const SidebarHeader = React.memo(function SidebarHeader() {
                     size="icon-xs"
                     className="text-muted-foreground"
                     aria-label="View options"
+                    data-workspace-board-preserve-open=""
                   >
                     <SlidersHorizontal className="size-3.5" strokeWidth={2.25} />
                   </Button>
@@ -141,7 +149,13 @@ const SidebarHeader = React.memo(function SidebarHeader() {
                 View options
               </TooltipContent>
             </Tooltip>
-            <DropdownMenuContent side="right" align="start" sideOffset={8} className="w-56 pb-2">
+            <DropdownMenuContent
+              side="right"
+              align="start"
+              sideOffset={8}
+              className="w-56 pb-2"
+              data-workspace-board-preserve-open=""
+            >
               <DropdownMenuLabel>Group by</DropdownMenuLabel>
               <div className="px-2 pt-0.5 pb-1">
                 <ToggleGroup
@@ -251,7 +265,9 @@ const SidebarHeader = React.memo(function SidebarHeader() {
       </div>
       <WorkspaceKanbanDrawer
         open={workspaceBoardOpen}
+        preserveOpenForMenu={workspaceBoardMenuOpen}
         onOpenChange={handleWorkspaceBoardOpenChange}
+        onMenuOpenChange={setWorkspaceBoardMenuOpen}
       />
     </>
   )

--- a/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React, { useCallback, useMemo, useRef, useState } from 'react'
 import { useAppStore } from '@/store'
 import { useAllWorktrees, useRepoMap } from '@/store/selectors'
 import { Sheet, SheetContent } from '@/components/ui/sheet'
@@ -14,21 +14,27 @@ import {
 import { useWorkspaceStatusDocumentDrop } from './use-workspace-status-drop'
 import { useWorkspaceKanbanAreaSelection } from './use-workspace-kanban-area-selection'
 import { useWorkspaceKanbanSelection } from './use-workspace-kanban-selection'
-import type { WorkspaceStatus, Worktree } from '../../../../shared/types'
+import {
+  isWorkspaceBoardKeepOpenTarget,
+  useWorkspaceKanbanOutsideDismiss
+} from './use-workspace-kanban-outside-dismiss'
+import { useVisibleWorkspaceKanbanWorktreeIds } from './use-visible-workspace-kanban-worktree-ids'
+import { groupWorkspaceKanbanWorktrees } from './workspace-kanban-worktree-groups'
+import type { WorkspaceStatus } from '../../../../shared/types'
 import { makeWorkspaceStatusId } from '../../../../shared/workspace-statuses'
 
 type WorkspaceKanbanDrawerProps = {
   open: boolean
+  preserveOpenForMenu: boolean
   onOpenChange: (open: boolean) => void
-}
-
-function sortBoardWorktrees(a: Worktree, b: Worktree): number {
-  return b.lastActivityAt - a.lastActivityAt || a.displayName.localeCompare(b.displayName)
+  onMenuOpenChange: (open: boolean) => void
 }
 
 export default function WorkspaceKanbanDrawer({
   open,
-  onOpenChange
+  preserveOpenForMenu,
+  onOpenChange,
+  onMenuOpenChange
 }: WorkspaceKanbanDrawerProps): React.JSX.Element {
   const allWorktrees = useAllWorktrees()
   const repoMap = useRepoMap()
@@ -48,21 +54,19 @@ export default function WorkspaceKanbanDrawer({
   const [dragOverStatus, setDragOverStatus] = useState<WorkspaceStatus | null>(null)
   const [pinDragOver, setPinDragOver] = useState(false)
 
+  const visibleWorktreeIdSet = useVisibleWorkspaceKanbanWorktreeIds({
+    allWorktrees,
+    activeWorktreeId,
+    repoMap
+  })
+
   const worktreesByStatus = useMemo(() => {
-    const grouped = new Map<WorkspaceStatus, Worktree[]>(
-      workspaceStatuses.map((status) => [status.id, []])
-    )
-    for (const worktree of allWorktrees) {
-      if (worktree.isArchived) {
-        continue
-      }
-      grouped.get(getWorkspaceStatus(worktree, workspaceStatuses))!.push(worktree)
-    }
-    for (const items of grouped.values()) {
-      items.sort((a, b) => Number(b.isPinned) - Number(a.isPinned) || sortBoardWorktrees(a, b))
-    }
-    return grouped
-  }, [allWorktrees, workspaceStatuses])
+    return groupWorkspaceKanbanWorktrees({
+      worktrees: allWorktrees,
+      visibleWorktreeIds: visibleWorktreeIdSet,
+      workspaceStatuses
+    })
+  }, [allWorktrees, visibleWorktreeIdSet, workspaceStatuses])
   const worktreeById = useMemo(
     () => new Map(allWorktrees.map((worktree) => [worktree.id, worktree])),
     [allWorktrees]
@@ -297,28 +301,7 @@ export default function WorkspaceKanbanDrawer({
     }
   )
 
-  useEffect(() => {
-    if (!open) {
-      return
-    }
-
-    const handlePointerDown = (event: PointerEvent): void => {
-      const content = boardRef.current?.closest<HTMLElement>('[data-slot="sheet-content"]')
-      if (!content) {
-        return
-      }
-      if (event.target instanceof Node && content.contains(event.target)) {
-        return
-      }
-      const rect = content.getBoundingClientRect()
-      if (event.clientX > rect.right && event.clientY >= rect.top && event.clientY <= rect.bottom) {
-        onOpenChange(false)
-      }
-    }
-
-    document.addEventListener('pointerdown', handlePointerDown, true)
-    return () => document.removeEventListener('pointerdown', handlePointerDown, true)
-  }, [onOpenChange, open])
+  useWorkspaceKanbanOutsideDismiss({ open, boardRef, preserveOpenForMenu, onOpenChange })
 
   const opacityPercent = Math.round(workspaceBoardOpacity * 100)
   const drawerLeft = sidebarOpen ? sidebarWidth : 0
@@ -350,7 +333,13 @@ export default function WorkspaceKanbanDrawer({
         onInteractOutside={(event) => {
           const originalEvent = event.detail.originalEvent
           const target = originalEvent.target
-          if (target instanceof Element && target.closest('[data-workspace-board-trigger]')) {
+          if (preserveOpenForMenu) {
+            // Why: the first outside click should close a board dropdown, not
+            // also dismiss the board that owns the dropdown.
+            event.preventDefault()
+            return
+          }
+          if (isWorkspaceBoardKeepOpenTarget(target)) {
             event.preventDefault()
             return
           }
@@ -373,6 +362,7 @@ export default function WorkspaceKanbanDrawer({
           onMoveStatus={handleMoveStatus}
           onRemoveStatus={handleRemoveStatus}
           onAddStatus={handleAddStatus}
+          onFilterMenuOpenChange={onMenuOpenChange}
         />
         <div
           ref={boardRef}

--- a/src/renderer/src/components/sidebar/WorkspaceKanbanDrawerHeader.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanDrawerHeader.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button'
 import { SheetClose, SheetDescription, SheetHeader, SheetTitle } from '@/components/ui/sheet'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import type { WorkspaceStatusDefinition } from '../../../../shared/types'
+import SidebarFilter from './SidebarFilter'
 import WorkspaceKanbanSettingsMenu from './WorkspaceKanbanSettingsMenu'
 
 type WorkspaceKanbanDrawerHeaderProps = {
@@ -19,6 +20,7 @@ type WorkspaceKanbanDrawerHeaderProps = {
   onMoveStatus: (statusId: string, direction: -1 | 1) => void
   onRemoveStatus: (statusId: string) => void
   onAddStatus: () => void
+  onFilterMenuOpenChange: (open: boolean) => void
 }
 
 export default function WorkspaceKanbanDrawerHeader({
@@ -33,13 +35,14 @@ export default function WorkspaceKanbanDrawerHeader({
   onChangeStatusIcon,
   onMoveStatus,
   onRemoveStatus,
-  onAddStatus
+  onAddStatus,
+  onFilterMenuOpenChange
 }: WorkspaceKanbanDrawerHeaderProps): React.JSX.Element {
   const BoardModeIcon = compact ? Rows3 : LayoutList
 
   return (
     <>
-      <SheetHeader className="border-b border-sidebar-border px-4 py-3 pr-24">
+      <SheetHeader className="border-b border-sidebar-border px-4 py-3 pr-32">
         <SheetTitle className="flex items-center gap-2 text-sm">
           <span>Workspace board</span>
           {selectedCount > 1 ? (
@@ -54,6 +57,12 @@ export default function WorkspaceKanbanDrawerHeader({
       </SheetHeader>
 
       <div className="absolute right-3 top-2.5 flex items-center gap-1">
+        <SidebarFilter
+          preserveWorkspaceBoardOpen
+          tooltipSide="top"
+          contentSide="bottom"
+          onMenuOpenChange={onFilterMenuOpenChange}
+        />
         <Tooltip>
           <TooltipTrigger asChild>
             <Button

--- a/src/renderer/src/components/sidebar/use-visible-workspace-kanban-worktree-ids.ts
+++ b/src/renderer/src/components/sidebar/use-visible-workspace-kanban-worktree-ids.ts
@@ -1,0 +1,55 @@
+import { useMemo } from 'react'
+import { useAppStore } from '@/store'
+import type { Repo, Worktree } from '../../../../shared/types'
+import { computeVisibleWorktreeIds } from './visible-worktrees'
+
+type UseVisibleWorkspaceKanbanWorktreeIdsParams = {
+  allWorktrees: readonly Worktree[]
+  activeWorktreeId: string | null
+  repoMap: Map<string, Repo>
+}
+
+export function useVisibleWorkspaceKanbanWorktreeIds({
+  allWorktrees,
+  activeWorktreeId,
+  repoMap
+}: UseVisibleWorkspaceKanbanWorktreeIdsParams): ReadonlySet<string> {
+  const worktreesByRepo = useAppStore((s) => s.worktreesByRepo)
+  const showActiveOnly = useAppStore((s) => s.showActiveOnly)
+  const hideDefaultBranchWorkspace = useAppStore((s) => s.hideDefaultBranchWorkspace)
+  const filterRepoIds = useAppStore((s) => s.filterRepoIds)
+  const tabsByWorktree = useAppStore((s) => (showActiveOnly ? s.tabsByWorktree : null))
+  const ptyIdsByTabId = useAppStore((s) => (showActiveOnly ? s.ptyIdsByTabId : null))
+  const browserTabsByWorktree = useAppStore((s) =>
+    showActiveOnly ? s.browserTabsByWorktree : null
+  )
+
+  return useMemo(() => {
+    // Why: the board has its own status ordering, but visibility must match
+    // the sidebar filters exactly so hidden workspaces do not reappear here.
+    const sortedIds = allWorktrees.map((worktree) => worktree.id)
+    return new Set(
+      computeVisibleWorktreeIds(worktreesByRepo, sortedIds, {
+        filterRepoIds,
+        showActiveOnly,
+        tabsByWorktree,
+        ptyIdsByTabId,
+        browserTabsByWorktree,
+        activeWorktreeId,
+        hideDefaultBranchWorkspace,
+        repoMap
+      })
+    )
+  }, [
+    activeWorktreeId,
+    allWorktrees,
+    browserTabsByWorktree,
+    filterRepoIds,
+    hideDefaultBranchWorkspace,
+    ptyIdsByTabId,
+    repoMap,
+    showActiveOnly,
+    tabsByWorktree,
+    worktreesByRepo
+  ])
+}

--- a/src/renderer/src/components/sidebar/use-workspace-kanban-outside-dismiss.ts
+++ b/src/renderer/src/components/sidebar/use-workspace-kanban-outside-dismiss.ts
@@ -1,0 +1,44 @@
+import { useEffect } from 'react'
+import type React from 'react'
+
+const WORKSPACE_BOARD_KEEP_OPEN_SELECTOR =
+  '[data-workspace-board-trigger], [data-workspace-board-preserve-open]'
+
+export function isWorkspaceBoardKeepOpenTarget(target: EventTarget | null): boolean {
+  return target instanceof Element && Boolean(target.closest(WORKSPACE_BOARD_KEEP_OPEN_SELECTOR))
+}
+
+export function useWorkspaceKanbanOutsideDismiss(params: {
+  open: boolean
+  boardRef: React.RefObject<HTMLDivElement | null>
+  preserveOpenForMenu: boolean
+  onOpenChange: (open: boolean) => void
+}): void {
+  const { open, boardRef, preserveOpenForMenu, onOpenChange } = params
+
+  useEffect(() => {
+    if (!open) {
+      return
+    }
+
+    const handlePointerDown = (event: PointerEvent): void => {
+      const content = boardRef.current?.closest<HTMLElement>('[data-slot="sheet-content"]')
+      if (!content || preserveOpenForMenu) {
+        return
+      }
+      if (event.target instanceof Node && content.contains(event.target)) {
+        return
+      }
+      if (isWorkspaceBoardKeepOpenTarget(event.target)) {
+        return
+      }
+      const rect = content.getBoundingClientRect()
+      if (event.clientX > rect.right && event.clientY >= rect.top && event.clientY <= rect.bottom) {
+        onOpenChange(false)
+      }
+    }
+
+    document.addEventListener('pointerdown', handlePointerDown, true)
+    return () => document.removeEventListener('pointerdown', handlePointerDown, true)
+  }, [boardRef, onOpenChange, open, preserveOpenForMenu])
+}

--- a/src/renderer/src/components/sidebar/workspace-kanban-worktree-groups.ts
+++ b/src/renderer/src/components/sidebar/workspace-kanban-worktree-groups.ts
@@ -1,0 +1,29 @@
+import type { WorkspaceStatus, WorkspaceStatusDefinition, Worktree } from '../../../../shared/types'
+import { getWorkspaceStatus } from './workspace-status'
+
+function sortBoardWorktrees(a: Worktree, b: Worktree): number {
+  return b.lastActivityAt - a.lastActivityAt || a.displayName.localeCompare(b.displayName)
+}
+
+export function groupWorkspaceKanbanWorktrees(params: {
+  worktrees: readonly Worktree[]
+  visibleWorktreeIds: ReadonlySet<string>
+  workspaceStatuses: readonly WorkspaceStatusDefinition[]
+}): Map<WorkspaceStatus, Worktree[]> {
+  const { worktrees, visibleWorktreeIds, workspaceStatuses } = params
+  const grouped = new Map<WorkspaceStatus, Worktree[]>(
+    workspaceStatuses.map((status) => [status.id, []])
+  )
+
+  for (const worktree of worktrees) {
+    if (!visibleWorktreeIds.has(worktree.id)) {
+      continue
+    }
+    grouped.get(getWorkspaceStatus(worktree, workspaceStatuses))!.push(worktree)
+  }
+
+  for (const items of grouped.values()) {
+    items.sort((a, b) => Number(b.isPinned) - Number(a.isPinned) || sortBoardWorktrees(a, b))
+  }
+  return grouped
+}


### PR DESCRIPTION
## Summary
- keep the workspace board open when sidebar Filter or View Options menus are clicked
- apply the sidebar workspace filters to the Kanban board
- add the same filter control to the workspace board header

## Verification
- pnpm lint src/renderer/src/components/sidebar/SidebarFilter.tsx src/renderer/src/components/sidebar/SidebarHeader.tsx src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.tsx src/renderer/src/components/sidebar/WorkspaceKanbanDrawerHeader.tsx src/renderer/src/components/sidebar/use-visible-workspace-kanban-worktree-ids.ts src/renderer/src/components/sidebar/workspace-kanban-worktree-groups.ts
- pnpm run typecheck:web
- pnpm test -- src/renderer/src/components/sidebar/visible-worktrees.test.ts src/renderer/src/components/sidebar/use-workspace-status-drop.test.ts

Runtime Electron validation was attempted, but the existing worktree dev app is currently failing in CrashReportDialog because the crash report preload API is unavailable; a fresh isolated instance exited before exposing CDP.