### PR TITLE
Remove dev identity from titlebar

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -94,7 +94,6 @@ import {
 import type { VirtualizedScrollAnchor } from './hooks/useVirtualizedScrollAnchor'
 import type { RemoteWorkspacePatchResult } from '../../shared/remote-workspace-types'
 import type { OnboardingState } from '../../shared/types'
-import type { AppIdentity } from '../../shared/app-identity'
 
 const isMac = navigator.userAgent.includes('Mac')
 const isWindows = !isMac && navigator.userAgent.includes('Windows')
@@ -360,27 +359,10 @@ function App(): React.JSX.Element {
   const [collapsedSidebarHeaderWidth, setCollapsedSidebarHeaderWidth] = useState(0)
   const [mountedLazyModalIds, setMountedLazyModalIds] = useState(() => new Set<string>())
   const [onboarding, setOnboarding] = useState<OnboardingState | null>(null)
-  const [appIdentity, setAppIdentity] = useState<AppIdentity | null>(null)
 
   // Subscribe to IPC push events
   useIpcEvents()
   useAutomationDispatchEvents()
-
-  useEffect(() => {
-    let disposed = false
-    void window.api.app
-      .getIdentity()
-      .then((identity) => {
-        if (!disposed) {
-          document.title = identity.name
-          setAppIdentity(identity)
-        }
-      })
-      .catch(console.error)
-    return () => {
-      disposed = true
-    }
-  }, [])
   // Why: retention must run at App level so the inline per-card agents list
   // always sees retained entries. If retention ran inside the sidebar-card
   // subtree, "done" agents would vanish any time the user collapsed a card's
@@ -1130,17 +1112,6 @@ function App(): React.JSX.Element {
     })
   }, [activeModal])
 
-  const appIdentityTitle =
-    appIdentity?.isDev === true
-      ? [
-          appIdentity.name,
-          appIdentity.devBranch ? `Branch: ${appIdentity.devBranch}` : null,
-          appIdentity.devRepoRoot ? `Path: ${appIdentity.devRepoRoot}` : null
-        ]
-          .filter(Boolean)
-          .join(' | ')
-      : undefined
-
   // Why: extracted so both the full-width titlebar (settings/landing) and
   // the sidebar-width left header (workspace view) can share the same
   // controls without duplicating the agent badge popover.
@@ -1185,18 +1156,8 @@ function App(): React.JSX.Element {
             {settings?.showTitlebarAppName !== false && (
               <ContextMenu>
                 <ContextMenuTrigger asChild>
-                  <div
-                    className="titlebar-app-name"
-                    aria-label={appIdentity?.name ?? 'Orca'}
-                    title={appIdentityTitle}
-                  >
+                  <div className="titlebar-app-name" aria-label="Orca">
                     <span className="titlebar-app-name-main">Orca</span>
-                    {appIdentity?.isDev && appIdentity.devLabel ? (
-                      <span className="titlebar-dev-label">{appIdentity.devLabel}</span>
-                    ) : null}
-                    {appIdentity?.isDev && appIdentity.dockBadgeLabel ? (
-                      <span className="titlebar-dev-badge">{appIdentity.dockBadgeLabel}</span>
-                    ) : null}
                   </div>
                 </ContextMenuTrigger>
                 <ContextMenuContent>

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -573,34 +573,6 @@
   flex: 0 0 auto;
 }
 
-.titlebar-dev-label {
-  min-width: 0;
-  overflow: hidden;
-  color: var(--foreground);
-  font-family: var(--font-mono);
-  font-weight: 500;
-  text-overflow: ellipsis;
-}
-
-.titlebar-dev-label::before {
-  content: 'Dev:';
-  margin-right: 4px;
-  color: var(--muted-foreground);
-}
-
-.titlebar-dev-badge {
-  flex: 0 0 auto;
-  height: 16px;
-  padding: 0 4px;
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  color: var(--muted-foreground);
-  font-family: var(--font-mono);
-  font-size: 10px;
-  font-weight: 600;
-  line-height: 14px;
-}
-
 .titlebar-icon-button {
   -webkit-app-region: no-drag;
   background: none;


### PR DESCRIPTION
## Summary
- render the titlebar app name as plain `Orca` in dev and production
- stop wiring the dev app identity into the renderer titlebar/document title
- remove dead CSS for the dev titlebar label and badge

## Verification
- `pnpm exec oxlint src/renderer/src/App.tsx src/renderer/src/assets/main.css`
- `pnpm run typecheck:web`
- `pnpm lint`
- `git diff --check`